### PR TITLE
feat(gwt): add --all flag to teardown for batch cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ exclude = '(?x)( \.venv/ | \.tox/ | \.vscode/ | \.git/ | build/ | config/tox/ | 
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-exclude = [".git", ".mypy_cache", ".tox", ".nox", ".venv", "build", "dist", ".vscode"]
+exclude = [".git", ".mypy_cache", ".tox", ".nox", ".venv", "build", "dist", ".vscode", "tests/bats/lib"]
 
 [tool.ruff.lint]
 # E, F: pyflakes/pycodestyle 기본 규칙

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -985,13 +985,16 @@ _gwt_teardown_all() {
     # flagging the `read -r` below as top-level interactive code.
     git rev-parse --git-common-dir >/dev/null 2>&1 || { ux_error "Not inside a git repository"; return 1; }
 
-    # Resolve main worktree (first entry of `git worktree list --porcelain`).
-    local main_wt
-    main_wt="$(git worktree list --porcelain | head -1)"
+    # Resolve main worktree and collect non-main worktrees from a single
+    # `git worktree list --porcelain` snapshot — one fork instead of two,
+    # and both parses see the same repo state.
+    local porcelain main_wt all_wts="" all_count=0
+    porcelain="$(git worktree list --porcelain)"
+    IFS= read -r main_wt <<EOF
+$porcelain
+EOF
     main_wt="${main_wt#worktree }"
 
-    # Collect non-main worktree paths.
-    local all_wts="" all_count=0
     while IFS= read -r line; do
         case "$line" in
             "worktree "*)
@@ -1004,7 +1007,7 @@ _gwt_teardown_all() {
                 ;;
         esac
     done <<EOF
-$(git worktree list --porcelain)
+$porcelain
 EOF
 
     if [ "$all_count" -eq 0 ]; then
@@ -1021,12 +1024,10 @@ $all_wts
 EOF
 
     if [ "$force" != true ]; then
-        printf 'Proceed? [y/N] '
-        read -r answer
-        case "$answer" in
-            [yY]*) ;;
-            *) ux_info "Aborted."; return 1 ;;
-        esac
+        if ! ux_confirm "Proceed with teardown?" "n"; then
+            ux_info "Aborted."
+            return 1
+        fi
     fi
 
     # Park in main repo so loop iterations have a stable cwd between runs.

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -61,8 +61,9 @@ _gwt_help_rows_spawn() {
 }
 
 _gwt_help_rows_teardown() {
-    ux_table_row "syntax" "gwt teardown [--force] [--keep-branch]" "Cleanup current AI worktree"
-    ux_table_row "context" "Run inside a worktree" "Syncs main repo after cleanup"
+    ux_table_row "syntax" "gwt teardown [--all|-a|all] [--force] [--keep-branch]" "Cleanup AI worktree(s)"
+    ux_table_row "context" "Single mode: run inside a worktree" "Syncs main repo after cleanup"
+    ux_table_row "all mode" "Run from main repo or any worktree" "Tears down every non-main worktree"
     ux_table_row "flags" "--force / --keep-branch" "Discard changes / keep branch"
 }
 
@@ -677,7 +678,7 @@ _gwt_report_unpushed() {
 
 # ============================================================================
 # Worktree teardown — remove worktree, sync main, delete branch, log
-# Usage: git_worktree_teardown [--force] [--keep-branch]
+# Usage: git_worktree_teardown [--all|-a|all] [--force] [--keep-branch]
 # ============================================================================
 git_worktree_teardown() {
     # zsh compatibility
@@ -685,19 +686,22 @@ git_worktree_teardown() {
         emulate -L sh
     fi
 
-    local force=false keep_branch=false
+    local force=false keep_branch=false all_mode=false
 
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)
                 ux_header "gwt teardown - AI worktree cleanup"
-                ux_info "Usage: gwt teardown [--force] [--keep-branch]"
+                ux_info "Usage: gwt teardown [--all|-a|all] [--force] [--keep-branch]"
                 ux_info ""
                 ux_info "Options:"
+                ux_info "  --all, -a, all tear down every non-main worktree (run from main"
+                ux_info "                 repo or inside any worktree)"
                 ux_info "  --force        discard uncommitted changes and force remove"
                 ux_info "  --keep-branch  keep the branch after removing worktree"
                 return 0
                 ;;
+            --all|-a|all) all_mode=true; shift ;;
             --force) force=true; shift ;;
             --keep-branch) keep_branch=true; shift ;;
             -*)
@@ -735,13 +739,50 @@ git_worktree_teardown() {
                     ux_info "Did you mean:"
                     ux_bullet "cd \"$1\" && gwt teardown     # full cleanup: remove + sync main + delete branch"
                     ux_bullet "gwt remove \"$1\"             # remove worktree only (no main sync, no branch delete)"
+                    ux_bullet "gwt teardown --all          # tear down every non-main worktree at once"
                 fi
                 return 1
                 ;;
         esac
     done
 
+    # Batch mode: tear down every non-main worktree.
+    if [ "$all_mode" = true ]; then
+        _gwt_teardown_all "$force" "$keep_branch"
+        return $?
+    fi
+
     # Must be inside a worktree
+    local git_common git_dir
+    git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        ux_error "Not inside a git repository"; return 1
+    }
+    git_dir="$(git rev-parse --git-dir)"
+    if [ "$git_dir" = "$git_common" ]; then
+        ux_error "Not inside a worktree. Nothing to tear down."
+        ux_info "  Use 'gwt teardown --all' to tear down every linked worktree."
+        return 1
+    fi
+
+    _gwt_teardown_one_inplace "$force" "$keep_branch"
+    return $?
+}
+
+# ============================================================================
+# Internal: tear down the worktree containing $PWD (single-mode pipeline).
+# Caller MUST already be inside the target worktree. Performs pre-flight
+# checks, removes the worktree, ff-syncs main, deletes the branch, logs.
+# Cd's to main repo on success, restores cwd to original worktree on failure.
+# Args: <force> <keep_branch>
+# ============================================================================
+_gwt_teardown_one_inplace() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local force="$1" keep_branch="$2"
+
     local git_common git_dir
     git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
         ux_error "Not inside a git repository"; return 1
@@ -922,6 +963,119 @@ git_worktree_teardown() {
     ux_info "  Removed: $wt_path"
     ux_info "  Now on:  $main_branch (out of sync)"
     return 1
+}
+
+# ============================================================================
+# Internal: tear down every non-main worktree (best-effort).
+# Args: <force> <keep_branch>
+# Returns 0 if all teardowns succeed, 1 if any failed (or aborted, or no repo).
+# ============================================================================
+_gwt_teardown_all() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local force="$1" keep_branch="$2"
+
+    # Must be inside a git repo (main or any worktree).
+    # Keep `|| { ...; }` on one line so the closing brace does not appear at
+    # line-start; library_purity_check tracks brace depth via `^\s*\}` and
+    # would otherwise treat this as the enclosing function's close, falsely
+    # flagging the `read -r` below as top-level interactive code.
+    git rev-parse --git-common-dir >/dev/null 2>&1 || { ux_error "Not inside a git repository"; return 1; }
+
+    # Resolve main worktree (first entry of `git worktree list --porcelain`).
+    local main_wt
+    main_wt="$(git worktree list --porcelain | head -1)"
+    main_wt="${main_wt#worktree }"
+
+    # Collect non-main worktree paths.
+    local all_wts="" all_count=0
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                local wt="${line#worktree }"
+                if [ "$wt" != "$main_wt" ]; then
+                    all_wts="${all_wts}${wt}
+"
+                    all_count=$((all_count + 1))
+                fi
+                ;;
+        esac
+    done <<EOF
+$(git worktree list --porcelain)
+EOF
+
+    if [ "$all_count" -eq 0 ]; then
+        ux_info "No worktrees to tear down."
+        return 0
+    fi
+
+    ux_warning "About to tear down $all_count worktree(s):"
+    while IFS= read -r wt; do
+        [ -n "$wt" ] || continue
+        ux_info "  $wt"
+    done <<EOF
+$all_wts
+EOF
+
+    if [ "$force" != true ]; then
+        printf 'Proceed? [y/N] '
+        read -r answer
+        case "$answer" in
+            [yY]*) ;;
+            *) ux_info "Aborted."; return 1 ;;
+        esac
+    fi
+
+    # Park in main repo so loop iterations have a stable cwd between runs.
+    cd "$main_wt" 2>/dev/null || { ux_error "Cannot cd to main repo: $main_wt"; return 1; }
+
+    local ok_count=0 fail_count=0 failed_wts=""
+    while IFS= read -r wt; do
+        [ -n "$wt" ] || continue
+        ux_header "Tearing down: $wt"
+        if [ ! -d "$wt" ]; then
+            ux_warning "  Path missing on disk — skipping (run 'gwt prune' to clean stale refs)."
+            fail_count=$((fail_count + 1))
+            failed_wts="${failed_wts}${wt} (missing)
+"
+            continue
+        fi
+        # Split across lines: naming_check.sh greedy-matches `".*<func>.*"` on
+        # a single line, so keeping `"$wt"` and `"$force"` from sandwiching the
+        # helper name on one physical line avoids a false-positive flag.
+        if ( cd "$wt" \
+             && _gwt_teardown_one_inplace "$force" "$keep_branch" ); then
+            ok_count=$((ok_count + 1))
+        else
+            fail_count=$((fail_count + 1))
+            failed_wts="${failed_wts}${wt}
+"
+        fi
+        # Restore cwd to main_wt — _gwt_teardown_one_inplace ran in subshell,
+        # so caller's cwd is unchanged, but defensively re-anchor.
+        cd "$main_wt" 2>/dev/null || true
+    done <<EOF
+$all_wts
+EOF
+
+    ux_header "Teardown summary"
+    ux_info "  Succeeded: $ok_count"
+    ux_info "  Failed:    $fail_count"
+    if [ "$fail_count" -gt 0 ]; then
+        ux_info "  Failed worktrees:"
+        while IFS= read -r wt; do
+            [ -n "$wt" ] || continue
+            ux_info "    $wt"
+        done <<EOF
+$failed_wts
+EOF
+        return 1
+    fi
+    ux_success "All worktrees torn down."
+    return 0
 }
 
 alias gwt-help='gwt_help'

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -295,3 +295,157 @@ _squash_merge_branch_into_origin_main() {
 
     git -C "$CLONE" worktree unlock "$WORKTREE" 2>/dev/null || true
 }
+
+# ---------------------------------------------------------------------------
+# Issue #204: --all batch teardown
+# ---------------------------------------------------------------------------
+
+# Add N extra worktrees on top of the default wt/test/1 fixture.
+# Each is rooted at $TEST_TEMP_HOME/clone-extra-<i> on branch wt/extra/<i>.
+_add_extra_worktrees() {
+    local count="$1" i
+    for i in $(seq 1 "$count"); do
+        git -C "$CLONE" worktree add -q -b "wt/extra/$i" \
+            "$TEST_TEMP_HOME/clone-extra-$i" origin/main
+    done
+}
+
+@test "teardown --all: from main repo tears down every linked worktree" {
+    _add_extra_worktrees 2
+
+    # Sanity: 4 worktrees total (main + wt/test/1 + 2 extras).
+    [ "$(git -C "$CLONE" worktree list --porcelain | grep -c '^worktree ')" -eq 4 ]
+
+    run_in_bash "cd '$CLONE' && gwt teardown --all --force 2>&1"
+    assert_success
+    assert_output --partial "Succeeded: 3"
+    assert_output --partial "Failed:    0"
+    assert_output --partial "All worktrees torn down."
+
+    # Only main repo remains.
+    [ "$(git -C "$CLONE" worktree list --porcelain | grep -c '^worktree ')" -eq 1 ]
+    [ ! -d "$WORKTREE" ]
+    [ ! -d "$TEST_TEMP_HOME/clone-extra-1" ]
+    [ ! -d "$TEST_TEMP_HOME/clone-extra-2" ]
+
+    # Branches deleted too.
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_failure
+    run git -C "$CLONE" rev-parse --verify --quiet wt/extra/1
+    assert_failure
+    run git -C "$CLONE" rev-parse --verify --quiet wt/extra/2
+    assert_failure
+}
+
+@test "teardown --all: short alias -a works the same as --all" {
+    _add_extra_worktrees 1
+
+    run_in_bash "cd '$CLONE' && gwt teardown -a --force 2>&1"
+    assert_success
+    assert_output --partial "Succeeded: 2"
+}
+
+@test "teardown --all: positional 'all' works the same as --all" {
+    _add_extra_worktrees 1
+
+    run_in_bash "cd '$CLONE' && gwt teardown all --force 2>&1"
+    assert_success
+    assert_output --partial "Succeeded: 2"
+}
+
+@test "teardown --all: from inside a worktree tears down self too" {
+    _add_extra_worktrees 1
+
+    # Run from inside one of the worktrees; --all should tear down everything,
+    # including the cwd worktree.
+    run_in_bash "cd '$WORKTREE' && gwt teardown --all --force 2>&1"
+    assert_success
+    assert_output --partial "Succeeded: 2"
+    [ ! -d "$WORKTREE" ]
+    [ ! -d "$TEST_TEMP_HOME/clone-extra-1" ]
+}
+
+@test "teardown --all: no extra worktrees prints info and exits 0" {
+    # Tear down the default fixture first so only main remains.
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+
+    run_in_bash "cd '$CLONE' && gwt teardown --all --force 2>&1"
+    assert_success
+    assert_output --partial "No worktrees to tear down."
+}
+
+@test "teardown --all: --keep-branch keeps branches" {
+    _add_extra_worktrees 1
+
+    run_in_bash "cd '$CLONE' && gwt teardown --all --force --keep-branch 2>&1"
+    assert_success
+    assert_output --partial "Succeeded: 2"
+
+    # Worktrees gone, branches still exist.
+    [ ! -d "$WORKTREE" ]
+    [ ! -d "$TEST_TEMP_HOME/clone-extra-1" ]
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_success
+    run git -C "$CLONE" rev-parse --verify --quiet wt/extra/1
+    assert_success
+}
+
+@test "teardown --all: best-effort — one failure does not abort the rest" {
+    _add_extra_worktrees 2
+
+    # Lock the first extra so its teardown fails. Other two should still run.
+    git -C "$CLONE" worktree lock --reason "held for test" "$TEST_TEMP_HOME/clone-extra-1"
+
+    run_in_bash "cd '$CLONE' && gwt teardown --all --force 2>&1"
+    assert_failure
+    assert_output --partial "Succeeded: 2"
+    assert_output --partial "Failed:    1"
+    assert_output --partial "clone-extra-1"
+
+    # The two unlocked ones are gone.
+    [ ! -d "$WORKTREE" ]
+    [ ! -d "$TEST_TEMP_HOME/clone-extra-2" ]
+    # The locked one survived.
+    [ -d "$TEST_TEMP_HOME/clone-extra-1" ]
+
+    git -C "$CLONE" worktree unlock "$TEST_TEMP_HOME/clone-extra-1" 2>/dev/null || true
+}
+
+@test "teardown --all: confirmation prompt rejects on default 'no'" {
+    _add_extra_worktrees 1
+
+    # Pipe an empty answer (defaults to N). Without --force the prompt fires.
+    run_in_bash "cd '$CLONE' && printf '\n' | gwt teardown --all 2>&1"
+    assert_failure
+    assert_output --partial "Aborted."
+    # Nothing was actually torn down.
+    [ -d "$WORKTREE" ]
+    [ -d "$TEST_TEMP_HOME/clone-extra-1" ]
+}
+
+@test "teardown --all: confirmation prompt proceeds on 'y'" {
+    _add_extra_worktrees 1
+
+    run_in_bash "cd '$CLONE' && printf 'y\n' | gwt teardown --all 2>&1"
+    assert_success
+    assert_output --partial "Succeeded: 2"
+    [ ! -d "$WORKTREE" ]
+    [ ! -d "$TEST_TEMP_HOME/clone-extra-1" ]
+}
+
+@test "teardown --all: --help mentions the new option" {
+    run_in_bash "gwt teardown --help 2>&1"
+    assert_success
+    assert_output --partial "--all"
+    assert_output --partial "tear down every non-main worktree"
+}
+
+@test "teardown (no --all) from main repo suggests --all in error" {
+    # Backward-compat: bare 'gwt teardown' from main repo still errors,
+    # but the error now points to --all as a way out.
+    run_in_bash "cd '$CLONE' && gwt teardown 2>&1"
+    assert_failure
+    assert_output --partial "Not inside a worktree"
+    assert_output --partial "gwt teardown --all"
+}


### PR DESCRIPTION
## Summary
- `gwt teardown` 에 `--all|-a|all` 플래그를 추가해 main 외 모든 워크트리를 한 번에 정리한다.
- 메인 레포·임의의 워크트리 어디서든 실행 가능하며, 한 워크트리 실패가 나머지를 막지 않는 best-effort 동작.
- `--force` 미지정 시 `[y/N]` 확인 프롬프트로 실수 방지.

## Changes
- `shell-common/functions/git_worktree.sh`
  - `git_worktree_teardown()` 옵션 파싱에 `--all|-a|all` 분기 추가, 도움말·suggest 갱신
  - 기존 단일 모드 본체를 `_gwt_teardown_one_inplace()` 헬퍼로 추출 — 동작 변경 없음
  - 새 `_gwt_teardown_all()` 헬퍼: main 외 worktree 목록을 수집해 best-effort 순회, 성공/실패 카운트 요약
  - `_gwt_help_rows_teardown()` 에 `all mode` 행 추가
  - hook 파서 우회: `|| { ...; }` 다중 라인 블록은 single-line 으로 압축, `if (cd && helper)` 구문은 line-continuation 으로 분리 (각 위치에 이유 주석)
- `tests/bats/functions/git_worktree_teardown.bats`
  - `--all` 신규 테스트 10케이스 추가 (메인 레포 실행, 별칭 `-a`/`all`, 워크트리 내부에서 자기 포함, 빈 상태, `--keep-branch`, locked 워크트리 best-effort, `[y/N]` 프롬프트 reject/accept, help 텍스트, backward-compat 에러 메시지)

## Test plan
- [ ] `bats tests/bats/functions/git_worktree_teardown.bats` 전부 통과
- [ ] 다중 워크트리 환경에서 `gwt teardown --all` 수동 실행 → 카운트 요약·main 동기화 확인
- [ ] `gwt teardown -a` / `gwt teardown all` 모두 동일 동작
- [ ] `gwt teardown --all --keep-branch` 시 브랜치만 보존됨
- [ ] 워크트리 내부에서 `gwt teardown --all` 실행 시 자기 자신도 정리되고 main 으로 cd 됨
- [ ] `--force` 없이 실행 시 프롬프트 출력, `n` 입력 시 abort
- [ ] `gwt teardown --help` 에 `--all` 옵션 노출
- [ ] 메인 레포에서 bare `gwt teardown` 시 에러 메시지가 `--all` 안내함

## Related
Closes #204

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
