### PR TITLE
fix: use official Ubuntu mirrors instead of Samsung internal Nexus

### DIFF
--- a/apt/sources.list.jammy
+++ b/apt/sources.list.jammy
@@ -1,0 +1,17 @@
+# MANAGED_BY_DOTFILES — do not edit manually (deployed by setup.sh)
+# Ubuntu 22.04 (jammy) APT sources — official Ubuntu mirrors
+# Source: ~/dotfiles/apt/sources.list.jammy
+#
+# Original backed up to /etc/apt/sources.list.backup.YYYYMMDDHHMMSS
+
+deb http://archive.ubuntu.com/ubuntu jammy main restricted
+deb http://archive.ubuntu.com/ubuntu jammy-updates main restricted
+deb http://archive.ubuntu.com/ubuntu jammy universe
+deb http://archive.ubuntu.com/ubuntu jammy-updates universe
+deb http://archive.ubuntu.com/ubuntu jammy multiverse
+deb http://archive.ubuntu.com/ubuntu jammy-updates multiverse
+deb http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+
+deb http://security.ubuntu.com/ubuntu jammy-security main restricted
+deb http://security.ubuntu.com/ubuntu jammy-security universe
+deb http://security.ubuntu.com/ubuntu jammy-security multiverse

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -455,9 +455,9 @@ setup_apt_sources() {
                 ux_info "Skipped: ${_apt_os_id:-unknown} detected (only Ubuntu is supported)"
                 return 0
             fi
-            _apt_source="${DOTFILES_ROOT}/apt/sources.list.${_apt_codename}.internal"
+            _apt_source="${DOTFILES_ROOT}/apt/sources.list.${_apt_codename}"
             if [ -z "$_apt_codename" ] || [ ! -f "$_apt_source" ]; then
-                ux_info "Skipped: no apt config for '${_apt_codename:-unknown}' (available: $(ls "${DOTFILES_ROOT}"/apt/sources.list.*.internal 2>/dev/null | sed 's/.*sources\.list\.\(.*\)\.internal/\1/' | tr '\n' ' ' || echo 'none'))"
+                ux_info "Skipped: no apt config for '${_apt_codename:-unknown}' (available: $(ls "${DOTFILES_ROOT}"/apt/sources.list.* 2>/dev/null | sed 's/.*sources\.list\.//' | grep -v '\.internal$' | tr '\n' ' ' || echo 'none'))"
                 return 0
             fi
 
@@ -471,8 +471,8 @@ setup_apt_sources() {
             fi
 
             $_apt_run_privileged cp "$_apt_source" "$sources_target"
-            ux_success "Copied: apt/sources.list.${_apt_codename}.internal → $sources_target"
-            ux_info "Using: Samsung internal Nexus mirror (Ubuntu ${_apt_codename})"
+            ux_success "Copied: apt/sources.list.${_apt_codename} → $sources_target"
+            ux_info "Using: official Ubuntu mirrors (Ubuntu ${_apt_codename})"
             ux_info "Run 'sudo apt update' to refresh package lists"
             ;;
         external|public)

--- a/shell-common/tools/custom/check_apt.sh
+++ b/shell-common/tools/custom/check_apt.sh
@@ -80,7 +80,7 @@ check_apt_config_files() {
         fi
 
         if [ -n "$os_codename" ]; then
-            local source_file="${DOTFILES_ROOT}/apt/sources.list.${os_codename}.internal"
+            local source_file="${DOTFILES_ROOT}/apt/sources.list.${os_codename}"
             if [ -f "$source_file" ]; then
                 ux_section "Drift Check"
                 if diff -q "$_SOURCES_TARGET" "$source_file" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Samsung internal Nexus mirror (`repository.samsungds.net`) returns 403, breaking `auug` on internal PCs
- `setup.sh` → `internal` 선택 시 공식 Ubuntu 미러(`archive.ubuntu.com`)를 적용하도록 변경
- `apt/sources.list.jammy` 공식 미러 파일 추가, `check_apt.sh` drift check도 동일하게 수정

## Test plan
- [ ] `setup.sh` 실행 → `internal` 선택 → `/etc/apt/sources.list`가 공식 미러로 설정되는지 확인
- [ ] `auug` 실행 → 403 에러 없이 정상 동작 확인
- [ ] `check-apt` 실행 → drift check가 공식 미러 파일 기준으로 비교되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->