### PR TITLE
Add design docs for gh-pr --ai options

### DIFF
--- a/docs/feature/gh-pr-approve-ai-option/design.md
+++ b/docs/feature/gh-pr-approve-ai-option/design.md
@@ -1,0 +1,122 @@
+# gh-pr-approve: --ai 실행 주체 선택 옵션 설계
+
+**작성일**: 2026-04-27
+**상태**: 설계 완료, 구현 대기
+**관련 이슈**: #208 (`gh-flow --ai`)
+
+## 1. 배경
+
+현재 `gh-pr-approve` (`shell-common/functions/gh_pr_approve.sh`)는 워커에서 실행 주체를 고정한다.
+
+- 현재 고정 실행: `claude --dangerously-skip-permissions -p "/gh-pr-approve <N>"`
+- 사용자 요구: `gh-flow` #208 과 동일하게 실행 주체를 선택 가능해야 함
+
+## 2. 목표 / 비목표
+
+### 목표
+- `gh-pr-approve --ai [claude(default)|codex|gemini]` 지원
+- 기존 호출(`gh-pr-approve 42`)과 완전 호환 (기본값 `claude`)
+- 병렬 워커/상태 파일/실패 격리 동작은 유지
+
+### 비목표
+- `/gh-pr-approve` 스킬 로직 변경
+- 승인 정책/리뷰 판단 기준 변경
+- `gh-flow` 구현 변경 (별도 #208 범위)
+
+## 3. CLI 계약
+
+### 3.1 사용법
+
+```bash
+gh-pr-approve <pr-number>... [--ai <agent>]
+gh-pr-approve --ai <agent> <pr-number>...
+gh-pr-approve -h | --help
+```
+
+- `<agent>` 허용값: `claude`, `codex`, `gemini`
+- 기본값: `claude`
+- `#` prefix PR 번호 허용 규칙은 기존 유지
+
+### 3.2 실행 예시
+
+```bash
+gh-pr-approve 42                          # default: claude
+gh-pr-approve 12 34 --ai codex           # codex worker 2개
+gh-pr-approve --ai gemini '#56' '#78'    # gemini + #prefix
+```
+
+### 3.3 에러 UX
+
+- `--ai` 값 누락: `missing value for --ai (expected: claude|codex|gemini)`
+- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)`
+- 미지원 옵션: `unknown option: '<arg>'`
+
+## 4. 설계
+
+### 4.1 파서 변경
+
+`gh_pr_approve()`의 인자 파싱을 2단계로 분리한다.
+
+1. 옵션 파싱: `--ai <agent>` 추출 (위치 무관)
+2. 위치 인자 검증: PR 번호 목록 검증(기존 `#` strip 규칙 유지)
+
+결과 변수:
+- `_ai` (`claude` 기본)
+- `_pr_args` (정규화된 숫자 목록)
+
+### 4.2 Precondition 변경
+
+기존의 `claude CLI not found` 하드코딩을 제거하고 선택된 `_ai` 기준으로 검사한다.
+
+- 공통 유지: `git`, `gh`, `gwt`, main repo 체크
+- AI별 검사:
+  - `claude`: `_have claude`
+  - `codex`: `_have codex`
+  - `gemini`: `_have gemini`
+
+### 4.3 워커 실행 분기
+
+워커에 `_ai`를 전달하고, 승인 단계에서 실행기 헬퍼를 사용한다.
+
+- spawn: `_gh_pr_approve_worker "$_pr" "$_ai"`
+- worker: `_gh_pr_approve_run_agent "$_ai" "/gh-pr-approve $_pr"`
+
+AI별 명령 매핑:
+- `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
+- `codex`: `codex exec --dangerously-bypass-approvals-and-sandbox "<prompt>"`
+- `gemini`: `gemini --yolo -p "<prompt>"`
+
+### 4.4 가시성
+
+상태 디렉토리에 `ai` 파일 추가를 권장한다.
+
+```
+~/.local/state/gh-pr-approve/<repo>/<pr>/ai
+```
+
+로그 첫 줄에 `ai=<agent>`를 남겨 사후 분석을 단순화한다.
+
+## 5. 테스트 계획
+
+대상: `tests/bats/functions/gh_pr_approve.bats`
+
+추가 케이스:
+1. `--ai codex` / `--ai gemini` 파싱 성공
+2. `42 --ai codex` (후행 옵션) 성공
+3. `--ai` 값 누락 실패
+4. `--ai unknown` 실패
+5. help 출력에 `--ai` 사용법 노출
+
+기존 케이스(정수 검증, `#` prefix, worktree guard)는 회귀 테스트로 유지.
+
+## 6. 리스크 / 미해결
+
+1. `codex exec`/`gemini -p`에서 slash command(`/gh-pr-approve`) 실행 결과가 `claude -p`와 완전히 동일한지 실측 필요
+2. CLI별 인증/정책(예: yolo/bypass) 차이로 결과 편차 가능
+3. 공통 헬퍼를 `gh_flow`까지 재사용할지(중복 제거) 범위 결정 필요
+
+## 7. 구현 파일
+
+- 수정: `shell-common/functions/gh_pr_approve.sh`
+- 수정: `tests/bats/functions/gh_pr_approve.bats`
+- 참고: `shell-common/functions/gh_flow.sh`, `shell-common/functions/gh_pr_reply.sh`

--- a/docs/feature/gh-pr-approve-ai-option/design.md
+++ b/docs/feature/gh-pr-approve-ai-option/design.md
@@ -48,7 +48,7 @@ gh-pr-approve --ai gemini '#56' '#78'    # gemini + #prefix
 ### 3.3 에러 UX
 
 - `--ai` 값 누락: `missing value for --ai (expected: claude|codex|gemini)`
-- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)`
+- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)` (실행기 선택 단계)
 - 미지원 옵션: `unknown option: '<arg>'`
 
 ## 4. 설계
@@ -57,29 +57,31 @@ gh-pr-approve --ai gemini '#56' '#78'    # gemini + #prefix
 
 `gh_pr_approve()`의 인자 파싱을 2단계로 분리한다.
 
-1. 옵션 파싱: `--ai <agent>` 추출 (위치 무관)
+1. 옵션 파싱: `--ai <agent>` 추출 (위치 무관, 값 존재 여부만 검증)
 2. 위치 인자 검증: PR 번호 목록 검증(기존 `#` strip 규칙 유지)
 
 결과 변수:
-- `_ai` (`claude` 기본)
+- `_ai_raw` (`claude` 기본, raw string)
 - `_pr_args` (정규화된 숫자 목록)
 
 ### 4.2 Precondition 변경
 
-기존의 `claude CLI not found` 하드코딩을 제거하고 선택된 `_ai` 기준으로 검사한다.
+기존의 `claude CLI not found` 하드코딩을 제거하고 실행기 선택 단계에서 `_ai_raw` 의미 검증 + CLI 존재 검사를 수행한다.
 
 - 공통 유지: `git`, `gh`, `gwt`, main repo 체크
-- AI별 검사:
+- 실행기 선택:
+  - `claude|codex|gemini` 외 값이면 `invalid --ai value`로 실패
+- 선택된 AI별 검사:
   - `claude`: `_have claude`
   - `codex`: `_have codex`
   - `gemini`: `_have gemini`
 
 ### 4.3 워커 실행 분기
 
-워커에 `_ai`를 전달하고, 승인 단계에서 실행기 헬퍼를 사용한다.
+워커에 `_ai`를 전달하고, 승인 단계에서 공통 실행기 헬퍼를 사용한다.
 
 - spawn: `_gh_pr_approve_worker "$_pr" "$_ai"`
-- worker: `_gh_pr_approve_run_agent "$_ai" "/gh-pr-approve $_pr"`
+- worker: `_gh_run_ai_agent "$_ai" "/gh-pr-approve $_pr"`
 
 AI별 명령 매핑:
 - `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
@@ -113,7 +115,7 @@ AI별 명령 매핑:
 
 1. `codex exec`/`gemini -p`에서 slash command(`/gh-pr-approve`) 실행 결과가 `claude -p`와 완전히 동일한지 실측 필요
 2. CLI별 인증/정책(예: yolo/bypass) 차이로 결과 편차 가능
-3. 공통 헬퍼를 `gh_flow`까지 재사용할지(중복 제거) 범위 결정 필요
+3. 공통 헬퍼 적용 시 `gh_flow` 마이그레이션 순서/호환성 점검 필요
 
 ## 7. 구현 파일
 

--- a/docs/feature/gh-pr-reply-ai-option/design.md
+++ b/docs/feature/gh-pr-reply-ai-option/design.md
@@ -1,0 +1,130 @@
+# gh-pr-reply: --ai 실행 주체 선택 옵션 설계
+
+**작성일**: 2026-04-27
+**상태**: 설계 완료, 구현 대기
+**관련 이슈**: #208 (`gh-flow --ai`)
+
+## 1. 배경
+
+현재 `gh-pr-reply` (`shell-common/functions/gh_pr_reply.sh`)는 워커에서 실행 주체를 고정한다.
+
+- 현재 고정 실행: `claude --dangerously-skip-permissions -p "/gh-pr-reply <N>"`
+- 사용자 요구: `gh-flow` #208 과 같은 패턴으로 `--ai` 선택 지원
+
+`gh-pr-reply`는 승인 러너와 달리 코드 수정/commit/push를 동반할 수 있어, 실패 시 worktree 보존 정책(`failed:replying`)을 반드시 유지해야 한다.
+
+## 2. 목표 / 비목표
+
+### 목표
+- `gh-pr-reply --ai [claude(default)|codex|gemini]` 지원
+- 기존 동작(`gh-pr-reply 42`) 100% 호환
+- 실패 시 teardown 생략(데이터 손실 방지) 정책 유지
+
+### 비목표
+- `/gh-pr-reply` 스킬 내부 로직 변경
+- 실패 시 자동 복구 정책 변경
+- `gh-pr-approve`/`gh-flow` 동시 리팩터링 (별도 이슈)
+
+## 3. CLI 계약
+
+### 3.1 사용법
+
+```bash
+gh-pr-reply <pr-number>... [--ai <agent>]
+gh-pr-reply --ai <agent> <pr-number>...
+gh-pr-reply -h | --help
+```
+
+- `<agent>` 허용값: `claude`, `codex`, `gemini`
+- 기본값: `claude`
+- `#` prefix PR 번호 허용 규칙은 기존 유지
+
+### 3.2 실행 예시
+
+```bash
+gh-pr-reply 42                           # default: claude
+gh-pr-reply 12 34 --ai codex            # codex worker 2개
+gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
+```
+
+### 3.3 에러 UX
+
+- `--ai` 값 누락: `missing value for --ai (expected: claude|codex|gemini)`
+- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)`
+- 미지원 옵션: `unknown option: '<arg>'`
+
+## 4. 설계
+
+### 4.1 파서 변경
+
+`gh_pr_reply()`에 옵션 파서를 추가한다.
+
+- `_ai=claude` 기본
+- `--ai <agent>` 1회 허용 (중복 지정 시 마지막 값 사용 또는 즉시 실패 중 택1; 구현 시 일관된 정책 필요)
+- 옵션 파싱 후 PR 번호 검증 수행
+
+### 4.2 Precondition 변경
+
+기존 `claude` 고정 체크를 `_ai` 기반 검사로 변경한다.
+
+- 공통 유지: `git`, `gh`, `gwt`, main repo 체크
+- AI별 검사:
+  - `claude`: `_have claude`
+  - `codex`: `_have codex`
+  - `gemini`: `_have gemini`
+
+### 4.3 워커 실행 분기
+
+spawn → worker 호출에 `_ai` 전달 추가:
+
+- spawn: `_gh_pr_reply_worker "$_pr" "$_ai"`
+- worker: `_gh_pr_reply_run_agent "$_ai" "/gh-pr-reply $_pr"`
+
+AI별 명령 매핑:
+- `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
+- `codex`: `codex exec --dangerously-bypass-approvals-and-sandbox "<prompt>"`
+- `gemini`: `gemini --yolo -p "<prompt>"`
+
+### 4.4 실패 보존 정책 유지 (핵심)
+
+`replying` 단계 실패 시 기존 정책을 유지한다.
+
+- state: `failed:replying`
+- teardown: 수행하지 않음
+- 목적: push 전 로컬 커밋 손실 방지
+
+AI가 달라도 이 정책은 동일해야 한다.
+
+### 4.5 가시성
+
+상태 디렉토리에 `ai` 파일 추가를 권장한다.
+
+```
+~/.local/state/gh-pr-reply/<repo>/<pr>/ai
+```
+
+로그 시작 줄에 `ai=<agent>`를 기록한다.
+
+## 5. 테스트 계획
+
+대상: `tests/bats/functions/gh_pr_reply.bats`
+
+추가 케이스:
+1. `--ai codex` / `--ai gemini` 파싱 성공
+2. `42 --ai codex` (후행 옵션) 성공
+3. `--ai` 값 누락 실패
+4. `--ai unknown` 실패
+5. help 출력에 `--ai` 사용법 노출
+6. `failed:*` 자동 재개 거부 정책이 `--ai` 경로에서도 동일하게 유지되는지 확인
+
+## 6. 리스크 / 미해결
+
+1. `codex`/`gemini` 경로에서 `/gh-pr-reply`의 "수정→commit→push→reply" 파이프라인 안정성 실측 필요
+2. CLI별 실패 코드/출력 포맷 차이로 워커 로그 판독성이 달라질 수 있음
+3. `--ai` 중복 지정 정책(마지막 우선 vs 에러) 확정 필요
+
+## 7. 구현 파일
+
+- 수정: `shell-common/functions/gh_pr_reply.sh`
+- 수정: `tests/bats/functions/gh_pr_reply.bats`
+- 참고: `shell-common/functions/gh_pr_approve.sh`, `shell-common/functions/gh_flow.sh`

--- a/docs/feature/gh-pr-reply-ai-option/design.md
+++ b/docs/feature/gh-pr-reply-ai-option/design.md
@@ -50,7 +50,7 @@ gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
 ### 3.3 에러 UX
 
 - `--ai` 값 누락: `missing value for --ai (expected: claude|codex|gemini)`
-- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)`
+- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)` (실행기 선택 단계)
 - 미지원 옵션: `unknown option: '<arg>'`
 
 ## 4. 설계
@@ -60,15 +60,17 @@ gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
 `gh_pr_reply()`에 옵션 파서를 추가한다.
 
 - `_ai=claude` 기본
-- `--ai <agent>` 1회 허용 (중복 지정 시 마지막 값 사용 또는 즉시 실패 중 택1; 구현 시 일관된 정책 필요)
+- `--ai <agent>` 허용 (중복 지정 시 마지막 값 사용; last-one-wins)
 - 옵션 파싱 후 PR 번호 검증 수행
 
 ### 4.2 Precondition 변경
 
-기존 `claude` 고정 체크를 `_ai` 기반 검사로 변경한다.
+기존 `claude` 고정 체크를 `_ai_raw` 기반 실행기 선택 + CLI 검사로 변경한다.
 
 - 공통 유지: `git`, `gh`, `gwt`, main repo 체크
-- AI별 검사:
+- 실행기 선택:
+  - `claude|codex|gemini` 외 값이면 `invalid --ai value`로 실패
+- 선택된 AI별 검사:
   - `claude`: `_have claude`
   - `codex`: `_have codex`
   - `gemini`: `_have gemini`
@@ -78,7 +80,7 @@ gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
 spawn → worker 호출에 `_ai` 전달 추가:
 
 - spawn: `_gh_pr_reply_worker "$_pr" "$_ai"`
-- worker: `_gh_pr_reply_run_agent "$_ai" "/gh-pr-reply $_pr"`
+- worker: `_gh_run_ai_agent "$_ai" "/gh-pr-reply $_pr"`
 
 AI별 명령 매핑:
 - `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
@@ -121,7 +123,7 @@ AI가 달라도 이 정책은 동일해야 한다.
 
 1. `codex`/`gemini` 경로에서 `/gh-pr-reply`의 "수정→commit→push→reply" 파이프라인 안정성 실측 필요
 2. CLI별 실패 코드/출력 포맷 차이로 워커 로그 판독성이 달라질 수 있음
-3. `--ai` 중복 지정 정책(마지막 우선 vs 에러) 확정 필요
+3. 공통 헬퍼 도입 시 `gh-pr-approve`/`gh-flow`와의 공통화 경계 점검 필요
 
 ## 7. 구현 파일
 


### PR DESCRIPTION
## Summary
- Add design documents for introducing `--ai` executor selection to `gh-pr-approve` and `gh-pr-reply`.
- Define CLI contract, parser/precondition updates, worker command mapping, and observability notes.
- Document risks and test plans to guide follow-up implementation.

## Changes
- `docs/feature/gh-pr-approve-ai-option/design.md`: design for `gh-pr-approve --ai` including parsing, preconditions, worker branching, and test cases.
- `docs/feature/gh-pr-reply-ai-option/design.md`: design for `gh-pr-reply --ai` including failure-preservation policy and test cases.

## Test plan
- [x] `tox -e ruff,mypy,shellcheck,shfmt`
- [ ] Implement shell function and bats test updates described in these design docs.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
