### PR TITLE
feat(skill): auto-claim issue assignee in gh:issue-implement

### DIFF
--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -46,7 +46,7 @@ Per `references/superpowers-detection.md`:
 - If plugin missing → force mode = `direct` + print one warning line.
 - Else → honor the requested mode.
 
-## Step 3: Fetch Issue
+## Step 3: Fetch + Claim Issue
 
 ```bash
 gh issue view <N> --repo "$TARGET_REPO" --json \
@@ -60,6 +60,15 @@ If `state == CLOSED`, stop with:
 Issue #<N> is CLOSED. Refuse to implement a closed issue — reopen it
 or pass a different number.
 ```
+
+Then claim the issue so teammates see it's being worked:
+
+```bash
+gh issue edit <N> --repo "$TARGET_REPO" --add-assignee @me
+```
+
+Soft-fail: on error print one stderr warning and continue. Rules in
+`references/claim-issue.md`.
 
 ## Step 4: Mode Dispatch
 

--- a/claude/skills/gh-issue-implement/references/claim-issue.md
+++ b/claude/skills/gh-issue-implement/references/claim-issue.md
@@ -1,0 +1,71 @@
+# gh:issue-implement — Claim Issue (Assignee)
+
+## Purpose
+
+Prevent two teammates from silently implementing the same issue at the
+same time. Adding `@me` to the issue's assignee list broadcasts "I've
+picked this up" on the GitHub issue page, in `gh issue list
+--assignee @me`, and on issue-list badges.
+
+## Command
+
+```bash
+gh issue edit <N> --repo "$TARGET_REPO" --add-assignee @me
+```
+
+Key properties:
+- `--add-assignee` **adds** to the existing list; it does not overwrite
+  existing assignees. Safe when a reviewer or collaborator is already
+  assigned.
+- Already assigned to `@me`? GitHub treats the re-add as a no-op — no
+  error, no duplicate entry.
+
+## Soft-fail rule
+
+This step must **never** block the implementation flow. Possible
+failure modes and responses:
+
+| Failure | Response |
+|---------|----------|
+| No write permission on repo (fork, readonly token) | Warn, continue |
+| GitHub API transient error / network | Warn, continue |
+| Issue locked or archived | Warn, continue |
+| `gh` not authenticated | Warn, continue (already caught in Step 3 if truly broken) |
+
+Warning line format (single line, prefixed `⚠️`):
+
+```
+⚠️  Could not claim issue #<N> as assignee (<short reason>) — continuing anyway.
+```
+
+Do NOT print a multi-line stack trace. The warning is informational;
+the implementation proceeds regardless.
+
+## Placement rationale
+
+The claim happens **after** the fetch + CLOSED check for two reasons:
+
+1. A CLOSED issue is never implemented, so claiming it would pollute
+   the assignee list for no reason.
+2. Fetch already validates the issue number exists and `gh` is
+   authenticated — the claim step can assume those hold and only needs
+   to handle write-permission / concurrency failures.
+
+It happens **before** Step 4 (mode dispatch) so the signal lands as
+early as possible — even if `writing-plans` / `brainstorming` takes
+minutes, teammates already see the claim.
+
+## What this does NOT do
+
+- Does not auto-unassign on failure in later steps. If implementation
+  fails or the user abandons the branch, the assignee stays set — the
+  human can clear it manually via `gh issue edit <N> --remove-assignee
+  @me`. Auto-unassign was considered and rejected because:
+  - Transient test failures shouldn't release the claim.
+  - The user may want to resume the branch later.
+  - Manual cleanup is a trivial one-liner.
+
+- Does not block if someone else is already assigned. `--add-assignee`
+  supplements rather than replacing, and the warning flow is reserved
+  for genuine errors — not "someone else is also looking at this". The
+  human can decide whether to coordinate via the issue thread.

--- a/claude/skills/gh-issue-implement/references/help.md
+++ b/claude/skills/gh-issue-implement/references/help.md
@@ -26,13 +26,14 @@ worktrees.
 
 1. Fetches the issue (same JSON fields as gh:issue-read).
 2. Verifies precondition: inside a git repo, on a non-base branch, working tree clean.
-3. Depending on mode:
+3. Claims the issue via `gh issue edit <N> --add-assignee @me` so teammates can see it's being worked (soft-fail: a permission/network error prints a single `⚠️` warning and continues; already-assigned is a no-op). Details in `references/claim-issue.md`.
+4. Depending on mode:
    - **direct** — explores the codebase, edits/creates files, runs tests.
    - **plan** — invokes superpowers:writing-plans with the issue body as context. If issue is ambiguous (see `references/implementation-flow.md` → "Ambiguity signals"), auto-promotes to brainstorming.
    - **brainstorming** — invokes superpowers:brainstorming, then writing-plans, then implements.
-4. Auto-detects the test runner from AGENTS.md → `tox.ini` → `pyproject.toml` → `package.json` → `tests/*.bats`, using the first that matches.
-5. Test-failure loop: up to 3 attempts to fix failures caused by its own edits; pre-existing failures are reported separately, not fixed.
-6. Prints a compact report: changed files, test result, next-step hint.
+5. Auto-detects the test runner from AGENTS.md → `tox.ini` → `pyproject.toml` → `package.json` → `tests/*.bats`, using the first that matches.
+6. Test-failure loop: up to 3 attempts to fix failures caused by its own edits; pre-existing failures are reported separately, not fixed.
+7. Prints a compact report: changed files, test result, next-step hint.
 
 ## superpowers plugin not installed → fallback
 

--- a/claude/skills/gh-issue-implement/references/help.md
+++ b/claude/skills/gh-issue-implement/references/help.md
@@ -26,7 +26,7 @@ worktrees.
 
 1. Fetches the issue (same JSON fields as gh:issue-read).
 2. Verifies precondition: inside a git repo, on a non-base branch, working tree clean.
-3. Claims the issue via `gh issue edit <N> --add-assignee @me` so teammates can see it's being worked (soft-fail: a permission/network error prints a single `⚠️` warning and continues; already-assigned is a no-op). Details in `references/claim-issue.md`.
+3. Claims the issue via `gh issue edit <N> --add-assignee @me` so teammates see it's being worked (soft-fail on error; see `references/claim-issue.md`).
 4. Depending on mode:
    - **direct** — explores the codebase, edits/creates files, runs tests.
    - **plan** — invokes superpowers:writing-plans with the issue body as context. If issue is ambiguous (see `references/implementation-flow.md` → "Ambiguity signals"), auto-promotes to brainstorming.


### PR DESCRIPTION
## Summary
- `gh:issue-implement` now auto-claims the issue by adding `@me` as an assignee, so two teammates don't silently work the same issue in parallel.
- Claim is best-effort: permission/network errors are a single-line stderr warning, already-assigned is a no-op.

## Changes
- `claude/skills/gh-issue-implement/SKILL.md` — Step 3 renamed to "Fetch + Claim Issue"; new `gh issue edit <N> --add-assignee @me` substep after the CLOSED-state check and before mode dispatch.
- `claude/skills/gh-issue-implement/references/claim-issue.md` (new) — placement rationale, soft-fail table, and explicit non-goals (no auto-unassign on later failure, no block when someone else is assigned).
- `claude/skills/gh-issue-implement/references/help.md` — added the claim step to the "What the skill does" list and renumbered.

## Test plan
- [ ] `markdownlint claude/skills/gh-issue-implement/**/*.md` — clean.
- [ ] Manual run of `/gh-issue-implement <N>` on an open issue; GitHub issue page shows `@me` as assignee after Step 3.
- [ ] Re-run on the same issue; no duplicate assignee, no error (GitHub `--add-assignee` semantics).
- [ ] Run on an issue in a repo without write permission (fork); see the `⚠️` stderr warning but the skill proceeds to implement.

## Related
Closes #167

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
