### PR TITLE
fix(gbr): avoid "#null null  null" when no PR exists for teardown

### DIFF
--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -220,11 +220,13 @@ git_branch_teardown() {
             *)
                 # Best-effort PR lookup — surfaces "#151 OPEN" so the blocker is obvious
                 # at a glance. Silent on gh missing/unauthed; table row is just skipped.
+                # Use `.[]` (not `.[0]`) so an empty array yields empty output instead
+                # of stringifying null fields into "#null null  null".
                 local pr_info=""
                 if command -v gh >/dev/null 2>&1; then
                     pr_info="$(gh pr list --head "$branch" --state all --limit 1 \
                         --json number,state,url \
-                        --jq '.[0] | "#\(.number) \(.state)  \(.url)"' 2>/dev/null)"
+                        --jq '.[] | "#\(.number) \(.state)  \(.url)"' 2>/dev/null)"
                 fi
 
                 ux_error "Cannot tear down — PR not merged yet"


### PR DESCRIPTION
## Summary
- `gbr teardown` 표 안의 Pull request 행이 PR이 없는 브랜치에도 `#null null  null`로 출력되던 표시 버그 수정.

## Changes
- `shell-common/functions/git_branch.sh`: PR lookup의 jq 필터를 `.[0] | ...`에서 `.[] | ...`로 변경. `gh pr list`가 빈 배열 `[]`을 반환할 때 `.[0]`은 null이 되고, 문자열 보간이 null 필드를 `"null"` 리터럴로 찍어 `#null null  null`을 만들어 `-n "$pr_info"` 가드를 그대로 통과시켜 표에 들어갔음. `.[]`는 빈 배열에서 아무것도 emit하지 않아 `pr_info`가 빈 문자열이 되고 해당 행이 정상적으로 생략됨. `--limit 1`이 이미 적용돼 있어 반복은 최대 1회로 안전.

## Test plan
- [x] 빈 배열 재현: `echo '[]' | jq -r '.[] | "#\(.number) \(.state)  \(.url)"'` → 빈 출력
- [x] 정상 케이스: `echo '[{"number":151,"state":"OPEN","url":"https://x"}]' | jq -r '.[] | ...'` → `#151 OPEN  https://x`
- [ ] PR이 없는 브랜치에서 `gbr teardown` 실행 시 Pull request 행이 표에서 생략되는지 확인
- [ ] PR이 열려 있는 브랜치에서 `gbr teardown` 실행 시 기존처럼 `#<N> OPEN  <url>`이 표에 출력되는지 확인

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
