### PR TITLE
feat(tmux): add -w flag for window mode in tmux-spawn

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -210,7 +210,7 @@ gwt() {
             ux_info "  list, ls                       list worktrees (with hints)"
             ux_info "  remove, rm <path|all> [--force] remove worktree + branch"
             ux_info "  prune                          clean up stale worktree refs"
-            ux_info "  spawn [agent] [--task slug]    create AI worktree (run from main repo)"
+            ux_info "  spawn [ai] [--task slug]       create AI worktree (run from main repo)"
             ux_info "  teardown [--force]             self-cleanup (run from inside worktree)"
             ux_info ""
             ux_info "Run 'gwt <command> --help' for command-specific help."
@@ -519,7 +519,7 @@ git_worktree_spawn() {
                 ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
                 ux_info ""
                 ux_info "Examples:"
-                ux_info "  gwt spawn                          # auto-detect agent"
+                ux_info "  gwt spawn                          # auto-detect AI (default=claude)"
                 ux_info "  gwt spawn claude                   # ../<project>-claude-1  wt/claude/1"
                 ux_info "  gwt spawn codex --task login-fix   # ../<project>-codex-1   wt/codex/1-login-fix"
                 return 0
@@ -548,8 +548,9 @@ git_worktree_spawn() {
         if [ "${CLAUDECODE:-}" = "1" ]; then agent="claude"
         elif [ "${GEMINI_CLI:-}" = "1" ]; then agent="gemini"
         elif [ "${CODEX_CLI:-}" = "1" ]; then agent="codex"
+        elif [ "${OPENCODE:-}" = "1" ]; then agent="opencode"
         elif [ "${CURSOR:-}" = "1" ] || [ "${TERM_PROGRAM:-}" = "cursor" ]; then agent="cursor"
-        else agent="agent"
+        else agent="claude"
         fi
     fi
 

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -36,9 +36,16 @@ tmux_spawn() {
     case "${1:-}" in
         -h|--help|help)
             ux_header "tmux-spawn - create tmux session with 3-pane layout"
-            ux_info "Usage: tmux-spawn [<agent>]"
+            ux_info "Usage: tmux-spawn [-w] [<agent>]"
+            ux_info ""
+            ux_info "Options:"
+            ux_info "  -w           Add new window to current session (must be inside tmux)"
             ux_info ""
             ux_info "Modes:"
+            ux_info "  (default)    Create new session with 3-pane layout"
+            ux_info "  -w           Add 3-pane window to current session"
+            ux_info ""
+            ux_info "Session naming:"
             ux_info "  Worktree dir  session = dir name, agent auto-detected"
             ux_info "  Main repo     session = <project>-<branch>, agent = claude"
             ux_info ""
@@ -53,6 +60,13 @@ tmux_spawn() {
             return 0
             ;;
     esac
+
+    # Parse -w flag
+    _ts_window_mode=0
+    if [ "${1:-}" = "-w" ]; then
+        _ts_window_mode=1
+        shift
+    fi
 
     _ts_arg="${1:-}"
     _ts_dir="$(pwd)"
@@ -93,6 +107,39 @@ tmux_spawn() {
 
     _ts_yolo="${_ts_agent}-yolo"
 
+    # --- Window mode: add new window to current session ---
+    if [ "$_ts_window_mode" = 1 ]; then
+        if [ -z "$TMUX" ]; then
+            ux_error "Option -w requires being inside a tmux session"
+            unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
+                  _ts_without_index _ts_candidate _ts_yolo _ts_window_mode
+            return 1
+        fi
+
+        _ts_cur_session="$(tmux display-message -p '#{session_name}')"
+
+        # Create new window named after agent
+        tmux new-window -t "$_ts_cur_session" -n "$_ts_agent" -c "$_ts_dir"
+        # Pane 1: right-top
+        tmux split-window -h -t "$_ts_cur_session" -c "$_ts_dir"
+        # Pane 2: right-bottom
+        tmux split-window -v -t "$_ts_cur_session" -c "$_ts_dir"
+
+        # Run ai-yolo in left pane (pane 0 of the new window)
+        _ts_new_win="$(tmux display-message -p '#{window_index}')"
+        tmux send-keys -t "${_ts_cur_session}:${_ts_new_win}.0" "$_ts_yolo" Enter
+
+        # Focus left pane
+        tmux select-pane -t "${_ts_cur_session}:${_ts_new_win}.0"
+
+        ux_success "Window '$_ts_agent' added to session '$_ts_cur_session' (3 panes, running $_ts_yolo)"
+
+        unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
+              _ts_without_index _ts_candidate _ts_yolo _ts_window_mode \
+              _ts_cur_session _ts_new_win
+        return 0
+    fi
+
     # Check if session already exists
     if tmux has-session -t "=$_ts_session" 2>/dev/null; then
         ux_warning "Session '$_ts_session' already exists"
@@ -103,7 +150,7 @@ tmux_spawn() {
             ux_info "Switch: tmux switch-client -t '$_ts_session'"
         fi
         unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
-              _ts_without_index _ts_candidate _ts_yolo
+              _ts_without_index _ts_candidate _ts_yolo _ts_window_mode
         return 0
     fi
 
@@ -133,7 +180,7 @@ tmux_spawn() {
     fi
 
     unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
-          _ts_without_index _ts_candidate _ts_yolo
+          _ts_without_index _ts_candidate _ts_yolo _ts_window_mode
 }
 
 tmux_teardown() {


### PR DESCRIPTION
## Summary
- Add `-w` flag to `tmux-spawn` that creates a new 3-pane window in the current tmux session
- Solves: running `tmux-spawn gemini` inside an existing session no longer fails with "already exists"
- Window is named after the agent (visible via `Ctrl+b, w`)

## Usage
```sh
tmux-spawn codex        # create new session (unchanged)
tmux-spawn -w gemini    # add window to current session
```

## Test plan
- [ ] `tmux-spawn -w gemini` inside tmux → 3-pane window created, gemini-yolo running
- [ ] `tmux-spawn -w codex` outside tmux → error message shown
- [ ] `tmux-spawn help` → updated help with -w option
- [ ] `tmux-spawn gemini` (without -w) → existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
