### PR TITLE
refactor(skill): apply progressive disclosure to gh-pr

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -14,8 +14,8 @@ allowed-tools: Bash, Read, Grep
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No API calls.
 
 ## Role
 
@@ -25,30 +25,31 @@ body. Push the branch if needed. Return the PR URL.
 ## Step 1: Determine Base Branch and State (parallel)
 
 Run in a single message:
+
 - `git rev-parse --abbrev-ref HEAD` — current branch
 - `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` — base
 - `git status`
-- `git fetch origin` — refresh remote refs
-
-Then:
-- `git log --oneline <base>..HEAD` — every commit in the PR range
+- `git fetch origin`
+- `git log --oneline <base>..HEAD` — every commit in the range
 - `git diff <base>...HEAD` — full diff
 - `git rev-parse --symbolic-full-name @{u} 2>/dev/null` — upstream check
 
 **Stop conditions:**
+
 - If current branch equals base branch → tell the user to create a feature
   branch first.
 - If `git log <base>..HEAD` is empty → tell the user there's nothing to PR.
 
 ## Step 2: Analyze ALL Commits in the Range
 
-Critical: the PR body must reflect **every commit** in the range, not just
-the latest one. Read `git log <base>..HEAD` output and group changes by
-theme. A 5-commit PR should mention all 5 concerns, not just HEAD's change.
+The PR body must reflect **every commit** in the range, not just the latest.
+Read `git log <base>..HEAD` output and group changes by theme. A 5-commit PR
+mentions all 5 concerns.
 
 ## Step 3: Resolve the Issue Number
 
 Same precedence as `gh:commit`:
+
 1. Explicit argument on `/gh:pr` (e.g., `/gh:pr 123`)
 2. Scan recent conversation for `#N` or `Issue #N created`
 3. Scan commit messages in the range for `Refs #N` / `Closes #N` / `Fixes #N`
@@ -57,44 +58,26 @@ Same precedence as `gh:commit`:
 ## Step 4: Draft Title and Body
 
 Read `references/pr-body-template.md` for title rules, body structure, and
-the `gh pr create` command. Match the language of existing commits (Korean
-if commits are Korean).
+the body markdown. Match the language of existing commits (Korean if commits
+are Korean).
 
 ## Step 5: Push and Create
 
-- If no upstream: `git push -u origin HEAD`
-- If upstream exists and local is ahead: `git push`
-- If upstream is diverged: **stop and ask the user before force-pushing**
-  (never force-push without explicit approval).
-
-Write the body to a unique temp file via `mktemp`, then create the PR with
-`--assignee @me` (always self-assigned). Full command in
-`references/pr-body-template.md`.
+Read `references/push-and-create.md` for the upstream-state push policy and
+the `gh pr create` command (uses `mktemp` body file, `--assignee @me`).
 
 ## Step 6: Apply Labels
 
-Derive labels from conventional-commit types in `git log <base>..HEAD`
-and PR scope (e.g. `skill` for `claude/skills/` changes). Apply only
-labels that exist in the repo (`gh label list`) — never create new ones.
-See `references/pr-body-template.md` for the full mapping + safe-apply loop.
+Derive labels from conventional-commit types in `git log <base>..HEAD` and
+PR scope (e.g. `skill` for `claude/skills/` changes). Apply only labels that
+exist in the repo (`gh label list`) — never create new ones. See
+`references/pr-body-template.md` for the full mapping and safe-apply loop.
 
 ## Step 7: Sync Project Board Status
 
-After the PR is created, push its project-board card to `In review` so
-reviewers see it on the kanban without manual drag. Source the shared
-helper (it lives in `shell-common/functions/gh_project_status.sh`) and
-call it with the new PR number — no guard option, because the PR
-lifecycle is linear and `In review` is the canonical resting state from
-PR open through approval:
-
-```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-_gh_project_status_sync pr <PR_NUMBER> "In review"
-```
-
-If the repo has no projectV2 board attached (auto-detected — the helper
-finds zero project items and silently returns 0), nothing happens. Opt
-out per-invocation with `GH_PROJECT_STATUS_SYNC=0`.
+Read `references/project-board-sync.md` for the helper-source snippet that
+pushes the new PR's project-board card to `In review`. Auto-skips when no
+projectV2 board is attached.
 
 ## Step 8: Report
 
@@ -104,14 +87,10 @@ Output **only** the PR URL:
 PR created: https://github.com/owner/repo/pull/<N>
 ```
 
-No preamble, no summary of what the PR does — the user opens GitHub directly.
+No preamble, no summary — the user opens GitHub directly.
 
 ## Constraints
 
-- Never force-push without explicit user approval.
-- Never target a base other than the repo's default branch unless the user
-  said so.
-- Never include `🤖 Generated with` or Claude Code footer unless the repo
-  already uses that convention in existing PRs.
-- Never skip commits in the Summary because "they're minor" — the range is
-  the contract.
+Read `references/constraints.md` for hard rules: no force-push without
+approval, default base only, no AI footer unless the repo already uses one,
+never skip commits in the Summary.

--- a/claude/skills/gh-pr/references/constraints.md
+++ b/claude/skills/gh-pr/references/constraints.md
@@ -1,0 +1,36 @@
+# Constraints — hard rules the gh:pr skill must never violate
+
+These apply across every step. If any rule would be broken, stop and ask
+the user instead of proceeding.
+
+## Force-push
+
+Never force-push without explicit user approval. If the upstream has
+diverged from local, surface the divergence and wait for the user to say
+either "force push" or "rebase first" — do not pick for them.
+
+## Base branch
+
+Never target a base other than the repo's default branch (resolved via
+`gh repo view --json defaultBranchRef`) unless the user explicitly asked
+for a different base on the slash-command invocation.
+
+## AI footers
+
+Never include `🤖 Generated with` or any "Claude Code" footer in the PR
+body **unless** the repo already uses that convention in existing PRs.
+Check recent merged PRs (`gh pr list --state merged --limit 5`) before
+deciding.
+
+## Commit coverage
+
+Never skip commits in the Summary because "they're minor" — the commit
+range `<base>..HEAD` is the contract. A 5-commit PR mentions all 5
+concerns. If commits are truly trivial (e.g. typo fixes), group them but
+still acknowledge them.
+
+## Output discipline
+
+The final report contains **only** the PR URL — no preamble, no summary
+of what the PR does, no next-step suggestions. Reviewers open GitHub
+directly.

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -1,0 +1,32 @@
+# Project Board Sync — push the new PR's card to "In review"
+
+After the PR is created, sync its project-board card so reviewers see it on
+the kanban without a manual drag.
+
+## Why "In review" with no guard
+
+The PR lifecycle is linear. `In review` is the canonical resting state from
+the moment a PR opens through approval, so unconditional sync is safe — there
+is no prior status that should block the move.
+
+## Snippet
+
+Source the shared helper, then call it with the new PR number:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+_gh_project_status_sync pr <PR_NUMBER> "In review"
+```
+
+## Behavior
+
+- **No projectV2 board attached** — the helper auto-detects zero project items
+  and silently returns 0. Nothing happens, no error.
+- **Opt-out per invocation** — set `GH_PROJECT_STATUS_SYNC=0` in the
+  environment to skip the sync entirely.
+
+## Where the helper lives
+
+`shell-common/functions/gh_project_status.sh` — shared between `gh:pr`,
+`gh:pr-reply`, and other PR/issue lifecycle skills. Do not inline-copy the
+snippet; always source the file so a single fix propagates everywhere.

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -15,7 +15,7 @@ Source the shared helper, then call it with the new PR number:
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-_gh_project_status_sync pr <PR_NUMBER> "In review"
+_gh_project_status_sync pr "$PR_NUMBER" "In review"
 ```
 
 ## Behavior

--- a/claude/skills/gh-pr/references/push-and-create.md
+++ b/claude/skills/gh-pr/references/push-and-create.md
@@ -1,0 +1,21 @@
+# Push and Create — branch push policy + PR creation command
+
+Used in Step 5 of the `gh:pr` skill, after the body is drafted.
+
+## Push policy
+
+| Upstream state | Action |
+|---|---|
+| No upstream tracking | `git push -u origin HEAD` |
+| Upstream exists, local ahead, no divergence | `git push` |
+| Upstream diverged (force-push needed) | **STOP** — ask the user before force-pushing. Never force-push without explicit approval. |
+
+Detect upstream with `git rev-parse --symbolic-full-name @{u} 2>/dev/null`
+(already gathered in Step 1). Compare with `git status -sb` or
+`git rev-list --left-right --count @{u}...HEAD`.
+
+## PR creation command
+
+Once the push succeeds, create the PR with the command and flags documented
+in `references/pr-body-template.md` (mktemp body file, `--assignee @me`,
+labels applied after creation).


### PR DESCRIPTION
## Summary

Apply Progressive Disclosure to the `gh:pr` skill so SKILL.md fits the
< 100-line ceiling. Detail moves into single-responsibility files under
`claude/skills/gh-pr/references/`.

## Refactoring Complete

### SKILL.md
Before: 117 lines -> After: 96 lines (down 18%)

### References Created
- `references/project-board-sync.md` (32 lines) - Step 7 helper-source snippet that pushes the new PR's card to "In review" and the auto-skip behavior when no projectV2 board is attached.
- `references/push-and-create.md` (21 lines) - Step 5 upstream-state push policy table; defers the `gh pr create` invocation to the existing `references/pr-body-template.md` to avoid duplication.
- `references/constraints.md` (36 lines) - Hard rules: no force-push without approval, default base only, no AI footer unless the repo already uses one, never skip commits in the Summary, output discipline.

### Validation

| Check                    | Result |
|--------------------------|--------|
| SKILL.md <= 100 lines    | PASS (96) |
| Frontmatter valid        | PASS (`name: gh:pr` colon form preserved byte-for-byte; YAML parses) |
| References linked        | PASS (each new file has at least one `references/<file>.md` pointer in SKILL.md) |
| Output format preserved  | PASS (Step 8 still prints only the PR URL) |

### Convention notes

- `name: gh:pr` colon form is the SSOT convention per `claude/skills/skill-refactor/references/naming-convention.md`. NOT rewritten to kebab.
- `allowed-tools: Bash, Read, Grep` unchanged.

## Test plan

- [x] `wc -l claude/skills/gh-pr/SKILL.md` returns 96 (<= 100).
- [x] `head -12 claude/skills/gh-pr/SKILL.md` shows `name: gh:pr` unchanged.
- [x] Each new reference is linked from SKILL.md (`grep -F "references/<file>.md"`).
- [x] YAML frontmatter parses with `python3 -c "import yaml; ..."`.
- [x] markdownlint passes on the four touched markdown files.
- [ ] Run `/skill:check` against `gh-pr` and confirm PASS.

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
