### PR TITLE
docs: gh-issue-implement --no-next-hint 옵션 명시

### DIFF
--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -23,7 +23,7 @@ output its content verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Repo + Preconditions
 
-Positional args: `<issue-number> [mode] [remote]`.
+Positional args: `<issue-number> [mode] [remote]`. Optional flag: `--no-next-hint`.
 
 - `issue-number` — required, positive integer.
 - `mode` — default `direct`. Must be `direct`, `plan`, or `brainstorming`.

--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -9,7 +9,8 @@ description: >-
   modes invoke the matching superpowers skills when the plugin is
   installed (falls back to direct with a warning if not). Precondition:
   user is already inside a dedicated git worktree on a feature branch.
-  Accepts `<issue-number> [direct|plan|brainstorming] [remote]` and
+  Accepts `<issue-number> [direct|plan|brainstorming] [remote]`,
+  optional `--no-next-hint` (suppress final `Next:` hint), and
   `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 ---
@@ -31,6 +32,8 @@ Positional args: `<issue-number> [mode] [remote]`. Optional flag: `--no-next-hin
   `git remote get-url <remote>`. Missing remote → list `git remote -v`
   and stop (no silent fallback to `origin`). Substeps in
   `references/repo-resolution.md`.
+- `--no-next-hint` — optional flag. When present, omit the final
+  `Next:` guidance line in Step 6 output.
 
 Check preconditions in parallel (exact rules in
 `references/implementation-flow.md` → "Preconditions"):
@@ -96,7 +99,7 @@ Use the direct-mode flow in `references/implementation-flow.md`:
 Print the success or failure report per
 `references/implementation-flow.md` → "Final report format". Always
 include the `Next:` hint pointing to `gh:commit` / `gh:pr` /
-`gh:issue-flow`.
+`gh:issue-flow`, unless `--no-next-hint` is set.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- `claude/skills/gh-issue-implement/SKILL.md` Step 1 인자 설명에 optional flag `--no-next-hint`를 명시했습니다.
- 문서와 실제 사용 인자 표기를 일치시켰습니다.

## Changes
- Positional args 문구를 다음으로 보강
  - before: `<issue-number> [mode] [remote]`
  - after: `<issue-number> [mode] [remote]`. Optional flag: `--no-next-hint`.

Closes #209

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<!-- /ai-metrics -->
