### PR TITLE
feat(gh-project-status): retry mutation once on transient failure

### DIFF
--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -142,31 +142,49 @@ EOF
             continue
         fi
 
-        # GraphQL variables ($proj, $item, ...) are NOT shell vars — they
-        # are bound via the -f flags below, so single quotes are intended.
-        # shellcheck disable=SC2016
-        if gh api graphql \
-            -f query='
-              mutation($proj: ID!, $item: ID!, $field: ID!, $option: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $proj
-                  itemId: $item
-                  fieldId: $field
-                  value: { singleSelectOptionId: $option }
-                }) { clientMutationId }
-              }' \
-            -f proj="$_proj" -f item="$_item" -f field="$_field" -f option="$_option" \
-            >/dev/null 2>&1; then
+        # One retry on mutation flake (GraphQL connection reset etc.).
+        # 5s fixed backoff — long enough to ride out transient resets,
+        # short enough to keep callers responsive. Query-stage retry is
+        # intentionally not added here (boards-not-attached looks like a
+        # transient failure to gh; tracked separately).
+        if _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
             printf '[gh-project-status] %s #%s -> "%s"\n' "$_kind" "$_num" "$_target"
         else
-            printf '[gh-project-status] mutation failed for %s #%s (target=%s)\n' \
-                "$_kind" "$_num" "$_target" >&2
+            sleep 5
+            if _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
+                printf '[gh-project-status] %s #%s -> "%s" (after 1 retry)\n' \
+                    "$_kind" "$_num" "$_target"
+            else
+                printf '[gh-project-status] mutation failed for %s #%s (target=%s)\n' \
+                    "$_kind" "$_num" "$_target" >&2
+            fi
         fi
     done <<EOF
 $_records
 EOF
 
     return 0
+}
+
+# Run the projectV2 Status mutation. Args: proj, item, field, option (all ids).
+# Extracted to a helper so the loop can retry it once without duplicating
+# the multi-line GraphQL query block. Stays silent — caller logs outcomes.
+_gh_project_status_mutate() {
+    # GraphQL variables ($proj, $item, ...) are NOT shell vars — they
+    # are bound via the -f flags below, so single quotes are intended.
+    # shellcheck disable=SC2016
+    gh api graphql \
+        -f query='
+          mutation($proj: ID!, $item: ID!, $field: ID!, $option: String!) {
+            updateProjectV2ItemFieldValue(input: {
+              projectId: $proj
+              itemId: $item
+              fieldId: $field
+              value: { singleSelectOptionId: $option }
+            }) { clientMutationId }
+          }' \
+        -f proj="$1" -f item="$2" -f field="$3" -f option="$4" \
+        >/dev/null 2>&1
 }
 
 # Membership test: returns 0 when $1 equals any comma-separated entry of $2.

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -38,6 +38,19 @@ teardown() {
     assert_output --partial "ok"
 }
 
+@test "bash: _gh_project_status_mutate helper exists" {
+    # Extracted in #244 so the mutation can be retried once on flake.
+    run_in_bash 'declare -f _gh_project_status_mutate >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_project_status_mutate helper exists" {
+    run_in_zsh 'typeset -f _gh_project_status_mutate >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
 # ---------------------------------------------------------------------------
 # Opt-out guards
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_gh_project_status_sync` 의 mutation 단계가 GraphQL connection reset 같은
  일시 장애에 silent fail 하던 문제 해결. 5초 고정 backoff 로 1회만 재시도.
- PR #241 사례에서 `In review` sync 가 2회 연속 실패해 카드가 14분간 Backlog
  에 갇히고 In review 컬럼을 건너뛴 적이 있었음 — 짧은 GraphQL 플레이크는
  이번 변경으로 자동 회복됨.
- query 단계 재시도는 의도적으로 추가 안 함. 보드 미부착 repo 의 응답이
  일시 장애와 외형이 같아서, error code 분기 없이 재시도하면 보드 없는
  repo 에서도 매번 5초 추가 lag 가 생김. 별도 이슈로 분리.

## Changes
- `shell-common/functions/gh_project_status.sh`
  - mutation 블록을 `_gh_project_status_mutate` 헬퍼로 추출 (재시도 시
    GraphQL query 중복 회피 목적).
  - mutation 실패 → `sleep 5` → 1회 재시도. 재시도 성공 시 로그 끝에
    `(after 1 retry)` suffix 를 붙여 trail 에 남김. 최종 실패 시 기존
    `mutation failed for <kind> #<n>` 메시지 유지.
- `tests/bats/functions/gh_project_status.bats`
  - 새 헬퍼 `_gh_project_status_mutate` 의 bash/zsh 존재 테스트 2건 추가
    (기존 `_gh_project_status_in_list` 와 동일 패턴).

## Test plan
- [x] `bash -n` / `zsh -n` syntax check
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_project_status.sh`
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/` (184/184 pass,
      `gh_project_status.bats` 17/17 incl. 새 헬퍼 테스트 2건)
- [x] `./tests/test` (979 passed)

## Related
Closes #244

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
