### PR TITLE
fix(repo): migrate Artifactory URLs to Nexus format

### DIFF
--- a/npm/npmrc.internal
+++ b/npm/npmrc.internal
@@ -7,10 +7,10 @@
 #
 # Note: prefix uses ${HOME} for portability (npm expands env vars in .npmrc)
 
-registry=https://repository.samsungds.net/artifactory/api/npm/npm/
+registry=http://repository.samsungds.net/repository/proxy-npm-registry.npmjs.org/
 strict-ssl=false
 cafile=/etc/ssl/certs/ca-certificates.crt
 proxy=http://12.26.204.100:8080
 https-proxy=http://12.26.204.100:8080
-noproxy=10.229.95.200,10.229.95.220,12.36.155.91,12.36.154.116,12.36.154.130,localhost,127.0.0.1,.samsung.net,.samsungds.net,ssai.samsungds.net,dsvdi.net,pfs.nprotect.com,10.227.253.89
+noproxy=10.229.95.200,10.229.95.220,12.36.155.91,12.36.154.116,12.36.154.130,localhost,127.0.0.1,.samsung.net,.samsungds.net,ssai.samsungds.net,stsds.secsso.net,dsvdi.net,pfs.nprotect.com,10.227.253.89
 prefix=${HOME}/.npm-global

--- a/pip/pip.conf.internal
+++ b/pip/pip.conf.internal
@@ -11,7 +11,7 @@
 [global]
 # Minimal configuration - matches company standard
 # Primary Samsung internal PyPI repository
-index-url = https://repository.samsungds.net/artifactory/api/pypi/pypi-remote/simple
+index-url = http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple
 
 # Trust the repository host (disable SSL verification if needed)
 trusted-host = repository.samsungds.net
@@ -27,4 +27,4 @@ trusted-host = repository.samsungds.net
 # extra-index-url = http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple
 
 # PyTorch wheels (commented - install via dedicated channel if needed)
-# find-links = https://repository.samsungds.net/artifactory/api/pypi/pypi-torch/torch_stable.html
+# find-links = http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/torch_stable.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ packages = []
 
 # [[tool.uv.index]]
 # name = "samsung"
-# url = "https://repository.samsungds.net/artifactory/api/pypi/pypi/simple"
+# url = "http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"
 # default = true
 
 

--- a/shell-common/env/proxy.local.example
+++ b/shell-common/env/proxy.local.example
@@ -16,7 +16,7 @@ export HTTPS_PROXY="$https_proxy"
 
 # Ref. https://confluence.samsungds.net/pages/viewpage.action?pageId=1367083095
 # FYI. NO_PROXY 값 사이에 공백이 있으면 제대로 인식되지 않을 수 있으니, 콤마(,)로만 구분 추천
-export no_proxy="10.229.95.200,10.229.95.220,12.36.155.91,12.36.154.116,12.36.154.130,localhost,127.0.0.1,.samsung.net,.samsungds.net,ssai.samsungds.net,dsvdi.net,pfs.nprotect.com,10.227.253.89"
+export no_proxy="10.229.95.200,10.229.95.220,12.36.155.91,12.36.154.116,12.36.154.130,localhost,127.0.0.1,.samsung.net,.samsungds.net,ssai.samsungds.net,stsds.secsso.net,dsvdi.net,pfs.nprotect.com,10.227.253.89"
 export NO_PROXY="$no_proxy"
 
 # ============================================================

--- a/shell-common/functions/pip_help.sh
+++ b/shell-common/functions/pip_help.sh
@@ -36,7 +36,7 @@ pip_help() {
 
         ux_section "Proxy & Repository Info"
         ux_bullet "Proxy:            http://12.26.204.100:8080"
-        ux_bullet "Internal Repo:    https://repository.samsungds.net/artifactory/api/pypi/pypi/simple"
+        ux_bullet "Internal Repo:    http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"
         ux_bullet "DataService Repo: http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple"
 
 

--- a/shell-common/tools/custom/check_pip.sh
+++ b/shell-common/tools/custom/check_pip.sh
@@ -128,7 +128,7 @@ check_pip_repository() {
     # Additional info about Samsung internal repos (for reference only)
     ux_section "Samsung Internal Repositories (Reference - requires internal network)"
     ux_info "These URLs are only accessible from internal company network or with proper proxy:"
-    ux_bullet "Primary: https://repository.samsungds.net/artifactory/api/pypi/pypi-remote/simple"
+    ux_bullet "Primary: http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"
     ux_bullet "DataService: http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple"
     echo ""
 }

--- a/uv/uv.toml.internal
+++ b/uv/uv.toml.internal
@@ -6,7 +6,9 @@
 #   Choose this option when using company internal repositories
 #
 # Note: Proxy is configured here (uv does not read shell proxy variables)
+# Note: native-tls required for corporate CA certificates (uv uses own TLS by default)
 
+native-tls = true
 https-proxy = "http://12.26.204.100:8080/"
 http-proxy = "http://12.26.204.100:8080/"
 no-proxy = [
@@ -20,8 +22,9 @@ no-proxy = [
   ".samsung.net",
   ".samsungds.net",
   "ssai.samsungds.net",
+  "stsds.secsso.net",
   "dsvdi.net",
   "pfs.nprotect.com",
   "10.227.253.89",
 ]
-extra-index-url = ["https://repository.samsungds.net/artifactory/api/pypi/pypi/simple"]
+extra-index-url = ["http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"]


### PR DESCRIPTION
## Summary
- **npm 404 수정**: Artifactory 경로 → Nexus 형식 (`/repository/proxy-npm-registry.npmjs.org/`)
- **uv SSL 수정**: `native-tls = true` 추가 + URL을 Nexus 형식으로 변경
- **pip URL 수정**: 공식 가이드 기준 Nexus 형식 URL로 통일
- **no_proxy 보완**: `stsds.secsso.net` (SSO 서버) 누락 항목 추가

## Context
PR #23에서 도메인을 `repo.samsungds.net` → `repository.samsungds.net`으로 마이그레이션했으나,
새 서버가 Nexus (Artifactory 아님)라서 URL 경로 형식이 달라 npm 404, uv SSL 에러 발생.
사내 공식 마이그레이션 가이드 기준으로 URL 경로를 Nexus 형식으로 수정.

## Test plan
- [x] `./setup.sh` (옵션 2: Internal PC) 실행
- [x] `npm config get registry` → `http://repository.samsungds.net/repository/proxy-npm-registry.npmjs.org/`
- [x] `npm ping` 정상 응답
- [x] `npm info lodash version` 정상 조회
- [x] `pip install --dry-run requests` 정상
- [x] `uv pip install --dry-run requests` 정상 (SSL 에러 없음)
- [x] `check-npm files` 심볼릭 링크 확인
- [x] `check-pip config` 설정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->