### PR TITLE
chore(vscode): silence python.envFile notice via useEnvFile

### DIFF
--- a/.vscode/base.json
+++ b/.vscode/base.json
@@ -73,6 +73,7 @@
     "explorer.confirmPasteNative": false,
     "cSpell.userWords": ["pkstock", "smtm"],
     "python.analysis.typeCheckingMode": "strict",
+    "python.terminal.useEnvFile": true,
     "notebook.output.wordWrap": true,
     "jupyter.askForKernelRestart": false,
     "testing.coverageToolbarEnabled": true,


### PR DESCRIPTION
## Summary
- `.vscode/base.json`에 `"python.terminal.useEnvFile": true` 1줄 추가
- VSCode Python 확장이 모든 워크스페이스에서 띄우던 *"terminal environment injection is disabled"* 알림 제거
- `python.envFile` 기본값(`${workspaceFolder}/.env`)이 항상 "configured"로 인식되는 동작과 신규 옵션 `useEnvFile` 기본 `false`가 맞물려 발생하던 문제. 옵션을 켜서 종전 암묵적 동작(`.env`가 있으면 터미널이 상속) 그대로 유지.

Refs #234

## Test plan
- [ ] `bash .vscode/sync-push.sh` 후 VSCode 재시작 → 알림 사라짐 확인 (HomePC에서 확인 완료)
- [ ] Internal PC에서 `git pull` 후 동일 절차 수행
- [ ] External PC에서 `git pull` 후 동일 절차 수행
- [ ] 두 PC 모두 확인되면 #234 close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- 워크스페이스 전체에서 `python.terminal.useEnvFile`를 `true`로 설정하도록 공용 VS Code 설정을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update shared VS Code settings to set python.terminal.useEnvFile to true across the workspace.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~2 min
<!-- /ai-metrics -->
