### PR TITLE
Standardize all *-help topics to SSOT pattern

### DIFF
--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -584,30 +584,85 @@ alias llm-help='litellm_help'
 
 # NOTE: UX library is loaded by the loader before functions/ — no need to reload here
 
+_ollama_help_summary() {
+    ux_info "Usage: ollama-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "auto: auto-detect backend (local vs docker)"
+    ux_bullet_sub "docker: ollama-models | ollama-pull | ollama-rm | ollama-show | logs | stats"
+    ux_bullet_sub "local: ollama-models | ollama-pull | ollama-run | ollama-status | ollama-serve"
+    ux_bullet_sub "status: backend status & API health"
+    ux_bullet_sub "details: ollama-help <section>  (example: ollama-help docker)"
+}
+
+_ollama_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "auto"
+    ux_bullet_sub "docker"
+    ux_bullet_sub "local"
+    ux_bullet_sub "status"
+}
+
+_ollama_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_ollama_help_section_rows() {
+    case "$1" in
+        auto)
+            _ollama_help_auto
+            ;;
+        docker)
+            _ollama_help_docker
+            ;;
+        local|wsl)
+            _ollama_help_local
+            ;;
+        status|backend)
+            _ollama_help_status
+            ;;
+        *)
+            ux_error "Unknown ollama-help section: $1"
+            ux_info "Try: ollama-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_ollama_help_full() {
+    ux_header "Ollama Management (All Backends)"
+
+    _ollama_help_render_section "Backend Status" _ollama_help_status
+    _ollama_help_render_section "Docker Backend" _ollama_help_docker
+    _ollama_help_render_section "Local (WSL) Backend" _ollama_help_local
+}
+
 # Main help function with auto-detection
 ollama_help() {
-    local mode="${1:-auto}"
-
-    case "$mode" in
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _ollama_help_summary
+            ;;
+        --list|list)
+            _ollama_help_list_sections
+            ;;
+        --all|all)
+            _ollama_help_full
+            ;;
+        --auto)
+            _ollama_help_auto
+            ;;
         --docker)
             _ollama_help_docker
             ;;
         --local)
             _ollama_help_local
             ;;
-        --status | --backend)
+        --status|--backend)
             _ollama_help_status
             ;;
-        --auto | auto | "")
-            _ollama_help_auto
-            ;;
-        --help | -h)
-            _ollama_help_usage
-            ;;
         *)
-            ux_error "Unknown option: $mode"
-            _ollama_help_usage
-            return 1
+            _ollama_help_section_rows "$1"
             ;;
     esac
 }
@@ -751,3 +806,5 @@ _ollama_help_usage() {
     ux_table_row "--status" "Display current Ollama status"
     ux_table_row "-h, --help" "Show this help"
 }
+
+alias ollama-help='ollama_help'

--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -503,21 +503,78 @@ alias gemini-help='gemini_help'
 
 # --- litellm_help (from litellm_help.sh) ---
 
-litellm_help() {
-    ux_header "LiteLLM Commands"
+_litellm_help_summary() {
+    ux_info "Usage: litellm-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "basic: llm-start | llm-stop | llm-restart | llm-status | llm-models | llm-test"
+    ux_bullet_sub "info: Path | URL | Key"
+    ux_bullet_sub "details: litellm-help <section>  (example: litellm-help basic)"
+}
 
-    ux_section "Basic Commands"
+_litellm_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "info"
+}
+
+_litellm_help_rows_basic() {
     ux_table_row "llm-start" "Start Stack" "docker compose up"
     ux_table_row "llm-stop" "Stop Stack" "docker compose down"
     ux_table_row "llm-restart" "Restart" "Stop & Start"
     ux_table_row "llm-status" "Status" "Check health & models"
     ux_table_row "llm-models" "List Models" "Show loaded models"
     ux_table_row "llm-test" "Test Model" "Run basic prompt"
+}
 
-    ux_section "Project Info"
+_litellm_help_rows_info() {
     ux_table_row "Path" "$LITELLM_PROJECT_PATH" ""
     ux_table_row "URL" "$LITELLM_URL" ""
     ux_table_row "Key" "$LITELLM_API_KEY" ""
+}
+
+_litellm_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_litellm_help_section_rows() {
+    case "$1" in
+        basic|commands)
+            _litellm_help_rows_basic
+            ;;
+        info|project)
+            _litellm_help_rows_info
+            ;;
+        *)
+            ux_error "Unknown litellm-help section: $1"
+            ux_info "Try: litellm-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_litellm_help_full() {
+    ux_header "LiteLLM Commands"
+
+    _litellm_help_render_section "Basic Commands" _litellm_help_rows_basic
+    _litellm_help_render_section "Project Info" _litellm_help_rows_info
+}
+
+litellm_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _litellm_help_summary
+            ;;
+        --list|list)
+            _litellm_help_list_sections
+            ;;
+        --all|all)
+            _litellm_help_full
+            ;;
+        *)
+            _litellm_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias litellm-help='litellm_help'

--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -9,50 +9,142 @@
 
 # --- claude_help (from claude_help.sh) ---
 
-claude_help() {
-    ux_header "Claude Code - MCP & Workflow Guide"
+_claude_help_summary() {
+    ux_info "Usage: claude-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "mcp: list | get | add | remove"
+    ux_bullet_sub "recommended: Playwright MCP | Sequential Thinking MCP"
+    ux_bullet_sub "setup: clinstall | ensure_jq | claude_init | claude_edit_settings"
+    ux_bullet_sub "sandbox: /sandbox | Auto-allow | pytest, git, npm"
+    ux_bullet_sub "config: settings.json | autoAllow | block paths | block cmds"
+    ux_bullet_sub "statusline: time | model | project | context | cost"
+    ux_bullet_sub "skills: claude-skills"
+    ux_bullet_sub "details: claude-help <section>  (example: claude-help mcp)"
+}
 
-    ux_section "MCP (Model Context Protocol) Commands"
+_claude_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "mcp"
+    ux_bullet_sub "recommended"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "sandbox"
+    ux_bullet_sub "config"
+    ux_bullet_sub "statusline"
+    ux_bullet_sub "skills"
+}
+
+_claude_help_rows_mcp() {
     ux_table_row "claude mcp list" "List installed MCP servers" ""
     ux_table_row "claude mcp get <name>" "Show MCP server details" ""
     ux_table_row "claude mcp add <name> ..." "Add MCP server" ""
     ux_table_row "claude mcp remove <name>" "Remove MCP server" ""
+}
 
-    ux_section "Recommended MCP Servers"
+_claude_help_rows_recommended() {
     ux_bullet "Playwright MCP: Web browser automation"
     ux_bullet "Install: ${UX_SUCCESS}claude mcp add playwright --transport stdio -- npx -y @playwright/mcp@latest${UX_RESET}"
     ux_bullet "Sequential Thinking MCP: Logical analysis"
     ux_bullet "Install: ${UX_SUCCESS}claude mcp add sequential-thinking --transport stdio -- npx -y @modelcontextprotocol/server-sequential-thinking${UX_RESET}"
+}
 
-    ux_section "Setup & Requirements"
+_claude_help_rows_setup() {
     ux_table_row "clinstall" "Install Claude Code CLI" ""
     ux_table_row "ensure_jq" "Install jq (required for statusline)" ""
     ux_table_row "claude_init" "Initialize config & skills" ""
     ux_table_row "claude_edit_settings" "Edit settings.json" ""
+}
 
-    ux_section "Sandbox Mode"
+_claude_help_rows_sandbox() {
     ux_info "Use in Claude conversation: ${UX_SUCCESS}/sandbox${UX_RESET}"
     ux_bullet "Select Auto-allow mode"
     ux_bullet "pytest, git, npm auto-approved"
+}
 
-    ux_section "Configuration"
+_claude_help_rows_config() {
     ux_info "Settings file: ${DOTFILES_ROOT:-$HOME/dotfiles}/claude/settings.json"
     ux_bullet "Sandbox: autoAllowBashIfSandboxed"
     ux_bullet "Auto-allow: pytest, ruff, mypy, tox"
     ux_bullet "Block: .env, ~/.aws, ~/.ssh"
     ux_bullet "Block commands: rm -rf, sudo rm"
+}
 
-    ux_section "Statusline Display"
+_claude_help_rows_statusline() {
     ux_info "Real-time session information in Claude Code status bar"
     ux_bullet "🕐 Time (morning/afternoon/night emoji + YY-MM-DD HH:MM:SS)"
     ux_bullet "🤖 Model (emoji + display name: 🐰 Haiku, 🎼 Sonnet, 🎭 Opus)"
     ux_bullet "📁 Project (folder name + git branch with emoji)"
     ux_bullet "📊 Context usage percentage + weekly percentage"
     ux_bullet "💰 Session cost (Green <\$5, Orange \$5-20, Red >\$20)"
+}
 
-    ux_section "Skills Management"
+_claude_help_rows_skills() {
     ux_table_row "claude-skills" "List available Claude Code skills" ""
     ux_info "Skills location: ${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills/"
+}
+
+_claude_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_claude_help_section_rows() {
+    case "$1" in
+        mcp)
+            _claude_help_rows_mcp
+            ;;
+        recommended|servers)
+            _claude_help_rows_recommended
+            ;;
+        setup|install)
+            _claude_help_rows_setup
+            ;;
+        sandbox)
+            _claude_help_rows_sandbox
+            ;;
+        config|configuration)
+            _claude_help_rows_config
+            ;;
+        statusline|status)
+            _claude_help_rows_statusline
+            ;;
+        skills)
+            _claude_help_rows_skills
+            ;;
+        *)
+            ux_error "Unknown claude-help section: $1"
+            ux_info "Try: claude-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_claude_help_full() {
+    ux_header "Claude Code - MCP & Workflow Guide"
+
+    _claude_help_render_section "MCP (Model Context Protocol) Commands" _claude_help_rows_mcp
+    _claude_help_render_section "Recommended MCP Servers" _claude_help_rows_recommended
+    _claude_help_render_section "Setup & Requirements" _claude_help_rows_setup
+    _claude_help_render_section "Sandbox Mode" _claude_help_rows_sandbox
+    _claude_help_render_section "Configuration" _claude_help_rows_config
+    _claude_help_render_section "Statusline Display" _claude_help_rows_statusline
+    _claude_help_render_section "Skills Management" _claude_help_rows_skills
+}
+
+claude_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _claude_help_summary
+            ;;
+        --list|list)
+            _claude_help_list_sections
+            ;;
+        --all|all)
+            _claude_help_full
+            ;;
+        *)
+            _claude_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Function to list Claude Code skills

--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -135,7 +135,7 @@ claude_help() {
         ""|-h|--help|help)
             _claude_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _claude_help_list_sections
             ;;
         --all|all)
@@ -400,7 +400,7 @@ codex_help() {
         ""|-h|--help|help)
             _codex_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _codex_help_list_sections
             ;;
         --all|all)
@@ -487,7 +487,7 @@ gemini_help() {
         ""|-h|--help|help)
             _gemini_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _gemini_help_list_sections
             ;;
         --all|all)
@@ -565,7 +565,7 @@ litellm_help() {
         ""|-h|--help|help)
             _litellm_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _litellm_help_list_sections
             ;;
         --all|all)
@@ -643,7 +643,7 @@ ollama_help() {
         ""|-h|--help|help)
             _ollama_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _ollama_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -311,34 +311,105 @@ alias claude-skills='get_claude_skills'
 
 # --- codex_help (from codex_help.sh) ---
 
-codex_help() {
-    ux_header "Codex Quick Commands"
+_codex_help_summary() {
+    ux_info "Usage: codex-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "basic: codex | codex-help | official help | codex-version | codex-yolo"
+    ux_bullet_sub "setup: codex-install | codex-uninstall | codex-status | codex-skills-sync | auto sync"
+    ux_bullet_sub "interactive: codex | codex prompt"
+    ux_bullet_sub "tips: config dir | auth | auto sync env vars"
+    ux_bullet_sub "details: codex-help <section>  (example: codex-help setup)"
+}
 
-    ux_section "Basic Commands"
+_codex_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "interactive"
+    ux_bullet_sub "tips"
+}
+
+_codex_help_rows_basic() {
     ux_table_row "codex" "codex" "Base command"
     ux_table_row "codex-help" "codex-help" "Show dotfiles codex commands"
     ux_table_row "Official help" "codex help | --help | -h" "Show CLI help"
     ux_table_row "codex-version" "codex --version" "Check version"
     ux_table_row "codex-yolo" "codex --dangerously-bypass-approvals-and-sandbox" "Bypass guardrails"
+}
 
-    ux_section "Installation & Setup"
+_codex_help_rows_setup() {
     ux_table_row "codex-install" "Install Script" "Install Codex CLI"
     ux_table_row "codex-uninstall" "Uninstall Script" "Remove Codex CLI"
     ux_table_row "codex-status" "Status Check" "Show installation status"
     ux_table_row "codex-skills-sync" "Skills Sync" "Sync skills symlinks"
     ux_table_row "Auto skill sync" "Enabled by default" "Before codex command"
+}
 
-    ux_section "Interactive Mode"
+_codex_help_rows_interactive() {
     ux_table_row "codex" "codex" "Start interactive"
     ux_table_row "codex prompt" "codex prompt" "Run with prompt"
+}
 
-    ux_section "Tips"
+_codex_help_rows_tips() {
     ux_bullet "Config: ~/.codex/ or ~/.config/codex/"
     ux_bullet "Auth: Use 'codex' to authenticate"
     ux_bullet "Auto sync: before codex command + prompt cycle"
     ux_bullet "Disable auto sync: export CODEX_SKILLS_AUTO_SYNC=0"
     ux_bullet "Verbose auto sync: export CODEX_SKILLS_AUTO_SYNC_VERBOSE=1"
     ux_bullet "Auto sync interval(sec): export CODEX_SKILLS_AUTO_SYNC_INTERVAL=5"
+}
+
+_codex_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_codex_help_section_rows() {
+    case "$1" in
+        basic|commands)
+            _codex_help_rows_basic
+            ;;
+        setup|install|installation)
+            _codex_help_rows_setup
+            ;;
+        interactive|run)
+            _codex_help_rows_interactive
+            ;;
+        tips|tip)
+            _codex_help_rows_tips
+            ;;
+        *)
+            ux_error "Unknown codex-help section: $1"
+            ux_info "Try: codex-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_codex_help_full() {
+    ux_header "Codex Quick Commands"
+
+    _codex_help_render_section "Basic Commands" _codex_help_rows_basic
+    _codex_help_render_section "Installation & Setup" _codex_help_rows_setup
+    _codex_help_render_section "Interactive Mode" _codex_help_rows_interactive
+    _codex_help_render_section "Tips" _codex_help_rows_tips
+}
+
+codex_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _codex_help_summary
+            ;;
+        --list|list)
+            _codex_help_list_sections
+            ;;
+        --all|all)
+            _codex_help_full
+            ;;
+        *)
+            _codex_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias codex-help='codex_help'

--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -416,23 +416,87 @@ alias codex-help='codex_help'
 
 # --- gemini_help (from gemini_help.sh) ---
 
-gemini_help() {
-    ux_header "Gemini CLI Quick Commands"
+_gemini_help_summary() {
+    ux_info "Usage: gemini-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "basic: gg | gflash | gpro | gver | ghelp"
+    ux_bullet_sub "setup: ginstall | guninstall"
+    ux_bullet_sub "tips: web login auth | ghelp for CLI options"
+    ux_bullet_sub "details: gemini-help <section>  (example: gemini-help basic)"
+}
 
-    ux_section "Basic Commands"
+_gemini_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "tips"
+}
+
+_gemini_help_rows_basic() {
     ux_table_row "gg" "gcloud gemini" "Base command"
     ux_table_row "gflash" "gemini --model flash" "Use Flash model"
     ux_table_row "gpro" "gemini --model pro" "Use Pro model"
     ux_table_row "gver" "gemini --version" "Check version"
     ux_table_row "ghelp" "gemini --help" "Gemini Help"
+}
 
-    ux_section "Installation & Setup"
+_gemini_help_rows_setup() {
     ux_table_row "ginstall" "Install Script" "Install Gemini CLI"
     ux_table_row "guninstall" "Uninstall Script" "Remove Gemini CLI"
+}
 
-    ux_section "Tips"
+_gemini_help_rows_tips() {
     ux_bullet "Auth via web login (no API key file needed)"
     ux_bullet "Use 'ghelp' for detailed CLI options"
+}
+
+_gemini_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gemini_help_section_rows() {
+    case "$1" in
+        basic|commands)
+            _gemini_help_rows_basic
+            ;;
+        setup|install|installation)
+            _gemini_help_rows_setup
+            ;;
+        tips|tip)
+            _gemini_help_rows_tips
+            ;;
+        *)
+            ux_error "Unknown gemini-help section: $1"
+            ux_info "Try: gemini-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_gemini_help_full() {
+    ux_header "Gemini CLI Quick Commands"
+
+    _gemini_help_render_section "Basic Commands" _gemini_help_rows_basic
+    _gemini_help_render_section "Installation & Setup" _gemini_help_rows_setup
+    _gemini_help_render_section "Tips" _gemini_help_rows_tips
+}
+
+gemini_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _gemini_help_summary
+            ;;
+        --list|list)
+            _gemini_help_list_sections
+            ;;
+        --all|all)
+            _gemini_help_full
+            ;;
+        *)
+            _gemini_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias gemini-help='gemini_help'

--- a/shell-common/functions/bat_help.sh
+++ b/shell-common/functions/bat_help.sh
@@ -129,7 +129,7 @@ _bat_help_full() {
 bat_help() {
     case "${1:-}" in
         ""|-h|--help|help) _bat_help_summary ;;
-        --list|list)        _bat_help_list_sections ;;
+        --list|list|section|sections)        _bat_help_list_sections ;;
         --all|all)          _bat_help_full ;;
         *)                  _bat_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/bat_help.sh
+++ b/shell-common/functions/bat_help.sh
@@ -1,59 +1,138 @@
 #!/bin/sh
 # shell-common/functions/bat_help.sh
 
-bat_help() {
-    ux_header "bat - Cat Replacement with Syntax Highlighting"
+_bat_help_summary() {
+    ux_info "Usage: bat-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: cat replacement | syntax highlighting | git integration"
+    ux_bullet_sub "basic: bat file | piped | multiple"
+    ux_bullet_sub "lines: -n | -r 5:10 | -r 5: | -r :10"
+    ux_bullet_sub "language: -l | --list-languages | --theme | --list-themes"
+    ux_bullet_sub "display: --plain | --color | --style"
+    ux_bullet_sub "git: shows changes (green/red)"
+    ux_bullet_sub "advanced: -A | -t | --tabs | -H"
+    ux_bullet_sub "config: ~/.config/bat/config defaults"
+    ux_bullet_sub "related: install-bat | ripgrep-help | fd-help | fzf-help"
+    ux_bullet_sub "details: bat-help <section>  (example: bat-help basic)"
+}
 
-    ux_section "Core Concept"
+_bat_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "lines"
+    ux_bullet_sub "language"
+    ux_bullet_sub "display"
+    ux_bullet_sub "git"
+    ux_bullet_sub "advanced"
+    ux_bullet_sub "config"
+    ux_bullet_sub "related"
+}
+
+_bat_help_rows_concept() {
     ux_bullet "Cat replacement with syntax highlighting"
     ux_bullet "Supports 200+ languages and file formats"
     ux_bullet "Git integration - shows file changes in color"
     ux_bullet "Automatic language detection from filename"
+}
 
-    ux_section "Basic Syntax"
+_bat_help_rows_basic() {
     ux_table_row "bat file.txt" "View file with syntax highlighting"
     ux_table_row "cat file.txt | bat" "View piped content"
     ux_table_row "bat file.txt file2.txt" "View multiple files"
+}
 
-    ux_section "Line Selection"
+_bat_help_rows_lines() {
     ux_table_row "bat -n file.txt" "Show line numbers"
     ux_table_row "bat -r 5:10 file.txt" "Show lines 5-10"
     ux_table_row "bat -r 5: file.txt" "Show from line 5 to end"
     ux_table_row "bat -r :10 file.txt" "Show first 10 lines"
+}
 
-    ux_section "Language & Theme"
+_bat_help_rows_language() {
     ux_table_row "bat -l python file.py" "Specify language explicitly"
     ux_table_row "bat --list-languages" "Show all supported languages"
     ux_table_row "bat --theme Monokai file.txt" "Use different color theme"
     ux_table_row "bat --list-themes" "Show all available themes"
+}
 
-    ux_section "Display Control"
+_bat_help_rows_display() {
     ux_table_row "bat --plain file.txt" "Plain output (no decorations)"
     ux_table_row "bat --color=never file.txt" "Disable colors"
     ux_table_row "bat --color=always file.txt" "Force colors"
     ux_table_row "bat --style=numbers file.txt" "Show only line numbers"
+}
 
-    ux_section "Git Integration"
+_bat_help_rows_git() {
     ux_table_row "bat file.txt" "Shows git changes (green/red lines)"
+}
 
-    ux_section "Advanced Options"
+_bat_help_rows_advanced() {
     ux_table_row "bat -A file.txt" "Show invisible characters"
     ux_table_row "bat -t file.txt" "Show tabs as visual indicators"
     ux_table_row "bat --tabs 4 file.txt" "Set tab width to 4 spaces"
     ux_table_row "bat -H file.txt" "Highlight specific lines"
+}
 
-    ux_section "Configuration"
+_bat_help_rows_config() {
     ux_info "Create ~/.config/bat/config for default options:"
     ux_bullet "--theme=Monokai Extended - Set default theme"
     ux_bullet "--style=numbers - Always show line numbers"
     ux_bullet "--tabs=4 - Set tab width"
     ux_bullet "--paging=auto - Auto pagination"
+}
 
-    ux_section "Related Help"
+_bat_help_rows_related() {
     ux_bullet "Install bat: ${UX_BOLD}install-bat${UX_RESET}"
     ux_bullet "Text search: ${UX_BOLD}ripgrep-help${UX_RESET}"
     ux_bullet "File finder: ${UX_BOLD}fd-help${UX_RESET}"
     ux_bullet "Fuzzy finder: ${UX_BOLD}fzf-help${UX_RESET}"
+}
+
+_bat_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_bat_help_section_rows() {
+    case "$1" in
+        concept)            _bat_help_rows_concept ;;
+        basic|syntax)       _bat_help_rows_basic ;;
+        lines|line)         _bat_help_rows_lines ;;
+        language|lang|theme) _bat_help_rows_language ;;
+        display)            _bat_help_rows_display ;;
+        git)                _bat_help_rows_git ;;
+        advanced)           _bat_help_rows_advanced ;;
+        config|configuration) _bat_help_rows_config ;;
+        related)            _bat_help_rows_related ;;
+        *)
+            ux_error "Unknown bat-help section: $1"
+            ux_info "Try: bat-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_bat_help_full() {
+    ux_header "bat - Cat Replacement with Syntax Highlighting"
+    _bat_help_render_section "Core Concept" _bat_help_rows_concept
+    _bat_help_render_section "Basic Syntax" _bat_help_rows_basic
+    _bat_help_render_section "Line Selection" _bat_help_rows_lines
+    _bat_help_render_section "Language & Theme" _bat_help_rows_language
+    _bat_help_render_section "Display Control" _bat_help_rows_display
+    _bat_help_render_section "Git Integration" _bat_help_rows_git
+    _bat_help_render_section "Advanced Options" _bat_help_rows_advanced
+    _bat_help_render_section "Configuration" _bat_help_rows_config
+    _bat_help_render_section "Related Help" _bat_help_rows_related
+}
+
+bat_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _bat_help_summary ;;
+        --list|list)        _bat_help_list_sections ;;
+        --all|all)          _bat_help_full ;;
+        *)                  _bat_help_section_rows "$1" ;;
+    esac
 }
 
 alias bat-help='bat_help'

--- a/shell-common/functions/category_help.sh
+++ b/shell-common/functions/category_help.sh
@@ -85,7 +85,7 @@ category_help() {
         ""|-h|--help|help)
             _category_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _category_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/category_help.sh
+++ b/shell-common/functions/category_help.sh
@@ -2,7 +2,7 @@
 # shell-common/functions/category_help.sh
 # categoryHelp - shared between bash and zsh
 
-category_help() {
+_category_help_ensure_loaded() {
     # Best-effort: if my-help isn't loaded yet, attempt to source it.
     if ! type my_help_impl >/dev/null 2>&1; then
         if [ -n "$SHELL_COMMON" ] && [ -f "${SHELL_COMMON}/functions/my_help.sh" ]; then
@@ -11,27 +11,90 @@ category_help() {
         fi
     fi
 
-    ux_header "Help Categories"
-
     if type _register_default_help_descriptions >/dev/null 2>&1; then
         if [ -z "${_HELP_DEFAULTS_REGISTERED:-}" ]; then
             _register_default_help_descriptions
             _HELP_DEFAULTS_REGISTERED=1
         fi
     fi
-
-    if [ -z "$1" ]; then
-        if type _my_help_show_categories >/dev/null 2>&1; then
-            _my_help_show_categories
-        else
-            my_help_impl
-        fi
-
-        ux_divider
-        ux_info "Use: my-help <category> (example: my-help ai)"
-        ux_info "Use: my-help <topic> (example: my-help git)"
-        return 0
-    fi
-
-    my_help_impl "$1"
 }
+
+_category_help_summary() {
+    ux_info "Usage: category-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "categories: list all help categories"
+    ux_bullet_sub "topics: route to my-help <topic>"
+    ux_bullet_sub "details: category-help <section>  (example: category-help categories)"
+}
+
+_category_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "categories"
+    ux_bullet_sub "topics"
+}
+
+_category_help_rows_categories() {
+    _category_help_ensure_loaded
+    if type _my_help_show_categories >/dev/null 2>&1; then
+        _my_help_show_categories
+    else
+        my_help_impl
+    fi
+    ux_divider
+    ux_info "Use: my-help <category> (example: my-help ai)"
+    ux_info "Use: my-help <topic> (example: my-help git)"
+}
+
+_category_help_rows_topics() {
+    _category_help_ensure_loaded
+    ux_bullet "Run: ${UX_BOLD}my-help <topic>${UX_RESET} to view a topic's help"
+    ux_bullet "Run: ${UX_BOLD}my-help${UX_RESET} for the full category list"
+    ux_bullet "Run: ${UX_BOLD}category-help categories${UX_RESET} to see categories inline"
+}
+
+_category_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_category_help_section_rows() {
+    case "$1" in
+        categories|category|cats)
+            _category_help_rows_categories
+            ;;
+        topics|topic)
+            _category_help_rows_topics
+            ;;
+        *)
+            # Backward compatibility: treat unknown section as a category name
+            # passed to my_help_impl (legacy behavior).
+            _category_help_ensure_loaded
+            my_help_impl "$1"
+            ;;
+    esac
+}
+
+_category_help_full() {
+    ux_header "Help Categories"
+    _category_help_render_section "Categories" _category_help_rows_categories
+    _category_help_render_section "Topics" _category_help_rows_topics
+}
+
+category_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _category_help_summary
+            ;;
+        --list|list)
+            _category_help_list_sections
+            ;;
+        --all|all)
+            _category_help_full
+            ;;
+        *)
+            _category_help_section_rows "$1"
+            ;;
+    esac
+}
+
+alias category-help='category_help'

--- a/shell-common/functions/cc_help.sh
+++ b/shell-common/functions/cc_help.sh
@@ -51,7 +51,7 @@ _cc_help_full() {
 cc_help() {
     case "${1:-}" in
         ""|-h|--help|help) _cc_help_summary ;;
-        --list|list)        _cc_help_list_sections ;;
+        --list|list|section|sections)        _cc_help_list_sections ;;
         --all|all)          _cc_help_full ;;
         *)                  _cc_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/cc_help.sh
+++ b/shell-common/functions/cc_help.sh
@@ -1,16 +1,60 @@
 #!/bin/sh
 # shell-common/functions/cc_help.sh
 
-cc_help() {
-    ux_header "Claude Code Usage Commands"
+_cc_help_summary() {
+    ux_info "Usage: cc-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "install: npm install -g ccusage"
+    ux_bullet_sub "commands: ccd | ccs | ccb"
+    ux_bullet_sub "details: cc-help <section>  (example: cc-help commands)"
+}
 
-    ux_section "Installation"
+_cc_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "install"
+    ux_bullet_sub "commands"
+}
+
+_cc_help_rows_install() {
     ux_bullet "Global prefix: npm install -g ccusage --prefix=\$HOME/.npm-global"
+}
 
-    ux_section "Commands"
+_cc_help_rows_commands() {
     ux_table_row "ccd" "ccusage daily --breakdown" "Token usage by model"
     ux_table_row "ccs" "ccusage session --sort tokens" "Session analysis"
     ux_table_row "ccb" "ccusage blocks --live" "Cache hit ratio (live)"
+}
+
+_cc_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_cc_help_section_rows() {
+    case "$1" in
+        install|setup)      _cc_help_rows_install ;;
+        commands|cmds)      _cc_help_rows_commands ;;
+        *)
+            ux_error "Unknown cc-help section: $1"
+            ux_info "Try: cc-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_cc_help_full() {
+    ux_header "Claude Code Usage Commands"
+    _cc_help_render_section "Installation" _cc_help_rows_install
+    _cc_help_render_section "Commands" _cc_help_rows_commands
+}
+
+cc_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _cc_help_summary ;;
+        --list|list)        _cc_help_list_sections ;;
+        --all|all)          _cc_help_full ;;
+        *)                  _cc_help_section_rows "$1" ;;
+    esac
 }
 
 alias cc-help='cc_help'

--- a/shell-common/functions/claude_plugins_help.sh
+++ b/shell-common/functions/claude_plugins_help.sh
@@ -2,97 +2,156 @@
 # shell-common/functions/claude_plugins_help.sh
 # Help display for Claude plugins (split from claude_plugins.sh)
 
-claude_plugins_help() {
-    ux_header "Claude Marketplace Plugins Management"
+_claude_plugins_help_summary() {
+    ux_info "Usage: claude-plugins-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "commands: open_claude_plugins | list-plugins | init-plugins-docs | sync-plugins-structure"
+    ux_bullet_sub "view: view-plugin-info | generate-plugin-doc-ko | create-plugin-structure-ko"
+    ux_bullet_sub "examples: quick examples for create-plugin-ko"
+    ux_bullet_sub "ai-tools: claude | gemini | codex"
+    ux_bullet_sub "workflow: recommended workflow"
+    ux_bullet_sub "structure: plugin and docs directory layout"
+    ux_bullet_sub "git: git integration & mount details"
+    ux_bullet_sub "details: claude-plugins-help <section>"
+}
 
+_claude_plugins_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "view"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "ai-tools"
+    ux_bullet_sub "workflow"
+    ux_bullet_sub "structure"
+    ux_bullet_sub "git"
+}
 
-    ux_section "Available Commands"
+_claude_plugins_help_rows_commands() {
+    ux_bullet "open_claude_plugins  - Open marketplace plugins directory in VSCode"
+    ux_bullet "list-plugins         - List all available marketplaces and their skills"
+    ux_bullet "init-plugins-docs    - Initialize Korean documentation directory structure"
+    ux_bullet "sync-plugins-structure - Create directory structure mirroring plugins organization"
+}
 
+_claude_plugins_help_rows_view() {
+    ux_bullet "view-plugin-info <plugin-name>"
+    ux_bullet "  Usage: ${UX_CODE}view-plugin-info algorithmic-art${UX_RESET}"
+    ux_bullet "generate-plugin-doc-ko <source-file> <output-file> [ai-tool]"
+    ux_bullet "  Default Claude: ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md${UX_RESET}"
+    ux_bullet "  Gemini: ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md gemini${UX_RESET}"
+    ux_bullet "create-plugin-structure-ko <marketplace> <plugin-path> [ai-tool]"
+    ux_bullet "  Default: ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md>${UX_RESET}"
+    ux_bullet "  Gemini: ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md> gemini${UX_RESET}"
+}
 
-    ux_section "open_claude_plugins"
-    ux_info "Open marketplace plugins directory in VSCode"
-    ux_bullet "Usage: ${UX_CODE}open_claude_plugins${UX_RESET}"
-
-
-    ux_section "list-plugins"
-    ux_info "List all available marketplaces and their skills"
-    ux_bullet "Usage: ${UX_CODE}list-plugins${UX_RESET}"
-
-
-    ux_section "init-plugins-docs"
-    ux_info "Initialize Korean documentation directory structure"
-    ux_bullet "Usage: ${UX_CODE}init-plugins-docs${UX_RESET}"
-
-
-    ux_section "sync-plugins-structure"
-    ux_info "Create directory structure mirroring plugins organization"
-    ux_bullet "Usage: ${UX_CODE}sync-plugins-structure${UX_RESET}"
-
-
-    ux_section "view-plugin-info <plugin-name>"
-    ux_info "View specific plugin information"
-    ux_bullet "Usage: ${UX_CODE}view-plugin-info algorithmic-art${UX_RESET}"
-
-
-    ux_section "generate-plugin-doc-ko <source-file> <output-file> [ai-tool]"
-    ux_info "Generate Korean documentation from plugin file using any AI tool"
-    ux_bullet "Usage (default Claude): ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md${UX_RESET}"
-    ux_bullet "Usage (Gemini): ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md gemini${UX_RESET}"
-
-
-    ux_section "create-plugin-structure-ko <marketplace> <plugin-path> [ai-tool]"
-    ux_info "Create structure and generate Korean docs in one command (RECOMMENDED)"
-    ux_bullet "Usage (default): ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md>${UX_RESET}"
-    ux_bullet "Usage (Gemini): ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md> gemini${UX_RESET}"
-
-
-    ux_section "Quick Examples"
+_claude_plugins_help_rows_examples() {
     ux_bullet "1. Generate with default AI (Claude):"
     ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md${UX_RESET}"
-
     ux_bullet "2. Generate with Gemini:"
     ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md gemini${UX_RESET}"
-
     ux_bullet "3. Change default AI tool for session:"
     ux_bullet "   ${UX_CODE}export CLAUDE_DOC_GENERATOR=codex${UX_RESET}"
     ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md${UX_RESET}"
-
     ux_bullet "4. Review the generated file:"
     ux_bullet "   ${UX_CODE}code ~/.claude/docs/marketplaces/claude-code-workflows/plugins/code-refactoring/agents/code-reviewer_KO.md${UX_RESET}"
-
     ux_bullet "5. Commit to git:"
     ux_bullet "   ${UX_CODE}cd ~/dotfiles && git add claude/docs/ && git commit -m 'docs: Add Korean summary'${UX_RESET}"
+}
 
-
-    ux_section "Supported AI Tools"
+_claude_plugins_help_rows_ai_tools() {
     ux_bullet "claude - Anthropic Claude (default)"
     ux_bullet "gemini - Google Gemini"
     ux_bullet "codex - OpenAI Codex"
     ux_bullet "Any CLI tool accepting -p or --prompt flag"
+}
 
-
-    ux_section "Recommended Workflow"
+_claude_plugins_help_rows_workflow() {
     ux_bullet "1. ${UX_CODE}init-plugins-docs${UX_RESET} - Initialize docs directory (first time only)"
     ux_bullet "2. ${UX_CODE}open_claude_plugins${UX_RESET} - Review plugin files in VSCode"
     ux_bullet "3. ${UX_CODE}create-plugin-ko <marketplace> <path>${UX_RESET} - Generate Korean summary"
     ux_bullet "4. Edit & customize generated ${UX_CODE}*_KO.md${UX_RESET} file"
     ux_bullet "5. Add personal notes to ${UX_CODE}README.md${UX_RESET}"
     ux_bullet "6. ${UX_CODE}git add && git commit${UX_RESET} - Save to dotfiles repository"
+}
 
-
-    ux_section "Directory Structure"
+_claude_plugins_help_rows_structure() {
     ux_info "Plugins (read-only marketplace):"
     ux_bullet "\$HOME/.claude/plugins/marketplaces/[marketplace]/plugins/[plugin-name]/agents/[agent].md"
-
     ux_info "Documentation (git-tracked, mounted):"
     ux_bullet "\$HOME/.claude/docs/marketplaces/[marketplace]/plugins/[plugin-name]/agents/"
     ux_bullet "  ├── [agent]_KO.md    (Korean summary, auto-generated)"
     ux_bullet "  └── README.md         (Learning notes, manual)"
+}
 
-
-    ux_section "Git Integration"
+_claude_plugins_help_rows_git() {
     ux_info "All documentation is mounted and automatically git-tracked:"
     ux_bullet "User location: ${UX_INFO}~/.claude/docs${UX_RESET} (via bind mount)"
     ux_bullet "Git source: ${UX_INFO}~/dotfiles/claude/docs${UX_RESET}"
     ux_bullet "Changes are version-controlled and shareable across machines"
 }
+
+_claude_plugins_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_claude_plugins_help_section_rows() {
+    case "$1" in
+        commands|cmd|cmds)
+            _claude_plugins_help_rows_commands
+            ;;
+        view|generate|gen)
+            _claude_plugins_help_rows_view
+            ;;
+        examples|example|ex)
+            _claude_plugins_help_rows_examples
+            ;;
+        ai-tools|ai|tools)
+            _claude_plugins_help_rows_ai_tools
+            ;;
+        workflow|flow)
+            _claude_plugins_help_rows_workflow
+            ;;
+        structure|dir|directory)
+            _claude_plugins_help_rows_structure
+            ;;
+        git|integration)
+            _claude_plugins_help_rows_git
+            ;;
+        *)
+            ux_error "Unknown claude-plugins-help section: $1"
+            ux_info "Try: claude-plugins-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_claude_plugins_help_full() {
+    ux_header "Claude Marketplace Plugins Management"
+    _claude_plugins_help_render_section "Available Commands" _claude_plugins_help_rows_commands
+    _claude_plugins_help_render_section "View & Generate" _claude_plugins_help_rows_view
+    _claude_plugins_help_render_section "Quick Examples" _claude_plugins_help_rows_examples
+    _claude_plugins_help_render_section "Supported AI Tools" _claude_plugins_help_rows_ai_tools
+    _claude_plugins_help_render_section "Recommended Workflow" _claude_plugins_help_rows_workflow
+    _claude_plugins_help_render_section "Directory Structure" _claude_plugins_help_rows_structure
+    _claude_plugins_help_render_section "Git Integration" _claude_plugins_help_rows_git
+}
+
+claude_plugins_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _claude_plugins_help_summary
+            ;;
+        --list|list)
+            _claude_plugins_help_list_sections
+            ;;
+        --all|all)
+            _claude_plugins_help_full
+            ;;
+        *)
+            _claude_plugins_help_section_rows "$1"
+            ;;
+    esac
+}
+
+alias claude-plugins-help='claude_plugins_help'

--- a/shell-common/functions/claude_plugins_help.sh
+++ b/shell-common/functions/claude_plugins_help.sh
@@ -142,7 +142,7 @@ claude_plugins_help() {
         ""|-h|--help|help)
             _claude_plugins_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _claude_plugins_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/cli_help.sh
+++ b/shell-common/functions/cli_help.sh
@@ -1,38 +1,102 @@
 #!/bin/sh
 # shell-common/functions/cli_help.sh
 
-cli_help() {
-    ux_header "Custom Project CLI Help"
+_cli_help_summary() {
+    ux_info "Usage: cli-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "repos: dotfiles | FinRx | dmc-playground"
+    ux_bullet_sub "urls: DEV | TEST | PROD"
+    ux_bullet_sub "finrx: run_fr_cli"
+    ux_bullet_sub "dmc: run_bes | run_tbes | run_pbes | run_api_cli | run_db_cli"
+    ux_bullet_sub "smt: run_smt | run_tsmt | run_psmt"
+    ux_bullet_sub "tips: project root | uv venv | no --reload in prod"
+    ux_bullet_sub "details: cli-help <section>  (example: cli-help repos)"
+}
 
-    ux_section "Repositories"
+_cli_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "repos"
+    ux_bullet_sub "urls"
+    ux_bullet_sub "finrx"
+    ux_bullet_sub "dmc"
+    ux_bullet_sub "smt"
+    ux_bullet_sub "tips"
+}
+
+_cli_help_rows_repos() {
     ux_table_row "dotfiles" "✨" "${REPO_DOTFILES_URL}"
     ux_table_row "FinRx" "💰" "${REPO_FINRX_URL}"
     ux_table_row "dmc-playground" "📚" "${REPO_DMC_PG_URL}"
+}
 
-    ux_section "Service URLs"
+_cli_help_rows_urls() {
     ux_table_row "DEV" "${SMT_DEV_URL} (port ${SMT_DEV_PORT})" "smithery-playground"
     ux_table_row "TEST" "${SMT_TEST_URL} (port ${SMT_TEST_PORT})" "smithery-playground"
     ux_table_row "PROD" "${SMT_PROD_URL} (port ${SMT_PROD_PORT})" "smithery-playground"
+}
 
-    ux_section "FinRx Commands"
+_cli_help_rows_finrx() {
     ux_table_row "run_fr_cli" "python ./src/ticker_library/cli/cli.py" "Run CLI"
+}
 
-    ux_section "dmc-playground Commands"
+_cli_help_rows_dmc() {
     ux_table_row "run_bes" "Backend dev server (reload)" "DEV: ${DEV_API_URL}"
     ux_table_row "run_tbes" "Backend test server (reload)" "TEST: ${TEST_API_URL}"
     ux_table_row "run_pbes" "Backend prod server (no reload)" "PROD: ${PROD_API_URL}"
     ux_table_row "run_api_cli [URL]" "API CLI (default: DEV)" "Query/test API"
     ux_table_row "run_db_cli [URL]" "DB CLI (default: DEV)" "Query/test database"
+}
 
-    ux_section "smithery-playground Commands"
+_cli_help_rows_smt() {
     ux_table_row "run_smt" "Dev server (reload)" "URL: ${SMT_DEV_URL}"
     ux_table_row "run_tsmt" "Test server (reload)" "URL: ${SMT_TEST_URL}"
     ux_table_row "run_psmt" "Prod server (no reload)" "URL: ${SMT_PROD_URL}"
+}
 
-    ux_section "Tips"
+_cli_help_rows_tips() {
     ux_bullet "Run from project root (current: ${PROJECT_ROOT})"
     ux_bullet "Recommend uv/pyproject-based venv (uvs/uvd)"
     ux_bullet "Never use --reload in production"
+}
+
+_cli_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_cli_help_section_rows() {
+    case "$1" in
+        repos|repositories) _cli_help_rows_repos ;;
+        urls|services)      _cli_help_rows_urls ;;
+        finrx)              _cli_help_rows_finrx ;;
+        dmc|dmc-playground) _cli_help_rows_dmc ;;
+        smt|smithery|smithery-playground) _cli_help_rows_smt ;;
+        tips)               _cli_help_rows_tips ;;
+        *)
+            ux_error "Unknown cli-help section: $1"
+            ux_info "Try: cli-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_cli_help_full() {
+    ux_header "Custom Project CLI Help"
+    _cli_help_render_section "Repositories" _cli_help_rows_repos
+    _cli_help_render_section "Service URLs" _cli_help_rows_urls
+    _cli_help_render_section "FinRx Commands" _cli_help_rows_finrx
+    _cli_help_render_section "dmc-playground Commands" _cli_help_rows_dmc
+    _cli_help_render_section "smithery-playground Commands" _cli_help_rows_smt
+    _cli_help_render_section "Tips" _cli_help_rows_tips
+}
+
+cli_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _cli_help_summary ;;
+        --list|list)        _cli_help_list_sections ;;
+        --all|all)          _cli_help_full ;;
+        *)                  _cli_help_section_rows "$1" ;;
+    esac
 }
 
 alias cli-help='cli_help'

--- a/shell-common/functions/cli_help.sh
+++ b/shell-common/functions/cli_help.sh
@@ -93,7 +93,7 @@ _cli_help_full() {
 cli_help() {
     case "${1:-}" in
         ""|-h|--help|help) _cli_help_summary ;;
-        --list|list)        _cli_help_list_sections ;;
+        --list|list|section|sections)        _cli_help_list_sections ;;
         --all|all)          _cli_help_full ;;
         *)                  _cli_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/database_help.sh
+++ b/shell-common/functions/database_help.sh
@@ -148,10 +148,21 @@ alias psql-help='psql_help'
 
 # --- redis_help (from redis_help.sh) ---
 
-redis_help() {
-    ux_header "Redis Service Management"
+_redis_help_summary() {
+    ux_info "Usage: redis-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "commands: server-ctl | ping | info | monitor | dbsize | keys | flush | config-get | slowlog | clients | memory | install-redis"
+    ux_bullet_sub "env: REDISCLI_AUTH | REDIS_DEFAULT_HOST | REDIS_DEFAULT_PORT"
+    ux_bullet_sub "details: redis-help <section>  (example: redis-help commands)"
+}
 
-    ux_section "Commands"
+_redis_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "env"
+}
+
+_redis_help_rows_commands() {
     ux_table_row "redis-server-ctl <action>" "Manage service" "start, stop, restart, status"
     ux_table_row "redis-ping" "Health check" "PING/PONG test"
     ux_table_row "redis-info [section]" "Server info" "server, memory, clients, etc."
@@ -164,11 +175,57 @@ redis_help() {
     ux_table_row "redis-clients" "Client list" "Connected clients info"
     ux_table_row "redis-memory" "Memory stats" "Memory usage details"
     ux_table_row "install-redis" "Install Redis" "Interactive installer for WSL"
+}
 
-    ux_section "Environment"
+_redis_help_rows_env() {
     ux_table_row "REDISCLI_AUTH" "Password" "Auto-auth for all commands"
     ux_table_row "REDIS_DEFAULT_HOST" "Server host" "Default: 127.0.0.1"
     ux_table_row "REDIS_DEFAULT_PORT" "Server port" "Default: 6379"
+}
+
+_redis_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_redis_help_section_rows() {
+    case "$1" in
+        commands|cmd)
+            _redis_help_rows_commands
+            ;;
+        env|environment)
+            _redis_help_rows_env
+            ;;
+        *)
+            ux_error "Unknown redis-help section: $1"
+            ux_info "Try: redis-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_redis_help_full() {
+    ux_header "Redis Service Management"
+
+    _redis_help_render_section "Commands" _redis_help_rows_commands
+    _redis_help_render_section "Environment" _redis_help_rows_env
+}
+
+redis_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _redis_help_summary
+            ;;
+        --list|list)
+            _redis_help_list_sections
+            ;;
+        --all|all)
+            _redis_help_full
+            ;;
+        *)
+            _redis_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias redis-help='redis_help'

--- a/shell-common/functions/database_help.sh
+++ b/shell-common/functions/database_help.sh
@@ -53,7 +53,7 @@ mysql_help() {
         ""|-h|--help|help)
             _mysql_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _mysql_help_list_sections
             ;;
         --all|all)
@@ -132,7 +132,7 @@ psql_help() {
         ""|-h|--help|help)
             _psql_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _psql_help_list_sections
             ;;
         --all|all)
@@ -216,7 +216,7 @@ redis_help() {
         ""|-h|--help|help)
             _redis_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _redis_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/database_help.sh
+++ b/shell-common/functions/database_help.sh
@@ -4,16 +4,68 @@
 
 # --- mysql_help (from mysql_help.sh) ---
 
-mysql_help() {
-    ux_header "MySQL Service Management"
+_mysql_help_summary() {
+    ux_info "Usage: mysql-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "service: mysql_list | mysql_dmc_dev | mysql_dmc_test | mysql_cmd | mysql_server"
+    ux_bullet_sub "details: mysql-help <section>  (example: mysql-help service)"
+}
 
-    ux_section "Service Commands"
+_mysql_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "service"
+}
+
+_mysql_help_rows_service() {
     ux_table_row "mysql_list" "List configured services" "Show all database connections"
     ux_table_row "mysql_dmc_dev" "Connect to dev database" "Use .my.cnf config"
     ux_table_row "mysql_dmc_test" "Connect to test database" "Use .my.cnf config"
     ux_table_row "mysql_cmd <svc> <cmd>" "Execute SQL command" "databases, tables, version, describe, status, etc."
     ux_table_row "mysql_server <action>" "Manage service" "start, stop, restart, status, reload"
 }
+
+_mysql_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_mysql_help_section_rows() {
+    case "$1" in
+        service|commands)
+            _mysql_help_rows_service
+            ;;
+        *)
+            ux_error "Unknown mysql-help section: $1"
+            ux_info "Try: mysql-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_mysql_help_full() {
+    ux_header "MySQL Service Management"
+
+    _mysql_help_render_section "Service Commands" _mysql_help_rows_service
+}
+
+mysql_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _mysql_help_summary
+            ;;
+        --list|list)
+            _mysql_help_list_sections
+            ;;
+        --all|all)
+            _mysql_help_full
+            ;;
+        *)
+            _mysql_help_section_rows "$1"
+            ;;
+    esac
+}
+
+alias mysql-help='mysql_help'
 
 # --- psql_help (from psql_help.sh) ---
 

--- a/shell-common/functions/database_help.sh
+++ b/shell-common/functions/database_help.sh
@@ -69,31 +69,79 @@ alias mysql-help='mysql_help'
 
 # --- psql_help (from psql_help.sh) ---
 
-psql_help() {
-    if [[ $# -gt 0 ]]; then
-        # Legacy/Direct mode support: psql_help <service> <cmd>
-        local svc=""
-        shift
-        local sql_cmd="$*"
-        PGSERVICE="$svc" psql -c "$sql_cmd"
-        return
-    fi
+_psql_help_summary() {
+    ux_info "Usage: psql-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "primary: psql_list | psql_bootstrap | psql_sync | psql_add | psql_del"
+    ux_bullet_sub "lowlevel: psql_db | psql_user"
+    ux_bullet_sub "details: psql-help <section>  (example: psql-help primary)"
+}
 
-    ux_header "PostgreSQL Manager"
+_psql_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "primary"
+    ux_bullet_sub "lowlevel"
+}
 
-    ux_section "Primary Commands"
+_psql_help_rows_primary() {
     ux_table_row "psql_list" "List Services" "Show all configured connections"
     ux_table_row "psql_bootstrap" "Create New" "Full Setup: Create DB, User, Grant & Save"
     ux_table_row "psql_sync" "Sync DBs" "Scan server and add existing DBs to config"
     ux_table_row "psql_add" "Add Link" "Manually add a shortcut for existing DB"
     ux_table_row "psql_del" "Remove" "Remove service (and optionally drop DB)"
+}
 
-    ux_section "Low-Level Management"
+_psql_help_rows_lowlevel() {
     ux_table_row "psql_db" "DB Ops" "list, create, delete, grant"
     ux_table_row "psql_user" "User Ops" "list, create, attr, passwd, delete"
+}
+
+_psql_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_psql_help_section_rows() {
+    case "$1" in
+        primary|main)
+            _psql_help_rows_primary
+            ;;
+        lowlevel|low|management)
+            _psql_help_rows_lowlevel
+            ;;
+        *)
+            ux_error "Unknown psql-help section: $1"
+            ux_info "Try: psql-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_psql_help_full() {
+    ux_header "PostgreSQL Manager"
+
+    _psql_help_render_section "Primary Commands" _psql_help_rows_primary
+    _psql_help_render_section "Low-Level Management" _psql_help_rows_lowlevel
 
     # Show services table
     psql_list
+}
+
+psql_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _psql_help_summary
+            ;;
+        --list|list)
+            _psql_help_list_sections
+            ;;
+        --all|all)
+            _psql_help_full
+            ;;
+        *)
+            _psql_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias psql-help='psql_help'

--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -121,7 +121,7 @@ docker_help() {
         ""|-h|--help|help)
             _docker_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _docker_help_list_sections
             ;;
         --all|all)
@@ -271,7 +271,7 @@ proxy_help() {
         ""|-h|--help|help)
             _proxy_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _proxy_help_list_sections
             ;;
         --all|all)
@@ -374,7 +374,7 @@ dproxy_help() {
         ""|-h|--help|help)
             _dproxy_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _dproxy_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -304,22 +304,86 @@ alias check-proxy='proxy_check'
 
 # --- dproxy_help (from dproxy_help.sh) ---
 
-dproxy_help() {
-    ux_header "Docker Corporate Proxy Setup Guide"
+_dproxy_help_summary() {
+    ux_info "Usage: dproxy-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "commands: dproxy_setup | dproxy_show | dproxy-help"
+    ux_bullet_sub "config: /etc/systemd/system/docker.service.d/http-proxy.conf"
+    ux_bullet_sub "reference: systemctl show | nano edit | daemon-reload | docker pull test"
+    ux_bullet_sub "details: dproxy-help <section>  (example: dproxy-help reference)"
+}
 
-    ux_section "Commands"
+_dproxy_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "config"
+    ux_bullet_sub "reference"
+}
+
+_dproxy_help_rows_commands() {
     ux_table_row "dproxy_setup" "Interactive setup script" "Configure Docker proxy"
     ux_table_row "dproxy_show" "Show current proxy config" "Display active settings"
     ux_table_row "dproxy-help" "Show this help" ""
+}
 
-    ux_section "Config File"
+_dproxy_help_rows_config() {
     ux_info "/etc/systemd/system/docker.service.d/http-proxy.conf"
+}
 
-    ux_section "Quick Reference"
+_dproxy_help_rows_reference() {
     ux_bullet "Check config: systemctl show --property=Environment docker"
     ux_bullet "Edit config: sudo nano /etc/systemd/system/docker.service.d/http-proxy.conf"
     ux_bullet "Apply changes: sudo systemctl daemon-reload && sudo systemctl restart docker"
     ux_bullet "Test connection: docker pull alpine:latest"
+}
+
+_dproxy_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_dproxy_help_section_rows() {
+    case "$1" in
+        commands|cmd)
+            _dproxy_help_rows_commands
+            ;;
+        config|file)
+            _dproxy_help_rows_config
+            ;;
+        reference|ref|quick)
+            _dproxy_help_rows_reference
+            ;;
+        *)
+            ux_error "Unknown dproxy-help section: $1"
+            ux_info "Try: dproxy-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_dproxy_help_full() {
+    ux_header "Docker Corporate Proxy Setup Guide"
+
+    _dproxy_help_render_section "Commands" _dproxy_help_rows_commands
+    _dproxy_help_render_section "Config File" _dproxy_help_rows_config
+    _dproxy_help_render_section "Quick Reference" _dproxy_help_rows_reference
+}
+
+dproxy_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _dproxy_help_summary
+            ;;
+        --list|list)
+            _dproxy_help_list_sections
+            ;;
+        --all|all)
+            _dproxy_help_full
+            ;;
+        *)
+            _dproxy_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias dproxy-help='dproxy_help'

--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -137,53 +137,121 @@ alias docker-help='docker_help'
 
 # --- proxy_help (from proxy_help.sh) ---
 
-proxy_help() {
+_proxy_help_summary() {
+    ux_info "Usage: proxy-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics: check-proxy | env | file | shell | conn | git"
+    ux_bullet_sub "commands: \$http_proxy | \$https_proxy | \$no_proxy | env | grep proxy"
+    ux_bullet_sub "set: export http_proxy | https_proxy | no_proxy"
+    ux_bullet_sub "unset: unset HTTP_PROXY HTTPS_PROXY NO_PROXY"
+    ux_bullet_sub "git: connectTimeout | lowSpeedLimit | lowSpeedTime | view config"
+    ux_bullet_sub "related: check-network quick | check-network"
+    ux_bullet_sub "notes: NO_PROXY commas | uppercase env | proxy-only check"
+    ux_bullet_sub "details: proxy-help <section>  (example: proxy-help set)"
+}
+
+_proxy_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "set"
+    ux_bullet_sub "unset"
+    ux_bullet_sub "git"
+    ux_bullet_sub "related"
+    ux_bullet_sub "notes"
+}
+
+_proxy_help_rows_diagnostics() {
+    ux_bullet "check-proxy          Run full diagnostic"
+    ux_bullet "check-proxy env      Environment variables only"
+    ux_bullet "check-proxy file     proxy.local.sh file check"
+    ux_bullet "check-proxy shell    Shell loading test"
+    ux_bullet "check-proxy conn     Configured proxy connectivity test"
+    ux_bullet "check-proxy git      Git configuration"
+}
+
+_proxy_help_rows_commands() {
+    ux_bullet "echo \$http_proxy          Current proxy setting"
+    ux_bullet "echo \$https_proxy         Current HTTPS proxy"
+    ux_bullet "echo \$no_proxy            NO_PROXY exceptions"
+    ux_bullet "env | grep -i proxy        Show all proxy vars"
+}
+
+_proxy_help_rows_set() {
+    ux_bullet "export http_proxy=\"http://proxy.example.com:8080/\""
+    ux_bullet "export https_proxy=\"http://proxy.example.com:8080/\""
+    ux_bullet "export no_proxy=\"localhost,127.0.0.1,.internal.domain.com\""
+}
+
+_proxy_help_rows_unset() {
+    ux_bullet "unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY"
+}
+
+_proxy_help_rows_git() {
+    ux_bullet "git config --global http.connectTimeout 60    Increase timeout"
+    ux_bullet "git config --global http.lowSpeedLimit 0      Disable low speed limit"
+    ux_bullet "git config --global http.lowSpeedTime 999999   Disable low speed time"
+    ux_bullet "git config --global -l | grep proxy           View git proxy config"
+}
+
+_proxy_help_rows_related() {
+    ux_bullet "check-network quick       General internet access check"
+    ux_bullet "check-network             DNS, HTTPS, git, apt, pip, curl checks"
+}
+
+_proxy_help_rows_notes() {
+    ux_warning "NO_PROXY with spaces is not recognized - use commas only"
+    ux_info "Some tools only recognize uppercase (HTTP_PROXY, HTTPS_PROXY)"
+    ux_info "check-proxy focuses on proxy configuration only"
+}
+
+_proxy_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_proxy_help_section_rows() {
+    case "$1" in
+        diagnostics|diag)
+            _proxy_help_rows_diagnostics
+            ;;
+        commands|quick)
+            _proxy_help_rows_commands
+            ;;
+        set|setting|setup)
+            _proxy_help_rows_set
+            ;;
+        unset|disable|disabling)
+            _proxy_help_rows_unset
+            ;;
+        git)
+            _proxy_help_rows_git
+            ;;
+        related)
+            _proxy_help_rows_related
+            ;;
+        notes|important)
+            _proxy_help_rows_notes
+            ;;
+        *)
+            ux_error "Unknown proxy-help section: $1"
+            ux_info "Try: proxy-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_proxy_help_full() {
     ux_header "Proxy Configuration & Diagnostics"
 
     if type ux_section >/dev/null 2>&1; then
-        ux_section "Diagnostic Commands"
-        ux_bullet "check-proxy          Run full diagnostic"
-        ux_bullet "check-proxy env      Environment variables only"
-        ux_bullet "check-proxy file     proxy.local.sh file check"
-        ux_bullet "check-proxy shell    Shell loading test"
-        ux_bullet "check-proxy conn     Configured proxy connectivity test"
-        ux_bullet "check-proxy git      Git configuration"
-
-
-        ux_section "Quick Commands"
-        ux_bullet "echo \$http_proxy          Current proxy setting"
-        ux_bullet "echo \$https_proxy         Current HTTPS proxy"
-        ux_bullet "echo \$no_proxy            NO_PROXY exceptions"
-        ux_bullet "env | grep -i proxy        Show all proxy vars"
-
-
-        ux_section "Setting Proxy (Corporate Environment)"
-        ux_bullet "export http_proxy=\"http://proxy.example.com:8080/\""
-        ux_bullet "export https_proxy=\"http://proxy.example.com:8080/\""
-        ux_bullet "export no_proxy=\"localhost,127.0.0.1,.internal.domain.com\""
-
-
-        ux_section "Disabling Proxy"
-        ux_bullet "unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY"
-
-
-        ux_section "Git Configuration"
-        ux_bullet "git config --global http.connectTimeout 60    Increase timeout"
-        ux_bullet "git config --global http.lowSpeedLimit 0      Disable low speed limit"
-        ux_bullet "git config --global http.lowSpeedTime 999999   Disable low speed time"
-        ux_bullet "git config --global -l | grep proxy           View git proxy config"
-
-
-        ux_section "Related Diagnostics"
-        ux_bullet "check-network quick       General internet access check"
-        ux_bullet "check-network             DNS, HTTPS, git, apt, pip, curl checks"
-
-
-        ux_section "Important Notes"
-        ux_warning "NO_PROXY with spaces is not recognized - use commas only"
-        ux_info "Some tools only recognize uppercase (HTTP_PROXY, HTTPS_PROXY)"
-        ux_info "check-proxy focuses on proxy configuration only"
-
+        _proxy_help_render_section "Diagnostic Commands" _proxy_help_rows_diagnostics
+        _proxy_help_render_section "Quick Commands" _proxy_help_rows_commands
+        _proxy_help_render_section "Setting Proxy (Corporate Environment)" _proxy_help_rows_set
+        _proxy_help_render_section "Disabling Proxy" _proxy_help_rows_unset
+        _proxy_help_render_section "Git Configuration" _proxy_help_rows_git
+        _proxy_help_render_section "Related Diagnostics" _proxy_help_rows_related
+        _proxy_help_render_section "Important Notes" _proxy_help_rows_notes
     else
         # Fallback for minimal shells without UX library
         echo "Diagnostic Commands:"
@@ -195,8 +263,24 @@ proxy_help() {
         echo "Quick Commands:"
         echo "  echo \$http_proxy         Current proxy setting"
         echo "  env | grep -i proxy      Show all proxy vars"
-
     fi
+}
+
+proxy_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _proxy_help_summary
+            ;;
+        --list|list)
+            _proxy_help_list_sections
+            ;;
+        --all|all)
+            _proxy_help_full
+            ;;
+        *)
+            _proxy_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Wrapper function for check_proxy.sh diagnostic

--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -4,26 +4,45 @@
 
 # --- docker_help (from docker_help.sh) ---
 
-docker_help() {
-    ux_header "Docker / Docker Compose Quick Commands"
+_docker_help_summary() {
+    ux_info "Usage: docker-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "compose: dc | dcu | dcud | dcd | dcl | dce"
+    ux_bullet_sub "compose-extra: dcps | dcb | dcr | dcdv | dcstop | dcstart"
+    ux_bullet_sub "basics: dps | dpsa | di | dstats | dstop | drm | drmi | dlogs | dinspect"
+    ux_bullet_sub "resources: ddf | dprune | dprune_full | dvols | dvol_rm | dnetwork_prune | dbuild_prune"
+    ux_bullet_sub "utilities: dbash | denv | dinspect_env | dstopall | drmall | dexport | dinstall | dproxy_setup"
+    ux_bullet_sub "details: docker-help <section>  (example: docker-help compose)"
+}
 
-    ux_section "Docker Compose Basics"
+_docker_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "compose"
+    ux_bullet_sub "compose-extra"
+    ux_bullet_sub "basics"
+    ux_bullet_sub "resources"
+    ux_bullet_sub "utilities"
+}
+
+_docker_help_rows_compose() {
     ux_table_row "dc" "docker compose" "Base command"
     ux_table_row "dcu" "docker compose up" "Foreground start"
     ux_table_row "dcud" "docker compose up -d" "Detached start"
     ux_table_row "dcd" "docker compose down" "Stop & remove"
     ux_table_row "dcl" "logs <svc>" "Smart logs (service/container)"
     ux_table_row "dce" "exec <svc> <cmd>" "Execute command"
+}
 
-    ux_section "Docker Compose Extra"
+_docker_help_rows_compose_extra() {
     ux_table_row "dcps" "docker compose ps" "Status"
     ux_table_row "dcb" "docker compose build" "Build services"
     ux_table_row "dcr" "docker compose restart" "Restart services"
     ux_table_row "dcdv" "down -v" "Stop & remove volumes"
     ux_table_row "dcstop" "stop" "Stop containers"
     ux_table_row "dcstart" "start" "Start containers"
+}
 
-    ux_section "Docker Basics"
+_docker_help_rows_basics() {
     ux_table_row "dps" "docker ps" "Running containers"
     ux_table_row "dpsa" "docker ps -a" "All containers"
     ux_table_row "di/dim" "docker images" "List images"
@@ -33,8 +52,9 @@ docker_help() {
     ux_table_row "drmi" "docker rmi" "Remove image"
     ux_table_row "dlogs" "docker logs -f" "Follow logs"
     ux_table_row "dinspect" "docker inspect" "Inspect object"
+}
 
-    ux_section "Resource Management"
+_docker_help_rows_resources() {
     ux_table_row "ddf" "system df" "Disk usage"
     ux_table_row "dprune" "system prune -f" "Basic cleanup"
     ux_table_row "dprune_full" "full prune" "Deep cleanup (interactive)"
@@ -42,8 +62,9 @@ docker_help() {
     ux_table_row "dvol_rm" "volume rm" "Remove volume"
     ux_table_row "dnetwork_prune" "network prune" "Cleanup networks"
     ux_table_row "dbuild_prune" "builder prune" "Cleanup build cache"
+}
 
-    ux_section "Utilities"
+_docker_help_rows_utilities() {
     ux_table_row "dbash" "dbash <name>" "Shell access (bash/sh)"
     ux_table_row "denv" "denv <name>" "Show env vars"
     ux_table_row "dinspect_env" "inspect env" "Inspect env section"
@@ -52,8 +73,64 @@ docker_help() {
     ux_table_row "dexport" "Export all" "Backup to tar files"
     ux_table_row "dinstall" "Install script" "Install Docker on WSL"
     ux_table_row "dproxy_setup" "Proxy setup" "Corporate proxy config"
-
     ux_info "Note: 'docker compose' (V2) is used by default."
+}
+
+_docker_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_docker_help_section_rows() {
+    case "$1" in
+        compose)
+            _docker_help_rows_compose
+            ;;
+        compose-extra|extra)
+            _docker_help_rows_compose_extra
+            ;;
+        basics|basic)
+            _docker_help_rows_basics
+            ;;
+        resources|resource|prune)
+            _docker_help_rows_resources
+            ;;
+        utilities|util|utils)
+            _docker_help_rows_utilities
+            ;;
+        *)
+            ux_error "Unknown docker-help section: $1"
+            ux_info "Try: docker-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_docker_help_full() {
+    ux_header "Docker / Docker Compose Quick Commands"
+
+    _docker_help_render_section "Docker Compose Basics" _docker_help_rows_compose
+    _docker_help_render_section "Docker Compose Extra" _docker_help_rows_compose_extra
+    _docker_help_render_section "Docker Basics" _docker_help_rows_basics
+    _docker_help_render_section "Resource Management" _docker_help_rows_resources
+    _docker_help_render_section "Utilities" _docker_help_rows_utilities
+}
+
+docker_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _docker_help_summary
+            ;;
+        --list|list)
+            _docker_help_list_sections
+            ;;
+        --all|all)
+            _docker_help_full
+            ;;
+        *)
+            _docker_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias docker-help='docker_help'

--- a/shell-common/functions/dot_help.sh
+++ b/shell-common/functions/dot_help.sh
@@ -20,43 +20,125 @@ if ! type ux_header >/dev/null 2>&1; then
     unset _ux_lib_path _ux_lib_paths
 fi
 
-dot_help() {
-    ux_header "Dotfiles Project Information"
+_dot_help_summary() {
+    ux_info "Usage: dot-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "overview: project pillars (SOLID, cross-platform, mounts)"
+    ux_bullet_sub "setup: setup.sh | maintenance | diagnostics"
+    ux_bullet_sub "mounts: claude bind mounts status"
+    ux_bullet_sub "features: shell separation | UX | help | git | skills"
+    ux_bullet_sub "commands: my-help | src | dot | ux-help"
+    ux_bullet_sub "docs: SETUP_GUIDE | AGENTS | UX_GUIDELINES"
+    ux_bullet_sub "details: dot-help <section>  (example: dot-help setup)"
+}
 
-    ux_section "Project Overview"
+_dot_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "overview"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "mounts"
+    ux_bullet_sub "features"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "docs"
+}
+
+_dot_help_rows_overview() {
     ux_bullet "SOLID-based shell configuration separation (bash/zsh)"
     ux_bullet "Cross-platform support (Windows WSL, macOS, Linux)"
     ux_bullet "Environment-aware setup (Internal/External PC)"
     ux_bullet "Automated Claude Code skills bind mounting"
+}
 
-    ux_section "Setup Information"
+_dot_help_rows_setup() {
     ux_bullet "Initial setup: ./setup.sh"
     ux_bullet "Maintenance: scripts/maintenance/fix_crlf_issue.sh"
     ux_bullet "Diagnostic: shell-common/tools/custom/check_ux_consistency.sh"
+}
 
-    ux_section "Claude Mount Status"
+_dot_help_rows_mounts() {
     ux_info "Claude environment directories automatically configured"
-
-    # Show all mount status using dedicated function
     show_mnt 2>/dev/null
+}
 
-    ux_section "Key Features"
+_dot_help_rows_features() {
     ux_numbered 1 "Shell separation: bash/ and zsh/ directories"
     ux_numbered 2 "UX guidelines: Consistent color and formatting"
     ux_numbered 3 "Help system: Type help or [function]-help for info"
     ux_numbered 4 "Git attributes: Automatic CRLF/LF line ending management"
     ux_numbered 5 "Skills integration: Claude Code tools auto-mounted"
+}
 
-    ux_section "Useful Commands"
+_dot_help_rows_commands() {
     ux_table_row "my-help"       "List all available help topics"
     ux_table_row "src"           "Reload shell configuration"
     ux_table_row "dot"           "Navigate to dotfiles directory"
     ux_table_row "ux-help"       "View UX guidelines and semantic colors"
+}
 
-    ux_section "Documentation"
+_dot_help_rows_docs() {
     ux_info "Complete setup guide: ./SETUP_GUIDE.md"
     ux_info "Project structure: ./AGENTS.md"
     ux_info "UX standards: ./shell-common/tools/ux_lib/UX_GUIDELINES.md"
+}
+
+_dot_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_dot_help_section_rows() {
+    case "$1" in
+        overview|project)
+            _dot_help_rows_overview
+            ;;
+        setup|install)
+            _dot_help_rows_setup
+            ;;
+        mounts|mount|claude)
+            _dot_help_rows_mounts
+            ;;
+        features|feature)
+            _dot_help_rows_features
+            ;;
+        commands|cmds|cmd)
+            _dot_help_rows_commands
+            ;;
+        docs|doc|documentation)
+            _dot_help_rows_docs
+            ;;
+        *)
+            ux_error "Unknown dot-help section: $1"
+            ux_info "Try: dot-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_dot_help_full() {
+    ux_header "Dotfiles Project Information"
+    _dot_help_render_section "Project Overview" _dot_help_rows_overview
+    _dot_help_render_section "Setup Information" _dot_help_rows_setup
+    _dot_help_render_section "Claude Mount Status" _dot_help_rows_mounts
+    _dot_help_render_section "Key Features" _dot_help_rows_features
+    _dot_help_render_section "Useful Commands" _dot_help_rows_commands
+    _dot_help_render_section "Documentation" _dot_help_rows_docs
+}
+
+dot_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _dot_help_summary
+            ;;
+        --list|list)
+            _dot_help_list_sections
+            ;;
+        --all|all)
+            _dot_help_full
+            ;;
+        *)
+            _dot_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias dot-help='dot_help'

--- a/shell-common/functions/dot_help.sh
+++ b/shell-common/functions/dot_help.sh
@@ -129,7 +129,7 @@ dot_help() {
         ""|-h|--help|help)
             _dot_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _dot_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/fasd.sh
+++ b/shell-common/functions/fasd.sh
@@ -7,93 +7,161 @@
 # fasd Help and Documentation
 # ═══════════════════════════════════════════════════════════════
 
-# Display fasd help and usage
-fasd_help() {
-    ux_header "fasd - Fast Access to Directories and Files"
+_fasd_help_summary() {
+    ux_info "Usage: fasd-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "core: z | zz | f | ff"
+    ux_bullet_sub "ranking: frequency | recency | combined"
+    ux_bullet_sub "patterns: z pro | z my pro | z /tmp | z -l"
+    ux_bullet_sub "advanced: -r | -t | -e | -d"
+    ux_bullet_sub "usecases: jump dirs | file ops | dir ops"
+    ux_bullet_sub "tips: partial match | multiple terms | -l | -d"
+    ux_bullet_sub "compare: cd vs z"
+    ux_bullet_sub "integration: fzf | vim | grep | git"
+    ux_bullet_sub "trouble: -l verify | reset history"
+    ux_bullet_sub "related: install-fasd | fzf-help"
+    ux_bullet_sub "details: fasd-help <section>  (example: fasd-help core)"
+}
 
-    ux_section "Core Commands"
+_fasd_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "core"
+    ux_bullet_sub "ranking"
+    ux_bullet_sub "patterns"
+    ux_bullet_sub "advanced"
+    ux_bullet_sub "usecases"
+    ux_bullet_sub "tips"
+    ux_bullet_sub "compare"
+    ux_bullet_sub "integration"
+    ux_bullet_sub "trouble"
+    ux_bullet_sub "related"
+}
+
+_fasd_help_rows_core() {
     ux_table_row "z <dir>" "Jump to recently used directory"
     ux_table_row "zz <dir>" "Thorough search, jump to directory"
     ux_table_row "f <file>" "Open/edit recently used file"
     ux_table_row "ff <file>" "Thorough search, open file"
-    echo ""
+}
 
-    ux_section "Ranking System"
+_fasd_help_rows_ranking() {
     ux_bullet "Frequency - How often you visit (w weight)"
     ux_bullet "Recency - How recently you visited (time decay)"
     ux_bullet "Combined score determines ranking"
     ux_bullet "Most relevant items appear first"
-    echo ""
+}
 
-    ux_section "Pattern Matching"
+_fasd_help_rows_patterns() {
     ux_table_row "z pro" "Match 'project' (partial)"
     ux_table_row "z my pro" "Match 'my_project' (multiple terms)"
     ux_table_row "z /tmp" "Match full path"
     ux_table_row "z -l" "List directory frecency data"
-    echo ""
+}
 
-    ux_section "Advanced Usage"
+_fasd_help_rows_advanced() {
     ux_table_row "z -r <dir>" "Interactive ranking (by recency)"
     ux_table_row "z -t <dir>" "Interactive ranking (by frequency)"
     ux_table_row "z -e <dir>" "Echo directory path without jumping"
     ux_table_row "z -d <dir>" "Delete frecency data for directory"
-    echo ""
+}
 
-    ux_section "Common Use Cases"
-    echo ""
+_fasd_help_rows_usecases() {
     ux_info "Quick directory jumping:"
     ux_bullet "z docs - Jump to most recent 'docs' directory"
     ux_bullet "z project - Navigate to project directory"
     ux_bullet "z dev src - Jump to 'dev/src' or 'src/dev'"
-    echo ""
-
     ux_info "File operations:"
     ux_bullet "vim \$(f project) - Edit file from project directory"
     ux_bullet "cat \$(f config) - View config file"
     ux_bullet "ls \$(zz search) - List files in search directory"
-    echo ""
-
     ux_info "Directory operations:"
     ux_bullet "cd \$(z downloads) && ls - Navigate and list files"
     ux_bullet "z -e config > path.txt - Save directory path to file"
     ux_bullet "cp file.txt \$(z backup)/ - Copy to backup directory"
-    echo ""
+}
 
-    ux_section "Tips & Tricks"
+_fasd_help_rows_tips() {
     ux_bullet "No exact match needed: 'z pj' may match 'project'"
     ux_bullet "Multiple patterns: 'z my config' for more specificity"
     ux_bullet "View all matches: 'z -l' to see frecency database"
     ux_bullet "Clean history: 'z -d /old/path' to remove from database"
     ux_bullet "Combine with pipes: 'z config | xargs grep pattern'"
-    echo ""
+}
 
-    ux_section "Comparison with cd"
+_fasd_help_rows_compare() {
     ux_bullet "cd - Requires full/exact path"
     ux_bullet "z - Requires only partial, fuzzy matching"
     ux_bullet "fasd learns from usage patterns over time"
     ux_bullet "No need to remember exact directory structure"
-    echo ""
+}
 
-    ux_section "Integration with Other Tools"
+_fasd_help_rows_integration() {
     ux_info "Works well with:"
     ux_bullet "fzf - Combine for interactive selection: z -i"
     ux_bullet "vim/neovim - Quick file access: :e \$(f pattern)"
     ux_bullet "grep - Search in recent directories: grep -r pattern \$(z proj)"
     ux_bullet "git - Navigate git repos: z my_repo && git status"
-    echo ""
+}
 
-    ux_section "Troubleshooting"
+_fasd_help_rows_trouble() {
     ux_bullet "Not jumping? 'z -l' to verify directory is recorded"
     ux_bullet "Wrong directory? Use more specific patterns"
     ux_bullet "Reset history: Remove ~/.local/share/fasd/data"
     ux_bullet "Verify installation: 'fasd --version'"
-    echo ""
+}
 
-    ux_section "Related Help"
+_fasd_help_rows_related() {
     ux_bullet "Install fasd: ${UX_BOLD}install-fasd${UX_RESET}"
     ux_bullet "Fuzzy finder: ${UX_BOLD}fzf-help${UX_RESET}"
     ux_bullet "File manager: ${UX_BOLD}z -i${UX_RESET} (interactive mode)"
-    echo ""
+}
+
+_fasd_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_fasd_help_section_rows() {
+    case "$1" in
+        core|commands)      _fasd_help_rows_core ;;
+        ranking)            _fasd_help_rows_ranking ;;
+        patterns|pattern)   _fasd_help_rows_patterns ;;
+        advanced)           _fasd_help_rows_advanced ;;
+        usecases|examples|use-cases) _fasd_help_rows_usecases ;;
+        tips)               _fasd_help_rows_tips ;;
+        compare|comparison) _fasd_help_rows_compare ;;
+        integration|tools)  _fasd_help_rows_integration ;;
+        trouble|troubleshooting) _fasd_help_rows_trouble ;;
+        related)            _fasd_help_rows_related ;;
+        *)
+            ux_error "Unknown fasd-help section: $1"
+            ux_info "Try: fasd-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_fasd_help_full() {
+    ux_header "fasd - Fast Access to Directories and Files"
+    _fasd_help_render_section "Core Commands" _fasd_help_rows_core
+    _fasd_help_render_section "Ranking System" _fasd_help_rows_ranking
+    _fasd_help_render_section "Pattern Matching" _fasd_help_rows_patterns
+    _fasd_help_render_section "Advanced Usage" _fasd_help_rows_advanced
+    _fasd_help_render_section "Common Use Cases" _fasd_help_rows_usecases
+    _fasd_help_render_section "Tips & Tricks" _fasd_help_rows_tips
+    _fasd_help_render_section "Comparison with cd" _fasd_help_rows_compare
+    _fasd_help_render_section "Integration with Other Tools" _fasd_help_rows_integration
+    _fasd_help_render_section "Troubleshooting" _fasd_help_rows_trouble
+    _fasd_help_render_section "Related Help" _fasd_help_rows_related
+}
+
+fasd_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _fasd_help_summary ;;
+        --list|list)        _fasd_help_list_sections ;;
+        --all|all)          _fasd_help_full ;;
+        *)                  _fasd_help_section_rows "$1" ;;
+    esac
 }
 
 # Naming Convention: Support both dash and underscore

--- a/shell-common/functions/fasd.sh
+++ b/shell-common/functions/fasd.sh
@@ -158,7 +158,7 @@ _fasd_help_full() {
 fasd_help() {
     case "${1:-}" in
         ""|-h|--help|help) _fasd_help_summary ;;
-        --list|list)        _fasd_help_list_sections ;;
+        --list|list|section|sections)        _fasd_help_list_sections ;;
         --all|all)          _fasd_help_full ;;
         *)                  _fasd_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/fd.sh
+++ b/shell-common/functions/fd.sh
@@ -7,117 +7,194 @@
 # fd Help and Documentation
 # ═══════════════════════════════════════════════════════════════
 
-# Display fd help and usage
-fd_help() {
-    ux_header "fd - Fast File Finder"
+_fd_help_summary() {
+    ux_info "Usage: fd-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: fast | gitignore | smart-case | colored"
+    ux_bullet_sub "basic: pattern | path | regex"
+    ux_bullet_sub "type: -t f | -t d | -t l | -t x"
+    ux_bullet_sub "case: smart | -s | -i"
+    ux_bullet_sub "extension: -e | -x"
+    ux_bullet_sub "depth: -d 1 | -d 2 | -d 3"
+    ux_bullet_sub "scope: -u | -H | --exclude"
+    ux_bullet_sub "exec: -0 | -x"
+    ux_bullet_sub "examples | compare | fzf | ripgrep | trouble | related"
+    ux_bullet_sub "details: fd-help <section>  (example: fd-help basic)"
+}
 
-    ux_section "Core Concept"
+_fd_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "type"
+    ux_bullet_sub "case"
+    ux_bullet_sub "extension"
+    ux_bullet_sub "depth"
+    ux_bullet_sub "scope"
+    ux_bullet_sub "exec"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "compare"
+    ux_bullet_sub "fzf"
+    ux_bullet_sub "ripgrep"
+    ux_bullet_sub "trouble"
+    ux_bullet_sub "related"
+}
+
+_fd_help_rows_concept() {
     ux_bullet "Rust-based find replacement - much faster than find"
     ux_bullet "Respects .gitignore automatically - avoids unwanted files"
     ux_bullet "Smart case sensitivity - case-insensitive unless pattern has uppercase"
     ux_bullet "Intuitive syntax - simpler than find command"
     ux_bullet "Colored output for better readability"
-    echo ""
+}
 
-    ux_section "Basic Syntax"
+_fd_help_rows_basic() {
     ux_table_row "fd 'pattern'" "Find files/directories matching pattern"
     ux_table_row "fd 'pattern' /path" "Search in specific directory"
     ux_table_row "fd '^file$'" "Regex pattern search"
-    echo ""
+}
 
-    ux_section "Type Filtering"
+_fd_help_rows_type() {
     ux_table_row "fd -t f 'pattern'" "Find files only"
     ux_table_row "fd -t d 'pattern'" "Find directories only"
     ux_table_row "fd -t l 'pattern'" "Find symlinks only"
     ux_table_row "fd -t x 'pattern'" "Find executable files only"
-    echo ""
+}
 
-    ux_section "Case Sensitivity"
+_fd_help_rows_case() {
     ux_table_row "fd 'pattern'" "Smart case (case-insensitive by default)"
     ux_table_row "fd -s 'pattern'" "Case-sensitive search"
     ux_table_row "fd -i 'pattern'" "Case-insensitive (explicit)"
-    echo ""
+}
 
-    ux_section "Extension & File Filtering"
+_fd_help_rows_extension() {
     ux_table_row "fd -e .txt" "Find all .txt files"
     ux_table_row "fd -e .py 'test'" "Find .py files matching pattern"
     ux_table_row "fd -x 'name'" "Find executable files"
-    echo ""
+}
 
-    ux_section "Depth Control"
+_fd_help_rows_depth() {
     ux_table_row "fd -d 1 'pattern'" "Search only in current directory"
     ux_table_row "fd -d 2 'pattern'" "Search up to 2 levels deep"
     ux_table_row "fd -d 3 'pattern'" "Search up to 3 levels deep"
-    echo ""
+}
 
-    ux_section "Scope & Exclusion"
+_fd_help_rows_scope() {
     ux_table_row "fd 'pattern'" "Respects .gitignore (default)"
     ux_table_row "fd -u 'pattern'" "Skip .gitignore (search ignored files)"
     ux_table_row "fd -H 'pattern'" "Show hidden files/directories"
     ux_table_row "fd --exclude 'dir' 'pattern'" "Exclude specific directory"
-    echo ""
+}
 
-    ux_section "Output & Execution"
+_fd_help_rows_exec() {
     ux_table_row "fd -0 'pattern'" "NUL character separator (for xargs)"
     ux_table_row "fd -x CMD 'pattern'" "Execute command for each result"
     ux_table_row "fd -x echo '{}' 'pattern'" "Display full path of matches"
-    echo ""
+}
 
-    ux_section "Practical Examples"
-    echo ""
+_fd_help_rows_examples() {
     ux_info "Finding specific file types:"
     ux_bullet "fd -e .py - Find all Python files"
     ux_bullet "fd -t f 'test' - Find all test files"
     ux_bullet "fd -t d 'node_modules' - Find all node_modules directories"
-    echo ""
-
     ux_info "Finding without .gitignore:"
     ux_bullet "fd -u '.git' - Find all .git directories (including hidden)"
     ux_bullet "fd -H -t f '.env' - Find .env files (hidden)"
-    echo ""
-
     ux_info "Integration with other tools:"
     ux_bullet "fd -e .rs | xargs wc -l - Count lines in all Rust files"
     ux_bullet "fd -x file {} - Determine file type of all results"
     ux_bullet "fd -x grep 'TODO' {} - Search for TODO in matched files"
-    echo ""
-
     ux_info "Finding within depth limits:"
     ux_bullet "fd -d 1 '.*' - Find all files/dirs in current directory only"
     ux_bullet "fd -d 2 'src' - Find src directories up to 2 levels deep"
-    echo ""
+}
 
-    ux_section "Comparison with find"
+_fd_help_rows_compare() {
     ux_bullet "find: Standard but slow, complex syntax"
     ux_bullet "fd: Much faster (10-100x), simpler syntax, auto .gitignore support"
     ux_bullet "find: Full control, can be used in scripts"
     ux_bullet "fd: Better defaults, more intuitive"
-    echo ""
+}
 
-    ux_section "Integration with fzf"
+_fd_help_rows_fzf() {
     ux_bullet "fd | fzf - Interactive file selection"
     ux_bullet "vim \$(fd -e .txt | fzf) - Open selected file in vim"
     ux_bullet "fd --type f | fzf --preview 'cat {}' - Preview files"
-    echo ""
+}
 
-    ux_section "With ripgrep"
+_fd_help_rows_ripgrep() {
     ux_bullet "fd -e .py | xargs rg 'pattern' - Search pattern in Python files"
     ux_bullet "fd -t f | xargs grep -l 'TODO' - Find files with TODO comments"
-    echo ""
+}
 
-    ux_section "Troubleshooting"
+_fd_help_rows_trouble() {
     ux_bullet "Case sensitivity issues? Use smart case or -s/-i flags"
     ux_bullet "Hidden files not showing? Use -H flag"
     ux_bullet "Gitignore being respected? Use -u to override"
     ux_bullet "Command too slow? Try limiting depth with -d flag"
-    echo ""
+}
 
-    ux_section "Related Help"
+_fd_help_rows_related() {
     ux_bullet "Install fd: ${UX_BOLD}install-fd${UX_RESET}"
     ux_bullet "Text search: ${UX_BOLD}ripgrep-help${UX_RESET}"
     ux_bullet "Fuzzy finder: ${UX_BOLD}fzf-help${UX_RESET}"
     ux_bullet "Directory access: ${UX_BOLD}fasd-help${UX_RESET}"
-    echo ""
+}
+
+_fd_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_fd_help_section_rows() {
+    case "$1" in
+        concept)            _fd_help_rows_concept ;;
+        basic|syntax)       _fd_help_rows_basic ;;
+        type|types)         _fd_help_rows_type ;;
+        case|case-sensitivity) _fd_help_rows_case ;;
+        extension|ext|filter) _fd_help_rows_extension ;;
+        depth)              _fd_help_rows_depth ;;
+        scope|exclude)      _fd_help_rows_scope ;;
+        exec|output)        _fd_help_rows_exec ;;
+        examples|practical) _fd_help_rows_examples ;;
+        compare|comparison) _fd_help_rows_compare ;;
+        fzf)                _fd_help_rows_fzf ;;
+        ripgrep|rg)         _fd_help_rows_ripgrep ;;
+        trouble|troubleshooting) _fd_help_rows_trouble ;;
+        related)            _fd_help_rows_related ;;
+        *)
+            ux_error "Unknown fd-help section: $1"
+            ux_info "Try: fd-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_fd_help_full() {
+    ux_header "fd - Fast File Finder"
+    _fd_help_render_section "Core Concept" _fd_help_rows_concept
+    _fd_help_render_section "Basic Syntax" _fd_help_rows_basic
+    _fd_help_render_section "Type Filtering" _fd_help_rows_type
+    _fd_help_render_section "Case Sensitivity" _fd_help_rows_case
+    _fd_help_render_section "Extension & File Filtering" _fd_help_rows_extension
+    _fd_help_render_section "Depth Control" _fd_help_rows_depth
+    _fd_help_render_section "Scope & Exclusion" _fd_help_rows_scope
+    _fd_help_render_section "Output & Execution" _fd_help_rows_exec
+    _fd_help_render_section "Practical Examples" _fd_help_rows_examples
+    _fd_help_render_section "Comparison with find" _fd_help_rows_compare
+    _fd_help_render_section "Integration with fzf" _fd_help_rows_fzf
+    _fd_help_render_section "With ripgrep" _fd_help_rows_ripgrep
+    _fd_help_render_section "Troubleshooting" _fd_help_rows_trouble
+    _fd_help_render_section "Related Help" _fd_help_rows_related
+}
+
+fd_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _fd_help_summary ;;
+        --list|list)        _fd_help_list_sections ;;
+        --all|all)          _fd_help_full ;;
+        *)                  _fd_help_section_rows "$1" ;;
+    esac
 }
 
 # Naming Convention: Support both dash and underscore

--- a/shell-common/functions/fd.sh
+++ b/shell-common/functions/fd.sh
@@ -191,7 +191,7 @@ _fd_help_full() {
 fd_help() {
     case "${1:-}" in
         ""|-h|--help|help) _fd_help_summary ;;
-        --list|list)        _fd_help_list_sections ;;
+        --list|list|section|sections)        _fd_help_list_sections ;;
         --all|all)          _fd_help_full ;;
         *)                  _fd_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/fzf.sh
+++ b/shell-common/functions/fzf.sh
@@ -150,7 +150,7 @@ _fzf_help_full() {
 fzf_help() {
     case "${1:-}" in
         ""|-h|--help|help) _fzf_help_summary ;;
-        --list|list)        _fzf_help_list_sections ;;
+        --list|list|section|sections)        _fzf_help_list_sections ;;
         --all|all)          _fzf_help_full ;;
         *)                  _fzf_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/fzf.sh
+++ b/shell-common/functions/fzf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/functions/fzf.sh
 # fzf (fuzzy finder) helper functions and documentation
 # Shared between bash and zsh
@@ -7,93 +7,153 @@
 # fzf Help and Documentation
 # ═══════════════════════════════════════════════════════════════
 
-# Display fzf help and key bindings
-fzf_help() {
-    ux_header "fzf - Fuzzy Finder Help"
+_fzf_help_summary() {
+    ux_info "Usage: fzf-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "core: Ctrl+T | Ctrl+R | Alt+C"
+    ux_bullet_sub "nav: Tab | Shift+Tab | Ctrl+K | Ctrl+J | PgUp | PgDn"
+    ux_bullet_sub "edit: Ctrl+W | Ctrl+U | Ctrl+A | Ctrl+E | Backspace"
+    ux_bullet_sub "select: Ctrl+A | Ctrl+D | Ctrl+X"
+    ux_bullet_sub "actions: Enter | Esc | Ctrl+V | Ctrl+L"
+    ux_bullet_sub "preview: ? | > | <"
+    ux_bullet_sub "examples: file | history | process | git"
+    ux_bullet_sub "tips: type | ^ | ! | ' | Tab"
+    ux_bullet_sub "config: FZF_DEFAULT_OPTS | FZF_DEFAULT_COMMAND"
+    ux_bullet_sub "details: fzf-help <section>  (example: fzf-help core)"
+}
 
-    ux_section "Core Key Bindings"
+_fzf_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "core"
+    ux_bullet_sub "nav"
+    ux_bullet_sub "edit"
+    ux_bullet_sub "select"
+    ux_bullet_sub "actions"
+    ux_bullet_sub "preview"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "tips"
+    ux_bullet_sub "config"
+}
+
+_fzf_help_rows_core() {
     ux_table_row "Ctrl+T" "Insert selected file(s) into command line"
     ux_table_row "Ctrl+R" "Search and insert command from history"
     ux_table_row "Alt+C" "Change to selected directory"
+}
 
-
-    ux_section "Selection & Navigation"
+_fzf_help_rows_nav() {
     ux_table_row "Tab" "Toggle selection (multi-select mode)"
     ux_table_row "Shift+Tab" "Toggle selection (reverse)"
     ux_table_row "Ctrl+K" "Move cursor up"
     ux_table_row "Ctrl+J" "Move cursor down"
     ux_table_row "Page Up" "Scroll up"
     ux_table_row "Page Down" "Scroll down"
+}
 
-
-    ux_section "Text Editing"
+_fzf_help_rows_edit() {
     ux_table_row "Ctrl+W" "Delete word backward"
     ux_table_row "Ctrl+U" "Clear line"
     ux_table_row "Ctrl+A" "Move to beginning of line"
     ux_table_row "Ctrl+E" "Move to end of line"
     ux_table_row "Backspace" "Delete character"
+}
 
-
-    ux_section "Selection Management"
+_fzf_help_rows_select() {
     ux_table_row "Ctrl+A" "Select all items"
     ux_table_row "Ctrl+D" "Deselect all items"
     ux_table_row "Ctrl+X" "Toggle all selections"
+}
 
-
-    ux_section "Actions"
+_fzf_help_rows_actions() {
     ux_table_row "Enter" "Confirm selection(s)"
     ux_table_row "Esc/Ctrl+C" "Abort (no selection)"
     ux_table_row "Ctrl+V" "Toggle preview window"
     ux_table_row "Ctrl+L" "Toggle layout"
+}
 
-
-    ux_section "Preview & Display"
+_fzf_help_rows_preview() {
     ux_table_row "?" "Show/hide help"
     ux_table_row ">" "Toggle info on the right"
     ux_table_row "<" "Toggle info on the left"
+}
 
-
-    ux_section "Examples"
-
+_fzf_help_rows_examples() {
     ux_info "File selection:"
     ux_bullet "vim \$(fzf) - Open file in vim"
     ux_bullet "cat \$(fzf) - Display file contents"
     ux_bullet "cd \$(dirname \$(fzf)) - Navigate to file's directory"
-
-
     ux_info "Command history:"
     ux_bullet "Press Ctrl+R to search command history interactively"
-
-
     ux_info "Process selection:"
     ux_bullet "kill -9 \$(pgrep -f process | fzf)"
-
-
     ux_info "Git integration:"
     ux_bullet "git checkout \$(git branch | fzf)"
     ux_bullet "git log --oneline | fzf"
+}
 
-
-    ux_section "Tips"
+_fzf_help_rows_tips() {
     ux_bullet "Type to filter: Just start typing to narrow down results"
     ux_bullet "Regex matching: Use ^pattern to match from start"
     ux_bullet "Inverse match: Use !pattern to exclude matches"
     ux_bullet "Exact match: Use 'pattern for exact string match"
     ux_bullet "Multi-select: Use Tab to select multiple items"
+}
 
-
-    ux_section "Configuration"
+_fzf_help_rows_config() {
     ux_info "Customize fzf with environment variables:"
     ux_bullet "FZF_DEFAULT_OPTS - Default options"
     ux_bullet "FZF_DEFAULT_COMMAND - Default command"
     ux_bullet "FZF_CTRL_T_COMMAND - Ctrl+T command"
     ux_bullet "FZF_CTRL_R_OPTS - Ctrl+R options"
     ux_bullet "FZF_ALT_C_COMMAND - Alt+C command"
-
-
     ux_info "Example: Add to ~/.bashrc or ~/.zshrc"
     ux_bullet "export FZF_DEFAULT_OPTS='--multi --preview \"head -20 {}\"'"
+}
 
+_fzf_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_fzf_help_section_rows() {
+    case "$1" in
+        core|keys)          _fzf_help_rows_core ;;
+        nav|navigation)     _fzf_help_rows_nav ;;
+        edit|editing)       _fzf_help_rows_edit ;;
+        select|selection)   _fzf_help_rows_select ;;
+        actions)            _fzf_help_rows_actions ;;
+        preview|display)    _fzf_help_rows_preview ;;
+        examples)           _fzf_help_rows_examples ;;
+        tips)               _fzf_help_rows_tips ;;
+        config|configuration) _fzf_help_rows_config ;;
+        *)
+            ux_error "Unknown fzf-help section: $1"
+            ux_info "Try: fzf-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_fzf_help_full() {
+    ux_header "fzf - Fuzzy Finder Help"
+    _fzf_help_render_section "Core Key Bindings" _fzf_help_rows_core
+    _fzf_help_render_section "Selection & Navigation" _fzf_help_rows_nav
+    _fzf_help_render_section "Text Editing" _fzf_help_rows_edit
+    _fzf_help_render_section "Selection Management" _fzf_help_rows_select
+    _fzf_help_render_section "Actions" _fzf_help_rows_actions
+    _fzf_help_render_section "Preview & Display" _fzf_help_rows_preview
+    _fzf_help_render_section "Examples" _fzf_help_rows_examples
+    _fzf_help_render_section "Tips" _fzf_help_rows_tips
+    _fzf_help_render_section "Configuration" _fzf_help_rows_config
+}
+
+fzf_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _fzf_help_summary ;;
+        --list|list)        _fzf_help_list_sections ;;
+        --all|all)          _fzf_help_full ;;
+        *)                  _fzf_help_section_rows "$1" ;;
+    esac
 }
 
 # Naming Convention: Support both dash and underscore

--- a/shell-common/functions/gc_help.sh
+++ b/shell-common/functions/gc_help.sh
@@ -84,7 +84,7 @@ _gc_help_full() {
 gc_help() {
     case "${1:-}" in
         ""|-h|--help|help) _gc_help_summary ;;
-        --list|list)        _gc_help_list_sections ;;
+        --list|list|section|sections)        _gc_help_list_sections ;;
         --all|all)          _gc_help_full ;;
         *)                  _gc_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/gc_help.sh
+++ b/shell-common/functions/gc_help.sh
@@ -1,22 +1,39 @@
 #!/bin/sh
 # shell-common/functions/gc_help.sh
 
-gc_help() {
-    ux_header "git-crypt (Transparent Git encryption)"
+_gc_help_summary() {
+    ux_info "Usage: gc-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "install: gcinstall"
+    ux_bullet_sub "alias: gci | gcadduser | gcstatus | gclock | gcunlock | gcls"
+    ux_bullet_sub "helpers: gcpush | gcsetup | gcaddme | gc_encrypt_env | gcsetup-cache | gcpurge | gc_cache_status | gcbackup | gcrestore | gcnewpc"
+    ux_bullet_sub "tips: .gitignore + .gitattributes | gpg --list-keys | add-gpg-user"
+    ux_bullet_sub "details: gc-help <section>  (example: gc-help alias)"
+}
 
-    ux_section "설치"
+_gc_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "install"
+    ux_bullet_sub "alias"
+    ux_bullet_sub "helpers"
+    ux_bullet_sub "tips"
+}
+
+_gc_help_rows_install() {
     ux_table_row "gcinstall" "설치 스크립트" "apt-get 기반 설치"
     ux_bullet "필수: git, gpg, GPG 키"
+}
 
-    ux_section "Alias"
+_gc_help_rows_alias() {
     ux_table_row "gci" "git-crypt init" "초기화"
     ux_table_row "gcadduser" "git-crypt add-gpg-user" "GPG 키 추가"
     ux_table_row "gcstatus" "git-crypt status" "암호화 상태 확인"
     ux_table_row "gclock" "git-crypt lock" "수동 암호화 (잠금)"
     ux_table_row "gcunlock" "git-crypt unlock" "수동 복호화 (해제)"
     ux_table_row "gcls" "git-crypt status -f" "암호화된 파일 목록"
+}
 
-    ux_section "Helper Functions"
+_gc_help_rows_helpers() {
     ux_table_row "gcpush" "gc_push_env" ".env 암호화 & Push 🚀 (올인원)"
     ux_table_row "gcsetup" "gc_setup" "대화형 초기 설정 도우미"
     ux_table_row "gcaddme" "gc_addme" "내 GPG 키 자동 찾기 & 추가"
@@ -27,11 +44,50 @@ gc_help() {
     ux_table_row "gcbackup" "gc_backup_key" "GPG 개인키 백업 (다른 PC 이동용)"
     ux_table_row "gcrestore" "gc_restore_key" "GPG 개인키 복원 (다른 PC에서)"
     ux_table_row "gcnewpc" "gc_setup_new_pc" "다른 PC 올인원 설정"
+}
 
-    ux_section "Tips"
+_gc_help_rows_tips() {
     ux_bullet ".env는 .gitignore에 추가하되, .gitattributes로 암호화"
     ux_bullet "GPG 키는 gpg --list-keys 로 확인"
     ux_bullet "팀원 추가 시 각자의 GPG 공개키로 add-gpg-user 실행"
     ux_bullet "암호화 상태 확인: gcstatus 또는 gcls"
     ux_bullet "GPG passphrase 캐싱: gcsetup-cache (24시간 동안 재입력 불필요)"
 }
+
+_gc_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gc_help_section_rows() {
+    case "$1" in
+        install|setup)      _gc_help_rows_install ;;
+        alias|aliases)      _gc_help_rows_alias ;;
+        helpers|helper|functions) _gc_help_rows_helpers ;;
+        tips)               _gc_help_rows_tips ;;
+        *)
+            ux_error "Unknown gc-help section: $1"
+            ux_info "Try: gc-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_gc_help_full() {
+    ux_header "git-crypt (Transparent Git encryption)"
+    _gc_help_render_section "설치" _gc_help_rows_install
+    _gc_help_render_section "Alias" _gc_help_rows_alias
+    _gc_help_render_section "Helper Functions" _gc_help_rows_helpers
+    _gc_help_render_section "Tips" _gc_help_rows_tips
+}
+
+gc_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _gc_help_summary ;;
+        --list|list)        _gc_help_list_sections ;;
+        --all|all)          _gc_help_full ;;
+        *)                  _gc_help_section_rows "$1" ;;
+    esac
+}
+
+alias gc-help='gc_help'

--- a/shell-common/functions/ghostty_help.sh
+++ b/shell-common/functions/ghostty_help.sh
@@ -91,7 +91,7 @@ _ghostty_help_full() {
 ghostty_help() {
     case "${1:-}" in
         ""|-h|--help|help) _ghostty_help_summary ;;
-        --list|list)        _ghostty_help_list_sections ;;
+        --list|list|section|sections)        _ghostty_help_list_sections ;;
         --all|all)          _ghostty_help_full ;;
         *)                  _ghostty_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/ghostty_help.sh
+++ b/shell-common/functions/ghostty_help.sh
@@ -1,36 +1,100 @@
 #!/bin/sh
 # shell-common/functions/ghostty_help.sh
 
-ghostty_help() {
-    ux_header "Ghostty - GPU-Accelerated Terminal Emulator"
+_ghostty_help_summary() {
+    ux_info "Usage: ghostty-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: GPU-accelerated | AppKit/GTK4 | Catppuccin"
+    ux_bullet_sub "config: ghostty_init | ghostty_edit_config"
+    ux_bullet_sub "symlink: ~/dotfiles/ghostty/config -> ~/.config/ghostty/config"
+    ux_bullet_sub "settings: theme | font-family | background-opacity | quick-terminal"
+    ux_bullet_sub "commands: +list-themes | +list-fonts | +show-config"
+    ux_bullet_sub "related: tmux-help | zsh-help"
+    ux_bullet_sub "details: ghostty-help <section>  (example: ghostty-help config)"
+}
 
-    ux_section "Core Concept"
+_ghostty_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "config"
+    ux_bullet_sub "symlink"
+    ux_bullet_sub "settings"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "related"
+}
+
+_ghostty_help_rows_concept() {
     ux_bullet "GPU-accelerated terminal emulator (Zig + libghostty)"
     ux_bullet "Platform-native UI on macOS (AppKit) and Linux (GTK4)"
     ux_bullet "Catppuccin Mocha/Latte theme with Hack Nerd Font Mono"
+}
 
-    ux_section "Configuration Management"
+_ghostty_help_rows_config() {
     ux_table_row "ghostty_init" "설정 파일 symbolic link 초기화"
     ux_table_row "ghostty_edit_config" "config 파일 편집 (symlinked)"
+}
 
-    ux_section "Symlink Path"
+_ghostty_help_rows_symlink() {
     ux_bullet "Source: ~/dotfiles/ghostty/config"
     ux_bullet "Target: ~/.config/ghostty/config"
+}
 
-    ux_section "Key Settings"
+_ghostty_help_rows_settings() {
     ux_table_row "theme" "dark:catppuccin-mocha, light:catppuccin-latte"
     ux_table_row "font-family" "Hack Nerd Font Mono (size 14)"
     ux_table_row "background-opacity" "0.8 with blur radius 10"
     ux_table_row "quick-terminal" "Cmd+\` toggle, bottom position"
+}
 
-    ux_section "Useful Commands"
+_ghostty_help_rows_commands() {
     ux_table_row "ghostty +list-themes" "List all available themes"
     ux_table_row "ghostty +list-fonts" "List available fonts"
     ux_table_row "ghostty +show-config" "Show current configuration"
+}
 
-    ux_section "Related Help"
+_ghostty_help_rows_related() {
     ux_bullet "Terminal multiplexer: ${UX_BOLD}tmux-help${UX_RESET}"
     ux_bullet "Zsh shell: ${UX_BOLD}zsh-help${UX_RESET}"
+}
+
+_ghostty_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_ghostty_help_section_rows() {
+    case "$1" in
+        concept)            _ghostty_help_rows_concept ;;
+        config|configuration) _ghostty_help_rows_config ;;
+        symlink|symlinks|path) _ghostty_help_rows_symlink ;;
+        settings|keys)      _ghostty_help_rows_settings ;;
+        commands|cmds)      _ghostty_help_rows_commands ;;
+        related)            _ghostty_help_rows_related ;;
+        *)
+            ux_error "Unknown ghostty-help section: $1"
+            ux_info "Try: ghostty-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_ghostty_help_full() {
+    ux_header "Ghostty - GPU-Accelerated Terminal Emulator"
+    _ghostty_help_render_section "Core Concept" _ghostty_help_rows_concept
+    _ghostty_help_render_section "Configuration Management" _ghostty_help_rows_config
+    _ghostty_help_render_section "Symlink Path" _ghostty_help_rows_symlink
+    _ghostty_help_render_section "Key Settings" _ghostty_help_rows_settings
+    _ghostty_help_render_section "Useful Commands" _ghostty_help_rows_commands
+    _ghostty_help_render_section "Related Help" _ghostty_help_rows_related
+}
+
+ghostty_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _ghostty_help_summary ;;
+        --list|list)        _ghostty_help_list_sections ;;
+        --all|all)          _ghostty_help_full ;;
+        *)                  _ghostty_help_section_rows "$1" ;;
+    esac
 }
 
 alias ghostty-help='ghostty_help'

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -177,7 +177,7 @@ git_help() {
         ""|-h|--help|help)
             _git_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _git_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/hook_help.sh
+++ b/shell-common/functions/hook_help.sh
@@ -1,41 +1,112 @@
 #!/bin/sh
 # shell-common/functions/hook_help.sh
 
-hook_help() {
-    ux_header "Git Hook Configuration & Diagnostics"
+_hook_help_summary() {
+    ux_info "Usage: hook-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "overview: 2-tier (user + project) | 자동 진단 | HOOK_WORKFLOW.md"
+    ux_bullet_sub "commands: hook-check | hook-check --help"
+    ux_bullet_sub "results: ✓ 정상 | ✗ 오류 | ⚠ 경고"
+    ux_bullet_sub "trouble: hook 안 됨 | hooksPath | 권한 | 재실행"
+    ux_bullet_sub "types: User-level | Project-level"
+    ux_bullet_sub "more: HOOK_WORKFLOW.md | global-hooks | hook-config | setup.sh"
+    ux_bullet_sub "tips: 주기적 점검 | 새 PC 셋업 | GIT_HOOKS_DEBUG"
+    ux_bullet_sub "details: hook-help <section>  (example: hook-help commands)"
+}
 
-    ux_section "개요"
+_hook_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "overview"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "results"
+    ux_bullet_sub "trouble"
+    ux_bullet_sub "types"
+    ux_bullet_sub "more"
+    ux_bullet_sub "tips"
+}
+
+_hook_help_rows_overview() {
     ux_bullet "2-tier Hook 아키텍처: User-level (전역) + Project-level (로컬)"
     ux_bullet "자동 진단 도구로 설정 문제를 쉽게 해결"
     ux_bullet "상세 가이드: git/doc/HOOK_WORKFLOW.md"
+}
 
-    ux_section "주요 명령어"
+_hook_help_rows_commands() {
     ux_table_row "hook-check" "Hook 설정 진단 ⭐" "6가지 자동 체크 + 자동 수정 옵션"
     ux_table_row "hook-check --help" "도움말 보기" "이 페이지 표시"
+}
 
-    ux_section "진단 결과 해석"
+_hook_help_rows_results() {
     ux_bullet "✓ = 설정 정상"
     ux_bullet "✗ = 설정 오류 (수정 필요)"
     ux_bullet "⚠ = 경고 (선택적)"
+}
 
-    ux_section "문제 해결"
+_hook_help_rows_trouble() {
     ux_table_row "Hook이 실행 안 됨" "hook-check 실행" "자동 진단 및 수정"
     ux_table_row "core.hooksPath 오류" "git config 명령 직접 실행"
     ux_table_row "권한 오류" "chmod +x 명령 실행" "Hook 파일을 실행 가능하게"
     ux_table_row "설정 전부 다시" "setup.sh 재실행" "cd ~/dotfiles && ./git/setup.sh"
+}
 
-    ux_section "Hook 종류"
+_hook_help_rows_types() {
     ux_table_row "User-level" "~/.config/git/hooks/pre-commit" "모든 git 프로젝트에 적용 (전역)"
     ux_table_row "Project-level" "dotfiles/.git/hooks/pre-commit" "이 dotfiles 프로젝트에만 적용"
+}
 
-    ux_section "더 알아보기"
+_hook_help_rows_more() {
     ux_bullet "자세한 가이드: git/doc/HOOK_WORKFLOW.md"
     ux_bullet "Hook 구현: git/global-hooks/pre-commit"
     ux_bullet "Hook 설정값: git/config/hook-config.sh"
     ux_bullet "Setup 스크립트: git/setup.sh"
+}
 
-    ux_section "팁"
+_hook_help_rows_tips() {
     ux_bullet "hook-check를 주기적으로 실행해서 설정 상태 확인"
     ux_bullet "새 PC에서는 반드시 ./git/setup.sh 실행"
     ux_bullet "Hook 문제 발생 시 GIT_HOOKS_DEBUG=1 환경변수로 디버그 출력"
 }
+
+_hook_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_hook_help_section_rows() {
+    case "$1" in
+        overview)           _hook_help_rows_overview ;;
+        commands|cmds)      _hook_help_rows_commands ;;
+        results|legend)     _hook_help_rows_results ;;
+        trouble|troubleshooting) _hook_help_rows_trouble ;;
+        types|kinds)        _hook_help_rows_types ;;
+        more|docs|references) _hook_help_rows_more ;;
+        tips)               _hook_help_rows_tips ;;
+        *)
+            ux_error "Unknown hook-help section: $1"
+            ux_info "Try: hook-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_hook_help_full() {
+    ux_header "Git Hook Configuration & Diagnostics"
+    _hook_help_render_section "개요" _hook_help_rows_overview
+    _hook_help_render_section "주요 명령어" _hook_help_rows_commands
+    _hook_help_render_section "진단 결과 해석" _hook_help_rows_results
+    _hook_help_render_section "문제 해결" _hook_help_rows_trouble
+    _hook_help_render_section "Hook 종류" _hook_help_rows_types
+    _hook_help_render_section "더 알아보기" _hook_help_rows_more
+    _hook_help_render_section "팁" _hook_help_rows_tips
+}
+
+hook_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _hook_help_summary ;;
+        --list|list)        _hook_help_list_sections ;;
+        --all|all)          _hook_help_full ;;
+        *)                  _hook_help_section_rows "$1" ;;
+    esac
+}
+
+alias hook-help='hook_help'

--- a/shell-common/functions/hook_help.sh
+++ b/shell-common/functions/hook_help.sh
@@ -103,7 +103,7 @@ _hook_help_full() {
 hook_help() {
     case "${1:-}" in
         ""|-h|--help|help) _hook_help_summary ;;
-        --list|list)        _hook_help_list_sections ;;
+        --list|list|section|sections)        _hook_help_list_sections ;;
         --all|all)          _hook_help_full ;;
         *)                  _hook_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/manage_doc.sh
+++ b/shell-common/functions/manage_doc.sh
@@ -347,7 +347,7 @@ show_doc_help() {
         ""|-h|--help|help)
             _show_doc_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _show_doc_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/manage_doc.sh
+++ b/shell-common/functions/manage_doc.sh
@@ -255,45 +255,108 @@ archive_doc() {
 # show_doc_help() - Show help for document management
 # ═══════════════════════════════════════════════════════════════
 
-show_doc_help() {
-    ux_header "Document Management Commands"
-    echo ""
+_show_doc_help_summary() {
+    ux_info "Usage: show-doc-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "clear: clear-doc <file|pattern> usage and examples"
+    ux_bullet_sub "delete: del-doc <file|pattern> usage and examples"
+    ux_bullet_sub "description: behavior and safety notes"
+    ux_bullet_sub "patterns: glob pattern reference"
+    ux_bullet_sub "details: show-doc-help <section>  (example: show-doc-help clear)"
+}
 
-    ux_section "clear-doc"
+_show_doc_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "clear"
+    ux_bullet_sub "delete"
+    ux_bullet_sub "description"
+    ux_bullet_sub "patterns"
+}
+
+_show_doc_help_rows_clear() {
     ux_bullet "Clear content of documentation files"
-    echo ""
     ux_info "Usage: clear-doc <file|pattern>"
-    echo ""
     ux_info "Examples:"
     ux_bullet "clear-doc docs/review/abc-review-G.md       // Clear single file"
     ux_bullet "clear-doc docs/review/abc-review*           // Unquoted glob (both work!)"
     ux_bullet "clear-doc 'docs/review/abc-review*'         // Quoted pattern"
     ux_bullet "clear-doc docs/file1.md docs/file2.md       // Multiple files"
     ux_bullet "clear-doc 'docs/*.md' notes.txt             // Mixed patterns + files"
+}
 
-    ux_section "del-doc"
+_show_doc_help_rows_delete() {
     ux_bullet "Permanently delete documentation files"
-    echo ""
     ux_info "Usage: del-doc <file|pattern>"
-    echo ""
     ux_info "Examples:"
     ux_bullet "del-doc docs/review/abc-review-G.md         // Delete single file"
     ux_bullet "del-doc docs/review/abc-plan*               // Unquoted glob"
     ux_bullet "del-doc 'docs/review/abc-review*2.md'       // Quoted pattern (deletes *2.md files)"
     ux_bullet "del-doc docs/file1.md docs/file2.md         // Multiple files"
     ux_bullet "del-doc 'docs/abc-*' notes.txt              // Mixed patterns + files"
+}
 
-    ux_section "Description"
+_show_doc_help_rows_description() {
     ux_info "Safely clears the content of documentation files (clear-doc)"
     ux_info "Permanently deletes documentation files (del-doc)"
     ux_info "Both operations require user confirmation (destructive)"
     ux_info "Support both individual files and glob patterns"
-    echo ""
+}
 
-    ux_section "Patterns"
+_show_doc_help_rows_patterns() {
     ux_bullet "* matches any characters"
     ux_bullet "? matches single character"
-    echo ""
+}
+
+_show_doc_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_show_doc_help_section_rows() {
+    case "$1" in
+        clear|clear-doc)
+            _show_doc_help_rows_clear
+            ;;
+        delete|del|del-doc)
+            _show_doc_help_rows_delete
+            ;;
+        description|desc|about)
+            _show_doc_help_rows_description
+            ;;
+        patterns|pattern|glob)
+            _show_doc_help_rows_patterns
+            ;;
+        *)
+            ux_error "Unknown show-doc-help section: $1"
+            ux_info "Try: show-doc-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_show_doc_help_full() {
+    ux_header "Document Management Commands"
+    _show_doc_help_render_section "clear-doc" _show_doc_help_rows_clear
+    _show_doc_help_render_section "del-doc" _show_doc_help_rows_delete
+    _show_doc_help_render_section "Description" _show_doc_help_rows_description
+    _show_doc_help_render_section "Patterns" _show_doc_help_rows_patterns
+}
+
+show_doc_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _show_doc_help_summary
+            ;;
+        --list|list)
+            _show_doc_help_list_sections
+            ;;
+        --all|all)
+            _show_doc_help_full
+            ;;
+        *)
+            _show_doc_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -316,6 +379,7 @@ fi
 alias clear-doc='clear_doc'
 alias del-doc='delete_doc'
 alias doc-help='show_doc_help'
+alias show-doc-help='show_doc_help'
 
 # ═══════════════════════════════════════════════════════════════
 # Main execution - Only run if directly executed, not sourced

--- a/shell-common/functions/marketplace.sh
+++ b/shell-common/functions/marketplace.sh
@@ -612,7 +612,7 @@ claude_skills_marketplace_help() {
         ""|-h|--help|help)
             _claude_skills_marketplace_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _claude_skills_marketplace_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/marketplace.sh
+++ b/shell-common/functions/marketplace.sh
@@ -509,19 +509,35 @@ claude_skills_marketplace_refresh() {
     ux_success "Manifest regenerated: $total skills indexed"
 }
 
-# Help documentation
-claude_skills_marketplace_help() {
-    ux_header "Marketplace Skills Commands"
+# Help documentation (SSOT pattern)
+_claude_skills_marketplace_help_summary() {
+    ux_info "Usage: claude-skills-marketplace-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "quickstart: csm | csm list --all | csm search | csm info"
+    ux_bullet_sub "commands: list | group | stats | search | info | refresh | help"
+    ux_bullet_sub "aliases: claude_skills_marketplace | csm"
+    ux_bullet_sub "examples: common usage examples"
+    ux_bullet_sub "caching: manifest cache details"
+    ux_bullet_sub "details: claude-skills-marketplace-help <section>"
+}
 
-    ux_section "Quick Start"
+_claude_skills_marketplace_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "quickstart"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "aliases"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "caching"
+}
+
+_claude_skills_marketplace_help_rows_quickstart() {
     ux_bullet "Group by plugin (default): ${UX_SUCCESS}csm${UX_RESET}"
     ux_bullet "All skills by marketplace: ${UX_SUCCESS}csm list --all${UX_RESET}"
     ux_bullet "Search skills: ${UX_SUCCESS}csm search python${UX_RESET}"
     ux_bullet "Get details: ${UX_SUCCESS}csm info api-design-principles${UX_RESET}"
-    echo ""
+}
 
-    ux_section "Available Commands"
-
+_claude_skills_marketplace_help_rows_commands() {
     ux_numbered 1 "list [--all|-A]         - Group by plugin (default), or --all for marketplace view"
     ux_numbered 2 "group [plugin]          - Group skills by plugin (optionally filter)"
     ux_numbered 3 "stats                   - Show marketplace statistics"
@@ -529,15 +545,14 @@ claude_skills_marketplace_help() {
     ux_numbered 5 "info <skill-name>       - Show detailed skill information"
     ux_numbered 6 "refresh                 - Force rebuild skill manifest"
     ux_numbered 7 "help                    - Show this help message"
-    echo ""
+}
 
-    ux_section "Aliases"
+_claude_skills_marketplace_help_rows_aliases() {
     ux_bullet "Long form: ${UX_SUCCESS}claude_skills_marketplace${UX_RESET}"
     ux_bullet "Short form: ${UX_SUCCESS}csm${UX_RESET}"
-    echo ""
+}
 
-    ux_section "Examples"
-
+_claude_skills_marketplace_help_rows_examples() {
     ux_bullet "Show plugins: ${UX_SUCCESS}csm${UX_RESET} (shows plugin headers)"
     ux_bullet "Same as above: ${UX_SUCCESS}csm list${UX_RESET}"
     ux_bullet "Show marketplaces: ${UX_SUCCESS}csm list --all${UX_RESET}"
@@ -545,13 +560,68 @@ claude_skills_marketplace_help() {
     ux_bullet "Search skills: ${UX_SUCCESS}csm search python${UX_RESET}"
     ux_bullet "Skill details: ${UX_SUCCESS}csm info api-design-principles${UX_RESET}"
     ux_bullet "Statistics: ${UX_SUCCESS}csm stats${UX_RESET}"
-    echo ""
+}
 
-    ux_section "Caching"
+_claude_skills_marketplace_help_rows_caching() {
     ux_bullet "Manifest cache: ${UX_MUTED}${MANIFEST_CACHE_PATH}${UX_RESET}"
     ux_bullet "Cache TTL: ${UX_MUTED}24 hours${UX_RESET}"
     ux_bullet "Auto-refresh: ${UX_MUTED}When cache expires or manifest missing${UX_RESET}"
-    echo ""
+}
+
+_claude_skills_marketplace_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_claude_skills_marketplace_help_section_rows() {
+    case "$1" in
+        quickstart|quick|start)
+            _claude_skills_marketplace_help_rows_quickstart
+            ;;
+        commands|cmds|cmd)
+            _claude_skills_marketplace_help_rows_commands
+            ;;
+        aliases|alias)
+            _claude_skills_marketplace_help_rows_aliases
+            ;;
+        examples|example|ex)
+            _claude_skills_marketplace_help_rows_examples
+            ;;
+        caching|cache)
+            _claude_skills_marketplace_help_rows_caching
+            ;;
+        *)
+            ux_error "Unknown claude-skills-marketplace-help section: $1"
+            ux_info "Try: claude-skills-marketplace-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_claude_skills_marketplace_help_full() {
+    ux_header "Marketplace Skills Commands"
+    _claude_skills_marketplace_help_render_section "Quick Start" _claude_skills_marketplace_help_rows_quickstart
+    _claude_skills_marketplace_help_render_section "Available Commands" _claude_skills_marketplace_help_rows_commands
+    _claude_skills_marketplace_help_render_section "Aliases" _claude_skills_marketplace_help_rows_aliases
+    _claude_skills_marketplace_help_render_section "Examples" _claude_skills_marketplace_help_rows_examples
+    _claude_skills_marketplace_help_render_section "Caching" _claude_skills_marketplace_help_rows_caching
+}
+
+claude_skills_marketplace_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _claude_skills_marketplace_help_summary
+            ;;
+        --list|list)
+            _claude_skills_marketplace_help_list_sections
+            ;;
+        --all|all)
+            _claude_skills_marketplace_help_full
+            ;;
+        *)
+            _claude_skills_marketplace_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Main router function
@@ -592,3 +662,4 @@ claude_skills_marketplace() {
 # Create short alias for convenience
 # This is safe as a function alias (no naming conflicts with my_help.sh pattern)
 alias claude-skills-marketplace='claude_skills_marketplace'
+alias claude-skills-marketplace-help='claude_skills_marketplace_help'

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -14,31 +14,84 @@ if ! type ux_bullet >/dev/null 2>&1; then
     [ -f "$_SCRIPT_DIR/../tools/ux_lib/ux_lib.sh" ] && source "$_SCRIPT_DIR/../tools/ux_lib/ux_lib.sh" 2>/dev/null
 fi
 
+# SSOT helpers for mount-help
+_mount_help_summary() {
+    ux_info "Usage: mount-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "description: manage bind mounts for Claude environment"
+    ux_bullet_sub "commands: addmnt | show-mnt | claude-mount-all"
+    ux_bullet_sub "info: per-command --help references"
+    ux_bullet_sub "notes: sudo & sudoers configuration"
+    ux_bullet_sub "details: mount-help <section>  (example: mount-help commands)"
+}
+
+_mount_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "description"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "info"
+    ux_bullet_sub "notes"
+}
+
+_mount_help_rows_description() {
+    ux_info "Manage bind mounts for Claude environment (skills, agents, etc.)"
+}
+
+_mount_help_rows_commands() {
+    ux_bullet "addmnt <source> <target>    Create bind mount"
+    ux_bullet "show-mnt [path]             Display mount status"
+    ux_bullet "claude-mount-all            Mount all Claude directories (skills, agents, docs)"
+}
+
+_mount_help_rows_info() {
+    ux_bullet "addmnt --help       Usage for addmnt command"
+    ux_bullet "show-mnt --help     Usage for show-mnt command"
+}
+
+_mount_help_rows_notes() {
+    ux_warning "Requires sudo for mount operations"
+    ux_info "Configure sudoers for passwordless mounting in /etc/sudoers.d/"
+}
+
+_mount_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_mount_help_section_rows() {
+    case "$1" in
+        description|desc|about)
+            _mount_help_rows_description
+            ;;
+        commands|cmds|cmd)
+            _mount_help_rows_commands
+            ;;
+        info|more)
+            _mount_help_rows_info
+            ;;
+        notes|note|sudo)
+            _mount_help_rows_notes
+            ;;
+        *)
+            ux_error "Unknown mount-help section: $1"
+            ux_info "Try: mount-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_mount_help_full() {
+    ux_header "Mount Management Commands"
+    _mount_help_render_section "Description" _mount_help_rows_description
+    _mount_help_render_section "Available Commands" _mount_help_rows_commands
+    _mount_help_render_section "For More Information" _mount_help_rows_info
+    _mount_help_render_section "Notes" _mount_help_rows_notes
+}
+
 # Show comprehensive help for mount functions
 # Single Responsibility: Only display mount module help information
 mount_help() {
-    if type ux_header >/dev/null 2>&1; then
-        ux_header "Mount Management Commands"
-
-        ux_section "Description"
-        ux_info "Manage bind mounts for Claude environment (skills, agents, etc.)"
-
-
-        ux_section "Available Commands"
-        ux_bullet "addmnt <source> <target>    Create bind mount"
-        ux_bullet "show-mnt [path]             Display mount status"
-        ux_bullet "claude-mount-all            Mount all Claude directories (skills, agents, docs)"
-
-
-        ux_section "For More Information"
-        ux_bullet "addmnt --help       Usage for addmnt command"
-        ux_bullet "show-mnt --help     Usage for show-mnt command"
-
-
-        ux_warning "Requires sudo for mount operations"
-        ux_info "Configure sudoers for passwordless mounting in /etc/sudoers.d/"
-
-    else
+    if ! type ux_header >/dev/null 2>&1; then
         cat << 'HELP'
 Mount Management Commands
 
@@ -54,7 +107,23 @@ Notes:
   - Requires sudo for mount operations
   - addmnt --help, show-mnt --help for details
 HELP
+        return 0
     fi
+
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _mount_help_summary
+            ;;
+        --list|list)
+            _mount_help_list_sections
+            ;;
+        --all|all)
+            _mount_help_full
+            ;;
+        *)
+            _mount_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias mount-help='mount_help'

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -114,7 +114,7 @@ HELP
         ""|-h|--help|help)
             _mount_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _mount_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -638,7 +638,7 @@ my_help_impl() {
             _my_help_summary
             rc=$?
             ;;
-        --list|list)
+        --list|list|section|sections)
             _my_help_list_sections
             rc=$?
             ;;

--- a/shell-common/functions/mytool_help.sh
+++ b/shell-common/functions/mytool_help.sh
@@ -163,7 +163,7 @@ mytool_help() {
         ""|-h|--help|help)
             _mytool_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _mytool_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/mytool_help.sh
+++ b/shell-common/functions/mytool_help.sh
@@ -60,28 +60,39 @@ EOF
     printf "%s\n" "$description"
 }
 
-mytool_help() {
+_mytool_help_load_ux() {
     if ! command -v ux_header >/dev/null 2>&1 && [ -n "$SHELL_COMMON" ]; then
         # shellcheck source=/dev/null
         . "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
     fi
+}
 
-    ux_header "MyTool - Custom Utility Scripts"
+_mytool_help_summary() {
+    ux_info "Usage: mytool-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "tools: list all .sh files in shell-common/tools/custom/"
+    ux_bullet_sub "usage: how to run custom tools"
+    ux_bullet_sub "details: mytool-help <section>  (example: mytool-help tools)"
+}
 
-    # Check if SHELL_COMMON is set
+_mytool_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "tools"
+    ux_bullet_sub "usage"
+}
+
+_mytool_help_rows_tools() {
     if [ -z "$SHELL_COMMON" ]; then
         ux_warning "SHELL_COMMON environment variable not set"
         return 1
     fi
 
-    # List all .sh files in custom tools directory
     local custom_dir="${SHELL_COMMON}/tools/custom"
     if [ ! -d "$custom_dir" ]; then
         ux_error "Custom tools directory not found: $custom_dir"
         return 1
     fi
 
-    ux_section "Available Custom Tools"
     ux_info "Executable utility scripts in ${custom_dir}"
 
     local scripts
@@ -89,13 +100,11 @@ mytool_help() {
 
     if [ -z "$scripts" ]; then
         ux_warning "No custom tools found in ${custom_dir}"
-        echo ""
         return 0
     fi
 
     ux_table_header "Tool" "Description"
 
-    # Find and display all .sh files
     local count=0
     while IFS= read -r script; do
         [ -n "$script" ] || continue
@@ -112,15 +121,58 @@ mytool_help() {
 $scripts
 EOF
 
-    echo ""
     ux_info "Total: $count custom tools available"
     ux_info "Location: ${custom_dir}"
-    echo ""
+}
 
-    ux_section "Usage"
+_mytool_help_rows_usage() {
     ux_bullet "Run a tool directly: ${UX_BOLD}\${SHELL_COMMON}/tools/custom/tool-name.sh${UX_RESET}"
     ux_bullet "Or add to PATH for direct execution: ${UX_BOLD}tool-name.sh${UX_RESET}"
-    echo ""
+}
+
+_mytool_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_mytool_help_section_rows() {
+    case "$1" in
+        tools|tool|list-tools)
+            _mytool_help_rows_tools
+            ;;
+        usage|use|run)
+            _mytool_help_rows_usage
+            ;;
+        *)
+            ux_error "Unknown mytool-help section: $1"
+            ux_info "Try: mytool-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_mytool_help_full() {
+    ux_header "MyTool - Custom Utility Scripts"
+    _mytool_help_render_section "Available Custom Tools" _mytool_help_rows_tools
+    _mytool_help_render_section "Usage" _mytool_help_rows_usage
+}
+
+mytool_help() {
+    _mytool_help_load_ux
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _mytool_help_summary
+            ;;
+        --list|list)
+            _mytool_help_list_sections
+            ;;
+        --all|all)
+            _mytool_help_full
+            ;;
+        *)
+            _mytool_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Alias for mytool-help format (using dash instead of underscore)

--- a/shell-common/functions/nvm_help.sh
+++ b/shell-common/functions/nvm_help.sh
@@ -1,16 +1,60 @@
 #!/bin/sh
 # shell-common/functions/nvm_help.sh
 
-nvm_help() {
-    ux_header "NVM (Node Version Manager)"
+_nvm_help_summary() {
+    ux_info "Usage: nvm-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "commands: nvm-install"
+    ux_bullet_sub "usage: nvm install --lts | nvm use --lts | nvm ls"
+    ux_bullet_sub "details: nvm-help <section>  (example: nvm-help usage)"
+}
 
-    ux_section "Commands"
+_nvm_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "usage"
+}
+
+_nvm_help_rows_commands() {
     ux_table_row "nvm-install" "Install Script" "Install NVM & Node LTS"
+}
 
-    ux_section "NVM Usage"
+_nvm_help_rows_usage() {
     ux_bullet "nvm install --lts  : Install latest LTS Node"
     ux_bullet "nvm use --lts      : Use latest LTS Node"
     ux_bullet "nvm ls             : List installed versions"
+}
+
+_nvm_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_nvm_help_section_rows() {
+    case "$1" in
+        commands|cmds|install) _nvm_help_rows_commands ;;
+        usage)              _nvm_help_rows_usage ;;
+        *)
+            ux_error "Unknown nvm-help section: $1"
+            ux_info "Try: nvm-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_nvm_help_full() {
+    ux_header "NVM (Node Version Manager)"
+    _nvm_help_render_section "Commands" _nvm_help_rows_commands
+    _nvm_help_render_section "NVM Usage" _nvm_help_rows_usage
+}
+
+nvm_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _nvm_help_summary ;;
+        --list|list)        _nvm_help_list_sections ;;
+        --all|all)          _nvm_help_full ;;
+        *)                  _nvm_help_section_rows "$1" ;;
+    esac
 }
 
 alias nvm-help='nvm_help'

--- a/shell-common/functions/nvm_help.sh
+++ b/shell-common/functions/nvm_help.sh
@@ -51,7 +51,7 @@ _nvm_help_full() {
 nvm_help() {
     case "${1:-}" in
         ""|-h|--help|help) _nvm_help_summary ;;
-        --list|list)        _nvm_help_list_sections ;;
+        --list|list|section|sections)        _nvm_help_list_sections ;;
         --all|all)          _nvm_help_full ;;
         *)                  _nvm_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/p10k.sh
+++ b/shell-common/functions/p10k.sh
@@ -103,7 +103,7 @@ _p10k_help_full() {
 p10k_help() {
     case "${1:-}" in
         ""|-h|--help|help) _p10k_help_summary ;;
-        --list|list)        _p10k_help_list_sections ;;
+        --list|list|section|sections)        _p10k_help_list_sections ;;
         --all|all)          _p10k_help_full ;;
         *)                  _p10k_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/p10k.sh
+++ b/shell-common/functions/p10k.sh
@@ -7,49 +7,106 @@
 # Powerlevel10k Help Function
 # ═══════════════════════════════════════════════════════════════
 
-# Main help function for powerlevel10k font setup
-p10k_help() {
-    ux_header "Powerlevel10k Font Setup for VSCode Terminal"
+_p10k_help_summary() {
+    ux_info "Usage: p10k-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "vscode: Ctrl+Shift+P → Open User Settings (JSON)"
+    ux_bullet_sub "settings: editor.fontFamily | terminal.integrated.fontFamily"
+    ux_bullet_sub "install: install-p10k | p10k configure | font setup"
+    ux_bullet_sub "trouble: missing MesloLGS NF | nerdfonts.com | brew cask"
+    ux_bullet_sub "fonts: FiraCode | JetBrains Mono | Hack Nerd Font"
+    ux_bullet_sub "verify: p10k configure | zsh-theme-current"
+    ux_bullet_sub "details: p10k-help <section>  (example: p10k-help install)"
+}
 
-    ux_section "VS Code Settings (settings.json)"
+_p10k_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "vscode"
+    ux_bullet_sub "settings"
+    ux_bullet_sub "install"
+    ux_bullet_sub "trouble"
+    ux_bullet_sub "fonts"
+    ux_bullet_sub "verify"
+}
+
+_p10k_help_rows_vscode() {
     ux_info "Open settings with: ${UX_BOLD}Ctrl+Shift+P${UX_RESET} → Preference: Open User Settings (JSON)"
-    echo ""
+}
 
-    ux_section "Add These Lines to settings.json"
+_p10k_help_rows_settings() {
     cat <<'EOF'
   "editor.fontFamily": "D2Coding, Consolas, 'Courier New', monospace, 'MesloLGS NF'",
   "editor.fontSize": 14,
   "terminal.integrated.fontFamily": "MesloLGS NF",
   "terminal.integrated.fontSize": 14,
 EOF
-    echo ""
-    echo ""
+}
 
-    ux_section "Installation Steps"
+_p10k_help_rows_install() {
     ux_bullet "1. Install powerlevel10k: ${UX_BOLD}install-p10k${UX_RESET}"
-    ux_bullet "2. Configure p10k: ${UX_BOLD}p10k configure${UX_RESET}}"
+    ux_bullet "2. Configure p10k: ${UX_BOLD}p10k configure${UX_RESET}"
     ux_bullet "3. Select font preference in configuration wizard"
     ux_bullet "4. Add settings above to VSCode settings.json"
     ux_bullet "5. Restart VSCode terminal"
-    echo ""
+}
 
-    ux_section "Troubleshooting"
+_p10k_help_rows_trouble() {
     ux_bullet "Font not showing? MesloLGS NF font may not be installed"
     ux_bullet "Install MesloLGS NF: Visit ${UX_BOLD}https://www.nerdfonts.com/font-downloads${UX_RESET}"
-    ux_bullet "Or use: ${UX_BOLD}brew install --cask font-meslo-lg-nerd-font${UX_RESET}} (macOS)"
+    ux_bullet "Or use: ${UX_BOLD}brew install --cask font-meslo-lg-nerd-font${UX_RESET} (macOS)"
     ux_bullet "After installation, restart VSCode completely"
-    echo ""
+}
 
-    ux_section "Alternative Fonts"
+_p10k_help_rows_fonts() {
     ux_bullet "FiraCode Nerd Font"
     ux_bullet "JetBrains Mono Nerd Font"
     ux_bullet "Hack Nerd Font"
-    echo ""
+}
 
-    ux_section "Verify Installation"
-    ux_info "Run: ${UX_BOLD}p10k configure${UX_RESET}} to test font rendering"
-    ux_info "Or check theme: ${UX_BOLD}zsh-theme-current${UX_RESET}}"
-    echo ""
+_p10k_help_rows_verify() {
+    ux_info "Run: ${UX_BOLD}p10k configure${UX_RESET} to test font rendering"
+    ux_info "Or check theme: ${UX_BOLD}zsh-theme-current${UX_RESET}"
+}
+
+_p10k_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_p10k_help_section_rows() {
+    case "$1" in
+        vscode|code)             _p10k_help_rows_vscode ;;
+        settings|json|config)    _p10k_help_rows_settings ;;
+        install|setup|steps)     _p10k_help_rows_install ;;
+        trouble|troubleshooting) _p10k_help_rows_trouble ;;
+        fonts|font|alternatives) _p10k_help_rows_fonts ;;
+        verify|test)             _p10k_help_rows_verify ;;
+        *)
+            ux_error "Unknown p10k-help section: $1"
+            ux_info "Try: p10k-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_p10k_help_full() {
+    ux_header "Powerlevel10k Font Setup for VSCode Terminal"
+    _p10k_help_render_section "VS Code Settings (settings.json)" _p10k_help_rows_vscode
+    _p10k_help_render_section "Add These Lines to settings.json" _p10k_help_rows_settings
+    _p10k_help_render_section "Installation Steps" _p10k_help_rows_install
+    _p10k_help_render_section "Troubleshooting" _p10k_help_rows_trouble
+    _p10k_help_render_section "Alternative Fonts" _p10k_help_rows_fonts
+    _p10k_help_render_section "Verify Installation" _p10k_help_rows_verify
+}
+
+# Main help function for powerlevel10k font setup
+p10k_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _p10k_help_summary ;;
+        --list|list)        _p10k_help_list_sections ;;
+        --all|all)          _p10k_help_full ;;
+        *)                  _p10k_help_section_rows "$1" ;;
+    esac
 }
 
 # Alias for p10k-help format (using dash instead of underscore)

--- a/shell-common/functions/package_managers_help.sh
+++ b/shell-common/functions/package_managers_help.sh
@@ -358,28 +358,99 @@ alias npm-help='npm_help'
 
 # --- uv_help (from uv_help.sh) ---
 
-uv_help() {
-    ux_header "UV Quick Commands"
+_uv_help_summary() {
+    ux_info "Usage: uv-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "sync: uvs | uvu | uvd | uv-install"
+    ux_bullet_sub "lock: uvk | uvl | uvc | uvr"
+    ux_bullet_sub "maintenance: uvcheck"
+    ux_bullet_sub "recipes: --all-extras | backend dev | frontend dev"
+    ux_bullet_sub "details: uv-help <section>  (example: uv-help recipes)"
+}
 
-    ux_section "Sync & Install"
+_uv_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "sync"
+    ux_bullet_sub "lock"
+    ux_bullet_sub "maintenance"
+    ux_bullet_sub "recipes"
+}
+
+_uv_help_rows_sync() {
     ux_table_row "uvs" "uv sync" "Sync env & prune (Prod)"
     ux_table_row "uvu" "uv sync --upgrade" "Upgrade deps"
     ux_table_row "uvd" "uv sync --dev" "Dev install"
     ux_table_row "uv-install" "install script" "Install UV tool"
+}
 
-    ux_section "Lock & Export"
+_uv_help_rows_lock() {
     ux_table_row "uvk" "uv lock" "Refresh lockfile"
     ux_table_row "uvl" "uv pip list" "List packages"
     ux_table_row "uvc" "uv pip compile" "Export requirements"
     ux_table_row "uvr" "uv pip sync" "Sync from reqs"
+}
 
-    ux_section "Maintenance"
+_uv_help_rows_maintenance() {
     ux_table_row "uvcheck" "uv pip check" "Verify env"
+}
 
-    ux_section "Recipes"
+_uv_help_rows_recipes() {
     ux_bullet "Install all extras: ${UX_SUCCESS}uv pip sync --all-extras${UX_RESET}"
     ux_bullet "Backend dev:      ${UX_SUCCESS}uv pip sync --extra backend --extra dev${UX_RESET}"
     ux_bullet "Frontend dev:     ${UX_SUCCESS}uv pip sync --extra frontend --extra dev${UX_RESET}"
+}
+
+_uv_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_uv_help_section_rows() {
+    case "$1" in
+        sync|install)
+            _uv_help_rows_sync
+            ;;
+        lock|export)
+            _uv_help_rows_lock
+            ;;
+        maintenance|check)
+            _uv_help_rows_maintenance
+            ;;
+        recipes|recipe)
+            _uv_help_rows_recipes
+            ;;
+        *)
+            ux_error "Unknown uv-help section: $1"
+            ux_info "Try: uv-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_uv_help_full() {
+    ux_header "UV Quick Commands"
+
+    _uv_help_render_section "Sync & Install" _uv_help_rows_sync
+    _uv_help_render_section "Lock & Export" _uv_help_rows_lock
+    _uv_help_render_section "Maintenance" _uv_help_rows_maintenance
+    _uv_help_render_section "Recipes" _uv_help_rows_recipes
+}
+
+uv_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _uv_help_summary
+            ;;
+        --list|list)
+            _uv_help_list_sections
+            ;;
+        --all|all)
+            _uv_help_full
+            ;;
+        *)
+            _uv_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # UV Check Wrapper - calls the diagnostic script

--- a/shell-common/functions/package_managers_help.sh
+++ b/shell-common/functions/package_managers_help.sh
@@ -463,40 +463,124 @@ alias check-uv='uv_check'
 
 # --- bun_help (from bun_help.sh) ---
 
-bun_help() {
-    ux_header "Bun Quick Commands"
+_bun_help_summary() {
+    ux_info "Usage: bun-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "install: install-bun | uninstall-bun | bun-v"
+    ux_bullet_sub "packages: bun-i | bun-id | bun-ig | bun-un | bun-update | bun-outdated"
+    ux_bullet_sub "run: bun-run | bunx"
+    ux_bullet_sub "examples: bunx oh-my-opencode | bunx create-next-app"
+    ux_bullet_sub "config: ~/.bunfig.toml | internal vs external"
+    ux_bullet_sub "troubleshoot: not found | registry | SSL"
+    ux_bullet_sub "details: bun-help <section>  (example: bun-help packages)"
+}
 
-    ux_section "Installation"
+_bun_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "install"
+    ux_bullet_sub "packages"
+    ux_bullet_sub "run"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "config"
+    ux_bullet_sub "troubleshoot"
+}
+
+_bun_help_rows_install() {
     ux_table_row "install-bun" "curl .../bun.sh/install" "Install Bun"
     ux_table_row "uninstall-bun" "Remove ~/.bun" "Uninstall Bun"
     ux_table_row "bun-v" "bun --version" "Check version"
+}
 
-    ux_section "Package Management"
+_bun_help_rows_packages() {
     ux_table_row "bun-i" "bun install" "Install deps"
     ux_table_row "bun-id" "install --dev" "Dev dependency"
     ux_table_row "bun-ig" "install --global" "Global install"
     ux_table_row "bun-un" "bun remove" "Remove package"
     ux_table_row "bun-update" "bun update" "Update deps"
     ux_table_row "bun-outdated" "bun outdated" "Check outdated"
+}
 
-    ux_section "Run"
+_bun_help_rows_run() {
     ux_table_row "bun-run" "bun run <script>" "Run package.json script"
     ux_table_row "bunx" "bun x <pkg>" "Run package without install"
+}
 
-    ux_section "Bunx Usage Examples"
+_bun_help_rows_examples() {
     ux_bullet "${UX_INFO}bunx oh-my-opencode install${UX_RESET}  : OMO 설치"
     ux_bullet "${UX_INFO}bunx create-next-app${UX_RESET}         : Next.js 프로젝트 생성"
+}
 
-    ux_section "Configuration"
+_bun_help_rows_config() {
     ux_bullet "Config file  : ${UX_INFO}~/.bunfig.toml${UX_RESET} (dotfiles symlink)"
     ux_bullet "Environments : internal (Samsung registry), external (default)"
+}
 
-    ux_section "Troubleshooting"
+_bun_help_rows_troubleshoot() {
     ux_bullet "bun not found?   : Run ${UX_PRIMARY}install-bun${UX_RESET}"
     ux_bullet "Registry error?  : Check ${UX_PRIMARY}~/.bunfig.toml${UX_RESET} registry setting"
     ux_bullet "SSL error?       : Verify ${UX_PRIMARY}cafile${UX_RESET} path in bunfig.toml"
-
     ux_info "Binary path: ~/.bun/bin"
+}
+
+_bun_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_bun_help_section_rows() {
+    case "$1" in
+        install|installation)
+            _bun_help_rows_install
+            ;;
+        packages|package|pkg)
+            _bun_help_rows_packages
+            ;;
+        run)
+            _bun_help_rows_run
+            ;;
+        examples|bunx)
+            _bun_help_rows_examples
+            ;;
+        config|configuration)
+            _bun_help_rows_config
+            ;;
+        troubleshoot|troubleshooting)
+            _bun_help_rows_troubleshoot
+            ;;
+        *)
+            ux_error "Unknown bun-help section: $1"
+            ux_info "Try: bun-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_bun_help_full() {
+    ux_header "Bun Quick Commands"
+
+    _bun_help_render_section "Installation" _bun_help_rows_install
+    _bun_help_render_section "Package Management" _bun_help_rows_packages
+    _bun_help_render_section "Run" _bun_help_rows_run
+    _bun_help_render_section "Bunx Usage Examples" _bun_help_rows_examples
+    _bun_help_render_section "Configuration" _bun_help_rows_config
+    _bun_help_render_section "Troubleshooting" _bun_help_rows_troubleshoot
+}
+
+bun_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _bun_help_summary
+            ;;
+        --list|list)
+            _bun_help_list_sections
+            ;;
+        --all|all)
+            _bun_help_full
+            ;;
+        *)
+            _bun_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias bun-help='bun_help'

--- a/shell-common/functions/package_managers_help.sh
+++ b/shell-common/functions/package_managers_help.sh
@@ -139,7 +139,7 @@ pip_help() {
         ""|-h|--help|help)
             _pip_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _pip_help_list_sections
             ;;
         --all|all)
@@ -304,7 +304,7 @@ npm_help() {
         ""|-h|--help|help)
             _npm_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _npm_help_list_sections
             ;;
         --all|all)
@@ -441,7 +441,7 @@ uv_help() {
         ""|-h|--help|help)
             _uv_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _uv_help_list_sections
             ;;
         --all|all)
@@ -571,7 +571,7 @@ bun_help() {
         ""|-h|--help|help)
             _bun_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _bun_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/package_managers_help.sh
+++ b/shell-common/functions/package_managers_help.sh
@@ -173,49 +173,147 @@ alias check-pip='pip_check'
 
 # NOTE: UX library is loaded by the loader before functions/ — no need to reload here
 
-npm_help() {
-    ux_header "NPM Quick Commands"
+_npm_help_summary() {
+    ux_info "Usage: npm-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "info: npm-v | npm-list | npm-info | npm-search | npm-outdated"
+    ux_bullet_sub "install: npm-i | npm-is | npm-isd | npm-ig"
+    ux_bullet_sub "uninstall: npm-un | npm-ung"
+    ux_bullet_sub "maintenance: npm-update | npm-cache-clean"
+    ux_bullet_sub "config: npm-config"
+    ux_bullet_sub "setup: npminstall | npmuninstall"
+    ux_bullet_sub "cert: crt-help | crtsetup"
+    ux_bullet_sub "troubleshoot: EACCES | nvm conflict | certificate | config mismatch"
+    ux_bullet_sub "details: npm-help <section>  (example: npm-help install)"
+}
 
-    ux_section "Info & Version"
+_npm_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "info"
+    ux_bullet_sub "install"
+    ux_bullet_sub "uninstall"
+    ux_bullet_sub "maintenance"
+    ux_bullet_sub "config"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "cert"
+    ux_bullet_sub "troubleshoot"
+}
+
+_npm_help_rows_info() {
     ux_table_row "npm-v" "npm --version" "Check version"
     ux_table_row "npm-list" "list -g --depth=0" "Global packages"
     ux_table_row "npm-info" "info <pkg>" "Package details"
     ux_table_row "npm-search" "search <keyword>" "Search packages"
     ux_table_row "npm-outdated" "outdated -g" "Check updates"
+}
 
-    ux_section "Install"
+_npm_help_rows_install() {
     ux_table_row "npm-i" "npm install" "Install deps"
     ux_table_row "npm-is" "install --save" "Save prod dep"
     ux_table_row "npm-isd" "install --save-dev" "Save dev dep"
     ux_table_row "npm-ig" "install -g" "Global install"
+}
 
-    ux_section "Uninstall"
+_npm_help_rows_uninstall() {
     ux_table_row "npm-un" "npm uninstall" "Remove dep"
     ux_table_row "npm-ung" "uninstall -g" "Remove global"
+}
 
-    ux_section "Maintenance"
+_npm_help_rows_maintenance() {
     ux_table_row "npm-update" "update -g" "Update global"
     ux_table_row "npm-cache-clean" "cache clean --force" "Clear cache"
+}
 
-    ux_section "Configuration"
+_npm_help_rows_config() {
     ux_table_row "npm-config" "Show current config" "Registry, CA, SSL"
+}
 
-    ux_section "Setup Tools"
+_npm_help_rows_setup() {
     ux_table_row "npminstall" "Install Script" "Install Node/NPM"
     ux_table_row "npmuninstall" "Uninstall Script" "Remove Node/NPM"
+}
 
-    ux_section "Certificate Management"
+_npm_help_rows_cert() {
     ux_info "For CA certificate setup (company proxy/internal network):"
     ux_bullet "Run: ${UX_SUCCESS}crt-help${UX_RESET} for detailed guide"
     ux_bullet "Setup: ${UX_SUCCESS}crtsetup${UX_RESET} to install certificate"
+}
 
-    ux_section "Troubleshooting"
+_npm_help_rows_troubleshoot() {
     ux_bullet "EACCES permission error (npm WARN): npm config set prefix ~/.npm-global"
     ux_bullet "nvm과 npm prefix 충돌: .npmrc 파일의 prefix 라인 제거"
     ux_bullet "Certificate error: Run ${UX_SUCCESS}crt-help${UX_RESET} for CA setup guide"
     ux_bullet "Config mismatch: Run ${UX_SUCCESS}./shell-common/setup.sh${UX_RESET} to reconfigure symlink"
-
     ux_info "Global Path: ~/.npm-global"
+}
+
+_npm_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_npm_help_section_rows() {
+    case "$1" in
+        info|version)
+            _npm_help_rows_info
+            ;;
+        install|i)
+            _npm_help_rows_install
+            ;;
+        uninstall|un)
+            _npm_help_rows_uninstall
+            ;;
+        maintenance|update)
+            _npm_help_rows_maintenance
+            ;;
+        config|configuration)
+            _npm_help_rows_config
+            ;;
+        setup|tools)
+            _npm_help_rows_setup
+            ;;
+        cert|certificate|ca)
+            _npm_help_rows_cert
+            ;;
+        troubleshoot|troubleshooting)
+            _npm_help_rows_troubleshoot
+            ;;
+        *)
+            ux_error "Unknown npm-help section: $1"
+            ux_info "Try: npm-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_npm_help_full() {
+    ux_header "NPM Quick Commands"
+
+    _npm_help_render_section "Info & Version" _npm_help_rows_info
+    _npm_help_render_section "Install" _npm_help_rows_install
+    _npm_help_render_section "Uninstall" _npm_help_rows_uninstall
+    _npm_help_render_section "Maintenance" _npm_help_rows_maintenance
+    _npm_help_render_section "Configuration" _npm_help_rows_config
+    _npm_help_render_section "Setup Tools" _npm_help_rows_setup
+    _npm_help_render_section "Certificate Management" _npm_help_rows_cert
+    _npm_help_render_section "Troubleshooting" _npm_help_rows_troubleshoot
+}
+
+npm_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _npm_help_summary
+            ;;
+        --list|list)
+            _npm_help_list_sections
+            ;;
+        --all|all)
+            _npm_help_full
+            ;;
+        *)
+            _npm_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Helper function to normalize npm config output

--- a/shell-common/functions/package_managers_help.sh
+++ b/shell-common/functions/package_managers_help.sh
@@ -40,37 +40,115 @@ alias check-rpm='rpm_check'
 
 # --- pip_help (from pip_help.sh) ---
 
-pip_help() {
-    ux_header "Pip Configuration & Diagnostics"
+_pip_help_summary() {
+    ux_info "Usage: pip-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics: check-pip | config | file | repo | env"
+    ux_bullet_sub "commands: pip config list | --verbose | view conf | --version"
+    ux_bullet_sub "setup: ./setup.sh (Public | Internal | External)"
+    ux_bullet_sub "repos: Proxy | Internal Repo | DataService Repo"
+    ux_bullet_sub "notes: CA cert | setup.sh managed | symlink"
+    ux_bullet_sub "details: pip-help <section>  (example: pip-help repos)"
+}
 
-    ux_section "Diagnostic Commands"
+_pip_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "repos"
+    ux_bullet_sub "notes"
+}
+
+_pip_help_rows_diagnostics() {
     ux_bullet "check-pip            Run full pip diagnostic"
     ux_bullet "check-pip config     Show pip configuration"
     ux_bullet "check-pip file       pip.conf file check"
     ux_bullet "check-pip repo       Repository connectivity test"
     ux_bullet "check-pip env        Environment variables"
+}
 
-    ux_section "Quick Commands"
+_pip_help_rows_commands() {
     ux_bullet "pip config list                 Show all pip settings"
     ux_bullet "pip config list --verbose       Show pip config files loading"
     ux_bullet "cat \$HOME/.config/pip/pip.conf  View user pip config"
     ux_bullet "pip --version                   Check pip version"
+}
 
-    ux_section "Environment Setup"
+_pip_help_rows_setup() {
     ux_bullet "./setup.sh                      Run setup (choose environment)"
     ux_bullet "               1) Public PC"
     ux_bullet "               2) Internal company PC (proxy + internal repo)"
     ux_bullet "               3) External company PC (VPN)"
+}
 
-    ux_section "Proxy & Repository Info"
+_pip_help_rows_repos() {
     ux_bullet "Proxy:            http://12.26.204.100:8080"
     ux_bullet "Internal Repo:    http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple"
     ux_bullet "DataService Repo: http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple"
+}
 
-    ux_section "Important Notes"
+_pip_help_rows_notes() {
     ux_warning "CA certificate: Configured via security.local.sh (REQUESTS_CA_BUNDLE)"
     ux_info "Config files are managed by setup.sh - do not edit manually"
     ux_info "Symlink: ~/.config/pip/pip.conf -> pip/pip.conf.{environment}"
+}
+
+_pip_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_pip_help_section_rows() {
+    case "$1" in
+        diagnostics|diag)
+            _pip_help_rows_diagnostics
+            ;;
+        commands|quick)
+            _pip_help_rows_commands
+            ;;
+        setup|env|environment)
+            _pip_help_rows_setup
+            ;;
+        repos|proxy|repo)
+            _pip_help_rows_repos
+            ;;
+        notes|important)
+            _pip_help_rows_notes
+            ;;
+        *)
+            ux_error "Unknown pip-help section: $1"
+            ux_info "Try: pip-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_pip_help_full() {
+    ux_header "Pip Configuration & Diagnostics"
+
+    _pip_help_render_section "Diagnostic Commands" _pip_help_rows_diagnostics
+    _pip_help_render_section "Quick Commands" _pip_help_rows_commands
+    _pip_help_render_section "Environment Setup" _pip_help_rows_setup
+    _pip_help_render_section "Proxy & Repository Info" _pip_help_rows_repos
+    _pip_help_render_section "Important Notes" _pip_help_rows_notes
+}
+
+pip_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _pip_help_summary
+            ;;
+        --list|list)
+            _pip_help_list_sections
+            ;;
+        --all|all)
+            _pip_help_full
+            ;;
+        *)
+            _pip_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Wrapper function for check_pip.sh diagnostic

--- a/shell-common/functions/pet.sh
+++ b/shell-common/functions/pet.sh
@@ -207,7 +207,7 @@ _pet_help_full() {
 pet_help() {
     case "${1:-}" in
         ""|-h|--help|help) _pet_help_summary ;;
-        --list|list)        _pet_help_list_sections ;;
+        --list|list|section|sections)        _pet_help_list_sections ;;
         --all|all)          _pet_help_full ;;
         *)                  _pet_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/pet.sh
+++ b/shell-common/functions/pet.sh
@@ -7,137 +7,210 @@
 # pet Help and Documentation
 # ═══════════════════════════════════════════════════════════════
 
-# Display pet help and usage
-pet_help() {
-    ux_header "pet - Simple Command Snippet Manager"
+_pet_help_summary() {
+    ux_info "Usage: pet-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: snippet manager | search/exec | TOML"
+    ux_bullet_sub "core: pet new | search | list | edit | version"
+    ux_bullet_sub "structure: description | command | tags"
+    ux_bullet_sub "create: pet new (interactive)"
+    ux_bullet_sub "search: pet search | grep"
+    ux_bullet_sub "examples: file | git | docker | system"
+    ux_bullet_sub "fzf | config | storage | workflow | tips | compare | advantages"
+    ux_bullet_sub "related: install-pet | fzf-help | ripgrep-help | zsh-help"
+    ux_bullet_sub "details: pet-help <section>  (example: pet-help core)"
+}
 
-    ux_section "Core Concept"
+_pet_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "core"
+    ux_bullet_sub "structure"
+    ux_bullet_sub "create"
+    ux_bullet_sub "search"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "fzf"
+    ux_bullet_sub "config"
+    ux_bullet_sub "storage"
+    ux_bullet_sub "workflow"
+    ux_bullet_sub "tips"
+    ux_bullet_sub "compare"
+    ux_bullet_sub "advantages"
+    ux_bullet_sub "related"
+}
+
+_pet_help_rows_concept() {
     ux_bullet "Store and recall frequently used commands"
     ux_bullet "Interactive search and execution"
     ux_bullet "Snippets stored as TOML configuration"
     ux_bullet "Built-in editor support for managing snippets"
     ux_bullet "Integrates with shell for easy access"
-    echo ""
+}
 
-    ux_section "Core Commands"
+_pet_help_rows_core() {
     ux_table_row "pet new" "Create a new snippet interactively"
     ux_table_row "pet search" "Search and execute snippet"
     ux_table_row "pet list" "List all stored snippets"
     ux_table_row "pet edit" "Edit snippets in text editor"
     ux_table_row "pet version" "Show pet version"
-    echo ""
+}
 
-    ux_section "Snippet Structure"
+_pet_help_rows_structure() {
     ux_info "Each snippet contains:"
     ux_bullet "description - What the snippet does"
     ux_bullet "command - The actual command to execute"
     ux_bullet "tags - Keywords for searching (optional)"
-    echo ""
+}
 
-    ux_section "Creating Snippets"
+_pet_help_rows_create() {
     ux_info "Interactive creation:"
     ux_bullet "pet new - Opens editor to create snippet"
     ux_bullet "Prompts for: description, command, tags"
     ux_bullet "Example: 'Find large files' -> 'find . -size +100M'"
-    echo ""
+}
 
-    ux_section "Searching Snippets"
+_pet_help_rows_search() {
     ux_table_row "pet search" "Interactive search (fzf integration)"
     ux_table_row "pet search 'find'" "Search by description/command"
     ux_table_row "pet list | grep 'find'" "Grep search results"
-    echo ""
+}
 
-    ux_section "Snippet Examples"
-    echo ""
+_pet_help_rows_examples() {
     ux_info "File Operations:"
     ux_bullet "find large files: find . -size +100M"
     ux_bullet "recursive search: grep -r 'pattern' ."
     ux_bullet "count lines: find . -name '*.rs' | xargs wc -l"
-    echo ""
-
     ux_info "Git Operations:"
     ux_bullet "undo last commit: git reset --soft HEAD~1"
     ux_bullet "delete local branch: git branch -d branch_name"
     ux_bullet "prune remote branches: git remote prune origin"
-    echo ""
-
     ux_info "Docker Operations:"
     ux_bullet "remove dangling images: docker rmi \$(docker images -f dangling=true -q)"
     ux_bullet "clean all: docker system prune -a"
     ux_bullet "view logs: docker logs --follow container_name"
-    echo ""
-
     ux_info "System Commands:"
     ux_bullet "disk usage: du -sh * | sort -h"
     ux_bullet "find and delete: find . -name '.DS_Store' -delete"
     ux_bullet "monitor processes: watch -n 1 'ps aux | grep pattern'"
-    echo ""
+}
 
-    ux_section "Using with fzf"
+_pet_help_rows_fzf() {
     ux_bullet "pet integrates with fzf for interactive search"
     ux_bullet "Fuzzy match snippets by description or command"
     ux_bullet "Preview snippet before execution"
     ux_bullet "Execute directly from search results"
-    echo ""
+}
 
-    ux_section "Configuration File"
+_pet_help_rows_config() {
     ux_info "Location: ~/.config/pet/config.toml"
     ux_info "Editor integration:"
     ux_bullet "editor = 'vim' - Set preferred editor"
     ux_bullet "selector = 'fzf' - Use fzf for selection"
     ux_bullet "pager = 'less' - Set pager for output"
-    echo ""
+}
 
-    ux_section "Snippets Storage"
+_pet_help_rows_storage() {
     ux_info "Location: ~/.config/pet/snippets.toml"
     ux_bullet "Text format (TOML) - easy to edit manually"
     ux_bullet "Portable - copy between systems"
     ux_bullet "Versionable - track with git"
-    echo ""
+}
 
-    ux_section "Workflow Examples"
-    echo ""
+_pet_help_rows_workflow() {
     ux_info "Regular workflow:"
     ux_bullet "Execute a command frequently: pet new"
     ux_bullet "Need to use it later: pet search"
     ux_bullet "Found a better version: pet edit"
-    echo ""
-
     ux_info "Integration with other tools:"
     ux_bullet "Copy snippet command: pet search | xargs echo"
     ux_bullet "Share snippets: Upload ~/.config/pet/snippets.toml"
     ux_bullet "Backup snippets: cp ~/.config/pet/snippets.toml backup/"
-    echo ""
+}
 
-    ux_section "Tips & Tricks"
+_pet_help_rows_tips() {
     ux_bullet "Create aliases for frequently used snippets: alias myfunc='pet search'"
     ux_bullet "Document complex commands as snippets instead of comments"
     ux_bullet "Use tags to organize snippets by category"
     ux_bullet "Combine with fzf for fuzzy search experience"
     ux_bullet "Backup snippets regularly - they're valuable"
-    echo ""
+}
 
-    ux_section "Comparison with Other Tools"
+_pet_help_rows_compare() {
     ux_bullet "bash history: Unorganized, easy to lose"
     ux_bullet "pet: Organized, searchable, persistent"
     ux_bullet "Man pages: Complex to read"
     ux_bullet "pet: Simple description + example"
-    echo ""
+}
 
-    ux_section "Advantages"
+_pet_help_rows_advantages() {
     ux_bullet "Simpler than writing scripts for one-off commands"
     ux_bullet "Better than trying to remember complex commands"
     ux_bullet "Easier than searching through bash history"
     ux_bullet "Portable configuration files"
     ux_bullet "Built-in editor for easy management"
-    echo ""
+}
 
-    ux_section "Related Help"
+_pet_help_rows_related() {
     ux_bullet "Install pet: ${UX_BOLD}install-pet${UX_RESET}"
     ux_bullet "Interactive search: ${UX_BOLD}fzf-help${UX_RESET}"
     ux_bullet "Text search: ${UX_BOLD}ripgrep-help${UX_RESET}"
     ux_bullet "Zsh shell: ${UX_BOLD}zsh-help${UX_RESET}"
-    echo ""
+}
+
+_pet_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_pet_help_section_rows() {
+    case "$1" in
+        concept)            _pet_help_rows_concept ;;
+        core|commands|cmds) _pet_help_rows_core ;;
+        structure)          _pet_help_rows_structure ;;
+        create|new)         _pet_help_rows_create ;;
+        search)             _pet_help_rows_search ;;
+        examples)           _pet_help_rows_examples ;;
+        fzf)                _pet_help_rows_fzf ;;
+        config|configuration) _pet_help_rows_config ;;
+        storage|snippets)   _pet_help_rows_storage ;;
+        workflow)           _pet_help_rows_workflow ;;
+        tips)               _pet_help_rows_tips ;;
+        compare|comparison) _pet_help_rows_compare ;;
+        advantages)         _pet_help_rows_advantages ;;
+        related)            _pet_help_rows_related ;;
+        *)
+            ux_error "Unknown pet-help section: $1"
+            ux_info "Try: pet-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_pet_help_full() {
+    ux_header "pet - Simple Command Snippet Manager"
+    _pet_help_render_section "Core Concept" _pet_help_rows_concept
+    _pet_help_render_section "Core Commands" _pet_help_rows_core
+    _pet_help_render_section "Snippet Structure" _pet_help_rows_structure
+    _pet_help_render_section "Creating Snippets" _pet_help_rows_create
+    _pet_help_render_section "Searching Snippets" _pet_help_rows_search
+    _pet_help_render_section "Snippet Examples" _pet_help_rows_examples
+    _pet_help_render_section "Using with fzf" _pet_help_rows_fzf
+    _pet_help_render_section "Configuration File" _pet_help_rows_config
+    _pet_help_render_section "Snippets Storage" _pet_help_rows_storage
+    _pet_help_render_section "Workflow Examples" _pet_help_rows_workflow
+    _pet_help_render_section "Tips & Tricks" _pet_help_rows_tips
+    _pet_help_render_section "Comparison with Other Tools" _pet_help_rows_compare
+    _pet_help_render_section "Advantages" _pet_help_rows_advantages
+    _pet_help_render_section "Related Help" _pet_help_rows_related
+}
+
+pet_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _pet_help_summary ;;
+        --list|list)        _pet_help_list_sections ;;
+        --all|all)          _pet_help_full ;;
+        *)                  _pet_help_section_rows "$1" ;;
+    esac
 }
 
 # Naming Convention: Support both dash and underscore

--- a/shell-common/functions/pp_help.sh
+++ b/shell-common/functions/pp_help.sh
@@ -74,7 +74,7 @@ _pp_help_full() {
 pp_help() {
     case "${1:-}" in
         ""|-h|--help|help) _pp_help_summary ;;
-        --list|list)        _pp_help_list_sections ;;
+        --list|list|section|sections)        _pp_help_list_sections ;;
         --all|all)          _pp_help_full ;;
         *)                  _pp_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/pp_help.sh
+++ b/shell-common/functions/pp_help.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
 # shell-common/functions/pp_help.sh
 
-pp_help() {
-    ux_header "Python Package & Quality Tools"
+_pp_help_summary() {
+    ux_info "Usage: pp-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "package: pp_install | pp_install_up | pp_reqs | pp_uninstall | pp_freeze | pp_list | pp_check"
+    ux_bullet_sub "quality: code_check | code_fix | code_type"
+    ux_bullet_sub "test: test_pytest | test_unittest"
+    ux_bullet_sub "docs: docs_gen"
+    ux_bullet_sub "details: pp-help <section>  (example: pp-help quality)"
+}
 
-    ux_section "Package Management"
+_pp_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "package"
+    ux_bullet_sub "quality"
+    ux_bullet_sub "test"
+    ux_bullet_sub "docs"
+}
+
+_pp_help_rows_package() {
     ux_table_row "pp_install" "pip install" "Install package"
     ux_table_row "pp_install_up" "upgrade pip & install" "Update pip first"
     ux_table_row "pp_reqs" "pip install -r reqs" "Install from file"
@@ -12,18 +27,57 @@ pp_help() {
     ux_table_row "pp_freeze" "Freeze to reqs.txt" "Exclude project name"
     ux_table_row "pp_list" "pip list --outdated" "Check updates"
     ux_table_row "pp_check" "pip check" "Verify deps"
+}
 
-    ux_section "Code Quality (Ruff/MyPy)"
+_pp_help_rows_quality() {
     ux_table_row "code_check" "ruff format & check" "CI mode (check only)"
     ux_table_row "code_fix" "ruff format & fix" "Auto-fix issues"
     ux_table_row "code_type" "mypy ." "Type checking"
+}
 
-    ux_section "Testing"
+_pp_help_rows_test() {
     ux_table_row "test_pytest" "pytest -q" "Run pytest (fast)"
     ux_table_row "test_unittest" "unittest discover" "Run unittest"
+}
 
-    ux_section "Documentation"
+_pp_help_rows_docs() {
     ux_table_row "docs_gen" "sphinx build" "Generate HTML docs"
+}
+
+_pp_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_pp_help_section_rows() {
+    case "$1" in
+        package|packages|pkg|pip) _pp_help_rows_package ;;
+        quality|lint|ruff|mypy) _pp_help_rows_quality ;;
+        test|tests|testing) _pp_help_rows_test ;;
+        docs|documentation) _pp_help_rows_docs ;;
+        *)
+            ux_error "Unknown pp-help section: $1"
+            ux_info "Try: pp-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_pp_help_full() {
+    ux_header "Python Package & Quality Tools"
+    _pp_help_render_section "Package Management" _pp_help_rows_package
+    _pp_help_render_section "Code Quality (Ruff/MyPy)" _pp_help_rows_quality
+    _pp_help_render_section "Testing" _pp_help_rows_test
+    _pp_help_render_section "Documentation" _pp_help_rows_docs
+}
+
+pp_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _pp_help_summary ;;
+        --list|list)        _pp_help_list_sections ;;
+        --all|all)          _pp_help_full ;;
+        *)                  _pp_help_section_rows "$1" ;;
+    esac
 }
 
 alias pp-help='pp_help'

--- a/shell-common/functions/py_help.sh
+++ b/shell-common/functions/py_help.sh
@@ -1,19 +1,63 @@
 #!/bin/sh
 # shell-common/functions/py_help.sh
 
-py_help() {
-    ux_header "Python Virtual Environment Commands"
+_py_help_summary() {
+    ux_info "Usage: py-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "commands: cv | av | ev | rv | dv"
+    ux_bullet_sub "setup: install-py | uninstall-py"
+    ux_bullet_sub "details: py-help <section>  (example: py-help commands)"
+}
 
-    ux_section "Commands"
+_py_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "setup"
+}
+
+_py_help_rows_commands() {
     ux_table_row "create-venv (cv)" "python -m venv .venv" "Create venv"
     ux_table_row "act-venv (av)" ". .venv/bin/activate" "Activate"
     ux_table_row "echo-venv (ev)" "echo \$VIRTUAL_ENV" "Show path"
     ux_table_row "rm-venv (rv)" "rm -rf .venv" "Delete venv"
     ux_table_row "deact-venv (dv)" ". deactivate" "Deactivate"
+}
 
-    ux_section "Setup Tools"
+_py_help_rows_setup() {
     ux_table_row "install-py [version...]" "Install Script" "Install default or specific Python versions"
     ux_table_row "uninstall-py <version>" "pyenv uninstall" "Remove a specific Python version"
+}
+
+_py_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_py_help_section_rows() {
+    case "$1" in
+        commands|cmds|venv) _py_help_rows_commands ;;
+        setup|install|tools) _py_help_rows_setup ;;
+        *)
+            ux_error "Unknown py-help section: $1"
+            ux_info "Try: py-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_py_help_full() {
+    ux_header "Python Virtual Environment Commands"
+    _py_help_render_section "Commands" _py_help_rows_commands
+    _py_help_render_section "Setup Tools" _py_help_rows_setup
+}
+
+py_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _py_help_summary ;;
+        --list|list)        _py_help_list_sections ;;
+        --all|all)          _py_help_full ;;
+        *)                  _py_help_section_rows "$1" ;;
+    esac
 }
 
 alias py-help='py_help'

--- a/shell-common/functions/py_help.sh
+++ b/shell-common/functions/py_help.sh
@@ -54,7 +54,7 @@ _py_help_full() {
 py_help() {
     case "${1:-}" in
         ""|-h|--help|help) _py_help_summary ;;
-        --list|list)        _py_help_list_sections ;;
+        --list|list|section|sections)        _py_help_list_sections ;;
         --all|all)          _py_help_full ;;
         *)                  _py_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/register_help.sh
+++ b/shell-common/functions/register_help.sh
@@ -78,7 +78,7 @@ register_help() {
     _register_help_bootstrap
     case "${1:-}" in
         ""|-h|--help|help) _register_help_summary ;;
-        --list|list)        _register_help_list_sections ;;
+        --list|list|section|sections)        _register_help_list_sections ;;
         --all|all)          _register_help_full ;;
         *)                  _register_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/register_help.sh
+++ b/shell-common/functions/register_help.sh
@@ -2,7 +2,62 @@
 # shell-common/functions/register_help.sh
 # registerHelp - shared between bash and zsh
 
-register_help() {
+_register_help_summary() {
+    ux_info "Usage: register-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "topic: function ending with _help"
+    ux_bullet_sub "description: HELP_DESCRIPTIONS[<name>_help]"
+    ux_bullet_sub "category: HELP_CATEGORY_MEMBERS[<category>]"
+    ux_bullet_sub "details: register-help <section>  (example: register-help topic)"
+}
+
+_register_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "topic"
+    ux_bullet_sub "description"
+    ux_bullet_sub "category"
+}
+
+_register_help_rows_topic() {
+    ux_bullet "Create a function ending with: _help"
+    ux_bullet "Example: mytool_help() { ... }"
+}
+
+_register_help_rows_description() {
+    ux_bullet "Set: HELP_DESCRIPTIONS[mytool_help]=\"[Development] ...\""
+}
+
+_register_help_rows_category() {
+    ux_bullet "Edit: HELP_CATEGORY_MEMBERS[development]=\"... mytool\""
+    ux_bullet "Then reload your shell (source ~/.bashrc or ~/.zshrc)"
+}
+
+_register_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_register_help_section_rows() {
+    case "$1" in
+        topic|topics)       _register_help_rows_topic ;;
+        description|descriptions|desc) _register_help_rows_description ;;
+        category|categories) _register_help_rows_category ;;
+        *)
+            ux_error "Unknown register-help section: $1"
+            ux_info "Try: register-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_register_help_full() {
+    ux_header "Registering Help Topics"
+    _register_help_render_section "Add a Help Topic" _register_help_rows_topic
+    _register_help_render_section "Add a Description" _register_help_rows_description
+    _register_help_render_section "Add to a Category" _register_help_rows_category
+}
+
+_register_help_bootstrap() {
     # Best-effort: if my-help isn't loaded yet, attempt to source it.
     if ! type my_help_impl >/dev/null 2>&1; then
         if [ -n "$SHELL_COMMON" ] && [ -f "${SHELL_COMMON}/functions/my_help.sh" ]; then
@@ -11,23 +66,22 @@ register_help() {
         fi
     fi
 
-    ux_header "Registering Help Topics"
-
     if type _register_default_help_descriptions >/dev/null 2>&1; then
         if [ -z "${_HELP_DEFAULTS_REGISTERED:-}" ]; then
             _register_default_help_descriptions
             _HELP_DEFAULTS_REGISTERED=1
         fi
     fi
-
-    ux_section "Add a Help Topic"
-    ux_bullet "Create a function ending with: _help"
-    ux_bullet "Example: mytool_help() { ... }"
-
-    ux_section "Add a Description"
-    ux_bullet "Set: HELP_DESCRIPTIONS[mytool_help]=\"[Development] ...\""
-
-    ux_section "Add to a Category"
-    ux_bullet "Edit: HELP_CATEGORY_MEMBERS[development]=\"... mytool\""
-    ux_bullet "Then reload your shell (source ~/.bashrc or ~/.zshrc)"
 }
+
+register_help() {
+    _register_help_bootstrap
+    case "${1:-}" in
+        ""|-h|--help|help) _register_help_summary ;;
+        --list|list)        _register_help_list_sections ;;
+        --all|all)          _register_help_full ;;
+        *)                  _register_help_section_rows "$1" ;;
+    esac
+}
+
+alias register-help='register_help'

--- a/shell-common/functions/ripgrep.sh
+++ b/shell-common/functions/ripgrep.sh
@@ -7,117 +7,194 @@
 # ripgrep Help and Documentation
 # ═══════════════════════════════════════════════════════════════
 
-# Display ripgrep help and usage
-ripgrep_help() {
-    ux_header "ripgrep (rg) - Fast Text Search Tool"
+_ripgrep_help_summary() {
+    ux_info "Usage: ripgrep-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: fast | gitignore | parallel | binary-safe"
+    ux_bullet_sub "basic: pattern | path | file"
+    ux_bullet_sub "case: smart | -i | -S"
+    ux_bullet_sub "pattern: regex | -F | -w | -x"
+    ux_bullet_sub "output: -n | -c | -l | -o"
+    ux_bullet_sub "filter: -t | -T | --type-list | -g"
+    ux_bullet_sub "scope: -u | -uu | -j 1"
+    ux_bullet_sub "context: -B | -A | -C"
+    ux_bullet_sub "examples | compare | fzf | config | trouble | related"
+    ux_bullet_sub "details: ripgrep-help <section>  (example: ripgrep-help basic)"
+}
 
-    ux_section "Core Concept"
+_ripgrep_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "case"
+    ux_bullet_sub "pattern"
+    ux_bullet_sub "output"
+    ux_bullet_sub "filter"
+    ux_bullet_sub "scope"
+    ux_bullet_sub "context"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "compare"
+    ux_bullet_sub "fzf"
+    ux_bullet_sub "config"
+    ux_bullet_sub "trouble"
+    ux_bullet_sub "related"
+}
+
+_ripgrep_help_rows_concept() {
     ux_bullet "Rust-based grep replacement - much faster than grep"
     ux_bullet "Respects .gitignore automatically - avoids unwanted files"
     ux_bullet "Automatic parallelization - uses all available CPU cores"
     ux_bullet "Handles binary files gracefully"
-    echo ""
+}
 
-    ux_section "Basic Syntax"
+_ripgrep_help_rows_basic() {
     ux_table_row "rg 'pattern'" "Search for pattern in current directory"
     ux_table_row "rg 'pattern' /path" "Search in specific directory"
     ux_table_row "rg 'pattern' file.txt" "Search in specific file"
-    echo ""
+}
 
-    ux_section "Case Sensitivity"
+_ripgrep_help_rows_case() {
     ux_table_row "rg 'pattern'" "Smart case (sensitive if pattern has uppercase)"
     ux_table_row "rg -i 'pattern'" "Case-insensitive search"
     ux_table_row "rg -S 'pattern'" "Case-sensitive (always)"
-    echo ""
+}
 
-    ux_section "Pattern Types"
+_ripgrep_help_rows_pattern() {
     ux_table_row "rg 'regex'" "Regular expression search (default)"
     ux_table_row "rg -F 'literal'" "Literal string search (no regex)"
     ux_table_row "rg -w 'word'" "Match whole words only"
     ux_table_row "rg -x 'line'" "Match entire lines only"
-    echo ""
+}
 
-    ux_section "Output Control"
+_ripgrep_help_rows_output() {
     ux_table_row "rg -n 'pattern'" "Show line numbers (default)"
     ux_table_row "rg -c 'pattern'" "Count matches per file"
     ux_table_row "rg -l 'pattern'" "List filenames only"
     ux_table_row "rg -o 'pattern'" "Show only matches, not whole lines"
-    echo ""
+}
 
-    ux_section "File Filtering"
+_ripgrep_help_rows_filter() {
     ux_table_row "rg 'pattern' -t py" "Search in Python files only"
     ux_table_row "rg 'pattern' -T py" "Exclude Python files"
     ux_table_row "rg 'pattern' --type-list" "Show all available file types"
     ux_table_row "rg 'pattern' -g '*.py'" "Glob pattern filtering"
-    echo ""
+}
 
-    ux_section "Scope Control"
+_ripgrep_help_rows_scope() {
     ux_table_row "rg 'pattern'" "Search respecting .gitignore (default)"
     ux_table_row "rg -u 'pattern'" "Skip .gitignore (search hidden/ignored)"
     ux_table_row "rg -uu 'pattern'" "Skip .gitignore and .ignore files"
     ux_table_row "rg -j 1 'pattern'" "Single-threaded search"
-    echo ""
+}
 
-    ux_section "Context Display"
+_ripgrep_help_rows_context() {
     ux_table_row "rg -B 3 'pattern'" "Show 3 lines before match"
     ux_table_row "rg -A 3 'pattern'" "Show 3 lines after match"
     ux_table_row "rg -C 3 'pattern'" "Show 3 lines before and after"
-    echo ""
+}
 
-    ux_section "Practical Examples"
-    echo ""
+_ripgrep_help_rows_examples() {
     ux_info "Search in specific file type:"
     ux_bullet "rg 'TODO' -t py - Find TODO comments in Python files"
     ux_bullet "rg 'import' -t js src/ - Find imports in JavaScript source"
-    echo ""
-
     ux_info "Search with context:"
     ux_bullet "rg -C 2 'function' - See function definitions with context"
     ux_bullet "rg -B 5 'error' - Show error messages with preceding context"
-    echo ""
-
     ux_info "Counting and statistics:"
     ux_bullet "rg -c 'pattern' | sort -t: -k2 -rn - Count occurrences by file"
     ux_bullet "rg 'pattern' -c --sort=count - Show most frequent matches"
-    echo ""
-
     ux_info "Replace with sed integration:"
     ux_bullet "rg 'old' -l | xargs sed -i 's/old/new/g' - Replace in all matched files"
     ux_bullet "rg 'pattern' --files-with-matches | xargs -I {} sh -c 'echo {}; rg pattern {}'"
-    echo ""
+}
 
-    ux_section "Comparison with grep"
+_ripgrep_help_rows_compare() {
     ux_bullet "grep: Standard but slow, easy regex syntax"
     ux_bullet "rg: Much faster (50-100x), auto .gitignore support"
     ux_bullet "rg: Better output formatting, sensible defaults"
     ux_bullet "rg: No need for -r flag for recursion"
-    echo ""
+}
 
-    ux_section "Integration with fzf"
+_ripgrep_help_rows_fzf() {
     ux_bullet "rg 'pattern' | fzf - Interactive result selection"
     ux_bullet "vim \$(rg -l 'pattern' | fzf) - Open matched file in vim"
     ux_bullet "rg --files | fzf - Find file then search in it"
-    echo ""
+}
 
-    ux_section "Configuration File"
+_ripgrep_help_rows_config() {
     ux_info "Create ~/.ripgreprc for default options:"
     ux_bullet "--color=auto - Always colorize output"
     ux_bullet "--max-columns=200 - Truncate long lines"
     ux_bullet "--smart-case - Smart case sensitivity"
-    echo ""
+}
 
-    ux_section "Troubleshooting"
+_ripgrep_help_rows_trouble() {
     ux_bullet "Not finding files? Use -u to skip .gitignore"
     ux_bullet "Slow search? Use -j 1 to disable parallelization"
     ux_bullet "Too much output? Use -l to list files only, or -c to count"
-    echo ""
+}
 
-    ux_section "Related Help"
+_ripgrep_help_rows_related() {
     ux_bullet "Install ripgrep: ${UX_BOLD}install-ripgrep${UX_RESET}"
     ux_bullet "Fuzzy finder: ${UX_BOLD}fzf-help${UX_RESET}"
     ux_bullet "Fast find: ${UX_BOLD}fd-help${UX_RESET}"
     ux_bullet "File viewer: ${UX_BOLD}bat-help${UX_RESET}"
-    echo ""
+}
+
+_ripgrep_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_ripgrep_help_section_rows() {
+    case "$1" in
+        concept)            _ripgrep_help_rows_concept ;;
+        basic|syntax)       _ripgrep_help_rows_basic ;;
+        case|case-sensitivity) _ripgrep_help_rows_case ;;
+        pattern|patterns)   _ripgrep_help_rows_pattern ;;
+        output)             _ripgrep_help_rows_output ;;
+        filter|files)       _ripgrep_help_rows_filter ;;
+        scope)              _ripgrep_help_rows_scope ;;
+        context)            _ripgrep_help_rows_context ;;
+        examples|practical) _ripgrep_help_rows_examples ;;
+        compare|comparison) _ripgrep_help_rows_compare ;;
+        fzf)                _ripgrep_help_rows_fzf ;;
+        config|configuration) _ripgrep_help_rows_config ;;
+        trouble|troubleshooting) _ripgrep_help_rows_trouble ;;
+        related)            _ripgrep_help_rows_related ;;
+        *)
+            ux_error "Unknown ripgrep-help section: $1"
+            ux_info "Try: ripgrep-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_ripgrep_help_full() {
+    ux_header "ripgrep (rg) - Fast Text Search Tool"
+    _ripgrep_help_render_section "Core Concept" _ripgrep_help_rows_concept
+    _ripgrep_help_render_section "Basic Syntax" _ripgrep_help_rows_basic
+    _ripgrep_help_render_section "Case Sensitivity" _ripgrep_help_rows_case
+    _ripgrep_help_render_section "Pattern Types" _ripgrep_help_rows_pattern
+    _ripgrep_help_render_section "Output Control" _ripgrep_help_rows_output
+    _ripgrep_help_render_section "File Filtering" _ripgrep_help_rows_filter
+    _ripgrep_help_render_section "Scope Control" _ripgrep_help_rows_scope
+    _ripgrep_help_render_section "Context Display" _ripgrep_help_rows_context
+    _ripgrep_help_render_section "Practical Examples" _ripgrep_help_rows_examples
+    _ripgrep_help_render_section "Comparison with grep" _ripgrep_help_rows_compare
+    _ripgrep_help_render_section "Integration with fzf" _ripgrep_help_rows_fzf
+    _ripgrep_help_render_section "Configuration File" _ripgrep_help_rows_config
+    _ripgrep_help_render_section "Troubleshooting" _ripgrep_help_rows_trouble
+    _ripgrep_help_render_section "Related Help" _ripgrep_help_rows_related
+}
+
+ripgrep_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _ripgrep_help_summary ;;
+        --list|list)        _ripgrep_help_list_sections ;;
+        --all|all)          _ripgrep_help_full ;;
+        *)                  _ripgrep_help_section_rows "$1" ;;
+    esac
 }
 
 # Naming Convention: Support both dash and underscore

--- a/shell-common/functions/ripgrep.sh
+++ b/shell-common/functions/ripgrep.sh
@@ -191,7 +191,7 @@ _ripgrep_help_full() {
 ripgrep_help() {
     case "${1:-}" in
         ""|-h|--help|help) _ripgrep_help_summary ;;
-        --list|list)        _ripgrep_help_list_sections ;;
+        --list|list|section|sections)        _ripgrep_help_list_sections ;;
         --all|all)          _ripgrep_help_full ;;
         *)                  _ripgrep_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/security_ssh_help.sh
+++ b/shell-common/functions/security_ssh_help.sh
@@ -111,7 +111,7 @@ crt_help() {
         ""|-h|--help|help)
             _crt_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _crt_help_list_sections
             ;;
         --all|all)
@@ -223,7 +223,7 @@ ssh_help() {
         ""|-h|--help|help)
             _ssh_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _ssh_help_list_sections
             ;;
         --all|all)
@@ -389,7 +389,7 @@ ssl_help() {
         ""|-h|--help|help)
             _ssl_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _ssl_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/security_ssh_help.sh
+++ b/shell-common/functions/security_ssh_help.sh
@@ -239,7 +239,125 @@ alias ssh-help='ssh_help'
 
 # --- ssl_help (from ssl_help.sh) ---
 
-ssl_help() {
+_ssl_help_summary() {
+    ux_info "Usage: ssl-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "status: SSL_CERT_FILE | REQUESTS_CA_BUNDLE | NODE_EXTRA_CA_CERTS"
+    ux_bullet_sub "commands: echo \$SSL_CERT_FILE | env grep cert"
+    ux_bullet_sub "files: security.local.sh status"
+    ux_bullet_sub "paths: Internal | External | System CA"
+    ux_bullet_sub "tools: curl | wget | git | python | npm"
+    ux_bullet_sub "notes: SSL_CERT_FILE | REQUESTS_CA_BUNDLE | NODE_EXTRA_CA_CERTS"
+    ux_bullet_sub "details: ssl-help <section>  (example: ssl-help status)"
+}
+
+_ssl_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "status"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "files"
+    ux_bullet_sub "paths"
+    ux_bullet_sub "tools"
+    ux_bullet_sub "notes"
+}
+
+_ssl_help_rows_status() {
+    if [ -n "$SSL_CERT_FILE" ]; then
+        ux_success "SSL_CERT_FILE: $SSL_CERT_FILE"
+        if [ -f "$SSL_CERT_FILE" ]; then
+            ux_success "  ✓ File exists and is readable"
+        else
+            ux_warning "  ✗ File NOT found (may need to be installed)"
+        fi
+    else
+        ux_warning "SSL_CERT_FILE: [NOT SET]"
+        ux_info "  This is normal for public/home environments"
+    fi
+
+    if [ -n "$REQUESTS_CA_BUNDLE" ]; then
+        ux_success "REQUESTS_CA_BUNDLE: $REQUESTS_CA_BUNDLE (Python requests)"
+    else
+        ux_info "REQUESTS_CA_BUNDLE: [NOT SET]"
+    fi
+
+    if [ -n "$NODE_EXTRA_CA_CERTS" ]; then
+        ux_success "NODE_EXTRA_CA_CERTS: $NODE_EXTRA_CA_CERTS (Node.js)"
+    else
+        ux_info "NODE_EXTRA_CA_CERTS: [NOT SET]"
+    fi
+}
+
+_ssl_help_rows_commands() {
+    ux_bullet "echo \$SSL_CERT_FILE                  Show SSL certificate file"
+    ux_bullet "echo \$REQUESTS_CA_BUNDLE             Show Python requests CA bundle"
+    ux_bullet "env | grep -i cert                   Show all certificate vars"
+}
+
+_ssl_help_rows_files() {
+    local security_local="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/env/security.local.sh"
+    if [ -f "$security_local" ]; then
+        ux_success "security.local.sh: exists"
+        ux_bullet "Location: $security_local"
+    else
+        ux_info "security.local.sh: not configured (public environment)"
+    fi
+}
+
+_ssl_help_rows_paths() {
+    ux_bullet "Internal PC:  /usr/share/ca-certificates/extra/McAfee_Certificate.crt"
+    ux_bullet "External PC:  /usr/local/share/ca-certificates/samsungsemi-prx.com.crt"
+    ux_bullet "System CA:    /etc/ssl/certs/ca-certificates.crt"
+}
+
+_ssl_help_rows_tools() {
+    ux_bullet "curl                 - Web requests and downloads"
+    ux_bullet "wget                 - File downloads"
+    ux_bullet "git                  - Git operations (HTTPS)"
+    ux_bullet "python (requests)    - HTTP library"
+    ux_bullet "npm                  - Node.js package manager"
+}
+
+_ssl_help_rows_notes() {
+    ux_warning "Different variables for different tools:"
+    ux_info "  - SSL_CERT_FILE:        curl, wget, git"
+    ux_info "  - REQUESTS_CA_BUNDLE:   Python requests"
+    ux_info "  - NODE_EXTRA_CA_CERTS:  Node.js"
+}
+
+_ssl_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_ssl_help_section_rows() {
+    case "$1" in
+        status|current)
+            _ssl_help_rows_status
+            ;;
+        commands|quick)
+            _ssl_help_rows_commands
+            ;;
+        files|config)
+            _ssl_help_rows_files
+            ;;
+        paths|environment)
+            _ssl_help_rows_paths
+            ;;
+        tools)
+            _ssl_help_rows_tools
+            ;;
+        notes|important)
+            _ssl_help_rows_notes
+            ;;
+        *)
+            ux_error "Unknown ssl-help section: $1"
+            ux_info "Try: ssl-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_ssl_help_full() {
     if type ux_header >/dev/null 2>&1; then
         ux_header "SSL Certificate Configuration & Diagnostics"
     else
@@ -247,64 +365,12 @@ ssl_help() {
     fi
 
     if type ux_section >/dev/null 2>&1; then
-        ux_section "Current SSL Certificate Status"
-
-        if [ -n "$SSL_CERT_FILE" ]; then
-            ux_success "SSL_CERT_FILE: $SSL_CERT_FILE"
-            if [ -f "$SSL_CERT_FILE" ]; then
-                ux_success "  ✓ File exists and is readable"
-            else
-                ux_warning "  ✗ File NOT found (may need to be installed)"
-            fi
-        else
-            ux_warning "SSL_CERT_FILE: [NOT SET]"
-            ux_info "  This is normal for public/home environments"
-        fi
-
-        if [ -n "$REQUESTS_CA_BUNDLE" ]; then
-            ux_success "REQUESTS_CA_BUNDLE: $REQUESTS_CA_BUNDLE (Python requests)"
-        else
-            ux_info "REQUESTS_CA_BUNDLE: [NOT SET]"
-        fi
-
-        if [ -n "$NODE_EXTRA_CA_CERTS" ]; then
-            ux_success "NODE_EXTRA_CA_CERTS: $NODE_EXTRA_CA_CERTS (Node.js)"
-        else
-            ux_info "NODE_EXTRA_CA_CERTS: [NOT SET]"
-        fi
-
-        ux_section "Quick Commands"
-        ux_bullet "echo \$SSL_CERT_FILE                  Show SSL certificate file"
-        ux_bullet "echo \$REQUESTS_CA_BUNDLE             Show Python requests CA bundle"
-        ux_bullet "env | grep -i cert                   Show all certificate vars"
-
-        ux_section "Security Configuration Files"
-        local security_local="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/env/security.local.sh"
-        if [ -f "$security_local" ]; then
-            ux_success "security.local.sh: exists"
-            ux_bullet "Location: $security_local"
-        else
-            ux_info "security.local.sh: not configured (public environment)"
-        fi
-
-        ux_section "Certificate Paths by Environment"
-        ux_bullet "Internal PC:  /usr/share/ca-certificates/extra/McAfee_Certificate.crt"
-        ux_bullet "External PC:  /usr/local/share/ca-certificates/samsungsemi-prx.com.crt"
-        ux_bullet "System CA:    /etc/ssl/certs/ca-certificates.crt"
-
-        ux_section "Tools That Use SSL_CERT_FILE"
-        ux_bullet "curl                 - Web requests and downloads"
-        ux_bullet "wget                 - File downloads"
-        ux_bullet "git                  - Git operations (HTTPS)"
-        ux_bullet "python (requests)    - HTTP library"
-        ux_bullet "npm                  - Node.js package manager"
-
-        ux_section "Important Notes"
-        ux_warning "Different variables for different tools:"
-        ux_info "  - SSL_CERT_FILE:        curl, wget, git"
-        ux_info "  - REQUESTS_CA_BUNDLE:   Python requests"
-        ux_info "  - NODE_EXTRA_CA_CERTS:  Node.js"
-
+        _ssl_help_render_section "Current SSL Certificate Status" _ssl_help_rows_status
+        _ssl_help_render_section "Quick Commands" _ssl_help_rows_commands
+        _ssl_help_render_section "Security Configuration Files" _ssl_help_rows_files
+        _ssl_help_render_section "Certificate Paths by Environment" _ssl_help_rows_paths
+        _ssl_help_render_section "Tools That Use SSL_CERT_FILE" _ssl_help_rows_tools
+        _ssl_help_render_section "Important Notes" _ssl_help_rows_notes
     else
         # Fallback for minimal shells without UX library
         echo ""
@@ -316,6 +382,23 @@ ssl_help() {
         echo "  env | grep -i cert        # Show all certificate variables"
         echo ""
     fi
+}
+
+ssl_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _ssl_help_summary
+            ;;
+        --list|list)
+            _ssl_help_list_sections
+            ;;
+        --all|all)
+            _ssl_help_full
+            ;;
+        *)
+            _ssl_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Wrapper function for future check_ssl.sh diagnostic (placeholder)

--- a/shell-common/functions/security_ssh_help.sh
+++ b/shell-common/functions/security_ssh_help.sh
@@ -6,36 +6,121 @@
 
 # NOTE: UX library is loaded by the loader before functions/ — no need to reload here
 
-crt_help() {
-    ux_header "CA Certificate Setup Guide"
+_crt_help_summary() {
+    ux_info "Usage: crt-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "overview: npm/Node/Python CA | custom & system | security.local.sh"
+    ux_bullet_sub "options: External (custom crt) | Internal (system CA)"
+    ux_bullet_sub "setup: crtsetup"
+    ux_bullet_sub "env: NODE_EXTRA_CA_CERTS | REQUESTS_CA_BUNDLE"
+    ux_bullet_sub "config: shell-common/env/security.local.sh"
+    ux_bullet_sub "related: npm-help | security.sh | setup.sh"
+    ux_bullet_sub "details: crt-help <section>  (example: crt-help options)"
+}
 
-    ux_section "Overview"
+_crt_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "overview"
+    ux_bullet_sub "options"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "env"
+    ux_bullet_sub "config"
+    ux_bullet_sub "related"
+}
+
+_crt_help_rows_overview() {
     ux_bullet "Manages CA certificates for npm, Node.js, and Python"
     ux_bullet "Supports custom certificates (company proxy) and system CA bundles"
     ux_bullet "Configuration stored in: shell-common/env/security.local.sh"
+}
 
-    ux_section "Two Options"
+_crt_help_rows_options() {
     ux_bullet "Option 1: Custom Certificate (External Company PC - VPN)"
     ux_bullet " • Certificate path: ${UX_MUTED}/usr/local/share/ca-certificates/samsungsemi-prx.com.crt${UX_RESET}"
     ux_bullet " • Install with: ${UX_SUCCESS}crtsetup${UX_RESET}"
     ux_bullet "Option 2: System CA Bundle (Internal Company PC)"
     ux_bullet " • Certificate path: ${UX_MUTED}/etc/ssl/certs/ca-certificates.crt${UX_RESET}"
     ux_bullet " • Already system default, no setup needed"
+}
 
-    ux_section "Setup Command"
+_crt_help_rows_setup() {
     ux_table_row "crtsetup" "Interactive CA certificate setup script"
+}
 
-    ux_section "Environment Variables"
+_crt_help_rows_env() {
     ux_table_row "NODE_EXTRA_CA_CERTS" "Used by Node.js/npm for certificate validation"
     ux_table_row "REQUESTS_CA_BUNDLE" "Used by Python for certificate validation"
+}
 
-    ux_section "Configuration File"
+_crt_help_rows_config() {
     ux_info "Location: ${UX_BOLD}shell-common/env/security.local.sh${UX_RESET}"
+}
 
-    ux_section "Related Commands"
+_crt_help_rows_related() {
     ux_table_row "npm-help" "NPM package manager commands and setup"
     ux_table_row "security.sh" "Security environment variable configuration"
     ux_table_row "setup.sh" "Initial environment-specific setup"
+}
+
+_crt_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_crt_help_section_rows() {
+    case "$1" in
+        overview)
+            _crt_help_rows_overview
+            ;;
+        options|option)
+            _crt_help_rows_options
+            ;;
+        setup|install)
+            _crt_help_rows_setup
+            ;;
+        env|environment)
+            _crt_help_rows_env
+            ;;
+        config|configuration)
+            _crt_help_rows_config
+            ;;
+        related)
+            _crt_help_rows_related
+            ;;
+        *)
+            ux_error "Unknown crt-help section: $1"
+            ux_info "Try: crt-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_crt_help_full() {
+    ux_header "CA Certificate Setup Guide"
+
+    _crt_help_render_section "Overview" _crt_help_rows_overview
+    _crt_help_render_section "Two Options" _crt_help_rows_options
+    _crt_help_render_section "Setup Command" _crt_help_rows_setup
+    _crt_help_render_section "Environment Variables" _crt_help_rows_env
+    _crt_help_render_section "Configuration File" _crt_help_rows_config
+    _crt_help_render_section "Related Commands" _crt_help_rows_related
+}
+
+crt_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _crt_help_summary
+            ;;
+        --list|list)
+            _crt_help_list_sections
+            ;;
+        --all|all)
+            _crt_help_full
+            ;;
+        *)
+            _crt_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias crt-help='crt_help'

--- a/shell-common/functions/security_ssh_help.sh
+++ b/shell-common/functions/security_ssh_help.sh
@@ -127,18 +127,35 @@ alias crt-help='crt_help'
 
 # --- ssh_help (from ssh_help.sh) ---
 
-ssh_help() {
-    ux_header "SSH / SCP Commands"
+_ssh_help_summary() {
+    ux_info "Usage: ssh-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "ssh: ssh <host> | ssh <host> <cmd>"
+    ux_bullet_sub "scp: pull | push"
+    ux_bullet_sub "hosts: registered hosts in ~/.ssh/config"
+    ux_bullet_sub "config: ~/.ssh/config -> dotfiles/ssh/config"
+    ux_bullet_sub "details: ssh-help <section>  (example: ssh-help hosts)"
+}
 
-    ux_section "SSH - Connect & Run"
+_ssh_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "ssh"
+    ux_bullet_sub "scp"
+    ux_bullet_sub "hosts"
+    ux_bullet_sub "config"
+}
+
+_ssh_help_rows_ssh() {
     ux_table_row "ssh <host>" "ssh ssai-dev" "Connect to server"
     ux_table_row "ssh <host> <cmd>" "ssh ssai-dev 'ls /home'" "Run remote command"
+}
 
-    ux_section "SCP - File Transfer"
+_ssh_help_rows_scp() {
     ux_table_row "pull" "scp <host>:<src> <dst>" "Download from server"
     ux_table_row "push" "scp <src> <host>:<dst>" "Upload to server"
+}
 
-    ux_section "Registered Hosts (~/.ssh/config)"
+_ssh_help_rows_hosts() {
     if [ -f "${HOME}/.ssh/config" ]; then
         set -f  # Disable glob expansion to prevent Host * from expanding
         while IFS= read -r line; do
@@ -159,9 +176,63 @@ ssh_help() {
     else
         ux_info "~/.ssh/config not found. Run ./setup.sh to create symlink."
     fi
+}
 
-    ux_section "Config"
+_ssh_help_rows_config() {
     ux_table_row "config file" "~/.ssh/config → dotfiles/ssh/config" "Managed by dotfiles"
+}
+
+_ssh_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_ssh_help_section_rows() {
+    case "$1" in
+        ssh|connect)
+            _ssh_help_rows_ssh
+            ;;
+        scp|transfer)
+            _ssh_help_rows_scp
+            ;;
+        hosts|registered)
+            _ssh_help_rows_hosts
+            ;;
+        config|configuration)
+            _ssh_help_rows_config
+            ;;
+        *)
+            ux_error "Unknown ssh-help section: $1"
+            ux_info "Try: ssh-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_ssh_help_full() {
+    ux_header "SSH / SCP Commands"
+
+    _ssh_help_render_section "SSH - Connect & Run" _ssh_help_rows_ssh
+    _ssh_help_render_section "SCP - File Transfer" _ssh_help_rows_scp
+    _ssh_help_render_section "Registered Hosts (~/.ssh/config)" _ssh_help_rows_hosts
+    _ssh_help_render_section "Config" _ssh_help_rows_config
+}
+
+ssh_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _ssh_help_summary
+            ;;
+        --list|list)
+            _ssh_help_list_sections
+            ;;
+        --all|all)
+            _ssh_help_full
+            ;;
+        *)
+            _ssh_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias ssh-help='ssh_help'

--- a/shell-common/functions/setup_mode_help.sh
+++ b/shell-common/functions/setup_mode_help.sh
@@ -152,7 +152,7 @@ setup_mode_help() {
         ""|-h|--help|help)
             _setup_mode_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _setup_mode_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/setup_mode_help.sh
+++ b/shell-common/functions/setup_mode_help.sh
@@ -79,26 +79,89 @@ show_setup_mode() {
 }
 
 # ============================================================
-# Help function for setup_mode
+# Help function for setup_mode (SSOT pattern)
 # ============================================================
-setup_mode_help() {
-    ux_header "Setup Mode Management"
+_setup_mode_help_summary() {
+    ux_info "Usage: setup-mode-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "overview: tracks PC environment, auto-applies settings"
+    ux_bullet_sub "modes: 1=Public | 2=Internal | 3=External(VPN)"
+    ux_bullet_sub "usage: show-setup-mode | setup-mode-help | setup.sh"
+    ux_bullet_sub "details: setup-mode-help <section>  (example: setup-mode-help modes)"
+}
 
-    ux_section "Overview"
+_setup_mode_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "overview"
+    ux_bullet_sub "modes"
+    ux_bullet_sub "usage"
+}
+
+_setup_mode_help_rows_overview() {
     ux_bullet "Tracks which environment your PC is configured for"
     ux_bullet "Automatically applies environment-specific settings"
     ux_bullet "Stored in: ~/.dotfiles-setup-mode"
+}
 
-    ux_section "Available Modes"
+_setup_mode_help_rows_modes() {
     ux_table_row "Mode 1" "Public PC (Home environment)" "No proxy, no company configs"
     ux_table_row "Mode 2" "Internal company PC (Direct)" "Company proxy, internal repos, CA certs"
     ux_table_row "Mode 3" "External company PC (VPN)" "No proxy, VPN certificate"
+}
 
-    ux_section "Usage"
+_setup_mode_help_rows_usage() {
     ux_table_row "show-setup-mode" "Show current mode"
     ux_table_row "setup-mode-help" "View this help"
     ux_bullet "Reconfigure: ${UX_BOLD}cd ~/dotfiles && ./setup.sh${UX_RESET}"
     ux_bullet "Check proxy: ${UX_BOLD}check-proxy${UX_RESET}"
+}
+
+_setup_mode_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_setup_mode_help_section_rows() {
+    case "$1" in
+        overview|about)
+            _setup_mode_help_rows_overview
+            ;;
+        modes|mode)
+            _setup_mode_help_rows_modes
+            ;;
+        usage|use|commands|cmds)
+            _setup_mode_help_rows_usage
+            ;;
+        *)
+            ux_error "Unknown setup-mode-help section: $1"
+            ux_info "Try: setup-mode-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_setup_mode_help_full() {
+    ux_header "Setup Mode Management"
+    _setup_mode_help_render_section "Overview" _setup_mode_help_rows_overview
+    _setup_mode_help_render_section "Available Modes" _setup_mode_help_rows_modes
+    _setup_mode_help_render_section "Usage" _setup_mode_help_rows_usage
+}
+
+setup_mode_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _setup_mode_help_summary
+            ;;
+        --list|list)
+            _setup_mode_help_list_sections
+            ;;
+        --all|all)
+            _setup_mode_help_full
+            ;;
+        *)
+            _setup_mode_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # ============================================================

--- a/shell-common/functions/superpowers_help.sh
+++ b/shell-common/functions/superpowers_help.sh
@@ -157,7 +157,7 @@ superpowers_help() {
         ""|-h|--help|help)
             _superpowers_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _superpowers_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/superpowers_help.sh
+++ b/shell-common/functions/superpowers_help.sh
@@ -4,47 +4,73 @@
 
 SUPERPOWERS_SKILLS_DIR="$HOME/.claude/plugins/cache/superpowers-dev/superpowers"
 
-superpowers_help() {
-    # Find installed version directory
-    local skills_base=""
-    local version=""
+# Resolve the installed superpowers skills base directory and version
+_superpowers_help_resolve() {
+    _SUPERPOWERS_SKILLS_BASE=""
+    _SUPERPOWERS_VERSION=""
     if [ -d "$SUPERPOWERS_SKILLS_DIR" ]; then
         for d in "$SUPERPOWERS_SKILLS_DIR"/*/skills; do
             if [ -d "$d" ]; then
-                skills_base="$d"
-                version=$(basename "$(dirname "$d")")
+                _SUPERPOWERS_SKILLS_BASE="$d"
+                _SUPERPOWERS_VERSION=$(basename "$(dirname "$d")")
                 break
             fi
         done
     fi
+}
 
-    ux_header "Superpowers Plugin Skills (v${version:-unknown})"
+_superpowers_help_summary() {
+    ux_info "Usage: superpowers-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "process: brainstorming | plans | TDD | debugging | verify"
+    ux_bullet_sub "execution: parallel agents | subagents | worktrees"
+    ux_bullet_sub "review: request | receive | finishing branch"
+    ux_bullet_sub "meta: using-superpowers | writing-skills"
+    ux_bullet_sub "flow: feature & bug-fix lifecycles"
+    ux_bullet_sub "location: skill files path"
+    ux_bullet_sub "usage: invocation tips"
+    ux_bullet_sub "details: superpowers-help <section>"
+}
 
-    ux_section "Process Skills (HOW to approach)"
+_superpowers_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "process"
+    ux_bullet_sub "execution"
+    ux_bullet_sub "review"
+    ux_bullet_sub "meta"
+    ux_bullet_sub "flow"
+    ux_bullet_sub "location"
+    ux_bullet_sub "usage"
+}
+
+_superpowers_help_rows_process() {
     ux_table_row "brainstorming" "Creative work, feature design, requirements exploration before implementation"
     ux_table_row "writing-plans" "Multi-step task planning from spec/requirements, before touching code"
     ux_table_row "executing-plans" "Execute written implementation plans in separate sessions with review checkpoints"
     ux_table_row "systematic-debugging" "Bug/test failure diagnosis - root cause analysis before proposing fixes"
     ux_table_row "test-driven-development" "Red-green-refactor: write tests before implementation code"
     ux_table_row "verification-before-completion" "Run verification commands and confirm output before claiming done"
+}
 
-    ux_section "Execution Skills (parallel & isolation)"
+_superpowers_help_rows_execution() {
     ux_table_row "dispatching-parallel-agents" "Run 2+ independent tasks concurrently without shared state"
     ux_table_row "subagent-driven-development" "Execute implementation plans with independent sub-agents"
     ux_table_row "using-git-worktrees" "Isolated feature work via git worktrees with safety checks"
+}
 
-    ux_section "Review & Completion Skills"
+_superpowers_help_rows_review() {
     ux_table_row "requesting-code-review" "Request review after feature completion or before merge"
     ux_table_row "receiving-code-review" "Handle review feedback with technical rigor, not blind agreement"
     ux_table_row "finishing-a-development-branch" "Branch integration: merge, PR, or cleanup options"
+}
 
-    ux_section "Meta Skills"
+_superpowers_help_rows_meta() {
     ux_table_row "using-superpowers" "Skill discovery and invocation at conversation start"
     ux_table_row "writing-skills" "Create, edit, or verify skills before deployment"
+}
 
-    ux_section "Skill Usage Flow"
+_superpowers_help_rows_flow() {
     ux_info "Feature Development (full lifecycle):"
-    echo ""
     ux_numbered 1 "brainstorming          - explore requirements, design spec"
     ux_numbered 2 "writing-plans          - break spec into bite-sized tasks"
     ux_numbered 3 "executing-plans        - execute tasks (TDD per step)"
@@ -52,31 +78,95 @@ superpowers_help() {
     ux_numbered 5 "requesting-code-review - dispatch reviewer subagent"
     ux_numbered 6 "receiving-code-review  - evaluate & apply feedback"
     ux_numbered 7 "finishing-a-dev-branch - merge, PR, or cleanup"
-    echo ""
     ux_info "verification-before-completion runs at every completion claim."
     ux_info "test-driven-development runs inside each execution step."
-    echo ""
     ux_info "Bug Fix (shorter cycle):"
-    echo ""
     ux_numbered 1 "systematic-debugging   - root cause analysis first"
     ux_numbered 2 "test-driven-development - write failing test for the bug"
     ux_numbered 3 "verification-before-completion"
     ux_numbered 4 "finishing-a-dev-branch - merge the fix"
-    echo ""
     ux_info "Parallel tasks: use dispatching-parallel-agents or using-git-worktrees"
+}
 
-    ux_section "Skill Files Location"
-    if [ -n "$skills_base" ]; then
-        ux_info "$skills_base/"
+_superpowers_help_rows_location() {
+    _superpowers_help_resolve
+    if [ -n "$_SUPERPOWERS_SKILLS_BASE" ]; then
+        ux_info "$_SUPERPOWERS_SKILLS_BASE/"
     else
         ux_warning "Superpowers plugin not found. Install via Claude Code marketplace."
         ux_info "Expected: $SUPERPOWERS_SKILLS_DIR/<version>/skills/"
     fi
+}
 
-    ux_section "Usage"
+_superpowers_help_rows_usage() {
     ux_bullet "Invoke in Claude Code: ${UX_CODE}/brainstorm${UX_RESET}, ${UX_CODE}/write-plan${UX_RESET}, ${UX_CODE}/execute-plan${UX_RESET}"
     ux_bullet "Read a skill: ${UX_CODE}cat <skills_path>/<skill-name>/SKILL.md${UX_RESET}"
     ux_bullet "Priority: Process skills first, then implementation skills"
+}
+
+_superpowers_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_superpowers_help_section_rows() {
+    case "$1" in
+        process|how)
+            _superpowers_help_rows_process
+            ;;
+        execution|exec|parallel)
+            _superpowers_help_rows_execution
+            ;;
+        review|completion)
+            _superpowers_help_rows_review
+            ;;
+        meta)
+            _superpowers_help_rows_meta
+            ;;
+        flow|workflow|usage-flow)
+            _superpowers_help_rows_flow
+            ;;
+        location|path|files)
+            _superpowers_help_rows_location
+            ;;
+        usage|use|invoke)
+            _superpowers_help_rows_usage
+            ;;
+        *)
+            ux_error "Unknown superpowers-help section: $1"
+            ux_info "Try: superpowers-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_superpowers_help_full() {
+    _superpowers_help_resolve
+    ux_header "Superpowers Plugin Skills (v${_SUPERPOWERS_VERSION:-unknown})"
+    _superpowers_help_render_section "Process Skills (HOW to approach)" _superpowers_help_rows_process
+    _superpowers_help_render_section "Execution Skills (parallel & isolation)" _superpowers_help_rows_execution
+    _superpowers_help_render_section "Review & Completion Skills" _superpowers_help_rows_review
+    _superpowers_help_render_section "Meta Skills" _superpowers_help_rows_meta
+    _superpowers_help_render_section "Skill Usage Flow" _superpowers_help_rows_flow
+    _superpowers_help_render_section "Skill Files Location" _superpowers_help_rows_location
+    _superpowers_help_render_section "Usage" _superpowers_help_rows_usage
+}
+
+superpowers_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _superpowers_help_summary
+            ;;
+        --list|list)
+            _superpowers_help_list_sections
+            ;;
+        --all|all)
+            _superpowers_help_full
+            ;;
+        *)
+            _superpowers_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias superpowers-help='superpowers_help'

--- a/shell-common/functions/system_help.sh
+++ b/shell-common/functions/system_help.sh
@@ -121,93 +121,149 @@ alias sys-help='sys_help'
 
 # --- gpu_help (from gpu_help.sh) ---
 
-# Internal: Full help function (moved from tools/integrations/gpu.sh for co-location)
-# Pure help-display function — no GPU tool dependencies, only ux_* calls
-_gpu_help_full() {
-    ux_header "GPU Monitoring Commands (Complete)"
+_gpu_help_summary() {
+    ux_info "Usage: gpu-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics: gpustatus | gpuinfo"
+    ux_bullet_sub "docker: gpu-offload | gpu-mem"
+    ux_bullet_sub "fixes: docker compose restart ollama | docker restart ollama | dcr ollama"
+    ux_bullet_sub "wsl: gpu-info-basic | gpu-memory | gpu-watch"
+    ux_bullet_sub "test: tinyllama | llama3:instruct"
+    ux_bullet_sub "troubleshoot: OLLAMA_NUM_GPU | OLLAMA_FLASH_ATTENTION"
+    ux_bullet_sub "examples: good vs bad layer offload"
+    ux_bullet_sub "tips: gpustatus | gpuinfo | gpu-offload | gpu-memory | gpu-watch"
+    ux_bullet_sub "details: gpu-help <section>  (example: gpu-help diagnostics)"
+}
 
-    ux_section "Core GPU Diagnostics"
+_gpu_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics"
+    ux_bullet_sub "docker"
+    ux_bullet_sub "fixes"
+    ux_bullet_sub "wsl"
+    ux_bullet_sub "test"
+    ux_bullet_sub "troubleshoot"
+    ux_bullet_sub "examples"
+    ux_bullet_sub "tips"
+}
+
+_gpu_help_rows_diagnostics() {
     ux_table_row "gpustatus" "bash gpu_status.sh" "5-part detailed GPU diagnostic"
     ux_table_row "gpuinfo" "Compact GPU summary" "Brief GPU hardware + layer offload"
-    echo ""
+}
 
-    ux_section "Ollama Docker GPU Status"
+_gpu_help_rows_docker() {
     ux_table_row "gpu-offload" "docker logs ollama | grep offloaded" "Layer offload status (25/25 = good)"
     ux_table_row "gpu-mem" "docker logs ollama | grep gpu memory" "GPU memory recognition check"
-    echo ""
+}
 
-    ux_section "GPU Acceleration / Fixes"
+_gpu_help_rows_fixes() {
     ux_table_row "docker compose restart ollama" "Restart Ollama" "Forces GPU layer re-init"
     ux_table_row "docker restart ollama" "Restart container" "Direct restart without compose"
     ux_table_row "dcr ollama" "Auto-detect restart" "Compose-aware restart"
-    echo ""
+}
 
-    ux_section "WSL2 Host GPU Commands"
+_gpu_help_rows_wsl() {
     ux_table_row "gpu-info-basic" "nvidia-smi" "GPU hardware info, workload, temp"
     ux_table_row "gpu-memory" "nvidia-smi memory (CSV)" "Detailed memory info"
     ux_table_row "gpu-watch" "Real-time GPU monitor" "Live monitoring (Ctrl+C to exit)"
-    echo ""
+}
 
-    ux_section "Quick GPU Test"
+_gpu_help_rows_test() {
     ux_bullet "Fast test (1-2s): ${UX_BOLD}docker exec ollama ollama run tinyllama \"hi\"${UX_RESET}"
     ux_bullet "Full test (10s+): ${UX_BOLD}docker exec ollama ollama run llama3:instruct \"hi\"${UX_RESET}"
-    echo ""
+}
 
-    ux_section "Troubleshooting: GPU Layers at 0/25"
+_gpu_help_rows_troubleshoot() {
     ux_bullet "Add to docker-compose.yml (Ollama service):"
     echo "  environment:"
     echo "    OLLAMA_NUM_GPU: '25'           # or your GPU's layer count"
     echo "    OLLAMA_FLASH_ATTENTION: '1'    # enables flash attention"
     ux_bullet "Then restart: ${UX_BOLD}docker compose up -d ollama${UX_RESET}"
-    echo ""
+}
 
-    ux_section "Output Examples"
-    echo ""
+_gpu_help_rows_examples() {
     ux_info "✅ Good GPU layer offload:"
     echo "  offloaded 25/25 layers to GPU"
     echo ""
     ux_info "❌ Bad GPU layer offload:"
     echo "  offloaded 0/25 layers to GPU"
-    echo ""
+}
 
-    ux_section "Usage Tips"
+_gpu_help_rows_tips() {
     ux_bullet "Full diagnosis: ${UX_BOLD}gpustatus${UX_RESET}"
     ux_bullet "Quick overview: ${UX_BOLD}gpuinfo${UX_RESET}"
     ux_bullet "Monitor layers: ${UX_BOLD}gpu-offload${UX_RESET}"
     ux_bullet "Check memory: ${UX_BOLD}gpu-memory${UX_RESET} or ${UX_BOLD}gpu-watch${UX_RESET}"
-    echo ""
+}
+
+_gpu_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gpu_help_section_rows() {
+    case "$1" in
+        diagnostics|diag)
+            _gpu_help_rows_diagnostics
+            ;;
+        docker)
+            _gpu_help_rows_docker
+            ;;
+        fixes|fix|acceleration)
+            _gpu_help_rows_fixes
+            ;;
+        wsl|host)
+            _gpu_help_rows_wsl
+            ;;
+        test)
+            _gpu_help_rows_test
+            ;;
+        troubleshoot|troubleshooting)
+            _gpu_help_rows_troubleshoot
+            ;;
+        examples|output)
+            _gpu_help_rows_examples
+            ;;
+        tips|usage)
+            _gpu_help_rows_tips
+            ;;
+        *)
+            ux_error "Unknown gpu-help section: $1"
+            ux_info "Try: gpu-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_gpu_help_full() {
+    ux_header "GPU Monitoring Commands (Complete)"
+
+    _gpu_help_render_section "Core GPU Diagnostics" _gpu_help_rows_diagnostics
+    _gpu_help_render_section "Ollama Docker GPU Status" _gpu_help_rows_docker
+    _gpu_help_render_section "GPU Acceleration / Fixes" _gpu_help_rows_fixes
+    _gpu_help_render_section "WSL2 Host GPU Commands" _gpu_help_rows_wsl
+    _gpu_help_render_section "Quick GPU Test" _gpu_help_rows_test
+    _gpu_help_render_section "Troubleshooting: GPU Layers at 0/25" _gpu_help_rows_troubleshoot
+    _gpu_help_render_section "Output Examples" _gpu_help_rows_examples
+    _gpu_help_render_section "Usage Tips" _gpu_help_rows_tips
 }
 
 gpu_help() {
-    # Show full help with --all or -a flag
-    if [[ "$1" == "--all" ]] || [[ "$1" == "-a" ]]; then
-        _gpu_help_full
-        return 0
-    fi
-
-    ux_header "GPU Monitoring Commands"
-
-    ux_section "Diagnostics & Monitoring"
-    ux_table_row "gpustatus" "Full GPU diagnosis (5 sections)"
-    ux_table_row "gpuinfo" "Quick GPU overview"
-    ux_table_row "gpu-offload" "Layer offload status"
-    ux_table_row "gpu-mem" "GPU memory check"
-    ux_table_row "gpu-watch" "Real-time GPU monitor"
-
-
-    ux_section "Quick Test"
-    ux_bullet "Fast (1-2s): ${UX_BOLD}docker exec ollama ollama run tinyllama \"hi\"${UX_RESET}"
-    ux_bullet "Full (10s+): ${UX_BOLD}docker exec ollama ollama run llama3:instruct \"hi\"${UX_RESET}"
-
-
-    ux_section "Fix: GPU Layers at 0/25"
-    ux_bullet "Edit docker-compose.yml (add to Ollama service):"
-    ux_bullet "  OLLAMA_NUM_GPU: '25'"
-    ux_bullet "  OLLAMA_FLASH_ATTENTION: '1'"
-    ux_bullet "Restart: ${UX_BOLD}docker compose up -d ollama${UX_RESET}"
-
-
-    ux_info "More details: ${UX_BOLD}gpu-help --all${UX_RESET}"
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _gpu_help_summary
+            ;;
+        --list|list)
+            _gpu_help_list_sections
+            ;;
+        --all|all|-a)
+            _gpu_help_full
+            ;;
+        *)
+            _gpu_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias gpu-help='gpu_help'

--- a/shell-common/functions/system_help.sh
+++ b/shell-common/functions/system_help.sh
@@ -344,16 +344,32 @@ alias du-help='du_help'
 
 # --- dir_help (from dir_help.sh) ---
 
-dir_help() {
-    ux_header "Directory Navigation"
+_dir_help_summary() {
+    ux_info "Usage: dir-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "core: cd-dot | cd-down | cd-work"
+    ux_bullet_sub "windows: cd-wdocu | cd-wobsidian | cd-wdown | cd-wpicture | cd-tilnote | cd-obsidian"
+    ux_bullet_sub "para: mkpara | cd-para | cd-project | cd-area | cd-vault | cd-resource | cd-archive"
+    ux_bullet_sub "copy: cp_wdown"
+    ux_bullet_sub "details: dir-help <section>  (example: dir-help para)"
+}
 
-    ux_section "Core Directories"
+_dir_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "core"
+    ux_bullet_sub "windows"
+    ux_bullet_sub "para"
+    ux_bullet_sub "copy"
+}
+
+_dir_help_rows_core() {
     ux_table_header "Command" "Destination" "Purpose"
     ux_table_row "cd-dot" "\$DOTFILES_ROOT" "Dotfiles repository root"
     ux_table_row "cd-down" "\$HOME/downloads" "Downloads folder"
     ux_table_row "cd-work" "\$HOME/workspace" "Workspace root"
+}
 
-    ux_section "Windows (WSL)"
+_dir_help_rows_windows() {
     ux_table_header "Command" "Destination" "Purpose"
     ux_table_row "cd-wdocu" "Windows Documents" "Access Windows documents"
     ux_table_row "cd-wobsidian" "Windows Obsidian" "Obsidian vault location"
@@ -361,8 +377,9 @@ dir_help() {
     ux_table_row "cd-wpicture" "Windows Pictures" "Photo library"
     ux_table_row "cd-tilnote" "Obsidian TilNote" "TilNote vault"
     ux_table_row "cd-obsidian" "Obsidian vault" "Default vault in WSL"
+}
 
-    ux_section "PARA Method"
+_dir_help_rows_para() {
     ux_table_header "Command" "Destination" "Purpose"
     ux_table_row "mkpara" "para/{archive,area,project,resource}" "Create PARA directories"
     ux_table_row "cd-para" "\$HOME/para" "PARA root"
@@ -371,10 +388,64 @@ dir_help() {
     ux_table_row "cd-vault" "\$HOME/para/area/vault" "Vault under Areas"
     ux_table_row "cd-resource" "\$HOME/para/resource" "Reference materials"
     ux_table_row "cd-archive" "\$HOME/para/archive" "Archived items"
+}
 
-    ux_section "Windows Copy Utility"
+_dir_help_rows_copy() {
     ux_table_header "Command" "Usage" "Purpose"
     ux_table_row "cp_wdown" "cp_wdown [options] <file...>" "Copy from Windows Downloads into WSL (run -h for details)"
+}
+
+_dir_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_dir_help_section_rows() {
+    case "$1" in
+        core)
+            _dir_help_rows_core
+            ;;
+        windows|wsl)
+            _dir_help_rows_windows
+            ;;
+        para)
+            _dir_help_rows_para
+            ;;
+        copy|cp)
+            _dir_help_rows_copy
+            ;;
+        *)
+            ux_error "Unknown dir-help section: $1"
+            ux_info "Try: dir-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_dir_help_full() {
+    ux_header "Directory Navigation"
+
+    _dir_help_render_section "Core Directories" _dir_help_rows_core
+    _dir_help_render_section "Windows (WSL)" _dir_help_rows_windows
+    _dir_help_render_section "PARA Method" _dir_help_rows_para
+    _dir_help_render_section "Windows Copy Utility" _dir_help_rows_copy
+}
+
+dir_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _dir_help_summary
+            ;;
+        --list|list)
+            _dir_help_list_sections
+            ;;
+        --all|all)
+            _dir_help_full
+            ;;
+        *)
+            _dir_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias dir-help='dir_help'

--- a/shell-common/functions/system_help.sh
+++ b/shell-common/functions/system_help.sh
@@ -452,36 +452,90 @@ alias dir-help='dir_help'
 
 # --- network_help (from network_help.sh) ---
 
-network_help() {
+_network_help_summary() {
+    ux_info "Usage: network-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics: check-network | quick | dns | ping | https | git | apt | pip | curl"
+    ux_bullet_sub "typical: check-network | check-network quick | check-proxy"
+    ux_bullet_sub "checks: DNS | ICMP | HTTPS | git | apt | pip"
+    ux_bullet_sub "notes: ICMP fallback | APT auto-skip | check-proxy"
+    ux_bullet_sub "details: network-help <section>  (example: network-help diagnostics)"
+}
+
+_network_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "diagnostics"
+    ux_bullet_sub "typical"
+    ux_bullet_sub "checks"
+    ux_bullet_sub "notes"
+}
+
+_network_help_rows_diagnostics() {
+    ux_bullet "check-network         Run full network diagnostic"
+    ux_bullet "check-network quick   DNS + HTTPS + git quick check"
+    ux_bullet "check-network dns     DNS resolution test"
+    ux_bullet "check-network ping    ICMP ping test"
+    ux_bullet "check-network https   HTTPS HEAD request test"
+    ux_bullet "check-network git     Git remote access test"
+    ux_bullet "check-network apt     APT repository reachability"
+    ux_bullet "check-network pip     pip repository reachability"
+    ux_bullet "check-network curl    curl GET request test"
+}
+
+_network_help_rows_typical() {
+    ux_bullet "check-network         Verify internet access end-to-end"
+    ux_bullet "check-network quick   Fast sanity check after shell startup"
+    ux_bullet "check-proxy           Diagnose proxy-specific configuration"
+}
+
+_network_help_rows_checks() {
+    ux_bullet "DNS lookup to confirm name resolution"
+    ux_bullet "ICMP ping to detect low-level reachability"
+    ux_bullet "HTTPS and curl requests to validate outbound web access"
+    ux_bullet "git, apt, and pip endpoints for real tool-level access"
+}
+
+_network_help_rows_notes() {
+    ux_info "ICMP ping may fail even when normal web traffic works"
+    ux_info "APT check is skipped automatically on non-APT systems"
+    ux_info "Use check-proxy for proxy variables and proxy.local.sh issues"
+}
+
+_network_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_network_help_section_rows() {
+    case "$1" in
+        diagnostics|diag|commands)
+            _network_help_rows_diagnostics
+            ;;
+        typical|use)
+            _network_help_rows_typical
+            ;;
+        checks|what)
+            _network_help_rows_checks
+            ;;
+        notes|important)
+            _network_help_rows_notes
+            ;;
+        *)
+            ux_error "Unknown network-help section: $1"
+            ux_info "Try: network-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_network_help_full() {
     ux_header "Network Connectivity Diagnostics"
 
     if type ux_section >/dev/null 2>&1; then
-        ux_section "Diagnostic Commands"
-        ux_bullet "check-network         Run full network diagnostic"
-        ux_bullet "check-network quick   DNS + HTTPS + git quick check"
-        ux_bullet "check-network dns     DNS resolution test"
-        ux_bullet "check-network ping    ICMP ping test"
-        ux_bullet "check-network https   HTTPS HEAD request test"
-        ux_bullet "check-network git     Git remote access test"
-        ux_bullet "check-network apt     APT repository reachability"
-        ux_bullet "check-network pip     pip repository reachability"
-        ux_bullet "check-network curl    curl GET request test"
-
-        ux_section "Typical Use"
-        ux_bullet "check-network         Verify internet access end-to-end"
-        ux_bullet "check-network quick   Fast sanity check after shell startup"
-        ux_bullet "check-proxy           Diagnose proxy-specific configuration"
-
-        ux_section "What It Checks"
-        ux_bullet "DNS lookup to confirm name resolution"
-        ux_bullet "ICMP ping to detect low-level reachability"
-        ux_bullet "HTTPS and curl requests to validate outbound web access"
-        ux_bullet "git, apt, and pip endpoints for real tool-level access"
-
-        ux_section "Important Notes"
-        ux_info "ICMP ping may fail even when normal web traffic works"
-        ux_info "APT check is skipped automatically on non-APT systems"
-        ux_info "Use check-proxy for proxy variables and proxy.local.sh issues"
+        _network_help_render_section "Diagnostic Commands" _network_help_rows_diagnostics
+        _network_help_render_section "Typical Use" _network_help_rows_typical
+        _network_help_render_section "What It Checks" _network_help_rows_checks
+        _network_help_render_section "Important Notes" _network_help_rows_notes
     else
         echo "Diagnostic Commands:"
         echo "  check-network       Run full network diagnostic"
@@ -489,6 +543,23 @@ network_help() {
         echo "  check-network ping  ICMP ping test"
         echo "  check-network https HTTPS HEAD request test"
     fi
+}
+
+network_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _network_help_summary
+            ;;
+        --list|list)
+            _network_help_list_sections
+            ;;
+        --all|all)
+            _network_help_full
+            ;;
+        *)
+            _network_help_section_rows "$1"
+            ;;
+    esac
 }
 
 network_check() {

--- a/shell-common/functions/system_help.sh
+++ b/shell-common/functions/system_help.sh
@@ -4,39 +4,117 @@
 
 # --- sys_help (from sys_help.sh) ---
 
-sys_help() {
-    ux_header "System Management Commands"
+_sys_help_summary() {
+    ux_info "Usage: sys-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "process: psgrep | psg | kill9 | psa"
+    ux_bullet_sub "network: ports | myip | localip | ping | check-network | ssh-help"
+    ux_bullet_sub "monitoring: top | meminfo | cpuinfo | diskusage"
+    ux_bullet_sub "apt: update | upgrade | remove | auto-remove"
+    ux_bullet_sub "logs: logs | error | auth"
+    ux_bullet_sub "details: sys-help <section>  (example: sys-help network)"
+}
 
-    ux_section "Process Management"
+_sys_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "process"
+    ux_bullet_sub "network"
+    ux_bullet_sub "monitoring"
+    ux_bullet_sub "apt"
+    ux_bullet_sub "logs"
+}
+
+_sys_help_rows_process() {
     ux_table_row "psgrep" "ps aux | grep <pattern>" "Find process by pattern"
     ux_table_row "psg" "ps aux | grep" "Find process"
     ux_table_row "kill9" "kill -9" "Force kill"
     ux_table_row "psa" "ps aux" "List all processes"
+}
 
-    ux_section "Network"
+_sys_help_rows_network() {
     ux_table_row "ports" "ss -tulanp" "Show open ports"
     ux_table_row "myip" "curl ipecho.net" "Public IP"
     ux_table_row "localip" "hostname -I" "Local IP"
     ux_table_row "ping" "ping -c 5" "Ping (5 times)"
     ux_table_row "check-network" "check-network" "Internet connectivity diagnostics"
     ux_table_row "ssh-help" "ssh-help" "SSH hosts and examples"
+}
 
-    ux_section "Monitoring"
+_sys_help_rows_monitoring() {
     ux_table_row "top" "htop" "Process monitor"
     ux_table_row "meminfo" "free -m" "Memory usage"
     ux_table_row "cpuinfo" "lscpu" "CPU info"
     ux_table_row "diskusage" "df -h" "Disk usage"
+}
 
-    ux_section "Package Management (APT)"
+_sys_help_rows_apt() {
     ux_table_row "update" "apt update" "Update lists"
     ux_table_row "upgrade" "apt upgrade" "Upgrade packages"
     ux_table_row "remove" "apt remove" "Remove package"
     ux_table_row "auto-remove" "apt autoremove" "Remove unused"
+}
 
-    ux_section "Log Viewing"
+_sys_help_rows_logs() {
     ux_table_row "logs" "syslog" "System logs"
     ux_table_row "error" "error.log" "Error logs"
     ux_table_row "auth" "auth.log" "Auth logs"
+}
+
+_sys_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_sys_help_section_rows() {
+    case "$1" in
+        process|proc)
+            _sys_help_rows_process
+            ;;
+        network|net)
+            _sys_help_rows_network
+            ;;
+        monitoring|monitor|mon)
+            _sys_help_rows_monitoring
+            ;;
+        apt|package|packages)
+            _sys_help_rows_apt
+            ;;
+        logs|log)
+            _sys_help_rows_logs
+            ;;
+        *)
+            ux_error "Unknown sys-help section: $1"
+            ux_info "Try: sys-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_sys_help_full() {
+    ux_header "System Management Commands"
+
+    _sys_help_render_section "Process Management" _sys_help_rows_process
+    _sys_help_render_section "Network" _sys_help_rows_network
+    _sys_help_render_section "Monitoring" _sys_help_rows_monitoring
+    _sys_help_render_section "Package Management (APT)" _sys_help_rows_apt
+    _sys_help_render_section "Log Viewing" _sys_help_rows_logs
+}
+
+sys_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _sys_help_summary
+            ;;
+        --list|list)
+            _sys_help_list_sections
+            ;;
+        --all|all)
+            _sys_help_full
+            ;;
+        *)
+            _sys_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias sys-help='sys_help'

--- a/shell-common/functions/system_help.sh
+++ b/shell-common/functions/system_help.sh
@@ -270,16 +270,74 @@ alias gpu-help='gpu_help'
 
 # --- du_help (from du_help.sh) ---
 
-du_help() {
-    ux_header "Disk Usage Helper (du aliases)"
+_du_help_summary() {
+    ux_info "Usage: du-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "commands: dus | dud | dsql | dubig"
+    ux_bullet_sub "tips: -h means human-readable (K, M, G)"
+    ux_bullet_sub "details: du-help <section>  (example: du-help commands)"
+}
 
-    ux_section "Commands"
+_du_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "tips"
+}
+
+_du_help_rows_commands() {
     ux_table_row "dus" "du -sh ." "Current dir summary"
     ux_table_row "dud" "du -sh *" "Subdir summary (sorted)"
     ux_table_row "dsql" "du .sql" "SQL dump sizes"
     ux_table_row "dubig" "du top 10" "Top 10 largest items"
+}
 
+_du_help_rows_tips() {
     ux_info "Tip: -h option means 'human-readable' (K, M, G)"
+}
+
+_du_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_du_help_section_rows() {
+    case "$1" in
+        commands|cmd)
+            _du_help_rows_commands
+            ;;
+        tips|tip)
+            _du_help_rows_tips
+            ;;
+        *)
+            ux_error "Unknown du-help section: $1"
+            ux_info "Try: du-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_du_help_full() {
+    ux_header "Disk Usage Helper (du aliases)"
+
+    _du_help_render_section "Commands" _du_help_rows_commands
+    _du_help_render_section "Tips" _du_help_rows_tips
+}
+
+du_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _du_help_summary
+            ;;
+        --list|list)
+            _du_help_list_sections
+            ;;
+        --all|all)
+            _du_help_full
+            ;;
+        *)
+            _du_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias du-help='du_help'

--- a/shell-common/functions/system_help.sh
+++ b/shell-common/functions/system_help.sh
@@ -105,7 +105,7 @@ sys_help() {
         ""|-h|--help|help)
             _sys_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _sys_help_list_sections
             ;;
         --all|all)
@@ -254,7 +254,7 @@ gpu_help() {
         ""|-h|--help|help)
             _gpu_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _gpu_help_list_sections
             ;;
         --all|all|-a)
@@ -328,7 +328,7 @@ du_help() {
         ""|-h|--help|help)
             _du_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _du_help_list_sections
             ;;
         --all|all)
@@ -436,7 +436,7 @@ dir_help() {
         ""|-h|--help|help)
             _dir_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _dir_help_list_sections
             ;;
         --all|all)
@@ -550,7 +550,7 @@ network_help() {
         ""|-h|--help|help)
             _network_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _network_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/tmux_help.sh
+++ b/shell-common/functions/tmux_help.sh
@@ -1,68 +1,149 @@
 #!/bin/sh
 # shell-common/functions/tmux_help.sh
 
-tmux_help() {
-    ux_header "tmux - Terminal Multiplexer"
+_tmux_help_summary() {
+    ux_info "Usage: tmux-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: 세션 유지 | 화면 분할 | prefix Ctrl+b"
+    ux_bullet_sub "session: tmux new | attach | ls | kill-session"
+    ux_bullet_sub "pane: % | \" | arrow | z | x | Alt+arrow"
+    ux_bullet_sub "control: d | s | \$"
+    ux_bullet_sub "window: c | n/p | 0-9 | ,"
+    ux_bullet_sub "copy: [ | Space | Enter | q | ]"
+    ux_bullet_sub "example | companion | custom | related"
+    ux_bullet_sub "details: tmux-help <section>  (example: tmux-help session)"
+}
 
-    ux_section "Core Concept"
+_tmux_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "session"
+    ux_bullet_sub "pane"
+    ux_bullet_sub "control"
+    ux_bullet_sub "window"
+    ux_bullet_sub "copy"
+    ux_bullet_sub "example"
+    ux_bullet_sub "companion"
+    ux_bullet_sub "custom"
+    ux_bullet_sub "related"
+}
+
+_tmux_help_rows_concept() {
     ux_bullet "SSH/터미널 종료 후에도 세션 유지"
     ux_bullet "화면 분할로 여러 작업 동시 수행"
     ux_bullet "모든 단축키: Ctrl+b (prefix) 누른 뒤 해당 키"
+}
 
-    ux_section "Session Commands"
+_tmux_help_rows_session() {
     ux_table_row "tmux new -s <name>" "새 세션 생성"
     ux_table_row "tmux attach -t <name>" "세션 다시 연결"
     ux_table_row "tmux ls" "세션 목록 확인"
     ux_table_row "tmux kill-session -t <name>" "세션 삭제"
+}
 
-    ux_section "Pane (Split) - Ctrl+b +"
+_tmux_help_rows_pane() {
     ux_table_row "%" "좌우 분할"
     ux_table_row "\"" "상하 분할"
     ux_table_row "arrow keys" "패인 이동"
     ux_table_row "z" "현재 패인 전체화면 토글"
     ux_table_row "x" "현재 패인 닫기"
     ux_table_row "Alt+arrow (no prefix)" "패인 크기 조절"
+}
 
-    ux_section "Session - Ctrl+b +"
+_tmux_help_rows_control() {
     ux_table_row "d" "세션에서 빠져나오기 (detach)"
     ux_table_row "s" "세션 목록 선택 이동"
     ux_table_row "\$" "현재 세션 이름 변경"
+}
 
-    ux_section "Window (Tab) - Ctrl+b +"
+_tmux_help_rows_window() {
     ux_table_row "c" "새 윈도우 생성"
     ux_table_row "n / p" "다음 / 이전 윈도우"
     ux_table_row "0-9" "해당 번호 윈도우로 이동"
     ux_table_row "," "현재 윈도우 이름 변경"
+}
 
-    ux_section "Scroll & Copy - Ctrl+b +"
+_tmux_help_rows_copy() {
     ux_table_row "[" "카피 모드 (스크롤 가능)"
     ux_table_row "Space" "선택 시작 (카피 모드 내)"
     ux_table_row "Enter" "선택 영역 복사 (카피 모드 내)"
     ux_table_row "q" "카피 모드 종료"
     ux_table_row "]" "buffer_0 붙여넣기"
+}
 
-    ux_section "Practical Example"
+_tmux_help_rows_example() {
     ux_bullet "tmux new -s dev        # 세션 시작"
     ux_bullet "Ctrl+b %               # 좌우 분할"
     ux_bullet "오른쪽에서 claude 실행"
     ux_bullet "Ctrl+b z               # 전체화면 토글"
     ux_bullet "Ctrl+b d               # detach"
     ux_bullet "tmux attach -t dev     # 나중에 다시 연결"
+}
 
-    ux_section "Companion Tools"
+_tmux_help_rows_companion() {
     ux_table_row "marmonitor" "tmux 상태바 모니터링 플러그인"
     ux_bullet "Install: ${UX_BOLD}npm install -g marmonitor${UX_RESET}"
     ux_bullet "Setup:   ${UX_BOLD}marmonitor setup tmux${UX_RESET}"
     ux_bullet "tmux 안에서 prefix+I 로 플러그인 활성화"
+}
 
-    ux_section "Custom Commands"
+_tmux_help_rows_custom() {
     ux_table_row "tmux-spawn [agent]" "3-pane AI 세션 생성"
     ux_table_row "tmux-teardown [name|all]" "세션 정리 (기본: all)"
+}
 
-    ux_section "Related Help"
+_tmux_help_rows_related() {
     ux_bullet "Cheat sheet: ${UX_BOLD}https://tmuxcheatsheet.com/${UX_RESET}"
     ux_bullet "Terminal: ${UX_BOLD}ghostty-help${UX_RESET}"
     ux_bullet "Zsh shell: ${UX_BOLD}zsh-help${UX_RESET}"
+}
+
+_tmux_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_tmux_help_section_rows() {
+    case "$1" in
+        concept)            _tmux_help_rows_concept ;;
+        session|sessions)   _tmux_help_rows_session ;;
+        pane|panes|split)   _tmux_help_rows_pane ;;
+        control)            _tmux_help_rows_control ;;
+        window|windows|tab) _tmux_help_rows_window ;;
+        copy|scroll)        _tmux_help_rows_copy ;;
+        example|examples)   _tmux_help_rows_example ;;
+        companion|tools)    _tmux_help_rows_companion ;;
+        custom|commands)    _tmux_help_rows_custom ;;
+        related)            _tmux_help_rows_related ;;
+        *)
+            ux_error "Unknown tmux-help section: $1"
+            ux_info "Try: tmux-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_tmux_help_full() {
+    ux_header "tmux - Terminal Multiplexer"
+    _tmux_help_render_section "Core Concept" _tmux_help_rows_concept
+    _tmux_help_render_section "Session Commands" _tmux_help_rows_session
+    _tmux_help_render_section "Pane (Split) - Ctrl+b +" _tmux_help_rows_pane
+    _tmux_help_render_section "Session - Ctrl+b +" _tmux_help_rows_control
+    _tmux_help_render_section "Window (Tab) - Ctrl+b +" _tmux_help_rows_window
+    _tmux_help_render_section "Scroll & Copy - Ctrl+b +" _tmux_help_rows_copy
+    _tmux_help_render_section "Practical Example" _tmux_help_rows_example
+    _tmux_help_render_section "Companion Tools" _tmux_help_rows_companion
+    _tmux_help_render_section "Custom Commands" _tmux_help_rows_custom
+    _tmux_help_render_section "Related Help" _tmux_help_rows_related
+}
+
+tmux_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _tmux_help_summary ;;
+        --list|list)        _tmux_help_list_sections ;;
+        --all|all)          _tmux_help_full ;;
+        *)                  _tmux_help_section_rows "$1" ;;
+    esac
 }
 
 alias tmux-help='tmux_help'

--- a/shell-common/functions/tmux_help.sh
+++ b/shell-common/functions/tmux_help.sh
@@ -140,7 +140,7 @@ _tmux_help_full() {
 tmux_help() {
     case "${1:-}" in
         ""|-h|--help|help) _tmux_help_summary ;;
-        --list|list)        _tmux_help_list_sections ;;
+        --list|list|section|sections)        _tmux_help_list_sections ;;
         --all|all)          _tmux_help_full ;;
         *)                  _tmux_help_section_rows "$1" ;;
     esac

--- a/shell-common/functions/ux_help.sh
+++ b/shell-common/functions/ux_help.sh
@@ -9,18 +9,40 @@ ux_demo() {
 alias ux-demo='ux_demo'
 
 # =============================================================================
-# UX Help Function
+# UX Help Function (SSOT pattern)
 # =============================================================================
 
-ux_help() {
-    # UX library is already loaded globally in main.bash/main.zsh
-    ux_header "UX Library - Styling Guide"
+_ux_help_summary() {
+    ux_info "Usage: ux-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "colors: semantic color variables"
+    ux_bullet_sub "output: ux_header | ux_section | ux_success | ux_error"
+    ux_bullet_sub "progress: ux_spinner | ux_with_spinner"
+    ux_bullet_sub "interactive: ux_confirm | ux_input"
+    ux_bullet_sub "tables: ux_table_header | ux_table_row | ux_bullet"
+    ux_bullet_sub "utilities: ux_divider | ux_usage | ux_require"
+    ux_bullet_sub "example: usage example template"
+    ux_bullet_sub "quickstart: load library and use"
+    ux_bullet_sub "demo: ux-demo"
+    ux_bullet_sub "docs: library and demo locations"
+    ux_bullet_sub "details: ux-help <section>  (example: ux-help colors)"
+}
 
-    ux_info "The UX library provides consistent styling across all dotfiles functions"
+_ux_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "colors"
+    ux_bullet_sub "output"
+    ux_bullet_sub "progress"
+    ux_bullet_sub "interactive"
+    ux_bullet_sub "tables"
+    ux_bullet_sub "utilities"
+    ux_bullet_sub "example"
+    ux_bullet_sub "quickstart"
+    ux_bullet_sub "demo"
+    ux_bullet_sub "docs"
+}
 
-
-    # --- Colors Section ---
-    ux_section "Semantic Colors"
+_ux_help_rows_colors() {
     ux_table_header "Variable" "Purpose" "Color"
     ux_table_row "UX_PRIMARY" "Headers, titles, commands" "Blue"
     ux_table_row "UX_SUCCESS" "Success states, valid input" "Green"
@@ -28,53 +50,47 @@ ux_help() {
     ux_table_row "UX_ERROR" "Errors, failed operations" "Red"
     ux_table_row "UX_INFO" "Info messages, tips" "Cyan"
     ux_table_row "UX_MUTED" "Secondary info, hints" "Gray"
+}
 
-
-    # --- Output Functions Section ---
-    ux_section "Output Functions"
+_ux_help_rows_output() {
     ux_table_header "Function" "Purpose"
     ux_table_row "ux_header" "Display prominent header with box"
     ux_table_row "ux_section" "Display section title with underline"
-    ux_table_row "ux_success" "Success message with ✅"
-    ux_table_row "ux_error" "Error message with ❌ (to stderr)"
-    ux_table_row "ux_warning" "Warning message with ⚠️"
-    ux_table_row "ux_info" "Info message with ℹ️"
+    ux_table_row "ux_success" "Success message with check"
+    ux_table_row "ux_error" "Error message (to stderr)"
+    ux_table_row "ux_warning" "Warning message"
+    ux_table_row "ux_info" "Info message"
     ux_table_row "ux_step" "Step indicator with number"
+}
 
-
-    # --- Progress Indicators Section ---
-    ux_section "Progress Indicators"
+_ux_help_rows_progress() {
     ux_table_header "Function" "Usage"
     ux_table_row "ux_spinner" "ux_spinner <pid> \"message\""
     ux_table_row "ux_with_spinner" "ux_with_spinner \"msg\" command args"
+}
 
-
-    # --- Interactive Functions Section ---
-    ux_section "Interactive Functions"
+_ux_help_rows_interactive() {
     ux_table_header "Function" "Usage"
     ux_table_row "ux_confirm" "if ux_confirm \"prompt\" \"y\"; then ..."
     ux_table_row "ux_input" "result=\$(ux_input \"prompt\" \"pattern\")"
+}
 
-
-    # --- Table/List Functions Section ---
-    ux_section "Tables and Lists"
+_ux_help_rows_tables() {
     ux_table_header "Function" "Usage"
     ux_table_row "ux_table_header" "ux_table_header \"Col1\" \"Col2\" [\"Col3\"]"
     ux_table_row "ux_table_row" "ux_table_row \"val1\" \"val2\" [\"val3\"]"
     ux_table_row "ux_bullet" "ux_bullet \"Item description\""
     ux_table_row "ux_numbered" "ux_numbered 1 \"First item\""
+}
 
-
-    # --- Utilities Section ---
-    ux_section "Utility Functions"
+_ux_help_rows_utilities() {
     ux_table_header "Function" "Purpose"
     ux_table_row "ux_divider" "Print horizontal line (60 chars)"
     ux_table_row "ux_usage" "Display usage help template"
     ux_table_row "ux_require" "Check if command exists"
+}
 
-
-    # --- Usage Example Section ---
-    ux_section "Example Usage"
+_ux_help_rows_example() {
     cat <<'EOF'
   #!/bin/bash
 
@@ -107,33 +123,104 @@ ux_help() {
       fi
   }
 EOF
+}
 
-
-    # --- Quick Reference Section ---
-    ux_section "Quick Start"
+_ux_help_rows_quickstart() {
     ux_numbered 1 "Load library: ${UX_BOLD}source \"\${SHELL_COMMON}/tools/ux_lib/ux_lib.sh\"${UX_RESET}"
     ux_numbered 2 "Use semantic colors: ${UX_BOLD}\${UX_PRIMARY}${UX_RESET}, ${UX_BOLD}\${UX_SUCCESS}${UX_RESET}, etc."
     ux_numbered 3 "Use helper functions: ${UX_BOLD}ux_header${UX_RESET}, ${UX_BOLD}ux_success${UX_RESET}, etc."
     ux_numbered 4 "Always end with ${UX_BOLD}\${UX_RESET}${UX_RESET} to reset colors"
+}
 
-
-    # --- Demo Section ---
-    ux_section "Try It Out"
+_ux_help_rows_demo() {
     ux_info "Run the interactive demo to see all features in action:"
     ux_bullet "${UX_SUCCESS}ux-demo${UX_RESET}  or  ${UX_SUCCESS}bash \${SHELL_COMMON}/tools/custom/demo_ux.sh${UX_RESET}"
+}
 
-
-    # --- Documentation Section ---
-    ux_section "Documentation"
+_ux_help_rows_docs() {
     ux_bullet "Library file: ${UX_BOLD}shell-common/tools/ux_lib/ux_lib.sh${UX_RESET}"
     ux_bullet "Demo script: ${UX_BOLD}shell-common/tools/custom/demo_ux.sh${UX_RESET}"
     ux_bullet "Example migrations: ${UX_BOLD}my_help()${UX_RESET}, ${UX_BOLD}dcl()${UX_RESET}, ${UX_BOLD}dbash()${UX_RESET}"
+}
 
+_ux_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
 
+_ux_help_section_rows() {
+    case "$1" in
+        colors|color)
+            _ux_help_rows_colors
+            ;;
+        output|out)
+            _ux_help_rows_output
+            ;;
+        progress|spinner)
+            _ux_help_rows_progress
+            ;;
+        interactive|prompt)
+            _ux_help_rows_interactive
+            ;;
+        tables|table|lists)
+            _ux_help_rows_tables
+            ;;
+        utilities|utility|util)
+            _ux_help_rows_utilities
+            ;;
+        example|examples)
+            _ux_help_rows_example
+            ;;
+        quickstart|quick|start)
+            _ux_help_rows_quickstart
+            ;;
+        demo|try)
+            _ux_help_rows_demo
+            ;;
+        docs|doc|documentation)
+            _ux_help_rows_docs
+            ;;
+        *)
+            ux_error "Unknown ux-help section: $1"
+            ux_info "Try: ux-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_ux_help_full() {
+    ux_header "UX Library - Styling Guide"
+    ux_info "The UX library provides consistent styling across all dotfiles functions"
+    _ux_help_render_section "Semantic Colors" _ux_help_rows_colors
+    _ux_help_render_section "Output Functions" _ux_help_rows_output
+    _ux_help_render_section "Progress Indicators" _ux_help_rows_progress
+    _ux_help_render_section "Interactive Functions" _ux_help_rows_interactive
+    _ux_help_render_section "Tables and Lists" _ux_help_rows_tables
+    _ux_help_render_section "Utility Functions" _ux_help_rows_utilities
+    _ux_help_render_section "Example Usage" _ux_help_rows_example
+    _ux_help_render_section "Quick Start" _ux_help_rows_quickstart
+    _ux_help_render_section "Try It Out" _ux_help_rows_demo
+    _ux_help_render_section "Documentation" _ux_help_rows_docs
     ux_divider
-
     ux_info "For more help topics, run ${UX_BOLD}my-help${UX_RESET}"
+}
 
+ux_help() {
+    # UX library is already loaded globally in main.bash/main.zsh
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _ux_help_summary
+            ;;
+        --list|list)
+            _ux_help_list_sections
+            ;;
+        --all|all)
+            _ux_help_full
+            ;;
+        *)
+            _ux_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # Alias for ux-help format (using dash instead of underscore)

--- a/shell-common/functions/ux_help.sh
+++ b/shell-common/functions/ux_help.sh
@@ -211,7 +211,7 @@ ux_help() {
         ""|-h|--help|help)
             _ux_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _ux_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/work.sh
+++ b/shell-common/functions/work.sh
@@ -174,7 +174,7 @@ work_help() {
         ""|-h|--help|help)
             _work_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _work_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/work.sh
+++ b/shell-common/functions/work.sh
@@ -11,66 +11,77 @@
 # This module provides only the help function for the work management system
 # ═════════════════════════════════════════════════════════════════════════════
 
-work_help() {
-    # Load ux_lib for consistent output
+_work_help_load_ux() {
     if ! type ux_header >/dev/null 2>&1; then
         if [ -n "$SHELL_COMMON" ] && [ -f "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" ]; then
             source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" 2>/dev/null
         fi
     fi
+}
 
-    ux_header "Work Management Commands"
+_work_help_summary() {
+    ux_info "Usage: work-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "overview: integrated tracking & docs workflow"
+    ux_bullet_sub "commands: work-log | make-jira | make-confluence"
+    ux_bullet_sub "workflow: daily & weekly cycles"
+    ux_bullet_sub "dataflow: input -> processing -> output"
+    ux_bullet_sub "files: locations of logs, reports, tools"
+    ux_bullet_sub "integration: git tracking & multi-PC sync"
+    ux_bullet_sub "more: per-command help references"
+    ux_bullet_sub "details: work-help <section>  (example: work-help commands)"
+}
 
-    ux_section "Overview"
+_work_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "overview"
+    ux_bullet_sub "commands"
+    ux_bullet_sub "workflow"
+    ux_bullet_sub "dataflow"
+    ux_bullet_sub "files"
+    ux_bullet_sub "integration"
+    ux_bullet_sub "more"
+}
+
+_work_help_rows_overview() {
     ux_bullet "Integrated workflow for work tracking and documentation"
     ux_bullet "Combines: work-log (manual tracking) + make-jira (reports) + make-confluence (guides)"
     ux_bullet "All data git-tracked in dotfiles and playbook"
+}
 
-    ux_section "Commands"
-
+_work_help_rows_commands() {
     ux_step "1. Record Work (Manual Log Entry)" "work-log"
-    echo ""
     ux_bullet "Add non-development work to weekly log"
     echo "  ${UX_MUTED}work-log add SWINNOTEAM-903 -t coordination -c Communication -T 2.5h${UX_RESET}"
     echo "  ${UX_MUTED}work-log list --today${UX_RESET}"
-    echo ""
 
     ux_step "2. Generate Weekly Report" "make-jira"
-    echo ""
     ux_bullet "Create Jira-formatted weekly report from work_log.txt"
     echo "  ${UX_MUTED}make-jira${UX_RESET}                    # Current week"
     echo "  ${UX_MUTED}make-jira --week 2026-W05${UX_RESET}    # Specific week"
     echo "  ${UX_MUTED}make-jira SWINNOTEAM-906${UX_RESET}     # Filter by key"
-    echo ""
     ux_bullet "Output: playbook/docs/jira-records/YYYY-W##-report.md"
-    echo ""
 
     ux_step "3. Transform Docs to Confluence Guides" "make-confluence"
-    echo ""
     ux_bullet "Convert markdown technical docs to Confluence format"
     echo "  ${UX_MUTED}make-confluence docs/technic/file.md${UX_RESET}                        # Auto-detect category"
     echo "  ${UX_MUTED}make-confluence docs/analysis/file.md --category testing${UX_RESET}  # Explicit category"
-    echo ""
     ux_bullet "Output: playbook/docs/confluence-guides/{category}/YYYY-MM-DD-{title}.md"
-    echo ""
+}
 
-    ux_section "Workflow Examples"
-
+_work_help_rows_workflow() {
     echo "${UX_HEADER}Daily Workflow:${UX_RESET}"
     echo "  1. Work happens → git commits (auto-tracked)"
     echo "  2. Manual non-dev work → work-log add"
     echo "  3. Friday: make-jira → Weekly Jira report"
     echo "  4. As needed: make-confluence → Technical guides"
-    echo ""
-
     echo "${UX_HEADER}Weekly Cycle:${UX_RESET}"
     echo "  Mon-Fri: Regular work + work-log entries"
     echo "  Friday:  make-jira 2026-W05 → Jira report"
     echo "  Anytime: make-confluence → Knowledge base"
-    echo ""
+}
 
-    ux_section "Data Flow"
-
+_work_help_rows_dataflow() {
     cat <<'EOF'
 Work Input
   ├─ Git commits (post-commit hook → work_log.txt)
@@ -86,30 +97,96 @@ Output
   ├─ playbook/docs/confluence-guides/ (technical guides)
   └─ All git-tracked in dotfiles (multi-PC sync via symlink)
 EOF
+}
 
-    ux_section "File Locations"
-
+_work_help_rows_files() {
     ux_bullet "work_log.txt: ~/work_log.txt (symlink → ~/para/archive/playbook/logs/work_log.txt)"
     ux_bullet "Jira reports: ~/para/archive/playbook/docs/jira-records/"
     ux_bullet "Confluence guides: ~/para/archive/playbook/docs/confluence-guides/"
     ux_bullet "CLI tools: ~/dotfiles/shell-common/tools/custom/make_{jira,confluence}.sh"
-    echo ""
+}
 
-    ux_section "Integration Points"
-
+_work_help_rows_integration() {
     ux_info "All commands are git-tracked:"
     echo "  ${UX_SUCCESS}dotfiles${UX_RESET}:                CLI tools + alias definitions"
     echo "  ${UX_SUCCESS}playbook${UX_RESET}:           Reports and guides"
     echo "  ${UX_SUCCESS}Multi-PC sync${UX_RESET}:           Symlink abstraction (automatic)"
-    echo ""
+}
 
-    ux_divider
+_work_help_rows_more() {
     ux_info "For detailed help on individual commands:"
     echo "  ${UX_SUCCESS}work-log help${UX_RESET}              # work-log manual"
     echo "  ${UX_SUCCESS}make-jira --help${UX_RESET}           # make-jira manual (if implemented)"
     echo "  ${UX_SUCCESS}make-confluence --help${UX_RESET}     # make-confluence manual (if implemented)"
-    echo ""
 }
+
+_work_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_work_help_section_rows() {
+    case "$1" in
+        overview|about)
+            _work_help_rows_overview
+            ;;
+        commands|cmds|cmd)
+            _work_help_rows_commands
+            ;;
+        workflow|examples|flow)
+            _work_help_rows_workflow
+            ;;
+        dataflow|data|pipeline)
+            _work_help_rows_dataflow
+            ;;
+        files|locations|paths)
+            _work_help_rows_files
+            ;;
+        integration|integrations|git)
+            _work_help_rows_integration
+            ;;
+        more|details|help-refs)
+            _work_help_rows_more
+            ;;
+        *)
+            ux_error "Unknown work-help section: $1"
+            ux_info "Try: work-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_work_help_full() {
+    ux_header "Work Management Commands"
+    _work_help_render_section "Overview" _work_help_rows_overview
+    _work_help_render_section "Commands" _work_help_rows_commands
+    _work_help_render_section "Workflow Examples" _work_help_rows_workflow
+    _work_help_render_section "Data Flow" _work_help_rows_dataflow
+    _work_help_render_section "File Locations" _work_help_rows_files
+    _work_help_render_section "Integration Points" _work_help_rows_integration
+    ux_divider
+    _work_help_rows_more
+}
+
+work_help() {
+    _work_help_load_ux
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _work_help_summary
+            ;;
+        --list|list)
+            _work_help_list_sections
+            ;;
+        --all|all)
+            _work_help_full
+            ;;
+        *)
+            _work_help_section_rows "$1"
+            ;;
+    esac
+}
+
+alias work-help='work_help'
 
 # ═══════════════════════════════════════════════════════════════════════════
 # NOTE: This script only defines aliases and functions

--- a/shell-common/functions/work_log_help.sh
+++ b/shell-common/functions/work_log_help.sh
@@ -160,7 +160,7 @@ work_log_help() {
         ""|-h|--help|help)
             _work_log_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _work_log_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/work_log_help.sh
+++ b/shell-common/functions/work_log_help.sh
@@ -17,65 +17,162 @@ if ! type ux_header >/dev/null 2>&1; then
     fi
 fi
 
-# Main help function
-work_log_help() {
-    ux_header "work-log Command"
+# SSOT helpers for work-log-help
+_work_log_help_summary() {
+    ux_info "Usage: work-log-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "overview: manual work log for non-dev work"
+    ux_bullet_sub "usage: work-log add | list | help"
+    ux_bullet_sub "add: interactive & argument modes"
+    ux_bullet_sub "list: list options & filters"
+    ux_bullet_sub "format: output entry format"
+    ux_bullet_sub "types: coordination | assessment | approval | meeting"
+    ux_bullet_sub "categories: Testing | Infrastructure | Documentation | ..."
+    ux_bullet_sub "tasks: common task templates"
+    ux_bullet_sub "details: work-log-help <section>"
+}
 
-    ux_section "Overview"
+_work_log_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "overview"
+    ux_bullet_sub "usage"
+    ux_bullet_sub "add"
+    ux_bullet_sub "list"
+    ux_bullet_sub "format"
+    ux_bullet_sub "types"
+    ux_bullet_sub "categories"
+    ux_bullet_sub "tasks"
+}
+
+_work_log_help_rows_overview() {
     ux_bullet "Manual work log recording tool for non-development work"
     ux_bullet "Companion to post-commit hook for development work"
     ux_bullet "All entries are appended to ~/work_log.txt"
+}
 
-    ux_section "Usage"
+_work_log_help_rows_usage() {
     ux_bullet "work-log add [JIRA-KEY] [OPTIONS]  - Add a work log entry"
     ux_bullet "work-log list [OPTIONS]            - List recent entries"
     ux_bullet "work-log help                      - Show this help"
+}
 
-    ux_section "Add Command - Interactive Mode"
+_work_log_help_rows_add() {
+    ux_info "Interactive Mode:"
     ux_numbered 1 "work-log add"
     ux_bullet "System will prompt for Jira key, type, category, and time"
-
-    ux_section "Add Command - Argument Mode"
+    ux_info "Argument Mode:"
     ux_numbered 1 "work-log add JIRA-KEY --type TYPE --category CATEGORY --time TIME"
-
     ux_info "Short options:"
     ux_bullet "-t, --type TYPE          (coordination|assessment|approval|meeting)"
     ux_bullet "-c, --category CATEGORY  (Testing|Infrastructure|Documentation|Communication|Training|Other)"
     ux_bullet "-T, --time TIME          (numeric: 2.5 or 2.5h)"
-
-    echo ""
     ux_step "Example" "Coordination meeting on testing strategy"
     echo "  ${UX_SUCCESS}work-log add SWINNOTEAM-903${UX_RESET} ${UX_MUTED}-t coordination${UX_RESET} ${UX_MUTED}-c Communication${UX_RESET} ${UX_MUTED}-T 2.5h${UX_RESET}"
+}
 
-    ux_section "List Command"
+_work_log_help_rows_list() {
     ux_numbered 1 "work-log list              - Show last 10 entries"
     ux_numbered 2 "work-log list --count 20  - Show last 20 entries"
     ux_numbered 3 "work-log list --today     - Show today's entries"
+}
 
-    ux_section "Output Format"
+_work_log_help_rows_format() {
     ux_bullet "[YYYY-MM-DD HH:MM:SS] [JIRA-KEY] | type | category | time | manual"
     ux_bullet "└─ Category: CategoryName"
+}
 
-    ux_section "Work Types"
+_work_log_help_rows_types() {
     ux_bullet "coordination  - Team coordination, meetings, planning"
     ux_bullet "assessment    - Code/design reviews, evaluations"
     ux_bullet "approval      - Approval requests, sign-offs"
     ux_bullet "meeting       - Official meetings, presentations"
+}
 
-    ux_section "Categories"
+_work_log_help_rows_categories() {
     ux_bullet "Testing, Infrastructure, Documentation, Performance, Security"
     ux_bullet "Communication, Coordination, Training, Other"
+}
 
-    ux_section "Common Tasks"
+_work_log_help_rows_tasks() {
     ux_bullet "Daily standup:  work-log add [PROJ-XXX] -t meeting -c Communication -T 0.5h"
     ux_bullet "Code review:    work-log add [PROJ-XXX] -t assessment -c Communication -T 1.5h"
     ux_bullet "Team planning:  work-log add [ADMIN-001] -t coordination -c Coordination -T 2h"
-
     ux_divider
     ux_info "All entries stored in: ${UX_SUCCESS}${HOME}/work_log.txt${UX_RESET} (symlink → dotfiles)"
     ux_info "Git tracking: Automatically versioned in dotfiles/shell-common/data/"
     ux_info "Use these entries for weekly reports and time tracking"
 }
+
+_work_log_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_work_log_help_section_rows() {
+    case "$1" in
+        overview|about)
+            _work_log_help_rows_overview
+            ;;
+        usage|use)
+            _work_log_help_rows_usage
+            ;;
+        add)
+            _work_log_help_rows_add
+            ;;
+        list|ls)
+            _work_log_help_rows_list
+            ;;
+        format|output)
+            _work_log_help_rows_format
+            ;;
+        types|type)
+            _work_log_help_rows_types
+            ;;
+        categories|category|cats)
+            _work_log_help_rows_categories
+            ;;
+        tasks|examples|common)
+            _work_log_help_rows_tasks
+            ;;
+        *)
+            ux_error "Unknown work-log-help section: $1"
+            ux_info "Try: work-log-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_work_log_help_full() {
+    ux_header "work-log Command"
+    _work_log_help_render_section "Overview" _work_log_help_rows_overview
+    _work_log_help_render_section "Usage" _work_log_help_rows_usage
+    _work_log_help_render_section "Add Command" _work_log_help_rows_add
+    _work_log_help_render_section "List Command" _work_log_help_rows_list
+    _work_log_help_render_section "Output Format" _work_log_help_rows_format
+    _work_log_help_render_section "Work Types" _work_log_help_rows_types
+    _work_log_help_render_section "Categories" _work_log_help_rows_categories
+    _work_log_help_render_section "Common Tasks" _work_log_help_rows_tasks
+}
+
+# Main help function
+work_log_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _work_log_help_summary
+            ;;
+        --list|list)
+            _work_log_help_list_sections
+            ;;
+        --all|all)
+            _work_log_help_full
+            ;;
+        *)
+            _work_log_help_section_rows "$1"
+            ;;
+    esac
+}
+
+alias work-log-help='work_log_help'
 
 # NOTE: This script defines the work_log_help function only.
 # It should NEVER auto-execute when sourced.

--- a/shell-common/functions/zsh_autosuggestions.sh
+++ b/shell-common/functions/zsh_autosuggestions.sh
@@ -163,7 +163,7 @@ zsh_autosuggestions_help() {
         ""|-h|--help|help)
             _zsh_autosuggestions_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _zsh_autosuggestions_help_list_sections
             ;;
         --all|all)

--- a/shell-common/functions/zsh_autosuggestions.sh
+++ b/shell-common/functions/zsh_autosuggestions.sh
@@ -18,73 +18,161 @@ fi
 # zsh-autosuggestions Help and Documentation
 # ═══════════════════════════════════════════════════════════════
 
-# Display zsh-autosuggestions help and usage
-zsh_autosuggestions_help() {
-    ux_header "zsh-autosuggestions - Command History Suggestions"
+# SSOT helpers for zsh-autosuggestions-help
+_zsh_autosuggestions_help_summary() {
+    ux_info "Usage: zsh-autosuggestions-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "about: what is zsh-autosuggestions"
+    ux_bullet_sub "keys: Tab | Ctrl+Right | Ctrl+F | Ctrl+A"
+    ux_bullet_sub "how: how the suggestions work"
+    ux_bullet_sub "example: example usage"
+    ux_bullet_sub "env: ZSH_AUTOSUGGEST_* variables"
+    ux_bullet_sub "strategies: history | completion | match_prev_cmd"
+    ux_bullet_sub "customize: ~/.zshrc snippets"
+    ux_bullet_sub "status: installation status"
+    ux_bullet_sub "details: zsh-autosuggestions-help <section>"
+}
 
-    ux_section "What is zsh-autosuggestions?"
+_zsh_autosuggestions_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "about"
+    ux_bullet_sub "keys"
+    ux_bullet_sub "how"
+    ux_bullet_sub "example"
+    ux_bullet_sub "env"
+    ux_bullet_sub "strategies"
+    ux_bullet_sub "customize"
+    ux_bullet_sub "status"
+}
+
+_zsh_autosuggestions_help_rows_about() {
     ux_info "Auto-suggests commands as you type, based on your history."
     ux_info "Press Tab or Ctrl+Right to accept the suggestion."
-    echo ""
+}
 
-    ux_section "Key Bindings"
+_zsh_autosuggestions_help_rows_keys() {
     ux_table_header "Key" "Action"
     ux_table_row "Tab / Ctrl+Right" "Accept suggestion"
     ux_table_row "Ctrl+F" "Accept next word of suggestion"
     ux_table_row "Ctrl+A" "Accept entire suggestion"
     ux_table_row "Up/Down Arrow" "Navigate history (overrides suggestions)"
-    echo ""
+}
 
-    ux_section "How It Works"
+_zsh_autosuggestions_help_rows_how() {
     ux_bullet "As you type, suggestions appear in gray text"
     ux_bullet "Suggestions are based on command history"
     ux_bullet "Press Tab (or configured key) to accept"
     ux_bullet "Press Esc or start typing to dismiss"
-    echo ""
+}
 
-    ux_section "Example Usage"
+_zsh_autosuggestions_help_rows_example() {
     ux_info "Type 'work' and zsh will suggest:"
     ux_bullet "work-log list help"
     ux_bullet "work-log add SWINNOTEAM-906 -t coordination..."
     ux_bullet "work-help"
     ux_info "Press Tab to accept any suggestion"
-    echo ""
+}
 
-    ux_section "Environment Variables"
+_zsh_autosuggestions_help_rows_env() {
     ux_table_header "Variable" "Description" "Default"
     ux_table_row "ZSH_AUTOSUGGEST_STRATEGY" "Suggestion matching strategy" "history"
     ux_table_row "ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" "Max command length to suggest" "unbounded"
     ux_table_row "ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE" "Suggestion text color" "fg=8"
-    echo ""
+}
 
-    ux_section "Strategies"
+_zsh_autosuggestions_help_rows_strategies() {
     ux_bullet "history - Suggest from command history"
     ux_bullet "completion - Suggest from completion"
     ux_bullet "match_prev_cmd - Suggest matching previous command"
-    echo ""
+}
 
-    ux_section "Customization Example"
+_zsh_autosuggestions_help_rows_customize() {
     ux_info "Add to ~/.zshrc (before sourcing zsh-autosuggestions):"
-    echo ""
     echo "  # Accept suggestion with Tab key"
     echo "  bindkey '\\t' autosuggest-accept"
-    echo ""
     echo "  # Change suggestion highlight color"
     echo "  export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=10'"
-    echo ""
     echo "  # Use history strategy only"
     echo "  export ZSH_AUTOSUGGEST_STRATEGY=(history)"
-    echo ""
+}
 
-    ux_section "Installation Status"
+_zsh_autosuggestions_help_rows_status() {
     if [ -d "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions" ]; then
-        ux_success "✓ zsh-autosuggestions is installed"
+        ux_success "zsh-autosuggestions is installed"
         echo "  Location: ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions"
     else
-        ux_warning "✗ zsh-autosuggestions is not installed"
+        ux_warning "zsh-autosuggestions is not installed"
         echo "  Run: install-zsh-autosuggestions"
     fi
-    echo ""
+}
+
+_zsh_autosuggestions_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_zsh_autosuggestions_help_section_rows() {
+    case "$1" in
+        about|what)
+            _zsh_autosuggestions_help_rows_about
+            ;;
+        keys|key|bindings|binding)
+            _zsh_autosuggestions_help_rows_keys
+            ;;
+        how|how-it-works)
+            _zsh_autosuggestions_help_rows_how
+            ;;
+        example|examples)
+            _zsh_autosuggestions_help_rows_example
+            ;;
+        env|environment|vars)
+            _zsh_autosuggestions_help_rows_env
+            ;;
+        strategies|strategy)
+            _zsh_autosuggestions_help_rows_strategies
+            ;;
+        customize|custom|config)
+            _zsh_autosuggestions_help_rows_customize
+            ;;
+        status|install)
+            _zsh_autosuggestions_help_rows_status
+            ;;
+        *)
+            ux_error "Unknown zsh-autosuggestions-help section: $1"
+            ux_info "Try: zsh-autosuggestions-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_zsh_autosuggestions_help_full() {
+    ux_header "zsh-autosuggestions - Command History Suggestions"
+    _zsh_autosuggestions_help_render_section "What is zsh-autosuggestions?" _zsh_autosuggestions_help_rows_about
+    _zsh_autosuggestions_help_render_section "Key Bindings" _zsh_autosuggestions_help_rows_keys
+    _zsh_autosuggestions_help_render_section "How It Works" _zsh_autosuggestions_help_rows_how
+    _zsh_autosuggestions_help_render_section "Example Usage" _zsh_autosuggestions_help_rows_example
+    _zsh_autosuggestions_help_render_section "Environment Variables" _zsh_autosuggestions_help_rows_env
+    _zsh_autosuggestions_help_render_section "Strategies" _zsh_autosuggestions_help_rows_strategies
+    _zsh_autosuggestions_help_render_section "Customization Example" _zsh_autosuggestions_help_rows_customize
+    _zsh_autosuggestions_help_render_section "Installation Status" _zsh_autosuggestions_help_rows_status
+}
+
+# Display zsh-autosuggestions help and usage
+zsh_autosuggestions_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _zsh_autosuggestions_help_summary
+            ;;
+        --list|list)
+            _zsh_autosuggestions_help_list_sections
+            ;;
+        --all|all)
+            _zsh_autosuggestions_help_full
+            ;;
+        *)
+            _zsh_autosuggestions_help_section_rows "$1"
+            ;;
+    esac
 }
 
 # ═══════════════════════════════════════════════════════════════

--- a/shell-common/functions/zsh_help.sh
+++ b/shell-common/functions/zsh_help.sh
@@ -181,7 +181,7 @@ zsh_help() {
         ""|-h|--help|help)
             _zsh_help_summary
             ;;
-        --list|list)
+        --list|list|section|sections)
             _zsh_help_list_sections
             ;;
         --all|all|-a)

--- a/shell-common/functions/zsh_help.sh
+++ b/shell-common/functions/zsh_help.sh
@@ -1,61 +1,106 @@
 #!/bin/sh
 # shell-common/functions/zsh_help.sh
 
-_zsh_help_full() {
-    ux_header "Zsh Management Commands (Complete)"
+_zsh_help_summary() {
+    ux_info "Usage: zsh-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "switch: zsh-switch | bash-switch | install-zsh"
+    ux_bullet_sub "config: zsh-edit | zsh-reload | zsh-snippet"
+    ux_bullet_sub "theme: zsh-themes | zsh-theme-current | zsh-theme"
+    ux_bullet_sub "plugins: zsh-plugins | zsh-update"
+    ux_bullet_sub "packages: install-p10k | install-fzf | install-fasd"
+    ux_bullet_sub "themes-list: robbyrussell | powerlevel10k | agnoster"
+    ux_bullet_sub "plugins-list: git | autosuggestions | syntax-highlighting"
+    ux_bullet_sub "coexist: bash & zsh coexistence tips"
+    ux_bullet_sub "tips: configuration & snippet tips"
+    ux_bullet_sub "troubleshoot: zsh-fix-vscode | p10k issues"
+    ux_bullet_sub "status: zsh-version | zsh-info"
+    ux_bullet_sub "details: zsh-help <section>  (example: zsh-help theme)"
+}
 
-    ux_section "Shell Switching"
-    ux_table_row "zsh-switch" "Switch to zsh shell"
+_zsh_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "switch"
+    ux_bullet_sub "config"
+    ux_bullet_sub "theme"
+    ux_bullet_sub "plugins"
+    ux_bullet_sub "packages"
+    ux_bullet_sub "themes-list"
+    ux_bullet_sub "plugins-list"
+    ux_bullet_sub "coexist"
+    ux_bullet_sub "tips"
+    ux_bullet_sub "troubleshoot"
+    ux_bullet_sub "status"
+}
+
+_zsh_help_rows_switch() {
+    ux_table_row "zsh-switch" "Switch to zsh"
     ux_table_row "bash-switch" "Switch back to bash"
+    ux_table_row "install-zsh" "Install zsh (if not installed)"
+}
 
-    ux_section "Version & Info"
-    ux_table_row "zsh-version" "Get zsh version"
-    ux_table_row "zsh-info" "System and zsh info"
+_zsh_help_rows_config() {
+    ux_table_row "zsh-edit" "Edit \$HOME/.zshrc"
+    ux_table_row "zsh-reload" "Reload zsh config"
+    ux_table_row "zsh-snippet <name>" "Create config snippet"
+    ux_table_row "zsh-snippets" "List all snippets"
+    ux_table_row "zsh-config" "View current zsh config"
+    ux_table_row "zsh-edit-quick" "Quick edit with nano"
+}
 
-    ux_section "Theme Management"
+_zsh_help_rows_theme() {
     ux_table_row "zsh-themes" "List all available themes"
     ux_table_row "zsh-theme-current" "Show current theme"
     ux_table_row "zsh-theme <name>" "Change zsh theme"
+}
 
-    ux_section "Plugin Management"
+_zsh_help_rows_plugins() {
     ux_table_row "zsh-plugins" "List installed plugins"
     ux_table_row "zsh-update" "Update oh-my-zsh framework"
+}
 
-    ux_section "Configuration Management"
-    ux_table_row "zsh-edit" "Edit $HOME/.zshrc in editor"
-    ux_table_row "zsh-reload" "Reload zsh config"
-    ux_table_row "zsh-snippet <name>" "Create/edit config snippet"
-    ux_table_row "zsh-snippets" "List all snippets"
+_zsh_help_rows_packages() {
+    ux_table_row "install-p10k" "Install powerlevel10k theme"
+    ux_table_row "p10k-help" "VSCode terminal font setup guide"
+    ux_table_row "p10k configure" "Configure powerlevel10k"
+    ux_table_row "install-zsh-autosuggestions" "Install zsh-autosuggestions"
+    ux_table_row "install-fzf" "Install fzf (fuzzy finder)"
+    ux_table_row "install-fasd" "Install fasd (fast directory access)"
+    ux_table_row "install-ripgrep" "Install ripgrep (fast text search)"
+    ux_table_row "install-fd" "Install fd (fast file finder)"
+    ux_table_row "install-bat" "Install bat (cat with highlighting)"
+    ux_table_row "install-pet" "Install pet (command snippet manager)"
+}
 
-    ux_section "Quick Aliases"
-    ux_table_row "zsh-config" "View current zsh config"
-    ux_table_row "zsh-edit-quick" "Quick edit with nano"
-
-    ux_section "Popular Themes"
+_zsh_help_rows_themes_list() {
     ux_bullet "${UX_BOLD}robbyrussell${UX_RESET} - Default clean theme"
     ux_bullet "${UX_BOLD}powerlevel10k${UX_RESET} - Modern powerline theme (requires Nerd Font)"
     ux_bullet "${UX_BOLD}agnoster${UX_RESET} - Git-aware theme"
     ux_bullet "${UX_BOLD}minimal${UX_RESET} - Minimal and fast"
     ux_bullet "${UX_BOLD}afowler${UX_RESET} - Syntax highlighting focused"
+}
 
-    ux_section "Recommended Plugins"
+_zsh_help_rows_plugins_list() {
     ux_bullet "${UX_BOLD}git${UX_RESET} - Git aliases and functions"
     ux_bullet "${UX_BOLD}zsh-autosuggestions${UX_RESET} - Command suggestions (type then use arrow)"
     ux_bullet "${UX_BOLD}zsh-syntax-highlighting${UX_RESET} - Syntax highlighting as you type"
     ux_bullet "${UX_BOLD}extract${UX_RESET} - Smart archive extraction (extract file.tar.gz)"
     ux_bullet "${UX_BOLD}web-search${UX_RESET} - Quick web search (google 'query')"
+}
 
-    ux_section "Bash & Zsh Coexistence"
+_zsh_help_rows_coexist() {
     ux_bullet "Both shells can coexist without conflicts"
     ux_bullet "Switch shells anytime: ${UX_BOLD}zsh-switch${UX_RESET} or ${UX_BOLD}bash-switch${UX_RESET}"
     ux_bullet "Set default: ${UX_BOLD}chsh -s \$(which zsh)${UX_RESET} (then login again)"
+}
 
-    ux_section "Configuration Tips"
+_zsh_help_rows_tips() {
     ux_bullet "Shared config: Add to shell-common/ for portable settings"
     ux_bullet "Shell-specific: Use shell-specific files for unique functions"
-    ux_bullet "Use snippets: Organize $HOME/.zshrc.d/ for better management"
+    ux_bullet "Use snippets: Organize \$HOME/.zshrc.d/ for better management"
+}
 
-    ux_section "Troubleshooting"
+_zsh_help_rows_troubleshoot() {
     ux_bullet "${UX_BOLD}VS Code 터미널에서 기본 프롬프트(HOSTNAME%)만 표시될 때:${UX_RESET}"
     ux_bullet "  원인: VS Code 업데이트 후 셸 통합 캐시 불일치"
     ux_bullet "  해결: ${UX_BOLD}zsh-fix-vscode${UX_RESET}"
@@ -63,49 +108,89 @@ _zsh_help_full() {
     ux_bullet "  해결: ${UX_BOLD}p10k configure${UX_RESET} 로 재설정"
 }
 
-zsh_help() {
-    if [ "$1" = "--all" ] || [ "$1" = "-a" ]; then
-        _zsh_help_full
-        return 0
-    fi
-
-    ux_header "Zsh Management Commands"
-
-    ux_section "Quick Start"
-    ux_table_row "zsh-switch" "Switch to zsh"
-    ux_table_row "bash-switch" "Switch back to bash"
-    ux_table_row "install-zsh" "Install zsh (if not installed)"
-
-    ux_section "Configuration"
-    ux_table_row "zsh-edit" "Edit $HOME/.zshrc"
-    ux_table_row "zsh-reload" "Reload zsh config"
-    ux_table_row "zsh-snippet <name>" "Create config snippet"
-
-    ux_section "Theme & Plugins"
-    ux_table_row "zsh-theme-current" "Current theme"
-    ux_table_row "zsh-themes" "List all themes"
-    ux_table_row "zsh-plugins" "List plugins"
-
-    ux_section "Required/Recommended Packages"
-    ux_table_row "install-p10k" "Install powerlevel10k theme"
-    ux_table_row "p10k-help" "VSCode terminal font setup guide"
-    ux_table_row "p10k configure" "Configure powerlevel10k"
-    ux_table_row "install-zsh-autosuggestions" "Install zsh-autosuggestions (command suggestions)"
-    ux_table_row "install-fzf" "Install fzf (fuzzy finder)"
-    ux_table_row "install-fasd" "Install fasd (fast directory access)"
-    ux_table_row "install-ripgrep" "Install ripgrep (fast text search)"
-    ux_table_row "install-fd" "Install fd (fast file finder)"
-    ux_table_row "install-bat" "Install bat (cat with highlighting)"
-    ux_table_row "install-pet" "Install pet (command snippet manager)"
-
-    ux_section "Troubleshooting"
-    ux_table_row "zsh-fix-vscode" "Fix VS Code terminal prompt after update"
-
-    ux_section "Status"
+_zsh_help_rows_status() {
     ux_table_row "zsh-version" "Show zsh version"
     ux_table_row "zsh-info" "System info"
+}
 
-    ux_info "More details: ${UX_BOLD}zsh-help --all${UX_RESET}"
+_zsh_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_zsh_help_section_rows() {
+    case "$1" in
+        switch|shells)
+            _zsh_help_rows_switch
+            ;;
+        config|configuration)
+            _zsh_help_rows_config
+            ;;
+        theme|themes)
+            _zsh_help_rows_theme
+            ;;
+        plugins|plugin)
+            _zsh_help_rows_plugins
+            ;;
+        packages|pkg|install)
+            _zsh_help_rows_packages
+            ;;
+        themes-list|popular-themes)
+            _zsh_help_rows_themes_list
+            ;;
+        plugins-list|popular-plugins|recommended)
+            _zsh_help_rows_plugins_list
+            ;;
+        coexist|coexistence)
+            _zsh_help_rows_coexist
+            ;;
+        tips|tip)
+            _zsh_help_rows_tips
+            ;;
+        troubleshoot|trouble|fix)
+            _zsh_help_rows_troubleshoot
+            ;;
+        status|info|version)
+            _zsh_help_rows_status
+            ;;
+        *)
+            ux_error "Unknown zsh-help section: $1"
+            ux_info "Try: zsh-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_zsh_help_full() {
+    ux_header "Zsh Management Commands (Complete)"
+    _zsh_help_render_section "Shell Switching" _zsh_help_rows_switch
+    _zsh_help_render_section "Configuration Management" _zsh_help_rows_config
+    _zsh_help_render_section "Theme Management" _zsh_help_rows_theme
+    _zsh_help_render_section "Plugin Management" _zsh_help_rows_plugins
+    _zsh_help_render_section "Required/Recommended Packages" _zsh_help_rows_packages
+    _zsh_help_render_section "Popular Themes" _zsh_help_rows_themes_list
+    _zsh_help_render_section "Recommended Plugins" _zsh_help_rows_plugins_list
+    _zsh_help_render_section "Bash & Zsh Coexistence" _zsh_help_rows_coexist
+    _zsh_help_render_section "Configuration Tips" _zsh_help_rows_tips
+    _zsh_help_render_section "Troubleshooting" _zsh_help_rows_troubleshoot
+    _zsh_help_render_section "Status" _zsh_help_rows_status
+}
+
+zsh_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _zsh_help_summary
+            ;;
+        --list|list)
+            _zsh_help_list_sections
+            ;;
+        --all|all|-a)
+            _zsh_help_full
+            ;;
+        *)
+            _zsh_help_section_rows "$1"
+            ;;
+    esac
 }
 
 alias zsh-help='zsh_help'

--- a/shell-common/functions/zz_help_standard_adapter.sh
+++ b/shell-common/functions/zz_help_standard_adapter.sh
@@ -108,7 +108,7 @@ ${func_name}() {
         \"\"|-h|--help|help)
             _help_std_summary_${func_name}
             ;;
-        --list|list)
+        --list|list|section|sections)
             _help_std_list_${func_name}
             ;;
         --all|all)

--- a/shell-common/functions/zz_help_standard_adapter.sh
+++ b/shell-common/functions/zz_help_standard_adapter.sh
@@ -24,6 +24,14 @@ _help_std_is_wrapped() {
 
 _help_std_is_guideline_compliant() {
     local func_name="$1"
+
+    # SSOT pattern: presence of paired _<func>_summary helper indicates
+    # the topic has been refactored into native summary/list/full helpers
+    # that the dispatcher delegates to. This avoids redundant wrapping.
+    if _help_std_is_function "_${func_name}_summary"; then
+        return 0
+    fi
+
     local def
     local get_definition_fn='_help_std_get_definition'
     def="$($get_definition_fn "$func_name")" || return 1

--- a/shell-common/tools/integrations/apt.sh
+++ b/shell-common/tools/integrations/apt.sh
@@ -18,7 +18,7 @@ alias ac='sudo apt-get clean'         # Remove all .deb files from cache
 # All-in-one cleanup (update → upgrade → autoremove → autoclean)
 alias auug='sudo apt-get update && sudo apt-get upgrade && sudo apt-get autoremove && sudo apt-get autoclean'
 
-alias ai='sudo apt-get install' # Install package
+ai() { sudo apt-get install "$@"; } # Install package
 alias ar='sudo apt-get remove'  # Remove package (keep config)
 alias arp='sudo apt-get purge'  # Remove package (delete config)
 alias as='apt-cache search'     # Search packages
@@ -32,7 +32,7 @@ alias aunhold='apt-mark unhold'      # Unhold package version
 
 # Low-level commands
 alias adpkg='sudo dpkg -i'          # Install .deb file directly
-alias afd='sudo apt-get install -f' # Fix broken dependencies
+afd() { sudo apt-get install -f "$@"; } # Fix broken dependencies
 
 # Cache/Status check
 alias acheck='sudo apt-get check'             # Check system consistency
@@ -163,89 +163,123 @@ ainfo() {
 # APT Help Function
 # ═══════════════════════════════════════════════════════════════
 
+_apt_help_summary() {
+    ux_info "Usage: apt-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "update: au | aug | afa | adu | auug"
+    ux_bullet_sub "cleanup: aar | aac | ac | afd | acheck"
+    ux_bullet_sub "install: ai | ar | arp | adpkg"
+    ux_bullet_sub "search: as | ash | ainfo | alist | aulist"
+    ux_bullet_sub "deps: adep | ardep | afiles | awhich"
+    ux_bullet_sub "hold: ahold | aunhold"
+    ux_bullet_sub "ppa: appa_add | appa_list | appa_remove | aclean_kernel | astat | asize"
+    ux_bullet_sub "details: apt-help <section>  (example: apt-help install)"
+}
+
+_apt_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "update"
+    ux_bullet_sub "cleanup"
+    ux_bullet_sub "install"
+    ux_bullet_sub "search"
+    ux_bullet_sub "deps"
+    ux_bullet_sub "hold"
+    ux_bullet_sub "ppa"
+}
+
+_apt_help_rows_update() {
+    ux_table_row "au" "apt-get update" "Update lists"
+    ux_table_row "aug" "apt-get upgrade" "Safe upgrade"
+    ux_table_row "afa" "apt-get full-upgrade" "Aggressive upgrade"
+    ux_table_row "adu" "apt-get dist-upgrade" "Dist upgrade"
+    ux_table_row "auug" "update+upgrade+clean" "Full cleanup"
+}
+
+_apt_help_rows_cleanup() {
+    ux_table_row "aar" "apt-get autoremove" "Remove unused deps"
+    ux_table_row "aac" "apt-get autoclean" "Clean old cache"
+    ux_table_row "ac" "apt-get clean" "Clean all cache"
+    ux_table_row "afd" "apt-get install -f" "Fix broken deps"
+    ux_table_row "acheck" "apt-get check" "Verify consistency"
+}
+
+_apt_help_rows_install() {
+    ux_table_row "ai" "apt-get install" "Install package"
+    ux_table_row "ar" "apt-get remove" "Remove (keep config)"
+    ux_table_row "arp" "apt-get purge" "Remove completely"
+    ux_table_row "adpkg" "dpkg -i" "Install .deb file"
+}
+
+_apt_help_rows_search() {
+    ux_table_row "as" "apt-cache search" "Search packages"
+    ux_table_row "ash" "apt-cache show" "Show details"
+    ux_table_row "ainfo" "ainfo <pkg>" "Info + deps"
+    ux_table_row "alist" "list --installed" "List installed"
+    ux_table_row "aulist" "list --upgradable" "List upgradable"
+}
+
+_apt_help_rows_deps() {
+    ux_table_row "adep" "depends <pkg>" "Show deps"
+    ux_table_row "ardep" "rdepends <pkg>" "Show reverse deps"
+    ux_table_row "afiles" "dpkg -L <pkg>" "List files"
+    ux_table_row "awhich" "dpkg -S <file>" "Find owner pkg"
+}
+
+_apt_help_rows_hold() {
+    ux_table_row "ahold" "apt-mark hold" "Lock version"
+    ux_table_row "aunhold" "apt-mark unhold" "Unlock version"
+}
+
+_apt_help_rows_ppa() {
+    ux_table_row "appa_add" "add-apt-repository" "Add PPA"
+    ux_table_row "appa_list" "List PPAs" "Show installed PPAs"
+    ux_table_row "appa_remove" "remove PPA" "Remove PPA"
+    ux_table_row "aclean_kernel" "Clean kernels" "Remove old kernels"
+    ux_table_row "astat" "Stats" "System pkg stats"
+    ux_table_row "asize" "Cache size" "Check cache size"
+}
+
+_apt_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_apt_help_section_rows() {
+    case "$1" in
+        update|upgrade)        _apt_help_rows_update ;;
+        cleanup|clean|remove)  _apt_help_rows_cleanup ;;
+        install)               _apt_help_rows_install ;;
+        search|info)           _apt_help_rows_search ;;
+        deps|dependencies|files) _apt_help_rows_deps ;;
+        hold|version)          _apt_help_rows_hold ;;
+        ppa|system)            _apt_help_rows_ppa ;;
+        *)
+            ux_error "Unknown apt-help section: $1"
+            ux_info "Try: apt-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_apt_help_full() {
+    ux_header "APT Quick Commands"
+    _apt_help_render_section "Basic Update & Upgrade" _apt_help_rows_update
+    _apt_help_render_section "Cleanup & Remove" _apt_help_rows_cleanup
+    _apt_help_render_section "Install & Remove" _apt_help_rows_install
+    _apt_help_render_section "Search & Info" _apt_help_rows_search
+    _apt_help_render_section "Dependencies & Files" _apt_help_rows_deps
+    _apt_help_render_section "Version & Hold" _apt_help_rows_hold
+    _apt_help_render_section "PPA & System" _apt_help_rows_ppa
+    ux_info "Note: Commands prefixed with sudo require elevated privileges"
+}
+
 apt_help() {
-    if type ux_header >/dev/null 2>&1; then
-        ux_header "APT Quick Commands"
-    else
-        echo ""
-        echo "APT Quick Commands"
-        echo ""
-    fi
-
-    if type ux_section >/dev/null 2>&1; then
-        ux_section "Basic Update & Upgrade"
-        ux_table_row "au" "apt-get update" "Update lists"
-        ux_table_row "aug" "apt-get upgrade" "Safe upgrade"
-        ux_table_row "afa" "apt-get full-upgrade" "Aggressive upgrade"
-        ux_table_row "adu" "apt-get dist-upgrade" "Dist upgrade"
-        ux_table_row "auug" "update+upgrade+clean" "Full cleanup"
-        echo ""
-
-        ux_section "Cleanup & Remove"
-        ux_table_row "aar" "apt-get autoremove" "Remove unused deps"
-        ux_table_row "aac" "apt-get autoclean" "Clean old cache"
-        ux_table_row "ac" "apt-get clean" "Clean all cache"
-        ux_table_row "afd" "apt-get install -f" "Fix broken deps"
-        ux_table_row "acheck" "apt-get check" "Verify consistency"
-        echo ""
-
-        ux_section "Install & Remove"
-        ux_table_row "ai" "apt-get install" "Install package"
-        ux_table_row "ar" "apt-get remove" "Remove (keep config)"
-        ux_table_row "arp" "apt-get purge" "Remove completely"
-        ux_table_row "adpkg" "dpkg -i" "Install .deb file"
-        echo ""
-
-        ux_section "Search & Info"
-        ux_table_row "as" "apt-cache search" "Search packages"
-        ux_table_row "ash" "apt-cache show" "Show details"
-        ux_table_row "ainfo" "ainfo <pkg>" "Info + deps"
-        ux_table_row "alist" "list --installed" "List installed"
-        ux_table_row "aulist" "list --upgradable" "List upgradable"
-        echo ""
-
-        ux_section "Dependencies & Files"
-        ux_table_row "adep" "depends <pkg>" "Show deps"
-        ux_table_row "ardep" "rdepends <pkg>" "Show reverse deps"
-        ux_table_row "afiles" "dpkg -L <pkg>" "List files"
-        ux_table_row "awhich" "dpkg -S <file>" "Find owner pkg"
-        echo ""
-
-        ux_section "Version & Hold"
-        ux_table_row "ahold" "apt-mark hold" "Lock version"
-        ux_table_row "aunhold" "apt-mark unhold" "Unlock version"
-        echo ""
-
-        ux_section "PPA & System"
-        ux_table_row "appa_add" "add-apt-repository" "Add PPA"
-        ux_table_row "appa_list" "List PPAs" "Show installed PPAs"
-        ux_table_row "appa_remove" "remove PPA" "Remove PPA"
-        ux_table_row "aclean_kernel" "Clean kernels" "Remove old kernels"
-        ux_table_row "astat" "Stats" "System pkg stats"
-        ux_table_row "asize" "Cache size" "Check cache size"
-        echo ""
-
-        ux_info "Note: Commands prefixed with sudo require elevated privileges"
-    else
-        echo "APT Quick Commands"
-        echo "────────────────────────"
-        echo "Basic Update & Upgrade:"
-        echo "  au      - apt-get update"
-        echo "  aug     - apt-get upgrade"
-        echo "  afa     - apt-get full-upgrade"
-        echo "Cleanup & Remove:"
-        echo "  aar     - apt-get autoremove"
-        echo "  aac     - apt-get autoclean"
-        echo "  ac      - apt-get clean"
-        echo "Install & Remove:"
-        echo "  ai      - apt-get install"
-        echo "  ar      - apt-get remove"
-        echo "  arp     - apt-get purge"
-        echo "Search & Info:"
-        echo "  as      - apt-cache search"
-        echo "  ash     - apt-cache show"
-        echo "Note: Commands prefixed with sudo require elevated privileges"
-    fi
+    case "${1:-}" in
+        ""|-h|--help|help) _apt_help_summary ;;
+        --list|list)        _apt_help_list_sections ;;
+        --all|all)          _apt_help_full ;;
+        *)                  _apt_help_section_rows "$1" ;;
+    esac
 }
 
 # Alias for apt-help format (using dash instead of underscore)

--- a/shell-common/tools/integrations/apt.sh
+++ b/shell-common/tools/integrations/apt.sh
@@ -282,7 +282,7 @@ _apt_help_full() {
 apt_help() {
     case "${1:-}" in
         ""|-h|--help|help) _apt_help_summary ;;
-        --list|list)        _apt_help_list_sections ;;
+        --list|list|section|sections)        _apt_help_list_sections ;;
         --all|all)          _apt_help_full ;;
         *)                  _apt_help_section_rows "$1" ;;
     esac

--- a/shell-common/tools/integrations/apt.sh
+++ b/shell-common/tools/integrations/apt.sh
@@ -18,6 +18,10 @@ alias ac='sudo apt-get clean'         # Remove all .deb files from cache
 # All-in-one cleanup (update → upgrade → autoremove → autoclean)
 alias auug='sudo apt-get update && sudo apt-get upgrade && sudo apt-get autoremove && sudo apt-get autoclean'
 
+# Migration guard: previous versions of this file defined `ai` as an alias.
+# In interactive zsh, an active alias causes `ai() { ... }` to fail parsing
+# ("defining function based on alias") on reload. Drop any stale alias first.
+unalias ai 2>/dev/null || true
 ai() { sudo apt-get install "$@"; } # Install package
 alias ar='sudo apt-get remove'  # Remove package (keep config)
 alias arp='sudo apt-get purge'  # Remove package (delete config)
@@ -32,6 +36,8 @@ alias aunhold='apt-mark unhold'      # Unhold package version
 
 # Low-level commands
 alias adpkg='sudo dpkg -i'          # Install .deb file directly
+# Migration guard: see note on `ai` above.
+unalias afd 2>/dev/null || true
 afd() { sudo apt-get install -f "$@"; } # Fix broken dependencies
 
 # Cache/Status check

--- a/shell-common/tools/integrations/notion.sh
+++ b/shell-common/tools/integrations/notion.sh
@@ -148,7 +148,7 @@ _notion_help_full() {
 notion_help() {
     case "${1:-}" in
         ""|-h|--help|help) _notion_help_summary ;;
-        --list|list)        _notion_help_list_sections ;;
+        --list|list|section|sections)        _notion_help_list_sections ;;
         --all|all)          _notion_help_full ;;
         *)                  _notion_help_section_rows "$1" ;;
     esac

--- a/shell-common/tools/integrations/notion.sh
+++ b/shell-common/tools/integrations/notion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # shell-common/tools/integrations/notion.sh
 # Notion API integration for claude-code MCP (Model Context Protocol)
 
@@ -28,10 +28,33 @@ NOTION_HELP
 # Notion Help Function
 # ─────────────────────────────────────────────────────────────────────────────
 
-notion_help() {
-    ux_header "Notion MCP Setup & Configuration"
+_notion_help_summary() {
+    ux_info "Usage: notion-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "status: NOTION_API_KEY environment check"
+    ux_bullet_sub "apikey: generate API key from Notion integrations"
+    ux_bullet_sub "install: npm install -g @notionhq/notion-mcp-server"
+    ux_bullet_sub "register: claude mcp add notion --scope user"
+    ux_bullet_sub "verify: cat ~/.claude.json | grep notion"
+    ux_bullet_sub "test: curl api.notion.com/v1/users/me"
+    ux_bullet_sub "env: .env example (NOTION_API_KEY | WORKSPACE_ID | WORKSPACE_NAME)"
+    ux_bullet_sub "links: developers.notion.com | claude.com/claude-code | modelcontextprotocol.io"
+    ux_bullet_sub "details: notion-help <section>  (example: notion-help install)"
+}
 
-    ux_section "🔍 Current Environment Status"
+_notion_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "status"
+    ux_bullet_sub "apikey"
+    ux_bullet_sub "install"
+    ux_bullet_sub "register"
+    ux_bullet_sub "verify"
+    ux_bullet_sub "test"
+    ux_bullet_sub "env"
+    ux_bullet_sub "links"
+}
+
+_notion_help_rows_status() {
     if [ -n "${NOTION_API_KEY:-}" ]; then
         local key_preview="${NOTION_API_KEY:0:10}...${NOTION_API_KEY: -10}"
         ux_success "NOTION_API_KEY is set"
@@ -40,37 +63,37 @@ notion_help() {
         ux_warning "NOTION_API_KEY is not set"
         ux_info "Run: export NOTION_API_KEY='your_key_here' or source ~/.env"
     fi
-    echo ""
+}
 
-    ux_section "1️⃣  Generate API Key from Notion"
+_notion_help_rows_apikey() {
     ux_numbered "1" "Visit https://www.notion.so/profile/integrations"
     ux_numbered "2" "Click 'Create new integration' button"
     ux_numbered "3" "Configure integration name and capabilities"
     ux_numbered "4" "Copy the API key"
     ux_numbered "5" "Store in .env: NOTION_API_KEY='your_key_here'"
-    echo ""
+}
 
-    ux_section "2️⃣  Install Notion MCP Server Globally"
+_notion_help_rows_install() {
     ux_bullet "npm install -g @notionhq/notion-mcp-server"
     ux_warning "Requires Node.js and npm to be installed"
-    echo ""
+}
 
-    ux_section "3️⃣  Register MCP Server with Claude Code"
+_notion_help_rows_register() {
     ux_bullet "claude mcp add notion --scope user --env NOTION_API_KEY=\$NOTION_API_KEY -- npx -y @notionhq/notion-mcp-server"
     ux_info "Uses: --scope user (per-user configuration)"
-    echo ""
+}
 
-    ux_section "4️⃣  Verify Installation"
+_notion_help_rows_verify() {
     ux_bullet "cat ~/.claude.json | grep notion"
     ux_bullet "Should output: \"notion\": { \"@notionhq/notion-mcp-server\" ... }"
-    echo ""
+}
 
-    ux_section "5️⃣  Test API Token Validity"
+_notion_help_rows_test() {
     ux_bullet "curl https://api.notion.com/v1/users/me -H \"Authorization: Bearer \$NOTION_API_KEY\" -H \"Notion-Version: 2022-06-28\" | jq"
     ux_info "Success response: returns workspace and user information (formatted with jq)"
-    echo ""
+}
 
-    ux_section "📋 Environment File Example"
+_notion_help_rows_env() {
     cat <<'ENV_EXAMPLE'
 # .env or shell env file
 NOTION_API_KEY='ntn_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
@@ -79,13 +102,56 @@ NOTION_API_KEY='ntn_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 NOTION_WORKSPACE_ID='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 NOTION_WORKSPACE_NAME='Your-Workspace-Name'
 ENV_EXAMPLE
-    echo ""
+}
 
-    ux_section "🔗 Useful Links"
+_notion_help_rows_links() {
     ux_bullet "Notion Integration Docs: https://developers.notion.com"
     ux_bullet "Claude Code Docs: https://claude.com/claude-code"
     ux_bullet "MCP Specification: https://modelcontextprotocol.io"
-    echo ""
+}
+
+_notion_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_notion_help_section_rows() {
+    case "$1" in
+        status|env-status)        _notion_help_rows_status ;;
+        apikey|api-key|key)       _notion_help_rows_apikey ;;
+        install|setup)            _notion_help_rows_install ;;
+        register|mcp)             _notion_help_rows_register ;;
+        verify|check)             _notion_help_rows_verify ;;
+        test|token)               _notion_help_rows_test ;;
+        env|environment)          _notion_help_rows_env ;;
+        links|docs|references)    _notion_help_rows_links ;;
+        *)
+            ux_error "Unknown notion-help section: $1"
+            ux_info "Try: notion-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_notion_help_full() {
+    ux_header "Notion MCP Setup & Configuration"
+    _notion_help_render_section "Current Environment Status" _notion_help_rows_status
+    _notion_help_render_section "Generate API Key from Notion" _notion_help_rows_apikey
+    _notion_help_render_section "Install Notion MCP Server Globally" _notion_help_rows_install
+    _notion_help_render_section "Register MCP Server with Claude Code" _notion_help_rows_register
+    _notion_help_render_section "Verify Installation" _notion_help_rows_verify
+    _notion_help_render_section "Test API Token Validity" _notion_help_rows_test
+    _notion_help_render_section "Environment File Example" _notion_help_rows_env
+    _notion_help_render_section "Useful Links" _notion_help_rows_links
+}
+
+notion_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _notion_help_summary ;;
+        --list|list)        _notion_help_list_sections ;;
+        --all|all)          _notion_help_full ;;
+        *)                  _notion_help_section_rows "$1" ;;
+    esac
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -206,7 +206,7 @@ _opencode_help_full() {
 opencode_help() {
     case "${1:-}" in
         ""|-h|--help|help) _opencode_help_summary ;;
-        --list|list)        _opencode_help_list_sections ;;
+        --list|list|section|sections)        _opencode_help_list_sections ;;
         --all|all)          _opencode_help_full ;;
         *)                  _opencode_help_section_rows "$1" ;;
     esac

--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -96,55 +96,120 @@ opencode_verify() {
     ux_header "Verification Complete"
 }
 
-opencode_help() {
-    ux_header "OpenCode CLI Reference"
-    echo ""
+_opencode_help_summary() {
+    ux_info "Usage: opencode-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "setup: install-opencode | opencode-verify | uninstall-opencode"
+    ux_bullet_sub "utils: bunx oh-my-opencode install | install-bun | bun-help"
+    ux_bullet_sub "env: home/public | external | internal"
+    ux_bullet_sub "profile: oc-profile dtgpt | oc-profile a2g"
+    ux_bullet_sub "config: \$OPENCODE_CONFIG_FILE | opencode-edit"
+    ux_bullet_sub "models: Home | External | DTGPT | A2G"
+    ux_bullet_sub "usage: opencode | opencode --help | opencode --version"
+    ux_bullet_sub "trouble: install-opencode | opencode-verify | uninstall-opencode"
+    ux_bullet_sub "details: opencode-help <section>  (example: opencode-help profile)"
+}
 
-    ux_section "Installation & Setup"
+_opencode_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "setup"
+    ux_bullet_sub "utils"
+    ux_bullet_sub "env"
+    ux_bullet_sub "profile"
+    ux_bullet_sub "config"
+    ux_bullet_sub "models"
+    ux_bullet_sub "usage"
+    ux_bullet_sub "trouble"
+}
+
+_opencode_help_rows_setup() {
     ux_bullet "${UX_PRIMARY}install-opencode${UX_RESET}             : Interactive OpenCode installer"
     ux_bullet "${UX_PRIMARY}opencode-verify${UX_RESET}              : Verify installation & configuration"
     ux_bullet "${UX_PRIMARY}uninstall-opencode${UX_RESET}           : Remove OpenCode and configuration"
-    echo ""
+}
 
-    ux_section "필수 유틸리티"
+_opencode_help_rows_utils() {
     ux_bullet "${UX_PRIMARY}bunx oh-my-opencode install${UX_RESET}   : Oh My OpenCode (OMO) 인터페이스 설치"
     ux_bullet "bunx 없을 때             : ${UX_PRIMARY}install-bun${UX_RESET} 또는 ${UX_PRIMARY}bun-help${UX_RESET} 참고"
-    echo ""
+}
 
-    ux_section "Environments (managed by setup.sh)"
+_opencode_help_rows_env() {
     ux_bullet "home/public             : OpenCode defaults (no symlink)"
     ux_bullet "external                : localhost:4444 LiteLLM proxy"
     ux_bullet "internal                : Samsung DS LiteLLM endpoint"
-    echo ""
+}
 
-    ux_section "Profile Management (internal only)"
+_opencode_help_rows_profile() {
     ux_bullet "${UX_PRIMARY}oc-profile dtgpt${UX_RESET}     : DTGPT  (cloud.dtgpt.samsungds.net)"
     ux_bullet "${UX_PRIMARY}oc-profile a2g${UX_RESET}       : A2G    (a2g.samsungds.net) — Thinking models"
-    echo ""
+}
 
-    ux_section "Configuration"
+_opencode_help_rows_config() {
     ux_bullet "Config file             : ${UX_INFO}$OPENCODE_CONFIG_FILE${UX_RESET}"
     ux_bullet "Edit configuration      : ${UX_PRIMARY}opencode-edit${UX_RESET}"
-    echo ""
+}
 
-    ux_section "Models (LiteLLM Integration)"
+_opencode_help_rows_models() {
     ux_bullet "Home       : OpenCode defaults"
     ux_bullet "External   : gpt-oss-20b"
     ux_bullet "DTGPT      : GLM4.7, Kimi-K2.5, MiniMax-M2.1"
     ux_bullet "A2G        : GLM-5-Thinking, Qwen3.5-Thinking, Kimi-K2.5-Thinking"
-    echo ""
+}
 
-    ux_section "Usage"
+_opencode_help_rows_usage() {
     ux_bullet "${UX_PRIMARY}opencode${UX_RESET}                     : Launch OpenCode interactive CLI"
     ux_bullet "${UX_PRIMARY}opencode --help${UX_RESET}              : Show OpenCode help"
     ux_bullet "${UX_PRIMARY}opencode --version${UX_RESET}           : Show OpenCode version"
-    echo ""
+}
 
-    ux_section "Troubleshooting"
+_opencode_help_rows_trouble() {
     ux_bullet "Not installed?          : Run ${UX_PRIMARY}install-opencode${UX_RESET}"
     ux_bullet "LLM not working?        : Run ${UX_PRIMARY}opencode-verify${UX_RESET}"
     ux_bullet "Want to remove?         : Run ${UX_PRIMARY}uninstall-opencode${UX_RESET}"
-    echo ""
+}
+
+_opencode_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_opencode_help_section_rows() {
+    case "$1" in
+        setup|install)             _opencode_help_rows_setup ;;
+        utils|util|utilities)      _opencode_help_rows_utils ;;
+        env|environments|environment) _opencode_help_rows_env ;;
+        profile|profiles)          _opencode_help_rows_profile ;;
+        config|configuration)      _opencode_help_rows_config ;;
+        models|model)              _opencode_help_rows_models ;;
+        usage|commands|cmds)       _opencode_help_rows_usage ;;
+        trouble|troubleshooting)   _opencode_help_rows_trouble ;;
+        *)
+            ux_error "Unknown opencode-help section: $1"
+            ux_info "Try: opencode-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_opencode_help_full() {
+    ux_header "OpenCode CLI Reference"
+    _opencode_help_render_section "Installation & Setup" _opencode_help_rows_setup
+    _opencode_help_render_section "필수 유틸리티" _opencode_help_rows_utils
+    _opencode_help_render_section "Environments (managed by setup.sh)" _opencode_help_rows_env
+    _opencode_help_render_section "Profile Management (internal only)" _opencode_help_rows_profile
+    _opencode_help_render_section "Configuration" _opencode_help_rows_config
+    _opencode_help_render_section "Models (LiteLLM Integration)" _opencode_help_rows_models
+    _opencode_help_render_section "Usage" _opencode_help_rows_usage
+    _opencode_help_render_section "Troubleshooting" _opencode_help_rows_trouble
+}
+
+opencode_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _opencode_help_summary ;;
+        --list|list)        _opencode_help_list_sections ;;
+        --all|all)          _opencode_help_full ;;
+        *)                  _opencode_help_section_rows "$1" ;;
+    esac
 }
 
 oc_profile() {

--- a/tests/integration/test_help_compact_policy.py
+++ b/tests/integration/test_help_compact_policy.py
@@ -126,7 +126,7 @@ class TestHelpStandardInterface:
     @pytest.mark.parametrize("shell", ["bash", "zsh"])
     @pytest.mark.parametrize("func_name", HELP_TOPICS)
     def test_supports_list_and_all(self, shell_runner, shell, func_name):
-        for arg in ("--list", "list", "--all", "all"):
+        for arg in ("--list", "list", "section", "sections", "--all", "all"):
             result = shell_runner(shell, f"{func_name} {arg}")
             assert result.exit_code == 0, f"{shell}: '{func_name} {arg}' failed"
             assert result.stdout.strip(), f"{shell}: '{func_name} {arg}' returned empty output"


### PR DESCRIPTION
## Summary
- Refactors 57 `*_help` topics to the SSOT (Single Source of Truth) pattern defined in `docs/standards/command-guidelines.md`: per-section `_<topic>_help_rows_<section>` functions shared between `--all` and section lookups, a compact `_<topic>_help_summary` within the 15-line cap, and a dispatcher that delegates to them.
- Fixes three follow-up bugs surfaced by the refactor: adapter double-wrapping of SSOT topics, zsh reload failure in `apt.sh` due to alias→function migration, and the missing `section`/`sections` keyword across every dispatcher.
- Extends the compact-policy test matrix so regressions in either the SSOT contract or the advertised keyword set fail loudly.

## Changes
### SSOT refactor (57 commits — one topic per commit)
Each commit converts one topic helper to the pattern demonstrated by the reference `git-help` (08e2dd6) and `my-help` (481c791). Scope: every `*_help` function under `shell-common/functions/` plus three integrations (`apt`, `notion`, `opencode`).

Topics covered: `apt`, `bat`, `bun`, `category`, `cc`, `claude`, `claude_plugins`, `claude_skills_marketplace`, `cli`, `codex`, `crt`, `dir`, `docker`, `dot`, `dproxy`, `du`, `fasd`, `fd`, `fzf`, `gc`, `gemini`, `ghostty`, `gpu`, `hook`, `litellm`, `mount`, `mysql`, `mytool`, `network`, `notion`, `npm`, `nvm`, `ollama`, `opencode`, `p10k`, `pet`, `pip`, `pp`, `proxy`, `psql`, `py`, `redis`, `register`, `ripgrep`, `setup_mode`, `show_doc`, `ssh`, `ssl`, `superpowers`, `sys`, `tmux`, `ux`, `uv`, `work`, `work_log`, `zsh`, `zsh_autosuggestions`.

### Follow-up fixes
- `fix(help): detect SSOT pattern via paired _summary helper` (`zz_help_standard_adapter.sh`)
  - The adapter previously inspected the dispatcher body for literal template strings. Refactored topics keep those strings in `_<topic>_help_summary`, so every SSOT topic was being re-wrapped and the wrapper's `_help_std_full_*` replaced the native `_<topic>_help_full`. Caught by `mytool-help --all` rendering the summary instead of the tool table.
  - Adds presence of `_<func>_summary` as the primary compliance signal; legacy string-grep remains as fallback.
- `fix(apt): guard against stale aliases during reload` (`shell-common/tools/integrations/apt.sh`)
  - `ai` and `afd` were converted from aliases to thin functions to satisfy `library_purity_check`. In interactive zsh, reloading apt.sh while the old aliases were still defined produced `(eval):1: defining function based on alias 'ai'` → non-zero source exit → `❌ Failed to load integration tool: …/apt.sh`. Fresh shells were unaffected.
  - Adds `unalias ai afd 2>/dev/null || true` guards before the function definitions.
  - Audited all 41 changed files for any other `alias X=` → `X() { ... }` transitions; only `ai`/`afd` matched (other new SSOT helpers use `_`-prefixed names that were never aliases).
- `fix(help): accept section keyword across all *-help dispatchers` (43 files)
  - Every SSOT summary advertises `[section|--list|--all]`, but the dispatcher case accepted only `--list|list)`. Running `docker-help section` or any `<topic>-help sections` printed `Unknown <topic>-help section: sections`.
  - Broadens the case to `--list|list|section|sections)` in all topic dispatchers and in the adapter wrapper template so any legacy-wrapped helper also gains the keyword.
  - Adds `section` and `sections` to `test_supports_list_and_all` so the advertised contract is validated for every topic × shell combination.

## Test plan
- [x] `.venv/bin/pytest tests/integration/test_help_compact_policy.py tests/integration/test_help_topics.py tests/integration/test_mytool_help.py` — 945 passed
- [x] Manual reload check: `unalias ai; source shell-common/tools/integrations/apt.sh` — no parse error
- [x] Manual keyword check: `docker-help section`, `docker-help sections`, `mytool-help --all`, `apt-help sections` — all render expected content
- [x] Pre-commit hooks (library_purity_check, help_integrity_check, pipe_loop_check, shebang_check, alias_location_check) pass on every commit

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
