### PR TITLE
fix(hooks): disable work_log.txt writing by default

### DIFF
--- a/git/doc/POST_COMMIT_GUIDE.md
+++ b/git/doc/POST_COMMIT_GUIDE.md
@@ -505,8 +505,8 @@ git log --oneline | grep "auto updated" | head -10
 
 ```bash
 # 켜기: ~/.env 또는 shell-common/env/*.local.sh 에 추가
-export DOTFILES_WORKLOG_ENABLED=1                  # work_log.txt 기록 활성화
-export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1      # playbook 자동 커밋 활성화
+export DOTFILES_WORKLOG_ENABLED=1             # work_log.txt 기록 활성화
+export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1 # playbook 자동 커밋 활성화
 
 # 끄기 (기본값, 별도 설정 불필요)
 ```

--- a/git/doc/POST_COMMIT_GUIDE.md
+++ b/git/doc/POST_COMMIT_GUIDE.md
@@ -494,16 +494,21 @@ cd ~/para/archive/playbook
 git log --oneline | grep "auto updated" | head -10
 ```
 
-### 문제: playbook 자동 커밋을 끄고 싶어요
+### 문제: work_log.txt 기록 또는 playbook 자동 커밋을 끄고 싶어요
 
-`DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT` 환경변수로 제어합니다 (기본값: `0` = 비활성).
+두 기능은 독립적으로 제어됩니다 (모두 기본값 `0` = 비활성).
+
+| 환경변수 | 기본값 | 역할 |
+|---|---|---|
+| `DOTFILES_WORKLOG_ENABLED` | `0` | work_log.txt 쓰기 |
+| `DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT` | `0` | playbook 자동 커밋 |
 
 ```bash
-# 끄기 (기본값, 별도 설정 불필요)
-# DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=0  ← 설정 안 해도 꺼져있음
-
 # 켜기: ~/.env 또는 shell-common/env/*.local.sh 에 추가
-export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1
+export DOTFILES_WORKLOG_ENABLED=1                  # work_log.txt 기록 활성화
+export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1      # playbook 자동 커밋 활성화
+
+# 끄기 (기본값, 별도 설정 불필요)
 ```
 
 변경 후 쉘 재시작 또는 `source ~/.bashrc` / `source ~/.zshrc`.

--- a/git/hooks/post-commit
+++ b/git/hooks/post-commit
@@ -41,11 +41,11 @@ fi
 # 활성화: DOTFILES_WORKLOG_ENABLED=1 (기본값: 비활성)
 if [ "${DOTFILES_WORKLOG_ENABLED:-0}" = "1" ]; then
     LOGFILE="${HOME}/work_log.txt"
-    if [ "$TIME" = "-" ]; then
-        echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | - | $HASH | $SUBJECT" >> "$LOGFILE"
-    else
-        echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | ${TIME}h | $HASH | $SUBJECT" >> "$LOGFILE"
+    time_log_part="-"
+    if [ "$TIME" != "-" ]; then
+        time_log_part="${TIME}h"
     fi
+    echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | $time_log_part | $HASH | $SUBJECT" >> "$LOGFILE"
 fi
 
 # 메타정보 (선택사항)

--- a/git/hooks/post-commit
+++ b/git/hooks/post-commit
@@ -38,11 +38,14 @@ fi
 
 # work_log.txt에 기록 (make-jira 호환 형식)
 # work_log.txt는 ~/para/archive/playbook/logs/work_log.txt로 symlink되어 있음
-LOGFILE="${HOME}/work_log.txt"
-if [ "$TIME" = "-" ]; then
-    echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | - | $HASH | $SUBJECT" >> "$LOGFILE"
-else
-    echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | ${TIME}h | $HASH | $SUBJECT" >> "$LOGFILE"
+# 활성화: DOTFILES_WORKLOG_ENABLED=1 (기본값: 비활성)
+if [ "${DOTFILES_WORKLOG_ENABLED:-0}" = "1" ]; then
+    LOGFILE="${HOME}/work_log.txt"
+    if [ "$TIME" = "-" ]; then
+        echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | - | $HASH | $SUBJECT" >> "$LOGFILE"
+    else
+        echo "[$TIMESTAMP] [$JIRA_KEY] | $TYPE | $CATEGORY | ${TIME}h | $HASH | $SUBJECT" >> "$LOGFILE"
+    fi
 fi
 
 # 메타정보 (선택사항)


### PR DESCRIPTION
## Summary

- `git/hooks/post-commit`: `DOTFILES_WORKLOG_ENABLED` 가드 추가 (기본값 `0` = 비활성)
- `git/doc/POST_COMMIT_GUIDE.md`: 두 토글 변수를 표로 정리

## Background

playbook 자동 커밋(#9)을 껐음에도 `work_log.txt`(symlink → playbook/logs/work_log.txt)에는 여전히 매 커밋마다 기록되어 playbook repo에 `M logs/work_log.txt` 상태가 쌓였음.

## 제어 변수 정리

| 환경변수 | 기본값 | 역할 |
|---|---|---|
| `DOTFILES_WORKLOG_ENABLED` | `0` | work_log.txt 쓰기 |
| `DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT` | `0` | playbook 자동 커밋 |

```bash
# 켜기 (~/.env 또는 *.local.sh 에 추가)
export DOTFILES_WORKLOG_ENABLED=1
export DOTFILES_WORKLOG_PLAYBOOK_AUTOCOMMIT=1
```

## Test plan

- [x] dotfiles 커밋 후 `~/work_log.txt`에 기록이 추가되지 않음
- [x] `DOTFILES_WORKLOG_ENABLED=1` 설정 시 기존처럼 기록 동작
- [x] playbook repo에 `M logs/work_log.txt` 상태가 쌓이지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->