### PR TITLE
docs(batch): clarify scope and soften PR wording

### DIFF
--- a/claude/built-in-skills/batch/PROMPT.md
+++ b/claude/built-in-skills/batch/PROMPT.md
@@ -99,7 +99,7 @@ After you finish implementing the change:
 ```javascript
 {
   name: "batch",
-  description: "Research and plan a large-scale change, then execute it in parallel across 5–30 isolated worktree agents that each open a PR.",
+  description: "Research and plan a large-scale change, then execute it in parallel across 5–30 isolated worktree agents that each attempt to open a PR.",
   whenToUse: "Use when the user wants to make a sweeping, mechanical change across many files (migrations, refactors, bulk renames) that can be decomposed into independent parallel units.",
   argumentHint: "<instruction>",
   userInvocable: true,

--- a/claude/built-in-skills/batch/README.md
+++ b/claude/built-in-skills/batch/README.md
@@ -111,7 +111,7 @@ background agent 완료 알림이 도착하면:
 | 1 | Simplify | `/simplify` skill을 호출하여 변경사항 리뷰 및 정리 |
 | 2 | Unit Test | 프로젝트 테스트 스위트 실행 (`npm test`, `pytest`, `go test` 등). 실패 시 수정 |
 | 3 | E2E Test | coordinator가 제공한 e2e 레시피 실행. skip 지시가 있으면 건너뜀 |
-| 4 | Commit & Push | 명확한 메시지로 commit, push, `gh pr create`로 PR 생성 |
+| 4 | Commit & Push | 명확한 메시지로 commit, push, `gh pr create`로 PR 생성 시도 |
 | 5 | Report | 마지막 줄에 `PR: <url>` 출력. PR 미생성 시 `PR: none — <reason>` |
 
 ## 전제 조건

--- a/claude/built-in-skills/batch/README.md
+++ b/claude/built-in-skills/batch/README.md
@@ -1,6 +1,8 @@
 # /batch - 대규모 병렬 코드 변경 오케스트레이터
 
-Claude Code 내장(built-in) 스킬. 플러그인/마켓플레이스가 아닌 Claude Code 바이너리에 포함되어 있어 파일시스템에 별도의 `SKILL.md`가 존재하지 않는다. 대규모 기계적 변경(마이그레이션, 리팩터링, 일괄 rename 등)을 5~30개의 독립된 worktree agent로 분해하여 병렬 실행하고, 각각 PR을 생성한다.
+**Claude Code 전용** 내장(built-in) 스킬. 플러그인/마켓플레이스가 아닌 Claude Code 바이너리에 포함되어 있어 파일시스템에 별도의 `SKILL.md`가 존재하지 않는다. `EnterPlanMode`, `ExitPlanMode`, `AskUserQuestion`, `Agent` 등 Claude Code 런타임 도구에 의존하므로 Codex 등 다른 코딩 에이전트에서는 동작하지 않는다.
+
+대규모 기계적 변경(마이그레이션, 리팩터링, 일괄 rename 등)을 5~30개의 독립된 worktree agent로 분해하여 병렬 실행하고, 각각 PR 생성을 시도한다.
 
 ## 동작 요약
 


### PR DESCRIPTION
## Summary
- `/batch` 스킬 문서 서두에 **Claude Code 전용** 명시 및 런타임 도구 의존성(`EnterPlanMode`, `ExitPlanMode`, `AskUserQuestion`, `Agent`) 나열 — Codex 등 다른 에이전트 사용자의 혼동 방지
- "각각 PR을 생성한다" → "각각 PR 생성을 시도한다"로 완화하여 `gh` CLI 미설치/실패 시 `PR: none` 보고와의 모순 해소

## Test plan
- [x] `claude/built-in-skills/batch/README.md` 렌더링 확인 (마크다운 볼드·코드 블록 정상)
- [x] 문서 내 PR 생성 관련 표현이 line 3, 113, 120에서 일관적인지 교차 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
