### PR TITLE
feat(project-board): automate kanban board setup (#232)

### DIFF
--- a/docs/playbooks/kanban-board-setup.md
+++ b/docs/playbooks/kanban-board-setup.md
@@ -1,62 +1,139 @@
 # Kanban Board Setup Playbook
 
-GitHub Projects v2 기반 단일 저장소 칸반보드를 30분 안에 셋업
-하는 실행 가이드. AI 에이전트(예: Claude)에게 이 문서를 그대로
-전달하고 "이 문서대로 칸반보드 구성해"라고 지시하면 end-to-end
-자동화된다.
+GitHub Projects v2 기반 단일 저장소 칸반보드를 빠르게 셋업하는
+실행 가이드다. 기본 경로는 `scripts/setup-kanban-board.sh` 1회 실행과
+GitHub UI 체크 몇 단계이며, 수동 절차는 스크립트 미사용 시나
+디버깅용 fallback 으로 남긴다.
 
-본 문서는 dotfiles repo의 SSOT(`docs/standards/github-project-board.md`)에서
-**재사용 가능한 실행 절차만 발췌**한 playbook이다. 의사결정 맥락이
-필요하면 SSOT 원본을 참고.
+본 문서는 dotfiles repo의 SSOT
+(`docs/standards/github-project-board.md`)에서 **재사용 가능한 실행
+절차만 발췌**한 playbook 이다. 운영 정책과 의사결정 배경은 SSOT를
+참고한다.
 
 ## 1. 목표 결과물
 
 - Project v2 보드 1개, 특정 repo에 연결.
-- Status 필드 6 옵션: `Backlog`, `Ready`, `In progress`, `In review`,
-  `Approved`, `Done`.
-- 10개 빌트인 워크플로우 중 9개 기본 `enabled`, `Auto-archive items`는
-  기본 `disabled` — 본 playbook §4.5 필터 적용 후 수동 enable.
-- **Issue 4단계**: `Backlog → In progress → In review → Done`.
-- **PR 4단계**: `Backlog → In review → Approved → Done`
-  (+ Changes requested 발생 시 `In progress`로 일시 루프).
-- 개인 repo 사용 시 `Approved`·`Ready` 컬럼은 view-level hide 권장.
+- Status 필드 6 옵션:
+  `Backlog`, `Ready`, `In progress`, `In review`, `Approved`, `Done`.
+- Issue 4단계: `Backlog → In progress → In review → Done`.
+- PR 4단계: `Backlog → In review → Approved → Done`
+  (`Changes requested` 발생 시 `In progress`로 일시 루프).
+- PR 템플릿에 `Closes #<N>` 자리표시자 포함.
+- 최종 UX: 스크립트 1회 실행 + UI 확인 몇 단계로 30분짜리 수동 셋업을
+  약 5분 경로로 단축.
 
-## 2. Prerequisites
+## 2. Quick Start
+
+### 2.1 Prerequisites
 
 ```bash
 gh auth refresh -s project
 gh auth status   # Token scopes 에 'project' 가 포함돼야 함
+jq --version
 ```
 
-## 3. 변수 (실행 전 export)
+- `gh`, `jq` 가 필요하다.
+- 대상 repo (`OWNER/REPO`) 는 이미 존재해야 한다.
+- 스크립트는 같은 title 의 보드가 이미 있으면 **정상 종료(0)** 하며
+  중복 생성하지 않는다.
 
-bash 코드 블록에서 `<PLACEHOLDER>` 형식은 쉘 리다이렉션으로 오해될
-위험이 있어 모두 `$VAR` 형식으로 사용한다. 아래 블록을 먼저 실행해
-세션에 변수를 export 해두고, 이후 섹션의 명령을 그대로 복사-실행.
+### 2.2 One-Click Setup
 
 ```bash
-export OWNER="dEitY719"           # GitHub user/org 슬러그
-export REPO="my-project"          # 대상 저장소 이름
-export PROJECT_TITLE="$REPO"      # 보드 제목 (대개 $REPO 와 동일)
+scripts/setup-kanban-board.sh \
+    --owner "$OWNER" \
+    --repo "$REPO"
 ```
 
-`$PROJECT_ID`, `$PROJECT_NUMBER`, `$STATUS_FIELD_ID`는 4.1/4.2 에서
-명령을 실행한 뒤 반환값으로 export 한다.
+옵션:
 
-## 4. 셋업 단계
+```bash
+scripts/setup-kanban-board.sh \
+    --owner "$OWNER" \
+    --repo "$REPO" \
+    [--title "$REPO"] \
+    [--auto-archive-window 2d] \
+    [--hide-columns] \
+    [--dry-run] \
+    [--skip-pr-template]
+```
 
-### 4.1 Project 생성
+스크립트가 자동으로 수행하는 일:
+
+1. `gh` / `jq` / auth scope / 대상 repo 존재 여부를 점검한다.
+2. 같은 title 의 Project 가 이미 있으면 URL을 출력하고 정상 종료한다.
+3. Project 를 생성한다.
+4. repo 를 Project 에 링크한다.
+5. Status 필드를 6옵션으로 교체한다.
+6. `.github/pull_request_template.md` 가 없으면 원격 repo 에 생성한다.
+   이미 있으면 `Closes #` 포함 여부만 확인하고, 없더라도 덮어쓰지 않는다.
+7. 마지막에 Project URL, Workflows URL, UI 체크리스트, smoke test 명령을
+   출력한다.
+
+## 3. UI Checklist After Script
+
+스크립트는 마지막에 아래 항목을 직접 URL과 함께 다시 출력한다.
+현재 공개 API 경로 기준으로는 built-in workflow 상세 설정까지 완전 자동화하지
+않고, 사용자가 UI에서 확인해야 한다.
+
+- `Auto-add to project`:
+  repo=`<OWNER>/<REPO>`, filter=`is:issue,pr is:open`
+  신규 open Issue/PR 카드가 자동 유입되도록 한다.
+- `Item added to project`:
+  Status=`Backlog`
+  새 카드의 초기 컬럼을 통일한다.
+- `Pull request linked to issue`:
+  Status=`In review`
+  PR 이 연결된 순간 Issue 카드가 리뷰 단계로 이동한다.
+- `Code review approved`:
+  Status=`Approved`
+  외부 approve 경로의 PR 카드 상태를 유지한다.
+- `Code changes requested`:
+  Status=`In progress`
+  리뷰 피드백 반영 루프를 보드에 드러낸다.
+- `Pull request merged`:
+  Status=`Done`
+  PR 카드 종료 상태를 맞춘다.
+- `Item closed`:
+  Status=`Done`
+  Issue/PR close 와 보드 종료 상태를 맞춘다.
+- `Auto-archive items`:
+  enable + filter=`is:issue,pr is:closed updated:<@today-2d`
+  Done 컬럼에서 오래된 카드를 자동 정리한다.
+- `--hide-columns` 를 사용한 solo repo:
+  Board view 에서 `Approved`, `Ready` 컬럼을 `Hide from view` 한다.
+
+## 4. Manual Fallback (스크립트 미사용 시 / 디버깅 시)
+
+### 4.1 변수
+
+```bash
+export OWNER="dEitY719"
+export REPO="my-project"
+export PROJECT_TITLE="$REPO"
+```
+
+### 4.2 Project 생성
 
 ```bash
 gh project create --owner "$OWNER" --title "$PROJECT_TITLE" --format json
 ```
 
-반환 JSON에서 다음 두 값을 export:
+반환 JSON에서 다음 값을 기록한다.
 
-- `id` → `PROJECT_ID` (예: `PVT_xxx...`) → `export PROJECT_ID=PVT_xxx...`
-- `number` → `PROJECT_NUMBER` (예: `3`) → `export PROJECT_NUMBER=3`
+- `id` → `PROJECT_ID`
+- `number` → `PROJECT_NUMBER`
 
-### 4.2 Status 필드 ID 조회
+### 4.3 repo ↔ project 링크
+
+```bash
+gh project link "$PROJECT_NUMBER" --owner "$OWNER" --repo "$OWNER/$REPO"
+```
+
+Project 생성만으로는 대상 repo 에서 카드가 유입되지 않는다. 이 링크가
+`Auto-add to project`와 후속 built-in workflow의 전제다.
+
+### 4.4 Status 필드 ID 조회
 
 ```bash
 gh api graphql -f query='
@@ -73,12 +150,9 @@ query($pid: ID!) {
 }' -f pid="$PROJECT_ID"
 ```
 
-`name: "Status"` 인 필드의 `id` → `STATUS_FIELD_ID` export
-(예: `export STATUS_FIELD_ID=PVTSSF_xxx...`)
+`name: "Status"` 인 필드의 `id` 를 `STATUS_FIELD_ID` 로 저장한다.
 
-### 4.3 Status 필드 옵션 6개로 교체
-
-기본 옵션(`Todo / In Progress / Done` 3개)을 전면 교체한다.
+### 4.5 Status 필드 옵션 6개로 교체
 
 ```bash
 gh api graphql -f query='
@@ -97,16 +171,16 @@ mutation($fid: ID!) {
 }' -f fid="$STATUS_FIELD_ID"
 ```
 
-### 4.4 PR 템플릿 생성
+### 4.6 PR 템플릿 생성
 
-`.github/pull_request_template.md` 파일을 repo에 추가
-(이미 있으면 `Closes #<N>` 자리표시자만 포함되면 됨):
+`.github/pull_request_template.md` 가 없으면 아래 내용을 추가한다.
+이미 있으면 `Closes #<N>` 자리표시자만 포함되면 된다.
 
 ```markdown
 <!--
-Closes #<N> 키워드가 반드시 포함되어야 Project 보드의 Done
-자동 전환이 동작합니다. 이슈를 완전히 해결하지 않는 PR은
-Closes 대신 Refs 를 사용하세요.
+Closes #<N> 키워드가 반드시 포함되어야 Project 보드의 Done 자동 전환이
+동작합니다. 이슈를 완전히 해결하지 않는 PR은 Closes 대신 Refs 를 사용하세요.
+상세는 docs/standards/github-project-board.md 를 참고하세요.
 -->
 
 ## Summary
@@ -122,125 +196,93 @@ Closes 대신 Refs 를 사용하세요.
 Closes #<N>
 ```
 
-### 4.5 빌트인 워크플로우 설정 (웹 UI)
+### 4.7 Built-in Workflows 설정 (웹 UI)
 
-URL: `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
+URL:
 
-(org 소유면 `/users/`를 `/orgs/`로 교체.)
+- user owner:
+  `https://github.com/users/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
+- org owner:
+  `https://github.com/orgs/<OWNER>/projects/<PROJECT_NUMBER>/workflows`
 
-신규 Project는 10개 워크플로우 중 `Auto-archive items`만 `disabled`,
-나머지 9개는 `enabled` 상태로 생성된다. 아래 Status 값·필터만
-확인·조정하면 된다.
+아래 값이 SSOT 와 맞는지 확인한다.
 
-| #  | 워크플로우                      | When                       | Set Status / Filter |
-|----|---------------------------------|----------------------------|---------------------|
-| 1  | `Auto-add to project`           | Filter: `is:issue,pr is:open` + repo: `<REPO>` | —          |
-| 2  | `Item added to project`         | issues + pull requests     | `Backlog`           |
-| 3  | `Pull request linked to issue`  | —                          | `In review`         |
-| 4  | `Code review approved`          | —                          | `Approved`          |
-| 5  | `Code changes requested`        | —                          | `In progress`       |
-| 6  | `Pull request merged`           | —                          | `Done`              |
-| 7  | `Item closed`                   | issues + pull requests     | `Done`              |
-| 8  | `Auto-close issue`              | — (구조적; 기본 유지)       | (Status 미설정)     |
-| 9  | `Auto-add sub-issues to project`| — (구조적; 기본 유지)       | (Status 미설정)     |
-| 10 | `Auto-archive items`            | Filter 매칭 카드 주기적 archive | **수동 enable** + Filter: `is:issue,pr is:closed updated:<@today-2d` |
+| #  | 워크플로우                      | Set Status / Filter |
+|----|---------------------------------|---------------------|
+| 1  | `Auto-add to project`           | Filter: `is:issue,pr is:open` + repo: `<REPO>` |
+| 2  | `Item added to project`         | `Backlog` |
+| 3  | `Pull request linked to issue`  | `In review` |
+| 4  | `Code review approved`          | `Approved` |
+| 5  | `Code changes requested`        | `In progress` |
+| 6  | `Pull request merged`           | `Done` |
+| 7  | `Item closed`                   | `Done` |
+| 8  | `Auto-close issue`              | 기본 유지 |
+| 9  | `Auto-add sub-issues to project`| 기본 유지 |
+| 10 | `Auto-archive items`            | 수동 enable + Filter: `is:issue,pr is:closed updated:<@today-2d` |
 
-**#10 `Auto-archive items` 설정 상세**:
+### 4.8 `Approved`·`Ready` 컬럼 hide (solo repo 권장)
 
-- 기본 disabled — 명시적으로 enable 해야 한다.
-- Filter 문법은 Issue/PR search query 문법을 따른다:
-  - `is:issue,pr` — Issue·PR 카드 모두 (Option B 운영 전제)
-  - `is:closed` — 닫힌(=머지된) 카드만. 본 문서 라이프사이클에서
-    Done 컬럼과 동치.
-  - `updated:<@today-2d` — 그제(2일 전) 자정 이전에 업데이트된
-    카드. 기간은 운영 취향에 따라 `<@today` (당일분만), `<@today-1w`
-    (1주분) 등으로 조정. dotfiles는 `<@today-2d` 채택 (Done 컬럼을
-    최근 2일분만 유지하여, 어제 머지된 카드도 오늘 시점에 보드
-    상에서 즉시 확인 가능).
-- archive 된 카드는 삭제가 아니라 기본 뷰에서 숨김 — 필터 바에
-  `is:archived` 입력 시 재조회, 카드 우클릭 `Restore from archive`로
-  복원 가능.
+Board 뷰에서 컬럼 헤더 옆 `⋯` → `Hide from view`.
 
-### 4.6 `Approved`·`Ready` 컬럼 hide (solo repo 권장)
-
-개인 repo에서는 다음 두 컬럼이 라이프사이클에서 방문되지 않아
-dead column이 된다. Board 뷰에서 컬럼 헤더 옆 `⋯` →
-`Hide from view`로 숨긴다.
-
-- **`Approved`**: `Code review approved` 워크플로우가 거의 발화하지
-  않아 PR 카드가 도달하지 않음.
-- **`Ready`**: Issue·PR 두 라이프사이클 모두 방문하지 않는 예약
-  컬럼 (미래 확장용). SSOT §컬럼별 의미 참고.
-
-- 중요: 이는 **view-level 설정**이며 Status 옵션 자체는 유지된다.
-  따라서 카드가 해당 컬럼에 들어가는 일이 생기면(예: 협업자 합류로
-  Approved 발화, 또는 Ready 단계 도입) 데이터는 건재하고, hide만
-  해제하면 즉시 가시화된다.
+- `Approved`: 1인 repo 에서는 외부 Approve 가 거의 없어 dead column 이 되기 쉽다.
+- `Ready`: 현재 dotfiles flow 에서는 방문하지 않는 예약 컬럼이다.
 
 ## 5. 라이프사이클 (한눈에)
 
-```
+```text
 Issue:
     Backlog ─[/gh-commit]──▶ In progress ─[PR open via Closes #N]──▶ In review ─[PR merge]──▶ Done
 
 PR:
-    Backlog ─[/gh-pr]──▶ In review ─[Approve]──▶ Approved ─[merge]──▶ Done
-                            ▲                        │
-                            └─ [수동 재리뷰] ── In progress ◀─ [Changes requested]
+    Backlog ─[/gh-pr]──▶ In review ─[/gh-pr-reply or 외부 Approve]──▶ Approved ─[merge]──▶ Done
+                            ▲                                            │
+                            └────────────── [수동 재리뷰] ── In progress ◀─ [Changes requested]
 ```
-
-`/gh-flow`, `/gh-pr`, `/gh-commit` 가 호출되면 위 두 진입 전환은
-자동으로 발생한다 (보드가 없는 repo 에서는 헬퍼가 자동으로 no-op).
-raw `git commit` / `gh pr create` 를 직접 사용하는 경로에서만 수동
-이동이 필요하다.
 
 ## 6. 자동 vs 수동
 
-- **Issue `Backlog → In progress`**: `/gh-flow`·`/gh-commit` 자동 /
-  raw `git commit` 사용 시 수동. `/gh-commit` 은 `--only-from Backlog`
-  가드를 사용하므로 PR 오픈 후 follow-up 커밋은 역행시키지 않는다.
-- **PR `Backlog → In review`**: `/gh-flow`·`/gh-pr` 자동 /
-  raw `gh pr create` 사용 시 수동.
-- **PR `In progress → In review`**: 수동 (Changes requested 루프
-  탈출 시 — 자동화 미지원).
-- **보드 미연결 repo**: 헬퍼 (`_gh_project_status_sync`) 가
-  `projectItems` 가 0건이면 조용히 return 0 — 즉 `dotfiles` 외 다른
-  프로젝트에서 `/gh-pr`·`/gh-commit` 을 써도 부작용이 없다.
-- 그 외 모든 전환: 자동 (GitHub Projects v2 빌트인 워크플로우).
+- Issue `Backlog → In progress`:
+  `/gh-flow`·`/gh-commit` 자동, raw `git commit` 사용 시 수동.
+- PR `Backlog → In review`:
+  `/gh-flow`·`/gh-pr` 자동, raw `gh pr create` 사용 시 수동.
+- PR `In review → Approved`:
+  `/gh-pr-reply` 자동, 또는 외부 협업자 Approve 시 built-in workflow 자동.
+  1인 repo 에서는 self-approve 불가라 `/gh-pr-reply` 가 사실상 갭을 메운다.
+- PR `In progress → In review`:
+  `Changes requested` 루프 탈출 시 수동.
+- 보드 미연결 repo:
+  `_gh_project_status_sync` 가 `projectItems == 0` 을 감지하고 조용히
+  return 0 한다. 호출자:
+  `/gh-flow`, `/gh-pr`, `/gh-commit`, `/gh-pr-reply`.
+- 그 외 상태 전환:
+  GitHub Projects v2 built-in workflow 가 자동 처리한다.
 
 ## 7. 검증 (smoke test)
 
 ```bash
-# Test issue 생성
 gh issue create --repo "$OWNER/$REPO" --title "[Test] kanban smoke" --body "ignore"
 ```
 
 기대:
 
-1. 수 초 내 보드 `Backlog` 컬럼에 새 카드 등장.
-2. `gh issue close <N>` 후 카드가 `Done`으로 이동.
-3. 확인 후 이슈 삭제: `gh issue delete <N>` (대화형).
+1. 수 초 내 보드 `Backlog` 컬럼에 새 카드가 생긴다.
+2. 연결된 PR 생성 시 Issue 카드가 `In review` 로 이동한다.
+3. PR merge 또는 issue close 후 카드가 `Done` 으로 이동한다.
 
-## 8. Gotchas
+## 8. References
 
-- Free plan private repo는 branch protection API가 HTTP 403을 반환한다.
-  merge에는 지장 없으나 `gh-pr-merge` 등 skill이 protection 존재 여부로
-  분기할 수 있다는 점만 기억.
-- PR 본문에 `Closes #N`이 빠지면 Issue 카드가 `Done`으로 가지 않는다.
-  PR 템플릿으로 강제 + 머지 전에 본문 재확인.
-- `Auto-add to project`의 필터 `is:issue,pr`은 GitHub Projects v2
-  공식 지원 문법(콤마 복수 지정). 일부 봇이 "미지원"이라 주장해도
-  실제로는 정상 동작.
-- `Approved` 컬럼 hide는 본인의 view에만 적용된다. 다른 뷰/협업자
-  화면에는 보임.
-
-## 9. References
-
-- 본 playbook 출처 SSOT: [docs/standards/github-project-board.md](../standards/github-project-board.md)
-- GitHub Projects v2 빌트인 automations:
+- 본 playbook 출처 SSOT:
+  [docs/standards/github-project-board.md](../standards/github-project-board.md)
+- GitHub Projects v2 built-in automations:
   <https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-built-in-automations>
-- 관련 skills (본 repo): `gh-issue-create`, `gh-commit`, `gh-pr`,
-  `gh-pr-merge`, `gh-pr-reply`, `gh-issue-flow`.
-- 관련 헬퍼: `shell-common/functions/gh_project_status.sh`
+- 관련 skills (본 repo):
+  `gh-issue-create`, `gh-commit`, `gh-pr`, `gh-pr-reply`,
+  `gh-pr-merge`, `gh-issue-flow`
+- 관련 헬퍼:
+  `shell-common/functions/gh_project_status.sh`
   (공용 `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`,
-  `/gh-commit` 이 모두 호출).
+  `/gh-commit`, `/gh-pr-reply` 가 모두 호출)
+- 관련 템플릿:
+  `.github/pull_request_template.md`
+- 자동화 스크립트:
+  `scripts/setup-kanban-board.sh`

--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -133,7 +133,7 @@ auth_scopes_csv() {
     local scopes
 
     scopes="$(gh auth status --json hosts 2>/dev/null | jq -r '
-        .hosts["github.com"][]
+        .hosts?["github.com"]?[]?
         | select(.active == true)
         | .scopes // empty
     ' | head -n1)"
@@ -200,7 +200,7 @@ load_repo_context() {
         }
     ' -f owner="$OWNER" -f repo="$REPO")" || die "Failed to query repository ${OWNER}/${REPO}"
 
-    if [ "$(printf '%s' "$repo_json" | jq -r '.data.repository == null')" = "true" ]; then
+    if [ "$(printf '%s' "$repo_json" | jq -r '.data?.repository? == null')" = "true" ]; then
         die "Repository ${OWNER}/${REPO} was not found or is not accessible."
     fi
 
@@ -249,7 +249,7 @@ find_existing_project() {
     ' -f owner="$OWNER")" || die "Failed to list existing projects for ${OWNER}"
 
     match="$(printf '%s' "$projects_json" | jq -r --arg title "$TITLE" '
-        .data.repositoryOwner.projectsV2.nodes[]
+        .data.repositoryOwner?.projectsV2?.nodes?[]?
         | select(.title == $title)
         | [.id, (.number | tostring), .url]
         | @tsv
@@ -347,7 +347,7 @@ fetch_status_field_id() {
     ' -f projectId="$PROJECT_ID")" || die "Failed to fetch Status field for project #${PROJECT_NUMBER}"
 
     printf '%s' "$field_json" | jq -r '
-        .data.node.fields.nodes[]
+        .data.node?.fields?.nodes?[]?
         | select(.name == "Status")
         | .id
     ' | head -n1
@@ -433,7 +433,7 @@ fetch_existing_pr_template() {
           }
         }
     ' -f owner="$OWNER" -f repo="$REPO" -f expr="${DEFAULT_BRANCH}:${PR_TEMPLATE_PATH}" |
-        jq -r '.data.repository.object.text // empty'
+        jq -r '.data.repository?.object?.text? // empty'
 }
 
 ensure_pr_template() {

--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -1,0 +1,573 @@
+#!/bin/bash
+
+set -euo pipefail
+
+_SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
+UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+
+if [ -f "$UX_LIB" ]; then
+    # shellcheck disable=SC1090
+    source "$UX_LIB"
+else
+    echo "Error: UX library not found at $UX_LIB" >&2
+    exit 1
+fi
+
+OWNER=""
+REPO=""
+TITLE=""
+AUTO_ARCHIVE_WINDOW="2d"
+HIDE_COLUMNS=false
+DRY_RUN=false
+SKIP_PR_TEMPLATE=false
+
+OWNER_TYPE=""
+OWNER_ID=""
+REPO_ID=""
+REPO_URL=""
+DEFAULT_BRANCH=""
+PROJECT_ID=""
+PROJECT_NUMBER=""
+PROJECT_URL=""
+WORKFLOWS_URL=""
+
+PR_TEMPLATE_PATH=".github/pull_request_template.md"
+PR_TEMPLATE_COMMIT_MESSAGE="Chore: add pull request template for kanban board setup"
+
+log_info() { ux_info "$1"; }
+log_success() { ux_success "$1"; }
+log_warning() { ux_warning "$1"; }
+log_error() { ux_error "$1"; }
+log_step() { ux_step "$1" "$2"; }
+log_dim() { printf "%s%s%s\n" "${UX_DIM}" "$1" "${UX_RESET}"; }
+
+die() {
+    log_error "$1"
+    exit 1
+}
+
+print_help() {
+    ux_header "Kanban Board Setup"
+    ux_usage "./scripts/setup-kanban-board.sh" "--owner <login> --repo <name> [options]" \
+        "Create a GitHub Projects v2 board, link the repo, sync the Status field, and print the remaining UI checklist."
+
+    ux_section "Options"
+    ux_bullet "--owner <login>              GitHub user or org that owns the project"
+    ux_bullet "--repo <name>                Repository name to link"
+    ux_bullet "--title <board-title>        Project title (default: repo name)"
+    ux_bullet "--auto-archive-window <dur>  Filter suffix for Done auto-archive (default: 2d)"
+    ux_bullet "--hide-columns               Add solo-repo hide guidance for Approved and Ready"
+    ux_bullet "--dry-run                    Print the plan without mutations"
+    ux_bullet "--skip-pr-template           Skip remote PR template creation/check"
+    ux_bullet "-h, --help                   Show this help"
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --owner)
+            [ "${2-}" ] || die "--owner requires a value"
+            OWNER="$2"
+            shift 2
+            ;;
+        --repo)
+            [ "${2-}" ] || die "--repo requires a value"
+            REPO="$2"
+            shift 2
+            ;;
+        --title)
+            [ "${2-}" ] || die "--title requires a value"
+            TITLE="$2"
+            shift 2
+            ;;
+        --auto-archive-window)
+            [ "${2-}" ] || die "--auto-archive-window requires a value"
+            AUTO_ARCHIVE_WINDOW="$2"
+            shift 2
+            ;;
+        --hide-columns)
+            HIDE_COLUMNS=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --skip-pr-template)
+            SKIP_PR_TEMPLATE=true
+            shift
+            ;;
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        *)
+            die "Unknown option: $1"
+            ;;
+        esac
+    done
+
+    [ -n "$OWNER" ] || die "--owner is required"
+    [ -n "$REPO" ] || die "--repo is required"
+
+    if [ -z "$TITLE" ]; then
+        TITLE="$REPO"
+    fi
+
+    if [[ ! "$AUTO_ARCHIVE_WINDOW" =~ ^[0-9]+[dwmy]$ ]]; then
+        die "--auto-archive-window must look like 2d, 1w, or 3m"
+    fi
+}
+
+require_command() {
+    local name="$1"
+    local install_hint="${2:-Install $1 first.}"
+
+    if ! command -v "$name" >/dev/null 2>&1; then
+        die "${name} is required. ${install_hint}"
+    fi
+}
+
+auth_scopes_csv() {
+    local scopes
+
+    scopes="$(gh auth status --json hosts 2>/dev/null | jq -r '
+        .hosts["github.com"][]
+        | select(.active == true)
+        | .scopes // empty
+    ' | head -n1)"
+
+    if [ -z "$scopes" ]; then
+        return 1
+    fi
+
+    printf "%s" "$scopes" | tr -d ' '
+}
+
+require_project_scope() {
+    local scopes_csv need_scope
+
+    if ! scopes_csv="$(auth_scopes_csv)"; then
+        die "gh auth status could not find an active github.com login. Run: gh auth login --scopes \"project\""
+    fi
+
+    need_scope="project"
+    if $DRY_RUN; then
+        case ",${scopes_csv}," in
+        *,project,* | *,read:project,*)
+            return 0
+            ;;
+        esac
+        die "Your gh token is missing project access. Run: gh auth refresh -s project"
+    fi
+
+    case ",${scopes_csv}," in
+    *,${need_scope},*)
+        return 0
+        ;;
+    esac
+
+    die "Your gh token is missing the project scope required for mutations. Run: gh auth refresh -s project"
+}
+
+gh_graphql() {
+    local query="$1"
+    shift
+    gh api graphql -f query="$query" "$@"
+}
+
+load_repo_context() {
+    local repo_json
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    repo_json="$(gh_graphql '
+        query RepoContext($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            id
+            name
+            url
+            owner {
+              __typename
+              login
+              id
+            }
+            defaultBranchRef {
+              name
+            }
+          }
+        }
+    ' -f owner="$OWNER" -f repo="$REPO")" || die "Failed to query repository ${OWNER}/${REPO}"
+
+    if [ "$(printf '%s' "$repo_json" | jq -r '.data.repository == null')" = "true" ]; then
+        die "Repository ${OWNER}/${REPO} was not found or is not accessible."
+    fi
+
+    OWNER_TYPE="$(printf '%s' "$repo_json" | jq -r '.data.repository.owner.__typename')"
+    OWNER_ID="$(printf '%s' "$repo_json" | jq -r '.data.repository.owner.id')"
+    REPO_ID="$(printf '%s' "$repo_json" | jq -r '.data.repository.id')"
+    REPO_URL="$(printf '%s' "$repo_json" | jq -r '.data.repository.url')"
+    DEFAULT_BRANCH="$(printf '%s' "$repo_json" | jq -r '.data.repository.defaultBranchRef.name // empty')"
+
+    if [ "$OWNER_TYPE" != "User" ] && [ "$OWNER_TYPE" != "Organization" ]; then
+        die "Unsupported repository owner type: ${OWNER_TYPE}"
+    fi
+}
+
+find_existing_project() {
+    local projects_json match
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    projects_json="$(gh_graphql '
+        query ExistingProjects($owner: String!) {
+          repositoryOwner(login: $owner) {
+            __typename
+            ... on User {
+              projectsV2(first: 100) {
+                nodes {
+                  id
+                  number
+                  title
+                  url
+                }
+              }
+            }
+            ... on Organization {
+              projectsV2(first: 100) {
+                nodes {
+                  id
+                  number
+                  title
+                  url
+                }
+              }
+            }
+          }
+        }
+    ' -f owner="$OWNER")" || die "Failed to list existing projects for ${OWNER}"
+
+    match="$(printf '%s' "$projects_json" | jq -r --arg title "$TITLE" '
+        .data.repositoryOwner.projectsV2.nodes[]
+        | select(.title == $title)
+        | [.id, (.number | tostring), .url]
+        | @tsv
+    ' | head -n1)"
+
+    if [ -n "$match" ]; then
+        IFS=$'\t' read -r PROJECT_ID PROJECT_NUMBER PROJECT_URL <<<"$match"
+        return 0
+    fi
+
+    return 1
+}
+
+create_project() {
+    local create_json
+
+    if $DRY_RUN; then
+        log_info "[dry-run] Would create project '${TITLE}' under ${OWNER}"
+        PROJECT_ID="PVT_DRY_RUN"
+        PROJECT_NUMBER="0"
+        PROJECT_URL="$(project_url_from_owner_type)"
+        return 0
+    fi
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    create_json="$(gh_graphql '
+        mutation CreateProject($ownerId: ID!, $title: String!) {
+          createProjectV2(input: {
+            ownerId: $ownerId
+            title: $title
+          }) {
+            projectV2 {
+              id
+              number
+              title
+              url
+            }
+          }
+        }
+    ' -f ownerId="$OWNER_ID" -f title="$TITLE")" || die "Failed to create project '${TITLE}'"
+
+    PROJECT_ID="$(printf '%s' "$create_json" | jq -r '.data.createProjectV2.projectV2.id')"
+    PROJECT_NUMBER="$(printf '%s' "$create_json" | jq -r '.data.createProjectV2.projectV2.number')"
+    PROJECT_URL="$(printf '%s' "$create_json" | jq -r '.data.createProjectV2.projectV2.url')"
+
+    if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
+        die "Project creation returned no project ID"
+    fi
+}
+
+link_repository_to_project() {
+    if $DRY_RUN; then
+        log_info "[dry-run] Would link ${OWNER}/${REPO} to project '${TITLE}'"
+        return 0
+    fi
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    gh_graphql '
+        mutation LinkProject($projectId: ID!, $repositoryId: ID!) {
+          linkProjectV2ToRepository(input: {
+            projectId: $projectId
+            repositoryId: $repositoryId
+          }) {
+            repository {
+              id
+            }
+          }
+        }
+    ' -f projectId="$PROJECT_ID" -f repositoryId="$REPO_ID" >/dev/null ||
+        die "Failed to link ${OWNER}/${REPO} to project #${PROJECT_NUMBER}"
+}
+
+fetch_status_field_id() {
+    local field_json
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    field_json="$(gh_graphql '
+        query StatusField($projectId: ID!) {
+          node(id: $projectId) {
+            ... on ProjectV2 {
+              fields(first: 20) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    ' -f projectId="$PROJECT_ID")" || die "Failed to fetch Status field for project #${PROJECT_NUMBER}"
+
+    printf '%s' "$field_json" | jq -r '
+        .data.node.fields.nodes[]
+        | select(.name == "Status")
+        | .id
+    ' | head -n1
+}
+
+update_status_field() {
+    local status_field_id="$1"
+
+    if [ -z "$status_field_id" ] || [ "$status_field_id" = "null" ]; then
+        die "Could not locate the Status field for project #${PROJECT_NUMBER}"
+    fi
+
+    if $DRY_RUN; then
+        log_info "[dry-run] Would replace Status options with the 6-option dotfiles workflow"
+        return 0
+    fi
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    gh_graphql '
+        mutation UpdateStatusField($fieldId: ID!) {
+          updateProjectV2Field(input: {
+            fieldId: $fieldId
+            singleSelectOptions: [
+              {name: "Backlog",     color: GRAY,   description: "Idea or request only"}
+              {name: "Ready",       color: BLUE,   description: "Reserved — unused in normal flow"}
+              {name: "In progress", color: YELLOW, description: "Issue: coding / PR: Changes requested loop"}
+              {name: "In review",   color: ORANGE, description: "Awaiting review or merge decision"}
+              {name: "Approved",    color: PURPLE, description: "PR only — review approved, awaiting merge"}
+              {name: "Done",        color: GREEN,  description: "Merged and closed"}
+            ]
+          }) {
+            projectV2Field {
+              ... on ProjectV2SingleSelectField {
+                id
+              }
+            }
+          }
+        }
+    ' -f fieldId="$status_field_id" >/dev/null ||
+        die "Failed to update the Status field for project #${PROJECT_NUMBER}"
+}
+
+pr_template_body() {
+    cat <<'EOF'
+<!--
+Closes #<N> 키워드가 반드시 포함되어야 Project 보드의 Done 자동 전환이
+동작합니다. 이슈를 완전히 해결하지 않는 PR은 Closes 대신 Refs 를 사용하세요.
+상세는 docs/standards/github-project-board.md 를 참고하세요.
+-->
+
+## Summary
+-
+
+## Changes
+-
+
+## Test plan
+- [ ]
+
+## Related
+Closes #<N>
+EOF
+}
+
+fetch_existing_pr_template() {
+    if [ -z "$DEFAULT_BRANCH" ]; then
+        printf ""
+        return 0
+    fi
+
+    # GraphQL variables are passed via -f flags below; single quotes are intentional.
+    # shellcheck disable=SC2016
+    gh_graphql '
+        query PullRequestTemplate($owner: String!, $repo: String!, $expr: String!) {
+          repository(owner: $owner, name: $repo) {
+            object(expression: $expr) {
+              __typename
+              ... on Blob {
+                text
+              }
+            }
+          }
+        }
+    ' -f owner="$OWNER" -f repo="$REPO" -f expr="${DEFAULT_BRANCH}:${PR_TEMPLATE_PATH}" |
+        jq -r '.data.repository.object.text // empty'
+}
+
+ensure_pr_template() {
+    local existing_template encoded_content
+
+    if $SKIP_PR_TEMPLATE; then
+        log_info "Skipped PR template handling (--skip-pr-template)"
+        return 0
+    fi
+
+    if [ -z "$DEFAULT_BRANCH" ]; then
+        die "Repository ${OWNER}/${REPO} has no default branch. Create an initial commit first, or re-run with --skip-pr-template."
+    fi
+
+    existing_template="$(fetch_existing_pr_template)"
+    if [ -n "$existing_template" ]; then
+        if [[ "$existing_template" == *"Closes #"* ]]; then
+            log_info "PR template already exists and contains 'Closes #'"
+        else
+            log_warning "PR template already exists but does not contain 'Closes #'. It was left untouched."
+        fi
+        return 0
+    fi
+
+    if $DRY_RUN; then
+        log_info "[dry-run] Would create ${PR_TEMPLATE_PATH} on ${DEFAULT_BRANCH}"
+        return 0
+    fi
+
+    encoded_content="$(pr_template_body | base64 | tr -d '\n')"
+    gh api \
+        --method PUT \
+        -H "Accept: application/vnd.github+json" \
+        "repos/${OWNER}/${REPO}/contents/${PR_TEMPLATE_PATH}" \
+        -f message="${PR_TEMPLATE_COMMIT_MESSAGE}" \
+        -f content="${encoded_content}" \
+        -f branch="${DEFAULT_BRANCH}" >/dev/null ||
+        die "Failed to create ${PR_TEMPLATE_PATH} in ${OWNER}/${REPO}"
+
+    log_success "Created ${PR_TEMPLATE_PATH} on ${DEFAULT_BRANCH}"
+}
+
+project_url_from_owner_type() {
+    local prefix="users"
+    if [ "$OWNER_TYPE" = "Organization" ]; then
+        prefix="orgs"
+    fi
+    printf "https://github.com/%s/%s/projects/%s" "$prefix" "$OWNER" "$PROJECT_NUMBER"
+}
+
+workflows_url_from_owner_type() {
+    local prefix="users"
+    if [ "$OWNER_TYPE" = "Organization" ]; then
+        prefix="orgs"
+    fi
+    printf "https://github.com/%s/%s/projects/%s/workflows" "$prefix" "$OWNER" "$PROJECT_NUMBER"
+}
+
+print_final_report() {
+    local auto_archive_filter="is:issue,pr is:closed updated:<@today-${AUTO_ARCHIVE_WINDOW}"
+
+    WORKFLOWS_URL="$(workflows_url_from_owner_type)"
+    if [ -z "$PROJECT_URL" ] || [ "$PROJECT_URL" = "null" ]; then
+        PROJECT_URL="$(project_url_from_owner_type)"
+    fi
+
+    ux_header "Kanban Board Ready"
+    log_success "Project board setup finished for ${OWNER}/${REPO}"
+    ux_section "Project"
+    ux_bullet "Board: ${PROJECT_URL}"
+    ux_bullet "Workflows: ${WORKFLOWS_URL}"
+    ux_bullet "Project number: ${PROJECT_NUMBER}"
+
+    ux_section "UI Checklist"
+    ux_bullet "Auto-add to project: choose ${OWNER}/${REPO} and set filter to 'is:issue,pr is:open' so new open issues and PRs land on the board."
+    ux_bullet "Item added to project: set Status to 'Backlog' so every new card starts in the intake column."
+    ux_bullet "Pull request linked to issue: set Status to 'In review' so linked issue cards move into review automatically."
+    ux_bullet "Code review approved: set Status to 'Approved' so PR cards reflect the pre-merge state."
+    ux_bullet "Code changes requested: set Status to 'In progress' so PR cards loop back during review feedback."
+    ux_bullet "Pull request merged: set Status to 'Done' so merged PR cards exit the active flow."
+    ux_bullet "Item closed: set Status to 'Done' so closed issues and PRs finish cleanly."
+    ux_bullet "Auto-archive items: enable it with '${auto_archive_filter}' so stale Done cards leave the board automatically."
+
+    if $HIDE_COLUMNS; then
+        ux_bullet "Board view: hide 'Approved' and 'Ready' if this is a solo repo and you want to reduce dead columns."
+    fi
+
+    ux_section "Smoke Test"
+    ux_bullet "gh issue create --repo ${OWNER}/${REPO} --title \"[Test] kanban smoke\" --body \"ignore\""
+
+    if $DRY_RUN; then
+        ux_section "Mode"
+        ux_bullet "Dry-run only: no project, link, field, or file mutations were sent."
+    fi
+}
+
+main() {
+    parse_args "$@"
+    require_command gh "Install GitHub CLI: https://cli.github.com/"
+    require_command jq "Install jq to parse GitHub API responses."
+    require_project_scope
+
+    ux_header "Kanban Board Setup"
+    log_step 1 "Validating repository access"
+    load_repo_context
+    log_info "Repository found: ${REPO_URL}"
+
+    log_step 2 "Checking for an existing project titled '${TITLE}'"
+    if find_existing_project; then
+        PROJECT_URL="${PROJECT_URL:-$(project_url_from_owner_type)}"
+        log_warning "A project titled '${TITLE}' already exists (#${PROJECT_NUMBER}). Delete it first if you need a fresh install."
+        ux_section "Existing Project"
+        ux_bullet "Board: ${PROJECT_URL}"
+        ux_bullet "Workflows: $(workflows_url_from_owner_type)"
+        exit 0
+    fi
+
+    log_step 3 "Creating the project"
+    create_project
+    log_success "Project prepared: ${TITLE} (#${PROJECT_NUMBER})"
+
+    log_step 4 "Linking the repository"
+    link_repository_to_project
+    log_success "Linked ${OWNER}/${REPO}"
+
+    log_step 5 "Replacing the Status options"
+    update_status_field "$(fetch_status_field_id)"
+    log_success "Status field synced to the 6-option workflow"
+
+    log_step 6 "Ensuring the pull request template"
+    ensure_pr_template
+
+    log_step 7 "Printing the remaining UI checklist"
+    print_final_report
+}
+
+main "$@"

--- a/tests/bats/tools/setup_kanban_board.bats
+++ b/tests/bats/tools/setup_kanban_board.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# tests/bats/tools/setup_kanban_board.bats
+# Offline coverage for scripts/setup-kanban-board.sh.
+
+load '../test_helper'
+
+SETUP_KANBAN_SCRIPT="${DOTFILES_ROOT}/scripts/setup-kanban-board.sh"
+
+setup() {
+    setup_isolated_home
+
+    MOCK_BIN="${TEST_TEMP_HOME}/mock-bin"
+    MOCK_LOG="${TEST_TEMP_HOME}/mock-gh.log"
+    mkdir -p "$MOCK_BIN"
+
+    cat >"${MOCK_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${MOCK_GH_LOG}"
+
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+    cat "${MOCK_GH_AUTH_JSON}"
+    exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+    query=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -f)
+                if [[ "${2-}" == query=* ]]; then
+                    query="${2#query=}"
+                fi
+                shift 2
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
+    case "$query" in
+        *"query RepoContext"*)
+            cat "${MOCK_GH_REPO_CONTEXT_JSON}"
+            ;;
+        *"query ExistingProjects"*)
+            cat "${MOCK_GH_EXISTING_PROJECTS_JSON}"
+            ;;
+        *"mutation CreateProject"*)
+            cat "${MOCK_GH_CREATE_PROJECT_JSON}"
+            ;;
+        *"mutation LinkProject"*)
+            printf '{"data":{"linkProjectV2ToRepository":{"repository":{"id":"R_123"}}}}\n'
+            ;;
+        *"query StatusField"*)
+            cat "${MOCK_GH_STATUS_FIELD_JSON}"
+            ;;
+        *"mutation UpdateStatusField"*)
+            printf '{"data":{"updateProjectV2Field":{"projectV2Field":{"id":"PVTSSF_status"}}}}\n'
+            ;;
+        *"query PullRequestTemplate"*)
+            cat "${MOCK_GH_TEMPLATE_JSON}"
+            ;;
+        *)
+            printf 'Unhandled graphql query:\n%s\n' "$query" >&2
+            exit 1
+            ;;
+    esac
+    exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "--method" && "$3" == "PUT" ]]; then
+    printf '{"content":{"path":".github/pull_request_template.md"}}\n'
+    exit 0
+fi
+
+printf 'Unhandled gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    export MOCK_GH_LOG="$MOCK_LOG"
+    export PATH="${MOCK_BIN}:${PATH}"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+write_json_fixture() {
+    local path="$1"
+    shift
+    cat >"$path" <<EOF
+$*
+EOF
+}
+
+run_setup_kanban() {
+    run bash "$SETUP_KANBAN_SCRIPT" "$@"
+}
+
+@test "dry-run accepts read-only project scope and prints org workflow checklist" {
+    export MOCK_GH_AUTH_JSON="${TEST_TEMP_HOME}/auth.json"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+
+    write_json_fixture "$MOCK_GH_AUTH_JSON" \
+        '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project"}]}}'
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_org","name":"widget","url":"https://github.com/acme/widget","owner":{"__typename":"Organization","login":"acme","id":"O_1"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"Organization","projectsV2":{"nodes":[]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" \
+        '{"data":{"createProjectV2":{"projectV2":{"id":"PVT_new","number":77,"title":"widget","url":"https://github.com/orgs/acme/projects/77"}}}}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" \
+        '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status"}]}}}}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" \
+        '{"data":{"repository":{"object":null}}}'
+
+    run_setup_kanban --owner acme --repo widget --dry-run --hide-columns
+    assert_success
+    assert_output --partial "[dry-run] Would create project 'widget' under acme"
+    assert_output --partial "Workflows: https://github.com/orgs/acme/projects/0/workflows"
+    assert_output --partial "hide 'Approved' and 'Ready'"
+
+    if grep -q 'mutation CreateProject' "$MOCK_LOG"; then
+        echo "CreateProject mutation should not run in dry-run mode"
+        return 1
+    fi
+}
+
+@test "existing project exits successfully without mutations" {
+    export MOCK_GH_AUTH_JSON="${TEST_TEMP_HOME}/auth.json"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+
+    write_json_fixture "$MOCK_GH_AUTH_JSON" \
+        '{"hosts":{"github.com":[{"active":true,"scopes":"repo, project"}]}}'
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_user","name":"dotfiles","url":"https://github.com/deity/dotfiles","owner":{"__typename":"User","login":"deity","id":"U_1"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"User","projectsV2":{"nodes":[{"id":"PVT_existing","number":12,"title":"dotfiles","url":"https://github.com/users/deity/projects/12"}]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" \
+        '{"data":{"createProjectV2":{"projectV2":{"id":"PVT_new","number":77,"title":"dotfiles","url":"https://github.com/users/deity/projects/77"}}}}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" \
+        '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status"}]}}}}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" \
+        '{"data":{"repository":{"object":null}}}'
+
+    run_setup_kanban --owner deity --repo dotfiles
+    assert_success
+    assert_output --partial "already exists (#12)"
+    assert_output --partial "https://github.com/users/deity/projects/12"
+
+    if grep -q 'mutation CreateProject' "$MOCK_LOG"; then
+        echo "CreateProject mutation should not run for an existing board"
+        return 1
+    fi
+}
+
+@test "new project path performs project, field, and template mutations" {
+    export MOCK_GH_AUTH_JSON="${TEST_TEMP_HOME}/auth.json"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+
+    write_json_fixture "$MOCK_GH_AUTH_JSON" \
+        '{"hosts":{"github.com":[{"active":true,"scopes":"repo, project"}]}}'
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_new","name":"widget","url":"https://github.com/deity/widget","owner":{"__typename":"User","login":"deity","id":"U_9"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"User","projectsV2":{"nodes":[]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" \
+        '{"data":{"createProjectV2":{"projectV2":{"id":"PVT_new","number":34,"title":"Widget Board","url":"https://github.com/users/deity/projects/34"}}}}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" \
+        '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status"}]}}}}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" \
+        '{"data":{"repository":{"object":null}}}'
+
+    run_setup_kanban --owner deity --repo widget --title "Widget Board"
+    assert_success
+    assert_output --partial "Created .github/pull_request_template.md on main"
+    assert_output --partial "Board: https://github.com/users/deity/projects/34"
+    assert_output --partial "gh issue create --repo deity/widget --title \"[Test] kanban smoke\" --body \"ignore\""
+
+    grep -q 'mutation CreateProject' "$MOCK_LOG"
+    grep -q 'mutation LinkProject' "$MOCK_LOG"
+    grep -q 'mutation UpdateStatusField' "$MOCK_LOG"
+    grep -q 'repos/deity/widget/contents/.github/pull_request_template.md' "$MOCK_LOG"
+}


### PR DESCRIPTION
## Summary
- 신규 스크립트 `scripts/setup-kanban-board.sh` (573 LOC) — GitHub Projects v2 보드를 1-click으로 부트스트랩. 보드 생성 + Status 6옵션 + repo 링크 + PR 템플릿까지 자동화하고, 마지막에 view UI에서 수동으로 마무리할 체크리스트를 출력.
  - 플래그: `--owner`, `--repo`, `--title`, `--auto-archive-window`, `--hide-columns`, `--dry-run`, `--skip-pr-template`, `-h/--help`
  - 사전 점검: `gh` / `jq` 의존성, 대상 repo 존재 여부
- 신규 bats 테스트 `tests/bats/tools/setup_kanban_board.bats` (199 LOC) — `gh`/`jq` 호출을 stub해 오프라인에서 인터페이스/플래그/dry-run 동작 검증.
- 기존 playbook `docs/playbooks/kanban-board-setup.md` 동기화 (322 lines 갱신):
  - `/gh-pr-reply`가 1인 repo의 In review → Approved 갭을 메우는 동작 명시
  - lifecycle 다이어그램에 솔로 repo 분기 보강
  - References 블록에 누락된 skill 보강 (`gh-pr-reply`)
  - 헬퍼 호출자 목록 정정 (`/gh-flow`, `/gh-pr`, `/gh-commit`, `/gh-pr-reply`)

Closes #232

## Test plan
- [ ] `bats tests/bats/tools/setup_kanban_board.bats` 전체 그린
- [ ] `scripts/setup-kanban-board.sh -h` 출력이 README와 일치
- [ ] `scripts/setup-kanban-board.sh --owner <me> --repo <test-repo> --dry-run` — 변경 없이 계획만 출력
- [ ] 실제 빈 repo에 1회 적용 → Projects v2 보드 / Status 옵션 / repo 링크 / PR 템플릿 모두 생성됨
- [ ] view UI 후속 체크리스트 안내가 실제 필요한 항목과 일치
- [ ] playbook의 lifecycle/References 갱신 내용이 SSOT(`docs/standards/github-project-board.md`)와 어긋나지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

단일 리포지토리에 대해 GitHub Projects v2 칸반 보드를 자동으로 설정하는 새로운 스크립트를 추가하고, 이를 지원하는 테스트 및 플레이북 문서를 업데이트합니다.

New Features:
- 대상 리포지토리에 대해 GitHub Projects v2 보드를 생성하고 설정하는 `setup-kanban-board` 셸 스크립트를 추가합니다. 이 스크립트는 상태 옵션 구성, 리포지토리 연결, PR 템플릿 부트스트랩 등을 한 번의 실행으로 처리합니다.

Enhancements:
- 칸반 보드 설정 플레이북을 재구성하고 확장하여 원클릭 스크립트 기반 플로우를 우선하도록 하고, 라이프사이클 및 워크플로 매핑을 명확히 하며, 단일(솔로) 리포지토리용 가이드와 UI 기반 대체(fallback) 단계에 대한 안내를 추가합니다.

Tests:
- GitHub CLI와 `jq` 상호작용을 스텁하는 Bats 테스트를 도입하여, 칸반 설정 스크립트의 인자 처리, 드라이런 모드, 기존 프로젝트 감지, 변경(mutation) 플로우가 오프라인에서도 올바르게 동작하는지 검증합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate GitHub Projects v2 kanban board setup for a single repo via a new script, with supporting tests and updated playbook documentation.

New Features:
- Add a setup-kanban-board shell script to create and configure a GitHub Projects v2 board for a target repository, including status options, repo linking, and PR template bootstrapping in a single run.

Enhancements:
- Restructure and expand the kanban board setup playbook to prefer the one-click script-based flow, clarify lifecycle and workflow mappings, and add guidance for solo repos and UI-only fallback steps.

Tests:
- Introduce Bats tests that stub GitHub CLI and jq interactions to validate the kanban setup script’s argument handling, dry-run mode, existing-project detection, and mutation flow offline.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
