### PR TITLE
feat(devx-trd-to-issues): scaffold /devx:trd-to-issues skill

### DIFF
--- a/claude/skills/devx-trd-to-issues/SKILL.md
+++ b/claude/skills/devx-trd-to-issues/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: devx:trd-to-issues
+description: >-
+  Decompose one or more TRD files (with optional companion PRD) into a
+  three-level Epic → Feature → Task plan and, on `--apply`, register the
+  resulting GitHub Milestones + Issues in bulk via `gh`. Use when the user
+  runs /devx:trd-to-issues, /devx-trd-to-issues, or asks "TRD를 마일스톤/이슈로
+  분해해줘", "PRD/TRD 파일로 일괄 등록", "decompose this TRD into milestones".
+  Default mode is `--dry-run` — only writes a Markdown plan; `--apply` mutates
+  GitHub. Refuses to auto-create missing labels and refuses an unknown remote.
+  Accepts `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Edit, Write, Grep
+---
+
+# devx:trd-to-issues — TRD → Milestones + Issues
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. **No API calls.**
+
+## Step 1: Parse Args + Resolve Repo
+
+Required positional: one or more `<trd-path>`. Flags: `--prd <path>`,
+`--remote <name>` (default `origin`), `--dry-run` (default), `--apply`,
+`--plan-out <path>` (default `.claude/.trd-to-issues.plan.md`),
+`--no-ready`. See `references/help.md` for the full table.
+
+Resolve `TARGET_REPO=<owner>/<repo>` per `references/repo-resolution.md`.
+Missing remote → list `git remote -v` and stop. **No silent fallback.**
+Every `<trd-path>` and `--prd <path>` must exist as a regular file; on
+the first miss, list the missing path and stop.
+
+## Step 2: Read TRD/PRD + Decompose
+
+Load each TRD (and optional PRD) via `Read`. Extract:
+
+- Milestones — TRD-named structure first; if absent, propose names and
+  ask the user to confirm before continuing.
+- Tasks — each must satisfy the criteria in
+  `references/decomposition-rules.md` (≤ 3 ACs, unit-testable,
+  independently committable). Items that fail the criteria are split
+  further or reported as "decomposition failures" in the plan.
+- Dependencies — extract `Depends on #...` keywords; emit virtual
+  citations (`#new-1`, `#new-2`, ...) that resolve to real numbers
+  during `--apply`.
+- Labels — apply the `pro-friendly` / `max-only` heuristic from
+  `references/decomposition-rules.md`; merge any priority labels named
+  in the TRD.
+
+## Step 3: Write Plan
+
+Write the decomposition to `--plan-out` using
+`references/plan-format.md` as the canonical skeleton. The plan is the
+single review surface for the user — it must round-trip back into Step 4
+without re-reading the TRD.
+
+In `--dry-run`, **stop here** and print:
+
+```
+Plan written: <plan-out> (M milestones, N tasks)
+Run with --apply to register on GitHub.
+```
+
+## Step 4: Apply (only if `--apply`)
+
+1. **Pre-validate labels** —
+   `gh label list --repo "$TARGET_REPO" --json name --jq '.[].name'`.
+   Any label referenced by the plan that is missing → stop with the
+   missing list. **Never POST `/labels`** (memory:
+   `feedback_gh_label_no_autocreate.md`).
+2. **Bulk-create milestones** —
+   `gh api repos/$TARGET_REPO/milestones -X POST -f title=... -f description=...`.
+   Title collision → stop and report (no silent skip/merge).
+3. **Create issues** — `gh issue create --repo "$TARGET_REPO" --title ...
+   --body-file <tmp> --milestone <title> --label <name>...` per task.
+4. **Resolve `#new-N` citations** — substitute virtual numbers with the
+   real numbers returned by step 3, then `gh issue edit <real-N>
+   --body-file <patched>`.
+5. **Promote first milestone to Ready** (skip if `--no-ready`) —
+   `claude-set-issue-status <real-N> "Ready"` per first-milestone issue.
+
+Mid-flow failure: report partial state (created milestones / issues so
+far) and stop — no automatic rollback.
+
+## Step 5: Report
+
+Print: `--plan-out` path, milestone count, task count, and (for
+`--apply`) the URL of the first created milestone for human verification.
+
+## Constraints
+
+- Default is `--dry-run`. `--apply` must be explicit.
+- Never auto-create labels — pre-validate, stop on miss.
+- Never silently fall back when `--remote <name>` is missing.
+- Never collapse the plan; the plan is the SSOT review surface.
+- Decomposition criteria are mandatory; failed items go into a
+  "decomposition failures" section, never silently dropped.

--- a/claude/skills/devx-trd-to-issues/SKILL.md
+++ b/claude/skills/devx-trd-to-issues/SKILL.md
@@ -35,8 +35,12 @@ the first miss, list the missing path and stop.
 
 Load each TRD (and optional PRD) via `Read`. Extract:
 
-- Milestones — TRD-named structure first; if absent, propose names and
-  ask the user to confirm before continuing.
+- Milestones — TRD-named structure first; if absent, write the
+  proposed names directly into the dry-run plan (under each
+  `## Milestone:` heading) so the user reviews them in the plan file
+  and edits or re-runs before `--apply`. Never block mid-flow on a
+  confirmation prompt — Claude Code is non-interactive and `read`
+  would hang.
 - Tasks — each must satisfy the criteria in
   `references/decomposition-rules.md` (≤ 3 ACs, unit-testable,
   independently committable). Items that fail the criteria are split

--- a/claude/skills/devx-trd-to-issues/references/decomposition-rules.md
+++ b/claude/skills/devx-trd-to-issues/references/decomposition-rules.md
@@ -1,0 +1,64 @@
+# Decomposition Rules + Labeling Heuristics
+
+Generalized from the manual decomposition done on
+[dev-team-404/AgentToolbox#433](https://github.com/dev-team-404/AgentToolbox/issues/433)
+(8 Milestones × 40 Issues). The rules below are the criteria the skill
+applies to every Task; the labeling heuristic decides which audience
+the Task is sized for.
+
+## Task-sizing criteria — must satisfy ALL three
+
+A Task is considered well-sized iff:
+
+1. **AC count: 1–3** — Acceptance Criteria are 1, 2, or 3 checkboxes.
+   4+ ACs means the task is doing too much; split it.
+2. **Unit-testable** — there is a clear way to verify the AC with a
+   unit test, integration test, or repeatable manual check. "Make X
+   look better" is not unit-testable; "X renders within 100ms on a
+   1000-row table" is.
+3. **Independently committable** — the Task can be committed without
+   waiting on a sibling Task in the same milestone. Tasks that share
+   uncommitted state with a sibling must be merged or re-split.
+
+If a Task fails any of the three, the skill attempts one
+auto-decomposition pass (split by AC, by file, or by stage). If still
+failing, the Task lands in the plan's **"Decomposition failures"**
+section with the failing criterion named — never silently dropped.
+
+## Labeling heuristic
+
+Exactly one of the size labels per Task:
+
+| Label | Heuristic |
+|-------|-----------|
+| `pro-friendly` | Estimated changed files ≤ 5 **and** estimated new lines of code ≤ 300. Single-session completability is clear. |
+| `max-only`     | Either heuristic exceeded, **or** the task carries non-trivial design judgment / external dependency complexity / cross-component contracts. |
+
+When the metrics are borderline but the context (TRD section, single
+file family, well-defined contract) makes single-session completion
+clear, prefer `pro-friendly` — see issue #433 for the original
+guidance.
+
+Priority labels (`⚡ High`, `🔥 Urgent`, etc.) are **lifted from the
+TRD** when the TRD names a priority for that section/task. They are
+additive — they do not replace the size label.
+
+## Hard rules
+
+- **Never auto-create labels.** If a label referenced by the plan is
+  missing on the target repo at `--apply` time, stop with the missing
+  list. Reason: `feedback_gh_label_no_autocreate.md` — POST `/labels`
+  silently creates the label, polluting the repo's label namespace.
+- **Never collapse "Decomposition failures" into the main task list.**
+  A failure is a signal that the user must split or rewrite the TRD
+  section; hiding it defeats the purpose of dry-run review.
+- **Never invent acceptance criteria.** If the TRD does not specify
+  ACs for a section, the Task lands in "Decomposition failures" with
+  reason "no AC found" — the user re-authors the TRD.
+
+## Pairs with
+
+- `references/plan-format.md` — where the labels and decomposition
+  failures appear in the rendered plan.
+- `references/samples/` — fixture verifying the rules apply
+  consistently to a small TRD.

--- a/claude/skills/devx-trd-to-issues/references/help.md
+++ b/claude/skills/devx-trd-to-issues/references/help.md
@@ -1,0 +1,97 @@
+# devx:trd-to-issues — Help
+
+## Usage
+
+```
+/devx:trd-to-issues <trd-path>... [flags]
+/devx-trd-to-issues docs/architecture/interface-ui.md
+/devx-trd-to-issues docs/trd-foo.md docs/trd-bar.md --prd docs/prd.md --apply
+/devx:trd-to-issues -h          # show this help
+/devx:trd-to-issues --help      # show this help
+/devx:trd-to-issues help        # show this help
+```
+
+## Arguments
+
+| # | Name | Required | Description |
+|---|------|----------|-------------|
+| 1+ | `<trd-path>` | yes | One or more TRD Markdown paths. Multiple TRDs are unioned. |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--prd <path>` | none | Companion PRD path. Multi-allowed. Used as cross-reference context for decomposition. |
+| `--remote <name>` | `origin` | Git remote whose repo will receive the milestones+issues on `--apply`. Missing remote → stop with `git remote -v` listing. |
+| `--dry-run` | **on** | Default. Writes the plan; **never** mutates GitHub. |
+| `--apply` | off | Mutate GitHub: bulk-create milestones + issues, resolve `#new-N` citations, promote first-milestone issues to Ready (unless `--no-ready`). |
+| `--plan-out <path>` | `.claude/.trd-to-issues.plan.md` | Where the plan Markdown lands. |
+| `--no-ready` | off | Skip Project board "Ready" promotion of first-milestone issues during `--apply`. Useful when the board is missing or the user wants manual triage. |
+
+## Examples
+
+```
+# 1. Inspect what would happen (no GitHub mutation):
+/devx-trd-to-issues docs/architecture/interface-ui.md
+
+# 2. Multiple TRDs + PRD context, custom plan path:
+/devx-trd-to-issues docs/trd-a.md docs/trd-b.md \
+    --prd docs/product-requirements.md \
+    --plan-out /tmp/trd-plan.md
+
+# 3. Apply (real GitHub mutation), no Ready promotion:
+/devx-trd-to-issues docs/trd-a.md --apply --no-ready
+
+# 4. Apply on a different remote than origin:
+/devx-trd-to-issues docs/trd-a.md --apply --remote upstream
+```
+
+## What the skill does
+
+1. Reads each TRD (and optional PRD) and decomposes them into a
+   three-level **Epic → Feature → Task** plan.
+2. Groups Tasks under Milestones — TRD-named structure first, otherwise
+   the skill proposes names and asks the user to confirm.
+3. Validates each Task against the decomposition rules in
+   `references/decomposition-rules.md`. Items that fail are split or
+   reported in the plan's "decomposition failures" section.
+4. Applies the `pro-friendly` / `max-only` heuristic plus any priority
+   labels carried in the TRD.
+5. Writes a Markdown plan to `--plan-out` matching
+   `references/plan-format.md`. The plan is the **single review
+   surface** before `--apply`.
+6. **`--apply` only** — pre-validates labels (no auto-create), bulk-
+   creates milestones, creates issues, resolves `#new-N` virtual
+   citations to real numbers, and promotes first-milestone issues to
+   Ready unless `--no-ready` is set.
+
+## What the skill will NOT do
+
+- Auto-create missing labels on `--apply` — pre-validates via `gh label
+  list` and stops with the missing list. Reason:
+  `feedback_gh_label_no_autocreate.md`.
+- Silently fall back to `origin` when `--remote <name>` is missing.
+- Auto-author TRD or PRD content — input only.
+- Auto-create Project board columns — uses the existing board.
+- Roll back partial mutations on a mid-flow `--apply` failure — reports
+  partial state and stops; the user owns cleanup.
+- Run on `--apply` without explicit `--apply` — `--dry-run` is the
+  default.
+
+## Prerequisites
+
+- A `gh` CLI authenticated against the target remote's host.
+- The target repo already has the labels referenced by the plan
+  (run a dry-run first, then create any missing labels manually).
+- For `--apply` Ready promotion: a Project board attached to the repo
+  with a `Status` field that includes a `Ready` option, or pass
+  `--no-ready`.
+
+## Pairs with
+
+- `requirement-spec` / `requirement-draft` — author the TRD/PRD before
+  invoking this skill.
+- `gh:issue-implement` / `gh:issue-flow` — pick up Task issues this
+  skill registered and implement them.
+- `gh:issue-create` — single-issue alternative when batch decomposition
+  is overkill.

--- a/claude/skills/devx-trd-to-issues/references/plan-format.md
+++ b/claude/skills/devx-trd-to-issues/references/plan-format.md
@@ -56,7 +56,7 @@ A plan written by this skill must be re-parseable by this skill, so:
 - Heading levels and ordering are stable (one `## Milestone:` per
   milestone, tasks as `- [ ] #new-N <title>` first-line).
 - Labels list is comma-separated, single line.
-- AC always nested under `  - AC:` exactly.
+- AC always nested under a `- AC:` bullet (two-space indent), exactly.
 - Decomposition failures live under one bottom-level `## Decomposition
   failures` heading; an empty list is rendered as a single line `_no
   failures._` to keep the section discoverable.

--- a/claude/skills/devx-trd-to-issues/references/plan-format.md
+++ b/claude/skills/devx-trd-to-issues/references/plan-format.md
@@ -1,0 +1,66 @@
+# Plan Markdown Format
+
+Canonical skeleton for the file `devx:trd-to-issues` writes to
+`--plan-out` (default `.claude/.trd-to-issues.plan.md`). The plan is
+the single review surface between dry-run and apply — it must
+round-trip back into Step 4 (`--apply`) without re-reading the TRD.
+
+## Top-level structure
+
+```markdown
+# TRD-to-Issues Plan
+Generated: <ISO 8601 local time>
+Source TRD: <comma-separated paths>
+Source PRD: <comma-separated paths or "(none)">
+Target repo: <owner/repo>
+Mode: dry-run
+
+## Milestone: <M0a-name> — <one-line summary>
+Description: <2-3 line milestone description>
+
+- [ ] #new-1 <conventional-commit title>
+  - Labels: <pro-friendly|max-only>, <priority-label?>
+  - Depends on: <#new-K, #new-L> | (none)
+  - AC:
+    - [ ] <criterion 1>
+    - [ ] <criterion 2>
+
+- [ ] #new-2 ...
+
+## Milestone: <M0b-name> — ...
+
+## Decomposition failures
+<empty list, OR>
+- <task title> — <reason: AC count > 3 / not unit-testable / not independent>
+```
+
+## Field rules
+
+- **`#new-N`** — virtual citation. `--apply` rewrites these to the real
+  GitHub issue numbers returned by `gh issue create` and patches the
+  `Depends on:` lines via `gh issue edit --body-file`.
+- **Labels** — exactly one of `pro-friendly` / `max-only`, plus
+  optional priority labels lifted from the TRD. Any label referenced
+  here that is missing on the target repo is caught during `--apply`'s
+  pre-validation (no auto-create).
+- **AC** — 1 to 3 checkboxes. Items requiring more get split or land
+  in "Decomposition failures".
+- **Depends on** — references must be `#new-N` (this skill's virtual
+  numbers). Cross-plan cites against pre-existing issues use the real
+  `#<number>` and pass through unchanged on `--apply`.
+
+## Round-trip invariant
+
+A plan written by this skill must be re-parseable by this skill, so:
+
+- Heading levels and ordering are stable (one `## Milestone:` per
+  milestone, tasks as `- [ ] #new-N <title>` first-line).
+- Labels list is comma-separated, single line.
+- AC always nested under `  - AC:` exactly.
+- Decomposition failures live under one bottom-level `## Decomposition
+  failures` heading; an empty list is rendered as a single line `_no
+  failures._` to keep the section discoverable.
+
+If a future variant changes the skeleton, update both this file and
+`samples/expected-plan.md` in lock-step — the round-trip parser is
+verified against the sample.

--- a/claude/skills/devx-trd-to-issues/references/repo-resolution.md
+++ b/claude/skills/devx-trd-to-issues/references/repo-resolution.md
@@ -1,0 +1,42 @@
+# devx:trd-to-issues — Repo resolution
+
+Substep procedure for Step 1 "Resolve Repo" — the skill keeps the
+workflow in `SKILL.md`; the substeps and error shape live here so
+multiple skills can reuse the convention.
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we're in a git repo.
+
+2. Determine the target remote:
+   - If the user passed `--remote <name>`, use that.
+   - Otherwise default to `origin`.
+
+3. Validate the remote and resolve owner/repo:
+
+   ```bash
+   git remote get-url <remote-name>
+   ```
+
+   On failure, list available remotes (`git remote -v`) and stop:
+
+   ```
+   Error: remote '<remote-name>' not found. Available remotes:
+   origin    https://github.com/user/repo.git (fetch)
+   upstream  https://github.com/org/repo.git (fetch)
+   ```
+
+4. Extract `owner/repo` from the URL:
+
+   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git`     → `<owner>/<repo>`
+
+   Stripped of any trailing `.git`.
+
+Store the resolved value as `TARGET_REPO` for use in Step 4 (`--apply`).
+
+## Failure rule
+
+If the user-specified remote does not exist, fail immediately with the
+list of available remotes. **Do not** fall back to `origin` silently —
+that masks typos and lands milestones/issues on the wrong repo.

--- a/claude/skills/devx-trd-to-issues/references/repo-resolution.md
+++ b/claude/skills/devx-trd-to-issues/references/repo-resolution.md
@@ -12,6 +12,14 @@ multiple skills can reuse the convention.
    - If the user passed `--remote <name>`, use that.
    - Otherwise default to `origin`.
 
+   The two cases below are NOT in conflict:
+   - `--remote` omitted → silently use `origin` (matches `gh-issue-create`
+     / `gh-pr` / `gh-pr-resolve-conflict` parity, the dotfiles
+     convention).
+   - `--remote <name>` passed but `<name>` does not exist → fail-fast.
+     The "no silent fallback" rule below applies **only** to this
+     second case.
+
 3. Validate the remote and resolve owner/repo:
 
    ```bash
@@ -26,12 +34,14 @@ multiple skills can reuse the convention.
    upstream  https://github.com/org/repo.git (fetch)
    ```
 
-4. Extract `owner/repo` from the URL:
+4. Extract `owner/repo` from the URL — host-agnostic patterns so
+   GitHub Enterprise / GHES / self-hosted forges work the same:
 
-   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
-   - `git@github.com:<owner>/<repo>.git`     → `<owner>/<repo>`
+   - `<protocol>://<host>/<owner>/<repo>.git` → `<owner>/<repo>`
+   - `<user>@<host>:<owner>/<repo>.git`       → `<owner>/<repo>`
 
-   Stripped of any trailing `.git`.
+   Stripped of any trailing `.git`. The host is never hardcoded; the
+   `<host>` segment is whatever the remote URL points at.
 
 Store the resolved value as `TARGET_REPO` for use in Step 4 (`--apply`).
 

--- a/claude/skills/devx-trd-to-issues/references/samples/README.md
+++ b/claude/skills/devx-trd-to-issues/references/samples/README.md
@@ -1,0 +1,37 @@
+# Samples — TRD fixture + expected plan
+
+Fixture used to verify `devx:trd-to-issues` behavior end-to-end without
+mutating GitHub.
+
+## Files
+
+- `trd-fixture.md` — small TRD with 3 Tasks across 2 Milestones,
+  written to exercise:
+  - TRD-named milestones (skill must NOT propose names),
+  - dependency lifting (`Depends on T1, T2`),
+  - priority labels lifted from the TRD (`⚡ High`),
+  - both label heuristics (`pro-friendly` for M0a tasks, `max-only`
+    for the multi-AC M0b task).
+- `expected-plan.md` — the reference Markdown the skill should emit
+  when run as:
+
+  ```
+  /devx:trd-to-issues claude/skills/devx-trd-to-issues/references/samples/trd-fixture.md \
+      --plan-out /tmp/plan.md
+  ```
+
+  with `Target repo: dEitY719/dotfiles`. The `Generated:` timestamp
+  obviously varies — diffs should ignore that line.
+
+## Manual verification
+
+```bash
+diff <(grep -v '^Generated:' /tmp/plan.md) \
+     <(grep -v '^Generated:' \
+       claude/skills/devx-trd-to-issues/references/samples/expected-plan.md)
+```
+
+Expect zero diff. Anything else means the decomposition rules,
+labeling heuristics, or plan format drifted — update **all three**
+(`decomposition-rules.md`, `plan-format.md`, `expected-plan.md`)
+before relying on the skill again.

--- a/claude/skills/devx-trd-to-issues/references/samples/expected-plan.md
+++ b/claude/skills/devx-trd-to-issues/references/samples/expected-plan.md
@@ -1,4 +1,5 @@
 # TRD-to-Issues Plan
+
 Generated: 2026-05-09T00:00:00
 Source TRD: claude/skills/devx-trd-to-issues/references/samples/trd-fixture.md
 Source PRD: (none)
@@ -6,6 +7,7 @@ Target repo: dEitY719/dotfiles
 Mode: dry-run
 
 ## Milestone: M0a — Scaffold & Tooling
+
 Description: Project skeleton, lint, and test scaffolding for the
 example-cli package. First milestone — eligible for Ready promotion
 on `--apply` unless `--no-ready` is set.
@@ -25,6 +27,7 @@ on `--apply` unless `--no-ready` is set.
     - [ ] `tox -e shellcheck` passes on an empty bash/ dir.
 
 ## Milestone: M0b — Commands
+
 Description: User-facing `example-cli init` and `example-cli build`
 commands, including `--dry-run` support and unit tests.
 
@@ -38,4 +41,5 @@ commands, including `--dry-run` support and unit tests.
     - [ ] Unit tests cover both commands.
 
 ## Decomposition failures
+
 _no failures._

--- a/claude/skills/devx-trd-to-issues/references/samples/expected-plan.md
+++ b/claude/skills/devx-trd-to-issues/references/samples/expected-plan.md
@@ -1,0 +1,41 @@
+# TRD-to-Issues Plan
+Generated: 2026-05-09T00:00:00
+Source TRD: claude/skills/devx-trd-to-issues/references/samples/trd-fixture.md
+Source PRD: (none)
+Target repo: dEitY719/dotfiles
+Mode: dry-run
+
+## Milestone: M0a — Scaffold & Tooling
+Description: Project skeleton, lint, and test scaffolding for the
+example-cli package. First milestone — eligible for Ready promotion
+on `--apply` unless `--no-ready` is set.
+
+- [ ] #new-1 chore(scaffold): bun + Next-style project bootstrap
+  - Labels: pro-friendly, ⚡ High
+  - Depends on: (none)
+  - AC:
+    - [ ] `bun install` succeeds on a fresh checkout.
+    - [ ] `bun test` runs zero tests successfully (scaffolding only).
+
+- [ ] #new-2 chore(ci): tox lint pipeline
+  - Labels: pro-friendly
+  - Depends on: #new-1
+  - AC:
+    - [ ] `tox -e ruff` passes on an empty src dir.
+    - [ ] `tox -e shellcheck` passes on an empty bash/ dir.
+
+## Milestone: M0b — Commands
+Description: User-facing `example-cli init` and `example-cli build`
+commands, including `--dry-run` support and unit tests.
+
+- [ ] #new-3 feat(cli): example-cli init / build with --dry-run
+  - Labels: max-only
+  - Depends on: #new-1, #new-2
+  - AC:
+    - [ ] `example-cli init` creates `./example.config.json`.
+    - [ ] `example-cli build --dry-run` prints the build plan and
+          exits 0 without writing files.
+    - [ ] Unit tests cover both commands.
+
+## Decomposition failures
+_no failures._

--- a/claude/skills/devx-trd-to-issues/references/samples/trd-fixture.md
+++ b/claude/skills/devx-trd-to-issues/references/samples/trd-fixture.md
@@ -1,0 +1,76 @@
+# TRD: example-cli
+
+> **Status**: Draft v1 (2026-05-09)
+> **Owner**: @example
+> **Adjacent TRDs**: (none)
+
+## 1. Overview
+
+A tiny example TRD used as a fixture for `devx:trd-to-issues`. It
+intentionally describes only three Tasks across two Milestones so the
+expected plan stays short enough to diff by eye.
+
+## 2. Goals / Non-Goals
+
+### Goals
+
+- Ship `example-cli init` and `example-cli build` commands.
+- Provide a flag `--dry-run` on both commands.
+
+### Non-Goals
+
+- Plugin loading.
+- Multi-tenant config.
+
+## 3. Architecture
+
+```
++-----------+      +-----------+
+|   shell   | ---> | example-  | --> ./build/
+|           |      |    cli    |
++-----------+      +-----------+
+```
+
+## 4. Milestones
+
+This TRD is decomposed into the following milestones:
+
+- **M0a — Scaffold & Tooling**: project skeleton, lint, test scaffolding.
+- **M0b — Commands**: user-facing `init` and `build` commands.
+
+## 5. Tasks
+
+### M0a — Scaffold & Tooling
+
+#### T1 — chore(scaffold): bun + Next-style project bootstrap
+
+Priority: ⚡ High
+
+Acceptance Criteria:
+
+- [ ] `bun install` succeeds on a fresh checkout.
+- [ ] `bun test` runs zero tests successfully (scaffolding only).
+
+#### T2 — chore(ci): tox lint pipeline
+
+Priority: (none)
+
+Depends on T1.
+
+Acceptance Criteria:
+
+- [ ] `tox -e ruff` passes on an empty src dir.
+- [ ] `tox -e shellcheck` passes on an empty bash/ dir.
+
+### M0b — Commands
+
+#### T3 — feat(cli): example-cli init / build with --dry-run
+
+Acceptance Criteria:
+
+- [ ] `example-cli init` creates `./example.config.json`.
+- [ ] `example-cli build --dry-run` prints the build plan and exits 0
+      without writing files.
+- [ ] Unit tests cover both commands.
+
+Depends on T1, T2.


### PR DESCRIPTION
## Summary

- 신규 슬래시 스킬 `/devx:trd-to-issues` 의 Progressive-Disclosure 골격 추가 — TRD/PRD 입력 → Epic → Feature → Task 3단계 분해 → `--dry-run` 으로 plan 마크다운 생성, `--apply` 로 GitHub Milestone+Issue 일괄 등록.
- 검증 사례인 dev-team-404/AgentToolbox#433 (8 Milestone × 40 Issue 수동 등록)을 일반화하여 분해 기준(AC 1~3, unit-testable, 독립 커밋)을 일관되게 강제한다.
- SSOT 검증용 `samples/` 픽스처(2 Milestone × 3 Task) + 기대 plan 결과를 동봉, 새 파일들은 markdownlint 통과.

## Changes

- `claude/skills/devx-trd-to-issues/SKILL.md` (98 lines) — frontmatter `name: devx:trd-to-issues`, args/flags, dry-run·apply 분기, `Depends on #new-N` → 실제 번호 해석, 라벨 사전 검증.
- `references/help.md` — `-h`/`--help`/`help` 본문, 사용 예시, 제약, 짝 스킬 (`requirement-spec`, `gh-issue-implement`, `gh-issue-flow`).
- `references/plan-format.md` — plan 마크다운 SSOT 골격 + round-trip 불변량.
- `references/decomposition-rules.md` — 분해 기준 (AC 1~3 / unit-testable / 독립 커밋) + `pro-friendly`/`max-only` 라벨 휴리스틱 (이슈 #433 일반화). 라벨 자동 생성 금지 명시 (memory: `feedback_gh_label_no_autocreate.md`).
- `references/repo-resolution.md` — `--remote` 미존재 시 `git remote -v` 출력 후 stop, `origin` 암묵적 fallback 금지.
- `references/samples/{trd-fixture.md, expected-plan.md, README.md}` — 작은 TRD 픽스처 + 기대 plan 결과 + 수동 검증 절차.
- 두 번째 커밋(0154ed7): plan-format.md L59 의 MD038 (space-in-code) 와 expected-plan.md 의 MD022 (blanks-around-headings) 를 정리해 새 스킬의 자체 파일들이 markdownlint 통과하도록 한다.

## Test plan

- [x] `find claude/skills/devx-trd-to-issues -type f | sort` — 8 파일 모두 의도한 위치에 존재.
- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` 로 SKILL.md frontmatter 파싱 확인 (`name: devx:trd-to-issues`, `allowed-tools: Bash, Read, Edit, Write, Grep`).
- [x] `wc -l SKILL.md` = 98 (under-100 규칙 준수).
- [x] `markdownlint claude/skills/devx-trd-to-issues/**/*.md` exit 0.
- [x] `tox -e shellcheck` OK (자체 변경 외 스크립트 없음).
- [x] `./tests/test` — 1009 passed in 186.53s (전체 회귀 없음).
- [ ] 수동 dry-run 시나리오: `/devx-trd-to-issues claude/skills/devx-trd-to-issues/references/samples/trd-fixture.md --plan-out /tmp/plan.md` → `expected-plan.md` 와 diff 0 (Generated 행 제외). *Followup — 본 PR은 골격만 추가. dry-run 실제 동작은 후속 PR에서 픽스처 검증과 함께 구현.*
- [ ] `--apply` 흐름은 본 골격에 명시만 — 실 호출은 후속 PR에서 통합 테스트와 함께.

## Related

Closes #400

---
<details>
<summary>🤖 AI Metrics · 📊 ~8000 tokens · 👤 ~8 h · 🤖 ~3 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~8000 tokens · 👤 ~8 h · 🤖 ~3 min
<\!-- /ai-metrics:gh-pr -->

</details>
