### PR TITLE
fix(skills/devx-resume-after-limit): inline cron prompt template

### DIFF
--- a/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
+++ b/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
@@ -18,11 +18,33 @@ Output: `<min> <hour> <dom> <month> <iso>` — first four = cron expression
 - `cron`: the four fields above followed by `*` (e.g. `"05 23 06 05 *"`)
 - `recurring`: `false`
 - `durable`: `true`
-- `prompt`: the template at
-  `../devx-rate-limit-guard/references/cron-prompt-template.md`,
-  substituting `<PWD_NOW>`, `<BRANCH>`, `<command>` from the loaded state
+- `prompt`: the inline template below, substituting `<PWD_NOW>`,
+  `<BRANCH>`, `<command>` from the loaded state.
 
 Save the returned ID as `<NEXT_ID>`.
+
+### Cron prompt template (inlined)
+
+This template is intentionally inlined here (not referenced via a
+cross-skill path) so `devx-resume-after-limit` stays independent of
+`devx-rate-limit-guard`'s directory layout. The same template lives at
+`devx-rate-limit-guard/references/cron-prompt-template.md` for the
+initial cycle 1 registration; both copies must stay in sync when edited.
+
+```
+[Auto-resume by /devx:rate-limit-guard]
+워크트리: <PWD_NOW>
+브랜치: <BRANCH>
+원본 명령: <command>
+
+현재 워크트리·브랜치가 위와 같으면 `/devx:resume-after-limit`을 호출하여
+재개. 그 스킬이 state 파일에서 multi-cycle 정보(`cycles_remaining`,
+`cycle_window_min`)를 읽어 다음 cycle을 자동 재무장한다. 워크트리/브랜치가
+다르면 사용자에게 알리고 중단.
+
+만약 `/devx:resume-after-limit` 스킬이 없는 환경이라면, fallback으로 원본
+명령을 직접 멱등 재실행 (단일 cycle 동작, PR #369 호환).
+```
 
 ## Update state file
 

--- a/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
+++ b/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
@@ -18,8 +18,10 @@ Output: `<min> <hour> <dom> <month> <iso>` — first four = cron expression
 - `cron`: the four fields above followed by `*` (e.g. `"05 23 06 05 *"`)
 - `recurring`: `false`
 - `durable`: `true`
-- `prompt`: the inline template below, substituting `<PWD_NOW>`,
-  `<BRANCH>`, `<command>` from the loaded state.
+- `prompt`: the inline template below, substituting `<PWD_NOW>` with
+  the state file's `worktree`, `<BRANCH>` with `branch`, and `<command>`
+  with `command`. Pass the substituted result to `CronCreate` verbatim —
+  do not paraphrase or wrap.
 
 Save the returned ID as `<NEXT_ID>`.
 


### PR DESCRIPTION
## Summary
- `devx-resume-after-limit` 스킬의 `preemptive-rearm.md`가 sibling 스킬
  (`devx-rate-limit-guard`)의 references 파일을 cross-skill 상대경로로
  참조해서 깨지기 쉬운 결합이 있던 것을 해소.
- 템플릿을 직접 인라인하여 두 스킬을 디렉토리 레이아웃 측면에서 독립.
- 동일 템플릿이 sibling에도 존재한다는 사실과 동기화 의무를 inline
  주석으로 남김.

## Changes
- `claude/skills/devx-resume-after-limit/references/preemptive-rearm.md`
  - `prompt:` 항목의 `../devx-rate-limit-guard/references/cron-prompt-template.md`
    상대경로 참조 제거
  - cron prompt 템플릿 본문을 `### Cron prompt template (inlined)`
    섹션으로 직접 삽입
  - 두 사본을 동기 유지해야 한다는 운영 노트 추가

## Test plan
- [x] `grep -r "\.\./devx-rate-limit-guard" claude/skills/devx-resume-after-limit/`
      → 결과 없음
- [x] `markdownlint claude/skills/devx-resume-after-limit/references/preemptive-rearm.md`
      → exit 0
- [ ] 다음 multi-cycle (`--max-cycles N > 1`) 시나리오에서
      `/devx:resume-after-limit` Step 4가 inline 템플릿으로 정상 cron 등록되는지
      실사용 검증

## Related
Closes #376

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
