### PR TITLE
feat: write-task-history skill, mount cleanup, and code review fixes

### DIFF
--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -51,7 +51,7 @@ Run these commands to collect context:
 
 ```bash
 # Project name from remote
-git remote -v 2>/dev/null | head -1 | sed 's/.*\/\([^.]*\).*/\1/'
+basename "$(git remote get-url origin 2>/dev/null)" .git 2>/dev/null
 
 # Commits made during this conversation (look for hashes mentioned in conversation)
 git log --oneline -10
@@ -150,11 +150,39 @@ Each entry uses this structure:
 
 The timestamp is the current time when the skill runs (24-hour format).
 
-### Step 7: Confirm to user
+### Step 7: Auto-commit to the task-history repository
 
-After writing, tell the user:
+After writing the file, automatically commit it in the repository where the file lives.
+The task-history file may be in a different repository than the current working directory.
+
+Commit format (fixed pattern):
+
+```
+chore(task-history): YYYY-MM-DD short task summary
+```
+
+Example:
+
+```
+chore(task-history): 2026-03-20 write-task-history skill design
+```
+
+Steps:
+
+```bash
+cd <directory-containing-the-task-history-file>
+git add <task-history-file>
+git commit -m "chore(task-history): YYYY-MM-DD short task summary"
+```
+
+This commit is low-importance and does not require review, so commit directly
+without asking the user for confirmation.
+
+### Step 8: Confirm to user
+
+After writing and committing, tell the user:
 - The file path that was written to
-- A brief summary of what was recorded
+- The commit hash and message
 - Whether a PR section was included or skipped
 
 ## Important rules

--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: write-task-history
+description: >
+  Write task history from current conversation to a daily task list file.
+  Generates two copy-paste-ready formats: JIRA ticket (plain text with section symbols)
+  and git PR description (markdown). Use this skill whenever the user wants to record,
+  document, or summarize completed work from the current session. Also trigger when the
+  user mentions task history, work log, JIRA ticket drafting from conversation context,
+  or preparing PR descriptions based on what was just done. Works across any project.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# write-task-history
+
+Document completed work from the current conversation into a daily task history file,
+producing JIRA ticket and git PR formats that can be directly copy-pasted.
+
+## When to use
+
+- User says "/write-task-history" with optional description
+- User asks to record, log, or summarize today's work
+- User wants a JIRA ticket or PR description based on work just completed
+
+## Step-by-step workflow
+
+### Step 1: Determine output file path
+
+Resolve the storage directory and today's filename:
+
+```
+directory = $TASK_HISTORY_DIR or ~/para/archive/playbook/docs/task-history/
+filename  = YYYY-MM-DD-task-list.md  (e.g. 2026-03-20-task-list.md)
+```
+
+Run `mkdir -p` on the directory if it does not exist.
+
+### Step 2: Analyze the current conversation
+
+Review the full conversation to extract:
+
+- **What was done**: list of concrete actions and changes
+- **Why it was done**: background, motivation, or triggering event
+- **What resulted**: outcomes, files created, PRs merged, issues resolved
+
+If the user provided a description argument, use it as additional context but still
+analyze the conversation for completeness.
+
+### Step 3: Gather git information (if in a git repo)
+
+Run these commands to collect context:
+
+```bash
+# Project name from remote
+git remote -v 2>/dev/null | head -1 | sed 's/.*\/\([^.]*\).*/\1/'
+
+# Commits made during this conversation (look for hashes mentioned in conversation)
+git log --oneline -10
+
+# Current branch and diff scope (if not on main)
+git branch --show-current
+git diff main...HEAD --stat 2>/dev/null
+```
+
+Use the conversation context to identify which commits were made during this session,
+not just today's commits. This avoids false positives from unrelated commits.
+
+### Step 4: Generate JIRA ticket format
+
+Write inside a `text` code block. Use `>` for section headers and `-` for items.
+Do not use markdown formatting, emoji, or special characters beyond `>` and `-`.
+The content should be directly pasteable into a JIRA Description field.
+
+**Template:**
+
+```text
+[Title]
+[project-name] Concise summary of work
+
+[Description]
+> Background
+- Why this work was needed
+- Context or triggering event
+
+> Work performed
+- Specific action 1
+- Specific action 2
+- Specific action 3
+
+> Results
+- Outcome 1
+- Outcome 2
+
+> Notes
+- Additional context if relevant
+```
+
+Omit the "Notes" section if there is nothing noteworthy.
+
+### Step 5: Generate PR format (only if commits exist)
+
+Only produce this section if the conversation included git commits, branch creation,
+or PR activity. If no commits were made, skip entirely — do not write an empty section
+or a placeholder.
+
+Write inside a `markdown` code block. Use plain section headers without emoji.
+
+**Template:**
+
+```markdown
+## Title
+Short PR title (under 70 characters)
+
+## Summary
+- Change description 1
+- Change description 2
+
+## Changes
+- `file-or-path`: what changed
+- `file-or-path`: what changed
+
+## Test plan
+- [ ] Verification step 1
+- [ ] Verification step 2
+```
+
+### Step 6: Write to file
+
+Check if the target file already exists:
+
+- **File does not exist**: Create it with a level-1 heading, then the entry.
+- **File exists**: Append a `---` separator followed by the new entry.
+
+Each entry uses this structure:
+
+```markdown
+## HH:MM | project-name | Short task title
+
+### JIRA Ticket
+
+\`\`\`text
+(JIRA content here)
+\`\`\`
+
+### PR
+
+\`\`\`markdown
+(PR content here — or omit this entire section if no commits)
+\`\`\`
+```
+
+The timestamp is the current time when the skill runs (24-hour format).
+
+### Step 7: Confirm to user
+
+After writing, tell the user:
+- The file path that was written to
+- A brief summary of what was recorded
+- Whether a PR section was included or skipped
+
+## Important rules
+
+- Never use emoji in any output (repo convention)
+- JIRA format uses only `>` and `-` symbols for structure, no markdown
+- PR section is conditional: only when commits exist in conversation context
+- Always append, never overwrite existing file content
+- The `text` and `markdown` code blocks are essential for copy-paste workflow
+- Determine project name from `git remote`, falling back to directory name, then "N/A"
+- Write content in the same language the user used during the conversation
+
+## Example
+
+Given a conversation where the user fixed a bug and committed:
+
+File: `~/para/archive/playbook/docs/task-history/2026-03-20-task-list.md`
+
+```markdown
+# Task History: 2026-03-20
+
+---
+
+## 14:30 | dotfiles | Fix symlink creation for pip config
+
+### JIRA Ticket
+
+\`\`\`text
+[Title]
+[dotfiles] pip config symlink 생성 오류 수정
+
+[Description]
+> 배경
+- setup.sh 실행 시 ~/.config/pip/pip.conf symlink가 생성되지 않는 문제 발견
+- 디렉터리 미존재가 원인
+
+> 수행 내용
+- shell-common/setup.sh에서 mkdir -p 호출 추가
+- pip config symlink 생성 로직 수정
+- 테스트 후 PR 생성
+
+> 결과
+- setup.sh 실행 시 pip config 정상 생성 확인
+- PR #33 생성 및 머지 완료
+\`\`\`
+
+### PR
+
+\`\`\`markdown
+## Title
+fix: add mkdir for pip config directory before symlink creation
+
+## Summary
+- Add `mkdir -p ~/.config/pip` before creating pip.conf symlink
+- Fixes setup.sh failure on fresh installations where ~/.config/pip does not exist
+
+## Changes
+- `shell-common/setup.sh`: Added directory creation before symlink
+
+## Test plan
+- [ ] Run setup.sh on clean home directory
+- [ ] Verify ~/.config/pip/pip.conf symlink exists after setup
+\`\`\`
+```

--- a/docs/feature/skill-write-task-history/design.md
+++ b/docs/feature/skill-write-task-history/design.md
@@ -8,7 +8,9 @@
 - **스킬 이름**: `write-task-history`
 - **호출**: `/write-task-history [설명]`
 - **적용 범위**: 모든 프로젝트 (dotfiles, rca-knowledge 등)
-- **저장 위치**: `~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md` (Single Source)
+- **저장 위치**: `$TASK_HISTORY_DIR/YYYY-MM-DD-task-list.md` (Single Source)
+- **기본 경로**: `~/para/archive/playbook/docs/task-history/`
+- **환경변수**: `TASK_HISTORY_DIR`로 오버라이드 가능
 
 ## 2. 요구사항
 
@@ -17,8 +19,8 @@
 | ID | 요구사항 | 비고 |
 |---|---|---|
 | R1 | 현재 대화 내용을 분석하여 작업 내역 추출 | 대화 컨텍스트 기반 |
-| R2 | JIRA 티켓 형태 출력 (text, ▶◇ 기호 활용) | JIRA가 마크다운 미지원이므로 |
-| R3 | git PR 형태 출력 (마크다운, 섹션별 이모지) | 커밋이 있는 경우만 |
+| R2 | JIRA 티켓 형태 출력 (text, 기호 활용) | JIRA가 마크다운 미지원이므로 |
+| R3 | git PR 형태 출력 (마크다운) | 대화 중 커밋이 있는 경우만 |
 | R4 | 일별 파일에 append (덮어쓰기 아님) | 하루에 여러 번 호출 가능 |
 | R5 | 모든 프로젝트에서 사용 가능 | 프로젝트 비종속적 |
 | R6 | 커밋 없으면 PR 섹션 생략 | 선택적 출력 |
@@ -26,7 +28,8 @@
 
 ### 출력 파일 규칙
 
-- **경로**: `~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md`
+- **경로**: `$TASK_HISTORY_DIR/YYYY-MM-DD-task-list.md`
+- **기본값**: `TASK_HISTORY_DIR=~/para/archive/playbook/docs/task-history`
 - **파일명 예시**: `2026-03-20-task-list.md`
 - **동작**: 파일이 없으면 생성, 있으면 append (`---` 구분선 포함)
 - **타임스탬프**: 각 항목에 HH:MM 표시
@@ -37,7 +40,7 @@
 | 소스 | 용도 | 필수 여부 |
 |---|---|---|
 | 현재 대화 컨텍스트 | 작업 내역 추출 | 필수 |
-| `git log` (현재 프로젝트) | 커밋 목록, PR 내용 | 선택 (커밋 있을 때) |
+| `git log` (현재 대화에서 생성된 커밋) | 커밋 목록, PR 내용 | 선택 |
 | `git diff main...HEAD` | 변경 사항 요약 | 선택 (브랜치 있을 때) |
 | `git remote -v` | 프로젝트명 추출 | 선택 |
 | 사용자 인자 (`[설명]`) | 추가 컨텍스트 | 선택 |
@@ -46,49 +49,48 @@
 
 ### 4-A. JIRA 티켓 형태
 
-JIRA가 마크다운을 지원하지 않으므로, ▶◇ 기호를 활용한 텍스트로 작성.
-가독성을 위해 섹션 구분에 ▶, 하위 항목에 ◇ 기호 사용.
+JIRA가 마크다운을 지원하지 않으므로, 기호를 활용한 텍스트로 작성.
+가독성을 위해 섹션 구분에 >, 하위 항목에 - 기호 사용.
 
 ```text
 [Title]
 [프로젝트명] 작업 제목 요약
 
 [Description]
-▶ 배경
-◇ 작업 배경 또는 원인 설명
-◇ 추가 배경 설명
+> 배경
+- 작업 배경 또는 원인 설명
+- 추가 배경 설명
 
-▶ 수행 내용
-◇ 수행한 작업 1
-◇ 수행한 작업 2
-◇ 수행한 작업 3
+> 수행 내용
+- 수행한 작업 1
+- 수행한 작업 2
+- 수행한 작업 3
 
-▶ 결과
-◇ 결과 요약 1
-◇ 결과 요약 2
+> 결과
+- 결과 요약 1
+- 결과 요약 2
 
-▶ 비고
-◇ 참고 사항 (있을 경우)
+> 비고
+- 참고 사항 (있을 경우)
 ```
 
 ### 4-B. git PR 형태
 
-커밋이 있는 경우에만 작성. GitHub PR 마크다운 형식.
-섹션 제목에 이모지를 포함.
+현재 대화에서 커밋이 있는 경우에만 작성. GitHub PR 마크다운 형식.
 
 ```markdown
 ## Title
 작업 제목 요약 (70자 이내)
 
-## 📋 Summary
+## Summary
 - 변경 사항 요약 1
 - 변경 사항 요약 2
 
-## 📝 Changes
+## Changes
 - `파일1`: 변경 내용
 - `파일2`: 변경 내용
 
-## ✅ Test plan
+## Test plan
 - [ ] 테스트 항목 1
 - [ ] 테스트 항목 2
 ```
@@ -113,8 +115,8 @@ JIRA/PR 내용은 각각 코드블럭으로 감싸서
 ...
 
 [Description]
-▶ 배경
-◇ ...
+> 배경
+- ...
 \`\`\`
 
 ### PR
@@ -123,7 +125,7 @@ JIRA/PR 내용은 각각 코드블럭으로 감싸서
 ## Title
 ...
 
-## 📋 Summary
+## Summary
 ...
 \`\`\`
 
@@ -137,7 +139,7 @@ JIRA/PR 내용은 각각 코드블럭으로 감싸서
 ...
 \`\`\`
 
-(커밋 없으므로 PR 섹션 생략)
+(현재 대화에서 커밋 없으므로 PR 섹션 생략)
 ```
 
 ## 5. 처리 흐름
@@ -146,8 +148,9 @@ JIRA/PR 내용은 각각 코드블럭으로 감싸서
 /write-task-history [설명]
         |
         v
-[Step 1] 현재 날짜로 파일 경로 결정
-         ~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md
+[Step 1] 저장 경로 결정
+         $TASK_HISTORY_DIR/YYYY-MM-DD-task-list.md
+         (미설정 시 ~/para/archive/playbook/docs/task-history/)
         |
         v
 [Step 2] 현재 대화 컨텍스트에서 작업 내역 분석
@@ -157,17 +160,17 @@ JIRA/PR 내용은 각각 코드블럭으로 감싸서
         |
         v
 [Step 3] git 정보 수집 (선택)
-         - git log: 오늘 커밋한 내역
+         - 현재 대화에서 생성된 커밋 파악
          - git remote: 프로젝트명
          - git diff main...HEAD: 변경 범위
         |
         v
 [Step 4] JIRA 티켓 형태 생성
-         - Title + Description (▶◇ 기호 활용 text)
+         - Title + Description (기호 활용 text)
         |
         v
-[Step 5] 커밋이 있는가?
-         ├─ YES → PR 형태 생성 (이모지 포함 마크다운)
+[Step 5] 현재 대화에서 커밋이 있는가?
+         ├─ YES → PR 형태 생성
          └─ NO  → PR 섹션 생략
         |
         v
@@ -194,7 +197,7 @@ claude/skills/write-task-history/
 name: write-task-history
 description: >
   Write task history from current conversation to daily task list file.
-  Generates JIRA ticket (text with ▶◇ symbols) and git PR (markdown with emoji) formats.
+  Generates JIRA ticket (text) and git PR (markdown) formats.
   Use when user wants to document completed work for internal tracking.
 triggers:
   - /write-task-history
@@ -210,12 +213,13 @@ triggers:
 
 ## 출력
 
-1. JIRA 티켓 형태 (text + ▶◇ 기호)
-2. git PR 형태 (마크다운 + 이모지) — 커밋이 있는 경우만
+1. JIRA 티켓 형태 (text + 기호)
+2. git PR 형태 (마크다운) — 현재 대화에서 커밋이 있는 경우만
 
 ## 저장 위치
 
-~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md
+$TASK_HISTORY_DIR/YYYY-MM-DD-task-list.md
+기본값: ~/para/archive/playbook/docs/task-history/
 ```
 
 ## 7. 설계 결정 사항 (리뷰 확정)
@@ -224,25 +228,23 @@ triggers:
 
 - `2026-03-20-task-list.md`
 - 이유: 검색 편의성, ISO 8601 표준 준수
-- ~~기존안 YYMMDD~~: 리뷰에서 YYYY-MM-DD 선택
 
-### 결정 2: 저장 경로 task-history
+### 결정 2: 저장 경로 외부화
 
-- `~/para/archive/playbook/docs/task-history/`
-- 이유: 스킬명(`write-task-history`)과 일관, "작업 이력" 의미 명확
-- ~~기존안 task/~~: "할 일 목록"으로 오해 가능
-- ~~동료안 history/~~: 너무 범용적
+- 환경변수 `TASK_HISTORY_DIR`로 오버라이드 가능
+- 기본값: `~/para/archive/playbook/docs/task-history/`
+- 이유: 다른 머신/사용자 계정에서도 동작 보장 (Finding #3 반영)
 
-### 결정 3: JIRA 형태는 ▶◇ 기호 텍스트
+### 결정 3: JIRA 형태는 기호 텍스트
 
-- ▶: 섹션 구분 (배경, 수행 내용, 결과, 비고)
-- ◇: 하위 항목
+- `>`: 섹션 구분 (배경, 수행 내용, 결과, 비고)
+- `-`: 하위 항목
 - 마크다운 렌더링이 안 되는 JIRA에서도 시각적 구분 가능
 
-### 결정 4: PR 섹션에 이모지
+### 결정 4: PR 섹션은 plain 마크다운
 
-- 📋 Summary, 📝 Changes, ✅ Test plan
-- 사내 PR 템플릿과 일치하면서 가독성 향상
+- 저장소 규칙에 따라 이모지를 사용하지 않음 (Finding #1 반영)
+- Summary, Changes, Test plan 등 섹션명만 사용
 
 ### 결정 5: append 구분선 `---`
 
@@ -254,10 +256,12 @@ triggers:
 - 각 항목 헤더에 `## HH:MM | 프로젝트명 | 작업 제목` 형식
 - 작업 시간대를 기록하여 추후 참조 용이
 
-### 결정 7: PR은 조건부 생성
+### 결정 7: PR 생성 기준은 대화 컨텍스트
 
-- `git log --since="today" --oneline` 결과가 비어있으면 PR 섹션 생략
-- 이유: 커밋 없는 작업(리서치, 문서 작성 등)에는 PR이 불필요
+- ~~기존안: `git log --since="today"`~~: 날짜 기반은 오탐/누락 발생 (Finding #2 반영)
+- 확정: 현재 대화에서 실제로 수행한 커밋 유무로 판정
+- 대화 컨텍스트에서 커밋 해시, 브랜치, PR 생성 여부를 파악
+- 커밋 없는 작업(리서치, 문서 작성 등)에는 PR 생략
 
 ### 결정 8: 프로젝트 비종속
 
@@ -275,7 +279,8 @@ triggers:
 | 케이스 | 처리 |
 |---|---|
 | task-history 디렉터리 미존재 | 자동 생성 (`mkdir -p`) |
+| TASK_HISTORY_DIR 미설정 | 기본 경로 사용 |
 | 같은 날 여러 번 호출 | `---` 구분선 후 append |
-| 커밋 없음 | PR 섹션 생략, JIRA만 작성 |
+| 현재 대화에서 커밋 없음 | PR 섹션 생략, JIRA만 작성 |
 | git repo 아닌 디렉터리에서 호출 | 프로젝트명 "N/A", PR 생략 |
 | 사용자 설명 미제공 | 대화 컨텍스트에서 자동 추출 |

--- a/docs/feature/skill-write-task-history/design.md
+++ b/docs/feature/skill-write-task-history/design.md
@@ -1,0 +1,281 @@
+# Skill Design: write-task-history
+
+## 1. 개요
+
+현재 대화에서 수행한 작업 내용을 정리하여, JIRA 티켓 등록용과 git PR용 두 가지 형태로
+일별 task history 파일에 append하는 스킬.
+
+- **스킬 이름**: `write-task-history`
+- **호출**: `/write-task-history [설명]`
+- **적용 범위**: 모든 프로젝트 (dotfiles, rca-knowledge 등)
+- **저장 위치**: `~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md` (Single Source)
+
+## 2. 요구사항
+
+### 핵심 요구사항
+
+| ID | 요구사항 | 비고 |
+|---|---|---|
+| R1 | 현재 대화 내용을 분석하여 작업 내역 추출 | 대화 컨텍스트 기반 |
+| R2 | JIRA 티켓 형태 출력 (text, ▶◇ 기호 활용) | JIRA가 마크다운 미지원이므로 |
+| R3 | git PR 형태 출력 (마크다운, 섹션별 이모지) | 커밋이 있는 경우만 |
+| R4 | 일별 파일에 append (덮어쓰기 아님) | 하루에 여러 번 호출 가능 |
+| R5 | 모든 프로젝트에서 사용 가능 | 프로젝트 비종속적 |
+| R6 | 커밋 없으면 PR 섹션 생략 | 선택적 출력 |
+| R7 | JIRA/PR 각각 코드블럭으로 감싸서 출력 | 복사/붙여넣기 용이하도록 |
+
+### 출력 파일 규칙
+
+- **경로**: `~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md`
+- **파일명 예시**: `2026-03-20-task-list.md`
+- **동작**: 파일이 없으면 생성, 있으면 append (`---` 구분선 포함)
+- **타임스탬프**: 각 항목에 HH:MM 표시
+- **인코딩**: UTF-8
+
+## 3. 데이터 소스
+
+| 소스 | 용도 | 필수 여부 |
+|---|---|---|
+| 현재 대화 컨텍스트 | 작업 내역 추출 | 필수 |
+| `git log` (현재 프로젝트) | 커밋 목록, PR 내용 | 선택 (커밋 있을 때) |
+| `git diff main...HEAD` | 변경 사항 요약 | 선택 (브랜치 있을 때) |
+| `git remote -v` | 프로젝트명 추출 | 선택 |
+| 사용자 인자 (`[설명]`) | 추가 컨텍스트 | 선택 |
+
+## 4. 출력 형식
+
+### 4-A. JIRA 티켓 형태
+
+JIRA가 마크다운을 지원하지 않으므로, ▶◇ 기호를 활용한 텍스트로 작성.
+가독성을 위해 섹션 구분에 ▶, 하위 항목에 ◇ 기호 사용.
+
+```text
+[Title]
+[프로젝트명] 작업 제목 요약
+
+[Description]
+▶ 배경
+◇ 작업 배경 또는 원인 설명
+◇ 추가 배경 설명
+
+▶ 수행 내용
+◇ 수행한 작업 1
+◇ 수행한 작업 2
+◇ 수행한 작업 3
+
+▶ 결과
+◇ 결과 요약 1
+◇ 결과 요약 2
+
+▶ 비고
+◇ 참고 사항 (있을 경우)
+```
+
+### 4-B. git PR 형태
+
+커밋이 있는 경우에만 작성. GitHub PR 마크다운 형식.
+섹션 제목에 이모지를 포함.
+
+```markdown
+## Title
+작업 제목 요약 (70자 이내)
+
+## 📋 Summary
+- 변경 사항 요약 1
+- 변경 사항 요약 2
+
+## 📝 Changes
+- `파일1`: 변경 내용
+- `파일2`: 변경 내용
+
+## ✅ Test plan
+- [ ] 테스트 항목 1
+- [ ] 테스트 항목 2
+```
+
+### 4-C. 파일 전체 구조
+
+하루에 여러 번 호출 시 append되는 형태.
+JIRA/PR 내용은 각각 코드블럭으로 감싸서
+사용자가 바로 복사/붙여넣기할 수 있도록 한다.
+
+```markdown
+# Task History: 2026-03-20
+
+---
+
+## 13:30 | dotfiles | rm -rf ~ 복구 작업
+
+### JIRA Ticket
+
+\`\`\`text
+[Title]
+...
+
+[Description]
+▶ 배경
+◇ ...
+\`\`\`
+
+### PR
+
+\`\`\`markdown
+## Title
+...
+
+## 📋 Summary
+...
+\`\`\`
+
+---
+
+## 15:00 | rca-knowledge | 분석 보고서 작성
+
+### JIRA Ticket
+
+\`\`\`text
+...
+\`\`\`
+
+(커밋 없으므로 PR 섹션 생략)
+```
+
+## 5. 처리 흐름
+
+```text
+/write-task-history [설명]
+        |
+        v
+[Step 1] 현재 날짜로 파일 경로 결정
+         ~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md
+        |
+        v
+[Step 2] 현재 대화 컨텍스트에서 작업 내역 분석
+         - 무엇을 했는지 (작업 목록)
+         - 왜 했는지 (배경/원인)
+         - 결과가 무엇인지
+        |
+        v
+[Step 3] git 정보 수집 (선택)
+         - git log: 오늘 커밋한 내역
+         - git remote: 프로젝트명
+         - git diff main...HEAD: 변경 범위
+        |
+        v
+[Step 4] JIRA 티켓 형태 생성
+         - Title + Description (▶◇ 기호 활용 text)
+        |
+        v
+[Step 5] 커밋이 있는가?
+         ├─ YES → PR 형태 생성 (이모지 포함 마크다운)
+         └─ NO  → PR 섹션 생략
+        |
+        v
+[Step 6] 파일에 append
+         - 파일 없으면: 헤더 + 내용 생성
+         - 파일 있으면: 구분선(---) + 내용 append
+        |
+        v
+[Step 7] 사용자에게 결과 요약 출력
+```
+
+## 6. 스킬 파일 구조
+
+```text
+claude/skills/write-task-history/
+  SKILL.md          # 스킬 정의 (호출 조건, 설명)
+  instructions.md   # 상세 구현 지침
+```
+
+### SKILL.md (초안)
+
+```markdown
+---
+name: write-task-history
+description: >
+  Write task history from current conversation to daily task list file.
+  Generates JIRA ticket (text with ▶◇ symbols) and git PR (markdown with emoji) formats.
+  Use when user wants to document completed work for internal tracking.
+triggers:
+  - /write-task-history
+---
+
+# write-task-history
+
+현재 대화의 작업 내용을 정리하여 일별 task history 파일에 기록합니다.
+
+## 호출
+
+/write-task-history [작업 설명]
+
+## 출력
+
+1. JIRA 티켓 형태 (text + ▶◇ 기호)
+2. git PR 형태 (마크다운 + 이모지) — 커밋이 있는 경우만
+
+## 저장 위치
+
+~/para/archive/playbook/docs/task-history/YYYY-MM-DD-task-list.md
+```
+
+## 7. 설계 결정 사항 (리뷰 확정)
+
+### 결정 1: 파일명 형식 YYYY-MM-DD
+
+- `2026-03-20-task-list.md`
+- 이유: 검색 편의성, ISO 8601 표준 준수
+- ~~기존안 YYMMDD~~: 리뷰에서 YYYY-MM-DD 선택
+
+### 결정 2: 저장 경로 task-history
+
+- `~/para/archive/playbook/docs/task-history/`
+- 이유: 스킬명(`write-task-history`)과 일관, "작업 이력" 의미 명확
+- ~~기존안 task/~~: "할 일 목록"으로 오해 가능
+- ~~동료안 history/~~: 너무 범용적
+
+### 결정 3: JIRA 형태는 ▶◇ 기호 텍스트
+
+- ▶: 섹션 구분 (배경, 수행 내용, 결과, 비고)
+- ◇: 하위 항목
+- 마크다운 렌더링이 안 되는 JIRA에서도 시각적 구분 가능
+
+### 결정 4: PR 섹션에 이모지
+
+- 📋 Summary, 📝 Changes, ✅ Test plan
+- 사내 PR 템플릿과 일치하면서 가독성 향상
+
+### 결정 5: append 구분선 `---`
+
+- 마크다운 표준 수평선
+- 하루에 여러 프로젝트/작업을 기록할 때 시각적 분리
+
+### 결정 6: 타임스탬프 HH:MM 표시
+
+- 각 항목 헤더에 `## HH:MM | 프로젝트명 | 작업 제목` 형식
+- 작업 시간대를 기록하여 추후 참조 용이
+
+### 결정 7: PR은 조건부 생성
+
+- `git log --since="today" --oneline` 결과가 비어있으면 PR 섹션 생략
+- 이유: 커밋 없는 작업(리서치, 문서 작성 등)에는 PR이 불필요
+
+### 결정 8: 프로젝트 비종속
+
+- `git remote -v`에서 프로젝트명 추출하여 자동 표시
+- 어떤 프로젝트 디렉터리에서든 호출 가능
+
+### 결정 9: 코드블럭 래핑
+
+- JIRA: `` ```text `` 블럭으로 감쌈
+- PR: `` ```markdown `` 블럭으로 감쌈
+- 이유: 사용자가 그대로 복사/붙여넣기 가능
+
+## 8. 엣지 케이스
+
+| 케이스 | 처리 |
+|---|---|
+| task-history 디렉터리 미존재 | 자동 생성 (`mkdir -p`) |
+| 같은 날 여러 번 호출 | `---` 구분선 후 append |
+| 커밋 없음 | PR 섹션 생략, JIRA만 작성 |
+| git repo 아닌 디렉터리에서 호출 | 프로젝트명 "N/A", PR 생략 |
+| 사용자 설명 미제공 | 대화 컨텍스트에서 자동 추출 |

--- a/docs/feature/skill-write-task-history/example-output.md
+++ b/docs/feature/skill-write-task-history/example-output.md
@@ -1,0 +1,78 @@
+# Example Output: /write-task-history
+
+아래는 오늘(2026-03-20) dotfiles 프로젝트에서 작업한 내용을 예시로 한 출력입니다.
+JIRA/PR 각각 코드블럭으로 감싸서 복사/붙여넣기가 용이한 형태.
+
+## 저장될 파일
+
+`~/para/archive/playbook/docs/task-history/2026-03-20-task-list.md`
+
+---
+
+아래부터가 실제 파일에 작성되는 내용입니다:
+
+---
+
+## Task History: 2026-03-20
+
+---
+
+### 13:50 | dotfiles | rm -rf ~ 홈 디렉터리 복구 및 git-crypt 키 백업
+
+#### JIRA Ticket
+
+```text
+[Title]
+[dotfiles] rm -rf ~ 사고 복구 및 git-crypt 대칭키 백업 체계 구축
+
+[Description]
+▶ 배경
+◇ 홈 디렉터리에 리터럴 "~" 디렉터리가 존재하여 삭제 시도
+◇ rm -rf ~ (따옴표 없이) 실행으로 홈 디렉터리 전체 삭제됨
+◇ bash/zsh 셸 설정, SSH 키, GPG 키, oh-my-zsh 등 전부 삭제
+
+▶ 수행 내용
+◇ dotfiles setup.sh 실행하여 셸 환경 복구 (bash, zsh, git, npm, pip 등 symlink 재생성)
+◇ oh-my-zsh + powerlevel10k + zsh-autosuggestions 재설치
+◇ pyenv + pyenv-virtualenv 재설치
+◇ git-crypt 대칭키 export 및 Obsidian 로컬 백업
+◇ GPG 키 복구 시도 (비밀번호 불일치로 실패, 대칭키로 대체)
+◇ fasd, uv 재설치
+◇ gh auth login 재인증
+◇ 리터럴 ~ 디렉터리를 git 추적에서 제거
+◇ .gitignore에 .claude/ 패턴 추가
+
+▶ 결과
+◇ 셸 환경 전체 정상 복구 (bash, zsh 모두 동작 확인)
+◇ git-crypt 대칭키 Obsidian 로컬 백업 완료 (SHA256 해시 포함)
+◇ 재해 복구 가이드 문서 작성: docs/todo/disaster-recovery-rm-rf-home.md
+◇ PR #32 생성 및 머지 완료
+
+▶ 비고
+◇ SSH 키가 새로 생성됨 (사내 서버 사용 시 공개키 재등록 필요)
+◇ GPG 비밀키는 분실 상태 (git-crypt 대칭키로 기능 대체)
+```
+
+#### PR
+
+```markdown
+## Title
+
+fix: remove accidental literal ~ directory and update .gitignore
+
+## 📋 Summary
+
+- Remove `~/.oh-my-zsh/custom/plugins/zsh-autosuggestions` submodule that was accidentally committed when `git clone` was run with quoted `"~"` path
+- Update `.gitignore`: replace `.claude/scheduled_tasks.lock` with broader `.claude/` pattern to ignore all project-local Claude Code settings
+
+## 📝 Changes
+
+- `~/.oh-my-zsh/custom/plugins/zsh-autosuggestions`: git 추적에서 제거 (리터럴 ~ 디렉터리 정리)
+- `.gitignore`: `.claude/scheduled_tasks.lock` -> `.claude/` 패턴 변경
+
+## ✅ Test plan
+
+- [x] `git status` shows clean working tree
+- [x] `ls ~/dotfiles/` no longer contains literal `~` directory
+- [x] `.claude/` directory no longer appears in untracked files
+```

--- a/docs/feature/skill-write-task-history/example-output.md
+++ b/docs/feature/skill-write-task-history/example-output.md
@@ -5,7 +5,8 @@ JIRA/PR 각각 코드블럭으로 감싸서 복사/붙여넣기가 용이한 형
 
 ## 저장될 파일
 
-`~/para/archive/playbook/docs/task-history/2026-03-20-task-list.md`
+`$TASK_HISTORY_DIR/2026-03-20-task-list.md`
+(기본: `~/para/archive/playbook/docs/task-history/2026-03-20-task-list.md`)
 
 ---
 
@@ -26,31 +27,31 @@ JIRA/PR 각각 코드블럭으로 감싸서 복사/붙여넣기가 용이한 형
 [dotfiles] rm -rf ~ 사고 복구 및 git-crypt 대칭키 백업 체계 구축
 
 [Description]
-▶ 배경
-◇ 홈 디렉터리에 리터럴 "~" 디렉터리가 존재하여 삭제 시도
-◇ rm -rf ~ (따옴표 없이) 실행으로 홈 디렉터리 전체 삭제됨
-◇ bash/zsh 셸 설정, SSH 키, GPG 키, oh-my-zsh 등 전부 삭제
+> 배경
+- 홈 디렉터리에 리터럴 "~" 디렉터리가 존재하여 삭제 시도
+- rm -rf ~ (따옴표 없이) 실행으로 홈 디렉터리 전체 삭제됨
+- bash/zsh 셸 설정, SSH 키, GPG 키, oh-my-zsh 등 전부 삭제
 
-▶ 수행 내용
-◇ dotfiles setup.sh 실행하여 셸 환경 복구 (bash, zsh, git, npm, pip 등 symlink 재생성)
-◇ oh-my-zsh + powerlevel10k + zsh-autosuggestions 재설치
-◇ pyenv + pyenv-virtualenv 재설치
-◇ git-crypt 대칭키 export 및 Obsidian 로컬 백업
-◇ GPG 키 복구 시도 (비밀번호 불일치로 실패, 대칭키로 대체)
-◇ fasd, uv 재설치
-◇ gh auth login 재인증
-◇ 리터럴 ~ 디렉터리를 git 추적에서 제거
-◇ .gitignore에 .claude/ 패턴 추가
+> 수행 내용
+- dotfiles setup.sh 실행하여 셸 환경 복구 (bash, zsh, git, npm, pip 등 symlink 재생성)
+- oh-my-zsh + powerlevel10k + zsh-autosuggestions 재설치
+- pyenv + pyenv-virtualenv 재설치
+- git-crypt 대칭키 export 및 Obsidian 로컬 백업
+- GPG 키 복구 시도 (비밀번호 불일치로 실패, 대칭키로 대체)
+- fasd, uv 재설치
+- gh auth login 재인증
+- 리터럴 ~ 디렉터리를 git 추적에서 제거
+- .gitignore에 .claude/ 패턴 추가
 
-▶ 결과
-◇ 셸 환경 전체 정상 복구 (bash, zsh 모두 동작 확인)
-◇ git-crypt 대칭키 Obsidian 로컬 백업 완료 (SHA256 해시 포함)
-◇ 재해 복구 가이드 문서 작성: docs/todo/disaster-recovery-rm-rf-home.md
-◇ PR #32 생성 및 머지 완료
+> 결과
+- 셸 환경 전체 정상 복구 (bash, zsh 모두 동작 확인)
+- git-crypt 대칭키 Obsidian 로컬 백업 완료 (SHA256 해시 포함)
+- 재해 복구 가이드 문서 작성: docs/todo/disaster-recovery-rm-rf-home.md
+- PR #32 생성 및 머지 완료
 
-▶ 비고
-◇ SSH 키가 새로 생성됨 (사내 서버 사용 시 공개키 재등록 필요)
-◇ GPG 비밀키는 분실 상태 (git-crypt 대칭키로 기능 대체)
+> 비고
+- SSH 키가 새로 생성됨 (사내 서버 사용 시 공개키 재등록 필요)
+- GPG 비밀키는 분실 상태 (git-crypt 대칭키로 기능 대체)
 ```
 
 #### PR
@@ -60,17 +61,17 @@ JIRA/PR 각각 코드블럭으로 감싸서 복사/붙여넣기가 용이한 형
 
 fix: remove accidental literal ~ directory and update .gitignore
 
-## 📋 Summary
+## Summary
 
 - Remove `~/.oh-my-zsh/custom/plugins/zsh-autosuggestions` submodule that was accidentally committed when `git clone` was run with quoted `"~"` path
 - Update `.gitignore`: replace `.claude/scheduled_tasks.lock` with broader `.claude/` pattern to ignore all project-local Claude Code settings
 
-## 📝 Changes
+## Changes
 
 - `~/.oh-my-zsh/custom/plugins/zsh-autosuggestions`: git 추적에서 제거 (리터럴 ~ 디렉터리 정리)
 - `.gitignore`: `.claude/scheduled_tasks.lock` -> `.claude/` 패턴 변경
 
-## ✅ Test plan
+## Test plan
 
 - [x] `git status` shows clean working tree
 - [x] `ls ~/dotfiles/` no longer contains literal `~` directory

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -26,22 +26,22 @@ mount_help() {
 
         ux_section "Available Commands"
         ux_bullet "addmnt <source> <target>    Create bind mount"
-        ux_bullet "show_mnt [path]             Display mount status"
-        ux_bullet "claude_mount_all            Mount all Claude directories (skills, agents, docs)"
-        ux_bullet "mount_help                  Show this help message"
+        ux_bullet "show-mnt [path]             Display mount status"
+        ux_bullet "claude-mount-all            Mount all Claude directories (skills, agents, docs)"
+        ux_bullet "mount-help                  Show this help message"
 
 
         ux_section "Quick Examples"
         ux_numbered 1 "Mount all Claude directories at once:"
-        ux_bullet "claude_mount_all"
+        ux_bullet "claude-mount-all"
 
 
         ux_numbered 2 "View all Claude mounts:"
-        ux_bullet "show_mnt"
+        ux_bullet "show-mnt"
 
 
         ux_numbered 3 "View specific mount:"
-        ux_bullet "show_mnt ~/.claude/skills"
+        ux_bullet "show-mnt ~/.claude/skills"
 
 
         ux_numbered 4 "Add new bind mount:"
@@ -50,7 +50,7 @@ mount_help() {
 
         ux_section "For More Information"
         ux_bullet "addmnt --help       Usage for addmnt command"
-        ux_bullet "show_mnt --help     Usage for show_mnt command"
+        ux_bullet "show-mnt --help     Usage for show-mnt command"
 
 
         ux_warning "Requires sudo for mount operations"
@@ -65,19 +65,18 @@ Description:
 
 Available Commands:
   addmnt <source> <target>       Create bind mount
-  show_mnt [path]                Display mount status
-  claude_mount_all               Mount all Claude directories (skills, docs)
-  mount_help                     Show this help message
+  show-mnt [path]                Display mount status
+  claude-mount-all               Mount all Claude directories (skills, docs)
+  mount-help                     Show this help message
 
 Examples:
-  claude_mount_all                              Mount all Claude directories
-  show_mnt                                      View all mounts
-  show_mnt ~/.claude/skills                     View specific mount
+  claude-mount-all                              Mount all Claude directories
+  show-mnt                                      View all mounts
+  show-mnt ~/.claude/skills                     View specific mount
   addmnt $DOTFILES_ROOT/claude/docs ~/.claude/docs      Add new mount
 
 Notes:
   - Requires sudo for mount operations
-  - Alias: show-mnt, mount-help
 HELP
     fi
 }
@@ -346,6 +345,67 @@ mount_show() {
         fi
     fi
 }
+
+# Mount all Claude directories (skills, agents, docs)
+# Reads mount pairs from claude/setup.sh bind mount configuration
+# and re-mounts any that are not currently mounted.
+claude_mount_all() {
+    local dotfiles_root="${DOTFILES_ROOT:-$HOME/dotfiles}"
+    local claude_source="${dotfiles_root}/claude"
+    local home_claude="${HOME}/.claude"
+    local mounted=0
+    local skipped=0
+
+    if type ux_header >/dev/null 2>&1; then
+        ux_header "Claude Bind Mount (remount all)"
+    else
+        echo "=== Claude Bind Mount (remount all) ==="
+    fi
+
+    # Define mount pairs: source -> target
+    # skills directory (primary, required)
+    _claude_mount_one "${claude_source}/skills" "${home_claude}/skills" "skills"
+
+    # Add more mount pairs here as needed:
+    # _claude_mount_one "${claude_source}/docs" "${home_claude}/docs" "docs"
+}
+
+# Internal: mount a single source->target pair if not already mounted
+_claude_mount_one() {
+    local source="$1"
+    local target="$2"
+    local label="$3"
+
+    if [ ! -d "$source" ]; then
+        if type ux_warning >/dev/null 2>&1; then
+            ux_warning "Source not found: $source"
+        fi
+        return 1
+    fi
+
+    mkdir -p "$target" 2>/dev/null
+
+    if _is_mounted "$target"; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "Already mounted: $label ($target)"
+        fi
+        return 0
+    fi
+
+    if sudo mount --bind "$source" "$target" 2>/dev/null; then
+        if type ux_success >/dev/null 2>&1; then
+            ux_success "Mounted: $label ($source -> $target)"
+        fi
+        return 0
+    else
+        if type ux_error >/dev/null 2>&1; then
+            ux_error "Failed to mount: $label"
+        fi
+        return 1
+    fi
+}
+
+alias claude-mount-all='claude_mount_all'
 
 # ============================================================================
 # Backward Compatibility Aliases

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -28,24 +28,6 @@ mount_help() {
         ux_bullet "addmnt <source> <target>    Create bind mount"
         ux_bullet "show-mnt [path]             Display mount status"
         ux_bullet "claude-mount-all            Mount all Claude directories (skills, agents, docs)"
-        ux_bullet "mount-help                  Show this help message"
-
-
-        ux_section "Quick Examples"
-        ux_numbered 1 "Mount all Claude directories at once:"
-        ux_bullet "claude-mount-all"
-
-
-        ux_numbered 2 "View all Claude mounts:"
-        ux_bullet "show-mnt"
-
-
-        ux_numbered 3 "View specific mount:"
-        ux_bullet "show-mnt ~/.claude/skills"
-
-
-        ux_numbered 4 "Add new bind mount:"
-        ux_bullet "addmnt ${DOTFILES_ROOT:-$HOME/dotfiles}/claude/docs ~/.claude/docs"
 
 
         ux_section "For More Information"
@@ -67,16 +49,10 @@ Available Commands:
   addmnt <source> <target>       Create bind mount
   show-mnt [path]                Display mount status
   claude-mount-all               Mount all Claude directories (skills, docs)
-  mount-help                     Show this help message
-
-Examples:
-  claude-mount-all                              Mount all Claude directories
-  show-mnt                                      View all mounts
-  show-mnt ~/.claude/skills                     View specific mount
-  addmnt $DOTFILES_ROOT/claude/docs ~/.claude/docs      Add new mount
 
 Notes:
   - Requires sudo for mount operations
+  - addmnt --help, show-mnt --help for details
 HELP
     fi
 }
@@ -316,7 +292,7 @@ mount_show() {
             if type ux_info >/dev/null 2>&1; then
                 ux_info "Not mounted: $mount_path"
             else
-                ux_bullet "(not mounted)" >&2
+                echo "(not mounted)" >&2
             fi
             return 1
         }
@@ -346,73 +322,11 @@ mount_show() {
     fi
 }
 
-# Mount all Claude directories (skills, agents, docs)
-# Reads mount pairs from claude/setup.sh bind mount configuration
-# and re-mounts any that are not currently mounted.
-claude_mount_all() {
-    local dotfiles_root="${DOTFILES_ROOT:-$HOME/dotfiles}"
-    local claude_source="${dotfiles_root}/claude"
-    local home_claude="${HOME}/.claude"
-    local mounted=0
-    local skipped=0
-
-    if type ux_header >/dev/null 2>&1; then
-        ux_header "Claude Bind Mount (remount all)"
-    else
-        echo "=== Claude Bind Mount (remount all) ==="
-    fi
-
-    # Define mount pairs: source -> target
-    # skills directory (primary, required)
-    _claude_mount_one "${claude_source}/skills" "${home_claude}/skills" "skills"
-
-    # Add more mount pairs here as needed:
-    # _claude_mount_one "${claude_source}/docs" "${home_claude}/docs" "docs"
-}
-
-# Internal: mount a single source->target pair if not already mounted
-_claude_mount_one() {
-    local source="$1"
-    local target="$2"
-    local label="$3"
-
-    if [ ! -d "$source" ]; then
-        if type ux_warning >/dev/null 2>&1; then
-            ux_warning "Source not found: $source"
-        fi
-        return 1
-    fi
-
-    mkdir -p "$target" 2>/dev/null
-
-    if _is_mounted "$target"; then
-        if type ux_info >/dev/null 2>&1; then
-            ux_info "Already mounted: $label ($target)"
-        fi
-        return 0
-    fi
-
-    if sudo mount --bind "$source" "$target" 2>/dev/null; then
-        if type ux_success >/dev/null 2>&1; then
-            ux_success "Mounted: $label ($source -> $target)"
-        fi
-        return 0
-    else
-        if type ux_error >/dev/null 2>&1; then
-            ux_error "Failed to mount: $label"
-        fi
-        return 1
-    fi
-}
-
-alias claude-mount-all='claude_mount_all'
-
 # ============================================================================
 # Backward Compatibility Aliases
 # ============================================================================
 alias addmnt='mount_add'
 alias show-mnt='mount_show'
-alias mount-help='mount_help'
 
 # Note: Functions are automatically exported in both bash and zsh
 # No need for explicit export declarations in POSIX-compatible scripts

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -315,6 +315,10 @@ claude_mount_all() {
     echo "Failed or already mounted: $failed_count"
 }
 
+alias claude-mount-all='claude_mount_all'
+alias claude-mount-skills='claude_mount_skills'
+alias claude-mount-docs='claude_mount_docs'
+
 # ═══════════════════════════════════════════════════════════════
 # Claude Code Marketplace Plugins Management
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Add `write-task-history` skill with auto-commit support (Step 7: `chore(task-history): YYYY-MM-DD summary`)
- Remove duplicate `claude_mount_all`/`_claude_mount_one` from `mount.sh` (already implemented in `integrations/claude.sh`)
- Clean up `mount-help`: remove self-reference and redundant Quick Examples section
- Add dash-form aliases (`claude-mount-all`, `claude-mount-skills`, `claude-mount-docs`)

## Changes
- `claude/skills/write-task-history/SKILL.md`: Add auto-commit step, fix fragile `git remote` sed pattern
- `shell-common/functions/mount.sh`: Remove 54 lines of duplicate code, fix `ux_bullet` bug in fallback path
- `shell-common/tools/integrations/claude.sh`: Add 3 dash-form aliases

## Context
Found by `/simplify` 3-agent parallel review (code reuse, quality, efficiency). Key finding: `_claude_mount_one()` was a near-copy of `mount_add()`, and `claude_mount_all()` was defined in two files causing a name collision.

## Test plan
- [ ] `mount-help` displays clean output without self-reference or examples section
- [ ] `claude-mount-all` remounts skills directory successfully
- [ ] `/write-task-history` generates file and auto-commits to task-history repo
- [ ] `show-mnt` displays mount status correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->