### PR TITLE
fix(gwt): improve teardown UX for submodule-blocked removal

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -889,6 +889,11 @@ _gwt_teardown_one_inplace() {
     fi
 
     if [ "$_gwt_rm_exit" -ne 0 ]; then
+        local _gwt_submodule_blocked=false
+        if grep -q "working trees containing submodules cannot be moved or removed" "$_gwt_rm_err_file" 2>/dev/null; then
+            _gwt_submodule_blocked=true
+        fi
+
         if [ "$force" = true ]; then
             ux_error "Failed to remove worktree: $wt_path"
         else
@@ -897,6 +902,24 @@ _gwt_teardown_one_inplace() {
         if [ -s "$_gwt_rm_err_file" ]; then
             ux_info "  git says:"
             sed 's/^/    /' "$_gwt_rm_err_file" >&2
+        fi
+        if [ "$_gwt_submodule_blocked" = true ]; then
+            ux_warning "  Git blocked removal because this worktree contains submodule(s)."
+            local _gwt_submodule_paths _gwt_submodule_path _gwt_submodule_count=0
+            _gwt_submodule_paths="$(git -C "$wt_path" config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')"
+            if [ -n "$_gwt_submodule_paths" ]; then
+                ux_info "  Submodules in this repository:"
+                while IFS= read -r _gwt_submodule_path; do
+                    [ -n "$_gwt_submodule_path" ] || continue
+                    ux_info "    - $_gwt_submodule_path"
+                    _gwt_submodule_count=$((_gwt_submodule_count + 1))
+                    [ "$_gwt_submodule_count" -ge 3 ] && break
+                done <<EOF
+$_gwt_submodule_paths
+EOF
+            fi
+            ux_info "  If worktree-local submodule state is disposable:"
+            ux_info "    gwt teardown --force"
         fi
         if [ "$force" != true ]; then
             ux_info "  Inspect:  git status --short"

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -282,6 +282,42 @@ _squash_merge_branch_into_origin_main() {
     git -C "$CLONE" worktree unlock "$WORKTREE" 2>/dev/null || true
 }
 
+@test "teardown: submodule block explains cause and suggests force" {
+    local sub_origin="$TEST_TEMP_HOME/sub-origin.git"
+    local sub_seed="$TEST_TEMP_HOME/sub-seed"
+    local sub_wt="$TEST_TEMP_HOME/clone-submodule-1"
+
+    git init --bare --initial-branch=main "$sub_origin" >/dev/null
+    git clone -q "$sub_origin" "$sub_seed"
+    (
+        cd "$sub_seed"
+        echo sub > sub.txt
+        git add sub.txt
+        git commit -q -m "sub-base"
+        git push -q origin main
+    )
+    rm -rf "$sub_seed"
+
+    (
+        cd "$CLONE"
+        git checkout -q main
+        git -c protocol.file.allow=always submodule add "$sub_origin" tests/bats/lib/bats-core >/dev/null
+        git commit -q -m "add test submodule"
+        git push -q origin main
+    )
+
+    git -C "$CLONE" worktree add -q -b wt/submodule/1 "$sub_wt" origin/main
+    git -C "$sub_wt" -c protocol.file.allow=always submodule update --init --recursive >/dev/null
+
+    run_in_bash "cd '$sub_wt' && gwt teardown 2>&1"
+    assert_failure
+    assert_output --partial "working trees containing submodules cannot be moved or removed"
+    assert_output --partial "Git blocked removal because this worktree contains submodule"
+    assert_output --partial "Submodules in this repository:"
+    assert_output --partial "tests/bats/lib/bats-core"
+    assert_output --partial "gwt teardown --force"
+}
+
 @test "teardown: on failure, cwd stays in the worktree (not main repo)" {
     # Same locked-worktree scenario as above. After teardown fails, the shell
     # should still be inside $WORKTREE so the user can `git status` without


### PR DESCRIPTION
## Summary
- detect submodule-specific git worktree removal failure message
- print clearer UX guidance that this is a Git submodule constraint
- surface submodule paths from `.gitmodules` (up to 3) when available
- add a bats test covering submodule-blocked teardown

## Verification
- `tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_teardown.bats`
- `tox -e shellcheck -- shell-common/functions/git_worktree.sh`

Closes #211

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
