### PR TITLE
refactor(kanban): inline UX helpers, drop ux_lib.sh dependency

### DIFF
--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 # -----------------------------------------------------------------------------
 if [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ] || ! command -v tput >/dev/null 2>&1; then
     UX_BOLD=""
-    UX_DIM=""
     UX_RESET=""
     UX_PRIMARY=""
     UX_SUCCESS=""
@@ -20,7 +19,6 @@ if [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ] || ! command -v tput >/dev
     UX_MUTED=""
 else
     UX_BOLD="$(tput bold 2>/dev/null || echo '')"
-    UX_DIM="$(tput dim 2>/dev/null || echo '')"
     UX_RESET="$(tput sgr0 2>/dev/null || echo '')"
     UX_PRIMARY="$(tput setaf 4 2>/dev/null || echo '')"
     UX_SUCCESS="$(tput setaf 2 2>/dev/null || echo '')"
@@ -34,7 +32,7 @@ ux_header() {
     local text="$1"
     echo ""
     printf "%s%s╔══════════════════════════════════════════════════════════════╗%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
-    printf "%s%s║%s %-60s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    printf "%s%s║%s %-58s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
     printf "%s%s╚══════════════════════════════════════════════════════════════╝%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
     echo ""
 }

--- a/scripts/setup-kanban-board.sh
+++ b/scripts/setup-kanban-board.sh
@@ -2,17 +2,72 @@
 
 set -euo pipefail
 
-_SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
-DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
-UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
-
-if [ -f "$UX_LIB" ]; then
-    # shellcheck disable=SC1090
-    source "$UX_LIB"
+# -----------------------------------------------------------------------------
+# Self-contained UX helpers — no external library required.
+# This script is a single-file SSOT meant to be copy-pasted into other repos
+# to bootstrap a GitHub Projects v2 kanban board, so it cannot depend on the
+# parent dotfiles tree.
+# -----------------------------------------------------------------------------
+if [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ] || ! command -v tput >/dev/null 2>&1; then
+    UX_BOLD=""
+    UX_DIM=""
+    UX_RESET=""
+    UX_PRIMARY=""
+    UX_SUCCESS=""
+    UX_WARNING=""
+    UX_ERROR=""
+    UX_INFO=""
+    UX_MUTED=""
 else
-    echo "Error: UX library not found at $UX_LIB" >&2
-    exit 1
+    UX_BOLD="$(tput bold 2>/dev/null || echo '')"
+    UX_DIM="$(tput dim 2>/dev/null || echo '')"
+    UX_RESET="$(tput sgr0 2>/dev/null || echo '')"
+    UX_PRIMARY="$(tput setaf 4 2>/dev/null || echo '')"
+    UX_SUCCESS="$(tput setaf 2 2>/dev/null || echo '')"
+    UX_WARNING="$(tput setaf 3 2>/dev/null || echo '')"
+    UX_ERROR="$(tput setaf 1 2>/dev/null || echo '')"
+    UX_INFO="$(tput setaf 6 2>/dev/null || echo '')"
+    UX_MUTED="$(tput setaf 8 2>/dev/null || echo '')"
 fi
+
+ux_header() {
+    local text="$1"
+    echo ""
+    printf "%s%s╔══════════════════════════════════════════════════════════════╗%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    printf "%s%s║%s %-60s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    printf "%s%s╚══════════════════════════════════════════════════════════════╝%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    echo ""
+}
+
+ux_section() {
+    local title="$1"
+    local underline
+    underline="$(printf '─%.0s' $(seq 1 ${#title}))"
+    echo ""
+    printf "%s%s%s%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$title" "${UX_RESET}"
+    printf "%s%s%s%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$underline" "${UX_RESET}"
+}
+
+ux_usage() {
+    local cmd_name="$1"
+    local args="$2"
+    local description="${3:-}"
+    ux_section "Usage"
+    echo "  ${UX_SUCCESS}${cmd_name}${UX_RESET} ${UX_MUTED}${args}${UX_RESET}"
+    if [ -n "$description" ]; then
+        echo ""
+        echo "  $description"
+    fi
+    echo ""
+}
+
+ux_success() { printf "%s%s✅%s %s\n" "${UX_BOLD}" "${UX_SUCCESS}" "${UX_RESET}" "$1"; }
+ux_error()   { printf "%s%s❌%s %s\n" "${UX_BOLD}" "${UX_ERROR}"   "${UX_RESET}" "$1" >&2; }
+ux_warning() { printf "%s%s⚠️%s  %s\n" "${UX_BOLD}" "${UX_WARNING}" "${UX_RESET}" "$1"; }
+ux_info()    { printf "%s%sℹ️%s  %s\n" "${UX_BOLD}" "${UX_INFO}"    "${UX_RESET}" "$1"; }
+ux_step()    { printf "%s%s[%s]%s %s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$1" "${UX_RESET}" "$2"; }
+ux_bullet()     { printf "  ${UX_PRIMARY}◆${UX_RESET} %s\n" "$1"; }
+ux_bullet_sub() { printf "    ${UX_INFO}•${UX_RESET} %s\n" "$1"; }
 
 OWNER=""
 REPO=""
@@ -40,7 +95,6 @@ log_success() { ux_success "$1"; }
 log_warning() { ux_warning "$1"; }
 log_error() { ux_error "$1"; }
 log_step() { ux_step "$1" "$2"; }
-log_dim() { printf "%s%s%s\n" "${UX_DIM}" "$1" "${UX_RESET}"; }
 
 die() {
     log_error "$1"


### PR DESCRIPTION
## Summary
- `scripts/setup-kanban-board.sh` 가 dotfiles 트리 안의 `shell-common/tools/ux_lib/ux_lib.sh` 를 source 해야만 동작하던 의존성을 제거.
- 이제 파일 한 개를 그대로 다른 레포(`quantfolio` 등)에 복사하면 즉시 실행 가능 — 진짜 단일 파일 SSOT playbook.
- 외부 동작/CLI 인터페이스/시각 출력은 동등하게 유지.

## Changes
- `scripts/setup-kanban-board.sh`: 상단의 `_SCRIPT_PATH` / `DOTFILES_ROOT` / `UX_LIB` source 가드 8줄 제거.
- 같은 위치에 self-contained UX 헬퍼 블록(~50줄) 인라인:
  - 함수: `ux_header`, `ux_section`, `ux_usage`, `ux_info`, `ux_success`, `ux_warning`, `ux_error`, `ux_step`, `ux_bullet`, `ux_bullet_sub` — 스크립트가 실제로 호출하는 함수만.
  - 색상 변수: `UX_BOLD` / `UX_DIM` / `UX_RESET` / `UX_PRIMARY` / `UX_SUCCESS` / `UX_WARNING` / `UX_ERROR` / `UX_INFO` / `UX_MUTED` — `print_final_report` 의 인라인 강조용 포함.
- `NO_COLOR` / `TERM=dumb` / `tput` 미설치 시 ANSI 시퀀스 자동 비활성.
- 호출처가 없는 `log_dim` 래퍼(데드 코드) 제거.

## 왜 인라인이 SSOT와 맞는가
- `ux_lib.sh` 자체에는 손대지 않음 → dotfiles 내부의 다른 스크립트들은 영향 없음.
- 이 스크립트는 docs/playbooks/kanban-board-setup.md 가 \"카피·페이스트만으로 외부 레포 부트스트랩\" 을 약속하는 핵심 자산이라, 외부 의존성을 가지면 약속 자체가 깨진다 (#273 의 동기와 동일 라인).
- 의존성을 ux_lib 쪽으로 흡수(예: `--standalone` 플래그)하는 안 대신 인라인을 택한 이유: 스크립트가 사용하는 심볼은 10개로 명확하고, 인라인 비용이 ~50줄 / +64L 로 작아 \"다른 레포에서 복사 가능\" 이라는 1차 목표에 가장 직접적이다.

## Test plan
- [x] `shellcheck scripts/setup-kanban-board.sh` — exit 0, 새 경고 없음.
- [x] `./scripts/setup-kanban-board.sh --help` — 헤더 박스/색상/아이콘 출력이 기존과 동등.
- [x] 외부 디렉터리 시뮬레이션: `cp scripts/setup-kanban-board.sh /tmp/foo/ && (cd /tmp/foo && ./setup-kanban-board.sh --help)` — 정상 동작 확인.
- [x] `NO_COLOR=1 ./scripts/setup-kanban-board.sh --help | cat -v` — `^[` ANSI 시퀀스 없음 확인.
- [ ] (수동) 외부 빈 레포에 단일 파일 복사 → `--dry-run` 으로 실제 권한 흐름까지 정상 동작 확인.

## Related
Closes #279

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics -->
