### PR TITLE
Refactor gwt-help summary to follow UX template

### DIFF
--- a/.ai/postmortems/2026-04-11-gwt-help-format-mismatch.md
+++ b/.ai/postmortems/2026-04-11-gwt-help-format-mismatch.md
@@ -1,0 +1,28 @@
+# Postmortem: gwt-help Format Mismatch
+
+## Date
+2026-04-11
+
+## Incident
+`gwt-help` summary format was delivered in legacy flat `ux_info` style, while `git-help` used the standard template (`Usage` + `ux_bullet`/`ux_bullet_sub`).
+
+## Impact
+- Output consistency between help commands was broken.
+- User had to report mismatch manually.
+
+## Root Cause
+1. Validation focused on function behavior and line-count policy, but not summary-template parity.
+2. No automated guard existed to reject legacy flat summary text (`sections: ...`) for `gwt-help`.
+
+## Corrective Actions
+1. Added explicit summary-template rule to `docs/standards/command-guidelines.md`.
+2. Added integration test `test_gwt_help_summary_uses_standard_template` to block regression.
+3. Refactored `gwt_help` to SSOT structure (`_gwt_help_rows_*`, `--list`, `--all`).
+
+## Prevention Checklist (Mandatory for help-command changes)
+1. Confirm default output uses `Usage` + `ux_bullet` + `ux_bullet_sub`.
+2. Reject flat legacy summary patterns like `ux_info "sections: ..."` in review.
+3. Run `pytest tests/integration/test_help_compact_policy.py -q` before reporting done.
+4. Validate in both shells with the target repo root explicitly set:
+   - `DOTFILES_ROOT=<repo> zsh -lc 'source <repo>/zsh/main.zsh; gwt_help'`
+   - `DOTFILES_FORCE_INIT=1 DOTFILES_ROOT=<repo> bash -lc 'source <repo>/bash/main.bash; gwt_help'`

--- a/docs/standards/command-guidelines.md
+++ b/docs/standards/command-guidelines.md
@@ -27,6 +27,11 @@
 - 기본 출력(`*-help`)은 15줄 이내를 목표로 한다.
 - 기본 출력은 요약 중심으로 구성한다.
 - 상세 표/긴 설명은 `--all`로 분리한다.
+- 기본 요약은 아래 템플릿을 기본값으로 사용한다:
+  - 첫 줄: `ux_info "Usage: <topic>-help [section|--list|--all]"`
+  - 섹션 루트: `ux_bullet "sections"`
+  - 섹션 항목: `ux_bullet_sub "..."`
+  - 금지: `ux_info "sections: ..."` 형태의 flat 나열 요약
 
 ### 3) 계층 출력 규칙
 
@@ -65,6 +70,7 @@
 
 - bash/zsh 모두에서 canonical help 호출 성공
 - `*-help` 기본 출력 줄 수 검증 (<= 15)
+- `*-help` 기본 출력이 템플릿(Usage + `ux_bullet`/`ux_bullet_sub`)을 따르는지 검증
 - `<topic>-help <section>` 출력이 `--all`의 동일 섹션 row와 일치
 - `my-help <topic> [args]` 인자 전달 정상 동작
 

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -9,52 +9,114 @@ unalias gwt 2>/dev/null || true
 # gwt-help — compact help (canonical)
 # Usage: gwt-help [section]
 # ============================================================================
-gwt_help() {
-    case "${1:-}" in
-        ""|-h|--help|help)
-            ux_info "gwt-help [section]"
-            ux_info "sections: add | list | remove | prune | spawn | teardown"
-            ux_info "add      : gwt add <path> [branch] [start]"
-            ux_info "list     : gwt list | gwt ls"
-            ux_info "remove   : gwt remove <path|agent|all> [--force]"
-            ux_info "prune    : gwt prune"
-            ux_info "spawn    : gwt spawn [agent] [--task slug] [--base ref] [--tmux]"
-            ux_info "teardown : gwt teardown [--force] [--keep-branch]"
-            ux_info "example  : gwt-help spawn"
-            ;;
+_gwt_help_summary() {
+    ux_info "Usage: gwt-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "add: gwt add <path> [branch] [start]"
+    ux_bullet_sub "list: gwt list | gwt ls"
+    ux_bullet_sub "remove: gwt remove <path|agent|all> [--force]"
+    ux_bullet_sub "prune: gwt prune"
+    ux_bullet_sub "spawn: gwt spawn [agent] [--task slug] [--base ref] [--tmux]"
+    ux_bullet_sub "teardown: gwt teardown [--force] [--keep-branch]"
+    ux_bullet_sub "details: gwt-help <section> (example: gwt-help spawn)"
+}
+
+_gwt_help_list_sections() {
+    ux_info "gwt sections"
+    ux_info "add list remove prune spawn teardown"
+}
+
+_gwt_help_rows_add() {
+    ux_table_row "syntax" "gwt add <path> [<new-branch> [<start-point>]]" "Create git-crypt-safe worktree"
+    ux_table_row "behavior" "Sparse checkout excludes encrypted paths" "Keeps encrypted layout safe"
+}
+
+_gwt_help_rows_list() {
+    ux_table_row "syntax" "gwt list | gwt ls" "List linked worktrees"
+    ux_table_row "output" "path | commit | branch" "Adds remove hint when count > 1"
+}
+
+_gwt_help_rows_remove() {
+    ux_table_row "syntax" "gwt remove <path|agent|all> [--force]" "Remove worktree + branch"
+    ux_table_row "agent mode" "<agent> matches *-<agent>-*" "Batch remove by agent"
+    ux_table_row "all mode" "all removes non-main worktrees" "Batch cleanup"
+    ux_table_row "force" "--force" "Force remove and branch delete"
+}
+
+_gwt_help_rows_prune() {
+    ux_table_row "syntax" "gwt prune" "Run: git worktree prune"
+}
+
+_gwt_help_rows_spawn() {
+    ux_table_row "syntax" "gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]" "Create AI worktree"
+    ux_table_row "context" "Run from main repo only" "Fails inside a worktree"
+    ux_table_row "agents" "claude | codex | gemini | opencode | cursor | copilot" "Default: auto-detect"
+    ux_table_row "example" "gwt spawn codex --task login-fix --base origin/main" "Task + base branch"
+}
+
+_gwt_help_rows_teardown() {
+    ux_table_row "syntax" "gwt teardown [--force] [--keep-branch]" "Cleanup current AI worktree"
+    ux_table_row "context" "Run inside a worktree" "Syncs main repo after cleanup"
+    ux_table_row "flags" "--force / --keep-branch" "Discard changes / keep branch"
+}
+
+_gwt_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gwt_help_section_rows() {
+    case "$1" in
         add)
-            ux_info "gwt add <path> [<new-branch> [<start-point>]]"
-            ux_info "Creates git-crypt safe worktree (encrypted paths excluded via sparse-checkout)."
+            _gwt_help_rows_add
             ;;
         list|ls)
-            ux_info "gwt list (or gwt ls)"
-            ux_info "Shows linked worktrees with path/commit/branch."
+            _gwt_help_rows_list
             ;;
         remove|rm)
-            ux_info "gwt remove <path|agent|all> [--force]"
-            ux_info "<agent> removes all *-<agent>-* worktrees, 'all' removes all non-main worktrees."
-            ux_info "--force also force-removes worktree and unmerged branch."
+            _gwt_help_rows_remove
             ;;
         prune)
-            ux_info "gwt prune"
-            ux_info "Runs: git worktree prune"
+            _gwt_help_rows_prune
             ;;
         spawn)
-            ux_info "gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]"
-            ux_info "Must run from main repo (not inside a worktree)."
-            ux_info "agent: claude | codex | gemini | opencode | cursor | copilot"
-            ux_info "example: gwt spawn codex --task login-fix --base origin/main"
+            _gwt_help_rows_spawn
             ;;
         teardown)
-            ux_info "gwt teardown [--force] [--keep-branch]"
-            ux_info "Must run inside a worktree. Removes worktree and syncs main repo."
-            ux_info "--force discards local changes/unpushed commits."
-            ux_info "--keep-branch keeps current branch after cleanup."
+            _gwt_help_rows_teardown
             ;;
         *)
             ux_error "Unknown gwt-help section: $1"
-            ux_info "Try: gwt-help"
+            ux_info "Try: gwt-help --list"
             return 1
+            ;;
+    esac
+}
+
+_gwt_help_full() {
+    ux_header "Git Worktree Commands"
+
+    _gwt_help_render_section "Add" _gwt_help_rows_add
+    _gwt_help_render_section "List" _gwt_help_rows_list
+    _gwt_help_render_section "Remove" _gwt_help_rows_remove
+    _gwt_help_render_section "Prune" _gwt_help_rows_prune
+    _gwt_help_render_section "Spawn" _gwt_help_rows_spawn
+    _gwt_help_render_section "Teardown" _gwt_help_rows_teardown
+}
+
+gwt_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _gwt_help_summary
+            ;;
+        --list|list)
+            _gwt_help_list_sections
+            ;;
+        --all|all)
+            _gwt_help_full
+            ;;
+        *)
+            _gwt_help_section_rows "$1"
             ;;
     esac
 }

--- a/tests/integration/test_help_compact_policy.py
+++ b/tests/integration/test_help_compact_policy.py
@@ -6,13 +6,22 @@ Validates the new help UX rules:
 - default help outputs are compact (<= 15 lines)
 """
 
+import re
+
 import pytest
+
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
 def _non_empty_line_count(shell_runner, shell, cmd):
     result = shell_runner(shell, f"{cmd} | wc -l")
     assert result.exit_code == 0, f"{shell}: failed to count lines for: {cmd}"
     return int(result.stdout.strip())
+
+
+def _normalized_lines(text):
+    stripped = ANSI_ESCAPE_RE.sub("", text)
+    return [line.strip() for line in stripped.splitlines() if line.strip()]
 
 
 class TestCompactHelpLineLimit:
@@ -42,7 +51,10 @@ class TestGwtHelpCanonicalEntrypoint:
         assert result.exit_code == 0, f"{shell}: gwt-help alias not defined"
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
-    @pytest.mark.parametrize("cmd", ["gwt-help", "gwt-help spawn", "gwt-help teardown"])
+    @pytest.mark.parametrize(
+        "cmd",
+        ["gwt-help", "gwt-help spawn", "gwt-help teardown", "gwt-help --list", "gwt-help --all"],
+    )
     def test_gwt_help_canonical_commands_work(self, shell_runner, shell, cmd):
         if shell == "bash":
             # bash non-interactive mode disables alias expansion by default.
@@ -56,3 +68,56 @@ class TestGwtHelpCanonicalEntrypoint:
     def test_legacy_gwt_help_forms_rejected(self, shell_runner, shell, cmd):
         result = shell_runner(shell, cmd)
         assert result.exit_code != 0, f"{shell}: legacy command should fail: {cmd}"
+
+
+class TestGwtHelpSotInterface:
+    """gwt-help supports list/all forms and reuses section rows in --all output."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("cmd", ["gwt_help --list", "gwt_help list", "gwt_help --all", "gwt_help all"])
+    def test_gwt_help_supports_list_and_all_forms(self, shell_runner, shell, cmd):
+        result = shell_runner(shell, cmd)
+        assert result.exit_code == 0, f"{shell}: '{cmd}' failed"
+        assert result.stdout.strip(), f"{shell}: '{cmd}' returned empty output"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_gwt_help_summary_uses_standard_template(self, shell_runner, shell):
+        result = shell_runner(shell, "gwt_help")
+        assert result.exit_code == 0, f"{shell}: 'gwt_help' failed"
+
+        lines = _normalized_lines(result.stdout)
+        assert any("Usage: gwt-help [section|--list|--all]" in line for line in lines), (
+            f"{shell}: usage template missing"
+        )
+        assert not any("sections: add | list | remove | prune | spawn | teardown" in line for line in lines), (
+            f"{shell}: legacy flat section summary detected"
+        )
+        assert any("details: gwt-help <section>" in line for line in lines), (
+            f"{shell}: details guide missing"
+        )
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize(
+        ("section_arg", "section_name"),
+        [
+            ("add", "add"),
+            ("ls", "list"),
+            ("remove", "remove"),
+            ("prune", "prune"),
+            ("spawn", "spawn"),
+            ("teardown", "teardown"),
+        ],
+    )
+    def test_gwt_help_section_rows_match_all_output(self, shell_runner, shell, section_arg, section_name):
+        section_result = shell_runner(shell, f"gwt_help {section_arg}")
+        assert section_result.exit_code == 0, f"{shell}: 'gwt_help {section_arg}' failed"
+
+        all_result = shell_runner(shell, "gwt_help --all")
+        assert all_result.exit_code == 0, f"{shell}: 'gwt_help --all' failed"
+
+        section_lines = _normalized_lines(section_result.stdout)
+        all_lines = _normalized_lines(all_result.stdout)
+        assert section_lines, f"{shell}: no rows found for section '{section_name}'"
+
+        for line in section_lines:
+            assert line in all_lines, f"{shell}: section '{section_name}' row not found in --all output: '{line}'"


### PR DESCRIPTION
## Summary
- Refactor `gwt-help` to follow the same compact summary template as `git-help`.
- Add guardrails so legacy flat summary output cannot regress.
- Record the mismatch incident and prevention checklist for future help changes.

## Changes
- `refactor(help)`: restructure `gwt_help` with SSOT row helpers and add `--list|list`, `--all|all` paths.
- `docs(standards)`: codify the default help summary template and ban flat `sections: ...` summary lines.
- `test`: extend integration coverage for canonical `gwt-help` forms, template conformance, and section-vs-`--all` row parity.
- `ops`: add `.ai/postmortems/2026-04-11-gwt-help-format-mismatch.md` with root cause and prevention steps.

## Test plan
- [x] `pytest tests/integration/test_help_compact_policy.py -q`
- [x] `pytest tests/integration/test_help_topics.py -q`
- [x] `DOTFILES_ROOT=/home/bwyoon/dotfiles-codex-1 zsh -lc 'source /home/bwyoon/dotfiles-codex-1/zsh/main.zsh; gwt_help'`
- [x] `DOTFILES_FORCE_INIT=1 DOTFILES_ROOT=/home/bwyoon/dotfiles-codex-1 bash -lc 'source /home/bwyoon/dotfiles-codex-1/bash/main.bash; gwt_help'`

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
