### PR TITLE
fix(gh-pr-resolve-conflict): use REST DELETE for conflict label removal

### DIFF
--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -102,15 +102,20 @@ the warning is cleared. Print the final report from
 
 **conflict 라벨 제거** (soft-fail — `mergeable == MERGEABLE` 인 경우에만):
 
-Check if `labels[].name` contains `"conflict"`. If so:
+Check if `labels[].name` contains `"conflict"`. If so, remove via REST DELETE
+(not `gh pr edit --remove-label`) — the latter can silent-fail on repos with
+classic Projects attached due to GraphQL deprecation (#326 Bug B, same pattern
+as `_gh_pr_edit_safe_label` fallback). 404 = label already absent → ignore.
 
 ```bash
-gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --remove-label "conflict" \
+gh api -X DELETE "repos/$TARGET_REPO/issues/$PR_NUMBER/labels/conflict" \
+    >/dev/null 2>&1 \
   && echo "✅ \`conflict\` 라벨 제거됨" \
-  || echo "⚠️  \`conflict\` 라벨 제거 실패 — 계속합니다."
+  || echo "⚠️  \`conflict\` 라벨 제거 실패 — GitHub Actions 가 cover."
 ```
 
-If the label is absent, skip silently (idempotent).
+If the label is absent, skip silently (idempotent — `gh api -X DELETE` returns
+404 which the `||` branch absorbs as a soft-fail warning).
 
 After the report, post a PR comment with ai-metrics (soft-fail — warn on
 error, never block). `CONFLICT_FILES` is the count of files that had

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -105,17 +105,25 @@ the warning is cleared. Print the final report from
 Check if `labels[].name` contains `"conflict"`. If so, remove via REST DELETE
 (not `gh pr edit --remove-label`) — the latter can silent-fail on repos with
 classic Projects attached due to GraphQL deprecation (#326 Bug B, same pattern
-as `_gh_pr_edit_safe_label` fallback). 404 = label already absent → ignore.
+as `_gh_pr_edit_safe_label` fallback). 404 = label already absent → the
+`||` branch surfaces a soft-fail warning, idempotent for the caller.
 
 ```bash
-gh api -X DELETE "repos/$TARGET_REPO/issues/$PR_NUMBER/labels/conflict" \
+gh api -X DELETE "repos/{owner}/{repo}/issues/$PR_NUMBER/labels/conflict" \
+    --repo "$TARGET_REPO" \
     >/dev/null 2>&1 \
   && echo "✅ \`conflict\` 라벨 제거됨" \
   || echo "⚠️  \`conflict\` 라벨 제거 실패 — GitHub Actions 가 cover."
 ```
 
-If the label is absent, skip silently (idempotent — `gh api -X DELETE` returns
-404 which the `||` branch absorbs as a soft-fail warning).
+`{owner}/{repo}` placeholder + `--repo "$TARGET_REPO"` 조합을 쓰는 이유:
+Step 1 의 `TARGET_REPO` 는 `git remote get-url` 결과(URL 형태)일 수
+있어 `repos/$TARGET_REPO/...` 직접 보간 시 경로가 깨질 수 있다. `gh api`
+의 `--repo` 플래그는 URL 과 `owner/repo` 양쪽 입력을 모두 안전하게
+파싱한다.
+
+If the label is absent, the `||` branch absorbs the 404 as a soft-fail
+warning (idempotent).
 
 After the report, post a PR comment with ai-metrics (soft-fail — warn on
 error, never block). `CONFLICT_FILES` is the count of files that had


### PR DESCRIPTION
## Summary
- PR #358 이 추가한 conflict 라벨 제거 명령이 #326 Bug B 의 회귀 패턴(classic Projects 부착 레포에서 GraphQL deprecation 으로 `gh pr edit --remove-label` silent fail)을 그대로 복제하고 있었다.
- `gh pr edit --remove-label` → `gh api -X DELETE` 직접 호출로 교체. 다른 3 개 스킬(`gh-issue-flow` / `gh-pr-reply` / `gh-pr`)이 이미 사용 중인 `_gh_pr_edit_safe_label` 우회 패턴과 같은 결로 정렬.

## Changes
- `claude/skills/gh-pr-resolve-conflict/SKILL.md`: conflict 라벨 제거 코드를 REST DELETE 로 교체. 주석에 `#326 Bug B`, `_gh_pr_edit_safe_label fallback` 출처를 명시하고, 404 응답을 idempotent 신호로 흡수 (`||` 분기에서 soft-fail 경고).

라벨 제거에는 `_gh_pr_edit_safe_label` 래퍼 대신 한 줄 REST DELETE 를 쓴 이유: 래퍼는 `gh label list` 사전 검증으로 자동 라벨 생성을 막는 게 목적인데, DELETE 는 자동 생성 위험 자체가 없어 (`feedback_gh_label_no_autocreate.md` 의 POST 사례와 다름) 사전 검증 단계가 불필요.

## Test plan
- [ ] classic Projects 보드가 부착된 dotfiles 레포에서 `/gh:pr-resolve-conflict` 실행 시 `✅ conflict 라벨 제거됨` 로그 확인.
- [ ] conflict 라벨이 이미 없는 PR 에 실행 시 404 가 `||` 분기에서 흡수되어 `⚠️ ... GitHub Actions 가 cover.` 로 떨어지고 후속 단계로 진행하는지 확인.
- [ ] `grep -n "_gh_pr_edit_safe_label\|gh api -X DELETE.*labels" claude/skills/` 결과가 `gh-issue-flow` / `gh-pr-reply` / `gh-pr-resolve-conflict` / `gh-pr/references/pr-body-template.md` 4 군데에서만 나오는지 확인 (라벨 처리 경로의 단일 SSOT 유지).

## Related
Refs #326

---
<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->
