### PR TITLE
feat(claude-yolo): main-guard function replaces plain alias

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -399,4 +399,27 @@ clskip() {
 # ═══════════════════════════════════════════════════════════════
 
 alias claude-skip='claude --dangerously-skip-permissions'
-alias claude-yolo='claude --dangerously-skip-permissions'
+
+# claude_yolo: run `claude --dangerously-skip-permissions`, but auto-switch
+# off main/master to `scratch/MMDD-HHMMSS` first so YOLO sessions never
+# land commits on the protected branch. Bypass with CLAUDE_YOLO_STAY=1.
+claude_yolo() {
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        command claude --dangerously-skip-permissions "$@"
+        return
+    fi
+
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+    case "$branch" in
+        main | master)
+            if [ -z "${CLAUDE_YOLO_STAY:-}" ]; then
+                new_branch="scratch/$(date +%m%d-%H%M%S)"
+                ux_warning "main 브랜치 감지 → ${new_branch} 로 전환 (bypass: CLAUDE_YOLO_STAY=1)"
+                git switch -c "$new_branch" || return 1
+            fi
+            ;;
+    esac
+
+    command claude --dangerously-skip-permissions "$@"
+}
+alias claude-yolo='claude_yolo'

--- a/tests/bats/functions/claude_yolo.bats
+++ b/tests/bats/functions/claude_yolo.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# tests/bats/functions/claude_yolo.bats
+# Test claude_yolo function: exists, alias maps correctly, and the
+# main-branch auto-switch behavior works. Uses a PATH-prepended shim
+# so `command claude ...` hits a fake binary that records the
+# current branch instead of invoking the real claude CLI.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    _install_claude_shim
+    _setup_fake_repo_on_main
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Install a fake `claude` binary into a dir we prepend to PATH. It
+# records the branch at invocation time into $MARKER, so tests can
+# assert what branch `claude_yolo` actually handed control to.
+_install_claude_shim() {
+    export STUB_BIN="$TEST_TEMP_HOME/bin"
+    export MARKER="$TEST_TEMP_HOME/marker"
+    mkdir -p "$STUB_BIN"
+    cat > "$STUB_BIN/claude" <<'SH'
+#!/usr/bin/env bash
+git symbolic-ref --short HEAD 2>/dev/null > "$MARKER" || echo "no-branch" > "$MARKER"
+SH
+    chmod +x "$STUB_BIN/claude"
+    export PATH="$STUB_BIN:$PATH"
+}
+
+_setup_fake_repo_on_main() {
+    export REPO="$TEST_TEMP_HOME/repo"
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init -q --initial-branch=main "$REPO"
+    (
+        cd "$REPO"
+        echo seed > seed.txt
+        git add seed.txt
+        git commit -q -m seed
+    )
+}
+
+# Run claude_yolo in bash with the shim on PATH and CWD at a given path.
+_run_yolo_bash() {
+    local cwd="$1"
+    shift
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${PATH}'
+        export MARKER='${MARKER}'
+        $*
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        cd '${cwd}'
+        claude_yolo
+    "
+}
+
+# --- function and alias wiring ---
+
+@test "bash: claude_yolo function exists" {
+    run_in_bash 'declare -f claude_yolo >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: claude-yolo alias maps to claude_yolo" {
+    run_in_bash 'alias claude-yolo'
+    assert_success
+    assert_output --partial "claude_yolo"
+}
+
+@test "zsh: claude_yolo function exists" {
+    run_in_zsh 'declare -f claude_yolo >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: claude-yolo alias maps to claude_yolo" {
+    run_in_zsh 'alias claude-yolo'
+    assert_success
+    assert_output --partial "claude_yolo"
+}
+
+# --- auto-switch behavior ---
+
+@test "bash: claude_yolo on main auto-switches to scratch/* then invokes claude" {
+    _run_yolo_bash "$REPO"
+    assert_success
+    run cat "$MARKER"
+    assert_output --regexp '^scratch/[0-9]{4}-[0-9]{6}$'
+}
+
+@test "bash: claude_yolo on main with CLAUDE_YOLO_STAY=1 stays on main" {
+    _run_yolo_bash "$REPO" "export CLAUDE_YOLO_STAY=1"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo on feature branch passes through without switching" {
+    git -C "$REPO" switch -q -c feat/demo
+    _run_yolo_bash "$REPO"
+    assert_success
+    run cat "$MARKER"
+    assert_output "feat/demo"
+}
+
+@test "bash: claude_yolo outside a git repo passes through" {
+    local non_repo="$TEST_TEMP_HOME/plain"
+    mkdir -p "$non_repo"
+    _run_yolo_bash "$non_repo"
+    assert_success
+    run cat "$MARKER"
+    assert_output "no-branch"
+}


### PR DESCRIPTION
## Summary

`claude-yolo` now runs through a `claude_yolo()` POSIX function
that detects `main`/`master` and auto-switches to
`scratch/MMDD-HHMMSS` before invoking
`claude --dangerously-skip-permissions`. This prevents YOLO sessions
from landing commits directly on the protected branch.

- Bypass: set `CLAUDE_YOLO_STAY=1` to stay on the current branch
- Non-git directories and feature branches pass through unchanged
- User-facing command is preserved via `alias claude-yolo='claude_yolo'`

## Test plan

- [x] `bash -n` and `zsh -n` on `claude.sh`
- [x] shellcheck adds no new warnings (pre-existing SC3043 not from diff)
- [x] 8/8 new bats tests pass (`claude_yolo.bats`)
- [x] Full functions+tools bats suite green

## Related

Closes #156

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
