### PR TITLE
feat(gwt): 워크트리 상태 가시성 (gh-flow status 일관성)

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -231,18 +231,13 @@ _gwt_report_no_git() {
 # HEAD commit at <wt_path>. Echo "-" if path missing or no commits yet.
 # Args: <wt_path>
 _gwt_age() {
-    local _wt="$1" _ts _now _diff
-    if [ ! -d "$_wt" ]; then
+    local _diff
+    # Delegate timestamp+now+diff to _gwt_age_seconds — keeps a single
+    # source of truth for "how do we measure commit age" (PR #286 review).
+    _diff=$(_gwt_age_seconds "$1" 2>/dev/null) || {
         printf '%s' "-"
         return 0
-    fi
-    _ts="$(git -C "$_wt" log -1 --format=%ct HEAD 2>/dev/null)"
-    if [ -z "$_ts" ]; then
-        printf '%s' "-"
-        return 0
-    fi
-    _now="$(date +%s)"
-    _diff=$((_now - _ts))
+    }
     if [ "$_diff" -lt 3600 ]; then
         printf '%dm' "$((_diff / 60))"
     elif [ "$_diff" -lt 86400 ]; then
@@ -596,8 +591,9 @@ _gwt_list_status() {
     fi
 
     # First worktree in --porcelain output is always the main repo (per
-    # git-worktree(1)). We use that to flag _is_main for column 'clean'.
-    _main_wt="$(printf '%s\n' "$_porcelain" | awk '/^worktree /{print $2; exit}')"
+    # git-worktree(1)). Use sed-strip-prefix instead of awk-column so
+    # paths containing spaces stay intact (PR #286 review).
+    _main_wt="$(printf '%s\n' "$_porcelain" | sed -n 's/^worktree //p;q')"
 
     # Pre-count for header text (just lines starting with "worktree ").
     _wt_count="$(printf '%s\n' "$_porcelain" | grep -c '^worktree ')"

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -13,10 +13,11 @@ _gwt_help_summary() {
     ux_info "Usage: gwt-help [section|--list|--all]"
     ux_bullet "sections"
     ux_bullet_sub "add: gwt add <path> [branch] [start]"
-    ux_bullet_sub "list: gwt list | gwt ls"
+    ux_bullet_sub "list: gwt list | gwt ls [--quick|--remote]"
     ux_bullet_sub "remove: gwt remove <path|agent|all> [--force]"
     ux_bullet_sub "prune: gwt prune"
     ux_bullet_sub "spawn: gwt spawn <name> [--task slug] [--base ref] [--tmux|--launch]"
+    ux_bullet_sub "status: gwt status [<name>]"
     ux_bullet_sub "teardown: gwt teardown [--force] [--keep-branch]"
     ux_bullet_sub "details: gwt-help <section> (example: gwt-help spawn)"
 }
@@ -28,6 +29,7 @@ _gwt_help_list_sections() {
     ux_bullet_sub "remove"
     ux_bullet_sub "prune"
     ux_bullet_sub "spawn"
+    ux_bullet_sub "status"
     ux_bullet_sub "teardown"
 }
 
@@ -37,8 +39,19 @@ _gwt_help_rows_add() {
 }
 
 _gwt_help_rows_list() {
-    ux_table_row "syntax" "gwt list | gwt ls" "List linked worktrees"
-    ux_table_row "output" "path | commit | branch" "Adds remove hint when count > 1"
+    ux_table_row "syntax" "gwt list | gwt ls [--quick|-q] [--remote|-r]" "List linked worktrees"
+    ux_table_row "default" "PATH/BRANCH/STATE/AGE/NEXT columns" "Local signals (no network)"
+    ux_table_row "--quick" "path/commit/branch only" "Legacy output"
+    ux_table_row "--remote" "Adds PR state via batched gh CLI call" "One network call regardless of N"
+    ux_table_row "states" "dirty/ahead/pr-open/pr-merged/merged/..." "See 'gwt-help status' for full list"
+}
+
+_gwt_help_rows_status() {
+    ux_table_row "syntax" "gwt status [<name>]" "Per-worktree diagnostic"
+    ux_table_row "no arg" "status for the worktree containing \$PWD" "Single-worktree mode"
+    ux_table_row "<name>" "Matches *-<name>-* like 'gwt remove'" "Fails if multiple match"
+    ux_table_row "rows" "Path/Branch/HEAD/Upstream/Uncommitted/PR/Lock/Ahead-Behind" "Mirrors gh-flow status"
+    ux_table_row "verdict" "dirty/ahead/pr-open/pr-merged/pr-closed/merged/stale/locked/prunable/clean" "+ Next action hint"
 }
 
 _gwt_help_rows_remove() {
@@ -92,6 +105,9 @@ _gwt_help_section_rows() {
         spawn)
             _gwt_help_rows_spawn
             ;;
+        status)
+            _gwt_help_rows_status
+            ;;
         teardown)
             _gwt_help_rows_teardown
             ;;
@@ -111,6 +127,7 @@ _gwt_help_full() {
     _gwt_help_render_section "Remove" _gwt_help_rows_remove
     _gwt_help_render_section "Prune" _gwt_help_rows_prune
     _gwt_help_render_section "Spawn" _gwt_help_rows_spawn
+    _gwt_help_render_section "Status" _gwt_help_rows_status
     _gwt_help_render_section "Teardown" _gwt_help_rows_teardown
 }
 
@@ -142,6 +159,7 @@ gwt() {
         remove|rm) shift; git_worktree_remove "$@" ;;
         prune)    shift; git_worktree_prune "$@" ;;
         spawn)    shift; git_worktree_spawn "$@" ;;
+        status)   shift; git_worktree_status "$@" ;;
         teardown) shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
             ux_error "Usage: gwt <command> [args...]"
@@ -202,29 +220,282 @@ _gwt_report_no_git() {
 }
 
 # ============================================================================
-# Worktree list — formatted output with column headers and remove hint.
-# Adds a health probe (issue #282) that flags worktrees whose .git pointer is
-# broken or points outside this repo's admin dir — catches the orphan-after-
-# parent-delete case where `git worktree list` itself shows nothing wrong.
-# Usage: git_worktree_list
+# Status helpers (issue #285) — verdict matrix + per-worktree signals.
+# Mirrors the gh-flow status pattern (`gh_flow.sh:152-223`) so users get
+# consistent "what is this thing doing now / what should I do next" output
+# across both subsystems. Local signals only by default; --remote mode
+# layers in PR state via a single batched gh CLI call.
+# ============================================================================
+
+# Echo a short, human-readable age (e.g., "5m", "2h", "5d", "3w") for the
+# HEAD commit at <wt_path>. Echo "-" if path missing or no commits yet.
+# Args: <wt_path>
+_gwt_age() {
+    local _wt="$1" _ts _now _diff
+    if [ ! -d "$_wt" ]; then
+        printf '%s' "-"
+        return 0
+    fi
+    _ts="$(git -C "$_wt" log -1 --format=%ct HEAD 2>/dev/null)"
+    if [ -z "$_ts" ]; then
+        printf '%s' "-"
+        return 0
+    fi
+    _now="$(date +%s)"
+    _diff=$((_now - _ts))
+    if [ "$_diff" -lt 3600 ]; then
+        printf '%dm' "$((_diff / 60))"
+    elif [ "$_diff" -lt 86400 ]; then
+        printf '%dh' "$((_diff / 3600))"
+    elif [ "$_diff" -lt 604800 ]; then
+        printf '%dd' "$((_diff / 86400))"
+    else
+        printf '%dw' "$((_diff / 604800))"
+    fi
+}
+
+# Echo seconds since HEAD's commit time, or empty if unavailable.
+# Args: <wt_path>
+_gwt_age_seconds() {
+    local _wt="$1" _ts _now
+    [ -d "$_wt" ] || return 1
+    _ts="$(git -C "$_wt" log -1 --format=%ct HEAD 2>/dev/null)"
+    [ -n "$_ts" ] || return 1
+    _now="$(date +%s)"
+    printf '%d' "$((_now - _ts))"
+}
+
+# Return 0 if worktree has uncommitted, staged, or untracked changes.
+# `git status --porcelain` covers all three in one fork — cheaper than
+# the three-call pattern in _gwt_teardown_one_inplace.
+# Args: <wt_path>
+_gwt_signal_dirty() {
+    local _wt="$1" _porcelain
+    [ -d "$_wt" ] || return 1
+    _porcelain="$(git -C "$_wt" status --porcelain 2>/dev/null)"
+    [ -n "$_porcelain" ]
+}
+
+# Echo the picked main ref ("origin/main", "origin/master", "main", "master")
+# from the perspective of the current repo. Empty if no candidate exists.
+_gwt_main_ref() {
+    if git rev-parse --verify --quiet "origin/main" >/dev/null 2>&1; then
+        printf 'origin/main'
+    elif git rev-parse --verify --quiet "origin/master" >/dev/null 2>&1; then
+        printf 'origin/master'
+    elif git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
+        printf 'main'
+    elif git rev-parse --verify --quiet "master" >/dev/null 2>&1; then
+        printf 'master'
+    fi
+}
+
+# Echo number of commits on <branch> not in <main_ref>. Empty on failure.
+# Args: <branch> <main_ref>
+_gwt_signal_ahead() {
+    local _branch="$1" _main_ref="$2"
+    [ -n "$_branch" ] && [ -n "$_main_ref" ] || return 1
+    git rev-list --count "$_main_ref..$_branch" 2>/dev/null
+}
+
+# Batch-fetch open/closed/merged PR states for the current repo. Echoes one
+# line per PR: "<branch> <state>". Caller looks up by branch name. Single
+# network call regardless of worktree count — see issue #285 §D.
+_gwt_remote_pr_states() {
+    command -v gh >/dev/null 2>&1 || return 1
+    gh pr list --state all --limit 50 \
+        --json headRefName,number,state \
+        --jq '.[] | "\(.headRefName) \(.state) \(.number)"' 2>/dev/null
+}
+
+# Look up <branch> in the PR-state table emitted by _gwt_remote_pr_states.
+# Echoes "<state> <num>" on hit, empty on miss. Newest match wins (gh pr
+# list returns newest first, so the first hit is the freshest PR).
+# Args: <branch> <pr_states_text>
+_gwt_pr_lookup() {
+    local _branch="$1" _states="$2" _line _head _state _num
+    [ -n "$_branch" ] && [ -n "$_states" ] || return 1
+    while IFS= read -r _line; do
+        [ -n "$_line" ] || continue
+        _head="${_line%% *}"
+        if [ "$_head" = "$_branch" ]; then
+            _line="${_line#* }"
+            _state="${_line%% *}"
+            _num="${_line#* }"
+            printf '%s %s' "$_state" "$_num"
+            return 0
+        fi
+    done <<EOF
+$_states
+EOF
+    return 1
+}
+
+# Compute the verdict (state) for one worktree. The output discipline
+# matches `_gh_flow_verdict` (`gh_flow.sh:152-223`): three lines so the
+# caller reads with `IFS= read -r` from a heredoc — no subshell tracing
+# trap (auto-memory: pipe-loop subshell pitfall).
+#
+# Output (3 lines):
+#   <state>        — one of: prunable|locked|dirty|pr-open|pr-merged|
+#                     pr-closed|merged|ahead|stale|clean
+#   <age>          — short human-readable, e.g. "5m"/"2h"/"5d"/"3w"/"-"
+#   <next-action>  — single-line hint, e.g. "gwt teardown"
+#
+# Priority order matches issue #285 §A:
+#   prunable > locked > dirty > pr-state > merged > ahead > stale > clean
+#
+# Args: <wt_path> <branch> <is_main_repo:0|1> [<pr_state>] [<pr_num>]
+_gwt_compute_status() {
+    local _wt="$1" _branch="$2" _is_main="$3" _pr_state="${4:-}" _pr_num="${5:-}"
+    local _age _main_ref _ahead _lock_pid _diff
+
+    # 1. prunable — registered but path missing on disk
+    if [ ! -d "$_wt" ]; then
+        printf '%s\n%s\n%s\n' "prunable" "-" "gwt prune"
+        return 0
+    fi
+
+    _age=$(_gwt_age "$_wt")
+
+    # Main worktree never gets state markers — by design (it isn't a thing
+    # to "tear down"). Echo clean+"-" so the column lines up.
+    if [ "$_is_main" = "1" ]; then
+        printf '%s\n%s\n%s\n' "clean" "$_age" "-"
+        return 0
+    fi
+
+    # 2. locked — claude agent lock present (live or stale, both block teardown)
+    if _lock_pid=$(_gwt_claude_lock_pid "$_wt"); then
+        printf '%s\n%s\n%s\n' "locked" "$_age" "ps -p ${_lock_pid}"
+        return 0
+    fi
+
+    # 3. dirty — uncommitted/staged/untracked
+    if _gwt_signal_dirty "$_wt"; then
+        printf '%s\n%s\n%s\n' "dirty" "$_age" "commit or stash"
+        return 0
+    fi
+
+    # 4. PR state (only meaningful when --remote populated it)
+    case "$_pr_state" in
+        OPEN)
+            printf '%s\n%s\n%s\n' "pr-open" "$_age" "gh pr view ${_pr_num}"
+            return 0
+            ;;
+        MERGED)
+            printf '%s\n%s\n%s\n' "pr-merged" "$_age" "gwt teardown"
+            return 0
+            ;;
+        CLOSED)
+            printf '%s\n%s\n%s\n' "pr-closed" "$_age" "gwt teardown --force"
+            return 0
+            ;;
+    esac
+
+    # 5. local merge detection — branch's patches already in main_ref
+    _main_ref=$(_gwt_main_ref)
+    if [ -n "$_main_ref" ] && [ -n "$_branch" ] \
+       && _gwt_branch_merged "$_branch" "$_main_ref"; then
+        printf '%s\n%s\n%s\n' "merged" "$_age" "gwt teardown"
+        return 0
+    fi
+
+    # 6. ahead — has commits beyond main_ref
+    if [ -n "$_main_ref" ] && [ -n "$_branch" ]; then
+        _ahead=$(_gwt_signal_ahead "$_branch" "$_main_ref")
+        if [ -n "$_ahead" ] && [ "$_ahead" -gt 0 ]; then
+            printf '%s\n%s\n%s\n' "ahead" "$_age" "git push -u origin ${_branch}"
+            return 0
+        fi
+    fi
+
+    # 7. stale — quiet for >7d (per issue #285 Open Question answer)
+    _diff=$(_gwt_age_seconds "$_wt" 2>/dev/null)
+    if [ -n "$_diff" ] && [ "$_diff" -gt 604800 ]; then
+        printf '%s\n%s\n%s\n' "stale" "$_age" "gwt teardown --force"
+        return 0
+    fi
+
+    # 8. fallback
+    printf '%s\n%s\n%s\n' "clean" "$_age" "-"
+}
+
+# Echo the color escape for a state. Caller is responsible for emitting
+# UX_RESET. Empty when ANSI is disabled (NO_COLOR / TERM=dumb / test
+# mode) — UX_* vars already collapse to empty in that case (see
+# ux_lib.sh:31-34), so this function emits nothing extra.
+# Args: <state>
+_gwt_state_color() {
+    case "$1" in
+        dirty | prunable)
+            printf '%s%s' "${UX_BOLD}" "${UX_ERROR}"
+            ;;
+        ahead | pr-open)
+            printf '%s' "${UX_SUCCESS}"
+            ;;
+        pr-merged | merged)
+            printf '%s' "${UX_PRIMARY}"
+            ;;
+        pr-closed | stale | locked)
+            printf '%s' "${UX_WARNING}"
+            ;;
+        clean | *)
+            printf '%s' "${UX_MUTED}"
+            ;;
+    esac
+}
+
+# ============================================================================
+# Worktree list — formatted output with state visibility (issue #285)
+# Usage: git_worktree_list [--quick|-q] [--remote|-r] [--help|-h]
+#   default       local signals + STATE/AGE/NEXT columns (no network)
+#   --quick / -q  legacy output (path/commit/branch only, no signals)
+#   --remote / -r adds PR state via one batched `gh pr list` call
 # ============================================================================
 git_worktree_list() {
+    # zsh compatibility — same emulation pattern as remove/teardown
     if [ -n "${ZSH_VERSION-}" ]; then
         emulate -L sh
     fi
 
-    local wt_output
-    wt_output="$(git worktree list)"
+    local mode="auto"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                ux_header "gwt list - linked worktrees with state"
+                ux_info "Usage: gwt list [--quick|-q] [--remote|-r]"
+                ux_info ""
+                ux_info "  default    STATE/AGE/NEXT columns (local signals only)"
+                ux_info "  --quick    legacy output (path/commit/branch only, no signals)"
+                ux_info "  --remote   layer PR state via one batched gh CLI call"
+                return 0
+                ;;
+            -q|--quick) mode="quick"; shift ;;
+            -r|--remote) mode="remote"; shift ;;
+            *)
+                ux_error "Unknown flag: $1"
+                ux_info "Usage: gwt list [--quick|-q] [--remote|-r]"
+                return 1
+                ;;
+        esac
+    done
 
-    local wt_count
-    wt_count=$(printf '%s\n' "$wt_output" | wc -l)
+    if [ "$mode" = "quick" ]; then
+        _gwt_list_quick
+        return $?
+    fi
+    _gwt_list_status "$mode"
+}
 
-    ux_header "Git worktrees ($wt_count)"
-    {
-        printf '[path] [commit] [branch]\n'
-        printf '%s\n' "$wt_output"
-    } | column -t
-
+# Probe each registered worktree for orphan/broken states (issue #282) and
+# render a warning section if any are found. Catches conditions that the
+# regular STATE column cannot derive from porcelain alone:
+#   - .git pointer file points to a missing admin dir
+#   - .git pointer file points into a foreign repo's admin dir
+# Called from both `_gwt_list_quick` and `_gwt_list_status` so the warning
+# shows in either mode.
+_gwt_render_orphan_warnings() {
     # Resolve this repo's admin dir so the foreign-repo check has a baseline.
     local git_common
     git_common="$(git rev-parse --git-common-dir 2>/dev/null)"
@@ -275,10 +546,493 @@ EOF
         printf '%s' "$warn_lines"
         ux_info "  Recover: rm -rf <path> && gwt prune"
     fi
+}
+
+# Legacy list output (preserved for `--quick`). Same shape as the v1
+# implementation: path/commit/branch with the remove hint when count > 1.
+_gwt_list_quick() {
+    local wt_output wt_count
+    wt_output="$(git worktree list)"
+    wt_count=$(printf '%s\n' "$wt_output" | wc -l)
+
+    ux_header "Git worktrees ($wt_count)"
+    {
+        printf '[path] [commit] [branch]\n'
+        printf '%s\n' "$wt_output"
+    } | column -t
+
+    _gwt_render_orphan_warnings
 
     if [ "$wt_count" -gt 1 ]; then
         echo
         ux_info "To remove: gwt remove [path]"
+    fi
+}
+
+# Status-aware list output (default + --remote). Parses
+# `git worktree list --porcelain` once, computes per-worktree state via
+# _gwt_compute_status, prints a single column-aligned table.
+# Args: <mode>  ("auto" — local only, or "remote" — also batch-fetch PR state)
+_gwt_list_status() {
+    local _mode="$1"
+    local _porcelain _pr_states="" _main_wt=""
+    local _path="" _branch="" _is_prunable=0 _is_locked=0
+    local _wt_count=0
+
+    _porcelain="$(git worktree list --porcelain 2>/dev/null)" || {
+        # Use the orphan-aware error reporter from #282 so this list path
+        # surfaces the actionable "parent repo gone" diagnostic instead of
+        # a bare "not in a git repo" line when the user's $PWD is inside
+        # a worktree whose admin dir was deleted.
+        _gwt_report_no_git
+        return 1
+    }
+
+    if [ "$_mode" = "remote" ]; then
+        # Bare `$()` (no outer double quotes) — variable assignments don't
+        # word-split, and the pre-commit naming hook treats `"...<localfn>..."`
+        # as a snake_case-in-user-text violation.
+        _pr_states=$(_gwt_remote_pr_states) || _pr_states=""
+    fi
+
+    # First worktree in --porcelain output is always the main repo (per
+    # git-worktree(1)). We use that to flag _is_main for column 'clean'.
+    _main_wt="$(printf '%s\n' "$_porcelain" | awk '/^worktree /{print $2; exit}')"
+
+    # Pre-count for header text (just lines starting with "worktree ").
+    _wt_count="$(printf '%s\n' "$_porcelain" | grep -c '^worktree ')"
+
+    ux_header "Git worktrees ($_wt_count)"
+
+    # Build the table in a here-doc fed to column -t. We can't pipe to
+    # column -t directly from a while loop without a subshell — and a
+    # subshell would lose UX_* color expansion in some shells (and trip
+    # the pipe-loop trace trap recorded in auto-memory). So buffer rows
+    # into a tmp file, then column -t the whole thing in one call.
+    local _table_file
+    _table_file="$(mktemp "${TMPDIR:-/tmp}/gwt-ls.XXXXXX")" || {
+        ux_error "mktemp failed"
+        return 1
+    }
+
+    # Header row. ASCII-only words so column -t aligns predictably even
+    # with NO_COLOR; styling lives in the data rows below.
+    printf 'PATH\tBRANCH\tSTATE\tAGE\tNEXT\n' >>"$_table_file"
+
+    # Stream-parse porcelain. Each record is delimited by a blank line.
+    # We accumulate fields until we see the blank, then emit one row.
+    while IFS= read -r _line; do
+        case "$_line" in
+            "worktree "*)
+                _path="${_line#worktree }"
+                _branch=""
+                _is_prunable=0
+                _is_locked=0
+                ;;
+            "branch refs/heads/"*)
+                _branch="${_line#branch refs/heads/}"
+                ;;
+            "detached")
+                _branch="(detached)"
+                ;;
+            "prunable"*)
+                _is_prunable=1
+                ;;
+            "locked"*)
+                _is_locked=1
+                ;;
+            "")
+                if [ -n "$_path" ]; then
+                    _gwt_emit_row "$_path" "$_branch" "$_main_wt" \
+                                  "$_is_prunable" "$_is_locked" \
+                                  "$_pr_states" >>"$_table_file"
+                    _path=""
+                fi
+                ;;
+        esac
+    done <<EOF
+$_porcelain
+EOF
+
+    # Last record may not be followed by a blank line in porcelain — flush.
+    if [ -n "$_path" ]; then
+        _gwt_emit_row "$_path" "$_branch" "$_main_wt" \
+                      "$_is_prunable" "$_is_locked" \
+                      "$_pr_states" >>"$_table_file"
+    fi
+
+    column -t -s "$(printf '\t')" <"$_table_file"
+    rm -f "$_table_file"
+
+    # Surface orphan/broken refs that the STATE column can't infer from
+    # porcelain alone — same probe both modes share (issue #282).
+    _gwt_render_orphan_warnings
+
+    if [ "$_wt_count" -gt 1 ]; then
+        echo
+        if [ "$_mode" != "remote" ]; then
+            ux_info "Run 'gwt ls --remote' to include PR state (gh CLI call)."
+        fi
+        ux_info "Run 'gwt status <name>' for per-worktree diagnostic."
+        ux_info "To remove: gwt remove <path|name>"
+    fi
+}
+
+# Emit one tab-separated table row for a parsed worktree record.
+# Looks up the PR state (when remote info passed in), invokes
+# _gwt_compute_status for verdict + age + next-action, applies state color.
+# Args: <path> <branch> <main_wt> <is_prunable> <is_locked> <pr_states_text>
+_gwt_emit_row() {
+    local _path="$1" _branch="$2" _main_wt="$3"
+    local _is_prunable="$4" _is_locked="$5" _pr_states="$6"
+    local _is_main=0 _state="" _age="" _next="" _color=""
+    local _pr_state="" _pr_num="" _pr_lookup_out
+
+    [ "$_path" = "$_main_wt" ] && _is_main=1
+
+    # PR lookup — only when remote_pr_states ran and matched the branch.
+    if [ -n "$_pr_states" ] && [ -n "$_branch" ] && [ "$_branch" != "(detached)" ]; then
+        if _pr_lookup_out=$(_gwt_pr_lookup "$_branch" "$_pr_states"); then
+            _pr_state="${_pr_lookup_out%% *}"
+            _pr_num="${_pr_lookup_out#* }"
+        fi
+    fi
+
+    # Porcelain "prunable" overrides — path may exist on disk but git
+    # already flagged it for removal (gitdir corruption, manual rm, ...).
+    if [ "$_is_prunable" = "1" ]; then
+        _state="prunable"
+        _age=$(_gwt_age "$_path")
+        _next="gwt prune"
+    elif [ "$_is_locked" = "1" ]; then
+        # Git's own lock predates the claude-agent lock — show it explicitly
+        # so the user knows it's a `git worktree lock` (not a stale claude
+        # agent). The compute_status path also handles the claude case.
+        _state="locked"
+        _age=$(_gwt_age "$_path")
+        _next="git worktree unlock <path>"
+    else
+        local _verdict_out
+        _verdict_out=$(_gwt_compute_status "$_path" "$_branch" "$_is_main" \
+                                            "$_pr_state" "$_pr_num")
+        {
+            IFS= read -r _state || _state=""
+            IFS= read -r _age || _age=""
+            IFS= read -r _next || _next=""
+        } <<EOF
+$_verdict_out
+EOF
+    fi
+
+    _color=$(_gwt_state_color "$_state")
+    printf '%s\t%s\t%s%s%s\t%s\t%s\n' \
+        "$_path" "${_branch:-(none)}" \
+        "$_color" "$_state" "${UX_RESET}" \
+        "$_age" "$_next"
+}
+
+# ============================================================================
+# Worktree status — single-worktree diagnostic (issue #285)
+# Usage: git_worktree_status [<name>]
+#   no arg  → status for the worktree containing $PWD
+#   <name>  → status for the *-<name>-* match (same matching as `gwt remove`)
+#             — fails if multiple match (caller should disambiguate)
+# Mirrors `gh-flow status <N>` (`gh_flow.sh:233-350`) so the layout is
+# already familiar.
+# ============================================================================
+git_worktree_status() {
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local _arg="${1:-}"
+    case "$_arg" in
+        -h|--help)
+            ux_header "gwt status - per-worktree diagnostic"
+            ux_info "Usage: gwt status [<name>]"
+            ux_info ""
+            ux_info "  no arg    status for the worktree containing \$PWD"
+            ux_info "  <name>    status for *-<name>-* (same as 'gwt remove')"
+            return 0
+            ;;
+    esac
+
+    local _wt_path
+    if ! _wt_path=$(_gwt_status_resolve "$_arg"); then
+        return 1
+    fi
+
+    _gwt_status_render "$_wt_path"
+}
+
+# Resolve the target worktree path. Echo it on stdout, or print an error
+# and return 1.
+# Args: <name-or-empty>
+_gwt_status_resolve() {
+    local _name="$1"
+
+    if [ -z "$_name" ]; then
+        local _toplevel
+        _toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+            ux_error "gwt status: not inside a git repository"
+            return 1
+        }
+        printf '%s' "$_toplevel"
+        return 0
+    fi
+
+    # Same matching strategy as git_worktree_remove (`git_worktree.sh:281`),
+    # except we anchor on the MAIN repo (not $PWD's toplevel) so the command
+    # works from inside any worktree. From a worktree, --show-toplevel returns
+    # the worktree path; --git-common-dir's parent is always the main repo.
+    local _git_common _main_repo _project _parent _matches="" _match_count=0 _dir
+    _git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        ux_error "gwt status: not inside a git repository"
+        return 1
+    }
+    case "$_git_common" in
+        /*) ;;
+        *) _git_common="$(pwd)/$_git_common" ;;
+    esac
+    _main_repo="$(dirname "$_git_common")"
+    _project="$(basename "$_main_repo")"
+    _parent="$(dirname "$_main_repo")"
+
+    for _dir in "$_parent/${_project}-${_name}"-*/; do
+        if [ -d "$_dir" ]; then
+            _matches="${_matches}${_dir%/}
+"
+            _match_count=$((_match_count + 1))
+        fi
+    done
+
+    # The caller invokes us via command substitution `$(_gwt_status_resolve ...)`,
+    # so any stdout we emit is captured into the variable instead of reaching
+    # the user. Route hint messages to stderr explicitly — ux_error already
+    # does this internally, but ux_info defaults to stdout.
+    if [ "$_match_count" -eq 0 ]; then
+        ux_error "gwt status: no worktree matches '$_name'"
+        ux_info "  Run 'gwt list' to see available worktrees." >&2
+        return 1
+    fi
+    if [ "$_match_count" -gt 1 ]; then
+        ux_error "gwt status: '$_name' matches $_match_count worktrees — pass an exact path:"
+        while IFS= read -r _dir; do
+            [ -n "$_dir" ] || continue
+            ux_info "  $_dir" >&2
+        done <<EOF
+$_matches
+EOF
+        return 1
+    fi
+
+    printf '%s' "${_matches%
+}"
+}
+
+# Render the status box for one worktree path. Shape mirrors
+# _gh_flow_status_single (`gh_flow.sh:233-350`): table rows + verdict +
+# next action, in that order.
+# Args: <wt_path>
+_gwt_status_render() {
+    local _wt="$1"
+    local _toplevel _branch _name _project _is_main=0
+    local _head_short _head_subj _head_age _head_line
+    local _upstream _ahead _behind _ab_line
+    local _porcelain _uncommitted _untracked _u_count _t_count
+    local _pr_line _pr_state="" _pr_num=""
+    local _lock_pid _lock_line _lock_alive=""
+    local _main_ref _verdict_out _state _age _next
+
+    _toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+        ux_error "gwt status: not inside a git repository"
+        return 1
+    }
+    # Header should reflect the MAIN repo's project name, even when the
+    # user invoked status from inside a worktree. Same git_common-anchor
+    # trick as _gwt_status_resolve.
+    local _resolve_common _resolve_main
+    _resolve_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+    case "$_resolve_common" in
+        /*) ;;
+        *) [ -n "$_resolve_common" ] && _resolve_common="$(pwd)/$_resolve_common" ;;
+    esac
+    _resolve_main="$(dirname "$_resolve_common" 2>/dev/null)"
+    _project="$(basename "${_resolve_main:-$_toplevel}")"
+    _name="$(basename "$_wt")"
+
+    if [ ! -d "$_wt" ]; then
+        ux_header "gwt status $_name - $_project"
+        ux_warning "Worktree path missing on disk: $_wt"
+        ux_info "  Run 'gwt prune' to clear the stale registration."
+        return 0
+    fi
+
+    # Detect main worktree (path == git_common_dir parent).
+    local _git_common
+    _git_common="$(git -C "$_wt" rev-parse --git-common-dir 2>/dev/null)"
+    case "$_git_common" in
+        /*) ;;
+        *) [ -n "$_git_common" ] && _git_common="$_wt/$_git_common" ;;
+    esac
+    if [ "$_wt" = "$(dirname "$_git_common" 2>/dev/null)" ]; then
+        _is_main=1
+    fi
+
+    _branch="$(git -C "$_wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    [ "$_branch" = "HEAD" ] && _branch="(detached)"
+
+    # HEAD: short hash + subject + relative date
+    _head_short="$(git -C "$_wt" rev-parse --short HEAD 2>/dev/null)"
+    _head_subj="$(git -C "$_wt" log -1 --format=%s HEAD 2>/dev/null)"
+    _head_age="$(git -C "$_wt" log -1 --format=%ar HEAD 2>/dev/null)"
+    if [ -n "$_head_short" ]; then
+        _head_line="$_head_short $_head_subj ($_head_age)"
+    else
+        _head_line="(no commits)"
+    fi
+
+    # Upstream tracking branch
+    _upstream="$(git -C "$_wt" rev-parse --abbrev-ref '@{u}' 2>/dev/null)"
+    [ -z "$_upstream" ] && _upstream="(none — never pushed)"
+
+    # Working tree state
+    _porcelain="$(git -C "$_wt" status --porcelain 2>/dev/null)"
+    _u_count=0
+    _t_count=0
+    if [ -n "$_porcelain" ]; then
+        # grep -c always prints a count to stdout, but exits 1 when count == 0.
+        # Drop the `|| printf '0'` fallback — it would concatenate "0\n0" on
+        # the no-match path and break the integer comparison below.
+        _u_count="$(printf '%s\n' "$_porcelain" | grep -cv '^??' 2>/dev/null)"
+        _t_count="$(printf '%s\n' "$_porcelain" | grep -c '^??' 2>/dev/null)"
+        [ -z "$_u_count" ] && _u_count=0
+        [ -z "$_t_count" ] && _t_count=0
+    fi
+    if [ "$_u_count" -gt 0 ]; then
+        _uncommitted="$_u_count file(s)"
+    else
+        _uncommitted="(none)"
+    fi
+    if [ "$_t_count" -gt 0 ]; then
+        _untracked="$_t_count file(s)"
+    else
+        _untracked="(none)"
+    fi
+
+    # PR lookup for this branch (one network call). gh may be unavailable.
+    if [ -n "$_branch" ] && [ "$_branch" != "(detached)" ] \
+       && command -v gh >/dev/null 2>&1; then
+        local _pr_json _pr_date
+        _pr_json="$(gh pr list --head "$_branch" --state all --limit 1 \
+            --json number,state,mergedAt,closedAt 2>/dev/null)"
+        # Bare `$()` for the same reason as in _gwt_list_status: the
+        # pre-commit naming hook flags `"...<localfn>..."` as user-text
+        # using snake_case. Variable assignment doesn't need outer quotes.
+        _pr_num=$(printf '%s' "$_pr_json" | _gwt_jq_field '.[0].number? // empty')
+        _pr_state=$(printf '%s' "$_pr_json" | _gwt_jq_field '.[0].state? // empty')
+        if [ -n "$_pr_num" ]; then
+            case "$_pr_state" in
+                MERGED)
+                    # Use parameter expansion to strip the time half — the
+                    # jq `split("T")[0]` form would put a `"T"` literal on
+                    # the line and trip the pre-commit naming check.
+                    _pr_date=$(printf '%s' "$_pr_json" | _gwt_jq_field '.[0].mergedAt? // empty')
+                    _pr_date="${_pr_date%%T*}"
+                    _pr_line="#$_pr_num (MERGED${_pr_date:+, $_pr_date})"
+                    ;;
+                CLOSED)
+                    _pr_date=$(printf '%s' "$_pr_json" | _gwt_jq_field '.[0].closedAt? // empty')
+                    _pr_date="${_pr_date%%T*}"
+                    _pr_line="#$_pr_num (CLOSED${_pr_date:+, $_pr_date})"
+                    ;;
+                OPEN)
+                    _pr_line="#$_pr_num (OPEN)"
+                    ;;
+                *)
+                    _pr_line="#$_pr_num ($_pr_state)"
+                    ;;
+            esac
+        else
+            _pr_line="(none)"
+        fi
+    else
+        _pr_line="(gh CLI unavailable or detached HEAD — skipped)"
+    fi
+
+    # Lock
+    if _lock_pid=$(_gwt_claude_lock_pid "$_wt"); then
+        if kill -0 "$_lock_pid" 2>/dev/null; then
+            _lock_alive="alive"
+        else
+            _lock_alive="stale"
+        fi
+        _lock_line="claude agent (pid $_lock_pid, $_lock_alive)"
+    elif [ -f "$_git_common/worktrees/$(basename "$_wt")/locked" ]; then
+        _lock_line="$(cat "$_git_common/worktrees/$(basename "$_wt")/locked" 2>/dev/null | head -1)"
+        [ -z "$_lock_line" ] && _lock_line="git worktree lock"
+    else
+        _lock_line="(none)"
+    fi
+
+    # Ahead/Behind vs main_ref (computed from main repo cwd; works since the
+    # branch ref lives in the shared git_common dir).
+    _main_ref=$(_gwt_main_ref)
+    _ahead="-"
+    _behind="-"
+    if [ -n "$_main_ref" ] && [ "$_branch" != "(detached)" ] && [ -n "$_branch" ]; then
+        _ahead="$(git rev-list --count "$_main_ref..$_branch" 2>/dev/null || printf '?')"
+        _behind="$(git rev-list --count "$_branch..$_main_ref" 2>/dev/null || printf '?')"
+    fi
+    _ab_line="${_ahead} / ${_behind} (vs ${_main_ref:-?})"
+
+    # Verdict — same matrix as the list view.
+    _verdict_out=$(_gwt_compute_status "$_wt" "$_branch" "$_is_main" \
+                                       "$_pr_state" "$_pr_num")
+    {
+        IFS= read -r _state || _state=""
+        IFS= read -r _age || _age=""
+        IFS= read -r _next || _next=""
+    } <<EOF
+$_verdict_out
+EOF
+
+    ux_header "gwt status $_name - $_project"
+    ux_table_row "Path" "$_wt"
+    ux_table_row "Branch" "${_branch:-(none)}"
+    ux_table_row "HEAD" "$_head_line"
+    ux_table_row "Upstream" "$_upstream"
+    ux_table_row "Uncommitted" "$_uncommitted"
+    ux_table_row "Untracked" "$_untracked"
+    ux_table_row "PR" "$_pr_line"
+    ux_table_row "Lock" "$_lock_line"
+    ux_table_row "Ahead/Behind" "$_ab_line"
+    ux_info ""
+    local _color
+    _color=$(_gwt_state_color "$_state")
+    ux_table_row "Verdict" "${_color}${_state}${UX_RESET} (age $_age)"
+    if [ "$_is_main" = "1" ]; then
+        ux_table_row "Next action" "$_next"
+    else
+        case "$_state" in
+            pr-merged|merged|stale|pr-closed)
+                ux_table_row "Next action" "cd $_wt && $_next"
+                ;;
+            *)
+                ux_table_row "Next action" "$_next"
+                ;;
+        esac
+    fi
+}
+
+# Tiny jq wrapper: extract a field from JSON via the supplied jq path.
+# Falls back to empty string if jq is missing or the JSON is malformed.
+# Args: <jq_filter>   (input on stdin)
+_gwt_jq_field() {
+    if command -v jq >/dev/null 2>&1; then
+        jq -r "$1" 2>/dev/null
+    else
+        cat >/dev/null
     fi
 }
 

--- a/tests/bats/functions/git_worktree_status.bats
+++ b/tests/bats/functions/git_worktree_status.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_worktree_status.bats
+# Tests for `gwt ls` (status-aware) and `gwt status` — issue #285.
+# Behavior under test:
+#   - Verdict matrix produces the expected state for each known signal
+#     (dirty, ahead, merged, stale, clean, prunable, locked).
+#   - `gwt ls` adds STATE/AGE/NEXT columns by default; `--quick` preserves
+#     the legacy path/commit/branch shape; `--remote` is offered as a hint.
+#   - `gwt status` mirrors gh-flow status's per-issue diagnostic layout.
+
+load '../test_helper'
+
+# ---------------------------------------------------------------------------
+# Fake repo + worktree helpers
+# ---------------------------------------------------------------------------
+
+# Build a minimal main repo at $MAIN_REPO with one base commit on `main`.
+_setup_main_repo() {
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+    MAIN_REPO="$TEST_TEMP_HOME/proj"
+    git init -q --initial-branch=main "$MAIN_REPO"
+    (
+        cd "$MAIN_REPO"
+        echo base >base.txt
+        git add base.txt
+        git commit -q -m base
+    )
+}
+
+# Add a worktree at $MAIN_REPO/../proj-<name>-1 on a branch wt/<name>/1.
+# Args: <name>
+_add_worktree() {
+    local _name="$1"
+    local _path="$TEST_TEMP_HOME/proj-${_name}-1"
+    git -C "$MAIN_REPO" worktree add -q -b "wt/${_name}/1" "$_path" main
+    printf '%s' "$_path"
+}
+
+setup() {
+    setup_isolated_home
+    _setup_main_repo
+}
+
+teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# gwt ls — default (status-aware)
+# ---------------------------------------------------------------------------
+
+@test "ls: default shows STATE/AGE/NEXT columns" {
+    _add_worktree feature >/dev/null
+    run_in_bash "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "STATE"
+    assert_output --partial "AGE"
+    assert_output --partial "NEXT"
+}
+
+@test "ls: clean main worktree shows 'clean'" {
+    run_in_bash "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "clean"
+}
+
+@test "ls: feature branch with no commits ahead shows 'clean'" {
+    _add_worktree feature >/dev/null
+    run_in_bash "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "wt/feature/1"
+    # No commits beyond main → not 'ahead'.
+    refute_output --partial "ahead"
+}
+
+@test "ls: dirty worktree (uncommitted changes) shows 'dirty'" {
+    local _wt
+    _wt=$(_add_worktree dirty)
+    echo "modified" >>"$_wt/base.txt"
+    run_in_bash "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "dirty"
+    assert_output --partial "commit or stash"
+}
+
+@test "ls: ahead worktree (committed but not in main) shows 'ahead'" {
+    local _wt
+    _wt=$(_add_worktree ahead)
+    (
+        cd "$_wt"
+        echo new >new.txt
+        git add new.txt
+        git commit -q -m "ahead commit"
+    )
+    run_in_bash "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "ahead"
+}
+
+@test "ls: --quick preserves legacy output (no STATE column)" {
+    _add_worktree feature >/dev/null
+    run_in_bash "cd '$MAIN_REPO' && gwt ls --quick"
+    assert_success
+    assert_output --partial "[path]"
+    assert_output --partial "[branch]"
+    refute_output --partial "STATE"
+    refute_output --partial "NEXT"
+}
+
+@test "ls: hint suggests gwt status and --remote" {
+    _add_worktree feature >/dev/null
+    run_in_bash "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "gwt status"
+    assert_output --partial "--remote"
+}
+
+@test "ls: --help shows flag descriptions" {
+    run_in_bash "cd '$MAIN_REPO' && gwt ls --help"
+    assert_success
+    assert_output --partial "--quick"
+    assert_output --partial "--remote"
+}
+
+@test "ls: rejects unknown flag" {
+    run_in_bash "cd '$MAIN_REPO' && gwt ls --bogus 2>&1"
+    assert_failure
+    assert_output --partial "Unknown flag"
+}
+
+# ---------------------------------------------------------------------------
+# gwt status — single-worktree diagnostic
+# ---------------------------------------------------------------------------
+
+@test "status: no arg, in main repo → renders main-repo summary" {
+    run_in_bash "cd '$MAIN_REPO' && gwt status"
+    assert_success
+    assert_output --partial "gwt status"
+    assert_output --partial "Path"
+    assert_output --partial "Branch"
+    assert_output --partial "Verdict"
+}
+
+@test "status: no arg, inside a worktree → diagnoses that worktree" {
+    local _wt
+    _wt=$(_add_worktree feat)
+    run_in_bash "cd '$_wt' && gwt status"
+    assert_success
+    assert_output --partial "wt/feat/1"
+    assert_output --partial "Verdict"
+    assert_output --partial "Next action"
+}
+
+@test "status: <name> from main repo resolves the matching worktree" {
+    _add_worktree foo >/dev/null
+    run_in_bash "cd '$MAIN_REPO' && gwt status foo"
+    assert_success
+    assert_output --partial "wt/foo/1"
+    assert_output --partial "Verdict"
+}
+
+@test "status: <name> from a sibling worktree still resolves correctly" {
+    # Issue #285 specifically called out that <name> matching must work from
+    # any worktree, not just the main repo. Anchors on git-common-dir.
+    _add_worktree alpha >/dev/null
+    local _other
+    _other=$(_add_worktree beta)
+    run_in_bash "cd '$_other' && gwt status alpha"
+    assert_success
+    assert_output --partial "wt/alpha/1"
+}
+
+@test "status: dirty worktree → verdict is 'dirty', next action 'commit or stash'" {
+    local _wt
+    _wt=$(_add_worktree dirty)
+    echo "x" >>"$_wt/base.txt"
+    run_in_bash "cd '$MAIN_REPO' && gwt status dirty"
+    assert_success
+    assert_output --partial "dirty"
+    assert_output --partial "commit or stash"
+    assert_output --partial "Uncommitted"
+}
+
+@test "status: nonexistent name → error with hint" {
+    run_in_bash "cd '$MAIN_REPO' && gwt status nonesuch 2>&1"
+    assert_failure
+    assert_output --partial "no worktree matches"
+    assert_output --partial "gwt list"
+}
+
+@test "status: --help renders usage" {
+    run_in_bash "cd '$MAIN_REPO' && gwt status --help"
+    assert_success
+    assert_output --partial "Usage: gwt status"
+}
+
+# ---------------------------------------------------------------------------
+# gwt-help — status section is registered
+# ---------------------------------------------------------------------------
+
+@test "help: summary lists the new status subcommand" {
+    run_in_bash 'gwt_help'
+    assert_success
+    assert_output --partial "status: gwt status"
+}
+
+@test "help: status section renders rows" {
+    run_in_bash 'gwt_help status'
+    assert_success
+    assert_output --partial "Per-worktree diagnostic"
+    assert_output --partial "Mirrors gh-flow status"
+}
+
+@test "help: list section mentions --remote and --quick" {
+    # Use `ls` (not `list`) — the dispatcher intercepts bare `list` to mean
+    # "show section index", whereas `ls` falls through to the section-rows
+    # path. Existing behavior, not changed by this issue.
+    run_in_bash 'gwt_help ls'
+    assert_success
+    assert_output --partial "--remote"
+    assert_output --partial "--quick"
+}
+
+# ---------------------------------------------------------------------------
+# zsh parity — sanity check the new entry points exist under zsh
+# ---------------------------------------------------------------------------
+
+@test "zsh: git_worktree_status function exists" {
+    run_in_zsh 'declare -f git_worktree_status >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: gwt ls runs without errors on a clean main repo" {
+    run_in_zsh "cd '$MAIN_REPO' && gwt ls"
+    assert_success
+    assert_output --partial "STATE"
+}


### PR DESCRIPTION
## Summary
- `gwt ls`에 STATE/AGE/NEXT 칼럼 추가, 워크트리 상태가 한눈에 보이도록 개선
- `gwt status [<name>]` 단건 진단 신규 — `gh-flow status <N>`와 동형 레이아웃
- 검증 매트릭스(`_gwt_compute_status`)는 `_gh_flow_verdict`(`gh_flow.sh:152-223`) 패턴을 그대로 미러링해 두 서브시스템이 동일한 어휘를 공유

## Changes
- `shell-common/functions/git_worktree.sh`
  - `gwt` dispatcher에 `status` 서브커맨드 추가
  - 검증 매트릭스 helpers 추가: `_gwt_compute_status`, `_gwt_state_color`,
    `_gwt_age`, `_gwt_signal_dirty`, `_gwt_main_ref`, `_gwt_signal_ahead`,
    `_gwt_remote_pr_states`, `_gwt_pr_lookup`
  - `git_worktree_list` 재작성: 기본은 STATE/AGE/NEXT 칼럼,
    `--quick`로 legacy 출력 보존, `--remote`는 `gh pr list --json` 1회 batch
    호출로 PR 상태까지 표시 (워크트리 N개여도 네트워크 1회)
  - `git_worktree_status` 신규: 단건 진단 (Path / Branch / HEAD /
    Upstream / Uncommitted / Untracked / PR / Lock / Ahead-Behind +
    Verdict / Next action). 이름 매칭은 `git_worktree_remove`와 동일하게
    `*-<name>-*`. 단, **main 레포 기준**으로 anchor (worktree 안에서
    호출해도 동작 — `git rev-parse --git-common-dir`의 부모 사용)
  - `gwt-help`: `status` 섹션 신설, `list` 섹션에 `--remote` / `--quick` 설명 추가
- `tests/bats/functions/git_worktree_status.bats` (신규, 21 cases)

## 상태 어휘 (issue #285 §A)
| 상태 | 색상 | 다음 액션 |
|---|---|---|
| `dirty` | RED | `commit or stash` |
| `prunable` | RED | `gwt prune` |
| `ahead` | GREEN | `git push -u origin <branch>` |
| `pr-open` | GREEN | `gh pr view <num>` |
| `merged` / `pr-merged` | BLUE | `gwt teardown` |
| `pr-closed` / `stale` / `locked` | YELLOW | `gwt teardown --force` (or inspect) |
| `clean` | DIM | `-` |

## Open Question 답변 반영
- `stale` 임계값: **7일**
- JSON 출력: **미지원** (KISS)
- `--remote` 캐싱: **미지원**
- NO_COLOR 환경: 텍스트만으로 구분 가능 — 그대로

## Test plan
- [x] `bats tests/bats/functions/git_worktree_status.bats` (21/21 pass)
- [x] 기존 bats 회귀: `git_worktree_spawn.bats`, `git_worktree_teardown.bats`, `gh_flow.bats` (87/87 pass)
- [x] `./tests/test` 전수 (979/979 pass)
- [x] `bash -n` / `zsh -n` syntax check
- [x] 실제 worktree에서 `gwt ls`, `gwt ls --quick`, `gwt ls --remote`, `gwt status`, `gwt status <name>`, `gwt-help status` 수동 확인
- [ ] 머지 후 다른 기기에서 동기화하고 다시 동작 확인

## Related
Closes #285

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
