### PR TITLE
fix(opencode): use envsubst to resolve env vars in profile config

### DIFF
--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -236,15 +236,15 @@ setup_opencode_config() {
         internal)
             mkdir -p "$(dirname "$opencode_target")"
             _prepare_config_target "$opencode_target"
-            envsubst < "${DOTFILES_ROOT}/opencode/opencode.json.internal" > "$opencode_target"
+            envsubst '${DTGPT_API_KEY}' < "${DOTFILES_ROOT}/opencode/opencode.json.internal" > "$opencode_target"
             ux_success "Created config: ~/.config/opencode/opencode.json (env vars resolved)"
             ux_info "Using: Samsung internal LiteLLM endpoint"
             ;;
         external)
             mkdir -p "$(dirname "$opencode_target")"
             _prepare_config_target "$opencode_target"
-            envsubst < "${DOTFILES_ROOT}/opencode/opencode.json.external" > "$opencode_target"
-            ux_success "Created config: ~/.config/opencode/opencode.json (env vars resolved)"
+            ln -s "${DOTFILES_ROOT}/opencode/opencode.json.external" "$opencode_target"
+            ux_success "Created symlink: ~/.config/opencode/opencode.json → opencode/opencode.json.external"
             ux_info "Using: Local LiteLLM proxy (localhost:4444)"
             ;;
         public)

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -234,6 +234,11 @@ setup_opencode_config() {
 
     case "$environment" in
         internal)
+            if ! command -v envsubst >/dev/null 2>&1; then
+                ux_error "envsubst not found — install gettext-base"
+                ux_bullet "  Ubuntu/Debian: sudo apt install gettext-base"
+                return 1
+            fi
             mkdir -p "$(dirname "$opencode_target")"
             _prepare_config_target "$opencode_target"
             envsubst '${DTGPT_API_KEY}' < "${DOTFILES_ROOT}/opencode/opencode.json.internal" > "$opencode_target"
@@ -248,7 +253,18 @@ setup_opencode_config() {
             ux_info "Using: Local LiteLLM proxy (localhost:4444)"
             ;;
         public)
-            _restore_config_from_backup "$opencode_target"
+            if [ -L "$opencode_target" ]; then
+                _restore_config_from_backup "$opencode_target"
+            elif [ -f "$opencode_target" ]; then
+                rm -f "$opencode_target"
+                _latest="$(ls -t "${opencode_target}.backup."* 2>/dev/null | head -1)"
+                if [ -n "$_latest" ]; then
+                    mv "$_latest" "$opencode_target"
+                    ux_success "Restored: $(basename "$_latest") → $opencode_target"
+                else
+                    ux_info "Removed dotfiles-managed config (using OpenCode defaults)"
+                fi
+            fi
             ;;
     esac
 }
@@ -610,7 +626,7 @@ main() {
             ux_info "  - Proxy: Company proxy (12.26.204.100:8080) configured"
             ux_info "  - NPM: ~/.npmrc → npm/npmrc.internal (Nexus + proxy)"
             ux_info "  - Bun: ~/.bunfig.toml → bun/bunfig.toml.internal (Nexus registry)"
-            ux_info "  - OpenCode: ~/.config/opencode/opencode.json → opencode/opencode.json.internal"
+            ux_info "  - OpenCode: ~/.config/opencode/opencode.json (generated from opencode.json.internal)"
             ux_info "  - Pip: Samsung internal repository configured"
             ux_info "  - uv: Samsung internal repository + proxy configured"
             ux_info "  - Cargo: ~/.cargo/config.toml (Nexus proxy for crates.io)"

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -236,15 +236,15 @@ setup_opencode_config() {
         internal)
             mkdir -p "$(dirname "$opencode_target")"
             _prepare_config_target "$opencode_target"
-            ln -s "${DOTFILES_ROOT}/opencode/opencode.json.internal" "$opencode_target"
-            ux_success "Created symlink: ~/.config/opencode/opencode.json → opencode/opencode.json.internal"
+            envsubst < "${DOTFILES_ROOT}/opencode/opencode.json.internal" > "$opencode_target"
+            ux_success "Created config: ~/.config/opencode/opencode.json (env vars resolved)"
             ux_info "Using: Samsung internal LiteLLM endpoint"
             ;;
         external)
             mkdir -p "$(dirname "$opencode_target")"
             _prepare_config_target "$opencode_target"
-            ln -s "${DOTFILES_ROOT}/opencode/opencode.json.external" "$opencode_target"
-            ux_success "Created symlink: ~/.config/opencode/opencode.json → opencode/opencode.json.external"
+            envsubst < "${DOTFILES_ROOT}/opencode/opencode.json.external" > "$opencode_target"
+            ux_success "Created config: ~/.config/opencode/opencode.json (env vars resolved)"
             ux_info "Using: Local LiteLLM proxy (localhost:4444)"
             ;;
         public)

--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -178,7 +178,10 @@ oc_profile() {
     fi
 
     mkdir -p "$(dirname "$OPENCODE_CONFIG_FILE")"
-    envsubst < "$src" > "$OPENCODE_CONFIG_FILE"
+    case "$profile" in
+        dtgpt) envsubst '${DTGPT_API_KEY}' < "$src" > "$OPENCODE_CONFIG_FILE" ;;
+        a2g)   envsubst '${A2G_API_KEY}'   < "$src" > "$OPENCODE_CONFIG_FILE" ;;
+    esac
     ux_success "OpenCode profile: $profile"
     ux_bullet "Config → $OPENCODE_CONFIG_FILE (env vars resolved)"
 }

--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -171,9 +171,16 @@ oc_profile() {
         return 1
     fi
 
-    ln -sf "$src" "$OPENCODE_CONFIG_FILE"
+    if ! command -v envsubst >/dev/null 2>&1; then
+        ux_error "envsubst not found — install gettext package"
+        ux_bullet "  Ubuntu/Debian: sudo apt install gettext-base"
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$OPENCODE_CONFIG_FILE")"
+    envsubst < "$src" > "$OPENCODE_CONFIG_FILE"
     ux_success "OpenCode profile: $profile"
-    ux_bullet "Config → $src"
+    ux_bullet "Config → $OPENCODE_CONFIG_FILE (env vars resolved)"
 }
 
 alias oc-profile='oc_profile'


### PR DESCRIPTION
## Summary
- `oc-profile` 전환 시 `ln -sf`(심링크) 방식에서 `envsubst` 치환 방식으로 변경
- opencode는 JSON 파일 내 `${VAR}` 환경변수를 자체적으로 확장하지 않아 API KEY 인식 불가 문제 발생
- `envsubst < template > ~/.config/opencode/opencode.json` 방식으로 전환 시점에 실제 키 주입
- dotfiles template 파일은 `${DTGPT_API_KEY}` / `${A2G_API_KEY}` placeholder 유지 (git-safe)

## Test plan
- [ ] `.env`에 `DTGPT_API_KEY=<실제키>` 설정 후 `oc-profile dtgpt` 실행
- [ ] `~/.config/opencode/opencode.json` 에 실제 키가 주입되었는지 확인
- [ ] opencode 실행 후 API KEY 에러 없이 정상 동작 확인
- [ ] `envsubst` 미설치 환경에서 적절한 에러 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->