### PR TITLE
fix(skill): reorder teardown steps and add worktree aliases

### DIFF
--- a/claude/skills/ai-worktree-teardown/SKILL.md
+++ b/claude/skills/ai-worktree-teardown/SKILL.md
@@ -46,15 +46,16 @@ Extract from current worktree:
 
 `git worktree remove <path>`. On failure, try `--force` if user opted in.
 
-### Step 6: Delete Branch
+### Step 6: Sync Main
+
+`git checkout main && git pull origin main`.
+Must run BEFORE branch delete so `git branch -d` can verify merge status.
+If pull conflicts, the AI agent attempts to resolve them and reports.
+
+### Step 7: Delete Branch
 
 `git branch -d <branch>` (safe delete — verifies merge status).
 Skip if `--keep-branch` is given. Warn if branch is not fully merged.
-
-### Step 7: Sync Main
-
-`git checkout main && git pull origin main`.
-If pull conflicts, the AI agent attempts to resolve them and reports.
 
 ### Step 8: Log
 

--- a/claude/skills/ai-worktree-teardown/references/bash-commands.md
+++ b/claude/skills/ai-worktree-teardown/references/bash-commands.md
@@ -92,35 +92,9 @@ git worktree prune
 echo "Worktree removed: $WORKTREE_PATH"
 ```
 
-## Step 6: Delete Branch
+## Step 6: Sync Main
 
-```bash
-delete_branch() {
-  local branch="$1"
-  local keep="${KEEP_BRANCH:-false}"
-
-  if [[ "$keep" == true ]]; then
-    echo "Branch kept: $branch (--keep-branch)"
-    return
-  fi
-
-  if git branch -d "$branch" 2>/dev/null; then
-    echo "Branch deleted: $branch"
-  else
-    if [[ "${FORCE:-false}" == true ]]; then
-      git branch -D "$branch"
-      echo "Branch force-deleted: $branch (was not fully merged)"
-    else
-      echo "Warning: Branch '$branch' not fully merged into main."
-      echo "  Use --force to delete anyway, or --keep-branch to keep it."
-    fi
-  fi
-}
-
-delete_branch "$BRANCH"
-```
-
-## Step 7: Sync Main
+Sync main BEFORE branch delete so `git branch -d` can verify merge status.
 
 ```bash
 # Resolve main branch name
@@ -151,6 +125,36 @@ if ! git pull origin "$MAIN_BRANCH"; then
   # If unresolvable:
   #   echo "Error: Cannot auto-resolve conflicts. Manual intervention needed."
 fi
+```
+
+## Step 7: Delete Branch
+
+Runs after sync so local main contains the merge commit.
+
+```bash
+delete_branch() {
+  local branch="$1"
+  local keep="${KEEP_BRANCH:-false}"
+
+  if [[ "$keep" == true ]]; then
+    echo "Branch kept: $branch (--keep-branch)"
+    return
+  fi
+
+  if git branch -d "$branch" 2>/dev/null; then
+    echo "Branch deleted: $branch"
+  else
+    if [[ "${FORCE:-false}" == true ]]; then
+      git branch -D "$branch"
+      echo "Branch force-deleted: $branch (was not fully merged)"
+    else
+      echo "Warning: Branch '$branch' not fully merged into main."
+      echo "  Use --force to delete anyway, or --keep-branch to keep it."
+    fi
+  fi
+}
+
+delete_branch "$BRANCH"
 ```
 
 ## Step 8: Log

--- a/shell-common/aliases/git.sh
+++ b/shell-common/aliases/git.sh
@@ -81,3 +81,5 @@ alias hook-check='hook_check'                     # Git hook 설정 진단 (hook
 
 # Git worktree
 alias gwt='git_worktree_add'                      # git-crypt safe worktree 생성 (gwt <path> [<branch>])
+alias gwtl='git worktree list'                     # worktree 목록 보기
+alias gwtr='git worktree remove'                   # worktree 제거 (gwtr <path>)


### PR DESCRIPTION
## Summary
- teardown 스킬의 Step 6(branch delete)과 Step 7(sync main) 순서를 교체: `git pull` 후에 `git branch -d`를 실행해야 merge 상태를 정확히 판단
- `gwtl` (git worktree list), `gwtr` (git worktree remove) alias 추가

## Test plan
- [ ] `/ai-worktree-teardown` 실행 시 PR merge 후 브랜치가 정상 삭제되는지 확인
- [ ] `gwtl`, `gwtr` alias 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
