### PR TITLE
docs(skill): use xdg-open instead of wslview in visualize

### DIFF
--- a/claude/skills/visualize/SKILL.md
+++ b/claude/skills/visualize/SKILL.md
@@ -24,7 +24,7 @@ Turn any idea, data, or content into a stunning single-file HTML visualization.
 ## After Creating a File
 
 **Always do BOTH after writing the HTML file:**
-1. **Auto-open:** `wslview <filename>.html` (WSL) · `xdg-open <filename>.html` (Linux) · `open <filename>.html` (macOS)
+1. **Auto-open:** `xdg-open <filename>.html` (Linux/WSL) · `open <filename>.html` (macOS). **Do NOT use `wslview`** — it frequently errors on HTML files; `xdg-open` works reliably on WSL.
 2. **Return URL:** Include `file://<absolute-path>` in response
 
 Example: `Created your visualization! 📄 file:///home/user/project/output.html`


### PR DESCRIPTION
## Summary
- `visualize` 스킬의 "After Creating a File" 단계에서 `wslview` 대신 `xdg-open` 을 사용하도록 변경
- 현재 WSL2 환경에서 `wslview <file>.html` 가 HTML 파일 열 때 계속 에러를 내는 반면 `xdg-open` 은 정상 동작

## Changes
- `claude/skills/visualize/SKILL.md`:
  - Auto-open 명령을 `xdg-open <filename>.html` (Linux/WSL) · `open` (macOS) 로 통일
  - "Do NOT use `wslview`" 경고 문구 추가 — 이유(HTML 파일에서 빈번히 에러)까지 명시해서 향후 리그레션 방지

## Test plan
- [ ] `/visualize` 실행 → 생성된 HTML 이 `xdg-open` 으로 자동 오픈되는지 확인
- [ ] Downstream (`~/.claude/skills/visualize/SKILL.md`) 로 symlink/sync 후에도 동일 동작 확인

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
