### PR TITLE
feat(apt): add APT sources.list config for internal PC

### DIFF
--- a/apt/sources.list.jammy.internal
+++ b/apt/sources.list.jammy.internal
@@ -1,0 +1,17 @@
+# MANAGED_BY_DOTFILES — do not edit manually (deployed by setup.sh)
+# Ubuntu 22.04 (jammy) APT sources via Samsung internal Nexus mirror
+# Source: ~/dotfiles/apt/sources.list.jammy.internal
+#
+# Original backed up to /etc/apt/sources.list.backup.YYYYMMDDHHMMSS
+
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy main restricted
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-updates main restricted
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy universe
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-updates universe
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy multiverse
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-updates multiverse
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-backports main restricted universe multiverse
+
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-security main restricted
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-security universe
+deb http://repository.samsungds.net/repository/proxy-apt-mirror.kakao.com-ubuntu/ubuntu jammy-security multiverse

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -363,6 +363,77 @@ setup_rpm_repo() {
     esac
 }
 
+setup_apt_sources() {
+    environment="$1"
+    sources_target="/etc/apt/sources.list"
+    marker="MANAGED_BY_DOTFILES"
+
+    ux_header "Setting up APT sources configuration for: $environment"
+
+    # Gate 1: Only proceed if apt is available
+    if ! command -v apt >/dev/null 2>&1; then
+        ux_info "Skipped: apt not found (not a Debian/Ubuntu system)"
+        return 0
+    fi
+
+    # Gate 2: Verify Ubuntu codename — match against available config files
+    _apt_codename=""
+    if [ -f /etc/os-release ]; then
+        _apt_codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-}")"
+    fi
+    _apt_source="${DOTFILES_ROOT}/apt/sources.list.${_apt_codename}.internal"
+    if [ -z "$_apt_codename" ] || [ ! -f "$_apt_source" ]; then
+        ux_info "Skipped: no apt config for '${_apt_codename:-unknown}' (available: $(ls "${DOTFILES_ROOT}"/apt/sources.list.*.internal 2>/dev/null | sed 's/.*sources\.list\.\(.*\)\.internal/\1/' | tr '\n' ' ' || echo 'none'))"
+        return 0
+    fi
+
+    # Gate 3: Verify privilege — use sudo if needed, skip if unavailable
+    _apt_run_privileged=""
+    if [ "$(id -u)" = "0" ]; then
+        _apt_run_privileged=""
+    elif command -v sudo >/dev/null 2>&1; then
+        _apt_run_privileged="sudo"
+        ux_info "Root privileges required for /etc/apt/sources.list — sudo will prompt for password"
+    else
+        ux_warning "Skipped: sudo not available and not running as root"
+        return 0
+    fi
+
+    case "$environment" in
+        internal)
+            # Backup existing sources.list if present and not already managed
+            if [ -f "$sources_target" ]; then
+                if ! grep -q "$marker" "$sources_target" 2>/dev/null; then
+                    backup="${sources_target}.backup.$(date +%Y%m%d%H%M%S)"
+                    $_apt_run_privileged cp "$sources_target" "$backup"
+                    ux_info "Backed up original: $backup"
+                fi
+            fi
+
+            $_apt_run_privileged cp "$_apt_source" "$sources_target"
+            ux_success "Copied: apt/sources.list.${_apt_codename}.internal → $sources_target"
+            ux_info "Using: Samsung internal Nexus mirror (Ubuntu ${_apt_codename})"
+            ux_info "Run 'sudo apt update' to refresh package lists"
+            ;;
+        external|public)
+            # Only restore if current file was deployed by dotfiles
+            if [ -f "$sources_target" ] && grep -q "$marker" "$sources_target" 2>/dev/null; then
+                # Find the most recent non-dotfiles backup
+                _apt_latest_backup="$(ls -t "${sources_target}".backup.* 2>/dev/null | head -1)"
+                if [ -n "$_apt_latest_backup" ]; then
+                    $_apt_run_privileged cp "$_apt_latest_backup" "$sources_target"
+                    ux_success "Restored original: $_apt_latest_backup → $sources_target"
+                else
+                    $_apt_run_privileged rm -f "$sources_target"
+                    ux_warning "Removed dotfiles-managed sources.list (no backup found to restore)"
+                fi
+            elif [ -f "$sources_target" ]; then
+                ux_info "Existing $sources_target is not managed by dotfiles — leaving untouched"
+            fi
+            ;;
+    esac
+}
+
 # ============================================================================
 # Main Menu
 # ============================================================================
@@ -390,6 +461,7 @@ main() {
             setup_pip_config "public"
             setup_uv_config "public"
             setup_rpm_repo "public"
+            setup_apt_sources "public"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
             echo ""
             ux_success "Setup complete for public PC (home environment)"
@@ -405,6 +477,7 @@ main() {
             setup_pip_config "internal"
             setup_uv_config "internal"
             setup_rpm_repo "internal"
+            setup_apt_sources "internal"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
             echo ""
             ux_success "Setup complete for internal company PC"
@@ -417,6 +490,7 @@ main() {
             ux_info "  - Pip: Samsung internal repository configured"
             ux_info "  - uv: Samsung internal repository + proxy configured"
             ux_info "  - RPM: /etc/yum.repos.d/ds.repo (if yum/dnf available)"
+            ux_info "  - APT: /etc/apt/sources.list (if Ubuntu jammy)"
             ux_info "Setup mode saved to: ~/.dotfiles-setup-mode"
             echo ""
             ux_section "⚠️  IMPORTANT: Reload your shell to apply changes"
@@ -433,6 +507,7 @@ main() {
             setup_pip_config "external"
             setup_uv_config "external"
             setup_rpm_repo "external"
+            setup_apt_sources "external"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
             echo ""
             ux_success "Setup complete for external company PC"

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -376,18 +376,7 @@ setup_apt_sources() {
         return 0
     fi
 
-    # Gate 2: Verify Ubuntu codename — match against available config files
-    _apt_codename=""
-    if [ -f /etc/os-release ]; then
-        _apt_codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-}")"
-    fi
-    _apt_source="${DOTFILES_ROOT}/apt/sources.list.${_apt_codename}.internal"
-    if [ -z "$_apt_codename" ] || [ ! -f "$_apt_source" ]; then
-        ux_info "Skipped: no apt config for '${_apt_codename:-unknown}' (available: $(ls "${DOTFILES_ROOT}"/apt/sources.list.*.internal 2>/dev/null | sed 's/.*sources\.list\.\(.*\)\.internal/\1/' | tr '\n' ' ' || echo 'none'))"
-        return 0
-    fi
-
-    # Gate 3: Verify privilege — use sudo if needed, skip if unavailable
+    # Gate 2: Verify privilege — use sudo if needed, skip if unavailable
     _apt_run_privileged=""
     if [ "$(id -u)" = "0" ]; then
         _apt_run_privileged=""
@@ -399,8 +388,27 @@ setup_apt_sources() {
         return 0
     fi
 
+    # Read OS identity (used by both deploy and restore paths)
+    _apt_os_id=""
+    _apt_codename=""
+    if [ -f /etc/os-release ]; then
+        _apt_os_id="$(. /etc/os-release && echo "${ID:-}")"
+        _apt_codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-}")"
+    fi
+
     case "$environment" in
         internal)
+            # Deploy gate: verify Ubuntu + matching config file exists
+            if [ "$_apt_os_id" != "ubuntu" ]; then
+                ux_info "Skipped: ${_apt_os_id:-unknown} detected (only Ubuntu is supported)"
+                return 0
+            fi
+            _apt_source="${DOTFILES_ROOT}/apt/sources.list.${_apt_codename}.internal"
+            if [ -z "$_apt_codename" ] || [ ! -f "$_apt_source" ]; then
+                ux_info "Skipped: no apt config for '${_apt_codename:-unknown}' (available: $(ls "${DOTFILES_ROOT}"/apt/sources.list.*.internal 2>/dev/null | sed 's/.*sources\.list\.\(.*\)\.internal/\1/' | tr '\n' ' ' || echo 'none'))"
+                return 0
+            fi
+
             # Backup existing sources.list if present and not already managed
             if [ -f "$sources_target" ]; then
                 if ! grep -q "$marker" "$sources_target" 2>/dev/null; then
@@ -416,9 +424,9 @@ setup_apt_sources() {
             ux_info "Run 'sudo apt update' to refresh package lists"
             ;;
         external|public)
-            # Only restore if current file was deployed by dotfiles
+            # Restore path: no codename/OS gate — must always reach here
+            # to handle post-upgrade scenarios (e.g., jammy → noble)
             if [ -f "$sources_target" ] && grep -q "$marker" "$sources_target" 2>/dev/null; then
-                # Find the most recent non-dotfiles backup
                 _apt_latest_backup="$(ls -t "${sources_target}".backup.* 2>/dev/null | head -1)"
                 if [ -n "$_apt_latest_backup" ]; then
                     $_apt_run_privileged cp "$_apt_latest_backup" "$sources_target"


### PR DESCRIPTION
## Summary
- Ubuntu (jammy) 환경의 APT 소스 목록을 사내 Nexus 미러로 전환하는 자동화
- RPM 설정과 동일한 3-gate 안전 패턴 적용
- 현재 프록시 경유 외부 미러로 정상 동작하지만, 내부 미러 사용 시 프록시 의존 제거 + 속도 향상

## Changes
- **New**: `apt/sources.list.jammy.internal` — Samsung Nexus 미러 (proxy-apt-mirror.kakao.com-ubuntu)
- **New**: `setup_apt_sources()` — 3-gate 안전 배포 함수
- 3개 환경 메뉴 모두에 통합

## Safety gates
1. **Gate 1 — apt 감지**: apt 없으면 skip (RHEL/macOS)
2. **Gate 2 — codename 매칭**: `/etc/os-release`의 `VERSION_CODENAME`과 설정 파일명 매칭 (jammy만 적용, focal/noble은 해당 파일 추가 시 자동 지원)
3. **Gate 3 — 권한**: root이면 sudo 생략, sudo 없으면 warn+skip
4. **마커 기반 소유권**: `MANAGED_BY_DOTFILES` 마커로 dotfiles 배포 파일만 관리
5. **원본 복구**: public/external 전환 시 백업에서 원본 복원

## RPM과의 차이점
| 항목 | RPM | APT |
|------|-----|-----|
| 대상 | `/etc/yum.repos.d/ds.repo` (추가) | `/etc/apt/sources.list` (교체) |
| Gate 2 | RHEL/CentOS 8.x | Ubuntu codename 매칭 |
| 복원 | 마커 있으면 백업+제거 | 마커 있으면 원본 백업에서 복원 |
| 침습성 | 낮음 (파일 추가) | 높음 (기존 파일 교체) |

## Test plan
- [ ] Ubuntu jammy 환경: `./setup.sh` → 옵션 2 → sources.list 교체 확인
- [ ] `sudo apt update` 정상 동작 확인
- [ ] 옵션 1 (public) → 원본 sources.list 복원 확인
- [ ] RHEL 환경: "Skipped: apt not found" 확인
- [ ] Ubuntu noble (24.04): "Skipped: no apt config for 'noble'" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->