### PR TITLE
refactor(gbr): clarify teardown blocker with PR # and action list

### DIFF
--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -218,9 +218,27 @@ git_branch_teardown() {
                 : # expected: remote branch deleted (PR merged + auto-delete or manual Delete button)
                 ;;
             *)
-                ux_error "Remote branch '$upstream_ref' still exists — PR not merged yet?"
-                ux_info "Track status: ${upstream_track:-up-to-date}"
-                ux_info "Run 'git fetch --prune' first (refreshes [gone]), or use --force to override."
+                # Best-effort PR lookup — surfaces "#151 OPEN" so the blocker is obvious
+                # at a glance. Silent on gh missing/unauthed; table row is just skipped.
+                local pr_info=""
+                if command -v gh >/dev/null 2>&1; then
+                    pr_info="$(gh pr list --head "$branch" --state all --limit 1 \
+                        --json number,state,url \
+                        --jq '.[0] | "#\(.number) \(.state)  \(.url)"' 2>/dev/null)"
+                fi
+
+                ux_error "Cannot tear down — PR not merged yet"
+                echo ""
+                ux_table_row "Branch" "$branch"
+                ux_table_row "Upstream" "$upstream_ref  (still on remote)"
+                ux_table_row "Track status" "${upstream_track:-up-to-date}"
+                if [ -n "$pr_info" ]; then
+                    ux_table_row "Pull request" "$pr_info"
+                fi
+                echo ""
+                ux_info "What to do next:"
+                ux_bullet "Merge the PR on GitHub, then: git fetch --prune && gbr teardown"
+                ux_bullet "Or override the safety check: gbr teardown --force"
                 return 1
                 ;;
         esac


### PR DESCRIPTION
## Summary
- `gbr teardown` previously printed three flat `ux_error`/`ux_info` lines when the remote branch still existed, so the blocker (unmerged PR) was easy to miss.
- This PR switches the blocker path to a `ux_lib`-rendered block with a clear title, a 4-row status table, and a `ux_bullet` action list.
- Adds a **best-effort `gh pr list --head`** lookup so the actual PR number/state/URL appears inline — e.g. `Pull request : #151 OPEN  https://github.com/…`. Silent when `gh` is missing or unauthed; the table row is just skipped.

## Before vs After

**Before**
```
❌ Remote branch 'origin/feat/foo' still exists — PR not merged yet?
ℹ️  Track status: up-to-date
ℹ️  Run 'git fetch --prune' first (refreshes [gone]), or use --force to override.
```

**After**
```
❌ Cannot tear down — PR not merged yet

  Branch         : feat/foo
  Upstream       : origin/feat/foo  (still on remote)
  Track status   : up-to-date
  Pull request   : #151 OPEN  https://github.com/dEitY719/dotfiles/pull/151

ℹ️  What to do next:
  ◆ Merge the PR on GitHub, then: git fetch --prune && gbr teardown
  ◆ Or override the safety check: gbr teardown --force
```

## Notes
- No new dependencies — uses `gh`'s built-in `--jq` flag, so `jq` is NOT required on the user's system.
- Same control flow and return-code semantics; purely presentational.
- If `gh` is missing or the user is unauthed, the `Pull request` row is skipped gracefully and the rest of the block still renders.

## Test plan
- [x] `shellcheck -s sh shell-common/functions/git_branch.sh` — only pre-existing SC3043 warnings (same class as other `local` declarations in this file; none newly introduced)
- [x] Simulated render in zsh with seeded `branch`/`upstream_ref`/`upstream_track` shows the new block, with the `gh` lookup resolving a real PR (verified against #151)
- [ ] Manual smoke: `gbr teardown` on an un-merged branch shows the new block
- [ ] Manual smoke: `gbr teardown` on a merged+deleted-remote branch still proceeds (success path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
