### PR TITLE
feat(redis): add Redis integration for WSL

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -144,7 +144,7 @@ _register_default_help_categories() {
 
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git uv py nvm npm pp cli ux du psql mytool}"
-    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql gpu network}"
+    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip}"
@@ -204,6 +204,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[gc_help]="${HELP_DESCRIPTIONS[gc_help]:-[CLI] git-crypt encryption}"
     HELP_DESCRIPTIONS[mytool_help]="${HELP_DESCRIPTIONS[mytool_help]:-[Development] Custom tools and scripts}"
     HELP_DESCRIPTIONS[mysql_help]="${HELP_DESCRIPTIONS[mysql_help]:-[DevOps] MySQL service management}"
+    HELP_DESCRIPTIONS[redis_help]="${HELP_DESCRIPTIONS[redis_help]:-[DevOps] Redis service management}"
     HELP_DESCRIPTIONS[zsh_help]="${HELP_DESCRIPTIONS[zsh_help]:-[CLI] Zsh shell management}"
     HELP_DESCRIPTIONS[zsh_autosuggestions_help]="${HELP_DESCRIPTIONS[zsh_autosuggestions_help]:-[CLI] zsh-autosuggestions plugin}"
     HELP_DESCRIPTIONS[bat_help]="${HELP_DESCRIPTIONS[bat_help]:-[CLI] bat file viewer}"

--- a/shell-common/functions/redis_help.sh
+++ b/shell-common/functions/redis_help.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# shell-common/functions/redis_help.sh
+
+redis_help() {
+    ux_header "Redis Service Management"
+
+    ux_section "Commands"
+    ux_table_row "redis-server-ctl <action>" "Manage service" "start, stop, restart, status"
+    ux_table_row "redis-ping" "Health check" "PING/PONG test"
+    ux_table_row "redis-info [section]" "Server info" "server, memory, clients, etc."
+    ux_table_row "redis-monitor" "Live monitor" "Real-time command stream"
+    ux_table_row "redis-dbsize" "Key count" "Current DB key count"
+    ux_table_row "redis-keys [pattern]" "Scan keys" "SCAN with glob pattern"
+    ux_table_row "redis-flush <db|all>" "Flush data" "Clear current DB or all DBs"
+    ux_table_row "redis-config-get <param>" "Config value" "Get runtime config"
+    ux_table_row "redis-slowlog [count]" "Slow queries" "Recent slow log entries"
+    ux_table_row "redis-clients" "Client list" "Connected clients info"
+    ux_table_row "redis-memory" "Memory stats" "Memory usage details"
+    ux_table_row "install-redis" "Install Redis" "Interactive installer for WSL"
+
+    ux_section "Environment"
+    ux_table_row "REDIS_DEFAULT_HOST" "Server host" "Default: 127.0.0.1"
+    ux_table_row "REDIS_DEFAULT_PORT" "Server port" "Default: 6379"
+}
+
+alias redis-help='redis_help'

--- a/shell-common/functions/redis_help.sh
+++ b/shell-common/functions/redis_help.sh
@@ -10,7 +10,7 @@ redis_help() {
     ux_table_row "redis-info [section]" "Server info" "server, memory, clients, etc."
     ux_table_row "redis-monitor" "Live monitor" "Real-time command stream"
     ux_table_row "redis-dbsize" "Key count" "Current DB key count"
-    ux_table_row "redis-keys [pattern]" "Scan keys" "SCAN with glob pattern"
+    ux_table_row "redis-keys [pattern] [limit]" "Scan keys" "SCAN with glob pattern (default: 20)"
     ux_table_row "redis-flush <db|all>" "Flush data" "Clear current DB or all DBs"
     ux_table_row "redis-config-get <param>" "Config value" "Get runtime config"
     ux_table_row "redis-slowlog [count]" "Slow queries" "Recent slow log entries"
@@ -19,6 +19,7 @@ redis_help() {
     ux_table_row "install-redis" "Install Redis" "Interactive installer for WSL"
 
     ux_section "Environment"
+    ux_table_row "REDISCLI_AUTH" "Password" "Auto-auth for all commands"
     ux_table_row "REDIS_DEFAULT_HOST" "Server host" "Default: 127.0.0.1"
     ux_table_row "REDIS_DEFAULT_PORT" "Server port" "Default: 6379"
 }

--- a/shell-common/tools/custom/install_redis.sh
+++ b/shell-common/tools/custom/install_redis.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# shell-common/tools/custom/install_redis.sh
+# Redis server installer for WSL/Ubuntu (interactive)
+
+set -e
+
+# Initialize common tools environment
+source "$(dirname "$0")/init.sh" || exit 1
+
+main() {
+    clear
+    ux_header "Redis Server Installer for WSL/Ubuntu"
+    ux_info "This script installs Redis server and CLI tools."
+
+    ux_section "Installation Steps"
+    ux_numbered 1 "Update package sources"
+    ux_numbered 2 "Install Redis server"
+    ux_numbered 3 "Start and enable Redis service"
+    ux_numbered 4 "Configure Redis (optional)"
+    ux_numbered 5 "Verify installation"
+    echo ""
+    ux_warning "This script requires sudo privileges."
+    echo ""
+
+    if ! ux_confirm "Do you want to proceed with the installation?" "y"; then
+        ux_warning "Installation cancelled."
+        exit 0
+    fi
+
+    # Request sudo privileges upfront
+    ux_info "Requesting sudo privileges for the installation..."
+    if ! sudo -v; then
+        ux_error "Sudo privileges are required. Aborting."
+        exit 1
+    fi
+    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done &>/dev/null &
+    local sudo_keep_alive_pid=$!
+    trap 'kill "$sudo_keep_alive_pid" 2>/dev/null' EXIT
+
+    # ========================================
+    # Step 1: Update package manager
+    # ========================================
+    ux_step "1/5" "Updating package sources..."
+    if ! ux_with_spinner "Updating apt cache" sudo apt-get update -qq; then
+        exit 1
+    fi
+
+    # ========================================
+    # Step 2: Install Redis
+    # ========================================
+    ux_step "2/5" "Installing Redis server..."
+    if ! ux_with_spinner "Installing redis-server" sudo apt-get install -y -qq redis-server redis-tools; then
+        ux_error "Redis installation failed."
+        exit 1
+    fi
+
+    # ========================================
+    # Step 3: Start & Enable Service
+    # ========================================
+    ux_step "3/5" "Starting and enabling Redis service..."
+
+    # Check if systemd is available
+    if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
+        if ! sudo systemctl start redis-server; then
+            ux_warning "Failed to start Redis service via systemctl."
+        else
+            ux_success "Redis service started."
+        fi
+        if ! sudo systemctl enable redis-server; then
+            ux_warning "Failed to enable Redis service on boot."
+        else
+            ux_success "Redis service enabled on boot."
+        fi
+    else
+        # WSL without systemd: use service command
+        if ! sudo service redis-server start; then
+            ux_warning "Failed to start Redis service."
+        else
+            ux_success "Redis service started."
+        fi
+        ux_info "systemd not detected. To auto-start Redis, enable systemd in /etc/wsl.conf:"
+        echo "  [boot]"
+        echo "  systemd=true"
+        echo ""
+        ux_info "Then restart WSL: ${UX_PRIMARY}wsl --shutdown${UX_RESET}"
+    fi
+    echo ""
+
+    # ========================================
+    # Step 4: Optional Configuration
+    # ========================================
+    ux_step "4/5" "Configuring Redis (optional)..."
+
+    # Bind to localhost only (security)
+    local redis_conf="/etc/redis/redis.conf"
+    if [[ -f "$redis_conf" ]]; then
+        ux_info "Redis config file: $redis_conf"
+
+        if ux_confirm "Set maxmemory to 256mb (recommended for dev)?" "y"; then
+            if grep -q "^maxmemory " "$redis_conf"; then
+                sudo sed -i 's/^maxmemory .*/maxmemory 256mb/' "$redis_conf"
+            else
+                echo "maxmemory 256mb" | sudo tee -a "$redis_conf" >/dev/null
+            fi
+            # Set eviction policy
+            if grep -q "^maxmemory-policy " "$redis_conf"; then
+                sudo sed -i 's/^maxmemory-policy .*/maxmemory-policy allkeys-lru/' "$redis_conf"
+            else
+                echo "maxmemory-policy allkeys-lru" | sudo tee -a "$redis_conf" >/dev/null
+            fi
+            ux_success "maxmemory set to 256mb with allkeys-lru eviction."
+
+            # Restart to apply config
+            if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
+                sudo systemctl restart redis-server
+            else
+                sudo service redis-server restart
+            fi
+        else
+            ux_info "Configuration skipped. Using defaults."
+        fi
+
+        if ux_confirm "Set a password for Redis? (recommended for security)" "n"; then
+            printf "%s> %sEnter Redis password: " "${UX_PRIMARY}" "${UX_RESET}"
+            read -r -s redis_pass
+            echo ""
+            if [[ -n "$redis_pass" ]]; then
+                if grep -q "^requirepass " "$redis_conf"; then
+                    sudo sed -i "s/^requirepass .*/requirepass $redis_pass/" "$redis_conf"
+                else
+                    echo "requirepass $redis_pass" | sudo tee -a "$redis_conf" >/dev/null
+                fi
+                ux_success "Password set. Use: redis-cli -a <password>"
+
+                # Restart to apply
+                if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
+                    sudo systemctl restart redis-server
+                else
+                    sudo service redis-server restart
+                fi
+            fi
+        fi
+    else
+        ux_warning "Redis config file not found at $redis_conf"
+    fi
+    echo ""
+
+    # ========================================
+    # Step 5: Verify Installation
+    # ========================================
+    ux_step "5/5" "Verifying installation..."
+
+    if command -v redis-server &>/dev/null; then
+        ux_info "Redis Server Version:"
+        redis-server --version
+    else
+        ux_error "redis-server command not found after installation."
+    fi
+
+    if command -v redis-cli &>/dev/null; then
+        ux_info "Redis CLI Version:"
+        redis-cli --version
+
+        # Ping test
+        local ping_result
+        ping_result=$(redis-cli ping 2>/dev/null)
+        if [[ "$ping_result" == "PONG" ]]; then
+            ux_success "Redis is responding to PING."
+        else
+            ux_warning "Redis did not respond to PING. Service may not be running."
+        fi
+    else
+        ux_error "redis-cli command not found."
+    fi
+
+    # Clean up sudo keep-alive
+    kill "$sudo_keep_alive_pid" 2>/dev/null || true
+    trap - EXIT
+
+    # ========================================
+    # Completion
+    # ========================================
+    echo ""
+    ux_header "Redis Installation Complete!"
+    ux_section "Next Steps"
+    ux_numbered 1 "Check status: ${UX_PRIMARY}redis-server-ctl status${UX_RESET}"
+    ux_numbered 2 "Test connection: ${UX_PRIMARY}redis-ping${UX_RESET}"
+    ux_numbered 3 "View all helpers: ${UX_PRIMARY}redis-help${UX_RESET}"
+    echo ""
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+    main "$@"
+fi

--- a/shell-common/tools/custom/install_redis.sh
+++ b/shell-common/tools/custom/install_redis.sh
@@ -7,12 +7,10 @@ set -e
 # Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
-# Internal: check if systemd is PID 1
 _installer_has_systemd() {
     command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]
 }
 
-# Internal: restart redis-server using appropriate init system
 _installer_restart_redis() {
     if _installer_has_systemd; then
         sudo systemctl restart redis-server
@@ -21,20 +19,22 @@ _installer_restart_redis() {
     fi
 }
 
-# Internal: safely write requirepass to redis.conf without sed interpolation issues
-# Uses grep + tee to avoid special character problems (/, &, \ in passwords)
+# Safely write requirepass to redis.conf.
+# Uses grep + printf to avoid sed special-character injection (/, &, \).
+# Temp file is created in /etc/redis/ for atomic mv on same filesystem.
 _installer_set_requirepass() {
     local redis_conf="$1"
     local password="$2"
+    local conf_dir
+    conf_dir=$(dirname "$redis_conf")
     local tmp_conf
+    tmp_conf=$(sudo mktemp "${conf_dir}/redis.conf.XXXXXX")
+    trap 'sudo rm -f "$tmp_conf"' RETURN
 
-    tmp_conf=$(mktemp)
-    # Remove existing requirepass line(s) and append the new one
     grep -v "^requirepass " "$redis_conf" | sudo tee "$tmp_conf" >/dev/null
     printf "requirepass %s\n" "$password" | sudo tee -a "$tmp_conf" >/dev/null
-    sudo cp "$tmp_conf" "$redis_conf"
-    sudo chmod 640 "$redis_conf"
-    rm -f "$tmp_conf"
+    sudo chmod 640 "$tmp_conf"
+    sudo mv "$tmp_conf" "$redis_conf"
 }
 
 main() {
@@ -57,7 +57,6 @@ main() {
         exit 0
     fi
 
-    # Request sudo privileges upfront
     ux_info "Requesting sudo privileges for the installation..."
     if ! sudo -v; then
         ux_error "Sudo privileges are required. Aborting."
@@ -67,26 +66,17 @@ main() {
     local sudo_keep_alive_pid=$!
     trap 'kill "$sudo_keep_alive_pid" 2>/dev/null' EXIT
 
-    # ========================================
-    # Step 1: Update package manager
-    # ========================================
     ux_step "1/5" "Updating package sources..."
     if ! ux_with_spinner "Updating apt cache" sudo apt-get update -qq; then
         exit 1
     fi
 
-    # ========================================
-    # Step 2: Install Redis
-    # ========================================
     ux_step "2/5" "Installing Redis server..."
     if ! ux_with_spinner "Installing redis-server" sudo apt-get install -y -qq redis-server redis-tools; then
         ux_error "Redis installation failed."
         exit 1
     fi
 
-    # ========================================
-    # Step 3: Start & Enable Service
-    # ========================================
     ux_step "3/5" "Starting and enabling Redis service..."
 
     if _installer_has_systemd; then
@@ -101,7 +91,6 @@ main() {
             ux_success "Redis service enabled on boot."
         fi
     else
-        # WSL without systemd: use service command
         if ! sudo service redis-server start; then
             ux_warning "Failed to start Redis service."
         else
@@ -115,9 +104,6 @@ main() {
     fi
     echo ""
 
-    # ========================================
-    # Step 4: Optional Configuration
-    # ========================================
     ux_step "4/5" "Configuring Redis (optional)..."
 
     local redis_conf="/etc/redis/redis.conf"
@@ -132,7 +118,6 @@ main() {
             else
                 echo "maxmemory 256mb" | sudo tee -a "$redis_conf" >/dev/null
             fi
-            # Set eviction policy
             if grep -q "^maxmemory-policy " "$redis_conf"; then
                 sudo sed -i 's/^maxmemory-policy .*/maxmemory-policy allkeys-lru/' "$redis_conf"
             else
@@ -160,9 +145,6 @@ main() {
     fi
     echo ""
 
-    # ========================================
-    # Step 5: Verify Installation
-    # ========================================
     ux_step "5/5" "Verifying installation..."
 
     if command -v redis-server &>/dev/null; then
@@ -176,7 +158,6 @@ main() {
         ux_info "Redis CLI Version:"
         redis-cli --version
 
-        # Ping test (use password if it was just set)
         local ping_result
         if [[ "$password_was_set" = "true" ]]; then
             ping_result=$(REDISCLI_AUTH="$redis_pass" redis-cli ping 2>/dev/null)
@@ -192,13 +173,9 @@ main() {
         ux_error "redis-cli command not found."
     fi
 
-    # Clean up sudo keep-alive
     kill "$sudo_keep_alive_pid" 2>/dev/null || true
     trap - EXIT
 
-    # ========================================
-    # Completion
-    # ========================================
     echo ""
     ux_header "Redis Installation Complete!"
 

--- a/shell-common/tools/custom/install_redis.sh
+++ b/shell-common/tools/custom/install_redis.sh
@@ -7,6 +7,36 @@ set -e
 # Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
+# Internal: check if systemd is PID 1
+_installer_has_systemd() {
+    command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]
+}
+
+# Internal: restart redis-server using appropriate init system
+_installer_restart_redis() {
+    if _installer_has_systemd; then
+        sudo systemctl restart redis-server
+    else
+        sudo service redis-server restart
+    fi
+}
+
+# Internal: safely write requirepass to redis.conf without sed interpolation issues
+# Uses grep + tee to avoid special character problems (/, &, \ in passwords)
+_installer_set_requirepass() {
+    local redis_conf="$1"
+    local password="$2"
+    local tmp_conf
+
+    tmp_conf=$(mktemp)
+    # Remove existing requirepass line(s) and append the new one
+    grep -v "^requirepass " "$redis_conf" | sudo tee "$tmp_conf" >/dev/null
+    printf "requirepass %s\n" "$password" | sudo tee -a "$tmp_conf" >/dev/null
+    sudo cp "$tmp_conf" "$redis_conf"
+    sudo chmod 640 "$redis_conf"
+    rm -f "$tmp_conf"
+}
+
 main() {
     clear
     ux_header "Redis Server Installer for WSL/Ubuntu"
@@ -59,8 +89,7 @@ main() {
     # ========================================
     ux_step "3/5" "Starting and enabling Redis service..."
 
-    # Check if systemd is available
-    if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
+    if _installer_has_systemd; then
         if ! sudo systemctl start redis-server; then
             ux_warning "Failed to start Redis service via systemctl."
         else
@@ -91,8 +120,9 @@ main() {
     # ========================================
     ux_step "4/5" "Configuring Redis (optional)..."
 
-    # Bind to localhost only (security)
     local redis_conf="/etc/redis/redis.conf"
+    local password_was_set=false
+
     if [[ -f "$redis_conf" ]]; then
         ux_info "Redis config file: $redis_conf"
 
@@ -109,13 +139,7 @@ main() {
                 echo "maxmemory-policy allkeys-lru" | sudo tee -a "$redis_conf" >/dev/null
             fi
             ux_success "maxmemory set to 256mb with allkeys-lru eviction."
-
-            # Restart to apply config
-            if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
-                sudo systemctl restart redis-server
-            else
-                sudo service redis-server restart
-            fi
+            _installer_restart_redis
         else
             ux_info "Configuration skipped. Using defaults."
         fi
@@ -125,19 +149,10 @@ main() {
             read -r -s redis_pass
             echo ""
             if [[ -n "$redis_pass" ]]; then
-                if grep -q "^requirepass " "$redis_conf"; then
-                    sudo sed -i "s/^requirepass .*/requirepass $redis_pass/" "$redis_conf"
-                else
-                    echo "requirepass $redis_pass" | sudo tee -a "$redis_conf" >/dev/null
-                fi
-                ux_success "Password set. Use: redis-cli -a <password>"
-
-                # Restart to apply
-                if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
-                    sudo systemctl restart redis-server
-                else
-                    sudo service redis-server restart
-                fi
+                _installer_set_requirepass "$redis_conf" "$redis_pass"
+                password_was_set=true
+                ux_success "Password set."
+                _installer_restart_redis
             fi
         fi
     else
@@ -161,9 +176,13 @@ main() {
         ux_info "Redis CLI Version:"
         redis-cli --version
 
-        # Ping test
+        # Ping test (use password if it was just set)
         local ping_result
-        ping_result=$(redis-cli ping 2>/dev/null)
+        if [[ "$password_was_set" = "true" ]]; then
+            ping_result=$(REDISCLI_AUTH="$redis_pass" redis-cli ping 2>/dev/null)
+        else
+            ping_result=$(redis-cli ping 2>/dev/null)
+        fi
         if [[ "$ping_result" == "PONG" ]]; then
             ux_success "Redis is responding to PING."
         else
@@ -182,6 +201,15 @@ main() {
     # ========================================
     echo ""
     ux_header "Redis Installation Complete!"
+
+    if [[ "$password_was_set" = "true" ]]; then
+        ux_section "Authentication"
+        ux_info "Password was configured. Add this to your shell profile:"
+        echo "  ${UX_PRIMARY}export REDISCLI_AUTH=\"<your-password>\"${UX_RESET}"
+        echo ""
+        ux_info "All redis-* helper commands will authenticate automatically via REDISCLI_AUTH."
+    fi
+
     ux_section "Next Steps"
     ux_numbered 1 "Check status: ${UX_PRIMARY}redis-server-ctl status${UX_RESET}"
     ux_numbered 2 "Test connection: ${UX_PRIMARY}redis-ping${UX_RESET}"

--- a/shell-common/tools/integrations/redis.sh
+++ b/shell-common/tools/integrations/redis.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+# shell-common/tools/integrations/redis.sh
+# Redis service bootstrap and helpers for WSL
+
+# -------------------------------
+# Configuration
+# -------------------------------
+REDIS_DEFAULT_HOST="${REDIS_DEFAULT_HOST:-127.0.0.1}"
+REDIS_DEFAULT_PORT="${REDIS_DEFAULT_PORT:-6379}"
+
+# -------------------------------
+# 1) Server Management
+# -------------------------------
+redis_server() {
+    local action="${1:-}"
+
+    if [ -z "$action" ]; then
+        ux_usage "redis-server-ctl" "<start|stop|restart|status>" "Manage Redis service"
+        ux_section "Commands"
+        ux_bullet "start   — Start Redis server"
+        ux_bullet "stop    — Stop Redis server"
+        ux_bullet "restart — Restart Redis server"
+        ux_bullet "status  — Show service status"
+        return 1
+    fi
+
+    case "$action" in
+    start | stop | restart | status)
+        if command -v systemctl >/dev/null 2>&1; then
+            ux_info "Running: sudo systemctl $action redis-server"
+            sudo systemctl "$action" redis-server
+        else
+            ux_info "Running: sudo service redis-server $action"
+            sudo service redis-server "$action"
+        fi
+        ;;
+    *)
+        ux_error "Unknown action: $action"
+        ux_usage "redis-server-ctl" "<start|stop|restart|status>" ""
+        return 1
+        ;;
+    esac
+}
+
+# -------------------------------
+# 2) Connection Helper
+# -------------------------------
+redis_cli_connect() {
+    local host="${1:-$REDIS_DEFAULT_HOST}"
+    local port="${2:-$REDIS_DEFAULT_PORT}"
+    local password="${3:-}"
+
+    if [ -n "$password" ]; then
+        redis-cli -h "$host" -p "$port" -a "$password"
+    else
+        redis-cli -h "$host" -p "$port"
+    fi
+}
+
+# -------------------------------
+# 3) Quick Commands
+# -------------------------------
+redis_ping() {
+    local host="${1:-$REDIS_DEFAULT_HOST}"
+    local port="${2:-$REDIS_DEFAULT_PORT}"
+    local result
+    result=$(redis-cli -h "$host" -p "$port" ping 2>/dev/null)
+    if [ "$result" = "PONG" ]; then
+        ux_success "Redis is running (${host}:${port})"
+    else
+        ux_error "Redis is not responding (${host}:${port})"
+        return 1
+    fi
+}
+
+redis_info() {
+    local section="${1:-server}"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" INFO "$section"
+}
+
+redis_monitor() {
+    ux_warning "Entering MONITOR mode (Ctrl+C to exit)"
+    ux_info "Shows all commands processed by Redis in real-time"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" MONITOR
+}
+
+redis_dbsize() {
+    local result
+    result=$(redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" DBSIZE 2>/dev/null)
+    ux_info "Database size: $result"
+}
+
+redis_keys() {
+    local pattern="${1:-*}"
+    local count="${2:-20}"
+    ux_info "Scanning keys matching '$pattern' (limit: $count)"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" --scan --pattern "$pattern" --count "$count"
+}
+
+redis_flush() {
+    local target="${1:-}"
+    if [ -z "$target" ]; then
+        ux_usage "redis-flush" "<db|all>" "Flush Redis data"
+        ux_bullet "db  — Flush current database (FLUSHDB)"
+        ux_bullet "all — Flush all databases (FLUSHALL)"
+        return 1
+    fi
+
+    case "$target" in
+    db)
+        if ux_confirm "Flush current Redis database?" "n"; then
+            redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" FLUSHDB
+            ux_success "Current database flushed."
+        else
+            ux_info "Operation cancelled."
+        fi
+        ;;
+    all)
+        if ux_confirm "Flush ALL Redis databases? This cannot be undone!" "n"; then
+            redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" FLUSHALL
+            ux_success "All databases flushed."
+        else
+            ux_info "Operation cancelled."
+        fi
+        ;;
+    *)
+        ux_error "Unknown target: $target (use 'db' or 'all')"
+        return 1
+        ;;
+    esac
+}
+
+redis_config_get() {
+    local param="${1:-}"
+    if [ -z "$param" ]; then
+        ux_usage "redis-config-get" "<parameter>" "Get Redis config value"
+        ux_bullet "Example: redis-config-get maxmemory"
+        return 1
+    fi
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" CONFIG GET "$param"
+}
+
+redis_slowlog() {
+    local count="${1:-10}"
+    ux_header "Redis Slow Log (last $count entries)"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" SLOWLOG GET "$count"
+}
+
+redis_clients() {
+    ux_header "Connected Redis Clients"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" CLIENT LIST
+}
+
+redis_memory() {
+    ux_header "Redis Memory Usage"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" INFO memory
+}
+
+# -------------------------------
+# 4) Install Wrapper
+# -------------------------------
+install_redis() {
+    bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_redis.sh"
+}
+
+# -------------------------------
+# 5) Aliases (dash-form)
+# -------------------------------
+alias redis-server-ctl='redis_server'
+alias redis-ping='redis_ping'
+alias redis-info='redis_info'
+alias redis-monitor='redis_monitor'
+alias redis-dbsize='redis_dbsize'
+alias redis-keys='redis_keys'
+alias redis-flush='redis_flush'
+alias redis-config-get='redis_config_get'
+alias redis-slowlog='redis_slowlog'
+alias redis-clients='redis_clients'
+alias redis-memory='redis_memory'
+alias install-redis='install_redis'

--- a/shell-common/tools/integrations/redis.sh
+++ b/shell-common/tools/integrations/redis.sh
@@ -12,10 +12,14 @@ REDIS_DEFAULT_PORT="${REDIS_DEFAULT_PORT:-6379}"
 # work transparently with or without a password.
 
 # -------------------------------
-# Internal: systemd availability check
+# Internal helpers
 # -------------------------------
 _redis_has_systemd() {
     command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]
+}
+
+_redis_cli() {
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" "$@"
 }
 
 # -------------------------------
@@ -53,17 +57,7 @@ redis_server() {
 }
 
 # -------------------------------
-# 2) Connection Helper
-# -------------------------------
-redis_cli_connect() {
-    local host="${1:-$REDIS_DEFAULT_HOST}"
-    local port="${2:-$REDIS_DEFAULT_PORT}"
-
-    redis-cli -h "$host" -p "$port"
-}
-
-# -------------------------------
-# 3) Quick Commands
+# 2) Quick Commands
 # -------------------------------
 redis_ping() {
     local host="${1:-$REDIS_DEFAULT_HOST}"
@@ -83,18 +77,18 @@ redis_ping() {
 
 redis_info() {
     local section="${1:-server}"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" INFO "$section"
+    _redis_cli INFO "$section"
 }
 
 redis_monitor() {
     ux_warning "Entering MONITOR mode (Ctrl+C to exit)"
     ux_info "Shows all commands processed by Redis in real-time"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" MONITOR
+    _redis_cli MONITOR
 }
 
 redis_dbsize() {
     local result
-    result=$(redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" DBSIZE 2>/dev/null)
+    result=$(_redis_cli DBSIZE 2>/dev/null)
     ux_info "Database size: $result"
 }
 
@@ -102,7 +96,7 @@ redis_keys() {
     local pattern="${1:-*}"
     local limit="${2:-20}"
     ux_info "Scanning keys matching '$pattern' (max: $limit results)"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" --scan --pattern "$pattern" | head -n "$limit"
+    _redis_cli --scan --pattern "$pattern" | head -n "$limit"
 }
 
 redis_flush() {
@@ -117,7 +111,7 @@ redis_flush() {
     case "$target" in
     db)
         if ux_confirm "Flush current Redis database?" "n"; then
-            redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" FLUSHDB
+            _redis_cli FLUSHDB
             ux_success "Current database flushed."
         else
             ux_info "Operation cancelled."
@@ -125,7 +119,7 @@ redis_flush() {
         ;;
     all)
         if ux_confirm "Flush ALL Redis databases? This cannot be undone!" "n"; then
-            redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" FLUSHALL
+            _redis_cli FLUSHALL
             ux_success "All databases flushed."
         else
             ux_info "Operation cancelled."
@@ -145,34 +139,34 @@ redis_config_get() {
         ux_bullet "Example: redis-config-get maxmemory"
         return 1
     fi
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" CONFIG GET "$param"
+    _redis_cli CONFIG GET "$param"
 }
 
 redis_slowlog() {
     local count="${1:-10}"
     ux_header "Redis Slow Log (last $count entries)"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" SLOWLOG GET "$count"
+    _redis_cli SLOWLOG GET "$count"
 }
 
 redis_clients() {
     ux_header "Connected Redis Clients"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" CLIENT LIST
+    _redis_cli CLIENT LIST
 }
 
 redis_memory() {
     ux_header "Redis Memory Usage"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" INFO memory
+    _redis_cli INFO memory
 }
 
 # -------------------------------
-# 4) Install Wrapper
+# 3) Install Wrapper
 # -------------------------------
 install_redis() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_redis.sh"
 }
 
 # -------------------------------
-# 5) Aliases (dash-form)
+# 4) Aliases (dash-form)
 # -------------------------------
 alias redis-server-ctl='redis_server'
 alias redis-ping='redis_ping'

--- a/shell-common/tools/integrations/redis.sh
+++ b/shell-common/tools/integrations/redis.sh
@@ -7,6 +7,16 @@
 # -------------------------------
 REDIS_DEFAULT_HOST="${REDIS_DEFAULT_HOST:-127.0.0.1}"
 REDIS_DEFAULT_PORT="${REDIS_DEFAULT_PORT:-6379}"
+# Authentication: set REDISCLI_AUTH env var for password-protected instances.
+# redis-cli reads REDISCLI_AUTH automatically, so all wrapper functions
+# work transparently with or without a password.
+
+# -------------------------------
+# Internal: systemd availability check
+# -------------------------------
+_redis_has_systemd() {
+    command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]
+}
 
 # -------------------------------
 # 1) Server Management
@@ -26,7 +36,7 @@ redis_server() {
 
     case "$action" in
     start | stop | restart | status)
-        if command -v systemctl >/dev/null 2>&1; then
+        if _redis_has_systemd; then
             ux_info "Running: sudo systemctl $action redis-server"
             sudo systemctl "$action" redis-server
         else
@@ -48,13 +58,8 @@ redis_server() {
 redis_cli_connect() {
     local host="${1:-$REDIS_DEFAULT_HOST}"
     local port="${2:-$REDIS_DEFAULT_PORT}"
-    local password="${3:-}"
 
-    if [ -n "$password" ]; then
-        redis-cli -h "$host" -p "$port" -a "$password"
-    else
-        redis-cli -h "$host" -p "$port"
-    fi
+    redis-cli -h "$host" -p "$port"
 }
 
 # -------------------------------
@@ -69,6 +74,9 @@ redis_ping() {
         ux_success "Redis is running (${host}:${port})"
     else
         ux_error "Redis is not responding (${host}:${port})"
+        if [ -z "${REDISCLI_AUTH:-}" ]; then
+            ux_info "If Redis requires a password, set: export REDISCLI_AUTH=<password>"
+        fi
         return 1
     fi
 }
@@ -92,9 +100,9 @@ redis_dbsize() {
 
 redis_keys() {
     local pattern="${1:-*}"
-    local count="${2:-20}"
-    ux_info "Scanning keys matching '$pattern' (limit: $count)"
-    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" --scan --pattern "$pattern" --count "$count"
+    local limit="${2:-20}"
+    ux_info "Scanning keys matching '$pattern' (max: $limit results)"
+    redis-cli -h "$REDIS_DEFAULT_HOST" -p "$REDIS_DEFAULT_PORT" --scan --pattern "$pattern" | head -n "$limit"
 }
 
 redis_flush() {


### PR DESCRIPTION
## Summary
- Add Redis integration with interactive installer, service management, and monitoring commands
- Support REDISCLI_AUTH env var for transparent password authentication across all wrapper functions
- Register redis-help in devops category of the help system

## New Files
| File | Role |
|------|------|
| `shell-common/tools/integrations/redis.sh` | Runtime functions + aliases (12 commands) |
| `shell-common/functions/redis_help.sh` | `redis-help` command |
| `shell-common/tools/custom/install_redis.sh` | `install-redis` interactive installer |

## Key Commands
- `install-redis` — Interactive WSL installer (apt, service, maxmemory, password)
- `redis-server-ctl` — Service management (start/stop/restart/status)
- `redis-ping` — Health check with NOAUTH hint
- `redis-info`, `redis-memory`, `redis-clients`, `redis-slowlog` — Monitoring
- `redis-keys`, `redis-flush`, `redis-config-get` — Data operations

## Review Feedback Addressed
- Unified systemd detection (PID 1 check) across redis.sh and installer
- Safe requirepass write via grep+tee+mv (no sed injection)
- Atomic config overwrite with same-filesystem tmpfile
- Extracted `_redis_cli()` helper to eliminate 10 repeated invocations

## Test plan
- [x] Run `install-redis` on a clean WSL instance
- [x] Verify `redis-ping` works with and without REDISCLI_AUTH
- [x] Verify `redis-server-ctl status` on both systemd and non-systemd WSL
- [x] Verify `redis-help` appears in `my-help devops` output
- [x] Set a password with special chars (`/`, `&`, `\`) during install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->