### PR TITLE
feat(claude): setup.sh / migrate 자동화 갭 3건 보강

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -341,6 +341,21 @@ EOF
 
 log_debug "\n--- Claude Code dotfiles setup 시작 ---"
 
+# settings.json 자동 부트스트랩 (issue #500, F-1).
+# Fresh checkout (gitignored settings.json 부재) 에서도 hard-fail 없이
+# 진행되도록 settings.template.json → settings.json 1회 복사. 멱등 —
+# 이미 존재하면 no-op. 템플릿까지 부재한 비정상 상태는 아래 hard-fail
+# 가드가 그대로 잡는다.
+CLAUDE_SETTINGS_TEMPLATE="${CLAUDE_DOTFILES}/settings.template.json"
+if [ ! -f "$CLAUDE_SETTINGS_SOURCE" ] && [ -f "$CLAUDE_SETTINGS_TEMPLATE" ]; then
+    if cp "$CLAUDE_SETTINGS_TEMPLATE" "$CLAUDE_SETTINGS_SOURCE"; then
+        log_warning "settings.json 자동 부트스트랩: settings.template.json → settings.json"
+        log_warning "  필요 시 직접 편집하세요 (gitignored, PC-private)"
+    else
+        log_warning "settings.json 자동 부트스트랩 실패: cp 오류 — 수동 복사 필요"
+    fi
+fi
+
 # 필수 dotfiles source 검증
 [ -f "$CLAUDE_SETTINGS_SOURCE" ]      || log_error_and_exit "settings.json 없음: $CLAUDE_SETTINGS_SOURCE"
 [ -f "$CLAUDE_STATUSLINE_SOURCE" ]    || log_error_and_exit "statusline-command.sh 없음: $CLAUDE_STATUSLINE_SOURCE"

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -1103,13 +1103,15 @@ claude_accounts_migrate() {
             ux_warning "  as-is, but you may need to re-login on first use."
         fi
     else
-        # Issue #500, F-3: pre-migrate .claude.json 이 아예 부재한 경우
-        # sealed snapshot 도 만들 수 없어 _claude_restore_if_reset 의
-        # 자동 복원이 불가능하다. 사용자에게 그 사실을 명시해, 첫 로그인
-        # 후 재발생 시 수동 재로그인이 필요하다는 점을 미리 알린다.
-        ux_warning "Pre-migrate ~/.claude/.claude.json 부재 — sealed snapshot 미생성"
-        ux_warning "  첫 로그인 후 .claude.json reset 발생 시 자동 복원 불가"
-        ux_warning "  (수동 재로그인 필요: claude-yolo 재실행)"
+        # Issue #500, F-3: pre-migrate .claude.json missing means we cannot
+        # seal a snapshot, so _claude_restore_if_reset cannot auto-recover
+        # later. Surface that fact up front so the user knows a manual
+        # re-login may be required after the first claude-yolo run.
+        # English wording + ux_info for the explanatory follow-up matches
+        # the surrounding _cam_pre_size block (PR #503 review).
+        ux_warning "Pre-migrate ~/.claude/.claude.json missing — sealed snapshot not created"
+        ux_info    "  Automatic restoration will be unavailable if .claude.json is reset"
+        ux_info    "  (manual re-login required: re-run claude-yolo after first login)"
     fi
 
     ux_warning "Will move ~/.claude → ~/.claude-personal"

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -516,8 +516,24 @@ _claude_restore_if_reset() {
     _crir_live="$_crir_dir/.claude.json"
     _crir_snap="$_crir_dir/.claude.json.preserved-by-migrate"
 
-    [ -f "$_crir_live" ] || return 0
+    # Snapshot 부재 시에는 어느 쪽으로도 복원 불가 — silent return.
     [ -f "$_crir_snap" ] || return 0
+
+    # Missing-case branch (issue #500, F-2): live .claude.json 자체가
+    # 사라진 상태도 reset 의 한 변종으로 처리. Claude CLI 가 빈
+    # CLAUDE_CONFIG_DIR 진입 시 "configuration file not found" 프롬프트를
+    #띄우기 전에 sealed snapshot 으로 복원해 사용자 개입을 없앤다.
+    if [ ! -f "$_crir_live" ]; then
+        ux_warning "Detected missing .claude.json — restoring from sealed migrate snapshot"
+        ux_info    "  → snapshot: $_crir_snap"
+        if cp "$_crir_snap" "$_crir_live" 2>/dev/null; then
+            _crir_restored_size=$(wc -c < "$_crir_live" 2>/dev/null | tr -d ' ')
+            ux_success "  Restored $_crir_live (${_crir_restored_size:-?} bytes)"
+        else
+            ux_error "  Restore failed — proceeding anyway (claude may prompt for re-login)"
+        fi
+        return 0
+    fi
 
     _crir_size=$(wc -c < "$_crir_live" 2>/dev/null | tr -d ' ')
     [ -n "$_crir_size" ] || return 0
@@ -1086,6 +1102,14 @@ claude_accounts_migrate() {
             ux_warning "  first-start placeholder state. Migration will preserve it"
             ux_warning "  as-is, but you may need to re-login on first use."
         fi
+    else
+        # Issue #500, F-3: pre-migrate .claude.json 이 아예 부재한 경우
+        # sealed snapshot 도 만들 수 없어 _claude_restore_if_reset 의
+        # 자동 복원이 불가능하다. 사용자에게 그 사실을 명시해, 첫 로그인
+        # 후 재발생 시 수동 재로그인이 필요하다는 점을 미리 알린다.
+        ux_warning "Pre-migrate ~/.claude/.claude.json 부재 — sealed snapshot 미생성"
+        ux_warning "  첫 로그인 후 .claude.json reset 발생 시 자동 복원 불가"
+        ux_warning "  (수동 재로그인 필요: claude-yolo 재실행)"
     fi
 
     ux_warning "Will move ~/.claude → ~/.claude-personal"

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -1005,8 +1005,8 @@ run_with_fake_ssot() {
 
     run_in_bash 'export CLAUDE_SKIP_BIND_MOUNT=1; printf "y\n" | claude_accounts_migrate'
     assert_success
-    assert_output --partial "Pre-migrate ~/.claude/.claude.json 부재"
-    assert_output --partial "sealed snapshot 미생성"
+    assert_output --partial "Pre-migrate ~/.claude/.claude.json missing"
+    assert_output --partial "sealed snapshot not created"
     # 부재 시에는 sealed snapshot 도 만들어지지 않아야 함.
     [ ! -f "$HOME/.claude-personal/.claude.json.preserved-by-migrate" ]
 }

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -941,6 +941,76 @@ run_with_fake_ssot() {
     [ "$leaked" -eq 0 ]
 }
 
+# ---------- Issue #500: setup.sh / migrate 자동화 갭 보강 ----------
+
+@test "issue #500-F1: setup.sh auto-bootstraps settings.json from template when missing" {
+    _setup_sh_prereqs
+    rm -f "${DOTFILES_ROOT}/claude/settings.json"
+    ln -s "${DOTFILES_ROOT}" "$HOME/dotfiles"
+
+    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
+    assert_success
+    assert_output --partial "settings.json 자동 부트스트랩"
+    [ -f "${DOTFILES_ROOT}/claude/settings.json" ]
+}
+
+@test "issue #500-F1: setup.sh leaves existing settings.json untouched (idempotent)" {
+    _setup_sh_prereqs
+    # _setup_sh_prereqs 가 이미 template -> settings.json 복사를 해두었음.
+    sentinel='__issue_500_idempotent_marker__'
+    cp "${DOTFILES_ROOT}/claude/settings.json" "${DOTFILES_ROOT}/claude/settings.json.before"
+    # 사용자 편집 흔적을 남겨 두번째 실행 후에도 보존되는지 검증.
+    jq --arg s "$sentinel" '. + {marker: $s}' \
+        "${DOTFILES_ROOT}/claude/settings.json" > "${DOTFILES_ROOT}/claude/settings.json.tmp" \
+        && mv "${DOTFILES_ROOT}/claude/settings.json.tmp" "${DOTFILES_ROOT}/claude/settings.json"
+    ln -s "${DOTFILES_ROOT}" "$HOME/dotfiles"
+
+    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
+    assert_success
+    refute_output --partial "자동 부트스트랩"
+    grep -q "$sentinel" "${DOTFILES_ROOT}/claude/settings.json"
+}
+
+@test "issue #500-F2: claude_yolo restores missing .claude.json from snapshot" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    # 사용자가 .claude.json 을 삭제했거나 다른 사고로 사라진 상태.
+    printf '{"firstStartTime":"x","oauthAccount":{"e":"a@b"},"migrationVersion":5}' \
+        > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    assert_output --partial "missing .claude.json"
+    assert_output --partial "Restored"
+    [ -f "$HOME/.claude-personal/.claude.json" ]
+    grep -q "oauthAccount" "$HOME/.claude-personal/.claude.json"
+    grep -q "migrationVersion" "$HOME/.claude-personal/.claude.json"
+}
+
+@test "issue #500-F2: claude_yolo silent on missing .claude.json with no snapshot" {
+    _setup_claude_mock
+    mkdir -p "$HOME/.claude-personal"
+    # snapshot 도 없는 fresh PC — 기존 동작 유지 (silent return).
+
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    assert_success
+    refute_output --partial "Restored"
+    refute_output --partial "missing .claude.json"
+}
+
+@test "issue #500-F3: claude_accounts_migrate warns on missing pre-migrate .claude.json" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude/projects"
+    # .claude.json 자체가 부재한 디렉토리 (Home-PC 일부 회복 시나리오).
+
+    run_in_bash 'export CLAUDE_SKIP_BIND_MOUNT=1; printf "y\n" | claude_accounts_migrate'
+    assert_success
+    assert_output --partial "Pre-migrate ~/.claude/.claude.json 부재"
+    assert_output --partial "sealed snapshot 미생성"
+    # 부재 시에는 sealed snapshot 도 만들어지지 않아야 함.
+    [ ! -f "$HOME/.claude-personal/.claude.json.preserved-by-migrate" ]
+}
+
 # ---------- Issue #344: backups outside the skill scanner ----------
 
 @test "issue #344: skills/ stays free of *-pre-sync-* / *-orphan-* siblings" {


### PR DESCRIPTION
## Summary
- Home-PC 첫 셋업의 `setup.sh` → `claude-accounts migrate` → `claude-yolo` 시퀀스에서 노출되던 자동화 갭 3건을 setup 레이어에서 차단.
- 모든 분기는 멱등이고 sealed snapshot 부재 시 silent return — fresh PC, 마이그된 PC, 부분 회복된 PC 모두 회귀 없음.
- bats 5개 케이스 추가로 F-1 / F-2 / F-3 의 success/no-op/silent 분기를 회귀 가드.

## Changes
- **F-1 `claude/setup.sh`** — 부재 시 `settings.template.json` → `settings.json` 자동 부트스트랩. 템플릿까지 부재한 비정상 상태는 기존 hard-fail 가드가 그대로 잡는다.
- **F-2 `shell-common/tools/integrations/claude.sh::_claude_restore_if_reset`** — live `.claude.json` 자체가 missing 인 케이스를 reset 의 한 변종으로 처리. sealed snapshot 이 있을 때만 복원/출력하므로 fresh PC 는 silent.
- **F-3 `claude_accounts_migrate`** — pre-migrate `~/.claude/.claude.json` 부재 시 sealed snapshot 미생성 사실 + 첫 로그인 후 수동 재로그인 필요성을 `ux_warning` 으로 명시.
- **tests/bats/integrations/claude_accounts.bats** — 이슈 #500 케이스 5개 (F-1 부트스트랩 / 멱등, F-2 missing 복원 / no-snapshot silent, F-3 pre-migrate 부재 경고).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/integrations/claude_accounts.bats --filter 'issue #500'` — 5/5 pass
- [x] `tox -e shellcheck`, `tox -e shfmt` — pass
- [x] 전체 `claude_accounts.bats` 회귀 없음 (사전 존재하던 #342 `claude-skills-sync (no changes)` 1건 외 변동 없음)
- [ ] reviewer: fresh checkout 에서 `./setup.sh` 가 `settings.json` 부재 상태로 hard-fail 없이 통과
- [ ] reviewer: `~/.claude-personal/.claude.json` 임의 삭제 후 `claude-yolo` → snapshot 복원 + "configuration file not found" 미표시
- [ ] reviewer: `~/.claude/` 만 있고 `.claude.json` 부재인 상태에서 `claude-accounts migrate` → snapshot 미생성 경고 1줄 노출

> Note: pre-push 단계의 `mdlint` 는 CLAUDE.md 정책 ("tox -e mdlint is **disabled** — do not run it") 에 따라 `GH_PR_LINT_BYPASS=1` 로 우회. 실패는 PR 범위 밖 `zsh/AGENTS.md` 의 사전 존재 부채.

## Related
Closes #500

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~8 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~8 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
