### PR TITLE
feat(gwt): add --tmux flag to spawn for auto tmux session setup

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -623,6 +623,8 @@ git_worktree_spawn() {
         ux_info "  tmux:   session '$project', window '$agent'"
         if [ -z "$TMUX" ]; then
             tmux attach -t "$project"
+        else
+            tmux switch-client -t "${project}:${agent}" 2>/dev/null || true
         fi
     else
         ux_info ""

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -496,7 +496,7 @@ git_worktree_add() {
 
 # ============================================================================
 # Worktree spawn — auto-index, auto-branch, log
-# Usage: git_worktree_spawn [<agent>] [--task <slug>] [--base <ref>]
+# Usage: git_worktree_spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]
 # ============================================================================
 git_worktree_spawn() {
     # zsh compatibility
@@ -504,33 +504,42 @@ git_worktree_spawn() {
         emulate -L sh
     fi
 
-    local task="" base="" agent=""
+    local task="" base="" agent="" use_tmux=0
 
     # Parse arguments
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help|help)
                 ux_header "gwt spawn - AI worktree auto-creation"
-                ux_info "Usage: gwt spawn [<agent>] [--task <slug>] [--base <ref>]"
+                ux_info "Usage: gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]"
                 ux_info ""
                 ux_info "Arguments:"
                 ux_info "  <agent>          claude | codex | gemini | opencode | cursor (auto-detect if omitted)"
                 ux_info "  --task <slug>    Add task slug to branch name"
                 ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
+                ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
                 ux_info ""
                 ux_info "Examples:"
                 ux_info "  gwt spawn                          # auto-detect AI (default=claude)"
                 ux_info "  gwt spawn claude                   # ../<project>-claude-1  wt/claude/1"
                 ux_info "  gwt spawn codex --task login-fix   # ../<project>-codex-1   wt/codex/1-login-fix"
+                ux_info "  gwt spawn gemini --tmux            # worktree + tmux window"
                 return 0
                 ;;
             --task) task="$2"; shift 2 ;;
             --base) base="$2"; shift 2 ;;
+            --tmux) use_tmux=1; shift ;;
             claude|codex|gemini|opencode|cursor|copilot)
                 agent="$1"; shift ;;
             *) ux_error "Unknown option: $1. Use --help for usage."; return 1 ;;
         esac
     done
+
+    # Validate --tmux dependency
+    if [ "$use_tmux" = 1 ] && ! command -v tmux >/dev/null 2>&1; then
+        ux_error "tmux is not installed (required for --tmux)"
+        return 1
+    fi
 
     # Must be inside a git repo, NOT a worktree
     local git_common git_dir
@@ -607,8 +616,18 @@ git_worktree_spawn() {
     ux_info "  Path:   $wt_path"
     ux_info "  Branch: $branch"
     ux_info "  Base:   $base"
-    ux_info ""
-    ux_info "  cd $wt_path"
+
+    # --- Optional tmux integration ---
+    if [ "$use_tmux" = 1 ]; then
+        _tmux_add_agent_window "$project" "$agent" "$wt_path"
+        ux_info "  tmux:   session '$project', window '$agent'"
+        if [ -z "$TMUX" ]; then
+            tmux attach -t "$project"
+        fi
+    else
+        ux_info ""
+        ux_info "  cd $wt_path"
+    fi
 }
 
 # ============================================================================

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -27,6 +27,34 @@ _ts_known_agent() {
     esac
 }
 
+# _tmux_add_agent_window <session> <agent> <dir>
+# Add a 3-pane window to a tmux session (creates session if needed).
+# Layout: LEFT (agent-yolo) | RIGHT-TOP / RIGHT-BOTTOM
+_tmux_add_agent_window() {
+    _taw_session="$1" _taw_agent="$2" _taw_dir="$3"
+    _taw_yolo="${_taw_agent}-yolo"
+
+    if tmux has-session -t "=$_taw_session" 2>/dev/null; then
+        tmux new-window -t "$_taw_session" -n "$_taw_agent" -c "$_taw_dir"
+    else
+        tmux new-session -d -s "$_taw_session" -n "$_taw_agent" -c "$_taw_dir"
+    fi
+
+    # Get the active window index (the one just created)
+    _taw_win="$(tmux list-windows -t "$_taw_session" \
+        -F '#{window_active} #{window_index}' | awk '$1 == 1 { print $2 }')"
+
+    # 3-pane layout
+    tmux split-window -h -t "${_taw_session}:${_taw_win}" -c "$_taw_dir"
+    tmux split-window -v -t "${_taw_session}:${_taw_win}" -c "$_taw_dir"
+
+    # Run ai-yolo in pane 0, focus it
+    tmux send-keys -t "${_taw_session}:${_taw_win}.0" "$_taw_yolo" Enter
+    tmux select-pane -t "${_taw_session}:${_taw_win}.0"
+
+    unset _taw_session _taw_agent _taw_dir _taw_yolo _taw_win
+}
+
 tmux_spawn() {
     if ! command -v tmux >/dev/null 2>&1; then
         ux_error "tmux is not installed"
@@ -117,26 +145,13 @@ tmux_spawn() {
         fi
 
         _ts_cur_session="$(tmux display-message -p '#{session_name}')"
+        _tmux_add_agent_window "$_ts_cur_session" "$_ts_agent" "$_ts_dir"
 
-        # Create new window named after agent
-        tmux new-window -t "$_ts_cur_session" -n "$_ts_agent" -c "$_ts_dir"
-        # Pane 1: right-top
-        tmux split-window -h -t "$_ts_cur_session" -c "$_ts_dir"
-        # Pane 2: right-bottom
-        tmux split-window -v -t "$_ts_cur_session" -c "$_ts_dir"
-
-        # Run ai-yolo in left pane (pane 0 of the new window)
-        _ts_new_win="$(tmux display-message -p '#{window_index}')"
-        tmux send-keys -t "${_ts_cur_session}:${_ts_new_win}.0" "$_ts_yolo" Enter
-
-        # Focus left pane
-        tmux select-pane -t "${_ts_cur_session}:${_ts_new_win}.0"
-
-        ux_success "Window '$_ts_agent' added to session '$_ts_cur_session' (3 panes, running $_ts_yolo)"
+        ux_success "Window '$_ts_agent' added to session '$_ts_cur_session' (3 panes, running ${_ts_agent}-yolo)"
 
         unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
               _ts_without_index _ts_candidate _ts_yolo _ts_window_mode \
-              _ts_cur_session _ts_new_win
+              _ts_cur_session
         return 0
     fi
 
@@ -155,22 +170,9 @@ tmux_spawn() {
     fi
 
     # --- Create session with 3-pane layout ---
-    # Note: = prefix works for has-session but NOT for
-    # session/pane-targeting commands in tmux 3.4
-    # Pane 0: left  (will run ai-yolo)
-    tmux new-session -d -s "$_ts_session" -n "$_ts_agent" -c "$_ts_dir"
-    # Pane 1: right-top
-    tmux split-window -h -t "$_ts_session" -c "$_ts_dir"
-    # Pane 2: right-bottom (split right pane vertically)
-    tmux split-window -v -t "$_ts_session" -c "$_ts_dir"
+    _tmux_add_agent_window "$_ts_session" "$_ts_agent" "$_ts_dir"
 
-    # Run ai-yolo in the left pane (pane 0)
-    tmux send-keys -t "${_ts_session}:0.0" "$_ts_yolo" Enter
-
-    # Focus left pane
-    tmux select-pane -t "${_ts_session}:0.0"
-
-    ux_success "Session '$_ts_session' created (3 panes, running $_ts_yolo)"
+    ux_success "Session '$_ts_session' created (3 panes, running ${_ts_agent}-yolo)"
 
     # Attach or advise
     if [ -z "$TMUX" ]; then

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -31,28 +31,24 @@ _ts_known_agent() {
 # Add a 3-pane window to a tmux session (creates session if needed).
 # Layout: LEFT (agent-yolo) | RIGHT-TOP / RIGHT-BOTTOM
 _tmux_add_agent_window() {
-    _taw_session="$1" _taw_agent="$2" _taw_dir="$3"
-    _taw_yolo="${_taw_agent}-yolo"
+    local session="$1" agent="$2" dir="$3"
+    local yolo="${agent}-yolo" win
 
-    if tmux has-session -t "=$_taw_session" 2>/dev/null; then
-        tmux new-window -t "$_taw_session" -n "$_taw_agent" -c "$_taw_dir"
+    if tmux has-session -t "=$session" 2>/dev/null; then
+        win=$(tmux new-window -P -F '#{window_index}' \
+            -t "$session" -n "$agent" -c "$dir")
     else
-        tmux new-session -d -s "$_taw_session" -n "$_taw_agent" -c "$_taw_dir"
+        win=$(tmux new-session -d -P -F '#{window_index}' \
+            -s "$session" -n "$agent" -c "$dir")
     fi
 
-    # Get the active window index (the one just created)
-    _taw_win="$(tmux list-windows -t "$_taw_session" \
-        -F '#{window_active} #{window_index}' | awk '$1 == 1 { print $2 }')"
-
     # 3-pane layout
-    tmux split-window -h -t "${_taw_session}:${_taw_win}" -c "$_taw_dir"
-    tmux split-window -v -t "${_taw_session}:${_taw_win}" -c "$_taw_dir"
+    tmux split-window -h -t "${session}:${win}" -c "$dir"
+    tmux split-window -v -t "${session}:${win}" -c "$dir"
 
     # Run ai-yolo in pane 0, focus it
-    tmux send-keys -t "${_taw_session}:${_taw_win}.0" "$_taw_yolo" Enter
-    tmux select-pane -t "${_taw_session}:${_taw_win}.0"
-
-    unset _taw_session _taw_agent _taw_dir _taw_yolo _taw_win
+    tmux send-keys -t "${session}:${win}.0" "$yolo" Enter
+    tmux select-pane -t "${session}:${win}.0"
 }
 
 tmux_spawn() {


### PR DESCRIPTION
## Summary
- Extract 3-pane layout logic into reusable `_tmux_add_agent_window` helper (creates session if needed, adds window if exists)
- Refactor `tmux_spawn` (both new-session and `-w` modes) to use the helper — no behavior change
- Add `--tmux` flag to `gwt spawn` — after worktree creation, auto-creates/joins a shared tmux session named after the project

### Workflow
```bash
gwt spawn gemini --tmux   # session 'dotfiles' created, window 'gemini' (3-pane)
gwt spawn codex --tmux    # window 'codex' added to session 'dotfiles'
gwt spawn claude --tmux   # window 'claude' added to session 'dotfiles'
```
Result: 1 tmux session, 3 windows, each with 3-pane layout pointing to its own worktree.

## Test plan
- [x] `_tmux_add_agent_window` creates new session with correct name/layout
- [x] `_tmux_add_agent_window` adds window to existing session
- [x] `tmux-spawn` new-session mode regression (from main repo)
- [x] `gwt spawn gemini --tmux` creates worktree + tmux session
- [x] `gwt spawn codex --tmux` adds window to existing session
- [x] `gwt spawn claude --tmux` adds third window
- [x] Verified: 1 session, 3 windows, 3 panes each, correct worktree paths
- [x] `gwt spawn` without `--tmux` still works as before (worktree only)
- [x] `bash -n` and `zsh -n` syntax checks pass
- [x] shellcheck — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
