### PR TITLE
feat(rpm): add yum repository config for internal PC

### DIFF
--- a/rpm/ds.repo.internal
+++ b/rpm/ds.repo.internal
@@ -1,0 +1,30 @@
+# ds.repo.internal
+# Samsung DS internal RPM repository configuration (RHEL 8.6)
+#
+# Usage:
+#   Copied to /etc/yum.repos.d/ds.repo by shell-common/setup.sh
+#   Choose "Internal company PC" option when running setup
+#
+# Note: Requires sudo for deployment to /etc/yum.repos.d/
+#       Uses Samsung internal Nexus repository (repository.samsungds.net)
+
+[ds]
+name=Repo DS
+baseurl=http://repository.samsungds.net/repository/proxy-yum-cdn.redhat.com-content-eus-rhel8-8.6-x86_64-baseos-os
+enabled=1
+gpgcheck=0
+gpgkey=
+
+[ds-app-stream]
+name=Repo DS App Stream
+baseurl=http://repository.samsungds.net/repository/proxy-yum-cdn.redhat.com-content-eus-rhel8-8.6-x86_64-appstream-os
+enabled=1
+gpgcheck=0
+gpgkey=
+
+[ds-codeready]
+name=Repo DS codeready
+baseurl=http://repository.samsungds.net/repository/proxy-yum-cdn.redhat.com-content-dist-rhel8-8-x86_64-codeready-builder-os
+enabled=1
+gpgcheck=0
+gpgkey=

--- a/rpm/ds.repo.internal
+++ b/rpm/ds.repo.internal
@@ -1,12 +1,6 @@
-# ds.repo.internal
+# MANAGED_BY_DOTFILES — do not edit manually (deployed by setup.sh)
 # Samsung DS internal RPM repository configuration (RHEL 8.6)
-#
-# Usage:
-#   Copied to /etc/yum.repos.d/ds.repo by shell-common/setup.sh
-#   Choose "Internal company PC" option when running setup
-#
-# Note: Requires sudo for deployment to /etc/yum.repos.d/
-#       Uses Samsung internal Nexus repository (repository.samsungds.net)
+# Source: ~/dotfiles/rpm/ds.repo.internal
 
 [ds]
 name=Repo DS

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -284,6 +284,48 @@ setup_pip_config() {
     esac
 }
 
+setup_rpm_repo() {
+    environment="$1"
+    repo_target="/etc/yum.repos.d/ds.repo"
+
+    ux_header "Setting up RPM repository configuration for: $environment"
+
+    # Only deploy if yum or dnf is available
+    if ! command -v yum >/dev/null 2>&1 && ! command -v dnf >/dev/null 2>&1; then
+        ux_info "Skipped: yum/dnf not found (not a RHEL/CentOS system)"
+        return 0
+    fi
+
+    case "$environment" in
+        internal)
+            # Ensure target directory exists
+            if [ ! -d "/etc/yum.repos.d" ]; then
+                sudo mkdir -p "/etc/yum.repos.d"
+                ux_info "Created directory: /etc/yum.repos.d"
+            fi
+
+            # Backup existing repo file if present
+            if [ -f "$repo_target" ]; then
+                backup="${repo_target}.backup.$(date +%Y%m%d%H%M%S)"
+                sudo mv "$repo_target" "$backup"
+                ux_info "Backed up existing file: $backup"
+            fi
+
+            # Copy (not symlink) since this is a system-level config in /etc/
+            sudo cp "${DOTFILES_ROOT}/rpm/ds.repo.internal" "$repo_target"
+            ux_success "Copied: rpm/ds.repo.internal → $repo_target"
+            ux_info "Using: Samsung DS internal repositories (RHEL 8.6)"
+            ;;
+        external|public)
+            if [ -f "$repo_target" ]; then
+                sudo rm -f "$repo_target"
+                ux_info "Removed internal repo config: $repo_target"
+            fi
+            ux_info "No custom RPM repository needed"
+            ;;
+    esac
+}
+
 # ============================================================================
 # Main Menu
 # ============================================================================
@@ -310,6 +352,7 @@ main() {
             setup_npm_symlink "public"
             setup_pip_config "public"
             setup_uv_config "public"
+            setup_rpm_repo "public"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
             echo ""
             ux_success "Setup complete for public PC (home environment)"
@@ -324,6 +367,7 @@ main() {
             setup_npm_symlink "internal"
             setup_pip_config "internal"
             setup_uv_config "internal"
+            setup_rpm_repo "internal"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
             echo ""
             ux_success "Setup complete for internal company PC"
@@ -335,6 +379,7 @@ main() {
             ux_info "  - NPM: ~/.npmrc → npm/npmrc.internal (Nexus + proxy)"
             ux_info "  - Pip: Samsung internal repository configured"
             ux_info "  - uv: Samsung internal repository + proxy configured"
+            ux_info "  - RPM: /etc/yum.repos.d/ds.repo (if yum/dnf available)"
             ux_info "Setup mode saved to: ~/.dotfiles-setup-mode"
             echo ""
             ux_section "⚠️  IMPORTANT: Reload your shell to apply changes"
@@ -350,6 +395,7 @@ main() {
             setup_npm_symlink "external"
             setup_pip_config "external"
             setup_uv_config "external"
+            setup_rpm_repo "external"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
             echo ""
             ux_success "Setup complete for external company PC"

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -287,12 +287,46 @@ setup_pip_config() {
 setup_rpm_repo() {
     environment="$1"
     repo_target="/etc/yum.repos.d/ds.repo"
+    marker="MANAGED_BY_DOTFILES"
 
     ux_header "Setting up RPM repository configuration for: $environment"
 
-    # Only deploy if yum or dnf is available
+    # Gate 1: Only proceed if yum or dnf is available
     if ! command -v yum >/dev/null 2>&1 && ! command -v dnf >/dev/null 2>&1; then
         ux_info "Skipped: yum/dnf not found (not a RHEL/CentOS system)"
+        return 0
+    fi
+
+    # Gate 2: Verify RHEL 8 — do not deploy RHEL 8.6 repos to Fedora/Rocky/RHEL 9
+    if [ -f /etc/os-release ]; then
+        _rpm_os_id="$(. /etc/os-release && echo "${ID:-}")"
+        _rpm_os_version="$(. /etc/os-release && echo "${VERSION_ID:-}")"
+        case "$_rpm_os_id" in
+            rhel|centos)
+                case "$_rpm_os_version" in
+                    8|8.*) ;; # RHEL 8.x — proceed
+                    *)
+                        ux_info "Skipped: RHEL ${_rpm_os_version} detected (repo is RHEL 8.6 only)"
+                        return 0
+                        ;;
+                esac
+                ;;
+            *)
+                ux_info "Skipped: ${_rpm_os_id} detected (repo is RHEL 8 only)"
+                return 0
+                ;;
+        esac
+    fi
+
+    # Gate 3: Verify privilege — use sudo if needed, skip if unavailable
+    _rpm_run_privileged=""
+    if [ "$(id -u)" = "0" ]; then
+        _rpm_run_privileged=""  # already root, no sudo needed
+    elif command -v sudo >/dev/null 2>&1; then
+        _rpm_run_privileged="sudo"
+        ux_info "Root privileges required for /etc/yum.repos.d/ — sudo will prompt for password"
+    else
+        ux_warning "Skipped: sudo not available and not running as root"
         return 0
     fi
 
@@ -300,28 +334,31 @@ setup_rpm_repo() {
         internal)
             # Ensure target directory exists
             if [ ! -d "/etc/yum.repos.d" ]; then
-                sudo mkdir -p "/etc/yum.repos.d"
+                $_rpm_run_privileged mkdir -p "/etc/yum.repos.d"
                 ux_info "Created directory: /etc/yum.repos.d"
             fi
 
             # Backup existing repo file if present
             if [ -f "$repo_target" ]; then
                 backup="${repo_target}.backup.$(date +%Y%m%d%H%M%S)"
-                sudo mv "$repo_target" "$backup"
+                $_rpm_run_privileged mv "$repo_target" "$backup"
                 ux_info "Backed up existing file: $backup"
             fi
 
             # Copy (not symlink) since this is a system-level config in /etc/
-            sudo cp "${DOTFILES_ROOT}/rpm/ds.repo.internal" "$repo_target"
+            $_rpm_run_privileged cp "${DOTFILES_ROOT}/rpm/ds.repo.internal" "$repo_target"
             ux_success "Copied: rpm/ds.repo.internal → $repo_target"
             ux_info "Using: Samsung DS internal repositories (RHEL 8.6)"
             ;;
         external|public)
-            if [ -f "$repo_target" ]; then
-                sudo rm -f "$repo_target"
-                ux_info "Removed internal repo config: $repo_target"
+            # Only remove if the file was deployed by dotfiles (has marker)
+            if [ -f "$repo_target" ] && grep -q "$marker" "$repo_target" 2>/dev/null; then
+                backup="${repo_target}.backup.$(date +%Y%m%d%H%M%S)"
+                $_rpm_run_privileged mv "$repo_target" "$backup"
+                ux_info "Backed up and removed dotfiles-managed repo: $backup"
+            elif [ -f "$repo_target" ]; then
+                ux_info "Existing $repo_target is not managed by dotfiles — leaving untouched"
             fi
-            ux_info "No custom RPM repository needed"
             ;;
     esac
 }


### PR DESCRIPTION
## Summary
- 사내 RHEL 환경의 yum/dnf 패키지 관리자용 RPM 저장소 설정 자동화
- 기존 npm/pip/uv 패턴과 동일한 구조로 `rpm/` 디렉터리에 설정 파일 관리
- `./setup.sh` 실행 시 옵션 2 (Internal PC) 선택하면 자동 배포

## Changes
- **New**: `rpm/ds.repo.internal` — Samsung DS Nexus 저장소 설정 (baseos, appstream, codeready-builder for RHEL 8.6)
- **New**: `setup_rpm_repo()` 함수 — yum/dnf 감지, 기존 파일 백업, sudo 복사
- 3개 환경 메뉴 모두에 통합 (public/internal은 배포, external은 정리)

## Design decisions
- **Copy (not symlink)**: `/etc/yum.repos.d/`는 시스템 설정이므로 사용자 홈 디렉터리 symlink 부적절
- **Auto-skip**: yum/dnf가 없으면 (Ubuntu/WSL) `ux_info`로 안내 후 건너뜀
- **Sudo per-command**: 1-2개 sudo 명령만 필요하므로 사전 캐싱 불필요

## Test plan
- [ ] RHEL 환경: `./setup.sh` → 옵션 2 → sudo 입력 → `/etc/yum.repos.d/ds.repo` 생성 확인
- [ ] RHEL 환경: `yum repolist` 정상 출력 확인
- [ ] Ubuntu/WSL 환경: `./setup.sh` → 옵션 2 → "Skipped: yum/dnf not found" 출력 확인
- [ ] 환경 전환: 옵션 1 (public) 선택 시 기존 ds.repo 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->