### PR TITLE
feat(skills): add --help to 4 gh:* skills + refactor 3 SKILL.md under 100 lines

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -9,11 +9,17 @@ description: >-
   alias additions). Use when the user runs /gh:commit, /gh-commit, or asks
   "커밋해", "지금까지 작업 커밋", "이슈 N번 연결해서 커밋". The user does NOT
   need to prefix with "git status 확인하고" — that is step 1 of this skill.
-  Creates a new commit — never amends. Never skips hooks.
+  Creates a new commit — never amends. Never skips hooks. Accepts
+  `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
 ---
 
 # gh:commit — Git Commit with Issue Linking
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
 
 ## Role
 

--- a/claude/skills/gh-commit/references/help.md
+++ b/claude/skills/gh-commit/references/help.md
@@ -1,0 +1,45 @@
+# gh:commit — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | issue-number, or `-h`/`--help`/`help` | auto-detected from chat | Link commit to this GitHub issue via `Refs #N` footer |
+
+## Usage
+
+- `/gh-commit` — inspect working tree, draft a commit, auto-detect issue
+  from recent chat (`#N`, `Issue #N created`)
+- `/gh-commit 123` — same, but force `Refs #123` in the footer
+- `/gh-commit -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Runs `git status`, `git diff`, `git diff --staged`, `git log --oneline -20`
+   unconditionally — the working-tree state is the source of truth.
+2. Resolves the issue number (explicit arg → recent chat scan → none).
+3. Drafts a commit message that mimics the repo's existing style (subject
+   line length, conventional-commit prefix usage, footer style).
+4. Stages only files relevant to this commit (never `git add -A`).
+5. Runs `git commit` via HEREDOC, including the mandatory `Co-Authored-By`
+   footer. See `references/commit-message-format.md` for the exact shape.
+6. Reports the short hash and subject. Linked issue number printed on a
+   second line if one was resolved.
+
+## What the skill will NOT do
+
+- Amend an existing commit (`--amend`) — always creates a new commit.
+- Skip hooks (`--no-verify`) or signing (`--no-gpg-sign`).
+- Stage `.env`, `credentials.json`, or obvious-secret files — stops and warns.
+- Push the commit — that is `/gh:pr`'s job.
+- Invent an issue number when none is resolvable.
+- Create empty commits.
+- Bundle two unrelated changes — asks to split first.
+
+## Good vs. bad invocation
+
+- **Good**: you made edits, type `/gh-commit` — the skill picks a subject
+  from the diff, links any recent `#N` from chat, commits, done.
+- **Good**: `/gh-commit 42` — same, but forces `Refs #42` regardless of chat.
+- **Bad**: calling this to push → use `/gh-pr` instead.
+- **Bad**: calling this with no changes in the tree → skill stops with "nothing to commit".

--- a/claude/skills/gh-issue/SKILL.md
+++ b/claude/skills/gh-issue/SKILL.md
@@ -10,27 +10,23 @@ description: >-
   compress — the issue is reused for PR drafts and blog posts, so preserve
   reasoning, decisions, and concrete details.
   Accepts an optional remote name argument (e.g., `/gh-issue upstream`) to
-  target a different remote's repository instead of origin.
+  target a different remote's repository instead of origin. Accepts
+  `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
 ---
 
 # gh:issue — Conversation → GitHub Issue
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
 
 ## Role
 
 Convert the current chat into a well-structured GitHub issue on the target
 repo. Execute immediately without confirmation. Print only the issue
 number + URL at the end — the user will open GitHub directly.
-
-## Arguments
-
-| Position | Name | Default | Description |
-|----------|------|---------|-------------|
-| 1 | `remote-name` | `origin` | Git remote to target (e.g., `upstream`) |
-
-Usage examples:
-- `/gh-issue` — create issue on `origin`
-- `/gh-issue upstream` — create issue on `upstream` remote's repo
 
 ## Step 1: Detect Repo Context
 

--- a/claude/skills/gh-issue/SKILL.md
+++ b/claude/skills/gh-issue/SKILL.md
@@ -30,29 +30,13 @@ number + URL at the end — the user will open GitHub directly.
 
 ## Step 1: Detect Repo Context
 
-1. `git rev-parse --show-toplevel` — confirm we're in a git repo.
+Confirm we're in a git repo (`git rev-parse --show-toplevel`), then pick
+the target remote (arg #1 if given, else `origin`) and resolve it to
+`TARGET_REPO=<owner>/<repo>`. If the remote does not exist, list
+`git remote -v` and stop — never fall back to `origin` silently.
 
-2. Determine the target remote:
-   - If the user passed an argument, use it as remote name.
-   - Otherwise default to `origin`.
-
-3. Validate the remote and resolve owner/repo:
-   ```bash
-   git remote get-url <remote-name>
-   ```
-   If this fails, list available remotes (`git remote -v`) and stop with an
-   error like:
-   ```
-   Error: remote '<remote-name>' not found. Available remotes:
-   origin  https://github.com/user/repo.git (fetch)
-   upstream  https://github.com/org/repo.git (fetch)
-   ```
-
-4. Extract `owner/repo` from the remote URL returned in step 3:
-   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
-   - `git@github.com:<owner>/<repo>.git` → `<owner>/<repo>`
-
-Store the resolved `owner/repo` as `TARGET_REPO` for use in Step 4.
+Read `references/repo-resolution.md` for the full substeps, error-message
+template, and `https` / `ssh` URL parsing rules.
 
 ## Step 2: Classify the Conversation
 

--- a/claude/skills/gh-issue/references/help.md
+++ b/claude/skills/gh-issue/references/help.md
@@ -1,0 +1,46 @@
+# gh:issue — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | remote-name, or `-h`/`--help`/`help` | `origin` | Git remote whose repo will own the new issue (e.g. `upstream`) |
+
+## Usage
+
+- `/gh-issue` — create issue on `origin`'s repo (the most common case)
+- `/gh-issue upstream` — create issue on the `upstream` remote's repo
+- `/gh-issue -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Confirms a git repo context and resolves `owner/repo` from the target
+   remote's URL. If the remote does not exist, lists `git remote -v` and
+   stops — no silent fallback to `origin`.
+2. Classifies the conversation into one of **feature** / **bug** / **misc**,
+   which determines the title prefix and body layout.
+3. Drafts a structured issue body matching the category, pulling template
+   from `references/issue-body-templates.md`. Writes the body in the
+   language the user was speaking (Korean chat → Korean issue).
+4. Creates the issue via `gh issue create --repo "$TARGET_REPO"` using a
+   temp file written by `mktemp` (avoids shell escaping bugs).
+5. Prints only `Issue #N created: <url>` — no preamble, no summary.
+
+## Detail preservation
+
+Do NOT over-compress. The issue is reused later for PR descriptions and
+blog posts, so preserve:
+- concrete file paths and line references
+- command outputs and error logs
+- decisions and the reasoning behind them
+- discussion log — never collapse to 2–3 bullets
+
+A 200-line issue is fine if the conversation warranted it.
+
+## What the skill will NOT do
+
+- Add `--assignee`, `--label`, or `--milestone` unless the user asked.
+- Fall back to `origin` when the user-specified remote is missing.
+- Ask "should I create it?" — running the skill is the confirmation.
+- Rely on implicit repo detection — always passes `--repo "$TARGET_REPO"`.
+- Truncate or summarize the conversation log.

--- a/claude/skills/gh-issue/references/repo-resolution.md
+++ b/claude/skills/gh-issue/references/repo-resolution.md
@@ -1,0 +1,42 @@
+# gh:issue — Repo resolution
+
+Detailed procedure for Step 1 "Detect Repo Context" — remote validation and
+owner/repo extraction. SKILL.md keeps only the workflow; this file holds
+the substeps and error-message shape.
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we're in a git repo.
+
+2. Determine the target remote:
+   - If the user passed an argument, use it as remote name.
+   - Otherwise default to `origin`.
+
+3. Validate the remote and resolve owner/repo:
+
+   ```bash
+   git remote get-url <remote-name>
+   ```
+
+   If this fails, list available remotes (`git remote -v`) and stop with
+   an error like:
+
+   ```
+   Error: remote '<remote-name>' not found. Available remotes:
+   origin  https://github.com/user/repo.git (fetch)
+   upstream  https://github.com/org/repo.git (fetch)
+   ```
+
+4. Extract `owner/repo` from the remote URL returned in step 3:
+
+   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git` → `<owner>/<repo>`
+
+Store the resolved `owner/repo` as `TARGET_REPO` for use in Step 4 of the
+main workflow.
+
+## Failure rule
+
+If the user-specified remote does not exist, fail immediately with the
+list of available remotes. **Do not** fall back to `origin` silently —
+that masks typos and creates issues in the wrong repo.

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -7,11 +7,17 @@ description: >-
   /gh-pr-reply, or asks "PR 리뷰 코멘트 확인하고 수정", "리뷰 답변 달아", "PR 123
   코멘트 처리해". Defaults to the PR for the current branch; accepts an explicit
   PR number as an argument. Every comment MUST get a reply — bot comments
-  (gemini, sourcery, copilot) included.
+  (gemini, sourcery, copilot) included. Accepts `-h`/`--help`/`help` to
+  print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---
 
 # gh:pr-reply — Address PR Review Comments
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
 
 ## Role
 

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -44,19 +44,10 @@ threads.
 
 ## Step 3: Evaluate Each Comment
 
-For each unaddressed comment, read the referenced file (`path` at `line`) and
-classify:
-
-- **ACCEPT** — reviewer is correct; the code should change
-- **ACCEPT-PARTIAL** — valid concern, but a different fix is better; note the
-  deviation in the reply
-- **DECLINE** — reviewer is wrong, misunderstanding the context, or the
-  suggestion would regress something; must explain why
-- **QUESTION** — reviewer asked for clarification rather than a change;
-  answer the question
-
+For each unaddressed comment, read the referenced file (`path` at `line`)
+and classify as **ACCEPT** / **ACCEPT-PARTIAL** / **DECLINE** / **QUESTION**.
 Bot comments (gemini-code-assist, sourcery-ai, copilot) follow the same
-rules — a bot nit is still a legitimate comment that deserves a reply.
+rules. See `references/reply-templates.md` for the full rubric.
 
 ## Step 4: Apply Fixes (ACCEPT / ACCEPT-PARTIAL only)
 

--- a/claude/skills/gh-pr-reply/references/help.md
+++ b/claude/skills/gh-pr-reply/references/help.md
@@ -1,0 +1,55 @@
+# gh:pr-reply — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | PR number, or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `123` |
+
+## Usage
+
+- `/gh-pr-reply` — process review comments on the PR for the current branch
+- `/gh-pr-reply 123` — process review comments on PR #123 explicitly
+- `/gh-pr-reply -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Resolves the target PR (explicit arg first, else the current branch's
+   PR via `gh pr view --json`). Never guesses "the latest PR".
+2. Fetches all review comments from the three GitHub endpoints (inline
+   thread, issue comment, review summary) per
+   `references/comment-fetching.md`, deduped and filtered to threads you
+   have not yet replied to.
+3. Classifies each unaddressed comment: **ACCEPT**, **ACCEPT-PARTIAL**
+   (valid concern, different fix), **DECLINE**, or **QUESTION**. Bots
+   (gemini-code-assist, sourcery-ai, copilot) are treated identically to
+   human reviewers.
+4. Applies ACCEPT / ACCEPT-PARTIAL fixes, keeping each fix minimal and
+   scoped. Groups related fixes into themed commits (not one commit per
+   comment). Never `--amend` or `--no-verify`.
+5. Replies to **every** identified comment using the inline-vs-top-level
+   endpoint and body template from `references/reply-templates.md`. This
+   is the politeness contract — declines and bot nits get replies too.
+6. Pushes fix commits (`git push`, never force) if any landed.
+7. Prints a compact summary: Accepted / Declined / Answered counts plus
+   commit SHAs, and lists any comments skipped as "already replied".
+
+## What the skill will NOT do
+
+- Skip a reply for a comment — silent fixes and silent declines are both
+  prohibited. Even "Declined: out of scope" one-liners count.
+- Dismiss bot comments as "just a bot".
+- Close or resolve threads programmatically — the user does that.
+- Fix comments touching files outside the PR's diff without flagging
+  scope creep to the user first.
+- Force-push. If history rewrite is required, it stops and asks.
+- Guess the PR when the current branch has none — it stops and asks.
+
+## Good vs. bad invocation
+
+- **Good**: after pushing commits, `/gh-pr-reply` — processes every new
+  review comment on your branch's PR.
+- **Good**: `/gh-pr-reply 99` — force target PR #99 even from a different branch.
+- **Bad**: running from a branch with no PR — skill stops and asks you to
+  open one first.
+- **Bad**: expecting the skill to fix unrelated files — it refuses scope creep.

--- a/claude/skills/gh-pr-reply/references/reply-templates.md
+++ b/claude/skills/gh-pr-reply/references/reply-templates.md
@@ -72,3 +72,19 @@ docs, other PR, or file that justifies the current design>.
   replies — reviewers need a pointer to verify the fix.
 - Declined replies must state a concrete reason, never a dismissive one-liner.
 - Bot comments get the exact same templates — no shortcuts.
+
+## Classification rubric
+
+Use these four classes in Step 3 of the SKILL.md workflow. Every
+unaddressed comment falls into exactly one.
+
+- **ACCEPT** — reviewer is correct; the code should change.
+- **ACCEPT-PARTIAL** — valid concern, but a different fix is better; note
+  the deviation in the reply (use the "Accepted with modification" body).
+- **DECLINE** — reviewer is wrong, misunderstanding the context, or the
+  suggestion would regress something; must explain why in the reply.
+- **QUESTION** — reviewer asked for clarification rather than a change;
+  answer the question directly.
+
+Bot comments (gemini-code-assist, sourcery-ai, copilot) follow the same
+rules — a bot nit is still a legitimate comment that deserves a reply.

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -6,11 +6,16 @@ description: >-
   /gh-pr, or asks "PR 생성", "풀리퀘 만들어", "지금까지 커밋들로 PR 올려". Pushes
   the branch if needed, drafts a structured PR body covering every commit in
   the range (not just HEAD), auto-links a related issue when known, and
-  returns only the PR URL.
+  returns only the PR URL. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
 ---
 
 # gh:pr — Create Pull Request
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
 
 ## Role
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -74,12 +74,9 @@ Write the body to a unique temp file via `mktemp`, then create the PR with
 ## Step 6: Apply Labels
 
 Derive labels from conventional-commit types in `git log <base>..HEAD`
-(`feat` → enhancement, `fix` → bug, `docs` → documentation, `refactor`,
-`style`, `perf`, `test`, `chore`, `ci`, `build`) plus judgment-based
-labels matching the PR scope (e.g., `skill` for `claude/skills/` changes).
-Query existing labels via `gh label list` and apply only labels that
-**already exist** in the repo — never create new labels. Details and the
-safe-application loop in `references/pr-body-template.md`.
+and PR scope (e.g. `skill` for `claude/skills/` changes). Apply only
+labels that exist in the repo (`gh label list`) — never create new ones.
+See `references/pr-body-template.md` for the full mapping + safe-apply loop.
 
 ## Step 7: Report
 

--- a/claude/skills/gh-pr/references/help.md
+++ b/claude/skills/gh-pr/references/help.md
@@ -1,0 +1,54 @@
+# gh:pr — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | issue-number, or `-h`/`--help`/`help` | auto-detected | Link PR to this GitHub issue via `Closes #N` / `Refs #N` in the body |
+
+## Usage
+
+- `/gh-pr` — push the current branch if needed, then open a PR against
+  the repo's default branch covering every commit in the range
+- `/gh-pr 123` — same, but force-link to issue `#123` regardless of chat/commits
+- `/gh-pr -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Resolves the base branch (`gh repo view --json defaultBranchRef`) and
+   checks the current branch is not the base. Fetches `origin` to make
+   sure the range is computed against up-to-date refs.
+2. Reads **all** commits in `<base>..HEAD` — the PR body must cover every
+   commit, not only HEAD. Groups them by theme for the Summary.
+3. Resolves the linked issue using the same precedence as `gh:commit`:
+   explicit arg → recent chat → commit footers → none.
+4. Drafts title + body per `references/pr-body-template.md`, matching the
+   language dominant in existing commits (Korean commits → Korean PR).
+5. Pushes the branch (`git push -u origin HEAD` if no upstream, `git push`
+   if ahead). Diverged upstream → stops and asks; never force-pushes on
+   its own.
+6. Creates the PR via `gh pr create --assignee @me` using a `mktemp` body
+   file. Always self-assigns.
+7. Applies labels derived from conventional-commit types (feat, fix, docs,
+   etc.) plus scope labels — but only labels that **already exist** in the
+   repo. Never creates new labels.
+8. Prints only `PR created: <url>`.
+
+## What the skill will NOT do
+
+- Force-push without explicit user approval.
+- Target a base branch other than the repo's default branch unless told.
+- Include the `🤖 Generated with Claude Code` footer unless the repo
+  already uses that convention in existing PRs.
+- Skip "minor" commits in the Summary — the range is the contract.
+- Create new labels — only applies labels that exist.
+- Open a PR when the branch has no commits ahead of base, or when you're
+  currently on the base branch (stops with guidance instead).
+
+## Good vs. bad invocation
+
+- **Good**: Feature branch with 3 commits, `/gh-pr` — body covers all 3,
+  links any `#N` in chat, returns the URL.
+- **Good**: `/gh-pr 42` after a hotfix — body includes `Closes #42`.
+- **Bad**: running on `main` — skill stops with "create a feature branch first".
+- **Bad**: running with an empty `<base>..HEAD` — skill stops with "nothing to PR".


### PR DESCRIPTION
## Summary
- Add `-h`/`--help`/`help` support to the four remaining `gh:*` skills (commit, issue, pr, pr-reply), matching the existing `gh-pr-approve` / `gh-pr-emergency-merge` pattern. Each skill gets a `## Help` pointer and a fresh `references/help.md` with arguments / usage / what-it-does / what-it-wont-do.
- Restore the 100-line cap from `claude/AGENTS.md:178` that the `--help` additions pushed over, by extracting workflow detail into `references/`.

## Changes
- `feat(skills): add --help support to gh-commit/issue/pr/pr-reply` — 8 files touched, 4 new `references/help.md` files.
- `refactor(skills): compress gh:issue SKILL.md via references/` — Step 1 "Detect Repo Context" moved to new `references/repo-resolution.md` (error example + URL parsing). SKILL.md: 111 → 95.
- `refactor(skills): compress gh:pr SKILL.md via references/` — Step 6 label detail replaced with a pointer; full mapping already lived in `references/pr-body-template.md`. SKILL.md: 102 → 99.
- `refactor(skills): compress gh:pr-reply SKILL.md via references/` — Step 3 classification rubric moved to `references/reply-templates.md`. SKILL.md: 106 → 97.

## Test plan
- [x] `wc -l` on all 6 `gh:*` SKILL.md files ≤ 100
- [x] Frontmatter (`name: gh:*` colon form per `feedback_skill_naming_convention.md`) preserved byte-for-byte
- [x] Every `references/*.md` pointer in each SKILL.md resolves to an existing file
- [x] Pre-commit hook (conventional commits + 72-char body) green on all 4 commits
- [ ] Spot-check: invoke `/gh-commit --help` in a fresh session and confirm it prints help without side effects
- [ ] Spot-check: invoke `/gh-issue` and confirm the Step-1 workflow still resolves `TARGET_REPO` via the pointer to `references/repo-resolution.md`

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
