### PR TITLE
feat(gh-pr-approve): warn on merge conflict instead of stopping

### DIFF
--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -43,8 +43,10 @@ Fetch in parallel before reading the diff:
 - Prior reviews/comments on this PR by `ME`.
 - `gh pr checks <N> --repo $TARGET_REPO`.
 
-Stop on `state != OPEN`, draft, merge conflicts, or required-check
-failure. If `author.login == ME`, follow `references/self-pr-handling.md`.
+Stop on `state != OPEN`, draft, or required-check failure. Warn (but
+do not stop) on `mergeable: CONFLICTING` — prepend a visible conflict
+warning block to the review body and include it in the Step 5 report.
+If `author.login == ME`, follow `references/self-pr-handling.md`.
 If prior `ME` comments/reviews exist, use re-review mode: every prior
 concern must be verified as fixed, tracked, or acceptably declined.
 
@@ -81,8 +83,9 @@ Match the PR's dominant language.
 
 Re-fetch `reviewDecision` + `mergeStateStatus`; for `--admin-merge`, also
 re-fetch `state` and `mergeCommit`. Report status, blocker/follow-up
-counts, issue links, merge state, and PR URL. For `--self-record`, confirm
-`reviewDecision` did not become `APPROVED`.
+counts, issue links, merge state, and PR URL. If the PR had
+`mergeable: CONFLICTING`, include the conflict warning in the report.
+For `--self-record`, confirm `reviewDecision` did not become `APPROVED`.
 
 ## Constraints
 

--- a/claude/skills/gh-pr-approve/references/help.md
+++ b/claude/skills/gh-pr-approve/references/help.md
@@ -27,7 +27,8 @@
 ## What the skill does
 
 1. Pre-flight gate — checks PR state, draft, author, merge conflicts, required CI.
-   Stops early on any blocker (can't approve a draft, conflicting PR, failing checks, etc.).
+   Stops on draft, closed PR, or required-check failure. Warns (but continues) on merge
+   conflicts — the conflict warning is prepended to the review body.
 2. Fetches diff, commits, and all three comment endpoints (inline / issue / review).
 3. Reviews against `references/review-criteria.md` — correctness, conventions, security,
    performance, tests. If you previously reviewed this PR, enters re-review mode and

--- a/claude/skills/gh-pr-approve/references/help.md
+++ b/claude/skills/gh-pr-approve/references/help.md
@@ -27,8 +27,8 @@
 ## What the skill does
 
 1. Pre-flight gate — checks PR state, draft, author, merge conflicts, required CI.
-   Stops on draft, closed PR, or required-check failure. Warns (but continues) on merge
-   conflicts — the conflict warning is prepended to the review body.
+   Stops on non-open PR (closed or merged), draft, or required-check failure. Warns (but continues) on merge
+   conflicts — the warning is prepended to the review body and included in the final report.
 2. Fetches diff, commits, and all three comment endpoints (inline / issue / review).
 3. Reviews against `references/review-criteria.md` — correctness, conventions, security,
    performance, tests. If you previously reviewed this PR, enters re-review mode and


### PR DESCRIPTION
## Summary
- `mergeable: CONFLICTING` PR에서 리뷰를 즉시 중단하지 않고 경고 후 진행
- 충돌 경고를 리뷰 본문 상단에 삽입하고 Step 5 리포트에도 포함
- `references/help.md` pre-flight gate 설명 업데이트

## Changes
- `claude/skills/gh-pr-approve/SKILL.md`: Step 1 pre-flight gate에서 merge conflict를 stop 조건에서 제외. `mergeable: CONFLICTING` 시 warn-but-continue로 변경하고 review body에 경고 블록 삽입 명시
- `claude/skills/gh-pr-approve/references/help.md`: pre-flight gate 설명을 새 동작에 맞게 업데이트

## Test plan
- [ ] bats 테스트 52개 전부 pass 확인 (`bats tests/bats/functions/gh_pr_approve.bats`)
- [ ] CONFLICTING PR에서 /gh-pr-approve 실행 시 경고만 출력하고 리뷰 진행되는지 확인 (manual)

## Related
Closes #288


---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->
