### PR TITLE
fix(pyenv): shell 시작 시 rehash race 제거 (--no-rehash)

### DIFF
--- a/shell-common/tools/integrations/pyenv.sh
+++ b/shell-common/tools/integrations/pyenv.sh
@@ -7,10 +7,16 @@ export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 
 # pyenv 초기화 (인터랙티브 셸 hook + PATH)
+# --no-rehash: shell 시작마다 rehash 하지 않음.
+#   - pyenv init - / --path 는 기본적으로 `command pyenv rehash 2>/dev/null` 를 emit
+#   - pyenv-rehash 는 "cannot rehash: ... .pyenv-shim exists" 를 stdout 으로 쏘므로
+#     2>/dev/null 로 막히지 않고, VSCode 가 동시에 여러 터미널을 열면 lock race 가 나
+#     Powerlevel10k instant-prompt warning 을 유발한다.
+#   - rehash 는 `pyenv install` / 새 entry-point 설치 후에만 수동으로 돌리면 충분.
+# init --path 는 .zprofile 전용 PATH 세팅용이라 init - 가 이미 PATH 를 깐 뒤에는 중복.
 if command -v pyenv >/dev/null; then
-    eval "$(pyenv init -)"
+    eval "$(pyenv init - --no-rehash)"
     eval "$(pyenv virtualenv-init -)" # pyenv-virtualenv 사용 시
-    eval "$(pyenv init --path)"       # 로그인 셸용 PATH
 fi
 
 # Python 설치 (대화형 스크립트)


### PR DESCRIPTION
## Summary

VSCode 재시작 시 여러 zsh 세션이 동시에 떠 발생하는 pyenv `rehash` 락 경합을 제거한다.

- `pyenv init -` 가 emit 하던 `command pyenv rehash 2>/dev/null` 는 `pyenv-rehash` 가 "cannot rehash: ... .pyenv-shim exists" 메시지를 **stdout** 으로 쏴서 `2>/dev/null` 로 막히지 않는다. 이 출력이 Powerlevel10k instant-prompt 의 "console output during zsh initialization" 경고를 유발했다.
- `pyenv init - --no-rehash` 로 바꿔 셸 시작마다 rehash 하지 않게 한다. rehash 는 `pyenv install` 또는 새 entry-point 설치 후에만 수동으로 돌리면 충분.
- 중복된 `pyenv init --path` 제거 — `init -` 가 이미 PATH 를 세팅하므로 redundant.

## Why

- VSCode 가 여러 터미널을 동시에 열면 `~/.pyenv/shims/.pyenv-shim` noclobber 락 파일을 두고 race 가 발생.
- 일부 셸이 `PYENV_REHASH_TIMEOUT=60` 안에 락을 못 잡고 stdout 으로 경고 출력 → P10k instant-prompt warning.
- shell 시작마다 rehash 하는 것은 본래 불필요 (shim 변동은 install 시점에만 발생).

## Test plan

- [x] `zsh -i -c 'pyenv version'` 정상 출력 (3.13.5), rehash 메시지 없음
- [x] pre-commit lint 통과 (shellcheck/shfmt 등)
- [ ] VSCode 재시작 후 다중 터미널을 열어도 P10k instant-prompt 경고 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)