### PR TITLE
fix(gwt): auto-recover submodule-blocked teardown

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -914,6 +914,8 @@ _gwt_teardown_one_inplace() {
         : > "$_gwt_rm_err_file"
         if git worktree remove --force "$wt_path" 2>"$_gwt_rm_err_file"; then
             _gwt_rm_exit=0
+        else
+            _gwt_rm_exit=$?
         fi
     fi
 

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -899,6 +899,24 @@ _gwt_teardown_one_inplace() {
         git worktree remove "$wt_path" 2>"$_gwt_rm_err_file" || _gwt_rm_exit=$?
     fi
 
+    # Auto-recovery for the submodule-block case. `git worktree remove` refuses
+    # any tree that contains submodules, even when their working trees are
+    # untouched — the AI-worktree workflow re-clones submodules on the next
+    # spawn, so their populated state is disposable. The parent worktree has
+    # already passed every dirty-state pre-flight above (uncommitted, staged,
+    # untracked, unpushed), so retrying with --force here only adds permission
+    # to drop populated submodule contents — exactly what we want. Without
+    # this, every teardown of a repo with submodules would force the user to
+    # rerun manually, which is what issue #211 was filed against.
+    if [ "$_gwt_rm_exit" -ne 0 ] && [ "$force" != true ] \
+       && grep -q "working trees containing submodules cannot be moved or removed" "$_gwt_rm_err_file" 2>/dev/null; then
+        ux_info "Submodules detected — retrying removal (parent worktree already verified clean)."
+        : > "$_gwt_rm_err_file"
+        if git worktree remove --force "$wt_path" 2>"$_gwt_rm_err_file"; then
+            _gwt_rm_exit=0
+        fi
+    fi
+
     if [ "$_gwt_rm_exit" -ne 0 ]; then
         local _gwt_submodule_blocked=false
         if grep -q "working trees containing submodules cannot be moved or removed" "$_gwt_rm_err_file" 2>/dev/null; then
@@ -915,7 +933,11 @@ _gwt_teardown_one_inplace() {
             sed 's/^/    /' "$_gwt_rm_err_file" >&2
         fi
         if [ "$_gwt_submodule_blocked" = true ]; then
-            ux_warning "  Git blocked removal because this worktree contains submodule(s)."
+            # Auto-recovery already retried with --force above; reaching here
+            # means even --force could not remove this worktree (locked
+            # submodule, permissions, gitlink corruption, etc.). The user has
+            # to investigate manually.
+            ux_warning "  Git blocked removal even with --force — a submodule is in an unusual state."
             local _gwt_submodule_paths _gwt_submodule_path _gwt_submodule_count=0
             _gwt_submodule_paths="$(git -C "$wt_path" config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')"
             if [ -n "$_gwt_submodule_paths" ]; then
@@ -929,8 +951,8 @@ _gwt_teardown_one_inplace() {
 $_gwt_submodule_paths
 EOF
             fi
-            ux_info "  If worktree-local submodule state is disposable, rerun:"
-            ux_info "    cd \"$wt_path\" && gwt teardown --force"
+            ux_info "  Inspect:  git -C \"$wt_path\" submodule foreach 'git status --short'"
+            ux_info "  Locks:    git -C \"$wt_path\" submodule foreach 'git config --get core.bare; git status'"
         elif [ "$force" != true ]; then
             ux_info "  Inspect:  git -C \"$wt_path\" status --short"
             ux_info "  Clean:    git -C \"$wt_path\" clean -fd"

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -282,10 +282,14 @@ _squash_merge_branch_into_origin_main() {
     git -C "$CLONE" worktree unlock "$WORKTREE" 2>/dev/null || true
 }
 
-@test "teardown: submodule block explains cause and suggests force" {
-    local sub_origin="$TEST_TEMP_HOME/sub-origin.git"
-    local sub_seed="$TEST_TEMP_HOME/sub-seed"
-    local sub_wt="$TEST_TEMP_HOME/clone-submodule-1"
+# Helper: bootstrap a parent clone whose main branch carries one submodule,
+# then create a worktree that has the submodule populated. Echoes the worktree
+# path on stdout. Caller passes a unique branch+worktree suffix.
+_setup_clone_with_submodule() {
+    local suffix="$1"
+    local sub_origin="$TEST_TEMP_HOME/sub-origin-$suffix.git"
+    local sub_seed="$TEST_TEMP_HOME/sub-seed-$suffix"
+    local sub_wt="$TEST_TEMP_HOME/clone-submodule-$suffix"
 
     git init --bare --initial-branch=main "$sub_origin" >/dev/null
     git clone -q "$sub_origin" "$sub_seed"
@@ -301,21 +305,28 @@ _squash_merge_branch_into_origin_main() {
     (
         cd "$CLONE"
         git checkout -q main
-        git -c protocol.file.allow=always submodule add "$sub_origin" tests/bats/lib/bats-core >/dev/null
-        git commit -q -m "add test submodule"
+        git -c protocol.file.allow=always submodule add "$sub_origin" "tests/bats/lib/bats-core-$suffix" >/dev/null
+        git commit -q -m "add test submodule $suffix"
         git push -q origin main
     )
 
-    git -C "$CLONE" worktree add -q -b wt/submodule/1 "$sub_wt" origin/main
+    git -C "$CLONE" worktree add -q -b "wt/submodule/$suffix" "$sub_wt" origin/main
     git -C "$sub_wt" -c protocol.file.allow=always submodule update --init --recursive >/dev/null
+    printf '%s\n' "$sub_wt"
+}
+
+@test "teardown: submodule block triggers auto-recovery and removes worktree" {
+    # Populated submodules block `git worktree remove`, but the parent worktree
+    # already passed every dirty-state pre-flight, so retrying with --force
+    # only authorizes dropping disposable submodule contents. Teardown should
+    # do this automatically — no manual --force rerun.
+    local sub_wt
+    sub_wt="$(_setup_clone_with_submodule clean)"
 
     run_in_bash "cd '$sub_wt' && gwt teardown 2>&1"
-    assert_failure
-    assert_output --partial "working trees containing submodules cannot be moved or removed"
-    assert_output --partial "Git blocked removal because this worktree contains submodule"
-    assert_output --partial "Submodules in this repository:"
-    assert_output --partial "tests/bats/lib/bats-core"
-    assert_output --partial "gwt teardown --force"
+    assert_success
+    assert_output --partial "Submodules detected — retrying removal"
+    [ ! -d "$sub_wt" ]
 }
 
 @test "teardown: on failure, cwd stays in the worktree (not main repo)" {


### PR DESCRIPTION
## Summary
- `git worktree remove` refuses any tree that contains submodules even when their working trees are clean, and only `--force` (not `submodule deinit`) actually unblocks it. PR #211 fixed only the error message — every submodule teardown still required a manual `gwt teardown --force` rerun.
- Auto-retry with `--force` scoped to the worktree-remove call when the original failure is the submodule-block error and the parent worktree has already passed every dirty-state pre-flight (uncommitted, staged, untracked, unpushed). The escalation only authorizes dropping disposable populated-submodule contents — they re-clone on the next `gwt spawn`.
- The submodule branch in the user-facing error block now reports the genuinely unusual case where even `--force` could not remove the worktree (locked submodule, permissions, gitlink corruption).

## Test plan
- [x] `bats tests/bats/functions/git_worktree_teardown.bats` — 23/23 pass, including the new `teardown: submodule block triggers auto-recovery and removes worktree` case
- [x] `bats tests/bats/{functions,init,tools}` — 183/183 pass, no regressions
- [x] Manual repro on `~/dotfiles-issue-222-1`: `gwt teardown` now removes the worktree in one step (no `--force` rerun)

Refs: #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
