### PR TITLE
feat(skills): rate-limit-guard 멀티사이클 옵션 (--max-cycles, --cycle-window)

### DIFF
--- a/claude/skills/devx-rate-limit-guard/SKILL.md
+++ b/claude/skills/devx-rate-limit-guard/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   completion. Use when the user runs /devx:rate-limit-guard,
   /devx-rate-limit-guard, or asks "rate limit 걸려도 자동 재개", "퇴근하면서
   작업 시키고 limit 풀리면 이어가게 해줘", "auto-resume after my token limit
-  resets". Requires the user to know their reset time (run /usage first).
-  Accepts `-h`/`--help`/`help` to print usage.
+  resets". Supports multi-cycle re-arming via `--max-cycles N`. Requires the
+  user to know their reset time (run /usage first). Accepts `-h`/`--help`/`help`
+  to print usage.
 allowed-tools: Bash, Read, Write, CronCreate, CronDelete
 ---
 
@@ -22,37 +23,36 @@ If arg #1 is `-h`/`--help`/`help`, print `references/help.md` verbatim and stop.
 ## Usage
 
 ```
-/devx:rate-limit-guard --reset HH:MM [--buffer M] <command>
+/devx:rate-limit-guard --reset HH:MM [--max-cycles N] [--cycle-window M] <command>
 ```
 
 - `--reset HH:MM` — local 24h reset time (REQUIRED, from `/usage`)
-- `--buffer M` — minutes after reset to fire (default: 5)
+- `--max-cycles N` — re-arm up to N cycles (default 1; PR #369 behavior)
+- `--cycle-window M` — minutes between fires for cycles 2..N (default 305)
+- `--buffer M` — **deprecated**: warn + ignore (5-min margin is constant now)
 - `<command>` — slash-command or natural-language task to wrap
 
 ## Steps
 
 ### 1. Parse Arguments
 
-Extract `--reset HH:MM` (required) and `--buffer M` (default 5). Everything
-after flags is the wrapped command (preserve quoting). If `--reset` is
-missing/malformed, print
+Extract `--reset HH:MM` (required), `--max-cycles` (positive int, default 1),
+`--cycle-window` (positive int, default 305). If `--buffer` is present, emit
+`⚠️ --buffer 폐지됨 (5분 마진 = 상수). 값 무시.` and continue. Remaining tokens
+are the wrapped command (preserve quoting). On missing/malformed `--reset`:
 `필수 인자 --reset HH:MM 누락. /usage로 리셋 시각 확인 후 재시도.` and stop.
 
-### 2. Compute Fire Time
+### 2. Compute First-Fire Time + Capture Context
 
 ```bash
-python3 claude/skills/devx-rate-limit-guard/references/compute-fire-time.py HH MM B
-```
-
-Output: `<min> <hour> <dom> <month> <iso>` — first four = cron expression, `<iso>` = state-file timestamp.
-
-### 3. Capture Worktree Context
-
-```bash
+python3 claude/skills/devx-rate-limit-guard/references/compute-fire-time.py HH MM 5
 PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
 ```
 
-### 4. Schedule via `CronCreate`
+`5` is the hardcoded margin (formerly `--buffer`). Output:
+`<min> <hour> <dom> <month> <iso>` (first four = cron expression).
+
+### 3. Schedule via `CronCreate`
 
 - `cron`: `"<min> <hour> <dom> <month> *"` (from step 2)
 - `prompt`: see `references/cron-prompt-template.md` — substitute
@@ -61,37 +61,39 @@ PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
 
 Save the returned job ID.
 
-### 5. Persist Cleanup State
+### 4. Persist Cleanup State
 
 Write `.claude/.rate-limit-guard.json` (worktree root):
 
 ```json
-{"cron_id":"<id>","command":"<command>","worktree":"<PWD_NOW>","branch":"<BRANCH>","scheduled_for":"<ISO>"}
+{"cron_id":"<id>","command":"<command>","worktree":"<PWD_NOW>","branch":"<BRANCH>","scheduled_for":"<ISO>","max_cycles":<N>,"cycles_remaining":<N>,"cycle_window_min":<M>}
 ```
 
-### 6. Confirm
+`cycles_remaining` starts at `max_cycles`; `/devx:resume-after-limit`
+decrements it as it re-arms subsequent cycles.
+
+### 5. Confirm
 
 ```
-🛡️ Rate-limit 안전망 등록
+🛡️ Rate-limit 안전망 등록 (사이클 1/<N>, 간격 <M>분)
   • 원본 명령: <command>
-  • 자동 재개 시각: <HH:MM + buffer> (job: <id>)
-  • 정상 완료 시 자동 해제됩니다.
+  • 자동 재개 시각: <HH:MM + 5min> (job: <id>)
 이제 원본 명령을 실행합니다 ↓
 ```
 
-### 7. Execute, then Cleanup on Success
+### 6. Execute, then Cleanup on Success
 
-Hand off to the wrapped command. After it finishes successfully, in the same turn:
+Hand off to the wrapped command. On success:
 `CronDelete(<id>)` → `rm -f .claude/.rate-limit-guard.json` →
-print `✅ 안전망 해제 — 정상 완료`.
+`✅ 안전망 해제 — 정상 완료`.
 
-On transient errors (rate limit, network, timeout), **leave the cron in
-place** — that is exactly when the safety net should fire. Only clean up
-on definitive success or explicit user request.
+On transient errors (rate limit / network / timeout), **leave the cron in
+place** — that is exactly when the safety net should fire.
 
 ## Constraints
 
 - Never schedule without explicit `--reset HH:MM`.
 - Never use `recurring: true` or `durable: false`.
-- Never auto-cleanup on rate-limit / network / timeout errors.
+- Never auto-cleanup on transient errors.
 - Never invoke from inside another skill — user-triggered only.
+- `--max-cycles 1` (default) preserves PR #369 behavior.

--- a/claude/skills/devx-rate-limit-guard/references/cron-prompt-template.md
+++ b/claude/skills/devx-rate-limit-guard/references/cron-prompt-template.md
@@ -1,8 +1,9 @@
 # Cron Prompt Template
 
-Use this exact text for the `prompt:` argument of `CronCreate` in Step 4.
-Substitute `<PWD_NOW>`, `<BRANCH>`, and `<command>` with the values
-captured in Steps 1 and 3.
+Use this exact text for the `prompt:` argument of `CronCreate` in Step 3 of
+the rate-limit-guard SKILL.md, **and** for the next-cycle cron registered
+by `/devx:resume-after-limit` (Step 4). Substitute `<PWD_NOW>`, `<BRANCH>`,
+and `<command>` with the values captured at registration time.
 
 ```
 [Auto-resume by /devx:rate-limit-guard]
@@ -10,16 +11,25 @@ captured in Steps 1 and 3.
 브랜치: <BRANCH>
 원본 명령: <command>
 
-현재 워크트리·브랜치가 위와 같으면 원본 명령을 다시 실행. 명령은 멱등적으로
-설계되어 이미 완료된 sub-step은 스킵됨. 다르면 사용자에게 알리고 중단.
-/devx:resume-after-limit 스킬이 존재하면 우선 호출.
+현재 워크트리·브랜치가 위와 같으면 `/devx:resume-after-limit`을 호출하여
+재개. 그 스킬이 state 파일에서 multi-cycle 정보(`cycles_remaining`,
+`cycle_window_min`)를 읽어 다음 cycle을 자동 재무장한다. 워크트리/브랜치가
+다르면 사용자에게 알리고 중단.
+
+만약 `/devx:resume-after-limit` 스킬이 없는 환경이라면, fallback으로 원본
+명령을 직접 멱등 재실행 (단일 cycle 동작, PR #369 호환).
 ```
 
 ## Why self-contained
 
-The prompt must work even before the companion `/devx:resume-after-limit`
-skill is implemented. By embedding worktree/branch/command directly, the
-fired prompt gives Claude enough context to resume safely on its own.
+The prompt embeds worktree/branch/command directly so it can resume safely
+even if `/devx:resume-after-limit` is unavailable. When the companion skill
+exists (the normal case post-PR #370), it reads the state file's
+`cycles_remaining` to decide whether to pre-arm the next cycle.
 
-When the companion skill exists, the last line nudges Claude to delegate
-to it for the standardized sanity check + announce flow.
+## Why the same template for cycle 2..N
+
+`/devx:resume-after-limit` reuses this same template when registering the
+next-cycle cron (Step 4). The cycle bookkeeping lives in the state file —
+the prompt itself is cycle-agnostic, which keeps the cron payload uniform
+and the template a single source of truth.

--- a/claude/skills/devx-rate-limit-guard/references/help.md
+++ b/claude/skills/devx-rate-limit-guard/references/help.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-/devx:rate-limit-guard --reset HH:MM [--buffer M] <command>
+/devx:rate-limit-guard --reset HH:MM [--max-cycles N] [--cycle-window M] <command>
 /devx-rate-limit-guard --reset 18:00 /gh-issue-flow 399
 /devx:rate-limit-guard -h            # show this help
 /devx:rate-limit-guard --help        # show this help
@@ -13,62 +13,86 @@
 ## Examples
 
 ```
-# Wrap /gh-issue-flow 399, fire safety net at 18:05
+# 1-shot safety net (default — same as PR #369 behavior)
 /devx:rate-limit-guard --reset 18:00 /gh-issue-flow 399
 
-# Custom buffer (10 min after reset)
-/devx:rate-limit-guard --reset 18:00 --buffer 10 /gh-issue-flow 399
+# Multi-cycle: re-arm up to 3 times, 305 min apart (5h05m default window)
+/devx:rate-limit-guard --reset 18:00 --max-cycles 3 /gh-issue-flow 399
+
+# Custom cycle window (e.g. 4h = 240 min)
+/devx:rate-limit-guard --reset 18:00 --max-cycles 4 --cycle-window 240 /gh-issue-flow 399
 
 # Wrap a natural-language task
-/devx:rate-limit-guard --reset 18:00 "PR 200 리뷰 코멘트 처리해"
+/devx:rate-limit-guard --reset 18:00 --max-cycles 2 "PR 200 리뷰 코멘트 처리해"
 ```
+
+## Arguments
+
+- `--reset HH:MM` — local 24h reset time (REQUIRED, from `/usage`).
+- `--max-cycles N` — re-arm up to N cycles (default 1; default = PR #369 behavior).
+- `--cycle-window M` — minutes between fires for cycles 2..N (default 305 = 5h05m).
+  Cumulative fire times: cycle 2 = `cycle 1 fire + M`, cycle 3 = `cycle 2 fire + M`, …
+- `--buffer M` — **deprecated**. The 5-minute margin after `--reset` is now a
+  hardcoded constant. Passing `--buffer` emits a warning and the value is ignored.
 
 ## What it does
 
 Wraps a long-running task with a rate-limit safety net so work resumes
 automatically when your token limit resets, even if you walked away.
 
-1. Schedules a `CronCreate(durable=true)` for `<reset + buffer>` whose
-   prompt re-runs the wrapped command (with worktree/branch context).
-2. Persists state to `.claude/.rate-limit-guard.json` (per worktree).
+1. Schedules a `CronCreate(durable=true)` for `<reset + 5min>` whose prompt
+   re-runs the wrapped command (with worktree/branch context).
+2. Persists state (including `max_cycles`/`cycles_remaining`/`cycle_window_min`)
+   to `.claude/.rate-limit-guard.json` (per worktree).
 3. Runs the wrapped command in the current session.
 4. On normal completion, removes the cron job and state file.
-5. If rate limit hits mid-task, the cron fires later in the (still-idle)
-   REPL — or in the next session if you reopen Claude Code in this
-   worktree (durable jobs persist via `.claude/scheduled_tasks.json`).
+5. If rate-limit hits mid-task, the cron fires later in the (still-idle) REPL.
+   `/devx:resume-after-limit` then handles re-arming subsequent cycles.
+
+## Multi-cycle scenarios
+
+A single Anthropic 5h reset window often isn't enough for an overnight
+`/gh-issue-flow`. With `--max-cycles 3 --cycle-window 305`:
+
+- Cycle 1: fires at `--reset + 5min` (e.g. 18:05)
+- Cycle 2: fires at cycle-1-fire + 305min (e.g. 23:10)
+- Cycle 3: fires at cycle-2-fire + 305min (e.g. 04:15 next day)
+
+Each cycle re-runs the wrapped command. Idempotent workflows
+(`/gh-issue-flow`) detect already-done sub-steps and skip them. Successful
+completion at any cycle clears all remaining crons + the state file.
 
 ## Prerequisites
 
 - Run `/usage` first to learn your reset time
-  (e.g. `Resets 6pm (Asia/Seoul)` → use `--reset 18:00`).
+  (e.g. `Resets 6pm (Asia/Seoul)` → `--reset 18:00`).
 - Pass `--reset` in 24h local format.
 - Keep this worktree's Claude Code session open (or reopen Claude Code in
-  this worktree) — the durable cron only fires while the REPL is idle.
+  this worktree) — durable crons only fire while a REPL is idle.
 
 ## When to invoke
 
-- Long workflows you might rate-limit during (`/gh-issue-flow`, `/loop`).
-- Leaving for the day with work still queued and wanting auto-resume.
-- Any task you'd otherwise have to manually retrigger 2-3 hours later.
+- Long workflows that may rate-limit (`/gh-issue-flow`, `/loop`).
+- Overnight runs where one 5h reset isn't enough — use `--max-cycles N`.
+- Any task you'd otherwise have to manually retrigger 2–3 hours later.
 
 ## Constraints
 
 - Claude Code only — `CronCreate` is not available on Codex/Gemini CLIs.
 - The worktree's Claude Code session must be open or be reopened in this
   worktree for the cron to fire.
-- The wrapped command must be reasonably idempotent — re-running should
-  detect and skip already-completed sub-steps (e.g. `/gh-issue-flow` will
-  not re-create an existing PR or duplicate a commit).
-- Default buffer is 5 minutes after reset; tune with `--buffer`.
+- The wrapped command must be idempotent; re-running should detect and skip
+  already-completed sub-steps (e.g. `/gh-issue-flow` won't re-create an
+  existing PR or duplicate a commit).
+- 5-min margin after `--reset` is hardcoded; `--buffer` is deprecated.
 - Cleanup runs only on definitive success — transient errors leave the
   safety net in place so it can still fire.
 
 ## Pairs with
 
-- `/devx:resume-after-limit` — planned companion skill that the cron
-  prompt prefers when present. Verifies worktree/branch sanity, then
-  re-runs the original command. The cron prompt is self-contained, so it
-  also works before this companion skill is built.
+- `/devx:resume-after-limit` — companion the cron prompt prefers. Verifies
+  worktree/branch sanity, pre-emptively re-arms the next cycle when
+  `cycles_remaining > 1`, then re-runs the original command.
 - `/devx:restart` — same-session recovery for non-rate-limit API flakes
   (socket disconnect, OOM). Different problem; not a substitute.
 - `/devx:schedule` — generic deferred execution; this skill is a

--- a/claude/skills/devx-resume-after-limit/SKILL.md
+++ b/claude/skills/devx-resume-after-limit/SKILL.md
@@ -3,13 +3,14 @@ name: devx:resume-after-limit
 description: >-
   [Claude Code Only] Companion to /devx:rate-limit-guard. Invoked by the
   scheduled cron when token-limit reset arrives — verifies the worktree/
-  branch context recorded by the guard, re-runs the original wrapped
-  command idempotently, and clears the state file on success. Use when the
-  user runs /devx:resume-after-limit, /devx-resume-after-limit, or when a
+  branch context recorded by the guard, pre-emptively re-arms the next cron
+  for multi-cycle runs (`--max-cycles N` > 1), re-runs the original wrapped
+  command idempotently, and clears state on success. Use when the user runs
+  /devx:resume-after-limit, /devx-resume-after-limit, or when a
   /devx:rate-limit-guard cron prompt fires. Accepts an optional <command>
   argument (cron path) or reads `.claude/.rate-limit-guard.json` (manual
   re-trigger). Accepts `-h`/`--help`/`help` to print usage.
-allowed-tools: Bash, Read
+allowed-tools: Bash, Read, Write, CronCreate, CronDelete
 ---
 
 # devx:resume-after-limit — Resume After Rate-Limit Reset
@@ -34,16 +35,14 @@ If arg #1 is `-h`/`--help`/`help`, print `references/help.md` verbatim and stop.
 test -f .claude/.rate-limit-guard.json && cat .claude/.rate-limit-guard.json
 ```
 
-If present, parse `command`, `worktree`, `branch`, `scheduled_for` (use
-`jq` or Python).
+Parse `command`, `worktree`, `branch`, `max_cycles`, `cycles_remaining`,
+`cycle_window_min` (jq or Python). Missing multi-cycle fields default to
+`max_cycles=1`, `cycles_remaining=1`, `cycle_window_min=305` (PR #369 compat).
 
 ### 2. Resolve the Command
 
-Precedence:
-
-1. State file's `command` (most reliable).
-2. The `<command>` argument (cron-prompt fallback path).
-3. If neither: print `재개할 명령을 알 수 없습니다 (state 파일·인자 모두 없음).` and stop.
+State file's `command` → `<command>` arg → stop with
+`재개할 명령을 알 수 없습니다 (state 파일·인자 모두 없음).`
 
 ### 3. Sanity Check Context
 
@@ -51,45 +50,50 @@ Precedence:
 PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
 ```
 
-- If state file present and `PWD_NOW != worktree`: STOP with
-  `❌ 워크트리 불일치 — 예상: <worktree>, 현재: <PWD_NOW>. 올바른 워크트리에서 재시도.`
-- If state file present and `BRANCH != branch`: warn but continue —
-  `⚠️ 브랜치가 <branch> → <BRANCH>로 이동했습니다 (그래도 진행).`
+- If `PWD_NOW != worktree`: STOP —
+  `❌ 워크트리 불일치 — 예상: <worktree>, 현재: <PWD_NOW>.`
+- If `BRANCH != branch`: warn `⚠️ 브랜치 이동` and continue.
 
-### 4. Announce
+### 4. Pre-emptive Re-arm
+
+If `cycles_remaining > 1`, register the next cycle's cron **before** running
+the wrapped command per `references/preemptive-rearm.md` (fire-time
+arithmetic, `CronCreate` args, state-file rewrite). Save `<NEXT_ID>` for
+Step 7. Otherwise skip.
+
+### 5. Announce
 
 ```
-🔄 [rate-limit-guard] 재개합니다: <command>
-  • 워크트리: <PWD_NOW>
-  • 브랜치: <BRANCH>
-  • 멱등 실행 — 이미 완료된 sub-step은 자동 스킵됩니다.
+🔄 [rate-limit-guard] 재개: <command>
+  • 워크트리: <PWD_NOW>  • 브랜치: <BRANCH>
+  • 사이클: <max_cycles - cycles_remaining + 1>/<max_cycles>
+  • 멱등 실행 — 이미 완료된 sub-step은 스킵.
 ```
 
-### 5. Execute the Command
+### 6. Execute the Command
 
-Hand off to the wrapped command. Claude executes it normally in this turn;
-the wrapped workflow's own idempotency handles already-done sub-steps.
+Hand off to the wrapped command. The wrapped workflow's own idempotency
+handles already-done sub-steps.
 
-### 6. Cleanup on Success
+### 7. Cleanup on Success
 
-In the same turn after the wrapped command finishes successfully:
+In the same turn after success:
 
 ```bash
+[ -n "$NEXT_ID" ] && CronDelete <NEXT_ID>   # only if Step 4 ran
 rm -f .claude/.rate-limit-guard.json
 ```
 
-Then print `✅ 재개 완료 — 안전망 상태 파일 정리됨`.
+Print `✅ 재개 완료 — 안전망 상태 파일 정리됨`.
 
-The cron job auto-deleted on fire (it was `recurring: false`), so no
-`CronDelete` is needed here.
+The just-fired cron auto-deleted (`recurring: false`); the next-cycle cron
+from Step 4 must be explicitly cancelled.
 
-If the wrapped command fails again (transient or otherwise), **leave the
-state file in place** — the user can re-invoke `/devx:resume-after-limit`
-manually after fixing the underlying issue.
+On failure (transient or otherwise), **leave state + next cron** in place —
+the next fire re-triggers this skill, or the user re-invokes manually.
 
 ## Constraints
 
 - Never proceed past Step 3 on worktree mismatch — wrong dir = wrong work.
-- Never re-schedule a new cron — that is `/devx:rate-limit-guard`'s job.
-- Never delete the state file before the wrapped command succeeds.
+- Never delete state or the next cron before the wrapped command succeeds.
 - Never invoke from inside another skill — cron- or user-triggered only.

--- a/claude/skills/devx-resume-after-limit/references/help.md
+++ b/claude/skills/devx-resume-after-limit/references/help.md
@@ -15,22 +15,39 @@
 Companion to `/devx:rate-limit-guard`. When the scheduled cron fires after
 the rate-limit reset, this skill:
 
-1. Reads `.claude/.rate-limit-guard.json` to recover the original command
-   and the worktree/branch the guard was registered in.
+1. Reads `.claude/.rate-limit-guard.json` to recover the original command,
+   the worktree/branch the guard was registered in, and the multi-cycle
+   bookkeeping (`max_cycles`, `cycles_remaining`, `cycle_window_min`).
 2. Verifies `pwd` matches the recorded worktree (STOPS on mismatch).
 3. Warns but continues if the branch has moved.
-4. Announces the resume to the user.
-5. Re-runs the original command — relying on its idempotency to skip
+4. **(multi-cycle)** If `cycles_remaining > 1`, pre-emptively registers the
+   next cycle's cron (fire = `now + cycle_window_min` minutes) **before**
+   running the wrapped command. The next cron's prompt also calls
+   `/devx:resume-after-limit`, with `cycles_remaining` decremented in state.
+5. Announces the resume to the user.
+6. Re-runs the original command — relying on its idempotency to skip
    already-completed sub-steps.
-6. On success, deletes the state file. (The cron itself auto-deleted on
-   fire because it was `recurring: false`.)
+7. On success, deletes the state file and `CronDelete`s the next-cycle cron
+   (if Step 4 ran). The just-fired cron auto-deleted (`recurring: false`).
 
 ## When to invoke
 
 - **Automatically**: by the cron prompt scheduled by `/devx:rate-limit-guard`
-  when token-limit reset arrives.
+  when token-limit reset (or a subsequent cycle window) arrives.
 - **Manually**: if Claude was closed when the cron should have fired and
   you want to trigger the same recovery flow yourself in the worktree.
+
+## Multi-cycle behavior
+
+With `--max-cycles N` (where N > 1), each fire of this skill re-arms the
+next cycle before running the wrapped command. This means:
+
+- Even if the wrapped command rate-limits or crashes mid-cycle, the next
+  cron is already in place — nothing to re-trigger manually.
+- On success at any cycle, the state file + the *next* cron are cleared,
+  so you don't get redundant fires.
+- `cycles_remaining` decrements per fire; on `cycles_remaining <= 1`,
+  Step 4 is skipped (no further cycles to schedule).
 
 ## Prerequisites
 
@@ -38,16 +55,19 @@ the rate-limit reset, this skill:
   was originally invoked.
 - `.claude/.rate-limit-guard.json` exists (auto-created by the guard).
   Without it, the only fallback is an explicit `<command>` argument.
+- A pre-PR-#370 state file (no multi-cycle fields) is treated as
+  `max_cycles=1`, behaving exactly like PR #369.
 
 ## Constraints
 
 - Stops on worktree mismatch — wrong directory = wrong work.
 - Branch movement triggers a warning but does not stop execution
   (you may have rebased or moved HEAD between guard-time and resume-time).
-- Never re-schedules a new cron — that is the guard's job.
+- Pre-emptive re-arm only fires when `cycles_remaining > 1`.
 - The wrapped command must be idempotent (`/gh-issue-flow` etc. are).
-- On a second failure (resume itself fails), the state file is preserved
-  so you can re-invoke this skill manually after fixing the issue.
+- On a second failure (resume itself fails), the state file **and** the
+  next-cycle cron are preserved so the next fire (or a manual re-invoke)
+  can pick up where this attempt left off.
 
 ## Pairs with
 

--- a/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
+++ b/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
@@ -1,0 +1,47 @@
+# Pre-emptive Re-arm — Step 4 Detail
+
+When the state file's `cycles_remaining > 1`, register the next cycle's
+cron **before** running the wrapped command. This guarantees a fresh
+safety net even if the wrapped command rate-limits or crashes mid-run.
+
+## Compute fire time
+
+```bash
+python3 -c "from datetime import datetime,timedelta as td; t=datetime.now()+td(minutes=$cycle_window_min); print(t.strftime('%M %H %d %m'),t.isoformat())"
+```
+
+Output: `<min> <hour> <dom> <month> <iso>` — first four = cron expression
+(no DoW), `<iso>` = state-file timestamp.
+
+## CronCreate parameters
+
+- `cron`: the four fields above followed by `*` (e.g. `"05 23 06 05 *"`)
+- `recurring`: `false`
+- `durable`: `true`
+- `prompt`: the template at
+  `../devx-rate-limit-guard/references/cron-prompt-template.md`,
+  substituting `<PWD_NOW>`, `<BRANCH>`, `<command>` from the loaded state
+
+Save the returned ID as `<NEXT_ID>`.
+
+## Update state file
+
+Overwrite `.claude/.rate-limit-guard.json`:
+
+```json
+{"cron_id":"<NEXT_ID>","command":"<command>","worktree":"<worktree>","branch":"<branch>","scheduled_for":"<new ISO>","max_cycles":<N>,"cycles_remaining":<cycles_remaining - 1>,"cycle_window_min":<M>}
+```
+
+`cycles_remaining` is decremented by 1; all other fields preserved.
+
+## Drift behavior
+
+The next fire is `now + cycle_window_min`, **not** `original_reset +
+cycles_so_far * cycle_window_min`. This naturally absorbs any drift from
+session-start delays — if cycle 1 fired 5 minutes late, cycle 2 will
+also be 5 minutes late, matching real session-window timing.
+
+Example (305-minute window, original reset 18:00, max-cycles 3):
+- Cycle 1 fires 18:05 (reset + 5min margin)
+- Cycle 2 fires `18:05 + 305min = 23:10`
+- Cycle 3 fires `23:10 + 305min = 04:15` next day


### PR DESCRIPTION
## Summary
- 장시간 워크플로우(`/gh-issue-flow` 등)가 1회 한도 리셋(5h)으로 끝나지 않는 케이스를 위해 PR #369의 1-shot 안전망을 N-cycle 자동 재무장으로 확장
- `--max-cycles N` (default 1, PR #369 호환) + `--cycle-window M` (default 305) 도입; `--buffer` 인자는 deprecated (5분 마진 = 상수)
- `/devx:resume-after-limit`이 wrapped 명령 실행 *전에* 다음 cron 선제 등록 — 도중 rate limit·crash가 나도 다음 사이클이 보장됨

## Changes
- `claude/skills/devx-rate-limit-guard/SKILL.md` (99줄) — 인자 파싱 확장, state 스키마에 `max_cycles`/`cycles_remaining`/`cycle_window_min` 추가, 5분 마진 상수화
- `claude/skills/devx-rate-limit-guard/references/help.md` — multi-cycle 예시·인자 표·deprecated `--buffer` 안내
- `claude/skills/devx-rate-limit-guard/references/cron-prompt-template.md` — `/devx:resume-after-limit`을 primary path로 명시, fallback 동작 보존
- `claude/skills/devx-resume-after-limit/SKILL.md` (99줄) — Step 4 "Pre-emptive Re-arm" 신설, Step 7 cleanup이 다음 cron `CronDelete` 처리, 누락 필드는 PR #369 호환 default
- `claude/skills/devx-resume-after-limit/references/help.md` — multi-cycle 동작·state 호환성 문서화
- `claude/skills/devx-resume-after-limit/references/preemptive-rearm.md` (NEW) — fire-time 산술(`now + cycle_window_min`)·`CronCreate` 인자·drift 흡수 예시 분리

## Test plan
- [ ] `--max-cycles 1` (default) 동작이 PR #369와 행동상 동일 (1회 fire 후 종료)
- [ ] `--max-cycles 3 --cycle-window 305`로 등록 시 state 파일에 `cycles_remaining: 3` 기록 확인
- [ ] resume-after-limit 호출 시 `cycles_remaining > 1`이면 다음 cron이 `CronCreate(durable=true)`로 새로 등록되며 state `cycles_remaining`이 1 감소
- [ ] resume의 wrapped 명령 정상 완료 시 다음 cron `CronDelete` + state 파일 삭제
- [ ] `--buffer 10` 전달 시 deprecated warning 출력 후 정상 동작 (값 무시)
- [ ] 두 SKILL.md 모두 100줄 미만 (현재 99/99)
- [ ] PR #369 baseline state 파일(누락 필드)에서 resume 호출 시 `max_cycles=1` default로 동작

## Related
Closes #370

---
<details>
<summary>🤖 AI Metrics · 📊 ~7500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~7500 tokens · 👤 ~8 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
