### PR TITLE
Add Jira create/read skills

### DIFF
--- a/claude/skills/jira-create/SKILL.md
+++ b/claude/skills/jira-create/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: jira:create
+description: >-
+  Create Jira tickets through the jiravis `jira create-ticket` CLI. Use this
+  skill whenever the user runs /jira:create, /jira-create, asks to create a
+  Jira ticket, says "Jira ticket", "Jira create", "Jira 생성", "Jira 티켓
+  만들어줘", or wants the current conversation turned into a Jira issue.
+  Requires jiravis CLI installed as `jira`.
+allowed-tools: Bash, Read, Grep
+---
+
+# jira:create
+
+## Help
+
+If the user asks for help (`-h`, `--help`, or `help`), read
+`references/help.md` and output it, then stop.
+
+## Role
+
+Create one Jira ticket by calling the bundled wrapper script. The script is a
+thin adapter over the jiravis CLI; it validates inputs, handles multiline
+descriptions safely, calls `jira create-ticket`, and parses JSON output.
+
+## Workflow
+
+1. Extract required fields from the user request:
+   - project key
+   - summary
+   - description
+2. Extract optional fields if present:
+   - issue type, default `Task`
+   - priority, default `Medium`
+   - assignee, labels, components, due date
+   - dry run, raw output, text output
+3. If a required field is missing, ask only for the missing value and do not
+   run the create command.
+4. Run `scripts/create_ticket.py` from this skill directory. Prefer
+   `--description` for conversation text; the script writes it to a temporary
+   file and passes `--description-file` to jiravis.
+5. Report the resulting `ticket_id`, `ticket_url`, `summary`, `issue_type`,
+   and `priority`. If the script fails, preserve the error code and message.
+
+## Command Pattern
+
+```bash
+python claude/skills/jira-create/scripts/create_ticket.py \
+  --project-key <PROJECT> \
+  --summary <SUMMARY> \
+  --description <DESCRIPTION> \
+  --issue-type Task \
+  --priority Medium
+```
+
+## Output Format
+
+For success, respond in this shape:
+
+```text
+Created Jira ticket: <ticket_id>
+URL: <ticket_url>
+Summary: <summary>
+Type: <issue_type>
+Priority: <priority>
+```
+
+For failures, state the failed command area, exit code when available, and the
+script error message. Do not expose tokens, config values, or secrets.
+
+## Constraints
+
+- Do not implement Jira REST calls in this skill.
+- Do not copy jiravis internal Python modules into this repository.
+- Do not create a ticket when project key, summary, or description is missing.
+- Do not hardcode Jira URLs, credentials, account IDs, or project defaults.
+- Keep the skill package independently shareable with its own `scripts/`.

--- a/claude/skills/jira-create/references/help.md
+++ b/claude/skills/jira-create/references/help.md
@@ -13,8 +13,19 @@ Create Jira tickets through the jiravis CLI.
 
 ```text
 /jira:create
+/jira:create help
+/jira:create -h
+/jira:create --help
 /jira:create project JIRAVIS summary "Build adapter" description "Details..."
 /jira-create JIRAVIS "Build adapter" "Details..."
+```
+
+Wrapper script help:
+
+```bash
+python claude/skills/jira-create/scripts/create_ticket.py help
+python claude/skills/jira-create/scripts/create_ticket.py -h
+python claude/skills/jira-create/scripts/create_ticket.py --help
 ```
 
 ## Required Inputs

--- a/claude/skills/jira-create/references/help.md
+++ b/claude/skills/jira-create/references/help.md
@@ -1,0 +1,54 @@
+# jira:create Help
+
+Create Jira tickets through the jiravis CLI.
+
+## Prerequisites
+
+- Python 3.10+
+- jiravis CLI installed as `jira`
+- `jira` available on `PATH`
+- jiravis authentication and config already set up
+
+## Usage
+
+```text
+/jira:create
+/jira:create project JIRAVIS summary "Build adapter" description "Details..."
+/jira-create JIRAVIS "Build adapter" "Details..."
+```
+
+## Required Inputs
+
+| Field | Description |
+|---|---|
+| project key | Jira project key, for example `JIRAVIS` |
+| summary | Jira issue summary |
+| description | Jira issue description |
+
+## Optional Inputs
+
+| Field | Default | Description |
+|---|---|---|
+| issue type | `Task` | `Task`, `Bug`, or `Story` |
+| priority | `Medium` | `Critical`, `High`, `Medium`, or `Low` |
+| assignee | unset | Passed through to jiravis |
+| labels | unset | Comma-separated labels |
+| components | unset | Comma-separated components |
+| due date | unset | `YYYY-MM-DD` |
+| dry run | off | Print planned command without calling Jira |
+
+## What This Skill Does
+
+1. Collects the required fields from the conversation.
+2. Refuses to create a ticket if required fields are missing.
+3. Runs `scripts/create_ticket.py`.
+4. The script writes multiline descriptions to a temporary file and calls
+   `jira create-ticket --description-file`.
+5. Summarizes the created ticket from JSON output.
+
+## What This Skill Will Not Do
+
+- It will not call Jira REST APIs directly.
+- It will not store credentials, URLs, tokens, or project defaults.
+- It will not vendor jiravis source code.
+- It will not create subtasks or update existing tickets.

--- a/claude/skills/jira-create/scripts/create_ticket.py
+++ b/claude/skills/jira-create/scripts/create_ticket.py
@@ -16,7 +16,7 @@ ISSUE_TYPES = ("Task", "Bug", "Story")
 PRIORITIES = ("Critical", "High", "Medium", "Low")
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Create a Jira ticket through the jiravis CLI.")
     parser.add_argument("--project-key", required=True, help="Jira project key, for example JIRAVIS")
     parser.add_argument("--summary", required=True, help="Jira issue summary")
@@ -32,7 +32,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true", help="Print the planned jiravis command without running it")
     parser.add_argument("--raw", action="store_true", help="Print raw jiravis output")
     parser.add_argument("--text", action="store_true", help="Print a concise text summary instead of JSON")
-    return parser.parse_args(argv)
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def print_help() -> None:
+    build_parser().print_help()
 
 
 def _require_text(value: str, field: str) -> None:
@@ -213,6 +221,10 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv == ["help"]:
+        print_help()
+        return 0
     try:
         return run(parse_args(argv))
     except Exception as exc:

--- a/claude/skills/jira-create/scripts/create_ticket.py
+++ b/claude/skills/jira-create/scripts/create_ticket.py
@@ -48,9 +48,13 @@ def _description_file_for_args(args: argparse.Namespace) -> tuple[str, bool]:
         return str(path), False
 
     temp = tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".md", delete=False)
-    with temp:
-        temp.write(args.description or "")
-    return temp.name, True
+    try:
+        with temp:
+            temp.write(args.description or "")
+        return temp.name, True
+    except Exception:
+        Path(temp.name).unlink(missing_ok=True)
+        raise
 
 
 def build_jira_command(args: argparse.Namespace, description_file: str) -> list[str]:
@@ -109,6 +113,8 @@ def parse_jira_json(stdout: str) -> dict[str, Any]:
 
 
 def normalize_success(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("status") == "error":
+        return payload
     data = payload.get("data") if payload.get("status") == "success" else payload
     if not isinstance(data, dict):
         data = {}
@@ -128,7 +134,20 @@ def normalize_success(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def render_text(payload: dict[str, Any]) -> str:
+    status = payload.get("status")
     data = payload.get("data", {})
+    if status == "dry-run":
+        return "\n".join(
+            [
+                f"Dry run: would create Jira ticket in project {data.get('project_key') or ''}",
+                f"Summary: {data.get('summary') or ''}",
+                f"Type: {data.get('issue_type') or ''}",
+                f"Priority: {data.get('priority') or ''}",
+            ]
+        )
+    if status == "error":
+        message = payload.get("message") or payload.get("stderr") or "Unknown error"
+        return f"Error: {message}"
     return "\n".join(
         [
             f"Created Jira ticket: {data.get('ticket_id') or ''}",
@@ -180,6 +199,12 @@ def run(args: argparse.Namespace) -> int:
             return completed.returncode
 
         normalized = normalize_success(parse_jira_json(completed.stdout))
+        if normalized.get("status") == "error":
+            print(
+                render_text(normalized) if args.text else json.dumps(normalized, indent=2, ensure_ascii=False),
+                file=sys.stderr,
+            )
+            return 1
         print(render_text(normalized) if args.text else json.dumps(normalized, indent=2, ensure_ascii=False))
         return 0
     finally:

--- a/claude/skills/jira-create/scripts/create_ticket.py
+++ b/claude/skills/jira-create/scripts/create_ticket.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Thin adapter for `jira create-ticket` from the jiravis CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ISSUE_TYPES = ("Task", "Bug", "Story")
+PRIORITIES = ("Critical", "High", "Medium", "Low")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a Jira ticket through the jiravis CLI.")
+    parser.add_argument("--project-key", required=True, help="Jira project key, for example JIRAVIS")
+    parser.add_argument("--summary", required=True, help="Jira issue summary")
+    desc_group = parser.add_mutually_exclusive_group(required=True)
+    desc_group.add_argument("--description", help="Issue description text")
+    desc_group.add_argument("--description-file", type=Path, help="Path to a file containing the description")
+    parser.add_argument("--issue-type", default="Task", choices=ISSUE_TYPES, help="Jira issue type")
+    parser.add_argument("--priority", default="Medium", choices=PRIORITIES, help="Jira priority")
+    parser.add_argument("--assignee", help="Assignee value accepted by jiravis")
+    parser.add_argument("--labels", help="Comma-separated labels")
+    parser.add_argument("--components", help="Comma-separated components")
+    parser.add_argument("--due-date", help="Due date in YYYY-MM-DD format")
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned jiravis command without running it")
+    parser.add_argument("--raw", action="store_true", help="Print raw jiravis output")
+    parser.add_argument("--text", action="store_true", help="Print a concise text summary instead of JSON")
+    return parser.parse_args(argv)
+
+
+def _require_text(value: str, field: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field} must not be empty")
+
+
+def _description_file_for_args(args: argparse.Namespace) -> tuple[str, bool]:
+    if args.description_file:
+        path = args.description_file
+        if not path.is_file():
+            raise ValueError(f"description file not found: {path}")
+        return str(path), False
+
+    temp = tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".md", delete=False)
+    with temp:
+        temp.write(args.description or "")
+    return temp.name, True
+
+
+def build_jira_command(args: argparse.Namespace, description_file: str) -> list[str]:
+    command = [
+        "jira",
+        "create-ticket",
+        "--project-key",
+        args.project_key,
+        "--summary",
+        args.summary,
+        "--description-file",
+        description_file,
+        "--issue-type",
+        args.issue_type,
+        "--priority",
+        args.priority,
+        "--output",
+        "json",
+        "--no-confirm",
+    ]
+    optional_pairs = [
+        ("--assignee", args.assignee),
+        ("--labels", args.labels),
+        ("--components", args.components),
+        ("--due-date", args.due_date),
+    ]
+    for flag, value in optional_pairs:
+        if value:
+            command.extend([flag, value])
+    return command
+
+
+def _planned_payload(args: argparse.Namespace, command: list[str]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "project_key": args.project_key,
+        "summary": args.summary,
+        "issue_type": args.issue_type,
+        "priority": args.priority,
+        "command": command,
+    }
+    for field in ("assignee", "labels", "components", "due_date"):
+        value = getattr(args, field)
+        if value:
+            payload[field] = value
+    return payload
+
+
+def parse_jira_json(stdout: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"jiravis returned non-JSON output: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("jiravis returned JSON, but the top-level value is not an object")
+    return payload
+
+
+def normalize_success(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data") if payload.get("status") == "success" else payload
+    if not isinstance(data, dict):
+        data = {}
+    return {
+        "status": "success",
+        "data": {
+            "ticket_id": data.get("ticket_id"),
+            "ticket_url": data.get("ticket_url"),
+            "summary": data.get("summary"),
+            "issue_type": data.get("issue_type"),
+            "priority": data.get("priority"),
+            "assignee": data.get("assignee"),
+            "due_date": data.get("due_date"),
+            "parent": data.get("parent"),
+        },
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    data = payload.get("data", {})
+    return "\n".join(
+        [
+            f"Created Jira ticket: {data.get('ticket_id') or ''}",
+            f"URL: {data.get('ticket_url') or ''}",
+            f"Summary: {data.get('summary') or ''}",
+            f"Type: {data.get('issue_type') or ''}",
+            f"Priority: {data.get('priority') or ''}",
+        ]
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    _require_text(args.project_key, "project key")
+    _require_text(args.summary, "summary")
+    if args.description is not None:
+        _require_text(args.description, "description")
+
+    if args.dry_run:
+        description_file = str(args.description_file) if args.description_file else "<temporary-description-file>"
+        command = build_jira_command(args, description_file)
+        dry_run = {"status": "dry-run", "data": _planned_payload(args, command)}
+        print(render_text(dry_run) if args.text else json.dumps(dry_run, indent=2, ensure_ascii=False))
+        return 0
+
+    temp_path: str | None = None
+    try:
+        description_file, is_temp = _description_file_for_args(args)
+        temp_path = description_file if is_temp else None
+        command = build_jira_command(args, description_file)
+
+        if not shutil.which("jira"):
+            raise RuntimeError("jiravis CLI not found: `jira` is not on PATH")
+
+        completed = subprocess.run(command, capture_output=True, check=False, text=True)
+        if args.raw:
+            print(completed.stdout, end="")
+            if completed.stderr:
+                print(completed.stderr, end="", file=sys.stderr)
+            return completed.returncode
+
+        if completed.returncode != 0:
+            error = {
+                "status": "error",
+                "exit_code": completed.returncode,
+                "stderr": completed.stderr.strip(),
+                "stdout": completed.stdout.strip(),
+            }
+            print(json.dumps(error, indent=2, ensure_ascii=False), file=sys.stderr)
+            return completed.returncode
+
+        normalized = normalize_success(parse_jira_json(completed.stdout))
+        print(render_text(normalized) if args.text else json.dumps(normalized, indent=2, ensure_ascii=False))
+        return 0
+    finally:
+        if temp_path:
+            Path(temp_path).unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return run(parse_args(argv))
+    except Exception as exc:
+        print(json.dumps({"status": "error", "message": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude/skills/jira-read/SKILL.md
+++ b/claude/skills/jira-read/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: jira:read
+description: >-
+  Read Jira ticket details through the jiravis `jira get-ticket-detail` CLI.
+  Use this skill whenever the user runs /jira:read, /jira-read, asks to read a
+  Jira ticket, provides a key like ABC-123, says "Jira issue detail",
+  "Jira 읽어줘", "Jira 이슈 파악", or wants a Jira ticket summarized for
+  implementation context. Read-only. Requires jiravis CLI installed as `jira`.
+allowed-tools: Bash, Read, Grep
+---
+
+# jira:read
+
+## Help
+
+If the user asks for help (`-h`, `--help`, or `help`), read
+`references/help.md` and output it, then stop.
+
+## Role
+
+Read one Jira ticket by calling the bundled wrapper script. The script is a
+thin read-only adapter over the jiravis CLI; it validates ticket keys, calls
+`jira get-ticket-detail`, and normalizes JSON output for implementation work.
+
+## Workflow
+
+1. Extract a Jira ticket key from the user request or explicit argument.
+2. If no key is present, ask for the ticket key and stop.
+3. Run `scripts/read_ticket.py --ticket-id <KEY>` from this skill directory.
+4. Report the normalized ticket context:
+   - ticket id, URL, summary, status, priority
+   - assignee and reporter
+   - description
+   - labels, components, created and updated timestamps
+   - subtasks
+5. If the user asks for raw JSON or text output, pass the matching script flag.
+
+## Command Pattern
+
+```bash
+python claude/skills/jira-read/scripts/read_ticket.py --ticket-id <PROJECT-123>
+```
+
+## Output Format
+
+For normal reads, respond in this shape:
+
+```text
+Jira ticket: <ticket_id>
+URL: <ticket_url>
+Summary: <summary>
+Status: <status>
+Priority: <priority>
+Assignee: <assignee>
+Reporter: <reporter>
+
+Description:
+<description>
+
+Metadata:
+Labels: <labels>
+Components: <components>
+Updated: <updated_at>
+
+Subtasks:
+<subtask list or None>
+```
+
+## Constraints
+
+- Read-only: never call create, update, transition, delete, comment, or link commands.
+- Do not implement Jira REST calls in this skill.
+- Do not copy jiravis internal Python modules into this repository.
+- Do not hardcode Jira URLs, credentials, account IDs, or project defaults.
+- Keep the skill package independently shareable with its own `scripts/`.

--- a/claude/skills/jira-read/references/help.md
+++ b/claude/skills/jira-read/references/help.md
@@ -1,0 +1,47 @@
+# jira:read Help
+
+Read Jira ticket details through the jiravis CLI.
+
+## Prerequisites
+
+- Python 3.10+
+- jiravis CLI installed as `jira`
+- `jira` available on `PATH`
+- jiravis authentication and config already set up
+
+## Usage
+
+```text
+/jira:read JIRAVIS-123
+/jira-read JIRAVIS-123
+JIRAVIS-123 읽어줘
+```
+
+## Required Inputs
+
+| Field | Description |
+|---|---|
+| ticket id | Jira key in `PROJECT-123` form |
+
+## Optional Modes
+
+| Mode | Description |
+|---|---|
+| raw JSON | Print raw jiravis JSON output |
+| text | Ask jiravis for text output and pass it through |
+| verbose | Add `--verbose` when using text mode |
+
+## What This Skill Does
+
+1. Finds a Jira key in the request.
+2. Normalizes it to uppercase.
+3. Runs `scripts/read_ticket.py`.
+4. The script calls `jira get-ticket-detail --output json --no-confirm`.
+5. Summarizes the ticket for implementation context.
+
+## What This Skill Will Not Do
+
+- It will not mutate Jira.
+- It will not call Jira REST APIs directly.
+- It will not store credentials, URLs, tokens, or project defaults.
+- It will not vendor jiravis source code.

--- a/claude/skills/jira-read/scripts/read_ticket.py
+++ b/claude/skills/jira-read/scripts/read_ticket.py
@@ -64,6 +64,8 @@ def _person_name(value: Any) -> str | None:
 
 
 def normalize_detail(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("status") == "error":
+        return payload
     data = payload.get("data") if payload.get("status") == "success" else payload
     if not isinstance(data, dict):
         data = {}
@@ -130,6 +132,9 @@ def run(args: argparse.Namespace) -> int:
         return completed.returncode
 
     normalized = normalize_detail(parse_jira_json(completed.stdout))
+    if normalized.get("status") == "error":
+        print(json.dumps(normalized, indent=2, ensure_ascii=False), file=sys.stderr)
+        return 1
     print(json.dumps(normalized, indent=2, ensure_ascii=False))
     return 0
 

--- a/claude/skills/jira-read/scripts/read_ticket.py
+++ b/claude/skills/jira-read/scripts/read_ticket.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Read-only adapter for `jira get-ticket-detail` from the jiravis CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+TICKET_ID_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read a Jira ticket through the jiravis CLI.")
+    parser.add_argument("--ticket-id", required=True, help="Jira ticket key, for example JIRAVIS-123")
+    parser.add_argument("--raw", action="store_true", help="Print raw jiravis JSON output")
+    parser.add_argument("--text", action="store_true", help="Print jiravis text output instead of normalized JSON")
+    parser.add_argument("--verbose", action="store_true", help="Pass --verbose when using text output")
+    return parser.parse_args(argv)
+
+
+def normalize_ticket_id(ticket_id: str) -> str:
+    normalized = ticket_id.strip().upper()
+    if not TICKET_ID_PATTERN.fullmatch(normalized):
+        raise ValueError(f"invalid Jira ticket id: {ticket_id!r}; expected PROJECT-123")
+    return normalized
+
+
+def build_jira_command(ticket_id: str, *, text_output: bool = False, verbose: bool = False) -> list[str]:
+    command = [
+        "jira",
+        "get-ticket-detail",
+        "--ticket-id",
+        ticket_id,
+        "--output",
+        "text" if text_output else "json",
+        "--no-confirm",
+    ]
+    if text_output and verbose:
+        command.append("--verbose")
+    return command
+
+
+def parse_jira_json(stdout: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"jiravis returned non-JSON output: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("jiravis returned JSON, but the top-level value is not an object")
+    return payload
+
+
+def _person_name(value: Any) -> str | None:
+    if isinstance(value, dict):
+        return value.get("display_name") or value.get("account_id")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def normalize_detail(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data") if payload.get("status") == "success" else payload
+    if not isinstance(data, dict):
+        data = {}
+
+    subtasks = data.get("subtasks") if isinstance(data.get("subtasks"), list) else []
+    normalized_subtasks = []
+    for subtask in subtasks:
+        if isinstance(subtask, dict):
+            normalized_subtasks.append(
+                {
+                    "ticket_id": subtask.get("ticket_id"),
+                    "ticket_url": subtask.get("ticket_url"),
+                    "summary": subtask.get("summary"),
+                    "status": subtask.get("status"),
+                    "priority": subtask.get("priority"),
+                    "assignee": subtask.get("assignee"),
+                }
+            )
+
+    return {
+        "status": "success",
+        "data": {
+            "ticket_id": data.get("ticket_id"),
+            "ticket_url": data.get("ticket_url"),
+            "summary": data.get("summary"),
+            "description": data.get("description"),
+            "issue_type": data.get("issue_type"),
+            "status": data.get("status"),
+            "priority": data.get("priority"),
+            "assignee": _person_name(data.get("assignee")) or "Unassigned",
+            "reporter": _person_name(data.get("reporter")) or "Unknown",
+            "due_date": data.get("due_date"),
+            "labels": data.get("labels") if isinstance(data.get("labels"), list) else [],
+            "components": data.get("components") if isinstance(data.get("components"), list) else [],
+            "created_at": data.get("created_at"),
+            "updated_at": data.get("updated_at"),
+            "subtasks": normalized_subtasks,
+        },
+    }
+
+
+def run(args: argparse.Namespace) -> int:
+    ticket_id = normalize_ticket_id(args.ticket_id)
+    command = build_jira_command(ticket_id, text_output=args.text, verbose=args.verbose)
+
+    if not shutil.which("jira"):
+        raise RuntimeError("jiravis CLI not found: `jira` is not on PATH")
+
+    completed = subprocess.run(command, capture_output=True, check=False, text=True)
+    if args.raw or args.text:
+        print(completed.stdout, end="")
+        if completed.stderr:
+            print(completed.stderr, end="", file=sys.stderr)
+        return completed.returncode
+
+    if completed.returncode != 0:
+        error = {
+            "status": "error",
+            "exit_code": completed.returncode,
+            "stderr": completed.stderr.strip(),
+            "stdout": completed.stdout.strip(),
+        }
+        print(json.dumps(error, indent=2, ensure_ascii=False), file=sys.stderr)
+        return completed.returncode
+
+    normalized = normalize_detail(parse_jira_json(completed.stdout))
+    print(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return run(parse_args(argv))
+    except Exception as exc:
+        print(json.dumps({"status": "error", "message": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_jira_skill_scripts.py
+++ b/tests/integration/test_jira_skill_scripts.py
@@ -48,6 +48,18 @@ def test_create_ticket_dry_run_uses_description_file_placeholder(capsys) -> None
     assert "--components" in command
 
 
+def test_create_ticket_help_alias_prints_usage(capsys) -> None:
+    module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_help")
+
+    exit_code = module.main(["help"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "usage:" in output
+    assert "--project-key" in output
+    assert "--description-file" in output
+
+
 def test_create_ticket_dry_run_text_does_not_claim_created(capsys) -> None:
     module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_text")
 

--- a/tests/integration/test_jira_skill_scripts.py
+++ b/tests/integration/test_jira_skill_scripts.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(path: str, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, ROOT / path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_create_ticket_dry_run_uses_description_file_placeholder(capsys) -> None:
+    module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket")
+
+    exit_code = module.main(
+        [
+            "--project-key",
+            "JIRAVIS",
+            "--summary",
+            "Build adapter",
+            "--description",
+            "Line 1\nLine 2",
+            "--labels",
+            "skill,jira",
+            "--components",
+            "Agent Enabler(AX)",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    command = payload["data"]["command"]
+    assert payload["status"] == "dry-run"
+    assert "--description-file" in command
+    assert "Line 1\nLine 2" not in command
+    assert "--labels" in command
+    assert "--components" in command
+
+
+def test_create_ticket_normalizes_jiravis_success(monkeypatch, capsys) -> None:
+    module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_success")
+    captured_description = {}
+
+    def fake_run(command, capture_output, check, text):
+        assert command[:2] == ["jira", "create-ticket"]
+        description_path = Path(command[command.index("--description-file") + 1])
+        captured_description["text"] = description_path.read_text(encoding="utf-8")
+        stdout = json.dumps(
+            {
+                "status": "success",
+                "data": {
+                    "ticket_id": "JIRAVIS-123",
+                    "ticket_url": "https://jira.example.com/browse/JIRAVIS-123",
+                    "summary": "Build adapter",
+                    "issue_type": "Task",
+                    "priority": "Medium",
+                },
+            }
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/jira")
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    exit_code = module.main(
+        [
+            "--project-key",
+            "JIRAVIS",
+            "--summary",
+            "Build adapter",
+            "--description",
+            "Detailed body",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured_description["text"] == "Detailed body"
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["data"]["ticket_id"] == "JIRAVIS-123"
+    assert payload["data"]["summary"] == "Build adapter"
+
+
+def test_read_ticket_validates_and_uppercases_ticket_id() -> None:
+    module = load_module("claude/skills/jira-read/scripts/read_ticket.py", "jira_read_ticket")
+
+    assert module.normalize_ticket_id("jiravis-123") == "JIRAVIS-123"
+
+    try:
+        module.normalize_ticket_id("not-a-ticket")
+    except ValueError as exc:
+        assert "expected PROJECT-123" in str(exc)
+    else:
+        raise AssertionError("expected invalid ticket id to raise")
+
+
+def test_read_ticket_calls_read_only_jiravis_command(monkeypatch, capsys) -> None:
+    module = load_module("claude/skills/jira-read/scripts/read_ticket.py", "jira_read_ticket_success")
+    captured_command = {}
+
+    def fake_run(command, capture_output, check, text):
+        captured_command["command"] = command
+        stdout = json.dumps(
+            {
+                "status": "success",
+                "data": {
+                    "ticket_id": "JIRAVIS-123",
+                    "ticket_url": "https://jira.example.com/browse/JIRAVIS-123",
+                    "summary": "Build adapter",
+                    "description": "Implementation context",
+                    "status": "In Progress",
+                    "priority": "High",
+                    "assignee": {"display_name": "Ada"},
+                    "reporter": {"display_name": "Grace"},
+                    "labels": ["skill"],
+                    "components": ["CLI"],
+                    "subtasks": [{"ticket_id": "JIRAVIS-124", "summary": "Child", "status": "Open"}],
+                },
+            }
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/jira")
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    exit_code = module.main(["--ticket-id", "jiravis-123"])
+
+    assert exit_code == 0
+    assert captured_command["command"][:2] == ["jira", "get-ticket-detail"]
+    assert "create-ticket" not in captured_command["command"]
+    assert "update-ticket" not in captured_command["command"]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["data"]["ticket_id"] == "JIRAVIS-123"
+    assert payload["data"]["assignee"] == "Ada"
+    assert payload["data"]["subtasks"][0]["ticket_id"] == "JIRAVIS-124"

--- a/tests/integration/test_jira_skill_scripts.py
+++ b/tests/integration/test_jira_skill_scripts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
+import tempfile
 from pathlib import Path
 from types import ModuleType
 
@@ -47,6 +48,28 @@ def test_create_ticket_dry_run_uses_description_file_placeholder(capsys) -> None
     assert "--components" in command
 
 
+def test_create_ticket_dry_run_text_does_not_claim_created(capsys) -> None:
+    module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_text")
+
+    exit_code = module.main(
+        [
+            "--project-key",
+            "JIRAVIS",
+            "--summary",
+            "Build adapter",
+            "--description",
+            "Line 1",
+            "--dry-run",
+            "--text",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Dry run: would create Jira ticket in project JIRAVIS" in output
+    assert "Created Jira ticket:" not in output
+
+
 def test_create_ticket_normalizes_jiravis_success(monkeypatch, capsys) -> None:
     module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_success")
     captured_description = {}
@@ -88,6 +111,72 @@ def test_create_ticket_normalizes_jiravis_success(monkeypatch, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["data"]["ticket_id"] == "JIRAVIS-123"
     assert payload["data"]["summary"] == "Build adapter"
+
+
+def test_create_ticket_preserves_jiravis_error_payload(monkeypatch, capsys) -> None:
+    module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_error")
+
+    def fake_run(command, capture_output, check, text):
+        stdout = json.dumps({"status": "error", "message": "Jira rejected the request"})
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/jira")
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    exit_code = module.main(
+        [
+            "--project-key",
+            "JIRAVIS",
+            "--summary",
+            "Build adapter",
+            "--description",
+            "Detailed body",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["status"] == "error"
+    assert payload["message"] == "Jira rejected the request"
+
+
+def test_create_ticket_temp_file_is_cleaned_when_write_fails(monkeypatch, tmp_path) -> None:
+    module = load_module("claude/skills/jira-create/scripts/create_ticket.py", "jira_create_ticket_temp_cleanup")
+    temp_path = tmp_path / "description.md"
+
+    class FailingTempFile:
+        name = str(temp_path)
+
+        def __enter__(self):
+            temp_path.touch()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def write(self, value):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", lambda *args, **kwargs: FailingTempFile())
+    args = module.parse_args(
+        [
+            "--project-key",
+            "JIRAVIS",
+            "--summary",
+            "Build adapter",
+            "--description",
+            "Detailed body",
+        ]
+    )
+
+    try:
+        module._description_file_for_args(args)
+    except OSError:
+        pass
+    else:
+        raise AssertionError("expected write failure")
+
+    assert not temp_path.exists()
 
 
 def test_read_ticket_validates_and_uppercases_ticket_id() -> None:
@@ -142,3 +231,21 @@ def test_read_ticket_calls_read_only_jiravis_command(monkeypatch, capsys) -> Non
     assert payload["data"]["ticket_id"] == "JIRAVIS-123"
     assert payload["data"]["assignee"] == "Ada"
     assert payload["data"]["subtasks"][0]["ticket_id"] == "JIRAVIS-124"
+
+
+def test_read_ticket_preserves_jiravis_error_payload(monkeypatch, capsys) -> None:
+    module = load_module("claude/skills/jira-read/scripts/read_ticket.py", "jira_read_ticket_error")
+
+    def fake_run(command, capture_output, check, text):
+        stdout = json.dumps({"status": "error", "message": "Ticket not found"})
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/jira")
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    exit_code = module.main(["--ticket-id", "JIRAVIS-123"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["status"] == "error"
+    assert payload["message"] == "Ticket not found"


### PR DESCRIPTION
## Summary
- Add two shareable Claude Code skills: `jira:create` and `jira:read`.
- Add bundled Python wrapper scripts that safely call the jiravis `jira` CLI instead of vendoring jiravis internals.
- Add pytest coverage for dry-run behavior, JSON normalization, ticket-key validation, and read-only command construction.

## Changes
- `jira:create`: adds a progressive-disclosure skill, help reference, and `scripts/create_ticket.py` adapter for `jira create-ticket`.
- `jira:read`: adds a read-only skill, help reference, and `scripts/read_ticket.py` adapter for `jira get-ticket-detail`.
- `tests`: covers the new adapters without requiring live Jira access.

## Test plan
- [x] `python -m pytest tests/integration/test_jira_skill_scripts.py -q`
- [x] `ruff check claude/skills/jira-create/scripts/create_ticket.py claude/skills/jira-read/scripts/read_ticket.py tests/integration/test_jira_skill_scripts.py`
- [x] `target_dir='claude/skills/jira-create/scripts/create_ticket.py claude/skills/jira-read/scripts/read_ticket.py tests/integration/test_jira_skill_scripts.py' tox -e ruff`
- [x] `python -m py_compile claude/skills/jira-create/scripts/create_ticket.py claude/skills/jira-read/scripts/read_ticket.py`
- [x] `python claude/skills/jira-create/scripts/create_ticket.py --project-key JIRAVIS --summary 'Dry run' --description 'Line 1\nLine 2' --dry-run`

## Related
Closes #352

---
<!-- ai-metrics:gh-pr -->
Tokens: ~9500 · Human: ~8 h · AI: ~18 min
<!-- /ai-metrics:gh-pr -->
