### PR TITLE
fix(tmux): improve Ghostty WSL Korean input compatibility

### DIFF
--- a/shell-common/config/symlinks.conf
+++ b/shell-common/config/symlinks.conf
@@ -13,3 +13,6 @@ ${HOME}/.ssh/config|${HOME}/dotfiles/ssh/config|SSH config (managed by dotfiles)
 
 # Ghostty Terminal
 ${HOME}/.config/ghostty/config|${HOME}/dotfiles/ghostty/config|Ghostty terminal config
+
+# tmux
+${HOME}/.tmux.conf|${HOME}/dotfiles/tmux/tmux.conf|tmux config

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,0 +1,14 @@
+# tmux configuration for WSL + Ghostty Korean IME compatibility
+# Managed via dotfiles:
+#   ~/.tmux.conf -> ~/dotfiles/tmux/tmux.conf
+
+# Preserve existing plugin setup.
+set -g @plugin 'mjjo16/marmonitor-tmux'
+
+# Use tmux terminfo for better key/terminal compatibility.
+set -g default-terminal "tmux-256color"
+
+# Workaround for Ghostty + tmux IME composition/input issues.
+# If you need full extended-key behavior in another terminal,
+# override this locally per host/session.
+set -s extended-keys off


### PR DESCRIPTION
## Summary
- add managed `tmux/tmux.conf` for WSL + Ghostty Korean IME workaround
- set `extended-keys off` to avoid IME composition/key encoding conflicts in tmux
- set `default-terminal` to `tmux-256color`
- register `~/.tmux.conf` symlink in `shell-common/config/symlinks.conf`

## Validation
- `ghostty --version` => `Ghostty 1.3.1` (meets 1.3.0+)
- `bash shell-common/tools/custom/symlink-manager.sh init` applied `~/.tmux.conf` symlink
- `tmux -L codex-ime -f ~/.tmux.conf new-session -d -s codex-test`
- `tmux -L codex-ime show -s extended-keys` => `extended-keys off`
- `tmux -L codex-ime show -g default-terminal` => `default-terminal tmux-256color`
- `tmux -L codex-ime kill-server`

## Notes
- Existing local `~/.tmux.conf` was backed up to `~/.tmux.conf.backup` by symlink manager.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
