### PR TITLE
fix(skill): harden gh-issue-flow against early turn-end

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -90,10 +90,9 @@ Resume hint logic:
 - Never skip a step. All 3 or stop.
 - Never mutate state between steps beyond what the sub-skills do.
 - Do NOT preface or summarize beyond the compact report.
-- Do NOT end the turn before Step 2.3 completes. A `Next:` /
-  resume-hint from a sub-skill (notably gh:issue-implement's
-  `Next: /gh-commit && /gh-pr <N>`) is a waypoint during this
-  composition, not a final answer — keep going. Only the Step 3
-  compact report ends the turn. On sub-skill failure, use the
-  failure template; don't let a success hint from 2.1 or 2.2 stop
-  the flow.
+- Do NOT end the turn until the Step 3 report is issued (success or
+  failure template). A `Next:` / resume-hint from a sub-skill
+  (notably gh:issue-implement's `Next: /gh-commit && /gh-pr <N>`) is
+  a waypoint during this composition, not a final answer — keep
+  going. Don't let a success hint from 2.1 or 2.2 end the flow
+  before Step 3.

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -90,3 +90,10 @@ Resume hint logic:
 - Never skip a step. All 3 or stop.
 - Never mutate state between steps beyond what the sub-skills do.
 - Do NOT preface or summarize beyond the compact report.
+- Do NOT end the turn before Step 2.3 completes. A `Next:` /
+  resume-hint from a sub-skill (notably gh:issue-implement's
+  `Next: /gh-commit && /gh-pr <N>`) is a waypoint during this
+  composition, not a final answer — keep going. Only the Step 3
+  compact report ends the turn. On sub-skill failure, use the
+  failure template; don't let a success hint from 2.1 or 2.2 stop
+  the flow.


### PR DESCRIPTION
## Summary

- `claude/skills/gh-issue-flow/SKILL.md`: add a Constraint that forbids sub-skill `Next:` resume hints from ending the turn during composition.

## Why

When `/gh-issue-flow <N>` ran under `claude -p` (non-interactive), the model treated gh:issue-implement's `Next: /gh-commit && /gh-pr <N>` hint as its final answer and stopped — leaving the branch with uncommitted changes and no PR. `gh-flow` workers silently recorded `failed:implementing`.

The shell-side fix for `gh-flow` workers already shipped in `bf3e765` (worker decomposes the flow into atomic per-step sub-skill calls with post-condition checks). This PR covers the remaining case: a human invoking `/gh-issue-flow` interactively.

## Test plan

- [x] `tests/bats/functions/gh_flow.bats` 15/15 pass
- [x] `wc -l claude/skills/gh-issue-flow/SKILL.md` → 99 (under 100-line rule)
- [x] Diff isolated to Constraints bullet; no logic or step changes

Closes #191

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
