### PR TITLE
test(bats): isolate setup.sh mocks under TEST_TEMP_HOME (#303)

### DIFF
--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -518,19 +518,11 @@ MOCK
 
 # ---------- Task 11: claude/setup.sh integration ----------
 
-# settings.json is gitignored (PC-specific) — generate from template if missing.
-# Same applies to other source dirs that may be empty in a fresh checkout.
+# Stage an isolated DOTFILES_ROOT under $TEST_TEMP_HOME so setup.sh's writes
+# (settings.json migration, *.pre-statusline-fix-* backup files) land in a
+# throwaway tree instead of the version-controlled checkout (issue #303).
 _setup_sh_prereqs() {
-    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
-    mkdir -p "${DOTFILES_ROOT}/claude/global-memory"
-    if [ ! -f "${DOTFILES_ROOT}/claude/settings.json" ]; then
-        if [ -f "${DOTFILES_ROOT}/claude/settings.template.json" ]; then
-            cp "${DOTFILES_ROOT}/claude/settings.template.json" \
-               "${DOTFILES_ROOT}/claude/settings.json"
-        else
-            echo '{}' > "${DOTFILES_ROOT}/claude/settings.json"
-        fi
-    fi
+    setup_isolated_dotfiles_root
 }
 
 @test "bash: claude/setup.sh creates ~/.claude-personal/ structure" {
@@ -596,18 +588,13 @@ _setup_sh_prereqs() {
 
 # ---------- Issue #300, item A: setup.sh auto-migrates legacy statusLine ----------
 #
-# Helpers below temporarily swap the gitignored claude/settings.json
-# (which lives in the shared DOTFILES_ROOT, not the per-test $HOME) for
-# a fixture, then restore it. Without the restore the next test inherits
-# our fixture and the regression test for #296 sees stale state.
-
-# Stage a fixture settings.json containing exactly the literal that
-# triggers item-A migration. Saves the original to $HOME first.
+# These tests overwrite settings.json with a fixture that triggers (or
+# avoids triggering) the item-A migration. Since _setup_sh_prereqs now
+# stages an isolated DOTFILES_ROOT under $TEST_TEMP_HOME (issue #303),
+# fixture writes and any *.pre-statusline-fix-* backup files setup.sh
+# produces are torn down with $TEST_TEMP_HOME — no save/restore needed.
 _use_settings_fixture() {
-    _uss_src="${DOTFILES_ROOT}/claude/settings.json"
-    _uss_bk="$HOME/.settings-original.json"
-    [ -f "$_uss_src" ] && cp "$_uss_src" "$_uss_bk"
-    cat > "$_uss_src" <<JSON
+    cat > "${DOTFILES_ROOT}/claude/settings.json" <<JSON
 {
   "statusLine": {
     "type": "command",
@@ -615,18 +602,6 @@ _use_settings_fixture() {
   }
 }
 JSON
-}
-
-_restore_settings_fixture() {
-    _rsf_src="${DOTFILES_ROOT}/claude/settings.json"
-    _rsf_bk="$HOME/.settings-original.json"
-    # Wipe migration backup files our test runs may have produced.
-    rm -f "${_rsf_src}".pre-statusline-fix-*
-    if [ -f "$_rsf_bk" ]; then
-        mv "$_rsf_bk" "$_rsf_src"
-    else
-        rm -f "$_rsf_src"
-    fi
 }
 
 @test "issue #300-A: setup.sh rewrites legacy statusLine.command literal" {
@@ -642,8 +617,6 @@ _restore_settings_fixture() {
     [ "$cmd" = '${HOME}/dotfiles/claude/statusline-command.sh' ]
     # Backup file present alongside the source.
     ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-[0-9]{14}'
-
-    _restore_settings_fixture
 }
 
 @test "issue #300-A: setup.sh leaves already-migrated statusLine.command alone" {
@@ -656,12 +629,7 @@ _restore_settings_fixture() {
     refute_output --partial "자동 마이그레이션 완료"
 
     # No backup spawned for a no-op run.
-    ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-' && {
-        _restore_settings_fixture
-        return 1
-    }
-
-    _restore_settings_fixture
+    ! ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-'
 }
 
 @test "issue #300-A: setup.sh preserves user-customised statusLine.command" {
@@ -675,8 +643,6 @@ _restore_settings_fixture() {
 
     cmd=$(jq -r '.statusLine.command' "${DOTFILES_ROOT}/claude/settings.json")
     [ "$cmd" = "$HOME/bin/my-custom-statusline.sh" ]
-
-    _restore_settings_fixture
 }
 
 # ---------- Issue #300, item C: claude_accounts_status shows oauth binding ----------

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -67,6 +67,12 @@ teardown_isolated_home() {
 # isolated tree. teardown_isolated_home restores the real values.
 # Precondition: setup_isolated_home must have run (TEST_TEMP_HOME exists).
 setup_isolated_dotfiles_root() {
+    # Hard-fail if the precondition isn't met. Without this, an empty
+    # TEST_TEMP_HOME makes `iso_root` resolve to `/dotfiles-iso` (system root).
+    [ -n "$TEST_TEMP_HOME" ] || {
+        echo "setup_isolated_dotfiles_root: TEST_TEMP_HOME not set — call setup_isolated_home first" >&2
+        return 1
+    }
     local real_root="$_BATS_REAL_DOTFILES_ROOT"
     local iso_root="$TEST_TEMP_HOME/dotfiles-iso"
 

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -12,11 +12,23 @@ load "${_BATS_LIB_DIR}/bats-assert/load"
 export DOTFILES_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export SHELL_COMMON="${DOTFILES_ROOT}/shell-common"
 
+# Frozen snapshot. setup_isolated_dotfiles_root overrides DOTFILES_ROOT for
+# its caller's test body; setup_isolated_home / teardown_isolated_home use
+# this snapshot to restore the real-tree value before/after each test so a
+# stale override from the previous test cannot leak.
+_BATS_REAL_DOTFILES_ROOT="$DOTFILES_ROOT"
+_BATS_REAL_SHELL_COMMON="$SHELL_COMMON"
+
 # Test isolation
 export DOTFILES_TEST_MODE=1
 export DOTFILES_FORCE_INIT=1
 
 setup_isolated_home() {
+    # Restore real DOTFILES_ROOT first — the previous test may have pointed
+    # it at a (now-deleted) isolated tree via setup_isolated_dotfiles_root.
+    export DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT"
+    export SHELL_COMMON="$_BATS_REAL_SHELL_COMMON"
+
     TEST_TEMP_HOME="$(mktemp -d)"
     export HOME="$TEST_TEMP_HOME"
     export ZDOTDIR="$TEST_TEMP_HOME"
@@ -30,6 +42,53 @@ teardown_isolated_home() {
     if [ -n "$TEST_TEMP_HOME" ] && [ -d "$TEST_TEMP_HOME" ]; then
         rm -rf "$TEST_TEMP_HOME"
     fi
+    export DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT"
+    export SHELL_COMMON="$_BATS_REAL_SHELL_COMMON"
+}
+
+# Stage an isolated DOTFILES_ROOT for tests that invoke claude/setup.sh or
+# write to ${DOTFILES_ROOT}/claude/. Without this, setup.sh leaves
+# `settings.json.pre-statusline-fix-*` backup files in the version-controlled
+# tree and fixture writes mutate the gitignored claude/settings.json — both
+# survive interrupted runs (issue #303).
+#
+# Layout: $TEST_TEMP_HOME/dotfiles-iso/
+#   bash, zsh, shell-common  → symlinks to real tree (read-only by tests)
+#   claude/                  → real dir (mutable; setup.sh writes backups here)
+#     setup.sh               → cp of real (NOT symlink — setup.sh resolves
+#                              DOTFILES_ROOT via realpath of its own path,
+#                              so a symlink would escape isolation)
+#     statusline-command.sh, settings.template.json → symlinks (read-only)
+#     settings.json          → cp of template (gitignored convention)
+#     skills/, docs/, global-memory/ → empty dirs (satisfy setup.sh's
+#                              `[ -d ]` source-existence guards)
+#
+# Side effect: re-exports DOTFILES_ROOT and SHELL_COMMON to point at the
+# isolated tree. teardown_isolated_home restores the real values.
+# Precondition: setup_isolated_home must have run (TEST_TEMP_HOME exists).
+setup_isolated_dotfiles_root() {
+    local real_root="$_BATS_REAL_DOTFILES_ROOT"
+    local iso_root="$TEST_TEMP_HOME/dotfiles-iso"
+
+    mkdir -p "$iso_root/claude"
+    ln -s "$real_root/shell-common" "$iso_root/shell-common"
+    ln -s "$real_root/bash" "$iso_root/bash"
+    ln -s "$real_root/zsh" "$iso_root/zsh"
+
+    cp "$real_root/claude/setup.sh" "$iso_root/claude/setup.sh"
+    ln -s "$real_root/claude/statusline-command.sh"  "$iso_root/claude/statusline-command.sh"
+    ln -s "$real_root/claude/settings.template.json" "$iso_root/claude/settings.template.json"
+
+    mkdir -p "$iso_root/claude/skills" "$iso_root/claude/docs" "$iso_root/claude/global-memory"
+
+    if [ -f "$iso_root/claude/settings.template.json" ]; then
+        cp "$iso_root/claude/settings.template.json" "$iso_root/claude/settings.json"
+    else
+        echo '{}' > "$iso_root/claude/settings.json"
+    fi
+
+    export DOTFILES_ROOT="$iso_root"
+    export SHELL_COMMON="$iso_root/shell-common"
 }
 
 # Run a command in bash subprocess with dotfiles loaded


### PR DESCRIPTION
## Summary

Refactor bats test helpers so `claude/setup.sh` integration tests no longer
mutate the version-controlled source tree.

- New `setup_isolated_dotfiles_root` helper in `tests/bats/test_helper.bash`
  stages a temp `DOTFILES_ROOT` under `$TEST_TEMP_HOME` — symlinks for
  read-only siblings (`shell-common/`, `bash/`, `zsh/`) and a writable
  `claude/` copy. `setup.sh` resolves `DOTFILES_ROOT` via `realpath` of its
  own `BASH_SOURCE`, so the file itself is `cp`'d (not symlinked) to keep
  isolation intact.
- `_setup_sh_prereqs` is now a one-line delegate to the helper. The
  `_use_settings_fixture` save logic and `_restore_settings_fixture`
  function are gone — `teardown_isolated_home` wipes `$TEST_TEMP_HOME`
  per-test, so an interrupted run no longer leaves
  `settings.json.pre-statusline-fix-*` artifacts under
  `claude/`.
- `setup_isolated_home` / `teardown_isolated_home` both restore
  `DOTFILES_ROOT` from a frozen snapshot so a stale isolated path from
  the previous test cannot leak into the next.

Addresses gemini-code-assist's high-priority comment on PR #301 — the
fix is wider than that PR's diff because the same staging pattern lives
in `_setup_sh_prereqs`, used by 4+ tests landed across PRs #287/#292/#297
plus the 3 #300-A tests added by #301.

## Test plan

- [x] `tests/bats/integrations/claude_accounts.bats` — 63/63 pass
- [x] Full bats suite (`init/`, `functions/`, `tools/`, `integrations/`)
      — 399/399 pass
- [x] `git status` clean after the run; no `*.pre-statusline-fix-*`
      leftovers under `claude/`
- [ ] Reviewer: spot-check a Ctrl-C mid-run scenario (e.g. interrupt
      during `issue #300-A: setup.sh rewrites legacy ...`) — fixture
      writes should still land in the temp tree only

Closes #303
Refs PR #301 (deferral context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
