### PR TITLE
feat(codex-skills): allowlist + budget diagnostic for #216

### DIFF
--- a/scripts/maintenance/README.md
+++ b/scripts/maintenance/README.md
@@ -28,6 +28,15 @@ Dotfiles 유지보수를 위한 1회성/주기적 도구 모음
   - Progress bar 및 rich formatting
   - 더 읽기 쉬운 출력 형식
 
+### check_codex_skills_budget.py
+- **목적**: Codex skill description 컨텍스트 예산 (~5440자) 초과 감지 (issue #216)
+- **사용**: `python3 check_codex_skills_budget.py [--budget N] [--top N] [--all] [--quiet]`
+- **요구사항**: Python stdlib 만 (외부 의존성 없음)
+- **기능**:
+  - `claude/skills/*/SKILL.md` frontmatter 의 `description` 길이 합산
+  - 가장 긴 설명 Top N 노출 (기본 10개)
+  - 예산 초과 시 종료 코드 1, 트리밍 또는 `.codex-allowlist` 사용 안내
+
 ## 💡 사용 시나리오
 
 ### Shebang 검증
@@ -39,6 +48,11 @@ Dotfiles 유지보수를 위한 1회성/주기적 도구 모음
 - Bash 파일 수정 후 동작 검증
 - 대규모 리팩토링 후 회귀 방지
 - 새로운 .bash 파일 추가 후 통합 테스트
+
+### Codex skill 예산 감시
+- 신규 skill 추가 / description 갱신 후 합계 점검
+- 트렁케이션 경고 발견 시 origin 추적
+- `.codex-allowlist` 운영 결정 자료로 활용
 
 ## 🔗 관련 문서
 

--- a/scripts/maintenance/check_codex_skills_budget.py
+++ b/scripts/maintenance/check_codex_skills_budget.py
@@ -63,7 +63,6 @@ def parse_skill_md(path: Path, fallback_name: str) -> tuple[str, str]:
     name = fallback_name
     desc_parts: list[str] = []
     in_block = False
-    folded = False
 
     for raw in lines[1:]:
         line = raw.rstrip("\r")
@@ -81,7 +80,6 @@ def parse_skill_md(path: Path, fallback_name: str) -> tuple[str, str]:
             value = m.group(1).strip()
             if value in FOLD_INDICATORS:
                 in_block = True
-                folded = value.startswith(">")
                 desc_parts = []
             else:
                 desc_parts = [value.strip("\"'")]
@@ -95,10 +93,7 @@ def parse_skill_md(path: Path, fallback_name: str) -> tuple[str, str]:
                 continue
             desc_parts.append(line.strip())
 
-    if in_block and folded:
-        text = " ".join(p for p in desc_parts if p)
-    else:
-        text = " ".join(p for p in desc_parts if p)
+    text = " ".join(p for p in desc_parts if p)
 
     return (name, re.sub(r"\s+", " ", text).strip())
 

--- a/scripts/maintenance/check_codex_skills_budget.py
+++ b/scripts/maintenance/check_codex_skills_budget.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Codex Skill Description Budget Checker
+
+Reports the total length of skill description metadata in claude/skills/.
+Codex truncates skill descriptions when they exceed roughly 2% of the
+context window (about 5440 chars on current builds), which silently degrades
+trigger accuracy. Run this to detect when the SSOT is approaching that limit.
+
+Usage:
+    python3 check_codex_skills_budget.py [--budget N] [--top N] [--all]
+                                          [--quiet] [--skills-dir PATH]
+
+Exit codes:
+    0  total description length is within budget
+    1  total description length exceeds budget
+    2  error (skills directory missing, parse failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+class Colors:
+    RESET = "\033[0m"
+    DIM = "\033[2m"
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    YELLOW = "\033[33m"
+    BLUE = "\033[34m"
+
+
+DEFAULT_BUDGET_CHARS = 5440  # observed Codex skill metadata budget
+DEFAULT_TOP_N = 10
+LONG_WARN = 400  # per-skill chars that strongly suggest trimming
+LONG_HINT = 250  # per-skill chars that hint at being on the long side
+
+NAME_RE = re.compile(r"^name:\s*(.+?)\s*$")
+DESC_RE = re.compile(r"^description:\s*(.*)$")
+KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*:")
+FOLD_INDICATORS = {">", ">-", ">+", "|", "|-", "|+"}
+
+
+def parse_skill_md(path: Path, fallback_name: str) -> tuple[str, str]:
+    """Extract (name, description) from a SKILL.md frontmatter block.
+
+    Supports single-line scalars and folded/literal block scalars
+    (``>``, ``>-``, ``|``, ...). Falls back to ``fallback_name`` if no
+    ``name:`` is declared in the frontmatter.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return (fallback_name, "")
+
+    if not lines or lines[0].strip() != "---":
+        return (fallback_name, "")
+
+    name = fallback_name
+    desc_parts: list[str] = []
+    in_block = False
+    folded = False
+
+    for raw in lines[1:]:
+        line = raw.rstrip("\r")
+        if line.strip() == "---":
+            break
+
+        m = NAME_RE.match(line)
+        if m:
+            name = m.group(1).strip().strip("\"'")
+            in_block = False
+            continue
+
+        m = DESC_RE.match(line)
+        if m:
+            value = m.group(1).strip()
+            if value in FOLD_INDICATORS:
+                in_block = True
+                folded = value.startswith(">")
+                desc_parts = []
+            else:
+                desc_parts = [value.strip("\"'")]
+                in_block = False
+            continue
+
+        if in_block:
+            # A new top-level YAML key terminates the block scalar.
+            if KEY_RE.match(line):
+                in_block = False
+                continue
+            desc_parts.append(line.strip())
+
+    if in_block and folded:
+        text = " ".join(p for p in desc_parts if p)
+    else:
+        text = " ".join(p for p in desc_parts if p)
+
+    return (name, re.sub(r"\s+", " ", text).strip())
+
+
+def collect_rows(skills_dir: Path) -> list[tuple[str, int, Path]]:
+    rows: list[tuple[str, int, Path]] = []
+    for entry in sorted(skills_dir.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        skill_md = entry / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        name, desc = parse_skill_md(skill_md, entry.name)
+        rows.append((name, len(desc), entry))
+    return rows
+
+
+def format_marker(length: int) -> str:
+    if length >= LONG_WARN:
+        return f"  {Colors.YELLOW}(>= {LONG_WARN} chars — consider trimming){Colors.RESET}"
+    if length >= LONG_HINT:
+        return f"  {Colors.DIM}(>= {LONG_HINT}){Colors.RESET}"
+    return ""
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=("Report Codex skill description length to detect context budget overruns."),
+    )
+    parser.add_argument(
+        "-b",
+        "--budget",
+        type=int,
+        default=DEFAULT_BUDGET_CHARS,
+        help=f"budget threshold in chars (default: {DEFAULT_BUDGET_CHARS})",
+    )
+    parser.add_argument(
+        "-n",
+        "--top",
+        type=int,
+        default=DEFAULT_TOP_N,
+        help=f"show top N longest descriptions (default: {DEFAULT_TOP_N})",
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        help="show all skills, not just the top N longest",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="print only the final budget verdict",
+    )
+    parser.add_argument(
+        "--skills-dir",
+        type=Path,
+        default=None,
+        help="skills directory (default: <dotfiles>/claude/skills)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.skills_dir is not None:
+        skills_dir = args.skills_dir
+    else:
+        script_path = Path(__file__).resolve()
+        skills_dir = script_path.parents[2] / "claude" / "skills"
+
+    if not skills_dir.is_dir():
+        print(
+            f"{Colors.RED}Error: skills source not found: {skills_dir}{Colors.RESET}",
+            file=sys.stderr,
+        )
+        return 2
+
+    rows = collect_rows(skills_dir)
+    total_chars = sum(r[1] for r in rows)
+    skill_count = len(rows)
+    avg = total_chars / skill_count if skill_count else 0
+    over_budget = total_chars > args.budget
+
+    if not args.quiet:
+        print(f"{Colors.BLUE}=== Codex Skill Description Budget ==={Colors.RESET}")
+        print(f"  Source dir: {skills_dir}")
+        print(f"  Skills:     {skill_count}")
+        print(f"  Total:      {total_chars} chars  (avg {avg:.0f}/skill)")
+        print(f"  Budget:     {args.budget} chars")
+        print()
+
+        rows_sorted = sorted(rows, key=lambda r: -r[1])
+        view = rows_sorted if args.all else rows_sorted[: args.top]
+        header = "All skills" if args.all else (f"Top {min(args.top, len(rows_sorted))} longest")
+        print(f"{Colors.BLUE}-- {header} --{Colors.RESET}")
+        for name, length, _path in view:
+            print(f"  {length:5d}  {name}{format_marker(length)}")
+
+    if over_budget:
+        print()
+        print(f"{Colors.RED}! Total description chars ({total_chars}) exceed budget ({args.budget}).{Colors.RESET}")
+        print(
+            f"{Colors.YELLOW}  Suggestion: trim long descriptions to "
+            f"150-250 chars, or pin Codex to a subset via "
+            f"claude/skills/.codex-allowlist.{Colors.RESET}"
+        )
+        return 1
+
+    if not args.quiet:
+        print(f"{Colors.GREEN}OK Within budget ({total_chars}/{args.budget} chars).{Colors.RESET}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -14,6 +14,12 @@
 #     ~/.codex/skills/.system                          ← local (codex managed)
 #     ~/.codex/skills/<custom-skill>                   → ~/dotfiles/claude/skills/<custom-skill>
 #
+#   - Codex 선택적 연결: claude/skills/.codex-allowlist 가 존재하고 비어 있지 않으면
+#     해당 파일에 나열된 skill 만 연결되고 나머지 SSOT skill 은 codex 관리 대상에서 제거됨.
+#     description 합계가 Codex 의 2% 컨텍스트 예산 (~5440자) 을 초과해 트렁케이션이
+#     발생하는 것을 막는 용도. 한 줄에 하나의 skill 디렉토리 이름, '#' 으로 시작하는
+#     주석과 빈 줄은 무시됨. 파일이 없거나 모두 비어 있으면 종전대로 전체 연결.
+#
 # ~/.claude/skills 는 claude/setup.sh (bind mount) 가 관리
 
 # --- Constants ---
@@ -38,8 +44,45 @@ log_warning() { ux_warning "$1"; }
 log_critical() { ux_error "$1"; exit 1; }
 
 CODEX_MANAGED_MARKER=".dotfiles-skill-source"
+CODEX_ALLOWLIST_FILE="${SKILLS_SOURCE}/.codex-allowlist"
 
 # --- Helper Functions ---
+
+# Read codex allowlist file and emit one skill name per line.
+# Strips comments (#...) and blank lines. Stdout is empty if no entries
+# were found, allowing callers to detect "no allowlist" via -z check.
+read_codex_allowlist() {
+    local file="${1:-$CODEX_ALLOWLIST_FILE}"
+    [ -f "$file" ] || return 0
+
+    awk '
+        {
+            sub(/#.*/, "")        # strip inline comments
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+            if (length($0) == 0) next
+            print
+        }
+    ' "$file"
+}
+
+# Test whether a skill name is allowed.
+# Args: <skill_name> <allowlist_text>
+# Returns 0 if skill is allowed (allowlist empty OR skill listed), 1 otherwise.
+codex_skill_is_allowed() {
+    local skill="$1"
+    local allowlist="$2"
+
+    [ -z "$allowlist" ] && return 0
+
+    case "
+${allowlist}
+" in
+        *"
+${skill}
+"*) return 0 ;;
+    esac
+    return 1
+}
 
 collect_codex_homes() {
     local default_config_home
@@ -143,15 +186,18 @@ link_skills_individual() {
 # - .system 은 로컬 보존
 # - custom skill 은 디렉토리 symlink (SSOT 직결)
 # - 기존 copy/marker 레이아웃(.dotfiles-skill-source)은 자동 마이그레이션
-# Usage: link_skills_individual_codex <target_dir>
+# - allowlist 가 존재하면 그 안에 명시된 skill 만 연결 (Codex 컨텍스트 예산 보호)
+# Usage: link_skills_individual_codex <target_dir> [allowlist_text]
 link_skills_individual_codex() {
     local target_dir="$1"
+    local allowlist="${2:-}"
     local linked=0
     local unchanged=0
     local migrated=0
     local skipped=0
     local pruned=0
     local prune_skipped=0
+    local excluded=0
     local source_root
     source_root="$(readlink -f "$SKILLS_SOURCE")"
 
@@ -163,6 +209,11 @@ link_skills_individual_codex() {
         local skill_name
         skill_name="$(basename "$skill_path")"
         if [ "$skill_name" = ".system" ]; then
+            continue
+        fi
+
+        if ! codex_skill_is_allowed "$skill_name" "$allowlist"; then
+            excluded=$((excluded + 1))
             continue
         fi
 
@@ -255,7 +306,8 @@ link_skills_individual_codex() {
             continue
         fi
 
-        if [ -d "${SKILLS_SOURCE}/${existing_name}" ]; then
+        if [ -d "${SKILLS_SOURCE}/${existing_name}" ] && \
+           codex_skill_is_allowed "$existing_name" "$allowlist"; then
             continue
         fi
 
@@ -291,7 +343,11 @@ link_skills_individual_codex() {
         prune_skipped=$((prune_skipped + 1))
     done
 
-    log_info "[codex] skill 연결 완료: ${linked}개 신규, ${unchanged}개 유지, ${migrated}개 마이그레이션, ${skipped}개 보존, ${pruned}개 정리, ${prune_skipped}개 stale 보존"
+    if [ -n "$allowlist" ]; then
+        log_info "[codex] skill 연결 완료: ${linked}개 신규, ${unchanged}개 유지, ${migrated}개 마이그레이션, ${skipped}개 보존, ${pruned}개 정리, ${prune_skipped}개 stale 보존, ${excluded}개 allowlist 제외"
+    else
+        log_info "[codex] skill 연결 완료: ${linked}개 신규, ${unchanged}개 유지, ${migrated}개 마이그레이션, ${skipped}개 보존, ${pruned}개 정리, ${prune_skipped}개 stale 보존"
+    fi
 }
 
 # --- Main ---
@@ -311,11 +367,17 @@ else
     link_skills_dir "opencode" "$OPENCODE_SKILLS"
 fi
 
-# 2. Codex: .system 보존 + custom skill 디렉토리 symlink
+# 2. Codex: .system 보존 + custom skill 디렉토리 symlink (선택적 allowlist 적용)
 CODEX_HOME_LIST="$(collect_codex_homes)"
 if [ -z "$CODEX_HOME_LIST" ]; then
     log_warning "Codex 설정 디렉토리가 없습니다. 건너뜁니다: ~/.codex 또는 ~/.config/codex"
 else
+    CODEX_ALLOWLIST_TEXT="$(read_codex_allowlist "$CODEX_ALLOWLIST_FILE")"
+    if [ -n "$CODEX_ALLOWLIST_TEXT" ]; then
+        codex_allowlist_count="$(printf '%s\n' "$CODEX_ALLOWLIST_TEXT" | grep -c .)"
+        log_info "[codex] allowlist 적용: ${codex_allowlist_count}개 skill (출처: $CODEX_ALLOWLIST_FILE)"
+    fi
+
     while IFS= read -r codex_home; do
         [ -n "$codex_home" ] || continue
 
@@ -337,7 +399,7 @@ else
 
         if [ "$codex_can_manage" -eq 1 ]; then
             mkdir -p "$CODEX_SKILLS"
-            link_skills_individual_codex "$CODEX_SKILLS"
+            link_skills_individual_codex "$CODEX_SKILLS" "$CODEX_ALLOWLIST_TEXT"
         fi
     done <<< "$CODEX_HOME_LIST"
 fi

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# tests/bats/tools/setup_skills_ssot.bats
+# Validate scripts/setup-skills-ssot.sh — focuses on the Codex allowlist
+# behaviour that gates the .codex-allowlist file (issue #216).
+
+load '../test_helper'
+
+SETUP_SSOT_SCRIPT="${DOTFILES_ROOT}/scripts/setup-skills-ssot.sh"
+DIAG_SCRIPT="${DOTFILES_ROOT}/scripts/maintenance/check_codex_skills_budget.py"
+UX_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+
+setup() {
+    setup_isolated_home
+
+    # Build a minimal dotfiles fixture under TEST_TEMP_HOME so the
+    # script can be invoked without touching the real dotfiles tree.
+    FIXTURE_DOTFILES="${TEST_TEMP_HOME}/fixture-dotfiles"
+    FIXTURE_HOME="${TEST_TEMP_HOME}/fixture-home"
+    mkdir -p \
+        "${FIXTURE_DOTFILES}/scripts" \
+        "${FIXTURE_DOTFILES}/claude/skills/alpha" \
+        "${FIXTURE_DOTFILES}/claude/skills/beta" \
+        "${FIXTURE_DOTFILES}/claude/skills/gamma" \
+        "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib" \
+        "${FIXTURE_HOME}/.codex/skills"
+
+    cp "$SETUP_SSOT_SCRIPT" "${FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
+    cp "$UX_LIB_SOURCE" "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib/ux_lib.sh"
+
+    for s in alpha beta gamma; do
+        cat > "${FIXTURE_DOTFILES}/claude/skills/${s}/SKILL.md" <<EOF
+---
+name: ${s}
+description: stub description for ${s}
+---
+EOF
+    done
+
+    export FIXTURE_DOTFILES FIXTURE_HOME
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+run_setup() {
+    HOME="$FIXTURE_HOME" run bash "${FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
+}
+
+# --- Allowlist behaviour ---
+
+@test "no allowlist file: every SSOT skill is symlinked into ~/.codex/skills" {
+    run_setup
+    assert_success
+
+    for s in alpha beta gamma; do
+        local target="${FIXTURE_HOME}/.codex/skills/${s}"
+        [ -L "$target" ]
+        local resolved
+        resolved="$(readlink -f "$target")"
+        [ "$resolved" = "$(readlink -f "${FIXTURE_DOTFILES}/claude/skills/${s}")" ]
+    done
+}
+
+@test "allowlist with two entries: only listed skills are linked" {
+    cat > "${FIXTURE_DOTFILES}/claude/skills/.codex-allowlist" <<EOF
+# Pinned codex skills
+alpha
+gamma
+EOF
+
+    run_setup
+    assert_success
+    assert_output --partial "allowlist 적용: 2개 skill"
+
+    [ -L "${FIXTURE_HOME}/.codex/skills/alpha" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/gamma" ]
+    [ ! -e "${FIXTURE_HOME}/.codex/skills/beta" ]
+}
+
+@test "allowlist prunes a previously linked skill that is no longer allowed" {
+    # First sync without an allowlist — beta gets linked.
+    run_setup
+    assert_success
+    [ -L "${FIXTURE_HOME}/.codex/skills/beta" ]
+
+    # Add an allowlist that excludes beta and re-run.
+    printf 'alpha\ngamma\n' \
+        > "${FIXTURE_DOTFILES}/claude/skills/.codex-allowlist"
+
+    run_setup
+    assert_success
+    [ ! -e "${FIXTURE_HOME}/.codex/skills/beta" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/alpha" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/gamma" ]
+}
+
+@test "allowlist with only comments behaves as if missing (link all)" {
+    cat > "${FIXTURE_DOTFILES}/claude/skills/.codex-allowlist" <<EOF
+# everything is commented out
+# beta
+EOF
+
+    run_setup
+    assert_success
+    refute_output --partial "allowlist 적용"
+
+    for s in alpha beta gamma; do
+        [ -L "${FIXTURE_HOME}/.codex/skills/${s}" ]
+    done
+}
+
+# --- Diagnostic script ---
+
+@test "check_codex_skills_budget: reports under-budget and exits 0" {
+    run python3 "$DIAG_SCRIPT" \
+        --skills-dir "${FIXTURE_DOTFILES}/claude/skills" \
+        --budget 1000
+    assert_success
+    assert_output --partial "Skills:     3"
+    assert_output --partial "Within budget"
+}
+
+@test "check_codex_skills_budget: flags over-budget and exits 1" {
+    run python3 "$DIAG_SCRIPT" \
+        --skills-dir "${FIXTURE_DOTFILES}/claude/skills" \
+        --budget 5
+    [ "$status" -eq 1 ]
+    assert_output --partial "exceed budget"
+    assert_output --partial ".codex-allowlist"
+}


### PR DESCRIPTION
## Summary
- Codex 가 skill description 합계가 컨텍스트 ~2% (≈5440자) 를 넘으면 조용히 잘라내 트리거 정확도가 떨어지는 문제를 해결.
- SSOT 를 트리밍하지 않고도 예산을 지킬 수 있도록 (1) `claude/skills/.codex-allowlist` 옵트인과 (2) 예산 진단 스크립트를 추가.
- bats 회귀 테스트로 allowlist 의 link/prune/주석-only 경로와 진단 스크립트의 pass/fail 종료 코드를 격리된 fixture 에서 검증.

## Changes
- `scripts/setup-skills-ssot.sh`: `claude/skills/.codex-allowlist` 가 있고 비어 있지 않으면 명시된 skill 만 `~/.codex/skills` 에 링크하고, 이전에 링크된 SSOT skill 중 allowlist 밖은 정리. `#` 주석과 빈 줄은 무시되어 전부 주석이면 파일이 없는 것과 동일하게 동작.
- `scripts/maintenance/check_codex_skills_budget.py`: stdlib 만 사용. skill 별 description 길이, 합계 vs 예산, 가장 긴 Top N 출력. 예산 초과 시 종료 코드 1 로 CI 게이팅 가능.
- `scripts/maintenance/README.md`: 신규 진단 스크립트 사용법·시나리오 섹션 추가.
- `tests/bats/tools/setup_skills_ssot.bats`: 격리된 fixture 로 (no-allowlist / 2-entry / prune / comment-only) 4 가지 link 동작과 진단 스크립트의 under-/over-budget 종료 코드를 회귀 검증.

## Test plan
- [x] `bats tests/bats/tools/setup_skills_ssot.bats` (6 cases) 로컬 통과
- [x] `python3 scripts/maintenance/check_codex_skills_budget.py` 실제 SSOT 에 대해 실행해 현재 합계 확인
- [ ] CI 에서 bats + python3 진단 모두 통과 확인
- [ ] 머지 후 `bash scripts/setup-skills-ssot.sh` 재실행 시 기존 codex link 가 변동 없이 유지되는지 (allowlist 부재 = 전체 링크) 확인

## Related
Closes #216

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
