### PR TITLE
feat(claude): manage global memory via dotfiles symlink

### DIFF
--- a/claude/global-memory/MEMORY.md
+++ b/claude/global-memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Global Memory Index
+
+## Feedback (Global Rules)
+- [PR workflow etiquette - always reply to review comments](pr_workflow_etiquette.md) — When fixing PR issues from review comments, always add a reply acknowledging the feedback. Standard code review courtesy, applies to all projects.

--- a/claude/global-memory/pr_workflow_etiquette.md
+++ b/claude/global-memory/pr_workflow_etiquette.md
@@ -1,0 +1,28 @@
+---
+name: PR workflow etiquette - always reply to review comments
+description: When PR receives comments and you make fixes, always reply to acknowledge feedback. This is standard code review courtesy, applies across all projects.
+type: feedback
+---
+
+## Rule: Always Reply to PR Review Comments When Fixing Issues
+
+**Do:** When reviewers (Gemini, Sourcery, etc.) comment on a PR and you make fixes in response, always add a reply comment acknowledging the feedback and confirming what you changed.
+
+**Why:** Standard code review etiquette. It closes the feedback loop, shows you took the review seriously, and helps reviewers track whether their feedback was implemented correctly. Without replies, reviewers can't tell if issues were addressed or ignored.
+
+**How to apply:**
+1. After creating/updating a PR, check for review comments with `gh pr view <PR> --comments`
+2. If comments exist, read them thoroughly
+3. If you make code changes in response, commit and push those changes
+4. **Always** add a reply comment (example: "Applied both suggestions: 1. Removed X per guidelines 2. Fixed Y in template. Changes pushed.")
+5. Include concrete details about what was changed (not generic "fixed it" messages)
+
+**Example workflow:**
+```
+1. gh pr create → PR #11
+2. Gemini comments: "Remove README.md" + "Fix subtitle heading"
+3. You: git rm README.md; edit SKILL.md; git push
+4. You: gh pr comment 11 --body "Applied both suggestions: ..."  ← THIS STEP IS REQUIRED
+```
+
+Skipping step 4 leaves reviewers wondering if you saw or agree with their feedback.

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -180,8 +180,8 @@ setup_skills_mount
 
 # global memory 디렉토리 심볼릭 링크 생성
 if [ ! -d "$(dirname "$HOME_GLOBAL_MEMORY")" ]; then
-    log_info "~/.claude/projects/GLOBAL 디렉토리 생성"
-    mkdir -p "$(dirname "$HOME_GLOBAL_MEMORY")" || log_error_and_exit "~/.claude/projects/GLOBAL 디렉토리 생성 실패"
+    log_info "'$(dirname "$HOME_GLOBAL_MEMORY")' 디렉토리 생성"
+    mkdir -p "$(dirname "$HOME_GLOBAL_MEMORY")" || log_error_and_exit "'$(dirname "$HOME_GLOBAL_MEMORY")' 디렉토리 생성 실패"
 fi
 create_symlink "$CLAUDE_GLOBAL_MEMORY_SOURCE" "$HOME_GLOBAL_MEMORY"
 

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -9,7 +9,8 @@
 #   1. Creates ~/.claude/settings.json symlink (Claude Code settings)
 #   2. Creates ~/.claude/statusline-command.sh symlink (status line script)
 #   3. Creates ~/.claude/skills symlink (custom skills directory)
-#   4. Verifies ~/.claude directory structure
+#   4. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
+#   5. Verifies ~/.claude directory structure
 #
 # These files/directories are version-controlled in dotfiles and should
 # be managed via symbolic links for consistency across machines.
@@ -28,11 +29,13 @@ HOME_CLAUDE="${HOME}/.claude"
 HOME_SETTINGS="${HOME_CLAUDE}/settings.json"
 HOME_STATUSLINE="${HOME_CLAUDE}/statusline-command.sh"
 HOME_SKILLS="${HOME_CLAUDE}/skills"
+HOME_GLOBAL_MEMORY="${HOME_CLAUDE}/projects/GLOBAL/memory"
 
 # Dotfiles source locations
 CLAUDE_SETTINGS_SOURCE="${CLAUDE_DOTFILES}/settings.json"
 CLAUDE_STATUSLINE_SOURCE="${CLAUDE_DOTFILES}/statusline-command.sh"
 CLAUDE_SKILLS_SOURCE="${CLAUDE_DOTFILES}/skills"
+CLAUDE_GLOBAL_MEMORY_SOURCE="${CLAUDE_DOTFILES}/global-memory"
 
 # Load UX library (unified library at shell-common/tools/ux_lib/)
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
@@ -155,6 +158,11 @@ if [ ! -d "$CLAUDE_SKILLS_SOURCE" ]; then
     log_error_and_exit "skills 디렉토리가 '${CLAUDE_SKILLS_SOURCE}' 경로에 존재하지 않습니다."
 fi
 
+# global-memory 디렉토리 존재 여부 확인
+if [ ! -d "$CLAUDE_GLOBAL_MEMORY_SOURCE" ]; then
+    log_error_and_exit "global-memory 디렉토리가 '${CLAUDE_GLOBAL_MEMORY_SOURCE}' 경로에 존재하지 않습니다."
+fi
+
 # settings.json 심볼릭 링크 생성
 create_symlink "$CLAUDE_SETTINGS_SOURCE" "$HOME_SETTINGS"
 
@@ -169,6 +177,13 @@ fi
 
 # skills bind mount를 위한 sudoers 설정
 setup_skills_mount
+
+# global memory 디렉토리 심볼릭 링크 생성
+if [ ! -d "$(dirname "$HOME_GLOBAL_MEMORY")" ]; then
+    log_info "~/.claude/projects/GLOBAL 디렉토리 생성"
+    mkdir -p "$(dirname "$HOME_GLOBAL_MEMORY")" || log_error_and_exit "~/.claude/projects/GLOBAL 디렉토리 생성 실패"
+fi
+create_symlink "$CLAUDE_GLOBAL_MEMORY_SOURCE" "$HOME_GLOBAL_MEMORY"
 
 # --- Verify Links ---
 
@@ -192,6 +207,12 @@ else
     log_error_and_exit "skills 디렉토리 생성 실패"
 fi
 
+if [ -L "$HOME_GLOBAL_MEMORY" ]; then
+    log_dim "✓ global memory 심볼릭 링크 확인됨"
+else
+    log_error_and_exit "global memory 심볼릭 링크 생성 실패"
+fi
+
 # --- Completion Messages ---
 
 log_debug "--- Claude Code dotfiles setup 완료 ---"
@@ -202,6 +223,7 @@ ux_info "다음 설정이 적용되었습니다:"
 ux_bullet "~/.claude/settings.json → ~/dotfiles/claude/settings.json (symlink)"
 ux_bullet "~/.claude/statusline-command.sh → ~/dotfiles/claude/statusline-command.sh (symlink)"
 ux_bullet "~/.claude/skills ← ~/dotfiles/claude/skills (bind mount)"
+ux_bullet "~/.claude/projects/GLOBAL/memory → ~/dotfiles/claude/global-memory (symlink)"
 ux_bullet "/etc/sudoers.d/claude-skills-mount (passwordless mount)"
 echo ""
 


### PR DESCRIPTION
## Summary
- Move `~/.claude/projects/GLOBAL/memory` to `dotfiles/claude/global-memory/` for version control
- Update `claude/setup.sh` to create symlink for global memory directory (same pattern as settings, statusline, skills)
- Includes parent directory auto-creation (`~/.claude/projects/GLOBAL/`) for fresh machine setup

## Test plan
- [ ] Run `claude/setup.sh` on a clean environment and verify symlink is created
- [ ] Verify Claude Code can read/write global memory through the symlink
- [ ] Confirm existing memory files (`MEMORY.md`, `pr_workflow_etiquette.md`) are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->