### PR TITLE
fix(ssh): improve connection performance

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -1,5 +1,25 @@
 Host *
      PubkeyAcceptedKeyTypes +ssh-rsa
+     ServerAliveInterval 60
+     ServerAliveCountMax 3
+     ConnectTimeout 10
+
+Host github.samsungds.net
+     User git
+     IdentityFile ~/.ssh/id_ed25519
+     IdentitiesOnly yes
+     ControlMaster auto
+     ControlPath ~/.ssh/control-%h-%p-%r
+     ControlPersist 600
+
+Host github.com
+     User git
+     IdentityFile ~/.ssh/id_ed25519
+     IdentitiesOnly yes
+     ConnectTimeout 5
+     # 사내망에서 port 22 차단 시 아래 두 줄 주석 해제
+     # Hostname ssh.github.com
+     # Port 443
 
 Host Replica-Gerrit
      HostName 10.166.101.44
@@ -17,11 +37,6 @@ Host 10.227.36.179
      KexAlgorithms diffie-hellman-group-exchange-sha256
      HostkeyAlgorithms +ssh-rsa
      PubkeyAcceptedKeyTypes +ssh-rsa
-
-Host github.samsungds.net
-     ControlMaster auto
-     ControlPath ~/.ssh/control-%h-%p-%r
-     ControlPersist 300
 
 # SSAI Server Access
 Host ssai-dev


### PR DESCRIPTION
## Summary

- `Host *`에 `ServerAliveInterval 60` / `ConnectTimeout 10` 추가 — 차단된 연결을 빠르게 감지
- `github.samsungds.net`에 `User git`, `IdentityFile`, `IdentitiesOnly yes` 추가 — 불필요한 키 5개 시도 제거
- `github.com` 블록 신규 추가 — `ConnectTimeout 5`로 타임아웃 2분 → 5초, port 443 우회 옵션 주석 포함
- `ControlPersist` 300s → 600s로 연장

## Problem

사내망에서 `git pull` 시간이 오래 걸리는 문제:
1. `github.com` port 22가 차단되어 연결 시도 시 2분 9초 대기
2. `github.samsungds.net`에서 존재하지 않는 키 파일 5개를 순서대로 시도

## Test plan

- [ ] `ssh -T git@github.samsungds.net` 빠르게 성공
- [ ] `ssh -T git@github.com` 5초 내 응답 (성공 또는 실패)
- [ ] `time git pull` 응답 시간 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->