### PR TITLE
Add --ai runner selection for gh-flow workers

### DIFF
--- a/docs/feature/gh-flow-automation/design.md
+++ b/docs/feature/gh-flow-automation/design.md
@@ -27,7 +27,7 @@ N개 이슈를 동시에 처리할 때 이 전 과정을 반복해야 해 집중
 ## 2. 목표 / 비목표
 
 ### 목표
-- 한 커맨드 `gh-flow <N> [<N2> ...]` 로 N개 이슈를 **병렬**로 전과정 자동화
+- 한 커맨드 `gh-flow <N> [<N2> ...] [--ai <claude|codex|gemini>]` 로 N개 이슈를 **병렬**로 전과정 자동화
 - **Fire-and-forget** — 커맨드 치고 자리 떠나도 됨, 결과는 칸반 보드에서 확인
 - 리뷰 대기 중 claude 세션 **0개** 유지 (토큰/메모리 소모 없음)
 - 실패 **격리** — 한 worker가 깨져도 다른 N-1개는 계속 진행
@@ -57,13 +57,13 @@ N개 이슈를 동시에 처리할 때 이 전 과정을 반복해야 해 집중
 각 worker 생명주기:
   1. gwt spawn issue-<N>
   2. cd <worktree>
-  3. claude -p "/gh-issue-flow <N>"          # implement → commit → PR
+  3. <ai-runner> -p|exec "/gh-issue-flow <N>" # implement → commit → PR
   4. poll 루프 (60s 간격):
        · gh pr view --json reviewDecision
        · APPROVED → loop 탈출
-       · 리뷰 코멘트 존재 AND reply 미수행 → claude -p "/gh-pr-reply" 1회 실행
+       · 리뷰 코멘트 존재 AND reply 미수행 → <ai-runner> "/gh-pr-reply" 1회 실행
        · 그 외: 계속 polling
-  5. claude -p "/gh-pr-merge"
+  5. <ai-runner> "/gh-pr-merge"
   6. gwt teardown
   7. exit
 
@@ -87,17 +87,21 @@ N개 이슈를 동시에 처리할 때 이 전 과정을 반복해야 해 집중
 POSIX 쉘 파일. bash/zsh에서 sourcing됨. 다음을 정의:
 
 - **`gh-flow`** (함수): 오케스트레이터
-  - Args: `<issue-number>... | -h|--help`
+  - Args: `<issue-number>... [--ai <claude|codex|gemini>] | -h|--help`
   - 전제: 메인 repo 내부 (worktree 아님), `gh` 인증됨
   - 동작: 각 이슈에 대해 `_gh_flow_worker`를 `nohup bash -c '...' &` 로 fork + `disown`
   - 출력: `ux_info "Spawned worker for #13 (pid=12345, log=...)"` 를 N번
   - 종료: 즉시 (백그라운드 워커는 살아있음)
+  - 기본 실행 주체: `claude` (옵션 미지정 시)
 
 - **`_gh_flow_worker`** (함수): worker 본체
   - Args: `<issue-number>`
   - 호출 경로: nohup된 서브셸이 `gh_flow.sh`를 source한 뒤 이 함수 호출
   - 단계별 실패 시 `state` 파일에 `failed:<step>` 쓰고 비정상 종료 (worktree 안 지움)
-  - 각 claude 호출은 `claude --dangerously-skip-permissions -p "<slash-command>"` 형태
+- 실행 주체별 호출 규칙:
+  - `claude` → `claude --dangerously-skip-permissions -p "<slash-command>"`
+  - `codex` → `codex exec --dangerously-bypass-approvals-and-sandbox "<slash-command>"`
+  - `gemini` → `gemini --yolo -p "<slash-command>"`
 
 - **`_gh_flow_poll_reviews`** (헬퍼 함수): PR 리뷰 상태 조회
   - Args: `<pr-number>`
@@ -230,6 +234,8 @@ docs/feature/gh-flow-automation/design.md  # 본 문서
 # 기본
 gh-flow 13                    # 단일 이슈
 gh-flow 13 42 88              # 3개 병렬
+gh-flow 33 --ai codex         # codex 실행
+gh-flow --ai gemini 44        # gemini 실행
 
 # 옵션
 gh-flow --help                # 도움말

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -67,6 +67,62 @@ _gh_flow_has_branch_commits() {
     [ "${_count:-0}" -gt 0 ]
 }
 
+# Returns 0 if the ai runner is one of: claude, codex, gemini.
+_gh_flow_known_ai() {
+    case "$1" in
+    claude | codex | gemini) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# Ensure the selected ai CLI exists in PATH.
+_gh_flow_require_ai_cli() {
+    case "$1" in
+    claude)
+        if ! _have claude; then
+            ux_error "claude CLI not found"
+            return 1
+        fi
+        ;;
+    codex)
+        if ! _have codex; then
+            ux_error "codex CLI not found"
+            return 1
+        fi
+        ;;
+    gemini)
+        if ! _have gemini; then
+            ux_error "gemini CLI not found"
+            return 1
+        fi
+        ;;
+    *)
+        ux_error "invalid --ai value: '$1' (allowed: claude, codex, gemini)"
+        return 1
+        ;;
+    esac
+}
+
+# Run one non-interactive prompt with the selected ai runner.
+_gh_flow_run_ai_prompt() {
+    local _ai="$1" _prompt="$2"
+    case "$_ai" in
+    claude)
+        claude --dangerously-skip-permissions -p "$_prompt"
+        ;;
+    codex)
+        codex exec --dangerously-bypass-approvals-and-sandbox "$_prompt"
+        ;;
+    gemini)
+        gemini --yolo -p "$_prompt"
+        ;;
+    *)
+        printf '[gh-flow-worker] invalid ai runner: %s\n' "$_ai" >&2
+        return 1
+        ;;
+    esac
+}
+
 # ============================================================================
 # status / prune subcommands
 # ============================================================================
@@ -127,12 +183,12 @@ _gh_flow_status() {
 _gh_flow_prune() {
     local _force=0
     case "${1:-}" in
-        --force|-f) _force=1 ;;
-        '') : ;;
-        *)
-            ux_error "gh-flow prune: unknown arg '$1' (only --force is accepted)"
-            return 1
-            ;;
+    --force | -f) _force=1 ;;
+    '') : ;;
+    *)
+        ux_error "gh-flow prune: unknown arg '$1' (only --force is accepted)"
+        return 1
+        ;;
     esac
 
     local _root _name _repo_dir _entry _issue _state _wt
@@ -158,29 +214,29 @@ _gh_flow_prune() {
         _wt="$(cat "$_entry/worktree.path" 2>/dev/null || printf '')"
 
         case "$_state" in
-            done)
-                rm -rf "$_entry"
-                ux_success "removed state for #$_issue (done)"
-                _removed=$((_removed + 1))
-                ;;
-            failed:*)
-                _failed=$((_failed + 1))
-                if [ "$_force" = "1" ] && [ -n "$_wt" ] && [ -d "$_wt" ]; then
-                    ux_warning "#$_issue $_state — tearing down $_wt"
-                    if (cd "$_wt" && gwt teardown --force); then
-                        rm -rf "$_entry"
-                        _torn_down=$((_torn_down + 1))
-                    else
-                        ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
-                    fi
+        done)
+            rm -rf "$_entry"
+            ux_success "removed state for #$_issue (done)"
+            _removed=$((_removed + 1))
+            ;;
+        failed:*)
+            _failed=$((_failed + 1))
+            if [ "$_force" = "1" ] && [ -n "$_wt" ] && [ -d "$_wt" ]; then
+                ux_warning "#$_issue $_state — tearing down $_wt"
+                if (cd "$_wt" && gwt teardown --force); then
+                    rm -rf "$_entry"
+                    _torn_down=$((_torn_down + 1))
                 else
-                    ux_warning "#$_issue $_state"
-                    if [ -n "$_wt" ] && [ -d "$_wt" ]; then
-                        ux_bullet_sub "worktree: $_wt"
-                        ux_bullet_sub "cleanup: cd $_wt && gwt teardown --force"
-                    fi
+                    ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
                 fi
-                ;;
+            else
+                ux_warning "#$_issue $_state"
+                if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+                    ux_bullet_sub "worktree: $_wt"
+                    ux_bullet_sub "cleanup: cd $_wt && gwt teardown --force"
+                fi
+            fi
+            ;;
         esac
     done
 
@@ -199,7 +255,8 @@ _gh_flow_prune() {
 gh_flow_help() {
     ux_header "gh-flow - fire-and-forget GitHub issue → PR automation"
     ux_info "Usage:"
-    ux_bullet "gh-flow <issue-number>...       spawn N parallel workers"
+    ux_bullet "gh-flow <issue-number>... [--ai <agent>]  spawn N parallel workers"
+    ux_bullet_sub "agent: claude (default) | codex | gemini"
     ux_bullet "gh-flow status                  show state of known issues in this repo"
     ux_bullet "gh-flow prune [--force]         clean 'done' state; list 'failed:*' worktrees"
     ux_bullet "gh-flow -h|--help|help          this help"
@@ -212,6 +269,8 @@ gh_flow_help() {
     ux_info "Examples:"
     ux_bullet "gh-flow 13                  # single issue"
     ux_bullet "gh-flow 13 42 88            # 3 issues in parallel"
+    ux_bullet "gh-flow 33 --ai codex       # run workers with codex CLI"
+    ux_bullet "gh-flow --ai gemini 44      # run workers with gemini CLI"
     ux_bullet "gh-flow status              # who's still running, who failed"
     ux_bullet "gh-flow prune               # remove 'done' state dirs; print hints for failures"
     ux_bullet "gh-flow prune --force       # also gwt teardown failed worktrees"
@@ -232,7 +291,7 @@ gh_flow_help() {
     ux_info ""
     ux_info "Preconditions:"
     ux_bullet "Run from main repo (not inside a worktree)"
-    ux_bullet "gh CLI authenticated, claude CLI on PATH, gwt loaded"
+    ux_bullet "gh CLI authenticated, selected AI CLI on PATH, gwt loaded"
 }
 
 # ============================================================================
@@ -246,21 +305,65 @@ gh_flow() {
     fi
 
     case "${1:-}" in
-        ""|-h|--help|help)
-            gh_flow_help
-            return 0
-            ;;
-        status)
-            shift
-            _gh_flow_status "$@"
-            return $?
-            ;;
-        prune)
-            shift
-            _gh_flow_prune "$@"
-            return $?
-            ;;
+    "" | -h | --help | help)
+        gh_flow_help
+        return 0
+        ;;
+    status)
+        shift
+        _gh_flow_status "$@"
+        return $?
+        ;;
+    prune)
+        shift
+        _gh_flow_prune "$@"
+        return $?
+        ;;
     esac
+
+    # Parse optional args:
+    #   --ai <claude|codex|gemini>
+    #   --ai=<claude|codex|gemini>
+    local _ai="claude"
+    local _issue_args=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        --ai)
+            shift
+            if [ $# -eq 0 ]; then
+                ux_error "--ai requires a value (claude|codex|gemini)"
+                return 1
+            fi
+            _ai="$1"
+            ;;
+        --ai=*)
+            _ai="${1#--ai=}"
+            ;;
+        -*)
+            ux_error "unknown option: '$1'"
+            ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|gemini>]"
+            return 1
+            ;;
+        *)
+            _issue_args="$_issue_args $1"
+            ;;
+        esac
+        shift
+    done
+
+    # Restore issue args for numeric validation / spawn loop.
+    # shellcheck disable=SC2086
+    set -- $_issue_args
+    if [ $# -eq 0 ]; then
+        ux_error "no issue numbers provided"
+        ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|gemini>]"
+        return 1
+    fi
+
+    if ! _gh_flow_known_ai "$_ai"; then
+        ux_error "invalid --ai value: '$_ai' (allowed: claude, codex, gemini)"
+        return 1
+    fi
 
     # Preconditions
     if ! _have git; then
@@ -271,8 +374,7 @@ gh_flow() {
         ux_error "gh CLI not found"
         return 1
     fi
-    if ! _have claude; then
-        ux_error "claude CLI not found"
+    if ! _gh_flow_require_ai_cli "$_ai"; then
         return 1
     fi
     if ! command -v gwt >/dev/null 2>&1; then
@@ -298,45 +400,47 @@ gh_flow() {
     local _issue
     for _issue in "$@"; do
         case "$_issue" in
-            ''|*[!0-9]*)
-                ux_error "invalid issue number: '$_issue' (must be positive integer)"
-                ux_info "subcommands: status, prune; or pass one or more issue numbers"
-                return 1
-                ;;
+        '' | *[!0-9]*)
+            ux_error "invalid issue number: '$_issue' (must be positive integer)"
+            ux_info "subcommands: status, prune; or pass one or more issue numbers"
+            return 1
+            ;;
         esac
     done
 
-    ux_header "gh-flow: spawning $# worker(s)"
+    ux_header "gh-flow: spawning $# worker(s) (ai=$_ai)"
     for _issue in "$@"; do
-        _gh_flow_spawn_worker "$_issue"
+        _gh_flow_spawn_worker "$_issue" "$_ai"
     done
     ux_success "All workers detached. Your shell is free. Results will appear on the kanban."
 }
 
 _gh_flow_spawn_worker() {
     local _issue="$1"
+    local _ai="${2:-claude}"
     local _dir _log _state _pid
     _dir=$(_gh_flow_issue_dir "$_issue")
     mkdir -p "$_dir"
     _log="$_dir/log"
+    printf '%s\n' "$_ai" >"$_dir/ai"
 
     # Idempotency check
     _state=$(_gh_flow_get_state "$_issue")
     case "$_state" in
-        done)
-            ux_info "#$_issue already done, skipping"
-            return 0
-            ;;
-        spawning|implementing|committing|opening-pr|polling|replying|merging|tearing-down)
-            if [ -f "$_dir/pid" ]; then
-                _pid="$(cat "$_dir/pid")"
-                if kill -0 "$_pid" 2>/dev/null; then
-                    ux_warning "#$_issue already running (pid=$_pid), skipping"
-                    return 0
-                fi
+    done)
+        ux_info "#$_issue already done, skipping"
+        return 0
+        ;;
+    spawning | implementing | committing | opening-pr | polling | replying | merging | tearing-down)
+        if [ -f "$_dir/pid" ]; then
+            _pid="$(cat "$_dir/pid")"
+            if kill -0 "$_pid" 2>/dev/null; then
+                ux_warning "#$_issue already running (pid=$_pid), skipping"
+                return 0
             fi
-            ux_info "#$_issue was in-progress but pid is dead — resuming with a new worker"
-            ;;
+        fi
+        ux_info "#$_issue was in-progress but pid is dead — resuming with a new worker"
+        ;;
     esac
 
     # Rotate previous log (keep one .prev for debugging)
@@ -350,12 +454,12 @@ _gh_flow_spawn_worker() {
     # shellcheck disable=SC2016
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_flow_worker "$1"
-    ' -- "$_issue" >"$_log" 2>&1 &
+        _gh_flow_worker "$1" "$2"
+    ' -- "$_issue" "$_ai" >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_issue → pid=$_pid  log=$_log"
+    ux_info "#$_issue → pid=$_pid  ai=$_ai  log=$_log"
 }
 
 # ============================================================================
@@ -364,11 +468,12 @@ _gh_flow_spawn_worker() {
 
 _gh_flow_worker() {
     local _issue="$1"
+    local _ai="${2:-claude}"
     local _dir _worktree _pr _spawn_name _decision _comments
     _dir=$(_gh_flow_issue_dir "$_issue")
     _spawn_name="issue-$_issue"
 
-    printf '[gh-flow-worker] issue=#%s start=%s\n' "$_issue" "$(date -Iseconds 2>/dev/null || date)"
+    printf '[gh-flow-worker] issue=#%s ai=%s start=%s\n' "$_issue" "$_ai" "$(date -Iseconds 2>/dev/null || date)"
 
     # ---- Step 1: spawn worktree ----
     # Snapshot the worktree list before and after `gwt spawn` and diff them
@@ -386,8 +491,8 @@ _gh_flow_worker() {
     _wt_after=$(git worktree list --porcelain 2>/dev/null | awk '$1=="worktree"{print $2}')
     _worktree=$(comm -13 \
         <(printf '%s\n' "$_wt_before" | sort) \
-        <(printf '%s\n' "$_wt_after" | sort) \
-        | head -n 1)
+        <(printf '%s\n' "$_wt_after" | sort) |
+        head -n 1)
 
     if [ -z "$_worktree" ] || [ ! -d "$_worktree" ]; then
         _gh_flow_set_state "$_dir" "failed:spawning"
@@ -403,14 +508,14 @@ _gh_flow_worker() {
         return 1
     }
 
-    # ---- Step 2a: implement (claude runs /gh-issue-implement) ----
-    # The original single `/gh-issue-flow` call was unreliable under `claude -p`
-    # (non-interactive): it often stopped after the implement phase and printed
+    # ---- Step 2a: implement (selected ai runs /gh-issue-implement) ----
+    # The original single `/gh-issue-flow` call was unreliable in
+    # non-interactive mode: it often stopped after the implement phase and printed
     # a "Next: …" hint without running commit/PR. We invoke the 3 atomic skills
     # ourselves so each phase has a distinct state + post-condition check.
     _gh_flow_set_state "$_dir" "implementing"
     _gh_project_status_sync issue "$_issue" "In progress"
-    if ! claude --dangerously-skip-permissions -p "/gh-issue-implement $_issue direct"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "/gh-issue-implement $_issue direct"; then
         _gh_flow_set_state "$_dir" "failed:implementing"
         printf '[gh-flow-worker] /gh-issue-implement failed\n' >&2
         return 1
@@ -421,9 +526,9 @@ _gh_flow_worker() {
         return 1
     fi
 
-    # ---- Step 2b: commit (claude runs /gh-commit) ----
+    # ---- Step 2b: commit (selected ai runs /gh-commit) ----
     _gh_flow_set_state "$_dir" "committing"
-    if ! claude --dangerously-skip-permissions -p "/gh-commit"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "/gh-commit"; then
         _gh_flow_set_state "$_dir" "failed:committing"
         printf '[gh-flow-worker] /gh-commit failed\n' >&2
         return 1
@@ -434,9 +539,9 @@ _gh_flow_worker() {
         return 1
     fi
 
-    # ---- Step 2c: open PR (claude runs /gh-pr) ----
+    # ---- Step 2c: open PR (selected ai runs /gh-pr) ----
     _gh_flow_set_state "$_dir" "opening-pr"
-    if ! claude --dangerously-skip-permissions -p "/gh-pr $_issue"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "/gh-pr $_issue"; then
         _gh_flow_set_state "$_dir" "failed:opening-pr"
         printf '[gh-flow-worker] /gh-pr failed\n' >&2
         return 1
@@ -472,7 +577,7 @@ _gh_flow_worker() {
             if [ -n "$_comments" ] && [ "$_comments" -gt 0 ]; then
                 _gh_flow_set_state "$_dir" "replying"
                 printf '[gh-flow-worker] running /gh-pr-reply (%s review(s))\n' "$_comments"
-                if claude --dangerously-skip-permissions -p "/gh-pr-reply"; then
+                if _gh_flow_run_ai_prompt "$_ai" "/gh-pr-reply"; then
                     touch "$_dir/reply.done"
                     _gh_flow_set_state "$_dir" "polling"
                 else
@@ -486,7 +591,7 @@ _gh_flow_worker() {
 
     # ---- Step 4: merge ----
     _gh_flow_set_state "$_dir" "merging"
-    if ! claude --dangerously-skip-permissions -p "/gh-pr-merge"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "/gh-pr-merge"; then
         _gh_flow_set_state "$_dir" "failed:merging"
         printf '[gh-flow-worker] /gh-pr-merge failed\n' >&2
         return 1

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -17,7 +17,7 @@ load '../test_helper'
 # `git rev-parse --show-toplevel`.
 _setup_fake_repo() {
     export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
-           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+        GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
     REPO_DIR="$TEST_TEMP_HOME/repo"
     mkdir -p "$REPO_DIR"
     git -C "$REPO_DIR" init --initial-branch=main -q
@@ -56,6 +56,8 @@ teardown() {
     assert_success
     assert_output --partial "gh-flow status"
     assert_output --partial "gh-flow prune"
+    assert_output --partial "--ai"
+    assert_output --partial "claude (default) | codex | gemini"
     # New distinct failure states must be documented.
     assert_output --partial "failed:committing"
     assert_output --partial "failed:opening-pr"
@@ -175,6 +177,19 @@ teardown() {
     # The error should point users to the subcommands.
     assert_output --partial "status"
     assert_output --partial "prune"
+}
+
+@test "dispatcher: invalid --ai value fails before worker spawn" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --ai not-supported 2>&1"
+    assert_failure
+    assert_output --partial "invalid --ai value"
+    assert_output --partial "claude, codex, gemini"
+}
+
+@test "dispatcher: --ai without value fails with clear message" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --ai 2>&1"
+    assert_failure
+    assert_output --partial "--ai requires a value"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `--ai` option to `gh-flow` so workers can run with `claude` (default), `codex`, or `gemini`.
- Route worker slash-command execution through a runner dispatcher instead of hardcoding Claude.
- Update docs and bats coverage for option parsing and validation.

## Changes
- `shell-common/functions/gh_flow.sh`: add `--ai` parsing/validation, AI CLI availability checks, and runner dispatch for all worker skill invocations.
- `tests/bats/functions/gh_flow.bats`: add assertions for `--ai` help text and invalid/missing `--ai` input handling.
- `docs/feature/gh-flow-automation/design.md`: document `--ai` usage and per-runner invocation behavior.

## Test plan
- [x] `bash -n shell-common/functions/gh_flow.sh`
- [x] `zsh -n shell-common/functions/gh_flow.sh`
- [ ] `tox` (`mdlint` has pre-existing repository-wide failures)

## Related
Closes #208

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
