### PR TITLE
feat(git): enable fetch.prune

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -18,3 +18,5 @@
 	locksverify = false
 [push]
 	autoSetupRemote = true
+[fetch]
+	prune = true


### PR DESCRIPTION
## Summary
- Add `fetch.prune = true` to `.gitconfig`
- Automatically cleans up stale remote-tracking refs (e.g. merged PR branches) on every `git fetch`

## Test plan
- [ ] Run `git fetch` and verify deleted remote branches are pruned locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->