### PR TITLE
feat(skill): add gh:pr-resolve-conflict

### DIFF
--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: gh:pr-resolve-conflict
+description: >-
+  Resolve a GitHub PR's "This branch has conflicts that must be resolved"
+  warning using rebase (never a merge commit), then push with
+  `--force-with-lease`. Use when the user runs /gh:pr-resolve-conflict,
+  /gh-pr-resolve-conflict, or asks "PR conflict 해결", "base 변경됐는데 rebase
+  해줘", "리베이스로 컨플릭트 풀어". Refuses to run on the default branch,
+  refuses plain `--force`, and never auto-guesses conflict content — the
+  user drives each resolution. Accepts `[pr-number] [remote]`; defaults to
+  the PR attached to the current branch. Accepts `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+# gh:pr-resolve-conflict — Rebase-based PR Conflict Resolution
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Parse Args + Preflight
+
+Positional args: `[pr-number] [remote]`. Both optional.
+
+- `pr-number` — if omitted, auto-detect via
+  `gh pr view --json number,headRefName,baseRefName,url,mergeable`
+  on the current branch. No PR for the branch → stop.
+- `remote` — default `origin`. Resolve `TARGET_REPO` via
+  `git remote get-url <remote>`; missing → `git remote -v` and stop.
+
+**Hard preconditions** (parallel batch; any fail → stop):
+- inside a git repo
+- current branch ≠ repo default (refuse to rebase `main`)
+- working tree clean, OR auto-stash per `references/safety.md`
+  (announce the stash before running it)
+- no in-progress rebase/merge/cherry-pick
+
+Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it so the user can
+`git reset --hard <sha>` if anything goes wrong.
+
+## Step 2: Fetch + Rebase
+
+```bash
+git fetch "$REMOTE" "$BASE"
+git rebase "$REMOTE/$BASE"
+```
+
+Full rebase mechanics, stash handling, and abort instructions live in
+`references/rebase-flow.md`.
+
+## Step 3: Conflict Resolution Loop
+
+If `git rebase` exits non-zero with conflicts:
+
+1. `git status --short` to list `UU` / `AA` / `DU` paths.
+2. Print the rebase context — `git log --oneline "$REMOTE/$BASE"..HEAD`
+   plus the applying commit (`git log -1 --format='%h %s' REBASE_HEAD`).
+3. Open each file, resolve with the user's intent. **Never auto-guess**
+   when the commit message doesn't make the choice obvious — ask.
+4. `git add <file>` once the user confirms each resolution.
+5. `git rebase --continue`. If more commits conflict, loop to step 1.
+
+Full rubric (abort guidance, squash suggestions for repeated conflicts)
+in `references/conflict-handling.md`.
+
+## Step 4: Push with `--force-with-lease`
+
+Only after `git rebase` exits 0 and the working tree is clean:
+
+```bash
+git push --force-with-lease "$REMOTE" HEAD
+```
+
+Never plain `--force`. If `--force-with-lease` is rejected (someone
+pushed while you rebased), stop and surface the upstream per
+`references/rebase-flow.md` — do NOT silently re-pull-and-rebase.
+
+## Step 5: Verify Mergeable + Report
+
+```bash
+gh pr view <N> --repo "$TARGET_REPO" --json mergeable,mergeStateStatus,url
+```
+
+If `mergeable == MERGEABLE` and `mergeStateStatus ∈ {CLEAN, UNSTABLE}`,
+the warning is cleared. Print the final report from
+`references/rebase-flow.md` → "Final report format". Still `CONFLICTING`
+/ `BEHIND` → print the PR URL, name which side diverged, do not loop.
+
+## Constraints
+
+- Never introduce a merge commit. Rebase-only.
+- Never use plain `git push --force`. `--force-with-lease` or stop.
+- Never rebase onto the default branch from the default branch.
+- Never auto-resolve ambiguous conflicts. Ask the user.
+- Never retry a rejected `--force-with-lease` by fetching and
+  re-rebasing on the user's behalf. Surface divergence and stop.
+- Never skip Step 5. The whole point is clearing the PR warning.

--- a/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
@@ -1,0 +1,96 @@
+# gh:pr-resolve-conflict — Conflict Handling
+
+## Per-commit loop
+
+After `git rebase` stops on a conflict, repeat until `git rebase --continue`
+succeeds or the user aborts:
+
+1. **List** — `git status --short | grep -E '^(UU|AA|DU|UD|AU|UA|DD) '`.
+   If the list is empty (`--continue` was not run yet but there are no
+   `U*` paths), fall through and run `git rebase --continue` directly.
+2. **Context** — print both:
+   - Commits still to apply:
+     `git log --oneline "$REMOTE/$BASE"..HEAD` (then the cursor).
+   - The commit currently being applied:
+     `git log -1 --format='%h %s%n%b' REBASE_HEAD`.
+3. **Resolve each file** — for every path:
+   - `Read` the file (include conflict markers).
+   - Decide intent from the commit message. If the intent is ambiguous
+     (both sides touched the same unrelated logic, or the commit
+     message is a generic "fix"), **ask the user which side to keep**.
+   - Edit the file to resolve; remove all `<<<<<<<`, `=======`, `>>>>>>>`.
+   - `git add <file>`.
+4. **Sanity check** — `git diff --cached --check` to catch whitespace
+   errors, and `git grep -n '^\(<<<<<<<\||=======\|>>>>>>>\)'` to catch
+   leftover markers.
+5. **Continue** — `git rebase --continue`. If the editor opens for a
+   commit message, accept the default unless the user asked to amend.
+6. **Loop** — back to step 1 if more conflicts surface.
+
+## When to suggest `git rebase --abort`
+
+Offer `--abort` if any of these apply:
+
+- The user says "stop" / "abort" / "멈춰" / "되돌려".
+- The same file conflicts in three or more consecutive commits. That's
+  often a sign the rebase is painful and should be planned differently
+  (see "Interactive rebase suggestion" below).
+- A conflicted file touches >500 lines or a `package-lock.json` /
+  `uv.lock` / `pnpm-lock.yaml`. These lockfiles are almost always
+  better resolved by regeneration than by hand-merging.
+
+Print the command; do not run it for the user.
+
+```
+Rebase looks painful. Consider:
+  git rebase --abort
+  git reset --hard <BACKUP_SHA>   # back to where you started
+Then decide: squash commits first, regenerate lockfiles, or keep pushing.
+```
+
+## Interactive rebase suggestion
+
+If the same path conflicts in multiple sequential commits, suggest — but
+do NOT run — squashing those commits first:
+
+```
+Commits <a>, <b>, <c> all touch the same file and conflict each round.
+Consider squashing them before rebasing:
+  git rebase --abort
+  git reset --hard <BACKUP_SHA>
+  git rebase -i "$REMOTE/$BASE"   # mark b, c as 'squash'
+  # then re-run /gh-pr-resolve-conflict
+```
+
+## Lockfile conflicts
+
+For `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`,
+`Cargo.lock`:
+
+1. Accept the base version: `git checkout --theirs <lockfile>`.
+2. Regenerate from the matching manifest in this commit:
+   `uv lock` / `npm install --package-lock-only` / `pnpm install
+   --lockfile-only` / `cargo generate-lockfile`.
+3. `git add <lockfile>`, then continue.
+
+If the manifest itself conflicts, resolve the manifest first, then the
+lockfile.
+
+## Detecting user-side abort
+
+If between iterations `.git/rebase-merge` and `.git/rebase-apply` both
+disappear and `HEAD` is back to `BACKUP_SHA`, the user ran
+`git rebase --abort` in another shell. Stop cleanly:
+
+```
+Rebase aborted (HEAD = BACKUP_SHA). No changes pushed.
+```
+
+## Stop points (never auto-proceed past these)
+
+- "this file is mine, I'll handle it" / "내가 직접 할게" — stop, print
+  `git status` and leave the tree in its conflicted state for the user.
+- Conflict in a file the user has not mentioned and whose intent can't
+  be inferred from the commit message — stop and ask.
+- Any edit that would drop a hunk the user hasn't seen — show the hunk
+  first.

--- a/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
@@ -70,7 +70,7 @@ For `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`,
 1. Accept the base version: `git checkout --theirs <lockfile>`.
 2. Regenerate from the matching manifest in this commit:
    `uv lock` / `npm install --package-lock-only` / `pnpm install
-   --lockfile-only` / `cargo generate-lockfile`.
+   --lockfile-only` / `yarn install` / `cargo generate-lockfile`.
 3. `git add <lockfile>`, then continue.
 
 If the manifest itself conflicts, resolve the manifest first, then the

--- a/claude/skills/gh-pr-resolve-conflict/references/help.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/help.md
@@ -1,0 +1,78 @@
+# gh:pr-resolve-conflict — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<pr-number>` or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `168` |
+| 2 | remote-name | `origin` | Git remote whose repo owns the PR |
+
+## Usage
+
+```
+/gh-pr-resolve-conflict              # PR attached to current branch, origin
+/gh-pr-resolve-conflict 168          # explicit PR, origin
+/gh-pr-resolve-conflict 168 upstream # explicit PR, upstream remote
+/gh-pr-resolve-conflict -h           # this help
+```
+
+## When to use this skill
+
+- GitHub shows **"This branch has conflicts that must be resolved"** on a PR.
+- A colleague's PR merged first and your PR's base (usually `main`) has moved.
+- You want to stay on the `--rebase` policy track — no merge commits.
+
+## When NOT to use
+
+- Conflicts are trivial enough that `gh pr merge --rebase` handles them.
+  (Use `/gh-pr-merge` — if it fails with `CONFLICTING`, come back here.)
+- You prefer a merge-commit strategy. This skill refuses that; edit the
+  PR with `git merge main` manually if that's really what you want.
+- You are on the repo's default branch. The skill refuses — create or
+  check out the feature branch first.
+
+## What the skill does
+
+1. Parses args. Auto-detects the PR from the current branch if omitted.
+2. Prints a **backup SHA** so `git reset --hard <sha>` can undo everything.
+3. Stashes a dirty working tree (announced before stashing).
+4. Fetches the base branch and runs `git rebase origin/<base>`.
+5. On each conflicting commit:
+   - lists conflicted paths,
+   - shows the rebase context (commit-applying + remaining commits),
+   - walks the user through each file,
+   - runs `git add` and `git rebase --continue` after confirmation.
+6. Pushes with `git push --force-with-lease` (never plain `--force`).
+7. Calls `gh pr view --json mergeable,mergeStateStatus` to confirm the
+   GitHub warning is cleared.
+8. Pops any stash it created.
+
+## Safety
+
+- **Backup SHA** printed before the rebase — `git reset --hard <sha>`
+  restores the pre-rebase state; `git reflog` is always available too.
+- **Stash** — only auto-applied if preflight detects a dirty tree, and
+  always announced. Popped at the end even on failure paths.
+- **`--force-with-lease`** — rejects the push if someone else pushed to
+  the branch while you rebased. The skill stops; it does NOT silently
+  re-fetch and re-rebase.
+- **Abort** — if you want out mid-rebase, type `git rebase --abort` in
+  a separate shell; the skill will detect the abort on the next
+  iteration and stop cleanly.
+
+## What this skill will NOT do
+
+- Create a merge commit. Rebase-only. Non-negotiable.
+- Run `git push --force` (without `-with-lease`).
+- Run on the repo's default branch.
+- Guess how to resolve an ambiguous conflict. If the commit message
+  doesn't make the choice obvious, it asks.
+- Re-pull-and-rebase after a rejected `--force-with-lease`. It reports
+  the divergence and stops, so you can decide.
+
+## Related skills
+
+- `gh:pr-merge` — merge an already-clean PR (rebase/squash/merge).
+- `gh:pr-emergency-merge` — admin-bypass merge with audit trail.
+- `gh:pr` — create a PR from the current branch.
+- `gh:pr-reply` — reply to PR review comments after rebasing.

--- a/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
@@ -9,8 +9,15 @@ git rev-parse --is-inside-work-tree
 git rev-parse --abbrev-ref HEAD
 gh repo view --json defaultBranchRef -q .defaultBranchRef.name
 git status --porcelain
-ls .git/rebase-merge .git/rebase-apply .git/MERGE_HEAD .git/CHERRY_PICK_HEAD 2>/dev/null
+ls "$(git rev-parse --git-path rebase-merge)" \
+   "$(git rev-parse --git-path rebase-apply)" \
+   "$(git rev-parse --git-path MERGE_HEAD)" \
+   "$(git rev-parse --git-path CHERRY_PICK_HEAD)" 2>/dev/null
 ```
+
+Use `git rev-parse --git-path <name>` instead of hardcoded `.git/<name>`
+— in a git worktree the real path is `.git/worktrees/<wt>/<name>`, and
+hardcoded paths silently miss the in-progress marker.
 
 Stop conditions:
 
@@ -18,7 +25,7 @@ Stop conditions:
 |---|---|
 | not a git repo | "not inside a git repository" |
 | current branch == default | "refuse to rebase the default branch" |
-| any of `.git/rebase-*`, `.git/MERGE_HEAD`, `.git/CHERRY_PICK_HEAD` | "rebase/merge/cherry-pick already in progress — finish or abort first" |
+| any of `rebase-merge` / `rebase-apply` / `MERGE_HEAD` / `CHERRY_PICK_HEAD` exists (resolved via `git rev-parse --git-path`) | "rebase/merge/cherry-pick already in progress — finish or abort first" |
 
 Dirty working tree is NOT a stop — it triggers the stash flow in
 `safety.md`.

--- a/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
@@ -1,0 +1,109 @@
+# gh:pr-resolve-conflict — Rebase Flow
+
+## Preconditions (parallel batch)
+
+Run all four in a single tool message. Any failure → stop immediately.
+
+```bash
+git rev-parse --is-inside-work-tree
+git rev-parse --abbrev-ref HEAD
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+git status --porcelain
+ls .git/rebase-merge .git/rebase-apply .git/MERGE_HEAD .git/CHERRY_PICK_HEAD 2>/dev/null
+```
+
+Stop conditions:
+
+| Check | Stop reason |
+|---|---|
+| not a git repo | "not inside a git repository" |
+| current branch == default | "refuse to rebase the default branch" |
+| any of `.git/rebase-*`, `.git/MERGE_HEAD`, `.git/CHERRY_PICK_HEAD` | "rebase/merge/cherry-pick already in progress — finish or abort first" |
+
+Dirty working tree is NOT a stop — it triggers the stash flow in
+`safety.md`.
+
+## Resolve base branch
+
+Prefer the PR's actual base (not the repo default):
+
+```bash
+BASE=$(gh pr view "$PR" --repo "$TARGET_REPO" --json baseRefName -q .baseRefName)
+```
+
+Fall back to `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
+only when auto-detecting a PR and `gh pr view` returned nothing yet.
+
+## Fetch + rebase
+
+```bash
+git fetch "$REMOTE" "$BASE"
+BACKUP_SHA=$(git rev-parse HEAD)
+echo "backup SHA: $BACKUP_SHA  (git reset --hard $BACKUP_SHA to undo)"
+git rebase "$REMOTE/$BASE"
+```
+
+Exit codes:
+
+| Exit | Meaning | Action |
+|---|---|---|
+| 0 | clean rebase | go to push step |
+| non-zero + conflicts | conflicts to resolve | enter conflict loop (`conflict-handling.md`) |
+| non-zero + other | rebase failed to start | print stderr, suggest `git rebase --abort`, stop |
+
+## Push
+
+Only after `git rebase` exits 0 and `git status` is clean:
+
+```bash
+git push --force-with-lease "$REMOTE" HEAD
+```
+
+Rejection modes:
+
+| Reason | Action |
+|---|---|
+| "stale info" (someone pushed to the branch) | **stop**; print `git fetch $REMOTE && git log --oneline HEAD..$REMOTE/<branch>` hint; do NOT auto re-rebase |
+| "protected branch" | stop; the branch is write-protected, user handles it |
+| network / auth | stop; surface stderr |
+
+Never substitute `--force` for `--force-with-lease`.
+
+## Verify mergeable
+
+```bash
+gh pr view "$PR" --repo "$TARGET_REPO" \
+  --json number,mergeable,mergeStateStatus,url
+```
+
+| `mergeable` | `mergeStateStatus` | Meaning |
+|---|---|---|
+| `MERGEABLE` | `CLEAN` / `UNSTABLE` | warning cleared, ready to merge (UNSTABLE = non-required CI pending) |
+| `MERGEABLE` | `BEHIND` | rare; user should fetch and retry |
+| `CONFLICTING` | `DIRTY` | GitHub still sees conflicts — stop, print URL |
+| `UNKNOWN` | * | API hasn't settled; retry once after `sleep 2`, then stop if still unknown |
+
+## Final report format
+
+```
+PR #<N> rebased onto <REMOTE>/<BASE>
+  Backup SHA:   <sha>          (git reset --hard to undo)
+  Pushed:       <new-sha>      (--force-with-lease)
+  Mergeable:    <mergeable> / <mergeStateStatus>
+  URL:          <pr-url>
+```
+
+If a stash was created and popped, append:
+
+```
+  Stash:        auto-stashed at preflight, popped after rebase
+```
+
+If the skill stopped before pushing, use:
+
+```
+gh:pr-resolve-conflict stopped at <step>
+  Reason:       <short reason>
+  Backup SHA:   <sha>
+  Resume:       <command the user should run>
+```

--- a/claude/skills/gh-pr-resolve-conflict/references/safety.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/safety.md
@@ -54,10 +54,13 @@ Triggered only when preflight detects a non-empty working tree
 
 ## In-progress operation guard
 
+Always resolve marker paths through `git rev-parse --git-path`. In a git
+worktree the actual paths are under `.git/worktrees/<wt>/`, and hardcoded
+`.git/<name>` checks silently miss the marker.
+
 ```bash
-for marker in \
-  .git/rebase-merge .git/rebase-apply \
-  .git/MERGE_HEAD .git/CHERRY_PICK_HEAD .git/REVERT_HEAD; do
+for name in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD; do
+    marker=$(git rev-parse --git-path "$name")
     if [ -e "$marker" ]; then
         echo "in-progress operation detected: $marker"
         echo "finish or abort it first:"

--- a/claude/skills/gh-pr-resolve-conflict/references/safety.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/safety.md
@@ -1,0 +1,116 @@
+# gh:pr-resolve-conflict — Safety Nets
+
+## Backup SHA
+
+Always captured before `git rebase`:
+
+```bash
+BACKUP_SHA=$(git rev-parse HEAD)
+```
+
+Printed up front so the user can paste it into a recovery command:
+
+```
+backup SHA: <sha>
+  undo everything :  git reset --hard <sha>
+  inspect history :  git reflog
+```
+
+`git reflog` is always a fallback — every rebase step is tracked there
+for ~90 days by default, so even `reset --hard` mistakes are usually
+recoverable.
+
+## Auto-stash
+
+Triggered only when preflight detects a non-empty working tree
+(`git status --porcelain` prints any line).
+
+1. Announce before running:
+
+    ```
+    Working tree is dirty. Auto-stashing:
+      git stash push -u -m "gh:pr-resolve-conflict auto-stash <timestamp>"
+    ```
+
+2. Stash:
+
+    ```bash
+    STASH_MSG="gh:pr-resolve-conflict auto-stash $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    git stash push -u -m "$STASH_MSG"
+    STASH_REF=$(git rev-parse -q --verify refs/stash)
+    ```
+
+3. Proceed with fetch + rebase.
+
+4. After a successful push (or on clean abort), pop:
+
+    ```bash
+    git stash pop "$STASH_REF" 2>/dev/null || \
+      echo "stash preserved — resolve and then: git stash pop $STASH_REF"
+    ```
+
+5. If `pop` itself conflicts, stop and print the stash ref. Never drop
+   the stash automatically.
+
+## In-progress operation guard
+
+```bash
+for marker in \
+  .git/rebase-merge .git/rebase-apply \
+  .git/MERGE_HEAD .git/CHERRY_PICK_HEAD .git/REVERT_HEAD; do
+    if [ -e "$marker" ]; then
+        echo "in-progress operation detected: $marker"
+        echo "finish or abort it first:"
+        echo "  git rebase --continue / --abort"
+        echo "  git merge --continue / --abort"
+        echo "  git cherry-pick --continue / --abort"
+        exit 1
+    fi
+done
+```
+
+## `--force-with-lease` vs `--force`
+
+`--force-with-lease` refuses the push if the remote ref has moved since
+you last fetched. That protects against:
+
+- a reviewer pushing a fix directly to your branch while you rebased,
+- an automation bot (dependabot, renovate) rebasing on top of you,
+- another machine of yours pushing from the same branch.
+
+Plain `--force` blows past all of that. This skill refuses to use it.
+
+If `--force-with-lease` rejects the push, the upstream moved. Show:
+
+```
+Push rejected by --force-with-lease: upstream has new commits you haven't seen.
+  git fetch <remote>
+  git log --oneline HEAD..<remote>/<branch>
+Decide whether to merge those in or discard them, then re-run this skill.
+```
+
+## Never run on the default branch
+
+```bash
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+DEFAULT=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+if [ "$CURRENT" = "$DEFAULT" ]; then
+    echo "refuse: currently on the default branch ($DEFAULT)."
+    echo "check out the PR's head branch first."
+    exit 1
+fi
+```
+
+The default branch should never be force-pushed by this skill. If the
+PR's head IS the default branch (cross-fork PR where the head came from
+a fork), that's out of scope — tell the user and stop.
+
+## Recovery cheat-sheet (for the final report)
+
+```
+If something went wrong:
+  git rebase --abort                 # during rebase
+  git reset --hard <BACKUP_SHA>      # after rebase, before push
+  git reflog                          # rummage for any lost ref
+  git stash list                      # auto-stash survives even if pop fails
+```


### PR DESCRIPTION
## Summary
- 신규 `gh:pr-resolve-conflict` 스킬 추가 — GitHub PR 의 "This branch has conflicts that must be resolved" 경고를 rebase 기반으로 해결.
- merge commit 을 절대 생성하지 않으며, 원격 갱신은 `git push --force-with-lease` 로만 수행 (CLAUDE.md `--rebase` 규칙 + 업데이트된 force-push 정책 준수).
- default 브랜치에서 실행 거부, 모호한 conflict 자동 해결 금지, backup SHA / auto-stash 안내, `gh pr view --json mergeable` 로 사후 검증까지 포함.

## Changes
- `claude/skills/gh-pr-resolve-conflict/SKILL.md` (98 lines): 스킬 진입점 — args 파싱, 병렬 preconditions, fetch + rebase, conflict 루프, `--force-with-lease` push, mergeable verify, report. Progressive Disclosure 를 위해 구체 로직은 references/ 로 분리.
- `references/help.md`: `/gh-pr-resolve-conflict [pr-number] [remote]` 사용법, 사용 장면 / 비사용 장면, 안전장치 요약, 관련 스킬(`gh:pr-merge`, `gh:pr-emergency-merge`, `gh:pr-reply`) 연결.
- `references/rebase-flow.md`: preconditions 병렬 체크, PR base 자동 해석, rebase exit 코드별 분기, push 거절 사유 표, `gh pr view` 결과 해석표, final report / 중단 리포트 포맷.
- `references/conflict-handling.md`: commit 단위 resolve loop, rebase 컨텍스트 출력, lockfile(uv/npm/pnpm/yarn/cargo) 재생성 레시피, 반복 conflict 시 interactive rebase 제안, 사용자 `--abort` 감지 처리.
- `references/safety.md`: backup SHA + reflog 안내, auto-stash 선언적 실행 / pop, in-progress 연산 가드(rebase/merge/cherry-pick/revert), `--force-with-lease` vs `--force` 정책 설명, 복구 치트시트.

## Test plan
- [x] `pytest tests/integration/` — 979 passed in 170s (0 실패).
- [x] `bash tests/golden_rules/test_golden_rules.sh` — 5/5 golden rules pass (이모지/하드코딩 경로/direct-exec 등).
- [x] SKILL.md 98 lines (< 100 lines Progressive Disclosure 규칙 준수).
- [x] 새 파일에 이모지 없음 (CLAUDE.md 규칙).
- [ ] 실제 conflict 상황 재현 — PR base 이동 후 `/gh-pr-resolve-conflict` 실행, mergeable 변화 확인.
- [ ] dirty tree 에서 auto-stash → rebase → pop 흐름 동작 확인.
- [ ] `--force-with-lease` 거절 시 (원격에 먼저 push 발생) 재-rebase 를 시도하지 않고 중단하는지 확인.

## Related
Closes #168

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
