### PR TITLE
fix(workers): redirect stdin from /dev/null on nohup worker spawn

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -448,7 +448,7 @@ _gh_flow_spawn_worker() {
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_flow_worker "$1" "$2"
-    ' -- "$_issue" "$_ai" >"$_log" 2>&1 &
+    ' -- "$_issue" "$_ai" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -293,7 +293,7 @@ _gh_pr_approve_spawn_worker() {
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_pr_approve_worker "$1" "$2"
-    ' -- "$_pr" "$_ai" >"$_log" 2>&1 &
+    ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -292,7 +292,7 @@ _gh_pr_reply_spawn_worker() {
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_pr_reply_worker "$1" "$2"
-    ' -- "$_pr" "$_ai" >"$_log" 2>&1 &
+    ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"


### PR DESCRIPTION
## Summary
- `gh-pr-approve --ai gemini` 실행 시 백그라운드 워커가 `EBADF: bad file descriptor, read` 로 크래시되는 문제 수정.
- 원인은 `nohup ... bash -c '...' >"$_log" 2>&1 &` 구문에서 `stdin` 리다이렉션이 빠져 출력 리다이렉션 파일이 FD 0번 자리를 차지(FD hijacking)하면서, Gemini CLI(Node.js)가 초기화 시 동기 `fs.readSync(0, ...)` 를 호출하다 쓰기 전용 FD에서 읽기를 시도하는 것.
- `gh-flow`, `gh-pr-approve`, `gh-pr-reply` 세 워커 spawn 지점 모두 동일 패턴이라 한 번에 같이 고침.

## Changes
- `shell-common/functions/gh_flow.sh`: `_gh_flow_spawn_worker` 의 `nohup` 라인에 `</dev/null` 추가.
- `shell-common/functions/gh_pr_approve.sh`: `_gh_pr_approve_spawn_worker` 의 `nohup` 라인에 `</dev/null` 추가.
- `shell-common/functions/gh_pr_reply.sh`: `_gh_pr_reply_spawn_worker` 의 `nohup` 라인에 `</dev/null` 추가.

## Test plan
- [ ] `bash -n shell-common/functions/{gh_flow,gh_pr_approve,gh_pr_reply}.sh`
- [ ] `shellcheck -s bash shell-common/functions/{gh_flow,gh_pr_approve,gh_pr_reply}.sh`
- [ ] 실 PR 에서 `gh-pr-approve --ai gemini <N>` 재현 → EBADF 없이 워커 정상 진행, 로그 끝에 토큰 사용량 블록까지 출력되는지 확인.
- [ ] `gh-pr-approve <N>` (claude 기본), `gh-pr-reply --ai codex <N>`, `gh-flow <issue> --ai gemini` 가 회귀 없이 동작하는지 스모크.

## Related
Closes #222

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
