### PR TITLE
feat(gbr): add gbr teardown for post-merge branch cleanup

### DIFF
--- a/shell-common/aliases/git.sh
+++ b/shell-common/aliases/git.sh
@@ -81,3 +81,6 @@ alias hook-check='hook_check'                     # Git hook 설정 진단 (hook
 
 # Git worktree (gwt is a function in functions/git.sh)
 # Usage: gwt add|list|remove|spawn|teardown [args...]
+
+# Git branch teardown (gbr is a function in functions/git_branch.sh)
+# Usage: gbr teardown [--force] [--keep-branch]

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -107,13 +107,26 @@ git_branch_teardown() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            -h|--help)
+            -h|--help|help)
                 ux_header "gbr teardown - feature branch cleanup after PR merge"
                 ux_info "Usage: gbr teardown [--force] [--keep-branch]"
+                ux_info ""
+                ux_info "Concept: SELF-CLEANUP on the CURRENT branch."
+                ux_info "  Stand on the branch, run teardown, land on main."
                 ux_info ""
                 ux_info "Options:"
                 ux_info "  --force        delete branch even if upstream still exists or not fully merged"
                 ux_info "  --keep-branch  sync main only, keep the current branch"
+                ux_info ""
+                ux_info "Typical flow (single branch):"
+                ux_bullet "gbr teardown                           # current branch, after PR merge"
+                ux_info ""
+                ux_info "Backlog of N merged PRs (order-independent):"
+                ux_bullet "git fetch --prune"
+                ux_bullet "git checkout <br1> && gbr teardown"
+                ux_bullet "git checkout <br2> && gbr teardown"
+                ux_info ""
+                ux_info "See also: 'gbr-help teardown' for the summary table."
                 return 0
                 ;;
             --force) force=true; shift ;;

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# shell-common/functions/git_branch.sh
+# Git branch management — feature-branch cleanup (gbr teardown)
+# Mirrors shell-common/functions/git_worktree.sh (gwt) design for consistency.
+
+# Override Oh My Zsh's `gbr` alias (zsh git plugin sets it to `git branch --remote`)
+unalias gbr 2>/dev/null || true
+
+# ============================================================================
+# gbr-help — compact help (canonical)
+# Usage: gbr-help [section|--list|--all]
+# ============================================================================
+_gbr_help_summary() {
+    ux_info "Usage: gbr-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "teardown: gbr teardown [--force] [--keep-branch]"
+    ux_bullet_sub "details: gbr-help <section> (example: gbr-help teardown)"
+}
+
+_gbr_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "teardown"
+}
+
+_gbr_help_rows_teardown() {
+    ux_table_row "syntax" "gbr teardown [--force] [--keep-branch]" "Cleanup merged feature branch"
+    ux_table_row "context" "Run from the feature branch (not main, not worktree)" "Switches to main, pulls, deletes current branch"
+    ux_table_row "signal" "Detects '[gone]' upstream as PR-merged" "Blocks otherwise; use --force to override"
+    ux_table_row "flags" "--force / --keep-branch" "Skip safety checks / sync main only"
+}
+
+_gbr_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gbr_help_section_rows() {
+    case "$1" in
+        teardown)
+            _gbr_help_rows_teardown
+            ;;
+        *)
+            ux_error "Unknown gbr-help section: $1"
+            ux_info "Try: gbr-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_gbr_help_full() {
+    ux_header "Git Branch Commands"
+    _gbr_help_render_section "Teardown" _gbr_help_rows_teardown
+}
+
+gbr_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _gbr_help_summary
+            ;;
+        --list|list|section|sections)
+            _gbr_help_list_sections
+            ;;
+        --all|all)
+            _gbr_help_full
+            ;;
+        *)
+            _gbr_help_section_rows "$1"
+            ;;
+    esac
+}
+
+# ============================================================================
+# gbr — git branch dispatcher
+# Usage: gbr <subcommand> [args...]
+# ============================================================================
+gbr() {
+    case "${1:-}" in
+        teardown) shift; git_branch_teardown "$@" ;;
+        -h|--help|help|"")
+            ux_error "Usage: gbr <command> [args...]"
+            ux_info "Run: gbr-help"
+            return 1
+            ;;
+        *)
+            ux_error "Unknown command: $1"
+            ux_info "Run: gbr-help"
+            return 1
+            ;;
+    esac
+}
+
+# ============================================================================
+# Branch teardown — feature-branch cleanup after PR merge
+#   1. Switch to main
+#   2. Pull origin main (fast-forward)
+#   3. Delete the just-merged feature branch
+#
+# Usage: git_branch_teardown [--force] [--keep-branch]
+# ============================================================================
+git_branch_teardown() {
+    # zsh compatibility: strict POSIX sh
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local force=false keep_branch=false
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                ux_header "gbr teardown - feature branch cleanup after PR merge"
+                ux_info "Usage: gbr teardown [--force] [--keep-branch]"
+                ux_info ""
+                ux_info "Options:"
+                ux_info "  --force        delete branch even if upstream still exists or not fully merged"
+                ux_info "  --keep-branch  sync main only, keep the current branch"
+                return 0
+                ;;
+            --force) force=true; shift ;;
+            --keep-branch) keep_branch=true; shift ;;
+            -*)
+                ux_error "Unknown option: $1. Use --help for usage."
+                return 1
+                ;;
+            *)
+                ux_error "'gbr teardown' does not accept a path argument."
+                echo ""
+                ux_info "This command is SELF-CLEANUP — it operates on the CURRENT branch."
+                echo ""
+                ux_info "Did you mean:"
+                ux_bullet "git checkout \"$1\" && gbr teardown     # switch first, then cleanup"
+                return 1
+                ;;
+        esac
+    done
+
+    # Must be in a git repo, NOT inside a worktree (worktree has gwt teardown)
+    local git_common git_dir
+    git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        ux_error "Not inside a git repository"
+        return 1
+    }
+    git_dir="$(git rev-parse --git-dir 2>/dev/null)"
+    if [ "$git_dir" != "$git_common" ]; then
+        ux_error "Inside a worktree — use 'gwt teardown' instead."
+        echo ""
+        ux_info "'gbr teardown' is for normal feature branches in the main repo."
+        ux_info "'gwt teardown' cleans up worktrees (remove + sync main + delete branch)."
+        return 1
+    fi
+
+    # Resolve current branch
+    local branch
+    branch="$(git symbolic-ref --short HEAD 2>/dev/null)" || {
+        ux_error "Detached HEAD — nothing to tear down."
+        return 1
+    }
+
+    # Determine main branch name (main preferred, master fallback)
+    local main_branch="main"
+    if ! git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
+        main_branch="master"
+    fi
+
+    # Block if already on main/master
+    if [ "$branch" = "$main_branch" ]; then
+        ux_error "Already on '$main_branch' — nothing to tear down."
+        echo ""
+        ux_warning "'gbr teardown' deletes the CURRENT branch after syncing main."
+        ux_warning "Running it on '$main_branch' itself would be destructive."
+        echo ""
+        ux_info "Did you mean:"
+        ux_bullet "git checkout <feature-branch> && gbr teardown"
+        return 1
+    fi
+
+    # Pre-flight: uncommitted changes
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        if [ "$force" = true ]; then
+            ux_warning "Uncommitted changes present (--force)"
+        else
+            ux_error "Uncommitted changes. Commit, stash, or use --force."
+            return 1
+        fi
+    fi
+
+    # Upstream check — `[gone]` means remote branch was deleted (PR merge signal)
+    if [ "$force" != true ]; then
+        local upstream_ref upstream_track
+        upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)" || upstream_ref=""
+        upstream_track="$(git for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null)"
+
+        if [ -z "$upstream_ref" ]; then
+            ux_error "Branch '$branch' has no upstream — never pushed?"
+            ux_info "Push and open a PR first, or use --force to delete anyway."
+            return 1
+        fi
+
+        case "$upstream_track" in
+            *gone*)
+                : # expected: upstream deleted after PR merge
+                ;;
+            *)
+                ux_error "Upstream '$upstream_ref' still exists — PR not merged yet?"
+                ux_info "Track status: ${upstream_track:-up-to-date}"
+                ux_info "Fetch first (git fetch --prune) or use --force to override."
+                return 1
+                ;;
+        esac
+    fi
+
+    # Switch to main
+    if ! git checkout "$main_branch" 2>/dev/null; then
+        ux_error "Failed to checkout $main_branch."
+        return 1
+    fi
+
+    # Pull main (fast-forward)
+    if ! git pull origin "$main_branch"; then
+        ux_warning "Pull failed (network?). Branch delete may misjudge merge status."
+    fi
+
+    # Delete branch
+    if [ "$keep_branch" = true ]; then
+        ux_info "Branch kept: $branch (--keep-branch)"
+    elif git branch -d "$branch" 2>/dev/null; then
+        : # safe-deleted
+    elif [ "$force" = true ]; then
+        git branch -D "$branch" 2>/dev/null || {
+            ux_error "Failed to force-delete branch '$branch'."
+            return 1
+        }
+    else
+        ux_warning "Branch '$branch' not fully merged into $main_branch. Use --force or --keep-branch."
+        return 1
+    fi
+
+    ux_success "Teardown complete"
+    ux_info "  Deleted: $branch"
+    ux_info "  Now on:  $main_branch"
+}
+
+alias gbr-help='gbr_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -156,7 +156,7 @@ _register_default_help_categories() {
     HELP_CATEGORIES[system]="${HELP_CATEGORIES[system]:-System tools (directory navigation, opencode)}"
 
     # Category membership (space-separated topic keys)
-    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt uv py nvm npm bun pp cli ux du psql mytool}"
+    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr uv py nvm npm bun pp cli ux du psql mytool}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
@@ -195,6 +195,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[uv_help]="${HELP_DESCRIPTIONS[uv_help]:-[Development] UV packages and environments}"
     HELP_DESCRIPTIONS[git_help]="${HELP_DESCRIPTIONS[git_help]:-[Development] Git version control shortcuts}"
     HELP_DESCRIPTIONS[gwt_help]="${HELP_DESCRIPTIONS[gwt_help]:-[Development] Git worktree command guide}"
+    HELP_DESCRIPTIONS[gbr_help]="${HELP_DESCRIPTIONS[gbr_help]:-[Development] Git feature-branch teardown guide}"
     HELP_DESCRIPTIONS[py_help]="${HELP_DESCRIPTIONS[py_help]:-[Development] Python environments and tooling}"
     HELP_DESCRIPTIONS[dir_help]="${HELP_DESCRIPTIONS[dir_help]:-[System] Directory navigation shortcuts}"
     HELP_DESCRIPTIONS[sys_help]="${HELP_DESCRIPTIONS[sys_help]:-[DevOps] System management helpers}"

--- a/shell-common/functions/zz_help_standard_adapter.sh
+++ b/shell-common/functions/zz_help_standard_adapter.sh
@@ -154,7 +154,7 @@ _help_std_wrap_one() {
     _help_std_define_zsh_dash_function "$alias_name" "$func_name"
 
     case "$func_name" in
-        git_help|gwt_help)
+        git_help|gwt_help|gbr_help)
             alias "${alias_name}=${func_name}" 2>/dev/null || true
             return 0
             ;;
@@ -183,6 +183,7 @@ _help_std_wrap_topics() {
     done <<'EOF'
 git
 gwt
+gbr
 uv
 py
 nvm


### PR DESCRIPTION
## Summary
- `gwt teardown` 과 대칭되는 `gbr teardown` 명령 추가 — PR merge 후 일반 feature 브랜치를 한 번에 정리.
- `[gone]` upstream 감지로 PR merge 여부를 네트워크 없이 판단, 미merge 브랜치 실수 삭제 방지.
- help 디스커버리(`my_help`, `zz_help_standard_adapter`, aliases 포인터) 3곳에 gwt 와 동일 패턴으로 등록.

## Changes
- **`shell-common/functions/git_branch.sh` (신규)**: `gbr` dispatcher + `gbr_help` (summary/list/teardown/--all) + `git_branch_teardown()` 구현. 11단계 safety layer (path-arg 거부, non-repo, worktree 내부면 gwt 로 redirect, detached HEAD, main 차단, uncommitted, no upstream, `[gone]` 아님, checkout 실패, pull 실패 경고, non-merged 브랜치). `--force` / `--keep-branch` 플래그는 gwt teardown 과 동일 스펙.
- **`shell-common/functions/my_help.sh`**: `HELP_CATEGORY_MEMBERS[development]` 에 `gbr` 추가, `HELP_DESCRIPTIONS[gbr_help]` 등록.
- **`shell-common/functions/zz_help_standard_adapter.sh`**: alias-preserve whitelist 에 `gbr_help` 추가, wrap-topics 목록에 `gbr` 추가.
- **`shell-common/aliases/git.sh`**: `gbr` 사용법 포인터 주석 (gwt 주석과 동일 스타일).

## Test plan
- [x] bash + zsh 양쪽에서 문법 검사 (`bash -n`, `zsh -n`) 통과
- [x] path-arg 거부 메시지 + rc=1 확인
- [x] no-upstream 브랜치 차단 확인
- [x] main/master 위에서 차단 + destructive 경고 확인
- [x] `--force` 전체 flow 실행 (checkout master → pull 실패 경고 → branch 삭제 → rc=0)
- [x] `gbr-help`, `gbr-help teardown`, `gbr-help --all` 렌더링 확인
- [x] `shellcheck -s sh`: SC3043 (POSIX `local`) 만 발생 — `git_worktree.sh` 기존 패턴과 동일, 의도된 무시
- [ ] 실제 PR merge 후 리얼 시나리오에서 `[gone]` 감지 + main 동기화 + 브랜치 삭제 end-to-end 검증 (본 PR merge 후 다음 작업에서 확인)

## Related
Closes #132

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
