### PR TITLE
docs(learnings): 재사용 패턴 지식 저장소 초기 구조 + 세 가지 시드 문서

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -69,6 +69,26 @@ After implementing changes from reviews:
 2. Update root AGENTS.md if Golden Rules changed
 3. Commit with reference to review item (e.g., "Fix: Issue #3 from abc-review-C")
 
+## Learnings vs Technic vs Memory (Boundary Rules)
+Four knowledge locations have distinct roles. Do not duplicate content — link instead.
+- **`docs/learnings/`**: Short reusable patterns/snippets (50–80 lines target) learned from actual PR/commit experience. Korean by default (for human teammates).
+- **`docs/technic/`**: Verified stack-centric technical docs (hundreds of lines). Full setup + tradeoffs.
+- **`docs/standards/`**: Project SSOTs and decision records.
+- **`memory/` (Claude-private)**: Cross-session context for AI. Entries should use pointers to `docs/learnings/` rather than duplicating content.
+
+## Learnings Reference-Linking Rule
+Every `docs/learnings/*.md` file SHOULD include traceability to its origin:
+- **PR number** (most stable, survives merges): `PR #130`
+- **Commit hash**: for pointing at a specific code example
+- **Issue number**: when related discussion/bug exists
+- **Review comment URL**: when the insight came from a bot/human review
+
+If no such reference is possible (local experiment, conversation-only discovery), omit the links but record the **situation** in the Context section concretely.
+
+## Language Policy for Docs
+- **Human-teammate docs** (learnings/, technic/ narrative, standards/): Korean
+- **AI-instruction docs** (SKILL.md, system prompts, machine-read templates): English
+
 # File Descriptions
 
 ## AGENTS_md_Master_Prompt.md (15,511 bytes) [in docs/archive/]
@@ -99,6 +119,12 @@ Feature-centric documentation bundles:
 - `analysis/` - Discovery, legacy analysis, category breakdowns
 - `planning/` - Roadmaps, phase detail, progress tracking, quick start
 - `requirements/` - REQ and design specification documents
+
+## docs/learnings/ (reusable-pattern knowledge base)
+Short snippets (50–80 lines) of reusable patterns extracted from real PRs/commits.
+- `README.md` - Index + authoring rules + boundary vs technic/standards/memory
+- Per-topic files follow 5-section template: Context / Pattern / Code / When to use / Related
+- See "Learnings Reference-Linking Rule" and "Language Policy for Docs" in Golden Rules above
 
 # Testing Strategy
 
@@ -139,3 +165,4 @@ echo "Archived: Replaced by new-guide.md (2026-01-01)" >> docs/archive/README.md
 - **[Parent Context](../AGENTS.md)** — Project root and TDD protocol
 - **[Bash Documentation](../bash/README.md)** — Detailed bash module docs
 - **[Shell Common](../shell-common/AGENTS.md)** — Shared utilities context
+- **[Learnings](./learnings/README.md)** — Reusable pattern snippets from actual PRs

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -1,0 +1,101 @@
+# Learnings
+
+## 개요
+
+이 디렉토리는 **작업 중 얻은 재사용 가능한 패턴·스니펫**을 짧은 글 단위로
+축적하는 지식 저장소입니다. 각 문서는 실제 PR·커밋·리뷰 경험에서 파생되며,
+다른 작업에 그대로 복사해 적용할 수 있는 수준으로 정리합니다.
+
+## 이웃 디렉토리와의 관계
+
+| 디렉토리 | 성격 | 분량 기준 | 예시 |
+|---|---|---|---|
+| `docs/technic/` | 검증된 스택 중심 기술 문서 | 수백 줄 | `parallel-testing-with-xdist.md` |
+| `docs/standards/` | 프로젝트 SSOT·의사결정 기록 | 중간 | `command-guidelines.md` |
+| `docs/feature/<name>/` | 피처별 설계·분석 번들 | 다수 파일 | `skill-ai-worktree-teardown/` |
+| **`docs/learnings/` (여기)** | **작업 중 얻은 재사용 패턴 스니펫** | **50–80줄 목표** | 아래 참조 |
+
+`memory/`(Claude 비공개 작업 메모리)와는 다음 규칙으로 역할 분담:
+
+- **`docs/learnings/`**: 공개·버전 관리되는 지식 — 개발자 동료도 읽는 곳
+- **`memory/`**: Claude 세션 간 컨텍스트 — 사용자·AI 협업 선호도·피드백 중심
+- 같은 내용을 양쪽에 중복 작성하지 않고, `memory/` 엔트리는 이 폴더의
+  파일을 **포인터로 참조**
+
+## 작성 규칙
+
+### 파일 구조 템플릿
+
+각 learning 문서는 다음 5개 섹션을 권장합니다.
+
+```markdown
+# <제목>
+
+## Context
+
+이 패턴이 어디서 나왔는지 — PR·이슈·커밋 링크 포함
+
+## Pattern
+
+핵심 원리를 1–3문장으로 요약
+
+## Code
+
+복붙 가능한 최소 예시 (언어 태그 포함)
+
+## When to use
+
+적용 조건 / 반대 조건
+
+## Related
+
+연결된 문서·코드 파일 경로, 참조 커밋·PR
+```
+
+### 참조 링크 지침
+
+각 learning 은 **출처 추적 가능성**이 생명입니다. 다음을 가능한 범위에서 기록:
+
+- **PR 번호**: `PR #130` — 가장 안정적인 참조 (병합 후에도 유지)
+- **커밋 해시**: `de96848` — 특정 코드 예시를 가리킬 때
+- **이슈 번호**: `#N` — 관련 discussion·bug 가 있을 경우
+- **리뷰 코멘트 URL**: 봇·사람 리뷰에서 얻은 insight 일 때
+
+불가능한 경우(로컬 실험·대화 중 발견 등)는 **생략**하되, 대신 Context 섹션에
+"어떤 상황에서 발견했는지"를 구체적으로 기록합니다.
+
+### 언어 정책
+
+- **동료 개발자용 문서**: 한국어 (이 폴더의 기본)
+- **AI 지침서 성격**(SKILL.md, system prompt 등): 영어
+
+## 현재 문서 목록
+
+### 1. UX 색 계층으로 "읽는 순서" 만들기
+
+**파일**: [`ux-color-hierarchy.md`](./ux-color-hierarchy.md)
+
+멀티라인 에러·가이드 메시지에서 **빨강 → 노랑 → 시안 → 파랑** 색 계층으로
+사용자의 시선을 "문제 → 원칙 → 대안" 순서로 유도하는 설계 패턴.
+
+### 2. Git worktree 컨텍스트 감지
+
+**파일**: [`git-worktree-detection.md`](./git-worktree-detection.md)
+
+`git rev-parse --git-dir` 와 `--git-common-dir` 비교로 현재 pwd 가 main
+repo 인지 worktree 인지 감지하는 최소 코드 패턴. `||` early-exit 로
+non-repo 케이스도 함께 처리.
+
+### 3. GitHub PR 리뷰 답글 API 엔드포인트 분기
+
+**파일**: [`github-pr-review-reply-api.md`](./github-pr-review-reply-api.md)
+
+inline diff 코멘트는 `/pulls/{n}/comments/{id}/replies` (스레드 유지),
+리뷰 요약·이슈 코멘트는 `/issues/{n}/comments` (top-level) 로 POST 해야
+하는 이유와 선택 기준.
+
+## 성장 전략
+
+- 3–10개: 플랫 구조 유지 (현재)
+- 10개 초과: `shell/`, `workflows/`, `ux/` 등 주제별 서브디렉토리로 분리
+- 30개 초과 또는 한 문서가 150줄 초과: `technic/` 승격 검토

--- a/docs/learnings/git-worktree-detection.md
+++ b/docs/learnings/git-worktree-detection.md
@@ -36,8 +36,9 @@ _git_dir="$(git rev-parse --git-dir 2>/dev/null)"
 [ "$_git_dir" != "$_git_common" ] && _in_worktree=true
 
 # worktree 또는 main repo 의 절대 경로
+# early-exit 을 이미 거쳤으므로 실패하지 않음 — fallback 불필요
 local _toplevel
-_toplevel="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+_toplevel="$(git rev-parse --show-toplevel)"
 ```
 
 ## 실제 출력 예시

--- a/docs/learnings/git-worktree-detection.md
+++ b/docs/learnings/git-worktree-detection.md
@@ -1,0 +1,85 @@
+# Git worktree 컨텍스트 감지
+
+## Context
+
+- **출처**: [PR #130](https://github.com/dEitY719/dotfiles/pull/130) — `gwt teardown` 에러 메시지에서 "사용자가 main repo 에 있는지 worktree 에 있는지"를 감지해야 했음
+- **커밋**: `de96848`, `6ea9531` (non-repo early-exit 추가)
+- **파일**: `shell-common/functions/git_worktree.sh:567-611`
+
+worktree 관련 헬퍼를 작성할 때 "현재 pwd 가 main repo 인가, 아니면 worktree
+내부인가?"를 구분해야 하는 경우가 자주 생깁니다. 매번 직접 구현하는 것보다
+확립된 3줄 패턴을 재사용하면 됩니다.
+
+## Pattern
+
+`git rev-parse --git-dir` 와 `git rev-parse --git-common-dir` 의 출력이
+**같으면 main repo**, **다르면 worktree** 입니다.
+
+- main repo: `git-dir` == `.git` 디렉토리 == `git-common-dir`
+- worktree: `git-dir` == `.git/worktrees/<name>/` (개별 metadata), `git-common-dir` == `.git` (공유)
+
+두 명령은 git repo 가 아닌 곳에서 실패 (exit 128) 하므로 `||` 로 early-exit 도
+동시에 처리할 수 있습니다.
+
+## Code
+
+```sh
+local _git_common _git_dir _in_worktree=false
+
+# non-repo 에서 early-exit
+_git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+    ux_error "Not inside a git repository"
+    return 1
+}
+
+_git_dir="$(git rev-parse --git-dir 2>/dev/null)"
+[ "$_git_dir" != "$_git_common" ] && _in_worktree=true
+
+# worktree 또는 main repo 의 절대 경로
+local _toplevel
+_toplevel="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+```
+
+## 실제 출력 예시
+
+```sh
+# main repo 안
+$ cd ~/dotfiles
+$ git rev-parse --git-dir
+.git
+$ git rev-parse --git-common-dir
+.git
+# → 같음 → main repo
+
+# worktree 안
+$ cd ~/dotfiles-claude-2
+$ git rev-parse --git-dir
+/home/bwyoon/dotfiles/.git/worktrees/dotfiles-claude-2
+$ git rev-parse --git-common-dir
+/home/bwyoon/dotfiles/.git
+# → 다름 → worktree
+```
+
+## When to use
+
+**적용하기 좋은 경우**
+- worktree 전용 동작과 main repo 전용 동작을 분기하는 헬퍼 함수
+- 에러 메시지에서 "사용자가 잘못된 위치에서 명령을 실행했는지" 판단
+- 같은 명령이 위치에 따라 의미가 달라지는 자체 정리(self-cleanup) 명령
+
+**불필요한 경우**
+- 단순히 repo root 경로만 필요 — `git rev-parse --show-toplevel` 하나로 충분
+- 브랜치 이름만 필요 — `git rev-parse --abbrev-ref HEAD` 로 충분
+
+## 주의점
+
+- `emulate -L sh` 를 쓰는 zsh-호환 POSIX 함수 안에서는 `local` 이 동작 —
+  shellcheck 가 SC3043 를 경고하지만 기존 `git_worktree.sh` 패턴이라 무시 가능
+- `2>/dev/null` 는 필수 — non-repo 에서 stderr 로 `fatal: not a git repository`
+  가 새면 사용자 혼란
+
+## Related
+
+- **구현**: `shell-common/functions/git_worktree.sh:567-611` (`git_worktree_teardown`)
+- **관련 learning**: [`ux-color-hierarchy.md`](./ux-color-hierarchy.md) — 이 감지 결과로 메시지를 분기한 방식
+- **git 문서**: `git-rev-parse(1)` — `--git-dir`, `--git-common-dir`, `--show-toplevel`

--- a/docs/learnings/github-pr-review-reply-api.md
+++ b/docs/learnings/github-pr-review-reply-api.md
@@ -40,10 +40,29 @@ gh api -X POST "repos/OWNER/REPO/issues/N/comments" \
 
 ## 실전 팁
 
-- 코멘트 ID 는 `gh api "repos/OWNER/REPO/pulls/N/comments"` 응답의 `.id` 필드
+- 코멘트 ID 추출 — `--jq` 로 바로 파이프 가능:
+  ```sh
+  gh api "repos/OWNER/REPO/pulls/N/comments" --jq '.[] | {id, user: .user.login, path, line, body}'
+  # 또는 미답변 스레드만 필터
+  gh api "repos/OWNER/REPO/pulls/N/comments" --jq '.[] | select(.in_reply_to_id == null) | .id'
+  ```
 - `pull_request_review_id` 는 리뷰 전체 ID 이지 개별 코멘트 ID 가 **아님** — 혼동 주의
 - 답글은 리뷰어의 언어로 (영어 리뷰 → 영어 답글, 한국어 리뷰 → 한국어 답글)
 - 봇 리뷰도 동일 정책으로 답글을 남김 — 마케팅 메시지도 "Declined: non-actionable" 한 줄 기록해야 감사 이력이 깔끔
+
+## 주의: 리뷰 요약(summary) 답글은 직접 API 가 없음
+
+`/pulls/{n}/reviews` 의 리뷰 바디(gemini-code-assist 가 남기는 "## Code Review" 같은
+전체 요약)에는 **직접 답글 API 가 존재하지 않습니다.** 대응 방법:
+
+1. 요약의 개별 항목이 inline 코멘트로도 존재한다면, 각 inline 스레드에 답글
+   (가장 흔한 경우 — 요약은 자동으로 맥락이 커버됨)
+2. 요약 자체에 actionable 내용이 있고 inline 이 없다면, `/issues/{n}/comments`
+   로 top-level 답글을 남기면서 `> blockquote` 로 요약 발췌를 인용
+3. Non-actionable (마케팅, 인사, 저작권 등) → 간단한 Declined 라벨 한 줄만
+
+이 문서의 "Pattern" 표에서 `/issues/{n}/comments` 를 답글 엔드포인트로 적은
+것이 바로 이 우회 방법입니다.
 
 ## When to use
 

--- a/docs/learnings/github-pr-review-reply-api.md
+++ b/docs/learnings/github-pr-review-reply-api.md
@@ -1,0 +1,68 @@
+# GitHub PR 리뷰 답글 API 엔드포인트 분기
+
+## Context
+
+- **출처**: [PR #130](https://github.com/dEitY719/dotfiles/pull/130) 리뷰 처리 중
+- **관련 스킬**: [`~/.claude/skills/gh-pr-reply/SKILL.md`](../../claude/skills/gh-pr-reply/SKILL.md)
+- **실제 답글 URL 예시**:
+  - inline reply: `https://github.com/dEitY719/dotfiles/pull/130#discussion_r3077014914`
+  - top-level reply: `https://github.com/dEitY719/dotfiles/pull/130#issuecomment-4241171344`
+
+PR 리뷰 코멘트에 답글을 남길 때, **코멘트 종류에 따라 POST 해야 하는 엔드포인트가 다릅니다.**
+잘못 선택하면 답글이 원하는 스레드에 붙지 않아 리뷰어가 답글을 놓치거나,
+top-level 이어야 할 답글이 inline 으로 붙어 맥락이 깨집니다.
+
+## Pattern
+
+PR 에는 세 종류의 "코멘트" 가 있으며 각각 다른 엔드포인트를 씁니다.
+
+| 종류 | 조회 엔드포인트 | 답글 엔드포인트 | 스레드 유지 |
+|---|---|---|---|
+| inline diff 코멘트 | `/pulls/{n}/comments` | `/pulls/{n}/comments/{id}/replies` | O |
+| 리뷰 요약 body | `/pulls/{n}/reviews` | `/issues/{n}/comments` (top-level) | X |
+| 이슈 레벨 PR 코멘트 | `/issues/{n}/comments` | `/issues/{n}/comments` (top-level) | X |
+
+**핵심 직관**:
+- 코멘트가 **diff 의 특정 라인에 고정**되어 있으면 inline → replies 엔드포인트
+- 코멘트가 **PR 전체에 대한 것**이면 top-level → issues/comments
+
+## Code
+
+```sh
+# 1. inline diff 코멘트에 스레드 답글
+gh api -X POST "repos/OWNER/REPO/pulls/N/comments/COMMENT_ID/replies" \
+  -f body="Accepted — fixed in abc1234."
+
+# 2. 리뷰 요약·이슈 코멘트에 top-level 답글
+gh api -X POST "repos/OWNER/REPO/issues/N/comments" \
+  -f body="@reviewer Thanks — ..."
+```
+
+## 실전 팁
+
+- 코멘트 ID 는 `gh api "repos/OWNER/REPO/pulls/N/comments"` 응답의 `.id` 필드
+- `pull_request_review_id` 는 리뷰 전체 ID 이지 개별 코멘트 ID 가 **아님** — 혼동 주의
+- 답글은 리뷰어의 언어로 (영어 리뷰 → 영어 답글, 한국어 리뷰 → 한국어 답글)
+- 봇 리뷰도 동일 정책으로 답글을 남김 — 마케팅 메시지도 "Declined: non-actionable" 한 줄 기록해야 감사 이력이 깔끔
+
+## When to use
+
+**적용**
+- PR 리뷰에 답글을 작성하는 모든 상황 (사람·봇 무관)
+- `/gh-pr-reply` 스킬 실행 중 수동 개입이 필요할 때
+- `gh` CLI 만으로 리뷰를 처리하는 자동화 스크립트 작성 시
+
+**불필요**
+- 웹 UI 에서 직접 답글 작성 — GitHub 이 알아서 올바른 엔드포인트로 보냄
+- 새 PR·이슈 생성 — `gh pr create` / `gh issue create` 는 별도 엔드포인트
+
+## 함정 사례
+
+- `gh pr comment <N> -b "..."` 은 **항상 top-level** 로 붙음 — inline 답글을 의도했다면 사용 금지
+- `/pulls/{n}/comments` 엔드포인트로 **POST** 하면 신규 inline 리뷰 코멘트 생성(기존 스레드에 답글이 아님) — 반드시 `/replies` 경로를 붙여야 함
+
+## Related
+
+- **스킬**: `claude/skills/gh-pr-reply/references/comment-fetching.md`, `reply-templates.md`
+- **GitHub API 문서**: [Review comments](https://docs.github.com/en/rest/pulls/comments), [Issue comments](https://docs.github.com/en/rest/issues/comments)
+- **관련 작업**: PR #130 의 gemini / sourcery 리뷰 답글 처리

--- a/docs/learnings/ux-color-hierarchy.md
+++ b/docs/learnings/ux-color-hierarchy.md
@@ -1,0 +1,62 @@
+# UX 색 계층으로 "읽는 순서" 만들기
+
+## Context
+
+- **출처**: [PR #130](https://github.com/dEitY719/dotfiles/pull/130) — `gwt teardown` 의 path-arg 에러 메시지를 컨텍스트 기반 가이드로 교체
+- **커밋**: `de96848` (초기 설계), `6ea9531` (리뷰 반영)
+- **파일**: `shell-common/functions/git_worktree.sh:592-624`
+
+terse 한 1–2줄 에러로는 사용자가 **왜 잘못했는지**를 재학습하지 못하는 경우가
+많습니다. 이 PR 에서 멀티라인 에러를 설계하면서 색을 3–4단계로 나눠 시각적
+"읽는 순서"를 강제하는 방법을 검증했습니다.
+
+## Pattern
+
+`ux_lib` 의 semantic 함수를 **색 강도 순서대로** 호출해 시선을 자연스럽게 이동시킴:
+
+1. **빨강 (`ux_error`, ❌, bold)** — 최상단 주의 환기 ("뭔가 잘못됐다")
+2. **시안 (`ux_info`, ℹ️)** — 현재 상태 사실 ("당신은 지금 X 에 있다")
+3. **노랑 (`ux_warning`, ⚠️)** — 지키지 못한 원칙 재강조 ("이 명령은 Y 규약이다")
+4. **파랑 (`ux_bullet`, ◆)** — 실행 가능한 대안 ("이렇게 하세요")
+
+한 블록에 3–4개 색이 동시에 있어도 혼잡하지 않은 이유는 **순서가 고정**되어
+있기 때문 — 사용자의 눈은 빨강을 먼저 잡고, 이후 아래로 내려가며 원인·대안을
+순차적으로 읽습니다.
+
+## Code
+
+```sh
+ux_error "'gwt teardown' does not accept a path argument."
+echo ""
+# 사실: 현재 상태
+ux_info "You are in:  main repo ($_gwt_loc)"
+ux_info "You passed:  $1"
+echo ""
+# 원칙 재강조
+ux_warning "'gwt teardown' is SELF-CLEANUP — it tears down the worktree"
+ux_warning "you are currently inside (cd into it first, then run)."
+echo ""
+# 실행 가능한 대안 2개
+ux_info "Did you mean:"
+ux_bullet "cd \"$1\" && gwt teardown     # full cleanup"
+ux_bullet "gwt remove \"$1\"             # remove only"
+```
+
+## When to use
+
+**적용하기 좋은 경우**
+- 멀티라인 에러·가이드 메시지 (3줄 이상)
+- 사용자가 같은 실수를 반복할 가능성이 있는 상황
+- "문제 → 원인·상태 → 원칙 → 대안" 플로우로 설명이 가능할 때
+
+**과할 수 있는 경우**
+- 단순 1줄 에러 (`ux_error` 하나면 충분)
+- 성공 메시지 — 순서 유도 불필요, `ux_success` 하나로
+- 빠른 진행이 핵심인 progress 표시 — 색 계층은 인지 부하를 늘림
+
+## Related
+
+- **가이드라인**: [`shell-common/tools/ux_lib/UX_GUIDELINES.md`](../../shell-common/tools/ux_lib/UX_GUIDELINES.md) — Color Semantics 섹션
+- **스킬**: [`claude/skills/ux-guidelines/README.md`](../../claude/skills/ux-guidelines/README.md)
+- **구현 참조**: `shell-common/functions/git_worktree.sh:592-624` (fix/gwt-teardown-path-error-ux 브랜치)
+- **ux_lib 함수 정의**: `shell-common/tools/ux_lib/ux_lib.sh:131-181`

--- a/docs/learnings/ux-color-hierarchy.md
+++ b/docs/learnings/ux-color-hierarchy.md
@@ -58,5 +58,5 @@ ux_bullet "gwt remove \"$1\"             # remove only"
 
 - **가이드라인**: [`shell-common/tools/ux_lib/UX_GUIDELINES.md`](../../shell-common/tools/ux_lib/UX_GUIDELINES.md) — Color Semantics 섹션
 - **스킬**: [`claude/skills/ux-guidelines/README.md`](../../claude/skills/ux-guidelines/README.md)
-- **구현 참조**: `shell-common/functions/git_worktree.sh:592-624` (fix/gwt-teardown-path-error-ux 브랜치)
+- **구현 참조**: `shell-common/functions/git_worktree.sh` 의 `git_worktree_teardown` 함수 `*)` 분기 — [PR #130](https://github.com/dEitY719/dotfiles/pull/130) 에서 main 에 머지. 라인 번호는 시간이 지나면 바뀔 수 있으므로 함수명으로 찾을 것
 - **ux_lib 함수 정의**: `shell-common/tools/ux_lib/ux_lib.sh:131-181`


### PR DESCRIPTION
## 요약

`docs/learnings/` 를 신규 도입합니다 — **작업 중 얻은 재사용 가능한 패턴 스니펫**을
짧은 글 단위로 축적하는 지식 저장소입니다. 기존 `docs/technic/`(본격 기술 문서)·
`docs/standards/`(SSOT)·`memory/`(Claude 비공개 작업 메모리) 와 역할을 분리하고,
세 곳이 중복 없이 포인터로 연결되도록 `docs/AGENTS.md` 의 규칙을 확장했습니다.

초기 시드로 [PR #130](https://github.com/dEitY719/dotfiles/pull/130) 에서 얻은
Insight 3개를 문서화했습니다.

## 왜

PR 마다 대화에서 쏟아지는 "이거 재사용하고 싶다" 싶은 짧은 패턴들이
`memory/` 에 묻히거나 세션이 끝나면 사라지는 문제가 있었습니다.
`technic/` 에 넣기엔 너무 가볍고, `standards/` 에 넣기엔 SSOT 성격이 아님.
이 간극을 메우는 새 채널이 필요했습니다.

## 디렉토리 경계

| 디렉토리 | 성격 | 분량 | 언어 |
|---|---|---|---|
| `docs/learnings/` (신규) | 재사용 패턴 스니펫 | 50–80줄 | 한국어 |
| `docs/technic/` | 검증된 스택 중심 기술 문서 | 수백 줄 | 한국어 |
| `docs/standards/` | 프로젝트 SSOT·의사결정 기록 | 중간 | 한국어 |
| `memory/` (Claude 비공개) | 세션 간 AI 작업 메모리 | 짧음 | 한국어 |

## 변경

### 1. 신규 `docs/learnings/` (4 files, 316 줄)

- **`README.md`** (101줄) — 인덱스 + 작성 규칙 + 이웃 디렉토리 경계 + 문서 템플릿 + 참조 링크 지침 + 성장 전략
- **`ux-color-hierarchy.md`** (62줄) — 빨강 → 시안 → 노랑 → 파랑 계층으로 멀티라인 에러의 "읽는 순서" 를 설계하는 패턴. PR #130, commit `de96848` 참조
- **`git-worktree-detection.md`** (85줄) — `git rev-parse --git-dir` vs `--git-common-dir` 비교 3줄 패턴. `||` 로 non-repo early-exit 통합. PR #130 참조
- **`github-pr-review-reply-api.md`** (68줄) — inline 리뷰 코멘트 (`/pulls/{n}/comments/{id}/replies`) vs 리뷰 요약·이슈 코멘트 (`/issues/{n}/comments`) 엔드포인트 선택 기준. PR #130 리뷰 답글 처리 경험

### 2. `docs/AGENTS.md` 업데이트 (+27줄)

**Golden Rules 에 3개 규칙 추가**:
- *Learnings vs Technic vs Memory (Boundary Rules)* — 네 지식 저장소의 역할 명시, 중복 금지·포인터 연결 원칙
- *Learnings Reference-Linking Rule* — 모든 learning 에 PR/commit/issue/review URL 중 가능한 참조 포함 (불가능 시 Context 에 상황 구체 기록)
- *Language Policy for Docs* — 동료 개발자용(`learnings/`, `technic/`) = 한국어, AI 지침서(`SKILL.md`) = 영어

**File Descriptions 에 `docs/learnings/` 항목 추가** 및 **Context Map 에 링크 연결**.

### 3. `memory/` 포인터 업데이트 (repo 외부)

이 PR 범위 밖이지만 참고용으로 기록: Claude 메모리에 3개 포인터 엔트리 추가해
`docs/learnings/` 를 참조하도록 했습니다. memory 에 같은 내용을 복사하지 않고
"핵심만 3줄 + 전체 내용은 여기" 식으로 연결합니다.

## 검증

- [x] 마크다운 구조 검토: ATX 헤더, 코드 블록 언어 태그, 상대 경로 링크 일관성
- [x] 5개 파일 모두 `docs/AGENTS.md` 의 markdown 포맷팅 규칙 준수
- [x] 참조 링크 유효성 확인 (PR #130, commit 해시, 파일 경로)
- [x] `docs/AGENTS.md` 500줄 미만 유지 확인
- [x] pre-commit 훅 통과

## 기대 효과

- 다음에 shell UX 설계 / worktree 헬퍼 작성 / PR 리뷰 답글 처리 상황이 오면,
  Claude 와 개발자 모두 `docs/learnings/` 를 먼저 조회해 이미 검증된 패턴을
  재사용할 수 있습니다
- `memory/` 가 비대해지는 것을 방지 (포인터만 유지)
- 새로운 learning 이 생길 때 일관된 5-섹션 템플릿으로 빠르게 추가 가능

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
