### PR TITLE
feat(gh-pr-approve): split self-PR into self-record and admin-merge

### DIFF
--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -1,112 +1,94 @@
 ---
 name: gh:pr-approve
 description: >-
-  Review a GitHub PR a colleague requested you review, then either approve
-  with an LGTM 👍 summary if flawless, or file remaining concerns as
-  follow-up GitHub issues and link them from a PR comment. Use when the
-  user runs /gh-pr-approve, /gh:pr-approve, or asks "PR 리뷰하고 승인해",
-  "approve PR 99", "#99 리뷰 승인", "동료 PR 검토 후 approve", "re-review
-  requested". Preserves the AI-driven issue workflow — non-blocking items
-  become issues the team can triage automatically, real blockers get an
-  explicit "Request changes" review. Project-agnostic; works in any repo
-  reachable via gh CLI. Accepts `-h`/`--help`/`help` to print usage.
+  Review a GitHub PR, approve it when clean, request changes for blockers,
+  or file follow-up issues for non-blocking concerns. Use for
+  /gh-pr-approve, /gh:pr-approve, "approve PR 99", "#99 리뷰 승인", or
+  "re-review requested". Self-authored PRs cannot be approved; they use
+  analysis-only, comment-only, or admin-merge paths.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
-# gh:pr-approve — Review → Approve or File Follow-up Issues
+# gh:pr-approve - Review, Approve, or Handle Self-PR
 
 ## Help
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls. Help is detected
-**only at arg #1** and takes precedence over the Step 1 arg parser —
-`--self-ok -h` is parsed as `--self-ok` followed by an unknown flag,
-not as a help request.
+output it verbatim, then stop. Help is detected only at arg #1, so
+`--self-ok -h` is parsed as unsupported `--self-ok` plus extra args.
 
 ## Step 1: Resolve + Pre-flight Gate (parallel)
 
 Parse args first. Positional: `<pr-number>` and `<remote>` (default
-`origin`). Optional flag: `--self-ok` (may appear in any position) —
-when present, set `SELF_OK=1`; otherwise `SELF_OK=0`. Use `--self-ok`
-only when the author and authenticated user collide intentionally
-(e.g. another AI agent acted as author, no human reviewer is
-available). It does NOT relax any other stop condition.
+`origin`). Flags may appear anywhere:
 
-Then fetch pre-flight signals in parallel before reading the diff:
+- `--self-record` - self-authored PR only; submit a comment-only record.
+- `--admin-merge` - self-authored PR only; after a blocker-free review,
+  run `gh pr merge --admin`.
+- `--squash`, `--rebase`, `--merge` - optional strategy for
+  `--admin-merge`; reject if used without it.
 
-- `TARGET_REPO` from `git remote get-url <remote>`. Missing remote →
+Reject unknown flags, `--self-record` with `--admin-merge`, and legacy
+`--self-ok` with:
+`--self-ok is not supported; GitHub blocks self-approval server-side.`
+
+Fetch in parallel before reading the diff:
+
+- `TARGET_REPO` from `git remote get-url <remote>`. Missing remote:
   list `git remote -v` and stop.
-- PR number: explicit arg → `gh pr view --json number` on current
-  branch → stop and ask.
-- `ME=$(gh api user -q .login)` for self-review / re-review checks.
+- PR number: explicit arg or `gh pr view --json number` on current
+  branch; if neither exists, stop and ask.
+- `ME=$(gh api user -q .login)`.
 - PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,files`
-- Prior reviews/comments on this PR by `ME`
-- `gh pr checks <N> --repo $TARGET_REPO`
+- Prior reviews/comments on this PR by `ME`.
+- `gh pr checks <N> --repo $TARGET_REPO`.
 
-**Stop conditions** (explain, don't approve): `state != OPEN` ·
-`isDraft == true` · `author.login == ME` *(skipped when `SELF_OK=1`)* ·
-`mergeable == CONFLICTING` · any required check failing.
+Stop on `state != OPEN`, draft, merge conflicts, or required-check
+failure. If `author.login == ME`, follow `references/self-pr-handling.md`.
+If prior `ME` comments/reviews exist, use re-review mode: every prior
+concern must be verified as fixed, tracked, or acceptably declined.
 
-When `SELF_OK=1` and `author.login == ME`, proceed but **record the
-bypass in the review body** per `references/approval-templates.md`
-("Self-approval audit trail"). Other stop conditions still apply.
+## Step 2: Fetch Review Material
 
-If prior `ME` comments/reviews exist → **re-review mode**: primary goal
-is verifying each prior concern was addressed by a subsequent commit.
-
-## Step 2: Fetch Review Material + Review
-
-In parallel: `gh pr diff <N>`, `gh pr view <N> --json commits`, and the
-three comment endpoints in `references/review-criteria.md`. Apply that
-file's checklist — correctness, conventions, security, performance,
-tests. In re-review mode, map each prior concern to the commit that
-resolved it (or flag "unresolved").
+In parallel: `gh pr diff <N>`, commits JSON, and the three comment
+endpoints in `references/review-criteria.md`. Apply that checklist. In
+re-review mode, map each prior concern to a fixing commit, tracking issue,
+or acceptable author reply.
 
 ## Step 3: Classify Findings
 
-Each concern is exactly one of **BLOCKER** (must fix before merge),
-**FOLLOW-UP** (valid but non-blocking), or **PRAISE** (collect ≥1 for
-approvals, anchored to a concrete diff location). See
-`references/review-criteria.md` for the BLOCKER / FOLLOW-UP line.
+Classify each concern as **BLOCKER**, **FOLLOW-UP**, or **PRAISE**. Praise
+for approvals must cite concrete diff locations. Path selection:
 
-Path selection:
-- 0 BLOCKER, 0 FOLLOW-UP → **4a** clean LGTM
-- 0 BLOCKER, ≥1 FOLLOW-UP → **4b** approve with follow-up issues
-- ≥1 BLOCKER → **4c** request changes
+- Non-self, 0 BLOCKER, 0 FOLLOW-UP: **4a** clean LGTM.
+- Non-self, 0 BLOCKER, at least 1 FOLLOW-UP: **4b** approve with issues.
+- Non-self, at least 1 BLOCKER: **4c** request changes.
+- Self-authored PR: use the selected path from `references/self-pr-handling.md`.
 
-## Step 4: Submit Review
+## Step 4: Submit Review or Self-PR Action
 
-Command shapes + body templates in `references/approval-templates.md`.
-Match the language dominant in the PR (Korean PR → Korean review).
+Use `references/approval-templates.md` for commands and body templates.
+Match the PR's dominant language.
 
-- **4a** `gh pr review --approve` with 👍 + 2–4 specific compliments.
-- **4b** One `gh issue create` per FOLLOW-UP → one PR comment linking
-  all of them → `gh pr review --approve`.
-- **4c** `gh pr review --request-changes` listing each BLOCKER with a
-  `file:line` pointer. Never silently file blockers as issues — they
-  stay on the PR so the author's next push triggers natural re-review.
+- **4a** Submit `gh pr review --approve`.
+- **4b** Create one issue per FOLLOW-UP, post one linking PR comment,
+  then submit `gh pr review --approve`.
+- **4c** Submit `gh pr review --request-changes`; blockers stay on the PR.
+- Self-authored PR: never approve. Use analysis-only, `--self-record`, or
+  `--admin-merge` exactly as specified in `references/self-pr-handling.md`.
 
 ## Step 5: Verify and Report
 
-Re-fetch `reviewDecision` + `mergeStateStatus`. If still BLOCKED despite
-an approval, diagnose (another reviewer CHANGES_REQUESTED, required
-check pending, branch out of date, reviewer lacks write access) and
-include that in the report.
-
-Print:
-```
-PR #<N>: <APPROVED|CHANGES_REQUESTED>
-  Blockers:   <n>
-  Follow-ups: <n>  → issues: #A, #B
-  Merge:      <CLEAN|BLOCKED — <reason>>
-  <PR URL>
-```
+Re-fetch `reviewDecision` + `mergeStateStatus`; for `--admin-merge`, also
+re-fetch `state` and `mergeCommit`. Report status, blocker/follow-up
+counts, issue links, merge state, and PR URL. For `--self-record`, confirm
+`reviewDecision` did not become `APPROVED`.
 
 ## Constraints
 
 - Never approve without reading the diff, nor approve your own PR.
-- Compliments must reference concrete diff locations — no generic praise.
-- Never fabricate follow-ups to look thorough. Each issue must represent
-  a real concern you can defend.
-- Never merge the PR — the author decides when to merge.
-- No labels/milestones on follow-up issues unless `gh label list` confirms the label exists.
+- GitHub blocks self-approval server-side; no token or flag can bypass it.
+- Never accept `--self-ok`; it describes an impossible operation.
+- Never fabricate follow-ups. Each issue must represent a defensible concern.
+- Never merge a colleague's PR. `--admin-merge` is self-PR only.
+- No labels/milestones unless `gh label list` confirms the label exists.

--- a/claude/skills/gh-pr-approve/references/approval-templates.md
+++ b/claude/skills/gh-pr-approve/references/approval-templates.md
@@ -9,12 +9,12 @@ BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 
 ## 6a — Clean LGTM
 
-No findings. Approve with 👍 and 2–4 specific compliments.
+No findings. Approve with 2–4 specific compliments.
 
 ### Body template
 
 ```markdown
-LGTM 👍
+LGTM
 
 ### 요약
 <한 문단 — 이 PR이 달성한 것, 리뷰 관점의 핵심 포인트>
@@ -92,7 +92,7 @@ Approve는 별도로 제출합니다 — 아래 리뷰 참고.
 Body template (extends 6a + a follow-up section):
 
 ```markdown
-LGTM 👍
+LGTM
 
 ### 요약
 <PR 핵심 요약 1문단>
@@ -140,44 +140,37 @@ Never approve. List each blocker with a `file:line` pointer and the minimal fix 
 gh pr review <N> --repo "$TARGET_REPO" --request-changes --body-file "$BODY"
 ```
 
-## Self-approval audit trail
+## Self-PR bodies
 
-When Step 1 is invoked with `--self-ok` and `author.login == ME`, prepend the
-following note to the review body for **6a** and **6b** (do not add to **6c**
-— request-changes never reaches this branch).
+Self-authored PRs never use `--approve`; GitHub rejects same-user approval
+server-side. Use `self-pr-handling.md` for mode selection and command shapes.
+
+### `--self-record` body suffix
+
+Append this to the review body before `gh pr review --comment` or fallback
+`gh pr comment`:
 
 ```markdown
-> ⚠️ Self-approval via `--self-ok`. Author and reviewer are the same GitHub
-> user (`<ME>`). Justification: <one concrete reason — see picker below>.
+### Self-PR note
+
+This is a self-authored PR. GitHub blocks self-approval server-side, so this
+comment records review analysis only and does not satisfy review-based branch
+protection. External review or admin merge is still required where protection
+rules apply.
 ```
 
-**Picking the justification.** Replace `<one concrete reason ...>` with a
-single, specific sentence. Do **not** paste a slash-separated list and do
-**not** leave the placeholder verbatim. Choose by scanning the user's
-invocation context (slash-command transcript, recent chat, PR description)
-in this order:
+### `--admin-merge` body note
 
-1. **Explicit user reason.** If the user named one (e.g. "동료 둘 다 연차",
-   "codex가 만든 PR을 claude가 리뷰"), reuse their phrasing trimmed to one
-   sentence.
-2. **Multi-AI workflow.** Use this when the author and reviewer are
-   different AI agents (codex/gemini/claude) acting under the same GitHub
-   user — phrase it concretely, e.g. "Authored by codex, reviewed by
-   claude under shared user `dEitY719`".
-3. **No human reviewer available.** Use when colleagues with review
-   access are unavailable; name the constraint, e.g. "All eligible
-   human reviewers OOO until 2026-05-02".
-4. **Last resort.** If none of the above applies, refuse the bypass —
-   `--self-ok` without a defensible justification defeats the audit trail.
-   Stop and ask the user before proceeding.
+If follow-up issues are created before an admin merge, post one PR comment:
 
-**Language convention.** The leading `⚠️ Self-approval via --self-ok` line
-stays in English regardless of the PR language — it's the searchable
-audit anchor across repos. Only the `Justification:` text matches the
-PR's dominant language (Korean PR → Korean justification).
+```markdown
+Self-authored PR reviewed before admin merge. GitHub blocks self-approval
+server-side, so no approving review was submitted.
 
-The note is required, not optional — the audit trail is the safety net that
-makes the bypass acceptable.
+Follow-up issues:
+- #<A> — <one-line summary>
+- #<B> — <one-line summary>
+```
 
 ## Language matching
 
@@ -186,5 +179,5 @@ Scan the PR body + most recent 3 human comments. Reply in the dominant language.
 ## Don'ts
 
 - **Never** attach `--label`/`--assignee`/`--milestone` to follow-up issues unless verified via `gh label list` / `gh api` that they exist — silent failures or surprise taxonomy damage is worse than terse issues.
-- **Never** submit a `--comment` review as a substitute for `--approve`. "Comment" reviews don't satisfy branch protection and will confuse the author.
+- **Never** submit a `--comment` review as a substitute for `--approve`, except the explicit `--self-record` path. Comment reviews do not satisfy branch protection.
 - **Never** re-submit a review if one already exists — GitHub dismisses stale ones; check `reviewDecision` first.

--- a/claude/skills/gh-pr-approve/references/help.md
+++ b/claude/skills/gh-pr-approve/references/help.md
@@ -11,27 +11,30 @@
 
 | Flag | Description |
 |------|-------------|
-| `--self-ok` | Skip the self-review pre-flight stop (`author.login == ME`). Use when another AI agent authored the PR or when no human reviewer is available. Other stop conditions (draft, conflicting, failing checks) still apply. The bypass is recorded in the review body for audit. |
+| `--self-record` | For a self-authored PR, read the diff and leave a comment-only review record. This does not satisfy review-based branch protection. |
+| `--admin-merge` | For a self-authored PR, read the diff and merge with `gh pr merge --admin` when there are no blockers. Requires admin rights. |
+| `--squash`, `--rebase`, `--merge` | Optional merge strategy for `--admin-merge`. |
 
 ## Usage
 
 - `/gh-pr-approve 99` — review PR #99 on `origin`
 - `/gh-pr-approve 99 upstream` — PR #99 on `upstream`'s repo
 - `/gh-pr-approve` — review the PR open on the current branch
-- `/gh-pr-approve 99 --self-ok` — review PR #99 even though you authored it (multi-AI workflow / no human reviewer)
+- `/gh-pr-approve 99 --self-record` — record self-PR analysis without approval
+- `/gh-pr-approve 99 --admin-merge --squash` — review, then admin-merge a clean self-PR
 - `/gh-pr-approve -h` / `--help` / `help` — print this help
 
 ## What the skill does
 
 1. Pre-flight gate — checks PR state, draft, author, merge conflicts, required CI.
-   Stops early on any blocker (won't approve your own PR, can't approve a draft, etc.).
+   Stops early on any blocker (can't approve a draft, conflicting PR, failing checks, etc.).
 2. Fetches diff, commits, and all three comment endpoints (inline / issue / review).
 3. Reviews against `references/review-criteria.md` — correctness, conventions, security,
    performance, tests. If you previously reviewed this PR, enters re-review mode and
    verifies every prior concern was addressed.
 4. Classifies findings as BLOCKER, FOLLOW-UP, or PRAISE.
 5. Submits the review:
-   - 0 BLOCKER, 0 FOLLOW-UP → **Approve with LGTM 👍** + specific compliments.
+   - 0 BLOCKER, 0 FOLLOW-UP → **Approve with LGTM** + specific compliments.
    - 0 BLOCKER, ≥1 FOLLOW-UP → files each follow-up as a GitHub issue, posts one PR
      comment linking them, then approves. Keeps the AI-driven issue workflow intact.
    - ≥1 BLOCKER → **Request changes** with per-blocker file:line pointers. Blockers
@@ -39,10 +42,30 @@
 6. Re-fetches `reviewDecision` + `mergeStateStatus` and reports a compact summary
    (plus diagnosis if merge is still blocked for reasons outside your review).
 
+## Self-authored PRs
+
+GitHub permanently blocks same-user self-approval server-side. The failing
+API error is:
+
+```text
+Review Can not approve your own pull request
+```
+
+`--self-ok` is not supported. No token, PAT, prompt, freeform flag, or option
+combination can make the same GitHub user approve their own PR.
+
+Legitimate alternatives:
+
+1. `gh pr merge --admin` — bypass branch protection and merge with admin rights.
+2. `gh pr review --comment` — preserve review analysis as a comment-only review.
+3. `gh pr comment` — preserve the same analysis as a normal PR comment.
+4. Request an external reviewer — the normal path that satisfies review rules.
+
 ## What the skill won't do
 
-- Approve your own PR (unless `--self-ok` is given — see Flags above).
+- Approve your own PR.
+- Accept `--self-ok`.
 - Approve without reading the diff.
-- Merge the PR (author decides).
+- Merge a colleague's PR (author decides). `--admin-merge` is only for self-authored PRs.
 - Create follow-up issues for trivia that don't justify a tracked item.
 - Attach labels/milestones to follow-up issues unless the label already exists in the repo.

--- a/claude/skills/gh-pr-approve/references/review-criteria.md
+++ b/claude/skills/gh-pr-approve/references/review-criteria.md
@@ -66,4 +66,7 @@ Generic praise ("great job!", "looks good!") is worse than none — it signals a
 
 ## Self-review guard
 
-Before submitting: if the PR author's login equals `ME`, stop. GitHub itself will reject the approval, but the skill should fail fast with a clear message rather than let `gh pr review` error out.
+Before submitting an approving review: if the PR author's login equals
+`ME`, do not call `gh pr review --approve`. GitHub rejects same-user
+self-approval server-side. Use `self-pr-handling.md` for the
+analysis-only, `--self-record`, or `--admin-merge` paths.

--- a/claude/skills/gh-pr-approve/references/self-pr-handling.md
+++ b/claude/skills/gh-pr-approve/references/self-pr-handling.md
@@ -1,0 +1,102 @@
+# Self-PR Handling
+
+GitHub blocks self-approval server-side. When `author.login == ME`, do not
+call `gh pr review --approve`; GitHub returns:
+
+```text
+Review Can not approve your own pull request
+```
+
+No prompt, token, PAT, or freeform flag can turn same-user self-approval
+into a valid approving review. In particular, `--self-ok` is unsupported
+and must be rejected before any API mutation.
+
+## Initial Message
+
+When the PR author is the authenticated user, print:
+
+```text
+self-PR detected (author == ME). GitHub blocks self-approval server-side.
+Choose:
+  --admin-merge   review then gh pr merge --admin (admin rights required)
+  --self-record   comment-only review record + external reviewer guidance
+  (default)       analyze only and exit without GitHub mutation
+```
+
+Then continue according to the selected mode.
+
+## Default: Analysis Only
+
+Read the diff and comments, classify findings, and print the review body
+locally. Do not create comments, reviews, issues, or merges.
+
+Append this line to the report:
+
+```text
+No GitHub review submitted because author and reviewer are the same user.
+```
+
+## `--self-record`: Comment-Only Record
+
+Use this when the user wants an audit trail but cannot satisfy branch
+protection by self-approval.
+
+If BLOCKER exists:
+
+```bash
+gh pr review <N> --repo "$TARGET_REPO" --comment --body-file "$BODY"
+```
+
+If no BLOCKER exists, use the same command with an LGTM-style body that
+explicitly says it is not an approval:
+
+```markdown
+LGTM analysis only
+
+This is a self-authored PR. GitHub blocks self-approval server-side, so this
+comment does not satisfy review-based branch protection.
+```
+
+If `gh pr review --comment` is rejected for a self-authored PR, fall back to:
+
+```bash
+gh pr comment <N> --repo "$TARGET_REPO" --body-file "$BODY"
+```
+
+After posting, re-fetch `reviewDecision` and report that external review or
+admin merge is still required when branch protection applies.
+
+## `--admin-merge`: Admin Bypass Merge
+
+Use this only for self-authored PRs and only after reading the diff.
+
+Rules:
+
+- If any BLOCKER exists, do not merge. Print blockers and stop.
+- If FOLLOW-UP exists, create follow-up issues first unless the user asked
+  for analysis only.
+- Skip `gh pr review --approve`; it cannot work for the same GitHub user.
+- Let `gh` print permission or branch-protection errors verbatim.
+
+Command:
+
+```bash
+gh pr merge <N> --repo "$TARGET_REPO" --admin
+```
+
+When the user supplied a strategy, append exactly one of:
+
+```bash
+--squash
+--rebase
+--merge
+```
+
+Do not silently switch strategies if GitHub rejects the selected method.
+
+## Legal Alternatives Summary
+
+- `gh pr merge --admin` - bypass branch protection using admin rights.
+- `gh pr review --comment` - keep review analysis as a comment-only review.
+- `gh pr comment` - fallback audit trail when comment reviews are rejected.
+- External reviewer request - the normal path that satisfies review rules.

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -53,36 +53,36 @@ _gh_pr_approve_get_state() {
 # Returns 0 if the ai runner is one of: claude, codex, gemini.
 _gh_pr_approve_known_ai() {
     case "$1" in
-        claude|codex|gemini) return 0 ;;
-        *) return 1 ;;
+    claude | codex | gemini) return 0 ;;
+    *) return 1 ;;
     esac
 }
 
 # Ensure the selected ai CLI exists in PATH.
 _gh_pr_approve_require_ai_cli() {
     case "$1" in
-        claude)
-            if ! _have claude; then
-                ux_error "claude CLI not found"
-                return 1
-            fi
-            ;;
-        codex)
-            if ! _have codex; then
-                ux_error "codex CLI not found"
-                return 1
-            fi
-            ;;
-        gemini)
-            if ! _have gemini; then
-                ux_error "gemini CLI not found"
-                return 1
-            fi
-            ;;
-        *)
-            ux_error "invalid --ai value: '$1' (allowed: claude, codex, gemini)"
+    claude)
+        if ! _have claude; then
+            ux_error "claude CLI not found"
             return 1
-            ;;
+        fi
+        ;;
+    codex)
+        if ! _have codex; then
+            ux_error "codex CLI not found"
+            return 1
+        fi
+        ;;
+    gemini)
+        if ! _have gemini; then
+            ux_error "gemini CLI not found"
+            return 1
+        fi
+        ;;
+    *)
+        ux_error "invalid --ai value: '$1' (allowed: claude, codex, gemini)"
+        return 1
+        ;;
     esac
 }
 
@@ -104,20 +104,23 @@ _gh_pr_approve_run_ai_prompt() {
 gh_pr_approve_help() {
     ux_header "gh-pr-approve - fire-and-forget GitHub PR approval runner"
     ux_info "Usage:"
-    ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>] [--self-ok]"
+    ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>] [--self-record|--admin-merge] [--squash|--rebase|--merge]"
     ux_bullet_sub "agent: claude (default) | codex | gemini"
-    ux_bullet_sub "--self-ok: bypass author==reviewer pre-flight stop in the worker's skill prompt"
+    ux_bullet_sub "--self-record: for self-authored PRs, leave a comment-only review record"
+    ux_bullet_sub "--admin-merge: for self-authored PRs, review then merge with gh pr merge --admin"
+    ux_bullet_sub "--squash|--rebase|--merge: optional merge strategy for --admin-merge"
     ux_bullet "gh-pr-approve -h|--help|help"
     ux_info ""
     ux_info "Spawns one background worker per PR. Each worker:"
-    ux_bullet "gwt spawn → <ai> -p '/gh-pr-approve <N> [--self-ok]' → gwt teardown"
+    ux_bullet "gwt spawn -> <ai> -p '/gh-pr-approve <N> [self-PR flags]' -> gwt teardown"
     ux_info ""
     ux_info "Examples:"
-    ux_bullet "gh-pr-approve 42                       # single PR (default: claude)"
-    ux_bullet "gh-pr-approve 12 34 56                 # 3 PRs in parallel"
-    ux_bullet "gh-pr-approve 42 --ai codex            # run worker with codex CLI"
-    ux_bullet "gh-pr-approve --ai gemini '#56' '#78'  # gemini + #prefix"
-    ux_bullet "gh-pr-approve 42 --self-ok             # multi-AI workflow / no human reviewer"
+    ux_bullet "gh-pr-approve 42                            # single PR (default: claude)"
+    ux_bullet "gh-pr-approve 12 34 56                      # 3 PRs in parallel"
+    ux_bullet "gh-pr-approve 42 --ai codex                 # run worker with codex CLI"
+    ux_bullet "gh-pr-approve --ai gemini '#56' '#78'       # gemini + #prefix"
+    ux_bullet "gh-pr-approve 42 --self-record              # self-PR comment-only record"
+    ux_bullet "gh-pr-approve 42 --admin-merge --squash     # self-PR admin merge"
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-approve/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
@@ -152,47 +155,81 @@ gh_pr_approve() {
     fi
 
     case "${1:-}" in
-        ""|-h|--help|help)
-            gh_pr_approve_help
-            return 0
-            ;;
+    "" | -h | --help | help)
+        gh_pr_approve_help
+        return 0
+        ;;
     esac
 
     # Parse optional args:
     #   --ai <claude|codex|gemini>
     #   --ai=<claude|codex|gemini>
-    #   --self-ok                 (bypass author==reviewer pre-flight in skill)
+    #   --self-record             (comment-only self-PR mode in skill)
+    #   --admin-merge             (admin merge self-PR mode in skill)
+    #   --squash|--rebase|--merge (optional admin merge strategy)
     # Position-agnostic: any flag may appear before, between, or after PR numbers.
     local _ai="claude"
-    local _self_ok=""
+    local _self_record=0
+    local _admin_merge=0
+    local _merge_strategy=""
+    local _self_args=""
     local _pr_input=""
     while [ $# -gt 0 ]; do
         case "$1" in
-            --ai)
-                shift
-                if [ $# -eq 0 ]; then
-                    ux_error "missing value for --ai (expected: claude|codex|gemini)"
-                    return 1
-                fi
-                _ai="$1"
-                ;;
-            --ai=*)
-                _ai="${1#--ai=}"
-                ;;
-            --self-ok)
-                _self_ok="--self-ok"
-                ;;
-            -*)
-                ux_error "unknown option: '$1'"
-                ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-ok]"
+        --ai)
+            shift
+            if [ $# -eq 0 ]; then
+                ux_error "missing value for --ai (expected: claude|codex|gemini)"
                 return 1
-                ;;
-            *)
-                _pr_input="$_pr_input $1"
-                ;;
+            fi
+            _ai="$1"
+            ;;
+        --ai=*)
+            _ai="${1#--ai=}"
+            ;;
+        --self-ok)
+            ux_error "--self-ok is not supported; GitHub blocks self-approval server-side"
+            ux_info "Use --self-record for a comment-only audit trail or --admin-merge if you have admin rights."
+            return 1
+            ;;
+        --self-record)
+            _self_record=1
+            ;;
+        --admin-merge)
+            _admin_merge=1
+            ;;
+        --squash | --rebase | --merge)
+            if [ -n "$_merge_strategy" ]; then
+                ux_error "multiple merge strategies provided: '$_merge_strategy' and '$1'"
+                return 1
+            fi
+            _merge_strategy="$1"
+            ;;
+        -*)
+            ux_error "unknown option: '$1'"
+            ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-record|--admin-merge]"
+            return 1
+            ;;
+        *)
+            _pr_input="$_pr_input $1"
+            ;;
         esac
         shift
     done
+
+    if [ "$_self_record" -eq 1 ] && [ "$_admin_merge" -eq 1 ]; then
+        ux_error "--self-record and --admin-merge are mutually exclusive"
+        return 1
+    fi
+    if [ -n "$_merge_strategy" ] && [ "$_admin_merge" -ne 1 ]; then
+        ux_error "$_merge_strategy requires --admin-merge"
+        return 1
+    fi
+    if [ "$_self_record" -eq 1 ]; then
+        _self_args="--self-record"
+    elif [ "$_admin_merge" -eq 1 ]; then
+        _self_args="--admin-merge${_merge_strategy:+ $_merge_strategy}"
+    fi
 
     if ! _gh_pr_approve_known_ai "$_ai"; then
         ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
@@ -238,10 +275,10 @@ gh_pr_approve() {
     for _pr in $_pr_input; do
         _pr_clean="${_pr#\#}"
         case "$_pr_clean" in
-            ''|*[!0-9]*)
-                ux_error "invalid PR number: '$_pr' (must be positive integer, '#' prefix allowed)"
-                return 1
-                ;;
+        '' | *[!0-9]*)
+            ux_error "invalid PR number: '$_pr' (must be positive integer, '#' prefix allowed)"
+            return 1
+            ;;
         esac
         _pr_args="$_pr_args $_pr_clean"
         _pr_count=$((_pr_count + 1))
@@ -249,13 +286,13 @@ gh_pr_approve() {
 
     if [ "$_pr_count" -eq 0 ]; then
         ux_error "no PR numbers provided"
-        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-ok]"
+        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-record|--admin-merge]"
         return 1
     fi
 
-    ux_header "gh-pr-approve: spawning $_pr_count worker(s) (ai=$_ai${_self_ok:+ self-ok})"
+    ux_header "gh-pr-approve: spawning $_pr_count worker(s) (ai=$_ai${_self_args:+ flags=$_self_args})"
     for _pr in $_pr_args; do
-        _gh_pr_approve_spawn_worker "$_pr" "$_ai" "$_self_ok"
+        _gh_pr_approve_spawn_worker "$_pr" "$_ai" "$_self_args"
     done
     ux_success "All workers detached. Your shell is free. Results appear on the PR."
 }
@@ -263,7 +300,7 @@ gh_pr_approve() {
 _gh_pr_approve_spawn_worker() {
     local _pr="$1"
     local _ai="${2:-claude}"
-    local _self_ok="${3:-}"
+    local _self_args="${3:-}"
     local _dir _log _state _pid
     _dir=$(_gh_pr_approve_pr_dir "$_pr")
     mkdir -p "$_dir"
@@ -273,20 +310,20 @@ _gh_pr_approve_spawn_worker() {
     # Idempotency check — mirrors gh-flow semantics.
     _state=$(_gh_pr_approve_get_state "$_pr")
     case "$_state" in
-        done)
-            ux_info "#$_pr already done, skipping"
-            return 0
-            ;;
-        spawning|approving|tearing-down)
-            if [ -f "$_dir/pid" ]; then
-                _pid="$(cat "$_dir/pid")"
-                if kill -0 "$_pid" 2>/dev/null; then
-                    ux_warning "#$_pr already running (pid=$_pid), skipping"
-                    return 0
-                fi
+    done)
+        ux_info "#$_pr already done, skipping"
+        return 0
+        ;;
+    spawning | approving | tearing-down)
+        if [ -f "$_dir/pid" ]; then
+            _pid="$(cat "$_dir/pid")"
+            if kill -0 "$_pid" 2>/dev/null; then
+                ux_warning "#$_pr already running (pid=$_pid), skipping"
+                return 0
             fi
-            ux_info "#$_pr was in-progress but pid is dead — resuming with a new worker"
-            ;;
+        fi
+        ux_info "#$_pr was in-progress but pid is dead — resuming with a new worker"
+        ;;
     esac
 
     # Rotate previous log (keep one .prev for debugging)
@@ -301,11 +338,11 @@ _gh_pr_approve_spawn_worker() {
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_pr_approve_worker "$1" "$2" "$3"
-    ' -- "$_pr" "$_ai" "$_self_ok" </dev/null >"$_log" 2>&1 &
+    ' -- "$_pr" "$_ai" "$_self_args" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_pr → pid=$_pid  ai=$_ai${_self_ok:+ self-ok}  log=$_log"
+    ux_info "#$_pr -> pid=$_pid  ai=$_ai${_self_args:+ flags=$_self_args}  log=$_log"
 }
 
 # ============================================================================
@@ -315,7 +352,7 @@ _gh_pr_approve_spawn_worker() {
 _gh_pr_approve_worker() {
     local _pr="$1"
     local _ai="${2:-claude}"
-    local _self_ok="${3:-}"
+    local _self_args="${3:-}"
     local _dir _worktree _spawn_name _usage_log _prompt
     _dir=$(_gh_pr_approve_pr_dir "$_pr")
     _spawn_name="pr-$_pr"
@@ -324,7 +361,7 @@ _gh_pr_approve_worker() {
     _usage_log="$_dir/usage.jsonl"
     : >"$_usage_log"
 
-    printf '[gh-pr-approve-worker] pr=#%s ai=%s%s start=%s\n' "$_pr" "$_ai" "${_self_ok:+ self-ok}" "$(date -Iseconds 2>/dev/null || date)"
+    printf '[gh-pr-approve-worker] pr=#%s ai=%s%s start=%s\n' "$_pr" "$_ai" "${_self_args:+ flags=$_self_args}" "$(date -Iseconds 2>/dev/null || date)"
 
     # ---- Step 1: spawn worktree ----
     # Snapshot the worktree list before and after `gwt spawn` and diff them
@@ -342,8 +379,8 @@ _gh_pr_approve_worker() {
     _wt_after=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
     _worktree=$(comm -13 \
         <(printf '%s\n' "$_wt_before" | sort) \
-        <(printf '%s\n' "$_wt_after" | sort) \
-        | head -n 1)
+        <(printf '%s\n' "$_wt_after" | sort) |
+        head -n 1)
 
     if [ -z "$_worktree" ] || [ ! -d "$_worktree" ]; then
         _gh_pr_approve_set_state "$_dir" "failed:spawning"
@@ -362,10 +399,10 @@ _gh_pr_approve_worker() {
     # ---- Step 2: approve (selected ai runs /gh-pr-approve <N>) ----
     # Single-shot. The skill either approves with LGTM or files follow-up
     # issues and exits. No polling, no reply loop — that's gh-flow's job.
-    # When --self-ok is in effect, append it to the prompt so the skill
-    # bypasses the author==reviewer pre-flight stop.
+    # Append selected self-PR mode flags so the skill can avoid GitHub's
+    # server-side self-approval block.
     _gh_pr_approve_set_state "$_dir" "approving"
-    _prompt="/gh-pr-approve $_pr${_self_ok:+ $_self_ok}"
+    _prompt="/gh-pr-approve $_pr${_self_args:+ $_self_args}"
     if ! _gh_pr_approve_run_ai_prompt "$_ai" "$_usage_log" "$_prompt" "$_prompt"; then
         _gh_pr_approve_set_state "$_dir" "failed:approving"
         printf '[gh-pr-approve-worker] /gh-pr-approve failed\n' >&2

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -337,7 +337,7 @@ _gh_pr_approve_spawn_worker() {
     # shellcheck disable=SC2016
     nohup env DOTFILES_FORCE_INIT=1 bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_pr_approve_worker "$1" "$2" "$3"
+        _gh_pr_approve_worker "$@"
     ' -- "$_pr" "$_ai" "$_self_args" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -146,6 +146,13 @@ teardown() {
     assert_output --partial "claude (default) | codex | gemini"
 }
 
+@test "help: documents self-PR modes" {
+    run_in_bash 'gh_pr_approve --help'
+    assert_success
+    assert_output --partial "--self-record"
+    assert_output --partial "--admin-merge"
+}
+
 @test "bash: '--ai codex' parses (precondition fails on missing codex CLI, not parser)" {
     # We can't easily fake the codex/gemini CLI here, so we assert the
     # parser accepted the value and produced a precondition-shaped error
@@ -191,4 +198,33 @@ teardown() {
     run_in_bash "cd '$FAKE_REPO' && gh_pr_approve --bogus 42 2>&1"
     assert_failure
     assert_output --partial "unknown option"
+}
+
+# ---------------------------------------------------------------------------
+# self-PR options
+# ---------------------------------------------------------------------------
+
+@test "bash: legacy --self-ok is rejected with server-side guidance" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --self-ok 2>&1"
+    assert_failure
+    assert_output --partial "--self-ok is not supported"
+    assert_output --partial "server-side"
+}
+
+@test "bash: '--self-record' parses as a self-PR mode" {
+    run_in_bash "cd '$FAKE_REPO' && PATH=/nonexistent gh_pr_approve 42 --self-record 2>&1 || true"
+    refute_output --partial "unknown option"
+    refute_output --partial "invalid PR number"
+}
+
+@test "bash: '--admin-merge --squash' parses as a self-PR mode" {
+    run_in_bash "cd '$FAKE_REPO' && PATH=/nonexistent gh_pr_approve 42 --admin-merge --squash 2>&1 || true"
+    refute_output --partial "unknown option"
+    refute_output --partial "invalid PR number"
+}
+
+@test "bash: merge strategy flags require --admin-merge" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --squash 2>&1"
+    assert_failure
+    assert_output --partial "--squash requires --admin-merge"
 }


### PR DESCRIPTION
## Summary
- Replace the unsupported `--self-ok` flag with explicit `--self-record` and `--admin-merge` modes for self-authored PRs.
- Document GitHub's server-side self-approval block and the three legal paths (analysis-only / comment-only audit trail / admin merge) in a new `references/self-pr-handling.md`.
- Make the legacy `--self-ok` invocation fail loudly with guidance instead of letting workers attempt an impossible approval.

## Changes
- `claude/skills/gh-pr-approve/SKILL.md`: trim Step 1 stop-conditions to delegate self-PR handling, add Step 4 self-PR action branch, drop the `--self-ok` audit-trail clause.
- `claude/skills/gh-pr-approve/references/self-pr-handling.md` (new): default / `--self-record` / `--admin-merge` mode definitions, including the `gh pr review --comment` → `gh pr comment` fallback chain and `--squash|--rebase|--merge` strategy rules.
- `claude/skills/gh-pr-approve/references/{help,approval-templates,review-criteria}.md`: align help text and templates with the three-mode model; remove `--self-ok` references.
- `shell-common/functions/gh_pr_approve.sh`: parse `--self-record` / `--admin-merge` / strategy flags (position-agnostic); reject `--self-ok` with an explanatory error pointing at the new modes; reject merge-strategy flags without `--admin-merge`; thread the resolved flags into the worker prompt.
- `tests/bats/functions/gh_pr_approve.bats`: 4 new cases — help mentions both modes, `--self-ok` rejection text matches, `--self-record` parses, `--admin-merge --squash` parses, `--squash` alone is rejected.

## Test plan
- [ ] `bats tests/bats/functions/gh_pr_approve.bats`
- [ ] Manual: `gh-pr-approve 199 --self-ok` — expect failure with "not supported" and pointer to `--self-record` / `--admin-merge`.
- [ ] Manual: `gh-pr-approve 199 --self-record` on a self-PR — expect comment-only review, no approval; if comment review is rejected, expect `gh pr comment` fallback.
- [ ] Manual: `gh-pr-approve 199 --admin-merge --squash` on a self-PR with admin rights — expect review then `gh pr merge --admin --squash`; without admin rights, expect `gh`'s permission error verbatim.

## Related
Closes #246

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
