### PR TITLE
docs(gh-commit): clarify auto-inspection and manual-edit handling

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -3,9 +3,13 @@ name: gh:commit
 description: >-
   Create a git commit for the current changes following the repo's style,
   auto-linking a GitHub issue number if it appears in the recent conversation
-  or is passed as an argument. Use when the user runs /gh:commit, /gh-commit,
-  or asks "커밋해", "지금까지 작업 커밋", "이슈 N번 연결해서 커밋". Creates a new
-  commit — never amends. Never skips hooks.
+  or is passed as an argument. Always inspects the current working-tree state
+  first — works equally for changes made by Claude in this conversation and
+  for changes the user made manually outside the conversation (e.g. quick
+  alias additions). Use when the user runs /gh:commit, /gh-commit, or asks
+  "커밋해", "지금까지 작업 커밋", "이슈 N번 연결해서 커밋". The user does NOT
+  need to prefix with "git status 확인하고" — that is step 1 of this skill.
+  Creates a new commit — never amends. Never skips hooks.
 allowed-tools: Bash, Read, Grep
 ---
 
@@ -17,7 +21,12 @@ Stage the relevant changes and create a new git commit that follows the
 repository's existing commit style, with an optional `Refs #N` / `Closes #N`
 footer when a GitHub issue is known.
 
-## Step 1: Inspect State (parallel)
+## Step 1: Inspect State (parallel) — ALWAYS FIRST
+
+This step runs **unconditionally** on every invocation, even bare `/gh-commit`
+with no prior conversation context. The working-tree state observed here is
+the source of truth — do NOT ask the user "what did you change?" before
+running these.
 
 Run these in a single message:
 - `git status` (never `-uall`)
@@ -40,6 +49,14 @@ Check in this order and use the first hit:
 Read `references/commit-message-format.md` for the message template, HEREDOC
 pattern, and `Closes` / `Refs` / `Fixes` rules. Match the repo's commit style
 derived from `git log`.
+
+**When there is no prior conversation context** (user ran `/gh-commit` on
+their own manual edits), derive intent from the diff itself:
+- File paths and function/alias names tell you *what* area changed.
+- Small additions (one new alias, one new config line) get a short subject
+  like `chore(aliases): add <name> shortcut` — no body required.
+- Do NOT ask the user "what was the intent?" for obviously self-describing
+  changes. Only ask if the diff is ambiguous or spans unrelated areas.
 
 ## Step 4: Stage and Commit
 

--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -54,7 +54,9 @@ derived from `git log`.
 their own manual edits), derive intent from the diff itself:
 - File paths and function/alias names tell you *what* area changed.
 - Small additions (one new alias, one new config line) get a short subject
-  like `chore(aliases): add <name> shortcut` — no body required.
+  like `chore(aliases): add <name> shortcut` — explanation body can be omitted
+  (but mandatory footers like `Co-Authored-By` still apply per
+  `references/commit-message-format.md`).
 - Do NOT ask the user "what was the intent?" for obviously self-describing
   changes. Only ask if the diff is ambiguous or spans unrelated areas.
 


### PR DESCRIPTION
## Summary
- Clarify that `/gh-commit` always inspects working-tree state first, including when the user has made manual edits outside the conversation.
- No workflow change — only description / Step 1 / Step 3 wording in `SKILL.md`.

## Changes
- `claude/skills/gh-commit/SKILL.md`
  - Frontmatter `description`: now states the skill works equally for Claude-made and user-made changes, and explicitly notes the user does NOT need to prefix `/gh-commit` with "git status 확인하고".
  - Step 1: adds an "ALWAYS FIRST" subtitle and a sentence clarifying that state inspection runs unconditionally on every invocation — the working tree is the source of truth.
  - Step 3: adds a branch for when there is no prior conversation context — infer intent from the diff (file paths, alias names), use short subjects for simple additions, and skip the "what was the intent?" question for self-describing changes.

## Test plan
- [ ] Run bare `/gh-commit` against a manually-edited file with no prior Claude conversation context and confirm `git status` / `git diff` run first without asking for intent.
- [ ] Add a single alias line and verify the drafted subject is a short `chore(aliases): ...` with no body.
- [ ] `wc -l claude/skills/gh-commit/SKILL.md` stays under 100 (Progressive Disclosure).

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
