### PR TITLE
feat(skills): add ai-metrics to remaining 9 gh-* skills (#319)

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -29,6 +29,8 @@ footer when a GitHub issue is known.
 
 ## Step 1: Inspect State (parallel) — ALWAYS FIRST
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
+
 This step runs **unconditionally** on every invocation, even bare `/gh-commit`
 with no prior conversation context. The working-tree state observed here is
 the source of truth — do NOT ask the user "what did you change?" before
@@ -77,18 +79,43 @@ their own manual edits), derive intent from the diff itself:
   fix the underlying issue, re-stage, and create a **new** commit.
 - See `references/commit-message-format.md` for the exact HEREDOC command.
 
-## Step 5: Sync Project Board Status
+## Step 5: AI Metrics + Sync Project Board Status
 
-If the commit message contains `Closes|Fixes|Refs #N` (i.e. the issue
-number resolved in Step 2 was actually written into the footer), push
-the linked Issue's project-board card to `In progress` — but only when
-its current Status is `Backlog`. The `--only-from Backlog` guard is
-mandatory: `/gh-commit` is invoked many times per branch (initial
-commit + follow-up fix commits), and after a PR opens the issue moves
-to `In review`; without the guard a follow-up fix commit would bounce
-it back to `In progress`.
+Before syncing the project board, record AI metrics (soft-fail — warn on
+error, never block). Compute elapsed time and post a comment on the linked
+issue (only when an issue number was resolved in Step 2):
 
-Skip this step entirely when no issue footer was written.
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+TOKENS=5000  # fallback; replace with char-count estimate when context is available
+gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
+  -X POST \
+  -f body="### 🤖 AI Metrics — gh-commit
+
+| 항목 | 값 |
+|------|-----|
+| 커밋 | $COMMIT_SHA |
+| 구현 시간 (gh-issue-implement) | ~${IMPL_MIN:-?} min |
+| 커밋 시간 (gh-commit) | ~$ELAPSED min |
+| 토큰 | ~$TOKENS |
+
+<!-- ai-metrics:gh-commit tokens=$TOKENS ai_min=$ELAPSED -->"
+```
+
+If no issue number exists, print the metrics to stdout only and skip the
+comment. On any API failure, print `⚠️  ai-metrics comment failed — continuing.`
+and proceed.
+
+Then sync the project board: if the commit message contains
+`Closes|Fixes|Refs #N` (i.e. the issue number resolved in Step 2 was
+actually written into the footer), push the linked Issue's project-board
+card to `In progress` — but only when its current Status is `Backlog`.
+The `--only-from Backlog` guard is mandatory: `/gh-commit` is invoked
+many times per branch (initial commit + follow-up fix commits), and after
+a PR opens the issue moves to `In review`; without the guard a follow-up
+fix commit would bounce it back to `In progress`.
+
+Skip the board sync entirely when no issue footer was written.
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null

--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -87,7 +87,10 @@ issue (only when an issue number was resolved in Step 2):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-TOKENS=5000  # fallback; replace with char-count estimate when context is available
+# Token estimate: (char count of commit diff + message) / 4, rounded to nearest 500, min 1000
+# See gh-issue-create/references/metrics-helper.md "Token Estimation" for the formula
+TOKENS=$(( ( ($(git diff HEAD~1 | wc -c) / 4 / 500) + 1 ) * 500 ))
+[ "$TOKENS" -lt 1000 ] && TOKENS=1000
 gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
   -X POST \
   -f body="### 🤖 AI Metrics — gh-commit

--- a/claude/skills/gh-issue-create/references/metrics-helper.md
+++ b/claude/skills/gh-issue-create/references/metrics-helper.md
@@ -1,0 +1,110 @@
+# AI Metrics Helper — Common Patterns for gh:* skills
+
+Reference for all skills that record `<!-- ai-metrics:* -->` blocks.
+
+## START_TS Recording
+
+Every skill records its start time at the top of Step 1:
+
+```bash
+START_TS=$(date +%s)
+```
+
+## Elapsed Time Computation
+
+Just before writing the metrics block:
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+```
+
+## Token Estimation
+
+Character count of key inputs ÷ 4, rounded to nearest 500. Minimum 1 000.
+
+```bash
+# Example: issue body + drafts
+CHAR_COUNT=$(echo "$ISSUE_BODY$DRAFT_TEXT" | wc -c)
+TOKENS=$(( (CHAR_COUNT / 4 / 500 + 1) * 500 ))
+[ "$TOKENS" -lt 1000 ] && TOKENS=1000
+```
+
+## Human Time Lookup
+
+From `gh-issue-create/references/metrics-baseline.md` by issue type:
+
+| Skill context      | human_h default      |
+|--------------------|----------------------|
+| `feat` (small)     | 4 h                  |
+| `feat` (medium)    | 8 h                  |
+| `feat` (large)     | 24 h                 |
+| `fix`              | 2 h                  |
+| `refactor`         | 4 h                  |
+| `docs`             | 1 h                  |
+| `chore`            | 0.5 h                |
+| `gh-pr-approve`    | 1 h (review fixed)   |
+| `gh-pr-merge`      | 0.25 h (merge chore) |
+| `gh-pr-reply`      | 0.25 h × comment count |
+| `gh-pr-resolve-conflict` | 0.5 h × conflict file count |
+
+## Block Formats by Artifact
+
+### GitHub Issue / PR body footer
+
+```
+---
+<!-- ai-metrics:<skill> -->
+📊 ~{TOKENS} tokens · 👤 ~{HUMAN_H} h · 🤖 ~{ELAPSED} min
+<!-- /ai-metrics:<skill> -->
+```
+
+Append via `printf` to a temp file before creating the artifact:
+
+```bash
+printf '\n---\n<!-- ai-metrics:%s -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:%s -->\n' \
+  "$SKILL" "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" >> "$BODY"
+```
+
+### GitHub PR / Issue comment
+
+Post after the artifact is created:
+
+```bash
+gh api "repos/$TARGET_REPO/issues/$ISSUE_OR_PR_NUM/comments" \
+  -X POST \
+  -f body="<!-- ai-metrics:$SKILL tokens=$TOKENS human_h=$HUMAN_H ai_min=$ELAPSED -->
+🤖 ~$ELAPSED min · 👤 ~$HUMAN_H h · 📊 ~$TOKENS tokens"
+```
+
+### stdout-only (read-only skills)
+
+```
+[ai-metrics:<skill>] 🤖 ~{ELAPSED} min (read-only — not written to GitHub)
+```
+
+### Context-only (intermediate skills)
+
+```
+[ai-metrics:<skill>] 🤖 ~{ELAPSED} min — will be included in gh-commit metrics
+```
+
+## Idempotency (strip before re-append)
+
+When editing an existing PR body (e.g., `gh-issue-flow`):
+
+```bash
+python3 -c "
+import re, sys
+body = sys.stdin.read()
+body = re.sub(r'\n?---\n<!-- ai-metrics -->.*?<!-- /ai-metrics -->\n?', '', body, flags=re.DOTALL)
+sys.stdout.write(body)" < existing_body > stripped_body
+```
+
+## Soft-fail Rule
+
+Every ai-metrics step must soft-fail: on any error, print a single
+warning line and continue — never block the main flow.
+
+```
+⚠️  ai-metrics append failed (<reason>) — continuing.
+```

--- a/claude/skills/gh-issue-create/references/metrics-helper.md
+++ b/claude/skills/gh-issue-create/references/metrics-helper.md
@@ -96,7 +96,7 @@ When editing an existing PR body (e.g., `gh-issue-flow`):
 python3 -c "
 import re, sys
 body = sys.stdin.read()
-body = re.sub(r'\n?---\n<!-- ai-metrics -->.*?<!-- /ai-metrics -->\n?', '', body, flags=re.DOTALL)
+body = re.sub(r'\n?---\n<!-- ai-metrics(:.*?)? -->.*?<!-- /ai-metrics(:.*?)? -->\n?', '', body, flags=re.DOTALL)
 sys.stdout.write(body)" < existing_body > stripped_body
 ```
 

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -58,9 +58,12 @@ if the previous completed successfully.
    Passing the issue number ensures `Closes #<N>` ends up in the PR
    body via gh:pr's Step 3 (issue resolution).
 
-4. **Step 2.4 — Append AI Metrics to PR** (only if 2.3 succeeded; soft-fail)
+4. **Step 2.4 — Post AI Metrics to Issue** (only if 2.3 succeeded; soft-fail)
 
-   Append the AI metrics footer block to the PR body created in Step 2.3.
+   Post a flow-level aggregate metrics comment on the **linked GitHub Issue**.
+   The PR body already carries the per-step `<!-- ai-metrics:gh-pr -->` block
+   written by `gh:pr`; this step adds the total across all three sub-skills to
+   the Issue so the Issue thread is the single place to review full AI effort.
    This step soft-fails — warn on any error but never block the flow.
 
    a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
@@ -71,22 +74,25 @@ if the previous completed successfully.
       For `feat`, infer size from the implementation scope.
    d. Token estimate: character count of (issue body + implementation file reads) ÷ 4,
       rounded to nearest 500. Minimum 1 000.
-   e. Get PR number, fetch current body, strip any existing block (idempotency),
-      append fresh block, update:
-      ```bash
-      PR_NUM=$(gh pr view --json number -q .number)
-      BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
-      gh pr view --json body -q .body | \
-        python3 -c "
-import re, sys
-body = sys.stdin.read()
-body = re.sub(r'\n?---\n<!-- ai-metrics -->.*?<!-- /ai-metrics -->\n?', '', body, flags=re.DOTALL)
-sys.stdout.write(body)" > "$BODY"
-      printf '\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
-        "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
-      gh pr edit "$PR_NUM" --body-file "$BODY"
-      ```
-   f. On failure: print `⚠️  ai-metrics append failed (<reason>) — continuing.`
+   e. Post the aggregate comment on the linked issue (body template below).
+   f. On failure: print `⚠️  ai-metrics comment failed (<reason>) — continuing.`
+
+```bash
+gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
+  -X POST \
+  -f body="### ✅ gh-issue-flow 완료
+
+| 단계 | AI 소요 |
+|------|---------|
+| gh-issue-implement | ~${IMPL_MIN:-?} min |
+| gh-commit | ~${COMMIT_MIN:-?} min |
+| gh-pr | ~${PR_MIN:-?} min |
+| **합계** | **~$ELAPSED min** |
+
+👤 예상 사람 시간: ~$HUMAN_H h · 📊 ~$TOKENS tokens
+
+<!-- ai-metrics:gh-issue-flow tokens=$TOKENS human_h=$HUMAN_H ai_min=$ELAPSED -->"
+```
 
 ## Step 3: Report
 

--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -24,6 +24,8 @@ output its content verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Repo + Preconditions
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 6.
+
 Positional args: `<issue-number> [mode] [remote]`. Optional flag: `--no-next-hint`.
 
 - `issue-number` — required, positive integer.
@@ -75,6 +77,15 @@ Print the success or failure report per
 `references/implementation-flow.md` → "Final report format". Always
 include the `Next:` hint pointing to `gh:commit` / `gh:pr` /
 `gh:issue-flow`, unless `--no-next-hint` is set.
+
+After the report, append the ai-metrics line (context only — no GitHub
+artifact exists yet at this stage):
+
+```
+[ai-metrics:gh-issue-implement] 🤖 ~{ELAPSED} min — will be included in gh-commit metrics
+```
+
+Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
 
 ## Constraints
 

--- a/claude/skills/gh-issue-read/SKILL.md
+++ b/claude/skills/gh-issue-read/SKILL.md
@@ -26,6 +26,8 @@ feeds downstream skills (like `gh:issue-implement`).
 
 ## Step 1: Parse Args + Resolve Repo
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
+
 Positional args: `<issue-number> [remote]`.
 
 - `issue-number` — required, positive integer. Missing/invalid → print
@@ -64,6 +66,15 @@ Header → Summary → Body → Discussion → Meta → Checklist.
 Print the formatted output directly. No preamble ("Here's the issue..."),
 no trailing summary ("Let me know if you want..."). The output IS the
 deliverable.
+
+After the formatted output, append the ai-metrics line (stdout only —
+this skill never mutates GitHub):
+
+```
+[ai-metrics:gh-issue-read] 🤖 ~{ELAPSED} min (read-only — not written to GitHub)
+```
+
+Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
 
 ## Constraints
 

--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -19,6 +19,8 @@ output it verbatim, then stop. Help is detected only at arg #1, so
 
 ## Step 1: Resolve + Pre-flight Gate (parallel)
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
+
 Parse args first. Positional: `<pr-number>` and `<remote>` (default
 `origin`). Flags may appear anywhere:
 
@@ -82,6 +84,19 @@ Match the PR's dominant language.
 - **4c** Submit `gh pr review --request-changes`; blockers stay on the PR.
 - Self-authored PR: never approve. Use analysis-only, `--self-record`, or
   `--admin-merge` exactly as specified in `references/self-pr-handling.md`.
+
+After submitting the review (any path), post a separate PR comment with
+ai-metrics (soft-fail — warn on error, never block):
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+  -X POST \
+  -f body="<!-- ai-metrics:gh-pr-approve tokens=${TOKENS:-5000} human_h=1 ai_min=$ELAPSED -->
+🤖 PR 리뷰: ~$ELAPSED min · 👤 ~1 h (estimate)"
+```
+
+On failure: `⚠️  ai-metrics comment failed — continuing.`
 
 ## Step 5: Verify and Report
 

--- a/claude/skills/gh-pr-merge-emergency/SKILL.md
+++ b/claude/skills/gh-pr-merge-emergency/SKILL.md
@@ -23,6 +23,8 @@ output it verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Target
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
+
 Positional args: `<PR> <reason> [remote]`.
 
 - `PR` — number (required). If omitted, try `gh pr view --json number` on
@@ -73,6 +75,16 @@ Non-negotiable audit tail. File `incident: emergency merge of PR #<N> —
 <reason first line>` with the body + retro checklist from
 `references/audit-templates.md`. Attach an `incident` label **only if**
 `gh label list --repo "$TARGET_REPO"` confirms it exists.
+
+Include the ai-metrics block in the incident issue body (append before
+creating — no soft-fail here since the incident issue is a required artifact):
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+# Append to the issue body temp file before gh issue create:
+printf '\n---\n<!-- ai-metrics:gh-pr-merge-emergency -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr-merge-emergency -->\n' \
+  "${TOKENS:-3000}" "${HUMAN_H:-1}" "$ELAPSED" >> "$INCIDENT_BODY"
+```
 
 ## Step 6: Sync Project Board Status
 

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -20,6 +20,8 @@ output its content verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Repo
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
+
 Positional args: `<pr-number> [strategy] [remote]`.
 
 - `pr-number` — required, positive integer. Missing/invalid → print
@@ -100,6 +102,18 @@ done
 Both helpers auto-detect repos without a projectV2 attachment and
 silently return. This step never blocks the report — failures are
 logged to stderr and ignored.
+
+After the board sync completes, post an ai-metrics PR comment (soft-fail):
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+  -X POST \
+  -f body="<!-- ai-metrics:gh-pr-merge tokens=${TOKENS:-2000} human_h=0.25 ai_min=$ELAPSED -->
+🤖 PR merge: ~$ELAPSED min"
+```
+
+On failure: `⚠️  ai-metrics comment failed — continuing.`
 
 ## Step 5: Fetch Merge SHA + Report
 

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -35,7 +35,8 @@ Precedence:
 2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`; if no PR exists, stop and tell the user.
 3. Never guess. Never pick "the latest PR in the repo".
 
-Also capture `owner/repo` via `gh repo view --json nameWithOwner`.
+Also capture `TARGET_REPO` via `gh repo view --json nameWithOwner -q .nameWithOwner`
+(e.g. `owner/repo`). Use `$TARGET_REPO` consistently in all subsequent API calls.
 
 ## Step 2: Fetch All Review Comments
 
@@ -83,7 +84,7 @@ addressed in Step 5 (including declined and bot comments):
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
 HUMAN_H=$(echo "scale=2; $COMMENT_COUNT * 0.25" | bc)
-gh api "repos/$OWNER_REPO/issues/$PR_NUMBER/comments" \
+gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
   -X POST \
   -f body="<!-- ai-metrics:gh-pr-reply tokens=${TOKENS:-5000} human_h=$HUMAN_H ai_min=$ELAPSED -->
 🤖 리뷰 답변: ~$ELAPSED min · 👤 ~$HUMAN_H h ($COMMENT_COUNT comments × 0.25 h)"

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -28,6 +28,8 @@ every thread. Silent fixes are not acceptable; silent declines are worse.
 
 ## Step 1: Resolve Target PR
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 7.
+
 Precedence:
 1. **Explicit argument** — `/gh:pr-reply 123` → PR #123.
 2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`; if no PR exists, stop and tell the user.
@@ -73,6 +75,21 @@ asked) and report new commit SHAs alongside the reply summary.
 Print the summary table per `references/final-summary.md` showing
 Accepted / Declined / Answered counts, commit SHAs, and any skipped
 already-replied comments.
+
+After printing the report, post a PR comment with ai-metrics (soft-fail —
+warn on error, never block). `COMMENT_COUNT` is the number of comments
+addressed in Step 5 (including declined and bot comments):
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+HUMAN_H=$(echo "scale=2; $COMMENT_COUNT * 0.25" | bc)
+gh api "repos/$OWNER_REPO/issues/$PR_NUMBER/comments" \
+  -X POST \
+  -f body="<!-- ai-metrics:gh-pr-reply tokens=${TOKENS:-5000} human_h=$HUMAN_H ai_min=$ELAPSED -->
+🤖 리뷰 답변: ~$ELAPSED min · 👤 ~$HUMAN_H h ($COMMENT_COUNT comments × 0.25 h)"
+```
+
+On failure: `⚠️  ai-metrics comment failed — continuing.`
 
 ## Constraints
 

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -21,6 +21,8 @@ output its content verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Preflight
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
+
 Positional args: `[pr-number] [remote]`. Both optional.
 
 - `pr-number` — if omitted, auto-detect via
@@ -86,6 +88,21 @@ If `mergeable == MERGEABLE` and `mergeStateStatus ∈ {CLEAN, UNSTABLE}`,
 the warning is cleared. Print the final report from
 `references/rebase-flow.md` → "Final report format". Still `CONFLICTING`
 / `BEHIND` → print the PR URL, name which side diverged, do not loop.
+
+After the report, post a PR comment with ai-metrics (soft-fail — warn on
+error, never block). `CONFLICT_FILES` is the count of files that had
+`UU`/`AA`/`DU` conflicts in Step 3:
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+HUMAN_H=$(echo "scale=2; $CONFLICT_FILES * 0.5" | bc)
+gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+  -X POST \
+  -f body="<!-- ai-metrics:gh-pr-resolve-conflict tokens=${TOKENS:-3000} human_h=$HUMAN_H ai_min=$ELAPSED -->
+🤖 컨플릭트 해결: ~$ELAPSED min · 👤 ~$HUMAN_H h ($CONFLICT_FILES files × 0.5 h)"
+```
+
+On failure: `⚠️  ai-metrics comment failed — continuing.`
 
 ## Constraints
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -24,6 +24,8 @@ body. Push the branch if needed. Return the PR URL.
 
 ## Step 1: Determine Base Branch and State (parallel)
 
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
+
 Run in a single message:
 
 - `git rev-parse --abbrev-ref HEAD` — current branch
@@ -60,6 +62,21 @@ Same precedence as `gh:commit`:
 Read `references/pr-body-template.md` for title rules, body structure, and
 the body markdown. Match the language of existing commits (Korean if commits
 are Korean).
+
+Before writing the body to the temp file, compute and append the ai-metrics
+footer block (soft-fail — warn on error, never block):
+
+1. `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
+2. Issue type: the conventional-commit prefix from the first commit subject.
+3. Human time: look up `gh-issue-create/references/metrics-baseline.md`.
+   For `feat`, infer size from the number of files changed.
+4. Token estimate: character count of (issue body + commit log) ÷ 4,
+   rounded to nearest 500. Minimum 1 000.
+
+```bash
+printf '\n---\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n' \
+  "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+```
 
 ## Step 5: Push and Create
 


### PR DESCRIPTION
## Summary
- 9개 gh-* 스킬(gh-issue-read, gh-issue-implement, gh-commit, gh-pr, gh-pr-approve, gh-pr-merge, gh-pr-merge-emergency, gh-pr-reply, gh-pr-resolve-conflict)에 `<!-- ai-metrics:* -->` 기록 로직 추가
- `gh-issue-create/references/metrics-helper.md` 신규 생성 — 공통 블록 포맷, 토큰 추정, soft-fail 규칙 문서화
- gh-issue-create / gh-issue-flow(#320)에 이어 11개 스킬 전체 ai-metrics 커버리지 완성

## Changes
- gh-issue-read: Step 4 Report 말미에 stdout 전용 메트릭 출력 (GitHub mutate 없음)
- gh-issue-implement: Step 6 Report 말미에 컨텍스트 전용 메트릭 출력 (gh-commit가 이슈에 기록)
- gh-commit: Step 5에 이슈 comment 로 메트릭 기록 (impl 시간 + commit 시간 포함)
- gh-pr: Step 4 PR body 말미에 ai-metrics footer 블록 append
- gh-pr-approve: Step 4 리뷰 제출 후 별도 PR comment 기록 (human_h=1h 고정)
- gh-pr-merge: Step 4 board sync 후 PR comment 기록 (human_h=0.25h 고정)
- gh-pr-merge-emergency: Step 5 incident 이슈 body에 ai-metrics 블록 포함
- gh-pr-reply: Step 7 Report 후 PR comment (human_h = 0.25h × 답변 comment 수)
- gh-pr-resolve-conflict: Step 5 Report 후 PR comment (human_h = 0.5h × 충돌 파일 수)
- references/metrics-helper.md: 공통 helper 패턴 신규 문서

## Test plan
- [ ] 각 스킬 실행 후 지정 아티팩트에 `<!-- ai-metrics:* -->` 블록 존재 확인
- [ ] gh-issue-read 실행 후 이슈 mutate 없음 확인
- [ ] gh-commit 실행 후 연결 이슈 comment 에 메트릭 테이블 존재 확인
- [ ] markdownlint 통과 (pre-existing zsh/AGENTS.md 실패 제외)

## Related
Closes #319

---
<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~8 h · 🤖 ~7 min
<!-- /ai-metrics:gh-pr -->