### PR TITLE
fix(gwt): teardown trusts gh PR signal past squash (#315)

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1608,10 +1608,40 @@ git_worktree_spawn() {
 }
 
 # ============================================================================
+# Internal: query GitHub for the PR attached to <branch> and verify its
+# merge_commit lives in <main_ref>'s history. Returns 0 only when the PR is
+# MERGED and the merge_commit is reachable from main_ref.
+#
+# Used as a final fallback by _gwt_commits_safe and _gwt_branch_merged for
+# the "squash-merged then origin/main progressed past the squash" case
+# where neither tree-equivalence nor patch-id can detect that the work is
+# already merged (issue #315). gwt status already trusts this signal via
+# _gwt_remote_pr_states; teardown should match for a coherent UX.
+#
+# Soft-fails (returns 1) when gh is missing/unauthenticated, the branch has
+# no PR, the PR is not MERGED, or the merge_commit is not yet fetched.
+# Callers treat 1 as "no signal" and continue with their existing checks.
+#
+# Usage: _gwt_pr_merged_into <branch> <main_ref>
+# ============================================================================
+_gwt_pr_merged_into() {
+    local branch="$1" main_ref="$2"
+    [ -n "$branch" ] && [ -n "$main_ref" ] || return 1
+    command -v gh >/dev/null 2>&1 || return 1
+    local pr_state merge_sha
+    pr_state="$(gh pr view "$branch" --json state -q .state 2>/dev/null)" || return 1
+    [ "$pr_state" = "MERGED" ] || return 1
+    merge_sha="$(gh pr view "$branch" --json mergeCommit -q .mergeCommit.oid 2>/dev/null)" || return 1
+    [ -n "$merge_sha" ] || return 1
+    git merge-base --is-ancestor "$merge_sha" "$main_ref" 2>/dev/null
+}
+
+# ============================================================================
 # Internal: check if current HEAD's commits are safe to discard
-# Returns 0 (safe) if: upstream matches, or HEAD is in origin/main,
-# or HEAD's tree matches origin/main (squash-merge), or all patches are
-# already in origin/main (rebase merge).
+# Returns 0 (safe) if: upstream matches, HEAD is in origin/main,
+# HEAD's tree matches origin/main (squash directly under main HEAD),
+# all patches are already in origin/main (rebase merge), or GitHub reports
+# the branch's PR as MERGED with the merge_commit reachable from main_ref.
 # ============================================================================
 _gwt_commits_safe() {
     local local_rev remote_rev
@@ -1630,12 +1660,14 @@ _gwt_commits_safe() {
         return 0
     fi
 
-    # 3. Working tree of HEAD matches origin/main (squash-merge case).
+    # 3. Working tree of HEAD matches origin/main (squash-merge case, narrow).
     # No diff means every change is already on main, even if no individual
     # commit is a patch-id match — squash collapses N→1, so `git cherry`
     # (step 4) cannot detect this. `--quiet` is fail-closed: exit 0 only on
     # genuine no-diff; on bad ref / git error it exits non-zero so we do NOT
-    # mistake a failed comparison for a clean tree.
+    # mistake a failed comparison for a clean tree. Loses signal once
+    # origin/main progresses past the squash with overlapping changes —
+    # step 5 (PR API) covers that broader case.
     if git diff --quiet "$main_ref" HEAD 2>/dev/null; then
         return 0
     fi
@@ -1644,12 +1676,23 @@ _gwt_commits_safe() {
     # git cherry marks already-applied commits with '-', unapplied with '+'.
     # If grep finds no '+' line, every HEAD commit is patch-id-equivalent to
     # something already in main_ref → safe. Misses squash-merge (handled in
-    # step 3) because squash maps N commits to a single patch-id on main.
+    # step 3 / 5) because squash maps N commits to a single patch-id on main.
     if ! git cherry "$main_ref" HEAD 2>/dev/null | grep -q '^+'; then
         return 0
     fi
 
-    # 5. Upstream exists but remote branch was deleted (PR merged + branch auto-deleted)
+    # 5. PR API verification. When squash collapses N→1 AND origin/main
+    # later progresses with overlapping changes, neither tree-equivalence
+    # (step 3) nor patch-id (step 4) detects it. Trust the same `gh` signal
+    # gwt status already uses; soft-fails when gh is unavailable.
+    local current_branch
+    current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    if [ -n "$current_branch" ] && [ "$current_branch" != "HEAD" ] \
+       && _gwt_pr_merged_into "$current_branch" "$main_ref"; then
+        return 0
+    fi
+
+    # 6. Upstream exists but remote branch was deleted (PR merged + branch auto-deleted)
     if [ "$remote_rev" = "no-upstream" ]; then
         # No upstream ever set — could be genuinely unpushed
         # Check if there are any commits beyond the merge-base with main
@@ -1674,11 +1717,18 @@ _gwt_branch_merged() {
     if ! git cherry "$target" "$branch" 2>/dev/null | grep -q '^+'; then
         return 0
     fi
-    # Squash merge: target collapsed N commits to 1, so patch-ids no longer
-    # match 1:1 — but the branch's tree is still present in target. `--quiet`
-    # is fail-closed: exit 0 only on genuine no-diff; bad ref / git error
-    # exits non-zero so a failed comparison is not mistaken for "merged".
-    git diff --quiet "$target" "$branch" 2>/dev/null
+    # Squash merge (narrow case): target collapsed N commits to 1, so
+    # patch-ids no longer match 1:1 — but the branch's tree is still present
+    # in target. `--quiet` is fail-closed: exit 0 only on genuine no-diff;
+    # bad ref / git error exits non-zero so a failed comparison is not
+    # mistaken for "merged".
+    if git diff --quiet "$target" "$branch" 2>/dev/null; then
+        return 0
+    fi
+    # PR API fallback (issue #315): once target progresses past the squash
+    # with overlapping changes, the diff is non-empty even though the work
+    # is merged. GitHub still knows.
+    _gwt_pr_merged_into "$branch" "$target"
 }
 
 # ============================================================================

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1628,11 +1628,21 @@ _gwt_pr_merged_into() {
     local branch="$1" main_ref="$2"
     [ -n "$branch" ] && [ -n "$main_ref" ] || return 1
     command -v gh >/dev/null 2>&1 || return 1
-    local pr_state merge_sha
-    pr_state="$(gh pr view "$branch" --json state -q .state 2>/dev/null)" || return 1
-    [ "$pr_state" = "MERGED" ] || return 1
-    merge_sha="$(gh pr view "$branch" --json mergeCommit -q .mergeCommit.oid 2>/dev/null)" || return 1
-    [ -n "$merge_sha" ] || return 1
+    # One `gh pr view` invocation, both fields. Two separate calls would
+    # mean two forks + two network round-trips per teardown — wasteful in
+    # `gwt teardown --all` where this runs once per worktree (PR #316
+    # gemini-code-assist review). `.mergeCommit?.oid // ""` is jq's
+    # null-safe pattern: an OPEN/CLOSED PR has `mergeCommit == null`, and
+    # the optional chain emits "" instead of erroring; the MERGED guard
+    # below still rejects non-merged states.
+    local pr_info pr_state merge_sha
+    pr_info="$(gh pr view "$branch" \
+        --json state,mergeCommit \
+        --jq '.state + " " + (.mergeCommit?.oid // "")' \
+        2>/dev/null)" || return 1
+    pr_state="${pr_info%% *}"
+    merge_sha="${pr_info#* }"
+    [ "$pr_state" = "MERGED" ] && [ -n "$merge_sha" ] || return 1
     git merge-base --is-ancestor "$merge_sha" "$main_ref" 2>/dev/null
 }
 

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -616,6 +616,125 @@ _squash_merge_multi_into_origin_main() {
     assert_failure
 }
 
+# ---------------------------------------------------------------------------
+# Issue #315: PR #307 follow-up — squash-merge then origin/main progresses
+# ---------------------------------------------------------------------------
+
+# Push another commit to origin/main that overlaps the squashed change so
+# tree-equivalence and patch-id BOTH break — the conditions that defeat
+# PR #307's local-only checks. <overlap_file>:<new_content> is what changes.
+_progress_origin_main_overlapping() {
+    local overlap_file="$1" new_content="$2"
+    local helper="$TEST_TEMP_HOME/progress-helper"
+    rm -rf "$helper"
+    git clone -q "$ORIGIN" "$helper"
+    (
+        cd "$helper"
+        printf '%s\n' "$new_content" > "$overlap_file"
+        echo extra > extra.txt
+        git add "$overlap_file" extra.txt
+        git commit -q -m "progress: another PR merged on top of squash"
+        git push -q origin main
+    )
+    rm -rf "$helper"
+    git -C "$CLONE" fetch -q origin
+}
+
+# Stub `gh` to return MERGED + a configurable merge_commit SHA for any
+# `gh pr view <branch> --json <fields> -q <expr>` invocation. The dotfiles
+# shell init does not call `gh`, so unhandled invocations are real test
+# bugs and exit 1 (same discipline as tests/bats/tools/setup_kanban_board.bats).
+_install_gh_mock() {
+    local mock_bin="$TEST_TEMP_HOME/mock-bin"
+    mkdir -p "$mock_bin"
+    cat >"$mock_bin/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+    expr=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -q) shift; expr="$1"; shift ;;
+            *) shift ;;
+        esac
+    done
+    case "$expr" in
+        .state)            printf 'MERGED\n' ;;
+        .mergeCommit.oid)  printf '%s\n' "${MOCK_GH_MERGE_SHA:-}" ;;
+        *)                 exit 1 ;;
+    esac
+    exit 0
+fi
+printf 'Unhandled gh invocation: %s\n' "$*" >&2
+exit 1
+GH_EOF
+    chmod +x "$mock_bin/gh"
+    export PATH="$mock_bin:$PATH"
+}
+
+@test "teardown: PR-merged + origin/main progressed past squash — safe via gh PR signal (issue #315)" {
+    # Issue #315 follow-up to PR #307. PR #307's tree-equivalence check works
+    # only while origin/main is *exactly* at the squash commit. Once another
+    # PR merges on top with overlapping changes, tree-equivalence AND
+    # patch-id both fail — but the PR is still genuinely merged. Trust the
+    # same `gh pr view` signal `gwt status` already uses.
+    (
+        cd "$WORKTREE"
+        git branch --unset-upstream 2>/dev/null || true
+        echo a > a.txt && git add a.txt && git commit -q -m "a"
+        echo b > b.txt && git add b.txt && git commit -q -m "b"
+        echo c > c.txt && git add c.txt && git commit -q -m "c"
+    )
+    _squash_merge_multi_into_origin_main
+
+    # Capture the squash commit SHA — this is what GitHub's mergeCommit.oid
+    # would return for the (mocked) PR. Read from CLONE so we do not have to
+    # re-fetch into WORKTREE before the assertions below.
+    local squash_sha
+    squash_sha="$(git -C "$CLONE" rev-parse origin/main)"
+
+    # Advance origin/main past the squash with overlapping changes — this is
+    # exactly what defeats PR #307's local-only checks.
+    _progress_origin_main_overlapping a.txt "a-progressed-by-other-pr"
+
+    # Sanity: confirm both local-only signals are now broken. If either
+    # accidentally still detects "safe", this test no longer exercises #315.
+    run git -C "$WORKTREE" diff --quiet origin/main HEAD
+    assert_failure
+    run bash -c "git -C '$WORKTREE' cherry origin/main HEAD | grep -q '^+'"
+    assert_success
+
+    _install_gh_mock
+    export MOCK_GH_MERGE_SHA="$squash_sha"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_success
+    assert_output --partial "rebase-merged"
+    [ ! -d "$WORKTREE" ]
+    run git -C "$CLONE" rev-parse --verify --quiet wt/test/1
+    assert_failure
+}
+
+@test "teardown: PR-merged signal ignored when merge_commit not in main_ref (issue #315)" {
+    # Defensive: if gh reports MERGED but the merge_commit is unreachable
+    # from origin/main (e.g. a typo SHA, wrong remote, unfetched), the helper
+    # must NOT mark commits safe — we'd rather fall back to the existing
+    # error path than discard real work.
+    (
+        cd "$WORKTREE"
+        git branch --unset-upstream 2>/dev/null || true
+        echo a > a.txt && git add a.txt && git commit -q -m "a"
+        echo b > b.txt && git add b.txt && git commit -q -m "b"
+    )
+
+    _install_gh_mock
+    # Bogus SHA shape (40 hex zeros) — not present anywhere in this repo.
+    export MOCK_GH_MERGE_SHA="0000000000000000000000000000000000000000"
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown 2>&1"
+    assert_failure
+    assert_output --partial "are not in origin/main"
+}
+
 @test "teardown: unpushed-commits report renders 'upstream: (none)' on one line" {
     # Reproduce the noisy two-line render from issue #307: when no upstream is
     # set, `git rev-parse --abbrev-ref '@{u}'` exits non-zero AND prints the

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -640,28 +640,19 @@ _progress_origin_main_overlapping() {
     git -C "$CLONE" fetch -q origin
 }
 
-# Stub `gh` to return MERGED + a configurable merge_commit SHA for any
-# `gh pr view <branch> --json <fields> -q <expr>` invocation. The dotfiles
-# shell init does not call `gh`, so unhandled invocations are real test
-# bugs and exit 1 (same discipline as tests/bats/tools/setup_kanban_board.bats).
+# Stub `gh` for the consolidated `gh pr view <branch> --json state,mergeCommit
+# --jq '.state + " " + (.mergeCommit?.oid // "")'` invocation _gwt_pr_merged_into
+# now uses (PR #316 review). MOCK_GH_MERGE_SHA unset → emit empty merge_sha so
+# the helper's negative-path test exercises the "no merge commit" branch.
+# The dotfiles shell init does not call `gh`, so unhandled invocations are real
+# test bugs and exit 1 (same discipline as tests/bats/tools/setup_kanban_board.bats).
 _install_gh_mock() {
     local mock_bin="$TEST_TEMP_HOME/mock-bin"
     mkdir -p "$mock_bin"
     cat >"$mock_bin/gh" <<'GH_EOF'
 #!/usr/bin/env bash
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-    expr=""
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            -q) shift; expr="$1"; shift ;;
-            *) shift ;;
-        esac
-    done
-    case "$expr" in
-        .state)            printf 'MERGED\n' ;;
-        .mergeCommit.oid)  printf '%s\n' "${MOCK_GH_MERGE_SHA:-}" ;;
-        *)                 exit 1 ;;
-    esac
+    printf 'MERGED %s\n' "${MOCK_GH_MERGE_SHA:-}"
     exit 0
 fi
 printf 'Unhandled gh invocation: %s\n' "$*" >&2


### PR DESCRIPTION
## Summary
- `gwt teardown` now trusts `gh pr view`'s `MERGED + mergeCommit.oid` signal — the same signal `gwt status --remote` already uses — so it accepts squash-merged worktrees as safe to clean up even after `origin/main` progresses past the squash with overlapping changes (issue #315).
- Soft-fails to the existing local-only checks when `gh` is missing/unauthenticated, the branch has no PR, or the merge commit is unreachable — no regression for offline / non-GitHub repos.
- Two new bats cases lock in both the positive path (post-progress safe teardown) and the negative path (unreachable `mergeCommit.oid` is not treated as safe).

## Changes
- `shell-common/functions/git_worktree.sh`: add `_gwt_pr_merged_into <branch> <main_ref>` helper; wire it into `_gwt_commits_safe` (between the patch-id walk and the no-upstream/ahead-zero fallback) and `_gwt_branch_merged` (after the diff-quiet branch-delete check). Comments now point step 3's tree-equivalence at "narrow case" so future readers know step 5 is the broader signal.
- `tests/bats/functions/git_worktree_teardown.bats`: two new tests under "Issue #315", plus `_progress_origin_main_overlapping` and `_install_gh_mock` helpers. The positive case advances `origin/main` past the squash with overlapping edits and asserts `git diff --quiet` AND `git cherry` are both broken before exercising the fix, so a future regression in either local-only check is caught.

## Why now
PR #307 (a6f32fb) added the tree-equivalence step so squash-merges (N→1) would no longer trip patch-id detection. It works only while `origin/main` is *exactly* at the squash commit. Real workflows squash-merge a PR and then merge several more on top within minutes — at that point both step 3 (tree-equivalence) and step 4 (patch-id) fail, so `_gwt_commits_safe` rejects a worktree whose PR `gwt status` correctly reports as `pr-merged`. Users were forced into `gwt teardown --force` despite `gwt status`'s advice to just run `gwt teardown`.

## Test plan
- [x] `bats tests/bats/functions/git_worktree_teardown.bats` — 31 / 31 passing (2 new + 29 pre-existing).
- [x] `bats tests/bats/functions/git_worktree_{status,spawn,orphan}.bats` — 70 / 70 passing.
- [x] `bash -n` and `zsh -n` syntax checks on the modified file.
- [x] Verified manually against the original failing repro: `git diff --quiet origin/main HEAD` exit=1, `git cherry` shows '+', `git merge-base --is-ancestor <merge_commit> origin/main` exit=0 — only the new gh-PR step recognizes safety.

## Related
Closes #315
Refs #307


---
<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics -->
