### PR TITLE
fix(skills): support multiline YAML descriptions

### DIFF
--- a/claude/skills/agents-md/SKILL.md
+++ b/claude/skills/agents-md/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: agents-md
-description: Generate or update AGENTS.md documentation system following SOLID principles and TDD. Use when creating project documentation, setting up context routing, or optimizing AI agent context windows. Enforces 500-line limit, token efficiency, and hierarchical structure.
+description: >-
+  Generate or update AGENTS.md documentation system following SOLID principles
+  and TDD. Use when creating project documentation, setting up context routing,
+  or optimizing AI agent context windows. Enforces 500-line limit, token
+  efficiency, and hierarchical structure.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 ---
 

--- a/claude/skills/brand-guidelines/SKILL.md
+++ b/claude/skills/brand-guidelines/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: brand-guidelines
-description: Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
+description: >-
+  Applies Anthropic's official brand colors and typography to any sort of
+  artifact that may benefit from having Anthropic's look-and-feel. Use it when
+  brand colors or style guidelines, visual formatting, or company design
+  standards apply.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/canvas-design/SKILL.md
+++ b/claude/skills/canvas-design/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: canvas-design
-description: Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.
+description: >-
+  Create beautiful visual art in .png and .pdf documents using design
+  philosophy. You should use this skill when the user asks to create a poster,
+  piece of art, design, or other static piece. Create original visual designs,
+  never copying existing artists' work to avoid copyright violations.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/cli-dev/SKILL.md
+++ b/claude/skills/cli-dev/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cli-dev
-description: CLI feature development skill. Implements CLI commands that wrap backend API endpoints. Follows TDD workflow with pytest, Rich console formatting, and session management. Use when implementing REQ-CLI-* requirements.
+description: >-
+  CLI feature development skill. Implements CLI commands that wrap backend API
+  endpoints. Follows TDD workflow with pytest, Rich console formatting, and
+  session management. Use when implementing REQ-CLI-* requirements.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 ---
 

--- a/claude/skills/dev-sh-generator/SKILL.md
+++ b/claude/skills/dev-sh-generator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dev-sh-generator
-description: Generate project-specific tools/dev.sh task runner following AGENTS.md standards. Use when creating or updating developer workflow automation scripts for Python/FastAPI projects.
+description: >-
+  Generate project-specific tools/dev.sh task runner following AGENTS.md
+  standards. Use when creating or updating developer workflow automation scripts
+  for Python/FastAPI projects.
 allowed-tools: Read, Glob, Grep, Write, Bash, Edit
 ---
 

--- a/claude/skills/dissect-builtin/SKILL.md
+++ b/claude/skills/dissect-builtin/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: dissect-builtin
-description: Analyze and document Claude Code built-in skills. Load a built-in skill's prompt via the Skill tool, explain its behavior in Korean, and save structured documentation (README.md + PROMPT.md) to the dotfiles repository. Use when the user wants to study, dissect, or document a built-in skill (e.g., "/dissect-builtin simplify", "/dissect-builtin loop"). Trigger on requests like "내장 스킬 분석", "built-in skill 공부", or "스킬 해부".
+description: >-
+  Analyze and document Claude Code built-in skills. Load a built-in skill's
+  prompt via the Skill tool, explain its behavior in Korean, and save structured
+  documentation (README.md + PROMPT.md) to the dotfiles repository. Use when the
+  user wants to study, dissect, or document a built-in skill (e.g.,
+  "/dissect-builtin simplify", "/dissect-builtin loop"). Trigger on requests
+  like "내장 스킬 분석", "built-in skill 공부", or "스킬 해부".
 ---
 
 # Dissect Built-in Skill

--- a/claude/skills/doc-coauthoring/SKILL.md
+++ b/claude/skills/doc-coauthoring/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: doc-coauthoring
-description: Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.
+description: >-
+  Guide users through a structured workflow for co-authoring documentation. Use
+  when user wants to write documentation, proposals, technical specs, decision
+  docs, or similar structured content. This workflow helps users efficiently
+  transfer context, refine content through iteration, and verify the doc works
+  for readers. Trigger when user mentions writing docs, creating proposals,
+  drafting specs, or similar documentation tasks.
 ---
 
 # Doc Co-Authoring Workflow

--- a/claude/skills/docx/SKILL.md
+++ b/claude/skills/docx/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: docx
-description: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. When Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+description: >-
+  Comprehensive document creation, editing, and analysis with support for
+  tracked changes, comments, formatting preservation, and text extraction. When
+  Claude needs to work with professional documents (.docx files) for: (1)
+  Creating new documents, (2) Modifying or editing content, (3) Working with
+  tracked changes, (4) Adding comments, or any other document tasks
 license: Proprietary. LICENSE.txt has complete terms
 ---
 

--- a/claude/skills/frontend-design/SKILL.md
+++ b/claude/skills/frontend-design/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+description: >-
+  Create distinctive, production-grade frontend interfaces with high design
+  quality. Use this skill when the user asks to build web components, pages,
+  artifacts, posters, or applications (examples include websites, landing pages,
+  dashboards, React components, HTML/CSS layouts, or when styling/beautifying
+  any web UI). Generates creative, polished code and UI design that avoids
+  generic AI aesthetics.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/internal-comms/SKILL.md
+++ b/claude/skills/internal-comms/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: internal-comms
-description: A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
+description: >-
+  A set of resources to help me write all kinds of internal communications,
+  using the formats that my company likes to use. Claude should use this skill
+  whenever asked to write some sort of internal communications (status reports,
+  leadership updates, 3P updates, company newsletters, FAQs, incident reports,
+  project updates, etc.).
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/mcp-builder/SKILL.md
+++ b/claude/skills/mcp-builder/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: mcp-builder
-description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+description: >-
+  Guide for creating high-quality MCP (Model Context Protocol) servers that
+  enable LLMs to interact with external services through well-designed tools.
+  Use when building MCP servers to integrate external APIs or services, whether
+  in Python (FastMCP) or Node/TypeScript (MCP SDK).
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/notion-knowledge-capture/SKILL.md
+++ b/claude/skills/notion-knowledge-capture/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: notion-knowledge-capture
-description: Transforms conversations and discussions into structured documentation pages in Notion. Captures insights, decisions, and knowledge from chat context, formats appropriately, and saves to wikis or databases with proper organization and linking for easy discovery.
+description: >-
+  Transforms conversations and discussions into structured documentation pages
+  in Notion. Captures insights, decisions, and knowledge from chat context,
+  formats appropriately, and saves to wikis or databases with proper
+  organization and linking for easy discovery.
 allowed-tools: Read, Glob
 ---
 

--- a/claude/skills/notion-meeting-intelligence/SKILL.md
+++ b/claude/skills/notion-meeting-intelligence/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: notion-meeting-intelligence
-description: Prepares meeting materials by gathering context from Notion, enriching with Claude research, and creating both an internal pre-read and external agenda saved to Notion. Helps you arrive prepared with comprehensive background and structured meeting docs.
+description: >-
+  Prepares meeting materials by gathering context from Notion, enriching with
+  Claude research, and creating both an internal pre-read and external agenda
+  saved to Notion. Helps you arrive prepared with comprehensive background and
+  structured meeting docs.
 ---
 
 # Meeting Intelligence

--- a/claude/skills/notion-research-documentation/SKILL.md
+++ b/claude/skills/notion-research-documentation/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: notion-research-documentation
-description: Searches across your Notion workspace, synthesizes findings from multiple pages, and creates comprehensive research documentation saved as new Notion pages. Turns scattered information into structured reports with proper citations and actionable insights.
+description: >-
+  Searches across your Notion workspace, synthesizes findings from multiple
+  pages, and creates comprehensive research documentation saved as new Notion
+  pages. Turns scattered information into structured reports with proper
+  citations and actionable insights.
 ---
 
 # Research & Documentation

--- a/claude/skills/notion-spec-to-implementation/SKILL.md
+++ b/claude/skills/notion-spec-to-implementation/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: notion-spec-to-implementation
-description: Turns product or tech specs into concrete Notion tasks that Claude code can implement. Breaks down spec pages into detailed implementation plans with clear tasks, acceptance criteria, and progress tracking to guide development from requirements to completion.
+description: >-
+  Turns product or tech specs into concrete Notion tasks that Claude code can
+  implement. Breaks down spec pages into detailed implementation plans with
+  clear tasks, acceptance criteria, and progress tracking to guide development
+  from requirements to completion.
 ---
 
 # Spec to Implementation

--- a/claude/skills/pdf/SKILL.md
+++ b/claude/skills/pdf/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pdf
-description: Comprehensive PDF manipulation toolkit for extracting text and tables, creating new PDFs, merging/splitting documents, and handling forms. When Claude needs to fill in a PDF form or programmatically process, generate, or analyze PDF documents at scale.
+description: >-
+  Comprehensive PDF manipulation toolkit for extracting text and tables,
+  creating new PDFs, merging/splitting documents, and handling forms. When
+  Claude needs to fill in a PDF form or programmatically process, generate, or
+  analyze PDF documents at scale.
 license: Proprietary. LICENSE.txt has complete terms
 ---
 

--- a/claude/skills/pptx/SKILL.md
+++ b/claude/skills/pptx/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pptx
-description: "Presentation creation, editing, and analysis. When Claude needs to work with presentations (.pptx files) for: (1) Creating new presentations, (2) Modifying or editing content, (3) Working with layouts, (4) Adding comments or speaker notes, or any other presentation tasks"
+description: >-
+  Presentation creation, editing, and analysis. When Claude needs to work with
+  presentations (.pptx files) for: (1) Creating new presentations, (2) Modifying
+  or editing content, (3) Working with layouts, (4) Adding comments or speaker
+  notes, or any other presentation tasks
 license: Proprietary. LICENSE.txt has complete terms
 ---
 

--- a/claude/skills/project-setup/SKILL.md
+++ b/claude/skills/project-setup/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: project-setup
-description: Initialize Python projects with standard configuration files (.markdownlint.json, tox.ini, pyproject.toml). Use when starting new Python projects or standardizing existing ones.
+description: >-
+  Initialize Python projects with standard configuration files
+  (.markdownlint.json, tox.ini, pyproject.toml). Use when starting new Python
+  projects or standardizing existing ones.
 allowed-tools: Write, Bash, Read, Glob
 ---
 

--- a/claude/skills/req-define/SKILL.md
+++ b/claude/skills/req-define/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: req-define
-description: Convert free-form requirements into structured REQ format. Use when defining new features, documenting urgent requests, or creating requirement specifications for feature_requirement_mvp1.md.
+description: >-
+  Convert free-form requirements into structured REQ format. Use when defining
+  new features, documenting urgent requests, or creating requirement
+  specifications for feature_requirement_mvp1.md.
 allowed-tools: Read, Glob, Grep, Write, Edit
 ---
 

--- a/claude/skills/req-draft/SKILL.md
+++ b/claude/skills/req-draft/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: req-draft
-description: Create and iterate on feature requirement draft documents. Use when starting new feature discussions, writing initial requirement drafts, or synthesizing colleague review documents. Triggered by "/req-draft", "요구사항 초안", "기능 초안 작성", or any request to create/update feature requirement documents in docs/feature/.
+description: >-
+  Create and iterate on feature requirement draft documents. Use when starting
+  new feature discussions, writing initial requirement drafts, or synthesizing
+  colleague review documents. Triggered by "/req-draft", "요구사항 초안", "기능 초안 작성",
+  or any request to create/update feature requirement documents in
+  docs/feature/.
 ---
 
 # Requirement Draft

--- a/claude/skills/req-workflow/SKILL.md
+++ b/claude/skills/req-workflow/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: req-workflow
-description: REQ-based 4-phase development workflow. Use when implementing features with "REQ-X-Y 개발해" format. Orchestrates Specification, Test Design, Implementation, Summary phases with user approval gates.
+description: >-
+  REQ-based 4-phase development workflow. Use when implementing features with
+  "REQ-X-Y 개발해" format. Orchestrates Specification, Test Design, Implementation,
+  Summary phases with user approval gates.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 ---
 

--- a/claude/skills/slack-gif-creator/SKILL.md
+++ b/claude/skills/slack-gif-creator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: slack-gif-creator
-description: Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
+description: >-
+  Knowledge and utilities for creating animated GIFs optimized for Slack.
+  Provides constraints, validation tools, and animation concepts. Use when users
+  request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/symlink-manager/SKILL.md
+++ b/claude/skills/symlink-manager/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: symlink-manager
-description: Manage dotfiles configuration files via symbolic links following standard patterns. Use when users request to manage config files with symbolic links, organize dotfiles, or set up configuration management.
+description: >-
+  Manage dotfiles configuration files via symbolic links following standard
+  patterns. Use when users request to manage config files with symbolic links,
+  organize dotfiles, or set up configuration management.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 ---
 

--- a/claude/skills/theme-factory/SKILL.md
+++ b/claude/skills/theme-factory/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: theme-factory
-description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.
+description: >-
+  Toolkit for styling artifacts with a theme. These artifacts can be slides,
+  docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with
+  colors/fonts that you can apply to any artifact that has been creating, or can
+  generate a new theme on-the-fly.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/tox-lint/SKILL.md
+++ b/claude/skills/tox-lint/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: tox-lint
-description: Run lint checks and auto-fix issues across Python, Markdown, and shell scripts. Use when running tox -e ruff/mdlint/shellcheck/shfmt, standardizing code before commits, or fixing CI lint failures.
+description: >-
+  Run lint checks and auto-fix issues across Python, Markdown, and shell
+  scripts. Use when running tox -e ruff/mdlint/shellcheck/shfmt, standardizing
+  code before commits, or fixing CI lint failures.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 ---
 

--- a/claude/skills/ux-guidelines/SKILL.md
+++ b/claude/skills/ux-guidelines/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ux-guidelines
-description: Apply UX_GUIDELINES.md standards to shell functions and help text. Use when refactoring help functions, creating new help commands, or ensuring consistent formatting with semantic UX functions (ux_header, ux_section, ux_bullet, etc).
+description: >-
+  Apply UX_GUIDELINES.md standards to shell functions and help text. Use when
+  refactoring help functions, creating new help commands, or ensuring consistent
+  formatting with semantic UX functions (ux_header, ux_section, ux_bullet, etc).
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 ---
 

--- a/claude/skills/visualize/SKILL.md
+++ b/claude/skills/visualize/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: visualize
-description: Create beautiful, self-contained HTML visualizations from any content or idea. Use for slide decks, presentations, infographics, dashboards, flowcharts, diagrams, timelines, comparison tables, data visualizations, landing pages, one-pagers, org charts, mind maps, process flows, kanban boards, report summaries, or any visual that helps humans digest information faster. Trigger on requests like "visualize this," "make a deck," "create a slide," "build an infographic," "show me a dashboard," "make this visual," or any request to present information in a visual HTML format.
+description: >-
+  Create beautiful, self-contained HTML visualizations from any content or idea.
+  Use for slide decks, presentations, infographics, dashboards, flowcharts,
+  diagrams, timelines, comparison tables, data visualizations, landing pages,
+  one-pagers, org charts, mind maps, process flows, kanban boards, report
+  summaries, or any visual that helps humans digest information faster. Trigger
+  on requests like "visualize this," "make a deck," "create a slide," "build an
+  infographic," "show me a dashboard," "make this visual," or any request to
+  present information in a visual HTML format.
 license: MIT
 metadata:
   author: careerhackeralex

--- a/claude/skills/web-artifacts-builder/SKILL.md
+++ b/claude/skills/web-artifacts-builder/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: web-artifacts-builder
-description: Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.
+description: >-
+  Suite of tools for creating elaborate, multi-component claude.ai HTML
+  artifacts using modern frontend web technologies (React, Tailwind CSS,
+  shadcn/ui). Use for complex artifacts requiring state management, routing, or
+  shadcn/ui components - not for simple single-file HTML/JSX artifacts.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/webapp-testing/SKILL.md
+++ b/claude/skills/webapp-testing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: webapp-testing
-description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+description: >-
+  Toolkit for interacting with and testing local web applications using
+  Playwright. Supports verifying frontend functionality, debugging UI behavior,
+  capturing browser screenshots, and viewing browser logs.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/skills/write-blog-dev-learnings/SKILL.md
+++ b/claude/skills/write-blog-dev-learnings/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: write-blog-dev-learnings
-description: Write entertaining Korean developer blog posts about debugging war stories, production incidents, and technical gotchas. Saves to ~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md. TRIGGER when user mentions writing a blog about a technical lesson, sharing a debugging experience, or documenting a "삽질" story for teammates. Common triggers include "블로그 써줘", "삽질 블로그", "dev-learnings에 글", "blog post about debugging", "이거 블로그로 정리", "동료한테 공유할 글", "오늘 삽질한 거 글로", or any request to turn a painful technical experience into a shareable narrative. Also trigger when the user recounts a debugging story and wants to preserve it. Do NOT trigger for formal RCA documents (use write-rca-doc), API documentation, README files, or non-narrative technical docs.
+description: >-
+  Write entertaining Korean developer blog posts about debugging war stories,
+  production incidents, and technical gotchas. Saves to
+  ~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md. TRIGGER when user
+  mentions writing a blog about a technical lesson, sharing a debugging
+  experience, or documenting a "삽질" story for teammates. Common triggers include
+  "블로그 써줘", "삽질 블로그", "dev-learnings에 글", "blog post about debugging", "이거 블로그로
+  정리", "동료한테 공유할 글", "오늘 삽질한 거 글로", or any request to turn a painful technical
+  experience into a shareable narrative. Also trigger when the user recounts a
+  debugging story and wants to preserve it. Do NOT trigger for formal RCA
+  documents (use write-rca-doc), API documentation, README files, or
+  non-narrative technical docs.
 ---
 
 # Developer Blog Writer — "삽질 블로그"

--- a/claude/skills/write-rca-doc/SKILL.md
+++ b/claude/skills/write-rca-doc/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: write-rca-doc
-description: Auto-document incidents, bug fixes, and technical challenges as structured markdown with root cause analysis, prevention checklists, and learning resources. Produces Jekyll-compatible publication-ready markdown (YAML frontmatter + single .md files) for postmortem review, technical blogging, AI tool training, and junior engineer onboarding. Saves to ~/para/archive/rca-knowledge with centralized media in _assets/.
+description: >-
+  Auto-document incidents, bug fixes, and technical challenges as structured
+  markdown with root cause analysis, prevention checklists, and learning
+  resources. Produces Jekyll-compatible publication-ready markdown (YAML
+  frontmatter + single .md files) for postmortem review, technical blogging, AI
+  tool training, and junior engineer onboarding. Saves to
+  ~/para/archive/rca-knowledge with centralized media in _assets/.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash, Ask
 ---
 

--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: write-task-history
-description: Write task history from current conversation to a daily task list file. Generates two copy-paste-ready formats: JIRA ticket (plain text with section symbols) and git PR description (markdown). Use this skill whenever the user wants to record, document, or summarize completed work from the current session. Also trigger when the user mentions task history, work log, JIRA ticket drafting from conversation context, or preparing PR descriptions based on what was just done. Works across any project.
+description: >-
+  Write task history from current conversation to a daily task list file.
+  Generates two copy-paste-ready formats: JIRA ticket (plain text with section
+  symbols) and git PR description (markdown). Use this skill whenever the user
+  wants to record, document, or summarize completed work from the current
+  session. Also trigger when the user mentions task history, work log, JIRA
+  ticket drafting from conversation context, or preparing PR descriptions based
+  on what was just done. Works across any project.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/claude/skills/xlsx/SKILL.md
+++ b/claude/skills/xlsx/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: xlsx
-description: "Comprehensive spreadsheet creation, editing, and analysis with support for formulas, formatting, data analysis, and visualization. When Claude needs to work with spreadsheets (.xlsx, .xlsm, .csv, .tsv, etc) for: (1) Creating new spreadsheets with formulas and formatting, (2) Reading or analyzing data, (3) Modify existing spreadsheets while preserving formulas, (4) Data analysis and visualization in spreadsheets, or (5) Recalculating formulas"
+description: >-
+  Comprehensive spreadsheet creation, editing, and analysis with support for
+  formulas, formatting, data analysis, and visualization. When Claude needs to
+  work with spreadsheets (.xlsx, .xlsm, .csv, .tsv, etc) for: (1) Creating new
+  spreadsheets with formulas and formatting, (2) Reading or analyzing data, (3)
+  Modify existing spreadsheets while preserving formulas, (4) Data analysis and
+  visualization in spreadsheets, or (5) Recalculating formulas
 license: Proprietary. LICENSE.txt has complete terms
 ---
 

--- a/shell-common/functions/claude_help.sh
+++ b/shell-common/functions/claude_help.sh
@@ -51,6 +51,99 @@ claude_help() {
 }
 
 # Function to list Claude Code skills
+_extract_skill_field_fallback() {
+    local skill_md="$1"
+    local field="$2"
+
+    awk -v field="$field" '
+BEGIN { in_fm=0; capturing=0; value="" }
+NR==1 && $0=="---" { in_fm=1; next }
+in_fm && $0=="---" {
+    if (capturing) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        capturing = 0
+        print value
+    }
+    exit
+}
+!in_fm { next }
+capturing {
+    if ($0 ~ /^[^[:space:]][^:]*:[[:space:]]*/) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        capturing = 0
+        print value
+        exit
+    }
+    line=$0
+    sub(/^[[:space:]]+/, "", line)
+    if (line != "") {
+        if (value != "") value = value " " line
+        else value = line
+    }
+    next
+}
+{
+    pattern = "^" field ":[[:space:]]*(.*)$"
+    if (match($0, pattern, m)) {
+        raw = m[1]
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", raw)
+        if (raw ~ /^[>|]/) {
+            capturing = 1
+            value = ""
+            next
+        }
+        sub(/^"/, "", raw)
+        sub(/"$/, "", raw)
+        print raw
+        exit
+    }
+}
+END {
+    if (capturing) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        print value
+    }
+}
+' "$skill_md" 2>/dev/null
+}
+
+_extract_skill_metadata() {
+    local skill_md="$1"
+    local parsed=""
+
+    # Prefer robust YAML parsing for multiline descriptions (>- and |)
+    if command -v ruby >/dev/null 2>&1; then
+        parsed="$(ruby -ryaml -e '
+path = ARGV[0]
+content = File.read(path)
+match = content.match(/\A---\n(.*?)\n---\n/m)
+exit 0 unless match
+data = YAML.safe_load(match[1]) || {}
+name = data["name"].to_s.gsub(/\s+/, " ").strip
+desc = data["description"].to_s.gsub(/\s+/, " ").strip
+puts name
+puts desc
+' "$skill_md" 2>/dev/null || true)"
+    fi
+
+    if [ -n "$parsed" ]; then
+        printf '%s\n' "$parsed"
+        return 0
+    fi
+
+    # Fallback for environments without ruby
+    local fallback_name fallback_desc
+    fallback_name=$(_extract_skill_field_fallback "$skill_md" "name")
+    fallback_desc=$(_extract_skill_field_fallback "$skill_md" "description")
+    printf '%s\n%s\n' "$fallback_name" "$fallback_desc"
+}
+
 get_claude_skills() {
     local skills_dir="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills"
 
@@ -81,12 +174,11 @@ get_claude_skills() {
         # Skip if SKILL.md doesn't exist
         [ -f "$skill_md" ] || continue
 
-        # Extract YAML content (between --- markers, excluding the markers)
-        local yaml_content="$(sed -n '/^---$/,/^---$/p' "$skill_md" | sed '1d;$d')"
-
         # Extract name and description from YAML frontmatter
-        local yaml_name="$(echo "$yaml_content" | grep '^name:' | head -1 | sed 's/^name: *//')"
-        local yaml_desc="$(echo "$yaml_content" | grep '^description:' | head -1 | sed 's/^description: *//')"
+        local metadata
+        metadata=$(_extract_skill_metadata "$skill_md")
+        local yaml_name="$(printf '%s\n' "$metadata" | sed -n '1p')"
+        local yaml_desc="$(printf '%s\n' "$metadata" | sed -n '2p')"
 
         # Use directory name as fallback
         [ -n "$yaml_name" ] || yaml_name="$skill_name"

--- a/shell-common/functions/claude_help.sh
+++ b/shell-common/functions/claude_help.sh
@@ -146,6 +146,7 @@ puts desc
 
 get_claude_skills() {
     local skills_dir="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills"
+    local skill_path skill_name skill_md yaml_name yaml_desc
 
     # Check if skills directory exists
     if [ ! -d "$skills_dir" ]; then
@@ -168,29 +169,31 @@ get_claude_skills() {
         # Skip if not a directory
         [ -d "$skill_path" ] || continue
 
-        local skill_name="$(basename "$skill_path")"
-        local skill_md="$skill_path/SKILL.md"
+        skill_name="$(basename "$skill_path")"
+        skill_md="$skill_path/SKILL.md"
 
         # Skip if SKILL.md doesn't exist
         [ -f "$skill_md" ] || continue
 
         # Extract name and description from YAML frontmatter
-        local metadata
-        metadata=$(_extract_skill_metadata "$skill_md")
-        local yaml_name="$(printf '%s\n' "$metadata" | sed -n '1p')"
-        local yaml_desc="$(printf '%s\n' "$metadata" | sed -n '2p')"
+        yaml_name=$(_extract_skill_metadata "$skill_md" | sed -n '1p')
+        yaml_desc=$(_extract_skill_metadata "$skill_md" | sed -n '2p')
 
         # Use directory name as fallback
         [ -n "$yaml_name" ] || yaml_name="$skill_name"
         [ -n "$yaml_desc" ] || yaml_desc="(No description)"
 
-        # Truncate description to 60 chars (more readable than 30)
-        if [ ${#yaml_desc} -gt 60 ]; then
-            yaml_desc="$(echo "$yaml_desc" | cut -c1-57)..."
+        # Truncate description to 160 chars for readability
+        if [ ${#yaml_desc} -gt 160 ]; then
+            yaml_desc="$(printf '%s' "$yaml_desc" | cut -c1-157)..."
         fi
 
-        # Output formatted line
-        printf "%-20s | %s\n" "$yaml_name" "$yaml_desc"
+        # Output formatted line (ux_bullet preferred for readability)
+        if command -v ux_bullet >/dev/null 2>&1; then
+            ux_bullet "$(printf '%-20s | %s' "$yaml_name" "$yaml_desc")"
+        else
+            printf "%-20s | %s\n" "$yaml_name" "$yaml_desc"
+        fi
 
         found_skills=1
     done

--- a/shell-common/functions/claude_help.sh
+++ b/shell-common/functions/claude_help.sh
@@ -183,9 +183,9 @@ get_claude_skills() {
         [ -n "$yaml_name" ] || yaml_name="$skill_name"
         [ -n "$yaml_desc" ] || yaml_desc="(No description)"
 
-        # Truncate description to 160 chars for readability
-        if [ ${#yaml_desc} -gt 160 ]; then
-            yaml_desc="$(printf '%s' "$yaml_desc" | cut -c1-157)..."
+        # Truncate description to 80 chars for readability
+        if [ ${#yaml_desc} -gt 80 ]; then
+            yaml_desc="$(printf '%s' "$yaml_desc" | cut -c1-77)..."
         fi
 
         # Output formatted line (ux_bullet preferred for readability)

--- a/shell-common/functions/claude_plugins.sh
+++ b/shell-common/functions/claude_plugins.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Claude Code Marketplace Plugins Management
 # Advanced utilities for managing and translating marketplace plugins
 
@@ -444,11 +445,93 @@ generate_plugin_doc_ko() {
 _get_plugin_description() {
     local file="$1"
 
+    _extract_yaml_field_fallback() {
+        local yaml_file="$1"
+        local field="$2"
+
+        awk -v field="$field" '
+BEGIN { in_fm=0; capturing=0; value="" }
+NR==1 && $0=="---" { in_fm=1; next }
+in_fm && $0=="---" {
+    if (capturing) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        capturing = 0
+        print value
+    }
+    exit
+}
+!in_fm { next }
+capturing {
+    if ($0 ~ /^[^[:space:]][^:]*:[[:space:]]*/) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        capturing = 0
+        print value
+        exit
+    }
+    line=$0
+    sub(/^[[:space:]]+/, "", line)
+    if (line != "") {
+        if (value != "") value = value " " line
+        else value = line
+    }
+    next
+}
+{
+    pattern = "^" field ":[[:space:]]*(.*)$"
+    if (match($0, pattern, m)) {
+        raw = m[1]
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", raw)
+        if (raw ~ /^[>|]/) {
+            capturing = 1
+            value = ""
+            next
+        }
+        sub(/^"/, "", raw)
+        sub(/"$/, "", raw)
+        print raw
+        exit
+    }
+}
+END {
+    if (capturing) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        print value
+    }
+}
+' "$yaml_file" 2>/dev/null
+    }
+
     # 1. Try to extract description from YAML frontmatter
-    local yaml_desc
-    yaml_desc=$(grep "^description:" "$file" 2>/dev/null | head -1 | sed 's/^description: *//; s/"//g' | cut -c1-100)
+    local yaml_desc=""
+
+    # Prefer robust YAML parsing for multiline descriptions (>- and |)
+    if command -v ruby >/dev/null 2>&1; then
+        yaml_desc="$(ruby -ryaml -e '
+path = ARGV[0]
+content = File.read(path)
+match = content.match(/\A---\n(.*?)\n---\n/m)
+exit 0 unless match
+data = YAML.safe_load(match[1]) || {}
+desc = data["description"].to_s.gsub(/\s+/, " ").strip
+puts desc
+' "$file" 2>/dev/null || true)"
+    fi
+
+    # Fallback for environments without ruby
+    if [ -z "$yaml_desc" ]; then
+        yaml_desc=$(_extract_yaml_field_fallback "$file" "description")
+    fi
 
     if [ -n "$yaml_desc" ]; then
+        if [ ${#yaml_desc} -gt 100 ]; then
+            yaml_desc="$(echo "$yaml_desc" | cut -c1-100)"
+        fi
         ux_info "$yaml_desc"
         return 0
     fi

--- a/shell-common/tools/custom/skill_loader.sh
+++ b/shell-common/tools/custom/skill_loader.sh
@@ -77,6 +77,101 @@ main() {
     return 0
 }
 
+# Extract skill name and description from YAML frontmatter.
+# Outputs two lines: name then description.
+extract_skill_field_fallback() {
+    local skill_md="$1"
+    local field="$2"
+
+    awk -v field="$field" '
+BEGIN { in_fm=0; capturing=0; value="" }
+NR==1 && $0=="---" { in_fm=1; next }
+in_fm && $0=="---" {
+    if (capturing) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        capturing = 0
+        print value
+    }
+    exit
+}
+!in_fm { next }
+capturing {
+    if ($0 ~ /^[^[:space:]][^:]*:[[:space:]]*/) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        capturing = 0
+        print value
+        exit
+    }
+    line=$0
+    sub(/^[[:space:]]+/, "", line)
+    if (line != "") {
+        if (value != "") value = value " " line
+        else value = line
+    }
+    next
+}
+{
+    pattern = "^" field ":[[:space:]]*(.*)$"
+    if (match($0, pattern, m)) {
+        raw = m[1]
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", raw)
+        if (raw ~ /^[>|]/) {
+            capturing = 1
+            value = ""
+            next
+        }
+        sub(/^"/, "", raw)
+        sub(/"$/, "", raw)
+        print raw
+        exit
+    }
+}
+END {
+    if (capturing) {
+        gsub(/[[:space:]]+/, " ", value)
+        sub(/^ /, "", value)
+        sub(/ $/, "", value)
+        print value
+    }
+}
+' "$skill_md" 2>/dev/null
+}
+
+extract_skill_metadata() {
+    local skill_md="$1"
+    local parsed=""
+
+    # Prefer robust YAML parsing for multiline descriptions (>- and |)
+    if command -v ruby >/dev/null 2>&1; then
+        parsed="$(ruby -ryaml -e '
+path = ARGV[0]
+content = File.read(path)
+match = content.match(/\A---\n(.*?)\n---\n/m)
+exit 0 unless match
+data = YAML.safe_load(match[1]) || {}
+name = data["name"].to_s.gsub(/\s+/, " ").strip
+desc = data["description"].to_s.gsub(/\s+/, " ").strip
+puts name
+puts desc
+' "$skill_md" 2>/dev/null || true)"
+    fi
+
+    if [ -n "$parsed" ]; then
+        printf '%s\n' "$parsed"
+        return 0
+    fi
+
+    # Fallback for environments without ruby
+    local fallback_name fallback_desc
+    fallback_name="$(extract_skill_field_fallback "$skill_md" "name")"
+    fallback_desc="$(extract_skill_field_fallback "$skill_md" "description")"
+    printf '%s\n%s\n' "$fallback_name" "$fallback_desc"
+}
+
 # List all available skills with descriptions
 list_skills() {
     local skills_dir="$1"
@@ -102,12 +197,13 @@ list_skills() {
         # Skip if SKILL.md doesn't exist
         [ -f "$skill_md" ] || continue
 
-        # Extract YAML content (between --- markers, excluding the markers)
-        local yaml_content="$(sed -n '/^---$/,/^---$/p' "$skill_md" | sed '1d;$d')"
-
         # Extract name and description from YAML frontmatter
-        local yaml_name="$(echo "$yaml_content" | grep '^name:' | head -1 | sed 's/^name: *//')"
-        local yaml_desc="$(echo "$yaml_content" | grep '^description:' | head -1 | sed 's/^description: *//')"
+        local metadata
+        metadata="$(extract_skill_metadata "$skill_md")"
+        local yaml_name
+        yaml_name="$(printf '%s\n' "$metadata" | sed -n '1p')"
+        local yaml_desc
+        yaml_desc="$(printf '%s\n' "$metadata" | sed -n '2p')"
 
         # Use directory name as fallback
         [ -n "$yaml_name" ] || yaml_name="$skill_name"


### PR DESCRIPTION
## Summary
- update skill metadata readers to parse YAML frontmatter including multiline `description` values (`>-`, `|`)
- add robust fallback parsing for environments where Ruby YAML parsing is unavailable
- migrate all `claude/skills/*/SKILL.md` descriptions to multiline block scalar format (`>-`)

## Details
- patched `claude-skills` listing parser in `shell-common/functions/claude_help.sh`
- patched `skill_loader --list` parser in `shell-common/tools/custom/skill_loader.sh`
- patched plugin description extractor in `shell-common/functions/claude_plugins.sh`
- normalized 33 skill files under `claude/skills/*/SKILL.md`

## Validation
- `tox -e shellcheck`
- manual checks
  - `shell-common/tools/custom/skill_loader.sh --list`
  - `get_claude_skills` output for multiline descriptions
  - YAML parse check for all skill frontmatters

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->