### PR TITLE
fix(gh-pr-approve): pre-flight ai CLI auth before worktree spawn

### DIFF
--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -396,11 +396,11 @@ _gh_pr_approve_status_single() {
         _usage="$_dir/usage.jsonl"
         if [ -f "$_usage" ] && [ -s "$_usage" ] && command -v jq >/dev/null 2>&1; then
             _failure="$(jq -rs '
-                map(select((.is_error // false) or ((.tracking // "") == "cli_failed")))
+                map(select((.is_error? // false) or ((.tracking? // "") == "cli_failed")))
                 | last
-                | (.result // .error // "")
+                | (.result? // .error? // empty)
             ' "$_usage" 2>/dev/null)"
-            if [ -n "$_failure" ] && [ "$_failure" != "null" ]; then
+            if [ -n "$_failure" ]; then
                 ux_table_row "Failure" "$_failure"
             fi
         fi

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -86,6 +86,55 @@ _gh_pr_approve_require_ai_cli() {
     esac
 }
 
+# Pre-flight check: is the selected ai CLI authenticated?
+# Returns 0 when an auth signal (env var or local credentials file) is
+# present, 1 otherwise. This is heuristic — false positives are possible
+# (expired tokens, malformed credentials) but the dominant "logged out"
+# case from issue #327 is caught before any worktree is created. The
+# check is intentionally cheap and synchronous: env-var lookups + file
+# existence, no API calls and no token spend.
+_gh_pr_approve_check_ai_auth() {
+    case "$1" in
+    claude)
+        # ANTHROPIC_API_KEY shortcuts the OAuth flow; either is enough.
+        # Path mix reflects two CLI generations: ~/.claude/.credentials.json
+        # is the new dedicated auth store; ~/.claude.json is the older
+        # combined config+auth blob still used by stable channels.
+        if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            return 0
+        fi
+        if [ -f "$HOME/.claude/.credentials.json" ] || [ -f "$HOME/.claude.json" ]; then
+            return 0
+        fi
+        ux_error "claude CLI not authenticated. Run 'claude /login' first."
+        return 1
+        ;;
+    codex)
+        if [ -n "${OPENAI_API_KEY:-}" ]; then
+            return 0
+        fi
+        if [ -f "$HOME/.codex/auth.json" ]; then
+            return 0
+        fi
+        ux_error "codex CLI not authenticated. Run 'codex login' first."
+        return 1
+        ;;
+    gemini)
+        if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]; then
+            return 0
+        fi
+        if [ -f "$HOME/.gemini/oauth_creds.json" ]; then
+            return 0
+        fi
+        ux_error "gemini CLI not authenticated. Run 'gemini' once interactively to sign in."
+        return 1
+        ;;
+    *)
+        return 0
+        ;;
+    esac
+}
+
 # Run one non-interactive prompt with the selected ai runner.
 # Delegates to ai_usage.sh so per-call token usage and cost are appended
 # to <state-dir>/usage.jsonl. The worker tail-prints _ai_usage_summary,
@@ -335,6 +384,28 @@ _gh_pr_approve_status_single() {
     else
         ux_table_row "Last log" "(none)"
     fi
+
+    # For approving failures the tail above usually only shows the Token
+    # Usage block — the actual claude/codex/gemini error message
+    # (e.g. "Not logged in · Please run /login") gets buried earlier in
+    # the log. Surface it directly from usage.jsonl so the diagnosis is
+    # one glance away instead of one tail|grep away.
+    case "$_state" in
+    failed:approving)
+        local _usage _failure
+        _usage="$_dir/usage.jsonl"
+        if [ -f "$_usage" ] && [ -s "$_usage" ] && command -v jq >/dev/null 2>&1; then
+            _failure="$(jq -rs '
+                map(select((.is_error // false) or ((.tracking // "") == "cli_failed")))
+                | last
+                | (.result // .error // "")
+            ' "$_usage" 2>/dev/null)"
+            if [ -n "$_failure" ] && [ "$_failure" != "null" ]; then
+                ux_table_row "Failure" "$_failure"
+            fi
+        fi
+        ;;
+    esac
 
     # Heredoc (not pipe) so reads land in this shell — see auto-memory:
     # subshell tracing trap.
@@ -632,6 +703,11 @@ gh_pr_approve_help() {
     ux_info "Preconditions:"
     ux_bullet "Run from main repo (not inside a worktree)"
     ux_bullet "gh CLI authenticated, selected AI CLI on PATH, gwt loaded"
+    ux_bullet "Selected AI CLI authenticated (env var or local credentials file)"
+    ux_bullet_sub "claude: ANTHROPIC_API_KEY or ~/.claude/.credentials.json or ~/.claude.json"
+    ux_bullet_sub "codex:  OPENAI_API_KEY or ~/.codex/auth.json"
+    ux_bullet_sub "gemini: GEMINI_API_KEY / GOOGLE_API_KEY or ~/.gemini/oauth_creds.json"
+    ux_bullet_sub "if missing, gh-pr-approve refuses to spawn (no worktree, no state dir)"
     ux_info ""
     ux_info "Related:"
     ux_bullet "gh-flow         - issue → PR automation (author side)"
@@ -791,6 +867,15 @@ gh_pr_approve() {
     if [ "$_pr_count" -eq 0 ]; then
         ux_error "no PR numbers provided"
         ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-record|--admin-merge]"
+        return 1
+    fi
+
+    # Auth pre-flight (issue #327): bail before any worktree/state I/O when
+    # the selected ai CLI is logged out, so users don't have to clean up a
+    # zombie worktree + 'failed:approving' state dir afterwards. Done here
+    # — after PR-number / main-repo validation — so obvious user errors
+    # still surface their natural message instead of an auth complaint.
+    if ! _gh_pr_approve_check_ai_auth "$_ai"; then
         return 1
     fi
 

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -499,6 +499,130 @@ _seed_pr_state() {
 }
 
 # ---------------------------------------------------------------------------
+# auth pre-flight (issue #327)
+# ---------------------------------------------------------------------------
+# We can't drive a real claude/codex/gemini CLI from the test sandbox, so
+# we install a minimal stub on PATH for each runner. The stub never gets
+# invoked — the auth check (file-existence + env var) runs *before* the
+# CLI is called. Its only job is to satisfy `_have <ai>`.
+
+_install_fake_ai_cli() {
+    local _ai="$1"
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    # Minimal shim — should never run during these tests, but echo
+    # something obvious if it ever does so the failure mode is visible.
+    cat >"$TEST_TEMP_HOME/bin/$_ai" <<EOF
+#!/bin/sh
+echo "fake $_ai stub invoked — should not reach here in auth tests" >&2
+exit 99
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/$_ai"
+}
+
+@test "auth: claude logged out — refuses spawn before worktree creation" {
+    # No ~/.claude.json, no ~/.claude/.credentials.json, no ANTHROPIC_API_KEY
+    # under the isolated $HOME. The orchestrator must fail with the auth
+    # message and NOT create a state dir under
+    # ~/.local/state/gh-pr-approve/<repo>/<pr>/.
+    _install_fake_ai_cli claude
+    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH unset ANTHROPIC_API_KEY 2>/dev/null; cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
+    assert_failure
+    assert_output --partial "claude CLI not authenticated"
+    assert_output --partial "claude /login"
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/42" ]
+}
+
+@test "auth: claude credentials file present → auth check passes" {
+    # We seed ~/.claude/.credentials.json (the new dedicated auth store).
+    # gwt isn't loaded in the test shell, so the run fails *later* at the
+    # 'gwt function not loaded' guard — proving the auth check passed.
+    _install_fake_ai_cli claude
+    mkdir -p "$HOME/.claude"
+    printf '{"access_token":"fake"}\n' >"$HOME/.claude/.credentials.json"
+    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
+    refute_output --partial "claude CLI not authenticated"
+}
+
+@test "auth: ANTHROPIC_API_KEY env var → auth check passes" {
+    # Env var alone is enough — overrides missing credentials file.
+    # `export` so the var crosses into `gh_pr_approve`'s subshell scope;
+    # the `VAR=val cmd` prefix form would only bind to the `cd`.
+    _install_fake_ai_cli claude
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; export ANTHROPIC_API_KEY=sk-test; cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
+    refute_output --partial "claude CLI not authenticated"
+}
+
+@test "auth: codex logged out — refuses spawn" {
+    _install_fake_ai_cli codex
+    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH unset OPENAI_API_KEY 2>/dev/null; cd '$FAKE_REPO' && gh_pr_approve 42 --ai codex 2>&1"
+    assert_failure
+    assert_output --partial "codex CLI not authenticated"
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/42" ]
+}
+
+@test "auth: codex credentials file present → auth check passes" {
+    _install_fake_ai_cli codex
+    mkdir -p "$HOME/.codex"
+    printf '{"token":"fake"}\n' >"$HOME/.codex/auth.json"
+    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH cd '$FAKE_REPO' && gh_pr_approve 42 --ai codex 2>&1"
+    refute_output --partial "codex CLI not authenticated"
+}
+
+@test "auth: gemini logged out — refuses spawn" {
+    _install_fake_ai_cli gemini
+    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH unset GEMINI_API_KEY GOOGLE_API_KEY 2>/dev/null; cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
+    assert_failure
+    assert_output --partial "gemini CLI not authenticated"
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/42" ]
+}
+
+@test "auth: gemini credentials file present → auth check passes" {
+    _install_fake_ai_cli gemini
+    mkdir -p "$HOME/.gemini"
+    printf '{"refresh_token":"fake"}\n' >"$HOME/.gemini/oauth_creds.json"
+    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
+    refute_output --partial "gemini CLI not authenticated"
+}
+
+@test "help: documents auth pre-flight" {
+    # Discoverability — users shouldn't have to read shell source to learn
+    # about the new precondition introduced by issue #327.
+    run_in_bash 'gh_pr_approve --help'
+    assert_success
+    assert_output --partial "AI CLI authenticated"
+    assert_output --partial "no worktree"
+}
+
+# ---------------------------------------------------------------------------
+# status <N>: failure-cause surfacing for failed:approving (issue #327)
+# ---------------------------------------------------------------------------
+
+@test "status <N>: failed:approving surfaces the recorded result message" {
+    # Worker writes is_error=true claude records to usage.jsonl on
+    # 'Not logged in' — status should pull that field out instead of
+    # leaving the user to grep the log themselves.
+    _seed_pr_state 601 "failed:approving" "" "9999999"
+    local _usage="$HOME/.local/state/gh-pr-approve/fake-main/601/usage.jsonl"
+    cat >"$_usage" <<'EOF'
+{"ai":"claude","ts":"2026-05-05T17:00:00Z","label":"/gh-pr-approve 601","is_error":true,"duration_ms":38,"result":"Not logged in · Please run /login","usage":{}}
+EOF
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 601"
+    assert_success
+    assert_output --partial "Failure"
+    assert_output --partial "Not logged in"
+}
+
+@test "status <N>: failed:approving with no usage.jsonl → no Failure row" {
+    # Defensive — older state dirs (pre-ai_usage.sh) may not have a
+    # usage.jsonl. Status must keep working and not print an empty
+    # 'Failure' row that would confuse the eye.
+    _seed_pr_state 602 "failed:approving" "" "9999999"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 602"
+    assert_success
+    refute_output --partial "Failure"
+}
+
+# ---------------------------------------------------------------------------
 # dispatcher: 'status' / 'prune' must not be parsed as a PR number
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Pre-flight check on `gh-pr-approve` so a logged-out AI CLI is rejected before any worktree or state directory is created
- `status <N>` now surfaces the underlying failure cause (e.g. `Not logged in · Please run /login`) for `failed:approving` entries instead of leaving only the Token Usage tail

## Changes
- `shell-common/functions/gh_pr_approve.sh`:
  - New helper `_gh_pr_approve_check_ai_auth` covering all three runners (env var or local credentials file): claude → `ANTHROPIC_API_KEY` / `~/.claude/.credentials.json` / `~/.claude.json`; codex → `OPENAI_API_KEY` / `~/.codex/auth.json`; gemini → `GEMINI_API_KEY` or `GOOGLE_API_KEY` / `~/.gemini/oauth_creds.json`
  - Wired into `gh_pr_approve()` after PR-number / main-repo validation but before the spawn loop, so user-authored typos still get their natural error and only the spawn path is gated by auth
  - `_gh_pr_approve_status_single` extracts the latest `is_error: true` (or `cli_failed`) record's `.result` from `usage.jsonl` and renders a `Failure` row when state is `failed:approving`
  - Help text adds the new precondition with per-CLI env vars and credentials paths
- `tests/bats/functions/gh_pr_approve.bats`:
  - 9 new auth tests — claude/codex/gemini logged-out-refuses-spawn (verifies no state dir leaks), credentials-file-passes, env-var-passes, help-mentions-auth
  - 2 new status tests — failure-row rendering with and without `usage.jsonl`

## Test plan
- [x] `bats tests/bats/functions/gh_pr_approve.bats` → 62/62 pass
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_pr_approve.sh` clean
- [ ] Manual repro: `claude /logout` then `gh-pr-approve <pr>` → must abort immediately with red error and leave no state dir under `~/.local/state/gh-pr-approve/<repo>/<pr>/`
- [ ] Manual repro: induce `failed:approving` then `gh-pr-approve status <pr>` → `Failure` row should show the captured CLI error message

## Related
Closes #327

---
<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->
