### PR TITLE
refactor: apply progressive disclosure to ux-guidelines skill

### DIFF
--- a/claude/skills/ux-guidelines/SKILL.md
+++ b/claude/skills/ux-guidelines/SKILL.md
@@ -9,356 +9,57 @@ allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 
 # UX Guidelines Skill
 
-## Role
+## Help
 
-You are the UX Consistency Specialist. Ensure all help functions and user-facing shell commands follow the dotfiles UX guidelines. Refactor hardcoded text output to use semantic UX library functions, maintain consistent color schemes, and improve readability.
+If the argument is `help`, read `references/help.md` and output it verbatim, then stop.
 
-## Trigger Scenarios
+## Objective
 
-### Individual Function Refactoring
+Enforce `shell-common/tools/ux_lib/UX_GUIDELINES.md` for user-facing shell output.
+Keep implementations semantic (`ux_*`), readable, and cross-shell compatible.
 
-Use this skill when refactoring specific help functions or creating new ones:
+Read `references/ux-foundation.md` for principles, color semantics, and UX function
+selection rules.
 
-- "proxy_help() 함수를 UX 가이드라인에 따라 리팩토링해"
-- "새 help 함수를 만드는데 UX_GUIDELINES 규칙을 따르고 싶어"
-- "현재 help 텍스트를 ux_lib 함수들로 다시 작성해"
-- "이 함수를 cc_help 스타일로 리팩토링해"
-- "help 함수들의 formatting을 일관되게 해줘"
+## Mode Selection
 
-### Bulk UX Compliance Review (Check shell-common/ against UX_GUIDELINES.md)
+Choose one mode before editing:
 
-Use this skill to scan all shell-common/*.sh files for UX guideline violations and document findings:
+1. **Individual function refactoring**: a specific function/module is requested.
+2. **Bulk compliance review**: user asks to scan `shell-common/**/*.sh` and write
+   findings to `docs/abc-review-*.md`.
 
-- "ux-guidelines 스킬을 사용하여 docs/abc-review-CX.md 문서에 작성해"
-  (Check shell-common/*.sh files, identify violations, write to abc-review-CX.md for ChatGPT review)
+## Mode A: Individual Function Refactoring
 
-- "ux-guidelines 스킬을 사용하여 docs/abc-review-C.md 문서에 작성해"
-  (Check shell-common/*.sh files, identify violations, write to abc-review-C.md for Claude review)
+Read `references/refactoring-playbook.md` when executing this mode.
 
-- "ux-guidelines 스킬을 사용하여 docs/abc-review-G.md 문서에 작성해"
-  (Check shell-common/*.sh files, identify violations, write to abc-review-G.md for Gemini review)
+1. Read the target module and locate hardcoded output patterns.
+2. Build a section map: header, grouped commands, procedures, warnings, tips.
+3. Ensure `ux_lib` is loaded with the approved conditional pattern.
+4. Replace hardcoded output (`cat <<EOF`, ANSI codes, raw status strings) with
+   semantic UX functions.
+5. Keep command behavior unchanged; refactor presentation only unless user asked
+   for behavior changes.
+6. Validate in both bash and zsh; run targeted help function checks.
+7. Report changes with file paths, key replacements, and validation results.
 
-## UX Guidelines Foundation
+## Mode B: Bulk UX Compliance Review
 
-The UX guidelines are defined in: `shell-common/tools/ux_lib/UX_GUIDELINES.md`
+Read `references/bulk-review-workflow.md` when executing this mode.
 
-### Core Principles
+1. Discover `shell-common/**/*.sh` files in scope.
+2. Analyze each file for UX guideline violations and exclusions.
+3. Categorize findings by severity (`high`, `medium`, `low`).
+4. Write the report to the requested file (`docs/abc-review-C.md`,
+   `docs/abc-review-CX.md`, or `docs/abc-review-G.md`).
+5. Include concrete file/line evidence and suggested fixes.
+6. Do not commit unless explicitly requested.
 
-1. **Consistency**: All functions use the same color scheme and formatting
-2. **Discoverability**: Help text is always available with no arguments; `my-help` lists all topics
-3. **Safety**: Destructive operations require explicit confirmation
-4. **Feedback**: Clear success/error/warning messages with progress indicators
-5. **Readability**: Well-structured output with semantic colors
+## Output Requirements
 
-### Color Semantics
+Always include:
 
-| Color | Usage | Function |
-|-------|-------|----------|
-| **Primary (Blue)** | Headers, section titles, command names | `ux_header()`, `ux_section()` |
-| **Success (Green)** | Successful operations, valid states | `ux_success()` |
-| **Warning (Yellow)** | Warnings, confirmations, risky actions | `ux_warning()` |
-| **Error (Red)** | Errors, failed operations, critical issues | `ux_error()` |
-| **Info (Cyan)** | Information, tips, guidance | `ux_info()` |
-| **Muted (Gray)** | Secondary info, hints, dividers | `ux_divider()` |
-
-## Available UX Functions
-
-```bash
-ux_header "Title"              # Styled header with border box
-ux_section "Title"             # Section header with underline
-ux_success "Message"           # Green success message
-ux_error "Message"             # Red error message
-ux_warning "Message"           # Yellow warning message
-ux_info "Message"              # Cyan info message
-ux_bullet "Text"               # Bullet point with • prefix
-ux_numbered "N" "Text"         # Numbered list item
-ux_divider                     # Thin horizontal line
-ux_divider_thick               # Thick horizontal line
-ux_confirm "Question"          # Interactive yes/no prompt
-ux_input "Prompt"              # Interactive text input
-ux_menu "Item1" "Item2" ...    # Interactive menu selection
-ux_table_row "Col1" "Col2"...  # Formatted table row
-ux_table_header "Col1" ...     # Table header row
-```
-
-## Refactoring Pattern
-
-### Step 1: Identify Current Implementation
-
-Check if the function uses:
-- Hardcoded `cat <<EOF ... EOF` output
-- Hardcoded ANSI color codes
-- Plain text formatting with emojis
-- Inconsistent spacing/alignment
-
-### Step 2: Load UX Library
-
-Add conditional loading at module startup:
-
-```bash
-# Load UX library if not already loaded
-if ! declare -f ux_header >/dev/null 2>&1; then
-    source "${BASH_SOURCE[0]%/*}/../tools/ux_lib/ux_lib.sh" 2>/dev/null || true
-fi
-```
-
-### Step 3: Replace Output with UX Functions
-
-**Before:**
-```bash
-proxy_help() {
-    cat <<-'EOF'
-
-[Proxy(Corporate) Commands & Diagnostics]
-
-🔍 DIAGNOSTIC COMMANDS
-  check-proxy          # Run full diagnostic
-  check-proxy env      # Environment variables only
-EOF
-}
-```
-
-**After:**
-```bash
-proxy_help() {
-    ux_header "Proxy(Corporate) Commands & Diagnostics"
-
-    ux_section "Diagnostic Commands"
-    ux_bullet "check-proxy          Run full diagnostic"
-    ux_bullet "check-proxy env      Environment variables only"
-    echo ""
-}
-```
-
-### Step 4: Organize Content Logically
-
-Use UX sections to group related commands:
-
-- `ux_header()` - Main title
-- `ux_section()` - Each logical grouping
-- `ux_bullet()` - Command lists
-- `ux_numbered()` - Step-by-step instructions
-- `ux_warning()` / `ux_info()` - Important notes
-- `echo ""` - Visual separators between sections
-
-### Step 5: Test Output
-
-```bash
-bash -c "source ./shell-common/env/proxy.sh && proxy_help"
-```
-
-Verify:
-- Colors display correctly
-- Alignment is consistent
-- All information is visible
-- Sections are clearly separated
-
-## Reference Example
-
-See: `shell-common/functions/cc_help.sh`
-
-```bash
-cc_help() {
-    ux_header "Claude Code Usage Commands"
-
-    ux_section "Installation"
-    ux_bullet "Global prefix: npm install -g ccusage --prefix=\$HOME/.npm-global"
-    echo ""
-
-    ux_section "Quick Commands (Aliases)"
-    ux_table_row "ccd" "ccusage daily --breakdown" "Token usage by model"
-    ux_table_row "ccs" "ccusage session --sort tokens" "Session analysis"
-    echo ""
-}
-
-alias cc-help='cc_help'
-```
-
-## Decision Framework
-
-### Use `ux_bullet()` For:
-- Command lists
-- Quick reference items
-- Short descriptions
-
-### Use `ux_numbered()` For:
-- Step-by-step instructions
-- Recipes that must be followed in order
-- Conditional procedures
-
-### Use `ux_table_row()` For:
-- Command-to-description mappings
-- Structured data with multiple columns
-- Command aliases and their meanings
-
-### Use `ux_section()` For:
-- Logical groupings of related commands
-- Different use cases or modes
-- Separating concerns (Setup, Configuration, Troubleshooting, etc)
-
-### Use `ux_warning()` / `ux_info()` For:
-- Important caveats
-- Reference links
-- Notes and tips
-- Best practices
-
-## Workflow
-
-When refactoring a help function:
-
-1. **Read** the current help function implementation
-2. **Identify** sections and logical groupings
-3. **Create** a plan of which UX functions to use
-4. **Edit** to replace hardcoded output with UX functions
-5. **Test** the output to verify formatting
-6. **Commit** with clear message about UX improvements
-
-## Example Commit Message
-
-```
-refactor: Reformat proxy_help() to follow UX guidelines
-
-Refactor proxy_help() function to use UX library functions (ux_header,
-ux_section, ux_bullet, ux_numbered, ux_warning, ux_info) instead of
-hardcoded text with cat <<EOF.
-
-Changes:
-- Load ux_lib.sh conditionally at module startup
-- Replace hardcoded text output with semantic UX function calls
-- Reorganize help content into logical sections
-- Use ux_bullet() for command lists
-- Use ux_numbered() for step-by-step recipes
-- Use ux_warning() and ux_info() for notes
-
-Benefits:
-- Consistent with UX_GUIDELINES.md standards
-- Automatic color and formatting consistency
-- Better readability and structure
-- Easier to maintain
-```
-
-## Best Practices
-
-1. **Never hardcode colors** - Use `UX_PRIMARY`, `UX_SUCCESS`, etc via UX functions
-2. **Use semantic functions** - Prefer `ux_success()` over `echo "${UX_SUCCESS}..."`
-3. **Provide clear feedback** - Inform user about operation state
-4. **Keep it clean** - Remove commented-out `tput` definitions after migration
-5. **Test across shells** - Verify in both bash and zsh
-6. **Document choices** - Explain why sections are organized certain way
-
-## Files to Know
-
-```
-shell-common/tools/ux_lib/ux_lib.sh         # UX function library
-shell-common/tools/ux_lib/UX_GUIDELINES.md  # Full guidelines
-shell-common/functions/cc_help.sh            # Reference pattern
-shell-common/tools/custom/demo_ux.sh        # Interactive demo
-shell-common/tools/custom/check_ux_consistency.sh  # Validation tool
-```
-
-## Validation
-
-Run consistency checker to ensure all help functions follow guidelines:
-
-```bash
-shell-common/tools/custom/check_ux_consistency.sh
-```
-
-## Bulk UX Compliance Review Workflow
-
-For scanning all shell-common/*.sh files against UX_GUIDELINES.md and documenting findings:
-
-### Overview
-
-This workflow allows you to:
-1. Scan all shell-common/ files for UX guideline violations
-2. Document findings in review files (`abc-review-C.md`, `abc-review-CX.md`, `abc-review-G.md`)
-3. Share violations with team members for collaborative review
-4. Track compliance issues before deciding on fixes
-
-### Review Documents
-
-Review documents follow this structure:
-
-- **abc-review-C.md** — Claude review (AI-generated analysis)
-- **abc-review-CX.md** — ChatGPT review (cross-AI validation)
-- **abc-review-G.md** — Gemini review (alternative perspective)
-
-See: `docs/AGENTS.md` for review document format specification.
-
-### Typical Violations to Document
-
-When scanning shell-common/, check for:
-
-1. **Hardcoded Colors** — Using ANSI codes instead of `UX_*` variables
-   - Problem: `echo -e "${COLOR_RED}Error${COLOR_RESET}"`
-   - Should be: `ux_error "Error"`
-
-2. **Hardcoded Output** — Using `cat <<EOF` instead of UX functions
-   - Problem: `cat <<EOF\n  Command A\n  Command B\nEOF`
-   - Should be: `ux_bullet "Command A"` + `ux_bullet "Command B"`
-
-3. **Missing Help** — Functions without help output
-   - Problem: Function has no `[ -z "$1" ]` check
-   - Should be: Show help when called with no args
-
-4. **Inconsistent Formatting** — Mixed styles (emojis, markdown, raw text)
-   - Problem: Some functions use emojis, others don't
-   - Should be: All use consistent UX semantic functions
-
-5. **Non-semantic Output** — Using plain echo without UX context
-   - Problem: `echo "Done"`
-   - Should be: `ux_success "Done"`
-
-### When NOT to Include Violations
-
-- Executable utility scripts (tools/custom/*.sh) that don't have user-facing output
-- Third-party wrappers that only delegate to external tools
-- Auto-generated files or templates
-
-### Review Process
-
-1. **Initial Scan** — Use ux-guidelines skill to create initial review document
-2. **Team Review** — Share with colleagues for feedback
-3. **Prioritize** — Identify high vs medium vs low priority fixes
-4. **Implement** — Fix violations as agreed upon
-5. **Validate** — Run check_ux_consistency.sh to verify
-
-## Execution
-
-### For Individual Function Refactoring
-
-When refactoring a specific help function:
-
-1. Read the current help function/module
-2. Identify sections and organize logically
-3. Plan which UX functions to use
-4. Conditionally load ux_lib.sh if needed
-5. Replace hardcoded output with UX function calls
-6. Test the refactored output
-7. Create commit documenting the changes
-
-**Start by reading the target file and understanding its current structure.**
-
-### For Bulk UX Compliance Review
-
-When scanning shell-common/ and creating review documents:
-
-1. **Discover** all shell-common/*.sh files (glob: `shell-common/**/*.sh`)
-2. **Analyze** each file against UX_GUIDELINES.md:
-   - Check for hardcoded colors (ANSI escape sequences)
-   - Check for hardcoded text output (cat <<EOF patterns)
-   - Check for missing help functionality
-   - Check for inconsistent formatting/styling
-   - Check for non-semantic output functions
-3. **Categorize** findings by severity:
-   - **High**: Breaks UX guidelines completely (e.g., hardcoded colors)
-   - **Medium**: Partially follows guidelines (e.g., inconsistent style)
-   - **Low**: Minor issues (e.g., missing comments)
-4. **Document** in target review file (abc-review-C.md, abc-review-CX.md, or abc-review-G.md):
-   - Reviewer name and date
-   - List of violations with file paths and line numbers
-   - Suggested fixes for each violation
-   - Overall compliance score
-5. **Format** as Markdown following docs/AGENTS.md review document structure
-6. **Output** the completed review document (do NOT commit; user will review with colleagues)
+1. Mode used (`individual` or `bulk`).
+2. Files inspected and files changed.
+3. Validation commands run and outcomes.
+4. Remaining risks or follow-up items, if any.

--- a/claude/skills/ux-guidelines/references/bulk-review-workflow.md
+++ b/claude/skills/ux-guidelines/references/bulk-review-workflow.md
@@ -1,0 +1,57 @@
+# Bulk Review Workflow — shell-common UX Compliance Audit
+
+Use this when asked to scan `shell-common/**/*.sh` and write findings to
+`docs/abc-review-C.md`, `docs/abc-review-CX.md`, or `docs/abc-review-G.md`.
+
+## Review Output Targets
+
+- `abc-review-C.md`: Claude review.
+- `abc-review-CX.md`: ChatGPT review.
+- `abc-review-G.md`: Gemini review.
+
+Follow the repository review format from `docs/AGENTS.md`.
+
+## Violations to Detect
+
+1. **Hardcoded colors**
+   - Example: `echo -e "${COLOR_RED}Error${COLOR_RESET}"`
+   - Expected: `ux_error "Error"`
+2. **Hardcoded help output blocks**
+   - Example: `cat <<EOF ... EOF`
+   - Expected: structured `ux_section` + `ux_bullet`/`ux_numbered`
+3. **Missing help discoverability**
+   - No clear help behavior for no-argument execution
+4. **Inconsistent presentation**
+   - Mixed styles, uneven grouping, non-semantic status messaging
+5. **Non-semantic messages**
+   - Plain `echo "Done"` where intent-specific UX functions are required
+
+## Exclusions
+
+Do not report these as UX violations unless user-facing output is explicit:
+
+- Utility scripts with no interactive user output.
+- Thin wrappers that only delegate to external tools.
+- Auto-generated files/templates.
+
+## Severity Model
+
+- `high`: directly violates UX foundations (hardcoded colors/format blocks).
+- `medium`: partial compliance, inconsistent structure.
+- `low`: minor readability or formatting issues.
+
+## Procedure
+
+1. Discover files in scope (`shell-common/**/*.sh`).
+2. Scan each file for violations and capture file/line evidence.
+3. Categorize by severity.
+4. Add concrete remediation guidance per finding.
+5. Produce final review Markdown at requested path.
+
+## Recommended Report Sections
+
+1. Reviewer and date
+2. Scope and file count
+3. Findings by severity
+4. Suggested fixes
+5. Overall compliance summary

--- a/claude/skills/ux-guidelines/references/help.md
+++ b/claude/skills/ux-guidelines/references/help.md
@@ -1,0 +1,38 @@
+# UX Guidelines Skill Help — Usage and Triggers
+
+Use this skill when you need consistent UX output for shell help text and
+user-facing commands in the dotfiles repository.
+
+## Typical Requests
+
+- `proxy_help() 함수를 UX 가이드라인에 맞게 리팩터링해`
+- `help 텍스트를 ux_lib 함수들로 바꿔줘`
+- `cc_help 스타일로 이 함수 정리해줘`
+- `shell-common 전체를 UX_GUIDELINES 기준으로 점검해서 docs/abc-review-C.md에 작성해줘`
+- `docs/abc-review-CX.md로 UX 위반 사항 정리해줘`
+
+## Modes
+
+1. **Individual function refactoring**
+   - Target: one function or module.
+   - Goal: replace hardcoded formatting with semantic `ux_*` calls.
+2. **Bulk compliance review**
+   - Target: `shell-common/**/*.sh`.
+   - Goal: produce a review document with violations, severity, and fixes.
+
+## Inputs to Confirm
+
+- Target file(s) or function name(s).
+- Requested output path for review documents (for bulk mode).
+- Whether behavior changes are allowed (default: no; presentation-only refactor).
+
+## Deliverables
+
+1. Updated shell code or a review Markdown document.
+2. Summary with files inspected/changed.
+3. Validation commands and outcomes.
+
+For detailed workflow and rules, read:
+- `references/ux-foundation.md`
+- `references/refactoring-playbook.md`
+- `references/bulk-review-workflow.md`

--- a/claude/skills/ux-guidelines/references/refactoring-playbook.md
+++ b/claude/skills/ux-guidelines/references/refactoring-playbook.md
@@ -1,0 +1,85 @@
+# Refactoring Playbook — Individual Function Migration
+
+Use this when refactoring a specific help function or user-facing command output.
+
+## Step 1: Identify Current Output Patterns
+
+Flag these patterns:
+
+- `cat <<EOF` blocks for help text.
+- Hardcoded ANSI colors.
+- Mixed style markers and inconsistent spacing.
+- Plain success/error text where semantic UX functions should be used.
+
+## Step 2: Load UX Library Safely
+
+Prefer approved path handling and conditional loading:
+
+```bash
+if ! declare -f ux_header >/dev/null 2>&1; then
+    source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
+fi
+```
+
+If the module already has standardized loading, keep that pattern.
+
+## Step 3: Convert to Semantic UX Calls
+
+Before:
+
+```bash
+proxy_help() {
+    cat <<-'EOF'
+[Proxy Commands]
+check-proxy      # Run diagnostic
+check-proxy env  # Environment only
+EOF
+}
+```
+
+After:
+
+```bash
+proxy_help() {
+    ux_header "Proxy Commands"
+    ux_section "Diagnostics"
+    ux_bullet "check-proxy      Run diagnostic"
+    ux_bullet "check-proxy env  Environment only"
+    echo ""
+}
+```
+
+## Step 4: Organize Information
+
+Use this ordering:
+
+1. Header
+2. Section groupings
+3. Command references or recipes
+4. Warnings and notes
+5. Optional divider/spacing for readability
+
+## Step 5: Validate Output
+
+Run targeted checks:
+
+```bash
+bash -c "source ./<target-file>.sh && <help_function>"
+zsh -c "source ./<target-file>.sh && <help_function>"
+```
+
+For wider checks:
+
+```bash
+shell-common/tools/custom/check_ux_consistency.sh
+```
+
+## Suggested Commit Message Template
+
+```text
+refactor: align <function_name> output with UX guidelines
+
+- replace hardcoded help text with ux_* functions
+- standardize section structure and message semantics
+- keep command behavior unchanged
+```

--- a/claude/skills/ux-guidelines/references/ux-foundation.md
+++ b/claude/skills/ux-guidelines/references/ux-foundation.md
@@ -1,0 +1,56 @@
+# UX Foundation — Principles, Colors, and Semantic Functions
+
+Source of truth: `shell-common/tools/ux_lib/UX_GUIDELINES.md`
+
+## Core Principles
+
+1. **Consistency**: same visual semantics across commands and modules.
+2. **Discoverability**: help is available without hidden entry points.
+3. **Safety**: risky operations require explicit warnings/confirmation.
+4. **Feedback**: user gets clear success, warning, and error states.
+5. **Readability**: output is grouped and scannable.
+
+## Color Semantics
+
+| Intent | Meaning | Preferred Function |
+|---|---|---|
+| Primary | Header and section framing | `ux_header`, `ux_section` |
+| Success | Completed and valid states | `ux_success` |
+| Warning | Caution, confirmation points | `ux_warning` |
+| Error | Failures and blocking issues | `ux_error` |
+| Info | Guidance and non-critical notes | `ux_info` |
+| Muted | Dividers and secondary context | `ux_divider` |
+
+## UX Function Catalog
+
+```bash
+ux_header "Title"
+ux_section "Title"
+ux_success "Message"
+ux_error "Message"
+ux_warning "Message"
+ux_info "Message"
+ux_bullet "Text"
+ux_numbered "1" "Text"
+ux_divider
+ux_divider_thick
+ux_confirm "Question"
+ux_input "Prompt"
+ux_menu "Item1" "Item2"
+ux_table_header "Col1" "Col2" "Col3"
+ux_table_row "Val1" "Val2" "Val3"
+```
+
+## Function Selection Rules
+
+- Use `ux_bullet` for short command references.
+- Use `ux_numbered` for ordered procedures.
+- Use `ux_table_*` when there are stable columns.
+- Use `ux_warning` and `ux_info` for caveats and tips.
+- Use plain `echo ""` only as visual spacing between logical groups.
+
+## Guardrails
+
+- Do not hardcode ANSI escape sequences.
+- Do not mix ad-hoc styles with semantic UX primitives.
+- Do not add emojis in shell help output.


### PR DESCRIPTION
## Summary
- Refactor `claude/skills/ux-guidelines/SKILL.md` into a progressive-disclosure control tower
- Reduce SKILL body from 364 lines to 65 lines (under the 100-line requirement)
- Extract detailed guidance into focused references under `claude/skills/ux-guidelines/references/`

## Changes
- Rewrote SKILL workflow around two execution modes:
  - individual function refactoring
  - bulk compliance review
- Added `references/help.md` for usage and trigger guidance
- Added `references/ux-foundation.md` for principles, color semantics, and function rules
- Added `references/refactoring-playbook.md` for step-by-step individual refactoring
- Added `references/bulk-review-workflow.md` for shell-common audit workflow

## Validation
- Verified `SKILL.md` line count is 65 (`<= 100`)
- Verified all reference files are explicitly linked from `SKILL.md`
- Frontmatter kept intact

## Notes
- Documentation-only change; no runtime code behavior changes

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
