### PR TITLE
feat(skills): /devx:schedule — N분 후 슬래시 커맨드 지연 실행 스킬 추가

### DIFF
--- a/claude/skills/devx-schedule/SKILL.md
+++ b/claude/skills/devx-schedule/SKILL.md
@@ -46,12 +46,12 @@ If M is not a positive integer, default to 5 and warn the user.
 Run Bash to get the target cron fields in local time:
 
 ```bash
-date -d "+M minutes" +"%M %H %d %m"
+python3 -c "from datetime import datetime, timedelta; print((datetime.now() + timedelta(minutes=M)).strftime('%M %H %d %m'))"
 ```
 
 Replace `M` with the parsed minute value. Output: `<min> <hour> <dom> <month>`.
 
-### 3. Schedule with CronCreate
+### 3. Schedule with `CronCreate`
 
 Call `CronCreate`:
 - `cron`: `"<min> <hour> <dom> <month> *"` (values from step 2)

--- a/claude/skills/devx-schedule/SKILL.md
+++ b/claude/skills/devx-schedule/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: devx:schedule
+description: >-
+  Schedule a skill or command to run after a specified delay (default: 5 min).
+  Use when the user says "N분 후에 /skill 실행해", "M분 뒤에 [skill] 수행해",
+  "/devx:schedule", "/devx-schedule", "schedule /skill in N minutes", or
+  "[command] N분 후에 해줘". Always invoke this skill whenever the user wants
+  to defer any slash-command or task to run after a time delay.
+---
+
+# devx:schedule — Deferred Skill Executor
+
+## Usage
+
+```
+/devx:schedule [--time M] "<command>"
+/devx:schedule [--time M] /skill-name [args...]
+```
+
+- `--time M` — delay in **minutes** (positive integer, default: **5**)
+- `<command>` — skill invocation or natural-language task to run after the delay
+
+## Examples
+
+```
+/devx:schedule --time 10 "/gh-pr-reply 350"      # /gh-pr-reply in 10 min
+/devx:schedule /gh-pr-resolve-conflict 351        # run in 5 min (default)
+/devx:schedule --time 3 "PR #200 리뷰 코멘트 처리해"
+```
+
+## Steps
+
+### 1. Parse Arguments
+
+Extract `--time M` (default 5) and the command/skill (everything after the flags).
+If M is not a positive integer, default to 5 and warn the user.
+
+| Input | M | command |
+|-------|---|---------|
+| `--time 10 "/gh-pr-reply 350"` | 10 | `/gh-pr-reply 350` |
+| `/gh-pr-resolve-conflict 351` | 5 | `/gh-pr-resolve-conflict 351` |
+| `--time 3 "PR 리뷰해"` | 3 | `PR 리뷰해` |
+
+### 2. Calculate Fire Time
+
+Run Bash to get the target cron fields in local time:
+
+```bash
+date -d "+M minutes" +"%M %H %d %m"
+```
+
+Replace `M` with the parsed minute value. Output: `<min> <hour> <dom> <month>`.
+
+### 3. Schedule with CronCreate
+
+Call `CronCreate`:
+- `cron`: `"<min> <hour> <dom> <month> *"` (values from step 2)
+- `prompt`: the extracted command (verbatim — passed to Claude at fire time)
+- `recurring`: `false` (one-shot — fires once then auto-deletes)
+
+### 4. Confirm to User
+
+Print one line after scheduling:
+
+```
+⏰ [M]분 후에 실행됩니다: <command>  (job: <returned-id>)
+```


### PR DESCRIPTION
## Summary
- `claude/skills/devx-schedule/SKILL.md` 신규 추가 — `CronCreate(recurring: false)`로 N분 후 one-shot 실행을 등록하는 스킬

## Changes
- feat(skills): `/devx:schedule` 스킬 추가 (67줄)
  - `--time M` 파싱 (기본 5분), 유효하지 않으면 fallback + 경고
  - `date -d "+M minutes"` 로 로컬 시간 기준 fire time 계산
  - `CronCreate` 호출: `recurring: false` (one-shot, 자동 삭제)
  - 확인 메시지 출력: `⏰ [M]분 후에 실행됩니다: <command>  (job: <id>)`

## Test plan
- [ ] `/devx:schedule --time 10 "/gh-pr-reply 350"` → 10분 후 job 등록 확인
- [ ] `/devx:schedule /gh-pr-resolve-conflict 351` → 기본 5분 후 등록 확인
- [ ] 잘못된 `--time` 값 입력 → 5분 fallback + 경고 확인

## Related
Closes #354

---
<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->
