### PR TITLE
Add --ai runner selection for gh-pr-reply workers

### DIFF
--- a/docs/feature/gh-pr-reply-ai-option/design.md
+++ b/docs/feature/gh-pr-reply-ai-option/design.md
@@ -1,17 +1,19 @@
 # gh-pr-reply: --ai 실행 주체 선택 옵션 설계
 
 **작성일**: 2026-04-27
-**상태**: 설계 완료, 구현 대기
-**관련 이슈**: #208 (`gh-flow --ai`)
+**상태**: 구현 완료
+**관련 이슈**: #215, 선행 #208 (`gh-flow --ai`)
 
 ## 1. 배경
 
-현재 `gh-pr-reply` (`shell-common/functions/gh_pr_reply.sh`)는 워커에서 실행 주체를 고정한다.
+`gh-pr-reply` (`shell-common/functions/gh_pr_reply.sh`)는 워커에서 실행 주체를
+`claude`로 고정하고 있었다.
 
-- 현재 고정 실행: `claude --dangerously-skip-permissions -p "/gh-pr-reply <N>"`
-- 사용자 요구: `gh-flow` #208 과 같은 패턴으로 `--ai` 선택 지원
+- 기존 고정 실행: `claude --dangerously-skip-permissions -p "/gh-pr-reply <N>"`
+- 사용자 요구: `gh-flow --ai` (#208) 와 같은 방식으로 실행 주체 선택 지원
 
-`gh-pr-reply`는 승인 러너와 달리 코드 수정/commit/push를 동반할 수 있어, 실패 시 worktree 보존 정책(`failed:replying`)을 반드시 유지해야 한다.
+`gh-pr-reply`는 승인 러너와 달리 코드 수정/commit/push를 동반할 수 있어,
+실패 시 worktree 보존 정책(`failed:replying`)을 반드시 유지해야 한다.
 
 ## 2. 목표 / 비목표
 
@@ -23,7 +25,7 @@
 ### 비목표
 - `/gh-pr-reply` 스킬 내부 로직 변경
 - 실패 시 자동 복구 정책 변경
-- `gh-pr-approve`/`gh-flow` 동시 리팩터링 (별도 이슈)
+- `gh-pr-approve` 동시 리팩터링 (별도 이슈)
 
 ## 3. CLI 계약
 
@@ -49,9 +51,10 @@ gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
 
 ### 3.3 에러 UX
 
-- `--ai` 값 누락: `missing value for --ai (expected: claude|codex|gemini)`
-- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)` (실행기 선택 단계)
+- `--ai` 값 누락: `--ai requires a value (expected: claude|codex|gemini)`
+- 잘못된 값: `invalid --ai value: '<value>' (expected: claude|codex|gemini)`
 - 미지원 옵션: `unknown option: '<arg>'`
+- `--ai` 중복 지정: 마지막 값 우선 (gh-flow와 동일 정책)
 
 ## 4. 설계
 
@@ -59,18 +62,17 @@ gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
 
 `gh_pr_reply()`에 옵션 파서를 추가한다.
 
-- `_ai=claude` 기본
-- `--ai <agent>` 허용 (중복 지정 시 마지막 값 사용; last-one-wins)
+- 기본 `_ai=claude`
+- `--ai <agent>` / `--ai=<agent>` 두 형태 모두 허용
 - 옵션 파싱 후 PR 번호 검증 수행
+- 옵션이 PR 번호 사이에 끼어 있어도 동작 (`42 --ai codex 56`)
 
 ### 4.2 Precondition 변경
 
-기존 `claude` 고정 체크를 `_ai_raw` 기반 실행기 선택 + CLI 검사로 변경한다.
+기존 `claude` 고정 체크를 `_ai` 기반 검사로 변경한다.
 
 - 공통 유지: `git`, `gh`, `gwt`, main repo 체크
-- 실행기 선택:
-  - `claude|codex|gemini` 외 값이면 `invalid --ai value`로 실패
-- 선택된 AI별 검사:
+- AI별 검사:
   - `claude`: `_have claude`
   - `codex`: `_have codex`
   - `gemini`: `_have gemini`
@@ -80,7 +82,7 @@ gh-pr-reply --ai gemini '#56' '#78'     # gemini + #prefix
 spawn → worker 호출에 `_ai` 전달 추가:
 
 - spawn: `_gh_pr_reply_worker "$_pr" "$_ai"`
-- worker: `_gh_run_ai_agent "$_ai" "/gh-pr-reply $_pr"`
+- worker: `_gh_pr_reply_run_ai_prompt "$_ai" "/gh-pr-reply $_pr"`
 
 AI별 명령 매핑:
 - `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
@@ -95,38 +97,36 @@ AI별 명령 매핑:
 - teardown: 수행하지 않음
 - 목적: push 전 로컬 커밋 손실 방지
 
-AI가 달라도 이 정책은 동일해야 한다.
+선택한 AI가 달라도 이 정책은 동일해야 한다.
 
 ### 4.5 가시성
 
-상태 디렉토리에 `ai` 파일 추가를 권장한다.
-
-```
-~/.local/state/gh-pr-reply/<repo>/<pr>/ai
-```
-
-로그 시작 줄에 `ai=<agent>`를 기록한다.
+- `~/.local/state/gh-pr-reply/<repo>/<pr>/ai` 파일에 선택된 AI 기록
+- spawn 로그: `#<pr> → pid=<pid>  ai=<agent>  log=<log>`
+- worker 시작 줄: `[gh-pr-reply-worker] pr=#<N> ai=<agent> start=...`
 
 ## 5. 테스트 계획
 
 대상: `tests/bats/functions/gh_pr_reply.bats`
 
 추가 케이스:
-1. `--ai codex` / `--ai gemini` 파싱 성공
-2. `42 --ai codex` (후행 옵션) 성공
-3. `--ai` 값 누락 실패
-4. `--ai unknown` 실패
-5. help 출력에 `--ai` 사용법 노출
-6. `failed:*` 자동 재개 거부 정책이 `--ai` 경로에서도 동일하게 유지되는지 확인
+1. help 출력에 `--ai` 사용법 노출
+2. `--ai codex` / `--ai gemini` 파싱 성공 (값 누락/invalid 메시지가 안 나오는 것으로 검증)
+3. 후행 옵션(`42 --ai codex`) 성공
+4. `--ai` 값 누락 실패 (`--ai requires a value` 메시지)
+5. invalid `--ai` 실패 (`invalid --ai value` 메시지)
+6. 알 수 없는 옵션 실패 (`unknown option`)
+7. `failed:*` 자동 재개 거부 정책이 `--ai` 경로에서도 동일
 
 ## 6. 리스크 / 미해결
 
-1. `codex`/`gemini` 경로에서 `/gh-pr-reply`의 "수정→commit→push→reply" 파이프라인 안정성 실측 필요
+1. `codex`/`gemini` 경로에서 `/gh-pr-reply`의 "수정→commit→push→reply" 파이프라인
+   안정성 실측 필요
 2. CLI별 실패 코드/출력 포맷 차이로 워커 로그 판독성이 달라질 수 있음
-3. 공통 헬퍼 도입 시 `gh-pr-approve`/`gh-flow`와의 공통화 경계 점검 필요
+3. 설치 전 환경에서 `_have <ai>` 실패 시 UX는 기존 메시지(`<ai> CLI not found`)와 동일
 
 ## 7. 구현 파일
 
 - 수정: `shell-common/functions/gh_pr_reply.sh`
 - 수정: `tests/bats/functions/gh_pr_reply.bats`
-- 참고: `shell-common/functions/gh_pr_approve.sh`, `shell-common/functions/gh_flow.sh`
+- 참고: `shell-common/functions/gh_flow.sh` (#208), `shell-common/functions/gh_pr_approve.sh`

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -57,28 +57,95 @@ _gh_pr_reply_get_state() {
 }
 
 # ============================================================================
+# AI runner helpers
+# ============================================================================
+# Mirrors the contract introduced by `gh-flow --ai` (#208) so all three
+# user-facing runners accept the same agent set with identical error UX.
+
+# Returns 0 if the ai runner is one of: claude, codex, gemini.
+_gh_pr_reply_known_ai() {
+    case "$1" in
+        claude|codex|gemini) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Ensure the selected ai CLI exists in PATH.
+_gh_pr_reply_require_ai_cli() {
+    case "$1" in
+        claude)
+            if ! _have claude; then
+                ux_error "claude CLI not found"
+                return 1
+            fi
+            ;;
+        codex)
+            if ! _have codex; then
+                ux_error "codex CLI not found"
+                return 1
+            fi
+            ;;
+        gemini)
+            if ! _have gemini; then
+                ux_error "gemini CLI not found"
+                return 1
+            fi
+            ;;
+        *)
+            ux_error "invalid --ai value: '$1' (expected: claude|codex|gemini)"
+            return 1
+            ;;
+    esac
+}
+
+# Run one non-interactive prompt with the selected ai runner.
+# Used by the worker to invoke /gh-pr-reply via the chosen CLI.
+_gh_pr_reply_run_ai_prompt() {
+    local _ai="$1" _prompt="$2"
+    case "$_ai" in
+        claude)
+            claude --dangerously-skip-permissions -p "$_prompt"
+            ;;
+        codex)
+            codex exec --dangerously-bypass-approvals-and-sandbox "$_prompt"
+            ;;
+        gemini)
+            gemini --yolo -p "$_prompt"
+            ;;
+        *)
+            printf '[gh-pr-reply-worker] invalid ai runner: %s\n' "$_ai" >&2
+            return 1
+            ;;
+    esac
+}
+
+# ============================================================================
 # Help
 # ============================================================================
 
 gh_pr_reply_help() {
     ux_header "gh-pr-reply - fire-and-forget GitHub PR review-reply runner"
-    ux_info "Usage: gh-pr-reply <pr-number>... | -h|--help"
+    ux_info "Usage: gh-pr-reply <pr-number>... [--ai <agent>] | -h|--help"
+    ux_bullet_sub "agent: claude (default) | codex | gemini"
     ux_info ""
     ux_info "Spawns one background worker per PR. Each worker:"
-    ux_bullet "gwt spawn → claude -p '/gh-pr-reply <N>' → gwt teardown"
+    ux_bullet "gwt spawn → <ai> -p '/gh-pr-reply <N>' → gwt teardown"
     ux_info ""
     ux_info "The /gh-pr-reply skill edits files, commits, pushes, and replies"
     ux_info "to each review comment (Accepted or Declined). This runner only"
     ux_info "manages the worktree lifecycle around the skill."
     ux_info ""
     ux_info "Examples:"
-    ux_bullet "gh-pr-reply 42                  # single PR"
+    ux_bullet "gh-pr-reply 42                  # single PR (claude)"
     ux_bullet "gh-pr-reply 12 34 56            # 3 PRs in parallel"
     ux_bullet "gh-pr-reply '#42'               # '#' prefix accepted"
+    ux_bullet "gh-pr-reply 33 --ai codex       # run worker with codex CLI"
+    ux_bullet "gh-pr-reply --ai gemini 44 55   # run workers with gemini CLI"
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-reply/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
     ux_bullet_sub "pid           - worker process id"
+    ux_bullet_sub "ai            - selected ai runner (claude|codex|gemini)"
     ux_bullet_sub "worktree.path - git worktree path"
     ux_bullet_sub "log           - full stdout+stderr"
     ux_bullet_sub "log.prev      - previous run's log (one generation)"
@@ -91,7 +158,7 @@ gh_pr_reply_help() {
     ux_info ""
     ux_info "Preconditions:"
     ux_bullet "Run from main repo (not inside a worktree)"
-    ux_bullet "gh CLI authenticated, claude CLI on PATH, gwt loaded"
+    ux_bullet "gh CLI authenticated, selected AI CLI on PATH, gwt loaded"
     ux_info ""
     ux_info "Related:"
     ux_bullet "gh-flow         - issue → PR automation (author side)"
@@ -116,6 +183,51 @@ gh_pr_reply() {
             ;;
     esac
 
+    # Parse optional args (PR numbers and --ai may interleave):
+    #   --ai <claude|codex|gemini>
+    #   --ai=<claude|codex|gemini>
+    # Last --ai wins on duplicates — same policy gh-flow chose for #208.
+    local _ai="claude"
+    local _pr_args=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --ai)
+                shift
+                if [ $# -eq 0 ]; then
+                    ux_error "--ai requires a value (expected: claude|codex|gemini)"
+                    return 1
+                fi
+                _ai="$1"
+                ;;
+            --ai=*)
+                _ai="${1#--ai=}"
+                ;;
+            -*)
+                ux_error "unknown option: '$1'"
+                ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>]"
+                return 1
+                ;;
+            *)
+                _pr_args="$_pr_args $1"
+                ;;
+        esac
+        shift
+    done
+
+    # Restore PR args for downstream validation / spawn loop.
+    # shellcheck disable=SC2086
+    set -- $_pr_args
+    if [ $# -eq 0 ]; then
+        ux_error "no PR numbers provided"
+        ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>]"
+        return 1
+    fi
+
+    if ! _gh_pr_reply_known_ai "$_ai"; then
+        ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
+        return 1
+    fi
+
     # Preconditions
     if ! _have git; then
         ux_error "git not found"
@@ -125,8 +237,7 @@ gh_pr_reply() {
         ux_error "gh CLI not found"
         return 1
     fi
-    if ! _have claude; then
-        ux_error "claude CLI not found"
+    if ! _gh_pr_reply_require_ai_cli "$_ai"; then
         return 1
     fi
     if ! command -v gwt >/dev/null 2>&1; then
@@ -152,7 +263,7 @@ gh_pr_reply() {
     # so `gh-pr-reply '#42'` works the same as `gh-pr-reply 42` — same
     # ergonomic deviation gh-pr-approve makes, since PR numbers are
     # almost always written as #N in conversation.
-    local _pr _pr_clean _pr_args=""
+    local _pr _pr_clean _pr_clean_args=""
     for _pr in "$@"; do
         _pr_clean="${_pr#\#}"
         case "$_pr_clean" in
@@ -161,22 +272,24 @@ gh_pr_reply() {
                 return 1
                 ;;
         esac
-        _pr_args="$_pr_args $_pr_clean"
+        _pr_clean_args="$_pr_clean_args $_pr_clean"
     done
 
-    ux_header "gh-pr-reply: spawning $# worker(s)"
-    for _pr in $_pr_args; do
-        _gh_pr_reply_spawn_worker "$_pr"
+    ux_header "gh-pr-reply: spawning $# worker(s) (ai=$_ai)"
+    for _pr in $_pr_clean_args; do
+        _gh_pr_reply_spawn_worker "$_pr" "$_ai"
     done
     ux_success "All workers detached. Your shell is free. Results appear on the PR."
 }
 
 _gh_pr_reply_spawn_worker() {
     local _pr="$1"
+    local _ai="${2:-claude}"
     local _dir _log _state _pid
     _dir=$(_gh_pr_reply_pr_dir "$_pr")
     mkdir -p "$_dir"
     _log="$_dir/log"
+    printf '%s\n' "$_ai" >"$_dir/ai"
 
     # Idempotency check — mirrors gh-pr-approve / gh-flow semantics.
     _state=$(_gh_pr_reply_get_state "$_pr")
@@ -216,12 +329,12 @@ _gh_pr_reply_spawn_worker() {
     # shellcheck disable=SC2016
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_pr_reply_worker "$1"
-    ' -- "$_pr" >"$_log" 2>&1 &
+        _gh_pr_reply_worker "$1" "$2"
+    ' -- "$_pr" "$_ai" >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_pr → pid=$_pid  log=$_log"
+    ux_info "#$_pr → pid=$_pid  ai=$_ai  log=$_log"
 }
 
 # ============================================================================
@@ -230,11 +343,12 @@ _gh_pr_reply_spawn_worker() {
 
 _gh_pr_reply_worker() {
     local _pr="$1"
+    local _ai="${2:-claude}"
     local _dir _worktree _spawn_name
     _dir=$(_gh_pr_reply_pr_dir "$_pr")
     _spawn_name="pr-$_pr"
 
-    printf '[gh-pr-reply-worker] pr=#%s start=%s\n' "$_pr" "$(date -Iseconds 2>/dev/null || date)"
+    printf '[gh-pr-reply-worker] pr=#%s ai=%s start=%s\n' "$_pr" "$_ai" "$(date -Iseconds 2>/dev/null || date)"
 
     # ---- Step 1: spawn worktree ----
     # Snapshot the worktree list before and after `gwt spawn` and diff them
@@ -269,7 +383,7 @@ _gh_pr_reply_worker() {
         return 1
     }
 
-    # ---- Step 2: reply (claude runs /gh-pr-reply <N>) ----
+    # ---- Step 2: reply (selected ai runs /gh-pr-reply <N>) ----
     # The skill is responsible for: review-comment fetch → evaluate → fix
     # files → commit → push → reply on each comment. The skill's exit
     # code is the source of truth for success/failure.
@@ -278,8 +392,9 @@ _gh_pr_reply_worker() {
     # local commits that were never pushed (e.g. push step failed mid-skill);
     # tearing down would permanently delete them. State is left as
     # 'failed:replying' for human recovery (#198 Open Question — Option 1).
+    # The data-loss policy is invariant across ai runners.
     _gh_pr_reply_set_state "$_dir" "replying"
-    if ! claude --dangerously-skip-permissions -p "/gh-pr-reply $_pr"; then
+    if ! _gh_pr_reply_run_ai_prompt "$_ai" "/gh-pr-reply $_pr"; then
         _gh_pr_reply_set_state "$_dir" "failed:replying"
         printf '[gh-pr-reply-worker] /gh-pr-reply failed — worktree preserved at %s for recovery\n' "$_worktree" >&2
         return 1

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -62,34 +62,11 @@ _gh_pr_reply_get_state() {
 # Mirrors the contract introduced by `gh-flow --ai` (#208) so all three
 # user-facing runners accept the same agent set with identical error UX.
 
-# Returns 0 if the ai runner is one of: claude, codex, gemini.
-_gh_pr_reply_known_ai() {
-    case "$1" in
-        claude|codex|gemini) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-# Ensure the selected ai CLI exists in PATH.
+# Validate the requested ai runner is supported and its CLI is on PATH.
 _gh_pr_reply_require_ai_cli() {
     case "$1" in
-        claude)
-            if ! _have claude; then
-                ux_error "claude CLI not found"
-                return 1
-            fi
-            ;;
-        codex)
-            if ! _have codex; then
-                ux_error "codex CLI not found"
-                return 1
-            fi
-            ;;
-        gemini)
-            if ! _have gemini; then
-                ux_error "gemini CLI not found"
-                return 1
-            fi
+        claude|codex|gemini)
+            ux_require "$1" || return 1
             ;;
         *)
             ux_error "invalid --ai value: '$1' (expected: claude|codex|gemini)"
@@ -220,11 +197,6 @@ gh_pr_reply() {
     if [ $# -eq 0 ]; then
         ux_error "no PR numbers provided"
         ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>]"
-        return 1
-    fi
-
-    if ! _gh_pr_reply_known_ai "$_ai"; then
-        ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
         return 1
     fi
 

--- a/tests/bats/functions/gh_pr_reply.bats
+++ b/tests/bats/functions/gh_pr_reply.bats
@@ -100,6 +100,16 @@ teardown() {
     assert_output --partial "preserved"
 }
 
+@test "bash: help documents --ai option and supported runners" {
+    # Issue #215 contract: --ai must be discoverable from help, with
+    # the explicit list of supported agents. If users don't see codex
+    # / gemini in help they have no way to know the option exists.
+    run_in_bash 'gh_pr_reply --help 2>&1'
+    assert_success
+    assert_output --partial "--ai"
+    assert_output --partial "claude (default) | codex | gemini"
+}
+
 # ---------------------------------------------------------------------------
 # Argument validation — must fail before any spawn attempt
 # ---------------------------------------------------------------------------
@@ -147,6 +157,80 @@ teardown() {
 # ---------------------------------------------------------------------------
 # Idempotency — failed runs must not be auto-resumed
 # ---------------------------------------------------------------------------
+
+@test "bash: --ai without value fails with clear message" {
+    # Trailing --ai with nothing after it is a common typo. The parser
+    # must catch it before any worker is spawned and must say what
+    # values are accepted, otherwise the user can't tell the option
+    # from a parser bug.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai 2>&1"
+    assert_failure
+    assert_output --partial "--ai requires a value"
+    assert_output --partial "claude|codex|gemini"
+}
+
+@test "bash: invalid --ai value is rejected with allowed list" {
+    # Misspellings ('claud', 'gpt') must be rejected with the explicit
+    # allowed list so the user can fix the typo without grepping the
+    # source. Same UX as gh-flow #208.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai not-supported 2>&1"
+    assert_failure
+    assert_output --partial "invalid --ai value"
+    assert_output --partial "claude|codex|gemini"
+}
+
+@test "bash: unknown long option is rejected" {
+    # Anything starting with '-' that isn't --ai|-h|--help|help is a
+    # caller error. Catching it pre-spawn prevents nohup'd workers
+    # from inheriting nonsense flags.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply --bogus 42 2>&1"
+    assert_failure
+    assert_output --partial "unknown option"
+}
+
+@test "bash: --ai codex is accepted by the parser (no parser-level error)" {
+    # The codex CLI is not installed in the test environment, so the
+    # call will fail somewhere downstream. What we're asserting here
+    # is that it does NOT fail with a parse-time '--ai' rejection
+    # message — i.e. 'codex' is a recognised value.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai codex 2>&1 || true"
+    refute_output --partial "invalid --ai value"
+    refute_output --partial "--ai requires a value"
+    refute_output --partial "unknown option"
+}
+
+@test "bash: --ai gemini with leading position is accepted" {
+    # Per issue #215 example: `gh-pr-reply --ai gemini '#56' '#78'` —
+    # --ai before PR numbers must parse just as well as after them.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply --ai gemini 42 2>&1 || true"
+    refute_output --partial "invalid --ai value"
+    refute_output --partial "--ai requires a value"
+    refute_output --partial "unknown option"
+}
+
+@test "bash: --ai=value form is accepted" {
+    # Optional --ai=<value> form mirrors gh-flow's parser. Same
+    # parser-level success criterion as the space-separated form.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai=codex 2>&1 || true"
+    refute_output --partial "invalid --ai value"
+    refute_output --partial "--ai requires a value"
+    refute_output --partial "unknown option"
+}
+
+@test "bash: failed-run guard still applies on --ai path" {
+    # The data-loss-prevention guarantee (failed:* must not auto-resume)
+    # is invariant across ai runners — switching --ai must not silently
+    # bypass the inspection step that protects unpushed commits.
+    # Use --ai claude here so we exercise the parser path without
+    # requiring codex/gemini to be installed in the test env.
+    local _state_dir="$HOME/.local/state/gh-pr-reply/fake-main/42"
+    mkdir -p "$_state_dir"
+    printf 'failed:replying\n' >"$_state_dir/state"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai claude 2>&1"
+    assert_success
+    assert_output --partial "previous run failed"
+    assert_output --partial "rm -rf"
+}
 
 @test "bash: refuses to auto-resume a previously failed run" {
     # Distinguishing behavior of gh-pr-reply vs gh-pr-approve. Because


### PR DESCRIPTION
## Summary
- Allow `gh-pr-reply` workers to run with `claude` (default), `codex`, or `gemini` via `--ai`, mirroring the contract `gh-flow` introduced in #208 so the three user-facing runners stay aligned.
- Preserve the failure policy: `failed:replying` still blocks auto-resume and the worktree is kept, regardless of which AI ran the skill — protects unpushed local commits.

## Changes
- `shell-common/functions/gh_pr_reply.sh`: add `--ai` parser (positional/`--ai=`/last-wins), generalize the `claude` precondition into a runner selector, thread `_ai` through spawn → worker, log `ai=<agent>` in spawn / worker start lines, and persist the choice to `~/.local/state/gh-pr-reply/<repo>/<pr>/ai`.
- `tests/bats/functions/gh_pr_reply.bats`: cover help discoverability, parser success on `codex` / `gemini` / `--ai=` / leading `--ai`, error UX for missing/invalid/unknown options, and the `failed:replying` no-auto-resume guard on the `--ai` path.
- `docs/feature/gh-pr-reply-ai-option/design.md`: design note capturing the CLI contract, runner mapping, and the unchanged data-loss-prevention policy.

## Test plan
- [ ] `bats tests/bats/functions/gh_pr_reply.bats`
- [ ] `gh-pr-reply --help` shows `--ai` and the three supported runners
- [ ] `gh-pr-reply 42 --ai` fails with the missing-value message
- [ ] `gh-pr-reply 42 --ai bogus` fails with the invalid-value message
- [ ] On a real PR: `gh-pr-reply <N>` (default claude) and `gh-pr-reply --ai codex <N>` both spawn and the state dir contains an `ai` file with the right value

## Related
Closes #215
Refs #208

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
