### PR TITLE
refactor(devx-rate-limit-guard): SKILL.md Usage 섹션 중복 제거

### DIFF
--- a/claude/skills/devx-rate-limit-guard/SKILL.md
+++ b/claude/skills/devx-rate-limit-guard/SKILL.md
@@ -18,19 +18,7 @@ allowed-tools: Bash, Read, Write, CronCreate, CronDelete
 > **Claude Code only**. Requires this worktree's Claude Code session to stay
 > open (or be reopened in this worktree) so the durable cron can fire.
 
-If arg #1 is `-h`/`--help`/`help`, print `references/help.md` verbatim and stop.
-
-## Usage
-
-```
-/devx:rate-limit-guard --reset HH:MM [--max-cycles N] [--cycle-window M] <command>
-```
-
-- `--reset HH:MM` — local 24h reset time (REQUIRED, from `/usage`)
-- `--max-cycles N` — re-arm up to N cycles (default 1; PR #369 behavior)
-- `--cycle-window M` — minutes between fires for cycles 2..N (default 305)
-- `--buffer M` — **deprecated**: warn + ignore (5-min margin is constant now)
-- `<command>` — slash-command or natural-language task to wrap
+If arg #1 is `-h`/`--help`/`help`, or when you need usage/examples, read `references/help.md` verbatim and stop.
 
 ## Steps
 

--- a/claude/skills/devx-rate-limit-guard/SKILL.md
+++ b/claude/skills/devx-rate-limit-guard/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Bash, Read, Write, CronCreate, CronDelete
 > **Claude Code only**. Requires this worktree's Claude Code session to stay
 > open (or be reopened in this worktree) so the durable cron can fire.
 
-If arg #1 is `-h`/`--help`/`help`, or when you need usage/examples, read `references/help.md` verbatim and stop.
+If arg #1 is `-h`/`--help`/`help`, or when you need usage/examples, print `references/help.md` verbatim and stop.
 
 ## Steps
 


### PR DESCRIPTION
## Summary
- `claude/skills/devx-rate-limit-guard/SKILL.md` 의 `## Usage` 섹션(라인 23–33, 11줄)이 `references/help.md` 와 완전 중복이라 제거했습니다.
- 기존 라인 21의 `-h`/`--help` 포인터와 합쳐 단일 포인터 한 줄로 통합 — `references/help.md` 가 Usage 단일 진실의 원천(SSOT) 이 됩니다.
- Progressive Disclosure 원칙(SKILL.md = control tower) 복구.

## Changes
- **`claude/skills/devx-rate-limit-guard/SKILL.md`**: 인라인 `## Usage` 섹션 11줄 + 기존 `-h`/`--help` 포인터 1줄 → 결합된 포인터 1줄로 교체
  - `If arg #1 is `-h`/`--help`/`help`, or when you need usage/examples, read `references/help.md` verbatim and stop.`
- 라인 수: 99 → 87 (12줄 감소, 이슈 목표 ~10줄 초과 달성)

## Test plan
- [ ] `wc -l claude/skills/devx-rate-limit-guard/SKILL.md` → 87 (≤ 100, Progressive Disclosure 충족)
- [ ] frontmatter 무결성: `head -14` 로 YAML 블록 정상 종료 확인
- [ ] `references/help.md` 가 Usage/Examples 전부 보유하고 있어 사용자 흐름에 정보 손실 없음
- [ ] 자동/수동 회귀: `/devx:rate-limit-guard --help` 실행 시 `references/help.md` 내용이 그대로 출력되는지

## Related
Closes #375

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
