### PR TITLE
feat(skills): /devx:rate-limit-guard + /devx:resume-after-limit

### DIFF
--- a/claude/skills/devx-rate-limit-guard/SKILL.md
+++ b/claude/skills/devx-rate-limit-guard/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: devx:rate-limit-guard
+description: >-
+  [Claude Code Only] Wrap a long-running command with a rate-limit safety net.
+  Schedules a `CronCreate(durable=true)` that fires at the user-supplied reset
+  time, runs the wrapped command, and clears the safety net on successful
+  completion. Use when the user runs /devx:rate-limit-guard,
+  /devx-rate-limit-guard, or asks "rate limit 걸려도 자동 재개", "퇴근하면서
+  작업 시키고 limit 풀리면 이어가게 해줘", "auto-resume after my token limit
+  resets". Requires the user to know their reset time (run /usage first).
+  Accepts `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Write, CronCreate, CronDelete
+---
+
+# devx:rate-limit-guard — Rate-Limit Resume Safety Net
+
+> **Claude Code only**. Requires this worktree's Claude Code session to stay
+> open (or be reopened in this worktree) so the durable cron can fire.
+
+If arg #1 is `-h`/`--help`/`help`, print `references/help.md` verbatim and stop.
+
+## Usage
+
+```
+/devx:rate-limit-guard --reset HH:MM [--buffer M] <command>
+```
+
+- `--reset HH:MM` — local 24h reset time (REQUIRED, from `/usage`)
+- `--buffer M` — minutes after reset to fire (default: 5)
+- `<command>` — slash-command or natural-language task to wrap
+
+## Steps
+
+### 1. Parse Arguments
+
+Extract `--reset HH:MM` (required) and `--buffer M` (default 5). Everything
+after flags is the wrapped command (preserve quoting). If `--reset` is
+missing/malformed, print
+`필수 인자 --reset HH:MM 누락. /usage로 리셋 시각 확인 후 재시도.` and stop.
+
+### 2. Compute Fire Time
+
+```bash
+python3 claude/skills/devx-rate-limit-guard/references/compute-fire-time.py HH MM B
+```
+
+Output: `<min> <hour> <dom> <month> <iso>` — first four = cron expression, `<iso>` = state-file timestamp.
+
+### 3. Capture Worktree Context
+
+```bash
+PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
+```
+
+### 4. Schedule via `CronCreate`
+
+- `cron`: `"<min> <hour> <dom> <month> *"` (from step 2)
+- `prompt`: see `references/cron-prompt-template.md` — substitute
+  `<PWD_NOW>`, `<BRANCH>`, `<command>` and pass verbatim
+- `recurring`: `false`, `durable`: `true`
+
+Save the returned job ID.
+
+### 5. Persist Cleanup State
+
+Write `.claude/.rate-limit-guard.json` (worktree root):
+
+```json
+{"cron_id":"<id>","command":"<command>","worktree":"<PWD_NOW>","branch":"<BRANCH>","scheduled_for":"<ISO>"}
+```
+
+### 6. Confirm
+
+```
+🛡️ Rate-limit 안전망 등록
+  • 원본 명령: <command>
+  • 자동 재개 시각: <HH:MM + buffer> (job: <id>)
+  • 정상 완료 시 자동 해제됩니다.
+이제 원본 명령을 실행합니다 ↓
+```
+
+### 7. Execute, then Cleanup on Success
+
+Hand off to the wrapped command. After it finishes successfully, in the same turn:
+`CronDelete(<id>)` → `rm -f .claude/.rate-limit-guard.json` →
+print `✅ 안전망 해제 — 정상 완료`.
+
+On transient errors (rate limit, network, timeout), **leave the cron in
+place** — that is exactly when the safety net should fire. Only clean up
+on definitive success or explicit user request.
+
+## Constraints
+
+- Never schedule without explicit `--reset HH:MM`.
+- Never use `recurring: true` or `durable: false`.
+- Never auto-cleanup on rate-limit / network / timeout errors.
+- Never invoke from inside another skill — user-triggered only.

--- a/claude/skills/devx-rate-limit-guard/references/compute-fire-time.py
+++ b/claude/skills/devx-rate-limit-guard/references/compute-fire-time.py
@@ -1,0 +1,22 @@
+"""Compute the next future <reset + buffer> moment as cron fields + ISO.
+
+Invoke from Bash with three integers inlined:
+
+    python3 references/compute-fire-time.py HH MM B
+
+Output (single line, space-separated):
+    <min> <hour> <dom> <month> <iso8601>
+
+The first four fields are the cron expression (minus DoW); the trailing
+ISO timestamp is for the state file written by Step 5 of SKILL.md.
+"""
+
+import sys
+from datetime import datetime, timedelta
+
+H, M, B = (int(x) for x in sys.argv[1:4])
+now = datetime.now()
+fire = now.replace(hour=H, minute=M, second=0, microsecond=0) + timedelta(minutes=B)
+if fire <= now:
+    fire += timedelta(days=1)
+print(fire.strftime("%M %H %d %m"), fire.isoformat())

--- a/claude/skills/devx-rate-limit-guard/references/cron-prompt-template.md
+++ b/claude/skills/devx-rate-limit-guard/references/cron-prompt-template.md
@@ -1,0 +1,25 @@
+# Cron Prompt Template
+
+Use this exact text for the `prompt:` argument of `CronCreate` in Step 4.
+Substitute `<PWD_NOW>`, `<BRANCH>`, and `<command>` with the values
+captured in Steps 1 and 3.
+
+```
+[Auto-resume by /devx:rate-limit-guard]
+워크트리: <PWD_NOW>
+브랜치: <BRANCH>
+원본 명령: <command>
+
+현재 워크트리·브랜치가 위와 같으면 원본 명령을 다시 실행. 명령은 멱등적으로
+설계되어 이미 완료된 sub-step은 스킵됨. 다르면 사용자에게 알리고 중단.
+/devx:resume-after-limit 스킬이 존재하면 우선 호출.
+```
+
+## Why self-contained
+
+The prompt must work even before the companion `/devx:resume-after-limit`
+skill is implemented. By embedding worktree/branch/command directly, the
+fired prompt gives Claude enough context to resume safely on its own.
+
+When the companion skill exists, the last line nudges Claude to delegate
+to it for the standardized sanity check + announce flow.

--- a/claude/skills/devx-rate-limit-guard/references/help.md
+++ b/claude/skills/devx-rate-limit-guard/references/help.md
@@ -1,0 +1,75 @@
+# devx:rate-limit-guard — Help
+
+## Usage
+
+```
+/devx:rate-limit-guard --reset HH:MM [--buffer M] <command>
+/devx-rate-limit-guard --reset 18:00 /gh-issue-flow 399
+/devx:rate-limit-guard -h            # show this help
+/devx:rate-limit-guard --help        # show this help
+/devx:rate-limit-guard help          # show this help
+```
+
+## Examples
+
+```
+# Wrap /gh-issue-flow 399, fire safety net at 18:05
+/devx:rate-limit-guard --reset 18:00 /gh-issue-flow 399
+
+# Custom buffer (10 min after reset)
+/devx:rate-limit-guard --reset 18:00 --buffer 10 /gh-issue-flow 399
+
+# Wrap a natural-language task
+/devx:rate-limit-guard --reset 18:00 "PR 200 리뷰 코멘트 처리해"
+```
+
+## What it does
+
+Wraps a long-running task with a rate-limit safety net so work resumes
+automatically when your token limit resets, even if you walked away.
+
+1. Schedules a `CronCreate(durable=true)` for `<reset + buffer>` whose
+   prompt re-runs the wrapped command (with worktree/branch context).
+2. Persists state to `.claude/.rate-limit-guard.json` (per worktree).
+3. Runs the wrapped command in the current session.
+4. On normal completion, removes the cron job and state file.
+5. If rate limit hits mid-task, the cron fires later in the (still-idle)
+   REPL — or in the next session if you reopen Claude Code in this
+   worktree (durable jobs persist via `.claude/scheduled_tasks.json`).
+
+## Prerequisites
+
+- Run `/usage` first to learn your reset time
+  (e.g. `Resets 6pm (Asia/Seoul)` → use `--reset 18:00`).
+- Pass `--reset` in 24h local format.
+- Keep this worktree's Claude Code session open (or reopen Claude Code in
+  this worktree) — the durable cron only fires while the REPL is idle.
+
+## When to invoke
+
+- Long workflows you might rate-limit during (`/gh-issue-flow`, `/loop`).
+- Leaving for the day with work still queued and wanting auto-resume.
+- Any task you'd otherwise have to manually retrigger 2-3 hours later.
+
+## Constraints
+
+- Claude Code only — `CronCreate` is not available on Codex/Gemini CLIs.
+- The worktree's Claude Code session must be open or be reopened in this
+  worktree for the cron to fire.
+- The wrapped command must be reasonably idempotent — re-running should
+  detect and skip already-completed sub-steps (e.g. `/gh-issue-flow` will
+  not re-create an existing PR or duplicate a commit).
+- Default buffer is 5 minutes after reset; tune with `--buffer`.
+- Cleanup runs only on definitive success — transient errors leave the
+  safety net in place so it can still fire.
+
+## Pairs with
+
+- `/devx:resume-after-limit` — planned companion skill that the cron
+  prompt prefers when present. Verifies worktree/branch sanity, then
+  re-runs the original command. The cron prompt is self-contained, so it
+  also works before this companion skill is built.
+- `/devx:restart` — same-session recovery for non-rate-limit API flakes
+  (socket disconnect, OOM). Different problem; not a substitute.
+- `/devx:schedule` — generic deferred execution; this skill is a
+  specialization for the rate-limit case with cleanup semantics.

--- a/claude/skills/devx-resume-after-limit/SKILL.md
+++ b/claude/skills/devx-resume-after-limit/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: devx:resume-after-limit
+description: >-
+  [Claude Code Only] Companion to /devx:rate-limit-guard. Invoked by the
+  scheduled cron when token-limit reset arrives — verifies the worktree/
+  branch context recorded by the guard, re-runs the original wrapped
+  command idempotently, and clears the state file on success. Use when the
+  user runs /devx:resume-after-limit, /devx-resume-after-limit, or when a
+  /devx:rate-limit-guard cron prompt fires. Accepts an optional <command>
+  argument (cron path) or reads `.claude/.rate-limit-guard.json` (manual
+  re-trigger). Accepts `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read
+---
+
+# devx:resume-after-limit — Resume After Rate-Limit Reset
+
+> **Claude Code only**. Companion to `/devx:rate-limit-guard`. Triggered by
+> that skill's scheduled cron, or invoked manually in the same worktree.
+
+If arg #1 is `-h`/`--help`/`help`, print `references/help.md` verbatim and stop.
+
+## Usage
+
+```
+/devx:resume-after-limit                # read state file, resume
+/devx:resume-after-limit <command>      # explicit override (cron path)
+```
+
+## Steps
+
+### 1. Load State
+
+```bash
+test -f .claude/.rate-limit-guard.json && cat .claude/.rate-limit-guard.json
+```
+
+If present, parse `command`, `worktree`, `branch`, `scheduled_for` (use
+`jq` or Python).
+
+### 2. Resolve the Command
+
+Precedence:
+
+1. State file's `command` (most reliable).
+2. The `<command>` argument (cron-prompt fallback path).
+3. If neither: print `재개할 명령을 알 수 없습니다 (state 파일·인자 모두 없음).` and stop.
+
+### 3. Sanity Check Context
+
+```bash
+PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
+```
+
+- If state file present and `PWD_NOW != worktree`: STOP with
+  `❌ 워크트리 불일치 — 예상: <worktree>, 현재: <PWD_NOW>. 올바른 워크트리에서 재시도.`
+- If state file present and `BRANCH != branch`: warn but continue —
+  `⚠️ 브랜치가 <branch> → <BRANCH>로 이동했습니다 (그래도 진행).`
+
+### 4. Announce
+
+```
+🔄 [rate-limit-guard] 재개합니다: <command>
+  • 워크트리: <PWD_NOW>
+  • 브랜치: <BRANCH>
+  • 멱등 실행 — 이미 완료된 sub-step은 자동 스킵됩니다.
+```
+
+### 5. Execute the Command
+
+Hand off to the wrapped command. Claude executes it normally in this turn;
+the wrapped workflow's own idempotency handles already-done sub-steps.
+
+### 6. Cleanup on Success
+
+In the same turn after the wrapped command finishes successfully:
+
+```bash
+rm -f .claude/.rate-limit-guard.json
+```
+
+Then print `✅ 재개 완료 — 안전망 상태 파일 정리됨`.
+
+The cron job auto-deleted on fire (it was `recurring: false`), so no
+`CronDelete` is needed here.
+
+If the wrapped command fails again (transient or otherwise), **leave the
+state file in place** — the user can re-invoke `/devx:resume-after-limit`
+manually after fixing the underlying issue.
+
+## Constraints
+
+- Never proceed past Step 3 on worktree mismatch — wrong dir = wrong work.
+- Never re-schedule a new cron — that is `/devx:rate-limit-guard`'s job.
+- Never delete the state file before the wrapped command succeeds.
+- Never invoke from inside another skill — cron- or user-triggered only.

--- a/claude/skills/devx-resume-after-limit/references/help.md
+++ b/claude/skills/devx-resume-after-limit/references/help.md
@@ -1,0 +1,57 @@
+# devx:resume-after-limit — Help
+
+## Usage
+
+```
+/devx:resume-after-limit              # read state file, resume
+/devx:resume-after-limit <command>    # explicit override (cron path)
+/devx:resume-after-limit -h           # show this help
+/devx:resume-after-limit --help
+/devx:resume-after-limit help
+```
+
+## What it does
+
+Companion to `/devx:rate-limit-guard`. When the scheduled cron fires after
+the rate-limit reset, this skill:
+
+1. Reads `.claude/.rate-limit-guard.json` to recover the original command
+   and the worktree/branch the guard was registered in.
+2. Verifies `pwd` matches the recorded worktree (STOPS on mismatch).
+3. Warns but continues if the branch has moved.
+4. Announces the resume to the user.
+5. Re-runs the original command — relying on its idempotency to skip
+   already-completed sub-steps.
+6. On success, deletes the state file. (The cron itself auto-deleted on
+   fire because it was `recurring: false`.)
+
+## When to invoke
+
+- **Automatically**: by the cron prompt scheduled by `/devx:rate-limit-guard`
+  when token-limit reset arrives.
+- **Manually**: if Claude was closed when the cron should have fired and
+  you want to trigger the same recovery flow yourself in the worktree.
+
+## Prerequisites
+
+- Run from inside the same git worktree where `/devx:rate-limit-guard`
+  was originally invoked.
+- `.claude/.rate-limit-guard.json` exists (auto-created by the guard).
+  Without it, the only fallback is an explicit `<command>` argument.
+
+## Constraints
+
+- Stops on worktree mismatch — wrong directory = wrong work.
+- Branch movement triggers a warning but does not stop execution
+  (you may have rebased or moved HEAD between guard-time and resume-time).
+- Never re-schedules a new cron — that is the guard's job.
+- The wrapped command must be idempotent (`/gh-issue-flow` etc. are).
+- On a second failure (resume itself fails), the state file is preserved
+  so you can re-invoke this skill manually after fixing the issue.
+
+## Pairs with
+
+- `/devx:rate-limit-guard` — the scheduler that creates the state and cron
+  this skill consumes.
+- `/devx:restart` — same-session API-flake recovery (socket disconnect,
+  OOM). Different problem; not a substitute.


### PR DESCRIPTION
## Summary
- 장시간 워크플로우 도중 토큰 한도에 도달해도 자동으로 이어가는 두 스킬 추가
- `/devx:rate-limit-guard` (스케줄러) + `/devx:resume-after-limit` (재개 실행자) 페어
- 워크트리별 `.claude/scheduled_tasks.json` 격리 활용 — 이슈마다 독립 동작

## Changes
- `claude/skills/devx-rate-limit-guard/`: `--reset HH:MM` 시점에 `CronCreate(durable=true, recurring=false)`로 안전망 등록 후 원본 명령 실행. 정상 완료 시 자동 해제. 트랜지언트 에러(rate limit/네트워크/타임아웃)에는 cron 유지하여 fire 시점에 작동. SKILL.md 97줄, references/에 `compute-fire-time.py`·`cron-prompt-template.md`·`help.md` 분리.
- `claude/skills/devx-resume-after-limit/`: cron fire 시 `.claude/.rate-limit-guard.json`의 워크트리·브랜치 컨텍스트를 sanity check한 뒤 원본 명령을 멱등 재실행. 워크트리 불일치는 정지, 브랜치 이동은 경고. `/gh-issue-flow` 등 sub-skill의 idempotency에 의존. SKILL.md 95줄.

## 활용 예
```
/usage                                                       # 리셋시각 확인 (예: Resets 6pm)
/devx:rate-limit-guard --reset 18:00 /gh-issue-flow 399    # 안전망 + 작업
```

## Test plan
- [ ] `/devx:rate-limit-guard -h` → `references/help.md` verbatim 출력
- [ ] `/devx:resume-after-limit -h` → 동일 패턴 출력
- [ ] `python3 claude/skills/devx-rate-limit-guard/references/compute-fire-time.py 18 0 5` → `MM HH DD MM ISO` 형식 정상
- [ ] 짧은 wrapper 명령으로 `--reset` 등록 → state 파일 생성 → 정상 완료 → state 파일·cron 자동 정리 검증
- [ ] (장기 검증) 실제 rate limit 도달 후 cron fire → resume → 멱등 재실행 동작 확인

---
<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->