### PR TITLE
feat: AI worktree git-crypt auto-unlock + gc-export-key helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ TDD cycle: Analyze → Write test (`pytest` or `demo_ux.sh`) → Implement minim
 - **Command UX Standard**: See `docs/standards/command-guidelines.md` (SSOT for command/help interface and formatting).
 - **Git Strategy**: Semantic commits (`Type: Summary`).
 - **Project Board**: See `docs/standards/github-project-board.md` (SSOT for Issue kanban workflow and closing-keyword policy).
+- **Known Pitfalls**: `Agent({ isolation: "worktree" })` is blocked by git-crypt smudge filter in this repo — see `claude/AGENTS.md` ("Known Pitfall: Agent isolation + git-crypt") and `docs/learnings/git-crypt-worktree-bootstrap.md`.
 - **Maintenance**: Update AGENTS.md when adding new modules.
 
 # Context Map

--- a/claude/skills/ai-worktree-spawn/SKILL.md
+++ b/claude/skills/ai-worktree-spawn/SKILL.md
@@ -56,13 +56,16 @@ Priority: `--base` arg > `origin/main` > `main`/`master` > current HEAD.
 git-crypt detection happens in Step 1.5. When active, resolve a key file via priority:
 `$GIT_CRYPT_KEY_FILE` > `~/.config/git-crypt/<project>.key` > `~/.config/git-crypt/default.key`.
 
-- **Key found (auto-unlock path)**: `git worktree add --no-checkout` first, then
-  `git-crypt unlock <key>` inside the new worktree, then `git checkout -- .`.
-  Encrypted files (`.env`, `.secrets/`) decrypt normally — full functionality.
+- **Key found (auto-unlock path)**: 4-step sequence — bypass-checkout (clean
+  ciphertext), worktree-local temp bypass, `git-crypt unlock <key>`, then
+  restore filter to git-crypt. Encrypted files (`.env`, `.secrets/`) decrypt
+  normally. **Caveat**: `git status` may show git-crypt files as `M` after
+  unlock (raw byte vs. textconv mismatch) — use explicit `git add <path>`,
+  never `-A` / `.` in auto-unlocked worktrees.
 - **Key not found (bypass path, backward-compatible)**: pass `-c filter.git-crypt.smudge=cat
   -c filter.git-crypt.clean=cat` to `git worktree add`, set worktree-local config
-  to disable filters permanently. Encrypted files stay binary. Print a hint about
-  `git-crypt export-key ~/.config/git-crypt/<project>.key` so next spawn can unlock.
+  to disable filters permanently. Encrypted files stay binary. Print hint:
+  run `gc-export-key` from main repo so next spawn can auto-unlock.
 
 If branch exists: `git worktree add <path> <branch>` (no `-b`).
 If new branch: `git worktree add -b <branch> <path> <base_ref>`.

--- a/claude/skills/ai-worktree-spawn/SKILL.md
+++ b/claude/skills/ai-worktree-spawn/SKILL.md
@@ -53,9 +53,16 @@ Priority: `--base` arg > `origin/main` > `main`/`master` > current HEAD.
 
 ### Step 6: Create Worktree
 
-Detect git-crypt first. If the repo uses git-crypt, pass `-c filter.git-crypt.smudge=cat
--c filter.git-crypt.clean=cat` to `git worktree add` to prevent smudge filter failure.
-After creation, set worktree-local config to disable git-crypt filters permanently.
+git-crypt detection happens in Step 1.5. When active, resolve a key file via priority:
+`$GIT_CRYPT_KEY_FILE` > `~/.config/git-crypt/<project>.key` > `~/.config/git-crypt/default.key`.
+
+- **Key found (auto-unlock path)**: `git worktree add --no-checkout` first, then
+  `git-crypt unlock <key>` inside the new worktree, then `git checkout -- .`.
+  Encrypted files (`.env`, `.secrets/`) decrypt normally — full functionality.
+- **Key not found (bypass path, backward-compatible)**: pass `-c filter.git-crypt.smudge=cat
+  -c filter.git-crypt.clean=cat` to `git worktree add`, set worktree-local config
+  to disable filters permanently. Encrypted files stay binary. Print a hint about
+  `git-crypt export-key ~/.config/git-crypt/<project>.key` so next spawn can unlock.
 
 If branch exists: `git worktree add <path> <branch>` (no `-b`).
 If new branch: `git worktree add -b <branch> <path> <base_ref>`.
@@ -73,7 +80,7 @@ Print result, then `cd` into the new worktree:
   Path:   ../my-app-claude-1
   Branch: wt/claude/1
   Base:   origin/main
-  git-crypt: disabled (encrypted files not decrypted)
+  git-crypt: unlocked via ~/.config/git-crypt/my-app.key
 
   Teardown after work is done:
     git push -u origin wt/claude/1
@@ -81,7 +88,9 @@ Print result, then `cd` into the new worktree:
     git branch -d wt/claude/1
 ```
 
-The `git-crypt` line only appears when the repo uses git-crypt.
+The `git-crypt` line only appears when the repo uses git-crypt. It shows either
+`unlocked via <key path>` (auto-unlock path) or `disabled (no key file)` (bypass
+path). When bypassed, the report also prints the `git-crypt export-key` hint.
 
 The script cannot change the caller's cwd. Print the `cd` command as guidance,
 then execute it yourself as the AI agent.

--- a/claude/skills/ai-worktree-spawn/references/bash-commands.md
+++ b/claude/skills/ai-worktree-spawn/references/bash-commands.md
@@ -53,18 +53,35 @@ detect_ai_agent() {
 AGENT="$(detect_ai_agent "${AGENT_OVERRIDE:-}")"
 ```
 
-## Step 1.5: Detect git-crypt
+## Step 1.5: Detect git-crypt and resolve key file
 
 ```bash
-# Check if repo uses git-crypt by looking for .gitattributes filter entries
+# Check if repo uses git-crypt
 GIT_CRYPT_ACTIVE=false
 if git config --get filter.git-crypt.smudge >/dev/null 2>&1; then
   GIT_CRYPT_ACTIVE=true
 fi
 
-# Build git-crypt bypass flags for worktree creation
-GIT_CRYPT_FLAGS=()
+# Resolve git-crypt key file via priority chain
+# 1) $GIT_CRYPT_KEY_FILE  2) ~/.config/git-crypt/<project>.key  3) ~/.config/git-crypt/default.key
+GIT_CRYPT_KEY=""
+PROJECT_NAME="$(basename "$(git rev-parse --show-toplevel)")"
 if [[ "$GIT_CRYPT_ACTIVE" == true ]]; then
+  for candidate in \
+    "${GIT_CRYPT_KEY_FILE:-}" \
+    "${HOME}/.config/git-crypt/${PROJECT_NAME}.key" \
+    "${HOME}/.config/git-crypt/default.key"; do
+    if [[ -n "$candidate" && -r "$candidate" ]]; then
+      GIT_CRYPT_KEY="$candidate"
+      break
+    fi
+  done
+fi
+
+# Bypass flags ONLY when git-crypt is active AND no key file resolved.
+# When a key is found, auto-unlock path runs in Step 6 instead.
+GIT_CRYPT_FLAGS=()
+if [[ "$GIT_CRYPT_ACTIVE" == true && -z "$GIT_CRYPT_KEY" ]]; then
   GIT_CRYPT_FLAGS=(-c filter.git-crypt.smudge=cat -c filter.git-crypt.clean=cat)
 fi
 ```
@@ -193,24 +210,46 @@ BASE_REF="$(resolve_base_ref "${BASE_OVERRIDE:-}")"
 ## Step 6: Create Worktree
 
 ```bash
-# Use GIT_CRYPT_FLAGS from Step 1.5 (empty array if no git-crypt)
-if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
-    # Existing branch -- no -b flag
-    git "${GIT_CRYPT_FLAGS[@]}" worktree add "${WORKTREE_PATH}" "${BRANCH}"
-else
-    # New branch -- create with -b
-    git "${GIT_CRYPT_FLAGS[@]}" worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
-fi
+# GIT_CRYPT_REPORT is consumed by Step 8 (skill report).
+GIT_CRYPT_REPORT=""
 
-# If git-crypt is active, disable filters in the new worktree permanently.
-# Encrypted files (.env, .secrets) stay as binary -- this is intentional.
-# The worktree is for code work; secrets are not needed.
-if [[ "$GIT_CRYPT_ACTIVE" == true ]]; then
-    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge cat
-    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
-    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
-    # Re-checkout so worktree-local config takes effect cleanly
-    git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null
+if [[ "$GIT_CRYPT_ACTIVE" == true && -n "$GIT_CRYPT_KEY" ]]; then
+    # ---- Auto-unlock path: --no-checkout, then unlock, then real checkout ----
+    if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+        git worktree add --no-checkout "${WORKTREE_PATH}" "${BRANCH}"
+    else
+        git worktree add --no-checkout -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
+    fi
+
+    # Run git-crypt unlock inside the new worktree (subshell preserves caller cwd).
+    if (cd "${WORKTREE_PATH}" && git-crypt unlock "${GIT_CRYPT_KEY}"); then
+        # Smudge filter now has the key; checkout decrypts encrypted files normally.
+        git -C "${WORKTREE_PATH}" checkout -- .
+        GIT_CRYPT_REPORT="unlocked via ${GIT_CRYPT_KEY}"
+    else
+        # Unlock failed -- fall through to bypass so worktree is at least usable.
+        echo "Warning: git-crypt unlock failed with ${GIT_CRYPT_KEY}; switching to bypass"
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge cat
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
+        git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null
+        GIT_CRYPT_REPORT="disabled (unlock failed; encrypted files stay binary)"
+    fi
+else
+    # ---- Bypass path (no git-crypt, or git-crypt active but no key file) ----
+    if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+        git "${GIT_CRYPT_FLAGS[@]}" worktree add "${WORKTREE_PATH}" "${BRANCH}"
+    else
+        git "${GIT_CRYPT_FLAGS[@]}" worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
+    fi
+    if [[ "$GIT_CRYPT_ACTIVE" == true ]]; then
+        # Make bypass permanent in the worktree.
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge cat
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
+        git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null
+        GIT_CRYPT_REPORT="disabled (no key; run from main repo: git-crypt export-key ~/.config/git-crypt/${PROJECT_NAME}.key)"
+    fi
 fi
 ```
 

--- a/claude/skills/ai-worktree-spawn/references/bash-commands.md
+++ b/claude/skills/ai-worktree-spawn/references/bash-commands.md
@@ -214,25 +214,35 @@ BASE_REF="$(resolve_base_ref "${BASE_OVERRIDE:-}")"
 GIT_CRYPT_REPORT=""
 
 if [[ "$GIT_CRYPT_ACTIVE" == true && -n "$GIT_CRYPT_KEY" ]]; then
-    # ---- Auto-unlock path: --no-checkout, then unlock, then real checkout ----
+    # ---- Auto-unlock path: 4-step sequence ----
+    # Step 1: worktree add WITH command-level smudge bypass.
+    # Why not --no-checkout: git-crypt unlock runs `git status` and rejects if
+    # working tree is "not clean"; an empty (--no-checkout) worktree counts as
+    # "all tracked files deleted" and unlock aborts. So we checkout ciphertext
+    # cleanly first, then have unlock decrypt in place.
     if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
-        git worktree add --no-checkout "${WORKTREE_PATH}" "${BRANCH}"
+        git -c filter.git-crypt.smudge=cat -c filter.git-crypt.clean=cat \
+            worktree add "${WORKTREE_PATH}" "${BRANCH}"
     else
-        git worktree add --no-checkout -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
+        git -c filter.git-crypt.smudge=cat -c filter.git-crypt.clean=cat \
+            worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "${BASE_REF}"
     fi
 
-    # Run git-crypt unlock inside the new worktree (subshell preserves caller cwd).
+    # Step 2: worktree-local TEMPORARY bypass so unlock's git-status check passes.
+    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge cat
+    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
+    git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
+
+    # Step 3: git-crypt unlock -- decrypts working tree + stores key in worktree GIT_DIR.
     if (cd "${WORKTREE_PATH}" && git-crypt unlock "${GIT_CRYPT_KEY}"); then
-        # Smudge filter now has the key; checkout decrypts encrypted files normally.
-        git -C "${WORKTREE_PATH}" checkout -- .
+        # Step 4: RESTORE filter to git-crypt so future commits encrypt properly.
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge "git-crypt smudge"
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean "git-crypt clean"
+        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required true
         GIT_CRYPT_REPORT="unlocked via ${GIT_CRYPT_KEY}"
     else
-        # Unlock failed -- fall through to bypass so worktree is at least usable.
-        echo "Warning: git-crypt unlock failed with ${GIT_CRYPT_KEY}; switching to bypass"
-        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.smudge cat
-        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
-        git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
-        git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null
+        # Unlock failed -- temp bypass from step 2 stays; worktree usable as binary.
+        echo "Warning: git-crypt unlock failed with ${GIT_CRYPT_KEY}; staying on bypass"
         GIT_CRYPT_REPORT="disabled (unlock failed; encrypted files stay binary)"
     fi
 else
@@ -248,7 +258,7 @@ else
         git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.clean cat
         git -C "${WORKTREE_PATH}" config --worktree filter.git-crypt.required false
         git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null
-        GIT_CRYPT_REPORT="disabled (no key; run from main repo: git-crypt export-key ~/.config/git-crypt/${PROJECT_NAME}.key)"
+        GIT_CRYPT_REPORT="disabled (no key; run from main repo: gc-export-key)"
     fi
 fi
 ```

--- a/claude/skills/ai-worktree-spawn/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-spawn/references/options-and-errors.md
@@ -26,4 +26,23 @@ command) and stop without creating anything.
 | Parent dir not writable | Print error, stop |
 | Lock acquisition failed (3 retries) | Print error, stop |
 | Stale lock (age > 10s) | Auto-remove lock, retry |
-| git-crypt active in repo | Auto-bypass: create worktree with filter disabled, encrypted files stay as binary |
+| git-crypt active + key file resolved | Auto-unlock: `--no-checkout` + `git-crypt unlock <key>` + `checkout` (encrypted files decrypt normally) |
+| git-crypt active + no key file | Bypass: create worktree with filter disabled (encrypted files stay as binary), print `git-crypt export-key` hint |
+| git-crypt active + unlock fails | Fall back to bypass, log warning |
+
+## git-crypt Key File Resolution
+
+When the repo uses git-crypt, the spawn step searches for a symmetric key file in this order:
+
+1. `$GIT_CRYPT_KEY_FILE` environment variable (if set and readable)
+2. `~/.config/git-crypt/<project-name>.key` where `<project-name>` is `basename` of the repo
+3. `~/.config/git-crypt/default.key`
+
+To produce a key file from an unlocked main repo:
+
+```bash
+git-crypt export-key ~/.config/git-crypt/<project-name>.key
+chmod 600 ~/.config/git-crypt/<project-name>.key
+```
+
+Treat this key file like a private credential: never commit it, never share over insecure channels.

--- a/claude/skills/ai-worktree-spawn/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-spawn/references/options-and-errors.md
@@ -26,9 +26,9 @@ command) and stop without creating anything.
 | Parent dir not writable | Print error, stop |
 | Lock acquisition failed (3 retries) | Print error, stop |
 | Stale lock (age > 10s) | Auto-remove lock, retry |
-| git-crypt active + key file resolved | Auto-unlock: `--no-checkout` + `git-crypt unlock <key>` + `checkout` (encrypted files decrypt normally) |
-| git-crypt active + no key file | Bypass: create worktree with filter disabled (encrypted files stay as binary), print `git-crypt export-key` hint |
-| git-crypt active + unlock fails | Fall back to bypass, log warning |
+| git-crypt active + key file resolved | Auto-unlock 4-step: bypass-checkout → temp bypass config → `git-crypt unlock <key>` → restore filter to git-crypt (encrypted files decrypt normally) |
+| git-crypt active + no key file | Bypass: create worktree with filter disabled (encrypted files stay as binary), print `gc-export-key` hint |
+| git-crypt active + unlock fails | Stay on temp bypass config, log warning, encrypted files stay binary |
 
 ## git-crypt Key File Resolution
 
@@ -38,11 +38,37 @@ When the repo uses git-crypt, the spawn step searches for a symmetric key file i
 2. `~/.config/git-crypt/<project-name>.key` where `<project-name>` is `basename` of the repo
 3. `~/.config/git-crypt/default.key`
 
-To produce a key file from an unlocked main repo:
+To produce a key file from an unlocked main repo, use the helper that handles
+the standard path and 0600 mode automatically:
 
 ```bash
-git-crypt export-key ~/.config/git-crypt/<project-name>.key
-chmod 600 ~/.config/git-crypt/<project-name>.key
+gc-export-key                  # writes ~/.config/git-crypt/<project-name>.key
+```
+
+Or call git-crypt directly if you want a custom path:
+
+```bash
+git-crypt export-key /custom/path/keyfile
+chmod 600 /custom/path/keyfile
 ```
 
 Treat this key file like a private credential: never commit it, never share over insecure channels.
+
+## Auto-Unlock Caveat: status appears dirty
+
+After auto-unlock, `git status` in the new worktree may list every git-crypt
+file as `M` (modified). `git diff` against those same files is empty (textconv
+comparison sees identical plaintext). The discrepancy comes from git comparing
+raw bytes: clean-filter output of the worktree's plaintext vs. the index's
+ciphertext. They are functionally equivalent (same plaintext after decrypt) but
+not byte-identical, likely due to a key-storage encoding difference between the
+main repo's `git-crypt/keys/default` and the per-worktree GIT_DIR copy.
+
+**Implication for AI agents and humans alike**: do NOT use `git add -A` /
+`git add .` in an auto-unlocked worktree — git-crypt files would be staged with
+re-encoded ciphertext that differs from the main repo's. Always use explicit
+`git add <path>` for the files you actually changed.
+
+If you accidentally stage a git-crypt file, run `git restore --staged <path>`
+to unstage. The actual encrypted content has not changed — verify with
+`git diff --cached` (textconv comparison shows no plaintext change).

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -541,17 +541,30 @@ git_worktree_spawn() {
         fi
     done
 
-    local wt_path="${parent}/${project}-${name}-${next_index}"
-
-    # Branch name
-    local branch
+    # Branch name + path must both be unique. A previous teardown may leave a
+    # branch (e.g., --keep-branch), so don't rely on directory scan alone.
+    local wt_path branch slug=""
     if [ -n "$task" ]; then
-        local slug
         slug=$(printf '%s' "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-30)
-        branch="wt/${name}/${next_index}-${slug}"
-    else
-        branch="wt/${name}/${next_index}"
     fi
+    while :; do
+        wt_path="${parent}/${project}-${name}-${next_index}"
+        if [ -n "$slug" ]; then
+            branch="wt/${name}/${next_index}-${slug}"
+        else
+            branch="wt/${name}/${next_index}"
+        fi
+
+        if [ -d "$wt_path" ]; then
+            next_index=$((next_index + 1))
+            continue
+        fi
+        if git rev-parse --verify --quiet "refs/heads/${branch}" >/dev/null 2>&1; then
+            next_index=$((next_index + 1))
+            continue
+        fi
+        break
+    done
 
     # Base ref
     if [ -z "$base" ]; then

--- a/shell-common/tools/custom/gc_help.sh
+++ b/shell-common/tools/custom/gc_help.sh
@@ -18,6 +18,7 @@ main() {
     ux_bullet "gc-push           : .env 파일 암호화 & 한 번에 push"
     ux_bullet "gc-backup         : GPG 개인키 백업 (GitHub에 안전하게 업로드)"
     ux_bullet "gc-restore        : GPG 개인키 복원"
+    ux_bullet "gc-export-key     : git-crypt symmetric key export (ai-worktree-spawn 자동 unlock용)"
     ux_bullet "gc-unlock         : git-crypt unlock (저장소 복호화)"
     ux_bullet "gc-lock           : git-crypt lock (저장소 암호화)"
     ux_bullet "gc-status         : git-crypt 상태 확인"

--- a/shell-common/tools/integrations/git_crypt.sh
+++ b/shell-common/tools/integrations/git_crypt.sh
@@ -56,6 +56,7 @@ alias gc-purge='gc_purge_cache'
 alias gc-add-me='gc_addme'
 alias gc-backup='gc_backup_key'
 alias gc-restore='gc_restore_key'
+alias gc-export-key='gc_export_key'
 alias gc-new-pc='gc_setup_new_pc'
 alias gc-push='gc_push_env'
 
@@ -811,6 +812,64 @@ gc_restore_key() {
         if [[ "$backup_file" == /tmp/* ]]; then
             rm -f "$backup_file"
         fi
+        return 1
+    fi
+}
+
+# git-crypt symmetric key를 ai-worktree-spawn 표준 위치로 export
+# 주의: gc-backup(GPG 개인키 백업)과 다름. 이 키는 git-crypt 자체 키.
+gc_export_key() {
+    local project_name
+    local key_path
+    local default_path
+
+    if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+        ux_error "Git 리포지토리가 아닙니다."
+        return 1
+    fi
+
+    if ! command -v git-crypt &>/dev/null; then
+        ux_error "git-crypt이 설치되어 있지 않습니다."
+        ux_info "설치: gc-install"
+        return 1
+    fi
+
+    if ! git-crypt status &>/dev/null; then
+        ux_error "git-crypt이 초기화되지 않았거나 unlocked 상태가 아닙니다."
+        ux_info "확인: gc-check, gc-status"
+        return 1
+    fi
+
+    project_name="$(basename "$(git rev-parse --show-toplevel)")"
+    default_path="${HOME}/.config/git-crypt/${project_name}.key"
+    key_path="${1:-$default_path}"
+
+    ux_header "git-crypt symmetric key export"
+    ux_info "Project : ${project_name}"
+    ux_info "Key path: ${key_path}"
+    echo ""
+
+    if [[ -f "$key_path" ]]; then
+        ux_warning "이미 키 파일이 존재합니다: ${key_path}"
+        if ! ux_confirm "덮어쓸까요?" "n"; then
+            ux_info "취소됨."
+            return 1
+        fi
+    fi
+
+    mkdir -p "$(dirname "$key_path")"
+
+    if git-crypt export-key "$key_path"; then
+        chmod 600 "$key_path"
+        ux_success "키 export 완료: ${key_path} (mode 0600)"
+        echo ""
+        ux_section "사용처"
+        ux_bullet "ai-worktree:spawn — 새 worktree에서 .env 자동 unlock"
+        ux_bullet "다른 PC로 옮길 때: 안전한 채널(USB, 1Password 등)로만 전송"
+        echo ""
+        ux_warning "절대 git에 commit하거나 클라우드/이메일에 업로드 금지"
+    else
+        ux_error "키 export 실패"
         return 1
     fi
 }

--- a/shell-common/tools/integrations/git_crypt.sh
+++ b/shell-common/tools/integrations/git_crypt.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-# shell-common/tools/external/git_crypt.sh
-# Git-crypt helper - shared across bash and zsh
+#!/bin/sh
+# shell-common/tools/integrations/git_crypt.sh
+# Git-crypt helper - shared across bash and zsh (sourced, not executed)
 
 : <<'GIT_CRYPT_DOC'
 ==========================================================

--- a/shell-common/tools/integrations/git_crypt.sh
+++ b/shell-common/tools/integrations/git_crypt.sh
@@ -828,15 +828,20 @@ gc_export_key() {
         return 1
     fi
 
-    if ! command -v git-crypt &>/dev/null; then
-        ux_error "git-crypt이 설치되어 있지 않습니다."
+    if ! ux_require "git-crypt" "git-crypt이 설치되어 있지 않습니다."; then
         ux_info "설치: gc-install"
         return 1
     fi
 
     if ! git-crypt status &>/dev/null; then
-        ux_error "git-crypt이 초기화되지 않았거나 unlocked 상태가 아닙니다."
+        ux_error "git-crypt이 초기화되지 않았습니다."
         ux_info "확인: gc-check, gc-status"
+        return 1
+    fi
+
+    if ! git-crypt export-key /dev/null &>/dev/null; then
+        ux_error "git-crypt이 locked 상태입니다."
+        ux_info "실행: gc-unlock"
         return 1
     fi
 
@@ -859,7 +864,7 @@ gc_export_key() {
 
     mkdir -p "$(dirname "$key_path")"
 
-    if git-crypt export-key "$key_path"; then
+    if (umask 077 && git-crypt export-key "$key_path"); then
         chmod 600 "$key_path"
         ux_success "키 export 완료: ${key_path} (mode 0600)"
         echo ""

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -7,11 +7,26 @@
 
 load '../test_helper'
 
+_setup_fake_main_repo() {
+    FAKE_REPO="$TEST_TEMP_HOME/fake-main"
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+    git init -q --initial-branch=main "$FAKE_REPO"
+    (
+        cd "$FAKE_REPO"
+        echo base >base.txt
+        git add base.txt
+        git commit -q -m base
+    )
+}
+
 setup() {
     setup_isolated_home
+    _setup_fake_main_repo
 }
 
 teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
     teardown_isolated_home
 }
 
@@ -59,4 +74,18 @@ teardown() {
     run_in_zsh 'git_worktree_spawn --help'
     assert_success
     assert_output --partial "--agent"
+}
+
+@test "bash: spawn auto-increments when branch exists without worktree" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        git branch wt/feat/1
+        git_worktree_spawn feat 2>&1
+        git show-ref --verify --quiet refs/heads/wt/feat/2 && echo BRANCH2_OK
+        [ -d '$TEST_TEMP_HOME/fake-main-feat-2' ] && echo PATH2_OK
+    "
+    assert_success
+    assert_output --partial "Branch: wt/feat/2"
+    assert_output --partial "BRANCH2_OK"
+    assert_output --partial "PATH2_OK"
 }


### PR DESCRIPTION
## Summary
- AI worktree spawn 시 git-crypt 활성 repo 에서 키 파일이 있으면 자동 unlock 하여 `.env` / `.secrets/` 등 암호화된 파일을 평문으로 사용 가능하게 함 (Issue #153 의 단기 + 장기 목표 모두 해소).
- `gc-export-key` helper 추가로 키 파일 표준 위치로 export 한 번에 처리.
- `--no-checkout` + unlock 흐름의 fundamental 한계를 발견하고 검증된 4-step 흐름으로 교체.

## Changes
- **`docs(agents)`** — 루트 `AGENTS.md` 에 git-crypt + worktree 우회 안내 한 줄 추가 (`claude/AGENTS.md` 의 "Known Pitfall" 섹션과 `docs/learnings/git-crypt-worktree-bootstrap.md` 포인터). 100줄 제한 준수 (92→93).
- **`feat(ai-worktree-spawn)`** — `SKILL.md` Step 6 / Step 8 에 키 파일 resolution + auto-unlock 분기 추가. `references/bash-commands.md` Step 1.5 / Step 6 코드 구현. Backward-compatible: 키가 없으면 기존 smudge=cat bypass 동작 유지.
- **`chore(git-crypt)`** — `shell-common/tools/integrations/git_crypt.sh` shebang 을 `#!/bin/sh` 로 정렬 (다른 integrations 와 일관, shebang_check 훅 위반 해소). source 되는 파일이라 functional impact 없음.
- **`feat(git-crypt)`** — `gc_export_key` 함수 + `gc-export-key` alias 추가. 기본 경로 `~/.config/git-crypt/<project>.key` 로 export, mode 0600 강제. `gc_help.sh` 에 alias 노출.
- **`fix(ai-worktree-spawn)`** — 검증 중 `--no-checkout` → unlock 흐름이 git-crypt 의 "working tree not clean" 검증으로 fail 함을 발견. 검증된 4-step 흐름으로 교체:
  1. `git -c filter.git-crypt.smudge=cat -c filter.git-crypt.clean=cat worktree add ...` (clean ciphertext checkout)
  2. worktree-local 일시 bypass config (unlock 의 git-status 검증 통과)
  3. `git-crypt unlock <key>` (working tree decrypt + 키를 worktree GIT_DIR 에 저장)
  4. worktree-local filter 를 `git-crypt smudge`/`clean` 으로 정상화 (향후 commit ciphertext 보장)

## Auto-Unlock Caveat (docs 에 명시)

새 worktree 에서 `git status` 가 git-crypt 파일을 `M` 으로 표시할 수 있음 (raw byte vs. textconv 비교 차이, root cause 는 main 의 `.git/git-crypt/keys/default` 와 worktree GIT_DIR 의 키 인코딩 차이로 추정). `git diff` 는 비어 있어 functional 영향 없으나, **`git add -A` / `git add .` 사용 금지** — 명시적 path 만 add. `references/options-and-errors.md` 의 "Auto-Unlock Caveat" 섹션 참고.

## Test plan
- [x] `gc-export-key` 가 `~/.config/git-crypt/<project>.key` 를 mode 0600 으로 생성 (검증됨: dotfiles repo 에서 148 bytes 키 생성)
- [x] 새 worktree 에서 `.env` 평문으로 unlock (검증됨: `/tmp/dotfiles-wt-test-*` 에서 1209 bytes plaintext, GITCRYPT magic 없음)
- [x] worktree-local filter 가 unlock 후 `git-crypt smudge`/`clean` 으로 정상화 (검증됨)
- [ ] PR merge 후 새 Claude session 에서 `Agent({ isolation: "worktree" })` 끝까지 PASS 확인 (실측 시점)
- [ ] 다른 PC (External/Work) 에서 setup 후 `gc-export-key` 한 번 실행하면 worktree spawn 정상 동작 확인

## Related
Closes #153

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
