### PR TITLE
[codex] Fix skill loading by normalizing SKILL.md metadata

### DIFF
--- a/claude/skills/make-confluence/SKILL.md
+++ b/claude/skills/make-confluence/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: make-confluence
+description: >-
+  Transform markdown technical documentation into Confluence-formatted guides
+  with structured problem-solution-results format.
+---
+
 # make-confluence: Technical Documentation to Confluence Guide
 
 Transform markdown technical documentation into Confluence-formatted guides with structured problem-solution-results format.

--- a/claude/skills/make-confluence/SKILL.md
+++ b/claude/skills/make-confluence/SKILL.md
@@ -5,9 +5,7 @@ description: >-
   with structured problem-solution-results format.
 ---
 
-# make-confluence: Technical Documentation to Confluence Guide
-
-Transform markdown technical documentation into Confluence-formatted guides with structured problem-solution-results format.
+# make-confluence
 
 ## Invocation
 

--- a/claude/skills/make-jira/SKILL.md
+++ b/claude/skills/make-jira/SKILL.md
@@ -4,9 +4,7 @@ description: >-
   Generate comprehensive weekly Jira reports from work logs.
 ---
 
-# make-jira: Weekly Jira Report Generator
-
-Generate comprehensive weekly Jira reports from work logs.
+# make-jira
 
 ## Invocation
 

--- a/claude/skills/make-jira/SKILL.md
+++ b/claude/skills/make-jira/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: make-jira
+description: >-
+  Generate comprehensive weekly Jira reports from work logs.
+---
+
 # make-jira: Weekly Jira Report Generator
 
 Generate comprehensive weekly Jira reports from work logs.


### PR DESCRIPTION
## Summary
- rename `claude/skills/make-confluence/skill.md` to `claude/skills/make-confluence/SKILL.md`
- rename `claude/skills/make-jira/skill.md` to `claude/skills/make-jira/SKILL.md`
- add required YAML frontmatter (`name`, `description`) to both `SKILL.md` files

## Why
Codex skill loader now expects `SKILL.md` files to start with YAML frontmatter. Without it, these skills are skipped with:
- `missing YAML frontmatter delimited by ---`

## Impact
- `make-confluence` and `make-jira` skills are loaded again instead of being skipped
- no behavior change in skill body instructions; metadata/filename compliance only

## Root Cause
The files were moved to `SKILL.md`, but they still used legacy body-only markdown format with no frontmatter.

## Validation
- `tox -e ruff,mypy,shellcheck,shfmt`
- local scan: all `claude/skills/*/SKILL.md` files start with `---`

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->