### PR TITLE
fix(claude): activate skills bind mount

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -130,18 +130,16 @@ EOF
     fi
 }
 
-is_skills_mounted() {
+_is_skills_mounted() {
     if command -v findmnt >/dev/null 2>&1; then
         findmnt "$HOME_SKILLS" >/dev/null 2>&1
-        return $?
+    else
+        mount | grep -q "on ${HOME_SKILLS} " 2>/dev/null
     fi
-
-    mount | grep -q "on ${HOME_SKILLS} " 2>/dev/null
-    return $?
 }
 
-mount_skills_directory() {
-    if is_skills_mounted; then
+_mount_skills_directory() {
+    if _is_skills_mounted; then
         log_dim "✓ skills bind mount가 이미 활성화되어 있습니다"
         return 0
     fi
@@ -202,10 +200,7 @@ fi
 setup_skills_mount
 
 # skills bind mount 활성화
-skills_mount_active=0
-if mount_skills_directory; then
-    skills_mount_active=1
-fi
+_mount_skills_directory
 
 # global memory 디렉토리 심볼릭 링크 생성
 if [ ! -d "$(dirname "$HOME_GLOBAL_MEMORY")" ]; then
@@ -254,7 +249,7 @@ ux_bullet "~/.claude/statusline-command.sh → ~/dotfiles/claude/statusline-comm
 ux_bullet "~/.claude/projects/GLOBAL/memory → ~/dotfiles/claude/global-memory (symlink)"
 ux_bullet "/etc/sudoers.d/claude-skills-mount (passwordless mount)"
 
-if [ "$skills_mount_active" -eq 1 ]; then
+if _is_skills_mounted; then
     ux_bullet "~/.claude/skills ← ~/dotfiles/claude/skills (bind mount active)"
 else
     ux_bullet "~/.claude/skills mount failed during setup; sudoers is configured"
@@ -262,7 +257,7 @@ fi
 echo ""
 
 ux_section "다음 단계"
-if [ "$skills_mount_active" -eq 1 ]; then
+if _is_skills_mounted; then
     ux_bullet "새 쉘에서도 skills bind mount를 자동으로 유지합니다"
 else
     ux_bullet "새 쉘에서 자동 mount를 재시도합니다"

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -107,7 +107,7 @@ setup_skills_mount() {
 
     # Create sudoers configuration
     log_info "sudoers 파일 생성: $sudoers_file"
-    cat << EOF | sudo tee "$sudoers_file" > /dev/null
+    if ! cat << EOF | sudo tee "$sudoers_file" > /dev/null
 # Allow passwordless bind mount for Claude Code skills directory
 # Created by dotfiles/claude/setup.sh
 ${USER} ALL=(ALL) NOPASSWD: /bin/mount --bind ${CLAUDE_SKILLS_SOURCE} ${HOME_SKILLS}
@@ -115,22 +115,45 @@ ${USER} ALL=(ALL) NOPASSWD: /usr/bin/mount --bind ${CLAUDE_SKILLS_SOURCE} ${HOME
 ${USER} ALL=(ALL) NOPASSWD: /bin/umount ${HOME_SKILLS}
 ${USER} ALL=(ALL) NOPASSWD: /usr/bin/umount ${HOME_SKILLS}
 EOF
-
-    if [ $? -ne 0 ]; then
+    then
         log_error "sudoers 파일 생성 실패"
         return 1
     fi
 
     # Set proper permissions
     log_info "sudoers 파일 권한 설정"
-    sudo chmod 440 "$sudoers_file"
-
-    if [ $? -eq 0 ]; then
+    if sudo chmod 440 "$sudoers_file"; then
         log_dim "✓ sudoers 설정 완료"
     else
         log_error "sudoers 파일 권한 설정 실패"
         return 1
     fi
+}
+
+is_skills_mounted() {
+    if command -v findmnt >/dev/null 2>&1; then
+        findmnt "$HOME_SKILLS" >/dev/null 2>&1
+        return $?
+    fi
+
+    mount | grep -q "on ${HOME_SKILLS} " 2>/dev/null
+    return $?
+}
+
+mount_skills_directory() {
+    if is_skills_mounted; then
+        log_dim "✓ skills bind mount가 이미 활성화되어 있습니다"
+        return 0
+    fi
+
+    log_info "skills bind mount 활성화: $HOME_SKILLS <- $CLAUDE_SKILLS_SOURCE"
+    if sudo mount --bind "$CLAUDE_SKILLS_SOURCE" "$HOME_SKILLS" 2>/dev/null; then
+        log_dim "✓ skills bind mount 완료"
+        return 0
+    fi
+
+    log_error "skills bind mount 실패"
+    return 1
 }
 
 # --- Main Script Logic ---
@@ -178,6 +201,12 @@ fi
 # skills bind mount를 위한 sudoers 설정
 setup_skills_mount
 
+# skills bind mount 활성화
+skills_mount_active=0
+if mount_skills_directory; then
+    skills_mount_active=1
+fi
+
 # global memory 디렉토리 심볼릭 링크 생성
 if [ ! -d "$(dirname "$HOME_GLOBAL_MEMORY")" ]; then
     log_info "'$(dirname "$HOME_GLOBAL_MEMORY")' 디렉토리 생성"
@@ -222,13 +251,23 @@ ux_success "Claude Code 설정이 완료되었습니다!"
 ux_info "다음 설정이 적용되었습니다:"
 ux_bullet "~/.claude/settings.json → ~/dotfiles/claude/settings.json (symlink)"
 ux_bullet "~/.claude/statusline-command.sh → ~/dotfiles/claude/statusline-command.sh (symlink)"
-ux_bullet "~/.claude/skills ← ~/dotfiles/claude/skills (bind mount)"
 ux_bullet "~/.claude/projects/GLOBAL/memory → ~/dotfiles/claude/global-memory (symlink)"
 ux_bullet "/etc/sudoers.d/claude-skills-mount (passwordless mount)"
+
+if [ "$skills_mount_active" -eq 1 ]; then
+    ux_bullet "~/.claude/skills ← ~/dotfiles/claude/skills (bind mount active)"
+else
+    ux_bullet "~/.claude/skills mount failed during setup; sudoers is configured"
+fi
 echo ""
 
 ux_section "다음 단계"
-ux_bullet "새 쉘을 열면 skills가 자동으로 bind mount됩니다"
+if [ "$skills_mount_active" -eq 1 ]; then
+    ux_bullet "새 쉘에서도 skills bind mount를 자동으로 유지합니다"
+else
+    ux_bullet "새 쉘에서 자동 mount를 재시도합니다"
+    ux_bullet "즉시 수동 실행: claude-mount-skills"
+fi
 ux_bullet "Claude Code 재시작하여 변경 사항 적용"
 ux_bullet "필요시 설정 파일 편집: ${UX_BOLD}vim ~/dotfiles/claude/settings.json${UX_RESET}"
 echo ""

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -274,9 +274,11 @@ claude_mount_docs() {
     fi
 }
 
-# NOTE: Auto-mount functionality removed from shell init to prevent sudo prompts
-# during shell startup. Since dotfiles configures passwordless sudoers for skills,
-# we can safely attempt a silent auto-mount in interactive shells.
+# NOTE: Auto-mount is controlled by environment variables:
+#   CLAUDE_AUTO_MOUNT_SKILLS=1
+#   CLAUDE_AUTO_MOUNT_DOCS=1
+# This repository sets defaults in shell-common/env/claude.sh.
+# Requires passwordless sudoers configured by dotfiles/claude/setup.sh
 
 # ═══════════════════════════════════════════════════════════════
 # Claude Code Mount All Helper
@@ -319,6 +321,9 @@ alias claude-mount-all='claude_mount_all'
 alias claude-mount-skills='claude_mount_skills'
 alias claude-mount-docs='claude_mount_docs'
 
+# Auto-mount configuration via environment variables
+# Set to "1" to enable auto-mounting in interactive shells
+# Example: export CLAUDE_AUTO_MOUNT_SKILLS=1
 _claude_try_auto_mount() {
     case "$-" in
         *i*) ;;

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -275,8 +275,8 @@ claude_mount_docs() {
 }
 
 # NOTE: Auto-mount functionality removed from shell init to prevent sudo prompts
-# during shell startup. Use explicit function instead:
-#   claude_mount_docs - Mount docs directory
+# during shell startup. Since dotfiles configures passwordless sudoers for skills,
+# we can safely attempt a silent auto-mount in interactive shells.
 
 # ═══════════════════════════════════════════════════════════════
 # Claude Code Mount All Helper
@@ -318,6 +318,23 @@ claude_mount_all() {
 alias claude-mount-all='claude_mount_all'
 alias claude-mount-skills='claude_mount_skills'
 alias claude-mount-docs='claude_mount_docs'
+
+_claude_try_auto_mount() {
+    case "$-" in
+        *i*) ;;
+        *) return 0 ;;
+    esac
+
+    if [ "${CLAUDE_AUTO_MOUNT_SKILLS:-0}" = "1" ]; then
+        claude_mount_skills >/dev/null 2>&1 || true
+    fi
+
+    if [ "${CLAUDE_AUTO_MOUNT_DOCS:-0}" = "1" ]; then
+        claude_mount_docs >/dev/null 2>&1 || true
+    fi
+}
+
+_claude_try_auto_mount
 
 # ═══════════════════════════════════════════════════════════════
 # Claude Code Marketplace Plugins Management

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -212,14 +212,12 @@ claude_mount_skills() {
             findmnt "$skills_target" > /dev/null 2>&1 && return 0
         else
             # Final fallback to mount command
-            mount | grep -q "${skills_target}" && return 0
+            mount | grep -q "on ${skills_target} " && return 0
         fi
     fi
 
     # Perform bind mount (will prompt for sudo password if needed)
-    sudo mount --bind "$skills_source" "$skills_target" 2>/dev/null
-
-    if [ $? -eq 0 ]; then
+    if sudo mount --bind "$skills_source" "$skills_target" 2>/dev/null; then
         return 0
     else
         # Silent fail - don't spam errors on every shell startup
@@ -259,14 +257,12 @@ claude_mount_docs() {
             findmnt "$docs_target" > /dev/null 2>&1 && return 0
         else
             # Final fallback to mount command
-            mount | grep -q "${docs_target}" && return 0
+            mount | grep -q "on ${docs_target} " && return 0
         fi
     fi
 
     # Perform bind mount (will prompt for sudo password if needed)
-    sudo mount --bind "$docs_source" "$docs_target" 2>/dev/null
-
-    if [ $? -eq 0 ]; then
+    if sudo mount --bind "$docs_source" "$docs_target" 2>/dev/null; then
         return 0
     else
         # Silent fail - don't spam errors on every shell startup


### PR DESCRIPTION
## Summary
- activate the Claude skills bind mount during `claude/setup.sh` instead of only configuring sudoers
- silently retry Claude skills/docs auto-mount on interactive shell startup
- make setup output reflect the real mount state instead of always claiming success

## Root Cause
`claude/setup.sh` created `~/.claude/skills` and the sudoers entry, but it did not actually run the bind mount. At the same time, the completion message claimed the mount was already active. `show-mnt` was therefore correct to show no mount.

## Verification
- reran `./claude/setup.sh` and confirmed `findmnt /home/bwyoon/.claude/skills`
- verified the interactive auto-mount path by sourcing the Claude integration in an interactive shell and checking `findmnt`
- commit hook pre-commit validation passed

## Notes
- I did not run full `tox`; verification was limited to the Claude mount path affected by this change.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->