### PR TITLE
chore(claude): enable GH_PR_REPLY_AUTO_APPROVE_REPOS in settings template

### DIFF
--- a/claude/settings.template.json
+++ b/claude/settings.template.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles"
+  },
   "permissions": {
     "allow": [
       "Edit(**/test_*.py)",


### PR DESCRIPTION
## Summary
- `settings.template.json`에 `GH_PR_REPLY_AUTO_APPROVE_REPOS` 환경변수 추가
- 신규 설치 시 gh:pr-reply Step 8 (보드 카드 자동 Approved 이동)이 기본 활성화됨

## Changes
- `claude/settings.template.json`: `env` 섹션 추가 — `GH_PR_REPLY_AUTO_APPROVE_REPOS=dEitY719/dotfiles` 설정

## Test plan
- [ ] 설치 후 `~/.claude/settings.json`에 env 블록이 포함되는지 확인
- [ ] `/gh:pr-reply` 실행 후 Step 8 Guard G1 통과 확인 (보드 카드 `In review` → `Approved` 이동)

## Related
Closes #416

---
<details>
<summary>AI Metrics · ~1000 tokens · ~0.5 h · ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
~1000 tokens · ~0.5 h · ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
