### PR TITLE
feat(help): add superpowers-help command

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -158,7 +158,7 @@ _register_default_help_categories() {
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git uv py nvm npm bun pp cli ux du psql mytool}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network}"
-    HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace}"
+    HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip ghostty}"
     HELP_CATEGORY_MEMBERS[docs]="${HELP_CATEGORY_MEMBERS[docs]:-dot show_doc notion work_log work}"
@@ -237,6 +237,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[mount_help]="${HELP_DESCRIPTIONS[mount_help]:-[DevOps] Mount helpers}"
     HELP_DESCRIPTIONS[claude_plugins_help]="${HELP_DESCRIPTIONS[claude_plugins_help]:-[AI/LLM] Claude plugins setup}"
     HELP_DESCRIPTIONS[claude_skills_marketplace_help]="${HELP_DESCRIPTIONS[claude_skills_marketplace_help]:-[AI/LLM] Skills marketplace system}"
+    HELP_DESCRIPTIONS[superpowers_help]="${HELP_DESCRIPTIONS[superpowers_help]:-[AI/LLM] Superpowers plugin skills reference}"
     HELP_DESCRIPTIONS[notion_help]="${HELP_DESCRIPTIONS[notion_help]:-[Docs] Notion integration}"
     HELP_DESCRIPTIONS[ollama_help]="${HELP_DESCRIPTIONS[ollama_help]:-[AI/LLM] Ollama local models}"
     HELP_DESCRIPTIONS[tmux_help]="${HELP_DESCRIPTIONS[tmux_help]:-[CLI] tmux terminal multiplexer}"

--- a/shell-common/functions/superpowers_help.sh
+++ b/shell-common/functions/superpowers_help.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# shell-common/functions/superpowers_help.sh
+# Help display for superpowers plugin skills
+
+SUPERPOWERS_SKILLS_DIR="$HOME/.claude/plugins/cache/superpowers-dev/superpowers"
+
+superpowers_help() {
+    # Find installed version directory
+    local skills_base=""
+    local version=""
+    if [ -d "$SUPERPOWERS_SKILLS_DIR" ]; then
+        for d in "$SUPERPOWERS_SKILLS_DIR"/*/skills; do
+            if [ -d "$d" ]; then
+                skills_base="$d"
+                version=$(basename "$(dirname "$d")")
+                break
+            fi
+        done
+    fi
+
+    ux_header "Superpowers Plugin Skills (v${version:-unknown})"
+
+    ux_section "Process Skills (HOW to approach)"
+    ux_table_row "brainstorming" "Creative work, feature design, requirements exploration before implementation"
+    ux_table_row "writing-plans" "Multi-step task planning from spec/requirements, before touching code"
+    ux_table_row "executing-plans" "Execute written implementation plans in separate sessions with review checkpoints"
+    ux_table_row "systematic-debugging" "Bug/test failure diagnosis - root cause analysis before proposing fixes"
+    ux_table_row "test-driven-development" "Red-green-refactor: write tests before implementation code"
+    ux_table_row "verification-before-completion" "Run verification commands and confirm output before claiming done"
+
+    ux_section "Execution Skills (parallel & isolation)"
+    ux_table_row "dispatching-parallel-agents" "Run 2+ independent tasks concurrently without shared state"
+    ux_table_row "subagent-driven-development" "Execute implementation plans with independent sub-agents"
+    ux_table_row "using-git-worktrees" "Isolated feature work via git worktrees with safety checks"
+
+    ux_section "Review & Completion Skills"
+    ux_table_row "requesting-code-review" "Request review after feature completion or before merge"
+    ux_table_row "receiving-code-review" "Handle review feedback with technical rigor, not blind agreement"
+    ux_table_row "finishing-a-development-branch" "Branch integration: merge, PR, or cleanup options"
+
+    ux_section "Meta Skills"
+    ux_table_row "using-superpowers" "Skill discovery and invocation at conversation start"
+    ux_table_row "writing-skills" "Create, edit, or verify skills before deployment"
+
+    ux_section "Skill Files Location"
+    if [ -n "$skills_base" ]; then
+        ux_info "$skills_base/"
+    else
+        ux_warning "Superpowers plugin not found. Install via Claude Code marketplace."
+        ux_info "Expected: $SUPERPOWERS_SKILLS_DIR/<version>/skills/"
+    fi
+
+    ux_section "Usage"
+    ux_bullet "Invoke in Claude Code: ${UX_CODE}/brainstorm${UX_RESET}, ${UX_CODE}/write-plan${UX_RESET}, ${UX_CODE}/execute-plan${UX_RESET}"
+    ux_bullet "Read a skill: ${UX_CODE}cat <skills_path>/<skill-name>/SKILL.md${UX_RESET}"
+    ux_bullet "Priority: Process skills first, then implementation skills"
+}
+
+alias superpowers-help='superpowers_help'


### PR DESCRIPTION
## Summary
- Add `superpowers-help` command listing all 14 superpowers plugin skills with 1-2 line descriptions
- Skills categorized by workflow phase: Process → Execution → Review & Completion → Meta
- Auto-detects installed plugin version and displays skill files path
- Registered in `my-help ai` category

## Test plan
- [ ] `superpowers-help` displays skill list with descriptions
- [ ] `my-help superpowers` routes correctly
- [ ] `my-help ai` shows superpowers topic
- [ ] Works in both bash and zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
