### PR TITLE
feat(gwt): add --agent flag to decouple worktree name from tmux agent

### DIFF
--- a/shell-common/functions/ai_setup.sh
+++ b/shell-common/functions/ai_setup.sh
@@ -13,36 +13,56 @@ ai_setup() {
         emulate -L sh
     fi
 
-    case "${1:-}" in
-        -h|--help|help)
-            ux_header "ai-setup - workspace orchestrator"
-            ux_info "Usage: ai-setup"
-            ux_info ""
-            ux_info "Interactive setup that creates git worktrees and"
-            ux_info "tmux sessions with 3-pane windows in one step."
-            ux_info ""
-            ux_info "Steps:"
-            ux_info "  1. Enter worktree names   (free-form: issue-11 login-fix)"
-            ux_info "  2. Enter tmux windows     (AI agents: claude codex gemini)"
-            ux_info "  3. Worktrees + tmux sessions are created automatically"
-            ux_info ""
-            ux_info "Note: worktree names are free-form (task/issue/feature slugs)."
-            ux_info "      tmux windows must be AI agent names (they run <agent>-yolo)."
-            ux_info ""
-            ux_info "Requirements: git, tmux, run from main repo (not worktree)"
-            return 0
-            ;;
-        "")
-            # No arguments — proceed to interactive mode
-            ;;
-        *)
-            ux_warning "Unexpected arguments: $*"
-            ux_info "Usage: ai-setup"
-            ux_info "This command takes no arguments. It prompts interactively."
-            ux_info "Run 'ai-setup --help' for details."
-            return 1
-            ;;
-    esac
+    local default_agent=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help|help)
+                ux_header "ai-setup - workspace orchestrator"
+                ux_info "Usage: ai-setup [--agent <agent>]"
+                ux_info ""
+                ux_info "Interactive setup that creates git worktrees and"
+                ux_info "tmux sessions with 3-pane windows in one step."
+                ux_info ""
+                ux_info "Options:"
+                ux_info "  --agent <agent>   Pre-fill the 'Tmux window agents' prompt"
+                ux_info "                    default (claude, codex, gemini,"
+                ux_info "                    opencode, cursor, copilot)."
+                ux_info ""
+                ux_info "Steps:"
+                ux_info "  1. Enter worktree names   (free-form: issue-11 login-fix)"
+                ux_info "  2. Enter tmux windows     (AI agents: claude codex gemini)"
+                ux_info "  3. Worktrees + tmux sessions are created automatically"
+                ux_info ""
+                ux_info "Note: worktree names are free-form (task/issue/feature slugs)."
+                ux_info "      tmux windows must be AI agent names (they run <agent>-yolo)."
+                ux_info ""
+                ux_info "Requirements: git, tmux, run from main repo (not worktree)"
+                return 0
+                ;;
+            --agent)
+                if [ -z "${2:-}" ]; then
+                    ux_error "--agent requires an argument"
+                    return 1
+                fi
+                if ! _ts_known_agent "$2"; then
+                    ux_error "Unknown agent: $2"
+                    ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
+                    return 1
+                fi
+                default_agent="$2"
+                shift 2
+                ;;
+            "")
+                shift
+                ;;
+            *)
+                ux_warning "Unexpected argument: $1"
+                ux_info "Usage: ai-setup [--agent <agent>]"
+                ux_info "Run 'ai-setup --help' for details."
+                return 1
+                ;;
+        esac
+    done
 
     # --- Guards ---
     ux_require "git" || return 1
@@ -92,11 +112,18 @@ ai_setup() {
     wt_names="${wt_names# }"
 
     # --- Step 2: Read tmux window agents (still AI-only: they run <agent>-yolo) ---
-    local win_input=""
+    local win_input="" win_prompt_hint="e.g. claude codex"
+    if [ -n "$default_agent" ]; then
+        win_prompt_hint="Enter for default: $default_agent"
+    fi
     while [ -z "$win_input" ]; do
-        printf "%s❯%s Tmux window agents (space-separated, e.g. claude codex): " \
-            "${UX_BOLD}${UX_INFO}" "${UX_RESET}"
+        printf "%s❯%s Tmux window agents (space-separated, %s): " \
+            "${UX_BOLD}${UX_INFO}" "${UX_RESET}" "$win_prompt_hint"
         read -r win_input || return 1
+        if [ -z "$win_input" ] && [ -n "$default_agent" ]; then
+            win_input="$default_agent"
+            break
+        fi
         if [ -z "$win_input" ]; then
             ux_error "At least one window required."
         fi

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -53,11 +53,12 @@ _gwt_help_rows_prune() {
 }
 
 _gwt_help_rows_spawn() {
-    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux]" "Create named worktree"
+    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux [--agent <agent>]]" "Create named worktree"
     ux_table_row "context" "Run from main repo only" "Fails inside a worktree"
     ux_table_row "name" "Free-form slug (required)" "e.g. issue-11, login-fix"
-    ux_table_row "--tmux caveat" "Runs <name>-yolo in pane" "Only AI names (claude, ...) have yolo aliases"
-    ux_table_row "example" "gwt spawn issue-11 --task auth --base origin/main" "Name + task + base"
+    ux_table_row "--agent" "AI agent for tmux pane (default: claude)" "claude, codex, gemini, opencode, cursor, copilot"
+    ux_table_row "--tmux" "Runs <agent>-yolo in pane" "Decoupled from worktree <name>"
+    ux_table_row "example" "gwt spawn issue-11 --tmux --agent codex" "Free-form name + codex agent"
 }
 
 _gwt_help_rows_teardown() {
@@ -423,26 +424,25 @@ git_worktree_add() {
 # ============================================================================
 _git_worktree_spawn_show_help() {
     ux_header "gwt spawn - create a named worktree"
-    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux]"
+    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux [--agent <agent>]]"
     ux_info ""
     ux_info "Arguments:"
     ux_info "  <name>           Free-form worktree name (required)."
     ux_info "                   Safe chars only: no '/', no spaces, no leading dash."
-    ux_info "                   Examples: issue-11, login-fix, claude, feature-x"
+    ux_info "                   Examples: issue-11, login-fix, feature-x"
     ux_info "  --task <slug>    Add task slug to branch name"
     ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
     ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
-    ux_info ""
-    ux_warning "Caveat for --tmux:"
-    ux_info "  The pane runs '<name>-yolo'. This alias only exists for known AI"
-    ux_info "  agents (claude, codex, gemini, opencode, cursor, copilot)."
-    ux_info "  For non-AI names, skip --tmux and run 'tmux-spawn <agent>' after."
-    ux_info "  (Follow-up: decouple via --agent flag — see issue #162)"
+    ux_info "  --agent <agent>  AI agent to run in the tmux pane (default: claude)"
+    ux_info "                   Known: claude, codex, gemini, opencode, cursor, copilot"
+    ux_info "                   Window name and 'yolo' command follow --agent,"
+    ux_info "                   so worktree <name> can be any free-form slug."
     ux_info ""
     ux_info "Examples:"
-    ux_info "  gwt spawn issue-11                   # ../<proj>-issue-11-1  wt/issue-11/1"
-    ux_info "  gwt spawn login-fix --task auth      # ../<proj>-login-fix-1 wt/login-fix/1-auth"
-    ux_info "  gwt spawn claude --tmux              # AI name: tmux compatible"
+    ux_info "  gwt spawn issue-11                           # ../<proj>-issue-11-1  wt/issue-11/1"
+    ux_info "  gwt spawn login-fix --task auth              # ../<proj>-login-fix-1 wt/login-fix/1-auth"
+    ux_info "  gwt spawn issue-11 --tmux                    # tmux window 'claude' runs 'claude-yolo'"
+    ux_info "  gwt spawn issue-11 --tmux --agent codex      # tmux window 'codex'  runs 'codex-yolo'"
 }
 
 git_worktree_spawn() {
@@ -451,7 +451,7 @@ git_worktree_spawn() {
         emulate -L sh
     fi
 
-    local task="" base="" name="" use_tmux=0
+    local task="" base="" name="" use_tmux=0 agent="claude"
 
     # Parse arguments
     while [ $# -gt 0 ]; do
@@ -462,6 +462,7 @@ git_worktree_spawn() {
                 ;;
             --task) task="$2"; shift 2 ;;
             --base) base="$2"; shift 2 ;;
+            --agent) agent="$2"; shift 2 ;;
             --tmux) use_tmux=1; shift ;;
             -*)
                 ux_error "Unknown option: $1"
@@ -501,6 +502,13 @@ git_worktree_spawn() {
     # Validate --tmux dependency
     if [ "$use_tmux" = 1 ] && ! command -v tmux >/dev/null 2>&1; then
         ux_error "tmux is not installed (required for --tmux)"
+        return 1
+    fi
+
+    # Validate --agent: must be a known AI agent (only when tmux will use it)
+    if [ "$use_tmux" = 1 ] && ! _ts_known_agent "$agent"; then
+        ux_error "Unknown agent: $agent"
+        ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
         return 1
     fi
 
@@ -571,12 +579,12 @@ git_worktree_spawn() {
 
     # --- Optional tmux integration ---
     if [ "$use_tmux" = 1 ]; then
-        _tmux_add_agent_window "$project" "$name" "$wt_path"
-        ux_info "  tmux:   session '$project', window '$name'"
+        _tmux_add_agent_window "$project" "$agent" "$wt_path"
+        ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo)"
         if [ -z "$TMUX" ]; then
             tmux attach -t "$project"
         else
-            tmux switch-client -t "${project}:${name}" 2>/dev/null || true
+            tmux switch-client -t "${project}:${agent}" 2>/dev/null || true
         fi
     else
         ux_info ""

--- a/tests/bats/functions/ai_setup.bats
+++ b/tests/bats/functions/ai_setup.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# tests/bats/functions/ai_setup.bats
+# Tests for ai_setup --agent flag (issue #162).
+# ai_setup is interactive, so we only exercise the argument-parsing
+# preamble that fails fast before the first prompt.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "bash: ai_setup function exists" {
+    run_in_bash 'declare -f ai_setup >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: ai-setup --help mentions --agent flag" {
+    run_in_bash 'ai_setup --help'
+    assert_success
+    assert_output --partial "--agent"
+}
+
+@test "bash: ai_setup --agent requires an argument" {
+    run_in_bash 'ai_setup --agent 2>&1'
+    assert_failure
+    assert_output --partial "--agent requires an argument"
+}
+
+@test "bash: ai_setup --agent rejects unknown agent" {
+    run_in_bash 'ai_setup --agent bogus 2>&1'
+    assert_failure
+    assert_output --partial "Unknown agent: bogus"
+}
+
+@test "zsh: ai_setup function exists" {
+    run_in_zsh 'declare -f ai_setup >/dev/null && echo ok'
+    assert_success
+}

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_worktree_spawn.bats
+# Tests for `gwt spawn --agent` flag (issue #162).
+# Focuses on argument parsing + validation paths that do NOT require tmux
+# or a real worktree layout — the interesting behavioral change is the
+# decoupling of worktree <name> from the tmux agent name.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "bash: git_worktree_spawn function exists" {
+    run_in_bash 'declare -f git_worktree_spawn >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: spawn --help mentions --agent flag" {
+    run_in_bash 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--agent"
+    assert_output --partial "claude"
+}
+
+@test "bash: spawn --help no longer shows the <name>-yolo caveat" {
+    # The old caveat read "The pane runs '<name>-yolo'". After the agent
+    # decoupling, tmux windows run '<agent>-yolo' regardless of <name>.
+    run_in_bash 'git_worktree_spawn --help'
+    assert_success
+    refute_output --partial "<name>-yolo"
+}
+
+@test "bash: spawn rejects unknown agent when --tmux is used" {
+    # --tmux triggers the agent validation path. Use a name inside an
+    # isolated dir so we reach validation without spawning anything real.
+    # The key assertion: an unknown agent must produce a helpful error.
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --tmux --agent notarealagent 2>&1
+    "
+    assert_failure
+    assert_output --partial "Unknown agent: notarealagent"
+    assert_output --partial "claude"
+}
+
+@test "zsh: git_worktree_spawn function exists" {
+    run_in_zsh 'declare -f git_worktree_spawn >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: spawn --help mentions --agent flag" {
+    run_in_zsh 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--agent"
+}


### PR DESCRIPTION
## Summary
- `gwt spawn <name> --tmux` 는 그동안 `<name>-yolo` 를 실행해서 `issue-11` 같은 자유형 이름에서는 빈 셸이 떨어졌다.
- 워크트리 이름(자유형 슬러그)과 tmux 에이전트를 분리하는 `--agent <agent>` 플래그를 `gwt spawn` 과 `ai-setup` 에 추가한다.
- 기본값은 `claude`, 값은 `_ts_known_agent` 로 검증한다.

## Changes
- `shell-common/functions/git_worktree.sh`
  - `git_worktree_spawn` 에 `--agent <agent>` 플래그 추가 (기본 `claude`).
  - `--tmux` 시 tmux 윈도우 이름과 `yolo` 명령이 `--agent` 값을 따름 (워크트리 이름은 계속 자유형).
  - `_ts_known_agent` 로 유효성 검사 + 미지정 에이전트는 알림과 함께 실패.
  - `--help` / `gwt-help spawn` 표 갱신: 기존 "주의" 문구 제거, `--agent` 예시 추가.
- `shell-common/functions/ai_setup.sh`
  - 선택 플래그 `--agent <agent>` 신설: "Tmux window agents" 프롬프트 기본값으로 사용 (Enter 만 누르면 적용).
  - 인터랙티브 플로우와 유효성 검사(기존 `_ts_known_agent`) 는 유지.
- `tests/bats/functions/git_worktree_spawn.bats` (신규): help 문구, caveat 제거, 미지정 에이전트 실패 (bash+zsh).
- `tests/bats/functions/ai_setup.bats` (신규): `--agent` 인자 검증 (bash+zsh).

## Test plan
- [x] `tox -e shellcheck` 통과
- [x] `tox -e shfmt-check` 통과
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/` 48/48 통과 (신규 11 개 포함)
- [ ] 로컬에서 `gwt spawn issue-162 --tmux --agent claude` → tmux 윈도우명 `claude`, `claude-yolo` 실행 확인
- [ ] `gwt spawn issue-162 --tmux --agent bogus` → `Unknown agent: bogus` 에러 확인
- [ ] `ai-setup --agent codex` → tmux 윈도우 프롬프트 기본값이 `codex` 로 표시되는지 확인

## Related
Closes #162

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
