### PR TITLE
fix(codex): use rm -f and check exit code in skills sync

### DIFF
--- a/shell-common/tools/integrations/codex.sh
+++ b/shell-common/tools/integrations/codex.sh
@@ -51,9 +51,12 @@ codex_skills_sync() {
     while read -r link; do
         if [ -L "$link" ] && [ ! -e "$link" ]; then
             name=$(basename "$link")
-            rm "$link"
-            ux_warning "Removed: $name"
-            removed=$((removed + 1))
+            if rm -f "$link"; then
+                ux_warning "Removed: $name"
+                removed=$((removed + 1))
+            else
+                ux_error "Failed to remove: $name"
+            fi
         fi
     done <<EOF
 $(find "$dst" -maxdepth 1 -type l)


### PR DESCRIPTION
## Summary
- `codex-skills-sync` 2번 실행 시 동일한 symlink가 반복 삭제되는 버그 수정
- `rm` 별칭(`rm -i`)이 스크립트 내에서 대화형 프롬프트를 유발해 실제 삭제 실패
- exit code 미확인으로 삭제 실패 여부와 무관하게 "Removed" 출력

## Root Cause
```sh
# 수정 전: rm -i 별칭이 프롬프트 띄우고 실패해도 항상 "Removed" 출력
rm "$link"
ux_warning "Removed: $name"  # exit code 무관하게 실행
```

## Fix
```sh
# 수정 후: rm -f로 별칭 우회 + exit code 확인
if rm -f "$link"; then
    ux_warning "Removed: $name"
    removed=$((removed + 1))
else
    ux_error "Failed to remove: $name"
fi
```

## Test plan
- [ ] `codex-skills-sync` 실행 후 broken symlink 실제 삭제 확인
- [ ] 2번째 실행 시 "Removed" 출력 없음 확인
- [ ] `rm -i` 별칭 환경에서 대화형 프롬프트 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->