### PR TITLE
fix(hooks): disable playbook auto-commit by default

### DIFF
--- a/git/doc/POST_COMMIT_GUIDE.md
+++ b/git/doc/POST_COMMIT_GUIDE.md
@@ -494,6 +494,20 @@ cd ~/para/archive/playbook
 git log --oneline | grep "auto updated" | head -10
 ```
 
+### 문제: playbook 자동 커밋을 끄고 싶어요
+
+`DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT` 환경변수로 제어합니다 (기본값: `0` = 비활성).
+
+```bash
+# 끄기 (기본값, 별도 설정 불필요)
+# DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=0  ← 설정 안 해도 꺼져있음
+
+# 켜기: ~/.env 또는 shell-common/env/*.local.sh 에 추가
+export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1
+```
+
+변경 후 쉘 재시작 또는 `source ~/.bashrc` / `source ~/.zshrc`.
+
 ---
 
 ## 📋 체크리스트

--- a/git/hooks/post-commit
+++ b/git/hooks/post-commit
@@ -50,12 +50,13 @@ fi
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Playbook 자동 커밋
+# 활성화: DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1 (기본값: 비활성)
 # ═══════════════════════════════════════════════════════════════════════════
 
 PLAYBOOK_DIR="${HOME}/para/archive/playbook"
 
 # Playbook 저장소가 있는지 확인
-if [ -d "$PLAYBOOK_DIR/.git" ]; then
+if [ "${DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT:-0}" = "1" ] && [ -d "$PLAYBOOK_DIR/.git" ]; then
     cd "$PLAYBOOK_DIR" || exit 1
 
     # work_log.txt가 변경되었는지 확인


### PR DESCRIPTION
## Summary

- `git/hooks/post-commit`: playbook 자동 커밋을 환경변수 가드로 비활성화 (기본값 `0`)
- `git/doc/POST_COMMIT_GUIDE.md`: 문제 해결 섹션에 토글 방법 문서화

## Background

dotfiles에 커밋할 때마다 `~/para/archive/playbook`에도 `chore(work-log): ...` 커밋이 자동 생성되는 기능이 있었음. 이를 기본값 비활성으로 전환.

## Toggle

```bash
# 켜기 (~/.env 또는 *.local.sh 에 추가)
export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1

# 끄기 (기본값, 설정 불필요)
```

## Test plan

- [ ] dotfiles 커밋 후 playbook에 자동 커밋이 생기지 않음
- [ ] `DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1` 설정 시 기존처럼 자동 커밋 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->