### PR TITLE
feat(devx-restart): 자발적 ESC 케이스를 트리거 범위에 포함

### DIFF
--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: devx:restart
 description: >-
-  Resume the previous in-progress task after an API error (socket disconnect,
-  service flake, OOM, etc.) without losing context. Use when the user runs
-  /devx:restart, /devx-restart, or asks "다시 작업해", "이어서 해줘",
-  "끊긴 데서 재개", "API 에러 복구". Identifies the in_progress TodoList
-  item, breaks the next step into single-tool-call chunks, and delegates
-  large reads/searches to subagents (Explore / general-purpose) so the main
-  context stays small. Does NOT re-invoke a process skill (brainstorming /
-  TDD / debugging) that already produced output earlier in the conversation —
-  it resumes from the implementation step they led to. Accepts
-  `-h`/`--help`/`help` to print usage.
+  Resume the previous in-progress task after an interruption — either an API
+  error (socket disconnect, service flake, OOM, etc.) or the user pressing
+  ESC because the turn was running too long — without losing context. Use
+  when the user runs /devx:restart, /devx-restart, or asks "다시 작업해",
+  "이어서 해줘", "끊긴 데서 재개", "API 에러 복구",
+  "15분 이상 걸려서 ESC 눌렀어", "작업이 너무 커서 중단했어",
+  "oversized turn interrupted by user ESC". Identifies the in_progress
+  TodoList item, breaks the next step into single-tool-call chunks, and
+  delegates large reads/searches to subagents (Explore / general-purpose)
+  so the main context stays small. Does NOT re-invoke a process skill
+  (brainstorming / TDD / debugging) that already produced output earlier
+  in the conversation — it resumes from the implementation step they led
+  to. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep, Agent, TaskList, TaskUpdate
 ---
 
@@ -25,9 +28,11 @@ its content verbatim, then stop. No tool calls beyond that read.
 
 The user invokes this when their previous work was interrupted — typically by
 an `API Error: socket connection was closed unexpectedly` or similar
-service-side flake. Pick up where the prior turn left off, but do it in
-smaller chunks so the next failure costs less. Stay in the current session;
-don't ask the user to start over.
+service-side flake, or by the user pressing ESC because the turn was running
+too long (e.g. a 15+ minute action that grew larger than expected). Pick up
+where the prior turn left off, but do it in smaller chunks so the next
+failure costs less. Stay in the current session; don't ask the user to
+start over.
 
 ## Step 1: Identify the Resume Target
 

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: devx:restart
 description: >-
-  Resume the previous in-progress task after an interruption — either an API
-  error (socket disconnect, service flake, OOM, etc.) or the user pressing
-  ESC because the turn was running too long — without losing context. Use
-  when the user runs /devx:restart, /devx-restart, or asks "다시 작업해",
+  [Claude Code Only] Resume the previous in-progress task after an interruption
+  — either an API error (socket disconnect, service flake, OOM, etc.) or the
+  user pressing ESC because the turn was running too long — without losing
+  context. Use when the user runs /devx:restart, /devx-restart, or asks "다시 작업해",
   "이어서 해줘", "끊긴 데서 재개", "API 에러 복구",
   "15분 이상 걸려서 ESC 눌렀어", "작업이 너무 커서 중단했어",
   "oversized turn interrupted by user ESC". Identifies the in_progress

--- a/claude/skills/devx-restart/references/help.md
+++ b/claude/skills/devx-restart/references/help.md
@@ -23,6 +23,7 @@ subagents so the next failure costs less.
 - Your last turn died mid-action and the spinner stopped.
 - The model produced an `API Error` and ended the turn.
 - A long batch of edits got cut off and you don't want to re-explain it.
+- 작업 범위가 너무 커서 사용자가 ESC로 끊고 더 작게 다시 시작하고 싶을 때.
 
 Do NOT invoke for:
 

--- a/claude/skills/devx-restart/references/help.md
+++ b/claude/skills/devx-restart/references/help.md
@@ -23,7 +23,7 @@ subagents so the next failure costs less.
 - Your last turn died mid-action and the spinner stopped.
 - The model produced an `API Error` and ended the turn.
 - A long batch of edits got cut off and you don't want to re-explain it.
-- 작업 범위가 너무 커서 사용자가 ESC로 끊고 더 작게 다시 시작하고 싶을 때.
+- The task was too large and you interrupted it with ESC to restart in smaller chunks.
 
 Do NOT invoke for:
 


### PR DESCRIPTION
## Summary
- `devx:restart` 스킬의 트리거 범위를 *비자발적 API 실패*뿐 아니라 *사용자가 작업이 너무 커서 ESC로 끊은 경우*까지 확장.
- 회복 로직(Step 1-4)·Constraints·`allowed-tools` 는 변경 없음 — 트리거 설명만 보강.
- description / Role 첫 문장 / `references/help.md` "When to invoke" 한 줄, 총 3곳 수정.

## Changes
- `claude/skills/devx-restart/SKILL.md`
  - frontmatter `description` — 한국어 트리거 `"15분 이상 걸려서 ESC 눌렀어"`, `"작업이 너무 커서 중단했어"` + 영문 `"oversized turn interrupted by user ESC"` 추가, opening 문장에 "or by the user pressing ESC because the turn was running too long" 병기.
  - Role 섹션 첫 문장 — 두 종류의 인터럽션(API 에러 + 사용자 ESC)을 모두 명시.
- `claude/skills/devx-restart/references/help.md`
  - "When to invoke" 섹션에 한 줄 추가 — `작업 범위가 너무 커서 사용자가 ESC로 끊고 더 작게 다시 시작하고 싶을 때.`

## Test plan
- [ ] `tox -e mdlint` 결과에서 `claude/skills/devx-restart/` 경로의 새 위반 없음 (사전 위반은 본 PR 범위 외).
- [ ] frontmatter `name`, `allowed-tools` 변경 없음 확인.
- [ ] `/devx:restart help` 출력에 ESC 관련 한국어 트리거 라인이 포함되는지 시각 확인.
- [ ] 회복 로직(Step 1-4)·Constraints diff 없음 확인 (`git diff main..HEAD -- claude/skills/devx-restart/SKILL.md` 의 변경 줄이 description + Role 첫 문장에 한정).

## Related
Closes #371

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
