### PR TITLE
fix(claude-accounts): preserve .claude.json across migrate

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -468,7 +468,53 @@ claude_yolo() {
         esac
     fi
 
+    # Pre-launch .claude.json integrity guard (issue #294).
+    # See _claude_restore_if_reset for the heuristic and rationale.
+    _claude_restore_if_reset "$_cy_config_dir"
+
     CLAUDE_CONFIG_DIR="$_cy_config_dir" command claude --dangerously-skip-permissions "$@"
+}
+
+# _claude_restore_if_reset — auto-restore .claude.json from sealed snapshot
+# when it has been reset to the "first-start placeholder" state (issue #294).
+#
+# Trigger requires ALL of:
+#   1. live .claude.json exists and is < 500 bytes (healthy file is 10-100 KB)
+#   2. live file contains `firstStartTime` but neither `oauthAccount` nor
+#      `migrationVersion` (positive evidence of reset state, not a partial
+#      write or unrelated tiny file)
+#   3. .claude.json.preserved-by-migrate snapshot exists in same dir
+#
+# Rationale: Claude CLI sometimes rewrites .claude.json to just
+# `{"firstStartTime":"..."}` on first run with a previously-unseen
+# CLAUDE_CONFIG_DIR, wiping the oauth + migration cache. Since the bug is
+# upstream, we can't prevent the rewrite — but we restore before the next
+# launch, so the user never sees the "configuration file not found" prompt.
+#
+# Bypass: delete the snapshot file (`rm <dir>/.claude.json.preserved-by-migrate`)
+# to opt out — useful if the user intentionally reset their config.
+_claude_restore_if_reset() {
+    _crir_dir="$1"
+    _crir_live="$_crir_dir/.claude.json"
+    _crir_snap="$_crir_dir/.claude.json.preserved-by-migrate"
+
+    [ -f "$_crir_live" ] || return 0
+    [ -f "$_crir_snap" ] || return 0
+
+    _crir_size=$(wc -c < "$_crir_live" 2>/dev/null | tr -d ' ')
+    [ -n "$_crir_size" ] || return 0
+    [ "$_crir_size" -lt 500 ] || return 0
+
+    grep -q 'firstStartTime' "$_crir_live" 2>/dev/null || return 0
+    grep -q 'oauthAccount\|migrationVersion' "$_crir_live" 2>/dev/null && return 0
+
+    ux_warning "Detected reset .claude.json (${_crir_size}B, no oauth/migration cache)"
+    ux_info    "  → restoring from sealed migrate snapshot: $_crir_snap"
+    if cp "$_crir_snap" "$_crir_live" 2>/dev/null; then
+        ux_success "  Restored $_crir_live ($(wc -c < "$_crir_live" | tr -d ' ') bytes)"
+    else
+        ux_error "  Restore failed — proceeding anyway (claude may prompt for re-login)"
+    fi
 }
 alias claude-yolo='claude_yolo'
 
@@ -697,6 +743,21 @@ claude_accounts_migrate() {
         return 0
     fi
 
+    # Diagnostic: capture .claude.json size BEFORE the mv (issue #294).
+    # If the file is already in the "first-start placeholder" state at this
+    # point, the regression is upstream of migrate (bad shutdown, prior
+    # corruption) — and the post-mv size check below will match.
+    _cam_pre_size=""
+    if [ -f "$HOME/.claude/.claude.json" ]; then
+        _cam_pre_size=$(wc -c < "$HOME/.claude/.claude.json" 2>/dev/null | tr -d ' ')
+        ux_info "Pre-migrate ~/.claude/.claude.json size: ${_cam_pre_size:-?} bytes"
+        if [ -n "$_cam_pre_size" ] && [ "$_cam_pre_size" -lt 500 ]; then
+            ux_warning "  .claude.json is suspiciously small (< 500B) — already in"
+            ux_warning "  first-start placeholder state. Migration will preserve it"
+            ux_warning "  as-is, but you may need to re-login on first use."
+        fi
+    fi
+
     ux_warning "Will move ~/.claude → ~/.claude-personal"
     ux_info    "Preserves: credentials, sessions, projects, history"
     printf "Continue? (y/N): "
@@ -727,6 +788,26 @@ claude_accounts_migrate() {
 
     # 3) 디렉토리 자체 이동
     mv "$HOME/.claude" "$HOME/.claude-personal"
+
+    # Diagnostic + safety net (issue #294): verify post-mv size matches and
+    # seal a snapshot so claude_yolo can recover if .claude.json is later
+    # reset (Claude CLI's first-run-with-new-CLAUDE_CONFIG_DIR can wipe it
+    # to a `firstStartTime`-only stub, which kills oauthAccount/migration
+    # cache and triggers a "configuration file not found" prompt).
+    if [ -f "$HOME/.claude-personal/.claude.json" ]; then
+        _cam_post_size=$(wc -c < "$HOME/.claude-personal/.claude.json" 2>/dev/null | tr -d ' ')
+        ux_info "Post-migrate ~/.claude-personal/.claude.json size: ${_cam_post_size:-?} bytes"
+        if [ -n "$_cam_pre_size" ] && [ -n "$_cam_post_size" ] \
+           && [ "$_cam_pre_size" != "$_cam_post_size" ]; then
+            ux_warning "  Size mismatch (pre=${_cam_pre_size}, post=${_cam_post_size}) —"
+            ux_warning "  another process modified .claude.json during migrate."
+        fi
+        _cam_snap="$HOME/.claude-personal/.claude.json.preserved-by-migrate"
+        if cp "$HOME/.claude-personal/.claude.json" "$_cam_snap" 2>/dev/null; then
+            ux_info "Sealed snapshot: $_cam_snap"
+            ux_info "  (claude-yolo auto-restores from this if .claude.json gets reset)"
+        fi
+    fi
 
     # 4) 빈 ~/.claude 재생성 + 모든 계정 init (멱등)
     claude_accounts_init

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -506,12 +506,13 @@ _claude_restore_if_reset() {
     [ "$_crir_size" -lt 500 ] || return 0
 
     grep -q 'firstStartTime' "$_crir_live" 2>/dev/null || return 0
-    grep -q 'oauthAccount\|migrationVersion' "$_crir_live" 2>/dev/null && return 0
+    grep -qE 'oauthAccount|migrationVersion' "$_crir_live" 2>/dev/null && return 0
 
     ux_warning "Detected reset .claude.json (${_crir_size}B, no oauth/migration cache)"
     ux_info    "  → restoring from sealed migrate snapshot: $_crir_snap"
     if cp "$_crir_snap" "$_crir_live" 2>/dev/null; then
-        ux_success "  Restored $_crir_live ($(wc -c < "$_crir_live" | tr -d ' ') bytes)"
+        _crir_restored_size=$(wc -c < "$_crir_live" 2>/dev/null | tr -d ' ')
+        ux_success "  Restored $_crir_live (${_crir_restored_size:-?} bytes)"
     else
         ux_error "  Restore failed — proceeding anyway (claude may prompt for re-login)"
     fi
@@ -806,6 +807,8 @@ claude_accounts_migrate() {
         if cp "$HOME/.claude-personal/.claude.json" "$_cam_snap" 2>/dev/null; then
             ux_info "Sealed snapshot: $_cam_snap"
             ux_info "  (claude-yolo auto-restores from this if .claude.json gets reset)"
+        else
+            ux_error "  Failed to create snapshot: $_cam_snap (recovery will be unavailable)"
         fi
     fi
 

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -258,6 +258,132 @@ LOCAL
     [ ! -d "$HOME/.claude-personal" ]
 }
 
+# ---------- Issue #294: .claude.json preservation + recovery ----------
+
+@test "bash: claude_accounts_migrate preserves .claude.json content (issue #294)" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude/projects"
+    # Realistic .claude.json with the fields users care about preserving.
+    cat > "$HOME/.claude/.claude.json" <<'JSON'
+{
+  "firstStartTime": "2026-01-01T00:00:00Z",
+  "oauthAccount": {"emailAddress": "test@example.com"},
+  "opusProMigrationComplete": true,
+  "sonnet1m45MigrationComplete": true,
+  "migrationVersion": 5
+}
+JSON
+    pre_size=$(wc -c < "$HOME/.claude/.claude.json")
+
+    run_in_bash 'export CLAUDE_SKIP_BIND_MOUNT=1; printf "y\n" | claude_accounts_migrate'
+    assert_success
+
+    [ -f "$HOME/.claude-personal/.claude.json" ]
+    post_size=$(wc -c < "$HOME/.claude-personal/.claude.json")
+    [ "$pre_size" = "$post_size" ]
+    grep -q "oauthAccount" "$HOME/.claude-personal/.claude.json"
+    grep -q "migrationVersion" "$HOME/.claude-personal/.claude.json"
+}
+
+@test "bash: claude_accounts_migrate logs pre/post .claude.json size (issue #294)" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude/projects"
+    printf '{"firstStartTime":"x","oauthAccount":{"e":"a@b"},"migrationVersion":5}' \
+        > "$HOME/.claude/.claude.json"
+
+    run_in_bash 'export CLAUDE_SKIP_BIND_MOUNT=1; printf "y\n" | claude_accounts_migrate'
+    assert_success
+    assert_output --partial "Pre-migrate"
+    assert_output --partial "Post-migrate"
+}
+
+@test "bash: claude_accounts_migrate creates sealed snapshot for recovery (issue #294)" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude/projects"
+    printf '{"firstStartTime":"x","oauthAccount":{"e":"a@b"},"migrationVersion":5}' \
+        > "$HOME/.claude/.claude.json"
+
+    run_in_bash 'export CLAUDE_SKIP_BIND_MOUNT=1; printf "y\n" | claude_accounts_migrate'
+    assert_success
+
+    [ -f "$HOME/.claude-personal/.claude.json.preserved-by-migrate" ]
+    grep -q "oauthAccount" "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
+}
+
+@test "bash: claude_accounts_migrate warns when pre-mv .claude.json is tiny (issue #294)" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude/projects"
+    # Already in first-start placeholder state before migrate runs.
+    printf '{"firstStartTime":"x"}' > "$HOME/.claude/.claude.json"
+
+    run_in_bash 'export CLAUDE_SKIP_BIND_MOUNT=1; printf "y\n" | claude_accounts_migrate'
+    assert_success
+    assert_output --partial "suspiciously small"
+}
+
+@test "bash: claude_yolo restores reset .claude.json from snapshot (issue #294)" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    # Snapshot has the real content.
+    printf '{"firstStartTime":"x","oauthAccount":{"e":"a@b"},"migrationVersion":5}' \
+        > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
+    # Live file has been reset to first-start placeholder (50B-ish).
+    printf '{"firstStartTime":"y"}' > "$HOME/.claude-personal/.claude.json"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    assert_output --partial "Restored"
+    grep -q "oauthAccount" "$HOME/.claude-personal/.claude.json"
+    grep -q "migrationVersion" "$HOME/.claude-personal/.claude.json"
+}
+
+@test "bash: claude_yolo does NOT restore healthy .claude.json (issue #294)" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    # Live file is healthy: > 500B AND has oauth marker.
+    {
+        printf '{"firstStartTime":"x","oauthAccount":{"e":"live@b"},"pad":"'
+        # 600 chars of padding to push size > 500B
+        printf 'x%.0s' $(seq 1 600)
+        printf '"}'
+    } > "$HOME/.claude-personal/.claude.json"
+    # Snapshot exists with DIFFERENT content; must not be used.
+    printf '{"firstStartTime":"y","oauthAccount":{"e":"snapshot@b"},"migrationVersion":5}' \
+        > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    refute_output --partial "Restored"
+    grep -q "live@b" "$HOME/.claude-personal/.claude.json"
+}
+
+@test "bash: claude_yolo does NOT restore when no snapshot (fresh setup, issue #294)" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    # First-start placeholder, but no migrate snapshot — fresh PC.
+    printf '{"firstStartTime":"x"}' > "$HOME/.claude-personal/.claude.json"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    refute_output --partial "Restored"
+    # Live file untouched.
+    grep -q "firstStartTime" "$HOME/.claude-personal/.claude.json"
+}
+
+@test "bash: claude_yolo does NOT restore when small file has oauth (issue #294)" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    # Small (< 500B) BUT contains oauthAccount → not the reset state.
+    printf '{"oauthAccount":{"e":"a@b"}}' > "$HOME/.claude-personal/.claude.json"
+    printf '{"oauthAccount":{"e":"OLD@b"},"migrationVersion":1}' \
+        > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    refute_output --partial "Restored"
+    grep -q '"a@b"' "$HOME/.claude-personal/.claude.json"
+}
+
 # ---------- Task 8: claude_accounts CLI ----------
 #
 # Aliases need `shopt -s expand_aliases` AND a separate parsing unit


### PR DESCRIPTION
## Summary
- Stops the post-migrate "configuration file not found" prompt by sealing a snapshot of `.claude.json` and restoring it before each `claude-yolo` exec when the live file is in the reset state.
- Adds the diagnostic logging the issue requested (pre/post-mv `.claude.json` size + warning when pre-mv file is already tiny).

## Changes
- `shell-common/tools/integrations/claude.sh`
  - `claude_accounts_migrate`: log pre-mv size, warn if `< 500B`, log post-mv size, warn on size mismatch, and seal `~/.claude-personal/.claude.json.preserved-by-migrate` after the `mv`.
  - `_claude_restore_if_reset` (new): restore from snapshot only when **all** of `live < 500B` + `has firstStartTime` + `lacks oauthAccount AND migrationVersion` + `snapshot exists`. Healthy files, fresh PCs, and small-but-authenticated files are untouched.
  - `claude_yolo`: invoke `_claude_restore_if_reset "$_cy_config_dir"` right before `command claude --dangerously-skip-permissions`. Bypass: `rm <dir>/.claude.json.preserved-by-migrate`.
- `tests/bats/integrations/claude_accounts.bats`: +8 tests — content/size preservation, snapshot creation, tiny-pre-mv warning, four restore-or-not branches.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/integrations/claude_accounts.bats` — 53/53 pass (was 45/45)
- [x] Full bats suite — 226/226 pass
- [x] End-to-end sandbox: 22B reset live + snapshot → `claude_yolo` restores to 70B before exec, mock `claude` runs with healthy config
- [ ] External-PC manual: rerun the issue's repro sequence (`migrate` → `status` → `claude-yolo --user work` → `./setup.sh` → `gwt spawn --launch --ai claude issue-XXX`) and verify no "configuration file not found" output

## Related
Closes #294

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->