### PR TITLE
fix(gwt): diagnosable teardown with ff-only sync and actionable errors

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -727,9 +727,17 @@ git_worktree_teardown() {
         fi
     fi
 
-    # Pre-flight: unpushed commits
-    # Fetch origin so origin/main is current for merge-base / cherry checks
-    git fetch origin 2>/dev/null || ux_warning "Fetch failed (network?). Merge status check may be stale."
+    # Pre-flight: unpushed commits.
+    # (A) Capture fetch stderr so failures surface the actual cause, not a
+    # misleading "network?" blurb. Real reason (auth, hook, URL, etc.) wins.
+    local _gwt_fetch_err_file="${TMPDIR:-/tmp}/gwt-fetch.$$.err"
+    if ! git fetch origin 2>"$_gwt_fetch_err_file" >/dev/null; then
+        ux_warning "git fetch origin failed — merge status check may be stale."
+        if [ -s "$_gwt_fetch_err_file" ]; then
+            sed 's/^/    /' "$_gwt_fetch_err_file" >&2
+        fi
+    fi
+    rm -f "$_gwt_fetch_err_file"
     # Checks (in order): upstream match → ancestor of origin/main → patch-id (rebase merge)
     if ! _gwt_commits_safe; then
         if [ "$force" = true ]; then
@@ -761,7 +769,7 @@ git_worktree_teardown() {
     fi
     git worktree prune
 
-    # Sync main BEFORE branch delete
+    # Sync main BEFORE branch delete.
     local main_branch="main"
     if ! git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
         main_branch="master"
@@ -770,7 +778,27 @@ git_worktree_teardown() {
         ux_error "Failed to checkout $main_branch in main repository."
         return 1
     fi
-    git pull origin "$main_branch" 2>/dev/null || ux_warning "Pull failed (network?). Branch delete may misjudge merge status."
+    # (B) Replace `git pull origin <main>` with local `git merge --ff-only
+    # origin/<main>`. We already fetched above — no second network round-trip,
+    # no rebase-merge surprises under pull.rebase=true. Diverged local main is
+    # reported clearly rather than collapsed into "network?".
+    local _gwt_ff_err_file="${TMPDIR:-/tmp}/gwt-ff.$$.err"
+    local main_sync_ok=true
+    if git rev-parse --verify --quiet "origin/$main_branch" >/dev/null 2>&1; then
+        if ! git merge --ff-only "origin/$main_branch" 2>"$_gwt_ff_err_file" >/dev/null; then
+            main_sync_ok=false
+            ux_error "Main sync failed — git merge --ff-only origin/$main_branch"
+            if [ -s "$_gwt_ff_err_file" ]; then
+                sed 's/^/    /' "$_gwt_ff_err_file" >&2
+            fi
+            ux_info "  Local '$main_branch' has diverged from origin/$main_branch."
+            ux_info "  Resolve manually (rebase / reset) before spawning new worktrees from local '$main_branch'."
+        fi
+    else
+        main_sync_ok=false
+        ux_warning "origin/$main_branch not found — skipping ff-sync (fetch likely failed)."
+    fi
+    rm -f "$_gwt_ff_err_file"
 
     # Delete branch
     if [ "$keep_branch" = true ]; then
@@ -793,9 +821,20 @@ git_worktree_teardown() {
         "$(date +%Y-%m-%dT%H:%M:%S%z)" "$wt_name" "$branch" "$wt_path" \
         >> "$(git rev-parse --git-common-dir)/ai-worktree-spawn.log"
 
-    ux_success "Teardown complete"
+    # (C-2) Strict exit: if main is not in sync with origin, report partial
+    # teardown and return non-zero so callers (CI, hooks, chained aliases)
+    # notice. Worktree removal and branch delete still ran.
+    if [ "$main_sync_ok" = true ]; then
+        ux_success "Teardown complete"
+        ux_info "  Removed: $wt_path"
+        ux_info "  Now on:  $main_branch"
+        return 0
+    fi
+
+    ux_warning "Teardown partial — worktree removed, main NOT in sync with origin/$main_branch"
     ux_info "  Removed: $wt_path"
-    ux_info "  Now on:  $main_branch"
+    ux_info "  Now on:  $main_branch (out of sync)"
+    return 1
 }
 
 alias gwt-help='gwt_help'

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -607,10 +607,10 @@ _gwt_commits_safe() {
     fi
 
     # 3. All patches already applied via rebase/squash merge (patch-id comparison)
-    # git cherry marks already-applied commits with '-', unapplied with '+'
-    local unapplied
-    unapplied="$(git cherry "$main_ref" HEAD 2>/dev/null | grep -c '^+' || echo "0")"
-    if [ "$unapplied" = "0" ]; then
+    # git cherry marks already-applied commits with '-', unapplied with '+'.
+    # If grep finds no '+' line, every HEAD commit is patch-id-equivalent to
+    # something already in main_ref → safe.
+    if ! git cherry "$main_ref" HEAD 2>/dev/null | grep -q '^+'; then
         return 0
     fi
 
@@ -635,9 +635,44 @@ _gwt_commits_safe() {
 # ============================================================================
 _gwt_branch_merged() {
     local branch="$1" target="$2"
-    local unapplied
-    unapplied="$(git cherry "$target" "$branch" 2>/dev/null | grep -c '^+' || echo "0")"
-    [ "$unapplied" = "0" ]
+    # No '+' line from git cherry → all patches already in target.
+    ! git cherry "$target" "$branch" 2>/dev/null | grep -q '^+'
+}
+
+# ============================================================================
+# Internal: pick the best merge-detection target. Prefer origin/<main> if
+# fetched, else fall back to local <main> (stale detection better than none).
+# Usage: _gwt_merge_target <main_branch>
+# ============================================================================
+_gwt_merge_target() {
+    local main_branch="$1"
+    if git rev-parse --verify --quiet "origin/$main_branch" >/dev/null 2>&1; then
+        printf '%s\n' "origin/$main_branch"
+    else
+        printf '%s\n' "$main_branch"
+    fi
+}
+
+# ============================================================================
+# Internal: render an actionable "unpushed commits" diagnostic.
+# Usage: _gwt_report_unpushed <branch>
+# ============================================================================
+_gwt_report_unpushed() {
+    local branch="$1"
+    local main_ref="origin/main"
+    git rev-parse --verify --quiet "$main_ref" >/dev/null 2>&1 || main_ref="origin/master"
+
+    local upstream ahead
+    upstream="$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null || echo "(none)")"
+    ahead="$(git rev-list --count "$main_ref"..HEAD 2>/dev/null || echo "?")"
+
+    ux_error "Unpushed commits on '$branch' ($ahead ahead of $main_ref, upstream: $upstream)."
+    ux_info "  Push:   git push -u origin $branch"
+    ux_info "  Or:     gwt teardown --force   # discard the unpushed commits"
+    if [ "$ahead" != "?" ] && [ "$ahead" != "0" ]; then
+        ux_info "  Unpushed commits (newest first):"
+        git log --no-color --format='    %h %s' "$main_ref"..HEAD 2>/dev/null | head -10
+    fi
 }
 
 # ============================================================================
@@ -743,7 +778,9 @@ git_worktree_teardown() {
         if [ "$force" = true ]; then
             ux_warning "Discarding unpushed commits (--force)"
         else
-            ux_error "Unpushed commits. Push first, or use --force."
+            # (E) Actionable diagnostic: show ahead count, upstream state,
+            # push command, and the list of unpushed commits.
+            _gwt_report_unpushed "$(git rev-parse --abbrev-ref HEAD)"
             return 1
         fi
     fi
@@ -774,7 +811,9 @@ git_worktree_teardown() {
     if ! git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
         main_branch="master"
     fi
-    if ! git checkout "$main_branch" 2>/dev/null; then
+    # (F) -q suppresses "Your branch is behind 'origin/<main>' by N commits"
+    # which git checkout prints to stdout (unsilenceable via 2>/dev/null).
+    if ! git checkout -q "$main_branch" 2>/dev/null; then
         ux_error "Failed to checkout $main_branch in main repository."
         return 1
     fi
@@ -800,13 +839,19 @@ git_worktree_teardown() {
     fi
     rm -f "$_gwt_ff_err_file"
 
+    # (D) Prefer origin/<main> over local <main> for rebase-merge detection.
+    # Local <main> can be stale when the ff-only sync above failed — exactly
+    # the scenario where we most need merge detection to still fire.
+    local merge_target
+    merge_target=$(_gwt_merge_target "$main_branch")
+
     # Delete branch
     if [ "$keep_branch" = true ]; then
         ux_info "Branch kept: $branch (--keep-branch)"
     elif git branch -d "$branch" 2>/dev/null; then
         : # deleted successfully (fast-forward or true merge)
-    elif _gwt_branch_merged "$branch" "$main_branch"; then
-        # Rebase/squash merge: commits are in main but SHAs differ
+    elif _gwt_branch_merged "$branch" "$merge_target"; then
+        # Rebase/squash merge: commits are in main_ref but SHAs differ.
         git branch -D "$branch" 2>/dev/null
         ux_success "Branch deleted (rebase-merged): $branch"
     elif [ "$force" = true ]; then

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_worktree_teardown.bats
+# Real-workflow tests for `gwt teardown` against a fake origin + clone + worktree.
+# Each test builds a bare remote and a local clone with a worktree branch,
+# simulates the scenario, runs the function via run_in_bash, and asserts on
+# both the command result and post-state (refs, branch existence).
+
+load '../test_helper'
+
+# ---------------------------------------------------------------------------
+# Fake-repo helpers (run in the bats shell, NOT the run_in_bash subshell)
+# ---------------------------------------------------------------------------
+
+# Create: $ORIGIN (bare) <- $CLONE (main) -- $WORKTREE (wt/test/1)
+_setup_fake_repo() {
+    ORIGIN="$TEST_TEMP_HOME/origin.git"
+    CLONE="$TEST_TEMP_HOME/clone"
+    WORKTREE="$TEST_TEMP_HOME/clone-test-1"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init --bare --initial-branch=main "$ORIGIN" >/dev/null
+    git clone -q "$ORIGIN" "$CLONE"
+    (
+        cd "$CLONE"
+        echo base > base.txt
+        git add base.txt
+        git commit -q -m "base"
+        git push -q origin main
+    )
+    git -C "$CLONE" worktree add -q -b wt/test/1 "$WORKTREE" origin/main
+}
+
+# Advance origin/main by one commit (simulates a merged PR).
+_advance_origin_main() {
+    local helper="$TEST_TEMP_HOME/helper"
+    rm -rf "$helper"
+    git clone -q "$ORIGIN" "$helper"
+    (
+        cd "$helper"
+        echo advance > advance.txt
+        git add advance.txt
+        git commit -q -m "advance"
+        git push -q origin main
+    )
+    rm -rf "$helper"
+    git -C "$CLONE" fetch -q origin
+}
+
+# Make clone's local main diverge from origin/main with a local-only commit.
+_diverge_local_main() {
+    (
+        cd "$CLONE"
+        git checkout -q main
+        echo divergence > divergence.txt
+        git add divergence.txt
+        git commit -q -m "local-only"
+        git checkout -q wt/test/1 2>/dev/null || true
+    )
+}
+
+setup() {
+    setup_isolated_home
+    _setup_fake_repo
+}
+
+teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# A/B/C: diagnosability + ff-only sync + strict exit on main-out-of-sync
+# ---------------------------------------------------------------------------
+
+@test "teardown: clean merged branch — ff-forwards local main to origin/main" {
+    # Simulate: branch was merged into origin/main (HEAD of worktree is the base,
+    # origin/main advanced ahead). Running teardown should succeed AND fast-forward
+    # the clone's local main to origin/main.
+    _advance_origin_main
+    local origin_main_sha
+    origin_main_sha="$(git -C "$CLONE" rev-parse origin/main)"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force"
+    assert_success
+
+    # B: local main advanced to origin/main (via merge --ff-only)
+    local after_main_sha
+    after_main_sha="$(git -C "$CLONE" rev-parse main)"
+    [ "$after_main_sha" = "$origin_main_sha" ]
+
+    # Branch removed
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_failure
+}
+
+@test "teardown: diverged local main — strict exit 1 (C-2) with actionable error" {
+    # Local main has a commit not in origin/main. fetch --ff-only cannot succeed.
+    # Teardown must exit non-zero and explain why.
+    _diverge_local_main
+    _advance_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force"
+    assert_failure
+    # Must mention the actual failing command, not a misleading "network?"
+    assert_output --partial "ff-only"
+    refute_output --partial "network?"
+}
+
+@test "teardown: fetch failure surfaces real stderr (A), not 'network?'" {
+    # Point origin at a non-existent path so `git fetch origin` fails at step 1.
+    git -C "$CLONE" remote set-url origin "$TEST_TEMP_HOME/does-not-exist.git"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    # The error output must include something from git itself (e.g. 'does-not-exist'
+    # or 'not a git repository' or 'could not read'), and must NOT reduce the
+    # problem to a bare 'network?' blurb.
+    refute_output --partial "Fetch failed (network?)"
+    assert_output --partial "does-not-exist"
+}
+
+@test "teardown: no second network round-trip (B) — works after remote is gone" {
+    # Advance origin/main, fetch once (teardown's own fetch does this), THEN
+    # break the remote. If teardown tried a second fetch/pull it would fail.
+    # With merge --ff-only against already-fetched origin/main it must still succeed.
+    _advance_origin_main
+
+    # Pre-fetch so origin/main is populated. Then remove the remote on disk.
+    git -C "$CLONE" fetch -q origin
+    rm -rf "$ORIGIN"
+
+    local origin_main_sha
+    origin_main_sha="$(git -C "$CLONE" rev-parse origin/main)"
+
+    # Teardown's own `git fetch` will now fail (that's Bug A — it should report,
+    # not silently eat it). It must still proceed to ff-only which works locally.
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+
+    local after_main_sha
+    after_main_sha="$(git -C "$CLONE" rev-parse main)"
+    [ "$after_main_sha" = "$origin_main_sha" ]
+}

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -142,3 +142,88 @@ teardown() {
     after_main_sha="$(git -C "$CLONE" rev-parse main)"
     [ "$after_main_sha" = "$origin_main_sha" ]
 }
+
+# ---------------------------------------------------------------------------
+# D/E/F: merge target = origin/main + actionable unpushed msg + quiet checkout
+# ---------------------------------------------------------------------------
+
+# Simulate a squash-merge of the worktree branch into origin/main.
+# After this: origin/main contains the worktree's change under a different SHA.
+_squash_merge_branch_into_origin_main() {
+    # Record the worktree's work commit tree contents
+    local wt_file wt_content
+    wt_file="$1"
+    wt_content="$2"
+
+    local helper="$TEST_TEMP_HOME/squash-helper"
+    rm -rf "$helper"
+    git clone -q "$ORIGIN" "$helper"
+    (
+        cd "$helper"
+        # Apply the same change as a single commit (squash equivalent)
+        printf '%s\n' "$wt_content" > "$wt_file"
+        git add "$wt_file"
+        git commit -q -m "squash: merged via PR"
+        git push -q origin main
+    )
+    rm -rf "$helper"
+    git -C "$CLONE" fetch -q origin
+}
+
+@test "teardown: D — rebase-merged detection uses origin/main even when local main stale" {
+    # 1. Worktree makes a commit with content X
+    (
+        cd "$WORKTREE"
+        echo contentX > feature.txt
+        git add feature.txt
+        git commit -q -m "feat: X"
+    )
+    # 2. Simulate PR squash-merge: origin/main gets X under a new SHA
+    _squash_merge_branch_into_origin_main feature.txt contentX
+
+    # 3. Make LOCAL main diverge so ff-only fails — _gwt_branch_merged will be
+    #    called with a stale local main. Without D fix, it compares patches
+    #    against the stale local main (which lacks X) and misses the merge.
+    _diverge_local_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    # Main sync fails (local diverged) so exit 1 per C-2. But branch delete
+    # should still announce "rebase-merged" because origin/main contains the
+    # branch's patches.
+    assert_failure
+    assert_output --partial "rebase-merged"
+    refute_output --partial "force-deleted"
+    refute_output --partial "not fully merged"
+}
+
+@test "teardown: E — unpushed-commits error shows ahead count and push hint" {
+    # Worktree branch is ahead of origin/main but never pushed. No --force.
+    (
+        cd "$WORKTREE"
+        echo a > a.txt && git add a.txt && git commit -q -m "a"
+        echo b > b.txt && git add b.txt && git commit -q -m "b"
+        echo c > c.txt && git add c.txt && git commit -q -m "c"
+    )
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_failure
+    # Must show how many commits are unpushed
+    assert_output --partial "3"
+    # Must suggest an actual push command the user can run
+    assert_output --partial "git push"
+    assert_output --partial "wt/test/1"
+    # And still mention --force as the alternative
+    assert_output --partial "--force"
+}
+
+@test "teardown: F — git checkout stdout noise ('Your branch is behind') suppressed" {
+    # Make local main behind origin/main. git checkout main would normally print
+    # "Your branch is behind 'origin/main' by 1 commits, and can be fast-forwarded."
+    # to stdout (unsilenceable by 2>/dev/null). With `checkout -q` it's gone.
+    _advance_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+    refute_output --partial "Your branch is behind"
+    refute_output --partial "use \"git pull\""
+}


### PR DESCRIPTION
## Summary
- `gwt teardown` was masking the real cause of `main ⇣N` partial-sync failures and surfacing every error as a generic "Pull failed (network?)". This PR replaces the fragile `git pull` in teardown with a local `git merge --ff-only origin/<main>` using the already-fetched ref, and makes the relevant error paths diagnosable and actionable.
- Under `pull.rebase=true`, teardown could silently leave local `main` out of sync with `origin/main` while still printing "✅ Teardown complete / Now on: main". This is now a strict non-zero exit with a "Teardown partial" summary so CI, hooks, and chained aliases can detect it.
- Adds the first real bats workflow tests for `git_worktree_teardown` — a bare origin + clone + worktree scaffold covers the 7 scenarios that matter (ff-forward, diverged main, fetch failure, no-second-network, rebase-merge detection, actionable unpushed diagnostic, stdout noise suppression).

## Changes

**`0f696c9 fix(gwt): surface real fetch/sync errors and ff-only main sync`**
- (A) Capture `git fetch origin` stderr to a temp file and echo it on failure, instead of `2>/dev/null` collapsing auth/hook/URL errors into an identical "network?" blurb.
- (B) Replace `git pull origin <main>` with `git merge --ff-only origin/<main>`. We already fetched — no second network round-trip, no rebase-merge surprises under `pull.rebase=true`, diverged local `main` gets a clean "Main sync failed" error with the git stderr attached.
- (C-2) When main cannot be fast-forwarded, print a "Teardown partial" summary and `return 1`. Worktree removal and branch delete still run, but callers now see the failure.

**`3e39248 fix(gwt): actionable unpushed diag + origin-based merge detect`**
- (D) Rebase-merge detection uses `origin/<main>` as target (via new `_gwt_merge_target` helper). Local `<main>` can be stale after a failed ff-only sync — exactly the scenario where missing a rebase- or squash-merged PR would be worst.
- (E) Replace the one-line "Unpushed commits. Push first, or use --force." with `_gwt_report_unpushed` — prints ahead count vs `origin/<main>`, upstream state, a ready-to-run `git push -u origin <branch>`, and the first 10 unpushed commits.
- (F) `git checkout -q` on the main branch — the usual `git checkout main` prints "Your branch is behind 'origin/main' by N commits" to **stdout**, which `2>/dev/null` cannot suppress and which previously looked like a teardown diagnostic.
- Bonus: fix a latent bug in `_gwt_commits_safe` / `_gwt_branch_merged` where `grep -c '^+' || echo "0"` double-appended "0" on zero-match (grep -c exits 1 on no match, tripping the `||` even though it had already printed "0"). That made every rebase/squash-merged worktree fail the pre-flight check. Rewritten as `! ... | grep -q '^+'`.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_teardown.bats` — new suite, 7/7 green.
- [x] Full bats functions suite — 37/37 green, no regressions.
- [x] Pre-commit hooks (naming, pipe-loop, etc.) pass on both commits.
- [ ] Manual smoke: in a real worktree with unpushed commits, `gwt teardown` now prints ahead count + push suggestion + commit list instead of the terse one-liner.
- [ ] Manual smoke: in a worktree whose PR was squash-merged, `gwt teardown` deletes the branch with "rebase-merged" message even when local `main` has not been fast-forwarded yet.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
