### PR TITLE
feat(tmux): add `ta` shortcut to attach first tmux session

### DIFF
--- a/shell-common/functions/ta.sh
+++ b/shell-common/functions/ta.sh
@@ -9,16 +9,13 @@
 # - No sessions: prints info and exits
 
 ta() {
-    if ! command -v tmux >/dev/null 2>&1; then
-        ux_error "tmux is not installed"
-        return 1
-    fi
+    ux_require "tmux" || return 1
 
+    local _ta_session
     _ta_session="$(tmux list-sessions -F '#{session_name}' 2>/dev/null | head -n 1)"
 
     if [ -z "$_ta_session" ]; then
         ux_info "No tmux sessions running."
-        unset _ta_session
         return 1
     fi
 
@@ -29,6 +26,4 @@ ta() {
     else
         tmux attach -t "$_ta_session"
     fi
-
-    unset _ta_session
 }

--- a/shell-common/functions/ta.sh
+++ b/shell-common/functions/ta.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# shell-common/functions/ta.sh
+# Quick attach to the first tmux session.
+#
+# Usage: ta
+#
+# - Outside tmux: attaches to the first session
+# - Inside tmux: switches client to the first session
+# - No sessions: prints info and exits
+
+ta() {
+    if ! command -v tmux >/dev/null 2>&1; then
+        ux_error "tmux is not installed"
+        return 1
+    fi
+
+    _ta_session="$(tmux list-sessions -F '#{session_name}' 2>/dev/null | head -n 1)"
+
+    if [ -z "$_ta_session" ]; then
+        ux_info "No tmux sessions running."
+        unset _ta_session
+        return 1
+    fi
+
+    ux_info "Attaching to '$_ta_session'"
+
+    if [ -n "$TMUX" ]; then
+        tmux switch-client -t "$_ta_session"
+    else
+        tmux attach -t "$_ta_session"
+    fi
+
+    unset _ta_session
+}

--- a/shell-common/functions/tmux_help.sh
+++ b/shell-common/functions/tmux_help.sh
@@ -36,7 +36,10 @@ tmux_help() {
 
     ux_section "Scroll & Copy - Ctrl+b +"
     ux_table_row "[" "카피 모드 (스크롤 가능)"
+    ux_table_row "Space" "선택 시작 (카피 모드 내)"
+    ux_table_row "Enter" "선택 영역 복사 (카피 모드 내)"
     ux_table_row "q" "카피 모드 종료"
+    ux_table_row "]" "buffer_0 붙여넣기"
 
     ux_section "Practical Example"
     ux_bullet "tmux new -s dev        # 세션 시작"


### PR DESCRIPTION
## Summary
- `ta` 명령어 추가: `tmux ls` 첫 번째 세션에 바로 attach
- tmux 안에서는 `switch-client`, 밖에서는 `attach` 자동 분기
- 세션 없으면 안내 메시지 출력

## Test plan
- [ ] `tmux-spawn`으로 세션 생성 후 `ta`로 접속 확인
- [ ] 세션 없는 상태에서 `ta` 실행 시 안내 메시지 확인
- [ ] tmux 안에서 `ta` 실행 시 switch-client 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
