### PR TITLE
fix(skills): pin gh:pr token input + REST fallback for gh pr edit

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -131,7 +131,12 @@ Resume hint logic:
 - Never skip a step. All 3 or stop.
 - Never mutate state between steps beyond what the sub-skills do.
   Exception: Step 2.4 may edit the PR body after Step 2.3 — this is
-  intentional and must soft-fail (never block the flow).
+  intentional and must soft-fail (never block the flow). If a future
+  variant of Step 2.4 needs to mutate PR labels or body, route through
+  `_pr_edit_safe_label` / `_pr_edit_safe_body`
+  (`shell-common/functions/gh_pr_edit_safe.sh`); plain `gh pr edit
+  --add-label` / `--body-file` silently exits 1 on repos with classic
+  Projects attached (issue #326 Bug B).
 - Do NOT preface or summarize beyond the compact report.
 - Do NOT end the turn until the Step 3 report is issued (success or
   failure template). A `Next:` / resume-hint from a sub-skill

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -99,3 +99,8 @@ On failure: `⚠️  ai-metrics comment failed — continuing.`
 - Never dismiss bot comments as "just a bot".
 - Never fix files outside the PR's diff without flagging scope creep first.
 - Never `--force-push`. If history rewrite is needed, stop and ask.
+- If a future fix flow needs to mutate PR labels or body, route through
+  `_pr_edit_safe_label` / `_pr_edit_safe_body`
+  (`shell-common/functions/gh_pr_edit_safe.sh`). Bare `gh pr edit
+  --add-label` / `--body-file` silently exits 1 on repos with classic
+  Projects attached (issue #326 Bug B).

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -70,10 +70,15 @@ footer block (soft-fail — warn on error, never block):
 2. Issue type: the conventional-commit prefix from the first commit subject.
 3. Human time: look up `gh-issue-create/references/metrics-baseline.md`.
    For `feat`, infer size from the number of files changed.
-4. Token estimate: character count of (issue body + commit log) ÷ 4,
-   rounded to nearest 500. Minimum 1 000.
+4. Token estimate: source `references/token-compute.sh` and call
+   `compute_pr_tokens "$ISSUE_BODY" "$COMMIT_LOG"`. Do NOT hand-roll
+   the math or pass `$BODY` (the PR body file) — see the helper's
+   header for the issue-#326 regression that motivated pinning this
+   contract in code.
 
 ```bash
+. ~/.claude/skills/gh-pr/references/token-compute.sh
+TOKENS=$(compute_pr_tokens "$ISSUE_BODY" "$COMMIT_LOG")
 printf '\n---\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n' \
   "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
 ```

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -63,9 +63,11 @@ Do NOT set `--draft` or `--reviewer` unless the user explicitly asked.
 
 ## Label Derivation
 
-Labels are applied **after** `gh pr create` via `gh pr edit --add-label`,
-because the label set must be validated against the repo's existing labels
-first (creating labels on the fly is forbidden).
+Labels are applied **after** `gh pr create` via `_pr_edit_safe_label`
+(a `gh pr edit --add-label` wrapper that falls back to the REST API
+when the GraphQL Projects(classic) deprecation warning trips a fatal
+exit code). The label set must be validated against the repo's
+existing labels first (creating labels on the fly is forbidden).
 
 ### Mapping from Conventional Commits
 
@@ -99,18 +101,29 @@ Use judgment; do not stretch — a label should meaningfully describe the PR.
 ### Safe application loop
 
 Labels that don't already exist in the repo **must be skipped silently** —
-never create new labels.
+never create new labels. Pre-filtering via `gh label list` is the only
+gate that prevents `_pr_edit_safe_label`'s REST fallback (which uses
+`POST /repos/.../labels`, an auto-creating endpoint) from inventing
+labels. Do NOT skip the pre-filter.
 
 ```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_edit_safe.sh"
 EXISTING=$(gh label list --limit 200 --json name -q '.[].name')
 PR_NUMBER=<the number gh pr create printed>
 
 for LABEL in <candidate-list>; do
   if printf '%s\n' "$EXISTING" | grep -Fxq "$LABEL"; then
-    gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+    _pr_edit_safe_label "$PR_NUMBER" "$LABEL"
   fi
 done
 ```
+
+`_pr_edit_safe_label` first tries `gh pr edit --add-label`; on the
+specific `Projects (classic) is being deprecated` GraphQL warning that
+trips `gh pr edit` to exit 1 in repos with classic boards attached
+(issue #326 Bug B), it retries via `gh api -X POST
+repos/<owner>/<repo>/issues/<pr>/labels`. Other failures are not
+retried — they are forwarded to stderr and surface as non-zero rc.
 
 Report the applied labels (and skipped ones, if any) alongside the PR URL
 in Step 7.

--- a/claude/skills/gh-pr/references/token-compute.sh
+++ b/claude/skills/gh-pr/references/token-compute.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# shellcheck shell=bash
+# claude/skills/gh-pr/references/token-compute.sh
+#
+# compute_pr_tokens — derive the ai-metrics token estimate for `gh:pr`.
+#
+# Why this lives in code, not prose
+# ---------------------------------
+# SKILL.md Step 4 used to describe the input contract in natural
+# language ("character count of (issue body + commit log) ÷ 4, rounded
+# to nearest 500, minimum 1 000"). At execution time the agent inferred
+# the inputs from the variables in scope and reached for `$BODY` (the
+# PR body draft) — the closest match — instead of `$ISSUE_BODY +
+# $COMMIT_LOG`. The result on PR #325 was a footer of `~1000 tokens`
+# (raw 500 → floored to 1000) when the spec-compliant value was 7000.
+# Pinning the contract in a callable function removes the ambiguity:
+# the function name forces the caller to supply both inputs and
+# documents which transform is applied.
+#
+# Usage (from Step 4):
+#   . ~/.claude/skills/gh-pr/references/token-compute.sh
+#   TOKENS=$(compute_pr_tokens "$ISSUE_BODY" "$COMMIT_LOG")
+#
+# Inputs:
+#   $1 — linked-issue body (full markdown). Empty when no issue is linked.
+#   $2 — `git log <base>..HEAD --format=%B` output (commit messages),
+#        optionally concatenated with `git diff <base>..HEAD` if that is
+#        what the caller wants to count. The function does not care which
+#        of the two it receives — the contract is "the second input is
+#        the commit-side context." Pass whichever one matches the
+#        spec the caller is implementing.
+#
+# Both args may be empty; the floor still produces 1 000.
+#
+# Regression case (issue #326): PR #325 — issue body 26 045 chars + commit
+# log 1 032 chars = 27 077 → /4 = 6 769 → round to 7 000.
+compute_pr_tokens() {
+    _gh_pr_issue_body="${1:-}"
+    _gh_pr_commit_log="${2:-}"
+    _gh_pr_issue_chars=$(printf '%s' "$_gh_pr_issue_body" | wc -m | tr -d ' ')
+    _gh_pr_log_chars=$(printf '%s' "$_gh_pr_commit_log" | wc -m | tr -d ' ')
+    _gh_pr_total=$((_gh_pr_issue_chars + _gh_pr_log_chars))
+    _gh_pr_t=$(((_gh_pr_total / 4 + 250) / 500 * 500))
+    [ "$_gh_pr_t" -lt 1000 ] && _gh_pr_t=1000
+    printf '%s\n' "$_gh_pr_t"
+    unset _gh_pr_issue_body _gh_pr_commit_log _gh_pr_issue_chars \
+        _gh_pr_log_chars _gh_pr_total _gh_pr_t
+}

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_pr_edit_safe.sh
+#
+# Wrappers around `gh pr edit` that gracefully fall back to the REST API
+# when the GraphQL Projects(classic) deprecation warning trips a fatal
+# exit code in the wrapped command.
+#
+# Background (issue #326, Bug B): on repos with classic Projects attached
+# (e.g. dEitY719/dotfiles), `gh pr edit ... --add-label` and
+# `--body-file` print the deprecation warning to stderr and exit 1,
+# leaving the label or body unmutated. The REST endpoints
+# (`POST /repos/:owner/:repo/issues/:n/labels` and
+# `PATCH /repos/:owner/:repo/pulls/:n`) do not trigger the GraphQL
+# warning, so a single retry through them recovers without any user
+# action. Symptom seen on PR #325: labels silently dropped, body
+# mutation silently skipped.
+#
+# Both helpers stay silent on success and emit a single one-line note
+# on stderr when the fallback path is taken, so callers can tell from
+# logs whether the GraphQL path or the REST path actually applied the
+# change. Failure on the fallback path returns the REST exit code so
+# the caller can react.
+#
+# Usage:
+#   _pr_edit_safe_label  <pr-number> <label>           [--repo <owner/repo>]
+#   _pr_edit_safe_body   <pr-number> <body-file-path>  [--repo <owner/repo>]
+#
+# When --repo is omitted, $GH_REPO is used; if also empty, the helper
+# resolves it via `gh repo view --json nameWithOwner -q .nameWithOwner`.
+#
+# Important: the label helper does NOT verify the label exists in the
+# repo. POST /issues/:n/labels auto-creates missing labels — which
+# violates the gh-pr "never create labels on the fly" rule. Callers
+# (notably gh-pr's safe-apply loop in pr-body-template.md) MUST
+# pre-filter the candidate list against `gh label list` before calling
+# this wrapper.
+
+# Resolve --repo / $GH_REPO / current cwd into stdout owner/repo.
+# Returns non-zero only if every resolution path fails. Silent on stderr.
+_pr_edit_safe_resolve_repo() {
+    if [ -n "$1" ]; then
+        printf '%s\n' "$1"
+        return 0
+    fi
+    if [ -n "${GH_REPO:-}" ]; then
+        printf '%s\n' "$GH_REPO"
+        return 0
+    fi
+    _gh_pr_safe_resolved=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+        unset _gh_pr_safe_resolved
+        return 1
+    }
+    [ -z "$_gh_pr_safe_resolved" ] && {
+        unset _gh_pr_safe_resolved
+        return 1
+    }
+    printf '%s\n' "$_gh_pr_safe_resolved"
+    unset _gh_pr_safe_resolved
+}
+
+# Internal: parse [--repo <owner/repo>] from a varargs tail and echo the
+# resolved repo on stdout. Fails (returns 1) only when --repo is supplied
+# without a value or all resolution paths come up empty.
+_pr_edit_safe_parse_repo() {
+    _gh_pr_safe_explicit=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --repo)
+            if [ -z "${2-}" ]; then
+                printf '[gh-pr-edit-safe] --repo requires an argument\n' >&2
+                unset _gh_pr_safe_explicit
+                return 1
+            fi
+            _gh_pr_safe_explicit="$2"
+            shift 2
+            ;;
+        *) shift ;;
+        esac
+    done
+    _pr_edit_safe_resolve_repo "$_gh_pr_safe_explicit"
+    _gh_pr_safe_rc=$?
+    unset _gh_pr_safe_explicit
+    return "$_gh_pr_safe_rc"
+}
+
+# Apply an existing label to a PR. The label MUST already exist in the
+# repo — this helper does NOT call `gh label list` itself.
+_pr_edit_safe_label() {
+    if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
+        printf '[gh-pr-edit-safe] usage: _pr_edit_safe_label <pr> <label> [--repo <owner/repo>]\n' >&2
+        return 2
+    fi
+    _gh_pr_safe_pr="$1"
+    _gh_pr_safe_label="$2"
+    shift 2
+
+    _gh_pr_safe_repo=$(_pr_edit_safe_parse_repo "$@") || {
+        printf '[gh-pr-edit-safe] could not resolve owner/repo for #%s\n' "$_gh_pr_safe_pr" >&2
+        unset _gh_pr_safe_pr _gh_pr_safe_label
+        return 2
+    }
+
+    _gh_pr_safe_err=$(mktemp -t gh-pr-edit-safe.XXXXXX) || {
+        unset _gh_pr_safe_pr _gh_pr_safe_label _gh_pr_safe_repo
+        return 1
+    }
+
+    gh pr edit "$_gh_pr_safe_pr" --repo "$_gh_pr_safe_repo" \
+        --add-label "$_gh_pr_safe_label" 2>"$_gh_pr_safe_err"
+    _gh_pr_safe_rc=$?
+
+    if [ "$_gh_pr_safe_rc" -ne 0 ] &&
+        grep -q 'Projects (classic) is being deprecated' "$_gh_pr_safe_err"; then
+        printf '[gh-pr-edit-safe] gh pr edit --add-label hit Projects(classic) deprecation; retrying via REST for #%s\n' \
+            "$_gh_pr_safe_pr" >&2
+        gh api -X POST "repos/$_gh_pr_safe_repo/issues/$_gh_pr_safe_pr/labels" \
+            -f "labels[]=$_gh_pr_safe_label" >/dev/null 2>&1
+        _gh_pr_safe_rc=$?
+    elif [ "$_gh_pr_safe_rc" -ne 0 ]; then
+        cat "$_gh_pr_safe_err" >&2
+    fi
+
+    rm -f "$_gh_pr_safe_err"
+    unset _gh_pr_safe_pr _gh_pr_safe_label _gh_pr_safe_repo _gh_pr_safe_err
+    _gh_pr_safe_final_rc="$_gh_pr_safe_rc"
+    unset _gh_pr_safe_rc
+    return "$_gh_pr_safe_final_rc"
+}
+
+# Replace the body of a PR. Reads the new body verbatim from <body-file>.
+_pr_edit_safe_body() {
+    if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
+        printf '[gh-pr-edit-safe] usage: _pr_edit_safe_body <pr> <body-file> [--repo <owner/repo>]\n' >&2
+        return 2
+    fi
+    _gh_pr_safe_pr="$1"
+    _gh_pr_safe_body_file="$2"
+    if [ ! -r "$_gh_pr_safe_body_file" ]; then
+        printf '[gh-pr-edit-safe] body file not readable: %s\n' "$_gh_pr_safe_body_file" >&2
+        unset _gh_pr_safe_pr _gh_pr_safe_body_file
+        return 2
+    fi
+    shift 2
+
+    _gh_pr_safe_repo=$(_pr_edit_safe_parse_repo "$@") || {
+        printf '[gh-pr-edit-safe] could not resolve owner/repo for #%s\n' "$_gh_pr_safe_pr" >&2
+        unset _gh_pr_safe_pr _gh_pr_safe_body_file
+        return 2
+    }
+
+    _gh_pr_safe_err=$(mktemp -t gh-pr-edit-safe.XXXXXX) || {
+        unset _gh_pr_safe_pr _gh_pr_safe_body_file _gh_pr_safe_repo
+        return 1
+    }
+
+    gh pr edit "$_gh_pr_safe_pr" --repo "$_gh_pr_safe_repo" \
+        --body-file "$_gh_pr_safe_body_file" 2>"$_gh_pr_safe_err"
+    _gh_pr_safe_rc=$?
+
+    if [ "$_gh_pr_safe_rc" -ne 0 ] &&
+        grep -q 'Projects (classic) is being deprecated' "$_gh_pr_safe_err"; then
+        printf '[gh-pr-edit-safe] gh pr edit --body-file hit Projects(classic) deprecation; retrying via REST for #%s\n' \
+            "$_gh_pr_safe_pr" >&2
+        # Read the body from the file so we avoid the gh `-F field=@file`
+        # ambiguity (gh treats `@file` only on a few projection fields).
+        _gh_pr_safe_payload=$(cat "$_gh_pr_safe_body_file")
+        gh api -X PATCH "repos/$_gh_pr_safe_repo/pulls/$_gh_pr_safe_pr" \
+            -f body="$_gh_pr_safe_payload" >/dev/null 2>&1
+        _gh_pr_safe_rc=$?
+        unset _gh_pr_safe_payload
+    elif [ "$_gh_pr_safe_rc" -ne 0 ]; then
+        cat "$_gh_pr_safe_err" >&2
+    fi
+
+    rm -f "$_gh_pr_safe_err"
+    unset _gh_pr_safe_pr _gh_pr_safe_body_file _gh_pr_safe_repo _gh_pr_safe_err
+    _gh_pr_safe_final_rc="$_gh_pr_safe_rc"
+    unset _gh_pr_safe_rc
+    return "$_gh_pr_safe_final_rc"
+}

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -115,7 +115,7 @@ _pr_edit_safe_label() {
         printf '[gh-pr-edit-safe] gh pr edit --add-label hit Projects(classic) deprecation; retrying via REST for #%s\n' \
             "$_gh_pr_safe_pr" >&2
         gh api -X POST "repos/$_gh_pr_safe_repo/issues/$_gh_pr_safe_pr/labels" \
-            -f "labels[]=$_gh_pr_safe_label" >/dev/null 2>&1
+            -f "labels[]=$_gh_pr_safe_label" >/dev/null
         _gh_pr_safe_rc=$?
     elif [ "$_gh_pr_safe_rc" -ne 0 ]; then
         cat "$_gh_pr_safe_err" >&2
@@ -162,13 +162,12 @@ _pr_edit_safe_body() {
         grep -q 'Projects (classic) is being deprecated' "$_gh_pr_safe_err"; then
         printf '[gh-pr-edit-safe] gh pr edit --body-file hit Projects(classic) deprecation; retrying via REST for #%s\n' \
             "$_gh_pr_safe_pr" >&2
-        # Read the body from the file so we avoid the gh `-F field=@file`
-        # ambiguity (gh treats `@file` only on a few projection fields).
-        _gh_pr_safe_payload=$(cat "$_gh_pr_safe_body_file")
+        # `-f body=@file` reads the file content directly: avoids ARG_MAX on
+        # large bodies and sidesteps the "@" prefix ambiguity that would hit
+        # if the body were expanded into argv as a string starting with @.
         gh api -X PATCH "repos/$_gh_pr_safe_repo/pulls/$_gh_pr_safe_pr" \
-            -f body="$_gh_pr_safe_payload" >/dev/null 2>&1
+            -f body=@"$_gh_pr_safe_body_file" >/dev/null
         _gh_pr_safe_rc=$?
-        unset _gh_pr_safe_payload
     elif [ "$_gh_pr_safe_rc" -ne 0 ]; then
         cat "$_gh_pr_safe_err" >&2
     fi

--- a/tests/bats/functions/gh_pr_edit_safe.bats
+++ b/tests/bats/functions/gh_pr_edit_safe.bats
@@ -1,0 +1,270 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_pr_edit_safe.bats
+# Unit tests for the _pr_edit_safe_label / _pr_edit_safe_body wrappers
+# extracted as a fix for issue #326 (Bug B). The real `gh` binary is
+# never invoked — a fake shim selected by FAKE_GH_MODE drives every
+# code path:
+#
+#   ok                — gh pr edit succeeds, no fallback path taken
+#   classic-deprec    — gh pr edit fails with the Projects(classic)
+#                       deprecation warning on stderr → REST fallback runs
+#   other-failure     — gh pr edit fails with an unrelated error → no
+#                       REST fallback, error is forwarded to caller
+#   resolve-repo      — `gh repo view --json nameWithOwner -q ...` echoes
+#                       owner/repo for the repo-resolution path
+#
+# Network-dependent paths (the actual REST POST/PATCH) are not exercised
+# directly — the fake shim only confirms the helper *picked the right
+# command*, recorded via FAKE_GH_LOG. This matches how
+# gh_project_status.bats covers its mutation helper.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    _setup_fake_gh
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Fake `gh` shim. Selects behavior by FAKE_GH_MODE; every call appends a
+# one-line trace to FAKE_GH_LOG so assertions can inspect what the helper
+# actually invoked.
+# ---------------------------------------------------------------------------
+_setup_fake_gh() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    mkdir -p "$STUB_BIN"
+    : > "$TEST_TEMP_HOME/gh.log"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Trace every invocation regardless of mode for assertion clarity.
+echo "gh $*" >> "${FAKE_GH_LOG:-/dev/null}"
+
+# `gh repo view --json nameWithOwner -q .nameWithOwner` is used by the
+# repo-resolution fallback. Always succeed regardless of FAKE_GH_MODE.
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+    echo "owner/repo"
+    exit 0
+fi
+
+case "${FAKE_GH_MODE:-ok}" in
+    ok)
+        # gh pr edit / gh api both succeed silently.
+        exit 0
+        ;;
+    classic-deprec)
+        if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+            echo "GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience" >&2
+            exit 1
+        fi
+        # gh api retry path succeeds.
+        exit 0
+        ;;
+    classic-deprec-then-rest-fail)
+        if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+            echo "GraphQL: Projects (classic) is being deprecated" >&2
+            exit 1
+        fi
+        if [ "$1" = "api" ]; then
+            echo "REST 500" >&2
+            exit 22
+        fi
+        exit 0
+        ;;
+    other-failure)
+        if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+            echo "HTTP 404: Not Found" >&2
+            exit 1
+        fi
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run a snippet through bash with the fake gh on PATH and dotfiles loaded.
+_run_with_fake_gh() {
+    local mode="$1" snippet="$2"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_GH_MODE='${mode}'
+        export FAKE_GH_LOG='${TEST_TEMP_HOME}/gh.log'
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        ${snippet}
+        echo \"rc=\$?\"
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Loading: helpers available in both bash and zsh after main.* sources them
+# ---------------------------------------------------------------------------
+
+@test "bash: _pr_edit_safe_label helper exists" {
+    run_in_bash 'declare -f _pr_edit_safe_label >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _pr_edit_safe_body helper exists" {
+    run_in_bash 'declare -f _pr_edit_safe_body >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _pr_edit_safe_label helper exists" {
+    run_in_zsh 'typeset -f _pr_edit_safe_label >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _pr_edit_safe_body helper exists" {
+    run_in_zsh 'typeset -f _pr_edit_safe_body >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Arg validation — must return early before touching gh
+# ---------------------------------------------------------------------------
+
+@test "label: missing args prints usage and returns 2" {
+    run_in_bash '_pr_edit_safe_label 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "usage: _pr_edit_safe_label"
+    assert_output --partial "rc=2"
+}
+
+@test "label: missing label arg returns 2 without calling gh" {
+    _run_with_fake_gh ok '_pr_edit_safe_label 99'
+    assert_output --partial "usage: _pr_edit_safe_label"
+    assert_output --partial "rc=2"
+    refute [ -s "$TEST_TEMP_HOME/gh.log" ]
+}
+
+@test "body: missing args prints usage and returns 2" {
+    run_in_bash '_pr_edit_safe_body 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "usage: _pr_edit_safe_body"
+    assert_output --partial "rc=2"
+}
+
+@test "body: unreadable body file rejected before any gh call" {
+    _run_with_fake_gh ok '_pr_edit_safe_body 99 /nonexistent/file --repo owner/repo'
+    assert_output --partial "body file not readable"
+    assert_output --partial "rc=2"
+    refute [ -s "$TEST_TEMP_HOME/gh.log" ]
+}
+
+@test "label: --repo without value returns 2" {
+    _run_with_fake_gh ok '_pr_edit_safe_label 99 enhancement --repo'
+    assert_output --partial "--repo requires an argument"
+    assert_output --partial "rc=2"
+}
+
+# ---------------------------------------------------------------------------
+# Happy path — gh pr edit succeeds, no REST fallback
+# ---------------------------------------------------------------------------
+
+@test "label: success path calls only gh pr edit, no REST" {
+    _run_with_fake_gh ok '_pr_edit_safe_label 99 enhancement --repo owner/repo'
+    assert_output --partial "rc=0"
+    run bash -c "grep -c 'gh pr edit' '$TEST_TEMP_HOME/gh.log' || true"
+    assert_output "1"
+    run bash -c "grep -c 'gh api -X' '$TEST_TEMP_HOME/gh.log' || true"
+    assert_output "0"
+}
+
+@test "body: success path calls only gh pr edit, no REST" {
+    body_file="$TEST_TEMP_HOME/body.md"
+    echo "## Hello" > "$body_file"
+    _run_with_fake_gh ok "_pr_edit_safe_body 99 '$body_file' --repo owner/repo"
+    assert_output --partial "rc=0"
+    run bash -c "grep -c 'gh pr edit' '$TEST_TEMP_HOME/gh.log' || true"
+    assert_output "1"
+    run bash -c "grep -c 'gh api -X' '$TEST_TEMP_HOME/gh.log' || true"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# Bug B regression — Projects(classic) deprecation triggers REST fallback
+# ---------------------------------------------------------------------------
+
+@test "label: classic-deprecation triggers REST fallback (#326 Bug B)" {
+    _run_with_fake_gh classic-deprec '_pr_edit_safe_label 99 enhancement --repo owner/repo'
+    assert_output --partial "Projects(classic) deprecation"
+    assert_output --partial "rc=0"
+    # Confirm both paths were tried in order: gh pr edit first, gh api second.
+    run grep -c "gh pr edit" "$TEST_TEMP_HOME/gh.log"
+    assert_success
+    assert_output "1"
+    run grep -E "gh api -X POST repos/owner/repo/issues/99/labels" "$TEST_TEMP_HOME/gh.log"
+    assert_success
+}
+
+@test "body: classic-deprecation triggers REST fallback" {
+    body_file="$TEST_TEMP_HOME/body.md"
+    echo "Updated body content" > "$body_file"
+    _run_with_fake_gh classic-deprec "_pr_edit_safe_body 99 '$body_file' --repo owner/repo"
+    assert_output --partial "Projects(classic) deprecation"
+    assert_output --partial "rc=0"
+    run grep -E "gh api -X PATCH repos/owner/repo/pulls/99" "$TEST_TEMP_HOME/gh.log"
+    assert_success
+}
+
+@test "label: REST fallback failure surfaces as non-zero rc" {
+    _run_with_fake_gh classic-deprec-then-rest-fail '_pr_edit_safe_label 99 enhancement --repo owner/repo'
+    refute_output --partial "rc=0"
+    assert_output --partial "Projects(classic) deprecation"
+}
+
+# ---------------------------------------------------------------------------
+# Non-deprecation failures must NOT trigger REST fallback
+# ---------------------------------------------------------------------------
+
+@test "label: unrelated gh failure forwards stderr and skips REST" {
+    _run_with_fake_gh other-failure '_pr_edit_safe_label 99 enhancement --repo owner/repo'
+    assert_output --partial "HTTP 404"
+    refute_output --partial "Projects(classic) deprecation"
+    refute_output --partial "rc=0"
+    run bash -c "grep -c 'gh api -X' '$TEST_TEMP_HOME/gh.log' || true"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# Repo resolution: --repo > $GH_REPO > gh repo view
+# ---------------------------------------------------------------------------
+
+@test "label: --repo flag wins over GH_REPO env" {
+    _run_with_fake_gh ok 'GH_REPO=other/wrong _pr_edit_safe_label 99 enhancement --repo owner/repo'
+    assert_output --partial "rc=0"
+    run grep -E "gh pr edit 99 --repo owner/repo --add-label enhancement" "$TEST_TEMP_HOME/gh.log"
+    assert_success
+}
+
+@test "label: GH_REPO env used when --repo absent" {
+    _run_with_fake_gh ok 'GH_REPO=env/repo _pr_edit_safe_label 99 enhancement'
+    assert_output --partial "rc=0"
+    run grep -E "gh pr edit 99 --repo env/repo --add-label enhancement" "$TEST_TEMP_HOME/gh.log"
+    assert_success
+}
+
+@test "label: falls back to gh repo view when neither --repo nor GH_REPO set" {
+    _run_with_fake_gh ok 'unset GH_REPO; _pr_edit_safe_label 99 enhancement'
+    assert_output --partial "rc=0"
+    # Helper called `gh repo view ...` to resolve the repo.
+    run grep -E "gh repo view" "$TEST_TEMP_HOME/gh.log"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- Bug A: gh:pr Step 4 의 토큰 산정 입력을 코드에 박제 — `compute_pr_tokens(issue_body, commit_log)` 헬퍼로 PR #325 회귀(1000 vs 7000) 재발 방지.
- Bug B: classic Projects attached 레포에서 `gh pr edit --add-label / --body-file` 가 GraphQL deprecation 으로 silent exit 1 하는 케이스를 REST API 로 fallback 하는 `_pr_edit_safe_label / _pr_edit_safe_body` wrapper 도입.

## Changes
- `claude/skills/gh-pr/references/token-compute.sh` (신규): `compute_pr_tokens` POSIX-sh 함수. 자연어 명세를 호출 한 줄로 압축, PR #325 회귀 데이터(26045 + 1032 chars → 7000) 그대로 통과. 헤더 주석에 RCA 와 호출 컨벤션 명시.
- `claude/skills/gh-pr/SKILL.md` Step 4: `compute_pr_tokens "$ISSUE_BODY" "$COMMIT_LOG"` 호출로 변경. `$BODY` (PR body 임시 파일) 사용 금지를 인라인으로 박제.
- `shell-common/functions/gh_pr_edit_safe.sh` (신규): `_pr_edit_safe_label / _pr_edit_safe_body` + 내부 `_pr_edit_safe_resolve_repo / _pr_edit_safe_parse_repo`. `gh pr edit` 1차 → stderr 에 "Projects (classic) is being deprecated" 가 잡힐 때만 REST 재시도, 다른 실패는 그대로 forward. `--repo` flag → `$GH_REPO` env → `gh repo view` 순으로 owner/repo 해석.
- `claude/skills/gh-pr/references/pr-body-template.md`: safe-apply 루프가 wrapper 사용. POST /labels 가 미존재 라벨을 자동 생성한다는 점을 caller pre-filter 의무로 양쪽(wrapper 헤더 + 본 문서)에 명시.
- `claude/skills/gh-pr-reply/SKILL.md`, `claude/skills/gh-issue-flow/SKILL.md` Constraints: 향후 PR mutation 추가 시 wrapper 경유하라는 forward-looking 안내.
- `tests/bats/functions/gh_pr_edit_safe.bats` (신규): 18 케이스 — loading(bash/zsh × 2), arg validation, classic-deprecation REST fallback, 다른 실패 forwarding, repo 해석 우선순위(`--repo` > `GH_REPO` > `gh repo view`).

## Test plan
- [x] `tests/bats/functions/gh_pr_edit_safe.bats` 18/18 통과 (fake gh shim 기반).
- [x] 전체 bats 365/365 통과 — 회귀 0.
- [x] `shellcheck -x -e SC1090,SC1091` 신규 두 파일 모두 clean.
- [x] `shfmt -i 4` 신규 두 파일 적용.
- [x] `compute_pr_tokens` PR #325 회귀 데이터(issue 26045 + log 1032) → 7000 직접 검증.
- [ ] 후속: 이번 PR 자체의 footer 토큰값이 helper-computed 2000 으로 박혀 들어가는지 머지 후 확인 (회귀 case 가 즉시 재현되는지가 fix 의 1차 시그널).

## Related
Closes #326

---
<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->
