### PR TITLE
fix(gwt): orphan-worktree recovery UX gaps

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -140,7 +140,7 @@ gwt() {
         add)      shift; git_worktree_add "$@" ;;
         list|ls)  shift; git_worktree_list "$@" ;;
         remove|rm) shift; git_worktree_remove "$@" ;;
-        prune)    shift; git worktree prune "$@" ;;
+        prune)    shift; git_worktree_prune "$@" ;;
         spawn)    shift; git_worktree_spawn "$@" ;;
         teardown) shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
@@ -157,10 +157,52 @@ gwt() {
 }
 
 # ============================================================================
-# Worktree list — formatted output with column headers and remove hint
+# Internal: detect an orphaned worktree (parent repo deleted out from under it).
+# Returns 0 and echoes the broken admin-dir path when $PWD/.git is a regular
+# file whose `gitdir:` pointer leads to a missing directory. Returns 1 on a
+# healthy worktree, a main repo (.git is a directory), or a non-git pwd.
+# ============================================================================
+_gwt_diagnose_orphan() {
+    [ -f .git ] || return 1
+    local pointer
+    pointer=$(awk '/^gitdir:/ {sub(/^gitdir:[[:space:]]*/, ""); print; exit}' .git 2>/dev/null)
+    [ -n "$pointer" ] || return 1
+    [ -d "$pointer" ] && return 1
+    printf '%s\n' "$pointer"
+}
+
+# ============================================================================
+# Internal: emit the right "no git here" diagnostic. Bare error for a true
+# non-git pwd; actionable recovery for an orphaned worktree (.git pointer
+# leads to a deleted admin dir — issue #282). Always returns 1 so callers can
+# `_gwt_report_no_git; return 1` to propagate.
+# ============================================================================
+_gwt_report_no_git() {
+    local broken
+    if broken=$(_gwt_diagnose_orphan); then
+        ux_error "Worktree's parent repo is gone — .git points to: $broken"
+        ux_info "  This worktree was created from a repo that has since been deleted."
+        ux_info "  Recover from outside this directory:"
+        ux_bullet "rm -rf \"$(pwd)\""
+        ux_bullet "Then in any other repo that registered this worktree: gwt prune"
+    else
+        ux_error "Not inside a git repository"
+    fi
+    return 1
+}
+
+# ============================================================================
+# Worktree list — formatted output with column headers and remove hint.
+# Adds a health probe (issue #282) that flags worktrees whose .git pointer is
+# broken or points outside this repo's admin dir — catches the orphan-after-
+# parent-delete case where `git worktree list` itself shows nothing wrong.
 # Usage: git_worktree_list
 # ============================================================================
 git_worktree_list() {
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
     local wt_output
     wt_output="$(git worktree list)"
 
@@ -173,10 +215,110 @@ git_worktree_list() {
         printf '%s\n' "$wt_output"
     } | column -t
 
+    # Resolve this repo's admin dir so the foreign-repo check has a baseline.
+    local git_common
+    git_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+    if [ -n "$git_common" ]; then
+        case "$git_common" in
+            /*) ;;
+            *) git_common="$(cd "$git_common" 2>/dev/null && pwd)" ;;
+        esac
+        git_common="${git_common%/}"
+    fi
+
+    local warn_lines="" warn_count=0
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                local wt_path="${line#worktree }"
+                local note=""
+                if [ ! -d "$wt_path" ]; then
+                    note="path missing on disk"
+                elif [ -f "$wt_path/.git" ]; then
+                    local pointer
+                    pointer="$(awk '/^gitdir:/ {sub(/^gitdir:[[:space:]]*/, ""); print; exit}' "$wt_path/.git" 2>/dev/null)"
+                    if [ -n "$pointer" ]; then
+                        if [ ! -d "$pointer" ]; then
+                            note=".git -> $pointer (admin dir missing)"
+                        elif [ -n "$git_common" ]; then
+                            case "$pointer" in
+                                "$git_common"/worktrees/*) ;;
+                                *) note=".git -> $pointer (foreign repo)" ;;
+                            esac
+                        fi
+                    fi
+                fi
+                if [ -n "$note" ]; then
+                    warn_count=$((warn_count + 1))
+                    warn_lines="${warn_lines}  ${wt_path}  [!] ${note}
+"
+                fi
+                ;;
+        esac
+    done <<EOF
+$(git worktree list --porcelain 2>/dev/null)
+EOF
+
+    if [ "$warn_count" -gt 0 ]; then
+        echo
+        ux_warning "$warn_count orphan/broken worktree ref(s):"
+        printf '%s' "$warn_lines"
+        ux_info "  Recover: rm -rf <path> && gwt prune"
+    fi
+
     if [ "$wt_count" -gt 1 ]; then
         echo
         ux_info "To remove: gwt remove [path]"
     fi
+}
+
+# ============================================================================
+# Worktree prune — UX wrapper over `git worktree prune`. Rejects positional
+# args (git's prune takes only flags), surfacing a friendly hint instead of
+# raw `usage: git worktree prune ...` (issue #282).
+# Usage: git_worktree_prune [-n|--dry-run] [-v|--verbose] [--expire <when>]
+# ============================================================================
+git_worktree_prune() {
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local expecting_expire_value=false
+    for arg do
+        if [ "$expecting_expire_value" = true ]; then
+            expecting_expire_value=false
+            continue
+        fi
+        case "$arg" in
+            -h|--help)
+                ux_header "gwt prune - remove stale worktree refs"
+                ux_info "Usage: gwt prune [-n|--dry-run] [-v|--verbose] [--expire <when>]"
+                ux_info "  Removes .git/worktrees/<name>/ entries whose path is missing."
+                ux_info "  Does NOT take a path argument."
+                ux_info "  Targeted removal:"
+                ux_bullet "gwt remove <path>      # remove a specific worktree"
+                ux_bullet "gwt teardown           # remove the worktree you're inside"
+                return 0
+                ;;
+            -n|--dry-run|-v|--verbose) ;;
+            --expire) expecting_expire_value=true ;;
+            --expire=*) ;;
+            -*)
+                ux_error "Unknown option for 'gwt prune': $arg"
+                ux_info "Run: gwt prune --help"
+                return 1
+                ;;
+            *)
+                ux_error "'gwt prune' does not accept a path argument: $arg"
+                ux_info "Did you mean:"
+                ux_bullet "gwt remove \"$arg\"        # remove a specific worktree"
+                ux_bullet "gwt prune                # prune stale refs (no path)"
+                return 1
+                ;;
+        esac
+    done
+
+    git worktree prune "$@"
 }
 
 # ============================================================================
@@ -559,7 +701,8 @@ git_worktree_spawn() {
     # Must be inside a git repo, NOT a worktree
     local git_common git_dir
     git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
-        ux_error "Not inside a git repository"; return 1
+        _gwt_report_no_git
+        return 1
     }
     git_dir="$(git rev-parse --git-dir)"
     if [ "$git_dir" != "$git_common" ]; then
@@ -804,7 +947,7 @@ git_worktree_teardown() {
                 # so we can tailor the error guidance to the mistake actually made.
                 local _gwt_common _gwt_dir _gwt_in_wt=false _gwt_loc
                 _gwt_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
-                    ux_error "Not inside a git repository"
+                    _gwt_report_no_git
                     return 1
                 }
                 _gwt_dir="$(git rev-parse --git-dir 2>/dev/null)"
@@ -846,7 +989,8 @@ git_worktree_teardown() {
     # Must be inside a worktree
     local git_common git_dir
     git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
-        ux_error "Not inside a git repository"; return 1
+        _gwt_report_no_git
+        return 1
     }
     git_dir="$(git rev-parse --git-dir)"
     if [ "$git_dir" = "$git_common" ]; then
@@ -899,7 +1043,8 @@ _gwt_teardown_one_inplace() {
 
     local git_common git_dir
     git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
-        ux_error "Not inside a git repository"; return 1
+        _gwt_report_no_git
+        return 1
     }
     git_dir="$(git rev-parse --git-dir)"
     if [ "$git_dir" = "$git_common" ]; then
@@ -1170,7 +1315,7 @@ _gwt_teardown_all() {
     # line-start; library_purity_check tracks brace depth via `^\s*\}` and
     # would otherwise treat this as the enclosing function's close, falsely
     # flagging the `read -r` below as top-level interactive code.
-    git rev-parse --git-common-dir >/dev/null 2>&1 || { ux_error "Not inside a git repository"; return 1; }
+    git rev-parse --git-common-dir >/dev/null 2>&1 || { _gwt_report_no_git; return 1; }
 
     # Resolve main worktree and collect non-main worktrees from a single
     # `git worktree list --porcelain` snapshot — one fork instead of two,

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -157,15 +157,25 @@ gwt() {
 }
 
 # ============================================================================
+# Internal: read a worktree's gitdir pointer (.git file). Echoes the bare
+# path on stdout if the file exists and contains a `gitdir:` line; returns 1
+# otherwise. Centralized so callers don't re-invent the parser per PR #284
+# review feedback.
+# ============================================================================
+_gwt_read_gitdir_pointer() {
+    [ -f "$1" ] || return 1
+    sed -n 's/^gitdir:[[:space:]]*//p' "$1"
+}
+
+# ============================================================================
 # Internal: detect an orphaned worktree (parent repo deleted out from under it).
 # Returns 0 and echoes the broken admin-dir path when $PWD/.git is a regular
 # file whose `gitdir:` pointer leads to a missing directory. Returns 1 on a
 # healthy worktree, a main repo (.git is a directory), or a non-git pwd.
 # ============================================================================
 _gwt_diagnose_orphan() {
-    [ -f .git ] || return 1
     local pointer
-    pointer=$(awk '/^gitdir:/ {sub(/^gitdir:[[:space:]]*/, ""); print; exit}' .git 2>/dev/null)
+    pointer=$(_gwt_read_gitdir_pointer .git) || return 1
     [ -n "$pointer" ] || return 1
     [ -d "$pointer" ] && return 1
     printf '%s\n' "$pointer"
@@ -236,7 +246,7 @@ git_worktree_list() {
                     note="path missing on disk"
                 elif [ -f "$wt_path/.git" ]; then
                     local pointer
-                    pointer="$(awk '/^gitdir:/ {sub(/^gitdir:[[:space:]]*/, ""); print; exit}' "$wt_path/.git" 2>/dev/null)"
+                    pointer=$(_gwt_read_gitdir_pointer "$wt_path/.git")
                     if [ -n "$pointer" ]; then
                         if [ ! -d "$pointer" ]; then
                             note=".git -> $pointer (admin dir missing)"

--- a/tests/bats/functions/git_worktree_orphan.bats
+++ b/tests/bats/functions/git_worktree_orphan.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_worktree_orphan.bats
+# Issue #282: orphan-worktree recovery UX
+#
+# Covers:
+#   - `gwt teardown` from inside an orphaned worktree (parent repo deleted)
+#     surfaces a recovery hint instead of bare "Not inside a git repository".
+#   - `gwt prune <path>` rejects with a friendly hint instead of git's raw
+#     `usage: git worktree prune` error.
+#   - `gwt ls` flags worktrees whose `.git` pointer leads outside the active
+#     repo's admin dir or to a missing admin dir.
+
+load '../test_helper'
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# A standard origin <- clone <- worktree triple, used by prune-passthrough tests
+# that just need a healthy git environment.
+_setup_fake_repo() {
+    ORIGIN="$TEST_TEMP_HOME/origin.git"
+    CLONE="$TEST_TEMP_HOME/clone"
+    WORKTREE="$TEST_TEMP_HOME/clone-test-1"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init --bare --initial-branch=main "$ORIGIN" >/dev/null
+    git clone -q "$ORIGIN" "$CLONE"
+    (
+        cd "$CLONE"
+        echo base > base.txt
+        git add base.txt
+        git commit -q -m "base"
+        git push -q origin main
+    )
+    git -C "$CLONE" worktree add -q -b wt/test/1 "$WORKTREE" origin/main
+}
+
+# Same as above, but then deletes the clone's .git so the worktree's `.git`
+# pointer now leads to a missing admin dir — exactly the situation the user
+# hit in #282 after their parent repo was removed.
+_setup_orphan_worktree() {
+    _setup_fake_repo
+    rm -rf "$CLONE/.git"
+}
+
+# A repo with a worktree whose `.git` pointer has been forged to point at a
+# non-existent path. From the active repo's POV, `git worktree list` shows it
+# fine; the on-disk `.git` is the broken half. Used to exercise gwt ls's
+# health probe.
+_setup_foreign_pointer_worktree() {
+    REPO="$TEST_TEMP_HOME/repo"
+    WT_FOREIGN="$TEST_TEMP_HOME/repo-foreign-1"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init -q --initial-branch=main "$REPO"
+    (
+        cd "$REPO"
+        echo base > base.txt
+        git add base.txt
+        git commit -q -m "base"
+    )
+    git -C "$REPO" worktree add -q -b wt/foreign/1 "$WT_FOREIGN" main
+
+    printf 'gitdir: %s/missing\n' "$TEST_TEMP_HOME" > "$WT_FOREIGN/.git"
+}
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Bug #1: orphan-worktree teardown
+# ---------------------------------------------------------------------------
+
+@test "teardown: orphan worktree (parent repo gone) shows recovery hint" {
+    _setup_orphan_worktree
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_failure
+    # Specific diagnostic mentions the broken pointer
+    assert_output --partial "parent repo is gone"
+    assert_output --partial ".git points to"
+    # Recovery instructions name the orphan path
+    assert_output --partial "$WORKTREE"
+    assert_output --partial "rm -rf"
+    assert_output --partial "gwt prune"
+    # The bare/legacy message should NOT be the only thing shown
+    refute_output --partial "❌ Not inside a git repository"
+}
+
+@test "teardown --all: orphan cwd shows recovery hint, not bare error" {
+    _setup_orphan_worktree
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --all --force 2>&1"
+    assert_failure
+    assert_output --partial "parent repo is gone"
+    refute_output --partial "❌ Not inside a git repository"
+}
+
+@test "teardown: truly non-git pwd still gets the bare error" {
+    # A plain temp dir with no .git anything is not an orphan worktree.
+    # Make sure the helper falls through to the standard message.
+    NON_GIT="$TEST_TEMP_HOME/not-a-repo"
+    mkdir -p "$NON_GIT"
+
+    run_in_bash "cd '$NON_GIT' && gwt teardown 2>&1"
+    assert_failure
+    assert_output --partial "Not inside a git repository"
+    refute_output --partial "parent repo is gone"
+}
+
+# ---------------------------------------------------------------------------
+# Bug #2: gwt prune argument validation
+# ---------------------------------------------------------------------------
+
+@test "prune: rejects path argument with friendly hint" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt prune /some/path 2>&1"
+    assert_failure
+    assert_output --partial "does not accept a path argument"
+    assert_output --partial "/some/path"
+    assert_output --partial "gwt remove"
+    # Must not fall through to git's raw usage line
+    refute_output --partial "usage: git worktree prune"
+}
+
+@test "prune: --help shows usage with no-path warning" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt prune --help 2>&1"
+    assert_success
+    assert_output --partial "gwt prune"
+    assert_output --partial "Does NOT take a path argument"
+}
+
+@test "prune: rejects unknown flag with hint to --help" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt prune --bogus 2>&1"
+    assert_failure
+    assert_output --partial "Unknown option"
+    assert_output --partial "gwt prune --help"
+}
+
+@test "prune: bare invocation still works (no args)" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt prune 2>&1"
+    assert_success
+}
+
+@test "prune: -v passthrough to git worktree prune" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt prune -v 2>&1"
+    assert_success
+}
+
+@test "prune: --expire <when> two-arg form passes through" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt prune --expire 1.day.ago 2>&1"
+    assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Bug #3: gwt ls health probe
+# ---------------------------------------------------------------------------
+
+@test "list: flags worktree with missing admin dir" {
+    _setup_foreign_pointer_worktree
+
+    run_in_bash "cd '$REPO' && gwt ls 2>&1"
+    assert_success
+    assert_output --partial "$WT_FOREIGN"
+    assert_output --partial "orphan/broken worktree"
+    assert_output --partial "admin dir missing"
+}
+
+@test "list: healthy worktree triggers no warning" {
+    _setup_fake_repo
+
+    run_in_bash "cd '$CLONE' && gwt ls 2>&1"
+    assert_success
+    refute_output --partial "orphan/broken worktree"
+    refute_output --partial "admin dir missing"
+}
+
+@test "list: missing-on-disk worktree path is flagged" {
+    _setup_fake_repo
+    # Remove only the worktree's working tree, leave the admin entry behind.
+    rm -rf "$WORKTREE"
+
+    run_in_bash "cd '$CLONE' && gwt ls 2>&1"
+    assert_success
+    assert_output --partial "path missing on disk"
+    assert_output --partial "$WORKTREE"
+}


### PR DESCRIPTION
## Summary

`gwt` (issue #282) had three rough edges around the recovery flow when a worktree's parent repo is deleted out from under it. This PR fixes all three with one helper pair + two function rewrites + 12 bats tests.

- **#1 — orphan teardown**: `gwt teardown` from inside a dangling worktree gave a bare "Not inside a git repository". Now detects the broken `.git` pointer (via new `_gwt_diagnose_orphan` / `_gwt_report_no_git` helpers) and emits the actual recovery recipe. Applied at all 5 sites that previously bare-errored.
- **#2 — prune passthrough**: `gwt prune <path>` fell through to git's raw `usage:` line. New `git_worktree_prune` validates args, rejects positional paths with a hint to `gwt remove`, adds `--help`. Pure passthrough still works for `-n`, `-v`, `--expire <when>`.
- **#3 — orphan in `ls`**: `gwt ls` reported orphans as healthy. `git_worktree_list` now probes each entry's `.git` pointer and warns when it's missing, points to a deleted admin dir, or points to a foreign repo (the dual-registration case from the original report).

## Test plan

- [x] `tests/bats/functions/git_worktree_orphan.bats` — 12 new cases covering all three fixes plus the non-regression "truly non-git pwd still gets the bare error" path
- [x] Full bats suite (297) green — no regressions in `git_worktree_teardown.bats`, `git_worktree_spawn.bats`, `git.bats`
- [x] Golden rules (5/5) pass
- [x] Manual smoke: orphan teardown, `gwt prune /some/path`, `gwt ls` against a forged-pointer worktree

Closes #282

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
