### PR TITLE
docs(kanban): switch Auto-archive retention from 당일 to 2일

### DIFF
--- a/docs/playbooks/kanban-board-setup.md
+++ b/docs/playbooks/kanban-board-setup.md
@@ -143,7 +143,7 @@ URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
 | 7  | `Item closed`                   | issues + pull requests     | `Done`              |
 | 8  | `Auto-close issue`              | — (구조적; 기본 유지)       | (Status 미설정)     |
 | 9  | `Auto-add sub-issues to project`| — (구조적; 기본 유지)       | (Status 미설정)     |
-| 10 | `Auto-archive items`            | Filter 매칭 카드 주기적 archive | **수동 enable** + Filter: `is:issue,pr is:closed updated:<@today` |
+| 10 | `Auto-archive items`            | Filter 매칭 카드 주기적 archive | **수동 enable** + Filter: `is:issue,pr is:closed updated:<@today-2d` |
 
 **#10 `Auto-archive items` 설정 상세**:
 
@@ -152,9 +152,11 @@ URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
   - `is:issue,pr` — Issue·PR 카드 모두 (Option B 운영 전제)
   - `is:closed` — 닫힌(=머지된) 카드만. 본 문서 라이프사이클에서
     Done 컬럼과 동치.
-  - `updated:<@today` — 오늘 이전에 업데이트된 카드. 기간은 운영
-    취향에 따라 `<@today-1d`, `<@today-2w` 등으로 조정. dotfiles는
-    `<@today` 채택 (Done 컬럼을 항상 당일분으로만 유지).
+  - `updated:<@today-2d` — 그제(2일 전) 자정 이전에 업데이트된
+    카드. 기간은 운영 취향에 따라 `<@today` (당일분만), `<@today-1w`
+    (1주분) 등으로 조정. dotfiles는 `<@today-2d` 채택 (Done 컬럼을
+    최근 2일분만 유지하여, 어제 머지된 카드도 오늘 시점에 보드
+    상에서 즉시 확인 가능).
 - archive 된 카드는 삭제가 아니라 기본 뷰에서 숨김 — 필터 바에
   `is:archived` 입력 시 재조회, 카드 우클릭 `Restore from archive`로
   복원 가능.

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -129,7 +129,7 @@ GitHub Projects v2의 빌트인 워크플로우 10개 중 9개가 `enabled`
 |----|-------------------------------------|---------------------------------------------------|
 | 8  | `Auto-close issue`                  | 부모 Issue의 모든 sub-issue가 close되면 부모를 auto-close |
 | 9  | `Auto-add sub-issues to project`    | 부모 Issue가 보드에 있으면 sub-issue도 자동 추가      |
-| 10 | `Auto-archive items`                | 필터 매칭 카드를 주기적으로 archive (Done 컬럼 정리용). 기본 `disabled` — 수동 enable 필요. dotfiles 채택 필터: `is:issue,pr is:closed updated:<@today` |
+| 10 | `Auto-archive items`                | 필터 매칭 카드를 주기적으로 archive (Done 컬럼 정리용). 기본 `disabled` — 수동 enable 필요. dotfiles 채택 필터: `is:issue,pr is:closed updated:<@today-2d` |
 
 ### 자동 전환 규칙 (스킬 경유)
 
@@ -220,8 +220,8 @@ gh auth refresh -s project
    - `Auto-close issue`, `Auto-add sub-issues to project`:
      Status를 건드리지 않는 구조적 워크플로우로 기본 설정 유지.
    - `Auto-archive items`: 수동 enable + 필터
-     `is:issue,pr is:closed updated:<@today` 입력 — Done 컬럼을
-     오늘 이전 분부터 자동 archive 하여 항상 당일분만 유지한다.
+     `is:issue,pr is:closed updated:<@today-2d` 입력 — Done 컬럼을
+     그제 이전 분부터 자동 archive 하여 최근 2일분만 유지한다.
 
 ## 운영 상의 유의사항
 


### PR DESCRIPTION
## Summary

- Changes the documented `Auto-archive items` filter from `is:issue,pr is:closed updated:<@today` (당일분만 유지) to `is:issue,pr is:closed updated:<@today-2d` (최근 2일분만 유지) in both the SSOT and the kanban-board-setup playbook.
- The live board has **already been reconfigured** to the new filter — this PR brings the documentation back into agreement so a fresh project initialized via these docs lands at the same retention policy.
- Self-consistent across three places per file: workflow table row, setup-guide step, and (in the playbook) the filter-syntax breakdown. The "운영 취향에 따라 다른 변형" example list now keeps `<@today` (당일) as one alternative for operators who want the strictest policy.

## Why

With `<@today`, yesterday's merged cards vanish from Done at midnight — the column is visibly empty most of the time, so the operator cannot do an end-of-day "what shipped?" review on the board itself. A 2-day window keeps the day a card merges and the day after both visible in Done, then archives on day three. Two-day retention is also the smallest window that works around the "I missed yesterday's review" gap without bloating Done.

## Stack history

Follow-up to #197 (the PR that introduced Auto-archive documentation in the first place — merged earlier today). Branched off `main` after #197 landed; no rebase needed.

## Test plan

- [ ] On the live board, confirm the filter currently reads `is:issue,pr is:closed updated:<@today-2d` (Workflows → Auto-archive items → Filter).
- [ ] Wait until tomorrow and verify that today's merged PRs are still in Done (not archived).
- [ ] Wait until day-after-tomorrow and verify they have moved to archive (visible via `is:archived` filter).
- [ ] Re-read both updated files and confirm no remaining mention of "당일분만" as the dotfiles-adopted policy (the surviving "당일분" reference in the playbook is intentional — it documents `<@today` as an alternative variant, not as the dotfiles choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
