### PR TITLE
refactor(help): unify git/gwt help UX and compact structure

### DIFF
--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -1,10 +1,28 @@
 #!/bin/sh
 # shell-common/functions/git_help.sh
 
-git_help() {
-    ux_header "Git Quick Commands"
+_git_help_summary() {
+    ux_info "Usage: git-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "basic: gs | ga | gc | gca | gp | gpl | gco | gd | grs | gb | grmc"
+    ux_bullet_sub "sync: gf | gfu | gfa | gsw | gr"
+    ux_bullet_sub "logs: gl | gl1 | gl2 | glref"
+    ux_bullet_sub "upstream: gupa | gupdel | glum | glub"
+    ux_bullet_sub "branch: gset-main | gset-dev | gset | gprune | git-clean-local"
+    ux_bullet_sub "stash: git stash list | show -p | pop | apply | drop"
+    ux_bullet_sub "pick: gcp | gcp_theirs | gcp_ours | gcp_author | gcp_scan"
+    ux_bullet_sub "special: gpf_dev_server | gpfu"
+    ux_bullet_sub "lfs: git_lfs_install | glfs"
+    ux_bullet_sub "ssh: git_ssh_check | git_ssh_setup"
+    ux_bullet_sub "details: git-help <section>  (example: git-help stash)"
+}
 
-    ux_section "Basic Commands"
+_git_help_list_sections() {
+    ux_info "Git sections"
+    ux_info "basic sync logs upstream branch stash pick special lfs ssh"
+}
+
+_git_help_rows_basic() {
     ux_table_row "gs" "git status -sb" "Short status"
     ux_table_row "ga" "git add ." "Stage all changes"
     ux_table_row "gc" "git commit -m" "Commit with message"
@@ -16,55 +34,150 @@ git_help() {
     ux_table_row "grs" "git restore" "Discard changes in file"
     ux_table_row "gb" "git branch" "List branches"
     ux_table_row "grmc" "git rm --cached" "Unstage, keep file"
+}
 
-    ux_section "Fetch & Sync"
+_git_help_rows_sync() {
     ux_table_row "gf [remote]" "gf / gf u / gf <name>" "Fetch & prune (default: origin, u=upstream)"
     ux_table_row "gfu" "git fetch upstream" "Fetch upstream"
     ux_table_row "gfa" "git fetch --all" "Fetch all & prune"
     ux_table_row "gsw" "git switch -c" "Switch to remote branch"
     ux_table_row "gr" "git remote -v" "List remotes"
+}
 
-    ux_section "Logs"
+_git_help_rows_logs() {
     ux_table_row "gl" "git-log" "Graph log (default 11)"
     ux_table_row "gl1" "log --oneline" "One-line graph log"
     ux_table_row "gl2" "git-log2" "Alternative log format"
     ux_table_row "glref" "log ref/main" "Ref log for main"
+}
 
-    ux_section "Upstream"
+_git_help_rows_upstream() {
     ux_table_row "gupa" "remote add upstream" "Add upstream remote"
     ux_table_row "gupdel" "gupdel <remote>" "Remove remote"
     ux_table_row "glum" "git-log-upstream" "Upstream main log"
     ux_table_row "glub" "glub [branch]" "Upstream branch log"
+}
 
-    ux_section "Branch Configuration"
+_git_help_rows_branch() {
     ux_table_row "gset-main" "set-upstream main" "Track origin/main"
     ux_table_row "gset-dev" "set-upstream dev" "Track origin/dev"
     ux_table_row "gset" "gset [branch]" "Track origin/[branch]"
     ux_table_row "gprune" "git-prune-remote <remote>" "Delete all branches except main"
     ux_table_row "git-clean-local" "git_clean_local" "Delete local branches (keeps: main + current)"
+}
 
-    ux_section "Cherry-pick"
+_git_help_rows_stash() {
+    ux_table_row "git stash list" "git stash list" "List saved stashes"
+    ux_table_row "git stash show -p" "git stash show -p [stash]" "Show stashed patch (default: latest)"
+    ux_table_row "git stash pop" "git stash pop [stash]" "Apply stash and remove it"
+    ux_table_row "git stash apply" "git stash apply [stash]" "Apply stash and keep it"
+    ux_table_row "git stash drop" "git stash drop [stash]" "Delete a stash entry"
+}
+
+_git_help_rows_pick() {
     ux_table_row "gcp" "gcp <commit>..." "Cherry-pick commits"
     ux_table_row "gcp_theirs" "gcp_theirs <commit>..." "Cherry-pick with -X theirs (incoming)"
     ux_table_row "gcp_ours" "gcp_ours <commit>..." "Cherry-pick with -X ours (current)"
     ux_table_row "gcp_author" "gcp_author <range> [author]" "Cherry-pick by author"
     ux_table_row "gcp_scan" "gcp_scan [base] [src] [--author=<name|all>]" "Compare & pick missing (default: main <- upstream/main, author=dEitY719)"
+}
 
-    ux_section "Cherry-pick -X (Merge Strategy)"
-    ux_bullet "gcp_theirs: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_WARNING}incoming(cherry-pick되는 커밋의 변경)${UX_RESET} 선택"
-    ux_bullet "gcp_ours: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_SUCCESS}current branch(현재 브랜치의 변경)${UX_RESET} 선택"
-
-    ux_section "Special"
+_git_help_rows_special() {
     ux_table_row "gpf_dev_server" "push force dev" "Force push dev-server"
     ux_table_row "gpfu" "push --force-with-lease" "Force push main"
+}
 
-    ux_section "Git LFS"
+_git_help_rows_lfs() {
     ux_table_row "git_lfs_install" "Install LFS" "Ubuntu setup"
     ux_table_row "glfs" "track <pattern>" "Track files with LFS"
+}
 
-    ux_section "SSH & Authentication"
+_git_help_rows_ssh() {
     ux_table_row "git_ssh_check" "Test GitHub SSH" "Verify GitHub SSH connection"
     ux_table_row "git_ssh_setup" "Setup SSH" "Manual SSH configuration guide"
+}
+
+_git_help_notes_pick_strategy() {
+    ux_bullet "gcp_theirs: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_WARNING}incoming(cherry-pick되는 커밋의 변경)${UX_RESET} 선택"
+    ux_bullet "gcp_ours: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_SUCCESS}current branch(현재 브랜치의 변경)${UX_RESET} 선택"
+}
+
+_git_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_git_help_section_rows() {
+    case "$1" in
+        basic)
+            _git_help_rows_basic
+            ;;
+        sync|fetch)
+            _git_help_rows_sync
+            ;;
+        logs|log)
+            _git_help_rows_logs
+            ;;
+        upstream)
+            _git_help_rows_upstream
+            ;;
+        branch|branches)
+            _git_help_rows_branch
+            ;;
+        stash)
+            _git_help_rows_stash
+            ;;
+        pick|cherrypick|cherry-pick)
+            _git_help_rows_pick
+            ;;
+        special)
+            _git_help_rows_special
+            ;;
+        lfs)
+            _git_help_rows_lfs
+            ;;
+        ssh|auth)
+            _git_help_rows_ssh
+            ;;
+        *)
+            ux_error "Unknown git-help section: $1"
+            ux_info "Try: git-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_git_help_full() {
+    ux_header "Git Quick Commands"
+
+    _git_help_render_section "Basic Commands" _git_help_rows_basic
+    _git_help_render_section "Fetch & Sync" _git_help_rows_sync
+    _git_help_render_section "Logs" _git_help_rows_logs
+    _git_help_render_section "Upstream" _git_help_rows_upstream
+    _git_help_render_section "Branch Configuration" _git_help_rows_branch
+    _git_help_render_section "Stash" _git_help_rows_stash
+    _git_help_render_section "Cherry-pick" _git_help_rows_pick
+    _git_help_render_section "Cherry-pick -X (Merge Strategy)" _git_help_notes_pick_strategy
+    _git_help_render_section "Special" _git_help_rows_special
+    _git_help_render_section "Git LFS" _git_help_rows_lfs
+    _git_help_render_section "SSH & Authentication" _git_help_rows_ssh
+}
+
+git_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _git_help_summary
+            ;;
+        --list|list)
+            _git_help_list_sections
+            ;;
+        --all|all)
+            _git_help_full
+            ;;
+        *)
+            _git_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias git-help='git_help'

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -6,6 +6,60 @@
 unalias gwt 2>/dev/null || true
 
 # ============================================================================
+# gwt-help — compact help (canonical)
+# Usage: gwt-help [section]
+# ============================================================================
+gwt_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            ux_info "gwt-help [section]"
+            ux_info "sections: add | list | remove | prune | spawn | teardown"
+            ux_info "add      : gwt add <path> [branch] [start]"
+            ux_info "list     : gwt list | gwt ls"
+            ux_info "remove   : gwt remove <path|agent|all> [--force]"
+            ux_info "prune    : gwt prune"
+            ux_info "spawn    : gwt spawn [agent] [--task slug] [--base ref] [--tmux]"
+            ux_info "teardown : gwt teardown [--force] [--keep-branch]"
+            ux_info "example  : gwt-help spawn"
+            ;;
+        add)
+            ux_info "gwt add <path> [<new-branch> [<start-point>]]"
+            ux_info "Creates git-crypt safe worktree (encrypted paths excluded via sparse-checkout)."
+            ;;
+        list|ls)
+            ux_info "gwt list (or gwt ls)"
+            ux_info "Shows linked worktrees with path/commit/branch."
+            ;;
+        remove|rm)
+            ux_info "gwt remove <path|agent|all> [--force]"
+            ux_info "<agent> removes all *-<agent>-* worktrees, 'all' removes all non-main worktrees."
+            ux_info "--force also force-removes worktree and unmerged branch."
+            ;;
+        prune)
+            ux_info "gwt prune"
+            ux_info "Runs: git worktree prune"
+            ;;
+        spawn)
+            ux_info "gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]"
+            ux_info "Must run from main repo (not inside a worktree)."
+            ux_info "agent: claude | codex | gemini | opencode | cursor | copilot"
+            ux_info "example: gwt spawn codex --task login-fix --base origin/main"
+            ;;
+        teardown)
+            ux_info "gwt teardown [--force] [--keep-branch]"
+            ux_info "Must run inside a worktree. Removes worktree and syncs main repo."
+            ux_info "--force discards local changes/unpushed commits."
+            ux_info "--keep-branch keeps current branch after cleanup."
+            ;;
+        *)
+            ux_error "Unknown gwt-help section: $1"
+            ux_info "Try: gwt-help"
+            return 1
+            ;;
+    esac
+}
+
+# ============================================================================
 # gwt — git worktree dispatcher
 # Usage: gwt <subcommand> [args...]
 # ============================================================================
@@ -18,22 +72,13 @@ gwt() {
         spawn)    shift; git_worktree_spawn "$@" ;;
         teardown) shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
-            ux_header "gwt - git worktree manager"
-            ux_info "Usage: gwt <command> [args...]"
-            ux_info ""
-            ux_info "Commands:"
-            ux_info "  add <path> [branch] [start]    create git-crypt safe worktree"
-            ux_info "  list, ls                       list worktrees (with hints)"
-            ux_info "  remove, rm <path|all> [--force] remove worktree + branch"
-            ux_info "  prune                          clean up stale worktree refs"
-            ux_info "  spawn [ai] [--task slug]       create AI worktree (run from main repo)"
-            ux_info "  teardown [--force]             self-cleanup (run from inside worktree)"
-            ux_info ""
-            ux_info "Run 'gwt <command> --help' for command-specific help."
-            return 0
+            ux_error "Usage: gwt <command> [args...]"
+            ux_info "Run: gwt-help"
+            return 1
             ;;
         *)
-            ux_error "Unknown command: $1. Run 'gwt help' for usage."
+            ux_error "Unknown command: $1"
+            ux_info "Run: gwt-help"
             return 1
             ;;
     esac
@@ -73,7 +118,7 @@ git_worktree_remove() {
     fi
 
     case "${1:-}" in
-        -h|--help|help)
+        -h|--help)
             ux_header "gwt remove - remove worktree and branch"
             ux_info "Usage: gwt remove <path|agent|all> [--force]"
             ux_info ""
@@ -254,7 +299,7 @@ _gwt_remove_one() {
 
 git_worktree_add() {
     case "${1:-}" in
-        -h|--help|help)
+        -h|--help)
             ux_header "gwt add - git-crypt safe worktree"
             ux_info "Usage: gwt add <path> [<new-branch> [<start-point>]]"
             ux_info "  Creates a worktree with git-crypt encrypted files excluded"
@@ -325,7 +370,7 @@ git_worktree_spawn() {
     # Parse arguments
     while [ $# -gt 0 ]; do
         case "$1" in
-            -h|--help|help)
+            -h|--help)
                 ux_header "gwt spawn - AI worktree auto-creation"
                 ux_info "Usage: gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]"
                 ux_info ""
@@ -462,7 +507,7 @@ git_worktree_teardown() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            -h|--help|help)
+            -h|--help)
                 ux_header "gwt teardown - AI worktree cleanup"
                 ux_info "Usage: gwt teardown [--force] [--keep-branch]"
                 ux_info ""
@@ -573,3 +618,5 @@ git_worktree_teardown() {
     ux_info "  Removed: $wt_path"
     ux_info "  Now on:  $main_branch"
 }
+
+alias gwt-help='gwt_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -156,7 +156,7 @@ _register_default_help_categories() {
     HELP_CATEGORIES[system]="${HELP_CATEGORIES[system]:-System tools (directory navigation, opencode)}"
 
     # Category membership (space-separated topic keys)
-    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git uv py nvm npm bun pp cli ux du psql mytool}"
+    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt uv py nvm npm bun pp cli ux du psql mytool}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
@@ -194,6 +194,7 @@ _register_default_help_descriptions() {
     # This approach works in both bash and zsh
     HELP_DESCRIPTIONS[uv_help]="${HELP_DESCRIPTIONS[uv_help]:-[Development] UV packages and environments}"
     HELP_DESCRIPTIONS[git_help]="${HELP_DESCRIPTIONS[git_help]:-[Development] Git version control shortcuts}"
+    HELP_DESCRIPTIONS[gwt_help]="${HELP_DESCRIPTIONS[gwt_help]:-[Development] Git worktree command guide}"
     HELP_DESCRIPTIONS[py_help]="${HELP_DESCRIPTIONS[py_help]:-[Development] Python environments and tooling}"
     HELP_DESCRIPTIONS[dir_help]="${HELP_DESCRIPTIONS[dir_help]:-[System] Directory navigation shortcuts}"
     HELP_DESCRIPTIONS[sys_help]="${HELP_DESCRIPTIONS[sys_help]:-[DevOps] System management helpers}"
@@ -411,7 +412,7 @@ _my_help_show_category() {
     done
 
     ux_divider
-    ux_info "Run: my-help <topic> (example: my-help git)"
+    ux_info "Run: my-help <topic> [args] (example: my-help git stash)"
     ux_bullet "Tip: Use dash form too (example: git-help)"
 
     if [ "$category" = "cli" ]; then
@@ -506,7 +507,7 @@ _my_help_show_all() {
     ux_section "Navigation"
     ux_bullet "my-help                 - Show categories"
     ux_bullet "my-help <category>      - Show a category (example: my-help ai)"
-    ux_bullet "my-help <topic>         - Show a topic (example: my-help git)"
+    ux_bullet "my-help <topic> [args]  - Show a topic (example: my-help git stash)"
     ux_bullet "category-help           - Browse categories"
     ux_bullet "register-help           - How to add new topics"
 
@@ -579,6 +580,7 @@ my_help_impl() {
     else
         # If argument is provided, show specific help for that command
         local cmd_name="$1"
+        shift || true
 
         # Category browsing: exact or unique prefix match (case-insensitive).
         local cat_matches=0
@@ -616,7 +618,7 @@ my_help_impl() {
             esac
 
             if _my_help_is_function "$helper_name"; then
-                "$helper_name"
+                "$helper_name" "$@"
                 rc=$?
             else
                 # Some modules only expose a dash-style function (e.g., apt-help). Only
@@ -634,10 +636,10 @@ my_help_impl() {
                             *) dash_name="${dash_name}-help" ;;
                         esac
                         if _my_help_is_function "$dash_name"; then
-                            "$dash_name"
+                            "$dash_name" "$@"
                             rc=$?
                         elif _my_help_is_function "$cmd_name"; then
-                            "$cmd_name"
+                            "$cmd_name" "$@"
                             rc=$?
                         elif type "$cmd_name" >/dev/null 2>&1; then
                             # Try calling command with --help
@@ -781,6 +783,11 @@ if [ -n "$ZSH_VERSION" ]; then
 
             if [ "$cmd_name" = "register-help" ]; then
                 register_help "$@"
+                return $?
+            fi
+
+            if [ "$cmd_name" = "gwt-help" ]; then
+                gwt_help "$@"
                 return $?
             fi
 

--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -421,7 +421,14 @@ ux_table_header() {
 # Display a bullet point
 # Usage: ux_bullet "Item description"
 ux_bullet() {
-    printf "  ${UX_PRIMARY}•${UX_RESET} %s\n" "$1"
+    printf "  ${UX_PRIMARY}◆${UX_RESET} %s\n" "$1"
+}
+
+# Display a second-level bullet point (deeper indentation + alternate bullet)
+# Usage: ux_bullet_sub "Nested item description"
+# Old style: ◦
+ux_bullet_sub() {
+    printf "    ${UX_INFO}•${UX_RESET} %s\n" "$1"
 }
 
 # Display a numbered item

--- a/tests/integration/test_help_compact_policy.py
+++ b/tests/integration/test_help_compact_policy.py
@@ -1,0 +1,58 @@
+"""
+Compact help policy tests.
+
+Validates the new help UX rules:
+- canonical gwt help entrypoint is gwt-help
+- default help outputs are compact (<= 15 lines)
+"""
+
+import pytest
+
+
+def _non_empty_line_count(shell_runner, shell, cmd):
+    result = shell_runner(shell, f"{cmd} | wc -l")
+    assert result.exit_code == 0, f"{shell}: failed to count lines for: {cmd}"
+    return int(result.stdout.strip())
+
+
+class TestCompactHelpLineLimit:
+    """Default help outputs must stay within 15 non-empty lines."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git_help",
+            "git_help stash",
+            "gwt_help",
+            "gwt_help spawn",
+        ],
+    )
+    def test_compact_help_within_15_lines(self, shell_runner, shell, cmd):
+        lines = _non_empty_line_count(shell_runner, shell, cmd)
+        assert lines <= 15, f"{shell}: '{cmd}' exceeded 15 lines ({lines})"
+
+
+class TestGwtHelpCanonicalEntrypoint:
+    """gwt help should be accessed via gwt-help."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_gwt_help_alias_exists(self, shell_runner, shell):
+        result = shell_runner(shell, "alias gwt-help")
+        assert result.exit_code == 0, f"{shell}: gwt-help alias not defined"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("cmd", ["gwt-help", "gwt-help spawn", "gwt-help teardown"])
+    def test_gwt_help_canonical_commands_work(self, shell_runner, shell, cmd):
+        if shell == "bash":
+            # bash non-interactive mode disables alias expansion by default.
+            result = shell_runner(shell, f"shopt -s expand_aliases; eval '{cmd}'")
+        else:
+            result = shell_runner(shell, cmd)
+        assert result.exit_code == 0, f"{shell}: '{cmd}' failed"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("cmd", ["gwt help", "gwt spawn help", "gwt teardown help"])
+    def test_legacy_gwt_help_forms_rejected(self, shell_runner, shell, cmd):
+        result = shell_runner(shell, cmd)
+        assert result.exit_code != 0, f"{shell}: legacy command should fail: {cmd}"

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -7,7 +7,7 @@ without errors in both bash and zsh environments.
 
 import pytest
 
-# Auto-sourced help topics (35 total)
+# Auto-sourced help topics
 # Excludes: mount-help, addmnt-help (not auto-loaded by main.bash/main.zsh)
 # Use function names (underscores) instead of aliases (dashes) for non-interactive subprocess testing
 HELP_TOPICS = [
@@ -28,6 +28,7 @@ HELP_TOPICS = [
     "gc_help",
     "gemini_help",
     "git_help",
+    "gwt_help",
     "gpu_help",
     "litellm_help",
     "mytool_help",
@@ -151,6 +152,13 @@ class TestHelpTopicsWithDifferentFormats:
         """Test my_help_impl with specific subtopic argument."""
         result = shell_runner(shell, "my_help_impl git")
         assert result.exit_code == 0, f"{shell}: my_help_impl git failed"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_my_help_invocation_with_topic_args(self, shell_runner, shell):
+        """Test my_help_impl forwards args to topic function."""
+        result = shell_runner(shell, "my_help_impl git stash")
+        assert result.exit_code == 0, f"{shell}: my_help_impl git stash failed"
+        assert "git stash" in result.stdout.lower(), f"{shell}: stash content not shown"
 
 
 class TestHelpTopicsErrorHandling:


### PR DESCRIPTION
## Summary
- standardize `git-help` into compact default output with section-based drill-down and `--all` detailed view
- refactor `git_help` into reusable section row functions (SSOT) so `git-help <section>` reuses the same table rows as `git-help --all`
- add canonical `gwt-help` usage path and route `my-help` topic args (e.g. `my-help git stash`)
- add nested bullet utility `ux_bullet_sub` and apply it to `git-help` summary hierarchy

## Behavior changes
- `git-help` now shows compact summary (<= 15 lines)
- `git-help stash` now renders the same table-row format used by `git-help --all`
- legacy gwt help forms (`gwt help`, `gwt spawn help`, `gwt teardown help`) are rejected and direct users to `gwt-help`

## Tests
- `pytest -q tests/integration/test_help_compact_policy.py tests/integration/test_help_topics.py -q`
- Result: `185 passed`

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
