### PR TITLE
fix(gh-pr-approve): query rebaseable via REST API

### DIFF
--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -40,12 +40,16 @@ Fetch in parallel before reading the diff:
   branch; if neither exists, stop and ask.
 - `ME=$(gh api user -q .login)`.
 - PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,files`
+- `REBASEABLE=$(gh api repos/$OWNER/$REPO/pulls/<N> --jq .rebaseable)` —
+  the `rebaseable` field is REST-only; `gh pr view --json rebaseable`
+  fails with `Unknown JSON field` because GraphQL has no such field.
 - Prior reviews/comments on this PR by `ME`.
 - `gh pr checks <N> --repo $TARGET_REPO`.
 
 Stop on `state != OPEN`, draft, or required-check failure. Warn (but
-do not stop) on `mergeable: CONFLICTING` — prepend a visible conflict
-warning block to the review body and include it in the Step 5 report.
+do not stop) on `mergeable: CONFLICTING` or `rebaseable: false` —
+prepend a visible conflict warning block to the review body and include
+it in the Step 5 report.
 If `author.login == ME`, follow `references/self-pr-handling.md`.
 If prior `ME` comments/reviews exist, use re-review mode: every prior
 concern must be verified as fixed, tracked, or acceptably declined.
@@ -84,7 +88,8 @@ Match the PR's dominant language.
 Re-fetch `reviewDecision` + `mergeStateStatus`; for `--admin-merge`, also
 re-fetch `state` and `mergeCommit`. Report status, blocker/follow-up
 counts, issue links, merge state, and PR URL. If the PR had
-`mergeable: CONFLICTING`, include the conflict warning in the report.
+`mergeable: CONFLICTING` or `rebaseable: false`, include the conflict
+warning in the report.
 For `--self-record`, confirm `reviewDecision` did not become `APPROVED`.
 
 ## Constraints


### PR DESCRIPTION
## Summary
- `gh:pr-approve` aborted in pre-flight because `gh pr view --json
  rebaseable` is rejected by GitHub's GraphQL API (no such field).
- Move the lookup to REST (`gh api .../pulls/<N> --jq .rebaseable`) and
  extend the existing conflict-warning gate so `rebaseable: false` is
  surfaced alongside `mergeable: CONFLICTING`.

## Changes
- `claude/skills/gh-pr-approve/SKILL.md` — add the REST `rebaseable`
  fetch to the Step 1 parallel block, with an inline note explaining why
  GraphQL won't work; broaden the warn-not-stop gate and Step 5 report
  text to include `rebaseable: false`.

## Test plan
- [ ] `npx markdownlint claude/skills/gh-pr-approve/SKILL.md` clean (verified locally).
- [ ] Smoke: `gh api repos/dEitY719/dotfiles/pulls/<this-PR> --jq .rebaseable`
      returns `true|false|null` (not the previous `Unknown JSON field` error).
- [ ] Re-run `/gh:pr-approve` against an open PR and confirm pre-flight
      no longer aborts on the rebaseable lookup.

## Related
Closes #302

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->