### PR TITLE
feat(project-board): auto-sync cards on any merge path

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,0 +1,49 @@
+name: project-board-sync
+
+# Reconcile the projectV2 kanban board for any merged PR, regardless of
+# how it was merged (skill, web UI, mobile, raw `gh pr merge`).
+#
+# Why this exists (#266): /gh-pr-merge's in-skill Step 4(a) only fires
+# when the skill is invoked. Web UI / raw `gh pr merge` bypass it, so PR
+# cards stay at "Approved" and linked Issue cards occasionally stick at
+# "In review" when the GitHub builtin "Item closed" workflow drops the
+# event. This job catches every merge and pushes the cards forward.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  sync-cards:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync PR + linked Issue cards to "Done"
+        env:
+          # PROJECT_BOARD_PAT must carry the `project` scope (read+write).
+          # The default GITHUB_TOKEN cannot mutate projectV2.
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+              echo "::warning::PROJECT_BOARD_PAT secret is not set; skipping project-board sync."
+              exit 0
+          fi
+          # shellcheck source=shell-common/functions/gh_project_status.sh
+          . shell-common/functions/gh_project_status.sh
+          _gh_project_status_sync pr "$PR_NUMBER" "Done"
+          for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO"); do
+              _gh_project_status_sync issue "$_issue" "Done" \
+                  --only-from "Backlog,In progress,In review"
+          done

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -160,12 +160,21 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
   이므로 `Approved` 와 정합한다. `--only-from "Backlog,In progress,In
   review"` 가드를 적용해 머지된 PR (`Done`) 에 잘못 호출되었을 때
   카드가 `Approved` 로 되돌아가는 regression 을 막는다.
-- **PR 카드 `Approved → Done`**: `/gh-pr-merge` 와
-  `/gh-pr-merge-emergency` 가 머지 성공 직후 자동 전환한다. GitHub
-  Projects 빌트인 `Pull request merged` / `Item closed` 가 켜져 있어도,
-  저장소·보드 설정 차이로 PR 카드가 `Approved` 에 남는 경우를 막기 위한
-  보정 경로다. raw `gh pr merge` 나 웹 UI 머지는 빌트인 워크플로우에
-  의존하므로, PR 카드가 남으면 수동으로 `Done` 으로 옮긴다.
+- **PR 카드 `Approved → Done`**: 두 갈래로 보정한다.
+  - `/gh-pr-merge` / `/gh-pr-merge-emergency` 경유 머지: 스킬이 머지
+    성공 직후 in-skill Step 4(a) 에서 직접 전환한다.
+  - 웹 UI / 모바일 / raw `gh pr merge` 경유 머지 (#266): GitHub Actions
+    워크플로우 `.github/workflows/project-board-sync.yml` 가
+    `pull_request.closed && merged == true` 에 자동 fire 하여 동일
+    헬퍼 (`_gh_project_status_sync pr <N> "Done"`) 를 호출한다. 즉
+    머지 경로가 무엇이든 PR 카드는 `Done` 으로 수렴한다.
+
+  GitHub Projects 빌트인 `Pull request merged` (#6) 는 enabled 이지만
+  저장소·보드 설정 차이로 fire 가 누락되는 사례가 #265 머지에서
+  관측되어 (#266) 위 두 보정 경로가 안전망 역할을 한다. 워크플로우는
+  `secrets.PROJECT_BOARD_PAT` (project 스코프 PAT) 를 사용한다 — PAT
+  미설정 시엔 워크플로우가 warning 을 남기고 no-op 으로 종료하므로
+  포크 PR 도 안전하다.
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:
   `Changes requested` 루프에서 수정·재푸시 후 리뷰가 다시 달리기를
   기대할 때 **수동**으로 복귀시킨다. Projects v2 빌트인에도 dotfiles
@@ -173,13 +182,16 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
   (`→ Done`) 은 빌트인 `Pull request merged` / `Item closed` 가
   자동 처리한다.
 - **Issue 카드 `In review → Done` (PR-Closes 경로 보강)**:
-  `/gh-pr-merge` 가 머지 직후 PR 의 `closingIssuesReferences` 를
-  순회하며 각 Issue 카드를 `Done` 으로 강제 이동한다. 빌트인
-  `Item closed` 워크플로우는 best-effort delivery 이므로 드물게
-  Status 업데이트 이벤트가 누락되어 Issue 카드가 `In review` 에
-  잔류하는 케이스가 관측된다 (#239 / #250). 본 보강 전환은 그 갭을
-  메우며 `--only-from "Backlog,In progress,In review"` 가드로
-  이미 `Done` 상태인 카드를 다시 건드리지 않는다.
+  `/gh-pr-merge` 와 `.github/workflows/project-board-sync.yml` 둘 다
+  머지 직후 PR 의 `closingIssuesReferences` 를 순회하며 각 Issue
+  카드를 `Done` 으로 강제 이동한다. 빌트인 `Item closed` 워크플로우는
+  best-effort delivery 이므로 드물게 Status 업데이트 이벤트가
+  누락되어 Issue 카드가 `In review` 에 잔류하는 케이스가 관측된다
+  (#239 / #250). 본 보강 전환은 그 갭을 메우며 `--only-from
+  "Backlog,In progress,In review"` 가드로 이미 `Done` 상태인 카드를
+  다시 건드리지 않는다. 머지 경로가 스킬이든 웹 UI 든 동일 헬퍼
+  (`_gh_pr_closing_issue_numbers` + `_gh_project_status_sync`) 가
+  호출되므로 동작이 수렴한다.
 
 ### 용어 교정 (2026-04-24)
 

--- a/tests/bats/init/project_board_sync_workflow.bats
+++ b/tests/bats/init/project_board_sync_workflow.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# tests/bats/init/project_board_sync_workflow.bats
+# Static sanity checks for `.github/workflows/project-board-sync.yml`.
+# Behavioural correctness of the helpers it calls is covered in
+# tests/bats/functions/gh_project_status.bats; here we only verify
+# wiring — the workflow exists, triggers on the right event, calls the
+# right helpers, and points at the PROJECT_BOARD_PAT secret.
+
+load '../test_helper'
+
+WORKFLOW="${DOTFILES_ROOT}/.github/workflows/project-board-sync.yml"
+
+@test "workflow file exists" {
+    [ -f "$WORKFLOW" ]
+}
+
+@test "triggers on pull_request closed events" {
+    grep -q "^on:" "$WORKFLOW"
+    grep -q "pull_request:" "$WORKFLOW"
+    grep -q "types: \[closed\]" "$WORKFLOW"
+}
+
+@test "guards on merged == true (closed-without-merge skipped)" {
+    grep -q "github.event.pull_request.merged == true" "$WORKFLOW"
+}
+
+@test "uses PROJECT_BOARD_PAT secret (not the default GITHUB_TOKEN)" {
+    # projectV2 mutation requires the `project` scope, which the default
+    # GITHUB_TOKEN cannot grant. The workflow must read PAT from secrets.
+    grep -q 'secrets.PROJECT_BOARD_PAT' "$WORKFLOW"
+}
+
+@test "sources the shared gh_project_status.sh helper" {
+    # SSOT: the workflow must reuse the same helper /gh-pr-merge uses,
+    # not inline a copy.
+    grep -q 'shell-common/functions/gh_project_status.sh' "$WORKFLOW"
+}
+
+@test "calls _gh_project_status_sync for the PR card" {
+    grep -Eq '_gh_project_status_sync[[:space:]]+pr[[:space:]]+"\$PR_NUMBER"[[:space:]]+"Done"' "$WORKFLOW"
+}
+
+@test "iterates closingIssuesReferences via the shared helper" {
+    # _gh_pr_closing_issue_numbers is the helper extracted in #264;
+    # the workflow must use it instead of inlining `gh pr view --json
+    # closingIssuesReferences` (which does not work on gh ≤ 2.45).
+    grep -q '_gh_pr_closing_issue_numbers' "$WORKFLOW"
+    ! grep -q 'gh pr view .* closingIssuesReferences' "$WORKFLOW"
+}
+
+@test "applies --only-from guard when moving Issue cards" {
+    # Mirrors /gh-pr-merge Step 4(b): never bounce a card already at
+    # "Approved" or "Done" backwards.
+    grep -q -- '--only-from "Backlog,In progress,In review"' "$WORKFLOW"
+}
+
+@test "skips silently when PROJECT_BOARD_PAT is missing" {
+    # Soft-fail: fork PRs and freshly forked clones have no access to
+    # repo secrets. The workflow must warn and exit 0, not error.
+    grep -q 'PROJECT_BOARD_PAT secret is not set' "$WORKFLOW"
+}


### PR DESCRIPTION
## Summary
- 머지 경로에 무관하게 (스킬 / 웹 UI / 모바일 / raw `gh pr merge`) PR 카드와 연결 Issue 카드가 `Done` 으로 이동하도록 GitHub Actions 워크플로우를 추가한다. PR #265 머지 시 `Approved` 잔류로 드러난 #266 의 known gap 을 자동 보정.
- `/gh-pr-merge` 의 in-skill Step 4(a)/4(b) 와 동일한 헬퍼 (`_gh_project_status_sync`, `_gh_pr_closing_issue_numbers`) 를 재사용한다 — SSOT 유지, 동작 수렴.

## Changes
- `.github/workflows/project-board-sync.yml` (신규): `pull_request: closed && merged == true` 트리거. `secrets.PROJECT_BOARD_PAT` (project 스코프 PAT) 으로 projectV2 mutate. PAT 미설정 시 warning + no-op (포크 PR 안전).
- `docs/standards/github-project-board.md`: PR 카드 `Approved → Done` 섹션을 두 갈래 (skill in-skill / GHA 워크플로우) 로 재서술. "수동으로 옮긴다" 라인 제거. Issue 카드 `In review → Done` 섹션도 양쪽 경로 표기.
- `tests/bats/init/project_board_sync_workflow.bats` (신규, 9 케이스): 워크플로우 파일이 트리거·머지 가드·시크릿 이름·헬퍼 sourcing·`--only-from` 가드·soft-fail 메시지를 모두 갖췄는지 정적 검증. 헬퍼 자체 동작은 `tests/bats/functions/gh_project_status.bats` 가 계속 커버.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/init/project_board_sync_workflow.bats` — 9/9 pass.
- [x] 전체 bats suite (`init` + `functions` + `tools`) — 254/254 pass.
- [x] YAML 문법: `python -c "import yaml; yaml.safe_load(...)"` 로 파싱 정상.
- [ ] 라이브 검증 (병합 후): 다음번 웹 UI 머지에서 PR 카드가 자동으로 `Done` 으로 이동하는지 확인. 실패 시 GH Actions 로그에서 `_gh_project_status_sync` 의 stderr 메시지 확인.

## Operator note (PAT 셋업)
워크플로우는 `secrets.PROJECT_BOARD_PAT` 를 요구합니다. 본 머지 전후로:
1. https://github.com/settings/tokens 에서 `project` 스코프 PAT 발급.
2. Repo Settings > Secrets and variables > Actions > `PROJECT_BOARD_PAT` 등록.
3. PAT 미등록 상태로 머지해도 워크플로우는 warning 만 남기고 종료하므로 무중단.

## Related
Closes #266

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
