### PR TITLE
refactor(devx-restart): SKILL.md 100줄 한도 준수 — chunking-rules.md 추출

### DIFF
--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -57,27 +57,17 @@ Print one line so the user sees what you picked up:
 재개: <task subject> — 작은 단위로 쪼개서 진행합니다.
 ```
 
-Then mentally split the next concrete action into 1-tool-call increments:
-
-- One `Read` per file (no batch reads of 5 files).
-- One `Edit` per logical change (no multi-file `replace_all` sweeps).
-- One `Bash` per command (avoid long `&&` chains that re-run on retry).
-- One subagent per investigation (don't fan out 4 in parallel here — the
-  whole point is to reduce blast radius on the next flake).
+Read `references/chunking-rules.md` for 1-tool-call splitting rules and
+subagent delegation thresholds.
 
 Mark the task `in_progress` with `TaskUpdate` if it isn't already.
 
 ## Step 3: Delegate Large Outputs
 
-Anything that would dump > ~200 lines into the main context (broad `grep`,
-`find` over the whole repo, reading a 1k-line file you only need a slice of,
-multi-file conformance checks) MUST be delegated to a subagent:
-
-- Broad code search / cross-file consistency → `Agent(subagent_type=Explore)`.
-- Multi-step research or "go figure out X" → `Agent(subagent_type="general-purpose")`.
-
-Brief the agent with the resume target and ask for a < 200-word report.
-Keep the main context lean so the next API hiccup doesn't wipe progress.
+Per the thresholds in `references/chunking-rules.md`, large outputs
+(broad search, full-repo `find`, multi-file conformance checks) MUST go
+through a subagent. Brief it with the resume target and cap the response
+at ~200 words so the main context stays lean.
 
 ## Step 4: Execute, Then Hand Back
 

--- a/claude/skills/devx-restart/references/chunking-rules.md
+++ b/claude/skills/devx-restart/references/chunking-rules.md
@@ -1,0 +1,32 @@
+# devx:restart — Chunking & Delegation Rules
+
+## 1-tool-call splitting
+
+When resuming an interrupted task, split the next concrete action into
+single-tool-call increments so the next flake costs less:
+
+- **One `Read` per file.** No batch reads of 5 files in a single turn.
+- **One `Edit` per logical change.** No multi-file `replace_all` sweeps.
+- **One `Bash` per command.** Avoid long `&&` chains that re-run from
+  the start on retry.
+- **One subagent per investigation.** Don't fan out 4 in parallel here —
+  the whole point is to reduce blast radius on the next flake.
+
+## Subagent delegation thresholds
+
+Anything that would dump > ~200 lines into the main context MUST be
+delegated to a subagent. Triggers:
+
+- Broad code search across the repo (unscoped `grep` / `rg`).
+- `find` over the whole tree.
+- Reading a 1k-line file when only a slice is needed.
+- Multi-file conformance / consistency checks.
+
+Routing:
+
+- Broad code search / cross-file consistency → `Agent(subagent_type=Explore)`.
+- Multi-step research or "go figure out X" →
+  `Agent(subagent_type="general-purpose")`.
+
+Brief the agent with the resume target and cap the response at ~200 words.
+Keeping the main context lean is the whole reason this skill exists.

--- a/claude/skills/devx-restart/references/chunking-rules.md
+++ b/claude/skills/devx-restart/references/chunking-rules.md
@@ -24,7 +24,7 @@ delegated to a subagent. Triggers:
 
 Routing:
 
-- Broad code search / cross-file consistency → `Agent(subagent_type=Explore)`.
+- Broad code search / cross-file consistency → `Agent(subagent_type="Explore")`.
 - Multi-step research or "go figure out X" →
   `Agent(subagent_type="general-purpose")`.
 


### PR DESCRIPTION
## Summary
- `claude/skills/devx-restart/SKILL.md`이 Progressive Disclosure 100줄 한도(104줄)를 초과해 워크플로 로직과 도메인 지식이 인라인으로 섞여 있었다.
- Step 2의 1-tool-call 분할 규칙과 Step 3의 subagent 위임 기준을 신규 `references/chunking-rules.md`로 추출하고, SKILL.md에는 포인터 라인만 남겼다.

## Changes
- `claude/skills/devx-restart/SKILL.md`: 104 → 94 줄. Step 2/3의 인라인 규칙 블록을 한 줄 포인터로 교체.
- `claude/skills/devx-restart/references/chunking-rules.md` 신규 (32 줄): "1-tool-call splitting" 4 항목 + "Subagent delegation thresholds" 트리거·라우팅 매트릭스 수록.

## Test plan
- [x] `wc -l claude/skills/devx-restart/SKILL.md` → 94 (≤ 100)
- [x] `tox -e mdlint` 결과 변경 파일에 위반 없음 (zsh/AGENTS.md의 기존 실패는 무관)
- [ ] 다음 `/devx:restart` 호출에서 Step 2/3가 포인터를 따라가 chunking-rules.md를 정상 참조하는지 확인

## Related
Closes #374

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
