### PR TITLE
fix(ssh): enable github.com port 443 fallback

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -17,9 +17,8 @@ Host github.com
      IdentityFile ~/.ssh/id_ed25519
      IdentitiesOnly yes
      ConnectTimeout 5
-     # 사내망에서 port 22 차단 시 아래 두 줄 주석 해제
-     # Hostname ssh.github.com
-     # Port 443
+     Hostname ssh.github.com
+     Port 443
 
 Host Replica-Gerrit
      HostName 10.166.101.44


### PR DESCRIPTION
## Summary

- `github.com` 블록에서 `Hostname ssh.github.com` / `Port 443` 주석 해제
- 사내 방화벽의 port 22 차단 우회 → SSH 트래픽을 443 포트로 라우팅

## Problem

`git fetch upstream` 13초 소요 — upstream remote가 `https://github.com`이고, HTTPS가 사내망에서 느림.

**해결 방법**: upstream remote를 HTTPS → SSH로 변경하면 `ssh.github.com:443` 경로를 타게 되어 빠르게 연결됨.

사내 머신에서 아래 명령 실행 필요:
```bash
git remote set-url upstream git@github.com:dEitY719/dotfiles.git
```

## Test plan

- [ ] `ssh -T git@github.com` 성공 (ssh.github.com:443 경유)
- [ ] `time git fetch upstream` 13초 → 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->