### PR TITLE
fix(gwt): unalias Oh My Zsh gwt before function definition

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -4,7 +4,7 @@
 # (No bash-specific features)
 
 # Override Oh My Zsh's git aliases with our functions (zsh only)
-unalias gl gd glum glog 2>/dev/null || true
+unalias gl gd glum glog gwt 2>/dev/null || true
 
 # ============================================================================
 # Shared git log formatter


### PR DESCRIPTION
## Summary
- Oh My Zsh git plugin이 `gwt='git worktree'` alias를 정의하여, `gwt()` 함수 정의 시 zsh parse error 발생
- `unalias` 목록에 `gwt` 추가하여 해결

## Error
```
shell-common/functions/git.sh:196: defining function based on alias 'gwt'
shell-common/functions/git.sh:196: parse error near '()'
```

## Test plan
- [ ] `src` (source) 후 `gwt help` 정상 출력 확인
- [ ] `type gwt` → `gwt is a shell function` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
