### PR TITLE
feat(skills): sync project-board Status from /gh-pr and /gh-commit

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -77,7 +77,28 @@ their own manual edits), derive intent from the diff itself:
   fix the underlying issue, re-stage, and create a **new** commit.
 - See `references/commit-message-format.md` for the exact HEREDOC command.
 
-## Step 5: Verify
+## Step 5: Sync Project Board Status
+
+If the commit message contains `Closes|Fixes|Refs #N` (i.e. the issue
+number resolved in Step 2 was actually written into the footer), push
+the linked Issue's project-board card to `In progress` — but only when
+its current Status is `Backlog`. The `--only-from Backlog` guard is
+mandatory: `/gh-commit` is invoked many times per branch (initial
+commit + follow-up fix commits), and after a PR opens the issue moves
+to `In review`; without the guard a follow-up fix commit would bounce
+it back to `In progress`.
+
+Skip this step entirely when no issue footer was written.
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+_gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog
+```
+
+If the repo has no projectV2 board (auto-detected) the helper silently
+returns 0. Opt out with `GH_PROJECT_STATUS_SYNC=0`.
+
+## Step 6: Verify
 
 After commit succeeds, run `git status` and report:
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -78,7 +78,25 @@ and PR scope (e.g. `skill` for `claude/skills/` changes). Apply only
 labels that exist in the repo (`gh label list`) — never create new ones.
 See `references/pr-body-template.md` for the full mapping + safe-apply loop.
 
-## Step 7: Report
+## Step 7: Sync Project Board Status
+
+After the PR is created, push its project-board card to `In review` so
+reviewers see it on the kanban without manual drag. Source the shared
+helper (it lives in `shell-common/functions/gh_project_status.sh`) and
+call it with the new PR number — no guard option, because the PR
+lifecycle is linear and `In review` is the canonical resting state from
+PR open through approval:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+_gh_project_status_sync pr <PR_NUMBER> "In review"
+```
+
+If the repo has no projectV2 board attached (auto-detected — the helper
+finds zero project items and silently returns 0), nothing happens. Opt
+out per-invocation with `GH_PROJECT_STATUS_SYNC=0`.
+
+## Step 8: Report
 
 Output **only** the PR URL:
 

--- a/docs/playbooks/kanban-board-setup.md
+++ b/docs/playbooks/kanban-board-setup.md
@@ -156,20 +156,32 @@ URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
 
 ```
 Issue:
-    Backlog ─[수동]──▶ In progress ─[PR open via Closes #N]──▶ In review ─[PR merge]──▶ Done
+    Backlog ─[/gh-commit]──▶ In progress ─[PR open via Closes #N]──▶ In review ─[PR merge]──▶ Done
 
 PR:
-    Backlog ─[수동]──▶ In review ─[Approve]──▶ Approved ─[merge]──▶ Done
-                           ▲                        │
-                           └─ [수동 재리뷰] ── In progress ◀─ [Changes requested]
+    Backlog ─[/gh-pr]──▶ In review ─[Approve]──▶ Approved ─[merge]──▶ Done
+                            ▲                        │
+                            └─ [수동 재리뷰] ── In progress ◀─ [Changes requested]
 ```
+
+`/gh-flow`, `/gh-pr`, `/gh-commit` 가 호출되면 위 두 진입 전환은
+자동으로 발생한다 (보드가 없는 repo 에서는 헬퍼가 자동으로 no-op).
+raw `git commit` / `gh pr create` 를 직접 사용하는 경로에서만 수동
+이동이 필요하다.
 
 ## 6. 자동 vs 수동
 
-- **Issue `Backlog → In progress`**: 수동 (브랜치 생성 시점).
-- **PR `Backlog → In review`**: 수동 (리뷰 기대 시점).
-- **PR `In progress → In review`**: 수동 (Changes requested 루프 탈출 시).
-- 그 외 모든 전환: 자동.
+- **Issue `Backlog → In progress`**: `/gh-flow`·`/gh-commit` 자동 /
+  raw `git commit` 사용 시 수동. `/gh-commit` 은 `--only-from Backlog`
+  가드를 사용하므로 PR 오픈 후 follow-up 커밋은 역행시키지 않는다.
+- **PR `Backlog → In review`**: `/gh-flow`·`/gh-pr` 자동 /
+  raw `gh pr create` 사용 시 수동.
+- **PR `In progress → In review`**: 수동 (Changes requested 루프
+  탈출 시 — 자동화 미지원).
+- **보드 미연결 repo**: 헬퍼 (`_gh_project_status_sync`) 가
+  `projectItems` 가 0건이면 조용히 return 0 — 즉 `dotfiles` 외 다른
+  프로젝트에서 `/gh-pr`·`/gh-commit` 을 써도 부작용이 없다.
+- 그 외 모든 전환: 자동 (GitHub Projects v2 빌트인 워크플로우).
 
 ## 7. 검증 (smoke test)
 
@@ -202,5 +214,8 @@ gh issue create --repo "$OWNER/$REPO" --title "[Test] kanban smoke" --body "igno
 - 본 playbook 출처 SSOT: [docs/standards/github-project-board.md](../standards/github-project-board.md)
 - GitHub Projects v2 빌트인 automations:
   <https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-built-in-automations>
-- 관련 skills (본 repo): `gh-issue-create`, `gh-pr`, `gh-pr-merge`,
-  `gh-pr-reply`, `gh-issue-flow`.
+- 관련 skills (본 repo): `gh-issue-create`, `gh-commit`, `gh-pr`,
+  `gh-pr-merge`, `gh-pr-reply`, `gh-issue-flow`.
+- 관련 헬퍼: `shell-common/functions/gh_project_status.sh`
+  (공용 `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`,
+  `/gh-commit` 이 모두 호출).

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -129,17 +129,29 @@ GitHub Projects v2의 빌트인 워크플로우 9개가 모두 `enabled`
 | 8 | `Auto-close issue`                  | 부모 Issue의 모든 sub-issue가 close되면 부모를 auto-close |
 | 9 | `Auto-add sub-issues to project`    | 부모 Issue가 보드에 있으면 sub-issue도 자동 추가      |
 
-### 수동 이동
+### 자동 전환 규칙 (스킬 경유)
 
-- **Issue 카드 `Backlog → In progress`**: 작업자가 브랜치 생성·
-  작업 시작 시점에 직접 옮긴다. Issue 카드의 유일한 수동 단계다.
-- **PR 카드 `Backlog → In review`**: Projects v2 빌트인에 "PR
-  open → In review" 전환을 담당하는 워크플로우가 **존재하지 않는다**.
-  PR을 열어 리뷰를 기대하는 시점에 작업자가 직접 옮긴다.
+GitHub 빌트인이 커버하지 않는 두 진입 전환은 dotfiles 의 스킬이
+공용 헬퍼 `_gh_project_status_sync`
+(`shell-common/functions/gh_project_status.sh`) 를 통해 자동화한다.
+보드가 없는 repo (예: `dotfiles` 이외의 사이드 프로젝트) 에선 헬퍼가
+`projectItems` 0건을 감지하고 조용히 no-op 하므로 추가 분기가 필요
+없다.
+
+- **Issue 카드 `Backlog → In progress`**: `/gh-flow` 워커 또는
+  `/gh-commit` 단독 실행이 커밋 메시지에서 `Closes|Fixes|Refs #N` 을
+  찾으면 자동 전환한다. 단, `--only-from Backlog` 가드가 적용되어
+  같은 이슈에 대해 follow-up 커밋이 들어와도 `In review` 상태를
+  되돌리지 않는다. raw `git commit` 으로 진행하는 경로에선 작업자가
+  수동으로 옮긴다.
+- **PR 카드 `Backlog → In review`**: `/gh-flow` 워커 또는 `/gh-pr`
+  단독 실행이 PR 생성 직후 자동 전환한다. raw `gh pr create` 로
+  PR 을 만든 경우엔 수동 이동이 필요하다.
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:
   `Changes requested` 루프에서 수정·재푸시 후 리뷰가 다시 달리기를
-  기대할 때 수동으로 복귀시킨다. 이 외의 PR 전환(`→ Approved`,
-  `→ Done`)은 모두 자동이다.
+  기대할 때 **수동**으로 복귀시킨다. Projects v2 빌트인에도 dotfiles
+  스킬에도 이 전환을 자동화하는 경로가 없다. 이 외의 PR 전환(`→
+  Approved`, `→ Done`)은 모두 빌트인 워크플로우로 자동 처리된다.
 
 ### 용어 교정 (2026-04-24)
 
@@ -202,13 +214,19 @@ gh auth refresh -s project
   merged`로 Done 이동). PR 템플릿과 `gh:pr` 스킬이 이를 방지하지만,
   사람이 수동으로 본문을 지울 경우를 대비해 머지 전에 한 번 더
   확인한다.
-- Issue 카드의 `Backlog → In progress` 는 유일한 **수동 이동**
-  지점이다 (브랜치 생성·작업 시작 시점). 이후 전환(`→ In review`
-  `→ Done`)은 모두 자동이다.
-- PR 카드도 두 지점에 수동 이동이 필요하다: `Backlog → In review`
-  (PR 오픈 후 리뷰 대기 상태로 알릴 때), `In progress → In review`
-  (`Changes requested` 루프에서 재리뷰 요청 시). 그 외 PR 전환은
-  모두 자동이다.
+- Issue 카드의 `Backlog → In progress` 는 dotfiles 스킬
+  (`/gh-flow`, `/gh-commit`) 사용 시 자동, raw `git commit` 사용
+  시에만 수동이다. `/gh-commit` 은 `--only-from Backlog` 가드를
+  사용하므로 PR 오픈 후 follow-up 커밋이 들어와도 `In review` 상태를
+  되돌리지 않는다.
+- PR 카드 `Backlog → In review` 는 dotfiles 스킬 (`/gh-flow`,
+  `/gh-pr`) 사용 시 자동, raw `gh pr create` 사용 시에만 수동이다.
+  `In progress → In review` (`Changes requested` 루프 탈출 시)
+  전환만 항상 수동이다 — 빌트인·스킬 모두 이 경로를 자동화하지
+  않는다.
+- 보드가 없는 repo 에서 `/gh-pr` 또는 `/gh-commit` 을 실행하면
+  공용 헬퍼 `_gh_project_status_sync` 가 `projectItems` 가 0건임을
+  자동 감지하고 조용히 no-op 한다 (별도 분기 불필요).
 - 수동으로 카드를 옮긴 경우 다음 자동 이벤트가 상태를 덮어쓸
   수 있다. 특히 Issue 카드를 `Approved`로 옮겨도 `Item closed`가
   PR 머지 시점에 곧바로 `Done`으로 이동시키므로 의미가 없다
@@ -230,7 +248,11 @@ gh auth refresh -s project
 - 관련 Issue: #169 (본 문서의 도입 근거).
 - 관련 스킬:
   - `claude/skills/gh-issue-create/SKILL.md`
+  - `claude/skills/gh-commit/SKILL.md`
   - `claude/skills/gh-pr/SKILL.md`
   - `claude/skills/gh-pr-merge/SKILL.md`
   - `claude/skills/gh-issue-flow/SKILL.md`
+- 관련 헬퍼: `shell-common/functions/gh_project_status.sh` (공용
+  `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`, `/gh-commit` 이
+  모두 호출).
 - 관련 템플릿: `.github/pull_request_template.md`.

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -409,7 +409,7 @@ _gh_flow_worker() {
     # a "Next: …" hint without running commit/PR. We invoke the 3 atomic skills
     # ourselves so each phase has a distinct state + post-condition check.
     _gh_flow_set_state "$_dir" "implementing"
-    _gh_flow_set_project_status issue "$_issue" "In progress"
+    _gh_project_status_sync issue "$_issue" "In progress"
     if ! claude --dangerously-skip-permissions -p "/gh-issue-implement $_issue direct"; then
         _gh_flow_set_state "$_dir" "failed:implementing"
         printf '[gh-flow-worker] /gh-issue-implement failed\n' >&2
@@ -451,7 +451,7 @@ _gh_flow_worker() {
     printf '[gh-flow-worker] PR=#%s\n' "$_pr"
     # PR card auto-transition is not covered by any built-in workflow;
     # move it to "In review" explicitly so reviewers see it on the board.
-    _gh_flow_set_project_status pr "$_pr" "In review"
+    _gh_project_status_sync pr "$_pr" "In review"
 
     # ---- Step 3: poll for review / approval ----
     _gh_flow_set_state "$_dir" "polling"
@@ -507,120 +507,11 @@ _gh_flow_worker() {
 # ============================================================================
 # Project board Status sync
 # ============================================================================
-# Push a projectV2 Status transition for an Issue or PR. Auto-discovers every
-# projectV2 the target belongs to; for each project that has a "Status" field
-# with an option matching $3, updates the item's Status to that option.
-#
-# Failure is always quiet (returns 0) — the worker's primary job is
-# implement/commit/PR, not board bookkeeping. Opt out with
-# GH_FLOW_PROJECT_STATUS_SYNC=0.
-#
-# Usage: _gh_flow_set_project_status <issue|pr> <number> <status-name>
-#   _gh_flow_set_project_status issue 42 "In progress"
-#   _gh_flow_set_project_status pr    17 "In review"
-
-_gh_flow_set_project_status() {
-    local _kind="$1" _num="$2" _target="$3"
-    local _owner _repo _q_field _triples _proj _item _field _option
-
-    if [ "${GH_FLOW_PROJECT_STATUS_SYNC-1}" = "0" ]; then
-        return 0
-    fi
-    if [ -z "$_kind" ] || [ -z "$_num" ] || [ -z "$_target" ]; then
-        return 0
-    fi
-
-    case "$_kind" in
-        issue) _q_field='issue' ;;
-        pr) _q_field='pullRequest' ;;
-        *)
-            printf '[gh-flow-worker] project-status: invalid kind=%s, skipping\n' "$_kind" >&2
-            return 0
-            ;;
-    esac
-
-    # Single `gh repo view` call — two forks were redundant.
-    if ! read -r _owner _repo <<EOF
-$(gh repo view --json owner,name --jq '"\(.owner.login) \(.name)"' 2>/dev/null)
-EOF
-    then
-        printf '[gh-flow-worker] project-status: could not determine owner/repo, skipping\n' >&2
-        return 0
-    fi
-    if [ -z "$_owner" ] || [ -z "$_repo" ]; then
-        printf '[gh-flow-worker] project-status: could not determine owner/repo, skipping\n' >&2
-        return 0
-    fi
-
-    # Single query: find every projectV2 item for this issue/PR along with
-    # the project's Status field and the target option (if it exists there).
-    _triples=$(gh api graphql \
-        -f query="
-          query(\$owner: String!, \$repo: String!, \$number: Int!, \$target: String!) {
-            repository(owner: \$owner, name: \$repo) {
-              ${_q_field}(number: \$number) {
-                projectItems(first: 10) {
-                  nodes {
-                    id
-                    project {
-                      id
-                      field(name: \"Status\") {
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          options(names: [\$target]) { id name }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }" \
-        -f owner="$_owner" -f repo="$_repo" -F number="$_num" -f target="$_target" \
-        --jq ".data.repository.${_q_field}.projectItems.nodes[]
-              | select(.project.field.options? | length > 0)
-              | \"\(.project.id)|\(.id)|\(.project.field.id)|\(.project.field.options[0].id)\"" \
-        2>/dev/null) || {
-        printf '[gh-flow-worker] project-status: query failed for %s #%s (target=%s)\n' \
-            "$_kind" "$_num" "$_target" >&2
-        return 0
-    }
-
-    if [ -z "$_triples" ]; then
-        printf '[gh-flow-worker] project-status: %s #%s not in any project with "%s" option\n' \
-            "$_kind" "$_num" "$_target" >&2
-        return 0
-    fi
-
-    # Avoid subshell — keep heredoc pattern instead of pipe (zsh/bash tracing).
-    while IFS='|' read -r _proj _item _field _option; do
-        [ -z "$_proj" ] && continue
-        # GraphQL variables ($proj, $item, ...) are NOT shell vars — they
-        # are bound via the -f flags below, so single quotes are intended.
-        # shellcheck disable=SC2016
-        if gh api graphql \
-            -f query='
-              mutation($proj: ID!, $item: ID!, $field: ID!, $option: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $proj
-                  itemId: $item
-                  fieldId: $field
-                  value: { singleSelectOptionId: $option }
-                }) { clientMutationId }
-              }' \
-            -f proj="$_proj" -f item="$_item" -f field="$_field" -f option="$_option" \
-            >/dev/null 2>&1; then
-            printf '[gh-flow-worker] project-status: %s #%s -> "%s"\n' "$_kind" "$_num" "$_target"
-        else
-            printf '[gh-flow-worker] project-status: mutation failed for %s #%s (target=%s)\n' \
-                "$_kind" "$_num" "$_target" >&2
-        fi
-    done <<EOF
-$_triples
-EOF
-
-    return 0
-}
+# Helper extracted to shell-common/functions/gh_project_status.sh so /gh-pr
+# and /gh-commit (single-skill execution paths, not the gh-flow worker) can
+# also push board transitions. The worker calls _gh_project_status_sync at
+# Step 2a (implement → "In progress") and after Step 2c (PR opened →
+# "In review"); see lines 412 and 454.
 
 # ============================================================================
 # Aliases (hyphenated command names per shell-common convention)

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_project_status.sh
+# Push a projectV2 Status transition for an Issue or PR. Auto-discovers every
+# projectV2 the target belongs to; for each project that has a "Status" field
+# with an option matching the target name, updates the item's Status to that
+# option.
+#
+# Failure is always quiet (returns 0) — the caller's primary job is shipping
+# code, not board bookkeeping. Boards in repos that have no projectV2 attached
+# (e.g. side projects without a board) are auto-detected: the helper finds
+# zero project items and silently returns 0.
+#
+# Opt out with GH_PROJECT_STATUS_SYNC=0. The legacy gh-flow-era variable
+# GH_FLOW_PROJECT_STATUS_SYNC=0 is still honored for backwards compatibility.
+#
+# Usage:
+#   _gh_project_status_sync <issue|pr> <number> <target-status> [--only-from <list>]
+#
+# Examples:
+#   _gh_project_status_sync issue 42 "In progress"
+#   _gh_project_status_sync pr    17 "In review"
+#   _gh_project_status_sync issue 42 "In progress" --only-from Backlog
+#
+# --only-from <list>: comma-separated whitelist of CURRENT Status values.
+# If the item's current Status is not in the list, the transition is skipped
+# for that project. Used to prevent regression — e.g. /gh-commit must not
+# bounce an issue from "In review" back to "In progress" when a follow-up
+# fix commit lands. Status names with internal spaces are supported
+# ("Backlog,In progress"); do not pad with spaces around the comma.
+
+_gh_project_status_sync() {
+    local _kind="$1" _num="$2" _target="$3"
+    [ "$#" -ge 3 ] && shift 3
+
+    local _only_from=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --only-from)
+                if [ -z "${2-}" ]; then
+                    printf '[gh-project-status] --only-from requires an argument\n' >&2
+                    return 0
+                fi
+                _only_from="$2"
+                shift 2
+                ;;
+            *)
+                printf '[gh-project-status] unknown option: %s\n' "$1" >&2
+                return 0
+                ;;
+        esac
+    done
+
+    # Opt-out: either env var disables the sync.
+    if [ "${GH_PROJECT_STATUS_SYNC-1}" = "0" ] \
+        || [ "${GH_FLOW_PROJECT_STATUS_SYNC-1}" = "0" ]; then
+        return 0
+    fi
+    if [ -z "$_kind" ] || [ -z "$_num" ] || [ -z "$_target" ]; then
+        return 0
+    fi
+
+    local _q_field
+    case "$_kind" in
+        issue) _q_field='issue' ;;
+        pr) _q_field='pullRequest' ;;
+        *)
+            printf '[gh-project-status] invalid kind=%s, skipping\n' "$_kind" >&2
+            return 0
+            ;;
+    esac
+
+    # Resolve owner/repo via gh.
+    local _owner _repo
+    if ! read -r _owner _repo <<EOF
+$(gh repo view --json owner,name --jq '"\(.owner.login) \(.name)"' 2>/dev/null)
+EOF
+    then
+        printf '[gh-project-status] could not determine owner/repo, skipping\n' >&2
+        return 0
+    fi
+    if [ -z "$_owner" ] || [ -z "$_repo" ]; then
+        printf '[gh-project-status] could not determine owner/repo, skipping\n' >&2
+        return 0
+    fi
+
+    # Single query: per projectV2 item, return
+    #   project.id | item.id | field.id | target_option.id | current_status_name
+    # The current_status_name is needed for --only-from gating.
+    local _records
+    _records=$(gh api graphql \
+        -f query="
+          query(\$owner: String!, \$repo: String!, \$number: Int!, \$target: String!) {
+            repository(owner: \$owner, name: \$repo) {
+              ${_q_field}(number: \$number) {
+                projectItems(first: 10) {
+                  nodes {
+                    id
+                    fieldValueByName(name: \"Status\") {
+                      ... on ProjectV2ItemFieldSingleSelectValue { name }
+                    }
+                    project {
+                      id
+                      field(name: \"Status\") {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          options(names: [\$target]) { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }" \
+        -f owner="$_owner" -f repo="$_repo" -F number="$_num" -f target="$_target" \
+        --jq ".data.repository.${_q_field}.projectItems.nodes[]
+              | select(.project.field.options? | length > 0)
+              | \"\(.project.id)|\(.id)|\(.project.field.id)|\(.project.field.options[0].id)|\(.fieldValueByName.name // \"\")\"" \
+        2>/dev/null) || {
+        printf '[gh-project-status] query failed for %s #%s (target=%s)\n' \
+            "$_kind" "$_num" "$_target" >&2
+        return 0
+    }
+
+    if [ -z "$_records" ]; then
+        printf '[gh-project-status] %s #%s not in any project with "%s" option\n' \
+            "$_kind" "$_num" "$_target" >&2
+        return 0
+    fi
+
+    # Avoid subshell — heredoc instead of pipe (zsh/bash tracing parity).
+    local _proj _item _field _option _current
+    while IFS='|' read -r _proj _item _field _option _current; do
+        [ -z "$_proj" ] && continue
+
+        # --only-from guard: skip when current Status is not in the whitelist.
+        if [ -n "$_only_from" ] \
+            && ! _gh_project_status_in_list "$_current" "$_only_from"; then
+            printf '[gh-project-status] %s #%s skipped (current="%s" not in only-from="%s")\n' \
+                "$_kind" "$_num" "$_current" "$_only_from" >&2
+            continue
+        fi
+
+        # GraphQL variables ($proj, $item, ...) are NOT shell vars — they
+        # are bound via the -f flags below, so single quotes are intended.
+        # shellcheck disable=SC2016
+        if gh api graphql \
+            -f query='
+              mutation($proj: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $proj
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }) { clientMutationId }
+              }' \
+            -f proj="$_proj" -f item="$_item" -f field="$_field" -f option="$_option" \
+            >/dev/null 2>&1; then
+            printf '[gh-project-status] %s #%s -> "%s"\n' "$_kind" "$_num" "$_target"
+        else
+            printf '[gh-project-status] mutation failed for %s #%s (target=%s)\n' \
+                "$_kind" "$_num" "$_target" >&2
+        fi
+    done <<EOF
+$_records
+EOF
+
+    return 0
+}
+
+# Membership test: returns 0 when $1 equals any comma-separated entry of $2.
+# Uses pure parameter expansion to keep Status names with internal spaces
+# (e.g. "In progress") intact. Empty $1 never matches.
+_gh_project_status_in_list() {
+    local _val="$1" _list="$2"
+    [ -z "$_val" ] && return 1
+    case ",${_list}," in
+        *",${_val},"*) return 0 ;;
+    esac
+    return 1
+}

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -115,8 +115,8 @@ EOF
           }" \
         -f owner="$_owner" -f repo="$_repo" -F number="$_num" -f target="$_target" \
         --jq ".data.repository.${_q_field}.projectItems.nodes[]
-              | select(.project.field.options? | length > 0)
-              | \"\(.project.id)|\(.id)|\(.project.field.id)|\(.project.field.options[0].id)|\(.fieldValueByName.name // \"\")\"" \
+              | select(.project?.field?.options? | length > 0)
+              | \"\(.project?.id)|\(.id)|\(.project?.field?.id)|\(.project?.field?.options?[0]?.id)|\(.fieldValueByName?.name? // \"\")\"" \
         2>/dev/null) || {
         printf '[gh-project-status] query failed for %s #%s (target=%s)\n' \
             "$_kind" "$_num" "$_target" >&2

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -1,9 +1,10 @@
 #!/usr/bin/env bats
 # tests/bats/functions/gh_flow.bats
-# Unit tests for gh_flow subcommands, post-condition helpers, and the
-# _gh_flow_set_project_status board-sync helper. The worker pipeline itself
-# (Step 2: implement → commit → pr) is not exercised here — it needs claude /
-# gh / gwt and is covered by manual integration testing.
+# Unit tests for gh_flow subcommands and post-condition helpers. The worker
+# pipeline itself (Step 2: implement → commit → pr) is not exercised here —
+# it needs claude / gh / gwt and is covered by manual integration testing.
+# Project-board sync coverage moved to tests/bats/functions/gh_project_status.bats
+# when the helper was extracted to its own module.
 
 load '../test_helper'
 
@@ -219,39 +220,5 @@ teardown() {
     assert_output --partial "YES"
 }
 
-# ---------------------------------------------------------------------------
-# _gh_flow_set_project_status — loading and guard paths (no network required)
-# ---------------------------------------------------------------------------
-
-@test "bash: _gh_flow_set_project_status helper exists" {
-    run_in_bash 'declare -f _gh_flow_set_project_status >/dev/null && echo ok'
-    assert_success
-    assert_output --partial "ok"
-}
-
-@test "zsh: _gh_flow_set_project_status helper exists" {
-    run_in_zsh 'typeset -f _gh_flow_set_project_status >/dev/null && echo ok'
-    assert_success
-    assert_output --partial "ok"
-}
-
-@test "project-status: opt-out via GH_FLOW_PROJECT_STATUS_SYNC=0 returns silently" {
-    run_in_bash 'GH_FLOW_PROJECT_STATUS_SYNC=0 _gh_flow_set_project_status issue 1 "In progress" 2>&1; echo "rc=$?"'
-    assert_success
-    assert_output --partial "rc=0"
-    refute_output --partial "project-status:"
-}
-
-@test "project-status: missing args returns silently" {
-    run_in_bash '_gh_flow_set_project_status 2>&1; echo "rc=$?"'
-    assert_success
-    assert_output --partial "rc=0"
-    refute_output --partial "project-status:"
-}
-
-@test "project-status: invalid kind returns 0 with warning" {
-    run_in_bash '_gh_flow_set_project_status bogus 42 "In progress" 2>&1; echo "rc=$?"'
-    assert_success
-    assert_output --partial "rc=0"
-    assert_output --partial "invalid kind=bogus"
-}
+# Project-board sync helper tests live in
+# tests/bats/functions/gh_project_status.bats.

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_project_status.bats
+# Unit tests for the shared _gh_project_status_sync helper extracted from
+# gh_flow.sh. Network-dependent paths (the actual GraphQL query + mutation)
+# are not exercised — fixturing live projectV2 state is impractical. We
+# cover loading, opt-out guards, arg validation, --only-from option
+# parsing, and the _gh_project_status_in_list membership helper.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Loading: helper available in both bash and zsh after main.* sources it
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_project_status_sync helper exists" {
+    run_in_bash 'declare -f _gh_project_status_sync >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_project_status_sync helper exists" {
+    run_in_zsh 'typeset -f _gh_project_status_sync >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_project_status_in_list helper exists" {
+    run_in_bash 'declare -f _gh_project_status_in_list >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Opt-out guards
+# ---------------------------------------------------------------------------
+
+@test "opt-out: GH_PROJECT_STATUS_SYNC=0 returns silently" {
+    run_in_bash 'GH_PROJECT_STATUS_SYNC=0 _gh_project_status_sync issue 1 "In progress" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "[gh-project-status]"
+}
+
+@test "opt-out: legacy GH_FLOW_PROJECT_STATUS_SYNC=0 still honored" {
+    # Backwards-compat: callers that exported the old name in their env or
+    # CI config keep working without churn.
+    run_in_bash 'GH_FLOW_PROJECT_STATUS_SYNC=0 _gh_project_status_sync issue 1 "In progress" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "[gh-project-status]"
+}
+
+# ---------------------------------------------------------------------------
+# Arg validation (early returns, no network)
+# ---------------------------------------------------------------------------
+
+@test "validation: missing args returns silently" {
+    run_in_bash '_gh_project_status_sync 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "[gh-project-status]"
+}
+
+@test "validation: invalid kind returns 0 with warning" {
+    run_in_bash '_gh_project_status_sync bogus 42 "In progress" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "invalid kind=bogus"
+}
+
+# ---------------------------------------------------------------------------
+# --only-from option parsing
+# ---------------------------------------------------------------------------
+
+@test "only-from: unknown option rejected with stderr warning" {
+    run_in_bash '_gh_project_status_sync issue 42 "In progress" --bogus 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "unknown option: --bogus"
+}
+
+@test "only-from: missing value rejected" {
+    run_in_bash '_gh_project_status_sync issue 42 "In progress" --only-from 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "--only-from requires an argument"
+}
+
+# ---------------------------------------------------------------------------
+# _gh_project_status_in_list membership semantics
+# ---------------------------------------------------------------------------
+
+@test "in_list: single-item match" {
+    run_in_bash '_gh_project_status_in_list "Backlog" "Backlog" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "MATCH"
+}
+
+@test "in_list: comma-separated match (first)" {
+    run_in_bash '_gh_project_status_in_list "Backlog" "Backlog,In progress" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "MATCH"
+}
+
+@test "in_list: comma-separated match (last)" {
+    run_in_bash '_gh_project_status_in_list "In progress" "Backlog,In progress" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "MATCH"
+}
+
+@test "in_list: no match returns 1" {
+    run_in_bash '_gh_project_status_in_list "In review" "Backlog,In progress" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "NO"
+}
+
+@test "in_list: empty current value never matches" {
+    # Important guard: items with no Status set should not satisfy
+    # --only-from "" or any non-empty whitelist.
+    run_in_bash '_gh_project_status_in_list "" "Backlog" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "NO"
+}
+
+@test "in_list: status names with internal spaces are preserved" {
+    # Regression: a naive trim or word-split would break "In progress".
+    run_in_bash '_gh_project_status_in_list "In progress" "In progress" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "MATCH"
+}


### PR DESCRIPTION
## Summary
- Extract `_gh_flow_set_project_status` from `gh_flow.sh` into a shared helper `_gh_project_status_sync` (`shell-common/functions/gh_project_status.sh`) so `/gh-pr` and `/gh-commit` (the atomic skills, not just the `/gh-flow` worker) can also push projectV2 board transitions.
- Add an `--only-from <list>` guard so `/gh-commit`'s `Backlog → In progress` transition only fires from `Backlog`. Without it, follow-up fix commits to an open PR would bounce the issue card from `In review` back to `In progress` each time.
- Repos with no projectV2 attached are auto-detected (helper finds zero project items, returns 0 silently) — no behavioral impact on side projects without a board.

## Changes
- `shell-common/functions/gh_project_status.sh` (new): shared helper with arg parsing, opt-out (`GH_PROJECT_STATUS_SYNC=0`, plus legacy `GH_FLOW_PROJECT_STATUS_SYNC=0` for back-compat), single GraphQL query that also returns the current Status (needed for `--only-from`), and the `_gh_project_status_in_list` membership predicate (preserves Status names with internal spaces like `In progress`).
- `shell-common/functions/gh_flow.sh`: drop the inline `_gh_flow_set_project_status` body; worker now calls `_gh_project_status_sync` for both Step 2a (`Issue → In progress`) and post-Step 2c (`PR → In review`).
- `claude/skills/gh-pr/SKILL.md`: insert new Step 7 (`PR → In review` sync) and renumber Report to Step 8.
- `claude/skills/gh-commit/SKILL.md`: insert new Step 5 (`Issue Backlog → In progress` with mandatory `--only-from Backlog` guard) and renumber Verify to Step 6.
- `docs/standards/github-project-board.md`, `docs/playbooks/kanban-board-setup.md`: update the automation matrix and "수동 vs 자동" tables to reflect that the two entry transitions are now skill-driven (with no-op fallback on board-less repos).
- `tests/bats/functions/gh_project_status.bats` (new, 13 cases): loading in bash + zsh, opt-out via both env vars, arg validation, `--only-from` parsing edge cases, and `_gh_project_status_in_list` membership semantics including the `In progress` whitespace regression.
- `tests/bats/functions/gh_flow.bats`: drop the now-orphaned `_gh_flow_set_project_status` cases (coverage moved with the helper).

## Test plan
- [x] `bats tests/bats/functions/gh_project_status.bats` → 13/13 pass
- [x] `bats tests/bats/functions/gh_flow.bats` → still passes after the helper extraction
- [x] `bats tests/bats/functions/` full suite green
- [x] `shellcheck` + `bash -n` + `zsh -n` clean on the new helper
- [ ] Live: run `/gh-pr 199` against this branch and confirm the PR card moves to `In review` on the project board (this very PR is the smoke test)
- [ ] Live: run `/gh-commit` on a follow-up tweak to issue #199 and confirm `--only-from Backlog` guard skips the transition (issue stays at `In review`, no regression to `In progress`)
- [ ] Live: invoke `/gh-pr` or `/gh-commit` in a side repo without a projectV2 board → expect silent no-op

## Related
Closes #199

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
