### PR TITLE
feat(skills): add gh:* workflow skills with progressive disclosure

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: gh:commit
+description: >-
+  Create a git commit for the current changes following the repo's style,
+  auto-linking a GitHub issue number if it appears in the recent conversation
+  or is passed as an argument. Use when the user runs /gh:commit, /gh-commit,
+  or asks "커밋해", "지금까지 작업 커밋", "이슈 N번 연결해서 커밋". Creates a new
+  commit — never amends. Never skips hooks.
+allowed-tools: Bash, Read, Grep
+---
+
+# gh:commit — Git Commit with Issue Linking
+
+## Role
+
+Stage the relevant changes and create a new git commit that follows the
+repository's existing commit style, with an optional `Refs #N` / `Closes #N`
+footer when a GitHub issue is known.
+
+## Step 1: Inspect State (parallel)
+
+Run these in a single message:
+- `git status` (never `-uall`)
+- `git diff` (staged + unstaged)
+- `git diff --staged` if anything is already staged
+- `git log --oneline -20` — mimic the repo's commit message style
+
+## Step 2: Resolve the Issue Number
+
+Check in this order and use the first hit:
+
+1. **Explicit argument** — if the user said `/gh:commit 123` or mentioned
+   "이슈 123번 연결" in their latest message.
+2. **Recent conversation** — scan the last ~10 messages for `#N` or
+   "Issue #N created" (gh:issue's output format). If found, use it.
+3. **None** — skip the footer. Do NOT invent an issue number.
+
+## Step 3: Draft the Commit Message
+
+Follow the repo's style (derived from `git log`). Typical structure:
+
+```
+<type>(<scope>): <concise summary in imperative mood>
+
+<body explaining the WHY, not the WHAT — the diff shows the what>
+
+Refs #<N>        ← only if issue number resolved
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+Rules:
+- **Why, not what** — the diff already shows what changed.
+- Match the repo's conventions: if recent commits use `feat:`/`fix:`, follow
+  suit; if they use plain sentences, follow that.
+- Use `Closes #N` only if the commit fully resolves the issue; otherwise
+  `Refs #N`.
+- If the change is a bug fix for a tracked issue, prefer `Fixes #N`.
+
+## Step 4: Stage and Commit
+
+- Stage only the files relevant to this commit. Prefer listing files by name
+  over `git add -A` / `git add .` to avoid sweeping in secrets or unrelated
+  changes.
+- Never stage files that look like secrets (`.env`, `credentials.json`, keys).
+  If the diff touches such files, stop and warn the user.
+- Commit using HEREDOC to preserve formatting:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <summary>
+
+<body>
+
+Refs #<N>
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- **NEVER** use `--amend` unless the user explicitly asked.
+- **NEVER** use `--no-verify` / `--no-gpg-sign`. If a pre-commit hook fails,
+  fix the underlying issue, re-stage, and create a **new** commit.
+
+## Step 5: Verify
+
+After commit succeeds, run `git status` and report:
+
+```
+Committed <short-hash>: <subject line>
+```
+
+If an issue was linked, mention the issue number on a second line.
+
+## Constraints
+
+- One commit per invocation by default. If the diff is clearly two unrelated
+  changes, ask the user whether to split before staging.
+- Never push. `/gh:pr` handles pushing.
+- Never create empty commits.
+- Never edit git config.

--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -37,49 +37,20 @@ Check in this order and use the first hit:
 
 ## Step 3: Draft the Commit Message
 
-Follow the repo's style (derived from `git log`). Typical structure:
-
-```
-<type>(<scope>): <concise summary in imperative mood>
-
-<body explaining the WHY, not the WHAT — the diff shows the what>
-
-Refs #<N>        ← only if issue number resolved
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
-```
-
-Rules:
-- **Why, not what** — the diff already shows what changed.
-- Match the repo's conventions: if recent commits use `feat:`/`fix:`, follow
-  suit; if they use plain sentences, follow that.
-- Use `Closes #N` only if the commit fully resolves the issue; otherwise
-  `Refs #N`.
-- If the change is a bug fix for a tracked issue, prefer `Fixes #N`.
+Read `references/commit-message-format.md` for the message template, HEREDOC
+pattern, and `Closes` / `Refs` / `Fixes` rules. Match the repo's commit style
+derived from `git log`.
 
 ## Step 4: Stage and Commit
 
-- Stage only the files relevant to this commit. Prefer listing files by name
-  over `git add -A` / `git add .` to avoid sweeping in secrets or unrelated
-  changes.
-- Never stage files that look like secrets (`.env`, `credentials.json`, keys).
-  If the diff touches such files, stop and warn the user.
-- Commit using HEREDOC to preserve formatting:
-
-```bash
-git commit -m "$(cat <<'EOF'
-<type>(<scope>): <summary>
-
-<body>
-
-Refs #<N>
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
-EOF
-)"
-```
-
+- Stage only files relevant to this commit. Prefer listing files by name over
+  `git add -A` / `git add .` to avoid sweeping in secrets or unrelated changes.
+- **Never stage files that look like secrets** (`.env`, `credentials.json`,
+  keys). If the diff touches such files, stop and warn the user.
 - **NEVER** use `--amend` unless the user explicitly asked.
 - **NEVER** use `--no-verify` / `--no-gpg-sign`. If a pre-commit hook fails,
   fix the underlying issue, re-stage, and create a **new** commit.
+- See `references/commit-message-format.md` for the exact HEREDOC command.
 
 ## Step 5: Verify
 

--- a/claude/skills/gh-commit/references/commit-message-format.md
+++ b/claude/skills/gh-commit/references/commit-message-format.md
@@ -1,0 +1,42 @@
+# Commit Message Format — for gh:commit skill
+
+Details of the commit message structure, footer conventions, and the HEREDOC commit command used by the `gh:commit` skill.
+
+## Structure Template
+
+```
+<type>(<scope>): <concise summary in imperative mood>
+
+<body explaining the WHY, not the WHAT — the diff shows the what>
+
+Refs #<N>        ← only if issue number resolved
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+## Rules
+
+- **Why, not what** — the diff already shows what changed. The body explains motivation, trade-offs, and context.
+- **Match the repo's conventions** — if recent commits use `feat:` / `fix:` prefixes, follow suit; if they use plain sentences, follow that. Derive style from `git log --oneline -20`.
+- **Issue footer selection**:
+  - `Closes #N` — only when the commit fully resolves the issue.
+  - `Fixes #N` — preferred when the change is a bug fix for a tracked issue.
+  - `Refs #N` — partial progress, or a reference without closing.
+- Omit the footer entirely if no issue number was resolved. Never invent one.
+
+## HEREDOC Commit Command
+
+Always commit using HEREDOC to preserve multi-line formatting:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <summary>
+
+<body>
+
+Refs #<N>
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Use single-quoted `'EOF'` to prevent shell expansion inside the message body.

--- a/claude/skills/gh-issue/SKILL.md
+++ b/claude/skills/gh-issue/SKILL.md
@@ -52,10 +52,13 @@ abbreviate the discussion log to 2–3 bullets.
 
 ## Step 4: Create the Issue
 
-Write the body to a temp file (to avoid shell escaping issues), then:
+Write the body to a unique temp file via `mktemp` (avoids shell escaping
+issues and concurrent-run collisions), then:
 
 ```bash
-gh issue create --title "<title>" --body-file /tmp/gh-issue-body.md
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write the drafted body to "$BODY" ...
+gh issue create --title "<title>" --body-file "$BODY"
 ```
 
 Do NOT add `--assignee`, `--label`, or `--milestone` unless the user explicitly

--- a/claude/skills/gh-issue/SKILL.md
+++ b/claude/skills/gh-issue/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: gh:issue
+description: >-
+  Save the current conversation as a GitHub issue in the current repository.
+  Use when the user runs /gh:issue, /gh-issue, or asks to "이 대화 이슈로 등록",
+  "chat을 깃허브 이슈로 남겨", "기록용 이슈 만들어". Summarizes the conversation so
+  far into a structured issue body (feature request / error analysis / misc),
+  creates it via `gh issue create` on the current repo's origin without asking
+  for confirmation, and prints only the issue number and URL. Do NOT over-
+  compress — the issue is reused for PR drafts and blog posts, so preserve
+  reasoning, decisions, and concrete details.
+allowed-tools: Bash, Read, Grep
+---
+
+# gh:issue — Conversation → GitHub Issue
+
+## Role
+
+Convert the current chat into a well-structured GitHub issue on the current
+repo's origin. Execute immediately without confirmation. Print only the issue
+number + URL at the end — the user will open GitHub directly.
+
+## Step 1: Detect Repo Context
+
+Run in parallel:
+- `git rev-parse --show-toplevel` — confirm we're in a git repo
+- `gh repo view --json nameWithOwner -q .nameWithOwner` — get owner/repo
+
+If either fails, stop and tell the user the skill requires a git repo with a
+GitHub remote configured.
+
+## Step 2: Classify the Conversation
+
+Pick exactly one category based on the dominant intent of the chat:
+
+- **feature** — 신규 기능 요청, 개선 제안, 리팩토링 아이디어
+- **bug** — 에러 로그 분석, 버그 재현, 원인 추적
+- **misc** — 질문/논의/조사/문서화 등 위 두 가지에 속하지 않는 것
+
+The category determines the title prefix and section layout below.
+
+## Step 3: Draft the Issue Body
+
+**DO NOT over-compress.** This issue is reused later for PR descriptions and
+blog posts. Preserve concrete file paths, command outputs, decisions, and
+reasoning. A 200-line issue is fine if the conversation warranted it.
+
+Write the body in the language the user was speaking (Korean for Korean chats).
+
+### Title format
+- feature: `[Feature] <구체적인 한 줄 요약>`
+- bug: `[Bug] <증상 한 줄 요약>`
+- misc: `[Misc] <주제 한 줄 요약>`
+
+### Body structure (feature)
+```markdown
+## Context
+<왜 이 기능이 필요한가 — 사용자가 말한 배경/동기>
+
+## Proposal
+<무엇을 만들 것인가 — 요구사항 목록>
+
+## Discussion Log
+<대화에서 오간 의사결정, 대안 검토, 네이밍 논의 등 원문에 가깝게>
+
+## Open Questions
+<아직 결정 안 된 것, 확인 필요한 것>
+
+## References
+- 관련 파일: `path/to/file.ext`
+- 관련 이슈/PR: (있으면)
+```
+
+### Body structure (bug)
+```markdown
+## Symptom
+<에러 메시지, 실패 증상>
+
+## Reproduction
+<재현 절차 — 대화에서 나온 명령, 환경>
+
+## Root Cause Analysis
+<원인 추적 과정과 결론>
+
+## Fix Plan
+<수정 방향 — 아직 수정 안 했으면 계획만>
+
+## Logs / Evidence
+<로그 발췌, 파일 위치 등>
+```
+
+### Body structure (misc)
+```markdown
+## Topic
+<대화 주제>
+
+## Summary
+<논의된 내용 정리>
+
+## Decisions
+<도출된 결론>
+
+## Notes
+<추가 맥락>
+```
+
+## Step 4: Create the Issue
+
+Write the body to a temp file (to avoid shell escaping issues), then:
+
+```bash
+gh issue create --title "<title>" --body-file /tmp/gh-issue-body.md
+```
+
+Do NOT add `--assignee`, `--label`, or `--milestone` unless the user explicitly
+asked. Do NOT ask for confirmation — run it immediately.
+
+## Step 5: Report
+
+Output **only** the issue number and URL, nothing else:
+
+```
+Issue #123 created: https://github.com/owner/repo/issues/123
+```
+
+No summary, no "I created...", no markdown headings. The user checks GitHub
+directly.
+
+## Constraints
+
+- Never use `--assignee @me` or labels unless the user asked.
+- Never create the issue on a different repo than the current `origin`.
+- Never abbreviate the discussion log to 2–3 bullets — preserve detail.
+- Never ask "should I create it?" — the user already said yes by running the
+  skill.

--- a/claude/skills/gh-issue/SKILL.md
+++ b/claude/skills/gh-issue/SKILL.md
@@ -37,72 +37,18 @@ Pick exactly one category based on the dominant intent of the chat:
 - **bug** — 에러 로그 분석, 버그 재현, 원인 추적
 - **misc** — 질문/논의/조사/문서화 등 위 두 가지에 속하지 않는 것
 
-The category determines the title prefix and section layout below.
+The category determines the title prefix and section layout.
 
 ## Step 3: Draft the Issue Body
 
+Read `references/issue-body-templates.md` and select the title format + body
+structure matching the category from Step 2. Write the body in the language
+the user was speaking (Korean for Korean chats).
+
 **DO NOT over-compress.** This issue is reused later for PR descriptions and
 blog posts. Preserve concrete file paths, command outputs, decisions, and
-reasoning. A 200-line issue is fine if the conversation warranted it.
-
-Write the body in the language the user was speaking (Korean for Korean chats).
-
-### Title format
-- feature: `[Feature] <구체적인 한 줄 요약>`
-- bug: `[Bug] <증상 한 줄 요약>`
-- misc: `[Misc] <주제 한 줄 요약>`
-
-### Body structure (feature)
-```markdown
-## Context
-<왜 이 기능이 필요한가 — 사용자가 말한 배경/동기>
-
-## Proposal
-<무엇을 만들 것인가 — 요구사항 목록>
-
-## Discussion Log
-<대화에서 오간 의사결정, 대안 검토, 네이밍 논의 등 원문에 가깝게>
-
-## Open Questions
-<아직 결정 안 된 것, 확인 필요한 것>
-
-## References
-- 관련 파일: `path/to/file.ext`
-- 관련 이슈/PR: (있으면)
-```
-
-### Body structure (bug)
-```markdown
-## Symptom
-<에러 메시지, 실패 증상>
-
-## Reproduction
-<재현 절차 — 대화에서 나온 명령, 환경>
-
-## Root Cause Analysis
-<원인 추적 과정과 결론>
-
-## Fix Plan
-<수정 방향 — 아직 수정 안 했으면 계획만>
-
-## Logs / Evidence
-<로그 발췌, 파일 위치 등>
-```
-
-### Body structure (misc)
-```markdown
-## Topic
-<대화 주제>
-
-## Summary
-<논의된 내용 정리>
-
-## Decisions
-<도출된 결론>
-
-## Notes
-<추가 맥락>
-```
+reasoning. A 200-line issue is fine if the conversation warranted it. Never
+abbreviate the discussion log to 2–3 bullets.
 
 ## Step 4: Create the Issue
 

--- a/claude/skills/gh-issue/references/issue-body-templates.md
+++ b/claude/skills/gh-issue/references/issue-body-templates.md
@@ -1,0 +1,60 @@
+# Issue Body Templates — for gh:issue skill
+
+Title format and body structures for the three issue categories (feature / bug / misc). Select the template matching the category chosen in Step 2.
+
+## Title format
+- feature: `[Feature] <구체적인 한 줄 요약>`
+- bug: `[Bug] <증상 한 줄 요약>`
+- misc: `[Misc] <주제 한 줄 요약>`
+
+## Body structure (feature)
+```markdown
+## Context
+<왜 이 기능이 필요한가 — 사용자가 말한 배경/동기>
+
+## Proposal
+<무엇을 만들 것인가 — 요구사항 목록>
+
+## Discussion Log
+<대화에서 오간 의사결정, 대안 검토, 네이밍 논의 등 원문에 가깝게>
+
+## Open Questions
+<아직 결정 안 된 것, 확인 필요한 것>
+
+## References
+- 관련 파일: `path/to/file.ext`
+- 관련 이슈/PR: (있으면)
+```
+
+## Body structure (bug)
+```markdown
+## Symptom
+<에러 메시지, 실패 증상>
+
+## Reproduction
+<재현 절차 — 대화에서 나온 명령, 환경>
+
+## Root Cause Analysis
+<원인 추적 과정과 결론>
+
+## Fix Plan
+<수정 방향 — 아직 수정 안 했으면 계획만>
+
+## Logs / Evidence
+<로그 발췌, 파일 위치 등>
+```
+
+## Body structure (misc)
+```markdown
+## Topic
+<대화 주제>
+
+## Summary
+<논의된 내용 정리>
+
+## Decisions
+<도출된 결론>
+
+## Notes
+<추가 맥락>
+```

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -16,41 +16,25 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ## Role
 
 Systematically process every code-review comment on a PR: judge validity,
-fix valid ones in code, and reply to each comment individually with the
-outcome. This is the politeness rule — reviewers must see an explicit
-response on every thread so they know their feedback was processed.
+fix valid ones, and reply to each comment with the outcome. This is the
+**politeness rule** — reviewers (humans and bots alike) must see an
+explicit response on every thread. Silent fixes are not acceptable;
+silent declines are worse.
 
 ## Step 1: Resolve Target PR
 
 Precedence:
 1. **Explicit argument** — `/gh:pr-reply 123` → PR #123
-2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`
-   - If no PR exists for the branch, stop and tell the user.
+2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`; if no PR exists for the branch, stop and tell the user.
 3. Never guess. Never pick "the latest PR in the repo".
 
 Also capture `owner/repo` via `gh repo view --json nameWithOwner`.
 
 ## Step 2: Fetch All Review Comments
 
-PRs have two distinct comment APIs — fetch **both**:
-
-```bash
-# Inline code review comments (line-anchored)
-gh api "repos/<owner>/<repo>/pulls/<N>/comments" --paginate
-
-# Top-level issue-style comments on the PR conversation
-gh api "repos/<owner>/<repo>/issues/<N>/comments" --paginate
-
-# Review summaries (bots often put content here)
-gh api "repos/<owner>/<repo>/pulls/<N>/reviews" --paginate
-```
-
-For each comment, record: `id`, `user.login`, `path`, `line`, `body`,
-`in_reply_to_id` (for threading), and `html_url`.
-
-**Filter out already-replied-to comments**: if a human or Claude has already
-posted a reply in the same thread (check `in_reply_to_id` chains), skip it
-unless the user explicitly says to re-process.
+Read `references/comment-fetching.md` for the three API endpoints, field
+extraction, and dedup rule. Fetch all three; filter out already-replied
+threads.
 
 ## Step 3: Evaluate Each Comment
 
@@ -66,75 +50,30 @@ classify:
   answer the question
 
 Bot comments (gemini-code-assist, sourcery-ai, copilot) follow the same
-rules — a bot nit about a rename is still a legitimate comment that deserves
-a reply.
+rules — a bot nit is still a legitimate comment that deserves a reply.
 
 ## Step 4: Apply Fixes (ACCEPT / ACCEPT-PARTIAL only)
 
-- Edit files with the Edit tool. Keep each fix minimal and scoped to the
-  comment — don't drive-by refactor.
-- Group related fixes into logical commits. If the user hasn't said otherwise,
-  make one commit per theme, not one commit per comment.
-- Commit message should reference the PR and the comment intent, e.g.:
-  `fix(review): address X as suggested in PR #123 review`
+- Keep each fix minimal and scoped — don't drive-by refactor.
+- Group related fixes into logical commits: one per theme, not one per
+  comment, unless the user says otherwise.
+- Commit message references the PR, e.g.
+  `fix(review): address X as suggested in PR #123 review`.
 - Never use `--amend` or `--no-verify`.
 
 ## Step 5: Reply to Every Comment
 
-This is non-negotiable. **Every** comment identified in Step 2 must receive
-a reply, even declined ones, even bot comments.
+**This is non-negotiable. Every comment identified in Step 2 must receive a
+reply, even declined ones, even bot comments.**
 
-### For inline review comments (Step 2's `/pulls/N/comments`)
-
-Reply in-thread:
-
-```bash
-gh api "repos/<owner>/<repo>/pulls/<N>/comments/<comment_id>/replies" \
-  -X POST \
-  -f body="<reply text>"
-```
-
-### For top-level issue comments
-
-```bash
-gh api "repos/<owner>/<repo>/issues/<N>/comments" \
-  -X POST \
-  -f body="> <blockquote of original>
-
-<reply text>"
-```
-
-### Reply body templates
-
-**Accepted:**
-```
-Accepted. Fixed in <short-sha> — <one-line what changed>.
-```
-
-**Accepted with deviation:**
-```
-Accepted with modification. Rather than <their suggestion>, I went with
-<actual fix> in <short-sha> because <reason>.
-```
-
-**Declined:**
-```
-Declined. <specific reason tied to the code/context>. <optional: pointer to
-docs, other PR, or file that justifies the current design>.
-```
-
-**Question answered:**
-```
-<direct answer>. <optional: link to file:line for reference>.
-```
-
-Reply in the language the reviewer used (Korean reviewer → Korean reply).
+Read `references/reply-templates.md` for POST command shapes (inline thread
+vs top-level) and the four body templates (Accepted / Accepted-with-modification
+/ Declined / Question). Reply in the reviewer's language.
 
 ## Step 6: Push the Fix Commits
 
-If any fixes were committed:
-- `git push` (never force-push unless user asked)
-- Report new commit SHAs alongside the reply summary
+If any fixes were committed: `git push` (never force-push unless the user
+asked) and report new commit SHAs alongside the reply summary.
 
 ## Step 7: Report
 
@@ -142,10 +81,10 @@ Print a table the user can scan:
 
 ```
 PR #123 review comments processed: 5 total
-  ✓ Accepted: 3 (commits abc1234, def5678)
-  ✗ Declined: 1
-  ? Answered: 1
-  → All comments replied to.
+  Accepted: 3 (commits abc1234, def5678)
+  Declined: 1
+  Answered: 1
+  -> All comments replied to.
 ```
 
 If any comments were skipped as "already replied", list them at the bottom.
@@ -153,7 +92,7 @@ If any comments were skipped as "already replied", list them at the bottom.
 ## Constraints
 
 - **Never skip a reply.** Even a one-line "Declined: out of scope" is
-  required. This is the core contract of the skill.
+  required. This is the core contract of the skill — bot comments included.
 - Never close or resolve threads programmatically — leave that to the user.
 - Never dismiss bot comments as "just a bot". Reply to them too.
 - Never fix comments that touch files outside the PR's diff without

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: gh:pr-reply
+description: >-
+  Fetch code review comments on a GitHub PR, evaluate each one, apply valid
+  fixes, and leave an individual reply on every comment (Accepted with what
+  changed, or Declined with reasoning). Use when the user runs /gh:pr-reply,
+  /gh-pr-reply, or asks "PR 리뷰 코멘트 확인하고 수정", "리뷰 답변 달아", "PR 123
+  코멘트 처리해". Defaults to the PR for the current branch; accepts an explicit
+  PR number as an argument. Every comment MUST get a reply — bot comments
+  (gemini, sourcery, copilot) included.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+# gh:pr-reply — Address PR Review Comments
+
+## Role
+
+Systematically process every code-review comment on a PR: judge validity,
+fix valid ones in code, and reply to each comment individually with the
+outcome. This is the politeness rule — reviewers must see an explicit
+response on every thread so they know their feedback was processed.
+
+## Step 1: Resolve Target PR
+
+Precedence:
+1. **Explicit argument** — `/gh:pr-reply 123` → PR #123
+2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`
+   - If no PR exists for the branch, stop and tell the user.
+3. Never guess. Never pick "the latest PR in the repo".
+
+Also capture `owner/repo` via `gh repo view --json nameWithOwner`.
+
+## Step 2: Fetch All Review Comments
+
+PRs have two distinct comment APIs — fetch **both**:
+
+```bash
+# Inline code review comments (line-anchored)
+gh api "repos/<owner>/<repo>/pulls/<N>/comments" --paginate
+
+# Top-level issue-style comments on the PR conversation
+gh api "repos/<owner>/<repo>/issues/<N>/comments" --paginate
+
+# Review summaries (bots often put content here)
+gh api "repos/<owner>/<repo>/pulls/<N>/reviews" --paginate
+```
+
+For each comment, record: `id`, `user.login`, `path`, `line`, `body`,
+`in_reply_to_id` (for threading), and `html_url`.
+
+**Filter out already-replied-to comments**: if a human or Claude has already
+posted a reply in the same thread (check `in_reply_to_id` chains), skip it
+unless the user explicitly says to re-process.
+
+## Step 3: Evaluate Each Comment
+
+For each unaddressed comment, read the referenced file (`path` at `line`) and
+classify:
+
+- **ACCEPT** — reviewer is correct; the code should change
+- **ACCEPT-PARTIAL** — valid concern, but a different fix is better; note the
+  deviation in the reply
+- **DECLINE** — reviewer is wrong, misunderstanding the context, or the
+  suggestion would regress something; must explain why
+- **QUESTION** — reviewer asked for clarification rather than a change;
+  answer the question
+
+Bot comments (gemini-code-assist, sourcery-ai, copilot) follow the same
+rules — a bot nit about a rename is still a legitimate comment that deserves
+a reply.
+
+## Step 4: Apply Fixes (ACCEPT / ACCEPT-PARTIAL only)
+
+- Edit files with the Edit tool. Keep each fix minimal and scoped to the
+  comment — don't drive-by refactor.
+- Group related fixes into logical commits. If the user hasn't said otherwise,
+  make one commit per theme, not one commit per comment.
+- Commit message should reference the PR and the comment intent, e.g.:
+  `fix(review): address X as suggested in PR #123 review`
+- Never use `--amend` or `--no-verify`.
+
+## Step 5: Reply to Every Comment
+
+This is non-negotiable. **Every** comment identified in Step 2 must receive
+a reply, even declined ones, even bot comments.
+
+### For inline review comments (Step 2's `/pulls/N/comments`)
+
+Reply in-thread:
+
+```bash
+gh api "repos/<owner>/<repo>/pulls/<N>/comments/<comment_id>/replies" \
+  -X POST \
+  -f body="<reply text>"
+```
+
+### For top-level issue comments
+
+```bash
+gh api "repos/<owner>/<repo>/issues/<N>/comments" \
+  -X POST \
+  -f body="> <blockquote of original>
+
+<reply text>"
+```
+
+### Reply body templates
+
+**Accepted:**
+```
+Accepted. Fixed in <short-sha> — <one-line what changed>.
+```
+
+**Accepted with deviation:**
+```
+Accepted with modification. Rather than <their suggestion>, I went with
+<actual fix> in <short-sha> because <reason>.
+```
+
+**Declined:**
+```
+Declined. <specific reason tied to the code/context>. <optional: pointer to
+docs, other PR, or file that justifies the current design>.
+```
+
+**Question answered:**
+```
+<direct answer>. <optional: link to file:line for reference>.
+```
+
+Reply in the language the reviewer used (Korean reviewer → Korean reply).
+
+## Step 6: Push the Fix Commits
+
+If any fixes were committed:
+- `git push` (never force-push unless user asked)
+- Report new commit SHAs alongside the reply summary
+
+## Step 7: Report
+
+Print a table the user can scan:
+
+```
+PR #123 review comments processed: 5 total
+  ✓ Accepted: 3 (commits abc1234, def5678)
+  ✗ Declined: 1
+  ? Answered: 1
+  → All comments replied to.
+```
+
+If any comments were skipped as "already replied", list them at the bottom.
+
+## Constraints
+
+- **Never skip a reply.** Even a one-line "Declined: out of scope" is
+  required. This is the core contract of the skill.
+- Never close or resolve threads programmatically — leave that to the user.
+- Never dismiss bot comments as "just a bot". Reply to them too.
+- Never fix comments that touch files outside the PR's diff without
+  flagging it to the user first — that's scope creep.
+- Never `--force-push`. If a fix needs history rewrite, stop and ask.

--- a/claude/skills/gh-pr-reply/references/comment-fetching.md
+++ b/claude/skills/gh-pr-reply/references/comment-fetching.md
@@ -29,9 +29,32 @@ gh api "repos/<owner>/<repo>/pulls/<N>/reviews" --paginate
 
 ## Deduplication rule
 
-Skip threads where a human or Claude has already posted a reply. Check the
-`in_reply_to_id` chains: if any descendant in the thread is authored by the
-current user or by Claude, treat the thread as already addressed.
+Skip a thread only if the **latest** comment in the thread is authored by
+the current user or by Claude. This allows the skill to respond when a
+reviewer leaves a follow-up comment after a previous Claude reply.
+
+Algorithm:
+1. Build threads by chaining `in_reply_to_id` from each comment back to its
+   root (comments with `in_reply_to_id == null`).
+2. For each thread, sort descendants by `created_at`.
+3. Look at the last (most recent) comment. If its `user.login` is the
+   current user or Claude, skip the thread. Otherwise process it.
 
 Exception: if the user explicitly asks to re-process, ignore this filter and
 reply to everything fresh.
+
+## Review summaries
+
+`/pulls/<N>/reviews` entries have no line anchor and no `replies` sub-resource.
+Handle each review summary as follows:
+
+- **Actionable content** (reviewer wrote a critical concern in the summary
+  body itself, not just linking to inline comments): post a new top-level
+  issue comment that blockquotes the review summary and addresses it, using
+  the top-level reply shape from `reply-templates.md`.
+- **Meta content** (summary just recaps the inline comments, or is a service
+  notice like "your repo doesn't have access to X"): no reply needed; note
+  it in the Step 7 report as "skipped (meta summary)".
+
+Judgment: if deleting the summary would lose information not already
+captured in an inline comment, it is actionable.

--- a/claude/skills/gh-pr-reply/references/comment-fetching.md
+++ b/claude/skills/gh-pr-reply/references/comment-fetching.md
@@ -1,0 +1,37 @@
+# Comment Fetching — for gh:pr-reply skill
+
+PRs expose review feedback through three distinct API endpoints — all must be
+queried. Missing any one of them means missing comments (bots especially tend
+to scatter content across these endpoints).
+
+## The three endpoints
+
+```bash
+# Inline code review comments (line-anchored)
+gh api "repos/<owner>/<repo>/pulls/<N>/comments" --paginate
+
+# Top-level issue-style comments on the PR conversation
+gh api "repos/<owner>/<repo>/issues/<N>/comments" --paginate
+
+# Review summaries (bots often put content here)
+gh api "repos/<owner>/<repo>/pulls/<N>/reviews" --paginate
+```
+
+## Fields to extract per comment
+
+- `id` — comment identifier (needed for replying)
+- `user.login` — author (including bots: gemini-code-assist, sourcery-ai, copilot)
+- `path` — file the comment is anchored to (inline comments only)
+- `line` — line number in the file (inline comments only)
+- `body` — comment text
+- `in_reply_to_id` — parent comment id, for threading
+- `html_url` — link back to the comment on GitHub
+
+## Deduplication rule
+
+Skip threads where a human or Claude has already posted a reply. Check the
+`in_reply_to_id` chains: if any descendant in the thread is authored by the
+current user or by Claude, treat the thread as already addressed.
+
+Exception: if the user explicitly asks to re-process, ignore this filter and
+reply to everything fresh.

--- a/claude/skills/gh-pr-reply/references/reply-templates.md
+++ b/claude/skills/gh-pr-reply/references/reply-templates.md
@@ -19,15 +19,24 @@ gh api "repos/<owner>/<repo>/pulls/<N>/comments/<comment_id>/replies" \
 ### Top-level issue comment (from `/issues/<N>/comments`)
 
 No thread reply endpoint exists; post a new issue comment that blockquotes
-the original so the context is clear:
+the original so the context is clear. **Every line of the original must be
+prefixed with `> ` individually** — a single `> ` only quotes the first
+line in GitHub-flavored Markdown.
 
 ```bash
+# Build a properly quoted blockquote from the original body
+QUOTED=$(printf '%s\n' "$ORIGINAL_BODY" | sed 's/^/> /')
+
 gh api "repos/<owner>/<repo>/issues/<N>/comments" \
   -X POST \
-  -f body="> <blockquote of original>
+  -f body="$QUOTED
 
 <reply text>"
 ```
+
+The same pattern applies when replying to a review summary from
+`/pulls/<N>/reviews`: there is no per-review reply endpoint, so post a
+top-level issue comment that blockquotes the review body and addresses it.
 
 ## Reply body templates
 

--- a/claude/skills/gh-pr-reply/references/reply-templates.md
+++ b/claude/skills/gh-pr-reply/references/reply-templates.md
@@ -1,0 +1,65 @@
+# Reply Templates — for gh:pr-reply skill
+
+Reply in the language the reviewer used. Korean reviewer → Korean reply.
+Japanese reviewer → Japanese reply. English reviewer → English reply. Match
+their register and tone (formal/informal) as well.
+
+## POST command shapes
+
+### Inline review comment (from `/pulls/<N>/comments`)
+
+Reply in-thread using the replies sub-resource:
+
+```bash
+gh api "repos/<owner>/<repo>/pulls/<N>/comments/<comment_id>/replies" \
+  -X POST \
+  -f body="<reply text>"
+```
+
+### Top-level issue comment (from `/issues/<N>/comments`)
+
+No thread reply endpoint exists; post a new issue comment that blockquotes
+the original so the context is clear:
+
+```bash
+gh api "repos/<owner>/<repo>/issues/<N>/comments" \
+  -X POST \
+  -f body="> <blockquote of original>
+
+<reply text>"
+```
+
+## Reply body templates
+
+### Accepted
+
+```
+Accepted. Fixed in <short-sha> — <one-line what changed>.
+```
+
+### Accepted with modification
+
+```
+Accepted with modification. Rather than <their suggestion>, I went with
+<actual fix> in <short-sha> because <reason>.
+```
+
+### Declined
+
+```
+Declined. <specific reason tied to the code/context>. <optional: pointer to
+docs, other PR, or file that justifies the current design>.
+```
+
+### Question answered
+
+```
+<direct answer>. <optional: link to file:line for reference>.
+```
+
+## Notes
+
+- Always include the commit short-sha for Accepted / Accepted-with-modification
+  replies — reviewers need a pointer to verify the fix.
+- Declined replies must state a concrete reason, never a dismissive one-liner.
+- Bot comments get the exact same templates — no shortcuts.

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -55,17 +55,28 @@ Read `references/pr-body-template.md` for title rules, body structure, and
 the `gh pr create` command. Match the language of existing commits (Korean
 if commits are Korean).
 
-## Step 5: Push and Create (parallel where possible)
+## Step 5: Push and Create
 
 - If no upstream: `git push -u origin HEAD`
 - If upstream exists and local is ahead: `git push`
 - If upstream is diverged: **stop and ask the user before force-pushing**
   (never force-push without explicit approval).
 
-Then write the body to a unique temp file via `mktemp` and run `gh pr create`
-as documented in `references/pr-body-template.md`.
+Write the body to a unique temp file via `mktemp`, then create the PR with
+`--assignee @me` (always self-assigned). Full command in
+`references/pr-body-template.md`.
 
-## Step 6: Report
+## Step 6: Apply Labels
+
+Derive labels from conventional-commit types in `git log <base>..HEAD`
+(`feat` → enhancement, `fix` → bug, `docs` → documentation, `refactor`,
+`style`, `perf`, `test`, `chore`, `ci`, `build`) plus judgment-based
+labels matching the PR scope (e.g., `skill` for `claude/skills/` changes).
+Query existing labels via `gh label list` and apply only labels that
+**already exist** in the repo — never create new labels. Details and the
+safe-application loop in `references/pr-body-template.md`.
+
+## Step 7: Report
 
 Output **only** the PR URL:
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: gh:pr
+description: >-
+  Create a GitHub pull request from the current branch, bundling all commits
+  since it diverged from the base branch. Use when the user runs /gh:pr,
+  /gh-pr, or asks "PR 생성", "풀리퀘 만들어", "지금까지 커밋들로 PR 올려". Pushes
+  the branch if needed, drafts a structured PR body covering every commit in
+  the range (not just HEAD), auto-links a related issue when known, and
+  returns only the PR URL.
+allowed-tools: Bash, Read, Grep
+---
+
+# gh:pr — Create Pull Request
+
+## Role
+
+Bundle the current branch's commits into a GitHub PR with a well-structured
+body. Push the branch if needed. Return the PR URL.
+
+## Step 1: Determine Base Branch and State (parallel)
+
+Run in a single message:
+- `git rev-parse --abbrev-ref HEAD` — current branch
+- `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` — base
+- `git status`
+- `git fetch origin` — refresh remote refs
+
+Then:
+- `git log --oneline <base>..HEAD` — every commit in the PR range
+- `git diff <base>...HEAD` — full diff
+- `git rev-parse --symbolic-full-name @{u} 2>/dev/null` — check if branch has
+  an upstream
+
+**Stop conditions:**
+- If current branch equals base branch → tell the user to create a feature
+  branch first.
+- If `git log <base>..HEAD` is empty → tell the user there's nothing to PR.
+
+## Step 2: Analyze ALL Commits in the Range
+
+This is critical: the PR body must reflect **every commit** in the range, not
+just the latest one. Read `git log <base>..HEAD` output and group changes by
+theme. A 5-commit PR should mention all 5 concerns, not just HEAD's change.
+
+## Step 3: Resolve the Issue Number
+
+Same precedence as `gh:commit`:
+1. Explicit argument on `/gh:pr` (e.g., `/gh:pr 123`)
+2. Scan recent conversation for `#N` or `Issue #N created`
+3. Scan commit messages in the range for `Refs #N` / `Closes #N` / `Fixes #N`
+4. None — omit the link
+
+## Step 4: Draft Title and Body
+
+**Title** — under 70 chars, imperative mood, matches commit style of the repo.
+Do NOT stuff details into the title; they belong in the body.
+
+**Body template** (language: match the repo — Korean if commits are Korean):
+
+```markdown
+## Summary
+- <1–3 bullets covering the whole PR, not just HEAD>
+
+## Changes
+- <commit-scope 1>: <what changed and why>
+- <commit-scope 2>: <...>
+<one bullet per meaningful commit or logical group>
+
+## Test plan
+- [ ] <concrete manual or automated check>
+- [ ] <another check>
+
+## Related
+Closes #<N>        ← only if issue resolved
+Refs #<N>          ← if related but not fully resolving
+```
+
+Omit `## Related` entirely if no issue is known.
+
+## Step 5: Push and Create (parallel where possible)
+
+- If no upstream: `git push -u origin HEAD`
+- If upstream exists and local is ahead: `git push`
+- If upstream is diverged: stop and ask the user before force-pushing
+  (never force-push without explicit approval)
+
+Write the body to a temp file, then:
+
+```bash
+gh pr create \
+  --base <base> \
+  --title "<title>" \
+  --body-file /tmp/gh-pr-body.md
+```
+
+Do NOT set `--draft`, `--reviewer`, `--assignee`, or `--label` unless the user
+asked.
+
+## Step 6: Report
+
+Output **only** the PR URL:
+
+```
+PR created: https://github.com/owner/repo/pull/<N>
+```
+
+No preamble, no summary of what the PR does — the user opens GitHub directly.
+
+## Constraints
+
+- Never force-push without explicit user approval.
+- Never target a base other than the repo's default branch unless the user
+  said so.
+- Never include `🤖 Generated with` or Claude Code footer unless the repo
+  already uses that convention in existing PRs.
+- Never skip commits in the Summary because "they're minor" — the range is
+  the contract.

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -62,8 +62,8 @@ if commits are Korean).
 - If upstream is diverged: **stop and ask the user before force-pushing**
   (never force-push without explicit approval).
 
-Then write the body to a temp file and run `gh pr create` as documented in
-`references/pr-body-template.md`.
+Then write the body to a unique temp file via `mktemp` and run `gh pr create`
+as documented in `references/pr-body-template.md`.
 
 ## Step 6: Report
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -28,8 +28,7 @@ Run in a single message:
 Then:
 - `git log --oneline <base>..HEAD` — every commit in the PR range
 - `git diff <base>...HEAD` — full diff
-- `git rev-parse --symbolic-full-name @{u} 2>/dev/null` — check if branch has
-  an upstream
+- `git rev-parse --symbolic-full-name @{u} 2>/dev/null` — upstream check
 
 **Stop conditions:**
 - If current branch equals base branch → tell the user to create a feature
@@ -38,8 +37,8 @@ Then:
 
 ## Step 2: Analyze ALL Commits in the Range
 
-This is critical: the PR body must reflect **every commit** in the range, not
-just the latest one. Read `git log <base>..HEAD` output and group changes by
+Critical: the PR body must reflect **every commit** in the range, not just
+the latest one. Read `git log <base>..HEAD` output and group changes by
 theme. A 5-commit PR should mention all 5 concerns, not just HEAD's change.
 
 ## Step 3: Resolve the Issue Number
@@ -52,49 +51,19 @@ Same precedence as `gh:commit`:
 
 ## Step 4: Draft Title and Body
 
-**Title** — under 70 chars, imperative mood, matches commit style of the repo.
-Do NOT stuff details into the title; they belong in the body.
-
-**Body template** (language: match the repo — Korean if commits are Korean):
-
-```markdown
-## Summary
-- <1–3 bullets covering the whole PR, not just HEAD>
-
-## Changes
-- <commit-scope 1>: <what changed and why>
-- <commit-scope 2>: <...>
-<one bullet per meaningful commit or logical group>
-
-## Test plan
-- [ ] <concrete manual or automated check>
-- [ ] <another check>
-
-## Related
-Closes #<N>        ← only if issue resolved
-Refs #<N>          ← if related but not fully resolving
-```
-
-Omit `## Related` entirely if no issue is known.
+Read `references/pr-body-template.md` for title rules, body structure, and
+the `gh pr create` command. Match the language of existing commits (Korean
+if commits are Korean).
 
 ## Step 5: Push and Create (parallel where possible)
 
 - If no upstream: `git push -u origin HEAD`
 - If upstream exists and local is ahead: `git push`
-- If upstream is diverged: stop and ask the user before force-pushing
-  (never force-push without explicit approval)
+- If upstream is diverged: **stop and ask the user before force-pushing**
+  (never force-push without explicit approval).
 
-Write the body to a temp file, then:
-
-```bash
-gh pr create \
-  --base <base> \
-  --title "<title>" \
-  --body-file /tmp/gh-pr-body.md
-```
-
-Do NOT set `--draft`, `--reviewer`, `--assignee`, or `--label` unless the user
-asked.
+Then write the body to a temp file and run `gh pr create` as documented in
+`references/pr-body-template.md`.
 
 ## Step 6: Report
 

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -35,13 +35,16 @@ Refs #<N>          ← if related but not fully resolving
 
 ## Create Command
 
-Write the body to a temp file, then run:
+Write the body to a unique temp file via `mktemp` (avoids concurrent-run
+collisions), then run:
 
 ```bash
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write the drafted body to "$BODY" ...
 gh pr create \
   --base <base> \
   --title "<title>" \
-  --body-file /tmp/gh-pr-body.md
+  --body-file "$BODY"
 ```
 
 Do NOT set `--draft`, `--reviewer`, `--assignee`, or `--label` unless the user

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -1,0 +1,48 @@
+# PR Body Template — for gh:pr skill
+
+Use this template when drafting the title and body in Step 4 of the `gh:pr` skill.
+
+## Title Rules
+
+- Under 70 characters.
+- Imperative mood (e.g., "Add", "Fix", "Refactor").
+- Match the commit style of the repo (scan recent commits/PRs).
+- Do NOT stuff details into the title — they belong in the body.
+
+## Body Template
+
+Language: match the repo. Use Korean if existing commits are Korean.
+
+```markdown
+## Summary
+- <1–3 bullets covering the whole PR, not just HEAD>
+
+## Changes
+- <commit-scope 1>: <what changed and why>
+- <commit-scope 2>: <...>
+<one bullet per meaningful commit or logical group>
+
+## Test plan
+- [ ] <concrete manual or automated check>
+- [ ] <another check>
+
+## Related
+Closes #<N>        ← only if issue resolved
+Refs #<N>          ← if related but not fully resolving
+```
+
+- Omit the `## Related` section entirely if no issue number is known.
+
+## Create Command
+
+Write the body to a temp file, then run:
+
+```bash
+gh pr create \
+  --base <base> \
+  --title "<title>" \
+  --body-file /tmp/gh-pr-body.md
+```
+
+Do NOT set `--draft`, `--reviewer`, `--assignee`, or `--label` unless the user
+explicitly asked.

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -44,8 +44,64 @@ BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 gh pr create \
   --base <base> \
   --title "<title>" \
-  --body-file "$BODY"
+  --body-file "$BODY" \
+  --assignee @me
 ```
 
-Do NOT set `--draft`, `--reviewer`, `--assignee`, or `--label` unless the user
-explicitly asked.
+`--assignee @me` is always applied — the skill self-assigns every PR.
+
+Do NOT set `--draft` or `--reviewer` unless the user explicitly asked.
+
+## Label Derivation
+
+Labels are applied **after** `gh pr create` via `gh pr edit --add-label`,
+because the label set must be validated against the repo's existing labels
+first (creating labels on the fly is forbidden).
+
+### Mapping from Conventional Commits
+
+Scan `git log <base>..HEAD --format=%s` and collect types from each subject:
+
+| Commit type | Candidate label     |
+|-------------|---------------------|
+| `feat`      | `enhancement`       |
+| `fix`       | `bug`               |
+| `docs`      | `documentation`     |
+| `refactor`  | `refactor`          |
+| `style`     | `style`             |
+| `perf`      | `performance`       |
+| `test`      | `test`              |
+| `chore`     | `chore`             |
+| `ci`        | `ci`                |
+| `build`     | `build`             |
+
+Multiple commit types → multiple candidate labels (dedup first).
+
+### Judgment-based additions
+
+Add scope labels that match the PR's actual footprint, e.g.:
+
+- `claude/skills/**` changes → `skill`
+- `docs/**` or `**/*.md` only → `documentation`
+- Changes under a specific package → that package's label if one exists
+
+Use judgment; do not stretch — a label should meaningfully describe the PR.
+
+### Safe application loop
+
+Labels that don't already exist in the repo **must be skipped silently** —
+never create new labels.
+
+```bash
+EXISTING=$(gh label list --limit 200 --json name -q '.[].name')
+PR_NUMBER=<the number gh pr create printed>
+
+for LABEL in <candidate-list>; do
+  if printf '%s\n' "$EXISTING" | grep -Fxq "$LABEL"; then
+    gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+  fi
+done
+```
+
+Report the applied labels (and skipped ones, if any) alongside the PR URL
+in Step 7.


### PR DESCRIPTION
## Summary
- Introduce four user-level skills — `gh:issue`, `gh:commit`, `gh:pr`, `gh:pr-reply` — that encode the conversation→GitHub workflow previously driven by ad-hoc natural language.
- Each SKILL.md follows Progressive Disclosure: control-tower phases inline (≤ 100 lines), templates and long examples extracted to `references/` files.
- `gh:pr-reply` bakes in the "every reviewer comment must get a reply, bots included" rule that was previously only in personal memory.

## Changes

### Commit 1 — `feat(skills): add gh:* workflow skills for issue/commit/pr/review` (cb4ee8d)
- `claude/skills/gh-issue/SKILL.md` — summarizes the current chat into a structured feature/bug/misc issue, creates it via `gh issue create` without confirmation, returns only the issue number + URL.
- `claude/skills/gh-commit/SKILL.md` — creates a new commit following the repo's commit style, auto-linking an issue number from conversation or argument. Never amends, never skips hooks, never stages files that look like secrets.
- `claude/skills/gh-pr/SKILL.md` — pushes the branch if needed and bundles **all** commits in `<base>..HEAD` (not just HEAD) into a structured PR body.
- `claude/skills/gh-pr-reply/SKILL.md` — fetches inline + top-level + review-summary comments on the PR (current branch by default, or explicit `/gh:pr-reply <N>`), judges each with a 4-way classification (ACCEPT / ACCEPT-PARTIAL / DECLINE / QUESTION), applies valid fixes, and replies to every thread.

### Commit 2 — `refactor(skills): apply progressive disclosure to gh:* skills` (928ff1e)
Moves verbose content out of each SKILL.md into focused `references/` files while preserving behavior and all critical safety rules inline.

| Skill | Before | After | References added |
|---|---|---|---|
| `gh:issue` | 135 | 81 | `issue-body-templates.md` |
| `gh:commit` | 100 | 71 | `commit-message-format.md` |
| `gh:pr` | 117 | 86 | `pr-body-template.md` |
| `gh:pr-reply` | 161 | 100 | `comment-fetching.md`, `reply-templates.md` |

Extracted: issue body templates, commit message HEREDOC pattern, PR body markdown template, GitHub comment API endpoints, reply body templates. Kept inline: safety rules (no \`--amend\` / \`--no-verify\` / \`--force-push\` / secret staging), stop conditions, decision logic, the "always reply" contract.

## Test plan
- [ ] `/gh:issue` in a different project creates an issue on that project's origin and prints only `Issue #N` + URL.
- [ ] `/gh:commit` stages and commits with a clean message; `/gh:commit 42` adds `Refs #42` footer.
- [ ] `/gh:pr` on a multi-commit branch produces a PR body that mentions every commit in the range, not just HEAD.
- [ ] `/gh:pr-reply` on a PR with bot review comments fetches from all 3 endpoints, classifies each, applies valid fixes, and posts an individual reply on every thread.
- [ ] All four SKILL.md files stay ≤ 100 lines (verified at commit time: 81, 71, 86, 100).
- [ ] Pre-commit validation passes on both commits (verified locally).

## Notes
- Personal memory file `feedback_pr_review_replies.md` updated locally to note the rule is now baked into `gh:pr-reply` — not part of this PR (memory is not tracked).
- `~/.claude/skills/` lives on a separate filesystem from the dotfiles SSoT; future edits should go through `claude/skills/` in the repo and sync via `claude/setup.sh` per existing convention.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
