### PR TITLE
feat(bun): add bun config management with environment-specific symlinks

### DIFF
--- a/bun/bunfig.toml.external
+++ b/bun/bunfig.toml.external
@@ -1,0 +1,14 @@
+# bunfig.toml.external
+# Samsung external PC configuration (VPN, direct internet access)
+#
+# Usage:
+#   This file is symlinked to ~/.bunfig.toml by shell-common/setup.sh
+#   Choose this option when using VPN connection to company network
+#
+# Note: No proxy needed (direct internet access via VPN)
+
+[install]
+# Public npm registry (default)
+registry = "https://registry.npmjs.org/"
+# Corporate CA certificate for SSL verification
+cafile = "/usr/local/share/ca-certificates/samsungsemi-prx.com.crt"

--- a/bun/bunfig.toml.internal
+++ b/bun/bunfig.toml.internal
@@ -1,0 +1,17 @@
+# bunfig.toml.internal
+# Samsung internal PC configuration (direct connection, requires proxy)
+#
+# Usage:
+#   This file is symlinked to ~/.bunfig.toml by shell-common/setup.sh
+#   Choose this option when using company internal network
+#
+# Note: Proxy is managed via environment variables (proxy.local.sh sets
+#       HTTP_PROXY, HTTPS_PROXY, NO_PROXY which bun respects automatically).
+#       bunfig.toml does NOT have proxy fields.
+# Note: bun uses system SSL by default, so cafile points to system CA bundle.
+
+[install]
+# Samsung internal Nexus proxy for npm registry
+registry = "http://repository.samsungds.net/repository/proxy-npm-registry.npmjs.org/"
+# System CA bundle (same as npmrc.internal)
+cafile = "/etc/ssl/certs/ca-certificates.crt"

--- a/shell-common/env/path.sh
+++ b/shell-common/env/path.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # path.bash
 # PATH 관련 환경 변수 설정
 
@@ -10,6 +10,13 @@ export PATH="/usr/local/go/bin:$PATH" # Go
 
 # 사용자 정의 스크립트 경로
 export PATH="${DOTFILES_BASH_DIR:-${DOTFILES_ROOT:-$HOME/dotfiles}/bash}/scripts:$PATH"
+
+# Bun (JavaScript runtime/package manager)
+# bun.sh/install 로 설치 시 ~/.bun/bin 에 바이너리 설치됨
+if [ -d "$HOME/.bun/bin" ]; then
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+fi
 
 # PATH 변수 중복 제거 함수
 # PathCleaner.clean_paths()

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -206,23 +206,22 @@ setup_bun_config() {
 
     ux_header "Setting up Bun configuration for: $environment"
 
-    _prepare_config_target "$bunfig_target"
-
     # Create symlink based on environment
     case "$environment" in
         internal)
+            _prepare_config_target "$bunfig_target"
             ln -s "${DOTFILES_ROOT}/bun/bunfig.toml.internal" "$bunfig_target"
             ux_success "Created symlink: ~/.bunfig.toml → bun/bunfig.toml.internal"
             ux_info "Using: Samsung internal Nexus registry for npm packages"
             ;;
         external)
+            _prepare_config_target "$bunfig_target"
             ln -s "${DOTFILES_ROOT}/bun/bunfig.toml.external" "$bunfig_target"
             ux_success "Created symlink: ~/.bunfig.toml → bun/bunfig.toml.external"
             ux_info "Using: Public npmjs registry (no proxy)"
             ;;
         public)
-            # Public PC: no bunfig.toml needed (defaults)
-            ux_info "No bunfig.toml needed (using bun defaults)"
+            _restore_config_from_backup "$bunfig_target"
             ;;
     esac
 }

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -34,6 +34,7 @@ SECURITY_CONFIG_internal="/etc/ssl/certs/ca-certificates.crt"
 # Tool-specific configurations are managed via tracked files at project root
 # and symlinked to their respective locations:
 #   npm/   → ~/.npmrc
+#   bun/   → ~/.bunfig.toml
 #   pip/   → ~/.config/pip/pip.conf
 #   uv/    → ~/.config/uv/uv.toml
 
@@ -195,6 +196,33 @@ setup_npm_symlink() {
         public)
             # Public PC: no .npmrc needed (defaults)
             ux_info "No .npmrc needed (using npm defaults)"
+            ;;
+    esac
+}
+
+setup_bun_config() {
+    environment="$1"
+    bunfig_target="$HOME/.bunfig.toml"
+
+    ux_header "Setting up Bun configuration for: $environment"
+
+    _prepare_config_target "$bunfig_target"
+
+    # Create symlink based on environment
+    case "$environment" in
+        internal)
+            ln -s "${DOTFILES_ROOT}/bun/bunfig.toml.internal" "$bunfig_target"
+            ux_success "Created symlink: ~/.bunfig.toml → bun/bunfig.toml.internal"
+            ux_info "Using: Samsung internal Nexus registry for npm packages"
+            ;;
+        external)
+            ln -s "${DOTFILES_ROOT}/bun/bunfig.toml.external" "$bunfig_target"
+            ux_success "Created symlink: ~/.bunfig.toml → bun/bunfig.toml.external"
+            ux_info "Using: Public npmjs registry (no proxy)"
+            ;;
+        public)
+            # Public PC: no bunfig.toml needed (defaults)
+            ux_info "No bunfig.toml needed (using bun defaults)"
             ;;
     esac
 }
@@ -518,6 +546,7 @@ main() {
             ux_info "Selected: Public PC"
             cleanup_local_files
             setup_npm_symlink "public"
+            setup_bun_config "public"
             setup_pip_config "public"
             setup_uv_config "public"
             setup_cargo_config "public"
@@ -536,6 +565,7 @@ main() {
             cleanup_local_files
             setup_local_files "internal"
             setup_npm_symlink "internal"
+            setup_bun_config "internal"
             setup_pip_config "internal"
             setup_uv_config "internal"
             setup_cargo_config "internal"
@@ -551,6 +581,7 @@ main() {
             ux_info "  - SSL Certificate: McAfee (/usr/share/ca-certificates/extra/McAfee_Certificate.crt)"
             ux_info "  - Proxy: Company proxy (12.26.204.100:8080) configured"
             ux_info "  - NPM: ~/.npmrc → npm/npmrc.internal (Nexus + proxy)"
+            ux_info "  - Bun: ~/.bunfig.toml → bun/bunfig.toml.internal (Nexus registry)"
             ux_info "  - Pip: Samsung internal repository configured"
             ux_info "  - uv: Samsung internal repository + proxy configured"
             ux_info "  - Cargo: ~/.cargo/config.toml (Nexus proxy for crates.io)"
@@ -570,6 +601,7 @@ main() {
             cleanup_local_files
             setup_local_files "external"
             setup_npm_symlink "external"
+            setup_bun_config "external"
             setup_pip_config "external"
             setup_uv_config "external"
             setup_cargo_config "external"
@@ -585,6 +617,7 @@ main() {
             ux_info "  - SSL Certificate: samsungsemi (/usr/local/share/ca-certificates/samsungsemi-prx.com.crt)"
             ux_info "  - Proxy: Skipped (not needed for VPN - direct connection)"
             ux_info "  - NPM: ~/.npmrc → npm/npmrc.external (npmjs + no proxy)"
+            ux_info "  - Bun: ~/.bunfig.toml → bun/bunfig.toml.external (public registry)"
             ux_info "  - Pip: Public PyPI configured"
             ux_info "  - Next: Run 'setup_crt.sh' to install the certificate"
             ux_info "Setup mode saved to: ~/.dotfiles-setup-mode"


### PR DESCRIPTION
## Summary
- bun PATH를 `bash/profile.bash`에서 `shell-common/env/path.sh`로 이동하여 bash/zsh 공통 조건부 로딩
- `bun/bunfig.toml.internal` (사내 Nexus registry), `bun/bunfig.toml.external` (public registry) 환경별 config 추가
- `shell-common/setup.sh`에 `setup_bun_config()` 함수 추가 — npm/pip/uv/cargo와 동일한 symlink 패턴
- public 환경 전환 시 `_restore_config_from_backup()`으로 사용자 설정 복원 (cargo/nuget 패턴 준수)

## Test plan
- [x] `./setup.sh` 실행 후 환경별(1/2/3) `~/.bunfig.toml` symlink 정상 생성 확인
- [x] internal → public 전환 시 기존 사용자 bunfig.toml 백업 복원 확인
- [x] bun 미설치 환경에서 PATH 오류 없이 shell 시작 확인
- [ ] `bunx oh-my-opencode install` 사내 PC(zsh)에서 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->