### PR TITLE
fix(ssh-help): Host * glob expansion causing garbage host list

### DIFF
--- a/shell-common/functions/ssh_help.sh
+++ b/shell-common/functions/ssh_help.sh
@@ -29,19 +29,22 @@ ssh_help() {
 
     ux_section "Registered Hosts (~/.ssh/config)"
     if [ -f "${HOME}/.ssh/config" ]; then
+        set -f  # Disable glob expansion to prevent Host * from expanding
         while IFS= read -r line; do
             # Trim leading whitespace
             line_trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
             case "$line_trimmed" in
-                \#* | "") continue ;;   # Skip comments and empty lines
+                \#* | "")  continue ;;  # Skip comments and empty lines
+                Host\ \*)  continue ;;  # Skip wildcard Host *
                 Host\ *)
                     hosts="${line_trimmed#Host }"
                     for host in $hosts; do
-                        [ "$host" != "*" ] && ux_bullet "$host"
+                        ux_bullet "$host"
                     done
                     ;;
             esac
         done < "${HOME}/.ssh/config"
+        set +f  # Re-enable glob expansion
     else
         ux_info "~/.ssh/config not found. Run ./setup.sh to create symlink."
     fi


### PR DESCRIPTION
## Summary

- `ssh-help`의 Registered Hosts 목록에 홈 디렉토리 파일명이 출력되는 버그 수정

## Root Cause

`Host *` 라인 처리 시 `hosts="*"` 가 되고, `for host in $hosts` (unquoted) 에서
shell이 `*`를 현재 작업 디렉토리 파일 목록으로 glob 확장함.
`[ "$host" != "*" ]` 체크가 이미 확장된 후라 무의미.

```
# 문제 상황
hosts="*"
for host in $hosts; do   # * → applications convert-to-ssh.sh dotfiles ...
    [ "$host" != "*" ]   # 이미 확장됐으므로 체크 불가
```

## Fix

- `set -f` / `set +f` 로 루프 전후 glob 비활성화
- `Host \*` 케이스 명시적 skip 추가

## Test plan

- [ ] `ssh-help` 실행 시 Registered Hosts에 `~/.ssh/config`의 Host 항목만 출력되는지 확인
- [ ] `Host *` wildcard가 목록에 포함되지 않는지 확인
- [ ] `Host host1 host2` 다중 호스트 라인 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->