### PR TITLE
fix(my-help): use whence-based function check in zsh

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -107,6 +107,19 @@ get_help_description() {
 # Helper: Get all help functions (bash/zsh compatible)
 # ═══════════════════════════════════════════════════════════════
 
+# Cross-shell function existence check.
+# - bash: typeset -f inside a function is reliable
+# - zsh:  typeset -f inside a function can shadow/declare a local variable;
+#         use whence -w instead which only inspects, never declares
+_my_help_is_function() {
+    if [ -n "$ZSH_VERSION" ]; then
+        # whence -w prints "name: function" for functions
+        whence -w "$1" 2>/dev/null | grep -q ": function$"
+    else
+        declare -f "$1" >/dev/null 2>&1
+    fi
+}
+
 _get_help_functions() {
     # Prefer bash builtin when available.
     if command -v compgen >/dev/null 2>&1; then
@@ -599,13 +612,13 @@ my_help_impl() {
                 *) helper_name="${helper_name}_help" ;;
             esac
 
-            if typeset -f "$helper_name" >/dev/null 2>&1; then
+            if _my_help_is_function "$helper_name"; then
                 "$helper_name"
                 rc=$?
             else
-                # Some modules only expose a dash-style alias (e.g., apt-help). Safely detect
-                # aliases/functions using dash notation and execute them via eval so alias
-                # expansion occurs in both bash and zsh.
+                # Some modules only expose a dash-style function (e.g., apt-help). Only
+                # call dash-style names if they resolve to actual *functions* — not aliases
+                # that point to binaries (e.g., codex-help='codex --help').
                 case "$cmd_name" in
                     *[!A-Za-z0-9_-]*)
                         rc=1
@@ -617,10 +630,10 @@ my_help_impl() {
                             *-help) ;;
                             *) dash_name="${dash_name}-help" ;;
                         esac
-                        if type "$dash_name" >/dev/null 2>&1; then
-                            eval "$dash_name"
+                        if _my_help_is_function "$dash_name"; then
+                            "$dash_name"
                             rc=$?
-                        elif typeset -f "$cmd_name" >/dev/null 2>&1; then
+                        elif _my_help_is_function "$cmd_name"; then
                             "$cmd_name"
                             rc=$?
                         elif type "$cmd_name" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- `my-help codex` 실행 시 `codex_help()` 대신 실제 `codex` CLI가 호출되는 버그 수정
- `typeset -f` 대신 `_my_help_is_function()` 헬퍼를 도입해 zsh/bash 호환 함수 존재 체크
- dash-style fallback(`codex-help`)을 함수만 감지하도록 제한, alias 오호출 방지

## Root Cause

`typeset -f funcname` inside a zsh function can shadow a global function
with a local binding, causing the check to behave unexpectedly.

Fallback chain for `my-help codex`:
1. `typeset -f "codex_help"` → zsh에서 신뢰할 수 없음
2. `type "codex-help"` → `alias codex-help='codex --help'` 발견 (codex.sh에서 정의)
3. `eval "codex-help"` → 실제 `codex --help` 호출됨 ← **버그**

## Fix

Added `_my_help_is_function()` helper:
- **zsh**: `whence -w name | grep ": function$"` — pure lookup, never declares
- **bash**: `declare -f name`

Replaced all `typeset -f` and `type "$dash_name"` checks with `_my_help_is_function`.
`alias codex-help='codex --help'` is now correctly skipped as it is not a function.

## Test plan

- [ ] `my-help codex` → shows dotfiles codex shortcuts (not `codex --help`)
- [ ] `my-help git` → still works correctly
- [ ] `my-help docker` → still works correctly
- [ ] `codex-help` alias still runs `codex --help` as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->