### PR TITLE
feat(gh-pr-approve): honest ai-metrics + Explore for large diffs

### DIFF
--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -58,10 +58,10 @@ concern must be verified as fixed, tracked, or acceptably declined.
 
 ## Step 2: Fetch Review Material
 
-Decide path by diff size: `gh pr view <N> --json additions,deletions`.
+Decide path by diff size: `gh pr view <N> --repo $TARGET_REPO --json additions,deletions`.
 When `additions + deletions` meets the threshold defined in
 `references/large-diff-delegation.md`, dispatch an Explore subagent
-per that file and skip loading the full diff into the main context;
+following that file and skip loading the full diff into the main context;
 use the returned BLOCKER/FOLLOW-UP/PRAISE summary as the input for
 Step 3. Below the threshold, fall back to the inline path.
 

--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   /gh-pr-approve, /gh:pr-approve, "approve PR 99", "#99 리뷰 승인", or
   "re-review requested". Self-authored PRs cannot be approved; they use
   analysis-only, comment-only, or admin-merge paths.
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash, Read, Grep, Glob, Agent
 ---
 
 # gh:pr-approve - Review, Approve, or Handle Self-PR
@@ -58,10 +58,17 @@ concern must be verified as fixed, tracked, or acceptably declined.
 
 ## Step 2: Fetch Review Material
 
-In parallel: `gh pr diff <N>`, commits JSON, and the three comment
-endpoints in `references/review-criteria.md`. Apply that checklist. In
-re-review mode, map each prior concern to a fixing commit, tracking issue,
-or acceptable author reply.
+Decide path by diff size: `gh pr view <N> --json additions,deletions`.
+When `additions + deletions` meets the threshold defined in
+`references/large-diff-delegation.md`, dispatch an Explore subagent
+per that file and skip loading the full diff into the main context;
+use the returned BLOCKER/FOLLOW-UP/PRAISE summary as the input for
+Step 3. Below the threshold, fall back to the inline path.
+
+Inline path — in parallel: `gh pr diff <N>`, commits JSON, and the
+three comment endpoints in `references/review-criteria.md`. Apply
+that checklist. In re-review mode, map each prior concern to a
+fixing commit, tracking issue, or acceptable author reply.
 
 ## Step 3: Classify Findings
 
@@ -96,10 +103,15 @@ if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
 else
     gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
       -X POST \
-      -f body="<!-- ai-metrics:gh-pr-approve tokens=${TOKENS:-5000} human_h=1 ai_min=$ELAPSED -->
-🤖 PR 리뷰: ~$ELAPSED min · 👤 ~1 h (estimate)"
+      -f body="<!-- ai-metrics:gh-pr-approve ai_min=$ELAPSED -->
+🤖 PR 리뷰: ~$ELAPSED min"
 fi
 ```
+
+The `tokens` and `human_h` fields are intentionally omitted: this skill
+has no real measurement source for either, and the prior `${TOKENS:-5000}`
+/ `human_h=1` placeholders would silently inject the same false numbers
+into every aggregator (issue #403). Only `ai_min` is reported.
 
 On failure: `⚠️  ai-metrics comment failed — continuing.`
 

--- a/claude/skills/gh-pr-approve/references/large-diff-delegation.md
+++ b/claude/skills/gh-pr-approve/references/large-diff-delegation.md
@@ -1,0 +1,54 @@
+# Large-Diff Explore Delegation
+
+Step 2 of `gh:pr-approve` decides between an inline diff read and a
+subagent delegation based on PR size. Large diffs would otherwise
+crowd the main context and accumulate cost across chained PR reviews
+in the same session.
+
+## Threshold (single source of truth)
+
+`THRESHOLD_LINES = 800` — the sum of `additions + deletions` from
+`gh pr view <N> --json additions,deletions`. PRs at or above this
+threshold are delegated; below it, the inline path runs unchanged.
+
+The number is a starting point. Tune it in this file when PR-size
+distribution data justifies it. Do **not** hardcode the threshold
+anywhere else (issue #403 acceptance criterion: single source of
+truth in references/).
+
+## When to delegate
+
+Pure size gate. Re-review mode does not change the decision: the
+returned summary still feeds Step 3, and prior-concern mapping
+happens on top of it.
+
+## Dispatch
+
+Invoke `Agent(subagent_type="Explore")` with this prompt template
+(substitute `<N>` and `<TARGET_REPO>`):
+
+> Summarize the diff for PR #<N> in repo <TARGET_REPO> for review
+> classification. Run `gh pr diff <N> --repo <TARGET_REPO>` (and any
+> follow-up grep / file read needed for context). Return a short
+> report (≤ 300 words) split into three sections:
+>
+> 1. **BLOCKER candidates** — correctness, security, regression risks.
+>    Each item: `file:line` + one-line reason.
+> 2. **FOLLOW-UP candidates** — non-blocking quality concerns. Each
+>    item: `file:line` + one-line reason.
+> 3. **PRAISE candidates** — concrete diff locations worth highlighting.
+>    Each item: `file:line` + one-line reason.
+>
+> Do not include the full diff text. Only the classified items. If a
+> section is empty, write `(none)`.
+
+Use the returned summary as input to Step 3 classification. The
+Step 4 templates and the 4a / 4b / 4c approval-path branching remain
+unchanged — only the source of the classified findings differs.
+
+## Why not delegate every PR
+
+Small PRs would pay the subagent dispatch overhead (cold context,
+extra round-trip) for no context-savings benefit. The size gate
+keeps the inline path on the hot path while bounding worst-case
+context growth on large reviews.


### PR DESCRIPTION
## Summary
- gh-pr-approve 스킬의 ai-metrics 코멘트가 매번 `tokens=5000` / `human_h=1` 라는 거짓 상수를 박던 문제를 제거하고, 측정 가능한 `ai_min` 만 남겼다.
- Step 2 의 diff 처리에 사이즈 게이트를 도입해, 800 줄 이상의 큰 PR 은 Explore 서브에이전트로 위임해 main context 점유를 줄인다.
- 임계치는 새 `references/large-diff-delegation.md` 에 단일 소스로 두고, `allowed-tools` 에 `Agent` 를 추가해 위임이 구조적으로 가능하게 했다.

## Changes
- `claude/skills/gh-pr-approve/SKILL.md`
  - frontmatter: `allowed-tools` 에 `Agent` 추가 (F-3).
  - Step 2: `additions+deletions` 임계치(800) 분기 추가 — 임계치 이상이면 Explore 위임, 미만이면 기존 inline 경로 (F-2).
  - Step 4 ai-metrics 블록: `tokens=${TOKENS:-5000}` / `human_h=1` 제거. 측정 가능한 `ai_min=$ELAPSED` 만 보낸다 (F-1, 옵션 b 채택).
  - 변경 의도를 본문에 못박는 짧은 주석 한 단락 추가 (issue #403).
- `claude/skills/gh-pr-approve/references/large-diff-delegation.md` (신규)
  - 임계치 `THRESHOLD_LINES = 800` 단일 SSOT.
  - Explore 서브에이전트 dispatch 프롬프트 (BLOCKER/FOLLOW-UP/PRAISE 분류, ≤300 단어).
  - 임계치 이하 PR 은 기존 inline 경로 유지 — NF-1 (작은 PR 오버헤드 없음) 보존.

기존 4a / 4b / 4c 분기 동작과 `GH_DISABLE_AI_METRICS` env-guard, ai-metrics 코멘트의 soft-fail 동작 모두 보존.

## Test plan
- [x] `tox -e ruff,mypy,shellcheck,shfmt` — pass.
- [x] doc-guard 정합성 (tests/bats/skills/gh_disable_ai_metrics.bats 가 요구하는 `GH_DISABLE_AI_METRICS:-0` 리터럴 보존) 수동 확인.
- [ ] 작은 PR (`additions+deletions < 800`) 1건에서 inline 경로가 그대로 도는지 회귀 확인.
- [ ] 큰 PR (`additions+deletions >= 800`) 1건에서 Explore 위임이 발동하고, 분류 결과가 Step 3 으로 흘러가는지 회귀 확인.
- [ ] 새 ai-metrics 코멘트가 `<!-- ai-metrics:gh-pr-approve ai_min=$ELAPSED -->` 한 줄만 박는지 확인.

## Related
Closes #403

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>

