### PR TITLE
feat(bun): add Bun/bunx integration and opencode-help utilities section

### DIFF
--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -282,6 +282,32 @@ zsh -c "source shell-common/functions/git.sh && type git_help"
 5. Test with both bash and zsh
 6. Run `shellcheck -s sh <file>.sh`
 
+## Adding a New Tool Integration (3-Step Pattern)
+
+새 외부 도구(예: bun, foo) 통합 시 항상 3개 파일이 필요:
+
+**Step 1** — `tools/integrations/<tool>.sh` (자동 로드됨)
+- PATH export, aliases, install/uninstall 함수
+- UX lib guard 패턴 포함:
+  ```sh
+  if ! type ux_header >/dev/null 2>&1; then
+      _dir="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"
+      . "${_dir}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
+      unset _dir
+  fi
+  ```
+
+**Step 2** — `functions/<tool>_help.sh` (자동 로드됨)
+- `<tool>_help()` 함수 + `alias <tool>-help='<tool>_help'`
+- `ux_table_row` / `ux_section` / `ux_bullet` 사용
+
+**Step 3** — `functions/my_help.sh` 수동 등록 (자동 등록 안 됨!)
+- `HELP_CATEGORY_MEMBERS[<category>]`에 토픽 추가
+- `HELP_DESCRIPTIONS[<tool>_help]` 항목 추가
+- 카테고리: `development`, `devops`, `ai`, `cli`, `config`, `docs`, `system`, `meta`
+
+**참조 예시**: `npm.sh` + `npm_help.sh` + `my_help.sh`의 npm 항목
+
 ## Splitting Large Files
 If any file exceeds 200 lines:
 - Split by functional boundary

--- a/shell-common/functions/bun_help.sh
+++ b/shell-common/functions/bun_help.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# shell-common/functions/bun_help.sh
+
+# ========================================
+# Load UX Library (POSIX portable)
+# ========================================
+if ! type ux_header >/dev/null 2>&1; then
+    _ux_lib_paths="
+        ${SHELL_COMMON}/tools/ux_lib/ux_lib.sh
+        ${HOME}/.local/dotfiles/shell-common/tools/ux_lib/ux_lib.sh
+        $(dirname "$0")/../tools/ux_lib/ux_lib.sh
+    "
+    for _ux_lib_path in $_ux_lib_paths; do
+        if [ -f "$_ux_lib_path" ]; then
+            # shellcheck disable=SC1090
+            . "$_ux_lib_path"
+            break
+        fi
+    done
+    unset _ux_lib_path _ux_lib_paths
+fi
+
+bun_help() {
+    ux_header "Bun Quick Commands"
+
+    ux_section "Installation"
+    ux_table_row "install-bun" "curl .../bun.sh/install" "Install Bun"
+    ux_table_row "uninstall-bun" "Remove ~/.bun" "Uninstall Bun"
+    ux_table_row "bun-v" "bun --version" "Check version"
+
+    ux_section "Package Management"
+    ux_table_row "bun-i" "bun install" "Install deps"
+    ux_table_row "bun-id" "install --dev" "Dev dependency"
+    ux_table_row "bun-ig" "install --global" "Global install"
+    ux_table_row "bun-un" "bun remove" "Remove package"
+    ux_table_row "bun-update" "bun update" "Update deps"
+    ux_table_row "bun-outdated" "bun outdated" "Check outdated"
+
+    ux_section "Run"
+    ux_table_row "bun-run" "bun run <script>" "Run package.json script"
+    ux_table_row "bunx" "bun x <pkg>" "Run package without install"
+
+    ux_section "Bunx Usage Examples"
+    ux_bullet "${UX_INFO}bunx oh-my-opencode install${UX_RESET}  : OMO 설치"
+    ux_bullet "${UX_INFO}bunx create-next-app${UX_RESET}         : Next.js 프로젝트 생성"
+
+    ux_section "Configuration"
+    ux_bullet "Config file  : ${UX_INFO}~/.bunfig.toml${UX_RESET} (dotfiles symlink)"
+    ux_bullet "Environments : internal (Samsung registry), external (default)"
+
+    ux_section "Troubleshooting"
+    ux_bullet "bun not found?   : Run ${UX_PRIMARY}install-bun${UX_RESET}"
+    ux_bullet "Registry error?  : Check ${UX_PRIMARY}~/.bunfig.toml${UX_RESET} registry setting"
+    ux_bullet "SSL error?       : Verify ${UX_PRIMARY}cafile${UX_RESET} path in bunfig.toml"
+
+    ux_info "Binary path: ~/.bun/bin"
+}
+
+alias bun-help='bun_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -143,7 +143,7 @@ _register_default_help_categories() {
     HELP_CATEGORIES[system]="${HELP_CATEGORIES[system]:-System tools (directory navigation, opencode)}"
 
     # Category membership (space-separated topic keys)
-    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git uv py nvm npm pp cli ux du psql mytool}"
+    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git uv py nvm npm bun pp cli ux du psql mytool}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc}"
@@ -197,6 +197,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[codex_help]="${HELP_DESCRIPTIONS[codex_help]:-[AI/LLM] Codex CLI commands}"
     HELP_DESCRIPTIONS[dproxy_help]="${HELP_DESCRIPTIONS[dproxy_help]:-[DevOps] Docker corporate proxy}"
     HELP_DESCRIPTIONS[npm_help]="${HELP_DESCRIPTIONS[npm_help]:-[Development] npm package manager}"
+    HELP_DESCRIPTIONS[bun_help]="${HELP_DESCRIPTIONS[bun_help]:-[Development] Bun runtime and bunx}"
     HELP_DESCRIPTIONS[nvm_help]="${HELP_DESCRIPTIONS[nvm_help]:-[Development] nvm node versions}"
     HELP_DESCRIPTIONS[litellm_help]="${HELP_DESCRIPTIONS[litellm_help]:-[AI/LLM] LiteLLM proxy and routing}"
     HELP_DESCRIPTIONS[gpu_help]="${HELP_DESCRIPTIONS[gpu_help]:-[DevOps] GPU monitoring (WSL)}"

--- a/shell-common/tools/integrations/bun.sh
+++ b/shell-common/tools/integrations/bun.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# shell-common/tools/integrations/bun.sh
+# Bun JavaScript runtime - PATH setup, install helpers, and aliases
+#
+# Configuration:
+#   ~/.bunfig.toml is managed as a symlink to bun/bunfig.toml.{environment}
+#   Run ./shell-common/setup.sh to configure for your environment
+
+# ========================================
+# Load UX Library
+# ========================================
+if ! type ux_header >/dev/null 2>&1; then
+    _bun_dir="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"
+    . "${_bun_dir}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
+    unset _bun_dir
+fi
+
+# ========================================
+# PATH Setup
+# ========================================
+export PATH="$HOME/.bun/bin:$PATH"
+
+# ========================================
+# Bun Aliases
+# ========================================
+alias bun-v='bun --version'
+alias bun-i='bun install'
+alias bun-id='bun install --dev'
+alias bun-ig='bun install --global'
+alias bun-un='bun remove'
+alias bun-run='bun run'
+alias bun-update='bun update'
+alias bun-outdated='bun outdated'
+
+# ========================================
+# Install / Uninstall
+# ========================================
+
+install_bun() {
+    ux_header "Bun 설치"
+    echo ""
+
+    if command -v bun >/dev/null 2>&1; then
+        ux_success "Bun이 이미 설치되어 있습니다: $(bun --version)"
+        echo ""
+        return 0
+    fi
+
+    ux_info "공식 설치 스크립트 실행 중..."
+    curl -fsSL https://bun.sh/install | bash
+
+    # Reload PATH for current session
+    export PATH="$HOME/.bun/bin:$PATH"
+
+    if command -v bun >/dev/null 2>&1; then
+        echo ""
+        ux_success "Bun 설치 완료: $(bun --version)"
+        ux_info "새 셸을 열거나 'source ~/.bashrc' 실행 후 사용하세요"
+    else
+        ux_error "설치 후에도 bun을 찾을 수 없습니다"
+        ux_info "PATH에 ~/.bun/bin이 포함되어 있는지 확인하세요"
+        return 1
+    fi
+    echo ""
+}
+
+uninstall_bun() {
+    ux_header "Bun 제거"
+    echo ""
+
+    printf "%sBun을 제거하시겠습니까? (y/N): %s" "$UX_PRIMARY" "$UX_RESET"
+    read -r confirm
+    if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+        ux_info "제거 취소됨"
+        return 0
+    fi
+    echo ""
+
+    if [ -d "$HOME/.bun" ]; then
+        ux_info "~/.bun 디렉토리 제거 중..."
+        rm -rf "$HOME/.bun"
+        ux_success "Bun 제거 완료"
+    else
+        ux_info "Bun 설치 디렉토리를 찾을 수 없습니다: ~/.bun"
+    fi
+
+    if [ -f "$HOME/.bunfig.toml" ] || [ -L "$HOME/.bunfig.toml" ]; then
+        ux_info "~/.bunfig.toml 제거 중..."
+        rm -f "$HOME/.bunfig.toml"
+        ux_success "bunfig.toml 제거 완료"
+    fi
+    echo ""
+
+    ux_header "Bun 제거 완료"
+    ux_info "재설치: install-bun"
+    echo ""
+}
+
+# ========================================
+# Aliases
+# ========================================
+alias install-bun='install_bun'
+alias uninstall-bun='uninstall_bun'

--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -106,6 +106,10 @@ opencode_help() {
     ux_bullet "${UX_PRIMARY}uninstall-opencode${UX_RESET}           : Remove OpenCode and configuration"
     echo ""
 
+    ux_section "필수 유틸리티"
+    ux_bullet "${UX_PRIMARY}bunx oh-my-opencode install${UX_RESET}   : Oh My OpenCode (OMO) 인터페이스 설치"
+    echo ""
+
     ux_section "Environments (managed by setup.sh)"
     ux_bullet "home/public             : OpenCode defaults (no symlink)"
     ux_bullet "external                : localhost:4444 LiteLLM proxy"

--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -108,6 +108,7 @@ opencode_help() {
 
     ux_section "필수 유틸리티"
     ux_bullet "${UX_PRIMARY}bunx oh-my-opencode install${UX_RESET}   : Oh My OpenCode (OMO) 인터페이스 설치"
+    ux_bullet "bunx 없을 때             : ${UX_PRIMARY}install-bun${UX_RESET} 또는 ${UX_PRIMARY}bun-help${UX_RESET} 참고"
     echo ""
 
     ux_section "Environments (managed by setup.sh)"


### PR DESCRIPTION
## Summary

- `shell-common/tools/integrations/bun.sh`: Bun 런타임 통합 — PATH 설정, `install-bun`/`uninstall-bun` 함수, 패키지 관리 aliases (`bun-i`, `bun-ig`, `bun-run` 등)
- `shell-common/functions/bun_help.sh`: `bun-help` 명령어 — 설치·패키지·bunx 사용법 one-stop 참조
- `shell-common/functions/my_help.sh`: development 카테고리에 `bun` 등록
- `shell-common/tools/integrations/opencode.sh`: `opencode-help`에 **필수 유틸리티** 섹션 추가 (`bunx oh-my-opencode install`, `bun-help` 참조)
- `shell-common/AGENTS.md`: 새 도구 통합 3단계 패턴 문서화 (integration.sh + _help.sh + my_help.sh 등록)

## Test plan

- [x] `source ~/.bashrc` 후 `bun-help` 명령어 출력 확인
- [x] `install-bun` 실행 시 Bun 설치 흐름 확인
- [x] `opencode-help` 출력에 **필수 유틸리티** 섹션 표시 확인
- [x] `my-help development` 목록에 `bun-help` 항목 포함 확인
- [x] `shellcheck -s sh` lint 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->