### PR TITLE
fix(claude-accounts): move sync backups out of skill scanner view (#344)

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -688,12 +688,24 @@ _claude_ensure_bind_mount() {
 #
 # Behavior (idempotent):
 # 1. Each SSOT entry → ensured as symlink. Real-dir collision → backed up
-#    as "<entry>-pre-sync-<TS>". Stale symlink (wrong target) → replaced.
+#    to "<cdir>/.sync-backup/<name>/<entry>-pre-sync-<TS>". Stale symlink
+#    (wrong target) → replaced.
 # 2. Orphan cleanup: entries in target with no SSOT match. Symlinks →
-#    auto-removed. Real dirs → backed up as "<entry>-orphan-<TS>" (never
-#    auto-deleted; preserves any user data the user dropped here).
-# 3. Backup files (already named *-pre-sync-* / *-orphan-*) are skipped
-#    so re-running the sync does not nest backups.
+#    auto-removed. Real dirs → backed up to
+#    "<cdir>/.sync-backup/<name>/<entry>-orphan-<TS>" (never auto-deleted;
+#    preserves any user data the user dropped here).
+# 3. Pre-step migration: any pre-existing legacy backup at
+#    "<cdir>/<name>/*-pre-sync-*" / "*-orphan-*" (created by older
+#    versions of this function) is moved to "<cdir>/.sync-backup/<name>/"
+#    so the Claude Code skill scanner stops indexing backups as skills
+#    (issue #344). Idempotent — no-op once migrated.
+#
+# Backup location rationale (issue #344): the Claude Code skill scanner
+# treats every directory under "<cdir>/skills/" as a skill candidate, so
+# placing backups inside "<cdir>/skills/" caused duplicate skills like
+# "cli-dev" + "cli-dev-pre-sync-<TS>" to appear in available-skills.
+# "<cdir>/.sync-backup/<name>/" sits outside the scanner's view while
+# remaining co-located for easy `ls`-driven discovery.
 #
 # Side effect (return globals — POSIX sh has no array returns):
 #   _CLAUDE_DIR_SYNC_LAST_CHANGED — number of mutating actions
@@ -709,6 +721,7 @@ _claude_dir_sync_one() {
     # crippled login shell), don't construct paths starting at /.
     _cdso_src_root="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/$_cdso_name"
     _cdso_tgt_root="$_cdso_cdir/$_cdso_name"
+    _cdso_backup_root="$_cdso_cdir/.sync-backup/$_cdso_name"
     _CLAUDE_DIR_SYNC_LAST_CHANGED=0
     _CLAUDE_DIR_SYNC_LAST_LINKED=0
     _CLAUDE_DIR_SYNC_LAST_SOURCE=0
@@ -719,6 +732,20 @@ _claude_dir_sync_one() {
 
     mkdir -p "$_cdso_tgt_root"
     _cdso_ts=$(date +%Y%m%d%H%M%S)
+
+    # Pre-step: migrate legacy backups out of the scanner's view (issue #344).
+    # Older versions placed *-pre-sync-* / *-orphan-* directly under
+    # "<cdir>/<name>/", which Claude Code indexed as duplicate skills.
+    # Idempotent: only moves entries that still live in the legacy location.
+    for _cdso_legacy in "$_cdso_tgt_root"/*-pre-sync-* "$_cdso_tgt_root"/*-orphan-*; do
+        [ -e "$_cdso_legacy" ] || [ -L "$_cdso_legacy" ] || continue
+        mkdir -p "$_cdso_backup_root"
+        _cdso_legacy_name=$(basename "$_cdso_legacy")
+        if mv "$_cdso_legacy" "$_cdso_backup_root/$_cdso_legacy_name"; then
+            ux_info "  $_cdso_name/$_cdso_legacy_name: migrated legacy backup → .sync-backup/$_cdso_name/"
+            _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
+        fi
+    done
 
     # Pass 1: ensure each SSOT entry has matching symlink
     for _cdso_src in "$_cdso_src_root"/*/; do
@@ -737,8 +764,9 @@ _claude_dir_sync_one() {
             ux_info "  $_cdso_name/$_cdso_basename: replacing stale symlink"
             rm "$_cdso_tgt"
         elif [ -e "$_cdso_tgt" ]; then
-            _cdso_backup="${_cdso_tgt}-pre-sync-${_cdso_ts}"
-            ux_warning "  $_cdso_name/$_cdso_basename: backing up real dir → $(basename "$_cdso_backup")"
+            mkdir -p "$_cdso_backup_root"
+            _cdso_backup="$_cdso_backup_root/${_cdso_basename}-pre-sync-${_cdso_ts}"
+            ux_warning "  $_cdso_name/$_cdso_basename: backing up real dir → .sync-backup/$_cdso_name/$(basename "$_cdso_backup")"
             mv "$_cdso_tgt" "$_cdso_backup"
         fi
 
@@ -751,7 +779,10 @@ _claude_dir_sync_one() {
         fi
     done
 
-    # Pass 2: orphan cleanup — entries in target that no longer match SSOT
+    # Pass 2: orphan cleanup — entries in target that no longer match SSOT.
+    # The *-pre-sync-* / *-orphan-* skip is defensive: backups now live in
+    # .sync-backup/<name>/ (issue #344) so should never appear here, but
+    # the guard remains in case a leftover somehow lands in the scan dir.
     for _cdso_entry in "$_cdso_tgt_root"/*; do
         [ -e "$_cdso_entry" ] || [ -L "$_cdso_entry" ] || continue
         _cdso_ename=$(basename "$_cdso_entry")
@@ -766,9 +797,10 @@ _claude_dir_sync_one() {
                 _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
             fi
         else
-            _cdso_obackup="${_cdso_entry}-orphan-${_cdso_ts}"
+            mkdir -p "$_cdso_backup_root"
+            _cdso_obackup="$_cdso_backup_root/${_cdso_ename}-orphan-${_cdso_ts}"
             if mv "$_cdso_entry" "$_cdso_obackup"; then
-                ux_warning "  $_cdso_name/$_cdso_ename: orphan dir → $(basename "$_cdso_obackup")"
+                ux_warning "  $_cdso_name/$_cdso_ename: orphan dir → .sync-backup/$_cdso_name/$(basename "$_cdso_obackup")"
                 _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
             fi
         fi

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -780,10 +780,13 @@ run_with_fake_ssot() {
     assert_success
 
     [ -L "$HOME/.claude-personal/skills/cli-dev" ]
-    # Backup directory present with the user's local file preserved
-    local_backup=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* 2>/dev/null | head -1)
+    # Backup directory present (under .sync-backup/, issue #344) with the
+    # user's local file preserved.
+    local_backup=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"cli-dev-pre-sync-* 2>/dev/null | head -1)
     [ -n "$local_backup" ]
     [ -f "$local_backup/local-file.md" ]
+    # Issue #344: backup must NOT live alongside the skill in skills/.
+    ! ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* >/dev/null 2>&1
 }
 
 @test "issue #342: stale symlink (wrong target) is replaced with correct one" {
@@ -819,10 +822,13 @@ run_with_fake_ssot() {
     assert_success
 
     [ ! -d "$HOME/.claude-personal/skills/user-data-dont-touch" ]
-    orphan_backup=$(ls -d "$HOME/.claude-personal/skills/"user-data-dont-touch-orphan-* 2>/dev/null | head -1)
+    # Backup lives under .sync-backup/ (issue #344), not skills/.
+    orphan_backup=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"user-data-dont-touch-orphan-* 2>/dev/null | head -1)
     [ -n "$orphan_backup" ]
     [ -f "$orphan_backup/keep.txt" ]
     grep -q "important" "$orphan_backup/keep.txt"
+    # Issue #344: orphan backup must NOT pollute the skill scanner directory.
+    ! ls -d "$HOME/.claude-personal/skills/"user-data-dont-touch-orphan-* >/dev/null 2>&1
 }
 
 @test "issue #342: second run is a no-op (idempotent — 0 changes)" {
@@ -924,8 +930,83 @@ run_with_fake_ssot() {
     run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
     assert_success
 
-    backups=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* 2>/dev/null | wc -l)
+    # Backups land under .sync-backup/ (issue #344). Exactly one backup,
+    # no nested -orphan- chain.
+    backups=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"cli-dev-pre-sync-* 2>/dev/null | wc -l)
     [ "$backups" -eq 1 ]
-    nested=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-*-orphan-* 2>/dev/null | wc -l)
+    nested=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"cli-dev-pre-sync-*-orphan-* 2>/dev/null | wc -l)
     [ "$nested" -eq 0 ]
+    # And nothing leaks back into the scan dir.
+    leaked=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* 2>/dev/null | wc -l)
+    [ "$leaked" -eq 0 ]
+}
+
+# ---------- Issue #344: backups outside the skill scanner ----------
+
+@test "issue #344: skills/ stays free of *-pre-sync-* / *-orphan-* siblings" {
+    _seed_ssot_skills alpha
+    # Trigger BOTH backup branches: real-dir collision (Pass 1) and
+    # orphan real dir (Pass 2).
+    mkdir -p "$HOME/.claude-personal/skills/alpha"          # collision
+    echo "x" > "$HOME/.claude-personal/skills/alpha/x.md"
+    mkdir -p "$HOME/.claude-personal/skills/orphan-real"    # orphan
+    echo "y" > "$HOME/.claude-personal/skills/orphan-real/y.md"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    # The scan-visible directory contains only real SSOT-linked skills.
+    # Anything matching the backup naming convention is a regression of
+    # the issue #344 symptom (duplicate "<name>-pre-sync-<TS>" skills in
+    # available-skills).
+    leaked_pre=$(find "$HOME/.claude-personal/skills/" -maxdepth 1 -name '*-pre-sync-*' 2>/dev/null | wc -l)
+    leaked_orphan=$(find "$HOME/.claude-personal/skills/" -maxdepth 1 -name '*-orphan-*' 2>/dev/null | wc -l)
+    [ "$leaked_pre" -eq 0 ]
+    [ "$leaked_orphan" -eq 0 ]
+
+    # And both backup payloads are recoverable from .sync-backup/.
+    [ -d "$HOME/.claude-personal/.sync-backup/skills" ]
+    [ "$(find "$HOME/.claude-personal/.sync-backup/skills/" -maxdepth 1 -name '*-pre-sync-*' | wc -l)" -ge 1 ]
+    [ "$(find "$HOME/.claude-personal/.sync-backup/skills/" -maxdepth 1 -name '*-orphan-*' | wc -l)" -ge 1 ]
+}
+
+@test "issue #344: legacy backups in skills/ are migrated to .sync-backup/" {
+    _seed_ssot_skills alpha
+    # Simulate a user already on the buggy version: legacy backups sit
+    # inside the scan dir from a previous run.
+    mkdir -p "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000"
+    echo "legacy-pre" > "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000/SKILL.md"
+    mkdir -p "$HOME/.claude-personal/skills/agents-md-orphan-20260101000000"
+    echo "legacy-orphan" > "$HOME/.claude-personal/skills/agents-md-orphan-20260101000000/SKILL.md"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
+    assert_success
+
+    # Legacy entries are gone from the scan dir.
+    [ ! -e "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000" ]
+    [ ! -e "$HOME/.claude-personal/skills/agents-md-orphan-20260101000000" ]
+
+    # And recoverable from .sync-backup/, content intact.
+    [ -d "$HOME/.claude-personal/.sync-backup/skills/cli-dev-pre-sync-20260101000000" ]
+    [ -d "$HOME/.claude-personal/.sync-backup/skills/agents-md-orphan-20260101000000" ]
+    grep -q "legacy-pre" "$HOME/.claude-personal/.sync-backup/skills/cli-dev-pre-sync-20260101000000/SKILL.md"
+    grep -q "legacy-orphan" "$HOME/.claude-personal/.sync-backup/skills/agents-md-orphan-20260101000000/SKILL.md"
+}
+
+@test "issue #344: legacy-backup migration is idempotent (second run is no-op)" {
+    _seed_ssot_skills alpha
+    mkdir -p "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000"
+    echo "x" > "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000/SKILL.md"
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "FIRST=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
+    assert_success
+    assert_output --partial "FIRST=2"   # 1 migration + 1 alpha link
+
+    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "SECOND=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
+    assert_success
+    assert_output --partial "SECOND=0"
+
+    # Backup directory not double-nested by the second run.
+    nested=$(find "$HOME/.claude-personal/.sync-backup/" -name 'cli-dev-pre-sync-20260101000000' 2>/dev/null | wc -l)
+    [ "$nested" -eq 1 ]
 }


### PR DESCRIPTION
## Summary
- PR #343 머지 후 `claude-accounts skills-sync` 첫 실행에서 백업/orphan 디렉토리가 `~/.claude-personal/skills/` **안쪽**에 생성되어 Claude Code skill scanner 가 `cli-dev` 와 `cli-dev-pre-sync-<TS>` 를 둘 다 색인하던 문제 (issue #344) 수정.
- 백업 위치를 `<cdir>/.sync-backup/<name>/<entry>-{pre-sync,orphan}-<TS>` 로 이동해 스캐너 시야 밖에 두고, 기존 잔존 백업은 sync 진입 시 자동으로 새 위치로 옮기는 idempotent 마이그레이션을 추가.

## Changes
- `shell-common/tools/integrations/claude.sh`
  - `_claude_dir_sync_one()`: Pass 1/2 의 백업 경로를 `<cdir>/<name>/<entry>-…` → `<cdir>/.sync-backup/<name>/<entry>-…` 로 변경.
  - 함수 진입 직후 pre-step 으로 `<cdir>/<name>/*-pre-sync-* | *-orphan-*` 잔존물을 `.sync-backup/<name>/` 로 이동 (멱등 — 이미 옮겨진 경우 no-op).
  - docstring 갱신 — 새 백업 위치 + 결정 근거 (스캐너 시야 분리) 명시.
  - Pass 2 의 `*-pre-sync-*|*-orphan-*` skip 케이스는 방어용으로 유지 (이제는 정상 흐름에서는 도달 불가).

- `tests/bats/integrations/claude_accounts.bats`
  - 기존 issue #342 테스트 3 종 (collision/orphan/no-nest) — 백업 경로 단언을 새 `.sync-backup/skills/` 로 갱신 + `skills/` 에는 백업 형태 디렉토리가 남지 않는다는 negative assertion 추가.
  - 신규 issue #344 테스트 3 종:
    - `skills/` 가 `*-pre-sync-*` / `*-orphan-*` 형제 없이 깨끗한지 (Pass 1+2 동시 트리거)
    - 레거시 잔존 백업이 `.sync-backup/skills/` 로 자동 이전되는지 (콘텐츠 보존 포함)
    - 마이그레이션 멱등성 — 두 번째 실행은 `_CLAUDE_DIR_SYNC_LAST_CHANGED=0`, 백업 dir 중첩 없음

## Test plan
- [x] `bats tests/bats/integrations/claude_accounts.bats` — issue #344 테스트 3/3, 수정된 issue #342 테스트 3/3 통과
- [x] `sh -n shell-common/tools/integrations/claude.sh` — syntax OK
- [ ] 머지 후 Home-PC personal 계정에서 `claude-accounts skills-sync` 실행 → `available-skills` 목록에 `*-pre-sync-*` / `*-orphan-*` 이름이 사라지는지 육안 확인
- [ ] 동일 머신에서 한 번 더 sync 실행 → `(no changes — skills/docs already in sync)` 출력 확인 (멱등성)

## Notes
- 사전 존재 테스트 1 건 `issue #342: second claude-skills-sync prints (no changes)` 은 본 PR 변경 전에도 실패하던 항목으로 (main 에서 재현 확인) 별개 이슈로 분리 가능.

## Related
Closes #344

---
<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->
