### PR TITLE
fix(codex): auto-sync skills and unify help commands

### DIFF
--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -9,8 +9,9 @@
 #   - 전체 디렉토리 symlink: tools skills dir가 없거나 빈 경우
 #     ~/.config/opencode/skills/ → ~/dotfiles/claude/skills/
 #     ~/.gemini/skills/          → ~/dotfiles/claude/skills/
-#   - 개별 skill symlink: tools skills dir에 기존 내용이 있는 경우
-#     ~/.codex/skills/<skill>/   → ~/dotfiles/claude/skills/<skill>/
+#   - Codex 전용 개별 연결: skill 디렉토리는 실제 폴더로 만들고
+#     내부 항목(SKILL.md, references/, scripts/...)만 symlink
+#     ~/.codex/skills/<skill>/<entry> → ~/dotfiles/claude/skills/<skill>/<entry>
 #
 # ~/.claude/skills 는 claude/setup.sh (bind mount) 가 관리
 
@@ -34,6 +35,8 @@ log_error() { ux_error "$1"; }
 log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
 log_warning() { ux_warning "$1"; }
 log_critical() { ux_error "$1"; exit 1; }
+
+CODEX_MANAGED_MARKER=".dotfiles-skill-source"
 
 # --- Helper Functions ---
 
@@ -103,6 +106,148 @@ link_skills_individual() {
     log_info "[$tool] 개별 skill 연결 완료: ${linked}개 신규, ${skipped}개 기존 유지"
 }
 
+# Codex는 symlink된 skill 디렉토리를 스캔하지 못할 수 있어,
+# skill 디렉토리는 실디렉토리로 유지하고 내부 엔트리만 symlink 한다.
+# Usage: link_skills_individual_codex <target_dir>
+link_skills_individual_codex() {
+    local target_dir="$1"
+    local linked=0
+    local migrated=0
+    local skipped=0
+    local pruned=0
+    local prune_skipped=0
+
+    mkdir -p "$target_dir"
+
+    for skill_path in "$SKILLS_SOURCE"/*/; do
+        [ -d "$skill_path" ] || continue
+
+        local skill_name
+        skill_name="$(basename "$skill_path")"
+
+        local skill_target_dir="${target_dir}/${skill_name}"
+        local marker_file="${skill_target_dir}/${CODEX_MANAGED_MARKER}"
+        local source_realpath
+        source_realpath="$(readlink -f "$skill_path")"
+
+        if [ -L "$skill_target_dir" ]; then
+            local current_target
+            current_target="$(readlink -f "$skill_target_dir" 2>/dev/null)"
+            if [ "$current_target" = "$source_realpath" ]; then
+                rm "$skill_target_dir"
+                migrated=$((migrated + 1))
+            else
+                log_dim "[codex] 기존 사용자 symlink 보존: $skill_target_dir"
+                skipped=$((skipped + 1))
+                continue
+            fi
+        fi
+
+        if [ -d "$skill_target_dir" ]; then
+            if [ -f "$marker_file" ] && grep -Fqx "$source_realpath" "$marker_file"; then
+                :
+            elif [ -f "$marker_file" ]; then
+                printf "%s\n" "$source_realpath" > "$marker_file"
+            elif [ -z "$(ls -A "$skill_target_dir" 2>/dev/null)" ]; then
+                printf "%s\n" "$source_realpath" > "$marker_file"
+            else
+                log_dim "[codex] 기존 디렉토리 보존: $skill_target_dir"
+                skipped=$((skipped + 1))
+                continue
+            fi
+        else
+            mkdir -p "$skill_target_dir"
+            printf "%s\n" "$source_realpath" > "$marker_file"
+        fi
+
+        local entry_path
+        for entry_path in "$skill_path"* "$skill_path".*; do
+            [ -e "$entry_path" ] || continue
+
+            local entry_name
+            entry_name="$(basename "$entry_path")"
+            if [ "$entry_name" = "." ] || [ "$entry_name" = ".." ]; then
+                continue
+            fi
+
+            local entry_target="${skill_target_dir}/${entry_name}"
+            local entry_source_realpath
+            entry_source_realpath="$(readlink -f "$entry_path")"
+
+            if [ -L "$entry_target" ]; then
+                local current_entry_target
+                current_entry_target="$(readlink -f "$entry_target" 2>/dev/null)"
+                if [ "$current_entry_target" = "$entry_source_realpath" ]; then
+                    continue
+                fi
+                rm "$entry_target"
+            elif [ -e "$entry_target" ]; then
+                log_dim "[codex] 기존 엔트리 보존: $entry_target"
+                continue
+            fi
+
+            ln -s "$entry_path" "$entry_target" || {
+                log_error "[codex] skill 엔트리 symlink 생성 실패: $entry_target"
+                continue
+            }
+        done
+
+        if [ -e "${skill_target_dir}/SKILL.md" ]; then
+            linked=$((linked + 1))
+        else
+            log_warning "[codex] SKILL.md 미연결: $skill_target_dir"
+        fi
+    done
+
+    local existing_skill_dir
+    for existing_skill_dir in "$target_dir"/*/; do
+        [ -d "$existing_skill_dir" ] || continue
+
+        local existing_name
+        existing_name="$(basename "$existing_skill_dir")"
+        if [ "$existing_name" = ".system" ]; then
+            continue
+        fi
+
+        local existing_marker
+        existing_marker="${existing_skill_dir%/}/${CODEX_MANAGED_MARKER}"
+        [ -f "$existing_marker" ] || continue
+
+        if [ -d "${SKILLS_SOURCE}/${existing_name}" ]; then
+            continue
+        fi
+
+        local has_nonsymlink=0
+        local existing_entry
+        for existing_entry in "${existing_skill_dir%/}"/* "${existing_skill_dir%/}"/.*; do
+            [ -e "$existing_entry" ] || continue
+            local existing_entry_name
+            existing_entry_name="$(basename "$existing_entry")"
+            if [ "$existing_entry_name" = "." ] || [ "$existing_entry_name" = ".." ] || [ "$existing_entry_name" = "$CODEX_MANAGED_MARKER" ]; then
+                continue
+            fi
+            if [ ! -L "$existing_entry" ]; then
+                has_nonsymlink=1
+                break
+            fi
+        done
+
+        if [ "$has_nonsymlink" -eq 1 ]; then
+            log_warning "[codex] stale skill 보존(사용자 데이터 감지): ${existing_skill_dir%/}"
+            prune_skipped=$((prune_skipped + 1))
+            continue
+        fi
+
+        rm -rf "${existing_skill_dir%/}" || {
+            log_error "[codex] stale skill 제거 실패: ${existing_skill_dir%/}"
+            continue
+        }
+        pruned=$((pruned + 1))
+    done
+
+    log_info "[codex] skill 연결 완료: ${linked}개 준비, ${migrated}개 마이그레이션, ${skipped}개 기존 유지, ${pruned}개 정리, ${prune_skipped}개 보존"
+}
+
 # --- Main ---
 
 log_dim "\n--- Skills SSOT 연결 시작 ---"
@@ -120,16 +265,26 @@ else
     link_skills_dir "opencode" "$OPENCODE_SKILLS"
 fi
 
-# 2. Codex: 개별 skill symlink (.system 보존)
+# 2. Codex: skill 디렉토리는 실디렉토리, 내부 엔트리만 symlink (.system 보존)
 CODEX_SKILLS="${HOME}/.codex/skills"
 if [ ! -d "${HOME}/.codex" ]; then
     log_warning "Codex 설정 디렉토리가 없습니다. 건너뜁니다: ${HOME}/.codex"
-elif [ ! -d "$CODEX_SKILLS" ]; then
-    # skills 디렉토리 자체가 없으면 전체 symlink
-    link_skills_dir "codex" "$CODEX_SKILLS"
 else
-    # 기존 skills 디렉토리 있음 (.system 등 보존) → 개별 symlink
-    link_skills_individual "codex" "$CODEX_SKILLS"
+    codex_can_manage=1
+    # 기존에 전체 dir symlink였다면 해제 후 codex 전용 방식으로 마이그레이션
+    if [ -L "$CODEX_SKILLS" ]; then
+        local_codex_target="$(readlink -f "$CODEX_SKILLS" 2>/dev/null)"
+        if [ "$local_codex_target" = "$(readlink -f "$SKILLS_SOURCE")" ]; then
+            rm "$CODEX_SKILLS"
+        else
+            log_warning "Codex skills 경로가 사용자 symlink입니다. 건너뜁니다: $CODEX_SKILLS"
+            codex_can_manage=0
+        fi
+    fi
+    if [ "$codex_can_manage" -eq 1 ]; then
+        mkdir -p "$CODEX_SKILLS"
+        link_skills_individual_codex "$CODEX_SKILLS"
+    fi
 fi
 
 # 3. Gemini: 전체 디렉토리 symlink
@@ -147,7 +302,7 @@ log_dim "\n--- Skills SSOT 연결 확인 ---"
 verify_link() {
     local tool="$1"
     local path="$2"
-    local mode="$3"   # "dir" or "individual"
+    local mode="$3"   # "dir" or "individual" or "codex"
 
     if [ "$mode" = "dir" ]; then
         if [ -L "$path" ]; then
@@ -155,20 +310,20 @@ verify_link() {
         else
             log_warning "[$tool] symlink 확인 실패: $path"
         fi
-    else
+    elif [ "$mode" = "individual" ]; then
         local count
         count=$(find "$path" -maxdepth 1 -type l 2>/dev/null | wc -l)
         log_dim "✓ [$tool] $path (개별 symlink: ${count}개)"
+    else
+        local count
+        count=$(find "$path" -mindepth 2 -maxdepth 2 -name "SKILL.md" 2>/dev/null | wc -l)
+        log_dim "✓ [$tool] $path (SKILL.md 감지: ${count}개)"
     fi
 }
 
 [ -d "${HOME}/.config/opencode" ] && verify_link "opencode" "$OPENCODE_SKILLS" "dir"
 if [ -d "${HOME}/.codex" ]; then
-    if [ -L "$CODEX_SKILLS" ]; then
-        verify_link "codex" "$CODEX_SKILLS" "dir"
-    else
-        verify_link "codex" "$CODEX_SKILLS" "individual"
-    fi
+    verify_link "codex" "$CODEX_SKILLS" "codex"
 fi
 [ -d "${HOME}/.gemini" ] && verify_link "gemini" "$GEMINI_SKILLS" "dir"
 

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -134,7 +134,9 @@ link_skills_individual_codex() {
             local current_target
             current_target="$(readlink -f "$skill_target_dir" 2>/dev/null)"
             if [ "$current_target" = "$source_realpath" ]; then
-                rm "$skill_target_dir"
+                if [ -e "$skill_target_dir" ] || [ -L "$skill_target_dir" ]; then
+                    rm -f "$skill_target_dir"
+                fi
                 migrated=$((migrated + 1))
             else
                 log_dim "[codex] 기존 사용자 symlink 보존: $skill_target_dir"
@@ -275,7 +277,9 @@ else
     if [ -L "$CODEX_SKILLS" ]; then
         local_codex_target="$(readlink -f "$CODEX_SKILLS" 2>/dev/null)"
         if [ "$local_codex_target" = "$(readlink -f "$SKILLS_SOURCE")" ]; then
-            rm "$CODEX_SKILLS"
+            if [ -e "$CODEX_SKILLS" ] || [ -L "$CODEX_SKILLS" ]; then
+                rm -f "$CODEX_SKILLS"
+            fi
         else
             log_warning "Codex skills 경로가 사용자 symlink입니다. 건너뜁니다: $CODEX_SKILLS"
             codex_can_manage=0

--- a/shell-common/functions/codex_help.sh
+++ b/shell-common/functions/codex_help.sh
@@ -16,6 +16,7 @@ codex_help() {
     ux_table_row "codex-uninstall" "Uninstall Script" "Remove Codex CLI"
     ux_table_row "codex-status" "Status Check" "Show installation status"
     ux_table_row "codex-skills-sync" "Skills Sync" "Sync skills symlinks"
+    ux_table_row "Auto skill sync" "Enabled by default" "Before codex command"
 
     ux_section "Interactive Mode"
     ux_table_row "codex" "codex" "Start interactive"
@@ -24,6 +25,8 @@ codex_help() {
     ux_section "Tips"
     ux_bullet "Config: ~/.codex/ or ~/.config/codex/"
     ux_bullet "Auth: Use 'codex' to authenticate"
+    ux_bullet "Disable auto sync: export CODEX_SKILLS_AUTO_SYNC=0"
+    ux_bullet "Verbose auto sync: export CODEX_SKILLS_AUTO_SYNC_VERBOSE=1"
 }
 
 alias codex-quick-help='codex_help'

--- a/shell-common/functions/codex_help.sh
+++ b/shell-common/functions/codex_help.sh
@@ -6,8 +6,8 @@ codex_help() {
 
     ux_section "Basic Commands"
     ux_table_row "codex" "codex" "Base command"
-    ux_table_row "codex-help" "codex --help" "Show help"
-    ux_table_row "codex-quick-help" "codex-quick-help" "Show dotfiles codex commands"
+    ux_table_row "codex-help" "codex-help" "Show dotfiles codex commands"
+    ux_table_row "Official help" "codex help | --help | -h" "Show CLI help"
     ux_table_row "codex-version" "codex --version" "Check version"
     ux_table_row "codex-yolo" "codex --dangerously-bypass-approvals-and-sandbox" "Bypass guardrails"
 
@@ -29,4 +29,4 @@ codex_help() {
     ux_bullet "Verbose auto sync: export CODEX_SKILLS_AUTO_SYNC_VERBOSE=1"
 }
 
-alias codex-quick-help='codex_help'
+alias codex-help='codex_help'

--- a/shell-common/tools/custom/install_codex.sh
+++ b/shell-common/tools/custom/install_codex.sh
@@ -99,7 +99,7 @@ main() {
     ux_bullet "Check your PATH if the command is not found: ${UX_PRIMARY}echo \$PATH${UX_RESET}"
     ux_bullet "View help: ${UX_PRIMARY}codex --help${UX_RESET}"
     echo ""
-    ux_info "For more project-specific commands, run: ${UX_PRIMARY}codex-quick-help${UX_RESET}"
+    ux_info "For more project-specific commands, run: ${UX_PRIMARY}codex-help${UX_RESET}"
     echo ""
 }
 

--- a/shell-common/tools/integrations/codex.sh
+++ b/shell-common/tools/integrations/codex.sh
@@ -42,28 +42,12 @@ _codex_skills_state_file() {
 
 _codex_skills_fingerprint() {
     local src="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills"
-    local skill_dir entry entry_name
 
     [ -d "$src" ] || return 1
 
-    # zsh: prevent nomatch errors for patterns like "$skill_dir".*
-    if [ -n "$ZSH_VERSION" ]; then
-        setopt local_options nonomatch
-    fi
-
     (
-        for skill_dir in "$src"/*/; do
-            [ -d "$skill_dir" ] || continue
-            echo "skill:$(basename "$skill_dir")"
-            for entry in "$skill_dir"* "$skill_dir".*; do
-                [ -e "$entry" ] || continue
-                entry_name=$(basename "$entry")
-                if [ "$entry_name" = "." ] || [ "$entry_name" = ".." ]; then
-                    continue
-                fi
-                echo "entry:$(basename "$skill_dir")/$entry_name"
-            done
-        done
+        cd "$src" || exit 1
+        find . -mindepth 1 -maxdepth 2 -not -name "." -not -name ".."
     ) | LC_ALL=C sort | cksum | awk '{print $1 ":" $2}'
 }
 
@@ -160,62 +144,9 @@ _codex_maybe_auto_sync() {
     CODEX_AUTO_SYNC_IN_PROGRESS="$prev_in_progress"
 }
 
-_codex_should_sync_for_command() {
-    case "$1" in
-        codex|codex\ *)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-_codex_zsh_preexec_auto_sync() {
-    _codex_should_sync_for_command "$1" || return 0
+codex() {
     _codex_maybe_auto_sync
-}
-
-_codex_register_zsh_hook() {
-    [ -n "$ZSH_VERSION" ] || return 0
-    case "$-" in
-        *i*) ;;
-        *) return 0 ;;
-    esac
-
-    autoload -Uz add-zsh-hook 2>/dev/null || return 0
-    add-zsh-hook preexec _codex_zsh_preexec_auto_sync
-}
-
-_codex_bash_debug_auto_sync() {
-    _codex_should_sync_for_command "${BASH_COMMAND:-}" || return 0
-    _codex_maybe_auto_sync
-}
-
-_codex_register_bash_hook() {
-    [ -n "$BASH_VERSION" ] || return 0
-    case "$-" in
-        *i*) ;;
-        *) return 0 ;;
-    esac
-    [ "${CODEX_BASH_HOOK_REGISTERED:-0}" = "1" ] && return 0
-
-    local existing_debug_trap
-    existing_debug_trap="$(trap -p DEBUG)"
-    case "$existing_debug_trap" in
-        *"_codex_bash_debug_auto_sync"*)
-            CODEX_BASH_HOOK_REGISTERED=1
-            return 0
-            ;;
-    esac
-
-    if [ -n "$existing_debug_trap" ]; then
-        ux_warning "DEBUG trap already configured; skipping codex auto-sync hook (bash)"
-        return 0
-    fi
-
-    trap '_codex_bash_debug_auto_sync' DEBUG
-    CODEX_BASH_HOOK_REGISTERED=1
+    command codex "$@"
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -258,7 +189,5 @@ codex_status() {
     fi
 }
 
-# Register hooks and prime state once per interactive shell session.
-_codex_register_zsh_hook
-_codex_register_bash_hook
+# Prime state once per interactive shell session.
 _codex_maybe_auto_sync

--- a/shell-common/tools/integrations/codex.sh
+++ b/shell-common/tools/integrations/codex.sh
@@ -33,48 +33,127 @@ alias codex-status='codex_status'   # Check Codex status
 # Codex Skills Sync
 # ═══════════════════════════════════════════════════════════════
 
-codex_skills_sync() {
+_codex_skills_sync_script() {
+    echo "${DOTFILES_ROOT:-$HOME/dotfiles}/scripts/setup-skills-ssot.sh"
+}
+
+_codex_skills_state_file() {
+    echo "$HOME/.codex/.skills-sync-state"
+}
+
+_codex_skills_fingerprint() {
     local src="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills"
-    local dst="$HOME/.codex/skills"
-    local added=0
-    local removed=0
-    local name link
+    local skill_dir entry entry_name
 
-    ux_header "Codex Skills Sync"
+    [ -d "$src" ] || return 1
 
-    if [ ! -d "$dst" ]; then
-        ux_warning "Target directory not found: $dst"
+    # zsh: prevent nomatch errors for patterns like "$skill_dir".*
+    if [ -n "$ZSH_VERSION" ]; then
+        setopt local_options nonomatch
+    fi
+
+    (
+        for skill_dir in "$src"/*/; do
+            [ -d "$skill_dir" ] || continue
+            echo "skill:$(basename "$skill_dir")"
+            for entry in "$skill_dir"* "$skill_dir".*; do
+                [ -e "$entry" ] || continue
+                entry_name=$(basename "$entry")
+                if [ "$entry_name" = "." ] || [ "$entry_name" = ".." ]; then
+                    continue
+                fi
+                echo "entry:$(basename "$skill_dir")/$entry_name"
+            done
+        done
+    ) | LC_ALL=C sort | cksum | awk '{print $1 ":" $2}'
+}
+
+_codex_skills_write_state() {
+    local fingerprint="$1"
+    local state_file
+    state_file="$(_codex_skills_state_file)"
+    mkdir -p "$(dirname "$state_file")" >/dev/null 2>&1 || true
+    printf "%s\n" "$fingerprint" > "$state_file"
+}
+
+_codex_skills_read_state() {
+    local state_file
+    state_file="$(_codex_skills_state_file)"
+    [ -f "$state_file" ] || return 1
+    head -n 1 "$state_file"
+}
+
+_codex_skills_run_sync_script() {
+    local quiet="${1:-0}"
+    local sync_script
+    sync_script="$(_codex_skills_sync_script)"
+
+    if [ ! -f "$sync_script" ]; then
+        [ "$quiet" -eq 1 ] || ux_error "Sync script not found: $sync_script"
         return 1
     fi
 
-    # Remove broken symlinks
-    while read -r link; do
-        if [ -L "$link" ] && [ ! -e "$link" ]; then
-            name=$(basename "$link")
-            if rm -f "$link"; then
-                ux_warning "Removed: $name"
-                removed=$((removed + 1))
-            else
-                ux_error "Failed to remove: $name"
-            fi
-        fi
-    done <<EOF
-$(find "$dst" -maxdepth 1 -type l)
-EOF
+    if [ "$quiet" -eq 1 ]; then
+        bash "$sync_script" >/dev/null 2>&1
+    else
+        bash "$sync_script"
+    fi
+}
 
-    # Add missing symlinks for each skill directory
-    for dir in "$src"/*/; do
-        name=$(basename "$dir")
-        if [ ! -e "$dst/$name" ]; then
-            ln -s "$dir" "$dst/$name"
-            ux_success "Added: $name"
-            added=$((added + 1))
-        fi
-    done
+codex_skills_sync_if_needed() {
+    local quiet="${1:-0}"
+    local force="${2:-0}"
+    local current_fingerprint previous_fingerprint
 
-    echo ""
-    ux_table_row "Added"   "$added"   ""
-    ux_table_row "Removed" "$removed" ""
+    current_fingerprint="$(_codex_skills_fingerprint 2>/dev/null)" || return 0
+    previous_fingerprint="$(_codex_skills_read_state 2>/dev/null || true)"
+
+    if [ "$force" -eq 0 ] && [ "$current_fingerprint" = "$previous_fingerprint" ]; then
+        return 0
+    fi
+
+    if [ "$quiet" -eq 0 ]; then
+        ux_info "Skill changes detected. Syncing codex skills..."
+    fi
+
+    if _codex_skills_run_sync_script "$quiet"; then
+        _codex_skills_write_state "$current_fingerprint"
+        [ "$quiet" -eq 1 ] || ux_success "Codex skills sync completed"
+        return 0
+    fi
+
+    [ "$quiet" -eq 1 ] || ux_error "Codex skills sync failed"
+    return 1
+}
+
+codex_skills_sync() {
+    ux_header "Codex Skills Sync"
+    codex_skills_sync_if_needed 0 1
+}
+
+_codex_auto_sync_enabled() {
+    [ "${CODEX_SKILLS_AUTO_SYNC:-1}" != "0" ]
+}
+
+_codex_auto_sync_quiet() {
+    [ "${CODEX_SKILLS_AUTO_SYNC_VERBOSE:-0}" != "1" ]
+}
+
+_codex_maybe_auto_sync() {
+    if ! _codex_auto_sync_enabled; then
+        return 0
+    fi
+
+    if _codex_auto_sync_quiet; then
+        codex_skills_sync_if_needed 1 0
+    else
+        codex_skills_sync_if_needed 0 0
+    fi
+}
+
+codex() {
+    _codex_maybe_auto_sync
+    command codex "$@"
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -116,3 +195,6 @@ codex_status() {
         echo "  (No codex packages found)"
     fi
 }
+
+# Prime skills state once per interactive shell session.
+_codex_maybe_auto_sync

--- a/shell-common/tools/integrations/codex.sh
+++ b/shell-common/tools/integrations/codex.sh
@@ -21,7 +21,6 @@
 # Essential Command Aliases
 # ═══════════════════════════════════════════════════════════════
 
-alias codex-help='codex --help'     # Show help
 alias codex-version='codex --version' # Show version
 alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'
 alias codex-skills-sync='codex_skills_sync' # Sync skills symlinks

--- a/shell-common/tools/integrations/codex.sh
+++ b/shell-common/tools/integrations/codex.sh
@@ -140,7 +140,15 @@ _codex_auto_sync_quiet() {
 }
 
 _codex_maybe_auto_sync() {
+    local prev_in_progress
+    prev_in_progress="${CODEX_AUTO_SYNC_IN_PROGRESS:-0}"
+    if [ "$prev_in_progress" = "1" ]; then
+        return 0
+    fi
+    CODEX_AUTO_SYNC_IN_PROGRESS=1
+
     if ! _codex_auto_sync_enabled; then
+        CODEX_AUTO_SYNC_IN_PROGRESS="$prev_in_progress"
         return 0
     fi
 
@@ -149,11 +157,66 @@ _codex_maybe_auto_sync() {
     else
         codex_skills_sync_if_needed 0 0
     fi
+
+    CODEX_AUTO_SYNC_IN_PROGRESS="$prev_in_progress"
 }
 
-codex() {
+_codex_should_sync_for_command() {
+    case "$1" in
+        codex|codex\ *)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+_codex_zsh_preexec_auto_sync() {
+    _codex_should_sync_for_command "$1" || return 0
     _codex_maybe_auto_sync
-    command codex "$@"
+}
+
+_codex_register_zsh_hook() {
+    [ -n "$ZSH_VERSION" ] || return 0
+    case "$-" in
+        *i*) ;;
+        *) return 0 ;;
+    esac
+
+    autoload -Uz add-zsh-hook 2>/dev/null || return 0
+    add-zsh-hook preexec _codex_zsh_preexec_auto_sync
+}
+
+_codex_bash_debug_auto_sync() {
+    _codex_should_sync_for_command "${BASH_COMMAND:-}" || return 0
+    _codex_maybe_auto_sync
+}
+
+_codex_register_bash_hook() {
+    [ -n "$BASH_VERSION" ] || return 0
+    case "$-" in
+        *i*) ;;
+        *) return 0 ;;
+    esac
+    [ "${CODEX_BASH_HOOK_REGISTERED:-0}" = "1" ] && return 0
+
+    local existing_debug_trap
+    existing_debug_trap="$(trap -p DEBUG)"
+    case "$existing_debug_trap" in
+        *"_codex_bash_debug_auto_sync"*)
+            CODEX_BASH_HOOK_REGISTERED=1
+            return 0
+            ;;
+    esac
+
+    if [ -n "$existing_debug_trap" ]; then
+        ux_warning "DEBUG trap already configured; skipping codex auto-sync hook (bash)"
+        return 0
+    fi
+
+    trap '_codex_bash_debug_auto_sync' DEBUG
+    CODEX_BASH_HOOK_REGISTERED=1
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -196,5 +259,7 @@ codex_status() {
     fi
 }
 
-# Prime skills state once per interactive shell session.
+# Register hooks and prime state once per interactive shell session.
+_codex_register_zsh_hook
+_codex_register_bash_hook
 _codex_maybe_auto_sync


### PR DESCRIPTION
## Summary
- fix Codex skill visibility by switching Codex sync to real skill directories with per-entry symlinks (`SKILL.md`, `references/`, `scripts/`)
- add stale-skill prune logic for Codex while preserving `.system` and user-managed data
- add automatic Codex skills sync on shell command execution using interactive shell hooks
- normalize help UX so `codex-help` shows dotfiles custom help, while official help uses `codex help|--help|-h`

## Changes
- `scripts/setup-skills-ssot.sh`
  - Codex-specific migration and sync behavior
  - stale-skill cleanup safety logic
- `shell-common/tools/integrations/codex.sh`
  - fingerprint/state-based auto-sync
  - interactive shell hook registration (zsh preexec / bash DEBUG)
- `shell-common/functions/codex_help.sh`
  - help text updates and alias normalization (`codex-help`)
- `shell-common/tools/custom/install_codex.sh`
  - post-install guidance updated to `codex-help`

## Validation
- `bash -n` syntax checks on modified shell scripts
- full `./setup.sh` flow run (mode 3) confirming:
  - opencode/gemini behavior unchanged
  - codex `SKILL.md` detection works
- interactive verification:
  - `type codex` resolves to binary (not function)
  - add/remove temp skill triggers auto-sync behavior
  - `codex help`, `codex --help`, `codex -h` still show official CLI help

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
