### PR TITLE
refactor(shell-common): unify retry-sleep env across retry paths

### DIFF
--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -146,13 +146,13 @@ _gh_project_status_sync() {
 
         # One retry on mutation flake (GraphQL connection reset etc.).
         # 5s fixed backoff — long enough to ride out transient resets,
-        # short enough to keep callers responsive. Query-stage retry is
-        # intentionally not added here (boards-not-attached looks like a
-        # transient failure to gh; tracked separately).
+        # short enough to keep callers responsive. Override
+        # _GH_PROJECT_STATUS_RETRY_SLEEP in tests to skip the wait,
+        # matching the auto-detect retry above.
         if _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
             printf '[gh-project-status] %s #%s -> "%s"\n' "$_kind" "$_num" "$_target"
         else
-            sleep 5
+            sleep "${_GH_PROJECT_STATUS_RETRY_SLEEP-5}"
             if _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
                 printf '[gh-project-status] %s #%s -> "%s" (after 1 retry)\n' \
                     "$_kind" "$_num" "$_target"


### PR DESCRIPTION
## Summary
- Apply `_GH_PROJECT_STATUS_RETRY_SLEEP` to the mutation-stage retry path so both retry paths share one backoff knob (auto-detect retry already honors it from PR #345).
- No runtime behavior change at the default value (still 5s sleep) — pure refactor.

## Changes
- **`shell-common/functions/gh_project_status.sh`**: replace hardcoded `sleep 5` with `sleep "${_GH_PROJECT_STATUS_RETRY_SLEEP-5}"` in the mutation retry block; refresh the adjacent comment to point at the auto-detect retry above and drop the now-stale `"Query-stage retry is intentionally not added here"` line (PR #345 added exactly that).

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_project_status.bats` — 33/33 pass.
- [x] `tox -e shellcheck` — clean.
- [ ] Future follow-up: stateful fake-`gh` regression test for `flake_then_ok` on the mutation update path (issue body suggests this is now feasible with the unified env override; deferred to keep this PR tight).

## Related
Closes #347

---
<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->
