### PR TITLE
feat(hooks): block direct commits on main/master via pre-commit guard

### DIFF
--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: gh:pr-approve
+description: >-
+  Review a GitHub PR a colleague requested you review, then either approve
+  with an LGTM 👍 summary if flawless, or file remaining concerns as
+  follow-up GitHub issues and link them from a PR comment. Use when the
+  user runs /gh-pr-approve, /gh:pr-approve, or asks "PR 리뷰하고 승인해",
+  "approve PR 99", "#99 리뷰 승인", "동료 PR 검토 후 approve", "re-review
+  requested". Preserves the AI-driven issue workflow — non-blocking items
+  become issues the team can triage automatically, real blockers get an
+  explicit "Request changes" review. Project-agnostic; works in any repo
+  reachable via gh CLI. Accepts `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# gh:pr-approve — Review → Approve or File Follow-up Issues
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Resolve + Pre-flight Gate (parallel)
+
+Resolve context, then fetch pre-flight signals in parallel before
+reading the diff:
+
+- `TARGET_REPO` from `git remote get-url <remote>` (arg #2, default
+  `origin`). Missing remote → list `git remote -v` and stop.
+- PR number: explicit arg #1 → `gh pr view --json number` on current
+  branch → stop and ask.
+- `ME=$(gh api user -q .login)` for self-review / re-review checks.
+- PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,files`
+- Prior reviews/comments on this PR by `ME`
+- `gh pr checks <N> --repo $TARGET_REPO`
+
+**Stop conditions** (explain, don't approve): `state != OPEN` ·
+`isDraft == true` · `author.login == ME` · `mergeable == CONFLICTING` ·
+any required check failing.
+
+If prior `ME` comments/reviews exist → **re-review mode**: primary goal
+is verifying each prior concern was addressed by a subsequent commit.
+
+## Step 2: Fetch Review Material + Review
+
+In parallel: `gh pr diff <N>`, `gh pr view <N> --json commits`, and the
+three comment endpoints in `references/review-criteria.md`. Apply that
+file's checklist — correctness, conventions, security, performance,
+tests. In re-review mode, map each prior concern to the commit that
+resolved it (or flag "unresolved").
+
+## Step 3: Classify Findings
+
+Each concern is exactly one of **BLOCKER** (must fix before merge),
+**FOLLOW-UP** (valid but non-blocking), or **PRAISE** (collect ≥1 for
+approvals, anchored to a concrete diff location). See
+`references/review-criteria.md` for the BLOCKER / FOLLOW-UP line.
+
+Path selection:
+- 0 BLOCKER, 0 FOLLOW-UP → **4a** clean LGTM
+- 0 BLOCKER, ≥1 FOLLOW-UP → **4b** approve with follow-up issues
+- ≥1 BLOCKER → **4c** request changes
+
+## Step 4: Submit Review
+
+Command shapes + body templates in `references/approval-templates.md`.
+Match the language dominant in the PR (Korean PR → Korean review).
+
+- **4a** `gh pr review --approve` with 👍 + 2–4 specific compliments.
+- **4b** One `gh issue create` per FOLLOW-UP → one PR comment linking
+  all of them → `gh pr review --approve`.
+- **4c** `gh pr review --request-changes` listing each BLOCKER with a
+  `file:line` pointer. Never silently file blockers as issues — they
+  stay on the PR so the author's next push triggers natural re-review.
+
+## Step 5: Verify and Report
+
+Re-fetch `reviewDecision` + `mergeStateStatus`. If still BLOCKED despite
+an approval, diagnose (another reviewer CHANGES_REQUESTED, required
+check pending, branch out of date, reviewer lacks write access) and
+include that in the report.
+
+Print:
+```
+PR #<N>: <APPROVED|CHANGES_REQUESTED>
+  Blockers:   <n>
+  Follow-ups: <n>  → issues: #A, #B
+  Merge:      <CLEAN|BLOCKED — <reason>>
+  <PR URL>
+```
+
+## Constraints
+
+- Never approve without reading the diff, nor approve your own PR.
+- Compliments must reference concrete diff locations — no generic praise.
+- Never fabricate follow-ups to look thorough. Each issue must represent
+  a real concern you can defend.
+- Never merge the PR — the author decides when to merge.
+- No labels/milestones on follow-up issues unless `gh label list` confirms the label exists.

--- a/claude/skills/gh-pr-approve/references/approval-templates.md
+++ b/claude/skills/gh-pr-approve/references/approval-templates.md
@@ -1,0 +1,151 @@
+# Approval Templates — for gh:pr-approve skill
+
+All three paths write the body to a `mktemp` file first (avoids shell-escaping and concurrent-run collisions), then call `gh`. Match the language dominant in the PR body/comments.
+
+```bash
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write the drafted body to "$BODY" ...
+```
+
+## 6a — Clean LGTM
+
+No findings. Approve with 👍 and 2–4 specific compliments.
+
+### Body template
+
+```markdown
+LGTM 👍
+
+### 요약
+<한 문단 — 이 PR이 달성한 것, 리뷰 관점의 핵심 포인트>
+
+### 잘 된 점
+- <file:path:line 또는 short-sha 근거>로 <왜 좋은지>
+- <...>
+- <...>
+
+<선택: 이 PR이 프로젝트에 주는 가치를 1줄로>
+```
+
+### Command
+
+```bash
+gh pr review <N> --repo "$TARGET_REPO" --approve --body-file "$BODY"
+```
+
+## 6b — Approve with Follow-up Issues
+
+No BLOCKERs, ≥1 FOLLOW-UP. Three-step sequence — **do them in order**.
+
+### Step 1 — Create one issue per follow-up
+
+```bash
+ISSUE_BODY=$(mktemp) && trap 'rm -f "$ISSUE_BODY"' EXIT
+# ... write the issue body ...
+gh issue create \
+  --repo "$TARGET_REPO" \
+  --title "<type>: <concise description>" \
+  --body-file "$ISSUE_BODY"
+```
+
+Issue body template:
+
+```markdown
+## 배경
+PR #<PR> 리뷰 중 발견된 후속 개선 항목.
+
+## 현상
+<file:path:line 또는 함수/블록 이름>에서 <observation>.
+
+## 제안
+<actionable fix — code snippet or prose>
+
+## 참고
+- Refs #<PR> (리뷰 시점: <short-sha>)
+- <optional: 관련 docs/링크>
+```
+
+Collect each created issue number for Step 2.
+
+### Step 2 — Post one PR comment linking all follow-ups
+
+```bash
+COMMENT_BODY=$(mktemp) && trap 'rm -f "$COMMENT_BODY"' EXIT
+# ... write comment body ...
+gh pr comment <N> --repo "$TARGET_REPO" --body-file "$COMMENT_BODY"
+```
+
+Comment template:
+
+```markdown
+리뷰하면서 발견한 후속 개선 항목을 이슈로 분리해 두었습니다. 이 PR 머지와 독립적으로 처리해주시면 됩니다.
+
+- #<A> — <한 줄 요약>
+- #<B> — <한 줄 요약>
+- #<C> — <한 줄 요약>
+
+Approve는 별도로 제출합니다 — 아래 리뷰 참고.
+```
+
+### Step 3 — Submit approving review
+
+Body template (extends 6a + a follow-up section):
+
+```markdown
+LGTM 👍
+
+### 요약
+<PR 핵심 요약 1문단>
+
+### 잘 된 점
+- <file:line 근거로 왜 좋은지>
+- <...>
+
+### 후속 개선 (별도 이슈)
+- #<A>, #<B>, #<C> — 본 PR 머지와 독립적으로 추적합니다.
+```
+
+```bash
+gh pr review <N> --repo "$TARGET_REPO" --approve --body-file "$BODY"
+```
+
+## 6c — Request Changes (BLOCKERs present)
+
+Never approve. List each blocker with a `file:line` pointer and the minimal fix expected. Blockers stay on the PR; the author's next push triggers natural re-review.
+
+### Body template
+
+```markdown
+머지 전에 반드시 수정이 필요한 항목이 있어 **Request changes**로 남깁니다.
+
+### Blockers
+
+1. **<short title>** — `<file>:<line>`
+   - 증상: <what's wrong>
+   - 제안: <minimal fix>
+   - 근거: <why this blocks merge — regression / security / spec violation>
+
+2. **<...>** — `<file>:<line>`
+   - ...
+
+### 참고로 잘 된 점
+- <1–2 specific compliments so the author knows what to keep>
+
+수정 후 push 주시면 재리뷰하겠습니다.
+```
+
+### Command
+
+```bash
+gh pr review <N> --repo "$TARGET_REPO" --request-changes --body-file "$BODY"
+```
+
+## Language matching
+
+Scan the PR body + most recent 3 human comments. Reply in the dominant language. Korean PR → Korean review. Mixed → match the PR body.
+
+## Don'ts
+
+- **Never** attach `--label`/`--assignee`/`--milestone` to follow-up issues unless verified via `gh label list` / `gh api` that they exist — silent failures or surprise taxonomy damage is worse than terse issues.
+- **Never** submit a `--comment` review as a substitute for `--approve`. "Comment" reviews don't satisfy branch protection and will confuse the author.
+- **Never** re-submit a review if one already exists — GitHub dismisses stale ones; check `reviewDecision` first.

--- a/claude/skills/gh-pr-approve/references/help.md
+++ b/claude/skills/gh-pr-approve/references/help.md
@@ -1,0 +1,41 @@
+# gh:pr-approve — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | PR number, or `-h`/`--help`/`help` | required unless current branch has a PR | Target PR, e.g. `99` |
+| 2 | remote name | `origin` | Git remote for the target repo |
+
+## Usage
+
+- `/gh-pr-approve 99` — review PR #99 on `origin`
+- `/gh-pr-approve 99 upstream` — PR #99 on `upstream`'s repo
+- `/gh-pr-approve` — review the PR open on the current branch
+- `/gh-pr-approve -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Pre-flight gate — checks PR state, draft, author, merge conflicts, required CI.
+   Stops early on any blocker (won't approve your own PR, can't approve a draft, etc.).
+2. Fetches diff, commits, and all three comment endpoints (inline / issue / review).
+3. Reviews against `references/review-criteria.md` — correctness, conventions, security,
+   performance, tests. If you previously reviewed this PR, enters re-review mode and
+   verifies every prior concern was addressed.
+4. Classifies findings as BLOCKER, FOLLOW-UP, or PRAISE.
+5. Submits the review:
+   - 0 BLOCKER, 0 FOLLOW-UP → **Approve with LGTM 👍** + specific compliments.
+   - 0 BLOCKER, ≥1 FOLLOW-UP → files each follow-up as a GitHub issue, posts one PR
+     comment linking them, then approves. Keeps the AI-driven issue workflow intact.
+   - ≥1 BLOCKER → **Request changes** with per-blocker file:line pointers. Blockers
+     stay on the PR so the author's next push triggers natural re-review.
+6. Re-fetches `reviewDecision` + `mergeStateStatus` and reports a compact summary
+   (plus diagnosis if merge is still blocked for reasons outside your review).
+
+## What the skill won't do
+
+- Approve your own PR.
+- Approve without reading the diff.
+- Merge the PR (author decides).
+- Create follow-up issues for trivia that don't justify a tracked item.
+- Attach labels/milestones to follow-up issues unless the label already exists in the repo.

--- a/claude/skills/gh-pr-approve/references/review-criteria.md
+++ b/claude/skills/gh-pr-approve/references/review-criteria.md
@@ -1,0 +1,69 @@
+# Review Criteria — for gh:pr-approve skill
+
+## Three comment endpoints (fetch all)
+
+Bot tools and humans scatter feedback across three APIs. Missing one means missing comments.
+
+```bash
+# Inline code review comments (line-anchored)
+gh api "repos/<owner>/<repo>/pulls/<N>/comments" --paginate
+
+# Top-level issue-style comments on the PR conversation
+gh api "repos/<owner>/<repo>/issues/<N>/comments" --paginate
+
+# Review summaries (bots often put content here)
+gh api "repos/<owner>/<repo>/pulls/<N>/reviews" --paginate
+```
+
+For threading / dedup details see the sibling skill
+`gh-pr-reply/references/comment-fetching.md` if installed.
+
+## Review checklist
+
+Work through each dimension; skip categories that don't apply to the diff.
+
+1. **Correctness** — does the code do what the PR title/body says? Spot-check each changed hunk against the claim. For scripts, trace the happy path + one failure path.
+2. **Conventions** — naming, file location, import order, error-handling idioms match the surrounding code. Check for any `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, or `.editorconfig` in the repo root or changed directories and apply those rules.
+3. **Security** — input validation, shell-injection (`set -euo pipefail`, quoted expansions), hardcoded secrets, unsafe `eval`, missing authn/z checks, over-broad `sudo` usage, signed-by on apt keys, etc.
+4. **Performance** — obvious N+1 patterns, unnecessary I/O inside hot loops, missing caching on expensive calls. Don't over-engineer — flag only concrete wins.
+5. **Tests** — are the new paths covered? If the repo has a test suite and the PR touches logic, absence of tests is usually a BLOCKER. Docs-only or shell-bootstrap scripts can waive this with a note.
+6. **Docs / comments** — public API changes without doc updates, lies in comments, stale references.
+7. **Backward compatibility** — breaking API/CLI/config changes flagged in the PR body? Migration path documented?
+
+## Re-review verification (when prior comments by ME exist)
+
+Re-review mode is the dominant case for this skill. The contract is:
+**every prior concern must be accounted for**.
+
+1. Pull the list of prior comments/reviews by `ME` from the three endpoints.
+2. For each concern, locate one of:
+   - A commit in the PR that resolves it (link the short SHA in the review body).
+   - A follow-up issue the author opened with a back-link to the PR.
+   - A reply from the author explaining why it was declined (judge: is the reasoning acceptable?).
+3. Any concern with none of the above → escalate to **BLOCKER** (unresolved prior review comment).
+
+Do not silently let a prior concern drop. That erodes trust in the review process.
+
+## BLOCKER vs FOLLOW-UP — where to draw the line
+
+Ask: *"If the author merged this PR right now, would something break or regress?"*
+
+- **Yes** → BLOCKER. Request changes. Examples: failing tests, introduced bug, security regression, API break without migration, unresolved prior review concern.
+- **No, but the team would want it tracked** → FOLLOW-UP. File an issue. Examples: nice refactor, test-coverage gap on an untriggered path, doc phrasing improvement, TODO left unresolved for a future edge case, minor idiom mismatch with the rest of the codebase.
+- **No and too small to track** → PRAISE or ignore. Don't file trivia as an issue — it creates noise and trains the team to ignore your issues.
+
+When in doubt between FOLLOW-UP and ignore: file it if you can state, in one sentence, the concrete harm of leaving it. Otherwise drop it.
+
+## Praise is part of the review
+
+Approvals without specifics ("LGTM!") teach authors nothing. Every approval body should include ≥1 compliment anchored to a file:line or commit SHA. Examples:
+
+- `set -euo pipefail` + `pipefail`-aware piping in `scripts/install.sh:2`
+- `BASH_SOURCE` anchoring for idempotent lock files at `b665789`
+- Table in `setup.md` making the lock-file convention discoverable
+
+Generic praise ("great job!", "looks good!") is worse than none — it signals a skimmed review.
+
+## Self-review guard
+
+Before submitting: if the PR author's login equals `ME`, stop. GitHub itself will reject the approval, but the skill should fail fast with a clear message rather than let `gh pr review` error out.

--- a/git/hooks/checks/main_branch_guard.sh
+++ b/git/hooks/checks/main_branch_guard.sh
@@ -14,19 +14,23 @@
 #
 # No arguments. Reads HEAD via `git symbolic-ref` to find current branch.
 # Honors env var ALLOW_MAIN_COMMIT=1 as an escape hatch.
+#
+# Side effect: exports MAIN_BRANCH_GUARD_CURRENT so callers can display
+# the branch name in error messages without re-forking `git symbolic-ref`.
+# Empty on detached HEAD or when the escape hatch is active.
 check_main_branch_guard() {
     # Escape hatch: user explicitly opted in.
+    MAIN_BRANCH_GUARD_CURRENT=""
     if [ "${ALLOW_MAIN_COMMIT:-0}" = "1" ]; then
         return 0
     fi
 
-    local current_branch
-    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+    MAIN_BRANCH_GUARD_CURRENT=$(git symbolic-ref --short HEAD 2>/dev/null || true)
 
     # Detached HEAD (e.g. rebase, bisect) — nothing to guard.
-    [ -z "$current_branch" ] && return 0
+    [ -z "$MAIN_BRANCH_GUARD_CURRENT" ] && return 0
 
-    case "$current_branch" in
+    case "$MAIN_BRANCH_GUARD_CURRENT" in
         main | master)
             return 1
             ;;

--- a/git/hooks/checks/main_branch_guard.sh
+++ b/git/hooks/checks/main_branch_guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# git/hooks/checks/main_branch_guard.sh
+#
+# Blocks commits on protected branches (main, master) to prevent
+# accidental direct commits. Intended for workflows where all work
+# happens on feature branches and lands on main via pull requests.
+#
+# Escape hatch:
+#   ALLOW_MAIN_COMMIT=1 git commit ...
+#
+# Returns 0 if the current branch is allowed, 1 otherwise.
+
+# check_main_branch_guard
+#
+# No arguments. Reads HEAD via `git symbolic-ref` to find current branch.
+# Honors env var ALLOW_MAIN_COMMIT=1 as an escape hatch.
+check_main_branch_guard() {
+    # Escape hatch: user explicitly opted in.
+    if [ "${ALLOW_MAIN_COMMIT:-0}" = "1" ]; then
+        return 0
+    fi
+
+    local current_branch
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+
+    # Detached HEAD (e.g. rebase, bisect) — nothing to guard.
+    [ -z "$current_branch" ] && return 0
+
+    case "$current_branch" in
+        main | master)
+            return 1
+            ;;
+    esac
+
+    return 0
+}

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -94,6 +94,25 @@ source_check_or_exit "${CHECKS_DIR}/help_integrity_check.sh"
 source_check_or_exit "${CHECKS_DIR}/auto_execution_check.sh"
 source_check_or_exit "${CHECKS_DIR}/direct_exec_guard_check.sh"
 source_check_or_exit "${CHECKS_DIR}/shellcheck_check.sh"
+source_check_or_exit "${CHECKS_DIR}/main_branch_guard.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Protected-branch guard (fail fast, before any file scanning)
+# ═══════════════════════════════════════════════════════════════════════════
+
+if ! check_main_branch_guard; then
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "<unknown>")
+    echo ""
+    echo -e "${RED}✗ BLOCKING: direct commit on protected branch '${current_branch}'${NC}"
+    echo ""
+    echo -e "${YELLOW}  Create a feature branch first, for example:${NC}"
+    echo -e "${YELLOW}    git switch -c feat/your-change${NC}"
+    echo ""
+    echo -e "${YELLOW}  Escape hatch (use sparingly, e.g. release/hotfix commits):${NC}"
+    echo -e "${YELLOW}    ALLOW_MAIN_COMMIT=1 git commit ...${NC}"
+    echo ""
+    exit 1
+fi
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Get staged files (git diff --cached)

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -101,9 +101,8 @@ source_check_or_exit "${CHECKS_DIR}/main_branch_guard.sh"
 # ═══════════════════════════════════════════════════════════════════════════
 
 if ! check_main_branch_guard; then
-    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "<unknown>")
     echo ""
-    echo -e "${RED}✗ BLOCKING: direct commit on protected branch '${current_branch}'${NC}"
+    echo -e "${RED}✗ BLOCKING: direct commit on protected branch '${MAIN_BRANCH_GUARD_CURRENT:-<unknown>}'${NC}"
     echo ""
     echo -e "${YELLOW}  Create a feature branch first, for example:${NC}"
     echo -e "${YELLOW}    git switch -c feat/your-change${NC}"


### PR DESCRIPTION
## Summary
- Adds a pre-commit guard that blocks direct commits on `main`/`master`, catching accidental main-branch commits at the local hook layer before they're pushed or reach CI.
- Fails fast (early in the pre-commit chain, before shellcheck / help-integrity passes) so the user sees the branch error immediately.
- Honors `ALLOW_MAIN_COMMIT=1` as an escape hatch for intentional release/hotfix commits — this is a safety net, not a policy wall.

## Changes
- `git/hooks/checks/main_branch_guard.sh` (new, 36 lines): defines `check_main_branch_guard()`. Reads HEAD via `git symbolic-ref`, honors `ALLOW_MAIN_COMMIT=1`, passes through detached HEAD (rebase, bisect) untouched, and returns 1 only when the current branch is `main` or `master`.
- `git/hooks/pre-commit`: sources the new check and wires it into the pre-commit chain **before** the file-scanning passes. On failure, prints a red `✗ BLOCKING` message with the current branch name and yellow hint lines pointing at `git switch -c feat/…` and the `ALLOW_MAIN_COMMIT=1` escape hatch.

## Test plan
- [x] Commit on this feature branch (`feat/main-branch-guards`) — commit `85d8e88` itself exercised the allow path end-to-end.
- [ ] Smoke: `git checkout main && touch /tmp/x && git add /tmp/x && git commit -m test` → should block with the red message and exit 1.
- [ ] Smoke: `ALLOW_MAIN_COMMIT=1 git commit …` on main → should pass.
- [ ] Smoke: during an interactive rebase (detached HEAD) → guard should pass through without interference.
- [ ] Ordering: verify the `BLOCKING` message appears within a second of invoking `git commit` on main — it must fire before the slower shellcheck/help-integrity checks.

## Notes
- Self-hosting moment: from this PR forward, the guard enforces itself — any future attempt to commit directly on main will be blocked by the very check this PR adds. Creating the guard on a dedicated feature branch (this PR's branch name is literal) avoids the bootstrap paradox.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
