### PR TITLE
feat(cargo,nuget): add Cargo and NuGet config for internal PC

### DIFF
--- a/cargo/config.toml.internal
+++ b/cargo/config.toml.internal
@@ -1,0 +1,18 @@
+# config.toml.internal
+# Samsung internal Cargo registry configuration
+#
+# Usage:
+#   Symlinked to ~/.cargo/config.toml by shell-common/setup.sh
+#   Choose "Internal company PC" option when running setup
+#
+# Note: Uses Samsung internal Nexus proxy for crates.io
+
+# Makes internal Nexus the default registry
+[registry]
+default = "cargo-proxy"
+
+[registries.cargo-proxy]
+index = "sparse+http://repository.samsungds.net/repository/proxy-cargo-index.crates.io/"
+
+[source.crates-io]
+replace-with = "cargo-proxy"

--- a/nuget/NuGet.Config.internal
+++ b/nuget/NuGet.Config.internal
@@ -3,16 +3,21 @@
      Samsung internal NuGet repository configuration
 
      Usage:
-       Symlinked to ~/.nuget/NuGet/NuGet.Config by shell-common/setup.sh
+       Symlinked to ~/.nuget/NuGet/NuGet.Config and
+       ~/.config/NuGet/NuGet.Config by shell-common/setup.sh
        Choose "Internal company PC" option when running setup
 
      Install example:
        nuget install BlazorDownloadFile -Version 2.1.6 -Source DSNuget
        dotnet add package BlazorDownloadFile -s DSNuget
+
+     Note: <clear/> prevents merging with machine-level NuGet sources.
+           DSNuget is listed first to be preferred during restore.
 -->
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <clear />
     <add key="DSNuget" value="https://repository.samsungds.net/repository/proxy-nuget-www.nuget.org/index.json" protocolVersion="3" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/nuget/NuGet.Config.internal
+++ b/nuget/NuGet.Config.internal
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- NuGet.Config.internal
+     Samsung internal NuGet repository configuration
+
+     Usage:
+       Symlinked to ~/.nuget/NuGet/NuGet.Config by shell-common/setup.sh
+       Choose "Internal company PC" option when running setup
+
+     Install example:
+       nuget install BlazorDownloadFile -Version 2.1.6 -Source DSNuget
+       dotnet add package BlazorDownloadFile -s DSNuget
+-->
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="DSNuget" value="https://repository.samsungds.net/repository/proxy-nuget-www.nuget.org/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -294,68 +294,87 @@ setup_cargo_config() {
 
     ux_header "Setting up Cargo configuration for: $environment"
 
-    # Handle existing config.toml (symlink, file, or directory)
-    if [ -L "$cargo_conf" ]; then
-        rm -f "$cargo_conf"
-        ux_info "Removed existing symlink: $cargo_conf"
-    elif [ -d "$cargo_conf" ]; then
-        backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$cargo_conf" "$backup"
-        ux_warning "Backed up existing directory: $backup"
-    elif [ -f "$cargo_conf" ]; then
-        backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$cargo_conf" "$backup"
-        ux_info "Backed up existing file: $backup"
-    fi
-
-    # Create symlink based on environment
     case "$environment" in
         internal)
+            # Handle existing config.toml (symlink, file, or directory)
+            if [ -L "$cargo_conf" ]; then
+                rm -f "$cargo_conf"
+                ux_info "Removed existing symlink: $cargo_conf"
+            elif [ -d "$cargo_conf" ]; then
+                backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
+                mv "$cargo_conf" "$backup"
+                ux_warning "Backed up existing directory: $backup"
+            elif [ -f "$cargo_conf" ]; then
+                backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
+                mv "$cargo_conf" "$backup"
+                ux_info "Backed up existing file: $backup"
+            fi
+
             ln -s "${DOTFILES_ROOT}/cargo/config.toml.internal" "$cargo_conf"
             ux_success "Created symlink: ~/.cargo/config.toml → cargo/config.toml.internal"
             ux_info "Using: Samsung internal Nexus proxy for crates.io"
             ;;
         external|public)
-            # No custom config needed (defaults to crates.io)
-            ux_info "No custom Cargo config needed (using crates.io defaults)"
+            # Remove dotfiles symlink and restore backup if available
+            if [ -L "$cargo_conf" ]; then
+                rm -f "$cargo_conf"
+                _cargo_latest_backup="$(ls -t "${cargo_conf}".backup.* 2>/dev/null | head -1)"
+                if [ -n "$_cargo_latest_backup" ]; then
+                    mv "$_cargo_latest_backup" "$cargo_conf"
+                    ux_success "Restored: $_cargo_latest_backup → $cargo_conf"
+                else
+                    ux_info "Removed dotfiles symlink (no backup to restore, using defaults)"
+                fi
+            else
+                ux_info "No dotfiles Cargo config to remove"
+            fi
             ;;
     esac
 }
 
 setup_nuget_config() {
     environment="$1"
-    nuget_config_dir="${HOME}/.nuget/NuGet"
-    nuget_conf="${nuget_config_dir}/NuGet.Config"
-
-    # Ensure ~/.nuget/NuGet directory exists
-    mkdir -p "$nuget_config_dir"
+    # NuGet config can be read from two paths depending on tooling
+    nuget_primary="${HOME}/.nuget/NuGet/NuGet.Config"
+    nuget_secondary="${HOME}/.config/NuGet/NuGet.Config"
 
     ux_header "Setting up NuGet configuration for: $environment"
 
-    # Handle existing NuGet.Config (symlink, file, or directory)
-    if [ -L "$nuget_conf" ]; then
-        rm -f "$nuget_conf"
-        ux_info "Removed existing symlink: $nuget_conf"
-    elif [ -d "$nuget_conf" ]; then
-        backup="${nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$nuget_conf" "$backup"
-        ux_warning "Backed up existing directory: $backup"
-    elif [ -f "$nuget_conf" ]; then
-        backup="${nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$nuget_conf" "$backup"
-        ux_info "Backed up existing file: $backup"
-    fi
-
-    # Create symlink based on environment
     case "$environment" in
         internal)
-            ln -s "${DOTFILES_ROOT}/nuget/NuGet.Config.internal" "$nuget_conf"
-            ux_success "Created symlink: ~/.nuget/NuGet/NuGet.Config → nuget/NuGet.Config.internal"
+            # Deploy symlinks to both paths
+            for _nuget_conf in "$nuget_primary" "$nuget_secondary"; do
+                mkdir -p "$(dirname "$_nuget_conf")"
+                if [ -L "$_nuget_conf" ]; then
+                    rm -f "$_nuget_conf"
+                elif [ -d "$_nuget_conf" ]; then
+                    backup="${_nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
+                    mv "$_nuget_conf" "$backup"
+                    ux_warning "Backed up existing directory: $backup"
+                elif [ -f "$_nuget_conf" ]; then
+                    backup="${_nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
+                    mv "$_nuget_conf" "$backup"
+                    ux_info "Backed up existing file: $backup"
+                fi
+                ln -s "${DOTFILES_ROOT}/nuget/NuGet.Config.internal" "$_nuget_conf"
+            done
+            ux_success "Created symlinks: NuGet.Config → nuget/NuGet.Config.internal"
+            ux_info "  ~/.nuget/NuGet/ (dotnet CLI) + ~/.config/NuGet/ (mono)"
             ux_info "Using: Samsung internal Nexus proxy for NuGet"
             ;;
         external|public)
-            # No custom config needed (defaults to nuget.org)
-            ux_info "No custom NuGet config needed (using nuget.org defaults)"
+            # Remove dotfiles symlinks and restore backups
+            for _nuget_conf in "$nuget_primary" "$nuget_secondary"; do
+                if [ -L "$_nuget_conf" ]; then
+                    rm -f "$_nuget_conf"
+                    _nuget_latest_backup="$(ls -t "${_nuget_conf}".backup.* 2>/dev/null | head -1)"
+                    if [ -n "$_nuget_latest_backup" ]; then
+                        mv "$_nuget_latest_backup" "$_nuget_conf"
+                        ux_success "Restored: $(basename "$_nuget_latest_backup") → $_nuget_conf"
+                    fi
+                fi
+            done
+            ux_info "NuGet config restored to defaults"
             ;;
     esac
 }

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -41,6 +41,43 @@ SECURITY_CONFIG_internal="/etc/ssl/certs/ca-certificates.crt"
 # Helper Functions
 # ============================================================================
 
+# Prepare a config target path for symlink creation.
+# Removes existing symlinks, backs up regular files and directories.
+# Usage: _prepare_config_target "/path/to/config"
+_prepare_config_target() {
+    _target="$1"
+    if [ -L "$_target" ]; then
+        rm -f "$_target"
+        ux_info "Removed existing symlink: $_target"
+    elif [ -d "$_target" ]; then
+        _backup="${_target}.backup.$(date +%Y%m%d%H%M%S)"
+        mv "$_target" "$_backup"
+        ux_warning "Backed up existing directory: $_backup"
+    elif [ -f "$_target" ]; then
+        _backup="${_target}.backup.$(date +%Y%m%d%H%M%S)"
+        mv "$_target" "$_backup"
+        ux_info "Backed up existing file: $_backup"
+    fi
+}
+
+# Restore a config target from the latest backup after removing a dotfiles symlink.
+# Usage: _restore_config_from_backup "/path/to/config"
+_restore_config_from_backup() {
+    _target="$1"
+    if [ -L "$_target" ]; then
+        rm -f "$_target"
+        _latest="$(ls -t "${_target}".backup.* 2>/dev/null | head -1)"
+        if [ -n "$_latest" ]; then
+            mv "$_latest" "$_target"
+            ux_success "Restored: $(basename "$_latest") → $_target"
+        else
+            ux_info "Removed dotfiles symlink (no backup to restore, using defaults)"
+        fi
+    else
+        ux_info "No dotfiles config to remove: $_target"
+    fi
+}
+
 cleanup_local_files() {
     # Find all .local.sh files
     ux_header "Cleaning up environment-specific files"
@@ -141,19 +178,7 @@ setup_npm_symlink() {
 
     ux_header "Setting up npm configuration for: $environment"
 
-    # Handle existing ~/.npmrc (symlink, file, or directory)
-    if [ -L "$npmrc_target" ]; then
-        rm -f "$npmrc_target"
-        ux_info "Removed existing symlink: $npmrc_target"
-    elif [ -d "$npmrc_target" ]; then
-        backup="${npmrc_target}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$npmrc_target" "$backup"
-        ux_warning "Backed up existing directory: $backup"
-    elif [ -f "$npmrc_target" ]; then
-        backup="${npmrc_target}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$npmrc_target" "$backup"
-        ux_info "Backed up existing file: $backup"
-    fi
+    _prepare_config_target "$npmrc_target"
 
     # Create symlink based on environment
     case "$environment" in
@@ -217,19 +242,7 @@ setup_uv_config() {
 
     ux_header "Setting up uv configuration for: $environment"
 
-    # Handle existing uv.toml (symlink, file, or directory)
-    if [ -L "$uv_conf" ]; then
-        rm -f "$uv_conf"
-        ux_info "Removed existing symlink: $uv_conf"
-    elif [ -d "$uv_conf" ]; then
-        backup="${uv_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$uv_conf" "$backup"
-        ux_warning "Backed up existing directory: $backup"
-    elif [ -f "$uv_conf" ]; then
-        backup="${uv_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$uv_conf" "$backup"
-        ux_info "Backed up existing file: $backup"
-    fi
+    _prepare_config_target "$uv_conf"
 
     # Create symlink based on environment
     case "$environment" in
@@ -255,19 +268,7 @@ setup_pip_config() {
 
     ux_header "Setting up pip configuration for: $environment"
 
-    # Handle existing pip.conf (symlink, file, or directory)
-    if [ -L "$pip_conf" ]; then
-        rm -f "$pip_conf"
-        ux_info "Removed existing symlink: $pip_conf"
-    elif [ -d "$pip_conf" ]; then
-        backup="${pip_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$pip_conf" "$backup"
-        ux_warning "Backed up existing directory: $backup"
-    elif [ -f "$pip_conf" ]; then
-        backup="${pip_conf}.backup.$(date +%Y%m%d%H%M%S)"
-        mv "$pip_conf" "$backup"
-        ux_info "Backed up existing file: $backup"
-    fi
+    _prepare_config_target "$pip_conf"
 
     # Create symlink based on environment
     case "$environment" in
@@ -296,38 +297,13 @@ setup_cargo_config() {
 
     case "$environment" in
         internal)
-            # Handle existing config.toml (symlink, file, or directory)
-            if [ -L "$cargo_conf" ]; then
-                rm -f "$cargo_conf"
-                ux_info "Removed existing symlink: $cargo_conf"
-            elif [ -d "$cargo_conf" ]; then
-                backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
-                mv "$cargo_conf" "$backup"
-                ux_warning "Backed up existing directory: $backup"
-            elif [ -f "$cargo_conf" ]; then
-                backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
-                mv "$cargo_conf" "$backup"
-                ux_info "Backed up existing file: $backup"
-            fi
-
+            _prepare_config_target "$cargo_conf"
             ln -s "${DOTFILES_ROOT}/cargo/config.toml.internal" "$cargo_conf"
             ux_success "Created symlink: ~/.cargo/config.toml → cargo/config.toml.internal"
             ux_info "Using: Samsung internal Nexus proxy for crates.io"
             ;;
         external|public)
-            # Remove dotfiles symlink and restore backup if available
-            if [ -L "$cargo_conf" ]; then
-                rm -f "$cargo_conf"
-                _cargo_latest_backup="$(ls -t "${cargo_conf}".backup.* 2>/dev/null | head -1)"
-                if [ -n "$_cargo_latest_backup" ]; then
-                    mv "$_cargo_latest_backup" "$cargo_conf"
-                    ux_success "Restored: $_cargo_latest_backup → $cargo_conf"
-                else
-                    ux_info "Removed dotfiles symlink (no backup to restore, using defaults)"
-                fi
-            else
-                ux_info "No dotfiles Cargo config to remove"
-            fi
+            _restore_config_from_backup "$cargo_conf"
             ;;
     esac
 }
@@ -342,20 +318,9 @@ setup_nuget_config() {
 
     case "$environment" in
         internal)
-            # Deploy symlinks to both paths
             for _nuget_conf in "$nuget_primary" "$nuget_secondary"; do
                 mkdir -p "$(dirname "$_nuget_conf")"
-                if [ -L "$_nuget_conf" ]; then
-                    rm -f "$_nuget_conf"
-                elif [ -d "$_nuget_conf" ]; then
-                    backup="${_nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
-                    mv "$_nuget_conf" "$backup"
-                    ux_warning "Backed up existing directory: $backup"
-                elif [ -f "$_nuget_conf" ]; then
-                    backup="${_nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
-                    mv "$_nuget_conf" "$backup"
-                    ux_info "Backed up existing file: $backup"
-                fi
+                _prepare_config_target "$_nuget_conf"
                 ln -s "${DOTFILES_ROOT}/nuget/NuGet.Config.internal" "$_nuget_conf"
             done
             ux_success "Created symlinks: NuGet.Config → nuget/NuGet.Config.internal"
@@ -363,16 +328,8 @@ setup_nuget_config() {
             ux_info "Using: Samsung internal Nexus proxy for NuGet"
             ;;
         external|public)
-            # Remove dotfiles symlinks and restore backups
             for _nuget_conf in "$nuget_primary" "$nuget_secondary"; do
-                if [ -L "$_nuget_conf" ]; then
-                    rm -f "$_nuget_conf"
-                    _nuget_latest_backup="$(ls -t "${_nuget_conf}".backup.* 2>/dev/null | head -1)"
-                    if [ -n "$_nuget_latest_backup" ]; then
-                        mv "$_nuget_latest_backup" "$_nuget_conf"
-                        ux_success "Restored: $(basename "$_nuget_latest_backup") → $_nuget_conf"
-                    fi
-                fi
+                _restore_config_from_backup "$_nuget_conf"
             done
             ux_info "NuGet config restored to defaults"
             ;;

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -284,6 +284,82 @@ setup_pip_config() {
     esac
 }
 
+setup_cargo_config() {
+    environment="$1"
+    cargo_config_dir="${HOME}/.cargo"
+    cargo_conf="${cargo_config_dir}/config.toml"
+
+    # Ensure ~/.cargo directory exists
+    mkdir -p "$cargo_config_dir"
+
+    ux_header "Setting up Cargo configuration for: $environment"
+
+    # Handle existing config.toml (symlink, file, or directory)
+    if [ -L "$cargo_conf" ]; then
+        rm -f "$cargo_conf"
+        ux_info "Removed existing symlink: $cargo_conf"
+    elif [ -d "$cargo_conf" ]; then
+        backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
+        mv "$cargo_conf" "$backup"
+        ux_warning "Backed up existing directory: $backup"
+    elif [ -f "$cargo_conf" ]; then
+        backup="${cargo_conf}.backup.$(date +%Y%m%d%H%M%S)"
+        mv "$cargo_conf" "$backup"
+        ux_info "Backed up existing file: $backup"
+    fi
+
+    # Create symlink based on environment
+    case "$environment" in
+        internal)
+            ln -s "${DOTFILES_ROOT}/cargo/config.toml.internal" "$cargo_conf"
+            ux_success "Created symlink: ~/.cargo/config.toml → cargo/config.toml.internal"
+            ux_info "Using: Samsung internal Nexus proxy for crates.io"
+            ;;
+        external|public)
+            # No custom config needed (defaults to crates.io)
+            ux_info "No custom Cargo config needed (using crates.io defaults)"
+            ;;
+    esac
+}
+
+setup_nuget_config() {
+    environment="$1"
+    nuget_config_dir="${HOME}/.nuget/NuGet"
+    nuget_conf="${nuget_config_dir}/NuGet.Config"
+
+    # Ensure ~/.nuget/NuGet directory exists
+    mkdir -p "$nuget_config_dir"
+
+    ux_header "Setting up NuGet configuration for: $environment"
+
+    # Handle existing NuGet.Config (symlink, file, or directory)
+    if [ -L "$nuget_conf" ]; then
+        rm -f "$nuget_conf"
+        ux_info "Removed existing symlink: $nuget_conf"
+    elif [ -d "$nuget_conf" ]; then
+        backup="${nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
+        mv "$nuget_conf" "$backup"
+        ux_warning "Backed up existing directory: $backup"
+    elif [ -f "$nuget_conf" ]; then
+        backup="${nuget_conf}.backup.$(date +%Y%m%d%H%M%S)"
+        mv "$nuget_conf" "$backup"
+        ux_info "Backed up existing file: $backup"
+    fi
+
+    # Create symlink based on environment
+    case "$environment" in
+        internal)
+            ln -s "${DOTFILES_ROOT}/nuget/NuGet.Config.internal" "$nuget_conf"
+            ux_success "Created symlink: ~/.nuget/NuGet/NuGet.Config → nuget/NuGet.Config.internal"
+            ux_info "Using: Samsung internal Nexus proxy for NuGet"
+            ;;
+        external|public)
+            # No custom config needed (defaults to nuget.org)
+            ux_info "No custom NuGet config needed (using nuget.org defaults)"
+            ;;
+    esac
+}
+
 setup_rpm_repo() {
     environment="$1"
     repo_target="/etc/yum.repos.d/ds.repo"
@@ -468,6 +544,8 @@ main() {
             setup_npm_symlink "public"
             setup_pip_config "public"
             setup_uv_config "public"
+            setup_cargo_config "public"
+            setup_nuget_config "public"
             setup_rpm_repo "public"
             setup_apt_sources "public"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
@@ -484,6 +562,8 @@ main() {
             setup_npm_symlink "internal"
             setup_pip_config "internal"
             setup_uv_config "internal"
+            setup_cargo_config "internal"
+            setup_nuget_config "internal"
             setup_rpm_repo "internal"
             setup_apt_sources "internal"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"
@@ -497,6 +577,8 @@ main() {
             ux_info "  - NPM: ~/.npmrc → npm/npmrc.internal (Nexus + proxy)"
             ux_info "  - Pip: Samsung internal repository configured"
             ux_info "  - uv: Samsung internal repository + proxy configured"
+            ux_info "  - Cargo: ~/.cargo/config.toml (Nexus proxy for crates.io)"
+            ux_info "  - NuGet: ~/.nuget/NuGet/NuGet.Config (Nexus proxy for nuget.org)"
             ux_info "  - RPM: /etc/yum.repos.d/ds.repo (if yum/dnf available)"
             ux_info "  - APT: /etc/apt/sources.list (if Ubuntu jammy)"
             ux_info "Setup mode saved to: ~/.dotfiles-setup-mode"
@@ -514,6 +596,8 @@ main() {
             setup_npm_symlink "external"
             setup_pip_config "external"
             setup_uv_config "external"
+            setup_cargo_config "external"
+            setup_nuget_config "external"
             setup_rpm_repo "external"
             setup_apt_sources "external"
             echo "$choice" > "$HOME/.dotfiles-setup-mode"


### PR DESCRIPTION
## Summary
- Cargo/NuGet 패키지 관리자 설정을 사내 Nexus 프록시로 자동 구성
- 기존 npm/pip/uv symlink 패턴과 동일한 구조

## Changes
| 파일 | 대상 | 방식 |
|------|------|------|
| `cargo/config.toml.internal` | `~/.cargo/config.toml` | symlink |
| `nuget/NuGet.Config.internal` | `~/.nuget/NuGet/NuGet.Config` | symlink |

### Cargo
- `sparse+http://repository.samsungds.net/repository/proxy-cargo-index.crates.io/`
- crates.io를 내부 Nexus 프록시로 대체 (source replacement)

### NuGet
- `https://repository.samsungds.net/repository/proxy-nuget-www.nuget.org/index.json`
- DSNuget 소스 추가 + nuget.org fallback 유지

## Test plan
- [ ] `./setup.sh` → 옵션 2 → Cargo/NuGet symlink 생성 확인
- [ ] `ls -al ~/.cargo/config.toml ~/.nuget/NuGet/NuGet.Config`
- [ ] `cargo install --list` 정상 (config 파싱 에러 없음)
- [ ] 옵션 1 (public) → symlink 제거, 기본값 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->