### PR TITLE
fix(ssh): optimize Host priority and consolidate SSAI config

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -2,16 +2,7 @@
 Include ~/.ssh/config.d/*
 
 # ==========================================
-# 1. Global Settings (공통 설정)
-# ==========================================
-Host *
-    PubkeyAcceptedKeyTypes +ssh-rsa
-    ServerAliveInterval 60
-    ServerAliveCountMax 3
-    ConnectTimeout 10
-
-# ==========================================
-# 2. Corporate Gerrit & Git (삼성 내부 및 Gerrit)
+# 1. Corporate Gerrit & Git (삼성 내부 및 Gerrit)
 # ==========================================
 Host github.samsungds.net
     User git
@@ -29,7 +20,7 @@ Host Replica-Gerrit
     HostkeyAlgorithms +ssh-rsa
 
 # ==========================================
-# 3. Public GitHub (HTTPS over SSH)
+# 2. Public GitHub (HTTPS over SSH)
 # ==========================================
 Host github.com
     Hostname ssh.github.com
@@ -38,3 +29,12 @@ Host github.com
     IdentityFile ~/.ssh/id_ed25519
     IdentitiesOnly yes
     ConnectTimeout 5
+
+# ==========================================
+# 3. Global Settings (최하단 배치 - first match wins)
+# ==========================================
+Host *
+    PubkeyAcceptedKeyTypes +ssh-rsa
+    ServerAliveInterval 60
+    ServerAliveCountMax 3
+    ConnectTimeout 10

--- a/ssh/config.d/ssai.conf
+++ b/ssh/config.d/ssai.conf
@@ -4,16 +4,19 @@
 # Installed by: shell-common/setup.sh (environment: internal)
 # Symlink: ~/.ssh/config.d/ssai.conf -> dotfiles/ssh/config.d/ssai.conf
 
+# SSAI 프로젝트 공통 설정 (IdentityFile 통합 관리)
+Host ssai-* server-ssai-*
+    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
+    IdentitiesOnly yes
+
 # SSAI 개발 서버
 Host ssai-dev
     HostName 12.81.221.129
     User bwyoon
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 # SSAI 운영 서버 공통 설정
 Host ssai-ops server-ssai-ops-*
     HostName 12.81.221.140
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
 
 # SSAI 운영 서버 (개인 계정)
 Host ssai-ops


### PR DESCRIPTION
## Summary
- Host * to bottom (fix ConnectTimeout 5 being ignored)
- Consolidate SSAI IdentityFile into ssai-* server-ssai-* wildcard
- Add IdentitiesOnly yes for SSAI servers

## Test plan
- [ ] ssh -G github.com connecttimeout = 5
- [ ] ssh -G ssai-dev identityfile check
- [ ] VSCode Remote SSH test on internal PC

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
