### PR TITLE
fix(src): always reload from canonical dotfiles tree (#310)

### DIFF
--- a/shell-common/aliases/core.sh
+++ b/shell-common/aliases/core.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # core_aliases.bash
 # 기본 명령어에 대한 alias 정의
 
@@ -6,14 +7,39 @@
 alias reload='exec ${SHELL##*/}'
 alias rs='reload'
 
-# Shell-aware configuration reload (sources appropriate rc file)
+# Shell-aware configuration reload — always reloads from the canonical
+# dotfiles tree ($DOTFILES_CANONICAL or $HOME/dotfiles), even when the
+# current shell inherited a worktree-leaked $DOTFILES_ROOT (issue #310).
 src() {
+    local _canon="${DOTFILES_CANONICAL:-$HOME/dotfiles}"
+
+    if [ ! -d "$_canon" ]; then
+        if command -v ux_error >/dev/null 2>&1; then
+            ux_error "src: canonical dotfiles not found at $_canon"
+        else
+            echo "src: canonical dotfiles not found at $_canon" >&2
+        fi
+        return 1
+    fi
+
+    # Force-reset before re-sourcing so zsh/main.zsh's `if [ -z "$DOTFILES_ROOT" ]`
+    # guard cannot preserve a worktree-leaked value.
+    export DOTFILES_ROOT="$_canon"
+    export SHELL_COMMON="$_canon/shell-common"
+    unset DOTFILES_BASH_DIR
+
     if [ -n "$ZSH_VERSION" ]; then
-        # Running in zsh
-        source ~/.zshrc
+        # shellcheck source=/dev/null
+        . "$_canon/zsh/zshrc"
     else
-        # Default to bash
-        source ~/.bashrc
+        # shellcheck source=/dev/null
+        . "$_canon/bash/main.bash"
+    fi
+
+    if command -v ux_info >/dev/null 2>&1; then
+        ux_info "src: reloaded from $_canon"
+    else
+        echo "src: reloaded from $_canon"
     fi
 }
 

--- a/tests/bats/init/src_reload.bats
+++ b/tests/bats/init/src_reload.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/bats/init/src_reload.bats
+# Verify `src` always reloads from the canonical dotfiles tree, even when
+# the inherited shell has DOTFILES_ROOT leaked to a worktree path
+# (regression for issue #310).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+
+    # Stub canonical dotfiles tree under the isolated HOME.
+    FAKE_CANON="$TEST_TEMP_HOME/fake-canon"
+    mkdir -p "$FAKE_CANON/bash" "$FAKE_CANON/zsh" "$FAKE_CANON/shell-common"
+
+    # Stub rc files — `src` only needs them to source successfully.
+    : >"$FAKE_CANON/bash/main.bash"
+    : >"$FAKE_CANON/zsh/zshrc"
+
+    # Path that simulates a worktree-leaked DOTFILES_ROOT.
+    LEAK_ROOT="$TEST_TEMP_HOME/leaked-worktree"
+    mkdir -p "$LEAK_ROOT"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Helper: run `src` in a clean bash subshell with leaked DOTFILES_ROOT
+# preset, and capture the resulting environment.
+_run_src_bash() {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        export DOTFILES_CANONICAL='$FAKE_CANON'
+        export DOTFILES_ROOT='$LEAK_ROOT'
+        export SHELL_COMMON='$LEAK_ROOT/shell-common'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/tools/ux_lib/ux_lib.sh'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/aliases/core.sh'
+        src || exit \$?
+        printf 'AFTER:DOTFILES_ROOT=%s\n' \"\$DOTFILES_ROOT\"
+        printf 'AFTER:SHELL_COMMON=%s\n' \"\$SHELL_COMMON\"
+        printf 'AFTER:DOTFILES_BASH_DIR=%s\n' \"\${DOTFILES_BASH_DIR-<unset>}\"
+    "
+}
+
+_run_src_zsh() {
+    run zsh -f -c "
+        export HOME='$HOME'
+        export DOTFILES_CANONICAL='$FAKE_CANON'
+        export DOTFILES_ROOT='$LEAK_ROOT'
+        export SHELL_COMMON='$LEAK_ROOT/shell-common'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/tools/ux_lib/ux_lib.sh'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/aliases/core.sh'
+        src || exit \$?
+        printf 'AFTER:DOTFILES_ROOT=%s\n' \"\$DOTFILES_ROOT\"
+        printf 'AFTER:SHELL_COMMON=%s\n' \"\$SHELL_COMMON\"
+    "
+}
+
+@test "bash: src resets leaked DOTFILES_ROOT to canonical" {
+    _run_src_bash
+    assert_success
+    assert_output --partial "AFTER:DOTFILES_ROOT=$FAKE_CANON"
+    assert_output --partial "AFTER:SHELL_COMMON=$FAKE_CANON/shell-common"
+}
+
+@test "bash: src unsets DOTFILES_BASH_DIR before re-sourcing" {
+    _run_src_bash
+    assert_success
+    # Stub main.bash is empty, so DOTFILES_BASH_DIR stays unset after src.
+    assert_output --partial "AFTER:DOTFILES_BASH_DIR=<unset>"
+}
+
+@test "zsh: src resets leaked DOTFILES_ROOT to canonical" {
+    _run_src_zsh
+    assert_success
+    assert_output --partial "AFTER:DOTFILES_ROOT=$FAKE_CANON"
+    assert_output --partial "AFTER:SHELL_COMMON=$FAKE_CANON/shell-common"
+}
+
+@test "bash: src fails with non-zero when canonical dir is missing" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        export DOTFILES_CANONICAL='$TEST_TEMP_HOME/does-not-exist'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/tools/ux_lib/ux_lib.sh'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/aliases/core.sh'
+        src
+    "
+    assert_failure
+    assert_output --partial "canonical dotfiles not found"
+}
+
+@test "bash: src defaults to \$HOME/dotfiles when DOTFILES_CANONICAL is unset" {
+    # Stage a fake canonical at $HOME/dotfiles inside the isolated home.
+    mkdir -p "$HOME/dotfiles/bash"
+    : >"$HOME/dotfiles/bash/main.bash"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        unset DOTFILES_CANONICAL
+        export DOTFILES_ROOT='$LEAK_ROOT'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/tools/ux_lib/ux_lib.sh'
+        . '$_BATS_REAL_DOTFILES_ROOT/shell-common/aliases/core.sh'
+        src || exit \$?
+        printf 'AFTER:DOTFILES_ROOT=%s\n' \"\$DOTFILES_ROOT\"
+    "
+    assert_success
+    assert_output --partial "AFTER:DOTFILES_ROOT=$HOME/dotfiles"
+}


### PR DESCRIPTION
## Summary
- 워크트리 셸에서 `src` 가 캐노니컬 dotfiles 가 아닌 워크트리 트리를 재로드하던 문제 수정 (issue #310)
- `DOTFILES_ROOT` / `SHELL_COMMON` 을 캐노니컬로 강제 reset 하고, 캐노니컬 rc 파일을 직접 source 하도록 변경
- 5개 bats 회귀 테스트 추가 (`tests/bats/init/src_reload.bats`)

## Changes
- **`shell-common/aliases/core.sh`**: `src()` 가 호출 시 `${DOTFILES_CANONICAL:-$HOME/dotfiles}` 으로 환경 변수 (`DOTFILES_ROOT`, `SHELL_COMMON`) 를 선재할당하고 `DOTFILES_BASH_DIR` 을 unset 한 뒤 `$_canon/zsh/zshrc` 또는 `$_canon/bash/main.bash` 를 직접 source. 캐노니컬 dir 부재 시 명확한 에러로 거부, 성공 시 `src: reloaded from <path>` 한 줄 안내 출력. 누락된 `#!/bin/sh` 셔뱅도 함께 추가 (pre-commit shebang 게이트 통과용).
- **`tests/bats/init/src_reload.bats`** (신규): bash/zsh 양쪽에서 leak reset 검증, `DOTFILES_BASH_DIR` 정리 검증, 캐노니컬 누락 시 실패 모드 검증, `DOTFILES_CANONICAL` 미설정 시 `$HOME/dotfiles` 디폴트 검증.

## Out of scope (후속 이슈로 분리 권장)
이슈 본문의 우선순위에 따라 1순위만 구현. 2/3순위는 leak 경로 자체를 줄이는 후속 개선:
- 2순위: `zsh/main.zsh:22` 의 `if [ -z "$DOTFILES_ROOT" ]` 가드 강화 (외부 주입 화이트리스트/재계산)
- 3순위: `bash/setup.sh`, `zsh/setup.sh`, `shell-common/setup.sh` 의 `DOTFILES_ROOT` export 범위 축소

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/init/src_reload.bats` → 5/5 pass
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/{init,functions,tools,integrations}` → 406/406 pass (회귀 없음)
- [x] `shellcheck -e SC1090,SC1091 -x shell-common/aliases/core.sh` → clean
- [ ] 수동 검증: `DOTFILES_ROOT=/some/worktree zsh -c 'src; echo $DOTFILES_ROOT'` → 캐노니컬 경로 출력
- [ ] 수동 검증: 워크트리 디렉터리에서 `./bash/setup.sh` 후 같은 셸에서 `src` → `DOTFILES_ROOT` 가 캐노니컬로 복귀

## Related
Closes #310


---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
