### PR TITLE
fix(claude): auto-migrate legacy plugin paths in setup.sh

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -136,6 +136,105 @@ _migrate_legacy_statusline_command() {
     fi
 }
 
+# Auto-migrate legacy Claude Code plugin paths (issue #340).
+#
+# Claude Code recently moved its plugin storage from
+# ${HOME}/.claude/plugins/... to ${HOME}/.claude-personal/plugins/... but
+# pre-existing JSON state files still hold the old prefix. Symptoms:
+#   - /doctor: 다수의 "Plugin <name> not found in marketplace" 경고
+#   - /plugin: "Marketplace has corrupted installLocation ... expected a
+#     path inside .claude-personal/plugins/marketplaces" 갱신 실패
+#
+# Fix: rewrite the prefix in two JSON state files in place. Idempotent —
+# only acts when an old-prefix entry is present, otherwise no-op.
+#
+# Targets:
+#   - ~/.claude-shared/plugins/known_marketplaces.json (top-level
+#     <marketplace>.installLocation)
+#   - ~/.claude-shared/plugins/installed_plugins.json
+#     (.plugins[<key>][<idx>].installPath)
+_migrate_legacy_plugin_paths() {
+    local plugins_root="${HOME}/.claude-shared/plugins"
+    local old_prefix="${HOME}/.claude/plugins/"
+    local new_prefix="${HOME}/.claude-personal/plugins/"
+
+    [ -d "$plugins_root" ] || return 0
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log_warning "jq 미설치 — plugin 경로 자동 마이그레이션 건너뜀"
+        return 0
+    fi
+
+    _migrate_one_plugin_json() {
+        local file="$1"
+        local stale_filter="$2"
+        local rewrite_filter="$3"
+
+        [ -f "$file" ] || return 0
+
+        local stale_count
+        stale_count=$(jq --arg old "$old_prefix" "$stale_filter" "$file" 2>/dev/null) || stale_count=0
+        [ "${stale_count:-0}" -gt 0 ] || return 0
+
+        local backup tmp
+        backup="${file}.pre-plugin-path-fix-$(date +%Y%m%d%H%M%S)"
+        if ! cp "$file" "$backup"; then
+            log_error "$(basename "$file") 백업 실패: $backup — 마이그레이션 중단"
+            return 1
+        fi
+        tmp=$(mktemp "${file}.XXXXXX") || {
+            log_error "임시 파일 생성 실패 — 마이그레이션 중단"
+            rm -f "$backup"
+            return 1
+        }
+
+        if jq --arg old "$old_prefix" --arg new "$new_prefix" \
+                "$rewrite_filter" "$file" > "$tmp" && mv "$tmp" "$file"; then
+            log_warning "$(basename "$file") plugin 경로 마이그레이션: ${stale_count}건"
+            log_warning "  backup: $backup"
+        else
+            rm -f "$tmp"
+            log_error "$(basename "$file") 갱신 실패 — 백업 보존: $backup"
+            return 1
+        fi
+    }
+
+    # jq 변수 ($old/$new) 은 --arg 로 주입 — shell 변수 아님.
+    # shellcheck disable=SC2016
+    _migrate_one_plugin_json \
+        "${plugins_root}/known_marketplaces.json" \
+        '[.[] | select(.installLocation? | type == "string" and startswith($old))] | length' \
+        'with_entries(
+            if (.value.installLocation? | type) == "string"
+               and (.value.installLocation | startswith($old))
+            then .value.installLocation |= sub("^"+$old; $new)
+            else . end
+        )'
+
+    # shellcheck disable=SC2016
+    _migrate_one_plugin_json \
+        "${plugins_root}/installed_plugins.json" \
+        '[.plugins // {} | to_entries[] | .value[]? | select(.installPath? | type == "string" and startswith($old))] | length' \
+        '.plugins |= with_entries(
+            .value |= map(
+                if (.installPath? | type) == "string"
+                   and (.installPath | startswith($old))
+                then .installPath |= sub("^"+$old; $new)
+                else . end
+            )
+        )'
+
+    unset -f _migrate_one_plugin_json
+}
+
+# /sandbox 기능은 socat 을 요구하지만 sudo 가 필요한 install 이라
+# 자동 처리하지 않고 경고만 노출 (issue #340).
+_check_socat_for_sandbox() {
+    if ! command -v socat >/dev/null 2>&1; then
+        log_warning "socat 미설치 — /sandbox 사용 시 'sudo apt install -y socat' 필요"
+    fi
+}
+
 _setup_bind_mount_sudoers() {
     local sudoers_file="$1"
     local description="$2"
@@ -205,6 +304,13 @@ fi
 # 빈 ~/.claude/ 가드 디렉토리 + ~/.claude-shared/plugins
 mkdir -p "$HOME/.claude"
 mkdir -p "$HOME/.claude-shared/plugins"
+
+# Claude Code plugin 경로 마이그레이션 (issue #340). 멱등 — 옛 prefix 가
+# 남아있을 때만 갱신, 그 외 no-op. 백업은 timestamped 보존.
+_migrate_legacy_plugin_paths
+
+# /sandbox 의존성 점검 (issue #340).
+_check_socat_for_sandbox
 
 # 활성 계정 목록을 한 번만 조회하여 재사용 (PR #292 review 반영)
 ENABLED_ACCOUNTS=$(_claude_resolve_account --list)

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -207,7 +207,7 @@ _migrate_legacy_plugin_paths() {
         'with_entries(
             if (.value.installLocation? | type) == "string"
                and (.value.installLocation | startswith($old))
-            then .value.installLocation |= sub("^"+$old; $new)
+            then .value.installLocation |= ($new + .[($old | length):])
             else . end
         )'
 
@@ -219,7 +219,7 @@ _migrate_legacy_plugin_paths() {
             .value |= map(
                 if (.installPath? | type) == "string"
                    and (.installPath | startswith($old))
-                then .installPath |= sub("^"+$old; $new)
+                then .installPath |= ($new + .[($old | length):])
                 else . end
             )
         )'


### PR DESCRIPTION
## Summary

- `setup.sh` 가 Claude Code 의 plugin 경로 마이그레이션을 자동 처리.
  외부 PC 에서 수동으로 정리한 `/doctor` 53건 경고 + `/plugin`
  refresh 실패 문제가 다른 머신(Internal/Home PC)에서도 동일하게
  재현될 가능성이 높아, 1회성 수동 작업 대신 idempotent helper 로
  코드화.
- `socat` 의존성도 warning level 로 노출 (sudo 자동 install 안 함).

## Background — 외부 PC 수동 정리에서 확인된 증상

Claude Code 가 plugin storage prefix 를 `${HOME}/.claude/plugins/...`
에서 `${HOME}/.claude-personal/plugins/...` 로 옮긴 뒤, 두 JSON state
파일이 옛 prefix 를 그대로 들고 있을 때 다음이 발생함:

- `/doctor` — 설치된 거의 모든 플러그인에 대해
  `Plugin <name> not found in marketplace <mkt>` 경고 (외부 PC 53건)
- `/plugin` marketplace refresh — 첫 marketplace 에서
  `corrupted installLocation … expected a path inside
  .claude-personal/plugins/marketplaces` 로 abort

대상 파일 (둘 다 Claude Code 가 런타임에 관리, dotfiles 추적 외):

- `~/.claude-shared/plugins/known_marketplaces.json` —
  `<marketplace>.installLocation`
- `~/.claude-shared/plugins/installed_plugins.json` —
  `.plugins[<key>][<idx>].installPath`

## Changes

`claude/setup.sh`:

- `_migrate_legacy_plugin_paths` — 두 JSON 파일에 `${HOME}/.claude/plugins/`
  로 시작하는 항목이 있을 때만 `${HOME}/.claude-personal/plugins/` 로
  in-place 치환. 이미 새 경로인 항목과 무관 값은 보존. 수정 시
  timestamped `*.pre-plugin-path-fix-<TS>` 백업 보존. `jq` 미설치 시
  warning + skip.
- `_check_socat_for_sandbox` — `socat` 미설치 시 `/sandbox` 사용 안내
  warning. install 은 sudo 필요해서 자동 처리하지 않고 명령만 노출.

호출 위치는 `~/.claude-shared/plugins` guard mkdir 직후, 계정 loop 전 —
기존 `_migrate_legacy_statusline_command` (이슈 #300) 패턴과 동일.

## Test plan

- [x] `bash -n` / `shellcheck` clean.
- [x] 외부 PC (이미 정리된 상태) 에서 dry-run — md5 unchanged, no backup.
- [x] Synthetic stale fixture (옛+새 prefix 혼재):
  - 첫 실행: 2개 backup 생성, 옛 경로 → 새 경로 정확히 변환, 이미 새
    경로인 항목 보존
  - 두 번째 실행: no-op, backup 추가 안 됨 (idempotent)
- [ ] Internal PC 에서 `./setup.sh` 재실행 시 plugin 경로 자동
  마이그레이션 적용되는지 확인
- [ ] Home PC 에서 동일 검증

## Related

Closes #340

---
<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->
