### PR TITLE
fix(gwt): friendly error when teardown receives a path arg

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -473,7 +473,17 @@ git_worktree_teardown() {
                 ;;
             --force) force=true; shift ;;
             --keep-branch) keep_branch=true; shift ;;
-            *) ux_error "Unknown option: $1. Use --help for usage."; return 1 ;;
+            -*)
+                ux_error "Unknown option: $1. Use --help for usage."
+                return 1
+                ;;
+            *)
+                ux_error "'gwt teardown' is a self-cleanup command (run from inside a worktree)."
+                ux_info "  It does not accept a path argument."
+                ux_info "  To remove a specific worktree by path, use:"
+                ux_info "    gwt remove $1"
+                return 1
+                ;;
         esac
     done
 


### PR DESCRIPTION
## Summary

- `gwt teardown` is a **cwd-based self-cleanup** command — it only accepts `--force` / `--keep-branch` flags. But users naturally type `gwt teardown <path>` (especially after `gwt ls` prints the hint `To remove: gwt remove [path]`), and the old parser rejected the path with `"Unknown option: /home/..."`, which gave no clue about the actual design or the right alternative.
- Split the parser's default case in `git_worktree_teardown` into `-*)` (unknown flag — original message preserved) and `*)` (positional arg — new friendly error that explains self-cleanup and suggests `gwt remove <user's path>` with the path echoed back so it's copy-paste ready).
- No behavior change for `--force`, `--keep-branch`, `--help`, or unknown flags.

### Before

\`\`\`
$ gwt teardown /home/bwyoon/para/archive/playbook-knox-blog
❌ Unknown option: /home/bwyoon/para/archive/playbook-knox-blog. Use --help for usage.
\`\`\`

### After

\`\`\`
$ gwt teardown /home/bwyoon/para/archive/playbook-knox-blog
❌ 'gwt teardown' is a self-cleanup command (run from inside a worktree).
ℹ️    It does not accept a path argument.
ℹ️    To remove a specific worktree by path, use:
ℹ️      gwt remove /home/bwyoon/para/archive/playbook-knox-blog
\`\`\`

## Why this matters

Good CLI error messages answer three questions: (1) what went wrong, (2) **why** it's wrong (design intent), (3) **what to do instead**. The old message answered only (1). The new message covers all three and — crucially — echoes the user's path back inside the suggested command so the fix is one copy-paste away.

## Test plan

Verified locally by sourcing the function and exercising four input shapes:

- [x] Positional absolute path → new friendly error, exit 1
- [x] Positional relative path (`../some/worktree`) → new friendly error, exit 1
- [x] Unknown flag (`--bogus`) → original `Unknown option: --bogus` message, exit 1 (regression guard)
- [x] `--help` → unchanged help output, exit 0
- [x] shellcheck on the edited region (lines 463–488): no new warnings
- [x] pre-commit hook (pipe-loop / zsh-emulation checks): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
