### PR TITLE
fix(gwt): re-add help guard lost in merge

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -190,10 +190,23 @@ EOF
 # Usage: git_worktree_add <path> [<new-branch> [<start-point>]]
 # ============================================================================
 git_worktree_add() {
-    if [ -z "$1" ]; then
-        ux_error "Usage: git_worktree_add <path> [<new-branch> [<start-point>]]"
-        return 1
-    fi
+    case "${1:-}" in
+        -h|--help|help)
+            ux_info "Usage: gwt <path> [<new-branch> [<start-point>]]"
+            ux_info "  Creates a git-crypt safe worktree (encrypted files excluded)"
+            ux_info ""
+            ux_info "Related commands:"
+            ux_info "  gwtl              list worktrees"
+            ux_info "  gwtr <path>       remove worktree"
+            ux_info "  gwt-spawn [agent] auto-create AI worktree (gwt-spawn --help)"
+            ux_info "  gwt-teardown      auto-remove AI worktree from inside it"
+            return 0
+            ;;
+        "")
+            ux_error "Usage: gwt <path> [<new-branch> [<start-point>]]"
+            return 1
+            ;;
+    esac
 
     local wt_path="$1"
     local branch="$2"

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -192,8 +192,8 @@ EOF
 git_worktree_add() {
     case "${1:-}" in
         -h|--help|help)
+            ux_header "gwt - git-crypt safe worktree"
             ux_info "Usage: gwt <path> [<new-branch> [<start-point>]]"
-            ux_info "  Creates a git-crypt safe worktree (encrypted files excluded)"
             ux_info ""
             ux_info "Related commands:"
             ux_info "  gwtl              list worktrees"


### PR DESCRIPTION
## Summary
- PR #84에서 추가한 `gwt` help guard가 PR #85 merge 시 덮어씌워져 누락됨
- `gwt help` 실행 시 "help"라는 이름의 worktree가 생성되는 문제 재발 방지

## Test plan
- [ ] `gwt help` → usage 출력 확인
- [ ] `gwt --help` → usage 출력 확인
- [ ] `gwt` (인자 없이) → error 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
