### PR TITLE
fix(skill): correct teardown preflight check

### DIFF
--- a/claude/skills/ai-worktree-teardown/references/bash-commands.md
+++ b/claude/skills/ai-worktree-teardown/references/bash-commands.md
@@ -65,12 +65,11 @@ preflight_check() {
     fi
   fi
 
-  # Unpushed commits
-  local local_rev remote_rev
-  local_rev="$(git -C "$worktree_path" rev-parse HEAD)"
-  remote_rev="$(git -C "$worktree_path" rev-parse @{u} 2>/dev/null || echo "no-upstream")"
+  # Unpushed commits (only commits in HEAD that are NOT in upstream)
+  local unpushed
+  unpushed="$(git -C "$worktree_path" log --oneline @{u}..HEAD 2>/dev/null)"
 
-  if [[ "$remote_rev" != "no-upstream" && "$local_rev" != "$remote_rev" ]]; then
+  if [[ -n "$unpushed" ]]; then
     if [[ "$force" == true ]]; then
       echo "Warning: Discarding unpushed commits (--force)"
     else


### PR DESCRIPTION
## Summary
- Fix false-positive "unpushed commits" warning in `ai-worktree-teardown` pre-flight check
- Replace `HEAD != @{u}` comparison with `@{u}..HEAD` range to only detect commits ahead of upstream
- Previous logic also triggered when upstream was ahead (e.g., after PR merge advances `origin/main`)

## Test plan
- [ ] Run `/ai-worktree-teardown` on a worktree whose PR is already merged — should not warn about unpushed commits
- [ ] Run on a worktree with actual unpushed commits — should still block correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
