### PR TITLE
fix(claude-accounts): replace bind mount with per-skill symlink

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -704,7 +704,10 @@ _claude_ensure_bind_mount() {
 _claude_dir_sync_one() {
     _cdso_cdir="$1"
     _cdso_name="$2"
-    _cdso_src_root="${DOTFILES_ROOT}/claude/$_cdso_name"
+    # Fallback parity with claude_mount_skills/claude_init in this file: if
+    # the function is invoked before the dotfiles env loader runs (or in a
+    # crippled login shell), don't construct paths starting at /.
+    _cdso_src_root="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/$_cdso_name"
     _cdso_tgt_root="$_cdso_cdir/$_cdso_name"
     _CLAUDE_DIR_SYNC_LAST_CHANGED=0
     _CLAUDE_DIR_SYNC_LAST_LINKED=0
@@ -778,7 +781,9 @@ _claude_dir_sync_one() {
 _claude_count_dir_sync() {
     _ccds_cdir="$1"
     _ccds_name="$2"
-    _ccds_src_root="${DOTFILES_ROOT}/claude/$_ccds_name"
+    # Same fallback as _claude_dir_sync_one — must agree, otherwise the
+    # ratio would lie about a sync that did happen.
+    _ccds_src_root="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/$_ccds_name"
     _ccds_tgt_root="$_ccds_cdir/$_ccds_name"
 
     _ccds_source=0

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -415,13 +415,14 @@ alias claude-skip='claude --dangerously-skip-permissions'
 # 4. CLAUDE_CONFIG_DIR 환경 주입 + command claude --dangerously-skip-permissions
 claude_yolo() {
     _cy_account="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
+    _cy_no_sync=0
 
     # zsh disables word-splitting; emulate sh inside this function.
     if [ -n "${ZSH_VERSION:-}" ]; then
         emulate -L sh
     fi
 
-    # --user 가로채고 나머지는 위치 인자로 보존 (POSIX 안전)
+    # --user / --no-sync 가로채고 나머지는 위치 인자로 보존 (POSIX 안전)
     set -- "$@" "__CY_END__"
     while [ "$1" != "__CY_END__" ]; do
         case "$1" in
@@ -431,6 +432,10 @@ claude_yolo() {
                 ;;
             --user=*)
                 _cy_account="${1#--user=}"
+                shift
+                ;;
+            --no-sync)
+                _cy_no_sync=1
                 shift
                 ;;
             *)
@@ -476,6 +481,14 @@ claude_yolo() {
     # Opt-in via CLAUDE_ACCOUNT_EMAIL_<account>; silent unless the mapping
     # AND a populated .claude.json AND a mismatch are all present.
     _claude_validate_login "$_cy_config_dir" "$_cy_account"
+
+    # Pre-launch skills/docs sync (issue #342). Silent when in-sync; emits
+    # one line per action when something changed (so the user sees newly
+    # added skills landing without having to run `claude-accounts
+    # skills-sync` themselves). Opt out with `claude-yolo --no-sync ...`.
+    if [ "$_cy_no_sync" = "0" ]; then
+        CLAUDE_SKILLS_SYNC_QUIET=1 claude_skills_sync || true
+    fi
 
     CLAUDE_CONFIG_DIR="$_cy_config_dir" command claude --dangerously-skip-permissions "$@"
 }
@@ -664,7 +677,176 @@ _claude_ensure_bind_mount() {
     fi
 }
 
-# _claude_account_setup_one — 단일 계정의 link/mount 멱등 셋업.
+# _claude_dir_sync_one — per-account, per-dir symlink sync (issue #342).
+#
+# Replaces the bind-mount design: each SSOT entry under
+# "${DOTFILES_ROOT}/claude/<name>" gets an individual symlink under
+# "<cdir>/<name>/<entry>". No sudo, persists across reboot, drift visible
+# via plain `ls -la` / `find -type l`.
+#
+# Args: <cdir> <name>   e.g. "$HOME/.claude-personal" "skills"
+#
+# Behavior (idempotent):
+# 1. Each SSOT entry → ensured as symlink. Real-dir collision → backed up
+#    as "<entry>-pre-sync-<TS>". Stale symlink (wrong target) → replaced.
+# 2. Orphan cleanup: entries in target with no SSOT match. Symlinks →
+#    auto-removed. Real dirs → backed up as "<entry>-orphan-<TS>" (never
+#    auto-deleted; preserves any user data the user dropped here).
+# 3. Backup files (already named *-pre-sync-* / *-orphan-*) are skipped
+#    so re-running the sync does not nest backups.
+#
+# Side effect (return globals — POSIX sh has no array returns):
+#   _CLAUDE_DIR_SYNC_LAST_CHANGED — number of mutating actions
+#   _CLAUDE_DIR_SYNC_LAST_LINKED  — symlinks pointing at correct SSOT entry
+#   _CLAUDE_DIR_SYNC_LAST_SOURCE  — total SSOT entries
+#
+# Silent (no output) when fully in-sync. Otherwise emits one line per action.
+_claude_dir_sync_one() {
+    _cdso_cdir="$1"
+    _cdso_name="$2"
+    _cdso_src_root="${DOTFILES_ROOT}/claude/$_cdso_name"
+    _cdso_tgt_root="$_cdso_cdir/$_cdso_name"
+    _CLAUDE_DIR_SYNC_LAST_CHANGED=0
+    _CLAUDE_DIR_SYNC_LAST_LINKED=0
+    _CLAUDE_DIR_SYNC_LAST_SOURCE=0
+
+    if [ ! -d "$_cdso_src_root" ]; then
+        return 0
+    fi
+
+    mkdir -p "$_cdso_tgt_root"
+    _cdso_ts=$(date +%Y%m%d%H%M%S)
+
+    # Pass 1: ensure each SSOT entry has matching symlink
+    for _cdso_src in "$_cdso_src_root"/*/; do
+        [ -d "$_cdso_src" ] || continue
+        _cdso_basename=$(basename "$_cdso_src")
+        _CLAUDE_DIR_SYNC_LAST_SOURCE=$((_CLAUDE_DIR_SYNC_LAST_SOURCE + 1))
+        _cdso_src_canon="$_cdso_src_root/$_cdso_basename"
+        _cdso_tgt="$_cdso_tgt_root/$_cdso_basename"
+
+        if [ -L "$_cdso_tgt" ]; then
+            _cdso_current=$(readlink "$_cdso_tgt")
+            if [ "$_cdso_current" = "$_cdso_src_canon" ]; then
+                _CLAUDE_DIR_SYNC_LAST_LINKED=$((_CLAUDE_DIR_SYNC_LAST_LINKED + 1))
+                continue
+            fi
+            ux_info "  $_cdso_name/$_cdso_basename: replacing stale symlink"
+            rm "$_cdso_tgt"
+        elif [ -e "$_cdso_tgt" ]; then
+            _cdso_backup="${_cdso_tgt}-pre-sync-${_cdso_ts}"
+            ux_warning "  $_cdso_name/$_cdso_basename: backing up real dir → $(basename "$_cdso_backup")"
+            mv "$_cdso_tgt" "$_cdso_backup"
+        fi
+
+        if ln -s "$_cdso_src_canon" "$_cdso_tgt"; then
+            ux_success "  $_cdso_name/$_cdso_basename: linked"
+            _CLAUDE_DIR_SYNC_LAST_LINKED=$((_CLAUDE_DIR_SYNC_LAST_LINKED + 1))
+            _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
+        else
+            ux_error "  $_cdso_name/$_cdso_basename: ln -s failed"
+        fi
+    done
+
+    # Pass 2: orphan cleanup — entries in target that no longer match SSOT
+    for _cdso_entry in "$_cdso_tgt_root"/*; do
+        [ -e "$_cdso_entry" ] || [ -L "$_cdso_entry" ] || continue
+        _cdso_ename=$(basename "$_cdso_entry")
+        case "$_cdso_ename" in
+            *-pre-sync-*|*-orphan-*) continue ;;
+        esac
+        [ -d "$_cdso_src_root/$_cdso_ename" ] && continue
+
+        if [ -L "$_cdso_entry" ]; then
+            if rm "$_cdso_entry"; then
+                ux_info "  $_cdso_name/$_cdso_ename: removed orphan symlink"
+                _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
+            fi
+        else
+            _cdso_obackup="${_cdso_entry}-orphan-${_cdso_ts}"
+            if mv "$_cdso_entry" "$_cdso_obackup"; then
+                ux_warning "  $_cdso_name/$_cdso_ename: orphan dir → $(basename "$_cdso_obackup")"
+                _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
+            fi
+        fi
+    done
+}
+
+# _claude_count_dir_sync — print "<linked>|<source>" counts for one
+# account/dirname. Used by claude_accounts_status to display drift ratio.
+# Read-only; never mutates.
+_claude_count_dir_sync() {
+    _ccds_cdir="$1"
+    _ccds_name="$2"
+    _ccds_src_root="${DOTFILES_ROOT}/claude/$_ccds_name"
+    _ccds_tgt_root="$_ccds_cdir/$_ccds_name"
+
+    _ccds_source=0
+    if [ -d "$_ccds_src_root" ]; then
+        for _ccds_s in "$_ccds_src_root"/*/; do
+            [ -d "$_ccds_s" ] || continue
+            _ccds_source=$((_ccds_source + 1))
+        done
+    fi
+
+    _ccds_linked=0
+    if [ -d "$_ccds_tgt_root" ]; then
+        for _ccds_t in "$_ccds_tgt_root"/*; do
+            [ -L "$_ccds_t" ] || continue
+            _ccds_n=$(basename "$_ccds_t")
+            [ -d "$_ccds_src_root/$_ccds_n" ] || continue
+            _ccds_real=$(readlink "$_ccds_t")
+            if [ "$_ccds_real" = "$_ccds_src_root/$_ccds_n" ]; then
+                _ccds_linked=$((_ccds_linked + 1))
+            fi
+        done
+    fi
+
+    echo "$_ccds_linked|$_ccds_source"
+}
+
+# claude_skills_sync — public entry: sync skills + docs across all enabled
+# accounts via per-skill symlinks. Replaces the legacy bind-mount approach
+# (issue #342). Idempotent — second run reports "no changes".
+#
+# Quiet mode: set CLAUDE_SKILLS_SYNC_QUIET=1 to suppress header/summary
+# (per-action output is preserved so changes remain visible).
+claude_skills_sync() {
+    if [ -n "${ZSH_VERSION:-}" ]; then
+        emulate -L sh
+    fi
+
+    if [ -z "${CLAUDE_SKILLS_SYNC_QUIET:-}" ]; then
+        ux_header "Claude Skills Sync"
+    fi
+
+    _css_total=0
+    for _css_acct in $(_claude_resolve_account --list); do
+        _css_cdir=$(_claude_resolve_account "$_css_acct")
+        [ -d "$_css_cdir" ] || continue
+
+        if [ -z "${CLAUDE_SKILLS_SYNC_QUIET:-}" ]; then
+            ux_section "Account: $_css_acct ($_css_cdir)"
+        fi
+
+        _claude_dir_sync_one "$_css_cdir" skills
+        _css_total=$((_css_total + _CLAUDE_DIR_SYNC_LAST_CHANGED))
+        _claude_dir_sync_one "$_css_cdir" docs
+        _css_total=$((_css_total + _CLAUDE_DIR_SYNC_LAST_CHANGED))
+    done
+
+    if [ "$_css_total" -eq 0 ]; then
+        if [ -z "${CLAUDE_SKILLS_SYNC_QUIET:-}" ]; then
+            ux_info "(no changes — skills/docs already in sync)"
+        fi
+    else
+        ux_success "skills/docs sync: $_css_total change(s)"
+    fi
+    return 0
+}
+alias claude-skills-sync='claude_skills_sync'
+
+# _claude_account_setup_one — 단일 계정의 link/sync 멱등 셋업.
 _claude_account_setup_one() {
     _caso_acct="$1"
     _caso_cdir="$2"
@@ -678,14 +860,12 @@ _claude_account_setup_one() {
     _claude_ensure_symlink "$HOME/.claude-shared/plugins"                   "$_caso_cdir/plugins"
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/global-memory"          "$_caso_cdir/projects/GLOBAL/memory"
 
-    if [ "${CLAUDE_SKIP_BIND_MOUNT:-0}" = "1" ]; then
-        # Visible warning, not info — production users may misuse this and
-        # silently lose bind mounts. Test harness sees the warning too.
-        ux_warning "  (CLAUDE_SKIP_BIND_MOUNT=1 → skipping bind mounts)"
-    else
-        _claude_ensure_bind_mount "${DOTFILES_ROOT}/claude/skills"  "$_caso_cdir/skills"
-        _claude_ensure_bind_mount "${DOTFILES_ROOT}/claude/docs"    "$_caso_cdir/docs"
-    fi
+    # Per-skill / per-doc symlinks (issue #342). Replaces the legacy bind
+    # mount: no sudo, persists across reboot, no silent regression when
+    # mount drops. CLAUDE_SKIP_BIND_MOUNT is preserved as a no-op for
+    # backward compat with existing test harnesses.
+    _claude_dir_sync_one "$_caso_cdir" skills
+    _claude_dir_sync_one "$_caso_cdir" docs
 }
 
 # _claude_status_show_oauth — append OAuth binding (email/org) to the
@@ -778,11 +958,19 @@ claude_accounts_status() {
             fi
         done
 
-        for _cas_mount in skills docs; do
-            if _is_mounted "$_cas_cdir/$_cas_mount"; then
-                echo "  $_cas_mount: bind mount ✓"
+        # Skills/docs sync ratio (issue #342) — replaces the legacy bind
+        # mount status. `linked/source ✓` when fully synced, `(drift)`
+        # marker + recovery hint when partial.
+        for _cas_dir in skills docs; do
+            _cas_ratio=$(_claude_count_dir_sync "$_cas_cdir" "$_cas_dir")
+            _cas_linked=${_cas_ratio%|*}
+            _cas_source=${_cas_ratio#*|}
+            if [ "$_cas_source" -eq 0 ]; then
+                echo "  $_cas_dir: source missing ✗"
+            elif [ "$_cas_linked" -eq "$_cas_source" ]; then
+                echo "  $_cas_dir: $_cas_linked/$_cas_source ✓"
             else
-                echo "  $_cas_mount: ✗ not mounted"
+                echo "  $_cas_dir: $_cas_linked/$_cas_source ⚠️  (run: claude-accounts skills-sync)"
             fi
         done
         echo ""
@@ -927,11 +1115,12 @@ _claude_accounts_help() {
     ux_info "Usage: claude-accounts [<subcommand>]"
     ux_info ""
     ux_info "Subcommands:"
-    ux_info "  status     (default) Show all accounts: path/credentials/symlinks/mounts"
-    ux_info "  list       List enabled accounts"
-    ux_info "  setup      Idempotent setup (creates dirs, symlinks, bind mounts)"
-    ux_info "  migrate    One-time migration: ~/.claude → ~/.claude-personal (Home-PC)"
-    ux_info "  -h|--help  This help"
+    ux_info "  status        (default) Show all accounts: path/credentials/symlinks/sync"
+    ux_info "  list          List enabled accounts"
+    ux_info "  setup         Idempotent setup (creates dirs + symlinks)"
+    ux_info "  skills-sync   Re-sync skills/docs symlinks across all enabled accounts"
+    ux_info "  migrate       One-time migration: ~/.claude → ~/.claude-personal (Home-PC)"
+    ux_info "  -h|--help     This help"
     ux_info ""
     ux_info "Env vars:"
     ux_info "  CLAUDE_DEFAULT_ACCOUNT     Default for \`claude-yolo\` (default: personal)"
@@ -944,6 +1133,7 @@ claude_accounts() {
         status)         claude_accounts_status ;;
         list)           _claude_resolve_account --list ;;
         setup)          claude_accounts_init ;;
+        skills-sync)    claude_skills_sync ;;
         migrate)        claude_accounts_migrate ;;
         -h|--help|help) _claude_accounts_help ;;
         *)              ux_error "Unknown subcommand: $1"; _claude_accounts_help; return 1 ;;

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -730,3 +730,202 @@ JSON
     assert_success
     refute_output --partial "Account mismatch"
 }
+
+# ---------- Issue #342: skills/docs sync via per-skill symlinks ----------
+#
+# Replaces the legacy bind mount with idempotent per-skill symlinks. Five
+# acceptance scenarios from the issue + status ratio + sub-command wiring.
+
+# Stage a FAKE_DOTFILES_ROOT under $HOME with skills/<name>/SKILL.md fixtures.
+# bash/main.bash unconditionally re-derives DOTFILES_ROOT from its own path
+# (see bash/main.bash:59), so setup_isolated_dotfiles_root cannot survive a
+# run_in_bash. Instead we override DOTFILES_ROOT *after* main.bash sources —
+# claude.sh reads ${DOTFILES_ROOT} at call time, not load time, so the
+# override takes effect for the function call under test.
+_seed_ssot_skills() {
+    export FAKE_DOTFILES_ROOT="$HOME/fake-dotfiles"
+    rm -rf "$FAKE_DOTFILES_ROOT"
+    mkdir -p "$FAKE_DOTFILES_ROOT/claude/skills" "$FAKE_DOTFILES_ROOT/claude/docs"
+    for _skill in "$@"; do
+        mkdir -p "$FAKE_DOTFILES_ROOT/claude/skills/${_skill}"
+        printf -- '---\nname: %s\ndescription: stub for %s\n---\n' "$_skill" "$_skill" \
+            > "$FAKE_DOTFILES_ROOT/claude/skills/${_skill}/SKILL.md"
+    done
+}
+
+# Wrap run_in_bash with a DOTFILES_ROOT override for the seeded fake root.
+run_with_fake_ssot() {
+    run_in_bash "export DOTFILES_ROOT='$FAKE_DOTFILES_ROOT'; $1"
+}
+
+@test "issue #342: empty target → SSOT skills become symlinks" {
+    _seed_ssot_skills alpha beta gamma
+    mkdir -p "$HOME/.claude-personal"
+
+    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal _claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    for s in alpha beta gamma; do
+        [ -L "$HOME/.claude-personal/skills/$s" ]
+        [ "$(readlink "$HOME/.claude-personal/skills/$s")" = "$FAKE_DOTFILES_ROOT/claude/skills/$s" ]
+    done
+}
+
+@test "issue #342: real-dir collision is backed up to *-pre-sync-* and replaced" {
+    _seed_ssot_skills cli-dev
+    mkdir -p "$HOME/.claude-personal/skills/cli-dev"
+    echo "stale-content" > "$HOME/.claude-personal/skills/cli-dev/local-file.md"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    [ -L "$HOME/.claude-personal/skills/cli-dev" ]
+    # Backup directory present with the user's local file preserved
+    local_backup=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* 2>/dev/null | head -1)
+    [ -n "$local_backup" ]
+    [ -f "$local_backup/local-file.md" ]
+}
+
+@test "issue #342: stale symlink (wrong target) is replaced with correct one" {
+    _seed_ssot_skills cli-dev
+    mkdir -p "$HOME/.claude-personal/skills" "$HOME/elsewhere/cli-dev"
+    ln -s "$HOME/elsewhere/cli-dev" "$HOME/.claude-personal/skills/cli-dev"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    [ -L "$HOME/.claude-personal/skills/cli-dev" ]
+    [ "$(readlink "$HOME/.claude-personal/skills/cli-dev")" = "$FAKE_DOTFILES_ROOT/claude/skills/cli-dev" ]
+}
+
+@test "issue #342: orphan symlink (no SSOT match) is auto-removed" {
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal/skills" "$HOME/leftover"
+    ln -s "$HOME/leftover" "$HOME/.claude-personal/skills/removed-skill"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    [ ! -e "$HOME/.claude-personal/skills/removed-skill" ]
+    [ ! -L "$HOME/.claude-personal/skills/removed-skill" ]
+}
+
+@test "issue #342: orphan REAL dir is backed up to *-orphan-*, never deleted" {
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal/skills/user-data-dont-touch"
+    echo "important" > "$HOME/.claude-personal/skills/user-data-dont-touch/keep.txt"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    [ ! -d "$HOME/.claude-personal/skills/user-data-dont-touch" ]
+    orphan_backup=$(ls -d "$HOME/.claude-personal/skills/"user-data-dont-touch-orphan-* 2>/dev/null | head -1)
+    [ -n "$orphan_backup" ]
+    [ -f "$orphan_backup/keep.txt" ]
+    grep -q "important" "$orphan_backup/keep.txt"
+}
+
+@test "issue #342: second run is a no-op (idempotent — 0 changes)" {
+    _seed_ssot_skills alpha beta
+    mkdir -p "$HOME/.claude-personal"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "FIRST_CHANGED=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
+    assert_success
+    assert_output --partial "FIRST_CHANGED=2"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "SECOND_CHANGED=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
+    assert_success
+    assert_output --partial "SECOND_CHANGED=0"
+}
+
+@test "issue #342: claude-skills-sync alias triggers sync across enabled accounts" {
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal" "$HOME/.claude-work"
+
+    run_with_fake_ssot 'shopt -s expand_aliases; eval "claude-skills-sync"'
+    assert_success
+    [ -L "$HOME/.claude-personal/skills/alpha" ]
+    [ -L "$HOME/.claude-work/skills/alpha" ]
+}
+
+@test "issue #342: claude-accounts skills-sync sub-command works" {
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal"
+
+    run_with_fake_ssot 'shopt -s expand_aliases; eval "claude-accounts skills-sync"'
+    assert_success
+    [ -L "$HOME/.claude-personal/skills/alpha" ]
+}
+
+@test "issue #342: second claude-skills-sync prints (no changes)" {
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal" "$HOME/.claude-work"
+
+    run_with_fake_ssot 'claude_skills_sync >/dev/null; claude_skills_sync'
+    assert_success
+    assert_output --partial "no changes"
+}
+
+@test "issue #342: claude_accounts_status shows skills sync ratio" {
+    _seed_ssot_skills alpha beta
+    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init >/dev/null && CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
+    assert_success
+    assert_output --partial "skills: 2/2 ✓"
+}
+
+@test "issue #342: claude_accounts_status flags drift when symlinks missing" {
+    _seed_ssot_skills alpha beta gamma
+    # Set up only one of three symlinks → ratio shows 1/3 with drift marker.
+    mkdir -p "$HOME/.claude-personal/skills"
+    ln -s "$FAKE_DOTFILES_ROOT/claude/skills/alpha" "$HOME/.claude-personal/skills/alpha"
+
+    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
+    assert_success
+    assert_output --partial "skills: 1/3"
+    assert_output --partial "claude-accounts skills-sync"
+}
+
+@test "issue #342: claude_yolo --no-sync skips auto-sync" {
+    _setup_claude_mock
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal"
+
+    run_with_fake_ssot "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --no-sync"
+    assert_success
+    [ ! -e "$HOME/.claude-personal/skills/alpha" ]
+}
+
+@test "issue #342: claude_yolo auto-syncs by default" {
+    _setup_claude_mock
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal"
+
+    run_with_fake_ssot "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    [ -L "$HOME/.claude-personal/skills/alpha" ]
+}
+
+@test "issue #342: claude-accounts help mentions skills-sync sub-command" {
+    run_in_bash 'shopt -s expand_aliases; eval "claude-accounts -h"'
+    assert_success
+    assert_output --partial "skills-sync"
+}
+
+@test "issue #342: re-running sync does NOT nest pre-sync backups" {
+    _seed_ssot_skills cli-dev
+    mkdir -p "$HOME/.claude-personal/skills/cli-dev"
+    echo "first-run-content" > "$HOME/.claude-personal/skills/cli-dev/x.md"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+    # Sleep 1 to ensure a new TS would differ; then run again — Pass 2 must
+    # skip *-pre-sync-* entries so they don't get -orphan- nested.
+    sleep 1
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    backups=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* 2>/dev/null | wc -l)
+    [ "$backups" -eq 1 ]
+    nested=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-*-orphan-* 2>/dev/null | wc -l)
+    [ "$nested" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Replaces the bind-mount design for `~/.claude-{personal,work}/skills` with per-skill symlinks pointing into the dotfiles SSOT (`~/dotfiles/claude/skills/`). Closes #342.
- Adds `claude_skills_sync` (alias `claude-skills-sync`, sub-command `claude-accounts skills-sync`) as the 1-shot recovery + drift-fix entry point.
- Updates `claude_accounts_status` to show `skills: <linked>/<source> ✓` (or ⚠️ + recovery hint on drift) instead of the legacy bind-mount line.
- `claude_yolo` auto-syncs silently on launch; `--no-sync` opts out.

## Why

Home-PC observation (2026-05-06): `~/.claude-personal/skills/` had 10 stale real dirs from migration time, `~/dotfiles/claude/skills/` had grown to 56 — the bind mount had dropped without anyone noticing. Symlinks fix the silent regression: no sudo, reboot-safe, drift detectable with `ls -la`.

Behavior summary (per issue acceptance criteria):

- Each SSOT skill → symlink at `~/.claude-<acct>/skills/<name>`
- Real-dir collision → backed up to `<name>-pre-sync-<TS>`, replaced with symlink
- Stale symlinks (wrong target) → replaced
- Orphan symlinks (no SSOT match) → auto-removed
- Orphan real dirs → `<name>-orphan-<TS>` backup only (never auto-deleted)
- Idempotent — second run reports `(no changes)`
- Same logic applied to `docs/` for parity

## Test plan

- [x] 15 new bats covering the 5 acceptance scenarios + CLI wiring + status ratio + `--no-sync` opt-out + nested-backup guard
- [x] `tests/bats/integrations/claude_accounts.bats` — 78/78 pass
- [x] Full bats suite (507 tests) — all pass, exit 0
- [x] zsh smoke test of `_claude_dir_sync_one` (POSIX `emulate -L sh` parity)
- [x] shellcheck — no new warnings in added code
- [ ] Manual on Home-PC after merge: run `claude-accounts skills-sync` once, verify `claude-accounts status` shows `skills: 56/56 ✓`

🤖 Generated with [Claude Code](https://claude.com/claude-code)