### PR TITLE
fix(project-board): sync merged PR cards to Done

### DIFF
--- a/claude/skills/gh-pr-merge-emergency/SKILL.md
+++ b/claude/skills/gh-pr-merge-emergency/SKILL.md
@@ -42,18 +42,16 @@ Fetch in parallel; evaluate stops **before** touching merge:
 - PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,baseRefName,headRefName`
 - `gh pr checks <N> --repo $TARGET_REPO --required`
 
-**Hard stops** (emergency ≠ reckless): `state != OPEN` · `isDraft == true` ·
-`mergeable == CONFLICTING` · any required check failing/pending. Emergency
-bypasses **approval**, not **CI** — fix or rerun CI instead of bypassing.
+**Hard stops**: `state != OPEN`, draft, conflicts, or failing/pending required
+checks. Emergency bypasses **approval**, not **CI**.
 
-**Soft warnings** (print, continue): base `BEHIND` → note in audit. No
-approving review → expected here, but surface it in the confirmation prompt.
+**Soft warnings**: base `BEHIND`; no approving review.
 
 ## Step 3: Confirm with the User
 
 Print the planned action (repo, PR, author, base/head, CI summary, reason)
-followed by `Proceed? (yes/ok/진행/머지)`. Never auto-proceed; ambiguous
-reply → ask again. Exact prompt template in `references/audit-templates.md`.
+followed by `Proceed? (yes/ok/진행/머지)`. Exact prompt template:
+`references/audit-templates.md`. Never auto-proceed.
 
 ## Step 4: Audit Comment + Admin Merge
 
@@ -61,7 +59,7 @@ Order matters — comment first so the audit survives branch deletion.
 
 1. `gh pr comment <N> --repo "$TARGET_REPO"` with the "PR audit comment"
    body from `references/audit-templates.md`; capture the comment URL for
-   Step 6.
+   Step 7.
 2. `gh pr merge <N> --repo "$TARGET_REPO" --admin --squash --delete-branch`
    (flag rationale in the same reference file). If it fails with "Must
    have admin rights", **stop** and report — do NOT fall back to
@@ -76,7 +74,12 @@ Non-negotiable audit tail. File `incident: emergency merge of PR #<N> —
 `references/audit-templates.md`. Attach an `incident` label **only if**
 `gh label list --repo "$TARGET_REPO"` confirms it exists.
 
-## Step 6: Report
+## Step 6: Sync Project Board Status
+
+Read `references/project-board-sync.md` and push the merged PR card to
+`Done`. Sync failure never blocks the audit report.
+
+## Step 7: Report
 
 ```
 Emergency-merged PR #<N>

--- a/claude/skills/gh-pr-merge-emergency/references/help.md
+++ b/claude/skills/gh-pr-merge-emergency/references/help.md
@@ -37,7 +37,8 @@
 3. Posts a visible audit comment on the PR explaining *why* this is being emergency-merged.
 4. Runs `gh pr merge --admin --squash --delete-branch` to bypass approval requirements.
 5. Creates a follow-up `incident:` issue with a retro checklist so the decision is tracked and reviewed later.
-6. Reports the merge SHA, audit comment URL, and incident issue number.
+6. Moves the PR project-board card to `Done` when a projectV2 board is attached.
+7. Reports the merge SHA, audit comment URL, and incident issue number.
 
 ## Good reason examples
 

--- a/claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
@@ -1,0 +1,33 @@
+# Project Board Sync — push emergency-merged PR card to `Done`
+
+After the admin merge succeeds, sync the PR's project-board card to `Done`.
+The emergency path bypasses approval, but it still completes the same PR
+lifecycle as a normal merge.
+
+## Why no `--only-from` guard
+
+`Done` is the terminal PR state after merge. Emergency merges may happen from
+`In review`, `Approved`, or another in-flight status; all should move forward
+to `Done`. Repeating the sync on an already-`Done` card is harmless.
+
+## Snippet
+
+Source the shared helper, then call it with the merged PR number:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+_gh_project_status_sync pr <PR_NUMBER> "Done"
+```
+
+## Behavior
+
+- **No projectV2 board attached** — the helper auto-detects zero project
+  items and returns 0.
+- **Sync failure** — the helper logs to stderr and returns 0; merge/audit
+  success remains the primary outcome.
+- **Opt-out per invocation** — set `GH_PROJECT_STATUS_SYNC=0` to skip sync.
+
+## Where the helper lives
+
+`shell-common/functions/gh_project_status.sh` — shared by PR and Issue
+lifecycle skills. Do not inline-copy the GraphQL logic.

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -71,16 +71,23 @@ If `gh` returns "merge method is not allowed", print the repo-settings
 guidance from `references/strategy-selection.md` and stop. **Never**
 silently switch strategies.
 
-## Step 4: Reconcile linked Issue cards on the project board
+## Step 4: Sync Project Board Status
 
-GitHub Projects v2 builtin `Item closed` is best-effort and occasionally
-drops events, leaving Issue cards stuck at `In review` even after the
-Issue auto-closes from this merge. Read
-`references/project-board-sync.md` for the failure mode and the gating
-rationale; the call shape:
+Read `references/project-board-sync.md` for the failure modes and
+gating rationale. Two reconciliations run after a successful merge:
+
+(a) PR card → `Done` (closes the gap from #248 where the merged PR
+    card stayed at `Approved`):
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done"
+```
+
+(b) Linked Issue cards from `closingIssuesReferences` → `Done`
+    (boosts the best-effort `Item closed` builtin per #250):
+
+```bash
 for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
                   --json closingIssuesReferences \
                   --jq '.closingIssuesReferences?[]?.number'); do
@@ -89,8 +96,8 @@ for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
 done
 ```
 
-The helper auto-detects boards on repos without a projectV2 attachment
-and silently returns. This step never blocks the report — failures are
+Both helpers auto-detect repos without a projectV2 attachment and
+silently return. This step never blocks the report — failures are
 logged to stderr and ignored.
 
 ## Step 5: Fetch Merge SHA + Report

--- a/claude/skills/gh-pr-merge/references/help.md
+++ b/claude/skills/gh-pr-merge/references/help.md
@@ -36,7 +36,8 @@ _Availability depends on repo settings → General → Pull Requests. If a strat
    - Review decision ≠ APPROVED → suggests `gh:pr-merge-emergency` instead
    - Required check failing or pending
 5. Runs `gh pr merge <N> --repo $TARGET_REPO --<strategy> --delete-branch` **without confirmation**.
-6. Fetches the merge SHA and prints a compact report.
+6. Moves the PR project-board card to `Done` when a projectV2 board is attached.
+7. Fetches the merge SHA and prints a compact report.
 
 ## What the skill will NOT do
 

--- a/claude/skills/gh-pr-merge/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge/references/project-board-sync.md
@@ -1,30 +1,45 @@
-# Project Board Sync — reconcile linked Issue cards after merge
+# Project Board Sync — reconcile board cards after merge
 
-## Why this step exists
+`/gh-pr-merge` performs two independent reconciliations after a
+successful merge:
 
-GitHub Projects v2 builtin workflows are best-effort only. The
-`Item closed` workflow that should move closed Issue cards to `Done`
-occasionally drops events, leaving Issue cards stuck at `In review` even
-though the Issue itself is `CLOSED`. Concrete observation:
-`dEitY719/dotfiles` Issue #239 stayed at `In review` after PR #241 merged
-at 2026-04-28T03:24:34Z — 16 of 17 other Issues closed around the same
-time on the same board moved to `Done` correctly, ruling out a setup
-problem and pointing at transient delivery loss (issue #250).
+1. **PR card → `Done`** — closes the gap reported in #248 where the
+   merged PR card stayed at `Approved`.
+2. **Linked Issue cards → `Done`** — closes the gap reported in #250
+   where Issue cards stayed at `In review` after auto-close.
 
-`/gh-pr-merge` is the only natural surface that knows which Issues will
-auto-close from a merge — they are listed in the PR's
-`closingIssuesReferences` (Closes / Fixes / Resolves keywords). Adding a
-post-merge reconciliation here closes the gap without depending on
-builtin workflow reliability.
+Both run from the shared helper
+`shell-common/functions/gh_project_status.sh`. Failures never block
+the merge report — the helper logs to stderr and returns 0.
 
-## How to call it
-
-After Step 3 succeeds, fetch the PR's `closingIssuesReferences` and force
-each linked Issue card to `Done`:
+## (1) PR card → `Done`
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done"
+```
 
+`Done` is the terminal PR state after merge, regardless of which
+column the card was in (`In review`, `Approved`, or `In progress` if a
+`Changes requested` loop was still pending). No `--only-from` guard is
+needed; repeating the sync on an already-`Done` card is a no-op.
+
+## (2) Linked Issue cards → `Done`
+
+GitHub Projects v2 builtin workflows are best-effort only. The
+`Item closed` workflow that should move closed Issue cards to `Done`
+occasionally drops events, leaving Issue cards stuck at `In review`
+even though the Issue itself is `CLOSED`. Concrete observation:
+`dEitY719/dotfiles` Issue #239 stayed at `In review` after PR #241
+merged at 2026-04-28T03:24:34Z — 16 of 17 other Issues closed around
+the same time on the same board moved to `Done` correctly, ruling out
+a setup problem and pointing at transient delivery loss (issue #250).
+
+`/gh-pr-merge` is the only natural surface that knows which Issues
+will auto-close from a merge — they are listed in the PR's
+`closingIssuesReferences` (Closes / Fixes / Resolves keywords).
+
+```bash
 for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
                   --json closingIssuesReferences \
                   --jq '.closingIssuesReferences?[]?.number'); do
@@ -38,26 +53,28 @@ The `--only-from` whitelist enforces three properties:
 - An Issue already at `Done` (builtin fired this round) is left alone —
   no churn, no duplicate update.
 - Issue cards never visit `Approved` per
-  `docs/standards/github-project-board.md`; if one shows up there, it is
-  a manual override worth investigating, so the helper skips rather than
-  silently overwriting.
+  `docs/standards/github-project-board.md`; if one shows up there, it
+  is a manual override worth investigating, so the helper skips rather
+  than silently overwriting.
 - Empty current Status (card never mounted on the board) is also
   skipped, so this never accidentally adds boards to repos that don't
   have one.
 
-## When it does nothing
+## When either step does nothing
 
 - PR body has no `Closes / Fixes / Resolves #N` →
-  `closingIssuesReferences` is empty → loop body never runs.
-- Repo has no projectV2 board attached → helper finds zero project items
-  and silently returns 0.
-- `GH_PROJECT_STATUS_SYNC=0` set in environment → opt-out, helper returns
-  immediately.
-- Issue card already at `Done` → helper skips per `--only-from` guard.
+  `closingIssuesReferences` is empty → step (2) loop body never runs.
+  Step (1) still runs.
+- Repo has no projectV2 board attached → helper finds zero project
+  items and silently returns 0 for both steps.
+- `GH_PROJECT_STATUS_SYNC=0` set in environment → opt-out, helper
+  returns immediately for both steps.
+- For step (2) only: Issue card already at `Done` → helper skips per
+  `--only-from` guard.
 
 ## Where the helper lives
 
 `shell-common/functions/gh_project_status.sh` — shared with `gh:pr`,
-`gh:pr-reply`, `gh:commit`, and `gh:flow`. Source the file each
-invocation; do not inline-copy the snippet so a single fix propagates
-everywhere.
+`gh:pr-reply`, `gh:commit`, `gh:flow`, and `gh:pr-merge-emergency`.
+Source the file each invocation; do not inline-copy the snippet so a
+single fix propagates everywhere.

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -10,12 +10,13 @@ SSOT이다.
 
 - 저장소: `dEitY719/dotfiles` (repo-level project)
 - 카드 종류: Issue와 PR 모두 (보드에서 함께 추적)
-- 자동화 수단: GitHub Projects v2 빌트인 워크플로우 (별도 Action 없음)
-- 관련 스킬: `gh:issue-create`, `gh:pr`, `gh:pr-merge`, `gh:issue-flow`
+- 자동화 수단: GitHub Projects v2 빌트인 워크플로우 + dotfiles 스킬 보정
+- 관련 스킬: `gh:issue-create`, `gh:pr`, `gh:pr-merge`,
+  `gh:pr-merge-emergency`, `gh:issue-flow`
 
 차용 원본: `skill-hub`의 `.claude/workflow.md`와 `github-integration.md`.
-dotfiles는 동일 원칙을 따르되 범위(단일 repo)와 자동화 수준(빌트인만)
-측면에서 최소화한 변형을 사용한다.
+dotfiles는 동일 원칙을 따르되 범위(단일 repo)와 자동화 수준(별도
+Action 없음) 측면에서 최소화한 변형을 사용한다.
 
 ## 보드 구조
 
@@ -159,6 +160,12 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
   이므로 `Approved` 와 정합한다. `--only-from "Backlog,In progress,In
   review"` 가드를 적용해 머지된 PR (`Done`) 에 잘못 호출되었을 때
   카드가 `Approved` 로 되돌아가는 regression 을 막는다.
+- **PR 카드 `Approved → Done`**: `/gh-pr-merge` 와
+  `/gh-pr-merge-emergency` 가 머지 성공 직후 자동 전환한다. GitHub
+  Projects 빌트인 `Pull request merged` / `Item closed` 가 켜져 있어도,
+  저장소·보드 설정 차이로 PR 카드가 `Approved` 에 남는 경우를 막기 위한
+  보정 경로다. raw `gh pr merge` 나 웹 UI 머지는 빌트인 워크플로우에
+  의존하므로, PR 카드가 남으면 수동으로 `Done` 으로 옮긴다.
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:
   `Changes requested` 루프에서 수정·재푸시 후 리뷰가 다시 달리기를
   기대할 때 **수동**으로 복귀시킨다. Projects v2 빌트인에도 dotfiles
@@ -251,7 +258,7 @@ gh auth refresh -s project
   review` (`Changes requested` 루프 탈출 시) 전환만 항상 수동이다
   — 빌트인·스킬 모두 이 경로를 자동화하지 않는다.
 - 보드가 없는 repo 에서 `/gh-pr`, `/gh-commit`, `/gh-pr-reply`,
-  또는 `/gh-pr-merge` 를 실행하면 공용 헬퍼
+  `/gh-pr-merge`, 또는 `/gh-pr-merge-emergency` 를 실행하면 공용 헬퍼
   `_gh_project_status_sync` 가 `projectItems` 가 0건임을 자동
   감지하고 조용히 no-op 한다 (별도 분기 불필요).
 - Projects v2 빌트인 워크플로우는 best-effort delivery 라 드물게


### PR DESCRIPTION
## Summary
- `/gh-pr-merge` 와 `/gh-pr-merge-emergency` 가 머지 직후 PR 의 프로젝트
  보드 카드를 `Approved → Done` 으로 강제 동기화하도록 보강 (#248 갭 봉합).
- main 의 #250 (Issue 카드 reconciliation) 과 한 단계 안에서 보완 동작 —
  `gh-pr-merge` Step 4 가 (a) PR 카드 sync 와 (b) `closingIssuesReferences`
  의 Issue 카드 sync 둘 다 수행.
- SSOT 문서에 PR 카드 `Approved → Done` 자동 전환 규칙·운영 유의사항을 추가해
  코드와 선언을 정렬.

## Changes
- `claude/skills/gh-pr-merge/SKILL.md`: Step 4 를 "PR card → Done" + "Issue
  cards → Done" 두 호출로 통합. 호출 스니펫 인라인.
- `claude/skills/gh-pr-merge/references/project-board-sync.md`: PR card
  / Issue cards 두 섹션 구조로 재구성. 각 trigger·가드·no-op 조건 명시.
- `claude/skills/gh-pr-merge-emergency/SKILL.md`: Step 6 (Sync Project
  Board Status) 신설, 기존 Step 6 (Report) → Step 7 로 리넘버.
- `claude/skills/gh-pr-merge-emergency/references/project-board-sync.md`
  (new): emergency 변종은 `--only-from` 가드 없이 PR card 만 push.
- `claude/skills/gh-pr-merge*/references/help.md`: Step 추가에 맞춰
  단계 설명 갱신.
- `docs/standards/github-project-board.md`: 새 bullet "PR 카드
  `Approved → Done`" 추가 + "보드 없는 repo" no-op 목록과 관련 스킬
  리스트에 `/gh-pr-merge-emergency` 추가.

## Test plan
- [x] `tox -e shellcheck` clean.
- [x] `tox -e bats` 229/229 통과 (`gh_project_status` helper 회귀 없음).
- [x] `markdownlint-cli` 변경 파일 5건 lint clean (pre-existing
      `zsh/AGENTS.md` 등 위반은 out of scope).
- [ ] **본 PR 머지가 자체 dogfooding** — 머지 직후 PR #N 카드가
      `Approved → Done` 으로 자동 이동하는지 확인.
- [ ] 보드 없는 repo (예: jemings/SkillHub) 에서 `/gh-pr-merge` 호출 시
      helper 가 zero project items 감지하고 silent no-op 하는지 확인.

## Related
Closes #248
Refs #250

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
