### PR TITLE
fix(project-board): hard-fail on missing PAT for canonical PRs

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -65,41 +65,6 @@ jobs:
           echo "::error::PROJECT_BOARD_PAT secret is missing on $GH_REPO. Project board cards will not sync. Set it via: gh secret set PROJECT_BOARD_PAT --repo $GH_REPO --body '<PAT-with-project-scope>'"
           exit 1
 
-      - name: DEBUG — verify PAT scope and project access
-        if: >-
-          github.event_name == 'pull_request' &&
-          contains(fromJSON('["opened","ready_for_review","reopened","synchronize"]'), github.event.action)
-        env:
-          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        shell: bash
-        continue-on-error: true
-        run: |
-          set +e
-          echo "--- gh api /user (auth check) ---"
-          gh api /user --jq '.login' || echo "FAIL: gh api /user"
-          echo "--- gh api rate_limit (scope check) ---"
-          gh api /rate_limit --jq '.resources | keys' || echo "FAIL: rate_limit"
-          echo "--- token scopes (response header) ---"
-          gh api /user -i 2>&1 | grep -i "x-oauth-scopes\|x-accepted-oauth-scopes" || echo "no scope headers"
-          echo "--- raw projectItems query (no stderr suppression) ---"
-          gh api graphql -f query='
-            query($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $number) {
-                  projectItems(first: 10) {
-                    nodes {
-                      id
-                      fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
-                      project { id title }
-                    }
-                  }
-                }
-              }
-            }' \
-            -f owner="${GH_REPO%/*}" -f repo="${GH_REPO#*/}" -F number="$PR_NUMBER"
-
       - name: PR opened → In review (PR) + In progress (linked Issues)
         if: >-
           github.event_name == 'pull_request' &&

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -65,6 +65,41 @@ jobs:
           echo "::error::PROJECT_BOARD_PAT secret is missing on $GH_REPO. Project board cards will not sync. Set it via: gh secret set PROJECT_BOARD_PAT --repo $GH_REPO --body '<PAT-with-project-scope>'"
           exit 1
 
+      - name: DEBUG — verify PAT scope and project access
+        if: >-
+          github.event_name == 'pull_request' &&
+          contains(fromJSON('["opened","ready_for_review","reopened","synchronize"]'), github.event.action)
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        continue-on-error: true
+        run: |
+          set +e
+          echo "--- gh api /user (auth check) ---"
+          gh api /user --jq '.login' || echo "FAIL: gh api /user"
+          echo "--- gh api rate_limit (scope check) ---"
+          gh api /rate_limit --jq '.resources | keys' || echo "FAIL: rate_limit"
+          echo "--- token scopes (response header) ---"
+          gh api /user -i 2>&1 | grep -i "x-oauth-scopes\|x-accepted-oauth-scopes" || echo "no scope headers"
+          echo "--- raw projectItems query (no stderr suppression) ---"
+          gh api graphql -f query='
+            query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+                      project { id title }
+                    }
+                  }
+                }
+              }
+            }' \
+            -f owner="${GH_REPO%/*}" -f repo="${GH_REPO#*/}" -F number="$PR_NUMBER"
+
       - name: PR opened → In review (PR) + In progress (linked Issues)
         if: >-
           github.event_name == 'pull_request' &&

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -42,6 +42,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Guard — require PROJECT_BOARD_PAT on canonical PRs
+        # Fail loudly when the secret is missing on a same-repo PR. Without
+        # this guard the workflow silently no-ops and the GitHub builtin
+        # "Pull request linked to issue" (#3) keeps stranding Issue cards
+        # at "In review". For fork PRs GitHub never injects repo secrets,
+        # so we soft-skip those — that is expected and not a regression.
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT }}
+          GH_REPO: ${{ github.repository }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${GH_TOKEN:-}" ]; then
+            exit 0
+          fi
+          if [ "${PR_HEAD_REPO:-}" != "$GH_REPO" ]; then
+            echo "::warning::PROJECT_BOARD_PAT not available for fork PR ($PR_HEAD_REPO); skipping project-board sync."
+            exit 0
+          fi
+          echo "::error::PROJECT_BOARD_PAT secret is missing on $GH_REPO. Project board cards will not sync. Set it via: gh secret set PROJECT_BOARD_PAT --repo $GH_REPO --body '<PAT-with-project-scope>'"
+          exit 1
+
       - name: PR opened → In review (PR) + In progress (linked Issues)
         if: >-
           github.event_name == 'pull_request' &&
@@ -53,10 +76,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::PROJECT_BOARD_PAT secret is not set; skipping project-board sync."
-            exit 0
-          fi
+          # Guard step already validated PROJECT_BOARD_PAT presence (or
+          # soft-skipped for fork PRs). If we're here without a token it
+          # means the fork-soft-skip path; nothing more to do.
+          [ -n "${GH_TOKEN:-}" ] || exit 0
           # shellcheck source=shell-common/functions/gh_project_status.sh
           . shell-common/functions/gh_project_status.sh
           _gh_project_status_sync pr "$PR_NUMBER" "In review"
@@ -79,10 +102,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::PROJECT_BOARD_PAT secret is not set; skipping project-board sync."
-            exit 0
-          fi
+          [ -n "${GH_TOKEN:-}" ] || exit 0
           # shellcheck source=shell-common/functions/gh_project_status.sh
           . shell-common/functions/gh_project_status.sh
           _gh_project_status_sync pr "$PR_NUMBER" "Approved" \
@@ -100,10 +120,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::PROJECT_BOARD_PAT secret is not set; skipping project-board sync."
-            exit 0
-          fi
+          [ -n "${GH_TOKEN:-}" ] || exit 0
           # shellcheck source=shell-common/functions/gh_project_status.sh
           . shell-common/functions/gh_project_status.sh
           _gh_project_status_sync pr "$PR_NUMBER" "Done"

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -180,8 +180,7 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
   - **Fork PR** (`head.repo.full_name != github.repository`): GitHub
     이 정책상 secrets 를 주입하지 않으므로 `::warning::` 만 남기고
     `exit 0` 으로 soft-skip — 외부 기여자가 빨간 CI 를 보지 않게 한다.
-  - **Canonical PR** (same-repo): `::error::` 와 `gh secret set
-    PROJECT_BOARD_PAT` 안내를 출력하고 `exit 1` 로 hard-fail. PR #290
+  - **Canonical PR** (same-repo): `::error::` 와 `gh secret set PROJECT_BOARD_PAT` 안내를 출력하고 `exit 1` 로 hard-fail. PR #290
     머지 후 PAT 미설정으로 워크플로가 silent no-op 한 상태가 #300
     까지 발견되지 못한 회귀 (#bug/1) 의 재발 방지 가드다.
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -175,8 +175,15 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
   GitHub Projects 빌트인 `Pull request merged` (#6) 는 enabled 이지만
   저장소·보드 설정 차이로 fire 가 누락되는 사례가 #265 머지에서
   관측되어 (#266) 위 두 보정 경로가 안전망 역할을 한다. 워크플로우는
-  `secrets.PROJECT_BOARD_PAT` (project 스코프 PAT) 를 사용한다 — PAT
-  미설정 시엔 warning 을 남기고 no-op 으로 종료하므로 포크 PR 도 안전하다.
+  `secrets.PROJECT_BOARD_PAT` (project 스코프 PAT) 를 사용한다.
+  미설정 처리는 fork 와 canonical 이 분기된다:
+  - **Fork PR** (`head.repo.full_name != github.repository`): GitHub
+    이 정책상 secrets 를 주입하지 않으므로 `::warning::` 만 남기고
+    `exit 0` 으로 soft-skip — 외부 기여자가 빨간 CI 를 보지 않게 한다.
+  - **Canonical PR** (same-repo): `::error::` 와 `gh secret set
+    PROJECT_BOARD_PAT` 안내를 출력하고 `exit 1` 로 hard-fail. PR #290
+    머지 후 PAT 미설정으로 워크플로가 silent no-op 한 상태가 #300
+    까지 발견되지 못한 회귀 (#bug/1) 의 재발 방지 가드다.
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:
   `Changes requested` 루프에서 수정·재푸시 후 리뷰가 다시 달리기를
   기대할 때 **수동**으로 복귀시킨다. Projects v2 빌트인에도 dotfiles

--- a/tests/bats/init/project_board_sync_workflow.bats
+++ b/tests/bats/init/project_board_sync_workflow.bats
@@ -85,8 +85,28 @@ WORKFLOW="${DOTFILES_ROOT}/.github/workflows/project-board-sync.yml"
     grep -q -- '--only-from "Backlog,In progress,In review"' "$WORKFLOW"
 }
 
-@test "skips silently when PROJECT_BOARD_PAT is missing" {
-    # Soft-fail: fork PRs and freshly forked clones have no access to
-    # repo secrets. The workflow must warn and exit 0, not error.
-    grep -q 'PROJECT_BOARD_PAT secret is not set' "$WORKFLOW"
+@test "fork PRs without the PAT soft-skip with a warning" {
+    # GitHub does not pass repo secrets to fork PR runs. The guard step
+    # must warn-and-exit-0 in that case so external contributors do not
+    # get red CI for a sync they cannot perform.
+    grep -q '::warning::PROJECT_BOARD_PAT not available for fork PR' "$WORKFLOW"
+}
+
+@test "canonical PRs without the PAT fail loudly with an actionable error" {
+    # Regression guard for #289 / #300: prior revision warned-and-exit-0
+    # on the canonical repo too, so the workflow silently no-op'd from
+    # PR #290 merge until detection. Now the missing-secret case must
+    # error-and-exit-1 on the canonical repo so a misconfigured setup
+    # cannot ride along undetected.
+    grep -q '::error::PROJECT_BOARD_PAT secret is missing' "$WORKFLOW"
+    grep -q 'gh secret set PROJECT_BOARD_PAT' "$WORKFLOW"
+}
+
+@test "guard step runs first and discriminates fork vs canonical via PR_HEAD_REPO" {
+    # The guard step must compare github.event.pull_request.head.repo.full_name
+    # against github.repository — equality means same-repo PR (PAT must
+    # exist), inequality means fork PR (soft-skip is correct).
+    grep -q 'PR_HEAD_REPO:' "$WORKFLOW"
+    grep -q 'github.event.pull_request.head.repo.full_name' "$WORKFLOW"
+    grep -q '"${PR_HEAD_REPO:-}" != "$GH_REPO"' "$WORKFLOW"
 }

--- a/tests/bats/init/project_board_sync_workflow.bats
+++ b/tests/bats/init/project_board_sync_workflow.bats
@@ -108,5 +108,8 @@ WORKFLOW="${DOTFILES_ROOT}/.github/workflows/project-board-sync.yml"
     # exist), inequality means fork PR (soft-skip is correct).
     grep -q 'PR_HEAD_REPO:' "$WORKFLOW"
     grep -q 'github.event.pull_request.head.repo.full_name' "$WORKFLOW"
-    grep -q '"${PR_HEAD_REPO:-}" != "$GH_REPO"' "$WORKFLOW"
+    # Pin the intent (PR_HEAD_REPO is compared inequality-wise to GH_REPO),
+    # not the quoting or brace style. Tolerates rewrites like
+    # ${PR_HEAD_REPO}, $PR_HEAD_REPO, "${PR_HEAD_REPO:-}", etc.
+    grep -Eq 'PR_HEAD_REPO[^!]*!=[[:space:]]*"?\$\{?GH_REPO' "$WORKFLOW"
 }


### PR DESCRIPTION
## Summary

- `project-board-sync.yml`: 첫 step 으로 `Guard — require PROJECT_BOARD_PAT on canonical PRs` 추가. fork/canonical 분기 후 canonical 에서 PAT 누락이면 `::error::` + 해결 명령 출력하고 `exit 1`. fork PR 은 기존대로 `::warning::` + `exit 0` (GitHub 정책상 secret 미주입).
- `project-board-sync.yml`: 세 sync step 의 중복된 PAT 체크를 `[ -n "${GH_TOKEN:-}" ] || exit 0` 한 줄로 축약 (fork-soft-skip 경로용 안전망).
- `tests/bats/init/project_board_sync_workflow.bats`: 기존 "skips silently when missing" 어서션을 두 어서션 (fork soft-skip + canonical hard-fail) 으로 분리하고, `PR_HEAD_REPO` 기반 fork/canonical 판별을 검증하는 어서션 추가.
- `docs/standards/github-project-board.md`: PAT 미설정 처리를 fork/canonical 분기로 재기술하고 #289 / wt/bug/1 회귀 사유 명시.

## Root cause

PR #290 가 워크플로 코드/bats/문서를 모두 추가했으나 `PROJECT_BOARD_PAT` repo secret 자체는 설정되지 않은 채 머지됐다. 워크플로의 보호 분기는 `if [ -z "\${GH_TOKEN:-}" ]; then ... exit 0; fi` 였기 때문에 #290 머지부터 매 PR 마다 다음 메시지만 남기고 그대로 종료:

```
##[warning]PROJECT_BOARD_PAT secret is not set; skipping project-board sync.
```

빌트인 `Pull request linked to issue` (#3) 가 Issue 카드를 `In review` 로 옮겨도 우리 워크플로의 교정 step (`In progress` 로 복구) 이 실행되지 않았다. PR #301 (이슈 #300) 에서 "In review 잔류" 로 재발 발견 — #289 와 동일 증상.

## Fix

Guard step 에서 `github.event.pull_request.head.repo.full_name` 와 `github.repository` 를 비교해 두 경로로 분기:

- **Fork PR** (head.repo ≠ canonical): GitHub 이 정책상 secret 을 주입하지 않으므로 `::warning::` + `exit 0` — 외부 기여자의 CI 가 빨간색이 되지 않게 한다.
- **Canonical PR** (same-repo): PAT 누락은 명백한 설정 오류이므로 `::error::` 와 정확한 `gh secret set PROJECT_BOARD_PAT --repo <repo> --body '<PAT>'` 명령을 출력하고 `exit 1`. silent no-op 으로 회귀하는 경로를 구조적으로 차단.

이번 PR 머지 전에 `PROJECT_BOARD_PAT` secret 을 이미 설정해 두었으므로, 다음 canonical PR 부터 정상 sync 동작 시작.

## Test plan

- [x] 워크플로 정적 grep 어서션 11개 수동 매치 확인 (submodule 미초기화 환경)
- [ ] 본 PR 자체가 첫 검증: 머지 시 PR card `Done`, linked Issue 카드 (있다면) `Done` 으로 자동 전환되는지 확인
- [ ] Secret 임시 제거 후 캐노니컬 PR 1건 열어 `::error::` 와 함께 CI 가 빨간색으로 fail 하는지 확인 (옵션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->