### PR TITLE
feat(git): add gwt-spawn and gwt-teardown shell functions

### DIFF
--- a/shell-common/aliases/git.sh
+++ b/shell-common/aliases/git.sh
@@ -83,3 +83,5 @@ alias hook-check='hook_check'                     # Git hook 설정 진단 (hook
 alias gwt='git_worktree_add'                      # git-crypt safe worktree 생성 (gwt <path> [<branch>])
 alias gwtl='git worktree list'                     # worktree 목록 보기
 alias gwtr='git worktree remove'                   # worktree 제거 (gwtr <path>)
+alias gwt-spawn='git_worktree_spawn'               # AI worktree 자동 생성 (auto-index, auto-branch)
+alias gwt-teardown='git_worktree_teardown'          # AI worktree 정리 (remove + sync + branch delete)

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -223,7 +223,7 @@ git_worktree_add() {
 
 # ============================================================================
 # Worktree spawn — auto-index, auto-branch, log
-# Usage: git_worktree_spawn [--task <slug>] [--base <ref>]
+# Usage: git_worktree_spawn [<agent>] [--task <slug>] [--base <ref>]
 # ============================================================================
 git_worktree_spawn() {
     # zsh compatibility
@@ -231,14 +231,31 @@ git_worktree_spawn() {
         emulate -L sh
     fi
 
-    local task="" base=""
+    local task="" base="" agent=""
 
     # Parse arguments
     while [ $# -gt 0 ]; do
         case "$1" in
+            -h|--help|help)
+                ux_header "gwt-spawn - AI worktree auto-creation"
+                ux_info "Usage: gwt-spawn [<agent>] [--task <slug>] [--base <ref>]"
+                ux_info ""
+                ux_info "Arguments:"
+                ux_info "  <agent>          claude | codex | gemini | opencode | cursor (auto-detect if omitted)"
+                ux_info "  --task <slug>    Add task slug to branch name"
+                ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
+                ux_info ""
+                ux_info "Examples:"
+                ux_info "  gwt-spawn                          # auto-detect agent"
+                ux_info "  gwt-spawn claude                   # ../<project>-claude-1  wt/claude/1"
+                ux_info "  gwt-spawn codex --task login-fix   # ../<project>-codex-1   wt/codex/1-login-fix"
+                return 0
+                ;;
             --task) task="$2"; shift 2 ;;
             --base) base="$2"; shift 2 ;;
-            *) ux_error "Unknown option: $1"; return 1 ;;
+            claude|codex|gemini|opencode|cursor|copilot)
+                agent="$1"; shift ;;
+            *) ux_error "Unknown option: $1. Use --help for usage."; return 1 ;;
         esac
     done
 
@@ -253,12 +270,14 @@ git_worktree_spawn() {
         return 1
     fi
 
-    # Detect agent
-    local agent="agent"
-    if [ "${CLAUDECODE:-}" = "1" ]; then agent="claude"
-    elif [ "${GEMINI_CLI:-}" = "1" ]; then agent="gemini"
-    elif [ "${CODEX_CLI:-}" = "1" ]; then agent="codex"
-    elif [ "${CURSOR:-}" = "1" ] || [ "${TERM_PROGRAM:-}" = "cursor" ]; then agent="cursor"
+    # Detect agent (explicit arg > env vars > fallback)
+    if [ -z "$agent" ]; then
+        if [ "${CLAUDECODE:-}" = "1" ]; then agent="claude"
+        elif [ "${GEMINI_CLI:-}" = "1" ]; then agent="gemini"
+        elif [ "${CODEX_CLI:-}" = "1" ]; then agent="codex"
+        elif [ "${CURSOR:-}" = "1" ] || [ "${TERM_PROGRAM:-}" = "cursor" ]; then agent="cursor"
+        else agent="agent"
+        fi
     fi
 
     # Compute project, parent, next index

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -290,7 +290,7 @@ git_worktree_spawn() {
             local n="${dir##*-}"
             n="${n%/}"
             case "$n" in
-                *[!0-9]*) continue ;;
+                "" | *[!0-9]*) continue ;;
             esac
             if [ "$n" -ge "$next_index" ]; then
                 next_index=$((n + 1))
@@ -417,7 +417,10 @@ git_worktree_teardown() {
     if ! git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
         main_branch="master"
     fi
-    git checkout "$main_branch" 2>/dev/null
+    if ! git checkout "$main_branch" 2>/dev/null; then
+        ux_error "Failed to checkout $main_branch in main repository."
+        return 1
+    fi
     git pull origin "$main_branch" 2>/dev/null || ux_warning "Pull failed (network?). Branch delete may misjudge merge status."
 
     # Delete branch

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -222,6 +222,207 @@ git_worktree_add() {
 }
 
 # ============================================================================
+# Worktree spawn — auto-index, auto-branch, log
+# Usage: git_worktree_spawn [--task <slug>] [--base <ref>]
+# ============================================================================
+git_worktree_spawn() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local task="" base=""
+
+    # Parse arguments
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --task) task="$2"; shift 2 ;;
+            --base) base="$2"; shift 2 ;;
+            *) ux_error "Unknown option: $1"; return 1 ;;
+        esac
+    done
+
+    # Must be inside a git repo, NOT a worktree
+    local git_common git_dir
+    git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        ux_error "Not inside a git repository"; return 1
+    }
+    git_dir="$(git rev-parse --git-dir)"
+    if [ "$git_dir" != "$git_common" ]; then
+        ux_error "Cannot spawn from inside a worktree. Run from the main repo."
+        return 1
+    fi
+
+    # Detect agent
+    local agent="agent"
+    if [ "${CLAUDECODE:-}" = "1" ]; then agent="claude"
+    elif [ "${GEMINI_CLI:-}" = "1" ]; then agent="gemini"
+    elif [ "${CODEX_CLI:-}" = "1" ]; then agent="codex"
+    elif [ "${CURSOR:-}" = "1" ] || [ "${TERM_PROGRAM:-}" = "cursor" ]; then agent="cursor"
+    fi
+
+    # Compute project, parent, next index
+    local project parent next_index=1
+    project="$(basename "$(git rev-parse --show-toplevel)")"
+    parent="$(dirname "$(git rev-parse --show-toplevel)")"
+
+    for dir in "$parent/${project}-${agent}"-*/; do
+        if [ -d "$dir" ]; then
+            local n="${dir##*-}"
+            n="${n%/}"
+            case "$n" in
+                *[!0-9]*) continue ;;
+            esac
+            if [ "$n" -ge "$next_index" ]; then
+                next_index=$((n + 1))
+            fi
+        fi
+    done
+
+    local wt_path="${parent}/${project}-${agent}-${next_index}"
+
+    # Branch name
+    local branch
+    if [ -n "$task" ]; then
+        local slug
+        slug=$(printf '%s' "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-30)
+        branch="wt/${agent}/${next_index}-${slug}"
+    else
+        branch="wt/${agent}/${next_index}"
+    fi
+
+    # Base ref
+    if [ -z "$base" ]; then
+        if git rev-parse --verify --quiet "origin/main" >/dev/null 2>&1; then
+            base="origin/main"
+        elif git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
+            base="main"
+        else
+            base="HEAD"
+        fi
+    fi
+
+    # Create worktree (reuse git_worktree_add for git-crypt safety)
+    git_worktree_add "$wt_path" "$branch" "$base" || return 1
+
+    # Log
+    printf '[%s] SPAWN agent=%s index=%s path=%s branch=%s base=%s\n' \
+        "$(date +%Y-%m-%dT%H:%M:%S%z)" "$agent" "$next_index" "$wt_path" "$branch" "$base" \
+        >> "${git_common}/ai-worktree-spawn.log"
+
+    ux_header "Worktree spawned"
+    ux_info "  Path:   $wt_path"
+    ux_info "  Branch: $branch"
+    ux_info "  Base:   $base"
+    ux_info ""
+    ux_info "  cd $wt_path"
+}
+
+# ============================================================================
+# Worktree teardown — remove worktree, sync main, delete branch, log
+# Usage: git_worktree_teardown [--force] [--keep-branch]
+# ============================================================================
+git_worktree_teardown() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local force=false keep_branch=false
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --force) force=true; shift ;;
+            --keep-branch) keep_branch=true; shift ;;
+            *) ux_error "Unknown option: $1"; return 1 ;;
+        esac
+    done
+
+    # Must be inside a worktree
+    local git_common git_dir
+    git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        ux_error "Not inside a git repository"; return 1
+    }
+    git_dir="$(git rev-parse --git-dir)"
+    if [ "$git_dir" = "$git_common" ]; then
+        ux_error "Not inside a worktree. Nothing to tear down."
+        return 1
+    fi
+
+    # Pre-flight: uncommitted changes
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        if [ "$force" = true ]; then
+            ux_warning "Discarding uncommitted changes (--force)"
+        else
+            ux_error "Uncommitted changes. Commit, stash, or use --force."
+            return 1
+        fi
+    fi
+
+    # Pre-flight: unpushed commits
+    local local_rev remote_rev
+    local_rev="$(git rev-parse HEAD)"
+    remote_rev="$(git rev-parse '@{u}' 2>/dev/null || echo "no-upstream")"
+    if [ "$remote_rev" != "no-upstream" ] && [ "$local_rev" != "$remote_rev" ]; then
+        if [ "$force" = true ]; then
+            ux_warning "Discarding unpushed commits (--force)"
+        else
+            ux_error "Unpushed commits. Push first, or use --force."
+            return 1
+        fi
+    fi
+
+    # Collect info before leaving
+    local wt_path branch wt_name main_repo
+    wt_path="$(git rev-parse --show-toplevel)"
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    wt_name="$(basename "$wt_path")"
+    main_repo="$(dirname "$git_common")"
+
+    # Switch to main repo
+    cd "$main_repo" || { ux_error "Cannot cd to $main_repo"; return 1; }
+
+    # Remove worktree
+    if ! git worktree remove "$wt_path" 2>/dev/null; then
+        if [ "$force" = true ]; then
+            git worktree remove --force "$wt_path" || { ux_error "Failed to remove worktree"; return 1; }
+        else
+            ux_error "Cannot remove worktree. Use --force to override."
+            return 1
+        fi
+    fi
+    git worktree prune
+
+    # Sync main BEFORE branch delete
+    local main_branch="main"
+    if ! git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
+        main_branch="master"
+    fi
+    git checkout "$main_branch" 2>/dev/null
+    git pull origin "$main_branch" 2>/dev/null || ux_warning "Pull failed (network?). Branch delete may misjudge merge status."
+
+    # Delete branch
+    if [ "$keep_branch" = true ]; then
+        ux_info "Branch kept: $branch (--keep-branch)"
+    elif git branch -d "$branch" 2>/dev/null; then
+        : # deleted successfully
+    elif [ "$force" = true ]; then
+        git branch -D "$branch" 2>/dev/null
+    else
+        ux_warning "Branch '$branch' not fully merged. Use --force or --keep-branch."
+    fi
+
+    # Log
+    printf '[%s] TEARDOWN worktree=%s branch=%s path=%s\n' \
+        "$(date +%Y-%m-%dT%H:%M:%S%z)" "$wt_name" "$branch" "$wt_path" \
+        >> "$(git rev-parse --git-common-dir)/ai-worktree-spawn.log"
+
+    ux_success "Teardown complete"
+    ux_info "  Removed: $wt_path"
+    ux_info "  Now on:  $main_branch"
+}
+
+# ============================================================================
 # Aliases
 # ============================================================================
 alias git-log='git_log'


### PR DESCRIPTION
## Summary
- AI 스킬(ai-worktree:spawn/teardown)을 셸 함수로 전환 — AI tool call 왕복 제거로 30초+ → 1초
- `git_worktree_spawn`: agent 자동 감지, index 자동 증가, branch 자동 생성, git-crypt 안전 (기존 `git_worktree_add` 재활용)
- `git_worktree_teardown`: worktree 제거, main sync 후 branch 삭제 (순서 수정 반영), `--force`/`--keep-branch` 지원
- alias: `gwt-spawn`, `gwt-teardown`

## Usage
```bash
# Spawn (from main repo)
gwt-spawn                        # wt/claude/1
gwt-spawn --task login-feature   # wt/claude/1-login-feature
gwt-spawn --base develop         # custom base ref

# Teardown (from inside worktree)
gwt-teardown                     # remove + sync + branch delete
gwt-teardown --keep-branch       # keep branch after removal
gwt-teardown --force             # discard uncommitted changes
```

## Test plan
- [ ] `gwt-spawn` 실행 → worktree 생성, 올바른 index/branch 확인
- [ ] `gwt-spawn --task test-feature` → branch 이름에 slug 포함 확인
- [ ] worktree 내부에서 `gwt-teardown` → 정상 정리 확인
- [ ] `gwt-teardown --keep-branch` → branch 유지 확인
- [ ] bash/zsh 양쪽에서 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
