### PR TITLE
refactor(skill): apply progressive disclosure to gh-pr-reply

### DIFF
--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -22,16 +22,15 @@ output its content verbatim, then stop. No API calls.
 ## Role
 
 Systematically process every code-review comment on a PR: judge validity,
-fix valid ones, and reply to each comment with the outcome. This is the
-**politeness rule** — reviewers (humans and bots alike) must see an
-explicit response on every thread. Silent fixes are not acceptable;
-silent declines are worse.
+fix valid ones, and reply to each comment with the outcome. **Politeness
+rule** — reviewers (humans and bots alike) must see an explicit response on
+every thread. Silent fixes are not acceptable; silent declines are worse.
 
 ## Step 1: Resolve Target PR
 
 Precedence:
-1. **Explicit argument** — `/gh:pr-reply 123` → PR #123
-2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`; if no PR exists for the branch, stop and tell the user.
+1. **Explicit argument** — `/gh:pr-reply 123` → PR #123.
+2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`; if no PR exists, stop and tell the user.
 3. Never guess. Never pick "the latest PR in the repo".
 
 Also capture `owner/repo` via `gh repo view --json nameWithOwner`.
@@ -39,8 +38,7 @@ Also capture `owner/repo` via `gh repo view --json nameWithOwner`.
 ## Step 2: Fetch All Review Comments
 
 Read `references/comment-fetching.md` for the three API endpoints, field
-extraction, and dedup rule. Fetch all three; filter out already-replied
-threads.
+extraction, and dedup rule. Fetch all three; filter out already-replied threads.
 
 ## Step 3: Evaluate Each Comment
 
@@ -51,17 +49,15 @@ rules. See `references/reply-templates.md` for the full rubric.
 
 ## Step 4: Apply Fixes (ACCEPT / ACCEPT-PARTIAL only)
 
-- Keep each fix minimal and scoped — don't drive-by refactor.
-- Group related fixes into logical commits: one per theme, not one per
-  comment, unless the user says otherwise.
-- Commit message references the PR, e.g.
-  `fix(review): address X as suggested in PR #123 review`.
-- Never use `--amend` or `--no-verify`.
+Keep each fix minimal and scoped — no drive-by refactors. Group related
+fixes into themed commits (one per theme, not one per comment) with messages
+like `fix(review): address X as suggested in PR #123 review`. Never
+`--amend` or `--no-verify`.
 
 ## Step 5: Reply to Every Comment
 
-**This is non-negotiable. Every comment identified in Step 2 must receive a
-reply, even declined ones, even bot comments.**
+**Non-negotiable. Every comment identified in Step 2 must receive a reply,
+including declined ones and bot comments.**
 
 Read `references/reply-templates.md` for POST command shapes (inline thread
 vs top-level) and the four body templates (Accepted / Accepted-with-modification
@@ -74,49 +70,19 @@ asked) and report new commit SHAs alongside the reply summary.
 
 ## Step 7: Sync Project Board Status
 
-After all replies are posted, push the PR's project-board card to
-`Approved` so the kanban reflects "review round closed, awaiting merge".
-GitHub's `Code review approved` built-in workflow only fires when a
-reviewer submits an `APPROVED` review — and on solo repos the PR author
-cannot self-approve their own PR, so without this step the card never
-leaves `In review` (or `Backlog` if the worker missed the initial
-`Backlog → In review` transition). `/gh-pr-reply` closes that gap.
-
-Source the shared helper (it lives in
-`shell-common/functions/gh_project_status.sh`) and call it with the
-PR number, guarding the transition with `--only-from` so the card
-never regresses from `Done` (e.g. when the user invokes
-`/gh-pr-reply` on an already-merged PR by mistake):
-
-```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-_gh_project_status_sync pr <PR_NUMBER> "Approved" --only-from "Backlog,In progress,In review"
-```
-
-If the repo has no projectV2 board attached (auto-detected — the helper
-finds zero project items and silently returns 0), nothing happens. Opt
-out per-invocation with `GH_PROJECT_STATUS_SYNC=0`.
+Read `references/project-board-sync.md` and run the helper to push the PR's
+project card to `Approved` (no-op when no projectV2 board is attached).
 
 ## Step 8: Report
 
-Print a table the user can scan:
-
-```
-PR #123 review comments processed: 5 total
-  Accepted: 3 (commits abc1234, def5678)
-  Declined: 1
-  Answered: 1
-  -> All comments replied to.
-```
-
-If any comments were skipped as "already replied", list them at the bottom.
+Print the summary table per `references/final-summary.md` showing
+Accepted / Declined / Answered counts, commit SHAs, and any skipped
+already-replied comments.
 
 ## Constraints
 
-- **Never skip a reply.** Even a one-line "Declined: out of scope" is
-  required. This is the core contract of the skill — bot comments included.
+- **Never skip a reply** — even "Declined: out of scope" counts. Bot comments included. This is the core contract of the skill.
 - Never close or resolve threads programmatically — leave that to the user.
-- Never dismiss bot comments as "just a bot". Reply to them too.
-- Never fix comments that touch files outside the PR's diff without
-  flagging it to the user first — that's scope creep.
-- Never `--force-push`. If a fix needs history rewrite, stop and ask.
+- Never dismiss bot comments as "just a bot".
+- Never fix files outside the PR's diff without flagging scope creep first.
+- Never `--force-push`. If history rewrite is needed, stop and ask.

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -71,7 +71,7 @@ asked) and report new commit SHAs alongside the reply summary.
 ## Step 7: Sync Project Board Status
 
 Read `references/project-board-sync.md` and run the helper to push the PR's
-project card to `Approved` (no-op when no projectV2 board is attached).
+project card to `Approved` (no-op when no `projectV2` board is attached).
 
 ## Step 8: Report
 

--- a/claude/skills/gh-pr-reply/references/final-summary.md
+++ b/claude/skills/gh-pr-reply/references/final-summary.md
@@ -1,0 +1,26 @@
+# Final Summary — output table printed by gh:pr-reply Step 8
+
+Print a table the user can scan after all replies are posted:
+
+```
+PR #123 review comments processed: 5 total
+  Accepted: 3 (commits abc1234, def5678)
+  Declined: 1
+  Answered: 1
+  -> All comments replied to.
+```
+
+## Required fields
+
+- **Total** — count of comments identified in Step 2 (after dedup).
+- **Accepted** — count + the commit short-SHAs that landed the fixes.
+- **Declined** — count of comments classified DECLINE.
+- **Answered** — count of comments classified QUESTION.
+- **Closing line** — `-> All comments replied to.` confirms the
+  politeness contract was met.
+
+## Optional appendix
+
+If any comments were skipped as "already replied", list them at the
+bottom under a `Skipped (already replied):` header with the comment IDs
+or short bodies, so the user can verify nothing was silently ignored.

--- a/claude/skills/gh-pr-reply/references/final-summary.md
+++ b/claude/skills/gh-pr-reply/references/final-summary.md
@@ -1,4 +1,4 @@
-# Final Summary — output table printed by gh:pr-reply Step 8
+# Final Summary — output table printed by `gh:pr-reply` Step 8
 
 Print a table the user can scan after all replies are posted:
 

--- a/claude/skills/gh-pr-reply/references/project-board-sync.md
+++ b/claude/skills/gh-pr-reply/references/project-board-sync.md
@@ -26,6 +26,6 @@ _gh_project_status_sync pr <PR_NUMBER> "Approved" --only-from "Backlog,In progre
 
 ## When it does nothing
 
-If the repo has no projectV2 board attached (auto-detected — the helper
+If the repo has no `projectV2` board attached (auto-detected — the helper
 finds zero project items and silently returns 0), nothing happens. Opt
 out per-invocation with `GH_PROJECT_STATUS_SYNC=0`.

--- a/claude/skills/gh-pr-reply/references/project-board-sync.md
+++ b/claude/skills/gh-pr-reply/references/project-board-sync.md
@@ -1,0 +1,31 @@
+# Project Board Sync — push PR card to `Approved` after replies
+
+## Why this step exists
+
+After all replies are posted, push the PR's project-board card to
+`Approved` so the kanban reflects "review round closed, awaiting merge".
+
+GitHub's `Code review approved` built-in workflow only fires when a
+reviewer submits an `APPROVED` review — and on solo repos the PR author
+cannot self-approve their own PR, so without this step the card never
+leaves `In review` (or `Backlog` if the worker missed the initial
+`Backlog → In review` transition). `/gh-pr-reply` closes that gap.
+
+## How to call it
+
+Source the shared helper (it lives in
+`shell-common/functions/gh_project_status.sh`) and call it with the
+PR number, guarding the transition with `--only-from` so the card
+never regresses from `Done` (e.g. when the user invokes
+`/gh-pr-reply` on an already-merged PR by mistake):
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+_gh_project_status_sync pr <PR_NUMBER> "Approved" --only-from "Backlog,In progress,In review"
+```
+
+## When it does nothing
+
+If the repo has no projectV2 board attached (auto-detected — the helper
+finds zero project items and silently returns 0), nothing happens. Opt
+out per-invocation with `GH_PROJECT_STATUS_SYNC=0`.


### PR DESCRIPTION
## Summary

- Shrink `claude/skills/gh-pr-reply/SKILL.md` from **122 → 88 lines** (≤ 100-line limit) by extracting detail into `references/`.
- Extract the project-board-sync helper invocation (~24 lines, why + how + opt-out) → `references/project-board-sync.md`.
- Extract the Step 8 report-table example and required fields → `references/final-summary.md`.
- Tighten Step 4 fix-policy bullets and the Constraints block; keep the **"every comment must get a reply"** politeness contract explicit in Step 5 and Constraints.
- Preserve `name: gh:pr-reply` frontmatter byte-for-byte (colon form per `skill-refactor/references/naming-convention.md`).

## Refactoring Complete

### SKILL.md
Before: 122 lines → After: 88 lines (↓ 28%)

### References Created
- `references/project-board-sync.md` — 31 lines — why/how to push the PR card to `Approved`, opt-out flag.
- `references/final-summary.md` — 26 lines — report table format, required fields, optional skipped-comments appendix.

### Validation
| Check                    | Result |
|--------------------------|--------|
| SKILL.md ≤ 100 lines     | PASS (88) |
| Frontmatter valid        | PASS (`name: gh:pr-reply` preserved, YAML parses) |
| References linked        | PASS (5/5: help, comment-fetching, reply-templates, project-board-sync, final-summary) |
| Output format preserved  | PASS (final-summary.md retains the table example verbatim) |

## Test plan

- [x] `wc -l claude/skills/gh-pr-reply/SKILL.md` → 88 (≤ 100).
- [x] `head -20 SKILL.md` shows `name: gh:pr-reply` unchanged.
- [x] Each new reference file is grep-linked from SKILL.md.
- [x] `python3 -c "yaml.safe_load(...)"` parses frontmatter cleanly.
- [x] `markdownlint` passes for all three changed files.
- [x] Pre-commit hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
