### PR TITLE
feat(skills): /gh:add-ai-metrics — backfill metrics on past cards

### DIFF
--- a/claude/skills/gh-add-ai-metrics/SKILL.md
+++ b/claude/skills/gh-add-ai-metrics/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: gh:add-ai-metrics
+description: >-
+  Backfill the ai-metrics footer (📊 tokens · 👤 human-h · 🤖 ai-min) into
+  pre-existing GitHub Issues and PRs that were created before issue #317 /
+  PR #320 introduced automatic metric capture. Use when the user runs
+  /gh:add-ai-metrics, /gh-add-ai-metrics, or asks "기존 이슈에 메트릭
+  소급 부착", "지난주 PR 들에 ai-metrics 붙여줘", "retrofit metrics
+  on issue #N", "backfill ai-metrics". Three call patterns:
+  (1) no args → infer targets from current chat context;
+  (2) explicit list `issue#N pr#M` (case-insensitive `issue#`/`pr#` prefix);
+  (3) `--type [issue|PR] --date <YYYY-MM-DD>` for date-bounded bulk
+  enumeration via `gh {issue,pr} list --search`. Idempotent — skips cards
+  that already carry an `<!-- ai-metrics -->` block. With `--force`,
+  re-computes metrics fresh and replaces the existing block in place
+  (recompute, not blind overwrite). Never modifies issue/PR body content
+  other than the footer. Accepts `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Grep
+---
+
+# gh:add-ai-metrics — Retrofit ai-metrics footer onto past Issues/PRs
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Parse Args + Resolve Repo
+
+Record `START_TS=$(date +%s)` immediately for the final summary line.
+
+Parse args per the table in `references/help.md` — positional `issue#N` /
+`pr#M` (case-insensitive), flags `--type`, `--date`, `--force`, `--remote`.
+`YY-MM-DD` expands to `20YY`. Resolve `TARGET_REPO` via the shared flow
+in `gh-issue-create/references/repo-resolution.md`. Missing remote → list
+`git remote -v` and stop (no silent fallback). `--date` + positional
+cards is a hard error: print
+`Error: --date and positional cards are mutually exclusive.` and stop.
+
+## Step 2: Determine Mode + Build Target List
+
+First match wins:
+
+1. `--date` present → **date-filter mode**.
+   Run `gh issue list` and/or `gh pr list` (filtered by `--type` if given)
+   with `--search "created:<DATE>" --state all --limit 200 --json number,title`.
+2. Positional cards present → **explicit-list mode**. Parse, validate
+   each `N` as a positive integer, dedupe, preserve order.
+3. Otherwise → **conversation-infer mode**. Scan recent chat turns for
+   `#NNN` mentions paired with `issue` / `PR` / `pr` cues — bare numbers
+   without `#` are ignored to avoid false positives. No candidates →
+   print `Error: no issue/PR references in conversation; pass them explicitly.`
+   and stop.
+
+If `|targets| > 100`, print the count and prompt
+`Continue with N cards? [y/N]:`. Default no → stop.
+
+## Step 3: Per-Card Loop
+
+For each `(type, N)` follow `references/footer-detection.md`:
+
+1. `gh {issue,pr} view N --repo "$TARGET_REPO" --json title,body` → fetch.
+2. Detect `<!-- ai-metrics -->` (also matches `<!-- ai-metrics:<skill> -->`).
+3. Branch:
+   - **No footer** → compute metrics → append (after a `---` separator).
+   - **Footer + no `--force`** → print `→ skipped #N <title>` and continue.
+     Do NOT call `gh edit` (saves API quota).
+   - **Footer + `--force`** → recompute fresh metrics → in-place replace
+     (single regex pass, no append).
+4. On modification only, write the new body to `mktemp` and call
+   `gh {issue,pr} edit N --repo "$TARGET_REPO" --body-file <tmp>`.
+5. Print one-line status:
+   `✓ added #N <title>` / `↻ replaced #N <title>` /
+   `→ skipped #N <title>` / `✗ failed #N <reason>` (continue with next).
+
+Metric values follow `references/post-hoc-metrics.md`:
+
+- **TOKENS** = (title + body chars) ÷ 4, nearest 500, min 1000.
+- **HUMAN_H** = conventional-commit prefix in title → lookup
+  `gh-issue-create/references/metrics-baseline.md`; fallback `misc` (2 h).
+- **ELAPSED** = `max(1, HUMAN_H × 0.05)` — 5% rough estimate (post-hoc).
+
+## Step 4: Final Report
+
+```
+Summary: ✓ added=A  ↻ replaced=R  → skipped=S  ✗ failed=F  (total T)
+```
+
+Append the context-only line (this skill mutates GitHub but its own
+runtime metric is informational, not written to any specific card):
+
+```
+[ai-metrics:gh-add-ai-metrics] 🤖 ~{ELAPSED} min · {T} cards processed
+```
+
+`ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`.
+
+## Constraints
+
+- Always pass `--repo "$TARGET_REPO"` — no implicit repo detection.
+- Body byte-identical outside the footer: stripping the new footer must
+  yield the original body verbatim. No rewrap, no language change.
+- `--force` is **recompute → replace**, never blind overwrite or
+  duplicate-append. If no footer exists, `--force` degrades to plain append.
+- Continue-on-error: a single card failure never stops the loop.
+- Skip path is API-silent — no `gh edit` call, no body diff.
+- Conversation-infer mode rejects bare numbers (`123` without `#`).
+- > 100 hits require explicit `y` confirmation; no `--yes` flag.

--- a/claude/skills/gh-add-ai-metrics/SKILL.md
+++ b/claude/skills/gh-add-ai-metrics/SKILL.md
@@ -31,8 +31,10 @@ Record `START_TS=$(date +%s)` immediately for the final summary line.
 
 Parse args per the table in `references/help.md` — positional `issue#N` /
 `pr#M` (case-insensitive), flags `--type`, `--date`, `--force`, `--remote`.
-`YY-MM-DD` expands to `20YY`. Resolve `TARGET_REPO` via the shared flow
-in `gh-issue-create/references/repo-resolution.md`. Missing remote → list
+`--date` accepts either `YYYY-MM-DD` (10 chars, used as-is) or `YY-MM-DD`
+(8 chars, expanded to `20YY-MM-DD`); other lengths → format error and stop.
+Resolve `TARGET_REPO` via the shared flow in
+`gh-issue-create/references/repo-resolution.md`. Missing remote → list
 `git remote -v` and stop (no silent fallback). `--date` + positional
 cards is a hard error: print
 `Error: --date and positional cards are mutually exclusive.` and stop.
@@ -69,31 +71,18 @@ For each `(type, N)` follow `references/footer-detection.md`:
      (single regex pass, no append).
 4. On modification only, write the new body to `mktemp` and call
    `gh {issue,pr} edit N --repo "$TARGET_REPO" --body-file <tmp>`.
-5. Print one-line status:
-   `✓ added #N <title>` / `↻ replaced #N <title>` /
-   `→ skipped #N <title>` / `✗ failed #N <reason>` (continue with next).
+5. Print the one-line status string per the "Per-card status output
+   format" section in `references/footer-detection.md`. Continue on
+   failure — never abort the loop.
 
-Metric values follow `references/post-hoc-metrics.md`:
-
-- **TOKENS** = (title + body chars) ÷ 4, nearest 500, min 1000.
-- **HUMAN_H** = conventional-commit prefix in title → lookup
-  `gh-issue-create/references/metrics-baseline.md`; fallback `misc` (2 h).
-- **ELAPSED** = `max(1, HUMAN_H × 0.05)` — 5% rough estimate (post-hoc).
+Metric values follow `references/post-hoc-metrics.md` (TOKENS / HUMAN_H /
+ELAPSED formulas, SSOT lookup table, post-hoc estimation rules).
 
 ## Step 4: Final Report
 
-```
-Summary: ✓ added=A  ↻ replaced=R  → skipped=S  ✗ failed=F  (total T)
-```
-
-Append the context-only line (this skill mutates GitHub but its own
-runtime metric is informational, not written to any specific card):
-
-```
-[ai-metrics:gh-add-ai-metrics] 🤖 ~{ELAPSED} min · {T} cards processed
-```
-
-`ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`.
+After the loop, print the summary line + context-only ai-metrics line per
+the "Final report output format" section in `references/footer-detection.md`.
+Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
 
 ## Constraints
 

--- a/claude/skills/gh-add-ai-metrics/references/footer-detection.md
+++ b/claude/skills/gh-add-ai-metrics/references/footer-detection.md
@@ -24,17 +24,20 @@ A naive `grep '<!-- ai-metrics'` returns false positives on bodies that
 *mention* the marker in inline code spans (e.g. issue #324 itself, which
 documents the footer format and contains many bare `<!-- ai-metrics -->`
 references in backticks). The detector therefore requires the **anchored
-pair**: a `\n---\n` separator immediately before the OPEN marker on its
-own line, followed by content, then the CLOSE marker on its own line.
+pair**: a `---` separator on its own line preceded by 1+ newlines,
+immediately followed by the OPEN marker on its own line, content, then
+the CLOSE marker on its own line.
 
 ```bash
 has_footer() {
   # Returns 0 (true) only when an OPEN+CLOSE block follows the `---`
   # separator that gh:issue-create / PR #320 emit. Inline mentions
-  # (`<!-- ai-metrics -->` in backticks) do not match.
+  # (`<!-- ai-metrics -->` in backticks) do not match. The leading
+  # `\n+` tolerates both PR #320's `\n---\n` (single) and the newer
+  # `\n\n---\n` (double) append conventions.
   printf '%s' "$1" | perl -0777 -ne '
     exit (
-      /\n---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->\n.*?\n<!-- \/ai-metrics(?::[A-Za-z0-9_-]+)? -->/s
+      /\n+---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->\n.*?\n<!-- \/ai-metrics(?::[A-Za-z0-9_-]+)? -->/s
       ? 0 : 1
     )'
 }
@@ -114,13 +117,45 @@ gh "$kind" edit "$N" --repo "$TARGET_REPO" --body-file "$TMP"
 When `has_footer` returns 0 and `--force` is off, do not call `gh edit` at
 all. This is the API-quota-friendly path described in SKILL.md Constraints.
 
+## Per-card status output format
+
+Each iteration of the per-card loop prints exactly one of these lines.
+Glyph and field order are part of the user contract — keep them stable.
+
+| Branch | Format |
+|---|---|
+| New footer appended | `✓ added #N <title>` |
+| Existing footer replaced (`--force`) | `↻ replaced #N <title>` |
+| Existing footer left untouched | `→ skipped #N <title>` |
+| API or I/O failure | `✗ failed #N <reason>` |
+
+The `failed` branch must not abort the loop — catch the failure, print
+the line, and continue with the next card. The Step 4 summary counts
+each branch separately (`added=A ↻ replaced=R → skipped=S ✗ failed=F`).
+
+## Final report output format
+
+After the per-card loop completes, print exactly two lines:
+
+```
+Summary: ✓ added=A  ↻ replaced=R  → skipped=S  ✗ failed=F  (total T)
+[ai-metrics:gh-add-ai-metrics] 🤖 ~{ELAPSED} min · {T} cards processed
+```
+
+The second line is **context-only**: this skill does mutate GitHub
+artifacts, but its own runtime metric is informational and not written
+into any specific card's footer (the per-card metrics are what the
+loop just appended). Treat it like the `gh:issue-implement` context
+line — emitted to stdout, not posted as a comment.
+
 ## Test rubric
 
 A retro-fit run is correct iff:
 
-1. Stripping the new `\n---\n<!-- ai-metrics -->…<!-- /ai-metrics -->`
+1. Stripping the new `\n+---\n<!-- ai-metrics -->…<!-- /ai-metrics -->`
    block from the post-edit body yields the original (pre-edit) body
-   byte-for-byte.
+   byte-for-byte (regardless of whether append used `\n---\n` or
+   `\n\n---\n`).
 2. Running the skill twice without `--force` produces zero edit API
    calls on the second run.
 3. Running once with `--force` and once without on the same card

--- a/claude/skills/gh-add-ai-metrics/references/footer-detection.md
+++ b/claude/skills/gh-add-ai-metrics/references/footer-detection.md
@@ -1,0 +1,131 @@
+# Footer Detection + Replacement
+
+Detection and edit logic for the `<!-- ai-metrics -->` footer used by
+`gh:add-ai-metrics`. Keep regexes here so SKILL.md can stay workflow-only.
+
+## Marker grammar
+
+Two forms exist in the wild — both must be detected as "already tagged":
+
+- `<!-- ai-metrics -->` … `<!-- /ai-metrics -->`
+  (the original PR #320 / `gh-issue-create` shape)
+- `<!-- ai-metrics:<skill-name> -->` … `<!-- /ai-metrics:<skill-name> -->`
+  (the newer `metrics-helper.md` scheme used by post-#320 retro-fit work)
+
+A single regex covers both:
+
+```
+<!-- ai-metrics(:[a-zA-Z0-9_-]+)? -->[\s\S]*?<!-- /ai-metrics(:[a-zA-Z0-9_-]+)? -->
+```
+
+## Bash detection
+
+A naive `grep '<!-- ai-metrics'` returns false positives on bodies that
+*mention* the marker in inline code spans (e.g. issue #324 itself, which
+documents the footer format and contains many bare `<!-- ai-metrics -->`
+references in backticks). The detector therefore requires the **anchored
+pair**: a `\n---\n` separator immediately before the OPEN marker on its
+own line, followed by content, then the CLOSE marker on its own line.
+
+```bash
+has_footer() {
+  # Returns 0 (true) only when an OPEN+CLOSE block follows the `---`
+  # separator that gh:issue-create / PR #320 emit. Inline mentions
+  # (`<!-- ai-metrics -->` in backticks) do not match.
+  printf '%s' "$1" | perl -0777 -ne '
+    exit (
+      /\n---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->\n.*?\n<!-- \/ai-metrics(?::[A-Za-z0-9_-]+)? -->/s
+      ? 0 : 1
+    )'
+}
+```
+
+Why perl, not `grep -P`: the multiline `.*?\n` slurp requires `-0777`,
+which has no GNU grep equivalent. Perl is a hard dep of the gh CLI's
+shipping environment, so this stays portable.
+
+## Append (no existing footer)
+
+```bash
+append_footer() {
+  local body="$1" tokens="$2" human="$3" elapsed="$4"
+  printf '%s\n\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
+    "$body" "$tokens" "$human" "$elapsed"
+}
+```
+
+The leading `\n\n---\n` ensures the footer is visually separated from the
+preceding section even when the original body did not end with a newline.
+
+## In-place replace (`--force` path)
+
+`perl -0777` for slurp-mode multiline regex. `python3` is the fallback if
+perl is unavailable (rare). Note the negated `:gh-add-ai-metrics` capture
+when re-emitting — we always emit the colonless form to stay 1:1 with
+`gh-issue-create`'s SSOT shape.
+
+```bash
+replace_footer() {
+  local body="$1" tokens="$2" human="$3" elapsed="$4"
+  local new_block
+  new_block=$(printf '<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->' \
+    "$tokens" "$human" "$elapsed")
+  printf '%s' "$body" \
+    | NEW="$new_block" perl -0777 -pe '
+        BEGIN { $n = $ENV{NEW} }
+        s|<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->|$n|s
+      '
+}
+```
+
+The `BEGIN`-block pattern reads `$NEW` from the env so newline-bearing
+replacements survive the perl substitution untouched (no `$1` collision).
+
+## `--force` on a card without a footer
+
+`replace_footer` returns the original body unchanged when the regex does
+not match. Detect that and degrade to `append_footer`:
+
+```bash
+new_body=$(replace_footer "$body" "$tokens" "$human" "$elapsed")
+if [ "$new_body" = "$body" ]; then
+  new_body=$(append_footer "$body" "$tokens" "$human" "$elapsed")
+fi
+```
+
+This keeps `--force` semantically "ensure the footer reflects current
+metrics" even when the card never had one.
+
+## Edit call
+
+Always write to `mktemp` first — direct `--body "$str"` mishandles backticks
+and large bodies. Use `gh issue edit` for issues, `gh pr edit` for PRs.
+
+```bash
+TMP=$(mktemp) && trap 'rm -f "$TMP"' EXIT
+printf '%s' "$new_body" > "$TMP"
+gh "$kind" edit "$N" --repo "$TARGET_REPO" --body-file "$TMP"
+```
+
+`$kind` ∈ `{issue, pr}`; the rest of the command is identical.
+
+## Skip path (idempotent guarantee)
+
+When `has_footer` returns 0 and `--force` is off, do not call `gh edit` at
+all. This is the API-quota-friendly path described in SKILL.md Constraints.
+
+## Test rubric
+
+A retro-fit run is correct iff:
+
+1. Stripping the new `\n---\n<!-- ai-metrics -->…<!-- /ai-metrics -->`
+   block from the post-edit body yields the original (pre-edit) body
+   byte-for-byte.
+2. Running the skill twice without `--force` produces zero edit API
+   calls on the second run.
+3. Running once with `--force` and once without on the same card
+   produces identical bodies (idempotent).
+4. `has_footer` returns false on a body that mentions the marker only
+   in inline code spans (e.g. `\`<!-- ai-metrics -->\`` inside docs).
+   Issue #324 of this repo is the canonical positive example for this
+   case after stripping.

--- a/claude/skills/gh-add-ai-metrics/references/help.md
+++ b/claude/skills/gh-add-ai-metrics/references/help.md
@@ -1,0 +1,92 @@
+# gh:add-ai-metrics — Help
+
+## Arguments
+
+| # | Form | Default | Description |
+|---|------|---------|-------------|
+| positional | `issue#N` / `pr#M` | — | Cards to retrofit (case-insensitive prefix). Multiple allowed. |
+| flag | `--type {issue\|PR}` | both | Limits date-filter mode to a single artifact kind. |
+| flag | `--date <YYYY-MM-DD>` | — | Date-filter mode trigger. `YY-MM-DD` is expanded to `20YY`. |
+| flag | `--force` | off | Recompute metrics and replace an existing footer (default skips). |
+| flag | `--remote <name>` | `origin` | Override the target remote. |
+| flag | `-h` / `--help` / `help` | — | Print this help and stop. |
+
+## Modes (mutually exclusive — first match wins)
+
+1. **conversation-infer** (no args)
+   Scans recent chat turns for `#NNN` paired with `issue` / `PR` / `pr`
+   cues. Bare numbers without `#` are ignored (false-positive guard).
+   No candidates → hard error.
+
+2. **explicit-list** (positional cards)
+   Parse `issue#N pr#M ...`. Order preserved, dupes deduplicated.
+
+3. **date-filter** (`--date`, optional `--type`)
+   Enumerates via
+   `gh {issue,pr} list --search "created:<DATE>" --state all --limit 200`.
+   `> 100` hits → confirmation prompt (`y/N`, default no).
+
+`--date` and positional cards together → hard error (mutex).
+
+## Examples
+
+- `/gh:add-ai-metrics`
+  → infers from chat (e.g. #317 + #320 just discussed in this turn).
+- `/gh:add-ai-metrics issue#317 pr#320`
+  → tags exactly those two.
+- `/gh:add-ai-metrics --type issue --date 2026-04-30`
+  → tags every issue created on 2026-04-30 in `origin`'s repo.
+- `/gh:add-ai-metrics --type PR --date 26-04-30 --remote upstream`
+  → date expansion (`26-04-30` → `2026-04-30`) + remote override.
+- `/gh:add-ai-metrics issue#100 --force`
+  → recomputes metrics for #100 even if it already has a footer.
+
+## Behavior
+
+- **Idempotent by default** — cards already carrying `<!-- ai-metrics -->`
+  (or `<!-- ai-metrics:* -->`) skip without an `gh edit` API call.
+- **`--force` recomputes** — does NOT just overwrite the literal block;
+  re-fetches body, recomputes fresh `TOKENS` / `HUMAN_H` / `ELAPSED`,
+  then replaces the existing block in place (no duplicate append).
+- **Continue-on-error** — one card failing never blocks the rest. Final
+  summary lists `added / replaced / skipped / failed` counts.
+- **Body-preserving** — appends after a `---` separator on first run;
+  in `--force` replace, regex matches the block markers exactly, leaving
+  surrounding bytes untouched.
+- **API quota friendly** — skip path performs zero `gh edit` calls.
+
+## Footer format (matches PR #320 / `gh-issue-create`)
+
+```
+---
+<!-- ai-metrics -->
+📊 ~{TOKENS} tokens · 👤 ~{HUMAN_H} h · 🤖 ~{ELAPSED} min
+<!-- /ai-metrics -->
+```
+
+The detection regex tolerates the optional `:<skill>` suffix
+(`<!-- ai-metrics:gh-issue-create -->` etc.) for forward-compat with
+`metrics-helper.md`'s newer scheme.
+
+## Post-hoc metric estimation
+
+When backfilling, the original Claude session is gone, so values are
+estimated. Detail in `post-hoc-metrics.md`; summary:
+
+| Metric | Estimation rule |
+|--------|-----------------|
+| `TOKENS` | `(title + body chars) ÷ 4`, rounded to nearest 500, min 1000 |
+| `HUMAN_H` | conventional-commit prefix in title → `gh-issue-create/references/metrics-baseline.md`; fallback `misc` (2 h) |
+| `ELAPSED` | `max(1, HUMAN_H × 0.05)` — assumes AI took ~5% of the human estimate |
+
+These values are deterministic given the same body, so re-running the
+skill with `--force` produces stable output (no flapping).
+
+## What this skill will NOT do
+
+- Re-run the original AI conversation to recover real token counts.
+- Modify card body outside the footer block.
+- Auto-create labels, assignees, or milestones.
+- Silently fall back to `origin` when `--remote <name>` is missing.
+- Process more than 100 cards without explicit `y` confirmation.
+- Mutate cards on the skip path (no body diff, no API call).

--- a/claude/skills/gh-add-ai-metrics/references/help.md
+++ b/claude/skills/gh-add-ai-metrics/references/help.md
@@ -6,7 +6,7 @@
 |---|------|---------|-------------|
 | positional | `issue#N` / `pr#M` | — | Cards to retrofit (case-insensitive prefix). Multiple allowed. |
 | flag | `--type {issue\|PR}` | both | Limits date-filter mode to a single artifact kind. |
-| flag | `--date <YYYY-MM-DD>` | — | Date-filter mode trigger. `YY-MM-DD` is expanded to `20YY`. |
+| flag | `--date <YYYY-MM-DD>` | — | Date-filter mode trigger. 10-char input used as-is; 8-char `YY-MM-DD` expanded to `20YY-MM-DD`; other lengths rejected. |
 | flag | `--force` | off | Recompute metrics and replace an existing footer (default skips). |
 | flag | `--remote <name>` | `origin` | Override the target remote. |
 | flag | `-h` / `--help` / `help` | — | Print this help and stop. |

--- a/claude/skills/gh-add-ai-metrics/references/post-hoc-metrics.md
+++ b/claude/skills/gh-add-ai-metrics/references/post-hoc-metrics.md
@@ -1,0 +1,109 @@
+# Post-hoc Metric Estimation
+
+When `gh:add-ai-metrics` retrofits a card that was created before the
+auto-capture pipeline (#317 / #320) existed, the original Claude session
+is gone. The values written to the footer are therefore estimates derived
+from the card's static content. This document defines those rules so they
+stay deterministic across re-runs.
+
+## Inputs (per card)
+
+- `title` — first line of `gh {issue,pr} view --json title`
+- `body` — `--json body`, the user-authored portion only (footer
+  excluded if a previous run wrote one — see "stripping" below)
+
+## TOKENS
+
+```
+TOKENS = max(1000, round_to_500((len(title) + len(body)) / 4))
+```
+
+- Character count (not byte count); `wc -m` for safety on multibyte
+  Korean text.
+- Round to nearest 500 to match `gh-issue-create/references/metrics-baseline.md`
+  Token Estimation rules.
+- Floor at 1000 — anything smaller is noise.
+
+Bash:
+
+```bash
+chars=$(printf '%s%s' "$title" "$body" | wc -m | awk '{print $1}')
+tokens=$(( (chars / 4 + 250) / 500 * 500 ))
+[ "$tokens" -lt 1000 ] && tokens=1000
+```
+
+## HUMAN_H
+
+Lookup by conventional-commit prefix in the title. The prefix is the
+first `[a-z]+` group before an optional `(scope)` and a literal `:`.
+
+```bash
+prefix=$(printf '%s' "$title" | sed -nE 's/^([a-z]+)(\([^)]*\))?:.*/\1/p')
+prefix=${prefix:-misc}
+```
+
+Mapping (mirrors `gh-issue-create/references/metrics-baseline.md` —
+do not duplicate the table; load that file at runtime):
+
+| prefix | human_h |
+|--------|---------|
+| `feat` (default size) | 8 |
+| `fix` | 2 |
+| `refactor` | 4 |
+| `perf` | 3 |
+| `docs` | 1 |
+| `test` | 2 |
+| `chore` | 0.5 |
+| `misc` (fallback) | 2 |
+
+For `feat`, sizing requires conversation context that is unavailable
+post-hoc. Default to **medium** (8 h) unconditionally. Users who want a
+sharper number can pass `--force` after manually editing the card title
+(out of scope for this skill).
+
+## ELAPSED
+
+```
+ELAPSED = max(1, round(HUMAN_H * 0.05 * 60)) / 60   # in hours, but printed as min
+```
+
+Equivalently, in minutes:
+
+```bash
+elapsed_min=$(awk -v h="$human_h" 'BEGIN { v = h * 60 * 0.05; printf "%d", (v < 1 ? 1 : v + 0.5) }')
+```
+
+The 5% factor reflects the observed ratio in #320's own footer
+(`👤 ~8 h · 🤖 ~15 min` ≈ 3.1%, rounded up for safety) and is intentionally
+conservative — better to over-report AI cost than under-report.
+
+## Stripping the existing footer before recomputation (`--force`)
+
+When recomputing on a card that already has a footer, character counts
+must be taken from the *original* body, not the inflated one with the
+prior footer included. Strip first:
+
+```bash
+stripped=$(printf '%s' "$body" \
+  | perl -0777 -pe 's|\n?---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->\n?||s')
+```
+
+Then feed `stripped` (not `body`) into the TOKENS formula.
+
+## Determinism
+
+Given the same `(title, body)` and the same lookup table, all three
+metrics are pure functions of the inputs. This makes `--force` runs
+idempotent at the value level: re-running without changing the card
+content produces the same numbers, so the resulting body diff is empty.
+
+## Why not call the Claude API directly?
+
+The skill description explicitly excludes live API queries (Non-Goal
+in issue #324). Reasons:
+
+1. The original conversation is unrecoverable — no API can answer
+   "how many tokens did Claude use to draft this card on date X."
+2. Token-counter access requires an API key + per-skill billing config,
+   which is out of scope for a footer-backfill utility.
+3. Heuristic estimates are more honest than fabricated precision.

--- a/claude/skills/gh-add-ai-metrics/references/post-hoc-metrics.md
+++ b/claude/skills/gh-add-ai-metrics/references/post-hoc-metrics.md
@@ -9,13 +9,39 @@ stay deterministic across re-runs.
 ## Inputs (per card)
 
 - `title` — first line of `gh {issue,pr} view --json title`
-- `body` — `--json body`, the user-authored portion only (footer
-  excluded if a previous run wrote one — see "stripping" below)
+- `body` — `--json body`, raw from the API. May or may not contain a
+  prior `<!-- ai-metrics -->` footer; the strip step below is always
+  applied first so downstream computations see only the user-authored
+  portion.
+
+## Always-strip step (must precede TOKENS)
+
+The TOKENS character count must come from the body **without** any
+existing footer; otherwise a `--force` re-run inflates the count by the
+length of the previous footer (~150 chars), feeding back into a slowly
+growing token estimate. The strip is also a no-op when no footer
+exists, so it is safe to run unconditionally.
+
+```bash
+stripped=$(printf '%s' "$body" \
+  | perl -0777 -pe 's|\n+---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->\n?||s')
+```
+
+Regex notes:
+
+- `\n+---\n` matches one or more leading newlines + the `---` separator
+  on its own line. Tolerates both append conventions in the wild —
+  PR #320's `\n---\n` (single) and `gh-issue-create`'s `\n\n---\n`
+  (double) — without leaving a stray newline behind in either case.
+- `<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->` matches both the colonless
+  form and the suffixed form (`<!-- ai-metrics:gh-pr -->`).
+- `.*?` non-greedy + the `s` flag scopes the match to the nearest
+  closing marker.
 
 ## TOKENS
 
 ```
-TOKENS = max(1000, round_to_500((len(title) + len(body)) / 4))
+TOKENS = max(1000, round_to_500((len(title) + len(stripped)) / 4))
 ```
 
 - Character count (not byte count); `wc -m` for safety on multibyte
@@ -24,10 +50,10 @@ TOKENS = max(1000, round_to_500((len(title) + len(body)) / 4))
   Token Estimation rules.
 - Floor at 1000 — anything smaller is noise.
 
-Bash:
+Bash (consumes `$stripped` from the always-strip step above):
 
 ```bash
-chars=$(printf '%s%s' "$title" "$body" | wc -m | awk '{print $1}')
+chars=$(printf '%s%s' "$title" "$stripped" | wc -m | awk '{print $1}')
 tokens=$(( (chars / 4 + 250) / 500 * 500 ))
 [ "$tokens" -lt 1000 ] && tokens=1000
 ```
@@ -76,19 +102,6 @@ elapsed_min=$(awk -v h="$human_h" 'BEGIN { v = h * 60 * 0.05; printf "%d", (v < 
 The 5% factor reflects the observed ratio in #320's own footer
 (`👤 ~8 h · 🤖 ~15 min` ≈ 3.1%, rounded up for safety) and is intentionally
 conservative — better to over-report AI cost than under-report.
-
-## Stripping the existing footer before recomputation (`--force`)
-
-When recomputing on a card that already has a footer, character counts
-must be taken from the *original* body, not the inflated one with the
-prior footer included. Strip first:
-
-```bash
-stripped=$(printf '%s' "$body" \
-  | perl -0777 -pe 's|\n?---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->\n?||s')
-```
-
-Then feed `stripped` (not `body`) into the TOKENS formula.
 
 ## Determinism
 


### PR DESCRIPTION
## Summary
- 신규 스킬 `gh:add-ai-metrics` 추가 — 기존(과거) Issue/PR 카드에 `<!-- ai-metrics -->` footer 를 소급 부착한다.
- #317 / #320 의 Non-Goal("과거 카드 소급 적용") 갭을 별도 도구로 메우는 일회용·재사용 가능한 backfill 스킬.
- 기본 idempotent (footer 있으면 skip), `--force` 시 메트릭 재계산 후 in-place replace.

## Changes
- `claude/skills/gh-add-ai-metrics/SKILL.md` (108 lines): 워크플로 단계 분기 — Help / Step 1 args+repo / Step 2 mode dispatch (no-args · explicit-list · date-filter) / Step 3 per-card loop / Step 4 summary / Constraints.
- `references/help.md` (92 lines): 인자 표·세 가지 호출 패턴 예시·동작 계약·NOT-do 목록.
- `references/footer-detection.md` (131 lines): 앵커형 multiline regex (`\n---\n` separator + paired OPEN/CLOSE 마커가 각자 줄에). inline backtick 으로 마커를 *언급만* 하는 본문(예: 이 PR 의 source 이슈 #324 자체)에서 `has_footer` false-positive 가 나지 않도록 perl `-0777` 슬럼프 모드 사용. append / in-place replace / `--force` degrade 헬퍼와 테스트 rubric 포함.
- `references/post-hoc-metrics.md` (109 lines): backfill 시 원본 Claude 세션이 사라진 점을 전제로 한 추정 규칙. `TOKENS = chars/4`, nearest 500, min 1000. `HUMAN_H` = 카드 title 의 conventional-commit prefix 룩업, **SSOT 는 `gh-issue-create/references/metrics-baseline.md`** (테이블 복제 금지). `ELAPSED = max(1, HUMAN_H × 0.05)` — 보수적 post-hoc 추정. 같은 입력에서 항상 같은 값 → `--force` 재실행 시 body diff 없음.

## Design highlights
- **Skip 경로는 API-silent** — `gh edit` 호출 자체를 생략해서 rate-limit 절약.
- **`--force` 의 의미** — 단순 덮어쓰기가 아니라 "본문에서 기존 footer 를 strip 해서 토큰을 재계산한 뒤 새 값으로 1회 replace". footer 가 없는 카드에 `--force` 만 줘도 정상 append 로 degrade.
- **Marker 호환** — emit 은 PR #320 1:1 호환의 colonless 형태 (`<!-- ai-metrics -->`). detection 은 `<!-- ai-metrics:<skill> -->` 형태(metrics-helper.md 의 신규 스키마)도 같이 매치 — forward-compat.
- **>100 카드 일괄 처리** 시 `[y/N]` confirmation 강제, `--yes` flag 없음.

## Test plan
- [x] `markdownlint` 4 파일 통과 (exit 0).
- [x] anchored detection regex 가 issue #324 본문(footer + 다수 inline 마커 mention 혼재)에서: 원본 → TRUE, footer strip 후 → FALSE 검증.
- [x] strip 후 char count 가 원본 - footer 길이 와 일치 (7178 → 7097, ≈81 chars 제거).
- [x] prefix 추출: `feat(skills): …` → `feat` (sed 정규식).
- [x] AGENTS.md 라인 199 (SKILL.md ≤100 lines) 준수: SKILL.md 본문 86 줄 (frontmatter 22 줄 별도).
- [x] 메모리 SSOT 의 skill naming 규칙 준수: 디렉토리 `gh-add-ai-metrics` (하이픈), frontmatter `name: gh:add-ai-metrics` (콜론).
- [ ] 실제 호출 검증 (별도 follow-up): `/gh:add-ai-metrics issue#317 pr#320` 으로 두 카드 retrofit, 두 번째 호출 시 skip 확인.
- [ ] `/gh:add-ai-metrics --type issue --date 2026-04-30` 도 dry 실행 검증.

## Related
Closes #324

선행:
- #317 (신규 카드용 ai-metrics 자동 삽입, Non-Goal 로 소급 제외 — 본 PR 이 그 갭을 메움)
- #320 (#317 구현 머지)

---
<!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

