### PR TITLE
fix(ux_lib): route interactive prompts to stderr

### DIFF
--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -273,14 +273,18 @@ ux_progress_dots() {
 # Ask for confirmation (yes/no)
 # Usage: if ux_confirm "Are you sure?" "n"; then ... fi
 # Second argument is default: "y" or "n"
+#
+# Prompts are written to stderr so they remain visible when the caller
+# captures stdout (e.g., inside $(...)). Return value is conveyed via
+# exit code, so no stdout pollution either way.
 ux_confirm() {
     local prompt="$1"
     local default="${2:-n}"
 
     if [ "$default" = "y" ]; then
-        printf "%s❓%s %s [Y/n]: " "${UX_WARNING}" "${UX_RESET}" "$prompt"
+        printf "%s❓%s %s [Y/n]: " "${UX_WARNING}" "${UX_RESET}" "$prompt" >&2
     else
-        printf "%s❓%s %s [y/N]: " "${UX_WARNING}" "${UX_RESET}" "$prompt"
+        printf "%s❓%s %s [y/N]: " "${UX_WARNING}" "${UX_RESET}" "$prompt" >&2
     fi
 
     read -r response
@@ -294,13 +298,18 @@ ux_confirm() {
 
 # Ask for text input with validation
 # Usage: result=$(ux_input "Enter name:" "^[a-zA-Z]+$")
+#
+# The prompt is written to stderr so it remains visible when the caller
+# captures stdout with $(...). The user's validated response is written
+# to stdout — that is the function's return value. Matches bash's own
+# `read -p` convention, which also routes the prompt to stderr.
 ux_input() {
     local prompt="$1"
     local pattern="${2:-.*}"
     local response
 
     while true; do
-        printf "%s❯%s %s " "${UX_INFO}" "${UX_RESET}" "$prompt"
+        printf "%s❯%s %s " "${UX_INFO}" "${UX_RESET}" "$prompt" >&2
         read -r response
 
         if echo "$response" | grep -qE "$pattern"; then


### PR DESCRIPTION
## 요약

`ux_input()` 이 프롬프트를 stdout에 쓰고 있어서 `result=$(ux_input "...")` 캡처 구문(라이브러리 docstring이 공식적으로 예시로 드는 바로 그 패턴) 안에서 프롬프트가 사라지는 버그를 수정합니다.

## 재현

`shell-common/tools/custom/backup_git_crypt_usb.sh` 의 Step 1이 세 번의 `USB_ROOT="$(ask_path ...)"` 호출로 시작합니다. 사용자 입장에서는:

```
[1/5] Questions (we will ask these up-front)

<여기서 터미널이 멈춘 것처럼 보임>
```

프롬프트 `❯ USB mount path (...)` 가 `$(...)` 에 의해 USB_ROOT 변수로 빨려 들어가고, `read` 는 조용히 stdin을 대기 중. 처음 쓰는 사용자는 무엇을 입력해야 할지 알 수 없음.

## 변경

- `ux_input`: prompt 를 `>&2` 로 stderr에 출력. 리턴값(`echo "$response"`)은 기존대로 stdout 유지.
- `ux_confirm`: 동일 convention 적용. 현재 콜러는 모두 `if ux_confirm ...` 형태라 동작 변화 없음 — 미래에 `$(...)` 로 감싸졌을 때 같은 증상을 겪지 않도록 하는 defense-in-depth.
- 두 함수에 stdout/stderr 분할 이유를 설명하는 docstring 추가해 다음 메인테이너가 되돌리지 않도록.

bash 의 `read -p` 가 프롬프트를 stderr에 보내는 이유와 동일 — interactive prompt는 stdout 리턴값과 충돌하지 않도록 stderr 에 속함.

## 검증

```sh
# prompt → stderr (터미널에 보임), 캡처값은 순수
$ source shell-common/tools/ux_lib/ux_lib.sh
$ result="$(ux_input "Type hello:" "" <<<"hello")"
❯ Type hello:
$ echo "[$result]"
[hello]
```

- [x] `bash -n shell-common/tools/ux_lib/ux_lib.sh` 통과
- [x] pre-commit 훅 통과
- [x] `$(ux_input ...)` 캡처 시 prompt 가시, 반환값 순수
- [x] `if ux_confirm ...` 일반 사용 회귀 없음

## 후속 대응 (이 PR 범위 밖)

- `backup_git_crypt_usb.sh` 의 UX 개선 — 현재는 3개 질문 중 첫 번째가 갑자기 나와서 맥락이 없음. "이제부터 세 가지 질문: (1) USB 경로, (2) SSH 백업 여부, (3) 백업 파일 보호 암호" 식의 사전 안내 추가를 검토할만함.
- `ux_lib.sh` 의 다른 인터랙티브 함수(`ux_menu` 등)도 동일 패턴 확인 필요.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
