### PR TITLE
feat(skill): add write:insight + record colon naming convention

### DIFF
--- a/claude/skills/skill-check/SKILL.md
+++ b/claude/skills/skill-check/SKILL.md
@@ -41,10 +41,13 @@ WARN — mostly workflow but some templates/tables inline
 FAIL — large reference content embedded directly in SKILL.md
 
 **Check 3: Frontmatter Validity**
-Look for: `name` present (colons allowed as namespace separator, e.g. `skill:check`),
-`description` present, only known attributes present.
+Look for: `name` present, `description` present, only known attributes present.
 Known attributes: `name`, `description`, `allowed-tools`, `compatibility`,
 `metadata`, `user-invocable`, `argument-hint`, `disable-model-invocation`, `license`.
+**Naming**: read `references/naming-convention.md` — `category:action` colon
+form is the SSOT convention and reports as PASS, not WARN. Folder/name
+kebab-vs-colon mismatch is also PASS when folder is the kebab form of the
+colon name (e.g., `name: gh:pr` + folder `gh-pr/`).
 PASS — valid | WARN — minor issues | FAIL — missing fields or unknown attributes
 
 **Check 4: References Directory Usage**

--- a/claude/skills/skill-check/references/naming-convention.md
+++ b/claude/skills/skill-check/references/naming-convention.md
@@ -1,0 +1,59 @@
+# Skill Naming Convention — `category:action` Colon Form Preferred
+
+This user's SSOT (`~/dotfiles/claude/skills/`) uses **`category:action`** in
+the `name:` frontmatter field, and the **kebab form** for the folder name.
+The colon is intentional. Audits must report it as PASS, not WARN.
+
+## Rule
+
+| frontmatter `name:` | folder name |
+|---|---|
+| `gh:commit` | `gh-commit/` |
+| `gh:pr` | `gh-pr/` |
+| `gh:pr-reply` | `gh-pr-reply/` |
+| `gh:issue` | `gh-issue/` |
+| `skill:refactor` | `skill-refactor/` |
+| `skill:check` | `skill-check/` |
+| `skill:create` | `skill-create/` |
+| `ai-worktree:spawn` | `ai-worktree-spawn/` |
+| `ai-worktree:teardown` | `ai-worktree-teardown/` |
+| `write:insight` | `write-insight/` |
+
+14+ skills already follow this form. Mixing kebab and colon fragments the
+mental model.
+
+## Why colon
+
+- **Memorable grouping**: `gh:*` = GitHub actions, `skill:*` = skill
+  maintenance, `ai-worktree:*` = worktree lifecycle. Users tab-complete
+  or recall by category.
+- **User-stated preference** (2026-04): "category:actions 형태는 기억하기
+  쉬운 이점이 있음."
+
+## Common false alarms — DO NOT downgrade to WARN/FAIL on these
+
+- **VS Code Anthropic Agent extension** flags `name: foo:bar` and
+  `name`/folder mismatch as diagnostics. These are **cosmetic only** —
+  Claude Code CLI accepts both, and 14+ live skills prove it.
+- **Anthropic-published skills** (`document-skills/*`) use kebab-only.
+  That is Anthropic's house style, not a CLI requirement. The user's SSOT
+  has its own convention.
+- **"Verb-first names not allowed"** is a myth. `write:insight` works
+  fine — any rejection some tool cites is purely the colon character, not
+  the verb.
+
+## Audit rule for Check 3 (Frontmatter Validity)
+
+- Colon in `name:` → **PASS**.
+- Folder/name kebab-vs-colon mismatch → **PASS** when the folder is the
+  kebab form of the colon name (e.g., `name: gh:pr` + folder `gh-pr/`).
+- Only flag when the skill's `name:` deviates from BOTH conventions
+  (neither colon SSOT form nor consistent kebab) — that is genuine
+  inconsistency.
+
+## History
+
+This file exists because the colon-naming question came up twice in
+quick succession (2026-04). The first time, the assistant proposed
+kebab "fix" based on a VS Code diagnostic; the user pushed back with the
+correct reasoning. Recording here so the same mistake is not made again.

--- a/claude/skills/skill-refactor/SKILL.md
+++ b/claude/skills/skill-refactor/SKILL.md
@@ -53,6 +53,10 @@ After confirmation:
 
 **3b. Rewrite SKILL.md**
 - Keep frontmatter unchanged (fix only if frontmatter has issues)
+- **Naming**: never silently rewrite `name: foo:bar` → `foo-bar` to "fix"
+  a VS Code diagnostic. Read `references/naming-convention.md` if the
+  skill uses `category:action` colon form — that is the SSOT convention,
+  preserve it byte-for-byte.
 - Replace extracted blocks with pointer lines:
   `Read references/<filename>.md when <trigger condition>.`
 - Compress step descriptions to action-oriented one-liners

--- a/claude/skills/skill-refactor/references/naming-convention.md
+++ b/claude/skills/skill-refactor/references/naming-convention.md
@@ -1,0 +1,68 @@
+# Skill Naming Convention — `category:action` Colon Form Preferred
+
+This user's SSOT (`~/dotfiles/claude/skills/`) uses **`category:action`** in
+the `name:` frontmatter field, and the **kebab form** for the folder name.
+The colon is intentional and should be preserved across refactors.
+
+## Rule
+
+| frontmatter `name:` | folder name |
+|---|---|
+| `gh:commit` | `gh-commit/` |
+| `gh:pr` | `gh-pr/` |
+| `gh:pr-reply` | `gh-pr-reply/` |
+| `gh:issue` | `gh-issue/` |
+| `skill:refactor` | `skill-refactor/` |
+| `skill:check` | `skill-check/` |
+| `skill:create` | `skill-create/` |
+| `ai-worktree:spawn` | `ai-worktree-spawn/` |
+| `ai-worktree:teardown` | `ai-worktree-teardown/` |
+| `write:insight` | `write-insight/` |
+
+14+ skills already follow this form. Mixing kebab and colon fragments the
+mental model.
+
+## Why colon
+
+- **Memorable grouping**: `gh:*` = GitHub actions, `skill:*` = skill
+  maintenance, `ai-worktree:*` = worktree lifecycle. Users tab-complete or
+  recall by category.
+- **User-stated preference** (2026-04): "category:actions 형태는 기억하기
+  쉬운 이점이 있음."
+
+## Common false alarms — DO NOT act on these
+
+- **VS Code Anthropic Agent extension** flags `name: foo:bar` and
+  `name`/folder mismatch as diagnostics. These are **cosmetic only** —
+  Claude Code CLI accepts both, and 14+ live skills prove it.
+- **Anthropic-published skills** (`document-skills/*`) use kebab-only.
+  That is Anthropic's house style, not a CLI requirement. The user's SSOT
+  has its own convention.
+- **"Verb-first names not allowed"** is a myth. `write:insight` works
+  fine — any rejection some tool cites is purely the colon character, not
+  the verb.
+
+## Refactor rule
+
+When refactoring (Step 3b "Keep frontmatter unchanged"):
+
+- **Never silently rewrite `name: foo:bar` → `foo-bar`** to "fix" a
+  diagnostic. If the skill already follows the SSOT colon convention,
+  preserve it byte-for-byte.
+- The folder being kebab while `name:` is colon is **not a mismatch to
+  fix** — it is the convention.
+- If the user explicitly asks to switch to kebab, do it. Otherwise
+  preserve the colon form.
+
+## Audit rule (mirrors `skill:check` Check 3)
+
+- Colon in `name:` → **PASS**, not WARN.
+- Folder/name kebab-vs-colon mismatch → **PASS** when the folder is the
+  kebab form of the colon name.
+
+## History
+
+This file exists because the colon-naming question came up twice in
+quick succession (2026-04). The first time, the assistant proposed
+kebab "fix" based on a VS Code diagnostic; the user pushed back with the
+correct reasoning. Recording here so the same mistake is not made again.

--- a/claude/skills/write-insight/SKILL.md
+++ b/claude/skills/write-insight/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: write:insight
+description: >-
+  Archive a reusable insight from the current conversation as a short Korean
+  learning note under `docs/learnings/<slug>.md`, following this repo's
+  README.md conventions (5-section template, 50–80 lines, source links to
+  PR / commit / file:line). Use when the user runs `/write:insight`,
+  `/write-insight`, or asks "이 내용 learning 으로 정리해줘", "방금 발견한 거
+  learnings 에 남겨", "insight 아카이브해줘", or otherwise wants to capture a
+  concrete pattern, debugging path, or review-driven discovery from the chat.
+  Pulls source material from the live conversation (recent PRs, commits,
+  review threads, repro experiments) rather than asking the user to retype
+  it. Refuses topics that belong in `docs/technic/`, `docs/standards/`,
+  `docs/feature/`, or `claude/skills/` and routes them to the correct home.
+  Do NOT trigger for narrative "삽질" blog posts (use `write-blog-dev-learnings`),
+  formal RCA postmortems (use `write-rca-doc`), or JIRA/PR description drafts
+  (use `write-task-history`) — those write to `~/para/archive/`. This skill
+  writes inside the current repo's `docs/learnings/` and is repo-specific.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+# write:insight — Conversation → docs/learnings/ note
+
+If the argument is `help`, read `references/help.md` and output it verbatim, then stop.
+
+## Role
+
+Capture one reusable insight from the current chat as a short Korean note in
+`<repo-root>/docs/learnings/`. Source comes from the conversation — don't make
+the user retype what they already lived through. Output one file path + one-line
+summary at the end, nothing else.
+
+## Step 1: Resolve repo + read the rulebook
+
+In parallel: `git rev-parse --show-toplevel`, read `<repo-root>/docs/learnings/README.md`,
+list existing notes. If `docs/learnings/` is missing, stop — this skill is repo-specific.
+The README is SSOT for template/length/language; re-read it every run.
+
+## Step 2: Identify the candidate
+
+With a hint (`/write:insight <hint>`): anchor on it. Without: propose 1–3 candidates
+from recent turns with one-line previews and let the user pick. Don't draft speculatively.
+
+Read `references/routing.md` to check whether the candidate actually belongs in
+`docs/learnings/`. If it fits a neighbor directory or sibling write-* skill, decline
+using the phrasing template there.
+
+## Step 3: Check for overlap
+
+`grep -li '<keywords>' docs/learnings/*.md` — if a real overlap exists, recommend
+updating the existing file instead. Same check against `~/.claude/projects/*/memory/MEMORY.md`
+when accessible: learnings holds the body, memory keeps a one-line pointer.
+
+## Step 4: Mine the conversation for sources
+
+Extract from chat: PR numbers, commit SHAs, issue numbers, review URLs
+(`discussion_r...`), file paths with line ranges. A learning without provenance
+is forgettable trivia — if extraction yields nothing, the Context section must
+state the concrete situation ("발견 상황: …"), not vague claims.
+
+## Step 5: Draft the note
+
+Read `references/template.md` for section structure, length policy, filename rules,
+and bonus-section criteria. Read `references/examples.md` for tone anchors from the
+three notes already in repo. Filename names the **pattern**, not the action.
+Target 50–80 lines; past 150 → recommend `docs/technic/` instead.
+
+## Step 6: Write the file + update README index
+
+Write `docs/learnings/<slug>.md`. Edit `docs/learnings/README.md` "현재 문서 목록"
+section: append a numbered entry matching the existing 3-line format (heading link
++ 2–3 line summary).
+
+## Step 7: Suggest a memory pointer (don't auto-create)
+
+If the insight is cross-session reusable, ask: `memory/reference_learnings_<slug>.md`
+포인터 추가할까요? (한 줄짜리, 본문은 learnings, memory 는 경로만). Wait for yes —
+`MEMORY.md` is loaded into every session, churn there is expensive.
+
+## Step 8: Report
+
+Output exactly two lines, no preamble, no recap:
+
+```
+docs/learnings/<slug>.md (<N> lines)
+<one-line summary — the same hook used in README index>
+```
+
+## Constraints
+
+- **Korean body, English headings** — note is for human teammates per README's language policy.
+- **No abstract generalities** — no PR/commit/file:line link → reject. Back to Step 4 or decline.
+- **Don't paraphrase the README** — re-read every run; if rules conflict, README wins.
+- **One file per invocation** — multiple insights → pick one, offer the rest as a follow-up run.
+- **Never auto-write to `memory/`** — suggest, wait for confirmation.
+- **Never overwrite silently** — existing slug → surface diff, ask update vs. new slug.

--- a/claude/skills/write-insight/references/examples.md
+++ b/claude/skills/write-insight/references/examples.md
@@ -1,0 +1,54 @@
+# Tone & Structure Anchors
+
+The three notes already in `docs/learnings/` define what "good" looks like
+for this skill. Read them before drafting; match their depth, density, and
+rhythm — don't invent a new style.
+
+## Existing notes (as of skill creation)
+
+| File | Lines | What it nails |
+|---|---|---|
+| `docs/learnings/ux-color-hierarchy.md` | 62 | Tight Pattern (numbered color levels) + concrete `ux_*` example block + symmetric apply / don't-apply pairs |
+| `docs/learnings/git-worktree-detection.md` | 86 | Diagnostic comparison ("같으면 main repo, 다르면 worktree"), bonus "실제 출력 예시" + "주의점" sections that earn their place |
+| `docs/learnings/github-pr-review-reply-api.md` | 87 | Three-endpoint table, real `gh api` invocations, threading rule explained from first principles |
+
+## Patterns worth copying
+
+**Context section opens with bulleted source links.** All three start with
+`- **출처**: [PR #N](...)` then `- **커밋**: <sha>` then `- **파일**: <path:line>`.
+This is the spine — without it the note degrades into folklore.
+
+**Pattern is short.** 1–3 sentences or a short numbered list. If the
+Pattern section grows into multiple paragraphs, the insight isn't a
+"learning", it's a tutorial — route to `docs/technic/`.
+
+**Code is minimal and runnable.** No imports of fictional helpers, no
+`...` ellipses inside the snippet. A reader pasting the block should see
+something that runs (or, for shell, sources cleanly).
+
+**When to use is two columns of intent.** Apply conditions and don't-apply
+conditions live as parallel bullet lists. The don't-apply column matters
+more — it's what stops cargo-culting.
+
+**Related is for navigation, not citation.** Link to:
+- the implementation file (function name preferred over line number — line
+  numbers rot)
+- adjacent learnings that compose with this one
+- the upstream doc / man page if the pattern relies on documented behavior
+
+## Anti-patterns to avoid
+
+- **No PR/commit anywhere** → not a learning, it's a vibe. Reject.
+- **Pattern section explains the code line-by-line** → the code already
+  does that. Pattern explains *why* the code is shaped that way.
+- **150+ lines** → README's growth strategy says promote to `docs/technic/`.
+- **Copy-pasted shell session as the entire body** → distill the pattern
+  out; the session is at most a "실제 출력 예시" bonus.
+- **Generic title like "Git tips"** → titles name the specific pattern
+  ("Git worktree 컨텍스트 감지", not "Git stuff I learned").
+
+## Length calibration
+
+If you have to ask "is this enough detail?" — it probably is. Existing
+notes hit 60–90 lines including frontmatter and blank lines. Aim for
+that band; let the content decide whether you land at 55 or 85.

--- a/claude/skills/write-insight/references/help.md
+++ b/claude/skills/write-insight/references/help.md
@@ -1,0 +1,44 @@
+# write:insight — help
+
+## Usage
+
+```
+/write:insight [topic-hint]
+/write-insight [topic-hint]
+```
+
+## Arguments
+
+- `topic-hint` (optional) — a phrase anchoring which insight from the
+  current chat to capture. If omitted, the skill scans recent turns and
+  proposes 1–3 candidates for you to pick.
+
+## What it does
+
+Archives one reusable insight from the current conversation as a short
+Korean note in `<repo-root>/docs/learnings/<slug>.md`, following the
+repo's README-defined template (5 sections, 50–80 lines, source links to
+PR / commit / file:line). Also updates `docs/learnings/README.md` index.
+
+## Examples
+
+```
+/write:insight                       # propose candidates from recent chat
+/write:insight upstream short        # focus on the %(upstream:short) finding
+/write:insight gh deprecation        # focus on the gh CLI deprecation workaround
+```
+
+## Related skills
+
+- `write-blog-dev-learnings` — narrative "삽질" blog posts in `~/para/archive/`
+- `write-rca-doc` — formal RCA / postmortem (Jekyll)
+- `write-task-history` — JIRA / PR description drafting from session work
+
+If your intent matches one of those, use that skill instead — write:insight
+is for short, repo-internal technical patterns aimed at human teammates.
+
+## Refuses to write
+
+See `references/routing.md`. Topics belonging in `docs/technic/`,
+`docs/standards/`, `docs/feature/<name>/`, `claude/skills/`, or `memory/`
+are routed to the correct home instead of forced into `docs/learnings/`.

--- a/claude/skills/write-insight/references/routing.md
+++ b/claude/skills/write-insight/references/routing.md
@@ -1,0 +1,44 @@
+# Routing — When to decline and where to send the user instead
+
+`docs/learnings/` is one home among several for technical writing in this
+repo. A learning is the **smallest unit**: a 50–80 line snippet pulled
+from a single concrete experience. If the candidate is bigger, more
+formal, or for a different audience, refuse and route.
+
+## Neighbor-directory map
+
+| Material | Belongs in | Why it's not a learning |
+|---|---|---|
+| Long-form tech doc, hundreds of lines | `docs/technic/` | learning is a 50–80 line snippet, not a manual |
+| Project SSOT / decision record / policy | `docs/standards/` | standards are normative ("we do X"), learnings are experiential ("we discovered X works") |
+| Feature design bundle (multi-file, diagrams) | `docs/feature/<name>/` | feature dirs hold many artifacts together; learnings are single files |
+| AI behavior instructions | `claude/skills/<name>/SKILL.md` (English) | learnings are for human teammates; SKILL files are for AI |
+| User preference / collaboration style | `memory/` (auto-memory) | memory is private to Claude sessions, learnings are public |
+
+If a candidate fits one of these rows, decline the write and tell the
+user the right home in one sentence.
+
+## Sibling write-* skills (same `~/dotfiles/claude/skills/`, different output target)
+
+These are the other "write" skills the user has installed. Hand off to
+them when the request is clearly their territory — don't try to bend
+write-insight to cover them.
+
+| Skill | Output target | Use it when |
+|---|---|---|
+| `write-blog-dev-learnings` | `~/para/archive/playbook/docs/dev-learnings/` | User wants a narrative "삽질" blog post in entertaining tone |
+| `write-rca-doc` | `~/para/archive/rca-knowledge/` | User wants a formal RCA / postmortem with Jekyll frontmatter |
+| `write-task-history` | daily task list file | User wants JIRA ticket text or PR description draft from session work |
+
+The discriminator is **where the file lands**. write-insight always
+writes inside the **current repo's** `docs/learnings/`; the siblings
+write to `~/para/archive/` or task lists. If the user has any doubt,
+confirm the destination before drafting.
+
+## Decline phrasing template
+
+When refusing, name the right home explicitly so the user can pivot:
+
+> 이 내용은 learnings (`docs/learnings/`) 보다는 **`<target>`** 에 더 맞을 것
+> 같습니다 — 이유: `<one-line reason from the table above>`. 거기로 작성을
+> 진행할까요?

--- a/claude/skills/write-insight/references/template.md
+++ b/claude/skills/write-insight/references/template.md
@@ -1,0 +1,68 @@
+# Template — Section structure, length policy, filename rules
+
+This is the schema for a learning note. The repo's
+`docs/learnings/README.md` is the upstream authoritative source — re-read
+it at the start of every run (Step 1). This file is a fast-path summary
+of what to put where, derived from that README.
+
+## Filename
+
+`<repo-root>/docs/learnings/<slug>.md`
+
+- `<slug>` is descriptive, lowercase, kebab-case
+- Specific over generic: `git-worktree-detection.md` ✓ — `git-tips.md` ✗
+- Verb-free nouns: name the **pattern**, not the action
+
+## Frontmatter
+
+None. Learning notes are pure markdown — no YAML block. The README
+itself has no frontmatter; match it.
+
+## Required sections (in order)
+
+Headings stay English (`## Context`, `## Pattern`, …) per the in-repo
+convention; body is Korean.
+
+1. **`## Context`** — sources first, situation second
+   - Bulleted source links: `- **출처**: [PR #N](url)` then `- **커밋**: <sha>` then `- **파일**: <path:line>`
+   - Then 1–3 sentences on what discovery prompted this note
+2. **`## Pattern`** — the core principle in 1–3 sentences or a short
+   numbered list. Explains *why* the code is shaped this way, not *what*
+   the code does. If this section grows past one paragraph, the insight
+   is a tutorial — route to `docs/technic/`.
+3. **`## Code`** — the smallest copy-pastable example, language tag
+   included (` ```sh `, ` ```python `, …). No fictional helpers, no `...`
+   ellipses inside the snippet.
+4. **`## When to use`** — apply / don't-apply as parallel bullet lists.
+   The don't-apply column matters more — it's what stops cargo-culting.
+5. **`## Related`** — navigation, not citation:
+   - Implementation file (function name preferred over line number)
+   - Adjacent learnings that compose with this one
+   - Upstream doc / man page if relevant
+
+## Optional bonus sections
+
+Two patterns from existing notes — use only when they pull their weight:
+
+- **`## 실제 출력 예시`** — concrete shell session showing the diagnostic
+  outputs the Pattern section described. Useful when the pattern is a
+  comparison ("if A == B then X").
+- **`## 주의점`** — non-obvious gotchas that didn't fit cleanly under
+  Pattern (zsh quirks, shellcheck SC codes, side effects).
+
+Don't pad. If a note has both bonus sections plus the 5 required ones, the
+content had better justify the length.
+
+## Length policy
+
+| Range | Action |
+|---|---|
+| 50–80 lines | Target. Existing notes hit 60–90 incl. blanks. |
+| 80–150 lines | OK if content earns it. Resist padding to look thorough. |
+| 150+ lines | Stop. Recommend `docs/technic/` instead. The repo's README growth-strategy section says so. |
+
+## Tone anchors
+
+Read `references/examples.md` for the tone/depth/link-density anchors
+extracted from the three notes already in the repo. Match those, don't
+invent a new style.


### PR DESCRIPTION
## 요약

skill 카테고리 두 건을 함께 묶음. 두 커밋은 다른 기능이지만 같은
세션에서 발견된 연관성이 있어 단일 PR로 처리.

### 1. `feat(skill): add write:insight ...` (9d81697)

대화 중 발견한 인사이트를 `<repo-root>/docs/learnings/<slug>.md` 로
한 번에 하나씩 아카이브하는 신규 스킬. `docs/learnings/README.md` 의
5-section 템플릿(Context / Pattern / Code / When to use / Related),
50–80 line 타깃, 출처 링크 (PR/commit/file:line) 규칙을 그대로 따름.

- `claude/skills/write-insight/SKILL.md` (96 lines, control tower)
- `references/routing.md` — 이웃 디렉토리/시블링 스킬 라우팅
- `references/template.md` — 섹션 구조, 길이 정책
- `references/examples.md` — 톤 앵커
- `references/help.md` — 사용법

`write-blog-dev-learnings` (`~/para/archive/` 블로그), `write-rca-doc`
(formal RCA), `write-task-history` (PR 본문/JIRA) 와 명확히 구분 —
write:insight 은 **레포 내부**의 50–80 line 짧은 인사이트 전용.

### 2. `docs(skill): record colon naming convention rule` (85b5020)

write:insight 작업 중에 콜론(`name: write:insight`) vs 케밥
(`write-insight`) 논쟁이 발생. VS Code Anthropic Agent 확장의
diagnostic 만 보고 콜론을 케밥으로 "고치려" 한 시도 발생 → 사용자가
SSOT 에 14+ 개 콜론 스킬이 살아 동작 중임을 지적.

이 사실을 두 스킬에 내장:

- `claude/skills/skill-refactor/references/naming-convention.md` (NEW)
  - skill:refactor Step 3b 가 포인터 트리거 → "name: foo:bar 를
    silently 케밥으로 rewrite 하지 말 것"
- `claude/skills/skill-check/references/naming-convention.md` (NEW)
  - skill:check Check 3 가 포인터 트리거 → 콜론 name 은 PASS,
    folder/name kebab-vs-colon mismatch 도 PASS

두 reference 파일 모두 14+ 개 SSOT 스킬 표 + "왜 콜론을 선호하는가"
+ "false-alarm 목록" + "2026-04 incident history" 포함.

두 SKILL.md 는 100-line 캡 유지 (skill:refactor 79 / skill:check 65).

## 동기

같은 세션의 두 가지 발견을 분리하면 컨텍스트가 사라짐 — 콜론 룰이
write:insight 에서 트리거된 사실을 PR description 에 묶어둬야 미래
다시 같은 검토를 할 때 추적 가능.

## Test plan

- [ ] `/skill:check claude/skills/write-insight/SKILL.md` → PASS
- [ ] `/skill:check claude/skills/skill-refactor/SKILL.md` → PASS
      (콜론 name 이 PASS 로 보고되는지 확인)
- [ ] `/skill:check claude/skills/skill-check/SKILL.md` → PASS
- [ ] `/write:insight` 호출 시 references/help.md 를 verbatim 출력
- [ ] `claude/skills/write-insight/references/routing.md` 의
      decline 템플릿이 실제 케이스에서 적용되는지 mental check

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
