### PR TITLE
feat(gwt): add --launch flag for inline cd + agent yolo

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -16,7 +16,7 @@ _gwt_help_summary() {
     ux_bullet_sub "list: gwt list | gwt ls"
     ux_bullet_sub "remove: gwt remove <path|agent|all> [--force]"
     ux_bullet_sub "prune: gwt prune"
-    ux_bullet_sub "spawn: gwt spawn <name> [--task slug] [--base ref] [--tmux]"
+    ux_bullet_sub "spawn: gwt spawn <name> [--task slug] [--base ref] [--tmux|--launch]"
     ux_bullet_sub "teardown: gwt teardown [--force] [--keep-branch]"
     ux_bullet_sub "details: gwt-help <section> (example: gwt-help spawn)"
 }
@@ -53,12 +53,14 @@ _gwt_help_rows_prune() {
 }
 
 _gwt_help_rows_spawn() {
-    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux [--agent <agent>]]" "Create named worktree"
+    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch [--agent <agent>]]" "Create named worktree"
     ux_table_row "context" "Run from main repo only" "Fails inside a worktree"
     ux_table_row "name" "Free-form slug (required)" "e.g. issue-11, login-fix"
-    ux_table_row "--agent" "AI agent for tmux pane (default: claude)" "claude, codex, gemini, opencode, cursor, copilot"
-    ux_table_row "--tmux" "Runs <agent>-yolo in pane" "Decoupled from worktree <name>"
+    ux_table_row "--agent" "AI agent (default: claude)" "claude, codex, gemini, opencode, cursor, copilot"
+    ux_table_row "--tmux" "Runs <agent>-yolo in new tmux pane" "Mutually exclusive with --launch"
+    ux_table_row "--launch" "cd into worktree + run <agent>-yolo inline" "Current shell, no tmux"
     ux_table_row "example" "gwt spawn issue-11 --tmux --agent codex" "Free-form name + codex agent"
+    ux_table_row "example" "gwt spawn feat --launch" "spawn -> cd -> claude-yolo (one shot)"
 }
 
 _gwt_help_rows_teardown() {
@@ -421,11 +423,11 @@ git_worktree_add() {
 
 # ============================================================================
 # Worktree spawn — auto-index, auto-branch, log
-# Usage: git_worktree_spawn <name> [--task <slug>] [--base <ref>] [--tmux]
+# Usage: git_worktree_spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--agent <agent>]
 # ============================================================================
 _git_worktree_spawn_show_help() {
     ux_header "gwt spawn - create a named worktree"
-    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux [--agent <agent>]]"
+    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--agent <agent>]"
     ux_info ""
     ux_info "Arguments:"
     ux_info "  <name>           Free-form worktree name (required)."
@@ -434,7 +436,9 @@ _git_worktree_spawn_show_help() {
     ux_info "  --task <slug>    Add task slug to branch name"
     ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
     ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
-    ux_info "  --agent <agent>  AI agent to run in the tmux pane (default: claude)"
+    ux_info "  --launch         cd into the new worktree and run <agent>-yolo in the"
+    ux_info "                   current shell. Mutually exclusive with --tmux."
+    ux_info "  --agent <agent>  AI agent for --tmux pane or --launch (default: claude)"
     ux_info "                   Known: claude, codex, gemini, opencode, cursor, copilot"
     ux_info "                   Window name and 'yolo' command follow --agent,"
     ux_info "                   so worktree <name> can be any free-form slug."
@@ -444,6 +448,8 @@ _git_worktree_spawn_show_help() {
     ux_info "  gwt spawn login-fix --task auth              # ../<proj>-login-fix-1 wt/login-fix/1-auth"
     ux_info "  gwt spawn issue-11 --tmux                    # tmux window 'claude' runs 'claude-yolo'"
     ux_info "  gwt spawn issue-11 --tmux --agent codex      # tmux window 'codex'  runs 'codex-yolo'"
+    ux_info "  gwt spawn feat --launch                      # cd into new worktree + claude-yolo"
+    ux_info "  gwt spawn feat --launch --agent codex        # cd + codex-yolo"
 }
 
 git_worktree_spawn() {
@@ -452,7 +458,7 @@ git_worktree_spawn() {
         emulate -L sh
     fi
 
-    local task="" base="" name="" use_tmux=0 agent="claude"
+    local task="" base="" name="" use_tmux=0 use_launch=0 agent="claude"
 
     # Parse arguments
     while [ $# -gt 0 ]; do
@@ -465,6 +471,7 @@ git_worktree_spawn() {
             --base) base="$2"; shift 2 ;;
             --agent) agent="$2"; shift 2 ;;
             --tmux) use_tmux=1; shift ;;
+            --launch) use_launch=1; shift ;;
             -*)
                 ux_error "Unknown option: $1"
                 echo ""
@@ -500,14 +507,23 @@ git_worktree_spawn() {
             ;;
     esac
 
+    # --tmux and --launch are mutually exclusive (tmux opens a new pane,
+    # --launch runs in the current shell — combining them is incoherent).
+    if [ "$use_tmux" = 1 ] && [ "$use_launch" = 1 ]; then
+        ux_error "--tmux and --launch are mutually exclusive"
+        echo ""
+        _git_worktree_spawn_show_help
+        return 1
+    fi
+
     # Validate --tmux dependency
     if [ "$use_tmux" = 1 ] && ! command -v tmux >/dev/null 2>&1; then
         ux_error "tmux is not installed (required for --tmux)"
         return 1
     fi
 
-    # Validate --agent: must be a known AI agent (only when tmux will use it)
-    if [ "$use_tmux" = 1 ] && ! _ts_known_agent "$agent"; then
+    # Validate --agent: must be a known AI agent (only when tmux/launch will use it)
+    if { [ "$use_tmux" = 1 ] || [ "$use_launch" = 1 ]; } && ! _ts_known_agent "$agent"; then
         ux_error "Unknown agent: $agent"
         ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
         return 1
@@ -600,6 +616,13 @@ git_worktree_spawn() {
         else
             tmux switch-client -t "${project}:${agent}" 2>/dev/null || true
         fi
+    elif [ "$use_launch" = 1 ]; then
+        # cd in the caller's shell (gwt is a function, not a subshell), then
+        # run <agent>-yolo. eval re-parses the command so the alias resolves
+        # against the current shell's alias table — handles both bash and zsh.
+        ux_info "  launch: cd $wt_path && ${agent}-yolo"
+        cd "$wt_path" || { ux_error "Cannot cd to $wt_path"; return 1; }
+        eval "${agent}-yolo"
     else
         ux_info ""
         ux_info "  cd $wt_path"

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -76,6 +76,36 @@ teardown() {
     assert_output --partial "--agent"
 }
 
+@test "bash: spawn --help mentions --launch flag" {
+    run_in_bash 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--launch"
+}
+
+@test "bash: spawn rejects --tmux and --launch together" {
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --tmux --launch 2>&1
+    "
+    assert_failure
+    assert_output --partial "mutually exclusive"
+}
+
+@test "bash: spawn rejects unknown agent when --launch is used" {
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --launch --agent notarealagent 2>&1
+    "
+    assert_failure
+    assert_output --partial "Unknown agent: notarealagent"
+}
+
+@test "zsh: spawn --help mentions --launch flag" {
+    run_in_zsh 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--launch"
+}
+
 @test "bash: spawn auto-increments when branch exists without worktree" {
     run_in_bash "
         cd '$FAKE_REPO' || exit 1

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -91,8 +91,26 @@ teardown() {
     assert_output --partial "mutually exclusive"
 }
 
+@test "zsh: spawn rejects --tmux and --launch together" {
+    run_in_zsh "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --tmux --launch 2>&1
+    "
+    assert_failure
+    assert_output --partial "mutually exclusive"
+}
+
 @test "bash: spawn rejects unknown agent when --launch is used" {
     run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --launch --agent notarealagent 2>&1
+    "
+    assert_failure
+    assert_output --partial "Unknown agent: notarealagent"
+}
+
+@test "zsh: spawn rejects unknown agent when --launch is used" {
+    run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
         git_worktree_spawn issue-xyz --launch --agent notarealagent 2>&1
     "


### PR DESCRIPTION
## Summary
- `gwt spawn ... --launch` 한 줄로 worktree 생성 → cd → `<agent>-yolo` 까지 단번에 실행 (기존 3개 명령 시퀀스 대체)
- `--tmux` 와는 상호 배타 (tmux는 새 페인, `--launch` 는 현재 셸 inline)
- bats 테스트 4개 추가로 동작 보장

## Changes
- `shell-common/functions/git_worktree.sh` —
  - `git_worktree_spawn` 에 `--launch` 플래그 추가
  - `--tmux` ↔ `--launch` 동시 지정 시 즉시 에러 + usage 출력
  - `--agent` 검증을 `--launch` 모드에서도 적용 (claude / codex / gemini / opencode / cursor / copilot)
  - 본문 디스패치: spawn 성공 후 `cd "$wt_path"` → `eval "${agent}-yolo"` 로 alias 를 현재 셸의 alias 테이블에 대해 재파싱 (bash/zsh 양쪽 대응)
  - help summary, spawn 섹션 표, `_git_worktree_spawn_show_help` 본문 모두 갱신
- `tests/bats/functions/git_worktree_spawn.bats` —
  - `--help` 가 `--launch` 를 노출하는지 (bash + zsh)
  - `--tmux --launch` 조합이 "mutually exclusive" 메시지로 거절되는지
  - `--launch --agent <unknown>` 이 에이전트 검증으로 거절되는지

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_spawn.bats` — 11 passed (7 baseline + 4 new)
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_teardown.bats` — 19 passed (회귀 없음)
- [x] `tox -e shellcheck,shfmt-check` — congrats :)
- [ ] (수동) 메인 레포에서 `gwt spawn smoke --launch` 실행해 cd + claude-yolo 진입 확인
- [ ] (수동) `gwt spawn smoke --launch --agent codex` 로 다른 agent 분기 확인
- [ ] (수동) `gwt spawn smoke --tmux --launch` 가 사용법 출력과 함께 거절되는지 확인

## Related
Closes #240

## Summary by Sourcery

`gwt spawn`에 인라인 실행 옵션을 추가하여 새 worktree로 즉시 진입하고 AI 에이전트 세션을 시작하며, 이에 맞게 도움말 텍스트와 테스트를 업데이트했습니다.

New Features:
- `gwt spawn`에 `--launch` 플래그를 도입하여 새 worktree로 `cd`한 뒤 현재 셸에서 선택된 `<agent>-yolo` 명령을 실행할 수 있도록 합니다.
- worktree spawn 시 AI 에이전트를 시작할 때 `--agent` 옵션을 `--tmux`와 `--launch` 양쪽과 함께 사용할 수 있도록 허용합니다.

Enhancements:
- worktree spawn 시 `--tmux`와 `--launch`가 동시에 사용되지 못하도록 상호 배타성을 강제하고, 둘 다 제공된 경우 사용 방법이 포함된 명확한 에러를 표시합니다.
- spawn 도움말 요약과 상세 사용 문서를 확장하여 새로운 `--launch` 워크플로우와 업데이트된 `--agent` 의미를 설명합니다.

Tests:
- `--launch` 도움말 표시 여부, `--tmux`와 `--launch`의 상호 배타성, 그리고 `--launch` 사용 시 에이전트 검증을 다루는 bats 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an inline launch option to `gwt spawn` to immediately enter the new worktree and start an AI agent session, updating help text and tests accordingly.

New Features:
- Introduce a `--launch` flag to `gwt spawn` to cd into the new worktree and run the selected `<agent>-yolo` command in the current shell.
- Allow the `--agent` option to be used with both `--tmux` and `--launch` when starting AI agents from worktree spawns.

Enhancements:
- Enforce mutual exclusivity between `--tmux` and `--launch` for worktree spawning and surface a clear error with usage help when both are provided.
- Expand spawn help summaries and detailed usage docs to describe the new `--launch` workflow and updated `--agent` semantics.

Tests:
- Add bats tests to cover `--launch` help visibility, mutual exclusion of `--tmux` and `--launch`, and agent validation when `--launch` is used.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
