### PR TITLE
Standardize help interfaces and fix gwt-help section aliases

### DIFF
--- a/bash/main.bash
+++ b/bash/main.bash
@@ -154,6 +154,10 @@ if [ -d "${SHELL_COMMON}/tools/integrations" ]; then
     done
 fi
 
+# Normalize help interfaces after all help providers are sourced
+# (functions + integrations).
+type -t apply_help_standard_adapter &>/dev/null && apply_help_standard_adapter
+
 load_category "projects"
 
 # --- Load bash-specific ENV directory ---

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -18,8 +18,17 @@ _git_help_summary() {
 }
 
 _git_help_list_sections() {
-    ux_info "Git sections"
-    ux_info "basic sync logs upstream branch stash pick special lfs ssh"
+    ux_bullet "sections"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "sync"
+    ux_bullet_sub "logs"
+    ux_bullet_sub "upstream"
+    ux_bullet_sub "branch"
+    ux_bullet_sub "stash"
+    ux_bullet_sub "pick"
+    ux_bullet_sub "special"
+    ux_bullet_sub "lfs"
+    ux_bullet_sub "ssh"
 }
 
 _git_help_rows_basic() {

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -22,8 +22,13 @@ _gwt_help_summary() {
 }
 
 _gwt_help_list_sections() {
-    ux_info "gwt sections"
-    ux_info "add list remove prune spawn teardown"
+    ux_bullet "sections"
+    ux_bullet_sub "add"
+    ux_bullet_sub "list"
+    ux_bullet_sub "remove"
+    ux_bullet_sub "prune"
+    ux_bullet_sub "spawn"
+    ux_bullet_sub "teardown"
 }
 
 _gwt_help_rows_add() {

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -114,7 +114,7 @@ gwt_help() {
         ""|-h|--help|help)
             _gwt_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _gwt_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -548,6 +548,65 @@ _my_help_show_all() {
     return 0
 }
 
+_my_help_summary() {
+    ux_info "Usage: my-help [topic|category|section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "categories: ai | cli | config | development | devops | docs | meta | system"
+    ux_bullet_sub "popular: git | docker | claude | uv | fzf"
+    ux_bullet_sub "navigation: my-help <topic> [args] / my-help <category>"
+    ux_bullet_sub "details: my-help <section>  (example: my-help categories)"
+}
+
+_my_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "categories"
+    ux_bullet_sub "popular"
+    ux_bullet_sub "navigation"
+}
+
+_my_help_show_popular() {
+    ux_section "Popular Topics"
+    ux_table_header "Topic" "Description"
+    local desc
+    desc=$(_my_help_topic_description git)
+    ux_table_row "git" "$desc"
+    desc=$(_my_help_topic_description docker)
+    ux_table_row "docker" "$desc"
+    desc=$(_my_help_topic_description claude)
+    ux_table_row "claude" "$desc"
+    desc=$(_my_help_topic_description uv)
+    ux_table_row "uv" "$desc"
+    desc=$(_my_help_topic_description fzf)
+    ux_table_row "fzf" "$desc"
+}
+
+_my_help_show_navigation() {
+    ux_section "Navigation"
+    ux_bullet "my-help <category>      - Show a category (example: my-help ai)"
+    ux_bullet "my-help <topic> [args]  - Show a topic (example: my-help git stash)"
+    ux_bullet "category-help           - Browse categories"
+    ux_bullet "register-help           - How to add new topics"
+}
+
+_my_help_section_rows() {
+    case "$1" in
+        categories)
+            _my_help_show_categories
+            ;;
+        popular)
+            _my_help_show_popular
+            ;;
+        navigation)
+            _my_help_show_navigation
+            ;;
+        *)
+            ux_error "Unknown my-help section: $1"
+            ux_info "Try: my-help --list"
+            return 1
+            ;;
+    esac
+}
+
 # Main help function - displays all registered commands or specific help
 my_help_impl() {
     local rc=0
@@ -574,10 +633,24 @@ my_help_impl() {
         _HELP_DEFAULTS_REGISTERED=1
     fi
 
-    if [ -z "$1" ]; then
-        _my_help_show_all
-        rc=$?
-    else
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _my_help_summary
+            rc=$?
+            ;;
+        --list|list)
+            _my_help_list_sections
+            rc=$?
+            ;;
+        --all|all)
+            _my_help_show_all
+            rc=$?
+            ;;
+        categories|popular|navigation)
+            _my_help_section_rows "$1"
+            rc=$?
+            ;;
+        *)
         # If argument is provided, show specific help for that command
         local cmd_name="$1"
         shift || true
@@ -667,7 +740,8 @@ my_help_impl() {
                 esac
             fi
         fi
-    fi
+            ;;
+    esac
 
     if [ "$_my_help_restore_xtrace" = "1" ]; then
         if [ -n "$BASH_VERSION" ]; then

--- a/shell-common/functions/zz_help_standard_adapter.sh
+++ b/shell-common/functions/zz_help_standard_adapter.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# shell-common/functions/zz_help_standard_adapter.sh
+# Normalizes my-help topic functions to the command-guidelines interface.
+
+_help_std_is_function() {
+    if [ -n "${ZSH_VERSION:-}" ]; then
+        whence -w "$1" 2>/dev/null | grep -q ": function$"
+    else
+        declare -f "$1" >/dev/null 2>&1
+    fi
+}
+
+_help_std_get_definition() {
+    if [ -n "${ZSH_VERSION:-}" ]; then
+        typeset -f "$1" 2>/dev/null
+    else
+        declare -f "$1" 2>/dev/null
+    fi
+}
+
+_help_std_is_wrapped() {
+    _help_std_is_function "_help_std_orig_$1"
+}
+
+_help_std_is_guideline_compliant() {
+    local func_name="$1"
+    local def
+    local get_definition_fn='_help_std_get_definition'
+    def="$($get_definition_fn "$func_name")" || return 1
+
+    printf "%s\n" "$def" | grep -Fq "[section|--list|--all]" || return 1
+    printf "%s\n" "$def" | grep -Fq 'ux_bullet "sections"' || return 1
+    return 0
+}
+
+_help_std_func_to_alias() {
+    local func_name="$1"
+    local topic="${func_name%_help}"
+    printf "%s-help" "${topic//_/-}"
+}
+
+_help_std_strip_category_prefix() {
+    printf "%s\n" "$1" | sed "s/^\[[^]]*\][[:space:]]*//"
+}
+
+_help_std_get_description() {
+    local func_name="$1"
+    local value=""
+
+    if [ -n "${BASH_VERSION:-}" ] || [ -n "${ZSH_VERSION:-}" ]; then
+        eval "value=\${HELP_DESCRIPTIONS[$func_name]:-}"
+    fi
+
+    if [ -n "$value" ]; then
+        _help_std_strip_category_prefix "$value"
+    else
+        local topic="${func_name%_help}"
+        printf "%s command reference" "${topic//_/ }"
+    fi
+}
+
+_help_std_clone_original() {
+    local func_name="$1"
+    local def
+    local cloned_name="_help_std_orig_${func_name}"
+    local get_definition_fn='_help_std_get_definition'
+
+    def="$($get_definition_fn "$func_name")" || return 1
+    def="$(printf "%s\n" "$def" | sed "1s/^${func_name}[[:space:]]*()/${cloned_name}()/")"
+    eval "$def"
+}
+
+_help_std_define_wrapper() {
+    local func_name="$1"
+    local alias_name="$2"
+    local description="$3"
+
+    eval "
+_help_std_summary_${func_name}() {
+    ux_info \"Usage: ${alias_name} [section|--list|--all]\"
+    ux_bullet \"sections\"
+    ux_bullet_sub \"overview: ${description}\"
+    ux_bullet_sub \"details: ${alias_name} <section>  (example: ${alias_name} overview)\"
+}
+
+_help_std_list_${func_name}() {
+    ux_bullet \"overview\"
+}
+
+_help_std_rows_${func_name}_overview() {
+    _help_std_orig_${func_name}
+}
+
+_help_std_full_${func_name}() {
+    _help_std_rows_${func_name}_overview
+}
+
+${func_name}() {
+    case \"\${1:-}\" in
+        \"\"|-h|--help|help)
+            _help_std_summary_${func_name}
+            ;;
+        --list|list)
+            _help_std_list_${func_name}
+            ;;
+        --all|all)
+            _help_std_full_${func_name}
+            ;;
+        overview)
+            _help_std_rows_${func_name}_overview
+            ;;
+        *)
+            _help_std_orig_${func_name} \"\$@\"
+            ;;
+    esac
+}
+"
+}
+
+_help_std_define_zsh_dash_function() {
+    local alias_name="$1"
+    local func_name="$2"
+
+    [ -n "${ZSH_VERSION:-}" ] || return 0
+
+    if _help_std_is_function "$alias_name"; then
+        return 0
+    fi
+
+    setopt localoptions no_aliases
+    eval "
+${alias_name}() {
+    ${func_name} \"\$@\"
+}
+"
+}
+
+_help_std_wrap_one() {
+    local func_name="$1"
+    local alias_name
+    local description
+    local get_description_fn='_help_std_get_description'
+
+    _help_std_is_function "$func_name" || return 0
+    alias_name="$(_help_std_func_to_alias "$func_name")"
+    _help_std_define_zsh_dash_function "$alias_name" "$func_name"
+
+    case "$func_name" in
+        git_help|gwt_help)
+            alias "${alias_name}=${func_name}" 2>/dev/null || true
+            return 0
+            ;;
+    esac
+
+    _help_std_is_wrapped "$func_name" && return 0
+    _help_std_is_guideline_compliant "$func_name" && return 0
+
+    description="$($get_description_fn "$func_name")"
+
+    _help_std_clone_original "$func_name" || return 1
+    _help_std_define_wrapper "$func_name" "$alias_name" "$description"
+
+    alias "${alias_name}=${func_name}" 2>/dev/null || true
+    return 0
+}
+
+_help_std_wrap_topics() {
+    local topic
+    local helper_name
+
+    while IFS= read -r topic; do
+        [ -n "$topic" ] || continue
+        helper_name="${topic}_help"
+        _help_std_wrap_one "$helper_name" || true
+    done <<'EOF'
+git
+gwt
+uv
+py
+nvm
+npm
+bun
+pp
+cli
+ux
+du
+psql
+mytool
+docker
+dproxy
+sys
+proxy
+ssl
+mount
+mysql
+redis
+gpu
+network
+claude
+cc
+gemini
+codex
+litellm
+ollama
+claude_plugins
+claude_skills_marketplace
+superpowers
+fzf
+fd
+fasd
+ripgrep
+pet
+bat
+zsh
+zsh_autosuggestions
+gc
+tmux
+p10k
+crt
+apt
+pip
+ghostty
+dot
+show_doc
+notion
+work_log
+work
+dir
+opencode
+category
+register
+EOF
+}
+
+apply_help_standard_adapter() {
+    if _help_std_is_function "_register_default_help_descriptions"; then
+        _register_default_help_descriptions >/dev/null 2>&1 || true
+    fi
+
+    _help_std_wrap_topics
+}
+
+# Apply once for help functions sourced from shell-common/functions/.
+# bash/zsh loader re-applies after integrations are sourced.
+apply_help_standard_adapter

--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -28,13 +28,30 @@ fi
 # Color Definitions (tput-based with fallback to empty strings)
 # =============================================================================
 
+_UX_DISABLE_ANSI=false
+if [ "${DOTFILES_TEST_MODE:-}" = "1" ] || [ "${TERM:-}" = "dumb" ] || [ -n "${NO_COLOR:-}" ]; then
+    _UX_DISABLE_ANSI=true
+fi
+
 # Text styles
 export UX_BOLD
-UX_BOLD=$(tput bold 2>/dev/null || echo "")
+if $_UX_DISABLE_ANSI; then
+    UX_BOLD=""
+else
+    UX_BOLD=$(tput bold 2>/dev/null || echo "")
+fi
 export UX_DIM
-UX_DIM=$(tput dim 2>/dev/null || echo "")
+if $_UX_DISABLE_ANSI; then
+    UX_DIM=""
+else
+    UX_DIM=$(tput dim 2>/dev/null || echo "")
+fi
 export UX_RESET
-UX_RESET=$(tput sgr0 2>/dev/null || echo "")
+if $_UX_DISABLE_ANSI; then
+    UX_RESET=""
+else
+    UX_RESET=$(tput sgr0 2>/dev/null || echo "")
+fi
 
 # Determine directory where this script is located
 # This allows the library to be self-contained and portable
@@ -69,17 +86,41 @@ ux_get_safe_script_name() {
 # Semantic colors (named by purpose, not appearance)
 # Use these instead of direct color codes for consistency
 export UX_PRIMARY
-UX_PRIMARY=$(tput setaf 4 2>/dev/null || echo "") # blue - headers, titles
+if $_UX_DISABLE_ANSI; then
+    UX_PRIMARY=""
+else
+    UX_PRIMARY=$(tput setaf 4 2>/dev/null || echo "") # blue - headers, titles
+fi
 export UX_SUCCESS
-UX_SUCCESS=$(tput setaf 2 2>/dev/null || echo "") # green - success states
+if $_UX_DISABLE_ANSI; then
+    UX_SUCCESS=""
+else
+    UX_SUCCESS=$(tput setaf 2 2>/dev/null || echo "") # green - success states
+fi
 export UX_WARNING
-UX_WARNING=$(tput setaf 3 2>/dev/null || echo "") # yellow - warnings
+if $_UX_DISABLE_ANSI; then
+    UX_WARNING=""
+else
+    UX_WARNING=$(tput setaf 3 2>/dev/null || echo "") # yellow - warnings
+fi
 export UX_ERROR
-UX_ERROR=$(tput setaf 1 2>/dev/null || echo "") # red - errors
+if $_UX_DISABLE_ANSI; then
+    UX_ERROR=""
+else
+    UX_ERROR=$(tput setaf 1 2>/dev/null || echo "") # red - errors
+fi
 export UX_INFO
-UX_INFO=$(tput setaf 6 2>/dev/null || echo "") # cyan - info messages
+if $_UX_DISABLE_ANSI; then
+    UX_INFO=""
+else
+    UX_INFO=$(tput setaf 6 2>/dev/null || echo "") # cyan - info messages
+fi
 export UX_MUTED
-UX_MUTED=$(tput setaf 8 2>/dev/null || echo "") # gray - secondary info
+if $_UX_DISABLE_ANSI; then
+    UX_MUTED=""
+else
+    UX_MUTED=$(tput setaf 8 2>/dev/null || echo "") # gray - secondary info
+fi
 
 # =============================================================================
 # Standard Output Functions

--- a/tests/integration/test_help_compact_policy.py
+++ b/tests/integration/test_help_compact_policy.py
@@ -173,7 +173,15 @@ class TestGwtHelpCanonicalEntrypoint:
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     @pytest.mark.parametrize(
         "cmd",
-        ["gwt-help", "gwt-help spawn", "gwt-help teardown", "gwt-help --list", "gwt-help --all"],
+        [
+            "gwt-help",
+            "gwt-help spawn",
+            "gwt-help teardown",
+            "gwt-help --list",
+            "gwt-help --all",
+            "gwt-help section",
+            "gwt-help sections",
+        ],
     )
     def test_gwt_help_canonical_commands_work(self, shell_runner, shell, cmd):
         if shell == "bash":
@@ -194,7 +202,17 @@ class TestGwtHelpSotInterface:
     """gwt-help supports list/all forms and reuses section rows in --all output."""
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
-    @pytest.mark.parametrize("cmd", ["gwt_help --list", "gwt_help list", "gwt_help --all", "gwt_help all"])
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gwt_help --list",
+            "gwt_help list",
+            "gwt_help section",
+            "gwt_help sections",
+            "gwt_help --all",
+            "gwt_help all",
+        ],
+    )
     def test_gwt_help_supports_list_and_all_forms(self, shell_runner, shell, cmd):
         result = shell_runner(shell, cmd)
         assert result.exit_code == 0, f"{shell}: '{cmd}' failed"

--- a/tests/integration/test_help_compact_policy.py
+++ b/tests/integration/test_help_compact_policy.py
@@ -1,9 +1,10 @@
 """
 Compact help policy tests.
 
-Validates the new help UX rules:
-- canonical gwt help entrypoint is gwt-help
+Validates help UX rules from docs/standards/command-guidelines.md:
+- canonical *-help entrypoints
 - default help outputs are compact (<= 15 lines)
+- standardized summary/list/all interface
 """
 
 import re
@@ -11,6 +12,62 @@ import re
 import pytest
 
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+HELP_TOPICS = [
+    "apt_help",
+    "bat_help",
+    "bun_help",
+    "category_help",
+    "cc_help",
+    "claude_help",
+    "claude_plugins_help",
+    "claude_skills_marketplace_help",
+    "cli_help",
+    "codex_help",
+    "crt_help",
+    "dir_help",
+    "docker_help",
+    "dot_help",
+    "dproxy_help",
+    "du_help",
+    "fasd_help",
+    "fd_help",
+    "fzf_help",
+    "gc_help",
+    "gemini_help",
+    "git_help",
+    "gwt_help",
+    "gpu_help",
+    "litellm_help",
+    "mytool_help",
+    "mysql_help",
+    "network_help",
+    "notion_help",
+    "npm_help",
+    "nvm_help",
+    "ollama_help",
+    "opencode_help",
+    "p10k_help",
+    "pip_help",
+    "pet_help",
+    "pp_help",
+    "proxy_help",
+    "psql_help",
+    "py_help",
+    "redis_help",
+    "register_help",
+    "ripgrep_help",
+    "show_doc_help",
+    "ssl_help",
+    "superpowers_help",
+    "sys_help",
+    "tmux_help",
+    "uv_help",
+    "work_help",
+    "work_log_help",
+    "zsh_help",
+    "zsh_autosuggestions_help",
+]
 
 
 def _non_empty_line_count(shell_runner, shell, cmd):
@@ -24,22 +81,85 @@ def _normalized_lines(text):
     return [line.strip() for line in stripped.splitlines() if line.strip()]
 
 
-class TestCompactHelpLineLimit:
-    """Default help outputs must stay within 15 non-empty lines."""
+def _func_to_alias(func_name):
+    topic = func_name.removesuffix("_help")
+    return f"{topic.replace('_', '-')}-help"
+
+
+def _first_section_token(list_output):
+    stopwords = {"usage", "try", "sections", "section", "help", "and", "or"}
+    stripped = ANSI_ESCAPE_RE.sub("", list_output.lower())
+    tokens = re.findall(r"[a-z0-9_-]+", stripped)
+    for token in tokens:
+        if token in stopwords:
+            continue
+        if token.endswith("-help"):
+            continue
+        return token
+    return "overview"
+
+
+class TestHelpStandardInterface:
+    """All my-help topics should expose the standard help interface."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("func_name", HELP_TOPICS)
+    def test_default_help_within_15_lines(self, shell_runner, shell, func_name):
+        lines = _non_empty_line_count(shell_runner, shell, func_name)
+        assert lines <= 15, f"{shell}: '{func_name}' exceeded 15 lines ({lines})"
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     @pytest.mark.parametrize(
-        "cmd",
-        [
-            "git_help",
-            "git_help stash",
-            "gwt_help",
-            "gwt_help spawn",
-        ],
+        "func_name",
+        HELP_TOPICS,
     )
-    def test_compact_help_within_15_lines(self, shell_runner, shell, cmd):
-        lines = _non_empty_line_count(shell_runner, shell, cmd)
-        assert lines <= 15, f"{shell}: '{cmd}' exceeded 15 lines ({lines})"
+    def test_default_help_uses_standard_template(self, shell_runner, shell, func_name):
+        result = shell_runner(shell, func_name)
+        assert result.exit_code == 0, f"{shell}: '{func_name}' failed"
+        lines = _normalized_lines(result.stdout)
+
+        assert any("[section|--list|--all]" in line for line in lines), (
+            f"{shell}: '{func_name}' missing standard usage template"
+        )
+        assert any("sections" in line.lower() for line in lines), f"{shell}: '{func_name}' missing sections summary"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("func_name", HELP_TOPICS)
+    def test_supports_list_and_all(self, shell_runner, shell, func_name):
+        for arg in ("--list", "list", "--all", "all"):
+            result = shell_runner(shell, f"{func_name} {arg}")
+            assert result.exit_code == 0, f"{shell}: '{func_name} {arg}' failed"
+            assert result.stdout.strip(), f"{shell}: '{func_name} {arg}' returned empty output"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("func_name", HELP_TOPICS)
+    def test_section_lookup_is_available(self, shell_runner, shell, func_name):
+        list_result = shell_runner(shell, f"{func_name} --list")
+        assert list_result.exit_code == 0, f"{shell}: '{func_name} --list' failed"
+
+        section = _first_section_token(list_result.stdout)
+        section_result = shell_runner(shell, f"{func_name} {section}")
+        assert section_result.exit_code == 0, f"{shell}: '{func_name} {section}' failed"
+        assert section_result.stdout.strip(), f"{shell}: '{func_name} {section}' returned empty output"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("func_name", HELP_TOPICS)
+    def test_canonical_alias_exists(self, shell_runner, shell, func_name):
+        alias_name = _func_to_alias(func_name)
+        result = shell_runner(shell, f"alias {alias_name}")
+        assert result.exit_code == 0, f"{shell}: '{alias_name}' alias not defined"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("func_name", HELP_TOPICS)
+    def test_canonical_alias_invocation_works(self, shell_runner, shell, func_name):
+        alias_name = _func_to_alias(func_name)
+        cmd = f"{alias_name} --list"
+        if shell == "bash":
+            # bash non-interactive mode disables alias expansion by default.
+            result = shell_runner(shell, f"shopt -s expand_aliases; eval '{cmd}'")
+        else:
+            result = shell_runner(shell, cmd)
+        assert result.exit_code == 0, f"{shell}: '{cmd}' failed"
 
 
 class TestGwtHelpCanonicalEntrypoint:
@@ -92,9 +212,7 @@ class TestGwtHelpSotInterface:
         assert not any("sections: add | list | remove | prune | spawn | teardown" in line for line in lines), (
             f"{shell}: legacy flat section summary detected"
         )
-        assert any("details: gwt-help <section>" in line for line in lines), (
-            f"{shell}: details guide missing"
-        )
+        assert any("details: gwt-help <section>" in line for line in lines), f"{shell}: details guide missing"
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     @pytest.mark.parametrize(

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -1,22 +1,24 @@
 """
 Test suite for my-help() help topics.
 
-Tests that all auto-sourced help topics (34 total) are callable
+Tests that all registered my-help topics are callable
 without errors in both bash and zsh environments.
 """
 
 import pytest
 
-# Auto-sourced help topics
-# Excludes: mount-help, addmnt-help (not auto-loaded by main.bash/main.zsh)
-# Use function names (underscores) instead of aliases (dashes) for non-interactive subprocess testing
 HELP_TOPICS = [
     "apt_help",
     "bat_help",
+    "bun_help",
+    "category_help",
     "cc_help",
     "claude_help",
+    "claude_plugins_help",
+    "claude_skills_marketplace_help",
     "cli_help",
     "codex_help",
+    "crt_help",
     "dir_help",
     "docker_help",
     "dot_help",
@@ -34,18 +36,31 @@ HELP_TOPICS = [
     "mytool_help",
     "mysql_help",
     "network_help",
+    "notion_help",
     "npm_help",
     "nvm_help",
+    "ollama_help",
+    "opencode_help",
     "p10k_help",
+    "pip_help",
     "pet_help",
     "pp_help",
     "proxy_help",
     "psql_help",
     "py_help",
+    "redis_help",
+    "register_help",
     "ripgrep_help",
+    "show_doc_help",
+    "ssl_help",
+    "superpowers_help",
     "sys_help",
+    "tmux_help",
     "uv_help",
+    "work_help",
+    "work_log_help",
     "zsh_help",
+    "zsh_autosuggestions_help",
 ]
 
 

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -84,7 +84,7 @@ class TestHelpTopicsBasic:
         """Verify `my-help` works in zsh even when alias expansion is disabled."""
         result = shell_runner("zsh", "setopt no_aliases; my-help")
         assert result.exit_code == 0, f"zsh: my-help failed with exit code {result.exit_code}"
-        assert "Dotfiles Help Functions" in result.stdout
+        assert "Usage: my-help [topic|category|section|--list|--all]" in result.stdout
 
     def test_my_help_dash_command_survives_conflicting_alias_in_zsh(self, shell_runner):
         """Verify sourcing `my_help.sh` doesn't fail even if `my-help` alias already exists."""
@@ -97,14 +97,22 @@ class TestHelpTopicsBasic:
         )
         result = shell_runner("zsh", cmd)
         assert result.exit_code == 0
-        assert "Dotfiles Help Functions" in result.stdout
+        assert "Usage: my-help [topic|category|section|--list|--all]" in result.stdout
 
     def test_my_help_works_under_strict_zsh_options(self, shell_runner):
         """`my-help` should work even with common strict options enabled."""
         cmd = "setopt err_exit pipe_fail noclobber; my-help"
         result = shell_runner("zsh", cmd)
         assert result.exit_code == 0
-        assert "Discovered help functions" in result.stdout
+        assert "sections" in result.stdout.lower()
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("arg", ["--list", "list", "--all", "all", "categories", "popular", "navigation"])
+    def test_my_help_standard_section_interface(self, shell_runner, shell, arg):
+        """my-help should support list/all/section interface."""
+        result = shell_runner(shell, f"my_help_impl {arg}")
+        assert result.exit_code == 0, f"{shell}: my_help_impl {arg} failed"
+        assert result.stdout.strip(), f"{shell}: my_help_impl {arg} returned empty output"
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     def test_help_descriptions_initialized(self, shell_runner, shell):
@@ -192,11 +200,11 @@ class TestHelpTopicsErrorHandling:
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     def test_my_help_without_args_lists_topics(self, shell_runner, shell):
-        """Test my_help_impl without arguments lists available help topics."""
+        """Test my_help_impl without arguments shows compact summary."""
         result = shell_runner(shell, "my_help_impl")
         assert result.exit_code == 0, f"{shell}: my_help_impl with no args failed"
-        # Should list multiple help topics
-        assert len(result.stdout.split("\n")) > 5, f"{shell}: my_help_impl output seems incomplete"
+        assert "Usage: my-help [topic|category|section|--list|--all]" in result.stdout
+        assert "sections" in result.stdout.lower()
 
 
 class TestHelpTopicsEnvironmentIntegrity:

--- a/tests/integration/test_mytool_help.py
+++ b/tests/integration/test_mytool_help.py
@@ -36,8 +36,8 @@ class TestMytoolHelpLists:
 
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     def test_mytool_help_lists_all_tools(self, shell_runner, shell):
-        """Test that mytool_help output contains key tool names."""
-        result = shell_runner(shell, "mytool_help")
+        """Detailed mytool output should contain key tool names."""
+        result = shell_runner(shell, "mytool_help --all")
         assert result.exit_code == 0
 
         output = result.stdout.lower()
@@ -65,5 +65,5 @@ class TestMytoolErrorHandling:
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     def test_mytool_help_resilient_to_missing_tools(self, shell_runner, shell):
         """Test that mytool_help function handles missing tool descriptions gracefully."""
-        result = shell_runner(shell, "mytool_help")
+        result = shell_runner(shell, "mytool_help --all")
         assert result.exit_code == 0, f"{shell}: mytool_help failed"

--- a/zsh/main.zsh
+++ b/zsh/main.zsh
@@ -131,6 +131,10 @@ if [ -d "${SHELL_COMMON}/tools/integrations" ]; then
     done
 fi
 
+# Normalize help interfaces after all help providers are sourced
+# (functions + integrations).
+typeset -f apply_help_standard_adapter >/dev/null 2>&1 && apply_help_standard_adapter
+
 # ═══════════════════════════════════════════════════════════════
 # Phase 7: Load Shared Tools - Custom (shell-common/tools/custom/)
 # NOTE: shell-common/tools/custom/ contains executable utility scripts


### PR DESCRIPTION
## Summary
- Standardized `*-help` interfaces across my-help topics to follow the command guidelines.
- Unified default/list/all/section behavior for `git-help`, `gwt-help`, and `my-help`.
- Fixed `gwt-help section` and `gwt-help sections` to behave as list entrypoints.

## Changes
- `refactor(help): normalize git-help list sections`
  - Converted `git_help --list` output to hierarchical `ux_bullet`/`ux_bullet_sub` tokens.
- `refactor(help): normalize gwt-help list sections`
  - Converted `gwt_help --list` output to section-token bullets.
- `feat(help): standardize help topics via adapter`
  - Added `zz_help_standard_adapter.sh` to normalize non-compliant topic help interfaces.
  - Re-applied adapter after integrations load in both bash/zsh loaders.
  - Added zsh-safe dashed help command shims and stabilized ANSI output in test/dumb terminals.
  - Expanded integration policy coverage for help topics and canonical alias invocation.
- `refactor(help): standardize my-help interface`
  - Updated `my-help` to compact summary + `--list/--all/<section>` interface while preserving topic/category routing.
- `fix(help): accept section keywords in gwt-help`
  - Mapped `section|sections` to list-mode behavior.
  - Added regression tests for canonical and function-style entrypoints.

## Test plan
- [x] `pytest -q tests/integration/test_help_compact_policy.py tests/integration/test_help_topics.py tests/integration/test_mytool_help.py`
- [x] `tox -e ruff,mypy,shellcheck,shfmt`
- [x] Manual check: `my-help gwt`, `gwt-help section`, `gwt-help sections`

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
