### PR TITLE
docs(skills): warn about outer-shell cwd in ai-worktree:teardown

### DIFF
--- a/claude/skills/ai-worktree-teardown/SKILL.md
+++ b/claude/skills/ai-worktree-teardown/SKILL.md
@@ -72,4 +72,14 @@ Append `TEARDOWN` entry to `ai-worktree-spawn.log` (same file as spawn).
   Removed:  ../my-app-gemini-1
   Branch:   wt/gemini/1 (deleted)
   Now on:   main (up to date with origin/main)
+
+  Note: if your outer shell (the one that launched claude) was cd'd
+  inside the removed worktree, run `cd <main-repo>` there now —
+  otherwise its next prompt will spew `getcwd: cannot access parent
+  directories` errors from zsh/pyenv/p10k.
 ```
+
+Always include the `Note:` block — the skill cannot detect the outer
+shell's cwd, so the hint is unconditional. Substitute `<main-repo>`
+with the absolute path of the main repo this skill is running from
+(`git rev-parse --show-toplevel`).


### PR DESCRIPTION
## Summary
- After `/exit` from a claude session that ran `ai-worktree:teardown` on its own worktree, the user's outer shell — still cd'd inside the now-deleted worktree — hits a `getcwd()` cascade (zsh + pyenv + p10k) on the next prompt render.
- The skill enforces "must run from the main repo" so claude's own shell is safe; the breakage lives purely in the user's outer shell, which the skill cannot detect from inside.
- Add an unconditional `Note:` block to the Step 8 report template instructing the user to `cd <main-repo>` in the outer shell, with `<main-repo>` resolved via `git rev-parse --show-toplevel`.

## Changes
- `claude/skills/ai-worktree-teardown/SKILL.md`: extend the Step 8 report block with the cwd hint, plus a meta-instruction line below the fence explaining why the hint is unconditional and how to substitute `<main-repo>`.

## Test plan
- [ ] Spawn a worktree, `cd` into it from a host shell, launch claude, run `/ai-worktree:teardown`, exit claude — confirm the host shell's prompt no longer cascades `getcwd: cannot access parent directories` from zsh / pyenv / p10k.
- [ ] Verify the Step 8 report renders the new `Note:` block cleanly on a normal teardown (no broken markdown / fence).

---
<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->
