### PR TITLE
fix(skills/ai-metrics): wrap footer in <details> to hide HTML tags

### DIFF
--- a/claude/skills/gh-add-ai-metrics/references/footer-detection.md
+++ b/claude/skills/gh-add-ai-metrics/references/footer-detection.md
@@ -5,14 +5,16 @@ Detection and edit logic for the `<!-- ai-metrics -->` footer used by
 
 ## Marker grammar
 
-Two forms exist in the wild — both must be detected as "already tagged":
+Three forms exist in the wild — all must be detected as "already tagged":
 
 - `<!-- ai-metrics -->` … `<!-- /ai-metrics -->`
   (the original PR #320 / `gh-issue-create` shape)
 - `<!-- ai-metrics:<skill-name> -->` … `<!-- /ai-metrics:<skill-name> -->`
-  (the newer `metrics-helper.md` scheme used by post-#320 retro-fit work)
+  (the `metrics-helper.md` scheme used by post-#320 retro-fit work)
+- `<details>\n<summary>🤖 AI Metrics · …</summary>\n\n<!-- ai-metrics(:<skill>)? -->` … `<!-- /ai-metrics(:<skill>)? -->\n\n</details>`
+  (the new `<details>`-wrapped form introduced in issue #367 — default for new cards)
 
-A single regex covers both:
+A single regex covers all three:
 
 ```
 <!-- ai-metrics(:[a-zA-Z0-9_-]+)? -->[\s\S]*?<!-- /ai-metrics(:[a-zA-Z0-9_-]+)? -->
@@ -35,9 +37,10 @@ has_footer() {
   # (`<!-- ai-metrics -->` in backticks) do not match. The leading
   # `\n+` tolerates both PR #320's `\n---\n` (single) and the newer
   # `\n\n---\n` (double) append conventions.
+  # The optional `<details>…</summary>\n\n` allows the new #367 wrapped form.
   printf '%s' "$1" | perl -0777 -ne '
     exit (
-      /\n+---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->\n.*?\n<!-- \/ai-metrics(?::[A-Za-z0-9_-]+)? -->/s
+      /\n+---\n(?:<details>\n<summary>[^\n]*<\/summary>\n\n)?<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->\n.*?\n<!-- \/ai-metrics(?::[A-Za-z0-9_-]+)? -->/s
       ? 0 : 1
     )'
 }
@@ -52,37 +55,40 @@ shipping environment, so this stays portable.
 ```bash
 append_footer() {
   local body="$1" tokens="$2" human="$3" elapsed="$4"
-  printf '%s\n\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
-    "$body" "$tokens" "$human" "$elapsed"
+  printf '%s\n\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
+    "$body" "$tokens" "$human" "$elapsed" "$tokens" "$human" "$elapsed"
 }
 ```
 
 The leading `\n\n---\n` ensures the footer is visually separated from the
 preceding section even when the original body did not end with a newline.
+The `<details>` wrapper collapses the block on GitHub by default, keeping
+the PR/issue body readable while the metrics remain accessible on click.
 
 ## In-place replace (`--force` path)
 
 `perl -0777` for slurp-mode multiline regex. `python3` is the fallback if
-perl is unavailable (rare). Note the negated `:gh-add-ai-metrics` capture
-when re-emitting — we always emit the colonless form to stay 1:1 with
-`gh-issue-create`'s SSOT shape.
+perl is unavailable (rare). We always emit the new `<details>`-wrapped form
+regardless of which form was found — this upgrades old-format footers in place.
 
 ```bash
 replace_footer() {
   local body="$1" tokens="$2" human="$3" elapsed="$4"
   local new_block
-  new_block=$(printf '<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->' \
-    "$tokens" "$human" "$elapsed")
+  new_block=$(printf '<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>' \
+    "$tokens" "$human" "$elapsed" "$tokens" "$human" "$elapsed")
   printf '%s' "$body" \
     | NEW="$new_block" perl -0777 -pe '
         BEGIN { $n = $ENV{NEW} }
-        s|<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->|$n|s
+        s|(?:<details>\n<summary>[^\n]*</summary>\n\n)?<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->(?:\n\n</details>)?|$n|s
       '
 }
 ```
 
 The `BEGIN`-block pattern reads `$NEW` from the env so newline-bearing
 replacements survive the perl substitution untouched (no `$1` collision).
+The outer `(?:<details>…)?` / `(?:…</details>)?` optionals match both the
+old bare form and the new wrapped form, enabling in-place upgrade.
 
 ## `--force` on a card without a footer
 
@@ -152,10 +158,10 @@ line — emitted to stdout, not posted as a comment.
 
 A retro-fit run is correct iff:
 
-1. Stripping the new `\n+---\n<!-- ai-metrics -->…<!-- /ai-metrics -->`
+1. Stripping the new `\n+---\n<details>…<!-- ai-metrics -->…<!-- /ai-metrics -->…</details>`
    block from the post-edit body yields the original (pre-edit) body
    byte-for-byte (regardless of whether append used `\n---\n` or
-   `\n\n---\n`).
+   `\n\n---\n`). Same must hold for the legacy bare form.
 2. Running the skill twice without `--force` produces zero edit API
    calls on the second run.
 3. Running once with `--force` and once without on the same card
@@ -164,3 +170,7 @@ A retro-fit run is correct iff:
    in inline code spans (e.g. `\`<!-- ai-metrics -->\`` inside docs).
    Issue #324 of this repo is the canonical positive example for this
    case after stripping.
+5. `has_footer` returns true for the new `<details>`-wrapped form
+   (issue #367) as well as for legacy bare `<!-- ai-metrics -->` blocks.
+6. `replace_footer` called on a legacy bare-form footer emits the new
+   `<details>`-wrapped form (in-place upgrade on `--force`).

--- a/claude/skills/gh-add-ai-metrics/references/post-hoc-metrics.md
+++ b/claude/skills/gh-add-ai-metrics/references/post-hoc-metrics.md
@@ -24,7 +24,7 @@ exists, so it is safe to run unconditionally.
 
 ```bash
 stripped=$(printf '%s' "$body" \
-  | perl -0777 -pe 's|\n+---\n<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->\n?||s')
+  | perl -0777 -pe 's|\n+---\n(?:<details>\n<summary>[^\n]*</summary>\n\n)?<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->.*?<!-- /ai-metrics(?::[A-Za-z0-9_-]+)? -->(?:\n\n</details>)?\n?||s')
 ```
 
 Regex notes:
@@ -33,10 +33,13 @@ Regex notes:
   on its own line. Tolerates both append conventions in the wild —
   PR #320's `\n---\n` (single) and `gh-issue-create`'s `\n\n---\n`
   (double) — without leaving a stray newline behind in either case.
+- `(?:<details>\n<summary>[^\n]*</summary>\n\n)?` optionally matches the
+  new `<details>` wrapper prefix introduced in issue #367.
 - `<!-- ai-metrics(?::[A-Za-z0-9_-]+)? -->` matches both the colonless
   form and the suffixed form (`<!-- ai-metrics:gh-pr -->`).
 - `.*?` non-greedy + the `s` flag scopes the match to the nearest
   closing marker.
+- `(?:\n\n</details>)?` optionally matches the closing `</details>` tag.
 
 ## TOKENS
 

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -93,8 +93,8 @@ Store results as `TOKENS`, `HUMAN_H`, `ELAPSED` for use in Step 4.
 ```bash
 BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 # ... write body to "$BODY" ...
-printf '\n---\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n' \
-  "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
+  "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
 gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY"
 ```
 

--- a/claude/skills/gh-issue-create/references/metrics-baseline.md
+++ b/claude/skills/gh-issue-create/references/metrics-baseline.md
@@ -86,10 +86,18 @@ Priority order — first available wins:
 Append after a `---` horizontal rule at the end of the body:
 
     ---
+    <details>
+    <summary>🤖 AI Metrics · 📊 ~X tokens · 👤 ~M h · 🤖 ~L min</summary>
+
     <!-- ai-metrics -->
     📊 ~X tokens · 👤 ~M h · 🤖 ~L min
     <!-- /ai-metrics -->
 
+    </details>
+
 - `X` — estimated tokens (see Token Estimation above)
 - `M` — human hours from the lookup table (e.g. `4 h`, `8 h`, `~1 d`)
 - `L` — elapsed minutes from skill entry to issue/PR creation
+- The `<details>` wrapper collapses the block by default on GitHub,
+  keeping the body readable while making metrics accessible on click.
+  The HTML comment markers inside are hidden by GitHub's renderer.

--- a/claude/skills/gh-issue-create/references/metrics-helper.md
+++ b/claude/skills/gh-issue-create/references/metrics-helper.md
@@ -53,16 +53,21 @@ From `gh-issue-create/references/metrics-baseline.md` by issue type:
 
 ```
 ---
+<details>
+<summary>🤖 AI Metrics · 📊 ~{TOKENS} tokens · 👤 ~{HUMAN_H} h · 🤖 ~{ELAPSED} min</summary>
+
 <!-- ai-metrics:<skill> -->
 📊 ~{TOKENS} tokens · 👤 ~{HUMAN_H} h · 🤖 ~{ELAPSED} min
 <!-- /ai-metrics:<skill> -->
+
+</details>
 ```
 
 Append via `printf` to a temp file before creating the artifact:
 
 ```bash
-printf '\n---\n<!-- ai-metrics:%s -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:%s -->\n' \
-  "$SKILL" "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" >> "$BODY"
+printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:%s -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:%s -->\n\n</details>\n' \
+  "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" >> "$BODY"
 ```
 
 ### GitHub PR / Issue comment
@@ -96,7 +101,9 @@ When editing an existing PR body (e.g., `gh-issue-flow`):
 python3 -c "
 import re, sys
 body = sys.stdin.read()
-body = re.sub(r'\n?---\n<!-- ai-metrics(:.*?)? -->.*?<!-- /ai-metrics(:.*?)? -->\n?', '', body, flags=re.DOTALL)
+body = re.sub(
+  r'\n?---\n(?:<details>\n<summary>[^\n]*</summary>\n\n)?<!-- ai-metrics(:.*?)? -->.*?<!-- /ai-metrics(:.*?)? -->(?:\n\n</details>)?\n?',
+  '', body, flags=re.DOTALL)
 sys.stdout.write(body)" < existing_body > stripped_body
 ```
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -79,8 +79,8 @@ footer block (soft-fail — warn on error, never block):
 ```bash
 # After running the snippet from references/metrics-helper.md, $TOKENS is
 # bound to the correct estimate. Now append the footer to $BODY.
-printf '\n---\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n' \
-  "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n\n</details>\n' \
+  "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
 ```
 
 ## Step 5: Push and Create


### PR DESCRIPTION
## Summary

- `gh:pr`, `gh:issue-create`, `gh:add-ai-metrics` 스킬의 ai-metrics footer를 `<details>` 블록으로 래핑하여 HTML 주석 태그 노출 문제를 수정

## Changes

- **gh-pr/SKILL.md, gh-issue-create/SKILL.md**: `printf` 템플릿을 `<details>` 래핑 형식으로 변경 — GitHub에서 collapsed로 기본 표시되어 본문 가독성 보존
- **footer-detection.md**: `has_footer()` regex에 `<details>` prefix 추가; `append_footer()`가 새 형식 emit; `replace_footer()`가 구형/신형 양쪽 탐지 및 `--force` 시 구형 → 신형 자동 업그레이드; test rubric 항목 5·6 추가
- **post-hoc-metrics.md**: always-strip regex에 `<details>` wrapper 포함
- **metrics-baseline.md, metrics-helper.md**: Block Format 문서를 새 canonical 형식으로 업데이트

## Test plan

- [ ] `has_footer()` — 기존 `<\!-- ai-metrics -->` bare 형식 탐지 확인
- [ ] `has_footer()` — 신형 `<details>` 래핑 형식 탐지 확인
- [ ] `replace_footer()` — 구형 bare footer에 `--force` 적용 시 신형으로 업그레이드되는지 확인
- [ ] `append_footer()` — 새 `<details>` 블록 포맷으로 append되는지 확인
- [ ] `post-hoc-metrics.md` strip regex — 신형 footer 제거 후 원본 body 복원 확인

## Related

Closes #367

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
