### PR TITLE
fix: filter non-HTTP APT URIs in check-network

### DIFF
--- a/shell-common/tools/custom/check_network.sh
+++ b/shell-common/tools/custom/check_network.sh
@@ -87,7 +87,7 @@ detect_apt_target() {
         return 1
     fi
 
-    apt_uri="$(apt-get indextargets --format '$(URI)' 2>/dev/null | grep -E '^https?://' | head -n 1)"
+    apt_uri="$(apt-get indextargets --format '$(URI)' 2>/dev/null | grep -E -m 1 '^https?://')"
     if [ -n "$apt_uri" ]; then
         printf "%s\n" "$apt_uri"
         return 0

--- a/shell-common/tools/custom/check_network.sh
+++ b/shell-common/tools/custom/check_network.sh
@@ -87,7 +87,7 @@ detect_apt_target() {
         return 1
     fi
 
-    apt_uri="$(apt-get indextargets --format '$(URI)' 2>/dev/null | head -n 1)"
+    apt_uri="$(apt-get indextargets --format '$(URI)' 2>/dev/null | grep -E '^https?://' | head -n 1)"
     if [ -n "$apt_uri" ]; then
         printf "%s\n" "$apt_uri"
         return 0


### PR DESCRIPTION
## Summary
- `check-network apt` 테스트에서 `detect_apt_target`이 `file:` 스킴의 로컬 저장소 URI(예: cuDNN local repo)를 반환하여 curl이 실패하는 false failure 수정
- `apt-get indextargets` 결과에서 `http://` 또는 `https://`로 시작하는 URI만 필터링하도록 변경

## Test plan
- [ ] `file:` 스킴 APT 소스만 있는 환경에서 `check-network apt` 실행 → "Could not detect" 경고 출력 확인
- [ ] HTTP(S) APT 소스가 있는 환경에서 `check-network apt` 실행 → 정상 reachability 검사 확인
- [ ] `check-network` 전체 실행 시 APT 섹션 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->