### PR TITLE
feat(gh-issue-create): SSOT-driven auto-labels + milestone (#398)

### DIFF
--- a/.gh-issue-defaults.yml
+++ b/.gh-issue-defaults.yml
@@ -1,0 +1,21 @@
+# Repo SSOT for gh:issue-create auto-labelling.
+#
+# Read by claude/skills/gh-issue-create (Step 2.5) when a repo signal is
+# detected — see references/auto-labels.md for the full dispatch order.
+# Schema:
+#   default_labels.static          - labels appended to every new issue
+#   default_labels.by_title_prefix - conventional-commit prefix -> labels
+#   milestone                      - "auto" | "none" | "<exact name>"
+
+default_labels:
+  static: []
+  by_title_prefix:
+    feat: [feat]
+    fix: [bug]
+    refactor: [refactor]
+    test: [test]
+    ci: [ci]
+    docs: [documentation]
+    chore: []
+
+milestone: none

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -11,8 +11,11 @@ description: >-
   compress — the issue is reused for PR drafts and blog posts, so preserve
   reasoning, decisions, and concrete details.
   Accepts an optional remote name argument (e.g., `/gh-issue-create upstream`) to
-  target a different remote's repository instead of origin. Accepts
-  `-h`/`--help`/`help` to print usage.
+  target a different remote's repository instead of origin. When the
+  target repo ships a `.gh-issue-defaults.yml`, default labels and a
+  milestone are auto-applied per that file (Step 2.5); pass
+  `--no-auto-labels` to opt out or `--auto-label-debug` for the dispatch
+  trace. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
 ---
 
@@ -33,11 +36,19 @@ number + URL at the end.
 
 Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 3.5.
 
-Confirm we're in a git repo (`git rev-parse --show-toplevel`), pick the
-target remote (arg #1 if given, else `origin`), and resolve it to
-`TARGET_REPO=<owner>/<repo>`. If the remote does not exist, list
-`git remote -v` and stop — never silently fall back to `origin`. Full
-substeps in `references/repo-resolution.md`.
+Parse the positional remote argument and the optional flags before
+resolving the repo:
+
+- Remote name — first non-flag positional arg, default `origin`.
+- `--no-auto-labels` — skip Step 2.5 entirely; user `--label` flags
+  remain in effect. Default off.
+- `--auto-label-debug` — verbose stderr trace of Stage-1 detection and
+  the kept/dropped label sets. Default off.
+
+Confirm we're in a git repo (`git rev-parse --show-toplevel`) and resolve
+the remote to `TARGET_REPO=<owner>/<repo>`. If the remote does not
+exist, list `git remote -v` and stop — never silently fall back to
+`origin`. Full substeps in `references/repo-resolution.md`.
 
 ## Step 2: Classify the Conversation
 
@@ -57,6 +68,38 @@ Pick exactly one conventional-commit prefix as the dominant intent.
 모호하면 묻지 말고 가장 보수적인 `misc` 로 떨어진다. 대형 `feat`
 휴리스틱(영향 컴포넌트 ≥3 / NF 명시 / 결정 누적 — 둘 이상)은
 `references/templates/feat.md` "대형 feat 가이드" 를 따른다.
+
+## Step 2.5: Auto-labels + Milestone (opt-in via SSOT)
+
+If `--no-auto-labels` was passed in Step 1, skip this step entirely.
+
+Otherwise check `$TARGET_REPO` for the Stage-1 signals listed in
+`references/auto-labels.md` ("Stage 1 — Repo signal detection"). If no
+signal fires, skip and continue.
+
+When a signal fires:
+
+1. Source `${SHELL_COMMON}/functions/parse_yaml_defaults.sh` and load
+   `static_labels`, `prefix_labels` (using the prefix from Step 2), and
+   `milestone_value` from `.gh-issue-defaults.yml`.
+2. Compose the candidate label set as
+   `static_labels ∪ prefix_labels ∪ user_labels`. User-supplied
+   `--label` values are merged, never overridden.
+3. Validate every candidate against
+   `gh label list --repo "$TARGET_REPO" --json name --jq '.[].name'`.
+   Missing labels emit `auto-labels: label '<x>' not found in
+   $TARGET_REPO — skip` on stderr and are dropped. **Never** auto-create
+   labels.
+4. Resolve the milestone — `auto`, `none`, or an exact title — per
+   `references/auto-labels.md` ("Dispatch order"). Unknown names
+   warn-and-skip.
+5. Stash the kept labels and resolved milestone for Step 4 to thread
+   into `gh issue create`.
+
+If `--auto-label-debug` is set, print Stage-1 evaluation, loaded YAML
+values, and kept/dropped sets to stderr before Step 4 runs. The full
+schema, dispatch order, and compatibility matrix live in
+`references/auto-labels.md`.
 
 ## Step 3: Draft the Issue Body
 
@@ -95,11 +138,20 @@ BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 # ... write body to "$BODY" ...
 printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
   "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
-gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY"
+gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY" \
+    "${LABEL_ARGS[@]}" "${MILESTONE_ARGS[@]}"
 ```
 
-`--assignee` / `--label` / `--milestone` 은 사용자가 명시 요청하지
-않은 한 추가하지 않는다. 확인 질문하지 말고 즉시 실행.
+`LABEL_ARGS` / `MILESTONE_ARGS` are the arrays Step 2.5 prepared (one
+`--label <name>` per kept label; `--milestone <title>` if resolved).
+Both are empty when Step 2.5 was skipped — the `gh issue create`
+invocation degrades to its original form.
+
+`--assignee` is still only added when the user asks. User-supplied
+`--label` flags survive Step 2.5 (union with auto labels) unless
+`--no-auto-labels` was set, in which case Step 2.5 is bypassed and the
+user's labels pass straight through `LABEL_ARGS` from Step 1.
+확인 질문하지 말고 즉시 실행.
 
 ## Step 5: Report
 
@@ -111,7 +163,10 @@ Issue #123 created: https://github.com/owner/repo/issues/123
 
 ## Constraints
 
-- `--assignee @me` / 라벨은 사용자 요청이 있을 때만 추가.
+- `--assignee @me` 는 사용자 요청이 있을 때만 추가.
+- 라벨/마일스톤 은 (a) 사용자 명시 또는 (b) Step 2.5 의 SSOT 기반
+  자동 적용 일 때만 부착. 자동 적용 결과는 항상 `gh label list` 검증
+  통과한 라벨만 유지 — 미존재 라벨 자동 생성 금지.
 - 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
 - 사용자 지정 remote 가 없으면 즉시 실패.
 - discussion log 를 2~3줄로 압축하지 말 것.

--- a/claude/skills/gh-issue-create/references/auto-labels.md
+++ b/claude/skills/gh-issue-create/references/auto-labels.md
@@ -1,0 +1,107 @@
+# gh:issue-create — Auto-labels (Step 2.5)
+
+Detail companion to SKILL.md Step 2.5. Step 2.5 attaches default labels
+and a milestone to a freshly drafted issue **only when the target repo
+opts in** by checking in a `.gh-issue-defaults.yml` (the SSOT). Repos
+without that file keep the original behavior — no label or milestone is
+auto-applied.
+
+## Stage 1 — Repo signal detection
+
+Step 2.5 runs only if at least one of the following signals is present
+in `$TARGET_REPO`'s working tree:
+
+1. `.gh-issue-defaults.yml` exists at the repo root. **Primary signal.**
+   When present, it is also the schema source — Step 2.5 reads it.
+2. `.github/workflows/stacked-closes-rollup.yml` exists. (Inherited from
+   the stacked-PR Stage-1 detection contract — co-located automation
+   policy lives here.)
+3. `agent-toolbox/` directory exists at the repo root.
+4. `CLAUDE.md`, `AGENTS.md`, or `.claude/github-integration.md` mentions
+   `.gh-issue-defaults.yml` (`grep -q`).
+
+If none match, skip Step 2.5 entirely. The skill still creates the issue
+without labels or milestones — the historical default.
+
+If signal #1 is absent but signal #2/#3/#4 fired, Step 2.5 also stops:
+without the SSOT it has no schema to follow. Print one stderr line
+(`auto-labels: signal detected but .gh-issue-defaults.yml missing — skip`)
+and continue to Step 4.
+
+## Schema (recognised keys)
+
+```yaml
+default_labels:
+  static:           [<label>, ...]   # appended to every new issue
+  by_title_prefix:                   # conventional-commit prefix → labels
+    feat:     [feat]
+    fix:      [bug]
+    refactor: [refactor]
+    test:     [test]
+    ci:       [ci]
+    docs:     [documentation]
+    chore:    []                     # explicit empty = "no label"
+
+milestone: auto                      # auto | none | "<exact name>"
+```
+
+- `static` accepts both inline (`[a, b]`) and block-list (`- a` lines).
+- `by_title_prefix` keys must be lowercase conventional-commit prefixes.
+  Anything not listed (e.g. `perf`, `misc`) yields no label.
+- `milestone: auto` resolves to the most recent open milestone returned
+  by `gh api repos/$TARGET_REPO/milestones?state=open` (highest `number`).
+- `milestone: none` (or empty) skips milestone application.
+- `milestone: "<name>"` matches an open milestone with that exact title;
+  unknown names warn-and-skip.
+
+The shipped parser (`shell-common/functions/parse_yaml_defaults.sh`) is
+intentionally minimal and only understands those keys — anchors, nested
+maps, multi-doc files, and other YAML features are NOT supported.
+
+## Dispatch order (inside Step 2.5)
+
+1. Detect Stage-1 signals (above). If absent → skip.
+2. Source `parse_yaml_defaults.sh` and load:
+   - `static_labels` ← `_parse_yaml_defaults_static <yml>`
+   - `prefix_labels` ← `_parse_yaml_defaults_by_prefix <yml> <prefix>`
+     (`<prefix>` = the conventional-commit prefix chosen in Step 2)
+   - `milestone_value` ← `_parse_yaml_defaults_milestone <yml>`
+3. Compose the **candidate label set** as
+   `static_labels ∪ prefix_labels ∪ user_labels`. (`user_labels` are the
+   `--label foo` values the operator passed on the CLI — they are
+   merged, never overridden. `--no-auto-labels` short-circuits Step 2.5
+   entirely so user labels are kept untouched.)
+4. Validate each candidate against `gh label list --repo $TARGET_REPO
+   --json name --jq '.[].name'`. Missing labels emit
+   `auto-labels: label '<x>' not found in $TARGET_REPO — skip` on stderr
+   and are dropped from the set. **Never auto-create labels** — see the
+   pinned memory rule "gh labels — verify before apply".
+5. Resolve the milestone:
+   - `auto` → query open milestones, pick the highest `number`.
+   - `none`/empty → skip.
+   - `"<name>"` → match by exact title; missing → warn-skip.
+6. Build the `gh issue create` arg list with one `--label <x>` per kept
+   label and (optionally) `--milestone <name>`.
+
+## Operator escapes
+
+- `--no-auto-labels` — skip Step 2.5 entirely. User-supplied `--label`
+  values still apply.
+- `--auto-label-debug` — print the full Stage-1 evaluation, the YAML
+  values that were loaded, and the kept/dropped sets to stderr before
+  Step 4 runs.
+
+## Compatibility matrix
+
+| Scenario | repo signal | SSOT file | Outcome |
+|---|---|---|---|
+| dotfiles, title `feat: ...` | yes | yes | `--label feat` |
+| dotfiles, title `chore: ...` | yes | yes | no label (chore=[]) |
+| dotfiles, title `feat: ...` + `--label skill` | yes | yes | `--label feat --label skill` (union) |
+| AgentToolbox, title `feat: ...` | yes | yes | static + prefix labels both applied |
+| Generic repo | no | no | original behaviour, no auto labels |
+| `--no-auto-labels` | n/a | n/a | original behaviour |
+| dotfiles, title `docs: ...`, `documentation` label missing | yes | yes | warn + skip; other labels still apply |
+
+The bats suite at `tests/bats/skills/gh_issue_create_auto_labels.bats`
+locks all seven rows.

--- a/claude/skills/gh-issue-create/references/help.md
+++ b/claude/skills/gh-issue-create/references/help.md
@@ -6,10 +6,19 @@
 |---|------|---------|-------------|
 | 1 | remote-name, or `-h`/`--help`/`help` | `origin` | Git remote whose repo will own the new issue (e.g. `upstream`) |
 
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--no-auto-labels` | off | Skip Step 2.5 — never auto-attach labels/milestones from `.gh-issue-defaults.yml`. User-supplied `--label` flags still apply. |
+| `--auto-label-debug` | off | Print Stage-1 detection trace plus kept/dropped label sets to stderr before issue creation. |
+
 ## Usage
 
 - `/gh-issue-create` — create issue on `origin`'s repo (the most common case)
 - `/gh-issue-create upstream` — create issue on the `upstream` remote's repo
+- `/gh-issue-create --no-auto-labels` — skip the SSOT auto-label step
+- `/gh-issue-create --auto-label-debug` — verbose label-dispatch trace
 - `/gh-issue-create -h` / `--help` / `help` — print this help
 
 ## What the skill does
@@ -37,9 +46,14 @@
 
 3. Drafts a structured issue body matching the template in the language
    the user was speaking (Korean chat → Korean issue).
-4. Creates the issue via `gh issue create --repo "$TARGET_REPO"` using a
+4. **Auto-labels (Step 2.5, opt-in)** — when `$TARGET_REPO` ships
+   `.gh-issue-defaults.yml`, attaches default labels and (optionally) a
+   milestone per that SSOT. Missing labels warn-and-skip; never auto-
+   created. Disabled by `--no-auto-labels`. See
+   `references/auto-labels.md`.
+5. Creates the issue via `gh issue create --repo "$TARGET_REPO"` using a
    temp file written by `mktemp` (avoids shell escaping bugs).
-5. Prints only `Issue #N created: <url>` — no preamble, no summary.
+6. Prints only `Issue #N created: <url>` — no preamble, no summary.
 
 ## Title format
 
@@ -60,7 +74,9 @@ A 200-line issue is fine if the conversation warranted it.
 
 ## What the skill will NOT do
 
-- Add `--assignee`, `--label`, or `--milestone` unless the user asked.
+- Add `--assignee` unless the user asked.
+- Auto-create labels that don't exist on the target repo (warn + skip).
+- Apply auto labels/milestones on repos without `.gh-issue-defaults.yml`.
 - Fall back to `origin` when the user-specified remote is missing.
 - Ask "should I create it?" — running the skill is the confirmation.
 - Rely on implicit repo detection — always passes `--repo "$TARGET_REPO"`.

--- a/shell-common/functions/parse_yaml_defaults.sh
+++ b/shell-common/functions/parse_yaml_defaults.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# shell-common/functions/parse_yaml_defaults.sh
+# POSIX-compatible mini-parser for `.gh-issue-defaults.yml` consumed by
+# claude/skills/gh-issue-create Step 2.5. Avoids a hard `yq` dependency
+# so the skill works on any host with awk + sh. Recognises only the
+# narrow schema documented in claude/skills/gh-issue-create/references/
+# auto-labels.md ("Schema (recognised keys)" section) — anything richer
+# should reach for a real YAML parser instead.
+#
+# Public helpers (all read from $1, write newline-separated labels or a
+# single milestone string to stdout, return 0 even when no match):
+#
+#   _parse_yaml_defaults_static <yml>
+#   _parse_yaml_defaults_by_prefix <yml> <prefix>
+#   _parse_yaml_defaults_milestone <yml>
+#
+# Each helper exits 1 only on missing-file / empty-file argument errors.
+
+# Static labels under `default_labels.static: [a, b]` or block-list form.
+_parse_yaml_defaults_static() {
+    _yml="$1"
+    [ -n "$_yml" ] && [ -r "$_yml" ] || return 1
+    awk '
+        BEGIN { in_dl = 0; in_static = 0 }
+        /^[[:space:]]*#/ { next }
+        /^default_labels:[[:space:]]*$/ { in_dl = 1; next }
+        in_dl && /^[^[:space:]]/ { in_dl = 0; in_static = 0 }
+        in_dl && /^[[:space:]]+static:[[:space:]]*\[/ {
+            line = $0
+            sub(/^[^\[]*\[/, "", line)
+            sub(/\].*/, "", line)
+            n = split(line, a, ",")
+            for (i = 1; i <= n; i++) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", a[i])
+                gsub(/^["'\'']|["'\'']$/, "", a[i])
+                if (a[i] != "") print a[i]
+            }
+            next
+        }
+        in_dl && /^[[:space:]]+static:[[:space:]]*$/ { in_static = 1; next }
+        in_static && /^[[:space:]]+-[[:space:]]+/ {
+            v = $0
+            sub(/^[[:space:]]+-[[:space:]]+/, "", v)
+            gsub(/^["'\'']|["'\'']$/, "", v)
+            print v
+            next
+        }
+        in_static && /^[[:space:]]+[A-Za-z_]/ { in_static = 0 }
+    ' "$_yml"
+}
+
+# Labels mapped from a conventional-commit title prefix.
+_parse_yaml_defaults_by_prefix() {
+    _yml="$1"
+    _prefix="$2"
+    [ -n "$_yml" ] && [ -r "$_yml" ] || return 1
+    [ -n "$_prefix" ] || return 1
+    awk -v want="$_prefix" '
+        BEGIN { in_dl = 0; in_btp = 0 }
+        /^[[:space:]]*#/ { next }
+        /^default_labels:[[:space:]]*$/ { in_dl = 1; next }
+        in_dl && /^[^[:space:]]/ { in_dl = 0; in_btp = 0 }
+        in_dl && /^[[:space:]]+by_title_prefix:[[:space:]]*$/ { in_btp = 1; next }
+        in_btp && /^[[:space:]]+[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*\[/ {
+            key = $0
+            sub(/^[[:space:]]+/, "", key)
+            sub(/:.*/, "", key)
+            if (key != want) next
+            line = $0
+            sub(/^[^\[]*\[/, "", line)
+            sub(/\].*/, "", line)
+            n = split(line, a, ",")
+            for (i = 1; i <= n; i++) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", a[i])
+                gsub(/^["'\'']|["'\'']$/, "", a[i])
+                if (a[i] != "") print a[i]
+            }
+            next
+        }
+        in_btp && /^[^[:space:]]/ { in_btp = 0 }
+    ' "$_yml"
+}
+
+# Milestone field — emits the literal value or nothing.
+_parse_yaml_defaults_milestone() {
+    _yml="$1"
+    [ -n "$_yml" ] && [ -r "$_yml" ] || return 1
+    awk '
+        /^[[:space:]]*#/ { next }
+        /^milestone:[[:space:]]*/ {
+            v = $0
+            sub(/^milestone:[[:space:]]*/, "", v)
+            sub(/[[:space:]]*#.*$/, "", v)
+            sub(/[[:space:]]+$/, "", v)
+            gsub(/^["'\'']|["'\'']$/, "", v)
+            print v
+            exit
+        }
+    ' "$_yml"
+}

--- a/shell-common/functions/parse_yaml_defaults.sh
+++ b/shell-common/functions/parse_yaml_defaults.sh
@@ -61,10 +61,10 @@ _parse_yaml_defaults_by_prefix() {
         /^default_labels:[[:space:]]*$/ { in_dl = 1; next }
         in_dl && /^[^[:space:]]/ { in_dl = 0; in_btp = 0 }
         in_dl && /^[[:space:]]+by_title_prefix:[[:space:]]*$/ { in_btp = 1; next }
-        in_btp && /^[[:space:]]+[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*\[/ {
+        in_btp && /^[[:space:]]+[A-Za-z_][A-Za-z0-9_-]*[[:space:]]*:[[:space:]]*\[/ {
             key = $0
             sub(/^[[:space:]]+/, "", key)
-            sub(/:.*/, "", key)
+            sub(/[[:space:]]*:.*/, "", key)
             if (key != want) next
             line = $0
             sub(/^[^\[]*\[/, "", line)
@@ -87,9 +87,9 @@ _parse_yaml_defaults_milestone() {
     [ -n "$_yml" ] && [ -r "$_yml" ] || return 1
     awk '
         /^[[:space:]]*#/ { next }
-        /^milestone:[[:space:]]*/ {
+        /^[[:space:]]*milestone:[[:space:]]*/ {
             v = $0
-            sub(/^milestone:[[:space:]]*/, "", v)
+            sub(/^[[:space:]]*milestone:[[:space:]]*/, "", v)
             sub(/[[:space:]]*#.*$/, "", v)
             sub(/[[:space:]]+$/, "", v)
             gsub(/^["'\'']|["'\'']$/, "", v)

--- a/tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh
+# Source-of-truth mirror for the Step 2.5 dispatch flow documented in
+# claude/skills/gh-issue-create/SKILL.md and references/auto-labels.md.
+#
+# The skill itself runs inside Claude, but the dispatch logic boils down
+# to: "given an SSOT file (or none), a conventional-commit prefix, a
+# comma-separated list of user-supplied labels, the set of labels that
+# already exist on the target repo, and the --no-auto-labels flag —
+# what is the final label set we hand to `gh issue create`?"
+#
+# Keep this file in sync with SKILL.md Step 2.5 + references/auto-labels.md.
+# If the dispatch order changes, mirror the change here so the bats
+# suite catches drift.
+
+# Load the real awk parser.
+# shellcheck disable=SC1091
+. "${_BATS_REAL_SHELL_COMMON}/functions/parse_yaml_defaults.sh"
+
+# gh_issue_create_compose_labels
+#   $1 — path to .gh-issue-defaults.yml ("" => no SSOT, signal absent)
+#   $2 — conventional-commit prefix (feat/fix/refactor/test/ci/docs/chore/...)
+#   $3 — comma-separated user labels passed via `--label`
+#   $4 — comma-separated labels that exist on the target repo (mock)
+#   $5 — "1" if --no-auto-labels, "0" otherwise
+#
+# Stdout: final kept labels, one per line, in dispatch order
+#         (static first, then prefix-mapped, then user labels), de-duped.
+# Stderr: one `auto-labels: label '<x>' not found ...` line per dropped.
+# Returns: 0 always (the skill never aborts the issue creation).
+gh_issue_create_compose_labels() {
+    _yml="$1"
+    _prefix="$2"
+    _user_csv="$3"
+    _existing_csv="$4"
+    _no_auto="$5"
+
+    # User labels are unconditional unless --no-auto-labels is set, in
+    # which case Step 2.5 is skipped and only user labels remain.
+    if [ "$_no_auto" = "1" ]; then
+        _emit_csv "$_user_csv" "$_existing_csv"
+        return 0
+    fi
+
+    # Stage-1 signal: SSOT file present. For the bats suite this is the
+    # only signal we exercise — the others (rollup workflow, agent-toolbox
+    # dir, AGENTS.md grep) reduce to the same "load YAML or skip" branch
+    # and are documented in references/auto-labels.md.
+    if [ -z "$_yml" ] || [ ! -r "$_yml" ]; then
+        _emit_csv "$_user_csv" "$_existing_csv"
+        return 0
+    fi
+
+    _static=$(_parse_yaml_defaults_static "$_yml")
+    _prefix_labels=$(_parse_yaml_defaults_by_prefix "$_yml" "$_prefix")
+
+    # Merge static ∪ prefix ∪ user, preserving order, then validate.
+    {
+        [ -n "$_static" ] && printf '%s\n' "$_static"
+        [ -n "$_prefix_labels" ] && printf '%s\n' "$_prefix_labels"
+        _emit_csv_raw "$_user_csv"
+    } | _validate_against "$_existing_csv"
+}
+
+# Emit the user-only label set, validated against existing repo labels.
+_emit_csv() {
+    _csv="$1"
+    _existing="$2"
+    _emit_csv_raw "$_csv" | _validate_against "$_existing"
+}
+
+_emit_csv_raw() {
+    _csv="$1"
+    [ -z "$_csv" ] && return 0
+    printf '%s' "$_csv" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$'
+}
+
+_validate_against() {
+    _existing_csv="$1"
+    awk -v existing="$_existing_csv" '
+        BEGIN {
+            n = split(existing, parts, ",")
+            for (i = 1; i <= n; i++) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", parts[i])
+                if (parts[i] != "") have[parts[i]] = 1
+            }
+        }
+        {
+            if (seen[$0]++) next
+            if ($0 == "") next
+            if ($0 in have) {
+                print
+            } else {
+                printf("auto-labels: label '\''%s'\'' not found in target repo — skip\n", $0) > "/dev/stderr"
+            }
+        }
+    '
+}

--- a/tests/bats/skills/gh_issue_create_auto_labels.bats
+++ b/tests/bats/skills/gh_issue_create_auto_labels.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_create_auto_labels.bats
+# Locks the seven-row compatibility matrix documented in
+#   claude/skills/gh-issue-create/references/auto-labels.md
+# and the Step 2.5 dispatch flow in
+#   claude/skills/gh-issue-create/SKILL.md.
+#
+# Source-of-truth fixture: _fixtures/gh_issue_create_auto_labels.sh.
+# It loads the real awk parser shipped at
+# shell-common/functions/parse_yaml_defaults.sh and exposes a single
+# helper — gh_issue_create_compose_labels — that mirrors the SKILL
+# dispatch order so these tests catch drift between the prose and the
+# implementation.
+
+bats_require_minimum_version 1.5.0
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh"
+
+    # The dotfiles SSOT under test (committed alongside this suite).
+    DOTFILES_YML="${_BATS_REAL_DOTFILES_ROOT}/.gh-issue-defaults.yml"
+    # Mock of `gh label list --jq '.[].name'` for the dotfiles repo.
+    DOTFILES_EXISTING="bug,documentation,enhancement,feat,refactor,test,ci,skill"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ── Row 1 ────────────────────────────────────────────────────────────
+@test "auto-labels: dotfiles 'feat: ...' → --label feat" {
+    run gh_issue_create_compose_labels \
+        "$DOTFILES_YML" feat "" "$DOTFILES_EXISTING" 0
+    assert_success
+    assert_output 'feat'
+}
+
+# ── Row 2 ────────────────────────────────────────────────────────────
+@test "auto-labels: dotfiles 'chore: ...' → empty (chore=[])" {
+    run gh_issue_create_compose_labels \
+        "$DOTFILES_YML" chore "" "$DOTFILES_EXISTING" 0
+    assert_success
+    assert_output ''
+}
+
+# ── Row 3 ────────────────────────────────────────────────────────────
+@test "auto-labels: feat + user '--label skill' → union (feat, skill)" {
+    run gh_issue_create_compose_labels \
+        "$DOTFILES_YML" feat "skill" "$DOTFILES_EXISTING" 0
+    assert_success
+    assert_line --index 0 'feat'
+    assert_line --index 1 'skill'
+    [ "${#lines[@]}" -eq 2 ]
+}
+
+# ── Row 4 ────────────────────────────────────────────────────────────
+@test "auto-labels: AgentToolbox-style static + prefix → both applied" {
+    YML="$(mktemp)"
+    cat >"$YML" <<'YAML'
+default_labels:
+  static: [pro-friendly, phase:1]
+  by_title_prefix:
+    feat: [feat]
+milestone: auto
+YAML
+    EXISTING="pro-friendly,phase:1,feat,bug"
+
+    run gh_issue_create_compose_labels "$YML" feat "" "$EXISTING" 0
+    rm -f "$YML"
+
+    assert_success
+    assert_line --index 0 'pro-friendly'
+    assert_line --index 1 'phase:1'
+    assert_line --index 2 'feat'
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+# ── Row 5 ────────────────────────────────────────────────────────────
+@test "auto-labels: generic repo (no SSOT) → no auto labels" {
+    run gh_issue_create_compose_labels "" feat "" "$DOTFILES_EXISTING" 0
+    assert_success
+    assert_output ''
+}
+
+# ── Row 6 ────────────────────────────────────────────────────────────
+@test "auto-labels: --no-auto-labels honours user labels only" {
+    run gh_issue_create_compose_labels \
+        "$DOTFILES_YML" feat "skill" "$DOTFILES_EXISTING" 1
+    assert_success
+    assert_output 'skill'
+}
+
+# ── Row 7 ────────────────────────────────────────────────────────────
+@test "auto-labels: missing target label → warn skip + keep others" {
+    # 'documentation' is the prefix-mapped label for docs; user added
+    # 'skill'; the mocked repo is missing 'documentation'.
+    EXISTING_NO_DOCS="bug,enhancement,feat,refactor,test,ci,skill"
+
+    # Use --separate-stderr so we can assert stdout (kept labels) and
+    # stderr (warning) independently.
+    run --separate-stderr gh_issue_create_compose_labels \
+        "$DOTFILES_YML" docs "skill" "$EXISTING_NO_DOCS" 0
+    assert_success
+    # 'documentation' got dropped; 'skill' (user) survives on stdout.
+    assert_output 'skill'
+    # The drop surfaces on stderr.
+    [[ "$stderr" == *"auto-labels: label 'documentation' not found"* ]]
+    [[ "$stderr" != *"label 'skill' not found"* ]]
+}


### PR DESCRIPTION
## Summary
- `gh:issue-create` 가 repo 의 `.gh-issue-defaults.yml` 를 읽어 conventional-commit prefix → 라벨 + 마일스톤 을 자동 부착 (Step 2.5 신설).
- dotfiles 자체에도 SSOT (`feat→feat`, `fix→bug`, `docs→documentation`, `chore=[]` …) 추가 — AgentToolbox 류 자동화에서 사일런트 누락되던 문제 해소.
- 사용자 명시 `--label` 은 합집합 (override 아님), `--no-auto-labels` / `--auto-label-debug` escape 제공, 미존재 라벨은 warn-and-skip (memory rule 준수).

## Changes
- `.gh-issue-defaults.yml` (신규) — dotfiles SSOT. feat/fix/refactor/test/ci/docs prefix → 매칭 라벨, chore 는 의도적으로 빈 리스트, milestone none.
- `shell-common/functions/parse_yaml_defaults.sh` (신규) — `yq` 의존 없는 POSIX awk 미니파서. 좁은 SSOT 스키마만 인식 (anchors/multi-doc 등 미지원). 인라인 `[a, b]` + 블록 `- a` 양쪽 지원.
- `claude/skills/gh-issue-create/SKILL.md` — Step 1 에 `--no-auto-labels` / `--auto-label-debug` flag 파싱, Step 2.5 신설, Step 4 에서 `${LABEL_ARGS[@]}` / `${MILESTONE_ARGS[@]}` 를 `gh issue create` 에 thread.
- `claude/skills/gh-issue-create/references/auto-labels.md` (신규) — Stage-1 신호 감지, 스키마, dispatch order, escape 의미, 호환성 매트릭스.
- `claude/skills/gh-issue-create/references/help.md` — flag 표 + "what the skill will NOT do" 갱신.
- `tests/bats/skills/gh_issue_create_auto_labels.bats` + `_fixtures/gh_issue_create_auto_labels.sh` (신규) — 인수 기준 7 row 매트릭스를 회귀 테스트로 락. 픽스처가 SKILL.md 의 dispatch 알고리즘을 미러링하므로 prose ↔ 구현 drift 발생 시 즉시 fail.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/` → 70/70 pass (auto-labels 7 row + 기존 63 row 회귀 무).
- [x] `shellcheck -s sh shell-common/functions/parse_yaml_defaults.sh tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh` → 0 warnings.
- [x] `bash -n` + `zsh -n` clean on the new sh/awk surface.
- [x] 라이브 `gh issue create` 호출은 의도적으로 미실행 — memory rule "No live gh/API smoke tests for new helpers" 준수. 검증은 fake-shim 기반 bats 로 한정.
- [ ] 후속: AgentToolbox repo 가 자체 `.gh-issue-defaults.yml` 를 추가했을 때 (해당 repo 측 결정), 같은 dispatch 가 `pro-friendly` / `phase:1` / `auto` milestone 을 부착하는지 일회성 dry-run 확인.

## Related
Closes #398

---
<details>
<summary>🤖 AI Metrics · 📊 ~7500 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~7500 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
