### PR TITLE
feat(skill): gh:pr-merge accepts empty reviewDecision on solo repo

### DIFF
--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -40,7 +40,7 @@ Run in one message:
 Then detect whether the base branch has protection rules (uses
 `baseRefName` from the previous call):
 
-- `gh api repos/$TARGET_REPO/branches/<baseRefName>/protection`
+- `gh api "repos/$TARGET_REPO/branches/<baseRefName>/protection"`
   - HTTP 200 → protection **present**; strict rules apply.
   - HTTP 403 (Free plan locks the feature) or 404 (not configured)
     → protection **absent**; empty `reviewDecision` is accepted

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -37,11 +37,25 @@ Run in one message:
 - `gh pr view <N> --repo $TARGET_REPO --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,url`
 - `gh pr checks <N> --repo $TARGET_REPO --required`
 
+Then detect whether the base branch has protection rules (uses
+`baseRefName` from the previous call):
+
+- `gh api repos/$TARGET_REPO/branches/<baseRefName>/protection`
+  - HTTP 200 → protection **present**; strict rules apply.
+  - HTTP 403 (Free plan locks the feature) or 404 (not configured)
+    → protection **absent**; empty `reviewDecision` is accepted
+    (solo / personal repos where no one can approve your own PR).
+
 **Hard stops** (see `references/strategy-selection.md` for exact table):
 - `state != OPEN`
 - `isDraft == true`
 - `mergeable == CONFLICTING`
 - `reviewDecision != APPROVED` → suggest `/gh-pr-emergency-merge` for admin bypass
+  - Exception: protection **absent** (403/404) **AND** `reviewDecision == ""`
+    → accept and print an informational line:
+    `INFO: No branch protection on <baseRefName> — accepting empty reviewDecision.`
+    A non-empty non-APPROVED value (`REVIEW_REQUIRED`,
+    `CHANGES_REQUESTED`) still stops regardless of protection.
 - `mergeStateStatus ∈ {BEHIND, BLOCKED, DIRTY}`
 - Any required check FAILURE or pending
 

--- a/claude/skills/gh-pr-merge/references/help.md
+++ b/claude/skills/gh-pr-merge/references/help.md
@@ -44,3 +44,32 @@ _Availability depends on repo settings → General → Pull Requests. If a strat
 - Fall back to another strategy on failure.
 - Merge an un-approved PR — use `gh:pr-emergency-merge` for admin bypass with audit trail.
 - Keep the head branch — always `--delete-branch`.
+
+## Solo / personal repo behavior
+
+GitHub disallows PR authors from self-approving, and Branch Protection
+Rules are locked on Free-plan private repos. The combination leaves
+`reviewDecision` permanently empty (`""`) on solo repos — so a strict
+`APPROVED` check would make this skill unusable without routing every
+merge through `gh:pr-emergency-merge`.
+
+To avoid that, the skill detects whether the base branch has protection:
+
+- `gh api repos/<owner>/<repo>/branches/<base>/protection` returning
+  HTTP 200 → protection **present** → strict `APPROVED` required.
+- HTTP 403 (Free plan locks the feature) or 404 (not configured) →
+  protection **absent** → empty `reviewDecision` is accepted and the
+  skill prints `INFO: No branch protection on <base> — accepting empty reviewDecision.`
+
+Non-empty non-APPROVED values (`CHANGES_REQUESTED`, `REVIEW_REQUIRED`)
+still hard-stop regardless of protection — someone explicitly blocked
+the PR, and protection absence does not override that signal.
+
+### When to use which skill
+
+| Situation | Skill |
+|---|---|
+| Protected base, reviewer approved | `gh:pr-merge` |
+| No branch protection (solo repo), no blocking review | `gh:pr-merge` (auto-accepts empty `reviewDecision`) |
+| Protected base, needs bypass for incident/hotfix | `gh:pr-emergency-merge` (forces audit comment + incident issue) |
+| Protected base, explicit `CHANGES_REQUESTED` | neither — address the review or use emergency-merge with a written reason |

--- a/claude/skills/gh-pr-merge/references/help.md
+++ b/claude/skills/gh-pr-merge/references/help.md
@@ -55,11 +55,11 @@ merge through `gh:pr-emergency-merge`.
 
 To avoid that, the skill detects whether the base branch has protection:
 
-- `gh api repos/<owner>/<repo>/branches/<base>/protection` returning
+- `gh api "repos/<owner>/<repo>/branches/<baseRefName>/protection"` returning
   HTTP 200 → protection **present** → strict `APPROVED` required.
 - HTTP 403 (Free plan locks the feature) or 404 (not configured) →
   protection **absent** → empty `reviewDecision` is accepted and the
-  skill prints `INFO: No branch protection on <base> — accepting empty reviewDecision.`
+  skill prints `INFO: No branch protection on <baseRefName> — accepting empty reviewDecision.`
 
 Non-empty non-APPROVED values (`CHANGES_REQUESTED`, `REVIEW_REQUIRED`)
 still hard-stop regardless of protection — someone explicitly blocked

--- a/claude/skills/gh-pr-merge/references/strategy-selection.md
+++ b/claude/skills/gh-pr-merge/references/strategy-selection.md
@@ -44,9 +44,42 @@ gh pr view <N> --repo "$TARGET_REPO" --json \
 | `state` | `!= OPEN` → "PR already <closed\|merged>" |
 | `isDraft` | `true` → "draft PR — mark ready first" |
 | `mergeable` | `CONFLICTING` → "resolve conflicts first" |
-| `reviewDecision` | `!= APPROVED` → "not approved — use /gh-pr-emergency-merge for admin bypass" |
+| `reviewDecision` | `!= APPROVED` → "not approved — use /gh-pr-emergency-merge for admin bypass". **Conditional exception**: see "Branch protection detection" below — empty `reviewDecision` is accepted when the base branch has no protection rules (solo / personal repos). |
 | `mergeStateStatus` | `BEHIND`/`BLOCKED`/`DIRTY` → "rebase or fix conflicts first" |
 | required checks | any `FAILURE` / `IN_PROGRESS` / `QUEUED` → "CI not green — fix or wait" |
+
+## Branch protection detection
+
+GitHub Free on private repos disables Branch Protection Rules, and
+GitHub forbids PR authors from self-approving. Together, that means
+solo / personal repos produce a permanently empty `reviewDecision`
+(`""`) for every PR — strict `APPROVED` enforcement would make the
+skill unusable there and force users into `gh-pr-emergency-merge`,
+which is reserved for audited admin bypass.
+
+Detect protection presence:
+
+```bash
+gh api "repos/$TARGET_REPO/branches/$BASE/protection" >/dev/null 2>&1
+# exit 0 → protection PRESENT  (strict rules apply)
+# non-zero → protection ABSENT (403 Free-plan or 404 not-configured)
+```
+
+Behavior table for the `reviewDecision` check:
+
+| Protection | `reviewDecision` | Action |
+|---|---|---|
+| present | `APPROVED` | proceed |
+| present | anything else (`""`, `REVIEW_REQUIRED`, `CHANGES_REQUESTED`) | hard stop — redirect to `gh-pr-emergency-merge` |
+| absent | `APPROVED` | proceed |
+| absent | `""` (empty) | proceed; print `INFO: No branch protection on <BASE> — accepting empty reviewDecision.` |
+| absent | `CHANGES_REQUESTED` / `REVIEW_REQUIRED` | hard stop — someone explicitly blocked this PR, protection absence does not override that |
+
+Rationale for treating 403 and 404 the same: both mean "branch
+protection is not gating this merge" from the caller's perspective.
+403 means the feature is locked by plan; 404 means it is unlocked
+but not configured. Either way, no rule would have required an
+approval. Distinguishing them in the log adds noise without value.
 
 ## Required checks
 

--- a/claude/skills/gh-pr-merge/references/strategy-selection.md
+++ b/claude/skills/gh-pr-merge/references/strategy-selection.md
@@ -72,7 +72,7 @@ Behavior table for the `reviewDecision` check:
 | present | `APPROVED` | proceed |
 | present | anything else (`""`, `REVIEW_REQUIRED`, `CHANGES_REQUESTED`) | hard stop — redirect to `gh-pr-emergency-merge` |
 | absent | `APPROVED` | proceed |
-| absent | `""` (empty) | proceed; print `INFO: No branch protection on <BASE> — accepting empty reviewDecision.` |
+| absent | `""` (empty) | proceed; print `INFO: No branch protection on <baseRefName> — accepting empty reviewDecision.` |
 | absent | `CHANGES_REQUESTED` / `REVIEW_REQUIRED` | hard stop — someone explicitly blocked this PR, protection absence does not override that |
 
 Rationale for treating 403 and 404 the same: both mean "branch


### PR DESCRIPTION
## Summary
- Solo / personal repos (GitHub Free private) leave `reviewDecision` permanently empty — self-approve is forbidden and Branch Protection is locked, so the existing strict `APPROVED` check rejected every merge and forced routine work through `gh:pr-emergency-merge`.
- `gh:pr-merge` now detects whether the base branch has protection and accepts an empty `reviewDecision` only when protection is absent. Explicit blocks (`CHANGES_REQUESTED`, `REVIEW_REQUIRED`) still hard-stop either way, and protected bases keep their strict `APPROVED` requirement.

## Changes
- `claude/skills/gh-pr-merge/SKILL.md` — add a protection-detection substep after the existing parallel pre-flight; extend the hard-stop list with the conditional exception and the informational log line.
- `claude/skills/gh-pr-merge/references/strategy-selection.md` — rewrite the `reviewDecision` row to point at the new "Branch protection detection" section, which adds a full protection × `reviewDecision` behavior matrix plus rationale for treating 403 (Free-plan lock) and 404 (not configured) identically.
- `claude/skills/gh-pr-merge/references/help.md` — add "Solo / personal repo behavior" explaining the why, plus a "When to use which skill" table differentiating `gh:pr-merge` from `gh:pr-emergency-merge` now that some empty-review cases route to the former.

## Test plan
- [ ] On a solo repo (no branch protection), `/gh-pr-merge <N>` succeeds on a PR with empty `reviewDecision`; stdout contains `INFO: No branch protection on main — accepting empty reviewDecision.`
- [ ] On a repo with protection but no approval, `/gh-pr-merge <N>` still hard-stops and points at `/gh-pr-emergency-merge`.
- [ ] On any repo, a PR with `reviewDecision == CHANGES_REQUESTED` hard-stops regardless of protection.
- [ ] `gh api repos/.../branches/main/protection` returning 403 (Free plan) is treated identically to 404 (not configured).
- [ ] `/gh-pr-merge -h` help output includes the new "Solo / personal repo behavior" section.

## Related
Closes #172

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
