### PR TITLE
feat(claude-accounts): #300 follow-up — 3 multi-account UX guards

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -75,6 +75,65 @@ log_error_and_exit() {
 
 # --- Functions ---
 
+# Auto-migrate legacy statusLine.command (issue #300, item A).
+#
+# PR #297 updated settings.template.json to point at the dotfiles SSOT path
+# (${HOME}/dotfiles/claude/statusline-command.sh) but left the gitignored
+# claude/settings.json copy untouched. Users on the multi-account layout
+# whose live settings.json still hardcodes the legacy ${HOME}/.claude/...
+# path silently lose the statusline because that file no longer exists
+# under the empty guard directory.
+#
+# This helper detects that exact legacy literal and rewrites it in place
+# (preserving any other field), with a timestamped backup. Any other
+# value — user customisation, already-migrated, missing field — is left
+# alone so the helper is fully idempotent.
+_migrate_legacy_statusline_command() {
+    local source_file="$CLAUDE_SETTINGS_SOURCE"
+    # Literal ${HOME}; Claude Code expands it when reading settings.json.
+    # shellcheck disable=SC2016
+    local legacy_literal='${HOME}/.claude/statusline-command.sh'
+    # shellcheck disable=SC2016
+    local new_literal='${HOME}/dotfiles/claude/statusline-command.sh'
+
+    [ -f "$source_file" ] || return 0
+    if ! command -v jq >/dev/null 2>&1; then
+        log_warning "jq 미설치 — settings.json statusLine 자동 마이그레이션 건너뜀"
+        log_warning "  ensure_jq 실행 후 setup.sh 재실행 권장"
+        return 0
+    fi
+
+    local current
+    current=$(jq -r '.statusLine.command // ""' "$source_file" 2>/dev/null)
+    [ "$current" = "$legacy_literal" ] || return 0
+
+    local backup
+    backup="${source_file}.pre-statusline-fix-$(date +%Y%m%d%H%M%S)"
+    if ! cp "$source_file" "$backup"; then
+        log_error "settings.json 백업 실패: $backup — 마이그레이션 중단"
+        return 1
+    fi
+
+    local tmp
+    tmp=$(mktemp "${source_file}.XXXXXX") || {
+        log_error "임시 파일 생성 실패 — 마이그레이션 중단"
+        rm -f "$backup"
+        return 1
+    }
+
+    if jq --arg new "$new_literal" '.statusLine.command = $new' \
+            "$source_file" > "$tmp" && mv "$tmp" "$source_file"; then
+        log_warning "settings.json statusLine.command 자동 마이그레이션 완료:"
+        log_warning "  before: $legacy_literal"
+        log_warning "  after:  $new_literal"
+        log_warning "  backup: $backup"
+    else
+        rm -f "$tmp"
+        log_error "settings.json 갱신 실패 — 백업 보존: $backup"
+        return 1
+    fi
+}
+
 _setup_bind_mount_sudoers() {
     local sudoers_file="$1"
     local description="$2"
@@ -121,6 +180,11 @@ log_debug "\n--- Claude Code dotfiles setup 시작 ---"
 [ -d "$CLAUDE_SKILLS_SOURCE" ]        || log_error_and_exit "skills 디렉토리 없음: $CLAUDE_SKILLS_SOURCE"
 [ -d "$CLAUDE_DOCS_SOURCE" ]          || log_error_and_exit "docs 디렉토리 없음: $CLAUDE_DOCS_SOURCE"
 [ -d "$CLAUDE_GLOBAL_MEMORY_SOURCE" ] || log_error_and_exit "global-memory 없음: $CLAUDE_GLOBAL_MEMORY_SOURCE"
+
+# Auto-migrate legacy statusLine.command in claude/settings.json before any
+# downstream symlink uses it (issue #300, item A). Idempotent — only acts
+# on the exact PR #292 legacy literal, otherwise no-op.
+_migrate_legacy_statusline_command
 
 # 다중 계정 함수 source (env + integration)
 . "$DOTFILES_ROOT/shell-common/env/claude.sh"

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -104,7 +104,9 @@ _migrate_legacy_statusline_command() {
     fi
 
     local current
-    current=$(jq -r '.statusLine.command // ""' "$source_file" 2>/dev/null)
+    # Null-safe (?) so a settings.json that omits .statusLine entirely or
+    # has a non-object value there still falls through cleanly.
+    current=$(jq -r '.statusLine?.command? // empty' "$source_file" 2>/dev/null)
     [ "$current" = "$legacy_literal" ] || return 0
 
     local backup

--- a/shell-common/env/claude.local.example
+++ b/shell-common/env/claude.local.example
@@ -20,3 +20,12 @@
 #
 # export CLAUDE_DEFAULT_ACCOUNT="work"
 # export CLAUDE_ENABLED_ACCOUNTS="work"
+
+# ─── 계정 ↔ 이메일 expected 매핑 (issue #300, item B) ───────────
+# 정의하면 `claude-yolo --user <name>` 가 .claude.json 의 실제
+# oauthAccount.emailAddress 와 비교하여 mismatch 면 경고 출력.
+# `claude-accounts status` 도 같은 매핑을 ⚠️ 마커로 시각화.
+# 미정의면 silent (opt-in, 기본 회귀 0).
+#
+# export CLAUDE_ACCOUNT_EMAIL_personal="alice@gmail.com"
+# export CLAUDE_ACCOUNT_EMAIL_work="alice@corp.com"

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -547,7 +547,7 @@ _claude_validate_login() {
     [ -f "$_cvl_json" ] || return 0
     command -v jq >/dev/null 2>&1 || return 0
 
-    _cvl_actual=$(jq -r '.oauthAccount.emailAddress // empty' "$_cvl_json" 2>/dev/null)
+    _cvl_actual=$(jq -r '.oauthAccount?.emailAddress? // empty' "$_cvl_json" 2>/dev/null)
     [ -n "$_cvl_actual" ] || return 0
     [ "$_cvl_expected" = "$_cvl_actual" ] && return 0
 
@@ -709,11 +709,16 @@ _claude_status_show_oauth() {
     [ -f "$_csso_json" ] || return 0
     command -v jq >/dev/null 2>&1 || return 0
 
-    _csso_email=$(jq -r '.oauthAccount.emailAddress // empty' "$_csso_json" 2>/dev/null)
+    # Single jq invocation (was 3 separate forks — claude_accounts_status
+    # iterates per account so the saving compounds). `|` delimiter chosen
+    # because the gemini-suggested space form breaks on real-world
+    # organizationName values that contain spaces (observed: "★ S.LSI AX
+    # Agent ★"). POSIX heredoc — no bash process substitution.
+    _csso_blob=$(jq -r '"\(.oauthAccount?.emailAddress? // "")|\(.oauthAccount?.organizationName? // "")|\(.oauthAccount?.organizationType? // "")"' "$_csso_json" 2>/dev/null)
+    IFS='|' read -r _csso_email _csso_org _csso_type <<EOF
+$_csso_blob
+EOF
     [ -n "$_csso_email" ] || return 0
-
-    _csso_org=$(jq -r '.oauthAccount.organizationName // empty' "$_csso_json" 2>/dev/null)
-    _csso_type=$(jq -r '.oauthAccount.organizationType // empty' "$_csso_json" 2>/dev/null)
 
     _csso_marker=""
     _csso_expected=$(_claude_expected_email "$_csso_acct")

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -472,6 +472,11 @@ claude_yolo() {
     # See _claude_restore_if_reset for the heuristic and rationale.
     _claude_restore_if_reset "$_cy_config_dir"
 
+    # Pre-launch account binding sanity (issue #300, item B).
+    # Opt-in via CLAUDE_ACCOUNT_EMAIL_<account>; silent unless the mapping
+    # AND a populated .claude.json AND a mismatch are all present.
+    _claude_validate_login "$_cy_config_dir" "$_cy_account"
+
     CLAUDE_CONFIG_DIR="$_cy_config_dir" command claude --dangerously-skip-permissions "$@"
 }
 
@@ -517,6 +522,41 @@ _claude_restore_if_reset() {
         ux_error "  Restore failed — proceeding anyway (claude may prompt for re-login)"
     fi
 }
+
+# _claude_validate_login — expected ↔ actual oauth email check (issue #300-B).
+#
+# Catches the "wrong Google account on browser" trap: a leftover personal
+# Google session bleeds into the OAuth flow for `claude-yolo --user work`,
+# leaving the work CLAUDE_CONFIG_DIR populated with personal credentials.
+# The code in this repo can't influence the browser, but it CAN cross-check
+# the resulting .claude.json against an expected email and warn loudly so
+# the user can recover before the misbinding becomes load-bearing.
+#
+# Opt-in: caller defines `CLAUDE_ACCOUNT_EMAIL_<account>` (e.g.
+# `CLAUDE_ACCOUNT_EMAIL_work=alice@corp.com`) in claude.local.sh. Without
+# the mapping the function silently returns — zero-config / zero-regression
+# for everyone who doesn't opt in.
+_claude_validate_login() {
+    _cvl_dir="$1"
+    _cvl_acct="$2"
+
+    _cvl_expected=$(_claude_expected_email "$_cvl_acct")
+    [ -n "$_cvl_expected" ] || return 0
+
+    _cvl_json="$_cvl_dir/.claude.json"
+    [ -f "$_cvl_json" ] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    _cvl_actual=$(jq -r '.oauthAccount.emailAddress // empty' "$_cvl_json" 2>/dev/null)
+    [ -n "$_cvl_actual" ] || return 0
+    [ "$_cvl_expected" = "$_cvl_actual" ] && return 0
+
+    ux_warning "Account mismatch on '$_cvl_acct':"
+    ux_warning "  expected: $_cvl_expected (CLAUDE_ACCOUNT_EMAIL_${_cvl_acct})"
+    ux_warning "  actual:   $_cvl_actual (.claude.json oauthAccount)"
+    ux_info    "  → 다른 Google 계정으로 잘못 로그인된 자격증명일 수 있습니다."
+    ux_info    "  → 복구: rm '$_cvl_dir/.credentials.json' '$_cvl_json' && claude-yolo --user $_cvl_acct"
+}
 alias claude-yolo='claude_yolo'
 
 # ═══════════════════════════════════════════════════════════════
@@ -552,6 +592,21 @@ _claude_resolve_account() {
         work)     echo "$HOME/.claude-work" ;;
         *)        return 1 ;;
     esac
+}
+
+# _claude_expected_email <account-name> — expected oauth email lookup.
+# Reads CLAUDE_ACCOUNT_EMAIL_<account> if defined, else echoes nothing.
+# Opt-in mapping convention from issue #300, items B and C — kept in a
+# helper so claude_yolo and claude_accounts_status share the same source
+# of truth.
+#
+# Uses eval (not ${!var}) for POSIX sh portability — the input is always
+# an account name vetted by _claude_resolve_account, so injection is not
+# a concern.
+_claude_expected_email() {
+    _ceeem_acct="$1"
+    [ -n "$_ceeem_acct" ] || return 0
+    eval "echo \"\${CLAUDE_ACCOUNT_EMAIL_${_ceeem_acct}:-}\""
 }
 
 # _claude_ensure_symlink — 멱등 symlink 생성.
@@ -633,6 +688,49 @@ _claude_account_setup_one() {
     fi
 }
 
+# _claude_status_show_oauth — append OAuth binding (email/org) to the
+# Credentials line in claude_accounts_status (issue #300, item C).
+#
+# Visibility goal: the status command already says "✓ logged in" but does
+# not say *which* Anthropic account those credentials map to. Without
+# that, item-B's misbinding trap is invisible at diagnosis time. This
+# helper jq-extracts the .oauthAccount fields populated by Claude after
+# its first authenticated call, and prints two indented lines.
+#
+# Silent skip when: .claude.json missing, jq missing, or oauthAccount
+# field absent (e.g. first-start placeholder before login completes).
+# When item-B's expected mapping is also defined and disagrees with the
+# observed email, append a ⚠️ marker to make the discrepancy obvious.
+_claude_status_show_oauth() {
+    _csso_dir="$1"
+    _csso_acct="$2"
+    _csso_json="$_csso_dir/.claude.json"
+
+    [ -f "$_csso_json" ] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    _csso_email=$(jq -r '.oauthAccount.emailAddress // empty' "$_csso_json" 2>/dev/null)
+    [ -n "$_csso_email" ] || return 0
+
+    _csso_org=$(jq -r '.oauthAccount.organizationName // empty' "$_csso_json" 2>/dev/null)
+    _csso_type=$(jq -r '.oauthAccount.organizationType // empty' "$_csso_json" 2>/dev/null)
+
+    _csso_marker=""
+    _csso_expected=$(_claude_expected_email "$_csso_acct")
+    if [ -n "$_csso_expected" ] && [ "$_csso_expected" != "$_csso_email" ]; then
+        _csso_marker=" ⚠️  expected $_csso_expected"
+    fi
+
+    echo "    └─ Email: $_csso_email$_csso_marker"
+    if [ -n "$_csso_org" ]; then
+        if [ -n "$_csso_type" ]; then
+            echo "    └─ Org:   $_csso_org ($_csso_type)"
+        else
+            echo "    └─ Org:   $_csso_org"
+        fi
+    fi
+}
+
 # claude_accounts_status — 진단 출력 (모든 ENABLED 계정의 상태).
 claude_accounts_status() {
     ux_header "Claude Accounts Status"
@@ -661,6 +759,7 @@ claude_accounts_status() {
 
         if [ -f "$_cas_cdir/.credentials.json" ]; then
             echo "  Credentials: .credentials.json ✓ logged in"
+            _claude_status_show_oauth "$_cas_cdir" "$_cas_acct"
         else
             echo "  Credentials: .credentials.json ✗ NOT logged in"
             echo "                → Run: claude-yolo --user $_cas_acct"

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -593,3 +593,174 @@ _setup_sh_prereqs() {
         [ -x "$expanded" ]
     done
 }
+
+# ---------- Issue #300, item A: setup.sh auto-migrates legacy statusLine ----------
+#
+# Helpers below temporarily swap the gitignored claude/settings.json
+# (which lives in the shared DOTFILES_ROOT, not the per-test $HOME) for
+# a fixture, then restore it. Without the restore the next test inherits
+# our fixture and the regression test for #296 sees stale state.
+
+# Stage a fixture settings.json containing exactly the literal that
+# triggers item-A migration. Saves the original to $HOME first.
+_use_settings_fixture() {
+    _uss_src="${DOTFILES_ROOT}/claude/settings.json"
+    _uss_bk="$HOME/.settings-original.json"
+    [ -f "$_uss_src" ] && cp "$_uss_src" "$_uss_bk"
+    cat > "$_uss_src" <<JSON
+{
+  "statusLine": {
+    "type": "command",
+    "command": "$1"
+  }
+}
+JSON
+}
+
+_restore_settings_fixture() {
+    _rsf_src="${DOTFILES_ROOT}/claude/settings.json"
+    _rsf_bk="$HOME/.settings-original.json"
+    # Wipe migration backup files our test runs may have produced.
+    rm -f "${_rsf_src}".pre-statusline-fix-*
+    if [ -f "$_rsf_bk" ]; then
+        mv "$_rsf_bk" "$_rsf_src"
+    else
+        rm -f "$_rsf_src"
+    fi
+}
+
+@test "issue #300-A: setup.sh rewrites legacy statusLine.command literal" {
+    _setup_sh_prereqs
+    _use_settings_fixture '${HOME}/.claude/statusline-command.sh'
+    ln -s "${DOTFILES_ROOT}" "$HOME/dotfiles"
+
+    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
+    assert_success
+    assert_output --partial "자동 마이그레이션 완료"
+
+    cmd=$(jq -r '.statusLine.command' "${DOTFILES_ROOT}/claude/settings.json")
+    [ "$cmd" = '${HOME}/dotfiles/claude/statusline-command.sh' ]
+    # Backup file present alongside the source.
+    ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-[0-9]{14}'
+
+    _restore_settings_fixture
+}
+
+@test "issue #300-A: setup.sh leaves already-migrated statusLine.command alone" {
+    _setup_sh_prereqs
+    _use_settings_fixture '${HOME}/dotfiles/claude/statusline-command.sh'
+    ln -s "${DOTFILES_ROOT}" "$HOME/dotfiles"
+
+    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
+    assert_success
+    refute_output --partial "자동 마이그레이션 완료"
+
+    # No backup spawned for a no-op run.
+    ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-' && {
+        _restore_settings_fixture
+        return 1
+    }
+
+    _restore_settings_fixture
+}
+
+@test "issue #300-A: setup.sh preserves user-customised statusLine.command" {
+    _setup_sh_prereqs
+    _use_settings_fixture "$HOME/bin/my-custom-statusline.sh"
+    ln -s "${DOTFILES_ROOT}" "$HOME/dotfiles"
+
+    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
+    assert_success
+    refute_output --partial "자동 마이그레이션 완료"
+
+    cmd=$(jq -r '.statusLine.command' "${DOTFILES_ROOT}/claude/settings.json")
+    [ "$cmd" = "$HOME/bin/my-custom-statusline.sh" ]
+
+    _restore_settings_fixture
+}
+
+# ---------- Issue #300, item C: claude_accounts_status shows oauth binding ----------
+
+@test "issue #300-C: claude_accounts_status prints email/org from .claude.json" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude-personal"
+    echo "creds" > "$HOME/.claude-personal/.credentials.json"
+    cat > "$HOME/.claude-personal/.claude.json" <<'JSON'
+{
+  "oauthAccount": {
+    "emailAddress": "alice@example.com",
+    "organizationName": "Example Inc",
+    "organizationType": "claude_team"
+  }
+}
+JSON
+
+    run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init >/dev/null && CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
+    assert_success
+    assert_output --partial "Email: alice@example.com"
+    assert_output --partial "Org:   Example Inc (claude_team)"
+}
+
+@test "issue #300-C: claude_accounts_status omits oauth lines when .claude.json missing" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude-personal"
+    echo "creds" > "$HOME/.claude-personal/.credentials.json"
+    # No .claude.json — first run / fresh login.
+
+    run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init >/dev/null && CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
+    assert_success
+    refute_output --partial "Email:"
+    refute_output --partial "Org:"
+}
+
+@test "issue #300-C: claude_accounts_status flags expected/actual mismatch with marker" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude-work"
+    echo "creds" > "$HOME/.claude-work/.credentials.json"
+    cat > "$HOME/.claude-work/.claude.json" <<'JSON'
+{"oauthAccount":{"emailAddress":"personal@gmail.com","organizationName":"Personal"}}
+JSON
+
+    run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_ENABLED_ACCOUNTS=work CLAUDE_DEFAULT_ACCOUNT=work claude_accounts_init >/dev/null && CLAUDE_ENABLED_ACCOUNTS=work CLAUDE_DEFAULT_ACCOUNT=work CLAUDE_ACCOUNT_EMAIL_work=work@corp.com claude_accounts_status'
+    assert_success
+    assert_output --partial "Email: personal@gmail.com"
+    assert_output --partial "expected work@corp.com"
+}
+
+# ---------- Issue #300, item B: claude_yolo expected ↔ actual email check ----------
+
+@test "issue #300-B: claude_yolo silent when CLAUDE_ACCOUNT_EMAIL matches actual" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    printf '{"oauthAccount":{"emailAddress":"alice@example.com"}}' \
+        > "$HOME/.claude-personal/.claude.json"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 CLAUDE_ACCOUNT_EMAIL_personal=alice@example.com claude_yolo"
+    assert_success
+    refute_output --partial "Account mismatch"
+}
+
+@test "issue #300-B: claude_yolo warns on CLAUDE_ACCOUNT_EMAIL mismatch" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-work"
+    printf '{"oauthAccount":{"emailAddress":"personal@gmail.com"}}' \
+        > "$HOME/.claude-work/.claude.json"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 CLAUDE_ACCOUNT_EMAIL_work=work@corp.com claude_yolo --user work"
+    assert_success
+    assert_output --partial "Account mismatch on 'work'"
+    assert_output --partial "expected: work@corp.com"
+    assert_output --partial "actual:   personal@gmail.com"
+    assert_output --partial "복구:"
+}
+
+@test "issue #300-B: claude_yolo silent when no CLAUDE_ACCOUNT_EMAIL mapping defined" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-work"
+    printf '{"oauthAccount":{"emailAddress":"anyone@anywhere.com"}}' \
+        > "$HOME/.claude-work/.claude.json"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user work"
+    assert_success
+    refute_output --partial "Account mismatch"
+}


### PR DESCRIPTION
## Summary
- Three small follow-up UX guards on the multi-account stack landed by PR #292/#297-#299, surfaced during the manual verification flow of #293.
- All guards are opt-in or self-targeting (legacy-literal match, env-var mapping) — zero regression for users who haven't hit the trap yet.

## Changes
- **A — `claude/setup.sh`**: auto-rewrites the legacy `${HOME}/.claude/statusline-command.sh` literal in the gitignored `claude/settings.json` to the new SSOT path. Gated on the exact PR-292-era literal so user customisation is preserved; backup written to `settings.json.pre-statusline-fix-<TS>`.
- **B — `claude_yolo`**: pre-launch cross-check of `.claude.json` `oauthAccount.emailAddress` against an opt-in `CLAUDE_ACCOUNT_EMAIL_<account>` mapping. Catches the "browser still logged into the wrong Google account" trap where personal Anthropic creds get sealed into `~/.claude-work/`. Mapping undefined → silent.
- **C — `claude_accounts_status`**: prints email + org under each `✓ logged in` line, with a ⚠️  marker when item-B's mapping disagrees. Makes B's misbinding visible at diagnosis time without inspecting `.claude.json` by hand.
- **`shell-common/env/claude.local.example`**: documents the new `CLAUDE_ACCOUNT_EMAIL_<account>` mapping convention used by B and C.
- **+9 bats** in `tests/bats/integrations/claude_accounts.bats` (3 per item, including no-mapping silent-path coverage).

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/integrations tests/bats/init tests/bats/functions tests/bats/tools` — 399/399 PASS, 0 fail
- [x] `shellcheck claude/setup.sh` — clean (SC2016 disabled where `${HOME}` must stay literal for Claude Code's own expansion)
- [ ] (수동) Legacy literal 가진 PC: `./setup.sh` → 자동 마이그 경고 + 새 path + backup 파일 생성 확인
- [ ] (수동) `claude.local.sh` 에 `CLAUDE_ACCOUNT_EMAIL_work=alice@corp.com` 정의 후 잘못된 Google 계정으로 로그인된 상태에서 `claude-yolo --user work` → mismatch 경고 출력 확인
- [ ] (수동) `claude-accounts status` 의 각 `✓ logged in` 줄 아래 Email/Org 줄 출력 확인 (mismatch 시 ⚠️  마커)

## Related
Closes #300
Refs #293
Refs #287 (multi-account Phase 1)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~24 min
<!-- /ai-metrics -->