### PR TITLE
refactor(skill:cli-dev): references/ 분리 + UX 보강 (#460)

### DIFF
--- a/claude/skills/cli-dev/SKILL.md
+++ b/claude/skills/cli-dev/SKILL.md
@@ -9,48 +9,36 @@ allowed-tools: Read, Glob, Grep, Write, Edit, Bash
 
 # CLI Feature Development
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 ## Role
 
-You are the CLI Development Specialist. Implement CLI commands that wrap backend API endpoints for developer testing. Follow TDD approach with pytest, use Rich for console output, and manage session state properly.
+You are the CLI Development Specialist. Implement CLI commands that wrap
+backend API endpoints for developer testing. Use TDD (pytest), Rich for
+console output, manage session state through `CLIContext`.
 
 ## Trigger Scenarios
 
-Use this skill when:
+"REQ-CLI-AUTH-1 구현해", "CLI 에 survey schema 명령어 추가", "auth login 만들어" 등 — `REQ-CLI-*` 구현 요청 전반.
 
-- "REQ-CLI-AUTH-1 구현해"
-- "CLI에 survey schema 명령어 추가해"
-- "auth login 명령어 만들어"
-- Implementing any REQ-CLI-* requirement
+## Tech Stack & Project Layout
 
-## Tech Stack
+cmd2 · rich · httpx · pytest+unittest.mock. 코드: `src/cli/{main,context,client}.py` + `src/cli/actions/<domain>.py`. 테스트: `tests/cli/test_<domain>_actions.py`.
 
-- **Command Parsing**: cmd2 (interactive shell)
-- **Output Formatting**: rich (colors, tables, panels)
-- **HTTP Client**: httpx (async API calls)
-- **Testing**: pytest + unittest.mock
+## Arguments
 
-## Project Structure
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<REQ-CLI-id>` | 구현할 요구사항 ID (예: `REQ-CLI-AUTH-1`) | 필수 |
+| `-h` / `--help` / `help` | `references/help.md` 출력 후 종료 | — |
 
-```
-src/cli/
-├── main.py              # CLI entry point
-├── context.py           # CLIContext (session state)
-├── client.py            # APIClient (httpx wrapper)
-├── actions/             # Command handlers
-│   ├── auth.py
-│   ├── survey.py
-│   └── ...
-tests/cli/
-├── test_auth_actions.py
-├── test_survey_actions.py
-└── ...
-```
-
-## Workflow
+## Workflow (stop on first failure — 어느 Step 이든 실패 시 즉시 중단)
 
 ### Step 1: Read Requirement
 
-Extract from `docs/CLI-FEATURE-REQUIREMENTS.md`:
+`docs/CLI-FEATURE-REQUIREMENTS.md` 에서 다음 키를 추출:
 
 ```yaml
 req_id: REQ-CLI-AUTH-1
@@ -60,108 +48,25 @@ session_state: ["token", "user_id"]
 error_cases: ["server error", "invalid input"]
 ```
 
+요구사항이 파일에 없으면 stop + `[FAIL] cli-dev — Step 1: REQ-CLI-id 미발견`.
+
 ### Step 2: Write Tests First (TDD)
 
-Create `tests/cli/test_<domain>_actions.py`:
-
-```python
-import pytest
-from unittest.mock import AsyncMock, patch
-from src.cli.actions.auth import AuthActions
-from src.cli.context import CLIContext
-
-class TestAuthActions:
-    """Tests for REQ-CLI-AUTH-1"""
-
-    @pytest.fixture
-    def context(self):
-        return CLIContext()
-
-    @pytest.fixture
-    def actions(self, context):
-        return AuthActions(context)
-
-    @pytest.mark.asyncio
-    async def test_login_success(self, actions, context):
-        """TC-1: Successful login stores JWT"""
-        with patch.object(
-            actions.api_client, "post",
-            new_callable=AsyncMock,
-            return_value={"token": "jwt...", "user_id": "123"}
-        ):
-            result = await actions.login("user")
-            assert result is True
-            assert context.session.token == "jwt..."
-
-    @pytest.mark.asyncio
-    async def test_login_missing_arg(self, actions):
-        """TC-2: Missing username shows usage"""
-        result = await actions.login(None)
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_login_api_error(self, actions):
-        """TC-3: API error handled gracefully"""
-        with patch.object(
-            actions.api_client, "post",
-            new_callable=AsyncMock,
-            side_effect=Exception("Network error")
-        ):
-            result = await actions.login("user")
-            assert result is False
-```
+Read `references/test-template.md` and create `tests/cli/test_<domain>_actions.py`.
+최소 3 시나리오 (success / missing-arg / api-error).
 
 ### Step 3: Implement Action Handler
 
-Create `src/cli/actions/<domain>.py`:
-
-```python
-from rich.console import Console
-from src.cli.client import APIClient
-from src.cli.context import CLIContext
-
-console = Console()
-
-class AuthActions:
-    """Auth CLI actions - REQ-CLI-AUTH-1"""
-
-    def __init__(self, context: CLIContext):
-        self.context = context
-        self.api_client = APIClient(context)
-
-    async def login(self, username: str | None) -> bool:
-        # 1. Validate input
-        if not username:
-            console.print("Usage: auth login [username]", markup=False)
-            return False
-
-        # 2. Call API
-        try:
-            console.print(f"Logging in as '{username}'...", style="yellow")
-            response = await self.api_client.post(
-                "/auth/login",
-                json={"username": username}
-            )
-
-            # 3. Update session
-            self.context.session.token = response["token"]
-            self.context.session.user_id = response["user_id"]
-
-            # 4. Display success
-            console.print(f"Successfully logged in", style="green")
-            return True
-
-        except Exception as e:
-            # 5. Handle error
-            console.print(f"Login failed: {e}", style="red")
-            return False
-```
+Read `references/action-template.md` and create `src/cli/actions/<domain>.py`.
+`references/patterns.md` 의 5 패턴 + 출력 포맷 + 명명 규칙 일관 적용.
 
 ### Step 4: Run Tests
 
 ```bash
 pytest tests/cli/test_<domain>_actions.py -v
 ```
+
+실패 테스트가 있으면 stop.
 
 ### Step 5: Run Quality Checks
 
@@ -170,113 +75,25 @@ ruff check --fix src/cli/
 ruff format src/cli/
 ```
 
-## Key Patterns
+`references/patterns.md` 끝의 Validation Checklist 점검 후 Output 단계로.
 
-### Pattern 1: Input Validation
+## Output
 
-```python
-# CORRECT
-if not username:
-    console.print("Usage: auth login [username]", markup=False)
-    return False
-
-# WRONG - crashes on None
-response = await self.api_client.post(...)
-```
-
-### Pattern 2: Session State
-
-```python
-# CORRECT - persists across commands
-self.context.session.token = response["token"]
-
-# WRONG - lost after function returns
-token = response["token"]
-```
-
-### Pattern 3: Rich Output (markup=False!)
-
-```python
-# CORRECT - brackets preserved
-console.print("Usage: cmd [ARG]", markup=False)
-
-# WRONG - brackets interpreted as markup tags
-console.print("Usage: cmd [ARG]")  # Brackets disappear!
-```
-
-### Pattern 4: Auth Check
-
-```python
-# CORRECT
-if not self.context.session.token:
-    console.print("Not authenticated. Run: auth login [user]",
-                  markup=False, style="red")
-    return False
-```
-
-### Pattern 5: Error Handling
-
-```python
-# CORRECT - graceful handling
-try:
-    response = await self.api_client.post(...)
-except Exception as e:
-    console.print(f"Error: {e}", style="red")
-    return False
-
-# WRONG - crashes CLI
-response = await self.api_client.post(...)
-```
-
-## Output Formatting
-
-```python
-# Success
-console.print("Success message", style="green")
-
-# Error
-console.print("Error message", style="red")
-
-# Progress
-console.print("Processing...", style="yellow")
-
-# Details (indented)
-console.print(f"  Detail: {value}", markup=False)
-```
-
-## Command Naming
+성공 시:
 
 ```
-CORRECT:
-  auth login
-  survey schema
-  questions generate
+[OK] cli-dev — REQ-CLI-<scope>-<n> implemented
+  files:
+    src/cli/actions/<domain>.py
+    tests/cli/test_<domain>_actions.py
+  tests: <n_passed>/<n_total> passed
+  lint:  clean
 
-WRONG:
-  login (too vague)
-  get_schema (not CLI style)
+Next: /gh:commit
 ```
 
-## Validation Checklist
+실패 시:
 
-Before completing:
-
-- [ ] Tests cover happy path + error cases
-- [ ] All tests pass
-- [ ] Session state updated correctly
-- [ ] `markup=False` for usage messages
-- [ ] Error handling (no crashes)
-- [ ] Lint checks pass
-
-## Execution
-
-When invoked:
-
-1. Read requirement from CLI-FEATURE-REQUIREMENTS.md
-2. Write pytest tests (TDD)
-3. Implement action handler
-4. Run tests
-5. Run lint checks
-6. Report results
-
-**Start with reading the requirement.**
+```
+[FAIL] cli-dev — Step <n>: <reason>
+```

--- a/claude/skills/cli-dev/references/action-template.md
+++ b/claude/skills/cli-dev/references/action-template.md
@@ -26,7 +26,7 @@ class AuthActions:
 
         # 2. Call API
         try:
-            console.print(f"Logging in as '{username}'...", style="yellow")
+            console.print(f"Logging in as '{username}'...", style="yellow", markup=False)
             response = await self.api_client.post(
                 "/auth/login",
                 json={"username": username},
@@ -42,7 +42,7 @@ class AuthActions:
 
         except Exception as e:
             # 5. Handle error
-            console.print(f"Login failed: {e}", style="red")
+            console.print(f"Login failed: {e}", style="red", markup=False)
             return False
 ```
 
@@ -51,7 +51,7 @@ class AuthActions:
 - 도메인별 클래스 이름: `<Domain>Actions`
 - action 메서드는 `async def`, 반환값은 `bool` (성공/실패)
 - 진행 메시지: `style="yellow"` / 성공: `"green"` / 에러: `"red"`
-- 사용법 메시지: 반드시 `markup=False` (Rich 가 `[ARG]` 를 markup 으로 오인하지 않게)
+- 모든 동적 메시지(사용법·에러·사용자 입력 등): 반드시 `markup=False` (Rich 가 `[...]` 를 markup 으로 오인하지 않게)
 - 외부 호출은 try/except 로 감싸기 — CLI 가 크래시하지 않도록
 - 세션 state 갱신은 `self.context.session.<field>` 만 사용 (로컬 변수에 담지 말기)
 

--- a/claude/skills/cli-dev/references/action-template.md
+++ b/claude/skills/cli-dev/references/action-template.md
@@ -1,0 +1,58 @@
+# Step 3: Action Handler 템플릿
+
+`src/cli/actions/<domain>.py` 를 위 도메인의 action 클래스로 작성한다.
+아래는 `auth login` 예시 — 5단계 흐름 (validate → call → update → display → handle):
+
+```python
+from rich.console import Console
+from src.cli.client import APIClient
+from src.cli.context import CLIContext
+
+console = Console()
+
+
+class AuthActions:
+    """Auth CLI actions - REQ-CLI-AUTH-1"""
+
+    def __init__(self, context: CLIContext):
+        self.context = context
+        self.api_client = APIClient(context)
+
+    async def login(self, username: str | None) -> bool:
+        # 1. Validate input
+        if not username:
+            console.print("Usage: auth login [username]", markup=False)
+            return False
+
+        # 2. Call API
+        try:
+            console.print(f"Logging in as '{username}'...", style="yellow")
+            response = await self.api_client.post(
+                "/auth/login",
+                json={"username": username},
+            )
+
+            # 3. Update session
+            self.context.session.token = response["token"]
+            self.context.session.user_id = response["user_id"]
+
+            # 4. Display success
+            console.print("Successfully logged in", style="green")
+            return True
+
+        except Exception as e:
+            # 5. Handle error
+            console.print(f"Login failed: {e}", style="red")
+            return False
+```
+
+## 적용 규칙
+
+- 도메인별 클래스 이름: `<Domain>Actions`
+- action 메서드는 `async def`, 반환값은 `bool` (성공/실패)
+- 진행 메시지: `style="yellow"` / 성공: `"green"` / 에러: `"red"`
+- 사용법 메시지: 반드시 `markup=False` (Rich 가 `[ARG]` 를 markup 으로 오인하지 않게)
+- 외부 호출은 try/except 로 감싸기 — CLI 가 크래시하지 않도록
+- 세션 state 갱신은 `self.context.session.<field>` 만 사용 (로컬 변수에 담지 말기)
+
+상세 패턴은 `references/patterns.md` 참고.

--- a/claude/skills/cli-dev/references/help.md
+++ b/claude/skills/cli-dev/references/help.md
@@ -1,0 +1,53 @@
+# cli-dev — Usage
+
+## Synopsis
+
+```
+/cli-dev <REQ-CLI-id>
+/cli-dev -h | --help | help
+```
+
+## Description
+
+CLI 기능 구현 스킬. `docs/CLI-FEATURE-REQUIREMENTS.md`에 정의된
+`REQ-CLI-*` 요구사항을 TDD 워크플로 (pytest + Rich + cmd2 + httpx) 로
+구현한다. 새 action handler 와 매칭 테스트를 동시에 생성.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<REQ-CLI-id>` | 구현할 요구사항 ID (예: `REQ-CLI-AUTH-1`) | 필수 |
+| `-h` / `--help` / `help` | 본 사용법 출력 후 종료 | — |
+
+## Workflow
+
+1. Read requirement from `docs/CLI-FEATURE-REQUIREMENTS.md`
+2. Write pytest tests first (TDD)
+3. Implement action handler
+4. Run tests
+5. Run lint checks (`ruff check --fix` + `ruff format`)
+6. Print structured verdict
+
+## Output
+
+성공 시 `[OK]` + 생성 파일·테스트 통과 수·다음 명령 hint.
+실패 시 `[FAIL]` + 실패 단계 + 이유.
+
+## Examples
+
+```
+/cli-dev REQ-CLI-AUTH-1
+/cli-dev REQ-CLI-SURVEY-2
+```
+
+## Stop conditions
+
+- 요구사항 ID 가 `docs/CLI-FEATURE-REQUIREMENTS.md`에 없을 때
+- 어느 Step 이든 실패 시 즉시 중단 (다음 Step 진행 금지)
+
+## See also
+
+- `references/test-template.md` — Step 2 pytest 템플릿
+- `references/action-template.md` — Step 3 action handler 템플릿
+- `references/patterns.md` — 5 가지 코드 패턴 + 출력 포맷 + 명명 규칙

--- a/claude/skills/cli-dev/references/patterns.md
+++ b/claude/skills/cli-dev/references/patterns.md
@@ -52,7 +52,7 @@ if not self.context.session.token:
 try:
     response = await self.api_client.post(...)
 except Exception as e:
-    console.print(f"Error: {e}", style="red")
+    console.print(f"Error: {e}", style="red", markup=False)
     return False
 
 # WRONG - crashes CLI

--- a/claude/skills/cli-dev/references/patterns.md
+++ b/claude/skills/cli-dev/references/patterns.md
@@ -1,0 +1,98 @@
+# cli-dev — 5 패턴 + 출력 포맷 + 명명 규칙
+
+## Pattern 1: Input Validation
+
+```python
+# CORRECT
+if not username:
+    console.print("Usage: auth login [username]", markup=False)
+    return False
+
+# WRONG - crashes on None
+response = await self.api_client.post(...)
+```
+
+## Pattern 2: Session State
+
+```python
+# CORRECT - persists across commands
+self.context.session.token = response["token"]
+
+# WRONG - lost after function returns
+token = response["token"]
+```
+
+## Pattern 3: Rich Output (markup=False!)
+
+```python
+# CORRECT - brackets preserved
+console.print("Usage: cmd [ARG]", markup=False)
+
+# WRONG - brackets interpreted as markup tags
+console.print("Usage: cmd [ARG]")  # Brackets disappear!
+```
+
+## Pattern 4: Auth Check
+
+```python
+# CORRECT
+if not self.context.session.token:
+    console.print(
+        "Not authenticated. Run: auth login [user]",
+        markup=False,
+        style="red",
+    )
+    return False
+```
+
+## Pattern 5: Error Handling
+
+```python
+# CORRECT - graceful handling
+try:
+    response = await self.api_client.post(...)
+except Exception as e:
+    console.print(f"Error: {e}", style="red")
+    return False
+
+# WRONG - crashes CLI
+response = await self.api_client.post(...)
+```
+
+## Output Formatting
+
+```python
+# Success
+console.print("Success message", style="green")
+
+# Error
+console.print("Error message", style="red")
+
+# Progress
+console.print("Processing...", style="yellow")
+
+# Details (indented)
+console.print(f"  Detail: {value}", markup=False)
+```
+
+## Command Naming
+
+```
+CORRECT:
+  auth login
+  survey schema
+  questions generate
+
+WRONG:
+  login (too vague)
+  get_schema (not CLI style)
+```
+
+## Validation Checklist (Step 5 직후)
+
+- [ ] Tests cover happy path + error cases
+- [ ] All tests pass
+- [ ] Session state updated correctly
+- [ ] `markup=False` for usage messages
+- [ ] Error handling (no crashes)
+- [ ] Lint checks pass

--- a/claude/skills/cli-dev/references/test-template.md
+++ b/claude/skills/cli-dev/references/test-template.md
@@ -1,0 +1,61 @@
+# Step 2: pytest TDD 템플릿
+
+새 도메인의 action 을 구현하기 전에 먼저 `tests/cli/test_<domain>_actions.py`
+를 작성한다. 아래는 `auth` 도메인 예시 — happy path, missing-arg, API-error
+세 가지 경우를 모두 커버.
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+from src.cli.actions.auth import AuthActions
+from src.cli.context import CLIContext
+
+
+class TestAuthActions:
+    """Tests for REQ-CLI-AUTH-1"""
+
+    @pytest.fixture
+    def context(self):
+        return CLIContext()
+
+    @pytest.fixture
+    def actions(self, context):
+        return AuthActions(context)
+
+    @pytest.mark.asyncio
+    async def test_login_success(self, actions, context):
+        """TC-1: Successful login stores JWT"""
+        with patch.object(
+            actions.api_client, "post",
+            new_callable=AsyncMock,
+            return_value={"token": "jwt...", "user_id": "123"},
+        ):
+            result = await actions.login("user")
+            assert result is True
+            assert context.session.token == "jwt..."
+
+    @pytest.mark.asyncio
+    async def test_login_missing_arg(self, actions):
+        """TC-2: Missing username shows usage"""
+        result = await actions.login(None)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_login_api_error(self, actions):
+        """TC-3: API error handled gracefully"""
+        with patch.object(
+            actions.api_client, "post",
+            new_callable=AsyncMock,
+            side_effect=Exception("Network error"),
+        ):
+            result = await actions.login("user")
+            assert result is False
+```
+
+## 적용 규칙
+
+- 도메인별 클래스 이름: `Test<Domain>Actions`
+- 테스트 함수 이름: `test_<action>_<scenario>` (예: `test_login_success`)
+- 시나리오 최소 3종: success / missing-arg or invalid-input / api-error
+- `AsyncMock` 으로 `api_client.post` 등 비동기 메서드 mock
+- 세션 state 검증: `context.session.<field>` 직접 단언


### PR DESCRIPTION
## Summary

`cli-dev` SKILL.md 282 → 99 줄 (Check 1 FAIL→PASS).

- 코드 템플릿·패턴을 4 개 `references/` 파일로 추출
- Help flag, Options 표, stop-on-error 정책, `[OK]`/`[FAIL]` verdict, `Next:` 힌트 추가
- 사용자 경험: 슬래시 호출 `/cli-dev -h` 로 사용법 즉시 확인

## Why

`/skill:check` 자동 감사(#427)에서 detected: 282 lines, references/ 부재,
help/options/verdict/next-action 모두 부재 (POOR 3/10 PASS, 1 WARN, 6 FAIL).

## Files

| File | Role |
|------|------|
| \`claude/skills/cli-dev/SKILL.md\` | 워크플로 phases 만 (99 lines) |
| \`references/help.md\` | \`-h/--help/help\` verbatim 사용법 |
| \`references/test-template.md\` | Step 2 pytest TDD 템플릿 + 적용 규칙 |
| \`references/action-template.md\` | Step 3 action handler 템플릿 + 5단계 흐름 |
| \`references/patterns.md\` | 5 코드 패턴 + 출력 포맷 + 명명 + Validation Checklist |

## SKILL.md 새 섹션

- \`## Help\` — 헬프 인자 분기
- \`## Arguments\` — Option/Description/Default 표
- Workflow 헤더에 \`(stop on first failure ...)\`
- \`## Output\` — \`[OK]\`/\`[FAIL]\` verdict 포맷 + \`Next: /gh:commit\`

## Test plan

- [x] \`wc -l\` 99 줄
- [x] pre-commit 통과
- [ ] 머지 후 \`/skill-check claude/skills/cli-dev/SKILL.md\` 재실행 — POOR→GOOD/EXCELLENT 기대

Closes #460
🤖 Generated with [Claude Code](https://claude.com/claude-code)