### PR TITLE
feat(gbr): auto-fetch and squash-merge fallback in teardown

### DIFF
--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -122,8 +122,7 @@ git_branch_teardown() {
                 ux_bullet "gbr teardown                           # current branch, after PR merge"
                 ux_info ""
                 ux_info "Backlog of N merged PRs (order-independent):"
-                ux_bullet "git fetch --prune"
-                ux_bullet "git checkout <br1> && gbr teardown"
+                ux_bullet "git checkout <br1> && gbr teardown   # auto-fetches refs"
                 ux_bullet "git checkout <br2> && gbr teardown"
                 ux_info ""
                 ux_info "See also: 'gbr-help teardown' for the summary table."
@@ -197,6 +196,16 @@ git_branch_teardown() {
         fi
     fi
 
+    # Auto-refresh remote tracking refs so `[gone]` is accurate.
+    # Without this, a just-merged PR leaves stale `origin/<branch>` and the
+    # upstream check below would reject with "PR not merged yet". Fail-soft:
+    # offline sessions continue with whatever refs are cached locally.
+    local upstream_gone=false
+    if [ "$force" != true ]; then
+        git fetch --prune --quiet origin 2>/dev/null \
+            || ux_warning "Fetch failed (offline?) — proceeding with stale refs."
+    fi
+
     # Upstream check — `[gone]` means remote branch was deleted (PR merge signal).
     # Use `%(upstream:short)` (not `@{u}`) to detect "was ever pushed",
     # because `@{u}` fails to resolve once the remote-tracking ref is pruned.
@@ -215,7 +224,7 @@ git_branch_teardown() {
 
         case "$upstream_track" in
             *gone*)
-                : # expected: remote branch deleted (PR merged + auto-delete or manual Delete button)
+                upstream_gone=true
                 ;;
             *)
                 # Best-effort PR lookup — surfaces "#151 OPEN" so the blocker is obvious
@@ -237,7 +246,7 @@ git_branch_teardown() {
                 fi
                 echo ""
                 ux_info "What to do next:"
-                ux_bullet "Merge the PR on GitHub, then: git fetch --prune && gbr teardown"
+                ux_bullet "Merge the PR on GitHub, then re-run: gbr teardown"
                 ux_bullet "Or override the safety check: gbr teardown --force"
                 return 1
                 ;;
@@ -256,15 +265,23 @@ git_branch_teardown() {
     fi
 
     # Delete branch
+    #
+    # `git branch -d` only sees branches whose commits appear verbatim in main.
+    # Squash/rebase merges rewrite the commits, so -d rejects them even though
+    # the PR was merged. When upstream is `[gone]` we already know the PR
+    # landed, so upgrade to -D without requiring --force.
     if [ "$keep_branch" = true ]; then
         ux_info "Branch kept: $branch (--keep-branch)"
     elif git branch -d "$branch" 2>/dev/null; then
-        : # safe-deleted
-    elif [ "$force" = true ]; then
+        : # safe-deleted (merge-commit merge)
+    elif [ "$force" = true ] || [ "$upstream_gone" = true ]; then
         git branch -D "$branch" 2>/dev/null || {
             ux_error "Failed to force-delete branch '$branch'."
             return 1
         }
+        if [ "$upstream_gone" = true ] && [ "$force" != true ]; then
+            ux_info "Force-deleted (squash/rebase merge detected via [gone] upstream)."
+        fi
     else
         ux_warning "Branch '$branch' not fully merged into $main_branch. Use --force or --keep-branch."
         return 1

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -197,13 +197,21 @@ git_branch_teardown() {
     fi
 
     # Auto-refresh remote tracking refs so `[gone]` is accurate.
-    # Without this, a just-merged PR leaves stale `origin/<branch>` and the
+    # Without this, a just-merged PR leaves stale `<remote>/<branch>` and the
     # upstream check below would reject with "PR not merged yet". Fail-soft:
     # offline sessions continue with whatever refs are cached locally.
+    #
+    # Remote is derived from the branch's own upstream (fork workflows may
+    # track `upstream/<branch>` instead of `origin/<branch>`); fall back to
+    # `origin` when no upstream is configured.
     local upstream_gone=false
     if [ "$force" != true ]; then
-        git fetch --prune --quiet origin 2>/dev/null \
-            || ux_warning "Fetch failed (offline?) — proceeding with stale refs."
+        local fetch_remote upstream_short
+        upstream_short="$(git for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)"
+        fetch_remote="${upstream_short%%/*}"
+        [ -z "$fetch_remote" ] && fetch_remote="origin"
+        git fetch --prune --quiet "$fetch_remote" 2>/dev/null \
+            || ux_warning "Fetch from '$fetch_remote' failed (offline?) — proceeding with stale refs."
     fi
 
     # Upstream check — `[gone]` means remote branch was deleted (PR merge signal).


### PR DESCRIPTION
## Summary
- `gbr teardown`이 upstream 체크 직전에 `git fetch --prune origin`을 자동 수행. PR merge 직후 stale `origin/<branch>` 때문에 생기는 "PR not merged yet" 오검출을 제거. 네트워크 실패 시 warning 후 진행하는 fail-soft 설계.
- `[gone]` 감지 시 `git branch -d` 실패하면 `--force` 없이도 자동으로 `-D` 폴백. squash/rebase merge는 main 히스토리에 원본 커밋이 그대로 남지 않아 `-d`가 거부하지만, gone 상태 자체가 PR merge 완료를 증명하므로 안전하게 force-delete.
- 도움말과 hint 텍스트에서 이제 불필요한 `git fetch --prune` 사전 실행 안내 제거.

## Motivation
기존 흐름은 사용자가 `gf && gbr teardown` 두 단계를 수동으로 실행해야 했고, squash merge된 브랜치는 그 후에도 "not fully merged" 경고로 다시 막혔다. 흔한 경로 한 번에 끝내도록 정리.

## Test plan
- [x] `tools/dev.sh lint` — ruff / mypy / shellcheck / shfmt 모두 통과
- [x] `tools/dev.sh test` — 979 테스트 통과
- [x] `bash -n` / `zsh -n` 구문 검사 통과, 양쪽에서 함수 로드 후 `--help` 출력 정상
- [ ] 실제 merged PR에서 `gbr teardown` 한 번에 teardown 완료되는지 수동 확인

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
