### PR TITLE
feat(shell-common): --user 옵션 + multi-account 워커 라우팅

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -599,8 +599,10 @@ _gh_flow_prune() {
 gh_flow_help() {
     ux_header "gh-flow - fire-and-forget GitHub issue → PR automation"
     ux_info "Usage:"
-    ux_bullet "gh-flow <issue-number>... [--ai <agent>]  spawn N parallel workers"
+    ux_bullet "gh-flow <issue-number>... [--ai <agent>] [--user <account>]  spawn N parallel workers"
     ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "--user <account>: claude account (personal|work). Only with --ai claude."
+    ux_bullet_sub "                  Default: \$CLAUDE_DEFAULT_ACCOUNT (multi-account env)"
     ux_bullet "gh-flow status [<N>]            full table, or per-issue diagnostic"
     ux_bullet "gh-flow prune [--force] [<N>...] clean 'done' state, or scoped per-issue prune"
     ux_bullet "gh-flow -h|--help|help           this help"
@@ -615,6 +617,7 @@ gh_flow_help() {
     ux_bullet "gh-flow 13 42 88            # 3 issues in parallel"
     ux_bullet "gh-flow 33 --ai codex       # run workers with codex CLI"
     ux_bullet "gh-flow --ai gemini 44      # run workers with gemini CLI"
+    ux_bullet "gh-flow 13 --user work      # multi-account: route worker to ~/.claude-work"
     ux_bullet "gh-flow status              # full table — who's still running, who failed"
     ux_bullet "gh-flow status 153          # per-issue diagnostic (verdict + next action)"
     ux_bullet "gh-flow prune               # remove 'done' state dirs; print hints for failures"
@@ -672,7 +675,10 @@ gh_flow() {
     # Parse optional args:
     #   --ai <claude|codex|gemini>
     #   --ai=<claude|codex|gemini>
+    #   --user <account>          (claude multi-account, issue #365)
+    #   --user=<account>
     local _ai="claude"
+    local _account=""
     local _issue_args=""
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -687,9 +693,20 @@ gh_flow() {
         --ai=*)
             _ai="${1#--ai=}"
             ;;
+        --user)
+            shift
+            if [ $# -eq 0 ]; then
+                ux_error "--user requires a value (e.g., personal|work)"
+                return 1
+            fi
+            _account="$1"
+            ;;
+        --user=*)
+            _account="${1#--user=}"
+            ;;
         -*)
             ux_error "unknown option: '$1'"
-            ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|gemini>]"
+            ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|gemini>] [--user <account>]"
             return 1
             ;;
         *)
@@ -711,6 +728,24 @@ gh_flow() {
     if ! _gh_flow_known_ai "$_ai"; then
         ux_error "invalid --ai value: '$_ai' (allowed: claude, codex, gemini)"
         return 1
+    fi
+
+    # Validate --user (issue #365): only meaningful with --ai claude.
+    # Mirrors gwt spawn's policy and reuses _claude_resolve_account SSOT.
+    if [ -n "$_account" ]; then
+        if [ "$_ai" != "claude" ]; then
+            ux_error "--user is only supported with --ai claude (got: --ai $_ai)"
+            return 1
+        fi
+        if ! command -v _claude_resolve_account >/dev/null 2>&1; then
+            ux_error "--user requires shell-common claude integration (claude.sh) to be loaded"
+            return 1
+        fi
+        if ! _claude_resolve_account "$_account" >/dev/null 2>&1; then
+            ux_error "Unknown account: $_account"
+            ux_info "Available: $(_claude_resolve_account --list 2>/dev/null | tr '\n' ' ')"
+            return 1
+        fi
     fi
 
     # Preconditions
@@ -756,9 +791,9 @@ gh_flow() {
         esac
     done
 
-    ux_header "gh-flow: spawning $# worker(s) (ai=$_ai)"
+    ux_header "gh-flow: spawning $# worker(s) (ai=$_ai${_account:+ user=$_account})"
     for _issue in "$@"; do
-        _gh_flow_spawn_worker "$_issue" "$_ai"
+        _gh_flow_spawn_worker "$_issue" "$_ai" "$_account"
     done
     ux_success "All workers detached. Your shell is free. Results will appear on the kanban."
 }
@@ -766,11 +801,27 @@ gh_flow() {
 _gh_flow_spawn_worker() {
     local _issue="$1"
     local _ai="${2:-claude}"
-    local _dir _log _state _pid
+    local _account="${3:-}"
+    local _dir _log _state _pid _cfg_dir _resolve_account
     _dir=$(_gh_flow_issue_dir "$_issue")
     mkdir -p "$_dir"
     _log="$_dir/log"
     printf '%s\n' "$_ai" >"$_dir/ai"
+
+    # Resolve CLAUDE_CONFIG_DIR for the worker (issue #365). Without this,
+    # the bare `claude` binary inside the worker falls back to ~/.claude/
+    # which has no credentials in multi-account setups → "Not logged in".
+    # Priority: explicit --user > $CLAUDE_DEFAULT_ACCOUNT > none.
+    _cfg_dir=""
+    if [ "$_ai" = "claude" ]; then
+        _resolve_account="${_account:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
+        if [ -n "$_resolve_account" ]; then
+            if command -v _claude_resolve_account >/dev/null 2>&1; then
+                _cfg_dir="$(_claude_resolve_account "$_resolve_account" 2>/dev/null || true)"
+            fi
+            [ -z "$_cfg_dir" ] && _cfg_dir="$HOME/.claude-$_resolve_account"
+        fi
+    fi
 
     # Idempotency check
     _state=$(_gh_flow_get_state "$_issue")
@@ -799,15 +850,17 @@ _gh_flow_spawn_worker() {
     # Fork detached worker. DOTFILES_FORCE_INIT=1 forces full shell-common
     # loading in the non-interactive subshell so `gwt`, `ux_*`, and helpers
     # resolve. The subshell sources ~/.bashrc then calls _gh_flow_worker.
-    # shellcheck disable=SC2016
-    nohup env DOTFILES_FORCE_INIT=1 bash -c '
+    # CLAUDE_CONFIG_DIR is injected only when an account was resolved
+    # (issue #365) — single-account setups stay on the legacy path.
+    # shellcheck disable=SC2016,SC2086
+    nohup env DOTFILES_FORCE_INIT=1 ${_cfg_dir:+CLAUDE_CONFIG_DIR="$_cfg_dir"} bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_flow_worker "$1" "$2"
     ' -- "$_issue" "$_ai" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_issue → pid=$_pid  ai=$_ai  log=$_log"
+    ux_info "#$_issue → pid=$_pid  ai=$_ai${_cfg_dir:+ user=$_resolve_account}  log=$_log"
 }
 
 # ============================================================================

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -696,7 +696,7 @@ gh_flow() {
         --user)
             shift
             if [ $# -eq 0 ]; then
-                ux_error "--user requires a value (e.g., personal|work)"
+                ux_error "--user requires a value (expected: $(_claude_resolve_account --list 2>/dev/null | tr '\n' '|' | sed 's/|$//'))"
                 return 1
             fi
             _account="$1"
@@ -852,11 +852,22 @@ _gh_flow_spawn_worker() {
     # resolve. The subshell sources ~/.bashrc then calls _gh_flow_worker.
     # CLAUDE_CONFIG_DIR is injected only when an account was resolved
     # (issue #365) — single-account setups stay on the legacy path.
-    # shellcheck disable=SC2016,SC2086
-    nohup env DOTFILES_FORCE_INIT=1 ${_cfg_dir:+CLAUDE_CONFIG_DIR="$_cfg_dir"} bash -c '
-        . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_flow_worker "$1" "$2"
-    ' -- "$_issue" "$_ai" </dev/null >"$_log" 2>&1 &
+    # Branched explicitly (PR #366 review) instead of `${var:+VAR="$var"}`
+    # parameter expansion: the conditional form depends on POSIX word-split
+    # semantics that differ in zsh without `emulate -L sh`, and breaks if
+    # $HOME ever contains whitespace. The if/else version is shell-agnostic.
+    # shellcheck disable=SC2016
+    if [ -n "$_cfg_dir" ]; then
+        nohup env DOTFILES_FORCE_INIT=1 CLAUDE_CONFIG_DIR="$_cfg_dir" bash -c '
+            . "$HOME/.bashrc" 2>/dev/null || true
+            _gh_flow_worker "$1" "$2"
+        ' -- "$_issue" "$_ai" </dev/null >"$_log" 2>&1 &
+    else
+        nohup env DOTFILES_FORCE_INIT=1 bash -c '
+            . "$HOME/.bashrc" 2>/dev/null || true
+            _gh_flow_worker "$1" "$2"
+        ' -- "$_issue" "$_ai" </dev/null >"$_log" 2>&1 &
+    fi
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -109,8 +109,16 @@ _gh_pr_approve_check_ai_auth() {
         # profile's credentials.json first.
         _ccaa_account="${2:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
         _ccaa_dir=""
-        if [ -n "$_ccaa_account" ] && command -v _claude_resolve_account >/dev/null 2>&1; then
-            _ccaa_dir="$(_claude_resolve_account "$_ccaa_account" 2>/dev/null || true)"
+        if [ -n "$_ccaa_account" ]; then
+            if command -v _claude_resolve_account >/dev/null 2>&1; then
+                _ccaa_dir="$(_claude_resolve_account "$_ccaa_account" 2>/dev/null || true)"
+            fi
+            # Direct-path fallback (PR #366 review) — keeps auth check in
+            # sync with _gh_pr_approve_spawn_worker. Without this, a setup
+            # where claude.sh integration isn't loaded but the user has a
+            # ~/.claude-<account>/ profile would false-negative here while
+            # the worker would still successfully use the directory.
+            [ -z "$_ccaa_dir" ] && _ccaa_dir="$HOME/.claude-$_ccaa_account"
         fi
         if [ -n "$_ccaa_dir" ] && [ -f "$_ccaa_dir/.credentials.json" ]; then
             return 0
@@ -1000,11 +1008,22 @@ _gh_pr_approve_spawn_worker() {
     # resolve. The subshell sources ~/.bashrc then calls _gh_pr_approve_worker.
     # CLAUDE_CONFIG_DIR is injected only when an account was resolved
     # (issue #365) — single-account setups stay on the legacy path.
-    # shellcheck disable=SC2016,SC2086
-    nohup env DOTFILES_FORCE_INIT=1 ${_cfg_dir:+CLAUDE_CONFIG_DIR="$_cfg_dir"} bash -c '
-        . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_pr_approve_worker "$@"
-    ' -- "$_pr" "$_ai" "$_self_args" </dev/null >"$_log" 2>&1 &
+    # Branched explicitly (PR #366 review) instead of `${var:+VAR="$var"}`
+    # parameter expansion: the conditional form depends on POSIX word-split
+    # semantics that differ in zsh without `emulate -L sh`, and breaks if
+    # $HOME ever contains whitespace. The if/else version is shell-agnostic.
+    # shellcheck disable=SC2016
+    if [ -n "$_cfg_dir" ]; then
+        nohup env DOTFILES_FORCE_INIT=1 CLAUDE_CONFIG_DIR="$_cfg_dir" bash -c '
+            . "$HOME/.bashrc" 2>/dev/null || true
+            _gh_pr_approve_worker "$@"
+        ' -- "$_pr" "$_ai" "$_self_args" </dev/null >"$_log" 2>&1 &
+    else
+        nohup env DOTFILES_FORCE_INIT=1 bash -c '
+            . "$HOME/.bashrc" 2>/dev/null || true
+            _gh_pr_approve_worker "$@"
+        ' -- "$_pr" "$_ai" "$_self_args" </dev/null >"$_log" 2>&1 &
+    fi
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -103,10 +103,22 @@ _gh_pr_approve_check_ai_auth() {
         if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
             return 0
         fi
+        # Multi-account aware (issue #365): when --user is set or
+        # CLAUDE_DEFAULT_ACCOUNT routes the worker to ~/.claude-<account>/,
+        # the legacy paths below would false-positive. Check the resolved
+        # profile's credentials.json first.
+        _ccaa_account="${2:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
+        _ccaa_dir=""
+        if [ -n "$_ccaa_account" ] && command -v _claude_resolve_account >/dev/null 2>&1; then
+            _ccaa_dir="$(_claude_resolve_account "$_ccaa_account" 2>/dev/null || true)"
+        fi
+        if [ -n "$_ccaa_dir" ] && [ -f "$_ccaa_dir/.credentials.json" ]; then
+            return 0
+        fi
         if [ -f "$HOME/.claude/.credentials.json" ] || [ -f "$HOME/.claude.json" ]; then
             return 0
         fi
-        ux_error "claude CLI not authenticated. Run 'claude /login' first."
+        ux_error "claude CLI not authenticated${_ccaa_account:+ for account [$_ccaa_account]}. Run 'claude /login' first."
         return 1
         ;;
     codex)
@@ -659,8 +671,10 @@ _gh_pr_approve_prune() {
 gh_pr_approve_help() {
     ux_header "gh-pr-approve - fire-and-forget GitHub PR approval runner"
     ux_info "Usage:"
-    ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>] [--self-record|--admin-merge] [--squash|--rebase|--merge]"
+    ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>] [--user <account>] [--self-record|--admin-merge] [--squash|--rebase|--merge]"
     ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "--user <account>: claude account (personal|work). Only with --ai claude."
+    ux_bullet_sub "                  Default: \$CLAUDE_DEFAULT_ACCOUNT (multi-account env)"
     ux_bullet_sub "--self-record: for self-authored PRs, leave a comment-only review record"
     ux_bullet_sub "--admin-merge: for self-authored PRs, review then merge with gh pr merge --admin"
     ux_bullet_sub "--squash|--rebase|--merge: optional merge strategy for --admin-merge"
@@ -676,6 +690,7 @@ gh_pr_approve_help() {
     ux_bullet "gh-pr-approve 12 34 56                      # 3 PRs in parallel"
     ux_bullet "gh-pr-approve 42 --ai codex                 # run worker with codex CLI"
     ux_bullet "gh-pr-approve --ai gemini '#56' '#78'       # gemini + #prefix"
+    ux_bullet "gh-pr-approve 42 --user work                # multi-account: route worker to ~/.claude-work"
     ux_bullet "gh-pr-approve 42 --self-record              # self-PR comment-only record"
     ux_bullet "gh-pr-approve 42 --admin-merge --squash     # self-PR admin merge"
     ux_bullet "gh-pr-approve status                        # full table — who's still running, who failed"
@@ -744,11 +759,14 @@ gh_pr_approve() {
     # Parse optional args:
     #   --ai <claude|codex|gemini>
     #   --ai=<claude|codex|gemini>
+    #   --user <account>          (claude multi-account, issue #365)
+    #   --user=<account>
     #   --self-record             (comment-only self-PR mode in skill)
     #   --admin-merge             (admin merge self-PR mode in skill)
     #   --squash|--rebase|--merge (optional admin merge strategy)
     # Position-agnostic: any flag may appear before, between, or after PR numbers.
     local _ai="claude"
+    local _account=""
     local _self_record=0
     local _admin_merge=0
     local _merge_strategy=""
@@ -766,6 +784,17 @@ gh_pr_approve() {
             ;;
         --ai=*)
             _ai="${1#--ai=}"
+            ;;
+        --user)
+            shift
+            if [ $# -eq 0 ]; then
+                ux_error "missing value for --user (expected: $(_claude_resolve_account --list 2>/dev/null | tr '\n' '|' | sed 's/|$//'))"
+                return 1
+            fi
+            _account="$1"
+            ;;
+        --user=*)
+            _account="${1#--user=}"
             ;;
         --self-ok)
             ux_error "--self-ok is not supported; GitHub blocks self-approval server-side"
@@ -787,7 +816,7 @@ gh_pr_approve() {
             ;;
         -*)
             ux_error "unknown option: '$1'"
-            ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-record|--admin-merge]"
+            ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--user <account>] [--self-record|--admin-merge]"
             return 1
             ;;
         *)
@@ -814,6 +843,24 @@ gh_pr_approve() {
     if ! _gh_pr_approve_known_ai "$_ai"; then
         ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
         return 1
+    fi
+
+    # Validate --user (issue #365): only meaningful with --ai claude.
+    # Mirrors gwt spawn's policy and reuses _claude_resolve_account SSOT.
+    if [ -n "$_account" ]; then
+        if [ "$_ai" != "claude" ]; then
+            ux_error "--user is only supported with --ai claude (got: --ai $_ai)"
+            return 1
+        fi
+        if ! command -v _claude_resolve_account >/dev/null 2>&1; then
+            ux_error "--user requires shell-common claude integration (claude.sh) to be loaded"
+            return 1
+        fi
+        if ! _claude_resolve_account "$_account" >/dev/null 2>&1; then
+            ux_error "Unknown account: $_account"
+            ux_info "Available: $(_claude_resolve_account --list 2>/dev/null | tr '\n' ' ')"
+            return 1
+        fi
     fi
 
     # Preconditions
@@ -866,7 +913,7 @@ gh_pr_approve() {
 
     if [ "$_pr_count" -eq 0 ]; then
         ux_error "no PR numbers provided"
-        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--self-record|--admin-merge]"
+        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--user <account>] [--self-record|--admin-merge]"
         return 1
     fi
 
@@ -875,13 +922,15 @@ gh_pr_approve() {
     # zombie worktree + 'failed:approving' state dir afterwards. Done here
     # — after PR-number / main-repo validation — so obvious user errors
     # still surface their natural message instead of an auth complaint.
-    if ! _gh_pr_approve_check_ai_auth "$_ai"; then
+    # Pass --user account (or default) so multi-account profiles are
+    # checked against the right .credentials.json (issue #365).
+    if ! _gh_pr_approve_check_ai_auth "$_ai" "$_account"; then
         return 1
     fi
 
-    ux_header "gh-pr-approve: spawning $_pr_count worker(s) (ai=$_ai${_self_args:+ flags=$_self_args})"
+    ux_header "gh-pr-approve: spawning $_pr_count worker(s) (ai=$_ai${_account:+ user=$_account}${_self_args:+ flags=$_self_args})"
     for _pr in $_pr_args; do
-        _gh_pr_approve_spawn_worker "$_pr" "$_ai" "$_self_args"
+        _gh_pr_approve_spawn_worker "$_pr" "$_ai" "$_self_args" "$_account"
     done
     ux_success "All workers detached. Your shell is free. Results appear on the PR."
 }
@@ -890,11 +939,28 @@ _gh_pr_approve_spawn_worker() {
     local _pr="$1"
     local _ai="${2:-claude}"
     local _self_args="${3:-}"
-    local _dir _log _state _pid
+    local _account="${4:-}"
+    local _dir _log _state _pid _cfg_dir _resolve_account
     _dir=$(_gh_pr_approve_pr_dir "$_pr")
     mkdir -p "$_dir"
     _log="$_dir/log"
     printf '%s\n' "$_ai" >"$_dir/ai"
+
+    # Resolve CLAUDE_CONFIG_DIR for the worker (issue #365). Without this,
+    # the bare `claude` binary inside the worker falls back to ~/.claude/
+    # which has no credentials in multi-account setups → "Not logged in".
+    # Priority: explicit --user > $CLAUDE_DEFAULT_ACCOUNT > none. Fallback
+    # path used when claude.sh integration is not loaded in the parent.
+    _cfg_dir=""
+    if [ "$_ai" = "claude" ]; then
+        _resolve_account="${_account:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
+        if [ -n "$_resolve_account" ]; then
+            if command -v _claude_resolve_account >/dev/null 2>&1; then
+                _cfg_dir="$(_claude_resolve_account "$_resolve_account" 2>/dev/null || true)"
+            fi
+            [ -z "$_cfg_dir" ] && _cfg_dir="$HOME/.claude-$_resolve_account"
+        fi
+    fi
     # Record self-PR launch flags so `status <N>` can show them later.
     # Empty $_self_args → no file (status renders "(none)" then). Single
     # line, written even before the worker forks so a fail-fast spawn
@@ -932,15 +998,17 @@ _gh_pr_approve_spawn_worker() {
     # Fork detached worker. DOTFILES_FORCE_INIT=1 forces full shell-common
     # loading in the non-interactive subshell so `gwt`, `ux_*`, and helpers
     # resolve. The subshell sources ~/.bashrc then calls _gh_pr_approve_worker.
-    # shellcheck disable=SC2016
-    nohup env DOTFILES_FORCE_INIT=1 bash -c '
+    # CLAUDE_CONFIG_DIR is injected only when an account was resolved
+    # (issue #365) — single-account setups stay on the legacy path.
+    # shellcheck disable=SC2016,SC2086
+    nohup env DOTFILES_FORCE_INIT=1 ${_cfg_dir:+CLAUDE_CONFIG_DIR="$_cfg_dir"} bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_pr_approve_worker "$@"
     ' -- "$_pr" "$_ai" "$_self_args" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_pr -> pid=$_pid  ai=$_ai${_self_args:+ flags=$_self_args}  log=$_log"
+    ux_info "#$_pr -> pid=$_pid  ai=$_ai${_cfg_dir:+ user=$_resolve_account}${_self_args:+ flags=$_self_args}  log=$_log"
 }
 
 # ============================================================================

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -91,8 +91,10 @@ _gh_pr_reply_run_ai_prompt() {
 
 gh_pr_reply_help() {
     ux_header "gh-pr-reply - fire-and-forget GitHub PR review-reply runner"
-    ux_info "Usage: gh-pr-reply <pr-number>... [--ai <agent>] | -h|--help"
+    ux_info "Usage: gh-pr-reply <pr-number>... [--ai <agent>] [--user <account>] | -h|--help"
     ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "--user <account>: claude account (personal|work). Only with --ai claude."
+    ux_bullet_sub "                  Default: \$CLAUDE_DEFAULT_ACCOUNT (multi-account env)"
     ux_info ""
     ux_info "Spawns one background worker per PR. Each worker:"
     ux_bullet "gwt spawn → <ai> -p '/gh-pr-reply <N>' → gwt teardown"
@@ -107,6 +109,7 @@ gh_pr_reply_help() {
     ux_bullet "gh-pr-reply '#42'               # '#' prefix accepted"
     ux_bullet "gh-pr-reply 33 --ai codex       # run worker with codex CLI"
     ux_bullet "gh-pr-reply --ai gemini 44 55   # run workers with gemini CLI"
+    ux_bullet "gh-pr-reply 42 --user work      # multi-account: route worker to ~/.claude-work"
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-reply/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
@@ -153,8 +156,11 @@ gh_pr_reply() {
     # Parse optional args (PR numbers and --ai may interleave):
     #   --ai <claude|codex|gemini>
     #   --ai=<claude|codex|gemini>
-    # Last --ai wins on duplicates — same policy gh-flow chose for #208.
+    #   --user <account>          (claude multi-account, issue #365)
+    #   --user=<account>
+    # Last --ai/--user wins on duplicates — same policy gh-flow chose for #208.
     local _ai="claude"
+    local _account=""
     local _pr_args=""
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -169,9 +175,20 @@ gh_pr_reply() {
             --ai=*)
                 _ai="${1#--ai=}"
                 ;;
+            --user)
+                shift
+                if [ $# -eq 0 ]; then
+                    ux_error "--user requires a value (e.g., personal|work)"
+                    return 1
+                fi
+                _account="$1"
+                ;;
+            --user=*)
+                _account="${1#--user=}"
+                ;;
             -*)
                 ux_error "unknown option: '$1'"
-                ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>]"
+                ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>] [--user <account>]"
                 return 1
                 ;;
             *)
@@ -186,8 +203,26 @@ gh_pr_reply() {
     set -- $_pr_args
     if [ $# -eq 0 ]; then
         ux_error "no PR numbers provided"
-        ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>]"
+        ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>] [--user <account>]"
         return 1
+    fi
+
+    # Validate --user (issue #365): only meaningful with --ai claude.
+    # Mirrors gwt spawn's policy and reuses _claude_resolve_account SSOT.
+    if [ -n "$_account" ]; then
+        if [ "$_ai" != "claude" ]; then
+            ux_error "--user is only supported with --ai claude (got: --ai $_ai)"
+            return 1
+        fi
+        if ! command -v _claude_resolve_account >/dev/null 2>&1; then
+            ux_error "--user requires shell-common claude integration (claude.sh) to be loaded"
+            return 1
+        fi
+        if ! _claude_resolve_account "$_account" >/dev/null 2>&1; then
+            ux_error "Unknown account: $_account"
+            ux_info "Available: $(_claude_resolve_account --list 2>/dev/null | tr '\n' ' ')"
+            return 1
+        fi
     fi
 
     # Preconditions
@@ -237,9 +272,9 @@ gh_pr_reply() {
         _pr_clean_args="$_pr_clean_args $_pr_clean"
     done
 
-    ux_header "gh-pr-reply: spawning $# worker(s) (ai=$_ai)"
+    ux_header "gh-pr-reply: spawning $# worker(s) (ai=$_ai${_account:+ user=$_account})"
     for _pr in $_pr_clean_args; do
-        _gh_pr_reply_spawn_worker "$_pr" "$_ai"
+        _gh_pr_reply_spawn_worker "$_pr" "$_ai" "$_account"
     done
     ux_success "All workers detached. Your shell is free. Results appear on the PR."
 }
@@ -247,11 +282,27 @@ gh_pr_reply() {
 _gh_pr_reply_spawn_worker() {
     local _pr="$1"
     local _ai="${2:-claude}"
-    local _dir _log _state _pid
+    local _account="${3:-}"
+    local _dir _log _state _pid _cfg_dir _resolve_account
     _dir=$(_gh_pr_reply_pr_dir "$_pr")
     mkdir -p "$_dir"
     _log="$_dir/log"
     printf '%s\n' "$_ai" >"$_dir/ai"
+
+    # Resolve CLAUDE_CONFIG_DIR for the worker (issue #365). Without this,
+    # the bare `claude` binary inside the worker falls back to ~/.claude/
+    # which has no credentials in multi-account setups → "Not logged in".
+    # Priority: explicit --user > $CLAUDE_DEFAULT_ACCOUNT > none.
+    _cfg_dir=""
+    if [ "$_ai" = "claude" ]; then
+        _resolve_account="${_account:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
+        if [ -n "$_resolve_account" ]; then
+            if command -v _claude_resolve_account >/dev/null 2>&1; then
+                _cfg_dir="$(_claude_resolve_account "$_resolve_account" 2>/dev/null || true)"
+            fi
+            [ -z "$_cfg_dir" ] && _cfg_dir="$HOME/.claude-$_resolve_account"
+        fi
+    fi
 
     # Idempotency check — mirrors gh-pr-approve / gh-flow semantics.
     _state=$(_gh_pr_reply_get_state "$_pr")
@@ -288,15 +339,17 @@ _gh_pr_reply_spawn_worker() {
     # Fork detached worker. DOTFILES_FORCE_INIT=1 forces full shell-common
     # loading in the non-interactive subshell so `gwt`, `ux_*`, and helpers
     # resolve. The subshell sources ~/.bashrc then calls _gh_pr_reply_worker.
-    # shellcheck disable=SC2016
-    nohup env DOTFILES_FORCE_INIT=1 bash -c '
+    # CLAUDE_CONFIG_DIR is injected only when an account was resolved
+    # (issue #365) — single-account setups stay on the legacy path.
+    # shellcheck disable=SC2016,SC2086
+    nohup env DOTFILES_FORCE_INIT=1 ${_cfg_dir:+CLAUDE_CONFIG_DIR="$_cfg_dir"} bash -c '
         . "$HOME/.bashrc" 2>/dev/null || true
         _gh_pr_reply_worker "$1" "$2"
     ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"
-    ux_info "#$_pr → pid=$_pid  ai=$_ai  log=$_log"
+    ux_info "#$_pr → pid=$_pid  ai=$_ai${_cfg_dir:+ user=$_resolve_account}  log=$_log"
 }
 
 # ============================================================================

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -178,7 +178,7 @@ gh_pr_reply() {
             --user)
                 shift
                 if [ $# -eq 0 ]; then
-                    ux_error "--user requires a value (e.g., personal|work)"
+                    ux_error "--user requires a value (expected: $(_claude_resolve_account --list 2>/dev/null | tr '\n' '|' | sed 's/|$//'))"
                     return 1
                 fi
                 _account="$1"
@@ -341,11 +341,22 @@ _gh_pr_reply_spawn_worker() {
     # resolve. The subshell sources ~/.bashrc then calls _gh_pr_reply_worker.
     # CLAUDE_CONFIG_DIR is injected only when an account was resolved
     # (issue #365) — single-account setups stay on the legacy path.
-    # shellcheck disable=SC2016,SC2086
-    nohup env DOTFILES_FORCE_INIT=1 ${_cfg_dir:+CLAUDE_CONFIG_DIR="$_cfg_dir"} bash -c '
-        . "$HOME/.bashrc" 2>/dev/null || true
-        _gh_pr_reply_worker "$1" "$2"
-    ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
+    # Branched explicitly (PR #366 review) instead of `${var:+VAR="$var"}`
+    # parameter expansion: the conditional form depends on POSIX word-split
+    # semantics that differ in zsh without `emulate -L sh`, and breaks if
+    # $HOME ever contains whitespace. The if/else version is shell-agnostic.
+    # shellcheck disable=SC2016
+    if [ -n "$_cfg_dir" ]; then
+        nohup env DOTFILES_FORCE_INIT=1 CLAUDE_CONFIG_DIR="$_cfg_dir" bash -c '
+            . "$HOME/.bashrc" 2>/dev/null || true
+            _gh_pr_reply_worker "$1" "$2"
+        ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
+    else
+        nohup env DOTFILES_FORCE_INIT=1 bash -c '
+            . "$HOME/.bashrc" 2>/dev/null || true
+            _gh_pr_reply_worker "$1" "$2"
+        ' -- "$_pr" "$_ai" </dev/null >"$_log" 2>&1 &
+    fi
     _pid=$!
     disown "$_pid" 2>/dev/null || true
     printf '%s\n' "$_pid" >"$_dir/pid"

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -223,6 +223,42 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# --user option (multi-account, issue #365)
+# ---------------------------------------------------------------------------
+
+@test "dispatcher: --user without value fails with clear message" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --user 2>&1"
+    assert_failure
+    assert_output --partial "--user requires a value"
+}
+
+@test "dispatcher: --user <unknown> is rejected with available list" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --user nope 2>&1"
+    assert_failure
+    assert_output --partial "Unknown account: nope"
+    assert_output --partial "Available:"
+}
+
+@test "dispatcher: --user with --ai codex is rejected (claude-only)" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --user personal --ai codex 2>&1"
+    assert_failure
+    assert_output --partial "--user is only supported with --ai claude"
+}
+
+@test "dispatcher: --user personal parses (parser accepts known account)" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --user personal 2>&1 || true"
+    refute_output --partial "Unknown account"
+    refute_output --partial "--user requires a value"
+    refute_output --partial "only supported with --ai claude"
+}
+
+@test "help: documents --user option" {
+    run_in_bash "gh_flow_help"
+    assert_success
+    assert_output --partial "--user"
+}
+
+# ---------------------------------------------------------------------------
 # post-condition helpers (the ones the worker uses between Step 2 sub-steps)
 # ---------------------------------------------------------------------------
 

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -201,6 +201,50 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# --user option (multi-account, issue #365)
+# ---------------------------------------------------------------------------
+
+@test "bash: '--user' without value fails with clear message" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --user 2>&1"
+    assert_failure
+    assert_output --partial "missing value for --user"
+}
+
+@test "bash: '--user <unknown>' is rejected with available list" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --user nope 2>&1"
+    assert_failure
+    assert_output --partial "Unknown account: nope"
+    assert_output --partial "Available:"
+}
+
+@test "bash: '--user personal --ai codex' is rejected (claude-only)" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --user personal --ai codex 2>&1"
+    assert_failure
+    assert_output --partial "--user is only supported with --ai claude"
+}
+
+@test "bash: '--user personal' parses (parser accepts known account)" {
+    # Reaches a later precondition error (no claude CLI / no auth) — proving
+    # the parser/validator block didn't reject the flag itself.
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --user personal 2>&1 || true"
+    refute_output --partial "Unknown account"
+    refute_output --partial "missing value for --user"
+    refute_output --partial "only supported with --ai claude"
+}
+
+@test "bash: '--user=work' equals form is accepted" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --user=work 2>&1 || true"
+    refute_output --partial "Unknown account"
+    refute_output --partial "missing value for --user"
+}
+
+@test "help: documents --user option" {
+    run_in_bash "gh_pr_approve_help"
+    assert_success
+    assert_output --partial "--user"
+}
+
+# ---------------------------------------------------------------------------
 # self-PR options
 # ---------------------------------------------------------------------------
 

--- a/tests/bats/functions/gh_pr_reply.bats
+++ b/tests/bats/functions/gh_pr_reply.bats
@@ -217,6 +217,48 @@ teardown() {
     refute_output --partial "unknown option"
 }
 
+# ---------------------------------------------------------------------------
+# --user option (multi-account, issue #365)
+# ---------------------------------------------------------------------------
+
+@test "bash: '--user' without value fails with clear message" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --user 2>&1"
+    assert_failure
+    assert_output --partial "--user requires a value"
+}
+
+@test "bash: '--user <unknown>' is rejected with available list" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --user nope 2>&1"
+    assert_failure
+    assert_output --partial "Unknown account: nope"
+    assert_output --partial "Available:"
+}
+
+@test "bash: '--user' with --ai codex is rejected (claude-only)" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --user personal --ai codex 2>&1"
+    assert_failure
+    assert_output --partial "--user is only supported with --ai claude"
+}
+
+@test "bash: '--user personal' parses (parser accepts known account)" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --user personal 2>&1 || true"
+    refute_output --partial "Unknown account"
+    refute_output --partial "--user requires a value"
+    refute_output --partial "only supported with --ai claude"
+}
+
+@test "bash: '--user=work' equals form is accepted" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --user=work 2>&1 || true"
+    refute_output --partial "Unknown account"
+    refute_output --partial "--user requires a value"
+}
+
+@test "help: documents --user option" {
+    run_in_bash "gh_pr_reply_help"
+    assert_success
+    assert_output --partial "--user"
+}
+
 @test "bash: failed-run guard still applies on --ai path" {
     # The data-loss-prevention guarantee (failed:* must not auto-resume)
     # is invariant across ai runners — switching --ai must not silently


### PR DESCRIPTION
## Summary
- gh-pr-approve / gh-flow / gh-pr-reply 의 detach 워커가 multi-account
  환경에서 즉시 "Not logged in"으로 실패하던 회귀를 수정.
- 3개 명령어에 `--user [personal|work]` 옵션 추가 — gwt spawn (#295)
  의 디자인을 그대로 차용해 일관성 유지.
- spawn 라인에 `${_cfg_dir:+CLAUDE_CONFIG_DIR=...}` 단발성 주입으로
  single-account 사용자에겐 영향 없음.

## Changes
- **shell-common/functions/gh_pr_approve.sh**
  - `--user <account>` / `--user=<account>` 파싱 추가
  - validator: `--ai claude` 와만 결합 가능, `_claude_resolve_account` SSOT 검증
  - `_gh_pr_approve_check_ai_auth` multi-account 인지화: `$_account` 매개변수
    추가, `$_cfg_dir/.credentials.json` 우선 검사 후 legacy fallback
  - spawn 함수: `_resolve_account` (`--user` ∨ `$CLAUDE_DEFAULT_ACCOUNT`) →
    `_cfg_dir` 해석 → `nohup env … ${_cfg_dir:+CLAUDE_CONFIG_DIR=…}` 조건부 주입
  - help: 옵션 1 줄, 예제 1 줄 추가
- **shell-common/functions/gh_flow.sh** — 동일 패턴 (auth pre-flight 없으므로 5 단계 중 4 단계만 적용)
- **shell-common/functions/gh_pr_reply.sh** — 동일 패턴
- **tests/bats/functions/{gh_pr_approve,gh_flow,gh_pr_reply}.bats** — 17 개 신규 테스트
  - parser: `--user` 값 누락, 알 수 없는 account, `=` 폼
  - validator: `--user` + 비-claude `--ai` 거부, known account 수용
  - help: `--user` 노출 검증

## Test plan
- [x] `bash -n` / `zsh -n` clean — 3 개 .sh 파일
- [x] `shellcheck -s sh` — 신규 경고 0 건 (기존 SC3043/SC3001/SC3044 baseline 보존)
- [x] `tests/bats/functions/` 전체 326 개 테스트 통과 (회귀 0 건)
- [x] live smoke-test: `${_cfg_dir:+CLAUDE_CONFIG_DIR=…}` argv 확장이
  의도한 결과를 생성 — 빈 값 → arg 미주입, 비어 있지 않음 → 단일 env arg
- [x] live worker spawn: `~/.claude-{personal,work}/.credentials.json` 경로의
  자격증명을 워커가 정확히 사용함을 확인

## Notes
- `_claude_resolve_account` 가 로드되지 않은 환경(claude.sh 통합 미적용)
  에서는 spawn-time fallback 으로 `$HOME/.claude-${account}` 직접 구성.
  parser-time validator 는 SSOT 부재시 명확한 에러로 거부.
- shellcheck 디렉티브 `SC2086` 추가 (3 곳) — `${var:+key=$var}` 패턴이 의도한
  POSIX 조건부 argv 확장이라 word-split 경고는 의도된 동작.

## Related
Closes #365

---
<\!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~4 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->
