### PR TITLE
Fix gh token scope detection for kanban setup

### DIFF
--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -132,11 +132,17 @@ require_command() {
 auth_scopes_csv() {
     local scopes
 
-    scopes="$(gh auth status --json hosts 2>/dev/null | jq -r '
-        .hosts?["github.com"]?[]?
-        | select(.active == true)
-        | .scopes // empty
-    ' | head -n1)"
+    scopes="$(gh api user -i 2>/dev/null | awk '
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            if (index(tolower(line), "x-oauth-scopes:") == 1) {
+                sub(/^[^:]*:[[:space:]]*/, "", line)
+                print line
+                exit
+            }
+        }
+    ')"
 
     if [ -z "$scopes" ]; then
         return 1
@@ -149,7 +155,7 @@ require_project_scope() {
     local scopes_csv need_scope
 
     if ! scopes_csv="$(auth_scopes_csv)"; then
-        die "gh auth status could not find an active github.com login. Run: gh auth login --scopes \"project\""
+        die "gh api user could not read token scopes. Run: gh auth login --scopes \"project\""
     fi
 
     need_scope="project"

--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -136,6 +136,9 @@ auth_scopes_csv() {
         {
             line = $0
             sub(/\r$/, "", line)
+            if (line == "") {
+                exit
+            }
             if (index(tolower(line), "x-oauth-scopes:") == 1) {
                 sub(/^[^:]*:[[:space:]]*/, "", line)
                 print line

--- a/tests/bats/tools/setup_kanban_board.bats
+++ b/tests/bats/tools/setup_kanban_board.bats
@@ -20,7 +20,12 @@ set -euo pipefail
 printf '%s\n' "$*" >> "${MOCK_GH_LOG}"
 
 if [[ "$1" == "auth" && "$2" == "status" ]]; then
-    cat "${MOCK_GH_AUTH_JSON}"
+    printf 'unknown flag: --json\n' >&2
+    exit 1
+fi
+
+if [[ "$1" == "api" && "$2" == "user" && "${3-}" == "-i" ]]; then
+    cat "${MOCK_GH_AUTH_HEADERS}"
     exit 0
 fi
 
@@ -96,20 +101,32 @@ $*
 EOF
 }
 
+write_auth_headers() {
+    local path="$1"
+    local scopes="$2"
+
+    cat >"$path" <<EOF
+HTTP/2 200
+x-oauth-scopes: ${scopes}
+content-type: application/json
+
+{"login":"mock"}
+EOF
+}
+
 run_setup_kanban() {
     run bash "$SETUP_KANBAN_SCRIPT" "$@"
 }
 
 @test "dry-run accepts read-only project scope and prints org workflow checklist" {
-    export MOCK_GH_AUTH_JSON="${TEST_TEMP_HOME}/auth.json"
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
     export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
     export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
     export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
     export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
     export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
 
-    write_json_fixture "$MOCK_GH_AUTH_JSON" \
-        '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project"}]}}'
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, read:project"
     write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
         '{"data":{"repository":{"id":"R_org","name":"widget","url":"https://github.com/acme/widget","owner":{"__typename":"Organization","login":"acme","id":"O_1"},"defaultBranchRef":{"name":"main"}}}}'
     write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
@@ -127,6 +144,12 @@ run_setup_kanban() {
     assert_output --partial "Workflows: https://github.com/orgs/acme/projects/0/workflows"
     assert_output --partial "hide 'Approved' and 'Ready'"
 
+    grep -q '^api user -i$' "$MOCK_LOG"
+    if grep -q '^auth status' "$MOCK_LOG"; then
+        echo "auth status should not be used for scope detection"
+        return 1
+    fi
+
     if grep -q 'mutation CreateProject' "$MOCK_LOG"; then
         echo "CreateProject mutation should not run in dry-run mode"
         return 1
@@ -134,15 +157,14 @@ run_setup_kanban() {
 }
 
 @test "existing project exits successfully without mutations" {
-    export MOCK_GH_AUTH_JSON="${TEST_TEMP_HOME}/auth.json"
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
     export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
     export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
     export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
     export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
     export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
 
-    write_json_fixture "$MOCK_GH_AUTH_JSON" \
-        '{"hosts":{"github.com":[{"active":true,"scopes":"repo, project"}]}}'
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, project"
     write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
         '{"data":{"repository":{"id":"R_user","name":"dotfiles","url":"https://github.com/deity/dotfiles","owner":{"__typename":"User","login":"deity","id":"U_1"},"defaultBranchRef":{"name":"main"}}}}'
     write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
@@ -166,15 +188,14 @@ run_setup_kanban() {
 }
 
 @test "new project path performs project, field, and template mutations" {
-    export MOCK_GH_AUTH_JSON="${TEST_TEMP_HOME}/auth.json"
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
     export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
     export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
     export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
     export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
     export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
 
-    write_json_fixture "$MOCK_GH_AUTH_JSON" \
-        '{"hosts":{"github.com":[{"active":true,"scopes":"repo, project"}]}}'
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, project"
     write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
         '{"data":{"repository":{"id":"R_new","name":"widget","url":"https://github.com/deity/widget","owner":{"__typename":"User","login":"deity","id":"U_9"},"defaultBranchRef":{"name":"main"}}}}'
     write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
@@ -196,4 +217,15 @@ run_setup_kanban() {
     grep -q 'mutation LinkProject' "$MOCK_LOG"
     grep -q 'mutation UpdateStatusField' "$MOCK_LOG"
     grep -q 'repos/deity/widget/contents/.github/pull_request_template.md' "$MOCK_LOG"
+}
+
+@test "missing project scope fails from gh api header scopes" {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, gist"
+
+    run_setup_kanban --owner deity --repo dotfiles
+    assert_failure
+    assert_output --partial "Your gh token is missing the project scope required for mutations"
+    grep -q '^api user -i$' "$MOCK_LOG"
 }

--- a/tests/bats/tools/setup_kanban_board.bats
+++ b/tests/bats/tools/setup_kanban_board.bats
@@ -229,3 +229,20 @@ run_setup_kanban() {
     assert_output --partial "Your gh token is missing the project scope required for mutations"
     grep -q '^api user -i$' "$MOCK_LOG"
 }
+
+@test "scope parser ignores x-oauth-scopes text in response body" {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+
+    cat >"$MOCK_GH_AUTH_HEADERS" <<'EOF'
+HTTP/2 200
+content-type: application/json
+
+x-oauth-scopes: project
+{"login":"mock"}
+EOF
+
+    run_setup_kanban --owner deity --repo dotfiles
+    assert_failure
+    assert_output --partial "gh api user could not read token scopes"
+    grep -q '^api user -i$' "$MOCK_LOG"
+}


### PR DESCRIPTION
## Summary
- `setup-kanban-board.sh` 의 GitHub 토큰 scope 감지를 `gh auth status --json` 에서 `gh api user -i` 응답 헤더 기반으로 교체했습니다.
- 구버전 `gh` CLI 에서 `--json hosts` 가 지원되지 않아 valid token 이 거부되던 회귀를 차단합니다.
- 오프라인 bats mock 이 legacy auth-status probe 를 실패시키고 header parser 경로를 검증하도록 업데이트했습니다.

## Changes
- `scripts/setup-kanban-board.sh`: `X-OAuth-Scopes` 헤더를 awk 로 파싱해 `project` / `read:project` scope 판단에 사용하고, 실패 메시지도 새 probe 에 맞게 정리했습니다.
- `tests/bats/tools/setup_kanban_board.bats`: `gh api user -i` mock, read-only project scope, full project scope, missing-scope 실패 케이스를 header fixture 로 검증합니다.

## Test plan
- [x] `bash -n scripts/setup-kanban-board.sh tests/bats/tools/setup_kanban_board.bats`
- [x] `shellcheck -x -e SC1090,SC1091 scripts/setup-kanban-board.sh`
- [x] `shfmt -d -i 4 scripts/setup-kanban-board.sh tests/bats/tools/setup_kanban_board.bats`
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/setup_kanban_board.bats`
- [x] `tox -e bats` — 205 passed
- [ ] `tox` — `ruff`, `mypy`, `shellcheck`, `shfmt` passed; `mdlint` fails on pre-existing Markdown violations and is disabled by project instructions

## Related
Closes #253

## Summary by Sourcery

kanban 보드 설정을 업데이트하여, `auth status --json` 결과 대신 `gh api` 응답 헤더를 통해 GitHub 토큰 스코프를 감지하도록 변경하고, 새로운 감지 방식에 맞게 테스트를 정렬했습니다.

버그 수정:
- `auth status --json`를 지원하지 않는 예전 버전의 gh CLI에서 kanban 설정이 실패하던 문제를, 헤더 기반 스코프 감지 방식으로 전환하여 수정했습니다.

테스트:
- `gh api user -i` 헤더 응답을 에뮬레이션하도록 bats mock과 fixture를 조정하고, 스코프 파싱 동작(스코프 누락 시 실패 포함)을 검증했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update kanban board setup to detect GitHub token scopes via gh api response headers instead of auth status JSON, and align tests with the new detection method.

Bug Fixes:
- Fix kanban setup failure on older gh CLI versions that do not support auth status --json by switching to header-based scope detection.

Tests:
- Adjust bats mocks and fixtures to emulate gh api user -i header responses and verify scope parsing behavior, including missing-scope failures.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
