### PR TITLE
refactor(gh-api): -f/-F type-mapping convention + lint guard (#395)

### DIFF
--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -103,6 +103,15 @@ inline diff 코멘트는 `/pulls/{n}/comments/{id}/replies` (스레드 유지),
 git-crypt failed`로 막힌다. AI 에이전트의 `isolation: "worktree"` 병렬
 디스패치 실패 시 sequential 전환 또는 `--no-checkout` + 수동 unlock.
 
+### 5. `gh api graphql`의 `-f` vs `-F` 타입 캐스팅 함정
+
+**파일**: [`gh-api-type-casting.md`](./gh-api-type-casting.md)
+
+`-f` 는 raw String (`String!`/`ID!`), `-F` 는 type inference (`Int!`).
+숫자만 있는 ID 문자열을 `-F` 로 넘기면 자동 Int 캐스팅 → 422 silent fail.
+호출부에 `# Variables: $x Type!, ...` 주석으로 사람-가독 타입 계약 박기 +
+bats 휴리스틱 + pre-commit warning 으로 회귀 가드.
+
 ## 성장 전략
 
 - 3–10개: 플랫 구조 유지 (현재)

--- a/docs/learnings/gh-api-type-casting.md
+++ b/docs/learnings/gh-api-type-casting.md
@@ -1,0 +1,71 @@
+# `gh api graphql`의 `-f` vs `-F` 타입 캐스팅 함정
+
+## Context
+
+PR·이슈 추적: 이슈 [#384](https://github.com/dEitY719/dotfiles/issues/384)
+검토 노트, 이슈 [#395](https://github.com/dEitY719/dotfiles/issues/395) 구현.
+
+`shell-common/functions/gh_project_status.sh`의 projectV2 mutation에서
+`updateProjectV2ItemFieldValue` 호출이 GraphQL `422` 로 silent fail 한
+사례에서 출발. 호출부 변수 매핑(`-f` vs `-F`)이 query의 `String!`/`ID!`/`Int!`
+타입과 맞지 않아도 `gh api`가 stderr에 한 줄 찍고 종료하는데, 보통 helper
+들은 `2>/dev/null` 로 stderr를 버려 caller가 실패를 인지하지 못한다.
+
+## Pattern
+
+`gh api graphql` 변수 바인딩은 두 종류:
+
+| Flag | 동작 | GraphQL 타입 |
+|---|---|---|
+| `-f name=value` | **raw String**으로 전달 | `String!`, `ID!` |
+| `-F name=value` | **type inference** — 순수 숫자면 자동 `Int` 캐스팅 | `Int!` |
+
+함정:
+
+```sh
+# WRONG — -F 가 "12345" 를 Int 로 캐스팅 → ID! 에 Int 전달 → 422
+gh api graphql -f query='mutation($id: ID!) {...}' -F id="12345"
+
+# WRONG — -f 가 "42" 를 String 으로 전달 → Int! 에 String → 422
+gh api graphql -f query='query($num: Int!) {...}' -f num="42"
+```
+
+## Code
+
+호출부에 **`# Variables: $x Type!, ...` 주석**을 붙이는 것이 1차 방어선.
+리뷰어/미래의 본인이 `-f`/`-F` 가 query 의 타입과 맞는지 한눈에 검증 가능.
+
+```sh
+# Variables: $owner String!, $repo String!, $number Int!, $target String!
+gh api graphql \
+    -f query='
+      query($owner: String!, $repo: String!, $number: Int!, $target: String!) {
+        repository(owner: $owner, name: $repo) {
+          issue(number: $number) { ... }
+        }
+      }' \
+    -f owner="$_owner" \
+    -f repo="$_repo" \
+    -F number="$_num" \
+    -f target="$_target"
+```
+
+`$VAR` 가 number 인지 string 인지는 lint 시점에 알 수 없으므로 사람이 의도를
+**주석으로 박아두는** 것이 가장 안전한 회귀 가드.
+
+## When to use
+
+- 모든 `gh api graphql` 호출 — `mutation`, `query` 어느 쪽이든.
+- `gh api repos/...` 같은 REST 엔드포인트는 해당 없음 (REST는 path/JSON
+  body 기반이라 GraphQL 타입 시스템과 무관).
+- pre-commit `git/hooks/checks/gh_api_type_check.sh`가 위 컨벤션 부재를
+  warning 수준으로 잡아낸다 (false-positive 위험으로 block 안 함).
+
+## Related
+
+- 코드: `shell-common/functions/gh_project_status.sh`,
+  `shell-common/functions/gh_audit_builtin_workflows.sh`
+- 회귀 가드: `tests/bats/lint/gh_api_type_mapping.bats`
+- pre-commit 훅: `git/hooks/checks/gh_api_type_check.sh`
+- 이슈: [#384](https://github.com/dEitY719/dotfiles/issues/384) (검토 노트),
+  [#395](https://github.com/dEitY719/dotfiles/issues/395) (구현)

--- a/git/hooks/checks/gh_api_type_check.sh
+++ b/git/hooks/checks/gh_api_type_check.sh
@@ -57,10 +57,19 @@ check_gh_api_type_mapping() {
     grep -q 'gh api graphql' "$abs_path" 2>/dev/null || return 0
 
     # Signal 1: -F with literal non-numeric value.
-    # Pattern: -F<space>name="<chars-with-letters-or-underscore>"
-    # Excludes $VAR references and pure digits.
-    local matches
-    matches=$(grep -nE '\-F[[:space:]]+[A-Za-z_][A-Za-z0-9_]*="[^"$]*[A-Za-z_][^"]*"' "$abs_path" 2>/dev/null || true)
+    # Two patterns — double- and single-quoted forms. Single-quoted
+    # added per PR #407 review (gemini): repos may use single quotes for
+    # literal IDs since `$VAR` is meaningless inside single quotes
+    # anyway. Both quote styles are flagged; unquoted forms are not —
+    # the shellcheck linter enforces quoting independently.
+    #
+    # Each grep is run separately and the results merged. Keeping the
+    # regexes split avoids the alternation-with-quote-escaping that
+    # makes a combined POSIX BRE/ERE pattern unreadable.
+    local matches sq dq sq2 dq2
+    dq=$(grep -nE '\-F[[:space:]]+[A-Za-z_][A-Za-z0-9_]*="[^"$]*[A-Za-z_][^"]*"' "$abs_path" 2>/dev/null || true)
+    sq=$(grep -nE "\-F[[:space:]]+[A-Za-z_][A-Za-z0-9_]*='[^']*[A-Za-z_][^']*'" "$abs_path" 2>/dev/null || true)
+    matches=$(printf '%s\n%s\n' "$dq" "$sq" | grep -v '^$' || true)
     if [ -n "$matches" ]; then
         while IFS= read -r line; do
             [ -z "$line" ] && continue
@@ -71,9 +80,10 @@ check_gh_api_type_mapping() {
     fi
 
     # Signal 2: -f with literal all-digit value.
-    # Pattern: -f<space>name="<digits>"
-    # Excludes $VAR references and quoted strings with letters.
-    matches=$(grep -nE '\-f[[:space:]]+[A-Za-z_][A-Za-z0-9_]*="[0-9]+"' "$abs_path" 2>/dev/null || true)
+    # Same dual-pattern approach as Signal 1.
+    dq2=$(grep -nE '\-f[[:space:]]+[A-Za-z_][A-Za-z0-9_]*="[0-9]+"' "$abs_path" 2>/dev/null || true)
+    sq2=$(grep -nE "\-f[[:space:]]+[A-Za-z_][A-Za-z0-9_]*='[0-9]+'" "$abs_path" 2>/dev/null || true)
+    matches=$(printf '%s\n%s\n' "$dq2" "$sq2" | grep -v '^$' || true)
     if [ -n "$matches" ]; then
         while IFS= read -r line; do
             [ -z "$line" ] && continue

--- a/git/hooks/checks/gh_api_type_check.sh
+++ b/git/hooks/checks/gh_api_type_check.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# git/hooks/checks/gh_api_type_check.sh
+#
+# Heuristic regression guard for `gh api graphql` -f/-F flag mapping.
+# Issue #395 / design #384.
+#
+# `gh api graphql` accepts two flag flavors for binding GraphQL variables:
+#   -f name=value  → raw String (use for String!, ID!)
+#   -F name=value  → type inference; pure numeric → Int (use for Int!)
+#
+# Mismatch is silent: GraphQL returns 422, jq prints empty, the caller's
+# best-effort path eats the failure. Recurring incidents (#384) motivated
+# a static guard. Heuristic — false positives are tolerated; this check
+# only WARNS, never blocks.
+#
+# Three signals:
+#   1. -F with literal non-numeric value (e.g. -F id="PVTI_xxx").
+#      $VAR references are not flagged (cannot tell at lint time whether
+#      the var holds a number).
+#   2. -f with literal all-digit value (likely Int! that should use -F).
+#      $VAR references are not flagged (same reason).
+#   3. `gh api graphql` block lacking a `# Variables: ...` annotation
+#      within the preceding 5 lines. The convention establishes a single
+#      place a reviewer can verify type contracts at a glance.
+#
+# Usage:
+#   . git/hooks/checks/gh_api_type_check.sh
+#   check_gh_api_type_mapping <abs_path> <warnings_file>
+#
+# Returns 0 on no findings, 1 on at least one finding (caller decides
+# whether to surface as warning or hard fail). Pre-commit currently
+# treats it as a warning per the design.
+
+check_gh_api_type_mapping() {
+    local abs_path="$1"
+    local warnings_file="$2"
+    local found=0
+
+    [ -f "$abs_path" ] || return 0
+
+    # Skip docs and meta-files (this check itself, the bats fixtures
+    # that exercise it). Those files describe the convention or are
+    # the test corpus, so they cite `gh api graphql` as prose, not as
+    # caller code. An explicit opt-out marker lets future docs/tests
+    # opt out without editing this list.
+    case "$abs_path" in
+        */docs/*) return 0 ;;
+        */git/hooks/checks/gh_api_type_check.sh) return 0 ;;
+        */tests/bats/lint/gh_api_type_mapping.bats) return 0 ;;
+    esac
+    if grep -q 'gh-api-type-check: skip-file' "$abs_path" 2>/dev/null; then
+        return 0
+    fi
+
+    # Skip files that don't even mention `gh api graphql` — keeps the
+    # check cheap on the bulk of staged files.
+    grep -q 'gh api graphql' "$abs_path" 2>/dev/null || return 0
+
+    # Signal 1: -F with literal non-numeric value.
+    # Pattern: -F<space>name="<chars-with-letters-or-underscore>"
+    # Excludes $VAR references and pure digits.
+    local matches
+    matches=$(grep -nE '\-F[[:space:]]+[A-Za-z_][A-Za-z0-9_]*="[^"$]*[A-Za-z_][^"]*"' "$abs_path" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            printf '%s:%s [WARN] -F with literal non-numeric value — likely should be -f for String!/ID!\n' \
+                "$abs_path" "$line" >>"$warnings_file"
+            found=1
+        done <<<"$matches"
+    fi
+
+    # Signal 2: -f with literal all-digit value.
+    # Pattern: -f<space>name="<digits>"
+    # Excludes $VAR references and quoted strings with letters.
+    matches=$(grep -nE '\-f[[:space:]]+[A-Za-z_][A-Za-z0-9_]*="[0-9]+"' "$abs_path" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            # Skip query= itself, which is naturally a multi-line string.
+            case "$line" in
+                *'-f query='*) continue ;;
+            esac
+            printf '%s:%s [WARN] -f with literal numeric value — likely should be -F for Int!\n' \
+                "$abs_path" "$line" >>"$warnings_file"
+            found=1
+        done <<<"$matches"
+    fi
+
+    # Signal 3: `gh api graphql` block without preceding `Variables:`.
+    # Look back up to 5 lines from each occurrence for the annotation.
+    local line_no
+    while IFS=: read -r line_no _; do
+        [ -z "$line_no" ] && continue
+        local start=$((line_no - 5))
+        [ "$start" -lt 1 ] && start=1
+        local window
+        window=$(sed -n "${start},${line_no}p" "$abs_path" 2>/dev/null)
+        case "$window" in
+            *Variables:*) ;;
+            *)
+                # shellcheck disable=SC2016
+                # The literal "$x Type!" is part of the convention message;
+                # single quotes are intentional to prevent shell expansion.
+                printf '%s:%s [WARN] gh api graphql call missing `# Variables: $x Type!, ...` annotation\n' \
+                    "$abs_path" "$line_no" >>"$warnings_file"
+                found=1
+                ;;
+        esac
+    done < <(grep -nE 'gh api graphql' "$abs_path" 2>/dev/null || true)
+
+    [ "$found" -eq 0 ] && return 0
+    return 1
+}

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -60,8 +60,9 @@ BACKUP_FILES_FILE=$(mktemp "$TMPDIR/backup_files_XXXXXX.txt")
 HELP_INTEGRITY_VIOLATIONS_FILE=$(mktemp "$TMPDIR/help_integrity_violations_XXXXXX.txt")
 DIRECT_EXEC_GUARD_FILE=$(mktemp "$TMPDIR/direct_exec_guard_XXXXXX.txt")
 SHELLCHECK_VIOLATIONS_FILE=$(mktemp "$TMPDIR/shellcheck_violations_XXXXXX.txt")
+GH_API_TYPE_FILE=$(mktemp "$TMPDIR/gh_api_type_XXXXXX.txt")
 
-trap 'rm -f "$VIOLATIONS_FILE" "$FUNC_VIOLATIONS_FILE" "$SHEBANG_VIOLATIONS_FILE" "$SUBSHELL_VIOLATIONS_FILE" "$PIPE_LOOP_VIOLATIONS_FILE" "$ZSH_EMULATION_FILE" "$ALIAS_CONFLICT_FILE" "$ALIAS_LOCATION_FILE" "$WRAPPER_VIOLATIONS_FILE" "$CUSTOM_TOOLS_SOURCING_FILE" "$AUTO_EXEC_CUSTOM_FILE" "$AUTO_EXEC_SOURCED_FILE" "$PURITY_VIOLATIONS_FILE" "$BACKUP_FILES_FILE" "$HELP_INTEGRITY_VIOLATIONS_FILE" "$DIRECT_EXEC_GUARD_FILE" "$SHELLCHECK_VIOLATIONS_FILE"' EXIT
+trap 'rm -f "$VIOLATIONS_FILE" "$FUNC_VIOLATIONS_FILE" "$SHEBANG_VIOLATIONS_FILE" "$SUBSHELL_VIOLATIONS_FILE" "$PIPE_LOOP_VIOLATIONS_FILE" "$ZSH_EMULATION_FILE" "$ALIAS_CONFLICT_FILE" "$ALIAS_LOCATION_FILE" "$WRAPPER_VIOLATIONS_FILE" "$CUSTOM_TOOLS_SOURCING_FILE" "$AUTO_EXEC_CUSTOM_FILE" "$AUTO_EXEC_SOURCED_FILE" "$PURITY_VIOLATIONS_FILE" "$BACKUP_FILES_FILE" "$HELP_INTEGRITY_VIOLATIONS_FILE" "$DIRECT_EXEC_GUARD_FILE" "$SHELLCHECK_VIOLATIONS_FILE" "$GH_API_TYPE_FILE"' EXIT
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Load check modules
@@ -94,6 +95,7 @@ source_check_or_exit "${CHECKS_DIR}/help_integrity_check.sh"
 source_check_or_exit "${CHECKS_DIR}/auto_execution_check.sh"
 source_check_or_exit "${CHECKS_DIR}/direct_exec_guard_check.sh"
 source_check_or_exit "${CHECKS_DIR}/shellcheck_check.sh"
+source_check_or_exit "${CHECKS_DIR}/gh_api_type_check.sh"
 source_check_or_exit "${CHECKS_DIR}/main_branch_guard.sh"
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -144,6 +146,7 @@ backup_files_found=0
 help_integrity_violations=0
 direct_exec_guard_violations=0
 shellcheck_violations=0
+gh_api_type_violations=0
 
 # 1) Shebang consistency for staged .sh files under shell-common/bash/zsh
 while IFS= read -r file; do
@@ -259,6 +262,16 @@ while IFS= read -r file; do
     fi
 done <<<"$STAGED_FILES"
 
+# 8) gh api graphql -f/-F type-mapping heuristic (warning only — issue #395)
+while IFS= read -r file; do
+    [[ "$file" != *.sh && "$file" != *.bash && "$file" != *.md ]] && continue
+    abs_path="$REPO_ROOT/$file"
+    [ -f "$abs_path" ] || continue
+    if ! check_gh_api_type_mapping "$abs_path" "$GH_API_TYPE_FILE" 2>/dev/null; then
+        ((gh_api_type_violations++))
+    fi
+done <<<"$STAGED_FILES"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Reporting and exit logic
 # ═══════════════════════════════════════════════════════════════════════════
@@ -268,7 +281,7 @@ echo -e "${BLUE}Pre-commit validation (staged files only)${NC}"
 echo ""
 
 blocking_violations=$((shebang_violations + naming_violations + function_naming_violations + alias_conflict_violations + alias_location_violations + custom_tools_sourcing_violations + auto_exec_custom_violations + auto_exec_sourced_violations + library_purity_violations + help_integrity_violations + direct_exec_guard_violations + pipe_loop_violations + shellcheck_violations))
-warning_count=$((subshell_violations + wrapper_violations + ux_violations + backup_files_found))
+warning_count=$((subshell_violations + wrapper_violations + ux_violations + backup_files_found + gh_api_type_violations))
 
 if [ $blocking_violations -eq 0 ]; then
     has_warnings=0
@@ -311,6 +324,15 @@ if [ $blocking_violations -eq 0 ]; then
         echo -e "${YELLOW}ℹ [INFO] Zsh compatibility suggestions ($zsh_emulation_violations):${NC}"
         head -n 2 "$ZSH_EMULATION_FILE" | sed 's/^/  /'
         [ $(wc -l <"$ZSH_EMULATION_FILE") -gt 2 ] && echo "  ..." && echo ""
+        echo ""
+        has_warnings=1
+    fi
+
+    if [ $gh_api_type_violations -gt 0 ] && [ -s "$GH_API_TYPE_FILE" ]; then
+        echo -e "${YELLOW}⚠ [WARNING] gh api graphql -f/-F type-mapping heuristics ($gh_api_type_violations file(s)):${NC}"
+        head -n 5 "$GH_API_TYPE_FILE" | sed 's/^/  /'
+        [ $(wc -l <"$GH_API_TYPE_FILE") -gt 5 ] && echo "  ... and more"
+        echo "  See: docs/learnings/gh-api-type-casting.md (issue #395)"
         echo ""
         has_warnings=1
     fi

--- a/shell-common/functions/gh_audit_builtin_workflows.sh
+++ b/shell-common/functions/gh_audit_builtin_workflows.sh
@@ -161,6 +161,7 @@ gh_audit_builtin_workflows() {
     #
     # GraphQL variables ($owner, $repo) are bound via -f below — single-quoted
     # query string is intentional (would otherwise interpolate at shell level).
+    # Variables: $owner String!, $repo String!
     # shellcheck disable=SC2016
     local _records
     _records=$(gh api graphql \

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -134,6 +134,8 @@ _gh_project_status_sync() {
     # Single query: per projectV2 item, return
     #   project.id | item.id | field.id | target_option.id | current_status_name
     # The current_status_name is needed for --only-from gating.
+    #
+    # Variables: $owner String!, $repo String!, $number Int!, $target String!
     local _records
     _records=$(gh api graphql \
         -f query="
@@ -296,6 +298,7 @@ _gh_project_status_query_current() {
     _owner="${_resolved%% *}"
     _repo="${_resolved#* }"
 
+    # Variables: $owner String!, $repo String!, $number Int!
     gh api graphql \
         -f query="
           query(\$owner: String!, \$repo: String!, \$number: Int!) {
@@ -348,6 +351,7 @@ EOF
 _gh_project_status_mutate() {
     # GraphQL variables ($proj, $item, ...) are NOT shell vars — they
     # are bound via the -f flags below, so single quotes are intended.
+    # Variables: $proj ID!, $item ID!, $field ID!, $option String!
     # shellcheck disable=SC2016
     gh api graphql \
         -f query='
@@ -391,6 +395,7 @@ _gh_pr_closing_issue_numbers() {
 
     # GraphQL variables ($owner, $repo, $num) are bound via the -f/-F flags
     # below, so single quotes around the query are intentional.
+    # Variables: $owner String!, $repo String!, $num Int!
     # shellcheck disable=SC2016
     gh api graphql \
         -f owner="$_owner" -f repo="$_name" -F num="$_pr" \

--- a/tests/bats/lint/gh_api_type_mapping.bats
+++ b/tests/bats/lint/gh_api_type_mapping.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/bats/lint/gh_api_type_mapping.bats
+# Issue #395 — heuristic regression guard for `gh api graphql` -f/-F mapping.
+#
+# Static-grep tests only — never invokes a live gh API call. Verifies the
+# heuristic in git/hooks/checks/gh_api_type_check.sh fires on bad fixtures
+# and stays silent on the real repo (which is expected to follow the
+# convention after the issue #395 sweep).
+
+load '../test_helper'
+
+CHECK_PATH="${_BATS_REAL_DOTFILES_ROOT}/git/hooks/checks/gh_api_type_check.sh"
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1090
+    . "$CHECK_PATH"
+    WARN_FILE="$(mktemp "$BATS_TEST_TMPDIR/warn.XXXXXX")"
+}
+
+teardown() {
+    [ -n "$WARN_FILE" ] && rm -f "$WARN_FILE"
+    teardown_isolated_home
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# Fixture-based tests: bad samples must fire, good samples must stay quiet
+# ─────────────────────────────────────────────────────────────────────────
+
+@test "signal 1: -F with literal non-numeric ID is flagged" {
+    local f="$BATS_TEST_TMPDIR/bad_F_id.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# Variables: $id ID!
+gh api graphql \
+    -f query='mutation($id: ID!) { ... }' \
+    -F id="PVTI_lADO123abc"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+    grep -q 'literal non-numeric value' "$WARN_FILE"
+}
+
+@test "signal 2: -f with literal all-digit value is flagged" {
+    local f="$BATS_TEST_TMPDIR/bad_f_int.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# Variables: $num Int!
+gh api graphql \
+    -f query='query($num: Int!) { ... }' \
+    -f num="42"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+    grep -q 'literal numeric value' "$WARN_FILE"
+}
+
+@test "signal 3: missing Variables: annotation is flagged" {
+    local f="$BATS_TEST_TMPDIR/bad_no_variables.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# A query helper that forgot the type annotation.
+gh api graphql \
+    -f query='query($owner: String!) { repository(owner: $owner) { name } }' \
+    -f owner="$_owner"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+    grep -q 'missing.*Variables' "$WARN_FILE"
+}
+
+@test "good: -f \$VAR for String! variable is silent" {
+    local f="$BATS_TEST_TMPDIR/good_f_var.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# Variables: $owner String!, $repo String!
+gh api graphql \
+    -f query='query($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { id } }' \
+    -f owner="$_owner" \
+    -f repo="$_repo"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+@test "good: -F \$VAR for Int! variable is silent" {
+    local f="$BATS_TEST_TMPDIR/good_F_var.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# Variables: $num Int!
+gh api graphql \
+    -f query='query($num: Int!) { ... }' \
+    -F num="$_num"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+@test "scope: file without 'gh api graphql' is silent" {
+    local f="$BATS_TEST_TMPDIR/unrelated.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+echo "no graphql here"
+gh api repos/foo/bar/issues
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+@test "scope: docs files are skipped (prose mentions, not callers)" {
+    # Docs that describe the convention will mention `gh api graphql`
+    # in prose. The heuristic skips them so the docs file documenting
+    # the convention does not trigger itself.
+    local d="$BATS_TEST_TMPDIR/docs/learnings"
+    mkdir -p "$d"
+    local f="$d/gh-api-type-casting.md"
+    cat >"$f" <<'EOF'
+# Doc — `gh api graphql`의 `-f` vs `-F`
+gh api graphql -f query='...' -F id="PVTI_xxx"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+@test "scope: explicit 'gh-api-type-check: skip-file' marker opts out" {
+    local f="$BATS_TEST_TMPDIR/exempt_via_marker.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# gh-api-type-check: skip-file
+# This file documents bad patterns intentionally.
+gh api graphql -f query='...' -F id="PVTI_xxx"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# Real-repo regression: every checked-in GraphQL caller is convention-clean
+# ─────────────────────────────────────────────────────────────────────────
+
+@test "real repo: shell-common/functions/gh_project_status.sh is clean" {
+    local f="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_project_status.sh"
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    if [ "$status" -ne 0 ]; then
+        echo "Findings:"
+        cat "$WARN_FILE"
+    fi
+    [ "$status" -eq 0 ]
+}
+
+@test "real repo: shell-common/functions/gh_audit_builtin_workflows.sh is clean" {
+    local f="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_audit_builtin_workflows.sh"
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    if [ "$status" -ne 0 ]; then
+        echo "Findings:"
+        cat "$WARN_FILE"
+    fi
+    [ "$status" -eq 0 ]
+}

--- a/tests/bats/lint/gh_api_type_mapping.bats
+++ b/tests/bats/lint/gh_api_type_mapping.bats
@@ -27,8 +27,8 @@ teardown() {
 # Fixture-based tests: bad samples must fire, good samples must stay quiet
 # ─────────────────────────────────────────────────────────────────────────
 
-@test "signal 1: -F with literal non-numeric ID is flagged" {
-    local f="$BATS_TEST_TMPDIR/bad_F_id.sh"
+@test "signal 1: -F with double-quoted literal non-numeric ID is flagged" {
+    local f="$BATS_TEST_TMPDIR/bad_F_id_dq.sh"
     cat >"$f" <<'EOF'
 #!/bin/sh
 # Variables: $id ID!
@@ -41,14 +41,44 @@ EOF
     grep -q 'literal non-numeric value' "$WARN_FILE"
 }
 
-@test "signal 2: -f with literal all-digit value is flagged" {
-    local f="$BATS_TEST_TMPDIR/bad_f_int.sh"
+@test "signal 1: -F with single-quoted literal non-numeric ID is flagged" {
+    # PR #407 review: also flag single-quoted literals.
+    local f="$BATS_TEST_TMPDIR/bad_F_id_sq.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# Variables: $id ID!
+gh api graphql \
+    -f query='mutation($id: ID!) { ... }' \
+    -F id='PVTI_lADO123abc'
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+    grep -q 'literal non-numeric value' "$WARN_FILE"
+}
+
+@test "signal 2: -f with double-quoted literal all-digit value is flagged" {
+    local f="$BATS_TEST_TMPDIR/bad_f_int_dq.sh"
     cat >"$f" <<'EOF'
 #!/bin/sh
 # Variables: $num Int!
 gh api graphql \
     -f query='query($num: Int!) { ... }' \
     -f num="42"
+EOF
+    run check_gh_api_type_mapping "$f" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+    grep -q 'literal numeric value' "$WARN_FILE"
+}
+
+@test "signal 2: -f with single-quoted literal all-digit value is flagged" {
+    # PR #407 review: also flag single-quoted literals.
+    local f="$BATS_TEST_TMPDIR/bad_f_int_sq.sh"
+    cat >"$f" <<'EOF'
+#!/bin/sh
+# Variables: $num Int!
+gh api graphql \
+    -f query='query($num: Int!) { ... }' \
+    -f num='42'
 EOF
     run check_gh_api_type_mapping "$f" "$WARN_FILE"
     [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary
- `gh api graphql` 호출의 `-f` (String\!/ID\!) vs `-F` (Int\!) 매핑 컨벤션을 정착.
- 기존 5개 GraphQL 호출부를 audit — 모두 정확, 별도 follow-up 이슈 불필요.
- bats 휴리스틱 + pre-commit warning hook + 학습 노트로 회귀 가드 3중화.

## Changes
- **shell-common/functions/gh_project_status.sh** — 4개 GraphQL 호출부에
  `# Variables: $x Type\!, ...` 컨벤션 주석 추가 (sync query, verify query,
  mutate, closing-issues helper).
- **shell-common/functions/gh_audit_builtin_workflows.sh** — Variables 주석 추가.
- **새 `git/hooks/checks/gh_api_type_check.sh`** — 세 시그널의 휴리스틱
  체크 (literal-non-numeric `-F`, literal-numeric `-f`, Variables 주석 부재).
  warning 수준 (false positive 위험) — `docs/`, 체크 자체, bats 테스트,
  `gh-api-type-check: skip-file` 마커가 있는 파일은 스킵.
- **`git/hooks/pre-commit`** — 새 체크 등록 + 경고 출력 섹션 추가.
- **새 `tests/bats/lint/gh_api_type_mapping.bats`** — 10개 정적 grep 테스트
  (3 bad / 5 good incl. carve-outs / 2 real-repo). live API 호출 없음.
- **새 `docs/learnings/gh-api-type-casting.md`** — `-f` vs `-F` 함정 노트
  + 호환성 매트릭스. README index에 5번째 항목으로 추가.

## Audit 결과 (참고)
설계 코멘트의 8개 위치 중 6개 SKILL.md (gh-commit, gh-pr-merge,
gh-pr-approve, gh-pr-reply, gh-pr-merge-emergency, gh-pr-resolve-conflict)
는 REST 엔드포인트만 사용하고 GraphQL을 호출하지 않으므로 컨벤션이
적용되지 않음. 실제 GraphQL surface는 `shell-common/functions/`의
2개 파일 5개 호출부로 좁혀지며 모두 매핑 정확.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/lint` — 10/10 pass.
- [x] `shellcheck` 경고 없음 (신규 추가 파일 기준).
- [x] 휴리스틱이 fixture 'bad' 케이스에 정확히 발화.
- [x] 휴리스틱이 fixture 'good' + 실제 repo 파일에 false positive 없음.
- [ ] 리뷰어가 `# Variables: ...` 주석이 query 타입 선언과 일치하는지 확인.

## Related
Closes #395

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~4 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
