### PR TITLE
feat(gh-flow): pre-flight gh auth 체크 + failed:precondition:gh-auth

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -103,6 +103,14 @@ _gh_flow_require_ai_cli() {
     esac
 }
 
+# Pre-flight health check for the gh CLI token. Returns 0 if `gh api user`
+# succeeds (token valid + network reachable), non-zero otherwise. Run by the
+# worker BEFORE `gwt spawn` so an expired token cannot waste an AI turn on
+# /gh-issue-implement (issue #378, #437 incident).
+_gh_flow_check_gh_auth() {
+    gh api user --jq .login >/dev/null 2>&1
+}
+
 # Run one non-interactive prompt with the selected ai runner.
 # Delegates to ai_usage.sh so each invocation appends a usage record
 # (tokens, cost, duration) to <state-dir>/usage.jsonl. A gh-flow worker
@@ -194,6 +202,10 @@ _gh_flow_verdict() {
             fi
             ;;
         esac
+        ;;
+    failed:precondition:gh-auth)
+        _verdict="precondition failed — gh auth invalid"
+        _action="gh auth login -h github.com && gh-flow $_issue"
         ;;
     failed:*)
         if [ -n "$_wt" ] && [ -d "$_wt" ]; then
@@ -637,8 +649,10 @@ gh_flow_help() {
     ux_info "Failure isolation:"
     ux_bullet "One worker failure does not affect others."
     ux_bullet "Failed worker leaves worktree intact; state shows 'failed:<step>'."
-    ux_bullet "Distinct failure states: failed:implementing, failed:committing,"
-    ux_bullet_sub "failed:opening-pr, failed:replying, failed:merging, failed:tearing-down."
+    ux_bullet "Distinct failure states: failed:precondition:gh-auth, failed:implementing,"
+    ux_bullet_sub "failed:committing, failed:opening-pr, failed:replying,"
+    ux_bullet_sub "failed:merging, failed:tearing-down."
+    ux_bullet "Re-auth recovery: failed:precondition:gh-auth → gh auth login + gh-flow <N>."
     ux_info ""
     ux_info "Preconditions:"
     ux_bullet "Run from main repo (not inside a worktree)"
@@ -890,6 +904,18 @@ _gh_flow_worker() {
     : >"$_usage_log"
 
     printf '[gh-flow-worker] issue=#%s ai=%s start=%s\n' "$_issue" "$_ai" "$(date -Iseconds 2>/dev/null || date)"
+
+    # ---- Step 0: pre-flight gh auth check (issue #378) ----
+    # Without this, an expired token lets the pipeline proceed: gwt spawn
+    # creates a worktree, project board flips to "In progress", then the AI
+    # burns one turn trying to fetch the issue with an invalid token. Catching
+    # it here costs 0 AI tokens and leaves no worktree behind.
+    if ! _gh_flow_check_gh_auth; then
+        _gh_flow_set_state "$_dir" "failed:precondition:gh-auth"
+        printf '[gh-flow-worker] precondition failed: gh auth invalid (gh api user failed)\n' >&2
+        printf '[gh-flow-worker] recover with: gh auth login -h github.com && gh-flow %s\n' "$_issue" >&2
+        return 1
+    fi
 
     # ---- Step 1: spawn worktree ----
     # Snapshot the worktree list before and after `gwt spawn` and diff them

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -205,7 +205,7 @@ _gh_flow_verdict() {
         ;;
     failed:precondition:gh-auth)
         _verdict="precondition failed — gh auth invalid"
-        _action="gh auth login -h github.com && gh-flow $_issue"
+        _action="gh auth login && gh-flow $_issue"
         ;;
     failed:*)
         if [ -n "$_wt" ] && [ -d "$_wt" ]; then
@@ -913,7 +913,7 @@ _gh_flow_worker() {
     if ! _gh_flow_check_gh_auth; then
         _gh_flow_set_state "$_dir" "failed:precondition:gh-auth"
         printf '[gh-flow-worker] precondition failed: gh auth invalid (gh api user failed)\n' >&2
-        printf '[gh-flow-worker] recover with: gh auth login -h github.com && gh-flow %s\n' "$_issue" >&2
+        printf '[gh-flow-worker] recover with: gh auth login && gh-flow %s\n' "$_issue" >&2
         return 1
     fi
 

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -61,6 +61,9 @@ teardown() {
     # New distinct failure states must be documented.
     assert_output --partial "failed:committing"
     assert_output --partial "failed:opening-pr"
+    # Pre-flight gh-auth state and its recovery hint (issue #378).
+    assert_output --partial "failed:precondition:gh-auth"
+    assert_output --partial "gh auth login"
 }
 
 # ---------------------------------------------------------------------------
@@ -490,6 +493,75 @@ STUB
     run_in_bash "cd '$REPO_DIR' && gh_flow status 504 505 2>&1"
     assert_failure
     assert_output --partial "only one issue number"
+}
+
+# ---------------------------------------------------------------------------
+# pre-flight gh auth check (issue #378)
+# ---------------------------------------------------------------------------
+
+# Install a `gh` stub on PATH that controls only the `gh api` exit code.
+# Other subcommands return 0 with no output so unrelated callers don't break.
+# $1 = "ok" (auth valid) or "fail" (auth invalid → exit 1).
+_install_gh_api_stub() {
+    local _mode="${1:-ok}"
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    if [ "$_mode" = "ok" ]; then
+        cat >"$TEST_TEMP_HOME/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+    printf 'mockuser\n'
+    exit 0
+fi
+exit 0
+STUB
+    else
+        cat >"$TEST_TEMP_HOME/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+    printf 'gh api: token invalid\n' >&2
+    exit 1
+fi
+exit 0
+STUB
+    fi
+    chmod +x "$TEST_TEMP_HOME/bin/gh"
+    export PATH="$TEST_TEMP_HOME/bin:$PATH"
+}
+
+@test "pre-flight: _gh_flow_check_gh_auth returns 0 when gh api user succeeds" {
+    _install_gh_api_stub ok
+    run_in_bash "_gh_flow_check_gh_auth && echo OK || echo FAIL"
+    assert_success
+    assert_output --partial "OK"
+}
+
+@test "pre-flight: _gh_flow_check_gh_auth returns non-zero when gh api user fails" {
+    _install_gh_api_stub fail
+    run_in_bash "_gh_flow_check_gh_auth && echo OK || echo FAIL"
+    assert_success
+    assert_output --partial "FAIL"
+}
+
+@test "verdict: failed:precondition:gh-auth → re-auth Next action" {
+    _seed_state 601 "failed:precondition:gh-auth" "" ""
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 601"
+    assert_success
+    assert_line --index 0 "precondition failed — gh auth invalid"
+    assert_output --partial "gh auth login"
+    assert_output --partial "gh-flow 601"
+}
+
+@test "verdict: failed:precondition:gh-auth distinct from generic failed:* dead-failure verdict" {
+    # Same shape as 601 but a generic failed:implementing — must NOT collapse
+    # into the precondition branch. Guards the case-statement ordering
+    # (precondition entry must come before failed:* glob).
+    _seed_state 602 "failed:implementing" "" ""
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 602"
+    assert_success
+    assert_output --partial "dead failure"
+    refute_output --partial "precondition failed"
 }
 
 # Project-board sync helper tests live in


### PR DESCRIPTION
## Summary
- gh-flow worker가 expired/invalid `gh` token 환경에서 worktree spawn → AI 호출(~$0.44 Opus) 1턴 소비 후 `failed:implementing/no-op` 으로 죽던 문제(#437 회고)를 pre-flight check 한 번으로 차단.
- 새 상태 `failed:precondition:gh-auth` + `gh-flow status` Next action 분기로 사용자에게 정확한 복구 절차(재인증 + `gh-flow <N>`)를 안내.
- 회귀 방어를 위해 헬퍼/verdict/help 텍스트 모두 bats 테스트로 잠금.

## Changes
- `shell-common/functions/gh_flow.sh`
  - 신규 헬퍼 `_gh_flow_check_gh_auth`: `gh api user --jq .login` 으로 토큰 + 네트워크 동시 검증.
  - `_gh_flow_worker` 진입부 (gwt spawn 이전) 에서 호출 — 실패 시 `failed:precondition:gh-auth` 로 즉시 종료. AI 호출 0회, worktree 미생성, 보드 카드 미이동.
  - `_gh_flow_verdict` 에 새 case 추가 — 순서상 `failed:precondition:*` 가 generic `failed:*` glob 보다 먼저 매칭되도록 명시.
  - 도움말 (`gh_flow_help`) 의 "Distinct failure states" 라인 + 복구 안내 1줄 추가.
- `tests/bats/functions/gh_flow.bats`
  - 신규 stub 헬퍼 `_install_gh_api_stub` (ok/fail 모드).
  - 헬퍼 happy/sad path 2건.
  - 신규 verdict 분기 테스트 1건 + case-순서 회귀 방지 테스트 1건.
  - 기존 help 테스트에 `failed:precondition:gh-auth`, `gh auth login` partial 어서션 추가.

## Test plan
- [x] `bats tests/bats/functions/gh_flow.bats` — 44/44 (4 신규).
- [x] `bats tests/bats/{init,functions,tools,integrations}` 전체 — 480/480.
- [x] `bash -n shell-common/functions/gh_flow.sh` — 문법 OK.
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_flow.sh` — clean.
- [ ] (수동) 토큰 만료 환경에서 `gh-flow N` 실행 시 worktree가 생기지 않고 `gh-flow status N` 이 재인증 안내를 출력하는지 확인.

## Acceptance (issue #378)
- [x] `gh auth` invalid 환경에서 worker가 spawn 되지 않고 즉시 `failed:precondition:gh-auth` 로 끝남 — claude 토큰 0 소모.
- [x] `gh-flow status N` 의 Next action 이 재인증 + `gh-flow <N>` 안내.
- [x] `failed:implementing` (no-op) 와 새 상태가 별개 표시, 각자 Next action 다름.
- [x] bats 테스트로 두 분기 모두 회귀 방어.

## Related
Closes #378

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~4 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
