### PR TITLE
docs(kanban): add Auto-archive items as #10 built-in workflow

### DIFF
--- a/docs/playbooks/kanban-board-setup.md
+++ b/docs/playbooks/kanban-board-setup.md
@@ -143,7 +143,7 @@ URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
 | 7  | `Item closed`                   | issues + pull requests     | `Done`              |
 | 8  | `Auto-close issue`              | — (구조적; 기본 유지)       | (Status 미설정)     |
 | 9  | `Auto-add sub-issues to project`| — (구조적; 기본 유지)       | (Status 미설정)     |
-| 10 | `Auto-archive items`            | Filter 매칭 카드 주기적 archive | **수동 enable** + Filter: `is:issue,pr is:closed updated:<@today-1d` |
+| 10 | `Auto-archive items`            | Filter 매칭 카드 주기적 archive | **수동 enable** + Filter: `is:issue,pr is:closed updated:<@today` |
 
 **#10 `Auto-archive items` 설정 상세**:
 
@@ -152,9 +152,9 @@ URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
   - `is:issue,pr` — Issue·PR 카드 모두 (Option B 운영 전제)
   - `is:closed` — 닫힌(=머지된) 카드만. 본 문서 라이프사이클에서
     Done 컬럼과 동치.
-  - `updated:<@today-1d` — 1일 동안 손대지 않은 것. 기간은 운영
-    취향에 따라 `-5d`, `-2w` 등으로 조정. dotfiles는 `-1d` 채택
-    (Done 컬럼을 항상 당일분으로만 유지).
+  - `updated:<@today` — 오늘 이전에 업데이트된 카드. 기간은 운영
+    취향에 따라 `<@today-1d`, `<@today-2w` 등으로 조정. dotfiles는
+    `<@today` 채택 (Done 컬럼을 항상 당일분으로만 유지).
 - archive 된 카드는 삭제가 아니라 기본 뷰에서 숨김 — 필터 바에
   `is:archived` 입력 시 재조회, 카드 우클릭 `Restore from archive`로
   복원 가능.

--- a/docs/playbooks/kanban-board-setup.md
+++ b/docs/playbooks/kanban-board-setup.md
@@ -14,11 +14,12 @@ GitHub Projects v2 기반 단일 저장소 칸반보드를 30분 안에 셋업
 - Project v2 보드 1개, 특정 repo에 연결.
 - Status 필드 6 옵션: `Backlog`, `Ready`, `In progress`, `In review`,
   `Approved`, `Done`.
-- 9개 빌트인 워크플로우 전부 `enabled` + 목적별 Status 기본값 설정.
+- 10개 빌트인 워크플로우 중 9개 기본 `enabled`, `Auto-archive items`는
+  기본 `disabled` — 본 playbook §4.5 필터 적용 후 수동 enable.
 - **Issue 4단계**: `Backlog → In progress → In review → Done`.
 - **PR 4단계**: `Backlog → In review → Approved → Done`
   (+ Changes requested 발생 시 `In progress`로 일시 루프).
-- 개인 repo 사용 시 `Approved` 컬럼은 view-level hide 권장.
+- 개인 repo 사용 시 `Approved`·`Ready` 컬럼은 view-level hide 권장.
 
 ## 2. Prerequisites
 
@@ -127,30 +128,52 @@ URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
 
 (org 소유면 `/users/`를 `/orgs/`로 교체.)
 
-신규 Project는 9개 워크플로우가 모두 `enabled` 상태로 생성된다.
-아래 Status 값만 확인·조정하면 된다.
+신규 Project는 10개 워크플로우 중 `Auto-archive items`만 `disabled`,
+나머지 9개는 `enabled` 상태로 생성된다. 아래 Status 값·필터만
+확인·조정하면 된다.
 
-| # | 워크플로우                      | When                       | Set Status         |
-|---|---------------------------------|----------------------------|--------------------|
-| 1 | `Auto-add to project`           | Filter: `is:issue,pr is:open` + repo: `<REPO>` | —        |
-| 2 | `Item added to project`         | issues + pull requests     | `Backlog`          |
-| 3 | `Pull request linked to issue`  | —                          | `In review`        |
-| 4 | `Code review approved`          | —                          | `Approved`         |
-| 5 | `Code changes requested`        | —                          | `In progress`      |
-| 6 | `Pull request merged`           | —                          | `Done`             |
-| 7 | `Item closed`                   | issues + pull requests     | `Done`             |
-| 8 | `Auto-close issue`              | — (구조적; 기본 유지)       | (Status 미설정)    |
-| 9 | `Auto-add sub-issues to project`| — (구조적; 기본 유지)       | (Status 미설정)    |
+| #  | 워크플로우                      | When                       | Set Status / Filter |
+|----|---------------------------------|----------------------------|---------------------|
+| 1  | `Auto-add to project`           | Filter: `is:issue,pr is:open` + repo: `<REPO>` | —          |
+| 2  | `Item added to project`         | issues + pull requests     | `Backlog`           |
+| 3  | `Pull request linked to issue`  | —                          | `In review`         |
+| 4  | `Code review approved`          | —                          | `Approved`          |
+| 5  | `Code changes requested`        | —                          | `In progress`       |
+| 6  | `Pull request merged`           | —                          | `Done`              |
+| 7  | `Item closed`                   | issues + pull requests     | `Done`              |
+| 8  | `Auto-close issue`              | — (구조적; 기본 유지)       | (Status 미설정)     |
+| 9  | `Auto-add sub-issues to project`| — (구조적; 기본 유지)       | (Status 미설정)     |
+| 10 | `Auto-archive items`            | Filter 매칭 카드 주기적 archive | **수동 enable** + Filter: `is:issue,pr is:closed updated:<@today-1d` |
 
-### 4.6 `Approved` 컬럼 hide (solo repo 권장)
+**#10 `Auto-archive items` 설정 상세**:
 
-개인 repo에서는 `Code review approved` 워크플로우가 거의 발화하지
-않아 `Approved`가 dead column이 된다. Board 뷰에서 컬럼 헤더 옆
-`⋯` → `Hide from view`로 숨긴다.
+- 기본 disabled — 명시적으로 enable 해야 한다.
+- Filter 문법은 Issue/PR search query 문법을 따른다:
+  - `is:issue,pr` — Issue·PR 카드 모두 (Option B 운영 전제)
+  - `is:closed` — 닫힌(=머지된) 카드만. 본 문서 라이프사이클에서
+    Done 컬럼과 동치.
+  - `updated:<@today-1d` — 1일 동안 손대지 않은 것. 기간은 운영
+    취향에 따라 `-5d`, `-2w` 등으로 조정. dotfiles는 `-1d` 채택
+    (Done 컬럼을 항상 당일분으로만 유지).
+- archive 된 카드는 삭제가 아니라 기본 뷰에서 숨김 — 필터 바에
+  `is:archived` 입력 시 재조회, 카드 우클릭 `Restore from archive`로
+  복원 가능.
+
+### 4.6 `Approved`·`Ready` 컬럼 hide (solo repo 권장)
+
+개인 repo에서는 다음 두 컬럼이 라이프사이클에서 방문되지 않아
+dead column이 된다. Board 뷰에서 컬럼 헤더 옆 `⋯` →
+`Hide from view`로 숨긴다.
+
+- **`Approved`**: `Code review approved` 워크플로우가 거의 발화하지
+  않아 PR 카드가 도달하지 않음.
+- **`Ready`**: Issue·PR 두 라이프사이클 모두 방문하지 않는 예약
+  컬럼 (미래 확장용). SSOT §컬럼별 의미 참고.
 
 - 중요: 이는 **view-level 설정**이며 Status 옵션 자체는 유지된다.
-  따라서 PR이 Approved에 들어가는 일이 생기면(예: 협업자 합류)
-  데이터는 건재하고, hide만 해제하면 즉시 가시화된다.
+  따라서 카드가 해당 컬럼에 들어가는 일이 생기면(예: 협업자 합류로
+  Approved 발화, 또는 Ready 단계 도입) 데이터는 건재하고, hide만
+  해제하면 즉시 가시화된다.
 
 ## 5. 라이프사이클 (한눈에)
 

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -129,7 +129,7 @@ GitHub Projects v2의 빌트인 워크플로우 10개 중 9개가 `enabled`
 |----|-------------------------------------|---------------------------------------------------|
 | 8  | `Auto-close issue`                  | 부모 Issue의 모든 sub-issue가 close되면 부모를 auto-close |
 | 9  | `Auto-add sub-issues to project`    | 부모 Issue가 보드에 있으면 sub-issue도 자동 추가      |
-| 10 | `Auto-archive items`                | 필터 매칭 카드를 주기적으로 archive (Done 컬럼 정리용). 기본 `disabled` — 수동 enable 필요. dotfiles 채택 필터: `is:issue,pr is:closed updated:<@today-1d` |
+| 10 | `Auto-archive items`                | 필터 매칭 카드를 주기적으로 archive (Done 컬럼 정리용). 기본 `disabled` — 수동 enable 필요. dotfiles 채택 필터: `is:issue,pr is:closed updated:<@today` |
 
 ### 수동 이동
 
@@ -197,8 +197,8 @@ gh auth refresh -s project
    - `Auto-close issue`, `Auto-add sub-issues to project`:
      Status를 건드리지 않는 구조적 워크플로우로 기본 설정 유지.
    - `Auto-archive items`: 수동 enable + 필터
-     `is:issue,pr is:closed updated:<@today-1d` 입력 — Done 컬럼을
-     1일 경과분부터 자동 archive 하여 항상 당일분만 유지한다.
+     `is:issue,pr is:closed updated:<@today` 입력 — Done 컬럼을
+     오늘 이전 분부터 자동 archive 하여 항상 당일분만 유지한다.
 
 ## 운영 상의 유의사항
 

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -106,9 +106,10 @@ Project 보드와 일관된 운영 방식 확보가 목적.
 
 ## 자동 전환 규칙
 
-GitHub Projects v2의 빌트인 워크플로우 9개가 모두 `enabled`
-상태로 운영된다 (신규 Project 기본값). 카드 타입에 따라 영향
-범위가 다르다.
+GitHub Projects v2의 빌트인 워크플로우 10개 중 9개가 `enabled`
+상태로 운영되고, `Auto-archive items`(#10)는 `disabled` 기본값에서
+명시적으로 enable 해 Done 컬럼 정리용으로 활용한다. 카드 타입에
+따라 영향 범위가 다르다.
 
 ### Status를 변경하는 워크플로우
 
@@ -124,10 +125,11 @@ GitHub Projects v2의 빌트인 워크플로우 9개가 모두 `enabled`
 
 ### Status를 변경하지 않는 구조적 워크플로우
 
-| # | 워크플로우                          | 동작                                              |
-|---|-------------------------------------|---------------------------------------------------|
-| 8 | `Auto-close issue`                  | 부모 Issue의 모든 sub-issue가 close되면 부모를 auto-close |
-| 9 | `Auto-add sub-issues to project`    | 부모 Issue가 보드에 있으면 sub-issue도 자동 추가      |
+| #  | 워크플로우                          | 동작                                              |
+|----|-------------------------------------|---------------------------------------------------|
+| 8  | `Auto-close issue`                  | 부모 Issue의 모든 sub-issue가 close되면 부모를 auto-close |
+| 9  | `Auto-add sub-issues to project`    | 부모 Issue가 보드에 있으면 sub-issue도 자동 추가      |
+| 10 | `Auto-archive items`                | 필터 매칭 카드를 주기적으로 archive (Done 컬럼 정리용). 기본 `disabled` — 수동 enable 필요. dotfiles 채택 필터: `is:issue,pr is:closed updated:<@today-1d` |
 
 ### 수동 이동
 
@@ -176,9 +178,9 @@ gh auth refresh -s project
    `Approved`, `Done`.
 
 4. 빌트인 워크플로우 설정 (Project > Workflows):
-   신규 Project는 9개 워크플로우 모두 `enabled` 상태로 생성된다.
-   아래 Status 값이 올바른지만 확인한다 (위 "자동 전환 규칙" 표와
-   동일).
+   신규 Project는 10개 워크플로우 중 9개가 `enabled`, `Auto-archive
+   items`만 `disabled` 상태로 생성된다. 아래 Status 값·필터가
+   올바른지 확인한다 (위 "자동 전환 규칙" 표와 동일).
 
    - `Auto-add to project`: repo 드롭다운에서 `dotfiles` 선택,
      필터 `is:issue,pr is:open`.
@@ -194,6 +196,9 @@ gh auth refresh -s project
      Status=`Done`.
    - `Auto-close issue`, `Auto-add sub-issues to project`:
      Status를 건드리지 않는 구조적 워크플로우로 기본 설정 유지.
+   - `Auto-archive items`: 수동 enable + 필터
+     `is:issue,pr is:closed updated:<@today-1d` 입력 — Done 컬럼을
+     1일 경과분부터 자동 archive 하여 항상 당일분만 유지한다.
 
 ## 운영 상의 유의사항
 


### PR DESCRIPTION
## Summary
- Projects v2 10번째 빌트인 워크플로우 `Auto-archive items` 를 SSOT·playbook 에 정식 문서화 (이전엔 9개만 기술해 Done 컬럼 누적을 외부 자동화 문제로 취급)
- solo repo view-level hide 권장 대상을 `Approved` → `Approved`+`Ready` 로 확장 (둘 다 dotfiles 라이프사이클에서 방문되지 않는 예약 컬럼)

## Changes
- `docs/standards/github-project-board.md` (SSOT):
  - §자동 전환 규칙 문두: "9개 모두 enabled" → "10개 중 9개 enabled, Auto-archive items 1개는 disabled 기본값"
  - 구조적 워크플로우 표에 #10 `Auto-archive items` 추가 + dotfiles 채택 필터 `is:issue,pr is:closed updated:<@today-1d` 명시
  - §보드 초기 셋업 4단계에 `Auto-archive items` 수동 enable 절차 추가
- `docs/playbooks/kanban-board-setup.md` (playbook):
  - §1 목표 결과물 요약 줄 업데이트 (10개 / 9+1 구분, `Ready` hide 포함)
  - §4.5 워크플로우 표를 10행으로 확장 + #10 상세 블록 (filter 문법, 기간 조정 가이드, archive·복원 UX) 추가
  - §4.6 제목·본문을 `Approved`+`Ready` 둘 다 커버하도록 확장

## Test plan
- [ ] GitHub 웹 뷰에서 두 문서의 10행 표가 깨짐 없이 렌더되는지 확인
- [ ] 실제 보드 https://github.com/users/dEitY719/projects/3/workflows 에서 `Auto-archive items` 가 enabled + 필터 `is:issue,pr is:closed updated:<@today-1d` 로 세팅돼 있는지 재확인 (이미 설정 완료됨)
- [ ] 1일 이상 지난 시점에 Done 카드가 실제로 archive 되어 보드에서 사라지는지 관찰

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
