### PR TITLE
refactor(cli): rename --agent option to --ai for naming consistency

### DIFF
--- a/claude/skills/ai-worktree-spawn/SKILL.md
+++ b/claude/skills/ai-worktree-spawn/SKILL.md
@@ -29,7 +29,7 @@ check parent directory write permission.
 ### Step 2: Detect AI Agent
 
 Read `references/agent-detection.md` for the full priority chain and env var table.
-Priority: `--agent` arg > `$AI_AGENT_NAME` > agent-specific env vars > `agent`.
+Priority: `--ai` arg > `$AI_AGENT_NAME` > agent-specific env vars > `agent`.
 
 ### Step 3: Compute Project Name and Index
 

--- a/claude/skills/ai-worktree-spawn/references/agent-detection.md
+++ b/claude/skills/ai-worktree-spawn/references/agent-detection.md
@@ -4,7 +4,7 @@
 
 Determine `agent_name` using this order (first match wins):
 
-1. `--agent <name>` argument (if user provided)
+1. `--ai <name>` argument (if user provided)
 2. `$AI_AGENT_NAME` environment variable
 3. Agent-specific env vars (see table below)
 4. Fallback: `agent`

--- a/claude/skills/ai-worktree-spawn/references/bash-commands.md
+++ b/claude/skills/ai-worktree-spawn/references/bash-commands.md
@@ -26,7 +26,7 @@ test -w "$PARENT" || { echo "Error: Permission denied: $PARENT"; exit 1; }
 
 ```bash
 detect_ai_agent() {
-  # Priority 1: --agent argument (passed as $1)
+  # Priority 1: --ai argument (passed as $1)
   if [[ -n "${1:-}" ]]; then
     echo "$1"
     return

--- a/claude/skills/ai-worktree-spawn/references/options-and-errors.md
+++ b/claude/skills/ai-worktree-spawn/references/options-and-errors.md
@@ -4,7 +4,7 @@
 
 | Option | Description | Default |
 |---|---|---|
-| `--agent <name>` | Override agent name | auto-detect |
+| `--ai <name>` | Override agent name | auto-detect |
 | `--task "slug"` | Add task slug to branch name (English only) | none |
 | `--base <ref>` | Base branch/commit | `origin/main` |
 | `--dry-run` | Print plan without creating anything | `false` |

--- a/docs/feature/skill-git-worktree-create/design-C.md
+++ b/docs/feature/skill-git-worktree-create/design-C.md
@@ -82,7 +82,7 @@
 
 | 우선순위 | 방법 | 예시 |
 |---|---|---|
-| 1 | 명시 인자 `--agent` | `--agent claude` |
+| 1 | 명시 인자 `--ai` | `--ai claude` |
 | 2 | 환경변수 `AI_AGENT_NAME` | `export AI_AGENT_NAME=gemini` |
 | 3 | 에이전트별 고유 환경변수 | 아래 감지 테이블 참조 |
 | 4 | fallback 기본값 | `agent` |
@@ -188,7 +188,7 @@ git worktree add -b "${branch_name}" "${worktree_path}" "${base_ref}"
 
 | 옵션 | 설명 | 기본값 |
 |---|---|---|
-| `--agent <name>` | 에이전트명 수동 지정 | 자동 감지 |
+| `--ai <name>` | 에이전트명 수동 지정 | 자동 감지 |
 | `--task "slug"` | 브랜치 slug 생성에 사용 (영문만) | 없음 |
 | `--base <ref>` | 기반 브랜치/커밋 지정 | `origin/main` |
 | `--dry-run` | 실제 생성 없이 계획만 출력 | `false` |
@@ -310,7 +310,7 @@ AI: [dry-run] 아래 계획을 실행할 예정입니다:
     |     -> 부모 디렉토리 쓰기 권한 확인
     |
     +-- 2. AI 에이전트 감지 (detect_ai_agent)
-    |     -> --agent > $AI_AGENT_NAME > 고유 env > fallback
+    |     -> --ai > $AI_AGENT_NAME > 고유 env > fallback
     |
     +-- 3. 프로젝트명 추출
     |     -> basename $(git rev-parse --show-toplevel)
@@ -406,7 +406,7 @@ tools/
 tools/ai-worktree-spawn.sh [options] [branch-name]
 
 # 옵션
---agent <name>    에이전트명 수동 지정
+--ai <name>    에이전트명 수동 지정
 --task "slug"     브랜치 slug 생성 (영문 소문자/숫자/하이픈)
 --base <ref>      기반 브랜치 지정 (default: origin/main)
 --dry-run         계획만 출력
@@ -477,7 +477,7 @@ git branch --merged main | grep "^  wt/" | xargs git branch -d
 | 결정 사항 | 채택 출처 | 근거 |
 |---|---|---|
 | 목표/비목표 분리 | design-CX | scope creep 방지. PR 자동화 등은 비목표로 명시 |
-| 에이전트 식별 4단계 우선순위 | design-CX | `--agent` override가 없으면 환경변수 바뀔 때 대응 불가 |
+| 에이전트 식별 4단계 우선순위 | design-CX | `--ai` override가 없으면 환경변수 바뀔 때 대응 불가 |
 | lock 기반 동시성 제어 | design-CX | 6개 TUI 동시 실행 시 번호 충돌은 실제 발생 가능 |
 | 브랜치 네임스페이스 `wt/` | design-CX | 일반 브랜치와 구분, 일괄 정리 용이 (`git branch \| grep wt/`) |
 | `--dry-run` 옵션 | design-CX | 실행 전 검증은 안전성의 기본 |

--- a/shell-common/functions/ai_setup.sh
+++ b/shell-common/functions/ai_setup.sh
@@ -18,13 +18,13 @@ ai_setup() {
         case "$1" in
             -h|--help|help)
                 ux_header "ai-setup - workspace orchestrator"
-                ux_info "Usage: ai-setup [--agent <agent>]"
+                ux_info "Usage: ai-setup [--ai <agent>]"
                 ux_info ""
                 ux_info "Interactive setup that creates git worktrees and"
                 ux_info "tmux sessions with 3-pane windows in one step."
                 ux_info ""
                 ux_info "Options:"
-                ux_info "  --agent <agent>   Pre-fill the 'Tmux window agents' prompt"
+                ux_info "  --ai <agent>   Pre-fill the 'Tmux window agents' prompt"
                 ux_info "                    default (claude, codex, gemini,"
                 ux_info "                    opencode, cursor, copilot)."
                 ux_info ""
@@ -39,9 +39,9 @@ ai_setup() {
                 ux_info "Requirements: git, tmux, run from main repo (not worktree)"
                 return 0
                 ;;
-            --agent)
+            --ai)
                 if [ -z "${2:-}" ]; then
-                    ux_error "--agent requires an argument"
+                    ux_error "--ai requires an argument"
                     return 1
                 fi
                 if ! _ts_known_agent "$2"; then
@@ -57,7 +57,7 @@ ai_setup() {
                 ;;
             *)
                 ux_warning "Unexpected argument: $1"
-                ux_info "Usage: ai-setup [--agent <agent>]"
+                ux_info "Usage: ai-setup [--ai <agent>]"
                 ux_info "Run 'ai-setup --help' for details."
                 return 1
                 ;;

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -53,13 +53,13 @@ _gwt_help_rows_prune() {
 }
 
 _gwt_help_rows_spawn() {
-    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch [--agent <agent>]]" "Create named worktree"
+    ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch [--ai <agent>]]" "Create named worktree"
     ux_table_row "context" "Run from main repo only" "Fails inside a worktree"
     ux_table_row "name" "Free-form slug (required)" "e.g. issue-11, login-fix"
-    ux_table_row "--agent" "AI agent (default: claude)" "claude, codex, gemini, opencode, cursor, copilot"
+    ux_table_row "--ai" "AI agent (default: claude)" "claude, codex, gemini, opencode, cursor, copilot"
     ux_table_row "--tmux" "Runs <agent>-yolo in new tmux pane" "Mutually exclusive with --launch"
     ux_table_row "--launch" "cd into worktree + run <agent>-yolo inline" "Current shell, no tmux"
-    ux_table_row "example" "gwt spawn issue-11 --tmux --agent codex" "Free-form name + codex agent"
+    ux_table_row "example" "gwt spawn issue-11 --tmux --ai codex" "Free-form name + codex agent"
     ux_table_row "example" "gwt spawn feat --launch" "spawn -> cd -> claude-yolo (one shot)"
 }
 
@@ -450,11 +450,11 @@ _gwt_yolo_command() {
 
 # ============================================================================
 # Worktree spawn — auto-index, auto-branch, log
-# Usage: git_worktree_spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--agent <agent>]
+# Usage: git_worktree_spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--ai <agent>]
 # ============================================================================
 _git_worktree_spawn_show_help() {
     ux_header "gwt spawn - create a named worktree"
-    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--agent <agent>]"
+    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--ai <agent>]"
     ux_info ""
     ux_info "Arguments:"
     ux_info "  <name>           Free-form worktree name (required)."
@@ -465,18 +465,18 @@ _git_worktree_spawn_show_help() {
     ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
     ux_info "  --launch         cd into the new worktree and run <agent>-yolo in the"
     ux_info "                   current shell. Mutually exclusive with --tmux."
-    ux_info "  --agent <agent>  AI agent for --tmux pane or --launch (default: claude)"
+    ux_info "  --ai <agent>  AI agent for --tmux pane or --launch (default: claude)"
     ux_info "                   Known: claude, codex, gemini, opencode, cursor, copilot"
-    ux_info "                   Window name and 'yolo' command follow --agent,"
+    ux_info "                   Window name and 'yolo' command follow --ai,"
     ux_info "                   so worktree <name> can be any free-form slug."
     ux_info ""
     ux_info "Examples:"
     ux_info "  gwt spawn issue-11                           # ../<proj>-issue-11-1  wt/issue-11/1"
     ux_info "  gwt spawn login-fix --task auth              # ../<proj>-login-fix-1 wt/login-fix/1-auth"
     ux_info "  gwt spawn issue-11 --tmux                    # tmux window 'claude' runs 'claude-yolo'"
-    ux_info "  gwt spawn issue-11 --tmux --agent codex      # tmux window 'codex'  runs 'codex-yolo'"
+    ux_info "  gwt spawn issue-11 --tmux --ai codex      # tmux window 'codex'  runs 'codex-yolo'"
     ux_info "  gwt spawn feat --launch                      # cd into new worktree + claude-yolo"
-    ux_info "  gwt spawn feat --launch --agent codex        # cd + codex-yolo"
+    ux_info "  gwt spawn feat --launch --ai codex        # cd + codex-yolo"
 }
 
 git_worktree_spawn() {
@@ -496,7 +496,7 @@ git_worktree_spawn() {
                 ;;
             --task) task="$2"; shift 2 ;;
             --base) base="$2"; shift 2 ;;
-            --agent) agent="$2"; shift 2 ;;
+            --ai) agent="$2"; shift 2 ;;
             --tmux) use_tmux=1; shift ;;
             --launch) use_launch=1; shift ;;
             -*)
@@ -549,7 +549,7 @@ git_worktree_spawn() {
         return 1
     fi
 
-    # Validate --agent: must be a known AI agent (only when tmux/launch will use it)
+    # Validate --ai: must be a known AI agent (only when tmux/launch will use it)
     if { [ "$use_tmux" = 1 ] || [ "$use_launch" = 1 ]; } && ! _ts_known_agent "$agent"; then
         ux_error "Unknown agent: $agent"
         ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"

--- a/tests/bats/functions/ai_setup.bats
+++ b/tests/bats/functions/ai_setup.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 # tests/bats/functions/ai_setup.bats
-# Tests for ai_setup --agent flag (issue #162).
+# Tests for ai_setup --ai flag (issue #162).
 # ai_setup is interactive, so we only exercise the argument-parsing
 # preamble that fails fast before the first prompt.
 
@@ -20,20 +20,20 @@ teardown() {
     assert_output --partial "ok"
 }
 
-@test "bash: ai-setup --help mentions --agent flag" {
+@test "bash: ai-setup --help mentions --ai flag" {
     run_in_bash 'ai_setup --help'
     assert_success
-    assert_output --partial "--agent"
+    assert_output --partial "--ai"
 }
 
-@test "bash: ai_setup --agent requires an argument" {
-    run_in_bash 'ai_setup --agent 2>&1'
+@test "bash: ai_setup --ai requires an argument" {
+    run_in_bash 'ai_setup --ai 2>&1'
     assert_failure
-    assert_output --partial "--agent requires an argument"
+    assert_output --partial "--ai requires an argument"
 }
 
-@test "bash: ai_setup --agent rejects unknown agent" {
-    run_in_bash 'ai_setup --agent bogus 2>&1'
+@test "bash: ai_setup --ai rejects unknown agent" {
+    run_in_bash 'ai_setup --ai bogus 2>&1'
     assert_failure
     assert_output --partial "Unknown agent: bogus"
 }

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 # tests/bats/functions/git_worktree_spawn.bats
-# Tests for `gwt spawn --agent` flag (issue #162).
+# Tests for `gwt spawn --ai` flag (issue #162).
 # Focuses on argument parsing + validation paths that do NOT require tmux
 # or a real worktree layout — the interesting behavioral change is the
 # decoupling of worktree <name> from the tmux agent name.
@@ -36,10 +36,10 @@ teardown() {
     assert_output --partial "ok"
 }
 
-@test "bash: spawn --help mentions --agent flag" {
+@test "bash: spawn --help mentions --ai flag" {
     run_in_bash 'git_worktree_spawn --help'
     assert_success
-    assert_output --partial "--agent"
+    assert_output --partial "--ai"
     assert_output --partial "claude"
 }
 
@@ -57,7 +57,7 @@ teardown() {
     # The key assertion: an unknown agent must produce a helpful error.
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --tmux --agent notarealagent 2>&1
+        git_worktree_spawn issue-xyz --tmux --ai notarealagent 2>&1
     "
     assert_failure
     assert_output --partial "Unknown agent: notarealagent"
@@ -70,10 +70,10 @@ teardown() {
     assert_output --partial "ok"
 }
 
-@test "zsh: spawn --help mentions --agent flag" {
+@test "zsh: spawn --help mentions --ai flag" {
     run_in_zsh 'git_worktree_spawn --help'
     assert_success
-    assert_output --partial "--agent"
+    assert_output --partial "--ai"
 }
 
 @test "bash: spawn --help mentions --launch flag" {
@@ -103,7 +103,7 @@ teardown() {
 @test "bash: spawn rejects unknown agent when --launch is used" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --agent notarealagent 2>&1
+        git_worktree_spawn issue-xyz --launch --ai notarealagent 2>&1
     "
     assert_failure
     assert_output --partial "Unknown agent: notarealagent"
@@ -112,7 +112,7 @@ teardown() {
 @test "zsh: spawn rejects unknown agent when --launch is used" {
     run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --agent notarealagent 2>&1
+        git_worktree_spawn issue-xyz --launch --ai notarealagent 2>&1
     "
     assert_failure
     assert_output --partial "Unknown agent: notarealagent"


### PR DESCRIPTION
## Summary
- Align `gwt spawn`, `ai-setup`, and the `ai-worktree:spawn` skill to use `--ai` instead of `--agent`, matching `gh-flow` / `gh-pr-reply` / `gh-pr-approve`.
- Pure CLI surface rename — internal `agent` shell variables and the `$AI_AGENT_NAME` env var stay untouched per the answers on issue #270's open questions.
- Touches help text, argument parsers, bats assertions, the design-C.md spec, and the ai-worktree:spawn skill bundle.

## Changes
- `shell-common/functions/git_worktree.sh`: rename the CLI option in help/usage rows, the parser case-arm, and the validation comment.
- `shell-common/functions/ai_setup.sh`: rename in help, the parser case-arm, the "requires an argument" message, and the unexpected-argument usage line.
- `tests/bats/functions/git_worktree_spawn.bats` + `ai_setup.bats`: update assertions, test descriptions, and the failure-path inputs for the new flag.
- `claude/skills/ai-worktree-spawn/SKILL.md` + `references/{agent-detection,bash-commands,options-and-errors}.md`: update the priority chain, the option table, and the `detect_ai_agent` comment.
- `docs/feature/skill-git-worktree-create/design-C.md`: rename in the priority table (FR-2), the options table (FR-6), the flowchart, the usage block (Section 9.3), and the Appendix A reasoning row — so future searches against `--agent` find nothing.

## Test plan
- [x] Targeted bats: `tests/bats/functions/git_worktree_spawn.bats` + `ai_setup.bats` — 30/30 pass with the new `--ai` assertions.
- [x] `bash -n` syntax check on both modified `.sh` files.
- [x] `grep -rn "\-\-agent\b"` returns no matches in tracked files (excluding the `tests/bats/lib/` bats-core submodules).

## Related
Closes #270

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
