### PR TITLE
feat(codex): add codex-yolo alias and fix purity check

### DIFF
--- a/git/hooks/checks/library_purity_check.sh
+++ b/git/hooks/checks/library_purity_check.sh
@@ -50,7 +50,7 @@ check_library_purity() {
 
     local install_ere="${DOTFILES_HOOKS_LIBRARY_PURITY_INSTALL_ERE:-apt-get[[:space:]]+install|apt[[:space:]]+install|dnf[[:space:]]+install|yum[[:space:]]+install|pacman[[:space:]]+-S|pip[[:space:]]+install|uv[[:space:]]+pip[[:space:]]+install|npm[[:space:]]+install|brew[[:space:]]+install}"
     local install_hits
-    install_hits=$(grep -nE "$install_ere" "$tmp_file" 2>/dev/null || true)
+    install_hits=$(grep -nE "$install_ere" "$tmp_file" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' || true)
 
     local violation_count=0
 

--- a/git/hooks/checks/library_purity_check.sh
+++ b/git/hooks/checks/library_purity_check.sh
@@ -15,8 +15,9 @@ check_library_purity() {
     tmp_file=$(mktemp "$tmpdir/purity_stage_XXXXXX.txt")
     write_staged_or_worktree_to_tmp "$repo_root" "$repo_rel_path" "$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 0; }
 
+    local install_ere="${DOTFILES_HOOKS_LIBRARY_PURITY_INSTALL_ERE:-apt-get[[:space:]]+install|apt[[:space:]]+install|dnf[[:space:]]+install|yum[[:space:]]+install|pacman[[:space:]]+-S|pip[[:space:]]+install|uv[[:space:]]+pip[[:space:]]+install|npm[[:space:]]+install|brew[[:space:]]+install}"
     local hits
-    hits=$(awk '
+    hits=$(awk -v install_ere="$install_ere" '
         function is_comment(line) { return line ~ /^[[:space:]]*#/ }
         BEGIN { depth=0 }
         {
@@ -44,13 +45,14 @@ check_library_purity() {
                 line !~ /^[[:space:]]*(main|[a-z_][a-z0-9_]*_main)[[:space:]]*\(\)[[:space:]]*\{/) {
                 printf "MAIN_CALL:%d:%s\n", NR, line
             }
-            # INSTALL lines are detected outside awk using SSOT regex (from hook-config.sh)
+            if (depth==0 && line ~ install_ere) {
+                printf "INSTALL:%d:%s\n", NR, line
+            }
         }
     ' "$tmp_file" 2>/dev/null || true)
 
-    local install_ere="${DOTFILES_HOOKS_LIBRARY_PURITY_INSTALL_ERE:-apt-get[[:space:]]+install|apt[[:space:]]+install|dnf[[:space:]]+install|yum[[:space:]]+install|pacman[[:space:]]+-S|pip[[:space:]]+install|uv[[:space:]]+pip[[:space:]]+install|npm[[:space:]]+install|brew[[:space:]]+install}"
     local install_hits
-    install_hits=$(grep -nE "$install_ere" "$tmp_file" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+    install_hits=$(echo "$hits" | grep '^INSTALL:' | sed 's/^INSTALL://' || true)
 
     local violation_count=0
 

--- a/git/tests/test_hooks.sh
+++ b/git/tests/test_hooks.sh
@@ -197,6 +197,26 @@ EOF
   rm -rf "$repo_dir"
 }
 
+test_allows_library_purity_commented_install() {
+  local repo_dir
+  repo_dir="$(mktemp -d /tmp/dotfiles-hook-test.XXXXXX)"
+  make_repo "$repo_dir"
+
+  mkdir -p "$repo_dir/shell-common/tools/integrations"
+  cat >"$repo_dir/shell-common/tools/integrations/ok.sh" <<'EOF'
+#!/bin/sh
+# Example:
+#   npm install -g some-package
+#   apt-get install -y something
+alias foo='bar'
+EOF
+
+  git -C "$repo_dir" add shell-common/tools/integrations/ok.sh
+  assert_success "git -C \"$repo_dir\" commit -m \"commented install ok\""
+
+  rm -rf "$repo_dir"
+}
+
 main() {
   ux_header "Hook integration tests"
   test_allows_spaces_in_filename
@@ -206,6 +226,7 @@ main() {
   test_blocks_custom_script_wrong_shebang
   test_blocks_library_purity_top_level_read
   test_blocks_library_purity_top_level_install
+  test_allows_library_purity_commented_install
   ux_success "All hook tests passed"
 }
 

--- a/shell-common/tools/integrations/codex.sh
+++ b/shell-common/tools/integrations/codex.sh
@@ -24,6 +24,7 @@
 alias cx='codex'                    # Basic command
 alias cxhelp='codex --help'         # Show help
 alias cxver='codex --version'       # Show version
+alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'
 
 # ═══════════════════════════════════════════════════════════════
 # Codex Installation


### PR DESCRIPTION
## Summary

- Add `codex-yolo` alias consistent with `claude-yolo` / `gemini-yolo` patterns
  ```sh
  alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'
  ```
- Fix `library_purity_check.sh`: `install_hits` grep was not excluding comment lines, causing false positive on `codex.sh:14` (`#    npm install -g ...`)

## Root Cause

`awk` block correctly skipped comments via `is_comment()`, but `install_hits` used a separate `grep` directly on the raw file — missing the comment filter.

## Test plan

- [ ] `codex-yolo` alias resolves after sourcing `codex.sh`
- [ ] Pre-commit hook passes on `codex.sh` without false positive
- [ ] Hook still catches real `npm install` calls outside comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->