### PR TITLE
fix(ssh): use Windows absolute path for SSAI ops IdentityFile

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -1,41 +1,40 @@
 # Environment-specific configs (e.g., SSAI servers for internal PC)
 Include ~/.ssh/config.d/*
 
+# ==========================================
+# 1. Global Settings (공통 설정)
+# ==========================================
 Host *
-     PubkeyAcceptedKeyTypes +ssh-rsa
-     ServerAliveInterval 60
-     ServerAliveCountMax 3
-     ConnectTimeout 10
+    PubkeyAcceptedKeyTypes +ssh-rsa
+    ServerAliveInterval 60
+    ServerAliveCountMax 3
+    ConnectTimeout 10
 
+# ==========================================
+# 2. Corporate Gerrit & Git (삼성 내부 및 Gerrit)
+# ==========================================
 Host github.samsungds.net
-     User git
-     IdentityFile ~/.ssh/id_ed25519
-     IdentitiesOnly yes
-     ControlMaster auto
-     ControlPath ~/.ssh/control-%h-%p-%r
-     ControlPersist 600
-
-Host github.com
-     User git
-     IdentityFile ~/.ssh/id_ed25519
-     IdentitiesOnly yes
-     ConnectTimeout 5
-     Hostname ssh.github.com
-     Port 443
+    User git
+    IdentityFile ~/.ssh/id_ed25519
+    IdentitiesOnly yes
+    ControlMaster auto
+    ControlPath ~/.ssh/control-%h-%p-%r
+    ControlPersist 600
 
 Host Replica-Gerrit
-     HostName 10.166.101.44
-     Port 29418
-     User byoungwoo.yoon
-     PreferredAuthentications publickey
-     HostkeyAlgorithms +ssh-rsa
-     PubkeyAcceptedKeyTypes +ssh-rsa
+    HostName 10.166.101.44
+    Port 29418
+    User byoungwoo.yoon
+    PreferredAuthentications publickey
+    HostkeyAlgorithms +ssh-rsa
 
-Host 10.227.36.179
-     HostName 10.227.36.179
-     Port 29418
-     User byoungwoo.yoon
-     PreferredAuthentications publickey
-     KexAlgorithms diffie-hellman-group-exchange-sha256
-     HostkeyAlgorithms +ssh-rsa
-     PubkeyAcceptedKeyTypes +ssh-rsa
+# ==========================================
+# 3. Public GitHub (HTTPS over SSH)
+# ==========================================
+Host github.com
+    Hostname ssh.github.com
+    Port 443
+    User git
+    IdentityFile ~/.ssh/id_ed25519
+    IdentitiesOnly yes
+    ConnectTimeout 5

--- a/ssh/config.d/ssai.conf
+++ b/ssh/config.d/ssai.conf
@@ -1,25 +1,31 @@
 # ==========================================
-# 4. SSAI Project Servers (Internal PC only)
+# 4. SSAI Project Servers
 # ==========================================
 # Installed by: shell-common/setup.sh (environment: internal)
 # Symlink: ~/.ssh/config.d/ssai.conf -> dotfiles/ssh/config.d/ssai.conf
 
 # SSAI 개발 서버
-Host server-ssai-dev
-     HostName 12.81.221.129
-     User bwyoon
-     IdentityFile ~/.ssh/id_rsa_ssai_bwyoon
+Host ssai-dev
+    HostName 12.81.221.129
+    User bwyoon
 
-# SSAI 운영 서버 (공통 설정 활용)
-Host server-ssai-ops-*
-     HostName 12.81.221.140
-     IdentityFile ~/.ssh/id_rsa_ssai_bwyoon
+# SSAI 운영 서버 (개인 계정)
+Host ssai-ops
+    HostName 12.81.221.140
+    User bwyoon
 
+# SSAI 운영 서버 (공유 및 역할 계정)
 Host server-ssai-ops-devops
-     User devops
+    HostName 12.81.221.140
+    User devops
+    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 Host server-ssai-ops-jiravis
-     User jiravis
+    HostName 12.81.221.140
+    User jiravis
+    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 Host server-ssai-ops-bwyoon
-     User bwyoon
+    HostName 12.81.221.140
+    User bwyoon
+    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon

--- a/ssh/config.d/ssai.conf
+++ b/ssh/config.d/ssai.conf
@@ -8,24 +8,23 @@
 Host ssai-dev
     HostName 12.81.221.129
     User bwyoon
+    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
+
+# SSAI 운영 서버 공통 설정
+Host ssai-ops server-ssai-ops-*
+    HostName 12.81.221.140
+    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 # SSAI 운영 서버 (개인 계정)
 Host ssai-ops
-    HostName 12.81.221.140
     User bwyoon
 
 # SSAI 운영 서버 (공유 및 역할 계정)
 Host server-ssai-ops-devops
-    HostName 12.81.221.140
     User devops
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 Host server-ssai-ops-jiravis
-    HostName 12.81.221.140
     User jiravis
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 Host server-ssai-ops-bwyoon
-    HostName 12.81.221.140
     User bwyoon
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon


### PR DESCRIPTION
## Summary
- Gemini 리뷰 반영으로 변경한 portable `~/.ssh` 경로가 사내 PC VSCode Remote SSH에서 동작하지 않아, SSAI 운영서버 IdentityFile을 Windows 절대경로(`C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon`)로 변경
- SSAI Host 별칭 단순화: `server-ssai-dev` → `ssai-dev`, `server-ssai-ops` → `ssai-ops`
- 미사용 `Host 10.227.36.179` 섹션 제거 및 config 포맷 정리

## Test plan
- [ ] 사내 PC VSCode에서 `ssai-dev`, `ssai-ops` Remote SSH 접속 확인
- [ ] `server-ssai-ops-devops`, `server-ssai-ops-jiravis`, `server-ssai-ops-bwyoon` 접속 확인
- [ ] `github.com`, `github.samsungds.net` SSH 연결 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
