### PR TITLE
feat(gh-pr): Step 4.5 lint guard — tox / shellcheck / actionlint

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -83,6 +83,24 @@ printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%
   "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
 ```
 
+## Step 4.5: Lint Guard (pre-push)
+
+Read `references/lint-guard.md` for tool detection priority, scope, and
+the bypass policy. Source the helper and run it against `$BASE_BRANCH`
+**before** the push in Step 5:
+
+```bash
+. "${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common/functions/gh_pr_lint.sh"
+_gh_pr_lint_run "$BASE_BRANCH" || {
+    printf 'gh:pr stopped at Step 4.5 (lint guard).\n' >&2
+    exit 1
+}
+```
+
+Hard-fails when any detected tool reports lint errors. Auto-skips when
+no tools are detected, when the change set is empty, or when
+`GH_PR_LINT_BYPASS=1` is set.
+
 ## Step 5: Push and Create
 
 Read `references/push-and-create.md` for the upstream-state push policy and

--- a/claude/skills/gh-pr/references/lint-guard.md
+++ b/claude/skills/gh-pr/references/lint-guard.md
@@ -1,0 +1,111 @@
+# Lint Guard — pre-push lint detection and execution
+
+Used by Step 4.5 of the `gh:pr` skill, **before** Step 5 pushes the branch.
+Source: issue #396, design SSOT in
+[#384#issuecomment-4403809305](https://github.com/dEitY719/dotfiles/issues/384#issuecomment-4403809305).
+
+## Why
+
+Some repos rely on a pre-commit hook for lint gating; others ship a
+`tox.ini` or rely on CI. When the hook is missing or skipped, broken
+lint quietly slips through to CI and burns review cycles. This step
+runs the project's own lint tools on the PR's changed files just before
+push, surfacing failures before they hit the remote.
+
+## Helper
+
+The detection and execution logic is implemented in
+`shell-common/functions/gh_pr_lint.sh` as `_gh_pr_lint_run <base>`.
+The skill sources the file and calls the function — never inline the
+detection logic in `SKILL.md`.
+
+```bash
+. "${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common/functions/gh_pr_lint.sh"
+_gh_pr_lint_run "$BASE_BRANCH" || {
+    printf 'gh:pr stopped at Step 4.5 (lint guard).\n' >&2
+    exit 1
+}
+```
+
+## Detection priority
+
+The guard picks tools in this order, top-down:
+
+1. **tox** — `tox.ini` exists and declares at least one of these envs:
+   `[testenv:ruff]`, `[testenv:mdlint]`, `[testenv:shellcheck]`,
+   `[testenv:shfmt]`, `[testenv:actionlint]`. Runs `tox -e <list>` with
+   only the envs that are actually declared.
+2. **shellcheck** — `command -v shellcheck` succeeds **and** the changed
+   file set contains at least one `*.sh`. Runs
+   `shellcheck -x -S warning <changed-sh-files>`.
+3. **actionlint** — `command -v actionlint` succeeds **and** the change
+   set contains at least one `.github/workflows/*`. Runs
+   `actionlint <changed-workflow-files>`.
+4. **pre-commit** — `.pre-commit-config.yaml` exists and
+   `command -v pre-commit` succeeds. Runs
+   `pre-commit run --files <changed-files>`.
+
+When tox runs, the individual fallbacks (shellcheck / actionlint /
+pre-commit) are skipped — tox already owns the project's lint surface.
+When tox is absent, fallbacks run independently and accumulate failures.
+
+## Scope: changed files only
+
+The guard never lints the whole repo. Files come from:
+
+```sh
+git diff --name-only "$BASE...HEAD"
+```
+
+Per-tool filtering then keeps only the relevant subset (e.g. `*.sh` for
+shellcheck, `.github/workflows/*` for actionlint). This keeps the
+runtime small and avoids dragging in pre-existing lint debt that the PR
+did not introduce.
+
+If the changed set is empty (e.g. cherry-pick that yields no diff), the
+guard logs `no changed files vs <base> — skip` and returns 0.
+
+## Bypass
+
+| Env var | Effect |
+|---|---|
+| `GH_PR_LINT_BYPASS=1` | Skip the guard entirely. Logs `bypassed (GH_PR_LINT_BYPASS=1)` and returns 0. Use for emergency pushes when the lint debt is known and tracked elsewhere. |
+| `GH_PR_LINT_TOOLS=auto` | Default — auto-detect tools per the priority list. |
+| `GH_PR_LINT_TOOLS=tox,shellcheck` | Restrict to a comma-list of tools. Each named tool is still subject to its own detection rule (existence + applicable changed files). |
+
+## Failure behaviour
+
+On any tool's non-zero exit, the guard records a failure but continues
+running remaining tools so the user sees every failure in one pass.
+After all tools finish, if any failed:
+
+1. Return 1 from `_gh_pr_lint_run`.
+2. The caller (skill Step 4.5) prints
+   `gh:pr stopped at Step 4.5 (lint guard).` and exits non-zero **before
+   pushing**.
+3. The user fixes the listed errors and re-runs `/gh:pr`, or sets
+   `GH_PR_LINT_BYPASS=1` for a one-shot escape.
+
+## Skip matrix
+
+| Condition | Result |
+|---|---|
+| `GH_PR_LINT_BYPASS=1` | skip + log |
+| Empty `git diff --name-only "$BASE...HEAD"` | skip + log |
+| No detected tool applies (no tox.ini, no shellcheck/actionlint/pre-commit) | skip + log |
+| Tool detected but its file-type filter yields zero matches | tool not run; other tools still evaluated |
+
+## Why fail-loud over warn-only
+
+The design discussion (#384) considered warn-only with an opt-in to
+hard-fail. We picked hard-fail with an env-var escape because:
+
+- Warn-only is silent in scrollback and easy to ignore.
+- Lint failures here always block CI later — failing now saves a round
+  trip with reviewers.
+- The escape (`GH_PR_LINT_BYPASS=1`) is one env var away, so emergency
+  pushes are still cheap.
+
+If a user complains the guard is too aggressive, the fix is to set
+`GH_PR_LINT_TOOLS=` to an empty list locally (in `~/.zprofile` or
+similar) — never to soften the default.

--- a/shell-common/functions/gh_pr_lint.sh
+++ b/shell-common/functions/gh_pr_lint.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_pr_lint.sh
+# Optional pre-push lint guard for the `gh:pr` skill (issue #396, design
+# in #384#issuecomment-4403809305).
+#
+# Detects repo lint capability (tox > shellcheck > actionlint > pre-commit),
+# runs detected tools against the PR's changed files only, and hard-fails on
+# any lint error. Bypass via GH_PR_LINT_BYPASS=1.
+#
+# Usage:
+#   _gh_pr_lint_run <base-branch>
+#
+# Env overrides:
+#   GH_PR_LINT_BYPASS=1            — skip the entire guard (escape hatch)
+#   GH_PR_LINT_TOOLS=auto          — auto-detect (default)
+#   GH_PR_LINT_TOOLS=tox,shellcheck — comma-list of tools to force-run
+#                                    (still subject to per-tool detection)
+#
+# Return codes:
+#   0 — all detected tools passed, or skipped (no tools / bypass / no changes)
+#   1 — at least one tool failed; caller should block the push
+#   2 — usage error (missing base-branch argument)
+
+_gh_pr_lint__log() {
+    printf '[lint guard] %s\n' "$*"
+}
+
+_gh_pr_lint__has_tox_envs() {
+    # tox.ini exists AND declares at least one of the lint envs we recognise.
+    [ -f tox.ini ] || return 1
+    grep -qE '^\[testenv:(ruff|mdlint|shellcheck|shfmt|actionlint)\]' tox.ini
+}
+
+_gh_pr_lint__tox_env_list() {
+    # Print a comma-separated list of declared lint envs in tox.ini, in
+    # priority order (ruff, mdlint, shellcheck, shfmt, actionlint).
+    [ -f tox.ini ] || return 0
+    _envs=""
+    for _e in ruff mdlint shellcheck shfmt actionlint; do
+        if grep -qE "^\[testenv:$_e\]" tox.ini; then
+            _envs="${_envs:+$_envs,}$_e"
+        fi
+    done
+    printf '%s' "$_envs"
+    unset _envs _e
+}
+
+_gh_pr_lint__filter_changed() {
+    # Stdin: list of changed files (one per line).
+    # Args:  glob pattern(s) to keep (e.g. '*.sh', '.github/workflows/*').
+    # Stdout: filtered subset, preserving order.
+    _pat="$1"
+    while IFS= read -r _f; do
+        # Use a case-glob — POSIX, no GNU-only flags.
+        # shellcheck disable=SC2254
+        case "$_f" in
+            $_pat) printf '%s\n' "$_f" ;;
+        esac
+    done
+    unset _pat _f
+}
+
+_gh_pr_lint__want_tool() {
+    # 0 if $GH_PR_LINT_TOOLS is unset/auto, or if $1 appears in the
+    # comma-separated list. 1 otherwise.
+    _tools="${GH_PR_LINT_TOOLS:-auto}"
+    case "$_tools" in
+        auto|"")  unset _tools; return 0 ;;
+    esac
+    case ",$_tools," in
+        *",$1,"*) unset _tools; return 0 ;;
+    esac
+    unset _tools
+    return 1
+}
+
+_gh_pr_lint_run() {
+    _base="$1"
+    if [ -z "$_base" ]; then
+        printf '[gh-pr-lint] usage: _gh_pr_lint_run <base-branch>\n' >&2
+        unset _base
+        return 2
+    fi
+
+    if [ "${GH_PR_LINT_BYPASS:-0}" = "1" ]; then
+        _gh_pr_lint__log "bypassed (GH_PR_LINT_BYPASS=1)"
+        unset _base
+        return 0
+    fi
+
+    # Compute the PR's changed-file set against the base branch.
+    _changed=$(git diff --name-only "$_base...HEAD" 2>/dev/null)
+    if [ -z "$_changed" ]; then
+        _gh_pr_lint__log "no changed files vs $_base — skip"
+        unset _base _changed
+        return 0
+    fi
+
+    _ran_any=0
+    _failed=0
+
+    # ---- tox (highest priority) ----------------------------------------
+    if _gh_pr_lint__want_tool tox \
+        && command -v tox >/dev/null 2>&1 \
+        && _gh_pr_lint__has_tox_envs; then
+        _envs=$(_gh_pr_lint__tox_env_list)
+        if [ -n "$_envs" ]; then
+            _gh_pr_lint__log "running tox -e $_envs"
+            if tox -e "$_envs"; then
+                _gh_pr_lint__log "tox passed"
+            else
+                _gh_pr_lint__log "tox FAILED"
+                _failed=1
+            fi
+            _ran_any=1
+        fi
+        unset _envs
+    fi
+
+    # When tox already covered the repo, individual fallbacks are redundant.
+    if [ "$_ran_any" = "0" ]; then
+        # ---- shellcheck (changed *.sh) ---------------------------------
+        if _gh_pr_lint__want_tool shellcheck \
+            && command -v shellcheck >/dev/null 2>&1; then
+            _sh_files=$(printf '%s\n' "$_changed" \
+                | _gh_pr_lint__filter_changed '*.sh')
+            if [ -n "$_sh_files" ]; then
+                _gh_pr_lint__log "running shellcheck on $(printf '%s\n' "$_sh_files" | wc -l | tr -d ' ') file(s)"
+                # POSIX-safe: feed file list through xargs.
+                if printf '%s\n' "$_sh_files" \
+                    | xargs shellcheck -x -S warning; then
+                    _gh_pr_lint__log "shellcheck passed"
+                else
+                    _gh_pr_lint__log "shellcheck FAILED"
+                    _failed=1
+                fi
+                _ran_any=1
+            fi
+            unset _sh_files
+        fi
+
+        # ---- actionlint (changed .github/workflows/*) ------------------
+        if _gh_pr_lint__want_tool actionlint \
+            && command -v actionlint >/dev/null 2>&1; then
+            _wf_files=$(printf '%s\n' "$_changed" \
+                | _gh_pr_lint__filter_changed '.github/workflows/*')
+            if [ -n "$_wf_files" ]; then
+                _gh_pr_lint__log "running actionlint on $(printf '%s\n' "$_wf_files" | wc -l | tr -d ' ') file(s)"
+                if printf '%s\n' "$_wf_files" | xargs actionlint; then
+                    _gh_pr_lint__log "actionlint passed"
+                else
+                    _gh_pr_lint__log "actionlint FAILED"
+                    _failed=1
+                fi
+                _ran_any=1
+            fi
+            unset _wf_files
+        fi
+
+        # ---- pre-commit (changed files) --------------------------------
+        if _gh_pr_lint__want_tool pre-commit \
+            && [ -f .pre-commit-config.yaml ] \
+            && command -v pre-commit >/dev/null 2>&1; then
+            _gh_pr_lint__log "running pre-commit on changed files"
+            if printf '%s\n' "$_changed" | xargs pre-commit run --files; then
+                _gh_pr_lint__log "pre-commit passed"
+            else
+                _gh_pr_lint__log "pre-commit FAILED"
+                _failed=1
+            fi
+            _ran_any=1
+        fi
+    fi
+
+    if [ "$_ran_any" = "0" ]; then
+        _gh_pr_lint__log "no lint tools detected — skip"
+        unset _base _changed _ran_any _failed
+        return 0
+    fi
+
+    if [ "$_failed" = "1" ]; then
+        printf '\n' >&2
+        _gh_pr_lint__log "FAILED — fix lint errors and re-run /gh:pr, or set GH_PR_LINT_BYPASS=1 to skip" >&2
+        unset _base _changed _ran_any _failed
+        return 1
+    fi
+
+    unset _base _changed _ran_any _failed
+    return 0
+}

--- a/shell-common/functions/gh_pr_lint.sh
+++ b/shell-common/functions/gh_pr_lint.sh
@@ -62,11 +62,17 @@ _gh_pr_lint__filter_changed() {
 }
 
 _gh_pr_lint__want_tool() {
-    # 0 if $GH_PR_LINT_TOOLS is unset/auto, or if $1 appears in the
+    # 0 if $GH_PR_LINT_TOOLS is unset or "auto", or if $1 appears in the
     # comma-separated list. 1 otherwise.
-    _tools="${GH_PR_LINT_TOOLS:-auto}"
+    #
+    # Note the `${VAR-default}` form (no `:`) — empty-string and unset are
+    # treated differently. Empty (`GH_PR_LINT_TOOLS=`) means "no tools
+    # match", which is the documented soft-disable knob in lint-guard.md.
+    # Unset falls through to "auto" → all detected tools run.
+    _tools="${GH_PR_LINT_TOOLS-auto}"
     case "$_tools" in
-        auto|"")  unset _tools; return 0 ;;
+        auto) unset _tools; return 0 ;;
+        "")   unset _tools; return 1 ;;
     esac
     case ",$_tools," in
         *",$1,"*) unset _tools; return 0 ;;
@@ -127,15 +133,22 @@ _gh_pr_lint_run() {
                 | _gh_pr_lint__filter_changed '*.sh')
             if [ -n "$_sh_files" ]; then
                 _gh_pr_lint__log "running shellcheck on $(printf '%s\n' "$_sh_files" | wc -l | tr -d ' ') file(s)"
-                # POSIX-safe: feed file list through xargs.
-                if printf '%s\n' "$_sh_files" \
-                    | xargs shellcheck -x -S warning; then
+                # POSIX-safe: build positional params one-by-one so paths
+                # with spaces survive (xargs would word-split).
+                set --
+                while IFS= read -r _f; do
+                    [ -n "$_f" ] && set -- "$@" "$_f"
+                done <<EOF
+$_sh_files
+EOF
+                if shellcheck -x -S warning "$@"; then
                     _gh_pr_lint__log "shellcheck passed"
                 else
                     _gh_pr_lint__log "shellcheck FAILED"
                     _failed=1
                 fi
                 _ran_any=1
+                unset _f
             fi
             unset _sh_files
         fi
@@ -147,13 +160,20 @@ _gh_pr_lint_run() {
                 | _gh_pr_lint__filter_changed '.github/workflows/*')
             if [ -n "$_wf_files" ]; then
                 _gh_pr_lint__log "running actionlint on $(printf '%s\n' "$_wf_files" | wc -l | tr -d ' ') file(s)"
-                if printf '%s\n' "$_wf_files" | xargs actionlint; then
+                set --
+                while IFS= read -r _f; do
+                    [ -n "$_f" ] && set -- "$@" "$_f"
+                done <<EOF
+$_wf_files
+EOF
+                if actionlint "$@"; then
                     _gh_pr_lint__log "actionlint passed"
                 else
                     _gh_pr_lint__log "actionlint FAILED"
                     _failed=1
                 fi
                 _ran_any=1
+                unset _f
             fi
             unset _wf_files
         fi
@@ -163,13 +183,20 @@ _gh_pr_lint_run() {
             && [ -f .pre-commit-config.yaml ] \
             && command -v pre-commit >/dev/null 2>&1; then
             _gh_pr_lint__log "running pre-commit on changed files"
-            if printf '%s\n' "$_changed" | xargs pre-commit run --files; then
+            set --
+            while IFS= read -r _f; do
+                [ -n "$_f" ] && set -- "$@" "$_f"
+            done <<EOF
+$_changed
+EOF
+            if pre-commit run --files "$@"; then
                 _gh_pr_lint__log "pre-commit passed"
             else
                 _gh_pr_lint__log "pre-commit FAILED"
                 _failed=1
             fi
             _ran_any=1
+            unset _f
         fi
     fi
 

--- a/tests/bats/functions/gh_pr_lint.bats
+++ b/tests/bats/functions/gh_pr_lint.bats
@@ -98,11 +98,14 @@ _setup_stub_bin() {
 } >> '__LOG__'
 exit "${__RC_VAR__:-0}"
 STUB
-        sed -i \
+        # POSIX `sed > tmp && mv tmp` instead of `sed -i` so the test
+        # is portable to BSD sed (macOS) without the `-i ''` quirk.
+        sed \
             -e "s|__TOOL__|$tool|" \
             -e "s|__LOG__|$TOOL_LOG|" \
             -e "s|__RC_VAR__|$rc_var|" \
-            "$STUB_BIN/$tool"
+            "$STUB_BIN/$tool" > "$STUB_BIN/$tool.tmp" \
+            && mv "$STUB_BIN/$tool.tmp" "$STUB_BIN/$tool"
         chmod +x "$STUB_BIN/$tool"
     done
 }
@@ -118,6 +121,10 @@ _run_helper() {
     if [ "$mode" = "stubs" ]; then
         extra_path="${STUB_BIN}:"
     fi
+    # Pass GH_PR_LINT_BYPASS / GH_PR_LINT_TOOLS through ONLY when the
+    # parent test set them (non-empty). Empty `GH_PR_LINT_TOOLS=''` now
+    # has explicit "no tools match" semantics, so accidental empty
+    # exports would mask intended detection.
     run bash --noprofile --norc -c "
         export DOTFILES_ROOT='${DOTFILES_ROOT}'
         export SHELL_COMMON='${SHELL_COMMON}'
@@ -130,8 +137,8 @@ _run_helper() {
         export FAKE_SHELLCHECK_RC='${FAKE_SHELLCHECK_RC:-0}'
         export FAKE_ACTIONLINT_RC='${FAKE_ACTIONLINT_RC:-0}'
         export FAKE_PRE_COMMIT_RC='${FAKE_PRECOMMIT_RC:-0}'
-        export GH_PR_LINT_BYPASS='${GH_PR_LINT_BYPASS-}'
-        export GH_PR_LINT_TOOLS='${GH_PR_LINT_TOOLS-}'
+        ${GH_PR_LINT_BYPASS:+export GH_PR_LINT_BYPASS='${GH_PR_LINT_BYPASS}'}
+        ${GH_PR_LINT_TOOLS:+export GH_PR_LINT_TOOLS='${GH_PR_LINT_TOOLS}'}
         cd '${REPO_DIR}' || exit 99
         . '${DOTFILES_ROOT}/shell-common/functions/gh_pr_lint.sh'
         ${snippet}
@@ -248,6 +255,21 @@ TOX
     _run_helper stubs '_gh_pr_lint_run main 2>&1'
     assert_output --partial "rc=0"
     assert_output --partial "no changed files vs main — skip"
+    run wc -l <"$TOOL_LOG"
+    assert_output --partial "0"
+}
+
+# ---------------------------------------------------------------------------
+# Empty-string semantics for GH_PR_LINT_TOOLS — the soft-disable knob
+# documented in lint-guard.md. Distinguishes empty (no tools) from unset
+# (auto). Regression for PR #411 review.
+# ---------------------------------------------------------------------------
+
+@test "GH_PR_LINT_TOOLS='' → soft-disables all tools (no tool calls)" {
+    _stage_changes "foo.sh:echo hi"
+    GH_PR_LINT_TOOLS="" _run_helper stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=0"
+    assert_output --partial "no lint tools detected — skip"
     run wc -l <"$TOOL_LOG"
     assert_output --partial "0"
 }

--- a/tests/bats/functions/gh_pr_lint.bats
+++ b/tests/bats/functions/gh_pr_lint.bats
@@ -1,0 +1,265 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_pr_lint.bats
+# Unit tests for _gh_pr_lint_run — the optional pre-push lint guard
+# documented in claude/skills/gh-pr/references/lint-guard.md and exercised
+# from gh:pr Step 4.5 (issue #396).
+#
+# Network is never touched. Lint tools (tox, shellcheck, actionlint,
+# pre-commit) are stubbed via PATH shims that record their invocation in
+# $TOOL_LOG and honour FAKE_<TOOL>_RC for failure simulation.
+#
+# Each test runs inside an ephemeral git repo with a `main` base branch and
+# a feature branch carrying the test's changed files, so the helper's
+# `git diff --name-only main...HEAD` query returns the expected list.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    _init_test_repo
+    _setup_stub_bin
+}
+
+teardown() {
+    teardown_isolated_home
+    unset FAKE_TOX_RC FAKE_SHELLCHECK_RC FAKE_ACTIONLINT_RC FAKE_PRECOMMIT_RC
+    unset GH_PR_LINT_BYPASS GH_PR_LINT_TOOLS
+}
+
+# ---------------------------------------------------------------------------
+# Per-test git scratch repo:
+#   main:    initial empty commit
+#   feature: HEAD — caller adds changed files here
+# Caller chdirs into REPO_DIR before running _gh_pr_lint_run.
+# ---------------------------------------------------------------------------
+_init_test_repo() {
+    REPO_DIR="$TEST_TEMP_HOME/repo"
+    mkdir -p "$REPO_DIR"
+    (
+        cd "$REPO_DIR" || exit 1
+        git init -q -b main
+        git config user.email "test@example.invalid"
+        git config user.name "bats"
+        : >.gitkeep
+        git add .gitkeep
+        git commit -q -m "initial"
+        git checkout -q -b feature
+    )
+}
+
+# Commit one or more files to the feature branch.
+#   _stage_changes path:contents [path:contents ...]
+# If <path> already exists, its contents are preserved (the test wrote
+# them directly) — only the staging+commit happens. Otherwise the body
+# is written to <path>. Empty body is allowed.
+_stage_changes() {
+    (
+        cd "$REPO_DIR" || exit 1
+        for spec in "$@"; do
+            local path="${spec%%:*}"
+            local body="${spec#*:}"
+            mkdir -p "$(dirname "$path")"
+            if [ ! -f "$path" ]; then
+                printf '%s\n' "$body" >"$path"
+            fi
+            git add "$path"
+        done
+        git commit -q -m "feature changes"
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Stub binaries — tox/shellcheck/actionlint/pre-commit. Each records its
+# argv to $TOOL_LOG (one line per call, format: `<tool> [arg1] [arg2] ...`)
+# and returns FAKE_<TOOL>_RC (default 0).
+#
+# Implementation note: the shim template uses a single-quoted heredoc so
+# that bash history expansion never touches `!` in `#!/usr/bin/env bash`
+# or in `${var:-default}`. Per-shim values are substituted via sed.
+#
+# Tests opt in by adding $STUB_BIN to PATH; tests for "no tools detected"
+# simply skip the addition.
+# ---------------------------------------------------------------------------
+_setup_stub_bin() {
+    STUB_BIN="$TEST_TEMP_HOME/stub-bin"
+    TOOL_LOG="$TEST_TEMP_HOME/tool.log"
+    mkdir -p "$STUB_BIN"
+    : >"$TOOL_LOG"
+
+    for tool in tox shellcheck actionlint pre-commit; do
+        local rc_var
+        rc_var="FAKE_$(printf '%s' "$tool" | tr 'a-z-' 'A-Z_')_RC"
+        cat >"$STUB_BIN/$tool" <<'STUB'
+#!/usr/bin/env bash
+{
+    printf '%s' '__TOOL__'
+    for a in "$@"; do printf ' [%s]' "$a"; done
+    printf '\n'
+} >> '__LOG__'
+exit "${__RC_VAR__:-0}"
+STUB
+        sed -i \
+            -e "s|__TOOL__|$tool|" \
+            -e "s|__LOG__|$TOOL_LOG|" \
+            -e "s|__RC_VAR__|$rc_var|" \
+            "$STUB_BIN/$tool"
+        chmod +x "$STUB_BIN/$tool"
+    done
+}
+
+# Run a snippet in bash with the helper sourced and PATH controlled.
+#   _run_helper <path-mode> <snippet>
+# path-mode:
+#   stubs   — STUB_BIN prepended to PATH (tools resolvable)
+#   no-stubs — STUB_BIN NOT on PATH (simulates "tool absent")
+_run_helper() {
+    local mode="$1" snippet="$2"
+    local extra_path=""
+    if [ "$mode" = "stubs" ]; then
+        extra_path="${STUB_BIN}:"
+    fi
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${extra_path}/usr/local/bin:/usr/bin:/bin'
+        export FAKE_TOX_RC='${FAKE_TOX_RC:-0}'
+        export FAKE_SHELLCHECK_RC='${FAKE_SHELLCHECK_RC:-0}'
+        export FAKE_ACTIONLINT_RC='${FAKE_ACTIONLINT_RC:-0}'
+        export FAKE_PRE_COMMIT_RC='${FAKE_PRECOMMIT_RC:-0}'
+        export GH_PR_LINT_BYPASS='${GH_PR_LINT_BYPASS-}'
+        export GH_PR_LINT_TOOLS='${GH_PR_LINT_TOOLS-}'
+        cd '${REPO_DIR}' || exit 99
+        . '${DOTFILES_ROOT}/shell-common/functions/gh_pr_lint.sh'
+        ${snippet}
+        echo \"rc=\$?\"
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Loading: helper exists in bash and zsh
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_pr_lint_run exists after sourcing" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_pr_lint.sh"; \
+                 declare -f _gh_pr_lint_run >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_pr_lint_run exists after sourcing" {
+    run_in_zsh '. "$DOTFILES_ROOT/shell-common/functions/gh_pr_lint.sh"; \
+                typeset -f _gh_pr_lint_run >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+@test "missing base-branch arg returns 2" {
+    _run_helper no-stubs '_gh_pr_lint_run 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage:"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 — tox.ini detected → tox runs, individual fallbacks suppressed
+# ---------------------------------------------------------------------------
+
+@test "tox.ini detected → tox runs with declared envs, fallbacks skipped" {
+    cat >"$REPO_DIR/tox.ini" <<'TOX'
+[testenv:ruff]
+[testenv:shellcheck]
+TOX
+    _stage_changes "tox.ini:added" "foo.sh:#!/bin/sh"
+    _run_helper stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=0"
+    assert_output --partial "running tox -e ruff,shellcheck"
+    assert_output --partial "tox passed"
+    # tox invoked exactly once with the right env list (bracket-format log)
+    run grep -cF '[-e] [ruff,shellcheck]' "$TOOL_LOG"
+    assert_output "1"
+    # When tox runs, the shellcheck fallback must stay silent.
+    run grep -c '^shellcheck' "$TOOL_LOG"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2 — no tox, shellcheck detected → shellcheck runs on changed *.sh only
+# ---------------------------------------------------------------------------
+
+@test "shellcheck detected → runs only on changed .sh files" {
+    _stage_changes "foo.sh:echo hi" "bar.sh:echo bye" "README.md:doc"
+    _run_helper stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=0"
+    assert_output --partial "running shellcheck on 2 file(s)"
+    assert_output --partial "shellcheck passed"
+    # The lint tool was invoked once with -x -S warning + both .sh files.
+    run grep -cF '[-x] [-S] [warning]' "$TOOL_LOG"
+    assert_output "1"
+    run grep -cF '[bar.sh]' "$TOOL_LOG"
+    assert_output "1"
+    run grep -cF '[foo.sh]' "$TOOL_LOG"
+    assert_output "1"
+    # README.md must NOT appear in the shellcheck call
+    run grep -c 'README.md' "$TOOL_LOG"
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# Case 3 — no lint tools detected → skip with informative log
+# ---------------------------------------------------------------------------
+
+@test "no tools detected → skip with log" {
+    _stage_changes "README.md:no shell scripts here"
+    _run_helper no-stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=0"
+    assert_output --partial "no lint tools detected — skip"
+}
+
+# ---------------------------------------------------------------------------
+# Case 4 — GH_PR_LINT_BYPASS=1 → bypass all detection, return 0
+# ---------------------------------------------------------------------------
+
+@test "GH_PR_LINT_BYPASS=1 → guard skipped entirely (no tool calls)" {
+    cat >"$REPO_DIR/tox.ini" <<'TOX'
+[testenv:ruff]
+TOX
+    _stage_changes "tox.ini:added" "foo.sh:echo hi"
+    GH_PR_LINT_BYPASS=1 _run_helper stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=0"
+    assert_output --partial "bypassed (GH_PR_LINT_BYPASS=1)"
+    # No tool was invoked
+    run wc -l <"$TOOL_LOG"
+    assert_output --partial "0"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5 — empty changed-file set → skip without invoking any tool
+# ---------------------------------------------------------------------------
+
+@test "no changed files vs base → skip" {
+    # feature branch has no commits beyond main
+    _run_helper stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=0"
+    assert_output --partial "no changed files vs main — skip"
+    run wc -l <"$TOOL_LOG"
+    assert_output --partial "0"
+}
+
+# ---------------------------------------------------------------------------
+# Bonus: lint failure → rc=1 with bypass guidance (covers the hard-fail path)
+# ---------------------------------------------------------------------------
+
+@test "shellcheck failure → rc=1 + bypass guidance" {
+    _stage_changes "foo.sh:echo hi"
+    FAKE_SHELLCHECK_RC=1 _run_helper stubs '_gh_pr_lint_run main 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "shellcheck FAILED"
+    assert_output --partial "GH_PR_LINT_BYPASS=1"
+}


### PR DESCRIPTION
## Summary
- `gh:pr` Step 5 (push) 직전에 optional lint guard (Step 4.5) 추가 — broken shell / workflow / markdown lint이 silent하게 PR로 흘러가는 것을 차단
- 도구 자동 감지 (tox > shellcheck > actionlint > pre-commit), 변경 파일에만 적용, hard-fail with `GH_PR_LINT_BYPASS=1` escape hatch
- 9-case bats coverage가 5 acceptance criteria + bypass + helper-existence + arg-validation + lint-failure 경로를 모두 검증

## Changes
- `claude/skills/gh-pr/SKILL.md` — body draft과 push 사이에 Step 4.5 추가, 새 helper를 source해서 실행
- `claude/skills/gh-pr/references/lint-guard.md` (신규) — 감지 우선순위, `git diff --name-only "$BASE...HEAD"` 스코프 룰, 환경변수 컨트랙트 (`GH_PR_LINT_BYPASS`, `GH_PR_LINT_TOOLS`) 문서화
- `shell-common/functions/gh_pr_lint.sh` (신규) — `_gh_pr_lint_run <base>` POSIX shell helper. tox 감지 시 fallbacks suppress, tox 없을 때는 shellcheck/actionlint/pre-commit이 독립적으로 실행되어 한 번에 모든 lint 에러 노출. 리턴: 0 (pass/skip), 1 (fail → push 차단), 2 (usage error)
- `tests/bats/functions/gh_pr_lint.bats` (신규) — 9 케이스. PATH stub은 single-quoted heredoc + sed 치환으로 작성: 처음에 unquoted heredoc을 썼더니 bash history-expansion이 shebang을 망가뜨려 dash로 fallback되는 버그를 발견함

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_lint.bats` — 9/9 pass
- [x] Full functions suite `bats tests/bats/functions/` — 371/371 pass (no regression)
- [x] `shellcheck -x -S warning` clean on new `.sh` and `.bats` files
- [x] `markdownlint` clean on new/modified `.md` files
- [ ] Manual: `/gh:pr` on a feature branch with intentionally broken `*.sh` should hard-fail at Step 4.5 unless `GH_PR_LINT_BYPASS=1`

## Related
Closes #396

Design SSOT: [#384#issuecomment-4403809305](https://github.com/dEitY719/dotfiles/issues/384#issuecomment-4403809305)

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
