### PR TITLE
fix(gh-issue-flow): harness hook prevents mid-chain stop (#383)

### DIFF
--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -71,8 +71,17 @@ def _block(reason: str) -> int:
     return 0
 
 
-def _iter_text_blocks(message: dict[str, Any]) -> list[str]:
-    """Return all text-bearing chunks in a message's content array."""
+def _iter_text_blocks(message: dict[str, Any], include_tool_results: bool = True) -> list[str]:
+    """Return all text-bearing chunks in a message's content array.
+
+    `include_tool_results` gates whether tool_result blocks contribute their
+    text. Boundary detection (Step 1) sets it to False because a tool_result
+    can carry arbitrary file contents — if a file the model reads happens to
+    contain "/gh-issue-flow", the substring would otherwise falsely mark a
+    flow boundary in an unrelated session. Terminal-marker scanning
+    (Step 2) keeps it True so a sub-skill's stdout that prints the Step 3
+    "complete (#N)" line still counts.
+    """
     parts: list[str] = []
     content = message.get("content")
     if isinstance(content, str):
@@ -86,7 +95,7 @@ def _iter_text_blocks(message: dict[str, Any]) -> list[str]:
                 t = block.get("text")
                 if isinstance(t, str):
                     parts.append(t)
-            elif btype == "tool_result":
+            elif btype == "tool_result" and include_tool_results:
                 # tool_result.content can be a string or list of text blocks
                 rc = block.get("content")
                 if isinstance(rc, str):
@@ -151,19 +160,26 @@ def _message_payload(entry: dict[str, Any]) -> dict[str, Any]:
 def _find_flow_boundary(messages: list[dict[str, Any]]) -> int:
     """Return the index of the most recent gh-issue-flow START, or -1.
 
-    Boundary signals:
-      - any message text containing /gh-issue-flow or /gh:issue-flow, OR
-      - any assistant tool_use targeting Skill(gh-issue-flow|gh:issue-flow)
+    Boundary signals (role-restricted to avoid false positives from file
+    content read into tool_result blocks — see PR #386 review feedback):
+      - assistant message: tool_use of Skill(gh-issue-flow | gh:issue-flow)
+      - user message: text content begins with /gh-issue-flow or /gh:issue-flow
+        (tool_result blocks excluded so a file mentioning the command does
+        not trip the boundary)
     """
     for i in range(len(messages) - 1, -1, -1):
         msg = _message_payload(messages[i])
-        for skill in _iter_skill_uses(msg):
-            if skill in FLOW_SKILL_NAMES:
-                return i
-        for text in _iter_text_blocks(msg):
-            for tok in FLOW_START_TOKENS:
-                if tok in text:
+        role = msg.get("role")
+        if role == "assistant":
+            for skill in _iter_skill_uses(msg):
+                if skill in FLOW_SKILL_NAMES:
                     return i
+        elif role == "user":
+            for text in _iter_text_blocks(msg, include_tool_results=False):
+                stripped = text.lstrip()
+                for tok in FLOW_START_TOKENS:
+                    if stripped.startswith(tok):
+                        return i
     return -1
 
 

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Claude Code Stop hook: harness-level guard for /gh-issue-flow early-stop (issue #383).
+
+Reads a Stop event JSON from stdin, parses the conversation transcript, and
+emits a `block` decision when the model tries to end its turn while a
+gh-issue-flow chain is still in progress (5 sub-skills + Step 3 report).
+
+Failure mode being mitigated: the model self-authors a markdown success
+report between Skill() calls in Step 2 of gh-issue-flow and treats that
+report as a turn-ending answer, even though `--no-next-hint` suppressed
+the sub-skill's own trailing `Next:` line. Prose rules in SKILL.md alone
+are not enough — the harness must mechanically force continuation.
+
+Safety rails (each is critical — never accidentally trap the user):
+  - Empty / unreadable / malformed stdin → exit 0 (allow stop).
+  - Missing or unreadable transcript_path → exit 0.
+  - `stop_hook_active == True` → exit 0 (we already blocked once in this
+    chain; bowing out prevents an infinite Stop→block→Stop loop).
+  - No gh-issue-flow boundary in the transcript → exit 0 (not our flow).
+  - Terminal Step 3 marker present → exit 0 (chain finished cleanly).
+  - Any unexpected exception → exit 0 (fail open).
+
+The hook only ever does two things: emit nothing (allow), or emit one JSON
+object `{"decision":"block","reason":"..."}` on stdout (block + nudge).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Sub-skill names accepted in either hyphen or colon namespace form.
+# Order matters — it's the canonical 5-step gh-issue-flow chain.
+EXPECTED_CHAIN: list[tuple[str, str]] = [
+    ("gh-issue-implement", "gh:issue-implement"),
+    ("gh-commit", "gh:commit"),
+    ("gh-pr", "gh:pr"),
+    ("devx-schedule", "devx:schedule"),
+    ("gh-pr-resolve-conflict", "gh:pr-resolve-conflict"),
+]
+SUB_SKILL_NAMES: set[str] = {n for pair in EXPECTED_CHAIN for n in pair}
+
+# Terminal Step 3 markers — presence in any assistant text after the
+# gh-issue-flow boundary means the flow has finished and the model may stop.
+TERMINAL_PATTERNS: tuple[str, ...] = (
+    "gh:issue-flow complete (#",
+    "gh:issue-flow stopped at step",
+    "gh-issue-flow complete (#",
+    "gh-issue-flow stopped at step",
+)
+
+# Tokens that mark the *start* of a gh-issue-flow chain. Either the user
+# typed `/gh-issue-flow ...` or the assistant invoked `Skill(gh-issue-flow)`.
+FLOW_START_TOKENS: tuple[str, ...] = (
+    "/gh-issue-flow",
+    "/gh:issue-flow",
+)
+FLOW_SKILL_NAMES: set[str] = {"gh-issue-flow", "gh:issue-flow"}
+
+
+def _allow() -> int:
+    """Allow the stop. Hook protocol: silent stdout + exit 0."""
+    return 0
+
+
+def _block(reason: str) -> int:
+    """Block the stop with a directive shown to the model."""
+    json.dump({"decision": "block", "reason": reason}, sys.stdout)
+    return 0
+
+
+def _iter_text_blocks(message: dict[str, Any]) -> list[str]:
+    """Return all text-bearing chunks in a message's content array."""
+    parts: list[str] = []
+    content = message.get("content")
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                t = block.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+            elif btype == "tool_result":
+                # tool_result.content can be a string or list of text blocks
+                rc = block.get("content")
+                if isinstance(rc, str):
+                    parts.append(rc)
+                elif isinstance(rc, list):
+                    for sub in rc:
+                        if isinstance(sub, dict) and sub.get("type") == "text":
+                            st = sub.get("text")
+                            if isinstance(st, str):
+                                parts.append(st)
+    return parts
+
+
+def _iter_skill_uses(message: dict[str, Any]) -> list[str]:
+    """Return the skill names invoked via Skill tool_use blocks in this message."""
+    out: list[str] = []
+    content = message.get("content")
+    if not isinstance(content, list):
+        return out
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use":
+            continue
+        if block.get("name") != "Skill":
+            continue
+        tool_input = block.get("input")
+        if not isinstance(tool_input, dict):
+            continue
+        skill = tool_input.get("skill")
+        if isinstance(skill, str):
+            out.append(skill)
+    return out
+
+
+def _load_transcript(path: Path) -> list[dict[str, Any]]:
+    """Best-effort JSONL load. Skips malformed lines, never raises."""
+    out: list[dict[str, Any]] = []
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    out.append(obj)
+    except OSError:
+        return []
+    return out
+
+
+def _message_payload(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return the inner `message` dict if present, else the entry itself."""
+    inner = entry.get("message")
+    return inner if isinstance(inner, dict) else entry
+
+
+def _find_flow_boundary(messages: list[dict[str, Any]]) -> int:
+    """Return the index of the most recent gh-issue-flow START, or -1.
+
+    Boundary signals:
+      - any message text containing /gh-issue-flow or /gh:issue-flow, OR
+      - any assistant tool_use targeting Skill(gh-issue-flow|gh:issue-flow)
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = _message_payload(messages[i])
+        for skill in _iter_skill_uses(msg):
+            if skill in FLOW_SKILL_NAMES:
+                return i
+        for text in _iter_text_blocks(msg):
+            for tok in FLOW_START_TOKENS:
+                if tok in text:
+                    return i
+    return -1
+
+
+def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bool, list[str]]:
+    """Walk forward from the boundary.
+
+    Returns (terminal_seen, ordered_distinct_sub_skill_invocations).
+    Sub-skill names are normalized to the hyphen form for comparison.
+    """
+    terminal = False
+    seen: list[str] = []
+    for entry in messages[start:]:
+        msg = _message_payload(entry)
+        for text in _iter_text_blocks(msg):
+            if any(pat in text for pat in TERMINAL_PATTERNS):
+                terminal = True
+        for skill in _iter_skill_uses(msg):
+            if skill not in SUB_SKILL_NAMES:
+                continue
+            normalized = skill.replace(":", "-")
+            if normalized not in seen:
+                seen.append(normalized)
+    return terminal, seen
+
+
+def _next_step_label(seen: list[str]) -> str:
+    """Map the highest-index sub-skill seen to a human label for the *next* one."""
+    canonical = [hyphen for hyphen, _ in EXPECTED_CHAIN]
+    next_idx = 0
+    for i, name in enumerate(canonical):
+        if name in seen:
+            next_idx = i + 1
+    if next_idx >= len(canonical):
+        return "Step 3 — emit the final 'gh:issue-flow complete (#N)' report"
+    step_num = next_idx + 1  # 1-based for human display
+    return f"Step 2.{step_num} — Skill({canonical[next_idx]})"
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return _allow()
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError:
+        return _allow()
+    if not isinstance(event, dict):
+        return _allow()
+
+    if event.get("stop_hook_active"):
+        return _allow()
+
+    transcript_path = event.get("transcript_path")
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return _allow()
+    p = Path(transcript_path)
+    if not p.is_file():
+        return _allow()
+
+    messages = _load_transcript(p)
+    if not messages:
+        return _allow()
+
+    boundary = _find_flow_boundary(messages)
+    if boundary < 0:
+        return _allow()
+
+    terminal, seen = _scan_after_boundary(messages, boundary)
+    if terminal:
+        return _allow()
+
+    next_label = _next_step_label(seen)
+    reason = (
+        f"gh-issue-flow incomplete: {len(seen)}/5 sub-skills invoked since the "
+        f"flow started, and no terminal Step 3 report ('gh:issue-flow complete' "
+        f"or 'gh:issue-flow stopped at step') has been emitted yet. Per the "
+        f"CRITICAL CONTRACT in claude/skills/gh-issue-flow/SKILL.md, you MUST "
+        f"continue immediately. Next action: {next_label}. Output ZERO "
+        f"conversational text — no recap, no markdown summary, no per-step "
+        f"bullets, no progress headers — just the next Skill() call (or, if all "
+        f"5 sub-skills are already done, the Step 3 success/failure report "
+        f"verbatim per the SKILL.md template)."
+    )
+    return _block(reason)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Final fail-open. Never accidentally trap the user inside a turn.
+        sys.exit(0)

--- a/claude/settings.template.json
+++ b/claude/settings.template.json
@@ -42,6 +42,18 @@
     "type": "command",
     "command": "${HOME}/dotfiles/claude/statusline-command.sh"
   },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "document-skills@anthropic-agent-skills": true,
     "example-skills@anthropic-agent-skills": true

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -227,6 +227,72 @@ _migrate_legacy_plugin_paths() {
     unset -f _migrate_one_plugin_json
 }
 
+# Auto-install gh-issue-flow Stop hook into existing settings.json (issue #383).
+#
+# A new mechanical guard (`claude/hooks/gh_issue_flow_stop_guard.py`) blocks the
+# model from ending its turn while a /gh-issue-flow chain is still mid-flight.
+# settings.template.json already declares this hook for new installs, but the
+# user-private claude/settings.json (gitignored) survives across template
+# updates and would otherwise miss it.
+#
+# This helper rewrites .hooks.Stop in place, only when the exact entry is
+# absent. Idempotent — present-with-same-command → no-op. Different command in
+# .hooks.Stop is left alone (user customisation respected) and a warning is
+# printed so the user can manually merge.
+_migrate_install_gh_issue_flow_stop_hook() {
+    local source_file="$CLAUDE_SETTINGS_SOURCE"
+    # shellcheck disable=SC2016
+    local hook_command='${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py'
+
+    [ -f "$source_file" ] || return 0
+    if ! command -v jq >/dev/null 2>&1; then
+        log_warning "jq 미설치 — gh-issue-flow Stop hook 자동 등록 건너뜀"
+        return 0
+    fi
+
+    local current_count
+    current_count=$(jq --arg cmd "$hook_command" \
+        '[.hooks?.Stop?[]?.hooks?[]? | select(.command == $cmd)] | length' \
+        "$source_file" 2>/dev/null) || current_count=0
+    [ "${current_count:-0}" -eq 0 ] || return 0
+
+    # If user already has *some* Stop hook entry, don't clobber — warn instead.
+    local existing_stop
+    existing_stop=$(jq '[.hooks?.Stop?[]?] | length' "$source_file" 2>/dev/null) || existing_stop=0
+    if [ "${existing_stop:-0}" -gt 0 ]; then
+        log_warning "settings.json 에 다른 Stop hook 이 이미 있습니다 — 자동 머지 생략."
+        log_warning "  수동 추가 필요: claude/hooks/gh_issue_flow_stop_guard.py"
+        log_warning "  참조: claude/skills/gh-issue-flow/references/stop-guard.md"
+        return 0
+    fi
+
+    local backup tmp
+    backup="${source_file}.pre-stop-hook-fix-$(date +%Y%m%d%H%M%S)"
+    if ! cp "$source_file" "$backup"; then
+        log_error "settings.json 백업 실패: $backup — 마이그레이션 중단"
+        return 1
+    fi
+    tmp=$(mktemp "${source_file}.XXXXXX") || {
+        log_error "임시 파일 생성 실패 — 마이그레이션 중단"
+        rm -f "$backup"
+        return 1
+    }
+
+    # jq 변수 ($cmd) 은 --arg 로 주입 — shell 변수 아님.
+    # shellcheck disable=SC2016
+    if jq --arg cmd "$hook_command" \
+            '.hooks = ((.hooks // {}) | .Stop = ((.Stop // []) + [{"hooks":[{"type":"command","command":$cmd}]}]))' \
+            "$source_file" > "$tmp" && mv "$tmp" "$source_file"; then
+        log_warning "settings.json 에 gh-issue-flow Stop hook 자동 등록 완료"
+        log_warning "  hook: $hook_command"
+        log_warning "  backup: $backup"
+    else
+        rm -f "$tmp"
+        log_error "settings.json 갱신 실패 — 백업 보존: $backup"
+        return 1
+    fi
+}
+
 # /sandbox 기능은 socat 을 요구하지만 sudo 가 필요한 install 이라
 # 자동 처리하지 않고 경고만 노출 (issue #340).
 _check_socat_for_sandbox() {
@@ -286,6 +352,10 @@ log_debug "\n--- Claude Code dotfiles setup 시작 ---"
 # downstream symlink uses it (issue #300, item A). Idempotent — only acts
 # on the exact PR #292 legacy literal, otherwise no-op.
 _migrate_legacy_statusline_command
+
+# Auto-install gh-issue-flow Stop hook (issue #383). Idempotent — only adds
+# the entry when it's missing AND no conflicting Stop hook is configured.
+_migrate_install_gh_issue_flow_stop_hook
 
 # 다중 계정 함수 source (env + integration)
 . "$DOTFILES_ROOT/shell-common/env/claude.sh"

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -18,22 +18,36 @@ allowed-tools: Bash, Read, Grep
 
 ## ⚠️ CRITICAL CONTRACT — read before editing
 
-**Recurring failure mode: early-stop after Step 2.1.** When `gh:issue-implement`
-emits its `Next: /gh-commit && /gh-pr <N>` success hint, the model treats it
-as a final answer and ends the turn — leaving the user to manually re-trigger
-`gh:commit` and `gh:pr`. Reported by users as "100번 실행하면 50번은 stop"
-(half of all runs stop early). See issue #333 for history.
+**Recurring failure mode: early-stop after Step 2.x.** When a sub-skill
+(`gh:issue-implement`, `gh:commit`, …) returns, the model treats its own
+self-authored success block as a turn-ending answer and stops mid-chain —
+leaving the user to manually re-trigger the rest. Reported by users as
+"100번 실행하면 50번은 stop" (half of all runs stop early). History:
+issue #333 (introduced `--no-next-hint`), issue #383 (re-occurred even
+with `--no-next-hint`).
 
-**The mechanical guard is `--no-next-hint`** on the Step 2.1 invocation
-(`gh:issue-implement` already supports the flag and suppresses its trailing
-`Next:` line when set). With the trip-wire gone, the model sees a plain
-success report and proceeds naturally to Step 2.2. **Do not drop this flag.**
-If you edit Step 2 in any way, re-verify `--no-next-hint` is still present.
+**Three guards are layered against this — do not remove any of them.**
 
-**Zero conversational text between the five `Skill()` calls in Step 2.**
-No recap, no "now committing", no markdown headers, no progress bullets —
-those tokens read as a turn-ending summary and re-introduce the early-stop.
-The only text allowed in Step 2 is the final Step 3 report.
+1. **`--no-next-hint` on Step 2.1** — suppresses `gh:issue-implement`'s
+   trailing `Next:` hint, the original trip-wire from #333. Load-bearing
+   even though insufficient on its own (see #383).
+2. **Zero conversational text between the five `Skill()` calls in Step 2** —
+   no recap, no "now committing", no markdown headers, no progress
+   bullets. Those tokens read as a turn-ending summary and re-introduce
+   the early-stop. The only prose allowed inside Step 2 is the final
+   Step 3 report.
+3. **Harness Stop hook (`claude/hooks/gh_issue_flow_stop_guard.py`)** —
+   when the model nonetheless tries to end its turn mid-flow, this hook
+   parses the transcript, detects that fewer than 5 sub-skills have run
+   without a Step 3 marker, and returns `{"decision":"block","reason":...}`
+   so Claude Code re-prompts the model to invoke the next sub-skill.
+   See `references/stop-guard.md` for the detection logic, safety rails,
+   and how to disable it temporarily for debugging.
+
+If you edit Step 2 in any way, re-verify all three guards are still in
+place. The harness guard is a backstop, not a license to weaken the
+prose rules — Claude can still emit verbose text BEFORE attempting to
+stop, which the hook cannot prevent.
 
 ## Help
 

--- a/claude/skills/gh-issue-flow/references/stop-guard.md
+++ b/claude/skills/gh-issue-flow/references/stop-guard.md
@@ -1,0 +1,102 @@
+# Stop hook — harness-level guard against gh-issue-flow early-stop
+
+## Why this exists
+
+`gh:issue-flow` chains 5 sub-skills (`gh:issue-implement` → `gh:commit` →
+`gh:pr` → `devx:schedule` → `gh:pr-resolve-conflict`) plus a final Step 3
+report. Across multiple revisions of this skill (issue #333, issue #383)
+the model has repeatedly invented a "I'm done now" markdown block between
+Skill() calls and ended its turn early — leaving the user to manually
+finish the chain.
+
+Two earlier mitigations help but are not sufficient:
+
+- **`--no-next-hint`** (#333): suppresses the sub-skill's own trailing
+  `Next: /gh-commit && /gh-pr <N>` line so it stops looking like a final
+  answer. Effective for the original failure mode.
+- **Prose rules in `SKILL.md`** that forbid conversational text between
+  Skill() calls. Documented but not enforced — observed bypass rate of
+  ~50% in practice, even with bold/CRITICAL framing.
+
+#383 confirmed both are insufficient: the model authors a fresh
+`gh:issue-implement #N complete` block + bullet recap + ai-metrics line
+on its own — none of which `--no-next-hint` controls — and the prose
+rule is silently violated.
+
+The fix: a **Stop hook** that mechanically blocks turn-end while a
+gh-issue-flow chain is mid-flight. The hook does not need the model's
+cooperation; it intervenes after the model has already decided to stop.
+
+## What it does
+
+`claude/hooks/gh_issue_flow_stop_guard.py` is registered as a `Stop`
+hook in `claude/settings.template.json` (and auto-installed into
+existing `claude/settings.json` by `claude/setup.sh` via
+`_migrate_install_gh_issue_flow_stop_hook`).
+
+On every Stop event:
+
+1. Read JSON from stdin (`hook_event_name`, `transcript_path`,
+   `stop_hook_active`, …).
+2. Bail out (allow stop) if any of these is true:
+   - stdin is empty / not JSON / not a dict
+   - `stop_hook_active == true` (we already blocked once in this chain)
+   - `transcript_path` missing or unreadable
+3. Walk the transcript JSONL backwards to find the most recent
+   gh-issue-flow boundary — either the user typed `/gh-issue-flow` or
+   the assistant invoked `Skill(gh-issue-flow)`.
+4. From that boundary forward, scan all assistant text for any
+   terminal Step 3 marker:
+   - `gh:issue-flow complete (#`
+   - `gh:issue-flow stopped at step`
+   - (and the hyphen variants)
+5. If no terminal marker is present, count the distinct sub-skill
+   `Skill()` invocations after the boundary and pick the *next* one
+   in the canonical chain.
+6. Emit `{"decision":"block","reason":"…"}` on stdout. The `reason`
+   tells the model exactly which Skill() call to make next, with the
+   "no conversational text" rule restated.
+
+## Safety rails
+
+The hook runs on every Stop event in the session, not just
+gh-issue-flow ones, so misbehaviour would be very visible. Defenses:
+
+- **Fail-open everywhere.** Every code path that hits an unexpected
+  state — bad JSON, missing file, no boundary, etc. — exits 0 with
+  no output, which Claude Code interprets as "allow the stop."
+- **Outermost `try/except`** in `__main__` catches any uncaught
+  exception and exits 0.
+- **`stop_hook_active` short-circuit.** When Claude Code re-fires Stop
+  after a previous block, the field is set; the hook bails out so we
+  never form an infinite Stop→block→Stop loop within a single chain.
+- **No state file, no network, no writes.** The hook only reads stdin
+  and the transcript. There is nothing to corrupt.
+
+## Disabling temporarily
+
+Three escape hatches when debugging or when you genuinely want to
+end a turn mid-flow:
+
+1. **Comment the entry out** in `~/.claude/settings.json` (or whichever
+   account-specific copy you use) and restart the session.
+2. **Rename or `chmod -x`** the script — the hook command will fail to
+   exec and Claude Code will treat that as a no-op (allow stop).
+3. **Patch the script** to `print('{}'); return 0` at the top of
+   `main()` for the duration of the debug session.
+
+Re-install via `./setup.sh` to restore the default behaviour.
+
+## Tests
+
+`tests/integration/test_gh_issue_flow_stop_guard.py` covers:
+
+- empty stdin / malformed JSON → allow
+- missing transcript_path → allow
+- transcript with no gh-issue-flow boundary → allow
+- mid-flow transcript (e.g. only `gh:issue-implement` invoked) → block
+  with a reason naming the next sub-skill
+- complete transcript (terminal Step 3 marker present) → allow
+- `stop_hook_active == true` → allow regardless of mid-flow state
+
+Run: `pytest tests/integration/test_gh_issue_flow_stop_guard.py -v`.

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -62,6 +62,28 @@ def _assistant_text(text: str) -> dict[str, Any]:
     }
 
 
+def _user_tool_result(text: str) -> dict[str, Any]:
+    """Build a user message carrying a single tool_result block.
+
+    Used to simulate Read/Bash tool output landing in the transcript — i.e.
+    file content that happens to mention "/gh-issue-flow" but is NOT a
+    user-typed command.
+    """
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_test",
+                    "content": text,
+                }
+            ],
+        },
+    }
+
+
 def _assistant_skill(skill: str, args: str = "") -> dict[str, Any]:
     """Build an assistant tool_use message invoking Skill(<skill>)."""
     return {
@@ -301,6 +323,77 @@ def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
         f.write(json.dumps(_assistant_skill("gh-issue-implement")) + "\n")
         f.write("\n")  # blank line
     result = _run_hook(_hook_event(p))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+
+
+def test_tool_result_mentioning_command_not_treated_as_boundary(tmp_path: Path) -> None:
+    """File content read by the model that contains "/gh-issue-flow" must
+    NOT be treated as the user invoking the command (PR #386 review fix).
+
+    Regression for the boundary-detection false positive: previously,
+    `_find_flow_boundary` did `tok in text` across all blocks including
+    tool_result, so any session that read this skill's own SKILL.md (which
+    documents `/gh-issue-flow ...`) would be flagged as in-flow and stops
+    would be blocked.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("can you read the gh-issue-flow SKILL.md and explain it?"),
+            # Simulate a Read tool_result returning the SKILL.md content,
+            # which legitimately contains the command string.
+            _user_tool_result(
+                "# gh:issue-flow — Issue → PR composition\n\n"
+                "Use when the user runs /gh-issue-flow N or /gh:issue-flow N.\n"
+                "Step 2.1 invokes Skill(gh-issue-implement) ...\n"
+            ),
+            _assistant_text("Here's how the skill works: ..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    # No real /gh-issue-flow boundary anywhere — must allow stop.
+    assert result.stdout.strip() == "", (
+        f"Hook treated tool_result file content as a flow boundary. stdout={result.stdout!r}"
+    )
+
+
+def test_command_only_at_start_of_user_text_counts(tmp_path: Path) -> None:
+    """User text that *mentions* /gh-issue-flow mid-sentence is NOT a
+    command; only text starting with the token counts as a boundary
+    (PR #386 review fix — preferred form per gemini suggestion).
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text(
+                "I was reading the docs about /gh-issue-flow and got confused — "
+                "could you summarize how Step 2.x chains together?"
+            ),
+            _assistant_text("Sure — here's a summary: ..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"Hook treated mid-sentence mention of /gh-issue-flow as a command. stdout={result.stdout!r}"
+    )
+
+
+def test_command_with_leading_whitespace_still_counts(tmp_path: Path) -> None:
+    """Leading whitespace before /gh-issue-flow is tolerated (typo-friendly)
+    so users who paste with indent still get the chain protection.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("   /gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -1,0 +1,330 @@
+"""Tests for claude/hooks/gh_issue_flow_stop_guard.py (issue #383).
+
+The hook is invoked as a Claude Code Stop event handler. It reads a JSON
+event from stdin, optionally parses the conversation transcript at
+event['transcript_path'], and either:
+
+  - exits 0 with empty stdout  → allow the model to stop, OR
+  - exits 0 with `{"decision":"block","reason":"..."}` on stdout
+    → block the stop and re-prompt the model.
+
+These tests assemble synthetic transcript fixtures (one JSONL line per
+message) covering the full state space and assert the hook's stdout +
+exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / "claude" / "hooks" / "gh_issue_flow_stop_guard.py"
+
+
+def _run_hook(stdin_payload: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the hook with the given stdin string."""
+    return subprocess.run(
+        ["python3", str(HOOK_PATH)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def _write_transcript(tmp_path: Path, messages: list[dict[str, Any]]) -> Path:
+    """Write a list of dict messages to a JSONL transcript file."""
+    p = tmp_path / "transcript.jsonl"
+    with p.open("w", encoding="utf-8") as f:
+        for m in messages:
+            f.write(json.dumps(m) + "\n")
+    return p
+
+
+def _user_text(text: str) -> dict[str, Any]:
+    """Build a user-typed message entry."""
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _assistant_text(text: str) -> dict[str, Any]:
+    """Build an assistant text-only message entry."""
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _assistant_skill(skill: str, args: str = "") -> dict[str, Any]:
+    """Build an assistant tool_use message invoking Skill(<skill>)."""
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": f"toolu_{skill}",
+                    "name": "Skill",
+                    "input": {"skill": skill, "args": args},
+                }
+            ],
+        },
+    }
+
+
+def _hook_event(transcript_path: Path | None, **extras: Any) -> str:
+    """Build a Stop hook stdin payload."""
+    payload: dict[str, Any] = {
+        "hook_event_name": "Stop",
+        "session_id": "test-session",
+        "stop_hook_active": False,
+    }
+    if transcript_path is not None:
+        payload["transcript_path"] = str(transcript_path)
+    payload.update(extras)
+    return json.dumps(payload)
+
+
+def test_hook_script_exists_and_is_executable() -> None:
+    assert HOOK_PATH.is_file(), f"Hook script missing: {HOOK_PATH}"
+    # Either the +x bit OR being callable via `python3` is enough.
+    # We exercise the python3 path in the rest of the suite.
+
+
+def test_empty_stdin_allows_stop() -> None:
+    result = _run_hook("")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_malformed_json_stdin_allows_stop() -> None:
+    result = _run_hook("this is not json {{{")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_stdin_not_a_dict_allows_stop() -> None:
+    result = _run_hook(json.dumps([1, 2, 3]))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_missing_transcript_path_allows_stop() -> None:
+    result = _run_hook(json.dumps({"hook_event_name": "Stop"}))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_unreadable_transcript_path_allows_stop(tmp_path: Path) -> None:
+    fake = tmp_path / "does-not-exist.jsonl"
+    result = _run_hook(_hook_event(fake))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_no_flow_boundary_in_transcript_allows_stop(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("just chatting about something else"),
+            _assistant_text("sure, here's an answer to that unrelated question."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_stop_hook_active_short_circuits(tmp_path: Path) -> None:
+    """Even if mid-flow, stop_hook_active=true must allow the stop.
+
+    Otherwise we form an infinite Stop→block→Stop loop within a chain.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement", "42 direct origin --no-next-hint"),
+        ],
+    )
+    payload = _hook_event(transcript, stop_hook_active=True)
+    result = _run_hook(payload)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_completed_flow_allows_stop(tmp_path: Path) -> None:
+    """All 5 sub-skills + Step 3 marker present → allow stop."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr"),
+            _assistant_skill("devx-schedule"),
+            _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_text("gh:issue-flow complete (#42)\n  PR URL: https://github.com/example/repo/pull/99"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_stopped_marker_also_allows_stop(tmp_path: Path) -> None:
+    """The 'stopped at step' failure marker counts as terminal too."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_text("gh:issue-flow stopped at step 1/5 (gh:issue-implement)"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_mid_flow_after_step_2_1_blocks_with_next_hint(tmp_path: Path) -> None:
+    """Only gh-issue-implement called → block, naming gh-commit as next."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement", "42 direct origin --no-next-hint"),
+            # The model writes a fake-looking success block but no Step 3 marker.
+            _assistant_text("gh:issue-implement #42 complete\n  Mode: direct\n  Tests: 42 passed, 0 failed"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "expected a block decision, got nothing"
+    decision = json.loads(result.stdout)
+    assert decision.get("decision") == "block"
+    reason = decision.get("reason", "")
+    assert "gh-commit" in reason
+    assert "Step 2.2" in reason
+    assert "1/5" in reason
+
+
+def test_mid_flow_skill_call_with_colon_namespace_counted(tmp_path: Path) -> None:
+    """Skill names like 'gh:issue-implement' (colon form) count too."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh:issue-implement"),
+            _assistant_skill("gh:commit"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-pr" in decision["reason"]
+    assert "Step 2.3" in decision["reason"]
+    assert "2/5" in decision["reason"]
+
+
+def test_mid_flow_after_all_5_blocks_for_step_3_report(tmp_path: Path) -> None:
+    """All 5 sub-skills run but no terminal marker → block, ask for Step 3."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr"),
+            _assistant_skill("devx-schedule"),
+            _assistant_skill("gh-pr-resolve-conflict"),
+            # No Step 3 report yet.
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "Step 3" in decision["reason"]
+    assert "5/5" in decision["reason"]
+
+
+def test_skill_invocation_via_assistant_works_as_boundary(tmp_path: Path) -> None:
+    """Boundary can be a Skill(gh-issue-flow) tool_use, not just user text."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _assistant_skill("gh-issue-flow", "42"),
+            _assistant_skill("gh-issue-implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+
+
+def test_unrelated_skill_after_boundary_not_counted(tmp_path: Path) -> None:
+    """Random other Skill() calls don't advance the gh-issue-flow counter."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("some-unrelated-skill"),
+            _assistant_skill("another-helper"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    # Still only 1/5 — the unrelated skills must not bump the counter.
+    assert "1/5" in decision["reason"]
+
+
+def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
+    """Garbage lines in the middle of the transcript don't crash the hook."""
+    p = tmp_path / "transcript.jsonl"
+    with p.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_user_text("/gh-issue-flow 42")) + "\n")
+        f.write("not valid json at all {{{\n")
+        f.write(json.dumps(_assistant_skill("gh-issue-implement")) + "\n")
+        f.write("\n")  # blank line
+    result = _run_hook(_hook_event(p))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+
+
+@pytest.mark.parametrize(
+    "exec_form",
+    [
+        ["python3", str(HOOK_PATH)],
+        [str(HOOK_PATH)],  # via shebang
+    ],
+)
+def test_hook_callable_two_ways(tmp_path: Path, exec_form: list[str]) -> None:
+    """Both `python3 hook.py` and direct `./hook.py` (via shebang) work."""
+    transcript = _write_transcript(
+        tmp_path,
+        [_user_text("just an unrelated chat")],
+    )
+    result = subprocess.run(
+        exec_form,
+        input=_hook_event(transcript),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- Add a Claude Code Stop hook that mechanically blocks the model from ending its turn while a `/gh-issue-flow` chain is still mid-flight, fixing the reproducible early-stop after Step 2.x even with `--no-next-hint` (issue #383, regression of #333 mitigation).
- Three layered guards now defend the contract: `--no-next-hint`, the existing zero-prose rule, and the new harness-level hook.

## Changes
- **claude/hooks/gh_issue_flow_stop_guard.py** *(new, +200 LoC)*: parses the Stop event JSON on stdin, walks the transcript JSONL, finds the most recent `/gh-issue-flow` boundary, counts distinct sub-skill invocations after it, and looks for a terminal Step 3 marker (`gh:issue-flow complete (#…)` / `gh:issue-flow stopped at step …`). Emits `{"decision":"block","reason":"…"}` when fewer than 5 sub-skills have run with no terminal marker — the reason names the next required `Skill()` call. Fail-open on every error path and on `stop_hook_active=true` to prevent Stop→block→Stop loops.
- **claude/settings.template.json**: declare the Stop hook for new installs.
- **claude/setup.sh**: add `_migrate_install_gh_issue_flow_stop_hook()`, an idempotent helper that injects the entry into existing user-private `claude/settings.json` (gitignored). Backs up before edit; refuses to clobber a pre-existing user Stop hook (warns instead, points at `references/stop-guard.md`).
- **claude/skills/gh-issue-flow/SKILL.md**: rewrite the CRITICAL CONTRACT to enumerate the three layered guards and pin the harness hook as the backstop (with a reminder that prose rules still matter — the hook only catches stop-attempt, not verbose mid-flow text).
- **claude/skills/gh-issue-flow/references/stop-guard.md** *(new)*: design rationale, detection logic, safety rails, and three escape hatches for debugging.
- **tests/integration/test_gh_issue_flow_stop_guard.py** *(new, 18 cases)*: empty stdin, malformed JSON, missing/unreadable transcript, no-flow-context, mid-flow at each step boundary (1/5 → 5/5), completed flow, stopped flow, both colon and hyphen namespace forms, `stop_hook_active` short-circuit, and shebang-vs-`python3` invocation parity.

## Test plan
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py` — 18/18 passed.
- [x] `./tests/test` — 1006/1006 passed (full suite, no regressions).
- [x] `tox -e ruff` and `tox -e mypy` — clean.
- [x] `tox -e shellcheck` on the modified `claude/setup.sh` — clean.
- [x] Manual `jq` smoke-test of the migration filter on a synthetic settings.json (insertion + idempotent re-run).
- [ ] Run `/gh-issue-flow <N>` end-to-end on a fresh worktree after merging — confirm Step 2.x → 2.(x+1) progression no longer stops mid-chain even when the model emits a self-authored success block.
- [ ] Verify the hook's `stop_hook_active` short-circuit on a real session by intentionally writing a fake terminal marker mid-flow (e.g., echo a fake "complete" report) and confirming subsequent legit stops are not blocked.

## Related
Closes #383
Refs #333

---
<details>
<summary>🤖 AI Metrics · 📊 ~9500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~9500 tokens · 👤 ~2 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
