### PR TITLE
feat(diagnostics): add network checks and interactive cleanup

### DIFF
--- a/shell-common/functions/file_cleanup.sh
+++ b/shell-common/functions/file_cleanup.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# shell-common/functions/file_cleanup.sh
+# Interactive cleanup for backup/original files in the current directory
+
+_cleanup_set_default_patterns() {
+    CLEANUP_DEFAULT_PATTERNS=(
+        '.*backup*'
+        '.*.bak*'
+        '.*-original'
+    )
+}
+
+_cleanup_collect_matches() {
+    local search_dir="$1"
+    shift
+
+    local find_args=("$search_dir" -maxdepth 1 -type f "(")
+    local first_pattern=1
+    local pattern=""
+
+    for pattern in "$@"; do
+        if [ "$first_pattern" -eq 0 ]; then
+            find_args+=(-o)
+        fi
+        find_args+=(-name "$pattern")
+        first_pattern=0
+    done
+    find_args+=(")")
+
+    CLEANUP_MATCHES_OUTPUT="$(find "${find_args[@]}" -print 2>/dev/null | LC_ALL=C sort -u)"
+}
+
+_cleanup_file_size() {
+    local file="$1"
+    CLEANUP_FILE_SIZE="$(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null || printf '%s\n' '?')"
+}
+
+_cleanup_preview() {
+    local search_dir="$1"
+    shift
+
+    local patterns=("$@")
+    local files=()
+    local matches=""
+    local file=""
+
+    _cleanup_collect_matches "$search_dir" "${patterns[@]}"
+    matches="$CLEANUP_MATCHES_OUTPUT"
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        files+=("$file")
+    done <<EOF
+$matches
+EOF
+
+    ux_header "File Cleanup Preview"
+    ux_section "Target Directory"
+    ux_bullet "$search_dir"
+
+    ux_section "Patterns"
+    for file in "${patterns[@]}"; do
+        ux_bullet "$file"
+    done
+
+    if [ "${#files[@]}" -eq 0 ]; then
+        ux_warning "No matching files found"
+        return 1
+    fi
+
+    ux_section "Matched Files (${#files[@]})"
+    for file in "${files[@]}"; do
+        local size=""
+        _cleanup_file_size "$file"
+        size="$CLEANUP_FILE_SIZE"
+        ux_bullet "$(basename "$file") ($size bytes)"
+    done
+
+    DEL_FILE_MATCHED_FILES=("${files[@]}")
+    return 0
+}
+
+_cleanup_delete_one() {
+    local file="$1"
+    if rm -f -- "$file" 2>/dev/null; then
+        ux_success "Deleted: $file"
+        return 0
+    fi
+
+    ux_error "Failed to delete: $file"
+    return 1
+}
+
+_cleanup_delete_all() {
+    local files=("$@")
+    local file=""
+    local success_count=0
+    local error_count=0
+
+    if ! ux_confirm "Delete all ${#files[@]} file(s)?" "n"; then
+        ux_info "Operation cancelled"
+        return 0
+    fi
+
+    ux_section "Deleting Files"
+    for file in "${files[@]}"; do
+        if _cleanup_delete_one "$file"; then
+            success_count=$((success_count + 1))
+        else
+            error_count=$((error_count + 1))
+        fi
+    done
+
+    ux_section "Summary"
+    if [ "$error_count" -eq 0 ]; then
+        ux_success "$success_count file(s) deleted successfully"
+        return 0
+    fi
+
+    ux_warning "$success_count succeeded, $error_count failed"
+    return 1
+}
+
+_cleanup_delete_individually() {
+    local files=("$@")
+    local file=""
+    local success_count=0
+    local skip_count=0
+    local error_count=0
+
+    ux_section "Review Each File"
+    for file in "${files[@]}"; do
+        if ux_confirm "Delete $(basename "$file")?" "n"; then
+            if _cleanup_delete_one "$file"; then
+                success_count=$((success_count + 1))
+            else
+                error_count=$((error_count + 1))
+            fi
+        else
+            ux_info "Skipped: $file"
+            skip_count=$((skip_count + 1))
+        fi
+    done
+
+    ux_section "Summary"
+    ux_success "$success_count file(s) deleted"
+    ux_info "$skip_count file(s) skipped"
+    if [ "$error_count" -gt 0 ]; then
+        ux_warning "$error_count file(s) failed"
+        return 1
+    fi
+
+    return 0
+}
+
+_cleanup_select_mode() {
+    ux_section "Choose Deletion Mode"
+    ux_bullet "1  Delete all matched files"
+    ux_bullet "2  Review each matched file"
+    ux_bullet "0  Cancel"
+
+    while true; do
+        printf "%s❯%s Select 0, 1, or 2: " "${UX_INFO}" "${UX_RESET}"
+        read -r DEL_FILE_SELECTION
+        case "$DEL_FILE_SELECTION" in
+            0|1|2)
+                return 0
+                ;;
+            *)
+                ux_error "Invalid input. Enter 0, 1, or 2."
+                ;;
+        esac
+    done
+}
+
+del_file() {
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        ux_error "del-file requires an interactive terminal"
+        return 1
+    fi
+
+    local search_dir="${PWD}"
+    local patterns=()
+    local extra_pattern=""
+    local default_pattern=""
+    local selection=""
+
+    _cleanup_set_default_patterns
+    for default_pattern in "${CLEANUP_DEFAULT_PATTERNS[@]}"; do
+        [ -n "$default_pattern" ] || continue
+        patterns+=("$default_pattern")
+    done
+
+    for extra_pattern in "$@"; do
+        [ -n "$extra_pattern" ] || continue
+        patterns+=("$extra_pattern")
+    done
+
+    if ! _cleanup_preview "$search_dir" "${patterns[@]}"; then
+        return 1
+    fi
+
+    ux_section "Deletion Modes"
+    ux_bullet "Delete all   Delete every matched file after one confirmation"
+    ux_bullet "Review each  Ask once per file before deleting"
+    ux_bullet "Cancel       Do nothing"
+
+    _cleanup_select_mode || return 0
+    selection="$DEL_FILE_SELECTION"
+
+    case "$selection" in
+        1)
+            _cleanup_delete_all "${DEL_FILE_MATCHED_FILES[@]}"
+            ;;
+        2)
+            _cleanup_delete_individually "${DEL_FILE_MATCHED_FILES[@]}"
+            ;;
+        *)
+            ux_info "Operation cancelled"
+            return 0
+            ;;
+    esac
+}
+
+alias del-file='del_file'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -144,7 +144,7 @@ _register_default_help_categories() {
 
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git uv py nvm npm pp cli ux du psql mytool}"
-    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql gpu}"
+    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql gpu network}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip}"
@@ -209,6 +209,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[bat_help]="${HELP_DESCRIPTIONS[bat_help]:-[CLI] bat file viewer}"
     HELP_DESCRIPTIONS[dot_help]="${HELP_DESCRIPTIONS[dot_help]:-[Docs] Dotfiles overview and setup}"
     HELP_DESCRIPTIONS[proxy_help]="${HELP_DESCRIPTIONS[proxy_help]:-[DevOps] Proxy config and diagnostics}"
+    HELP_DESCRIPTIONS[network_help]="${HELP_DESCRIPTIONS[network_help]:-[DevOps] Internet connectivity diagnostics}"
     HELP_DESCRIPTIONS[ssl_help]="${HELP_DESCRIPTIONS[ssl_help]:-[DevOps] SSL certificate config and diagnostics}"
     HELP_DESCRIPTIONS[fasd_help]="${HELP_DESCRIPTIONS[fasd_help]:-[CLI] fasd directory jump}"
     HELP_DESCRIPTIONS[fd_help]="${HELP_DESCRIPTIONS[fd_help]:-[CLI] fd file finder}"

--- a/shell-common/functions/network_help.sh
+++ b/shell-common/functions/network_help.sh
@@ -3,11 +3,7 @@
 # Network connectivity diagnostic help (POSIX-compatible, shared between bash and zsh)
 
 network_help() {
-    if type ux_header >/dev/null 2>&1; then
-        ux_header "Network Connectivity Diagnostics"
-    else
-        ux_header "Network Connectivity Diagnostics"
-    fi
+    ux_header "Network Connectivity Diagnostics"
 
     if type ux_section >/dev/null 2>&1; then
         ux_section "Diagnostic Commands"
@@ -53,7 +49,7 @@ network_check() {
         if type ux_error >/dev/null 2>&1; then
             ux_error "check_network.sh not found at $check_network_script"
         else
-            echo "ERROR: check_network.sh not found at $check_network_script" >&2
+            echo "Error: check_network.sh not found at $check_network_script" >&2
         fi
         return 1
     fi

--- a/shell-common/functions/network_help.sh
+++ b/shell-common/functions/network_help.sh
@@ -33,11 +33,11 @@ network_help() {
         ux_info "APT check is skipped automatically on non-APT systems"
         ux_info "Use check-proxy for proxy variables and proxy.local.sh issues"
     else
-        ux_header "Diagnostic Commands:"
-        ux_bullet "check-network       Run full network diagnostic"
-        ux_bullet "check-network dns   DNS resolution test"
-        ux_bullet "check-network ping  ICMP ping test"
-        ux_bullet "check-network https HTTPS HEAD request test"
+        echo "Diagnostic Commands:"
+        echo "  check-network       Run full network diagnostic"
+        echo "  check-network dns   DNS resolution test"
+        echo "  check-network ping  ICMP ping test"
+        echo "  check-network https HTTPS HEAD request test"
     fi
 }
 

--- a/shell-common/functions/network_help.sh
+++ b/shell-common/functions/network_help.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# shell-common/functions/network_help.sh
+# Network connectivity diagnostic help (POSIX-compatible, shared between bash and zsh)
+
+network_help() {
+    if type ux_header >/dev/null 2>&1; then
+        ux_header "Network Connectivity Diagnostics"
+    else
+        ux_header "Network Connectivity Diagnostics"
+    fi
+
+    if type ux_section >/dev/null 2>&1; then
+        ux_section "Diagnostic Commands"
+        ux_bullet "check-network         Run full network diagnostic"
+        ux_bullet "check-network quick   DNS + HTTPS + git quick check"
+        ux_bullet "check-network dns     DNS resolution test"
+        ux_bullet "check-network ping    ICMP ping test"
+        ux_bullet "check-network https   HTTPS HEAD request test"
+        ux_bullet "check-network git     Git remote access test"
+        ux_bullet "check-network apt     APT repository reachability"
+        ux_bullet "check-network pip     pip repository reachability"
+        ux_bullet "check-network curl    curl GET request test"
+
+        ux_section "Typical Use"
+        ux_bullet "check-network         Verify internet access end-to-end"
+        ux_bullet "check-network quick   Fast sanity check after shell startup"
+        ux_bullet "check-proxy           Diagnose proxy-specific configuration"
+
+        ux_section "What It Checks"
+        ux_bullet "DNS lookup to confirm name resolution"
+        ux_bullet "ICMP ping to detect low-level reachability"
+        ux_bullet "HTTPS and curl requests to validate outbound web access"
+        ux_bullet "git, apt, and pip endpoints for real tool-level access"
+
+        ux_section "Important Notes"
+        ux_info "ICMP ping may fail even when normal web traffic works"
+        ux_info "APT check is skipped automatically on non-APT systems"
+        ux_info "Use check-proxy for proxy variables and proxy.local.sh issues"
+    else
+        ux_header "Diagnostic Commands:"
+        ux_bullet "check-network       Run full network diagnostic"
+        ux_bullet "check-network dns   DNS resolution test"
+        ux_bullet "check-network ping  ICMP ping test"
+        ux_bullet "check-network https HTTPS HEAD request test"
+    fi
+}
+
+network_check() {
+    local check_network_script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/check_network.sh"
+    if [ -f "$check_network_script" ]; then
+        bash "$check_network_script" "$@"
+    else
+        if type ux_error >/dev/null 2>&1; then
+            ux_error "check_network.sh not found at $check_network_script"
+        else
+            echo "ERROR: check_network.sh not found at $check_network_script" >&2
+        fi
+        return 1
+    fi
+}
+
+alias network-help='network_help'
+alias check-network='network_check'

--- a/shell-common/functions/proxy_help.sh
+++ b/shell-common/functions/proxy_help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/functions/proxy_help.sh
 # Proxy help function (bash/zsh compatible, uses local keyword)
 
@@ -17,7 +17,7 @@ proxy_help() {
         ux_bullet "check-proxy env      Environment variables only"
         ux_bullet "check-proxy file     proxy.local.sh file check"
         ux_bullet "check-proxy shell    Shell loading test"
-        ux_bullet "check-proxy conn     Connectivity test"
+        ux_bullet "check-proxy conn     Configured proxy connectivity test"
         ux_bullet "check-proxy git      Git configuration"
 
 
@@ -45,9 +45,15 @@ proxy_help() {
         ux_bullet "git config --global -l | grep proxy           View git proxy config"
 
 
+        ux_section "Related Diagnostics"
+        ux_bullet "check-network quick       General internet access check"
+        ux_bullet "check-network             DNS, HTTPS, git, apt, pip, curl checks"
+
+
         ux_section "Important Notes"
         ux_warning "NO_PROXY with spaces is not recognized - use commas only"
         ux_info "Some tools only recognize uppercase (HTTP_PROXY, HTTPS_PROXY)"
+        ux_info "check-proxy focuses on proxy configuration only"
 
     else
         # Fallback for minimal shells without UX library
@@ -55,6 +61,7 @@ proxy_help() {
         ux_bullet "check-proxy          Run full diagnostic"
         ux_bullet "check-proxy env      Environment variables only"
         ux_bullet "check-proxy file     proxy.local.sh file check"
+        ux_bullet "check-network quick  General internet access check"
 
         ux_header "Quick Commands:"
         ux_bullet "echo \$http_proxy         Current proxy setting"
@@ -64,17 +71,10 @@ proxy_help() {
 }
 
 # Wrapper function for check_proxy.sh diagnostic
-# Also runs pip_check for comprehensive network diagnostics
 proxy_check() {
     local check_proxy_script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/check_proxy.sh"
     if [ -f "$check_proxy_script" ]; then
         bash "$check_proxy_script" "$@"
-
-
-        # Also run pip check for comprehensive diagnostics
-        if type pip_check >/dev/null 2>&1; then
-            pip_check "$@"
-        fi
     else
         # Error handling with fallback (guard ux_error)
         if type ux_error >/dev/null 2>&1; then

--- a/shell-common/functions/proxy_help.sh
+++ b/shell-common/functions/proxy_help.sh
@@ -3,13 +3,7 @@
 # Proxy help function (bash/zsh compatible, uses local keyword)
 
 proxy_help() {
-    if type ux_header >/dev/null 2>&1; then
-        ux_header "Proxy Configuration & Diagnostics"
-    else
-
-        ux_header "Proxy Configuration & Diagnostics"
-
-    fi
+    ux_header "Proxy Configuration & Diagnostics"
 
     if type ux_section >/dev/null 2>&1; then
         ux_section "Diagnostic Commands"

--- a/shell-common/functions/proxy_help.sh
+++ b/shell-common/functions/proxy_help.sh
@@ -51,15 +51,15 @@ proxy_help() {
 
     else
         # Fallback for minimal shells without UX library
-        ux_header "Diagnostic Commands:"
-        ux_bullet "check-proxy          Run full diagnostic"
-        ux_bullet "check-proxy env      Environment variables only"
-        ux_bullet "check-proxy file     proxy.local.sh file check"
-        ux_bullet "check-network quick  General internet access check"
-
-        ux_header "Quick Commands:"
-        ux_bullet "echo \$http_proxy         Current proxy setting"
-        ux_bullet "env | grep -i proxy      Show all proxy vars"
+        echo "Diagnostic Commands:"
+        echo "  check-proxy          Run full diagnostic"
+        echo "  check-proxy env      Environment variables only"
+        echo "  check-proxy file     proxy.local.sh file check"
+        echo "  check-network quick  General internet access check"
+        echo ""
+        echo "Quick Commands:"
+        echo "  echo \$http_proxy         Current proxy setting"
+        echo "  env | grep -i proxy      Show all proxy vars"
 
     fi
 }

--- a/shell-common/functions/sys_help.sh
+++ b/shell-common/functions/sys_help.sh
@@ -17,6 +17,7 @@ sys_help() {
     ux_table_row "myip" "curl ipecho.net" "Public IP"
     ux_table_row "localip" "hostname -I" "Local IP"
     ux_table_row "ping" "ping -c 5" "Ping (5 times)"
+    ux_table_row "check-network" "check-network" "Internet connectivity diagnostics"
     ux_table_row "ssh-help" "ssh-help" "SSH hosts and examples"
     echo ""
 

--- a/shell-common/tools/custom/check_network.sh
+++ b/shell-common/tools/custom/check_network.sh
@@ -1,0 +1,449 @@
+#!/bin/bash
+# shell-common/tools/custom/check_network.sh
+# Comprehensive internet connectivity diagnostic script
+# Usage: check_network [quick|dns|ping|https|git|apt|pip|curl|all]
+
+source "$(dirname "$0")/init.sh" || exit 1
+
+NETWORK_DNS_TARGET="${NETWORK_DNS_TARGET:-example.com}"
+NETWORK_PING_TARGET="${NETWORK_PING_TARGET:-1.1.1.1}"
+NETWORK_HTTPS_TARGET="${NETWORK_HTTPS_TARGET:-https://example.com}"
+NETWORK_GIT_TARGET="${NETWORK_GIT_TARGET:-https://github.com/git/git.git}"
+NETWORK_PIP_TARGET_DEFAULT="${NETWORK_PIP_TARGET_DEFAULT:-https://pypi.org/simple/pip/}"
+
+NETWORK_PASS_COUNT=0
+NETWORK_WARN_COUNT=0
+NETWORK_FAIL_COUNT=0
+
+record_pass() {
+    NETWORK_PASS_COUNT=$((NETWORK_PASS_COUNT + 1))
+}
+
+record_warn() {
+    NETWORK_WARN_COUNT=$((NETWORK_WARN_COUNT + 1))
+}
+
+record_fail() {
+    NETWORK_FAIL_COUNT=$((NETWORK_FAIL_COUNT + 1))
+}
+
+have_command() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+run_with_timeout() {
+    local seconds="$1"
+    shift
+
+    if have_command timeout; then
+        timeout "$seconds" "$@"
+        return $?
+    fi
+
+    if have_command gtimeout; then
+        gtimeout "$seconds" "$@"
+        return $?
+    fi
+
+    "$@"
+}
+
+test_http_head() {
+    local url="$1"
+    local http_code=""
+
+    if ! have_command curl; then
+        return 127
+    fi
+
+    http_code="$(curl -I -sS -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "$url" 2>/dev/null)"
+    if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
+        printf "%s\n" "$http_code"
+        return 0
+    fi
+
+    return 1
+}
+
+test_http_get() {
+    local url="$1"
+    local http_code=""
+
+    if ! have_command curl; then
+        return 127
+    fi
+
+    http_code="$(curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "$url" 2>/dev/null)"
+    if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
+        printf "%s\n" "$http_code"
+        return 0
+    fi
+
+    return 1
+}
+
+detect_pip_target() {
+    local configured_repo=""
+
+    if have_command pip; then
+        configured_repo="$(pip config list 2>/dev/null | grep "global.index-url" | head -n 1 | cut -d "=" -f 2- | tr -d "'" | xargs)"
+    fi
+
+    if [ -n "${PIP_INDEX_URL:-}" ]; then
+        configured_repo="${PIP_INDEX_URL}"
+    fi
+
+    if [ -n "$configured_repo" ]; then
+        printf "%s\n" "$configured_repo"
+    else
+        printf "%s\n" "$NETWORK_PIP_TARGET_DEFAULT"
+    fi
+}
+
+detect_apt_target() {
+    local apt_uri=""
+    local source_file=""
+
+    if ! have_command apt-get; then
+        return 1
+    fi
+
+    apt_uri="$(apt-get indextargets --format '$(URI)' 2>/dev/null | head -n 1)"
+    if [ -n "$apt_uri" ]; then
+        printf "%s\n" "$apt_uri"
+        return 0
+    fi
+
+    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+        if [ -f "$source_file" ]; then
+            apt_uri="$(grep -E '^[[:space:]]*deb[[:space:]]+https?://' "$source_file" 2>/dev/null | awk '{print $2; exit}')"
+            if [ -n "$apt_uri" ]; then
+                printf "%s\n" "$apt_uri"
+                return 0
+            fi
+        fi
+    done
+
+    for source_file in /etc/apt/sources.list.d/*.sources; do
+        if [ -f "$source_file" ]; then
+            apt_uri="$(grep -E '^[[:space:]]*URIs:[[:space:]]+https?://' "$source_file" 2>/dev/null | awk '{print $2; exit}')"
+            if [ -n "$apt_uri" ]; then
+                printf "%s\n" "$apt_uri"
+                return 0
+            fi
+        fi
+    done
+
+    return 1
+}
+
+check_network_dns() {
+    ux_header "1. DNS Resolution"
+    ux_section "Target"
+    ux_bullet "$NETWORK_DNS_TARGET"
+
+    if have_command getent; then
+        local result=""
+        result="$(getent hosts "$NETWORK_DNS_TARGET" 2>/dev/null | head -n 1)"
+        if [ -n "$result" ]; then
+            ux_success "DNS lookup successful"
+            ux_bullet "$result"
+            record_pass
+        else
+            ux_error "DNS lookup failed via getent"
+            record_fail
+        fi
+    elif have_command nslookup; then
+        local result=""
+        result="$(nslookup "$NETWORK_DNS_TARGET" 2>/dev/null | awk '/^Address: / { print $2; exit }')"
+        if [ -n "$result" ]; then
+            ux_success "DNS lookup successful"
+            ux_bullet "$result"
+            record_pass
+        else
+            ux_error "DNS lookup failed via nslookup"
+            record_fail
+        fi
+    elif have_command host; then
+        local result=""
+        result="$(host "$NETWORK_DNS_TARGET" 2>/dev/null | head -n 1)"
+        if [ -n "$result" ]; then
+            ux_success "DNS lookup successful"
+            ux_bullet "$result"
+            record_pass
+        else
+            ux_error "DNS lookup failed via host"
+            record_fail
+        fi
+    else
+        ux_warning "No DNS lookup command available (getent/nslookup/host)"
+        record_warn
+    fi
+    echo ""
+}
+
+check_network_ping() {
+    ux_header "2. ICMP Ping"
+    ux_section "Target"
+    ux_bullet "$NETWORK_PING_TARGET"
+
+    if ! have_command ping; then
+        ux_warning "ping command not available"
+        record_warn
+        echo ""
+        return 0
+    fi
+
+    if run_with_timeout 3 ping -c 1 "$NETWORK_PING_TARGET" >/dev/null 2>&1; then
+        ux_success "ICMP ping successful"
+        record_pass
+    else
+        ux_warning "No ICMP reply received"
+        ux_info "This can be normal when ICMP is blocked by firewall or network policy"
+        record_warn
+    fi
+    echo ""
+}
+
+check_network_https() {
+    ux_header "3. HTTPS HEAD Request"
+    ux_section "Target"
+    ux_bullet "$NETWORK_HTTPS_TARGET"
+
+    local http_code=""
+    http_code="$(test_http_head "$NETWORK_HTTPS_TARGET")"
+    case $? in
+        0)
+            ux_success "HTTPS request successful (HTTP $http_code)"
+            record_pass
+            ;;
+        127)
+            ux_warning "curl command not available"
+            record_warn
+            ;;
+        *)
+            ux_error "HTTPS request failed"
+            record_fail
+            ;;
+    esac
+    echo ""
+}
+
+check_network_git() {
+    ux_header "4. Git Remote Access"
+    ux_section "Target"
+    ux_bullet "$NETWORK_GIT_TARGET"
+
+    if ! have_command git; then
+        ux_warning "git command not available"
+        record_warn
+        echo ""
+        return 0
+    fi
+
+    if run_with_timeout 10 git ls-remote "$NETWORK_GIT_TARGET" HEAD >/dev/null 2>&1; then
+        ux_success "Git remote access successful"
+        record_pass
+    else
+        ux_error "Git remote access failed"
+        record_fail
+    fi
+    echo ""
+}
+
+check_network_apt() {
+    ux_header "5. APT Repository Reachability"
+
+    if ! have_command apt-get; then
+        ux_info "APT is not available on this system"
+        record_warn
+        echo ""
+        return 0
+    fi
+
+    local apt_target=""
+    apt_target="$(detect_apt_target)"
+    if [ -z "$apt_target" ]; then
+        ux_warning "Could not detect an APT repository URL"
+        record_warn
+        echo ""
+        return 0
+    fi
+
+    ux_section "Target"
+    ux_bullet "$apt_target"
+
+    local http_code=""
+    http_code="$(test_http_head "$apt_target")"
+    case $? in
+        0)
+            ux_success "APT repository reachable (HTTP $http_code)"
+            record_pass
+            ;;
+        127)
+            ux_warning "curl command not available for APT reachability test"
+            record_warn
+            ;;
+        *)
+            ux_error "APT repository not reachable"
+            record_fail
+            ;;
+    esac
+    echo ""
+}
+
+check_network_pip() {
+    ux_header "6. pip Repository Reachability"
+
+    if ! have_command pip; then
+        ux_warning "pip command not available"
+        record_warn
+        echo ""
+        return 0
+    fi
+
+    local pip_target=""
+    pip_target="$(detect_pip_target)"
+
+    ux_section "Target"
+    ux_bullet "$pip_target"
+
+    local http_code=""
+    http_code="$(test_http_head "$pip_target")"
+    case $? in
+        0)
+            ux_success "pip repository reachable (HTTP $http_code)"
+            record_pass
+            ;;
+        127)
+            ux_warning "curl command not available for pip reachability test"
+            record_warn
+            ;;
+        *)
+            ux_error "pip repository not reachable"
+            record_fail
+            ;;
+    esac
+    echo ""
+}
+
+check_network_curl() {
+    ux_header "7. curl External Service Access"
+    ux_section "Target"
+    ux_bullet "$NETWORK_HTTPS_TARGET"
+
+    local http_code=""
+    http_code="$(test_http_get "$NETWORK_HTTPS_TARGET")"
+    case $? in
+        0)
+            ux_success "curl GET request successful (HTTP $http_code)"
+            record_pass
+            ;;
+        127)
+            ux_warning "curl command not available"
+            record_warn
+            ;;
+        *)
+            ux_error "curl GET request failed"
+            record_fail
+            ;;
+    esac
+    echo ""
+}
+
+show_usage() {
+    ux_header "check-network Usage"
+    ux_bullet "check-network         Run all connectivity checks"
+    ux_bullet "check-network quick   Run DNS, HTTPS, and git checks"
+    ux_bullet "check-network dns     DNS resolution test"
+    ux_bullet "check-network ping    ICMP ping test"
+    ux_bullet "check-network https   HTTPS HEAD request test"
+    ux_bullet "check-network git     Git remote access test"
+    ux_bullet "check-network apt     APT repository reachability"
+    ux_bullet "check-network pip     pip repository reachability"
+    ux_bullet "check-network curl    curl GET request test"
+    echo ""
+}
+
+show_summary() {
+    ux_divider_thick
+    ux_section "Summary"
+    ux_bullet "Passed: $NETWORK_PASS_COUNT"
+    ux_bullet "Warnings: $NETWORK_WARN_COUNT"
+    ux_bullet "Failures: $NETWORK_FAIL_COUNT"
+    echo ""
+}
+
+run_all_checks() {
+    check_network_dns
+    check_network_ping
+    check_network_https
+    check_network_git
+    check_network_apt
+    check_network_pip
+    check_network_curl
+}
+
+run_quick_checks() {
+    check_network_dns
+    check_network_https
+    check_network_git
+}
+
+check_network() {
+    local mode="${1:-all}"
+
+    case "$mode" in
+        quick)
+            run_quick_checks
+            ;;
+        dns)
+            check_network_dns
+            ;;
+        ping)
+            check_network_ping
+            ;;
+        https)
+            check_network_https
+            ;;
+        git)
+            check_network_git
+            ;;
+        apt)
+            check_network_apt
+            ;;
+        pip)
+            check_network_pip
+            ;;
+        curl)
+            check_network_curl
+            ;;
+        help|-h|--help)
+            show_usage
+            ;;
+        all)
+            run_all_checks
+            ;;
+        *)
+            ux_error "Unknown mode: $mode"
+            show_usage
+            record_fail
+            ;;
+    esac
+
+    show_summary
+
+    if [ "$NETWORK_FAIL_COUNT" -gt 0 ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+main() {
+    check_network "$@"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+    main "$@"
+fi

--- a/shell-common/tools/custom/check_network.sh
+++ b/shell-common/tools/custom/check_network.sh
@@ -27,27 +27,6 @@ record_fail() {
     NETWORK_FAIL_COUNT=$((NETWORK_FAIL_COUNT + 1))
 }
 
-have_command() {
-    command -v "$1" >/dev/null 2>&1
-}
-
-run_with_timeout() {
-    local seconds="$1"
-    shift
-
-    if have_command timeout; then
-        timeout "$seconds" "$@"
-        return $?
-    fi
-
-    if have_command gtimeout; then
-        gtimeout "$seconds" "$@"
-        return $?
-    fi
-
-    "$@"
-}
-
 test_http_head() {
     local url="$1"
     local http_code=""
@@ -420,6 +399,7 @@ check_network() {
             ;;
         help|-h|--help)
             show_usage
+            return 0
             ;;
         all)
             run_all_checks

--- a/shell-common/tools/custom/check_proxy.sh
+++ b/shell-common/tools/custom/check_proxy.sh
@@ -6,6 +6,26 @@
 # Initialize common tools environment (DOTFILES_ROOT/SHELL_COMMON + ux_lib)
 source "$(dirname "$0")/init.sh" || exit 1
 
+# Shared target constant (SSOT: same default as check_network.sh)
+NETWORK_GIT_TARGET="${NETWORK_GIT_TARGET:-https://github.com/git/git.git}"
+
+# Result counters (consistent with check_network.sh)
+PROXY_PASS_COUNT=0
+PROXY_WARN_COUNT=0
+PROXY_FAIL_COUNT=0
+
+record_pass() {
+    PROXY_PASS_COUNT=$((PROXY_PASS_COUNT + 1))
+}
+
+record_warn() {
+    PROXY_WARN_COUNT=$((PROXY_WARN_COUNT + 1))
+}
+
+record_fail() {
+    PROXY_FAIL_COUNT=$((PROXY_FAIL_COUNT + 1))
+}
+
 # ============================================================
 # Helper functions
 # ============================================================
@@ -27,6 +47,7 @@ check_setup_mode() {
     if [ ! -f "$setup_mode_file" ]; then
         ux_warning "Setup mode not configured"
         ux_bullet "Run: ./setup.sh in ~/dotfiles to configure"
+        record_warn
         echo ""
         return 0
     fi
@@ -38,17 +59,21 @@ check_setup_mode() {
         1)
             ux_success "Setup Mode: Public PC (Home environment)"
             ux_info "Expected behavior: NO proxy variables should be set"
+            record_pass
             ;;
         2)
             ux_success "Setup Mode: Internal company PC (Direct connection)"
             ux_info "Expected behavior: Company proxy SHOULD be set (12.26.204.100:8080)"
+            record_pass
             ;;
         3)
             ux_success "Setup Mode: External company PC (VPN)"
             ux_info "Expected behavior: NO proxy variables should be set"
+            record_pass
             ;;
         *)
             ux_error "Unknown setup mode: $mode"
+            record_fail
             ;;
     esac
     echo ""
@@ -85,6 +110,9 @@ check_proxy_env() {
                 ux_error "ISSUE DETECTED: Proxy is set but should not be (Mode $mode)"
                 ux_info "This may be inherited from WSL or the system environment"
                 ux_info "Solution: Restart your shell or run: source ~/.bashrc"
+                record_fail
+            else
+                record_pass
             fi
             ;;
         2)
@@ -92,6 +120,9 @@ check_proxy_env() {
                 echo ""
                 ux_warning "No proxy set but Mode 2 (Internal PC) expects proxy"
                 ux_info "Check if proxy.local.sh exists and is properly sourced"
+                record_warn
+            else
+                record_pass
             fi
             ;;
     esac
@@ -125,14 +156,18 @@ check_proxy_local_sh() {
         ux_section "Content Validation"
         if grep -q "export http_proxy" "$proxy_local"; then
             ux_success "http_proxy export found"
+            record_pass
         else
             ux_warning "http_proxy export not found"
+            record_warn
         fi
 
         if grep -q "export no_proxy" "$proxy_local"; then
             ux_success "no_proxy export found"
+            record_pass
         else
             ux_warning "no_proxy export not found"
+            record_warn
         fi
     else
         ux_warning "proxy.local.sh NOT FOUND"
@@ -141,6 +176,7 @@ check_proxy_local_sh() {
         ux_bullet "Option 2 (Internal PC): Run setup.sh and select option 2"
         ux_bullet "Option 3 (VPN): Uses direct connection - file not needed"
         ux_info "Continue with diagnostics for public/VPN environments..."
+        record_warn
     fi
     echo ""
 }
@@ -164,26 +200,33 @@ check_proxy_shell_loading() {
     bash_result=$(bash -c "source \"$proxy_sh\" 2>/dev/null && echo \${http_proxy:-[NOT SET]}" 2>/dev/null)
     if [ "$bash_result" != "[NOT SET]" ] && [ -n "$bash_result" ]; then
         ux_success "Bash loading: $bash_result"
+        record_pass
     elif [ "$expected_proxy" -eq 1 ]; then
         ux_warning "Bash loading: proxy not loaded but Mode 2 expects one"
+        record_warn
     else
         ux_success "Bash loading: no proxy configured (expected for this environment)"
+        record_pass
     fi
     echo ""
 
     ux_section "Zsh"
-    if command -v zsh >/dev/null 2>&1; then
+    if have_command zsh; then
         ux_info "Testing: zsh -c 'source proxy.sh && echo \$http_proxy'"
         zsh_result=$(zsh -c "source \"$proxy_sh\" 2>/dev/null && echo \${http_proxy:-[NOT SET]}" 2>/dev/null)
         if [ "$zsh_result" != "[NOT SET]" ] && [ -n "$zsh_result" ]; then
             ux_success "Zsh loading: $zsh_result"
+            record_pass
         elif [ "$expected_proxy" -eq 1 ]; then
             ux_warning "Zsh loading: proxy not loaded but Mode 2 expects one"
+            record_warn
         else
             ux_success "Zsh loading: no proxy configured (expected for this environment)"
+            record_pass
         fi
     else
         ux_warning "Zsh not installed"
+        record_warn
     fi
     echo ""
 }
@@ -193,10 +236,11 @@ check_proxy_connectivity() {
 
     local mode
     mode="$(get_setup_mode)"
-    if [ -z "$http_proxy" ] && [ -z "$HTTP_PROXY" ]; then
+    if [ -z "${http_proxy:-}" ] && [ -z "${HTTP_PROXY:-}" ]; then
         if [ "$mode" = "2" ]; then
             ux_warning "No proxy configured but Mode 2 expects one"
             ux_info "Check proxy.local.sh and shell loading diagnostics"
+            record_warn
         else
             ux_info "No proxy configured, skipping proxy connectivity test"
             ux_info "Run check-network quick for general internet connectivity"
@@ -212,10 +256,12 @@ check_proxy_connectivity() {
     ux_bullet "Target: https://github.com"
     echo ""
 
-    if timeout 5 curl -v --proxy "$proxy" https://github.com 2>&1 | grep -q "HTTP\|Connected"; then
+    if run_with_timeout 5 curl -v --proxy "$proxy" https://github.com 2>&1 | grep -q "HTTP\|Connected"; then
         ux_success "Proxy connection successful"
+        record_pass
     else
         ux_error "Proxy connection failed or timeout"
+        record_fail
     fi
     echo ""
 }
@@ -233,12 +279,23 @@ check_git_config() {
     echo ""
 
     ux_section "Git Remote Access Test"
-    ux_info "Testing: timeout 5 git ls-remote https://github.com/git/git.git HEAD"
-    if timeout 5 git ls-remote https://github.com/git/git.git HEAD >/dev/null 2>&1; then
+    ux_info "Testing: timeout 5 git ls-remote $NETWORK_GIT_TARGET HEAD"
+    if run_with_timeout 5 git ls-remote "$NETWORK_GIT_TARGET" HEAD >/dev/null 2>&1; then
         ux_success "Git remote access successful"
+        record_pass
     else
         ux_error "Git remote access failed"
+        record_fail
     fi
+    echo ""
+}
+
+show_summary() {
+    ux_divider_thick
+    ux_section "Summary"
+    ux_bullet "Passed: $PROXY_PASS_COUNT"
+    ux_bullet "Warnings: $PROXY_WARN_COUNT"
+    ux_bullet "Failures: $PROXY_FAIL_COUNT"
     echo ""
 }
 
@@ -271,7 +328,7 @@ check_proxy() {
         git)
             check_git_config
             ;;
-        all|*)
+        all)
             check_setup_mode
             check_proxy_env
             check_proxy_local_sh
@@ -279,10 +336,20 @@ check_proxy() {
             check_proxy_connectivity
             check_git_config
             ;;
+        *)
+            ux_error "Unknown mode: $mode"
+            ux_info "Usage: check_proxy [mode|env|file|shell|conn|git|all]"
+            record_fail
+            ;;
     esac
 
-    ux_divider_thick
-    echo ""
+    show_summary
+
+    if [ "$PROXY_FAIL_COUNT" -gt 0 ]; then
+        return 1
+    fi
+
+    return 0
 }
 
 # ============================================================

--- a/shell-common/tools/custom/check_proxy.sh
+++ b/shell-common/tools/custom/check_proxy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shell-common/tools/custom/check_proxy.sh
 # Comprehensive proxy diagnostic script
-# Usage: check_proxy [env|file|shell|conn|git|all]
+# Usage: check_proxy [mode|env|file|shell|conn|git|all]
 
 # Initialize common tools environment (DOTFILES_ROOT/SHELL_COMMON + ux_lib)
 source "$(dirname "$0")/init.sh" || exit 1
@@ -54,6 +54,13 @@ check_setup_mode() {
     echo ""
 }
 
+get_setup_mode() {
+    local setup_mode_file="$HOME/.dotfiles-setup-mode"
+    if [ -f "$setup_mode_file" ]; then
+        cat "$setup_mode_file" 2>/dev/null
+    fi
+}
+
 check_proxy_env() {
     ux_header "1. Current Environment Variables"
 
@@ -69,36 +76,34 @@ check_proxy_env() {
     _format_env "HTTPS_PROXY" "${HTTPS_PROXY:-[NOT SET]}"
 
     # Validate against setup mode
-    local setup_mode_file="$HOME/.dotfiles-setup-mode"
-    if [ -f "$setup_mode_file" ]; then
-        local mode
-        mode=$(cat "$setup_mode_file" 2>/dev/null)
-        case "$mode" in
-            1|3)
-                # Should NOT have proxy
-                if [ "$has_proxy" -eq 1 ]; then
-                    echo ""
-                    ux_error "⚠️  ISSUE DETECTED: Proxy is set but shouldn't be (Mode $mode)"
-                    ux_info "This may be inherited from WSL/system level"
-                    ux_info "Solution: Restart your shell or run: source ~/.bashrc"
-                fi
-                ;;
-            2)
-                # Should have proxy
-                if [ "$has_proxy" -eq 0 ]; then
-                    echo ""
-                    ux_warning "⚠️  No proxy set but Mode 2 (Internal PC) expects proxy"
-                    ux_info "Check if proxy.local.sh exists and is properly sourced"
-                fi
-                ;;
-        esac
-    fi
+    local mode
+    mode="$(get_setup_mode)"
+    case "$mode" in
+        1|3)
+            if [ "$has_proxy" -eq 1 ]; then
+                echo ""
+                ux_error "ISSUE DETECTED: Proxy is set but should not be (Mode $mode)"
+                ux_info "This may be inherited from WSL or the system environment"
+                ux_info "Solution: Restart your shell or run: source ~/.bashrc"
+            fi
+            ;;
+        2)
+            if [ "$has_proxy" -eq 0 ]; then
+                echo ""
+                ux_warning "No proxy set but Mode 2 (Internal PC) expects proxy"
+                ux_info "Check if proxy.local.sh exists and is properly sourced"
+            fi
+            ;;
+    esac
     echo ""
 
     ux_section "NO Proxy (Exceptions)"
-    if [ -n "$no_proxy" ]; then
+    if [ -n "${no_proxy:-}" ]; then
         ux_bullet "no_proxy (lowercase) entries:"
         echo "$no_proxy" | tr ',' '\n' | sed 's/^/    - /'
+    elif [ -n "${NO_PROXY:-}" ]; then
+        ux_bullet "NO_PROXY (uppercase) entries:"
+        echo "$NO_PROXY" | tr ',' '\n' | sed 's/^/    - /'
     else
         ux_warning "no_proxy: [NOT SET]"
     fi
@@ -144,14 +149,25 @@ check_proxy_shell_loading() {
     ux_header "3. Shell Loading Test"
 
     local proxy_sh="${SHELL_COMMON}/env/proxy.sh"
+    local mode
+    mode="$(get_setup_mode)"
+    local bash_result=""
+    local zsh_result=""
+    local expected_proxy=0
+
+    if [ "$mode" = "2" ]; then
+        expected_proxy=1
+    fi
 
     ux_section "Bash"
     ux_info "Testing: bash -c 'source proxy.sh && echo \$http_proxy'"
     bash_result=$(bash -c "source \"$proxy_sh\" 2>/dev/null && echo \${http_proxy:-[NOT SET]}" 2>/dev/null)
     if [ "$bash_result" != "[NOT SET]" ] && [ -n "$bash_result" ]; then
         ux_success "Bash loading: $bash_result"
+    elif [ "$expected_proxy" -eq 1 ]; then
+        ux_warning "Bash loading: proxy not loaded but Mode 2 expects one"
     else
-        ux_warning "Bash loading: [NOT SET] or failed"
+        ux_success "Bash loading: no proxy configured (expected for this environment)"
     fi
     echo ""
 
@@ -161,8 +177,10 @@ check_proxy_shell_loading() {
         zsh_result=$(zsh -c "source \"$proxy_sh\" 2>/dev/null && echo \${http_proxy:-[NOT SET]}" 2>/dev/null)
         if [ "$zsh_result" != "[NOT SET]" ] && [ -n "$zsh_result" ]; then
             ux_success "Zsh loading: $zsh_result"
+        elif [ "$expected_proxy" -eq 1 ]; then
+            ux_warning "Zsh loading: proxy not loaded but Mode 2 expects one"
         else
-            ux_warning "Zsh loading: [NOT SET] or failed"
+            ux_success "Zsh loading: no proxy configured (expected for this environment)"
         fi
     else
         ux_warning "Zsh not installed"
@@ -173,8 +191,16 @@ check_proxy_shell_loading() {
 check_proxy_connectivity() {
     ux_header "4. Proxy Connectivity Test"
 
+    local mode
+    mode="$(get_setup_mode)"
     if [ -z "$http_proxy" ] && [ -z "$HTTP_PROXY" ]; then
-        ux_warning "No proxy configured, skipping connectivity test"
+        if [ "$mode" = "2" ]; then
+            ux_warning "No proxy configured but Mode 2 expects one"
+            ux_info "Check proxy.local.sh and shell loading diagnostics"
+        else
+            ux_info "No proxy configured, skipping proxy connectivity test"
+            ux_info "Run check-network quick for general internet connectivity"
+        fi
         echo ""
         return 0
     fi
@@ -207,8 +233,8 @@ check_git_config() {
     echo ""
 
     ux_section "Git Remote Access Test"
-    ux_info "Testing: timeout 5 git ls-remote https://github.com/anthropics/claude-code.git"
-    if timeout 5 git ls-remote https://github.com/anthropics/claude-code.git >/dev/null 2>&1; then
+    ux_info "Testing: timeout 5 git ls-remote https://github.com/git/git.git HEAD"
+    if timeout 5 git ls-remote https://github.com/git/git.git HEAD >/dev/null 2>&1; then
         ux_success "Git remote access successful"
     else
         ux_error "Git remote access failed"

--- a/shell-common/tools/custom/init.sh
+++ b/shell-common/tools/custom/init.sh
@@ -71,5 +71,34 @@ if [ -f "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" ]; then
     # UX library loaded successfully (fallback already replaced)
 fi
 
+# Shared utility functions (SSOT: used by check_network.sh, check_proxy.sh, etc.)
+have_command() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+run_with_timeout() {
+    local seconds="$1"
+    shift
+
+    if have_command timeout; then
+        timeout "$seconds" "$@"
+        return $?
+    fi
+
+    if have_command gtimeout; then
+        gtimeout "$seconds" "$@"
+        return $?
+    fi
+
+    "$@"
+}
+
 # Mark as initialized to prevent re-sourcing
 _CUSTOM_TOOLS_INITIALIZED=1
+
+# Direct-exec guard: this file is source-only, not meant to be executed directly
+if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+    echo "Error: init.sh is meant to be sourced, not executed directly." >&2
+    echo "Usage: source \"\$(dirname \"\$0\")/init.sh\"" >&2
+    exit 1
+fi

--- a/tests/test_file_cleanup.py
+++ b/tests/test_file_cleanup.py
@@ -1,0 +1,34 @@
+"""
+Tests for del_file() interactive cleanup function.
+
+These tests cover only non-interactive invariants so they remain hermetic.
+"""
+
+import pytest
+
+
+class TestFileCleanupFunction:
+    """Basic loading checks for file cleanup helpers."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_del_file_function_exists(self, shell_runner, shell):
+        result = shell_runner(shell, "declare -f del_file | head -1")
+        assert result.exit_code == 0, f"{shell}: del_file not defined"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_del_file_alias_exists(self, shell_runner, shell):
+        result = shell_runner(shell, "alias del-file")
+        assert result.exit_code == 0, f"{shell}: del-file alias not defined"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_default_patterns_are_stable(self, shell_runner, shell):
+        result = shell_runner(
+            shell,
+            '_cleanup_set_default_patterns; for p in "${CLEANUP_DEFAULT_PATTERNS[@]}"; do echo "$p"; done',
+        )
+        assert result.exit_code == 0, f"{shell}: _cleanup_set_default_patterns failed"
+        assert result.stdout.splitlines() == [
+            ".*backup*",
+            ".*.bak*",
+            ".*-original",
+        ]

--- a/tests/test_help_topics.py
+++ b/tests/test_help_topics.py
@@ -7,7 +7,7 @@ without errors in both bash and zsh environments.
 
 import pytest
 
-# Auto-sourced help topics (34 total)
+# Auto-sourced help topics (35 total)
 # Excludes: mount-help, addmnt-help (not auto-loaded by main.bash/main.zsh)
 # Use function names (underscores) instead of aliases (dashes) for non-interactive subprocess testing
 HELP_TOPICS = [
@@ -32,6 +32,7 @@ HELP_TOPICS = [
     "litellm_help",
     "mytool_help",
     "mysql_help",
+    "network_help",
     "npm_help",
     "nvm_help",
     "p10k_help",

--- a/tests/test_mytool_help.py
+++ b/tests/test_mytool_help.py
@@ -15,12 +15,13 @@ REPO_ROOT = Path(__file__).parent.parent
 SHELL_COMMON = REPO_ROOT / "shell-common"
 TOOLS_CUSTOM = SHELL_COMMON / "tools" / "custom"
 
-# Custom tool commands (37 total)
+# Custom tool commands (38 total)
 # Note: devx is now a function in shell-common/functions/devx.sh, not a custom tool
 # Note: mount is now a function in shell-common/functions/mount.sh, not a custom tool
 MYTOOL_COMMANDS = [
     "analyze_bash_scripts",
     "check_proxy",
+    "check_network",
     "check_ux_consistency",
     "demo_ux",
     "docker_configure_proxy",


### PR DESCRIPTION
## Summary
- add `check-network` and `network-help` for DNS, ICMP, HTTPS, git, apt, pip, and curl diagnostics
- narrow `check-proxy` back to proxy-specific behavior and improve messaging for non-proxy environments
- add interactive `del-file` cleanup for backup/original files in the current directory with preview and delete modes
- keep diagnostic help wiring consistent in `sys_help`, `my_help`, and custom tool tests

## Testing
- [x] `pytest tests/test_help_topics.py tests/test_mytool_help.py -q`
- [x] `pytest tests/test_file_cleanup.py -q`
- [x] Manual: `network_check quick`
- [x] Manual: `proxy_check conn` in a non-proxy environment shows guidance instead of a false warning
- [x] Manual PTY: `del-file` preview, mode selection, and per-file confirmation flow

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->