### PR TITLE
fix(shell-common): retry gh_project_status auto-detect on flake

### DIFF
--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -70,19 +70,21 @@ _gh_project_status_sync() {
             ;;
     esac
 
-    # Resolve owner/repo via gh.
-    local _owner _repo
-    if ! read -r _owner _repo <<EOF
-$(gh repo view --json owner,name --jq '"\(.owner.login) \(.name)"' 2>/dev/null)
-EOF
-    then
-        printf '[gh-project-status] could not determine owner/repo, skipping\n' >&2
-        return 0
+    # Resolve owner/repo via gh, with one 5s retry on transient failure
+    # (e.g. graphql socket reset). Mirrors the mutation step's retry —
+    # without it, a single transient `gh repo view` flake silently aborts
+    # the whole sync (issue #341). Override _GH_PROJECT_STATUS_RETRY_SLEEP
+    # in tests to skip the wait.
+    local _owner _repo _resolved
+    if ! _resolved=$(_gh_project_status_resolve_owner_repo); then
+        sleep "${_GH_PROJECT_STATUS_RETRY_SLEEP-5}"
+        if ! _resolved=$(_gh_project_status_resolve_owner_repo); then
+            printf '[gh-project-status] could not determine owner/repo, skipping\n' >&2
+            return 0
+        fi
     fi
-    if [ -z "$_owner" ] || [ -z "$_repo" ]; then
-        printf '[gh-project-status] could not determine owner/repo, skipping\n' >&2
-        return 0
-    fi
+    _owner="${_resolved%% *}"
+    _repo="${_resolved#* }"
 
     # Single query: per projectV2 item, return
     #   project.id | item.id | field.id | target_option.id | current_status_name
@@ -163,6 +165,28 @@ EOF
 $_records
 EOF
 
+    return 0
+}
+
+# Resolve cwd's GitHub owner/repo via `gh repo view`. Prints
+# "<owner> <repo>" on success; returns non-zero on failure (gh exit,
+# empty output, or partial output). Extracted so the auto-detect step in
+# _gh_project_status_sync can mirror the mutation step's single-retry
+# pattern (issue #341): without retry, one transient `gh repo view`
+# socket reset silently aborts the sync.
+_gh_project_status_resolve_owner_repo() {
+    local _output _owner _repo
+    _output=$(gh repo view --json owner,name --jq '"\(.owner.login) \(.name)"' 2>/dev/null) || return 1
+    [ -z "$_output" ] && return 1
+    if ! read -r _owner _repo <<EOF
+$_output
+EOF
+    then
+        return 1
+    fi
+    [ -z "$_owner" ] && return 1
+    [ -z "$_repo" ] && return 1
+    printf '%s %s\n' "$_owner" "$_repo"
     return 0
 }
 

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -94,6 +94,19 @@ _run_closing_issues_bash() {
     assert_output --partial "ok"
 }
 
+@test "bash: _gh_project_status_resolve_owner_repo helper exists" {
+    # Extracted in #341 so the auto-detect step can be retried once on flake.
+    run_in_bash 'declare -f _gh_project_status_resolve_owner_repo >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_project_status_resolve_owner_repo helper exists" {
+    run_in_zsh 'typeset -f _gh_project_status_resolve_owner_repo >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
 # ---------------------------------------------------------------------------
 # Opt-out guards
 # ---------------------------------------------------------------------------
@@ -265,4 +278,109 @@ _run_closing_issues_bash() {
     assert_success
     assert_output --partial "rc=0"
     refute_output --partial "Unknown JSON field"
+}
+
+# ---------------------------------------------------------------------------
+# _gh_project_status_resolve_owner_repo — issue #341 (auto-detect retry)
+# ---------------------------------------------------------------------------
+#
+# A stateful fake `gh` covers the retry-on-flake path. The shim records each
+# invocation in a counter file so a single bash subprocess sees deterministic
+# pass/fail sequences, mirroring how a real graphql connection-reset would be
+# observed by the helper (one transient failure followed by recovery).
+
+_setup_fake_gh_repo_view() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    FAKE_GH_COUNTER="$TEST_TEMP_HOME/fake_gh_calls"
+    mkdir -p "$STUB_BIN"
+    : >"$FAKE_GH_COUNTER"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Only the `gh repo view --json owner,name --jq ...` shape used by
+# _gh_project_status_resolve_owner_repo is exercised here.
+COUNTER="${FAKE_GH_COUNTER:?FAKE_GH_COUNTER not set}"
+n=$(wc -l <"$COUNTER" 2>/dev/null | tr -d ' ')
+n=$((n + 1))
+echo "$n" >>"$COUNTER"
+case "${FAKE_GH_REPO_MODE:-ok}" in
+    ok)            echo "owner reponame" ; exit 0 ;;
+    empty)         exit 0 ;;
+    error)         echo "graphql: connection reset" >&2 ; exit 1 ;;
+    flake_then_ok) [ "$n" -ge 2 ] && { echo "owner reponame" ; exit 0 ; } ; exit 1 ;;
+    flake_twice)   exit 1 ;;
+    *)             exit 0 ;;
+esac
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run a snippet in a bash subshell with fake gh on PATH and counter env wired.
+# Mirrors _run_closing_issues_bash but exposes FAKE_GH_REPO_MODE +
+# FAKE_GH_COUNTER and forwards the counter so cross-call state is visible.
+_run_resolve_bash() {
+    local mode="$1" snippet="$2"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_GH_REPO_MODE='${mode}'
+        export FAKE_GH_COUNTER='${FAKE_GH_COUNTER}'
+        export _GH_PROJECT_STATUS_RETRY_SLEEP=0
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        ${snippet}
+    "
+}
+
+@test "resolve: prints owner repo on success" {
+    _setup_fake_gh_repo_view
+    _run_resolve_bash ok '_gh_project_status_resolve_owner_repo; echo "rc=$?"'
+    assert_success
+    assert_output --partial "owner reponame"
+    assert_output --partial "rc=0"
+}
+
+@test "resolve: empty gh output returns failure" {
+    _setup_fake_gh_repo_view
+    _run_resolve_bash empty '_gh_project_status_resolve_owner_repo; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "resolve: gh non-zero exit returns failure" {
+    _setup_fake_gh_repo_view
+    _run_resolve_bash error '_gh_project_status_resolve_owner_repo 2>/dev/null; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "sync auto-detect: retries once and recovers on transient failure" {
+    # Regression for #341 — first `gh repo view` fails (simulated socket
+    # reset), second succeeds. With the retry in place the helper should
+    # proceed past auto-detect into the graphql query stage; that stage
+    # is faked to return zero records so the sync exits with the
+    # "not in any project" branch (proves we got past auto-detect).
+    _setup_fake_gh_repo_view
+    _run_resolve_bash flake_then_ok '_gh_project_status_sync issue 42 "In progress" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "could not determine owner/repo"
+    # Counter records each gh invocation: 2 for repo view (fail+ok) plus 1
+    # for the graphql query that fakes back empty.
+    run cat "$FAKE_GH_COUNTER"
+    [ "${#lines[@]}" -ge 2 ]
+}
+
+@test "sync auto-detect: stays fail-quiet when both attempts fail" {
+    _setup_fake_gh_repo_view
+    _run_resolve_bash flake_twice '_gh_project_status_sync issue 42 "In progress" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "could not determine owner/repo, skipping"
+    # Counter must show exactly 2 invocations — one initial, one retry.
+    run cat "$FAKE_GH_COUNTER"
+    [ "${#lines[@]}" -eq 2 ]
 }


### PR DESCRIPTION
## Summary
- `gh_project_status_sync` 의 owner/repo auto-detect 단계가 transient `gh repo view` 실패에 retry 없이 silent fail 해, 보드 동기화 1회 절단으로 PR 카드가 `Backlog` 에 멈추던 문제를 수정.
- mutation 단계와 동일한 5초 backoff·1회 retry 패턴을 auto-detect 단계에도 도입해 비대칭을 제거.
- 회귀 방지용 bats 케이스 추가 (resolver 단위 + sync 통합 retry 경로).

## Changes
- `shell-common/functions/gh_project_status.sh`: `_gh_project_status_resolve_owner_repo` helper 추출, sync 진입부에서 1회 retry 로 감싼 호출로 교체. retry sleep 은 `_GH_PROJECT_STATUS_RETRY_SLEEP` 로 테스트에서 0 으로 오버라이드 가능 (mutation 측 `sleep 5` 와의 비대칭 해소).
- `tests/bats/functions/gh_project_status.bats`: helper 존재(bash/zsh) + resolver 성공/empty/error 단위 + stateful fake `gh` 로 retry recovery / 두 번 모두 실패 시 fail-quiet 를 검증하는 5종 케이스 추가.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_project_status.bats` (33/33 ok)
- [x] `tox -e bats` (441/441 ok)
- [x] `tox -e shellcheck` (clean)
- [ ] PR 머지 후 다음 `/gh-pr` 호출 시 `gh-pr` Step 7 의 `could not determine owner/repo, skipping` 메시지가 더 이상 보이지 않는지 운영 환경에서 확인

## Related
Closes #341

---
<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->
