### PR TITLE
fix(gh-pr-reply): early-exit when no unaddressed review comments

### DIFF
--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -43,6 +43,17 @@ Also capture `TARGET_REPO` via `gh repo view --json nameWithOwner -q .nameWithOw
 Read `references/comment-fetching.md` for the three API endpoints, field
 extraction, and dedup rule. Fetch all three; filter out already-replied threads.
 
+## Step 2.5: Early Exit — No Unaddressed Comments
+
+If Step 2 yields **zero unaddressed threads** after deduplication:
+
+1. Print exactly one line:
+   ```
+   No unaddressed review comments — nothing to do.
+   ```
+2. **Stop immediately.** Do not run Steps 3–7. Do not post an ai-metrics
+   comment. Do not push anything.
+
 ## Step 3: Evaluate Each Comment
 
 For each unaddressed comment, read the referenced file (`path` at `line`)


### PR DESCRIPTION
## Summary
- `gh-pr-reply` 스킬이 미처리 리뷰 댓글이 없을 때도 Step 3~7 및 ai-metrics PR 코멘트를 실행하는 문제를 수정

## Changes
- `gh-pr-reply/SKILL.md`: Step 2.5 추가 — Step 2 dedup 후 unaddressed thread가 0개면 한 줄 출력 후 즉시 종료. ai-metrics 포스팅과 git push를 포함한 Step 3~7 전체를 건너뜀

## Test plan
- [ ] 미처리 댓글 없는 PR에서 `/gh:pr-reply` 실행 → `No unaddressed review comments — nothing to do.` 출력 후 종료
- [ ] PR에 ai-metrics 코멘트가 게시되지 않음 확인

## Related
Closes #356

---
<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->
