### PR TITLE
docs(company): expand OKR guide with prefix grammar and HTML viz

### DIFF
--- a/docs/company/OKR_Structure_Guide.html
+++ b/docs/company/OKR_Structure_Guide.html
@@ -1,0 +1,1151 @@
+<!DOCTYPE html>
+<html lang="ko" class="theme-light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>2026 AI Enable 파트 OKR Structure 소개</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { interpolate-size: allow-keywords; }
+
+    html.theme-dark {
+      --bg: #0A0A0A; --surface: #141414; --surface-hover: #1C1C1C;
+      --border: rgba(255,255,255,0.06);
+      --text: #EDEDED; --text-secondary: #9CA3AF;
+      --accent: #60A5FA; --accent-secondary: #A78BFA;
+      --positive: #10b981; --negative: #f43f5e; --warning: #f59e0b;
+      --code-bg: #0F172A; --code-text: #E2E8F0;
+      --muted-bg: rgba(96,165,250,0.08);
+      --grad-hero: radial-gradient(60% 80% at 50% 0%, rgba(96,165,250,0.18), transparent 70%),
+                   radial-gradient(40% 60% at 100% 100%, rgba(167,139,250,0.10), transparent 70%);
+    }
+    html.theme-light {
+      --bg: #FAFAF9; --surface: #FFFFFF; --surface-hover: #F5F5F4;
+      --border: rgba(15,23,42,0.08);
+      --text: #0f172a; --text-secondary: #64748b;
+      --accent: #2563eb; --accent-secondary: #7c3aed;
+      --positive: #059669; --negative: #e11d48; --warning: #d97706;
+      --code-bg: #0F172A; --code-text: #E2E8F0;
+      --muted-bg: rgba(37,99,235,0.06);
+      --grad-hero: radial-gradient(60% 80% at 50% 0%, rgba(37,99,235,0.12), transparent 70%),
+                   radial-gradient(40% 60% at 100% 100%, rgba(124,58,237,0.06), transparent 70%);
+    }
+
+    body {
+      font-family: 'Noto Sans KR', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--text);
+      line-height: 1.7; -webkit-font-smoothing: antialiased;
+      letter-spacing: -0.01em; font-feature-settings: 'cv11', 'ss01';
+      transition: background 0.3s, color 0.3s;
+      scrollbar-gutter: stable;
+    }
+    h1,h2,h3,h4,h5,h6 {
+      color: var(--text);
+      letter-spacing: -0.03em;
+      line-height: 1.15;
+      text-wrap: balance;
+      font-family: 'Inter', 'Noto Sans KR', sans-serif;
+    }
+    h1 { font-weight: 800; font-size: clamp(2.2rem, 5vw, 3.6rem); }
+    h2 { font-weight: 700; font-size: clamp(1.6rem, 3.2vw, 2.2rem); letter-spacing: -0.02em; }
+    h3 { font-weight: 600; font-size: clamp(1.2rem, 2.2vw, 1.5rem); }
+    p, li, td, th, span, label { color: var(--text); font-size: 1rem; }
+    .text-secondary { color: var(--text-secondary); }
+    code, pre, .mono { font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace; font-feature-settings: 'cv11'; }
+
+    /* ===== LAYOUT ===== */
+    .container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
+    section { padding: 80px 0; scroll-margin-top: 24px; }
+    section + section { border-top: 1px solid var(--border); }
+
+    /* ===== HERO ===== */
+    .hero {
+      padding: 120px 0 80px;
+      background: var(--grad-hero);
+      position: relative;
+    }
+    .hero .eyebrow {
+      display: inline-block;
+      padding: 6px 14px;
+      border-radius: 999px;
+      background: var(--muted-bg);
+      color: var(--accent);
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      margin-bottom: 24px;
+    }
+    .hero h1 {
+      font-size: clamp(2.4rem, 6vw, 4rem);
+      background: linear-gradient(135deg, var(--text) 0%, var(--accent) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 20px;
+    }
+    .hero .lead {
+      font-size: clamp(1.1rem, 2vw, 1.3rem);
+      color: var(--text-secondary);
+      max-width: 720px;
+      margin-bottom: 32px;
+    }
+    .hero .key-msg {
+      display: flex;
+      gap: 16px;
+      align-items: flex-start;
+      padding: 24px 28px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 12px;
+      max-width: 820px;
+    }
+    .hero .key-msg strong { color: var(--accent); }
+
+    /* ===== CARD ===== */
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 28px;
+      transition: box-shadow 0.2s ease, transform 0.2s ease;
+    }
+    .card:hover {
+      box-shadow: 0 0 0 1px var(--accent), 0 12px 24px rgba(0,0,0,0.06);
+      transform: translateY(-2px);
+    }
+
+    /* ===== SECTION HEADER ===== */
+    .section-num {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--accent);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+    .section-num .num {
+      width: 28px; height: 28px; border-radius: 50%;
+      background: var(--muted-bg);
+      color: var(--accent);
+      display: inline-flex; align-items: center; justify-content: center;
+      font-weight: 700;
+    }
+    h2.section-title { margin-bottom: 16px; }
+    .section-desc { color: var(--text-secondary); max-width: 720px; margin-bottom: 48px; font-size: 1.05rem; }
+
+    /* ===== STATS GRID ===== */
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+      margin: 32px 0;
+    }
+    .stat-card {
+      padding: 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      text-align: center;
+    }
+    .stat-card .value {
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      font-weight: 800;
+      color: var(--accent);
+      line-height: 1;
+      margin-bottom: 8px;
+    }
+    .stat-card .label {
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+    }
+
+    /* ===== FLOW DIAGRAM (TL;DR) ===== */
+    .flow {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
+      gap: 16px;
+      align-items: center;
+      margin-top: 32px;
+    }
+    .flow-col { display: flex; flex-direction: column; gap: 8px; }
+    .flow-col-title {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-secondary);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-align: center;
+      margin-bottom: 8px;
+    }
+    .flow-item {
+      padding: 14px 16px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      font-size: 0.85rem;
+      line-height: 1.4;
+    }
+    .flow-item.ghrp { border-left: 3px solid var(--accent); }
+    .flow-item.person { border-left: 3px solid var(--accent-secondary); font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; }
+    .flow-item.part { border-left: 3px solid var(--positive); font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; }
+    .flow-item.team { border-left: 3px solid var(--warning); font-size: 0.78rem; }
+    .flow-item .weight { font-size: 0.72rem; color: var(--text-secondary); margin-top: 2px; }
+    .flow-arrow {
+      color: var(--text-secondary);
+      font-size: 1.4rem;
+      font-weight: 300;
+      text-align: center;
+    }
+    .flow-caption {
+      margin-top: 24px;
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      gap: 16px;
+      text-align: center;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+    }
+    @media (max-width: 900px) {
+      .flow, .flow-caption { grid-template-columns: 1fr; gap: 8px; }
+      .flow-arrow { transform: rotate(90deg); }
+    }
+
+    /* ===== GRAMMAR DIAGRAM ===== */
+    .grammar-box {
+      padding: 32px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      margin: 32px 0;
+    }
+    .grammar-syntax {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: clamp(1rem, 2.2vw, 1.4rem);
+      text-align: center;
+      padding: 24px;
+      background: var(--muted-bg);
+      border-radius: 12px;
+      margin-bottom: 24px;
+      letter-spacing: 0.02em;
+    }
+    .grammar-syntax .tok-1 { color: var(--accent); font-weight: 700; }
+    .grammar-syntax .tok-2 { color: var(--positive); font-weight: 700; }
+    .grammar-syntax .tok-3 { color: var(--warning); font-weight: 700; }
+    .grammar-legend {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+    }
+    .legend-item {
+      padding: 18px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--bg);
+    }
+    .legend-item .label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      margin-bottom: 8px;
+    }
+    .legend-item.t1 .label { color: var(--accent); }
+    .legend-item.t2 .label { color: var(--positive); }
+    .legend-item.t3 .label { color: var(--warning); }
+    .legend-item .values {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.9rem;
+      margin-bottom: 6px;
+      font-weight: 600;
+    }
+    .legend-item .desc { font-size: 0.85rem; color: var(--text-secondary); line-height: 1.5; }
+
+    /* ===== INSTANCE TABLE ===== */
+    .table-wrap { overflow-x: auto; margin: 24px 0; border-radius: 12px; border: 1px solid var(--border); }
+    table.instances {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--surface);
+    }
+    table.instances th, table.instances td {
+      padding: 14px 16px;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.92rem;
+    }
+    table.instances thead th {
+      background: var(--muted-bg);
+      color: var(--accent);
+      font-weight: 700;
+      font-size: 0.8rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    table.instances tbody tr:hover { background: var(--surface-hover); }
+    table.instances tbody tr:last-child td { border-bottom: none; }
+    table.instances .idx {
+      display: inline-flex;
+      width: 24px; height: 24px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: white;
+      font-size: 0.8rem;
+      font-weight: 700;
+      align-items: center;
+      justify-content: center;
+    }
+    table.instances code {
+      background: var(--muted-bg);
+      padding: 3px 8px;
+      border-radius: 4px;
+      font-size: 0.85em;
+      color: var(--accent);
+      font-weight: 600;
+    }
+    table.instances .qty {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== TREE DIAGRAM ===== */
+    .tree {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      line-height: 1.7;
+      background: var(--code-bg);
+      color: var(--code-text);
+      padding: 24px;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      margin: 24px 0;
+    }
+    .tree .comment { color: #94A3B8; }
+    .tree .prefix { color: #7DD3FC; font-weight: 600; }
+    .tree .prefix-part { color: #86EFAC; font-weight: 600; }
+    .tree .prefix-k { color: #FCD34D; font-weight: 600; }
+    .tree .prefix-epic { color: #F0ABFC; font-weight: 700; }
+
+    /* ===== MEMBER GRID ===== */
+    .member-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 12px;
+      margin: 24px 0;
+    }
+    .member-card {
+      text-align: center;
+      padding: 18px 12px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      transition: all 0.2s;
+    }
+    .member-card:hover {
+      border-color: var(--accent);
+      background: var(--muted-bg);
+    }
+    .member-card .greek {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: var(--accent);
+      font-family: 'Inter', sans-serif;
+      display: block;
+      margin-bottom: 4px;
+    }
+    .member-card .code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== JQL EXAMPLE ===== */
+    .jql-example {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 20px;
+    }
+    .jql-example:hover { border-color: var(--accent); }
+    .jql-question {
+      font-weight: 600;
+      margin-bottom: 14px;
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+    }
+    .jql-question .q-icon {
+      width: 28px; height: 28px;
+      border-radius: 8px;
+      background: var(--muted-bg);
+      color: var(--accent);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 0.85rem;
+      flex-shrink: 0;
+    }
+    .jql-query {
+      background: var(--code-bg);
+      color: var(--code-text);
+      padding: 14px 18px;
+      border-radius: 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.9rem;
+      margin-bottom: 12px;
+      overflow-x: auto;
+    }
+    .jql-query .kw { color: #F472B6; font-weight: 600; }
+    .jql-query .op { color: #FCD34D; }
+    .jql-query .str { color: #86EFAC; }
+    .jql-result {
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+      padding-left: 4px;
+      border-left: 3px solid var(--positive);
+      padding-left: 14px;
+    }
+    .jql-result strong { color: var(--text); }
+
+    /* ===== LEVEL CARDS ===== */
+    .level-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      background: var(--muted-bg);
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 0.9rem;
+      margin-bottom: 16px;
+    }
+
+    /* ===== STORY LIST (Level 1) ===== */
+    .story-list {
+      display: grid;
+      gap: 12px;
+      margin: 24px 0;
+    }
+    .story-item {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      align-items: center;
+      gap: 20px;
+      padding: 18px 22px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 10px;
+    }
+    .story-item .summary {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--text);
+      font-weight: 600;
+    }
+    .story-item .desc { color: var(--text-secondary); font-size: 0.85rem; margin-top: 4px; }
+    .story-item .weight {
+      font-family: 'Inter', sans-serif;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--accent);
+    }
+    .story-item .weight .pct { font-size: 0.85rem; font-weight: 500; color: var(--text-secondary); }
+
+    /* ===== CALLOUT ===== */
+    .callout {
+      padding: 28px 32px;
+      background: linear-gradient(135deg, var(--muted-bg) 0%, transparent 100%);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 12px;
+      margin: 32px 0;
+    }
+    .callout strong { color: var(--accent); }
+
+    /* ===== FOOTER ===== */
+    footer {
+      padding: 60px 0 40px;
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      border-top: 1px solid var(--border);
+    }
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    /* ===== ANIMATIONS ===== */
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    .animate { animation: fadeInUp 0.7s ease-out both; }
+    .animate.delay-1 { animation-delay: 0.1s; }
+    .animate.delay-2 { animation-delay: 0.2s; }
+    .animate.delay-3 { animation-delay: 0.3s; }
+    .animate.delay-4 { animation-delay: 0.4s; }
+
+    .reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.7s ease, transform 0.7s ease; }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .reveal { opacity: 1; transform: none; }
+    }
+
+    /* ===== PRINT ===== */
+    @media print {
+      body { background: white !important; color: black !important; }
+      .viz-menu, .hero { display: revert; opacity: 1 !important; transform: none !important; }
+      .card, .story-item, .jql-example, .grammar-box, .stat-card { break-inside: avoid; }
+      section { break-inside: avoid-page; page-break-inside: avoid; padding: 32px 0; }
+      * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+    @page { margin: 0.8in; @bottom-center { content: "Page " counter(page) " / AI Enable OKR Guide"; font-size: 9pt; color: #666; } }
+
+    /* ===== MENU ===== */
+    .viz-menu { position: fixed; top: 16px; right: 16px; z-index: 9999; }
+    .viz-menu-toggle {
+      width: 44px; height: 44px; border-radius: 12px;
+      background: var(--surface); border: 1px solid var(--border);
+      color: var(--text); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      backdrop-filter: blur(12px); transition: all 0.2s;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    }
+    .viz-menu-toggle:hover { background: var(--surface-hover); }
+    .viz-menu-dropdown {
+      position: absolute; top: 52px; right: 0; min-width: 200px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 8px;
+      opacity: 0; visibility: hidden; transform: translateY(-8px);
+      transition: all 0.2s; backdrop-filter: blur(16px);
+      box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+    }
+    .viz-menu-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+    .viz-menu-dropdown button {
+      width: 100%; padding: 10px 14px; border: none; border-radius: 8px;
+      background: transparent; color: var(--text); font-size: 14px;
+      font-family: inherit; cursor: pointer; text-align: left;
+      display: flex; align-items: center; gap: 10px; transition: background 0.15s;
+    }
+    .viz-menu-dropdown button:hover { background: var(--surface-hover); }
+
+    /* ===== SKIP TO CONTENT ===== */
+    .skip-to-content {
+      position: absolute; top: -40px; left: 6px; background: var(--accent);
+      color: white; padding: 8px 12px; text-decoration: none;
+      border-radius: 4px; opacity: 0; pointer-events: none;
+      transition: all 0.2s; z-index: 10000;
+    }
+    .skip-to-content:focus { top: 6px; opacity: 1; pointer-events: auto; }
+  </style>
+</head>
+<body>
+  <!-- MENU -->
+  <div class="viz-menu">
+    <button class="viz-menu-toggle" onclick="toggleMenu()" aria-label="Menu">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="5" x2="17" y2="5"/><line x1="3" y1="10" x2="17" y2="10"/><line x1="3" y1="15" x2="17" y2="15"/>
+      </svg>
+    </button>
+    <div class="viz-menu-dropdown" id="vizMenuDropdown">
+      <button onclick="cycleTheme()" aria-label="Toggle theme"><span id="themeIcon">☀️</span><span id="themeLabel">Light</span></button>
+      <button onclick="downloadImage()" aria-label="Download as PNG"><span>📥</span><span>Download PNG</span></button>
+      <button onclick="window.print()" aria-label="Print or save as PDF"><span>🖨️</span><span>Print / PDF</span></button>
+    </div>
+  </div>
+
+  <a href="#main-content" class="skip-to-content">Skip to content</a>
+
+  <main id="main-content" role="main">
+
+    <!-- ============= HERO ============= -->
+    <section class="hero">
+      <div class="container">
+        <div class="animate">
+          <span class="eyebrow">2026 AI Enable · 파트원용 가이드</span>
+          <h1>내 Objective 만 집중하면<br/>팀 성과는 자동으로 따라옵니다</h1>
+          <p class="lead">
+            2026년 AI Enable 파트의 GHRP 평가는 OKR 프레임워크로 재설계되어
+            JIRA Structure 로 구현되었습니다. 당신의 Story 4개가 파트·팀 미션에
+            자연스럽게 rollup 되는 구조입니다.
+          </p>
+        </div>
+        <div class="key-msg animate delay-2" role="note" aria-label="핵심 메시지">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="color: var(--accent); flex-shrink: 0; margin-top: 2px;" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+          </svg>
+          <div>
+            <strong>핵심 메시지</strong><br/>
+            당신은 당신의 Objective 에만 집중하세요. 성과는 자동으로 파트 → 팀으로 rollup 됩니다.
+            Structure 를 이해할 필요도 없습니다 — <strong>Story 4개</strong> 만 매달 꾸준히 업데이트 하세요.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= STATS ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">0</span><span>한눈에 보는 숫자</span></div>
+        <h2 class="section-title">규모와 구조</h2>
+        <div class="stats-grid">
+          <div class="stat-card">
+            <div class="value" data-count="9" data-suffix="명">9명</div>
+            <div class="label">파트원 (Greek letter 할당)</div>
+          </div>
+          <div class="stat-card">
+            <div class="value" data-count="5" data-suffix="개">5개</div>
+            <div class="label">GHRP 평가 항목 (O-1~O-5)</div>
+          </div>
+          <div class="stat-card">
+            <div class="value" data-count="4" data-suffix="개">4개</div>
+            <div class="label">핵심제품 라인업 (K-1~K-4)</div>
+          </div>
+          <div class="stat-card">
+            <div class="value" data-count="45" data-suffix="+1">45+1</div>
+            <div class="label">Story 총 수 (+파트 Epic)</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= TL;DR FLOW ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">1</span><span>TL;DR</span></div>
+        <h2 class="section-title">GHRP → JIRA 으로 번역된 Structure</h2>
+        <p class="section-desc">
+          회사의 평가 체계(GHRP)가 어떻게 우리가 실제로 일하는 JIRA Structure 로
+          맵핑되었는지 한 장에 담았습니다. 왼쪽에서 오른쪽으로 읽으세요 — 당신의 일이
+          파트·팀 성과에 어떻게 자동으로 rollup 되는지 보입니다.
+        </p>
+
+        <div class="flow">
+          <!-- GHRP -->
+          <div class="flow-col">
+            <div class="flow-col-title">GHRP 평가항목</div>
+            <div class="flow-item ghrp">조직목표달성<div class="weight">50%</div></div>
+            <div class="flow-item ghrp">혁신/개선<div class="weight">20%</div></div>
+            <div class="flow-item ghrp">조직시너지<div class="weight">20%</div></div>
+            <div class="flow-item ghrp">역량강화<div class="weight">10%</div></div>
+            <div class="flow-item ghrp">수명업무<div class="weight">tracking</div></div>
+          </div>
+          <div class="flow-arrow" aria-hidden="true">→</div>
+
+          <!-- Person -->
+          <div class="flow-col">
+            <div class="flow-col-title">개인 (9명)</div>
+            <div class="flow-item person">[AIE-δ O-1 K-n]</div>
+            <div class="flow-item person">[AIE-δ O-2]</div>
+            <div class="flow-item person">[AIE-δ O-3]</div>
+            <div class="flow-item person">[AIE-δ O-4]</div>
+            <div class="flow-item person">(Task 만)</div>
+          </div>
+          <div class="flow-arrow" aria-hidden="true">→</div>
+
+          <!-- Part -->
+          <div class="flow-col">
+            <div class="flow-col-title">파트 (1개)</div>
+            <div class="flow-item part">[AIE O-1] P-1</div>
+            <div class="flow-item part">[AIE O-2] P-2</div>
+            <div class="flow-item part">[AIE O-3] P-3</div>
+            <div class="flow-item part">[AIE O-4] P-4</div>
+            <div class="flow-item part">[AIE O-5] P-5</div>
+          </div>
+          <div class="flow-arrow" aria-hidden="true">→</div>
+
+          <!-- Team -->
+          <div class="flow-col">
+            <div class="flow-col-title">팀 (상위)</div>
+            <div class="flow-item team">팀 Story (SWINNOTEAM-1274)</div>
+            <div class="flow-item team">E3 간접</div>
+            <div class="flow-item team">E1, E2 간접</div>
+            <div class="flow-item team">E1~E4 지원</div>
+            <div class="flow-item team" style="opacity:0.5">—</div>
+          </div>
+        </div>
+
+        <div class="flow-caption">
+          <div>회사 평가 체계</div>
+          <div>본인 집중 영역</div>
+          <div>자동 rollup</div>
+          <div>팀 목표 기여</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= PREFIX GRAMMAR ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">2</span><span>Prefix 공통 문법</span></div>
+        <h2 class="section-title">[ 소속 · Objective-N · Key-N ] — 단 하나의 문법</h2>
+        <p class="section-desc">
+          모든 JIRA Summary 접두어는 <strong>단 하나의 공통 문법</strong> 하나로 통일됩니다.
+          이것이 Structure 의 설계 언어입니다. 왼쪽일수록 상위 레벨, 오른쪽일수록 세부 분류.
+        </p>
+
+        <div class="grammar-box">
+          <div class="grammar-syntax" role="presentation">
+            [ <span class="tok-1">소속</span>&nbsp;&nbsp;<span class="tok-2">Objective-N</span>&nbsp;&nbsp;<span class="tok-3">Key-N</span> ]
+          </div>
+
+          <div class="grammar-legend">
+            <div class="legend-item t1">
+              <div class="label">1. 소속</div>
+              <div class="values"><code>AIE</code> · <code>AIE-{letter}</code></div>
+              <div class="desc"><code>AIE</code> = 파트. <code>AIE-{letter}</code> = 파트원 (letter ∈ {δ, ξ, λ, ψ, σ, π, θ, ζ, γ}) — 한 번 배정된 Greek letter 는 평생 고정.</div>
+            </div>
+            <div class="legend-item t2">
+              <div class="label">2. Objective</div>
+              <div class="values"><code>O-N</code> (N = 1..5)</div>
+              <div class="desc">GHRP 5개 평가 항목과 1:1 대응. 모든 Summary 에 필수로 포함됩니다 (Epic 제외).</div>
+            </div>
+            <div class="legend-item t3">
+              <div class="label">3. Key (선택)</div>
+              <div class="values"><code>K-n</code> (n = 1..4)</div>
+              <div class="desc">핵심제품 번호. <strong>O-1 (조직목표달성) 에만</strong> 부착되는 꼬리표 — 제품별 성과 집계를 위해.</div>
+            </div>
+          </div>
+        </div>
+
+        <h3 style="margin: 48px 0 16px;">공통 문법의 5가지 실제 인스턴스</h3>
+        <div class="table-wrap">
+          <table class="instances">
+            <thead>
+              <tr><th>#</th><th>인스턴스</th><th>형식</th><th>예시</th><th>수량</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="idx">1</span></td>
+                <td>파트 Epic</td>
+                <td><code>[AIE M&amp;V]</code></td>
+                <td>[AIE M&amp;V] 임직원이 체감하는 AI 효용성</td>
+                <td class="qty">1</td>
+              </tr>
+              <tr>
+                <td><span class="idx">2</span></td>
+                <td>파트 Story</td>
+                <td><code>[AIE O-N]</code></td>
+                <td>[AIE O-2] 2026 혁신/개선업무</td>
+                <td class="qty">5 (N=1..5)</td>
+              </tr>
+              <tr>
+                <td><span class="idx">3</span></td>
+                <td>파트 제품 Story</td>
+                <td><code>[AIE O-1 K-n]</code></td>
+                <td>[AIE O-1 K-1] SLSI Agent App Store</td>
+                <td class="qty">4 (n=1..4)</td>
+              </tr>
+              <tr>
+                <td><span class="idx">4</span></td>
+                <td>파트원 M-1 Story</td>
+                <td><code>[AIE-{letter} O-1 K-n]</code></td>
+                <td>[AIE-δ O-1 K-1] 2026 조직목표달성</td>
+                <td class="qty">9 (인당 1개)</td>
+              </tr>
+              <tr>
+                <td><span class="idx">5</span></td>
+                <td>파트원 M-2~M-4 Story</td>
+                <td><code>[AIE-{letter} O-N]</code></td>
+                <td>[AIE-δ O-2] 2026 혁신/개선업무</td>
+                <td class="qty">27 (9 × 3)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="callout">
+          <strong>합계 46개</strong> (Epic 포함) = 1 + 5 + 4 + 9 + 27. 수명업무(O-5) 는
+          파트 Story 한 개만 존재하고 파트원 개별 Story 는 없습니다 — Task 만 동적 생성.
+          근거: <a href="https://github.com/dEitY719/dotfiles/pull/147" style="color: var(--accent); text-decoration: underline;">PR #147</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= LEVEL 1 ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">3</span><span>Bottom-Up · Level 1</span></div>
+        <span class="level-badge">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="8" r="5"/><path d="M20 21c0-4.4-3.6-8-8-8s-8 3.6-8 8"/></svg>
+          개인 레벨
+        </span>
+        <h2 class="section-title">당신의 Objective — Story 4개</h2>
+        <p class="section-desc">
+          파트원 한 명은 Story 를 4개 가집니다. 이게 1년 동안 당신이 신경써야 할 전부입니다.
+          아래는 파트원 <code>δ</code> 를 예로 든 샘플 — 담당 제품이 K-1 인 경우.
+        </p>
+
+        <div class="story-list">
+          <div class="story-item">
+            <div>
+              <div class="summary">[AIE-δ O-1 K-1]</div>
+              <div class="desc">2026 조직목표달성 — OKR 기반 핵심과제 수행 (담당 제품 K-1)</div>
+            </div>
+            <div></div>
+            <div class="weight"><span>50</span><span class="pct">%</span></div>
+          </div>
+          <div class="story-item" style="border-left-color: var(--accent-secondary)">
+            <div>
+              <div class="summary">[AIE-δ O-2]</div>
+              <div class="desc">2026 혁신/개선업무 — 공통업무 개선 및 Tool/AI 기여</div>
+            </div>
+            <div></div>
+            <div class="weight" style="color: var(--accent-secondary)"><span>20</span><span class="pct">%</span></div>
+          </div>
+          <div class="story-item" style="border-left-color: var(--positive)">
+            <div>
+              <div class="summary">[AIE-δ O-3]</div>
+              <div class="desc">2026 조직시너지 창출 — 데이터 공유 및 동료 성공 기여</div>
+            </div>
+            <div></div>
+            <div class="weight" style="color: var(--positive)"><span>20</span><span class="pct">%</span></div>
+          </div>
+          <div class="story-item" style="border-left-color: var(--warning)">
+            <div>
+              <div class="summary">[AIE-δ O-4]</div>
+              <div class="desc">2026 개인역량강화 — 특허 · 논문 · 어학 · 자격 · 시상</div>
+            </div>
+            <div></div>
+            <div class="weight" style="color: var(--warning)"><span>10</span><span class="pct">%</span></div>
+          </div>
+        </div>
+
+        <h3 style="margin: 40px 0 16px;">Story 아래에 Task/Sub-task 는 자유롭게</h3>
+        <div class="tree" role="img" aria-label="Story 하위 Task 트리 구조 예시">
+<span class="prefix">[AIE-δ O-1 K-1]</span> 2026 조직목표달성  <span class="comment">← Story (당신의 Objective)</span>
+  ├─ Task: [4월] OKR 수립·승인          <span class="comment">← 월간 단위 task</span>
+  ├─ Task: [5월] 1차 KPI 점검
+  ├─ Task: Feature A 개발                <span class="comment">← 구체적 업무</span>
+  │    ├─ Sub-task: API 설계
+  │    ├─ Sub-task: 구현
+  │    └─ Sub-task: 테스트
+  └─ Task: Customer 인터뷰
+        </div>
+
+        <div class="callout">
+          <strong>규칙은 단 하나 —</strong> 해당 Story 하위에 <strong>Link 연결</strong> 만 보장하세요.
+          그러면 평가 시점에 "이 일이 어느 Objective 의 성과인지" 자동으로 집계됩니다.
+          Task 이름, 개수, 쪼개는 방식은 모두 <strong>당신의 재량</strong>.
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= LEVEL 2 ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">4</span><span>Bottom-Up · Level 2</span></div>
+        <span class="level-badge" style="color: var(--positive); background: rgba(5,150,105,0.08);">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          파트 레벨
+        </span>
+        <h2 class="section-title">9명이 모여 파트 Objective 을 형성</h2>
+        <p class="section-desc">
+          당신의 Story 는 파트 Story 의 하위로 자동 연결됩니다.
+          예를 들어 혁신/개선업무(O-2) 파트 Story 아래에는 9명의 Story 가 모두 포함됩니다.
+        </p>
+
+        <h3 style="margin-bottom: 16px;">AI Enable 파트원 9명</h3>
+        <div class="member-grid" role="list" aria-label="파트원 9명 코드 매핑">
+          <div class="member-card" role="listitem"><span class="greek">δ</span><span class="code">AIE-δ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">ξ</span><span class="code">AIE-ξ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">λ</span><span class="code">AIE-λ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">ψ</span><span class="code">AIE-ψ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">σ</span><span class="code">AIE-σ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">π</span><span class="code">AIE-π</span></div>
+          <div class="member-card" role="listitem"><span class="greek">θ</span><span class="code">AIE-θ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">ζ</span><span class="code">AIE-ζ</span></div>
+          <div class="member-card" role="listitem"><span class="greek">γ</span><span class="code">AIE-γ</span></div>
+        </div>
+
+        <h3 style="margin: 32px 0 16px;">예: [AIE O-2] 혁신/개선업무 하위 Structure</h3>
+        <div class="tree" role="img" aria-label="파트 Story 하위에 9명의 개인 Story 가 모인 구조">
+<span class="prefix-part">[AIE O-2]</span> 2026 혁신/개선업무  <span class="comment">← 파트 Story (P-2)</span>
+  ├─ <span class="prefix">[AIE-δ O-2]</span>   (파트원 1)
+  ├─ <span class="prefix">[AIE-ξ O-2]</span>   (파트원 2)
+  ├─ <span class="prefix">[AIE-λ O-2]</span>   (파트원 3)
+  ├─ <span class="prefix">[AIE-ψ O-2]</span>   (파트원 4)
+  ├─ <span class="prefix">[AIE-σ O-2]</span>   (파트원 5)
+  ├─ <span class="prefix">[AIE-π O-2]</span>   (파트원 6)
+  ├─ <span class="prefix">[AIE-θ O-2]</span>   (파트원 7)
+  ├─ <span class="prefix">[AIE-ζ O-2]</span>   (파트원 8)
+  └─ <span class="prefix">[AIE-γ O-2]</span>   (파트원 9)
+        </div>
+
+        <h3 style="margin: 32px 0 16px;">특수 케이스 — 조직목표달성(O-1)은 제품별로 분기</h3>
+        <p class="section-desc" style="margin-bottom: 16px;">
+          O-1 은 제품 라인업(K-1~K-4) 단위로 KPI 를 집계해야 하므로 중간에
+          <strong>제품 Story</strong> 계층을 하나 더 둡니다.
+        </p>
+        <div class="tree" role="img" aria-label="O-1 조직목표달성의 제품별 분기 구조">
+<span class="prefix-part">[AIE O-1]</span> 2026 조직목표달성  <span class="comment">← 파트 Story (P-1)</span>
+  ├─ <span class="prefix-k">[AIE O-1 K-1]</span> SLSI Agent App Store
+  │   ├─ <span class="prefix">[AIE-δ O-1 K-1]</span>  <span class="comment">← δ 가 K-1 담당</span>
+  │   └─ <span class="prefix">[AIE-ξ O-1 K-1]</span>  <span class="comment">← ξ 가 K-1 담당</span>
+  ├─ <span class="prefix-k">[AIE O-1 K-2]</span> SLSI Alpha Agent
+  │   └─ <span class="prefix">[AIE-λ O-1 K-2]</span>  <span class="comment">← λ 가 K-2 담당</span>
+  ├─ <span class="prefix-k">[AIE O-1 K-3]</span> SLSI Cowork
+  │   └─ <span class="prefix">[AIE-ψ O-1 K-3]</span>  <span class="comment">← ψ 가 K-3 담당</span>
+  └─ <span class="prefix-k">[AIE O-1 K-4]</span> MCP/Skill Hub
+      └─ <span class="prefix">[AIE-σ O-1 K-4]</span>  <span class="comment">← σ 가 K-4 담당</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= LEVEL 3 ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">5</span><span>Bottom-Up · Level 3</span></div>
+        <span class="level-badge" style="color: var(--warning); background: rgba(217,119,6,0.08);">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          팀 레벨
+        </span>
+        <h2 class="section-title">파트 Objective 이 팀 Epic 에 자연스럽게 귀결</h2>
+        <p class="section-desc">
+          Task 하나를 완료하면 → 개인 Story → 파트 Story → 팀 Story → 팀 Epic 까지
+          자동으로 progress 가 전파됩니다. 당신은 맨 아래 Task 하나만 잘 하면 됩니다.
+        </p>
+
+        <div class="tree" role="img" aria-label="팀 Epic → 팀 Story → 파트 Story → 파트원 Story 전체 계층">
+<span class="prefix-epic">[E4]</span> Avatar 7000명 양성  <span class="comment">← 팀 Epic (이미 존재)</span>
+  └─ SWINNOTEAM-1274: Document Agent 개발  <span class="comment">← 팀 Story (MAU ≥ 5,000명)</span>
+      └─ <span class="prefix-part">[AIE O-1]</span> 2026 조직목표달성  <span class="comment">← 우리 파트의 P-1</span>
+          └─ <span class="prefix-k">[AIE O-1 K-n]</span>  <span class="comment">K-1..K-4 제품 Story</span>
+              └─ <span class="prefix">[AIE-{letter} O-1 K-n]</span>  <span class="comment">9명의 파트원 M-1 Story</span>
+                  └─ Task / Sub-task  <span class="comment">← 당신의 일상 업무</span>
+        </div>
+
+        <div class="callout">
+          <strong>Task 하나가 올라가면 →</strong> 개인 Story 진행률 ↑ → 파트 Story ↑ →
+          팀 Story ↑ → 팀 Epic 달성률 ↑.<br/>
+          당신의 Objective 만 신경쓰세요. <strong>rollup 은 Structure 가 자동 처리</strong> 합니다.
+        </div>
+
+        <p style="margin-top: 24px; color: var(--text-secondary); font-size: 0.95rem;">
+          혁신/개선(P-2), 조직시너지(P-3), 역량강화(P-4) 는 팀 Epic 에 직접 연결되지는 않지만
+          E1, E2, E3 와 방향성 일치로 <strong>간접 기여</strong> 합니다. 50% 항목인 O-1 만 팀 Story
+          직속으로 두고 나머지는 파트 독립 영역으로 분리 — 평가 관점의 명확성을 위한 의도적 설계입니다.
+        </p>
+      </div>
+    </section>
+
+    <!-- ============= JQL CHEATSHEET ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">6</span><span>Structure 활용</span></div>
+        <h2 class="section-title">JQL 검색 치트시트 — 질문 → 쿼리 → 결과</h2>
+        <p class="section-desc">
+          Prefix 규칙만 알면 별도 Label/Component 없이 <strong>Summary 접두어만으로</strong>
+          누구나 즉석 JQL 쿼리를 만들 수 있습니다. 아래는 자주 쓰는 7가지 패턴.
+        </p>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q1</span><div>O-1(조직목표달성)에 몇 명의 파트원이 일하고 있지?</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"O-1"</span> <span class="kw">AND</span> summary <span class="op">!~</span> <span class="str">"AIE O-1"</span></div>
+          <div class="jql-result">→ <strong>[AIE-δ O-1 K-1]</strong>, <strong>[AIE-λ O-1 K-2]</strong>, ... 9개 Story 조회. 제품별 인원 분포가 한눈에 보임.</div>
+        </div>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q2</span><div>AIE-λ 는 이번 주에 어떤 일들을 했지?</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"-λ"</span> <span class="kw">AND</span> updated <span class="op">&gt;=</span> <span class="str">-7d</span></div>
+          <div class="jql-result">→ λ 의 4개 Story (M-1~M-4) 와 하위 Task/Sub-task 중 최근 7일 업데이트 전부. <strong>1:1 미팅 자료가 자동 생성</strong>.</div>
+        </div>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q3</span><div>혁신/개선업무(O-2) 쪽 파트 전체 진행률은?</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"O-2"</span></div>
+          <div class="jql-result">→ <strong>[AIE O-2]</strong> (파트) + <strong>[AIE-δ O-2]</strong>..<strong>[AIE-γ O-2]</strong> 총 10개 Story 로 파트 전체 혁신 활동 조회.</div>
+        </div>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q4</span><div>K-1(Agent App Store) 담당자들이 지금 뭐하고 있지?</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"K-1"</span></div>
+          <div class="jql-result">→ K-1 파트 Story + K-1 담당 파트원 M-1 Story + 하위 Task. <strong>제품팀 스탠드업</strong> 자료로 즉시 사용.</div>
+        </div>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q5</span><div>역량강화(O-4) 자격증/특허 계획을 모은 리스트 줘</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"O-4"</span> <span class="kw">AND</span> issuetype <span class="op">=</span> Story</div>
+          <div class="jql-result">→ 9명 + 파트 Story 총 10개. 각 Description 의 자격/특허/어학 목표가 <strong>SCI 리뷰 자료</strong> 로 export 가능.</div>
+        </div>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q6</span><div>지난 분기 AIE-δ 의 조직시너지(O-3) 기여 건수 집계</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"-δ"</span> <span class="kw">AND</span> summary <span class="op">~</span> <span class="str">"O-3"</span> <span class="kw">AND</span> status <span class="op">=</span> Done <span class="kw">AND</span> resolved <span class="op">&gt;=</span> <span class="str">-90d</span></div>
+          <div class="jql-result">→ δ 의 O-3 하위 Task 중 완료된 것만. <strong>평가 시즌 정량 지표</strong> 확보 10초.</div>
+        </div>
+
+        <div class="jql-example">
+          <div class="jql-question"><span class="q-icon">Q7</span><div>우리 파트의 수명업무(O-5) 비중이 얼마나 되지?</div></div>
+          <div class="jql-query">summary <span class="op">~</span> <span class="str">"AIE O-5"</span></div>
+          <div class="jql-result">→ 본 Story 하위 Task 개수·평균 소요시간 집계 → <strong>비계획 업무 비중</strong> 산출. OKR 재조정 근거 데이터.</div>
+        </div>
+
+        <div class="callout">
+          <strong>핵심:</strong> 위 7가지는 전부 <strong>접두어 조합</strong> 만으로 만들어집니다.
+          Label/Component 를 따로 관리할 필요 없음 — Summary 접두어가 바로 살아있는 필터 인덱스 역할.
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= CLOSING ============= -->
+    <section data-reveal>
+      <div class="container">
+        <div class="section-num"><span class="num">7</span><span>마무리</span></div>
+        <h2 class="section-title">당신에게 부탁드리는 것</h2>
+
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; margin: 32px 0;">
+          <div class="card">
+            <div style="font-size: 1.4rem; font-weight: 800; color: var(--accent); margin-bottom: 8px;">1</div>
+            <h3>본인의 Story 4개만 관리</h3>
+            <p class="text-secondary" style="margin-top: 8px; font-size: 0.92rem;">조직목표달성 1, 혁신/개선 1, 시너지 1, 역량강화 1. 이게 1년 동안 당신이 신경쓸 전부입니다.</p>
+          </div>
+          <div class="card">
+            <div style="font-size: 1.4rem; font-weight: 800; color: var(--accent); margin-bottom: 8px;">2</div>
+            <h3>Task / Sub-task 는 자유롭게</h3>
+            <p class="text-secondary" style="margin-top: 8px; font-size: 0.92rem;">이름·개수·쪼개는 방식은 당신의 재량. 규칙은 단 하나 — Story 하위로 Link.</p>
+          </div>
+          <div class="card">
+            <div style="font-size: 1.4rem; font-weight: 800; color: var(--accent); margin-bottom: 8px;">3</div>
+            <h3>Task 완료 시마다 Status 업데이트</h3>
+            <p class="text-secondary" style="margin-top: 8px; font-size: 0.92rem;">rollup 은 Structure 가 자동 처리 — 당신은 자신의 Task 상태만 정확히.</p>
+          </div>
+          <div class="card">
+            <div style="font-size: 1.4rem; font-weight: 800; color: var(--accent); margin-bottom: 8px;">4</div>
+            <h3>월 1회 1:1 리뷰</h3>
+            <p class="text-secondary" style="margin-top: 8px; font-size: 0.92rem;">본인 Story 를 펼쳐서 TL 과 함께 점검. TL 이 자료 준비.</p>
+          </div>
+          <div class="card">
+            <div style="font-size: 1.4rem; font-weight: 800; color: var(--accent); margin-bottom: 8px;">5</div>
+            <h3>수명업무는 [AIE O-5] 하위에</h3>
+            <p class="text-secondary" style="margin-top: 8px; font-size: 0.92rem;">비계획 지시 업무도 Task 로 등록. 나중에 OKR 재조정의 근거가 됩니다.</p>
+          </div>
+        </div>
+
+        <div class="callout" style="text-align: center; font-size: 1.15rem; padding: 40px 32px; margin-top: 40px;">
+          <strong>"나는 내 Objective 에만 집중하면,<br/>파트 성과 → 팀 성과로 자동 rollup 된다."</strong>
+          <p style="margin-top: 16px; color: var(--text-secondary); font-size: 0.95rem;">
+            Structure 를 이해 할 필요는 없습니다. 당신이 Story 4개를 매월 꾸준히 업데이트 하면,
+            Structure 가 당신의 기여를 증명하는 수치를 TL·임원에게 전달합니다.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <div class="container">
+        <p>2026 AI Enable 파트 · OKR Structure 가이드</p>
+        <p style="margin-top: 8px;">
+          <a href="https://github.com/dEitY719/dotfiles/pull/147">Prefix 규칙 근거 PR #147</a> ·
+          <a href="https://github.com/dEitY719/dotfiles/pull/148">공통 문법 통합 PR #148</a>
+        </p>
+      </div>
+    </footer>
+
+  </main>
+
+  <script>
+    // === Menu ===
+    function toggleMenu() {
+      var dropdown = document.getElementById('vizMenuDropdown');
+      if (dropdown) dropdown.classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      if (!e.target.closest('.viz-menu')) {
+        var dropdown = document.getElementById('vizMenuDropdown');
+        if (dropdown) dropdown.classList.remove('open');
+      }
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') {
+        var dropdown = document.getElementById('vizMenuDropdown');
+        if (dropdown) dropdown.classList.remove('open');
+      }
+    });
+
+    // === Theme ===
+    var savedTheme = localStorage.getItem('viz-theme');
+    var currentTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    function applyTheme(t) {
+      document.documentElement.className = 'theme-' + t;
+      document.getElementById('themeIcon').textContent = t === 'dark' ? '🌙' : '☀️';
+      document.getElementById('themeLabel').textContent = t === 'dark' ? 'Dark' : 'Light';
+      localStorage.setItem('viz-theme', t);
+      currentTheme = t;
+    }
+    function cycleTheme() { applyTheme(currentTheme === 'dark' ? 'light' : 'dark'); }
+    applyTheme(currentTheme);
+
+    // === Scroll Reveal ===
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { el.classList.add('reveal'); });
+    var revealObserver = new IntersectionObserver(function(entries) {
+      entries.forEach(function(e) {
+        if (e.isIntersecting) { e.target.classList.add('visible'); revealObserver.unobserve(e.target); }
+      });
+    }, { threshold: 0.12 });
+    document.querySelectorAll('.reveal').forEach(function(el) { revealObserver.observe(el); });
+
+    // === Number Counter ===
+    function animateCounters() {
+      document.querySelectorAll('[data-count]').forEach(function(el) {
+        if (el.dataset.counted) return;
+        el.dataset.counted = '1';
+        var target = parseFloat(el.dataset.count);
+        var suffix = el.dataset.suffix || '';
+        var start = performance.now();
+        var duration = 1200;
+        var originalText = el.textContent;
+        (function tick(now) {
+          var p = Math.min((now - start) / duration, 1);
+          var eased = 1 - Math.pow(1 - p, 3);
+          el.textContent = Math.round(target * eased).toLocaleString() + suffix;
+          if (p < 1) requestAnimationFrame(tick);
+          else el.textContent = originalText;
+        })(start);
+      });
+    }
+    var counterEl = document.querySelector('[data-count]');
+    if (counterEl) {
+      var cObs = new IntersectionObserver(function(entries) {
+        entries.forEach(function(e) { if (e.isIntersecting) { animateCounters(); cObs.disconnect(); } });
+      }, { threshold: 0.3 });
+      cObs.observe(counterEl);
+    }
+
+    // === Download PNG ===
+    async function downloadImage() {
+      var menu = document.querySelector('.viz-menu');
+      menu.style.display = 'none';
+      try {
+        var url = await htmlToImage.toPng(document.body, {
+          quality: 1, pixelRatio: 2,
+          filter: function(n) { return !n.classList || !n.classList.contains('viz-menu'); }
+        });
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'okr-structure-guide.png';
+        a.click();
+      } catch (e) { console.error('Download failed:', e); }
+      menu.style.display = '';
+    }
+  </script>
+</body>
+</html>

--- a/docs/company/OKR_Structure_Guide.html
+++ b/docs/company/OKR_Structure_Guide.html
@@ -756,15 +756,15 @@
               </tr>
               <tr>
                 <td><span class="idx">4</span></td>
-                <td>파트원 M-1 Story</td>
+                <td>파트원 O-1 Story</td>
                 <td><code>[AIE-{letter} O-1 K-n]</code></td>
                 <td>[AIE-δ O-1 K-1] 2026 조직목표달성</td>
                 <td class="qty">9 (인당 1개)</td>
               </tr>
               <tr>
                 <td><span class="idx">5</span></td>
-                <td>파트원 M-2~M-4 Story</td>
-                <td><code>[AIE-{letter} O-N]</code></td>
+                <td>파트원 O-2~O-4 Story</td>
+                <td><code>[AIE-{letter} O-N]</code> (N=2..4)</td>
                 <td>[AIE-δ O-2] 2026 혁신/개선업무</td>
                 <td class="qty">27 (9 × 3)</td>
               </tr>
@@ -857,7 +857,7 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
           파트 레벨
         </span>
-        <h2 class="section-title">9명이 모여 파트 Objective 을 형성</h2>
+        <h2 class="section-title">9명이 모여 파트 Objective를 형성</h2>
         <p class="section-desc">
           당신의 Story 는 파트 Story 의 하위로 자동 연결됩니다.
           예를 들어 혁신/개선업무(O-2) 파트 Story 아래에는 9명의 Story 가 모두 포함됩니다.

--- a/docs/company/OKR_Structure_Guide.html
+++ b/docs/company/OKR_Structure_Guide.html
@@ -10,6 +10,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js"></script>
+  <script>
+    // === FOUC prevention: apply theme before body renders ===
+    (function () {
+      var t = localStorage.getItem('viz-theme');
+      if (!t) t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      document.documentElement.className = 'theme-' + t;
+    })();
+  </script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root { interpolate-size: allow-keywords; }
@@ -1143,7 +1151,10 @@
         a.href = url;
         a.download = 'okr-structure-guide.png';
         a.click();
-      } catch (e) { console.error('Download failed:', e); }
+      } catch (e) {
+        console.error('Download failed:', e);
+        alert('이미지 다운로드에 실패했습니다. 브라우저 콘솔에서 오류를 확인해 주세요.');
+      }
       menu.style.display = '';
     }
   </script>

--- a/docs/company/OKR_Structure_Guide.md
+++ b/docs/company/OKR_Structure_Guide.md
@@ -6,7 +6,8 @@
 > **관련 문서**:
 > - 상세 스펙: `JIRA_Story_draft_2026.md`
 > - 붙여넣기용: `paste_ready/` (개인별 `AIE-{letter}.md`)
-> - 코드 ↔ 실명 매핑 (PL 전용): `AIE_member_code_mapping.md`
+> - 코드 ↔ 실명 매핑 (TL 전용): `AIE_member_code_mapping.md`
+> - **Prefix 규칙 근거 PR**: [#147 `docs(company): rename [AIE 파트] prefix to [AIE O-N]`](https://github.com/dEitY719/dotfiles/pull/147) — 구 `[AIE 파트]` 공통 prefix 를 OKR 정렬(`[AIE O-N]`)로 재명명하며 공통 문법을 확정
 
 ---
 
@@ -51,13 +52,49 @@ GHRP 에서는 다음 5개 항목으로 평가합니다.
 | 부서원/개인역량강화 | 10% | 교육·자격·특허·논문 |
 | 수명업무 | tracking | 비계획 지시 업무 |
 
-**여기서의 설계 결정**: 각 평가 항목을 **하나의 Story** 로 만들어서 **Objective** 로 취급합니다. 그래서 Summary 접두어에 `O-N` 을 붙였습니다 (N = 1..5).
+**설계 결정**: 각 평가 항목을 **하나의 Story** 로 만들어 **Objective** 로 취급합니다. 그 결과, 모든 JIRA Summary 접두어가 **단 하나의 공통 문법** 하나로 귀결됩니다.
 
-- `[AIE O-1]` = 파트 레벨의 Objective 1 (조직목표달성)
-- `[AIE-δ O-1 K-n]` = 파트원 δ 의 Objective 1 — **M-1 은 제품별로 분류** 해야 해서 담당 제품 번호 `K-n` (n=1..4) 이 끝에 붙습니다
-- `[AIE-δ O-2]` = 파트원 δ 의 Objective 2 (혁신/개선업무, K 없음)
+### 1-1. Prefix 공통 문법 (확정)
 
-이렇게 하면 "평가받는 항목 = 일하는 단위" 가 되어 따로 매핑할 필요가 없습니다.
+모든 Summary 는 아래 한 문법으로 통일됩니다 — 이게 본 Structure 의 **설계 언어** 입니다.
+
+```text
+[ 소속   Objective-N   Key-N ]
+   ↓         ↓            ↓
+AIE      O-N (필수)     K-n (선택, O-1 에만)
+AIE-{letter}   N=1..5   n=1..4
+(파트 or 파트원)
+```
+
+**구성 요소**:
+
+| 요소 | 값 | 의미 |
+|------|-----|------|
+| **소속** | `AIE` | 파트 자신 |
+|       | `AIE-{letter}` | 파트원 (letter ∈ {δ, ξ, λ, ψ, σ, π, θ, ζ, γ}) |
+| **Objective** | `O-N` (N=1..5) | GHRP 5개 평가 항목과 1:1 대응 (필수) |
+| **Key** | `K-n` (n=1..4) | 핵심제품 번호 — **O-1 (조직목표달성) 에만** 부착 |
+
+**문법 규칙**:
+1. **왼쪽일수록 상위 레벨**, 오른쪽일수록 세부 분류 (읽기 순서 = 계층 순서)
+2. **Key (`K-n`) 는 항상 브라켓 맨 끝** — 담당 제품은 "어느 Objective 의 세부 분기인가" 를 표시하는 꼬리표
+3. **Epic 만 예외**: 파트 Epic 은 `[AIE M&V]` (Mission & Vision) — 최상위 미션이라 Objective 번호가 없음
+
+### 1-2. 공통 문법의 5가지 실제 인스턴스
+
+| # | 인스턴스 | 형식 | 예시 | 수량 |
+|---|---------|------|------|------|
+| 1 | 파트 Epic | `[AIE M&V]` | `[AIE M&V] 임직원이 체감하는 AI 효용성` | 1 |
+| 2 | 파트 Story | `[AIE O-N]` | `[AIE O-2] 2026 혁신/개선업무` | 5 (N=1..5) |
+| 3 | 파트 제품 Story | `[AIE O-1 K-n]` | `[AIE O-1 K-1] SLSI Agent App Store` | 4 (n=1..4) |
+| 4 | 파트원 M-1 Story | `[AIE-{letter} O-1 K-n]` | `[AIE-δ O-1 K-1] 2026 조직목표달성` | 9 (인당 1개, 담당 제품 n) |
+| 5 | 파트원 M-2~M-4 Story | `[AIE-{letter} O-N]` (N=2..4) | `[AIE-δ O-2] 2026 혁신/개선업무` | 27 (9명 × 3개) |
+
+합계 **46개** — Epic 1 + 파트 Story 5 + 제품 Story 4 + 파트원 Story 36 (M-1: 9 + M-2~4: 27). 수명업무(O-5) 는 **파트 Story 한 개만** 존재하고 파트원 개별 Story 는 없음 — Task 만 동적 생성됩니다.
+
+> **근거 문서**: PR [#147](https://github.com/dEitY719/dotfiles/pull/147) — `[AIE 파트]` 공통 prefix 의 가독성 문제를 해결하기 위해 OKR 업계 표준(`O` = Objective) 을 도입, 동시에 향후 KR 레벨(`[AIE O-1 KR-1.1]`) 확장 여지까지 확보.
+
+이렇게 하면 **"평가받는 항목 = 일하는 단위 = Summary 접두어"** 가 1:1 매핑되어 별도 Label/Component 없이 접두어만으로 JQL 필터링이 가능해집니다 (→ §6 참조).
 
 ---
 
@@ -92,7 +129,7 @@ Story 는 **큰 틀** 입니다. 그 아래에 실제 업무를 **Task / Sub-tas
 
 ### Summary 의 letter 가 왜 Greek 문자인가?
 
-δ, ξ, λ 같은 Greek letter 는 **실명 비노출** 을 위한 토큰입니다. Evaluation grade 같은 민감 정보를 JIRA Summary 에 실수로 노출하지 않기 위한 장치 — 실명 매핑은 PL 전용 `AIE_member_code_mapping.md` 에만 존재합니다.
+δ, ξ, λ 같은 Greek letter 는 **실명 비노출** 을 위한 토큰입니다. Evaluation grade 같은 민감 정보를 JIRA Summary 에 실수로 노출하지 않기 위한 장치 — 실명 매핑은 TL 전용 `AIE_member_code_mapping.md` 에만 존재합니다.
 
 **letter 는 평생 토큰** 입니다. 한 번 배정된 letter 는 변경하지 않습니다. 과거 JIRA 이력·평가 기록·검색 쿼리 전체가 letter 를 키로 연결되기 때문입니다.
 
@@ -247,7 +284,7 @@ summary ~ "AIE O-5"
 1. **본인의 4개 Story 만 관리** 하세요. (조직목표달성 1, 혁신/개선 1, 시너지 1, 역량강화 1)
 2. 그 아래에 Task / Sub-task 를 **자유롭게** 만드세요. 규칙은 **Link 를 해당 Story 하위로** 유지하는 것 하나.
 3. Task 완료 시마다 Status 를 업데이트하세요. rollup 은 Structure 가 자동 처리합니다.
-4. 월 1회 1:1 때 본인의 Story 를 펼쳐서 같이 리뷰합니다 (PL 이 준비).
+4. 월 1회 1:1 때 본인의 Story 를 펼쳐서 같이 리뷰합니다 (TL 이 준비).
 5. 수명업무(비계획 지시)는 `[AIE O-5]` 하위에 Task 로 등록하세요 — 나중에 OKR 재조정의 근거가 됩니다.
 
 ### 기억해주세요
@@ -263,7 +300,7 @@ summary ~ "AIE O-5"
 | 문서 | 용도 | 접근 권한 |
 |------|------|-----------|
 | `JIRA_Story_draft_2026.md` | 전체 45 Story 상세 스펙 | 파트 전체 |
-| `paste_ready/AIE-{letter}.md` | 개인별 JIRA 복붙용 | 본인 + PL |
-| `paste_ready/part_independent.md` | 파트 Story 복붙용 | PL |
-| `AIE_member_code_mapping.md` | letter ↔ 실명 매핑 | **PL 전용** |
+| `paste_ready/AIE-{letter}.md` | 개인별 JIRA 복붙용 | 본인 + TL |
+| `paste_ready/part_independent.md` | 파트 Story 복붙용 | TL |
+| `AIE_member_code_mapping.md` | letter ↔ 실명 매핑 | **TL 전용** |
 | 본 문서 | 컨셉 설명 (onboarding) | 파트 전체 |

--- a/docs/company/OKR_Structure_Guide.md
+++ b/docs/company/OKR_Structure_Guide.md
@@ -87,10 +87,10 @@ AIE-{letter}   N=1..5   n=1..4
 | 1 | 파트 Epic | `[AIE M&V]` | `[AIE M&V] 임직원이 체감하는 AI 효용성` | 1 |
 | 2 | 파트 Story | `[AIE O-N]` | `[AIE O-2] 2026 혁신/개선업무` | 5 (N=1..5) |
 | 3 | 파트 제품 Story | `[AIE O-1 K-n]` | `[AIE O-1 K-1] SLSI Agent App Store` | 4 (n=1..4) |
-| 4 | 파트원 M-1 Story | `[AIE-{letter} O-1 K-n]` | `[AIE-δ O-1 K-1] 2026 조직목표달성` | 9 (인당 1개, 담당 제품 n) |
-| 5 | 파트원 M-2~M-4 Story | `[AIE-{letter} O-N]` (N=2..4) | `[AIE-δ O-2] 2026 혁신/개선업무` | 27 (9명 × 3개) |
+| 4 | 파트원 O-1 Story | `[AIE-{letter} O-1 K-n]` | `[AIE-δ O-1 K-1] 2026 조직목표달성` | 9 (인당 1개, 담당 제품 n) |
+| 5 | 파트원 O-2~O-4 Story | `[AIE-{letter} O-N]` (N=2..4) | `[AIE-δ O-2] 2026 혁신/개선업무` | 27 (9명 × 3개) |
 
-합계 **46개** — Epic 1 + 파트 Story 5 + 제품 Story 4 + 파트원 Story 36 (M-1: 9 + M-2~4: 27). 수명업무(O-5) 는 **파트 Story 한 개만** 존재하고 파트원 개별 Story 는 없음 — Task 만 동적 생성됩니다.
+합계 **46개** — Epic 1 + 파트 Story 5 + 제품 Story 4 + 파트원 Story 36 (O-1: 9 + O-2~O-4: 27). 수명업무(O-5) 는 **파트 Story 한 개만** 존재하고 파트원 개별 Story 는 없음 — Task 만 동적 생성됩니다.
 
 > **근거 문서**: PR [#147](https://github.com/dEitY719/dotfiles/pull/147) — `[AIE 파트]` 공통 prefix 의 가독성 문제를 해결하기 위해 OKR 업계 표준(`O` = Objective) 을 도입, 동시에 향후 KR 레벨(`[AIE O-1 KR-1.1]`) 확장 여지까지 확보.
 


### PR DESCRIPTION
## Summary
- 파트원용 `OKR_Structure_Guide.md` 확장: §1-1/§1-2 Prefix 공통 문법 확정 섹션 추가
- `[소속 Objective-N Key-N]` 단일 문법으로 전체 prefix 체계 정형화 + PR #147 근거 링크
- Single-file HTML visualization (`OKR_Structure_Guide.html`) 신규 추가 — 파트원 배포용

## Changes

### `1b82436` expand OKR guide with prefix grammar section
- **§1-1** Prefix 공통 문법 `[소속 Objective-N Key-N]` 분해표 + 문법 규칙 3종
  - 소속 (`AIE` vs `AIE-{letter}`), Objective (`O-N`, N=1..5), Key (`K-n`, n=1..4, O-1 전용)
  - 왼쪽일수록 상위 레벨 + Key 는 항상 브라켓 맨 끝 + Epic 예외 (`[AIE M&V]`)
- **§1-2** 5가지 실제 인스턴스 표 + 수량 검증 (Epic 포함 46, 제외 45)
- 상단 관련 문서에 [PR #147](https://github.com/dEitY719/dotfiles/pull/147) 링크 추가
- `PL` → `TL` (Technical Leader) 용어 통일

### `e2123fa` add OKR structure guide HTML visualization
- Single-file long-scroll infographic `OKR_Structure_Guide.html` (1,151 lines, 52 KB)
- 8 sections: Hero / Stats / TL;DR Flow / Prefix Grammar / Level 1~3 Bottom-up / JQL Cheatsheet / Closing
- 3-color syntax diagram for `[소속 O-N K-n]` + 5 인스턴스 인터랙티브 표
- 7 JQL 질문·쿼리·결과 카드 (syntax-highlighted code blocks)
- Light/Dark 테마 토글 · PNG 다운로드 · Print/PDF · 375px 반응형
- Noto Sans KR + JetBrains Mono 트리 다이어그램

## Test plan
- [ ] 로컬에서 `OKR_Structure_Guide.html` 렌더 확인 (Light/Dark 토글 작동)
- [ ] bottom-up 흐름 (개인 → 파트 → 팀) 이 자연스럽게 연결되는지 스팟체크
- [ ] §1-1/§1-2 설명이 `JIRA_Story_draft_2026.md` 스펙과 정합되는지 교차검증
- [ ] 7개 JQL 쿼리를 실제 JIRA 에서 실행하여 의도된 결과가 조회되는지 확인
- [ ] 375px 뷰포트 (모바일) 에서 horizontal overflow 없는지
- [ ] Print 프리뷰에서 page-break 가 섹션 경계에 올바르게 위치하는지

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
