### PR TITLE
feat(skill): add visualize skill for HTML visualizations

### DIFF
--- a/claude/skills/visualize/SKILL.md
+++ b/claude/skills/visualize/SKILL.md
@@ -1,0 +1,883 @@
+---
+name: visualize
+description: >
+  Create beautiful, self-contained HTML visualizations from any content or idea.
+  Use for: slide decks, presentations, infographics, dashboards, flowcharts, diagrams,
+  timelines, comparison tables, data visualizations, landing pages, one-pagers, org charts,
+  mind maps, process flows, kanban boards, report summaries, or any visual that helps
+  humans digest information faster. Trigger on requests like "visualize this," "make a deck,"
+  "create a slide," "build an infographic," "show me a dashboard," "make this visual,"
+  or any request to present information in a visual HTML format.
+license: MIT
+metadata:
+  author: careerhackeralex
+  version: 0.3.0
+  category: document-creation
+  tags: [visualization, html, slides, dashboard, infographic]
+---
+
+# Visualize
+
+Turn any idea, data, or content into a stunning single-file HTML visualization.
+
+## After Creating a File
+
+**Always do BOTH of these after writing the HTML file:**
+
+1. **Auto-open in browser:** Run `wslview <filename>.html` to open in the default Windows browser via WSL
+2. **Return the file path as a clickable URL:** Include `file://<absolute-path>` in your response so the user can click to open it
+
+Example response after creation:
+```
+Created your visualization! Opening in browser now...
+📄 file:///home/user/project/my-dashboard.html
+```
+
+## Critical Requirements (NON-NEGOTIABLE)
+
+⚠️ **EVALUATION FAILURE GUARANTEED WITHOUT THESE 8 ELEMENTS** ⚠️
+
+**EVERY file MUST start from the skeleton template in [references/skeleton.md](references/skeleton.md) — copy the ENTIRE template, then add your content.**
+
+1. **CSS Custom Properties:** Exact names required: `--bg, --surface, --surface-hover, --border, --text, --text-secondary, --accent, --accent-secondary, --positive, --negative, --warning` — NO other names (not --bg-primary, not --text-primary). **CRITICAL:** These exact property names are required for evaluation system compatibility.
+2. **Utility Menu System (MANDATORY):** Complete `.viz-menu` element with `.viz-menu-toggle` button, `.viz-menu-dropdown` container, download PNG button (`onclick="downloadImage()"`), print button (`onclick="window.print()"`), and html-to-image CDN script (`<script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>`). **EVALUATION CRITICAL:** Menu system is automatically checked and WILL CAUSE FAILURES if missing.
+3. **Theme Classes (EVALUATION CRITICAL):** Must explicitly define BOTH `.theme-light` and `.theme-dark` classes in stylesheet with complete custom property definitions. **EXAMPLE REQUIRED:**
+```css
+:root { /* base properties */ }
+.theme-light { --bg: #ffffff; --surface: #f8f9fa; --text: #1a1a1a; /* etc */ }
+.theme-dark { --bg: #0a0a0a; --surface: #1a1a1a; --text: #ffffff; /* etc */ }
+```
+**NEVER rely on just `:root` or `@media (prefers-color-scheme)` — evaluation system checks for class-based themes.**
+4. **Semantic HTML:** `<main id="main-content">` element, **MANDATORY: Multiple `<section>` elements for major content blocks** (header, metrics, charts, etc.), skip-to-content link. Each distinct content area must be wrapped in semantic `<section>` tags.
+5. **Chart.js Requirements (EVALUATION CRITICAL):** MUST include `<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>` before closing `</head>`. **MANDATORY:** IMMEDIATELY after Chart.js script, add `<script>Chart.defaults.animation = false;</script>` (prevents animation glitches and is automatically checked by evaluation system). **MANDATORY CHART VALIDATION:** Every chart function MUST start with `if (typeof Chart === 'undefined') { console.error('Chart.js not loaded'); return; }`. **CHART ACCESSIBILITY:** Every canvas element MUST have `role="img"` and descriptive `aria-label` attributes. **CRITICAL CHART CONFIG:** Set `maintainAspectRatio: false`, `responsive: true`, and `plugins: { tooltip: { enabled: true } }` for accessibility. **NEVER disable tooltips** - evaluation system checks for enabled tooltips. **CHART RELIABILITY SYSTEM:** Use dedicated ChartManager pattern for bulletproof integration:
+```javascript
+var ChartManager = {
+  charts: new Map(),
+  safeInit: function(canvasId, config) {
+    if (typeof Chart === 'undefined') {
+      console.error('Chart.js library not loaded - check CDN inclusion');
+      return null;
+    }
+    try {
+      if (this.charts.has(canvasId)) {
+        this.charts.get(canvasId).destroy();
+        this.charts.delete(canvasId);
+      }
+      var ctx = document.getElementById(canvasId);
+      if (!ctx) {
+        console.error('Canvas element not found: ' + canvasId);
+        return null;
+      }
+      // Ensure no conflicting chart instances
+      if (ctx.chart) {
+        ctx.chart.destroy();
+        delete ctx.chart;
+      }
+      // Set accessibility attributes
+      ctx.setAttribute('role', 'img');
+      if (!ctx.getAttribute('aria-label')) {
+        ctx.setAttribute('aria-label', 'Chart visualization');
+      }
+      // Initialize with enhanced error handling
+      var chart = new Chart(ctx, config);
+      this.charts.set(canvasId, chart);
+      return chart;
+    } catch (error) {
+      console.error('Chart initialization failed for ' + canvasId + ':', error);
+      return null;
+    }
+  },
+  updateTheme: function() {
+    if (typeof Chart === 'undefined') return;
+    this.charts.forEach(function(chart, canvasId) {
+      try {
+        chart.update();
+      } catch (error) {
+        console.error('Chart theme update failed for ' + canvasId + ':', error);
+      }
+    });
+  },
+  destroyAll: function() {
+    this.charts.forEach(function(chart) {
+      try {
+        chart.destroy();
+      } catch (error) {
+        console.error('Chart destruction failed:', error);
+      }
+    });
+    this.charts.clear();
+  }
+};
+```
+Use `ChartManager.safeInit()` instead of raw `new Chart()`. **CRITICAL CHART CONFIG:** Set `maintainAspectRatio: false`, `responsive: true`, and `plugins: { tooltip: { enabled: true } }` for accessibility. **CHART CONTAINER DIMENSIONS:** Container must have explicit `height` >= 300px for charts to render properly. Use theme-aware colors with CSS custom properties, never static hex colors. **NEVER use import/export syntax with Chart.js CDN** — use standard var declarations only.
+
+**CHART.JS TROUBLESHOOTING (CRITICAL):** If charts appear as blank white spaces:
+- Verify Chart.js CDN is included before `</head>`
+- Verify `Chart.defaults.animation = false;` is immediately after CDN
+- Verify chart initialization is in DOMContentLoaded event listener
+- Verify no module import/export syntax anywhere in the file
+- Verify ChartManager.safeInit() pattern is used correctly
+- Verify canvas has `role="img"` and `aria-label` attributes
+
+6. **Responsive Design:** Section spacing ≥48px, **CRITICAL: NO horizontal overflow at 375px viewport** (MANDATORY: add `@media (max-width: 375px) { body { overflow-x: hidden; } }` to prevent horizontal scroll), **MANDATORY FONT-SIZE HIERARCHY:** h1 ≥ 2.5rem, h2 ≥ 2rem, h3 ≥ 1.5rem, body = 1rem. **SLIDE DECK REQUIREMENTS:** Title slide h1 ≥ 3rem, content slide titles ≥ 2.5rem, clear visual distinction between heading levels. **SLIDE SECTION SPACING:** Major sections within slides must have ≥48px spacing (title-to-content, content-to-charts, charts-to-navigation). **Test all layouts at 375px width — dashboards especially prone to chart container overflow.** **CSS CONTAINER QUERIES:** For advanced responsiveness, use container-based queries:
+```css
+.chart-container { container-type: inline-size; }
+@container (max-width: 400px) { 
+  .chart-legend { display: none; } 
+  .chart-title { font-size: 1rem; }
+}
+```
+This provides true component-level responsiveness beyond viewport media queries.
+7. **Print & Accessibility:** `@media print` styles, `@media (prefers-reduced-motion: reduce)` with disabled animations
+8. **Entrance Animations (MANDATORY):** Must include entrance animations via `.animate` classes, `data-reveal` attributes, or CSS `@keyframes`. **EVALUATION CRITICAL:** Animation presence is automatically detected and required.
+9. **JavaScript Functions:** `cycleTheme()`, `toggleMenu()`, top-level variables use `var` not `let`/`const`
+
+**🔥 CRITICAL: Copy skeleton.md exactly → Replace "YOUR CONTENT HERE" with visualization content → Save file**
+
+## Core Principles
+
+1. **Single-file HTML** — one `.html` file with inline CSS/JS. Opens in any browser, works offline, emails easily.
+2. **Light theme optimized** — modern designs prioritize light mode quality. Dark theme available via toggle.
+3. **Beautiful by default** — the first output should look professional with zero iteration.
+4. **Content-first** — the visualization serves the message. Never sacrifice clarity for aesthetics.
+5. **Responsive** — works on desktop, tablet, and mobile unless explicitly fixed-dimension (e.g., 16:9 slides).
+6. **Visual restraint** — Professional designs avoid decorative elements that add noise. No floating gradient orbs, rainbow borders, or ornamental animations.
+
+## Philosophy
+
+HTML is not a "website" — it's a visualization tool. Code is cheap. Everyone should feel empowered to visualize anything. This skill turns conversation context, URLs, articles, data, or raw ideas into something visual and digestible in seconds.
+
+Users invoke this **mid-conversation** with Claude Code. Use the full conversation context — whatever they've been discussing, any links they've shared, any data they've pasted — as source material. When given a URL, crawl it and extract the content to visualize.
+
+## Output Rules
+
+**MANDATORY FIRST STEP: Copy the complete skeleton from [references/skeleton.md](references/skeleton.md) — this includes all required elements (menu, theme system, CSS properties, semantic HTML, accessibility features). Never write HTML from scratch.**
+
+- Write ONE `.html` file to `~/Downloads/` (or user-specified path)
+- Filename: descriptive kebab-case, e.g., `q4-revenue-dashboard.html`, `team-roadmap-deck.html`
+- Start with skeleton.md template, add your content to the `<!-- YOUR CONTENT HERE -->` section
+- All custom styles in `<style>` after the skeleton's base styles
+- **CDN libraries are encouraged** — use the best tool for the job:
+  - **Tailwind CSS** — `https://cdn.tailwindcss.com` (utility-first styling, use freely)
+  - **Chart.js** — `https://cdn.jsdelivr.net/npm/chart.js` (bar, line, pie, radar, doughnut)
+  - **D3.js** — `https://cdn.jsdelivr.net/npm/d3@7` (complex/custom data viz, force graphs)
+  - **Mermaid** — `https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js` (flowcharts, sequence diagrams)
+  - **Three.js** — 3D when appropriate
+  - **Reveal.js** — full-featured slide engine when needed. **CRITICAL:** Must set `html, body { height: 100%; overflow: hidden; }` and give the `.reveal` container `height: 100%`. Config MUST use numeric dimensions: `Reveal.initialize({ width: 1280, height: 720, center: true, controls: false })` — NEVER use string percentages like `'100%'` which cause zero-height viewport and blank slides. **MANDATORY: Disable Reveal.js default controls** (`controls: false`) — the default `<` `>` arrow overlays are ugly. Instead, add a custom minimal bottom nav bar:
+```html
+<nav class="slide-nav" aria-label="Slide navigation">
+  <button onclick="prevSlide()" aria-label="Previous slide">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+  </button>
+  <span class="slide-counter" id="slideCounter">1 / 8</span>
+  <button onclick="nextSlide()" aria-label="Next slide">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+  </button>
+</nav>
+```
+```css
+.slide-nav { position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); display: flex; align-items: center; gap: 8px; z-index: 9998; }
+.slide-nav button { width: 28px; height: 28px; border-radius: 6px; background: transparent; border: none; color: var(--text-secondary); cursor: pointer; display: flex; align-items: center; justify-content: center; opacity: 0.3; transition: opacity 0.2s; }
+.slide-nav button:hover { opacity: 0.7; }
+.slide-counter { font-size: 12px; color: var(--text-secondary); font-weight: 400; min-width: 40px; text-align: center; opacity: 0.35; }
+```
+  - **Leaflet** — maps and geospatial data (`https://unpkg.com/leaflet@1.9/dist/leaflet.js` + CSS). **Required for geographic data** — never hand-draw SVG continent shapes. Use OpenStreetMap tiles or a minimal tile provider.
+- SVG for icons and simple graphics — never use external image URLs unless user provides them
+- Prefer CSS animations over JS when possible
+
+See [references/libraries.md](references/libraries.md) for detailed CDN links, patterns, and tips.
+
+## Design System
+
+Apply these defaults. They are opinionated and tested — override only when user requests it.
+
+**Full design system reference:** See [references/design-system.md](references/design-system.md) for complete typography, color, spacing, animation, accessibility, and visual polish specifications.
+
+Key highlights (consult reference for full details):
+
+### Design Notes
+
+**Theming System (CRITICAL):**
+- Use **class-based theming ONLY** — `<html class="theme-dark">` or `<html class="theme-light">`
+- Theme toggle changes html class: `document.documentElement.className = 'theme-' + newTheme`
+- **Never use `data-theme` attributes** — the evaluation system expects class-based themes
+- **Required CSS custom properties:** `--bg, --surface, --text, --accent, --border` (minimum set for evaluation compatibility)
+
+**Typography:**
+- **Inter font mandatory** — `https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap`
+- **MANDATORY font weight hierarchy:** h1 ≥ 700, h2 ≥ 600, h3 ≥ 500, body = 400 (critical evaluation requirement)
+- -0.03em tracking on headings
+- **KOREAN TYPOGRAPHY EXCELLENCE:** For Korean content, use Noto Sans KR for body text with Inter for UI elements. Apply `line-height: 1.6` for Korean (vs 1.4 for Latin). Korean Medium weight maps to Western Regular (400). Include: `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap`
+
+**Colors:**
+- Class-based theming only (NO @media prefers-color-scheme)
+- Dark: #0A0A0A bg, #EDEDED text. Light: #FAFAF9 bg, #0f172a text
+- See reference for full palette.
+- **Cards:** 8px radius, shadow-only hover (no translateY/scale), 1px solid var(--border). **GLASS MORPHISM UPGRADE:** For premium layouts, use glass containers with `backdrop-filter: blur(8px)`, semi-transparent backgrounds with CSS var `--glass-opacity: 0.08`, and elevated shadows. Apply selectively to hero sections or primary cards for sophisticated layering.
+- **Animations:** CSS @keyframes for page-load (.animate + .delay-N), data-reveal + IntersectionObserver for scroll, data-count for counters. Content visible by default. **Above-fold content must NEVER use data-reveal** — use `.animate` classes instead. Use `data-reveal` sparingly (max 3-4 sections) for below-fold content only.
+- **Accessibility:** Skip-to-content, aria-labels, landmark roles, :focus-visible, sr-only for chart data. See reference for full checklist.
+- **Icons:** Inline SVG only, never emojis. Lucide-style 24x24, stroke-based.
+- **Chart.js (MANDATORY PATTERNS):** `Chart.defaults.animation = false;` at top of script, destroy+recreate on theme toggle, explicit rgba() colors, tooltips always enabled, `maintainAspectRatio: false` on all chart options. **Accessibility: Wrap canvas in div with `role="img"` and descriptive `aria-label`**. **Guard pattern:** Use `chartsBuilt` flag — `onThemeChange()` must check `if (chartsBuilt)` before rebuilding. **Chart containers need min-height: 360px for substantial presence.**
+- **Chart.js customization:** Apply professional styling beyond defaults — custom padding (`layout: { padding: 30 }`), remove excessive gridlines (opacity ≤ 0.04), use rounded corners (`borderRadius: 4`), thoughtful color palettes that match theme. Chart containers need 12px border radius, 40px internal padding, and 360px minimum height for substantial presence. Avoid library defaults that look auto-generated.
+- **Typography hierarchy:** MANDATORY descending font-size scale: h1 > h2 > h3 > body text. **REQUIRED MINIMUMS:** h1: ≥3rem (48px), h2: ≥2rem (32px), h3: ≥1.5rem (24px), body: 1rem (16px). **EVALUATION CRITICAL:** Each heading level must be visibly smaller than the previous level with at least 0.5rem difference between levels. Example valid hierarchy: h1: 3rem, h2: 2.5rem, h3: 1.5rem, body: 1rem.
+- **Visual restraint:** No floating orbs, gradient borders, gradient text on headings, scale transforms, glow effects, decorative animations.
+- **Stat value colors:** Colored numbers must have semantic meaning (green/positive = good metric, red/negative = bad metric, accent = primary/neutral highlight). If no clear semantic meaning, use `var(--text)`. Never randomly colorize stat values. **For KPI grids with 4+ cards:** use at most 2 accent colors for values — `var(--accent)` for the single most important metric and `var(--text)` for all others. Reserve `var(--positive)`/`var(--negative)` only for delta indicators (arrows, percentages), not the main card value.
+- **Background atmosphere:** One subtle technique per file (radial gradient, noise texture, or dot grid). **Adapt the atmosphere to the content** — a game dashboard should feel different from a financial report. Adjust accent colors and gradient hues to match the subject matter.
+- **AI-NATIVE INFORMATION ARCHITECTURE:** Modern designs prioritize insight-driven hierarchy. Place the most important metric/insight above the fold. Use progressive revelation patterns — show key data immediately, provide drill-down on hover/click. Contextual actions should appear near relevant content. Lead with conclusions, support with details.
+- **Entrance animations mandatory:** fadeInUp + stagger on all cards/sections.
+- **Single-screen posters:** overflow:hidden + justify-content:space-between on fixed-dimension body. See reference for 9:16, 1:1, 4:5 sizing.
+
+
+## Critical Implementation Requirements
+
+**MANDATORY: Use the skeleton template** — see [references/skeleton.md](references/skeleton.md) for complete copy-paste HTML with all requirements built-in.
+
+**JavaScript Implementation Rules:**
+- **All top-level variables MUST use `var`** (not `let`/`const`) to avoid TDZ errors with function hoisting
+- **Theme toggle MUST use `cycleTheme()` function** — this is built into the skeleton with proper `applyTheme()` implementation
+- **Menu MUST use `toggleMenu()` with outside-click handling** — skeleton includes automatic dropdown closure on outside clicks and escape key
+- **Chart rebuilding:** Define `function onThemeChange() {}` for chart re-rendering on theme changes
+- **Mobile responsive:** Test all layouts at 375px viewport width — use CSS Grid `minmax(320px, 1fr)` for card grids
+
+**Evaluation Checkers Expect:**
+- `cycleTheme()` function exists and works (changes html class)
+- `toggleMenu()` function exists and closes on outside clicks  
+- Top-level JS variables are declared with `var`
+- No horizontal overflow at 375px width
+- Interactive elements beyond basic menu (hover states, chart interactions, etc.)
+
+**The skeleton template automatically provides all required functionality. ALWAYS start from skeleton.md to avoid implementation errors.**
+
+## Semantic HTML Requirements
+
+All visualizations must include these semantic elements:
+
+**Required Structure:**
+- `<main>` element containing primary content
+- `<section>` elements for major content blocks
+- Landmark roles (`role="banner"`, `role="main"`, `role="complementary"`) OR skip-to-content link
+- Chart accessibility: `role="img"` and `aria-label` on chart containers
+
+**Additional Requirements:**
+- `@media print` styles defined
+- `@media (prefers-reduced-motion)` styles for accessibility
+- Adequate spacing between sections (≥48px)
+- Hover states for interactive elements
+
+## Visualization Types
+
+Choose the right format. See [references/types.md](references/types.md) for detailed patterns.
+
+| Type | When to Use | Key Feature |
+|------|-------------|-------------|
+| **Slide Deck** | Presentations, pitches | 16:9, keyboard nav, transitions |
+| **Infographic** | Data summaries, visual stories | Long scroll, big numbers, sections |
+| **Dashboard** | Metrics, KPIs | Grid of cards + charts |
+| **Flowchart** | Processes, architecture | Mermaid or SVG diagrams |
+| **Timeline** | Chronological events | Alternating left/right, scroll-triggered |
+| **Comparison** | Side-by-side analysis | Feature matrix, pros/cons |
+| **Data Viz** | Charts, data stories | Chart.js or D3 |
+| **One-Pager** | Summaries, briefs | Single viewport, print-friendly |
+| **Mind Map** | Concept relationships | Radial SVG layout |
+| **Kanban** | Status tracking | Column-based cards |
+| **Carousel Cards** | Social media (IG/LinkedIn) | 1080×1080 per card, swipeable, bold text |
+| **Event Poster** | Conferences, meetups, webinars | Portrait A4/letter, bold headline, date/venue |
+| **Resume/CV** | Job applications | One-page, two-column, print-optimized |
+| **Banner/Header** | Email, blog, social cover | 1200×630 or 1500×500, centered text on visual bg |
+| **Quote Card** | Social proof, testimonials | Portrait/square, large quote, attribution |
+| **Process Guide** | How-to, step-by-step | Numbered steps, icons, clear flow |
+| **Status Report** | Executive updates | KPIs + progress bars + highlights, one-page |
+| **Org Chart** | Team structure | Hierarchical tree, photos/avatars, roles |
+| **Data Story** | Narrative + data | Scrollytelling, charts woven with narrative text |
+| **Product Card** | Feature highlight, launch | Hero image area, feature pills, CTA |
+
+### Carousel Card Rules
+
+Carousel cards are huge for social media. Get these right:
+
+- **Square format** — `1080×1080px` (or configurable via CSS var)
+- **One idea per card** — bold headline + 1-2 supporting points max
+- **Swipe nav** — arrows + dots + touch swipe + keyboard
+- **Card counter** — "3 / 8" visible
+- **Download all** — PNG export of individual cards or full set
+- **Typography dominates** — headline at 2.5-4rem, minimal body text
+- **Color-coded** — each card can have a subtle accent shift
+- **Print layout** — grid of all cards for printing
+- **Max 10 cards** — keep it focused
+
+### Event Poster Rules
+
+- **Portrait orientation** — A4/letter ratio or square
+- **Visual hierarchy** — Event name (largest) → Date/Time → Location → Description → CTA
+- **Bold headline** — 3-5rem, max 6 words
+- **Date/time prominent** — styled as a badge or highlighted block
+- **QR code area** — placeholder box for registration link
+- **Print-first** — looks great printed, dark or light theme
+
+### Quote Card Rules
+
+- **Large quotation marks** — decorative " " in accent color, oversized
+- **Quote text** — 1.5-2.5rem, serif or italic weight for contrast
+- **Attribution** — name, title, company below quote
+- **Square or portrait** — optimized for social sharing
+- **Minimal design** — quote is the hero, everything else is subtle
+
+### Single-Screen / Mobile-Fit Rules (Posters, Cards, One-Pagers)
+
+When the user asks for something that fits "one screen," "phone screen," "9:16," or "mobile-fit," create a **fixed-dimension single-viewport** visualization — NOT a scrolling page.
+
+**Dimensions:**
+- **9:16 portrait (phone):** `width: 1080px; height: 1920px;` — standard Instagram Story / phone screen
+- **1:1 square:** `width: 1080px; height: 1080px;` — Instagram post
+- **4:5 portrait:** `width: 1080px; height: 1350px;` — Instagram portrait post
+- **16:9 landscape:** `width: 1920px; height: 1080px;` — presentation slide
+
+**Critical CSS pattern:**
+```css
+body {
+  width: 1080px; height: 1920px; /* or chosen ratio */
+  overflow: hidden; /* MUST — prevents scroll, enforces single screen */
+  display: flex; flex-direction: column; /* Flex column fills canvas completely */
+}
+.poster-header { padding: 44px 48px 0; }
+.poster-grid { flex: 1; padding: 24px 48px 0; } /* flex:1 expands to fill remaining space */
+.poster-footer { padding: 16px 48px 36px; }
+```
+
+**Layout rules:**
+- `overflow: hidden` on body — this is what makes it "one screen." Non-negotiable.
+- `justify-content: space-between` on the main container — distributes sections evenly with NO dead gaps.
+- **Use `flex: 1` on the main content area** (grid, body, etc.) so it expands to fill ALL remaining space between header and footer. Never use fixed `height` values that leave dead space.
+- Wrap each logical section in a `<div>` so flexbox distributes them as blocks.
+- **Zero dead space rule:** The poster canvas should be 100% utilized. No large empty margins at bottom or sides. If there's visible empty space, either expand content to fill it or reduce padding. Content should feel like it "fits" the frame perfectly.
+- **Test mentally:** count your sections, divide 1920px among them. Each section gets ~200-300px. If content is sparse, make elements bigger (larger fonts, more padding, bigger icons).
+- **No hamburger menu** for fixed-dimension posters — it wastes space and the poster is meant for screenshot/export, not interaction.
+
+**Content density for 9:16:**
+- Hero (title + subtitle): ~25% of height
+- 2-3 content sections: ~55% of height
+- Footer/CTA: ~10% of height
+- Breathing room (gaps): ~10% of height
+- **If it looks empty, your content is too small.** Scale up fonts, add more grid items, use larger icons.
+
+**Font sizing for 1080px-wide posters:**
+- Hero h1: `68-80px` (bigger than web — this is a poster)
+- Section labels: `15-18px` uppercase, letter-spacing `0.06em`
+- Card text: `16-20px`
+- Body: `20-24px`
+
+**Common mistake:** Making a scrolling page and screenshotting it. That's NOT a poster — it's a webpage screenshot. A poster is a fixed canvas where every pixel is intentional.
+
+## Slide Deck Rules
+
+Slides are the most common request. Get these right:
+
+- **16:9 aspect ratio** — `100vw × 100vh`, content centered
+- **Responsive breakpoints** — Use `clamp()` and container queries for mobile-friendly slides:
+  ```css
+  .slide-container { container-type: inline-size; }
+  .slide-title { font-size: clamp(2rem, 8vw, 4rem); }
+  @container (width < 768px) { .slide-content { padding: 1rem; } }
+  ```
+- **One idea per slide** — if you need a second thought, make a second slide
+- **Max 40 words per slide** — more than that, split or use visuals
+- **Headlines max 6 words** — short, punchy, memorable
+- **Big number + small label** for stat slides — number at 3-5rem, label at 0.875rem
+- **Keyboard nav** — ← → arrows, Space, Enter
+- **Touch nav** — swipe left/right
+- **Click nav** — left third = prev, right two-thirds = next
+- **Progress bar** — thin gradient bar at top showing position
+- **Slide counter** — "3 / 12" in bottom nav
+- **Mobile navigation prominence** — Ensure navigation controls are clearly visible on mobile. Use larger touch targets (min 44px), contrasting colors, and backdrop-blur for floating nav
+- **Smooth transitions** — `transform: translateX()` with 500ms cubic-bezier
+- **Entrance animations** — elements within slides animate in with staggered delays
+- **Speaker notes** — `data-notes` attribute, visible in print only
+
+### High-Impact Presentation Slides (Business Context)
+For investor presentations, startup pitches, and executive briefings:
+- **Hero slide visual weight** — Use stronger gradients, larger typography (4-6rem), and compelling statistics prominently displayed
+- **Value proposition clarity** — Hero should communicate core value in under 5 seconds
+- **Professional credibility** — Ensure typography, spacing, and color choices match enterprise/investment-grade expectations
+- **Data storytelling** — Each chart slide should have clear insight callouts, not just raw data visualization
+
+### Theme-Aware Slide Gradients (CRITICAL)
+
+Slide decks MUST look visually distinct in dark vs light themes. Gradient backgrounds must change:
+
+```css
+/* Dark theme: deep, saturated gradients */
+.theme-dark .slide-title { background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #1e3a5f 100%); }
+.theme-dark .slide-content { background: var(--bg); }
+
+/* Light theme: soft, pastel gradients */
+.theme-light .slide-title { background: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 50%, #dbeafe 100%); }
+.theme-light .slide-content { background: var(--bg); }
+```
+
+Rules:
+- Title/section slides: use theme-specific gradient pairs (dark=deep+saturated, light=soft+pastel). **Choose gradient colors that evoke the content's subject matter** — a tech pitch uses cool blues, a game pitch uses vibrant purples/cyans, a healthcare deck uses calming greens/teals.
+- Content slides: use `var(--bg)` or `var(--surface)` — NOT hardcoded dark backgrounds
+- Data cards on slides: use `var(--surface)` with `var(--border)` — they auto-adapt
+- Never hardcode `#1a1a2e` or similar dark colors on slide content — use CSS variables
+- Test: toggle theme and every slide should look intentionally designed for that mode
+
+### Slide Types
+1. **Title** — theme-aware gradient background, big headline, subtitle. Center aligned.
+2. **Content** — heading + bullets OR heading + visual. Never text-heavy.
+3. **Section divider** — full-bleed accent color, section title only.
+4. **Stat** — one big number, one label, one insight sentence.
+5. **Chart** — Chart.js visualization with title and key takeaway. MUST use chart-container wrapper class.
+6. **Two-column** — split layout for comparisons, text+visual.
+7. **Quote** — large pull quote with attribution.
+8. **Closing** — CTA, contact info, or summary + social links.
+
+### Slide Deck Chart Requirements (CRITICAL)
+Chart slides in presentations MUST follow the same container standards as dashboards:
+```html
+<div class="chart-slide-container">
+  <h2>Chart Title</h2>
+  <div class="chart-container" style="height: 400px; padding: 40px; border-radius: 12px; background: var(--surface);">
+    <canvas id="slideChart" role="img" aria-label="Description"></canvas>
+  </div>
+</div>
+```
+- **Use chart-container class** — maintains evaluation consistency across formats
+- **Minimum height 400px** for slide charts — larger than dashboard charts for presentation readability
+- **maintainAspectRatio: false** — required for proper sizing in slide layouts
+
+## Data Ingestion
+
+When user provides data:
+- **CSV** — parse with JS, auto-detect headers, render appropriate chart type
+- **JSON** — extract keys as labels, values as data, nested objects as series
+- **Tables** — convert to visual comparison or chart
+- **Numbers in text** — extract and highlight as stat cards
+- **URLs** — crawl, extract key info, visualize as summary
+
+## Context Awareness
+
+This skill is used mid-conversation. Leverage everything:
+
+- **Conversation context** — summarize, structure, or visualize what's been discussed
+- **URLs/links** — crawl and extract content, then visualize
+- **Pasted data** — CSV, JSON, tables → charts, dashboards
+- **Ideas/concepts** — turn abstract discussions into visual diagrams
+- **Code/architecture** — visualize system designs, data flows
+
+Always use real content. Never generate placeholder data when real context exists.
+
+## Type-Specific Interactivity (Mandatory)
+
+Every file MUST have at least ONE meaningful interaction beyond theme toggle + menu. Static-feeling pages score low on interactivity.
+
+| Type | Required Interaction |
+|------|---------------------|
+| **Cheatsheet** | Search/filter input + copy-to-clipboard on code blocks. Use `<details name="...">` for collapsible groups. |
+| **Dashboard** | Filter toolbar or metric drill-down. At minimum: date range or category filter. |
+| **Status Report** | Collapsible detail sections (use `<details>`). Progress bars animate on scroll. |
+| **Quote Card** | Auto-cycling quotes OR swipeable carousel. Share/copy button. |
+| **Event Poster** | Animated countdown timer (days/hours/min/sec). RSVP/register button. |
+| **Process Guide** | Steps as exclusive accordion (`<details name="steps">`). Or interactive progress tracker. |
+| **Architecture** | Clickable nodes with popover details (use Popover API). Hover highlights connections. |
+| **Timeline** | Filter by era/category. Or click to expand event details. |
+| **Comparison** | Toggle categories on/off. Or highlight winner per row. |
+| **Carousel** | Touch swipe + keyboard + auto-advance option. Card counter always visible. |
+| **Slide Deck** | Already interactive (nav). Add: presenter timer, slide overview grid. |
+
+If a type isn't listed, add at minimum: a filter, search, sort, or expand/collapse interaction.
+
+## Layout Variation (CRITICAL)
+
+Every file must feel like a UNIQUE design, not a template with different text. Vary these per file type:
+- **Grid structure**: Mix 1-col, 2-col, 3-col. Use CSS Grid `span 2` for featured cards. **CRITICAL: Always test at 768px and 375px - no horizontal overflow allowed.**
+
+**Mobile-First Responsive Pattern (MANDATORY):**
+```css
+.grid { 
+  display: grid; 
+  gap: 24px; 
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); 
+}
+@media (max-width: 768px) { 
+  .grid { grid-template-columns: 1fr; gap: 16px; }
+  .container { padding: 24px 16px; }
+}
+@media (max-width: 375px) {
+  .card { padding: 16px; }  
+  .stat-value { font-size: 2rem; }
+}
+```
+- **Section rhythm**: Alternate between full-width sections, card grids, and single-focus sections.
+- **Content density**: More content at smaller sizes looks more professional than sparse content at large sizes. A dashboard with 8 KPI cards + 4 charts feels real; 4 KPI cards + 2 charts feels like a demo.
+- **Visual focal point**: Every file needs ONE visually dominant element (hero stat, key chart, primary message) — not everything at equal weight.
+- **No orphaned grid items**: When a grid has an odd number of items where the last row isn't full, use `grid-column: span 2` on the last item or adjust `grid-template-columns` to avoid a single card stranded alone on a row.
+
+## Anti-Patterns
+
+- ❌ Walls of text — if it reads like a document, it's not a visualization
+- ❌ Tiny fonts — minimum 14px body, 20px+ for presentation headings
+- ❌ Rainbow colors — stick to 2-3 colors from the palette + neutrals
+- ❌ Placeholder content — never use "Lorem ipsum" or fake data
+- ❌ Over-engineering — simplest approach that looks stunning
+- ❌ Cramped layouts — when in doubt, add more whitespace
+- ❌ Generic design — each visualization should feel intentional, not templated
+- ❌ Missing menu — every output needs the hamburger menu
+- ❌ Broken print — always include `@media print` styles
+
+## Advanced Techniques
+
+Use these when they add value. See [references/css-techniques.md](references/css-techniques.md) for code snippets.
+
+- **Glass morphism** — `backdrop-blur-md bg-white/5 border border-white/10` for floating cards
+- **Gradient text** — `background: linear-gradient(...); -webkit-background-clip: text` for hero headlines
+- **Scroll-snap** — `scroll-snap-type: y mandatory` as alternative slide navigation (no JS needed)
+- **Conic gradients** — `conic-gradient()` for pure CSS pie/donut charts
+- **Number animations** — animate counters from 0 to target value on scroll
+- **Spring easing** — `cubic-bezier(0.34, 1.56, 0.64, 1)` for playful micro-interactions
+- **Animate to auto** — `interpolate-size: allow-keywords` on `:root` enables smooth `height: auto` transitions (Chrome 129+)
+- **CSS counters** — auto-numbering for step-by-step processes
+- **View Transitions API** — smooth theme switching animations
+- **Inline SVG icons** — draw simple icons as `<svg>` paths, no icon library needed
+
+## Mandatory HTML Skeleton
+
+**EVERY visualization MUST start from the skeleton.** Copy it, then add content.
+
+**Full skeleton code:** See [references/skeleton.md](references/skeleton.md) for the complete copy-paste HTML template with themes, print styles, Inter font, animations, menu, and hover effects.
+
+The skeleton provides:
+- Class-based dark/light theming (OS detection on first visit, localStorage persistence)
+- CSS @keyframes animations (fadeInUp, fadeIn, slideInLeft, slideInRight) + .animate/.delay-N classes
+- Scroll-reveal via data-reveal attribute + IntersectionObserver
+- Number counter via data-count attribute
+- Hamburger menu with theme toggle, PNG download (html-to-image), print/PDF
+- Popover and details accordion CSS (Chrome 114+/120+)
+- Print styles with @page margin boxes
+- prefers-reduced-motion support
+
+### Skeleton Rules
+- Use `var` for all top-level JS variables (prevents TDZ errors)
+- MANDATORY: Use `data-reveal` for scroll animation OR `.animate.delay-N` for page-load entrance. Add JavaScript scroll observer for `.reveal` classes.
+- Define `function onThemeChange() {}` to re-render charts on theme toggle
+- Use semantic HTML: `<main>`, `<section>`, `<header>`, `<article>`
+- Don't use `let`/`const` at script top level
+
+## Minimum Sizing Rules
+
+Elements must be large enough to read and feel substantial:
+
+- **Timeline cards:** minimum width 280px, minimum padding 20px
+- **Timeline layout:** Distribute timeline items evenly to prevent large gaps. If you have 5 items but only fill 60% of the vertical space, add more content sections (like investment breakdown or impact metrics) to fill the remaining 40%. Never leave massive empty spaces below the last timeline item.
+- **Chart containers:** minimum 60% of parent width, minimum height 300px (360px+ for dashboards). In grid layouts, charts should use `flex-grow: 1` to fill available space — 300px is a floor, not a target.
+- **Stat numbers:** minimum font-size 2rem (32px), bold/extrabold weight
+- **Card content area:** minimum padding 24px
+- **Section spacing:** **MANDATORY minimum 48px between major sections** — use `margin-bottom: 48px` or larger on section elements
+- **Slide headings:** minimum 2rem (32px), maximum 6 words
+- **Body text:** minimum 1rem (16px), never smaller
+
+**If content feels too small, it IS too small. Err on the side of larger.**
+
+## Text Visibility Rules
+
+**Text must ALWAYS be visible.** This is the #1 cause of broken outputs.
+
+- Dark theme: text MUST use `var(--text)` which resolves to `#f9fafb` (near-white)
+- Light theme: text MUST use `var(--text)` which resolves to `#0f172a` (near-black)
+- On gradient backgrounds: add `text-shadow: 0 1px 3px rgba(0,0,0,0.3)` for readability
+- On hero slides with gradient/image backgrounds: use a dark overlay (`rgba(0,0,0,0.5)`)
+- NEVER set text color to a value close to the background color
+- Test mentally: "would this text be visible on BOTH dark (#030712) and light (#f8fafc) backgrounds?"
+
+## Chart.js Integration Rules (CRITICAL — MOST COMMON FAILURE)
+
+Charts are the second most common failure. These rules are MANDATORY for every chart:
+
+### 1. Container Structure (REQUIRED)
+```html
+<!-- MANDATORY PATTERN FOR EVERY CHART -->
+<div role="img" aria-label="Detailed description of chart data and insights">
+  <div class="chart-container" style="height: 360px; padding: 40px; border-radius: 12px; background: var(--surface);">
+    <canvas id="uniqueChartId"></canvas>
+  </div>
+</div>
+```
+
+### 2. Canvas Dimensions (REQUIRED)
+- **Container must have explicit height:** minimum 360px for dashboards, 300px for other types
+- **Canvas element needs no sizing** — Chart.js handles this when `maintainAspectRatio: false`
+- **Container padding:** 40px internal padding for professional spacing
+- **Container border-radius:** 12px for modern card appearance
+
+### 3. Chart.js Initialization (MANDATORY PATTERN)
+```javascript
+// REQUIRED: Chart destruction and canvas reset to prevent "Canvas already in use" errors
+var chartsBuilt = false; // Guard flag
+
+function buildCharts() {
+  if (chartsBuilt) return; // Prevent double-initialization during theme detection
+  
+  // REQUIRED: Reset canvas before building
+  function resetCanvas(id) {
+    var old = document.getElementById(id);
+    if (!old) return null;
+    var parent = old.parentNode;
+    var canvas = document.createElement('canvas');
+    canvas.id = id;
+    parent.replaceChild(canvas, old);
+    return canvas;
+  }
+  
+  // Example chart with required settings
+  var ctx = resetCanvas('myChart');
+  if (ctx) {
+    new Chart(ctx, {
+      type: 'bar',
+      data: { /* your data */ },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false, // REQUIRED
+        animation: false, // MANDATORY: Plus set Chart.defaults.animation = false globally
+        plugins: {
+          tooltip: {
+            enabled: true, // NEVER disable tooltips
+            padding: 12,
+            cornerRadius: 8
+          }
+        },
+        layout: { padding: 20 } // REQUIRED: breathing room
+      }
+    });
+  }
+  
+  chartsBuilt = true; // Mark as built
+}
+
+// CRITICAL: Disable Chart.js default animations IMMEDIATELY after Chart.js loads
+Chart.defaults.animation = false; // MUST be set before any chart creation
+
+// REQUIRED: Build charts after DOM loads
+document.addEventListener('DOMContentLoaded', buildCharts);
+
+// REQUIRED: Rebuild charts on theme change
+function onThemeChange() {
+  chartsBuilt = false; // Reset flag
+  setTimeout(buildCharts, 100); // Slight delay for CSS variable updates
+}
+```
+- **MANDATORY: Hover tooltips enabled** — never disable Chart.js tooltips:
+  ```javascript
+  options: {
+    plugins: {
+      tooltip: {
+        enabled: true, // NEVER set to false
+        mode: 'index',
+        intersect: false
+      }
+    }
+  }
+  ```
+- **Minimum chart height:** 300px on desktop, 250px on mobile
+- **Font size defaults:** Axis tick labels at 13px minimum, axis titles at 14px, chart titles at 16px minimum. Legend at 13px.
+- **Chart padding:** Add `layout: { padding: { top: 20, right: 20, bottom: 20, left: 20 } }` for breathing room
+- **Axis tick config:** `maxRotation: 0` to keep labels horizontal. If labels overflow, use `maxTicksLimit` to reduce count
+- **Grid lines:** Very faint — `rgba(255,255,255,0.04)` in dark, `rgba(0,0,0,0.06)` in light
+- **Tooltip styling:** `padding: 12`, `cornerRadius: 8`, `titleFont: { size: 14 }`, `bodyFont: { size: 13 }`
+- **Point radius:** 0 by default, 6 on hover — cleaner line charts
+- **Set `maintainAspectRatio: false`** and control size via CSS container
+- **Use theme-aware colors:** read CSS vars at render time, re-render on theme change
+- **Chart text colors:** set `Chart.defaults.color = getComputedStyle(root).getPropertyValue('--text-secondary').trim()`
+- **Grid line colors:** use `var(--border)` value
+- **Legend position:** 'top' for horizontal charts, 'right' for vertical with space
+- **Axis labels:** Keep horizontal when possible - avoid rotation unless absolutely necessary
+- **Donut/pie charts:** Always include percentage labels on segments
+- **Responsive:** `responsive: true` is default, but container must have explicit dimensions
+- **High contrast colors:** Ensure sufficient color difference between data series for accessibility
+
+```javascript
+// Theme-aware Chart.js setup (include in every chart visualization)
+function getChartColors() {
+  var s = getComputedStyle(document.documentElement);
+  return {
+    text: s.getPropertyValue('--text').trim(),
+    textSecondary: s.getPropertyValue('--text-secondary').trim(),
+    border: s.getPropertyValue('--border').trim(),
+    surface: s.getPropertyValue('--surface').trim(),
+    accent: s.getPropertyValue('--accent').trim(),
+  };
+}
+
+// REQUIRED: Reset canvas before rebuilding charts (prevents "Canvas already in use" errors)
+function resetCanvas(id) {
+  var old = document.getElementById(id);
+  var parent = old.parentNode;
+  var canvas = document.createElement('canvas');
+  canvas.id = id;
+  parent.replaceChild(canvas, old);
+  return canvas;
+}
+
+// Usage in buildCharts():
+//   try { if (window.myChart) window.myChart.destroy(); } catch(e) {}
+//   window.myChart = new Chart(resetCanvas('myChart'), { ... });
+
+// CRITICAL: Always check chart existence before destroy() to prevent console errors
+function buildCharts() {
+  var isDark = document.documentElement.classList.contains('theme-dark');
+  var colors = getChartColors();
+  
+  // Safe chart destruction and rebuild pattern
+  if (window.myChart) {
+    try { window.myChart.destroy(); } catch(e) { /* ignore */ }
+  }
+  window.myChart = new Chart(resetCanvas('myChart'), {
+    // chart config with theme-aware colors
+    options: {
+      scales: {
+        x: { ticks: { color: colors.textSecondary }, grid: { color: colors.border } },
+        y: { ticks: { color: colors.textSecondary }, grid: { color: colors.border } }
+      }
+    }
+  });
+}
+```
+
+## Critical Debugging Patterns
+
+### Counter Animation Debug Pattern
+If KPI values show "0%" instead of animating, add this debug pattern:
+```javascript
+// DEBUG: Add after counter observer setup to verify intersection
+var counterEl = document.querySelector('[data-count]');
+if (counterEl) {
+  console.log('Counter element found:', counterEl); // DEBUG
+  var cObs = new IntersectionObserver(function(entries) {
+    console.log('Counter intersection triggered:', entries); // DEBUG
+    entries.forEach(function(e) { 
+      if (e.isIntersecting) { 
+        console.log('Starting counter animation'); // DEBUG
+        animateCounters(); 
+        cObs.disconnect(); 
+      } 
+    });
+  }, { threshold: 0.3 });
+  cObs.observe(counterEl);
+} else {
+  console.warn('No [data-count] elements found'); // DEBUG
+}
+```
+
+### Chart.js Integration Safety Pattern
+MANDATORY for all Chart.js usage to prevent console errors:
+```javascript
+// STEP 1: Global variables - MUST use var, never let/const
+var chartsBuilt = false;
+
+// STEP 2: Chart building function with validation
+function buildCharts() {
+  // CRITICAL: Always validate Chart.js loaded first
+  if (chartsBuilt || typeof Chart === 'undefined') return;
+  
+  // STEP 3: Destroy existing charts to prevent "Canvas already in use"
+  if (window.myChart) window.myChart.destroy();
+  
+  // STEP 4: Reset canvas elements
+  var canvas = document.getElementById('chartId');
+  if (!canvas) return;
+  
+  // STEP 5: Get theme colors from CSS variables
+  var isDark = document.documentElement.className.includes('theme-dark');
+  var textColor = isDark ? '#EDEDED' : '#0f172a';
+  var gridColor = isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.06)';
+  
+  // STEP 6: Create chart with proper options
+  try {
+    window.myChart = new Chart(canvas.getContext('2d'), {
+      // Your chart configuration here
+      options: {
+        responsive: true,
+        maintainAspectRatio: false, // REQUIRED
+        plugins: {
+          tooltip: { enabled: true }, // REQUIRED - never disable
+          legend: { 
+            labels: { color: textColor, font: { family: 'Inter' } }
+          }
+        },
+        scales: {
+          x: { 
+            ticks: { color: textColor },
+            grid: { color: gridColor }
+          },
+          y: { 
+            ticks: { color: textColor },
+            grid: { color: gridColor }
+          }
+        }
+      }
+    });
+    
+    chartsBuilt = true;
+  } catch (error) {
+    console.error('Chart creation failed:', error);
+  }
+}
+
+// STEP 7: Theme change handler
+function onThemeChange() {
+  if (chartsBuilt) {
+    chartsBuilt = false;
+    buildCharts();
+  }
+    var ctx = document.getElementById('myChart');
+    if (!ctx) {
+      console.error('Chart canvas #myChart not found');
+      return;
+    }
+    // ... build chart
+  } catch (error) {
+    console.error('Chart building failed:', error);
+  }
+}
+```
+
+### Menu Outside-Click Fix
+Ensure menu closes when clicking outside by strengthening the event handler:
+```javascript
+document.addEventListener('click', function(e) { 
+  var menu = document.querySelector('.viz-menu');
+  var dropdown = document.getElementById('vizMenuDropdown');
+  if (!e.target.closest('.viz-menu') && dropdown) {
+    dropdown.classList.remove('open');
+  }
+});
+```
+
+## Process
+
+1. **Understand** — what's the message? Who's the audience? What format fits?
+2. **Start from skeleton** — copy the Mandatory HTML Skeleton above. NEVER start from a blank file.
+3. **Structure** — outline content/sections BEFORE filling in the skeleton
+4. **Build** — add content, charts, styles. Keep all colors as CSS vars.
+5. **Verify checklist:**
+   - [ ] `html.theme-dark` and `html.theme-light` class-based theme selectors (NO @media prefers-color-scheme)?
+   - [ ] JS detects OS preference on first visit, stores in localStorage?
+   - [ ] All text uses `var(--text)` or `var(--text-secondary)`?
+   - [ ] `@media print` hides menu, shows all content?
+   - [ ] `@media (prefers-reduced-motion: reduce)` present?
+   - [ ] `.viz-menu` with toggle, theme, download, print?
+   - [ ] Correct font loaded? (Inter default, Noto Sans KR for Korean, etc.)
+   - [ ] Non-Latin content has appropriate CJK/RTL font?
+   - [ ] Entrance animations via `.animate` classes (CSS @keyframes)?
+   - [ ] Scroll sections use `data-reveal` (visible without JS)?
+   - [ ] `.card:hover` has transform effect?
+   - [ ] All top-level JS variables use `var` (not `let`/`const`)?
+   - [ ] Charts use `var` declarations + `onThemeChange` hook?
+   - [ ] **MANDATORY:** All charts wrapped with `role="img" aria-label="..."`?
+   - [ ] **MANDATORY:** All charts have hover tooltips enabled (never disabled)?
+   - [ ] Animated number counters use `data-count` where stats exist?
+   - [ ] Semantic HTML: `<main>`, `<section>`, `<header>`, `<article>`?
+   - [ ] All charts have explicit container sizing (≥300px height)?
+   - [ ] Hero/title text visible on both themes?
+   - [ ] Minimum sizing rules followed (cards 280px+, text 16px+)?
+   - [ ] Zero console errors on load?
+
+The quality bar: **"good, period"** — not "good for AI-generated."

--- a/claude/skills/visualize/examples/EXAMPLES.md
+++ b/claude/skills/visualize/examples/EXAMPLES.md
@@ -1,0 +1,51 @@
+# Visualization Examples – Quality Self-Assessment
+
+## 1. 🍳 Startup Pitch Deck (`startup-pitch-deck.html`)
+**Rating: 9/10**
+- 10-slide deck with keyboard/swipe navigation, smooth transitions
+- Chart.js market size bar chart and traction line chart
+- Strong visual hierarchy with gradient big numbers, card-based layouts, team avatars
+- 16:9 full-viewport slides, nav dots, slide counter
+- Could improve: slide transition variety, more animation polish on chart entrance
+
+## 2. 📊 SaaS Dashboard (`saas-dashboard.html`)
+**Rating: 9/10**
+- 6 KPIs with color-coded left borders and trend indicators
+- 4 charts: revenue line, churn donut, user growth bar, revenue by plan donut
+- Responsive grid, fade-up animations, auto-updating date
+- Clean data visualization hierarchy
+- Could improve: sparklines in KPI cards, time range selector
+
+## 3. 🤖 AI Timeline (`ai-timeline.html`)
+**Rating: 8.5/10**
+- 15 milestones from 1950–2025, alternating left/right layout
+- Scroll-triggered fade-in animations via IntersectionObserver
+- Central connecting line with accent dot markers
+- Emoji icons per milestone, gradient hero title
+- Could improve: replace emoji with proper inline SVG icons, add parallax effects
+
+## 4. 🏠 Comparison Infographic (`comparison-infographic.html`)
+**Rating: 8.5/10**
+- Long-scroll format with big stats, pros/cons columns, charts, icon cards
+- Radar chart for satisfaction comparison, horizontal bar for productivity
+- Color-coded remote (teal) vs office (purple) throughout
+- Scroll-triggered section animations
+- Could improve: animated counters for big numbers, more visual variety between sections
+
+## 5. 🏗️ System Architecture (`system-architecture.html`)
+**Rating: 8/10**
+- Mermaid.js diagram: Clients → API Gateway → 4 Services → Data Layer → External APIs
+- Subgraph grouping with color-coded borders
+- Legend + 4 annotation cards with architectural details
+- Clean professional layout
+- Could improve: Mermaid theme toggle is fragile, could add interactive tooltips on hover
+
+---
+
+## Common Features (all 5 files)
+✅ Hamburger menu with theme toggle, PNG download, print/PDF
+✅ Dark/light theme via CSS custom properties + `data-theme`
+✅ HSL color system, system fonts, responsive design
+✅ html-to-image CDN for PNG export
+✅ Single self-contained HTML files (no external deps except CDN)
+✅ WCAG AA contrast ratios maintained in both themes

--- a/claude/skills/visualize/examples/ai-timeline.html
+++ b/claude/skills/visualize/examples/ai-timeline.html
@@ -1,0 +1,541 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Evolution Timeline - 1950 to 2025</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    
+    
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.04);
+      --text: #EDEDED; --text-secondary: #888888;
+      --accent: #14b8a6; --accent-secondary: #0d9488;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #FFFFFF; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.06);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #14b8a6; --accent-secondary: #0d9488;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6; -webkit-font-smoothing: antialiased;
+      letter-spacing: -0.011em; font-feature-settings: 'cv11', 'ss01';
+      transition: background 0.3s, color 0.3s;
+      font-weight: 400;
+      scrollbar-gutter: stable;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+    html.theme-light body { background: #f8fafc; }
+    html.theme-light body::before {
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent), transparent 95%), transparent);
+    }
+    h1, h2, h3 { color: var(--text); letter-spacing: -0.03em; line-height: 1.05; font-weight: 700; text-wrap: balance; }
+    h2 { font-weight: 600; letter-spacing: -0.02em; }
+    h3 { font-weight: 600; letter-spacing: -0.02em; }
+    .text-secondary { color: var(--text-secondary); }
+
+    .skip-link {
+      position: absolute; top: -40px; left: 16px; padding: 8px 16px;
+      background: var(--accent); color: #fff; text-decoration: none;
+      border-radius: 8px; z-index: 10000; font-weight: 600;
+    }
+    .skip-link:focus { top: 16px; }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes timelinePulse { 
+      0%, 100% { box-shadow: 0 0 20px rgba(20,184,166,0.5); transform: translate(0, -50%) scale(1); } 
+      50% { box-shadow: 0 0 25px rgba(20,184,166,0.8); transform: translate(0, -50%) scale(1.1); } 
+    }
+    @keyframes timelineDotPulse { 
+      0%, 100% { border-color: var(--accent); box-shadow: 0 0 0 4px var(--bg); } 
+      50% { border-color: var(--accent); box-shadow: 0 0 0 4px var(--bg), 0 0 15px rgba(20,184,166,0.6); } 
+    }
+    .animate { animation: fadeInUp 0.5s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+
+    .reveal { opacity: 0; transform: translateY(20px); transition: opacity 0.5s ease, transform 0.5s ease; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .reveal { opacity: 1; transform: none; }
+    }
+
+    @media print {
+      body { background: #fff !important; color: #000 !important; }
+      .viz-menu, .section-nav { display: none !important; }
+      .reveal { opacity: 1 !important; transform: none !important; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* Menu */
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    html.theme-dark .theme-toggle .sun-icon { display: none; }
+    html.theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle {
+      width: 40px; height: 40px; border-radius: 8px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center; transition: background 0.15s;
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown {
+      position: absolute; top: 48px; right: 0; min-width: 160px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 4px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05);
+      opacity: 0; visibility: hidden;
+      transform: translateY(-4px); transition: all 0.15s;
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button {
+      width: 100%; padding: 8px 12px; border: none; border-radius: 6px;
+      background: transparent; color: var(--text-secondary); font-size: 0.875rem;
+      font-family: inherit; cursor: pointer; text-align: left;
+      display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s;
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+
+    /* Layout */
+    .container { max-width: 1000px; margin: 0 auto; padding: 0 24px; }
+
+    /* Hero */
+    .hero { padding: 48px 0 32px; text-align: center; }
+    .hero h1 { 
+      font-size: clamp(3rem, 8vw, 4.5rem); 
+      margin-bottom: 16px; 
+      letter-spacing: -0.03em;
+      line-height: 1.05;
+      font-weight: 700;
+    }
+    .hero p { font-size: 1.125rem; color: var(--text-secondary); max-width: 540px; margin: 0 auto; line-height: 1.6; }
+
+    /* Stats */
+    .stats { 
+      display: grid; 
+      grid-template-columns: repeat(4, 1fr); 
+      gap: 1px; 
+      background: var(--border); 
+      border-radius: 12px; 
+      overflow: hidden; 
+      margin-bottom: 64px; 
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    html.theme-light .stats { border: 1px solid rgba(0,0,0,0.08); }
+    .stat { 
+      background: var(--surface); 
+      padding: 32px 24px; 
+      text-align: center; 
+      transition: box-shadow 0.2s ease;
+    }
+    .stat:hover {
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+    }
+    html.theme-light .stat:hover {
+      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+    }
+    .stat-number { 
+      font-size: 2.5rem; 
+      font-weight: 700; 
+      letter-spacing: -0.04em; 
+      color: var(--accent); 
+      display: block; 
+      margin-bottom: 6px;
+      text-shadow: 0 0 40px rgba(20,184,166,0.4);
+      line-height: 1;
+    }
+    .stat-label { 
+      font-size: 0.6875rem; 
+      color: var(--text-secondary); 
+      text-transform: uppercase; 
+      letter-spacing: 0.1em; 
+      font-weight: 500; 
+    }
+
+    /* Section nav */
+    .section-nav {
+      position: sticky; top: 0; z-index: 100; background: var(--bg);
+      border-bottom: 1px solid var(--border); padding: 12px 0;
+      display: flex; gap: 8px; overflow-x: auto; margin-bottom: 48px;
+    }
+    .section-nav a {
+      color: var(--text-secondary); text-decoration: none; font-size: 13px;
+      padding: 4px 12px; border-radius: 6px; white-space: nowrap;
+      transition: color 0.15s, background 0.15s; font-weight: 500;
+    }
+    .section-nav a:hover { color: var(--text); background: var(--surface); }
+
+    /* Timeline */
+    .timeline { position: relative; padding-left: 40px; }
+    .timeline::before {
+      content: ''; position: absolute; left: 10px; top: 0; bottom: 0;
+      width: 4px; 
+      background: linear-gradient(180deg, var(--accent) 0%, var(--accent-secondary) 100%);
+      border-radius: 2px;
+      box-shadow: 0 0 8px rgba(59,130,246,0.3);
+    }
+
+    .era-label {
+      font-size: 0.6875rem; 
+      font-weight: 500; 
+      text-transform: uppercase;
+      letter-spacing: 0.1em; 
+      color: var(--text-secondary);
+      padding: 32px 0 20px; 
+      position: relative;
+    }
+    .era-label::before {
+      content: ''; position: absolute; left: -40px; top: 50%;
+      width: 18px; height: 18px; border-radius: 50%;
+      background: var(--accent); 
+      transform: translate(0, -50%);
+      box-shadow: 0 0 20px rgba(59,130,246,0.4);
+      border: 2px solid var(--bg);
+    }
+
+    .timeline-item { 
+      padding-bottom: 48px; 
+      position: relative; 
+      background: var(--surface);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 8px;
+      padding: 24px;
+      margin-bottom: 20px;
+      margin-left: 24px;
+      transition: box-shadow 0.2s ease, transform 0.2s ease;
+    }
+    .timeline-item:hover {
+      box-shadow: 0 0 0 1px rgba(255,255,255,0.12), 0 8px 16px rgba(0,0,0,0.15);
+    }
+    .comparison-block:hover, .card:hover, [data-reveal]:hover { border-color: rgba(255,255,255,0.12); }
+    html.theme-light .timeline-item { 
+      border: 1px solid rgba(0,0,0,0.08); 
+    }
+    html.theme-light .timeline-item:hover {
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.08);
+    }
+    .timeline-item::before {
+      content: ''; position: absolute; left: -53px; top: 40px;
+      width: 12px; height: 12px; border-radius: 50%;
+      border: 3px solid var(--accent); 
+      background: var(--bg);
+      box-shadow: 0 0 0 4px var(--bg);
+      animation: timelineDotPulse 3s infinite ease-in-out;
+    }
+
+    .timeline-year {
+      font-size: 0.75rem; 
+      font-weight: 600; 
+      color: var(--accent);
+      margin-bottom: 6px; 
+      font-variant-numeric: tabular-nums;
+      text-shadow: 0 0 20px rgba(20,184,166,0.5);
+    }
+    .timeline-title { 
+      font-size: 1.25rem; 
+      font-weight: 600; 
+      margin-bottom: 12px; 
+      letter-spacing: -0.02em; 
+      line-height: 1.2;
+    }
+    .timeline-desc { 
+      color: var(--text-secondary); 
+      font-size: 1rem; 
+      line-height: 1.6; 
+      margin-bottom: 16px; 
+    }
+
+    .timeline-impact {
+      font-size: 0.875rem; 
+      color: var(--text-secondary);
+      padding: 16px 20px; 
+      background: rgba(20,184,166,0.05); 
+      border-radius: 10px;
+      border: 1px solid rgba(20,184,166,0.15);
+      border-left: 3px solid transparent;
+    }
+    .timeline-impact strong { 
+      color: var(--accent); 
+      font-weight: 600; 
+    }
+
+    /* Era color variations */
+    .timeline-item.era-foundations { border-left: 3px solid transparent; }
+    .timeline-item.era-strategic { border-left: 3px solid transparent; }
+    .timeline-item.era-deep { border-left: 3px solid transparent; }
+    .timeline-item.era-generative { border-left: 3px solid transparent; }
+    
+    /* Width variations */
+    .timeline-item.width-compact { width: 85%; }
+    .timeline-item.width-wide { width: 110%; margin-left: 8px; }
+
+    /* Future */
+    .future { 
+      text-align: center; 
+      padding: 48px 32px; 
+      margin: 48px 0 0; 
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    html.theme-light .future { border: 1px solid rgba(0,0,0,0.08); }
+    .future h2 { 
+      font-size: 2.5rem; 
+      margin-bottom: 16px; 
+      letter-spacing: -0.03em;
+      line-height: 1.05;
+      color: var(--accent);
+    }
+    .future p { 
+      color: var(--text-secondary); 
+      max-width: 600px; 
+      margin: 0 auto; 
+      font-size: 1.125rem; 
+      line-height: 1.6; 
+    }
+
+    @media (max-width: 640px) {
+      .container { padding: 0 16px; }
+      .stats { grid-template-columns: repeat(2, 1fr); }
+      .stat { padding: 24px 16px; }
+      .stat-number { font-size: 2rem; }
+      .hero { padding: 60px 0 48px; }
+      .timeline { padding-left: 24px; }
+      .timeline-item { 
+        padding: 20px; 
+        margin-left: 12px;
+      }
+      .timeline-item:hover {
+        background: var(--surface-hover);
+      }
+      .timeline-item::before {
+        left: -37px;
+      }
+      .era-label::before {
+        left: -24px;
+      }
+      .future { padding: 60px 24px; }
+      .future h2 { font-size: 2rem; }
+    }
+  
+    @keyframes pulse { 0%, 100% { box-shadow: 0 0 0 0 var(--accent); } 50% { box-shadow: 0 0 0 8px transparent; } }
+    .timeline-dot, .era-marker { animation: pulse 2s ease-in-out infinite; }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><span id="themeIcon">🌙</span><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><span>📥</span><span>Download PNG</span></button>
+      <button onclick="window.print()"><span>🖨️</span><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <main id="main-content">
+    <div class="container">
+      <header class="hero animate">
+        <h1>The Evolution of AI</h1>
+        <p>Seven decades of breakthroughs, from Turing's vision to modern generative intelligence</p>
+      </header>
+
+      <section class="stats animate delay-1" role="region" aria-label="Key statistics">
+        <div class="stat">
+          <span class="stat-number" data-count="75" data-suffix="+">75+</span>
+          <span class="stat-label">Years of Research</span>
+        </div>
+        <div class="stat">
+          <span class="stat-number" data-count="1956">1956</span>
+          <span class="stat-label">AI Coined</span>
+        </div>
+        <div class="stat">
+          <span class="stat-number" data-count="2012">2012</span>
+          <span class="stat-label">Deep Learning</span>
+        </div>
+        <div class="stat">
+          <span class="stat-number" data-count="100" data-suffix="B+">100B+</span>
+          <span class="stat-label">Parameters Today</span>
+        </div>
+      </section>
+
+      <nav class="section-nav" aria-label="Era navigation">
+        <a href="#era-foundations">Foundations</a>
+        <a href="#era-strategic">Strategic AI</a>
+        <a href="#era-deep">Deep Learning</a>
+        <a href="#era-generative">Generative AI</a>
+      </nav>
+
+      <section class="timeline" role="list" aria-label="Timeline">
+
+        <div class="era-label" id="era-foundations">Early Foundations</div>
+
+        <article class="timeline-item era-foundations width-compact" role="listitem" data-reveal>
+          <div class="timeline-year">1950</div>
+          <h3 class="timeline-title">The Turing Test</h3>
+          <p class="timeline-desc">Alan Turing publishes "Computing Machinery and Intelligence," proposing the fundamental question: can machines think?</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Established the philosophical foundation for AI research and the first benchmark for machine intelligence.</div>
+        </article>
+
+        <article class="timeline-item era-foundations width-wide" role="listitem" data-reveal>
+          <div class="timeline-year">1956</div>
+          <h3 class="timeline-title">Birth of AI</h3>
+          <p class="timeline-desc">The Dartmouth Summer Research Project coins "Artificial Intelligence." McCarthy, Minsky, and others formally launch AI as a field of study.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Created AI as a discipline and attracted the first wave of research funding.</div>
+        </article>
+
+        <article class="timeline-item era-foundations" role="listitem" data-reveal>
+          <div class="timeline-year">1966</div>
+          <h3 class="timeline-title">ELIZA Chatbot</h3>
+          <p class="timeline-desc">Joseph Weizenbaum creates ELIZA, the first chatbot that engaged in conversation through pattern matching and substitution.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Demonstrated that simple algorithms could create convincing human-like interactions.</div>
+        </article>
+
+        <article class="timeline-item era-foundations width-compact" role="listitem" data-reveal>
+          <div class="timeline-year">1980s</div>
+          <h3 class="timeline-title">Expert Systems Boom</h3>
+          <p class="timeline-desc">Systems like MYCIN and XCON demonstrate AI's commercial potential, generating billions in revenue across specialized domains.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> First successful commercial AI applications, proving business value.</div>
+        </article>
+
+        <div class="era-label" id="era-strategic">Strategic AI</div>
+
+        <article class="timeline-item era-strategic width-wide" role="listitem" data-reveal>
+          <div class="timeline-year">1997</div>
+          <h3 class="timeline-title">Deep Blue Defeats Kasparov</h3>
+          <p class="timeline-desc">IBM's Deep Blue becomes the first computer to defeat a world chess champion, beating Garry Kasparov 3.5–2.5.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Proved AI could exceed human expertise in complex strategic domains.</div>
+        </article>
+
+        <div class="era-label" id="era-deep">Deep Learning Era</div>
+
+        <article class="timeline-item era-deep" role="listitem" data-reveal>
+          <div class="timeline-year">2006</div>
+          <h3 class="timeline-title">Deep Learning Renaissance</h3>
+          <p class="timeline-desc">Geoffrey Hinton's breakthroughs in deep neural networks, combined with GPU computing, make training large networks feasible.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Launched the modern AI era — vision, speech, and language understanding all advanced rapidly.</div>
+        </article>
+
+        <article class="timeline-item era-deep width-compact" role="listitem" data-reveal>
+          <div class="timeline-year">2012</div>
+          <h3 class="timeline-title">ImageNet Breakthrough</h3>
+          <p class="timeline-desc">AlexNet wins ImageNet with 15.3% error rate, dramatically outperforming traditional approaches at 26.2%.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Proved deep learning's superiority in computer vision, triggering massive AI investment.</div>
+        </article>
+
+        <article class="timeline-item era-deep width-wide" role="listitem" data-reveal>
+          <div class="timeline-year">2016</div>
+          <h3 class="timeline-title">AlphaGo Masters Go</h3>
+          <p class="timeline-desc">DeepMind's AlphaGo defeats world champion Lee Sedol 4–1 in Go, previously thought impossible for computers.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Showed AI could handle intuitive, creative thinking beyond brute-force calculation.</div>
+        </article>
+
+        <div class="era-label" id="era-generative">Generative AI</div>
+
+        <article class="timeline-item era-generative width-compact" role="listitem" data-reveal>
+          <div class="timeline-year">2020</div>
+          <h3 class="timeline-title">GPT-3</h3>
+          <p class="timeline-desc">OpenAI releases GPT-3 with 175B parameters, demonstrating unprecedented language understanding and generation.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Sparked the generative AI boom, leading to ChatGPT and widespread AI adoption.</div>
+        </article>
+
+        <article class="timeline-item era-generative width-wide" role="listitem" data-reveal>
+          <div class="timeline-year">2022</div>
+          <h3 class="timeline-title">ChatGPT Goes Mainstream</h3>
+          <p class="timeline-desc">ChatGPT reaches 100M users in 2 months — the fastest-growing consumer application in history.</p>
+          <div class="timeline-impact"><strong>Impact:</strong> Made AI accessible to everyone, transforming how people work, learn, and create.</div>
+        </article>
+      </section>
+
+      <section class="future" data-reveal>
+        <h2>The Next Frontier</h2>
+        <p>AI continues evolving toward artificial general intelligence, with potential to revolutionize healthcare, education, scientific discovery, and creative expression.</p>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme');
+    var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var ro = new IntersectionObserver(function(entries) {
+      entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); ro.unobserve(e.target); } });
+    }, { threshold: 0.15 });
+    document.querySelectorAll('.reveal').forEach(function(el) { ro.observe(el); });
+    setTimeout(function() { document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); }); }, 500);
+
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return; el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), dur = 1000;
+        (function tick(now) {
+          var p = Math.min((now - start) / dur, 1), e = 1 - Math.pow(1 - p, 3);
+          el.textContent = prefix + Math.round(target * e).toLocaleString() + suffix;
+          if (p < 1) requestAnimationFrame(tick);
+        })(start);
+      });
+    }
+    var ce = document.querySelector('[data-count]');
+    if (ce) { var co = new IntersectionObserver(function(es) { es.forEach(function(e) { if (e.isIntersecting) { animateCounters(); co.disconnect(); } }); }, { threshold: 0.3 }); co.observe(ce); }
+
+    async function downloadImage() {
+      var m = document.querySelector('.viz-menu'); m.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } });
+        var a = document.createElement('a'); a.href = url; a.download = 'ai-timeline.png'; a.click();
+      } catch(e) { console.error(e); }
+      m.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/carousel-infographic.html
+++ b/claude/skills/visualize/examples/carousel-infographic.html
@@ -1,0 +1,593 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>7 Habits of Highly Effective Engineers</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /* Auto color scheme detection removed - force dark theme default */
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.08);
+      --text: #EDEDED; --text-secondary: #888;
+      --accent: #8b5cf6; --accent-secondary: #7c3aed;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.08);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #8b5cf6; --accent-secondary: #7c3aed;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; letter-spacing: -0.011em; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; overflow: hidden;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 20px;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .card:hover {
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+    }
+
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    @keyframes slideInFromRight {
+      from { opacity: 0; transform: translateX(40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes slideInFromLeft {
+      from { opacity: 0; transform: translateX(-40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+    .animate.delay-5 { animation-delay: 0.5s; }
+    .animate.delay-6 { animation-delay: 0.6s; }
+
+    .reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.6s ease, transform 0.6s ease; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .reveal { opacity: 1; transform: none; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; overflow: visible !important; height: auto !important; }
+      .viz-menu, .carousel-nav, .carousel-dots, .card-counter { display: none !important; }
+      .carousel-viewport { overflow: visible !important; }
+      .carousel-track { display: grid !important; grid-template-columns: repeat(2, 1fr) !important; gap: 16px !important; transform: none !important; transition: none !important; }
+      .carousel-card { width: auto !important; min-width: 0 !important; break-inside: avoid; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* ===== VISIBLE THEME TOGGLE ===== */
+    .theme-toggle {
+      position: fixed; top: 16px; right: 16px; z-index: 9999;
+      width: 44px; height: 44px; border-radius: 8px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+      font-size: 20px;
+    }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* ===== MENU ===== */
+    .viz-menu { position: fixed; top: 16px; left: 16px; z-index: 9999; }
+    .viz-menu-toggle {
+      width: 44px; height: 44px; border-radius: 8px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .viz-menu-dropdown {
+      position: absolute; top: 52px; left: 0; min-width: 160px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 4px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05);
+      opacity: 0; visibility: hidden; transform: translateY(-4px);
+      transition: all 0.15s;
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button {
+      width: 100%; padding: 8px 12px; border: none; border-radius: 8px;
+      background: transparent; color: var(--text-secondary); font-size: 0.875rem;
+      font-family: inherit; cursor: pointer; text-align: left;
+      display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s;
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+    .viz-menu-dropdown button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* ===== CAROUSEL ===== */
+    .carousel-wrapper {
+      width: min(1000px, 90vmin); height: min(700px, 80vmin);
+      position: relative;
+    }
+    .carousel-viewport {
+      width: 100%; height: 100%; overflow: hidden; border-radius: 12px;
+      border: 1px solid var(--border); 
+      box-shadow: 0 4px 24px rgba(0,0,0,0.12), 0 0 0 1px rgba(255,255,255,0.05);
+    }
+    .carousel-track {
+      display: flex; height: 100%;
+      transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    .carousel-card {
+      min-width: 100%; height: 100%;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      padding: 48px 56px; text-align: center; position: relative;
+      background: var(--surface); overflow: hidden;
+      border-left: 4px solid transparent;
+      transition: border-color 0.3s ease;
+    }
+    .carousel-card.active {
+      border-left: 3px solid transparent;
+      animation: slideInFromRight 0.6s ease-out;
+    }
+    .carousel-card::before {
+      content: ''; position: absolute; inset: 0;
+      background: radial-gradient(ellipse at 30% 20%, var(--card-accent, var(--accent)) 0%, transparent 60%);
+      opacity: 0.7; pointer-events: none;
+    }
+
+    .card-number {
+      font-size: clamp(4rem, 12vmin, 8rem); font-weight: 900;
+      color: var(--card-accent, var(--accent)); opacity: 0.4;
+      position: absolute; top: 32px; left: 48px; line-height: 1;
+      text-shadow: 0 0 32px color-mix(in srgb, var(--card-accent, var(--accent)), transparent 50%);
+    }
+    .card-habit-name {
+      font-size: clamp(2rem, 6vmin, 3.5rem); font-weight: 700;
+      line-height: 1.15; margin-bottom: 24px; max-width: 14ch;
+      text-wrap: balance;
+    }
+    .card-description {
+      font-size: clamp(1rem, 2.5vmin, 1.35rem); color: var(--text-secondary);
+      max-width: 28ch; line-height: 1.6;
+    }
+    .card-title-main {
+      font-size: clamp(3rem, 10vmin, 5.5rem); font-weight: 900;
+      line-height: 1.05; margin-bottom: 16px;
+      color: var(--text);
+      text-wrap: balance;
+    }
+    .card-subtitle {
+      font-size: clamp(1rem, 2.5vmin, 1.25rem); color: var(--accent);
+      font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+      background: color-mix(in srgb, var(--accent), transparent 90%);
+      padding: 8px 16px; border-radius: 6px; display: inline-block;
+      border: 1px solid color-mix(in srgb, var(--accent), transparent 70%);
+    }
+    .card-icon {
+      width: 56px; height: 56px; margin-bottom: 24px;
+      color: var(--card-accent, var(--accent));
+    }
+
+    /* Hero card preview thumbnails */
+    .preview-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr);
+      gap: 16px; margin-top: 40px; max-width: 420px;
+    }
+    .preview-thumb {
+      aspect-ratio: 1; background: color-mix(in srgb, var(--thumb-accent), transparent 85%);
+      border: 2px solid var(--thumb-accent); border-radius: 12px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.75rem; color: var(--thumb-accent);
+      transition: all 0.2s ease; cursor: pointer;
+      position: relative; overflow: hidden; padding: 12px;
+    }
+    .preview-thumb::before {
+      content: ''; position: absolute; inset: 0;
+      background: var(--thumb-accent); opacity: 0; pointer-events: none;
+      transition: opacity 0.2s ease;
+    }
+    .preview-thumb:hover {
+      background: color-mix(in srgb, var(--thumb-accent), transparent 75%);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px color-mix(in srgb, var(--thumb-accent), transparent 70%);
+    }
+    .preview-thumb:hover::before { opacity:  0.5; }
+    .preview-thumb svg { 
+      width: 20px; height: 20px; 
+      color: var(--thumb-accent);
+      filter: brightness(1.1);
+    }
+    .preview-thumb:nth-child(1) { --thumb-accent: #8b5cf6; }
+    .preview-thumb:nth-child(2) { --thumb-accent: #ec4899; }
+    .preview-thumb:nth-child(3) { --thumb-accent: #f59e0b; }
+    .preview-thumb:nth-child(4) { --thumb-accent: #10b981; }
+    .preview-thumb:nth-child(5) { --thumb-accent: #06b6d4; }
+    .preview-thumb:nth-child(6) { --thumb-accent: #f43f5e; }
+    .preview-thumb:nth-child(7) { --thumb-accent: #8b5cf6; }
+
+    /* Accent colors per card */
+    .carousel-card:nth-child(1) { --card-accent: #3b82f6; }
+    .carousel-card:nth-child(2) { --card-accent: #8b5cf6; }
+    .carousel-card:nth-child(3) { --card-accent: #ec4899; }
+    .carousel-card:nth-child(4) { --card-accent: #f59e0b; }
+    .carousel-card:nth-child(5) { --card-accent: #10b981; }
+    .carousel-card:nth-child(6) { --card-accent: #06b6d4; }
+    .carousel-card:nth-child(7) { --card-accent: #f43f5e; }
+    .carousel-card:nth-child(8) { --card-accent: #8b5cf6; }
+
+    /* Navigation */
+    .carousel-nav {
+      position: absolute; top: 50%; transform: translateY(-50%);
+      width: 48px; height: 48px; border-radius: 50%;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: box-shadow 0.2s ease; z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    }
+    .carousel-nav:hover { background: var(--surface-hover); box-shadow: 0 4px 16px rgba(0,0,0,0.3); }
+    .carousel-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .carousel-nav.prev { left: -24px; }
+    .carousel-nav.next { right: -24px; }
+    .carousel-nav:disabled { opacity: 0.3; cursor: default; }
+    .carousel-nav:disabled:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.2); background: var(--surface); }
+
+    /* Dot navigation */
+    .carousel-dots {
+      position: absolute; bottom: -60px; left: 50%; transform: translateX(-50%);
+      display: flex; gap: 12px; align-items: center;
+    }
+    .carousel-dot {
+      width: 12px; height: 12px; border-radius: 50%;
+      background: var(--border); cursor: pointer;
+      transition: all 0.2s ease; border: none;
+    }
+    .carousel-dot:hover { background: var(--text-secondary); }
+    .carousel-dot.active { 
+      background: var(--accent); 
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent), transparent 80%);
+    }
+    .carousel-dot:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    .card-counter {
+      position: absolute; bottom: 24px; right: 32px;
+      font-size: 0.875rem; color: var(--text-secondary);
+      font-weight: 600; font-variant-numeric: tabular-nums;
+    }
+
+    .skip-link {
+      position: absolute; top: -100px; left: 16px; padding: 8px 16px;
+      background: var(--accent); color: #fff; border-radius: 8px;
+      text-decoration: none; z-index: 99999; font-weight: 600;
+    }
+    .skip-link:focus { top: 16px; }
+
+    /* Keyboard navigation hint */
+    .keyboard-hint {
+      position: absolute; bottom: 24px; left: 32px;
+      font-size: 0.75rem; color: var(--text-secondary);
+      display: flex; align-items: center; gap: 6px;
+      opacity: 0; animation: fadeIn 1s ease 2s both;
+    }
+    .keyboard-hint kbd {
+      background: var(--surface-hover); border: 1px solid var(--border);
+      border-radius: 4px; padding: 2px 6px; font-size: 0.625rem;
+      color: var(--text); font-family: inherit;
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <!-- VISIBLE THEME TOGGLE -->
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <span id="themeIcon">🌙</span>
+  </button>
+
+  <!-- MENU -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="downloadCurrentCard()"><span>📥</span><span>Download Card PNG</span></button>
+      <button onclick="window.print()"><span>🖨️</span><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <div class="carousel-wrapper" role="region" aria-label="Carousel: 7 Habits of Highly Effective Engineers" aria-roledescription="carousel">
+    <button class="carousel-nav prev" onclick="goTo(currentSlide-1)" aria-label="Previous card">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
+    </button>
+    <button class="carousel-nav next" onclick="goTo(currentSlide+1)" aria-label="Next card">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+    </button>
+
+    <div class="carousel-viewport">
+      <div class="carousel-track" id="carouselTrack" aria-live="polite">
+
+        <!-- Card 1: Title -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 1 of 8: Title">
+          <!-- Enhanced hero section with gradient background -->
+          <div style="position:absolute;inset:0;pointer-events:none;overflow:hidden;">
+            <div style="position:absolute;inset:0;background:linear-gradient(135deg, color-mix(in srgb, var(--accent), transparent 88%) 0%, color-mix(in srgb, var(--accent-secondary), transparent 92%) 50%, transparent 100%);"></div>
+          </div>
+          <!-- Bold hero visual element -->
+          <div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:1;">
+            <svg viewBox="0 0 400 400" fill="none" style="width:320px;height:320px;opacity: 0.75;">
+              <!-- Central gear/cog representing engineering -->
+              <circle cx="200" cy="200" r="100" fill="var(--accent)"/>
+              <circle cx="200" cy="200" r="60" fill="var(--surface)"/>
+              <!-- Gear teeth -->
+              <path d="M200 80 L220 100 L180 100 Z" fill="var(--accent)"/>
+              <path d="M320 200 L300 220 L300 180 Z" fill="var(--accent)"/>
+              <path d="M200 320 L180 300 L220 300 Z" fill="var(--accent)"/>
+              <path d="M80 200 L100 180 L100 220 Z" fill="var(--accent)"/>
+              <!-- Diagonal teeth -->
+              <path d="M271 129 L285 143 L257 157 Z" fill="var(--accent)"/>
+              <path d="M271 271 L257 243 L285 257 Z" fill="var(--accent)"/>
+              <path d="M129 271 L143 257 L157 285 Z" fill="var(--accent)"/>
+              <path d="M129 129 L157 115 L143 143 Z" fill="var(--accent)"/>
+              <!-- Central number 7 -->
+              <text x="200" y="220" text-anchor="middle" font-family="Inter" font-size="48" font-weight="900" fill="var(--accent)">7</text>
+            </svg>
+          </div>
+          <div class="keyboard-hint">
+            <span>Navigate:</span>
+            <kbd>←</kbd>
+            <kbd>→</kbd>
+          </div>
+          <div class="card-subtitle animate">A CAROUSEL GUIDE</div>
+          <h1 class="card-title-main animate delay-1">7 Habits of Highly Effective Engineers</h1>
+          <p class="card-description animate delay-2">Swipe through to level up your engineering career →</p>
+          <!-- Colored section divider -->
+          <div style="width:80px;height:4px;background:linear-gradient(90deg,var(--accent),var(--accent-secondary));border-radius:2px;margin:24px auto;" class="animate delay-3"></div>
+          
+          <!-- Preview thumbnails -->
+          <div class="preview-grid animate delay-3">
+            <div class="preview-thumb" onclick="goTo(1)" title="Write It Down">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/>
+              </svg>
+            </div>
+            <div class="preview-thumb" onclick="goTo(2)" title="Ship Small, Ship Often">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+              </svg>
+            </div>
+            <div class="preview-thumb" onclick="goTo(3)" title="Read the Error Message">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/>
+              </svg>
+            </div>
+            <div class="preview-thumb" onclick="goTo(4)" title="Automate the Boring Stuff">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 12h4m4 0h4"/>
+              </svg>
+            </div>
+            <div class="preview-thumb" onclick="goTo(5)" title="Ask Why, Not Just How">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>
+              </svg>
+            </div>
+            <div class="preview-thumb" onclick="goTo(6)" title="Review Others' Code">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/>
+              </svg>
+            </div>
+            <div class="preview-thumb" onclick="goTo(7)" title="Protect Your Focus">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+              </svg>
+            </div>
+          </div>
+          <div class="card-counter" aria-live="polite" id="cardCounter">1 / 8</div>
+        </div>
+
+        <!-- Card 2 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 2 of 8: Write It Down">
+          <div class="card-number">01</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+          <h2 class="card-habit-name">Write It Down</h2>
+          <p class="card-description">Document decisions, architecture, and context. Your future self and teammates will thank you endlessly.</p>
+        </div>
+
+        <!-- Card 3 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 3 of 8: Ship Small, Ship Often">
+          <div class="card-number">02</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          <h2 class="card-habit-name">Ship Small, Ship Often</h2>
+          <p class="card-description">Small PRs get reviewed faster, break less, and build momentum. Aim for daily deploys.</p>
+        </div>
+
+        <!-- Card 4 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 4 of 8: Read the Error Message">
+          <div class="card-number">03</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+          <h2 class="card-habit-name">Read the Error Message</h2>
+          <p class="card-description">Seriously. 80% of debugging is reading what the computer already told you. Slow down and read.</p>
+        </div>
+
+        <!-- Card 5 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 5 of 8: Automate the Boring Stuff">
+          <div class="card-number">04</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 12h4m4 0h4"/></svg>
+          <h2 class="card-habit-name">Automate the Boring Stuff</h2>
+          <p class="card-description">If you've done it three times, script it. Invest 30 minutes now to save hours later.</p>
+        </div>
+
+        <!-- Card 6 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 6 of 8: Ask Why, Not Just How">
+          <div class="card-number">05</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>
+          <h2 class="card-habit-name">Ask Why, Not Just How</h2>
+          <p class="card-description">Understanding the business context behind a task helps you build the right thing, not just build the thing right.</p>
+        </div>
+
+        <!-- Card 7 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 7 of 8: Review Others' Code">
+          <div class="card-number">06</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+          <h2 class="card-habit-name">Review Others' Code</h2>
+          <p class="card-description">Code review is the fastest way to learn patterns, catch bugs early, and build shared ownership across the team.</p>
+        </div>
+
+        <!-- Card 8 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="Slide 8 of 8: Protect Your Focus">
+          <div class="card-number">07</div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          <h2 class="card-habit-name">Protect Your Focus</h2>
+          <p class="card-description">Block deep-work time. Turn off Slack. A 4-hour uninterrupted block is worth more than a full day of context-switching.</p>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Prominent dot navigation -->
+    <div class="carousel-dots" id="carouselDots">
+      <button class="carousel-dot active" onclick="goTo(0)" aria-label="Go to slide 1"></button>
+      <button class="carousel-dot" onclick="goTo(1)" aria-label="Go to slide 2"></button>
+      <button class="carousel-dot" onclick="goTo(2)" aria-label="Go to slide 3"></button>
+      <button class="carousel-dot" onclick="goTo(3)" aria-label="Go to slide 4"></button>
+      <button class="carousel-dot" onclick="goTo(4)" aria-label="Go to slide 5"></button>
+      <button class="carousel-dot" onclick="goTo(5)" aria-label="Go to slide 6"></button>
+      <button class="carousel-dot" onclick="goTo(6)" aria-label="Go to slide 7"></button>
+      <button class="carousel-dot" onclick="goTo(7)" aria-label="Go to slide 8"></button>
+    </div>
+  </div>
+
+  </main>
+  <script>
+    // === Menu ===
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    // === Theme ===
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      localStorage.setItem('viz-theme', t);
+      currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    // === Scroll Reveal ===
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var revealObserver = new IntersectionObserver(function(entries) {
+      entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); revealObserver.unobserve(e.target); } });
+    }, { threshold: 0.15 });
+    document.querySelectorAll('.reveal').forEach(function(el) { revealObserver.observe(el); });
+    setTimeout(function() { document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); }); }, 500);
+
+    // === Carousel ===
+    var currentSlide = 0;
+    var totalSlides = document.querySelectorAll('.carousel-card').length;
+    var track = document.getElementById('carouselTrack');
+    
+    function updateDots() {
+      var dots = document.querySelectorAll('.carousel-dot');
+      dots.forEach(function(dot, i) {
+        dot.classList.toggle('active', i === currentSlide);
+      });
+    }
+    
+    function goTo(index) {
+      if (index < 0 || index >= totalSlides) return;
+      currentSlide = index;
+      track.style.transform = 'translateX(-' + (currentSlide * 100) + '%)';
+      document.querySelector('.carousel-nav.prev').disabled = currentSlide === 0;
+      document.querySelector('.carousel-nav.next').disabled = currentSlide === totalSlides - 1;
+      document.getElementById('cardCounter').textContent = (currentSlide + 1) + ' / ' + totalSlides;
+      
+      // Update active slide animation
+      document.querySelectorAll('.carousel-card').forEach(function(card, i) {
+        card.classList.toggle('active', i === currentSlide);
+      });
+      
+      updateDots();
+    }
+    goTo(0);
+
+    // Keyboard nav
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); goTo(currentSlide - 1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); goTo(currentSlide + 1); }
+    });
+
+    // Touch swipe
+    var touchStartX = 0;
+    var touchEndX = 0;
+    var viewport = document.querySelector('.carousel-viewport');
+    viewport.addEventListener('touchstart', function(e) { touchStartX = e.changedTouches[0].screenX; }, { passive: true });
+    viewport.addEventListener('touchend', function(e) {
+      touchEndX = e.changedTouches[0].screenX;
+      var diff = touchStartX - touchEndX;
+      if (Math.abs(diff) > 50) {
+        if (diff > 0) goTo(currentSlide + 1);
+        else goTo(currentSlide - 1);
+      }
+    });
+
+    // === Download Current Card as PNG ===
+    async function downloadCurrentCard() {
+      var menu = document.querySelector('.viz-menu');
+      var themeToggle = document.querySelector('.theme-toggle');
+      var navs = document.querySelectorAll('.carousel-nav, .carousel-dots');
+      menu.style.display = 'none';
+      themeToggle.style.display = 'none';
+      navs.forEach(function(n) { n.style.display = 'none'; });
+      try {
+        var cards = document.querySelectorAll('.carousel-card');
+        var card = cards[currentSlide];
+        var url = await htmlToImage.toPng(card, { quality: 1, pixelRatio: 2, width: 1080, height: 1080 });
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'habit-' + (currentSlide + 1) + '-of-' + totalSlides + '.png';
+        a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+      themeToggle.style.display = '';
+      navs.forEach(function(n) { n.style.display = ''; });
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/carousel-korean.html
+++ b/claude/skills/visualize/examples/carousel-korean.html
@@ -1,0 +1,669 @@
+<!DOCTYPE html>
+<html lang="ko" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI 시대, 개발자가 살아남는 5가지 방법</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    
+    
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.08);
+      --text: #EDEDED; --text-secondary: #888;
+      --accent: #8b5cf6; --accent-secondary: #7c3aed;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.08);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #8b5cf6; --accent-secondary: #7c3aed;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+    }
+
+    body {
+      font-family: 'Noto Sans KR', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; letter-spacing: -0.011em; -webkit-font-smoothing: antialiased;
+      scrollbar-gutter: stable;
+      font-feature-settings: 'cv11', 'ss01';
+      transition: background 0.3s, color 0.3s;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; overflow: hidden;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 8px; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes slideInFromRight {
+      from { opacity: 0; transform: translateX(40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; overflow: visible !important; height: auto !important; }
+      .viz-menu, .theme-toggle, .carousel-nav, .card-counter { display: none !important; }
+      .carousel-viewport { overflow: visible !important; }
+      .carousel-track { display: grid !important; grid-template-columns: repeat(2, 1fr) !important; gap: 16px !important; transform: none !important; transition: none !important; }
+      .carousel-card { width: auto !important; min-width: 0 !important; break-inside: avoid; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* === Hamburger Menu === */
+    .viz-menu {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 9999;
+      font-family: var(--font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    }
+
+    .viz-menu-toggle {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .viz-menu-toggle:hover {
+      background: var(--surface-hover);
+      transform: scale(1.05);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+
+    .viz-menu-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      min-width: 200px;
+      background: var(--surface);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 6px;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px) scale(0.96);
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+
+    .viz-menu-dropdown.open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0) scale(1);
+    }
+
+    .viz-menu-dropdown button {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border: none;
+      background: transparent;
+      color: var(--text);
+      font-size: 0.875rem;
+      cursor: pointer;
+      border-radius: 8px;
+      transition: background 0.15s;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    .viz-menu-dropdown button:hover {
+      background: var(--surface-hover);
+    }
+
+    .viz-menu-icon {
+      font-size: 1rem;
+      width: 20px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    /* ===== CAROUSEL ===== */
+    .carousel-wrapper {
+      width: min(1200px, 95vmin); height: min(1200px, 95vmin);
+      position: relative;
+    }
+    .carousel-viewport {
+      width: 100%; height: 100%; overflow: hidden; border-radius: 12px;
+      border: 1px solid var(--border); 
+      box-shadow: 0 4px 24px rgba(0,0,0,0.12), 0 0 0 1px rgba(255,255,255,0.05);
+    }
+    .carousel-track {
+      display: flex; height: 100%;
+      transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    .carousel-card {
+      min-width: 100%; height: 100%;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      padding: 64px; text-align: center; position: relative;
+      background: var(--surface);
+      overflow: hidden;
+      border-left: 4px solid transparent;
+      transition: border-color 0.3s ease;
+    }
+    .carousel-card.active {
+      border-left: 3px solid transparent;
+      animation: slideInFromRight 0.6s ease-out;
+    }
+
+    /* Per-card accent colors */
+    .carousel-card:nth-child(1) { --card-accent: #3b82f6; }
+    .carousel-card:nth-child(2) { --card-accent: #8b5cf6; }
+    .carousel-card:nth-child(3) { --card-accent: #ec4899; }
+    .carousel-card:nth-child(4) { --card-accent: #10b981; }
+    .carousel-card:nth-child(5) { --card-accent: #f59e0b; }
+    .carousel-card:nth-child(6) { --card-accent: #06b6d4; }
+    .carousel-card:nth-child(7) { --card-accent: #f43f5e; }
+
+    /* Subtle radial glow per card */
+    .carousel-card::before {
+      content: ''; position: absolute; inset: 0;
+      background: radial-gradient(ellipse 60% 50% at 50% 30%, var(--card-accent) 0%, transparent 70%);
+      opacity: 0.7; pointer-events: none;
+    }
+
+    /* Enhanced cover decoration */
+    .cover-decoration {
+      position: absolute; inset: 0; pointer-events: none; overflow: hidden;
+    }
+    .cover-decoration svg { position: absolute; opacity: 0.75; }
+    .cover-decoration .mesh-tl { top: -10%; left: -10%; width: 60%; height: 60%; }
+    .cover-decoration .mesh-br { bottom: -10%; right: -10%; width: 50%; height: 50%; }
+    .cover-decoration .mesh-ring { top: 50%; left: 50%; transform: translate(-50%, -50%); width: 80%; height: 80%; opacity:  0.5; }
+
+    .card-number {
+      font-size: clamp(4rem, 12vmin, 8rem); font-weight: 900;
+      color: var(--card-accent); opacity: 0.4;
+      position: absolute; top: 32px; left: 48px; line-height: 1;
+      font-family: 'Inter', sans-serif;
+      text-shadow: 0 0 32px color-mix(in srgb, var(--card-accent), transparent 50%);
+    }
+    .card-tip-title {
+      font-size: clamp(1.8rem, 5.5vmin, 3rem); font-weight: 700;
+      line-height: 1.25; margin-bottom: 24px; max-width: 16ch;
+      letter-spacing: -0.03em;
+      text-wrap: balance;
+      }
+    .card-description {
+      font-size: clamp(1rem, 2.5vmin, 1.35rem); color: var(--text-secondary);
+      max-width: 28ch; line-height: 1.7;
+    }
+    .card-title-main {
+      font-size: clamp(2.8rem, 9vmin, 5rem); font-weight: 900;
+      line-height: 1.15; margin-bottom: 20px;
+      color: var(--text);
+      letter-spacing: -0.03em;
+      text-wrap: balance;
+      }
+    .card-subtitle {
+      font-size: clamp(0.75rem, 2vmin, 0.875rem); color: var(--accent);
+      font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+      background: color-mix(in srgb, var(--accent), transparent 90%);
+      padding: 8px 16px; border-radius: 6px; display: inline-block;
+      border: 1px solid color-mix(in srgb, var(--accent), transparent 70%);
+    }
+    .card-handle {
+      font-size: clamp(0.875rem, 2vmin, 1rem); color: var(--text-secondary);
+      font-weight: 600; margin-top: 24px;
+    }
+    .card-icon {
+      width: 56px; height: 56px; margin-bottom: 24px;
+      color: var(--card-accent);
+    }
+
+    /* Enhanced step indicator dots on content cards */
+    .step-dots {
+      display: flex; gap: 12px; margin-bottom: 32px;
+    }
+    .step-dots span {
+      width: 12px; height: 12px; border-radius: 50%;
+      background: var(--border);
+      transition: all 0.3s ease;
+      position: relative;
+    }
+    .step-dots span.active {
+      background: var(--card-accent);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--card-accent), transparent 80%);
+    }
+
+    /* Navigation */
+    .carousel-nav {
+      position: absolute; top: 50%; transform: translateY(-50%);
+      width: 48px; height: 48px; border-radius: 50%;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .carousel-nav:hover { 
+      background: var(--surface-hover); 
+      box-shadow: 0 6px 20px rgba(0,0,0,0.25); 
+      transform: translateY(-50%) scale(1.05);
+    }
+    .carousel-nav.prev { left: -24px; }
+    .carousel-nav.next { right: -24px; }
+    .carousel-nav:disabled { 
+      opacity: 0.3; 
+      cursor: default; 
+      transform: translateY(-50%) scale(1);
+    }
+    
+    /* Mobile responsiveness for navigation */
+    @media (max-width: 768px) {
+      .carousel-nav.prev { left: 16px; }
+      .carousel-nav.next { right: 16px; }
+      .carousel-nav {
+        width: 40px; height: 40px;
+        bottom: 16px; top: auto; transform: none;
+      }
+      .carousel-nav.prev { bottom: 16px; left: 16px; }
+      .carousel-nav.next { bottom: 16px; right: 16px; }
+    }
+
+    .card-counter {
+      position: absolute; bottom: 24px; right: 32px;
+      font-size: 0.875rem; color: var(--text-secondary);
+      font-weight: 600; font-variant-numeric: tabular-nums;
+      font-family: 'Inter', sans-serif;
+    }
+
+    /* CTA card */
+    .cta-list {
+      list-style: none; text-align: left; margin: 24px 0;
+      font-size: clamp(0.875rem, 2vmin, 1.1rem); color: var(--text-secondary);
+      line-height: 2.2;
+    }
+    .cta-list li { 
+      display: flex; align-items: center; gap: 12px; 
+      padding: 8px 12px; margin: 4px 0; border-radius: 8px;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      cursor: pointer;
+    }
+    .cta-list li:hover {
+      background: var(--surface-hover);
+      color: var(--text);
+      transform: translateX(4px);
+    }
+    .cta-list li svg { width: 16px; height: 16px; color: var(--accent); flex-shrink: 0; }
+    .cta-handle {
+      font-size: clamp(1.25rem, 3.5vmin, 1.75rem); font-weight: 700;
+      margin-top: 24px; color: var(--accent);
+    }
+
+    .skip-link {
+      position: absolute; top: -100px; left: 16px; padding: 8px 16px;
+      background: var(--accent); color: #fff; border-radius: 8px;
+      text-decoration: none; z-index: 99999; font-weight: 600;
+    }
+    .skip-link:focus { top: 16px; }
+
+    /* Hero content previews */
+    .hero-previews {
+      display: grid; grid-template-columns: repeat(3, 1fr);
+      gap: 18px; margin-top: 40px; max-width: 450px;
+    }
+    .hero-preview {
+      aspect-ratio: 1; background: color-mix(in srgb, var(--preview-accent), transparent 88%);
+      border: 1px solid color-mix(in srgb, var(--preview-accent), transparent 30%); border-radius: 12px;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      font-size: 0.8rem; color: var(--preview-accent); text-align: center;
+      transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1); cursor: pointer;
+      position: relative; overflow: hidden;
+      padding: 16px 12px; font-weight: 600;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    }
+    .hero-preview::before {
+      content: ''; position: absolute; inset: 0;
+      background: var(--preview-accent); opacity: 0; pointer-events: none;
+      transition: opacity 0.25s ease;
+    }
+    .hero-preview:hover {
+      background: color-mix(in srgb, var(--preview-accent), transparent 80%);
+      transform: translateY(-3px) scale(1.02);
+      box-shadow: 0 8px 24px color-mix(in srgb, var(--preview-accent), transparent 65%);
+      border-color: var(--preview-accent);
+    }
+    .hero-preview:hover::before { opacity: 0.1; }
+    .hero-preview:nth-child(1) { --preview-accent: #8b5cf6; }
+    .hero-preview:nth-child(2) { --preview-accent: #ec4899; }
+    .hero-preview:nth-child(3) { --preview-accent: #10b981; }
+    .hero-preview:nth-child(4) { --preview-accent: #f59e0b; }
+    .hero-preview:nth-child(5) { --preview-accent: #06b6d4; }
+    .hero-preview svg {
+      width: 24px; height: 24px; margin-bottom: 10px;
+      color: var(--preview-accent);
+      filter: brightness(1.1);
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">콘텐츠로 건너뛰기</a>
+  <main id="main-content">
+
+  <!-- Hamburger Menu -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="메뉴">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/>
+        <line x1="3" y1="10" x2="17" y2="10"/>
+        <line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()">
+        <span class="viz-menu-icon">◐</span>
+        <span>테마: <span id="themeLabel">Dark</span></span>
+      </button>
+      <button onclick="downloadCurrentCard()">
+        <span class="viz-menu-icon">⤓</span>
+        <span>카드 PNG 다운로드</span>
+      </button>
+      <button onclick="printPDF()">
+        <span class="viz-menu-icon">⎙</span>
+        <span>인쇄 / PDF</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="carousel-wrapper" role="region" aria-label="캐러셀: AI 시대, 개발자가 살아남는 5가지 방법" aria-roledescription="carousel">
+    <button class="carousel-nav prev" onclick="goTo(currentSlide-1)" aria-label="이전 카드">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
+    </button>
+    <button class="carousel-nav next" onclick="goTo(currentSlide+1)" aria-label="다음 카드">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+    </button>
+
+    <div class="carousel-viewport">
+      <div class="carousel-track" id="carouselTrack" aria-live="polite">
+
+        <!-- Card 1: Title -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 1/7: 타이틀">
+          <!-- Enhanced hero section with gradient background -->
+          <div style="position:absolute;inset:0;pointer-events:none;overflow:hidden;">
+            <div style="position:absolute;inset:0;background:linear-gradient(135deg, color-mix(in srgb, var(--accent), transparent 88%) 0%, color-mix(in srgb, var(--accent-secondary), transparent 92%) 50%, transparent 100%);"></div>
+          </div>
+          <!-- Bold AI-themed hero visual element -->
+          <div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:1;">
+            <svg viewBox="0 0 480 480" fill="none" style="width:380px;height:380px;opacity:0.2;">
+              <!-- Central AI brain/processor -->
+              <circle cx="240" cy="240" r="120" fill="var(--accent)" opacity="0.8"/>
+              <circle cx="240" cy="240" r="80" fill="var(--surface)" opacity="0.9"/>
+              <!-- Neural network nodes -->
+              <circle cx="180" cy="160" r="16" fill="var(--accent)" opacity="0.9"/>
+              <circle cx="300" cy="160" r="16" fill="var(--accent-secondary)" opacity="0.9"/>
+              <circle cx="160" cy="240" r="16" fill="var(--positive)" opacity="0.9"/>
+              <circle cx="320" cy="240" r="16" fill="var(--warning)" opacity="0.9"/>
+              <circle cx="180" cy="320" r="16" fill="var(--negative)" opacity="0.9"/>
+              <circle cx="300" cy="320" r="16" fill="var(--accent-secondary)" opacity="0.9"/>
+              <!-- Connections between nodes -->
+              <line x1="180" y1="160" x2="240" y2="200" stroke="var(--accent)" stroke-width="3" opacity="0.6"/>
+              <line x1="300" y1="160" x2="240" y2="200" stroke="var(--accent-secondary)" stroke-width="3" opacity="0.6"/>
+              <line x1="160" y1="240" x2="200" y2="240" stroke="var(--positive)" stroke-width="3" opacity="0.6"/>
+              <line x1="320" y1="240" x2="280" y2="240" stroke="var(--warning)" stroke-width="3" opacity="0.6"/>
+              <line x1="180" y1="320" x2="240" y2="280" stroke="var(--negative)" stroke-width="3" opacity="0.6"/>
+              <line x1="300" y1="320" x2="240" y2="280" stroke="var(--accent-secondary)" stroke-width="3" opacity="0.6"/>
+              <!-- Central number 5 for "5가지 방법" -->
+              <text x="240" y="260" text-anchor="middle" font-family="Noto Sans KR, Inter" font-size="64" font-weight="900" fill="var(--accent)">5</text>
+            </svg>
+          </div>
+          <div class="card-subtitle animate">개발자 생존 가이드</div>
+          <h1 class="card-title-main animate delay-1">AI 시대,<br>개발자가 살아남는<br>5가지 방법</h1>
+          <p class="card-description animate delay-2">스와이프하여 확인하세요 →</p>
+          <!-- Colored section divider -->
+          <div style="width:80px;height:4px;background:linear-gradient(90deg,var(--accent),var(--accent-secondary));border-radius:2px;margin:24px auto;" class="animate delay-3"></div>
+          
+          <!-- Content previews -->
+          <div class="hero-previews animate delay-3">
+            <div class="hero-preview" onclick="goTo(1)" title="AI 도구 활용">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+              </svg>
+              AI 도구
+            </div>
+            <div class="hero-preview" onclick="goTo(2)" title="프롬프트 엔지니어링">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
+              </svg>
+              프롬프트
+            </div>
+            <div class="hero-preview" onclick="goTo(3)" title="시스템 사고">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33"/>
+              </svg>
+              시스템
+            </div>
+            <div class="hero-preview" onclick="goTo(4)" title="1인 팀">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/>
+              </svg>
+              1인 팀
+            </div>
+            <div class="hero-preview" onclick="goTo(5)" title="학습과 실행">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+              </svg>
+              학습
+            </div>
+          </div>
+          
+          <div class="card-handle animate delay-3">@careerhackeralex</div>
+          <div class="card-counter" aria-live="polite" id="cardCounter">1 / 7</div>
+        </div>
+
+        <!-- Card 2: Tip 1 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 2/7: AI 도구를 활용하라">
+          <div class="card-number">01</div>
+          <div class="step-dots"><span class="active"></span><span></span><span></span><span></span><span></span></div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+          <h2 class="card-tip-title">AI 도구를 두려워하지 말고 활용하라</h2>
+          <p class="card-description">AI는 당신의 대체재가 아니라 부조종사입니다. 함께 일하면 혼자보다 10배 빠릅니다.</p>
+          <div class="card-counter">2 / 7</div>
+        </div>
+
+        <!-- Card 3: Tip 2 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 3/7: 프롬프트 엔지니어링">
+          <div class="card-number">02</div>
+          <div class="step-dots"><span></span><span class="active"></span><span></span><span></span><span></span></div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+          <h2 class="card-tip-title">프롬프트 엔지니어링을 마스터하라</h2>
+          <p class="card-description">AI와 소통하는 능력이 새로운 코딩 스킬입니다. 질문을 잘하는 사람이 답을 잘 얻습니다.</p>
+          <div class="card-counter">3 / 7</div>
+        </div>
+
+        <!-- Card 4: Tip 3 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 4/7: 시스템 사고">
+          <div class="card-number">03</div>
+          <div class="step-dots"><span></span><span></span><span class="active"></span><span></span><span></span></div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+          <h2 class="card-tip-title">시스템 사고를 키워라</h2>
+          <p class="card-description">AI가 코드를 생성하지만, 시스템을 설계하는 건 인간입니다. 큰 그림을 보는 능력이 핵심입니다.</p>
+          <div class="card-counter">4 / 7</div>
+        </div>
+
+        <!-- Card 5: Tip 4 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 5/7: 1인 팀의 힘">
+          <div class="card-number">04</div>
+          <div class="step-dots"><span></span><span></span><span></span><span class="active"></span><span></span></div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          <h2 class="card-tip-title">1인 팀의 힘을 믿어라</h2>
+          <p class="card-description">한 사람 + AI는 AI 없는 대규모 팀보다 강력합니다. 레버리지의 시대가 왔습니다.</p>
+          <div class="card-counter">5 / 7</div>
+        </div>
+
+        <!-- Card 6: Tip 5 -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 6/7: 끊임없이 배우고 실행하라">
+          <div class="card-number">05</div>
+          <div class="step-dots"><span></span><span></span><span></span><span></span><span class="active"></span></div>
+          <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+          <h2 class="card-tip-title">끊임없이 배우고 빠르게 실행하라</h2>
+          <p class="card-description">배움의 속도가 유일한 경쟁 우위입니다. 완벽보다 속도, 이론보다 실행이 중요합니다.</p>
+          <div class="card-counter">6 / 7</div>
+        </div>
+
+        <!-- Card 7: CTA -->
+        <div class="carousel-card" role="group" aria-roledescription="slide" aria-label="슬라이드 7/7: 팔로우 CTA">
+          <div class="cover-decoration">
+            <svg class="mesh-ring" viewBox="0 0 400 400" fill="none">
+              <circle cx="200" cy="200" r="180" stroke="var(--accent)" stroke-width="0.4" stroke-dasharray="8 12"/>
+              <circle cx="200" cy="200" r="140" stroke="var(--accent-secondary)" stroke-width="0.4" stroke-dasharray="6 10"/>
+              <!-- Success/completion pattern -->
+              <path d="M140 200 L180 240 L260 160" stroke="var(--positive)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+              <circle cx="200" cy="200" r="80" stroke="var(--positive)" stroke-width="0.6" opacity="0.4"/>
+            </svg>
+          </div>
+          <h2 class="card-tip-title" style="margin-bottom: 8px;">요약하면</h2>
+          <ul class="cta-list">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg> AI 도구를 활용하라</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg> 프롬프트 엔지니어링을 마스터하라</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg> 시스템 사고를 키워라</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg> 1인 팀의 힘을 믿어라</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg> 끊임없이 배우고 빠르게 실행하라</li>
+          </ul>
+          <div class="cta-handle">팔로우하세요 @careerhackeralex</div>
+          <div class="card-counter">7 / 7</div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  </main>
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    // === Theme system ===
+    const themes = [
+      { name: 'Dark', class: 'theme-dark' },
+      { name: 'Light', class: 'theme-light' },
+      { name: 'Auto', class: 'theme-auto' },
+    ];
+    let currentTheme = 0;
+
+    function cycleTheme() {
+      // Remove all theme classes
+      themes.forEach(t => document.documentElement.classList.remove(t.class));
+      // Advance to next
+      currentTheme = (currentTheme + 1) % themes.length;
+      document.documentElement.classList.add(themes[currentTheme].class);
+      document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      // Persist
+      localStorage.setItem('viz-theme', currentTheme);
+    }
+
+    // Restore saved theme on load
+    (function() {
+      const saved = localStorage.getItem('viz-theme');
+      if (saved !== null) {
+        currentTheme = parseInt(saved);
+        document.documentElement.classList.add(themes[currentTheme].class);
+        document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      }
+    })();
+
+    // === Print as PDF ===
+    function printPDF() {
+      window.print();
+    }
+
+    var currentSlide = 0;
+    var totalSlides = document.querySelectorAll('.carousel-card').length;
+    var track = document.getElementById('carouselTrack');
+
+    function goTo(index) {
+      if (index < 0 || index >= totalSlides) return;
+      currentSlide = index;
+      track.style.transform = 'translateX(-' + (currentSlide * 100) + '%)';
+      document.querySelector('.carousel-nav.prev').disabled = currentSlide === 0;
+      document.querySelector('.carousel-nav.next').disabled = currentSlide === totalSlides - 1;
+      document.getElementById('cardCounter').textContent = (currentSlide + 1) + ' / ' + totalSlides;
+      
+      // Update active slide animation
+      document.querySelectorAll('.carousel-card').forEach(function(card, i) {
+        card.classList.toggle('active', i === currentSlide);
+      });
+    }
+    goTo(0);
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); goTo(currentSlide - 1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); goTo(currentSlide + 1); }
+    });
+
+    var touchStartX = 0;
+    var viewport = document.querySelector('.carousel-viewport');
+    viewport.addEventListener('touchstart', function(e) { touchStartX = e.changedTouches[0].screenX; }, { passive: true });
+    viewport.addEventListener('touchend', function(e) {
+      var diff = touchStartX - e.changedTouches[0].screenX;
+      if (Math.abs(diff) > 50) { diff > 0 ? goTo(currentSlide + 1) : goTo(currentSlide - 1); }
+    });
+
+    async function downloadCurrentCard() {
+      var menu = document.querySelector('.viz-menu');
+      var navs = document.querySelectorAll('.carousel-nav');
+      menu.style.display = 'none';
+      navs.forEach(function(n) { n.style.display = 'none'; });
+      try {
+        var card = document.querySelectorAll('.carousel-card')[currentSlide];
+        var url = await htmlToImage.toPng(card, { 
+          quality: 1, 
+          pixelRatio: 2, 
+          width: 1080, 
+          height: 1080,
+          filter: function(n) { 
+            return !n.classList || (!n.classList.contains('viz-menu') && !n.classList.contains('carousel-nav')); 
+          } 
+        });
+        var a = document.createElement('a'); a.href = url;
+        a.download = 'ai-시대-카드-' + (currentSlide + 1) + '.png'; a.click();
+      } catch(e) { 
+        console.error('다운로드 실패:', e); 
+        alert('카드 다운로드에 실패했습니다. 인쇄 기능을 사용해 보세요.');
+      }
+      menu.style.display = '';
+      navs.forEach(function(n) { n.style.display = ''; });
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/carousel-threads.html
+++ b/claude/skills/visualize/examples/carousel-threads.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>5 AI Tools That Replaced My Entire Team</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #f43f5e; --accent-secondary: #e11d48; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #f43f5e; --accent-secondary: #e11d48; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.5; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; padding: 24px;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes slideInFromRight { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    /* ===== CAROUSEL ===== */
+    .carousel-wrapper { display: flex; flex-direction: column; align-items: center; gap: 20px; max-width: 600px; width: 100%; }
+    .carousel-viewport { width: 100%; aspect-ratio: 1; max-width: 540px; position: relative; overflow: hidden; border-radius: 20px; box-shadow: 0 12px 48px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.08); }
+    .carousel-track { display: flex; height: 100%; transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+
+    .carousel-card {
+      min-width: 100%; height: 100%; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; padding: 48px 40px;
+      position: relative; text-align: center;
+      border-left: 4px solid transparent;
+      transition: border-color 0.3s ease;
+    }
+    .carousel-card.active {
+      border-left: 3px solid transparent;
+      animation: slideInFromRight 0.6s ease-out;
+    }
+
+    /* Card gradients — dark */
+    .card-0 { background: linear-gradient(145deg, #0f172a 0%, #1e1b4b 50%, #312e81 100%); }
+    .card-1 { background: linear-gradient(145deg, #0f172a 0%, #1e3a5f 50%, #1e40af 100%); }
+    .card-2 { background: linear-gradient(145deg, #0f172a 0%, #14532d 50%, #166534 100%); }
+    .card-3 { background: linear-gradient(145deg, #0f172a 0%, #4a1d6a 50%, #6b21a8 100%); }
+    .card-4 { background: linear-gradient(145deg, #0f172a 0%, #78350f 50%, #92400e 100%); }
+    .card-5 { background: linear-gradient(145deg, #0f172a 0%, #701a1a 50%, #991b1b 100%); }
+    .card-6 { background: linear-gradient(145deg, #0f172a 0%, #1e1b4b 50%, #312e81 100%); }
+
+    .theme-light .card-0 { background: linear-gradient(145deg, #e0e7ff 0%, #c7d2fe 50%, #a5b4fc 100%); }
+    .theme-light .card-1 { background: linear-gradient(145deg, #dbeafe 0%, #bfdbfe 50%, #93c5fd 100%); }
+    .theme-light .card-2 { background: linear-gradient(145deg, #d1fae5 0%, #a7f3d0 50%, #6ee7b7 100%); }
+    .theme-light .card-3 { background: linear-gradient(145deg, #ede9fe 0%, #ddd6fe 50%, #c4b5fd 100%); }
+    .theme-light .card-4 { background: linear-gradient(145deg, #fef3c7 0%, #fde68a 50%, #fcd34d 100%); }
+    .theme-light .card-5 { background: linear-gradient(145deg, #ffe4e6 0%, #fecdd3 50%, #fda4af 100%); }
+    .theme-light .card-6 { background: linear-gradient(145deg, #e0e7ff 0%, #c7d2fe 50%, #a5b4fc 100%); }
+
+    .carousel-card * { color: #f9fafb; }
+    .theme-light .carousel-card * { color: #0f172a; }
+
+    .card-number { font-size: 6rem; font-weight: 900; line-height: 1; opacity: 0.4; position: absolute; top: 24px; right: 32px; text-shadow: 0 0 32px rgba(255,255,255,0.5); }
+
+    .card-icon {
+      width: 56px; height: 56px; border-radius: 14px;
+      background: rgba(255,255,255,0.12); backdrop-filter: blur(8px);
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 16px;
+    }
+    .theme-light .card-icon { background: rgba(0,0,0,0.08); }
+
+    .card-tool-name { font-size: 2.2rem; font-weight: 700; line-height: 1.1; margin-bottom: 8px; text-shadow: 0 2px 8px rgba(0,0,0,0.3); text-wrap: balance; }
+    .theme-light .card-tool-name { text-shadow: none; }
+    .card-replaces { font-size: 0.9rem; font-weight: 600; opacity: 0.7; margin-bottom: 20px; text-transform: uppercase; letter-spacing: 0.05em; }
+    .card-insight { font-size: 1.05rem; line-height: 1.5; max-width: 380px; opacity: 0.9; }
+
+    /* Cover card */
+    .card-title-main { font-size: 3.5rem; font-weight: 900; line-height: 1.08; text-shadow: 0 2px 12px rgba(0,0,0,0.3); margin-bottom: 16px; text-wrap: balance; }
+    .theme-light .card-title-main { text-shadow: none; }
+    .card-subtitle { font-size: 1rem; font-weight: 500; opacity: 0.75; margin-bottom: 32px; }
+    .card-handle { font-size: 0.9rem; opacity: 0.5; position: absolute; bottom: 32px; }
+    .cover-badge { display: inline-flex; align-items: center; gap: 8px; background: rgba(59,130,246,0.2); backdrop-filter: blur(8px); padding: 12px 20px; border-radius: 99px; font-size: 0.9rem; font-weight: 700; margin-bottom: 24px; border: 1px solid rgba(59,130,246,0.4); }
+    .theme-light .cover-badge { background: rgba(59,130,246,0.15); border: 1px solid rgba(59,130,246,0.3); }
+
+    /* CTA card */
+    .card-cta-title { font-size: 1.8rem; font-weight: 700; margin-bottom: 24px; text-shadow: 0 2px 8px rgba(0,0,0,0.3); text-wrap: balance; }
+    .theme-light .card-cta-title { text-shadow: none; }
+    .cta-summary { font-size: 0.85rem; line-height: 1.7; opacity: 0.8; max-width: 340px; text-align: left; list-style: none; }
+    .cta-summary li { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+
+    /* NAV */
+    .carousel-nav { display: flex; align-items: center; gap: 16px; }
+    .nav-btn {
+      width: 44px; height: 44px; border-radius: 50%;
+      border: 1px solid var(--border); background: var(--surface);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center; 
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    }
+    .nav-btn:hover { 
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15); 
+      transform: scale(1.05);
+      background: var(--surface-hover);
+    }
+    .nav-btn:disabled { 
+      opacity: 0.3; 
+      cursor: not-allowed; 
+      transform: scale(1);
+    }
+
+    .progress-bar { display: flex; gap: 4px; align-items: center; }
+    .progress-segment { 
+      width: 24px; height: 3px; border-radius: 2px; 
+      background: var(--text-secondary); opacity: 0.2; 
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      cursor: pointer;
+    }
+    .progress-segment:hover {
+      opacity: 0.4;
+      transform: scaleY(1.5);
+    }
+    .progress-segment.active { 
+      opacity: 1; 
+      background: var(--accent); 
+      width: 32px; 
+      box-shadow: 0 0 8px color-mix(in srgb, var(--accent), transparent 50%);
+    }
+    .progress-segment.past { 
+      opacity: 0.6; 
+      background: var(--accent); 
+    }
+
+    .card-counter { font-size: 0.85rem; color: var(--text-secondary); font-weight: 500; min-width: 40px; text-align: center; }
+
+    .download-card-btn {
+      padding: 10px 20px; border-radius: 8px; border: 1px solid var(--border);
+      background: var(--surface); color: var(--text); cursor: pointer;
+      font-family: inherit; font-size: 0.85rem; font-weight: 500;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); 
+      display: flex; align-items: center; gap: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    }
+    .download-card-btn:hover { 
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15); 
+      transform: translateY(-1px);
+      background: var(--surface-hover);
+      border-color: var(--accent);
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; }
+      .viz-menu, .carousel-nav, .download-card-btn { display: none !important; }
+      .carousel-track { flex-wrap: wrap; transform: none !important; }
+      .carousel-card { min-width: 50%; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* === Hamburger Menu === */
+    .viz-menu {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 9999;
+      font-family: var(--font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    }
+
+    .viz-menu-toggle {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .viz-menu-toggle:hover {
+      background: var(--surface-hover);
+      transform: scale(1.05);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+
+    .viz-menu-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      min-width: 200px;
+      background: var(--surface);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 6px;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px) scale(0.96);
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+
+    .viz-menu-dropdown.open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0) scale(1);
+    }
+
+    .viz-menu-dropdown button {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border: none;
+      background: transparent;
+      color: var(--text);
+      font-size: 0.875rem;
+      cursor: pointer;
+      border-radius: 8px;
+      transition: background 0.15s;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    .viz-menu-dropdown button:hover {
+      background: var(--surface-hover);
+    }
+
+    .viz-menu-icon {
+      font-size: 1rem;
+      width: 20px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    .skip-link { position: absolute; top: -100px; left: 16px; padding: 8px 16px; background: var(--accent); color: #fff; border-radius: 8px; text-decoration: none; z-index: 99999; font-weight: 600; }
+    .skip-link:focus { top: 16px; }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <!-- Hamburger Menu -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/>
+        <line x1="3" y1="10" x2="17" y2="10"/>
+        <line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()">
+        <span class="viz-menu-icon">◐</span>
+        <span>Theme: <span id="themeLabel">Dark</span></span>
+      </button>
+      <button onclick="downloadCurrentCard()">
+        <span class="viz-menu-icon">⤓</span>
+        <span>Download Card PNG</span>
+      </button>
+      <button onclick="printPDF()">
+        <span class="viz-menu-icon">⎙</span>
+        <span>Print / PDF</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="carousel-wrapper animate" role="region" aria-label="Carousel: 5 AI Tools That Replaced My Entire Team">
+    <div class="carousel-viewport">
+      <div class="carousel-track" id="carouselTrack" role="group" aria-label="Carousel cards">
+
+        <!-- Cover -->
+        <article class="carousel-card card-0">
+          <!-- Bold hero visual element -->
+          <div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:1;">
+            <svg viewBox="0 0 360 360" fill="none" style="width:300px;height:300px;opacity:0.25;">
+              <!-- Central automation hub -->
+              <circle cx="180" cy="180" r="80" fill="rgba(255,255,255,0.2)" stroke="rgba(255,255,255,0.4)" stroke-width="2"/>
+              <circle cx="180" cy="180" r="40" fill="rgba(255,255,255,0.3)"/>
+              <!-- Number 5 in center -->
+              <text x="180" y="195" text-anchor="middle" font-family="Inter" font-size="42" font-weight="900" fill="rgba(255,255,255,0.9)">5</text>
+              <!-- Tool nodes arranged around the center -->
+              <g opacity="0.8">
+                <!-- Top: Code -->
+                <circle cx="180" cy="80" r="24" fill="rgba(59,130,246,0.8)"/>
+                <text x="180" y="88" text-anchor="middle" font-family="Inter" font-size="20" font-weight="700" fill="white">&lt;/&gt;</text>
+                <!-- Top Right: Design -->
+                <circle cx="260" cy="120" r="24" fill="rgba(139,92,246,0.8)"/>
+                <rect x="248" y="108" width="24" height="24" rx="3" fill="none" stroke="white" stroke-width="2"/>
+                <rect x="252" y="112" width="16" height="2" fill="white"/>
+                <rect x="252" y="116" width="16" height="2" fill="white"/>
+                <!-- Bottom Right: Search -->
+                <circle cx="260" cy="240" r="24" fill="rgba(16,185,129,0.8)"/>
+                <circle cx="257" cy="237" r="8" fill="none" stroke="white" stroke-width="2"/>
+                <line x1="263" y1="243" x2="268" y2="248" stroke="white" stroke-width="2" stroke-linecap="round"/>
+                <!-- Bottom: Voice -->
+                <circle cx="180" cy="280" r="24" fill="rgba(244,63,94,0.8)"/>
+                <ellipse cx="180" cy="275" rx="6" ry="10" fill="none" stroke="white" stroke-width="2"/>
+                <path d="M165 280 Q180 290 195 280" stroke="white" stroke-width="2" fill="none"/>
+                <!-- Bottom Left: AI -->
+                <circle cx="100" cy="240" r="24" fill="rgba(245,158,11,0.8)"/>
+                <circle cx="95" cy="235" r="3" fill="white"/>
+                <circle cx="105" cy="235" r="3" fill="white"/>
+                <circle cx="95" cy="245" r="3" fill="white"/>
+                <circle cx="105" cy="245" r="3" fill="white"/>
+                <line x1="95" y1="235" x2="105" y2="245" stroke="white" stroke-width="1.5"/>
+                <line x1="105" y1="235" x2="95" y2="245" stroke="white" stroke-width="1.5"/>
+                <!-- Top Left: Edit -->
+                <circle cx="100" cy="120" r="24" fill="rgba(6,182,212,0.8)"/>
+                <path d="M90 125 L95 130 L110 115" stroke="white" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+              </g>
+              <!-- Connection lines removed for cleaner design -->
+            </svg>
+          </div>
+          <div class="cover-badge">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+            Automation Revolution
+          </div>
+          <div class="card-title-main">5 AI Tools<br>That Replaced<br>My Entire Team</div>
+          <div class="card-subtitle">Real productivity gains from the builders who shipped</div>
+          <!-- Colored section divider -->
+          <div style="width:80px;height:4px;background:linear-gradient(90deg,rgba(59,130,246,0.8),rgba(139,92,246,0.8));border-radius:2px;margin:16px auto;"></div>
+          <div class="card-handle">@careerhackeralex</div>
+        </article>
+
+        <!-- Card 1: Claude Code -->
+        <article class="carousel-card card-1">
+          <div class="card-number">1</div>
+          <div class="card-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16,18 22,12 16,6"/><polyline points="8,6 2,12 8,18"/></svg></div>
+          <div class="card-tool-name">Claude Code</div>
+          <div class="card-replaces">Replaces: Junior Developer</div>
+          <div class="card-insight">Writes, edits, and debugs code across your entire codebase. Reads files, runs tests, commits changes — like pair programming with a senior dev.</div>
+          <div class="card-handle">@careerhackeralex</div>
+        </article>
+
+        <!-- Card 2: Cursor -->
+        <article class="carousel-card card-2">
+          <div class="card-number">2</div>
+          <div class="card-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></div>
+          <div class="card-tool-name">Cursor</div>
+          <div class="card-replaces">Replaces: Code Review Team</div>
+          <div class="card-insight">AI-native IDE that autocompletes entire functions, refactors on command, and understands your full project context. 10x faster than VS Code alone.</div>
+          <div class="card-handle">@careerhackeralex</div>
+        </article>
+
+        <!-- Card 3: v0 -->
+        <article class="carousel-card card-3">
+          <div class="card-number">3</div>
+          <div class="card-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg></div>
+          <div class="card-tool-name">v0 by Vercel</div>
+          <div class="card-replaces">Replaces: UI/UX Designer</div>
+          <div class="card-insight">Describe any interface and get production-ready React components. From wireframe to deployed UI in minutes, not weeks.</div>
+          <div class="card-handle">@careerhackeralex</div>
+        </article>
+
+        <!-- Card 4: Perplexity -->
+        <article class="carousel-card card-4">
+          <div class="card-number">4</div>
+          <div class="card-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg></div>
+          <div class="card-tool-name">Perplexity</div>
+          <div class="card-replaces">Replaces: Research Analyst</div>
+          <div class="card-insight">AI search engine that reads the entire internet for you. Cites sources, synthesizes findings, and delivers answers — not links.</div>
+          <div class="card-handle">@careerhackeralex</div>
+        </article>
+
+        <!-- Card 5: ElevenLabs -->
+        <article class="carousel-card card-5">
+          <div class="card-number">5</div>
+          <div class="card-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></div>
+          <div class="card-tool-name">ElevenLabs</div>
+          <div class="card-replaces">Replaces: Voice Actor / Audio Team</div>
+          <div class="card-insight">Clone any voice, generate podcasts, narrate videos — with emotion and nuance that's indistinguishable from real humans.</div>
+          <div class="card-handle">@careerhackeralex</div>
+        </article>
+
+        <!-- CTA -->
+        <article class="carousel-card card-6">
+          <div class="card-cta-title">Follow<br>@careerhackeralex<br>for more</div>
+          <ul class="cta-summary">
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20,6 9,17 4,12"/></svg> Claude Code — Developer</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20,6 9,17 4,12"/></svg> Cursor — Code Review</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20,6 9,17 4,12"/></svg> v0 — UI/UX Design</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20,6 9,17 4,12"/></svg> Perplexity — Research</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20,6 9,17 4,12"/></svg> ElevenLabs — Voice/Audio</li>
+          </ul>
+        </article>
+      </div>
+    </div>
+
+    <nav class="carousel-nav" aria-label="Carousel navigation">
+      <button class="nav-btn" id="prevBtn" onclick="goTo(currentSlide - 1)" aria-label="Previous card">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M15 18l-6-6 6-6"/></svg>
+      </button>
+      <div class="progress-bar" id="progressBar" role="tablist" aria-label="Card indicators"></div>
+      <span class="card-counter" id="cardCounter" aria-live="polite">1 / 7</span>
+      <button class="nav-btn" id="nextBtn" onclick="goTo(currentSlide + 1)" aria-label="Next card">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M9 18l6-6-6-6"/></svg>
+      </button>
+    </nav>
+
+    <button class="download-card-btn" onclick="downloadCurrentCard()" aria-label="Download current card as PNG">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      Download this card as PNG
+    </button>
+  </div>
+
+  </main>
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    // === Theme system ===
+    const themes = [
+      { name: 'Dark', class: 'theme-dark' },
+      { name: 'Light', class: 'theme-light' },
+      { name: 'Auto', class: 'theme-auto' },
+    ];
+    let currentTheme = 0;
+
+    function cycleTheme() {
+      // Remove all theme classes
+      themes.forEach(t => document.documentElement.classList.remove(t.class));
+      // Advance to next
+      currentTheme = (currentTheme + 1) % themes.length;
+      document.documentElement.classList.add(themes[currentTheme].class);
+      document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      // Persist
+      localStorage.setItem('viz-theme', currentTheme);
+    }
+
+    // Restore saved theme on load
+    (function() {
+      const saved = localStorage.getItem('viz-theme');
+      if (saved !== null) {
+        currentTheme = parseInt(saved);
+        document.documentElement.classList.add(themes[currentTheme].class);
+        document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      }
+    })();
+
+    // === Print as PDF ===
+    function printPDF() {
+      window.print();
+    }
+
+    var currentSlide = 0, totalSlides = 7;
+    var track = document.getElementById('carouselTrack');
+    var counter = document.getElementById('cardCounter');
+    var prevBtn = document.getElementById('prevBtn');
+    var nextBtn = document.getElementById('nextBtn');
+    var progressBar = document.getElementById('progressBar');
+
+    for (var i = 0; i < totalSlides; i++) {
+      var seg = document.createElement('button');
+      seg.className = 'progress-segment' + (i === 0 ? ' active' : '');
+      seg.setAttribute('aria-label', 'Go to card ' + (i + 1));
+      seg.setAttribute('role', 'tab');
+      seg.dataset.index = i;
+      seg.onclick = function() { goTo(parseInt(this.dataset.index)); };
+      progressBar.appendChild(seg);
+    }
+
+    function goTo(index) {
+      if (index < 0 || index >= totalSlides) return;
+      currentSlide = index;
+      track.style.transform = 'translateX(-' + (currentSlide * 100) + '%)';
+      counter.textContent = (currentSlide + 1) + ' / ' + totalSlides;
+      prevBtn.disabled = currentSlide === 0;
+      nextBtn.disabled = currentSlide === totalSlides - 1;
+      
+      // Update active slide animation
+      document.querySelectorAll('.carousel-card').forEach(function(card, i) {
+        card.classList.toggle('active', i === currentSlide);
+      });
+      
+      var segs = progressBar.querySelectorAll('.progress-segment');
+      segs.forEach(function(s, i) {
+        s.classList.toggle('active', i === currentSlide);
+        s.classList.toggle('past', i < currentSlide);
+      });
+    }
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'ArrowLeft') goTo(currentSlide - 1);
+      if (e.key === 'ArrowRight') goTo(currentSlide + 1);
+    });
+
+    var touchStartX = 0;
+    var viewport = document.querySelector('.carousel-viewport');
+    viewport.addEventListener('touchstart', function(e) { touchStartX = e.changedTouches[0].screenX; }, { passive: true });
+    viewport.addEventListener('touchend', function(e) {
+      var diff = touchStartX - e.changedTouches[0].screenX;
+      if (Math.abs(diff) > 50) { diff > 0 ? goTo(currentSlide + 1) : goTo(currentSlide - 1); }
+    }, { passive: true });
+
+    goTo(0);
+
+    async function downloadCurrentCard() {
+      var cards = document.querySelectorAll('.carousel-card');
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(cards[currentSlide], { quality: 1, pixelRatio: 2, width: 1080, height: 1080 });
+        var a = document.createElement('a'); a.href = url; a.download = 'card-' + (currentSlide + 1) + '.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/cheatsheet-claude-code.html
+++ b/claude/skills/visualize/examples/cheatsheet-claude-code.html
@@ -1,0 +1,466 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Code Cheat Sheet</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #f97316; --accent-secondary: #ea580c; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #f97316; --accent-secondary: #ea580c; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.5; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+    }
+    body::after {
+      content: ''; position: fixed; inset: 0; z-index: -1; opacity: 0.03;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    /* ===== LAYOUT ===== */
+    .cheatsheet { max-width: 1100px; margin: 0 auto; padding: 32px 24px 16px; }
+
+    .cheatsheet-header { text-align: center; margin-bottom: 20px; }
+    .cheatsheet-header h1 { font-size: 2.2rem; font-weight: 900; letter-spacing: -0.03em; color: var(--text); margin-bottom: 4px; text-wrap: balance; }
+    .cheatsheet-header .subtitle { font-size: 0.9rem; color: var(--text-secondary); }
+
+    /* Search */
+    .search-bar {
+      max-width: 480px; margin: 20px auto; position: relative;
+    }
+    .search-bar input {
+      width: 100%; padding: 12px 16px 12px 44px; border-radius: 12px;
+      border: 1px solid var(--border); background: var(--surface);
+      color: var(--text); font-family: inherit; font-size: 0.9rem;
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+    .search-bar input::placeholder { color: var(--text-secondary); }
+    .search-bar input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent), transparent 80%); }
+    .search-bar svg { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-secondary); }
+    .search-count { text-align: center; font-size: 0.8rem; color: var(--text-secondary); margin-top: 8px; min-height: 1.2em; }
+
+    /* Sections as details */
+    .sections-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+
+    details.section-card {
+      background: var(--surface); border: 4px solid var(--border);
+      border-radius: 14px; overflow: hidden;
+      transition: all 0.2s; position: relative;
+    }
+    details.section-card::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+      background: linear-gradient(90deg, var(--section-color, var(--accent)), color-mix(in srgb, var(--section-color, var(--accent)), var(--accent-secondary) 50%));
+    }
+    details.section-card:hover { 
+      box-shadow: 0 0 0 1px var(--section-color, var(--accent)), 0 8px 24px rgba(0,0,0,0.12);
+      transform: translateY(-1px);
+    }
+    details.section-card[open] { 
+      box-shadow: 0 0 0 1px var(--section-color, var(--accent)), 0 8px 24px rgba(0,0,0,0.12);
+      border-color: var(--section-color, var(--accent));
+    }
+
+    details.section-card summary {
+      padding: 14px 16px; cursor: pointer; list-style: none;
+      font-size: 0.82rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.05em; color: var(--section-color, var(--accent));
+      display: flex; align-items: center; gap: 8px;
+      border-bottom: 4px solid var(--section-color, var(--accent));
+    }
+    details.section-card summary::-webkit-details-marker { display: none; }
+    details.section-card summary::after {
+      content: ''; width: 0; height: 0; margin-left: auto;
+      border-left: 5px solid transparent; border-right: 5px solid transparent;
+      border-top: 5px solid var(--text-secondary);
+      transition: transform 0.2s;
+    }
+    details.section-card[open] summary::after { transform: rotate(180deg); }
+    details.section-card summary svg { width: 16px; height: 16px; flex-shrink: 0; }
+
+    ::details-content {
+      transition: block-size 0.3s ease, opacity 0.3s ease;
+      block-size: 0; opacity: 0; overflow: hidden;
+    }
+    details[open]::details-content { block-size: auto; opacity: 1; }
+
+    .section-body { padding: 12px 16px 14px; }
+
+    .cmd-list { list-style: none; }
+    .cmd-list li {
+      padding: 5px 0; font-size: 0.8rem; line-height: 1.45;
+      border-bottom: 1px solid var(--border);
+      display: flex; gap: 8px; align-items: baseline;
+    }
+    .cmd-list li:last-child { border-bottom: none; }
+    .cmd-list li.hidden { display: none; }
+
+    code {
+      font-family: 'JetBrains Mono', 'SF Mono', monospace;
+      font-size: 0.73rem; background: var(--surface-hover);
+      padding: 2px 6px; border-radius: 4px; white-space: nowrap;
+      color: var(--accent); font-weight: 500; cursor: pointer;
+      transition: background 0.15s;
+    }
+    code:hover { background: color-mix(in srgb, var(--accent), transparent 85%); }
+    .desc { color: var(--text-secondary); font-size: 0.78rem; }
+
+    .tip-box {
+      background: color-mix(in srgb, var(--warning), transparent 88%);
+      border: 1px solid color-mix(in srgb, var(--warning), transparent 60%);
+      border-radius: 8px; padding: 8px 10px; font-size: 0.78rem;
+      margin-top: 8px; line-height: 1.4; display: flex; align-items: flex-start; gap: 6px;
+    }
+    .tip-box svg { flex-shrink: 0; color: var(--warning); margin-top: 1px; }
+
+    .span-2 { grid-column: span 2; }
+
+    .footer { text-align: center; padding: 12px 0 8px; font-size: 0.75rem; color: var(--text-secondary); border-top: 1px solid var(--border); margin-top: 20px; }
+    
+    /* Copy toast notification */
+    .copy-toast {
+      position: fixed; top: 20px; right: 20px; z-index: 1000;
+      background: var(--positive); color: white; padding: 12px 16px;
+      border-radius: 8px; font-size: 0.875rem; font-weight: 600;
+      transform: translateX(100%); opacity: 0;
+      transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+    .copy-toast.show {
+      transform: translateX(0); opacity: 1;
+    }
+
+    .s-setup { --section-color: #3b82f6; }
+    .s-commands { --section-color: #8b5cf6; }
+    .s-workflow { --section-color: #10b981; }
+    .s-multifile { --section-color: #ec4899; }
+    .s-tools { --section-color: #f59e0b; }
+    .s-keyboard { --section-color: #06b6d4; }
+    .s-protips { --section-color: #f43f5e; }
+    .s-perms { --section-color: #3b82f6; }
+
+    @media (max-width: 768px) {
+      .sections-grid { grid-template-columns: 1fr; }
+      .span-2 { grid-column: span 1; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; font-size: 10pt; }
+      .viz-menu, .search-bar, .search-count { display: none !important; }
+      details.section-card { break-inside: avoid; }
+      details.section-card[open] summary::after { display: none; }
+      code { background: #f1f5f9; color: #2563eb; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-dark .theme-toggle .sun-icon { display: none; }
+    .theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle { width: 44px; height: 44px; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { position: absolute; top: 52px; right: 0; min-width: 200px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 8px; opacity: 0; visibility: hidden; transform: translateY(-8px); transition: all 0.2s; backdrop-filter: blur(16px); }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+    .viz-menu-dropdown button { width: 100%; padding: 10px 14px; border: none; border-radius: 8px; background: transparent; color: var(--text); font-size: 14px; font-family: inherit; cursor: pointer; text-align: left; display: flex; align-items: center; gap: 10px; transition: background 0.15s; }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); }
+
+    .skip-link { position: absolute; top: -100px; left: 16px; padding: 8px 16px; background: var(--accent); color: #fff; border-radius: 8px; text-decoration: none; z-index: 99999; font-weight: 600; }
+    .skip-link:focus { top: 16px; }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/></svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span>Download PNG</span></button>
+      <button onclick="window.print()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6,9 6,2 18,2 18,9"/><path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <div class="cheatsheet">
+    <header class="cheatsheet-header animate" role="banner">
+      <h1>Claude Code Cheat Sheet</h1>
+      <p class="subtitle">The essential reference for Anthropic's AI coding CLI</p>
+    </header>
+
+    <div class="search-bar animate delay-1">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+      <input type="text" id="searchInput" placeholder="Search commands..." aria-label="Search commands" oninput="filterCommands()">
+    </div>
+    <div class="search-count" id="searchCount"></div>
+
+    <div class="sections-grid" role="region" aria-label="Cheat sheet sections">
+
+      <details class="section-card s-setup animate delay-1" name="cheatsheet" open aria-label="Setup and Install">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+          Setup &amp; Install
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>npm i -g @anthropic-ai/claude-code</code> <span class="desc">Install globally</span></li>
+            <li><code>claude</code> <span class="desc">Launch in current directory</span></li>
+            <li><code>claude -p "query"</code> <span class="desc">One-shot prompt mode</span></li>
+            <li><code>claude config</code> <span class="desc">Open settings</span></li>
+            <li><code>claude update</code> <span class="desc">Update to latest version</span></li>
+            <li><code>cat file | claude -p "fix"</code> <span class="desc">Pipe input as context</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-commands animate delay-1" name="cheatsheet" aria-label="Key Commands">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 3a3 3 0 00-3 3v12a3 3 0 003 3 3 3 0 003-3 3 3 0 00-3-3H6a3 3 0 00-3 3 3 3 0 003 3 3 3 0 003-3V6a3 3 0 00-3-3"/></svg>
+          Key Commands
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>/help</code> <span class="desc">Show all slash commands</span></li>
+            <li><code>/compact</code> <span class="desc">Summarize &amp; compress context</span></li>
+            <li><code>/clear</code> <span class="desc">Reset conversation history</span></li>
+            <li><code>/cost</code> <span class="desc">Show token usage &amp; cost</span></li>
+            <li><code>/model</code> <span class="desc">Switch model mid-session</span></li>
+            <li><code>/review</code> <span class="desc">Code review current changes</span></li>
+            <li><code>/init</code> <span class="desc">Create CLAUDE.md for project</span></li>
+            <li><code>/memory</code> <span class="desc">Edit project memory file</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-workflow animate delay-2" name="cheatsheet" aria-label="Workflow Tips">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/></svg>
+          Workflow Tips
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><span class="desc">Start with a plan — ask Claude to outline before coding</span></li>
+            <li><span class="desc">Use <code>/compact</code> when context gets long</span></li>
+            <li><span class="desc">Add <code>CLAUDE.md</code> to repos for persistent instructions</span></li>
+            <li><span class="desc">Give Claude tests to validate against</span></li>
+            <li><span class="desc">Commit often — Claude can revert if needed</span></li>
+            <li><span class="desc">Use headless mode for CI/CD pipelines</span></li>
+          </ul>
+          <div class="tip-box">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+            Run <code>claude -p "..." | pbcopy</code> to pipe output directly to clipboard.
+          </div>
+        </div>
+      </details>
+
+      <details class="section-card s-multifile animate delay-2" name="cheatsheet" aria-label="Multi-file Editing">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7.5L14.5 2z"/><polyline points="14,2 14,8 20,8"/></svg>
+          Multi-file Editing
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><span class="desc">Claude reads &amp; writes files across your project</span></li>
+            <li><span class="desc">Reference files by name — "update App.tsx and its tests"</span></li>
+            <li><span class="desc">Ask "find all files that..." for codebase search</span></li>
+            <li><span class="desc">Claude auto-creates new files when needed</span></li>
+            <li><span class="desc">Uses git diff to track all changes made</span></li>
+            <li><span class="desc">Respects .gitignore for file discovery</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-tools animate delay-2" name="cheatsheet" aria-label="Tool Use Patterns">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+          Tool Use Patterns
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>Read</code> <span class="desc">Read file contents</span></li>
+            <li><code>Write</code> <span class="desc">Create/overwrite files</span></li>
+            <li><code>Edit</code> <span class="desc">Surgical find &amp; replace edits</span></li>
+            <li><code>Bash</code> <span class="desc">Run shell commands</span></li>
+            <li><code>Glob</code> <span class="desc">Search for files by pattern</span></li>
+            <li><code>Grep</code> <span class="desc">Search file contents (regex)</span></li>
+            <li><code>LS</code> <span class="desc">List directory contents</span></li>
+          </ul>
+          <div class="tip-box">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+            Claude chains tools automatically — just describe the goal.
+          </div>
+        </div>
+      </details>
+
+      <details class="section-card s-keyboard animate delay-2" name="cheatsheet" aria-label="Keyboard Shortcuts">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10"/></svg>
+          Keyboard Shortcuts
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>Ctrl+C</code> <span class="desc">Cancel current generation</span></li>
+            <li><code>Ctrl+D</code> <span class="desc">Exit Claude Code</span></li>
+            <li><code>Esc</code> <span class="desc">Cancel current input</span></li>
+            <li><code>Up Arrow</code> <span class="desc">Previous message</span></li>
+            <li><code>Tab</code> <span class="desc">Accept suggestion</span></li>
+            <li><code>Shift+Tab</code> <span class="desc">Toggle vim mode</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-protips span-2 animate delay-2" name="cheatsheet" aria-label="Pro Tips">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+          Pro Tips
+        </summary>
+        <div class="section-body">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;">
+            <ul class="cmd-list">
+              <li><span class="desc">Be specific: "Add error handling to the fetch in api.ts line 42"</span></li>
+              <li><span class="desc">Paste error messages directly — Claude reads stack traces</span></li>
+              <li><span class="desc">Use git branches for experimental Claude changes</span></li>
+              <li><span class="desc">"Write tests first, then implement" — TDD with Claude</span></li>
+            </ul>
+            <ul class="cmd-list">
+              <li><span class="desc">Add CLAUDE.md to every repo with project conventions</span></li>
+              <li><span class="desc">Use <code>--allowedTools</code> flag to pre-approve tools</span></li>
+              <li><span class="desc">Chain sessions: output of one becomes input to next</span></li>
+              <li><span class="desc">"Show me the plan first" before big refactors</span></li>
+            </ul>
+          </div>
+        </div>
+      </details>
+
+      <details class="section-card s-perms animate delay-2" name="cheatsheet" aria-label="Permission Model">
+        <summary>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+          Permissions
+        </summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><span class="desc"><strong>Read</strong> — always allowed (safe)</span></li>
+            <li><span class="desc"><strong>Write/Edit</strong> — asks on first use</span></li>
+            <li><span class="desc"><strong>Bash</strong> — asks for each new command</span></li>
+            <li><span class="desc">Accept once = allowed for session</span></li>
+            <li><span class="desc"><code>--dangerously-skip-permissions</code> for CI</span></li>
+          </ul>
+        </div>
+      </details>
+
+    </div>
+
+    <footer class="footer">careerhackeralex.com · Claude Code by Anthropic · 2025</footer>
+  </div>
+
+  </main>
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    // Search/filter
+    function filterCommands() {
+      var query = document.getElementById('searchInput').value.toLowerCase().trim();
+      var allItems = document.querySelectorAll('.cmd-list li');
+      var visible = 0;
+      allItems.forEach(function(li) {
+        var text = li.textContent.toLowerCase();
+        var match = !query || text.indexOf(query) !== -1;
+        li.classList.toggle('hidden', !match);
+        if (match) visible++;
+      });
+      var countEl = document.getElementById('searchCount');
+      countEl.textContent = query ? visible + ' result' + (visible !== 1 ? 's' : '') : '';
+      // Open sections with matches
+      if (query) {
+        document.querySelectorAll('details.section-card').forEach(function(d) {
+          var hasVisible = d.querySelector('.cmd-list li:not(.hidden)');
+          d.open = !!hasVisible;
+        });
+      }
+    }
+
+    // Copy code on click with toast notification
+    document.addEventListener('click', function(e) {
+      if (e.target.tagName === 'CODE') {
+        navigator.clipboard.writeText(e.target.textContent).then(function() {
+          e.target.style.background = 'color-mix(in srgb, var(--positive), transparent 80%)';
+          setTimeout(function() { e.target.style.background = ''; }, 600);
+          
+          // Show toast notification
+          showCopyToast();
+        });
+      }
+    });
+    
+    function showCopyToast() {
+      var existingToast = document.querySelector('.copy-toast');
+      if (existingToast) existingToast.remove();
+      
+      var toast = document.createElement('div');
+      toast.className = 'copy-toast';
+      toast.textContent = 'Copied! ✓';
+      document.body.appendChild(toast);
+      
+      setTimeout(function() { toast.classList.add('show'); }, 10);
+      setTimeout(function() { 
+        toast.classList.remove('show');
+        setTimeout(function() { if (toast.parentNode) toast.remove(); }, 300);
+      }, 2000);
+    }
+
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      // Open all sections for export
+      document.querySelectorAll('details.section-card').forEach(function(d) { d.open = true; });
+      try {
+        var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } });
+        var a = document.createElement('a'); a.href = url; a.download = 'claude-code-cheat-sheet.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/cheatsheet-git.html
+++ b/claude/skills/visualize/examples/cheatsheet-git.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Git Commands Cheat Sheet</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #ef4444; --accent-secondary: #dc2626; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #ef4444; --accent-secondary: #dc2626; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.5; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+    }
+    body::after {
+      content: ''; position: fixed; inset: 0; z-index: -1; opacity: 0.03;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    .cheatsheet { max-width: 1100px; margin: 0 auto; padding: 28px 24px 16px; }
+    .cheatsheet-header { text-align: center; margin-bottom: 16px; }
+    .cheatsheet-header h1 { font-size: 2.2rem; font-weight: 900; letter-spacing: -0.03em; color: var(--text); text-wrap: balance; }
+    .cheatsheet-header .subtitle { font-size: 0.9rem; color: var(--text-secondary); margin-top: 4px; }
+
+    /* Search */
+    .search-bar { max-width: 480px; margin: 16px auto; position: relative; }
+    .search-bar input {
+      width: 100%; padding: 12px 16px 12px 44px; border-radius: 12px;
+      border: 1px solid var(--border); background: var(--surface);
+      color: var(--text); font-family: inherit; font-size: 0.9rem;
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+    .search-bar input::placeholder { color: var(--text-secondary); }
+    .search-bar input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent), transparent 80%); }
+    .search-bar svg { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-secondary); }
+    .search-count { text-align: center; font-size: 0.8rem; color: var(--text-secondary); margin-top: 8px; min-height: 1.2em; }
+
+    /* Flow diagram */
+    .flow-diagram {
+      display: flex; align-items: center; justify-content: center; gap: 0;
+      margin-bottom: 16px; padding: 16px 20px;
+      background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+    }
+    .flow-box { padding: 10px 20px; border-radius: 8px; font-weight: 700; font-size: 0.8rem; text-align: center; white-space: nowrap; }
+    .flow-working { background: color-mix(in srgb, #f97316, transparent 82%); border: 1px solid color-mix(in srgb, #f97316, transparent 50%); color: #f97316; }
+    .flow-staging { background: color-mix(in srgb, #3b82f6, transparent 82%); border: 1px solid color-mix(in srgb, #3b82f6, transparent 50%); color: #3b82f6; }
+    .flow-local { background: color-mix(in srgb, #10b981, transparent 82%); border: 1px solid color-mix(in srgb, #10b981, transparent 50%); color: #10b981; }
+    .flow-remote { background: color-mix(in srgb, #8b5cf6, transparent 82%); border: 1px solid color-mix(in srgb, #8b5cf6, transparent 50%); color: #8b5cf6; }
+    .flow-arrow { font-size: 0.7rem; color: var(--text-secondary); padding: 0 10px; display: flex; flex-direction: column; align-items: center; gap: 2px; font-family: 'JetBrains Mono', monospace; font-weight: 500; }
+    .flow-arrow svg { width: 24px; height: 16px; color: var(--text-secondary); }
+
+    .sections-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+
+    details.section-card {
+      background: var(--surface); border: 4px solid var(--border);
+      border-radius: 8px; overflow: hidden; transition: box-shadow 0.2s;
+    }
+    details.section-card:hover { box-shadow: 0 0 0 1px var(--border), 0 4px 16px rgba(0,0,0,0.08); }
+
+    details.section-card summary {
+      padding: 14px 16px; cursor: pointer; list-style: none;
+      font-size: 0.82rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.05em; color: var(--section-color, var(--accent));
+      display: flex; align-items: center; gap: 8px;
+      border-bottom: 4px solid var(--section-color, var(--accent));
+    }
+    details.section-card summary::-webkit-details-marker { display: none; }
+    details.section-card summary::after {
+      content: ''; width: 0; height: 0; margin-left: auto;
+      border-left: 5px solid transparent; border-right: 5px solid transparent;
+      border-top: 5px solid var(--text-secondary); transition: transform 0.2s;
+    }
+    details.section-card[open] summary::after { transform: rotate(180deg); }
+    details.section-card summary svg { width: 15px; height: 15px; flex-shrink: 0; }
+
+    ::details-content {
+      transition: block-size 0.3s ease, opacity 0.3s ease;
+      block-size: 0; opacity: 0; overflow: hidden;
+    }
+    details[open]::details-content { block-size: auto; opacity: 1; }
+
+    .section-body { padding: 12px 16px 14px; }
+
+    .cmd-list { list-style: none; }
+    .cmd-list li {
+      padding: 4px 0; font-size: 0.78rem; line-height: 1.4;
+      border-bottom: 1px solid var(--border);
+      display: flex; gap: 6px; align-items: baseline;
+    }
+    .cmd-list li:last-child { border-bottom: none; }
+    .cmd-list li.hidden { display: none; }
+
+    code {
+      font-family: 'JetBrains Mono', 'SF Mono', monospace;
+      font-size: 0.72rem; background: var(--surface-hover);
+      padding: 1px 5px; border-radius: 4px; white-space: nowrap;
+      color: var(--section-color, var(--accent)); font-weight: 500;
+      cursor: pointer; transition: background 0.15s;
+    }
+    code:hover { background: color-mix(in srgb, var(--accent), transparent 85%); }
+    .desc { color: var(--text-secondary); font-size: 0.76rem; }
+    .span-2 { grid-column: span 2; }
+
+    .s-setup { --section-color: #3b82f6; }
+    .s-basic { --section-color: #10b981; }
+    .s-branch { --section-color: #f97316; }
+    .s-merge { --section-color: #ec4899; }
+    .s-remote { --section-color: #8b5cf6; }
+    .s-undo { --section-color: #f43f5e; }
+    .s-stash { --section-color: #06b6d4; }
+    .s-advanced { --section-color: #f59e0b; }
+
+    .footer { text-align: center; padding: 12px 0 8px; font-size: 0.75rem; color: var(--text-secondary); border-top: 1px solid var(--border); margin-top: 18px; }
+
+    @media (max-width: 768px) {
+      .sections-grid { grid-template-columns: 1fr; }
+      .span-2 { grid-column: span 1; }
+      .flow-diagram { flex-wrap: wrap; gap: 8px; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; font-size: 9.5pt; }
+      .viz-menu, .search-bar, .search-count { display: none !important; }
+      details.section-card { break-inside: avoid; }
+      code { background: #f1f5f9; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-dark .theme-toggle .sun-icon { display: none; }
+    .theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle { width: 44px; height: 44px; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { position: absolute; top: 52px; right: 0; min-width: 200px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 8px; opacity: 0; visibility: hidden; transform: translateY(-8px); transition: all 0.2s; backdrop-filter: blur(16px); }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+    .viz-menu-dropdown button { width: 100%; padding: 10px 14px; border: none; border-radius: 8px; background: transparent; color: var(--text); font-size: 14px; font-family: inherit; cursor: pointer; text-align: left; display: flex; align-items: center; gap: 10px; transition: background 0.15s; }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); }
+
+    .skip-link { position: absolute; top: -100px; left: 16px; padding: 8px 16px; background: var(--accent); color: #fff; border-radius: 8px; text-decoration: none; z-index: 99999; font-weight: 600; }
+    .skip-link:focus { top: 16px; }
+    
+    /* Copy toast notification */
+    .copy-toast {
+      position: fixed; top: 20px; right: 20px; z-index: 1000;
+      background: var(--positive); color: white; padding: 12px 16px;
+      border-radius: 8px; font-size: 0.875rem; font-weight: 600;
+      transform: translateX(100%); opacity: 0;
+      transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+    .copy-toast.show {
+      transform: translateX(0); opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/></svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span>Download PNG</span></button>
+      <button onclick="window.print()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6,9 6,2 18,2 18,9"/><path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <div class="cheatsheet">
+    <header class="cheatsheet-header animate" role="banner">
+      <h1>Git Commands Cheat Sheet</h1>
+      <p class="subtitle">Every command you need — from basics to advanced workflows</p>
+    </header>
+
+    <div class="search-bar animate delay-1">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+      <input type="text" id="searchInput" placeholder="Search git commands..." aria-label="Search git commands" oninput="filterCommands()">
+    </div>
+    <div class="search-count" id="searchCount"></div>
+
+    <section class="flow-diagram animate delay-1" role="img" aria-label="Git workflow: Working Directory to Staging Area to Local Repository to Remote Repository">
+      <div class="flow-box flow-working">Working<br>Directory</div>
+      <div class="flow-arrow">git add<svg viewBox="0 0 24 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M2 8h18M16 4l4 4-4 4"/></svg></div>
+      <div class="flow-box flow-staging">Staging<br>Area</div>
+      <div class="flow-arrow">git commit<svg viewBox="0 0 24 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M2 8h18M16 4l4 4-4 4"/></svg></div>
+      <div class="flow-box flow-local">Local<br>Repository</div>
+      <div class="flow-arrow">git push<svg viewBox="0 0 24 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M2 8h18M16 4l4 4-4 4"/></svg></div>
+      <div class="flow-box flow-remote">Remote<br>Repository</div>
+    </section>
+
+    <div class="sections-grid" role="region" aria-label="Git command sections">
+
+      <details class="section-card s-setup animate delay-2" name="git" open aria-label="Setup">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>Setup</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git init</code> <span class="desc">Initialize new repo</span></li>
+            <li><code>git clone &lt;url&gt;</code> <span class="desc">Clone remote repo</span></li>
+            <li><code>git config user.name "N"</code> <span class="desc">Set name</span></li>
+            <li><code>git config user.email "E"</code> <span class="desc">Set email</span></li>
+            <li><code>git config --global -l</code> <span class="desc">List config</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-basic animate delay-2" name="git" aria-label="Basic Workflow">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9,11 12,14 22,4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>Basic Workflow</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git status</code> <span class="desc">Show working tree status</span></li>
+            <li><code>git add .</code> <span class="desc">Stage all changes</span></li>
+            <li><code>git add &lt;file&gt;</code> <span class="desc">Stage specific file</span></li>
+            <li><code>git commit -m "msg"</code> <span class="desc">Commit staged changes</span></li>
+            <li><code>git log --oneline</code> <span class="desc">Compact commit history</span></li>
+            <li><code>git diff</code> <span class="desc">Show unstaged changes</span></li>
+            <li><code>git diff --staged</code> <span class="desc">Show staged changes</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-branch animate delay-2" name="git" aria-label="Branching">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 01-9 9"/></svg>Branching</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git branch</code> <span class="desc">List branches</span></li>
+            <li><code>git branch &lt;name&gt;</code> <span class="desc">Create branch</span></li>
+            <li><code>git checkout &lt;name&gt;</code> <span class="desc">Switch branch</span></li>
+            <li><code>git switch -c &lt;name&gt;</code> <span class="desc">Create &amp; switch</span></li>
+            <li><code>git branch -d &lt;name&gt;</code> <span class="desc">Delete branch</span></li>
+            <li><code>git branch -a</code> <span class="desc">List all (incl. remote)</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-merge animate delay-2" name="git" aria-label="Merging">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 9v9"/><path d="M9 6h6a3 3 0 013 3v6"/></svg>Merging</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git merge &lt;branch&gt;</code> <span class="desc">Merge into current</span></li>
+            <li><code>git merge --no-ff &lt;b&gt;</code> <span class="desc">Merge with commit</span></li>
+            <li><code>git merge --abort</code> <span class="desc">Abort merge</span></li>
+            <li><code>git mergetool</code> <span class="desc">Open merge tool</span></li>
+            <li><code>git log --merge</code> <span class="desc">Show conflicting commits</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-remote animate delay-2" name="git" aria-label="Remote">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>Remote</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git remote -v</code> <span class="desc">List remotes</span></li>
+            <li><code>git remote add origin &lt;u&gt;</code> <span class="desc">Add remote</span></li>
+            <li><code>git push -u origin main</code> <span class="desc">Push &amp; set upstream</span></li>
+            <li><code>git pull</code> <span class="desc">Fetch &amp; merge</span></li>
+            <li><code>git fetch</code> <span class="desc">Download without merge</span></li>
+            <li><code>git push --force-with-lease</code> <span class="desc">Safe force push</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-undo animate delay-2" name="git" aria-label="Undoing Changes">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1,4 1,10 7,10"/><path d="M3.51 15a9 9 0 102.13-9.36L1 10"/></svg>Undoing Changes</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git restore &lt;file&gt;</code> <span class="desc">Discard changes</span></li>
+            <li><code>git restore --staged &lt;f&gt;</code> <span class="desc">Unstage file</span></li>
+            <li><code>git reset HEAD~1</code> <span class="desc">Undo last commit (keep)</span></li>
+            <li><code>git reset --hard HEAD~1</code> <span class="desc">Undo &amp; discard</span></li>
+            <li><code>git revert &lt;hash&gt;</code> <span class="desc">Reverse a commit</span></li>
+            <li><code>git clean -fd</code> <span class="desc">Remove untracked files</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-stash animate delay-2" name="git" aria-label="Stashing">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>Stashing</summary>
+        <div class="section-body">
+          <ul class="cmd-list">
+            <li><code>git stash</code> <span class="desc">Save dirty working dir</span></li>
+            <li><code>git stash pop</code> <span class="desc">Apply &amp; remove stash</span></li>
+            <li><code>git stash list</code> <span class="desc">List all stashes</span></li>
+            <li><code>git stash apply</code> <span class="desc">Apply without removing</span></li>
+            <li><code>git stash drop</code> <span class="desc">Delete latest stash</span></li>
+            <li><code>git stash -m "msg"</code> <span class="desc">Stash with message</span></li>
+          </ul>
+        </div>
+      </details>
+
+      <details class="section-card s-advanced span-2 animate delay-2" name="git" aria-label="Advanced">
+        <summary><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>Advanced</summary>
+        <div class="section-body">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px 16px;">
+            <ul class="cmd-list">
+              <li><code>git rebase main</code> <span class="desc">Rebase onto main</span></li>
+              <li><code>git rebase -i HEAD~3</code> <span class="desc">Interactive rebase (last 3)</span></li>
+              <li><code>git cherry-pick &lt;hash&gt;</code> <span class="desc">Apply specific commit</span></li>
+              <li><code>git bisect start</code> <span class="desc">Binary search for bugs</span></li>
+              <li><code>git reflog</code> <span class="desc">History of HEAD changes</span></li>
+            </ul>
+            <ul class="cmd-list">
+              <li><code>git tag v1.0</code> <span class="desc">Create lightweight tag</span></li>
+              <li><code>git tag -a v1.0 -m "msg"</code> <span class="desc">Annotated tag</span></li>
+              <li><code>git blame &lt;file&gt;</code> <span class="desc">Show who changed what</span></li>
+              <li><code>git log --graph --all</code> <span class="desc">Visual branch graph</span></li>
+              <li><code>git worktree add ../fix b</code> <span class="desc">Multiple working trees</span></li>
+            </ul>
+          </div>
+        </div>
+      </details>
+
+    </div>
+
+    <footer class="footer">careerhackeralex.com · Git by Linus Torvalds · 2025</footer>
+  </div>
+
+  </main>
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    function filterCommands() {
+      var query = document.getElementById('searchInput').value.toLowerCase().trim();
+      var allItems = document.querySelectorAll('.cmd-list li');
+      var visible = 0;
+      allItems.forEach(function(li) {
+        var match = !query || li.textContent.toLowerCase().indexOf(query) !== -1;
+        li.classList.toggle('hidden', !match);
+        if (match) visible++;
+      });
+      document.getElementById('searchCount').textContent = query ? visible + ' result' + (visible !== 1 ? 's' : '') : '';
+      if (query) {
+        document.querySelectorAll('details.section-card').forEach(function(d) {
+          d.open = !!d.querySelector('.cmd-list li:not(.hidden)');
+        });
+      }
+    }
+
+    // Copy code on click with toast notification
+    document.addEventListener('click', function(e) {
+      if (e.target.tagName === 'CODE') {
+        navigator.clipboard.writeText(e.target.textContent).then(function() {
+          e.target.style.background = 'color-mix(in srgb, var(--positive), transparent 80%)';
+          setTimeout(function() { e.target.style.background = ''; }, 600);
+          
+          // Show toast notification
+          showCopyToast();
+        });
+      }
+    });
+    
+    function showCopyToast() {
+      var existingToast = document.querySelector('.copy-toast');
+      if (existingToast) existingToast.remove();
+      
+      var toast = document.createElement('div');
+      toast.className = 'copy-toast';
+      toast.textContent = 'Copied! ✓';
+      document.body.appendChild(toast);
+      
+      setTimeout(function() { toast.classList.add('show'); }, 10);
+      setTimeout(function() { 
+        toast.classList.remove('show');
+        setTimeout(function() { if (toast.parentNode) toast.remove(); }, 300);
+      }, 2000);
+    }
+
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      document.querySelectorAll('details.section-card').forEach(function(d) { d.open = true; });
+      try {
+        var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } });
+        var a = document.createElement('a'); a.href = url; a.download = 'git-cheat-sheet.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/claude-code-poster-1x1.html
+++ b/claude/skills/visualize/examples/claude-code-poster-1x1.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="ko" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Code — 노트북 하나로 모든 것을</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Noto Sans KR', 'Inter', sans-serif;
+      width: 1080px; height: 1080px;
+      overflow: hidden;
+      background: #050505;
+      color: #f0f0f0;
+      -webkit-font-smoothing: antialiased;
+      position: relative;
+    }
+
+    /* === Ambient glow === */
+    .glow-1 {
+      position: absolute; top: -200px; left: -200px;
+      width: 600px; height: 600px;
+      background: radial-gradient(circle, rgba(217,119,87,0.12) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .glow-2 {
+      position: absolute; bottom: -200px; right: -150px;
+      width: 500px; height: 500px;
+      background: radial-gradient(circle, rgba(139,92,246,0.1) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .glow-3 {
+      position: absolute; top: 40%; left: 50%;
+      width: 400px; height: 400px;
+      transform: translate(-50%, -50%);
+      background: radial-gradient(circle, rgba(59,130,246,0.06) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    /* === Header === */
+    .header {
+      padding: 56px 60px 0;
+      position: relative; z-index: 1;
+    }
+    .badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: rgba(217,119,87,0.1); border: 1px solid rgba(217,119,87,0.2);
+      border-radius: 100px; padding: 6px 14px;
+      font-size: 12px; font-weight: 600; color: #d97757;
+      letter-spacing: 0.02em;
+      margin-bottom: 20px;
+    }
+    .badge::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: #d97757; }
+    .title {
+      font-size: 42px; font-weight: 800; line-height: 1.15;
+      letter-spacing: -0.03em;
+      background: linear-gradient(135deg, #ffffff 0%, #d97757 100%);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 10px;
+    }
+    .subtitle {
+      font-size: 16px; color: #888; font-weight: 400;
+      letter-spacing: -0.01em;
+    }
+
+    /* === Grid === */
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      grid-template-rows: repeat(3, 1fr);
+      gap: 10px;
+      padding: 32px 60px 0;
+      position: relative; z-index: 1;
+      height: 620px;
+    }
+    .cell {
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 14px;
+      padding: 20px;
+      display: flex; flex-direction: column;
+      justify-content: space-between;
+      position: relative;
+      overflow: hidden;
+      transition: all 0.2s;
+    }
+    .cell::before {
+      content: '';
+      position: absolute; top: 0; left: 0; right: 0;
+      height: 2px;
+      background: var(--cell-accent, transparent);
+      opacity: 0.6;
+    }
+    .cell-icon {
+      font-size: 24px;
+      margin-bottom: 8px;
+      width: 40px; height: 40px;
+      display: flex; align-items: center; justify-content: center;
+      border-radius: 10px;
+      background: rgba(255,255,255,0.04);
+    }
+    .cell-title {
+      font-size: 15px; font-weight: 700;
+      letter-spacing: -0.02em;
+      line-height: 1.3;
+      margin-bottom: 4px;
+    }
+    .cell-desc {
+      font-size: 11.5px; color: #666; font-weight: 400;
+      line-height: 1.5;
+    }
+    .cell-tag {
+      display: inline-block;
+      font-size: 10px; font-weight: 600;
+      padding: 3px 8px; border-radius: 4px;
+      margin-top: auto;
+      background: rgba(255,255,255,0.04);
+      color: #555;
+      letter-spacing: 0.03em;
+    }
+
+    /* Feature cell — larger */
+    .cell.featured {
+      grid-column: span 2;
+      background: rgba(217,119,87,0.04);
+      border-color: rgba(217,119,87,0.1);
+      --cell-accent: #d97757;
+    }
+    .cell.featured .cell-title { font-size: 18px; }
+
+    /* Accent colors per row */
+    .cell.c-orange { --cell-accent: #d97757; }
+    .cell.c-blue { --cell-accent: #3b82f6; }
+    .cell.c-purple { --cell-accent: #8b5cf6; }
+    .cell.c-green { --cell-accent: #10b981; }
+    .cell.c-pink { --cell-accent: #ec4899; }
+    .cell.c-yellow { --cell-accent: #f59e0b; }
+
+    /* === Footer === */
+    .footer {
+      position: absolute; bottom: 0; left: 0; right: 0;
+      padding: 0 60px 40px;
+      display: flex; justify-content: space-between; align-items: flex-end;
+      z-index: 1;
+    }
+    .footer-left {
+      font-size: 12px; color: #444; font-weight: 500;
+      display: flex; align-items: center; gap: 6px;
+    }
+    .footer-logo {
+      width: 16px; height: 16px; border-radius: 4px;
+      background: linear-gradient(135deg, #d97757, #c2410c);
+    }
+    .footer-right {
+      font-size: 11px; color: #333; font-weight: 400;
+    }
+    .footer-cta {
+      font-size: 13px; color: #d97757; font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+  </style>
+</head>
+<body>
+  <div class="glow-1"></div>
+  <div class="glow-2"></div>
+  <div class="glow-3"></div>
+
+  <div class="header">
+    <div class="badge">Claude Code</div>
+    <div class="title">노트북 하나로<br>모든 것을 만든다</div>
+    <div class="subtitle">AI 코딩 에이전트가 바꾸는 1인 개발의 새로운 기준</div>
+  </div>
+
+  <div class="grid">
+    <!-- Row 1 -->
+    <div class="cell featured c-orange">
+      <div>
+        <div class="cell-icon">🚀</div>
+        <div class="cell-title">풀스택 앱 개발</div>
+        <div class="cell-desc">프론트엔드부터 백엔드, DB 설계까지<br>"앱 만들어줘" 한 마디면 끝</div>
+      </div>
+      <div class="cell-tag">REACT · NEXT.JS · POSTGRES</div>
+    </div>
+    <div class="cell c-blue">
+      <div>
+        <div class="cell-icon">🔧</div>
+        <div class="cell-title">리팩토링 & 디버깅</div>
+        <div class="cell-desc">10만 줄 코드베이스도 한번에 분석</div>
+      </div>
+      <div class="cell-tag">레거시 → 모던</div>
+    </div>
+    <div class="cell c-purple">
+      <div>
+        <div class="cell-icon">🧪</div>
+        <div class="cell-title">테스트 자동 생성</div>
+        <div class="cell-desc">유닛 · 통합 · E2E 테스트를 알아서</div>
+      </div>
+      <div class="cell-tag">COVERAGE ↑</div>
+    </div>
+
+    <!-- Row 2 -->
+    <div class="cell c-green">
+      <div>
+        <div class="cell-icon">📊</div>
+        <div class="cell-title">데이터 분석</div>
+        <div class="cell-desc">CSV → 인사이트 → 시각화까지 원스톱</div>
+      </div>
+      <div class="cell-tag">PANDAS · D3</div>
+    </div>
+    <div class="cell c-pink">
+      <div>
+        <div class="cell-icon">🎨</div>
+        <div class="cell-title">UI/UX 디자인</div>
+        <div class="cell-desc">피그마 없이 픽셀 퍼펙트 인터페이스</div>
+      </div>
+      <div class="cell-tag">TAILWIND CSS</div>
+    </div>
+    <div class="cell featured c-blue">
+      <div>
+        <div class="cell-icon">🤖</div>
+        <div class="cell-title">멀티 에이전트 시스템</div>
+        <div class="cell-desc">AI 에이전트가 AI 에이전트를 만들고<br>스스로 개선하는 자동화 파이프라인</div>
+      </div>
+      <div class="cell-tag">AGENT → AGENT → SHIP</div>
+    </div>
+
+    <!-- Row 3 -->
+    <div class="cell c-yellow">
+      <div>
+        <div class="cell-icon">📱</div>
+        <div class="cell-title">모바일 앱</div>
+        <div class="cell-desc">React Native / Flutter 앱도 혼자서</div>
+      </div>
+      <div class="cell-tag">iOS + ANDROID</div>
+    </div>
+    <div class="cell c-purple">
+      <div>
+        <div class="cell-icon">🔐</div>
+        <div class="cell-title">인프라 & 배포</div>
+        <div class="cell-desc">Docker, CI/CD, 클라우드 셋업</div>
+      </div>
+      <div class="cell-tag">AWS · VERCEL</div>
+    </div>
+    <div class="cell c-orange">
+      <div>
+        <div class="cell-icon">✍️</div>
+        <div class="cell-title">콘텐츠 제작</div>
+        <div class="cell-desc">블로그, 문서, 프레젠테이션 자동화</div>
+      </div>
+      <div class="cell-tag">마크다운 → HTML</div>
+    </div>
+    <div class="cell c-green">
+      <div>
+        <div class="cell-icon">🧠</div>
+        <div class="cell-title">AI 모델 파인튜닝</div>
+        <div class="cell-desc">데이터 준비부터 학습, 배포까지</div>
+      </div>
+      <div class="cell-tag">ML OPS</div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <div class="footer-left">
+      <div class="footer-logo"></div>
+      claude code · anthropic
+    </div>
+    <div class="footer-cta">개발자 1명 = 팀 전체</div>
+    <div class="footer-right">@careerhackeralex</div>
+  </div>
+</body>
+</html>

--- a/claude/skills/visualize/examples/comparison-infographic.html
+++ b/claude/skills/visualize/examples/comparison-infographic.html
@@ -1,0 +1,515 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Remote Work vs Office Work</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #6366f1; --accent-secondary: #4f46e5; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; --remote: #3b82f6; --office: #8b5cf6; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #6366f1; --accent-secondary: #4f46e5; --positive: #059669; --negative: #e11d48; --warning: #d97706; --remote: #2563eb; --office: #7c3aed; }
+
+    body { 
+      font-family: 'Inter', -apple-system, sans-serif; 
+      background: var(--bg);
+      color: var(--text); line-height: 1.6; -webkit-font-smoothing: antialiased; 
+      scrollbar-gutter: stable;
+      letter-spacing: -0.011em; font-feature-settings: 'cv11', 'ss01'; 
+      font-weight: 400;
+      transition: background 0.3s, color 0.3s;
+    }
+    body::after {
+      content: ''; position: fixed; inset: 0; z-index: -1; opacity: 0.03;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+    h1, h2, h3 { color: var(--text); letter-spacing: -0.03em; line-height: 1.05; font-weight: 700; text-wrap: balance; }
+    h2 { font-weight: 600; letter-spacing: -0.02em; }
+    h3 { font-weight: 600; letter-spacing: -0.02em; }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+
+    .skip-link { position: absolute; top: -40px; left: 16px; padding: 8px 16px; background: var(--accent); color: #fff; text-decoration: none; border-radius: 8px; z-index: 10000; }
+    .skip-link:focus { top: 16px; }
+
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
+    .animate { animation: fadeInUp 0.5s ease-out both; }
+
+    .comparison-block, .chart-section, .verdict {
+      animation: fadeInUp 0.5s ease both;
+    }
+    .comparison-block:nth-of-type(1) { animation-delay: 0s; }
+    .comparison-block:nth-of-type(2) { animation-delay: 0.08s; }
+    .chart-section:nth-of-type(1) { animation-delay: 0.16s; }
+    .chart-section:nth-of-type(2) { animation-delay: 0.24s; }
+    .chart-section:nth-of-type(3) { animation-delay: 0.32s; }
+    .reveal { opacity: 0; transform: translateY(20px); transition: opacity 0.5s, transform 0.5s; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+    @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; transition: none !important; } .reveal { opacity: 1; transform: none; } }
+
+    @media print { body { background: #fff !important; color: #000 !important; } .viz-menu { display: none !important; } .reveal { opacity: 1 !important; transform: none !important; } * { print-color-adjust: exact; -webkit-print-color-adjust: exact; } }
+
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-dark .theme-toggle .sun-icon { display: none; }
+    .theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle { width: 40px; height: 40px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { position: absolute; top: 48px; right: 0; min-width: 160px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05); opacity: 0; visibility: hidden; transform: translateY(-4px); transition: all 0.15s; }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button { width: 100%; padding: 8px 12px; border: none; border-radius: 6px; background: transparent; color: var(--text-secondary); font-size: 0.875rem; font-family: inherit; cursor: pointer; text-align: left; display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s; }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+
+    .container { max-width: 1000px; margin: 0 auto; padding: 0 24px; }
+
+    /* Hero — infographic style, not dashboard */
+    .hero { padding: 48px 0 32px; text-align: center; }
+    .hero h1 { 
+      font-size: clamp(3rem, 8vw, 4.5rem); 
+      margin-bottom: 16px; 
+      letter-spacing: -0.03em;
+      text-wrap: balance;
+        line-height: 1.05;
+      font-weight: 700;
+    }
+    .hero p { font-size: 1.125rem; color: var(--text-secondary); max-width: 520px; margin: 0 auto; line-height: 1.6; }
+
+    /* Big stat callouts — infographic hero numbers */
+    .hero-stats { display: flex; justify-content: center; gap: 48px; margin: 64px 0; flex-wrap: wrap; }
+    .hero-stat { text-align: center; }
+    .hero-stat-number { 
+      font-size: 3.5rem; 
+      font-weight: 700; 
+      letter-spacing: -0.04em; 
+      color: var(--accent); 
+      display: block;
+      text-shadow: 0 0 40px rgba(99,102,241,0.4);
+      line-height: 1;
+      margin-bottom: 8px;
+    }
+    .hero-stat-label { 
+      font-size: 0.6875rem; 
+      color: var(--text-secondary); 
+      text-transform: uppercase; 
+      letter-spacing: 0.1em; 
+      font-weight: 500; 
+    }
+
+    /* Section divider */
+    .divider { height: 1px; background: var(--border); margin: 64px 0; }
+
+    /* Comparison sections — sequential flow, not grid */
+    .section-label { 
+      font-size: 0.6875rem; 
+      font-weight: 500; 
+      text-transform: uppercase; 
+      letter-spacing: 0.1em; 
+      color: var(--text-secondary); 
+      margin-bottom: 16px; 
+    }
+
+    .comparison-block { 
+      margin-bottom: 48px; 
+      padding: 24px;
+      background: var(--surface);
+      border: 4px solid rgba(255,255,255,0.08);
+      border-radius: 8px;
+      transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+    .comparison-block.remote-section {
+      background: color-mix(in srgb, var(--surface) 85%, var(--remote) 15%);
+    }
+    .comparison-block.office-section {
+      background: color-mix(in srgb, var(--surface) 85%, var(--office) 15%);
+    }
+    .comparison-block:hover {
+      box-shadow: 0 0 0 1px rgba(255,255,255,0.12), 0 8px 16px rgba(0,0,0,0.15);
+      border-color: rgba(255,255,255,0.12);
+      transform: translateY(-2px);
+    }
+    .theme-light .comparison-block { border: 4px solid rgba(0,0,0,0.08); }
+    .theme-light .comparison-block:hover { 
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.08); 
+      border-color: rgba(0,0,0,0.12);
+      transform: translateY(-2px);
+    }
+    .comparison-block:hover, .card:hover, [data-reveal]:hover { border-color: rgba(255,255,255,0.12); }
+    .comparison-block h2 { font-size: 1.75rem; margin-bottom: 12px; display: flex; align-items: center; gap: 12px; letter-spacing: -0.02em; }
+    .comparison-block h2 svg { width: 28px; height: 28px; color: var(--accent); flex-shrink: 0; }
+    .comparison-block > p { color: var(--text-secondary); margin-bottom: 28px; font-size: 1.0625rem; line-height: 1.6; }
+
+    .pros-cons-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .pros-col h3, .cons-col h3 { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px; }
+    .pros-col h3 { color: var(--accent); }
+    .cons-col h3 { color: var(--accent-secondary); }
+    .pros-col ul, .cons-col ul { list-style: none; padding: 0; }
+    .pros-col li, .cons-col li { font-size: 0.875rem; color: var(--text-secondary); padding: 6px 0; display: flex; gap: 8px; align-items: flex-start; }
+    .pros-col li::before { content: '+'; color: var(--accent); font-weight: 600; flex-shrink: 0; }
+    .cons-col li::before { content: '−'; color: var(--accent-secondary); font-weight: 600; flex-shrink: 0; }
+
+    /* Charts */
+    .chart-section { 
+      margin-bottom: 40px; 
+      padding: 24px;
+      background: var(--surface);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 8px;
+      transition: box-shadow 0.2s ease;
+    }
+    .chart-section:hover {
+      box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 8px 16px rgba(0,0,0,0.08);
+    }
+    .theme-light .chart-section { border: 1px solid rgba(0,0,0,0.08); }
+    .theme-light .chart-section:hover { box-shadow: 0 0 0 1px rgba(0,0,0,0.08), 0 8px 16px rgba(0,0,0,0.08); }
+    .chart-section h3 { font-size: 1.25rem; font-weight: 600; margin-bottom: 6px; letter-spacing: -0.02em; }
+    .chart-section .chart-sub { font-size: 0.875rem; color: var(--text-secondary); margin-bottom: 24px; line-height: 1.5; }
+    .chart-wrapper { position: relative; height: 420px; width: 100%; }
+    .chart-wrapper canvas { display: block; }
+
+    /* Verdict / conclusion — infographic style */
+    .verdict { 
+      text-align: center; 
+      padding: 48px 32px; 
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      border-radius: 8px;
+      margin-top: 32px;
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .theme-light .verdict { border: 1px solid rgba(0,0,0,0.08); }
+    .verdict h2 { font-size: 2.25rem; margin-bottom: 16px; letter-spacing: -0.03em; line-height: 1.05; }
+      text-wrap: balance;
+      .verdict p { color: var(--text-secondary); max-width: 560px; margin: 0 auto; font-size: 1.125rem; line-height: 1.6; }
+    .verdict-stat { 
+      display: inline-block; 
+      font-size: 5rem; 
+      font-weight: 700; 
+      letter-spacing: -0.05em; 
+      color: var(--accent); 
+      margin-bottom: 12px;
+      text-shadow: 0 0 40px rgba(59,130,246,0.3);
+      line-height: 1;
+    }
+
+    @media (max-width: 640px) {
+      .container { padding: 0 16px; }
+      .hero { padding: 60px 0 40px; }
+      .hero-stats { gap: 24px; }
+      .hero-stat-number { font-size: 2.5rem; }
+      .comparison-block { padding: 20px; margin-bottom: 36px; }
+      .comparison-block h2 { font-size: 1.5rem; }
+      .pros-cons-row { grid-template-columns: 1fr; gap: 20px; }
+      .chart-section { padding: 20px; }
+      .chart-wrapper { height: 300px; }
+      .verdict { padding: 60px 24px; }
+      .verdict-stat { font-size: 4rem; }
+      .verdict h2 { font-size: 1.875rem; }
+    }
+  
+    .stat-card, .metric-card, .kpi-card { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover, .metric-card:hover, .kpi-card:hover { transform: translateY(-2px); box-shadow: 0 8px 25px rgba(0,0,0,0.15); } /* hover-lift */
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/></svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><span id="themeIcon">🌙</span><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><span>📥</span> Download PNG</button>
+      <button onclick="window.print()"><span>🖨️</span> Print / PDF</button>
+    </div>
+  </div>
+
+  <main id="main-content">
+    <div class="container">
+
+      <header class="hero animate">
+        <h1>Remote vs Office Work</h1>
+        <p>A data-driven look at the modern work environment debate</p>
+      </header>
+
+      <section class="hero-stats animate" role="region" aria-label="Key statistics">
+        <div class="hero-stat">
+          <span class="hero-stat-number" data-count="42" data-suffix="%">42%</span>
+          <span class="hero-stat-label">Work Remote</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-number" data-count="16" data-suffix="%">+16%</span>
+          <span class="hero-stat-label">Productivity Gain</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-number" data-count="54">54</span>
+          <span class="hero-stat-label">Minutes Saved/Day</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-number" data-count="73" data-suffix="%">73%</span>
+          <span class="hero-stat-label">Prefer Hybrid</span>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- Remote Work section -->
+      <section class="comparison-block remote-section" data-reveal role="region" aria-label="Remote work advantages">
+        <div class="section-label">Part 1</div>
+        <h2>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+          Remote Work
+        </h2>
+        <p>The flexibility revolution — working from anywhere with digital-first collaboration.</p>
+        <div class="pros-cons-row">
+          <div class="pros-col">
+            <h3>Advantages</h3>
+            <ul>
+              <li>No commute saves 54 minutes daily</li>
+              <li>Better work-life balance</li>
+              <li>16% productivity increase</li>
+              <li>Lower overhead costs</li>
+              <li>Access to global talent</li>
+            </ul>
+          </div>
+          <div class="cons-col">
+            <h3>Challenges</h3>
+            <ul>
+              <li>Increased isolation</li>
+              <li>Communication barriers</li>
+              <li>Home distractions</li>
+              <li>Tech setup burden</li>
+              <li>Fewer promotion opportunities</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Office Work section -->
+      <section class="comparison-block office-section" data-reveal role="region" aria-label="Office work advantages">
+        <div class="section-label">Part 2</div>
+        <h2>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 21h18"/><path d="M5 21V7l8-4v18"/><path d="M19 21V11l-6-4"/></svg>
+          Office Work
+        </h2>
+        <p>The traditional model — structured environments built for in-person collaboration.</p>
+        <div class="pros-cons-row">
+          <div class="pros-col">
+            <h3>Advantages</h3>
+            <ul>
+              <li>Face-to-face collaboration</li>
+              <li>Clear work-life boundaries</li>
+              <li>Better mentorship access</li>
+              <li>Immediate IT support</li>
+              <li>Stronger team culture</li>
+            </ul>
+          </div>
+          <div class="cons-col">
+            <h3>Challenges</h3>
+            <ul>
+              <li>Commute stress and time</li>
+              <li>Office interruptions</li>
+              <li>Higher costs ($20K/yr per seat)</li>
+              <li>Rigid schedules</li>
+              <li>Limited to local talent</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- Data section -->
+      <section class="chart-section" data-reveal>
+        <div class="section-label">The Data</div>
+        <h3>Productivity Comparison</h3>
+        <p class="chart-sub">Indexed scores (office baseline = 100)</p>
+        <div role="img" aria-label="Bar chart comparing remote vs office productivity metrics">
+          <div class="sr-only">Task Completion: Remote 116, Office 100. Quality Score: Remote 118, Office 100. Hours Worked: Remote 95, Office 100. Overall Rating: Remote 116, Office 100.</div>
+          <div class="chart-wrapper"><canvas id="productivityChart"></canvas></div>
+        </div>
+      </section>
+
+      <section class="chart-section" data-reveal>
+        <h3>Employee Satisfaction</h3>
+        <p class="chart-sub">Self-reported satisfaction across six dimensions</p>
+        <div role="img" aria-label="Radar chart of employee satisfaction across six dimensions">
+          <div class="sr-only">Work-Life Balance: Remote 90, Office 65. Stress Level: Remote 75, Office 60. Collaboration: Remote 65, Office 85. Focus Time: Remote 85, Office 70. Career Growth: Remote 70, Office 80. Satisfaction: Remote 80, Office 75.</div>
+          <div class="chart-wrapper"><canvas id="satisfactionChart"></canvas></div>
+        </div>
+      </section>
+
+      <section class="chart-section" data-reveal>
+        <h3>Work Preference Distribution</h3>
+        <p class="chart-sub">What workers actually want</p>
+        <div role="img" aria-label="Doughnut chart showing 73% prefer hybrid, 19% remote, 8% office">
+          <div class="sr-only">Hybrid: 73%. Remote Only: 19%. Office Only: 8%.</div>
+          <div class="chart-wrapper" style="height: 280px;"><canvas id="preferenceChart"></canvas></div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- Verdict -->
+      <section class="verdict" data-reveal role="region" aria-label="Verdict and conclusion">
+        <span class="verdict-stat">73%</span>
+        <h2>The Future is Hybrid</h2>
+        <p>The data is clear: most workers prefer flexibility. The most successful companies will offer hybrid models that combine the best of both worlds.</p>
+      </section>
+
+    </div>
+  </main>
+
+  <script>
+    var productivityChart, satisfactionChart, preferenceChart;
+
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var ro = new IntersectionObserver(function(entries) { entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); ro.unobserve(e.target); } }); }, { threshold: 0.1 });
+    document.querySelectorAll('.reveal').forEach(function(el) { ro.observe(el); });
+
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return; el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), dur = 1000;
+        (function tick(now) { var p = Math.min((now - start) / dur, 1), e = 1 - Math.pow(1 - p, 3); el.textContent = prefix + Math.round(target * e).toLocaleString() + suffix; if (p < 1) requestAnimationFrame(tick); })(start);
+      });
+    }
+    var ce = document.querySelector('[data-count]');
+    if (ce) { var co = new IntersectionObserver(function(es) { es.forEach(function(e) { if (e.isIntersecting) { animateCounters(); co.disconnect(); } }); }, { threshold: 0.3 }); co.observe(ce); }
+
+    function getColors() {
+      var s = getComputedStyle(document.documentElement);
+      return { text: s.getPropertyValue('--text').trim(), sub: s.getPropertyValue('--text-secondary').trim(), border: s.getPropertyValue('--border').trim(), surface: s.getPropertyValue('--surface').trim(), remote: s.getPropertyValue('--remote').trim(), office: s.getPropertyValue('--office').trim(), accent: s.getPropertyValue('--accent').trim() };
+    }
+    function getCanvas(id) { return document.getElementById(id); }
+
+    function buildCharts() {
+      var c = getColors();
+      Chart.defaults.color = c.sub;
+      Chart.defaults.borderColor = 'transparent';
+      Chart.defaults.animation = false;
+
+      try { if (productivityChart) productivityChart.destroy(); } catch(e) {}
+      try { if (satisfactionChart) satisfactionChart.destroy(); } catch(e) {}
+      try { if (preferenceChart) preferenceChart.destroy(); } catch(e) {}
+
+      var tooltipStyle = { backgroundColor: c.surface, titleColor: c.text, bodyColor: c.text, borderColor: c.border, borderWidth: 1, padding: 12, cornerRadius: 8, titleFont: { size: 14 }, bodyFont: { size: 13 } };
+
+      // Use explicit colors instead of CSS var concatenation for better reliability
+      var remoteColor = '#3b82f6';
+      var officeColor = '#8b5cf6';
+      var accentColor = '#3b82f6';
+
+      productivityChart = new Chart(getCanvas('productivityChart'), {
+        type: 'bar',
+        data: {
+          labels: ['Task Completion', 'Quality Score', 'Hours Worked', 'Overall Rating'],
+          datasets: [
+            { label: 'Remote', data: [116, 118, 95, 116], backgroundColor: 'rgba(59, 130, 246, 0.75)', borderRadius: 4, barPercentage: 0.8, categoryPercentage: 0.7 },
+            { label: 'Office', data: [100, 100, 100, 100], backgroundColor: 'rgba(139, 92, 246, 0.75)', borderRadius: 4, barPercentage: 0.8, categoryPercentage: 0.7 }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            tooltip: tooltipStyle,
+            legend: { position: 'top', labels: { color: c.text, font: { size: 14 }, usePointStyle: true, pointStyle: 'circle', padding: 20 } }
+          },
+          scales: {
+            y: { beginAtZero: true, max: 130, grid: { color: 'rgba(255,255,255,0.06)' }, ticks: { color: c.sub, font: { size: 13 } } },
+            x: { grid: { display: false }, ticks: { color: c.sub, font: { size: 13 } } }
+          }
+        }
+      });
+
+      satisfactionChart = new Chart(getCanvas('satisfactionChart'), {
+        type: 'bar',
+        data: { labels: ['Work-Life\nBalance', 'Stress\nLevel', 'Collaboration', 'Focus\nTime', 'Career\nGrowth', 'Satisfaction'],
+          datasets: [
+            { label: 'Remote', data: [90, 75, 65, 85, 70, 80], backgroundColor: 'rgba(59, 130, 246, 0.75)', borderRadius: 4, barPercentage: 0.7, categoryPercentage: 0.7 },
+            { label: 'Office', data: [65, 60, 85, 70, 80, 75], backgroundColor: 'rgba(139, 92, 246, 0.75)', borderRadius: 4, barPercentage: 0.7, categoryPercentage: 0.7 }
+          ] },
+        options: { responsive: true, maintainAspectRatio: false, indexAxis: 'y', layout: { padding: 10 },
+          plugins: { tooltip: { enabled: true, ...tooltipStyle }, legend: { position: 'top', labels: { color: c.text, font: { size: 14 }, usePointStyle: true, padding: 20 } } },
+          scales: { x: { beginAtZero: true, max: 100, grid: { color: c.border }, ticks: { color: c.sub, font: { size: 13 } }, border: { display: false } }, y: { grid: { display: false }, ticks: { color: c.sub, font: { size: 13 } }, border: { display: false } } } }
+      });
+
+      preferenceChart = new Chart(getCanvas('preferenceChart'), {
+        type: 'doughnut',
+        data: { labels: ['Hybrid', 'Remote Only', 'Office Only'], datasets: [{ data: [73, 19, 8], backgroundColor: [accentColor, remoteColor, officeColor], borderWidth: 2, borderColor: c.surface }] },
+        options: { responsive: true, maintainAspectRatio: false, layout: { padding: 30 },
+          plugins: { tooltip: { enabled: true, ...tooltipStyle, callbacks: { label: function(ctx) { return ctx.label + ': ' + ctx.parsed + '%'; } } },
+            legend: { position: 'bottom', labels: { color: c.text, font: { size: 14 }, usePointStyle: true, padding: 20 } } }, 
+          cutout: '60%', 
+          elements: { arc: { borderWidth: 0 } }
+        }
+      });
+    }
+
+    function onThemeChange() { 
+      requestAnimationFrame(function() {
+        setTimeout(buildCharts, 100); 
+      });
+    }
+    
+    // Build charts after everything is loaded and visible
+    window.addEventListener('load', function() {
+      document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); });
+      setTimeout(function() {
+        buildCharts();
+        // Force resize to ensure proper rendering
+        window.dispatchEvent(new Event('resize'));
+      }, 200);
+    });
+    // Fallback if load already fired
+    if (document.readyState === 'complete') {
+      setTimeout(function() {
+        document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); });
+        buildCharts();
+        window.dispatchEvent(new Event('resize'));
+      }, 200);
+    }
+
+    document.addEventListener('visibilitychange', function() {
+      if (!document.hidden) { setTimeout(buildCharts, 200); }
+    });
+
+    async function downloadImage() {
+      var m = document.querySelector('.viz-menu'); m.style.display = 'none';
+      try { var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } }); var a = document.createElement('a'); a.href = url; a.download = 'remote-vs-office.png'; a.click(); } catch(e) { console.error(e); }
+      m.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/event-poster.html
+++ b/claude/skills/visualize/examples/event-poster.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Summit 2026 — San Francisco</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #ec4899; --accent-secondary: #db2777; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #ec4899; --accent-secondary: #db2777; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; letter-spacing: -0.011em; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+      display: flex; align-items: flex-start; justify-content: center;
+      min-height: 100vh; padding: 32px 16px;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+    .animate.delay-5 { animation-delay: 0.5s; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    /* ===== POSTER ===== */
+    .poster {
+      width: 100%; max-width: 720px;
+      background: var(--surface); border: 4px solid var(--border);
+      border-radius: 32px; overflow: hidden;
+      box-shadow: 0 32px 96px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05);
+    }
+
+    .poster-hero {
+      padding: 56px 48px 40px; text-align: center; position: relative;
+      background: linear-gradient(135deg, color-mix(in srgb, var(--accent), var(--bg) 60%), color-mix(in srgb, var(--accent-secondary), var(--bg) 60%));
+    }
+    .poster-hero::after {
+      content: ''; position: absolute; inset: 0; opacity: 0.04;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+
+    .poster-eyebrow { font-size: 0.85rem; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin-bottom: 12px; position: relative; z-index: 1; background: color-mix(in srgb, var(--accent), transparent 85%); padding: 8px 16px; border-radius: 8px; display: inline-block; border: 4px solid var(--accent); }
+    .poster-title { font-size: clamp(3.5rem, 9vw, 6rem); font-weight: 900; line-height: 0.9; margin-bottom: 8px; color: var(--text); position: relative; z-index: 1; letter-spacing: -0.04em; text-shadow: 0 4px 8px rgba(0,0,0,0.3); text-wrap: balance; }
+    .poster-location-line { font-size: 1.1rem; color: var(--text-secondary); font-weight: 500; position: relative; z-index: 1; }
+
+    /* Countdown */
+    .countdown-section { padding: 0 48px; position: relative; z-index: 1; margin-top: -20px; }
+    .countdown {
+      display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+      background: var(--surface); border: 4px solid var(--border);
+      border-radius: 16px; padding: 20px; text-align: center;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.12);
+    }
+    .countdown-unit { display: flex; flex-direction: column; gap: 4px; }
+    .countdown-value { font-size: 2rem; font-weight: 700; color: var(--accent); line-height: 1; letter-spacing: -0.02em; }
+    .countdown-label { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-secondary); }
+
+    .poster-body { padding: 32px 48px 48px; }
+
+    .date-badge {
+      display: inline-flex; align-items: center; gap: 10px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+      color: #fff; padding: 12px 24px; border-radius: 12px;
+      font-weight: 700; font-size: 1.1rem; margin: 16px 0 32px;
+    }
+
+    .poster-section { margin-bottom: 28px; }
+    .poster-section-title { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: var(--accent); margin-bottom: 16px; }
+
+    .speaker-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+    .speaker-card {
+      background: var(--surface-hover); border-radius: 12px; padding: 16px;
+      border: 4px solid var(--border); display: flex; gap: 12px; align-items: center;
+      transition: box-shadow 0.2s, transform 0.2s;
+    }
+    .speaker-card:hover { 
+      box-shadow: 0 0 0 1px var(--border), 0 4px 12px rgba(0,0,0,0.08); 
+      transform: translateY(-2px);
+    }
+    .speaker-avatar {
+      width: 44px; height: 44px; border-radius: 50%; flex-shrink: 0;
+      background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 700; color: #fff; font-size: 0.8rem;
+    }
+    .speaker-name { font-weight: 700; font-size: 0.9rem; }
+    .speaker-topic { font-size: 0.8rem; color: var(--text-secondary); margin-top: 2px; }
+
+    .schedule-tracks { display: flex; flex-direction: column; gap: 10px; }
+    .track {
+      display: flex; align-items: center; gap: 12px;
+      background: var(--surface-hover); border-radius: 10px; padding: 12px 16px;
+      border: 4px solid var(--border); transition: box-shadow 0.2s, transform 0.2s;
+    }
+    .track:hover { 
+      box-shadow: 0 0 0 1px var(--border), 0 4px 12px rgba(0,0,0,0.08); 
+      transform: translateY(-1px);
+    }
+    .track-color { width: 4px; height: 32px; border-radius: 4px; flex-shrink: 0; }
+    .track-name { font-weight: 700; font-size: 0.9rem; }
+    .track-desc { font-size: 0.8rem; color: var(--text-secondary); }
+
+    .location-row { display: flex; align-items: center; gap: 16px; }
+    .map-placeholder {
+      width: 80px; height: 80px; border-radius: 12px; flex-shrink: 0;
+      background: var(--surface-hover); border: 4px solid var(--border);
+      display: flex; align-items: center; justify-content: center; color: var(--text-secondary);
+    }
+    .location-name { font-weight: 700; font-size: 1rem; }
+    .location-address { font-size: 0.85rem; color: var(--text-secondary); }
+
+    .cta-section {
+      text-align: center; padding: 24px;
+      background: color-mix(in srgb, var(--accent), transparent 92%);
+      border-radius: 16px; border: 4px solid var(--border);
+    }
+    .cta-button {
+      display: inline-block; padding: 16px 40px; border-radius: 16px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+      color: #fff; font-weight: 700; font-size: 1.1rem;
+      text-decoration: none; border: none; cursor: pointer;
+      transition: all 0.2s; box-shadow: 0 4px 16px rgba(59,130,246,0.2);
+    }
+    .cta-button:hover { 
+      box-shadow: 0 12px 32px rgba(59,130,246,0.4); 
+      transform: translateY(-2px);
+    }
+
+    .qr-placeholder {
+      width: 96px; height: 96px; margin: 16px auto 0;
+      background: #fff; border-radius: 8px;
+      display: flex; align-items: center; justify-content: center;
+    }
+
+    @media (max-width: 560px) {
+      .poster-hero { padding: 40px 24px 32px; }
+      .poster-body { padding: 24px; }
+      .countdown-section { padding: 0 24px; }
+      .speaker-grid { grid-template-columns: 1fr; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; padding: 0 !important; }
+      .viz-menu { display: none !important; }
+      .poster { box-shadow: none !important; border: 1px solid #ddd !important; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-dark .theme-toggle .sun-icon { display: none; }
+    .theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle { width: 44px; height: 44px; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { position: absolute; top: 52px; right: 0; min-width: 200px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 8px; opacity: 0; visibility: hidden; transform: translateY(-8px); transition: all 0.2s; backdrop-filter: blur(16px); }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+    .viz-menu-dropdown button { width: 100%; padding: 10px 14px; border: none; border-radius: 8px; background: transparent; color: var(--text); font-size: 14px; font-family: inherit; cursor: pointer; text-align: left; display: flex; align-items: center; gap: 10px; transition: background 0.15s; }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); }
+
+    .skip-link { position: absolute; top: -100px; left: 16px; padding: 8px 16px; background: var(--accent); color: #fff; border-radius: 8px; text-decoration: none; z-index: 99999; font-weight: 600; }
+    .skip-link:focus { top: 16px; }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/></svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span>Download PNG</span></button>
+      <button onclick="window.print()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6,9 6,2 18,2 18,9"/><path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <article class="poster animate" role="region" aria-label="AI Summit 2026 event poster">
+    <header class="poster-hero">
+      <!-- Bold hero visual element -->
+      <div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:1;">
+        <svg viewBox="0 0 400 320" fill="none" style="width:350px;height:280px;opacity:0.15;">
+          <!-- Central conference symbol -->
+          <circle cx="200" cy="160" r="100" fill="var(--accent)" opacity="0.3"/>
+          <circle cx="200" cy="160" r="60" fill="var(--surface)" opacity="0.8"/>
+          <!-- Conference podium -->
+          <rect x="170" y="140" width="60" height="40" rx="8" fill="var(--accent)" opacity="0.6"/>
+          <rect x="175" y="145" width="50" height="6" rx="3" fill="var(--surface)" opacity="0.9"/>
+          <!-- Year 2026 in large text -->
+          <text x="200" y="85" text-anchor="middle" font-family="Inter" font-size="72" font-weight="900" fill="var(--accent)" opacity="0.4">2026</text>
+        </svg>
+      </div>
+      <div class="poster-eyebrow animate delay-1">The Premier AI Conference</div>
+      <h1 class="poster-title animate delay-1">AI Summit 2026</h1>
+      <div class="poster-location-line animate delay-2">San Francisco, California</div>
+    </header>
+
+    <div class="countdown-section animate delay-2">
+      <div class="countdown" role="timer" aria-label="Countdown to event">
+        <div class="countdown-unit"><span class="countdown-value" id="cd-days">---</span><span class="countdown-label">Days</span></div>
+        <div class="countdown-unit"><span class="countdown-value" id="cd-hours">--</span><span class="countdown-label">Hours</span></div>
+        <div class="countdown-unit"><span class="countdown-value" id="cd-min">--</span><span class="countdown-label">Minutes</span></div>
+        <div class="countdown-unit"><span class="countdown-value" id="cd-sec">--</span><span class="countdown-label">Seconds</span></div>
+      </div>
+    </div>
+
+    <div class="poster-body">
+      <div style="text-align:center;" class="animate delay-2">
+        <div class="date-badge">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+          September 15–17, 2026 · 9 AM – 6 PM
+        </div>
+      </div>
+
+      <section class="poster-section animate delay-3" role="region" aria-label="Featured speakers">
+        <h2 class="poster-section-title">Featured Speakers</h2>
+        <div class="speaker-grid">
+          <div class="speaker-card">
+            <div class="speaker-avatar" aria-hidden="true">SL</div>
+            <div><div class="speaker-name">Dr. Sarah Lin</div><div class="speaker-topic">The Future of Multimodal AI</div></div>
+          </div>
+          <div class="speaker-card">
+            <div class="speaker-avatar" aria-hidden="true">MK</div>
+            <div><div class="speaker-name">Marcus Kim</div><div class="speaker-topic">Scaling LLMs to 10T Parameters</div></div>
+          </div>
+          <div class="speaker-card">
+            <div class="speaker-avatar" aria-hidden="true">AP</div>
+            <div><div class="speaker-name">Aisha Patel</div><div class="speaker-topic">AI Safety &amp; Alignment</div></div>
+          </div>
+          <div class="speaker-card">
+            <div class="speaker-avatar" aria-hidden="true">JC</div>
+            <div><div class="speaker-name">James Chen</div><div class="speaker-topic">Autonomous Agents in Production</div></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="poster-section animate delay-4" role="region" aria-label="Conference tracks">
+        <h2 class="poster-section-title">Tracks</h2>
+        <div class="schedule-tracks">
+          <div class="track"><div class="track-color" style="background: var(--accent);"></div><div><div class="track-name">Research &amp; Foundations</div><div class="track-desc">Cutting-edge papers, model architectures, training techniques</div></div></div>
+          <div class="track"><div class="track-color" style="background: var(--accent-secondary);"></div><div><div class="track-name">Engineering &amp; Infrastructure</div><div class="track-desc">MLOps, deployment, scaling, monitoring in production</div></div></div>
+          <div class="track"><div class="track-color" style="background: var(--positive);"></div><div><div class="track-name">Ethics, Safety &amp; Policy</div><div class="track-desc">Responsible AI, governance frameworks, alignment research</div></div></div>
+        </div>
+      </section>
+
+      <section class="poster-section animate delay-4" role="region" aria-label="Venue information">
+        <h2 class="poster-section-title">Venue</h2>
+        <div class="location-row">
+          <div class="map-placeholder" aria-hidden="true">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+          </div>
+          <div>
+            <div class="location-name">Moscone Center West</div>
+            <div class="location-address">747 Howard St, San Francisco, CA 94103</div>
+            <div class="location-address" style="margin-top: 4px;">Parking available · Transit accessible (BART Powell St)</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta-section animate delay-5" role="region" aria-label="Registration">
+        <div style="font-weight: 700; font-size: 1.25rem; margin-bottom: 4px;">Early Bird Tickets Available</div>
+        <div style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 16px;">$499 until June 30 · $799 after</div>
+        <button class="cta-button" aria-label="Register for AI Summit 2026">Register Now
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" style="vertical-align:middle;margin-left:4px;"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
+        </button>
+        <div class="qr-placeholder" aria-label="QR code for registration">
+          <svg width="80" height="80" viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg">
+            <rect x="0" y="0" width="7" height="7" fill="#000"/><rect x="1" y="1" width="5" height="5" fill="#fff"/><rect x="2" y="2" width="3" height="3" fill="#000"/>
+            <rect x="14" y="0" width="7" height="7" fill="#000"/><rect x="15" y="1" width="5" height="5" fill="#fff"/><rect x="16" y="2" width="3" height="3" fill="#000"/>
+            <rect x="0" y="14" width="7" height="7" fill="#000"/><rect x="1" y="15" width="5" height="5" fill="#fff"/><rect x="2" y="16" width="3" height="3" fill="#000"/>
+            <rect x="8" y="0" width="1" height="1" fill="#000"/><rect x="10" y="0" width="1" height="1" fill="#000"/><rect x="12" y="0" width="1" height="1" fill="#000"/>
+            <rect x="9" y="9" width="1" height="1" fill="#000"/><rect x="11" y="9" width="1" height="1" fill="#000"/><rect x="13" y="9" width="1" height="1" fill="#000"/>
+            <rect x="9" y="11" width="1" height="1" fill="#000"/><rect x="12" y="11" width="1" height="1" fill="#000"/><rect x="15" y="11" width="1" height="1" fill="#000"/>
+            <rect x="9" y="13" width="1" height="1" fill="#000"/><rect x="14" y="13" width="1" height="1" fill="#000"/><rect x="18" y="13" width="1" height="1" fill="#000"/>
+            <rect x="10" y="15" width="1" height="1" fill="#000"/><rect x="13" y="15" width="1" height="1" fill="#000"/><rect x="18" y="15" width="1" height="1" fill="#000"/>
+            <rect x="9" y="17" width="1" height="1" fill="#000"/><rect x="12" y="17" width="1" height="1" fill="#000"/><rect x="17" y="17" width="1" height="1" fill="#000"/>
+            <rect x="10" y="19" width="1" height="1" fill="#000"/><rect x="15" y="19" width="1" height="1" fill="#000"/><rect x="18" y="19" width="1" height="1" fill="#000"/>
+          </svg>
+        </div>
+      </section>
+    </div>
+  </article>
+
+  </main>
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    // Countdown timer
+    var eventDate = new Date('2026-09-15T09:00:00-07:00').getTime();
+    function updateCountdown() {
+      var now = Date.now();
+      var diff = eventDate - now;
+      if (diff <= 0) {
+        document.getElementById('cd-days').textContent = '0';
+        document.getElementById('cd-hours').textContent = '0';
+        document.getElementById('cd-min').textContent = '0';
+        document.getElementById('cd-sec').textContent = '0';
+        return;
+      }
+      var d = Math.floor(diff / 86400000);
+      var h = Math.floor((diff % 86400000) / 3600000);
+      var m = Math.floor((diff % 3600000) / 60000);
+      var s = Math.floor((diff % 60000) / 1000);
+      document.getElementById('cd-days').textContent = d;
+      document.getElementById('cd-hours').textContent = h;
+      document.getElementById('cd-min').textContent = m;
+      document.getElementById('cd-sec').textContent = s;
+    }
+    updateCountdown();
+    setInterval(updateCountdown, 1000);
+
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.querySelector('.poster'), { quality: 1, pixelRatio: 2 });
+        var a = document.createElement('a'); a.href = url; a.download = 'ai-summit-2026-poster.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/neuralchef-pitch.html
+++ b/claude/skills/visualize/examples/neuralchef-pitch.html
@@ -1,0 +1,568 @@
+<!DOCTYPE html>
+<html lang="ko" class="theme-light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NeuralChef — AI 푸드테크 피치덱</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.06);
+      --text: #EDEDED; --text-secondary: #888;
+      --accent: #f97316; --accent-secondary: #ea580c;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+      --slide-gradient-1: linear-gradient(135deg, #1a0800 0%, #431407 50%, #1c1917 100%);
+      --slide-gradient-2: linear-gradient(135deg, #0c0a09 0%, #292524 100%);
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #FFFFFF; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.06);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #ea580c; --accent-secondary: #c2410c;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+      --slide-gradient-1: linear-gradient(135deg, #fff7ed 0%, #fed7aa 50%, #fef3c7 100%);
+      --slide-gradient-2: linear-gradient(135deg, #FAFAF9 0%, #f5f5f4 100%);
+    }
+
+    body {
+      font-family: 'Noto Sans KR', 'Inter', -apple-system, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; -webkit-font-smoothing: antialiased;
+      overflow: hidden; height: 100vh; width: 100vw;
+    }
+    h1,h2,h3,h4 { letter-spacing: -0.03em; line-height: 1.1; text-wrap: balance; }
+
+    /* ===== SLIDES ===== */
+    .deck { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+    .slide {
+      position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+      display: flex; flex-direction: column; justify-content: center; align-items: center;
+      padding: clamp(2rem, 5vw, 6rem);
+      opacity: 0; transform: translateX(60px);
+      transition: opacity 0.5s cubic-bezier(.4,0,.2,1), transform 0.5s cubic-bezier(.4,0,.2,1);
+      pointer-events: none;
+    }
+    .slide.active { opacity: 1; transform: translateX(0); pointer-events: all; }
+    .slide.prev { opacity: 0; transform: translateX(-60px); }
+
+    .slide-title { background: var(--slide-gradient-1); }
+    .slide-content { background: var(--slide-gradient-2); }
+    .slide-section {
+      background: var(--accent);
+      --text: #fff; --text-secondary: rgba(255,255,255,0.8);
+    }
+
+    /* ===== PROGRESS ===== */
+    .progress { position: fixed; top: 0; left: 0; height: 3px; background: var(--accent); z-index: 100; transition: width 0.4s ease; }
+    .slide-counter {
+      position: fixed; bottom: 24px; right: 32px; font-size: 13px;
+      color: var(--text-secondary); font-weight: 500; z-index: 100;
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* ===== CARDS ===== */
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 28px;
+      transition: box-shadow 0.2s ease;
+    }
+    .card:hover { box-shadow: 0 8px 24px rgba(0,0,0,0.08); }
+
+    .stat-card { text-align: center; }
+    .stat-number { font-size: clamp(2.5rem, 6vw, 4rem); font-weight: 800; color: var(--accent); line-height: 1; }
+    .stat-label { font-size: 0.875rem; color: var(--text-secondary); margin-top: 8px; font-weight: 500; }
+    .stat-delta { font-size: 0.8rem; color: var(--positive); margin-top: 4px; font-weight: 600; }
+
+    /* ===== GRID ===== */
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; width: 100%; max-width: 900px; }
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; width: 100%; max-width: 1000px; }
+    .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; width: 100%; max-width: 1000px; }
+
+    /* ===== TYPOGRAPHY ===== */
+    .slide-h1 { font-size: clamp(2.5rem, 7vw, 4.5rem); font-weight: 800; color: var(--text); margin-bottom: 16px; }
+    .slide-h2 { font-size: clamp(1.8rem, 5vw, 3rem); font-weight: 700; color: var(--text); margin-bottom: 24px; }
+    .slide-subtitle { font-size: clamp(1rem, 2.5vw, 1.4rem); color: var(--text-secondary); font-weight: 400; max-width: 600px; text-align: center; }
+    .slide-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin-bottom: 12px; }
+    .bullet { color: var(--text-secondary); font-size: 1.05rem; line-height: 1.8; }
+    .bullet li { padding-left: 4px; }
+    .bullet li::marker { color: var(--accent); }
+
+    .icon-circle {
+      width: 48px; height: 48px; border-radius: 50%;
+      background: color-mix(in srgb, var(--accent) 12%, transparent);
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 16px;
+    }
+
+    /* ===== TEAM ===== */
+    .team-card { text-align: center; padding: 24px 16px; }
+    .team-avatar {
+      width: 64px; height: 64px; border-radius: 50%;
+      background: color-mix(in srgb, var(--accent) 15%, transparent);
+      display: flex; align-items: center; justify-content: center;
+      margin: 0 auto 12px; font-size: 1.5rem;
+    }
+    .team-name { font-weight: 700; font-size: 1rem; margin-bottom: 2px; }
+    .team-role { font-size: 0.8rem; color: var(--text-secondary); }
+    .team-exp { font-size: 0.75rem; color: var(--accent); margin-top: 6px; font-weight: 500; }
+
+    /* ===== CHART ===== */
+    .chart-wrap { width: 100%; max-width: 700px; min-height: 360px; position: relative; }
+
+    /* ===== ENTRANCE ANIMATIONS ===== */
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .delay-1 { animation-delay: 0.1s; }
+    .delay-2 { animation-delay: 0.2s; }
+    .delay-3 { animation-delay: 0.3s; }
+    .delay-4 { animation-delay: 0.4s; }
+    .delay-5 { animation-delay: 0.5s; }
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    /* ===== MENU ===== */
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle {
+      width: 44px; height: 44px; border-radius: 12px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown {
+      position: absolute; top: 52px; right: 0; min-width: 200px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 8px;
+      opacity: 0; visibility: hidden; transform: translateY(-8px);
+      transition: all 0.2s; backdrop-filter: blur(16px);
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+    .viz-menu-dropdown button {
+      width: 100%; padding: 10px 14px; border: none; border-radius: 8px;
+      background: transparent; color: var(--text); font-size: 14px;
+      font-family: inherit; cursor: pointer; text-align: left;
+      display: flex; align-items: center; gap: 10px; transition: background 0.15s;
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); }
+
+    /* ===== NAV DOTS ===== */
+    .nav-dots {
+      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+      display: flex; gap: 8px; z-index: 100;
+    }
+    .nav-dot {
+      width: 8px; height: 8px; border-radius: 50%;
+      background: var(--border); border: none; cursor: pointer;
+      transition: all 0.3s; padding: 0;
+    }
+    .nav-dot.active { background: var(--accent); width: 24px; border-radius: 4px; }
+
+    @media print {
+      body { overflow: visible; height: auto; }
+      .slide { position: relative; opacity: 1; transform: none; pointer-events: all; page-break-after: always; height: 100vh; }
+      .viz-menu, .progress, .slide-counter, .nav-dots { display: none; }
+    }
+
+    @container (width < 768px) {
+      .grid-3, .grid-4 { grid-template-columns: 1fr 1fr; }
+      .grid-2 { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+
+  <!-- MENU -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="메뉴">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><span id="themeIcon">☀️</span><span id="themeLabel">Light</span></button>
+      <button onclick="downloadImage()"><span>📥</span><span>PNG 다운로드</span></button>
+      <button onclick="window.print()"><span>🖨️</span><span>프린트 / PDF</span></button>
+    </div>
+  </div>
+
+  <div class="progress" id="progress"></div>
+  <div class="slide-counter" id="slideCounter"></div>
+
+  <div class="deck" id="deck">
+
+    <!-- SLIDE 1: Title -->
+    <section class="slide slide-title active" data-notes="오프닝 슬라이드 - AI 기반 개인화 푸드테크">
+      <div class="animate">
+        <div class="slide-label">시리즈 A 투자 제안서</div>
+      </div>
+      <h1 class="slide-h1 animate delay-1">NeuralChef</h1>
+      <p class="slide-subtitle animate delay-2">AI가 당신의 냉장고를 분석하고,<br>완벽한 레시피를 제안합니다</p>
+      <div class="animate delay-3" style="margin-top: 32px; display: flex; gap: 16px; align-items: center;">
+        <div style="font-size: 0.85rem; color: var(--text-secondary);">2026년 3월 · Confidential</div>
+      </div>
+    </section>
+
+    <!-- SLIDE 2: Problem -->
+    <section class="slide slide-content" data-notes="문제 정의 - 음식물 쓰레기와 시간 낭비">
+      <div class="slide-label animate">문제</div>
+      <h2 class="slide-h2 animate delay-1">매일 반복되는 고민</h2>
+      <div class="grid-3 animate delay-2" style="container-type: inline-size;">
+        <div class="card stat-card">
+          <div class="icon-circle" style="margin: 0 auto 12px;">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          </div>
+          <div class="stat-number" style="font-size: 2rem;">30%</div>
+          <div class="stat-label">가정 식재료 폐기율</div>
+        </div>
+        <div class="card stat-card">
+          <div class="icon-circle" style="margin: 0 auto 12px;">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+          </div>
+          <div class="stat-number" style="font-size: 2rem;">47분</div>
+          <div class="stat-label">일일 평균 식사 고민 시간</div>
+        </div>
+        <div class="card stat-card">
+          <div class="icon-circle" style="margin: 0 auto 12px;">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>
+          </div>
+          <div class="stat-number" style="font-size: 2rem;">₩54만</div>
+          <div class="stat-label">월 평균 외식비 (2인 가구)</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- SLIDE 3: Solution -->
+    <section class="slide slide-content" data-notes="솔루션 - 냉장고 인식 → AI 레시피 추천">
+      <div class="slide-label animate">솔루션</div>
+      <h2 class="slide-h2 animate delay-1">냉장고 → AI → 레시피</h2>
+      <div class="grid-2 animate delay-2" style="max-width: 850px; container-type: inline-size;">
+        <div>
+          <ul class="bullet">
+            <li>📸 냉장고 사진 한 장으로 식재료 자동 인식</li>
+            <li>🧠 개인 취향 + 건강 데이터 기반 레시피 추천</li>
+            <li>🛒 부족한 재료는 원클릭 장보기 연동</li>
+            <li>👨‍🍳 단계별 AI 쿡킹 가이드 (영상 + 음성)</li>
+          </ul>
+        </div>
+        <div class="card" style="display: flex; align-items: center; justify-content: center; min-height: 240px; background: color-mix(in srgb, var(--accent) 5%, var(--surface));">
+          <div style="text-align: center;">
+            <svg width="80" height="80" viewBox="0 0 80 80" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round">
+              <rect x="15" y="10" width="50" height="60" rx="8"/>
+              <line x1="25" y1="35" x2="55" y2="35"/>
+              <circle cx="40" cy="52" r="8"/>
+              <path d="M36 52l3 3 5-6"/>
+            </svg>
+            <div style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 12px;">앱 프로토타입</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- SLIDE 4: Market -->
+    <section class="slide slide-content" data-notes="시장 규모 - TAM/SAM/SOM">
+      <div class="slide-label animate">시장 규모</div>
+      <h2 class="slide-h2 animate delay-1">₩180조 푸드테크 시장</h2>
+      <div class="grid-3 animate delay-2" style="container-type: inline-size;">
+        <div class="card stat-card">
+          <div class="stat-label" style="color: var(--text-secondary);">TAM</div>
+          <div class="stat-number">₩180조</div>
+          <div class="stat-label">글로벌 푸드테크</div>
+        </div>
+        <div class="card stat-card">
+          <div class="stat-label" style="color: var(--text-secondary);">SAM</div>
+          <div class="stat-number">₩12조</div>
+          <div class="stat-label">한국 밀키트 + 레시피</div>
+        </div>
+        <div class="card stat-card">
+          <div class="stat-label" style="color: var(--text-secondary);">SOM</div>
+          <div class="stat-number">₩3,600억</div>
+          <div class="stat-label">AI 레시피 플랫폼</div>
+        </div>
+      </div>
+      <div class="animate delay-3" style="margin-top: 20px; font-size: 0.9rem; color: var(--text-secondary);">
+        한국 1인 가구 비율 34.5% · 밀키트 시장 연 23% 성장 · Z세대 AI 서비스 수용률 78%
+      </div>
+    </section>
+
+    <!-- SLIDE 5: Traction -->
+    <section class="slide slide-content" data-notes="트랙션 - MAU 12만, MRR 3억원">
+      <div class="slide-label animate">트랙션</div>
+      <h2 class="slide-h2 animate delay-1">폭발적 성장</h2>
+      <div class="grid-4 animate delay-2" style="margin-bottom: 24px; container-type: inline-size;">
+        <div class="card stat-card">
+          <div class="stat-number" data-count="120000" style="font-size: 2.2rem;">0</div>
+          <div class="stat-label">MAU</div>
+          <div class="stat-delta">↑ 340% YoY</div>
+        </div>
+        <div class="card stat-card">
+          <div class="stat-number" data-count="3" data-suffix="억" style="font-size: 2.2rem;">0</div>
+          <div class="stat-label">MRR (₩)</div>
+          <div class="stat-delta">↑ 28% MoM</div>
+        </div>
+        <div class="card stat-card">
+          <div class="stat-number" style="font-size: 2.2rem;">72%</div>
+          <div class="stat-label">D30 리텐션</div>
+          <div class="stat-delta">업계 평균 대비 3.6x</div>
+        </div>
+        <div class="card stat-card">
+          <div class="stat-number" style="font-size: 2.2rem;">4.8</div>
+          <div class="stat-label">앱스토어 평점</div>
+          <div class="stat-delta">리뷰 2.3만개</div>
+        </div>
+      </div>
+      <div class="chart-wrap animate delay-3" role="img" aria-label="월별 MAU 성장 차트">
+        <canvas id="tractionChart"></canvas>
+      </div>
+    </section>
+
+    <!-- SLIDE 6: Business Model -->
+    <section class="slide slide-content" data-notes="비즈니스 모델 - 프리미엄 + 커머스">
+      <div class="slide-label animate">비즈니스 모델</div>
+      <h2 class="slide-h2 animate delay-1">이중 수익 구조</h2>
+      <div class="grid-2 animate delay-2" style="container-type: inline-size;">
+        <div class="card">
+          <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 16px;">
+            <div class="icon-circle">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+            </div>
+            <h3 style="font-weight: 700; font-size: 1.1rem;">프리미엄 구독</h3>
+          </div>
+          <ul class="bullet" style="font-size: 0.95rem;">
+            <li>무제한 AI 레시피 추천</li>
+            <li>영양 분석 + 식단 관리</li>
+            <li>월 ₩9,900 · 전환율 12%</li>
+          </ul>
+        </div>
+        <div class="card">
+          <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 16px;">
+            <div class="icon-circle">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/></svg>
+            </div>
+            <h3 style="font-weight: 700; font-size: 1.1rem;">커머스 수수료</h3>
+          </div>
+          <ul class="bullet" style="font-size: 0.95rem;">
+            <li>장보기 연동 (쿠팡, 마켓컬리)</li>
+            <li>밀키트 브랜드 파트너십</li>
+            <li>CPS 8-12% 수수료</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- SLIDE 7: Team -->
+    <section class="slide slide-content" data-notes="팀 소개">
+      <div class="slide-label animate">팀</div>
+      <h2 class="slide-h2 animate delay-1">검증된 팀</h2>
+      <div class="grid-4 animate delay-2" style="container-type: inline-size;">
+        <div class="card team-card">
+          <div class="team-avatar">👨‍💻</div>
+          <div class="team-name">김민수</div>
+          <div class="team-role">CEO / Co-founder</div>
+          <div class="team-exp">전 쿠팡 PM Lead · 카이스트 CS</div>
+        </div>
+        <div class="card team-card">
+          <div class="team-avatar">👩‍🔬</div>
+          <div class="team-name">박서연</div>
+          <div class="team-role">CTO / Co-founder</div>
+          <div class="team-exp">전 네이버 AI Lab · MLOps 전문</div>
+        </div>
+        <div class="card team-card">
+          <div class="team-avatar">👨‍🍳</div>
+          <div class="team-name">이준호</div>
+          <div class="team-role">CPO</div>
+          <div class="team-exp">전 배달의민족 디자인 리드</div>
+        </div>
+        <div class="card team-card">
+          <div class="team-avatar">👩‍💼</div>
+          <div class="team-name">최윤지</div>
+          <div class="team-role">COO</div>
+          <div class="team-exp">전 마켓컬리 그로스 매니저</div>
+        </div>
+      </div>
+      <div class="animate delay-3" style="margin-top: 20px; font-size: 0.9rem; color: var(--text-secondary);">
+        엔지니어 12명 · 데이터 사이언티스트 4명 · 푸드 전문가 3명 · 총 23명
+      </div>
+    </section>
+
+    <!-- SLIDE 8: Ask -->
+    <section class="slide slide-title" data-notes="투자 요청 - 시리즈 A 50억원">
+      <div class="slide-label animate">투자 요청</div>
+      <h2 class="slide-h2 animate delay-1" style="font-size: clamp(2rem, 5vw, 3.5rem);">시리즈 A · ₩50억</h2>
+      <div class="grid-3 animate delay-2" style="margin-top: 8px; container-type: inline-size;">
+        <div class="card stat-card" style="background: color-mix(in srgb, var(--accent) 8%, var(--surface));">
+          <div class="stat-number" style="font-size: 1.8rem;">60%</div>
+          <div class="stat-label">제품 개발 + AI 고도화</div>
+        </div>
+        <div class="card stat-card" style="background: color-mix(in srgb, var(--accent) 8%, var(--surface));">
+          <div class="stat-number" style="font-size: 1.8rem;">25%</div>
+          <div class="stat-label">마케팅 + 유저 확보</div>
+        </div>
+        <div class="card stat-card" style="background: color-mix(in srgb, var(--accent) 8%, var(--surface));">
+          <div class="stat-number" style="font-size: 1.8rem;">15%</div>
+          <div class="stat-label">팀 빌딩 + 운영</div>
+        </div>
+      </div>
+      <div class="animate delay-3" style="margin-top: 32px; text-align: center;">
+        <div style="font-size: 1.1rem; font-weight: 600; color: var(--text);">목표: 2027년 MAU 100만 · ARR ₩500억</div>
+        <div style="font-size: 0.9rem; color: var(--text-secondary); margin-top: 8px;">contact@neuralchef.ai · neuralchef.ai</div>
+      </div>
+    </section>
+
+  </div>
+
+  <!-- NAV DOTS -->
+  <div class="nav-dots" id="navDots"></div>
+
+  </main>
+
+  <script>
+    // === Menu ===
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    // === Theme ===
+    var savedTheme = localStorage.getItem('viz-theme');
+    var currentTheme = savedTheme || 'light';
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t);
+      currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    // === Slide Navigation ===
+    var slides = document.querySelectorAll('.slide');
+    var currentSlide = 0;
+    var totalSlides = slides.length;
+
+    function showSlide(n) {
+      if (n < 0 || n >= totalSlides) return;
+      slides[currentSlide].classList.remove('active');
+      slides[currentSlide].classList.add(n > currentSlide ? 'prev' : '');
+      currentSlide = n;
+      slides[currentSlide].classList.remove('prev');
+      slides[currentSlide].classList.add('active');
+      document.getElementById('progress').style.width = ((currentSlide + 1) / totalSlides * 100) + '%';
+      document.getElementById('slideCounter').textContent = (currentSlide + 1) + ' / ' + totalSlides;
+      document.querySelectorAll('.nav-dot').forEach(function(d, i) { d.classList.toggle('active', i === currentSlide); });
+      animateCounters();
+    }
+
+    // Build nav dots
+    var dotsContainer = document.getElementById('navDots');
+    for (var i = 0; i < totalSlides; i++) {
+      var dot = document.createElement('button');
+      dot.className = 'nav-dot' + (i === 0 ? ' active' : '');
+      dot.setAttribute('aria-label', '슬라이드 ' + (i + 1));
+      dot.dataset.slide = i;
+      dot.onclick = function() { showSlide(parseInt(this.dataset.slide)); };
+      dotsContainer.appendChild(dot);
+    }
+
+    // Keyboard nav
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'Enter') { e.preventDefault(); showSlide(currentSlide + 1); }
+      if (e.key === 'ArrowLeft') { e.preventDefault(); showSlide(currentSlide - 1); }
+      if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open');
+    });
+
+    // Touch nav
+    var touchStartX = 0;
+    document.addEventListener('touchstart', function(e) { touchStartX = e.touches[0].clientX; });
+    document.addEventListener('touchend', function(e) {
+      var diff = touchStartX - e.changedTouches[0].clientX;
+      if (Math.abs(diff) > 50) { diff > 0 ? showSlide(currentSlide + 1) : showSlide(currentSlide - 1); }
+    });
+
+    // Click nav (left third = prev, right two-thirds = next)
+    document.querySelector('.deck').addEventListener('click', function(e) {
+      if (e.target.closest('.viz-menu') || e.target.closest('.nav-dots') || e.target.closest('button') || e.target.closest('a')) return;
+      e.clientX < window.innerWidth / 3 ? showSlide(currentSlide - 1) : showSlide(currentSlide + 1);
+    });
+
+    // Init
+    showSlide(0);
+
+    // === Chart.js (Traction) ===
+    Chart.defaults.animation = false;
+    var tractionCtx = document.getElementById('tractionChart');
+    var tractionChart = null;
+
+    function buildTractionChart() {
+      var style = getComputedStyle(document.documentElement);
+      var accent = style.getPropertyValue('--accent').trim();
+      var textColor = style.getPropertyValue('--text-secondary').trim();
+      var borderColor = style.getPropertyValue('--border').trim();
+      if (tractionChart) tractionChart.destroy();
+      tractionChart = new Chart(tractionCtx, {
+        type: 'bar',
+        data: {
+          labels: ['9월', '10월', '11월', '12월', '1월', '2월'],
+          datasets: [{
+            label: 'MAU (만)',
+            data: [3.2, 4.8, 6.5, 8.1, 10.2, 12.0],
+            backgroundColor: accent,
+            borderRadius: 6,
+            barPercentage: 0.6
+          }]
+        },
+        options: {
+          responsive: true, maintainAspectRatio: false,
+          scales: {
+            y: { beginAtZero: true, grid: { color: borderColor }, ticks: { color: textColor, font: { family: 'Noto Sans KR' } } },
+            x: { grid: { display: false }, ticks: { color: textColor, font: { family: 'Noto Sans KR' } } }
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: { enabled: true, backgroundColor: 'rgba(0,0,0,0.8)', titleFont: { family: 'Noto Sans KR' }, bodyFont: { family: 'Noto Sans KR' } }
+          }
+        }
+      });
+    }
+    buildTractionChart();
+
+    function onThemeChange() { buildTractionChart(); }
+
+    // === Number Counters ===
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return;
+        el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), duration = 1200;
+        (function tick(now) {
+          var p = Math.min((now - start) / duration, 1), eased = 1 - Math.pow(1 - p, 3);
+          el.textContent = prefix + Math.round(target * eased).toLocaleString() + suffix;
+          if (p < 1) requestAnimationFrame(tick);
+        })(start);
+      });
+    }
+
+    // === Download PNG ===
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } });
+        var a = document.createElement('a'); a.href = url;
+        a.download = 'neuralchef-pitch-slide-' + (currentSlide + 1) + '.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/process-guide.html
+++ b/claude/skills/visualize/examples/process-guide.html
@@ -1,0 +1,549 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ship Your First Open Source Project</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    
+    
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.08);
+      --text: #EDEDED; --text-secondary: #888;
+      --accent: #06b6d4; --accent-secondary: #0891b2;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.08);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #06b6d4; --accent-secondary: #0891b2;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; letter-spacing: -0.011em; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+    }
+
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 24px;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    }
+    .card:hover {
+      box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+      transform: translateY(-4px);
+      border-color: var(--accent);
+    }
+
+    .step-row {
+      animation: fadeInUp 0.5s ease both;
+    }
+    .step-row:nth-child(1) { animation-delay: 0s; }
+    .step-row:nth-child(2) { animation-delay: 0.08s; }
+    .step-row:nth-child(3) { animation-delay: 0.16s; }
+    .step-row:nth-child(4) { animation-delay: 0.24s; }
+    .step-row:nth-child(5) { animation-delay: 0.32s; }
+    .step-row:nth-child(6) { animation-delay: 0.4s; }
+    .step-row:nth-child(7) { animation-delay: 0.48s; }
+    .step-row:nth-child(8) { animation-delay: 0.56s; }
+    .step-content {
+      transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      border-radius: 12px; padding: 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      flex: 1;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+      cursor: pointer;
+    }
+    .step-row:hover .step-content {
+      box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+      transform: translateY(-3px);
+      border-color: var(--accent);
+      background: var(--surface-hover);
+    }
+
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes slideInLeft { from { opacity: 0; transform: translateX(-40px); } to { opacity: 1; transform: translateX(0); } }
+    @keyframes slideInRight { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
+
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+    .animate.delay-5 { animation-delay: 0.5s; }
+    .animate.delay-6 { animation-delay: 0.6s; }
+
+    .reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.6s ease, transform 0.6s ease; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .reveal { opacity: 1; transform: none; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; }
+      .viz-menu, .scroll-progress { display: none !important; }
+      .reveal { opacity: 1 !important; transform: none !important; }
+      .card { break-inside: avoid; box-shadow: none; border: 1px solid #ddd; }
+      .step-row { flex-direction: row !important; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* === Hamburger Menu === */
+    .viz-menu {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 9999;
+      font-family: var(--font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    }
+
+    .viz-menu-toggle {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .viz-menu-toggle:hover {
+      background: var(--surface-hover);
+      transform: scale(1.05);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+
+    .viz-menu-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      min-width: 200px;
+      background: var(--surface);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 6px;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px) scale(0.96);
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+
+    .viz-menu-dropdown.open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0) scale(1);
+    }
+
+    .viz-menu-dropdown button {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border: none;
+      background: transparent;
+      color: var(--text);
+      font-size: 0.875rem;
+      cursor: pointer;
+      border-radius: 8px;
+      transition: background 0.15s;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    .viz-menu-dropdown button:hover {
+      background: var(--surface-hover);
+    }
+
+    .viz-menu-dropdown button:focus-visible { 
+      outline: 2px solid var(--accent); 
+      outline-offset: 2px; 
+    }
+
+    .viz-menu-icon {
+      font-size: 1rem;
+      width: 20px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    /* ===== SCROLL PROGRESS ===== */
+    .scroll-progress {
+      position: fixed; top: 0; left: 0; width: 0%; height: 3px;
+      background: linear-gradient(90deg, var(--accent), var(--accent-secondary));
+      z-index: 9998; transition: width 0.1s linear;
+    }
+
+    /* ===== GUIDE ===== */
+    .guide-container {
+      max-width: 800px; margin: 0 auto; padding: 48px 24px 96px;
+    }
+
+    .guide-header {
+      text-align: center; margin-bottom: 64px; padding-top: 32px;
+    }
+    .guide-eyebrow {
+      font-size: 0.75rem; font-weight: 700; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--accent); margin-bottom: 12px;
+    }
+    .guide-title {
+      font-size: clamp(2rem, 6vw, 3.5rem); font-weight: 900; line-height: 1.1;
+      margin-bottom: 16px;
+      color: var(--text);
+      letter-spacing: -0.03em;
+      text-wrap: balance;
+      }
+    .guide-subtitle {
+      font-size: clamp(1rem, 2.5vw, 1.2rem); color: var(--text-secondary);
+      max-width: 50ch; margin: 0 auto;
+    }
+
+    .steps { display: flex; flex-direction: column; gap: 0; position: relative; }
+
+    /* Vertical timeline spine */
+    .steps::before {
+      content: '';
+      position: absolute;
+      left: 27px; /* center of step-number (56px/2 - 1) */
+      top: 56px;
+      bottom: 56px;
+      width: 2px;
+      background: linear-gradient(180deg, var(--accent), var(--accent-secondary), var(--accent));
+      opacity: 0.2;
+    }
+
+    .step-row {
+      display: flex; align-items: flex-start; gap: 32px;
+      padding: 24px 0;
+      position: relative;
+    }
+    .step-row.reverse { flex-direction: row-reverse; }
+
+    @media (max-width: 600px) {
+      .step-row, .step-row.reverse { flex-direction: column; }
+      .steps::before { left: 27px; }
+    }
+
+    .step-icon-col {
+      flex-shrink: 0; display: flex; flex-direction: column; align-items: center; gap: 8px;
+      position: relative; z-index: 1;
+    }
+    .step-number {
+      width: 56px; height: 56px; border-radius: 50%;
+      background: var(--surface);
+      border: 3px solid var(--accent);
+      color: var(--accent); display: flex; align-items: center; justify-content: center;
+      font-size: 1.25rem; font-weight: 700;
+      box-shadow: 0 0 0 4px var(--bg), 0 4px 12px rgba(0,0,0,0.1);
+      transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .step-row:hover .step-number {
+      background: var(--accent);
+      color: var(--surface);
+      transform: scale(1.1);
+      box-shadow: 0 0 0 4px var(--bg), 0 8px 24px color-mix(in srgb, var(--accent), transparent 50%);
+    }
+    .step-row:nth-child(odd) .step-number { border-color: var(--accent); color: var(--accent); }
+    .step-row:nth-child(even) .step-number { border-color: var(--accent-secondary); color: var(--accent-secondary); }
+    .step-icon {
+      width: 48px; height: 48px; color: var(--text-secondary); margin-top: 4px;
+    }
+
+    .step-content { flex: 1; }
+    .step-title {
+      font-size: clamp(1.25rem, 3vw, 1.5rem); font-weight: 700;
+      margin-bottom: 8px;
+      text-wrap: balance;
+    }
+    .step-description {
+      font-size: 1rem; color: var(--text-secondary); line-height: 1.7;
+      margin-bottom: 12px;
+    }
+    .tip-box {
+      background: color-mix(in srgb, var(--accent), transparent 92%);
+      border: 4px solid color-mix(in srgb, var(--accent), transparent 75%);
+      border-radius: 8px; padding: 12px 16px;
+      font-size: 0.875rem; display: flex; gap: 8px; align-items: flex-start;
+    }
+    .step-row:nth-child(even) .tip-box {
+      background: color-mix(in srgb, var(--accent-secondary), transparent 92%);
+      border-color: color-mix(in srgb, var(--accent-secondary), transparent 75%);
+    }
+    .tip-box .tip-icon { flex-shrink: 0; color: var(--accent); margin-top: 2px; }
+    .step-row:nth-child(even) .tip-box .tip-icon { color: var(--accent-secondary); }
+    .tip-box .tip-text { color: var(--text); }
+
+    .skip-link {
+      position: absolute; top: -100px; left: 16px; padding: 8px 16px;
+      background: var(--accent); color: #fff; border-radius: 8px;
+      text-decoration: none; z-index: 99999; font-weight: 600;
+    }
+    .skip-link:focus { top: 16px; }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="scroll-progress" id="scrollProgress" role="progressbar" aria-label="Reading progress"></div>
+  <main id="main-content">
+
+  <!-- Hamburger Menu -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/>
+        <line x1="3" y1="10" x2="17" y2="10"/>
+        <line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()">
+        <span class="viz-menu-icon">◐</span>
+        <span>Theme: <span id="themeLabel">Dark</span></span>
+      </button>
+      <button onclick="downloadImage()">
+        <span class="viz-menu-icon">⤓</span>
+        <span>Download PNG</span>
+      </button>
+      <button onclick="printPDF()">
+        <span class="viz-menu-icon">⎙</span>
+        <span>Print / PDF</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="guide-container">
+    <header class="guide-header animate">
+      <div class="guide-eyebrow">Step-by-Step Guide</div>
+      <h1 class="guide-title">Ship Your First Open Source Project</h1>
+      <p class="guide-subtitle">From idea to published package in 8 clear steps. No prior OSS experience needed.</p>
+    </header>
+
+    <div class="steps">
+
+      <!-- Step 1 -->
+      <section class="step-row" data-reveal data-step="1" aria-label="Step 1">
+        <div class="step-icon-col">
+          <div class="step-number">1</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Find a Real Problem</h2>
+          <p class="step-description">Start with a pain point you've experienced. The best open source projects solve the author's own problem first. Check if solutions already exist — if they do, consider contributing instead.</p>
+          <div class="tip-box">
+            <svg class="tip-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2v1M12 7a4 4 0 014 4c0 1.5-.8 2.8-2 3.4V16h-4v-1.6A4 4 0 018 11a4 4 0 014-4z"/></svg>
+            <span class="tip-text">Search GitHub Issues and Stack Overflow for recurring complaints — that's where gold ideas live.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Step 2 -->
+      <section class="step-row reverse" data-reveal data-step="2" aria-label="Step 2">
+        <div class="step-icon-col">
+          <div class="step-number">2</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Build an MVP</h2>
+          <p class="step-description">Build the smallest version that works. One feature, done well. Don't over-engineer — you can refactor later. Ship v0.1.0 with just the core functionality.</p>
+          <div class="tip-box">
+            <svg class="tip-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2v1M12 7a4 4 0 014 4c0 1.5-.8 2.8-2 3.4V16h-4v-1.6A4 4 0 018 11a4 4 0 014-4z"/></svg>
+            <span class="tip-text">Write the README before writing code. If you can't explain it simply, the scope is too broad.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Step 3 -->
+      <section class="step-row" data-reveal data-step="3" aria-label="Step 3">
+        <div class="step-icon-col">
+          <div class="step-number">3</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Set Up the Repository</h2>
+          <p class="step-description">Create a GitHub repo with a clear name. Add a .gitignore, choose a license (MIT is safe for most projects), and structure your files cleanly from the start.</p>
+        </div>
+      </section>
+
+      <!-- Step 4 -->
+      <section class="step-row reverse" data-reveal data-step="4" aria-label="Step 4">
+        <div class="step-icon-col">
+          <div class="step-number">4</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Write Great Documentation</h2>
+          <p class="step-description">Your README is your project's front door. Include: what it does, how to install it, a quick-start example, and how to contribute. Good docs are the #1 predictor of adoption.</p>
+          <div class="tip-box">
+            <svg class="tip-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2v1M12 7a4 4 0 014 4c0 1.5-.8 2.8-2 3.4V16h-4v-1.6A4 4 0 018 11a4 4 0 014-4z"/></svg>
+            <span class="tip-text">Add a CONTRIBUTING.md — it signals "I want help" and lowers the barrier for first-time contributors.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Step 5 -->
+      <section class="step-row" data-reveal data-step="5" aria-label="Step 5">
+        <div class="step-icon-col">
+          <div class="step-number">5</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Add Tests & CI</h2>
+          <p class="step-description">Even basic tests build confidence. Set up GitHub Actions for automated testing on every PR. This protects you and tells contributors their changes won't break things.</p>
+        </div>
+      </section>
+
+      <!-- Step 6 -->
+      <section class="step-row reverse" data-reveal data-step="6" aria-label="Step 6">
+        <div class="step-icon-col">
+          <div class="step-number">6</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Publish Your Package</h2>
+          <p class="step-description">Publish to npm, PyPI, crates.io, or wherever your ecosystem lives. Use semantic versioning. Tag your release on GitHub with a changelog describing what's included.</p>
+          <div class="tip-box">
+            <svg class="tip-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2v1M12 7a4 4 0 014 4c0 1.5-.8 2.8-2 3.4V16h-4v-1.6A4 4 0 018 11a4 4 0 014-4z"/></svg>
+            <span class="tip-text">Automate releases with GitHub Actions — publish on tag push so you never forget a step.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Step 7 -->
+      <section class="step-row" data-reveal data-step="7" aria-label="Step 7">
+        <div class="step-icon-col">
+          <div class="step-number">7</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Share & Get Feedback</h2>
+          <p class="step-description">Post on Twitter/X, Reddit, Hacker News, Discord communities, or dev.to. Be genuine — share what you built and why. Early feedback shapes the roadmap.</p>
+        </div>
+      </section>
+
+      <!-- Step 8 -->
+      <section class="step-row reverse" data-reveal data-step="8" aria-label="Step 8">
+        <div class="step-icon-col">
+          <div class="step-number">8</div>
+          <svg class="step-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+        </div>
+        <div class="step-content">
+          <h2 class="step-title">Nurture Your Community</h2>
+          <p class="step-description">Respond to issues kindly. Label "good first issue" for newcomers. Celebrate contributors. A welcoming community grows faster than clever code ever will.</p>
+          <div class="tip-box">
+            <svg class="tip-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2v1M12 7a4 4 0 014 4c0 1.5-.8 2.8-2 3.4V16h-4v-1.6A4 4 0 018 11a4 4 0 014-4z"/></svg>
+            <span class="tip-text">Add an ALL-CONTRIBUTORS badge to recognize every type of contribution, not just code.</span>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+
+  </main>
+  <script>
+    // === Menu ===
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    // === Theme system ===
+    const themes = [
+      { name: 'Dark', class: 'theme-dark' },
+      { name: 'Light', class: 'theme-light' },
+      { name: 'Auto', class: 'theme-auto' },
+    ];
+    let currentTheme = 0;
+
+    function cycleTheme() {
+      // Remove all theme classes
+      themes.forEach(t => document.documentElement.classList.remove(t.class));
+      // Advance to next
+      currentTheme = (currentTheme + 1) % themes.length;
+      document.documentElement.classList.add(themes[currentTheme].class);
+      document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      // Persist
+      localStorage.setItem('viz-theme', currentTheme);
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+
+    // Restore saved theme on load
+    (function() {
+      const saved = localStorage.getItem('viz-theme');
+      if (saved !== null) {
+        currentTheme = parseInt(saved);
+        document.documentElement.classList.add(themes[currentTheme].class);
+        document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      }
+    })();
+
+    // === Print as PDF ===
+    function printPDF() {
+      window.print();
+    }
+
+    // === Scroll Reveal ===
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var revealObserver = new IntersectionObserver(function(entries) {
+      entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); revealObserver.unobserve(e.target); } });
+    }, { threshold: 0.15 });
+    document.querySelectorAll('.reveal').forEach(function(el) { revealObserver.observe(el); });
+    setTimeout(function() { document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); }); }, 500);
+
+    // === Scroll Progress ===
+    var progressBar = document.getElementById('scrollProgress');
+    window.addEventListener('scroll', function() {
+      var scrollTop = window.scrollY;
+      var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      var progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      progressBar.style.width = progress + '%';
+    }, { passive: true });
+
+    // === Download PNG ===
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      var progress = document.getElementById('scrollProgress');
+      menu.style.display = 'none';
+      progress.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.querySelector('.guide-container'), { quality: 1, pixelRatio: 2 });
+        var a = document.createElement('a'); a.href = url;
+        a.download = 'ship-open-source-guide.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+      progress.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/quote-card.html
+++ b/claude/skills/visualize/examples/quote-card.html
@@ -1,0 +1,594 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tech Leader Quotes</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:ital,wght@0,400;0,600;1,400;1,600&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #f59e0b; --accent-secondary: #d97706; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #f59e0b; --accent-secondary: #d97706; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; letter-spacing: -0.011em; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+      min-height: 100vh; padding: 48px 16px;
+      display: flex; flex-direction: column; align-items: center;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent-secondary), transparent 94%), transparent);
+    }
+
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 8px; }
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+    }
+
+    .page-title { font-size: clamp(1.5rem, 4vw, 2.5rem); font-weight: 700; text-align: center; margin-bottom: 8px; letter-spacing: -0.03em; text-wrap: balance; }
+    .page-subtitle { font-size: 1rem; color: var(--text-secondary); text-align: center; margin-bottom: 40px; }
+
+    /* Category filters */
+    .category-filters {
+      display: flex; gap: 12px; margin-bottom: 32px; flex-wrap: wrap;
+      justify-content: center; align-items: center;
+    }
+    .category-filter {
+      padding: 8px 16px; border: 1px solid var(--border); border-radius: 8px;
+      background: var(--surface); color: var(--text-secondary); cursor: pointer;
+      font-size: 0.875rem; font-family: inherit; font-weight: 500;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    }
+    .category-filter:hover { 
+      background: var(--surface-hover); 
+      color: var(--text); 
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .category-filter.active { 
+      background: var(--accent); 
+      color: #fff; 
+      border-color: var(--accent);
+      box-shadow: 0 2px 8px color-mix(in srgb, var(--accent), transparent 70%);
+      transform: translateY(-1px);
+    }
+    .category-filter:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* Masonry-style grid */
+    .quotes-grid {
+      columns: 2; column-gap: 20px; max-width: 1000px; width: 100%;
+    }
+    @media (max-width: 700px) { .quotes-grid { columns: 1; } }
+    @media (min-width: 1200px) { .quotes-grid { columns: 3; } }
+
+    .quote-card {
+      break-inside: avoid; margin-bottom: 20px;
+      background: var(--surface);
+      border: 1px solid var(--border); border-radius: 12px;
+      padding: 32px; position: relative; overflow: hidden;
+      cursor: pointer; transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      border-left: 4px solid var(--q-accent, var(--accent));
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+    .quote-card::before {
+      content: ''; position: absolute; inset: 0;
+      background: linear-gradient(135deg, color-mix(in srgb, var(--q-accent, var(--accent)), transparent 96%), transparent);
+      pointer-events: none;
+      opacity: 0; transition: opacity 0.25s ease;
+    }
+    .quote-card:hover {
+      transform: translateY(-6px);
+      box-shadow: 0 8px 24px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.1);
+      border-left-width: 6px;
+    }
+    .quote-card:hover::before {
+      opacity: 1;
+    }
+    .quote-card:focus-visible {
+      outline: 2px solid var(--q-accent, var(--accent));
+      outline-offset: 2px;
+    }
+
+    /* Hero quote - larger featured quote */
+    .quote-card.hero {
+      grid-column: span 1;
+      padding: 48px;
+      margin-bottom: 32px;
+      border-left-width: 5px;
+    }
+    .quote-card.hero .quote-text {
+      font-size: clamp(1.25rem, 3vw, 1.75rem);
+      line-height: 1.5;
+    }
+    .quote-card.hero .quote-mark {
+      font-size: 6rem;
+      top: 16px; left: 32px;
+    }
+
+    /* Staggered animation */
+    .quote-card:nth-child(1) { animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) both 0s; }
+    .quote-card:nth-child(2) { animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) both 0.1s; }
+    .quote-card:nth-child(3) { animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) both 0.15s; }
+    .quote-card:nth-child(4) { animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) both 0.2s; }
+    .quote-card:nth-child(5) { animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) both 0.25s; }
+    .quote-card:nth-child(6) { animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) both 0.3s; }
+
+    /* Muted theme accent colors */
+    .quote-card:nth-child(1) { --q-accent: #3b82f6; }
+    .quote-card:nth-child(2) { --q-accent: #8b5cf6; }
+    .quote-card:nth-child(3) { --q-accent: #10b981; }
+    .quote-card:nth-child(4) { --q-accent: #f59e0b; }
+
+    .quote-mark {
+      font-size: 4rem; line-height: 1; font-weight: 900;
+      color: var(--q-accent, var(--accent)); opacity: 0.3;
+      position: absolute; top: 16px; left: 24px;
+      font-family: 'Lora', Georgia, serif;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+      transform: scale(1);
+    }
+    .quote-text {
+      font-family: 'Lora', Georgia, serif;
+      font-size: clamp(1rem, 2.2vw, 1.25rem);
+      font-style: italic; line-height: 1.6;
+      color: var(--text); margin-bottom: 24px;
+      position: relative; z-index: 1;
+    }
+    .quote-attribution { position: relative; z-index: 1; }
+    .quote-divider { width: 60px; height: 4px; border-radius: 2px; background: linear-gradient(90deg, var(--q-accent, var(--accent)), color-mix(in srgb, var(--q-accent, var(--accent)), var(--accent-secondary) 50%)); margin-bottom: 12px; opacity: 0.9; }
+    .quote-name { font-weight: 700; font-size: 0.95rem; }
+    .quote-title-company { font-size: 0.8rem; color: var(--text-secondary); margin-top: 2px; }
+
+    /* Enhanced copy button */
+    .copy-btn {
+      position: absolute; bottom: 16px; right: 16px;
+      width: 36px; height: 36px; border-radius: 8px;
+      border: 1px solid var(--border); background: var(--surface);
+      color: var(--text-secondary); cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      opacity: 0; transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      backdrop-filter: blur(8px);
+    }
+    .quote-card:hover .copy-btn { 
+      opacity: 1; 
+      transform: translateY(-2px);
+    }
+    .copy-btn:hover { 
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      color: var(--q-accent, var(--accent)); 
+      background: var(--surface-hover);
+      border-color: var(--q-accent, var(--accent));
+      transform: translateY(-2px) scale(1.05);
+    }
+
+    /* Expandable quote functionality */
+    .quote-card.expanded {
+      position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+      z-index: 9998; max-width: 600px; max-height: 80vh;
+      overflow-y: auto; cursor: default;
+      border-left-width: 5px;
+    }
+    .quote-overlay {
+      position: fixed; inset: 0; z-index: 9997;
+      background: rgba(0,0,0,0.7); backdrop-filter: blur(8px);
+      opacity: 0; visibility: hidden; transition: all 0.3s ease;
+    }
+    .quote-overlay.active {
+      opacity: 1; visibility: visible;
+    }
+
+    /* Fullscreen */
+    .fullscreen-overlay {
+      position: fixed; inset: 0; z-index: 9998;
+      background: rgba(0,0,0,0.85); backdrop-filter: blur(8px);
+      display: none; align-items: center; justify-content: center;
+      padding: 32px; cursor: pointer;
+    }
+    .fullscreen-overlay.active { display: flex; }
+    .fullscreen-overlay .quote-card { 
+      width: min(90vmin, 600px); max-width: none; cursor: default;
+      border-left-width: 5px;
+    }
+    .fullscreen-overlay .quote-card:hover { box-shadow: none; }
+    .fullscreen-overlay .copy-btn { opacity: 1; }
+    .fullscreen-close {
+      position: absolute; top: 24px; right: 24px;
+      width: 44px; height: 44px; border-radius: 8px;
+      background: rgba(255,255,255,0.1); border: none;
+      color: #fff; cursor: pointer; display: flex;
+      align-items: center; justify-content: center; 
+      transition: background 0.2s;
+    }
+    .fullscreen-close:hover { background: rgba(255,255,255,0.2); }
+
+    @media print {
+      body { background: white !important; color: black !important; }
+      .viz-menu, .theme-toggle, .fullscreen-overlay, .copy-btn, .category-filters { display: none !important; }
+      .quote-card { break-inside: avoid; box-shadow: none; border: 1px solid #ddd; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* === Hamburger Menu === */
+    .viz-menu {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 9999;
+      font-family: var(--font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    }
+
+    .viz-menu-toggle {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .viz-menu-toggle:hover {
+      background: var(--surface-hover);
+      transform: scale(1.05);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+
+    .viz-menu-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      min-width: 200px;
+      background: var(--surface);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 6px;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px) scale(0.96);
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+
+    .viz-menu-dropdown.open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0) scale(1);
+    }
+
+    .viz-menu-dropdown button {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border: none;
+      background: transparent;
+      color: var(--text);
+      font-size: 0.875rem;
+      cursor: pointer;
+      border-radius: 8px;
+      transition: background 0.15s;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    .viz-menu-dropdown button:hover {
+      background: var(--surface-hover);
+    }
+
+    .viz-menu-icon {
+      font-size: 1rem;
+      width: 20px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    .skip-link { 
+      position: absolute; top: -100px; left: 16px; padding: 8px 16px; 
+      background: var(--accent); color: #fff; border-radius: 8px; 
+      text-decoration: none; z-index: 99999; font-weight: 600; 
+    }
+    .skip-link:focus { top: 16px; }
+  
+    .quote-card { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .quote-card:hover { transform: translateY(-4px); box-shadow: 0 12px 30px rgba(0,0,0,0.12); } /* hover-lift */
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <!-- Hamburger Menu -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/>
+        <line x1="3" y1="10" x2="17" y2="10"/>
+        <line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()">
+        <span class="viz-menu-icon">◐</span>
+        <span>Theme: <span id="themeLabel">Dark</span></span>
+      </button>
+      <button onclick="downloadImage()">
+        <span class="viz-menu-icon">⤓</span>
+        <span>Download as PNG</span>
+      </button>
+      <button onclick="printPDF()">
+        <span class="viz-menu-icon">⎙</span>
+        <span>Print / Save PDF</span>
+      </button>
+    </div>
+  </div>
+
+  <header>
+    <h1 class="page-title animate">Voices in Tech</h1>
+    <p class="page-subtitle animate delay-1">Wisdom from the builders shaping our future</p>
+    
+    <!-- Category filters -->
+    <div class="category-filters animate delay-2">
+      <button class="category-filter active" onclick="filterQuotes('all')">All</button>
+      <button class="category-filter" onclick="filterQuotes('leadership')">Leadership</button>
+      <button class="category-filter" onclick="filterQuotes('innovation')">Innovation</button>
+      <button class="category-filter" onclick="filterQuotes('ai')">AI & Future</button>
+    </div>
+  </header>
+
+  <section class="quotes-grid" role="region" aria-label="Quote cards">
+    <!-- Hero quote - larger featured quote -->
+    <div class="quote-card hero" tabindex="0" role="button" aria-label="View quote by Satya Nadella fullscreen" onclick="openFullscreen(0)" data-category="leadership">
+      <div class="quote-mark" aria-hidden="true">"</div>
+      <blockquote class="quote-text">Our industry does not respect tradition — it only respects innovation. The true scarce commodity is increasingly human attention.</blockquote>
+      <div class="quote-attribution">
+        <div class="quote-divider"></div>
+        <div class="quote-name">Satya Nadella</div>
+        <div class="quote-title-company">CEO, Microsoft</div>
+      </div>
+      <button class="copy-btn" onclick="event.stopPropagation();copyQuote(0)" aria-label="Copy quote">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      </button>
+    </div>
+
+    <div class="quote-card" tabindex="0" role="button" aria-label="View quote by Jensen Huang fullscreen" onclick="openFullscreen(1)" data-category="ai">
+      <div class="quote-mark" aria-hidden="true">"</div>
+      <blockquote class="quote-text">Software is eating the world, but AI is going to eat software. The more you learn, the more you realize how much you don't know.</blockquote>
+      <div class="quote-attribution">
+        <div class="quote-divider"></div>
+        <div class="quote-name">Jensen Huang</div>
+        <div class="quote-title-company">CEO, NVIDIA</div>
+      </div>
+      <button class="copy-btn" onclick="event.stopPropagation();copyQuote(1)" aria-label="Copy quote">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      </button>
+    </div>
+
+    <div class="quote-card" tabindex="0" role="button" aria-label="View quote by Mira Murati fullscreen" onclick="openFullscreen(2)" data-category="innovation">
+      <div class="quote-mark" aria-hidden="true">"</div>
+      <blockquote class="quote-text">The most important thing is to build technology that genuinely helps people. Safety and capability aren't at odds — they reinforce each other.</blockquote>
+      <div class="quote-attribution">
+        <div class="quote-divider"></div>
+        <div class="quote-name">Mira Murati</div>
+        <div class="quote-title-company">Former CTO, OpenAI</div>
+      </div>
+      <button class="copy-btn" onclick="event.stopPropagation();copyQuote(2)" aria-label="Copy quote">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      </button>
+    </div>
+
+    <div class="quote-card" tabindex="0" role="button" aria-label="View quote by Gwynne Shotwell fullscreen" onclick="openFullscreen(3)" data-category="leadership">
+      <div class="quote-mark" aria-hidden="true">"</div>
+      <blockquote class="quote-text">I always tell people: focus on being really good at what you do. Success follows competence. Simplicity scales, complexity fails.</blockquote>
+      <div class="quote-attribution">
+        <div class="quote-divider"></div>
+        <div class="quote-name">Gwynne Shotwell</div>
+        <div class="quote-title-company">President &amp; COO, SpaceX</div>
+      </div>
+      <button class="copy-btn" onclick="event.stopPropagation();copyQuote(3)" aria-label="Copy quote">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      </button>
+    </div>
+
+    <!-- Additional quotes for more variety -->
+    <div class="quote-card" tabindex="0" role="button" aria-label="View quote by Tim Cook fullscreen" onclick="openFullscreen(4)" data-category="innovation">
+      <div class="quote-mark" aria-hidden="true">"</div>
+      <blockquote class="quote-text">Technology alone is not enough. It's technology married with the liberal arts and humanities that yields results that make our hearts sing.</blockquote>
+      <div class="quote-attribution">
+        <div class="quote-divider"></div>
+        <div class="quote-name">Tim Cook</div>
+        <div class="quote-title-company">CEO, Apple</div>
+      </div>
+      <button class="copy-btn" onclick="event.stopPropagation();copyQuote(4)" aria-label="Copy quote">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      </button>
+    </div>
+
+    <div class="quote-card" tabindex="0" role="button" aria-label="View quote by Sam Altman fullscreen" onclick="openFullscreen(5)" data-category="ai">
+      <div class="quote-mark" aria-hidden="true">"</div>
+      <blockquote class="quote-text">The biggest thing is that we need to become much better at creating systems that can adapt and learn. The future belongs to those who can learn fast.</blockquote>
+      <div class="quote-attribution">
+        <div class="quote-divider"></div>
+        <div class="quote-name">Sam Altman</div>
+        <div class="quote-title-company">CEO, OpenAI</div>
+      </div>
+      <button class="copy-btn" onclick="event.stopPropagation();copyQuote(5)" aria-label="Copy quote">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      </button>
+    </div>
+  </section>
+
+  <div class="fullscreen-overlay" id="fullscreenOverlay" onclick="closeFullscreen(event)">
+    <button class="fullscreen-close" onclick="closeFullscreen(event)" aria-label="Close fullscreen view">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>
+    </button>
+    <div id="fullscreenContent"></div>
+  </div>
+
+  </main>
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') { document.getElementById('vizMenuDropdown').classList.remove('open'); closeFullscreen(e); } });
+
+    // === Theme system ===
+    const themes = [
+      { name: 'Dark', class: 'theme-dark' },
+      { name: 'Light', class: 'theme-light' },
+      { name: 'Auto', class: 'theme-auto' },
+    ];
+    let currentTheme = 0;
+
+    function cycleTheme() {
+      // Remove all theme classes
+      themes.forEach(t => document.documentElement.classList.remove(t.class));
+      // Advance to next
+      currentTheme = (currentTheme + 1) % themes.length;
+      document.documentElement.classList.add(themes[currentTheme].class);
+      document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      // Persist
+      localStorage.setItem('viz-theme', currentTheme);
+    }
+
+    // Restore saved theme on load
+    (function() {
+      const saved = localStorage.getItem('viz-theme');
+      if (saved !== null) {
+        currentTheme = parseInt(saved);
+        document.documentElement.classList.add(themes[currentTheme].class);
+        document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      }
+    })();
+
+    // === Print as PDF ===
+    function printPDF() {
+      window.print();
+    }
+
+    var quoteCards = document.querySelectorAll('.quotes-grid .quote-card');
+    var quoteTexts = [];
+    quoteCards.forEach(function(c) {
+      var q = c.querySelector('.quote-text').textContent.trim();
+      var n = c.querySelector('.quote-name').textContent.trim();
+      quoteTexts.push('"' + q + '" — ' + n);
+    });
+
+    function copyQuote(i) {
+      navigator.clipboard.writeText(quoteTexts[i]).then(function() {
+        var btn = quoteCards[i].querySelector('.copy-btn');
+        var originalHTML = btn.innerHTML;
+        btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--positive)" stroke-width="2.5" stroke-linecap="round"><polyline points="20,6 9,17 4,12"/></svg>';
+        setTimeout(function() {
+          btn.innerHTML = originalHTML;
+        }, 1500);
+      });
+    }
+
+    function openFullscreen(index) {
+      var card = quoteCards[index];
+      var clone = card.cloneNode(true);
+      clone.removeAttribute('onclick'); clone.removeAttribute('tabindex'); clone.removeAttribute('role');
+      clone.style.cursor = 'default';
+      var container = document.getElementById('fullscreenContent');
+      container.innerHTML = '';
+      container.appendChild(clone);
+      document.getElementById('fullscreenOverlay').classList.add('active');
+    }
+    
+    function closeFullscreen(e) {
+      if (e && e.target && e.target.closest('.quote-card')) return;
+      document.getElementById('fullscreenOverlay').classList.remove('active');
+    }
+
+    // Category filtering
+    function filterQuotes(category) {
+      // Update filter buttons
+      document.querySelectorAll('.category-filter').forEach(function(btn) {
+        btn.classList.remove('active');
+      });
+      event.target.classList.add('active');
+
+      // Filter quote cards
+      quoteCards.forEach(function(card, i) {
+        var cardCategory = card.getAttribute('data-category');
+        if (category === 'all' || cardCategory === category) {
+          card.style.display = 'block';
+          card.style.animation = 'fadeInUp 0.4s ease both ' + (i * 0.05) + 's';
+        } else {
+          card.style.display = 'none';
+        }
+      });
+    }
+
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      var themeToggle = document.querySelector('.theme-toggle');
+      menu.style.display = 'none';
+      themeToggle.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.querySelector('main'), { 
+          quality: 1, 
+          pixelRatio: 2, 
+          filter: function(n) { 
+            return !n.classList || (!n.classList.contains('viz-menu') && !n.classList.contains('theme-toggle')); 
+          } 
+        });
+        var a = document.createElement('a'); 
+        a.href = url; 
+        a.download = 'tech-leader-quotes.png'; 
+        a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+      themeToggle.style.display = '';
+    }
+
+    // Smooth quote mark animations on hover
+    quoteCards.forEach(function(card) {
+      const quoteMark = card.querySelector('.quote-mark');
+      card.addEventListener('mouseenter', function() {
+        if (quoteMark) {
+          quoteMark.style.opacity = '0.5';
+          quoteMark.style.transform = 'scale(1.05)';
+        }
+      });
+      card.addEventListener('mouseleave', function() {
+        if (quoteMark) {
+          quoteMark.style.opacity = '0.3';
+          quoteMark.style.transform = 'scale(1)';
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/saas-dashboard.html
+++ b/claude/skills/visualize/examples/saas-dashboard.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SaaS Analytics Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    
+    
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888; --accent: #10b981; --accent-secondary: #059669; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; --accent: #10b981; --accent-secondary: #059669; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body { 
+      font-family: 'Inter', -apple-system, sans-serif; 
+      background: var(--bg);
+      color: var(--text); 
+      line-height: 1.6; 
+      -webkit-font-smoothing: antialiased; 
+      scrollbar-gutter: stable;
+      letter-spacing: -0.011em; 
+      font-feature-settings: 'cv11', 'ss01'; 
+      font-weight: 400;
+      transition: background 0.3s, color 0.3s;
+    }
+    body::after {
+      content: ''; position: fixed; inset: 0; z-index: -1; opacity: 0.03;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+    h1, h2, h3, h4 { color: var(--text); letter-spacing: -0.03em; line-height: 1.05; font-weight: 700; text-wrap: balance; }
+    h2, h3 { font-weight: 600; letter-spacing: -0.02em; }
+    h4 { font-weight: 600; }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+
+    .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+    .kpi:nth-child(1) { animation: fadeInUp 0.5s ease both 0s; }
+    .kpi:nth-child(2) { animation: fadeInUp 0.5s ease both 0.08s; }
+    .kpi:nth-child(3) { animation: fadeInUp 0.5s ease both 0.16s; }
+    .kpi:nth-child(4) { animation: fadeInUp 0.5s ease both 0.24s; }
+    .chart-card { animation: fadeInUp 0.5s ease both 0.32s; }
+    .bottom-card:nth-child(1) { animation: fadeInUp 0.5s ease both 0.4s; }
+    .bottom-card:nth-child(2) { animation: fadeInUp 0.5s ease both 0.48s; }
+
+    .skip-link { position: absolute; left: -9999px; top: auto; width: 1px; height: 1px; overflow: hidden; z-index: 10000; padding: 8px 16px; background: var(--accent); color: #fff; text-decoration: none; border-radius: 8px; }
+    .skip-link:focus { left: 16px; top: 16px; width: auto; height: auto; overflow: visible; }
+
+    @media print { body { background: #fff !important; color: #000 !important; } .viz-menu { display: none !important; } * { print-color-adjust: exact; -webkit-print-color-adjust: exact; } }
+
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-dark .theme-toggle .sun-icon { display: none; }
+    .theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle { width: 40px; height: 40px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { position: absolute; top: 48px; right: 0; min-width: 160px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05); opacity: 0; visibility: hidden; transform: translateY(-4px); transition: all 0.15s; }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button { width: 100%; padding: 8px 12px; border: none; border-radius: 6px; background: transparent; color: var(--text-secondary); font-size: 0.875rem; font-family: inherit; cursor: pointer; text-align: left; display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s; }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+
+    .dashboard { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    .dash-header { margin-bottom: 32px; }
+    .dash-header h1 { 
+      font-size: clamp(1.75rem, 4vw, 2.5rem); 
+      margin-bottom: 8px; 
+      letter-spacing: -0.03em;
+      text-wrap: balance;
+        line-height: 1.05;
+      font-weight: 700;
+    }
+    .dash-header p { color: var(--text-secondary); font-size: 1rem; line-height: 1.5; }
+
+    /* KPI row */
+    .kpi-grid { 
+      display: grid; 
+      grid-template-columns: repeat(4, 1fr); 
+      gap: 2px; 
+      background: var(--border); 
+      border-radius: 12px; 
+      overflow: hidden; 
+      margin-bottom: 32px; 
+      border: 4px solid rgba(255,255,255,0.08);
+      box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+    }
+    .theme-light .kpi-grid { border: 4px solid rgba(0,0,0,0.08); }
+    .kpi { 
+      background: var(--surface); 
+      padding: 28px; 
+      transition: all 0.2s ease, transform 0.2s ease; 
+      position: relative;
+    }
+    .kpi:hover {
+      box-shadow: inset 0 0 0 1px var(--accent);
+      background: color-mix(in srgb, var(--accent), transparent 96%);
+      transform: scale(1.02);
+    }
+    .kpi:hover {
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+    }
+    .theme-light .kpi:hover {
+      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+    }
+    .kpi-label { 
+      font-size: 0.6875rem; 
+      color: var(--text-secondary); 
+      text-transform: uppercase; 
+      letter-spacing: 0.1em; 
+      font-weight: 500; 
+      margin-bottom: 12px; 
+    }
+    .kpi-value { 
+      font-size: 2.25rem; 
+      font-weight: 700; 
+      letter-spacing: -0.04em; 
+      margin-bottom: 8px; 
+      color: var(--accent);
+      line-height: 1;
+    }
+    .kpi-change { font-size: 0.8125rem; font-weight: 500; }
+    .kpi-change.up { color: var(--positive); }
+    .kpi-change.down { color: var(--negative); }
+
+    /* Charts */
+    .charts-row { display: grid; grid-template-columns: 3fr 2fr; gap: 20px; margin-bottom: 24px; }
+    .chart-card { 
+      background: var(--surface); 
+      border: 1px solid rgba(255,255,255,0.08); 
+      border-radius: 8px; 
+      padding: 24px; 
+      transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+    .chart-card:hover {
+      box-shadow: 0 0 0 1px rgba(255,255,255,0.12), 0 8px 16px rgba(0,0,0,0.08);
+      border-color: rgba(255,255,255,0.12);
+    }
+    .theme-light .chart-card { border: 1px solid rgba(0,0,0,0.08); }
+    .theme-light .chart-card:hover { 
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.08); 
+      border-color: rgba(0,0,0,0.12);
+    }
+    .chart-card h3 { 
+      font-size: 1rem; 
+      font-weight: 600; 
+      margin-bottom: 6px; 
+      letter-spacing: -0.02em; 
+    }
+    .chart-card .chart-sub { 
+      font-size: 0.8125rem; 
+      color: var(--text-secondary); 
+      margin-bottom: 24px; 
+      line-height: 1.5;
+    }
+    .chart-wrap { position: relative; height: 320px; }
+
+    /* Bottom row */
+    .bottom-row { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+    .bottom-card { 
+      background: var(--surface); 
+      border: 1px solid rgba(255,255,255,0.08); 
+      border-radius: 8px; 
+      padding: 24px; 
+      transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+    .bottom-card:hover {
+      box-shadow: 0 0 0 1px rgba(255,255,255,0.12), 0 8px 16px rgba(0,0,0,0.08);
+      border-color: rgba(255,255,255,0.12);
+    }
+    .theme-light .bottom-card { border: 1px solid rgba(0,0,0,0.08); }
+    .theme-light .bottom-card:hover { 
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.08); 
+      border-color: rgba(0,0,0,0.12);
+    }
+    .comparison-block:hover, .card:hover, [data-reveal]:hover { border-color: rgba(255,255,255,0.12); }
+    .bottom-card h3 { 
+      font-size: 1rem; 
+      font-weight: 600; 
+      margin-bottom: 20px; 
+      letter-spacing: -0.02em; 
+    }
+
+    .activity-item { display: flex; align-items: center; gap: 12px; padding: 10px 0; border-bottom: 1px solid var(--border); }
+    .activity-item:last-child { border-bottom: none; }
+    .activity-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); flex-shrink: 0; }
+    .activity-text { flex: 1; }
+    .activity-text h4 { font-size: 0.8125rem; font-weight: 500; margin-bottom: 2px; }
+    .activity-text p { font-size: 0.75rem; color: var(--text-secondary); }
+    .activity-time { font-size: 0.6875rem; color: var(--text-secondary); white-space: nowrap; }
+
+    table { width: 100%; border-collapse: collapse; }
+    th { text-align: left; padding: 8px 0; font-size: 0.6875rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; border-bottom: 1px solid var(--border); }
+    td { padding: 10px 0; font-size: 0.8125rem; border-bottom: 1px solid var(--border); }
+    tr:last-child td { border-bottom: none; }
+    .badge { font-size: 0.6875rem; font-weight: 500; padding: 2px 8px; border-radius: 4px; }
+    .badge.up { background: rgba(12,206,107,0.1); color: var(--positive); }
+    .badge.down { background: rgba(238,0,0,0.1); color: var(--negative); }
+
+    @media (max-width: 768px) {
+      .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+      .charts-row, .bottom-row { grid-template-columns: 1fr; }
+      .kpi-value { font-size: 1.5rem; }
+    }
+    @media (max-width: 480px) {
+      .kpi-grid { grid-template-columns: 1fr; }
+    }
+  
+    .stat-card, .metric-card, .kpi-card { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover, .metric-card:hover, .kpi-card:hover { transform: translateY(-2px); box-shadow: 0 8px 25px rgba(0,0,0,0.15); } /* hover-lift */
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/></svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><span id="themeIcon">🌙</span><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><span>📥</span> Download PNG</button>
+      <button onclick="window.print()"><span>🖨️</span> Print / PDF</button>
+    </div>
+  </div>
+
+  <main id="main-content">
+    <div class="dashboard">
+      <header class="dash-header">
+        <h1>Analytics Dashboard</h1>
+        <p>Real-time performance metrics</p>
+      </header>
+
+      <section class="kpi-grid" role="region" aria-label="Key metrics">
+        <div class="kpi" role="group" aria-label="Active Users: 8,547">
+          <div class="kpi-label">Active Users</div>
+          <div class="kpi-value" data-count="8547">8,547</div>
+          <div class="kpi-change up">↑ 12.5% from last month</div>
+        </div>
+        <div class="kpi" role="group" aria-label="Revenue: $142K">
+          <div class="kpi-label">Monthly Revenue</div>
+          <div class="kpi-value" data-count="142" data-prefix="$" data-suffix="K">$142K</div>
+          <div class="kpi-change up">↑ 8.2% from last month</div>
+        </div>
+        <div class="kpi" role="group" aria-label="Churn Rate: 3.2%">
+          <div class="kpi-label">Churn Rate</div>
+          <div class="kpi-value" data-count="3.2" data-suffix="%">3.2%</div>
+          <div class="kpi-change down">↑ 0.4% from last month</div>
+        </div>
+        <div class="kpi" role="group" aria-label="Uptime: 96.8%">
+          <div class="kpi-label">System Uptime</div>
+          <div class="kpi-value" data-count="96.8" data-suffix="%">96.8%</div>
+          <div class="kpi-change up">↑ 0.3% from last month</div>
+        </div>
+      </section>
+
+      <section class="charts-row" aria-label="Charts">
+        <div class="chart-card" role="img" aria-label="Revenue growth line chart">
+          <h3>Revenue Growth</h3>
+          <p class="chart-sub">Last 12 months</p>
+          <div class="sr-only">Revenue by month: Jan $98K, Feb $102K, Mar $108K, Apr $115K, May $121K, Jun $128K, Jul $124K, Aug $132K, Sep $138K, Oct $135K, Nov $142K, Dec $142K.</div>
+          <div class="chart-wrap"><canvas id="revenueChart"></canvas></div>
+        </div>
+        <div class="chart-card" role="img" aria-label="User acquisition doughnut chart">
+          <h3>User Acquisition</h3>
+          <p class="chart-sub">Current month breakdown</p>
+          <div class="sr-only">Organic: 45%. Paid Ads: 28%. Referrals: 15%. Direct: 12%.</div>
+          <div class="chart-wrap"><canvas id="acquisitionChart"></canvas></div>
+        </div>
+      </section>
+
+      <section class="bottom-row" aria-label="Activity and features">
+        <div class="bottom-card">
+          <h3>Recent Activity</h3>
+          <div class="activity-item"><div class="activity-dot"></div><div class="activity-text"><h4>New user registration</h4><p>sarah.chen@example.com</p></div><span class="activity-time">2m ago</span></div>
+          <div class="activity-item"><div class="activity-dot" style="background:var(--positive)"></div><div class="activity-text"><h4>Payment received</h4><p>$299 annual — Acme Corp</p></div><span class="activity-time">15m ago</span></div>
+          <div class="activity-item"><div class="activity-dot" style="background:var(--text-secondary)"></div><div class="activity-text"><h4>Maintenance complete</h4><p>Server cluster updated</p></div><span class="activity-time">1h ago</span></div>
+          <div class="activity-item"><div class="activity-dot" style="background:var(--warning)"></div><div class="activity-text"><h4>Security alert</h4><p>Failed logins from unknown IP</p></div><span class="activity-time">3h ago</span></div>
+        </div>
+
+        <div class="bottom-card">
+          <h3>Top Features</h3>
+          <table aria-label="Feature usage and growth">
+            <thead><tr><th>Feature</th><th>Usage</th><th>Growth</th></tr></thead>
+            <tbody>
+              <tr><td>Analytics Dashboard</td><td>89.2%</td><td><span class="badge up">+5.1%</span></td></tr>
+              <tr><td>API Integration</td><td>76.8%</td><td><span class="badge up">+12.3%</span></td></tr>
+              <tr><td>Team Collaboration</td><td>68.4%</td><td><span class="badge up">+8.7%</span></td></tr>
+              <tr><td>Mobile App</td><td>54.6%</td><td><span class="badge down">-2.1%</span></td></tr>
+              <tr><td>Reporting Tools</td><td>43.2%</td><td><span class="badge up">+15.8%</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    var revenueChart, acquisitionChart;
+
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return; el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), dur = 1000;
+        (function tick(now) { var p = Math.min((now - start) / dur, 1), e = 1 - Math.pow(1 - p, 3), cur = target * e; el.textContent = prefix + (target % 1 !== 0 ? cur.toFixed(1) : Math.round(cur)).toLocaleString() + suffix; if (p < 1) requestAnimationFrame(tick); })(start);
+      });
+    }
+    setTimeout(animateCounters, 300);
+
+    function getColors() {
+      var s = getComputedStyle(document.documentElement);
+      return { text: s.getPropertyValue('--text').trim(), sub: s.getPropertyValue('--text-secondary').trim(), border: s.getPropertyValue('--border').trim(), surface: s.getPropertyValue('--surface').trim(), accent: s.getPropertyValue('--accent').trim(), accent2: s.getPropertyValue('--accent-secondary').trim(), positive: s.getPropertyValue('--positive').trim(), warning: s.getPropertyValue('--warning').trim() };
+    }
+    function getCanvas(id) { return document.getElementById(id); }
+
+    function buildCharts() {
+      var c = getColors();
+      Chart.defaults.color = c.sub; 
+      Chart.defaults.borderColor = 'transparent';
+      Chart.defaults.animation = false;      var tt = { backgroundColor: c.surface, titleColor: c.text, bodyColor: c.text, borderColor: c.border, borderWidth: 1, padding: 12, cornerRadius: 8, titleFont: { size: 14 }, bodyFont: { size: 13 } };
+
+      try { if (revenueChart) revenueChart.destroy(); } catch(e) {}
+      try { if (acquisitionChart) acquisitionChart.destroy(); } catch(e) {}
+
+      // Use explicit colors for better reliability
+      var accentColor = '#3b82f6';
+      var accent2Color = '#8b5cf6';
+      var positiveColor = '#10b981';
+      var warningColor = '#f59e0b';
+
+      var rc = getCanvas('revenueChart'), ctx = rc.getContext('2d');
+      var grad = ctx.createLinearGradient(0, 0, 0, 320); 
+      grad.addColorStop(0, 'rgba(59, 130, 246, 0.3)'); 
+      grad.addColorStop(1, 'rgba(59, 130, 246, 0)');
+      
+      revenueChart = new Chart(rc, {
+        type: 'line',
+        data: { labels: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+          datasets: [{ 
+            label: 'Revenue ($K)', 
+            data: [98,102,108,115,121,128,124,132,138,135,142,142], 
+            borderColor: accentColor, 
+            backgroundColor: grad, 
+            borderWidth: 3, 
+            fill: true, 
+            tension: 0.4, 
+            pointRadius: 3, 
+            pointHoverRadius: 8, 
+            pointBackgroundColor: accentColor,
+            pointBorderColor: '#ffffff',
+            pointBorderWidth: 2
+          }] },
+        options: { 
+          responsive: true, 
+          maintainAspectRatio: false, 
+          layout: { padding: { top: 20, right: 20, bottom: 20, left: 20 } },
+          plugins: { 
+            tooltip: { enabled: true, mode: 'index', intersect: false, ...tt, callbacks: { label: function(ctx) { return '$' + ctx.parsed.y + 'K'; } } }, 
+            legend: { display: false }
+          },
+          scales: { 
+            y: { beginAtZero: false, grid: { color: c.border }, ticks: { color: c.sub, font: { size: 14 }, callback: function(v) { return '$' + v + 'K'; } }, border: { display: false } }, 
+            x: { grid: { display: false }, ticks: { color: c.sub, font: { size: 14 } }, border: { display: false } } 
+          },
+          interaction: { intersect: false, mode: 'index' } 
+        }
+      });
+
+      acquisitionChart = new Chart(getCanvas('acquisitionChart'), {
+        type: 'doughnut',
+        data: { 
+          labels: ['Organic', 'Paid Ads', 'Referrals', 'Direct'], 
+          datasets: [{ 
+            data: [45, 28, 15, 12], 
+            backgroundColor: [accentColor, accent2Color, positiveColor, warningColor], 
+            borderWidth: 2, 
+            borderColor: c.surface,
+            hoverOffset: 6 
+          }] 
+        },
+        options: { 
+          responsive: true, 
+          maintainAspectRatio: false, 
+          layout: { padding: 20 },
+          plugins: { 
+            tooltip: { enabled: true, ...tt, callbacks: { label: function(ctx) { return ctx.label + ': ' + ctx.parsed + '%'; } } }, 
+            legend: { position: 'bottom', labels: { color: c.text, font: { size: 14 }, usePointStyle: true, padding: 20 } } 
+          }, 
+          cutout: '60%' 
+        }
+      });
+    }
+
+    function onThemeChange() { 
+      requestAnimationFrame(function() {
+        setTimeout(buildCharts, 100); 
+      });
+    }
+    
+    // Ensure charts render after DOM is fully loaded
+    document.addEventListener('DOMContentLoaded', function() {
+      setTimeout(buildCharts, 500);
+    });
+    
+    // Fallback in case DOMContentLoaded already fired
+    if (document.readyState === 'loading') {
+      setTimeout(buildCharts, 800);
+    } else {
+      setTimeout(buildCharts, 300);
+    }
+
+    document.addEventListener('visibilitychange', function() {
+      if (!document.hidden) { setTimeout(buildCharts, 200); }
+    });
+
+    async function downloadImage() {
+      var m = document.querySelector('.viz-menu'); m.style.display = 'none';
+      try { var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } }); var a = document.createElement('a'); a.href = url; a.download = 'saas-dashboard.png'; a.click(); } catch(e) { console.error(e); }
+      m.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/slide-deck-demo.html
+++ b/claude/skills/visualize/examples/slide-deck-demo.html
@@ -1,0 +1,644 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Next-Gen Analytics Platform</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html.theme-dark { 
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; 
+      --border: rgba(255,255,255,0.08); --text: #EDEDED; --text-secondary: #888; 
+      --accent: #0ea5e9; --accent-secondary: #0284c7; 
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; 
+    }
+    html.theme-light { 
+      --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; 
+      --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; 
+      --accent: #0ea5e9; --accent-secondary: #0284c7; 
+      --positive: #059669; --negative: #e11d48; --warning: #d97706; 
+    }
+
+    body { 
+      font-family: 'Inter', -apple-system, sans-serif; 
+      background: var(--bg); color: var(--text); 
+      line-height: 1.6; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01'; 
+      scrollbar-gutter: stable;
+      letter-spacing: -0.011em; overflow: hidden; font-weight: 400;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+    
+    h1, h2, h3 { 
+      color: var(--text); letter-spacing: -0.03em; 
+      line-height: 1.05; font-weight: 700; 
+      text-wrap: balance;
+    }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 8px; }
+
+    .skip-link { 
+      position: absolute; top: -40px; left: 16px; padding: 8px 16px; 
+      background: var(--accent); color: #fff; text-decoration: none; 
+      border-radius: 8px; z-index: 10000; 
+    }
+    .skip-link:focus { top: 16px; }
+
+    @media (prefers-reduced-motion: reduce) { 
+      *, *::before, *::after { animation: none !important; transition: none !important; } 
+    }
+    @media print { 
+      body { background: #fff !important; color: #000 !important; overflow: visible; } 
+      .viz-menu, .theme-toggle, .slide-nav { display: none !important; } 
+      .slide { position: static !important; page-break-after: always; } 
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; } 
+    }
+
+    /* ===== VISIBLE THEME TOGGLE ===== */
+    .theme-toggle {
+      position: fixed; top: 16px; right: 16px; z-index: 9999;
+      width: 44px; height: 44px; border-radius: 8px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+      font-size: 20px;
+    }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* ===== MENU ===== */
+    .viz-menu { position: fixed; top: 16px; left: 16px; z-index: 9999; }
+    .viz-menu-toggle { 
+      width: 44px; height: 44px; border-radius: 8px; 
+      background: var(--surface); border: 1px solid var(--border); 
+      color: var(--text); cursor: pointer; display: flex; 
+      align-items: center; justify-content: center; 
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { 
+      position: absolute; top: 52px; left: 0; min-width: 160px; 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 8px; padding: 4px; 
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05); 
+      opacity: 0; visibility: hidden; transform: translateY(-4px); 
+      transition: all 0.15s; 
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button { 
+      width: 100%; padding: 8px 12px; border: none; border-radius: 8px; 
+      background: transparent; color: var(--text-secondary); font-size: 0.875rem; 
+      font-family: inherit; cursor: pointer; text-align: left; 
+      display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s; 
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+
+    /* Slides */
+    .slides-container { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+    .slide { 
+      position: absolute; top: 0; left: 0; width: 100vw; height: 100vh; 
+      display: flex; flex-direction: column; justify-content: center; align-items: center; 
+      padding: 48px; text-align: center; opacity: 0; visibility: hidden; 
+      pointer-events: none; transition: opacity 0.4s ease, visibility 0.4s; 
+    }
+    .slide.active { opacity: 1; visibility: visible; pointer-events: auto; }
+
+    /* Title slide with enhanced hero graphic */
+    .slide.title-slide { 
+      background: linear-gradient(135deg, var(--bg) 0%, #0d1117 50%, var(--bg) 100%);
+      position: relative;
+    }
+    .slide.title-slide::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+      background-image: 
+        radial-gradient(circle at 1px 1px, rgba(255,255,255,0.04) 1px, transparent 0),
+        linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(255,255,255,0.02) 1px, transparent 1px);
+      background-size: 32px 32px, 64px 64px, 64px 64px;
+      pointer-events: none;
+    }
+    .theme-light .slide.title-slide { 
+      background: linear-gradient(180deg, #f5f5f0 0%, #eeeee8 50%, #f5f5f0 100%);
+    }
+    .theme-light .slide.title-slide::before {
+      background-image: radial-gradient(circle at 1px 1px, rgba(0,0,0,0.06) 1px, transparent 0);
+      background-size: 24px 24px;
+    }
+    .slide.title-slide h1 { 
+      font-size: clamp(3.5rem, 10vw, 6rem); margin-bottom: 24px; 
+      letter-spacing: -0.04em; line-height: 1; font-weight: 700;
+      text-shadow: 0 0 60px rgba(59,130,246,0.3);
+    }
+    .slide.title-slide p { 
+      font-size: 1.75rem; color: var(--text-secondary); 
+      max-width: 700px; line-height: 1.4; margin-bottom: 32px; position: relative;
+    }
+    .slide.title-slide p::after {
+      content: ''; position: absolute; bottom: -16px; left: 50%; transform: translateX(-50%);
+      width: 80px; height: 1px; 
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    }
+    .slide.title-slide .meta { 
+      margin-top: 40px; font-size: 1rem; color: var(--text-secondary); font-weight: 500;
+    }
+
+    /* Analytics Hero Graphic */
+    .hero-graphic {
+      position: absolute; inset: 0; pointer-events: none; overflow: hidden;
+    }
+    .hero-graphic svg {
+      position: absolute; inset: 0; width: 100%; height: 100%; opacity:  0.5;
+    }
+
+    /* Section slide */
+    .slide.section-slide { 
+      background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #1e3a5f 100%);
+      position: relative;
+    }
+    .slide.section-slide::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+      background-image: linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px),
+                        linear-gradient(0deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+      background-size: 40px 40px; pointer-events: none;
+    }
+    .theme-light .slide.section-slide { 
+      background: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 50%, #dbeafe 100%);
+    }
+    .theme-light .slide.section-slide::before {
+      background-image: linear-gradient(90deg, rgba(0,0,0,0.05) 1px, transparent 1px),
+                        linear-gradient(0deg, rgba(0,0,0,0.05) 1px, transparent 1px);
+    }
+    .slide.section-slide h2 { 
+      font-size: clamp(3.5rem, 10vw, 6rem); color: #fff; 
+      letter-spacing: -0.04em; line-height: 1; font-weight: 700;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    .theme-light .slide.section-slide h2 {
+      color: #1e1b4b; text-shadow: none;
+    }
+    .slide.section-slide p { 
+      color: rgba(255,255,255,0.9); font-size: 1.5rem; 
+      max-width: 700px; margin-top: 24px; line-height: 1.4;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+    .theme-light .slide.section-slide p {
+      color: rgba(30,27,75,0.8); text-shadow: none;
+    }
+
+    /* Content slide with unique background accents */
+    .slide.content-slide { 
+      background: linear-gradient(135deg, var(--bg) 0%, #0d1117 50%, var(--bg) 100%);
+      position: relative;
+    }
+    .slide.content-slide::before {
+      content: ''; position: absolute; inset: 0;
+      background: radial-gradient(ellipse at var(--slide-position, 30% 20%), var(--slide-accent, var(--accent)) 0%, transparent 60%);
+      opacity:  0.5; pointer-events: none;
+    }
+    .theme-light .slide.content-slide { 
+      background: linear-gradient(180deg, #f5f5f0 0%, #eeeee8 50%, #f5f5f0 100%);
+    }
+    
+    /* Slide-specific accents */
+    .slide:nth-child(2) { --slide-accent: #8b5cf6; --slide-position: 70% 30%; }
+    .slide:nth-child(3) { --slide-accent: #ec4899; --slide-position: 20% 70%; }
+    .slide:nth-child(4) { --slide-accent: #10b981; --slide-position: 80% 70%; }
+    .slide:nth-child(5) { --slide-accent: #f59e0b; --slide-position: 50% 80%; }
+    .slide:nth-child(6) { --slide-accent: #06b6d4; --slide-position: 30% 20%; }
+    .slide:nth-child(7) { --slide-accent: #f43f5e; --slide-position: 70% 40%; }
+
+    .slide.content-slide h2 { 
+      font-size: clamp(2.5rem, 8vw, 4rem); margin-bottom: 40px; 
+      letter-spacing: -0.03em; line-height: 1.05; font-weight: 700;
+      text-wrap: balance;
+      }
+    .slide.content-slide p { 
+      color: var(--text-secondary); font-size: 1.25rem; 
+      max-width: 720px; margin-bottom: 48px; line-height: 1.5;
+    }
+
+    /* Stat grid */
+    .stat-grid { 
+      display: grid; grid-template-columns: repeat(3, 1fr); 
+      gap: 1px; background: var(--border); border-radius: 8px; 
+      overflow: hidden; max-width: 800px; width: 100%; 
+      border: 1px solid var(--border);
+    }
+    .theme-light .stat-grid { border: 1px solid var(--border); }
+    .stat-grid.cols-4 { grid-template-columns: repeat(4, 1fr); max-width: 1000px; }
+    .stat-cell { 
+      background: var(--surface); padding: 32px 24px; text-align: center; 
+      transition: all 0.2s ease;
+    }
+    .stat-cell:hover { background: var(--surface-hover); }
+    .stat-cell .num { 
+      font-size: 5rem; font-weight: 700; letter-spacing: -0.05em; 
+      color: var(--text); display: block; margin-bottom: 12px; 
+      line-height: 1; text-shadow: 0 0 60px rgba(59,130,246,0.4);
+    }
+    .stat-cell .label { 
+      font-size: 0.75rem; color: var(--text-secondary); 
+      text-transform: uppercase; letter-spacing: 0.1em; 
+      font-weight: 500; line-height: 1.3;
+    }
+
+    /* Feature list */
+    .feature-list { 
+      list-style: none; text-align: left; max-width: 560px; width: 100%; 
+    }
+    .feature-list li { 
+      display: flex; align-items: center; gap: 12px; padding: 12px 0; 
+      font-size: 1.0625rem; border-bottom: 1px solid var(--border); 
+      transition: all 0.2s ease;
+    }
+    .feature-list li:hover {
+      color: var(--text); transform: translateX(4px);
+    }
+    .feature-list li:last-child { border-bottom: none; }
+    .feature-list .dot { 
+      width: 8px; height: 8px; border-radius: 50%; 
+      background: var(--accent); flex-shrink: 0; 
+    }
+
+    /* Chart */
+    .chart-card { 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 8px; padding: 24px; max-width: 600px; 
+      width: 100%; transition: box-shadow 0.2s ease;
+    }
+    .chart-card:hover {
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+    }
+    .theme-light .chart-card { border: 1px solid var(--border); }
+    .theme-light .chart-card:hover { box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08); }
+    .chart-wrap { height: 320px; position: relative; }
+
+    /* Navigation */
+    .slide-nav { 
+      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 24px; padding: 8px 16px; display: flex; 
+      align-items: center; gap: 12px; z-index: 1000; 
+    }
+    .nav-btn { 
+      width: 32px; height: 32px; border: none; border-radius: 50%; 
+      background: transparent; color: var(--text); cursor: pointer; 
+      display: flex; align-items: center; justify-content: center; 
+    }
+    .nav-btn:hover { background: var(--surface-hover); }
+    .nav-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+    .slide-counter { 
+      font-size: 0.875rem; color: var(--text); min-width: 48px; 
+      text-align: center; font-variant-numeric: tabular-nums; font-weight: 600; 
+    }
+    .progress-bar { 
+      position: fixed; top: 0; left: 0; right: 0; height: 3px; 
+      background: var(--border); z-index: 1000; 
+    }
+    .progress-fill { 
+      height: 100%; background: var(--accent); transition: width 0.4s; 
+    }
+
+    /* Keyboard navigation hints */
+    .keyboard-hint {
+      position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%);
+      font-size: 0.75rem; color: var(--text-secondary);
+      display: flex; align-items: center; gap: 8px;
+      opacity: 0; animation: fadeIn 1s ease 2s both;
+    }
+    .keyboard-hint kbd {
+      background: var(--surface-hover); border: 1px solid var(--border);
+      border-radius: 4px; padding: 2px 6px; font-size: 0.625rem;
+      color: var(--text); font-family: inherit;
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+    @media (max-width: 768px) {
+      .slide { padding: 24px; }
+      .stat-grid { grid-template-columns: repeat(2, 1fr); }
+      .stat-grid.cols-4 { grid-template-columns: repeat(2, 1fr); }
+      .stat-cell { padding: 24px 16px; }
+      .stat-cell .num { font-size: 3rem; }
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- VISIBLE THEME TOGGLE -->
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <span id="themeIcon">🌙</span>
+  </button>
+
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="downloadImage()"><span>📥</span> Download PNG</button>
+      <button onclick="window.print()"><span>🖨️</span> Print / PDF</button>
+    </div>
+  </div>
+
+  <main id="main-content" role="main">
+    <div class="progress-bar"><div class="progress-fill" id="progressFill"></div></div>
+    <div id="slideAnnounce" aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);"></div>
+
+    <div class="slides-container" id="slidesContainer" role="region" aria-roledescription="slide deck">
+
+      <section class="slide title-slide" role="group" aria-roledescription="slide" aria-label="Title">
+        <!-- Enhanced analytics hero graphic -->
+        <div class="hero-graphic">
+          <svg viewBox="0 0 1200 800" fill="none">
+            <!-- Main dashboard container -->
+            <rect x="200" y="150" width="800" height="500" rx="12" stroke="var(--accent)" stroke-width="1.2" opacity="0.6"/>
+            
+            <!-- Header bar -->
+            <rect x="220" y="170" width="760" height="40" rx="6" fill="var(--accent)" opacity="0.2"/>
+            <circle cx="250" cy="190" r="4" fill="var(--accent)" opacity="0.6"/>
+            <circle cx="270" cy="190" r="4" fill="var(--accent-secondary)" opacity="0.6"/>
+            <circle cx="290" cy="190" r="4" fill="var(--warning)" opacity="0.6"/>
+            
+            <!-- Charts and graphs -->
+            <!-- Line chart -->
+            <rect x="240" y="240" width="340" height="180" rx="8" stroke="var(--accent)" stroke-width="0.8" opacity="0.5"/>
+            <path d="M260 380 L300 340 L340 300 L380 280 L420 250 L460 220 L500 200 L540 180" stroke="var(--accent)" stroke-width="2" fill="none" opacity="0.7"/>
+            <path d="M260 380 L300 360 L340 320 L380 300 L420 280 L460 260 L500 240 L540 220" stroke="var(--accent-secondary)" stroke-width="2" fill="none" opacity="0.7"/>
+            
+            <!-- Bar chart -->
+            <rect x="620" y="240" width="320" height="180" rx="8" stroke="var(--accent)" stroke-width="0.8" opacity="0.5"/>
+            <rect x="640" y="360" width="40" height="40" fill="var(--accent)" opacity="0.5"/>
+            <rect x="700" y="340" width="40" height="60" fill="var(--accent)" opacity="0.6"/>
+            <rect x="760" y="320" width="40" height="80" fill="var(--accent)" opacity="0.7"/>
+            <rect x="820" y="300" width="40" height="100" fill="var(--accent)" opacity="0.8"/>
+            <rect x="880" y="280" width="40" height="120" fill="var(--accent)" opacity="0.9"/>
+            
+            <!-- KPI cards -->
+            <rect x="240" y="450" width="140" height="80" rx="6" stroke="var(--positive)" stroke-width="0.8" opacity="0.5"/>
+            <rect x="420" y="450" width="140" height="80" rx="6" stroke="var(--warning)" stroke-width="0.8" opacity="0.5"/>
+            <rect x="600" y="450" width="140" height="80" rx="6" stroke="var(--accent-secondary)" stroke-width="0.8" opacity="0.5"/>
+            <rect x="780" y="450" width="140" height="80" rx="6" stroke="var(--negative)" stroke-width="0.8" opacity="0.5"/>
+            
+            <!-- Data points -->
+            <circle cx="320" cy="320" r="3" fill="var(--accent)" opacity="0.8"/>
+            <circle cx="400" cy="280" r="3" fill="var(--accent)" opacity="0.8"/>
+            <circle cx="480" cy="220" r="3" fill="var(--accent)" opacity="0.8"/>
+            <circle cx="520" cy="200" r="3" fill="var(--accent)" opacity="0.8"/>
+            
+            <!-- Connection lines -->
+            <line x1="100" y1="400" x2="1100" y2="400" stroke="var(--accent)" stroke-width="0.5" opacity="0.3" stroke-dasharray="4 8"/>
+            <line x1="600" y1="100" x2="600" y2="700" stroke="var(--accent)" stroke-width="0.5" opacity="0.3" stroke-dasharray="4 8"/>
+          </svg>
+        </div>
+        
+        <div class="keyboard-hint">
+          <span>Navigate:</span>
+          <kbd>←</kbd>
+          <kbd>→</kbd>
+          <kbd>Space</kbd>
+        </div>
+        <h1>Next-Gen Analytics</h1>
+        <p>Revolutionizing data insights for modern businesses</p>
+        <div class="meta">Product Launch · 2026</div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="The Challenge">
+        <h2>The Challenge</h2>
+        <p>Businesses struggle with fragmented data, complex tools, and delayed insights</p>
+        <div class="stat-grid">
+          <div class="stat-cell"><span class="num" data-count="73" data-suffix="%">73%</span><span class="label">Overwhelmed by data</span></div>
+          <div class="stat-cell"><span class="num" data-count="48">48</span><span class="label">Hours per report</span></div>
+          <div class="stat-cell"><span class="num" data-count="65" data-suffix="%">65%</span><span class="label">Decide without data</span></div>
+        </div>
+      </section>
+
+      <section class="slide section-slide" role="group" aria-roledescription="slide" aria-label="Our Solution">
+        <h2>Our Solution</h2>
+        <p>A unified platform that transforms complex data into actionable insights in real-time</p>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Key Features">
+        <h2>Key Features</h2>
+        <ul class="feature-list">
+          <li><span class="dot"></span>Real-time data processing and visualization</li>
+          <li><span class="dot"></span>AI-powered insights and recommendations</li>
+          <li><span class="dot"></span>No-code dashboard builder</li>
+          <li><span class="dot"></span>100+ data source integrations</li>
+        </ul>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Market Opportunity">
+        <h2>Market Opportunity</h2>
+        <p>Global business analytics: unprecedented growth</p>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 32px; max-width: 800px; width: 100%; align-items: center;">
+          <div class="stat-grid" style="grid-template-columns: 1fr;">
+            <div class="stat-cell"><span class="num" data-count="420" data-prefix="$" data-suffix="B">$420B</span><span class="label">Market by 2030</span></div>
+            <div class="stat-cell"><span class="num" data-count="15.3" data-suffix="%">15.3%</span><span class="label">CAGR</span></div>
+          </div>
+          <div class="chart-card" role="img" aria-label="Market growth chart">
+            <div class="chart-wrap"><canvas id="marketChart"></canvas></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Traction">
+        <h2>Our Traction</h2>
+        <p>Rapid growth across all key metrics in year one</p>
+        <div class="stat-grid cols-4">
+          <div class="stat-cell"><span class="num" data-count="150" data-suffix="+">150+</span><span class="label">Customers</span></div>
+          <div class="stat-cell"><span class="num" data-count="2.4" data-prefix="$" data-suffix="M">$2.4M</span><span class="label">ARR</span></div>
+          <div class="stat-cell"><span class="num" data-count="98" data-suffix="%">98%</span><span class="label">Satisfaction</span></div>
+          <div class="stat-cell"><span class="num" data-count="45" data-suffix="%">45%</span><span class="label">MoM Growth</span></div>
+        </div>
+      </section>
+
+      <section class="slide section-slide" role="group" aria-roledescription="slide" aria-label="What's Next">
+        <h2>What's Next</h2>
+        <p>Global expansion, AI v2, and mobile launch in Q2 2026</p>
+      </section>
+
+      <section class="slide title-slide" role="group" aria-roledescription="slide" aria-label="Thank You">
+        <h1 style="font-size: clamp(3.5rem, 10vw, 6rem); font-weight: 700; letter-spacing: -0.04em;">Thank You</h1>
+        <p style="font-size: 1.5rem; margin-bottom: 24px;">Ready to transform your data into insights?</p>
+        <div class="meta" style="font-size: 1.125rem; font-weight: 500;">hello@analyticsplatform.com</div>
+      </section>
+    </div>
+
+    <nav class="slide-nav" aria-label="Slide navigation">
+      <button class="nav-btn" id="prevBtn" onclick="prevSlide()" aria-label="Previous">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="15,18 9,12 15,6"/>
+        </svg>
+      </button>
+      <span class="slide-counter" id="slideCounter">1 / 8</span>
+      <button class="nav-btn" id="nextBtn" onclick="nextSlide()" aria-label="Next">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="9,18 15,12 9,6"/>
+        </svg>
+      </button>
+    </nav>
+  </main>
+
+  <script>
+    var currentSlide = 0, totalSlides = 8, marketChart;
+
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    function updateSlide() {
+      var slides = document.querySelectorAll('.slide');
+      slides.forEach(function(s, i) { s.classList.toggle('active', i === currentSlide); });
+      document.getElementById('slideCounter').textContent = (currentSlide + 1) + ' / ' + totalSlides;
+      document.getElementById('progressFill').style.width = ((currentSlide + 1) / totalSlides * 100) + '%';
+      document.getElementById('prevBtn').disabled = currentSlide === 0;
+      document.getElementById('nextBtn').disabled = currentSlide === totalSlides - 1;
+      var label = slides[currentSlide].getAttribute('aria-label') || ('Slide ' + (currentSlide + 1));
+      document.getElementById('slideAnnounce').textContent = label;
+      setTimeout(function() { animateCounters(slides[currentSlide]); }, 200);
+    }
+    function nextSlide() { if (currentSlide < totalSlides - 1) { currentSlide++; updateSlide(); } }
+    function prevSlide() { if (currentSlide > 0) { currentSlide--; updateSlide(); } }
+
+    document.addEventListener('keydown', function(e) {
+      if (document.getElementById('vizMenuDropdown').classList.contains('open')) return;
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { e.preventDefault(); prevSlide(); }
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === ' ' || e.key === 'Enter') { e.preventDefault(); nextSlide(); }
+    });
+    var touchX = 0;
+    document.addEventListener('touchstart', function(e) { touchX = e.changedTouches[0].screenX; });
+    document.addEventListener('touchend', function(e) { var d = touchX - e.changedTouches[0].screenX; if (Math.abs(d) > 50) { d > 0 ? nextSlide() : prevSlide(); } });
+    document.addEventListener('click', function(e) { if (e.target.closest('.viz-menu,.theme-toggle,.slide-nav,button,canvas')) return; e.clientX < window.innerWidth / 3 ? prevSlide() : nextSlide(); });
+
+    function animateCounters(container) {
+      (container || document).querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return; el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), dur = 1000;
+        (function tick(now) { 
+          var p = Math.min((now - start) / dur, 1), e = 1 - Math.pow(1 - p, 3), cur = target * e; 
+          el.textContent = prefix + (target % 1 !== 0 ? cur.toFixed(1) : Math.round(cur)).toLocaleString() + suffix; 
+          if (p < 1) requestAnimationFrame(tick); 
+        })(start);
+      });
+    }
+
+    function getColors() { 
+      var s = getComputedStyle(document.documentElement); 
+      return { 
+        text: s.getPropertyValue('--text').trim(), 
+        sub: s.getPropertyValue('--text-secondary').trim(), 
+        border: s.getPropertyValue('--border').trim(), 
+        surface: s.getPropertyValue('--surface').trim(), 
+        accent: s.getPropertyValue('--accent').trim() 
+      }; 
+    }
+    function getCanvas(id) { return document.getElementById(id); }
+
+    function buildChart() {
+      var c = getColors();
+      Chart.defaults.color = c.sub;
+      Chart.defaults.animation = false;
+      
+      try { if (marketChart) marketChart.destroy(); } catch(e) {}
+      var cv = getCanvas('marketChart'); if (!cv) return;
+      
+      var accentColor = '#3b82f6';
+      var ctx = cv.getContext('2d');
+      var g = ctx.createLinearGradient(0, 0, 0, 320);
+      g.addColorStop(0, 'rgba(59, 130, 246, 0.3)');
+      g.addColorStop(1, 'rgba(59, 130, 246, 0)');
+      
+      marketChart = new Chart(cv, {
+        type: 'line',
+        data: { 
+          labels: ['2020','2022','2024','2026','2028','2030'], 
+          datasets: [{ 
+            data: [195,245,305,340,380,420], 
+            borderColor: accentColor, 
+            backgroundColor: g, 
+            borderWidth: 3, 
+            fill: true, 
+            tension: 0.4, 
+            pointRadius: 0, 
+            pointHoverRadius: 8, 
+            pointBackgroundColor: accentColor 
+          }] 
+        },
+        options: { 
+          responsive: true, 
+          maintainAspectRatio: false, 
+          layout: { padding: { top: 20, right: 20, bottom: 20, left: 20 } },
+          plugins: { 
+            tooltip: { 
+              enabled: true, 
+              mode: 'index', 
+              intersect: false, 
+              backgroundColor: c.surface, 
+              titleColor: c.text, 
+              bodyColor: c.text, 
+              borderColor: c.border, 
+              borderWidth: 1, 
+              padding: 12, 
+              cornerRadius: 8, 
+              callbacks: { label: function(ctx) { return '$' + ctx.parsed.y + 'B'; } } 
+            }, 
+            legend: { display: false } 
+          },
+          scales: { 
+            y: { 
+              grid: { color: c.border }, 
+              ticks: { color: c.sub, font: { size: 14 }, callback: function(v) { return '$'+v+'B'; } }, 
+              border: { display: false } 
+            }, 
+            x: { 
+              grid: { display: false }, 
+              ticks: { color: c.sub, font: { size: 14 } }, 
+              border: { display: false } 
+            } 
+          },
+          interaction: { intersect: false, mode: 'index' } 
+        }
+      });
+    }
+    function onThemeChange() { setTimeout(buildChart, 50); }
+    updateSlide(); setTimeout(buildChart, 300);
+
+    async function downloadImage() {
+      var els = ['.viz-menu','.theme-toggle','.slide-nav'].map(function(s){return document.querySelector(s);});
+      els.forEach(function(el){if(el)el.style.display='none';});
+      try { 
+        var url = await htmlToImage.toPng(document.querySelectorAll('.slide')[currentSlide], { 
+          quality: 1, pixelRatio: 2, width: 1920, height: 1080 
+        }); 
+        var a = document.createElement('a'); 
+        a.href = url; 
+        a.download = 'slide-'+(currentSlide+1)+'.png'; 
+        a.click(); 
+      } catch(e) { console.error(e); }
+      els.forEach(function(el){if(el)el.style.display='';});
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/startup-pitch-deck.html
+++ b/claude/skills/visualize/examples/startup-pitch-deck.html
@@ -1,0 +1,774 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EcoFlow - AI-Powered Sustainability</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html.theme-dark { 
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; 
+      --border: rgba(255,255,255,0.08); --text: #EDEDED; --text-secondary: #888; 
+      --accent: #8b5cf6; --accent-secondary: #7c3aed; 
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; 
+    }
+    html.theme-light { 
+      --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; 
+      --border: rgba(0,0,0,0.08); --text: #0f172a; --text-secondary: #64748b; 
+      --accent: #8b5cf6; --accent-secondary: #7c3aed; 
+      --positive: #059669; --negative: #e11d48; --warning: #d97706; 
+    }
+
+    body { 
+      font-family: 'Inter', -apple-system, sans-serif; 
+      background: var(--bg); color: var(--text); 
+      line-height: 1.6; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01'; 
+      scrollbar-gutter: stable;
+      letter-spacing: -0.011em; overflow: hidden; font-weight: 400;
+    }
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+        color-mix(in srgb, var(--accent), transparent 92%), transparent);
+    }
+    
+    h1, h2, h3 { 
+      color: var(--text); letter-spacing: -0.03em; 
+      line-height: 1.05; font-weight: 700; 
+      text-wrap: balance;
+    }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 8px; }
+
+    .skip-link { 
+      position: absolute; top: -40px; left: 16px; padding: 8px 16px; 
+      background: var(--accent); color: #fff; text-decoration: none; 
+      border-radius: 8px; z-index: 10000; 
+    }
+    .skip-link:focus { top: 16px; }
+
+    @media (prefers-reduced-motion: reduce) { 
+      *, *::before, *::after { animation: none !important; transition: none !important; } 
+    }
+    @media print { 
+      body { background: #fff !important; color: #000 !important; overflow: visible; } 
+      .viz-menu, .theme-toggle, .slide-nav { display: none !important; } 
+      .slide { position: static !important; page-break-after: always; } 
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; } 
+    }
+
+    /* ===== VISIBLE THEME TOGGLE ===== */
+    .theme-toggle {
+      position: fixed; top: 16px; right: 16px; z-index: 9999;
+      width: 44px; height: 44px; border-radius: 8px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+      font-size: 20px;
+    }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* ===== MENU ===== */
+    .viz-menu { position: fixed; top: 16px; left: 16px; z-index: 9999; }
+    .viz-menu-toggle { 
+      width: 44px; height: 44px; border-radius: 8px; 
+      background: var(--surface); border: 1px solid var(--border); 
+      color: var(--text); cursor: pointer; display: flex; 
+      align-items: center; justify-content: center; 
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { 
+      position: absolute; top: 52px; left: 0; min-width: 160px; 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 8px; padding: 4px; 
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05); 
+      opacity: 0; visibility: hidden; transform: translateY(-4px); 
+      transition: all 0.15s; 
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button { 
+      width: 100%; padding: 8px 12px; border: none; border-radius: 8px; 
+      background: transparent; color: var(--text-secondary); font-size: 0.875rem; 
+      font-family: inherit; cursor: pointer; text-align: left; 
+      display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s; 
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+
+    .slides-container { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+    .slide { 
+      position: absolute; top: 0; left: 0; width: 100vw; height: 100vh; 
+      display: flex; flex-direction: column; justify-content: center; align-items: center; 
+      padding: 48px; text-align: center; opacity: 0; visibility: hidden; 
+      pointer-events: none; transition: opacity 0.4s ease, visibility 0.4s; 
+    }
+    .slide.active { opacity: 1; visibility: visible; pointer-events: auto; }
+
+    /* Title slide with sustainability visual */
+    .slide.title-slide { 
+      background: linear-gradient(135deg, var(--bg) 0%, #0d1117 50%, var(--bg) 100%);
+      position: relative;
+    }
+    .slide.title-slide::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+      background-image: 
+        radial-gradient(circle at 1px 1px, rgba(255,255,255,0.04) 1px, transparent 0),
+        linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(255,255,255,0.02) 1px, transparent 1px);
+      background-size: 32px 32px, 64px 64px, 64px 64px;
+      pointer-events: none;
+    }
+    .theme-light .slide.title-slide { 
+      background: linear-gradient(180deg, #f5f5f0 0%, #eeeee8 50%, #f5f5f0 100%);
+    }
+    .theme-light .slide.title-slide::before {
+      background-image: radial-gradient(circle at 1px 1px, rgba(0,0,0,0.06) 1px, transparent 0);
+      background-size: 24px 24px;
+    }
+    .slide.title-slide h1 { 
+      font-size: clamp(4rem, 12vw, 8rem); margin-bottom: 24px; 
+      letter-spacing: -0.04em; line-height: 1; font-weight: 700;
+      text-shadow: 0 0 60px rgba(16,185,129,0.3);
+    }
+    .slide.title-slide p { 
+      font-size: 1.75rem; color: var(--text-secondary); 
+      max-width: 700px; line-height: 1.4; margin-bottom: 32px; position: relative;
+    }
+    .slide.title-slide p::after {
+      content: ''; position: absolute; bottom: -16px; left: 50%; transform: translateX(-50%);
+      width: 80px; height: 1px; 
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    }
+    .slide.title-slide .meta { 
+      margin-top: 40px; font-size: 1rem; color: var(--text-secondary); font-weight: 500;
+    }
+
+    /* Enhanced EcoFlow hero visual */
+    .hero-visual {
+      position: absolute; inset: 0; pointer-events: none; overflow: hidden;
+    }
+    .hero-visual svg {
+      position: absolute; inset: 0; width: 100%; height: 100%; opacity:  0.5;
+    }
+
+    /* Section slide */
+    .slide.section-slide { 
+      background: linear-gradient(135deg, #065f46 0%, #059669 50%, #047857 100%);
+      position: relative;
+    }
+    .slide.section-slide::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+      background-image: linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px),
+                        linear-gradient(0deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+      background-size: 40px 40px; pointer-events: none;
+    }
+    .theme-light .slide.section-slide { 
+      background: linear-gradient(135deg, #dcfce7 0%, #bbf7d0 50%, #d1fae5 100%);
+    }
+    .theme-light .slide.section-slide::before {
+      background-image: linear-gradient(90deg, rgba(0,0,0,0.05) 1px, transparent 1px),
+                        linear-gradient(0deg, rgba(0,0,0,0.05) 1px, transparent 1px);
+    }
+    .slide.section-slide h2 { 
+      font-size: clamp(3.5rem, 10vw, 6rem); color: #fff; 
+      letter-spacing: -0.04em; line-height: 1; font-weight: 700;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    .theme-light .slide.section-slide h2 {
+      color: #065f46; text-shadow: none;
+    }
+    .slide.section-slide p { 
+      color: rgba(255,255,255,0.9); font-size: 1.5rem; 
+      max-width: 700px; margin-top: 24px; line-height: 1.4;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+    .theme-light .slide.section-slide p {
+      color: rgba(6,95,70,0.8); text-shadow: none;
+    }
+
+    /* Content slide with unique background accents */
+    .slide.content-slide { 
+      background: linear-gradient(135deg, var(--bg) 0%, #0d1117 50%, var(--bg) 100%);
+      position: relative;
+    }
+    .slide.content-slide::before {
+      content: ''; position: absolute; inset: 0;
+      background: radial-gradient(ellipse at var(--slide-position, 30% 20%), var(--slide-accent, var(--accent)) 0%, transparent 60%);
+      opacity:  0.5; pointer-events: none;
+    }
+    .theme-light .slide.content-slide { 
+      background: linear-gradient(180deg, #f5f5f0 0%, #eeeee8 50%, #f5f5f0 100%);
+    }
+    
+    /* Slide-specific accents */
+    .slide:nth-child(2) { --slide-accent: #f43f5e; --slide-position: 70% 30%; }
+    .slide:nth-child(3) { --slide-accent: #10b981; --slide-position: 20% 70%; }
+    .slide:nth-child(4) { --slide-accent: #06b6d4; --slide-position: 80% 70%; }
+    .slide:nth-child(5) { --slide-accent: #f59e0b; --slide-position: 50% 80%; }
+    .slide:nth-child(6) { --slide-accent: #8b5cf6; --slide-position: 30% 20%; }
+    .slide:nth-child(7) { --slide-accent: #ec4899; --slide-position: 70% 40%; }
+    .slide:nth-child(8) { --slide-accent: #3b82f6; --slide-position: 40% 60%; }
+    .slide:nth-child(9) { --slide-accent: #10b981; --slide-position: 60% 30%; }
+    .slide:nth-child(10) { --slide-accent: #06b6d4; --slide-position: 30% 70%; }
+
+    .slide.content-slide h2 { 
+      font-size: clamp(2.5rem, 8vw, 4rem); margin-bottom: 40px; 
+      letter-spacing: -0.03em; line-height: 1.05; font-weight: 700;
+      text-wrap: balance;
+      }
+    .slide.content-slide p { 
+      color: var(--text-secondary); font-size: 1.25rem; 
+      max-width: 720px; margin-bottom: 48px; line-height: 1.5;
+    }
+
+    .stat-grid { 
+      display: grid; grid-template-columns: repeat(3, 1fr); 
+      gap: 1px; background: var(--border); border-radius: 8px; 
+      overflow: hidden; max-width: 800px; width: 100%; 
+      border: 1px solid var(--border);
+    }
+    .theme-light .stat-grid { border: 1px solid var(--border); }
+    .stat-grid.cols-4 { grid-template-columns: repeat(4, 1fr); max-width: 1000px; }
+    .stat-cell { 
+      background: var(--surface); padding: 32px 24px; text-align: center; 
+      transition: all 0.2s ease;
+    }
+    .stat-cell:hover { background: var(--surface-hover); }
+    .stat-cell .num { 
+      font-size: 5rem; font-weight: 700; letter-spacing: -0.05em; 
+      color: var(--text); display: block; margin-bottom: 12px; 
+      line-height: 1; text-shadow: 0 0 60px rgba(16,185,129,0.4);
+    }
+    .stat-cell .label { 
+      font-size: 0.75rem; color: var(--text-secondary); 
+      text-transform: uppercase; letter-spacing: 0.1em; 
+      font-weight: 500; line-height: 1.3;
+    }
+
+    .problem-list { 
+      list-style: none; text-align: left; max-width: 560px; width: 100%; 
+    }
+    .problem-list li { 
+      display: flex; align-items: flex-start; gap: 12px; padding: 12px 0; 
+      font-size: 1rem; color: var(--text-secondary); border-bottom: 1px solid var(--border);
+      transition: all 0.2s ease;
+    }
+    .problem-list li:hover {
+      color: var(--text); transform: translateX(4px);
+    }
+    .problem-list li:last-child { border-bottom: none; }
+    .problem-list .icon { 
+      width: 20px; height: 20px; color: var(--negative); 
+      flex-shrink: 0; margin-top: 2px; 
+    }
+
+    .solution-grid { 
+      display: grid; grid-template-columns: repeat(2, 1fr); 
+      gap: 16px; max-width: 700px; width: 100%; 
+    }
+    .solution-card { 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 8px; padding: 32px 24px; text-align: left; 
+      transition: all 0.2s ease;
+    }
+    .solution-card:hover {
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+      border-color: var(--accent);
+    }
+    .theme-light .solution-card { border: 1px solid var(--border); }
+    .theme-light .solution-card:hover { 
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08); 
+      border-color: var(--accent);
+    }
+    .solution-card h4 { 
+      font-size: 0.875rem; font-weight: 600; margin-bottom: 8px; 
+      color: var(--accent); letter-spacing: -0.01em; 
+    }
+    .solution-card p { 
+      font-size: 0.8125rem; color: var(--text-secondary); line-height: 1.5; 
+    }
+
+    .pricing-grid { 
+      display: grid; grid-template-columns: repeat(3, 1fr); 
+      gap: 16px; max-width: 640px; width: 100%; 
+    }
+    .price-card { 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 8px; padding: 24px; text-align: center; 
+      transition: all 0.2s ease;
+    }
+    .price-card:hover {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 1px var(--accent), 0 4px 12px rgba(0,0,0,0.08);
+    }
+    .price-card h4 { font-size: 0.875rem; font-weight: 600; margin-bottom: 8px; }
+    .price-card .price { 
+      font-size: 2rem; font-weight: 700; letter-spacing: -0.03em; 
+      text-wrap: balance;
+        color: var(--accent); margin-bottom: 4px; 
+    }
+    .price-card .desc { font-size: 0.75rem; color: var(--text-secondary); }
+
+    .team-grid { 
+      display: grid; grid-template-columns: repeat(4, 1fr); 
+      gap: 24px; max-width: 640px; width: 100%; 
+    }
+    .team-member { text-align: center; }
+    .team-avatar { 
+      width: 64px; height: 64px; border-radius: 50%; 
+      background: var(--surface); border: 1px solid var(--border); 
+      margin: 0 auto 8px; display: flex; align-items: center; justify-content: center; 
+      font-size: 1.125rem; font-weight: 600; color: var(--text-secondary); 
+    }
+    .team-name { font-size: 0.8125rem; font-weight: 600; margin-bottom: 2px; }
+    .team-role { 
+      font-size: 0.6875rem; color: var(--accent); 
+      text-transform: uppercase; letter-spacing: 0.03em; 
+    }
+
+    .chart-card { 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 8px; padding: 24px; max-width: 520px; 
+      width: 100%; transition: box-shadow 0.2s ease;
+    }
+    .chart-card:hover {
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+    }
+    .theme-light .chart-card { border: 1px solid var(--border); }
+    .theme-light .chart-card:hover { box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08); }
+    .chart-wrap { height: 300px; position: relative; }
+
+    .slide-nav { 
+      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); 
+      background: var(--surface); border: 1px solid var(--border); 
+      border-radius: 24px; padding: 8px 16px; display: flex; 
+      align-items: center; gap: 12px; z-index: 1000; 
+    }
+    .nav-btn { 
+      width: 32px; height: 32px; border: none; border-radius: 50%; 
+      background: transparent; color: var(--text); cursor: pointer; 
+      display: flex; align-items: center; justify-content: center; 
+    }
+    .nav-btn:hover { background: var(--surface-hover); }
+    .nav-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+    .slide-counter { 
+      font-size: 0.875rem; color: var(--text); min-width: 48px; 
+      text-align: center; font-variant-numeric: tabular-nums; font-weight: 600; 
+    }
+    .progress-bar { 
+      position: fixed; top: 0; left: 0; right: 0; height: 3px; 
+      background: var(--border); z-index: 1000; 
+    }
+    .progress-fill { 
+      height: 100%; background: var(--accent); transition: width 0.4s; 
+    }
+
+    /* Keyboard navigation hints */
+    .keyboard-hint {
+      position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%);
+      font-size: 0.75rem; color: var(--text-secondary);
+      display: flex; align-items: center; gap: 8px;
+      opacity: 0; animation: fadeIn 1s ease 2s both;
+    }
+    .keyboard-hint kbd {
+      background: var(--surface-hover); border: 1px solid var(--border);
+      border-radius: 4px; padding: 2px 6px; font-size: 0.625rem;
+      color: var(--text); font-family: inherit;
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+    @media (max-width: 768px) {
+      .slide { padding: 24px; }
+      .stat-grid, .stat-grid.cols-4 { grid-template-columns: repeat(2, 1fr); }
+      .solution-grid, .pricing-grid { grid-template-columns: 1fr; }
+      .team-grid { grid-template-columns: repeat(2, 1fr); }
+      .stat-cell { padding: 24px 16px; }
+      .stat-cell .num { font-size: 3rem; }
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- VISIBLE THEME TOGGLE -->
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <span id="themeIcon">🌙</span>
+  </button>
+
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="downloadImage()"><span>📥</span> Download PNG</button>
+      <button onclick="window.print()"><span>🖨️</span> Print / PDF</button>
+    </div>
+  </div>
+
+  <main id="main-content" role="main">
+    <div class="progress-bar"><div class="progress-fill" id="progressFill"></div></div>
+    <div id="slideAnnounce" aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);"></div>
+
+    <div class="slides-container" id="slidesContainer" role="region" aria-roledescription="slide deck">
+
+      <section class="slide title-slide" role="group" aria-roledescription="slide" aria-label="EcoFlow">
+        <!-- Enhanced sustainability hero visual -->
+        <div class="hero-visual">
+          <svg viewBox="0 0 1200 800" fill="none">
+            <!-- Leaf/nature pattern -->
+            <path d="M600 100 Q550 150 600 200 Q650 150 600 100" fill="var(--accent)" opacity="0.1"/>
+            <path d="M600 100 Q580 130 600 160 Q620 130 600 100" fill="var(--accent)" opacity="0.15"/>
+            <path d="M600 120 L600 180" stroke="var(--accent)" stroke-width="1" opacity="0.6"/>
+            
+            <!-- Removed decorative flow circles for cleaner design -->
+            
+            <!-- Trees/sustainability symbols -->
+            <rect x="250" y="250" width="4" height="40" fill="var(--accent)" opacity="0.5"/>
+            <circle cx="252" cy="240" r="15" fill="var(--accent)" opacity="0.3"/>
+            
+            <rect x="850" y="250" width="4" height="40" fill="var(--accent-secondary)" opacity="0.5"/>
+            <circle cx="852" cy="240" r="15" fill="var(--accent-secondary)" opacity="0.3"/>
+            
+            <rect x="550" y="450" width="4" height="40" fill="var(--accent)" opacity="0.5"/>
+            <circle cx="552" cy="440" r="15" fill="var(--accent)" opacity="0.3"/>
+            
+            <!-- Data visualization elements -->
+            <rect x="100" y="600" width="200" height="100" rx="8" stroke="var(--accent)" stroke-width="0.8" fill="none" opacity="0.4"/>
+            <rect x="120" y="660" width="20" height="20" fill="var(--accent)" opacity="0.5"/>
+            <rect x="150" y="650" width="20" height="30" fill="var(--accent)" opacity="0.6"/>
+            <rect x="180" y="640" width="20" height="40" fill="var(--accent)" opacity="0.7"/>
+            <rect x="210" y="630" width="20" height="50" fill="var(--accent)" opacity="0.8"/>
+            <rect x="240" y="620" width="20" height="60" fill="var(--accent)" opacity="0.9"/>
+            
+            <!-- CO2 reduction arrows -->
+            <path d="M900 600 L900 550" stroke="var(--positive)" stroke-width="2" marker-end="url(#arrowhead)" opacity="0.6"/>
+            <path d="M950 600 L950 540" stroke="var(--positive)" stroke-width="2" marker-end="url(#arrowhead)" opacity="0.7"/>
+            <path d="M1000 600 L1000 530" stroke="var(--positive)" stroke-width="2" marker-end="url(#arrowhead)" opacity="0.8"/>
+            
+            <defs>
+              <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                <polygon points="0 0, 10 3.5, 0 7" fill="var(--positive)" opacity="0.8"/>
+              </marker>
+            </defs>
+            
+            <!-- Grid pattern -->
+            <defs>
+              <pattern id="grid" width="50" height="50" patternUnits="userSpaceOnUse">
+                <path d="M 50 0 L 0 0 0 50" fill="none" stroke="var(--accent)" stroke-width="0.3" opacity="0.2"/>
+              </pattern>
+            </defs>
+            <rect width="1200" height="800" fill="url(#grid)"/>
+          </svg>
+        </div>
+        
+        <div class="keyboard-hint">
+          <span>Navigate:</span>
+          <kbd>←</kbd>
+          <kbd>→</kbd>
+          <kbd>Space</kbd>
+        </div>
+        <h1>EcoFlow</h1>
+        <p>AI-powered sustainability platform for enterprise</p>
+        <div class="meta">Seed Round · $2M Raising · 2026</div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="The Problem">
+        <h2>The Problem</h2>
+        <p>Companies struggle to measure and reduce their environmental impact</p>
+        <ul class="problem-list">
+          <li>
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/>
+              <line x1="9" y1="9" x2="15" y2="15"/>
+            </svg>
+            73% lack comprehensive carbon tracking
+          </li>
+          <li>
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/>
+              <line x1="9" y1="9" x2="15" y2="15"/>
+            </svg>
+            Reporting takes 120+ hours/month
+          </li>
+          <li>
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/>
+              <line x1="9" y1="9" x2="15" y2="15"/>
+            </svg>
+            ESG compliance costs $2.3M/year avg
+          </li>
+          <li>
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/>
+              <line x1="9" y1="9" x2="15" y2="15"/>
+            </svg>
+            Fragmented data blocks optimization
+          </li>
+        </ul>
+      </section>
+
+      <section class="slide section-slide" role="group" aria-roledescription="slide" aria-label="Our Solution">
+        <h2>Our Solution</h2>
+        <p>AI platform that automates sustainability tracking, reporting, and optimization</p>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="How It Works">
+        <h2>How It Works</h2>
+        <div class="solution-grid">
+          <div class="solution-card">
+            <h4>Smart Collection</h4>
+            <p>Connects to 200+ enterprise systems for real-time environmental data</p>
+          </div>
+          <div class="solution-card">
+            <h4>AI Analytics</h4>
+            <p>ML models identify patterns, predict trends, recommend optimizations</p>
+          </div>
+          <div class="solution-card">
+            <h4>Compliance</h4>
+            <p>One-click reporting for GRI, SASB, TCFD, EU Taxonomy</p>
+          </div>
+          <div class="solution-card">
+            <h4>Action Insights</h4>
+            <p>Personalized recommendations to reduce emissions and waste</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Market">
+        <h2>Market Opportunity</h2>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 32px; max-width: 800px; width: 100%; align-items: center;">
+          <div class="stat-grid" style="grid-template-columns: 1fr;">
+            <div class="stat-cell"><span class="num" data-count="16.2" data-prefix="$" data-suffix="B">$16.2B</span><span class="label">TAM by 2030</span></div>
+            <div class="stat-cell"><span class="num" data-count="28" data-suffix="%">28%</span><span class="label">CAGR</span></div>
+            <div class="stat-cell"><span class="num" data-count="84" data-suffix="%">84%</span><span class="label">F500 with ESG goals</span></div>
+          </div>
+          <div class="chart-card" role="img" aria-label="Market growth chart">
+            <div class="chart-wrap"><canvas id="marketChart"></canvas></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Business Model">
+        <h2>Business Model</h2>
+        <p>SaaS subscription tiered by company size</p>
+        <div class="pricing-grid">
+          <div class="price-card">
+            <h4>Starter</h4>
+            <div class="price">$2K</div>
+            <div class="desc">per month · ≤500 employees</div>
+          </div>
+          <div class="price-card">
+            <h4>Professional</h4>
+            <div class="price">$8K</div>
+            <div class="desc">per month · ≤5,000 employees</div>
+          </div>
+          <div class="price-card">
+            <h4>Enterprise</h4>
+            <div class="price">$25K</div>
+            <div class="desc">per month · unlimited</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Traction">
+        <h2>Traction</h2>
+        <p>Strong early validation from pilot customers</p>
+        <div class="stat-grid cols-4">
+          <div class="stat-cell"><span class="num" data-count="12">12</span><span class="label">Pilots</span></div>
+          <div class="stat-cell"><span class="num" data-count="340" data-prefix="$" data-suffix="K">$340K</span><span class="label">Pipeline</span></div>
+          <div class="stat-cell"><span class="num" data-count="87" data-suffix="%">87%</span><span class="label">CSAT</span></div>
+          <div class="stat-cell"><span class="num" data-count="42" data-suffix="%">42%</span><span class="label">CO₂ Reduction</span></div>
+        </div>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Team">
+        <h2>Our Team</h2>
+        <p>Deep expertise in AI, sustainability, and enterprise software</p>
+        <div class="team-grid">
+          <div class="team-member">
+            <div class="team-avatar">SL</div>
+            <div class="team-name">Sarah Liu</div>
+            <div class="team-role">CEO</div>
+          </div>
+          <div class="team-member">
+            <div class="team-avatar">MK</div>
+            <div class="team-name">Marcus Kim</div>
+            <div class="team-role">CTO</div>
+          </div>
+          <div class="team-member">
+            <div class="team-avatar">AR</div>
+            <div class="team-name">Amara Raj</div>
+            <div class="team-role">Product</div>
+          </div>
+          <div class="team-member">
+            <div class="team-avatar">DC</div>
+            <div class="team-name">David Chen</div>
+            <div class="team-role">Sales</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide section-slide" role="group" aria-roledescription="slide" aria-label="The Ask">
+        <h2>Raising $2M Seed</h2>
+        <p>60% Product · 25% Go-to-Market · 15% Operations</p>
+      </section>
+
+      <section class="slide content-slide" role="group" aria-roledescription="slide" aria-label="Use of Funds">
+        <h2>Use of Funds</h2>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 32px; max-width: 700px; width: 100%; align-items: center;">
+          <div class="stat-grid" style="grid-template-columns: 1fr;">
+            <div class="stat-cell"><span class="num" data-count="60" data-suffix="%">60%</span><span class="label">Product Dev</span></div>
+            <div class="stat-cell"><span class="num" data-count="25" data-suffix="%">25%</span><span class="label">Sales & Marketing</span></div>
+            <div class="stat-cell"><span class="num" data-count="15" data-suffix="%">15%</span><span class="label">Operations</span></div>
+          </div>
+          <div class="chart-card" role="img" aria-label="Funding allocation chart">
+            <div class="chart-wrap"><canvas id="fundingChart"></canvas></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide title-slide" role="group" aria-roledescription="slide" aria-label="Thank You">
+        <h1 style="font-size: clamp(2.5rem, 6vw, 4rem);">Let's Build Sustainably</h1>
+        <p>Join us in transforming enterprise sustainability</p>
+        <div class="meta">sarah@ecoflow.ai · ecoflow.ai</div>
+      </section>
+    </div>
+
+    <nav class="slide-nav" aria-label="Slide navigation">
+      <button class="nav-btn" id="prevBtn" onclick="prevSlide()" aria-label="Previous">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="15,18 9,12 15,6"/>
+        </svg>
+      </button>
+      <span class="slide-counter" id="slideCounter">1 / 11</span>
+      <button class="nav-btn" id="nextBtn" onclick="nextSlide()" aria-label="Next">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="9,18 15,12 9,6"/>
+        </svg>
+      </button>
+    </nav>
+  </main>
+
+  <script>
+    var currentSlide = 0, totalSlides = 11, marketChart, fundingChart;
+
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    function updateSlide() {
+      var slides = document.querySelectorAll('.slide');
+      slides.forEach(function(s, i) { s.classList.toggle('active', i === currentSlide); });
+      document.getElementById('slideCounter').textContent = (currentSlide + 1) + ' / ' + totalSlides;
+      document.getElementById('progressFill').style.width = ((currentSlide + 1) / totalSlides * 100) + '%';
+      document.getElementById('prevBtn').disabled = currentSlide === 0;
+      document.getElementById('nextBtn').disabled = currentSlide === totalSlides - 1;
+      document.getElementById('slideAnnounce').textContent = slides[currentSlide].getAttribute('aria-label') || '';
+      setTimeout(function() { animateCounters(slides[currentSlide]); }, 200);
+    }
+    function nextSlide() { if (currentSlide < totalSlides - 1) { currentSlide++; updateSlide(); } }
+    function prevSlide() { if (currentSlide > 0) { currentSlide--; updateSlide(); } }
+
+    document.addEventListener('keydown', function(e) {
+      if (document.getElementById('vizMenuDropdown').classList.contains('open')) return;
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { e.preventDefault(); prevSlide(); }
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === ' ' || e.key === 'Enter') { e.preventDefault(); nextSlide(); }
+    });
+    var touchX = 0;
+    document.addEventListener('touchstart', function(e) { touchX = e.changedTouches[0].screenX; });
+    document.addEventListener('touchend', function(e) { var d = touchX - e.changedTouches[0].screenX; if (Math.abs(d) > 50) { d > 0 ? nextSlide() : prevSlide(); } });
+    document.addEventListener('click', function(e) { if (e.target.closest('.viz-menu,.theme-toggle,.slide-nav,button,canvas')) return; e.clientX < window.innerWidth / 3 ? prevSlide() : nextSlide(); });
+
+    function animateCounters(container) {
+      (container || document).querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return; el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), dur = 1000;
+        (function tick(now) { 
+          var p = Math.min((now - start) / dur, 1), e = 1 - Math.pow(1 - p, 3), cur = target * e; 
+          el.textContent = prefix + (target % 1 !== 0 ? cur.toFixed(1) : Math.round(cur)).toLocaleString() + suffix; 
+          if (p < 1) requestAnimationFrame(tick); 
+        })(start);
+      });
+    }
+
+    function getColors() { 
+      var s = getComputedStyle(document.documentElement); 
+      return { 
+        text: s.getPropertyValue('--text').trim(), 
+        sub: s.getPropertyValue('--text-secondary').trim(), 
+        border: s.getPropertyValue('--border').trim(), 
+        surface: s.getPropertyValue('--surface').trim(), 
+        accent: s.getPropertyValue('--accent').trim(), 
+        accent2: s.getPropertyValue('--accent-secondary').trim(), 
+        warning: s.getPropertyValue('--warning').trim() 
+      }; 
+    }
+    function getCanvas(id) { return document.getElementById(id); }
+
+    function buildCharts() {
+      var c = getColors();
+      Chart.defaults.color = c.sub;
+      Chart.defaults.animation = false;
+      var tt = { backgroundColor: c.surface, titleColor: c.text, bodyColor: c.text, borderColor: c.border, borderWidth: 1, padding: 12, cornerRadius: 8, titleFont: { size: 14 }, bodyFont: { size: 13 } };
+      try { if (marketChart) marketChart.destroy(); } catch(e) {}
+      try { if (fundingChart) fundingChart.destroy(); } catch(e) {}
+
+      var mc = getCanvas('marketChart');
+      if (mc) {
+        var ctx = mc.getContext('2d'), g = ctx.createLinearGradient(0,0,0,260); 
+        g.addColorStop(0, c.accent + '30'); g.addColorStop(1, c.accent + '00');
+        marketChart = new Chart(mc, {
+          type: 'line', 
+          data: { labels: ['2022','2024','2026','2028','2030'], datasets: [{ data: [2.1,4.8,7.2,11.3,16.2], borderColor: c.accent, backgroundColor: g, borderWidth: 2, fill: true, tension: 0.4, pointRadius: 0, pointHoverRadius: 6 }] },
+          options: { responsive: true, maintainAspectRatio: false, layout: { padding: 10 }, plugins: { tooltip: { enabled: true, mode: 'index', intersect: false, ...tt, callbacks: { label: function(ctx) { return '$'+ctx.parsed.y+'B'; } } }, legend: { display: false } },
+            scales: { y: { grid: { color: c.border }, ticks: { color: c.sub, font: { size: 13 }, callback: function(v){return '$'+v+'B';} }, border: { display: false } }, x: { grid: { display: false }, ticks: { color: c.sub, font: { size: 13 } }, border: { display: false } } }, interaction: { intersect: false, mode: 'index' } }
+        });
+      }
+      var fc = getCanvas('fundingChart');
+      if (fc) {
+        fundingChart = new Chart(fc, {
+          type: 'doughnut', data: { labels: ['Product','Sales & Marketing','Operations'], datasets: [{ data: [60,25,15], backgroundColor: [c.accent, c.accent2, c.warning], borderWidth: 0 }] },
+          options: { responsive: true, maintainAspectRatio: false, layout: { padding: 10 }, plugins: { tooltip: { enabled: true, ...tt, callbacks: { label: function(ctx) { return ctx.label+': '+ctx.parsed+'%'; } } }, legend: { position: 'bottom', labels: { color: c.text, font: { size: 13 }, usePointStyle: true, padding: 16 } } }, cutout: '65%' }
+        });
+      }
+    }
+    function onThemeChange() { setTimeout(buildCharts, 50); }
+    updateSlide(); setTimeout(buildCharts, 300);
+
+    async function downloadImage() {
+      var els = ['.viz-menu','.theme-toggle','.slide-nav'].map(function(s){return document.querySelector(s);});
+      els.forEach(function(el){if(el)el.style.display='none';});
+      try { 
+        var url = await htmlToImage.toPng(document.querySelectorAll('.slide')[currentSlide], { 
+          quality: 1, pixelRatio: 2, width: 1920, height: 1080 
+        }); 
+        var a = document.createElement('a'); 
+        a.href = url; 
+        a.download = 'ecoflow-slide-'+(currentSlide+1)+'.png'; 
+        a.click(); 
+      } catch(e) { console.error(e); }
+      els.forEach(function(el){if(el)el.style.display='';});
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/status-report.html
+++ b/claude/skills/visualize/examples/status-report.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Phoenix — February 2026 Status Report</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    
+    
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.08);
+      --text: #EDEDED; --text-secondary: #888;
+      --accent: #3b82f6; --accent-secondary: #2563eb;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.08);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #3b82f6; --accent-secondary: #2563eb;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; letter-spacing: -0.011em; -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
+      scrollbar-gutter: stable;
+      transition: background 0.3s, color 0.3s;
+      padding: 32px 16px;
+    }
+    body::after {
+      content: ''; position: fixed; inset: 0; z-index: -1; opacity: 0.03;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 16px; padding: 24px;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .card:hover {
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+    }
+
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+    .animate.delay-5 { animation-delay: 0.5s; }
+    .animate.delay-6 { animation-delay: 0.6s; }
+
+    .reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.6s ease, transform 0.6s ease; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .reveal { opacity: 1; transform: none; }
+    }
+
+    @media print {
+      body { background: white !important; color: black !important; padding: 16px !important; }
+      .viz-menu { display: none !important; }
+      .reveal { opacity: 1 !important; transform: none !important; }
+      .card { break-inside: avoid; box-shadow: none; border: 1px solid #ddd; }
+      .report { box-shadow: none !important; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+
+    /* === Hamburger Menu === */
+    .viz-menu {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 9999;
+      font-family: var(--font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    }
+
+    .viz-menu-toggle {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .viz-menu-toggle:hover {
+      background: var(--surface-hover);
+      transform: scale(1.05);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+
+    .viz-menu-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      min-width: 200px;
+      background: var(--surface);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 6px;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px) scale(0.96);
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    }
+
+    .viz-menu-dropdown.open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0) scale(1);
+    }
+
+    .viz-menu-dropdown button {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border: none;
+      background: transparent;
+      color: var(--text);
+      font-size: 0.875rem;
+      cursor: pointer;
+      border-radius: 8px;
+      transition: background 0.15s;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    .viz-menu-dropdown button:hover {
+      background: var(--surface-hover);
+    }
+
+    .viz-menu-dropdown button:focus-visible { 
+      outline: 2px solid var(--accent); 
+      outline-offset: 2px; 
+    }
+
+    .viz-menu-icon {
+      font-size: 1rem;
+      width: 20px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    /* ===== REPORT ===== */
+    .report {
+      max-width: 900px; margin: 0 auto;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 24px; padding: 48px; position: relative;
+      box-shadow: 0 24px 80px rgba(0,0,0,0.15);
+    }
+
+    .report-header {
+      display: flex; align-items: flex-start; justify-content: space-between;
+      flex-wrap: wrap; gap: 16px; margin-bottom: 40px;
+      padding-bottom: 24px; border-bottom: 1px solid var(--border);
+    }
+    .report-title { font-size: clamp(1.75rem, 4vw, 2.5rem); font-weight: 700; text-wrap: balance; }
+    .report-subtitle { font-size: 0.9rem; color: var(--text-secondary); margin-top: 4px; }
+    .status-badge {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 8px 16px; border-radius: 8px; font-weight: 700; font-size: 0.85rem;
+      white-space: nowrap;
+    }
+    .status-badge.on-track { background: color-mix(in srgb, var(--positive), transparent 85%); color: var(--positive); }
+    .status-badge.at-risk { background: color-mix(in srgb, var(--warning), transparent 85%); color: var(--warning); }
+    .status-badge.delayed { background: color-mix(in srgb, var(--negative), transparent 85%); color: var(--negative); }
+    .status-dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; }
+
+    .section-title {
+      font-size: 0.7rem; font-weight: 700; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--accent); margin-bottom: 16px;
+      text-wrap: balance;
+    }
+    .report-section { margin-bottom: 36px; }
+
+    /* KPI Cards */
+    .kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
+    .kpi-card {
+      background: var(--surface-hover); border: 1px solid var(--border);
+      border-radius: 12px; padding: 20px; text-align: center;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .kpi-card:hover { box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08); }
+    .kpi-value { font-size: 2rem; font-weight: 700; margin-bottom: 4px; }
+    .kpi-label { font-size: 0.8rem; color: var(--text-secondary); font-weight: 500; }
+    .kpi-sub { font-size: 0.75rem; color: var(--text-secondary); margin-top: 4px; }
+
+    /* Progress bars */
+    .workstream { margin-bottom: 16px; }
+    .workstream-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+    .workstream-name { font-weight: 600; font-size: 0.95rem; }
+    .workstream-pct { font-weight: 700; font-size: 0.9rem; font-variant-numeric: tabular-nums; }
+    .progress-track {
+      width: 100%; height: 8px; background: var(--surface);
+      border-radius: 4px; overflow: hidden; border: 1px solid var(--border);
+    }
+    .progress-fill {
+      height: 100%; border-radius: 4px;
+      transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    /* Milestones */
+    .milestone-timeline { display: flex; flex-direction: column; gap: 0; }
+    .milestone {
+      display: flex; align-items: flex-start; gap: 16px; padding: 12px 0;
+      position: relative;
+    }
+    .milestone:not(:last-child)::after {
+      content: ''; position: absolute; left: 15px; top: 36px;
+      width: 2px; height: calc(100% - 24px);
+      background: var(--border);
+    }
+    .milestone-dot {
+      width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.75rem; font-weight: 700; position: relative; z-index: 1;
+    }
+    .milestone-dot.completed { background: var(--positive); color: #fff; }
+    .milestone-dot.current { background: var(--accent); color: #fff; box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent), transparent 70%); }
+    .milestone-dot.upcoming { background: var(--surface-hover); color: var(--text-secondary); border: 2px solid var(--border); }
+    .milestone-info { flex: 1; padding-top: 4px; }
+    .milestone-name { font-weight: 600; font-size: 0.9rem; }
+    .milestone-date { font-size: 0.8rem; color: var(--text-secondary); }
+
+    /* Risks */
+    .risk-item {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 14px 16px; background: var(--surface-hover);
+      border-radius: 10px; margin-bottom: 10px;
+      border: 1px solid var(--border);
+    }
+    .severity-badge {
+      padding: 3px 10px; border-radius: 6px; font-size: 0.7rem;
+      font-weight: 700; text-transform: uppercase; white-space: nowrap; flex-shrink: 0;
+    }
+    .severity-badge.high { background: color-mix(in srgb, var(--negative), transparent 85%); color: var(--negative); }
+    .severity-badge.medium { background: color-mix(in srgb, var(--warning), transparent 85%); color: var(--warning); }
+    .severity-badge.low { background: color-mix(in srgb, var(--positive), transparent 85%); color: var(--positive); }
+    .risk-text { font-size: 0.9rem; }
+
+    /* Action items */
+    .action-item {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 0; border-bottom: 1px solid var(--border);
+    }
+    .action-item:last-child { border-bottom: none; }
+    .action-check {
+      width: 20px; height: 20px; border-radius: 6px;
+      border: 2px solid var(--border); flex-shrink: 0;
+    }
+    .action-text { flex: 1; font-size: 0.9rem; }
+    .action-meta { font-size: 0.75rem; color: var(--text-secondary); text-align: right; white-space: nowrap; }
+
+    .skip-link {
+      position: absolute; top: -100px; left: 16px; padding: 8px 16px;
+      background: var(--accent); color: #fff; border-radius: 8px;
+      text-decoration: none; z-index: 99999; font-weight: 600;
+    }
+    .skip-link:focus { top: 16px; }
+  
+    .stat-card, .metric-card, .kpi-card { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover, .metric-card:hover, .kpi-card:hover { transform: translateY(-2px); box-shadow: 0 8px 25px rgba(0,0,0,0.15); } /* hover-lift */
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <main id="main-content">
+
+  <!-- Hamburger Menu -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/>
+        <line x1="3" y1="10" x2="17" y2="10"/>
+        <line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()">
+        <span class="viz-menu-icon">◐</span>
+        <span>Theme: <span id="themeLabel">Dark</span></span>
+      </button>
+      <button onclick="downloadImage()">
+        <span class="viz-menu-icon">⤓</span>
+        <span>Download PNG</span>
+      </button>
+      <button onclick="printPDF()">
+        <span class="viz-menu-icon">⎙</span>
+        <span>Print / PDF</span>
+      </button>
+    </div>
+  </div>
+
+  <article class="report">
+
+    <header class="report-header animate">
+      <div>
+        <h1 class="report-title">Project Phoenix</h1>
+        <div class="report-subtitle">Monthly Status Report · February 1–28, 2026</div>
+      </div>
+      <div class="status-badge on-track" aria-label="Status: On Track">
+        <span class="status-dot"></span> On Track
+      </div>
+    </header>
+
+    <!-- KPIs -->
+    <section class="report-section animate delay-1" data-reveal aria-label="Key Performance Indicators">
+      <h2 class="section-title">Key Metrics</h2>
+      <div class="kpi-grid">
+        <div class="kpi-card">
+          <div class="kpi-value" style="color: var(--accent);">$<span data-count="1200" data-prefix="">1,200</span>K</div>
+          <div class="kpi-label">Budget Spent</div>
+          <div class="kpi-sub">of $1,500K allocated</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-value" style="color: var(--positive);"><span data-count="68" data-suffix="%">68%</span></div>
+          <div class="kpi-label">Timeline Complete</div>
+          <div class="kpi-sub">Target: 65% by Feb 28</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-value" style="color: var(--accent-secondary);"><span data-count="12">12</span></div>
+          <div class="kpi-label">Team Members</div>
+          <div class="kpi-sub">3 eng · 2 design · 4 dev · 3 QA</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-value" style="color: var(--warning);"><span data-count="42">42</span></div>
+          <div class="kpi-label">Sprint Velocity</div>
+          <div class="kpi-sub">pts/sprint (avg last 3)</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Workstreams -->
+    <section class="report-section animate delay-2" data-reveal aria-label="Workstream Progress">
+      <h2 class="section-title">Workstream Progress</h2>
+
+      <div class="workstream">
+        <div class="workstream-header">
+          <span class="workstream-name">Backend API & Infrastructure</span>
+          <span class="workstream-pct" style="color: var(--positive);">82%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" style="width: 82%; background: var(--positive);"></div>
+        </div>
+      </div>
+
+      <div class="workstream">
+        <div class="workstream-header">
+          <span class="workstream-name">Frontend & User Experience</span>
+          <span class="workstream-pct" style="color: var(--accent);">61%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" style="width: 61%; background: var(--accent);"></div>
+        </div>
+      </div>
+
+      <div class="workstream">
+        <div class="workstream-header">
+          <span class="workstream-name">Data Pipeline & ML Models</span>
+          <span class="workstream-pct" style="color: var(--warning);">45%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" style="width: 45%; background: var(--warning);"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Milestones -->
+    <section class="report-section animate delay-3" data-reveal aria-label="Milestones">
+      <h2 class="section-title">Milestones</h2>
+      <div class="milestone-timeline">
+        <div class="milestone">
+          <div class="milestone-dot completed" aria-label="Completed">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+          </div>
+          <div class="milestone-info">
+            <div class="milestone-name">Project kickoff & team onboarding</div>
+            <div class="milestone-date">Completed · Nov 1, 2025</div>
+          </div>
+        </div>
+        <div class="milestone">
+          <div class="milestone-dot completed" aria-label="Completed">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+          </div>
+          <div class="milestone-info">
+            <div class="milestone-name">Architecture review & tech stack finalized</div>
+            <div class="milestone-date">Completed · Dec 15, 2025</div>
+          </div>
+        </div>
+        <div class="milestone">
+          <div class="milestone-dot completed" aria-label="Completed">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+          </div>
+          <div class="milestone-info">
+            <div class="milestone-name">MVP backend API deployed to staging</div>
+            <div class="milestone-date">Completed · Jan 20, 2026</div>
+          </div>
+        </div>
+        <div class="milestone">
+          <div class="milestone-dot current" aria-label="Current milestone">●</div>
+          <div class="milestone-info">
+            <div class="milestone-name">Frontend alpha release (internal)</div>
+            <div class="milestone-date">In Progress · Target: Mar 10, 2026</div>
+          </div>
+        </div>
+        <div class="milestone">
+          <div class="milestone-dot upcoming" aria-label="Upcoming">○</div>
+          <div class="milestone-info">
+            <div class="milestone-name">Beta launch with 50 pilot users</div>
+            <div class="milestone-date">Planned · Apr 15, 2026</div>
+          </div>
+        </div>
+        <div class="milestone">
+          <div class="milestone-dot upcoming" aria-label="Upcoming">○</div>
+          <div class="milestone-info">
+            <div class="milestone-name">Production GA release</div>
+            <div class="milestone-date">Planned · Jun 1, 2026</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Risks -->
+    <section class="report-section animate delay-4" data-reveal aria-label="Risks and Blockers">
+      <h2 class="section-title">Risks & Blockers</h2>
+      <div class="risk-item">
+        <span class="severity-badge high" aria-label="High severity">High</span>
+        <span class="risk-text">ML model training data pipeline has intermittent failures; reliability at 94% (target 99.5%)</span>
+      </div>
+      <div class="risk-item">
+        <span class="severity-badge medium" aria-label="Medium severity">Medium</span>
+        <span class="risk-text">Design system migration to new component library causing 1-week frontend delay</span>
+      </div>
+      <div class="risk-item">
+        <span class="severity-badge low" aria-label="Low severity">Low</span>
+        <span class="risk-text">Third-party auth provider deprecating v2 API; migration to v3 needed by Q3</span>
+      </div>
+    </section>
+
+    <!-- Next Steps -->
+    <section class="report-section animate delay-5" data-reveal aria-label="Next Steps">
+      <h2 class="section-title">Next Steps</h2>
+      <div class="action-item">
+        <div class="action-check"></div>
+        <div class="action-text">Resolve ML pipeline reliability to 99%+ uptime</div>
+        <div class="action-meta">Sarah L. · Mar 7</div>
+      </div>
+      <div class="action-item">
+        <div class="action-check"></div>
+        <div class="action-text">Complete frontend component library migration</div>
+        <div class="action-meta">James C. · Mar 14</div>
+      </div>
+      <div class="action-item">
+        <div class="action-check"></div>
+        <div class="action-text">User testing sessions with 10 internal stakeholders</div>
+        <div class="action-meta">Aisha P. · Mar 10</div>
+      </div>
+      <div class="action-item">
+        <div class="action-check"></div>
+        <div class="action-text">Security audit & penetration testing for beta</div>
+        <div class="action-meta">Marcus K. · Mar 21</div>
+      </div>
+    </section>
+
+  </article>
+
+  </main>
+  <script>
+    // === Menu ===
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    // === Theme system ===
+    const themes = [
+      { name: 'Dark', class: 'theme-dark' },
+      { name: 'Light', class: 'theme-light' },
+      { name: 'Auto', class: 'theme-auto' },
+    ];
+    let currentTheme = 0;
+
+    function cycleTheme() {
+      // Remove all theme classes
+      themes.forEach(t => document.documentElement.classList.remove(t.class));
+      // Advance to next
+      currentTheme = (currentTheme + 1) % themes.length;
+      document.documentElement.classList.add(themes[currentTheme].class);
+      document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      // Persist
+      localStorage.setItem('viz-theme', currentTheme);
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+
+    // Restore saved theme on load
+    (function() {
+      const saved = localStorage.getItem('viz-theme');
+      if (saved !== null) {
+        currentTheme = parseInt(saved);
+        document.documentElement.classList.add(themes[currentTheme].class);
+        document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+      }
+    })();
+
+    // === Print as PDF ===
+    function printPDF() {
+      window.print();
+    }
+
+    // === Scroll Reveal ===
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var revealObserver = new IntersectionObserver(function(entries) {
+      entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); revealObserver.unobserve(e.target); } });
+    }, { threshold: 0.15 });
+    document.querySelectorAll('.reveal').forEach(function(el) { revealObserver.observe(el); });
+    setTimeout(function() { document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); }); }, 500);
+
+    // === Number Counter ===
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return;
+        el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), duration = 1200;
+        (function tick(now) {
+          var p = Math.min((now - start) / duration, 1), eased = 1 - Math.pow(1 - p, 3);
+          el.textContent = prefix + Math.round(target * eased).toLocaleString() + suffix;
+          if (p < 1) requestAnimationFrame(tick);
+        })(start);
+      });
+    }
+    var counterEl = document.querySelector('[data-count]');
+    if (counterEl) {
+      var cObs = new IntersectionObserver(function(entries) {
+        entries.forEach(function(e) { if (e.isIntersecting) { animateCounters(); cObs.disconnect(); } });
+      }, { threshold: 0.3 });
+      cObs.observe(counterEl);
+    }
+
+    // === Download PNG ===
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      try {
+        var report = document.querySelector('.report');
+        var url = await htmlToImage.toPng(report, { quality: 1, pixelRatio: 2 });
+        var a = document.createElement('a'); a.href = url;
+        a.download = 'project-phoenix-feb-2026.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/examples/system-architecture.html
+++ b/claude/skills/visualize/examples/system-architecture.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E-Commerce Microservices Architecture</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html.theme-dark { --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C; --border: rgba(255,255,255,0.04); --text: #EDEDED; --text-secondary: #888888; --accent: #6366f1; --accent-secondary: #4f46e5; --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b; }
+    html.theme-light { --bg: #FAFAF9; --surface: #ffffff; --surface-hover: #F5F5F4; --border: rgba(0,0,0,0.06); --text: #0f172a; --text-secondary: #64748b; --accent: #6366f1; --accent-secondary: #4f46e5; --positive: #059669; --negative: #e11d48; --warning: #d97706; }
+
+    body { 
+      font-family: 'Inter', -apple-system, sans-serif; 
+      background: var(--bg); 
+      background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+      background-size: 24px 24px;
+      color: var(--text); 
+      line-height: 1.6; 
+      -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01'; 
+      scrollbar-gutter: stable;
+      letter-spacing: -0.011em; 
+      font-weight: 400;
+    }
+    html.theme-light body {
+      background: #f8fafc;
+      background-image: radial-gradient(circle, rgba(0,0,0,0.04) 1px, transparent 1px);
+      background-size: 24px 24px;
+    }
+    h1, h2, h3 { 
+      color: var(--text); 
+      letter-spacing: -0.03em; 
+      line-height: 1.05; 
+      font-weight: 700; 
+      text-wrap: balance;
+    }
+    h2 { font-weight: 600; letter-spacing: -0.02em; }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+
+    .skip-link { position: absolute; top: -40px; left: 16px; padding: 8px 16px; background: var(--accent); color: #fff; text-decoration: none; border-radius: 8px; z-index: 10000; }
+    .skip-link:focus { top: 16px; }
+
+    .reveal { opacity: 0; transform: translateY(16px); transition: opacity 0.4s, transform 0.4s; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+    @media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; } *, *::before, *::after { animation: none !important; transition: none !important; } }
+    @media print { body { background: #fff !important; color: #000 !important; } .viz-menu { display: none !important; } .reveal { opacity: 1 !important; transform: none !important; } * { print-color-adjust: exact; -webkit-print-color-adjust: exact; } }
+
+    .theme-toggle { position: fixed; top: 16px; right: 68px; z-index: 9999; width: 44px; height: 44px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(12px); transition: all 0.2s; }
+    .theme-toggle:hover { background: var(--surface-hover); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-dark .theme-toggle .sun-icon { display: none; }
+    .theme-light .theme-toggle .moon-icon { display: none; }
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle { width: 40px; height: 40px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center; }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown { position: absolute; top: 48px; right: 0; min-width: 160px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05); opacity: 0; visibility: hidden; transform: translateY(-4px); transition: all 0.15s; }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); animation: dropdownIn 0.15s ease; }
+    @keyframes dropdownIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+    .viz-menu-dropdown button { width: 100%; padding: 8px 12px; border: none; border-radius: 6px; background: transparent; color: var(--text-secondary); font-size: 0.875rem; font-family: inherit; cursor: pointer; text-align: left; display: flex; align-items: center; gap: 8px; transition: background 0.15s, color 0.15s; }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); color: var(--text); }
+
+    .container { max-width: 1000px; margin: 0 auto; padding: 0 24px; }
+
+    .hero { padding: 48px 0 48px; text-align: center; }
+    .hero h1 { 
+      font-size: clamp(3.5rem, 10vw, 6rem); 
+      margin-bottom: 16px; 
+      letter-spacing: -0.04em;
+      line-height: 1.05;
+      font-weight: 700;
+      text-shadow: 0 0 60px rgba(0,112,243,0.3);
+    }
+    .hero p { 
+      color: var(--text-secondary); 
+      font-size: 1.125rem; 
+      line-height: 1.5;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    /* Stats bar */
+    .stats-bar { 
+      display: grid; 
+      grid-template-columns: repeat(4, 1fr); 
+      gap: 1px; 
+      background: var(--border); 
+      border-radius: 8px; 
+      overflow: hidden; 
+      margin-bottom: 48px; 
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .theme-light .stats-bar { border: 1px solid rgba(0,0,0,0.08); }
+    .stat { 
+      background: var(--surface); 
+      padding: 24px; 
+      text-align: center; 
+      transition: box-shadow 0.2s ease;
+    }
+    .stat:hover {
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+    }
+    .theme-light .stat:hover {
+      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+    }
+    .stat-num { 
+      font-size: 2rem; 
+      font-weight: 700; 
+      letter-spacing: -0.04em; 
+      display: block; 
+      margin-bottom: 6px; 
+      text-shadow: 0 0 40px rgba(0,112,243,0.3);
+      line-height: 1;
+    }
+    .stat-label { 
+      font-size: 0.6875rem; 
+      color: var(--text-secondary); 
+      text-transform: uppercase; 
+      letter-spacing: 0.1em; 
+      font-weight: 500; 
+    }
+
+    /* Section nav */
+    .section-nav { 
+      position: sticky; 
+      top: 0; 
+      z-index: 100; 
+      background: var(--bg); 
+      border-bottom: 1px solid var(--border); 
+      padding: 12px 0; 
+      display: flex; 
+      gap: 8px; 
+      overflow-x: auto; 
+      margin-bottom: 48px; 
+      backdrop-filter: blur(8px);
+    }
+    .section-nav a { 
+      color: var(--text-secondary); 
+      text-decoration: none; 
+      font-size: 0.8125rem; 
+      padding: 6px 16px; 
+      border-radius: 8px; 
+      white-space: nowrap; 
+      font-weight: 500; 
+      transition: all 0.2s ease;
+    }
+    .section-nav a:hover { 
+      color: var(--text); 
+      background: var(--surface); 
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+
+    /* Layer */
+    .layer { margin-bottom: 48px; }
+    .layer-header { 
+      display: flex; 
+      align-items: center; 
+      gap: 12px; 
+      margin-bottom: 24px; 
+      padding: 16px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .layer-dot { 
+      width: 10px; 
+      height: 10px; 
+      border-radius: 50%; 
+      box-shadow: 0 0 20px currentColor;
+    }
+    .layer-name { 
+      font-size: 0.75rem; 
+      font-weight: 600; 
+      text-transform: uppercase; 
+      letter-spacing: 0.1em; 
+      color: var(--text-secondary); 
+    }
+
+    .nodes { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
+    .node { 
+      background: var(--surface); 
+      border: 2px solid rgba(255,255,255,0.08); 
+      border-radius: 16px; 
+      padding: 24px; 
+      display: flex; 
+      gap: 16px; 
+      transition: all 0.2s ease; 
+      cursor: pointer; 
+      position: relative;
+    }
+    .node::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px;
+      background: linear-gradient(90deg, var(--accent), var(--accent-secondary));
+      border-radius: 16px 16px 0 0; opacity: 0; transition: opacity 0.2s ease;
+    }
+    .node:hover { 
+      box-shadow: 0 0 0 1px var(--accent), 0 12px 32px rgba(0,0,0,0.15); 
+      border-color: var(--accent);
+      transform: translateY(-2px);
+    }
+    .node:hover::before { opacity: 1; }
+    .theme-light .node { border: 1px solid rgba(0,0,0,0.08); }
+    .theme-light .node:hover { 
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.08); 
+      border-color: rgba(0,0,0,0.12);
+    }
+
+    .node-icon { 
+      width: 40px; 
+      height: 40px; 
+      border-radius: 8px; 
+      display: flex; 
+      align-items: center; 
+      justify-content: center; 
+      flex-shrink: 0; 
+      background: var(--surface-hover); 
+      color: var(--text-secondary); 
+      transition: background 0.2s ease;
+    }
+    .node:hover .node-icon {
+      background: var(--accent);
+      color: #fff;
+    }
+    .node h4 { 
+      font-size: 0.875rem; 
+      font-weight: 600; 
+      margin-bottom: 6px; 
+      display: flex; 
+      align-items: center; 
+      gap: 8px; 
+      letter-spacing: -0.02em; 
+    }
+    .node p { 
+      font-size: 0.8125rem; 
+      color: var(--text-secondary); 
+      line-height: 1.5; 
+      margin-bottom: 12px; 
+    }
+    .node-tags { display: flex; gap: 4px; flex-wrap: wrap; }
+    .tag { font-size: 0.625rem; padding: 2px 6px; border-radius: 4px; background: var(--surface-hover); color: var(--text-secondary); font-weight: 500; }
+
+    .status { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
+    .status.ok { background: var(--positive); }
+    .status.warn { background: var(--warning); }
+
+    /* Connection indicator */
+    .connector { display: flex; justify-content: center; padding: 8px 0; }
+    .conn-arrow { width: 2px; height: 24px; background: var(--text-secondary); position: relative; border-radius: 1px; }
+    .conn-arrow::after { content: ''; position: absolute; bottom: -4px; left: -4px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 6px solid var(--text-secondary); }
+
+    /* Notes */
+    .notes-section { margin-top: 48px; border-top: 1px solid var(--border); padding-top: 40px; }
+    .notes-section h2 { font-size: 1.25rem; margin-bottom: 20px; }
+    .notes-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+    .note { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; }
+    .note h3 { font-size: 0.8125rem; font-weight: 600; margin-bottom: 8px; letter-spacing: -0.01em; }
+    .note p { font-size: 0.8125rem; color: var(--text-secondary); line-height: 1.5; }
+
+    @media (max-width: 640px) {
+      .stats-bar { grid-template-columns: repeat(2, 1fr); }
+      .nodes { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <button class="theme-toggle" onclick="cycleTheme()" aria-label="Toggle theme">
+    <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+  </button>
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/></svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><span id="themeIcon">🌙</span><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><span>📥</span> Download PNG</button>
+      <button onclick="window.print()"><span>🖨️</span> Print / PDF</button>
+    </div>
+  </div>
+
+  <main id="main-content">
+    <div class="container">
+
+      <header class="hero">
+        <h1>Microservices Architecture</h1>
+        <p>E-Commerce Platform System Overview</p>
+      </header>
+
+      <section class="stats-bar" role="region" aria-label="System stats">
+        <div class="stat"><span class="stat-num" data-count="99.97" data-suffix="%">99.97%</span><span class="stat-label">Uptime</span></div>
+        <div class="stat"><span class="stat-num" data-count="12" data-suffix="K">12K</span><span class="stat-label">Req/sec</span></div>
+        <div class="stat"><span class="stat-num" data-count="47">47</span><span class="stat-label">Services</span></div>
+        <div class="stat"><span class="stat-num" data-count="2.3" data-suffix="TB">2.3TB</span><span class="stat-label">Daily Data</span></div>
+      </section>
+
+      <nav class="section-nav" aria-label="Layer navigation">
+        <a href="#clients">Clients</a>
+        <a href="#gateway">Gateway</a>
+        <a href="#services">Services</a>
+        <a href="#data">Data</a>
+        <a href="#external">External</a>
+        <a href="#principles">Principles</a>
+      </nav>
+
+      <!-- Clients -->
+      <section class="layer" id="clients" data-reveal role="region" aria-label="Client Applications layer">
+        <div class="layer-header"><div class="layer-dot" style="background:var(--accent)" aria-hidden="true"></div><span class="layer-name">Client Applications</span></div>
+        <div class="nodes">
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15 15 0 014 10 15 15 0 01-4 10 15 15 0 01-4-10 15 15 0 014-10z"/></svg></div><div><h4>Web App <span class="status ok" aria-label="Status: Healthy"></span></h4><p>React SPA with SSR, edge caching, 8K concurrent users</p><div class="node-tags"><span class="tag">React</span><span class="tag">SSR</span><span class="tag">CDN</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg></div><div><h4>Mobile Apps <span class="status ok" aria-label="Status: Healthy"></span></h4><p>React Native iOS/Android with offline-first architecture</p><div class="node-tags"><span class="tag">React Native</span><span class="tag">Offline</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></div><div><h4>Admin Dashboard <span class="status ok" aria-label="Status: Healthy"></span></h4><p>Vue.js internal ops dashboard with RBAC and SAML SSO</p><div class="node-tags"><span class="tag">Vue.js</span><span class="tag">RBAC</span></div></div></div>
+        </div>
+      </section>
+
+      <div class="connector"><div class="conn-arrow"></div></div>
+
+      <!-- Gateway -->
+      <section class="layer" id="gateway" data-reveal role="region" aria-label="API Gateway layer">
+        <div class="layer-header"><div class="layer-dot" style="background:var(--warning)" aria-hidden="true"></div><span class="layer-name">API Gateway</span></div>
+        <div class="nodes">
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg></div><div><h4>Auth Gateway <span class="status ok" aria-label="Status: Healthy"></span></h4><p>JWT + OAuth2, rate limiting at 1K req/min, circuit breaker</p><div class="node-tags"><span class="tag">JWT</span><span class="tag">OAuth2</span><span class="tag">Rate Limit</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/></svg></div><div><h4>Load Balancer <span class="status ok" aria-label="Status: Healthy"></span></h4><p>NGINX with health checks, TLS 1.3, automatic failover</p><div class="node-tags"><span class="tag">NGINX</span><span class="tag">HA</span><span class="tag">TLS</span></div></div></div>
+        </div>
+      </section>
+
+      <div class="connector"><div class="conn-arrow"></div></div>
+
+      <!-- Services -->
+      <section class="layer" id="services" data-reveal role="region" aria-label="Business Services layer">
+        <div class="layer-header"><div class="layer-dot" style="background:var(--positive)" aria-hidden="true"></div><span class="layer-name">Business Services</span></div>
+        <div class="nodes">
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div><div><h4>User Service <span class="status ok" aria-label="Status: Healthy"></span></h4><p>Auth, profiles, GDPR compliance with encrypted PII</p><div class="node-tags"><span class="tag">Go</span><span class="tag">GDPR</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg></div><div><h4>Product Catalog <span class="status ok" aria-label="Status: Healthy"></span></h4><p>2M+ products, dynamic pricing, Elasticsearch sync</p><div class="node-tags"><span class="tag">Python</span><span class="tag">ES</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/></svg></div><div><h4>Orders <span class="status ok" aria-label="Status: Healthy"></span></h4><p>Cart, checkout, saga pattern, 5K+ orders/day</p><div class="node-tags"><span class="tag">Java</span><span class="tag">Saga</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="4" width="22" height="16" rx="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg></div><div><h4>Payments <span class="status warn" aria-label="Status: Warning"></span></h4><p>Stripe, elevated latency (p99 &gt; 800ms), auto-scaling</p><div class="node-tags"><span class="tag">Node.js</span><span class="tag">PCI-DSS</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22 6 12 13 2 6"/></svg></div><div><h4>Notifications <span class="status ok" aria-label="Status: Healthy"></span></h4><p>Email, push, SMS — 50K+ messages/day, 99.7% delivery</p><div class="node-tags"><span class="tag">SendGrid</span><span class="tag">Twilio</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div><div><h4>Search <span class="status ok" aria-label="Status: Healthy"></span></h4><p>Elasticsearch, semantic search, &lt;50ms p95, 100K queries/day</p><div class="node-tags"><span class="tag">Rust</span><span class="tag">ML</span></div></div></div>
+        </div>
+      </section>
+
+      <div class="connector"><div class="conn-arrow"></div></div>
+
+      <!-- Data -->
+      <section class="layer" id="data" data-reveal role="region" aria-label="Data and Storage layer">
+        <div class="layer-header"><div class="layer-dot" style="background:#ec4899" aria-hidden="true"></div><span class="layer-name">Data &amp; Storage</span></div>
+        <div class="nodes">
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg></div><div><h4>PostgreSQL <span class="status ok" aria-label="Status: Healthy"></span></h4><p>3-node cluster, streaming replication, 12K queries/sec</p><div class="node-tags"><span class="tag">HA</span><span class="tag">PgBouncer</span><span class="tag">2.3TB</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div><div><h4>Redis Cache <span class="status ok" aria-label="Status: Healthy"></span></h4><p>6-node cluster, 128GB, 99.99% hit rate, Sentinel HA</p><div class="node-tags"><span class="tag">Redis</span><span class="tag">128GB</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></div><div><h4>Message Queue <span class="status ok" aria-label="Status: Healthy"></span></h4><p>RabbitMQ, 200K+ msg/min, durable queues, DLX</p><div class="node-tags"><span class="tag">RabbitMQ</span><span class="tag">AMQP</span></div></div></div>
+        </div>
+      </section>
+
+      <div class="connector"><div class="conn-arrow"></div></div>
+
+      <!-- External -->
+      <section class="layer" id="external" data-reveal role="region" aria-label="External Services layer">
+        <div class="layer-header"><div class="layer-dot" style="background:var(--accent-secondary)" aria-hidden="true"></div><span class="layer-name">External Services</span></div>
+        <div class="nodes">
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg></div><div><h4>Payment Gateways <span class="status ok" aria-label="Status: Healthy"></span></h4><p>Stripe + PayPal, PCI-DSS L1, $5M+/month</p><div class="node-tags"><span class="tag">Stripe</span><span class="tag">PayPal</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></div><div><h4>Fulfillment <span class="status ok" aria-label="Status: Healthy"></span></h4><p>ShipStation, multi-carrier, real-time tracking</p><div class="node-tags"><span class="tag">ShipStation</span><span class="tag">UPS</span></div></div></div>
+          <div class="node"><div class="node-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg></div><div><h4>Monitoring <span class="status ok" aria-label="Status: Healthy"></span></h4><p>DataDog + Mixpanel + GA4, real-time alerting</p><div class="node-tags"><span class="tag">DataDog</span><span class="tag">Mixpanel</span></div></div></div>
+        </div>
+      </section>
+
+      <!-- Architecture Notes -->
+      <section class="notes-section" id="principles" data-reveal role="region" aria-label="Architecture principles">
+        <h2>Architecture Principles</h2>
+        <div class="notes-grid">
+          <div class="note"><h3>Event-Driven</h3><p>Services communicate via RabbitMQ for loose coupling. Each publishes domain events others subscribe to.</p></div>
+          <div class="note"><h3>Auto-Scaling</h3><p>Kubernetes HPA scales pods based on CPU/memory. Circuit breakers prevent cascade failures.</p></div>
+          <div class="note"><h3>Security-First</h3><p>Zero-trust networking, mTLS between services, encrypted at rest. SOC 2 Type II compliant.</p></div>
+          <div class="note"><h3>Observability</h3><p>Distributed tracing with Jaeger, structured logging with ELK stack, custom dashboards.</p></div>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+  <script>
+    function toggleMenu() { document.getElementById('vizMenuDropdown').classList.toggle('open'); }
+    document.addEventListener('click', function(e) { if (!e.target.closest('.viz-menu')) document.getElementById('vizMenuDropdown').classList.remove('open'); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open'); });
+
+    var savedTheme = localStorage.getItem('viz-theme'); var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t); currentTheme = t;
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var ro = new IntersectionObserver(function(entries) { entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); ro.unobserve(e.target); } }); }, { threshold: 0.1 });
+    document.querySelectorAll('.reveal').forEach(function(el) { ro.observe(el); });
+    setTimeout(function() { document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); }); }, 500);
+
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return; el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), dur = 1000;
+        (function tick(now) { var p = Math.min((now - start) / dur, 1), e = 1 - Math.pow(1 - p, 3), cur = target * e; el.textContent = prefix + (target % 1 !== 0 ? cur.toFixed(2) : Math.round(cur)).toLocaleString() + suffix; if (p < 1) requestAnimationFrame(tick); })(start);
+      });
+    }
+    setTimeout(animateCounters, 300);
+
+    async function downloadImage() {
+      var m = document.querySelector('.viz-menu'); m.style.display = 'none';
+      try { var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } }); var a = document.createElement('a'); a.href = url; a.download = 'architecture.png'; a.click(); } catch(e) { console.error(e); }
+      m.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/claude/skills/visualize/references/animations.md
+++ b/claude/skills/visualize/references/animations.md
@@ -1,0 +1,166 @@
+# Animation Reference — CSS-First, JS-Enhanced
+
+## Philosophy
+
+**CSS animations are the primary animation system.** They're reliable, performant, and don't break when JS has scoping issues. JavaScript is used only for scroll-triggered reveals and number counters.
+
+**Rule: Content must ALWAYS be visible in CSS.** JavaScript adds `.visible` class for entrance animations. If JS fails, everything still shows.
+
+## CDN (Optional — only include when needed)
+
+Motion.js is available for advanced spring physics but is NOT required:
+```html
+<!-- OPTIONAL: only include for spring physics or complex orchestration -->
+<script src="https://cdn.jsdelivr.net/npm/motion@12/dist/motion.js"></script>
+```
+
+## CSS Animations (Primary)
+
+### Entrance Animations
+```css
+/* Base: content is visible by default */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes slideInLeft {
+  from { opacity: 0; transform: translateX(-40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes slideInRight {
+  from { opacity: 0; transform: translateX(40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+/* Apply with staggered delays */
+.animate { animation: fadeInUp 0.6s ease-out both; }
+.animate.delay-1 { animation-delay: 0.1s; }
+.animate.delay-2 { animation-delay: 0.2s; }
+.animate.delay-3 { animation-delay: 0.3s; }
+.animate.delay-4 { animation-delay: 0.4s; }
+.animate.delay-5 { animation-delay: 0.5s; }
+.animate.delay-6 { animation-delay: 0.6s; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate, [class*="animate"] { animation: none !important; }
+}
+```
+
+### Hover Effects (Pure CSS)
+```css
+/* Shadow-only hover — no translateY or scale transforms */
+.card {
+  transition: box-shadow 0.2s ease;
+}
+.card:hover {
+  box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+}
+```
+
+### Scroll-Triggered Reveals (CSS + minimal JS)
+```css
+/* Elements start visible. JS adds .reveal class to opt-in to scroll animation. */
+.reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Stagger children */
+.reveal.visible .stagger:nth-child(1) { transition-delay: 0.05s; }
+.reveal.visible .stagger:nth-child(2) { transition-delay: 0.1s; }
+.reveal.visible .stagger:nth-child(3) { transition-delay: 0.15s; }
+.reveal.visible .stagger:nth-child(4) { transition-delay: 0.2s; }
+.reveal.visible .stagger:nth-child(5) { transition-delay: 0.25s; }
+.reveal.visible .stagger:nth-child(6) { transition-delay: 0.3s; }
+```
+
+## JavaScript (Minimal — scroll observer + counters only)
+
+### Scroll Observer (10 lines)
+```javascript
+// Add .reveal class via JS (not CSS) so content is visible without JS
+document.querySelectorAll('[data-reveal]').forEach(el => el.classList.add('reveal'));
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('visible'); observer.unobserve(e.target); } });
+}, { threshold: 0.15 });
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+```
+
+**Key:** The `data-reveal` attribute marks elements for scroll animation. JS adds the `.reveal` class (which sets opacity:0). When scrolled into view, `.visible` is added (which sets opacity:1). If JS fails, elements never get `.reveal`, so they stay visible.
+
+### Number Counter (15 lines)
+```javascript
+function animateCounters() {
+  document.querySelectorAll('[data-count]').forEach(el => {
+    const target = parseFloat(el.dataset.count);
+    const prefix = el.dataset.prefix || '';
+    const suffix = el.dataset.suffix || '';
+    const duration = 1200;
+    const start = performance.now();
+    function tick(now) {
+      const progress = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
+      el.textContent = prefix + Math.round(target * eased).toLocaleString() + suffix;
+      if (progress < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  });
+}
+// Trigger on scroll into view
+const counterObserver = new IntersectionObserver((entries) => {
+  entries.forEach(e => { if (e.isIntersecting) { animateCounters(); counterObserver.disconnect(); } });
+}, { threshold: 0.3 });
+const firstCounter = document.querySelector('[data-count]');
+if (firstCounter) counterObserver.observe(firstCounter);
+```
+
+### Slide Transitions (CSS-based)
+```css
+.slide { display: none; opacity: 0; transition: opacity 0.3s ease; }
+.slide.active { display: flex; opacity: 1; }
+```
+```javascript
+// Simple slide nav — no animation libraries needed
+var current = 0;
+var transitioning = false;
+function goToSlide(n) {
+  if (n === current || n < 0 || n >= slides.length || transitioning) return;
+  transitioning = true;
+  slides[current].classList.remove('active');
+  slides[n].classList.add('active');
+  current = n;
+  updateUI();
+  setTimeout(() => { transitioning = false; }, 350);
+}
+```
+
+## When to Use Motion.js (Optional)
+
+Only include Motion.js when you specifically need:
+- **Spring physics** — bouncy, organic-feeling animations
+- **Complex orchestration** — multiple elements with precise timing relationships
+- **Scroll-linked animations** — parallax, progress bars linked to scroll position
+
+For everything else, CSS is simpler and more reliable.
+
+## Anti-Patterns
+
+- ❌ `Motion.animate().finished.then()` — Promise chain breaks silently if Motion API changes
+- ❌ `Motion.inView()` with `opacity: 0` in CSS — content invisible if JS fails
+- ❌ `let` declarations for chart variables called before initialization — use `var` for variables referenced across function hoisting boundaries
+- ❌ Complex stagger calculations in JS — use CSS `nth-child` delays instead
+- ❌ Hiding content by default and revealing via JS — content must be visible without JS

--- a/claude/skills/visualize/references/anthropic-skill-guide-notes.md
+++ b/claude/skills/visualize/references/anthropic-skill-guide-notes.md
@@ -1,0 +1,34 @@
+# Anthropic Skill Best Practices — Key Takeaways
+
+Source: "The Complete Guide to Building Skills for Claude" (Anthropic, Jan 2026)
+
+## Critical Rules We Must Follow
+
+1. **SKILL.md naming** — Must be exactly `SKILL.md` (case-sensitive) ✅ We have this
+2. **Folder naming** — kebab-case only ✅ `visualize/`
+3. **No README.md inside skill folder** — All docs in SKILL.md or references/ ⚠️ Need to check
+4. **YAML frontmatter** — Must have `---` delimiters, `name` and `description` required
+5. **No XML tags** (`<` or `>`) in frontmatter — security restriction
+6. **Description must include WHAT and WHEN** — trigger phrases are critical
+7. **SKILL.md under 5,000 words** — move detailed docs to references/
+8. **No "claude" or "anthropic" in skill name** — reserved
+
+## Progressive Disclosure (3 levels)
+- **Level 1 (YAML frontmatter)**: Always in system prompt. Minimal — just enough to trigger.
+- **Level 2 (SKILL.md body)**: Loaded when skill is relevant. Full instructions.
+- **Level 3 (references/)**: Linked files loaded only as needed.
+
+## Our Category
+We are **Category 1: Document & Asset Creation** — creating consistent, high-quality output.
+
+## Key Patterns
+- **Pattern 3: Iterative refinement** — matches our eval loop approach
+- **Pattern 5: Domain-specific intelligence** — our design system knowledge
+
+## What We Should Fix
+1. Check if we have README.md inside skill folder (forbidden)
+2. SKILL.md might be too long (>5000 words) — move more to references/
+3. Ensure YAML description includes clear trigger phrases
+4. Add `metadata` fields (author, version)
+5. Consider adding `license: MIT` to frontmatter
+6. Add `allowed-tools` if applicable

--- a/claude/skills/visualize/references/css-techniques.md
+++ b/claude/skills/visualize/references/css-techniques.md
@@ -1,0 +1,1399 @@
+# Round 2: Advanced CSS & HTML Techniques for Stunning Visualizations
+
+> Compiled 2026-02-25. Every snippet is self-contained and production-ready.
+
+---
+
+## 1. CSS-Only Techniques
+
+### 1.1 Scroll-Snap Presentation (Slide Deck)
+
+```html
+<div class="deck">
+  <section class="slide" style="--bg: #1a1a2e">
+    <h1>Slide One</h1>
+    <p>Full-screen scroll-snap presentation</p>
+  </section>
+  <section class="slide" style="--bg: #16213e">
+    <h1>Slide Two</h1>
+    <p>Each section snaps into view</p>
+  </section>
+  <section class="slide" style="--bg: #0f3460">
+    <h1>Slide Three</h1>
+    <p>No JavaScript required</p>
+  </section>
+</div>
+
+<style>
+.deck {
+  height: 100vh;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+.slide {
+  height: 100vh;
+  scroll-snap-align: start;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  background: var(--bg);
+  color: #fff;
+  font-family: system-ui;
+}
+.slide h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  margin: 0 0 .5em;
+}
+</style>
+```
+
+### 1.2 Conic-Gradient Pie Chart
+
+```html
+<div class="pie-chart" style="--s1: 35; --s2: 25; --s3: 20; --s4: 20;">
+  <div class="legend">
+    <span style="--c: #e63946">Revenue 35%</span>
+    <span style="--c: #457b9d">Costs 25%</span>
+    <span style="--c: #2a9d8f">Growth 20%</span>
+    <span style="--c: #e9c46a">Other 20%</span>
+  </div>
+</div>
+
+<style>
+.pie-chart {
+  --c1: #e63946; --c2: #457b9d; --c3: #2a9d8f; --c4: #e9c46a;
+  width: 250px; height: 250px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--c1) 0% calc(var(--s1) * 1%),
+    var(--c2) calc(var(--s1) * 1%) calc((var(--s1) + var(--s2)) * 1%),
+    var(--c3) calc((var(--s1) + var(--s2)) * 1%) calc((var(--s1) + var(--s2) + var(--s3)) * 1%),
+    var(--c4) calc((var(--s1) + var(--s2) + var(--s3)) * 1%) 100%
+  );
+  position: relative;
+  margin: 2rem;
+}
+/* Donut hole */
+.pie-chart::after {
+  content: '';
+  position: absolute;
+  inset: 25%;
+  background: #fff;
+  border-radius: 50%;
+}
+.legend {
+  position: absolute;
+  top: 110%; left: 0;
+  display: flex; flex-wrap: wrap; gap: .5rem;
+}
+.legend span::before {
+  content: '';
+  display: inline-block;
+  width: 12px; height: 12px;
+  background: var(--c);
+  border-radius: 2px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+</style>
+```
+
+### 1.3 CSS Counters for Auto-Numbering
+
+```html
+<ol class="fancy-list">
+  <li>Define your strategy</li>
+  <li>Gather the data</li>
+  <li>Build the prototype</li>
+  <li>Ship it</li>
+</ol>
+
+<style>
+.fancy-list {
+  counter-reset: steps;
+  list-style: none;
+  padding: 0;
+}
+.fancy-list li {
+  counter-increment: steps;
+  padding: 1rem 1rem 1rem 4rem;
+  position: relative;
+  margin-bottom: 1rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+.fancy-list li::before {
+  content: counter(steps, decimal-leading-zero);
+  position: absolute;
+  left: 1rem; top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #e63946;
+  font-family: system-ui;
+}
+</style>
+```
+
+### 1.4 Container Queries
+
+```html
+<div class="card-container">
+  <article class="card">
+    <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='200'><rect fill='%23457b9d' width='400' height='200'/></svg>" alt="">
+    <div class="card-body">
+      <h3>Responsive Card</h3>
+      <p>This card adapts to its container width, not the viewport.</p>
+    </div>
+  </article>
+</div>
+
+<style>
+.card-container {
+  container-type: inline-size;
+  container-name: card-wrap;
+}
+.card {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+}
+.card img { width: 100%; border-radius: 8px; }
+
+@container card-wrap (min-width: 500px) {
+  .card {
+    grid-template-columns: 200px 1fr;
+    align-items: center;
+  }
+}
+@container card-wrap (min-width: 800px) {
+  .card {
+    grid-template-columns: 300px 1fr;
+    padding: 2rem;
+  }
+  .card h3 { font-size: 1.5rem; }
+}
+</style>
+```
+
+### 1.5 Scroll-Driven Animations
+
+```html
+<div class="scroll-container">
+  <div class="progress-bar"></div>
+  <article class="content">
+    <h1>Scroll-Driven Progress Bar</h1>
+    <p>Lorem ipsum dolor sit amet... (repeat for scrollable content)</p>
+    <!-- Add enough content to scroll -->
+  </article>
+</div>
+
+<style>
+@keyframes grow-progress {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+
+.scroll-container {
+  height: 100vh;
+  overflow-y: scroll;
+}
+
+.progress-bar {
+  position: sticky;
+  top: 0;
+  height: 4px;
+  background: #e63946;
+  transform-origin: left;
+  animation: grow-progress linear;
+  animation-timeline: scroll();
+}
+</style>
+```
+
+### 1.6 View Transitions API (requires JS trigger, CSS defines the animation)
+
+```html
+<style>
+/* Define custom view transition animations */
+::view-transition-old(slide-it) {
+  animation: slide-out 0.4s ease-in both;
+}
+::view-transition-new(slide-it) {
+  animation: slide-in 0.4s ease-out both;
+}
+
+@keyframes slide-out {
+  to { transform: translateX(-100%); opacity: 0; }
+}
+@keyframes slide-in {
+  from { transform: translateX(100%); opacity: 0; }
+}
+
+.main-content {
+  view-transition-name: slide-it;
+}
+</style>
+
+<script>
+// Trigger: call this when swapping content
+function navigate(newHTML) {
+  if (!document.startViewTransition) {
+    document.querySelector('.main-content').innerHTML = newHTML;
+    return;
+  }
+  document.startViewTransition(() => {
+    document.querySelector('.main-content').innerHTML = newHTML;
+  });
+}
+</script>
+```
+
+---
+
+## 2. SVG Animation
+
+### 2.1 Stroke Drawing Animation (stroke-dasharray)
+
+```html
+<svg viewBox="0 0 200 200" width="200" height="200">
+  <path class="draw-path"
+    d="M 10,100 Q 50,10 100,100 T 190,100"
+    fill="none" stroke="#e63946" stroke-width="3"
+    stroke-linecap="round" />
+</svg>
+
+<style>
+.draw-path {
+  stroke-dasharray: 400;
+  stroke-dashoffset: 400;
+  animation: draw 2s ease forwards;
+}
+@keyframes draw {
+  to { stroke-dashoffset: 0; }
+}
+</style>
+```
+
+### 2.2 SVG Morphing with CSS (using d: path())
+
+```html
+<svg viewBox="0 0 200 200" width="200">
+  <path class="morph" fill="#2a9d8f"
+    d="M100,10 L190,70 L160,170 L40,170 L10,70 Z" />
+</svg>
+
+<style>
+.morph {
+  transition: d 0.6s ease-in-out;
+}
+.morph:hover {
+  d: path("M100,10 C155,10 190,55 190,100 C190,145 155,190 100,190 C45,190 10,145 10,100 C10,55 45,10 100,10 Z");
+}
+</style>
+```
+
+### 2.3 Animated SVG Spinner
+
+```html
+<svg class="spinner" viewBox="0 0 50 50" width="50" height="50">
+  <circle cx="25" cy="25" r="20"
+    fill="none" stroke="#457b9d" stroke-width="4"
+    stroke-linecap="round"
+    stroke-dasharray="90 150"
+    stroke-dashoffset="0">
+    <animateTransform attributeName="transform"
+      type="rotate" from="0 25 25" to="360 25 25"
+      dur="1s" repeatCount="indefinite"/>
+  </circle>
+</svg>
+```
+
+### 2.4 Animated SVG Line Chart
+
+```html
+<svg viewBox="0 0 400 200" width="400" style="background:#1a1a2e;border-radius:8px;padding:10px">
+  <!-- Grid lines -->
+  <g stroke="#ffffff15" stroke-width="0.5">
+    <line x1="0" y1="50" x2="400" y2="50"/>
+    <line x1="0" y1="100" x2="400" y2="100"/>
+    <line x1="0" y1="150" x2="400" y2="150"/>
+  </g>
+  <!-- Data line -->
+  <polyline class="chart-line"
+    points="20,160 70,140 120,90 170,120 220,60 270,80 320,30 370,50"
+    fill="none" stroke="#e63946" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Area fill -->
+  <polygon
+    points="20,160 70,140 120,90 170,120 220,60 270,80 320,30 370,50 370,180 20,180"
+    fill="url(#area-grad)" opacity="0.3"/>
+  <defs>
+    <linearGradient id="area-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e63946"/>
+      <stop offset="100%" stop-color="transparent"/>
+    </linearGradient>
+  </defs>
+</svg>
+
+<style>
+.chart-line {
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: draw-line 1.5s ease forwards;
+}
+@keyframes draw-line {
+  to { stroke-dashoffset: 0; }
+}
+</style>
+```
+
+---
+
+## 3. Modern CSS Features
+
+### 3.1 @layer (Cascade Layers)
+
+```css
+/* Control specificity without !important wars */
+@layer reset, base, components, utilities;
+
+@layer reset {
+  *, *::before, *::after { box-sizing: border-box; margin: 0; }
+}
+
+@layer base {
+  body { font-family: system-ui; line-height: 1.6; color: #333; }
+  h1, h2, h3 { line-height: 1.2; }
+}
+
+@layer components {
+  .btn {
+    padding: .75em 1.5em;
+    border: none;
+    border-radius: 8px;
+    background: #457b9d;
+    color: #fff;
+    cursor: pointer;
+    font-weight: 600;
+  }
+}
+
+@layer utilities {
+  .text-center { text-align: center; }
+  .mt-1 { margin-top: 1rem; }
+}
+```
+
+### 3.2 :has() — The Parent Selector
+
+```css
+/* Card with image gets different layout */
+.card:has(img) {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+}
+
+/* Form group highlights when child input is focused */
+.form-group:has(input:focus) {
+  outline: 2px solid #457b9d;
+  border-radius: 8px;
+}
+
+/* Hide placeholder when sibling has content */
+.wrapper:has(.list:empty) .empty-state {
+  display: block;
+}
+```
+
+### 3.3 color-mix() and OKLCH Colors
+
+```css
+:root {
+  /* OKLCH: perceptually uniform, great for design systems */
+  --primary: oklch(55% 0.25 260);        /* vibrant blue */
+  --primary-light: oklch(75% 0.15 260);
+  --primary-dark: oklch(35% 0.25 260);
+
+  /* Generate hover states with color-mix */
+  --btn-hover: color-mix(in oklch, var(--primary) 85%, white);
+  --btn-active: color-mix(in oklch, var(--primary) 85%, black);
+
+  /* Semi-transparent from any color */
+  --overlay: color-mix(in srgb, var(--primary) 50%, transparent);
+}
+
+.badge {
+  /* Automatic tints */
+  --badge-bg: color-mix(in oklch, var(--badge-color, #e63946) 20%, white);
+  background: var(--badge-bg);
+  color: var(--badge-color, #e63946);
+  padding: .25em .75em;
+  border-radius: 999px;
+  font-weight: 600;
+}
+```
+
+### 3.4 Subgrid
+
+```html
+<div class="grid-parent">
+  <article class="grid-child">
+    <h3>Title</h3>
+    <p>Description that might be long</p>
+    <footer>Action</footer>
+  </article>
+  <article class="grid-child">
+    <h3>Short</h3>
+    <p>Brief</p>
+    <footer>Action</footer>
+  </article>
+</div>
+
+<style>
+.grid-parent {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1.5rem;
+  /* Define the row template children align to */
+  grid-template-rows: subgrid; /* only works in explicit grid */
+}
+
+/* Practical subgrid: cards with aligned rows */
+.grid-child {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+.grid-child footer {
+  align-self: end;
+}
+</style>
+```
+
+### 3.5 Anchor Positioning
+
+```html
+<button id="trigger" class="anchor-btn">Hover me</button>
+<div class="tooltip" popover>I'm anchored to the button!</div>
+
+<style>
+.anchor-btn {
+  anchor-name: --my-anchor;
+  padding: .75em 1.5em;
+  background: #457b9d;
+  color: white;
+  border: none;
+  border-radius: 8px;
+}
+
+.tooltip {
+  position: fixed;
+  position-anchor: --my-anchor;
+  top: anchor(bottom);
+  left: anchor(center);
+  translate: -50% 8px;
+  background: #1a1a2e;
+  color: white;
+  padding: .5em 1em;
+  border-radius: 6px;
+  font-size: .875rem;
+  margin: 0;
+  border: none;
+}
+
+.anchor-btn:hover + .tooltip {
+  display: block;
+}
+</style>
+```
+
+---
+
+## 4. Print CSS Mastery
+
+### 4.1 Complete Print Stylesheet
+
+```css
+@media print {
+  /* Page setup */
+  @page {
+    size: A4 portrait;
+    margin: 2cm 2.5cm;
+
+    @top-center {
+      content: "Company Report 2026";
+      font-size: 9pt;
+      color: #999;
+    }
+    @bottom-right {
+      content: "Page " counter(page) " of " counter(pages);
+      font-size: 9pt;
+      color: #999;
+    }
+  }
+
+  @page :first {
+    @top-center { content: none; } /* No header on first page */
+    margin-top: 4cm;
+  }
+
+  /* Clean up for print */
+  body {
+    font-size: 11pt;
+    line-height: 1.5;
+    color: #000;
+    background: #fff;
+  }
+
+  /* Hide non-print elements */
+  nav, .sidebar, .no-print, button, .interactive {
+    display: none !important;
+  }
+
+  /* Page break control */
+  h1, h2, h3 {
+    break-after: avoid;   /* Don't break right after a heading */
+    page-break-after: avoid;
+  }
+
+  table, figure, .chart {
+    break-inside: avoid;  /* Keep tables/figures together */
+    page-break-inside: avoid;
+  }
+
+  section {
+    break-before: page;   /* Each section starts a new page */
+  }
+
+  /* Make links visible */
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 9pt;
+    color: #666;
+  }
+
+  /* Force backgrounds to print */
+  .chart, .badge, .highlight {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* Table styling for print */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    border: 0.5pt solid #ccc;
+    padding: 6pt 8pt;
+    text-align: left;
+  }
+  thead {
+    display: table-header-group; /* Repeat header on each page */
+  }
+}
+```
+
+### 4.2 Print-Specific Page Types
+
+```css
+@page cover {
+  margin: 0;
+  @top-center { content: none; }
+  @bottom-right { content: none; }
+}
+
+@page landscape {
+  size: A4 landscape;
+}
+
+.cover-page { page: cover; }
+.wide-table-page { page: landscape; }
+```
+
+---
+
+## 5. Micro-Interactions
+
+### 5.1 Magnetic Hover Button
+
+```html
+<button class="mag-btn">
+  <span>Get Started</span>
+</button>
+
+<style>
+.mag-btn {
+  --x: 0; --y: 0;
+  position: relative;
+  padding: 1em 2.5em;
+  background: #1a1a2e;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1); /* spring */
+}
+
+.mag-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at var(--x, 50%) var(--y, 50%),
+    rgba(255,255,255,0.15) 0%,
+    transparent 60%
+  );
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.mag-btn:hover::before { opacity: 1; }
+
+.mag-btn:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+}
+
+.mag-btn:active {
+  transform: translateY(0) scale(0.98);
+  transition-duration: 0.1s;
+}
+</style>
+
+<script>
+document.querySelector('.mag-btn').addEventListener('mousemove', e => {
+  const r = e.target.getBoundingClientRect();
+  e.target.style.setProperty('--x', ((e.clientX - r.left) / r.width * 100) + '%');
+  e.target.style.setProperty('--y', ((e.clientY - r.top) / r.height * 100) + '%');
+});
+</script>
+```
+
+### 5.2 Spring Animation with CSS
+
+```css
+/* Spring-like bounce via cubic-bezier overshoot */
+.spring-pop {
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.spring-pop:hover {
+  transform: scale(1.1);
+}
+
+/* Multi-step spring with keyframes */
+@keyframes spring-in {
+  0%   { transform: scale(0); opacity: 0; }
+  50%  { transform: scale(1.12); }
+  70%  { transform: scale(0.95); }
+  85%  { transform: scale(1.03); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.spring-enter {
+  animation: spring-in 0.6s ease both;
+}
+```
+
+### 5.3 Staggered Card Reveal
+
+```html
+<div class="card-grid">
+  <div class="reveal-card" style="--i:0">Card 1</div>
+  <div class="reveal-card" style="--i:1">Card 2</div>
+  <div class="reveal-card" style="--i:2">Card 3</div>
+  <div class="reveal-card" style="--i:3">Card 4</div>
+</div>
+
+<style>
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(30px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.reveal-card {
+  animation: fade-up 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: calc(var(--i) * 0.1s);
+  padding: 2rem;
+  background: #f8f9fa;
+  border-radius: 12px;
+  text-align: center;
+  font-weight: 600;
+}
+</style>
+```
+
+### 5.4 Ripple Effect (CSS + minimal JS)
+
+```html
+<button class="ripple-btn" onclick="ripple(event)">Click Me</button>
+
+<style>
+.ripple-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 1em 2em;
+  background: #2a9d8f;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.ripple-btn .ripple-circle {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.4);
+  transform: scale(0);
+  animation: ripple-anim 0.6s ease-out;
+  pointer-events: none;
+}
+
+@keyframes ripple-anim {
+  to { transform: scale(4); opacity: 0; }
+}
+</style>
+
+<script>
+function ripple(e) {
+  const btn = e.currentTarget;
+  const c = document.createElement('span');
+  c.classList.add('ripple-circle');
+  const r = btn.getBoundingClientRect();
+  const d = Math.max(r.width, r.height);
+  c.style.width = c.style.height = d + 'px';
+  c.style.left = (e.clientX - r.left - d/2) + 'px';
+  c.style.top = (e.clientY - r.top - d/2) + 'px';
+  btn.appendChild(c);
+  c.addEventListener('animationend', () => c.remove());
+}
+</script>
+```
+
+---
+
+## 6. Data Visualization Without Libraries
+
+### 6.1 Pure CSS Bar Chart
+
+```html
+<div class="bar-chart" style="--max: 100">
+  <div class="bar" style="--val: 85; --c: #e63946">
+    <span class="label">Q1</span>
+    <span class="value">85%</span>
+  </div>
+  <div class="bar" style="--val: 62; --c: #457b9d">
+    <span class="label">Q2</span>
+    <span class="value">62%</span>
+  </div>
+  <div class="bar" style="--val: 94; --c: #2a9d8f">
+    <span class="label">Q3</span>
+    <span class="value">94%</span>
+  </div>
+  <div class="bar" style="--val: 71; --c: #e9c46a">
+    <span class="label">Q4</span>
+    <span class="value">71%</span>
+  </div>
+</div>
+
+<style>
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 1.5rem;
+  height: 250px;
+  padding: 1rem 2rem;
+  border-left: 2px solid #ddd;
+  border-bottom: 2px solid #ddd;
+}
+
+.bar {
+  flex: 1;
+  height: calc(var(--val) / var(--max) * 100%);
+  background: var(--c);
+  border-radius: 8px 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  padding-bottom: 0.5rem;
+  position: relative;
+  transition: height 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
+  min-width: 60px;
+}
+
+.bar .value {
+  position: absolute;
+  top: -1.5rem;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: var(--c);
+}
+
+.bar .label {
+  position: absolute;
+  bottom: -2rem;
+  font-size: 0.8rem;
+  color: #666;
+  font-weight: 600;
+}
+</style>
+```
+
+### 6.2 CSS Horizontal Bar Chart (Data Table Hybrid)
+
+```html
+<table class="h-bar-chart">
+  <tr><th>React</th><td style="--val: 92"><span>92%</span></td></tr>
+  <tr><th>Vue</th><td style="--val: 67"><span>67%</span></td></tr>
+  <tr><th>Svelte</th><td style="--val: 54"><span>54%</span></td></tr>
+  <tr><th>Angular</th><td style="--val: 48"><span>48%</span></td></tr>
+</table>
+
+<style>
+.h-bar-chart {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: system-ui;
+}
+.h-bar-chart th {
+  text-align: right;
+  padding: .75rem 1rem;
+  width: 100px;
+  font-weight: 600;
+  color: #333;
+}
+.h-bar-chart td {
+  padding: .75rem 0;
+  position: relative;
+}
+.h-bar-chart td::before {
+  content: '';
+  display: block;
+  height: 32px;
+  width: calc(var(--val) * 1%);
+  background: linear-gradient(90deg, #457b9d, #2a9d8f);
+  border-radius: 0 6px 6px 0;
+  transition: width 1s ease;
+}
+.h-bar-chart td span {
+  position: absolute;
+  left: calc(var(--val) * 1% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: .8rem;
+  font-weight: 700;
+  color: #457b9d;
+}
+</style>
+```
+
+### 6.3 CSS Heatmap
+
+```html
+<div class="heatmap">
+  <div class="cell" style="--v:0.1">M</div>
+  <div class="cell" style="--v:0.4">T</div>
+  <div class="cell" style="--v:0.8">W</div>
+  <div class="cell" style="--v:0.6">T</div>
+  <div class="cell" style="--v:0.95">F</div>
+  <div class="cell" style="--v:0.3">S</div>
+  <div class="cell" style="--v:0.1">S</div>
+</div>
+
+<style>
+.heatmap {
+  display: grid;
+  grid-template-columns: repeat(7, 48px);
+  gap: 4px;
+}
+.cell {
+  aspect-ratio: 1;
+  display: grid;
+  place-content: center;
+  border-radius: 6px;
+  font-size: .75rem;
+  font-weight: 600;
+  /* Interpolate green heatmap via oklch */
+  background: color-mix(
+    in oklch,
+    oklch(90% 0.05 145) calc((1 - var(--v)) * 100%),
+    oklch(55% 0.2 145) calc(var(--v) * 100%)
+  );
+  color: color-mix(
+    in oklch,
+    oklch(30% 0.05 145) calc(var(--v) * 100%),
+    oklch(50% 0.05 145) calc((1 - var(--v)) * 100%)
+  );
+}
+</style>
+```
+
+### 6.4 CSS Sparkline (inline mini chart)
+
+```html
+<span class="sparkline" style="--d: polygon(0% 80%, 14% 60%, 28% 40%, 42% 70%, 57% 20%, 71% 35%, 85% 10%, 100% 30%, 100% 100%, 0% 100%)"></span>
+
+<style>
+.sparkline {
+  display: inline-block;
+  width: 80px;
+  height: 24px;
+  background: linear-gradient(to top, rgba(42,157,143,0.2), rgba(42,157,143,0.05));
+  clip-path: var(--d);
+  vertical-align: middle;
+}
+</style>
+```
+
+---
+
+## 7. Typography Tricks
+
+### 7.1 Fluid Type with clamp()
+
+```css
+:root {
+  /* Fluid type scale — no media queries needed */
+  --fs-sm: clamp(0.8rem, 0.7rem + 0.25vw, 0.9rem);
+  --fs-base: clamp(1rem, 0.9rem + 0.35vw, 1.125rem);
+  --fs-lg: clamp(1.25rem, 1rem + 0.75vw, 1.75rem);
+  --fs-xl: clamp(1.75rem, 1.2rem + 1.5vw, 3rem);
+  --fs-2xl: clamp(2.5rem, 1.5rem + 3vw, 5rem);
+}
+
+body { font-size: var(--fs-base); }
+h1 { font-size: var(--fs-2xl); }
+h2 { font-size: var(--fs-xl); }
+h3 { font-size: var(--fs-lg); }
+small { font-size: var(--fs-sm); }
+```
+
+### 7.2 Text Gradient
+
+```css
+.gradient-text {
+  background: linear-gradient(135deg, #e63946, #457b9d, #2a9d8f);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-size: clamp(2rem, 5vw, 5rem);
+  font-weight: 900;
+  line-height: 1.1;
+}
+```
+
+### 7.3 Variable Fonts
+
+```css
+@font-face {
+  font-family: 'Inter';
+  src: url('Inter-VariableFont.woff2') format('woff2-variations');
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+.variable-demo {
+  font-family: 'Inter', system-ui;
+  font-variation-settings: 'wght' 400, 'slnt' 0;
+  transition: font-variation-settings 0.3s ease;
+}
+
+.variable-demo:hover {
+  font-variation-settings: 'wght' 800, 'slnt' -10;
+}
+
+/* Animating weight */
+@keyframes breathe {
+  0%, 100% { font-variation-settings: 'wght' 300; }
+  50%      { font-variation-settings: 'wght' 800; }
+}
+
+.text-breathe {
+  animation: breathe 3s ease-in-out infinite;
+}
+```
+
+### 7.4 Optical Sizing & Kerning
+
+```css
+.refined-type {
+  font-kerning: auto;
+  font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+  font-optical-sizing: auto;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.02em; /* tighten display type */
+  text-wrap: balance; /* modern balanced wrapping */
+}
+```
+
+---
+
+## 8. Design Trends in CSS
+
+### 8.1 Glassmorphism
+
+```html
+<div class="glass-bg">
+  <div class="glass-card">
+    <h3>Glass Card</h3>
+    <p>Frosted glass effect with backdrop-filter</p>
+  </div>
+</div>
+
+<style>
+.glass-bg {
+  min-height: 300px;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  display: grid;
+  place-content: center;
+  padding: 2rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 16px;
+  padding: 2rem 3rem;
+  color: white;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+</style>
+```
+
+### 8.2 Neumorphism
+
+```html
+<div class="neu-surface">
+  <div class="neu-card">
+    <div class="neu-inset">42</div>
+    <p>Metric Value</p>
+  </div>
+</div>
+
+<style>
+.neu-surface {
+  background: #e0e5ec;
+  min-height: 300px;
+  display: grid;
+  place-content: center;
+  padding: 2rem;
+}
+
+.neu-card {
+  background: #e0e5ec;
+  border-radius: 20px;
+  padding: 2rem 3rem;
+  text-align: center;
+  box-shadow:
+    8px 8px 16px #b8bec7,
+    -8px -8px 16px #ffffff;
+}
+
+.neu-inset {
+  background: #e0e5ec;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: #457b9d;
+  box-shadow:
+    inset 4px 4px 8px #b8bec7,
+    inset -4px -4px 8px #ffffff;
+}
+</style>
+```
+
+### 8.3 Claymorphism
+
+```css
+.clay-card {
+  background: linear-gradient(135deg, #f5e6ff, #e8d5f5);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow:
+    8px 8px 16px rgba(0, 0, 0, 0.1),
+    inset -4px -4px 8px rgba(0, 0, 0, 0.05),
+    inset 4px 4px 8px rgba(255, 255, 255, 0.8);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+}
+```
+
+---
+
+## 9. Dark Mode Best Practices
+
+### 9.1 Complete Dark Mode System
+
+```css
+:root {
+  /* Light mode (default) */
+  color-scheme: light dark;
+
+  --surface-0: #ffffff;
+  --surface-1: #f8f9fa;
+  --surface-2: #e9ecef;
+  --text-primary: #1a1a2e;
+  --text-secondary: #6c757d;
+  --border: #dee2e6;
+  --accent: oklch(55% 0.25 260);
+  --shadow: rgba(0, 0, 0, 0.1);
+
+  /* Semantic tokens */
+  --success: oklch(60% 0.2 145);
+  --warning: oklch(75% 0.18 85);
+  --danger: oklch(55% 0.22 25);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface-0: #0d1117;
+    --surface-1: #161b22;
+    --surface-2: #21262d;
+    --text-primary: #e6edf3;
+    --text-secondary: #8b949e;
+    --border: #30363d;
+    --accent: oklch(72% 0.18 260);
+    --shadow: rgba(0, 0, 0, 0.4);
+
+    --success: oklch(72% 0.16 145);
+    --warning: oklch(80% 0.14 85);
+    --danger: oklch(70% 0.18 25);
+  }
+}
+
+/* Manual toggle override */
+[data-theme="dark"] {
+  --surface-0: #0d1117;
+  --surface-1: #161b22;
+  --surface-2: #21262d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --border: #30363d;
+  --accent: oklch(72% 0.18 260);
+  --shadow: rgba(0, 0, 0, 0.4);
+}
+
+/* Usage */
+body {
+  background: var(--surface-0);
+  color: var(--text-primary);
+}
+
+.card {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 8px var(--shadow);
+}
+```
+
+### 9.2 Dark Mode Image Handling
+
+```css
+/* Dim images slightly in dark mode */
+@media (prefers-color-scheme: dark) {
+  img:not([src*=".svg"]) {
+    filter: brightness(0.85) contrast(1.1);
+  }
+
+  /* Invert diagrams/illustrations that are black-on-white */
+  img.invertible {
+    filter: invert(1) hue-rotate(180deg) brightness(0.9);
+  }
+
+  /* Reduce shadow intensity on elevated surfaces */
+  .elevated {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  }
+}
+```
+
+---
+
+## 10. Performance
+
+### 10.1 CSS Containment
+
+```css
+/* Tell the browser this element is isolated — huge perf win for complex pages */
+.widget {
+  contain: layout style paint; /* or contain: strict for all */
+  content-visibility: auto;    /* skip rendering when off-screen */
+  contain-intrinsic-size: 0 500px; /* estimated size for content-visibility */
+}
+
+/* For repeated list items */
+.list-item {
+  contain: layout style;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 80px;
+}
+```
+
+### 10.2 will-change (Use Sparingly)
+
+```css
+/* Only apply will-change right before animation */
+.animated-el {
+  transition: transform 0.3s, opacity 0.3s;
+}
+.animated-el:hover {
+  will-change: transform, opacity;
+}
+.animated-el.animating {
+  will-change: transform, opacity;
+}
+/* Remove after animation completes via JS */
+
+/* NEVER do this globally: */
+/* * { will-change: transform; }  ← destroys performance */
+```
+
+### 10.3 Reducing Repaints
+
+```css
+/* Use transform/opacity for animations — they don't trigger layout/paint */
+.good {
+  /* ✅ GPU-composited, no repaints */
+  transition: transform 0.3s, opacity 0.3s;
+}
+.good:hover {
+  transform: translateY(-4px) scale(1.02);
+  opacity: 0.9;
+}
+
+.bad {
+  /* ❌ Triggers layout recalc + repaint */
+  transition: top 0.3s, width 0.3s, margin 0.3s;
+}
+
+/* Use translate instead of positioning */
+.slide-in {
+  transform: translateX(-100%);
+  transition: transform 0.4s ease;
+}
+.slide-in.active {
+  transform: translateX(0);
+}
+```
+
+### 10.4 Lazy Loading & Resource Hints
+
+```html
+<!-- Native lazy loading -->
+<img src="hero.jpg" alt="Hero" loading="eager" fetchpriority="high">
+<img src="below-fold.jpg" alt="" loading="lazy">
+
+<!-- Preload critical resources -->
+<link rel="preload" href="critical-font.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="hero.jpg" as="image" fetchpriority="high">
+
+<!-- Preconnect to external origins -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="dns-prefetch" href="https://analytics.example.com">
+
+<!-- Optimal font loading -->
+<style>
+@font-face {
+  font-family: 'MyFont';
+  src: url('myfont.woff2') format('woff2');
+  font-display: swap; /* Show fallback immediately, swap when ready */
+  unicode-range: U+0000-00FF; /* Only load Latin chars */
+}
+</style>
+```
+
+### 10.5 Critical CSS Pattern
+
+```html
+<head>
+  <!-- Inline critical CSS for above-the-fold content -->
+  <style>
+    /* Only what's needed for first paint */
+    body { margin: 0; font-family: system-ui; }
+    .hero { min-height: 100vh; display: grid; place-content: center; }
+  </style>
+
+  <!-- Defer non-critical CSS -->
+  <link rel="preload" href="full-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="full-styles.css"></noscript>
+</head>
+```
+
+---
+
+## Bonus: Composable Utility Patterns
+
+### Animation Composition
+
+```css
+/* Reusable timing functions */
+:root {
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-in-out-circ: cubic-bezier(0.85, 0, 0.15, 1);
+}
+
+/* Stagger system */
+[data-stagger] > * {
+  --delay: calc(var(--i, 0) * 80ms);
+  animation-delay: var(--delay) !important;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+### Complete Design Token System
+
+```css
+:root {
+  /* Spacing scale */
+  --space-xs: clamp(0.25rem, 0.2rem + 0.15vw, 0.375rem);
+  --space-sm: clamp(0.5rem, 0.4rem + 0.3vw, 0.75rem);
+  --space-md: clamp(1rem, 0.85rem + 0.5vw, 1.5rem);
+  --space-lg: clamp(1.5rem, 1.2rem + 1vw, 2.5rem);
+  --space-xl: clamp(2rem, 1.5rem + 2vw, 4rem);
+
+  /* Border radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-full: 999px;
+
+  /* Shadows (elevation system) */
+  --shadow-sm: 0 1px 2px var(--shadow);
+  --shadow-md: 0 4px 12px var(--shadow);
+  --shadow-lg: 0 12px 32px var(--shadow);
+  --shadow-xl: 0 24px 48px var(--shadow);
+}
+```

--- a/claude/skills/visualize/references/design-system.md
+++ b/claude/skills/visualize/references/design-system.md
@@ -1,0 +1,598 @@
+## Design System
+
+Apply these defaults. They are opinionated and tested — override only when user requests it.
+
+### Design Notes
+- **Use inline SVG for icons, NOT emojis.** Simple path-based SVGs for a professional look. See the Icons section above.
+- **Chart.js charts MUST be destroyed and recreated on theme toggle** — not just CSS variable swaps. Colors are read at render time, so the chart must be rebuilt with new computed values.
+- **Chart.js: DISABLE default animation** — Add `Chart.defaults.animation = false;` before creating charts. Default animations cause charts to appear blank/broken in screenshots, Playwright tests, and initial renders. This is a recurring bug that caused "broken charts" in rounds 13-25.
+- **Chart.js: Use explicit color values** — Don't concatenate CSS variable values with hex alpha suffixes (e.g., `c.remote + '18'`). Use explicit `rgba()` values instead: `'rgba(12, 206, 107, 0.15)'`.
+- **Chart.js: Don't use resetCanvas** — Just reuse the same canvas element. Destroy the old chart instance with `.destroy()` then create a new one on the same canvas.
+- **Chart.js: Build after layout is stable** — Use `window.addEventListener('load', ...)` with a short `setTimeout(200)` and trigger `window.dispatchEvent(new Event('resize'))` after building.
+
+### Typography
+- **Primary font:** Inter via Google Fonts CDN — `https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap`
+- **Professional letter-spacing (Apple/Stripe-inspired):**
+  - **Hero headings (h1):** `letter-spacing: -0.03em` — tight like Apple keynote titles
+  - **Section headings (h2-h3):** `letter-spacing: -0.02em`
+  - **Body text:** `letter-spacing: -0.011em` for refined readability
+  - **Labels/caps:** `letter-spacing: 0.05em` for small uppercase text
+  - **Font features:** `font-feature-settings: 'cv11', 'ss01';` for Inter's stylistic alternates
+- **Font-weight hierarchy (Stripe-inspired):**
+  - **h1:** `font-weight: 700` (bold, not 800 — optically cleaner at large sizes)
+  - **h2:** `font-weight: 600` (semibold)
+  - **Card titles:** `font-weight: 600`
+  - **Body text:** `font-weight: 400` (regular)
+  - **Labels:** `font-weight: 500` (medium)
+- **Text colors (Vercel-inspired):** Never pure white. Use `#ededed` or `var(--text)` which maps to `#f5f5f7` in dark mode. Secondary text at 60% opacity feel (`#888` or `var(--text-secondary)`)
+- **NO gradient text on headings** — use solid colors only. Gradient text looks cheap at scale.
+- **Multilingual support:** When content includes non-Latin text (Korean, Japanese, Chinese, etc.), add the appropriate Google Fonts:
+  - **Korean:** Noto Sans KR — `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap`
+  - **Japanese:** Noto Sans JP — `https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700;800;900&display=swap`
+  - **Chinese (Simplified):** Noto Sans SC — `https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;600;700;800;900&display=swap`
+  - **Arabic:** Noto Sans Arabic — `https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@300;400;500;600;700;800;900&display=swap`
+  - Set `font-family: 'Noto Sans KR', 'Inter', sans-serif;` (CJK font first, then Inter fallback for numbers/Latin)
+  - Set `<html lang="ko">` (or appropriate language code)
+- **Custom fonts:** When the user requests a specific font or vibe:
+  - **Serif/editorial:** Lora, Playfair Display, Source Serif Pro
+  - **Monospace/code:** JetBrains Mono, Fira Code, Source Code Pro
+  - **Display/creative:** Space Grotesk, Outfit, Sora, Poppins
+  - **Handwritten:** Caveat, Patrick Hand
+  - Always load via Google Fonts CDN: `https://fonts.googleapis.com/css2?family=FONTNAME:wght@WEIGHTS&display=swap`
+  - Update the `--font-primary` CSS var and `body { font-family: ... }` accordingly
+- **Light mode text optimization:** Use softer text colors, not harsh black:
+  - Primary text: `#1a1a1a` (not #000000) for better readability
+  - Secondary text: `#666666` for proper hierarchy
+  - Never pure black text on white backgrounds - it's too harsh
+- **Font detection:** Infer the right font from context:
+  - Korean/Japanese/Chinese content → auto-add Noto Sans KR/JP/SC
+  - Code-heavy content (cheat sheets) → add JetBrains Mono for code blocks
+  - Formal/editorial content → consider a serif font for headings
+  - Playful/creative content → consider display fonts
+- **Monospace:** JetBrains Mono or system `'SF Mono', 'Fira Code', 'Consolas', monospace`
+- **Fallback:** `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`
+- **Type scale (dramatic):** Make hero titles bigger, body should breathe more — 14 → 16 → 20 → 25 → 31 → 39 → 49px
+- **Line-height:** 1.5–1.7 for body, 1.1 for headings (tight for professional feel)
+- **Max line width:** 65–75 characters for readability
+- Use `clamp()` for fluid responsive sizing: `clamp(1rem, 2.5vw, 1.25rem)`
+
+### Modern CSS Techniques (Chrome 105+)
+
+Use these cutting-edge CSS features where supported for better UX:
+
+**Popover API** (Chrome 114+) — Zero-JS tooltips, info panels, and modals:
+```html
+<button popovertarget="info-panel">ℹ Details</button>
+<div id="info-panel" popover>
+  <h3>More Information</h3>
+  <p>Details shown on click, no JS needed.</p>
+</div>
+```
+```css
+[popover] {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 16px; max-width: 320px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+}
+[popover]::backdrop { background: rgba(0,0,0,0.3); }
+```
+Use for: dashboard metric details, architecture node info, chart annotations.
+
+**Exclusive `<details>` Accordion** (Chrome 120+) — Collapsible sections, no JS:
+```html
+<details name="faq" open><summary>Section 1</summary><p>Content</p></details>
+<details name="faq"><summary>Section 2</summary><p>Content</p></details>
+```
+Same `name` attribute = only one open at a time. Use for: cheatsheets, process guides, FAQs, any content with collapsible groups.
+
+**`::details-content` Styling** (Chrome 131+) — Animate accordion open/close:
+```css
+details { overflow: hidden; }
+::details-content {
+  transition: block-size 0.3s ease, opacity 0.3s ease;
+  block-size: 0; opacity: 0;
+}
+details[open]::details-content {
+  block-size: auto; opacity: 1;
+}
+```
+
+**CSS Anchor Positioning** (Chrome 125+) — Position tooltips relative to elements:
+```css
+.node { anchor-name: --node-tooltip; }
+.tooltip {
+  position: fixed; position-anchor: --node-tooltip;
+  position-area: block-start; margin-bottom: 8px;
+}
+```
+Use for: architecture diagrams, org charts, any element needing positioned annotations.
+
+**Container Queries** — Size elements based on their container, not viewport:
+```css
+.card-container {
+  container-type: inline-size;
+  container-name: card;
+}
+@container card (width > 400px) {
+  .card-title { font-size: clamp(1.25rem, 4cqi, 2rem); }
+}
+```
+
+**:has() Parent Selector** — Style elements based on their children:
+```css
+/* Style card if it contains an image */
+.card:has(img) { padding-block: 2rem; }
+/* Reduce spacing on headings followed by subheadings */
+h1:has(+ h2) { margin-bottom: 0.25rem; }
+```
+
+**color-mix() Function** — Dynamic color generation:
+```css
+background: color-mix(in oklch, var(--accent), transparent 20%);
+border-color: color-mix(in srgb, var(--text), var(--bg) 85%);
+```
+
+**light-dark() Function** (Chrome 123+) — Single-property theme switching:
+```css
+:root { color-scheme: light dark; }
+background: light-dark(white, #1a1a1a);
+color: light-dark(#333, #fff);
+```
+
+**@starting-style** (Chrome 117+) — Entry animations for new elements:
+```css
+.modal {
+  opacity: 1; transform: scale(1);
+  transition: opacity 0.3s, transform 0.3s;
+  @starting-style {
+    opacity: 0; transform: scale(0.8);
+  }
+}
+```
+
+### Color System (Class-Based Theming — NO @media prefers-color-scheme)
+
+**CRITICAL: Do NOT use `@media (prefers-color-scheme)` for theme variables.** It fights with class-based `.theme-dark`/`.theme-light` and causes themes to break when OS mode differs from selected theme. Use ONLY class-based selectors on `html`:
+
+```css
+/* Theme via class on <html> — JS detects prefers-color-scheme on first load */
+html.theme-dark {
+  --bg: #0A0A0A;              /* near-black (Linear-inspired) */
+  --surface: #141414;          /* barely lighter than bg */
+  --surface-hover: #1C1C1C;
+  --border: rgba(255,255,255,0.04);  /* nearly invisible borders */
+  --text: #EDEDED;             /* not pure white */
+  --text-secondary: #888888;
+  --accent: #3b82f6;
+  --accent-secondary: #8b5cf6;
+  --positive: #10b981;
+  --negative: #f43f5e;
+  --warning: #f59e0b;
+  --info: #06b6d4;             /* semantic info color */
+  --muted: #0f0f0f;            /* subtle backgrounds */
+}
+html.theme-light {
+  --bg: #FAFAF9;               /* warm off-white */
+  --surface: #FFFFFF;
+  --surface-hover: #F5F5F4;
+  --border: #e5e5e5;           /* more visible than 0.06 opacity */
+  --text: #1a1a1a;             /* softer than pure black */
+  --text-secondary: #666666;   /* better contrast than #64748b */
+  --accent: #2563eb;
+  --accent-secondary: #7c3aed;
+  --positive: #059669;
+  --negative: #e11d48;
+  --warning: #d97706;
+  --info: #0ea5e9;             /* semantic info color */
+  --muted: #f8fafc;            /* subtle backgrounds */
+}
+```
+
+**JS theme init** detects OS preference on first visit, then uses localStorage override:
+```javascript
+var saved = localStorage.getItem('viz-theme');
+var initial = saved || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+applyTheme(initial);
+```
+
+Chart color sequence: `#3b82f6, #8b5cf6, #ec4899, #f59e0b, #10b981, #06b6d4, #f43f5e`
+
+### Semantic Color Usage (Professional Standards)
+
+Use colors with semantic meaning, not decoration:
+
+**Success/Positive Metrics** — `var(--positive)` (green):
+- Revenue growth, user acquisition, completion rates
+- Up arrows, positive percentages, "good" status indicators
+
+**Warning/Caution** — `var(--warning)` (amber):
+- Metrics approaching thresholds, pending statuses
+- Neutral alerts, "attention needed" indicators
+
+**Error/Negative Metrics** — `var(--negative)` (red):
+- Declining metrics, failures, critical alerts
+- Down arrows, negative percentages, error states
+
+**Info/Primary Actions** — `var(--info)` (blue):
+- Primary CTAs, informational highlights, process steps
+
+**Accent Restraint Rules**:
+- **KPI grids with 4+ cards:** Use at most 2 accent colors — `var(--accent)` for the single most important metric, `var(--text)` for others
+- **Never colorize numbers randomly** — color must indicate semantic meaning
+- **Delta indicators only:** Use `var(--positive)`/`var(--negative)` for arrows and percentages, not main values
+
+### Professional Card System
+
+Modern card styling beyond basic borders:
+
+```css
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;                    /* Larger than 8px for premium feel */
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05); /* Subtle depth in light mode */
+  padding: 24px;                          /* Generous internal spacing */
+  transition: all 0.15s ease;
+}
+
+/* Light mode: visible shadows */
+.theme-light .card {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05), 0 0 0 1px rgba(0,0,0,0.03);
+}
+
+/* Dark mode: border emphasis */
+.theme-dark .card {
+  box-shadow: 0 0 0 1px var(--border);
+}
+
+.card:hover {
+  /* Light mode: deeper shadow */
+  box-shadow: 0 4px 16px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.03);
+}
+
+.theme-dark .card:hover {
+  /* Dark mode: brighter border */
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
+}
+```
+
+**Key principles:**
+- 12px border radius for premium feel (not 8px)
+- Light mode emphasizes shadows, dark mode emphasizes borders
+- Consistent 24px internal padding
+- Hover states enhance the existing visual style
+
+### Chart.js Professional Styling
+
+Beyond library defaults — apply these to every chart:
+
+```css
+.chart-container {
+  padding: 40px;          /* Breathing room around chart */
+  min-height: 360px;      /* Substantial presence on dashboard */
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+/* Remove excessive grid lines */
+.chart-canvas {
+  border-radius: 8px;     /* Inner chart gets smaller radius */
+}
+```
+
+**Chart configuration enhancements:**
+- Custom padding: `layout: { padding: { top: 30, right: 30, bottom: 30, left: 30 } }`
+- Rounded corners on bars: `borderRadius: 4`
+- Professional grid opacity: Light mode `rgba(0,0,0,0.04)`, Dark mode `rgba(255,255,255,0.02)`
+- Thoughtful color palettes matching theme accent
+- Axis label sizing: minimum 13px for readability
+- Remove default animations: `Chart.defaults.animation = false`
+
+### Spacing
+- **8px grid** — all spacing in multiples: 4, 8, 12, 16, 24, 32, 48, 64, 96px
+- **Generous padding** — `p-6` to `p-8` on cards, `px-8` on containers
+- **Container:** `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8`
+- **Card gaps:** `gap-6` minimum
+
+### Mobile Responsiveness (Critical)
+**All visualizations must work flawlessly on mobile. No horizontal overflow allowed.**
+
+```css
+/* Required mobile breakpoints */
+@media (max-width: 768px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr; /* Single column on tablet */
+    gap: 1rem; /* Reduced gap */
+  }
+  .chart-section {
+    grid-template-columns: 1fr; /* Stack chart sections */
+  }
+  .container {
+    padding: 1rem; /* Reduced container padding */
+  }
+}
+
+@media (max-width: 375px) {
+  .container {
+    padding: 0.75rem; /* Minimal padding on small phones */
+  }
+  .kpi-card, .chart-card {
+    padding: 1rem; /* Reduced card padding */
+  }
+  .filter-toolbar {
+    flex-direction: column; /* Stack filters vertically */
+    align-items: stretch;
+  }
+}
+```
+
+**Testing checklist:**
+- ✅ No horizontal scrolling at 768px viewport
+- ✅ No horizontal scrolling at 375px viewport  
+- ✅ All text remains readable (min 16px)
+- ✅ Touch targets are ≥44px
+- ✅ Charts resize appropriately
+
+### Card Hover Microinteractions
+All cards should have subtle hover effects — shadow elevation ONLY, no transforms:
+```css
+.card, .stat-card, .kpi-card, .stat-item, .chart-container {
+  transition: box-shadow 0.2s ease;
+}
+.card:hover, .stat-card:hover, .kpi-card:hover, .stat-item:hover {
+  box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+}
+```
+- NO `translateY` or `scale` on card hover — it looks cheap
+- Timeline items: subtle background highlight on hover
+- Architecture nodes: subtle shadow elevation on hover
+- List items: subtle background tint on hover, not translateX
+
+### :focus-visible Standard
+Every file MUST include:
+```css
+*:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+```
+
+### SVG Chart Hover Pattern
+For inline SVG chart elements (bars, donut segments, data points):
+```css
+svg rect, svg circle, svg path.data-element {
+  transition: opacity 0.2s, transform 0.2s;
+}
+svg rect:hover, svg circle:hover {
+  opacity: 0.8;
+  filter: brightness(1.1);
+}
+```
+Always add `<title>` elements inside SVG shapes for native browser tooltips:
+```html
+<rect x="10" y="20" width="50" height="100">
+  <title>Revenue: $142K</title>
+</rect>
+```
+
+### Visual Polish (Stripe/Vercel-level)
+- **Border radius:** `8px` consistently (not 12px, not 16px — Stripe uses 8px)
+- **Shadows (dark mode):** Almost none — `box-shadow: 0 0 0 1px var(--border)` is sufficient. Let borders do the work.
+- **Shadows (light mode):** Subtle layers — `box-shadow: 0 0 0 1px rgba(0,0,0,0.03), 0 2px 4px rgba(0,0,0,0.05)`
+- **Card hover:** Shadow deepens slightly. NO translateY, NO scale transforms. Just: `box-shadow: 0 0 0 1px rgba(0,0,0,0.03), 0 8px 16px rgba(0,0,0,0.08)`
+- **Clean card borders:** `border: 1px solid var(--border)` — no gradient borders, no colored left/top borders
+- **Glass morphism:** Use sparingly, only for floating UI elements (menus, tooltips), not cards
+- **Restrained accents:** Use accent color for ONE thing per section (a button, a link, an icon) — not everywhere
+- **Transitions:** `transition: box-shadow 0.2s ease` — only animate what changes
+
+### Background Atmosphere (Avoid Generic Dark)
+Every visualization should have a SUBTLE background personality. Avoid flat `--bg` backgrounds that look like every dark template. Choose ONE technique per file:
+
+1. **Subtle radial gradient** — a single, very faint radial gradient from the center:
+   ```css
+   body { background: var(--bg); }
+   body::before {
+     content: ''; position: fixed; inset: 0; z-index: -1;
+     background: radial-gradient(ellipse 80% 50% at 50% 20%, 
+       color-mix(in srgb, var(--accent), transparent 92%), transparent);
+   }
+   ```
+2. **Noise/grain texture** (Vercel-style): use a tiny inline SVG noise filter:
+   ```css
+   body::after {
+     content: ''; position: fixed; inset: 0; z-index: -1; opacity: 0.03;
+     background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+   }
+   ```
+3. **Dot grid** (use sparingly, only for tech/architecture files):
+   ```css
+   body { background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+     background-size: 24px 24px; }
+   ```
+
+Choose the technique that matches the content personality. Timelines → radial gradient. Dashboards → grain. Architecture → dot grid. Slide decks → radial gradient with content-specific accent color.
+
+### Dropdown Menu Styling (Mandatory)
+The settings/export dropdown MUST look polished:
+```css
+.dropdown-menu {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05);
+  padding: 4px;
+  min-width: 160px;
+  animation: dropdownIn 0.15s ease;
+}
+.dropdown-menu button {
+  width: 100%; text-align: left; padding: 8px 12px;
+  border-radius: 6px; border: none; background: transparent;
+  color: var(--text-secondary); font-size: 0.875rem; cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.dropdown-menu button:hover {
+  background: var(--surface-hover); color: var(--text);
+}
+@keyframes dropdownIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+```
+
+### Entrance Animations (Mandatory for All Files)
+Every file MUST have subtle entrance animations. Static-feeling pages score low on interactivity. Use CSS-only `@keyframes` on page load:
+```css
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.card, .step, .quote-card, section > * {
+  animation: fadeInUp 0.5s ease both;
+}
+/* Stagger children */
+.card:nth-child(1) { animation-delay: 0s; }
+.card:nth-child(2) { animation-delay: 0.08s; }
+.card:nth-child(3) { animation-delay: 0.16s; }
+.card:nth-child(4) { animation-delay: 0.24s; }
+```
+Also add hover states on ALL cards/items — even "static" content like cheatsheets and quote cards:
+```css
+.card:hover, .command-group:hover, blockquote:hover {
+  background: var(--surface-hover);
+  box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+}
+```
+
+### Theme-Adaptive Content (Carousels, Posters)
+When cards use decorative gradients (e.g., Instagram-style pastel slides), the gradients MUST adapt to the theme. Don't use fixed pastel colors that look identical in dark/light mode:
+```css
+/* BAD — same gradient in both themes */
+.card { background: linear-gradient(135deg, #ff9a9e, #fecfef); }
+
+/* GOOD — theme-adaptive gradients */
+.theme-dark .card-1 { background: linear-gradient(135deg, #1a1a2e, #16213e); }
+.theme-light .card-1 { background: linear-gradient(135deg, #ff9a9e, #fecfef); }
+```
+
+### Slide Deck Light Mode
+Slide decks are designed dark-first, but light mode must NOT feel like an afterthought. For presentations in light mode:
+- Use a subtle warm gray background (`#f5f5f0`) not pure white
+- Add a faint top-down gradient for depth
+- Ensure headings use dark text with sufficient weight
+- Grid/glow backgrounds should switch to subtle dot patterns or soft gradients in light mode
+
+### Chart Accessibility (Mandatory)
+All CSS-only charts (bars, radar, donut) and Chart.js charts MUST expose data to screen readers:
+```html
+<div role="img" aria-label="Bar chart showing React at 85%, Vue at 72%, Angular at 58%">
+  <!-- visual chart here -->
+  <div class="sr-only">React: 85%. Vue: 72%. Angular: 58%.</div>
+</div>
+```
+Add `.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }` to every file.
+
+### Visual Restraint Anti-Patterns (NEVER DO)
+- ❌ **Floating gradient orbs** — decorative blurred circles behind content look amateurish
+- ❌ **Rainbow/gradient borders** — colored top-borders or left-borders on cards scream "template"
+- ❌ **Gradient text** on headings — use solid colors. Gradient text is a 2020 trend that aged poorly
+- ❌ **Scale transforms on hover** — `scale(1.02)` on cards feels janky, not premium
+- ❌ **Glow effects** — `box-shadow: 0 0 20px rgba(blue)` never looks good
+- ❌ **Decorative animations** — spinning rings, floating particles, pulsing dots are noise
+- ❌ **Color-coded borders** — left/top colored borders on cards feel like Bootstrap components
+- ❌ **Stat numbers with gradient text** — use a solid accent color or var(--text) instead
+
+### Accessibility (Mandatory)
+
+Every visualization MUST meet these baseline accessibility requirements:
+
+**Minimum Accessibility Checklist:**
+- [ ] Skip-to-content link present
+- [ ] `role="region"` on all major sections with `aria-label`
+- [ ] `role="group"` on comparison sections, architecture layers, slide groups
+- [ ] `role="list"` / `role="listitem"` on timeline sections and items
+- [ ] `aria-label` on all icon-only buttons
+- [ ] `aria-describedby` on chart sections linking to data descriptions
+- [ ] `:focus-visible` with `border-radius: 4px` on all interactive elements
+- [ ] `aria-live="polite"` on slide counters / dynamic content
+
+- **Skip navigation:** Add `<a href="#main-content" class="skip-link">Skip to content</a>` at the top of `<body>`. Style: visually hidden, visible on focus.
+- **Landmark roles:** Use `<main>`, `<nav>`, `<header>`, `<footer>`, `<section>` with `aria-label` where there are multiple of the same landmark.
+- **Interactive elements:** All buttons, links, and controls must have `aria-label` if their text content is not descriptive (e.g., icon-only buttons).
+- **Focus indicators:** Add visible `:focus-visible` styles on all interactive elements: `outline: 2px solid var(--accent); outline-offset: 2px;`
+- **Color-only indicators:** Status dots, colored badges, etc. MUST have a text alternative. E.g., a green status dot should also show "Healthy" text or `aria-label="Status: Healthy"`.
+- **Charts and diagrams (MANDATORY):** 
+  - Wrap chart canvas in container with `role="img" aria-label="Description of what the chart shows"`
+  - **ALL charts MUST have hover tooltips enabled** — never disable Chart.js tooltips
+  - Include data table alternative or visually-hidden summary for screen readers
+  - Use high contrast colors with sufficient color difference between data series
+- **Screen reader descriptions:** Add `aria-description` or visually-hidden text describing key takeaways for complex visualizations.
+- **Slide decks:** Use `aria-live="polite"` on the slide counter, and `aria-label` on navigation buttons.
+
+### Icons (Inline SVG Only)
+
+Use inline SVG for all icons. **Never use emoji as icons** — they look unprofessional and render inconsistently.
+
+Use simple Lucide-style paths: 24x24 viewBox, stroke-based, `stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"`.
+
+Common icons to use:
+- Moon/Sun for theme toggle
+- Download arrow for PNG export  
+- Printer for print
+- Arrow left/right for navigation
+- Check/X for pros/cons
+- Globe, Smartphone, Monitor for device types
+
+### Animations (CSS-First with Modern Features)
+
+**CSS animations are the primary system.** They're reliable, performant, and never break from JS scoping issues.
+
+See [references/animations.md](references/animations.md) for complete patterns.
+
+**Modern CSS Animation Features (Progressive Enhancement):**
+
+**Scroll-driven animations** (Chrome 115+) — Replace JS scroll listeners:
+```css
+.scroll-reveal {
+  animation: fadeInUp 1ms linear;
+  animation-timeline: view(); /* Animates based on viewport visibility */
+}
+.progress-bar {
+  animation: grow 1ms linear;  
+  animation-timeline: scroll(root inline); /* Animates based on page scroll */
+}
+```
+
+**Three animation techniques (all baked into the skeleton):**
+
+1. **Page-load entrance:** Add class `animate` (+ `delay-1` through `delay-6` for stagger)
+   ```html
+   <h1 class="animate">Title</h1>
+   <div class="card animate delay-1">Card 1</div>
+   <div class="card animate delay-2">Card 2</div>
+   ```
+
+2. **Scroll reveal:** Add `data-reveal` attribute. JS adds `.reveal` class (opacity:0), then `.visible` on scroll.
+   ```html
+   <section data-reveal>This fades in when scrolled into view</section>
+   ```
+
+3. **Number counters:** Add `data-count` attribute. JS animates from 0 to target.
+   ```html
+   <span data-count="77" data-suffix="%">77%</span>
+   ```
+
+**Hover effects** are pure CSS, baked into `.card` (translateY + scale on :hover).
+
+**Rules:**
+- Content is ALWAYS visible in CSS — JS animations are progressive enhancement
+- Use `@keyframes` for page-load animations, CSS `transition` for hover/state changes
+- `data-reveal` elements show their final content if JS fails (no blank sections)
+- `prefers-reduced-motion` disables all animations automatically
+- `data-reveal` elements MUST have `opacity: 1` as their default CSS state. JS adds `.reveal` class (which sets `opacity: 0`), then `.visible` restores it. If JS fails, content stays visible.
+- On page load, trigger ALL reveal elements visible after a short delay (500ms) so full-page screenshots and PNG exports capture all content:
+  ```javascript
+  setTimeout(function() { document.querySelectorAll('.reveal').forEach(function(el) { el.classList.add('visible'); }); }, 500);
+  ```
+

--- a/claude/skills/visualize/references/eval.md
+++ b/claude/skills/visualize/references/eval.md
@@ -1,0 +1,58 @@
+# Evaluation Rubric — Quick Reference
+
+Condensed scoring guide. Full protocol in `eval/SKILL.md`.
+
+## 8 Dimensions
+
+| # | Dimension | Weight | What to Check |
+|---|-----------|--------|---------------|
+| D1 | First Impression | 15% | 2-second gut reaction. Professional? Clear focal point? |
+| D2 | Typography | 15% | Hierarchy, sizes, line-height, max 2 fonts |
+| D3 | Color | 10% | Harmonious palette, WCAG AA, accent purpose, both themes |
+| D4 | Layout | 15% | Consistent spacing, whitespace, responsive, alignment |
+| D5 | Content | 15% | Accurate, clear message in 5s, right density, zero filler |
+| D6 | Interactivity | 10% | Menu, theme, download, print, navigation, hover states |
+| D7 | Technical | 10% | Zero errors, <200KB, semantic HTML, print CSS, a11y |
+| D8 | Shareability | 10% | Would you tweet this? Better than Gamma/Canva? |
+
+## Scoring Anchor Points
+
+| Score | Meaning | Comparable To |
+|-------|---------|---------------|
+| 10 | Perfection | Apple keynote, NYT data viz |
+| 9 | Impressive | Stripe's blog, top Dribbble shot |
+| 8 | Professional | Good Gamma template, polished Figma prototype |
+| 7 | Acceptable | Average corporate deck, basic Canva output |
+| 6 | Mediocre | Default PowerPoint, generic template |
+| 5 | Poor | Ugly but functional |
+| ≤4 | Broken | Layout issues, missing features, embarrassing |
+
+## Quality Gates
+
+| Gate | Overall | Min per Dimension | Action |
+|------|---------|-------------------|--------|
+| 🚀 VIRAL | ≥ 9.5 | ≥ 9 | Ship + promote everywhere |
+| ✅ SHIP | ≥ 9.0 | ≥ 8 | Ready for release |
+| ⚠️ GOOD | ≥ 8.0 | ≥ 7 | Fix before featuring |
+| 🔧 NEEDS WORK | ≥ 7.0 | any < 7 | Fix + re-evaluate |
+| ❌ FAIL | < 7.0 | any < 5 | Major rework |
+
+## Target: SHIP (≥ 9.0) for all outputs. VIRAL (≥ 9.5) for showcase examples.
+
+## Common Deductions
+
+| Issue | Dimension | Points Lost |
+|-------|-----------|-------------|
+| Menu missing | D6 | -4 |
+| Placeholder/lorem ipsum | D5 | -5 |
+| Broken at mobile | D4 | -3 |
+| No entrance animations | D1, D8 | -2 each |
+| Clashing colors | D3 | -3 |
+| All text same size | D2 | -3 |
+| Console errors | D7 | -2 each |
+| Light theme broken | D3, D6 | -2 each |
+| Too much text per slide | D5 | -3 |
+| No hover states | D6 | -1 |
+| No print styles | D7 | -2 |
+| Cramped spacing | D4 | -3 |
+| Generic/forgettable | D1, D8 | -2 each |

--- a/claude/skills/visualize/references/libraries.md
+++ b/claude/skills/visualize/references/libraries.md
@@ -1,0 +1,237 @@
+# CDN Library Reference
+
+Preferred CDN libraries and when to use them. Always use jsDelivr for consistent, fast loading.
+
+## Table of Contents
+- [Motion](#motion) ⭐ (animations — included in skeleton)
+- [Chart.js](#chartjs)
+- [D3.js](#d3js)
+- [Three.js](#threejs)
+- [Mermaid](#mermaid)
+- [Reveal.js](#revealjs)
+- [Leaflet](#leaflet)
+
+---
+
+## Motion
+
+**Best for:** ALL animations. Spring physics, scroll-triggered reveals, staggered entrances, number counters, hover micro-interactions. Replaces raw CSS @keyframes and IntersectionObserver.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/motion@12/dist/motion.js"></script>
+```
+
+**Included in the mandatory skeleton.** Exposes global `Motion` object.
+
+```javascript
+// Spring-animated card entrance
+Motion.animate('.card',
+  { opacity: [0, 1], y: [40, 0], scale: [0.95, 1] },
+  { delay: Motion.stagger(0.08), duration: 0.5, ease: Motion.spring({ stiffness: 200, damping: 22 }) }
+);
+
+// Scroll-triggered reveal
+Motion.inView('.section', (info) => {
+  Motion.animate(info.target, { opacity: 1, y: 0 }, { duration: 0.6 });
+});
+```
+
+See [animations.md](animations.md) for complete API reference and recipes (~15KB gzipped).
+
+---
+
+## Chart.js
+
+**Best for:** Standard charts with beautiful defaults. Bar, line, pie, doughnut, radar, polar area, scatter, bubble.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+```
+
+### When to Use
+- Quick data visualization with minimal config
+- Standard chart types (bar, line, pie, doughnut, radar)
+- When you want great defaults without deep customization
+- Responsive, animated charts out of the box
+
+### Pattern
+```html
+<canvas id="myChart"></canvas>
+<script>
+new Chart(document.getElementById('myChart'), {
+  type: 'bar', // line, pie, doughnut, radar, polarArea, scatter, bubble
+  data: {
+    labels: ['Jan', 'Feb', 'Mar'],
+    datasets: [{
+      label: 'Revenue',
+      data: [12, 19, 3],
+      backgroundColor: 'hsla(220, 80%, 55%, 0.7)',
+      borderColor: 'hsl(220, 80%, 55%)',
+      borderWidth: 2,
+      borderRadius: 6,
+    }]
+  },
+  options: {
+    responsive: true,
+    plugins: {
+      legend: { position: 'bottom' },
+      title: { display: true, text: 'Monthly Revenue' }
+    },
+    scales: { y: { beginAtZero: true } }
+  }
+});
+</script>
+```
+
+### Tips
+- Use `borderRadius` for rounded bar charts
+- `tension: 0.4` on line datasets for smooth curves
+- Combine chart types: `{ type: 'bar', datasets: [{ type: 'line', ... }, { ... }] }`
+
+---
+
+## D3.js
+
+**Best for:** Custom, complex, or unconventional data visualizations. Force-directed graphs, geographic maps, treemaps, sunbursts.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+```
+
+### When to Use
+- Custom visualizations Chart.js can't handle
+- Force-directed network graphs
+- Geographic/map visualizations (with topojson)
+- Treemaps, sunbursts, chord diagrams
+- When you need full SVG control
+
+### Pattern
+```html
+<div id="viz"></div>
+<script>
+const data = [30, 86, 168, 281, 303, 365];
+const width = 600, height = 400, margin = { top: 20, right: 20, bottom: 30, left: 40 };
+
+const svg = d3.select('#viz').append('svg')
+  .attr('viewBox', `0 0 ${width} ${height}`);
+
+const x = d3.scaleBand()
+  .domain(data.map((_, i) => i))
+  .range([margin.left, width - margin.right])
+  .padding(0.2);
+
+const y = d3.scaleLinear()
+  .domain([0, d3.max(data)])
+  .range([height - margin.bottom, margin.top]);
+
+svg.selectAll('rect').data(data).join('rect')
+  .attr('x', (_, i) => x(i))
+  .attr('y', d => y(d))
+  .attr('width', x.bandwidth())
+  .attr('height', d => y(0) - y(d))
+  .attr('rx', 4)
+  .attr('fill', 'hsl(220, 80%, 55%)');
+</script>
+```
+
+---
+
+## Three.js
+
+**Best for:** 3D visualizations, immersive data displays, architectural/spatial representations.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/three@0.170/build/three.module.min.js" type="module"></script>
+```
+
+### When to Use
+- 3D data visualization (3D scatter, terrain)
+- Product/architectural visualization
+- Immersive, impressive hero visuals
+- When 2D isn't enough to convey the concept
+
+---
+
+## Mermaid
+
+**Best for:** Diagrams from text definitions. Flowcharts, sequence diagrams, Gantt charts, ER diagrams, class diagrams.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({ startOnLoad: true, theme: 'neutral' });</script>
+```
+
+### When to Use
+- Quick flowcharts and process diagrams
+- Sequence diagrams for API/system interactions
+- Gantt charts for project timelines
+- When diagram accuracy matters more than custom styling
+
+### Pattern
+```html
+<pre class="mermaid">
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+</pre>
+```
+
+### Tips
+- Use `%%` for comments in Mermaid syntax
+- Themes: `default`, `neutral`, `dark`, `forest`
+- Custom styles: `style A fill:#f9f,stroke:#333`
+
+---
+
+## Reveal.js
+
+**Best for:** Full-featured slide decks when you need more than the basic template.
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/theme/white.css">
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.js"></script>
+```
+
+### When to Use
+- Complex presentations with nested slides (vertical + horizontal)
+- Markdown-based slide content
+- Built-in speaker notes, PDF export, overview mode
+- When the basic slide template isn't enough
+
+### Tips
+- Themes: `white`, `black`, `league`, `beige`, `moon`, `night`, `serif`, `simple`, `solarized`
+- Fragments for step-by-step reveals
+- Code highlighting with highlight.js plugin
+
+---
+
+## Leaflet
+
+**Best for:** Interactive maps with markers, polygons, heatmaps.
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1/dist/leaflet.css">
+<script src="https://cdn.jsdelivr.net/npm/leaflet@1/dist/leaflet.js"></script>
+```
+
+### When to Use
+- Location data visualization
+- Geographic comparisons
+- Travel/route visualization
+- Any data with lat/lng coordinates
+
+### Pattern
+```html
+<div id="map" style="height: 500px; border-radius: 12px;"></div>
+<script>
+const map = L.map('map').setView([37.5, -122.3], 10);
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '© OpenStreetMap'
+}).addTo(map);
+L.marker([37.5, -122.3]).addTo(map).bindPopup('Location');
+</script>
+```

--- a/claude/skills/visualize/references/menu.md
+++ b/claude/skills/visualize/references/menu.md
@@ -1,0 +1,353 @@
+# Hamburger Menu Component
+
+Every visualization MUST include a hamburger menu in the top-right corner with these features:
+1. **Theme toggle** — dark/light mode (or multi-theme selector)
+2. **Download as image** — PNG export via html-to-image
+3. **Print as PDF** — browser print with optimized print styles
+
+## Required CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+```
+
+## Complete Menu Implementation
+
+Paste this into every visualization. Customize theme colors to match the visualization's palette.
+
+### HTML (place just inside `<body>`)
+
+```html
+<!-- Hamburger Menu -->
+<div class="viz-menu">
+  <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+      <line x1="3" y1="5" x2="17" y2="5"/>
+      <line x1="3" y1="10" x2="17" y2="10"/>
+      <line x1="3" y1="15" x2="17" y2="15"/>
+    </svg>
+  </button>
+  <div class="viz-menu-dropdown" id="vizMenuDropdown">
+    <button onclick="cycleTheme()">
+      <span class="viz-menu-icon">◐</span>
+      <span>Theme: <span id="themeLabel">Dark</span></span>
+    </button>
+    <button onclick="downloadImage()">
+      <span class="viz-menu-icon">⤓</span>
+      <span>Download as PNG</span>
+    </button>
+    <button onclick="printPDF()">
+      <span class="viz-menu-icon">⎙</span>
+      <span>Print / Save PDF</span>
+    </button>
+  </div>
+</div>
+```
+
+### CSS
+
+```css
+/* === Hamburger Menu === */
+.viz-menu {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 9999;
+  font-family: var(--font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+}
+
+.viz-menu-toggle {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid var(--menu-border, rgba(128,128,128,0.3));
+  background: var(--menu-bg, rgba(0,0,0,0.5));
+  color: var(--menu-text, #fff);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: all 0.2s ease;
+}
+
+.viz-menu-toggle:hover {
+  background: var(--menu-bg-hover, rgba(0,0,0,0.7));
+  transform: scale(1.05);
+}
+
+.viz-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 200px;
+  background: var(--menu-bg, rgba(0,0,0,0.85));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--menu-border, rgba(128,128,128,0.2));
+  border-radius: 12px;
+  padding: 6px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px) scale(0.96);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+
+.viz-menu-dropdown.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.viz-menu-dropdown button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--menu-text, #fff);
+  font-size: 0.875rem;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.viz-menu-dropdown button:hover {
+  background: var(--menu-item-hover, rgba(255,255,255,0.1));
+}
+
+.viz-menu-icon {
+  font-size: 1rem;
+  width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+/* Hide menu in print */
+@media print {
+  .viz-menu { display: none !important; }
+}
+```
+
+### JavaScript
+
+```javascript
+// === Menu toggle ===
+function toggleMenu() {
+  document.getElementById('vizMenuDropdown').classList.toggle('open');
+}
+
+// Close menu when clicking outside
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.viz-menu')) {
+    document.getElementById('vizMenuDropdown').classList.remove('open');
+  }
+});
+
+// Close menu on Escape
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') document.getElementById('vizMenuDropdown').classList.remove('open');
+});
+
+// === Theme system ===
+const themes = [
+  { name: 'Dark', class: 'theme-dark' },
+  { name: 'Light', class: 'theme-light' },
+  { name: 'Auto', class: 'theme-auto' },
+];
+let currentTheme = 0;
+
+function cycleTheme() {
+  // Remove all theme classes
+  themes.forEach(t => document.documentElement.classList.remove(t.class));
+  // Advance to next
+  currentTheme = (currentTheme + 1) % themes.length;
+  document.documentElement.classList.add(themes[currentTheme].class);
+  document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+  // Persist
+  localStorage.setItem('viz-theme', currentTheme);
+}
+
+// Restore saved theme on load
+(function() {
+  const saved = localStorage.getItem('viz-theme');
+  if (saved !== null) {
+    currentTheme = parseInt(saved);
+    document.documentElement.classList.add(themes[currentTheme].class);
+    document.getElementById('themeLabel').textContent = themes[currentTheme].name;
+  }
+})();
+
+// === Download as PNG ===
+async function downloadImage() {
+  const btn = event.target.closest('button');
+  const origText = btn.querySelector('span:last-child').textContent;
+  btn.querySelector('span:last-child').textContent = 'Generating...';
+
+  try {
+    // Hide menu during capture
+    const menu = document.querySelector('.viz-menu');
+    menu.style.display = 'none';
+
+    const dataUrl = await htmlToImage.toPng(document.body, {
+      quality: 1,
+      pixelRatio: 2, // 2x for retina quality
+      cacheBust: true,
+      filter: (node) => !node.classList?.contains('viz-menu'),
+    });
+
+    menu.style.display = '';
+
+    // Trigger download
+    const link = document.createElement('a');
+    link.download = `${document.title || 'visualization'}.png`;
+    link.href = dataUrl;
+    link.click();
+  } catch (err) {
+    console.error('Image export failed:', err);
+    alert('Image export failed. Try Print → Save as PDF instead.');
+  }
+
+  btn.querySelector('span:last-child').textContent = origText;
+}
+
+// === Print as PDF ===
+function printPDF() {
+  window.print();
+}
+```
+
+## Theme CSS Pattern
+
+Define theme variables on `:root` for dark (default), and override on `.theme-light`:
+
+```css
+:root, .theme-dark {
+  --bg: hsl(220, 20%, 8%);
+  --surface: hsl(220, 15%, 14%);
+  --text: hsl(220, 10%, 92%);
+  --text-secondary: hsl(220, 10%, 60%);
+  --accent: hsl(220, 85%, 68%);
+  /* Menu overrides for dark */
+  --menu-bg: rgba(0, 0, 0, 0.7);
+  --menu-bg-hover: rgba(0, 0, 0, 0.85);
+  --menu-border: rgba(255, 255, 255, 0.1);
+  --menu-text: #fff;
+  --menu-item-hover: rgba(255, 255, 255, 0.1);
+}
+
+.theme-light {
+  --bg: hsl(220, 15%, 97%);
+  --surface: hsl(0, 0%, 100%);
+  --text: hsl(220, 20%, 15%);
+  --text-secondary: hsl(220, 10%, 45%);
+  --accent: hsl(220, 80%, 50%);
+  /* Menu overrides for light */
+  --menu-bg: rgba(255, 255, 255, 0.85);
+  --menu-bg-hover: rgba(255, 255, 255, 0.95);
+  --menu-border: rgba(0, 0, 0, 0.1);
+  --menu-text: #333;
+  --menu-item-hover: rgba(0, 0, 0, 0.06);
+}
+
+.theme-auto {
+  /* Uses prefers-color-scheme */
+}
+
+@media (prefers-color-scheme: light) {
+  .theme-auto {
+    --bg: hsl(220, 15%, 97%);
+    --surface: hsl(0, 0%, 100%);
+    --text: hsl(220, 20%, 15%);
+    --text-secondary: hsl(220, 10%, 45%);
+    --accent: hsl(220, 80%, 50%);
+    --menu-bg: rgba(255, 255, 255, 0.85);
+    --menu-bg-hover: rgba(255, 255, 255, 0.95);
+    --menu-border: rgba(0, 0, 0, 0.1);
+    --menu-text: #333;
+    --menu-item-hover: rgba(0, 0, 0, 0.06);
+  }
+}
+```
+
+## Print Styles
+
+Always include optimized print styles:
+
+```css
+@media print {
+  .viz-menu,
+  .nav,
+  .progress { display: none !important; }
+
+  body {
+    background: white !important;
+    color: black !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* For slide decks: print all slides */
+  .slide {
+    position: relative !important;
+    opacity: 1 !important;
+    transform: none !important;
+    page-break-after: always;
+    height: 100vh;
+    display: flex !important;
+  }
+
+  .slide.prev { display: flex !important; }
+}
+```
+
+## Best Practices
+
+1. **html-to-image over html2canvas** — better SVG support, smaller bundle, handles CSS custom properties
+2. **pixelRatio: 2** for retina-quality exports
+3. **Hide UI elements** during capture (menu, nav, progress bars)
+4. **cacheBust: true** to avoid stale image caching issues
+5. **filter function** to exclude interactive elements from the export
+6. **Fallback** — if html-to-image fails (CORS, complex SVG), suggest Print → Save as PDF
+7. **localStorage** for theme persistence across page reloads
+8. **Backdrop-filter** on the menu for frosted glass effect
+9. **print-color-adjust: exact** to preserve colors when printing
+10. **Page breaks** for slide decks so each slide is a separate PDF page
+
+## Slide Deck Special Handling
+
+For slide decks, the Download button should capture only the **current slide**, not the entire page:
+
+```javascript
+async function downloadImage() {
+  // For slide decks, capture only the active slide
+  const target = document.querySelector('.slide.active') || document.body;
+  const menu = document.querySelector('.viz-menu');
+  const nav = document.querySelector('.nav');
+
+  menu.style.display = 'none';
+  if (nav) nav.style.display = 'none';
+
+  const dataUrl = await htmlToImage.toPng(target, {
+    quality: 1,
+    pixelRatio: 2,
+    width: target.scrollWidth,
+    height: target.scrollHeight,
+  });
+
+  menu.style.display = '';
+  if (nav) nav.style.display = '';
+
+  const link = document.createElement('a');
+  const slideNum = document.querySelector('.slide.active')?.dataset?.slide || '';
+  link.download = `${document.title}-slide${slideNum}.png`;
+  link.href = dataUrl;
+  link.click();
+}
+```

--- a/claude/skills/visualize/references/skeleton.md
+++ b/claude/skills/visualize/references/skeleton.md
@@ -1,0 +1,327 @@
+## Mandatory HTML Skeleton
+
+**EVERY visualization MUST start from this skeleton.** Copy it, then add content. This gives you themes, print styles, Inter font, animations, menu, and hover effects — all working out of the box.
+
+**Design philosophy: CSS-first, JS-minimal.** Animations use CSS `@keyframes` and `transition` (always reliable). JavaScript is only for: menu, theme toggle, scroll observer, number counters, and PNG download. No animation libraries required.
+
+```html
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>YOUR TITLE HERE</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <!-- ADD LANGUAGE FONTS IF NEEDED: e.g. Noto Sans KR for Korean, Noto Sans JP for Japanese -->
+  <!-- <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet"> -->
+  <!-- ADD CDN LIBRARIES HERE (Chart.js, Mermaid, etc.) -->
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; } /* Enable smooth height:auto transitions (Chrome 129+) */
+
+    /* ===== THEMES (class-based ONLY — no @media prefers-color-scheme) ===== */
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.04);
+      --text: #EDEDED; --text-secondary: #888;
+      --accent: #3b82f6; --accent-secondary: #8b5cf6;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #FFFFFF; --surface-hover: #F5F5F4;
+      --border: rgba(0,0,0,0.06);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #2563eb; --accent-secondary: #7c3aed;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.6; -webkit-font-smoothing: antialiased;
+      letter-spacing: -0.01em; font-feature-settings: 'cv11', 'ss01';
+      transition: background 0.3s, color 0.3s;
+      scrollbar-gutter: stable;
+    }
+    h1,h2,h3,h4,h5,h6 { 
+      color: var(--text); 
+      letter-spacing: -0.03em; 
+      line-height: 1.08;
+      text-wrap: balance;
+    }
+    h1 { font-weight: 700; }
+    h2 { font-weight: 600; }
+    body, p, li, td, th, span, label { font-weight: 400; }
+    p,li,td,th,span,label { color: var(--text); }
+    .text-secondary { color: var(--text-secondary); }
+
+    /* ===== CARD ===== */
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 24px;
+      transition: box-shadow 0.2s ease;
+    }
+    .card:hover {
+      box-shadow: 0 0 0 1px var(--border), 0 8px 16px rgba(0,0,0,0.08);
+    }
+
+    /* ===== ANIMATIONS (CSS-first — always reliable) ===== */
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    @keyframes slideInLeft {
+      from { opacity: 0; transform: translateX(-40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes slideInRight {
+      from { opacity: 0; transform: translateX(40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    .animate { animation: fadeInUp 0.6s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+    .animate.delay-5 { animation-delay: 0.5s; }
+    .animate.delay-6 { animation-delay: 0.6s; }
+
+    /* Scroll-triggered: JS adds .reveal, then .visible on scroll */
+    .reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.6s ease, transform 0.6s ease; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .reveal { opacity: 1; transform: none; }
+    }
+
+    /* ===== PRINT ===== */
+    @media print {
+      body { background: white !important; color: black !important; }
+      .viz-menu, .reveal { display: revert; opacity: 1 !important; transform: none !important; }
+      .card { break-inside: avoid; border: 1px solid #ddd; box-shadow: none; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+    @page { margin: 1in; @bottom-center { content: "Page " counter(page); font-size: 9pt; color: #666; } }
+
+    /* ===== MENU ===== */
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle {
+      width: 44px; height: 44px; border-radius: 12px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown {
+      position: absolute; top: 52px; right: 0; min-width: 200px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 8px;
+      opacity: 0; visibility: hidden; transform: translateY(-8px);
+      transition: all 0.2s; backdrop-filter: blur(16px);
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+    .viz-menu-dropdown button {
+      width: 100%; padding: 10px 14px; border: none; border-radius: 8px;
+      background: transparent; color: var(--text); font-size: 14px;
+      font-family: inherit; cursor: pointer; text-align: left;
+      display: flex; align-items: center; gap: 10px; transition: background 0.15s;
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); }
+
+    /* ===== SKIP TO CONTENT (accessibility) ===== */
+    .skip-to-content {
+      position: absolute; top: -40px; left: 6px; background: var(--accent);
+      color: white; padding: 8px 12px; text-decoration: none;
+      border-radius: 4px; opacity: 0; pointer-events: none;
+      transition: all 0.2s; z-index: 10000;
+    }
+    .skip-to-content:focus { top: 6px; opacity: 1; pointer-events: auto; }
+
+    /* ===== DETAILS ACCORDION (Chrome 120+ exclusive, 131+ animated) ===== */
+    details { overflow: hidden; }
+    details summary { cursor: pointer; list-style: none; }
+    details summary::-webkit-details-marker { display: none; }
+    ::details-content {
+      transition: block-size 0.3s ease, opacity 0.3s ease;
+      block-size: 0; opacity: 0; overflow: hidden;
+    }
+    details[open]::details-content { block-size: auto; opacity: 1; }
+
+    /* ===== POPOVER (Chrome 114+, zero-JS tooltips/panels) ===== */
+    [popover] {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 16px; max-width: 320px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.2); color: var(--text);
+    }
+    [popover]::backdrop { background: rgba(0,0,0,0.3); }
+
+    /* ===== ADD YOUR STYLES BELOW ===== */
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;z-index:10000;padding:8px 16px;background:var(--accent);color:white;text-decoration:none;border-radius:4px;" onfocus="this.style.cssText='position:fixed;left:16px;top:16px;z-index:10000;padding:8px 16px;background:var(--accent);color:white;text-decoration:none;border-radius:4px;'" onblur="this.style.cssText='position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;'">Skip to content</a>
+  <main id="main-content">
+
+  <!-- MENU -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()"><span id="themeIcon">🌙</span><span id="themeLabel">Dark</span></button>
+      <button onclick="downloadImage()"><span>📥</span><span>Download PNG</span></button>
+      <button onclick="window.print()"><span>🖨️</span><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <!-- SKIP TO CONTENT (accessibility) -->
+  <a href="#main-content" class="skip-to-content">Skip to content</a>
+
+  <main id="main-content" role="main">
+    <!-- YOUR CONTENT HERE (use <section>, <header>, <article> for semantics) -->
+  </main>
+
+  <!-- EXAMPLE: Exclusive accordion (only one open at a time, no JS needed) -->
+  <!--
+  <details name="faq" open>
+    <summary>Section 1</summary>
+    <div class="section-body"><p>Content</p></div>
+  </details>
+  <details name="faq">
+    <summary>Section 2</summary>
+    <div class="section-body"><p>Content</p></div>
+  </details>
+  -->
+
+  <!-- EXAMPLE: Popover (zero-JS tooltip/info panel) -->
+  <!--
+  <button popovertarget="info-panel">Details</button>
+  <div id="info-panel" popover>
+    <h3>More Information</h3>
+    <p>Content shown on click, no JS needed.</p>
+  </div>
+  -->
+
+  </main>
+  <script>
+    // === Menu ===
+    function toggleMenu() { 
+      var dropdown = document.getElementById('vizMenuDropdown') || document.getElementById('vizMenu');
+      if (dropdown) dropdown.classList.toggle('open'); 
+    }
+    document.addEventListener('click', e => { 
+      if (!e.target.closest('.viz-menu')) {
+        var dropdown = document.getElementById('vizMenuDropdown') || document.getElementById('vizMenu');
+        if (dropdown) dropdown.classList.remove('open');
+      }
+    });
+    document.addEventListener('keydown', e => { 
+      if (e.key === 'Escape') {
+        var dropdown = document.getElementById('vizMenuDropdown') || document.getElementById('vizMenu');
+        if (dropdown) dropdown.classList.remove('open');
+      }
+    });
+
+    // === Theme (class-based, OS detection on first visit) ===
+    var savedTheme = localStorage.getItem('viz-theme');
+    var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t);
+      currentTheme = t;
+      if (typeof onThemeChange === 'function') onThemeChange();
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    // === Scroll Reveal (adds .reveal then .visible — content visible without JS) ===
+    document.querySelectorAll('[data-reveal]').forEach(el => el.classList.add('reveal'));
+    var revealObserver = new IntersectionObserver(function(entries) {
+      entries.forEach(function(e) { if (e.isIntersecting) { e.target.classList.add('visible'); revealObserver.unobserve(e.target); } });
+    }, { threshold: 0.15 });
+    document.querySelectorAll('.reveal').forEach(el => revealObserver.observe(el));
+
+    // === Number Counter (use data-count="77" data-suffix="%" on elements) ===
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return;
+        el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count), prefix = el.dataset.prefix || '', suffix = el.dataset.suffix || '';
+        var start = performance.now(), duration = 1200;
+        (function tick(now) {
+          var p = Math.min((now - start) / duration, 1), eased = 1 - Math.pow(1 - p, 3);
+          el.textContent = prefix + Math.round(target * eased).toLocaleString() + suffix;
+          if (p < 1) requestAnimationFrame(tick);
+        })(start);
+      });
+    }
+    var counterEl = document.querySelector('[data-count]');
+    if (counterEl) {
+      var cObs = new IntersectionObserver(function(entries) {
+        entries.forEach(function(e) { if (e.isIntersecting) { animateCounters(); cObs.disconnect(); } });
+      }, { threshold: 0.3 });
+      cObs.observe(counterEl);
+    }
+
+    // === Download PNG ===
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.body, { quality: 1, pixelRatio: 2, filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); } });
+        var a = document.createElement('a'); a.href = url;
+        a.download = document.title.replace(/\s+/g, '-').toLowerCase() + '.png'; a.click();
+      } catch(e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+
+    // === Chart.js Pattern (use when file has Chart.js) ===
+    // var chartsBuilt = false;
+    // function buildCharts() {
+    //   if (chartsBuilt || typeof Chart === 'undefined') return;
+    //   var isDark = document.documentElement.classList.contains('theme-dark');
+    //   var textColor = isDark ? '#EDEDED' : '#0f172a';
+    //   var borderColor = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+    //   // Create charts with theme-aware colors
+    //   chartsBuilt = true;
+    // }
+    // function onThemeChange() { chartsBuilt = false; buildCharts(); }
+    // window.addEventListener('load', buildCharts);
+
+    // === YOUR SCRIPTS BELOW (use var for top-level variables, define onThemeChange for chart re-renders) ===
+  </script>
+</body>
+</html>
+```
+
+### Skeleton Rules
+
+**Do:**
+- Use `var` for all top-level variables (avoids TDZ errors when functions are hoisted)
+- Use `data-reveal` attribute on sections/cards for scroll animation
+- Use `data-count="77" data-suffix="%"` for animated number counters
+- Use `.animate.delay-N` classes for page-load entrance animations
+- Use CSS `:hover` for hover effects (baked into `.card` already)
+- Define `function onThemeChange() {}` to re-render charts on theme toggle
+- Use `<main>`, `<section>`, `<header>`, `<article>` for semantic HTML
+- Keep all chart variables as `var` (not `let`/`const`) at script top level
+
+**Don't:**
+- Don't include Motion.js unless you specifically need spring physics
+- Don't hide content via JS/CSS for animation — use `data-reveal` pattern instead
+- Don't use `let`/`const` for variables that might be referenced before declaration
+- Don't use `.finished` Promise chains for sequencing — use `setTimeout`
+- Don't put animation logic that could crash before nav/chart setup code
+

--- a/claude/skills/visualize/references/types.md
+++ b/claude/skills/visualize/references/types.md
@@ -1,0 +1,303 @@
+# Visualization Type Patterns
+
+Detailed patterns for each visualization type. Load only the section relevant to the current task.
+
+## Table of Contents
+- [Slide Deck](#slide-deck)
+- [Infographic](#infographic)
+- [Dashboard](#dashboard)
+- [Flowchart / Diagram](#flowchart--diagram)
+- [Timeline](#timeline)
+- [Comparison](#comparison)
+- [Data Visualization](#data-visualization)
+- [One-Pager](#one-pager)
+- [Mind Map](#mind-map)
+- [Kanban Board](#kanban-board)
+
+---
+
+## Slide Deck
+
+### Structure
+```html
+<div class="deck">
+  <section class="slide" data-notes="Speaker notes here">
+    <!-- slide content -->
+  </section>
+</div>
+```
+
+### Navigation Pattern
+```javascript
+// Keyboard: ← → arrows, Space, Enter
+// Click: left third = prev, right two-thirds = next
+// Touch: swipe left/right
+// URL hash: #slide-3 for direct linking
+```
+
+### Slide Types
+1. **Title Slide** — big title, subtitle, optional author/date. Centered. Impactful.
+2. **Content Slide** — heading + bullets or heading + visual. Never both walls of text AND a visual.
+3. **Section Divider** — full-bleed color/gradient with section title. Breaks up the flow.
+4. **Image/Visual Slide** — full-bleed image or large SVG diagram with minimal text.
+5. **Two-Column** — split layout for comparisons, text+image, or code+explanation.
+6. **Quote Slide** — large pull quote with attribution. Elegant typography.
+7. **Data Slide** — chart/graph with one key insight called out.
+8. **Closing Slide** — CTA, contact info, or summary. Memorable.
+
+### Best Practices
+- First slide hooks attention — bold statement or question
+- One idea per slide
+- Use progressive reveal within slides (CSS animation delays) for builds
+- Consistent positioning: titles always same spot, content always same region
+- Slide transitions: `transform: translateX()` with `transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)`
+
+---
+
+## Infographic
+
+### Structure
+- Single long-scroll page
+- Clear visual hierarchy with sections
+- Use icons (inline SVG) to break up text
+- Number callouts for statistics
+- Color-coded sections
+
+### Layout Pattern
+```
+┌─────────────────────────┐
+│      HERO / TITLE       │
+├─────────────────────────┤
+│   Key Stat  │  Key Stat │
+├─────────────────────────┤
+│     Section 1           │
+│  ┌────┐ ┌────┐ ┌────┐  │
+│  │Icon│ │Icon│ │Icon│  │
+│  │Text│ │Text│ │Text│  │
+│  └────┘ └────┘ └────┘  │
+├─────────────────────────┤
+│     Chart / Visual      │
+├─────────────────────────┤
+│     Section 2           │
+│     Timeline/Flow       │
+├─────────────────────────┤
+│     CTA / Source        │
+└─────────────────────────┘
+```
+
+### Best Practices
+- Max width 800px, centered
+- Use scroll-triggered animations (IntersectionObserver)
+- Big numbers: 48px+ font size, bold, accent color
+- Source citations at bottom
+- Shareable: looks good when screenshotted
+
+---
+
+## Dashboard
+
+### Structure
+- CSS Grid layout with cards
+- Header with title + date/time
+- KPI cards at top (3-5 key metrics)
+- Charts/tables below in grid
+- Optional sidebar for filters
+
+### KPI Card Pattern
+```html
+<div class="kpi-card">
+  <span class="kpi-label">Revenue</span>
+  <span class="kpi-value">$1.2M</span>
+  <span class="kpi-change positive">↑ 12.3%</span>
+</div>
+```
+
+### Chart Patterns (SVG)
+- **Bar chart**: `<rect>` elements with CSS transitions on height
+- **Line chart**: `<polyline>` or `<path>` with stroke-dasharray animation
+- **Donut chart**: `<circle>` with stroke-dasharray/stroke-dashoffset
+- **Sparkline**: tiny `<polyline>` in KPI cards
+
+### Best Practices
+- Use CSS Grid with `auto-fit` and `minmax()` for responsive cards
+- Subtle card shadows, no borders
+- Color-code positive (green) and negative (red) changes
+- Tooltips on hover for data points
+- Auto-refresh indicator (even if static — sells the "live" feel)
+
+---
+
+## Flowchart / Diagram
+
+### Approach
+Use SVG for the diagram. Position nodes with CSS Grid or absolute positioning within an SVG viewBox.
+
+### Node Types
+```svg
+<!-- Rounded rectangle (process) -->
+<rect rx="8" />
+<!-- Diamond (decision) -->
+<polygon points="50,0 100,50 50,100 0,50" />
+<!-- Circle (start/end) -->
+<circle />
+<!-- Parallelogram (input/output) -->
+<polygon points="20,0 100,0 80,50 0,50" />
+```
+
+### Connection Lines
+- Use `<path>` with cubic bezier curves for smooth connections
+- Arrow markers: `<marker>` element with `<polygon>` arrowhead
+- Elbow connectors for orthogonal layouts
+
+### Best Practices
+- Left-to-right or top-to-bottom flow
+- Consistent node sizes
+- Labels centered in nodes
+- Color-code different paths (success=green, error=red)
+- Keep it simple: max 15-20 nodes before splitting into sub-diagrams
+
+---
+
+## Timeline
+
+### Layout Options
+1. **Vertical** — line down the center, events alternate left/right
+2. **Horizontal** — scrollable timeline for fewer events
+3. **Compact** — single column with dots and lines
+
+### Vertical Timeline Pattern
+```
+     ┌──────────┐
+     │ Event 1  │──── ●
+     └──────────┘     │
+                      │
+          ● ────┌──────────┐
+                │ Event 2  │
+                └──────────┘
+                      │
+     ┌──────────┐     │
+     │ Event 3  │──── ●
+     └──────────┘
+```
+
+### Best Practices
+- Alternating sides for visual balance
+- Dates prominently displayed
+- Color/icon differentiation for event types
+- Scroll-triggered entrance animations
+- "Now" marker for roadmaps
+
+---
+
+## Comparison
+
+### Layout Options
+1. **Side-by-side cards** — 2-3 options in columns
+2. **Feature matrix** — rows = features, columns = options, checkmarks/values
+3. **Before/After** — split screen
+
+### Feature Matrix Pattern
+- Sticky header row
+- Alternating row backgrounds
+- ✓ / ✗ icons (SVG) instead of text
+- Highlight recommended option with accent border/badge
+
+### Best Practices
+- Max 4 comparison columns (more = overwhelming)
+- Highlight key differentiators
+- Use icons for quick scanning
+- Color-code to guide toward recommended option (subtle, not pushy)
+
+---
+
+## Data Visualization
+
+### Chart Types (all SVG-based)
+- **Bar**: vertical or horizontal, grouped or stacked
+- **Line**: single or multi-series, area fills
+- **Pie/Donut**: max 6 segments, label percentages
+- **Scatter**: for correlations, size for third dimension
+- **Heatmap**: grid of colored cells
+
+### SVG Chart Essentials
+- Always include axes with labels
+- Grid lines: subtle (`stroke: #eee`, `stroke-dasharray: 4`)
+- Legend: positioned consistently (top-right or bottom)
+- Responsive viewBox: `viewBox="0 0 600 400"` with `preserveAspectRatio`
+- Animate on load: stroke-dasharray for lines, scaleY for bars
+
+### Best Practices
+- Lead with the insight, not the data
+- Annotate key data points directly on the chart
+- Don't use 3D effects
+- Start y-axis at 0 for bar charts (line charts can break this rule)
+- Max 5-7 data series per chart
+
+---
+
+## One-Pager
+
+### Structure
+- Hero section with headline + subtext
+- 3-4 content sections
+- Clear CTA or conclusion
+- Max viewport: feels complete without scrolling (or minimal scroll)
+
+### Best Practices
+- Large hero text (48px+)
+- Icon + text pairs for features
+- Centered layout, max-width 960px
+- Professional but not boring — one bold design choice
+- Works as a screenshot/PDF
+
+---
+
+## Mind Map
+
+### Approach
+- Central node with radiating branches
+- SVG with `<path>` curved connections
+- Color-code branches by category
+- Nodes expand on click (optional interactivity)
+
+### Layout Algorithm (simplified)
+- Center node at viewBox center
+- First-level nodes in a circle around center
+- Second-level nodes branch outward from their parent
+- Use polar coordinates for positioning
+
+### Best Practices
+- Max 2-3 levels deep for readability
+- Curved, organic-looking connections (bezier)
+- Node size reflects importance
+- Hover to highlight a branch and dim others
+
+---
+
+## Kanban Board
+
+### Structure
+```html
+<div class="board">
+  <div class="column">
+    <h3>To Do</h3>
+    <div class="card">Task</div>
+  </div>
+  <div class="column">
+    <h3>In Progress</h3>
+    <div class="card">Task</div>
+  </div>
+  <div class="column">
+    <h3>Done</h3>
+    <div class="card">Task</div>
+  </div>
+</div>
+```
+
+### Best Practices
+- 3-5 columns (horizontal scroll if needed)
+- Cards with title, optional tags/labels (color-coded chips), optional assignee avatar
+- Column headers with item count
+- Subtle drag-handle visual (even if not functional)
+- WIP limits indicator
+- Column background colors (very subtle) to differentiate stages


### PR DESCRIPTION
## Summary
- Port the open-source **visualize** skill (v0.3.0, MIT) from `para/project/visualize`
- Includes SKILL.md, 9 reference docs (design-system, skeleton, animations, etc.), and 18 HTML examples
- Adapt browser-open command from macOS `open` to WSL `wslview` for our environment

## Test plan
- [ ] Verify `/visualize` skill is recognized by Claude Code
- [ ] Test `wslview` opens generated HTML in Windows browser
- [ ] Confirm example files render correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->