### PR TITLE
refactor: rename pyenv aliases to install-py/uninstall-py

### DIFF
--- a/shell-common/functions/py_help.sh
+++ b/shell-common/functions/py_help.sh
@@ -22,8 +22,8 @@ py_help() {
     echo ""
 
     ux_section "Setup Tools"
-    ux_table_row "install-pyenv [version...]" "Install Script" "Install default or specific Python versions"
-    ux_table_row "uninstall-pyenv <version>" "pyenv uninstall" "Remove a specific Python version"
+    ux_table_row "install-py [version...]" "Install Script" "Install default or specific Python versions"
+    ux_table_row "uninstall-py <version>" "pyenv uninstall" "Remove a specific Python version"
     echo ""
 
     ux_section "Quick Workflow"

--- a/shell-common/functions/py_help.sh
+++ b/shell-common/functions/py_help.sh
@@ -22,8 +22,8 @@ py_help() {
     echo ""
 
     ux_section "Setup Tools"
-    ux_table_row "pyinstall [version...]" "Install Script" "Install default or specific Python versions"
-    ux_table_row "py-uninstall <version>" "pyenv uninstall" "Remove a specific Python version"
+    ux_table_row "install-pyenv [version...]" "Install Script" "Install default or specific Python versions"
+    ux_table_row "uninstall-pyenv <version>" "pyenv uninstall" "Remove a specific Python version"
     echo ""
 
     ux_section "Quick Workflow"

--- a/shell-common/tools/integrations/pyenv.sh
+++ b/shell-common/tools/integrations/pyenv.sh
@@ -1,36 +1,30 @@
 #!/bin/sh
-# shell-common/tools/external/pyenv.sh
-# Auto-generated from bash/app/pyenv.bash
+# shell-common/tools/integrations/pyenv.sh
 
 
 # pyenv의 루트 경로
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 
-# 인터랙티브 셸에서 pyenv hook 활성화
-# (pyenv shell, pyenv activate 같은 기능이 정상 동작하려면 필요)
+# pyenv 초기화 (인터랙티브 셸 hook + PATH)
 if command -v pyenv >/dev/null; then
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)" # pyenv-virtualenv 사용 시
-fi
-
-# pyenv PATH 초기화 (로그인 셸용)
-if command -v pyenv >/dev/null; then
-    eval "$(pyenv init --path)"
+    eval "$(pyenv init --path)"       # 로그인 셸용 PATH
 fi
 
 # Python 설치 (대화형 스크립트)
 py_install() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_python.sh" "$@"
 }
-alias install-pyenv='py_install'
+alias install-py='py_install'
 
 # 특정 Python 버전 제거
 py_uninstall() {
     local version="$1"
 
     if [ -z "$version" ]; then
-        ux_error "Usage: uninstall-pyenv <python_version>"
+        ux_error "Usage: uninstall-py <python_version>"
         return 1
     fi
 
@@ -57,4 +51,4 @@ py_uninstall() {
     fi
 }
 
-alias uninstall-pyenv='py_uninstall'
+alias uninstall-py='py_uninstall'

--- a/shell-common/tools/integrations/pyenv.sh
+++ b/shell-common/tools/integrations/pyenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/tools/external/pyenv.sh
 # Auto-generated from bash/app/pyenv.bash
 
@@ -20,16 +20,17 @@ if command -v pyenv >/dev/null; then
 fi
 
 # Python 설치 (대화형 스크립트)
-pyinstall() {
+py_install() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_python.sh" "$@"
 }
+alias install-pyenv='py_install'
 
 # 특정 Python 버전 제거
 py_uninstall() {
     local version="$1"
 
     if [ -z "$version" ]; then
-        ux_error "Usage: py-uninstall <python_version>"
+        ux_error "Usage: uninstall-pyenv <python_version>"
         return 1
     fi
 
@@ -56,4 +57,4 @@ py_uninstall() {
     fi
 }
 
-alias py-uninstall='py_uninstall'
+alias uninstall-pyenv='py_uninstall'


### PR DESCRIPTION
## Summary
- Rename `pyinstall`/`py-uninstall` aliases to `install-py`/`uninstall-py` for clarity — the install script sets up pyenv + Python versions together, not just pyenv
- Rename `pyinstall()` function to `py_install()` for snake_case consistency
- Consolidate duplicate `command -v pyenv` checks into single block (shell startup optimization)
- Fix stale comments (wrong file path, outdated "Auto-generated" note)

## Test plan
- [ ] Run `install-py --help` or `install-py` to verify alias works
- [ ] Run `uninstall-py` to verify usage message shows correct name
- [ ] Run `py-help` to verify help text shows `install-py`/`uninstall-py`
- [ ] Open new shell session to verify pyenv init loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->