### PR TITLE
feat(claude): gh:pr 보드 sync을 PostToolUse hook으로 분리 (#390)

### DIFF
--- a/claude/hooks/post-gh-pr-create.sh
+++ b/claude/hooks/post-gh-pr-create.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# claude/hooks/post-gh-pr-create.sh
+# Claude Code PostToolUse hook for `gh pr create`.
+#
+# Reads the PostToolUse event JSON from stdin, filters to Bash invocations
+# whose command starts with `gh pr create`, parses the PR URL from the
+# tool output, and syncs project-board status:
+#
+#   * PR card  → "In review"  (unconditional — verify pair handles races)
+#   * Linked issues (Closes #N) → "In progress" with --only-from guard so
+#     a re-opened, already-Done issue is not dragged backwards.
+#
+# Why a hook instead of inlining in claude/skills/gh-pr/SKILL.md Step 7:
+#   Three places try to sync after PR creation — the skill body, this hook,
+#   and (in AgentToolbox-style repos) GitHub project builtins. Triple-syncing
+#   wastes tokens and widens the race window. When this hook is installed the
+#   skill detects it (claude/skills/gh-pr/references/project-board-sync.md
+#   "Hook auto-skip") and bows out of inline sync — leaving exactly one
+#   responsible writer per environment. Idempotence is still guaranteed by
+#   the verify pair inside _gh_project_status_sync.
+#
+# Always exits 0 — board sync is best-effort, never blocks the user's flow.
+#
+# Reference: issue #390, design SSOT on parent issue #384 (good-point 9 +
+# conflict C).
+
+set -u
+
+# Read the PostToolUse payload from stdin. Empty input → bow out.
+input=$(cat 2>/dev/null) || exit 0
+[ -n "$input" ] || exit 0
+
+# Need jq to parse the JSON envelope. Without it the hook becomes a no-op
+# (fallback inline sync in the skill takes over).
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+[ "$tool_name" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+# Match `gh pr create` even when prefixed by env-vars (`FOO=bar gh pr create`)
+# or `command gh pr create`. Plain prefix-match would miss those.
+printf '%s' "$cmd" | grep -qE '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
+
+# `output` is the gh-cli stdout; tool_response shape varies between Claude
+# Code versions, so fall back through a couple of plausible field names
+# before giving up.
+output=$(printf '%s' "$input" |
+    jq -r '.tool_response.output // .tool_response.stdout // .tool_response // ""' \
+        2>/dev/null) || exit 0
+
+# `gh pr create` prints the new PR URL on success. Pull the trailing PR
+# number out of the first such URL we see.
+pr_num=$(printf '%s' "$output" |
+    grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' |
+    head -1 |
+    grep -oE '[0-9]+$')
+[ -n "$pr_num" ] || exit 0
+
+# Source the shared board-sync helper. Failure to source → silent no-op.
+_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+[ -r "$_helper" ] || exit 0
+# shellcheck disable=SC1090
+. "$_helper" 2>/dev/null || exit 0
+
+# Need owner/repo to look up linked issues. `_gh_project_status_sync` itself
+# does not need GH_REPO (it discovers projects via the item's node id), but
+# `_gh_pr_closing_issue_numbers` does.
+GH_REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)}"
+export GH_REPO
+
+printf '[post-gh-pr-create] PR #%s → "In review"\n' "$pr_num" >&2
+_gh_project_status_sync pr "$pr_num" "In review"
+
+if [ -n "$GH_REPO" ]; then
+    for _issue in $(_gh_pr_closing_issue_numbers "$pr_num" "$GH_REPO" 2>/dev/null); do
+        _gh_project_status_sync issue "$_issue" "In progress" \
+            --only-from "Backlog,Ready,In review"
+    done
+fi
+
+exit 0

--- a/claude/settings.template.json
+++ b/claude/settings.template.json
@@ -52,6 +52,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/post-gh-pr-create.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -98,8 +98,11 @@ exist in the repo (`gh label list`) — never create new ones. See
 ## Step 7: Sync Project Board Status
 
 Read `references/project-board-sync.md` for the helper-source snippet that
-pushes the new PR's project-board card to `In review`. Auto-skips when no
-projectV2 board is attached.
+pushes the new PR's project-board card to `In review`. The reference also
+documents the PostToolUse hook auto-skip (issue #390): if a
+`post-gh-pr-create.sh` / `post-pr-create-status.sh` hook is installed, this
+step is delegated to the hook and the inline sync is skipped to avoid
+triple-syncing. Auto-skips when no projectV2 board is attached either way.
 
 ## Step 8: Report
 

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -3,6 +3,40 @@
 After the PR is created, sync cards on the kanban so reviewers see the PR and
 the linked Issues are at the right column without a manual drag.
 
+## Hook auto-skip (issue #390)
+
+If a PostToolUse hook is going to do this work, the skill must NOT run the
+inline sync — triple-syncing (skill + hook + GitHub builtin) wastes tokens
+and widens the race window. Detect the hook by file presence and skip:
+
+```bash
+hook_skip=0
+for hook_path in \
+    "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/post-pr-create-status.sh" \
+    "$HOME/.claude/hooks/post-gh-pr-create.sh" \
+    "$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh"
+do
+    if [ -x "$hook_path" ]; then
+        hook_skip=1
+        printf '[gh-pr] board sync delegated to PostToolUse hook (%s) — skipping inline.\n' "$hook_path" >&2
+        break
+    fi
+done
+
+if [ "$hook_skip" -eq 0 ]; then
+    # Run the snippet below.
+    :
+fi
+```
+
+The three paths cover (a) AgentToolbox-style in-repo hook, (b) a runtime
+copy at `~/.claude/hooks/`, and (c) the dotfiles SSOT location. When **any**
+exists, the inline snippet is skipped — the hook (or the AgentToolbox hook)
+will handle it. When none exist, the inline snippet runs as a fallback,
+preserving behavior for environments without hook support. Idempotence of
+`_gh_project_status_sync` (verify pair, issue #393) absorbs the case where
+both a dotfiles hook and an AgentToolbox hook fire.
+
 ## Why "In review" with no guard (PR card)
 
 The PR lifecycle is linear. `In review` is the canonical resting state from

--- a/tests/bats/skills/post_gh_pr_create_hook.bats
+++ b/tests/bats/skills/post_gh_pr_create_hook.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# tests/bats/skills/post_gh_pr_create_hook.bats
+# Verify the PostToolUse hook documented in
+#   claude/hooks/post-gh-pr-create.sh
+# Source-of-truth fixture: _fixtures/post_gh_pr_create_hook.sh
+# (provides a fake gh_project_status.sh that records every call).
+#
+# Five cases drawn from issue #390's compatibility matrix:
+#   1. tool_name != Bash               → exit 0, no sync
+#   2. Bash + non-`gh pr create` cmd   → exit 0, no sync
+#   3. Bash + `gh pr create` + URL     → 1 call: pr <num> "In review"
+#   4. Bash + `gh pr create` + no URL  → exit 0, no sync (graceful)
+#   5. Empty stdin                     → exit 0, no sync (graceful)
+
+load '../test_helper'
+
+HOOK="${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/post-gh-pr-create.sh"
+
+setup() {
+    setup_isolated_home
+    # Stage a fake shell-common with a stub gh_project_status.sh that
+    # records every call into $CALL_LOG. The hook sources via
+    # $SHELL_COMMON/functions/gh_project_status.sh, so wiring SHELL_COMMON
+    # to a tmp tree lets us observe sync calls without a live projectV2.
+    FAKE_SHELL_COMMON="$TEST_TEMP_HOME/shell-common"
+    mkdir -p "$FAKE_SHELL_COMMON/functions"
+    CALL_LOG="$TEST_TEMP_HOME/calls.log"
+    : > "$CALL_LOG"
+    cat > "$FAKE_SHELL_COMMON/functions/gh_project_status.sh" <<EOF
+_gh_project_status_sync() { printf 'sync %s\n' "\$*" >> "$CALL_LOG"; return 0; }
+_gh_pr_closing_issue_numbers() { return 0; }  # no linked issues by default
+EOF
+    export SHELL_COMMON="$FAKE_SHELL_COMMON"
+    # Block real gh from running — the hook only calls `gh repo view` for
+    # GH_REPO; passing GH_REPO directly avoids the network and the PATH lookup.
+    export GH_REPO="owner/repo"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset SHELL_COMMON GH_REPO
+}
+
+@test "post-gh-pr-create: tool_name != Bash → no sync" {
+    payload='{"tool_name":"Read","tool_input":{"command":"gh pr create"},"tool_response":{"output":"https://github.com/owner/repo/pull/42"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -s "$CALL_LOG" ]
+}
+
+@test "post-gh-pr-create: Bash + non-pr-create command → no sync" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr list"},"tool_response":{"output":"https://github.com/owner/repo/pull/42"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -s "$CALL_LOG" ]
+}
+
+@test "post-gh-pr-create: Bash + gh pr create + PR URL → sync called" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"},"tool_response":{"output":"https://github.com/owner/repo/pull/123\n"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    # Expect exactly one sync invocation for the PR card itself.
+    assert_output --partial 'PR #123 → "In review"'
+    grep -q '^sync pr 123 In review$' "$CALL_LOG"
+}
+
+@test "post-gh-pr-create: Bash + gh pr create + no URL → no sync" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create"},"tool_response":{"output":"error: something went wrong"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -s "$CALL_LOG" ]
+}
+
+@test "post-gh-pr-create: empty stdin → no sync" {
+    run bash -c "printf '' | '$HOOK'"
+    assert_success
+    [ ! -s "$CALL_LOG" ]
+}
+
+@test "post-gh-pr-create: env-prefixed gh pr create still matches" {
+    # Regression for the regex — `FOO=bar gh pr create` and `command gh pr create`
+    # should both trigger. Without the (^|space) anchor, prefixes break detection.
+    payload='{"tool_name":"Bash","tool_input":{"command":"GH_TOKEN=x gh pr create --draft"},"tool_response":{"output":"https://github.com/owner/repo/pull/7"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    grep -q '^sync pr 7 In review$' "$CALL_LOG"
+}


### PR DESCRIPTION
## Summary
- `gh:pr` Step 7 의 board sync 호출을 PostToolUse hook 으로 분리해 skill 본문 축소 + 다중 호출 (skill + AT hook + builtin) 방지.
- hook 미설치 환경 fallback 보존 — `_gh_project_status_sync` 의 verify pair (#393) 가 idempotence 보장.
- Phase 1 한정 — severity 라벨 전파 (Phase 2) 는 별도 이슈로.

## Changes
- `claude/hooks/post-gh-pr-create.sh` (신규) — Bash matcher PostToolUse hook. stdin JSON 에서 `tool_name=Bash` + `gh pr create` 명령을 필터링, 출력에서 PR URL 을 파싱해 `_gh_project_status_sync pr <N> "In review"` 와 `_gh_pr_closing_issue_numbers` 기반 linked-issue → "In progress" (`--only-from "Backlog,Ready,In review"`) 동기화. 항상 `exit 0` (best-effort).
- `claude/settings.template.json` — `hooks.PostToolUse.[Bash matcher]` 항목에 hook 등록.
- `claude/skills/gh-pr/SKILL.md` Step 7 + `references/project-board-sync.md` — hook 파일 존재 시 inline sync skip 로직 명시. 세 검사 경로:
  - `$REPO_ROOT/.claude/hooks/post-pr-create-status.sh` (AgentToolbox-style)
  - `$HOME/.claude/hooks/post-gh-pr-create.sh` (runtime claude hooks)
  - `$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh` (dotfiles SSOT)
  하나라도 발견되면 `[gh-pr] board sync delegated to ...` 로그 후 inline sync skip. 미설치 환경은 기존 fallback.
- `tests/bats/skills/post_gh_pr_create_hook.bats` (신규) — filter/parse 회귀 6 cases:
  1. tool_name \!= Bash → no sync
  2. Bash + non-`gh pr create` → no sync
  3. Bash + `gh pr create` + URL → sync called with parsed PR number
  4. Bash + `gh pr create` + no URL → no sync (graceful)
  5. empty stdin → no sync (graceful)
  6. env-prefixed `GH_TOKEN=x gh pr create` → still matches

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/post_gh_pr_create_hook.bats` — 6/6 pass.
- [x] `bats tests/bats/{functions,init,integrations,skills,tools}` 회귀 — 581/581 pass.
- [x] `shellcheck -x -e SC1090,SC1091 claude/hooks/post-gh-pr-create.sh tests/bats/skills/post_gh_pr_create_hook.bats` clean.
- [x] `shfmt -d -i 4 claude/hooks/post-gh-pr-create.sh` clean.
- [x] `jq` 검증: `.hooks.PostToolUse | length == 1`.
- [ ] 머지 후 차기 PR 생성 시 hook 발화 + skill `[gh-pr] board sync delegated ...` 로그 확인.
- [ ] AgentToolbox 환경에서 dotfiles hook + AT hook 둘 다 발화해도 보드 Status 정상 (verify pair idempotence) 확인.

## Related
Closes #390

Refs:
- 검토 노트 — #384
- 좋은 점 9 (PostToolUse hook) — https://github.com/dEitY719/dotfiles/issues/384#issuecomment-4403809407
- 충돌 C (중복 호출 방지) — https://github.com/dEitY719/dotfiles/issues/384#issuecomment-4404284587


---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~2 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
