### PR TITLE
refactor(gwt) + feat(statusline): free-form names, git status

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Status line command for Claude Code
-# Format: YY-MM-DD HH:MM:SS | model | project-name(git-branch)
+# Format: YY-MM-DD HH:MM:SS | model | project(branch) | git-status
 
 # ANSI color codes
 CYAN='\033[36m'
@@ -14,62 +14,10 @@ RESET='\033[0m'
 # Read JSON input from stdin
 input=$(cat)
 
-# Debug: Log full JSON to find weekly usage information
-{
-  echo "=== Full JSON Structure ==="
-  echo "$input" | jq . 2>/dev/null || echo "$input"
-  echo "=== Debug Info ==="
-  echo "Time: $(date)"
-  echo "---"
-} >> /tmp/statusline-weekly-debug.log 2>&1
-
 # Extract current directory and model from JSON input
 cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
 model_id=$(echo "$input" | jq -r '.model.id // ""')
 model_display=$(echo "$input" | jq -r '.model.display_name // ""')
-
-# Extract context window information from Claude Code input
-total_input_tokens=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0')
-total_output_tokens=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
-context_window_size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
-
-# Prefer ccusage-based current usage percentage:
-# current_usage% = totalTokens / tokenLimitStatus.limit * 100
-context_used=""
-if command -v ccusage >/dev/null 2>&1; then
-    ccusage_json="$(ccusage blocks --active --token-limit max --json 2>/dev/null || true)"
-    if [[ -n "$ccusage_json" ]]; then
-        ccusage_pct="$(
-            echo "$ccusage_json" | jq -r '
-                if (.blocks | length) > 0
-                   and (.blocks[0].tokenLimitStatus.limit // 0) > 0
-                   and (.blocks[0].totalTokens // 0) >= 0
-                then
-                    ((.blocks[0].totalTokens / .blocks[0].tokenLimitStatus.limit) * 100)
-                else
-                    empty
-                end
-            ' 2>/dev/null
-        )"
-        if [[ -n "$ccusage_pct" ]] && [[ "$ccusage_pct" != "null" ]]; then
-            context_used="$(LC_ALL=C printf "%.0f" "$ccusage_pct" 2>/dev/null || true)"
-        fi
-    fi
-fi
-
-# Fallback: use Claude Code's official used_percentage
-if [[ -z "$context_used" ]] || [[ "$context_used" == "null" ]]; then
-    context_used=$(echo "$input" | jq -r '.context_window.used_percentage // ""')
-fi
-
-# If not available, calculate from token counts
-if [[ -z "$context_used" ]] || [[ "$context_used" == "null" ]]; then
-    if [[ "$total_input_tokens" =~ ^[0-9]+$ ]] && [[ "$total_output_tokens" =~ ^[0-9]+$ ]] && [[ "$context_window_size" -gt 0 ]]; then
-        total_tokens=$((total_input_tokens + total_output_tokens))
-        # Simple calculation: (total_tokens / context_window_size) * 100
-        context_used=$(( (total_tokens * 100) / context_window_size ))
-    fi
-fi
 
 # Get current time in YY-MM-DD HH:MM:SS format
 current_time=$(date +%y-%m-%d\ %H:%M:%S)
@@ -148,26 +96,50 @@ fi
 # Combine project name with branch: "📁 quantfolio(🌳 main)"
 project_branch="📁 ${project_name}(${branch_emoji} ${git_branch})"
 
-# Format usage information and determine color based on usage percentage
-usage_info=""
-usage_color="$GREEN"  # Default to green
-if [[ -n "$context_used" ]]; then
-    # Determine color based on usage percentage
-    if ((context_used >= 90)); then
-        usage_color="$RED"
-    elif ((context_used >= 70)); then
-        usage_color="$ORANGE"
-    else
-        usage_color="$GREEN"
+# Compact git status: dirty count / ahead / behind
+# Shows what workflow step is next:
+#   ●N  = N uncommitted changes (staged + unstaged + untracked) → /gh-commit
+#   ↑N  = N commits ahead of upstream → /gh-pr (after push)
+#   ↓N  = N commits behind upstream (need pull)
+#   ✓   = clean and in sync
+git_status_text=""
+git_status_color="$GREEN"
+if [ -n "$cwd" ] && [ -d "$cwd" ] && git -C "$cwd" rev-parse --git-dir >/dev/null 2>&1; then
+    dirty_count=$(git -C "$cwd" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    ahead=0
+    behind=0
+    if git -C "$cwd" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+        ahead=$(git -C "$cwd" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+        behind=$(git -C "$cwd" rev-list --count 'HEAD..@{u}' 2>/dev/null || echo 0)
     fi
 
-    usage_info="${usage_color}📊 ${context_used}% used${RESET}"
+    parts=()
+    [ "${dirty_count:-0}" -gt 0 ] && parts+=("●${dirty_count}")
+    [ "${ahead:-0}"       -gt 0 ] && parts+=("↑${ahead}")
+    [ "${behind:-0}"      -gt 0 ] && parts+=("↓${behind}")
+
+    if [ ${#parts[@]} -eq 0 ]; then
+        git_status_text="✓"
+        git_status_color="$GREEN"
+    else
+        git_status_text="${parts[*]}"
+        if [ "${dirty_count:-0}" -gt 0 ]; then
+            git_status_color="$RED"      # uncommitted work — commit first
+        else
+            git_status_color="$ORANGE"   # committed but not in sync with remote
+        fi
+    fi
+fi
+
+git_status_info=""
+if [ -n "$git_status_text" ]; then
+    git_status_info="${git_status_color}📝 ${git_status_text}${RESET}"
 fi
 
 # Output format with colors and emojis
-# Time: Cyan, Model: Orange, Project+Branch: Magenta, Usage: Dynamic color (Red/Orange/Green)
-if [[ -n "$usage_info" ]]; then
-    echo -e "${CYAN}${time_emoji} ${current_time}${RESET} | ${ORANGE}${model_emoji} ${model_name}${RESET} | ${MAGENTA}${project_branch}${RESET} | ${usage_info}"
+# Time: Cyan, Model: Orange, Project+Branch: Magenta, Git status: Red/Orange/Green
+if [[ -n "$git_status_info" ]]; then
+    echo -e "${CYAN}${time_emoji} ${current_time}${RESET} | ${ORANGE}${model_emoji} ${model_name}${RESET} | ${MAGENTA}${project_branch}${RESET} | ${git_status_info}"
 else
     echo -e "${CYAN}${time_emoji} ${current_time}${RESET} | ${ORANGE}${model_emoji} ${model_name}${RESET} | ${MAGENTA}${project_branch}${RESET}"
 fi

--- a/shell-common/functions/ai_setup.sh
+++ b/shell-common/functions/ai_setup.sh
@@ -15,16 +15,19 @@ ai_setup() {
 
     case "${1:-}" in
         -h|--help|help)
-            ux_header "ai-setup - AI workspace orchestrator"
+            ux_header "ai-setup - workspace orchestrator"
             ux_info "Usage: ai-setup"
             ux_info ""
             ux_info "Interactive setup that creates git worktrees and"
             ux_info "tmux sessions with 3-pane windows in one step."
             ux_info ""
             ux_info "Steps:"
-            ux_info "  1. Enter worktree agents  (e.g. claude codex)"
-            ux_info "  2. Enter tmux windows     (e.g. claude codex gemini)"
+            ux_info "  1. Enter worktree names   (free-form: issue-11 login-fix)"
+            ux_info "  2. Enter tmux windows     (AI agents: claude codex gemini)"
             ux_info "  3. Worktrees + tmux sessions are created automatically"
+            ux_info ""
+            ux_info "Note: worktree names are free-form (task/issue/feature slugs)."
+            ux_info "      tmux windows must be AI agent names (they run <agent>-yolo)."
             ux_info ""
             ux_info "Requirements: git, tmux, run from main repo (not worktree)"
             return 0
@@ -63,34 +66,35 @@ ai_setup() {
     ux_info "Project: $project ($repo_root)"
     echo
 
-    # --- Step 1: Read worktree agents ---
+    # --- Step 1: Read worktree names (free-form) ---
     local wt_input="" a
     while [ -z "$wt_input" ]; do
-        printf "%s❯%s Worktree agents (space-separated): " \
+        printf "%s❯%s Worktree names (space-separated, e.g. issue-11 login-fix): " \
             "${UX_BOLD}${UX_INFO}" "${UX_RESET}"
         read -r wt_input || return 1
         if [ -z "$wt_input" ]; then
-            ux_error "At least one agent required."
+            ux_error "At least one name required."
         fi
     done
 
-    # Validate worktree agents
-    local wt_agents="" wt_count=0
+    # Validate worktree names (free-form slug; no '/', no spaces, no leading dash)
+    local wt_names="" wt_count=0
     for a in $wt_input; do
-        if ! _ts_known_agent "$a"; then
-            ux_error "Unknown agent: $a"
-            ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
-            return 1
-        fi
-        wt_agents="$wt_agents $a"
+        case "$a" in
+            -* | */* | *" "*)
+                ux_error "Invalid name: '$a' (no '/', no spaces, no leading dash)"
+                return 1
+                ;;
+        esac
+        wt_names="$wt_names $a"
         wt_count=$((wt_count + 1))
     done
-    wt_agents="${wt_agents# }"
+    wt_names="${wt_names# }"
 
-    # --- Step 2: Read tmux window agents ---
+    # --- Step 2: Read tmux window agents (still AI-only: they run <agent>-yolo) ---
     local win_input=""
     while [ -z "$win_input" ]; do
-        printf "%s❯%s Tmux windows per session (space-separated): " \
+        printf "%s❯%s Tmux window agents (space-separated, e.g. claude codex): " \
             "${UX_BOLD}${UX_INFO}" "${UX_RESET}"
         read -r win_input || return 1
         if [ -z "$win_input" ]; then
@@ -98,7 +102,7 @@ ai_setup() {
         fi
     done
 
-    # Validate window agents
+    # Validate window agents (must be known AI agents)
     local win_agents="" win_count=0
     for a in $win_input; do
         if ! _ts_known_agent "$a"; then
@@ -115,11 +119,11 @@ ai_setup() {
 
     # --- Step 3: Create worktrees ---
     ux_info "Creating worktrees..."
-    local wt_paths="" wt_created=0 agent existing_path new_path new_branch dir
-    for agent in $wt_agents; do
-        # Check if worktree already exists for this agent
+    local wt_paths="" wt_created=0 name existing_path new_path new_branch dir
+    for name in $wt_names; do
+        # Check if worktree already exists for this name
         existing_path=""
-        for dir in "$parent/${project}-${agent}"-*/; do
+        for dir in "$parent/${project}-${name}"-*/; do
             if [ -d "$dir" ]; then
                 existing_path="${dir%/}"
                 break
@@ -130,12 +134,12 @@ ai_setup() {
             ux_warning "  $(basename "$existing_path") already exists — skipping"
             wt_paths="$wt_paths $existing_path"
         else
-            git_worktree_spawn "$agent" >/dev/null
+            git_worktree_spawn "$name" >/dev/null
             # Discover path from git worktree list (reliable across any index)
             new_path=""
             while IFS= read -r line; do
                 case "$line" in
-                    "worktree "*"-${agent}-"*)
+                    "worktree "*"-${name}-"*)
                         new_path="${line#worktree }" ;;
                 esac
             done <<EOF
@@ -147,7 +151,7 @@ EOF
                 wt_paths="$wt_paths $new_path"
                 wt_created=$((wt_created + 1))
             else
-                ux_error "  Failed to create worktree for $agent"
+                ux_error "  Failed to create worktree for $name"
             fi
         fi
     done

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -16,7 +16,7 @@ _gwt_help_summary() {
     ux_bullet_sub "list: gwt list | gwt ls"
     ux_bullet_sub "remove: gwt remove <path|agent|all> [--force]"
     ux_bullet_sub "prune: gwt prune"
-    ux_bullet_sub "spawn: gwt spawn [agent] [--task slug] [--base ref] [--tmux]"
+    ux_bullet_sub "spawn: gwt spawn <name> [--task slug] [--base ref] [--tmux]"
     ux_bullet_sub "teardown: gwt teardown [--force] [--keep-branch]"
     ux_bullet_sub "details: gwt-help <section> (example: gwt-help spawn)"
 }
@@ -42,8 +42,8 @@ _gwt_help_rows_list() {
 }
 
 _gwt_help_rows_remove() {
-    ux_table_row "syntax" "gwt remove <path|agent|all> [--force]" "Remove worktree + branch"
-    ux_table_row "agent mode" "<agent> matches *-<agent>-*" "Batch remove by agent"
+    ux_table_row "syntax" "gwt remove <path|name|all> [--force]" "Remove worktree + branch"
+    ux_table_row "name mode" "<name> matches *-<name>-*" "Batch remove by worktree name"
     ux_table_row "all mode" "all removes non-main worktrees" "Batch cleanup"
     ux_table_row "force" "--force" "Force remove and branch delete"
 }
@@ -53,10 +53,11 @@ _gwt_help_rows_prune() {
 }
 
 _gwt_help_rows_spawn() {
-    ux_table_row "syntax" "gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]" "Create AI worktree"
+    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux]" "Create named worktree"
     ux_table_row "context" "Run from main repo only" "Fails inside a worktree"
-    ux_table_row "agents" "claude | codex | gemini | opencode | cursor | copilot" "Default: auto-detect"
-    ux_table_row "example" "gwt spawn codex --task login-fix --base origin/main" "Task + base branch"
+    ux_table_row "name" "Free-form slug (required)" "e.g. issue-11, login-fix"
+    ux_table_row "--tmux caveat" "Runs <name>-yolo in pane" "Only AI names (claude, ...) have yolo aliases"
+    ux_table_row "example" "gwt spawn issue-11 --task auth --base origin/main" "Name + task + base"
 }
 
 _gwt_help_rows_teardown() {
@@ -187,17 +188,17 @@ git_worktree_remove() {
     case "${1:-}" in
         -h|--help)
             ux_header "gwt remove - remove worktree and branch"
-            ux_info "Usage: gwt remove <path|agent|all> [--force]"
+            ux_info "Usage: gwt remove <path|name|all> [--force]"
             ux_info ""
             ux_info "  <path>     full or relative worktree path"
-            ux_info "  <agent>    agent name (claude, codex, gemini, ...)"
-            ux_info "             removes ALL worktrees matching *-<agent>-*"
+            ux_info "  <name>     worktree name (free-form: issue-11, login-fix, ...)"
+            ux_info "             removes ALL worktrees matching *-<name>-*"
             ux_info "  all        remove ALL non-main worktrees"
             ux_info "  --force    force remove + force delete unmerged branch"
             return 0
             ;;
         "")
-            ux_error "Usage: gwt remove <path|agent> [--force]"
+            ux_error "Usage: gwt remove <path|name> [--force]"
             return 1
             ;;
     esac
@@ -260,20 +261,14 @@ EOF
         [ "$fail_count" -eq 0 ] && return 0 || return 1
     fi
 
-    # Known agent names — always resolve as agent pattern, never as local path
-    case "$target" in
-        claude|codex|gemini|opencode|cursor|copilot|agent)
-            ;;  # fall through to agent resolve below
-        *)
-            # Not an agent name: treat as direct path
-            if [ -d "$target" ] || [ -e "$target" ]; then
-                _gwt_remove_one "$target" "$force"
-                return $?
-            fi
-            ;;
-    esac
+    # If target is an existing path, remove directly.
+    # Otherwise treat it as a worktree name and resolve to *-<name>-* worktrees.
+    if [ -d "$target" ] || [ -e "$target" ]; then
+        _gwt_remove_one "$target" "$force"
+        return $?
+    fi
 
-    # Resolve agent name (or unknown target) to worktree path(s)
+    # Resolve worktree name to path(s)
     local project parent matches=""
     project="$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")"
     parent="$(dirname "$(git rev-parse --show-toplevel 2>/dev/null)")"
@@ -424,44 +419,84 @@ git_worktree_add() {
 
 # ============================================================================
 # Worktree spawn — auto-index, auto-branch, log
-# Usage: git_worktree_spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]
+# Usage: git_worktree_spawn <name> [--task <slug>] [--base <ref>] [--tmux]
 # ============================================================================
+_git_worktree_spawn_show_help() {
+    ux_header "gwt spawn - create a named worktree"
+    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux]"
+    ux_info ""
+    ux_info "Arguments:"
+    ux_info "  <name>           Free-form worktree name (required)."
+    ux_info "                   Safe chars only: no '/', no spaces, no leading dash."
+    ux_info "                   Examples: issue-11, login-fix, claude, feature-x"
+    ux_info "  --task <slug>    Add task slug to branch name"
+    ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
+    ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
+    ux_info ""
+    ux_warning "Caveat for --tmux:"
+    ux_info "  The pane runs '<name>-yolo'. This alias only exists for known AI"
+    ux_info "  agents (claude, codex, gemini, opencode, cursor, copilot)."
+    ux_info "  For non-AI names, skip --tmux and run 'tmux-spawn <agent>' after."
+    ux_info "  (Follow-up: decouple via --agent flag — see issue #162)"
+    ux_info ""
+    ux_info "Examples:"
+    ux_info "  gwt spawn issue-11                   # ../<proj>-issue-11-1  wt/issue-11/1"
+    ux_info "  gwt spawn login-fix --task auth      # ../<proj>-login-fix-1 wt/login-fix/1-auth"
+    ux_info "  gwt spawn claude --tmux              # AI name: tmux compatible"
+}
+
 git_worktree_spawn() {
     # zsh compatibility
     if [ -n "${ZSH_VERSION-}" ]; then
         emulate -L sh
     fi
 
-    local task="" base="" agent="" use_tmux=0
+    local task="" base="" name="" use_tmux=0
 
     # Parse arguments
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)
-                ux_header "gwt spawn - AI worktree auto-creation"
-                ux_info "Usage: gwt spawn [<agent>] [--task <slug>] [--base <ref>] [--tmux]"
-                ux_info ""
-                ux_info "Arguments:"
-                ux_info "  <agent>          claude | codex | gemini | opencode | cursor (auto-detect if omitted)"
-                ux_info "  --task <slug>    Add task slug to branch name"
-                ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
-                ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
-                ux_info ""
-                ux_info "Examples:"
-                ux_info "  gwt spawn                          # auto-detect AI (default=claude)"
-                ux_info "  gwt spawn claude                   # ../<project>-claude-1  wt/claude/1"
-                ux_info "  gwt spawn codex --task login-fix   # ../<project>-codex-1   wt/codex/1-login-fix"
-                ux_info "  gwt spawn gemini --tmux            # worktree + tmux window"
+                _git_worktree_spawn_show_help
                 return 0
                 ;;
             --task) task="$2"; shift 2 ;;
             --base) base="$2"; shift 2 ;;
             --tmux) use_tmux=1; shift ;;
-            claude|codex|gemini|opencode|cursor|copilot)
-                agent="$1"; shift ;;
-            *) ux_error "Unknown option: $1. Use --help for usage."; return 1 ;;
+            -*)
+                ux_error "Unknown option: $1"
+                echo ""
+                _git_worktree_spawn_show_help
+                return 1
+                ;;
+            *)
+                if [ -n "$name" ]; then
+                    ux_error "Multiple names given: '$name', '$1' (only one allowed)"
+                    echo ""
+                    _git_worktree_spawn_show_help
+                    return 1
+                fi
+                name="$1"
+                shift
+                ;;
         esac
     done
+
+    # Name is required
+    if [ -z "$name" ]; then
+        ux_error "<name> is required"
+        echo ""
+        _git_worktree_spawn_show_help
+        return 1
+    fi
+
+    # Validate name: no path separators, no spaces, no leading dash
+    case "$name" in
+        -* | */* | *" "*)
+            ux_error "Invalid name: '$name' (no '/', no spaces, no leading dash)"
+            return 1
+            ;;
+    esac
 
     # Validate --tmux dependency
     if [ "$use_tmux" = 1 ] && ! command -v tmux >/dev/null 2>&1; then
@@ -480,23 +515,12 @@ git_worktree_spawn() {
         return 1
     fi
 
-    # Detect agent (explicit arg > env vars > fallback)
-    if [ -z "$agent" ]; then
-        if [ "${CLAUDECODE:-}" = "1" ]; then agent="claude"
-        elif [ "${GEMINI_CLI:-}" = "1" ]; then agent="gemini"
-        elif [ "${CODEX_CLI:-}" = "1" ]; then agent="codex"
-        elif [ "${OPENCODE:-}" = "1" ]; then agent="opencode"
-        elif [ "${CURSOR:-}" = "1" ] || [ "${TERM_PROGRAM:-}" = "cursor" ]; then agent="cursor"
-        else agent="claude"
-        fi
-    fi
-
     # Compute project, parent, next index
     local project parent next_index=1
     project="$(basename "$(git rev-parse --show-toplevel)")"
     parent="$(dirname "$(git rev-parse --show-toplevel)")"
 
-    for dir in "$parent/${project}-${agent}"-*/; do
+    for dir in "$parent/${project}-${name}"-*/; do
         if [ -d "$dir" ]; then
             local n="${dir##*-}"
             n="${n%/}"
@@ -509,16 +533,16 @@ git_worktree_spawn() {
         fi
     done
 
-    local wt_path="${parent}/${project}-${agent}-${next_index}"
+    local wt_path="${parent}/${project}-${name}-${next_index}"
 
     # Branch name
     local branch
     if [ -n "$task" ]; then
         local slug
         slug=$(printf '%s' "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-30)
-        branch="wt/${agent}/${next_index}-${slug}"
+        branch="wt/${name}/${next_index}-${slug}"
     else
-        branch="wt/${agent}/${next_index}"
+        branch="wt/${name}/${next_index}"
     fi
 
     # Base ref
@@ -536,8 +560,8 @@ git_worktree_spawn() {
     git_worktree_add "$wt_path" "$branch" "$base" || return 1
 
     # Log
-    printf '[%s] SPAWN agent=%s index=%s path=%s branch=%s base=%s\n' \
-        "$(date +%Y-%m-%dT%H:%M:%S%z)" "$agent" "$next_index" "$wt_path" "$branch" "$base" \
+    printf '[%s] SPAWN name=%s index=%s path=%s branch=%s base=%s\n' \
+        "$(date +%Y-%m-%dT%H:%M:%S%z)" "$name" "$next_index" "$wt_path" "$branch" "$base" \
         >> "${git_common}/ai-worktree-spawn.log"
 
     ux_header "Worktree spawned"
@@ -547,12 +571,12 @@ git_worktree_spawn() {
 
     # --- Optional tmux integration ---
     if [ "$use_tmux" = 1 ]; then
-        _tmux_add_agent_window "$project" "$agent" "$wt_path"
-        ux_info "  tmux:   session '$project', window '$agent'"
+        _tmux_add_agent_window "$project" "$name" "$wt_path"
+        ux_info "  tmux:   session '$project', window '$name'"
         if [ -z "$TMUX" ]; then
             tmux attach -t "$project"
         else
-            tmux switch-client -t "${project}:${agent}" 2>/dev/null || true
+            tmux switch-client -t "${project}:${name}" 2>/dev/null || true
         fi
     else
         ux_info ""

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -98,33 +98,34 @@ tmux_spawn() {
     _ts_agent=""
     _ts_session=""
 
-    # --- Detect mode: worktree vs main repo ---
-    # Worktree pattern: <project>-<agent>-<index>
-    _ts_without_index="${_ts_basename%-*}"
-    _ts_candidate="${_ts_without_index##*-}"
+    # --- Detect mode: worktree vs main repo (via git, not filename) ---
+    # Filename-based detection fails once worktree names are free-form
+    # (e.g. dotfiles-issue-11-1), so rely on git's own notion of worktree.
+    _ts_git_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+    _ts_git_dir="$(git rev-parse --git-dir 2>/dev/null)"
 
-    if _ts_known_agent "$_ts_candidate"; then
-        # Mode 1: worktree directory
-        _ts_agent="$_ts_candidate"
+    if [ -n "$_ts_git_common" ] && [ "$_ts_git_dir" != "$_ts_git_common" ]; then
+        # Mode 1: inside a worktree — session = current dir basename
         _ts_session="$_ts_basename"
+        _ts_agent="${_ts_arg:-claude}"
     else
-        # Mode 2: main repo — use <project>-<branch>
+        # Mode 2: main repo (or not in git) — session = <project>-<branch>
         _ts_project="$_ts_basename"
         _ts_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")"
         _ts_session="${_ts_project}-${_ts_branch}"
         _ts_agent="${_ts_arg:-claude}"
         unset _ts_project _ts_branch
     fi
+    unset _ts_git_common _ts_git_dir
 
-    # Override agent if argument given
+    # Validate agent if argument given
     if [ -n "$_ts_arg" ]; then
         if _ts_known_agent "$_ts_arg"; then
             _ts_agent="$_ts_arg"
         else
             ux_error "Unknown agent: $_ts_arg"
             ux_info  "Available: claude, codex, gemini, opencode, cursor, copilot"
-            unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session \
-                  _ts_without_index _ts_candidate
+            unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session
             return 1
         fi
     fi


### PR DESCRIPTION
## Summary
- Drop the fixed AI-agent allowlist for `gwt spawn` / `ai-setup` — worktrees are now named by task context (issue, feature, bug) instead of by tool.
- Replace the statusline's `N% used` column with a compact git-status indicator so the next workflow step (commit / push / PR) is obvious at a glance.

## Changes

**`refactor(gwt)`** — `shell-common/functions/{git_worktree,ai_setup,tmux_spawn}.sh`
- `gwt spawn <name>`: name is now required and free-form. Validated against `/`, spaces, leading dash. Removed env-based agent auto-detect. Missing/invalid input → error + `--help`.
- `gwt remove`: dropped hardcoded AI case. Path check first, then pattern match on `*-<name>-*`.
- `ai-setup`: "Worktree agents" prompt → "Worktree names" (free-form). Tmux-window prompt still requires known AI agents, because it runs `<agent>-yolo`.
- `tmux_spawn`: worktree-vs-main detection moved from filename parsing (`<proj>-<agent>-<idx>`) to git (`--git-dir` vs `--git-common-dir`) — the old heuristic broke on free-form names.
- `--tmux` caveat documented in help (runs `<name>-yolo`, only AI names have yolo aliases). Proper decoupling tracked as follow-up.

**`feat(statusline)`** — `claude/statusline-command.sh`
- New compact indicator: `●N` dirty / `↑N` ahead / `↓N` behind / `✓` clean+synced, colored red/orange/green.
- Removed the `ccusage` subprocess call and the `N% used` display — the old indicator spawned `ccusage` on every statusline refresh (~300ms) without giving actionable workflow signal.

## Test plan
- [x] `bash -n` / `zsh -n` clean on all modified files
- [x] `tox -e shellcheck` clean
- [x] 933 integration tests pass (`test_help_topics.py`, `test_help_compact_policy.py`)
- [x] Manual: `gwt spawn issue-11`, `gwt spawn login-fix --task auth`, `gwt spawn claude --tmux` all work
- [x] Manual: invalid names (`foo/bar`, `-foo`, empty) rejected with `--help`
- [x] Manual: `gwt remove issue-11` removes matching worktree + branch
- [x] Manual: statusline renders correctly in clean/ahead/dirty states, ~22 ms total runtime
- [ ] After merge: `~/.claude/statusline-command.sh` symlink picks up new behavior automatically

## Related
Refs #162

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
