### PR TITLE
feat(gh-pr-merge): post-merge reconciliation for linked Issues (#250)

### DIFF
--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -71,7 +71,29 @@ If `gh` returns "merge method is not allowed", print the repo-settings
 guidance from `references/strategy-selection.md` and stop. **Never**
 silently switch strategies.
 
-## Step 4: Fetch Merge SHA + Report
+## Step 4: Reconcile linked Issue cards on the project board
+
+GitHub Projects v2 builtin `Item closed` is best-effort and occasionally
+drops events, leaving Issue cards stuck at `In review` even after the
+Issue auto-closes from this merge. Read
+`references/project-board-sync.md` for the failure mode and the gating
+rationale; the call shape:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+for _issue in $(gh pr view <N> --repo "$TARGET_REPO" \
+                  --json closingIssuesReferences \
+                  --jq '.closingIssuesReferences[].number'); do
+    _gh_project_status_sync issue "$_issue" "Done" \
+        --only-from "Backlog,In progress,In review"
+done
+```
+
+The helper auto-detects boards on repos without a projectV2 attachment
+and silently returns. This step never blocks the report — failures are
+logged to stderr and ignored.
+
+## Step 5: Fetch Merge SHA + Report
 
 ```bash
 gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -q .mergeCommit.oid

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -81,10 +81,10 @@ rationale; the call shape:
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-for _issue in $(gh pr view <N> --repo "$TARGET_REPO" \
+for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
                   --json closingIssuesReferences \
-                  --jq '.closingIssuesReferences[].number'); do
-    _gh_project_status_sync issue "$_issue" "Done" \
+                  --jq '.closingIssuesReferences?[]?.number'); do
+    GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
         --only-from "Backlog,In progress,In review"
 done
 ```

--- a/claude/skills/gh-pr-merge/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge/references/project-board-sync.md
@@ -2,7 +2,7 @@
 
 ## Why this step exists
 
-GitHub Projects v2 builtin workflows are best-effort delivery. The
+GitHub Projects v2 builtin workflows are best-effort only. The
 `Item closed` workflow that should move closed Issue cards to `Done`
 occasionally drops events, leaving Issue cards stuck at `In review` even
 though the Issue itself is `CLOSED`. Concrete observation:
@@ -27,8 +27,8 @@ each linked Issue card to `Done`:
 
 for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
                   --json closingIssuesReferences \
-                  --jq '.closingIssuesReferences[].number'); do
-    _gh_project_status_sync issue "$_issue" "Done" \
+                  --jq '.closingIssuesReferences?[]?.number'); do
+    GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
         --only-from "Backlog,In progress,In review"
 done
 ```
@@ -41,8 +41,9 @@ The `--only-from` whitelist enforces three properties:
   `docs/standards/github-project-board.md`; if one shows up there, it is
   a manual override worth investigating, so the helper skips rather than
   silently overwriting.
-- Empty current Status (card never mounted on the board) also skips, so
-  this never accidentally adds boards to repos that don't have one.
+- Empty current Status (card never mounted on the board) is also
+  skipped, so this never accidentally adds boards to repos that don't
+  have one.
 
 ## When it does nothing
 

--- a/claude/skills/gh-pr-merge/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge/references/project-board-sync.md
@@ -1,0 +1,62 @@
+# Project Board Sync — reconcile linked Issue cards after merge
+
+## Why this step exists
+
+GitHub Projects v2 builtin workflows are best-effort delivery. The
+`Item closed` workflow that should move closed Issue cards to `Done`
+occasionally drops events, leaving Issue cards stuck at `In review` even
+though the Issue itself is `CLOSED`. Concrete observation:
+`dEitY719/dotfiles` Issue #239 stayed at `In review` after PR #241 merged
+at 2026-04-28T03:24:34Z — 16 of 17 other Issues closed around the same
+time on the same board moved to `Done` correctly, ruling out a setup
+problem and pointing at transient delivery loss (issue #250).
+
+`/gh-pr-merge` is the only natural surface that knows which Issues will
+auto-close from a merge — they are listed in the PR's
+`closingIssuesReferences` (Closes / Fixes / Resolves keywords). Adding a
+post-merge reconciliation here closes the gap without depending on
+builtin workflow reliability.
+
+## How to call it
+
+After Step 3 succeeds, fetch the PR's `closingIssuesReferences` and force
+each linked Issue card to `Done`:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+
+for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
+                  --json closingIssuesReferences \
+                  --jq '.closingIssuesReferences[].number'); do
+    _gh_project_status_sync issue "$_issue" "Done" \
+        --only-from "Backlog,In progress,In review"
+done
+```
+
+The `--only-from` whitelist enforces three properties:
+
+- An Issue already at `Done` (builtin fired this round) is left alone —
+  no churn, no duplicate update.
+- Issue cards never visit `Approved` per
+  `docs/standards/github-project-board.md`; if one shows up there, it is
+  a manual override worth investigating, so the helper skips rather than
+  silently overwriting.
+- Empty current Status (card never mounted on the board) also skips, so
+  this never accidentally adds boards to repos that don't have one.
+
+## When it does nothing
+
+- PR body has no `Closes / Fixes / Resolves #N` →
+  `closingIssuesReferences` is empty → loop body never runs.
+- Repo has no projectV2 board attached → helper finds zero project items
+  and silently returns 0.
+- `GH_PROJECT_STATUS_SYNC=0` set in environment → opt-out, helper returns
+  immediately.
+- Issue card already at `Done` → helper skips per `--only-from` guard.
+
+## Where the helper lives
+
+`shell-common/functions/gh_project_status.sh` — shared with `gh:pr`,
+`gh:pr-reply`, `gh:commit`, and `gh:flow`. Source the file each
+invocation; do not inline-copy the snippet so a single fix propagates
+everywhere.

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -133,8 +133,8 @@ GitHub Projects v2의 빌트인 워크플로우 10개 중 9개가 `enabled`
 
 ### 자동 전환 규칙 (스킬 경유)
 
-GitHub 빌트인이 커버하지 않는 세 전환은 dotfiles 의 스킬이
-공용 헬퍼 `_gh_project_status_sync`
+GitHub 빌트인이 커버하지 않거나 누락 시 보강해야 하는 네 전환은
+dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
 (`shell-common/functions/gh_project_status.sh`) 를 통해 자동화한다.
 보드가 없는 repo (예: `dotfiles` 이외의 사이드 프로젝트) 에선 헬퍼가
 `projectItems` 0건을 감지하고 조용히 no-op 하므로 추가 분기가 필요
@@ -165,6 +165,14 @@ GitHub 빌트인이 커버하지 않는 세 전환은 dotfiles 의 스킬이
   스킬에도 이 전환을 자동화하는 경로가 없다. 이 외의 PR 전환
   (`→ Done`) 은 빌트인 `Pull request merged` / `Item closed` 가
   자동 처리한다.
+- **Issue 카드 `In review → Done` (PR-Closes 경로 보강)**:
+  `/gh-pr-merge` 가 머지 직후 PR 의 `closingIssuesReferences` 를
+  순회하며 각 Issue 카드를 `Done` 으로 강제 이동한다. 빌트인
+  `Item closed` 워크플로우는 best-effort delivery 이므로 드물게
+  Status 업데이트 이벤트가 누락되어 Issue 카드가 `In review` 에
+  잔류하는 케이스가 관측된다 (#239 / #250). 본 보강 전환은 그 갭을
+  메우며 `--only-from "Backlog,In progress,In review"` 가드로
+  이미 `Done` 상태인 카드를 다시 건드리지 않는다.
 
 ### 용어 교정 (2026-04-24)
 
@@ -242,10 +250,16 @@ gh auth refresh -s project
   영원히 트리거되지 않는 갭을 메우기 위함). `In progress → In
   review` (`Changes requested` 루프 탈출 시) 전환만 항상 수동이다
   — 빌트인·스킬 모두 이 경로를 자동화하지 않는다.
-- 보드가 없는 repo 에서 `/gh-pr`, `/gh-commit`, 또는
-  `/gh-pr-reply` 를 실행하면 공용 헬퍼 `_gh_project_status_sync` 가
-  `projectItems` 가 0건임을 자동 감지하고 조용히 no-op 한다 (별도
-  분기 불필요).
+- 보드가 없는 repo 에서 `/gh-pr`, `/gh-commit`, `/gh-pr-reply`,
+  또는 `/gh-pr-merge` 를 실행하면 공용 헬퍼
+  `_gh_project_status_sync` 가 `projectItems` 가 0건임을 자동
+  감지하고 조용히 no-op 한다 (별도 분기 불필요).
+- Projects v2 빌트인 워크플로우는 best-effort delivery 라 드물게
+  Status 업데이트 이벤트가 누락된다. PR-Closes 경로 (PR 머지로 Issue
+  가 auto-close 되는 경로) 는 `/gh-pr-merge` 의 Step 4 post-merge
+  reconciliation 이 자동 보강한다. 그 외 경로 (수동 close, 다른 도구로
+  close) 에서 Issue 카드가 `In review` 등에 잔류하면 카드를 수동으로
+  `Done` 으로 옮긴다.
 - 수동으로 카드를 옮긴 경우 다음 자동 이벤트가 상태를 덮어쓸
   수 있다. 특히 Issue 카드를 `Approved`로 옮겨도 `Item closed`가
   PR 머지 시점에 곧바로 `Done`으로 이동시키므로 의미가 없다
@@ -274,5 +288,5 @@ gh auth refresh -s project
   - `claude/skills/gh-issue-flow/SKILL.md`
 - 관련 헬퍼: `shell-common/functions/gh_project_status.sh` (공용
   `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`, `/gh-commit`,
-  `/gh-pr-reply` 가 모두 호출).
+  `/gh-pr-reply`, `/gh-pr-merge` 가 모두 호출).
 - 관련 템플릿: `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary
- `/gh-pr-merge` 가 머지 직후 PR 의 `closingIssuesReferences` 를 순회하며 각 Issue 카드를 보드의 `Done` 으로 강제 동기화하도록 Step 4 추가.
- 빌트인 `Item closed` 워크플로우의 best-effort delivery 누락 (예: #239) 으로 Issue 카드가 `In review` 잔류하는 갭을 dotfiles 측에서 흡수.
- SSOT 문서 (`docs/standards/github-project-board.md`) 에 네 번째 스킬 경유 전환 추가 + 운영 유의사항에 best-effort delivery 한계 명시.

## Changes
- `claude/skills/gh-pr-merge/references/project-board-sync.md` (new): post-merge reconciliation 의 동작·가드·no-op 조건 progressive disclosure.
- `claude/skills/gh-pr-merge/SKILL.md`: 기존 Step 4 (Fetch Merge SHA + Report) 를 Step 5 로 리넘버, 그 사이에 Step 4 (Reconcile linked Issue cards) 삽입. 호출 스니펫·`--only-from "Backlog,In progress,In review"` 가드 인라인.
- `docs/standards/github-project-board.md`:
  - "자동 전환 규칙 (스킬 경유)" 섹션 preamble "세 전환" → "네 전환".
  - 새 bullet "Issue 카드 `In review → Done` (PR-Closes 경로 보강)" 추가.
  - "운영 상의 유의사항" 의 보드 없는 repo bullet 에 `/gh-pr-merge` 추가, best-effort delivery 한계 bullet 신규.
  - "관련 헬퍼" 라인에 `/gh-pr-merge` caller 추가.

## Test plan
- [x] `markdownlint-cli` 편집 파일 3건 lint clean (pre-existing `zsh/AGENTS.md` 위반은 out of scope).
- [x] 셸 코드 무변경 → `_gh_project_status_sync` 헬퍼 회귀 없음.
- [ ] 다음 실제 머지 호출 시 `/gh-pr-merge` 가 Step 4 에서 `closingIssuesReferences` 를 순회하고 각 Issue 카드의 Status 를 검사·보정하는지 확인 (이번 PR 머지가 자체 검증 케이스).
- [ ] 보드 없는 repo (예: jemings/SkillHub) 에서 `/gh-pr-merge` 호출 시 헬퍼가 zero project items 감지하고 silent no-op 하는지 확인.

## Related
Closes #250

## Summary by Sourcery

머지된 이후에도 연결된 이슈 카드가 프로젝트 보드 상태와 동기화되도록 `/gh-pr-merge`에 머지 후 정합(reconciliation) 단계를 추가하고, 해당 동작과 한계를 GitHub 프로젝트 보드 기준(standards)에 문서화합니다.

Enhancements:
- 공용 `_gh_project_status_sync` 헬퍼를 사용하여 연결된 이슈(Issue)의 프로젝트 보드 카드를 `Done` 상태로 정합하는 새로운 `/gh-pr-merge` 단계를 도입하며, 실패 시에도 머지를 막지 않는(non-blocking) 동작을 유지합니다.
- 머지 후 이슈 카드 정합 워크플로우, 그에 대한 가드(guard) 조건, 그리고 no-op이 되는 조건들을 전용 참고(reference) 파일에 문서화합니다.
- 추가된 자동 전환에 대해 설명하고, 보드가 없는 리포지토리에서의 동작을 명확히 하며, 내장(builtin) 워크플로우의 최대 노력(best-effort) 제공 한계를 명시하도록 GitHub 프로젝트 보드 기준(standards)을 업데이트합니다.

Documentation:
- `/gh-pr-merge` SKILL 문서를 확장하여 새 이슈 카드 정합 단계를 포함하고, 기존 머지 리포트(merge-report) 단계를 이에 맞게 번호를 재정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a post-merge reconciliation step to /gh-pr-merge to keep linked Issue cards in sync with project board status and document the behavior and limitations in the GitHub project board standards.

Enhancements:
- Introduce a new /gh-pr-merge step that reconciles linked Issues’ project board cards to Done using the shared _gh_project_status_sync helper, while remaining non-blocking on failure.
- Document the post-merge Issue card reconciliation workflow, its guards, and no-op conditions in a dedicated reference file.
- Update GitHub project board standards to describe the additional automated transition, clarify behavior on repos without boards, and note best-effort delivery limitations of builtin workflows.

Documentation:
- Expand /gh-pr-merge SKILL documentation to include the new Issue card reconciliation step and renumber the existing merge-report step accordingly.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
