### PR TITLE
feat(project-board): auto-detect --owner/--repo via gh repo view

### DIFF
--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -137,7 +137,7 @@ detect_repo_defaults() {
     fi
 
     local detected_info detected_owner detected_repo
-    detected_info="$(gh repo view --json owner,name -q '.owner.login + " " + .name' 2>/dev/null || true)"
+    detected_info="$(gh repo view --json owner,name -q '(.owner.login? // empty) + " " + (.name? // empty)' 2>/dev/null || true)"
     [ -n "$detected_info" ] || return 0
 
     read -r detected_owner detected_repo <<<"$detected_info"

--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -49,12 +49,12 @@ die() {
 
 print_help() {
     ux_header "Kanban Board Setup"
-    ux_usage "./scripts/setup-kanban-board.sh" "--owner <login> --repo <name> [options]" \
+    ux_usage "./scripts/setup-kanban-board.sh" "[--owner <login>] [--repo <name>] [options]" \
         "Create a GitHub Projects v2 board, link the repo, sync the Status field, and print the remaining UI checklist."
 
     ux_section "Options"
-    ux_bullet "--owner <login>              GitHub user or org that owns the project"
-    ux_bullet "--repo <name>                Repository name to link"
+    ux_bullet "--owner <login>              GitHub user or org (default: current repo's owner via gh repo view)"
+    ux_bullet "--repo <name>                Repository name (default: current repo's name via gh repo view)"
     ux_bullet "--title <board-title>        Project title (default: repo name)"
     ux_bullet "--auto-archive-window <dur>  Filter suffix for Done auto-archive (default: 2d)"
     ux_bullet "--hide-columns               Add solo-repo hide guidance for Approved and Ready"
@@ -108,8 +108,10 @@ parse_args() {
         esac
     done
 
-    [ -n "$OWNER" ] || die "--owner is required"
-    [ -n "$REPO" ] || die "--repo is required"
+    detect_repo_defaults
+
+    [ -n "$OWNER" ] || die "--owner is required (auto-detect failed; pass --owner or run inside a GitHub-linked git repo)"
+    [ -n "$REPO" ] || die "--repo is required (auto-detect failed; pass --repo or run inside a GitHub-linked git repo)"
 
     if [ -z "$TITLE" ]; then
         TITLE="$REPO"
@@ -126,6 +128,24 @@ require_command() {
 
     if ! command -v "$name" >/dev/null 2>&1; then
         die "${name} is required. ${install_hint}"
+    fi
+}
+
+detect_repo_defaults() {
+    if [ -n "$OWNER" ] && [ -n "$REPO" ]; then
+        return 0
+    fi
+
+    local detected_info detected_owner detected_repo
+    detected_info="$(gh repo view --json owner,name -q '.owner.login + " " + .name' 2>/dev/null || true)"
+    [ -n "$detected_info" ] || return 0
+
+    read -r detected_owner detected_repo <<<"$detected_info"
+    if [ -z "$OWNER" ] && [ -n "${detected_owner-}" ]; then
+        OWNER="$detected_owner"
+    fi
+    if [ -z "$REPO" ] && [ -n "${detected_repo-}" ]; then
+        REPO="$detected_repo"
     fi
 }
 

--- a/tests/bats/tools/setup_kanban_board.bats
+++ b/tests/bats/tools/setup_kanban_board.bats
@@ -24,6 +24,15 @@ if [[ "$1" == "auth" && "$2" == "status" ]]; then
     exit 1
 fi
 
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+    if [ -n "${MOCK_GH_REPO_VIEW_OUTPUT-}" ]; then
+        printf '%s\n' "${MOCK_GH_REPO_VIEW_OUTPUT}"
+        exit 0
+    fi
+    printf 'no git remote found for current directory\n' >&2
+    exit 1
+fi
+
 if [[ "$1" == "api" && "$2" == "user" && "${3-}" == "-i" ]]; then
     cat "${MOCK_GH_AUTH_HEADERS}"
     exit 0
@@ -228,6 +237,69 @@ run_setup_kanban() {
     assert_failure
     assert_output --partial "Your gh token is missing the project scope required for mutations"
     grep -q '^api user -i$' "$MOCK_LOG"
+}
+
+@test "auto-detects --owner and --repo from current git context when both omitted" {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+    export MOCK_GH_REPO_VIEW_OUTPUT="acme widget"
+
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, read:project"
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_org","name":"widget","url":"https://github.com/acme/widget","owner":{"__typename":"Organization","login":"acme","id":"O_1"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"Organization","projectsV2":{"nodes":[]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" \
+        '{"data":{"createProjectV2":{"projectV2":{"id":"PVT_new","number":77,"title":"widget","url":"https://github.com/orgs/acme/projects/77"}}}}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" \
+        '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status"}]}}}}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" \
+        '{"data":{"repository":{"object":null}}}'
+
+    run_setup_kanban --dry-run
+    assert_success
+    assert_output --partial "[dry-run] Would create project 'widget' under acme"
+    grep -q '^repo view --json owner,name' "$MOCK_LOG"
+}
+
+@test "fails with auto-detect hint when args omitted and gh repo view fails" {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, project"
+
+    run_setup_kanban --dry-run
+    assert_failure
+    assert_output --partial "auto-detect"
+    grep -q '^repo view --json owner,name' "$MOCK_LOG"
+}
+
+@test "explicit --owner is preserved when only --repo can be auto-detected" {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+    export MOCK_GH_REPO_VIEW_OUTPUT="acme widget"
+
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, read:project"
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_org","name":"widget","url":"https://github.com/myorg/widget","owner":{"__typename":"Organization","login":"myorg","id":"O_2"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"Organization","projectsV2":{"nodes":[]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" \
+        '{"data":{"createProjectV2":{"projectV2":{"id":"PVT_new","number":77,"title":"widget","url":"https://github.com/orgs/myorg/projects/77"}}}}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" \
+        '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status"}]}}}}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" \
+        '{"data":{"repository":{"object":null}}}'
+
+    run_setup_kanban --owner myorg --dry-run
+    assert_success
+    assert_output --partial "[dry-run] Would create project 'widget' under myorg"
 }
 
 @test "scope parser ignores x-oauth-scopes text in response body" {


### PR DESCRIPTION
## Summary
- `scripts/setup-kanban-board.sh` 가 `--owner` / `--repo` 가 비어 있으면
  `gh repo view --json owner,name` 으로 현재 저장소 정보를 자동 채우도록 개선.
- 명시적으로 한쪽만 지정한 경우(예: `--owner` 만) 나머지 한쪽만 자동 감지해
  사용자의 입력을 절대 덮어쓰지 않음.

## Changes
- `scripts/setup-kanban-board.sh`: `detect_repo_defaults()` 추가 후
  `parse_args()` 의 필수값 검증 직전에 호출. 기존 die 문에는 자동 감지 실패
  안내 문구 추가. help 의 usage/옵션 설명을 옵션화 + 기본값 안내로 갱신.
- `tests/bats/tools/setup_kanban_board.bats`: mock `gh` 가
  `gh repo view --json owner,name` 를 처리하도록 확장하고, (1) 양쪽 자동
  감지, (2) 자동 감지 실패 메시지, (3) 명시적 `--owner` 보존 케이스 3종 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/setup_kanban_board.bats` (8/8 pass)
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/` (26/26 pass — 기존 회귀 없음)
- [x] `shellcheck scripts/setup-kanban-board.sh` (no findings)
- [x] `shfmt -d -i 4 scripts/setup-kanban-board.sh` (no diff)

## Related
Closes #254

## Summary by Sourcery

현재 git 컨텍스트를 사용하여 칸반 보드 설정 스크립트에서 저장소 소유자와 이름을 자동 감지하고, 이에 맞게 테스트를 조정합니다.

New Features:
- 칸반 보드 설정 스크립트가 명시적으로 제공되지 않았을 때 `gh repo view`를 통해 현재 저장소에서 `--owner`와 `--repo` 값을 추론할 수 있도록 허용합니다.

Enhancements:
- CLI 도움말 텍스트를 업데이트하여 선택적 `--owner`/`--repo` 플래그와 새로 추가된 자동 감지 기본값을 문서화합니다.
- 현재 저장소로부터 두 값 중 하나만 추론 가능한 경우에도, 사용자가 제공한 `--owner`/`--repo` 값이 유지되도록 보장합니다.

Tests:
- 자동 감지 성공, 자동 감지 실패 시 메시지, 그리고 명시적으로 제공된 `--owner` 값이 유지되는 경우를 포괄하도록 bats 테스트와 gh mock을 확장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Auto-detect repository owner and name in the Kanban board setup script using the current git context, and adjust tests accordingly.

New Features:
- Allow the Kanban board setup script to infer --owner and --repo from the current repository via gh repo view when not provided explicitly.

Enhancements:
- Update CLI help text to document optional --owner/--repo flags and their new auto-detected defaults.
- Ensure user-provided --owner/--repo values are preserved when only one of them can be inferred from the current repository.

Tests:
- Extend bats tests and gh mock to cover auto-detection success, auto-detection failure messaging, and preservation of explicit --owner values.

</details>

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
