### PR TITLE
feat(gh-add-ai-metrics): date ranges + pacing flags (#336 #337 #338)

### DIFF
--- a/claude/skills/gh-add-ai-metrics/SKILL.md
+++ b/claude/skills/gh-add-ai-metrics/SKILL.md
@@ -92,8 +92,11 @@ classification rows and the dry-run summary line, **never calling
 
 Otherwise, for each `(type, N)` follow `references/footer-detection.md`:
 
-1. **Stop check (top of iteration)** — before fetching this card:
-   - `check_budget "$elapsed" "$BUDGET_SECS"` true → break with
+1. **Stop check (top of iteration)** — before fetching this card.
+   Compute `elapsed_secs=$(( $(date +%s) - START_TS ))` here (seconds,
+   matching `check_budget`'s contract — Step 4's `ELAPSED` is a separate
+   minutes-rounded display value, do not reuse it):
+   - `check_budget "$elapsed_secs" "$BUDGET_SECS"` true → break with
      `stop_reason="--budget"`. (Skipped when `--budget` not set.)
    - `--limit` set and `modified_count >= LIMIT` → break with
      `stop_reason="--limit"`.

--- a/claude/skills/gh-add-ai-metrics/SKILL.md
+++ b/claude/skills/gh-add-ai-metrics/SKILL.md
@@ -30,9 +30,26 @@ output its content verbatim, then stop. No API calls.
 Record `START_TS=$(date +%s)` immediately for the final summary line.
 
 Parse args per the table in `references/help.md` — positional `issue#N` /
-`pr#M` (case-insensitive), flags `--type`, `--date`, `--force`, `--remote`.
-`--date` accepts either `YYYY-MM-DD` (10 chars, used as-is) or `YY-MM-DD`
-(8 chars, expanded to `20YY-MM-DD`); other lengths → format error and stop.
+`pr#M` (case-insensitive), flags `--type`, `--date`, `--force`, `--remote`,
+plus the pacing flags `--pace`, `--limit`, `--budget`, `--dry-run`.
+
+`--date` accepts four shapes — single day, whole month, or half-open range —
+parsed by `parse_date_arg` in `references/date-parsing.md`:
+
+| Length / shape          | Form                | Meaning                          |
+|-------------------------|---------------------|----------------------------------|
+| 5 chars `YY-MM`         | month               | whole month, 1st through last day |
+| 7 chars `YYYY-MM`       | month               | same                             |
+| 8 chars `YY-MM-DD`      | single              | one day (existing)               |
+| 10 chars `YYYY-MM-DD`   | single              | one day (existing)               |
+| contains `..` or `~`    | range `[start, end)` | end-day excluded; `~` normalized to `..` |
+
+Other inputs → format error and stop.
+
+`--pace`, `--budget` accept duration strings (`30s` / `5m` / `1h` / `1h30m`)
+parsed by `parse_duration` in `references/pace-control.md`. `--limit` takes
+a positive integer. `--dry-run` is a boolean flag.
+
 Resolve `TARGET_REPO` via the shared flow in
 `gh-issue-create/references/repo-resolution.md`. Missing remote → list
 `git remote -v` and stop (no silent fallback). `--date` + positional
@@ -44,8 +61,13 @@ cards is a hard error: print
 First match wins:
 
 1. `--date` present → **date-filter mode**.
-   Run `gh issue list` and/or `gh pr list` (filtered by `--type` if given)
-   with `--search "created:<DATE>" --state all --limit 200 --json number,title`.
+   Feed the value through `parse_date_arg` → three-token output
+   (`single|month|range <a> [<b>]`) → `build_search_clause` → the
+   `created:...` fragment for the GitHub query. Then run `gh issue list`
+   and/or `gh pr list` (filtered by `--type` if given) with
+   `--search "<clause>" --state all --limit 200 --json number,title`.
+   The `--limit 200` cap stays — for month/range queries that would exceed
+   it the user must narrow the date or split into sub-ranges.
 2. Positional cards present → **explicit-list mode**. Parse, validate
    each `N` as a positive integer, dedupe, preserve order.
 3. Otherwise → **conversation-infer mode**. Scan recent chat turns for
@@ -55,23 +77,40 @@ First match wins:
    and stop.
 
 If `|targets| > 100`, print the count and prompt
-`Continue with N cards? [y/N]:`. Default no → stop.
+`Continue with N cards? [y/N]:`. Default no → stop. `--limit <N>` does
+**not** suppress this prompt — the prompt protects against accidentally
+huge target lists (e.g. a typo'd month range), independent of how many
+the loop will actually modify.
 
 ## Step 3: Per-Card Loop
 
-For each `(type, N)` follow `references/footer-detection.md`:
+If `--dry-run` was passed, take the dry-run branch in
+`references/pace-control.md` → "`--dry-run` branch" — same per-card view
+fetch, but emits `· will-write` / `· will-skip` / `· will-force-replace`
+classification rows and the dry-run summary line, **never calling
+`gh edit`**. Then stop.
 
-1. `gh {issue,pr} view N --repo "$TARGET_REPO" --json title,body` → fetch.
-2. Detect `<!-- ai-metrics -->` (also matches `<!-- ai-metrics:<skill> -->`).
-3. Branch:
+Otherwise, for each `(type, N)` follow `references/footer-detection.md`:
+
+1. **Stop check (top of iteration)** — before fetching this card:
+   - `check_budget "$elapsed" "$BUDGET_SECS"` true → break with
+     `stop_reason="--budget"`. (Skipped when `--budget` not set.)
+   - `--limit` set and `modified_count >= LIMIT` → break with
+     `stop_reason="--limit"`.
+   See `references/pace-control.md` → "Stop-reason composition".
+2. `gh {issue,pr} view N --repo "$TARGET_REPO" --json title,body` → fetch.
+3. Detect `<!-- ai-metrics -->` (also matches `<!-- ai-metrics:<skill> -->`).
+4. Branch:
    - **No footer** → compute metrics → append (after a `---` separator).
-   - **Footer + no `--force`** → print `→ skipped #N <title>` and continue.
-     Do NOT call `gh edit` (saves API quota).
+   - **Footer + no `--force`** → print `→ skipped #N <title>` and continue
+     **without sleeping**. Do NOT call `gh edit` (saves API quota).
    - **Footer + `--force`** → recompute fresh metrics → in-place replace
      (single regex pass, no append).
-4. On modification only, write the new body to `mktemp` and call
-   `gh {issue,pr} edit N --repo "$TARGET_REPO" --body-file <tmp>`.
-5. Print the one-line status string per the "Per-card status output
+5. On modification only: write the new body to `mktemp`, call
+   `gh {issue,pr} edit N --repo "$TARGET_REPO" --body-file <tmp>`,
+   increment `modified_count`, then `sleep_pace "$PACE_SECS"` (no-op when
+   `--pace` not set, skipped on the last card so no trailing wait).
+6. Print the one-line status string per the "Per-card status output
    format" section in `references/footer-detection.md`. Continue on
    failure — never abort the loop.
 
@@ -84,6 +123,17 @@ After the loop, print the summary line + context-only ai-metrics line per
 the "Final report output format" section in `references/footer-detection.md`.
 Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
 
+When the loop exited early via `--limit` or `--budget`, append a third line
+naming the trigger and the count remaining in the original target list:
+
+```
+Stopped early: <stop_reason>; <X> cards remaining. Re-run the same command to resume (skip-existing makes this idempotent).
+```
+
+For `--dry-run`, the final report is the dry-run summary block from
+`references/pace-control.md` instead — no per-card metrics line, no
+edit-counters.
+
 ## Constraints
 
 - Always pass `--repo "$TARGET_REPO"` — no implicit repo detection.
@@ -92,6 +142,15 @@ Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
 - `--force` is **recompute → replace**, never blind overwrite or
   duplicate-append. If no footer exists, `--force` degrades to plain append.
 - Continue-on-error: a single card failure never stops the loop.
-- Skip path is API-silent — no `gh edit` call, no body diff.
+- Skip path is API-silent — no `gh edit` call, no body diff, **no sleep**.
 - Conversation-infer mode rejects bare numbers (`123` without `#`).
 - > 100 hits require explicit `y` confirmation; no `--yes` flag.
+- `--pace` sleeps **after** each successful modify, **never before**, and
+  **never after the last card** — no trailing wait.
+- `--dry-run` makes zero `gh edit` calls. `gh view` is still allowed
+  (needed to classify will-write vs will-skip vs will-force-replace).
+- `--limit` counts only cards that took the modify path (skipped cards
+  do not advance the counter — this makes "process N new backfills"
+  deterministic across re-runs).
+- `--limit` and `--budget` compose with **OR semantics** — whichever
+  fires first stops the loop. Stop reason is reported in the summary.

--- a/claude/skills/gh-add-ai-metrics/references/date-parsing.md
+++ b/claude/skills/gh-add-ai-metrics/references/date-parsing.md
@@ -43,6 +43,7 @@ parse_date_arg() {
     local start end
     start="${arg%%..*}"
     end="${arg##*..}"
+    [ -n "$start" ] && [ -n "$end" ] || return 1
     start=$(_expand_day "$start") || return 1
     end=$(_expand_day "$end") || return 1
     # Half-open: subtract 1 day from end so GitHub's inclusive `created:A..B`

--- a/claude/skills/gh-add-ai-metrics/references/date-parsing.md
+++ b/claude/skills/gh-add-ai-metrics/references/date-parsing.md
@@ -1,0 +1,183 @@
+# Date Argument Parsing — `--date` forms
+
+Parsing helpers for the `--date` flag of `gh:add-ai-metrics`. Pulled out of
+SKILL.md so the per-form regex/expansion logic is bats-testable and the
+SKILL.md prose stays workflow-only.
+
+## Supported forms
+
+The `--date` value falls into exactly one of four shapes. First match wins —
+they are detected by **length and content**, not by sniffing prefixes.
+
+| Form           | Example                       | Meaning                                    |
+|----------------|-------------------------------|--------------------------------------------|
+| month          | `26-04`, `2026-04`            | Whole month — 1st through last day         |
+| range (`..`)   | `26-04-03..26-04-11`          | Half-open `[start, end)` — end excluded    |
+| range (`~`)    | `26-04-03~26-04-11`           | Same as `..`; `~` is normalized to `..`    |
+| single day     | `26-04-30`, `2026-04-30`      | Exactly one day (existing behavior)        |
+
+Anything else → format error and stop.
+
+## Year normalization
+
+Two-digit `YY` always expands to `20YY`. We do **not** support 19xx or 21xx
+shorthand — backfill is for cards that exist now, all in the 20xx range.
+
+## `parse_date_arg` — top-level dispatch
+
+```bash
+# Echoes one of:
+#   single <YYYY-MM-DD>
+#   month  <YYYY-MM-DD> <YYYY-MM-DD>     (start, end-of-month)
+#   range  <YYYY-MM-DD> <YYYY-MM-DD>     (start, end-1day — already half-open
+#                                          adjusted, ready for GitHub query)
+# Exits non-zero on format error.
+parse_date_arg() {
+  local raw="$1"
+  # Normalize ~ to .. so range detection is single-pattern.
+  local arg="${raw//\~/..}"
+
+  # Range first — must check before single forms because '..' is a literal
+  # substring not produced by any other valid form.
+  if [[ "$arg" == *..* ]]; then
+    local start end
+    start="${arg%%..*}"
+    end="${arg##*..}"
+    start=$(_expand_day "$start") || return 1
+    end=$(_expand_day "$end") || return 1
+    # Half-open: subtract 1 day from end so GitHub's inclusive `created:A..B`
+    # query honors [start, end) semantics.
+    end=$(_minus_one_day "$end") || return 1
+    printf 'range %s %s\n' "$start" "$end"
+    return 0
+  fi
+
+  case "${#arg}" in
+    5)  # YY-MM
+      [[ "$arg" =~ ^[0-9]{2}-[0-9]{2}$ ]] || return 1
+      local yy="${arg%-*}" mm="${arg#*-}"
+      _emit_month "20$yy" "$mm"
+      ;;
+    7)  # YYYY-MM
+      [[ "$arg" =~ ^[0-9]{4}-[0-9]{2}$ ]] || return 1
+      local yyyy="${arg%-*}" mm="${arg#*-}"
+      _emit_month "$yyyy" "$mm"
+      ;;
+    8)  # YY-MM-DD
+      [[ "$arg" =~ ^[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+      printf 'single 20%s\n' "$arg"
+      ;;
+    10) # YYYY-MM-DD
+      [[ "$arg" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+      printf 'single %s\n' "$arg"
+      ;;
+    *)  return 1 ;;
+  esac
+}
+
+_emit_month() {
+  local yyyy="$1" mm="$2"
+  local last
+  last=$(last_day_of_month "$yyyy" "$mm") || return 1
+  printf 'month %s-%s-01 %s-%s-%s\n' "$yyyy" "$mm" "$yyyy" "$mm" "$last"
+}
+```
+
+## `last_day_of_month` — leap-year safe, no `cal` dependency
+
+Three-tier fallback: GNU `date` → BSD `date` → Python 3. Echoes a 2-digit
+day (`28`, `29`, `30`, `31`).
+
+```bash
+last_day_of_month() {
+  local yyyy="$1" mm="$2" out=""
+  # GNU date (Linux, WSL, most CI)
+  out=$(date -d "${yyyy}-${mm}-01 +1 month -1 day" +%d 2>/dev/null) \
+    && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  # BSD date (macOS)
+  out=$(date -j -f "%Y-%m-%d" -v+1m -v-1d "${yyyy}-${mm}-01" +%d 2>/dev/null) \
+    && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  # Python 3 fallback (final resort)
+  out=$(python3 -c "import calendar; print('%02d' % calendar.monthrange($yyyy, int('$mm'))[1])" 2>/dev/null) \
+    && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  return 1
+}
+```
+
+## `_minus_one_day` — for half-open range conversion
+
+Same fallback chain as `last_day_of_month`. Echoes `YYYY-MM-DD`.
+
+```bash
+_minus_one_day() {
+  local d="$1" out=""
+  out=$(date -d "$d -1 day" +%Y-%m-%d 2>/dev/null) \
+    && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  out=$(date -j -f "%Y-%m-%d" -v-1d "$d" +%Y-%m-%d 2>/dev/null) \
+    && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  out=$(python3 -c "import datetime; print((datetime.date.fromisoformat('$d') - datetime.timedelta(days=1)).isoformat())" 2>/dev/null) \
+    && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  return 1
+}
+```
+
+## `_expand_day` — normalize one endpoint of a range
+
+Accepts 8-char `YY-MM-DD` (expanded) or 10-char `YYYY-MM-DD` (passthrough).
+Mismatched length → fail. Range halves of *different* lengths are accepted
+(`26-04-03..2026-04-11` works) — each half is normalized independently.
+
+```bash
+_expand_day() {
+  local d="$1"
+  case "${#d}" in
+    8)  [[ "$d" =~ ^[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+        printf '20%s\n' "$d" ;;
+    10) [[ "$d" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+        printf '%s\n' "$d" ;;
+    *)  return 1 ;;
+  esac
+}
+```
+
+## `build_search_clause` — assemble the GitHub query fragment
+
+Takes the three-token output of `parse_date_arg` and emits the
+`created:...` clause for `gh issue list --search` / `gh pr list --search`.
+
+```bash
+# Usage: build_search_clause <kind> <a> [<b>]
+#   kind=single → "created:<a>"
+#   kind=month  → "created:<a>..<b>"
+#   kind=range  → "created:<a>..<b>"   (b is already half-open adjusted)
+build_search_clause() {
+  local kind="$1" a="$2" b="$3"
+  case "$kind" in
+    single) printf 'created:%s\n' "$a" ;;
+    month|range) printf 'created:%s..%s\n' "$a" "$b" ;;
+    *) return 1 ;;
+  esac
+}
+```
+
+## Examples — end-to-end
+
+| Input                       | `parse_date_arg` output           | `build_search_clause`                  |
+|-----------------------------|-----------------------------------|----------------------------------------|
+| `26-04`                     | `month 2026-04-01 2026-04-30`     | `created:2026-04-01..2026-04-30`       |
+| `2026-02`                   | `month 2026-02-01 2026-02-28`     | `created:2026-02-01..2026-02-28`       |
+| `24-02` (leap)              | `month 2024-02-01 2024-02-29`     | `created:2024-02-01..2024-02-29`       |
+| `26-04-03..26-04-11`        | `range 2026-04-03 2026-04-10`     | `created:2026-04-03..2026-04-10`       |
+| `26-04-03~26-04-11`         | `range 2026-04-03 2026-04-10`     | `created:2026-04-03..2026-04-10`       |
+| `26-04-30`                  | `single 2026-04-30`               | `created:2026-04-30`                   |
+| `2026-04-30`                | `single 2026-04-30`               | `created:2026-04-30`                   |
+| `26-4` (bad)                | exit 1                            | —                                      |
+| `2026-04-03..` (bad)        | exit 1                            | —                                      |
+
+## Why half-open `[start, end)` for ranges
+
+Matches Python slice (`list[3:11]` excludes index 11), git revision range
+(`commit1..commit2` excludes commit1's parent... well, mostly), and the
+mental model "I want everything FROM Monday UP TO but not including next
+Monday". Whole-month form is inclusive both ends because the unit IS the
+month — there is no "exclude the last day" interpretation that makes sense.

--- a/claude/skills/gh-add-ai-metrics/references/examples.md
+++ b/claude/skills/gh-add-ai-metrics/references/examples.md
@@ -1,0 +1,95 @@
+# gh:add-ai-metrics — Examples
+
+Split out from `help.md` to keep the help under the progressive-disclosure
+threshold (150 lines). Read this file when you want concrete invocation
+patterns; `help.md` covers argument shapes and behavioral contracts.
+
+## Single-shot
+
+```
+# Infer from the chat we just had
+/gh:add-ai-metrics
+
+# Tag exactly two cards
+/gh:add-ai-metrics issue#317 pr#320
+
+# Tag every card created on one day
+/gh:add-ai-metrics --type issue --date 2026-04-30
+
+# Force-recompute one card's footer
+/gh:add-ai-metrics issue#100 --force
+
+# Quick burst over a small explicit list — no pacing needed
+/gh:add-ai-metrics issue#101 issue#102 issue#103 issue#104 issue#105
+```
+
+## Whole-month backfill
+
+```
+/gh:add-ai-metrics --type PR --date 26-04
+/gh:add-ai-metrics --type issue --date 2026-04
+```
+
+Both expand to `created:2026-04-01..2026-04-30` (last day computed via
+`date -d` → BSD `date` → Python 3 fallback chain). February handles leap
+years correctly: `--date 24-02` → `created:2024-02-01..2024-02-29`,
+`--date 26-02` → `created:2026-02-01..2026-02-28`.
+
+## Range backfill — half-open `[start, end)`
+
+```
+# 4/3 through 4/10 inclusive — 4/11 excluded
+/gh:add-ai-metrics --type PR --date 26-04-03..26-04-11
+/gh:add-ai-metrics --type PR --date 26-04-03~26-04-11
+```
+
+`~` is normalized to `..` so muscle memory from "approximately X to Y"
+also works. Internally both expand to `created:2026-04-03..2026-04-10`.
+Half-open semantics match Python slice / git revision range — END is
+excluded so adjacent ranges concatenate without overlap:
+`A..B` then `B..C` covers `[A, C)` exactly once.
+
+## Nightly bulk backfill — 5h-limit safe
+
+```
+# 1. Just before leaving — preview the run
+/gh:add-ai-metrics --type PR --date 26-04 --pace 3m --budget 4h30m --dry-run
+# → "DRY RUN: 200 cards (180 will-write, 20 will-skip)"
+# → "         pace=3m budget=4h30m limit=unset"
+# → "         estimated wall-clock: 9h"
+
+# 2. Confidence check passed — start the real run
+/gh:add-ai-metrics --type PR --date 26-04 --pace 3m --budget 4h30m
+# → ✓ added #501 ...   (sleep 3m)
+# → ✓ added #502 ...   (sleep 3m)
+# → ...
+# → Stopped early: --budget (4h30m); 110 cards remaining. Re-run the
+#   same command to resume (skip-existing makes this idempotent).
+
+# 3. Next morning, re-run the same command
+#    First 90 cards already carry footers → skipped instantly (no API call,
+#    no sleep). Loop reaches card 91 and continues.
+/gh:add-ai-metrics --type PR --date 26-04 --pace 3m --budget 4h30m
+```
+
+## Composing `--limit` and `--budget`
+
+```
+# Process at most 50 cards OR 4 hours, whichever comes first.
+/gh:add-ai-metrics --type PR --date 26-04 --pace 3m --limit 50 --budget 4h
+```
+
+Both bounds are checked at the **top of every iteration**. Exit message
+identifies which one fired. `--limit` only counts cards that took the
+modify path — skipped cards do not advance the counter, so re-running
+the same command across a partially-processed list still yields exactly
+`--limit` modifications per night.
+
+## When to NOT use `--pace`
+
+- Small explicit lists (≤ 10 cards). The 5h limit doesn't bite at this
+  scale; pacing just slows you down.
+- Single-card retries. `--force` on one card needs no pacing.
+- CI / scripted backfills where wall-clock matters more than usage budget.
+
+The default `--pace 0` (no pacing) is correct for these.

--- a/claude/skills/gh-add-ai-metrics/references/help.md
+++ b/claude/skills/gh-add-ai-metrics/references/help.md
@@ -1,15 +1,50 @@
 # gh:add-ai-metrics — Help
 
+## Usage
+
+```
+/gh:add-ai-metrics [<targets>] [--type issue|PR] [--date <date>]
+                   [--pace <dur>] [--limit <N>] [--budget <dur>] [--dry-run]
+                   [--force] [--remote <name>]
+```
+
+`<targets>` are space-separated `issue#N` / `pr#M` tokens (case-insensitive).
+`<date>` is one of: `YY-MM`, `YYYY-MM`, `YY-MM-DD`, `YYYY-MM-DD`,
+`<start>..<end>`, or `<start>~<end>`. `<dur>` is a GNU-`sleep` style
+duration: `30s`, `5m`, `1h`, `1h30m`.
+
 ## Arguments
 
 | # | Form | Default | Description |
 |---|------|---------|-------------|
 | positional | `issue#N` / `pr#M` | — | Cards to retrofit (case-insensitive prefix). Multiple allowed. |
 | flag | `--type {issue\|PR}` | both | Limits date-filter mode to a single artifact kind. |
-| flag | `--date <YYYY-MM-DD>` | — | Date-filter mode trigger. 10-char input used as-is; 8-char `YY-MM-DD` expanded to `20YY-MM-DD`; other lengths rejected. |
+| flag | `--date <date>` | — | Date-filter mode trigger. Accepts single day (8 / 10 chars), whole month (`YY-MM` / `YYYY-MM`), or half-open range (`A..B` or `A~B`). See "Date forms" below. |
+| flag | `--pace <dur>` | `0` (no pace) | Sleep `<dur>` after each successful modify. Skipped on the last card and on every skip-path card. |
+| flag | `--limit <N>` | unset | Stop after `N` cards have been modified (skips do not count). |
+| flag | `--budget <dur>` | unset | Stop before exceeding `<dur>` of wall-clock. Composes with `--limit` via OR — whichever fires first wins. |
+| flag | `--dry-run` | off | Classify the target list without writing anything. View calls still happen (needed for state classification). |
 | flag | `--force` | off | Recompute metrics and replace an existing footer (default skips). |
 | flag | `--remote <name>` | `origin` | Override the target remote. |
 | flag | `-h` / `--help` / `help` | — | Print this help and stop. |
+
+## Date forms (used with `--date`)
+
+| Length / shape       | Example                | Meaning                                 |
+|----------------------|------------------------|-----------------------------------------|
+| 5 chars              | `26-04`                | Whole month — 2026-04-01 through 2026-04-30 |
+| 7 chars              | `2026-04`              | Same — 4-digit year explicit            |
+| 8 chars              | `26-04-30`             | Single day — `20YY` expansion           |
+| 10 chars             | `2026-04-30`           | Single day — used as-is                 |
+| range with `..`      | `26-04-03..26-04-11`   | Half-open `[start, end)` — end excluded |
+| range with `~`       | `26-04-03~26-04-11`    | Same as `..` (`~` is normalized)        |
+
+`A..B` uses **half-open `[start, end)`** semantics — END is excluded,
+matching Python slice and git revision-range conventions. Internally it
+is converted to GitHub's inclusive `created:A..B-1day` query.
+
+Whole-month form is **inclusive both ends** because the unit IS the month —
+there is no "exclude the last day" interpretation that makes sense.
 
 ## Modes (mutually exclusive — first match wins)
 
@@ -23,28 +58,32 @@
 
 3. **date-filter** (`--date`, optional `--type`)
    Enumerates via
-   `gh {issue,pr} list --search "created:<DATE>" --state all --limit 200`.
-   `> 100` hits → confirmation prompt (`y/N`, default no).
+   `gh {issue,pr} list --search "<clause>" --state all --limit 200`.
+   Clause shape per `parse_date_arg` in `references/date-parsing.md`.
+   `> 100` hits → confirmation prompt (`y/N`, default no), even when
+   `--limit` is set.
 
 `--date` and positional cards together → hard error (mutex).
 
 ## Examples
 
-- `/gh:add-ai-metrics`
-  → infers from chat (e.g. #317 + #320 just discussed in this turn).
-- `/gh:add-ai-metrics issue#317 pr#320`
-  → tags exactly those two.
-- `/gh:add-ai-metrics --type issue --date 2026-04-30`
-  → tags every issue created on 2026-04-30 in `origin`'s repo.
-- `/gh:add-ai-metrics --type PR --date 26-04-30 --remote upstream`
-  → date expansion (`26-04-30` → `2026-04-30`) + remote override.
-- `/gh:add-ai-metrics issue#100 --force`
-  → recomputes metrics for #100 even if it already has a footer.
+Concrete invocation patterns — single-shot, whole-month, range, and
+overnight nightly backfill — live in `references/examples.md` to keep
+this help under the progressive-disclosure threshold. Quick taste:
+
+```
+/gh:add-ai-metrics issue#317 pr#320                              # explicit
+/gh:add-ai-metrics --type PR --date 26-04                        # whole month
+/gh:add-ai-metrics --type PR --date 26-04-03..26-04-11           # range
+/gh:add-ai-metrics --type PR --date 26-04 --pace 3m --budget 4h30m   # overnight
+/gh:add-ai-metrics --type PR --date 26-04 --pace 3m --budget 4h30m --dry-run   # preview
+```
 
 ## Behavior
 
 - **Idempotent by default** — cards already carrying `<!-- ai-metrics -->`
-  (or `<!-- ai-metrics:* -->`) skip without an `gh edit` API call.
+  (or `<!-- ai-metrics:* -->`) skip without an `gh edit` API call AND
+  without sleeping (skip-path is fully API-silent).
 - **`--force` recomputes** — does NOT just overwrite the literal block;
   re-fetches body, recomputes fresh `TOKENS` / `HUMAN_H` / `ELAPSED`,
   then replaces the existing block in place (no duplicate append).
@@ -54,6 +93,17 @@
   in `--force` replace, regex matches the block markers exactly, leaving
   surrounding bytes untouched.
 - **API quota friendly** — skip path performs zero `gh edit` calls.
+
+## Notes
+
+- **Skip-existing = natural resume.** When `--limit` or `--budget`
+  stops the loop early, just re-run the same command — already-tagged
+  cards skip in seconds (no API call), and the loop picks up from the
+  first un-tagged card. No `--resume` flag needed.
+- **`--limit` + `--budget` = OR.** Whichever stops the loop first wins;
+  the final summary names which one fired.
+- **`--dry-run` is not zero-quota.** `gh view` is still called per card
+  (state classification needs the body). It's `gh edit` that is skipped.
 
 ## Footer format (matches PR #320 / `gh-issue-create`)
 
@@ -89,4 +139,5 @@ skill with `--force` produces stable output (no flapping).
 - Auto-create labels, assignees, or milestones.
 - Silently fall back to `origin` when `--remote <name>` is missing.
 - Process more than 100 cards without explicit `y` confirmation.
-- Mutate cards on the skip path (no body diff, no API call).
+- Mutate cards on the skip path (no body diff, no API call, no sleep).
+- Run cards in parallel (`--pace` is intentionally serial).

--- a/claude/skills/gh-add-ai-metrics/references/pace-control.md
+++ b/claude/skills/gh-add-ai-metrics/references/pace-control.md
@@ -1,0 +1,181 @@
+# Pace / Limit / Budget — overnight backfill controls
+
+Shell helpers for the `--pace`, `--limit`, `--budget`, and `--dry-run` flags
+of `gh:add-ai-metrics`. Pulled out of SKILL.md so the unit logic is
+bats-testable and the SKILL.md prose stays workflow-only.
+
+## `parse_duration` — `30s` / `5m` / `1h` / `1h30m` → seconds
+
+```bash
+# Echoes seconds (integer). Exits non-zero on bad input.
+# Accepts the same shapes as `/loop` (GNU sleep compatible).
+parse_duration() {
+  local raw="$1"
+  local total=0 num unit
+  local rest="$raw"
+  [ -n "$rest" ] || return 1
+  while [ -n "$rest" ]; do
+    [[ "$rest" =~ ^([0-9]+)([smh])(.*)$ ]] || return 1
+    num="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[2]}"
+    rest="${BASH_REMATCH[3]}"
+    case "$unit" in
+      s) total=$((total + num)) ;;
+      m) total=$((total + num * 60)) ;;
+      h) total=$((total + num * 3600)) ;;
+    esac
+  done
+  printf '%s\n' "$total"
+}
+```
+
+Examples: `30s` → 30, `5m` → 300, `1h` → 3600, `1h30m` → 5400.
+Rejects: empty, `3` (no unit), `5d` (unsupported), `1.5h` (no fractions),
+`1h30` (trailing bare number).
+
+## `format_duration` — seconds → human string for ETA output
+
+```bash
+# Echoes a compact human form: 90 → "1m30s", 3600 → "1h", 5400 → "1h30m".
+format_duration() {
+  local s="$1" h m
+  h=$(( s / 3600 )); s=$(( s % 3600 ))
+  m=$(( s / 60 ));   s=$(( s % 60 ))
+  local out=""
+  [ "$h" -gt 0 ] && out="${out}${h}h"
+  [ "$m" -gt 0 ] && out="${out}${m}m"
+  [ "$s" -gt 0 ] && out="${out}${s}s"
+  [ -z "$out" ] && out="0s"
+  printf '%s\n' "$out"
+}
+```
+
+## `sleep_pace` — no-op when 0
+
+```bash
+# Sleep $1 seconds. 0 (or unset) → return immediately, no `sleep` invocation.
+sleep_pace() {
+  local secs="${1:-0}"
+  [ "$secs" -gt 0 ] || return 0
+  sleep "$secs"
+}
+```
+
+## `check_budget` — should we stop before the next card?
+
+```bash
+# Returns 0 (true) when the budget is exhausted and the loop should stop.
+# Returns 1 (false) when there is room to process at least one more card.
+# Empty / 0 budget → never stops (1).
+#
+# Usage at top of each loop iteration:
+#   check_budget "$elapsed" "$budget_secs" && break
+check_budget() {
+  local elapsed="$1" budget="${2:-0}"
+  [ "$budget" -gt 0 ] || return 1
+  [ "$elapsed" -ge "$budget" ]
+}
+```
+
+We compare `elapsed >= budget` (not `>`), so a budget of `4h30m` (16200s)
+and an elapsed of exactly 16200s stops. Off-by-one in the conservative
+direction — we'd rather stop one card early than burn into the limit.
+
+## `compute_eta` — for `--dry-run` output
+
+```bash
+# Echoes a human ETA string for N writes paced at S seconds.
+# Skip-only runs (writes=0) → "0s (no writes)".
+compute_eta() {
+  local writes="$1" pace_secs="${2:-0}"
+  if [ "$writes" -le 0 ]; then
+    printf '0s (no writes)\n'
+    return 0
+  fi
+  if [ "$pace_secs" -le 0 ]; then
+    printf '<1m (no pace)\n'
+    return 0
+  fi
+  # (writes - 1) gaps × pace, since "after" sleep skips the trailing wait.
+  local total=$(( (writes - 1) * pace_secs ))
+  [ "$total" -lt 0 ] && total=0
+  format_duration "$total"
+}
+```
+
+The `(writes - 1)` accounts for the SKILL.md "sleep AFTER each card,
+except last" rule — N writes have N-1 gaps.
+
+## Stop-reason composition (`--limit` + `--budget`)
+
+When both are set, the loop stops on whichever fires first. The stop
+message identifies which one:
+
+```bash
+# Inside the per-card loop, BEFORE processing the next card:
+if check_budget "$elapsed" "$budget_secs"; then
+  stop_reason="--budget ($(format_duration "$budget_secs"))"
+  break
+fi
+if [ -n "$LIMIT" ] && [ "$modified_count" -ge "$LIMIT" ]; then
+  stop_reason="--limit ($LIMIT cards modified)"
+  break
+fi
+```
+
+`modified_count` only counts cards that took the write/replace path —
+skipped cards (footer present, no `--force`) do not advance the limit
+counter. This makes "process 50 NEW backfills tonight" a deterministic
+unit, even when re-running over a partially-processed list.
+
+## `--dry-run` branch — what it prints, what it skips
+
+Dry-run does NOT call `gh edit`. It still calls `gh view` (the `view` is
+how state classification — `will-write` vs `will-skip` vs
+`will-force-replace` — is decided; without it the ETA would be a guess).
+Per-card output uses a distinct glyph so dry-run rows are visually
+separable from real-run rows:
+
+| Branch                       | Real-run line          | Dry-run line                  |
+|------------------------------|------------------------|-------------------------------|
+| no footer                    | `✓ added #N <title>`   | `· will-write #N <title>`     |
+| footer + `--force`           | `↻ replaced #N <title>` | `· will-force-replace #N <title>` |
+| footer + no `--force`        | `→ skipped #N <title>` | `· will-skip #N <title>`      |
+| view failed                  | `✗ failed #N <reason>` | `· would-fail #N <reason>`    |
+
+Final dry-run summary line:
+
+```
+DRY RUN: T cards (W will-write, F will-force-replace, S will-skip)
+         pace=PACE budget=BUDGET limit=LIMIT
+         estimated wall-clock: ETA
+```
+
+`PACE`, `BUDGET`, `LIMIT` — display `unset` when the flag was not passed.
+
+## Resume semantics — natural via skip-existing
+
+The original skip-existing behavior already provides a free resume:
+
+1. Run #1 stops at card N due to `--budget` (M cards modified, X cards
+   ahead untouched).
+2. Re-running the same command: cards 1..N already carry footers → all
+   skipped (no API call) → loop reaches card N+1 in seconds.
+3. Continues from N+1 with the rest of the budget.
+
+No `--resume` flag, no state file, no checkpoint format. The card body
+itself IS the persisted state.
+
+## Test rubric
+
+A pacing run is correct iff:
+
+1. `parse_duration` accepts `30s`, `5m`, `1h`, `1h30m`, `1m30s` and
+   rejects `3`, `5d`, `1.5h`, empty.
+2. `sleep_pace 0` returns in <50ms (no actual `sleep` invocation).
+3. `check_budget 16199 16200` → false (1); `check_budget 16200 16200` → true (0).
+4. `compute_eta 1 180` → `0s` (one write, no gap); `compute_eta 12 180` → `33m`.
+5. `--dry-run` makes zero `gh edit` calls (verified via fake-shim log).
+6. `--limit 50` stops after 50 *modified* cards, ignoring skips in the count.
+7. Re-running the same command on the same target list after a budget
+   stop produces zero edit calls until reaching the first un-footered card.

--- a/claude/skills/gh-add-ai-metrics/references/pace-control.md
+++ b/claude/skills/gh-add-ai-metrics/references/pace-control.md
@@ -112,8 +112,11 @@ When both are set, the loop stops on whichever fires first. The stop
 message identifies which one:
 
 ```bash
-# Inside the per-card loop, BEFORE processing the next card:
-if check_budget "$elapsed" "$budget_secs"; then
+# Inside the per-card loop, BEFORE processing the next card.
+# elapsed_secs is in SECONDS — recomputed each iteration. Do not
+# substitute the minutes-rounded ELAPSED used by Step 4's display line.
+elapsed_secs=$(( $(date +%s) - START_TS ))
+if check_budget "$elapsed_secs" "$budget_secs"; then
   stop_reason="--budget ($(format_duration "$budget_secs"))"
   break
 fi

--- a/tests/bats/skills/_fixtures/date_parsing.sh
+++ b/tests/bats/skills/_fixtures/date_parsing.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/date_parsing.sh
+# Sourced by gh_add_ai_metrics_date.bats. Mirrors the helpers in
+# claude/skills/gh-add-ai-metrics/references/date-parsing.md so bats
+# can verify the intended logic. If the markdown changes, update this
+# file in lockstep — it is the testable copy of the same algorithm.
+
+last_day_of_month() {
+    local yyyy="$1" mm="$2" out=""
+    out=$(date -d "${yyyy}-${mm}-01 +1 month -1 day" +%d 2>/dev/null) \
+        && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    out=$(date -j -f "%Y-%m-%d" -v+1m -v-1d "${yyyy}-${mm}-01" +%d 2>/dev/null) \
+        && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    out=$(python3 -c "import calendar; print('%02d' % calendar.monthrange($yyyy, int('$mm'))[1])" 2>/dev/null) \
+        && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    return 1
+}
+
+_minus_one_day() {
+    local d="$1" out=""
+    out=$(date -d "$d -1 day" +%Y-%m-%d 2>/dev/null) \
+        && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    out=$(date -j -f "%Y-%m-%d" -v-1d "$d" +%Y-%m-%d 2>/dev/null) \
+        && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    out=$(python3 -c "import datetime; print((datetime.date.fromisoformat('$d') - datetime.timedelta(days=1)).isoformat())" 2>/dev/null) \
+        && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    return 1
+}
+
+_expand_day() {
+    local d="$1"
+    case "${#d}" in
+        8)  [[ "$d" =~ ^[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+            printf '20%s\n' "$d" ;;
+        10) [[ "$d" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+            printf '%s\n' "$d" ;;
+        *)  return 1 ;;
+    esac
+}
+
+_emit_month() {
+    local yyyy="$1" mm="$2" last
+    last=$(last_day_of_month "$yyyy" "$mm") || return 1
+    printf 'month %s-%s-01 %s-%s-%s\n' "$yyyy" "$mm" "$yyyy" "$mm" "$last"
+}
+
+parse_date_arg() {
+    local raw="$1"
+    [ -n "$raw" ] || return 1
+    local arg="${raw//\~/..}"
+
+    if [[ "$arg" == *..* ]]; then
+        local start end
+        start="${arg%%..*}"
+        end="${arg##*..}"
+        [ -n "$start" ] && [ -n "$end" ] || return 1
+        start=$(_expand_day "$start") || return 1
+        end=$(_expand_day "$end") || return 1
+        end=$(_minus_one_day "$end") || return 1
+        printf 'range %s %s\n' "$start" "$end"
+        return 0
+    fi
+
+    case "${#arg}" in
+        5)
+            [[ "$arg" =~ ^[0-9]{2}-[0-9]{2}$ ]] || return 1
+            local yy="${arg%-*}" mm="${arg#*-}"
+            _emit_month "20$yy" "$mm"
+            ;;
+        7)
+            [[ "$arg" =~ ^[0-9]{4}-[0-9]{2}$ ]] || return 1
+            local yyyy="${arg%-*}" mm="${arg#*-}"
+            _emit_month "$yyyy" "$mm"
+            ;;
+        8)
+            [[ "$arg" =~ ^[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+            printf 'single 20%s\n' "$arg"
+            ;;
+        10)
+            [[ "$arg" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+            printf 'single %s\n' "$arg"
+            ;;
+        *)  return 1 ;;
+    esac
+}
+
+build_search_clause() {
+    local kind="$1" a="$2" b="$3"
+    case "$kind" in
+        single)      printf 'created:%s\n' "$a" ;;
+        month|range) printf 'created:%s..%s\n' "$a" "$b" ;;
+        *)           return 1 ;;
+    esac
+}

--- a/tests/bats/skills/_fixtures/pace_control.sh
+++ b/tests/bats/skills/_fixtures/pace_control.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/pace_control.sh
+# Sourced by gh_add_ai_metrics_pace.bats. Mirrors the helpers in
+# claude/skills/gh-add-ai-metrics/references/pace-control.md so bats
+# can verify the intended logic. If the markdown changes, update this
+# file in lockstep — it is the testable copy of the same algorithm.
+
+parse_duration() {
+    local raw="$1"
+    local total=0 num unit
+    local rest="$raw"
+    [ -n "$rest" ] || return 1
+    while [ -n "$rest" ]; do
+        [[ "$rest" =~ ^([0-9]+)([smh])(.*)$ ]] || return 1
+        num="${BASH_REMATCH[1]}"
+        unit="${BASH_REMATCH[2]}"
+        rest="${BASH_REMATCH[3]}"
+        case "$unit" in
+            s) total=$((total + num)) ;;
+            m) total=$((total + num * 60)) ;;
+            h) total=$((total + num * 3600)) ;;
+        esac
+    done
+    printf '%s\n' "$total"
+}
+
+format_duration() {
+    local s="$1" h m
+    h=$(( s / 3600 )); s=$(( s % 3600 ))
+    m=$(( s / 60 ));   s=$(( s % 60 ))
+    local out=""
+    [ "$h" -gt 0 ] && out="${out}${h}h"
+    [ "$m" -gt 0 ] && out="${out}${m}m"
+    [ "$s" -gt 0 ] && out="${out}${s}s"
+    [ -z "$out" ] && out="0s"
+    printf '%s\n' "$out"
+}
+
+sleep_pace() {
+    local secs="${1:-0}"
+    [ "$secs" -gt 0 ] || return 0
+    sleep "$secs"
+}
+
+check_budget() {
+    local elapsed="$1" budget="${2:-0}"
+    [ "$budget" -gt 0 ] || return 1
+    [ "$elapsed" -ge "$budget" ]
+}
+
+compute_eta() {
+    local writes="$1" pace_secs="${2:-0}"
+    if [ "$writes" -le 0 ]; then
+        printf '0s (no writes)\n'
+        return 0
+    fi
+    if [ "$pace_secs" -le 0 ]; then
+        printf '<1m (no pace)\n'
+        return 0
+    fi
+    local total=$(( (writes - 1) * pace_secs ))
+    [ "$total" -lt 0 ] && total=0
+    format_duration "$total"
+}

--- a/tests/bats/skills/gh_add_ai_metrics_date.bats
+++ b/tests/bats/skills/gh_add_ai_metrics_date.bats
@@ -4,7 +4,6 @@
 # Source-of-truth lives at
 #   claude/skills/gh-add-ai-metrics/references/date-parsing.md
 # and is mirrored at tests/bats/skills/_fixtures/date_parsing.sh for testing.
-# Issues #336 + #337.
 
 load '../test_helper'
 
@@ -63,7 +62,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# parse_date_arg — month form (issue #336 + #337)
+# parse_date_arg — month form
 # ---------------------------------------------------------------------------
 
 @test "parse_date_arg: 5-char YY-MM → month range" {
@@ -91,7 +90,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# parse_date_arg — range form (issue #337)
+# parse_date_arg — range form
 # ---------------------------------------------------------------------------
 
 @test "parse_date_arg: 8-char range A..B → half-open (end -1 day)" {

--- a/tests/bats/skills/gh_add_ai_metrics_date.bats
+++ b/tests/bats/skills/gh_add_ai_metrics_date.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_add_ai_metrics_date.bats
+# Verify the date-argument parsing helpers used by /gh:add-ai-metrics.
+# Source-of-truth lives at
+#   claude/skills/gh-add-ai-metrics/references/date-parsing.md
+# and is mirrored at tests/bats/skills/_fixtures/date_parsing.sh for testing.
+# Issues #336 + #337.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/date_parsing.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# last_day_of_month — leap-year correctness across the fallback chain
+# ---------------------------------------------------------------------------
+
+@test "last_day_of_month: April → 30" {
+    run last_day_of_month 2026 04
+    assert_success
+    assert_output "30"
+}
+
+@test "last_day_of_month: February non-leap (2026) → 28" {
+    run last_day_of_month 2026 02
+    assert_success
+    assert_output "28"
+}
+
+@test "last_day_of_month: February leap year (2024) → 29" {
+    run last_day_of_month 2024 02
+    assert_success
+    assert_output "29"
+}
+
+@test "last_day_of_month: December → 31" {
+    run last_day_of_month 2026 12
+    assert_success
+    assert_output "31"
+}
+
+# ---------------------------------------------------------------------------
+# parse_date_arg — single-day form (existing behaviour, no regression)
+# ---------------------------------------------------------------------------
+
+@test "parse_date_arg: 10-char YYYY-MM-DD → single passthrough" {
+    run parse_date_arg "2026-04-30"
+    assert_success
+    assert_output "single 2026-04-30"
+}
+
+@test "parse_date_arg: 8-char YY-MM-DD → single with 20YY expansion" {
+    run parse_date_arg "26-04-30"
+    assert_success
+    assert_output "single 2026-04-30"
+}
+
+# ---------------------------------------------------------------------------
+# parse_date_arg — month form (issue #336 + #337)
+# ---------------------------------------------------------------------------
+
+@test "parse_date_arg: 5-char YY-MM → month range" {
+    run parse_date_arg "26-04"
+    assert_success
+    assert_output "month 2026-04-01 2026-04-30"
+}
+
+@test "parse_date_arg: 7-char YYYY-MM → month range" {
+    run parse_date_arg "2026-04"
+    assert_success
+    assert_output "month 2026-04-01 2026-04-30"
+}
+
+@test "parse_date_arg: month form covers leap February correctly" {
+    run parse_date_arg "24-02"
+    assert_success
+    assert_output "month 2024-02-01 2024-02-29"
+}
+
+@test "parse_date_arg: month form covers non-leap February" {
+    run parse_date_arg "26-02"
+    assert_success
+    assert_output "month 2026-02-01 2026-02-28"
+}
+
+# ---------------------------------------------------------------------------
+# parse_date_arg — range form (issue #337)
+# ---------------------------------------------------------------------------
+
+@test "parse_date_arg: 8-char range A..B → half-open (end -1 day)" {
+    run parse_date_arg "26-04-03..26-04-11"
+    assert_success
+    assert_output "range 2026-04-03 2026-04-10"
+}
+
+@test "parse_date_arg: 10-char range A..B → half-open (end -1 day)" {
+    run parse_date_arg "2026-04-03..2026-04-11"
+    assert_success
+    assert_output "range 2026-04-03 2026-04-10"
+}
+
+@test "parse_date_arg: range with ~ separator → normalized to .." {
+    run parse_date_arg "26-04-03~26-04-11"
+    assert_success
+    assert_output "range 2026-04-03 2026-04-10"
+}
+
+@test "parse_date_arg: range halves of mixed length both normalized" {
+    run parse_date_arg "26-04-03..2026-04-11"
+    assert_success
+    assert_output "range 2026-04-03 2026-04-10"
+}
+
+@test "parse_date_arg: range crossing month boundary" {
+    run parse_date_arg "26-04-30..26-05-02"
+    assert_success
+    assert_output "range 2026-04-30 2026-05-01"
+}
+
+@test "parse_date_arg: range crossing year boundary handles month rollover" {
+    run parse_date_arg "26-12-31..27-01-02"
+    assert_success
+    assert_output "range 2026-12-31 2027-01-01"
+}
+
+# ---------------------------------------------------------------------------
+# parse_date_arg — invalid inputs
+# ---------------------------------------------------------------------------
+
+@test "parse_date_arg: empty input rejected" {
+    run parse_date_arg ""
+    assert_failure
+}
+
+@test "parse_date_arg: 6-char YY-M-D rejected (wrong shape)" {
+    run parse_date_arg "26-4-3"
+    assert_failure
+}
+
+@test "parse_date_arg: range with empty start rejected" {
+    run parse_date_arg "..26-04-11"
+    assert_failure
+}
+
+@test "parse_date_arg: range with empty end rejected" {
+    run parse_date_arg "26-04-03.."
+    assert_failure
+}
+
+@test "parse_date_arg: alpha junk rejected" {
+    run parse_date_arg "april-30"
+    assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# build_search_clause
+# ---------------------------------------------------------------------------
+
+@test "build_search_clause: single → created:DATE" {
+    run build_search_clause single 2026-04-30
+    assert_success
+    assert_output "created:2026-04-30"
+}
+
+@test "build_search_clause: month → created:A..B" {
+    run build_search_clause month 2026-04-01 2026-04-30
+    assert_success
+    assert_output "created:2026-04-01..2026-04-30"
+}
+
+@test "build_search_clause: range → created:A..B (already half-open adjusted)" {
+    run build_search_clause range 2026-04-03 2026-04-10
+    assert_success
+    assert_output "created:2026-04-03..2026-04-10"
+}
+
+@test "build_search_clause: unknown kind rejected" {
+    run build_search_clause bogus 2026-04-01
+    assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end: parse_date_arg → build_search_clause composition
+# ---------------------------------------------------------------------------
+
+@test "e2e: month form composes to expected GitHub query" {
+    out=$(parse_date_arg "26-04")
+    # shellcheck disable=SC2086
+    set -- $out  # split into kind/a/b
+    run build_search_clause "$@"
+    assert_success
+    assert_output "created:2026-04-01..2026-04-30"
+}
+
+@test "e2e: range form composes (half-open semantics preserved)" {
+    out=$(parse_date_arg "26-04-03..26-04-11")
+    # shellcheck disable=SC2086
+    set -- $out
+    run build_search_clause "$@"
+    assert_success
+    assert_output "created:2026-04-03..2026-04-10"
+}

--- a/tests/bats/skills/gh_add_ai_metrics_pace.bats
+++ b/tests/bats/skills/gh_add_ai_metrics_pace.bats
@@ -4,7 +4,6 @@
 # Source-of-truth lives at
 #   claude/skills/gh-add-ai-metrics/references/pace-control.md
 # and is mirrored at tests/bats/skills/_fixtures/pace_control.sh for testing.
-# Issue #338.
 
 load '../test_helper'
 

--- a/tests/bats/skills/gh_add_ai_metrics_pace.bats
+++ b/tests/bats/skills/gh_add_ai_metrics_pace.bats
@@ -1,0 +1,225 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_add_ai_metrics_pace.bats
+# Verify the pace/limit/budget helpers used by /gh:add-ai-metrics.
+# Source-of-truth lives at
+#   claude/skills/gh-add-ai-metrics/references/pace-control.md
+# and is mirrored at tests/bats/skills/_fixtures/pace_control.sh for testing.
+# Issue #338.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/pace_control.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# parse_duration — accepted forms
+# ---------------------------------------------------------------------------
+
+@test "parse_duration: 30s → 30" {
+    run parse_duration "30s"
+    assert_success
+    assert_output "30"
+}
+
+@test "parse_duration: 5m → 300" {
+    run parse_duration "5m"
+    assert_success
+    assert_output "300"
+}
+
+@test "parse_duration: 1h → 3600" {
+    run parse_duration "1h"
+    assert_success
+    assert_output "3600"
+}
+
+@test "parse_duration: 1h30m → 5400 (compound)" {
+    run parse_duration "1h30m"
+    assert_success
+    assert_output "5400"
+}
+
+@test "parse_duration: 1m30s → 90 (compound minor units)" {
+    run parse_duration "1m30s"
+    assert_success
+    assert_output "90"
+}
+
+@test "parse_duration: 4h30m → 16200 (the canonical overnight budget)" {
+    run parse_duration "4h30m"
+    assert_success
+    assert_output "16200"
+}
+
+# ---------------------------------------------------------------------------
+# parse_duration — rejected forms
+# ---------------------------------------------------------------------------
+
+@test "parse_duration: empty rejected" {
+    run parse_duration ""
+    assert_failure
+}
+
+@test "parse_duration: bare number (no unit) rejected" {
+    run parse_duration "3"
+    assert_failure
+}
+
+@test "parse_duration: unsupported unit (d) rejected" {
+    run parse_duration "5d"
+    assert_failure
+}
+
+@test "parse_duration: fractional value rejected" {
+    run parse_duration "1.5h"
+    assert_failure
+}
+
+@test "parse_duration: trailing bare number rejected" {
+    run parse_duration "1h30"
+    assert_failure
+}
+
+@test "parse_duration: alpha junk rejected" {
+    run parse_duration "fast"
+    assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# format_duration — round-trip readability
+# ---------------------------------------------------------------------------
+
+@test "format_duration: 0 → 0s" {
+    run format_duration 0
+    assert_success
+    assert_output "0s"
+}
+
+@test "format_duration: 90 → 1m30s" {
+    run format_duration 90
+    assert_success
+    assert_output "1m30s"
+}
+
+@test "format_duration: 3600 → 1h" {
+    run format_duration 3600
+    assert_success
+    assert_output "1h"
+}
+
+@test "format_duration: 5400 → 1h30m" {
+    run format_duration 5400
+    assert_success
+    assert_output "1h30m"
+}
+
+@test "format_duration: 16200 → 4h30m (overnight budget)" {
+    run format_duration 16200
+    assert_success
+    assert_output "4h30m"
+}
+
+@test "format_duration: parse_duration round-trip preserves canonical strings" {
+    secs=$(parse_duration "1h30m")
+    run format_duration "$secs"
+    assert_success
+    assert_output "1h30m"
+}
+
+# ---------------------------------------------------------------------------
+# sleep_pace — must NOT actually sleep when 0
+# ---------------------------------------------------------------------------
+
+@test "sleep_pace: 0 returns immediately (no actual sleep)" {
+    start=$EPOCHREALTIME
+    run sleep_pace 0
+    assert_success
+    end=$EPOCHREALTIME
+    # Tolerate 50ms — well under any real sleep call.
+    delta_ms=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%d", (e - s) * 1000 }')
+    [ "$delta_ms" -lt 50 ]
+}
+
+@test "sleep_pace: unset arg defaults to 0 and returns immediately" {
+    start=$EPOCHREALTIME
+    run sleep_pace
+    assert_success
+    end=$EPOCHREALTIME
+    delta_ms=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%d", (e - s) * 1000 }')
+    [ "$delta_ms" -lt 50 ]
+}
+
+# ---------------------------------------------------------------------------
+# check_budget — boundary semantics
+# ---------------------------------------------------------------------------
+
+@test "check_budget: well under budget → false (continue)" {
+    run check_budget 100 16200
+    assert_failure
+}
+
+@test "check_budget: one second short of budget → false (continue)" {
+    run check_budget 16199 16200
+    assert_failure
+}
+
+@test "check_budget: exactly at budget → true (stop, conservative)" {
+    run check_budget 16200 16200
+    assert_success
+}
+
+@test "check_budget: over budget → true (stop)" {
+    run check_budget 99999 16200
+    assert_success
+}
+
+@test "check_budget: budget unset (0) → never stops" {
+    run check_budget 99999 0
+    assert_failure
+}
+
+@test "check_budget: budget empty string → never stops" {
+    run check_budget 99999 ""
+    assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# compute_eta — wall-clock estimate for --dry-run
+# ---------------------------------------------------------------------------
+
+@test "compute_eta: 0 writes → no-writes string" {
+    run compute_eta 0 180
+    assert_success
+    assert_output "0s (no writes)"
+}
+
+@test "compute_eta: 1 write → 0s (no gap to wait through)" {
+    run compute_eta 1 180
+    assert_success
+    assert_output "0s"
+}
+
+@test "compute_eta: 12 writes × 3m → 33m (11 gaps × 3m)" {
+    run compute_eta 12 180
+    assert_success
+    assert_output "33m"
+}
+
+@test "compute_eta: 200 writes × 3m → 9h57m" {
+    run compute_eta 200 180
+    assert_success
+    assert_output "9h57m"
+}
+
+@test "compute_eta: pace=0 (no pacing) → no-pace string" {
+    run compute_eta 100 0
+    assert_success
+    assert_output "<1m (no pace)"
+}


### PR DESCRIPTION
## Summary

Bundle of three related enhancements to `/gh:add-ai-metrics` so the skill can backfill an entire month (or any half-open date range) of cards overnight without bursting through the 5h Claude usage limit. The three issues compose naturally — date filter selects the targets, pacing walks them slowly — so they ship as one PR rather than three sequential ones.

- **#336** — `--date YY-MM` (whole-month, leap-year safe)
- **#337** — `--date YYYY-MM` and half-open ranges `A..B` / `A~B`
- **#338** — `--pace`, `--limit`, `--budget`, `--dry-run` overnight controls

## What's in the diff

| File | Change |
|---|---|
| `claude/skills/gh-add-ai-metrics/SKILL.md` | Step 1 parses new flags; Step 2 builds GitHub query via `parse_date_arg` → `build_search_clause`; Step 3 integrates `sleep_pace`, budget/limit stop checks, `--dry-run` branch; Constraints updated |
| `claude/skills/gh-add-ai-metrics/references/date-parsing.md` | **NEW** — `parse_date_arg`, `last_day_of_month` (3-tier fallback), `_minus_one_day`, `build_search_clause` |
| `claude/skills/gh-add-ai-metrics/references/pace-control.md` | **NEW** — `parse_duration`, `format_duration`, `sleep_pace`, `check_budget`, `compute_eta`, dry-run branch spec |
| `claude/skills/gh-add-ai-metrics/references/help.md` | New flags in Usage + Arguments table; Date-forms table; Notes section; Examples slimmed (143 lines, under 150-line threshold) |
| `claude/skills/gh-add-ai-metrics/references/examples.md` | **NEW** — single-shot, whole-month, range, nightly-bulk, OR composition examples (split out so help.md stays under threshold) |
| `tests/bats/skills/gh_add_ai_metrics_date.bats` | **NEW** — 27 tests: leap-year `last_day_of_month`, `parse_date_arg` for all 4 forms + invalid inputs, `build_search_clause`, e2e composition |
| `tests/bats/skills/gh_add_ai_metrics_pace.bats` | **NEW** — 31 tests: `parse_duration` accept/reject matrix, `format_duration` round-trip, `sleep_pace` no-op timing, `check_budget` boundary, `compute_eta` gap arithmetic |
| `tests/bats/skills/_fixtures/{date_parsing,pace_control}.sh` | **NEW** — sourceable mirrors of the markdown helpers so bats can verify the intended logic |

Total: 9 files, +1193/-32, 58 new tests (all green; 434 existing tests still green).

## Design highlights

### Half-open range semantics — `[start, end)`

Mirrors Python slice (`list[3:11]` excludes 11), git revision range (`commit1..commit2`), and the natural mental model "from Monday up to but not including next Monday". Adjacent ranges concatenate without overlap: `A..B` then `B..C` covers `[A, C)` exactly once. Whole-month form stays inclusive both ends because the unit IS the month.

### Skip-existing = natural resume

When `--budget` or `--limit` stops the loop early, just re-run the same command. Already-tagged cards skip in seconds (no API call, no sleep), and the loop picks up from the first un-tagged card. No `--resume` flag, no state file — the card body itself IS the persisted state. KISS.

### Sleep "after, except last"

`--pace` sleeps **after** each successful modify, **never before**, and **never after the last card** — N writes have N-1 gaps. Skip-path cards do not sleep at all (already API-silent). This makes ETA arithmetic clean: `compute_eta writes pace = (writes - 1) * pace`.

### `--dry-run` is not zero-quota

`gh view` is still called per card — state classification (`will-write` / `will-skip` / `will-force-replace`) needs the body. It's `gh edit` that is skipped. Help text and behavior section call this out explicitly so users don't expect a wholly free preview.

### Helpers extracted to `references/`

Both new feature areas have non-trivial parsing/arithmetic logic. Putting them inline in SKILL.md would have pushed the workflow file past readability; extracting them keeps SKILL.md as a workflow narrative and lets the helpers be unit-tested in isolation. Mirror fixtures under `tests/bats/skills/_fixtures/` are the testable copies — drift-prone, so any change to the markdown helpers must update the fixture in lockstep.

## Test plan

- [x] `tests/bats/skills/gh_add_ai_metrics_date.bats` — 27/27 green
- [x] `tests/bats/skills/gh_add_ai_metrics_pace.bats` — 31/31 green
- [x] Existing bats suite — 434/434 green (no regression)
- [x] shellcheck on new fixture `.sh` files — clean
- [x] `help.md` line count — 143 (under 150-line threshold per #338 AC)
- [ ] Reviewer manual: walk through `references/examples.md` nightly-bulk scenario in their head — does the skip-existing resume story hold?

## Acceptance Criteria coverage

### #336

- [x] `--date 26-04` → `created:2026-04-01..2026-04-30` end-to-end
- [x] `--date 26-02` (non-leap) → `2026-02-28`; `24-02` (leap) → `2024-02-29`
- [x] `--date 26-04-30` (8-char) regression-free
- [x] `--help` includes 6-char (5/7) examples
- [x] `--date 26-04 issue#100` mutex error preserved
- [x] `> 100` hits prompt still fires (independent of `--limit`)

### #337

- [x] `--date 26-04` (5) and `2026-04` (7) both → whole month
- [x] `--date A..B` and `A~B` → half-open `[start, end)` (verified via cross-month and cross-year boundary tests)
- [x] Existing single-day forms unchanged
- [x] Invalid lengths/shapes → format error and stop

### #338

- [x] `--pace 3m` sleeps 180s after each modify, not after last, not on skip
- [x] `--limit N` counts modify-only (skips don't advance)
- [x] `--budget <dur>` stops before exceeding (≥ semantics, conservative)
- [x] `--limit` + `--budget` OR composition; stop-reason reported
- [x] `--dry-run` makes zero `gh edit` calls
- [x] Default behavior (no new flags) unchanged
- [x] Bats coverage of all parsing branches and arithmetic
- [x] `--help` shows all 4 flags with format/default/description
- [x] Examples + Notes per spec
- [x] `--help` length ≤ 150 lines (split done at 143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~12 h · 🤖 ~25 min
<!-- /ai-metrics -->
