### PR TITLE
chore(git): add gl alias and ruff format cleanup

### DIFF
--- a/claude/skills/excalidraw-diagram/references/render_excalidraw.py
+++ b/claude/skills/excalidraw-diagram/references/render_excalidraw.py
@@ -82,7 +82,10 @@ def render(
         from playwright.sync_api import sync_playwright
     except ImportError:
         print("ERROR: playwright not installed.", file=sys.stderr)
-        print("Run: cd .claude/skills/excalidraw-diagram/references && uv sync && uv run playwright install chromium", file=sys.stderr)
+        print(
+            "Run: cd .claude/skills/excalidraw-diagram/references && uv sync && uv run playwright install chromium",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # Read and validate
@@ -95,7 +98,7 @@ def render(
 
     errors = validate_excalidraw(data)
     if errors:
-        print(f"ERROR: Invalid Excalidraw file:", file=sys.stderr)
+        print("ERROR: Invalid Excalidraw file:", file=sys.stderr)
         for err in errors:
             print(f"  - {err}", file=sys.stderr)
         sys.exit(1)
@@ -132,7 +135,10 @@ def render(
         except Exception as e:
             if "Executable doesn't exist" in str(e) or "browserType.launch" in str(e):
                 print("ERROR: Chromium not installed for Playwright.", file=sys.stderr)
-                print("Run: cd .claude/skills/excalidraw-diagram/references && uv run playwright install chromium", file=sys.stderr)
+                print(
+                    "Run: cd .claude/skills/excalidraw-diagram/references && uv run playwright install chromium",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
             raise
 
@@ -176,7 +182,9 @@ def render(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Render Excalidraw JSON to PNG")
     parser.add_argument("input", type=Path, help="Path to .excalidraw JSON file")
-    parser.add_argument("--output", "-o", type=Path, default=None, help="Output PNG path (default: same name with .png)")
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None, help="Output PNG path (default: same name with .png)"
+    )
     parser.add_argument("--scale", "-s", type=int, default=2, help="Device scale factor (default: 2)")
     parser.add_argument("--width", "-w", type=int, default=1920, help="Max viewport width (default: 1920)")
     args = parser.parse_args()

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -225,6 +225,7 @@ git_worktree_add() {
 # Aliases
 # ============================================================================
 alias git-log='git_log'
+alias gl='git-log'
 alias git-log-upstream='git_log_upstream'
 alias git-prune-remote='git_prune_remote'
 alias git-clean-local='git_clean_local'


### PR DESCRIPTION
## Summary
- add `gl` alias mapped to `git-log` in `shell-common/functions/git.sh`
- include separate Ruff auto-format cleanup in `claude/skills/excalidraw-diagram/references/render_excalidraw.py`

## Commits
- `0bbac0a` chore(git): add gl alias for git-log
- `8f668a6` style(excalidraw): apply ruff auto-format

## Notes
- no functional behavior change in the Ruff-formatted file

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~2 min
<!-- /ai-metrics -->
