### PR TITLE
chore(gh): gh CLI config dotfiles 통합 및 postponed alias 등록

### DIFF
--- a/gh/config.yml
+++ b/gh/config.yml
@@ -1,0 +1,18 @@
+# The current version of the config schema
+version: 1
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: https
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor:
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# A pager program to send command output to, e.g. "less". If blank, will refer to environment. Set the value to "cat" to disable the pager.
+pager:
+# Aliases allow you to create nicknames for gh commands
+aliases:
+    co: pr checkout
+    postponed: issue list --label "⏸️ Postpone" --state closed
+# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+http_unix_socket:
+# What web browser gh should use when opening URLs. If blank, will refer to environment.
+browser:

--- a/gh/setup.sh
+++ b/gh/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# gh/setup.sh: GitHub CLI configuration setup
+#
+# PURPOSE: Set up gh CLI configuration symlinks
+# WHEN TO RUN: Via ./setup.sh (do NOT run manually)
+#
+# SPECIAL FEATURES:
+#   1. Creates ~/.config/gh/config.yml symlink to gh/config.yml
+#   2. gh aliases (e.g. `gh postponed`) are version-controlled via this file
+
+DOTFILES_GH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GH_CONFIG_SOURCE="${DOTFILES_GH_DIR}/config.yml"
+GH_CONFIG_DIR="${HOME}/.config/gh"
+GH_CONFIG_TARGET="${GH_CONFIG_DIR}/config.yml"
+
+UX_LIB_SCRIPT="${DOTFILES_GH_DIR}/../shell-common/tools/ux_lib/ux_lib.sh"
+
+if [[ -f "${UX_LIB_SCRIPT}" ]]; then
+    source "${UX_LIB_SCRIPT}"
+else
+    echo "CRITICAL ERROR: UX library script not found at ${UX_LIB_SCRIPT}. Exiting." >&2
+    exit 1
+fi
+
+ux_header "GitHub CLI (gh) dotfiles setup 시작"
+
+mkdir -p "$GH_CONFIG_DIR"
+
+if [ -L "$GH_CONFIG_TARGET" ]; then
+    rm "$GH_CONFIG_TARGET"
+elif [ -f "$GH_CONFIG_TARGET" ]; then
+    ux_warning "기존 config.yml 백업: ${GH_CONFIG_TARGET}-$(date +%Y%m%d%H%M%S)-original"
+    cp "$GH_CONFIG_TARGET" "${GH_CONFIG_TARGET}-$(date +%Y%m%d%H%M%S)-original"
+    rm "$GH_CONFIG_TARGET"
+fi
+
+ln -s "$GH_CONFIG_SOURCE" "$GH_CONFIG_TARGET" || { ux_error "심볼릭 링크 생성 실패"; exit 1; }
+ux_success "심볼릭 링크 생성: $GH_CONFIG_TARGET -> $GH_CONFIG_SOURCE"
+
+ux_success "GitHub CLI (gh) dotfiles setup 완료"
+exit 0

--- a/gh/setup.sh
+++ b/gh/setup.sh
@@ -31,9 +31,10 @@ mkdir -p "$GH_CONFIG_DIR"
 if [ -L "$GH_CONFIG_TARGET" ]; then
     rm "$GH_CONFIG_TARGET"
 elif [ -f "$GH_CONFIG_TARGET" ]; then
-    ux_warning "기존 config.yml 백업: ${GH_CONFIG_TARGET}-$(date +%Y%m%d%H%M%S)-original"
-    cp "$GH_CONFIG_TARGET" "${GH_CONFIG_TARGET}-$(date +%Y%m%d%H%M%S)-original"
-    rm "$GH_CONFIG_TARGET"
+    BACKUP_DATE=$(date +%Y%m%d%H%M%S)
+    BACKUP_PATH="${GH_CONFIG_TARGET}-${BACKUP_DATE}-original"
+    ux_warning "기존 config.yml 백업: ${BACKUP_PATH}"
+    mv "$GH_CONFIG_TARGET" "$BACKUP_PATH"
 fi
 
 ln -s "$GH_CONFIG_SOURCE" "$GH_CONFIG_TARGET" || { ux_error "심볼릭 링크 생성 실패"; exit 1; }

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@
 #
 # See SETUP_GUIDE.md for detailed information
 #
-# ⚠️  IMPORTANT: Do NOT delete bash/setup.sh, zsh/setup.sh, git/setup.sh, or claude/setup.sh
+# ⚠️  IMPORTANT: Do NOT delete bash/setup.sh, zsh/setup.sh, git/setup.sh, claude/setup.sh, or gh/setup.sh
 #     They perform special initialization beyond simple symlink creation
 
 set -e
@@ -29,6 +29,7 @@ set -e
 ./scripts/setup-skills-ssot.sh
 ./vscode-extensions/setup.sh
 ./ssh/setup.sh
+./gh/setup.sh
 
 
 


### PR DESCRIPTION
## Summary

- GitHub CLI config(`~/.config/gh/config.yml`)를 dotfiles에 symlink로 통합하여 alias를 버전 관리
- `gh postponed` alias 등록 — `⏸️ Postpone` 라벨의 closed 이슈를 CLI에서 즉시 조회
- `gh/setup.sh` 추가로 새 머신 셋업 시 `./setup.sh` 한 번에 gh alias까지 자동 복원

## Changes

- `gh/config.yml`: `~/.config/gh/config.yml` 을 dotfiles로 이동 후 symlink
  - `co: pr checkout` (기존 alias 보존)
  - `postponed: issue list --label "⏸️ Postpone" --state closed` (신규)
- `gh/setup.sh`: `~/.config/gh/config.yml` symlink 생성 스크립트 (`git/setup.sh` 패턴 준수)
- `setup.sh`: `./gh/setup.sh` 오케스트레이션에 추가

## Test plan

- [ ] `gh alias list` 실행 → `postponed` alias 확인
- [ ] `gh postponed --repo dEitY719/dotfiles` 실행 → Issue #387 조회 확인
- [ ] 새 환경에서 `./setup.sh` 후 `~/.config/gh/config.yml` symlink 정상 생성 확인
- [ ] `ls -la ~/.config/gh/config.yml` → dotfiles/gh/config.yml 를 가리키는 symlink 확인

## Related

Closes #388
Refs #387

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~0.5 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~0.5 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
