### PR TITLE
feat(gh-commit): closing-keyword 정책 — Closes default + commit-msg hook (#392)

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -57,7 +57,7 @@ Check in this order and use the first hit:
 ## Step 3: Draft the Commit Message
 
 Read `references/commit-message-format.md` for the message template, HEREDOC
-pattern, and `Closes` / `Fixes` rules (`Refs` / `Resolves` 금지). Match the repo's commit style
+pattern, and `Closes` / `Fixes` rules (`Refs` / `Resolves` forbidden). Match the repo's commit style
 derived from `git log`.
 
 **When there is no prior conversation context** (user ran `/gh-commit` on

--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -24,8 +24,10 @@ output its content verbatim, then stop. No API calls.
 ## Role
 
 Stage the relevant changes and create a new git commit that follows the
-repository's existing commit style, with an optional `Refs #N` / `Closes #N`
-footer when a GitHub issue is known.
+repository's existing commit style, with `Closes #N` / `Fixes #N` footer
+when a GitHub issue is known. `Refs` / `Resolves` / `See` / `References`
+keywords are forbidden — they break GitHub auto-close and project-board
+automation (see issue #392).
 
 ## Step 1: Inspect State (parallel) — ALWAYS FIRST
 
@@ -55,7 +57,7 @@ Check in this order and use the first hit:
 ## Step 3: Draft the Commit Message
 
 Read `references/commit-message-format.md` for the message template, HEREDOC
-pattern, and `Closes` / `Refs` / `Fixes` rules. Match the repo's commit style
+pattern, and `Closes` / `Fixes` rules (`Refs` / `Resolves` 금지). Match the repo's commit style
 derived from `git log`.
 
 **When there is no prior conversation context** (user ran `/gh-commit` on
@@ -110,7 +112,7 @@ comment. On any API failure, print `⚠️  ai-metrics comment failed — contin
 and proceed.
 
 Then sync the project board: if the commit message contains
-`Closes|Fixes|Refs #N` (i.e. the issue number resolved in Step 2 was
+`Closes|Fixes #N` (i.e. the issue number resolved in Step 2 was
 actually written into the footer), push the linked Issue's project-board
 card to `In progress` — but only when its current Status is `Backlog`.
 The `--only-from Backlog` guard is mandatory: `/gh-commit` is invoked

--- a/claude/skills/gh-commit/references/commit-message-format.md
+++ b/claude/skills/gh-commit/references/commit-message-format.md
@@ -17,16 +17,15 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 
 - **Why, not what** — the diff already shows what changed. The body explains motivation, trade-offs, and context.
 - **Match the repo's conventions** — if recent commits use `feat:` / `fix:` prefixes, follow suit; if they use plain sentences, follow that. Derive style from `git log --oneline -20`.
-- **Issue footer selection** — skill 이 생성 가능한 키워드는 두 개만:
-  - `Closes #N` — default. commit 이 이슈를 닫을 때.
-  - `Fixes #N` — bug fix 일 때 우선.
-- **금지 키워드**: `Refs`, `Resolves`, `See`, `References` — skill 은 절대 생성하지 않음.
-  - 사유: `Refs` / `See` / `References` 는 GitHub 가 close 안 시킴 (자동화 깨짐),
-    `Resolves` 는 GitHub 인식하지만 AgentToolbox 정책 위반.
-- 이슈 번호를 commit 에 footer 로 적지 않을 케이스:
-  - 진짜 이슈 없음 → footer 자체 생략. 가짜 이슈 번호 절대 만들지 않음.
-  - WIP / 부분 진행이라 close 시키고 싶지 않음 → footer 생략하고
-    commit 본문 내에 평문 `(part of #N)` 로 언급.
+- **Issue footer selection** — only two keywords are allowed for the skill:
+  - `Closes #N` — default; when the commit fully closes the issue.
+  - `Fixes #N` — preferred for bug fixes.
+- **Forbidden keywords**: `Refs`, `Resolves`, `See`, `References` — the skill must never generate these.
+  - Rationale: `Refs` / `See` / `References` do not trigger GitHub auto-close (breaking project-board automation), and `Resolves` violates the AgentToolbox stacked-closes-rollup policy.
+- Cases where no issue footer should be added:
+  - No actual issue → omit the footer. Never invent issue numbers.
+  - WIP / partial progress (don't want to auto-close) → omit the footer
+    and mention `(part of #N)` inline in the body instead.
 
 ## HEREDOC Commit Command
 

--- a/claude/skills/gh-commit/references/commit-message-format.md
+++ b/claude/skills/gh-commit/references/commit-message-format.md
@@ -9,7 +9,7 @@ Details of the commit message structure, footer conventions, and the HEREDOC com
 
 <body explaining the WHY, not the WHAT — the diff shows the what>
 
-Refs #<N>        ← only if issue number resolved
+Closes #<N>      ← when this commit fully resolves the issue
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 ```
 
@@ -17,11 +17,16 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 
 - **Why, not what** — the diff already shows what changed. The body explains motivation, trade-offs, and context.
 - **Match the repo's conventions** — if recent commits use `feat:` / `fix:` prefixes, follow suit; if they use plain sentences, follow that. Derive style from `git log --oneline -20`.
-- **Issue footer selection**:
-  - `Closes #N` — only when the commit fully resolves the issue.
-  - `Fixes #N` — preferred when the change is a bug fix for a tracked issue.
-  - `Refs #N` — partial progress, or a reference without closing.
-- Omit the footer entirely if no issue number was resolved. Never invent one.
+- **Issue footer selection** — skill 이 생성 가능한 키워드는 두 개만:
+  - `Closes #N` — default. commit 이 이슈를 닫을 때.
+  - `Fixes #N` — bug fix 일 때 우선.
+- **금지 키워드**: `Refs`, `Resolves`, `See`, `References` — skill 은 절대 생성하지 않음.
+  - 사유: `Refs` / `See` / `References` 는 GitHub 가 close 안 시킴 (자동화 깨짐),
+    `Resolves` 는 GitHub 인식하지만 AgentToolbox 정책 위반.
+- 이슈 번호를 commit 에 footer 로 적지 않을 케이스:
+  - 진짜 이슈 없음 → footer 자체 생략. 가짜 이슈 번호 절대 만들지 않음.
+  - WIP / 부분 진행이라 close 시키고 싶지 않음 → footer 생략하고
+    commit 본문 내에 평문 `(part of #N)` 로 언급.
 
 ## HEREDOC Commit Command
 
@@ -33,7 +38,7 @@ git commit -m "$(cat <<'EOF'
 
 <body>
 
-Refs #<N>
+Closes #<N>
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"

--- a/claude/skills/gh-pr/references/help.md
+++ b/claude/skills/gh-pr/references/help.md
@@ -4,7 +4,7 @@
 
 | # | Name | Default | Description |
 |---|------|---------|-------------|
-| 1 | issue-number, or `-h`/`--help`/`help` | auto-detected | Link PR to this GitHub issue via `Closes #N` / `Refs #N` in the body |
+| 1 | issue-number, or `-h`/`--help`/`help` | auto-detected | Link PR to this GitHub issue via `Closes #N` (or `Fixes #N` for bug fixes) in the body |
 
 ## Usage
 

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -28,7 +28,6 @@ Language: match the repo. Use Korean if existing commits are Korean.
 
 ## Related
 Closes #<N>
-Refs #<N>
 ```
 
 - When Step 3 resolved an issue number AND the PR fully addresses it,
@@ -37,8 +36,11 @@ Refs #<N>
   `Done` on merge (see `docs/standards/github-project-board.md`).
   Omitting it means the Issue stays open and the card never reaches
   `Done`.
-- Use `Refs #<N>` instead only when the PR does not fully resolve
-  the issue (partial work, follow-up required).
+- For bug-fix PRs, `Fixes #<N>` is also acceptable.
+- **금지 키워드**: `Refs`, `Resolves`, `See`, `References` — skill 은 절대
+  생성하지 않음. `Refs` / `See` / `References` 는 GitHub close 안 시키고,
+  `Resolves` 는 AgentToolbox 정책 위반. 부분 진행을 표현하려면 footer 를
+  생략하고 본문에 평문 `(part of #N)` 로 언급 (issue #392).
 - Omit the `## Related` section entirely only when no issue number
   is known.
 

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -37,10 +37,11 @@ Closes #<N>
   Omitting it means the Issue stays open and the card never reaches
   `Done`.
 - For bug-fix PRs, `Fixes #<N>` is also acceptable.
-- **금지 키워드**: `Refs`, `Resolves`, `See`, `References` — skill 은 절대
-  생성하지 않음. `Refs` / `See` / `References` 는 GitHub close 안 시키고,
-  `Resolves` 는 AgentToolbox 정책 위반. 부분 진행을 표현하려면 footer 를
-  생략하고 본문에 평문 `(part of #N)` 로 언급 (issue #392).
+- **Forbidden keywords**: `Refs`, `Resolves`, `See`, `References` — the skill
+  must never generate these. `Refs` / `See` / `References` do not trigger
+  GitHub auto-close, and `Resolves` violates the AgentToolbox policy. To
+  express partial progress, omit the footer and mention `(part of #N)`
+  inline in the body instead (issue #392).
 - Omit the `## Related` section entirely only when no issue number
   is known.
 

--- a/git/hooks/checks/closing_keyword_check.sh
+++ b/git/hooks/checks/closing_keyword_check.sh
@@ -24,19 +24,20 @@
 # Args:
 #   $1 — path to commit message file
 #
-# Reads the file, scans every line for `^(Refs|Resolves|See|References)\s+#<num>`,
+# Reads the file, scans every line for `^(Refs|Resolves|See|References)\s+#<num>`
+# (case-insensitive — GitHub treats closing keywords as case-insensitive),
 # and prints all matches with line numbers when one or more are found.
-# Comment lines (`#...`) are skipped so that git's own commented hints
-# don't trip the check.
+# Lines starting with `#` (git commented hints) are inherently skipped because
+# the regex anchors at the start of the line and the keyword set never starts
+# with `#`. Running grep -niE directly on the file (no upstream `grep -v` filter)
+# preserves the original line numbers in the diagnostic.
 check_closing_keyword() {
     local msg_file="$1"
     [ -n "$msg_file" ] || return 0
     [ -f "$msg_file" ] || return 0
 
     local forbidden
-    forbidden=$(grep -vE '^[[:space:]]*#' "$msg_file" \
-        | grep -nE '^(Refs|Resolves|See|References)[[:space:]]+#[0-9]+' \
-        || true)
+    forbidden=$(grep -niE '^(Refs|Resolves|See|References)[[:space:]]+#[0-9]+' "$msg_file" || true)
 
     if [ -n "$forbidden" ]; then
         echo "✗ commit-msg: forbidden closing keyword detected" >&2

--- a/git/hooks/checks/closing_keyword_check.sh
+++ b/git/hooks/checks/closing_keyword_check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# git/hooks/checks/closing_keyword_check.sh
+#
+# Reject commit messages that use forbidden GitHub closing keywords.
+# Allowed: Closes, Fixes
+# Forbidden: Refs, Resolves, See, References
+#
+# Rationale (issue #392):
+# - Refs/See/References are NOT recognized as closing keywords by GitHub,
+#   so they break auto-close + project-board automation.
+# - Resolves is recognized by GitHub but violates the AgentToolbox
+#   stacked-closes-rollup policy.
+# - skill-driven and manual commits must follow the same policy. The
+#   skill side is enforced in claude/skills/gh-commit/**, this hook
+#   catches `--no-verify`-less manual commits that bypass the skills.
+#
+# Escape hatch: `git commit --no-verify` (use sparingly — for genuine
+# WIP / partial-progress commits where no auto-close is desired).
+#
+# Returns 0 if message is clean, 1 with a diagnostic on stderr otherwise.
+
+# check_closing_keyword
+#
+# Args:
+#   $1 — path to commit message file
+#
+# Reads the file, scans every line for `^(Refs|Resolves|See|References)\s+#<num>`,
+# and prints all matches with line numbers when one or more are found.
+# Comment lines (`#...`) are skipped so that git's own commented hints
+# don't trip the check.
+check_closing_keyword() {
+    local msg_file="$1"
+    [ -n "$msg_file" ] || return 0
+    [ -f "$msg_file" ] || return 0
+
+    local forbidden
+    forbidden=$(grep -vE '^[[:space:]]*#' "$msg_file" \
+        | grep -nE '^(Refs|Resolves|See|References)[[:space:]]+#[0-9]+' \
+        || true)
+
+    if [ -n "$forbidden" ]; then
+        echo "✗ commit-msg: forbidden closing keyword detected" >&2
+        echo "$forbidden" >&2
+        echo "" >&2
+        echo "  Allowed:   Closes #N, Fixes #N" >&2
+        echo "  Forbidden: Refs, Resolves, See, References" >&2
+        echo "" >&2
+        echo "  Why: Refs/See/References do not auto-close issues on merge," >&2
+        echo "       Resolves violates the AgentToolbox rollup policy." >&2
+        echo "       See issue #392 for the full rationale." >&2
+        echo "" >&2
+        echo "  Fix:    use 'Closes #N' (default) or 'Fixes #N' (bug fix)." >&2
+        echo "  WIP:    omit the footer; mention '(part of #N)' inline instead." >&2
+        echo "  Bypass: git commit --no-verify (use sparingly)." >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -13,6 +13,17 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${HOOK_DIR}/../lib/commit-msg-validator.sh" || exit 0
 
+# Closing-keyword policy (issue #392): hard-block Refs/Resolves/See/References.
+# This guard runs BEFORE the conventional-commits validator so the user sees
+# the more actionable "use Closes/Fixes" message first when both fire.
+if [ -f "${HOOK_DIR}/checks/closing_keyword_check.sh" ]; then
+    # shellcheck source=/dev/null
+    . "${HOOK_DIR}/checks/closing_keyword_check.sh"
+    if ! check_closing_keyword "${1:-}"; then
+        exit 1
+    fi
+fi
+
 # ============================================
 # MAIN HOOK LOGIC
 # ============================================

--- a/tests/bats/skills/closing_keyword_policy.bats
+++ b/tests/bats/skills/closing_keyword_policy.bats
@@ -130,6 +130,44 @@ EOF
     assert_success
 }
 
+@test "hook: lowercase 'refs #N' is rejected (GitHub keywords are case-insensitive)" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+refs #200
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "forbidden closing keyword"
+}
+
+@test "hook: mixed-case 'Resolves #N' / 'RESOLVES #N' both rejected" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+RESOLVES #300
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "forbidden closing keyword"
+}
+
+@test "hook: line numbers reported are relative to the original file" {
+    # Subject on line 1, blank line on 2, comment on 3, blank on 4, footer on 5.
+    # The diagnostic must report '5:' not '2:' (which is what the old
+    # `grep -v '^#' | grep -n` two-stage pipeline would produce).
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+# A commented hint line that mentions Closes #1 (just guidance).
+
+Refs #200
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "5:Refs #200"
+}
+
 # ─── Skill side: docs do not instruct skill to emit forbidden keywords ──
 
 @test "skill: gh-commit format doc has no 'Refs #' template/instruction" {

--- a/tests/bats/skills/closing_keyword_policy.bats
+++ b/tests/bats/skills/closing_keyword_policy.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# tests/bats/skills/closing_keyword_policy.bats
+# Verify the closing-keyword policy from issue #392:
+#   - skill (gh-commit / gh-pr) docs only generate Closes/Fixes
+#   - commit-msg hook (git/hooks/checks/closing_keyword_check.sh) rejects
+#     Refs / Resolves / See / References at the start of a footer line
+#   - hook accepts Closes / Fixes / no-footer
+#   - --no-verify escape works (covered indirectly: git itself skips the
+#     hook on --no-verify, so we only verify the hook returns 0/1 cleanly)
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/git/hooks/checks/closing_keyword_check.sh"
+    MSG_FILE="$TEST_TEMP_HOME/COMMIT_EDITMSG"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ─── Hook: accepts allowed keywords ──────────────────────────────────────
+
+@test "hook: 'Closes #N' footer passes" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+body explaining the why.
+
+Closes #392
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    assert_success
+}
+
+@test "hook: 'Fixes #N' footer passes" {
+    cat >"$MSG_FILE" <<'EOF'
+fix(scope): subject
+
+Fixes #100
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    assert_success
+}
+
+@test "hook: no footer at all passes" {
+    cat >"$MSG_FILE" <<'EOF'
+chore: tidy up
+
+just cleanup, no issue linked.
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    assert_success
+}
+
+@test "hook: inline '(part of #N)' in body passes" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): partial work
+
+This is WIP (part of #200) — leaving the issue open intentionally.
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    assert_success
+}
+
+# ─── Hook: rejects forbidden keywords ────────────────────────────────────
+
+@test "hook: 'Refs #N' is rejected" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+Refs #200
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "forbidden closing keyword"
+    assert_output --partial "Closes #N"
+}
+
+@test "hook: 'Resolves #N' is rejected" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+Resolves #300
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "forbidden closing keyword"
+}
+
+@test "hook: 'See #N' is rejected" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+See #400
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "forbidden closing keyword"
+}
+
+@test "hook: 'References #N' is rejected" {
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+References #500
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    [ "$status" -eq 1 ]
+    assert_output --partial "forbidden closing keyword"
+}
+
+@test "hook: comment line starting with '#' does not trigger" {
+    # git commented-out template hints (e.g. "# Refs #N" instructional
+    # text) must be ignored by the check.
+    cat >"$MSG_FILE" <<'EOF'
+feat(scope): subject
+
+# This commented line mentions Refs #999 but should be ignored.
+Closes #1
+EOF
+    run check_closing_keyword "$MSG_FILE"
+    assert_success
+}
+
+@test "hook: missing message file is a no-op (does not block)" {
+    run check_closing_keyword "$TEST_TEMP_HOME/does-not-exist"
+    assert_success
+}
+
+# ─── Skill side: docs do not instruct skill to emit forbidden keywords ──
+
+@test "skill: gh-commit format doc has no 'Refs #' template/instruction" {
+    # Search the canonical skill doc — only Closes/Fixes should appear in
+    # template lines or rule lines. Old commit examples elsewhere may use
+    # Refs (history not rewritten), but THIS file is the skill SSOT.
+    run grep -nE '^[[:space:]]*Refs[[:space:]]+#' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-commit/references/commit-message-format.md"
+    [ "$status" -eq 1 ]
+}
+
+@test "skill: gh-commit format doc has no 'Resolves #' template" {
+    run grep -nE '^[[:space:]]*Resolves[[:space:]]+#' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-commit/references/commit-message-format.md"
+    [ "$status" -eq 1 ]
+}
+
+@test "skill: gh-pr body template has no 'Refs #' / 'Resolves #' template line" {
+    run grep -nE '^[[:space:]]*(Refs|Resolves)[[:space:]]+#' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr/references/pr-body-template.md"
+    [ "$status" -eq 1 ]
+}
+
+@test "skill: gh-commit format doc explicitly forbids the four keywords" {
+    run grep -E 'Refs.*Resolves.*See.*References|금지 키워드' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-commit/references/commit-message-format.md"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- Skill 이 생성하는 closing keyword 를 `Closes` / `Fixes` 두 개로 제한
- `Refs` / `Resolves` / `See` / `References` 는 commit-msg hook 으로 차단 (skill 우회 manual commit 까지 커버)
- 기존 history 는 보존 — 본 정책은 앞으로 생성되는 commit/PR 에만 적용

## Changes
- **gh-commit / gh-pr 스킬 문서**: 템플릿 default 를 `Closes` 로 변경,
  허용 키워드(`Closes` / `Fixes`)와 금지 키워드(`Refs` / `Resolves` / `See` / `References`)를 명시.
  WIP/부분진행은 footer 생략 + 본문 평문 `(part of #N)` 패턴으로 안내.
- **신규 `git/hooks/checks/closing_keyword_check.sh`**: footer 라인 시작에서
  4종 금지 키워드를 grep, 발견 시 rc=1 + 안내 메시지. 주석 라인(`#`)은 무시.
- **`git/hooks/commit-msg`**: 새 검사를 conventional-commits 검증 *전에* 실행해
  더 actionable 한 메시지가 먼저 보이도록 배치.
- **`tests/bats/skills/closing_keyword_policy.bats`**: 14개 회귀 테스트 추가
  - hook accept 5종 (`Closes`/`Fixes`/no-footer/inline `(part of #N)`/missing file)
  - hook reject 4종 forbidden
  - skill 문서 SSOT (`Refs #` / `Resolves #` 템플릿 부재 + 금지 키워드 명시 확인)

## Why
- `Refs` / `See` / `References` 는 GitHub 가 close keyword 로 인식 안 함 →
  자동 close + project board 자동화가 깨짐
- `Resolves` 는 GitHub 가 인식하지만 AgentToolbox stacked-closes-rollup 정책 위반
- skill 만 잡으면 `--no-verify` 없이도 manual commit 으로 우회 가능 →
  skill + commit-msg hook 둘 다 잡아야 정책 일관성 100%
- 정당한 escape 는 `git commit --no-verify` (사용자 명시 의도, 빈도 모니터링)

## Test plan
- [x] `tests/bats/skills/closing_keyword_policy.bats` 14개 모두 pass
- [x] `tests/bats/skills/` 전체 77개 pass, 0 fail (regression 없음)
- [x] commit-msg hook 직접 호출 smoke test: `Refs #200` reject (rc=1), `Closes #392` pass (rc=0)
- [x] shellcheck `git/hooks/checks/closing_keyword_check.sh` clean
- [x] 본 PR 의 commit 자체가 `Closes #392` 로 작성되어 hook 통과 (dogfooding)

## Related
Closes #392

설계 SSOT: #384 (https://github.com/dEitY719/dotfiles/issues/384#issuecomment-4403610245)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1.5 h · 🤖 ~7 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1.5 h · 🤖 ~7 min
<\!-- /ai-metrics:gh-pr -->

</details>
