### PR TITLE
refactor(gwt): unify worktree commands under gwt dispatcher

### DIFF
--- a/shell-common/aliases/git.sh
+++ b/shell-common/aliases/git.sh
@@ -79,9 +79,5 @@ hook_check() {
 
 alias hook-check='hook_check'                     # Git hook 설정 진단 (hook-check --help로 도움말 보기)
 
-# Git worktree
-alias gwt='git_worktree_add'                      # git-crypt safe worktree 생성 (gwt <path> [<branch>])
-alias gwtl='git worktree list'                     # worktree 목록 보기
-alias gwtr='git worktree remove'                   # worktree 제거 (gwtr <path>)
-alias gwt-spawn='git_worktree_spawn'               # AI worktree 자동 생성 (auto-index, auto-branch)
-alias gwt-teardown='git_worktree_teardown'          # AI worktree 정리 (remove + sync + branch delete)
+# Git worktree (gwt is a function in functions/git.sh)
+# Usage: gwt add|list|remove|spawn|teardown [args...]

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -189,21 +189,47 @@ EOF
 # Creates a worktree without checking out git-crypt encrypted files
 # Usage: git_worktree_add <path> [<new-branch> [<start-point>]]
 # ============================================================================
+# ============================================================================
+# gwt — git worktree dispatcher
+# Usage: gwt <subcommand> [args...]
+# ============================================================================
+gwt() {
+    case "${1:-}" in
+        add)      shift; git_worktree_add "$@" ;;
+        list|ls)  shift; git worktree list "$@" ;;
+        remove|rm) shift; git worktree remove "$@" ;;
+        spawn)    shift; git_worktree_spawn "$@" ;;
+        teardown) shift; git_worktree_teardown "$@" ;;
+        -h|--help|help|"")
+            ux_header "gwt - git worktree manager"
+            ux_info "Usage: gwt <command> [args...]"
+            ux_info ""
+            ux_info "Commands:"
+            ux_info "  add <path> [branch] [start]   create git-crypt safe worktree"
+            ux_info "  list                           list worktrees"
+            ux_info "  remove <path>                  remove worktree"
+            ux_info "  spawn [agent] [--task slug]    auto-create AI worktree"
+            ux_info "  teardown [--force]             auto-remove AI worktree"
+            ux_info ""
+            ux_info "Run 'gwt <command> --help' for command-specific help."
+            return 0
+            ;;
+        *)
+            ux_error "Unknown command: $1. Run 'gwt help' for usage."
+            return 1
+            ;;
+    esac
+}
+
 git_worktree_add() {
     case "${1:-}" in
-        -h|--help|help)
-            ux_header "gwt - git-crypt safe worktree"
-            ux_info "Usage: gwt <path> [<new-branch> [<start-point>]]"
-            ux_info ""
-            ux_info "Related commands:"
-            ux_info "  gwtl              list worktrees"
-            ux_info "  gwtr <path>       remove worktree"
-            ux_info "  gwt-spawn [agent] auto-create AI worktree (gwt-spawn --help)"
-            ux_info "  gwt-teardown      auto-remove AI worktree from inside it"
+        -h|--help)
+            ux_info "Usage: gwt add <path> [<new-branch> [<start-point>]]"
+            ux_info "  Creates a git-crypt safe worktree (encrypted files excluded)"
             return 0
             ;;
         "")
-            ux_error "Usage: gwt <path> [<new-branch> [<start-point>]]"
+            ux_error "Usage: gwt add <path> [<new-branch> [<start-point>]]"
             return 1
             ;;
     esac
@@ -250,8 +276,8 @@ git_worktree_spawn() {
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help|help)
-                ux_header "gwt-spawn - AI worktree auto-creation"
-                ux_info "Usage: gwt-spawn [<agent>] [--task <slug>] [--base <ref>]"
+                ux_header "gwt spawn - AI worktree auto-creation"
+                ux_info "Usage: gwt spawn [<agent>] [--task <slug>] [--base <ref>]"
                 ux_info ""
                 ux_info "Arguments:"
                 ux_info "  <agent>          claude | codex | gemini | opencode | cursor (auto-detect if omitted)"
@@ -259,9 +285,9 @@ git_worktree_spawn() {
                 ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
                 ux_info ""
                 ux_info "Examples:"
-                ux_info "  gwt-spawn                          # auto-detect agent"
-                ux_info "  gwt-spawn claude                   # ../<project>-claude-1  wt/claude/1"
-                ux_info "  gwt-spawn codex --task login-fix   # ../<project>-codex-1   wt/codex/1-login-fix"
+                ux_info "  gwt spawn                          # auto-detect agent"
+                ux_info "  gwt spawn claude                   # ../<project>-claude-1  wt/claude/1"
+                ux_info "  gwt spawn codex --task login-fix   # ../<project>-codex-1   wt/codex/1-login-fix"
                 return 0
                 ;;
             --task) task="$2"; shift 2 ;;

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -205,9 +205,9 @@ gwt() {
             ux_info "Usage: gwt <command> [args...]"
             ux_info ""
             ux_info "Commands:"
-            ux_info "  add <path> [branch] [start]   create git-crypt safe worktree"
-            ux_info "  list                           list worktrees"
-            ux_info "  remove <path>                  remove worktree"
+            ux_info "  add <path> [branch] [start]    create git-crypt safe worktree"
+            ux_info "  list, ls                       list worktrees"
+            ux_info "  remove, rm <path>              remove worktree"
             ux_info "  spawn [agent] [--task slug]    auto-create AI worktree"
             ux_info "  teardown [--force]             auto-remove AI worktree"
             ux_info ""
@@ -223,9 +223,10 @@ gwt() {
 
 git_worktree_add() {
     case "${1:-}" in
-        -h|--help)
+        -h|--help|help)
+            ux_header "gwt add - git-crypt safe worktree"
             ux_info "Usage: gwt add <path> [<new-branch> [<start-point>]]"
-            ux_info "  Creates a git-crypt safe worktree (encrypted files excluded)"
+            ux_info "  Creates a worktree with git-crypt encrypted files excluded"
             return 0
             ;;
         "")
@@ -390,9 +391,18 @@ git_worktree_teardown() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
+            -h|--help|help)
+                ux_header "gwt teardown - AI worktree cleanup"
+                ux_info "Usage: gwt teardown [--force] [--keep-branch]"
+                ux_info ""
+                ux_info "Options:"
+                ux_info "  --force        discard uncommitted changes and force remove"
+                ux_info "  --keep-branch  keep the branch after removing worktree"
+                return 0
+                ;;
             --force) force=true; shift ;;
             --keep-branch) keep_branch=true; shift ;;
-            *) ux_error "Unknown option: $1"; return 1 ;;
+            *) ux_error "Unknown option: $1. Use --help for usage."; return 1 ;;
         esac
     done
 


### PR DESCRIPTION
## Summary
- 개별 alias 5개(gwt, gwtl, gwtr, gwt-spawn, gwt-teardown)를 단일 `gwt` 디스패처 함수로 통합
- `gwt add|list|remove|spawn|teardown` 서브커맨드 구조
- `gwt help` / `gwt` (인자 없이) → 전체 usage 출력
- 각 서브커맨드에 `--help` 지원

## Usage
```bash
gwt add <path> [branch] [start]    # git-crypt safe worktree 생성
gwt list                            # worktree 목록
gwt remove <path>                   # worktree 제거
gwt spawn [agent] [--task slug]     # AI worktree 자동 생성
gwt teardown [--force]              # AI worktree 정리
gwt help                            # usage 출력
```

## Test plan
- [ ] `gwt help` → 전체 usage 출력 확인
- [ ] `gwt add --help` → add 서브커맨드 help 확인
- [ ] `gwt spawn --help` → spawn help 확인
- [ ] `gwt list` → `git worktree list` 동작 확인
- [ ] `gwt spawn claude` → worktree 생성 확인
- [ ] `gwt` (인자 없이) → help 출력 확인 (worktree 생성 안 함)
- [ ] `gwt foo` → error 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
