### PR TITLE
fix(skills): gh:pr token input + GraphQL deprecation fallback

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -70,10 +70,15 @@ footer block (soft-fail — warn on error, never block):
 2. Issue type: the conventional-commit prefix from the first commit subject.
 3. Human time: look up `gh-issue-create/references/metrics-baseline.md`.
    For `feat`, infer size from the number of files changed.
-4. Token estimate: character count of (issue body + commit log) ÷ 4,
-   rounded to nearest 500. Minimum 1 000.
+4. Token estimate: read `references/metrics-helper.md` and paste the
+   `compute_pr_tokens` snippet in full. The inputs are **(linked-issue
+   body) + (commit log over `<base>..HEAD`)**, NOT the drafted PR body.
+   Counting `$BODY` (the PR-body temp file) is the regression that
+   produced PR #325's `📊 ~1000 tokens` footer (issue #326).
 
 ```bash
+# After running the snippet from references/metrics-helper.md, $TOKENS is
+# bound to the correct estimate. Now append the footer to $BODY.
 printf '\n---\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n' \
   "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
 ```

--- a/claude/skills/gh-pr/references/metrics-helper.md
+++ b/claude/skills/gh-pr/references/metrics-helper.md
@@ -1,0 +1,85 @@
+# Metrics Helper — token compute for the gh:pr footer
+
+Used in Step 4 of `gh:pr/SKILL.md` when building the `<!-- ai-metrics:gh-pr -->`
+footer block. The token estimate must reflect the AI input load that produced
+the PR — that's **(linked-issue body) + (commit log over `<base>..HEAD`)** —
+not the drafted PR body itself.
+
+## Why a code-ified helper
+
+Issue #326 traced PR #325's `📊 ~1000 tokens` footer to a Step 4 execution
+that counted `wc -m < "$BODY"` (the PR-body temp file) instead of the
+issue-body + commit-log pair. The natural-language spec ("character count
+of (issue body + commit log) ÷ 4") didn't bind tightly to a variable name
+at execution time, so the executor fell back to the closest in-scope file
+(`$BODY`) and the footer under-reported by ~7×.
+
+This file pins the exact bash so the inputs cannot drift again.
+
+## Snippet — paste into Step 4 verbatim
+
+```bash
+compute_pr_tokens() {
+    local _issue_body="$1" _commit_log="$2"
+    local _total _t
+    _total=$((
+        $(printf '%s' "$_issue_body" | wc -m) +
+        $(printf '%s' "$_commit_log" | wc -m)
+    ))
+    _t=$(( (_total / 4 + 250) / 500 * 500 ))
+    [ "$_t" -lt 1000 ] && _t=1000
+    printf '%s\n' "$_t"
+}
+
+ISSUE_BODY=""
+if [ -n "${ISSUE_NUMBER-}" ]; then
+    # gh resolves the repo from the current dir if --repo is omitted;
+    # callers that already have $TARGET_REPO bound can pass it explicitly.
+    if [ -n "${TARGET_REPO-}" ]; then
+        ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$TARGET_REPO" \
+            --json body --jq .body 2>/dev/null) || ISSUE_BODY=""
+    else
+        ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" \
+            --json body --jq .body 2>/dev/null) || ISSUE_BODY=""
+    fi
+fi
+COMMIT_LOG=$( { git log "$BASE_BRANCH..HEAD" --format=%B; \
+                git diff "$BASE_BRANCH...HEAD"; } 2>/dev/null )
+
+TOKENS=$(compute_pr_tokens "$ISSUE_BODY" "$COMMIT_LOG")
+```
+
+The two inputs are computed explicitly. `$BODY` (the PR body temp file) is
+deliberately not referenced — it's the wrong input.
+
+## Regression case — PR #325
+
+| Input | Char count |
+|---|---|
+| Issue #324 body                                   | ~13 800 |
+| `git log main..HEAD --format=%B` + `git diff`     | ~13 200 |
+| **Total**                                         | ~27 000 |
+| `total / 4`                                       | ~6 750  |
+| Rounded to nearest 500                            | **7 000** |
+
+A re-run of the helper on PR #325's range must yield 7 000 (±500 for diff
+drift on the same commit set), never 1 000.
+
+## Boundary fixtures
+
+- Both inputs empty → `compute_pr_tokens "" ""` returns `1000` (floor).
+- Tiny PR (total ≈ 50)        → `1000` (floor).
+- Mid PR  (total ≈ 12 000)    → `3000`.
+- Large PR (total ≈ 80 000)   → `20000`.
+
+Numbers match `(total / 4 + 250) / 500 * 500` exactly. Any drift in the
+formula must update both this table and the snippet above.
+
+## What `compute_pr_tokens` does NOT do
+
+- Does not fall back to the PR body when the issue body is unavailable.
+  Empty issue body is fine — the commit log alone usually pushes the
+  estimate past the 1000 floor on any non-trivial PR.
+- Does not include review comment bodies, CI logs, or AI scratchpads.
+  The footer is a coarse "AI input weight" signal, not a full
+  reconstruction of the conversation.

--- a/claude/skills/gh-pr/references/metrics-helper.md
+++ b/claude/skills/gh-pr/references/metrics-helper.md
@@ -37,10 +37,10 @@ if [ -n "${ISSUE_NUMBER-}" ]; then
     # callers that already have $TARGET_REPO bound can pass it explicitly.
     if [ -n "${TARGET_REPO-}" ]; then
         ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$TARGET_REPO" \
-            --json body --jq .body 2>/dev/null) || ISSUE_BODY=""
+            --json body --jq '.body? // empty' 2>/dev/null) || ISSUE_BODY=""
     else
         ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" \
-            --json body --jq .body 2>/dev/null) || ISSUE_BODY=""
+            --json body --jq '.body? // empty' 2>/dev/null) || ISSUE_BODY=""
     fi
 fi
 COMMIT_LOG=$( { git log "$BASE_BRANCH..HEAD" --format=%B; \

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -63,9 +63,17 @@ Do NOT set `--draft` or `--reviewer` unless the user explicitly asked.
 
 ## Label Derivation
 
-Labels are applied **after** `gh pr create` via `gh pr edit --add-label`,
-because the label set must be validated against the repo's existing labels
-first (creating labels on the fly is forbidden).
+Labels are applied **after** `gh pr create` via the
+`_gh_pr_edit_safe_label` wrapper (sourced from
+`shell-common/functions/gh_pr_edit_safe.sh`), because:
+
+1. The label set must be validated against the repo's existing labels first
+   (creating labels on the fly is forbidden).
+2. A bare `gh pr edit --add-label` call exits 1 with a `Projects (classic)
+   is being deprecated` GraphQL warning on repos that still have a classic
+   project board attached, silently dropping every label. The wrapper
+   detects that warning and falls back to the REST endpoint, which is
+   GraphQL-free. See issue #326.
 
 ### Mapping from Conventional Commits
 
@@ -99,18 +107,24 @@ Use judgment; do not stretch — a label should meaningfully describe the PR.
 ### Safe application loop
 
 Labels that don't already exist in the repo **must be skipped silently** —
-never create new labels.
+never create new labels. The `_gh_pr_edit_safe_label` wrapper enforces this
+even on the REST fallback path: it re-checks `gh label list` before POST.
 
 ```bash
-EXISTING=$(gh label list --limit 200 --json name -q '.[].name')
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_edit_safe.sh"
+
+EXISTING=$(gh label list --repo "$GH_REPO" --limit 200 --json name -q '.[].name')
 PR_NUMBER=<the number gh pr create printed>
 
 for LABEL in <candidate-list>; do
   if printf '%s\n' "$EXISTING" | grep -Fxq "$LABEL"; then
-    gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+    _gh_pr_edit_safe_label "$PR_NUMBER" "$LABEL" --repo "$GH_REPO"
   fi
 done
 ```
+
+`GH_REPO` is `owner/repo` (e.g. `dEitY719/dotfiles`). Resolve via
+`gh repo view --json nameWithOwner --jq .nameWithOwner` if not already set.
 
 Report the applied labels (and skipped ones, if any) alongside the PR URL
 in Step 7.

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_pr_edit_safe.sh
+# REST-fallback wrappers for `gh pr edit` PR mutations that fail silently on
+# repos with a classic GitHub Projects board attached.
+#
+# Background (issue #326):
+# `gh pr edit` issues a GraphQL request that resolves the PR's `projectCards`
+# field. After the GitHub Projects(classic) sunset (2024-05) that field is
+# deprecated, and GitHub returns a deprecation warning. `gh` treats the
+# warning as a fatal error → exit 1, with the requested mutation NOT applied.
+# Visible symptoms: silent label drops, body-update no-ops.
+#
+# These helpers retry via the REST endpoint, which is GraphQL-free and
+# unaffected by the deprecation. The first attempt still uses `gh pr edit`
+# so repos without a classic board pay no overhead.
+#
+# Usage:
+#   _gh_pr_edit_safe_label  <pr-number> <label>     [--repo owner/name]
+#   _gh_pr_edit_safe_body   <pr-number> <body-file> [--repo owner/name]
+#
+# Repo resolution precedence:
+#   1. Explicit --repo flag
+#   2. GH_REPO env var
+#   3. `gh repo view --json nameWithOwner --jq .nameWithOwner` (current dir)
+#
+# Return codes:
+#   0  — primary `gh pr edit` succeeded, OR REST fallback applied successfully
+#   1  — primary failed for a non-deprecation reason (stderr passed through)
+#   2  — usage error (missing args, unknown option, repo unresolved)
+#   3  — REST fallback refused (label does not exist; would auto-create)
+#
+# Defensive checks:
+#   _gh_pr_edit_safe_label validates the label exists in the repo before
+#   hitting the REST endpoint. Without this guard, POST /labels would
+#   auto-create a missing label silently — see project memory
+#   `feedback_gh_label_no_autocreate.md`.
+
+_gh_pr_edit_safe__deprecation_marker='Projects (classic) is being deprecated'
+
+_gh_pr_edit_safe__resolve_repo() {
+    if [ -n "$1" ]; then
+        printf '%s' "$1"
+        return 0
+    fi
+    if [ -n "${GH_REPO-}" ]; then
+        printf '%s' "$GH_REPO"
+        return 0
+    fi
+    gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null
+}
+
+_gh_pr_edit_safe_label() {
+    local _pr="$1" _label="$2"
+    [ "$#" -ge 2 ] && shift 2
+
+    local _repo_flag=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo)
+                if [ -z "${2-}" ]; then
+                    printf '[gh-pr-edit-safe] --repo requires an argument\n' >&2
+                    return 2
+                fi
+                _repo_flag="$2"
+                shift 2
+                ;;
+            *)
+                printf '[gh-pr-edit-safe] unknown option: %s\n' "$1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -z "$_pr" ] || [ -z "$_label" ]; then
+        printf '[gh-pr-edit-safe] usage: _gh_pr_edit_safe_label <pr> <label> [--repo owner/name]\n' >&2
+        return 2
+    fi
+
+    local _repo
+    _repo=$(_gh_pr_edit_safe__resolve_repo "$_repo_flag")
+    if [ -z "$_repo" ]; then
+        printf '[gh-pr-edit-safe] could not resolve repo (pass --repo or set GH_REPO)\n' >&2
+        return 2
+    fi
+
+    local _err
+    _err=$(mktemp) || return 2
+
+    if gh pr edit "$_pr" --repo "$_repo" --add-label "$_label" >/dev/null 2>"$_err"; then
+        rm -f "$_err"
+        return 0
+    fi
+
+    if ! grep -q "$_gh_pr_edit_safe__deprecation_marker" "$_err"; then
+        cat "$_err" >&2
+        rm -f "$_err"
+        return 1
+    fi
+
+    # Deprecation-warning path: validate label exists before REST fallback,
+    # else POST /labels would silently create a new label (issue #326).
+    if ! gh label list --repo "$_repo" --limit 200 --json name --jq '.[].name' 2>/dev/null \
+        | grep -Fxq "$_label"; then
+        printf '[gh-pr-edit-safe] label "%s" not in %s; refusing REST fallback (would auto-create)\n' \
+            "$_label" "$_repo" >&2
+        rm -f "$_err"
+        return 3
+    fi
+
+    if gh api -X POST "repos/$_repo/issues/$_pr/labels" \
+        -f "labels[]=$_label" >/dev/null 2>"$_err"; then
+        rm -f "$_err"
+        return 0
+    fi
+
+    cat "$_err" >&2
+    rm -f "$_err"
+    return 1
+}
+
+_gh_pr_edit_safe_body() {
+    local _pr="$1" _body_file="$2"
+    [ "$#" -ge 2 ] && shift 2
+
+    local _repo_flag=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo)
+                if [ -z "${2-}" ]; then
+                    printf '[gh-pr-edit-safe] --repo requires an argument\n' >&2
+                    return 2
+                fi
+                _repo_flag="$2"
+                shift 2
+                ;;
+            *)
+                printf '[gh-pr-edit-safe] unknown option: %s\n' "$1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -z "$_pr" ] || [ -z "$_body_file" ]; then
+        printf '[gh-pr-edit-safe] usage: _gh_pr_edit_safe_body <pr> <body-file> [--repo owner/name]\n' >&2
+        return 2
+    fi
+    if [ ! -f "$_body_file" ]; then
+        printf '[gh-pr-edit-safe] body-file not found: %s\n' "$_body_file" >&2
+        return 2
+    fi
+
+    local _repo
+    _repo=$(_gh_pr_edit_safe__resolve_repo "$_repo_flag")
+    if [ -z "$_repo" ]; then
+        printf '[gh-pr-edit-safe] could not resolve repo (pass --repo or set GH_REPO)\n' >&2
+        return 2
+    fi
+
+    local _err
+    _err=$(mktemp) || return 2
+
+    if gh pr edit "$_pr" --repo "$_repo" --body-file "$_body_file" >/dev/null 2>"$_err"; then
+        rm -f "$_err"
+        return 0
+    fi
+
+    if ! grep -q "$_gh_pr_edit_safe__deprecation_marker" "$_err"; then
+        cat "$_err" >&2
+        rm -f "$_err"
+        return 1
+    fi
+
+    # Build {"body": "<file-contents>"} as JSON for the REST PATCH.
+    # jq --rawfile slurps the file losslessly, preserving newlines and
+    # escapes that would mangle if passed via shell args.
+    local _payload
+    if ! _payload=$(jq -n --rawfile body "$_body_file" '{body: $body}' 2>"$_err"); then
+        cat "$_err" >&2
+        rm -f "$_err"
+        return 1
+    fi
+
+    if printf '%s' "$_payload" | gh api -X PATCH "repos/$_repo/pulls/$_pr" \
+        --input - >/dev/null 2>"$_err"; then
+        rm -f "$_err"
+        return 0
+    fi
+
+    cat "$_err" >&2
+    rm -f "$_err"
+    return 1
+}

--- a/tests/bats/functions/gh_pr_edit_safe.bats
+++ b/tests/bats/functions/gh_pr_edit_safe.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_pr_edit_safe.bats
+# Unit tests for _gh_pr_edit_safe_label / _gh_pr_edit_safe_body — the
+# REST fallback wrappers that recover from `gh pr edit` GraphQL deprecation
+# warnings on classic-Projects repos (issue #326).
+#
+# Network is never touched. A fake `gh` shim on PATH selects per-test
+# behavior via FAKE_GH_MODE, mirroring the gh_project_status.bats pattern.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    _setup_fake_gh
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Fake `gh` shim
+#
+# FAKE_GH_MODE controls behaviour of `gh pr edit` and `gh api`:
+#   ok          — `gh pr edit` succeeds (no warning, no fallback needed)
+#   deprecated  — `gh pr edit` prints deprecation warning + exit 1, then
+#                 `gh api POST .../labels` succeeds
+#   deprecated_body — same but for body PATCH path
+#   missing_label — `gh pr edit` prints deprecation, then `gh label list`
+#                   omits the label so REST fallback must be refused
+#   other_error — `gh pr edit` exits 1 with an unrelated error (no
+#                 deprecation marker → no fallback, error passed through)
+#   rest_fail   — deprecation warning, then REST POST also fails
+# A scratch log records every call for assertion: $TEST_TEMP_HOME/gh.log
+# ---------------------------------------------------------------------------
+_setup_fake_gh() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    mkdir -p "$STUB_BIN"
+    GH_LOG="$TEST_TEMP_HOME/gh.log"
+    : >"$GH_LOG"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Record the invocation for inspection.
+{ printf 'gh'; for a in "$@"; do printf ' %q' "$a"; done; printf '\n'; } \
+    >>"$GH_LOG"
+
+mode="${FAKE_GH_MODE:-ok}"
+
+# `gh repo view --json nameWithOwner --jq .nameWithOwner` — used by repo
+# resolution. Keep it boring.
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+    echo "fake/repo"
+    exit 0
+fi
+
+# `gh label list ...` — return the labels the test expects to exist.
+if [ "$1" = "label" ] && [ "$2" = "list" ]; then
+    case "$mode" in
+        missing_label) printf 'bug\nchore\n' ;;
+        *)             printf 'bug\nchore\nfeat\nskill\n' ;;
+    esac
+    exit 0
+fi
+
+# `gh pr edit <N> --repo R --add-label L` or `--body-file F`
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+    case "$mode" in
+        ok)
+            exit 0
+            ;;
+        deprecated|missing_label|rest_fail)
+            echo "GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience" >&2
+            exit 1
+            ;;
+        deprecated_body)
+            # Body path uses a different mode marker so we can
+            # assert different REST fallback (PATCH vs POST).
+            echo "GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience" >&2
+            exit 1
+            ;;
+        other_error)
+            echo "Some other unrelated error" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# `gh api -X POST .../labels` — REST fallback for labels
+if [ "$1" = "api" ] && [ "$3" = "POST" ]; then
+    case "$mode" in
+        rest_fail) echo "REST POST failed" >&2; exit 1 ;;
+        *)         exit 0 ;;
+    esac
+fi
+
+# `gh api -X PATCH .../pulls/N --input -` — REST fallback for body
+if [ "$1" = "api" ] && [ "$3" = "PATCH" ]; then
+    # Drain stdin to keep the pipe quiet
+    cat >/dev/null
+    case "$mode" in
+        rest_fail) echo "REST PATCH failed" >&2; exit 1 ;;
+        *)         exit 0 ;;
+    esac
+fi
+
+# Catch-all: success
+exit 0
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run a snippet in bash with the shim on PATH and the helper sourced.
+_run_helper() {
+    local mode="$1" snippet="$2"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_GH_MODE='${mode}'
+        export GH_LOG='${GH_LOG}'
+        . '${DOTFILES_ROOT}/shell-common/functions/gh_pr_edit_safe.sh'
+        ${snippet}
+        echo \"rc=\$?\"
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Loading: helpers exist after sourcing
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_pr_edit_safe_label exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_pr_edit_safe.sh"; \
+                 declare -f _gh_pr_edit_safe_label >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_pr_edit_safe_body exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_pr_edit_safe.sh"; \
+                 declare -f _gh_pr_edit_safe_body >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_pr_edit_safe_label exists" {
+    run_in_zsh '. "$DOTFILES_ROOT/shell-common/functions/gh_pr_edit_safe.sh"; \
+                typeset -f _gh_pr_edit_safe_label >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+@test "label: missing args returns 2" {
+    _run_helper ok '_gh_pr_edit_safe_label 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage:"
+}
+
+@test "label: unknown option returns 2" {
+    _run_helper ok '_gh_pr_edit_safe_label 99 feat --bogus 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "unknown option: --bogus"
+}
+
+@test "label: --repo without arg returns 2" {
+    _run_helper ok '_gh_pr_edit_safe_label 99 feat --repo 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "--repo requires an argument"
+}
+
+@test "body: missing body-file returns 2" {
+    _run_helper ok '_gh_pr_edit_safe_body 99 /nonexistent/path/abc.txt 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "body-file not found"
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: gh pr edit succeeds, no fallback
+# ---------------------------------------------------------------------------
+
+@test "label: ok mode — single gh pr edit call, no REST" {
+    _run_helper ok '_gh_pr_edit_safe_label 99 feat --repo fake/repo 2>&1'
+    assert_output --partial "rc=0"
+    # Exactly one `pr edit`, zero `api ... POST`
+    run grep -c 'pr edit' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'api .*POST' "$GH_LOG"
+    assert_output "0"
+}
+
+@test "body: ok mode — single gh pr edit call, no REST" {
+    _run_helper ok "
+        BF=\$(mktemp); printf 'hi' > \"\$BF\"
+        _gh_pr_edit_safe_body 99 \"\$BF\" --repo fake/repo
+        rm -f \"\$BF\"
+    "
+    assert_output --partial "rc=0"
+    run grep -c 'pr edit' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'api .*PATCH' "$GH_LOG"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# Fallback path: deprecation warning triggers REST
+# ---------------------------------------------------------------------------
+
+@test "label: deprecated mode — falls back to REST POST and succeeds" {
+    _run_helper deprecated '_gh_pr_edit_safe_label 99 feat --repo fake/repo 2>&1'
+    assert_output --partial "rc=0"
+    # gh pr edit attempted, then label list (validation), then api POST
+    run grep -c 'pr edit' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'label list' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'api .*POST' "$GH_LOG"
+    assert_output "1"
+}
+
+@test "body: deprecated mode — falls back to REST PATCH and succeeds" {
+    _run_helper deprecated_body "
+        BF=\$(mktemp); printf 'hello world' > \"\$BF\"
+        _gh_pr_edit_safe_body 99 \"\$BF\" --repo fake/repo
+        rm -f \"\$BF\"
+    "
+    assert_output --partial "rc=0"
+    run grep -c 'api .*PATCH' "$GH_LOG"
+    assert_output "1"
+}
+
+# ---------------------------------------------------------------------------
+# Defensive guard: REST fallback must NOT auto-create labels.
+# ---------------------------------------------------------------------------
+
+@test "label: missing-label mode — refuses REST fallback (rc=3)" {
+    _run_helper missing_label '_gh_pr_edit_safe_label 99 feat --repo fake/repo 2>&1'
+    assert_output --partial "rc=3"
+    assert_output --partial "refusing REST fallback (would auto-create)"
+    # No POST should have been issued.
+    run grep -c 'api .*POST' "$GH_LOG"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# Non-deprecation errors must NOT trigger fallback.
+# ---------------------------------------------------------------------------
+
+@test "label: other_error mode — passes error through (rc=1, no REST)" {
+    _run_helper other_error '_gh_pr_edit_safe_label 99 feat --repo fake/repo 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "Some other unrelated error"
+    run grep -c 'api .*POST' "$GH_LOG"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# REST fallback failure surfaces as rc=1
+# ---------------------------------------------------------------------------
+
+@test "label: rest_fail mode — REST POST failure surfaces as rc=1" {
+    _run_helper rest_fail '_gh_pr_edit_safe_label 99 feat --repo fake/repo 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "REST POST failed"
+}


### PR DESCRIPTION
## Summary
- `gh:pr` 가 PR #325 에서 노출한 두 개의 회귀를 해결 — Bug A(토큰 산정 입력 오류로 footer 가 ~7배 under-report) 와 Bug B(`gh pr edit` 가 Projects(classic) deprecation GraphQL 경고를 fatal 로 처리해 라벨/body 업데이트가 silent drop) 동시 수정.
- 자연어 명세를 코드로 박제(`compute_pr_tokens` SSOT) + REST fallback wrapper (`_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`) 도입.
- 회귀 보호용 bats 14 케이스 추가 (fake `gh` shim 기반, 라이브 API 호출 없음).

## Changes
- `claude/skills/gh-pr/references/metrics-helper.md` (new): `compute_pr_tokens(issue_body, commit_log)` 정식 bash 정의 + PR #325 회귀 케이스(27 000 chars → 7 000 tokens) + 경계값 fixtures(empty/tiny/mid/large).
- `claude/skills/gh-pr/SKILL.md` Step 4: 자연어 토큰 산정 문장을 helper 참조 + `$BODY` 사용 금지 명시로 교체. 회귀가 어떻게 발생했는지(#326) 인라인으로 박제.
- `claude/skills/gh-pr/references/pr-body-template.md` Label Derivation: `gh pr edit --add-label` 직호출을 `_gh_pr_edit_safe_label` 래퍼로 교체. 래퍼는 deprecation 경고 감지 시 REST POST 로 자동 fallback.
- `shell-common/functions/gh_pr_edit_safe.sh` (new): 두 래퍼 (`_gh_pr_edit_safe_label`, `_gh_pr_edit_safe_body`). 첫 시도는 `gh pr edit`, deprecation 마커 감지 시 REST(`POST .../labels`, `PATCH .../pulls/N`) 로 자동 fallback. 라벨 케이스는 `gh label list` 재검증으로 auto-create trap 방지(memory `feedback_gh_label_no_autocreate.md` 적용).
- `tests/bats/functions/gh_pr_edit_safe.bats` (new): 14 케이스 — 함수 로딩(bash/zsh) · arg validation · 정상 경로(no fallback) · deprecation fallback(POST/PATCH 양쪽) · 누락 라벨 거절(rc=3) · 비-deprecation 에러 통과(rc=1) · REST 실패 surfacing.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_edit_safe.bats` → 14/14 pass
- [x] 전체 bats suite (361 케이스) → exit 0
- [x] `compute_pr_tokens` boundary 검증: empty=1000 / tiny=1000 / mid 12 000=3000 / PR#325 27 000=7000 / large 80 000=20000 — formula `(total/4 + 250)/500*500` 정확히 일치
- [x] `shellcheck -e SC1090,SC1091 shell-common/functions/gh_pr_edit_safe.sh` → clean
- [x] `bash -n` / `zsh -n` 양쪽 syntax check 통과
- [ ] (post-merge) 본 PR 자체의 footer 토큰값이 ~7000~8000 범위(자가-검증) — PR #325 의 1000 floor 가 재발하지 않음 확인

## Related
Closes #326

---
<!-- ai-metrics:gh-pr -->
📊 ~8000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->
