### PR TITLE
fix(gwt): detect squash-merge via tree equivalence (#307)

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1631,11 +1631,12 @@ _gwt_commits_safe() {
     fi
 
     # 3. Working tree of HEAD matches origin/main (squash-merge case).
-    # An empty diff means every change is already on main, even if no
-    # individual commit is a patch-id match — squash collapses N→1, so
-    # `git cherry` (step 4) cannot detect this. Check tree equivalence
-    # before the more expensive patch-id walk.
-    if [ -z "$(git diff "$main_ref" HEAD 2>/dev/null)" ]; then
+    # No diff means every change is already on main, even if no individual
+    # commit is a patch-id match — squash collapses N→1, so `git cherry`
+    # (step 4) cannot detect this. `--quiet` is fail-closed: exit 0 only on
+    # genuine no-diff; on bad ref / git error it exits non-zero so we do NOT
+    # mistake a failed comparison for a clean tree.
+    if git diff --quiet "$main_ref" HEAD 2>/dev/null; then
         return 0
     fi
 
@@ -1674,9 +1675,10 @@ _gwt_branch_merged() {
         return 0
     fi
     # Squash merge: target collapsed N commits to 1, so patch-ids no longer
-    # match 1:1 — but the branch's tree is still present in target. Empty diff
-    # means every change has been incorporated.
-    [ -z "$(git diff "$target" "$branch" 2>/dev/null)" ]
+    # match 1:1 — but the branch's tree is still present in target. `--quiet`
+    # is fail-closed: exit 0 only on genuine no-diff; bad ref / git error
+    # exits non-zero so a failed comparison is not mistaken for "merged".
+    git diff --quiet "$target" "$branch" 2>/dev/null
 }
 
 # ============================================================================

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1610,7 +1610,8 @@ git_worktree_spawn() {
 # ============================================================================
 # Internal: check if current HEAD's commits are safe to discard
 # Returns 0 (safe) if: upstream matches, or HEAD is in origin/main,
-# or all patches are already in origin/main (rebase/squash merge).
+# or HEAD's tree matches origin/main (squash-merge), or all patches are
+# already in origin/main (rebase merge).
 # ============================================================================
 _gwt_commits_safe() {
     local local_rev remote_rev
@@ -1629,15 +1630,25 @@ _gwt_commits_safe() {
         return 0
     fi
 
-    # 3. All patches already applied via rebase/squash merge (patch-id comparison)
+    # 3. Working tree of HEAD matches origin/main (squash-merge case).
+    # An empty diff means every change is already on main, even if no
+    # individual commit is a patch-id match — squash collapses N→1, so
+    # `git cherry` (step 4) cannot detect this. Check tree equivalence
+    # before the more expensive patch-id walk.
+    if [ -z "$(git diff "$main_ref" HEAD 2>/dev/null)" ]; then
+        return 0
+    fi
+
+    # 4. All patches already applied via rebase merge (patch-id comparison).
     # git cherry marks already-applied commits with '-', unapplied with '+'.
     # If grep finds no '+' line, every HEAD commit is patch-id-equivalent to
-    # something already in main_ref → safe.
+    # something already in main_ref → safe. Misses squash-merge (handled in
+    # step 3) because squash maps N commits to a single patch-id on main.
     if ! git cherry "$main_ref" HEAD 2>/dev/null | grep -q '^+'; then
         return 0
     fi
 
-    # 4. Upstream exists but remote branch was deleted (PR merged + branch auto-deleted)
+    # 5. Upstream exists but remote branch was deleted (PR merged + branch auto-deleted)
     if [ "$remote_rev" = "no-upstream" ]; then
         # No upstream ever set — could be genuinely unpushed
         # Check if there are any commits beyond the merge-base with main
@@ -1658,8 +1669,14 @@ _gwt_commits_safe() {
 # ============================================================================
 _gwt_branch_merged() {
     local branch="$1" target="$2"
-    # No '+' line from git cherry → all patches already in target.
-    ! git cherry "$target" "$branch" 2>/dev/null | grep -q '^+'
+    # Rebase merge: every commit is patch-id-equivalent to one already in target.
+    if ! git cherry "$target" "$branch" 2>/dev/null | grep -q '^+'; then
+        return 0
+    fi
+    # Squash merge: target collapsed N commits to 1, so patch-ids no longer
+    # match 1:1 — but the branch's tree is still present in target. Empty diff
+    # means every change has been incorporated.
+    [ -z "$(git diff "$target" "$branch" 2>/dev/null)" ]
 }
 
 # ============================================================================
@@ -1686,7 +1703,13 @@ _gwt_report_unpushed() {
     git rev-parse --verify --quiet "$main_ref" >/dev/null 2>&1 || main_ref="origin/master"
 
     local upstream ahead remote_branch_ref remote_branch_exists
-    upstream="$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null || echo "(none)")"
+    # `git rev-parse --abbrev-ref '@{u}'` exits non-zero AND prints the
+    # literal "@{u}" to stdout when no upstream is set, which leaks into
+    # the captured value. Sanitize before display.
+    upstream="$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null)"
+    if [ -z "$upstream" ] || [ "$upstream" = "@{u}" ]; then
+        upstream="(none)"
+    fi
     ahead="$(git rev-list --count "$main_ref"..HEAD 2>/dev/null || echo "?")"
     remote_branch_ref="origin/$branch"
     if git rev-parse --verify --quiet "refs/remotes/$remote_branch_ref" >/dev/null 2>&1; then

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -565,3 +565,71 @@ _add_extra_worktrees() {
     assert_output --partial "Not inside a worktree"
     assert_output --partial "gwt teardown --all"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #307: squash-merge with N>1 local commits + missing upstream
+# ---------------------------------------------------------------------------
+
+# Apply the same final tree as the worktree's N commits, but as a SINGLE
+# commit on origin/main — the actual squash-merge shape that `git cherry`
+# (patch-id 1:1) cannot detect.
+_squash_merge_multi_into_origin_main() {
+    local helper="$TEST_TEMP_HOME/squash-multi-helper"
+    rm -rf "$helper"
+    git clone -q "$ORIGIN" "$helper"
+    (
+        cd "$helper"
+        echo a > a.txt
+        echo b > b.txt
+        echo c > c.txt
+        git add a.txt b.txt c.txt
+        git commit -q -m "squash: merged via PR (3 commits collapsed)"
+        git push -q origin main
+    )
+    rm -rf "$helper"
+    git -C "$CLONE" fetch -q origin
+}
+
+@test "teardown: squash-merged worktree (N>1 local commits) is safe without --force" {
+    # Worktree has 3 distinct commits never pushed. origin/main gains a single
+    # squash commit that materially equals the worktree's tree. Pre-fix:
+    # _gwt_commits_safe rejects via git cherry (3 patch-ids vs 1) and blocks
+    # teardown. Post-fix: tree equivalence (`git diff origin/main HEAD` is
+    # empty) recognizes safety AND _gwt_branch_merged announces rebase-merged
+    # so the branch is also cleaned up.
+    (
+        cd "$WORKTREE"
+        # `git worktree add -b ... origin/main` auto-tracks origin/main; clear
+        # it to faithfully reproduce the never-pushed worktree from issue #307.
+        git branch --unset-upstream 2>/dev/null || true
+        echo a > a.txt && git add a.txt && git commit -q -m "a"
+        echo b > b.txt && git add b.txt && git commit -q -m "b"
+        echo c > c.txt && git add c.txt && git commit -q -m "c"
+    )
+    _squash_merge_multi_into_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_success
+    assert_output --partial "rebase-merged"
+    [ ! -d "$WORKTREE" ]
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_failure
+}
+
+@test "teardown: unpushed-commits report renders 'upstream: (none)' on one line" {
+    # Reproduce the noisy two-line render from issue #307: when no upstream is
+    # set, `git rev-parse --abbrev-ref '@{u}'` exits non-zero AND prints the
+    # literal "@{u}" to stdout, which used to leak into the error message.
+    (
+        cd "$WORKTREE"
+        # `git worktree add -b ... origin/main` auto-tracks origin/main; clear
+        # it so @{u} is genuinely unset like the real never-pushed scenario.
+        git branch --unset-upstream 2>/dev/null || true
+        echo unpushed > unpushed.txt && git add unpushed.txt && git commit -q -m "unpushed"
+    )
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_failure
+    assert_output --partial "upstream: (none)"
+    refute_output --partial "upstream: @{u}"
+}


### PR DESCRIPTION
## Summary
- `gwt teardown` 가 squash-merge 후 워크트리를 정리하지 못하던 버그를 고칩니다 (#307).
- `_gwt_commits_safe` / `_gwt_branch_merged` 두 헬퍼에 트리 동등성(tree equivalence) 체크를 추가해 N→1 squash 케이스를 인식합니다.
- `_gwt_report_unpushed` 의 `upstream: @{u}\n(none)` 두 줄 출력 버그도 같이 수정합니다.

## Changes
- `shell-common/functions/git_worktree.sh`
  - `_gwt_commits_safe`: 기존 4개 체크 사이에 "tree equivalence" 단계를 추가합니다. `git diff origin/main HEAD` 가 비어 있으면 — 모든 변경분이 main 에 이미 반영된 상태이므로 — 안전하다고 판정합니다. patch-id 비교(`git cherry`)는 squash 가 N개 commit 을 1개로 합칠 때 1:1 매칭이 깨져 squash-merge 를 놓치는 한계가 있어, 그 앞에 더 저렴한 트리 비교를 둡니다.
  - `_gwt_branch_merged`: 같은 이유로 `git cherry` 매칭에 실패하면 `git diff <target> <branch>` 가 비었는지 한 번 더 확인합니다. 이 덕분에 teardown 의 branch-delete 경로(라인 2084)도 squash-merge 케이스에서 "rebase-merged" 로 정리됩니다.
  - `_gwt_report_unpushed`: `git rev-parse --abbrev-ref '@{u}'` 는 upstream 미설정 시 **stdout 으로 리터럴 `@{u}` 를 출력하면서** non-zero 로 종료합니다. 기존 `... || echo "(none)"` 패턴은 그 stdout 까지 같이 캡처해 변수에 두 줄(`@{u}\n(none)`)이 들어가고, 사용자에게 깨진 메시지가 보였습니다. 캡처 후 명시적으로 sanitize 하도록 변경했습니다.

- `tests/bats/functions/git_worktree_teardown.bats`
  - 새 픽스처 `_squash_merge_multi_into_origin_main`: 워크트리의 N개 commit 과 같은 최종 트리를 단일 squash commit 으로 origin/main 에 푸시하는 helper.
  - 회귀 테스트 1: 워크트리 3 commit + origin/main squash 1 commit 시나리오에서 `gwt teardown` (no `--force`) 가 성공하고, 브랜치까지 `rebase-merged` 로 삭제되는지 검증합니다.
  - 회귀 테스트 2: upstream 미설정 상태에서 unpushed 보고가 `upstream: (none)` 한 줄로 렌더되고 `upstream: @{u}` 가 출력되지 않는지 검증합니다.

## Test plan
- [x] `bats tests/bats/functions/git_worktree_teardown.bats` — 29 / 29 passed (신규 2 케이스 포함).
- [x] `bats tests/bats/functions/*.bats` — 276 / 276 passed (회귀 없음).
- [x] `shellcheck shell-common/functions/git_worktree.sh` — 신규 경고 없음 (기존 SC3043 만 잔존).
- [ ] (수동, 권장) 실제 worktree 에서 squash-merge 된 PR 시나리오로 `gwt teardown` 한 번 더 검증.

## Related
Closes #307


---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
