### PR TITLE
feat(skill): add ai-worktree:teardown skill

### DIFF
--- a/claude/skills/ai-worktree-teardown/SKILL.md
+++ b/claude/skills/ai-worktree-teardown/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ai-worktree:teardown
+description: >-
+  Clean up an AI worktree after work is done — remove worktree, delete branch,
+  sync main. The reverse of ai-worktree:spawn. Use when the user says "작업 끝",
+  "워크트리 정리", "teardown", "cleanup worktree", "작업 완료", "워크트리 제거",
+  or any request to clean up after finishing work in a worktree.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# AI Worktree Teardown
+
+Remove an AI worktree and sync main after work is complete.
+This is the reverse of `ai-worktree:spawn`.
+
+Read `references/options-and-errors.md` for CLI options and error handling.
+
+## Execution Steps
+
+Run these steps in order. Stop immediately on any error.
+Read `references/bash-commands.md` for exact bash implementations per step.
+
+### Step 1: Validate — Must Be Inside a Worktree
+
+Check `git-dir != git-common-dir`. If NOT inside a worktree, print error and stop.
+This is the inverse of spawn's check.
+
+### Step 2: Pre-flight Checks
+
+Block on uncommitted changes or unpushed commits to prevent work loss.
+Skip these checks if `--force` is given.
+
+### Step 3: Identify Main Repo and Worktree Info
+
+Extract from current worktree:
+- `WORKTREE_PATH` — current toplevel
+- `MAIN_REPO` — derived from git-common-dir
+- `BRANCH` — current branch name
+- `WORKTREE_NAME` — basename of worktree path
+
+### Step 4: Switch to Main Repo
+
+`cd` into the main repo directory. All subsequent commands run from there.
+
+### Step 5: Remove Worktree
+
+`git worktree remove <path>`. On failure, try `--force` if user opted in.
+
+### Step 6: Delete Branch
+
+`git branch -d <branch>` (safe delete — verifies merge status).
+Skip if `--keep-branch` is given. Warn if branch is not fully merged.
+
+### Step 7: Sync Main
+
+`git checkout main && git pull origin main`.
+If pull conflicts, the AI agent attempts to resolve them and reports.
+
+### Step 8: Log
+
+Append `TEARDOWN` entry to `ai-worktree-spawn.log` (same file as spawn).
+
+### Step 9: Report
+
+```
+[OK] Teardown complete
+  Removed:  ../my-app-gemini-1
+  Branch:   wt/gemini/1 (deleted)
+  Now on:   main (up to date with origin/main)
+```

--- a/claude/skills/ai-worktree-teardown/references/bash-commands.md
+++ b/claude/skills/ai-worktree-teardown/references/bash-commands.md
@@ -1,0 +1,162 @@
+# Bash Commands — implementation details for each execution step
+
+## Step 1: Validate — Must Be Inside a Worktree
+
+```bash
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+GIT_DIR="$(git rev-parse --git-dir)"
+
+if [[ "$GIT_DIR" == "$GIT_COMMON" ]]; then
+  echo "Error: Not inside a worktree. Nothing to tear down."
+  echo "  Run this from inside an AI worktree (e.g., ../my-app-claude-1)"
+  exit 1
+fi
+```
+
+## Step 2: Pre-flight Checks
+
+```bash
+preflight_check() {
+  local force="${1:-false}"
+
+  # Uncommitted changes (staged or unstaged)
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    if [[ "$force" == true ]]; then
+      echo "Warning: Discarding uncommitted changes (--force)"
+    else
+      echo "Error: Uncommitted changes detected."
+      echo "  Commit, stash, or use --force to discard."
+      exit 1
+    fi
+  fi
+
+  # Unpushed commits
+  local local_rev remote_rev
+  local_rev="$(git rev-parse HEAD)"
+  remote_rev="$(git rev-parse @{u} 2>/dev/null || echo "no-upstream")"
+
+  if [[ "$remote_rev" != "no-upstream" && "$local_rev" != "$remote_rev" ]]; then
+    if [[ "$force" == true ]]; then
+      echo "Warning: Discarding unpushed commits (--force)"
+    else
+      echo "Error: Unpushed commits detected."
+      echo "  Push first, or use --force to discard."
+      exit 1
+    fi
+  fi
+}
+
+preflight_check "${FORCE:-false}"
+```
+
+## Step 3: Identify Main Repo and Worktree Info
+
+```bash
+WORKTREE_PATH="$(git rev-parse --show-toplevel)"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+WORKTREE_NAME="$(basename "$WORKTREE_PATH")"
+
+# Derive main repo path from git-common-dir
+# git-common-dir returns something like /path/to/main-repo/.git
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+MAIN_REPO="$(dirname "$GIT_COMMON")"
+
+# Verify main repo exists
+if [[ ! -d "$MAIN_REPO/.git" && ! -f "$MAIN_REPO/.git" ]]; then
+  echo "Error: Cannot find main repo at $MAIN_REPO"
+  exit 1
+fi
+```
+
+## Step 4: Switch to Main Repo
+
+```bash
+cd "$MAIN_REPO" || { echo "Error: Cannot cd to $MAIN_REPO"; exit 1; }
+echo "Switched to main repo: $MAIN_REPO"
+```
+
+## Step 5: Remove Worktree
+
+```bash
+if ! git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
+  if [[ "${FORCE:-false}" == true ]]; then
+    echo "Warning: Force-removing worktree"
+    git worktree remove --force "$WORKTREE_PATH"
+  else
+    echo "Error: Cannot remove worktree. It may have uncommitted changes."
+    echo "  Use --force to override."
+    exit 1
+  fi
+fi
+git worktree prune
+echo "Worktree removed: $WORKTREE_PATH"
+```
+
+## Step 6: Delete Branch
+
+```bash
+delete_branch() {
+  local branch="$1"
+  local keep="${KEEP_BRANCH:-false}"
+
+  if [[ "$keep" == true ]]; then
+    echo "Branch kept: $branch (--keep-branch)"
+    return
+  fi
+
+  if git branch -d "$branch" 2>/dev/null; then
+    echo "Branch deleted: $branch"
+  else
+    if [[ "${FORCE:-false}" == true ]]; then
+      git branch -D "$branch"
+      echo "Branch force-deleted: $branch (was not fully merged)"
+    else
+      echo "Warning: Branch '$branch' not fully merged into main."
+      echo "  Use --force to delete anyway, or --keep-branch to keep it."
+    fi
+  fi
+}
+
+delete_branch "$BRANCH"
+```
+
+## Step 7: Sync Main
+
+```bash
+# Resolve main branch name
+resolve_main_branch() {
+  if git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
+    echo "main"
+  elif git rev-parse --verify --quiet "master" >/dev/null 2>&1; then
+    echo "master"
+  else
+    echo "Error: Neither 'main' nor 'master' branch found." >&2
+    exit 1
+  fi
+}
+
+MAIN_BRANCH="$(resolve_main_branch)"
+git checkout "$MAIN_BRANCH"
+
+# Pull with conflict detection
+if ! git pull origin "$MAIN_BRANCH"; then
+  echo "Conflict detected during pull."
+  echo "Attempting to resolve..."
+  # List conflicting files
+  git diff --name-only --diff-filter=U
+  # AI agent should analyze and resolve conflicts here
+  # If resolved:
+  #   git add <resolved-files>
+  #   git commit -m "chore: resolve merge conflicts after teardown"
+  # If unresolvable:
+  #   echo "Error: Cannot auto-resolve conflicts. Manual intervention needed."
+fi
+```
+
+## Step 8: Log
+
+```bash
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+echo "[$(date +%Y-%m-%dT%H:%M:%S%z)] TEARDOWN worktree=${WORKTREE_NAME} branch=${BRANCH} path=${WORKTREE_PATH}" \
+  >> "${GIT_COMMON}/ai-worktree-spawn.log"
+```

--- a/claude/skills/ai-worktree-teardown/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-teardown/references/options-and-errors.md
@@ -1,0 +1,25 @@
+# Options and Error Handling — CLI reference
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--force` | Skip pre-flight checks, force remove dirty worktree, force delete unmerged branch | `false` |
+| `--keep-branch` | Don't delete the branch after removing worktree | `false` |
+| `--dry-run` | Print plan without executing anything | `false` |
+
+When `--dry-run` is specified, print the full plan (worktree path, branch,
+main repo path, actions to take) and stop without executing anything.
+
+## Error Handling
+
+| Situation | Action |
+|---|---|
+| Not inside a worktree | Print error, stop |
+| Uncommitted changes | Warn, stop (unless `--force`) |
+| Unpushed commits | Warn, stop (unless `--force`) |
+| Worktree remove fails | Try `--force` if opted in, else stop |
+| Branch not fully merged | Warn, skip branch delete (unless `--force`) |
+| Main branch not found | Try `master`, then error |
+| Pull conflict | AI agent attempts resolution, reports to user |
+| Main repo path invalid | Print error, stop |

--- a/docs/feature/skill-ai-worktree-teardown/design-G.md
+++ b/docs/feature/skill-ai-worktree-teardown/design-G.md
@@ -1,0 +1,211 @@
+# ai-worktree:teardown — Design Document
+
+## Overview
+
+AI 워크트리 작업 완료 후 정리 스킬.
+`ai-worktree:spawn`의 역연산으로, 워크트리 제거 → main 복귀 → remote 동기화를 한 번에 수행한다.
+
+## Trigger Phrases
+
+- "작업 끝", "워크트리 정리", "teardown", "cleanup worktree"
+- "작업 완료됐어", "워크트리 제거해줘", "clean up and go back to main"
+
+## Preconditions
+
+사용자는 이미 다음을 완료한 상태:
+
+1. 워크트리에서 코드 작업 완료
+2. PR 생성 및 push 완료
+3. main에 merge 완료 (사용자가 직접 승인)
+
+## Execution Flow
+
+```
+[워크트리 내부에서 실행]
+    │
+    ├─ Step 1: Validate — 워크트리 내부인지 확인
+    │
+    ├─ Step 2: Pre-flight checks — uncommitted changes, unpushed commits
+    │
+    ├─ Step 3: Identify main repo — git-common-dir로 메인 repo 경로 추출
+    │
+    ├─ Step 4: Switch to main repo — cd {main-repo-path}
+    │
+    ├─ Step 5: Remove worktree — git worktree remove {path}
+    │
+    ├─ Step 6: Delete branch — git branch -d {branch} (safe delete)
+    │
+    ├─ Step 7: Sync main — git checkout main && git pull origin main
+    │
+    ├─ Step 8: Handle conflicts — (if any) resolve and report
+    │
+    ├─ Step 9: Log — append TEARDOWN entry to ai-worktree-spawn.log
+    │
+    └─ Step 10: Report
+```
+
+## Step Details
+
+### Step 1: Validate
+
+현재 위치가 worktree 내부인지 확인.
+
+```bash
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+GIT_DIR="$(git rev-parse --git-dir)"
+
+# 워크트리 내부: GIT_DIR != GIT_COMMON
+if [[ "$GIT_DIR" == "$GIT_COMMON" ]]; then
+  echo "Error: Not inside a worktree. Nothing to tear down."
+  exit 1
+fi
+```
+
+> **spawn과 반대**: spawn은 "워크트리 안이면 차단", teardown은 "워크트리 밖이면 차단".
+
+### Step 2: Pre-flight Checks
+
+uncommitted changes와 unpushed commits를 확인하여 작업 손실을 방지.
+
+```bash
+# Uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Warning: Uncommitted changes detected."
+  echo "  Options: commit, stash, or --force to discard"
+  # --force 없으면 중단
+fi
+
+# Unpushed commits
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse @{u} 2>/dev/null || echo "no-upstream")
+if [[ "$REMOTE" != "no-upstream" && "$LOCAL" != "$REMOTE" ]]; then
+  echo "Warning: Unpushed commits detected."
+  # --force 없으면 중단
+fi
+```
+
+### Step 3: Identify Main Repo and Worktree Info
+
+```bash
+WORKTREE_PATH="$(git rev-parse --show-toplevel)"
+MAIN_REPO="$(git rev-parse --git-common-dir | sed 's|/\.git$||')"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+WORKTREE_NAME="$(basename "$WORKTREE_PATH")"
+```
+
+### Step 4: Switch to Main Repo
+
+```bash
+cd "$MAIN_REPO"
+```
+
+### Step 5: Remove Worktree
+
+```bash
+git worktree remove "$WORKTREE_PATH"
+# 실패 시 (dirty worktree + --force)
+# git worktree remove --force "$WORKTREE_PATH"
+```
+
+### Step 6: Delete Branch
+
+safe delete로 merge 확인 후 삭제. merge되지 않았으면 경고.
+
+```bash
+if ! git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Warning: Branch '$BRANCH' not fully merged."
+  echo "  Use --force to delete anyway, or check merge status."
+  # --force 시: git branch -D "$BRANCH"
+fi
+```
+
+### Step 7: Sync Main
+
+```bash
+git checkout main
+git pull origin main
+```
+
+### Step 8: Handle Conflicts
+
+pull 중 conflict 발생 시:
+
+```bash
+if git pull origin main 2>&1 | grep -q "CONFLICT"; then
+  echo "Conflicts detected during pull. Resolving..."
+  # AI agent가 conflict 파일을 분석하고 해결 시도
+  # 해결 불가 시 사용자에게 보고
+fi
+```
+
+### Step 9: Log
+
+spawn 로그와 같은 파일에 TEARDOWN 이벤트 기록.
+
+```bash
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+echo "[$(date +%Y-%m-%dT%H:%M:%S%z)] TEARDOWN worktree=${WORKTREE_NAME} branch=${BRANCH} path=${WORKTREE_PATH}" \
+  >> "${GIT_COMMON}/ai-worktree-spawn.log"
+```
+
+### Step 10: Report
+
+```
+[OK] Teardown complete
+  Removed:  ../my-app-gemini-1
+  Branch:   wt/gemini/1 (deleted)
+  Now on:   main (up to date with origin/main)
+```
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--force` | Skip pre-flight checks, force remove dirty worktree | `false` |
+| `--keep-branch` | Don't delete the branch after removing worktree | `false` |
+| `--dry-run` | Print plan without executing | `false` |
+
+## Error Handling
+
+| Situation | Action |
+|---|---|
+| Not inside a worktree | Print error, stop |
+| Uncommitted changes | Warn, stop (unless `--force`) |
+| Unpushed commits | Warn, stop (unless `--force`) |
+| Branch not fully merged | Warn, stop branch delete (unless `--force`) |
+| Worktree remove fails | Try `--force`, report if still fails |
+| Pull conflict | AI agent attempts resolution, reports to user |
+| Main branch not found | Try `master`, then error |
+
+## Relationship with ai-worktree:spawn
+
+```
+spawn                          teardown
+─────                          ────────
+Validate (NOT in worktree)  ↔  Validate (IN worktree)
+Detect agent                   (not needed)
+Compute path + index           Extract path from current location
+Create worktree + branch       Remove worktree + branch
+Log SPAWN                      Log TEARDOWN
+cd into worktree               cd into main repo
+```
+
+spawn의 `ai-worktree-spawn.log`를 공유하여 생애주기 추적 가능.
+
+## File Structure (예상)
+
+```
+ai-worktree-teardown/
+├── SKILL.md
+└── references/
+    ├── bash-commands.md
+    └── options-and-errors.md
+```
+
+`agent-detection.md`는 불필요 (teardown은 agent 이름을 감지할 필요 없음 —
+현재 워크트리의 branch/path에서 정보를 추출).
+
+## git-crypt Consideration
+
+teardown에서는 git-crypt 문제 없음. worktree를 제거하고 main repo로 돌아가는
+과정에서 filter가 개입하지 않음. main repo는 이미 unlock 상태.


### PR DESCRIPTION
## Summary
- `ai-worktree:spawn`의 역연산 스킬 — 워크트리 제거 → 브랜치 삭제 → main 동기화
- Pre-flight safety: uncommitted changes / unpushed commits 차단 (`--force`로 우회)
- `ai-worktree-spawn.log`에 TEARDOWN 이벤트 기록으로 생애주기 추적
- Progressive Disclosure 5/5 PASS (SKILL.md 70줄)

## Test plan
- [ ] 워크트리 내부에서 `/ai-worktree-teardown` 실행 → 정상 정리 확인
- [ ] 메인 repo에서 실행 → "Not inside a worktree" 에러 확인
- [ ] uncommitted changes 상태에서 실행 → 차단 확인
- [ ] `--force` 옵션으로 dirty worktree 강제 제거 확인
- [ ] teardown 후 `ai-worktree-spawn.log`에 TEARDOWN 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
