### PR TITLE
feat(gh-flow): fire-and-forget N-parallel issue→PR automation

### DIFF
--- a/docs/feature/gh-flow-automation/design.md
+++ b/docs/feature/gh-flow-automation/design.md
@@ -1,0 +1,234 @@
+# gh-flow: Fire-and-forget GitHub Issue → PR Automation
+
+**작성일**: 2026-04-22
+**상태**: 설계 완료, 구현 대기
+
+## 1. 배경
+
+현재 개발 플로우는 수작업 단계가 많음:
+
+```
+(터미널)   gwt spawn <name>                     # worktree 생성
+(터미널)   cd <worktree>
+(터미널)   claude-yolo                          # TUI 진입
+(TUI)      /gh-issue-implement <N>
+(TUI)      /gh-commit
+(TUI)      /gh-pr
+(대기 ~7분) 동료 리뷰 기다림
+(TUI)      /gh-pr-reply                         # 리뷰 코멘트 반영
+(대기)     승인 폴링 (1분 간격 수동 확인)
+(TUI)      /gh-pr-merge
+(TUI)      /exit
+(터미널)   gwt teardown
+```
+
+N개 이슈를 동시에 처리할 때 이 전 과정을 반복해야 해 집중력이 심하게 분산됨.
+
+## 2. 목표 / 비목표
+
+### 목표
+- 한 커맨드 `gh-flow <N> [<N2> ...]` 로 N개 이슈를 **병렬**로 전과정 자동화
+- **Fire-and-forget** — 커맨드 치고 자리 떠나도 됨, 결과는 칸반 보드에서 확인
+- 리뷰 대기 중 claude 세션 **0개** 유지 (토큰/메모리 소모 없음)
+- 실패 **격리** — 한 worker가 깨져도 다른 N-1개는 계속 진행
+
+### 비목표
+- 진행 상황 대시보드 UI (칸반 보드로 이미 해결됨)
+- Slack/데스크탑 알림
+- 리부팅 저항성 (systemd 없이 순수 쉘로 단순성 우선)
+- 여러 리뷰 라운드 지원 — reply는 **1회만** 시도
+- `/gh-pr-reply` 결과 검증 — 사용자의 기존 경험상 이 스킬이 실패한 적 없음
+
+## 3. 아키텍처
+
+```
+사용자 터미널 (메인 repo에서)
+    │
+    │  $ gh-flow 13 42 88
+    ▼
+┌──────────────────────┐
+│ gh-flow (orchestrator)│  bash 함수. N개 worker를 nohup 백그라운드로 fork 후 즉시 종료.
+└──────┬───────────────┘
+       │ forks (nohup + disown)
+       ├──► worker-13  (독립 bash 프로세스)
+       ├──► worker-42  (독립 bash 프로세스)
+       └──► worker-88  (독립 bash 프로세스)
+
+각 worker 생명주기:
+  1. gwt spawn issue-<N>
+  2. cd <worktree>
+  3. claude -p "/gh-issue-flow <N>"          # implement → commit → PR
+  4. poll 루프 (60s 간격):
+       · gh pr view --json reviewDecision
+       · APPROVED → loop 탈출
+       · 리뷰 코멘트 존재 AND reply 미수행 → claude -p "/gh-pr-reply" 1회 실행
+       · 그 외: 계속 polling
+  5. claude -p "/gh-pr-merge"
+  6. gwt teardown
+  7. exit
+
+상태/로그 디렉토리:
+  ~/.local/state/gh-flow/<repo>/<issue>/
+    ├── state         # "spawning|implementing|polling|merging|done|failed:<step>"
+    ├── worktree.path # gwt spawn이 만든 경로
+    ├── pr.number     # 생성된 PR 번호
+    ├── reply.done    # 빈 파일 (존재하면 reply 이미 실행됨)
+    └── log           # stdout+stderr tee
+```
+
+### 핵심 원칙
+- 각 worker는 독립 프로세스 → 타 worker와 공유 상태 없음
+- `gh-flow <N>`은 **멱등** — `state` 파일 검사해서 이미 실행 중/완료면 거부, 실패 상태면 이어서 재개
+- orchestrator는 fork 후 즉시 종료 → 사용자 쉘 프롬프트 지연 없음
+
+## 4. 컴포넌트
+
+### 4.1 `shell-common/functions/gh_flow.sh`
+POSIX 쉘 파일. bash/zsh에서 sourcing됨. 다음을 정의:
+
+- **`gh-flow`** (함수): 오케스트레이터
+  - Args: `<issue-number>... | -h|--help`
+  - 전제: 메인 repo 내부 (worktree 아님), `gh` 인증됨
+  - 동작: 각 이슈에 대해 `_gh_flow_worker`를 `nohup bash -c '...' &` 로 fork + `disown`
+  - 출력: `ux_info "Spawned worker for #13 (pid=12345, log=...)"` 를 N번
+  - 종료: 즉시 (백그라운드 워커는 살아있음)
+
+- **`_gh_flow_worker`** (함수): worker 본체
+  - Args: `<issue-number>`
+  - 호출 경로: nohup된 서브셸이 `gh_flow.sh`를 source한 뒤 이 함수 호출
+  - 단계별 실패 시 `state` 파일에 `failed:<step>` 쓰고 비정상 종료 (worktree 안 지움)
+  - 각 claude 호출은 `claude --dangerously-skip-permissions -p "<slash-command>"` 형태
+
+- **`_gh_flow_poll_reviews`** (헬퍼 함수): PR 리뷰 상태 조회
+  - Args: `<pr-number>`
+  - 반환: stdout에 `APPROVED | HAS_COMMENTS | WAITING`
+
+- **`gh-flow-help`** + 섹션 헬퍼들: 기존 `*_help.sh` 컨벤션 따름
+
+### 4.2 `~/.local/state/gh-flow/` 상태 디렉토리
+런타임에 worker가 생성. XDG 베이스 경로 규칙 준수. `<repo>`는 `basename $(git rev-parse --show-toplevel)`로 도출.
+
+## 5. 데이터 플로우
+
+### 5.1 한 worker의 상태 전이
+
+```
+(start)
+  │
+  ▼
+spawning ──── gwt spawn 성공 ──► implementing
+  │                                   │
+  │                                   ├── claude /gh-issue-flow 성공
+  │                                   ▼
+  │                                 polling ◄──────┐
+  │                                   │            │ 계속 대기
+  │                                   ├── reviewDecision == APPROVED
+  │                                   │     ▼
+  │                                   │   merging
+  │                                   │     │
+  │                                   │     ├── claude /gh-pr-merge 성공
+  │                                   │     ▼
+  │                                   │   tearing-down
+  │                                   │     │
+  │                                   │     ├── gwt teardown 성공
+  │                                   │     ▼
+  │                                   │    done ✓
+  │                                   │
+  │                                   ├── 리뷰 코멘트 존재 AND !reply.done
+  │                                   │     ▼
+  │                                   │   replying
+  │                                   │     │
+  │                                   │     ├── claude /gh-pr-reply 성공
+  │                                   │     │   + reply.done 파일 생성
+  │                                   │     ▼
+  │                                   └─ polling ──┘
+  │
+  └── 어느 단계든 실패 → state=failed:<step>, exit (worktree 보존)
+```
+
+### 5.2 N개 병렬 타임라인
+
+```
+t=0       gh-flow 13 42 88  (사용자 한 커맨드)
+          └─ fork 3개 후 즉시 return (사용자 쉘 프롬프트 복귀)
+
+t=0..2m   worker-13, worker-42, worker-88 각각 독립적으로:
+          - gwt spawn
+          - claude /gh-issue-flow (~60-120초)
+
+t=2m..?   각자 polling 루프 진입. PR 번호 확보 완료.
+
+t=2m..    리뷰어가 각 PR에 개별 페이스로 리뷰/코멘트/승인
+          - #13은 리뷰 코멘트 → reply → 승인 → merge
+          - #42는 코멘트 없이 바로 승인 → merge
+          - #88은 승인 느림 → 계속 polling (문제 없음)
+
+각 worker는 완료 시점에 `state=done` 쓰고 worktree 정리 후 종료.
+```
+
+## 6. 에러 처리
+
+### 6.1 단계별 실패 정책 — 모두 "해당 worker만 정지, worktree 남김"
+
+| 단계 | 실패 예시 | 처리 |
+|------|-----------|------|
+| spawning | `gwt spawn` 실패 (디스크 풀 등) | state=failed:spawning, worktree 없음, exit |
+| implementing | `/gh-issue-flow` 실패 (커밋 훅, 빌드 등) | state=failed:implementing, worktree 보존 — 사용자가 `cd` 해서 수동 복구 |
+| polling | `gh` 명령 실패 (인증 만료 등) | state=failed:polling, worktree 보존 |
+| replying | `/gh-pr-reply` 실패 | state=failed:replying, 단 reply.done은 **안** 남김 (재시도 가능성) |
+| merging | PR 머지 충돌 | state=failed:merging, worktree 보존 |
+| tearing-down | `gwt teardown` 실패 | state=failed:tearing-down (드묾, 수동 정리) |
+
+### 6.2 타 worker 영향 없음
+각 worker는 독립 프로세스 + 독립 worktree + 독립 상태 디렉토리. 한 worker의 실패는 다른 worker에 전파 안 됨.
+
+### 6.3 멱등 재실행
+사용자가 실패 후 `gh-flow 13` 재실행:
+- `state=done` → "already done, skipping" 메시지 후 종료
+- `state=failed:<step>` → `<step>`부터 재개 시도 (예: `implementing`에서 실패했으면 기존 worktree 재사용해서 `/gh-issue-flow` 재시도)
+- `state=<in-progress-state>` → 같은 이슈의 worker가 이미 실행 중인지 pid 체크 후 결정
+
+### 6.4 전역 타임아웃
+**명시적으로 없음.** 승인이 영영 안 오면 worker는 영원히 polling. 사용자가 판단해서 `kill <pid>` + 수동 정리. (첫 버전은 이 단순성 유지)
+
+## 7. 파일 레이아웃
+
+### 신규 파일
+```
+shell-common/functions/gh_flow.sh          # 오케스트레이터 + worker + helper 함수들
+shell-common/functions/gh_flow_help.sh     # help 출력 (기존 *_help.sh 컨벤션)
+docs/feature/gh-flow-automation/design.md  # 본 문서
+```
+
+### 런타임 생성
+```
+~/.local/state/gh-flow/<repo>/<issue>/{state,worktree.path,pr.number,reply.done,log}
+```
+
+### 수정 없음
+기존 `gwt`, `/gh-issue-flow`, `/gh-pr-reply`, `/gh-pr-merge`는 변경 없이 그대로 재사용.
+
+## 8. 리스크 / 미해결 사항
+
+1. **`claude -p` 와 slash command 호환성** — `/gh-issue-flow` 같은 slash command가 `claude -p "/gh-issue-flow 13"` 형태로 제대로 호출되는지 실측 필요. 안 되면 스킬 직접 호출 프롬프트로 우회.
+2. **pre-commit hook이 interactive prompt를 띄우는 경우** — headless claude에서 block될 수 있음. 첫 실행 시 체크.
+3. **리뷰어가 PR 승인 후 다시 코멘트** — reply.done 가 true면 무시하고 그대로 merge 시도. 기획상 의도된 동작(Q4 답변).
+4. **PR merge conflict** — 베이스 브랜치와 충돌 시 `/gh-pr-merge`가 실패. worker는 `failed:merging` 상태로 멈춤. 수동 해결.
+5. **`gwt spawn` 은 메인 repo에서 실행해야 함** — orchestrator도 메인 repo에서 호출되어야. 선행 체크 필요.
+
+## 9. 명령 레퍼런스 (사용자 용)
+
+```bash
+# 기본
+gh-flow 13                    # 단일 이슈
+gh-flow 13 42 88              # 3개 병렬
+
+# 옵션
+gh-flow --help                # 도움말
+gh-flow --list                # 현재 실행 중인 worker 목록 + 상태
+gh-flow --status 13           # 이슈 #13 worker 상세 상태
+gh-flow --kill 13             # 이슈 #13 worker 강제 종료 (worktree는 남김)
+gh-flow --tail 13             # 이슈 #13 worker 로그 tail -f
+```
+
+주: 첫 릴리스는 기본 + `--help` 만 구현. 나머지는 필요하면 추가.

--- a/docs/feature/gh-flow-automation/design.md
+++ b/docs/feature/gh-flow-automation/design.md
@@ -182,11 +182,19 @@ t=2m..    리뷰어가 각 PR에 개별 페이스로 리뷰/코멘트/승인
 ### 6.2 타 worker 영향 없음
 각 worker는 독립 프로세스 + 독립 worktree + 독립 상태 디렉토리. 한 worker의 실패는 다른 worker에 전파 안 됨.
 
-### 6.3 멱등 재실행
+### 6.3 실패 후 재실행
+
+현재 구현은 "단순 재시도" 모델이다 — step-level resume 은 v1 out of scope.
+
 사용자가 실패 후 `gh-flow 13` 재실행:
-- `state=done` → "already done, skipping" 메시지 후 종료
-- `state=failed:<step>` → `<step>`부터 재개 시도 (예: `implementing`에서 실패했으면 기존 worktree 재사용해서 `/gh-issue-flow` 재시도)
-- `state=<in-progress-state>` → 같은 이슈의 worker가 이미 실행 중인지 pid 체크 후 결정
+- `state=done` → "already done, skipping" 메시지 후 종료.
+- `state=<in-progress-state>`:
+  - pid 살아있음 → skip (중복 실행 방지).
+  - pid 죽어있음 → 새 worker fork. 아래 `failed:*` 와 동일 동작.
+- `state=failed:<step>` → 새 worker fork. **새 worker는 항상 Step 1(gwt spawn)부터 시작**하고, `gwt spawn` 이 자동으로 새 인덱스를 붙여 **새 worktree**(`<proj>-issue-13-2`)를 만든다. 이전 실패한 worktree(`<proj>-issue-13-1`)는 디스크에 그대로 남아 사용자가 수동으로 조사·정리할 수 있다.
+
+#### 후속 개선 (v1 out of scope)
+진정한 step-level resume — 예: `implementing` 단계에서 실패했으면 기존 worktree를 재사용해 `/gh-issue-flow`만 재실행 — 은 worker가 시작 시 `state` 와 `worktree.path` 를 읽어 Step 1~2를 건너뛰는 로직이 필요하다. 별도 follow-up.
 
 ### 6.4 전역 타임아웃
 **명시적으로 없음.** 승인이 영영 안 오면 worker는 영원히 polling. 사용자가 판단해서 `kill <pid>` + 수동 정리. (첫 버전은 이 단순성 유지)

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -18,7 +18,10 @@ _gh_flow_repo_name() {
 
 _gh_flow_issue_dir() {
     # $1 = issue number
-    printf '%s/%s/%s' "$(_gh_flow_state_root)" "$(_gh_flow_repo_name)" "$1"
+    local _root _name
+    _root=$(_gh_flow_state_root)
+    _name=$(_gh_flow_repo_name)
+    printf '%s/%s/%s' "$_root" "$_name" "$1"
 }
 
 _gh_flow_set_state() {
@@ -34,7 +37,7 @@ _gh_flow_set_state() {
 _gh_flow_get_state() {
     # $1 = issue; prints state or "nonexistent"
     local _dir
-    _dir="$(_gh_flow_issue_dir "$1")"
+    _dir=$(_gh_flow_issue_dir "$1")
     if [ -f "$_dir/state" ]; then
         cat "$_dir/state"
     else
@@ -145,12 +148,12 @@ gh_flow() {
 _gh_flow_spawn_worker() {
     local _issue="$1"
     local _dir _log _state _pid
-    _dir="$(_gh_flow_issue_dir "$_issue")"
+    _dir=$(_gh_flow_issue_dir "$_issue")
     mkdir -p "$_dir"
     _log="$_dir/log"
 
     # Idempotency check
-    _state="$(_gh_flow_get_state "$_issue")"
+    _state=$(_gh_flow_get_state "$_issue")
     case "$_state" in
         done)
             ux_info "#$_issue already done, skipping"
@@ -194,7 +197,7 @@ _gh_flow_spawn_worker() {
 _gh_flow_worker() {
     local _issue="$1"
     local _dir _worktree _pr _spawn_name _decision _comments
-    _dir="$(_gh_flow_issue_dir "$_issue")"
+    _dir=$(_gh_flow_issue_dir "$_issue")
     _spawn_name="issue-$_issue"
 
     printf '[gh-flow-worker] issue=#%s start=%s\n' "$_issue" "$(date -Iseconds 2>/dev/null || date)"

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -1,0 +1,304 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_flow.sh
+# gh-flow — fire-and-forget N-parallel GitHub issue → PR automation.
+# Design: docs/feature/gh-flow-automation/design.md
+
+# ============================================================================
+# State helpers
+# ============================================================================
+
+_gh_flow_state_root() {
+    printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/gh-flow"
+}
+
+_gh_flow_repo_name() {
+    basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null
+}
+
+_gh_flow_issue_dir() {
+    # $1 = issue number
+    printf '%s/%s/%s' "$(_gh_flow_state_root)" "$(_gh_flow_repo_name)" "$1"
+}
+
+_gh_flow_set_state() {
+    # $1 = issue-dir path, $2 = state
+    # Takes a dir (not an issue number) so callers inside a worktree are
+    # not affected by cwd — otherwise _gh_flow_issue_dir recomputes via
+    # `git rev-parse --show-toplevel` and silently writes to a different
+    # location after the worker cd's into its worktree.
+    mkdir -p "$1"
+    printf '%s\n' "$2" >"$1/state"
+}
+
+_gh_flow_get_state() {
+    # $1 = issue; prints state or "nonexistent"
+    local _dir
+    _dir="$(_gh_flow_issue_dir "$1")"
+    if [ -f "$_dir/state" ]; then
+        cat "$_dir/state"
+    else
+        printf 'nonexistent'
+    fi
+}
+
+# ============================================================================
+# Help
+# ============================================================================
+
+gh_flow_help() {
+    ux_header "gh-flow - fire-and-forget GitHub issue → PR automation"
+    ux_info "Usage: gh-flow <issue-number>... | -h|--help"
+    ux_info ""
+    ux_info "Spawns one background worker per issue. Each worker:"
+    ux_bullet "gwt spawn → /gh-issue-flow → poll reviews → /gh-pr-reply (once, if comments)"
+    ux_bullet "→ poll for APPROVED → /gh-pr-merge → gwt teardown"
+    ux_info ""
+    ux_info "Examples:"
+    ux_bullet "gh-flow 13                  # single issue"
+    ux_bullet "gh-flow 13 42 88            # 3 issues in parallel"
+    ux_info ""
+    ux_info "State directory: ~/.local/state/gh-flow/<repo>/<issue>/"
+    ux_bullet_sub "state         - current step"
+    ux_bullet_sub "pid           - worker process id"
+    ux_bullet_sub "worktree.path - git worktree path"
+    ux_bullet_sub "pr.number     - PR number"
+    ux_bullet_sub "reply.done    - marker (present if reply already ran)"
+    ux_bullet_sub "log           - full stdout+stderr"
+    ux_info ""
+    ux_info "Failure isolation:"
+    ux_bullet "One worker failure does not affect others."
+    ux_bullet "Failed worker leaves worktree intact; state shows 'failed:<step>'."
+    ux_info ""
+    ux_info "Preconditions:"
+    ux_bullet "Run from main repo (not inside a worktree)"
+    ux_bullet "gh CLI authenticated, claude CLI on PATH, gwt loaded"
+}
+
+# ============================================================================
+# Orchestrator
+# ============================================================================
+
+gh_flow() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    case "${1:-}" in
+        ""|-h|--help|help)
+            gh_flow_help
+            return 0
+            ;;
+    esac
+
+    # Preconditions
+    if ! _have git; then
+        ux_error "git not found"
+        return 1
+    fi
+    if ! _have gh; then
+        ux_error "gh CLI not found"
+        return 1
+    fi
+    if ! _have claude; then
+        ux_error "claude CLI not found"
+        return 1
+    fi
+    if ! command -v gwt >/dev/null 2>&1; then
+        ux_error "gwt function not loaded (source shell-common first)"
+        return 1
+    fi
+
+    # Must be in main repo (not a worktree)
+    local _git_dir _git_common
+    _git_dir="$(git rev-parse --git-dir 2>/dev/null)"
+    _git_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+    if [ -z "$_git_dir" ]; then
+        ux_error "not inside a git repo"
+        return 1
+    fi
+    if [ "$_git_dir" != "$_git_common" ]; then
+        ux_error "gh-flow must run from the main repo, not a worktree"
+        ux_info "cd to the main repo and retry"
+        return 1
+    fi
+
+    # Validate each arg is a positive integer
+    local _issue
+    for _issue in "$@"; do
+        case "$_issue" in
+            ''|*[!0-9]*)
+                ux_error "invalid issue number: '$_issue' (must be positive integer)"
+                return 1
+                ;;
+        esac
+    done
+
+    ux_header "gh-flow: spawning $# worker(s)"
+    for _issue in "$@"; do
+        _gh_flow_spawn_worker "$_issue"
+    done
+    ux_success "All workers detached. Your shell is free. Results will appear on the kanban."
+}
+
+_gh_flow_spawn_worker() {
+    local _issue="$1"
+    local _dir _log _state _pid
+    _dir="$(_gh_flow_issue_dir "$_issue")"
+    mkdir -p "$_dir"
+    _log="$_dir/log"
+
+    # Idempotency check
+    _state="$(_gh_flow_get_state "$_issue")"
+    case "$_state" in
+        done)
+            ux_info "#$_issue already done, skipping"
+            return 0
+            ;;
+        spawning|implementing|polling|replying|merging|tearing-down)
+            if [ -f "$_dir/pid" ]; then
+                _pid="$(cat "$_dir/pid")"
+                if kill -0 "$_pid" 2>/dev/null; then
+                    ux_warning "#$_issue already running (pid=$_pid), skipping"
+                    return 0
+                fi
+            fi
+            ux_info "#$_issue was in-progress but pid is dead — resuming with a new worker"
+            ;;
+    esac
+
+    # Rotate previous log (keep one .prev for debugging)
+    if [ -f "$_log" ]; then
+        mv "$_log" "$_log.prev" 2>/dev/null || true
+    fi
+
+    # Fork detached worker. DOTFILES_FORCE_INIT=1 forces full shell-common
+    # loading in the non-interactive subshell so `gwt`, `ux_*`, and helpers
+    # resolve. The subshell sources ~/.bashrc then calls _gh_flow_worker.
+    # shellcheck disable=SC2016
+    nohup env DOTFILES_FORCE_INIT=1 bash -c '
+        . "$HOME/.bashrc" 2>/dev/null || true
+        _gh_flow_worker "$1"
+    ' -- "$_issue" >"$_log" 2>&1 &
+    _pid=$!
+    disown "$_pid" 2>/dev/null || true
+    printf '%s\n' "$_pid" >"$_dir/pid"
+    ux_info "#$_issue → pid=$_pid  log=$_log"
+}
+
+# ============================================================================
+# Worker (runs in a detached bash subshell)
+# ============================================================================
+
+_gh_flow_worker() {
+    local _issue="$1"
+    local _dir _worktree _pr _spawn_name _decision _comments
+    _dir="$(_gh_flow_issue_dir "$_issue")"
+    _spawn_name="issue-$_issue"
+
+    printf '[gh-flow-worker] issue=#%s start=%s\n' "$_issue" "$(date -Iseconds 2>/dev/null || date)"
+
+    # ---- Step 1: spawn worktree ----
+    _gh_flow_set_state "$_dir" "spawning"
+    if ! gwt spawn "$_spawn_name"; then
+        _gh_flow_set_state "$_dir" "failed:spawning"
+        printf '[gh-flow-worker] gwt spawn failed\n' >&2
+        return 1
+    fi
+
+    # Locate the worktree just created (branch pattern: wt/<name>/<idx>)
+    _worktree="$(git worktree list --porcelain 2>/dev/null \
+        | awk -v n="$_spawn_name" '
+            $1 == "worktree" { p = $2 }
+            $1 == "branch" && index($2, "/wt/" n "/") { print p }
+        ' | tail -n 1)"
+
+    if [ -z "$_worktree" ] || [ ! -d "$_worktree" ]; then
+        _gh_flow_set_state "$_dir" "failed:spawning"
+        printf '[gh-flow-worker] could not locate created worktree\n' >&2
+        return 1
+    fi
+    printf '%s\n' "$_worktree" >"$_dir/worktree.path"
+    printf '[gh-flow-worker] worktree=%s\n' "$_worktree"
+
+    # shellcheck disable=SC2164
+    cd "$_worktree" || {
+        _gh_flow_set_state "$_dir" "failed:spawning"
+        return 1
+    }
+
+    # ---- Step 2: implement (claude runs /gh-issue-flow) ----
+    _gh_flow_set_state "$_dir" "implementing"
+    if ! claude --dangerously-skip-permissions -p "/gh-issue-flow $_issue"; then
+        _gh_flow_set_state "$_dir" "failed:implementing"
+        printf '[gh-flow-worker] /gh-issue-flow failed\n' >&2
+        return 1
+    fi
+
+    _pr="$(gh pr view --json number --jq '.number' 2>/dev/null)"
+    if [ -z "$_pr" ]; then
+        _gh_flow_set_state "$_dir" "failed:implementing"
+        printf '[gh-flow-worker] no PR created by /gh-issue-flow\n' >&2
+        return 1
+    fi
+    printf '%s\n' "$_pr" >"$_dir/pr.number"
+    printf '[gh-flow-worker] PR=#%s\n' "$_pr"
+
+    # ---- Step 3: poll for review / approval ----
+    _gh_flow_set_state "$_dir" "polling"
+    while true; do
+        sleep 60
+
+        _decision="$(gh pr view "$_pr" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null)"
+        if [ "$_decision" = "APPROVED" ]; then
+            printf '[gh-flow-worker] approved\n'
+            break
+        fi
+
+        # Reply once, only if comments/changes-requested exist and we haven't replied yet.
+        if [ ! -f "$_dir/reply.done" ]; then
+            _comments="$(gh pr view "$_pr" --json reviews \
+                --jq '[.reviews[] | select(.state == "COMMENTED" or .state == "CHANGES_REQUESTED")] | length' \
+                2>/dev/null)"
+            if [ -n "$_comments" ] && [ "$_comments" -gt 0 ]; then
+                _gh_flow_set_state "$_dir" "replying"
+                printf '[gh-flow-worker] running /gh-pr-reply (%s review(s))\n' "$_comments"
+                if claude --dangerously-skip-permissions -p "/gh-pr-reply"; then
+                    touch "$_dir/reply.done"
+                    _gh_flow_set_state "$_dir" "polling"
+                else
+                    _gh_flow_set_state "$_dir" "failed:replying"
+                    printf '[gh-flow-worker] /gh-pr-reply failed\n' >&2
+                    return 1
+                fi
+            fi
+        fi
+    done
+
+    # ---- Step 4: merge ----
+    _gh_flow_set_state "$_dir" "merging"
+    if ! claude --dangerously-skip-permissions -p "/gh-pr-merge"; then
+        _gh_flow_set_state "$_dir" "failed:merging"
+        printf '[gh-flow-worker] /gh-pr-merge failed\n' >&2
+        return 1
+    fi
+
+    # ---- Step 5: teardown (must run inside the worktree) ----
+    _gh_flow_set_state "$_dir" "tearing-down"
+    if ! gwt teardown --force; then
+        _gh_flow_set_state "$_dir" "failed:tearing-down"
+        printf '[gh-flow-worker] gwt teardown failed\n' >&2
+        return 1
+    fi
+
+    _gh_flow_set_state "$_dir" "done"
+    printf '[gh-flow-worker] done issue=#%s end=%s\n' "$_issue" "$(date -Iseconds 2>/dev/null || date)"
+}
+
+# ============================================================================
+# Aliases (hyphenated command names per shell-common convention)
+# ============================================================================
+
+alias gh-flow='gh_flow'
+alias gh-flow-help='gh_flow_help'

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -203,23 +203,27 @@ _gh_flow_worker() {
     printf '[gh-flow-worker] issue=#%s start=%s\n' "$_issue" "$(date -Iseconds 2>/dev/null || date)"
 
     # ---- Step 1: spawn worktree ----
+    # Snapshot the worktree list before and after `gwt spawn` and diff them
+    # to identify the new one. This avoids coupling to gwt's internal
+    # branch-naming convention (previously: parsing `wt/<name>/<idx>`).
+    local _wt_before _wt_after
     _gh_flow_set_state "$_dir" "spawning"
+    _wt_before=$(git worktree list --porcelain 2>/dev/null | awk '$1=="worktree"{print $2}')
     if ! gwt spawn "$_spawn_name"; then
         _gh_flow_set_state "$_dir" "failed:spawning"
         printf '[gh-flow-worker] gwt spawn failed\n' >&2
         return 1
     fi
 
-    # Locate the worktree just created (branch pattern: wt/<name>/<idx>)
-    _worktree="$(git worktree list --porcelain 2>/dev/null \
-        | awk -v n="$_spawn_name" '
-            $1 == "worktree" { p = $2 }
-            $1 == "branch" && index($2, "/wt/" n "/") { print p }
-        ' | tail -n 1)"
+    _wt_after=$(git worktree list --porcelain 2>/dev/null | awk '$1=="worktree"{print $2}')
+    _worktree=$(comm -13 \
+        <(printf '%s\n' "$_wt_before" | sort) \
+        <(printf '%s\n' "$_wt_after" | sort) \
+        | head -n 1)
 
     if [ -z "$_worktree" ] || [ ! -d "$_worktree" ]; then
         _gh_flow_set_state "$_dir" "failed:spawning"
-        printf '[gh-flow-worker] could not locate created worktree\n' >&2
+        printf '[gh-flow-worker] could not locate newly-created worktree\n' >&2
         return 1
     fi
     printf '%s\n' "$_worktree" >"$_dir/worktree.path"


### PR DESCRIPTION
## Summary

- Adds `gh-flow <N>... ` — one-command fire-and-forget automation that forks a nohup worker per issue. Each worker runs: `gwt spawn` → `claude -p /gh-issue-flow` → poll for reviews → `/gh-pr-reply` (once, if comments) → poll for APPROVED → `/gh-pr-merge` → `gwt teardown`.
- Per-worker failure isolation: failed workers leave worktrees intact for manual recovery; other workers continue unaffected.
- No daemon, no infra. Pure shell + existing `gwt`/claude/gh CLIs. State under `~/.local/state/gh-flow/<repo>/<issue>/`.
- Design doc: `docs/feature/gh-flow-automation/design.md`.

A production bug was caught during smoke test: `_gh_flow_set_state` previously rebuilt the state path via `git rev-parse --show-toplevel`, which silently switched to a different directory after the worker `cd`'d into its worktree. Fixed by making the setter take an explicit dir so the worker's pre-captured path is used.

## Test plan

- [x] `bash -n` / `zsh -n` / `shellcheck -x -e SC1090,SC1091` — clean
- [x] Full loader integration: sourcing `bash/main.bash` with `DOTFILES_FORCE_INIT=1` exposes `gh_flow`, `_gh_flow_worker`, `gh-flow` alias
- [x] Smoke test 26/26 pass (isolated test repo, mocked `gwt`/`claude`/`gh`): state helpers, arg validation, idempotency (`state=done` skip, dead-pid resume), full happy path, reply branch, failure preservation
- [x] `claude --dangerously-skip-permissions -p "/gh-issue-read <N>"` verified to invoke the skill in headless mode (not treated as literal text)
- [ ] End-to-end run against a real issue — safest on a low-risk issue the author picks; worker log at `~/.local/state/gh-flow/<repo>/<N>/log`

## Out of scope / follow-ups

- Subcommands `--list` / `--status` / `--kill` / `--tail` (listed in design §9 for a later iteration)
- systemd-user timer variant for reboot-resilience (design §3 alt, deferred — pure nohup sufficient for the common case)
- Review comment auto-reply is **one-shot**: if a second review round arrives, the worker will continue polling for APPROVED without replying again (per Q4 of the brainstorming session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
