### PR TITLE
docs: add CLAUDE.md with project context and critical rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,12 +78,12 @@ source "${SHELL_COMMON}/path/to/file.sh"
 
 **Interactive guard** — every file that produces output must start with:
 ```bash
-[[ $- == *i* ]] || return 0
+case $- in *i*) ;; *) return 0 ;; esac
 ```
 
 **No direct writes to `~/.bashrc`** — use symlinks via `setup.sh`.
 
-**After adding any new module**: update the parent `AGENTS.md` Context Map.
+**After adding a module**: update the `AGENTS.md` in the module root.
 
 **On lint/test failure**: fix the root cause — do not use `--no-verify` or skip hooks.
 
@@ -96,4 +96,4 @@ source "${SHELL_COMMON}/path/to/file.sh"
 - Git strategy: Semantic commits (`Type: Summary`)
 - Naming: `snake_case` for functions and filenames; dash-form for user-facing aliases
 - No emojis anywhere (token efficiency)
-- AGENTS.md files must stay under 100 lines each
+- For AGENTS.md files, aim to keep them under 100 lines each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Setup
+./setup.sh          # Symlinks + environment config
+./install.sh        # Full install
+
+# Lint (all)
+tox                 # ruff, mypy, shellcheck, shfmt
+
+# Lint (targeted)
+tox -e shellcheck   # Shell script validation
+tox -e shfmt        # Shell script formatting (bash/ only)
+tox -e ruff         # Python format + fix
+tox -e mypy         # Python type check
+
+# Tests
+./tests/test        # All tests (bats + pytest + golden rules)
+./tests/test -v     # Verbose
+pytest tests/integration/test_help_topics.py -v  # Single pytest file
+./tests/bats/lib/bats-core/bin/bats tests/bats/functions  # Bats only
+
+# UX demo
+shell-common/tools/custom/demo_ux.sh
+```
+
+Markdown linting (`tox -e mdlint`) is **disabled** — do not run it.
+
+## Architecture
+
+This repo is a modular dotfiles system. Shell config is split into three layers:
+
+- **`bash/`** — Bash-specific entry point (`main.bash`), env, utils
+- **`zsh/`** — Zsh-specific entry point (`main.zsh`), env, apps
+- **`shell-common/`** — POSIX-compatible shared code, sourced by both loaders
+
+### shell-common/ Directory Placement
+
+See `shell-common/AGENTS.md` → "Decision Tree" and "Quick Reference Table" for the full placement guide.
+
+Key rule: `tools/custom/` is **never auto-sourced** — scripts there must be called explicitly.
+
+### Adding a New Tool Integration
+
+See `shell-common/AGENTS.md` → "Adding a New Tool Integration (3-Step Pattern)" for the required 3-file sequence (`tools/integrations/`, `functions/*_help.sh`, `functions/my_help.sh` registration).
+
+### UX Library
+
+All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `ux_info`). Never use raw `echo`, `printf`, or `tput` in app scripts. Source: `shell-common/tools/ux_lib/ux_lib.sh`. Guidelines: `shell-common/tools/ux_lib/UX_GUIDELINES.md`.
+
+### Git Hooks
+
+`git/` manages a 2-tier hook system. Config SSOT is `git/config/hook-config.sh`. Debug with `GIT_HOOKS_DEBUG=1 git commit -m "msg"`. Test with `bash git/tests/test_hooks.sh`.
+
+### Claude Code Integration
+
+`claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` directory is bind-mounted to `~/.claude/skills/` (not symlinked).
+
+## Critical Rules
+
+**POSIX compatibility in shell-common/**
+- Use `>/dev/null 2>&1` (not `&>/dev/null`)
+- Use `[ ]` (not `[[ ]]`) unless inside a shell-detection branch
+- Use `#!/bin/sh` shebang
+
+**Sourcing across shells** — forbidden pattern:
+```bash
+# WRONG — bash-only, breaks in zsh
+source "${BASH_SOURCE[0]%/*}/file.sh"
+
+# CORRECT
+source "${SHELL_COMMON}/path/to/file.sh"
+```
+
+**Interactive guard** — every file that produces output must start with:
+```bash
+[[ $- == *i* ]] || return 0
+```
+
+**No direct writes to `~/.bashrc`** — use symlinks via `setup.sh`.
+
+**After adding any new module**: update the parent `AGENTS.md` Context Map.
+
+**On lint/test failure**: fix the root cause — do not use `--no-verify` or skip hooks.
+
+**Agent isolation is blocked in this repo.** `Agent({ isolation: "worktree" })` triggers a `git-crypt` smudge filter failure. Use sequential dispatch (no `isolation` key) or the `ai-worktree-spawn` skill. See `claude/AGENTS.md` and `docs/learnings/git-crypt-worktree-bootstrap.md`.
+
+## Standards & References
+
+- Command/help interface: `docs/standards/command-guidelines.md`
+- GitHub Project board: `docs/standards/github-project-board.md`
+- Git strategy: Semantic commits (`Type: Summary`)
+- Naming: `snake_case` for functions and filenames; dash-form for user-facing aliases
+- No emojis anywhere (token efficiency)
+- AGENTS.md files must stay under 100 lines each


### PR DESCRIPTION
## Summary
- CLAUDE.md 신규 추가 — Claude Code 인스턴스가 이 리포에서 빠르게 컨텍스트를 파악할 수 있도록 커맨드, 아키텍처, 핵심 규칙을 정리

## Changes
- docs(CLAUDE.md): 공통 커맨드(tox, tests/test, setup.sh) 및 각 tox 환경 설명 추가
- docs(CLAUDE.md): bash/zsh/shell-common 3계층 아키텍처 설명 및 shell-common 배치 규칙을 `shell-common/AGENTS.md`로 위임
- docs(CLAUDE.md): 신규 도구 통합 3-파일 패턴도 `shell-common/AGENTS.md`로 위임 (인라인 중복 제거)
- docs(CLAUDE.md): Critical Rules 섹션에 모듈 추가 후 AGENTS.md 업데이트 의무 및 hook 스킵 금지 규칙 추가
- docs(CLAUDE.md): git-crypt + Agent isolation 차단 이슈 문서화 (smudge filter 실패 패턴)

## Test plan
- [ ] `CLAUDE.md`가 `claude.ai/code`에서 정상 로드되는지 확인
- [ ] shell-common/AGENTS.md 링크가 올바른 섹션으로 연결되는지 확인
