### PR TITLE
feat(sh-check): /sh:check 신규 스킬 — 쉘 스크립트 품질 감사기

### DIFF
--- a/claude/skills/sh-check/SKILL.md
+++ b/claude/skills/sh-check/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: sh:check
+description: >-
+  Audit a shell script (`*.sh`) against the dotfiles quality bar derived from
+  `git_worktree.sh` — the canonical reference implementation. Reports
+  PASS/WARN/FAIL/N/A across 10 criteria covering POSIX hygiene, sourcing
+  guards, naming, ZSH compatibility, help UX, UX-lib usage, input validation,
+  verdict structure, and next-action hints. Use when the user says "check
+  this shell script", "is my .sh file production-ready?", "audit this shell
+  function", "/sh:check". Mirrors `skill:check` but for `.sh` files instead
+  of `SKILL.md`. Do NOT use for SKILL.md (use `skill:check`) or AGENTS.md
+  (use `agents-md:check`).
+compatibility:
+  tools: Read, Glob, Grep, Bash
+---
+
+# Shell Script Quality Auditor
+
+## Help
+
+If the argument is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No further checks.
+
+## Step 1: Locate the File
+
+- Argument given → audit that path. Reject if it doesn't exist or doesn't
+  end in `.sh`/`.bash`/`.zsh` (warn but continue if the user insists).
+- No argument → search the current directory for `*.sh` files. If exactly
+  one is found, audit it. If multiple, list them and ask which one. If none,
+  output a help hint pointing to `/sh:check path/to/file.sh`.
+
+Record:
+- `LINES` — `wc -l` of the target file
+- `IS_SOURCED` — heuristic: file is sourced if it lives under
+  `shell-common/functions/`, `bash/`, `zsh/`, or contains
+  `case $- in *i*)` near the top. Otherwise treat as an executable script.
+
+## Step 2: Run 10 Quality Checks
+
+Read `references/checks.md` for the full criteria. Each check returns one of:
+
+- **PASS** — meets the bar
+- **WARN** — partial / minor issue
+- **FAIL** — missing or violates rule
+- **N/A** — not applicable for this file class (e.g. interactive guard on
+  an executable script, ZSH guard on a bash-only script)
+
+The 10 checks are split into two groups:
+
+**Structure (1–5)**
+1. Shebang + POSIX Hygiene
+2. Interactive Guard
+3. Section Anatomy
+4. Naming Convention
+5. ZSH Compat Guard
+
+**UX Quality (6–10)**
+6. Help Flag
+7. UX Lib Usage
+8. Input Validation
+9. Verdict Output
+10. Next-action Hint
+
+Each check definition lists the concrete grep patterns / structural cues to
+look for. Treat `git_worktree.sh` as the canonical example — when the
+target file uses the same pattern, that check passes.
+
+## Step 3: Output the Report
+
+Read `references/report-template.md` for the exact format. The report has:
+
+- File path + line count
+- Two tables (Structure 1–5, UX 6–10) with PASS/WARN/FAIL/N/A + notes
+- Score line: `X/10 checks passed (Y warnings, Z N/A)`
+- **Verdict** — single-line classification: `EXCELLENT` / `GOOD` /
+  `NEEDS WORK` / `POOR`. Computed from Score per the table in
+  `references/report-template.md`.
+- **Next Actions** — one bullet per WARN/FAIL with a concrete fix command
+  or code snippet. Each bullet is anchored by `[<LEVEL> #N]` so the user
+  can map back to the table.
+
+Do NOT recommend changes for PASS or N/A rows. Do NOT add filler "looks
+great!" prose — the table and Verdict speak for themselves.
+
+## Constraints
+
+- Read-only audit — never edit the target file.
+- Quote actual file lines when describing problems in Next Actions.
+- If a check needs a tool the environment lacks (e.g. no `grep`), report
+  N/A with an explanatory note rather than failing silently.
+- The canonical reference is `shell-common/functions/git_worktree.sh`. When
+  in doubt about whether a pattern is "the right way", compare to it.

--- a/claude/skills/sh-check/references/checks.md
+++ b/claude/skills/sh-check/references/checks.md
@@ -166,8 +166,8 @@ output behind `[ "${DEBUG:-0}" = "1" ]`.
 
 **Grep hints**
 ```sh
-grep -cE '^[[:space:]]*(ux_)' "$FILE"
-grep -cE '^[[:space:]]*(echo|printf|tput) ' "$FILE"
+grep -cE 'ux_' "$FILE"
+grep -cE '(echo|printf|tput) ' "$FILE"
 ```
 
 ### Check 8 — Input Validation

--- a/claude/skills/sh-check/references/checks.md
+++ b/claude/skills/sh-check/references/checks.md
@@ -1,0 +1,247 @@
+# sh:check — 10 Quality Criteria
+
+Each check returns PASS / WARN / FAIL / N/A. The reference implementation
+is `shell-common/functions/git_worktree.sh` — when the target file uses
+the same pattern, the check passes.
+
+---
+
+## Structure Checks (1–5)
+
+### Check 1 — Shebang + POSIX Hygiene
+
+**What to look for**
+- Line 1 is `#!/bin/sh` (preferred) or `#!/usr/bin/env bash` (bash-only OK)
+- POSIX-portable syntax throughout: `[ ]` not `[[ ]]`, `>/dev/null 2>&1`
+  not `&>/dev/null`, `local var=""` not `declare`, no `function name()`.
+- For `shell-common/` files: must be `#!/bin/sh` (POSIX-only enforced).
+
+| Result | When |
+|--------|------|
+| PASS | `#!/bin/sh` shebang + POSIX-only syntax detected |
+| WARN | Shebang correct but `[[ ]]` or `&>` used in non-bash branch |
+| FAIL | Missing shebang, or shell-common file uses bash-only syntax |
+| N/A  | File is sourced fragment with no shebang AND lives outside shell-common (rare) |
+
+**Grep hints**
+```sh
+head -1 "$FILE"                    # shebang
+grep -nE '\[\[|&>/dev/null' "$FILE"   # bashisms
+```
+
+### Check 2 — Interactive Guard
+
+**What to look for**
+Sourced files (anything under `shell-common/functions/`, `bash/`, `zsh/`,
+or any file whose first few lines call `local`/`alias` without an `exec`
+context) must start with:
+
+```sh
+case $- in *i*) ;; *) return 0 ;; esac
+```
+
+| Result | When |
+|--------|------|
+| PASS | Guard present in the first ~10 lines of a sourced file |
+| WARN | Guard present but later in the file (after function defs) |
+| FAIL | Sourced file with no interactive guard |
+| N/A  | File is an executable script (has `#!` and is `chmod +x`'d) |
+
+**Grep hints**
+```sh
+head -20 "$FILE" | grep -F 'case $- in *i*'
+```
+
+### Check 3 — Section Anatomy
+
+**What to look for**
+Each public function is preceded by a `# ===…===` header block containing
+at minimum a one-line description. Substantial functions also have:
+- `# Usage: <name> <args>`
+- `# Args:` with one line per argument
+
+git_worktree.sh uses 78-char `=`-fences. Any consistent banner counts.
+
+| Result | When |
+|--------|------|
+| PASS | Banner + Usage/Args on most public functions |
+| WARN | Banners present but Usage/Args missing |
+| FAIL | No section structure — functions defined back-to-back |
+| N/A  | Single-function file under 30 lines |
+
+**Grep hints**
+```sh
+grep -cE '^# ={5,}' "$FILE"           # banner count
+grep -cE '^# Usage:'   "$FILE"
+```
+
+### Check 4 — Naming Convention
+
+**What to look for**
+- Private helpers use `_prefix_` (e.g. `_gwt_age`, `_gh_pr_edit_safe_label`)
+- Public functions are non-underscored (`gwt`, `gwt_help`, `gh_pr_status`)
+- All names in `snake_case` — no `camelCase`, no `kebab-case` for functions
+- User-facing aliases may use `dash-form` (e.g. `gwt-help`)
+
+| Result | When |
+|--------|------|
+| PASS | Consistent _private vs public, all snake_case |
+| WARN | Mostly consistent but 1–2 outliers |
+| FAIL | No discernible convention, or camelCase used |
+| N/A  | File defines no functions (pure config / sourced env file) |
+
+**Grep hints**
+```sh
+grep -E '^[A-Za-z_][A-Za-z0-9_]*\(\) *\{' "$FILE" \
+  | sed 's/().*//' | sort -u
+```
+
+### Check 5 — ZSH Compat Guard
+
+**What to look for**
+Any function exposed to *both* bash and zsh (i.e. defined in
+`shell-common/`) and that uses `local`, arrays, or `set -x` must contain:
+
+```sh
+[ -n "${ZSH_VERSION-}" ] && emulate -L sh
+```
+
+…near the top of the function. This avoids the zsh-tracing-of-`local`
+issue documented in MEMORY.md.
+
+| Result | When |
+|--------|------|
+| PASS | All cross-shell functions have the guard |
+| WARN | Some functions have it, others don't |
+| FAIL | File is in `shell-common/` and no function has the guard |
+| N/A  | File is bash-only (lives in `bash/`) or zsh-only (`zsh/`), or is an executable script |
+
+**Grep hints**
+```sh
+grep -nE 'emulate -L sh|ZSH_VERSION' "$FILE"
+```
+
+---
+
+## UX Quality Checks (6–10)
+
+### Check 6 — Help Flag
+
+**What to look for**
+Every public command-style function handles `-h|--help` and delegates to a
+structured help routine, then `return 0` (or `exit 0` for executables).
+
+git_worktree.sh pattern: `gwt-help [section]` with `--list` / `--all` /
+`<section>` arguments, all rendered via `ux_table_row`.
+
+| Result | When |
+|--------|------|
+| PASS | `-h\|--help` handled, structured help (table or sections), early return |
+| WARN | Help exists but is just an inline echo string, not a function |
+| FAIL | No help flag — user must read the source |
+| N/A  | Function takes no arguments (pure side-effect helper) |
+
+**Grep hints**
+```sh
+grep -nE -- '-h\|--help|--help)' "$FILE"
+```
+
+### Check 7 — UX Lib Usage
+
+**What to look for**
+Output goes through `ux_header`, `ux_section`, `ux_info`, `ux_success`,
+`ux_warn`, `ux_error`, `ux_bullet`, `ux_table_row`. **No raw `echo`,
+`printf`, or `tput`** in user-facing paths.
+
+Exceptions allowed: stdout used for return values (e.g.
+`printf '%s\n' "$result"` from a helper that's captured by `$()`), debug
+output behind `[ "${DEBUG:-0}" = "1" ]`.
+
+| Result | When |
+|--------|------|
+| PASS | All user-facing output via ux_* functions |
+| WARN | Mix — some ux_*, some raw echo for messages |
+| FAIL | Pure raw `echo`/`tput`, no ux_lib import or usage |
+| N/A  | File defines no user-facing output (e.g. pure data helper) |
+
+**Grep hints**
+```sh
+grep -cE '^[[:space:]]*(ux_)' "$FILE"
+grep -cE '^[[:space:]]*(echo|printf|tput) ' "$FILE"
+```
+
+### Check 8 — Input Validation
+
+**What to look for**
+- Required arguments checked: `[ -z "$1" ] && { ux_error …; return 1; }`
+- Mutually exclusive flags rejected explicitly
+- Unknown options trigger help + non-zero exit:
+  `*) ux_error "Unknown option: $1"; gwt-help; return 1 ;;`
+
+| Result | When |
+|--------|------|
+| PASS | Required args, mutex flags, unknown-option arm all present |
+| WARN | Some validation but missing one of the three |
+| FAIL | No validation — function silently does the wrong thing |
+| N/A  | Function takes no arguments |
+
+**Grep hints**
+```sh
+grep -nE 'Unknown option|Missing argument|Required' "$FILE"
+```
+
+### Check 9 — Verdict Output
+
+**What to look for**
+Status/diagnostic functions emit a structured 2–3 line verdict with an
+explicit state value. git_worktree.sh's `_gwt_compute_status` is the
+template:
+
+```
+state: dirty
+age:   2h
+next:  gwt push --force-with-lease
+```
+
+Or a key:value table via `ux_info "  Key: $value"`.
+
+| Result | When |
+|--------|------|
+| PASS | Explicit state + structured key:value rows |
+| WARN | Output is structured but no canonical "state" field |
+| FAIL | Free-form prose verdict ("looks good", "something wrong") |
+| N/A  | File defines no status/verdict function |
+
+### Check 10 — Next-action Hint
+
+**What to look for**
+Success output ends with a one-line hint pointing at the next command the
+user should run. git_worktree.sh's status verdicts include `next: gwt
+teardown`, `next: gwt push`, etc.
+
+| Result | When |
+|--------|------|
+| PASS | Every success path ends with a `Next:` / `next:` hint or `ux_bullet`'d command |
+| WARN | Some hints, but not consistently |
+| FAIL | No next-action guidance anywhere |
+| N/A  | Terminal command — there is no logical "next" step |
+
+**Grep hints**
+```sh
+grep -nE -- 'Next:|next:|next-action' "$FILE"
+```
+
+---
+
+## Scoring
+
+After running all 10 checks, compute:
+
+- `PASS_COUNT` — number of PASS results
+- `WARN_COUNT` — number of WARN results
+- `FAIL_COUNT` — number of FAIL results
+- `NA_COUNT`   — number of N/A results
+
+`Score: PASS_COUNT/(10 - NA_COUNT) checks passed (WARN_COUNT warnings)`
+
+The Verdict line is computed in `references/report-template.md`.

--- a/claude/skills/sh-check/references/help.md
+++ b/claude/skills/sh-check/references/help.md
@@ -1,0 +1,44 @@
+/sh:check — Audit a shell script (`*.sh`) against the dotfiles quality bar
+
+Usage:
+  /sh:check [path/to/script.sh]
+  /sh:check help
+
+Arguments:
+  [path]    Path to the shell script to audit (optional)
+            If omitted, searches the current directory for *.sh files
+
+What it checks (10 criteria, modeled on git_worktree.sh):
+
+  Structure (1–5)
+    1. Shebang + POSIX Hygiene   — #!/bin/sh, [ ], >/dev/null 2>&1
+    2. Interactive Guard         — case $- in *i*) ;; *) return 0 ;; esac
+    3. Section Anatomy           — # ====== headers + Usage: + Args:
+    4. Naming Convention         — _prefix private, snake_case
+    5. ZSH Compat Guard          — emulate -L sh in cross-shell functions
+
+  UX Quality (6–10)
+    6. Help Flag                 — -h/--help → structured help, return 0
+    7. UX Lib Usage              — ux_header/ux_info/ux_error/ux_success
+    8. Input Validation          — required args, mutex flags, unknown opts
+    9. Verdict Output            — explicit state + structured key:value
+   10. Next-action Hint          — success output points to next command
+
+Each check reports PASS / WARN / FAIL / N/A.
+
+Examples:
+  /sh:check shell-common/functions/git_worktree.sh
+  /sh:check bash/utils/my_function.sh
+  /sh:check
+  /sh:check help
+
+Output:
+  - Two tables (Structure, UX Quality) with results + notes
+  - Score: X/10 checks passed (Y warnings, Z N/A)
+  - Verdict: EXCELLENT / GOOD / NEEDS WORK / POOR
+  - Next Actions: concrete fixes for every WARN and FAIL
+
+Companion skills:
+  /skill:check         — audit a SKILL.md file (Progressive Disclosure)
+  /agents-md:check     — audit an AGENTS.md file
+  /claude-md-check     — audit a CLAUDE.md orchestrator file

--- a/claude/skills/sh-check/references/report-template.md
+++ b/claude/skills/sh-check/references/report-template.md
@@ -1,0 +1,79 @@
+# sh:check — Report Template
+
+Use this exact format when outputting the audit report.
+
+```
+## sh:check Report
+File: <path>
+Lines: <count>
+Class: <sourced fragment | executable script | bash-only | zsh-only>
+
+### Structure Checks
+| # | Check                  | Result | Notes                            |
+|---|------------------------|--------|----------------------------------|
+| 1 | Shebang + POSIX        | PASS   | #!/bin/sh, POSIX syntax          |
+| 2 | Interactive Guard      | WARN   | sourced file, no case $- guard   |
+| 3 | Section Anatomy        | PASS   | ===…=== + Usage + Args           |
+| 4 | Naming Convention      | PASS   | _gwt_ private, gwt_ public       |
+| 5 | ZSH Compat Guard       | PASS   | emulate -L sh in exposed funcs   |
+
+### UX Quality Checks
+| # | Check                  | Result | Notes                            |
+|---|------------------------|--------|----------------------------------|
+| 6 | Help Flag              | PASS   | -h/--help → _gwt_help_*          |
+| 7 | UX Lib Usage           | PASS   | ux_header/info/error throughout  |
+| 8 | Input Validation       | PASS   | required args, mutex, unknown    |
+| 9 | Verdict Output         | PASS   | state+age+next 3-line structure  |
+|10 | Next-action Hint       | PASS   | teardown/push/etc per state      |
+
+Score: 9/10 checks passed (1 warning, 0 N/A)
+Verdict: GOOD — production-ready, minor polish needed
+
+### Next Actions
+1. [WARN #2] Add interactive guard at top of file:
+     case $- in *i*) ;; *) return 0 ;; esac
+   Run /sh:check again after fix to verify.
+```
+
+---
+
+## Verdict Computation
+
+Map `PASS_COUNT` (out of `10 - NA_COUNT`) to a verdict:
+
+| PASS / Effective Total | Verdict      | Meaning                                     |
+|------------------------|--------------|---------------------------------------------|
+| 100%                   | EXCELLENT    | Reference-quality — could replace git_worktree.sh as canonical example |
+| ≥ 80% AND no FAIL      | GOOD         | Production-ready, minor polish needed       |
+| ≥ 60% OR exactly 1 FAIL| NEEDS WORK   | Functional but several gaps                 |
+| < 60% OR ≥ 2 FAILs     | POOR         | Major rework required                       |
+
+The Verdict line uses one of these four words exactly, followed by an
+em-dash and a one-line summary tailored to the dominant issue class
+(structure vs UX).
+
+---
+
+## Next Actions Rules
+
+- **One bullet per WARN and FAIL** — never per PASS or N/A.
+- Each bullet starts with `[<LEVEL> #<N>]` so the user can map back to
+  the table.
+- Provide a concrete fix:
+  - For structural issues — paste the exact line/snippet to add.
+  - For UX issues — name the ux_* function or pattern to adopt.
+- End the Next Actions section with:
+  `Run /sh:check again after fix to verify.`
+
+---
+
+## Output Rules
+
+- Tables MUST use the columns shown above (`#`, `Check`, `Result`, `Notes`).
+- Result column values: `PASS` / `WARN` / `FAIL` / `N/A` (uppercase).
+- Notes column ≤ 40 chars — concise enough to fit a terminal.
+- Quote actual file lines in the Next Actions section, not in the table.
+- Do NOT add filler prose ("the script looks great!") — the Verdict line
+  already classifies overall quality.
+- If `Score = 10/10` (no WARN, no FAIL), Next Actions section reads:
+  `No actions required.`


### PR DESCRIPTION
## Summary
- `skill:check`가 `SKILL.md`를 감사하듯, `*.sh` 파일을 동일한 패턴으로 감사하는 `/sh:check` 신규 스킬을 추가
- 캐노니컬 레퍼런스는 `shell-common/functions/git_worktree.sh` (2298 lines, 가장 완성도 높은 쉘 스크립트)
- 10개 품질 기준을 두 그룹(Structure 1–5, UX Quality 6–10)으로 분류하고 PASS/WARN/FAIL/N/A 판정

## Changes
- **`claude/skills/sh-check/SKILL.md`** (92 lines, ≤100줄 제한 준수): 3-step 실행 흐름 (locate → run 10 checks → output report)
- **`references/help.md`**: `-h/--help/help` verbatim 출력 — 사용법, 10개 기준 요약, 동반 스킬(`skill:check`, `agents-md:check`, `claude-md-check`) 안내
- **`references/checks.md`**: 10개 기준 정의 + 각 체크별 grep 힌트 + PASS/WARN/FAIL/N/A 결정 테이블
  - Structure: shebang+POSIX, interactive guard, section anatomy, naming convention, ZSH compat guard
  - UX Quality: help flag, ux_lib usage, input validation, verdict output, next-action hint
- **`references/report-template.md`**: 두 테이블(Structure, UX Quality) + Score + Verdict(EXCELLENT/GOOD/NEEDS WORK/POOR) + Next Actions 형식 명시

## Test plan
- [ ] `/sh:check help` → `references/help.md` verbatim 출력
- [ ] `/sh:check shell-common/functions/git_worktree.sh` → 캐노니컬 예제로 대부분 PASS, interactive guard만 WARN으로 보고
- [ ] `/sh:check`(인자 없음) → 현재 디렉토리에서 `*.sh` 탐색 또는 안내
- [ ] 10개 체크가 모두 PASS/WARN/FAIL/N/A 중 하나로 판정
- [ ] 최종 리포트에 Verdict + Next Actions 포함
- [ ] SKILL.md ≤ 100줄 제한 준수 (현재 92 lines)
- [ ] Frontmatter `name: sh:check` colon 형식 (AGENTS.md L103 SSOT)

## Related
Closes #418

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~2 h · 🤖 ~2 min
<\!-- /ai-metrics:gh-pr -->

</details>
