### PR TITLE
refactor(skills): rate-limit-guard step 4·5 detail → references/

### DIFF
--- a/claude/skills/devx-rate-limit-guard/SKILL.md
+++ b/claude/skills/devx-rate-limit-guard/SKILL.md
@@ -61,25 +61,11 @@ PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
 
 Save the returned job ID.
 
-### 4. Persist Cleanup State
+### 4. Persist Cleanup State + 5. Confirm
 
-Write `.claude/.rate-limit-guard.json` (worktree root):
-
-```json
-{"cron_id":"<id>","command":"<command>","worktree":"<PWD_NOW>","branch":"<BRANCH>","scheduled_for":"<ISO>","max_cycles":<N>,"cycles_remaining":<N>,"cycle_window_min":<M>}
-```
-
-`cycles_remaining` starts at `max_cycles`; `/devx:resume-after-limit`
-decrements it as it re-arms subsequent cycles.
-
-### 5. Confirm
-
-```
-🛡️ Rate-limit 안전망 등록 (사이클 1/<N>, 간격 <M>분)
-  • 원본 명령: <command>
-  • 자동 재개 시각: <HH:MM + 5min> (job: <id>)
-이제 원본 명령을 실행합니다 ↓
-```
+Write `.claude/.rate-limit-guard.json` at the worktree root, then print
+the confirm block. Read `references/state-and-confirm.md` for the
+schema (with field descriptions) and the verbatim output template.
 
 ### 6. Execute, then Cleanup on Success
 

--- a/claude/skills/devx-rate-limit-guard/references/state-and-confirm.md
+++ b/claude/skills/devx-rate-limit-guard/references/state-and-confirm.md
@@ -1,0 +1,42 @@
+# State File Schema + Confirm Output Template
+
+Single source of truth for `.claude/.rate-limit-guard.json` and the
+Step 5 user-facing confirm block. Both `devx:rate-limit-guard` (Steps
+4–5) and `devx:resume-after-limit` (`preemptive-rearm.md`) read from
+this file — change the schema here and only here.
+
+## State file: `.claude/.rate-limit-guard.json`
+
+Location: worktree root. One JSON object per line — written compact so
+it round-trips through `cat | jq` without reformat noise.
+
+```json
+{"cron_id":"<id>","command":"<command>","worktree":"<PWD_NOW>","branch":"<BRANCH>","scheduled_for":"<ISO>","max_cycles":<N>,"cycles_remaining":<N>,"cycle_window_min":<M>}
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `cron_id` | string | ID returned by the most recent `CronCreate`. Used by Step 6 cleanup and by `resume-after-limit` re-arm. |
+| `command` | string | Original wrapped command (verbatim, quoting preserved). Replayed unchanged on every cycle. |
+| `worktree` | string | Absolute path captured at registration (`PWD_NOW`). `resume-after-limit` refuses to fire from a different worktree. |
+| `branch` | string | Feature branch captured at registration. Sanity check only. |
+| `scheduled_for` | string (ISO 8601) | Local fire time of the *current* cron — updated each re-arm. |
+| `max_cycles` | int ≥ 1 | Total cycles requested via `--max-cycles N` (default 1). Constant for the lifetime of the state file. |
+| `cycles_remaining` | int 0..N | Starts at `max_cycles`; `resume-after-limit` decrements by 1 every time it pre-emptively re-arms. |
+| `cycle_window_min` | int ≥ 1 | Minutes between fires for cycles 2..N (`--cycle-window M`, default 305). |
+
+Invariants: `0 ≤ cycles_remaining ≤ max_cycles`; the state file exists
+iff a guard cron is currently scheduled. Step 6 deletes the file on
+clean completion.
+
+## Step 5 confirm output template
+
+Printed verbatim after Step 4 succeeds. The `<HH:MM + 5min>` shows the
+reset time plus the constant 5-minute margin.
+
+```
+🛡️ Rate-limit 안전망 등록 (사이클 1/<N>, 간격 <M>분)
+  • 원본 명령: <command>
+  • 자동 재개 시각: <HH:MM + 5min> (job: <id>)
+이제 원본 명령을 실행합니다 ↓
+```

--- a/claude/skills/devx-rate-limit-guard/references/state-and-confirm.md
+++ b/claude/skills/devx-rate-limit-guard/references/state-and-confirm.md
@@ -2,7 +2,7 @@
 
 Single source of truth for `.claude/.rate-limit-guard.json` and the
 Step 5 user-facing confirm block. Both `devx:rate-limit-guard` (Steps
-4–5) and `devx:resume-after-limit` (`preemptive-rearm.md`) read from
+4–5) and `devx:resume-after-limit` (`../../devx-resume-after-limit/references/preemptive-rearm.md`) read from
 this file — change the schema here and only here.
 
 ## State file: `.claude/.rate-limit-guard.json`

--- a/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
+++ b/claude/skills/devx-resume-after-limit/references/preemptive-rearm.md
@@ -26,13 +26,11 @@ Save the returned ID as `<NEXT_ID>`.
 
 ## Update state file
 
-Overwrite `.claude/.rate-limit-guard.json`:
-
-```json
-{"cron_id":"<NEXT_ID>","command":"<command>","worktree":"<worktree>","branch":"<branch>","scheduled_for":"<new ISO>","max_cycles":<N>,"cycles_remaining":<cycles_remaining - 1>,"cycle_window_min":<M>}
-```
-
-`cycles_remaining` is decremented by 1; all other fields preserved.
+Overwrite `.claude/.rate-limit-guard.json` using the schema defined in
+`../../devx-rate-limit-guard/references/state-and-confirm.md` (SSOT).
+Set `cron_id = <NEXT_ID>`, `scheduled_for = <new ISO>`, decrement
+`cycles_remaining` by 1; preserve `command`, `worktree`, `branch`,
+`max_cycles`, `cycle_window_min` from the loaded state.
 
 ## Drift behavior
 


### PR DESCRIPTION
## Summary
- `devx-rate-limit-guard` SKILL.md의 Step 4 JSON 스키마와 Step 5 confirm 출력 템플릿을 신규 `references/state-and-confirm.md`로 분리해 Progressive Disclosure를 적용
- `.claude/.rate-limit-guard.json` 스키마의 SSOT 확보 — `devx-rate-limit-guard`와 `devx-resume-after-limit`이 동일 references 파일을 가리킴

## Changes
- `claude/skills/devx-rate-limit-guard/SKILL.md`: Step 4·5의 인라인 JSON/출력 블록을 1줄 포인터로 대체 (99 → 85줄)
- `claude/skills/devx-rate-limit-guard/references/state-and-confirm.md` (신규): JSON 스키마 + 필드 설명 표 + Step 5 confirm 템플릿
- `claude/skills/devx-resume-after-limit/references/preemptive-rearm.md`: 별도 기술하던 JSON 블록을 SSOT 참조로 교체

## Test plan
- [x] `wc -l claude/skills/devx-rate-limit-guard/SKILL.md` → 85줄 (issue 목표 ~89줄 충족)
- [x] `tox -e mdlint` — 본 PR 수정 파일에 신규 경고 없음 (zsh/AGENTS.md의 기존 경고만 존재)
- [x] 상대 경로 `../../devx-rate-limit-guard/references/state-and-confirm.md` 가 `devx-resume-after-limit/references/preemptive-rearm.md` 위치에서 올바르게 해석됨

## Related
Closes #377

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
