### PR TITLE
feat(shell-common): board fail-closed audit + merge gate (#397)

### DIFF
--- a/claude/skills/gh-pr-approve/references/board-policy.md
+++ b/claude/skills/gh-pr-approve/references/board-policy.md
@@ -1,0 +1,83 @@
+# Board Status Policy — `Approved` column gate
+
+This is the single-source-of-truth for what the `Approved` column on a
+projectV2 board means in this org's workflow, and which guard rails
+enforce it.
+
+## Rule
+
+A PR card may only sit in the `Approved` column when GitHub's
+`reviewDecision` for that PR equals `APPROVED`. Any other state
+(`REVIEW_REQUIRED`, `CHANGES_REQUESTED`, empty) is a policy violation.
+
+The same rule cascades into `gh:pr-merge`: a card whose Status is not
+`Approved` cannot be merged via the regular `/gh-pr-merge` skill — the
+caller is redirected to `/gh-pr-merge-emergency` for an admin override
+with audit trail.
+
+## Why fail-closed instead of advisory
+
+`reviewDecision == APPROVED` is necessary but not sufficient on this
+board:
+
+- Solo / personal repos lack branch protection. `reviewDecision` stays
+  empty for self-authored PRs, so a CI-only check would pass without any
+  human signal at all.
+- Teammate review is captured by the board column, not by GitHub's
+  reviewer mechanism — the column is what the team eyes when triaging.
+
+A fail-closed guard at both write points (transition + merge) keeps the
+column meaningful: when you see a PR in `Approved`, it actually has been
+through reviewer eyes.
+
+## Two enforcement points
+
+### 1. Transition into the column (write side)
+
+`shell-common/functions/gh_project_status.sh` rejects any
+`_gh_project_status_sync pr <N> "Approved"` call when
+`gh pr view --json reviewDecision` returns anything other than
+`APPROVED`. Failure mode is `exit 2` with a clear stderr line; bypass is
+`_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1` for emergency operator
+intent.
+
+This guard was added in #393 along with the verify pair — both are
+defenses against the same class of bug (Status drifts away from what the
+helper thinks it set).
+
+### 2. Merge gate (read side)
+
+`gh:pr-merge` Step 4-B (added by #397) reads the current board Status
+before merging. If Status `!= Approved`, the merge is refused and the
+operator is redirected to `gh:pr-merge-emergency`. Escape:
+`GH_PR_MERGE_SKIP_BOARD_CHECK=1` for repos in transition or for
+single-shot bypass with audit trail.
+
+The two checks are intentionally redundant. If the helper's transition
+guard is bypassed, the merge gate still catches it; if the merge gate
+is bypassed (env var), the audit issue created by
+`gh:pr-merge-emergency` records it.
+
+## Out of scope
+
+- Issue cards never visit `Approved` per `github-project-board.md`;
+  guards above only apply when `kind == pr`.
+- Repos without a projectV2 attachment are auto-detected and skipped:
+  the helper finds zero items and returns 0. No board → no policy →
+  legacy CI-only flow (`reviewDecision == APPROVED` still required by
+  `gh:pr-merge` Step 2).
+
+## Audit
+
+`gh-audit-builtin-workflows` (shell-common function added in #397)
+checks that the asynchronous "Pull request linked to issue" builtin
+workflow is OFF on every attached projectV2 — that builtin races with
+the deterministic Status transitions and would silently invalidate this
+guard.
+
+## See also
+
+- `shell-common/functions/gh_project_status.sh` — write-side guard impl.
+- `claude/skills/gh-pr-merge/SKILL.md` Step 4-B — merge-gate impl.
+- `claude/skills/gh-pr-merge/references/board-policy.md` — cross-link.
+- `docs/standards/github-project-board.md` — column semantics SSOT.

--- a/claude/skills/gh-pr-approve/references/board-policy.md
+++ b/claude/skills/gh-pr-approve/references/board-policy.md
@@ -47,7 +47,7 @@ helper thinks it set).
 
 ### 2. Merge gate (read side)
 
-`gh:pr-merge` Step 4-B (added by #397) reads the current board Status
+`gh:pr-merge` Step 2-B (added by #397) reads the current board Status
 before merging. If Status `!= Approved`, the merge is refused and the
 operator is redirected to `gh:pr-merge-emergency`. Escape:
 `GH_PR_MERGE_SKIP_BOARD_CHECK=1` for repos in transition or for
@@ -78,6 +78,6 @@ guard.
 ## See also
 
 - `shell-common/functions/gh_project_status.sh` — write-side guard impl.
-- `claude/skills/gh-pr-merge/SKILL.md` Step 4-B — merge-gate impl.
+- `claude/skills/gh-pr-merge/SKILL.md` Step 2-B — merge-gate impl.
 - `claude/skills/gh-pr-merge/references/board-policy.md` — cross-link.
 - `docs/standards/github-project-board.md` — column semantics SSOT.

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -61,6 +61,45 @@ Then detect whether the base branch has protection rules (uses
 - `mergeStateStatus ∈ {BEHIND, BLOCKED, DIRTY}`
 - Any required check FAILURE or pending
 
+## Step 2-B: Project Board Approval Gate (fail-closed)
+
+Read `references/board-policy.md` for the rule set and the cross-link
+to `gh-pr-approve`. This step runs **before** Step 3 and gates merges
+on the team's projectV2 board column.
+
+```bash
+# Reuse the SSOT query helper — never inline a fresh GraphQL block.
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+
+# Operator escape hatch: GH_PR_MERGE_SKIP_BOARD_CHECK=1
+# Use for in-transition repos or one-shot ops (also leaves an audit signal:
+# any reviewer can re-run gh-pr-merge without the env var to verify).
+if [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
+    BOARD_STATUS=$(GH_REPO="$TARGET_REPO" \
+        _gh_project_status_query_current pr "$PR_NUMBER" 2>/dev/null)
+
+    # Empty result = no projectV2 attached OR no read access.
+    # Auto-skip in both cases — the merge gate is opt-in by board attachment.
+    if [ -n "$BOARD_STATUS" ] && [ "$BOARD_STATUS" != "Approved" ]; then
+        echo "Refusing to merge PR #$PR_NUMBER — board Status is \"$BOARD_STATUS\", required \"Approved\"."
+        echo "  Have a teammate move the card to Approved, or use /gh-pr-merge-emergency for admin bypass."
+        echo "  One-shot escape: GH_PR_MERGE_SKIP_BOARD_CHECK=1 /gh-pr-merge $PR_NUMBER"
+        exit 2
+    fi
+fi
+```
+
+Failure modes:
+
+- Board Status `!= Approved` (and non-empty) → exit 2, redirect to
+  `/gh-pr-merge-emergency`.
+- Empty Status (no projectV2 attached, or query failed) → silently
+  continue. Repos without a board run on the legacy `reviewDecision`
+  gate from Step 2 alone.
+- `GH_PR_MERGE_SKIP_BOARD_CHECK=1` → skip Step 2-B entirely. Document
+  the reason in the operator's commit message or Slack channel; this
+  flag is for repos in transition, not a quiet-the-warning button.
+
 ## Step 3: Merge (no confirmation)
 
 ```bash

--- a/claude/skills/gh-pr-merge/references/board-policy.md
+++ b/claude/skills/gh-pr-merge/references/board-policy.md
@@ -1,0 +1,33 @@
+# Board Status Policy — cross-link
+
+The full rule set for the `Approved` column gate lives in
+`claude/skills/gh-pr-approve/references/board-policy.md`. This file is
+a thin pointer so the merge skill can cite the SSOT without duplicating
+its prose.
+
+## TL;DR for `gh:pr-merge` callers
+
+- A PR card must sit in `Approved` to merge via `/gh-pr-merge`.
+- Status `!= Approved` → `/gh-pr-merge` exits 2 and points at
+  `/gh-pr-merge-emergency` for admin override + audit trail.
+- Repos without a projectV2 attachment auto-skip Step 4-B
+  (`gh-pr-merge` SKILL.md detects empty Status and continues).
+- Bypass for in-transition repos: `GH_PR_MERGE_SKIP_BOARD_CHECK=1`.
+
+## Implementation
+
+Step 4-B of `gh:pr-merge/SKILL.md` runs immediately before Step 3 (the
+merge call). It re-uses `_gh_project_status_query_current` from
+`shell-common/functions/gh_project_status.sh` so all helpers agree on
+which board / which Status is canonical (no inline GraphQL drift).
+
+## See also
+
+- `claude/skills/gh-pr-approve/references/board-policy.md` — full rule
+  set, why fail-closed, the dual-write guard rationale.
+- `shell-common/functions/gh_project_status.sh` — `Approved` write-side
+  guard (the other half of the dual gate).
+- `shell-common/functions/gh_audit_builtin_workflows.sh` — audits that
+  the "Pull request linked to issue" builtin is OFF, so the guard isn't
+  invalidated by an async overwrite.
+- `docs/standards/github-project-board.md` — column semantics SSOT.

--- a/claude/skills/gh-pr-merge/references/board-policy.md
+++ b/claude/skills/gh-pr-merge/references/board-policy.md
@@ -10,13 +10,13 @@ its prose.
 - A PR card must sit in `Approved` to merge via `/gh-pr-merge`.
 - Status `!= Approved` → `/gh-pr-merge` exits 2 and points at
   `/gh-pr-merge-emergency` for admin override + audit trail.
-- Repos without a projectV2 attachment auto-skip Step 4-B
+- Repos without a projectV2 attachment auto-skip Step 2-B
   (`gh-pr-merge` SKILL.md detects empty Status and continues).
 - Bypass for in-transition repos: `GH_PR_MERGE_SKIP_BOARD_CHECK=1`.
 
 ## Implementation
 
-Step 4-B of `gh:pr-merge/SKILL.md` runs immediately before Step 3 (the
+Step 2-B of `gh:pr-merge/SKILL.md` runs immediately before Step 3 (the
 merge call). It re-uses `_gh_project_status_query_current` from
 `shell-common/functions/gh_project_status.sh` so all helpers agree on
 which board / which Status is canonical (no inline GraphQL drift).

--- a/shell-common/functions/gh_audit_builtin_workflows.sh
+++ b/shell-common/functions/gh_audit_builtin_workflows.sh
@@ -99,27 +99,17 @@ _gh_audit_builtin_workflows_resolve_repo() {
 }
 
 # ---------------------------------------------------------------------------
-# Forbidden workflow names — single-source list, easy to extend later.
-# ---------------------------------------------------------------------------
-
-_gh_audit_builtin_workflows_forbidden() {
-    printf '%s\n' "Pull request linked to issue"
-}
-
-# ---------------------------------------------------------------------------
-# Membership test for forbidden list. Returns 0 when $1 matches a line in
-# _gh_audit_builtin_workflows_forbidden, 1 otherwise. Pure shell, no fork.
+# Forbidden workflow names — case statement (no fork, no command substitution).
+# Add new patterns above the catch-all `*)` line as new violations are
+# discovered. Reviewer note (PR #402): the prior heredoc-list pattern forked
+# a subshell on every check; case is O(1) and avoids the fork entirely.
 # ---------------------------------------------------------------------------
 
 _gh_audit_builtin_workflows_is_forbidden() {
-    local _name="$1" _line
-    [ -z "$_name" ] && return 1
-    while IFS= read -r _line; do
-        [ "$_line" = "$_name" ] && return 0
-    done <<EOF
-$(_gh_audit_builtin_workflows_forbidden)
-EOF
-    return 1
+    case "$1" in
+    "Pull request linked to issue") return 0 ;;
+    *) return 1 ;;
+    esac
 }
 
 # ---------------------------------------------------------------------------
@@ -163,8 +153,11 @@ gh_audit_builtin_workflows() {
     # lacks access, GitHub returns a partial result with `null` workflows —
     # that's why we filter `.workflows?.nodes? // []` rather than failing.
     #
-    # Output shape: one record per workflow, joined by `|`:
-    #   project_url | project_title | workflow_name | enabled (true|false)
+    # Output shape: one record per workflow, tab-separated:
+    #   project_url \t project_title \t workflow_name \t enabled (true|false)
+    # Tab is safer than `|` because project titles may contain that character
+    # (PR #402 review). Null-safe `// empty` on `.repository?` keeps callers
+    # from blowing up if GitHub returns a malformed response.
     #
     # GraphQL variables ($owner, $repo) are bound via -f below — single-quoted
     # query string is intentional (would otherwise interpolate at shell level).
@@ -187,10 +180,11 @@ gh_audit_builtin_workflows() {
             }
           }' \
         -f owner="$_owner" -f repo="$_repo" \
-        --jq '.data.repository.projectsV2.nodes[]?
+        --jq '.data.repository? // empty
+              | .projectsV2?.nodes[]?
               | . as $p
               | (.workflows?.nodes? // [])[]?
-              | "\($p.url)|\($p.title)|\(.name)|\(.enabled)"' \
+              | "\($p.url)\t\($p.title)\t\(.name)\t\(.enabled)"' \
         2>/dev/null) || {
         printf '[gh-audit-builtin-workflows] graphql query failed for %s/%s\n' \
             "$_owner" "$_repo" >&2
@@ -211,7 +205,7 @@ gh_audit_builtin_workflows() {
     # pre-commit hook enforces this in this repo).
     local _violations=0
     local _url _title _name _enabled
-    while IFS='|' read -r _url _title _name _enabled; do
+    while IFS=$'\t' read -r _url _title _name _enabled; do
         [ -z "$_name" ] && continue
         if _gh_audit_builtin_workflows_is_forbidden "$_name" &&
             [ "$_enabled" = "true" ]; then

--- a/shell-common/functions/gh_audit_builtin_workflows.sh
+++ b/shell-common/functions/gh_audit_builtin_workflows.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_audit_builtin_workflows.sh
+# Audit projectV2 boards attached to the current repo for builtin workflow
+# policy violations.
+#
+# Current policy (one rule, expandable as we observe more violations):
+#
+#   "Pull request linked to issue" must be DISABLED.
+#
+# Why this rule exists:
+# When ON, this builtin asynchronously rewrites the linked issue's Status
+# whenever a PR references it (#393 verify pair documents the race). It
+# fights every deterministic Status transition the gh-flow / gh-pr-merge
+# helpers issue. Disabling it lets these helpers own Status transitions
+# without write-loops.
+#
+# Usage:
+#   gh_audit_builtin_workflows                  # audit current repo's projects
+#   gh_audit_builtin_workflows --repo o/r       # audit explicit repo
+#   gh_audit_builtin_workflows -h | --help      # print help
+#
+# Aliases:
+#   gh-audit-builtin-workflows
+#
+# Exit codes:
+#   0 — all attached projectV2 boards policy-compliant (or no project / no
+#       board access — silent skip, like other gh_project_status_* helpers)
+#   2 — at least one attached projectV2 has a forbidden workflow ENABLED
+#
+# Project-agnostic: works in any repo where the caller has `gh` configured.
+# Repos without a projectV2 attachment exit 0 with a "no projects" notice.
+
+# ---------------------------------------------------------------------------
+# Help text
+# ---------------------------------------------------------------------------
+
+gh_audit_builtin_workflows_help() {
+    if type ux_header >/dev/null 2>&1; then
+        ux_header "gh-audit-builtin-workflows"
+        ux_section "Usage"
+        ux_bullet "gh-audit-builtin-workflows"
+        ux_bullet "gh-audit-builtin-workflows --repo owner/name"
+        ux_bullet "gh-audit-builtin-workflows -h | --help"
+        ux_section "Policy"
+        ux_bullet "\"Pull request linked to issue\" must be DISABLED on every"
+        ux_bullet "  attached projectV2 board. ON triggers async Status rewrites"
+        ux_bullet "  that race with deterministic helpers (issue #393)."
+        ux_section "Exit codes"
+        ux_bullet "0 — compliant (or no projects attached / no access)"
+        ux_bullet "2 — at least one violation detected"
+    else
+        cat <<'HELP'
+gh-audit-builtin-workflows — audit projectV2 builtin workflow policy
+
+Usage:
+  gh-audit-builtin-workflows
+  gh-audit-builtin-workflows --repo owner/name
+  gh-audit-builtin-workflows -h | --help
+
+Policy:
+  "Pull request linked to issue" must be DISABLED on every attached
+  projectV2 board. ON triggers async Status rewrites that race with
+  deterministic helpers (issue #393).
+
+Exit codes:
+  0  compliant (or no projects attached / no access)
+  2  at least one violation detected
+HELP
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Owner/repo resolution — same precedence as _gh_pr_edit_safe helpers:
+#   1. --repo flag
+#   2. GH_REPO env var
+#   3. `gh repo view --json nameWithOwner`
+# Prints "<owner> <repo>" on stdout, returns 1 on failure.
+# ---------------------------------------------------------------------------
+
+_gh_audit_builtin_workflows_resolve_repo() {
+    local _explicit="$1"
+    local _spec=""
+
+    if [ -n "$_explicit" ]; then
+        _spec="$_explicit"
+    elif [ -n "${GH_REPO-}" ]; then
+        _spec="$GH_REPO"
+    else
+        _spec=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || return 1
+    fi
+
+    [ -z "$_spec" ] && return 1
+    case "$_spec" in
+    */*) ;;
+    *) return 1 ;;
+    esac
+    printf '%s %s\n' "${_spec%/*}" "${_spec#*/}"
+}
+
+# ---------------------------------------------------------------------------
+# Forbidden workflow names — single-source list, easy to extend later.
+# ---------------------------------------------------------------------------
+
+_gh_audit_builtin_workflows_forbidden() {
+    printf '%s\n' "Pull request linked to issue"
+}
+
+# ---------------------------------------------------------------------------
+# Membership test for forbidden list. Returns 0 when $1 matches a line in
+# _gh_audit_builtin_workflows_forbidden, 1 otherwise. Pure shell, no fork.
+# ---------------------------------------------------------------------------
+
+_gh_audit_builtin_workflows_is_forbidden() {
+    local _name="$1" _line
+    [ -z "$_name" ] && return 1
+    while IFS= read -r _line; do
+        [ "$_line" = "$_name" ] && return 0
+    done <<EOF
+$(_gh_audit_builtin_workflows_forbidden)
+EOF
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main entry point.
+# ---------------------------------------------------------------------------
+
+gh_audit_builtin_workflows() {
+    local _repo_flag=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        -h | --help | help)
+            gh_audit_builtin_workflows_help
+            return 0
+            ;;
+        --repo)
+            if [ -z "${2-}" ]; then
+                printf '[gh-audit-builtin-workflows] --repo requires an argument\n' >&2
+                return 2
+            fi
+            _repo_flag="$2"
+            shift 2
+            ;;
+        *)
+            printf '[gh-audit-builtin-workflows] unknown option: %s\n' "$1" >&2
+            return 2
+            ;;
+        esac
+    done
+
+    local _resolved _owner _repo
+    if ! _resolved=$(_gh_audit_builtin_workflows_resolve_repo "$_repo_flag"); then
+        printf '[gh-audit-builtin-workflows] could not resolve repo (pass --repo or set GH_REPO)\n' >&2
+        return 2
+    fi
+    _owner="${_resolved%% *}"
+    _repo="${_resolved#* }"
+
+    # GraphQL: list every projectV2 attached to the repo and each project's
+    # builtin workflows. The `workflows` connection is publicly queryable,
+    # but `enabled` requires write access on the project. When the caller
+    # lacks access, GitHub returns a partial result with `null` workflows —
+    # that's why we filter `.workflows?.nodes? // []` rather than failing.
+    #
+    # Output shape: one record per workflow, joined by `|`:
+    #   project_url | project_title | workflow_name | enabled (true|false)
+    #
+    # GraphQL variables ($owner, $repo) are bound via -f below — single-quoted
+    # query string is intentional (would otherwise interpolate at shell level).
+    # shellcheck disable=SC2016
+    local _records
+    _records=$(gh api graphql \
+        -f query='
+          query($owner: String!, $repo: String!) {
+            repository(owner: $owner, name: $repo) {
+              projectsV2(first: 20) {
+                nodes {
+                  number
+                  title
+                  url
+                  workflows(first: 50) {
+                    nodes { name enabled number }
+                  }
+                }
+              }
+            }
+          }' \
+        -f owner="$_owner" -f repo="$_repo" \
+        --jq '.data.repository.projectsV2.nodes[]?
+              | . as $p
+              | (.workflows?.nodes? // [])[]?
+              | "\($p.url)|\($p.title)|\(.name)|\(.enabled)"' \
+        2>/dev/null) || {
+        printf '[gh-audit-builtin-workflows] graphql query failed for %s/%s\n' \
+            "$_owner" "$_repo" >&2
+        return 2
+    }
+
+    if [ -z "$_records" ]; then
+        if type ux_success >/dev/null 2>&1; then
+            ux_success "no projectV2 attached to ${_owner}/${_repo} (or no workflow access) — nothing to audit"
+        else
+            printf '[gh-audit-builtin-workflows] %s/%s: no projectV2 attached (or no workflow access) — nothing to audit\n' \
+                "$_owner" "$_repo"
+        fi
+        return 0
+    fi
+
+    # Iterate without subshell — heredoc not pipe (zsh/bash tracing parity,
+    # pre-commit hook enforces this in this repo).
+    local _violations=0
+    local _url _title _name _enabled
+    while IFS='|' read -r _url _title _name _enabled; do
+        [ -z "$_name" ] && continue
+        if _gh_audit_builtin_workflows_is_forbidden "$_name" &&
+            [ "$_enabled" = "true" ]; then
+            _violations=$((_violations + 1))
+            if type ux_error >/dev/null 2>&1; then
+                ux_error "✗ ${_title}: \"${_name}\" is ENABLED"
+                ux_bullet "  Settings → Workflows: ${_url}/workflows"
+            else
+                printf '✗ %s: "%s" is ENABLED\n' "$_title" "$_name"
+                printf '  Settings → Workflows: %s/workflows\n' "$_url"
+            fi
+        fi
+    done <<EOF
+$_records
+EOF
+
+    if [ "$_violations" -eq 0 ]; then
+        if type ux_success >/dev/null 2>&1; then
+            ux_success "✅ ${_owner}/${_repo}: all attached projectV2 boards policy-compliant"
+        else
+            printf '✅ %s/%s: all attached projectV2 boards policy-compliant\n' \
+                "$_owner" "$_repo"
+        fi
+        return 0
+    fi
+
+    printf '\n' >&2
+    printf '[gh-audit-builtin-workflows] %d violation(s) — disable the workflow(s) above and re-run.\n' \
+        "$_violations" >&2
+    return 2
+}
+
+# ---------------------------------------------------------------------------
+# Aliases (hyphenated command names per shell-common convention)
+# ---------------------------------------------------------------------------
+
+alias gh-audit-builtin-workflows='gh_audit_builtin_workflows'
+alias gh-audit-builtin-workflows-help='gh_audit_builtin_workflows_help'

--- a/tests/bats/functions/gh_audit_builtin_workflows.bats
+++ b/tests/bats/functions/gh_audit_builtin_workflows.bats
@@ -139,9 +139,12 @@ teardown() {
 _setup_fake_gh_audit() {
     STUB_BIN="$TEST_TEMP_HOME/bin"
     mkdir -p "$STUB_BIN"
+    # Tab-separated output mirrors the real --jq filter (PR #402 review:
+    # tab is safer than `|` for project titles containing that character).
     cat >"$STUB_BIN/gh" <<'GH'
 #!/usr/bin/env bash
 # Multiplexed: only `repo view --json nameWithOwner` and `api graphql` shapes.
+T=$'\t'
 case "$1 $2" in
     "repo view")
         echo "owner/reponame"
@@ -150,22 +153,16 @@ case "$1 $2" in
     "api graphql")
         case "${FAKE_AUDIT_MODE:-no-projects}" in
             compliant)
-                cat <<'OUT'
-https://github.com/orgs/owner/projects/1|Team Board|Pull request linked to issue|false
-https://github.com/orgs/owner/projects/1|Team Board|Item closed|true
-OUT
+                printf 'https://github.com/orgs/owner/projects/1%sTeam Board%sPull request linked to issue%sfalse\n' "$T" "$T" "$T"
+                printf 'https://github.com/orgs/owner/projects/1%sTeam Board%sItem closed%strue\n' "$T" "$T" "$T"
                 ;;
             violation)
-                cat <<'OUT'
-https://github.com/orgs/owner/projects/1|Team Board|Pull request linked to issue|true
-https://github.com/orgs/owner/projects/1|Team Board|Item closed|true
-OUT
+                printf 'https://github.com/orgs/owner/projects/1%sTeam Board%sPull request linked to issue%strue\n' "$T" "$T" "$T"
+                printf 'https://github.com/orgs/owner/projects/1%sTeam Board%sItem closed%strue\n' "$T" "$T" "$T"
                 ;;
             mixed)
-                cat <<'OUT'
-https://github.com/orgs/owner/projects/1|Team Board|Pull request linked to issue|false
-https://github.com/orgs/owner/projects/2|Side Board|Pull request linked to issue|true
-OUT
+                printf 'https://github.com/orgs/owner/projects/1%sTeam Board%sPull request linked to issue%sfalse\n' "$T" "$T" "$T"
+                printf 'https://github.com/orgs/owner/projects/2%sSide Board%sPull request linked to issue%strue\n' "$T" "$T" "$T"
                 ;;
             no-projects)
                 # repo has no projectV2 OR caller lacks workflow read perm.

--- a/tests/bats/functions/gh_audit_builtin_workflows.bats
+++ b/tests/bats/functions/gh_audit_builtin_workflows.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_audit_builtin_workflows.bats
+# Unit tests for gh_audit_builtin_workflows. The live GraphQL path needs
+# a real projectV2 with workflows visible to the caller, which is
+# impractical to fixture. We exercise loading, help/usage, arg
+# validation, the forbidden-list membership helper, and four end-to-end
+# audit scenarios via a fake `gh` shim that returns synthetic
+# repository.projectsV2.nodes[].workflows.nodes[] payloads.
+#
+# Coverage matches the issue #397 acceptance criteria:
+#   1. policy match (✅, exit 0)
+#   2. policy violation — "Pull request linked to issue" ON (✗, exit 2)
+#   3. multiple boards, mixed state (one violation surfaces)
+#   4. repo without any projectV2 (silent skip, exit 0)
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+@test "bash: gh_audit_builtin_workflows function exists" {
+    run_in_bash 'declare -f gh_audit_builtin_workflows >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: gh-audit-builtin-workflows alias resolves to gh_audit_builtin_workflows" {
+    run_in_bash "alias gh-audit-builtin-workflows 2>/dev/null | grep -q gh_audit_builtin_workflows && echo ok"
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: gh_audit_builtin_workflows function exists" {
+    run_in_zsh 'typeset -f gh_audit_builtin_workflows >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_audit_builtin_workflows_is_forbidden helper exists" {
+    run_in_bash 'declare -f _gh_audit_builtin_workflows_is_forbidden >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Help surface
+# ---------------------------------------------------------------------------
+
+@test "help: --help prints usage" {
+    run_in_bash 'gh_audit_builtin_workflows --help'
+    assert_success
+    assert_output --partial "Usage"
+    assert_output --partial "gh-audit-builtin-workflows"
+}
+
+@test "help: -h prints usage" {
+    run_in_bash 'gh_audit_builtin_workflows -h'
+    assert_success
+    assert_output --partial "Usage"
+}
+
+@test "help: text mentions Pull request linked to issue policy" {
+    run_in_bash 'gh_audit_builtin_workflows --help'
+    assert_success
+    assert_output --partial "Pull request linked to issue"
+    assert_output --partial "DISABLED"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+@test "validation: unknown option exits 2" {
+    run_in_bash 'gh_audit_builtin_workflows --bogus 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial "unknown option: --bogus"
+}
+
+@test "validation: --repo without value exits 2" {
+    run_in_bash 'gh_audit_builtin_workflows --repo 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial "--repo requires an argument"
+}
+
+@test "validation: --repo with malformed spec exits 2" {
+    # No-slash spec is malformed — resolver returns 1, function exits 2.
+    run_in_bash 'gh_audit_builtin_workflows --repo no-slash 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial "could not resolve repo"
+}
+
+# ---------------------------------------------------------------------------
+# Forbidden-list membership semantics
+# ---------------------------------------------------------------------------
+
+@test "forbidden: 'Pull request linked to issue' matches" {
+    run_in_bash '_gh_audit_builtin_workflows_is_forbidden "Pull request linked to issue" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "MATCH"
+}
+
+@test "forbidden: unrelated workflow name does not match" {
+    run_in_bash '_gh_audit_builtin_workflows_is_forbidden "Item closed" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "NO"
+}
+
+@test "forbidden: empty value never matches" {
+    run_in_bash '_gh_audit_builtin_workflows_is_forbidden "" && echo MATCH || echo NO'
+    assert_success
+    assert_output --partial "NO"
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end audit via fake `gh`
+#
+# The shim emits the same line shape the real --jq filter produces:
+#   project_url|project_title|workflow_name|enabled
+#
+# Mode is selected by FAKE_AUDIT_MODE:
+#   compliant     → one project, "Pull request linked to issue" disabled
+#   violation     → one project, "Pull request linked to issue" enabled
+#   mixed         → two projects; first compliant, second violates
+#   no-projects   → empty stdout (no projectV2 attached or no access)
+# ---------------------------------------------------------------------------
+
+_setup_fake_gh_audit() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    mkdir -p "$STUB_BIN"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Multiplexed: only `repo view --json nameWithOwner` and `api graphql` shapes.
+case "$1 $2" in
+    "repo view")
+        echo "owner/reponame"
+        exit 0
+        ;;
+    "api graphql")
+        case "${FAKE_AUDIT_MODE:-no-projects}" in
+            compliant)
+                cat <<'OUT'
+https://github.com/orgs/owner/projects/1|Team Board|Pull request linked to issue|false
+https://github.com/orgs/owner/projects/1|Team Board|Item closed|true
+OUT
+                ;;
+            violation)
+                cat <<'OUT'
+https://github.com/orgs/owner/projects/1|Team Board|Pull request linked to issue|true
+https://github.com/orgs/owner/projects/1|Team Board|Item closed|true
+OUT
+                ;;
+            mixed)
+                cat <<'OUT'
+https://github.com/orgs/owner/projects/1|Team Board|Pull request linked to issue|false
+https://github.com/orgs/owner/projects/2|Side Board|Pull request linked to issue|true
+OUT
+                ;;
+            no-projects)
+                # repo has no projectV2 OR caller lacks workflow read perm.
+                exit 0
+                ;;
+        esac
+        exit 0
+        ;;
+esac
+exit 0
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run the audit in bash with the fake gh on PATH. Mirrors the pattern in
+# gh_project_status.bats so isolation/env wiring stays consistent.
+_run_audit_bash() {
+    local mode="$1" args="$2"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_AUDIT_MODE='${mode}'
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        gh_audit_builtin_workflows ${args} 2>&1
+        echo \"rc=\$?\"
+    "
+}
+
+@test "audit: compliant project — exit 0 with success marker" {
+    _setup_fake_gh_audit
+    _run_audit_bash compliant ''
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "policy-compliant"
+    refute_output --partial "ENABLED"
+}
+
+@test "audit: violation — exit 2 with violation marker and settings URL" {
+    _setup_fake_gh_audit
+    _run_audit_bash violation ''
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial "Pull request linked to issue"
+    assert_output --partial "ENABLED"
+    assert_output --partial "Settings"
+    assert_output --partial "/workflows"
+}
+
+@test "audit: mixed boards — surfaces the violating board only" {
+    _setup_fake_gh_audit
+    _run_audit_bash mixed ''
+    assert_success
+    assert_output --partial "rc=2"
+    assert_output --partial "Side Board"
+    refute_output --partial "Team Board: \"Pull request linked to issue\" is ENABLED"
+}
+
+@test "audit: no projects attached — exit 0 with skip notice" {
+    _setup_fake_gh_audit
+    _run_audit_bash no-projects ''
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "no projectV2 attached"
+}

--- a/tests/bats/skills/_fixtures/gh_pr_merge_board_gate.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_board_gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_merge_board_gate.sh
+# Source-of-truth mirror for the Step 4-B board approval gate snippet
+# documented in claude/skills/gh-pr-merge/SKILL.md.
+#
+# The skill itself runs inside a Claude session, but the gating logic is
+# a small bash block that can be tested in isolation: given the values
+# of GH_PR_MERGE_SKIP_BOARD_CHECK and the current board Status, does the
+# gate accept (rc=0), reject (rc=2), or skip (rc=0) the merge?
+#
+# Keep this file in sync with SKILL.md Step 4-B. If the skill block
+# changes, mirror the change here so the bats suite catches drift.
+
+# Stand-in for _gh_project_status_query_current. The real helper lives in
+# shell-common/functions/gh_project_status.sh; tests inject mock values
+# via FAKE_BOARD_STATUS so we don't need a live projectV2.
+_gh_project_status_query_current() {
+    printf '%s' "${FAKE_BOARD_STATUS-}"
+}
+
+# Mirrors SKILL.md Step 4-B verbatim. Any change here must propagate to
+# the SKILL.md block, and vice versa. Returns:
+#   0 — proceed with merge (Approved, empty/no-board, or escape on)
+#   2 — refuse merge (board Status set to anything other than Approved)
+gh_pr_merge_board_gate() {
+    local _pr="$1" _repo="$2"
+
+    if [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" = "1" ]; then
+        return 0
+    fi
+
+    local _status
+    _status=$(GH_REPO="$_repo" \
+        _gh_project_status_query_current pr "$_pr" 2>/dev/null)
+
+    # Empty result = no projectV2 attached OR no read access. Auto-skip.
+    if [ -z "$_status" ]; then
+        return 0
+    fi
+
+    if [ "$_status" != "Approved" ]; then
+        printf 'Refusing to merge PR #%s — board Status is "%s", required "Approved".\n' \
+            "$_pr" "$_status"
+        printf '  Have a teammate move the card to Approved, or use /gh-pr-merge-emergency for admin bypass.\n'
+        printf '  One-shot escape: GH_PR_MERGE_SKIP_BOARD_CHECK=1 /gh-pr-merge %s\n' "$_pr"
+        return 2
+    fi
+
+    return 0
+}

--- a/tests/bats/skills/gh_pr_merge_board_gate.bats
+++ b/tests/bats/skills/gh_pr_merge_board_gate.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_merge_board_gate.bats
+# Verify the Step 4-B board approval gate documented in
+#   claude/skills/gh-pr-merge/SKILL.md
+# Source-of-truth fixture: _fixtures/gh_pr_merge_board_gate.sh.
+#
+# Five cases drawn from issue #397's acceptance criteria:
+#   1. board Status == "Approved"        → rc=0 (proceed)
+#   2. board Status == "In review"       → rc=2 (refuse + redirect)
+#   3. board Status empty (no board)     → rc=0 (silent skip)
+#   4. GH_PR_MERGE_SKIP_BOARD_CHECK=1    → rc=0 (escape, no read needed)
+#   5. board Status == "In progress"     → rc=2 (any non-Approved fails closed)
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_board_gate.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset FAKE_BOARD_STATUS GH_PR_MERGE_SKIP_BOARD_CHECK
+}
+
+@test "board-gate: Status=Approved → rc=0 (proceed silently)" {
+    FAKE_BOARD_STATUS="Approved"
+    run gh_pr_merge_board_gate 42 owner/repo
+    assert_success
+    refute_output --partial "Refusing"
+}
+
+@test "board-gate: Status=In review → rc=2 with redirect message" {
+    FAKE_BOARD_STATUS="In review"
+    run gh_pr_merge_board_gate 42 owner/repo
+    [ "$status" -eq 2 ]
+    assert_output --partial 'Refusing to merge PR #42'
+    assert_output --partial 'board Status is "In review"'
+    assert_output --partial '/gh-pr-merge-emergency'
+    assert_output --partial 'GH_PR_MERGE_SKIP_BOARD_CHECK=1'
+}
+
+@test "board-gate: empty Status (no projectV2 attached) → rc=0 silently skips" {
+    FAKE_BOARD_STATUS=""
+    run gh_pr_merge_board_gate 42 owner/repo
+    assert_success
+    refute_output --partial "Refusing"
+}
+
+@test "board-gate: GH_PR_MERGE_SKIP_BOARD_CHECK=1 bypasses gate" {
+    # Even with a clearly-violating status, the env-var escape lets the
+    # operator merge — this matches the documented in-transition workflow.
+    FAKE_BOARD_STATUS="In review"
+    GH_PR_MERGE_SKIP_BOARD_CHECK=1 run gh_pr_merge_board_gate 42 owner/repo
+    assert_success
+    refute_output --partial "Refusing"
+}
+
+@test "board-gate: Status=In progress (any non-Approved) → rc=2" {
+    # Verifies the gate is fail-closed, not whitelisted to specific values.
+    # In progress, Backlog, Done, and any custom column all fail closed.
+    FAKE_BOARD_STATUS="In progress"
+    run gh_pr_merge_board_gate 42 owner/repo
+    [ "$status" -eq 2 ]
+    assert_output --partial 'board Status is "In progress"'
+}


### PR DESCRIPTION
## Summary
- New `gh_audit_builtin_workflows` shell-common function audits projectV2 boards for the forbidden "Pull request linked to issue" builtin workflow (race source from #393).
- `gh:pr-merge` SKILL.md gains Step 2-B: fail-closed gate refusing to merge unless board Status is `Approved`. Reuses the `_gh_project_status_query_current` helper from #393 so all skills agree on the canonical Status.
- Two new reference docs cross-link the policy SSOT (`gh-pr-approve/references/board-policy.md` is canonical; `gh-pr-merge` carries a thin pointer).

## Changes
- `shell-common/functions/gh_audit_builtin_workflows.sh` — new function: lists every projectV2 attached to the repo via GraphQL, flags any forbidden builtin workflow that is `enabled`, prints the project's `…/workflows` settings URL. Exit 0 + ✅ when compliant, exit 2 + ✗ when a violation is found, silent skip when the repo has no projectV2 attached or the caller lacks workflow read permission. Honors `--repo` flag and `GH_REPO` env var.
- `claude/skills/gh-pr-merge/SKILL.md` — Step 2-B inserted before Step 3 (Merge). Reuses `_gh_project_status_query_current`, fails closed on non-Approved Status, auto-skips on empty Status (no-board repos), supports `GH_PR_MERGE_SKIP_BOARD_CHECK=1` operator escape for in-transition repos.
- `claude/skills/gh-pr-approve/references/board-policy.md` — new SSOT for the `Approved` column gate: rule, why fail-closed, two enforcement points (write-side guard from #393 + read-side merge gate from this PR), out-of-scope cases, audit pointer.
- `claude/skills/gh-pr-merge/references/board-policy.md` — new thin cross-link to the SSOT, with TL;DR for `gh:pr-merge` callers.
- `tests/bats/functions/gh_audit_builtin_workflows.bats` — 17 new cases covering loading (bash + zsh), help/usage, arg validation, forbidden-list membership, and 4 end-to-end audit scenarios via fake `gh` (compliant, violation, mixed boards, no projects).
- `tests/bats/skills/_fixtures/gh_pr_merge_board_gate.sh` + `tests/bats/skills/gh_pr_merge_board_gate.bats` — fixture mirroring the SKILL.md Step 2-B snippet plus 5 cases (Approved pass, In-review reject with redirect, empty skip, env-var bypass, any-non-Approved fail-closed).

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_audit_builtin_workflows.bats` — 17/17 pass.
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_merge_board_gate.bats` — 5/5 pass.
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_project_status.bats` — 48/48 still pass (no regressions in the helper this PR depends on).
- [x] `tests/test` (pytest) — 1009/1009 pass.
- [x] `shellcheck` clean on the new function (`-s bash -e SC1090,SC1091,SC2016`).
- [x] `bash -n` and `zsh -n` syntax check on the new function.
- [ ] Manual check on a repo with no projectV2 attached: `gh-audit-builtin-workflows` exits 0 with the "no projectV2 attached" notice.
- [ ] Manual check that `gh:pr-merge` Step 2-B refuses a PR whose board column is `In review` and the redirect message lists `/gh-pr-merge-emergency`.

## Related
Closes #397
Refs #393


---
<details>
<summary>🤖 AI Metrics · 📊 ~8500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~8500 tokens · 👤 ~8 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
