### PR TITLE
fix(hooks): allow git-crypt managed files in forbidden filename check

### DIFF
--- a/git/global-hooks/pre-commit
+++ b/git/global-hooks/pre-commit
@@ -100,6 +100,15 @@ ENV_BASENAME_ALLOW_ERE="${GIT_HOOKS_ENV_BASENAME_ALLOW_ERE:-^\.env\.([^.]+\.)*(e
 FORBIDDEN_PATH_ERE="${GIT_HOOKS_FORBIDDEN_PATH_ERE:-(^|/)\.aws/(credentials|config)$}"
 
 # ═══════════════════════════════════════════════════════════════════════════
+# FUNCTION: Check if a path is managed by git-crypt (will be encrypted)
+# ═══════════════════════════════════════════════════════════════════════════
+# Returns 0 if git-crypt managed, 1 otherwise
+is_git_crypt_managed() {
+    local path="$1"
+    git check-attr filter -- "$path" 2>/dev/null | grep -q "filter: git-crypt"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
 # FUNCTION: Check if a staged path contains forbidden filename/pattern
 # ═══════════════════════════════════════════════════════════════════════════
 # Returns 0 if forbidden, 1 if allowed
@@ -107,6 +116,11 @@ FORBIDDEN_PATH_ERE="${GIT_HOOKS_FORBIDDEN_PATH_ERE:-(^|/)\.aws/(credentials|conf
 is_forbidden_staged_path() {
     local path="$1"
     local base="${path##*/}"  # Extract basename (everything after last /)
+
+    # 0. Allow git-crypt managed files (stored encrypted in the index)
+    if is_git_crypt_managed "$path"; then
+        return 1
+    fi
 
     # 1. Check path-based rules first (most specific: .aws/credentials, etc.)
     if printf '%s\n' "$path" | grep -Eq "$FORBIDDEN_PATH_ERE"; then

--- a/git/global-hooks/pre-commit
+++ b/git/global-hooks/pre-commit
@@ -105,7 +105,11 @@ FORBIDDEN_PATH_ERE="${GIT_HOOKS_FORBIDDEN_PATH_ERE:-(^|/)\.aws/(credentials|conf
 # Returns 0 if git-crypt managed, 1 otherwise
 is_git_crypt_managed() {
     local path="$1"
-    git check-attr filter -- "$path" 2>/dev/null | grep -q "filter: git-crypt"
+    if [ "$DEBUG" = "1" ]; then
+        git check-attr filter -- "$path" | grep -q "filter: git-crypt"
+    else
+        git check-attr filter -- "$path" 2>/dev/null | grep -q "filter: git-crypt"
+    fi
 }
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- `is_git_crypt_managed()` 헬퍼 추가: `git check-attr filter`로 git-crypt 관리 여부 확인
- `is_forbidden_staged_path()` 최상단에서 git-crypt 파일을 허용 처리
- `.env` 등 `.gitattributes`에 `filter=git-crypt`로 등록된 파일은 forbidden 체크에서 제외

## Background
pre-commit hook은 git-crypt clean filter보다 먼저 실행되므로,
`.env`가 실제로 암호화되어 저장되더라도 hook이 평문 파일명을 보고 차단했음.
`git check-attr`을 통해 git-crypt 관리 파일을 정확히 식별하여 허용.

## Test plan
- [ ] `.gitattributes`에 등록된 `.env` staged 후 `git commit` → hook 통과 확인
- [ ] git-crypt 미설정 `.env` staged → 여전히 BLOCKED 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->