### PR TITLE
feat(tmux): fix pane targeting, add teardown & help

### DIFF
--- a/shell-common/functions/tmux_help.sh
+++ b/shell-common/functions/tmux_help.sh
@@ -52,6 +52,10 @@ tmux_help() {
     ux_bullet "Setup:   ${UX_BOLD}marmonitor setup tmux${UX_RESET}"
     ux_bullet "tmux 안에서 prefix+I 로 플러그인 활성화"
 
+    ux_section "Custom Commands"
+    ux_table_row "tmux-spawn [agent]" "3-pane AI 세션 생성"
+    ux_table_row "tmux-teardown [name|all]" "세션 정리 (기본: all)"
+
     ux_section "Related Help"
     ux_bullet "Cheat sheet: ${UX_BOLD}https://tmuxcheatsheet.com/${UX_RESET}"
     ux_bullet "Terminal: ${UX_BOLD}ghostty-help${UX_RESET}"

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -33,6 +33,27 @@ tmux_spawn() {
         return 1
     fi
 
+    case "${1:-}" in
+        -h|--help|help)
+            ux_header "tmux-spawn - create tmux session with 3-pane layout"
+            ux_info "Usage: tmux-spawn [<agent>]"
+            ux_info ""
+            ux_info "Modes:"
+            ux_info "  Worktree dir  session = dir name, agent auto-detected"
+            ux_info "  Main repo     session = <project>-<branch>, agent = claude"
+            ux_info ""
+            ux_info "Agents: claude, codex, gemini, opencode, cursor, copilot"
+            ux_info ""
+            ux_info "Layout:"
+            ux_info "  +----------+----------+"
+            ux_info "  |          | right-top|"
+            ux_info "  |   LEFT   +----------+"
+            ux_info "  | (ai-yolo)| right-bot|"
+            ux_info "  +----------+----------+"
+            return 0
+            ;;
+    esac
+
     _ts_arg="${1:-}"
     _ts_dir="$(pwd)"
     _ts_basename="$(basename "$_ts_dir")"
@@ -77,9 +98,9 @@ tmux_spawn() {
         ux_warning "Session '$_ts_session' already exists"
         if [ -z "$TMUX" ]; then
             ux_info "Attaching..."
-            tmux attach -t "=$_ts_session"
+            tmux attach -t "$_ts_session"
         else
-            ux_info "Switch: tmux switch-client -t '=$_ts_session'"
+            ux_info "Switch: tmux switch-client -t '$_ts_session'"
         fi
         unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
               _ts_without_index _ts_candidate _ts_yolo
@@ -87,30 +108,85 @@ tmux_spawn() {
     fi
 
     # --- Create session with 3-pane layout ---
+    # Note: = prefix works for has-session but NOT for pane-targeting
+    # commands (split-window, send-keys, select-pane) in tmux 3.4
     # Pane 0: left  (will run ai-yolo)
     tmux new-session -d -s "$_ts_session" -c "$_ts_dir"
     # Pane 1: right-top
-    tmux split-window -h -t "=$_ts_session" -c "$_ts_dir"
+    tmux split-window -h -t "$_ts_session" -c "$_ts_dir"
     # Pane 2: right-bottom (split right pane vertically)
-    tmux split-window -v -t "=$_ts_session" -c "$_ts_dir"
+    tmux split-window -v -t "$_ts_session" -c "$_ts_dir"
 
     # Run ai-yolo in the left pane (pane 0)
-    tmux send-keys -t "=${_ts_session}:0.0" "$_ts_yolo" Enter
+    tmux send-keys -t "${_ts_session}:0.0" "$_ts_yolo" Enter
 
     # Focus left pane
-    tmux select-pane -t "=${_ts_session}:0.0"
+    tmux select-pane -t "${_ts_session}:0.0"
 
     ux_success "Session '$_ts_session' created (3 panes, running $_ts_yolo)"
 
     # Attach or advise
     if [ -z "$TMUX" ]; then
-        tmux attach -t "=$_ts_session"
+        tmux attach -t "$_ts_session"
     else
-        ux_info "Switch: Ctrl+b s  or  tmux switch-client -t '=$_ts_session'"
+        ux_info "Switch: Ctrl+b s  or  tmux switch-client -t '$_ts_session'"
     fi
 
     unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
           _ts_without_index _ts_candidate _ts_yolo
 }
 
+tmux_teardown() {
+    if ! command -v tmux >/dev/null 2>&1; then
+        ux_error "tmux is not installed"
+        return 1
+    fi
+
+    _tt_target="${1:-all}"
+
+    case "$_tt_target" in
+        -h|--help|help)
+            ux_header "tmux-teardown - kill tmux sessions"
+            ux_info "Usage: tmux-teardown [all | <session-name>]"
+            ux_info ""
+            ux_info "  all (default)      kill ALL sessions"
+            ux_info "  <session-name>     kill a specific session"
+            unset _tt_target
+            return 0
+            ;;
+        all)
+            _tt_sessions="$(tmux list-sessions -F '#{session_name}' 2>/dev/null)"
+            if [ -z "$_tt_sessions" ]; then
+                ux_info "No tmux sessions running."
+                unset _tt_target _tt_sessions
+                return 0
+            fi
+
+            _tt_count="$(printf '%s\n' "$_tt_sessions" | wc -l)"
+            ux_warning "Killing $_tt_count session(s):"
+            printf '%s\n' "$_tt_sessions" | while IFS= read -r s; do
+                ux_info "  $s"
+            done
+
+            tmux kill-server
+            ux_success "All sessions killed."
+            unset _tt_target _tt_sessions _tt_count
+            ;;
+        *)
+            if tmux has-session -t "=$_tt_target" 2>/dev/null; then
+                tmux kill-session -t "=$_tt_target"
+                ux_success "Session '$_tt_target' killed."
+            else
+                ux_error "Session not found: $_tt_target"
+                ux_info "Running sessions:"
+                tmux list-sessions -F '  #{session_name}' 2>/dev/null || ux_info "  (none)"
+                unset _tt_target
+                return 1
+            fi
+            unset _tt_target
+            ;;
+    esac
+}
+
 alias tmux-spawn='tmux_spawn'
+alias tmux-teardown='tmux_teardown'

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -108,8 +108,8 @@ tmux_spawn() {
     fi
 
     # --- Create session with 3-pane layout ---
-    # Note: = prefix works for has-session but NOT for pane-targeting
-    # commands (split-window, send-keys, select-pane) in tmux 3.4
+    # Note: = prefix works for has-session but NOT for
+    # session/pane-targeting commands in tmux 3.4
     # Pane 0: left  (will run ai-yolo)
     tmux new-session -d -s "$_ts_session" -c "$_ts_dir"
     # Pane 1: right-top
@@ -137,53 +137,45 @@ tmux_spawn() {
 }
 
 tmux_teardown() {
-    if ! command -v tmux >/dev/null 2>&1; then
-        ux_error "tmux is not installed"
-        return 1
-    fi
+    ux_require "tmux" || return 1
 
-    _tt_target="${1:-all}"
+    local target="${1:-all}" sessions count s
 
-    case "$_tt_target" in
+    case "$target" in
         -h|--help|help)
             ux_header "tmux-teardown - kill tmux sessions"
             ux_info "Usage: tmux-teardown [all | <session-name>]"
             ux_info ""
             ux_info "  all (default)      kill ALL sessions"
             ux_info "  <session-name>     kill a specific session"
-            unset _tt_target
             return 0
             ;;
         all)
-            _tt_sessions="$(tmux list-sessions -F '#{session_name}' 2>/dev/null)"
-            if [ -z "$_tt_sessions" ]; then
+            sessions="$(tmux list-sessions -F '#{session_name}' 2>/dev/null)"
+            if [ -z "$sessions" ]; then
                 ux_info "No tmux sessions running."
-                unset _tt_target _tt_sessions
                 return 0
             fi
 
-            _tt_count="$(printf '%s\n' "$_tt_sessions" | wc -l)"
-            ux_warning "Killing $_tt_count session(s):"
-            printf '%s\n' "$_tt_sessions" | while IFS= read -r s; do
+            count="$(printf '%s\n' "$sessions" | wc -l)"
+            ux_warning "Killing $count session(s):"
+            printf '%s\n' "$sessions" | while IFS= read -r s; do
                 ux_info "  $s"
             done
 
             tmux kill-server
             ux_success "All sessions killed."
-            unset _tt_target _tt_sessions _tt_count
             ;;
         *)
-            if tmux has-session -t "=$_tt_target" 2>/dev/null; then
-                tmux kill-session -t "=$_tt_target"
-                ux_success "Session '$_tt_target' killed."
+            if tmux has-session -t "=$target" 2>/dev/null; then
+                tmux kill-session -t "$target"
+                ux_success "Session '$target' killed."
             else
-                ux_error "Session not found: $_tt_target"
+                ux_error "Session not found: $target"
                 ux_info "Running sessions:"
                 tmux list-sessions -F '  #{session_name}' 2>/dev/null || ux_info "  (none)"
-                unset _tt_target
                 return 1
             fi
-            unset _tt_target
             ;;
     esac
 }


### PR DESCRIPTION
## Summary
- tmux 3.4에서 `=` prefix가 pane 대상 명령(`split-window`, `send-keys`, `select-pane`)에서 동작하지 않는 문제 수정
- `tmux-teardown [all|<name>]` 명령 추가 — 세션 일괄/개별 삭제
- `tmux-spawn help` 옵션 추가
- `tmux-help`에 Custom Commands 섹션 추가

## Test plan
- [ ] `tmux-spawn` → 3-pane 에러 없이 생성 확인
- [ ] `tmux-spawn help` → 사용법 출력 확인
- [ ] `tmux-teardown` → 모든 세션 삭제 확인
- [ ] `tmux-teardown <name>` → 특정 세션만 삭제 확인
- [ ] `tmux-help` → Custom Commands 섹션 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
