### PR TITLE
feat(gh-pr-approve): status/prune subcommands mirror gh-flow

### DIFF
--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -98,6 +98,490 @@ _gh_pr_approve_run_ai_prompt() {
 }
 
 # ============================================================================
+# Verdict + PR-state helpers (used by status / prune)
+# ============================================================================
+
+# Echo a single line describing GitHub-side PR state for the entry whose
+# state-dir is $1. Format:
+#   <state>|<reviewDecision>|<date>
+# or the literal token UNREACHABLE if the gh CLI call fails.
+#
+# - <state>: OPEN | MERGED | CLOSED (per gh pr view --json state)
+# - <reviewDecision>: APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED |
+#   COMMENTED | "" (gh returns empty when no review yet)
+# - <date>: YYYY-MM-DD if MERGED/CLOSED, else empty
+#
+# This is a single gh pr view call. Verdict does NOT use this — it's purely
+# informational for `status <N>` (per issue #268). Verdict stays decoupled
+# from network state because the worker is single-shot: PR closure/merge
+# is unrelated to whether the local worker still has cleanup to do.
+_gh_pr_approve_pr_state() {
+    local _dir="$1"
+    local _pr_num _json _rc _state _decision _merged _closed _date
+    _pr_num="$(basename "$_dir")"
+    case "$_pr_num" in
+    '' | *[!0-9]*)
+        printf 'UNREACHABLE'
+        return 0
+        ;;
+    esac
+    _json="$(gh pr view "$_pr_num" --json state,reviewDecision,mergedAt,closedAt 2>/dev/null)"
+    _rc=$?
+    if [ "$_rc" -ne 0 ] || [ -z "$_json" ]; then
+        printf 'UNREACHABLE'
+        return 0
+    fi
+    # Note: outer "$(...)" intentionally omitted — POSIX sh does not
+    # word-split bare assignments, and a project pre-commit naming check
+    # heuristically flags any private-helper name that appears between two
+    # `"` on a single line as user-facing text.
+    _state=$(printf '%s' "$_json" | _gh_pr_approve_jq_field state)
+    _decision=$(printf '%s' "$_json" | _gh_pr_approve_jq_field reviewDecision)
+    _merged=$(printf '%s' "$_json" | _gh_pr_approve_jq_field mergedAt)
+    _closed=$(printf '%s' "$_json" | _gh_pr_approve_jq_field closedAt)
+    case "$_state" in
+    MERGED) _date="${_merged%%T*}" ;;
+    CLOSED) _date="${_closed%%T*}" ;;
+    *) _date="" ;;
+    esac
+    printf '%s|%s|%s' "$_state" "$_decision" "$_date"
+}
+
+# Pull a single field's plain string out of a gh `--json …` payload using
+# whichever JSON parser is on PATH. Mirrors the helper pattern used by
+# gh_flow.sh and keeps the gh dependency soft (no jq required).
+_gh_pr_approve_jq_field() {
+    local _field="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -r ".$_field // empty" 2>/dev/null
+    else
+        # Naive fallback: grep the "field":"value" pair. Good enough for
+        # the simple top-level fields we read from `gh pr view`.
+        sed -n "s/.*\"$_field\":\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
+    fi
+}
+
+# Print two lines for the given PR:
+#   <verdict-text>
+#   <next-action-text>
+# Reads <pr-dir>/state, /pid, /worktree.path, then composes the matrix
+# from the issue spec. gh-pr-approve's worker is single-shot (no polling,
+# no reply loop), so the matrix is strictly simpler than gh-flow's.
+_gh_pr_approve_verdict() {
+    local _pr="$1"
+    local _dir _state _wt _pid _pid_alive _verdict _action
+    _dir=$(_gh_pr_approve_pr_dir "$_pr")
+    if [ ! -d "$_dir" ]; then
+        printf 'no state — PR not tracked\n(none)\n'
+        return 0
+    fi
+    _state="$(cat "$_dir/state" 2>/dev/null || printf 'unknown')"
+    _wt="$(cat "$_dir/worktree.path" 2>/dev/null || printf '')"
+    _pid="$(cat "$_dir/pid" 2>/dev/null || printf '')"
+    _pid_alive=0
+    if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+        _pid_alive=1
+    fi
+
+    case "$_state" in
+    done)
+        _verdict="done — safe to prune"
+        _action="gh-pr-approve prune $_pr"
+        ;;
+    failed:*)
+        if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+            _verdict="dead failure, worktree alive"
+            _action="cd $_wt && gwt teardown --force, then gh-pr-approve prune $_pr"
+        else
+            _verdict="dead failure — state-only cleanup"
+            _action="gh-pr-approve prune $_pr"
+        fi
+        ;;
+    spawning | approving | tearing-down)
+        if [ "$_pid_alive" = "1" ]; then
+            _verdict="active worker ($_state) — leave alone"
+            _action="(none — still working)"
+        else
+            _verdict="dead worker mid-step ($_state)"
+            _action="gh-pr-approve prune $_pr"
+        fi
+        ;;
+    *)
+        _verdict="unknown state ($_state)"
+        _action="inspect $_dir"
+        ;;
+    esac
+
+    printf '%s\n%s\n' "$_verdict" "$_action"
+}
+
+# ============================================================================
+# status / prune subcommands
+# ============================================================================
+
+# Per-PR diagnostic. Renders header + State/Worker/PR/Worktree/Flags/
+# Last log (+ tail -5) + Verdict / Next action (via _gh_pr_approve_verdict).
+# Input: <pr-num> with optional leading '#'.
+_gh_pr_approve_status_single() {
+    local _arg="$1"
+    local _pr _dir _state _pid _wt _pid_state _wt_state
+    local _pr_state_raw _pr_state _pr_decision _pr_date _pr_info
+    local _flags _flags_state _log _log_mtime _etime
+    local _verdict_out _verdict_text _action_text _name
+
+    _pr="${_arg#\#}"
+    case "$_pr" in
+    '' | *[!0-9]*)
+        ux_error "gh-pr-approve status: invalid PR number '$_arg'"
+        return 1
+        ;;
+    esac
+
+    _name=$(_gh_pr_approve_repo_name)
+    if [ -z "$_name" ]; then
+        ux_error "gh-pr-approve status: not inside a git repo"
+        return 1
+    fi
+
+    _dir=$(_gh_pr_approve_pr_dir "$_pr")
+    ux_header "gh-pr-approve status #$_pr - $_name"
+    if [ ! -d "$_dir" ]; then
+        ux_warning "no state for #$_pr in $_name (worker never ran or already pruned)"
+        return 0
+    fi
+
+    _state="$(cat "$_dir/state" 2>/dev/null || printf 'unknown')"
+    _pid="$(cat "$_dir/pid" 2>/dev/null || printf '')"
+    _wt="$(cat "$_dir/worktree.path" 2>/dev/null || printf '')"
+
+    # Worker liveness with elapsed time (etime= is "[[DD-]HH:]MM:SS" on Linux).
+    if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+        _etime="$(ps -p "$_pid" -o etime= 2>/dev/null | tr -d ' ')"
+        if [ -n "$_etime" ]; then
+            _pid_state="pid=$_pid (alive, $_etime)"
+        else
+            _pid_state="pid=$_pid (alive)"
+        fi
+    elif [ -n "$_pid" ]; then
+        _pid_state="pid=$_pid (dead)"
+    else
+        _pid_state="-"
+    fi
+
+    # PR detail: single gh pr view call, includes reviewDecision and date.
+    _pr_state_raw=$(_gh_pr_approve_pr_state "$_dir")
+    if [ "$_pr_state_raw" = "UNREACHABLE" ]; then
+        _pr_info="#$_pr (unreachable — gh CLI failed)"
+    else
+        _pr_state="${_pr_state_raw%%|*}"
+        _pr_decision="${_pr_state_raw#*|}"
+        _pr_date="${_pr_decision#*|}"
+        _pr_decision="${_pr_decision%%|*}"
+        if [ -z "$_pr_state" ]; then
+            _pr_info="#$_pr (state unknown)"
+        else
+            _pr_info="#$_pr ($_pr_state"
+            if [ -n "$_pr_decision" ]; then
+                _pr_info="$_pr_info, review: $_pr_decision"
+            fi
+            if [ -n "$_pr_date" ]; then
+                _pr_info="$_pr_info, $_pr_date"
+            fi
+            _pr_info="$_pr_info)"
+        fi
+    fi
+
+    # Worktree presence.
+    if [ -n "$_wt" ]; then
+        if [ -d "$_wt" ]; then
+            _wt_state="$_wt (present)"
+        else
+            _wt_state="$_wt (absent)"
+        fi
+    else
+        _wt_state="(none)"
+    fi
+
+    # Flags recorded at spawn (only present when --self-record / --admin-merge
+    # were passed). Trim whitespace so a stray newline does not look weird.
+    if [ -f "$_dir/flags" ]; then
+        _flags="$(tr -d '\n' <"$_dir/flags" 2>/dev/null | sed 's/^ *//; s/ *$//')"
+        if [ -n "$_flags" ]; then
+            _flags_state="$_flags"
+        else
+            _flags_state="(none)"
+        fi
+    else
+        _flags_state="(none)"
+    fi
+
+    ux_table_row "State" "$_state"
+    ux_table_row "Worker" "$_pid_state"
+    ux_table_row "PR" "$_pr_info"
+    ux_table_row "Worktree" "$_wt_state"
+    ux_table_row "Flags" "$_flags_state"
+
+    _log="$_dir/log"
+    if [ -f "$_log" ]; then
+        _log_mtime="$(date -r "$_log" '+%Y-%m-%d %H:%M' 2>/dev/null)"
+        if [ -n "$_log_mtime" ]; then
+            ux_table_row "Last log" "$_log_mtime"
+        else
+            ux_table_row "Last log" "$_log"
+        fi
+        printf '\n  --- tail -5 %s ---\n' "$_log"
+        tail -n 5 "$_log" 2>/dev/null | sed 's/^/  /'
+        printf '  ---\n'
+    else
+        ux_table_row "Last log" "(none)"
+    fi
+
+    # Heredoc (not pipe) so reads land in this shell — see auto-memory:
+    # subshell tracing trap.
+    _verdict_out=$(_gh_pr_approve_verdict "$_pr")
+    {
+        IFS= read -r _verdict_text || _verdict_text=""
+        IFS= read -r _action_text || _action_text=""
+    } <<EOF
+$_verdict_out
+EOF
+
+    ux_info ""
+    ux_table_row "Verdict" "$_verdict_text"
+    ux_table_row "Next action" "$_action_text"
+}
+
+# List all known gh-pr-approve entries for the current repo, OR diagnose a
+# single PR if exactly one positional arg is given. Multiple positional args
+# are rejected (single-PR diagnostic only).
+_gh_pr_approve_status() {
+    if [ $# -gt 1 ]; then
+        ux_error "gh-pr-approve status: only one PR number accepted (got $#)"
+        return 1
+    fi
+    if [ -n "${1:-}" ]; then
+        _gh_pr_approve_status_single "$1"
+        return $?
+    fi
+
+    local _root _name _repo_dir _entry _pr _state _pid _wt _pid_state
+    _root=$(_gh_pr_approve_state_root)
+    _name=$(_gh_pr_approve_repo_name)
+    if [ -z "$_name" ]; then
+        ux_error "gh-pr-approve status: not inside a git repo"
+        return 1
+    fi
+    _repo_dir="$_root/$_name"
+
+    ux_header "gh-pr-approve status - $_name"
+    if [ ! -d "$_repo_dir" ]; then
+        ux_info "no state — no workers have ever run in this repo"
+        return 0
+    fi
+
+    local _found=0
+    ux_table_header "PR" "STATE" "PID / WORKTREE"
+    for _entry in "$_repo_dir"/*/; do
+        [ -d "$_entry" ] || continue
+        _pr="$(basename "$_entry")"
+        _state="$(cat "$_entry/state" 2>/dev/null || printf 'unknown')"
+        _pid="$(cat "$_entry/pid" 2>/dev/null || printf '')"
+        _wt="$(cat "$_entry/worktree.path" 2>/dev/null || printf '')"
+
+        if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+            _pid_state="pid=$_pid (alive)"
+        elif [ -n "$_pid" ]; then
+            _pid_state="pid=$_pid (dead)"
+        else
+            _pid_state="-"
+        fi
+
+        if [ -n "$_wt" ]; then
+            ux_table_row "#$_pr" "$_state" "$_pid_state  $_wt"
+        else
+            ux_table_row "#$_pr" "$_state" "$_pid_state"
+        fi
+        _found=1
+    done
+    if [ "$_found" = "0" ]; then
+        ux_info "no state entries under $_repo_dir"
+    fi
+    ux_info ""
+    ux_info "Run 'gh-pr-approve prune' to clean done entries and list failed worktrees."
+}
+
+# Scoped prune: only the PR numbers passed in are touched. Refuses to remove
+# a state dir whose worker is still alive (unless --force) or whose worktree
+# dir still exists (always rejected — that's `gwt teardown`'s job).
+# $1 = repo state dir, $2 = force flag (0|1), $3 = repo name (header),
+# remaining args = PR numbers.
+_gh_pr_approve_prune_scoped() {
+    local _repo_dir="$1" _force="$2" _name="$3"
+    shift 3
+
+    ux_header "gh-pr-approve prune - $_name"
+
+    local _pr _entry _state _pid _wt _pid_alive
+    local _processed=0 _rejected=0 _removed=0
+    for _pr in "$@"; do
+        _entry="$_repo_dir/$_pr"
+        _processed=$((_processed + 1))
+        if [ ! -d "$_entry" ]; then
+            ux_warning "#$_pr no state to prune"
+            continue
+        fi
+        _state="$(cat "$_entry/state" 2>/dev/null || printf '')"
+        _pid="$(cat "$_entry/pid" 2>/dev/null || printf '')"
+        _wt="$(cat "$_entry/worktree.path" 2>/dev/null || printf '')"
+
+        _pid_alive=0
+        if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+            _pid_alive=1
+        fi
+
+        # Worktree present? Always reject — even with --force. Tearing it down
+        # is `gwt teardown`'s job (branch admin, secrets, git worktree prune).
+        if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+            ux_error "#$_pr worktree exists at $_wt — run 'cd $_wt && gwt teardown --force' first"
+            _rejected=$((_rejected + 1))
+            continue
+        fi
+
+        # Alive worker? Accept only with --force.
+        if [ "$_pid_alive" = "1" ]; then
+            if [ "$_force" != "1" ]; then
+                ux_error "#$_pr worker pid=$_pid still alive — pass --force to kill and remove"
+                _rejected=$((_rejected + 1))
+                continue
+            fi
+            ux_warning "#$_pr killing worker pid=$_pid"
+            kill -TERM "$_pid" 2>/dev/null || true
+            sleep 1
+            if kill -0 "$_pid" 2>/dev/null; then
+                kill -KILL "$_pid" 2>/dev/null || true
+            fi
+        fi
+
+        rm -rf "$_entry"
+        ux_success "removed state for #$_pr (was: ${_state:-unknown})"
+        _removed=$((_removed + 1))
+    done
+
+    ux_info ""
+    if [ "$_rejected" -gt 0 ]; then
+        ux_warning "processed $_processed, removed $_removed, rejected $_rejected"
+        return 1
+    fi
+    ux_success "processed $_processed, removed $_removed"
+    return 0
+}
+
+# Prune state dirs. Two modes:
+#   1) No positional args:  full-scan flow — remove 'done', list 'failed:*'
+#      worktrees (and `gwt teardown` them when --force is set).
+#   2) One or more PR numbers: scoped flow (see _gh_pr_approve_prune_scoped).
+# Flag: --force changes scoped behavior (kill alive pid) and full-scan
+# behavior (auto-teardown failed worktrees).
+_gh_pr_approve_prune() {
+    local _force=0
+    local _scoped="" _arg _pr _parsing_flags=1
+
+    while [ $# -gt 0 ]; do
+        _arg="$1"
+        if [ "$_parsing_flags" = "1" ]; then
+            case "$_arg" in
+            --force | -f)
+                _force=1
+                shift
+                continue
+                ;;
+            --)
+                _parsing_flags=0
+                shift
+                continue
+                ;;
+            -*)
+                ux_error "gh-pr-approve prune: unknown arg '$_arg' (only --force is accepted)"
+                return 1
+                ;;
+            esac
+        fi
+
+        _pr="${_arg#\#}"
+        case "$_pr" in
+        '' | *[!0-9]*)
+            ux_error "gh-pr-approve prune: invalid PR number '$_arg'"
+            return 1
+            ;;
+        esac
+        _scoped="$_scoped $_pr"
+        shift
+    done
+
+    local _root _name _repo_dir _entry _state _wt
+    _root=$(_gh_pr_approve_state_root)
+    _name=$(_gh_pr_approve_repo_name)
+    if [ -z "$_name" ]; then
+        ux_error "gh-pr-approve prune: not inside a git repo"
+        return 1
+    fi
+    _repo_dir="$_root/$_name"
+
+    if [ -n "$_scoped" ]; then
+        # shellcheck disable=SC2086
+        _gh_pr_approve_prune_scoped "$_repo_dir" "$_force" "$_name" $_scoped
+        return $?
+    fi
+
+    ux_header "gh-pr-approve prune - $_name"
+    if [ ! -d "$_repo_dir" ]; then
+        ux_info "nothing to prune"
+        return 0
+    fi
+
+    local _removed=0 _failed=0 _torn_down=0
+    for _entry in "$_repo_dir"/*/; do
+        [ -d "$_entry" ] || continue
+        _pr="$(basename "$_entry")"
+        _state="$(cat "$_entry/state" 2>/dev/null || printf '')"
+        _wt="$(cat "$_entry/worktree.path" 2>/dev/null || printf '')"
+
+        case "$_state" in
+        done)
+            rm -rf "$_entry"
+            ux_success "removed state for #$_pr (done)"
+            _removed=$((_removed + 1))
+            ;;
+        failed:*)
+            _failed=$((_failed + 1))
+            if [ "$_force" = "1" ] && [ -n "$_wt" ] && [ -d "$_wt" ]; then
+                ux_warning "#$_pr $_state — tearing down $_wt"
+                if (cd "$_wt" && gwt teardown --force); then
+                    rm -rf "$_entry"
+                    _torn_down=$((_torn_down + 1))
+                else
+                    ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
+                fi
+            else
+                ux_warning "#$_pr $_state"
+                if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+                    ux_bullet_sub "worktree: $_wt"
+                    ux_bullet_sub "cleanup: cd $_wt && gwt teardown --force"
+                fi
+            fi
+            ;;
+        esac
+    done
+
+    ux_info ""
+    if [ "$_force" = "1" ]; then
+        ux_success "pruned $_removed done entr(ies), torn down $_torn_down failed worktree(s); $((_failed - _torn_down)) failure(s) still need attention"
+    else
+        ux_success "pruned $_removed done entr(ies); $_failed failure(s) need attention (pass --force to gwt teardown them)"
+    fi
+}
+
+# ============================================================================
 # Help
 # ============================================================================
 
@@ -109,6 +593,8 @@ gh_pr_approve_help() {
     ux_bullet_sub "--self-record: for self-authored PRs, leave a comment-only review record"
     ux_bullet_sub "--admin-merge: for self-authored PRs, review then merge with gh pr merge --admin"
     ux_bullet_sub "--squash|--rebase|--merge: optional merge strategy for --admin-merge"
+    ux_bullet "gh-pr-approve status [<N>]            full table, or per-PR diagnostic"
+    ux_bullet "gh-pr-approve prune [--force] [<N>...] clean 'done' state, or scoped per-PR prune"
     ux_bullet "gh-pr-approve -h|--help|help"
     ux_info ""
     ux_info "Spawns one background worker per PR. Each worker:"
@@ -121,12 +607,19 @@ gh_pr_approve_help() {
     ux_bullet "gh-pr-approve --ai gemini '#56' '#78'       # gemini + #prefix"
     ux_bullet "gh-pr-approve 42 --self-record              # self-PR comment-only record"
     ux_bullet "gh-pr-approve 42 --admin-merge --squash     # self-PR admin merge"
+    ux_bullet "gh-pr-approve status                        # full table — who's still running, who failed"
+    ux_bullet "gh-pr-approve status 42                     # per-PR diagnostic (verdict + next action)"
+    ux_bullet "gh-pr-approve prune                         # remove 'done' state dirs; print hints for failures"
+    ux_bullet "gh-pr-approve prune --force                 # also gwt teardown failed worktrees"
+    ux_bullet "gh-pr-approve prune 42 56                   # scoped — refuses if pid alive or worktree present"
+    ux_bullet "gh-pr-approve prune --force 42              # scoped + kill alive pid (worktree still rejected)"
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-approve/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
     ux_bullet_sub "ai            - selected ai runner (claude|codex|gemini)"
     ux_bullet_sub "pid           - worker process id"
     ux_bullet_sub "worktree.path - git worktree path"
+    ux_bullet_sub "flags         - launch flags (--self-record, --admin-merge, etc.)"
     ux_bullet_sub "log           - full stdout+stderr"
     ux_bullet_sub "log.prev      - previous run's log (one generation)"
     ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + gemini)"
@@ -134,6 +627,7 @@ gh_pr_approve_help() {
     ux_info "Failure isolation:"
     ux_bullet "One worker failure does not affect others."
     ux_bullet "Failed worker leaves worktree intact; state shows 'failed:<step>'."
+    ux_bullet "Distinct failure states: failed:spawning, failed:approving, failed:tearing-down."
     ux_info ""
     ux_info "Preconditions:"
     ux_bullet "Run from main repo (not inside a worktree)"
@@ -158,6 +652,16 @@ gh_pr_approve() {
     "" | -h | --help | help)
         gh_pr_approve_help
         return 0
+        ;;
+    status)
+        shift
+        _gh_pr_approve_status "$@"
+        return $?
+        ;;
+    prune)
+        shift
+        _gh_pr_approve_prune "$@"
+        return $?
         ;;
     esac
 
@@ -306,6 +810,15 @@ _gh_pr_approve_spawn_worker() {
     mkdir -p "$_dir"
     _log="$_dir/log"
     printf '%s\n' "$_ai" >"$_dir/ai"
+    # Record self-PR launch flags so `status <N>` can show them later.
+    # Empty $_self_args → no file (status renders "(none)" then). Single
+    # line, written even before the worker forks so a fail-fast spawn
+    # still leaves a useful breadcrumb.
+    if [ -n "$_self_args" ]; then
+        printf '%s\n' "$_self_args" >"$_dir/flags"
+    else
+        rm -f "$_dir/flags" 2>/dev/null || true
+    fi
 
     # Idempotency check — mirrors gh-flow semantics.
     _state=$(_gh_pr_approve_get_state "$_pr")

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -153,7 +153,7 @@ _gh_pr_approve_pr_state() {
 _gh_pr_approve_jq_field() {
     local _field="$1"
     if command -v jq >/dev/null 2>&1; then
-        jq -r ".$_field // empty" 2>/dev/null
+        jq -r ".$_field? // empty" 2>/dev/null
     else
         # Naive fallback: grep the "field":"value" pair. Good enough for
         # the simple top-level fields we read from `gh pr view`.

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -228,3 +228,288 @@ teardown() {
     assert_failure
     assert_output --partial "--squash requires --admin-merge"
 }
+
+# ---------------------------------------------------------------------------
+# status / prune subcommands (issue #268)
+# ---------------------------------------------------------------------------
+
+# Seed one gh_pr_approve state dir. Args: <pr> <state> [worktree] [pid] [flags]
+_seed_pr_state() {
+    local _pr="$1" _state="$2" _wt="${3:-}" _pid="${4:-}" _flags="${5:-}"
+    local _dir="$HOME/.local/state/gh-pr-approve/fake-main/$_pr"
+    mkdir -p "$_dir"
+    printf '%s\n' "$_state" >"$_dir/state"
+    if [ -n "$_wt" ]; then printf '%s\n' "$_wt" >"$_dir/worktree.path"; fi
+    if [ -n "$_pid" ]; then printf '%s\n' "$_pid" >"$_dir/pid"; fi
+    if [ -n "$_flags" ]; then printf '%s\n' "$_flags" >"$_dir/flags"; fi
+    return 0
+}
+
+@test "help: documents status and prune subcommands" {
+    run_in_bash 'gh_pr_approve --help'
+    assert_success
+    assert_output --partial "gh-pr-approve status"
+    assert_output --partial "gh-pr-approve prune"
+    assert_output --partial "failed:spawning"
+    assert_output --partial "failed:approving"
+    assert_output --partial "failed:tearing-down"
+    assert_output --partial "flags"
+}
+
+@test "status: empty repo — prints 'no state' and exits 0" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status"
+    assert_success
+    assert_output --partial "no state"
+}
+
+@test "status: lists each seeded entry with its state" {
+    _seed_pr_state 13 "approving" "" "99999"
+    _seed_pr_state 42 "failed:approving" "$TEST_TEMP_HOME/pr-42-wt" "12345"
+    _seed_pr_state 88 "done" "" ""
+
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status"
+    assert_success
+    assert_output --partial "#13"
+    assert_output --partial "approving"
+    assert_output --partial "#42"
+    assert_output --partial "failed:approving"
+    assert_output --partial "pr-42-wt"
+    assert_output --partial "#88"
+    assert_output --partial "done"
+}
+
+@test "status: pid liveness — current shell pid shown as alive" {
+    _seed_pr_state 77 "approving" "" "$$"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status"
+    assert_success
+    assert_output --partial "#77"
+    assert_output --partial "alive"
+}
+
+@test "status: pid liveness — unreachable pid shown as dead" {
+    _seed_pr_state 55 "failed:approving" "$TEST_TEMP_HOME/pr-55-wt" "9999999"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status"
+    assert_success
+    assert_output --partial "#55"
+    assert_output --partial "dead"
+}
+
+# ---------------------------------------------------------------------------
+# verdict matrix
+# ---------------------------------------------------------------------------
+
+@test "verdict: done → 'safe to prune' + scoped prune action" {
+    _seed_pr_state 100 "done" "" ""
+    run_in_bash "cd '$FAKE_REPO' && _gh_pr_approve_verdict 100"
+    assert_success
+    assert_line --index 0 "done — safe to prune"
+    assert_line --index 1 "gh-pr-approve prune 100"
+}
+
+@test "verdict: approving + alive pid → active worker, leave alone" {
+    _seed_pr_state 201 "approving" "" "$$"
+    run_in_bash "cd '$FAKE_REPO' && _gh_pr_approve_verdict 201"
+    assert_success
+    assert_output --partial "active worker (approving)"
+    assert_output --partial "still working"
+}
+
+@test "verdict: approving + dead pid → dead worker mid-step" {
+    _seed_pr_state 202 "approving" "" "9999999"
+    run_in_bash "cd '$FAKE_REPO' && _gh_pr_approve_verdict 202"
+    assert_success
+    assert_output --partial "dead worker mid-step (approving)"
+    assert_output --partial "gh-pr-approve prune 202"
+}
+
+@test "verdict: failed:* + worktree absent → state-only cleanup" {
+    _seed_pr_state 301 "failed:approving" "" "12345"
+    run_in_bash "cd '$FAKE_REPO' && _gh_pr_approve_verdict 301"
+    assert_success
+    assert_output --partial "dead failure"
+    assert_output --partial "gh-pr-approve prune 301"
+}
+
+@test "verdict: failed:* + worktree present → gwt teardown first" {
+    mkdir -p "$TEST_TEMP_HOME/pr-302-wt"
+    _seed_pr_state 302 "failed:tearing-down" "$TEST_TEMP_HOME/pr-302-wt" "12345"
+    run_in_bash "cd '$FAKE_REPO' && _gh_pr_approve_verdict 302"
+    assert_success
+    assert_output --partial "worktree alive"
+    assert_output --partial "gwt teardown --force"
+}
+
+@test "verdict: missing dir → 'no state — PR not tracked'" {
+    run_in_bash "cd '$FAKE_REPO' && _gh_pr_approve_verdict 999"
+    assert_success
+    assert_line --index 0 "no state — PR not tracked"
+    assert_line --index 1 "(none)"
+}
+
+# ---------------------------------------------------------------------------
+# full-scan prune
+# ---------------------------------------------------------------------------
+
+@test "prune: removes 'done' state dirs and keeps 'failed:*' ones" {
+    _seed_pr_state 10 "done" "" ""
+    _seed_pr_state 20 "failed:approving" "$TEST_TEMP_HOME/pr-20-wt" "12345"
+    _seed_pr_state 30 "done" "" ""
+
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune"
+    assert_success
+    assert_output --partial "#10"
+    assert_output --partial "#30"
+    assert_output --partial "#20"
+    assert_output --partial "failed:approving"
+
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/10" ]
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/30" ]
+    [ -d "$HOME/.local/state/gh-pr-approve/fake-main/20" ]
+}
+
+@test "prune: failed entry shows the gwt teardown hint when worktree exists" {
+    mkdir -p "$TEST_TEMP_HOME/pr-42-wt"
+    _seed_pr_state 42 "failed:approving" "$TEST_TEMP_HOME/pr-42-wt" "12345"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune"
+    assert_success
+    assert_output --partial "pr-42-wt"
+    assert_output --partial "gwt teardown"
+}
+
+@test "prune: empty state tree — 'nothing to prune' and exits 0" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune"
+    assert_success
+    assert_output --partial "nothing to prune"
+}
+
+@test "prune: rejects unknown flags" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune --bogus 2>&1"
+    assert_failure
+    assert_output --partial "unknown arg"
+}
+
+# ---------------------------------------------------------------------------
+# scoped prune
+# ---------------------------------------------------------------------------
+
+@test "prune <N>: rejects when worker pid is alive" {
+    _seed_pr_state 401 "approving" "" "$$"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune 401 2>&1"
+    assert_failure
+    assert_output --partial "#401"
+    assert_output --partial "still alive"
+    assert_output --partial "--force"
+    [ -d "$HOME/.local/state/gh-pr-approve/fake-main/401" ]
+}
+
+@test "prune <N>: rejects when worktree dir is present" {
+    mkdir -p "$TEST_TEMP_HOME/pr-402-wt"
+    _seed_pr_state 402 "failed:approving" "$TEST_TEMP_HOME/pr-402-wt" "9999999"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune 402 2>&1"
+    assert_failure
+    assert_output --partial "#402"
+    assert_output --partial "worktree exists"
+    assert_output --partial "gwt teardown --force"
+    [ -d "$HOME/.local/state/gh-pr-approve/fake-main/402" ]
+}
+
+@test "prune --force <N>: still rejects when worktree dir is present" {
+    mkdir -p "$TEST_TEMP_HOME/pr-403-wt"
+    _seed_pr_state 403 "failed:approving" "$TEST_TEMP_HOME/pr-403-wt" "9999999"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune --force 403 2>&1"
+    assert_failure
+    assert_output --partial "worktree exists"
+    [ -d "$HOME/.local/state/gh-pr-approve/fake-main/403" ]
+}
+
+@test "prune --force <N>: kills alive pid and removes state dir" {
+    sleep 60 &
+    local _victim=$!
+    _seed_pr_state 404 "approving" "" "$_victim"
+
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune --force 404"
+    assert_success
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/404" ]
+    run kill -0 "$_victim" 2>/dev/null
+    assert_failure
+    wait "$_victim" 2>/dev/null || true
+}
+
+@test "prune <N>: accepts '#N' form (strips leading #)" {
+    _seed_pr_state 405 "done" "" ""
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune '#405'"
+    assert_success
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/405" ]
+}
+
+@test "prune <N>: rejects non-integer PR arg" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune abc 2>&1"
+    assert_failure
+    assert_output --partial "invalid PR number"
+}
+
+# ---------------------------------------------------------------------------
+# per-PR status (issue #268 — flags display, full table)
+# ---------------------------------------------------------------------------
+
+@test "status <N>: prints header + Verdict + Next action" {
+    _seed_pr_state 501 "done" "" ""
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 501"
+    assert_success
+    assert_output --partial "gh-pr-approve status #501"
+    assert_output --partial "State"
+    assert_output --partial "done"
+    assert_output --partial "Verdict"
+    assert_output --partial "Next action"
+}
+
+@test "status <N>: '#N' form also accepted" {
+    _seed_pr_state 502 "done" "" ""
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status '#502'"
+    assert_success
+    assert_output --partial "#502"
+}
+
+@test "status <N>: missing state dir → warning, exits 0" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 503"
+    assert_success
+    assert_output --partial "no state for #503"
+}
+
+@test "status <N>: rejects multiple positional args" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 504 505 2>&1"
+    assert_failure
+    assert_output --partial "only one PR number"
+}
+
+@test "status <N>: shows recorded flags" {
+    _seed_pr_state 506 "approving" "" "$$" "--admin-merge --squash"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 506"
+    assert_success
+    assert_output --partial "Flags"
+    assert_output --partial "--admin-merge --squash"
+}
+
+@test "status <N>: missing flags file → '(none)'" {
+    _seed_pr_state 507 "approving" "" "$$"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 507"
+    assert_success
+    assert_output --partial "Flags"
+    assert_output --partial "(none)"
+}
+
+# ---------------------------------------------------------------------------
+# dispatcher: 'status' / 'prune' must not be parsed as a PR number
+# ---------------------------------------------------------------------------
+
+@test "dispatcher: 'status' is not parsed as an invalid PR number" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status"
+    assert_success
+    refute_output --partial "invalid PR number"
+}
+
+@test "dispatcher: 'prune' is not parsed as an invalid PR number" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune"
+    assert_success
+    refute_output --partial "invalid PR number"
+}


### PR DESCRIPTION
## Summary
- `gh-pr-approve` 에 `status` / `prune` 서브커맨드를 추가해 worker 진단과 state dir 정리를 수동 `rm -rf` 없이 처리할 수 있게 함 (gh-flow #252 미러)
- 단발 파이프라인 특성에 맞춰 verdict matrix 단순화: polling/reply 분기 없음, GitHub 측 PR state 는 `status <N>` 표에서 informational 로만 표시되고 verdict 결정에는 영향 없음
- spawn 시 사용된 self-PR 옵션을 `<pr-dir>/flags` 에 기록해 `status <N>` 의 `Flags` 라인에서 노출

## What changed
- **`shell-common/functions/gh_pr_approve.sh`**: 6개 helper 신규 (`_gh_pr_approve_pr_state`, `_jq_field`, `_verdict`, `_status`, `_status_single`, `_prune`, `_prune_scoped`), orchestrator 에 `status` / `prune` 분기 추가, `_spawn_worker` 에 `flags` 파일 기록, help 텍스트 갱신 (Examples / State directory / Failure isolation 블록)
- **`tests/bats/functions/gh_pr_approve.bats`**: verdict / 전체 prune / scoped prune / status 단일 PR / flags 표시 / dispatcher 분기에 대한 29개 테스트 추가 — gh_flow.bats 와 패턴 일치
- **`docs/feature/gh-pr-approve-status-prune/design.md`**: 설계 문서 신규

## Test plan
- [x] `bats tests/bats/functions/gh_pr_approve.bats` — 52/52 PASS
- [x] `bats tests/bats/functions/gh_flow.bats` — 33/33 PASS (regression)
- [x] `shellcheck` clean
- [x] `bash -n` / `zsh -n` 통과
- [ ] manual: `--admin-merge --squash` 로 spawn 후 `status <N>` 에 `Flags` 노출 확인
- [ ] manual: `failed:approving` + worktree 잔존 시 `prune` 힌트 → `prune --force` 가 자동 teardown
- [ ] manual: scoped `prune <N>` 가 worktree 존재하면 `--force` 여도 거부

Closes #268

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
