### PR TITLE
docs(claude.md): ai-metrics footer 이모지 narrow exception (#427)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,5 +95,5 @@ case $- in *i*) ;; *) return 0 ;; esac
 - GitHub Project board: `docs/standards/github-project-board.md`
 - Git strategy: Semantic commits (`Type: Summary`)
 - Naming: `snake_case` for functions and filenames; dash-form for user-facing aliases
-- No emojis anywhere (token efficiency) — **단 하나의 예외**: `<!-- ai-metrics -->` ~ `<!-- /ai-metrics -->` 블록 내부의 `📊 👤 🤖` 글리프. 이는 GitHub Issue/PR 카드 footer 의 의도된 시각 디자인이며 #317 F-2 요구사항 + PR #320 으로 SSOT 확정됨. 다른 어떤 위치에도 이모지 사용 금지.
+- No emojis anywhere (token efficiency) — **단 하나의 예외**: `ai-metrics` footer (`<details>` 래퍼 및 `<!-- ai-metrics -->` 블록) 내부의 `📊 👤 🤖` 글리프. 이는 GitHub Issue/PR 카드 footer 의 의도된 시각 디자인이며 #317 F-2 요구사항 + PR #320 으로 SSOT 확정됨 (#367 의 `<details><summary>🤖 AI Metrics</summary>` 래퍼 포함). 다른 어떤 위치에도 이모지 사용 금지.
 - For AGENTS.md files, aim to keep them under 100 lines each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,5 +95,5 @@ case $- in *i*) ;; *) return 0 ;; esac
 - GitHub Project board: `docs/standards/github-project-board.md`
 - Git strategy: Semantic commits (`Type: Summary`)
 - Naming: `snake_case` for functions and filenames; dash-form for user-facing aliases
-- No emojis anywhere (token efficiency)
+- No emojis anywhere (token efficiency) — **단 하나의 예외**: `<!-- ai-metrics -->` ~ `<!-- /ai-metrics -->` 블록 내부의 `📊 👤 🤖` 글리프. 이는 GitHub Issue/PR 카드 footer 의 의도된 시각 디자인이며 #317 F-2 요구사항 + PR #320 으로 SSOT 확정됨. 다른 어떤 위치에도 이모지 사용 금지.
 - For AGENTS.md files, aim to keep them under 100 lines each


### PR DESCRIPTION
## Summary

CLAUDE.md "No emojis anywhere" 룰에 **단 하나의 예외**를 명시:
\`<\!-- ai-metrics --> ... <\!-- /ai-metrics -->\` 블록 안 \`📊 👤 🤖\`.

## Why — 18+ child issue 의 fix 형태를 결정하는 정책 결정

이슈 #427 자동 감사가 18+ 스킬에서 "이모지 위반"으로 표시한 인스턴스의
다수가 \`ai-metrics\` footer (\`gh:issue-create\` / \`gh:issue-flow\` /
\`gh:add-ai-metrics\` 등) 안의 \`📊 👤 🤖\` 임. 이는 의도된 디자인:

- #317 F-2 가 이 포맷을 명시한 요구사항으로 정의
- #320 (Merged) 으로 SSOT 확정됨
- 사용자 성과 정량화 + JIRA 미러링 SSOT 로 활용

이 글리프를 강제로 제거하면 SSOT 가 깨짐. 반대로 "포괄적 이모지 금지"
룰을 명문화해놓고 footer 만 예외로 운영하면 신규 기여자가 혼란.

→ 1 줄로 narrow exception 을 명문화하여 \`#427\` 자동 감사가 발견한
18+ 인스턴스 중 footer 안의 것을 "no action" 으로 분류 가능하게 함.
나머지 footer 밖 이모지 (예: \`### 🤖 AI Metrics — gh-commit\` 헤더,
\`⚠️\` 경고 메시지, 한국어 출력의 \`✅\`) 는 여전히 위반으로 정정 대상.

## Files

| File | Change |
|------|--------|
| \`CLAUDE.md\` | L98 "No emojis anywhere" 룰에 narrow exception 한 줄 추가 |

## Follow-up

- 자동 감사가 ai-metrics 블록 안의 글리프를 false-positive 로 표시하지 않도록 \`skill-check/references/checks.md\` 도 갱신 가능 (별도 PR)
- POOR-tier 리팩터 (#460/#461/#487/#494) 진행 시 footer 안 이모지는 그대로 유지, footer 밖만 정정

## Test plan

- [x] pre-commit 통과
- [ ] 머지 후 \`gh:issue-create\` 실행 → 생성된 이슈 footer 글리프 그대로 유지 확인
- [ ] 머지 후 \`#460/#461/#487/#494\` PR 들이 footer 안 이모지를 건드리지 않는지 검토에서 확인

Refs #427 #317 #320
🤖 Generated with [Claude Code](https://claude.com/claude-code)