### PR TITLE
fix: use single-line YAML description in SKILL.md frontmatter

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -169,6 +169,7 @@ vim ~/dotfiles/claude/settings.json
 
 - **DO**: Create skills in `~/dotfiles/claude/skills/` for version control
 - **DO**: Use SKILL.md frontmatter format (name, description, allowed-tools)
+- **DO**: Write `description:` as a single line — NEVER use YAML multi-line scalars (`>`, `|`). Tools that parse frontmatter may only read the first line, causing descriptions to display as `>` instead of actual text.
 - **DO**: Keep SKILL.md under 500 lines
 - **DON'T**: Manually create files in `~/.claude/skills/` (managed by bind mount)
 - **DON'T**: Use symlinks for skills directory (use bind mount instead)

--- a/claude/skills/dissect-builtin/SKILL.md
+++ b/claude/skills/dissect-builtin/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: dissect-builtin
-description: >
-  Analyze and document Claude Code built-in skills. Load a built-in skill's
-  prompt via the Skill tool, explain its behavior in Korean, and save structured
-  documentation (README.md + PROMPT.md) to the dotfiles repository. Use when the
-  user wants to study, dissect, or document a built-in skill (e.g.,
-  "/dissect-builtin simplify", "/dissect-builtin loop"). Trigger on requests
-  like "내장 스킬 분석", "built-in skill 공부", or "스킬 해부".
+description: Analyze and document Claude Code built-in skills. Load a built-in skill's prompt via the Skill tool, explain its behavior in Korean, and save structured documentation (README.md + PROMPT.md) to the dotfiles repository. Use when the user wants to study, dissect, or document a built-in skill (e.g., "/dissect-builtin simplify", "/dissect-builtin loop"). Trigger on requests like "내장 스킬 분석", "built-in skill 공부", or "스킬 해부".
 ---
 
 # Dissect Built-in Skill

--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: write-task-history
-description: >
-  Write task history from current conversation to a daily task list file.
-  Generates two copy-paste-ready formats: JIRA ticket (plain text with section symbols)
-  and git PR description (markdown). Use this skill whenever the user wants to record,
-  document, or summarize completed work from the current session. Also trigger when the
-  user mentions task history, work log, JIRA ticket drafting from conversation context,
-  or preparing PR descriptions based on what was just done. Works across any project.
+description: Write task history from current conversation to a daily task list file. Generates two copy-paste-ready formats: JIRA ticket (plain text with section symbols) and git PR description (markdown). Use this skill whenever the user wants to record, document, or summarize completed work from the current session. Also trigger when the user mentions task history, work log, JIRA ticket drafting from conversation context, or preparing PR descriptions based on what was just done. Works across any project.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 


### PR DESCRIPTION
## Summary

- Fix SKILL.md `description:` field using YAML multi-line scalar (`>`) which causes `claude-skills` tool to display only `>` instead of actual description text
- Convert `dissect-builtin` and `write-task-history` to single-line format
- Add prevention rule to AGENTS.md: never use `>` or `|` in description field

## Test plan

- [ ] Run `claude-skills` and verify all skill descriptions display correctly
- [ ] Confirm no skill shows `>` as its description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->