### PR TITLE
feat(shell-common): verify pair + Approved fail-closed guard for _gh_project_status_sync

### DIFF
--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -28,6 +28,28 @@
 # bounce an issue from "In review" back to "In progress" when a follow-up
 # fix commit lands. Status names with internal spaces are supported
 # ("Backlog,In progress"); do not pad with spaces around the comma.
+#
+# Verify pair (race absorption, issue #393):
+# After every successful mutation the helper sleeps
+# _GH_PROJECT_STATUS_VERIFY_SLEEP seconds (default 1) and re-queries the
+# current Status. If the value reverted (a builtin workflow such as
+# "Pull request linked to issue" overwrote our write asynchronously), the
+# mutation is re-issued once. A second mismatch fails loud on stderr but
+# still returns 0 to honor the helper's best-effort policy. Override
+# _GH_PROJECT_STATUS_VERIFY_SLEEP=0 in tests to skip the wait.
+#
+# Fail-closed guard (issue #393, defense-in-depth):
+# kind=pr + target="Approved" requires the PR's reviewDecision to equal
+# APPROVED (looked up via `gh pr view --json reviewDecision`). Any other
+# decision — REVIEW_REQUIRED, CHANGES_REQUESTED, or an unreachable gh —
+# rejects the transition with exit code 2. Set
+# _GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1 for an emergency bypass.
+# Other targets (In review / Done / Backlog / etc.) and kind=issue are
+# never gated.
+#
+# Return codes:
+#   0 — success / no-op / best-effort skip (network flake, no project, etc.)
+#   2 — fail-closed policy rejection (Approved guard)
 
 _gh_project_status_sync() {
     local _kind="$1" _num="$2" _target="$3"
@@ -69,6 +91,29 @@ _gh_project_status_sync() {
             return 0
             ;;
     esac
+
+    # Fail-closed guard (issue #393): only an APPROVED PR may land in the
+    # "Approved" column. Other Statuses are unaffected. UNKNOWN (gh pr view
+    # failure) is treated as non-APPROVED — preferring a loud refusal over
+    # a possibly-incorrect mutation. Bypass via
+    # _GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1 (explicit operator intent).
+    if [ "$_kind" = "pr" ] \
+        && [ "$_target" = "Approved" ] \
+        && [ "${_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS-0}" != "1" ]; then
+        local _decision
+        _decision=$(gh pr view "$_num" --json reviewDecision \
+                    --jq '.reviewDecision // "REVIEW_REQUIRED"' 2>/dev/null) \
+            || _decision="UNKNOWN"
+        if [ -z "$_decision" ]; then
+            _decision="UNKNOWN"
+        fi
+        if [ "$_decision" != "APPROVED" ]; then
+            printf '[gh-project-status] refusing PR #%s -> "Approved": reviewDecision=%s\n' \
+                "$_num" "$_decision" >&2
+            printf '[gh-project-status]   bypass: _GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1\n' >&2
+            return 2
+        fi
+    fi
 
     # Resolve owner/repo via gh, with one 5s retry on transient failure
     # (e.g. graphql socket reset). Mirrors the mutation step's retry —
@@ -144,27 +189,130 @@ _gh_project_status_sync() {
             continue
         fi
 
-        # One retry on mutation flake (GraphQL connection reset etc.).
-        # 5s fixed backoff — long enough to ride out transient resets,
-        # short enough to keep callers responsive. Override
-        # _GH_PROJECT_STATUS_RETRY_SLEEP in tests to skip the wait,
-        # matching the auto-detect retry above.
-        if _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
-            printf '[gh-project-status] %s #%s -> "%s"\n' "$_kind" "$_num" "$_target"
-        else
-            sleep "${_GH_PROJECT_STATUS_RETRY_SLEEP-5}"
-            if _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
-                printf '[gh-project-status] %s #%s -> "%s" (after 1 retry)\n' \
-                    "$_kind" "$_num" "$_target"
-            else
-                printf '[gh-project-status] mutation failed for %s #%s (target=%s)\n' \
-                    "$_kind" "$_num" "$_target" >&2
-            fi
-        fi
+        # Mutate + verify pair (issue #393). Retry-on-flake (5s, _RETRY_SLEEP)
+        # and verify-then-re-set (1s, _VERIFY_SLEEP) live in the helper so
+        # this loop body stays focused on per-project gating.
+        _gh_project_status_set_and_verify \
+            "$_kind" "$_num" "$_proj" "$_item" "$_field" "$_option" "$_target"
     done <<EOF
 $_records
 EOF
 
+    return 0
+}
+
+# Run the projectV2 Status mutation, then verify the value stuck via a single
+# follow-up GraphQL read. If a builtin workflow ("Pull request linked to
+# issue", "Item closed", etc.) overwrote our write asynchronously, re-issue
+# the mutation once. A second mismatch fails loud on stderr but still
+# returns 0 — the helper's contract with callers is best-effort.
+#
+# Args: kind num proj item field option target
+# Returns: 0 (always — preserves the helper's best-effort policy).
+#
+# Sleep knobs:
+#   _GH_PROJECT_STATUS_RETRY_SLEEP — wait between mutation attempts on flake
+#                                    (default 5).
+#   _GH_PROJECT_STATUS_VERIFY_SLEEP — wait before each verify read so the
+#                                     builtin workflow has time to fire and
+#                                     be observed (default 1).
+# Both default to 0 in bats tests via env override.
+_gh_project_status_set_and_verify() {
+    local _kind="$1" _num="$2"
+    local _proj="$3" _item="$4" _field="$5" _option="$6" _target="$7"
+    local _actual _retry_label=''
+
+    if ! _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
+        sleep "${_GH_PROJECT_STATUS_RETRY_SLEEP-5}"
+        if ! _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
+            printf '[gh-project-status] mutation failed for %s #%s (target=%s)\n' \
+                "$_kind" "$_num" "$_target" >&2
+            return 0
+        fi
+        _retry_label=' after 1 retry'
+    fi
+
+    sleep "${_GH_PROJECT_STATUS_VERIFY_SLEEP-1}"
+    _actual=$(_gh_project_status_query_current "$_kind" "$_num")
+
+    if [ "$_actual" = "$_target" ]; then
+        printf '[gh-project-status] %s #%s -> "%s" (verified%s)\n' \
+            "$_kind" "$_num" "$_target" "$_retry_label"
+        return 0
+    fi
+
+    # Race: a builtin workflow (or another actor) overwrote our mutation.
+    # Re-set once. Logging both transitions so the user can audit afterwards.
+    printf '[gh-project-status] %s #%s reverted to "%s", re-setting...\n' \
+        "$_kind" "$_num" "$_actual" >&2
+    if ! _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
+        printf '[gh-project-status] ERROR: re-set mutation failed for %s #%s\n' \
+            "$_kind" "$_num" >&2
+        return 0
+    fi
+
+    sleep "${_GH_PROJECT_STATUS_VERIFY_SLEEP-1}"
+    _actual=$(_gh_project_status_query_current "$_kind" "$_num")
+    if [ "$_actual" = "$_target" ]; then
+        printf '[gh-project-status] %s #%s -> "%s" (verified after re-set)\n' \
+            "$_kind" "$_num" "$_target"
+    else
+        # Fail loud — a third mutation would risk a write-loop with the
+        # builtin workflow. Surface the mismatch so the operator can decide.
+        printf '[gh-project-status] ERROR: %s #%s verify failed twice (target="%s", actual="%s"). Manual intervention may be needed.\n' \
+            "$_kind" "$_num" "$_target" "$_actual" >&2
+    fi
+    return 0
+}
+
+# Best-effort read of the current Status for an issue/PR. Returns the first
+# non-empty Status value found across the item's project memberships — for
+# multi-board items the verify pair only checks one board's value, but every
+# board runs the same builtin workflows so observing one race surface is
+# sufficient for the recovery contract.
+#
+# Args: kind num
+# Output (stdout): current Status name or empty string when no project /
+#                  no Status / gh failure.
+# Returns: 0 always.
+_gh_project_status_query_current() {
+    local _kind="$1" _num="$2"
+    [ -z "$_kind" ] && return 0
+    [ -z "$_num" ] && return 0
+
+    local _q_field
+    case "$_kind" in
+        issue) _q_field='issue' ;;
+        pr) _q_field='pullRequest' ;;
+        *) return 0 ;;
+    esac
+
+    local _owner _repo _resolved
+    _resolved=$(_gh_project_status_resolve_owner_repo) || return 0
+    _owner="${_resolved%% *}"
+    _repo="${_resolved#* }"
+
+    gh api graphql \
+        -f query="
+          query(\$owner: String!, \$repo: String!, \$number: Int!) {
+            repository(owner: \$owner, name: \$repo) {
+              ${_q_field}(number: \$number) {
+                projectItems(first: 10) {
+                  nodes {
+                    fieldValueByName(name: \"Status\") {
+                      ... on ProjectV2ItemFieldSingleSelectValue { name }
+                    }
+                  }
+                }
+              }
+            }
+          }" \
+        -f owner="$_owner" -f repo="$_repo" -F number="$_num" \
+        --jq ".data.repository.${_q_field}.projectItems.nodes[]
+              | .fieldValueByName?.name?
+              | select(. != null and . != \"\")" \
+        2>/dev/null \
+        | head -n 1
     return 0
 }
 

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -102,7 +102,7 @@ _gh_project_status_sync() {
         && [ "${_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS-0}" != "1" ]; then
         local _decision
         _decision=$(gh pr view "$_num" --json reviewDecision \
-                    --jq '.reviewDecision // "REVIEW_REQUIRED"' 2>/dev/null) \
+                    --jq '.reviewDecision? // empty' 2>/dev/null) \
             || _decision="UNKNOWN"
         if [ -z "$_decision" ]; then
             _decision="UNKNOWN"
@@ -232,37 +232,41 @@ _gh_project_status_set_and_verify() {
         _retry_label=' after 1 retry'
     fi
 
-    sleep "${_GH_PROJECT_STATUS_VERIFY_SLEEP-1}"
-    _actual=$(_gh_project_status_query_current "$_kind" "$_num")
+    # Verify pair as a 2-attempt loop: sleep → query → compare. If attempt 1
+    # mismatches, log the race and re-mutate before attempt 2. A third
+    # attempt is intentionally not made — it would risk a write-loop with
+    # the builtin workflow. Always returns 0 (best-effort policy, #393).
+    local _attempt
+    for _attempt in 1 2; do
+        sleep "${_GH_PROJECT_STATUS_VERIFY_SLEEP-1}"
+        _actual=$(_gh_project_status_query_current "$_kind" "$_num")
 
-    if [ "$_actual" = "$_target" ]; then
-        printf '[gh-project-status] %s #%s -> "%s" (verified%s)\n' \
-            "$_kind" "$_num" "$_target" "$_retry_label"
-        return 0
-    fi
+        if [ "$_actual" = "$_target" ]; then
+            if [ "$_attempt" -eq 1 ]; then
+                printf '[gh-project-status] %s #%s -> "%s" (verified%s)\n' \
+                    "$_kind" "$_num" "$_target" "$_retry_label"
+            else
+                printf '[gh-project-status] %s #%s -> "%s" (verified after re-set)\n' \
+                    "$_kind" "$_num" "$_target"
+            fi
+            return 0
+        fi
 
-    # Race: a builtin workflow (or another actor) overwrote our mutation.
-    # Re-set once. Logging both transitions so the user can audit afterwards.
-    printf '[gh-project-status] %s #%s reverted to "%s", re-setting...\n' \
-        "$_kind" "$_num" "$_actual" >&2
-    if ! _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
-        printf '[gh-project-status] ERROR: re-set mutation failed for %s #%s\n' \
-            "$_kind" "$_num" >&2
-        return 0
-    fi
+        if [ "$_attempt" -eq 2 ]; then
+            printf '[gh-project-status] ERROR: %s #%s verify failed twice (target="%s", actual="%s"). Manual intervention may be needed.\n' \
+                "$_kind" "$_num" "$_target" "$_actual" >&2
+            return 0
+        fi
 
-    sleep "${_GH_PROJECT_STATUS_VERIFY_SLEEP-1}"
-    _actual=$(_gh_project_status_query_current "$_kind" "$_num")
-    if [ "$_actual" = "$_target" ]; then
-        printf '[gh-project-status] %s #%s -> "%s" (verified after re-set)\n' \
-            "$_kind" "$_num" "$_target"
-    else
-        # Fail loud — a third mutation would risk a write-loop with the
-        # builtin workflow. Surface the mismatch so the operator can decide.
-        printf '[gh-project-status] ERROR: %s #%s verify failed twice (target="%s", actual="%s"). Manual intervention may be needed.\n' \
-            "$_kind" "$_num" "$_target" "$_actual" >&2
-    fi
-    return 0
+        # Race observed — re-set once before the second verify attempt.
+        printf '[gh-project-status] %s #%s reverted to "%s", re-setting...\n' \
+            "$_kind" "$_num" "$_actual" >&2
+        if ! _gh_project_status_mutate "$_proj" "$_item" "$_field" "$_option"; then
+            printf '[gh-project-status] ERROR: re-set mutation failed for %s #%s\n' \
+                "$_kind" "$_num" >&2
+            return 0
+        fi
+    done
 }
 
 # Best-effort read of the current Status for an issue/PR. Returns the first

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -384,3 +384,313 @@ _run_resolve_bash() {
     run cat "$FAKE_GH_COUNTER"
     [ "${#lines[@]}" -eq 2 ]
 }
+
+# ---------------------------------------------------------------------------
+# Verify pair + Approved fail-closed guard — issue #393
+# ---------------------------------------------------------------------------
+#
+# These cases drive the full `_gh_project_status_sync` path (auto-detect →
+# discovery query → mutate → verify) plus the Approved guard branch.
+#
+# The fake `gh` here multiplexes four call shapes by inspecting argv:
+#   1. `gh pr view <num> --json reviewDecision --jq ...` → echoes
+#      $FAKE_REVIEW_DECISION (default APPROVED). Exits 1 when
+#      $FAKE_REVIEW_FAIL=1 to model a network/permission failure.
+#   2. `gh repo view --json owner,name --jq ...` → echoes "owner reponame".
+#   3. `gh api graphql ... query: mutation(...)` → mutation. Outcome (ok/fail)
+#      driven by $FAKE_MUTATE_SEQUENCE (pipe-separated, defaults to all-ok).
+#   4. `gh api graphql ... query: query(...) options(names:` → discovery
+#      query; emits one synthetic record so the sync loop iterates once.
+#   5. `gh api graphql ... query: query(...) fieldValueByName` (no options)
+#      → verify-current query; emits the next entry of
+#      $FAKE_VERIFY_SEQUENCE (pipe-separated; missing entries → empty).
+#
+# All call shapes append a tag to $FAKE_GH_LOG for assertions.
+
+_setup_fake_gh_full() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    FAKE_GH_LOG="$TEST_TEMP_HOME/fake_gh_log"
+    FAKE_MUTATE_IDX="$TEST_TEMP_HOME/fake_mutate_idx"
+    FAKE_VERIFY_IDX="$TEST_TEMP_HOME/fake_verify_idx"
+    mkdir -p "$STUB_BIN"
+    : >"$FAKE_GH_LOG"
+    echo 0 >"$FAKE_MUTATE_IDX"
+    echo 0 >"$FAKE_VERIFY_IDX"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Multiplexed fake gh — see _setup_fake_gh_full comment in bats file.
+LOG="${FAKE_GH_LOG:?FAKE_GH_LOG not set}"
+
+case "$1 $2" in
+    "pr view")
+        echo "pr-view" >>"$LOG"
+        if [ "${FAKE_REVIEW_FAIL:-0}" = "1" ]; then
+            exit 1
+        fi
+        # gh's --jq applies a default when reviewDecision is null. The helper
+        # uses `// "REVIEW_REQUIRED"`; we emit the raw decision here and let
+        # the helper's jq do the substitution.
+        echo "${FAKE_REVIEW_DECISION:-APPROVED}"
+        exit 0
+        ;;
+    "repo view")
+        echo "repo-view" >>"$LOG"
+        echo "owner reponame"
+        exit 0
+        ;;
+    "api graphql")
+        # Inspect the rest of argv to tell mutation / discovery / verify apart.
+        # The query body is passed as the value following `-f query=`.
+        all_args="$*"
+        if [[ "$all_args" == *"mutation("* ]]; then
+            echo "mutate" >>"$LOG"
+            idx=$(cat "$FAKE_MUTATE_IDX")
+            idx=$((idx + 1))
+            echo "$idx" >"$FAKE_MUTATE_IDX"
+            # Pipe-separated outcomes: ok|fail|ok ...; missing entries default ok.
+            IFS='|' read -ra out <<<"${FAKE_MUTATE_SEQUENCE:-ok}"
+            slot="${out[$((idx - 1))]:-ok}"
+            if [ "$slot" = "fail" ]; then
+                echo "graphql: mutation failed" >&2
+                exit 1
+            fi
+            exit 0
+        elif [[ "$all_args" == *"options(names:"* ]]; then
+            echo "discover" >>"$LOG"
+            # One synthetic project item with empty current Status. Fields are
+            # joined with `|` to match the helper's --jq output shape:
+            #   project.id | item.id | field.id | option.id | current_status
+            echo "proj1|item1|field1|opt1|"
+            exit 0
+        elif [[ "$all_args" == *"fieldValueByName"* ]]; then
+            echo "verify" >>"$LOG"
+            idx=$(cat "$FAKE_VERIFY_IDX")
+            idx=$((idx + 1))
+            echo "$idx" >"$FAKE_VERIFY_IDX"
+            IFS='|' read -ra seq <<<"${FAKE_VERIFY_SEQUENCE:-}"
+            val="${seq[$((idx - 1))]:-}"
+            [ -n "$val" ] && echo "$val"
+            exit 0
+        else
+            echo "graphql-other" >>"$LOG"
+            exit 0
+        fi
+        ;;
+esac
+exit 0
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run an arbitrary snippet in bash with the full fake gh on PATH.
+# All sleep knobs default to 0 so tests don't pause.
+_run_full_bash() {
+    local snippet="$1"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_GH_LOG='${FAKE_GH_LOG}'
+        export FAKE_MUTATE_IDX='${FAKE_MUTATE_IDX}'
+        export FAKE_VERIFY_IDX='${FAKE_VERIFY_IDX}'
+        export FAKE_REVIEW_DECISION='${FAKE_REVIEW_DECISION:-APPROVED}'
+        export FAKE_REVIEW_FAIL='${FAKE_REVIEW_FAIL:-0}'
+        export FAKE_MUTATE_SEQUENCE='${FAKE_MUTATE_SEQUENCE:-}'
+        export FAKE_VERIFY_SEQUENCE='${FAKE_VERIFY_SEQUENCE:-}'
+        export _GH_PROJECT_STATUS_RETRY_SLEEP=0
+        export _GH_PROJECT_STATUS_VERIFY_SLEEP=0
+        export _GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS='${_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS:-0}'
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        ${snippet}
+    "
+}
+
+@test "bash: _gh_project_status_query_current helper exists" {
+    run_in_bash 'declare -f _gh_project_status_query_current >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_project_status_query_current helper exists" {
+    run_in_zsh 'typeset -f _gh_project_status_query_current >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_project_status_set_and_verify helper exists" {
+    run_in_bash 'declare -f _gh_project_status_set_and_verify >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ------- verify pair -------------------------------------------------------
+
+@test "verify: happy path — single mutation, '(verified)' log" {
+    _setup_fake_gh_full
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial '-> "In review" (verified)'
+    refute_output --partial "(after 1 retry)"
+    refute_output --partial "(verified after re-set)"
+    refute_output --partial "ERROR"
+    # Exactly one mutation, one verify call.
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+@test "verify: race revert — re-set + second verify, '(verified after re-set)'" {
+    # First verify reads the builtin's overwrite ("In progress"); re-set
+    # mutation lands; second verify reads the target. Two mutations total.
+    _setup_fake_gh_full
+    FAKE_VERIFY_SEQUENCE="In progress|In review" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial 'reverted to "In progress", re-setting'
+    assert_output --partial '(verified after re-set)'
+    refute_output --partial "ERROR"
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 2 ]
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 2 ]
+}
+
+@test "verify: persistent revert — fail loud after 2 verifies, return 0" {
+    # Both verifies disagree with the target. Helper logs ERROR but still
+    # returns 0 — best-effort policy preserved.
+    _setup_fake_gh_full
+    FAKE_VERIFY_SEQUENCE="In progress|In progress" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial 'reverted to "In progress", re-setting'
+    assert_output --partial 'ERROR: pr #42 verify failed twice'
+    assert_output --partial 'target="In review"'
+    assert_output --partial 'actual="In progress"'
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 2 ]
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 2 ]
+}
+
+@test "verify: mutation flake then recovery — '(verified after 1 retry)'" {
+    # First mutation 500s, retry succeeds, verify matches. Two mutations
+    # plus one verify call.
+    _setup_fake_gh_full
+    FAKE_MUTATE_SEQUENCE="fail|ok" \
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial '(verified after 1 retry)'
+    refute_output --partial "ERROR"
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 2 ]
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+@test "verify: VERIFY_SLEEP override is honored (no pause in tests)" {
+    # Sanity check: when _GH_PROJECT_STATUS_VERIFY_SLEEP=0 the helper still
+    # runs the verify call (otherwise the rest of the suite would be lying
+    # about coverage). Time the call — must finish well under 1 second.
+    _setup_fake_gh_full
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash '
+            t0=$(date +%s)
+            _gh_project_status_sync pr 42 "In review" >/dev/null 2>&1
+            t1=$(date +%s)
+            echo "elapsed=$((t1 - t0))"
+        '
+    assert_success
+    assert_output --partial "elapsed=0"
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+# ------- Approved fail-closed guard ----------------------------------------
+
+@test "guard: target=Approved + decision=APPROVED → mutation runs" {
+    _setup_fake_gh_full
+    FAKE_REVIEW_DECISION="APPROVED" \
+    FAKE_VERIFY_SEQUENCE="Approved" \
+        _run_full_bash '_gh_project_status_sync pr 42 "Approved" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial '-> "Approved" (verified)'
+    refute_output --partial "refusing"
+    [ "$(grep -c '^pr-view$' "$FAKE_GH_LOG")" -eq 1 ]
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+@test "guard: target=Approved + decision=REVIEW_REQUIRED → exit 2, no mutation" {
+    _setup_fake_gh_full
+    FAKE_REVIEW_DECISION="REVIEW_REQUIRED" \
+        _run_full_bash '_gh_project_status_sync pr 42 "Approved" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial 'refusing PR #42 -> "Approved": reviewDecision=REVIEW_REQUIRED'
+    assert_output --partial "_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1"
+    [ "$(grep -c '^pr-view$' "$FAKE_GH_LOG")" -eq 1 ]
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 0 ]
+    [ "$(grep -c '^discover$' "$FAKE_GH_LOG")" -eq 0 ]
+}
+
+@test "guard: target=Approved + decision=CHANGES_REQUESTED → exit 2, no mutation" {
+    _setup_fake_gh_full
+    FAKE_REVIEW_DECISION="CHANGES_REQUESTED" \
+        _run_full_bash '_gh_project_status_sync pr 42 "Approved" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial 'reviewDecision=CHANGES_REQUESTED'
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 0 ]
+}
+
+@test "guard: target=Approved + gh pr view fails → UNKNOWN → exit 2" {
+    # Safe default: when gh can't tell us the decision, refuse rather than
+    # risk an incorrect mutation.
+    _setup_fake_gh_full
+    FAKE_REVIEW_FAIL=1 \
+        _run_full_bash '_gh_project_status_sync pr 42 "Approved" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial 'reviewDecision=UNKNOWN'
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 0 ]
+}
+
+@test "guard: target=Approved + bypass=1 → guard skipped, mutation runs" {
+    _setup_fake_gh_full
+    FAKE_REVIEW_DECISION="REVIEW_REQUIRED" \
+    FAKE_VERIFY_SEQUENCE="Approved" \
+    _GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1 \
+        _run_full_bash '_gh_project_status_sync pr 42 "Approved" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial '-> "Approved" (verified)'
+    refute_output --partial "refusing"
+    # gh pr view must NOT have been called when bypass is on.
+    [ "$(grep -c '^pr-view$' "$FAKE_GH_LOG")" -eq 0 ]
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+@test "guard: target=In review → guard does not fire (no pr-view call)" {
+    # The guard only inspects "Approved". Other targets must skip the
+    # gh pr view round-trip entirely.
+    _setup_fake_gh_full
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    [ "$(grep -c '^pr-view$' "$FAKE_GH_LOG")" -eq 0 ]
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+@test "guard: kind=issue + target=Approved → guard does not fire" {
+    # Guard is PR-only — issues never have a reviewDecision.
+    _setup_fake_gh_full
+    FAKE_VERIFY_SEQUENCE="Approved" \
+        _run_full_bash '_gh_project_status_sync issue 42 "Approved" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    [ "$(grep -c '^pr-view$' "$FAKE_GH_LOG")" -eq 0 ]
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
+}


### PR DESCRIPTION
## 요약

`_gh_project_status_sync` 헬퍼에 두 방향의 보강을 함께 추가:

1. **Verify pair (race 흡수)** — 모든 mutation 성공 후 `_GH_PROJECT_STATUS_VERIFY_SLEEP` 초 (default 1) 대기 후 신규 헬퍼 `_gh_project_status_query_current` 로 현재 Status 재조회. builtin workflow 가 비동기로 덮어쓴 경우 1회 자동 재시도, 두 번째에도 불일치하면 fail loud (stderr) — return 0 은 유지 (best-effort 정책).
2. **Approved 컬럼 fail-closed 가드 (defense-in-depth)** — `kind=pr` + `target="Approved"` 호출은 `gh pr view --json reviewDecision == APPROVED` 일 때만 통과. REVIEW_REQUIRED / CHANGES_REQUESTED / UNKNOWN (gh 실패) 는 모두 exit 2 로 거부. `_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1` 로 비상 우회 가능.

mutate + verify + retry 루프가 길어져 가독성을 위해 `_gh_project_status_set_and_verify` 보조 헬퍼로 추출. 함수 헤더 주석에 verify pair, fail-closed 가드 정책, return code (0=success/best-effort, 2=policy violation), 환경변수 전체를 SSOT 로 명시.

## Why

- Race 시나리오: GitHub Project 보드의 builtin "Pull request linked to issue", "Item closed" 워크플로우가 mutation 직후 비동기로 발화하여 우리 write 를 덮어씀 → 단순 "200 OK" 검증으로는 사일런트 실패. 검토 노트 #384 의 좋은 점 6.
- Approved 가드: 현재 호출 경로 (`gh:pr-approve` 4a + GitHub Actions `project-board-sync.yml`) 는 자연 fail-closed 지만, 미래의 직접 호출자 (신규 skill / 수동) 로부터 컬럼 의미를 보호. 검토 노트 #384 의 좋은 점 11.

자세한 설계는 issue #393 의 SSOT 코멘트 두 개 참고:
- Verify pair: dEitY719/dotfiles#384 (comment 4403710807)
- Approved guard: dEitY719/dotfiles#384 (comment 4403888019)

## 변경

### `shell-common/functions/gh_project_status.sh`

- 신규 헬퍼 `_gh_project_status_query_current <kind> <num>` — 단일 GraphQL query 로 현재 Status 만 조회, 첫 non-empty 값 반환 (multi-board 시 첫 board 만).
- 신규 헬퍼 `_gh_project_status_set_and_verify <kind> <num> <proj> <item> <field> <option> <target>` — mutate-on-flake retry + verify-then-re-set 사이클을 한 함수로 격리.
- `_gh_project_status_sync` 진입부에 Approved fail-closed 가드 블록 추가 (validation 다음, owner/repo 해석 전).
- 기존 mutation 루프 (라인 152-163) 를 `_gh_project_status_set_and_verify` 호출로 교체.
- 함수 헤더 주석에 verify pair, fail-closed 가드, env vars (`_GH_PROJECT_STATUS_VERIFY_SLEEP`, `_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS`), return code (0/2) 명시.

### `tests/bats/functions/gh_project_status.bats`

15 개 새 테스트 (기존 33 개 모두 통과 유지):

- 헬퍼 존재 검증 (3) — `_gh_project_status_query_current` (bash, zsh), `_gh_project_status_set_and_verify` (bash).
- Verify pair (5) — happy path "(verified)", race revert "(verified after re-set)", persistent revert "ERROR verify failed twice", mutation flake recovery "(verified after 1 retry)", VERIFY_SLEEP=0 timing.
- Approved guard (7) — APPROVED 통과, REVIEW_REQUIRED / CHANGES_REQUESTED / UNKNOWN 거부 (exit 2, mutation 0 회), bypass=1 skip, target=In review 가드 발화 안 함, kind=issue 가드 발화 안 함.

가짜 `gh` shim 이 argv 검사로 `pr view` / `repo view` / discovery `api graphql` / mutate `api graphql` / verify-current `api graphql` 5 가지 call 을 분기. 시퀀스(`FAKE_VERIFY_SEQUENCE`, `FAKE_MUTATE_SEQUENCE`) 와 카운터 파일로 race / flake 시나리오 결정적 재현.

## 호환성

| 시나리오 | 결과 |
|---|---|
| 기존 호출 (`gh:pr` Step 7, `gh:commit` Step 5, `gh:pr-merge` Step 4 등) | 무영향 — verify pair 가 자동 추가되어 로그에 `(verified)` 추가만 보임 |
| `target="Approved"` 직접 호출 (없음) | 가드 발화 → reviewDecision 검증 |
| GitHub Actions `project-board-sync.yml` "PR review approved" 단계 | 정상 (review.state==approved 일 때 reviewDecision 도 APPROVED 인 경우 통과) — 다중 reviewer required 환경에서는 `_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1` 추가 검토 가능 |
| 보드 없는 repo | 무영향 (query 단계에서 no-project return 0) |

## 검증

```
$ bats tests/bats/functions/gh_project_status.bats
1..48
ok 1..48
```

`_gh_project_status_sync issue 393 "In progress"` 호출 (gh-commit Step 5) 가 dogfood 로 실행되어 실제로 `(verified)` 로그를 출력함 — 본 PR 의 verify pair 가 production 에서 동작 확인.

Closes #393

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~8 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
