### PR TITLE
docs(skills): point at gh_pr_edit_safe wrapper in pr-reply / issue-flow

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -131,7 +131,12 @@ Resume hint logic:
 - Never skip a step. All 3 or stop.
 - Never mutate state between steps beyond what the sub-skills do.
   Exception: Step 2.4 may edit the PR body after Step 2.3 — this is
-  intentional and must soft-fail (never block the flow).
+  intentional and must soft-fail (never block the flow). If a future
+  variant of Step 2.4 needs to mutate PR labels or body, route through
+  `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
+  (`shell-common/functions/gh_pr_edit_safe.sh`); plain `gh pr edit
+  --add-label` / `--body-file` silently exits 1 on repos with classic
+  Projects attached (issue #326 Bug B).
 - Do NOT preface or summarize beyond the compact report.
 - Do NOT end the turn until the Step 3 report is issued (success or
   failure template). A `Next:` / resume-hint from a sub-skill

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -99,3 +99,8 @@ On failure: `⚠️  ai-metrics comment failed — continuing.`
 - Never dismiss bot comments as "just a bot".
 - Never fix files outside the PR's diff without flagging scope creep first.
 - Never `--force-push`. If history rewrite is needed, stop and ask.
+- If a future fix flow needs to mutate PR labels or body, route through
+  `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
+  (`shell-common/functions/gh_pr_edit_safe.sh`). Bare `gh pr edit
+  --add-label` / `--body-file` silently exits 1 on repos with classic
+  Projects attached (issue #326 Bug B).


### PR DESCRIPTION
## Summary
- `gh-pr-reply` 와 `gh-issue-flow` SKILL.md Constraints 에 `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body` 사용 안내 (각 5줄) 추가.
- 현재 두 스킬에 wrapper 가 필요한 call site 는 없음 — 향후 `gh pr edit --add-label` / `--body-file` 추가 시 #326 Bug B (classic Projects GraphQL deprecation silent exit 1) 트랩에 빠지는 것을 막기 위한 preventive note.

## Background
원래 [PR #329](https://github.com/dEitY719/dotfiles/pull/329) 에 포함되어 있던 두 노트입니다. #329 가 PR #328 과 동일 이슈(#326)·동일 스코프 중복으로 close 되면서, **#328 이 커버하지 않는 유일한 unique material** 인 이 두 노트를 별도 follow-up 으로 분리했습니다. 함수명도 #328 의 머지된 네이밍 `_gh_pr_edit_safe_*` (with `_gh_` prefix) 에 맞춰 통일.

## Changes
- `claude/skills/gh-pr-reply/SKILL.md` Constraints (마지막 항목 추가): wrapper 사용 안내.
- `claude/skills/gh-issue-flow/SKILL.md` Constraints (Step 2.4 exception 항목 확장): wrapper 사용 안내.

## Test plan
- [x] git pre-commit 훅 통과 (validation passes).
- [x] `git diff origin/main` 검토 — 정확히 두 파일에 5줄씩 추가만 있고 코드 경로 변화 없음.
- [ ] (선택) 머지 후 어느 한 스킬의 향후 `gh pr edit` 호출 시 Constraints 가 보이는지 확인.

## Related
Refs #326

---
<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~0.5 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->
