### PR TITLE
docs(agents): add package manager configuration reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,24 @@
 - **Stack**: Bash 5.x+, Python 3.10+, Tox, Ruff, Mypy.
 - **Structure**: Modular Bash (`bash/`), Zsh (`zsh/`), shared shell (`shell-common/`), Tests (`tests/`), Docs (`docs/`), Git hooks (`git/`), Claude Code (`claude/`).
 
+# Package Manager Configuration
+
+All managed by `shell-common/setup.sh` (environment menu: public / internal / external).
+
+| Manager | Config Dir | Target | Method | Gate |
+|---------|-----------|--------|--------|------|
+| npm | `npm/` | `~/.npmrc` | symlink | -- |
+| pip | `pip/` | `~/.config/pip/pip.conf` | symlink | -- |
+| uv | `uv/` | `~/.config/uv/uv.toml` | symlink | -- |
+| Cargo | `cargo/` | `~/.cargo/config.toml` | symlink | -- |
+| NuGet | `nuget/` | `~/.nuget/NuGet/` + `~/.config/NuGet/` | symlink (dual) | -- |
+| RPM | `rpm/` | `/etc/yum.repos.d/ds.repo` | sudo copy | RHEL 8.x + yum/dnf |
+| APT | `apt/` | `/etc/apt/sources.list` | sudo copy | Ubuntu + codename match |
+
+- **User-level** (npm/pip/uv/cargo/nuget): symlink to `{dir}/{config}.internal`, backup+restore on switch.
+- **System-level** (rpm/apt): sudo copy with 3-gate safety (tool exists, OS match, privilege), `MANAGED_BY_DOTFILES` marker for ownership.
+- **Adding new manager**: create `{dir}/{config}.internal`, add `setup_{name}()` function, wire into `main()` 3 menu cases.
+
 # Operational Commands
 
 - **Setup**: `./setup.sh` (Symlinks), `./install.sh` (Full install).


### PR DESCRIPTION
## Summary
- AGENTS.md에 7개 패키지 관리자 설정 레퍼런스 테이블 추가
- 새로운 패키지 관리자 추가 시 참고할 패턴 문서화

## Content
| Manager | Method | Gate |
|---------|--------|------|
| npm, pip, uv, cargo, nuget | symlink | -- |
| RPM | sudo copy | RHEL 8.x + yum/dnf |
| APT | sudo copy | Ubuntu + codename |

- user-level vs system-level 구분
- 새 매니저 추가 가이드 (3단계)
- 287행 (500행 제한 이내)

## Test plan
- [ ] AGENTS.md 500행 미만 확인
- [ ] 테이블 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->