### PR TITLE
fix(gwt): surface real reason when teardown fails

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -813,35 +813,37 @@ git_worktree_teardown() {
 
     # Remove worktree. Capture stderr so the actual git reason (locked, dirty
     # submodule, untracked residuals, etc.) reaches the user instead of being
-    # swallowed — same pattern as the fetch-stderr capture above. On failure,
-    # cd back into $wt_path so the user stays in the worktree they asked to
-    # remove (we already cd'd to $main_repo above) and can investigate.
+    # swallowed — same pattern as the fetch-stderr capture above. Choose the
+    # remove command upfront from $force so a single error-handling block
+    # covers both paths. On failure, cd back into $wt_path so the user stays
+    # in the worktree they asked to remove (we already cd'd to $main_repo
+    # above) and can investigate.
     local _gwt_rm_err_file="${TMPDIR:-/tmp}/gwt-rm.$$.err"
-    if ! git worktree remove "$wt_path" 2>"$_gwt_rm_err_file"; then
+    local _gwt_rm_exit=0
+    if [ "$force" = true ]; then
+        git worktree remove --force "$wt_path" 2>"$_gwt_rm_err_file" || _gwt_rm_exit=$?
+    else
+        git worktree remove "$wt_path" 2>"$_gwt_rm_err_file" || _gwt_rm_exit=$?
+    fi
+
+    if [ "$_gwt_rm_exit" -ne 0 ]; then
         if [ "$force" = true ]; then
-            if ! git worktree remove --force "$wt_path" 2>"$_gwt_rm_err_file"; then
-                ux_error "Failed to remove worktree: $wt_path"
-                if [ -s "$_gwt_rm_err_file" ]; then
-                    ux_info "  git says:"
-                    sed 's/^/    /' "$_gwt_rm_err_file" >&2
-                fi
-                rm -f "$_gwt_rm_err_file"
-                cd "$wt_path" 2>/dev/null || true
-                return 1
-            fi
+            ux_error "Failed to remove worktree: $wt_path"
         else
             ux_error "Cannot remove worktree: $wt_path"
-            if [ -s "$_gwt_rm_err_file" ]; then
-                ux_info "  git says:"
-                sed 's/^/    /' "$_gwt_rm_err_file" >&2
-            fi
+        fi
+        if [ -s "$_gwt_rm_err_file" ]; then
+            ux_info "  git says:"
+            sed 's/^/    /' "$_gwt_rm_err_file" >&2
+        fi
+        if [ "$force" != true ]; then
             ux_info "  Inspect:  git status --short"
             ux_info "  Clean:    git clean -fd"
             ux_info "  Override: gwt teardown --force"
-            rm -f "$_gwt_rm_err_file"
-            cd "$wt_path" 2>/dev/null || true
-            return 1
         fi
+        rm -f "$_gwt_rm_err_file"
+        cd "$wt_path" 2>/dev/null || true
+        return 1
     fi
     rm -f "$_gwt_rm_err_file"
     git worktree prune

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -762,6 +762,22 @@ git_worktree_teardown() {
         fi
     fi
 
+    # Pre-flight: untracked files.
+    # `git worktree remove` (without --force) refuses when untracked files
+    # exist. Catch it here with a message the user can act on, instead of
+    # letting the later remove call fail with a stderr we'd have to surface.
+    if git status --porcelain 2>/dev/null | grep -q '^??'; then
+        if [ "$force" = true ]; then
+            ux_warning "Discarding untracked files (--force)"
+        else
+            ux_error "Untracked files present — git worktree remove will refuse."
+            ux_info "  Inspect:  git status --short"
+            ux_info "  Clean:    git clean -fd"
+            ux_info "  Override: gwt teardown --force"
+            return 1
+        fi
+    fi
+
     # Pre-flight: unpushed commits.
     # (A) Capture fetch stderr so failures surface the actual cause, not a
     # misleading "network?" blurb. Real reason (auth, hook, URL, etc.) wins.
@@ -795,15 +811,39 @@ git_worktree_teardown() {
     # Switch to main repo
     cd "$main_repo" || { ux_error "Cannot cd to $main_repo"; return 1; }
 
-    # Remove worktree
-    if ! git worktree remove "$wt_path" 2>/dev/null; then
+    # Remove worktree. Capture stderr so the actual git reason (locked, dirty
+    # submodule, untracked residuals, etc.) reaches the user instead of being
+    # swallowed — same pattern as the fetch-stderr capture above. On failure,
+    # cd back into $wt_path so the user stays in the worktree they asked to
+    # remove (we already cd'd to $main_repo above) and can investigate.
+    local _gwt_rm_err_file="${TMPDIR:-/tmp}/gwt-rm.$$.err"
+    if ! git worktree remove "$wt_path" 2>"$_gwt_rm_err_file"; then
         if [ "$force" = true ]; then
-            git worktree remove --force "$wt_path" || { ux_error "Failed to remove worktree"; return 1; }
+            if ! git worktree remove --force "$wt_path" 2>"$_gwt_rm_err_file"; then
+                ux_error "Failed to remove worktree: $wt_path"
+                if [ -s "$_gwt_rm_err_file" ]; then
+                    ux_info "  git says:"
+                    sed 's/^/    /' "$_gwt_rm_err_file" >&2
+                fi
+                rm -f "$_gwt_rm_err_file"
+                cd "$wt_path" 2>/dev/null || true
+                return 1
+            fi
         else
-            ux_error "Cannot remove worktree. Use --force to override."
+            ux_error "Cannot remove worktree: $wt_path"
+            if [ -s "$_gwt_rm_err_file" ]; then
+                ux_info "  git says:"
+                sed 's/^/    /' "$_gwt_rm_err_file" >&2
+            fi
+            ux_info "  Inspect:  git status --short"
+            ux_info "  Clean:    git clean -fd"
+            ux_info "  Override: gwt teardown --force"
+            rm -f "$_gwt_rm_err_file"
+            cd "$wt_path" 2>/dev/null || true
             return 1
         fi
     fi
+    rm -f "$_gwt_rm_err_file"
     git worktree prune
 
     # Sync main BEFORE branch delete.

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -227,3 +227,71 @@ _squash_merge_branch_into_origin_main() {
     refute_output --partial "Your branch is behind"
     refute_output --partial "use \"git pull\""
 }
+
+# ---------------------------------------------------------------------------
+# Issue #195: untracked-files pre-flight, stderr surfacing, cwd-on-failure
+# ---------------------------------------------------------------------------
+
+@test "teardown: untracked files block teardown with actionable guidance (no --force)" {
+    # Put an untracked file inside the worktree — git worktree remove would
+    # refuse with a swallowed stderr. The new pre-flight should catch it.
+    printf 'stray\n' > "$WORKTREE/.DS_Store"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_failure
+    assert_output --partial "Untracked files present"
+    # Actionable next-steps surface the three commands from the issue spec.
+    assert_output --partial "git status --short"
+    assert_output --partial "git clean -fd"
+    assert_output --partial "gwt teardown --force"
+    # Worktree and branch still exist — we refused cleanly.
+    [ -d "$WORKTREE" ]
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_success
+}
+
+@test "teardown: untracked files pass with --force and worktree is removed" {
+    printf 'stray\n' > "$WORKTREE/.DS_Store"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+    # Worktree directory is gone and branch deleted.
+    [ ! -d "$WORKTREE" ]
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_failure
+}
+
+@test "teardown: failed remove surfaces git stderr + path (not just 'use --force')" {
+    # Force the `git worktree remove` step to fail with a git-reported reason
+    # by locking the worktree. The pre-flights pass (no dirty/untracked/
+    # unpushed), so control reaches the remove call. Without the fix, stderr
+    # is swallowed and the user sees only "Cannot remove worktree...".
+    git -C "$CLONE" worktree lock --reason "held for test" "$WORKTREE"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_failure
+    # Path appears so the user knows WHICH worktree failed.
+    assert_output --partial "$WORKTREE"
+    # git's own reason is surfaced under a "git says:" header, not silenced.
+    assert_output --partial "git says:"
+    assert_output --partial "locked"
+    # Next-action hints still render.
+    assert_output --partial "Override: gwt teardown --force"
+
+    # Cleanup: unlock so teardown doesn't leave the temp tree poisoned.
+    git -C "$CLONE" worktree unlock "$WORKTREE" 2>/dev/null || true
+}
+
+@test "teardown: on failure, cwd stays in the worktree (not main repo)" {
+    # Same locked-worktree scenario as above. After teardown fails, the shell
+    # should still be inside $WORKTREE so the user can `git status` without
+    # having to cd back. Verify by echoing pwd from inside the same subshell
+    # after the failing call.
+    git -C "$CLONE" worktree lock --reason "held for test" "$WORKTREE"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>/dev/null; printf 'CWD=%s\n' \"\$(pwd)\""
+    # Function returned non-zero but we chained with ; so the subshell exits 0.
+    assert_output --partial "CWD=$WORKTREE"
+
+    git -C "$CLONE" worktree unlock "$WORKTREE" 2>/dev/null || true
+}


### PR DESCRIPTION
## Summary

- `gwt teardown` now surfaces git's real failure reason (locked, dirty submodule, etc.) instead of a blanket "Cannot remove worktree. Use --force to override."
- Adds an untracked-files pre-flight so users see actionable next steps (`git status --short`, `git clean -fd`, `gwt teardown --force`) before the remove call.
- On failure, cwd stays inside the worktree the user asked to remove so they can investigate without cd'ing back.

## Why

`shell-common/functions/git_worktree.sh` was silencing `git worktree remove` stderr with `2>/dev/null`, so users couldn't see why teardown failed and reflexively re-ran with `--force`. The same function already used a stderr-capture pattern for `git fetch` — this PR extends that pattern to `git worktree remove` and adds a pre-flight for the most common cause (untracked files).

## Changes

- `shell-common/functions/git_worktree.sh`: capture `git worktree remove` stderr to a temp file, print it under a `git says:` header on failure, and `cd` back into `$wt_path`. Same treatment for the `--force` retry. Plus a new untracked-files pre-flight with `ux_error` + `ux_info` hints.
- `tests/bats/functions/git_worktree_teardown.bats`: four new cases — blocked-by-untracked, `--force`-overrides-untracked, stderr-surfaces-on-lock, and cwd-stays-in-worktree-on-fail.

## Test plan

- [x] `bats tests/bats/functions/git_worktree_teardown.bats` — all existing + 4 new cases pass
- [ ] Manual: create a worktree, touch an untracked file, run `gwt teardown` → expect actionable error; re-run with `--force` → succeeds
- [ ] Manual: `git worktree lock` a worktree, run `gwt teardown` → expect `git says: ... is locked` surfaced in output

## Related

Closes #195

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
