### PR TITLE
fix(gh-flow): polling verdict 분리 (reply.done × reviewDecision)

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -127,28 +127,36 @@ _gh_flow_run_ai_prompt() {
 # Verdict helpers (shared between status and scoped prune)
 # ============================================================================
 
-# Echo one of: MERGED | CLOSED | OPEN | EMPTY | UNREACHABLE
-# - EMPTY: pr.number missing or empty (worker never opened a PR)
-# - UNREACHABLE: gh CLI failed (network/auth) — verdict layer must tolerate it
-_gh_flow_pr_state() {
+# Echo two lines for the given issue's PR:
+#   <state>
+#   <reviewDecision>
+# state ∈ MERGED | CLOSED | OPEN | EMPTY | UNREACHABLE
+#   - EMPTY: pr.number missing or empty (worker never opened a PR)
+#   - UNREACHABLE: gh CLI failed (network/auth) — verdict layer must tolerate it
+# reviewDecision ∈ "" (no decision yet) | APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED
+# Issue #501: reviewDecision distinguishes polling pre-reply ("") from
+# post-reply Approve-wait, so callers can render granular verdicts instead
+# of one ambiguous "active polling" message.
+_gh_flow_pr_view() {
     local _dir="$1"
-    local _pr_num _state _rc
+    local _pr_num _out _rc
     if [ ! -s "$_dir/pr.number" ]; then
-        printf 'EMPTY'
+        printf 'EMPTY\n\n'
         return 0
     fi
     _pr_num="$(cat "$_dir/pr.number" 2>/dev/null)"
     if [ -z "$_pr_num" ]; then
-        printf 'EMPTY'
+        printf 'EMPTY\n\n'
         return 0
     fi
-    _state="$(gh pr view "$_pr_num" --json state --jq '.state? // empty' 2>/dev/null)"
+    _out="$(gh pr view "$_pr_num" --json state,reviewDecision \
+        --jq '"\(.state // "EMPTY")\n\(.reviewDecision // "")"' 2>/dev/null)"
     _rc=$?
-    if [ "$_rc" -ne 0 ] || [ -z "$_state" ]; then
-        printf 'UNREACHABLE'
+    if [ "$_rc" -ne 0 ] || [ -z "$_out" ]; then
+        printf 'UNREACHABLE\n\n'
         return 0
     fi
-    printf '%s' "$_state"
+    printf '%s\n' "$_out"
 }
 
 # Print two lines for the given issue:
@@ -160,6 +168,7 @@ _gh_flow_pr_state() {
 _gh_flow_verdict() {
     local _issue="$1"
     local _dir _state _wt _pid _pid_alive _pr_state _verdict _action
+    local _pr_view _pr_decision
     _dir=$(_gh_flow_issue_dir "$_issue")
     if [ ! -d "$_dir" ]; then
         printf 'no state — issue not tracked\n(none)\n'
@@ -172,7 +181,13 @@ _gh_flow_verdict() {
     if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
         _pid_alive=1
     fi
-    _pr_state=$(_gh_flow_pr_state "$_dir")
+    _pr_view=$(_gh_flow_pr_view "$_dir")
+    {
+        IFS= read -r _pr_state || _pr_state=""
+        IFS= read -r _pr_decision || _pr_decision=""
+    } <<EOF
+$_pr_view
+EOF
 
     case "$_state" in
     done)
@@ -190,7 +205,30 @@ _gh_flow_verdict() {
             fi
             ;;
         OPEN)
-            _verdict="active polling — leave alone"
+            # Issue #501: split the single "active polling" message into a
+            # granular matrix over (reply.done, reviewDecision) so the user
+            # can tell pre-reply from post-Approve-wait without reading log.
+            if [ "$_pr_decision" = "APPROVED" ]; then
+                _verdict="approved — worker about to merge"
+            elif [ -f "$_dir/reply.done" ]; then
+                case "$_pr_decision" in
+                CHANGES_REQUESTED)
+                    _verdict="additional changes requested after reply"
+                    ;;
+                *)
+                    _verdict="awaiting reviewer Approve (already replied)"
+                    ;;
+                esac
+            else
+                case "$_pr_decision" in
+                CHANGES_REQUESTED)
+                    _verdict="comments arrived — worker about to run /gh-pr-reply"
+                    ;;
+                *)
+                    _verdict="awaiting first review"
+                    ;;
+                esac
+            fi
             _action="(none — still working)"
             ;;
         *)
@@ -247,6 +285,7 @@ _gh_flow_status_single() {
     local _issue _dir _state _pid _wt _pr_num _pid_state _wt_state
     local _pr_state _pr_date _pr_info _markers _log _log_mtime _etime
     local _verdict_out _verdict_text _action_text _name
+    local _pr_view _pr_decision _review_info
 
     _issue="${_arg#\#}"
     case "$_issue" in
@@ -288,9 +327,17 @@ _gh_flow_status_single() {
         _pid_state="-"
     fi
 
-    # PR detail: state from _gh_flow_pr_state, plus a date for MERGED/CLOSED.
+    # PR detail: state + reviewDecision from _gh_flow_pr_view (one round-trip),
+    # plus a date for MERGED/CLOSED. reviewDecision drives the new "Review" row
+    # rendered below; see issue #501.
     if [ -n "$_pr_num" ]; then
-        _pr_state=$(_gh_flow_pr_state "$_dir")
+        _pr_view=$(_gh_flow_pr_view "$_dir")
+        {
+            IFS= read -r _pr_state || _pr_state=""
+            IFS= read -r _pr_decision || _pr_decision=""
+        } <<EOF
+$_pr_view
+EOF
         case "$_pr_state" in
         MERGED)
             _pr_date="$(gh pr view "$_pr_num" --json mergedAt --jq '.mergedAt? | select(. != null) | split("T")[0]' 2>/dev/null)"
@@ -306,6 +353,8 @@ _gh_flow_status_single() {
         esac
     else
         _pr_info="(none — worker never opened one)"
+        _pr_state=""
+        _pr_decision=""
     fi
 
     # Worktree presence.
@@ -328,6 +377,15 @@ _gh_flow_status_single() {
     ux_table_row "State" "$_state"
     ux_table_row "Worker" "$_pid_state"
     ux_table_row "PR" "$_pr_info"
+    # Review row appears only for OPEN PRs — for MERGED/CLOSED/EMPTY the
+    # decision is irrelevant. Issue #501.
+    if [ "$_pr_state" = "OPEN" ]; then
+        case "$_pr_decision" in
+        "") _review_info="pending" ;;
+        *) _review_info="$_pr_decision" ;;
+        esac
+        ux_table_row "Review" "$_review_info"
+    fi
     ux_table_row "Worktree" "$_wt_state"
     ux_table_row "Markers" "$_markers"
 

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -308,20 +308,26 @@ teardown() {
 # verdict matrix (issue #252)
 # ---------------------------------------------------------------------------
 
-# Install a tiny `gh` stub on PATH so _gh_flow_pr_state has predictable input.
-# $1 = state token returned by `gh pr view <n> --json state --jq '.state'`.
+# Install a tiny `gh` stub on PATH so _gh_flow_pr_view has predictable input.
+# $1 = state token returned by `gh pr view <n> --json state[,reviewDecision]`.
+# $2 = optional reviewDecision (empty by default) — appended on the
+#      "--json state,reviewDecision" path used by _gh_flow_pr_view (issue #501).
 # Empty $1 → simulate gh failure (exit 1) so verdict treats it as UNREACHABLE.
 _install_gh_stub() {
     local _state="${1:-}"
+    local _decision="${2:-}"
     mkdir -p "$TEST_TEMP_HOME/bin"
     if [ -z "$_state" ]; then
         printf '#!/usr/bin/env bash\nexit 1\n' >"$TEST_TEMP_HOME/bin/gh"
     else
         cat >"$TEST_TEMP_HOME/bin/gh" <<STUB
 #!/usr/bin/env bash
-# minimal gh pr view stub
+# minimal gh pr view stub. The state,reviewDecision branch must come BEFORE
+# the bare --json state branch — both contain "--json state" as a substring,
+# so case-glob ordering matters.
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
     case "\$*" in
+    *"--json state,reviewDecision"*) printf '%s\n%s' "$_state" "$_decision" ;;
     *"--json state"*) printf '%s' "$_state" ;;
     *"--json mergedAt"*) printf '%s' "2026-04-26" ;;
     *"--json closedAt"*) printf '%s' "2026-04-26" ;;
@@ -354,15 +360,76 @@ STUB
     assert_output --partial "gh-flow prune --force 201"
 }
 
-@test "verdict: polling + OPEN PR → active polling, leave alone" {
-    _install_gh_stub "OPEN"
+@test "verdict: polling + OPEN + no reply.done + no decision → awaiting first review" {
+    _install_gh_stub "OPEN" ""
     _seed_state 202 "polling" "" "$$"
     printf '888\n' >"$HOME/.local/state/gh-flow/repo/202/pr.number"
 
     run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 202"
     assert_success
-    assert_output --partial "active polling"
+    assert_output --partial "awaiting first review"
     assert_output --partial "still working"
+}
+
+# Issue #501 polling/OPEN matrix: (reply.done, reviewDecision) → verdict.
+
+@test "verdict: polling + OPEN + no reply.done + CHANGES_REQUESTED → comments arrived" {
+    _install_gh_stub "OPEN" "CHANGES_REQUESTED"
+    _seed_state 220 "polling" "" "$$"
+    printf '500\n' >"$HOME/.local/state/gh-flow/repo/220/pr.number"
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 220"
+    assert_success
+    assert_output --partial "comments arrived"
+    assert_output --partial "/gh-pr-reply"
+    assert_output --partial "still working"
+}
+
+@test "verdict: polling + OPEN + no reply.done + APPROVED → about to merge" {
+    _install_gh_stub "OPEN" "APPROVED"
+    _seed_state 221 "polling" "" "$$"
+    printf '501\n' >"$HOME/.local/state/gh-flow/repo/221/pr.number"
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 221"
+    assert_success
+    assert_output --partial "approved"
+    assert_output --partial "about to merge"
+}
+
+@test "verdict: polling + OPEN + reply.done + no decision → awaiting Approve (replied)" {
+    _install_gh_stub "OPEN" ""
+    _seed_state 222 "polling" "" "$$"
+    printf '502\n' >"$HOME/.local/state/gh-flow/repo/222/pr.number"
+    touch "$HOME/.local/state/gh-flow/repo/222/reply.done"
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 222"
+    assert_success
+    assert_output --partial "awaiting reviewer Approve"
+    assert_output --partial "already replied"
+    refute_output --partial "awaiting first review"
+}
+
+@test "verdict: polling + OPEN + reply.done + CHANGES_REQUESTED → additional changes after reply" {
+    _install_gh_stub "OPEN" "CHANGES_REQUESTED"
+    _seed_state 223 "polling" "" "$$"
+    printf '503\n' >"$HOME/.local/state/gh-flow/repo/223/pr.number"
+    touch "$HOME/.local/state/gh-flow/repo/223/reply.done"
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 223"
+    assert_success
+    assert_output --partial "additional changes requested after reply"
+}
+
+@test "verdict: polling + OPEN + reply.done + APPROVED → about to merge" {
+    _install_gh_stub "OPEN" "APPROVED"
+    _seed_state 224 "polling" "" "$$"
+    printf '504\n' >"$HOME/.local/state/gh-flow/repo/224/pr.number"
+    touch "$HOME/.local/state/gh-flow/repo/224/reply.done"
+
+    run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 224"
+    assert_success
+    assert_output --partial "approved"
+    assert_output --partial "about to merge"
 }
 
 @test "verdict: polling + no pr.number → stuck pre-PR" {
@@ -493,6 +560,42 @@ STUB
     run_in_bash "cd '$REPO_DIR' && gh_flow status 504 505 2>&1"
     assert_failure
     assert_output --partial "only one issue number"
+}
+
+@test "status <N>: OPEN PR with no decision shows 'Review: pending' (issue #501)" {
+    _install_gh_stub "OPEN" ""
+    _seed_state 510 "polling" "" "$$"
+    printf '700\n' >"$HOME/.local/state/gh-flow/repo/510/pr.number"
+
+    run_in_bash "cd '$REPO_DIR' && gh_flow status 510"
+    assert_success
+    assert_output --partial "PR"
+    assert_output --partial "Review"
+    assert_output --partial "pending"
+}
+
+@test "status <N>: OPEN PR with APPROVED decision shows 'Review: APPROVED' (issue #501)" {
+    _install_gh_stub "OPEN" "APPROVED"
+    _seed_state 511 "polling" "" "$$"
+    printf '701\n' >"$HOME/.local/state/gh-flow/repo/511/pr.number"
+
+    run_in_bash "cd '$REPO_DIR' && gh_flow status 511"
+    assert_success
+    assert_output --partial "Review"
+    assert_output --partial "APPROVED"
+}
+
+@test "status <N>: MERGED PR omits the Review row (issue #501)" {
+    # Review decision is irrelevant once the PR is merged — the row should
+    # not appear so the status table stays terse for resolved PRs.
+    _install_gh_stub "MERGED" ""
+    _seed_state 512 "polling" "" "$$"
+    printf '702\n' >"$HOME/.local/state/gh-flow/repo/512/pr.number"
+
+    run_in_bash "cd '$REPO_DIR' && gh_flow status 512"
+    assert_success
+    assert_output --partial "MERGED"
+    refute_output --partial "Review"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `gh-flow status <N>` 의 polling/OPEN verdict 가 PR 직후 첫 리뷰 대기와 reply 종료 후 Approve 대기를 모두 "active polling — leave alone" 한 줄로 보여 워커가 무엇을 기다리는지 구분 못 하던 문제 해결.
- `_gh_flow_pr_state` → `_gh_flow_pr_view` 로 교체 (round-trip 1회 유지, `--json state,reviewDecision` 두 줄 반환), verdict 매트릭스를 `(reply.done × reviewDecision)` 조합으로 세분화, `gh-flow status` 표에 OPEN PR 한정 `Review` 행 추가.
- bats 회귀: `gh_flow.bats` 380/380 통과 (기존 OPEN 테스트 문구 업데이트 + 매트릭스 5건 + Review 행 표시 3건 신규 = 총 +8 케이스).

## Changes
- `shell-common/functions/gh_flow.sh`
  - `_gh_flow_pr_state` (단일 state 1줄) → `_gh_flow_pr_view` (state\nreviewDecision 2줄). EMPTY/UNREACHABLE 도 2줄 형식으로 통일.
  - `_gh_flow_verdict` polling/OPEN 분기를 매트릭스로 확장:
    - `(reply.done 없음, decision="")` → `awaiting first review`
    - `(reply.done 없음, CHANGES_REQUESTED)` → `comments arrived — worker about to run /gh-pr-reply`
    - `(reply.done 있음, decision="")` → `awaiting reviewer Approve (already replied)`
    - `(reply.done 있음, CHANGES_REQUESTED)` → `additional changes requested after reply`
    - `(*, APPROVED)` → `approved — worker about to merge`
    - `Next action` 은 모두 `(none — still working)` 유지 (사용자 개입 불필요).
  - `_gh_flow_status_single` 표에 PR 행 바로 아래 `Review` 행 추가. OPEN PR 일 때만 출력하고 MERGED/CLOSED/EMPTY 는 생략 (해소된 PR status 표는 그대로 간결 유지).
- `tests/bats/functions/gh_flow.bats`
  - `_install_gh_stub` 두 번째 인자(reviewDecision) 지원, `--json state,reviewDecision` 패턴이 `--json state` 보다 먼저 매치되도록 case-glob 순서 보장 + 코멘트로 명시.
  - 기존 `verdict: polling + OPEN PR → active polling, leave alone` → `awaiting first review` 로 문구 갱신.
  - verdict 매트릭스 5개 신규 (CHANGES_REQUESTED / APPROVED / replied 전후 조합).
  - `status <N>: OPEN PR with no decision shows 'Review: pending'`, `Review: APPROVED`, `MERGED PR omits Review row` 3개 신규.

## Test plan
- [x] `tox -e shellcheck,shfmt` 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/` — 380/380 통과 (52건 gh_flow.bats 포함)
- [ ] 머지 후 실제 워커: `gh-flow <N>` 으로 PR 생성 → `gh-flow status <N>` 의 Verdict 가 단계별로 다르게 표시되는지 확인 (reviewDecision=null/CHANGES_REQUESTED/APPROVED 각 케이스)
- [ ] gh CLI round-trip 횟수 회귀 없음 확인 (`_gh_flow_pr_view` 가 기존 `_gh_flow_pr_state` 와 동일하게 1회만 호출).

## Related
Closes #501

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
