### PR TITLE
fix(gwt): teardown path-arg 에러를 컨텍스트 기반 가이드로 교체

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -590,10 +590,36 @@ git_worktree_teardown() {
                 return 1
                 ;;
             *)
-                ux_error "'gwt teardown' is a self-cleanup command (run from inside a worktree)."
-                ux_info "  It does not accept a path argument."
-                ux_info "  To remove a specific worktree by path, use:"
-                ux_info "    gwt remove $1"
+                # Detect whether current pwd is main repo or inside a worktree
+                # so we can tailor the error guidance to the mistake actually made.
+                local _gwt_common _gwt_dir _gwt_in_wt=false _gwt_loc
+                _gwt_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+                if [ -n "$_gwt_common" ]; then
+                    _gwt_dir="$(git rev-parse --git-dir 2>/dev/null)"
+                    [ "$_gwt_dir" != "$_gwt_common" ] && _gwt_in_wt=true
+                fi
+                _gwt_loc="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+                ux_error "'gwt teardown' does not accept a path argument."
+                echo ""
+                if [ "$_gwt_in_wt" = true ]; then
+                    # Scenario B: user is already in a worktree but still typed a path
+                    ux_info "You are already inside a worktree: $_gwt_loc"
+                    ux_info "Drop the path argument and just run:"
+                    echo ""
+                    ux_bullet "gwt teardown"
+                else
+                    # Scenario A: user is in the main repo (most common mistake)
+                    ux_info "You are in:  main repo ($_gwt_loc)"
+                    ux_info "You passed:  $1"
+                    echo ""
+                    ux_warning "'gwt teardown' is SELF-CLEANUP — it tears down the worktree"
+                    ux_warning "you are currently inside (cd into it first, then run)."
+                    echo ""
+                    ux_info "Did you mean:"
+                    ux_bullet "cd $1 && gwt teardown     # full cleanup: remove + sync main + delete branch"
+                    ux_bullet "gwt remove $1             # remove worktree only (no main sync, no branch delete)"
+                fi
                 return 1
                 ;;
         esac

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -593,11 +593,12 @@ git_worktree_teardown() {
                 # Detect whether current pwd is main repo or inside a worktree
                 # so we can tailor the error guidance to the mistake actually made.
                 local _gwt_common _gwt_dir _gwt_in_wt=false _gwt_loc
-                _gwt_common="$(git rev-parse --git-common-dir 2>/dev/null)"
-                if [ -n "$_gwt_common" ]; then
-                    _gwt_dir="$(git rev-parse --git-dir 2>/dev/null)"
-                    [ "$_gwt_dir" != "$_gwt_common" ] && _gwt_in_wt=true
-                fi
+                _gwt_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+                    ux_error "Not inside a git repository"
+                    return 1
+                }
+                _gwt_dir="$(git rev-parse --git-dir 2>/dev/null)"
+                [ "$_gwt_dir" != "$_gwt_common" ] && _gwt_in_wt=true
                 _gwt_loc="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
                 ux_error "'gwt teardown' does not accept a path argument."
@@ -617,8 +618,8 @@ git_worktree_teardown() {
                     ux_warning "you are currently inside (cd into it first, then run)."
                     echo ""
                     ux_info "Did you mean:"
-                    ux_bullet "cd $1 && gwt teardown     # full cleanup: remove + sync main + delete branch"
-                    ux_bullet "gwt remove $1             # remove worktree only (no main sync, no branch delete)"
+                    ux_bullet "cd \"$1\" && gwt teardown     # full cleanup: remove + sync main + delete branch"
+                    ux_bullet "gwt remove \"$1\"             # remove worktree only (no main sync, no branch delete)"
                 fi
                 return 1
                 ;;


### PR DESCRIPTION
## 요약

`gwt teardown <path>` 를 main repo 에서 실행했을 때 나오던 terse 에러를
컨텍스트 감지 기반 메시지로 교체합니다. "왜 경로 인자를 안 받는지"를
사용자가 다시 배우게 하는 대신, 현재 위치와 입력된 경로를 기반으로
의도한 동작 2개를 side-by-side 로 제시합니다.

## 재현

```sh
$ cd ~/dotfiles            # main repo
$ gwt teardown ~/dotfiles-claude-2
[ERROR] 'gwt teardown' is a self-cleanup command (run from inside a worktree).
  It does not accept a path argument.
  To remove a specific worktree by path, use:
    gwt remove ~/dotfiles-claude-2
```

기존 메시지는 사용자가 **path 인자를 안 받는다는 사실**만 알려줄 뿐,
`teardown` 이 왜 self-cleanup 컨벤션인지 / `gwt remove` 와 무엇이
다른지를 설명하지 않아 매번 help 를 다시 읽어야 합니다.

## 변경

`shell-common/functions/git_worktree.sh` 의 `*)` 분기만 수정.
`git rev-parse --git-dir` vs `--git-common-dir` 비교로 현재 위치를
감지해 두 시나리오로 분기합니다.

### Scenario A — main repo 에서 path 인자 사용 (가장 흔한 실수)

```
❌ 'gwt teardown' does not accept a path argument.

ℹ️  You are in:  main repo (/home/bwyoon/dotfiles)
ℹ️  You passed:  /home/bwyoon/dotfiles-claude-2

⚠️  'gwt teardown' is SELF-CLEANUP — it tears down the worktree
⚠️  you are currently inside (cd into it first, then run).

ℹ️  Did you mean:
  ◆ cd /home/bwyoon/dotfiles-claude-2 && gwt teardown     # full cleanup: remove + sync main + delete branch
  ◆ gwt remove /home/bwyoon/dotfiles-claude-2             # remove worktree only (no main sync, no branch delete)
```

### Scenario B — 이미 worktree 안에 있는데도 path 인자 사용

```
❌ 'gwt teardown' does not accept a path argument.

ℹ️  You are already inside a worktree: /home/bwyoon/dotfiles-claude-2
ℹ️  Drop the path argument and just run:

  ◆ gwt teardown
```

## 색상 계층 (UX_GUIDELINES 준수)

- `ux_error` (빨강 + ❌ + bold) — 최상단 주의 환기
- `ux_warning` (노랑 + ⚠️) — self-cleanup 원칙 재강조
- `ux_info` (시안 + ℹ️) — 현재 상태 / 대안 안내
- `ux_bullet` (파랑 ◆) — 실행 가능한 명령

빨강 → 노랑 → 시안 → 파랑 순으로 자연스러운 "읽는 순서" 를 만듭니다.

## 동작 변경 없음

- path 인자는 여전히 거부 (`return 1`)
- `gwt teardown` (인자 없음) 경로 영향 없음
- `gwt remove <path>` 경로 영향 없음

## 검증

- [x] `bash -n shell-common/functions/git_worktree.sh`
- [x] `zsh -n shell-common/functions/git_worktree.sh`
- [x] `shellcheck` — 신규 경고 0 (기존 `local` SC3043 패턴만 유지)
- [x] bash/zsh 양쪽에서 Scenario A/B 수동 렌더링 확인
- [x] pre-commit 훅 통과

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
