### PR TITLE
fix(project-board): include "In review" in opened-step guard

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -85,10 +85,12 @@ jobs:
           _gh_project_status_sync pr "$PR_NUMBER" "In review"
           # Move linked Issues to "In progress" — the builtin "Pull request linked
           # to issue" workflow moves them to "In review", which is wrong for Issues.
-          # --only-from prevents regressing Issues already past "Ready".
+          # "In review" is included in --only-from so we can correct the builtin's
+          # mis-move even when it fires first; "Done" is intentionally excluded so
+          # a re-opened PR cannot drag a closed Issue card backwards (#309).
           for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO"); do
             _gh_project_status_sync issue "$_issue" "In progress" \
-              --only-from "Backlog,Ready"
+              --only-from "Backlog,Ready,In review"
           done
 
       - name: PR review approved → Approved

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -17,9 +17,10 @@ intended Issue lifecycle is `Backlog → In progress → Done` — Issues must n
 visit "In review" or "Approved" (issue #289).
 
 Calling `_gh_project_status_sync issue … "In progress"` immediately after the
-PR is created corrects the builtin's transition. The `--only-from "Backlog,Ready"`
-guard prevents regressing Issues that are already further along (e.g., an Issue
-that was manually at "In progress" before the PR opened is left alone).
+PR is created corrects the builtin's transition. The
+`--only-from "Backlog,Ready,In review"` guard explicitly includes `In review`
+so we can undo the builtin's mis-move even when it fires before our sync, while
+still refusing to drag `Done` Issues backwards if a closed PR is re-opened (#309).
 
 ## Snippet
 
@@ -30,7 +31,7 @@ Source the shared helper, then call it with the new PR number:
 _gh_project_status_sync pr "$PR_NUMBER" "In review"
 for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO"); do
     _gh_project_status_sync issue "$_issue" "In progress" \
-        --only-from "Backlog,Ready"
+        --only-from "Backlog,Ready,In review"
 done
 ```
 

--- a/docs/standards/github-project-board.md
+++ b/docs/standards/github-project-board.md
@@ -147,9 +147,12 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
      가드가 적용되어 follow-up 커밋이 들어와도 상태를 되돌리지 않는다.
      raw `git commit` 경로에선 수동 이동.
   2. `/gh-pr` 또는 `project-board-sync.yml` (PR opened 이벤트) 가 PR 생성
-     직후 `_gh_project_status_sync issue … "In progress" --only-from "Backlog,Ready"` 를
+     직후 `_gh_project_status_sync issue … "In progress" --only-from "Backlog,Ready,In review"` 를
      호출한다. 이는 GitHub 빌트인 `Pull request linked to issue` (#3) 가
-     Issue 카드를 `In review` 로 잘못 이동시키는 것을 즉시 교정한다 (#289).
+     Issue 카드를 `In review` 로 잘못 이동시키는 것을 즉시 교정한다 (#289). 가드에
+     `In review` 가 포함되어 있어 빌트인이 먼저 발화한 뒤에도 보정이 동작하며,
+     `Done` 만은 가드에서 제외해 닫힌 Issue 가 재오픈된 PR 로 인해 역행하지 않는다
+     (#309).
 - **PR 카드 `Backlog → In review`**: `/gh-flow` 워커 또는 `/gh-pr`
   단독 실행이 PR 생성 직후 자동 전환한다. raw `gh pr create` 로
   PR 을 만든 경우엔 수동 이동이 필요하다. `project-board-sync.yml` 의

--- a/tests/bats/init/project_board_sync_workflow.bats
+++ b/tests/bats/init/project_board_sync_workflow.bats
@@ -56,11 +56,14 @@ WORKFLOW="${DOTFILES_ROOT}/.github/workflows/project-board-sync.yml"
     grep -Eq '_gh_project_status_sync[[:space:]]+pr[[:space:]]+"\$PR_NUMBER"[[:space:]]+"In review"' "$WORKFLOW"
 }
 
-@test "PR opened step: syncs linked Issues to In progress with Backlog,Ready guard" {
+@test "PR opened step: syncs linked Issues to In progress with Backlog,Ready,In review guard" {
     # Issues must not visit "In review" — the opened step immediately corrects
     # the builtin "Pull request linked to issue" workflow that would move them there.
+    # "In review" must be in the guard list so the correction still fires when the
+    # builtin runs first and the Issue is already at "In review" (#309). "Done" is
+    # intentionally excluded so a re-opened PR cannot regress a closed Issue card.
     grep -q '_gh_project_status_sync issue' "$WORKFLOW"
-    grep -q -- '--only-from "Backlog,Ready"' "$WORKFLOW"
+    grep -q -- '--only-from "Backlog,Ready,In review"' "$WORKFLOW"
 }
 
 @test "PR review approved step: syncs PR card to Approved" {


### PR DESCRIPTION
## Summary
- 빌트인 "Pull request linked to issue" 워크플로가 PR open 직후 Issue 카드를 `In review` 로 잘못 옮겨도, opened-step 의 `_gh_project_status_sync issue … "In progress"` 가드가 이를 되돌릴 수 있도록 화이트리스트에 `In review` 를 추가했다.
- 현재 가드(`Backlog,Ready`)는 빌트인이 먼저 발화하면 영구히 차단되는 결정론적 패턴 — race 가 아니다 (PR #308 → Issue #307 사례).
- `Done` 은 의도적으로 가드에서 제외해 닫힌 Issue 가 PR 재오픈 경로로 역행하지 않도록 한다.

## Changes
- `.github/workflows/project-board-sync.yml` — opened/ready_for_review/reopened 단계의 `--only-from "Backlog,Ready"` → `"Backlog,Ready,In review"` 로 확장. 의도 주석도 갱신해 `In review` 포함 / `Done` 제외 이유를 명시.
- `claude/skills/gh-pr/references/project-board-sync.md` — Snippet 의 가드 값 갱신 및 "Done 회귀 방지" 의도 명시. `/gh-pr` Step 7 (project board sync) 가 워크플로와 동일한 가드를 사용하므로 SSOT 가 깨지지 않게 동시 갱신.
- `docs/standards/github-project-board.md` — Issue 라이프사이클 자동 전환 규칙 문단의 가드 값 갱신 + `In review` 포함 / `Done` 제외 의도 추가.
- `tests/bats/init/project_board_sync_workflow.bats` — `Backlog,Ready` assertion 을 `Backlog,Ready,In review` 로 갱신, 테스트 이름도 새 가드 반영.

## Test plan
- [x] `bats tests/bats/init/project_board_sync_workflow.bats` — 17/17 통과 (가드 assertion 갱신 후 재실행)
- [x] `bats tests/bats/init/` — 38/38 통과
- [x] `bats tests/bats/functions/` — 274/274 통과 (`gh_project_status` 회귀 없음)
- [ ] PR merge 후 다음 PR 의 linked Issue 가 실제로 `In progress` 컬럼에 안착하는지 보드에서 확인

## Notes
- 정적 grep 만으로는 가드 값이 의도대로 동작하는지 검증 못 한다는 게 #289 → #309 의 교훈. 실제 라이브 행동 테스트(보드 픽스처에 Issue 를 `In review` 로 두고 sync 후 `In progress` 인지 확인)는 후속 PR 로 분리.
- `_gh_project_status_sync issue ... "Done" --only-from "Backlog,In progress,In review"` 가드(merged 단계)는 변경 없음 — 별개 이슈/회귀 영역.

## Related
Closes #309


---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
