### PR TITLE
feat(skill): add ai-worktree:spawn skill

### DIFF
--- a/claude/skills/ai-worktree-spawn/SKILL.md
+++ b/claude/skills/ai-worktree-spawn/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ai-worktree:spawn
+description: >-
+  Create an isolated git worktree workspace for the current AI coding agent.
+  Use when starting new parallel work in a multi-AI agent environment. Triggers
+  on: "새로운 작업 시작", "새 작업 시작하자", "격리된 작업 공간 만들어줘",
+  "start new task", "spawn a worktree", or any request to begin isolated work
+  in a multi-agent setup.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# AI Worktree Spawn
+
+Create an isolated git worktree so this AI agent can work without interfering
+with other agents running in the same repository.
+
+Read `references/options-and-errors.md` for CLI options and error handling.
+
+## Execution Steps
+
+Run these steps in order. Stop immediately on any error.
+Read `references/bash-commands.md` for exact bash implementations per step.
+
+### Step 1: Validate Preconditions
+
+Verify: git repo, NOT inside a worktree (block if so), warn on dirty state,
+check parent directory write permission.
+
+### Step 2: Detect AI Agent
+
+Read `references/agent-detection.md` for the full priority chain and env var table.
+Priority: `--agent` arg > `$AI_AGENT_NAME` > agent-specific env vars > `agent`.
+
+### Step 3: Compute Project Name and Index
+
+Extract project name via `basename $(git rev-parse --show-toplevel)`.
+Scan parent directory for `{project}-{agent}-N` pattern, assign max(N)+1.
+
+### Step 4: Determine Branch Name
+
+| Input | Branch Name |
+|---|---|
+| No arguments | `wt/{agent}/{N}` |
+| `--task "slug"` | `wt/{agent}/{N}-{slug}` |
+| Explicit branch name | Use as-is |
+
+If `--task` is given in Korean, translate to English slug first (lowercase,
+hyphens, max 30 chars). Example: "로그인 기능" -> `login-feature`.
+
+### Step 5: Determine Base Ref
+
+Priority: `--base` arg > `origin/main` > `main`/`master` > current HEAD.
+
+### Step 6: Create Worktree
+
+If branch exists: `git worktree add <path> <branch>` (no `-b`).
+If new branch: `git worktree add -b <branch> <path> <base_ref>`.
+
+### Step 7: Log the Creation
+
+Append structured log to `$(git rev-parse --git-common-dir)/ai-worktree-spawn.log`.
+
+### Step 8: Report and Move
+
+Print result, then `cd` into the new worktree:
+
+```
+[OK] Worktree ready
+  Path:   ../my-app-claude-1
+  Branch: wt/claude/1
+  Base:   origin/main
+
+  Teardown after work is done:
+    git push -u origin wt/claude/1
+    git worktree remove ../my-app-claude-1
+    git branch -d wt/claude/1
+```
+
+The script cannot change the caller's cwd. Print the `cd` command as guidance,
+then execute it yourself as the AI agent.

--- a/claude/skills/ai-worktree-spawn/references/agent-detection.md
+++ b/claude/skills/ai-worktree-spawn/references/agent-detection.md
@@ -1,0 +1,24 @@
+# Agent Detection -- priority chain and environment variables
+
+## Detection Priority
+
+Determine `agent_name` using this order (first match wins):
+
+1. `--agent <name>` argument (if user provided)
+2. `$AI_AGENT_NAME` environment variable
+3. Agent-specific env vars (see table below)
+4. Fallback: `agent`
+
+## Per-Agent Environment Variables
+
+| AI Agent | Detection Method | Result Name |
+|---|---|---|
+| Claude Code | `$CLAUDECODE == 1` | `claude` |
+| Gemini CLI | `$GEMINI_CLI == 1` or process name `gemini` | `gemini` |
+| Codex CLI | `$CODEX_CLI == 1` or process name `codex` | `codex` |
+| OpenCode | `$OPENCODE == 1` or `~/.opencode/` exists | `opencode` |
+| Cursor | `$CURSOR == 1` or `$TERM_PROGRAM == cursor` | `cursor` |
+| Copilot | `$GITHUB_COPILOT == 1` | `copilot` |
+
+Environment variable names may change across tool versions. The detection logic
+is isolated in `detect_ai_agent()` for easy extension.

--- a/claude/skills/ai-worktree-spawn/references/bash-commands.md
+++ b/claude/skills/ai-worktree-spawn/references/bash-commands.md
@@ -1,0 +1,66 @@
+# Bash Commands -- implementation details for each execution step
+
+## Step 1: Validate Preconditions
+
+```bash
+# Must be inside a git repo
+git rev-parse --show-toplevel
+
+# Must NOT be inside an existing worktree -- block if so
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+GIT_DIR="$(git rev-parse --git-dir)"
+if [[ "$GIT_DIR" != "$GIT_COMMON" ]]; then
+  echo "Error: Cannot spawn from inside a worktree. Run from the main repository."
+  exit 1
+fi
+
+# Warn on dirty state (do not block)
+git diff --quiet || echo "Warning: uncommitted changes in working directory"
+
+# Check parent directory is writable
+PARENT="$(dirname "$(git rev-parse --show-toplevel)")"
+test -w "$PARENT" || { echo "Error: Permission denied: $PARENT"; exit 1; }
+```
+
+## Step 3: Compute Project Name and Index
+
+```bash
+PROJECT="$(basename "$(git rev-parse --show-toplevel)")"
+AGENT="<detected-agent>"
+PARENT="$(dirname "$(git rev-parse --show-toplevel)")"
+
+# Find next available index
+# Scan parent directory for {PROJECT}-{AGENT}-N pattern
+NEXT_INDEX=1
+for dir in "${PARENT}/${PROJECT}-${AGENT}"-*/; do
+  if [[ -d "$dir" ]]; then
+    N="${dir##*-}"
+    N="${N%/}"
+    if [[ "$N" =~ ^[0-9]+$ ]] && (( N >= NEXT_INDEX )); then
+      NEXT_INDEX=$((N + 1))
+    fi
+  fi
+done
+
+WORKTREE_PATH="${PARENT}/${PROJECT}-${AGENT}-${NEXT_INDEX}"
+```
+
+## Step 6: Create Worktree
+
+```bash
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    # Existing branch -- no -b flag
+    git worktree add "${WORKTREE_PATH}" "${BRANCH}"
+else
+    # New branch -- create with -b
+    git worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
+fi
+```
+
+## Step 7: Log the Creation
+
+```bash
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+echo "[$(date -Iseconds)] SPAWN project=${PROJECT} agent=${AGENT} index=${NEXT_INDEX} path=${WORKTREE_PATH} branch=${BRANCH} base=${BASE_REF}" \
+  >> "${GIT_COMMON}/ai-worktree-spawn.log"
+```

--- a/claude/skills/ai-worktree-spawn/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-spawn/references/options-and-errors.md
@@ -1,0 +1,28 @@
+# Options and Error Handling -- CLI reference
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--agent <name>` | Override agent name | auto-detect |
+| `--task "slug"` | Add task slug to branch name (English only) | none |
+| `--base <ref>` | Base branch/commit | `origin/main` |
+| `--dry-run` | Print plan without creating anything | `false` |
+
+When `--dry-run` is specified, print the full plan (agent, path, branch, base,
+command) and stop without creating anything.
+
+`--list` is NOT included here. Use the separate `ai-worktree:list` skill instead.
+
+## Error Handling
+
+| Situation | Action |
+|---|---|
+| Not a git repo | Print error, stop |
+| Inside a worktree | Print error, stop (always use a new terminal on the main repo) |
+| Base ref not found | Suggest `main`/`origin/main`, stop |
+| Path already exists | Auto-increment to next index |
+| Branch in use by another worktree | Print error, ask user for different name |
+| Parent dir not writable | Print error, stop |
+| Lock acquisition failed (3 retries) | Print error, stop |
+| Stale lock (age > 10s) | Auto-remove lock, retry |


### PR DESCRIPTION
## Summary
- Add `ai-worktree:spawn` skill for multi-AI agent parallel development using git worktree isolation
- Auto-detects AI agent (Claude, Gemini, Codex, OpenCode) via env vars with 4-tier priority chain
- Creates isolated worktree at `../{project}-{agent}-{N}` with namespaced branch `wt/{agent}/{N}`
- Progressive Disclosure structure: SKILL.md (80 lines) + 3 reference files (118 lines)

## Files
- `claude/skills/ai-worktree-spawn/SKILL.md` — skill prompt with 8-step execution flow
- `references/bash-commands.md` — bash implementations per step
- `references/agent-detection.md` — agent detection priority chain and env var table
- `references/options-and-errors.md` — CLI options (`--agent`, `--task`, `--base`, `--dry-run`) and error handling

## Design document
- `docs/feature/skill-git-worktree-create/design-C.md` (already on main)
- Reviewed by Codex (design-CX) and Gemini (design-G), all feedback incorporated

## Test plan
- [ ] Run `/ai-worktree:spawn` in Claude Code terminal — verify worktree created at correct path
- [ ] Run `/ai-worktree:spawn --dry-run` — verify plan output without creation
- [ ] Run from inside a worktree — verify immediate error and block
- [ ] Run twice — verify index auto-increments (claude-1, claude-2)
- [ ] Verify `ai-worktree-spawn.log` is written to `$(git rev-parse --git-common-dir)/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
