### PR TITLE
fix: remove accidental literal ~ directory and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ __pycache__/
 
 # Claude Code personal settings (user-specific, environment-dependent)
 claude/settings.json
-.claude/scheduled_tasks.lock
+.claude/
 
 # VS Code settings (bidirectional sync system, PC-specific)
 .vscode/settings.json


### PR DESCRIPTION
## Summary
- Remove `~/.oh-my-zsh/custom/plugins/zsh-autosuggestions` submodule that was accidentally committed when `git clone` was run with quoted `"~"` path (creating a literal `~` directory instead of expanding to `$HOME`)
- Update `.gitignore`: replace `.claude/scheduled_tasks.lock` with broader `.claude/` pattern to ignore all project-local Claude Code settings

## Context
The literal `~` directory was created on 2026-01-28 and led to today's `rm -rf ~` incident (user saw `~` in `ls` output and tried to remove it without quotes, deleting the entire home directory).

## Test plan
- [x] `git status` shows clean working tree
- [x] `ls ~/dotfiles/` no longer contains literal `~` directory
- [x] `.claude/` directory no longer appears in untracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->