### PR TITLE
feat(gh-pr-resolve-conflict): skip clean PRs + remove conflict label

### DIFF
--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -31,6 +31,17 @@ Positional args: `[pr-number] [remote]`. Both optional.
 - `remote` — default `origin`. Resolve `TARGET_REPO` via
   `git remote get-url <remote>`; missing → `git remote -v` and stop.
 
+**Mergeable preflight** — immediately after resolving `PR_NUMBER`:
+
+```bash
+MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
+  --json mergeable --jq '.mergeable')
+```
+
+- `MERGEABLE == MERGEABLE` → print `✅ PR은 이미 충돌 없음 — skip.` and stop (success).
+- `MERGEABLE == UNKNOWN` → GitHub is still computing; continue the flow normally (do not skip).
+- Any other value (`CONFLICTING` etc.) → continue.
+
 **Hard preconditions** (parallel batch; any fail → stop):
 - inside a git repo
 - current branch ≠ repo default (refuse to rebase `main`)
@@ -81,13 +92,25 @@ pushed while you rebased), stop and surface the upstream per
 ## Step 5: Verify Mergeable + Report
 
 ```bash
-gh pr view <N> --repo "$TARGET_REPO" --json mergeable,mergeStateStatus,url
+gh pr view <N> --repo "$TARGET_REPO" --json mergeable,mergeStateStatus,url,labels
 ```
 
 If `mergeable == MERGEABLE` and `mergeStateStatus ∈ {CLEAN, UNSTABLE}`,
 the warning is cleared. Print the final report from
 `references/rebase-flow.md` → "Final report format". Still `CONFLICTING`
 / `BEHIND` → print the PR URL, name which side diverged, do not loop.
+
+**conflict 라벨 제거** (soft-fail — `mergeable == MERGEABLE` 인 경우에만):
+
+Check if `labels[].name` contains `"conflict"`. If so:
+
+```bash
+gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --remove-label "conflict" \
+  && echo "✅ \`conflict\` 라벨 제거됨" \
+  || echo "⚠️  \`conflict\` 라벨 제거 실패 — 계속합니다."
+```
+
+If the label is absent, skip silently (idempotent).
 
 After the report, post a PR comment with ai-metrics (soft-fail — warn on
 error, never block). `CONFLICT_FILES` is the count of files that had


### PR DESCRIPTION
## Summary
- `gh:pr-resolve-conflict` Step 1에 mergeable preflight를 추가하여 이미 충돌 없는 PR에서 불필요한 rebase/push를 방지
- Step 5에서 충돌 해결 성공 후 `conflict` 라벨이 붙어 있으면 자동 제거 (soft-fail, idempotent)

## Changes
- `gh-pr-resolve-conflict`: Step 1 — PR 번호 확정 직후 `mergeable` 상태 조회; `MERGEABLE`이면 skip, `UNKNOWN`이면 통과
- `gh-pr-resolve-conflict`: Step 5 — `gh pr view` JSON에 `labels` 추가; `conflict` 라벨 존재 시 제거, 실패 시 경고만 출력

## Test plan
- [ ] 이미 MERGEABLE 상태인 PR에서 실행 → "PR은 이미 충돌 없음 — skip." 출력 후 종료
- [ ] mergeable == UNKNOWN인 PR에서 실행 → skip 없이 정상 진행
- [ ] conflict 라벨이 붙은 PR에서 충돌 해결 후 → 라벨이 제거됨
- [ ] conflict 라벨 없는 PR → 에러 없이 완료
- [ ] 라벨 제거 API 실패 시 → 경고만 출력, 스킬 정상 종료

## Related
Closes #355

---
<\!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~4 h h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->
