### PR TITLE
fix(ai-worktree): add git-crypt detection and bypass

### DIFF
--- a/claude/skills/ai-worktree-spawn/SKILL.md
+++ b/claude/skills/ai-worktree-spawn/SKILL.md
@@ -53,6 +53,10 @@ Priority: `--base` arg > `origin/main` > `main`/`master` > current HEAD.
 
 ### Step 6: Create Worktree
 
+Detect git-crypt first. If the repo uses git-crypt, pass `-c filter.git-crypt.smudge=cat
+-c filter.git-crypt.clean=cat` to `git worktree add` to prevent smudge filter failure.
+After creation, set worktree-local config to disable git-crypt filters permanently.
+
 If branch exists: `git worktree add <path> <branch>` (no `-b`).
 If new branch: `git worktree add -b <branch> <path> <base_ref>`.
 
@@ -69,12 +73,15 @@ Print result, then `cd` into the new worktree:
   Path:   ../my-app-claude-1
   Branch: wt/claude/1
   Base:   origin/main
+  git-crypt: disabled (encrypted files not decrypted)
 
   Teardown after work is done:
     git push -u origin wt/claude/1
     git worktree remove ../my-app-claude-1
     git branch -d wt/claude/1
 ```
+
+The `git-crypt` line only appears when the repo uses git-crypt.
 
 The script cannot change the caller's cwd. Print the `cd` command as guidance,
 then execute it yourself as the AI agent.

--- a/claude/skills/ai-worktree-spawn/references/bash-commands.md
+++ b/claude/skills/ai-worktree-spawn/references/bash-commands.md
@@ -53,6 +53,22 @@ detect_ai_agent() {
 AGENT="$(detect_ai_agent "${AGENT_OVERRIDE:-}")"
 ```
 
+## Step 1.5: Detect git-crypt
+
+```bash
+# Check if repo uses git-crypt by looking for .gitattributes filter entries
+GIT_CRYPT_ACTIVE=false
+if git config --get filter.git-crypt.smudge >/dev/null 2>&1; then
+  GIT_CRYPT_ACTIVE=true
+fi
+
+# Build git-crypt bypass flags for worktree creation
+GIT_CRYPT_FLAGS=()
+if [[ "$GIT_CRYPT_ACTIVE" == true ]]; then
+  GIT_CRYPT_FLAGS=(-c filter.git-crypt.smudge=cat -c filter.git-crypt.clean=cat)
+fi
+```
+
 ## Step 3: Compute Project Name and Index
 
 ```bash
@@ -177,12 +193,24 @@ BASE_REF="$(resolve_base_ref "${BASE_OVERRIDE:-}")"
 ## Step 6: Create Worktree
 
 ```bash
+# Use GIT_CRYPT_FLAGS from Step 1.5 (empty array if no git-crypt)
 if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
     # Existing branch -- no -b flag
-    git worktree add "${WORKTREE_PATH}" "${BRANCH}"
+    git "${GIT_CRYPT_FLAGS[@]}" worktree add "${WORKTREE_PATH}" "${BRANCH}"
 else
     # New branch -- create with -b
-    git worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
+    git "${GIT_CRYPT_FLAGS[@]}" worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
+fi
+
+# If git-crypt is active, disable filters in the new worktree permanently.
+# Encrypted files (.env, .secrets) stay as binary -- this is intentional.
+# The worktree is for code work; secrets are not needed.
+if [[ "$GIT_CRYPT_ACTIVE" == true ]]; then
+    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge cat
+    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
+    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
+    # Re-checkout so worktree-local config takes effect cleanly
+    git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null
 fi
 ```
 

--- a/claude/skills/ai-worktree-spawn/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-spawn/references/options-and-errors.md
@@ -26,3 +26,4 @@ command) and stop without creating anything.
 | Parent dir not writable | Print error, stop |
 | Lock acquisition failed (3 retries) | Print error, stop |
 | Stale lock (age > 10s) | Auto-remove lock, retry |
+| git-crypt active in repo | Auto-bypass: create worktree with filter disabled, encrypted files stay as binary |


### PR DESCRIPTION
## Summary
- ai-worktree:spawn 스킬에서 git-crypt 사용 repo의 worktree 생성 실패 문제 해결
- Step 1.5(git-crypt 감지) 추가, Step 6에서 smudge filter 우회 후 worktree-local config 설정
- 암호화 파일(.env, .secrets)은 binary 상태로 유지, 메인 repo 설정 영향 없음

## Test plan
- [ ] git-crypt이 활성화된 repo에서 `/ai-worktree-spawn` 실행 → 정상 생성 확인
- [ ] git-crypt이 없는 repo에서 `/ai-worktree-spawn` 실행 → 기존 동작 유지 확인
- [ ] 생성된 worktree에서 `git status`, `git diff` 등 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
