### PR TITLE
feat(skills): extend project-board Status sync to /gh-pr-reply

### DIFF
--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -72,7 +72,32 @@ vs top-level) and the four body templates (Accepted / Accepted-with-modification
 If any fixes were committed: `git push` (never force-push unless the user
 asked) and report new commit SHAs alongside the reply summary.
 
-## Step 7: Report
+## Step 7: Sync Project Board Status
+
+After all replies are posted, push the PR's project-board card to
+`Approved` so the kanban reflects "review round closed, awaiting merge".
+GitHub's `Code review approved` built-in workflow only fires when a
+reviewer submits an `APPROVED` review — and on solo repos the PR author
+cannot self-approve their own PR, so without this step the card never
+leaves `In review` (or `Backlog` if the worker missed the initial
+`Backlog → In review` transition). `/gh-pr-reply` closes that gap.
+
+Source the shared helper (it lives in
+`shell-common/functions/gh_project_status.sh`) and call it with the
+PR number, guarding the transition with `--only-from` so the card
+never regresses from `Done` (e.g. when the user invokes
+`/gh-pr-reply` on an already-merged PR by mistake):
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+_gh_project_status_sync pr <PR_NUMBER> "Approved" --only-from "Backlog,In progress,In review"
+```
+
+If the repo has no projectV2 board attached (auto-detected — the helper
+finds zero project items and silently returns 0), nothing happens. Opt
+out per-invocation with `GH_PROJECT_STATUS_SYNC=0`.
+
+## Step 8: Report
 
 Print a table the user can scan:
 

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -131,7 +131,7 @@ GitHub Projects v2의 빌트인 워크플로우 9개가 모두 `enabled`
 
 ### 자동 전환 규칙 (스킬 경유)
 
-GitHub 빌트인이 커버하지 않는 두 진입 전환은 dotfiles 의 스킬이
+GitHub 빌트인이 커버하지 않는 세 전환은 dotfiles 의 스킬이
 공용 헬퍼 `_gh_project_status_sync`
 (`shell-common/functions/gh_project_status.sh`) 를 통해 자동화한다.
 보드가 없는 repo (예: `dotfiles` 이외의 사이드 프로젝트) 에선 헬퍼가
@@ -147,11 +147,22 @@ GitHub 빌트인이 커버하지 않는 두 진입 전환은 dotfiles 의 스킬
 - **PR 카드 `Backlog → In review`**: `/gh-flow` 워커 또는 `/gh-pr`
   단독 실행이 PR 생성 직후 자동 전환한다. raw `gh pr create` 로
   PR 을 만든 경우엔 수동 이동이 필요하다.
+- **PR 카드 `In review → Approved`**: `/gh-pr-reply` 가 reply 라운드
+  종료 후 자동 전환한다. GitHub 빌트인 `Code review approved` 는
+  누군가 `APPROVED` 상태의 review 를 제출해야만 트리거되는데,
+  GitHub 정책상 **PR 작성자는 자기 PR 을 Approve 할 수 없으므로**
+  1인 repo (`dotfiles` 처럼 단독 운영하는 저장소) 에서는 빌트인이
+  영원히 작동하지 않는다. `/gh-pr-reply` 가 그 갭을 메운다 — reply
+  라운드가 닫혔다는 것은 의미적으로 "리뷰 사이클 종료, 머지 대기"
+  이므로 `Approved` 와 정합한다. `--only-from "Backlog,In progress,In
+  review"` 가드를 적용해 머지된 PR (`Done`) 에 잘못 호출되었을 때
+  카드가 `Approved` 로 되돌아가는 regression 을 막는다.
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:
   `Changes requested` 루프에서 수정·재푸시 후 리뷰가 다시 달리기를
   기대할 때 **수동**으로 복귀시킨다. Projects v2 빌트인에도 dotfiles
-  스킬에도 이 전환을 자동화하는 경로가 없다. 이 외의 PR 전환(`→
-  Approved`, `→ Done`)은 모두 빌트인 워크플로우로 자동 처리된다.
+  스킬에도 이 전환을 자동화하는 경로가 없다. 이 외의 PR 전환
+  (`→ Done`) 은 빌트인 `Pull request merged` / `Item closed` 가
+  자동 처리한다.
 
 ### 용어 교정 (2026-04-24)
 
@@ -221,12 +232,15 @@ gh auth refresh -s project
   되돌리지 않는다.
 - PR 카드 `Backlog → In review` 는 dotfiles 스킬 (`/gh-flow`,
   `/gh-pr`) 사용 시 자동, raw `gh pr create` 사용 시에만 수동이다.
-  `In progress → In review` (`Changes requested` 루프 탈출 시)
-  전환만 항상 수동이다 — 빌트인·스킬 모두 이 경로를 자동화하지
-  않는다.
-- 보드가 없는 repo 에서 `/gh-pr` 또는 `/gh-commit` 을 실행하면
-  공용 헬퍼 `_gh_project_status_sync` 가 `projectItems` 가 0건임을
-  자동 감지하고 조용히 no-op 한다 (별도 분기 불필요).
+  `In review → Approved` 는 `/gh-pr-reply` 가 자동 처리한다 (1인
+  repo 에서 self-approve 불가로 빌트인 `Code review approved` 가
+  영원히 트리거되지 않는 갭을 메우기 위함). `In progress → In
+  review` (`Changes requested` 루프 탈출 시) 전환만 항상 수동이다
+  — 빌트인·스킬 모두 이 경로를 자동화하지 않는다.
+- 보드가 없는 repo 에서 `/gh-pr`, `/gh-commit`, 또는
+  `/gh-pr-reply` 를 실행하면 공용 헬퍼 `_gh_project_status_sync` 가
+  `projectItems` 가 0건임을 자동 감지하고 조용히 no-op 한다 (별도
+  분기 불필요).
 - 수동으로 카드를 옮긴 경우 다음 자동 이벤트가 상태를 덮어쓸
   수 있다. 특히 Issue 카드를 `Approved`로 옮겨도 `Item closed`가
   PR 머지 시점에 곧바로 `Done`으로 이동시키므로 의미가 없다
@@ -250,9 +264,10 @@ gh auth refresh -s project
   - `claude/skills/gh-issue-create/SKILL.md`
   - `claude/skills/gh-commit/SKILL.md`
   - `claude/skills/gh-pr/SKILL.md`
+  - `claude/skills/gh-pr-reply/SKILL.md`
   - `claude/skills/gh-pr-merge/SKILL.md`
   - `claude/skills/gh-issue-flow/SKILL.md`
 - 관련 헬퍼: `shell-common/functions/gh_project_status.sh` (공용
-  `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`, `/gh-commit` 이
-  모두 호출).
+  `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`, `/gh-commit`,
+  `/gh-pr-reply` 가 모두 호출).
 - 관련 템플릿: `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary

- Adds a Step 7 hook to `/gh-pr-reply` that pushes the PR card to `Approved` after replies are posted, closing the `In review → Approved` gap that solo repos hit because GitHub's `Code review approved` built-in needs an `APPROVED` review and PR authors cannot self-approve their own PRs.
- Uses the shared `_gh_project_status_sync` helper from #202 with `--only-from "Backlog,In progress,In review"` so the card never regresses from `Done` (e.g. when the user invokes `/gh-pr-reply` on an already-merged PR).
- Updates `docs/standards/github-project-board.md` so the "자동 전환 규칙 (스킬 경유)" list grows from two entries to three with a new `In review → Approved` row, the operational notes restate the same fact, and `/gh-pr-reply` joins the related-skills and shared-helper caller lists.

## Why

The board has six Status options including `Approved`, but on a 1-person repo the canonical PR lifecycle (`Backlog → In review → Approved → Done`) loses its middle automatic step: the `Code review approved` built-in only fires on a real `APPROVED` review, and GitHub forbids the PR author from approving their own PR. Without this hook PR cards stay in `In review` (or `Backlog` when the worker missed the initial transition) until merge time, when `Pull request merged` jumps them straight to `Done`. PRs #197 and #200 sat in exactly that state today — `Backlog`, awaiting merge.

## Stack history

Originally drafted as a stack PR on `wt/issue-199/1` (#202), which has since merged. Rebased onto `main`; git's patch-id detection auto-skipped the two #202 commits, leaving a single commit on top of current `main`.

## Test plan

- [ ] Run `/gh-pr-reply <N>` against an open PR whose card is in `Backlog` or `In review` and confirm the card moves to `Approved`.
- [ ] Run `/gh-pr-reply <N>` against an already-merged PR (card in `Done`) and confirm the `--only-from` guard skips the transition (card stays in `Done`).
- [ ] Run `/gh-pr-reply <N>` from a checkout that has no projectV2 board attached and confirm the helper silently no-ops.
- [ ] Re-read `docs/standards/github-project-board.md` end-to-end and confirm the "자동 전환 규칙 (스킬 경유)" list, operational notes, and References section are internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
