### PR TITLE
fix(claude): gh-issue-flow Stop hook 자동 등록을 shell 시작 시점으로 이동 (#505)

### DIFF
--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -27,9 +27,25 @@ object `{"decision":"block","reason":"..."}` on stdout (block + nudge).
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
+
+# Opt-in stderr trace to diagnose "hook is registered but never blocks"
+# cases (issue #505, fix-plan C). Default off so production runs stay
+# silent. Enable with `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1`.
+_TRACE_ENABLED: bool = os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_TRACE") == "1"
+
+
+def _trace(message: str) -> None:
+    """Emit a `[stop-guard]` trace line on stderr when trace mode is on."""
+    if _TRACE_ENABLED:
+        try:
+            print(f"[stop-guard] {message}", file=sys.stderr, flush=True)
+        except OSError:
+            pass
+
 
 # Sub-skill names accepted in either hyphen or colon namespace form.
 # Order matters — it's the canonical 5-step gh-issue-flow chain.
@@ -60,14 +76,17 @@ FLOW_START_TOKENS: tuple[str, ...] = (
 FLOW_SKILL_NAMES: set[str] = {"gh-issue-flow", "gh:issue-flow"}
 
 
-def _allow() -> int:
+def _allow(trace_reason: str = "") -> int:
     """Allow the stop. Hook protocol: silent stdout + exit 0."""
+    if trace_reason:
+        _trace(f"allow: {trace_reason}")
     return 0
 
 
 def _block(reason: str) -> int:
     """Block the stop with a directive shown to the model."""
     json.dump({"decision": "block", "reason": reason}, sys.stdout)
+    _trace("block: gh-issue-flow incomplete — re-prompting model")
     return 0
 
 
@@ -221,35 +240,38 @@ def _next_step_label(seen: list[str]) -> str:
 def main() -> int:
     raw = sys.stdin.read()
     if not raw.strip():
-        return _allow()
+        return _allow("empty stdin")
     try:
         event = json.loads(raw)
     except json.JSONDecodeError:
-        return _allow()
+        return _allow("malformed stdin JSON")
     if not isinstance(event, dict):
-        return _allow()
+        return _allow("event is not a JSON object")
 
     if event.get("stop_hook_active"):
-        return _allow()
+        return _allow("stop_hook_active=True (already blocked once)")
 
     transcript_path = event.get("transcript_path")
     if not isinstance(transcript_path, str) or not transcript_path:
-        return _allow()
+        return _allow("missing transcript_path")
     p = Path(transcript_path)
     if not p.is_file():
-        return _allow()
+        return _allow(f"transcript file not found: {transcript_path}")
 
     messages = _load_transcript(p)
     if not messages:
-        return _allow()
+        return _allow("transcript empty / unreadable")
 
     boundary = _find_flow_boundary(messages)
     if boundary < 0:
-        return _allow()
+        return _allow("no gh-issue-flow boundary in transcript")
 
     terminal, seen = _scan_after_boundary(messages, boundary)
+    _trace(
+        f"boundary={boundary} sub_skills_seen={len(seen)}/5 ({','.join(seen) if seen else 'none'}) terminal={terminal}"
+    )
     if terminal:
-        return _allow()
+        return _allow("Step 3 terminal marker present — flow finished")
 
     next_label = _next_step_label(seen)
     reason = (

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -267,9 +267,11 @@ def main() -> int:
         return _allow("no gh-issue-flow boundary in transcript")
 
     terminal, seen = _scan_after_boundary(messages, boundary)
-    _trace(
-        f"boundary={boundary} sub_skills_seen={len(seen)}/5 ({','.join(seen) if seen else 'none'}) terminal={terminal}"
-    )
+    if _TRACE_ENABLED:
+        _trace(
+            f"boundary={boundary} sub_skills_seen={len(seen)}/{len(EXPECTED_CHAIN)} "
+            f"({','.join(seen) if seen else 'none'}) terminal={terminal}"
+        )
     if terminal:
         return _allow("Step 3 terminal marker present — flow finished")
 

--- a/shell-common/functions/claude_stop_hook_install.sh
+++ b/shell-common/functions/claude_stop_hook_install.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# shell-common/functions/claude_stop_hook_install.sh
+#
+# Auto-install the gh-issue-flow Stop hook into claude/settings.json on
+# interactive shell startup (issue #505).
+#
+# Background: claude/setup.sh:_migrate_install_gh_issue_flow_stop_hook
+# already performs this migration, but it only runs when the user
+# explicitly re-executes setup.sh. Users on a multi-account layout
+# whose live settings.json predates issue #383 silently miss the hook —
+# the harness backstop documented in gh-issue-flow/SKILL.md never
+# fires, and /gh-issue-flow regresses to the early-stop pattern.
+#
+# This helper closes that gap by re-running the same idempotent
+# migration on every interactive shell. Hot-path is silent (no jq
+# rewrite when the hook entry is already present); the install path
+# emits a single stderr line so the user sees what changed.
+#
+# Behaviour matrix:
+#   - Already installed                 → silent no-op (fast path)
+#   - Other Stop hook present (custom)  → silent skip (preserve user config)
+#   - jq missing / settings.json absent → silent skip (best effort)
+#   - Hook missing, no conflict         → install + 1 stderr line + backup
+
+# The function definition is intentionally NOT gated by the interactive
+# guard — defining it has no side effects, and tests source this file
+# in non-interactive bash. Only the auto-fire at the bottom is gated.
+
+_claude_install_gh_issue_flow_stop_hook() {
+    _csh_dotfiles="${DOTFILES_ROOT:-$HOME/dotfiles}"
+    _csh_source_file="${_csh_dotfiles}/claude/settings.json"
+    # shellcheck disable=SC2016
+    _csh_hook_command='${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py'
+
+    [ -f "$_csh_source_file" ] || {
+        unset _csh_dotfiles _csh_source_file _csh_hook_command
+        return 0
+    }
+    if ! command -v jq >/dev/null 2>&1; then
+        unset _csh_dotfiles _csh_source_file _csh_hook_command
+        return 0
+    fi
+
+    _csh_count=$(jq --arg cmd "$_csh_hook_command" \
+        '[.hooks?.Stop?[]?.hooks?[]? | select(.command == $cmd)] | length' \
+        "$_csh_source_file" 2>/dev/null) || _csh_count=0
+    if [ "${_csh_count:-0}" -ne 0 ]; then
+        unset _csh_dotfiles _csh_source_file _csh_hook_command _csh_count
+        return 0
+    fi
+
+    _csh_existing=$(jq '[.hooks?.Stop?[]?] | length' "$_csh_source_file" 2>/dev/null) || _csh_existing=0
+    if [ "${_csh_existing:-0}" -gt 0 ]; then
+        unset _csh_dotfiles _csh_source_file _csh_hook_command _csh_count _csh_existing
+        return 0
+    fi
+
+    # Bypass shell aliases (e.g. `cp`/`mv`/`rm` aliased to `-i` in
+    # interactive bash) so the migration never blocks on a confirmation
+    # prompt at shell startup. The auto-fire path runs in interactive
+    # bash where alias expansion is enabled.
+    _csh_backup="${_csh_source_file}.pre-stop-hook-fix-$(date +%Y%m%d%H%M%S)"
+    if ! command cp "$_csh_source_file" "$_csh_backup"; then
+        unset _csh_dotfiles _csh_source_file _csh_hook_command _csh_count _csh_existing _csh_backup
+        return 1
+    fi
+
+    _csh_tmp=$(mktemp "${_csh_source_file}.XXXXXX") || {
+        command rm -f "$_csh_backup"
+        unset _csh_dotfiles _csh_source_file _csh_hook_command _csh_count _csh_existing _csh_backup
+        return 1
+    }
+
+    # shellcheck disable=SC2016
+    if jq --arg cmd "$_csh_hook_command" \
+        '.hooks = ((.hooks // {}) | .Stop = ((.Stop // []) + [{"hooks":[{"type":"command","command":$cmd}]}]))' \
+        "$_csh_source_file" >"$_csh_tmp" && command mv "$_csh_tmp" "$_csh_source_file"; then
+        echo "claude/settings.json: gh-issue-flow Stop hook 자동 등록 (issue #505 / #383, backup: $_csh_backup)" >&2
+        _csh_rc=0
+    else
+        command rm -f "$_csh_tmp"
+        echo "claude/settings.json: Stop hook 등록 실패 — 백업 보존 ($_csh_backup)" >&2
+        _csh_rc=1
+    fi
+
+    unset _csh_dotfiles _csh_source_file _csh_hook_command _csh_count _csh_existing _csh_backup _csh_tmp
+    return ${_csh_rc:-0}
+}
+
+# Auto-fire only on interactive shells. Silent fast-path on no-op; the
+# install path emits a single stderr line. Errors are swallowed
+# (`|| true`) so a settings.json write failure never aborts shell init.
+case $- in
+    *i*) _claude_install_gh_issue_flow_stop_hook || true ;;
+esac

--- a/tests/bats/functions/claude_stop_hook_install.bats
+++ b/tests/bats/functions/claude_stop_hook_install.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/bats/functions/claude_stop_hook_install.bats
+# Verify shell-common/functions/claude_stop_hook_install.sh installs the
+# gh-issue-flow Stop hook on interactive shell startup (issue #505).
+#
+# The helper is the runtime counterpart to
+# claude/setup.sh:_migrate_install_gh_issue_flow_stop_hook — same
+# idempotent migration, but fires once per interactive shell so users
+# who never re-run setup.sh still get the harness backstop documented
+# in claude/skills/gh-issue-flow/SKILL.md.
+
+load '../test_helper'
+
+HELPER_REL="shell-common/functions/claude_stop_hook_install.sh"
+
+setup() {
+    setup_isolated_home
+    setup_isolated_dotfiles_root
+
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not available — helper is a no-op without it"
+    fi
+
+    SETTINGS="${DOTFILES_ROOT}/claude/settings.json"
+    HELPER="${DOTFILES_ROOT}/${HELPER_REL}"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# shellcheck disable=SC2154
+_count_hook_entries() {
+    jq '[.hooks?.Stop?[]?.hooks?[]? | select(.command == $cmd)] | length' \
+        --arg cmd '${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py' \
+        "$1"
+}
+
+@test "installs hook when settings.json has no Stop block" {
+    # Strip the .hooks.Stop entry that the template ships with so we
+    # exercise the install path. Other fields stay intact.
+    tmp="$(mktemp)"
+    jq 'del(.hooks.Stop)' "$SETTINGS" > "$tmp"
+    mv "$tmp" "$SETTINGS"
+    [ "$(_count_hook_entries "$SETTINGS")" = "0" ]
+
+    run bash -c "
+        set -e
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        source '${HELPER}'
+        _claude_install_gh_issue_flow_stop_hook
+    "
+    assert_success
+    assert_output --partial "자동 등록"
+    [ "$(_count_hook_entries "$SETTINGS")" = "1" ]
+
+    # Backup file with the documented prefix must exist.
+    ls "${SETTINGS}".pre-stop-hook-fix-* >/dev/null 2>&1
+}
+
+@test "no-op when hook is already present (silent fast path)" {
+    # Template ships with the hook entry → first call should be silent.
+    [ "$(_count_hook_entries "$SETTINGS")" = "1" ]
+
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        source '${HELPER}'
+        _claude_install_gh_issue_flow_stop_hook
+    "
+    assert_success
+    [ -z "$output" ]
+    [ "$(_count_hook_entries "$SETTINGS")" = "1" ]
+
+    # No backup created on no-op path.
+    ! ls "${SETTINGS}".pre-stop-hook-fix-* >/dev/null 2>&1
+}
+
+@test "preserves user-installed Stop hook (no clobber)" {
+    # Replace the stop hook with a different command — represents user
+    # customisation that the helper must NOT overwrite.
+    tmp="$(mktemp)"
+    jq '.hooks.Stop = [{"hooks":[{"type":"command","command":"/usr/local/bin/my-custom-hook"}]}]' \
+        "$SETTINGS" > "$tmp"
+    mv "$tmp" "$SETTINGS"
+    [ "$(_count_hook_entries "$SETTINGS")" = "0" ]
+
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        source '${HELPER}'
+        _claude_install_gh_issue_flow_stop_hook
+    "
+    assert_success
+    [ "$(_count_hook_entries "$SETTINGS")" = "0" ]
+
+    # Custom hook must still be there, untouched.
+    custom=$(jq -r '.hooks.Stop[0].hooks[0].command' "$SETTINGS")
+    [ "$custom" = "/usr/local/bin/my-custom-hook" ]
+}
+
+@test "second invocation after install is a no-op" {
+    tmp="$(mktemp)"
+    jq 'del(.hooks.Stop)' "$SETTINGS" > "$tmp"
+    mv "$tmp" "$SETTINGS"
+
+    bash -c "export DOTFILES_ROOT='${DOTFILES_ROOT}'; source '${HELPER}'; _claude_install_gh_issue_flow_stop_hook" >/dev/null 2>&1
+    [ "$(_count_hook_entries "$SETTINGS")" = "1" ]
+    backup_count_before=$(ls "${SETTINGS}".pre-stop-hook-fix-* 2>/dev/null | wc -l)
+
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        source '${HELPER}'
+        _claude_install_gh_issue_flow_stop_hook
+    "
+    assert_success
+    [ -z "$output" ]
+    [ "$(_count_hook_entries "$SETTINGS")" = "1" ]
+    backup_count_after=$(ls "${SETTINGS}".pre-stop-hook-fix-* 2>/dev/null | wc -l)
+    [ "$backup_count_before" = "$backup_count_after" ]
+}
+
+@test "function is callable and silent in non-interactive shell" {
+    # The auto-fire at the bottom of the file is gated by `case \$-`,
+    # so non-interactive sourcing must NOT modify settings.json or emit
+    # output, but the function must still be defined.
+    md5_before=$(md5sum "$SETTINGS" | awk '{print $1}')
+
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        source '${HELPER}'
+        type _claude_install_gh_issue_flow_stop_hook >/dev/null && echo defined
+    "
+    assert_success
+    assert_output --partial "defined"
+
+    md5_after=$(md5sum "$SETTINGS" | awk '{print $1}')
+    [ "$md5_before" = "$md5_after" ]
+}

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -26,14 +26,24 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_PATH = REPO_ROOT / "claude" / "hooks" / "gh_issue_flow_stop_guard.py"
 
 
-def _run_hook(stdin_payload: str) -> subprocess.CompletedProcess[str]:
-    """Invoke the hook with the given stdin string."""
+def _run_hook(
+    stdin_payload: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the hook with the given stdin string and optional env overrides."""
+    import os as _os
+
+    final_env: dict[str, str] | None = None
+    if env is not None:
+        final_env = _os.environ.copy()
+        final_env.update(env)
     return subprocess.run(
         ["python3", str(HOOK_PATH)],
         input=stdin_payload,
         capture_output=True,
         text=True,
         timeout=10,
+        env=final_env,
     )
 
 
@@ -421,3 +431,88 @@ def test_hook_callable_two_ways(tmp_path: Path, exec_form: list[str]) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Trace mode (issue #505, fix-plan C)
+# ---------------------------------------------------------------------------
+
+
+def test_trace_off_by_default_no_stderr(tmp_path: Path) -> None:
+    """Without GH_ISSUE_FLOW_STOP_GUARD_TRACE=1, stderr stays clean."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    # Block decision on stdout; nothing on stderr.
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert result.stderr == ""
+
+
+def test_trace_on_emits_block_diagnostics(tmp_path: Path) -> None:
+    """With trace enabled, stderr describes the boundary + decision."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_ISSUE_FLOW_STOP_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    # Trace lines all share the [stop-guard] prefix.
+    assert "[stop-guard]" in result.stderr
+    # The boundary scan summary should report 1/5 sub-skills seen.
+    assert "sub_skills_seen=1/5" in result.stderr
+    assert "block:" in result.stderr
+
+
+def test_trace_on_emits_allow_reason_for_no_boundary(tmp_path: Path) -> None:
+    """Allow path should also report its reason when trace mode is on."""
+    transcript = _write_transcript(
+        tmp_path,
+        [_user_text("just a chat unrelated to gh-issue-flow")],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_ISSUE_FLOW_STOP_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert "[stop-guard] allow:" in result.stderr
+    assert "no gh-issue-flow boundary" in result.stderr
+
+
+def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None:
+    """Completed-flow allow path also reports its reason under trace."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr"),
+            _assistant_skill("devx-schedule"),
+            _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_text("gh:issue-flow complete (#42)"),
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_ISSUE_FLOW_STOP_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert "Step 3 terminal marker" in result.stderr
+    assert "sub_skills_seen=5/5" in result.stderr


### PR DESCRIPTION
## Summary
- `/gh-issue-flow` 의 harness Stop hook backstop 이 user-private `claude/settings.json` 에 누락된 채 남는 회귀 (issue #505) 해결.
- 기존 setup.sh 1회 재실행에 의존하던 마이그레이션을, 모든 인터랙티브 셸 시작 시 멱등 자동 실행되도록 shell-common helper 신규.
- 디버깅 견고성 강화: hook 에 `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1` 옵트인 stderr trace 추가.

## Changes
- **shell-common/functions/claude_stop_hook_install.sh** (신규): POSIX 멱등 마이그레이션. fast-path 는 `jq` 1회 호출 후 silent 종료, install path 만 stderr 1줄 + timestamped backup. `command cp/mv/rm` 으로 인터랙티브 bash 의 `-i` alias 우회 (smoke test 에서 발견된 회귀 방지). 다른 Stop hook 이 이미 있는 경우는 silent skip 하여 사용자 커스터마이제이션 보존.
- **claude/hooks/gh_issue_flow_stop_guard.py**: `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1` 옵트인 stderr trace. allow / block 결정과 boundary scan 요약을 `[stop-guard] ...` 라인으로 남겨, "등록은 되어 있는데 fire 안 하는" 케이스를 코드 수정 없이 분리 진단 가능 (이슈의 fix-plan C).
- **tests/bats/functions/claude_stop_hook_install.bats** (신규, 5건): install / silent fast-path / 사용자 hook 보호 / 멱등 / 비인터랙티브 sourcing 무영향.
- **tests/integration/test_gh_issue_flow_stop_guard.py** (+5건): trace mode off-by-default 무출력, on 일 때 block / allow / boundary scan summary 검증.

## Test plan
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py -v` — 25/25 passed (신규 5 + 기존 20).
- [x] `tests/bats/functions/claude_stop_hook_install.bats` — 5/5 passed.
- [x] `tox -e ruff / mypy / shellcheck / shfmt` — all green.
- [x] 실 환경 smoke: 신규 helper 가 `~/dotfiles/claude/settings.json` 에 hook 항목을 1회 install (timestamped backup 보존), 두 번째 셸에서는 silent no-op 동작 확인. issue #505 의 재현 시나리오 직접 해결.

## Related
Closes #505

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
