### PR TITLE
Add AI work-metrics footer to GitHub Issues and PRs

### DIFF
--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -31,6 +31,8 @@ number + URL at the end.
 
 ## Step 1: Detect Repo Context
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 3.5.
+
 Confirm we're in a git repo (`git rev-parse --show-toplevel`), pick the
 target remote (arg #1 if given, else `origin`), and resolve it to
 `TARGET_REPO=<owner>/<repo>`. If the remote does not exist, list
@@ -70,13 +72,29 @@ Step 2 의 prefix 에 매핑되는 템플릿을 로드한다:
 over-compress** — 파일 경로·명령 출력·결정·근거를 그대로 유지한다.
 대화가 길었다면 200줄짜리 이슈도 정상.
 
+## Step 3.5: Compute AI Metrics
+
+Before writing the body to the temp file, compute the metrics block:
+
+1. **Elapsed time**: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
+2. **Issue type**: the prefix from Step 2 (`feat`, `fix`, `refactor`, etc.)
+3. **Human time**: look up `references/metrics-baseline.md` by issue type.
+   For `feat`, infer size (small / medium / large) from the conversation scope.
+4. **Token estimate**: sum character counts of the drafted title + body, divide
+   by 4, round to nearest 500 (minimum 1 000). See `references/metrics-baseline.md`
+   for the full estimation rules.
+
+Store results as `TOKENS`, `HUMAN_H`, `ELAPSED` for use in Step 4.
+
 ## Step 4: Create the Issue
 
-`mktemp` 으로 임시 파일에 본문을 쓰고:
+`mktemp` 으로 임시 파일에 본문을 쓰고 metrics 블록을 append 한 뒤 생성한다:
 
 ```bash
 BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 # ... write body to "$BODY" ...
+printf '\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
+  "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
 gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY"
 ```
 

--- a/claude/skills/gh-issue-create/references/metrics-baseline.md
+++ b/claude/skills/gh-issue-create/references/metrics-baseline.md
@@ -1,0 +1,48 @@
+# AI Metrics Baseline
+
+Maps conventional-commit issue types to estimated junior-developer hours.
+Used by `gh:issue-create` and `gh:issue-flow` to populate `<!-- ai-metrics -->` footer blocks.
+
+## Human Time Lookup Table
+
+| Issue Type      | Human Time  |
+|-----------------|-------------|
+| `feat` (small)  | 4 h         |
+| `feat` (medium) | 8 h (1 d)   |
+| `feat` (large)  | 24 h (3 d)  |
+| `fix`           | 2 h         |
+| `refactor`      | 4 h         |
+| `docs`          | 1 h         |
+| `chore`         | 0.5 h       |
+| `perf`          | 3 h         |
+| `test`          | 2 h         |
+| `misc`          | 2 h         |
+
+## Size Heuristic for `feat`
+
+- **Small** (소): single component, ≤ 2 files, no NF requirements → 4 h
+- **Medium** (중): 2–5 files, some NF or cross-component work → 8 h
+- **Large** (대): ≥ 3 components, explicit NF requirements, architectural decisions → 24 h
+
+When unsure, default to **medium** (8 h).
+
+## Token Estimation
+
+Priority order — first available wins:
+
+1. Explicit `--tokens <N>` override passed to the skill
+2. Sum character counts of (issue body draft + title + key context), divide by 4, round to nearest 500. Minimum 1 000.
+3. Fallback: 5 000
+
+## Block Format
+
+Append after a `---` horizontal rule at the end of the body:
+
+    ---
+    <!-- ai-metrics -->
+    📊 ~X tokens · 👤 ~M h · 🤖 ~L min
+    <!-- /ai-metrics -->
+
+- `X` — estimated tokens (see Token Estimation above)
+- `M` — human hours from the lookup table (e.g. `4 h`, `8 h`, `~1 d`)
+- `L` — elapsed minutes from skill entry to issue/PR creation

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -30,6 +30,8 @@ gh:issue-implement, gh:commit, gh:pr.
 
 This skill takes no `mode` arg; implementation is always `direct`.
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 2.4.
+
 ## Step 2: Chain the 3 Skills
 
 Invoke in order. Each uses Claude Code's Skill tool. Each runs only
@@ -56,16 +58,42 @@ if the previous completed successfully.
    Passing the issue number ensures `Closes #<N>` ends up in the PR
    body via gh:pr's Step 3 (issue resolution).
 
+4. **Step 2.4 — Append AI Metrics to PR** (only if 2.3 succeeded; soft-fail)
+
+   Append the AI metrics footer block to the PR body created in Step 2.3.
+   This step soft-fails — warn on any error but never block the flow.
+
+   a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
+   b. Issue type: parse the conventional-commit prefix from the issue title
+      fetched in Step 2.1 (e.g. `feat`, `fix`, `refactor`).
+   c. Human time: read `~/.claude/skills/gh-issue-create/references/metrics-baseline.md`
+      and look up the issue type. For `feat`, infer size from the implementation scope.
+   d. Token estimate: character count of (issue body + implementation file reads) ÷ 4,
+      rounded to nearest 500. Minimum 1 000.
+   e. Get PR number and fetch current body, append block, update:
+      ```bash
+      PR_NUM=$(gh pr view --json number -q .number)
+      BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+      gh pr view --json body -q .body > "$BODY"
+      printf '\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
+        "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+      gh pr edit "$PR_NUM" --body-file "$BODY"
+      ```
+   f. On failure: print `⚠️  ai-metrics append failed (<reason>) — continuing.`
+
 ## Step 3: Report
 
-If all 3 succeeded:
+If all steps succeeded:
 ```
 gh:issue-flow complete (#<N>)
   ✓ Step 1: gh:issue-implement  (<n files changed>, <n tests passed>)
   ✓ Step 2: gh:commit            (<sha> "<subject>")
   ✓ Step 3: gh:pr                (PR #<M>)
+  ✓ Step 4: ai-metrics           (📊 ~X tokens · 👤 ~M h · 🤖 ~L min)
   PR URL: <pr-url>
 ```
+
+If Step 2.4 soft-failed, show `⚠️ Step 4: ai-metrics  (skipped — <reason>)` instead.
 
 If a step failed:
 ```
@@ -89,6 +117,8 @@ Resume hint logic:
 - Never retry a failed step. Human decides retry or fix.
 - Never skip a step. All 3 or stop.
 - Never mutate state between steps beyond what the sub-skills do.
+  Exception: Step 2.4 may edit the PR body after Step 2.3 — this is
+  intentional and must soft-fail (never block the flow).
 - Do NOT preface or summarize beyond the compact report.
 - Do NOT end the turn until the Step 3 report is issued (success or
   failure template). A `Next:` / resume-hint from a sub-skill

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -66,15 +66,22 @@ if the previous completed successfully.
    a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
    b. Issue type: parse the conventional-commit prefix from the issue title
       fetched in Step 2.1 (e.g. `feat`, `fix`, `refactor`).
-   c. Human time: read `~/.claude/skills/gh-issue-create/references/metrics-baseline.md`
-      and look up the issue type. For `feat`, infer size from the implementation scope.
+   c. Human time: look up the issue type in `gh-issue-create`'s
+      `references/metrics-baseline.md` (in the same skills directory).
+      For `feat`, infer size from the implementation scope.
    d. Token estimate: character count of (issue body + implementation file reads) ÷ 4,
       rounded to nearest 500. Minimum 1 000.
-   e. Get PR number and fetch current body, append block, update:
+   e. Get PR number, fetch current body, strip any existing block (idempotency),
+      append fresh block, update:
       ```bash
       PR_NUM=$(gh pr view --json number -q .number)
       BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
-      gh pr view --json body -q .body > "$BODY"
+      gh pr view --json body -q .body | \
+        python3 -c "
+import re, sys
+body = sys.stdin.read()
+body = re.sub(r'\n?---\n<!-- ai-metrics -->.*?<!-- /ai-metrics -->\n?', '', body, flags=re.DOTALL)
+sys.stdout.write(body)" > "$BODY"
       printf '\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
         "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
       gh pr edit "$PR_NUM" --body-file "$BODY"


### PR DESCRIPTION
## Summary
- `gh:issue-create`와 `gh:issue-flow`가 생성하는 모든 이슈/PR body에 AI 작업 메트릭 블록 자동 삽입
- 토큰 추정값·주니어 개발자 예상 소요 시간·AI 실제 소요 시간을 `<!-- ai-metrics -->` 형식으로 기록
- 메트릭 데이터는 GitHub Issue/PR 카드를 SSOT로 삼아 연말 성과 정량화에 활용

## Changes
- `gh-issue-create/references/metrics-baseline.md` (new): 이슈 종류별(feat/fix/refactor 등) 사람 소요 시간 룩업 테이블 및 토큰 추정 규칙 정의
- `gh-issue-create/SKILL.md`: Step 1에 `START_TS` 기록 추가, 새 Step 3.5에서 메트릭 계산, Step 4에서 `<!-- ai-metrics -->` 블록을 body에 append
- `gh-issue-flow/SKILL.md`: Step 1에 `START_TS` 기록 추가, 새 Step 2.4에서 PR body에 동일 블록 append (soft-fail), 리포트 포맷 및 Constraints 업데이트

## Test plan
- [ ] `/gh-issue-create` 실행 후 생성된 이슈 body 하단에 `<!-- ai-metrics -->` 블록 존재 확인
- [ ] 블록에 토큰 추정값·사람 소요 시간·AI 소요 시간이 모두 포함되어 있는지 확인
- [ ] `/gh-issue-flow` 로 생성된 PR body에도 동일 블록 존재 확인
- [ ] Step 2.4 실패 시 flow 전체가 중단되지 않고 경고만 출력되는지 확인

## Related
Closes #317
---
<!-- ai-metrics -->
📊 ~7500 tokens · 👤 ~8 h · 🤖 ~15 min
<!-- /ai-metrics -->