### PR TITLE
fix(skill): run teardown from main repo, not worktree

### DIFF
--- a/claude/skills/ai-worktree-teardown/SKILL.md
+++ b/claude/skills/ai-worktree-teardown/SKILL.md
@@ -42,8 +42,8 @@ Verify the path is a known worktree. If not, print error and stop.
 
 ### Step 3: Pre-flight Checks
 
-`cd` into the worktree temporarily to check for uncommitted changes or unpushed commits.
-Return to main repo after checks. Block on issues to prevent work loss.
+Use `git -C <worktree-path>` to check for uncommitted changes or unpushed commits.
+Block on issues to prevent work loss.
 Skip these checks if `--force` is given.
 
 ### Step 4: Remove Worktree

--- a/claude/skills/ai-worktree-teardown/SKILL.md
+++ b/claude/skills/ai-worktree-teardown/SKILL.md
@@ -2,7 +2,8 @@
 name: ai-worktree:teardown
 description: >-
   Clean up an AI worktree after work is done — remove worktree, delete branch,
-  sync main. The reverse of ai-worktree:spawn. Use when the user says "작업 끝",
+  sync main. The reverse of ai-worktree:spawn. Run from the MAIN repo, passing
+  the worktree path as an argument. Use when the user says "작업 끝",
   "워크트리 정리", "teardown", "cleanup worktree", "작업 완료", "워크트리 제거",
   or any request to clean up after finishing work in a worktree.
 allowed-tools: Bash, Read, Grep, Glob
@@ -13,6 +14,9 @@ allowed-tools: Bash, Read, Grep, Glob
 Remove an AI worktree and sync main after work is complete.
 This is the reverse of `ai-worktree:spawn`.
 
+**Must run from the main repo**, not from inside the worktree.
+The worktree path is passed as an argument (e.g., `/ai-worktree:teardown ~/dotfiles-claude-2`).
+
 Read `references/options-and-errors.md` for CLI options and error handling.
 
 ## Execution Steps
@@ -20,48 +24,48 @@ Read `references/options-and-errors.md` for CLI options and error handling.
 Run these steps in order. Stop immediately on any error.
 Read `references/bash-commands.md` for exact bash implementations per step.
 
-### Step 1: Validate — Must Be Inside a Worktree
+### Step 1: Validate — Must Be in Main Repo, NOT a Worktree
 
-Check `git-dir != git-common-dir`. If NOT inside a worktree, print error and stop.
-This is the inverse of spawn's check.
+Check `git-dir == git-common-dir`. If INSIDE a worktree, print error and stop.
+This is the same check as spawn — both run from the main repo.
 
-### Step 2: Pre-flight Checks
+Require a `<worktree-path>` argument. If missing, list existing worktrees and stop.
 
-Block on uncommitted changes or unpushed commits to prevent work loss.
-Skip these checks if `--force` is given.
+### Step 2: Resolve Worktree Info
 
-### Step 3: Identify Main Repo and Worktree Info
-
-Extract from current worktree:
-- `WORKTREE_PATH` — current toplevel
-- `MAIN_REPO` — derived from git-common-dir
-- `BRANCH` — current branch name
+From the given `<worktree-path>`, extract:
+- `WORKTREE_PATH` — resolved absolute path
+- `BRANCH` — branch checked out in that worktree (via `git worktree list`)
 - `WORKTREE_NAME` — basename of worktree path
 
-### Step 4: Switch to Main Repo
+Verify the path is a known worktree. If not, print error and stop.
 
-`cd` into the main repo directory. All subsequent commands run from there.
+### Step 3: Pre-flight Checks
 
-### Step 5: Remove Worktree
+`cd` into the worktree temporarily to check for uncommitted changes or unpushed commits.
+Return to main repo after checks. Block on issues to prevent work loss.
+Skip these checks if `--force` is given.
+
+### Step 4: Remove Worktree
 
 `git worktree remove <path>`. On failure, try `--force` if user opted in.
 
-### Step 6: Sync Main
+### Step 5: Sync Main
 
 `git checkout main && git pull origin main`.
 Must run BEFORE branch delete so `git branch -d` can verify merge status.
 If pull conflicts, the AI agent attempts to resolve them and reports.
 
-### Step 7: Delete Branch
+### Step 6: Delete Branch
 
 `git branch -d <branch>` (safe delete — verifies merge status).
 Skip if `--keep-branch` is given. Warn if branch is not fully merged.
 
-### Step 8: Log
+### Step 7: Log
 
 Append `TEARDOWN` entry to `ai-worktree-spawn.log` (same file as spawn).
 
-### Step 9: Report
+### Step 8: Report
 
 ```
 [OK] Teardown complete

--- a/claude/skills/ai-worktree-teardown/references/bash-commands.md
+++ b/claude/skills/ai-worktree-teardown/references/bash-commands.md
@@ -1,30 +1,65 @@
 # Bash Commands — implementation details for each execution step
 
-## Step 1: Validate — Must Be Inside a Worktree
+## Step 1: Validate — Must Be in Main Repo, NOT a Worktree
 
 ```bash
 GIT_COMMON="$(git rev-parse --git-common-dir)"
 GIT_DIR="$(git rev-parse --git-dir)"
 
-if [[ "$GIT_DIR" == "$GIT_COMMON" ]]; then
-  echo "Error: Not inside a worktree. Nothing to tear down."
-  echo "  Run this from inside an AI worktree (e.g., ../my-app-claude-1)"
+if [[ "$GIT_DIR" != "$GIT_COMMON" ]]; then
+  echo "Error: You are inside a worktree. Run this from the main repo."
+  echo "  cd $(dirname "$GIT_COMMON") && /ai-worktree:teardown <worktree-path>"
+  exit 1
+fi
+
+# Require worktree path argument
+WORKTREE_ARG="$1"
+if [[ -z "$WORKTREE_ARG" ]]; then
+  echo "Error: Missing worktree path argument."
+  echo ""
+  echo "Usage: /ai-worktree:teardown <worktree-path> [--force] [--keep-branch]"
+  echo ""
+  echo "Active worktrees:"
+  git worktree list
   exit 1
 fi
 ```
 
-## Step 2: Pre-flight Checks
+## Step 2: Resolve Worktree Info
+
+```bash
+# Resolve to absolute path
+WORKTREE_PATH="$(realpath "$WORKTREE_ARG")"
+WORKTREE_NAME="$(basename "$WORKTREE_PATH")"
+
+# Verify it's a known worktree and extract branch
+BRANCH="$(git worktree list --porcelain | awk -v wp="$WORKTREE_PATH" '
+  /^worktree / { wt = substr($0, 10) }
+  /^branch /   { if (wt == wp) { sub(/^branch refs\/heads\//, ""); print } }
+')"
+
+if [[ -z "$BRANCH" ]]; then
+  echo "Error: '$WORKTREE_PATH' is not a known worktree of this repo."
+  echo ""
+  echo "Active worktrees:"
+  git worktree list
+  exit 1
+fi
+```
+
+## Step 3: Pre-flight Checks
 
 ```bash
 preflight_check() {
-  local force="${1:-false}"
+  local worktree_path="$1"
+  local force="${2:-false}"
 
-  # Uncommitted changes (staged or unstaged)
-  if ! git diff --quiet || ! git diff --cached --quiet; then
+  # Check for uncommitted changes in the target worktree
+  if ! git -C "$worktree_path" diff --quiet || ! git -C "$worktree_path" diff --cached --quiet; then
     if [[ "$force" == true ]]; then
       echo "Warning: Discarding uncommitted changes (--force)"
     else
-      echo "Error: Uncommitted changes detected."
+      echo "Error: Uncommitted changes detected in $worktree_path."
       echo "  Commit, stash, or use --force to discard."
       exit 1
     fi
@@ -32,8 +67,8 @@ preflight_check() {
 
   # Unpushed commits
   local local_rev remote_rev
-  local_rev="$(git rev-parse HEAD)"
-  remote_rev="$(git rev-parse @{u} 2>/dev/null || echo "no-upstream")"
+  local_rev="$(git -C "$worktree_path" rev-parse HEAD)"
+  remote_rev="$(git -C "$worktree_path" rev-parse @{u} 2>/dev/null || echo "no-upstream")"
 
   if [[ "$remote_rev" != "no-upstream" && "$local_rev" != "$remote_rev" ]]; then
     if [[ "$force" == true ]]; then
@@ -46,36 +81,10 @@ preflight_check() {
   fi
 }
 
-preflight_check "${FORCE:-false}"
+preflight_check "$WORKTREE_PATH" "${FORCE:-false}"
 ```
 
-## Step 3: Identify Main Repo and Worktree Info
-
-```bash
-WORKTREE_PATH="$(git rev-parse --show-toplevel)"
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-WORKTREE_NAME="$(basename "$WORKTREE_PATH")"
-
-# Derive main repo path from git-common-dir
-# git-common-dir returns something like /path/to/main-repo/.git
-GIT_COMMON="$(git rev-parse --git-common-dir)"
-MAIN_REPO="$(dirname "$GIT_COMMON")"
-
-# Verify main repo exists
-if [[ ! -d "$MAIN_REPO/.git" && ! -f "$MAIN_REPO/.git" ]]; then
-  echo "Error: Cannot find main repo at $MAIN_REPO"
-  exit 1
-fi
-```
-
-## Step 4: Switch to Main Repo
-
-```bash
-cd "$MAIN_REPO" || { echo "Error: Cannot cd to $MAIN_REPO"; exit 1; }
-echo "Switched to main repo: $MAIN_REPO"
-```
-
-## Step 5: Remove Worktree
+## Step 4: Remove Worktree
 
 ```bash
 if ! git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
@@ -92,7 +101,7 @@ git worktree prune
 echo "Worktree removed: $WORKTREE_PATH"
 ```
 
-## Step 6: Sync Main
+## Step 5: Sync Main
 
 Sync main BEFORE branch delete so `git branch -d` can verify merge status.
 
@@ -127,7 +136,7 @@ if ! git pull origin "$MAIN_BRANCH"; then
 fi
 ```
 
-## Step 7: Delete Branch
+## Step 6: Delete Branch
 
 Runs after sync so local main contains the merge commit.
 
@@ -157,7 +166,7 @@ delete_branch() {
 delete_branch "$BRANCH"
 ```
 
-## Step 8: Log
+## Step 7: Log
 
 ```bash
 GIT_COMMON="$(git rev-parse --git-common-dir)"

--- a/claude/skills/ai-worktree-teardown/references/bash-commands.md
+++ b/claude/skills/ai-worktree-teardown/references/bash-commands.md
@@ -17,7 +17,7 @@ WORKTREE_ARG="$1"
 if [[ -z "$WORKTREE_ARG" ]]; then
   echo "Error: Missing worktree path argument."
   echo ""
-  echo "Usage: /ai-worktree:teardown <worktree-path> [--force] [--keep-branch]"
+  echo "Usage: /ai-worktree:teardown <worktree-path> [--force] [--keep-branch] [--dry-run]"
   echo ""
   echo "Active worktrees:"
   git worktree list

--- a/claude/skills/ai-worktree-teardown/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-teardown/references/options-and-errors.md
@@ -1,25 +1,35 @@
 # Options and Error Handling — CLI reference
 
+## Usage
+
+```
+/ai-worktree:teardown <worktree-path> [--force] [--keep-branch] [--dry-run]
+```
+
+Run from the **main repo** (not from inside a worktree).
+
 ## Options
 
 | Option | Description | Default |
 |---|---|---|
+| `<worktree-path>` | Path to the worktree to remove (required) | — |
 | `--force` | Skip pre-flight checks, force remove dirty worktree, force delete unmerged branch | `false` |
 | `--keep-branch` | Don't delete the branch after removing worktree | `false` |
 | `--dry-run` | Print plan without executing anything | `false` |
 
 When `--dry-run` is specified, print the full plan (worktree path, branch,
-main repo path, actions to take) and stop without executing anything.
+actions to take) and stop without executing anything.
 
 ## Error Handling
 
 | Situation | Action |
 |---|---|
-| Not inside a worktree | Print error, stop |
-| Uncommitted changes | Warn, stop (unless `--force`) |
-| Unpushed commits | Warn, stop (unless `--force`) |
+| Inside a worktree (not main repo) | Print error with `cd` hint, stop |
+| Missing `<worktree-path>` argument | List active worktrees, stop |
+| Path is not a known worktree | Print error, list active worktrees, stop |
+| Uncommitted changes in worktree | Warn, stop (unless `--force`) |
+| Unpushed commits in worktree | Warn, stop (unless `--force`) |
 | Worktree remove fails | Try `--force` if opted in, else stop |
 | Branch not fully merged | Warn, skip branch delete (unless `--force`) |
 | Main branch not found | Try `master`, then error |
 | Pull conflict | AI agent attempts resolution, reports to user |
-| Main repo path invalid | Print error, stop |


### PR DESCRIPTION
## Summary
- **Problem**: `/ai-worktree:teardown` 실행 시 sandbox가 main repo 접근을 차단하여 워크트리 제거 불가
- **Solution**: 워크트리 안에서 실행하는 대신 main repo에서 `<worktree-path>` 인자를 받아 실행하도록 변경
- **Symmetry**: spawn과 teardown 모두 main repo에서 실행하는 동일한 패턴으로 통일

## Changes
- `SKILL.md`: Step 1 검증 반전 (워크트리 내부 → main repo), 인자 필수화, 9→8 단계 축소
- `bash-commands.md`: `git -C` 사용으로 cd 없이 원격 체크, `git worktree list --porcelain`으로 브랜치 추출
- `options-and-errors.md`: Usage 섹션 추가, 새 에러 케이스 반영

## Test plan
- [ ] main repo에서 `/ai-worktree:teardown ~/dotfiles-claude-N` 실행 확인
- [ ] 인자 없이 실행 시 워크트리 목록 출력 확인
- [ ] 워크트리 내부에서 실행 시 에러 메시지 + cd 힌트 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
