### PR TITLE
feat(gh-issue-flow): PR 생성 후 5단계 자동화 추가

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -82,8 +82,8 @@ if the previous completed successfully.
    ```
    Passing the issue number ensures `Closes #<N>` ends up in the PR
    body via gh:pr's Step 3 (issue resolution).
-   After this step succeeds, extract `PR_NUM` from the PR URL in the
-   output (last path segment of the `https://github.com/.../pull/<M>` URL).
+   After this step succeeds, extract <PR_NUM> from the PR URL in the
+   output (e.g., 123 from `.../pull/123`).
    **Now invoke Step 2.4 — no recap, no summary, no header.**
 
 4. **Step 2.4 — devx:schedule** (only if 2.3 succeeded)
@@ -113,6 +113,14 @@ if the previous completed successfully.
    This step soft-fails — warn on any error but never block the flow.
 
    a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
+      Track per-step timing by recording `STEP_TS=$(date +%s)` at the
+      start of each sub-skill and computing its elapsed at the end:
+      - `IMPL_MIN` — elapsed for Step 2.1 (gh:issue-implement)
+      - `COMMIT_MIN` — elapsed for Step 2.2 (gh:commit)
+      - `PR_MIN` — elapsed for Step 2.3 (gh:pr)
+      - `SCHEDULE_MIN` — elapsed for Step 2.4 (devx:schedule)
+      - `CONFLICT_MIN` — elapsed for Step 2.5 (gh:pr-resolve-conflict)
+      Any variable not yet computed defaults to `?` in the template.
    b. Issue type: parse the conventional-commit prefix from the issue title
       fetched in Step 2.1 (e.g. `feat`, `fix`, `refactor`).
    c. Human time: look up the issue type in `gh-issue-create`'s

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -2,7 +2,8 @@
 name: gh:issue-flow
 description: >-
   Composition skill that chains gh:issue-implement → gh:commit → gh:pr
-  for a single issue number. Use when the user runs /gh:issue-flow,
+  → devx:schedule (pr-reply, 10 min) → gh:pr-resolve-conflict for a
+  single issue number. Use when the user runs /gh:issue-flow,
   /gh-issue-flow, or asks "issue #16 처음부터 PR까지 자동으로",
   "이슈 구현하고 커밋하고 PR까지 한방에", "full flow on #42". Uses
   direct implementation mode only — for plan/brainstorming modes, use
@@ -29,7 +30,7 @@ as a final answer and ends the turn — leaving the user to manually re-trigger
 success report and proceeds naturally to Step 2.2. **Do not drop this flag.**
 If you edit Step 2 in any way, re-verify `--no-next-hint` is still present.
 
-**Zero conversational text between the three `Skill()` calls in Step 2.**
+**Zero conversational text between the five `Skill()` calls in Step 2.**
 No recap, no "now committing", no markdown headers, no progress bullets —
 those tokens read as a turn-ending summary and re-introduce the early-stop.
 The only text allowed in Step 2 is the final Step 3 report.
@@ -39,8 +40,8 @@ The only text allowed in Step 2 is the final Step 3 report.
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
 output its content verbatim, then stop. No API calls.
 
-The help output explicitly names the 3 chained skills:
-gh:issue-implement, gh:commit, gh:pr.
+The help output explicitly names the 5 chained skills:
+gh:issue-implement, gh:commit, gh:pr, devx:schedule, gh:pr-resolve-conflict.
 
 ## Step 1: Parse Args
 
@@ -49,9 +50,9 @@ gh:issue-implement, gh:commit, gh:pr.
 
 This skill takes no `mode` arg; implementation is always `direct`.
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 2.4.
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 2.6.
 
-## Step 2: Chain the 3 Skills
+## Step 2: Chain the 5 Skills
 
 Invoke in order. Each uses Claude Code's Skill tool. Each runs only
 if the previous completed successfully.
@@ -81,12 +82,33 @@ if the previous completed successfully.
    ```
    Passing the issue number ensures `Closes #<N>` ends up in the PR
    body via gh:pr's Step 3 (issue resolution).
+   After this step succeeds, extract `PR_NUM` from the PR URL in the
+   output (last path segment of the `https://github.com/.../pull/<M>` URL).
+   **Now invoke Step 2.4 — no recap, no summary, no header.**
 
-4. **Step 2.4 — Post AI Metrics to Issue** (only if 2.3 succeeded; soft-fail)
+4. **Step 2.4 — devx:schedule** (only if 2.3 succeeded)
+   ```
+   Skill(devx:schedule, "--time 10 \"/gh-pr-reply <PR_NUM>\"")
+   ```
+   Schedules `/gh-pr-reply <PR_NUM>` to run 10 minutes after PR creation,
+   giving CI checks and reviewers time to post before the bot replies.
+   **Now invoke Step 2.5 — no recap, no summary, no header.**
+
+5. **Step 2.5 — gh:pr-resolve-conflict** (only if 2.4 succeeded)
+   ```
+   Skill(gh:pr-resolve-conflict, "<PR_NUM>")
+   ```
+   Checks and resolves any merge conflicts in the PR via rebase.
+   If the PR is already conflict-free (`MERGEABLE == MERGEABLE`), the
+   skill prints "PR은 이미 충돌 없음 — skip." and exits successfully —
+   this is the expected case for a freshly created PR. **Now invoke
+   Step 2.6 — no recap, no summary, no header.**
+
+6. **Step 2.6 — Post AI Metrics to Issue** (only if 2.5 succeeded; soft-fail)
 
    Post a flow-level aggregate metrics comment on the **linked GitHub Issue**.
    The PR body already carries the per-step `<!-- ai-metrics:gh-pr -->` block
-   written by `gh:pr`; this step adds the total across all three sub-skills to
+   written by `gh:pr`; this step adds the total across all five sub-skills to
    the Issue so the Issue thread is the single place to review full AI effort.
    This step soft-fails — warn on any error but never block the flow.
 
@@ -111,6 +133,8 @@ gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
 | gh-issue-implement | ~${IMPL_MIN:-?} min |
 | gh-commit | ~${COMMIT_MIN:-?} min |
 | gh-pr | ~${PR_MIN:-?} min |
+| devx:schedule (pr-reply) | ~${SCHEDULE_MIN:-?} min |
+| gh-pr-resolve-conflict | ~${CONFLICT_MIN:-?} min |
 | **합계** | **~$ELAPSED min** |
 
 👤 예상 사람 시간: ~$HUMAN_H h · 📊 ~$TOKENS tokens
@@ -123,21 +147,23 @@ gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
 If all steps succeeded:
 ```
 gh:issue-flow complete (#<N>)
-  ✓ Step 1: gh:issue-implement  (<n files changed>, <n tests passed>)
-  ✓ Step 2: gh:commit            (<sha> "<subject>")
-  ✓ Step 3: gh:pr                (PR #<M>)
-  ✓ Step 4: ai-metrics           (📊 ~X tokens · 👤 ~M h · 🤖 ~L min)
+  ✓ Step 1: gh:issue-implement       (<n files changed>, <n tests passed>)
+  ✓ Step 2: gh:commit                (<sha> "<subject>")
+  ✓ Step 3: gh:pr                    (PR #<M>)
+  ✓ Step 4: devx:schedule            (pr-reply in 10 min, job: <id>)
+  ✓ Step 5: gh:pr-resolve-conflict   (no conflicts / resolved)
+  ✓ Step 6: ai-metrics               (📊 ~X tokens · 👤 ~M h · 🤖 ~L min)
   PR URL: <pr-url>
 ```
 
-If Step 2.4 soft-failed, show `⚠️ Step 4: ai-metrics  (skipped — <reason>)` instead.
+If Step 2.6 soft-failed, show `⚠️ Step 6: ai-metrics  (skipped — <reason>)` instead.
 
 If a step failed:
 ```
-gh:issue-flow stopped at step <i>/3 (<skill-name>)
+gh:issue-flow stopped at step <i>/5 (<skill-name>)
   ✓ Step 1: gh:issue-implement  (<summary>)
   ✗ Step <i>: <skill-name>       (<failure reason>)
-  ⊘ Steps <i+1>..3               (not reached)
+  ⊘ Steps <i+1>..5               (not reached)
 
 Resume after fix:
   /<commands to finish>
@@ -147,16 +173,18 @@ Resume hint logic:
 - Failed at step 1 → `/gh-issue-implement <N>` (user decides retry).
 - Failed at step 2 → `/gh-commit && /gh-pr <N>`.
 - Failed at step 3 → `/gh-pr <N>`.
+- Failed at step 4 → `/devx:schedule --time 10 "/gh-pr-reply <PR_NUM>"`.
+- Failed at step 5 → `/gh-pr-resolve-conflict <PR_NUM>`.
 
 ## Constraints
 
 - Never invoke implementation modes other than `direct`.
 - Never retry a failed step. Human decides retry or fix.
-- Never skip a step. All 3 or stop.
+- Never skip a step. All 5 or stop.
 - Never mutate state between steps beyond what the sub-skills do.
-  Exception: Step 2.4 may edit the PR body after Step 2.3 — this is
+  Exception: Step 2.6 may post a comment after Step 2.5 — this is
   intentional and must soft-fail (never block the flow). If a future
-  variant of Step 2.4 needs to mutate PR labels or body, route through
+  variant of Step 2.6 needs to mutate PR labels or body, route through
   `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
   (`shell-common/functions/gh_pr_edit_safe.sh`); plain `gh pr edit
   --add-label` / `--body-file` silently exits 1 on repos with classic
@@ -177,3 +205,8 @@ Resume hint logic:
   markdown headers, no per-step bullet summaries. Such text reads as
   a turn-ending answer and re-introduces the early-stop. The only
   prose allowed inside Step 2 is the final Step 3 report.
+- **Do NOT stop after any sub-skill completes.** Each step (2.1 through
+  2.5) is a waypoint, not a final answer. Continue to the next step
+  immediately. The only valid stopping points are: a step failure
+  (output the failure report), or the Step 3 success report after all
+  5 steps complete.

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -9,17 +9,19 @@
 
 ## Usage
 
-- `/gh-issue-flow 16` — chain: implement → commit → PR for issue #16 on `origin`.
+- `/gh-issue-flow 16` — chain: implement → commit → PR → schedule pr-reply → resolve conflicts, for issue #16 on `origin`.
 - `/gh-issue-flow 16 upstream` — same chain on `upstream` remote.
 - `/gh-issue-flow -h` / `--help` / `help` — print this help.
 
 ## What this skill chains
 
-This skill invokes **3 skills in sequence** (each step runs only if the previous succeeded):
+This skill invokes **5 skills in sequence** (each step runs only if the previous succeeded):
 
 1. **`gh:issue-implement <N> direct`** — reads the issue, edits files, runs tests. No human intervention.
 2. **`gh:commit`** — creates a commit for the changes with a message derived from the conversation (follows the repo's commit style).
 3. **`gh:pr`** — pushes the branch and opens a PR, auto-linking `Closes #<N>`.
+4. **`devx:schedule --time 10 "/gh-pr-reply <PR#>"`** — schedules a pr-reply run 10 minutes after PR creation, giving CI and reviewers time to post before the bot replies.
+5. **`gh:pr-resolve-conflict <PR#>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
 
 If any step fails, the chain stops immediately. No automatic retry.
 The final report shows which steps ran, which failed, and how to

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -20,8 +20,8 @@ This skill invokes **5 skills in sequence** (each step runs only if the previous
 1. **`gh:issue-implement <N> direct`** — reads the issue, edits files, runs tests. No human intervention.
 2. **`gh:commit`** — creates a commit for the changes with a message derived from the conversation (follows the repo's commit style).
 3. **`gh:pr`** — pushes the branch and opens a PR, auto-linking `Closes #<N>`.
-4. **`devx:schedule --time 10 "/gh-pr-reply <PR#>"`** — schedules a pr-reply run 10 minutes after PR creation, giving CI and reviewers time to post before the bot replies.
-5. **`gh:pr-resolve-conflict <PR#>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
+4. **`devx:schedule` `--time 10 "/gh-pr-reply <PR_NUM>"`** — schedules a pr-reply run 10 minutes after PR creation, giving CI and reviewers time to post before the bot replies.
+5. **`gh:pr-resolve-conflict` `<PR_NUM>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
 
 If any step fails, the chain stops immediately. No automatic retry.
 The final report shows which steps ran, which failed, and how to


### PR DESCRIPTION
## Summary
- `gh-issue-flow` 워크플로우를 3단계에서 5단계로 확장 — PR 생성 후 pr-reply 예약과 conflict 해결을 자동으로 수행
- 조기 종료 방지를 위한 CRITICAL CONTRACT 강화 — "Do NOT stop after any sub-skill completes" 제약 명문화
- 보고 템플릿·resume hint·constraint 전반을 5단계 기준으로 업데이트

## Changes
- `gh-issue-flow/SKILL.md`: Step 2.4 (devx:schedule), Step 2.5 (gh-pr-resolve-conflict) 추가; 기존 ai-metrics를 Step 2.6으로 재번호; PR_NUM 추출 지시 추가
- `gh-issue-flow/references/help.md`: 5-step 체인 설명 및 사용 예시 업데이트

## Test plan
- [ ] `/gh-issue-flow <N>` 실행 시 5단계 전부 끊김 없이 완료 확인
- [ ] Step 3 완료 후 PR 번호가 Step 4·5에 올바르게 전달되는지 확인
- [ ] Step 4: `devx:schedule` 10분 예약 확인
- [ ] Step 5: `gh-pr-resolve-conflict` 충돌 없는 PR에서 skip 확인

## Related
Closes #360

---
<\!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~8 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->
