### PR TITLE
fix(gemini): bypass Trusted Folder check in automated environments

### DIFF
--- a/docs/feature/gh-flow-automation/design.md
+++ b/docs/feature/gh-flow-automation/design.md
@@ -101,7 +101,7 @@ POSIX 쉘 파일. bash/zsh에서 sourcing됨. 다음을 정의:
 - 실행 주체별 호출 규칙:
   - `claude` → `claude --dangerously-skip-permissions -p "<slash-command>"`
   - `codex` → `codex exec --dangerously-bypass-approvals-and-sandbox "<slash-command>"`
-  - `gemini` → `gemini --yolo -p "<slash-command>"`
+  - `gemini` → `gemini --approval-mode=yolo --skip-trust -p "<slash-command>"`
 
 - **`_gh_flow_poll_reviews`** (헬퍼 함수): PR 리뷰 상태 조회
   - Args: `<pr-number>`

--- a/docs/feature/gh-pr-approve-ai-option/design.md
+++ b/docs/feature/gh-pr-approve-ai-option/design.md
@@ -86,7 +86,7 @@ gh-pr-approve --ai gemini '#56' '#78'    # gemini + #prefix
 AI별 명령 매핑:
 - `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
 - `codex`: `codex exec --dangerously-bypass-approvals-and-sandbox "<prompt>"`
-- `gemini`: `gemini --yolo -p "<prompt>"`
+- `gemini`: `gemini --approval-mode=yolo --skip-trust -p "<prompt>"`
 
 ### 4.4 가시성
 

--- a/docs/feature/gh-pr-reply-ai-option/design.md
+++ b/docs/feature/gh-pr-reply-ai-option/design.md
@@ -87,7 +87,7 @@ spawn → worker 호출에 `_ai` 전달 추가:
 AI별 명령 매핑:
 - `claude`: `claude --dangerously-skip-permissions -p "<prompt>"`
 - `codex`: `codex exec --dangerously-bypass-approvals-and-sandbox "<prompt>"`
-- `gemini`: `gemini --yolo -p "<prompt>"`
+- `gemini`: `gemini --approval-mode=yolo --skip-trust -p "<prompt>"`
 
 ### 4.4 실패 보존 정책 유지 (핵심)
 

--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -212,7 +212,7 @@ _ai_usage_run() {
     gemini)
         _tmp=$(mktemp -t ai_usage_gemini.XXXXXX) || {
             printf '[ai-usage] mktemp failed; running gemini without tracking\n' >&2
-            gemini --yolo -p "$_prompt"
+            gemini --approval-mode=yolo --skip-trust -p "$_prompt"
             _ec=$?
             printf '{"ai":"gemini","ts":"%s","label":%s,"exit_code":%d,"tracking":"cli_failed"}\n' \
                 "$_now" \
@@ -221,7 +221,7 @@ _ai_usage_run() {
             return $_ec
         }
 
-        gemini --yolo --output-format json -p "$_prompt" >"$_tmp"
+        gemini --approval-mode=yolo --skip-trust --output-format json -p "$_prompt" >"$_tmp"
         _ec=$?
 
         if [ "$_ec" -ne 0 ] || ! [ -s "$_tmp" ]; then

--- a/shell-common/tools/integrations/gemini.sh
+++ b/shell-common/tools/integrations/gemini.sh
@@ -38,5 +38,5 @@ guninstall() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/uninstall_gemini.sh"
 }
 
-alias gemini-skip='gemini --yolo'
-alias gemini-yolo='gemini --yolo'
+alias gemini-skip='gemini --approval-mode=yolo --skip-trust'
+alias gemini-yolo='gemini --approval-mode=yolo --skip-trust'


### PR DESCRIPTION
## Summary
- Gemini CLI 호출 시 `--skip-trust` 플래그를 추가하여 자동화된 환경(headless)에서 "Trusted Folder" 체크로 인한 실패를 해결합니다.
- 기존 `--yolo` 플래그를 권장사항인 `--approval-mode=yolo`로 변경하여 미래 호환성을 확보합니다.

## Changes
- `shell-common/functions/ai_usage.sh`: `_ai_usage_run` 함수 내 `gemini` 호출 시 플래그 업데이트
- `shell-common/tools/integrations/gemini.sh`: `gemini-skip`, `gemini-yolo` 별칭 업데이트
- `docs/feature/*`: 관련 설계 문서 내 명령 매핑 가이드 업데이트

Closes #233

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
