### PR TITLE
fix(gh-issue-flow): pass --no-next-hint to stop early-stop

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -15,6 +15,25 @@ allowed-tools: Bash, Read, Grep
 
 # gh:issue-flow — Issue → PR composition
 
+## ⚠️ CRITICAL CONTRACT — read before editing
+
+**Recurring failure mode: early-stop after Step 2.1.** When `gh:issue-implement`
+emits its `Next: /gh-commit && /gh-pr <N>` success hint, the model treats it
+as a final answer and ends the turn — leaving the user to manually re-trigger
+`gh:commit` and `gh:pr`. Reported by users as "100번 실행하면 50번은 stop"
+(half of all runs stop early). See issue #333 for history.
+
+**The mechanical guard is `--no-next-hint`** on the Step 2.1 invocation
+(`gh:issue-implement` already supports the flag and suppresses its trailing
+`Next:` line when set). With the trip-wire gone, the model sees a plain
+success report and proceeds naturally to Step 2.2. **Do not drop this flag.**
+If you edit Step 2 in any way, re-verify `--no-next-hint` is still present.
+
+**Zero conversational text between the three `Skill()` calls in Step 2.**
+No recap, no "now committing", no markdown headers, no progress bullets —
+those tokens read as a turn-ending summary and re-introduce the early-stop.
+The only text allowed in Step 2 is the final Step 3 report.
+
 ## Help
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
@@ -39,9 +58,13 @@ if the previous completed successfully.
 
 1. **Step 2.1 — gh:issue-implement**
    ```
-   Skill(gh:issue-implement, "<N> direct <remote>")
+   Skill(gh:issue-implement, "<N> direct <remote> --no-next-hint")
    ```
-   Track success = skill returned its success report (not failure).
+   `--no-next-hint` is **load-bearing** — it suppresses the trailing
+   `Next:` hint that would otherwise read as a turn-ending answer
+   (see CRITICAL CONTRACT above). Track success = skill returned its
+   success report (not failure). **Now invoke Step 2.2 — no recap,
+   no summary, no header.**
 
 2. **Step 2.2 — gh:commit** (only if 2.1 succeeded)
    ```
@@ -49,7 +72,8 @@ if the previous completed successfully.
    ```
    gh:commit auto-detects the issue number from the conversation
    (the `#<N>` was just mentioned by Step 2.1's report), so no
-   explicit args needed.
+   explicit args needed. **Now invoke Step 2.3 — no recap, no
+   summary, no header.**
 
 3. **Step 2.3 — gh:pr** (only if 2.2 succeeded)
    ```
@@ -144,3 +168,12 @@ Resume hint logic:
   a waypoint during this composition, not a final answer — keep
   going. Don't let a success hint from 2.1 or 2.2 end the flow
   before Step 3.
+- **Never drop `--no-next-hint` from the Step 2.1 invocation.** It is
+  the mechanical guard against the early-stop failure mode documented
+  in the CRITICAL CONTRACT section. If a refactor of Step 2 looks
+  cleaner without it, the refactor is wrong.
+- **Zero conversational text between Skill() calls in Step 2.** No
+  recap ("Step 2.1 complete, now committing..."), no progress
+  markdown headers, no per-step bullet summaries. Such text reads as
+  a turn-ending answer and re-introduces the early-stop. The only
+  prose allowed inside Step 2 is the final Step 3 report.


### PR DESCRIPTION
## Summary
- `gh:issue-flow`가 Step 2.1(`gh:issue-implement`) 직후 약 50% 빈도로 턴을 종료해 사용자가 `/gh-commit`/`/gh-pr`을 다시 입력해야 했던 early-stop 회귀를 차단합니다.
- Step 2.1 호출에 `--no-next-hint`를 추가해 trip-wire 역할을 하던 `Next:` 라인을 원천 차단하고, 동시에 향후 리팩터에서 이 가드가 사라지지 않도록 SKILL.md 상단에 `⚠️ CRITICAL CONTRACT` 섹션을 둡니다.
- Constraints에 두 줄을 추가해 (a) `--no-next-hint` 제거 금지, (b) Step 2의 `Skill()` 호출 사이에 일체의 회고/요약/헤더 텍스트를 넣지 말 것을 명시합니다.

## Changes
- `claude/skills/gh-issue-flow/SKILL.md`
  - Step 2.1: `Skill(gh:issue-implement, "<N> direct <remote>")` → `Skill(gh:issue-implement, "<N> direct <remote> --no-next-hint")` (load-bearing 가드).
  - 상단 신규 섹션 `⚠️ CRITICAL CONTRACT — read before editing`: 재발 실패 모드(이름 명시), `--no-next-hint`의 역할, Step 2 내부 텍스트 금지 원칙을 한 번에 못 박음.
  - Step 2.1·Step 2.2 본문 끝에 인라인 리마인더 추가(`Now invoke Step 2.x — no recap, no summary, no header.`).
  - Constraints 두 항목 추가: `--no-next-hint` 제거 금지, Step 2 내부 대화형 텍스트 금지.

## Test plan
- [ ] `/gh-issue-flow <N>`을 작은 이슈에 실행해 한 턴 내에 implement → commit → pr 세 단계가 모두 발화되는지 확인 (수동 `/gh-commit` 개입 없음).
- [ ] `claude/skills/gh-issue-flow/SKILL.md`에 `--no-next-hint`가 5회(상단 컨트랙트 2회 + Step 2.1 호출 1회 + Step 2.1 본문 1회 + Constraints 1회) 등장하는지 grep으로 확인.
- [ ] markdownlint claude/skills/gh-issue-flow/SKILL.md → 0 issues.

## Related
Closes #333

---
<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->
