### PR TITLE
fix(skill:symlink-manager): POSIX + ux_lib 준수 (#467)

### DIFF
--- a/claude/skills/devx-symlink-manager/references/advanced-patterns.md
+++ b/claude/skills/devx-symlink-manager/references/advanced-patterns.md
@@ -13,7 +13,7 @@ git add config.json.template
 echo "bash/<category>/config.json" >> .gitignore
 
 # Add template copy logic to init function
-if [[ ! -f "$source" ]] && [[ -f "$source.template" ]]; then
+if [ ! -f "$source" ] && [ -f "$source.template" ]; then
     cp "$source.template" "$source"
 fi
 ```

--- a/claude/skills/devx-symlink-manager/references/function-templates.md
+++ b/claude/skills/devx-symlink-manager/references/function-templates.md
@@ -2,7 +2,8 @@
 
 > 본 템플릿은 CLAUDE.md "POSIX compatibility" + "All output must use ux_lib"
 > 규칙을 따르도록 작성됨. `[[ ]]` 대신 POSIX `[ ]`, raw `echo` 대신
-> `ux_info` / `ux_success` / `ux_warning` 사용. 사용자는 그대로 복사해 사용.
+> `ux_info` / `ux_success` / `ux_warning` / `ux_error` 사용. 사용자는 그대로
+> 복사해 사용.
 
 ## Symbolic Link Initialization Function
 

--- a/claude/skills/devx-symlink-manager/references/function-templates.md
+++ b/claude/skills/devx-symlink-manager/references/function-templates.md
@@ -1,5 +1,9 @@
 # Function Templates — management function code templates
 
+> 본 템플릿은 CLAUDE.md "POSIX compatibility" + "All output must use ux_lib"
+> 규칙을 따르도록 작성됨. `[[ ]]` 대신 POSIX `[ ]`, raw `echo` 대신
+> `ux_info` / `ux_success` / `ux_warning` 사용. 사용자는 그대로 복사해 사용.
+
 ## Symbolic Link Initialization Function
 
 Add to `bash/app/<app>.bash`:
@@ -9,32 +13,30 @@ Add to `bash/app/<app>.bash`:
     local source="$HOME/dotfiles/bash/<category>/<filename>"
     local target="<target_file>"
 
-    echo "Initializing <app> configuration..."
+    ux_info "Initializing <app> configuration..."
 
     # Create directory if needed
-    if [[ ! -d "$(dirname "$target")" ]]; then
-        echo "Creating $(dirname "$target") directory..."
+    if [ ! -d "$(dirname "$target")" ]; then
+        ux_info "Creating $(dirname "$target") directory..."
         mkdir -p "$(dirname "$target")"
     fi
 
     # Handle symbolic link
-    if [[ -L "$target" ]]; then
-        echo "<filename> symbolic link already exists"
-    elif [[ -f "$target" ]]; then
-        echo "<filename> exists as regular file"
-        echo "Backing up to <filename>.backup..."
+    if [ -L "$target" ]; then
+        ux_info "<filename> symbolic link already exists"
+    elif [ -f "$target" ]; then
+        ux_warning "<filename> exists as regular file"
+        ux_info "Backing up to <filename>.backup..."
         mv "$target" "$target.backup"
         ln -s "$source" "$target"
-        echo "Created symbolic link for <filename>"
+        ux_success "Created symbolic link for <filename>"
     else
         ln -s "$source" "$target"
-        echo "Created symbolic link for <filename>"
+        ux_success "Created symbolic link for <filename>"
     fi
 
-    echo ""
-    echo "<app> configuration initialization complete!"
-    echo ""
-    echo "Symbolic link:"
+    ux_success "<app> configuration initialization complete!"
+    ux_info "Symbolic link:"
     ls -la "$target"
 }
 ```
@@ -45,20 +47,18 @@ Add to `bash/app/<app>.bash`:
 <app>_edit_<config>() {
     local config_file="$HOME/dotfiles/bash/<category>/<filename>"
 
-    if [[ ! -f "$config_file" ]]; then
-        echo "Config file not found: $config_file"
+    if [ ! -f "$config_file" ]; then
+        ux_error "Config file not found: $config_file"
         return 1
     fi
 
-    echo "Editing <app> configuration..."
-    echo "File: $config_file"
-    echo ""
+    ux_info "Editing <app> configuration..."
+    ux_info "File: $config_file"
 
     ${EDITOR:-vim} "$config_file"
 
-    echo ""
-    echo "Configuration file edited"
-    echo "Changes will take effect immediately (symlinked)"
+    ux_success "Configuration file edited"
+    ux_info "Changes will take effect immediately (symlinked)"
 }
 ```
 
@@ -67,9 +67,15 @@ Add to `bash/app/<app>.bash`:
 Add to `<app>help` function:
 
 ```bash
-${bold}${blue}[Configuration Management]${reset}
-
-  ${green}<app>_init${reset}         : <app> 설정 파일 symbolic link 초기화
-                        (dotfiles/bash/<category>/<filename> ↔ <target_file>)
-  ${green}<app>_edit_<config>${reset} : <filename> 파일 편집
+ux_section "Configuration Management"
+ux_bullet "<app>_init         : <app> 설정 파일 symbolic link 초기화"
+ux_bullet_sub "(dotfiles/bash/<category>/<filename> ↔ <target_file>)"
+ux_bullet "<app>_edit_<config> : <filename> 파일 편집"
 ```
+
+## 의존성
+
+- `ux_lib`은 인터랙티브 셸에서 자동 로드됨 (`shell-common/tools/ux_lib/ux_lib.sh`).
+- `<app>_init` / `<app>_edit_*` 함수가 비인터랙티브 호출(예: 스크립트)에서도
+  실행될 수 있다면 함수 진입부에 `command -v ux_info >/dev/null 2>&1 ||
+  source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"` 가드를 권장.


### PR DESCRIPTION
## Summary

`devx:symlink-manager` 의 `references/` 가 사용자에게 가르치는 코드 패턴이
CLAUDE.md 핵심 규칙 두 개를 깨고 있어서 정정.

- **POSIX compatibility** (\`[ ]\` not \`[[ ]]\`) — 4 violations + 1 → 모두 POSIX
- **All output must use ux_lib** (raw \`echo\` 금지) — ~20 violations → ux_*

## Why

`/skill:check` 자동 감사(#427)에서 detected:
- references/function-templates.md L15, L21, L23, L48 \`[[ ]]\`
- references/advanced-patterns.md L16 \`[[ ]]\`
- function-templates.md ~20× raw \`echo\`

이 references 는 사용자가 \`<app>_init\` 함수를 작성할 때 그대로 복사해
사용하는 템플릿이라, 잘못된 패턴이 그대로 \`bash/\` / \`zsh/\` 코드로 박힘.

## Files

| File | Change |
|------|--------|
| `claude/skills/devx-symlink-manager/references/function-templates.md` | 헤더에 규칙 안내 + 4 \`[[ ]]\`→\`[ ]\` + 20 \`echo\`→ux_* + ux_lib 가드 안내 |
| `claude/skills/devx-symlink-manager/references/advanced-patterns.md` | L16 \`[[ ]]\`→\`[ ]\` |

남은 raw \`echo\` 1건 (\`echo "..." >> .gitignore\`)은 메시지 출력이 아니라
\`.gitignore\` 파일 append 라 의도적으로 유지.

## Test plan

- [x] \`grep -nE '\\[\\[|^\\s*echo ' references/*.md\` — 위 false-positive 제외 0
- [x] pre-commit 통과
- [ ] 머지 후 본 템플릿을 복사해 새 \`<app>_init\` 함수 작성 시 \`tox -e shellcheck\` 통과 확인

Closes #467
🤖 Generated with [Claude Code](https://claude.com/claude-code)