### PR TITLE
fix(claude): point statusLine.command at dotfiles SSOT (#296)

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -35,11 +35,14 @@ Edit `claude/settings.json` to match your personal environment:
    }
    ```
 
-3. **Status Line** - Configure how Claude Code displays status information
+3. **Status Line** - Configure how Claude Code displays status information.
+   The dotfiles SSOT path works across all multi-account `CLAUDE_CONFIG_DIR`
+   targets (e.g. `~/.claude-personal`, `~/.claude-work`) without depending on
+   per-account symlinks. See issue #296.
    ```json
    "statusLine": {
      "type": "command",
-     "command": "${HOME}/.claude/statusline-command.sh"
+     "command": "${HOME}/dotfiles/claude/statusline-command.sh"
    }
    ```
 

--- a/claude/settings.template.json
+++ b/claude/settings.template.json
@@ -40,7 +40,7 @@
   "model": "haiku",
   "statusLine": {
     "type": "command",
-    "command": "${HOME}/.claude/statusline-command.sh"
+    "command": "${HOME}/dotfiles/claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "document-skills@anthropic-agent-skills": true,

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -436,3 +436,34 @@ _setup_sh_prereqs() {
     assert_success
     assert_output --partial "already"
 }
+
+# ---------- Regression: issue #296 ----------
+#
+# After PR #292 (multi-account migration), `~/.claude/` becomes a guard
+# directory and `~/.claude/statusline-command.sh` no longer exists. The
+# template previously hardcoded that legacy path, causing statusline to
+# silently fail under `CLAUDE_CONFIG_DIR=~/.claude-personal`.
+# Fix: settings.template.json points at the dotfiles SSOT path, which is
+# reachable from every account's CONFIG_DIR via $HOME.
+
+@test "regression #296: statusLine.command in account settings.json resolves to executable" {
+    _setup_sh_prereqs
+
+    # Make $HOME/dotfiles resolve to the worktree so the template's
+    # ${HOME}/dotfiles/... path is reachable inside the isolated $HOME.
+    ln -s "${DOTFILES_ROOT}" "$HOME/dotfiles"
+
+    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
+    assert_success
+
+    for cdir in "$HOME/.claude-personal" "$HOME/.claude-work"; do
+        cmd=$(jq -r '.statusLine.command' < "$cdir/settings.json")
+
+        # The legacy ~/.claude/ path is the regression we are guarding against.
+        [ "$cmd" != '${HOME}/.claude/statusline-command.sh' ]
+
+        # Expand ${HOME} the same way Claude Code does and verify exec bit.
+        expanded=${cmd//\$\{HOME\}/$HOME}
+        [ -x "$expanded" ]
+    done
+}


### PR DESCRIPTION
## Summary
- multi-account 마이그레이션 후 statusline 이 사라지던 버그 수정 (#296).
- `settings.template.json` 의 `statusLine.command` 를 dotfiles SSOT 경로로 전환.
- bats 회귀 테스트로 모든 활성 계정에서 path → executable 보증.

## Background
PR #292 multi-account migration 이후 `~/.claude/` 는 빈 가드 디렉토리가 되고 실제 계정 데이터는 `~/.claude-personal/`, `~/.claude-work/` 로 이동했다. 그러나 `settings.template.json` 의 `statusLine.command` 가 `${HOME}/.claude/statusline-command.sh` (없는 경로) 로 하드코딩돼 있어, `claude-yolo` / `claude-yolo --user work` 실행 시 statusline 이 silent fail.

이슈에서 권장한 Option A (dotfiles SSOT 경로) 채택 — symlink 의존성 없이 모든 `CLAUDE_CONFIG_DIR` 에서 동일하게 동작.

## Changes
- `claude/settings.template.json`: `${HOME}/.claude/statusline-command.sh` → `${HOME}/dotfiles/claude/statusline-command.sh`.
- `claude/README.md`: 예시 동일하게 업데이트 + multi-account context 한 줄 추가 (#296 참조).
- `tests/bats/integrations/claude_accounts.bats`: regression #296 테스트 추가 — `setup.sh` 실행 후 `~/.claude-personal`, `~/.claude-work` 양쪽 `settings.json` 에서 `statusLine.command` 를 jq 로 추출, `${HOME}` 확장 후 `-x` 검증. legacy `~/.claude/...` 문자열도 함께 거부.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/integrations/claude_accounts.bats` — 46 passed (기존 45 + 신규 1)
- [x] `markdownlint claude/README.md` — clean
- [ ] (수동) `cp claude/settings.template.json claude/settings.json` 후 `claude-yolo` 실행 → 입력창 위 statusline 줄 출력 확인
- [ ] (수동) `claude-yolo --user work` 도 동일하게 statusline 출력 확인

## Notes for users
`claude/settings.json` 은 gitignored (개인 설정) — 이미 로컬 사본을 가진 사용자는 본인 파일의 `statusLine.command` 도 동일하게 수정하거나, 템플릿에서 다시 복사해야 한다.

## Related
Closes #296
Refs PR #292 (multi-account Phase 1)
Refs #293 (수동 검증 절차)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->