### PR TITLE
feat(gh-pr): stacked PR 자동 감지 + 수동 override 플래그 (#394)

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -22,25 +22,51 @@ its content verbatim, then stop. No API calls.
 Bundle the current branch's commits into a GitHub PR with a well-structured
 body. Push the branch if needed. Return the PR URL.
 
-## Step 1: Determine Base Branch and State (parallel)
+## Step 1: Parse Args, Resolve Base Branch, Gather State
 
 Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 
-Run in a single message:
+### Step 1a: Parse args + resolve base via stacked-PR detection
+
+Read `references/stacked-pr.md` for the SSOT bash bound to
+`parse_stacked_args`, `is_stacked_pr_repo`, and
+`find_parent_pr_candidates`, plus the dispatch block ("How Step 1 of
+SKILL.md ties it together"). Paste the four functions and the dispatch
+block verbatim. They set:
+
+- `BASE_BRANCH` — final base branch for `gh pr create --base`
+- `PARENT_PR` — non-empty PR number when the PR is stacked on another
+  open PR; empty otherwise
+- `ISSUE_NUMBER` — first positional integer arg if any (legacy
+  `/gh-pr 123` form)
+
+Honour `parse_stacked_args`'s exit codes:
+
+- rc=2 — mutually-exclusive flags (`--no-stack` / `--parent-pr` /
+  `--base`); abort, do not push.
+- rc=3 — bad value for `--parent-pr` or `--base`; abort, do not push.
+
+`PARENT_PR` flows into the body template "Depends on #N" rule
+(`pr-body-template.md`). `BASE_BRANCH` flows into Step 5's
+`gh pr create --base "$BASE_BRANCH"`.
+
+### Step 1b: Gather range + push state (parallel)
+
+Run in a single message, using `$BASE_BRANCH` from Step 1a:
 
 - `git rev-parse --abbrev-ref HEAD` — current branch
-- `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` — base
 - `git status`
 - `git fetch origin`
-- `git log --oneline <base>..HEAD` — every commit in the range
-- `git diff <base>...HEAD` — full diff
+- `git log --oneline "$BASE_BRANCH"..HEAD` — every commit in the range
+- `git diff "$BASE_BRANCH"...HEAD` — full diff
 - `git rev-parse --symbolic-full-name @{u} 2>/dev/null` — upstream check
 
 **Stop conditions:**
 
-- If current branch equals base branch → tell the user to create a feature
-  branch first.
-- If `git log <base>..HEAD` is empty → tell the user there's nothing to PR.
+- If current branch equals `BASE_BRANCH` → tell the user to create a
+  feature branch first.
+- If `git log "$BASE_BRANCH"..HEAD` is empty → tell the user there's
+  nothing to PR.
 
 ## Step 2: Analyze ALL Commits in the Range
 
@@ -86,7 +112,8 @@ printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%
 ## Step 5: Push and Create
 
 Read `references/push-and-create.md` for the upstream-state push policy and
-the `gh pr create` command (uses `mktemp` body file, `--assignee @me`).
+the `gh pr create` command (uses `mktemp` body file, `--assignee @me`,
+`--base "$BASE_BRANCH"` from Step 1a).
 
 ## Step 6: Apply Labels
 

--- a/claude/skills/gh-pr/references/constraints.md
+++ b/claude/skills/gh-pr/references/constraints.md
@@ -11,9 +11,20 @@ either "force push" or "rebase first" — do not pick for them.
 
 ## Base branch
 
-Never target a base other than the repo's default branch (resolved via
-`gh repo view --json defaultBranchRef`) unless the user explicitly asked
-for a different base on the slash-command invocation.
+The base branch is decided in Step 1a (`references/stacked-pr.md`):
+
+1. Default branch (`gh repo view --json defaultBranchRef`) when the
+   repo has no stacked-PR signals — solo / non-stacked workflow.
+2. Auto-detected parent PR's head ref when the repo opts into stacked
+   PRs *and* exactly one open PR is an ancestor of HEAD.
+3. The user-supplied target when one of `--no-stack` / `--parent-pr <N>`
+   / `--base <branch>` was passed (mutually exclusive — combining any
+   two aborts).
+
+Never target any base outside those three sources. In particular,
+never auto-stack on a repo that does not match `is_stacked_pr_repo`,
+and never silently downgrade to the default branch when the user
+explicitly passed `--parent-pr` or `--base`.
 
 ## AI footers
 

--- a/claude/skills/gh-pr/references/help.md
+++ b/claude/skills/gh-pr/references/help.md
@@ -6,29 +6,77 @@
 |---|------|---------|-------------|
 | 1 | issue-number, or `-h`/`--help`/`help` | auto-detected | Link PR to this GitHub issue via `Closes #N` / `Refs #N` in the body |
 
+## Stacked-PR flags (mutually exclusive)
+
+| Flag | Effect |
+|---|---|
+| `--no-stack` | force base = repo default branch, skip auto-detect |
+| `--parent-pr <N>` | force stack on PR #N (base = #N's head ref, body adds `Depends on #N`) |
+| `--base <branch>` | force base = `<branch>` (any branch name) |
+
+Auto-detect (default) is a no-op on solo / non-stacked repos. See
+"Behavior" below for what triggers it.
+
 ## Usage
 
-- `/gh-pr` — push the current branch if needed, then open a PR against
-  the repo's default branch covering every commit in the range
-- `/gh-pr 123` — same, but force-link to issue `#123` regardless of chat/commits
-- `/gh-pr -h` / `--help` / `help` — print this help
+- `/gh-pr` — push the current branch if needed, then open a PR.
+  Resolves base via auto-detect (default branch on solo repos).
+- `/gh-pr 123` — same, force-link to issue `#123`.
+- `/gh-pr --no-stack` — auto-detect off, base = default branch.
+- `/gh-pr --parent-pr 201` — auto-detect off, stack on PR #201.
+- `/gh-pr --base release/v2.0` — auto-detect off, custom base branch.
+- `/gh-pr -h` / `--help` / `help` — print this help.
+
+## Behavior
+
+Auto-detect fires only when **both** conditions hold:
+
+1. The repo opts into stacked PRs (one of: workflow file
+   `.github/workflows/stacked-closes-rollup.yml`, the keywords
+   `claude-enter-issue` / `stacked PR` / `Depends on #` in
+   `CLAUDE.md` / `AGENTS.md` / `.claude/github-integration.md`, or an
+   `agent-toolbox/` directory).
+2. There is exactly one open PR whose head ref is an ancestor of HEAD
+   *and* yields a more recent merge-base than the default branch.
+
+Otherwise the base falls back to the repo default branch — solo /
+non-stacked repos (the dotfiles default) see no behavioural change.
+
+## Examples
+
+```
+# dotfiles solo (auto-detect inactive — no signals)
+$ /gh-pr                        →  base=main, no Depends footer
+
+# Working in a stacked-PR repo, parent unique
+$ /gh-pr                        →  "Stacking on PR #201 (auto-detected)"
+                                   base=feat/parent-branch
+                                   body has "Depends on #201"
+
+# Auto-detect was wrong — escape hatch
+$ /gh-pr --no-stack             →  base=main forced
+$ /gh-pr --parent-pr 205        →  base=PR #205 head
+$ /gh-pr --base release/v2.0    →  base=release/v2.0
+```
 
 ## What the skill does
 
-1. Resolves the base branch (`gh repo view --json defaultBranchRef`) and
-   checks the current branch is not the base. Fetches `origin` to make
-   sure the range is computed against up-to-date refs.
+1. Parses args (`--no-stack` / `--parent-pr` / `--base`), then resolves
+   the base branch via the stacked-PR auto-detect flow (see
+   `references/stacked-pr.md`). Fetches `origin` to make sure the range
+   is computed against up-to-date refs.
 2. Reads **all** commits in `<base>..HEAD` — the PR body must cover every
    commit, not only HEAD. Groups them by theme for the Summary.
 3. Resolves the linked issue using the same precedence as `gh:commit`:
    explicit arg → recent chat → commit footers → none.
 4. Drafts title + body per `references/pr-body-template.md`, matching the
    language dominant in existing commits (Korean commits → Korean PR).
+   When stacked on a parent PR, inserts `Depends on #N` in the body.
 5. Pushes the branch (`git push -u origin HEAD` if no upstream, `git push`
    if ahead). Diverged upstream → stops and asks; never force-pushes on
    its own.
-6. Creates the PR via `gh pr create --assignee @me` using a `mktemp` body
-   file. Always self-assigns.
+6. Creates the PR via `gh pr create --assignee @me --base "$BASE_BRANCH"`
+   using a `mktemp` body file. Always self-assigns.
 7. Applies labels derived from conventional-commit types (feat, fix, docs,
    etc.) plus scope labels — but only labels that **already exist** in the
    repo. Never creates new labels.
@@ -37,7 +85,12 @@
 ## What the skill will NOT do
 
 - Force-push without explicit user approval.
-- Target a base branch other than the repo's default branch unless told.
+- Run auto-stack detection on a repo without stacked-PR signals — solo
+  repos always default to the repo's default branch.
+- Combine `--no-stack` / `--parent-pr` / `--base` (mutually exclusive,
+  rc=2 abort).
+- Mutate parent PR bodies — cross-PR rollup is the downstream repo's
+  job (e.g. AgentToolbox `stacked-closes-rollup.yml`).
 - Include the `🤖 Generated with Claude Code` footer unless the repo
   already uses that convention in existing PRs.
 - Skip "minor" commits in the Summary — the range is the contract.
@@ -50,5 +103,10 @@
 - **Good**: Feature branch with 3 commits, `/gh-pr` — body covers all 3,
   links any `#N` in chat, returns the URL.
 - **Good**: `/gh-pr 42` after a hotfix — body includes `Closes #42`.
+- **Good**: AgentToolbox stacked work, `/gh-pr` — auto-detects parent
+  PR and inserts `Depends on #N`.
+- **Good**: Hotfix landing on a release branch, `/gh-pr --base release/v2.0`.
 - **Bad**: running on `main` — skill stops with "create a feature branch first".
 - **Bad**: running with an empty `<base>..HEAD` — skill stops with "nothing to PR".
+- **Bad**: `/gh-pr --no-stack --parent-pr 5` — flags are mutually
+  exclusive, skill aborts before push.

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -42,6 +42,35 @@ Refs #<N>
 - Omit the `## Related` section entirely only when no issue number
   is known.
 
+### Stacked-PR `Depends on` insertion
+
+When Step 1a set `PARENT_PR` (auto-detected or `--parent-pr <N>` was
+passed), insert a `Depends on #<PARENT_PR>` line into the
+`## Related` section, alongside `Closes #<N>` / `Refs #<N>` if any:
+
+```markdown
+## Related
+Closes #42
+Depends on #201
+```
+
+Rules:
+
+- The line is added **only** when `PARENT_PR` is non-empty. `--no-stack`,
+  `--base <branch>`, and the no-signal solo path all leave it empty.
+- Order: any `Closes` / `Refs` line first, then `Depends on`. GitHub
+  rendering treats both as cross-references; the order is conventional.
+- Never mutate the parent PR's body to add a back-reference. Cross-PR
+  rollup is the downstream repo's job (e.g. AgentToolbox's
+  `stacked-closes-rollup.yml` workflow harvests `Depends on` lines).
+- If `## Related` would otherwise be omitted (no issue link), still add
+  the section with just the `Depends on` line:
+
+  ```markdown
+  ## Related
+  Depends on #201
+  ```
+
 ## Create Command
 
 Write the body to a unique temp file via `mktemp` (avoids concurrent-run
@@ -51,11 +80,15 @@ collisions), then run:
 BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 # ... write the drafted body to "$BODY" ...
 gh pr create \
-  --base <base> \
+  --base "$BASE_BRANCH" \
   --title "<title>" \
   --body-file "$BODY" \
   --assignee @me
 ```
+
+`$BASE_BRANCH` is bound by Step 1a (`references/stacked-pr.md`); it is
+either the repo default branch or — when stacking — a parent PR's
+head ref / a user-supplied `--base` value.
 
 `--assignee @me` is always applied — the skill self-assigns every PR.
 

--- a/claude/skills/gh-pr/references/push-and-create.md
+++ b/claude/skills/gh-pr/references/push-and-create.md
@@ -19,3 +19,9 @@ Detect upstream with `git rev-parse --symbolic-full-name @{u} 2>/dev/null`
 Once the push succeeds, create the PR with the command and flags documented
 in `references/pr-body-template.md` (mktemp body file, `--assignee @me`,
 labels applied after creation).
+
+The base branch passed to `gh pr create --base` is `$BASE_BRANCH` from
+Step 1a — that variable is set by the stacked-PR detection block (see
+`references/stacked-pr.md`) and may be either the repo default branch
+or the head ref of an auto-detected / explicitly-overridden parent PR.
+Always use the variable; never hard-code the default branch name here.

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -51,9 +51,11 @@ behavioural change.
    │   prints "Stacking on PR #<num> (auto-detected)"
    │   no prompt
    │
-   └─ 2+ candidates → ask the user once
-       "Multiple parent candidates: PR #N1, #N2. Stack on which? [N1/N2/main]"
-       (selection becomes BASE_BRANCH + PARENT_PR or default)
+   └─ 2+ candidates → dispatch returns rc=4 + candidate list on stderr
+       (bash is non-interactive in Claude Code — `read` would hang).
+       The AI executor asks the user via the platform's question
+       primitive, then re-invokes `gh:pr` with `--parent-pr <N>` /
+       `--base <branch>` / `--no-stack` based on the answer.
 ```
 
 ## Manual override (escape hatches)
@@ -83,7 +85,7 @@ is_stacked_pr_repo() {
     local _f
     for _f in CLAUDE.md AGENTS.md .claude/github-integration.md; do
         [ -f "$_repo_root/$_f" ] || continue
-        grep -qE 'claude-enter-issue|stacked.PR|Depends on #' \
+        grep -qE 'claude-enter-issue|stacked[[:space:]-]?PR|Depends on #' \
             "$_repo_root/$_f" 2>/dev/null && return 0
     done
 
@@ -123,6 +125,10 @@ parse_stacked_args() {
             --parent-pr)
                 _flags_seen=$((_flags_seen + 1))
                 STACK_MODE=parent-pr
+                if [ $# -lt 2 ]; then
+                    printf 'gh:pr: --parent-pr requires a PR number\n' >&2
+                    return 3
+                fi
                 STACK_PARENT="$2"
                 if ! printf '%s' "${STACK_PARENT-}" | grep -qE '^[1-9][0-9]*$'; then
                     printf 'gh:pr: --parent-pr requires a positive integer (got %s)\n' \
@@ -134,6 +140,10 @@ parse_stacked_args() {
             --base)
                 _flags_seen=$((_flags_seen + 1))
                 STACK_MODE=base
+                if [ $# -lt 2 ]; then
+                    printf 'gh:pr: --base requires a branch name\n' >&2
+                    return 3
+                fi
                 STACK_BASE="$2"
                 if [ -z "${STACK_BASE-}" ]; then
                     printf 'gh:pr: --base requires a branch name\n' >&2
@@ -258,16 +268,16 @@ case "$STACK_MODE" in
                     BASE_BRANCH="${CANDIDATES#*:}"
                     printf 'Stacking on PR #%s (auto-detected)\n' "$PARENT_PR" ;;
                 *)
-                    # 2+ candidates — ask the user once.
-                    printf 'Multiple parent candidates:\n%s\n' "$CANDIDATES"
-                    read -r CHOICE
-                    if [ "$CHOICE" = "$DEFAULT_BRANCH" ] || [ "$CHOICE" = "main" ]; then
-                        BASE_BRANCH="$DEFAULT_BRANCH" ; PARENT_PR=
-                    else
-                        PARENT_PR="$CHOICE"
-                        BASE_BRANCH=$(gh pr view "$PARENT_PR" \
-                            --json headRefName -q .headRefName)
-                    fi
+                    # 2+ candidates — bash cannot prompt safely (Claude Code is
+                    # non-interactive; `read` would hang the runtime). Print the
+                    # candidate set and exit the auto branch with both vars
+                    # unset; the AI executor handles the choice via the
+                    # platform's question primitive (e.g. AskUserQuestion in
+                    # Claude Code) and re-runs the case for `parent-pr` /
+                    # `base` / `no-stack` based on the user's reply.
+                    printf 'Multiple parent candidates:\n%s\n' "$CANDIDATES" >&2
+                    printf 'gh:pr: ambiguous parent — ask user, then re-invoke with --parent-pr / --base / --no-stack\n' >&2
+                    return 4
                     ;;
             esac
         else
@@ -280,6 +290,13 @@ esac
 `BASE_BRANCH` flows into Step 5 (`gh pr create --base "$BASE_BRANCH"`).
 `PARENT_PR`, when set, flows into the body-template "Depends on #N"
 insertion documented in `pr-body-template.md`.
+
+When the dispatch returns rc=4 (ambiguous parent), the AI executor — not
+the shell — must surface the candidate list to the user via the
+platform's question primitive (e.g. `AskUserQuestion` in Claude Code).
+Once the user picks one, re-invoke `gh:pr` with the matching escape
+hatch flag (`--parent-pr <N>`, `--base <branch>`, or `--no-stack`).
+This avoids hanging on `read` in non-interactive runtimes.
 
 ## Compatibility matrix (what the bats suite must keep covering)
 

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -1,0 +1,299 @@
+# Stacked PR Auto-Detection — Stage 1/2 logic for `gh:pr`
+
+Applied in Step 1 of `gh:pr/SKILL.md`. Decides the PR's base branch — and
+when applicable, an explicit parent PR — without making the user think
+about flags. Solo / non-stacked repos (the dotfiles default) see no
+behavioural change.
+
+> SSOT for the bash bound to `is_stacked_pr_repo`,
+> `parse_stacked_args`, and `find_parent_pr_candidates`. The bats
+> regression suite at `tests/bats/skills/gh_pr_stacked_detect.bats`
+> mirrors the same functions verbatim via
+> `tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh` — when this
+> file changes, mirror the change there too (and vice versa).
+
+## Design principles
+
+1. The user types `/gh-pr` once. Flags exist only as escape hatches.
+2. Backwards-compat is unconditional. No repo signal → auto-detect
+   never fires. dotfiles solo workflow is unchanged.
+3. Auto-detect can be overridden when wrong (`--no-stack`, `--parent-pr`,
+   `--base`).
+4. dotfiles never mutates the parent PR body. Cross-PR rollup is the
+   downstream repo's concern (e.g. AgentToolbox's
+   `stacked-closes-rollup.yml` workflow).
+
+## Auto-detect flow
+
+```
+/gh-pr called
+   │
+   ▼
+[Stage 1] is_stacked_pr_repo $REPO_ROOT
+   │  ├─ workflow .github/workflows/stacked-closes-rollup.yml exists?
+   │  ├─ CLAUDE.md / AGENTS.md / .claude/github-integration.md
+   │  │   contain "claude-enter-issue", "stacked PR", or "Depends on #"?
+   │  └─ agent-toolbox/ directory exists?
+   │
+   ├─ rc=1 (no signal) → BASE_BRANCH=$DEFAULT_BRANCH, PARENT_PR=, exit Stage 1
+   │
+   └─ rc=0 (stacked repo) → Stage 2
+            │
+            ▼
+[Stage 2] find_parent_pr_candidates $DEFAULT_BRANCH
+   - lists open PRs whose head ref is an ancestor of HEAD
+   - drops PRs whose head ref shares the same merge-base with HEAD as
+     the default branch (such PRs add no information beyond default)
+   │
+   ├─ 0 candidates → BASE_BRANCH=$DEFAULT_BRANCH (root issue case)
+   │
+   ├─ 1 candidate  → BASE_BRANCH=<head-of-PR>, PARENT_PR=<num>
+   │   prints "Stacking on PR #<num> (auto-detected)"
+   │   no prompt
+   │
+   └─ 2+ candidates → ask the user once
+       "Multiple parent candidates: PR #N1, #N2. Stack on which? [N1/N2/main]"
+       (selection becomes BASE_BRANCH + PARENT_PR or default)
+```
+
+## Manual override (escape hatches)
+
+| Flag | Semantics |
+|---|---|
+| `--no-stack` | skip auto-detect entirely, BASE_BRANCH=$DEFAULT_BRANCH |
+| `--parent-pr <N>` | skip auto-detect, BASE_BRANCH=head ref of PR #N, PARENT_PR=N |
+| `--base <branch>` | skip auto-detect, BASE_BRANCH=<branch>, PARENT_PR= |
+
+The three flags are mutually exclusive. Combining any two → rc=2 with
+an explanatory message; the skill aborts before any push.
+
+## Stage 1 — `is_stacked_pr_repo`
+
+```sh
+# Returns 0 when the repo opts into stacked PRs, 1 otherwise.
+# Signals are checked in priority order; the first match short-circuits.
+is_stacked_pr_repo() {
+    local _repo_root="${1:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+    [ -n "$_repo_root" ] || return 1
+
+    # 1. Workflow file (strongest, explicit opt-in).
+    [ -f "$_repo_root/.github/workflows/stacked-closes-rollup.yml" ] && return 0
+
+    # 2. Policy doc keywords.
+    local _f
+    for _f in CLAUDE.md AGENTS.md .claude/github-integration.md; do
+        [ -f "$_repo_root/$_f" ] || continue
+        grep -qE 'claude-enter-issue|stacked.PR|Depends on #' \
+            "$_repo_root/$_f" 2>/dev/null && return 0
+    done
+
+    # 3. AgentToolbox project copy signature.
+    [ -d "$_repo_root/agent-toolbox" ] && return 0
+
+    return 1
+}
+```
+
+False-positive prevention: each signal must be explicit. A repo with
+none of these is treated as solo / non-stacked.
+
+## Argument parsing — `parse_stacked_args`
+
+```sh
+# Reads positional args + flags from $@. Sets globals:
+#   STACK_MODE     — auto | no-stack | parent-pr | base
+#   STACK_PARENT   — PR number when STACK_MODE=parent-pr
+#   STACK_BASE     — branch name when STACK_MODE=base
+#   ISSUE_NUMBER   — first positional integer (legacy "/gh-pr 123" link)
+# Returns 0 on success, 2 on mutually-exclusive violation, 3 on bad value.
+parse_stacked_args() {
+    STACK_MODE=auto
+    STACK_PARENT=
+    STACK_BASE=
+    ISSUE_NUMBER=
+    local _flags_seen=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --no-stack)
+                _flags_seen=$((_flags_seen + 1))
+                STACK_MODE=no-stack
+                shift
+                ;;
+            --parent-pr)
+                _flags_seen=$((_flags_seen + 1))
+                STACK_MODE=parent-pr
+                STACK_PARENT="$2"
+                if ! printf '%s' "${STACK_PARENT-}" | grep -qE '^[1-9][0-9]*$'; then
+                    printf 'gh:pr: --parent-pr requires a positive integer (got %s)\n' \
+                        "${STACK_PARENT:-<empty>}" >&2
+                    return 3
+                fi
+                shift 2
+                ;;
+            --base)
+                _flags_seen=$((_flags_seen + 1))
+                STACK_MODE=base
+                STACK_BASE="$2"
+                if [ -z "${STACK_BASE-}" ]; then
+                    printf 'gh:pr: --base requires a branch name\n' >&2
+                    return 3
+                fi
+                shift 2
+                ;;
+            *)
+                if [ -z "$ISSUE_NUMBER" ] &&
+                    printf '%s' "$1" | grep -qE '^[1-9][0-9]*$'; then
+                    ISSUE_NUMBER="$1"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [ "$_flags_seen" -gt 1 ]; then
+        printf 'gh:pr: --no-stack / --parent-pr / --base are mutually exclusive\n' >&2
+        return 2
+    fi
+
+    return 0
+}
+```
+
+## Stage 2 — `find_parent_pr_candidates`
+
+```sh
+# Prints "<pr-number>:<head-ref>" lines, one per ancestor open PR.
+# Inputs:
+#   $1  default branch name (e.g. "main")
+# Helpers (overridable in tests via FAKE_* env vars):
+#   _gh_pr_default_open_pr_list
+#   _gh_pr_default_is_ancestor
+#   _gh_pr_default_default_tip_diff_check
+
+_gh_pr_default_open_pr_list() {
+    if [ -n "${FAKE_OPEN_PRS+set}" ]; then
+        printf '%s\n' "$FAKE_OPEN_PRS"
+        return 0
+    fi
+    gh pr list --state open --json number,headRefName \
+        --jq '.[] | "\(.number) \(.headRefName)"' 2>/dev/null
+}
+
+_gh_pr_default_is_ancestor() {
+    local _ref="$1" _ar
+    if [ -n "${FAKE_ANCESTOR_REFS+set}" ]; then
+        for _ar in $FAKE_ANCESTOR_REFS; do
+            [ "$_ar" = "$_ref" ] && return 0
+        done
+        return 1
+    fi
+    git merge-base --is-ancestor "$_ref" HEAD 2>/dev/null
+}
+
+_gh_pr_default_default_tip_diff_check() {
+    local _ref="$1" _default_tip="$2" _r
+    if [ -n "${FAKE_NONDEFAULT_REFS+set}" ]; then
+        for _r in $FAKE_NONDEFAULT_REFS; do
+            [ "$_r" = "$_ref" ] && return 0
+        done
+        return 1
+    fi
+    local _base_with_default _base_with_head
+    _base_with_default=$(git merge-base HEAD "$_default_tip" 2>/dev/null)
+    _base_with_head=$(git merge-base HEAD "$_ref" 2>/dev/null)
+    [ -n "$_base_with_default" ] && [ -n "$_base_with_head" ] &&
+        [ "$_base_with_head" != "$_base_with_default" ]
+}
+
+find_parent_pr_candidates() {
+    local _default_branch="$1"
+    local _default_tip="origin/$_default_branch"
+    local _line _pr _head _candidates
+
+    _candidates=$(_gh_pr_default_open_pr_list)
+    [ -z "$_candidates" ] && return 0
+
+    while IFS= read -r _line; do
+        [ -z "$_line" ] && continue
+        _pr="${_line%% *}"
+        _head="${_line#* }"
+        [ "$_head" = "$_default_branch" ] && continue
+        # Live mode only — fetch the head so the ancestor probe is fresh.
+        if [ -z "${FAKE_OPEN_PRS+set}" ]; then
+            git fetch origin "$_head" --quiet 2>/dev/null || continue
+        fi
+        _gh_pr_default_is_ancestor "origin/$_head" || continue
+        _gh_pr_default_default_tip_diff_check "origin/$_head" "$_default_tip" || continue
+        printf '%s:%s\n' "$_pr" "$_head"
+    done <<EOF
+$_candidates
+EOF
+}
+```
+
+## How Step 1 of `SKILL.md` ties it together
+
+```sh
+parse_stacked_args "$@" || exit $?
+
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+
+case "$STACK_MODE" in
+    no-stack)
+        BASE_BRANCH="$DEFAULT_BRANCH" ; PARENT_PR= ;;
+    parent-pr)
+        PARENT_PR="$STACK_PARENT"
+        BASE_BRANCH=$(gh pr view "$PARENT_PR" --json headRefName -q .headRefName) ;;
+    base)
+        BASE_BRANCH="$STACK_BASE" ; PARENT_PR= ;;
+    auto)
+        if is_stacked_pr_repo "$(git rev-parse --show-toplevel)"; then
+            CANDIDATES=$(find_parent_pr_candidates "$DEFAULT_BRANCH")
+            COUNT=$(printf '%s\n' "$CANDIDATES" | grep -c .)
+            case "$COUNT" in
+                0)  BASE_BRANCH="$DEFAULT_BRANCH" ; PARENT_PR= ;;
+                1)
+                    PARENT_PR="${CANDIDATES%%:*}"
+                    BASE_BRANCH="${CANDIDATES#*:}"
+                    printf 'Stacking on PR #%s (auto-detected)\n' "$PARENT_PR" ;;
+                *)
+                    # 2+ candidates — ask the user once.
+                    printf 'Multiple parent candidates:\n%s\n' "$CANDIDATES"
+                    read -r CHOICE
+                    if [ "$CHOICE" = "$DEFAULT_BRANCH" ] || [ "$CHOICE" = "main" ]; then
+                        BASE_BRANCH="$DEFAULT_BRANCH" ; PARENT_PR=
+                    else
+                        PARENT_PR="$CHOICE"
+                        BASE_BRANCH=$(gh pr view "$PARENT_PR" \
+                            --json headRefName -q .headRefName)
+                    fi
+                    ;;
+            esac
+        else
+            BASE_BRANCH="$DEFAULT_BRANCH" ; PARENT_PR=
+        fi
+        ;;
+esac
+```
+
+`BASE_BRANCH` flows into Step 5 (`gh pr create --base "$BASE_BRANCH"`).
+`PARENT_PR`, when set, flows into the body-template "Depends on #N"
+insertion documented in `pr-body-template.md`.
+
+## Compatibility matrix (what the bats suite must keep covering)
+
+| Scenario | Invocation | Expected effect |
+|---|---|---|
+| dotfiles solo | `/gh-pr` | Stage 1 fail → base=default, no prompt, no Depends footer |
+| AgentToolbox parent unique | `/gh-pr` | Stage 1 pass + 1 cand → base=parent head, "Stacking on PR #N" |
+| AgentToolbox parent ambiguous | `/gh-pr` | Stage 1 pass + 2+ cand → 1× prompt |
+| AgentToolbox no parent | `/gh-pr` | Stage 1 pass + 0 cand → base=default |
+| `--no-stack` override | `/gh-pr --no-stack` | base=default forced, no Stage 2 |
+| `--parent-pr 99` | `/gh-pr --parent-pr 99` | base=PR #99 head forced |
+| `--base release/v2.0` | `/gh-pr --base release/v2.0` | arbitrary branch forced |
+| Mutually-exclusive flags | `/gh-pr --no-stack --parent-pr 5` | rc=2, abort |
+| Bad `--parent-pr` value | `/gh-pr --parent-pr abc` | rc=3, abort |
+
+The 9 rows above are the regression contract — every change to the
+detection logic must keep them green.

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+# Source-of-truth mirror for the Stage 1/2 detection block documented in
+#   claude/skills/gh-pr/references/stacked-pr.md
+#
+# The skill itself runs inside a Claude session, but the detection logic
+# is pure bash that can be tested in isolation — given a synthetic repo
+# tree (Stage 1) or a fake `gh pr list`/ancestor result set (Stage 2),
+# does the code pick the right BASE_BRANCH / PARENT_PR?
+#
+# Tests inject Stage-2 inputs via FAKE_OPEN_PRS, FAKE_ANCESTOR_REFS,
+# FAKE_NONDEFAULT_REFS so we don't need a live `gh` or a real ancestor
+# graph. Stage 1 is exercised against real (mktemp) directory trees.
+#
+# Keep this file in sync with references/stacked-pr.md. If the skill
+# block changes, mirror the change here so the bats suite catches drift.
+
+# ── Stage 1 ────────────────────────────────────────────────────────────
+is_stacked_pr_repo() {
+    local _repo_root="${1:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+    [ -n "$_repo_root" ] || return 1
+
+    [ -f "$_repo_root/.github/workflows/stacked-closes-rollup.yml" ] && return 0
+
+    local _f
+    for _f in CLAUDE.md AGENTS.md .claude/github-integration.md; do
+        [ -f "$_repo_root/$_f" ] || continue
+        grep -qE 'claude-enter-issue|stacked.PR|Depends on #' \
+            "$_repo_root/$_f" 2>/dev/null && return 0
+    done
+
+    [ -d "$_repo_root/agent-toolbox" ] && return 0
+
+    return 1
+}
+
+# ── Argument parsing ───────────────────────────────────────────────────
+parse_stacked_args() {
+    STACK_MODE=auto
+    STACK_PARENT=
+    STACK_BASE=
+    ISSUE_NUMBER=
+    local _flags_seen=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --no-stack)
+                _flags_seen=$((_flags_seen + 1))
+                STACK_MODE=no-stack
+                shift
+                ;;
+            --parent-pr)
+                _flags_seen=$((_flags_seen + 1))
+                STACK_MODE=parent-pr
+                STACK_PARENT="$2"
+                if ! printf '%s' "${STACK_PARENT-}" | grep -qE '^[1-9][0-9]*$'; then
+                    printf 'gh:pr: --parent-pr requires a positive integer (got %s)\n' \
+                        "${STACK_PARENT:-<empty>}" >&2
+                    return 3
+                fi
+                shift 2
+                ;;
+            --base)
+                _flags_seen=$((_flags_seen + 1))
+                STACK_MODE=base
+                STACK_BASE="$2"
+                if [ -z "${STACK_BASE-}" ]; then
+                    printf 'gh:pr: --base requires a branch name\n' >&2
+                    return 3
+                fi
+                shift 2
+                ;;
+            *)
+                if [ -z "$ISSUE_NUMBER" ] &&
+                    printf '%s' "$1" | grep -qE '^[1-9][0-9]*$'; then
+                    ISSUE_NUMBER="$1"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [ "$_flags_seen" -gt 1 ]; then
+        printf 'gh:pr: --no-stack / --parent-pr / --base are mutually exclusive\n' >&2
+        return 2
+    fi
+
+    return 0
+}
+
+# ── Stage 2 ────────────────────────────────────────────────────────────
+_gh_pr_default_open_pr_list() {
+    if [ -n "${FAKE_OPEN_PRS+set}" ]; then
+        printf '%s\n' "$FAKE_OPEN_PRS"
+        return 0
+    fi
+    gh pr list --state open --json number,headRefName \
+        --jq '.[] | "\(.number) \(.headRefName)"' 2>/dev/null
+}
+
+_gh_pr_default_is_ancestor() {
+    local _ref="$1" _ar
+    if [ -n "${FAKE_ANCESTOR_REFS+set}" ]; then
+        for _ar in $FAKE_ANCESTOR_REFS; do
+            [ "$_ar" = "$_ref" ] && return 0
+        done
+        return 1
+    fi
+    git merge-base --is-ancestor "$_ref" HEAD 2>/dev/null
+}
+
+_gh_pr_default_default_tip_diff_check() {
+    local _ref="$1" _default_tip="$2" _r
+    if [ -n "${FAKE_NONDEFAULT_REFS+set}" ]; then
+        for _r in $FAKE_NONDEFAULT_REFS; do
+            [ "$_r" = "$_ref" ] && return 0
+        done
+        return 1
+    fi
+    local _base_with_default _base_with_head
+    _base_with_default=$(git merge-base HEAD "$_default_tip" 2>/dev/null)
+    _base_with_head=$(git merge-base HEAD "$_ref" 2>/dev/null)
+    [ -n "$_base_with_default" ] && [ -n "$_base_with_head" ] &&
+        [ "$_base_with_head" != "$_base_with_default" ]
+}
+
+find_parent_pr_candidates() {
+    local _default_branch="$1"
+    local _default_tip="origin/$_default_branch"
+    local _line _pr _head _candidates
+
+    _candidates=$(_gh_pr_default_open_pr_list)
+    [ -z "$_candidates" ] && return 0
+
+    while IFS= read -r _line; do
+        [ -z "$_line" ] && continue
+        _pr="${_line%% *}"
+        _head="${_line#* }"
+        [ "$_head" = "$_default_branch" ] && continue
+        if [ -z "${FAKE_OPEN_PRS+set}" ]; then
+            git fetch origin "$_head" --quiet 2>/dev/null || continue
+        fi
+        _gh_pr_default_is_ancestor "origin/$_head" || continue
+        _gh_pr_default_default_tip_diff_check "origin/$_head" "$_default_tip" || continue
+        printf '%s:%s\n' "$_pr" "$_head"
+    done <<EOF
+$_candidates
+EOF
+}

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -25,7 +25,7 @@ is_stacked_pr_repo() {
     local _f
     for _f in CLAUDE.md AGENTS.md .claude/github-integration.md; do
         [ -f "$_repo_root/$_f" ] || continue
-        grep -qE 'claude-enter-issue|stacked.PR|Depends on #' \
+        grep -qE 'claude-enter-issue|stacked[[:space:]-]?PR|Depends on #' \
             "$_repo_root/$_f" 2>/dev/null && return 0
     done
 
@@ -52,6 +52,10 @@ parse_stacked_args() {
             --parent-pr)
                 _flags_seen=$((_flags_seen + 1))
                 STACK_MODE=parent-pr
+                if [ $# -lt 2 ]; then
+                    printf 'gh:pr: --parent-pr requires a PR number\n' >&2
+                    return 3
+                fi
                 STACK_PARENT="$2"
                 if ! printf '%s' "${STACK_PARENT-}" | grep -qE '^[1-9][0-9]*$'; then
                     printf 'gh:pr: --parent-pr requires a positive integer (got %s)\n' \
@@ -63,6 +67,10 @@ parse_stacked_args() {
             --base)
                 _flags_seen=$((_flags_seen + 1))
                 STACK_MODE=base
+                if [ $# -lt 2 ]; then
+                    printf 'gh:pr: --base requires a branch name\n' >&2
+                    return 3
+                fi
                 STACK_BASE="$2"
                 if [ -z "${STACK_BASE-}" ]; then
                     printf 'gh:pr: --base requires a branch name\n' >&2

--- a/tests/bats/skills/gh_pr_stacked_detect.bats
+++ b/tests/bats/skills/gh_pr_stacked_detect.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_stacked_detect.bats
+# Verify the Step 1a stacked-PR auto-detect logic documented in
+#   claude/skills/gh-pr/references/stacked-pr.md
+# Source-of-truth fixture: _fixtures/gh_pr_stacked_detect.sh.
+#
+# 9-case compatibility matrix from issue #394:
+#   1. dotfiles solo (no stacked signals)        → Stage 1 fail, base=default
+#   2. AgentToolbox parent unique                → Stage 1+2, 1 candidate
+#   3. AgentToolbox parent ambiguous             → Stage 1+2, 2+ candidates
+#   4. AgentToolbox no parent (root issue)       → Stage 1 pass, 0 candidates
+#   5. --no-stack override                       → mode=no-stack
+#   6. --parent-pr <N> override                  → mode=parent-pr
+#   7. --base <branch> override                  → mode=base
+#   8. Mutually-exclusive flags                  → rc=2 abort
+#   9. --parent-pr <bad>                         → rc=3 abort
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh"
+    REPO_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] && rm -rf "$REPO_ROOT"
+    unset FAKE_OPEN_PRS FAKE_ANCESTOR_REFS FAKE_NONDEFAULT_REFS
+    unset STACK_MODE STACK_PARENT STACK_BASE ISSUE_NUMBER
+    teardown_isolated_home
+}
+
+# ── 1. Stage 1: solo / no signals ─────────────────────────────────────
+@test "stage1: empty repo (no signals) → not stacked (rc=1)" {
+    run is_stacked_pr_repo "$REPO_ROOT"
+    [ "$status" -eq 1 ]
+}
+
+# ── 2/3/4. Stage 1: each signal is detected ───────────────────────────
+@test "stage1: workflow file → stacked" {
+    mkdir -p "$REPO_ROOT/.github/workflows"
+    touch    "$REPO_ROOT/.github/workflows/stacked-closes-rollup.yml"
+    run is_stacked_pr_repo "$REPO_ROOT"
+    assert_success
+}
+
+@test "stage1: CLAUDE.md keyword → stacked" {
+    printf 'see claude-enter-issue for details\n' > "$REPO_ROOT/CLAUDE.md"
+    run is_stacked_pr_repo "$REPO_ROOT"
+    assert_success
+}
+
+@test "stage1: AGENTS.md 'Depends on #' → stacked" {
+    printf 'use Depends on # in PR bodies\n' > "$REPO_ROOT/AGENTS.md"
+    run is_stacked_pr_repo "$REPO_ROOT"
+    assert_success
+}
+
+@test "stage1: agent-toolbox/ dir → stacked" {
+    mkdir -p "$REPO_ROOT/agent-toolbox"
+    run is_stacked_pr_repo "$REPO_ROOT"
+    assert_success
+}
+
+@test "stage1: .claude/github-integration.md keyword → stacked" {
+    mkdir -p "$REPO_ROOT/.claude"
+    printf 'Backlog 중복 검사: stacked PR 정책\n' > "$REPO_ROOT/.claude/github-integration.md"
+    run is_stacked_pr_repo "$REPO_ROOT"
+    assert_success
+}
+
+@test "stage1: keyword absent in CLAUDE.md → not stacked" {
+    printf 'just a regular project doc\n' > "$REPO_ROOT/CLAUDE.md"
+    run is_stacked_pr_repo "$REPO_ROOT"
+    [ "$status" -eq 1 ]
+}
+
+# ── Compatibility matrix #1: dotfiles solo invocation ─────────────────
+# parse_stacked_args sets globals; bats `run` would fork a subshell and lose
+# them, so we invoke directly. A non-zero rc trips bats's test-body errexit.
+@test "matrix-1: dotfiles solo / no flags → mode=auto, no override" {
+    parse_stacked_args
+    [ "$STACK_MODE" = "auto" ]
+    [ -z "$STACK_PARENT" ]
+    [ -z "$STACK_BASE" ]
+}
+
+# ── Compatibility matrix #2: AgentToolbox parent unique ───────────────
+@test "matrix-2: stage2 with single ancestor PR → 1 candidate line" {
+    FAKE_OPEN_PRS=$'201 feat/parent-branch\n205 feat/sibling-branch'
+    FAKE_ANCESTOR_REFS='origin/feat/parent-branch'
+    FAKE_NONDEFAULT_REFS='origin/feat/parent-branch'
+    run find_parent_pr_candidates main
+    assert_success
+    assert_output --partial '201:feat/parent-branch'
+    refute_output --partial '205:'
+}
+
+# ── Compatibility matrix #3: AgentToolbox parent ambiguous ────────────
+@test "matrix-3: stage2 with two ancestor PRs → 2 candidate lines" {
+    FAKE_OPEN_PRS=$'201 feat/parent-a\n205 feat/parent-b\n300 feat/orphan'
+    FAKE_ANCESTOR_REFS='origin/feat/parent-a origin/feat/parent-b'
+    FAKE_NONDEFAULT_REFS='origin/feat/parent-a origin/feat/parent-b'
+    run find_parent_pr_candidates main
+    assert_success
+    assert_output --partial '201:feat/parent-a'
+    assert_output --partial '205:feat/parent-b'
+    refute_output --partial '300:'
+    [ "$(printf '%s\n' "$output" | grep -c .)" -eq 2 ]
+}
+
+# ── Compatibility matrix #4: AgentToolbox no parent ───────────────────
+@test "matrix-4: stage2 with zero ancestor PRs → empty output" {
+    FAKE_OPEN_PRS=$'201 feat/unrelated-a\n205 feat/unrelated-b'
+    FAKE_ANCESTOR_REFS=''
+    FAKE_NONDEFAULT_REFS=''
+    run find_parent_pr_candidates main
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "matrix-4b: stage2 candidate with same merge-base as default → dropped" {
+    # PR head is an ancestor of HEAD but its merge-base equals the default's
+    # — i.e. it doesn't actually advance the parent search. Must be skipped.
+    FAKE_OPEN_PRS='201 feat/same-as-default'
+    FAKE_ANCESTOR_REFS='origin/feat/same-as-default'
+    FAKE_NONDEFAULT_REFS=''
+    run find_parent_pr_candidates main
+    assert_success
+    [ -z "$output" ]
+}
+
+# ── Compatibility matrix #5: --no-stack ───────────────────────────────
+@test "matrix-5: --no-stack → STACK_MODE=no-stack" {
+    parse_stacked_args --no-stack
+    [ "$STACK_MODE" = "no-stack" ]
+}
+
+# ── Compatibility matrix #6: --parent-pr <N> ──────────────────────────
+@test "matrix-6: --parent-pr 201 → STACK_MODE=parent-pr, STACK_PARENT=201" {
+    parse_stacked_args --parent-pr 201
+    [ "$STACK_MODE" = "parent-pr" ]
+    [ "$STACK_PARENT" = "201" ]
+}
+
+# ── Compatibility matrix #7: --base <branch> ──────────────────────────
+@test "matrix-7: --base release/v2.0 → STACK_MODE=base, STACK_BASE=release/v2.0" {
+    parse_stacked_args --base release/v2.0
+    [ "$STACK_MODE" = "base" ]
+    [ "$STACK_BASE" = "release/v2.0" ]
+}
+
+# ── Compatibility matrix #8: mutually-exclusive flags ─────────────────
+@test "matrix-8: --no-stack --parent-pr 5 → rc=2 with explanatory message" {
+    run parse_stacked_args --no-stack --parent-pr 5
+    [ "$status" -eq 2 ]
+    assert_output --partial 'mutually exclusive'
+}
+
+# ── Compatibility matrix #9: bad --parent-pr value ────────────────────
+@test "matrix-9: --parent-pr abc → rc=3 with explanatory message" {
+    run parse_stacked_args --parent-pr abc
+    [ "$status" -eq 3 ]
+    assert_output --partial 'requires a positive integer'
+}
+
+# ── Legacy positional issue arg still parsed ──────────────────────────
+@test "parse: positional integer arg → ISSUE_NUMBER (legacy /gh-pr 123)" {
+    parse_stacked_args 123
+    [ "$STACK_MODE" = "auto" ]
+    [ "$ISSUE_NUMBER" = "123" ]
+}
+
+@test "parse: positional integer + --no-stack → both bound" {
+    parse_stacked_args 42 --no-stack
+    [ "$STACK_MODE" = "no-stack" ]
+    [ "$ISSUE_NUMBER" = "42" ]
+}

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ commands =
 description = Run bats shell unit tests
 skip_install = true
 allowlist_externals = tests/bats/lib/bats-core/bin/bats
-commands = tests/bats/lib/bats-core/bin/bats tests/bats/init tests/bats/functions tests/bats/tools tests/bats/integrations
+commands = tests/bats/lib/bats-core/bin/bats tests/bats/init tests/bats/functions tests/bats/tools tests/bats/integrations tests/bats/skills
 
 
 # --- 파이썬 버전별 테 스트 환경 ---


### PR DESCRIPTION
## Summary
- `gh:pr` 가 stacked PR 정책 repo (AgentToolbox 등) 에서 base 브랜치를
  자동 추정. dotfiles 같은 solo repo 는 신호 부재로 자동 감지가
  비활성화되어 기존 흐름 그대로.
- 사용자 override flag (`--no-stack` / `--parent-pr <N>` / `--base <branch>`)
  추가 — 자동 감지가 틀렸을 때만 수동 사용. 상호 배타.
- Stage 1/2 detection bash 를 SSOT (`references/stacked-pr.md`) +
  fixture mirror (`tests/bats/skills/_fixtures/`) 로 박제하고 9-case
  호환성 매트릭스를 19개 bats 케이스로 회귀 보호.

## Changes
- `claude/skills/gh-pr/SKILL.md`: Step 1 을 1a (args + Stage 1/2) /
  1b (range·push state) 로 분할, Step 5 가 `--base "$BASE_BRANCH"` 사용.
- `claude/skills/gh-pr/references/stacked-pr.md` (신규, 299 줄): Stage 1
  `is_stacked_pr_repo`, arg 파서 `parse_stacked_args`, Stage 2
  `find_parent_pr_candidates` 의 SSOT bash + 호환성 매트릭스.
- `claude/skills/gh-pr/references/help.md`: USAGE/Behavior/Examples 에
  자동 감지 트리거 조건 + 3개 override flag 문서화.
- `claude/skills/gh-pr/references/constraints.md`: Base branch 절을
  자동 감지 경로 + override flag 출처 3가지로 갱신.
- `claude/skills/gh-pr/references/pr-body-template.md`: `Depends on #N`
  삽입 규칙, `--base "$BASE_BRANCH"` 변수 인용 명시.
- `claude/skills/gh-pr/references/push-and-create.md`: `BASE_BRANCH`
  출처 안내 (Step 1a SSOT 참조, default 하드코딩 금지).
- `tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh` (신규): SKILL
  reference 와 비트 단위로 동기화되는 mirror — `is_stacked_pr_repo`,
  `parse_stacked_args`, `find_parent_pr_candidates` + Stage 2 helper
  3종 (`FAKE_OPEN_PRS` / `FAKE_ANCESTOR_REFS` / `FAKE_NONDEFAULT_REFS`
  으로 mock 가능).
- `tests/bats/skills/gh_pr_stacked_detect.bats` (신규): Stage 1 시그널
  6종, 9-case 호환성 매트릭스 (matrix-1..9 + 4b), 레거시 positional
  arg 호환성 — 총 19개.
- `tox.ini`: bats 환경 명령어에 `tests/bats/skills` 디렉토리 추가
  (기존 skills bats 들이 tox 에 안 묶여 있던 누수 동시 보정).

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_stacked_detect.bats`
  → 19/19 pass
- [x] 전체 bats suite 회귀 (init/functions/tools/integrations/skills)
  → 594/594 pass, exit 0
- [x] `shellcheck -e SC1090,SC1091 tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh`
  → clean
- [x] `shfmt -d -i 4 -ci tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh`
  → clean (적용 후 재실행)
- [ ] dotfiles solo (현재 repo) 에서 `/gh-pr` 실행 시 base=main, "Stacking
  on PR..." 출력 없음 — 본 PR 자체로 회귀 검증 (이 PR 이 통상 base=main)
- [ ] 다음 AgentToolbox 작업 시 자동 감지 발동 여부 1차 검증

## Related
Closes #394

---
<details>
<summary>🤖 AI Metrics · 📊 ~10000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~10000 tokens · 👤 ~8 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
