### PR TITLE
fix(gh-flow): prune --force가 worktree 없는 failed:* state를 정리 (#277)

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -556,19 +556,28 @@ _gh_flow_prune() {
             ;;
         failed:*)
             _failed=$((_failed + 1))
-            if [ "$_force" = "1" ] && [ -n "$_wt" ] && [ -d "$_wt" ]; then
-                ux_warning "#$_issue $_state — tearing down $_wt"
-                if (cd "$_wt" && gwt teardown --force); then
+            if [ "$_force" = "1" ]; then
+                if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+                    ux_warning "#$_issue $_state — tearing down $_wt"
+                    if (cd "$_wt" && git_worktree_teardown --force); then
+                        rm -rf "$_entry"
+                        _torn_down=$((_torn_down + 1))
+                    else
+                        ux_error "  teardown failed for $_wt; leaving state dir intact"
+                        ux_bullet_sub "manual fix: cd $_wt && gwt teardown --force, then gh-flow prune --force $_issue"
+                    fi
+                else
+                    ux_warning "#$_issue $_state — worktree gone, removing state"
                     rm -rf "$_entry"
                     _torn_down=$((_torn_down + 1))
-                else
-                    ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
                 fi
             else
                 ux_warning "#$_issue $_state"
                 if [ -n "$_wt" ] && [ -d "$_wt" ]; then
                     ux_bullet_sub "worktree: $_wt"
                     ux_bullet_sub "cleanup: cd $_wt && gwt teardown --force"
+                else
+                    ux_bullet_sub "worktree gone — run 'gh-flow prune --force $_issue' to drop state"
                 fi
             fi
             ;;
@@ -577,7 +586,7 @@ _gh_flow_prune() {
 
     ux_info ""
     if [ "$_force" = "1" ]; then
-        ux_success "pruned $_removed done entr(ies), torn down $_torn_down failed worktree(s); $((_failed - _torn_down)) failure(s) still need attention"
+        ux_success "pruned $_removed done entr(ies), cleaned up $_torn_down failed entr(ies); $((_failed - _torn_down)) failure(s) still need attention"
     else
         ux_success "pruned $_removed done entr(ies); $_failed failure(s) need attention (pass --force to gwt teardown them)"
     fi

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -145,6 +145,36 @@ teardown() {
     assert_output --partial "gwt teardown"
 }
 
+@test "prune: failed entry with no worktree shows scoped --force hint" {
+    _seed_state 51 "failed:implementing" "$TEST_TEMP_HOME/repo-issue-51-1" "12345"
+    # worktree.path points somewhere that does not exist on disk — simulates
+    # a worker that died after its own teardown or after the user manually
+    # cleaned up the tree.
+
+    run_in_bash "cd '$REPO_DIR' && gh_flow prune"
+    assert_success
+    assert_output --partial "#51"
+    assert_output --partial "gh-flow prune --force 51"
+    # State preserved when --force absent.
+    [ -d "$HOME/.local/state/gh-flow/repo/51" ]
+}
+
+@test "prune --force: removes failed:* state when worktree is already gone" {
+    _seed_state 61 "failed:implementing" "$TEST_TEMP_HOME/repo-issue-61-1" "12345"
+    _seed_state 62 "failed:opening-pr" "" "12346"
+
+    run_in_bash "cd '$REPO_DIR' && gh_flow prune --force"
+    assert_success
+    assert_output --partial "#61"
+    assert_output --partial "worktree gone"
+    assert_output --partial "#62"
+    # Both orphan-state entries removed.
+    [ ! -d "$HOME/.local/state/gh-flow/repo/61" ]
+    [ ! -d "$HOME/.local/state/gh-flow/repo/62" ]
+    # Counter reflects the cleanup.
+    assert_output --partial "cleaned up 2 failed entr(ies)"
+}
+
 @test "prune: empty state tree — 'nothing to prune' and exits 0" {
     run_in_bash "cd '$REPO_DIR' && gh_flow prune"
     assert_success


### PR DESCRIPTION
## Summary

- `gh-flow prune --force` (bulk 모드)가 worktree가 이미 사라진 `failed:*` state 디렉토리를 영원히 정리하지 못하던 버그 수정. cleanup 분기가 `[ -d "$_wt" ]` 가드에 묶여 있어, worker가 자기 worktree를 부분 정리한 뒤 죽었거나 사용자가 수동 teardown을 해버린 경우 state가 영구 누적됐었음.
- `_gh_flow_prune`의 `failed:*` 분기를 3-way로 분리: (1) `--force` + worktree 존재 → 기존대로 teardown + state 삭제, (2) `--force` + worktree 부재 → orphan state로 보고 즉시 `rm -rf`, (3) `--force` 없음 → 경고 + 상황별 hint(worktree 있으면 `gwt teardown`, 없으면 `gh-flow prune --force <N>`).
- 같은 분기 안에서 호출하던 `(cd "$_wt" && gwt teardown --force)`가 zsh 인터랙티브 셸의 `(...)` 서브셸에서 `git worktree teardown`으로 어긋나 실패하던 2차 증상도 함께 회피 — dispatcher를 거치지 않고 `git_worktree_teardown --force`를 직접 호출. 호출 위치가 이미 dotfiles 셸 환경 안이라 함수 가용성은 동일.
- 성공 메시지를 "torn down N failed worktree(s)" → "cleaned up N failed entr(ies)"로 일반화 (orphan cleanup도 카운터에 포함되므로).
- bats 테스트 2개 추가: orphan-state + `--force` 없는 경우 hint 검증, orphan-state + `--force` 케이스에서 state 디렉토리 실제 삭제 + 카운터 메시지 검증.

Closes #277

## Test plan

- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_flow.bats` — 35/35 통과 (기존 33 + 신규 2)
- [x] `shellcheck --severity=warning --shell=bash shell-common/functions/gh_flow.sh` — 깨끗
- [ ] 실 환경 확인: `failed:*` state + worktree 부재 시드 후 `gh-flow prune --force` → state 디렉토리 제거 + `gh-flow status`에서 사라짐
- [ ] scoped prune (`gh-flow prune --force <N>`) 회귀 없음 — 변경 안 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
