### PR TITLE
refactor: apply UX rules to 30 help functions

### DIFF
--- a/shell-common/functions/bat_help.sh
+++ b/shell-common/functions/bat_help.sh
@@ -1,13 +1,6 @@
 #!/bin/sh
 # shell-common/functions/bat_help.sh
-# bat help function and documentation
-# Shared between bash and zsh
 
-# ═══════════════════════════════════════════════════════════════
-# bat Help and Documentation
-# ═══════════════════════════════════════════════════════════════
-
-# Display bat help and usage
 bat_help() {
     ux_header "bat - Cat Replacement with Syntax Highlighting"
 
@@ -15,91 +8,39 @@ bat_help() {
     ux_bullet "Cat replacement with syntax highlighting"
     ux_bullet "Supports 200+ languages and file formats"
     ux_bullet "Git integration - shows file changes in color"
-    ux_bullet "Line numbers, ranges, and paging support"
     ux_bullet "Automatic language detection from filename"
-    echo ""
 
     ux_section "Basic Syntax"
     ux_table_row "bat file.txt" "View file with syntax highlighting"
     ux_table_row "cat file.txt | bat" "View piped content"
     ux_table_row "bat file.txt file2.txt" "View multiple files"
-    ux_table_row "bat - < file.txt" "Read from stdin"
-    echo ""
 
     ux_section "Line Selection"
     ux_table_row "bat -n file.txt" "Show line numbers"
     ux_table_row "bat -r 5:10 file.txt" "Show lines 5-10"
     ux_table_row "bat -r 5: file.txt" "Show from line 5 to end"
     ux_table_row "bat -r :10 file.txt" "Show first 10 lines"
-    echo ""
 
     ux_section "Language & Theme"
     ux_table_row "bat -l python file.py" "Specify language explicitly"
     ux_table_row "bat --list-languages" "Show all supported languages"
     ux_table_row "bat --theme Monokai file.txt" "Use different color theme"
     ux_table_row "bat --list-themes" "Show all available themes"
-    echo ""
 
     ux_section "Display Control"
     ux_table_row "bat --plain file.txt" "Plain output (no decorations)"
     ux_table_row "bat --color=never file.txt" "Disable colors"
     ux_table_row "bat --color=always file.txt" "Force colors"
     ux_table_row "bat --style=numbers file.txt" "Show only line numbers"
-    echo ""
 
     ux_section "Git Integration"
     ux_table_row "bat file.txt" "Shows git changes (green/red lines)"
-    ux_bullet "Green lines - added in working directory"
-    ux_bullet "Red lines - modified in working directory"
-    ux_bullet "Blue lines - deleted in working directory"
-    echo ""
 
     ux_section "Advanced Options"
     ux_table_row "bat -A file.txt" "Show invisible characters"
     ux_table_row "bat -t file.txt" "Show tabs as visual indicators"
     ux_table_row "bat --tabs 4 file.txt" "Set tab width to 4 spaces"
     ux_table_row "bat -H file.txt" "Highlight specific lines"
-    echo ""
-
-    ux_section "Practical Examples"
-    echo ""
-    ux_info "View source code with line numbers:"
-    ux_bullet "bat -n src/main.rs - View Rust file with syntax highlighting"
-    ux_bullet "bat -n config/app.json - View JSON with colors"
-    ux_bullet "bat -n script.sh - View shell script with colors"
-    echo ""
-
-    ux_info "View specific sections:"
-    ux_bullet "bat -r 1:30 file.txt - View first 30 lines"
-    ux_bullet "bat -r 100:150 file.txt - View lines 100-150"
-    ux_bullet "bat -r 1:5,10:15 file.txt - View multiple ranges"
-    echo ""
-
-    ux_info "Integration with other tools:"
-    ux_bullet "find . -name '*.py' | xargs bat - View all Python files"
-    ux_bullet "grep 'pattern' file.txt | bat --plain - Highlight grep results"
-    ux_bullet "git diff | bat - View git diff with colors"
-    echo ""
-
-    ux_info "Alias for common usage:"
-    ux_bullet "alias cat='bat' - Replace cat completely"
-    ux_bullet "bat --paging=never file.txt - View without paging"
-    echo ""
-
-    ux_section "Comparison with cat"
-    ux_bullet "cat: Basic output, no formatting"
-    ux_bullet "bat: Syntax highlighting, git awareness, better defaults"
-    ux_bullet "cat: Available everywhere"
-    ux_bullet "bat: Feature-rich, faster for code review"
-    echo ""
-
-    ux_section "Color Themes"
-    ux_info "Popular themes:"
-    ux_bullet "Monokai Extended - Dark theme, vibrant colors"
-    ux_bullet "Dracula - Dark theme, popular"
-    ux_bullet "GitHub - Light theme, GitHub-style colors"
-    ux_bullet "Solarized (dark/light) - Popular color scheme"
-    echo ""
 
     ux_section "Configuration"
     ux_info "Create ~/.config/bat/config for default options:"
@@ -107,31 +48,12 @@ bat_help() {
     ux_bullet "--style=numbers - Always show line numbers"
     ux_bullet "--tabs=4 - Set tab width"
     ux_bullet "--paging=auto - Auto pagination"
-    echo ""
-
-    ux_section "File Format Detection"
-    ux_bullet "bat automatically detects language from file extension"
-    ux_bullet "Supports .py, .rs, .js, .go, .c, .cpp, .java, etc."
-    ux_bullet "Use -l flag to override language detection"
-    ux_bullet "Use --list-languages to see all supported languages"
-    echo ""
-
-    ux_section "Troubleshooting"
-    ux_bullet "Not showing colors? Check TERM environment variable"
-    ux_bullet "Theme not found? List available: bat --list-themes"
-    ux_bullet "Wrong language detected? Use -l to specify language"
-    ux_bullet "Git changes not showing? Make sure file is in git repository"
-    echo ""
 
     ux_section "Related Help"
     ux_bullet "Install bat: ${UX_BOLD}install-bat${UX_RESET}"
     ux_bullet "Text search: ${UX_BOLD}ripgrep-help${UX_RESET}"
     ux_bullet "File finder: ${UX_BOLD}fd-help${UX_RESET}"
     ux_bullet "Fuzzy finder: ${UX_BOLD}fzf-help${UX_RESET}"
-    echo ""
 }
 
-# Naming Convention: Function uses underscore, alias provides dash format
-# Users call: bat-help (dash format)
-# Function: bat_help (underscore format - POSIX compatible)
 alias bat-help='bat_help'

--- a/shell-common/functions/cc_help.sh
+++ b/shell-common/functions/cc_help.sh
@@ -1,20 +1,16 @@
 #!/bin/sh
 # shell-common/functions/cc_help.sh
-# ccHelp - shared between bash and zsh
 
 cc_help() {
     ux_header "Claude Code Usage Commands"
 
     ux_section "Installation"
     ux_bullet "Global prefix: npm install -g ccusage --prefix=\$HOME/.npm-global"
-    echo ""
 
-    ux_section "Quick Commands (Aliases)"
+    ux_section "Commands"
     ux_table_row "ccd" "ccusage daily --breakdown" "Token usage by model"
     ux_table_row "ccs" "ccusage session --sort tokens" "Session analysis"
     ux_table_row "ccb" "ccusage blocks --live" "Cache hit ratio (live)"
-    echo ""
 }
 
-# Alias for cc-help format (using dash instead of underscore)
 alias cc-help='cc_help'

--- a/shell-common/functions/claude_help.sh
+++ b/shell-common/functions/claude_help.sh
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/functions/claude_help.sh
-# claudeHelp - shared between bash and zsh
 
 claude_help() {
     # Load UX library (unified library at shell-common/tools/ux_lib/)
@@ -14,13 +13,11 @@ claude_help() {
     ux_table_row "claude mcp add <name> ..." "Add MCP server" ""
     ux_table_row "claude mcp remove <name>" "Remove MCP server" ""
 
-
     ux_section "Recommended MCP Servers"
     ux_bullet "Playwright MCP: Web browser automation"
     ux_bullet "Install: ${UX_SUCCESS}claude mcp add playwright --transport stdio -- npx -y @playwright/mcp@latest${UX_RESET}"
     ux_bullet "Sequential Thinking MCP: Logical analysis"
     ux_bullet "Install: ${UX_SUCCESS}claude mcp add sequential-thinking --transport stdio -- npx -y @modelcontextprotocol/server-sequential-thinking${UX_RESET}"
-
 
     ux_section "Setup & Requirements"
     ux_table_row "clinstall" "Install Claude Code CLI" ""
@@ -28,18 +25,10 @@ claude_help() {
     ux_table_row "claude_init" "Initialize config & skills" ""
     ux_table_row "claude_edit_settings" "Edit settings.json" ""
 
-
-    ux_section "Workflow Patterns"
-    ux_bullet "Plan mode (recommended): ${UX_SUCCESS}claude${UX_RESET} → plan → approve → execute"
-    ux_bullet "Test workflow: ${UX_SUCCESS}cltest \"test description\"${UX_RESET}}"
-    ux_bullet "Skip permissions (caution): ${UX_SUCCESS}clskip \"request\"${UX_RESET}"
-
-
     ux_section "Sandbox Mode"
     ux_info "Use in Claude conversation: ${UX_SUCCESS}/sandbox${UX_RESET}"
     ux_bullet "Select Auto-allow mode"
     ux_bullet "pytest, git, npm auto-approved"
-
 
     ux_section "Configuration"
     ux_info "Settings file: ${DOTFILES_ROOT:-$HOME/dotfiles}/claude/settings.json"
@@ -47,7 +36,6 @@ claude_help() {
     ux_bullet "Auto-allow: pytest, ruff, mypy, tox"
     ux_bullet "Block: .env, ~/.aws, ~/.ssh"
     ux_bullet "Block commands: rm -rf, sudo rm"
-
 
     ux_section "Statusline Display"
     ux_info "Real-time session information in Claude Code status bar"
@@ -57,11 +45,9 @@ claude_help() {
     ux_bullet "📊 Context usage percentage + weekly percentage"
     ux_bullet "💰 Session cost (Green <\$5, Orange \$5-20, Red >\$20)"
 
-
     ux_section "Skills Management"
     ux_table_row "claude-skills" "List available Claude Code skills" ""
     ux_info "Skills location: ${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills/"
-
 }
 
 # Function to list Claude Code skills
@@ -77,10 +63,8 @@ get_claude_skills() {
     # Load UX library if available
     if command -v ux_header >/dev/null 2>&1; then
         ux_header "Claude Code Skills"
-
     else
         ux_info "=== Claude Code Skills ==="
-
     fi
 
     # Track if any skills found
@@ -125,14 +109,10 @@ get_claude_skills() {
         return 0
     fi
 
-
     if command -v ux_info >/dev/null 2>&1; then
-        ux_info "Skills location: $skills_dir"
-    else
         ux_info "Skills location: $skills_dir"
     fi
 }
 
-# Alias for claude-help format (using dash instead of underscore)
 alias claude-help='claude_help'
 alias claude-skills='get_claude_skills'

--- a/shell-common/functions/cli_help.sh
+++ b/shell-common/functions/cli_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/cli_help.sh
-# cliHelp - shared between bash and zsh
 
 cli_help() {
     ux_header "Custom Project CLI Help"
@@ -9,17 +8,14 @@ cli_help() {
     ux_table_row "dotfiles" "✨" "${REPO_DOTFILES_URL}"
     ux_table_row "FinRx" "💰" "${REPO_FINRX_URL}"
     ux_table_row "dmc-playground" "📚" "${REPO_DMC_PG_URL}"
-    echo ""
 
     ux_section "Service URLs"
     ux_table_row "DEV" "${SMT_DEV_URL} (port ${SMT_DEV_PORT})" "smithery-playground"
     ux_table_row "TEST" "${SMT_TEST_URL} (port ${SMT_TEST_PORT})" "smithery-playground"
     ux_table_row "PROD" "${SMT_PROD_URL} (port ${SMT_PROD_PORT})" "smithery-playground"
-    echo ""
 
     ux_section "FinRx Commands"
     ux_table_row "run_fr_cli" "python ./src/ticker_library/cli/cli.py" "Run CLI"
-    echo ""
 
     ux_section "dmc-playground Commands"
     ux_table_row "run_bes" "Backend dev server (reload)" "DEV: ${DEV_API_URL}"
@@ -27,20 +23,16 @@ cli_help() {
     ux_table_row "run_pbes" "Backend prod server (no reload)" "PROD: ${PROD_API_URL}"
     ux_table_row "run_api_cli [URL]" "API CLI (default: DEV)" "Query/test API"
     ux_table_row "run_db_cli [URL]" "DB CLI (default: DEV)" "Query/test database"
-    echo ""
 
     ux_section "smithery-playground Commands"
     ux_table_row "run_smt" "Dev server (reload)" "URL: ${SMT_DEV_URL}"
     ux_table_row "run_tsmt" "Test server (reload)" "URL: ${SMT_TEST_URL}"
     ux_table_row "run_psmt" "Prod server (no reload)" "URL: ${SMT_PROD_URL}"
-    echo ""
 
     ux_section "Tips"
     ux_bullet "Run from project root (current: ${PROJECT_ROOT})"
     ux_bullet "Recommend uv/pyproject-based venv (uvs/uvd)"
     ux_bullet "Never use --reload in production"
-    echo ""
 }
 
-# Alias for cli-help format (using dash instead of underscore)
 alias cli-help='cli_help'

--- a/shell-common/functions/codex_help.sh
+++ b/shell-common/functions/codex_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/codex_help.sh
-# codexHelp - shared between bash and zsh
 
 codex_help() {
     ux_header "Codex Quick Commands"
@@ -9,23 +8,18 @@ codex_help() {
     ux_table_row "cx" "codex" "Base command"
     ux_table_row "cxhelp" "codex --help" "Show help"
     ux_table_row "cxver" "codex --version" "Check version"
-    echo ""
 
     ux_section "Installation & Setup"
     ux_table_row "cxinstall" "Install Script" "Install Codex CLI"
     ux_table_row "cxuninstall" "Uninstall Script" "Remove Codex CLI"
-    echo ""
 
     ux_section "Interactive Mode"
     ux_table_row "cx" "codex" "Start interactive"
     ux_table_row "cx prompt" "codex prompt" "Run with prompt"
-    echo ""
 
     ux_section "Tips"
     ux_bullet "Config: ~/.codex/ or ~/.config/codex/"
     ux_bullet "Auth: Use 'cx' to authenticate"
-    echo ""
 }
 
-# Alias for codex-help format (using dash instead of underscore)
 alias codex-help='codex_help'

--- a/shell-common/functions/dir_help.sh
+++ b/shell-common/functions/dir_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/dir_help.sh
-# dirHelp - shared between bash and zsh
 
 dir_help() {
     ux_header "Directory Navigation"
@@ -10,7 +9,6 @@ dir_help() {
     ux_table_row "cd-dot" "\$DOTFILES_ROOT" "Dotfiles repository root"
     ux_table_row "cd-down" "\$HOME/downloads" "Downloads folder"
     ux_table_row "cd-work" "\$HOME/workspace" "Workspace root"
-    echo ""
 
     ux_section "Windows (WSL)"
     ux_table_header "Command" "Destination" "Purpose"
@@ -20,7 +18,6 @@ dir_help() {
     ux_table_row "cd-wpicture" "Windows Pictures" "Photo library"
     ux_table_row "cd-tilnote" "Obsidian TilNote" "TilNote vault"
     ux_table_row "cd-obsidian" "Obsidian vault" "Default vault in WSL"
-    echo ""
 
     ux_section "PARA Method"
     ux_table_header "Command" "Destination" "Purpose"
@@ -31,21 +28,10 @@ dir_help() {
     ux_table_row "cd-vault" "\$HOME/para/area/vault" "Vault under Areas"
     ux_table_row "cd-resource" "\$HOME/para/resource" "Reference materials"
     ux_table_row "cd-archive" "\$HOME/para/archive" "Archived items"
-    echo ""
 
     ux_section "Windows Copy Utility"
     ux_table_header "Command" "Usage" "Purpose"
     ux_table_row "cp_wdown" "cp_wdown [options] <file...>" "Copy from Windows Downloads into WSL (run -h for details)"
-    echo ""
-
-    ux_section "Quick Examples"
-    ux_table_header "Command" "Description"
-    ux_table_row "cd-dot" "Jump to dotfiles repository"
-    ux_table_row "cd-obsidian" "Open Obsidian vault"
-    ux_table_row 'cp_wdown "*.pdf"' "Copy all PDF files from Windows Downloads"
-    ux_table_row "cp_wdown -r folder" "Copy an entire folder"
-    echo ""
 }
 
-# Alias for dash format (interactive shells)
 alias dir-help='dir_help'

--- a/shell-common/functions/docker_help.sh
+++ b/shell-common/functions/docker_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/docker_help.sh
-# dockerHelp - shared between bash and zsh
 
 docker_help() {
     ux_header "Docker / Docker Compose Quick Commands"
@@ -12,7 +11,6 @@ docker_help() {
     ux_table_row "dcd" "docker compose down" "Stop & remove"
     ux_table_row "dcl" "logs <svc>" "Smart logs (service/container)"
     ux_table_row "dce" "exec <svc> <cmd>" "Execute command"
-    echo ""
 
     ux_section "Docker Compose Extra"
     ux_table_row "dcps" "docker compose ps" "Status"
@@ -21,7 +19,6 @@ docker_help() {
     ux_table_row "dcdv" "down -v" "Stop & remove volumes"
     ux_table_row "dcstop" "stop" "Stop containers"
     ux_table_row "dcstart" "start" "Start containers"
-    echo ""
 
     ux_section "Docker Basics"
     ux_table_row "dps" "docker ps" "Running containers"
@@ -33,7 +30,6 @@ docker_help() {
     ux_table_row "drmi" "docker rmi" "Remove image"
     ux_table_row "dlogs" "docker logs -f" "Follow logs"
     ux_table_row "dinspect" "docker inspect" "Inspect object"
-    echo ""
 
     ux_section "Resource Management"
     ux_table_row "ddf" "system df" "Disk usage"
@@ -43,7 +39,6 @@ docker_help() {
     ux_table_row "dvol_rm" "volume rm" "Remove volume"
     ux_table_row "dnetwork_prune" "network prune" "Cleanup networks"
     ux_table_row "dbuild_prune" "builder prune" "Cleanup build cache"
-    echo ""
 
     ux_section "Utilities"
     ux_table_row "dbash" "dbash <name>" "Shell access (bash/sh)"
@@ -54,11 +49,8 @@ docker_help() {
     ux_table_row "dexport" "Export all" "Backup to tar files"
     ux_table_row "dinstall" "Install script" "Install Docker on WSL"
     ux_table_row "dproxy_setup" "Proxy setup" "Corporate proxy config"
-    echo ""
 
     ux_info "Note: 'docker compose' (V2) is used by default."
-    echo ""
 }
 
-# Alias for docker-help format (using dash instead of underscore)
 alias docker-help='docker_help'

--- a/shell-common/functions/dot_help.sh
+++ b/shell-common/functions/dot_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/dot_help.sh
-# dot_help - Dotfiles project information and setup guidance
 
 # Load UX library if not already loaded (POSIX portable)
 if ! type ux_header >/dev/null 2>&1; then
@@ -29,21 +28,17 @@ dot_help() {
     ux_bullet "Cross-platform support (Windows WSL, macOS, Linux)"
     ux_bullet "Environment-aware setup (Internal/External PC)"
     ux_bullet "Automated Claude Code skills bind mounting"
-    echo ""
 
     ux_section "Setup Information"
     ux_bullet "Initial setup: ./setup.sh"
     ux_bullet "Maintenance: scripts/maintenance/fix_crlf_issue.sh"
     ux_bullet "Diagnostic: shell-common/tools/custom/check_ux_consistency.sh"
-    echo ""
 
     ux_section "Claude Mount Status"
     ux_info "Claude environment directories automatically configured"
-    echo ""
 
     # Show all mount status using dedicated function
     show_mnt 2>/dev/null
-    echo ""
 
     ux_section "Key Features"
     ux_numbered 1 "Shell separation: bash/ and zsh/ directories"
@@ -51,21 +46,17 @@ dot_help() {
     ux_numbered 3 "Help system: Type help or [function]-help for info"
     ux_numbered 4 "Git attributes: Automatic CRLF/LF line ending management"
     ux_numbered 5 "Skills integration: Claude Code tools auto-mounted"
-    echo ""
 
     ux_section "Useful Commands"
     ux_table_row "my-help"       "List all available help topics"
     ux_table_row "src"           "Reload shell configuration"
     ux_table_row "dot"           "Navigate to dotfiles directory"
     ux_table_row "ux-help"       "View UX guidelines and semantic colors"
-    echo ""
 
     ux_section "Documentation"
     ux_info "Complete setup guide: ./SETUP_GUIDE.md"
     ux_info "Project structure: ./AGENTS.md"
     ux_info "UX standards: ./shell-common/tools/ux_lib/UX_GUIDELINES.md"
-    echo ""
 }
 
-# Alias for dot-help format (using dash instead of underscore)
 alias dot-help='dot_help'

--- a/shell-common/functions/dproxy_help.sh
+++ b/shell-common/functions/dproxy_help.sh
@@ -1,54 +1,22 @@
 #!/bin/sh
 # shell-common/functions/dproxy_help.sh
-# dproxyHelp - shared between bash and zsh
 
 dproxy_help() {
     ux_header "Docker Corporate Proxy Setup Guide"
 
-    ux_section "1. Config File Location"
+    ux_section "Commands"
+    ux_table_row "dproxy_setup" "Interactive setup script" "Configure Docker proxy"
+    ux_table_row "dproxy_show" "Show current proxy config" "Display active settings"
+    ux_table_row "dproxy-help" "Show this help" ""
+
+    ux_section "Config File"
     ux_info "/etc/systemd/system/docker.service.d/http-proxy.conf"
-    echo ""
 
-    ux_section "2. Check Current Config"
-    ux_bullet "Command: systemctl show --property=Environment docker"
-    ux_info "Output: Environment=HTTP_PROXY=... HTTPS_PROXY=... NO_PROXY=..."
-    echo ""
-
-    ux_section "3. View Config File"
-    ux_bullet "cat /etc/systemd/system/docker.service.d/http-proxy.conf"
-    echo ""
-
-    ux_section "4. Edit Config"
-    ux_bullet "sudo nano /etc/systemd/system/docker.service.d/http-proxy.conf"
-    ux_success "Then reload:"
-    ux_bullet "sudo systemctl daemon-reload"
-    ux_bullet "sudo systemctl restart docker"
-    echo ""
-
-    ux_section "5. Remove Config"
-    ux_bullet "sudo rm -f /etc/systemd/system/docker.service.d/http-proxy.conf"
-    ux_success "Then reload:"
-    ux_bullet "sudo systemctl daemon-reload"
-    ux_bullet "sudo systemctl restart docker"
-    echo ""
-
-    ux_section "6. Test Connection"
-    ux_bullet "docker pull alpine:latest"
-    echo ""
-
-    ux_section "7. Reset All (Danger)"
-    ux_warning "Deletes all Docker drop-in configs:"
-    ux_bullet "sudo rm -rf /etc/systemd/system/docker.service.d/"
-    echo ""
-
-    ux_divider
-    echo ""
-    ux_info "Quick Commands:"
-    ux_bullet "${UX_SUCCESS}dproxy_setup${UX_RESET} : Interactive setup script"
-    ux_bullet "${UX_SUCCESS}dproxy-help${UX_RESET}  : Show this help"
-    ux_bullet "${UX_SUCCESS}dproxy_show${UX_RESET}  : Show current proxy config"
-    echo ""
+    ux_section "Quick Reference"
+    ux_bullet "Check config: systemctl show --property=Environment docker"
+    ux_bullet "Edit config: sudo nano /etc/systemd/system/docker.service.d/http-proxy.conf"
+    ux_bullet "Apply changes: sudo systemctl daemon-reload && sudo systemctl restart docker"
+    ux_bullet "Test connection: docker pull alpine:latest"
 }
 
-# Alias for dproxy-help format (using dash instead of underscore)
 alias dproxy-help='dproxy_help'

--- a/shell-common/functions/du_help.sh
+++ b/shell-common/functions/du_help.sh
@@ -1,20 +1,16 @@
 #!/bin/sh
 # shell-common/functions/du_help.sh
-# duHelp - shared between bash and zsh
 
 du_help() {
     ux_header "Disk Usage Helper (du aliases)"
 
-    ux_section "Aliases"
+    ux_section "Commands"
     ux_table_row "dus" "du -sh ." "Current dir summary"
     ux_table_row "dud" "du -sh *" "Subdir summary (sorted)"
     ux_table_row "dsql" "du .sql" "SQL dump sizes"
     ux_table_row "dubig" "du top 10" "Top 10 largest items"
-    echo ""
 
     ux_info "Tip: -h option means 'human-readable' (K, M, G)"
-    echo ""
 }
 
-# Alias for du-help format (using dash instead of underscore)
 alias du-help='du_help'

--- a/shell-common/functions/gc_help.sh
+++ b/shell-common/functions/gc_help.sh
@@ -1,24 +1,12 @@
 #!/bin/sh
 # shell-common/functions/gc_help.sh
-# gc Help - shared between bash and zsh
 
 gc_help() {
     ux_header "git-crypt (Transparent Git encryption)"
 
     ux_section "설치"
     ux_table_row "gcinstall" "설치 스크립트" "apt-get 기반 설치"
-    ux_table_row "패키지" "git-crypt" "apt-get install git-crypt"
     ux_bullet "필수: git, gpg, GPG 키"
-
-
-    ux_section "기본 워크플로 (자동 암호화/복호화)"
-    ux_table_row "1. 초기화" "gci (git-crypt init)" "리포지토리 설정"
-    ux_table_row "2. GPG 키 추가" "gcaddme (자동) ⭐" "내 GPG 키 자동 찾기 & 추가"
-    ux_table_row "   또는" "gcadduser KEY_ID (수동)" "GPG Key ID로 직접 추가"
-    ux_table_row "3. .gitattributes" "gc_encrypt_env (자동)" ".env 암호화 설정"
-    ux_table_row "4. Commit & Push" "git add && git commit && git push" "자동 암호화됨"
-    ux_table_row "5. Clone & Pull" "git clone && gcunlock" "자동 복호화됨"
-
 
     ux_section "Alias"
     ux_table_row "gci" "git-crypt init" "초기화"
@@ -28,9 +16,8 @@ gc_help() {
     ux_table_row "gcunlock" "git-crypt unlock" "수동 복호화 (해제)"
     ux_table_row "gcls" "git-crypt status -f" "암호화된 파일 목록"
 
-
     ux_section "Helper Functions"
-    ux_table_row "gcpush" "gc_push_env" ".env 암호화 & Push 🚀 (올인원, 가장 쉬움)"
+    ux_table_row "gcpush" "gc_push_env" ".env 암호화 & Push 🚀 (올인원)"
     ux_table_row "gcsetup" "gc_setup" "대화형 초기 설정 도우미"
     ux_table_row "gcaddme" "gc_addme" "내 GPG 키 자동 찾기 & 추가"
     ux_table_row "gc_encrypt_env" "암호화 .env" ".env 파일 암호화 퀵 스타트"
@@ -39,88 +26,7 @@ gc_help() {
     ux_table_row "gc_cache_status" "캐싱 상태" "GPG agent 캐싱 상태 확인"
     ux_table_row "gcbackup" "gc_backup_key" "GPG 개인키 백업 (다른 PC 이동용)"
     ux_table_row "gcrestore" "gc_restore_key" "GPG 개인키 복원 (다른 PC에서)"
-    ux_table_row "gcnewpc" "gc_setup_new_pc" "다른 PC 올인원 설정 (가장 쉬움)"
-
-
-    ux_section "git-secret과의 비교"
-    ux_bullet "${bold}git-crypt${reset}           ${bold}git-secret${reset}"
-    ux_bullet "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    ux_bullet "자동 암호화/복호화    수동 hide/reveal 필요"
-    ux_bullet ".gitattributes       .gitsecret/ 디렉토리"
-    ux_bullet "투명한 통합           명시적 명령어"
-    ux_bullet "git add 시 암호화    git secret hide 실행"
-    ux_bullet "git pull 시 복호화   git secret reveal 실행"
-
-
-    ux_section "다른 PC에서 사용하기 (개인 프로젝트)"
-
-    ux_bullet "${bold}⭐ 한 방에 설정 (올인원, 가장 쉬움)${reset}"
-    ux_bullet "════════════════════════════════════════════════════"
-    ux_bullet "  ${bold}git clone <repo> && cd dotfiles && bash shell-common/tools/custom/setup_new_pc.sh${reset}"
-
-    ux_bullet "  또는 dotfiles 적용 후: ${bold}gcnewpc${reset}"
-
-    ux_bullet "${green}→ 모든 단계를 인터랙티브하게 자동 진행!${reset}"
-    ux_bullet "  (git-crypt 설치 → GPG 복원 → 캐싱 설정 → unlock → 확인)"
-
-    ux_bullet "${bold}수동 설정 (단계별 제어)${reset}"
-    ux_bullet "────────────────────────────────────"
-    ux_bullet "${bold}현재 PC:${reset}"
-    ux_bullet "  1. gcbackup              # GPG 키 백업 + 대칭키 암호화"
-    ux_bullet "  2. git add .secrets/ && git commit && git push"
-
-    ux_bullet "${bold}다른 PC:${reset}"
-    ux_bullet "  1. git clone <repo> && cd dotfiles"
-    ux_bullet "  2. gcinstall             # git-crypt 설치"
-    ux_bullet "  3. gcrestore             # GPG 키 복원"
-    ux_bullet "  4. gcsetup-cache         # 캐싱 설정 (선택)"
-    ux_bullet "  5. git-crypt unlock      # .env 복호화"
-
-
-    ux_section "여러 프로젝트에서 사용하기 (개인 프로젝트)"
-
-    ux_bullet "${bold}⭐ 가장 쉬운 방법 (각 프로젝트마다)${reset}"
-    ux_bullet "════════════════════════════════════════════════════"
-    ux_bullet "  ${bold}cd ~/project-A && gcpush${reset}"
-    ux_bullet "  ${bold}cd ~/project-B && gcpush${reset}"
-
-    ux_bullet "${green}→ 한 명령어로 자동 진행!${reset}"
-    ux_bullet "  (git-crypt init → GPG 추가 → .gitattributes → commit → push)"
-
-
-    ux_section "Team 프로젝트에 Join하기"
-
-    ux_bullet "${bold}상황${reset}: 다른 팀원이 만든 프로젝트에 처음 join"
-
-    ux_bullet "${bold}Step 1️⃣  (프로젝트 소유자가 실행 - 1회만)${reset}"
-    ux_bullet "─────────────────────────────────"
-    ux_bullet "  1. 당신의 GPG 공개키 받기:"
-    ux_bullet "     ${bold}당신: gpg --export YOUR_EMAIL | 프로젝트 소유자에게 전달${reset}"
-
-    ux_bullet "  2. 소유자가 repo에서 add-gpg-user 실행:"
-    ux_bullet "     ${bold}소유자: git-crypt add-gpg-user YOUR_GPG_KEY_ID${reset}"
-    ux_bullet "     ${bold}소유자: git add .git-crypt/ && git commit && git push${reset}"
-
-    ux_bullet "${bold}Step 2️⃣  (당신이 이후 실행)${reset}"
-    ux_bullet "──────────────────────────────────"
-    ux_bullet "  ${bold}git clone <repo> && cd <repo>${reset}"
-    ux_bullet "  ${bold}git pull${reset}"
-    ux_bullet "  ${bold}git-crypt unlock${reset}"
-    ux_bullet "  ${bold}cat .env  # 성공 확인${reset}"
-
-
-    ux_section "Symmetric Key로 Join (소유자가 key 제공)"
-
-    ux_bullet "${bold}Step 1️⃣  (프로젝트 소유자가 1회만)${reset}"
-    ux_bullet "─────────────────────────────────"
-    ux_bullet "  ${bold}git-crypt export-key ~/repo-key.txt${reset}"
-    ux_bullet "  👉 이 파일을 안전하게 당신에게 전달"
-
-    ux_bullet "${bold}Step 2️⃣  (당신이 받은 후)${reset}"
-    ux_bullet "──────────────────────────────"
-    ux_bullet "  ${bold}git clone <repo> && cd <repo>${reset}"
-    ux_bullet "  ${bold}git-crypt unlock ~/repo-key.txt${reset}"
-
+    ux_table_row "gcnewpc" "gc_setup_new_pc" "다른 PC 올인원 설정"
 
     ux_section "Tips"
     ux_bullet ".env는 .gitignore에 추가하되, .gitattributes로 암호화"
@@ -128,9 +34,4 @@ gc_help() {
     ux_bullet "팀원 추가 시 각자의 GPG 공개키로 add-gpg-user 실행"
     ux_bullet "암호화 상태 확인: gcstatus 또는 gcls"
     ux_bullet "GPG passphrase 캐싱: gcsetup-cache (24시간 동안 재입력 불필요)"
-    ux_bullet ".gitattributes 예시:"
-    ux_bullet "  .env filter=git-crypt diff=git-crypt"
-    ux_bullet "  *.secret filter=git-crypt diff=git-crypt"
-    ux_bullet "  secrets/* filter=git-crypt diff=git-crypt"
-
 }

--- a/shell-common/functions/gemini_help.sh
+++ b/shell-common/functions/gemini_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/gemini_help.sh
-# geminiHelp - shared between bash and zsh
 
 gemini_help() {
     ux_header "Gemini CLI Quick Commands"
@@ -11,18 +10,14 @@ gemini_help() {
     ux_table_row "gpro" "gemini --model pro" "Use Pro model"
     ux_table_row "gver" "gemini --version" "Check version"
     ux_table_row "ghelp" "gemini --help" "Gemini Help"
-    echo ""
 
     ux_section "Installation & Setup"
     ux_table_row "ginstall" "Install Script" "Install Gemini CLI"
     ux_table_row "guninstall" "Uninstall Script" "Remove Gemini CLI"
-    echo ""
 
     ux_section "Tips"
     ux_bullet "Auth via web login (no API key file needed)"
     ux_bullet "Use 'ghelp' for detailed CLI options"
-    echo ""
 }
 
-# Alias for gemini-help format (using dash instead of underscore)
 alias gemini-help='gemini_help'

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/git_help.sh
-# gitHelp - shared between bash and zsh
 
 git_help() {
     ux_header "Git Quick Commands"
@@ -17,7 +16,6 @@ git_help() {
     ux_table_row "grs" "git restore" "Discard changes in file"
     ux_table_row "gb" "git branch" "List branches"
     ux_table_row "grmc" "git rm --cached" "Unstage, keep file"
-    echo ""
 
     ux_section "Fetch & Sync"
     ux_table_row "gf [remote]" "gf / gf u / gf <name>" "Fetch & prune (default: origin, u=upstream)"
@@ -25,21 +23,18 @@ git_help() {
     ux_table_row "gfa" "git fetch --all" "Fetch all & prune"
     ux_table_row "gsw" "git switch -c" "Switch to remote branch"
     ux_table_row "gr" "git remote -v" "List remotes"
-    echo ""
 
     ux_section "Logs"
     ux_table_row "gl" "git-log" "Graph log (default 11)"
     ux_table_row "gl1" "log --oneline" "One-line graph log"
     ux_table_row "gl2" "git-log2" "Alternative log format"
     ux_table_row "glref" "log ref/main" "Ref log for main"
-    echo ""
 
     ux_section "Upstream"
     ux_table_row "gupa" "remote add upstream" "Add upstream remote"
     ux_table_row "gupdel" "gupdel <remote>" "Remove remote"
     ux_table_row "glum" "git-log-upstream" "Upstream main log"
     ux_table_row "glub" "glub [branch]" "Upstream branch log"
-    echo ""
 
     ux_section "Branch Configuration"
     ux_table_row "gset-main" "set-upstream main" "Track origin/main"
@@ -47,39 +42,29 @@ git_help() {
     ux_table_row "gset" "gset [branch]" "Track origin/[branch]"
     ux_table_row "gprune" "git-prune-remote <remote>" "Delete all branches except main"
     ux_table_row "git-clean-local" "git_clean_local" "Delete local branches (keeps: main + current)"
-    echo ""
 
     ux_section "Cherry-pick"
     ux_table_row "gcp" "gcp <commit>..." "Cherry-pick commits"
     ux_table_row "gcp_theirs" "gcp_theirs <commit>..." "Cherry-pick with -X theirs (incoming)"
     ux_table_row "gcp_ours" "gcp_ours <commit>..." "Cherry-pick with -X ours (current)"
-    # ux_table_row "gcpa" "git cherry-pick --abort" "Abort cherry-pick operation"
-    # ux_table_row "gcpc" "git cherry-pick --continue" "Continue cherry-pick after resolving conflicts"
     ux_table_row "gcp_author" "gcp_author <range> [author]" "Cherry-pick by author"
     ux_table_row "gcp_scan" "gcp_scan [base] [src] [--author=<name|all>]" "Compare & pick missing (default: main <- upstream/main, author=dEitY719)"
-    echo ""
 
     ux_section "Cherry-pick -X (Merge Strategy)"
     ux_bullet "gcp_theirs: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_WARNING}incoming(cherry-pick되는 커밋의 변경)${UX_RESET} 선택"
     ux_bullet "gcp_ours: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_SUCCESS}current branch(현재 브랜치의 변경)${UX_RESET} 선택"
-    ux_bullet "예: gcp_theirs abc1234 def5678 - ${UX_MUTED}두 커밋을 theirs 전략으로 cherry-pick${UX_RESET}"
-    echo ""
 
     ux_section "Special"
     ux_table_row "gpf_dev_server" "push force dev" "Force push dev-server"
     ux_table_row "gpfu" "push --force-with-lease" "Force push main"
-    echo ""
 
     ux_section "Git LFS"
     ux_table_row "git_lfs_install" "Install LFS" "Ubuntu setup"
     ux_table_row "glfs" "track <pattern>" "Track files with LFS"
-    echo ""
 
     ux_section "SSH & Authentication"
     ux_table_row "git_ssh_check" "Test GitHub SSH" "Verify GitHub SSH connection"
     ux_table_row "git_ssh_setup" "Setup SSH" "Manual SSH configuration guide"
-    echo ""
 }
 
-# Alias for git-help format (using dash instead of underscore)
 alias git-help='git_help'

--- a/shell-common/functions/hook_help.sh
+++ b/shell-common/functions/hook_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/hook_help.sh
-# Git Hook Configuration Help and Diagnostic
 
 hook_help() {
     ux_header "Git Hook Configuration & Diagnostics"
@@ -14,65 +13,20 @@ hook_help() {
     ux_table_row "hook-check" "Hook 설정 진단 ⭐" "6가지 자동 체크 + 자동 수정 옵션"
     ux_table_row "hook-check --help" "도움말 보기" "이 페이지 표시"
 
-    ux_section "hook-check 동작 원리"
-    ux_bullet "CHECK 1: core.hooksPath 설정 확인"
-    ux_bullet "  → git config --global core.hooksPath"
-    ux_bullet ""
-    ux_bullet "CHECK 2: Hook 파일 존재 확인"
-    ux_bullet "  → ~/.config/git/hooks/pre-commit 존재?"
-    ux_bullet ""
-    ux_bullet "CHECK 3: Hook 파일 권한 확인"
-    ux_bullet "  → 실행 가능 파일(+x)인가?"
-    ux_bullet ""
-    ux_bullet "CHECK 4: 프로젝트 Hook 확인"
-    ux_bullet "  → .git/hooks/pre-commit 존재 및 권한?"
-    ux_bullet ""
-    ux_bullet "CHECK 5: Hook 문법 검증"
-    ux_bullet "  → bash -n로 syntax 체크"
-
-    ux_section "실행 방법"
-    ux_table_row "hook-check" "대화형 진단 (권장)" "문제 발견 시 자동 수정 제안"
-    ux_table_row "bash shell-common/tools/custom/hook_check.sh" "직접 실행" "setup이 필요 없을 때"
-
     ux_section "진단 결과 해석"
     ux_bullet "✓ = 설정 정상"
     ux_bullet "✗ = 설정 오류 (수정 필요)"
     ux_bullet "⚠ = 경고 (선택적)"
 
-    ux_section "자동 수정하기"
-    ux_bullet "hook-check 실행 시 문제 감지되면:"
-    ux_bullet "  1. '위 내용을 확인하세요' 메시지 표시"
-    ux_bullet "  2. '자동 수정할까요? (y/n)' 질문"
-    ux_bullet "  3. 'y' 입력하면 setup.sh 자동 실행"
-    ux_bullet "  4. 모든 설정 자동 복구"
-
-    ux_section "수동 수정하기"
-    ux_bullet "개별 명령어들:"
-    ux_bullet "  1. core.hooksPath 설정:"
-    ux_bullet "     git config --global core.hooksPath ~/.config/git/hooks"
-    ux_bullet ""
-    ux_bullet "  2. Hook 파일 권한 설정:"
-    ux_bullet "     chmod +x ~/.config/git/hooks/pre-commit"
-    ux_bullet ""
-    ux_bullet "  3. 전체 설정 재실행:"
-    ux_bullet "     cd ~/dotfiles && ./git/setup.sh"
-
     ux_section "문제 해결"
     ux_table_row "Hook이 실행 안 됨" "hook-check 실행" "자동 진단 및 수정"
-    ux_table_row "core.hooksPath 오류" "'수동 수정' 섹션 참고" "git config 명령 직접 실행"
+    ux_table_row "core.hooksPath 오류" "git config 명령 직접 실행"
     ux_table_row "권한 오류" "chmod +x 명령 실행" "Hook 파일을 실행 가능하게"
-    ux_table_row "설정 전부 다시 하고 싶음" "setup.sh 재실행" "cd ~/dotfiles && ./git/setup.sh"
+    ux_table_row "설정 전부 다시" "setup.sh 재실행" "cd ~/dotfiles && ./git/setup.sh"
 
     ux_section "Hook 종류"
-    ux_bullet "${bold}User-level Hook${reset} (~/.config/git/hooks/pre-commit)"
-    ux_bullet "  • 모든 git 프로젝트에 적용 (전역)"
-    ux_bullet "  • Secret/Key 감지, Conflict markers 확인 등"
-    ux_bullet "  • 빠름: ~150ms"
-    ux_bullet ""
-    ux_bullet "${bold}Project-level Hook${reset} (dotfiles/.git/hooks/pre-commit)"
-    ux_bullet "  • 이 dotfiles 프로젝트에만 적용 (로컬)"
-    ux_bullet "  • Shebang, Function naming, UX library 검사 등"
-    ux_bullet "  • 상대적으로 느림: ~1-3초"
+    ux_table_row "User-level" "~/.config/git/hooks/pre-commit" "모든 git 프로젝트에 적용 (전역)"
+    ux_table_row "Project-level" "dotfiles/.git/hooks/pre-commit" "이 dotfiles 프로젝트에만 적용"
 
     ux_section "더 알아보기"
     ux_bullet "자세한 가이드: git/doc/HOOK_WORKFLOW.md"
@@ -84,5 +38,4 @@ hook_help() {
     ux_bullet "hook-check를 주기적으로 실행해서 설정 상태 확인"
     ux_bullet "새 PC에서는 반드시 ./git/setup.sh 실행"
     ux_bullet "Hook 문제 발생 시 GIT_HOOKS_DEBUG=1 환경변수로 디버그 출력"
-
 }

--- a/shell-common/functions/litellm_help.sh
+++ b/shell-common/functions/litellm_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/litellm_help.sh
-# litellm Help - shared between bash and zsh
 
 litellm_help() {
     ux_header "LiteLLM Commands"
@@ -12,22 +11,12 @@ litellm_help() {
     ux_table_row "llm-status" "Status" "Check health & models"
     ux_table_row "llm-models" "List Models" "Show loaded models"
     ux_table_row "llm-test" "Test Model" "Run basic prompt"
-    echo ""
-
-    ux_section "Examples"
-    ux_bullet "Start: ${UX_SUCCESS}litellm_start${UX_RESET}"
-    # ux_bullet "Test:  ${UX_SUCCESS}litellm_test gemini-2.0-flash${UX_RESET}"
-    ux_bullet "Test:  ${UX_SUCCESS}litellm_test gpt-oss-20b${UX_RESET}"
-    ux_bullet "Check: ${UX_SUCCESS}litellm_status${UX_RESET}"
-    echo ""
 
     ux_section "Project Info"
     ux_table_row "Path" "$LITELLM_PROJECT_PATH" ""
     ux_table_row "URL" "$LITELLM_URL" ""
     ux_table_row "Key" "$LITELLM_API_KEY" ""
-    echo ""
 }
 
-# Alias for litellm-help format (using dash instead of underscore)
 alias litellm-help='litellm_help'
 alias llm-help='litellm_help'

--- a/shell-common/functions/mysql_help.sh
+++ b/shell-common/functions/mysql_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/mysql_help.sh
-# mysql Help - shared between bash and zsh
 
 mysql_help() {
     ux_header "MySQL Service Management"
@@ -11,12 +10,4 @@ mysql_help() {
     ux_table_row "mysql_dmc_test" "Connect to test database" "Use .my.cnf config"
     ux_table_row "mysql_cmd <svc> <cmd>" "Execute SQL command" "databases, tables, version, describe, status, etc."
     ux_table_row "mysql_server <action>" "Manage service" "start, stop, restart, status, reload"
-    echo ""
-
-    ux_section "Common Workflows"
-    ux_bullet "Show databases: mysql_cmd dmc_dev databases"
-    ux_bullet "Show tables: mysql_cmd dmc_dev tables"
-    ux_bullet "Check MySQL version: mysql_cmd dmc_dev version"
-    ux_bullet "Check service status: mysql_server status"
-    echo ""
 }

--- a/shell-common/functions/npm_help.sh
+++ b/shell-common/functions/npm_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/npm_help.sh
-# npmHelp - shared between bash and zsh
 
 # ========================================
 # Load UX Library (POSIX portable)
@@ -33,52 +32,37 @@ npm_help() {
     ux_table_row "npm-search" "search <keyword>" "Search packages"
     ux_table_row "npm-outdated" "outdated -g" "Check updates"
 
-
     ux_section "Install"
     ux_table_row "npm-i" "npm install" "Install deps"
     ux_table_row "npm-is" "install --save" "Save prod dep"
     ux_table_row "npm-isd" "install --save-dev" "Save dev dep"
     ux_table_row "npm-ig" "install -g" "Global install"
 
-
     ux_section "Uninstall"
     ux_table_row "npm-un" "npm uninstall" "Remove dep"
     ux_table_row "npm-ung" "uninstall -g" "Remove global"
-
 
     ux_section "Maintenance"
     ux_table_row "npm-update" "update -g" "Update global"
     ux_table_row "npm-cache-clean" "cache clean --force" "Clear cache"
 
-
     ux_section "Configuration"
     ux_table_row "npm-config" "Show current config" "Registry, CA, SSL"
-
 
     ux_section "Setup Tools"
     ux_table_row "npminstall" "Install Script" "Install Node/NPM"
     ux_table_row "npmuninstall" "Uninstall Script" "Remove Node/NPM"
-
 
     ux_section "Certificate Management"
     ux_info "For CA certificate setup (company proxy/internal network):"
     ux_bullet "Run: ${UX_SUCCESS}crt-help${UX_RESET} for detailed guide"
     ux_bullet "Setup: ${UX_SUCCESS}crtsetup${UX_RESET} to install certificate"
 
-
     ux_section "Troubleshooting"
     ux_bullet "EACCES permission error (npm WARN): npm config set prefix ~/.npm-global"
     ux_bullet "nvm과 npm prefix 충돌: .npmrc 파일의 prefix 라인 제거"
     ux_bullet "Certificate error: Run ${UX_SUCCESS}crt-help${UX_RESET} for CA setup guide"
     ux_bullet "Config mismatch: Run ${UX_SUCCESS}./shell-common/setup.sh${UX_RESET} to reconfigure symlink"
-
-
-    ux_section "Common Commands"
-    ux_bullet "npm init"
-    ux_bullet "npm run <script>"
-    ux_bullet "npm audit fix"
-    ux_bullet "npm config list"
-
 
     ux_info "Global Path: ~/.npm-global"
 }
@@ -104,25 +88,21 @@ npm_config() {
     ux_table_row "CA File" $(_npm_config_get cafile)
     ux_table_row "Strict SSL" $(_npm_config_get strict-ssl)
 
-
     ux_section "Proxy Settings"
     ux_table_row "Proxy" $(_npm_config_get proxy)
     ux_table_row "HTTPS Proxy" $(_npm_config_get https-proxy)
     ux_table_row "No Proxy" $(_npm_config_get noproxy)
 
-
     ux_section "Quick Commands"
     ux_bullet "npm-config              Show this configuration"
     ux_bullet "npm config list         Show all npm settings"
     ux_bullet "npm config set <key>    Update a setting"
-
 }
+
 # NPM Check Wrapper - calls the diagnostic script
 npm_check() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/check_npm.sh" "$@"
 }
 alias npm-config='npm_config'
 alias check-npm='npm_check'
-
-# Alias for npm-help format (using dash instead of underscore)
 alias npm-help='npm_help'

--- a/shell-common/functions/nvm_help.sh
+++ b/shell-common/functions/nvm_help.sh
@@ -1,20 +1,16 @@
 #!/bin/sh
 # shell-common/functions/nvm_help.sh
-# nvmHelp - shared between bash and zsh
 
 nvm_help() {
     ux_header "NVM (Node Version Manager)"
 
     ux_section "Commands"
     ux_table_row "nvm-install" "Install Script" "Install NVM & Node LTS"
-    echo ""
 
     ux_section "NVM Usage"
     ux_bullet "nvm install --lts  : Install latest LTS Node"
     ux_bullet "nvm use --lts      : Use latest LTS Node"
     ux_bullet "nvm ls             : List installed versions"
-    echo ""
 }
 
-# Alias for nvm-help format (using dash instead of underscore)
 alias nvm-help='nvm_help'

--- a/shell-common/functions/ollama_help.sh
+++ b/shell-common/functions/ollama_help.sh
@@ -3,10 +3,10 @@
 # Ollama / LLM Model Management Help (Hybrid: WSL + Docker)
 
 # Load UX library - use dynamic path detection with fallback
-if ! declare -f ux_header > /dev/null 2>&1; then
-    local ux_lib_path="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/tools/ux_lib/ux_lib.sh"
+if ! type ux_header > /dev/null 2>&1; then
+    ux_lib_path="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/tools/ux_lib/ux_lib.sh"
     if [ -f "$ux_lib_path" ]; then
-        source "$ux_lib_path" 2>/dev/null || true
+        . "$ux_lib_path" 2>/dev/null || true
     else
         # Fallback functions if UX library not found
         ux_header() { echo "=== $1 ==="; echo ""; }

--- a/shell-common/functions/ollama_help.sh
+++ b/shell-common/functions/ollama_help.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # shell-common/functions/ollama_help.sh
 # Ollama / LLM Model Management Help (Hybrid: WSL + Docker)
-# Follows UX_GUIDELINES.md for consistent, semantic output
 
 # Load UX library - use dynamic path detection with fallback
 if ! declare -f ux_header > /dev/null 2>&1; then
@@ -68,51 +67,42 @@ _ollama_help_local() {
     # Check if local ollama is available
     if ! command -v ollama &> /dev/null; then
         ux_header "WSL Ollama — Not Installed"
-        echo ""
+
         ux_section "Current Status"
         ux_error "WSL Ollama is not installed"
         ux_info "Currently using: Docker Ollama only"
-        echo ""
 
         ux_section "Install WSL Ollama"
-        ux_info "Run the installation command:"
-        ux_info "  install-ollama"
-        echo ""
+        ux_info "Run the installation command: install-ollama"
 
         ux_section "For Now"
         ux_info "Docker Ollama is running and ready to use."
         ux_info "View Docker commands with: ${UX_CODE}ollama-help --docker${UX_RESET}"
-        echo ""
         return 0
     fi
 
     ux_header "Ollama Management (WSL Local)"
 
     ux_section "Model Management"
-    ux_bullet "ollama-models       — List all installed models"
-    ux_bullet "ollama-pull <name>  — Download a model (e.g., gpt-oss:20b)"
-    ux_bullet "ollama-rm <name>    — Remove a model"
-    ux_bullet "ollama-show <name>  — Display model configuration"
-    echo ""
+    ux_table_row "ollama-models" "List all installed models"
+    ux_table_row "ollama-pull <name>" "Download a model (e.g., gpt-oss:20b)"
+    ux_table_row "ollama-rm <name>" "Remove a model"
+    ux_table_row "ollama-show <name>" "Display model configuration"
 
     ux_section "Model Usage"
-    ux_bullet "ollama-run <model>          — Interactive chat session"
-    ux_bullet "ollama-prompt <model> <txt> — Single prompt execution"
-    echo ""
+    ux_table_row "ollama-run <model>" "Interactive chat session"
+    ux_table_row "ollama-prompt <model> <txt>" "Single prompt execution"
 
     ux_section "Status & Information"
-    ux_bullet "ollama-version — Display Ollama version"
-    ux_bullet "ollama-status  — Check service status and API health"
-    echo ""
+    ux_table_row "ollama-version" "Display Ollama version"
+    ux_table_row "ollama-status" "Check service status and API health"
 
     ux_section "Server Management"
-    ux_bullet "ollama-serve         — Start Ollama server (foreground)"
-    ux_bullet "ollama-launch claude — Connect Claude Code to Ollama"
-    echo ""
+    ux_table_row "ollama-serve" "Start Ollama server (foreground)"
+    ux_table_row "ollama-launch claude" "Connect Claude Code to Ollama"
 
     ux_section "System Management"
-    ux_bullet "ollama-restart — Restart systemd service and verify all checks"
-    echo ""
+    ux_table_row "ollama-restart" "Restart systemd service and verify all checks"
 
     ux_section "Popular Models"
     ux_table_row "tinyllama:latest" "637 MB"  "Fast, lightweight"
@@ -120,31 +110,11 @@ _ollama_help_local() {
     ux_table_row "mistral"          "4.1 GB"  "General-purpose"
     ux_table_row "neural-chat"      "3.8 GB"  "Chat-optimized"
     ux_table_row "bge-m3:latest"    "1.2 GB"  "Embeddings/search"
-    echo ""
-
-    ux_section "Examples"
-    ux_numbered "1" "Start Ollama server:"
-    ux_info "   ollama-serve"
-    echo ""
-    ux_numbered "2" "Connect Claude Code (in another terminal):"
-    ux_info "   ollama-launch claude"
-    echo ""
-    ux_numbered "3" "Download and use a model:"
-    ux_info "   ollama-pull gpt-oss:20b"
-    ux_info "   ollama-pull glm-4.7-flash"
-    echo ""
-    ux_info "   ollama-run gpt-oss:20b"
-    ux_info "   ollama-run glm-4.7-flash"
-    echo ""
-    ux_numbered "4" "Single prompt:"
-    ux_info "   ollama-prompt gpt-oss:20b 'Explain quantum computing'"
-    echo ""
 
     ux_section "Quick Reference"
     ux_info "Storage:   ~/.ollama"
     ux_info "API:       http://127.0.0.1:11434"
     ux_info "Use ${UX_CODE}ollama-help --docker${UX_RESET} for Docker commands"
-    echo ""
 }
 
 # Docker Ollama Help
@@ -152,22 +122,18 @@ _ollama_help_docker() {
     ux_header "Ollama Management (Docker Container)"
 
     ux_section "Model Management"
-    ux_bullet "ollama-models [--docker]       — List all models"
-    ux_bullet "ollama-pull --docker <name>    — Download a model"
-    ux_bullet "ollama-rm --docker <name>      — Remove a model"
-    ux_bullet "ollama-show --docker <name>    — Show model details"
-    echo ""
+    ux_table_row "ollama-models [--docker]" "List all models"
+    ux_table_row "ollama-pull --docker <name>" "Download a model"
+    ux_table_row "ollama-rm --docker <name>" "Remove a model"
+    ux_table_row "ollama-show --docker <name>" "Show model details"
 
     ux_section "Model Usage"
-    ux_bullet "ollama-run --docker <model>    — Interactive chat"
-    ux_bullet "ollama-prompt --docker <...>   — Single prompt"
-    echo ""
+    ux_table_row "ollama-run --docker <model>" "Interactive chat"
+    ux_table_row "ollama-prompt --docker <...>" "Single prompt"
 
     ux_section "Container Operations"
-    ux_bullet "ollama-logs       — Follow container logs (real-time)"
-    ux_bullet "ollama-stats      — Monitor resource usage"
-    ux_bullet "docker logs -f ollama   — Raw Docker logs"
-    echo ""
+    ux_table_row "ollama-logs" "Follow container logs (real-time)"
+    ux_table_row "ollama-stats" "Monitor resource usage"
 
     ux_section "Popular Models"
     ux_table_row "tinyllama:latest" "637 MB"  "Fast, lightweight"
@@ -175,31 +141,16 @@ _ollama_help_docker() {
     ux_table_row "mistral"          "4.1 GB"  "General-purpose"
     ux_table_row "neural-chat"      "3.8 GB"  "Chat-optimized"
     ux_table_row "bge-m3:latest"    "1.2 GB"  "Embeddings/search"
-    echo ""
-
-    ux_section "Examples"
-    ux_numbered "1" "List models:"
-    ux_info "   ollama-models --docker"
-    echo ""
-    ux_numbered "2" "Download and use:"
-    ux_info "   ollama-pull --docker mistral"
-    ux_info "   ollama-run --docker mistral"
-    echo ""
-    ux_numbered "3" "Interactive chat:"
-    ux_info "   docker exec -it ollama ollama run tinyllama"
-    echo ""
 
     ux_section "Quick Reference"
     ux_info "Storage:   /root/.ollama (container volume)"
     ux_info "API:       http://localhost:11434"
     ux_info "Use ${UX_CODE}ollama-help --local${UX_RESET} for WSL commands"
-    echo ""
 }
 
 # Show current Ollama status
 _ollama_help_status() {
     ux_header "Current Ollama Backend Status"
-    echo ""
 
     if command -v ollama_backend_status &> /dev/null; then
         ollama_backend_status
@@ -219,32 +170,21 @@ _ollama_help_status() {
             ux_bullet "Docker: docker start ollama"
         fi
     fi
-    echo ""
 }
 
 # Show usage information
 _ollama_help_usage() {
     ux_header "ollama-help — Ollama Command Reference"
-    echo ""
 
     ux_section "Usage"
     ux_info "ollama-help [OPTION]"
-    echo ""
 
     ux_section "Options"
-    ux_bullet "--auto     Auto-detect backend (default when no option given)"
-    ux_bullet "--docker   Show Docker-specific commands"
-    ux_bullet "--local    Show WSL-specific commands"
-    ux_bullet "--status   Display current Ollama status"
-    ux_bullet "-h, --help Show this help"
-    echo ""
-
-    ux_section "Examples"
-    ux_info "ollama-help           # Auto-detect (recommended)"
-    ux_info "ollama-help --docker  # Docker-specific help"
-    ux_info "ollama-help --local   # WSL-specific help"
-    ux_info "ollama-help --status  # Show current status"
-    echo ""
+    ux_table_row "--auto" "Auto-detect backend (default)"
+    ux_table_row "--docker" "Show Docker-specific commands"
+    ux_table_row "--local" "Show WSL-specific commands"
+    ux_table_row "--status" "Display current Ollama status"
+    ux_table_row "-h, --help" "Show this help"
 }
 
 # Aliases defined in shell initialization (bashrc/zshrc) to avoid conflicts

--- a/shell-common/functions/pip_help.sh
+++ b/shell-common/functions/pip_help.sh
@@ -1,69 +1,37 @@
 #!/bin/sh
 # shell-common/functions/pip_help.sh
-# Pip help function (POSIX-compatible, shared between bash and zsh)
 
 pip_help() {
-    if type ux_header >/dev/null 2>&1; then
-        ux_header "Pip Configuration & Diagnostics"
-    else
+    ux_header "Pip Configuration & Diagnostics"
 
-        ux_header "Pip Configuration & Diagnostics"
+    ux_section "Diagnostic Commands"
+    ux_bullet "check-pip            Run full pip diagnostic"
+    ux_bullet "check-pip config     Show pip configuration"
+    ux_bullet "check-pip file       pip.conf file check"
+    ux_bullet "check-pip repo       Repository connectivity test"
+    ux_bullet "check-pip env        Environment variables"
 
-    fi
+    ux_section "Quick Commands"
+    ux_bullet "pip config list                 Show all pip settings"
+    ux_bullet "pip config list --verbose       Show pip config files loading"
+    ux_bullet "cat \$HOME/.config/pip/pip.conf  View user pip config"
+    ux_bullet "pip --version                   Check pip version"
 
-    if type ux_section >/dev/null 2>&1; then
-        ux_section "Diagnostic Commands"
-        ux_bullet "check-pip            Run full pip diagnostic"
-        ux_bullet "check-pip config     Show pip configuration"
-        ux_bullet "check-pip file       pip.conf file check"
-        ux_bullet "check-pip repo       Repository connectivity test"
-        ux_bullet "check-pip env        Environment variables"
+    ux_section "Environment Setup"
+    ux_bullet "./setup.sh                      Run setup (choose environment)"
+    ux_bullet "               1) Public PC"
+    ux_bullet "               2) Internal company PC (proxy + internal repo)"
+    ux_bullet "               3) External company PC (VPN)"
 
+    ux_section "Proxy & Repository Info"
+    ux_bullet "Proxy:            http://12.26.204.100:8080"
+    ux_bullet "Internal Repo:    http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"
+    ux_bullet "DataService Repo: http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple"
 
-        ux_section "Quick Commands"
-        ux_bullet "pip config list                 Show all pip settings"
-        ux_bullet "pip config list --verbose       Show pip config files loading"
-        ux_bullet "cat \$HOME/.config/pip/pip.conf  View user pip config"
-        ux_bullet "pip --version                   Check pip version"
-
-
-        ux_section "Environment Setup"
-        ux_bullet "./setup.sh                      Run setup (choose environment)"
-        ux_bullet "               1) Public PC"
-        ux_bullet "               2) Internal company PC (proxy + internal repo)"
-        ux_bullet "               3) External company PC (VPN)"
-
-
-        ux_section "Proxy & Repository Info"
-        ux_bullet "Proxy:            http://12.26.204.100:8080"
-        ux_bullet "Internal Repo:    http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"
-        ux_bullet "DataService Repo: http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple"
-
-
-        ux_section "Troubleshooting"
-        ux_bullet "pip install tox              Install package from configured repo"
-        ux_bullet "pip install -v tox           Verbose output for debugging"
-        ux_bullet "pip cache purge              Clear pip cache"
-        ux_bullet "pip config list --verbose    See which config file is loaded"
-
-
-        ux_section "Important Notes"
-        ux_warning "CA certificate: Configured via security.local.sh (REQUESTS_CA_BUNDLE)"
-        ux_info "Config files are managed by setup.sh - do not edit manually"
-        ux_info "Symlink: ~/.config/pip/pip.conf -> pip/pip.conf.{environment}"
-
-    else
-        # Fallback for minimal shells without UX library
-        ux_header "Diagnostic Commands:"
-        ux_bullet "check-pip            Run full pip diagnostic"
-        ux_bullet "check-pip config     Show pip configuration"
-        ux_bullet "check-pip repo       Repository connectivity test"
-
-        ux_header "Quick Commands:"
-        ux_bullet "pip config list      Show all pip settings"
-        ux_bullet "pip --version        Check pip version"
-
-    fi
+    ux_section "Important Notes"
+    ux_warning "CA certificate: Configured via security.local.sh (REQUESTS_CA_BUNDLE)"
+    ux_info "Config files are managed by setup.sh - do not edit manually"
+    ux_info "Symlink: ~/.config/pip/pip.conf -> pip/pip.conf.{environment}"
 }
 
 # Wrapper function for check_pip.sh diagnostic
@@ -81,6 +49,5 @@ pip_check() {
     fi
 }
 
-# Aliases for pip-help and check-pip
 alias pip-help='pip_help'
 alias check-pip='pip_check'

--- a/shell-common/functions/pp_help.sh
+++ b/shell-common/functions/pp_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/pp_help.sh
-# ppHelp - shared between bash and zsh
 
 pp_help() {
     ux_header "Python Package & Quality Tools"
@@ -13,23 +12,18 @@ pp_help() {
     ux_table_row "pp_freeze" "Freeze to reqs.txt" "Exclude project name"
     ux_table_row "pp_list" "pip list --outdated" "Check updates"
     ux_table_row "pp_check" "pip check" "Verify deps"
-    echo ""
 
     ux_section "Code Quality (Ruff/MyPy)"
     ux_table_row "code_check" "ruff format & check" "CI mode (check only)"
     ux_table_row "code_fix" "ruff format & fix" "Auto-fix issues"
     ux_table_row "code_type" "mypy ." "Type checking"
-    echo ""
 
     ux_section "Testing"
     ux_table_row "test_pytest" "pytest -q" "Run pytest (fast)"
     ux_table_row "test_unittest" "unittest discover" "Run unittest"
-    echo ""
 
     ux_section "Documentation"
     ux_table_row "docs_gen" "sphinx build" "Generate HTML docs"
-    echo ""
 }
 
-# Alias for pp-help format (using dash instead of underscore)
 alias pp-help='pp_help'

--- a/shell-common/functions/psql_help.sh
+++ b/shell-common/functions/psql_help.sh
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/functions/psql_help.sh
-# psqlHelp - shared between bash and zsh
 
 psql_help() {
     if [[ $# -gt 0 ]]; then
@@ -20,16 +19,13 @@ psql_help() {
     ux_table_row "psql_sync" "Sync DBs" "Scan server and add existing DBs to config"
     ux_table_row "psql_add" "Add Link" "Manually add a shortcut for existing DB"
     ux_table_row "psql_del" "Remove" "Remove service (and optionally drop DB)"
-    echo ""
 
     ux_section "Low-Level Management"
     ux_table_row "psql_db" "DB Ops" "list, create, delete, grant"
     ux_table_row "psql_user" "User Ops" "list, create, attr, passwd, delete"
-    echo ""
 
     # Show services table
     psql_list
 }
 
-# Alias for psql-help format (using dash instead of underscore)
 alias psql-help='psql_help'

--- a/shell-common/functions/py_help.sh
+++ b/shell-common/functions/py_help.sh
@@ -1,38 +1,19 @@
 #!/bin/sh
 # shell-common/functions/py_help.sh
-# pyHelp - shared between bash and zsh
 
 py_help() {
     ux_header "Python Virtual Environment Commands"
 
-    ux_section "Full Commands"
-    ux_table_row "create_venv" "python -m venv .venv" "Create venv"
-    ux_table_row "act_venv" "source .venv/bin/activate" "Activate"
-    ux_table_row "echo_venv" "echo \$VIRTUAL_ENV" "Show path"
-    ux_table_row "rm_venv" "rm -rf .venv" "Delete venv"
-    ux_table_row "deact_venv" "deactivate" "Deactivate"
-    echo ""
-
-    ux_section "Short Aliases"
-    ux_table_row "cv" "create venv" "Create"
-    ux_table_row "av" "activate venv" "Activate"
-    ux_table_row "ev" "echo venv" "Show path"
-    ux_table_row "rv" "remove venv" "Delete"
-    ux_table_row "dv" "deactivate" "Deactivate"
-    echo ""
+    ux_section "Commands"
+    ux_table_row "create-venv (cv)" "python -m venv .venv" "Create venv"
+    ux_table_row "act-venv (av)" "source .venv/bin/activate" "Activate"
+    ux_table_row "echo-venv (ev)" "echo \$VIRTUAL_ENV" "Show path"
+    ux_table_row "rm-venv (rv)" "rm -rf .venv" "Delete venv"
+    ux_table_row "deact-venv (dv)" "deactivate" "Deactivate"
 
     ux_section "Setup Tools"
     ux_table_row "install-py [version...]" "Install Script" "Install default or specific Python versions"
     ux_table_row "uninstall-py <version>" "pyenv uninstall" "Remove a specific Python version"
-    echo ""
-
-    ux_section "Quick Workflow"
-    ux_step 1 "${UX_SUCCESS}cv${UX_RESET}  # Create .venv"
-    ux_step 2 "${UX_SUCCESS}av${UX_RESET}  # Activate"
-    ux_step 3 "${UX_SUCCESS}pip install ...${UX_RESET}"
-    ux_step 4 "${UX_SUCCESS}dv${UX_RESET}  # Deactivate when done"
-    echo ""
 }
 
-# Alias for py-help format (using dash instead of underscore)
 alias py-help='py_help'

--- a/shell-common/functions/py_help.sh
+++ b/shell-common/functions/py_help.sh
@@ -6,10 +6,10 @@ py_help() {
 
     ux_section "Commands"
     ux_table_row "create-venv (cv)" "python -m venv .venv" "Create venv"
-    ux_table_row "act-venv (av)" "source .venv/bin/activate" "Activate"
+    ux_table_row "act-venv (av)" ". .venv/bin/activate" "Activate"
     ux_table_row "echo-venv (ev)" "echo \$VIRTUAL_ENV" "Show path"
     ux_table_row "rm-venv (rv)" "rm -rf .venv" "Delete venv"
-    ux_table_row "deact-venv (dv)" "deactivate" "Deactivate"
+    ux_table_row "deact-venv (dv)" ". deactivate" "Deactivate"
 
     ux_section "Setup Tools"
     ux_table_row "install-py [version...]" "Install Script" "Install default or specific Python versions"

--- a/shell-common/functions/security_help.sh
+++ b/shell-common/functions/security_help.sh
@@ -4,7 +4,7 @@
 
 # Load UX library (unified library at shell-common/tools/ux_lib/)
 if ! type ux_header >/dev/null 2>&1; then
-    source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+    . "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
 fi
 
 crt_help() {

--- a/shell-common/functions/security_help.sh
+++ b/shell-common/functions/security_help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/functions/security_help.sh
 # CA Certificate setup help and utilities
 
@@ -6,10 +6,6 @@
 if ! type ux_header >/dev/null 2>&1; then
     source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
 fi
-
-# ═══════════════════════════════════════════════════════════════
-# CA Certificate Setup Help
-# ═══════════════════════════════════════════════════════════════
 
 crt_help() {
     ux_header "CA Certificate Setup Guide"
@@ -19,77 +15,28 @@ crt_help() {
     ux_bullet "Supports custom certificates (company proxy) and system CA bundles"
     ux_bullet "Configuration stored in: shell-common/env/security.local.sh"
 
-
-    ux_section "Quick Start"
-    ux_info "1. Run setup.sh to initialize your environment:"
-    ux_bullet " ${UX_SUCCESS}./setup.sh${UX_RESET}"
-
-    ux_info "2. Select your environment (Public/Internal/External PC)"
-
-    ux_info "3. For external company PC with custom certificate:"
-    ux_bullet " ${UX_SUCCESS}crtsetup${UX_RESET}"
-
-
     ux_section "Two Options"
-
     ux_bullet "Option 1: Custom Certificate (External Company PC - VPN)"
-    ux_bullet " • Use when connecting via company VPN"
     ux_bullet " • Certificate path: ${UX_MUTED}/usr/local/share/ca-certificates/samsungsemi-prx.com.crt${UX_RESET}"
     ux_bullet " • Install with: ${UX_SUCCESS}crtsetup${UX_RESET}"
-
-
     ux_bullet "Option 2: System CA Bundle (Internal Company PC)"
-    ux_bullet " • Use when connecting directly from company network"
     ux_bullet " • Certificate path: ${UX_MUTED}/etc/ssl/certs/ca-certificates.crt${UX_RESET}"
     ux_bullet " • Already system default, no setup needed"
 
-
     ux_section "Setup Command"
     ux_table_row "crtsetup" "Interactive CA certificate setup script"
-
-    ux_info "This command will:"
-    ux_bullet "Check current certificate status"
-    ux_bullet "Obtain certificate file (from local file or manual setup)"
-    ux_bullet "Install certificate to system"
-    ux_bullet "Update system certificate store"
-    ux_bullet "Verify installation"
-
 
     ux_section "Environment Variables"
     ux_table_row "NODE_EXTRA_CA_CERTS" "Used by Node.js/npm for certificate validation"
     ux_table_row "REQUESTS_CA_BUNDLE" "Used by Python for certificate validation"
 
-
     ux_section "Configuration File"
     ux_info "Location: ${UX_BOLD}shell-common/env/security.local.sh${UX_RESET}"
-
-    ux_info "To configure:"
-    ux_bullet "1. Check current environment: ${UX_SUCCESS}./setup.sh${UX_RESET}"
-    ux_bullet "2. Edit file: ${UX_SUCCESS}vim shell-common/env/security.local.sh${UX_RESET}"
-    ux_bullet "3. Uncomment one CA_CERT option (choose based on your environment)"
-
-
-    ux_section "Troubleshooting"
-    ux_bullet "Certificate not found: Run ${UX_SUCCESS}crtsetup${UX_RESET} to install"
-    ux_bullet "NODE_EXTRA_CA_CERTS not set: Source ~/.bashrc (${UX_SUCCESS}source ~/.bashrc${UX_RESET})"
-    ux_bullet "npm fails with certificate error: Check ${UX_SUCCESS}echo \$NODE_EXTRA_CA_CERTS${UX_RESET}}"
-    ux_bullet "Need to remove certificate: ${UX_SUCCESS}sudo rm /usr/local/share/ca-certificates/<cert>.crt${UX_RESET}}"
-
 
     ux_section "Related Commands"
     ux_table_row "npm-help" "NPM package manager commands and setup"
     ux_table_row "security.sh" "Security environment variable configuration"
     ux_table_row "setup.sh" "Initial environment-specific setup"
-
 }
 
-# ═══════════════════════════════════════════════════════════════
-# Help Registration
-# ═══════════════════════════════════════════════════════════════
-
-# Note: HELP_DESCRIPTIONS registration is handled by my_help.sh
-# which loads before this file and properly initializes the array
-# in a shell-independent way
-
-# Alias for crt-help format (using dash instead of underscore)
 alias crt-help='crt_help'

--- a/shell-common/functions/setup_mode_help.sh
+++ b/shell-common/functions/setup_mode_help.sh
@@ -73,11 +73,9 @@ show_setup_mode() {
             ;;
     esac
 
-    echo ""
     ux_section "Setup Mode File"
     ux_bullet "Path: ~/.dotfiles-setup-mode"
     ux_bullet "Content: $mode"
-    echo ""
 }
 
 # ============================================================
@@ -90,39 +88,17 @@ setup_mode_help() {
     ux_bullet "Tracks which environment your PC is configured for"
     ux_bullet "Automatically applies environment-specific settings"
     ux_bullet "Stored in: ~/.dotfiles-setup-mode"
-    echo ""
 
     ux_section "Available Modes"
-    echo ""
-    echo "  Mode 1: Public PC (Home environment)"
-    echo "  ────────────────────────────────────"
-    echo "    • No corporate proxy"
-    echo "    • No company-specific configurations"
-    echo "    • Clean home environment"
-    echo ""
-
-    echo "  Mode 2: Internal company PC (Direct connection)"
-    echo "  ───────────────────────────────────────────────"
-    echo "    • Company proxy: http://12.26.204.100:8080"
-    echo "    • Internal repositories (Nexus)"
-    echo "    • Company CA certificates"
-    echo "    • McAfee proxy certificate"
-    echo ""
-
-    echo "  Mode 3: External company PC (VPN)"
-    echo "  ──────────────────────────────────"
-    echo "    • No company proxy (direct internet via VPN)"
-    echo "    • External repositories (npmjs, PyPI, etc)"
-    echo "    • VPN certificate configuration"
-    echo "    • samsungsemi CA certificate"
-    echo ""
+    ux_table_row "Mode 1" "Public PC (Home environment)" "No proxy, no company configs"
+    ux_table_row "Mode 2" "Internal company PC (Direct)" "Company proxy, internal repos, CA certs"
+    ux_table_row "Mode 3" "External company PC (VPN)" "No proxy, VPN certificate"
 
     ux_section "Usage"
-    ux_bullet "Show current mode: ${UX_BOLD}show-setup-mode${UX_RESET}"
+    ux_table_row "show-setup-mode" "Show current mode"
+    ux_table_row "setup-mode-help" "View this help"
     ux_bullet "Reconfigure: ${UX_BOLD}cd ~/dotfiles && ./setup.sh${UX_RESET}"
     ux_bullet "Check proxy: ${UX_BOLD}check-proxy${UX_RESET}"
-    ux_bullet "View this help: ${UX_BOLD}setup-mode-help${UX_RESET}"
-    echo ""
 }
 
 # ============================================================

--- a/shell-common/functions/setup_mode_help.sh
+++ b/shell-common/functions/setup_mode_help.sh
@@ -3,10 +3,10 @@
 # Setup mode management and help functions
 
 # Load UX library if not already loaded
-if ! declare -f ux_header >/dev/null 2>&1; then
+if ! type ux_header >/dev/null 2>&1; then
     _ux_lib="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/ux_lib/ux_lib.sh"
     if [ -f "$_ux_lib" ]; then
-        source "$_ux_lib"
+        . "$_ux_lib"
     fi
 fi
 

--- a/shell-common/functions/ssh_help.sh
+++ b/shell-common/functions/ssh_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/ssh_help.sh
-# SSH / SCP usage help with registered host list
 #
 # ═══════════════════════════════════════════════════════════════════════════════
 # DEVELOPER NOTES - NAMING CONVENTION (See AGENTS.md:174-178)
@@ -15,17 +14,10 @@ ssh_help() {
     ux_section "SSH - Connect & Run"
     ux_table_row "ssh <host>" "ssh ssai-dev" "Connect to server"
     ux_table_row "ssh <host> <cmd>" "ssh ssai-dev 'ls /home'" "Run remote command"
-    echo ""
 
     ux_section "SCP - File Transfer"
     ux_table_row "pull" "scp <host>:<src> <dst>" "Download from server"
     ux_table_row "push" "scp <src> <host>:<dst>" "Upload to server"
-    echo ""
-    ux_info "Examples:"
-    echo "  scp ssai-dev:/home/devops/certs/server.* ~/download/"
-    echo "  scp ./config.yaml ssai-dev:/home/devops/configs/"
-    echo "  scp -r ssai-ops:/home/devops/logs/ ./logs/"
-    echo ""
 
     ux_section "Registered Hosts (~/.ssh/config)"
     if [ -f "${HOME}/.ssh/config" ]; then
@@ -48,11 +40,9 @@ ssh_help() {
     else
         ux_info "~/.ssh/config not found. Run ./setup.sh to create symlink."
     fi
-    echo ""
 
     ux_section "Config"
     ux_table_row "config file" "~/.ssh/config → dotfiles/ssh/config" "Managed by dotfiles"
-    echo ""
 }
 
 alias ssh-help='ssh_help'

--- a/shell-common/functions/ssl_help.sh
+++ b/shell-common/functions/ssl_help.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 # shell-common/functions/ssl_help.sh
 # SSL certificate help function (bash/zsh compatible)
-#
-# Purpose: Provide SSL certificate configuration diagnostics
-# Usage: ssl-help [all|env|file|path]
 
 ssl_help() {
     if type ux_header >/dev/null 2>&1; then
@@ -13,7 +10,6 @@ ssl_help() {
     fi
 
     if type ux_section >/dev/null 2>&1; then
-        # === Quick Status Check ===
         ux_section "Current SSL Certificate Status"
 
         if [ -n "$SSL_CERT_FILE" ]; then
@@ -27,30 +23,24 @@ ssl_help() {
             ux_warning "SSL_CERT_FILE: [NOT SET]"
             ux_info "  This is normal for public/home environments"
         fi
-        echo ""
 
         if [ -n "$REQUESTS_CA_BUNDLE" ]; then
             ux_success "REQUESTS_CA_BUNDLE: $REQUESTS_CA_BUNDLE (Python requests)"
         else
             ux_info "REQUESTS_CA_BUNDLE: [NOT SET]"
         fi
-        echo ""
 
         if [ -n "$NODE_EXTRA_CA_CERTS" ]; then
             ux_success "NODE_EXTRA_CA_CERTS: $NODE_EXTRA_CA_CERTS (Node.js)"
         else
             ux_info "NODE_EXTRA_CA_CERTS: [NOT SET]"
         fi
-        echo ""
 
-        # === Quick Commands ===
         ux_section "Quick Commands"
         ux_bullet "echo \$SSL_CERT_FILE                  Show SSL certificate file"
         ux_bullet "echo \$REQUESTS_CA_BUNDLE             Show Python requests CA bundle"
         ux_bullet "env | grep -i cert                   Show all certificate vars"
-        echo ""
 
-        # === File Status ===
         ux_section "Security Configuration Files"
         local security_local="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/env/security.local.sh"
         if [ -f "$security_local" ]; then
@@ -59,49 +49,24 @@ ssl_help() {
         else
             ux_info "security.local.sh: not configured (public environment)"
         fi
-        echo ""
-
-        # === For Corporate Environments ===
-        ux_section "Corporate Environment Setup"
-        ux_info "1. Run setup.sh to configure SSL certificates"
-        ux_bullet "  cd ~/dotfiles"
-        ux_bullet "  ./setup.sh"
-        ux_bullet "  Select: [2] Internal company PC OR [3] External company PC"
-        echo ""
 
         ux_section "Certificate Paths by Environment"
         ux_bullet "Internal PC:  /usr/share/ca-certificates/extra/McAfee_Certificate.crt"
         ux_bullet "External PC:  /usr/local/share/ca-certificates/samsungsemi-prx.com.crt"
         ux_bullet "System CA:    /etc/ssl/certs/ca-certificates.crt"
-        echo ""
 
-        # === Tools & Libraries ===
         ux_section "Tools That Use SSL_CERT_FILE"
         ux_bullet "curl                 - Web requests and downloads"
         ux_bullet "wget                 - File downloads"
         ux_bullet "git                  - Git operations (HTTPS)"
         ux_bullet "python (requests)    - HTTP library"
         ux_bullet "npm                  - Node.js package manager"
-        echo ""
 
-        # === Verification ===
-        ux_section "Verify Certificate Installation"
-        ux_info "Check if certificate file exists:"
-        if [ -n "$SSL_CERT_FILE" ] && [ -f "$SSL_CERT_FILE" ]; then
-            ux_success "✓ Certificate file is accessible"
-            ux_bullet "openssl x509 -in \$SSL_CERT_FILE -text -noout   View cert details"
-        else
-            ux_warning "Certificate file not found - may need setup or installation"
-        fi
-        echo ""
-
-        # === Important Notes ===
         ux_section "Important Notes"
         ux_warning "Different variables for different tools:"
         ux_info "  - SSL_CERT_FILE:        curl, wget, git"
         ux_info "  - REQUESTS_CA_BUNDLE:   Python requests"
         ux_info "  - NODE_EXTRA_CA_CERTS:  Node.js"
-        echo ""
 
     else
         # Fallback for minimal shells without UX library
@@ -122,7 +87,6 @@ ssl_check() {
     if [ -f "$check_ssl_script" ]; then
         bash "$check_ssl_script" "$@"
     else
-        # For now, just show ssl-help since check_ssl.sh doesn't exist yet
         if type ux_info >/dev/null 2>&1; then
             ux_info "check-ssl script coming soon. Running ssl-help for now..."
         fi
@@ -130,6 +94,5 @@ ssl_check() {
     fi
 }
 
-# Aliases for ssl-help and check-ssl
 alias ssl-help='ssl_help'
 alias check-ssl='ssl_check'

--- a/shell-common/functions/sys_help.sh
+++ b/shell-common/functions/sys_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/sys_help.sh
-# sysHelp - shared between bash and zsh
 
 sys_help() {
     ux_header "System Management Commands"
@@ -10,7 +9,6 @@ sys_help() {
     ux_table_row "psg" "ps aux | grep" "Find process"
     ux_table_row "kill9" "kill -9" "Force kill"
     ux_table_row "psa" "ps aux" "List all processes"
-    echo ""
 
     ux_section "Network"
     ux_table_row "ports" "ss -tulanp" "Show open ports"
@@ -19,28 +17,23 @@ sys_help() {
     ux_table_row "ping" "ping -c 5" "Ping (5 times)"
     ux_table_row "check-network" "check-network" "Internet connectivity diagnostics"
     ux_table_row "ssh-help" "ssh-help" "SSH hosts and examples"
-    echo ""
 
     ux_section "Monitoring"
     ux_table_row "top" "htop" "Process monitor"
     ux_table_row "meminfo" "free -m" "Memory usage"
     ux_table_row "cpuinfo" "lscpu" "CPU info"
     ux_table_row "diskusage" "df -h" "Disk usage"
-    echo ""
 
     ux_section "Package Management (APT)"
     ux_table_row "update" "apt update" "Update lists"
     ux_table_row "upgrade" "apt upgrade" "Upgrade packages"
     ux_table_row "remove" "apt remove" "Remove package"
     ux_table_row "auto-remove" "apt autoremove" "Remove unused"
-    echo ""
 
     ux_section "Log Viewing"
     ux_table_row "logs" "syslog" "System logs"
     ux_table_row "error" "error.log" "Error logs"
     ux_table_row "auth" "auth.log" "Auth logs"
-    echo ""
 }
 
-# Alias for sys-help format (using dash instead of underscore)
 alias sys-help='sys_help'

--- a/shell-common/functions/uv_help.sh
+++ b/shell-common/functions/uv_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/uv_help.sh
-# uvHelp - shared between bash and zsh
 
 uv_help() {
     ux_header "UV Quick Commands"
@@ -10,24 +9,20 @@ uv_help() {
     ux_table_row "uvu" "uv sync --upgrade" "Upgrade deps"
     ux_table_row "uvd" "uv sync --dev" "Dev install"
     ux_table_row "uv-install" "install script" "Install UV tool"
-    echo ""
 
     ux_section "Lock & Export"
     ux_table_row "uvk" "uv lock" "Refresh lockfile"
     ux_table_row "uvl" "uv pip list" "List packages"
     ux_table_row "uvc" "uv pip compile" "Export requirements"
     ux_table_row "uvr" "uv pip sync" "Sync from reqs"
-    echo ""
 
     ux_section "Maintenance"
     ux_table_row "uvcheck" "uv pip check" "Verify env"
-    echo ""
 
     ux_section "Recipes"
     ux_bullet "Install all extras: ${UX_SUCCESS}uv pip sync --all-extras${UX_RESET}"
     ux_bullet "Backend dev:      ${UX_SUCCESS}uv pip sync --extra backend --extra dev${UX_RESET}"
     ux_bullet "Frontend dev:     ${UX_SUCCESS}uv pip sync --extra frontend --extra dev${UX_RESET}"
-    echo ""
 }
 
 # UV Check Wrapper - calls the diagnostic script
@@ -35,6 +30,5 @@ uv_check() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/check_uv.sh" "$@"
 }
 
-# Alias for uv-help format (using dash instead of underscore)
 alias uv-help='uv_help'
 alias check-uv='uv_check'

--- a/shell-common/functions/zsh_help.sh
+++ b/shell-common/functions/zsh_help.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shell-common/functions/zsh_help.sh
-# zsh help - shared between bash and zsh
 
 _zsh_help_full() {
     ux_header "Zsh Management Commands (Complete)"
@@ -9,23 +8,18 @@ _zsh_help_full() {
     ux_table_row "zsh-switch" "Switch to zsh shell"
     ux_table_row "bash-switch" "Switch back to bash"
 
-
     ux_section "Version & Info"
     ux_table_row "zsh-version" "Get zsh version"
     ux_table_row "zsh-info" "System and zsh info"
-
 
     ux_section "Theme Management"
     ux_table_row "zsh-themes" "List all available themes"
     ux_table_row "zsh-theme-current" "Show current theme"
     ux_table_row "zsh-theme <name>" "Change zsh theme"
-    ux_bullet "Example: zsh-theme powerlevel10k"
-
 
     ux_section "Plugin Management"
     ux_table_row "zsh-plugins" "List installed plugins"
     ux_table_row "zsh-update" "Update oh-my-zsh framework"
-
 
     ux_section "Configuration Management"
     ux_table_row "zsh-edit" "Edit $HOME/.zshrc in editor"
@@ -33,11 +27,9 @@ _zsh_help_full() {
     ux_table_row "zsh-snippet <name>" "Create/edit config snippet"
     ux_table_row "zsh-snippets" "List all snippets"
 
-
     ux_section "Quick Aliases"
     ux_table_row "zsh-config" "View current zsh config"
     ux_table_row "zsh-edit-quick" "Quick edit with nano"
-
 
     ux_section "Popular Themes"
     ux_bullet "${UX_BOLD}robbyrussell${UX_RESET} - Default clean theme"
@@ -46,30 +38,22 @@ _zsh_help_full() {
     ux_bullet "${UX_BOLD}minimal${UX_RESET} - Minimal and fast"
     ux_bullet "${UX_BOLD}afowler${UX_RESET} - Syntax highlighting focused"
 
-
     ux_section "Recommended Plugins"
-
-    ux_info "In your $HOME/.zshrc, modify the plugins line:"
-    ux_bullet "plugins=(git zsh-autosuggestions zsh-syntax-highlighting extract)"
-
     ux_bullet "${UX_BOLD}git${UX_RESET} - Git aliases and functions"
     ux_bullet "${UX_BOLD}zsh-autosuggestions${UX_RESET} - Command suggestions (type then use arrow)"
     ux_bullet "${UX_BOLD}zsh-syntax-highlighting${UX_RESET} - Syntax highlighting as you type"
     ux_bullet "${UX_BOLD}extract${UX_RESET} - Smart archive extraction (extract file.tar.gz)"
     ux_bullet "${UX_BOLD}web-search${UX_RESET} - Quick web search (google 'query')"
 
-
     ux_section "Bash & Zsh Coexistence"
     ux_bullet "Both shells can coexist without conflicts"
     ux_bullet "Switch shells anytime: ${UX_BOLD}zsh-switch${UX_RESET} or ${UX_BOLD}bash-switch${UX_RESET}"
     ux_bullet "Set default: ${UX_BOLD}chsh -s \$(which zsh)${UX_RESET} (then login again)"
 
-
     ux_section "Configuration Tips"
     ux_bullet "Shared config: Add to shell-common/ for portable settings"
     ux_bullet "Shell-specific: Use shell-specific files for unique functions"
     ux_bullet "Use snippets: Organize $HOME/.zshrc.d/ for better management"
-
 }
 
 zsh_help() {
@@ -85,18 +69,15 @@ zsh_help() {
     ux_table_row "bash-switch" "Switch back to bash"
     ux_table_row "install-zsh" "Install zsh (if not installed)"
 
-
     ux_section "Configuration"
     ux_table_row "zsh-edit" "Edit $HOME/.zshrc"
     ux_table_row "zsh-reload" "Reload zsh config"
     ux_table_row "zsh-snippet <name>" "Create config snippet"
 
-
     ux_section "Theme & Plugins"
     ux_table_row "zsh-theme-current" "Current theme"
     ux_table_row "zsh-themes" "List all themes"
     ux_table_row "zsh-plugins" "List plugins"
-
 
     ux_section "Required/Recommended Packages"
     ux_table_row "install-p10k" "Install powerlevel10k theme"
@@ -110,15 +91,11 @@ zsh_help() {
     ux_table_row "install-bat" "Install bat (cat with highlighting)"
     ux_table_row "install-pet" "Install pet (command snippet manager)"
 
-
     ux_section "Status"
     ux_table_row "zsh-version" "Show zsh version"
     ux_table_row "zsh-info" "System info"
 
-
     ux_info "More details: ${UX_BOLD}zsh-help --all${UX_RESET}"
-
 }
 
-# Alias for zsh-help format (using dash instead of underscore)
 alias zsh-help='zsh_help'

--- a/shell-common/tools/integrations/python.sh
+++ b/shell-common/tools/integrations/python.sh
@@ -1,28 +1,25 @@
-#!/bin/bash
-# shell-common/tools/external/python.sh
-# Auto-generated from bash/app/python.bash
-
-
-# bash/app/python.bash
+#!/bin/sh
+# shell-common/tools/integrations/python.sh
 
 # Add user-installed Python scripts to the PATH (for pip packages like gemini-cli)
 export PATH="$HOME/.local/bin:$PATH"
 
 # Python Virtual Environment
-alias create_venv='python -m venv .venv'
-alias act_venv='source .venv/bin/activate'
-alias echo_venv='echo "$VIRTUAL_ENV"'
-alias rm_venv='rm -rf .venv'
-alias deact_venv='deactivate'
-
-alias cv='python -m venv .venv'
-alias av='source .venv/bin/activate'
-alias ev='echo $VIRTUAL_ENV'
-alias rv='rm -rf .venv'
-alias dv='source deactivate'
-# deactivate는 source 없이도 작동합니다.
 # pyenv-virtualenv: deactivate must be sourced. Run 'source deactivate' instead of 'deactivate'
+create_venv() { python -m venv .venv; }
+act_venv() { . .venv/bin/activate; }
+echo_venv() { echo "$VIRTUAL_ENV"; }
+rm_venv() { rm -rf .venv; }
+deact_venv() { source deactivate; }
 
-# -------------------------------
-# Python venv 도움말
-# -------------------------------
+alias create-venv='create_venv'
+alias act-venv='act_venv'
+alias echo-venv='echo_venv'
+alias rm-venv='rm_venv'
+alias deact-venv='deact_venv'
+
+alias cv='create_venv'
+alias av='act_venv'
+alias ev='echo_venv'
+alias rv='rm_venv'
+alias dv='deact_venv'

--- a/shell-common/tools/integrations/python.sh
+++ b/shell-common/tools/integrations/python.sh
@@ -6,20 +6,14 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Python Virtual Environment
 # pyenv-virtualenv: deactivate must be sourced. Run 'source deactivate' instead of 'deactivate'
-create_venv() { python -m venv .venv; }
-act_venv() { . .venv/bin/activate; }
-echo_venv() { echo "$VIRTUAL_ENV"; }
-rm_venv() { rm -rf .venv; }
-deact_venv() { source deactivate; }
+alias create-venv='python -m venv .venv'
+alias act-venv='. .venv/bin/activate'
+alias echo-venv='echo "$VIRTUAL_ENV"'
+alias rm-venv='rm -rf .venv'
+alias deact-venv='source deactivate'
 
-alias create-venv='create_venv'
-alias act-venv='act_venv'
-alias echo-venv='echo_venv'
-alias rm-venv='rm_venv'
-alias deact-venv='deact_venv'
-
-alias cv='create_venv'
-alias av='act_venv'
-alias ev='echo_venv'
-alias rv='rm_venv'
-alias dv='deact_venv'
+alias cv='python -m venv .venv'
+alias av='. .venv/bin/activate'
+alias ev='echo $VIRTUAL_ENV'
+alias rv='rm -rf .venv'
+alias dv='source deactivate'

--- a/shell-common/tools/integrations/python.sh
+++ b/shell-common/tools/integrations/python.sh
@@ -5,15 +5,15 @@
 export PATH="$HOME/.local/bin:$PATH"
 
 # Python Virtual Environment
-# pyenv-virtualenv: deactivate must be sourced. Run 'source deactivate' instead of 'deactivate'
+# pyenv-virtualenv: deactivate must be dot-sourced ('. deactivate')
 alias create-venv='python -m venv .venv'
 alias act-venv='. .venv/bin/activate'
 alias echo-venv='echo "$VIRTUAL_ENV"'
 alias rm-venv='rm -rf .venv'
-alias deact-venv='source deactivate'
+alias deact-venv='. deactivate'
 
 alias cv='python -m venv .venv'
 alias av='. .venv/bin/activate'
-alias ev='echo $VIRTUAL_ENV'
+alias ev='echo "$VIRTUAL_ENV"'
 alias rv='rm -rf .venv'
-alias dv='source deactivate'
+alias dv='. deactivate'


### PR DESCRIPTION
## Summary
- Apply 5 UX rules consistently across all `*_help.sh` files (30 files, 31 total changed)
- Remove `echo ""` between sections — `ux_section` handles spacing
- Merge "Full Commands" + "Short Aliases" into single "Commands" section with `long-name (short)` format
- Remove Quick Workflow / Practical Examples / Troubleshooting narrative sections
- Rename venv aliases to dash-form (`create-venv`, `act-venv`, etc.)
- Fix shebangs to `#!/bin/sh` where needed
- Net result: **-786 lines** of redundant help text

## Changed Files (31)
- 30 help functions under `shell-common/functions/`
- 1 integration file: `shell-common/tools/integrations/python.sh` (venv alias rename)

## Test plan
- [x] `sh -n` syntax check passed for all 29 files
- [ ] Run `py-help`, `git-help`, `docker-help` to verify output
- [ ] Run `my-help` to verify help system still works
- [ ] Open new shell session to verify aliases load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->