### PR TITLE
docs(claude): warn that Agent isolation breaks on git-crypt repos

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -151,8 +151,8 @@ Use one of:
 - **Sequential dispatch** — call `Agent` without `isolation` and let tasks
   run in the main workspace serially.
 - **Manual worktree first** — invoke the `ai-worktree:spawn` skill (or run
-  `gwt`); it passes `-c filter.git-crypt.smudge=cat` so worktree creation
-  succeeds. Then dispatch non-isolated agents into that path.
+  `gwt`), which handles the git-crypt filter bypass automatically. Then
+  dispatch non-isolated agents into that path.
 
 See `docs/learnings/git-crypt-worktree-bootstrap.md` for the failing log,
 the `--no-checkout` + manual unlock fallback, and tracking issue

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -137,6 +137,27 @@ Use the Agent tool to launch all agents concurrently in a single message.
 
 Both depend on Step 1 (load prompt) but not on each other → parallel.
 
+## Known Pitfall: Agent isolation + git-crypt
+
+Claude Code's built-in `Agent({ isolation: "worktree" })` (used by `/batch` and
+similar) calls `git worktree add` without any git-crypt filter bypass. This
+dotfiles repo sets `filter.git-crypt.required=true` and maps `.env` plus
+`.secrets/**` through git-crypt in `.gitattributes`, so harness-spawned
+worktrees abort with `fatal: .env: smudge filter git-crypt failed`.
+
+**In this repo, do NOT pass `isolation: "worktree"` to the `Agent` tool.**
+Use one of:
+
+- **Sequential dispatch** — call `Agent` without `isolation` and let tasks
+  run in the main workspace serially.
+- **Manual worktree first** — invoke the `ai-worktree:spawn` skill (or run
+  `gwt`); it passes `-c filter.git-crypt.smudge=cat` so worktree creation
+  succeeds. Then dispatch non-isolated agents into that path.
+
+See `docs/learnings/git-crypt-worktree-bootstrap.md` for the failing log,
+the `--no-checkout` + manual unlock fallback, and tracking issue
+[#153](https://github.com/dEitY719/dotfiles/issues/153).
+
 # Testing Strategy
 
 ## Manual Verification

--- a/claude/built-in-skills/batch/README.md
+++ b/claude/built-in-skills/batch/README.md
@@ -16,7 +16,7 @@ git-crypt 필터 우회 플래그를 주지 않으므로 모든 워커가
 
 - **Sequential 인라인 실행** — 메인 워크스페이스에서 작업을 순차 진행 (단위 수가 적을 때)
 - **수동 worktree 부트스트랩** — `gwt` 또는 `ai-worktree:spawn` 스킬로 worktree를 먼저
-  만들고(이쪽은 `-c filter.git-crypt.smudge=cat`을 명시적으로 전달함), 그 안에서
+  만들고(git-crypt 필터 우회를 자동 처리), 그 안에서
   isolation 없는 `Agent`를 디스패치
 - 추적 이슈: [#153](https://github.com/dEitY719/dotfiles/issues/153)
 - 상세: `docs/learnings/git-crypt-worktree-bootstrap.md`

--- a/claude/built-in-skills/batch/README.md
+++ b/claude/built-in-skills/batch/README.md
@@ -4,6 +4,23 @@
 
 대규모 기계적 변경(마이그레이션, 리팩터링, 일괄 rename 등)을 5~30개의 독립된 worktree agent로 분해하여 병렬 실행하고, 각각 PR 생성을 시도한다.
 
+## 주의: 이 dotfiles repo에서는 동작하지 않음
+
+이 repo는 `.gitattributes`에서 `.env` / `.secrets/**`를 git-crypt 필터에 매핑하고
+로컬 git config에 `filter.git-crypt.required=true`를 두고 있다. `/batch`는 각 워커를
+`Agent({ isolation: "worktree" })`로 띄우는데, harness가 `git worktree add`를 호출할 때
+git-crypt 필터 우회 플래그를 주지 않으므로 모든 워커가
+`fatal: .env: smudge filter git-crypt failed`로 종료된다.
+
+**대안**:
+
+- **Sequential 인라인 실행** — 메인 워크스페이스에서 작업을 순차 진행 (단위 수가 적을 때)
+- **수동 worktree 부트스트랩** — `gwt` 또는 `ai-worktree:spawn` 스킬로 worktree를 먼저
+  만들고(이쪽은 `-c filter.git-crypt.smudge=cat`을 명시적으로 전달함), 그 안에서
+  isolation 없는 `Agent`를 디스패치
+- 추적 이슈: [#153](https://github.com/dEitY719/dotfiles/issues/153)
+- 상세: `docs/learnings/git-crypt-worktree-bootstrap.md`
+
 ## 동작 요약
 
 | Phase | 이름 | 모드 | 핵심 동작 |


### PR DESCRIPTION
## Summary
- Document a hard incompatibility between Claude Code's `Agent({ isolation: "worktree" })` mechanism and git-crypt-protected repos like this one.
- Steer contributors toward sequential dispatch or manual `gwt` / `ai-worktree:spawn` bootstrapping, both of which pass the `-c filter.git-crypt.smudge=cat` workaround.

## Changes
- `claude/AGENTS.md`: add a "Known Pitfall: Agent isolation + git-crypt" section explaining why harness-spawned worktrees abort with `fatal: .env: smudge filter git-crypt failed`, and link to `docs/learnings/git-crypt-worktree-bootstrap.md` and tracking issue #153.
- `claude/built-in-skills/batch/README.md`: prepend a "이 dotfiles repo에서는 동작하지 않음" callout so anyone tempted to run `/batch` here sees the failure mode and approved alternatives upfront.

## Test plan
- [x] `git diff main...HEAD` reviewed — only the two doc files changed, no behavioral code touched.
- [ ] Skim `claude/AGENTS.md` rendered on GitHub to confirm the new section nests cleanly under the parallel-dispatch guidance.
- [ ] Skim `claude/built-in-skills/batch/README.md` to confirm the callout sits above the existing "동작 요약" table.

## Related
Refs #153

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
