### PR TITLE
feat(gh-pr-approve): add --self-ok flag to bypass author check (#239)

### DIFF
--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -22,12 +22,18 @@ output its content verbatim, then stop. No API calls.
 
 ## Step 1: Resolve + Pre-flight Gate (parallel)
 
-Resolve context, then fetch pre-flight signals in parallel before
-reading the diff:
+Parse args first. Positional: `<pr-number>` and `<remote>` (default
+`origin`). Optional flag: `--self-ok` (may appear in any position) —
+when present, set `SELF_OK=1`; otherwise `SELF_OK=0`. Use `--self-ok`
+only when the author and authenticated user collide intentionally
+(e.g. another AI agent acted as author, no human reviewer is
+available). It does NOT relax any other stop condition.
 
-- `TARGET_REPO` from `git remote get-url <remote>` (arg #2, default
-  `origin`). Missing remote → list `git remote -v` and stop.
-- PR number: explicit arg #1 → `gh pr view --json number` on current
+Then fetch pre-flight signals in parallel before reading the diff:
+
+- `TARGET_REPO` from `git remote get-url <remote>`. Missing remote →
+  list `git remote -v` and stop.
+- PR number: explicit arg → `gh pr view --json number` on current
   branch → stop and ask.
 - `ME=$(gh api user -q .login)` for self-review / re-review checks.
 - PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,files`
@@ -35,8 +41,12 @@ reading the diff:
 - `gh pr checks <N> --repo $TARGET_REPO`
 
 **Stop conditions** (explain, don't approve): `state != OPEN` ·
-`isDraft == true` · `author.login == ME` · `mergeable == CONFLICTING` ·
-any required check failing.
+`isDraft == true` · `author.login == ME` *(skipped when `SELF_OK=1`)* ·
+`mergeable == CONFLICTING` · any required check failing.
+
+When `SELF_OK=1` and `author.login == ME`, proceed but **record the
+bypass in the review body** per `references/approval-templates.md`
+("Self-approval audit trail"). Other stop conditions still apply.
 
 If prior `ME` comments/reviews exist → **re-review mode**: primary goal
 is verifying each prior concern was addressed by a subsequent commit.

--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -18,7 +18,10 @@ allowed-tools: Bash, Read, Grep, Glob
 ## Help
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
+output its content verbatim, then stop. No API calls. Help is detected
+**only at arg #1** and takes precedence over the Step 1 arg parser —
+`--self-ok -h` is parsed as `--self-ok` followed by an unknown flag,
+not as a help request.
 
 ## Step 1: Resolve + Pre-flight Gate (parallel)
 

--- a/claude/skills/gh-pr-approve/references/approval-templates.md
+++ b/claude/skills/gh-pr-approve/references/approval-templates.md
@@ -140,6 +140,21 @@ Never approve. List each blocker with a `file:line` pointer and the minimal fix 
 gh pr review <N> --repo "$TARGET_REPO" --request-changes --body-file "$BODY"
 ```
 
+## Self-approval audit trail
+
+When Step 1 is invoked with `--self-ok` and `author.login == ME`, prepend the
+following note to the review body for **6a** and **6b** (do not add to **6c**
+— request-changes never reaches this branch). Match the review language.
+
+```markdown
+> ⚠️ Self-approval via `--self-ok`. Author and reviewer are the same GitHub
+> user (`<ME>`). Justification: <multi-AI workflow / no human reviewer
+> available / etc.>.
+```
+
+The note is required, not optional — the audit trail is the safety net that
+makes the bypass acceptable.
+
 ## Language matching
 
 Scan the PR body + most recent 3 human comments. Reply in the dominant language. Korean PR → Korean review. Mixed → match the PR body.

--- a/claude/skills/gh-pr-approve/references/approval-templates.md
+++ b/claude/skills/gh-pr-approve/references/approval-templates.md
@@ -144,13 +144,37 @@ gh pr review <N> --repo "$TARGET_REPO" --request-changes --body-file "$BODY"
 
 When Step 1 is invoked with `--self-ok` and `author.login == ME`, prepend the
 following note to the review body for **6a** and **6b** (do not add to **6c**
-— request-changes never reaches this branch). Match the review language.
+— request-changes never reaches this branch).
 
 ```markdown
 > ⚠️ Self-approval via `--self-ok`. Author and reviewer are the same GitHub
-> user (`<ME>`). Justification: <multi-AI workflow / no human reviewer
-> available / etc.>.
+> user (`<ME>`). Justification: <one concrete reason — see picker below>.
 ```
+
+**Picking the justification.** Replace `<one concrete reason ...>` with a
+single, specific sentence. Do **not** paste a slash-separated list and do
+**not** leave the placeholder verbatim. Choose by scanning the user's
+invocation context (slash-command transcript, recent chat, PR description)
+in this order:
+
+1. **Explicit user reason.** If the user named one (e.g. "동료 둘 다 연차",
+   "codex가 만든 PR을 claude가 리뷰"), reuse their phrasing trimmed to one
+   sentence.
+2. **Multi-AI workflow.** Use this when the author and reviewer are
+   different AI agents (codex/gemini/claude) acting under the same GitHub
+   user — phrase it concretely, e.g. "Authored by codex, reviewed by
+   claude under shared user `dEitY719`".
+3. **No human reviewer available.** Use when colleagues with review
+   access are unavailable; name the constraint, e.g. "All eligible
+   human reviewers OOO until 2026-05-02".
+4. **Last resort.** If none of the above applies, refuse the bypass —
+   `--self-ok` without a defensible justification defeats the audit trail.
+   Stop and ask the user before proceeding.
+
+**Language convention.** The leading `⚠️ Self-approval via --self-ok` line
+stays in English regardless of the PR language — it's the searchable
+audit anchor across repos. Only the `Justification:` text matches the
+PR's dominant language (Korean PR → Korean justification).
 
 The note is required, not optional — the audit trail is the safety net that
 makes the bypass acceptable.

--- a/claude/skills/gh-pr-approve/references/help.md
+++ b/claude/skills/gh-pr-approve/references/help.md
@@ -7,11 +7,18 @@
 | 1 | PR number, or `-h`/`--help`/`help` | required unless current branch has a PR | Target PR, e.g. `99` |
 | 2 | remote name | `origin` | Git remote for the target repo |
 
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--self-ok` | Skip the self-review pre-flight stop (`author.login == ME`). Use when another AI agent authored the PR or when no human reviewer is available. Other stop conditions (draft, conflicting, failing checks) still apply. The bypass is recorded in the review body for audit. |
+
 ## Usage
 
 - `/gh-pr-approve 99` — review PR #99 on `origin`
 - `/gh-pr-approve 99 upstream` — PR #99 on `upstream`'s repo
 - `/gh-pr-approve` — review the PR open on the current branch
+- `/gh-pr-approve 99 --self-ok` — review PR #99 even though you authored it (multi-AI workflow / no human reviewer)
 - `/gh-pr-approve -h` / `--help` / `help` — print this help
 
 ## What the skill does
@@ -34,7 +41,7 @@
 
 ## What the skill won't do
 
-- Approve your own PR.
+- Approve your own PR (unless `--self-ok` is given — see Flags above).
 - Approve without reading the diff.
 - Merge the PR (author decides).
 - Create follow-up issues for trivia that don't justify a tracked item.

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -104,18 +104,20 @@ _gh_pr_approve_run_ai_prompt() {
 gh_pr_approve_help() {
     ux_header "gh-pr-approve - fire-and-forget GitHub PR approval runner"
     ux_info "Usage:"
-    ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>]"
+    ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>] [--self-ok]"
     ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "--self-ok: bypass author==reviewer pre-flight stop in the worker's skill prompt"
     ux_bullet "gh-pr-approve -h|--help|help"
     ux_info ""
     ux_info "Spawns one background worker per PR. Each worker:"
-    ux_bullet "gwt spawn → <ai> -p '/gh-pr-approve <N>' → gwt teardown"
+    ux_bullet "gwt spawn → <ai> -p '/gh-pr-approve <N> [--self-ok]' → gwt teardown"
     ux_info ""
     ux_info "Examples:"
     ux_bullet "gh-pr-approve 42                       # single PR (default: claude)"
     ux_bullet "gh-pr-approve 12 34 56                 # 3 PRs in parallel"
     ux_bullet "gh-pr-approve 42 --ai codex            # run worker with codex CLI"
     ux_bullet "gh-pr-approve --ai gemini '#56' '#78'  # gemini + #prefix"
+    ux_bullet "gh-pr-approve 42 --self-ok             # multi-AI workflow / no human reviewer"
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-approve/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
@@ -159,8 +161,10 @@ gh_pr_approve() {
     # Parse optional args:
     #   --ai <claude|codex|gemini>
     #   --ai=<claude|codex|gemini>
-    # Position-agnostic: --ai may appear before, between, or after PR numbers.
+    #   --self-ok                 (bypass author==reviewer pre-flight in skill)
+    # Position-agnostic: any flag may appear before, between, or after PR numbers.
     local _ai="claude"
+    local _self_ok=""
     local _pr_input=""
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -175,9 +179,12 @@ gh_pr_approve() {
             --ai=*)
                 _ai="${1#--ai=}"
                 ;;
+            --self-ok)
+                _self_ok="--self-ok"
+                ;;
             -*)
                 ux_error "unknown option: '$1'"
-                ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>]"
+                ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-ok]"
                 return 1
                 ;;
             *)
@@ -242,13 +249,13 @@ gh_pr_approve() {
 
     if [ "$_pr_count" -eq 0 ]; then
         ux_error "no PR numbers provided"
-        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>]"
+        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-ok]"
         return 1
     fi
 
-    ux_header "gh-pr-approve: spawning $_pr_count worker(s) (ai=$_ai)"
+    ux_header "gh-pr-approve: spawning $_pr_count worker(s) (ai=$_ai${_self_ok:+ self-ok})"
     for _pr in $_pr_args; do
-        _gh_pr_approve_spawn_worker "$_pr" "$_ai"
+        _gh_pr_approve_spawn_worker "$_pr" "$_ai" "$_self_ok"
     done
     ux_success "All workers detached. Your shell is free. Results appear on the PR."
 }
@@ -256,6 +263,7 @@ gh_pr_approve() {
 _gh_pr_approve_spawn_worker() {
     local _pr="$1"
     local _ai="${2:-claude}"
+    local _self_ok="${3:-}"
     local _dir _log _state _pid
     _dir=$(_gh_pr_approve_pr_dir "$_pr")
     mkdir -p "$_dir"
@@ -292,12 +300,12 @@ _gh_pr_approve_spawn_worker() {
     # shellcheck disable=SC2016
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_pr_approve_worker "$1" "$2"
-    ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
+        _gh_pr_approve_worker "$1" "$2" "$3"
+    ' -- "$_pr" "$_ai" "$_self_ok" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_pr → pid=$_pid  ai=$_ai  log=$_log"
+    ux_info "#$_pr → pid=$_pid  ai=$_ai${_self_ok:+ self-ok}  log=$_log"
 }
 
 # ============================================================================
@@ -307,7 +315,8 @@ _gh_pr_approve_spawn_worker() {
 _gh_pr_approve_worker() {
     local _pr="$1"
     local _ai="${2:-claude}"
-    local _dir _worktree _spawn_name _usage_log
+    local _self_ok="${3:-}"
+    local _dir _worktree _spawn_name _usage_log _prompt
     _dir=$(_gh_pr_approve_pr_dir "$_pr")
     _spawn_name="pr-$_pr"
     # Resolve the usage log path while still in the main repo: once we cd
@@ -315,7 +324,7 @@ _gh_pr_approve_worker() {
     _usage_log="$_dir/usage.jsonl"
     : >"$_usage_log"
 
-    printf '[gh-pr-approve-worker] pr=#%s ai=%s start=%s\n' "$_pr" "$_ai" "$(date -Iseconds 2>/dev/null || date)"
+    printf '[gh-pr-approve-worker] pr=#%s ai=%s%s start=%s\n' "$_pr" "$_ai" "${_self_ok:+ self-ok}" "$(date -Iseconds 2>/dev/null || date)"
 
     # ---- Step 1: spawn worktree ----
     # Snapshot the worktree list before and after `gwt spawn` and diff them
@@ -353,8 +362,11 @@ _gh_pr_approve_worker() {
     # ---- Step 2: approve (selected ai runs /gh-pr-approve <N>) ----
     # Single-shot. The skill either approves with LGTM or files follow-up
     # issues and exits. No polling, no reply loop — that's gh-flow's job.
+    # When --self-ok is in effect, append it to the prompt so the skill
+    # bypasses the author==reviewer pre-flight stop.
     _gh_pr_approve_set_state "$_dir" "approving"
-    if ! _gh_pr_approve_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr-approve $_pr" "/gh-pr-approve $_pr"; then
+    _prompt="/gh-pr-approve $_pr${_self_ok:+ $_self_ok}"
+    if ! _gh_pr_approve_run_ai_prompt "$_ai" "$_usage_log" "$_prompt" "$_prompt"; then
         _gh_pr_approve_set_state "$_dir" "failed:approving"
         printf '[gh-pr-approve-worker] /gh-pr-approve failed\n' >&2
         # Print usage even on failure — knowing how much quota a failed


### PR DESCRIPTION
## Summary
- `gh:pr-approve` 스킬에 `--self-ok` 플래그 추가 — Step 1 pre-flight gate의 `author.login == ME` stop을 의도적으로 우회.
- 우회 범위는 self-review 조건만. 다른 stop(`state != OPEN`, `isDraft`, `mergeable == CONFLICTING`, 필수 체크 실패)은 그대로 유지.
- 우회 시 `references/approval-templates.md`에 정의된 audit-trail 노트를 6a/6b 리뷰 본문에 prepend (강제, 옵션 아님).
- 후속 `6ff69ea`: 오케스트레이터 `shell-common/functions/gh_pr_approve.sh`가 `--self-ok`를 인자로 받아 워커 프롬프트까지 전달하도록 보강. 리뷰에서 지적된 audit-trail 모호성 정리(4-step justification picker + 영문 anchor 고정).

## Context
사람 리뷰어 가정의 self-review 가드가 두 가지 운영 시나리오에서 hard block으로 작동:
1. 리뷰 가능한 동료가 모두 부재 — 작은 변경(설정/문서/스킬 수정)도 진척 불가.
2. 멀티-AI 워크플로우 — codex/gemini/claude가 번갈아 author·reviewer 역할을 하지만 GitHub는 같은 사용자로 인식.

## Changes
- `claude/skills/gh-pr-approve/SKILL.md` — Step 1 args 파싱 단락 신설, stop conditions에 `(skipped when SELF_OK=1)` 명시, 우회 시 audit-trail 의무화. Help precedence 명시(arg #1만 -h 인식).
- `claude/skills/gh-pr-approve/references/help.md` — `### Flags` 표 신설, `--self-ok` 사용 예시 추가, "What the skill won't do" 항목 갱신.
- `claude/skills/gh-pr-approve/references/approval-templates.md` — `## Self-approval audit trail` 섹션 신설. 4-step justification picker(① 사용자 명시 사유 → ② 멀티-AI → ③ no-human-reviewer → ④ 거부). 영문 anchor 고정, Justification 본문은 PR 언어 매칭.
- `shell-common/functions/gh_pr_approve.sh` — 인자 파서에 `--self-ok` 케이스 추가, `_gh_pr_approve_spawn_worker` → `_gh_pr_approve_worker` → AI 프롬프트(`/gh-pr-approve <N> --self-ok`)까지 전달.

## Test plan
- [ ] `gh:pr-approve <PR> --self-ok` — author == ME 인 PR에서도 Step 2 이후로 진행
- [ ] `gh:pr-approve <PR>` (플래그 없음) — author == ME 면 종전과 동일하게 hard stop
- [ ] `gh:pr-approve <draft PR> --self-ok` — draft stop은 여전히 동작 (다른 가드 미회피 확인)
- [ ] `gh:pr-approve <conflicting PR> --self-ok` — CONFLICTING stop은 여전히 동작
- [ ] `--self-ok` 사용 시 6a/6b 리뷰 본문에 `> ⚠️ Self-approval via --self-ok` 라인 prepend 확인
- [ ] `gh-pr-approve 42 --self-ok` (오케스트레이터) — 워커 로그에 `self-ok` 표시 + AI 프롬프트에 `--self-ok` 동봉

## Related
Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Summary by Sourcery

감사 가능한 이력을 남기면서, GitHub PR에 대한 자기 승인(self-approval)을 허용하기 위한 명시적 옵트인 플래그를 도입하고, 새로운 동작 방식과 그 제약 사항을 문서화합니다.

New Features:
- 통제된 시나리오에서 self-review author 체크를 우회할 수 있도록, `gh-pr-approve` 스킬에 `--self-ok` 플래그를 추가합니다.

Enhancements:
- `--self-ok` 플래그를 인식하도록 인자 파싱을 문서화하고, 조건부 중지 검사(conditional stop checks)를 위한 사전 점검(프리플라이트) 신호인 SELF_OK를 도출합니다.
- 자기 승인(self-approval) 우회가 표준화된 감사 이력(audit-trail) 노트 템플릿을 사용하여 리뷰 본문에 기록되도록 요구합니다.

Documentation:
- `--self-ok` 플래그, 그 사용 방법, 그리고 자기 승인 감사 이력 요구 사항을 설명하도록 스킬, 도움말, 참조 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an explicit opt-in flag to allow self-approval of GitHub PRs with an auditable trail while documenting the new behavior and its constraints.

New Features:
- Add a `--self-ok` flag to the gh-pr-approve skill to allow bypassing the self-review author check in controlled scenarios.

Enhancements:
- Document argument parsing to recognize the `--self-ok` flag and derive a SELF_OK pre-flight signal for conditional stop checks.
- Require that self-approval bypasses be recorded in the review body using a standardized audit-trail note template.

Documentation:
- Update skill, help, and reference documentation to describe the `--self-ok` flag, its usage, and the self-approval audit trail requirements.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
