### PR TITLE
feat(gh-pr-reply): add N-parallel PR review-reply runner

### DIFF
--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -1,0 +1,305 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_pr_reply.sh
+# gh-pr-reply — fire-and-forget N-parallel GitHub PR review-reply runner.
+# Sibling of gh-pr-approve (shell-common/functions/gh_pr_approve.sh) and
+# gh-flow (shell-common/functions/gh_flow.sh); single-shot pipeline per
+# PR: spawn worktree → run /gh-pr-reply → teardown.
+#
+# Key difference from gh-pr-approve: the /gh-pr-reply skill EDITS files
+# (review-fix → commit → push). If the skill fails partway, unpushed
+# local commits may remain in the worktree. To prevent data loss, this
+# runner deliberately SKIPS teardown on skill failure and leaves the
+# worktree intact for human recovery (see issue #198 Open Question —
+# Option 1 chosen).
+
+# ============================================================================
+# State helpers
+# ============================================================================
+
+_gh_pr_reply_state_root() {
+    printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/gh-pr-reply"
+}
+
+_gh_pr_reply_repo_name() {
+    basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null
+}
+
+_gh_pr_reply_pr_dir() {
+    # $1 = PR number
+    local _root _name
+    _root=$(_gh_pr_reply_state_root)
+    _name=$(_gh_pr_reply_repo_name)
+    printf '%s/%s/%s' "$_root" "$_name" "$1"
+}
+
+_gh_pr_reply_set_state() {
+    # $1 = pr-dir path, $2 = state
+    # Takes a dir (not a PR number) so callers inside a worktree are not
+    # affected by cwd — otherwise _gh_pr_reply_pr_dir recomputes via
+    # `git rev-parse --show-toplevel` and silently writes elsewhere after
+    # the worker cd's into its worktree.
+    mkdir -p "$1"
+    printf '%s\n' "$2" >"$1/state"
+}
+
+_gh_pr_reply_get_state() {
+    # $1 = PR number; prints state or "nonexistent"
+    local _dir
+    _dir=$(_gh_pr_reply_pr_dir "$1")
+    if [ -f "$_dir/state" ]; then
+        cat "$_dir/state"
+    else
+        printf 'nonexistent'
+    fi
+}
+
+# ============================================================================
+# Help
+# ============================================================================
+
+gh_pr_reply_help() {
+    ux_header "gh-pr-reply - fire-and-forget GitHub PR review-reply runner"
+    ux_info "Usage: gh-pr-reply <pr-number>... | -h|--help"
+    ux_info ""
+    ux_info "Spawns one background worker per PR. Each worker:"
+    ux_bullet "gwt spawn → claude -p '/gh-pr-reply <N>' → gwt teardown"
+    ux_info ""
+    ux_info "The /gh-pr-reply skill edits files, commits, pushes, and replies"
+    ux_info "to each review comment (Accepted or Declined). This runner only"
+    ux_info "manages the worktree lifecycle around the skill."
+    ux_info ""
+    ux_info "Examples:"
+    ux_bullet "gh-pr-reply 42                  # single PR"
+    ux_bullet "gh-pr-reply 12 34 56            # 3 PRs in parallel"
+    ux_bullet "gh-pr-reply '#42'               # '#' prefix accepted"
+    ux_info ""
+    ux_info "State directory: ~/.local/state/gh-pr-reply/<repo>/<pr>/"
+    ux_bullet_sub "state         - current step"
+    ux_bullet_sub "pid           - worker process id"
+    ux_bullet_sub "worktree.path - git worktree path"
+    ux_bullet_sub "log           - full stdout+stderr"
+    ux_bullet_sub "log.prev      - previous run's log (one generation)"
+    ux_info ""
+    ux_info "Failure isolation:"
+    ux_bullet "One worker failure does not affect others."
+    ux_bullet "On skill failure, teardown is SKIPPED and the worktree is"
+    ux_bullet_sub "preserved so unpushed commits are not lost."
+    ux_bullet_sub "state shows 'failed:<step>'; recover manually."
+    ux_info ""
+    ux_info "Preconditions:"
+    ux_bullet "Run from main repo (not inside a worktree)"
+    ux_bullet "gh CLI authenticated, claude CLI on PATH, gwt loaded"
+    ux_info ""
+    ux_info "Related:"
+    ux_bullet "gh-flow         - issue → PR automation (author side)"
+    ux_bullet "gh-pr-approve   - read-only LGTM/follow-up runner (reviewer side)"
+    ux_bullet "/gh-pr-reply    - skill invoked inside the worker"
+}
+
+# ============================================================================
+# Orchestrator
+# ============================================================================
+
+gh_pr_reply() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    case "${1:-}" in
+        ""|-h|--help|help)
+            gh_pr_reply_help
+            return 0
+            ;;
+    esac
+
+    # Preconditions
+    if ! _have git; then
+        ux_error "git not found"
+        return 1
+    fi
+    if ! _have gh; then
+        ux_error "gh CLI not found"
+        return 1
+    fi
+    if ! _have claude; then
+        ux_error "claude CLI not found"
+        return 1
+    fi
+    if ! command -v gwt >/dev/null 2>&1; then
+        ux_error "gwt function not loaded (source shell-common first)"
+        return 1
+    fi
+
+    # Must be in main repo (not a worktree)
+    local _git_dir _git_common
+    _git_dir="$(git rev-parse --git-dir 2>/dev/null)"
+    _git_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+    if [ -z "$_git_dir" ]; then
+        ux_error "not inside a git repo"
+        return 1
+    fi
+    if [ "$_git_dir" != "$_git_common" ]; then
+        ux_error "gh-pr-reply must run from the main repo, not a worktree"
+        ux_info "cd to the main repo and retry"
+        return 1
+    fi
+
+    # Validate each arg is a positive integer. Strip an optional leading '#'
+    # so `gh-pr-reply '#42'` works the same as `gh-pr-reply 42` — same
+    # ergonomic deviation gh-pr-approve makes, since PR numbers are
+    # almost always written as #N in conversation.
+    local _pr _pr_clean _pr_args=""
+    for _pr in "$@"; do
+        _pr_clean="${_pr#\#}"
+        case "$_pr_clean" in
+            ''|*[!0-9]*)
+                ux_error "invalid PR number: '$_pr' (must be positive integer, '#' prefix allowed)"
+                return 1
+                ;;
+        esac
+        _pr_args="$_pr_args $_pr_clean"
+    done
+
+    ux_header "gh-pr-reply: spawning $# worker(s)"
+    for _pr in $_pr_args; do
+        _gh_pr_reply_spawn_worker "$_pr"
+    done
+    ux_success "All workers detached. Your shell is free. Results appear on the PR."
+}
+
+_gh_pr_reply_spawn_worker() {
+    local _pr="$1"
+    local _dir _log _state _pid
+    _dir=$(_gh_pr_reply_pr_dir "$_pr")
+    mkdir -p "$_dir"
+    _log="$_dir/log"
+
+    # Idempotency check — mirrors gh-pr-approve / gh-flow semantics.
+    _state=$(_gh_pr_reply_get_state "$_pr")
+    case "$_state" in
+        done)
+            ux_info "#$_pr already done, skipping"
+            return 0
+            ;;
+        spawning|replying|tearing-down)
+            if [ -f "$_dir/pid" ]; then
+                _pid="$(cat "$_dir/pid")"
+                if kill -0 "$_pid" 2>/dev/null; then
+                    ux_warning "#$_pr already running (pid=$_pid), skipping"
+                    return 0
+                fi
+            fi
+            ux_info "#$_pr was in-progress but pid is dead — resuming with a new worker"
+            ;;
+        failed:*)
+            # Don't auto-resume a failed run — the worktree may contain
+            # unpushed commits. The user must inspect and clear state
+            # explicitly. Mirrors how gh-flow's pr-reply step behaves.
+            ux_warning "#$_pr previous run failed (state=$_state); inspect $_dir and worktree before retrying"
+            ux_info "to retry: rm -rf $_dir   (after recovering any local commits)"
+            return 0
+            ;;
+    esac
+
+    # Rotate previous log (keep one .prev for debugging)
+    if [ -f "$_log" ]; then
+        mv "$_log" "$_log.prev" 2>/dev/null || true
+    fi
+
+    # Fork detached worker. DOTFILES_FORCE_INIT=1 forces full shell-common
+    # loading in the non-interactive subshell so `gwt`, `ux_*`, and helpers
+    # resolve. The subshell sources ~/.bashrc then calls _gh_pr_reply_worker.
+    # shellcheck disable=SC2016
+    nohup env DOTFILES_FORCE_INIT=1 bash -c '
+        . "$HOME/.bashrc" 2>/dev/null || true
+        _gh_pr_reply_worker "$1"
+    ' -- "$_pr" >"$_log" 2>&1 &
+    _pid=$!
+    disown "$_pid" 2>/dev/null || true
+    printf '%s\n' "$_pid" >"$_dir/pid"
+    ux_info "#$_pr → pid=$_pid  log=$_log"
+}
+
+# ============================================================================
+# Worker (runs in a detached bash subshell)
+# ============================================================================
+
+_gh_pr_reply_worker() {
+    local _pr="$1"
+    local _dir _worktree _spawn_name
+    _dir=$(_gh_pr_reply_pr_dir "$_pr")
+    _spawn_name="pr-$_pr"
+
+    printf '[gh-pr-reply-worker] pr=#%s start=%s\n' "$_pr" "$(date -Iseconds 2>/dev/null || date)"
+
+    # ---- Step 1: spawn worktree ----
+    # Snapshot the worktree list before and after `gwt spawn` and diff them
+    # to identify the new one. Same pattern as gh-flow / gh-pr-approve —
+    # avoids coupling to gwt's internal branch-naming convention.
+    local _wt_before _wt_after
+    _gh_pr_reply_set_state "$_dir" "spawning"
+    _wt_before=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
+    if ! gwt spawn "$_spawn_name"; then
+        _gh_pr_reply_set_state "$_dir" "failed:spawning"
+        printf '[gh-pr-reply-worker] gwt spawn failed\n' >&2
+        return 1
+    fi
+
+    _wt_after=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
+    _worktree=$(comm -13 \
+        <(printf '%s\n' "$_wt_before" | sort) \
+        <(printf '%s\n' "$_wt_after" | sort) \
+        | head -n 1)
+
+    if [ -z "$_worktree" ] || [ ! -d "$_worktree" ]; then
+        _gh_pr_reply_set_state "$_dir" "failed:spawning"
+        printf '[gh-pr-reply-worker] could not locate newly-created worktree\n' >&2
+        return 1
+    fi
+    printf '%s\n' "$_worktree" >"$_dir/worktree.path"
+    printf '[gh-pr-reply-worker] worktree=%s\n' "$_worktree"
+
+    # shellcheck disable=SC2164
+    cd "$_worktree" || {
+        _gh_pr_reply_set_state "$_dir" "failed:spawning"
+        return 1
+    }
+
+    # ---- Step 2: reply (claude runs /gh-pr-reply <N>) ----
+    # The skill is responsible for: review-comment fetch → evaluate → fix
+    # files → commit → push → reply on each comment. The skill's exit
+    # code is the source of truth for success/failure.
+    #
+    # CRITICAL: on failure we DO NOT teardown. The worktree may contain
+    # local commits that were never pushed (e.g. push step failed mid-skill);
+    # tearing down would permanently delete them. State is left as
+    # 'failed:replying' for human recovery (#198 Open Question — Option 1).
+    _gh_pr_reply_set_state "$_dir" "replying"
+    if ! claude --dangerously-skip-permissions -p "/gh-pr-reply $_pr"; then
+        _gh_pr_reply_set_state "$_dir" "failed:replying"
+        printf '[gh-pr-reply-worker] /gh-pr-reply failed — worktree preserved at %s for recovery\n' "$_worktree" >&2
+        return 1
+    fi
+
+    # ---- Step 3: teardown (must run inside the worktree) ----
+    # The skill has already pushed any commits it created, so the
+    # worktree is safe to remove. Only reached on a clean skill exit.
+    _gh_pr_reply_set_state "$_dir" "tearing-down"
+    if ! gwt teardown --force; then
+        _gh_pr_reply_set_state "$_dir" "failed:tearing-down"
+        printf '[gh-pr-reply-worker] gwt teardown failed\n' >&2
+        return 1
+    fi
+
+    _gh_pr_reply_set_state "$_dir" "done"
+    printf '[gh-pr-reply-worker] done pr=#%s end=%s\n' "$_pr" "$(date -Iseconds 2>/dev/null || date)"
+}
+
+# ============================================================================
+# Aliases (hyphenated command names per shell-common convention)
+# ============================================================================
+
+alias gh-pr-reply='gh_pr_reply'
+alias gh-pr-reply-help='gh_pr_reply_help'

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -22,7 +22,9 @@ _gh_pr_reply_state_root() {
 }
 
 _gh_pr_reply_repo_name() {
-    basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null
+    local _top
+    _top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+    basename "$_top"
 }
 
 _gh_pr_reply_pr_dir() {

--- a/tests/bats/functions/gh_pr_reply.bats
+++ b/tests/bats/functions/gh_pr_reply.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_pr_reply.bats
+# Smoke tests for the gh-pr-reply orchestrator. These cover the
+# pre-spawn surface (loading, help, arg validation, idempotency) — the
+# detached-worker pipeline is not exercised here because it would
+# require mocking gwt, gh, and claude inside a subshell. That's
+# consistent with how gh-flow and gh-pr-approve are tested today.
+
+load '../test_helper'
+
+# Spin up a throwaway main repo so arg-validation tests don't trip the
+# "must run from main repo" precondition check — the bats host repo is
+# itself a worktree, which would short-circuit the validator.
+_setup_fake_main_repo() {
+    FAKE_REPO="$TEST_TEMP_HOME/fake-main"
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+    git init -q --initial-branch=main "$FAKE_REPO"
+    (
+        cd "$FAKE_REPO"
+        echo base >base.txt
+        git add base.txt
+        git commit -q -m base
+    )
+}
+
+setup() {
+    setup_isolated_home
+    _setup_fake_main_repo
+}
+
+teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+@test "bash: gh_pr_reply function exists" {
+    run_in_bash 'declare -f gh_pr_reply >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: gh-pr-reply alias resolves to gh_pr_reply" {
+    run_in_bash "alias gh-pr-reply 2>/dev/null | grep -q gh_pr_reply && echo ok"
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: gh_pr_reply function exists" {
+    run_in_zsh 'typeset -f gh_pr_reply >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Help surface (bypasses all preconditions)
+# ---------------------------------------------------------------------------
+
+@test "bash: gh-pr-reply with no args prints help" {
+    run_in_bash 'gh_pr_reply'
+    assert_success
+    assert_output --partial "gh-pr-reply"
+    assert_output --partial "pr-number"
+}
+
+@test "bash: gh-pr-reply --help prints help" {
+    run_in_bash 'gh_pr_reply --help'
+    assert_success
+    assert_output --partial "Usage:"
+    assert_output --partial "gh-pr-reply"
+}
+
+@test "bash: gh-pr-reply -h prints help" {
+    run_in_bash 'gh_pr_reply -h'
+    assert_success
+}
+
+@test "bash: help documents parallel usage and state dir" {
+    # The help must describe the two things that distinguish this from
+    # running /gh-pr-reply manually: parallelism and the state dir.
+    # If either is missing, users lose the discoverability the feature
+    # was designed around.
+    run_in_bash 'gh_pr_reply --help 2>&1'
+    assert_success
+    assert_output --partial "parallel"
+    assert_output --partial "state"
+}
+
+@test "bash: help documents teardown-skip on failure" {
+    # The defining behavior vs gh-pr-approve: the skill edits files +
+    # commits + pushes, and on failure the worktree is preserved so
+    # local commits aren't lost. If this guarantee disappears from
+    # help, users may delete worktrees thinking they're empty.
+    run_in_bash 'gh_pr_reply --help 2>&1'
+    assert_success
+    assert_output --partial "preserved"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation — must fail before any spawn attempt
+# ---------------------------------------------------------------------------
+
+@test "bash: non-integer PR number is rejected" {
+    # 'abc' is obviously not a PR number. The function must reject it
+    # rather than hand it to gwt and produce a confusing failure later.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply abc 2>&1"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+@test "bash: mixed valid + invalid args reject the batch" {
+    # Fail-fast: one bad arg in the list aborts the whole batch. This
+    # matches gh-flow / gh-pr-approve behavior and prevents half-spawned
+    # state.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 notanumber 2>&1"
+    assert_failure
+    assert_output --partial "invalid"
+}
+
+@test "bash: '#' prefix on PR number is accepted (ergonomic)" {
+    # Same ergonomic deviation as gh-pr-approve. PR numbers are written
+    # as #N in conversation, so both forms work. We can't run the worker
+    # in tests, but we can at least prove the validator accepts '#42' —
+    # the error, if any, must come later than the 'invalid PR number'
+    # check.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply '#42' 2>&1 || true"
+    refute_output --partial "invalid PR number"
+}
+
+@test "bash: rejects run from inside a worktree" {
+    # The orchestrator must refuse to spawn from a worktree — workers
+    # would otherwise create worktrees-of-worktrees, which gwt doesn't
+    # support. Same guard as gh-flow / gh-pr-approve.
+    (
+        cd "$FAKE_REPO"
+        git worktree add -q -b test-wt "$TEST_TEMP_HOME/fake-wt" 2>/dev/null
+    )
+    run_in_bash "cd '$TEST_TEMP_HOME/fake-wt' && gh_pr_reply 42 2>&1"
+    assert_failure
+    assert_output --partial "main repo"
+}
+
+# ---------------------------------------------------------------------------
+# Idempotency — failed runs must not be auto-resumed
+# ---------------------------------------------------------------------------
+
+@test "bash: refuses to auto-resume a previously failed run" {
+    # Distinguishing behavior of gh-pr-reply vs gh-pr-approve. Because
+    # the skill commits and pushes, a failed worker may leave unpushed
+    # local commits in the worktree. Re-spawning would re-run gwt spawn,
+    # which is a no-op (worktree already exists) but would also re-run
+    # the skill — fine in itself, but if the user hasn't yet recovered
+    # the prior commits, automation noise drowns the warning. So instead
+    # we refuse and tell the user to inspect + clear state explicitly.
+    # XDG_STATE_HOME is not exported to run_in_bash subprocesses, so the
+    # function falls back to $HOME/.local/state. setup_isolated_home set
+    # HOME to TEST_TEMP_HOME, and FAKE_REPO basename is 'fake-main'.
+    local _state_dir="$HOME/.local/state/gh-pr-reply/fake-main/42"
+    mkdir -p "$_state_dir"
+    printf 'failed:replying\n' >"$_state_dir/state"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 2>&1"
+    assert_success
+    assert_output --partial "previous run failed"
+    assert_output --partial "rm -rf"
+}


### PR DESCRIPTION
## Summary
- Add `gh-pr-reply` shell command — N-parallel runner for the existing `/gh-pr-reply` skill, sibling to `gh-flow` and `gh-pr-approve`.
- One detached worker per PR: `gwt spawn` -> `claude -p '/gh-pr-reply <N>'` -> `gwt teardown`. Workers run in parallel and are isolated from each other.
- Critical safety deviation from `gh-pr-approve`: because the skill commits and pushes, this runner **skips teardown on skill failure** to preserve unpushed local commits.

## Changes
- `shell-common/functions/gh_pr_reply.sh` — orchestrator + worker + helpers + aliases (`gh-pr-reply`, `gh-pr-reply-help`). Mirrors `gh_pr_approve.sh` structure with three deviations:
  - State machine uses `replying` instead of `approving`.
  - On `/gh-pr-reply` skill failure, teardown is skipped and `state=failed:replying` is recorded with the worktree intact (issue #198 Open Question — Option 1).
  - Idempotency check refuses to auto-resume a `failed:*` run; user must inspect the worktree, recover any local commits, then `rm -rf` the state dir to retry. This is the consequence of Option 1 — silently re-spawning could destroy unrecovered work.
- `tests/bats/functions/gh_pr_reply.bats` — 13 smoke tests covering loading (bash + zsh), help surface (parallel + state dir + teardown-skip guarantee), arg validation, `'#42'` ergonomic prefix, `must run from main repo` guard, and the new `failed:*` no-auto-resume idempotency.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_reply.bats` → 13/13 pass
- [x] Sibling regressions: `bats tests/bats/functions/{gh_pr_approve,gh_flow}.bats` → 31/31 still pass
- [x] Full function suite: `bats tests/bats/functions/` → 89/89 pass
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_pr_reply.sh` clean
- [x] `bash -n` and `zsh -n` parse OK
- [x] Auto-source verified in both shells (function, worker helpers, both aliases)
- [ ] Manual: run `gh-pr-reply <N>` against a real PR with review comments and confirm worker completes through `state=done`
- [ ] Manual: simulate skill failure mid-run and confirm worktree is preserved + `state=failed:replying`

## Related
Closes #198

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
