### PR TITLE
feat(skill:check): UX 품질 체크 5개 추가 — 10대 기준으로 확장 (#416)

### DIFF
--- a/claude/skills/skill-check/SKILL.md
+++ b/claude/skills/skill-check/SKILL.md
@@ -1,64 +1,39 @@
 ---
 name: skill:check
 description: >-
-  Audit a SKILL.md file for Progressive Disclosure compliance — checks if it
-  follows the under-100-lines rule and properly separates detail into references/.
-  Use when the user says "check my skill", "is my SKILL.md too long?", "audit
-  my skill structure", "does this skill follow progressive disclosure?",
-  "/skill:check". Reports PASS/WARN/FAIL per criterion with concrete fixes.
+  Audit a SKILL.md for structure and UX quality — checks line count,
+  progressive disclosure, frontmatter, references usage, output format,
+  help flag pattern, step structure, options docs, verdict output, and
+  next-action hints. Use when the user says "check my skill", "audit my
+  skill", "does this skill follow best practices?", "/skill:check".
+  Reports PASS/WARN/FAIL/N/A per criterion with concrete fixes.
   Do NOT use for AGENTS.md or CLAUDE.md files — use agents-md:check or
   claude-md-check instead.
 compatibility:
   tools: Read, Glob, Grep, Bash
 ---
 
-# SKILL.md Progressive Disclosure Auditor
+# SKILL.md Quality Auditor
 
 ## Help
 
 If the argument is `help`, read `references/help.md` and output its content verbatim, then stop.
-
-> **Pattern**: All skills should place help content (usage, arguments, examples) in
-> `references/help.md` and use a one-line pointer here. This keeps SKILL.md under
-> the 100-line limit while making help always reachable.
 
 ## Step 1: Locate the File
 
 If the user specifies a path, use it. Otherwise search for SKILL.md from the
 current directory.
 
-## Step 2: Run Five Checks
+## Step 2: Run Ten Checks
 
-Assign **PASS** / **WARN** / **FAIL** per check.
+Read `references/checks.md` for all 10 check definitions and PASS/WARN/FAIL/N/A criteria.
+Assign one result per check.
 
-**Check 1: Line Count**
-PASS ≤ 100 | WARN 101–150 | FAIL > 150
-Every line over 100 is a candidate for `references/` extraction.
+**Checks 1–5: Structure**
+Line Count · Progressive Disclosure · Frontmatter Validity · References Directory · Output Report
 
-**Check 2: Progressive Disclosure Structure**
-PASS — workflow phases only in SKILL.md; detail in `references/`
-WARN — mostly workflow but some templates/tables inline
-FAIL — large reference content embedded directly in SKILL.md
-
-**Check 3: Frontmatter Validity**
-Look for: `name` present, `description` present, only known attributes present.
-Known attributes: `name`, `description`, `allowed-tools`, `compatibility`,
-`metadata`, `user-invocable`, `argument-hint`, `disable-model-invocation`, `license`.
-**Naming**: read `references/naming-convention.md` — `category:action` colon
-form is the SSOT convention and reports as PASS, not WARN. Folder/name
-kebab-vs-colon mismatch is also PASS when folder is the kebab form of the
-colon name (e.g., `name: gh:pr` + folder `gh-pr/`).
-PASS — valid | WARN — minor issues | FAIL — missing fields or unknown attributes
-
-**Check 4: References Directory Usage**
-PASS — `references/` exists with focused files, each referenced from SKILL.md
-WARN — `references/` exists but not clearly triggered from SKILL.md body
-FAIL — SKILL.md > 100 lines AND no `references/` directory
-
-**Check 5: Output Report Defined**
-PASS — output format with example clearly defined
-WARN — output described but vague
-FAIL — no output format defined
+**Checks 6–10: UX Quality**
+Help Flag Pattern · Step Structure · Options Documentation · Verdict Output · Next-action Hint
 
 ## Step 3: Output the Report
 

--- a/claude/skills/skill-check/references/checks.md
+++ b/claude/skills/skill-check/references/checks.md
@@ -1,0 +1,69 @@
+# Skill Quality Checks
+
+Ten checks, each rated PASS / WARN / FAIL / N/A.
+
+---
+
+## Structure Checks (1–5)
+
+### Check 1: Line Count
+PASS ≤ 100 | WARN 101–150 | FAIL > 150
+Every line over 100 is a candidate for `references/` extraction.
+
+### Check 2: Progressive Disclosure Structure
+PASS — workflow phases only in SKILL.md; detail in `references/`
+WARN — mostly workflow but some templates/tables inline
+FAIL — large reference content embedded directly in SKILL.md
+
+### Check 3: Frontmatter Validity
+Look for: `name` present, `description` present, only known attributes present.
+Known attributes: `name`, `description`, `allowed-tools`, `compatibility`,
+`metadata`, `user-invocable`, `argument-hint`, `disable-model-invocation`, `license`.
+**Naming**: read `references/naming-convention.md` — `category:action` colon
+form is the SSOT convention and reports as PASS, not WARN. Folder/name
+kebab-vs-colon mismatch is also PASS when folder is the kebab form of the
+colon name (e.g., `name: gh:pr` + folder `gh-pr/`).
+PASS — valid | WARN — minor issues | FAIL — missing fields or unknown attributes
+
+### Check 4: References Directory Usage
+PASS — `references/` exists with focused files, each referenced from SKILL.md
+WARN — `references/` exists but not clearly triggered from SKILL.md body
+FAIL — SKILL.md > 100 lines AND no `references/` directory
+
+### Check 5: Output Report Defined
+PASS — output format with example clearly defined
+WARN — output described but vague
+FAIL — no output format defined
+
+---
+
+## UX Quality Checks (6–10)
+
+### Check 6: Help Flag Pattern
+PASS — `-h`/`--help`/`help` arg → reads `references/help.md` verbatim, then stops. No API calls.
+WARN — help exists but inline (not in `references/help.md`) or not verbatim
+FAIL — no `-h`/`--help`/`help` support at all
+
+### Check 7: Step Structure
+PASS — execution steps numbered (Step 1, Step 2, …) with explicit stop-on-error policy
+WARN — steps described but unnumbered, or no stop-on-error policy stated
+FAIL — no clear execution flow
+N/A — skill is a single read-only lookup (no multi-step execution)
+
+### Check 8: Options Documentation
+PASS — all accepted options in a table: Option | Description | Default
+WARN — options listed but missing defaults or described in prose only
+FAIL — options accepted but not documented
+N/A — skill takes no arguments or options
+
+### Check 9: Verdict Output
+PASS — final output has explicit `[OK]`/`[FAIL]` verdict + structured key-value pairs
+WARN — success/failure indicated but unstructured (plain prose)
+FAIL — no explicit verdict in output
+N/A — skill is purely informational (no action outcome to report)
+
+### Check 10: Next-action Hint
+PASS — success report includes next steps, follow-up commands, or teardown
+WARN — partial guidance (mentions what comes next but no concrete commands)
+FAIL — output ends without any guidance on what to do next
+N/A — skill is terminal (no natural follow-up action exists)

--- a/claude/skills/skill-check/references/help.md
+++ b/claude/skills/skill-check/references/help.md
@@ -1,4 +1,4 @@
-/skill:check — Audit a SKILL.md for Progressive Disclosure compliance
+/skill:check — Audit a SKILL.md for structure and UX quality
 
 Usage:
   /skill:check [path/to/SKILL.md]
@@ -14,3 +14,9 @@ Examples:
 
 Options:
   help    Show this message
+
+Checks run (10 total):
+  Structure (1-5):   Line Count, Progressive Disclosure, Frontmatter Validity,
+                     References Directory Usage, Output Report Defined
+  UX Quality (6-10): Help Flag Pattern, Step Structure, Options Documentation,
+                     Verdict Output, Next-action Hint

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -26,8 +26,8 @@ References dir: <exists / missing>
 | 9 | Verdict Output               | FAIL   | output ends without [OK]/[FAIL]       |
 |10 | Next-action Hint             | PASS   | teardown shown in success report      |
 
-Score: 5/8 checks passed (2 warnings, 1 N/A)
-Verdict: NEEDS WORK — fix FAIL items before treating as production-ready
+Score: 5/9 checks passed (2 warnings, 2 fails, 1 N/A)
+Verdict: POOR — significant gaps, major rework needed
 
 ## Issues & Improvements
 

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -8,15 +8,26 @@ File: <path>
 Lines: <count>
 References dir: <exists / missing>
 
+### Structure Checks
 | # | Check                        | Result | Notes                           |
 |---|------------------------------|--------|---------------------------------|
-| 1 | Line Count                   | PASS   | 87 lines — within 100-line goal |
+| 1 | Line Count                   | PASS   | 42 lines — within 100-line goal |
 | 2 | Progressive Disclosure       | WARN   | templates inline, not in refs/  |
 | 3 | Frontmatter Validity         | PASS   | name, description valid         |
 | 4 | References Directory Usage   | FAIL   | no references/ directory        |
 | 5 | Output Report Defined        | PASS   | template in Step 3              |
 
-Score: X/5 checks passed (Y warnings)
+### UX Quality Checks
+| # | Check                        | Result | Notes                                 |
+|---|------------------------------|--------|---------------------------------------|
+| 6 | Help Flag Pattern            | PASS   | -h/--help → references/help.md        |
+| 7 | Step Structure               | WARN   | steps present but no stop-on-error    |
+| 8 | Options Documentation        | N/A    | skill takes no arguments              |
+| 9 | Verdict Output               | FAIL   | output ends without [OK]/[FAIL]       |
+|10 | Next-action Hint             | PASS   | teardown shown in success report      |
+
+Score: 5/8 checks passed (2 warnings, 1 N/A)
+Verdict: NEEDS WORK — fix FAIL items before treating as production-ready
 
 ## Issues & Improvements
 
@@ -28,11 +39,19 @@ Score: X/5 checks passed (Y warnings)
 **Problem:** <specific issue>
 **How to fix:** <concrete suggestion>
 
-## Summary
-<2–3 sentences: overall quality, most critical fix, ready for /skill:refactor?>
+## Next Actions
+1. <highest priority fix>
+2. <next fix>
+Run /skill:check again after fixes to verify.
 ```
 
 Rules:
-- Only include WARN and FAIL items in Issues section
+- Only include WARN and FAIL items in Issues & Improvements section
 - Quote actual lines from the file when describing problems
-- If score < 4/5, end Summary with: "Run /skill:refactor to fix structural issues."
+- Score denominator excludes N/A checks
+- Verdict labels:
+  - All applicable checks PASS → `EXCELLENT — gold standard`
+  - ≥80% PASS, no FAIL → `GOOD — production-ready, minor polish needed`
+  - ≥60% PASS or any FAIL → `NEEDS WORK — fix FAIL items before shipping`
+  - <60% PASS → `POOR — significant gaps, major rework needed`
+- Always end with "Next Actions" section listing concrete fixes in priority order


### PR DESCRIPTION
## Summary

- `skill:check` 감사 체크를 5개(구조)에서 10개(구조 5 + UX 품질 5)로 확장
- 체크 기준 전체를 `references/checks.md`로 추출해 SKILL.md를 66줄 → 40줄로 단순화
- 리포트에 Verdict 레이블 4단계(EXCELLENT/GOOD/NEEDS WORK/POOR)와 Next Actions 섹션 추가

## Changes

### `SKILL.md`
- 제목: "Progressive Disclosure Auditor" → "Quality Auditor"
- Step 2: 5개 체크 인라인 정의 → `references/checks.md` 한 줄 위임
- description 트리거 문구 확장 (PASS/WARN/FAIL/N/A 언급)

### `references/checks.md` (신규)
- 구조 체크 5개: Line Count · Progressive Disclosure · Frontmatter · References Directory · Output Report
- UX 품질 체크 5개: Help Flag Pattern · Step Structure · Options Documentation · Verdict Output · Next-action Hint
- 각 체크에 N/A 판정 조건 포함 (read-only 스킬, 인자 없는 스킬 등)

### `references/report-template.md`
- 단일 테이블 → Structure / UX Quality 2개 섹션으로 분리
- Verdict 레이블 4단계 정의
- "Summary" 섹션 → "Next Actions" 섹션으로 교체

### `references/help.md`
- 10개 체크 목록 추가

## Test plan

- [ ] `/skill:check` 실행 시 10개 체크 PASS/WARN/FAIL/N/A 판정
- [ ] `/skill:check help` → `references/help.md` verbatim 출력
- [ ] SKILL.md ≤ 100줄 유지 확인

Closes #416

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<\!-- /ai-metrics:gh-pr -->

</details>
