### PR TITLE
feat(hooks): extend env allowlist for .env.<prefix>.example pattern

### DIFF
--- a/git/config/hook-config.sh
+++ b/git/config/hook-config.sh
@@ -34,7 +34,7 @@ GIT_HOOKS_DEBUG_GREP_EXCLUDES=(
 # Forbidden filename detection (basename/path + env allowlist)
 GIT_HOOKS_FORBIDDEN_BASENAME_ERE="${GIT_HOOKS_FORBIDDEN_BASENAME_ERE:-^(\\.git-credentials|credentials\\.json|private\\.key|secret\\.key|id_rsa|id_dsa|id_ed25519|.*\\.pem)$}"
 GIT_HOOKS_ENV_BASENAME_BLOCK_ERE="${GIT_HOOKS_ENV_BASENAME_BLOCK_ERE:-^\\.env(\\..*)?$}"
-GIT_HOOKS_ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\\.env\\.(example|sample|template|dist|.*\\.corp\\.example)$}"
+GIT_HOOKS_ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\\.env\\.([^.]+\\.)*(example|sample|template|dist)$}"
 GIT_HOOKS_FORBIDDEN_PATH_ERE="${GIT_HOOKS_FORBIDDEN_PATH_ERE:-(^|/)\\.aws/(credentials|config)$}"
 
 # Large file threshold

--- a/git/global-hooks/pre-commit
+++ b/git/global-hooks/pre-commit
@@ -94,7 +94,7 @@ FORBIDDEN_BASENAME_ERE="${GIT_HOOKS_FORBIDDEN_BASENAME_ERE:-^(\.git-credentials|
 
 # Env files: blocked by default, but allow example/sample/template/dist
 ENV_BASENAME_BLOCK_ERE="${GIT_HOOKS_ENV_BASENAME_BLOCK_ERE:-^\.env(\..*)?$}"
-ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\.env\.(example|sample|template|dist)$}"
+ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\.env\.([^.]+\.)?(example|sample|template|dist)$}"
 
 # Path-based sensitive locations (repo-relative, including directories)
 FORBIDDEN_PATH_ERE="${GIT_HOOKS_FORBIDDEN_PATH_ERE:-(^|/)\.aws/(credentials|config)$}"

--- a/git/global-hooks/pre-commit
+++ b/git/global-hooks/pre-commit
@@ -94,7 +94,7 @@ FORBIDDEN_BASENAME_ERE="${GIT_HOOKS_FORBIDDEN_BASENAME_ERE:-^(\.git-credentials|
 
 # Env files: blocked by default, but allow example/sample/template/dist
 ENV_BASENAME_BLOCK_ERE="${GIT_HOOKS_ENV_BASENAME_BLOCK_ERE:-^\.env(\..*)?$}"
-ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\.env\.([^.]+\.)?(example|sample|template|dist)$}"
+ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\.env\.([^.]+\.)*(example|sample|template|dist)$}"
 
 # Path-based sensitive locations (repo-relative, including directories)
 FORBIDDEN_PATH_ERE="${GIT_HOOKS_FORBIDDEN_PATH_ERE:-(^|/)\.aws/(credentials|config)$}"

--- a/shell-common/functions/ssh_help.sh
+++ b/shell-common/functions/ssh_help.sh
@@ -29,19 +29,22 @@ ssh_help() {
 
     ux_section "Registered Hosts (~/.ssh/config)"
     if [ -f "${HOME}/.ssh/config" ]; then
+        set -f  # Disable glob expansion to prevent Host * from expanding
         while IFS= read -r line; do
             # Trim leading whitespace
             line_trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
             case "$line_trimmed" in
-                \#* | "") continue ;;   # Skip comments and empty lines
+                \#* | "")  continue ;;  # Skip comments and empty lines
+                Host\ \*)  continue ;;  # Skip wildcard Host *
                 Host\ *)
                     hosts="${line_trimmed#Host }"
                     for host in $hosts; do
-                        [ "$host" != "*" ] && ux_bullet "$host"
+                        ux_bullet "$host"
                     done
                     ;;
             esac
         done < "${HOME}/.ssh/config"
+        set +f  # Re-enable glob expansion
     else
         ux_info "~/.ssh/config not found. Run ./setup.sh to create symlink."
     fi


### PR DESCRIPTION
## Summary

- `.env.corp.example`, `.env.local.template` 등 prefix가 포함된 env 파일을 pre-commit에서 허용
- `hook-config.sh`와 `pre-commit` 두 파일의 regex를 동일하게 통일

## Changes

**허용 패턴 변경:**
```
Before: ^\.env\.(example|sample|template|dist)$
After:  ^\.env\.([^.]+\.)*(example|sample|template|dist)$
```

**허용 예시:**
| 파일명 | Before | After |
|---|---|---|
| `.env.example` | ✅ | ✅ |
| `.env.corp.example` | ❌ | ✅ |
| `.env.local.template` | ❌ | ✅ |
| `.env.a.b.c.example` | ❌ | ✅ |
| `.env.secret` | ❌ | ❌ |
| `.env` | ❌ | ❌ |

## Test plan

- [ ] `.env.corp.example` 파일 커밋 시 pre-commit 통과 확인
- [ ] `.env.secret` 파일 커밋 시 pre-commit 차단 확인
- [ ] `hook-config.sh`와 `pre-commit` regex 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->