### PR TITLE
fix(claude/setup): add docs bind mount with NOPASSWD and sudoers validation

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -111,11 +111,14 @@ _setup_bind_mount_sudoers() {
     local source="$3"
     local target="$4"
 
+    [ -d "$source" ] || return 0
+
     log_info "$description 디렉토리 bind mount sudoers 설정"
-    if [ -f "$sudoers_file" ]; then
+    if [ -f "$sudoers_file" ] && sudo grep -qF "$source" "$sudoers_file" 2>/dev/null; then
         log_dim "✓ sudoers 설정이 이미 존재합니다"
         return 0
     fi
+    [ -f "$sudoers_file" ] && log_info "sudoers 경로가 변경되었습니다. 재생성합니다: $sudoers_file"
 
     if ! cat << EOF | sudo tee "$sudoers_file" > /dev/null
 # Allow passwordless bind mount for Claude Code $description directory

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -29,12 +29,14 @@ HOME_CLAUDE="${HOME}/.claude"
 HOME_SETTINGS="${HOME_CLAUDE}/settings.json"
 HOME_STATUSLINE="${HOME_CLAUDE}/statusline-command.sh"
 HOME_SKILLS="${HOME_CLAUDE}/skills"
+HOME_DOCS="${HOME_CLAUDE}/docs"
 HOME_GLOBAL_MEMORY="${HOME_CLAUDE}/projects/GLOBAL/memory"
 
 # Dotfiles source locations
 CLAUDE_SETTINGS_SOURCE="${CLAUDE_DOTFILES}/settings.json"
 CLAUDE_STATUSLINE_SOURCE="${CLAUDE_DOTFILES}/statusline-command.sh"
 CLAUDE_SKILLS_SOURCE="${CLAUDE_DOTFILES}/skills"
+CLAUDE_DOCS_SOURCE="${CLAUDE_DOTFILES}/docs"
 CLAUDE_GLOBAL_MEMORY_SOURCE="${CLAUDE_DOTFILES}/global-memory"
 
 # Load UX library (unified library at shell-common/tools/ux_lib/)
@@ -130,13 +132,17 @@ EOF
     fi
 }
 
-_is_skills_mounted() {
+_is_mounted() {
+    local target="$1"
     if command -v findmnt >/dev/null 2>&1; then
-        findmnt "$HOME_SKILLS" >/dev/null 2>&1
+        findmnt "$target" >/dev/null 2>&1
     else
-        mount | grep -q "on ${HOME_SKILLS} " 2>/dev/null
+        mount | grep -q "on ${target} " 2>/dev/null
     fi
 }
+
+_is_skills_mounted() { _is_mounted "$HOME_SKILLS"; }
+_is_docs_mounted()   { _is_mounted "$HOME_DOCS"; }
 
 _mount_skills_directory() {
     if _is_skills_mounted; then
@@ -151,6 +157,60 @@ _mount_skills_directory() {
     fi
 
     log_error "skills bind mount 실패"
+    return 1
+}
+
+setup_docs_mount() {
+    local sudoers_file="/etc/sudoers.d/claude-docs-mount"
+
+    log_info "Docs 디렉토리 bind mount 설정"
+
+    if [ -f "$sudoers_file" ]; then
+        log_dim "✓ docs sudoers 설정이 이미 존재합니다"
+        return 0
+    fi
+
+    log_info "sudoers 파일 생성: $sudoers_file"
+    if ! cat << EOF | sudo tee "$sudoers_file" > /dev/null
+# Allow passwordless bind mount for Claude Code docs directory
+# Created by dotfiles/claude/setup.sh
+${USER} ALL=(ALL) NOPASSWD: /bin/mount --bind ${CLAUDE_DOCS_SOURCE} ${HOME_DOCS}
+${USER} ALL=(ALL) NOPASSWD: /usr/bin/mount --bind ${CLAUDE_DOCS_SOURCE} ${HOME_DOCS}
+${USER} ALL=(ALL) NOPASSWD: /bin/umount ${HOME_DOCS}
+${USER} ALL=(ALL) NOPASSWD: /usr/bin/umount ${HOME_DOCS}
+EOF
+    then
+        log_error "docs sudoers 파일 생성 실패"
+        return 1
+    fi
+
+    if sudo chmod 440 "$sudoers_file"; then
+        log_dim "✓ docs sudoers 설정 완료"
+    else
+        log_error "docs sudoers 파일 권한 설정 실패"
+        return 1
+    fi
+}
+
+_mount_docs_directory() {
+    [ -d "$CLAUDE_DOCS_SOURCE" ] || return 0
+
+    if _is_docs_mounted; then
+        log_dim "✓ docs bind mount가 이미 활성화되어 있습니다"
+        return 0
+    fi
+
+    if [ ! -d "$HOME_DOCS" ]; then
+        mkdir -p "$HOME_DOCS" || { log_error "~/.claude/docs 디렉토리 생성 실패"; return 1; }
+    fi
+
+    log_info "docs bind mount 활성화: $HOME_DOCS <- $CLAUDE_DOCS_SOURCE"
+    if sudo mount --bind "$CLAUDE_DOCS_SOURCE" "$HOME_DOCS" 2>/dev/null; then
+        log_dim "✓ docs bind mount 완료"
+        return 0
+    fi
+
+    log_error "docs bind mount 실패"
     return 1
 }
 
@@ -202,6 +262,12 @@ setup_skills_mount
 # skills bind mount 활성화
 _mount_skills_directory
 
+# docs bind mount를 위한 sudoers 설정
+setup_docs_mount
+
+# docs bind mount 활성화
+_mount_docs_directory
+
 # global memory 디렉토리 심볼릭 링크 생성
 if [ ! -d "$(dirname "$HOME_GLOBAL_MEMORY")" ]; then
     log_info "'$(dirname "$HOME_GLOBAL_MEMORY")' 디렉토리 생성"
@@ -248,11 +314,18 @@ ux_bullet "~/.claude/settings.json → ~/dotfiles/claude/settings.json (symlink)
 ux_bullet "~/.claude/statusline-command.sh → ~/dotfiles/claude/statusline-command.sh (symlink)"
 ux_bullet "~/.claude/projects/GLOBAL/memory → ~/dotfiles/claude/global-memory (symlink)"
 ux_bullet "/etc/sudoers.d/claude-skills-mount (passwordless mount)"
+ux_bullet "/etc/sudoers.d/claude-docs-mount (passwordless mount)"
 
 if _is_skills_mounted; then
     ux_bullet "~/.claude/skills ← ~/dotfiles/claude/skills (bind mount active)"
 else
     ux_bullet "~/.claude/skills mount failed during setup; sudoers is configured"
+fi
+
+if _is_docs_mounted; then
+    ux_bullet "~/.claude/docs ← ~/dotfiles/claude/docs (bind mount active)"
+else
+    ux_bullet "~/.claude/docs mount failed during setup; sudoers is configured"
 fi
 echo ""
 

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -48,6 +48,15 @@ else
     exit 1
 fi
 
+# Load mount utilities (provides _is_mounted)
+MOUNT_LIB="${DOTFILES_ROOT}/shell-common/functions/mount.sh"
+if [ -f "$MOUNT_LIB" ]; then
+    source "$MOUNT_LIB"
+else
+    echo "Error: Mount library not found at $MOUNT_LIB"
+    exit 1
+fi
+
 # --- Logging Compatibility Functions ---
 
 log_info() { ux_info "$1"; }
@@ -96,123 +105,71 @@ create_symlink() {
     ln -s "$target" "$link_name" || log_error_and_exit "심볼릭 링크 생성 실패: $link_name -> $target"
 }
 
-setup_skills_mount() {
-    local sudoers_file="/etc/sudoers.d/claude-skills-mount"
+_setup_bind_mount_sudoers() {
+    local sudoers_file="$1"
+    local description="$2"
+    local source="$3"
+    local target="$4"
 
-    log_info "Skills 디렉토리 bind mount 설정"
-
-    # Check if sudoers file already exists
+    log_info "$description 디렉토리 bind mount sudoers 설정"
     if [ -f "$sudoers_file" ]; then
         log_dim "✓ sudoers 설정이 이미 존재합니다"
         return 0
     fi
 
-    # Create sudoers configuration
-    log_info "sudoers 파일 생성: $sudoers_file"
     if ! cat << EOF | sudo tee "$sudoers_file" > /dev/null
-# Allow passwordless bind mount for Claude Code skills directory
+# Allow passwordless bind mount for Claude Code $description directory
 # Created by dotfiles/claude/setup.sh
-${USER} ALL=(ALL) NOPASSWD: /bin/mount --bind ${CLAUDE_SKILLS_SOURCE} ${HOME_SKILLS}
-${USER} ALL=(ALL) NOPASSWD: /usr/bin/mount --bind ${CLAUDE_SKILLS_SOURCE} ${HOME_SKILLS}
-${USER} ALL=(ALL) NOPASSWD: /bin/umount ${HOME_SKILLS}
-${USER} ALL=(ALL) NOPASSWD: /usr/bin/umount ${HOME_SKILLS}
+${USER} ALL=(ALL) NOPASSWD: /bin/mount --bind ${source} ${target}
+${USER} ALL=(ALL) NOPASSWD: /usr/bin/mount --bind ${source} ${target}
+${USER} ALL=(ALL) NOPASSWD: /bin/umount ${target}
+${USER} ALL=(ALL) NOPASSWD: /usr/bin/umount ${target}
 EOF
     then
-        log_error "sudoers 파일 생성 실패"
+        log_error "$description sudoers 파일 생성 실패"
         return 1
     fi
 
-    # Set proper permissions
-    log_info "sudoers 파일 권한 설정"
     if sudo chmod 440 "$sudoers_file"; then
-        log_dim "✓ sudoers 설정 완료"
+        log_dim "✓ $description sudoers 설정 완료"
     else
-        log_error "sudoers 파일 권한 설정 실패"
+        log_error "$description sudoers 파일 권한 설정 실패"
         return 1
     fi
 }
 
-_is_mounted() {
-    local target="$1"
-    if command -v findmnt >/dev/null 2>&1; then
-        findmnt "$target" >/dev/null 2>&1
-    else
-        mount | grep -q "on ${target} " 2>/dev/null
-    fi
-}
+setup_skills_mount() { _setup_bind_mount_sudoers "/etc/sudoers.d/claude-skills-mount" "Skills" "$CLAUDE_SKILLS_SOURCE" "$HOME_SKILLS"; }
+setup_docs_mount()   { _setup_bind_mount_sudoers "/etc/sudoers.d/claude-docs-mount"   "Docs"   "$CLAUDE_DOCS_SOURCE"   "$HOME_DOCS"; }
 
 _is_skills_mounted() { _is_mounted "$HOME_SKILLS"; }
 _is_docs_mounted()   { _is_mounted "$HOME_DOCS"; }
 
-_mount_skills_directory() {
-    if _is_skills_mounted; then
-        log_dim "✓ skills bind mount가 이미 활성화되어 있습니다"
+_mount_bind_mount() {
+    local source="$1"
+    local target="$2"
+    local description="$3"
+
+    [ -d "$source" ] || return 0
+
+    if _is_mounted "$target"; then
+        log_dim "✓ $description bind mount가 이미 활성화되어 있습니다"
         return 0
     fi
 
-    log_info "skills bind mount 활성화: $HOME_SKILLS <- $CLAUDE_SKILLS_SOURCE"
-    if sudo mount --bind "$CLAUDE_SKILLS_SOURCE" "$HOME_SKILLS" 2>/dev/null; then
-        log_dim "✓ skills bind mount 완료"
+    mkdir -p "$target" || { log_error "$description 디렉토리 생성 실패"; return 1; }
+
+    log_info "$description bind mount 활성화: $target <- $source"
+    if sudo mount --bind "$source" "$target" 2>/dev/null; then
+        log_dim "✓ $description bind mount 완료"
         return 0
     fi
 
-    log_error "skills bind mount 실패"
+    log_error "$description bind mount 실패"
     return 1
 }
 
-setup_docs_mount() {
-    local sudoers_file="/etc/sudoers.d/claude-docs-mount"
-
-    log_info "Docs 디렉토리 bind mount 설정"
-
-    if [ -f "$sudoers_file" ]; then
-        log_dim "✓ docs sudoers 설정이 이미 존재합니다"
-        return 0
-    fi
-
-    log_info "sudoers 파일 생성: $sudoers_file"
-    if ! cat << EOF | sudo tee "$sudoers_file" > /dev/null
-# Allow passwordless bind mount for Claude Code docs directory
-# Created by dotfiles/claude/setup.sh
-${USER} ALL=(ALL) NOPASSWD: /bin/mount --bind ${CLAUDE_DOCS_SOURCE} ${HOME_DOCS}
-${USER} ALL=(ALL) NOPASSWD: /usr/bin/mount --bind ${CLAUDE_DOCS_SOURCE} ${HOME_DOCS}
-${USER} ALL=(ALL) NOPASSWD: /bin/umount ${HOME_DOCS}
-${USER} ALL=(ALL) NOPASSWD: /usr/bin/umount ${HOME_DOCS}
-EOF
-    then
-        log_error "docs sudoers 파일 생성 실패"
-        return 1
-    fi
-
-    if sudo chmod 440 "$sudoers_file"; then
-        log_dim "✓ docs sudoers 설정 완료"
-    else
-        log_error "docs sudoers 파일 권한 설정 실패"
-        return 1
-    fi
-}
-
-_mount_docs_directory() {
-    [ -d "$CLAUDE_DOCS_SOURCE" ] || return 0
-
-    if _is_docs_mounted; then
-        log_dim "✓ docs bind mount가 이미 활성화되어 있습니다"
-        return 0
-    fi
-
-    if [ ! -d "$HOME_DOCS" ]; then
-        mkdir -p "$HOME_DOCS" || { log_error "~/.claude/docs 디렉토리 생성 실패"; return 1; }
-    fi
-
-    log_info "docs bind mount 활성화: $HOME_DOCS <- $CLAUDE_DOCS_SOURCE"
-    if sudo mount --bind "$CLAUDE_DOCS_SOURCE" "$HOME_DOCS" 2>/dev/null; then
-        log_dim "✓ docs bind mount 완료"
-        return 0
-    fi
-
-    log_error "docs bind mount 실패"
-    return 1
-}
+_mount_skills_directory() { _mount_bind_mount "$CLAUDE_SKILLS_SOURCE" "$HOME_SKILLS" "skills"; }
+_mount_docs_directory()   { _mount_bind_mount "$CLAUDE_DOCS_SOURCE"   "$HOME_DOCS"   "docs"; }
 
 # --- Main Script Logic ---
 
@@ -250,22 +207,10 @@ create_symlink "$CLAUDE_SETTINGS_SOURCE" "$HOME_SETTINGS"
 # statusline-command.sh 심볼릭 링크 생성
 create_symlink "$CLAUDE_STATUSLINE_SOURCE" "$HOME_STATUSLINE"
 
-# skills 디렉토리 생성 (bind mount 사용)
-if [ ! -d "$HOME_SKILLS" ]; then
-    log_info "~/.claude/skills 디렉토리 생성"
-    mkdir -p "$HOME_SKILLS" || log_error_and_exit "~/.claude/skills 디렉토리 생성 실패"
-fi
-
-# skills bind mount를 위한 sudoers 설정
 setup_skills_mount
-
-# skills bind mount 활성화
 _mount_skills_directory
 
-# docs bind mount를 위한 sudoers 설정
 setup_docs_mount
-
-# docs bind mount 활성화
 _mount_docs_directory
 
 # global memory 디렉토리 심볼릭 링크 생성


### PR DESCRIPTION
## 문제

터미널 시작 시마다 `sudo` 패스워드 프롬프트가 3번 뜨는 문제.

**원인**: `setup.sh`가 `skills` 디렉토리만 `/etc/sudoers.d/`에 NOPASSWD로 등록하고, `docs` 디렉토리는 등록하지 않았음. 반면 shell 시작 시 `_claude_try_auto_mount`가 두 디렉토리 모두 mount를 시도함.

## 변경 사항

### `fix(claude): add docs bind mount NOPASSWD to setup.sh` (8ab500b)
- `HOME_DOCS`, `CLAUDE_DOCS_SOURCE` 상수 추가
- `setup_docs_mount()` — `/etc/sudoers.d/claude-docs-mount` 생성
- `_mount_docs_directory()` — docs bind mount 활성화
- 완료 메시지에 docs mount 상태 표시 추가

### `refactor(claude/setup): eliminate duplication in bind mount setup` (593967a)
- `_setup_bind_mount_sudoers(file, desc, src, tgt)` — sudoers 생성 공통 헬퍼
- `_mount_bind_mount(src, tgt, desc)` — bind mount 공통 헬퍼
- 로컬 `_is_mounted()` 제거 → `mount.sh` 소싱 (입력 검증·tilde 처리 포함)
- 불필요한 `mkdir -p` guard 및 설명성 인라인 주석 제거
- 순 변화: -55줄

### `fix(claude/setup): guard sudoers on source existence and content` (c57076a)
- source 디렉토리가 없으면 sudoers 생성 스킵 (docs 없는 환경에서 불필요한 NOPASSWD 방지)
- 파일 존재 여부만 체크하던 로직 → `sudo grep -qF "$source"` 로 경로 내용 검증; dotfiles 위치 변경 후 stale 규칙 자동 재생성

## 테스트

- [x] 새 터미널 시작 시 패스워드 프롬프트 미발생 확인
- [x] `bash -n claude/setup.sh` syntax 검증 통과

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->