### PR TITLE
feat(gh-skills): GH_DISABLE_AI_METRICS env toggle for footer attachment

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -85,7 +85,9 @@ their own manual edits), derive intent from the diff itself:
 
 Before syncing the project board, record AI metrics (soft-fail — warn on
 error, never block). Compute elapsed time and post a comment on the linked
-issue (only when an issue number was resolved in Step 2):
+issue (only when an issue number was resolved in Step 2). When
+`GH_DISABLE_AI_METRICS=1`, skip the comment entirely — board sync below
+still runs (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
@@ -93,9 +95,12 @@ ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
 # See gh-issue-create/references/metrics-helper.md "Token Estimation" for the formula
 TOKENS=$(( ( ($(git diff HEAD~1 | wc -c) / 4 / 500) + 1 ) * 500 ))
 [ "$TOKENS" -lt 1000 ] && TOKENS=1000
-gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
-  -X POST \
-  -f body="### 🤖 AI Metrics — gh-commit
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
+      -X POST \
+      -f body="### 🤖 AI Metrics — gh-commit
 
 | 항목 | 값 |
 |------|-----|
@@ -105,6 +110,7 @@ gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
 | 토큰 | ~$TOKENS |
 
 <!-- ai-metrics:gh-commit tokens=$TOKENS ai_min=$ELAPSED -->"
+fi
 ```
 
 If no issue number exists, print the metrics to stdout only and skip the

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -131,13 +131,19 @@ Store results as `TOKENS`, `HUMAN_H`, `ELAPSED` for use in Step 4.
 
 ## Step 4: Create the Issue
 
-`mktemp` 으로 임시 파일에 본문을 쓰고 metrics 블록을 append 한 뒤 생성한다:
+`mktemp` 으로 임시 파일에 본문을 쓰고 metrics 블록을 append 한 뒤 생성한다.
+`GH_DISABLE_AI_METRICS=1` 이면 footer append 를 skip — 본문만 그대로
+생성된다 (issue #399).
 
 ```bash
 BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
 # ... write body to "$BODY" ...
-printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
-  "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
+      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+fi
 gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY" \
     "${LABEL_ARGS[@]}" "${MILESTONE_ARGS[@]}"
 ```

--- a/claude/skills/gh-issue-create/references/metrics-helper.md
+++ b/claude/skills/gh-issue-create/references/metrics-helper.md
@@ -2,6 +2,35 @@
 
 Reference for all skills that record `<!-- ai-metrics:* -->` blocks.
 
+## Opt-out via `GH_DISABLE_AI_METRICS`
+
+Setting `GH_DISABLE_AI_METRICS=1` skips footer attachment in every
+`gh:*` skill that posts to GitHub (issue/PR body footer or comment).
+Default behaviour (footer attached) is unchanged when the variable is
+unset or not equal to `1`.
+
+```bash
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics skipped via GH_DISABLE_AI_METRICS
+else
+    # ...attach footer / post comment...
+fi
+```
+
+Scope:
+
+| Skill | Honors env? |
+|---|---|
+| `gh-issue-create`, `gh-pr`, `gh-pr-merge-emergency` (body footer) | yes |
+| `gh-commit`, `gh-pr-reply`, `gh-pr-approve`, `gh-pr-merge`, `gh-pr-resolve-conflict`, `gh-issue-flow` (PR/issue comment) | yes |
+| `gh-issue-implement`, `gh-issue-read` (stdout-only context block) | no — never writes to GitHub |
+| `gh-add-ai-metrics` (backfill tool) | **no — explicit retrofit intent overrides the env var** |
+
+Backfill is the deliberate "fill in the missing footer" path; respecting
+the env there would defeat its purpose. Every other `gh:*` skill must
+short-circuit before the GitHub write when the var is `1`. Catalog
+entry: `docs/standards/env-vars.md`.
+
 ## START_TS Recording
 
 Every skill records its start time at the top of Step 1:
@@ -63,22 +92,32 @@ From `gh-issue-create/references/metrics-baseline.md` by issue type:
 </details>
 ```
 
-Append via `printf` to a temp file before creating the artifact:
+Append via `printf` to a temp file before creating the artifact (skip
+entirely when `GH_DISABLE_AI_METRICS=1`):
 
 ```bash
-printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:%s -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:%s -->\n\n</details>\n' \
-  "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" >> "$BODY"
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:%s -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:%s -->\n\n</details>\n' \
+      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" "$TOKENS" "$HUMAN_H" "$ELAPSED" "$SKILL" >> "$BODY"
+fi
 ```
 
 ### GitHub PR / Issue comment
 
-Post after the artifact is created:
+Post after the artifact is created (skip when
+`GH_DISABLE_AI_METRICS=1`):
 
 ```bash
-gh api "repos/$TARGET_REPO/issues/$ISSUE_OR_PR_NUM/comments" \
-  -X POST \
-  -f body="<!-- ai-metrics:$SKILL tokens=$TOKENS human_h=$HUMAN_H ai_min=$ELAPSED -->
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$ISSUE_OR_PR_NUM/comments" \
+      -X POST \
+      -f body="<!-- ai-metrics:$SKILL tokens=$TOKENS human_h=$HUMAN_H ai_min=$ELAPSED -->
 🤖 ~$ELAPSED min · 👤 ~$HUMAN_H h · 📊 ~$TOKENS tokens"
+fi
 ```
 
 ### stdout-only (read-only skills)

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -143,12 +143,18 @@ if the previous completed successfully.
    d. Token estimate: character count of (issue body + implementation file reads) ÷ 4,
       rounded to nearest 500. Minimum 1 000.
    e. Post the aggregate comment on the linked issue (body template below).
+      Skip the post entirely when `GH_DISABLE_AI_METRICS=1` (issue #399);
+      the five sub-skills already honour the same env var, so a disabled
+      run leaves zero ai-metrics artifacts on the issue or PR.
    f. On failure: print `⚠️  ai-metrics comment failed (<reason>) — continuing.`
 
 ```bash
-gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
-  -X POST \
-  -f body="### ✅ gh-issue-flow 완료
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
+      -X POST \
+      -f body="### ✅ gh-issue-flow 완료
 
 | 단계 | AI 소요 |
 |------|---------|
@@ -162,6 +168,7 @@ gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
 👤 예상 사람 시간: ~$HUMAN_H h · 📊 ~$TOKENS tokens
 
 <!-- ai-metrics:gh-issue-flow tokens=$TOKENS human_h=$HUMAN_H ai_min=$ELAPSED -->"
+fi
 ```
 
 ## Step 3: Report

--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -86,14 +86,19 @@ Match the PR's dominant language.
   `--admin-merge` exactly as specified in `references/self-pr-handling.md`.
 
 After submitting the review (any path), post a separate PR comment with
-ai-metrics (soft-fail — warn on error, never block):
+ai-metrics (soft-fail — warn on error, never block). When
+`GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-  -X POST \
-  -f body="<!-- ai-metrics:gh-pr-approve tokens=${TOKENS:-5000} human_h=1 ai_min=$ELAPSED -->
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="<!-- ai-metrics:gh-pr-approve tokens=${TOKENS:-5000} human_h=1 ai_min=$ELAPSED -->
 🤖 PR 리뷰: ~$ELAPSED min · 👤 ~1 h (estimate)"
+fi
 ```
 
 On failure: `⚠️  ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr-merge-emergency/SKILL.md
+++ b/claude/skills/gh-pr-merge-emergency/SKILL.md
@@ -77,13 +77,19 @@ Non-negotiable audit tail. File `incident: emergency merge of PR #<N> —
 `gh label list --repo "$TARGET_REPO"` confirms it exists.
 
 Include the ai-metrics block in the incident issue body (append before
-creating — no soft-fail here since the incident issue is a required artifact):
+creating — no soft-fail here since the incident issue is a required
+artifact). When `GH_DISABLE_AI_METRICS=1`, skip the footer; the
+incident issue itself is still created (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
 # Append to the issue body temp file before gh issue create:
-printf '\n---\n<!-- ai-metrics:gh-pr-merge-emergency -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr-merge-emergency -->\n' \
-  "${TOKENS:-3000}" "${HUMAN_H:-1}" "$ELAPSED" >> "$INCIDENT_BODY"
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<!-- ai-metrics:gh-pr-merge-emergency -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr-merge-emergency -->\n' \
+      "${TOKENS:-3000}" "${HUMAN_H:-1}" "$ELAPSED" >> "$INCIDENT_BODY"
+fi
 ```
 
 ## Step 6: Sync Project Board Status

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -142,14 +142,19 @@ Both helpers auto-detect repos without a projectV2 attachment and
 silently return. This step never blocks the report — failures are
 logged to stderr and ignored.
 
-After the board sync completes, post an ai-metrics PR comment (soft-fail):
+After the board sync completes, post an ai-metrics PR comment (soft-fail).
+When `GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-  -X POST \
-  -f body="<!-- ai-metrics:gh-pr-merge tokens=${TOKENS:-2000} human_h=0.25 ai_min=$ELAPSED -->
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="<!-- ai-metrics:gh-pr-merge tokens=${TOKENS:-2000} human_h=0.25 ai_min=$ELAPSED -->
 🤖 PR merge: ~$ELAPSED min"
+fi
 ```
 
 On failure: `⚠️  ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -90,15 +90,20 @@ already-replied comments.
 
 After printing the report, post a PR comment with ai-metrics (soft-fail —
 warn on error, never block). `COMMENT_COUNT` is the number of comments
-addressed in Step 5 (including declined and bot comments):
+addressed in Step 5 (including declined and bot comments). When
+`GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
 HUMAN_H=$(echo "scale=2; $COMMENT_COUNT * 0.25" | bc)
-gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-  -X POST \
-  -f body="<!-- ai-metrics:gh-pr-reply tokens=${TOKENS:-5000} human_h=$HUMAN_H ai_min=$ELAPSED -->
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="<!-- ai-metrics:gh-pr-reply tokens=${TOKENS:-5000} human_h=$HUMAN_H ai_min=$ELAPSED -->
 🤖 리뷰 답변: ~$ELAPSED min · 👤 ~$HUMAN_H h ($COMMENT_COUNT comments × 0.25 h)"
+fi
 ```
 
 On failure: `⚠️  ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -127,15 +127,20 @@ warning (idempotent).
 
 After the report, post a PR comment with ai-metrics (soft-fail — warn on
 error, never block). `CONFLICT_FILES` is the count of files that had
-`UU`/`AA`/`DU` conflicts in Step 3:
+`UU`/`AA`/`DU` conflicts in Step 3. When `GH_DISABLE_AI_METRICS=1`,
+skip the comment entirely (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
 HUMAN_H=$(echo "scale=2; $CONFLICT_FILES * 0.5" | bc)
-gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-  -X POST \
-  -f body="<!-- ai-metrics:gh-pr-resolve-conflict tokens=${TOKENS:-3000} human_h=$HUMAN_H ai_min=$ELAPSED -->
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="<!-- ai-metrics:gh-pr-resolve-conflict tokens=${TOKENS:-3000} human_h=$HUMAN_H ai_min=$ELAPSED -->
 🤖 컨플릭트 해결: ~$ELAPSED min · 👤 ~$HUMAN_H h ($CONFLICT_FILES files × 0.5 h)"
+fi
 ```
 
 On failure: `⚠️  ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -76,11 +76,20 @@ footer block (soft-fail — warn on error, never block):
    Counting `$BODY` (the PR-body temp file) is the regression that
    produced PR #325's `📊 ~1000 tokens` footer (issue #326).
 
+When `GH_DISABLE_AI_METRICS=1`, skip the footer entirely (issue #399).
+The PR body is otherwise identical, and the linked issue still gets
+its body — only the footer block is omitted.
+
 ```bash
 # After running the snippet from references/metrics-helper.md, $TOKENS is
-# bound to the correct estimate. Now append the footer to $BODY.
-printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n\n</details>\n' \
-  "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+# bound to the correct estimate. Now append the footer to $BODY — unless
+# the operator opted out via GH_DISABLE_AI_METRICS=1.
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n\n</details>\n' \
+      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+fi
 ```
 
 ## Step 5: Push and Create

--- a/docs/standards/env-vars.md
+++ b/docs/standards/env-vars.md
@@ -1,0 +1,86 @@
+# Environment Variables Catalog
+
+Cross-skill / cross-tool env vars that change runtime behaviour. New
+toggles MUST land here so operators can grep one file before adopting
+a new repo or workspace.
+
+## `gh:*` skills
+
+### `GH_DISABLE_AI_METRICS`
+
+| Field | Value |
+|---|---|
+| Default | unset |
+| Active when | set to `1` |
+| Scope | every `gh:*` skill that writes to GitHub (issue/PR body footer, issue/PR comment) |
+| Source SSOT | `claude/skills/gh-issue-create/references/metrics-helper.md` |
+| Issue | [#399](https://github.com/dEitY719/dotfiles/issues/399) — design comment [#384](https://github.com/dEitY719/dotfiles/issues/384#issuecomment-4404284951) |
+
+When the variable is `1`, the following skills skip ai-metrics
+attachment and produce identical artifacts otherwise:
+
+- `gh:issue-create` — issue body footer
+- `gh:pr` — PR body footer
+- `gh:commit` — linked-issue comment
+- `gh:pr-reply`, `gh:pr-approve`, `gh:pr-merge`, `gh:pr-resolve-conflict` — PR comment
+- `gh:pr-merge-emergency` — incident issue body footer
+- `gh:issue-flow` — flow-aggregate issue comment (Step 2.6)
+
+`gh:issue-implement` and `gh:issue-read` print metrics to stdout only,
+so the env var has no effect there.
+
+`gh:add-ai-metrics` is the **deliberate retrofit** path and **ignores**
+this var — that is its entire purpose.
+
+Use cases:
+
+- External / company repos that disallow AI-usage markers in artifacts
+- Debugging or one-off invocations where the footer would be noise
+- Mirroring a teammate's preference temporarily
+
+Per-call examples:
+
+```bash
+GH_DISABLE_AI_METRICS=1 /gh-pr 399
+GH_DISABLE_AI_METRICS=1 /gh-commit
+```
+
+Persist for a session:
+
+```bash
+export GH_DISABLE_AI_METRICS=1
+```
+
+### `GH_PR_MERGE_SKIP_BOARD_CHECK`
+
+| Field | Value |
+|---|---|
+| Default | unset |
+| Active when | set to `1` |
+| Scope | `gh:pr-merge` board approval gate (Step 4-B) |
+| Source SSOT | `claude/skills/gh-pr-merge/SKILL.md` |
+| Issue | [#397](https://github.com/dEitY719/dotfiles/issues/397) |
+
+When `1`, bypasses the projectV2 board "Approved" check inside
+`gh:pr-merge`. Used during board-config transitions where the
+authoritative status moves between fields.
+
+### `GH_PROJECT_STATUS_SYNC`
+
+| Field | Value |
+|---|---|
+| Default | unset (treated as enabled) |
+| Active when | set to `0` |
+| Scope | every `gh:*` skill that calls `_gh_project_status_sync` |
+| Source SSOT | `shell-common/functions/gh_project_status.sh` |
+
+When `0`, skip pushing project-board card status updates. Repos
+without a projectV2 attachment auto-skip without needing the var.
+
+## How to add a new entry
+
+1. Document the var here first (this file is the catalog SSOT).
+2. Implement the env branch in the skill / function SSOT.
+3. Add a regression test in `tests/bats/` that covers the set/unset
+   branches.
+4. Land all three in the same PR.

--- a/tests/bats/skills/_fixtures/gh_disable_ai_metrics.sh
+++ b/tests/bats/skills/_fixtures/gh_disable_ai_metrics.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_disable_ai_metrics.sh
+# Source-of-truth mirror for the GH_DISABLE_AI_METRICS env-guard pattern
+# documented in claude/skills/gh-issue-create/references/metrics-helper.md.
+#
+# The pattern is small but invariant across every gh:* skill that writes
+# ai-metrics to GitHub — wrap the printf/gh-api call in:
+#
+#     if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+#         : # skip
+#     else
+#         <existing block>
+#     fi
+#
+# This fixture mirrors that block in isolation so the bats suite catches
+# behavioural drift (e.g. someone changing the comparison to a truthy
+# coercion that opts unrelated values into skip).
+
+# Append the footer to $1 (path to a temp body file). Returns 0 in both
+# branches — the env-guard never blocks the surrounding flow (soft-fail).
+gh_metrics_append_footer() {
+    local _body="$1"
+    if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+        : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+    else
+        printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:test -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:test -->\n\n</details>\n' \
+            1000 1 5 1000 1 5 >> "$_body"
+    fi
+}
+
+# Convenience wrapper — creates a tempfile, appends, and cats the result
+# so `run` can `assert_output --partial`. Cleans up the tempfile.
+gh_metrics_append_footer_to_tempfile() {
+    local _body
+    _body=$(mktemp)
+    gh_metrics_append_footer "$_body"
+    cat "$_body"
+    rm -f "$_body"
+}

--- a/tests/bats/skills/gh_disable_ai_metrics.bats
+++ b/tests/bats/skills/gh_disable_ai_metrics.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_disable_ai_metrics.bats
+# Issue #399 — verify every gh:* skill that writes ai-metrics to GitHub
+# carries the GH_DISABLE_AI_METRICS=1 short-circuit.
+#
+# Two layers:
+#   1. Doc-level: each SKILL.md that calls `gh api ... comments`,
+#      `gh issue create`, or appends a `<!-- ai-metrics:* -->` block
+#      to a body file MUST contain the env-guard literal. Catches
+#      future SKILL.md edits that forget to wrap a new metrics block.
+#   2. Behavioural: a fixture mirrors the exact env-guard pattern from
+#      the SSOT (gh-issue-create/references/metrics-helper.md). With
+#      env unset/empty/!=1 the body is appended; with env=1 it is
+#      skipped. Catches semantic drift in the guard itself.
+#
+# Backfill (gh-add-ai-metrics) is intentionally exempt — it ignores
+# the env var by design (see issue #399 acceptance criteria).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_disable_ai_metrics.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset GH_DISABLE_AI_METRICS
+}
+
+# -- Layer 1: doc-level env-guard presence -----------------------------------
+
+# Every entry: <skill-dir>:<expected-substring-anchor> — anchor is something
+# unique to that skill's metrics block so the test pinpoints the right region.
+SKILLS_REQUIRING_GUARD=(
+    "gh-issue-create"
+    "gh-pr"
+    "gh-commit"
+    "gh-pr-reply"
+    "gh-pr-approve"
+    "gh-pr-merge"
+    "gh-pr-merge-emergency"
+    "gh-pr-resolve-conflict"
+    "gh-issue-flow"
+)
+
+@test "doc-guard: every gh:* SKILL.md that writes ai-metrics has GH_DISABLE_AI_METRICS branch" {
+    for skill in "${SKILLS_REQUIRING_GUARD[@]}"; do
+        local f="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}/SKILL.md"
+        run grep -F 'GH_DISABLE_AI_METRICS:-0' "$f"
+        [ "$status" -eq 0 ] || {
+            echo "missing GH_DISABLE_AI_METRICS guard in $f"
+            return 1
+        }
+    done
+}
+
+@test "doc-guard: SSOT metrics-helper.md documents the env var" {
+    local f="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-issue-create/references/metrics-helper.md"
+    run grep -F 'GH_DISABLE_AI_METRICS' "$f"
+    assert_success
+    run grep -F 'gh-add-ai-metrics' "$f"
+    assert_success
+}
+
+@test "doc-guard: gh-add-ai-metrics SKILL.md does NOT skip on the env var (backfill is explicit)" {
+    # Backfill is the deliberate retrofit path; respecting the env there
+    # would defeat the entire purpose of the tool. Verify it never adds
+    # an opt-out branch by accident.
+    local f="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-add-ai-metrics/SKILL.md"
+    run grep -F 'GH_DISABLE_AI_METRICS' "$f"
+    [ "$status" -ne 0 ] || {
+        echo "gh-add-ai-metrics must not honor GH_DISABLE_AI_METRICS — backfill is explicit"
+        return 1
+    }
+}
+
+@test "doc-guard: env-vars.md catalog registers GH_DISABLE_AI_METRICS" {
+    local f="${_BATS_REAL_DOTFILES_ROOT}/docs/standards/env-vars.md"
+    [ -f "$f" ] || {
+        echo "missing catalog: $f"
+        return 1
+    }
+    run grep -F 'GH_DISABLE_AI_METRICS' "$f"
+    assert_success
+}
+
+# -- Layer 2: behavioural mirror of the SSOT guard ---------------------------
+
+@test "behaviour: env unset → footer appended" {
+    unset GH_DISABLE_AI_METRICS
+    local body
+    body=$(mktemp)
+    run gh_metrics_append_footer "$body"
+    assert_success
+    run grep -c 'ai-metrics' "$body"
+    [ "$output" -ge 2 ]
+    rm -f "$body"
+}
+
+@test "behaviour: env empty → footer appended (treated as unset)" {
+    GH_DISABLE_AI_METRICS="" run gh_metrics_append_footer_to_tempfile
+    assert_success
+    assert_output --partial 'ai-metrics:test'
+}
+
+@test "behaviour: env=0 → footer appended" {
+    GH_DISABLE_AI_METRICS=0 run gh_metrics_append_footer_to_tempfile
+    assert_success
+    assert_output --partial 'ai-metrics:test'
+}
+
+@test "behaviour: env=1 → footer skipped, body untouched" {
+    GH_DISABLE_AI_METRICS=1 run gh_metrics_append_footer_to_tempfile
+    assert_success
+    refute_output --partial 'ai-metrics'
+    refute_output --partial 'AI Metrics'
+}
+
+@test "behaviour: env=2 → footer appended (only literal '1' opts out)" {
+    # Guards against future drift to truthy-coercion that would silently
+    # opt unrelated values into skip behaviour.
+    GH_DISABLE_AI_METRICS=2 run gh_metrics_append_footer_to_tempfile
+    assert_success
+    assert_output --partial 'ai-metrics:test'
+}
+
+@test "behaviour: env=true → footer appended (only literal '1' opts out)" {
+    GH_DISABLE_AI_METRICS=true run gh_metrics_append_footer_to_tempfile
+    assert_success
+    assert_output --partial 'ai-metrics:test'
+}


### PR DESCRIPTION
## Summary
- 모든 `gh:*` skill 의 ai-metrics footer/comment 부착에 `GH_DISABLE_AI_METRICS=1` 비활성화 토글 추가 (#399).
- 기본 동작 (footer 부착) 보존 — env unset 또는 `1` 이외 값일 때는 현행 그대로.
- `gh-add-ai-metrics` (backfill 도구) 는 의도적으로 env 무시 — 본 토글의 예외.

## Changes
- `claude/skills/gh-issue-create/references/metrics-helper.md` — env-guard SSOT 문서화. 적용 범위 매트릭스 + per-skill 매핑.
- `claude/skills/gh-issue-create/SKILL.md` · `gh-pr/SKILL.md` · `gh-pr-merge-emergency/SKILL.md` — body footer `printf` 를 env-guard 로 wrap.
- `claude/skills/gh-commit/SKILL.md` · `gh-pr-reply/SKILL.md` · `gh-pr-approve/SKILL.md` · `gh-pr-merge/SKILL.md` · `gh-pr-resolve-conflict/SKILL.md` — issue/PR comment `gh api ... POST` 를 env-guard 로 wrap.
- `claude/skills/gh-issue-flow/SKILL.md` — Step 2.6 의 flow-aggregate comment 를 env-guard 로 wrap. 5개 sub-skill 이 모두 env 를 honor 하므로 disabled 실행 시 issue/PR 양쪽에 ai-metrics 흔적 0건.
- `docs/standards/env-vars.md` (신규) — env-vars 카탈로그 신설. `GH_DISABLE_AI_METRICS` · `GH_PR_MERGE_SKIP_BOARD_CHECK` · `GH_PROJECT_STATUS_SYNC` 한 곳에 정리.
- `tests/bats/skills/gh_disable_ai_metrics.bats` (신규) — 10 tests. 두 레이어:
  1. doc-guard — 9개 SKILL.md 가 `GH_DISABLE_AI_METRICS:-0` literal 보유, `gh-add-ai-metrics` 는 보유하지 않음, 카탈로그가 등재됨.
  2. behaviour — env unset / `""` / `0` / `1` / `2` / `true` 6 케이스를 fixture 가 mirror.
- `tests/bats/skills/_fixtures/gh_disable_ai_metrics.sh` (신규) — SSOT 의 env-guard 패턴을 isolation 에서 검증 가능하도록 mirror.

## 적용 범위

| Skill | env honors? |
|---|---|
| `gh:issue-create`, `gh:pr`, `gh:pr-merge-emergency` (body footer) | yes |
| `gh:commit`, `gh:pr-reply`, `gh:pr-approve`, `gh:pr-merge`, `gh:pr-resolve-conflict`, `gh:issue-flow` (issue/PR comment) | yes |
| `gh:issue-implement`, `gh:issue-read` (stdout-only) | no — GitHub 에 안 씀 |
| `gh:add-ai-metrics` (backfill) | **no — 명시적 retrofit, env 무시** |

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_disable_ai_metrics.bats` — 10/10 pass
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/init tests/bats/functions tests/bats/tools tests/bats/skills` — **504/504 pass**, 0 failures, exit 0
- [ ] (옵션) `GH_DISABLE_AI_METRICS=1 /gh-pr-reply 999` 같은 라이브 호출 — 문서/테스트 변경뿐이라 회귀 위험 낮음.

## Related
Closes #399

---
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~8 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
