### PR TITLE
fix(gh-pr-merge): use GraphQL for closingIssuesReferences

### DIFF
--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -85,12 +85,13 @@ GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done"
 ```
 
 (b) Linked Issue cards from `closingIssuesReferences` → `Done`
-    (boosts the best-effort `Item closed` builtin per #250):
+    (boosts the best-effort `Item closed` builtin per #250). Use the
+    `_gh_pr_closing_issue_numbers` helper instead of
+    `gh pr view --json closingIssuesReferences` — older `gh` (≤ 2.45)
+    rejects that field with "Unknown JSON field" (#264):
 
 ```bash
-for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
-                  --json closingIssuesReferences \
-                  --jq '.closingIssuesReferences?[]?.number'); do
+for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO"); do
     GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
         --only-from "Backlog,In progress,In review"
 done

--- a/claude/skills/gh-pr-merge/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge/references/project-board-sync.md
@@ -39,10 +39,17 @@ a setup problem and pointing at transient delivery loss (issue #250).
 will auto-close from a merge — they are listed in the PR's
 `closingIssuesReferences` (Closes / Fixes / Resolves keywords).
 
+The closing-issue list comes from a shared helper rather than
+`gh pr view --json closingIssuesReferences`:
+`gh` 2.45.0 (and earlier) does not include `closingIssuesReferences`
+in `pr view --json`'s allow-list and exits with "Unknown JSON field"
+(#264). The `_gh_pr_closing_issue_numbers` helper in
+`shell-common/functions/gh_project_status.sh` issues a direct GraphQL
+query, which is supported across all `gh` versions that ship the
+`api graphql` subcommand.
+
 ```bash
-for _issue in $(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
-                  --json closingIssuesReferences \
-                  --jq '.closingIssuesReferences?[]?.number'); do
+for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO"); do
     GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
         --only-from "Backlog,In progress,In review"
 done

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -187,6 +187,49 @@ _gh_project_status_mutate() {
         >/dev/null 2>&1
 }
 
+# Print one closing-issue number per line for PR <num> in <owner/repo>.
+# Stays silent on every failure mode (boards-not-set-up, GraphQL errors,
+# missing args, malformed repo) so the caller's for-loop just iterates over
+# nothing and the merge report is never blocked.
+#
+# Why this is a helper instead of `gh pr view --json closingIssuesReferences`:
+# the `--json` projection on `gh` 2.45.0 does not list
+# `closingIssuesReferences` in its allow-list — invoking it prints
+# "Unknown JSON field" and exits non-zero (#264). The GraphQL schema has the
+# connection so we go around the CLI's allow-list with a direct query.
+#
+# Args: <pr-number> <owner/repo>
+_gh_pr_closing_issue_numbers() {
+    local _pr="$1" _repo="$2"
+    [ -z "$_pr" ] && return 0
+    [ -z "$_repo" ] && return 0
+    case "$_repo" in
+        */*) ;;
+        *) return 0 ;;
+    esac
+    local _owner _name
+    _owner="${_repo%/*}"
+    _name="${_repo#*/}"
+    [ -z "$_owner" ] && return 0
+    [ -z "$_name" ] && return 0
+
+    # GraphQL variables ($owner, $repo, $num) are bound via the -f/-F flags
+    # below, so single quotes around the query are intentional.
+    # shellcheck disable=SC2016
+    gh api graphql \
+        -f owner="$_owner" -f repo="$_name" -F num="$_pr" \
+        -f query='query($owner: String!, $repo: String!, $num: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $num) {
+              closingIssuesReferences(first: 20) { nodes { number } }
+            }
+          }
+        }' \
+        --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number' \
+        2>/dev/null
+    return 0
+}
+
 # Membership test: returns 0 when $1 equals any comma-separated entry of $2.
 # Uses pure parameter expansion to keep Status names with internal spaces
 # (e.g. "In progress") intact. Empty $1 never matches.

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -225,7 +225,7 @@ _gh_pr_closing_issue_numbers() {
             }
           }
         }' \
-        --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number' \
+        --jq '.data.repository?.pullRequest?.closingIssuesReferences?.nodes[]?.number // empty' \
         2>/dev/null
     return 0
 }

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -17,6 +17,49 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Fake `gh` shim used by the _gh_pr_closing_issue_numbers cases below.
+# Behaviour is selected by FAKE_GH_MODE so a single stub covers every case
+# we need (#264): zero closing issues, one, many, and the GraphQL-failure
+# path that proves the helper stays silent and returns 0.
+# ---------------------------------------------------------------------------
+_setup_fake_gh() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    mkdir -p "$STUB_BIN"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Only the `gh api graphql ... --jq <expr>` shape is exercised here.
+case "${FAKE_GH_MODE:-zero}" in
+    zero)  exit 0 ;;
+    one)   echo 248 ; exit 0 ;;
+    many)  printf '248\n239\n241\n' ; exit 0 ;;
+    error) echo "graphql: Unknown JSON field" >&2 ; exit 1 ;;
+    *)     exit 0 ;;
+esac
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run _gh_pr_closing_issue_numbers in a bash subshell that has the fake gh
+# on PATH and FAKE_GH_MODE set. We can't reuse run_in_bash because it does
+# not forward PATH/env into the subshell.
+_run_closing_issues_bash() {
+    local mode="$1" args="$2"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_GH_MODE='${mode}'
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        _gh_pr_closing_issue_numbers ${args}
+        echo \"rc=\$?\"
+    "
+}
+
+# ---------------------------------------------------------------------------
 # Loading: helper available in both bash and zsh after main.* sources it
 # ---------------------------------------------------------------------------
 
@@ -148,4 +191,78 @@ teardown() {
     run_in_bash '_gh_project_status_in_list "In progress" "In progress" && echo MATCH || echo NO'
     assert_success
     assert_output --partial "MATCH"
+}
+
+# ---------------------------------------------------------------------------
+# _gh_pr_closing_issue_numbers — issue #264 (gh pr view --json missing field)
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_pr_closing_issue_numbers helper exists" {
+    run_in_bash 'declare -f _gh_pr_closing_issue_numbers >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_pr_closing_issue_numbers helper exists" {
+    run_in_zsh 'typeset -f _gh_pr_closing_issue_numbers >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "closing-issues: missing pr arg returns silently" {
+    run_in_bash '_gh_pr_closing_issue_numbers "" "owner/repo" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+}
+
+@test "closing-issues: missing repo arg returns silently" {
+    run_in_bash '_gh_pr_closing_issue_numbers 99 "" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+}
+
+@test "closing-issues: malformed repo without slash returns silently" {
+    # Guards against feeding a bare project name to gh, which would surface
+    # as a noisy GraphQL error in the merge report.
+    run_in_bash '_gh_pr_closing_issue_numbers 99 "no-slash" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "248"
+}
+
+@test "closing-issues: zero closing issues prints nothing, rc=0" {
+    _setup_fake_gh
+    _run_closing_issues_bash zero '99 owner/repo'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --regexp '^[0-9]+$'
+}
+
+@test "closing-issues: one closing issue emits its number" {
+    _setup_fake_gh
+    _run_closing_issues_bash one '99 owner/repo'
+    assert_success
+    assert_output --partial "248"
+    assert_output --partial "rc=0"
+}
+
+@test "closing-issues: multiple closing issues each on their own line" {
+    _setup_fake_gh
+    _run_closing_issues_bash many '99 owner/repo'
+    assert_success
+    assert_output --partial "248"
+    assert_output --partial "239"
+    assert_output --partial "241"
+    assert_output --partial "rc=0"
+}
+
+@test "closing-issues: gh failure stays silent and returns 0" {
+    # This is the regression for #264: when the graphql call (or the older
+    # `gh pr view --json closingIssuesReferences` it replaces) errors out,
+    # the helper must swallow the error so the merge report is not blocked.
+    _setup_fake_gh
+    _run_closing_issues_bash error '99 owner/repo'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "Unknown JSON field"
 }


### PR DESCRIPTION
## Summary
- Replace `gh pr view --json closingIssuesReferences` with a direct GraphQL query so `/gh-pr-merge`'s Issue-card reconciliation actually fires on `gh` ≤ 2.45 (the field is missing from the CLI's `--json` allow-list and the loop was a silent no-op).
- Extract `_gh_pr_closing_issue_numbers` into the shared `gh_project_status.sh` helper so the SKILL.md step and the `project-board-sync.md` reference reuse a single source.

## Changes
- `shell-common/functions/gh_project_status.sh`: new `_gh_pr_closing_issue_numbers <pr> <owner/repo>` that runs `gh api graphql` and stays silent on every failure mode (missing args, malformed repo, GraphQL error).
- `claude/skills/gh-pr-merge/SKILL.md` (Step 4b) and `references/project-board-sync.md` (section 2): swap the inline `gh pr view --json` snippet for the helper, with a note pointing at the gh allow-list root cause.
- `tests/bats/functions/gh_project_status.bats`: 9 new cases covering bash/zsh load, arg validation (missing pr/repo, malformed repo), plus 0/1/many/error closing-issue paths via a `FAKE_GH_MODE`-driven `gh` stub on PATH.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_project_status.bats` — 26/26 pass
- [x] Full bats suite (`init` + `functions` + `tools`) — 245/245 pass
- [x] `git/hooks/checks/pipe_loop_check.sh` + `zsh_emulation_check.sh` — pass on the touched file
- [ ] Live smoke: merge a PR that has a `Closes #N` keyword, verify the linked Issue card moves to `Done` automatically (this is the regression #264 was reporting).

## Related
Closes #264

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
