### PR TITLE
feat(skills): add gh-pr-emergency-merge for admin-bypass merge

### DIFF
--- a/claude/skills/gh-pr-emergency-merge/SKILL.md
+++ b/claude/skills/gh-pr-emergency-merge/SKILL.md
@@ -59,20 +59,22 @@ reply → ask again. Exact prompt template in `references/audit-templates.md`.
 
 Order matters — comment first so the audit survives branch deletion.
 
-1. `gh pr comment <N>` with the "PR audit comment" body from
-   `references/audit-templates.md`; capture the comment URL for Step 6.
-2. `gh pr merge <N> --admin --squash --delete-branch` (flag rationale in
-   the same reference file). If it fails with "Must have admin rights",
-   **stop** and report — do NOT fall back to `--merge`/`--rebase`.
+1. `gh pr comment <N> --repo "$TARGET_REPO"` with the "PR audit comment"
+   body from `references/audit-templates.md`; capture the comment URL for
+   Step 6.
+2. `gh pr merge <N> --repo "$TARGET_REPO" --admin --squash --delete-branch`
+   (flag rationale in the same reference file). If it fails with "Must
+   have admin rights", **stop** and report — do NOT fall back to
+   `--merge`/`--rebase`.
 3. Capture the merge SHA:
-   `gh pr view <N> --json mergeCommit -q .mergeCommit.oid`.
+   `gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -q .mergeCommit.oid`.
 
 ## Step 5: Create Post-Merge Incident Issue
 
 Non-negotiable audit tail. File `incident: emergency merge of PR #<N> —
 <reason first line>` with the body + retro checklist from
 `references/audit-templates.md`. Attach an `incident` label **only if**
-`gh label list` confirms it exists.
+`gh label list --repo "$TARGET_REPO"` confirms it exists.
 
 ## Step 6: Report
 

--- a/claude/skills/gh-pr-emergency-merge/SKILL.md
+++ b/claude/skills/gh-pr-emergency-merge/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: gh:pr-emergency-merge
+description: >-
+  Emergency-merge a GitHub PR by bypassing branch-protection approval
+  requirements via admin override, while forcing an audit trail: a reason
+  comment on the PR and a follow-up incident issue for later retro. Use
+  when the user runs /gh-pr-emergency-merge, /gh:pr-emergency-merge, or
+  asks "긴급 머지", "주말 핫픽스 머지", "approval 없이 머지", "admin bypass
+  merge". NOT a replacement for normal review — the skill actively blocks
+  overuse by requiring a written reason and creating a post-merge issue.
+  Required CI must still pass; conflicts still stop the merge. Accepts
+  `-h`/`--help`/`help` to print usage. Project-agnostic; works in any repo
+  where the caller has admin/merge permission.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# gh:pr-emergency-merge — Admin-Bypass Merge with Audit Trail
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output it verbatim, then stop. No API calls.
+
+## Step 1: Parse Args + Resolve Target
+
+Positional args: `<PR> <reason> [remote]`.
+
+- `PR` — number (required). If omitted, try `gh pr view --json number` on
+  current branch; else stop with a usage pointer.
+- `reason` — **required**, ≥10 chars, must reference an incident/ticket
+  ID or concrete user impact. Vague reasons (`"urgent"`, `"fix"`) → refuse.
+  Examples in `references/help.md`.
+- `remote` — default `origin`. Resolve `TARGET_REPO` via
+  `git remote get-url`; missing → `git remote -v` and stop.
+
+Capture `ME=$(gh api user -q .login)`, `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)`.
+
+## Step 2: Pre-flight Safety Gate (parallel)
+
+Fetch in parallel; evaluate stops **before** touching merge:
+
+- PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,baseRefName,headRefName`
+- `gh pr checks <N> --repo $TARGET_REPO --required`
+
+**Hard stops** (emergency ≠ reckless): `state != OPEN` · `isDraft == true` ·
+`mergeable == CONFLICTING` · any required check failing/pending. Emergency
+bypasses **approval**, not **CI** — fix or rerun CI instead of bypassing.
+
+**Soft warnings** (print, continue): base `BEHIND` → note in audit. No
+approving review → expected here, but surface it in the confirmation prompt.
+
+## Step 3: Confirm with the User
+
+Print the planned action (repo, PR, author, base/head, CI summary, reason)
+followed by `Proceed? (yes/ok/진행/머지)`. Never auto-proceed; ambiguous
+reply → ask again. Exact prompt template in `references/audit-templates.md`.
+
+## Step 4: Audit Comment + Admin Merge
+
+Order matters — comment first so the audit survives branch deletion.
+
+1. `gh pr comment <N>` with the "PR audit comment" body from
+   `references/audit-templates.md`; capture the comment URL for Step 6.
+2. `gh pr merge <N> --admin --squash --delete-branch` (flag rationale in
+   the same reference file). If it fails with "Must have admin rights",
+   **stop** and report — do NOT fall back to `--merge`/`--rebase`.
+3. Capture the merge SHA:
+   `gh pr view <N> --json mergeCommit -q .mergeCommit.oid`.
+
+## Step 5: Create Post-Merge Incident Issue
+
+Non-negotiable audit tail. File `incident: emergency merge of PR #<N> —
+<reason first line>` with the body + retro checklist from
+`references/audit-templates.md`. Attach an `incident` label **only if**
+`gh label list` confirms it exists.
+
+## Step 6: Report
+
+```
+Emergency-merged PR #<N>
+  Merge SHA:       <sha>
+  Audit comment:   <url>
+  Incident issue:  #<M> (<url>)
+  Reason:          <reason>
+  ⚠️  Add retro notes to incident issue within 72h.
+```
+
+## Constraints
+
+- Never bypass CI. Approval bypass only.
+- Never skip the incident issue — the audit tail is the whole point.
+- Never run without an affirmative user confirmation.
+- Never use `--merge`/`--rebase` to dodge a failing admin merge.
+- Reason must be substantive; refuse `"urgent"`/`"fix"`/`"merge now"`.

--- a/claude/skills/gh-pr-emergency-merge/references/audit-templates.md
+++ b/claude/skills/gh-pr-emergency-merge/references/audit-templates.md
@@ -169,7 +169,7 @@ are complete.
 gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$ISSUE"
 ```
 
-Do NOT add labels/milestones unless `gh label list` confirms an `incident`
-label already exists; if it does, apply it.
+Do NOT add labels/milestones unless `gh label list --repo "$TARGET_REPO"`
+confirms an `incident` label already exists; if it does, apply it.
 
 Capture the issue URL + number from the command output for Step 7's report.

--- a/claude/skills/gh-pr-emergency-merge/references/audit-templates.md
+++ b/claude/skills/gh-pr-emergency-merge/references/audit-templates.md
@@ -1,0 +1,175 @@
+# Audit Templates — for gh:pr-emergency-merge skill
+
+All bodies are written to `mktemp` files first (avoids shell escaping and
+concurrent-run collisions). Match the language dominant in the PR body
+(Korean PR → Korean audit notes).
+
+```bash
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write the drafted body to "$BODY" ...
+```
+
+## Step 4 — PR audit comment (posted BEFORE merge)
+
+Anchors the event on the PR timeline so it survives branch deletion.
+
+### Body template (English)
+
+```markdown
+🚨 **Emergency merge** by @<ME> at <NOW> UTC
+
+**Reason:** <reason>
+
+This PR is being merged via `gh pr merge --admin`, bypassing the normal
+approval requirement. A follow-up incident issue will be filed immediately
+after merge for retro within 72h.
+
+**Pre-merge state**
+- Base: `<baseRefName>` · Head: `<headRefName>`
+- Required CI: ✅ passing
+- Approving reviews: <count> (normal merge would need ≥1)
+- Merge status at decision time: `<mergeStateStatus>`
+
+If you believe this bypass was not justified, comment here or on the
+incident issue — the decision is auditable.
+```
+
+### Body template (Korean)
+
+```markdown
+🚨 **긴급 머지** — @<ME>, <NOW> UTC
+
+**사유:** <reason>
+
+이 PR은 `gh pr merge --admin`으로 approval 요구사항을 건너뛰고
+머지됩니다. 머지 직후 회고용 incident 이슈가 자동 생성되며, 72시간
+이내 retro 작성이 원칙입니다.
+
+**머지 직전 상태**
+- Base: `<baseRefName>` · Head: `<headRefName>`
+- 필수 CI: ✅ 통과
+- Approve 리뷰: <count>건 (정상 경로는 ≥1 필요)
+- Merge status: `<mergeStateStatus>`
+
+바이패스 타당성에 의문이 있으면 이 코멘트 또는 incident 이슈에 남겨
+주세요 — 의사결정이 감사 가능하도록 기록됩니다.
+```
+
+### Command
+
+```bash
+gh pr comment <N> --repo "$TARGET_REPO" --body-file "$COMMENT"
+```
+
+Capture the comment URL from the command output for Step 7's report.
+
+## Step 5 — Admin merge command
+
+```bash
+gh pr merge <N> --repo "$TARGET_REPO" --admin --squash --delete-branch
+```
+
+Flags rationale:
+- `--admin` — bypasses branch protection (approval requirement, up-to-date
+  branch rule). This is the whole point of the skill.
+- `--squash` — single atomic commit on base; trivially revertable if the
+  hotfix itself regresses something.
+- `--delete-branch` — head branch is disposable once merged; keeps the repo
+  tidy and prevents accidental future pushes to it.
+
+If the command fails with "Must have admin rights" → the caller does not
+have admin. Stop; do NOT retry with `--merge` / `--rebase` (those won't
+bypass protection either, and trying them wastes audit clarity).
+
+Extract the merge commit SHA from PR JSON after merge:
+```bash
+SHA=$(gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -q .mergeCommit.oid)
+```
+
+## Step 6 — Post-merge incident issue
+
+Title format: `incident: emergency merge of PR #<N> — <reason first line truncated to 60 chars>`
+
+### Body template (English)
+
+```markdown
+## Context
+
+Emergency-merged **PR #<N>** at <NOW> UTC by @<ME>, bypassing the normal
+approval path via `gh pr merge --admin`.
+
+- PR:         <PR URL>
+- Merge SHA:  `<SHA>`
+- Base:       `<baseRefName>`
+- Author:     @<PR author>
+
+## Stated reason
+
+> <reason>
+
+## Retro checklist (complete within 72h)
+
+- [ ] Root cause — 1 sentence, tied to the user impact.
+- [ ] Why normal review path wasn't viable at decision time.
+- [ ] What made this a *real* emergency vs. just inconvenient timing.
+- [ ] Follow-up actions: tests added, alerting added, process change, etc.
+- [ ] Any collateral risk taken on by the bypass (e.g., skipped reviewer
+      perspective) and how it will be reviewed post-hoc.
+- [ ] Link to postmortem / retro document, if one was written.
+
+## Prevention
+
+- [ ] Could an earlier alert / test / guardrail have prevented the need
+      for an emergency?
+- [ ] Is the on-call reviewer rotation healthy? Any gap to fix?
+
+Close this issue with a comment summarizing the retro once items above
+are complete.
+```
+
+### Body template (Korean)
+
+```markdown
+## 컨텍스트
+
+**PR #<N>** 을 <NOW> UTC에 @<ME> 가 긴급 머지 (`gh pr merge --admin`
+으로 approval 경로 우회).
+
+- PR:         <PR URL>
+- Merge SHA:  `<SHA>`
+- Base:       `<baseRefName>`
+- Author:     @<PR author>
+
+## 사유
+
+> <reason>
+
+## 회고 체크리스트 (72시간 이내 완료)
+
+- [ ] 근본 원인 — 유저 영향과 연결된 한 문장으로.
+- [ ] 의사결정 시점에 정상 리뷰 경로가 불가능했던 이유.
+- [ ] 단순히 타이밍이 안 맞는 게 아니라 *진짜* 긴급이었던 근거.
+- [ ] 후속 액션: 테스트 추가, 알림 추가, 프로세스 변경 등.
+- [ ] 바이패스로 감수한 부수 리스크 (예: 리뷰어 관점 누락) 및 사후
+      검토 방법.
+- [ ] 포스트모템/회고 문서 링크 (있으면).
+
+## 재발 방지
+
+- [ ] 더 이른 시점의 alert / test / 가드레일로 이 긴급을 예방할 수
+      있었는가?
+- [ ] 당번 리뷰어 로테이션은 건강한 상태인가? 메울 공백이 있는가?
+
+위 항목이 채워지면 회고 요약 코멘트와 함께 이 이슈를 닫는다.
+```
+
+### Command
+
+```bash
+gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$ISSUE"
+```
+
+Do NOT add labels/milestones unless `gh label list` confirms an `incident`
+label already exists; if it does, apply it.
+
+Capture the issue URL + number from the command output for Step 7's report.

--- a/claude/skills/gh-pr-emergency-merge/references/help.md
+++ b/claude/skills/gh-pr-emergency-merge/references/help.md
@@ -1,0 +1,70 @@
+# gh:pr-emergency-merge — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | PR number, or `-h`/`--help`/`help` | required (or current-branch PR) | Target PR, e.g. `42` |
+| 2 | reason | **required** | Written justification, ≥10 chars, must reference incident/ticket or user impact |
+| 3 | remote name | `origin` | Git remote for the target repo |
+
+## Usage
+
+```
+/gh-pr-emergency-merge 42 "INC-1031 prod 500 error on login since 14:00 KST"
+/gh-pr-emergency-merge 42 "revenue impact — checkout broken for 12% of users" upstream
+/gh-pr-emergency-merge -h
+```
+
+## When to use this skill
+
+- Weekend / after-hours hotfix and no reviewer is reachable.
+- Production incident mitigation (revert / feature-flag kill / config).
+- Security patch that cannot wait for async review.
+
+## When NOT to use
+
+- "My reviewer is slow" — ping them or reassign instead.
+- Missing a tiny nit you want to skip — ask for a lightweight re-review.
+- Self-assigned vanity PR — normal review path applies.
+- CI is failing and you think it's flaky — rerun, don't bypass. This
+  skill refuses to merge with failing required CI.
+
+## What the skill does
+
+1. Validates PR state (open, not draft, no conflicts) and that required CI is green.
+2. Shows you the exact plan (repo, PR, base/head, CI summary, reason) and waits for your confirmation.
+3. Posts a visible audit comment on the PR explaining *why* this is being emergency-merged.
+4. Runs `gh pr merge --admin --squash --delete-branch` to bypass approval requirements.
+5. Creates a follow-up `incident:` issue with a retro checklist so the decision is tracked and reviewed later.
+6. Reports the merge SHA, audit comment URL, and incident issue number.
+
+## Good reason examples
+
+- `"INC-1031 prod 500 on /login since 14:00 KST — reviewer on vacation"`
+- `"revenue impact — checkout 5xx for paid tier, hotfix reverts PR #41"`
+- `"security: CVE-2024-XXXX RCE in dependency, upstream patched 2h ago"`
+- `"customer-reported data loss on /projects; kill-switch flag via config"`
+
+## Bad reason examples (will be refused)
+
+- `"urgent"` — too vague
+- `"fix"` / `"hotfix"` — no user impact stated
+- `"reviewer slow"` — use normal path or reassign
+- `"merge now"` — not a reason
+
+## What this skill will NOT do
+
+- Bypass CI failures (approval bypass only).
+- Merge a draft PR or one with conflicts.
+- Skip the incident issue — the audit tail is mandatory.
+- Auto-confirm; it always asks before executing.
+- Push code or fix the underlying issue — it only merges what's already in the PR.
+
+## After the merge
+
+Within 72h, add to the incident issue:
+- Root cause 1-liner.
+- Why normal review path wasn't viable.
+- Follow-up actions (tests added, process change, etc.).
+- Close the incident issue with the retro link.


### PR DESCRIPTION
## Summary

- New `gh-pr-emergency-merge` skill: emergency-merge a PR by bypassing branch-protection approval via `gh pr merge --admin`, while forcing an audit trail (visible reason comment on the PR + post-merge incident issue with a 72h retro checklist).
- Required CI must still pass — **approval bypass only**, not CI bypass.
- Multi-layer guardrails against casual use: mandatory substantive reason (≥10 chars, rejects "urgent"/"fix"), user confirmation before execution, and a mandatory follow-up incident issue so every use is auditable and retro'd.

## Why

Originally a conversation spin-off from #155 — the \`/gh-pr-approve\` skill deliberately doesn't support self-approve (GitHub rejects it at the API level anyway). Weekend/after-hours hotfix scenarios are a separate workflow that needs its own skill with its own guardrails, not an \`--self\` flag on the approve skill.

Design goal: make emergency merges **possible but uncomfortable**, so they stay rare and well-documented.

## Structure

\`\`\`
claude/skills/gh-pr-emergency-merge/
├── SKILL.md                        94 lines  — workflow + guardrails
└── references/
    ├── help.md                     70 lines  — \`-h\` output: args, good/bad reason examples, "when NOT to use"
    └── audit-templates.md         175 lines  — PR audit comment + incident issue body (EN + KR)
\`\`\`

Passes \`/skill-check\`: 5/5 PASS (SKILL.md under 100 lines, progressive disclosure clean).

## Usage

\`\`\`
/gh-pr-emergency-merge 42 "INC-1031 prod 500 on /login since 14:00 KST"
/gh-pr-emergency-merge 42 "revenue impact — checkout 5xx for paid tier" upstream
/gh-pr-emergency-merge -h
\`\`\`

## Test plan

- [ ] \`/gh-pr-emergency-merge -h\` prints usage from \`references/help.md\`.
- [ ] Vague reason like "urgent" is refused before any API calls.
- [ ] Draft PR / PR with conflicts / failing required CI → hard-stop before merge.
- [ ] Affirmative-reply path: audit comment posted → admin merge → incident issue created → compact report printed.
- [ ] Incident issue body contains the retro checklist (root cause, why-not-normal-path, follow-ups, prevention).
- [ ] Label attachment only happens if \`incident\` label exists in the target repo.

## Out of scope

- A self-approve variant of \`/gh-pr-approve\` — GitHub rejects self-approve at the API level; use this skill instead.
- Automated incident-issue closure or retro-reminder nudges (could be a follow-up scheduled agent).

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
