### PR TITLE
refactor(skill:dev-sh-generator): references/ 분리 + UX 보강 (#461)

### DIFF
--- a/claude/skills/dev-sh-generator/SKILL.md
+++ b/claude/skills/dev-sh-generator/SKILL.md
@@ -7,15 +7,18 @@ description: >-
 allowed-tools: Read, Glob, Grep, Write, Bash, Edit
 ---
 
-# dev.sh Generator Skill
+# dev-sh-generator
 
-## Role
+## Help
 
-You are a Development Workflow Automation Specialist. Generate standardized, project-specific `tools/dev.sh` task runner scripts that follow the patterns defined in `tools/AGENTS.md`.
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
 
-## Purpose
+## Role & Purpose
 
-Automate the creation of `tools/dev.sh` files that provide a consistent developer interface across projects for common tasks: server startup, testing, formatting, shell access, and CLI interaction. Ensure commands are reproducible, idempotent, and follow project-specific conventions.
+Development Workflow Automation Specialist. Generate standardized,
+project-specific `tools/dev.sh` task runners that follow `tools/AGENTS.md` —
+the SSOT for command shape, env vars, and conventions — so server, test,
+format, shell, and CLI tasks behave consistently across projects.
 
 ## Trigger Scenarios
 
@@ -28,737 +31,68 @@ Use this skill when users request:
 - "개발 스크립트 만들어줘"
 - "Update tools/dev.sh to match AGENTS.md"
 
-## Pre-Flight Checklist
+## Options
 
-Execute BEFORE writing any files:
+See `references/options.md` for the full env-var table
+(`PY_RUN`, `PY_TEST`, `UVICORN_ENTRY`, `USE_ALEMBIC`, `IS_DJANGO`,
+`MANAGE_PY`, `DEFAULT_DATASET`, `CLI_ENTRY`, plus runtime overrides
+`APP_ENV`, `DATASET`, `DJANGO_SETTINGS_MODULE`).
 
-1. **Verify AGENTS.md Exists**: Read `tools/AGENTS.md` to extract configuration requirements
-2. **Detect Project Type**: Check `pyproject.toml`, `package.json`, or other dependency files
-3. **Identify Entry Points**: Locate server entry, CLI entry, test configuration
-4. **Check Existing dev.sh**: Backup if present, note customizations
-5. **Verify Tools Available**: Check for `uv`, `poetry`, `tox`, `pytest`
-6. **Plan Generation**: Announce what will be generated before writing
+## Workflow (stop on first failure — any phase failure halts the chain)
 
-## Implementation Protocol
+1. Analyze project — read `tools/AGENTS.md`, `pyproject.toml`, scan structure.
+   See `references/preflight-and-analysis.md`. SSOT: `tools/AGENTS.md`.
+2. Generate `tools/dev.sh` using the matching template (T1/T2/T3).
+   See `references/generation-protocol.md`. Template choice rubric is in
+   `references/templates.md` (uv.lock → T1, Django → T2, alembic.ini → T3).
+3. Validate against quality gates — bash syntax, no emojis, executable,
+   smoke tests. See `references/generation-protocol.md` → Phase 3.
+4. Report verdict using the Output format below.
 
-### Phase 0: Analysis (ALWAYS)
+Error / degradation branches (missing AGENTS.md, no entry point, permission
+issues, pre-existing emojis): see `references/error-handling.md`.
 
-Execute BEFORE generating file:
+Linting layout (why `lint` is split from `mdlint`):
+see `references/linting-strategy.md`.
 
-1. **Read tools/AGENTS.md**
+## Output
 
-   ```bash
-   # Verify AGENTS.md exists
-   test -f tools/AGENTS.md && echo "Found" || echo "Missing"
-   ```
+Success:
 
-   Extract from AGENTS.md:
-   - Python runner preference (PY_RUN)
-   - Test runner configuration (PY_TEST)
-   - Server entry point (UVICORN_ENTRY)
-   - Migration strategy (USE_ALEMBIC, IS_DJANGO)
-   - CLI entry path
-   - Format/lint commands
+```
+[OK] tools/dev.sh generated
+  template: <T1|T2|T3>
+  applied: PY_RUN=<...>, PY_TEST=<...>, UVICORN_ENTRY=<...>, USE_ALEMBIC=<...>, CLI_ENTRY=<...>
 
-2. **Scan Project Structure**
-
-   ```bash
-   # Check dependency management
-   ls -la pyproject.toml uv.lock poetry.lock requirements.txt 2>/dev/null
-
-   # Find entry points
-   find src -name "main.py" -o -name "app.py" 2>/dev/null
-
-   # Check for CLI
-   find src -path "*/cli/*.py" 2>/dev/null
-   ```
-
-3. **Read pyproject.toml**
-
-   Extract:
-   - Project name
-   - Python version requirements
-   - Dependencies (fastapi, django, uvicorn)
-   - Dev dependencies (pytest, tox, ruff)
-   - Package structure (src layout)
-
-4. **Check Existing tools/dev.sh**
-
-   If exists:
-   - Create timestamped backup
-   - Note custom commands to preserve
-   - Identify deviations from standard
-
-Output: Configuration map with all detected values
-
-### Phase 1: Configuration Extraction (ALWAYS)
-
-Build configuration from analysis:
-
-```bash
-# Python Runner Priority:
-# 1. AGENTS.md specification
-# 2. Detected lock file (uv.lock -> "uv run", poetry.lock -> "poetry run")
-# 3. Default to "python"
-
-# Test Runner Priority:
-# 1. AGENTS.md specification
-# 2. pyproject.toml [tool.pytest] configuration
-# 3. Default to "$PY_RUN pytest -q"
-
-# Server Entry Priority:
-# 1. AGENTS.md specification
-# 2. Search for FastAPI app instance in src/
-# 3. Search for Django settings
-# 4. Leave empty if not found
-
-# CLI Entry Priority:
-# 1. AGENTS.md specification
-# 2. Search for src/*/cli/*.py files
-# 3. Omit cli command if not found
+Next: ./tools/dev.sh help
+Then: ./tools/dev.sh up
 ```
 
-Required Variables:
-- `PY_RUN`: Python execution command
-- `PY_TEST`: Test execution command
-- `UVICORN_ENTRY`: FastAPI/Uvicorn entry point (empty string if none)
-- `USE_ALEMBIC`: Boolean for Alembic migrations
-- `IS_DJANGO`: Boolean for Django projects
-- `MANAGE_PY`: Django manage.py path
-- `DEFAULT_DATASET`: Default data directory path
-- `CLI_ENTRY`: CLI script path (empty string if none)
+Failure:
 
-### Phase 2: Generate tools/dev.sh (SEQUENTIAL)
-
-1. **Create Backup** (if existing file)
-
-   ```bash
-   if [ -f tools/dev.sh ]; then
-     cp tools/dev.sh "tools/dev.sh.backup.$(date +%Y%m%d_%H%M%S)"
-   fi
-   ```
-
-2. **Write tools/dev.sh**
-
-   Use template structure:
-
-   ```bash
-   #!/usr/bin/env bash
-   set -euo pipefail
-
-   # Configuration (extracted from project)
-   PY_RUN="..."
-   PY_TEST="..."
-   UVICORN_ENTRY="..."
-   USE_ALEMBIC=false
-   IS_DJANGO=false
-   MANAGE_PY="manage.py"
-   DEFAULT_DATASET="./data"
-   CLI_ENTRY="..."
-
-   cmd="${1:-help}"
-
-   case "$cmd" in
-     up)
-       # Server startup logic
-       ;;
-     test)
-       # Test execution logic
-       ;;
-     fmt|format)
-       # Format/lint logic
-       ;;
-     shell)
-       # Shell entry logic
-       ;;
-     cli)
-       # CLI launch logic (only if CLI_ENTRY exists)
-       ;;
-     *)
-       # Help text
-       ;;
-   esac
-   ```
-
-3. **Command Implementation Rules**
-
-   **up command**:
-   - NO emojis in echo statements (violates AGENTS.md token efficiency)
-   - Check IS_DJANGO first, then USE_ALEMBIC
-   - Export APP_ENV and DATASET before uvicorn
-   - Use --reload for development
-   - Bind to 0.0.0.0:8000 for Docker compatibility
-   - Exit 1 with clear message if no entry point
-
-   **test command**:
-   - Pass through additional arguments: `$PY_TEST "${@:2}"`
-   - Keep output quiet by default (-q flag)
-   - NO emoji in echo
-
-   **fmt/format command**:
-   - Check for tox first: `command -v tox`
-   - Use `tox -e ruff` as default
-   - Provide install instructions if missing
-   - NO emoji in echo
-
-   **lint command**:
-   - Run linters excluding markdown: `tox -e ruff,mypy,shellcheck,shfmt`
-   - Covers: ruff (Python format/lint), mypy (type check), shellcheck (bash), shfmt (bash format)
-   - Markdown linting available separately via `mdlint` command
-   - Rationale: Markdown errors can be numerous; separate for selective use
-   - NO emoji in echo
-
-   **mdlint command** (optional, separate):
-   - Only include if project has markdown files
-   - Run markdown linter: `tox -e mdlint "${@:2}"`
-   - Allows users to run markdown checks on-demand
-   - NO emoji in echo
-
-   **shell command**:
-   - Check for uv: `command -v uv`
-   - Use `exec` to replace shell process
-   - Fall back with clear error
-   - NO emoji in echo
-
-   **cli command**:
-   - Only include if CLI_ENTRY is non-empty
-   - Pass through all arguments: `"${@:2}"`
-   - Use $PY_RUN to execute
-   - NO emoji in echo
-
-   **help (default)**:
-   - Use heredoc for clean formatting
-   - List only implemented commands
-   - Provide examples with env var overrides
-   - NO emojis (strict compliance with AGENTS.md)
-   - Keep ASCII-only for maximum compatibility
-
-4. **Set Permissions**
-
-   ```bash
-   chmod +x tools/dev.sh
-   ```
-
-### Phase 3: Validation (ALWAYS)
-
-Verify ALL:
-
-- [ ] tools/dev.sh created successfully
-- [ ] File is executable (chmod +x applied)
-- [ ] NO emojis in any echo or cat statements
-- [ ] All variables have default values
-- [ ] Error handling checks for missing binaries
-- [ ] Heredoc properly formatted (no tabs before HELP)
-- [ ] Case statement has default/help handler
-- [ ] Commands match AGENTS.md specification
-- [ ] Backup created if file existed
-- [ ] Line endings are LF (not CRLF)
-
-**Linting**:
-
-```bash
-# Shell syntax check
-bash -n tools/dev.sh
-
-# Shellcheck (if available)
-shellcheck tools/dev.sh 2>/dev/null || echo "shellcheck not available"
-
-# Check for emojis (MUST be zero)
-grep -P '[\x{1F300}-\x{1F9FF}]' tools/dev.sh && echo "FAIL: Emojis found" || echo "PASS: No emojis"
+```
+[FAIL] dev-sh-generator — Phase <n>: <reason>
 ```
 
-**Smoke Tests**:
-
-```bash
-# Help command works
-./tools/dev.sh help
-
-# Test command handles args
-./tools/dev.sh test --help
-
-# Invalid command shows help
-./tools/dev.sh invalid 2>&1 | grep -q "Usage:"
-```
-
-### Phase 4: Report (ALWAYS)
-
-Provide summary:
-
-1. **File Status**
-   - Created: tools/dev.sh (executable)
-   - Backup: tools/dev.sh.backup.TIMESTAMP (if applicable)
-
-2. **Configuration Applied**
-   ```
-   PY_RUN: uv run
-   PY_TEST: uv run pytest -q
-   UVICORN_ENTRY: src.backend.main:app
-   USE_ALEMBIC: false
-   CLI_ENTRY: src/backend/cli/app.py
-   ```
-
-3. **Available Commands**
-   - up: Start development server
-   - test: Run test suite
-   - format: Format and lint code
-   - shell: Enter project shell
-   - cli: Launch interactive CLI (if applicable)
-
-4. **Next Steps**
-   ```bash
-   # Test the script
-   ./tools/dev.sh help
-
-   # Start development
-   ./tools/dev.sh up
-
-   # Run tests
-   ./tools/dev.sh test
-
-   # Format code
-   ./tools/dev.sh format
-   ```
-
-5. **Compliance Check**
-   - [ ] No emojis (token efficiency)
-   - [ ] Follows AGENTS.md patterns
-   - [ ] All commands idempotent
-   - [ ] Error messages actionable
-
-## Configuration Templates
-
-### Template 1: FastAPI with uv
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-PY_RUN="uv run"
-PY_TEST="uv run pytest -q"
-UVICORN_ENTRY="src.backend.main:app"
-USE_ALEMBIC=false
-IS_DJANGO=false
-MANAGE_PY="manage.py"
-DEFAULT_DATASET="./data"
-CLI_ENTRY="src/backend/cli/app.py"
-
-cmd="${1:-help}"
-
-case "$cmd" in
-  up)
-    echo "Starting dev server..."
-    if [ -n "$UVICORN_ENTRY" ]; then
-      APP_ENV=${APP_ENV:-development} DATASET=${DATASET:-"$DEFAULT_DATASET"} \
-      $PY_RUN uvicorn "$UVICORN_ENTRY" --reload --host 0.0.0.0 --port 8000
-    else
-      echo "ERROR: No dev server configured. Edit tools/dev.sh to add entry point."
-      exit 1
-    fi
-    ;;
-
-  test)
-    echo "Running tests..."
-    $PY_TEST "${@:2}"
-    ;;
-
-  fmt|format)
-    echo "Formatting code (tox -e ruff)..."
-    if command -v tox >/dev/null 2>&1; then
-      tox -e ruff
-    else
-      echo "ERROR: tox not found. Install: uv pip install tox"
-      exit 1
-    fi
-    ;;
-
-  shell)
-    echo "Entering project shell..."
-    if command -v uv >/dev/null 2>&1; then
-      exec uv run bash
-    else
-      echo "ERROR: uv not found. Activate virtualenv manually."
-      exit 1
-    fi
-    ;;
-
-  cli)
-    echo "Starting interactive CLI..."
-    $PY_RUN python "$CLI_ENTRY" "${@:2}"
-    ;;
-
-  *)
-    cat <<'HELP'
-Usage: ./tools/dev.sh <command>
-
-Commands:
-  up           Start dev server (uvicorn on :8000)
-  test         Run test suite (pytest)
-  format       Format and lint code (tox -e ruff)
-  shell        Enter project shell
-  cli          Start interactive CLI
-
-Examples:
-  ./tools/dev.sh up
-  ./tools/dev.sh test -k test_api
-  DATASET=/custom/path ./tools/dev.sh up
-  APP_ENV=production ./tools/dev.sh up
-
-HELP
-    ;;
-esac
-```
-
-### Template 2: Django with Poetry
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-PY_RUN="poetry run"
-PY_TEST="poetry run pytest -q"
-UVICORN_ENTRY=""
-USE_ALEMBIC=false
-IS_DJANGO=true
-MANAGE_PY="manage.py"
-DEFAULT_DATASET="./data"
-CLI_ENTRY=""
-
-cmd="${1:-help}"
-
-case "$cmd" in
-  up)
-    echo "Starting Django dev server..."
-    export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-"config.settings.dev"}
-    $PY_RUN python "$MANAGE_PY" migrate
-    $PY_RUN python "$MANAGE_PY" runserver 0.0.0.0:8000
-    ;;
-
-  test)
-    echo "Running tests..."
-    $PY_TEST "${@:2}"
-    ;;
-
-  fmt|format)
-    echo "Formatting code (black)..."
-    if command -v poetry >/dev/null 2>&1; then
-      poetry run black .
-    else
-      echo "ERROR: poetry not found. Install: pip install poetry"
-      exit 1
-    fi
-    ;;
-
-  shell)
-    echo "Entering Django shell..."
-    $PY_RUN python "$MANAGE_PY" shell
-    ;;
-
-  *)
-    cat <<'HELP'
-Usage: ./tools/dev.sh <command>
-
-Commands:
-  up           Start Django dev server (migrations + runserver)
-  test         Run test suite (pytest)
-  format       Format code (black)
-  shell        Enter Django shell
-
-Examples:
-  ./tools/dev.sh up
-  DJANGO_SETTINGS_MODULE=config.settings.prod ./tools/dev.sh up
-
-HELP
-    ;;
-esac
-```
-
-### Template 3: FastAPI with Alembic
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-PY_RUN="uv run"
-PY_TEST="uv run pytest -q"
-UVICORN_ENTRY="src.main:app"
-USE_ALEMBIC=true
-IS_DJANGO=false
-MANAGE_PY="manage.py"
-DEFAULT_DATASET="./data"
-CLI_ENTRY=""
-
-cmd="${1:-help}"
-
-case "$cmd" in
-  up)
-    echo "Starting dev server..."
-    if $USE_ALEMBIC; then
-      echo "Running Alembic migrations..."
-      $PY_RUN alembic upgrade head
-    fi
-    if [ -n "$UVICORN_ENTRY" ]; then
-      APP_ENV=${APP_ENV:-development} \
-      $PY_RUN uvicorn "$UVICORN_ENTRY" --reload --host 0.0.0.0 --port 8000
-    else
-      echo "ERROR: No dev server configured."
-      exit 1
-    fi
-    ;;
-
-  test)
-    echo "Running tests..."
-    $PY_TEST "${@:2}"
-    ;;
-
-  fmt|format)
-    echo "Formatting code (ruff)..."
-    if command -v ruff >/dev/null 2>&1; then
-      ruff format .
-      ruff check . --fix
-    else
-      echo "ERROR: ruff not found. Install: uv pip install ruff"
-      exit 1
-    fi
-    ;;
-
-  shell)
-    echo "Entering project shell..."
-    exec uv run bash
-    ;;
-
-  *)
-    cat <<'HELP'
-Usage: ./tools/dev.sh <command>
-
-Commands:
-  up           Start dev server (alembic + uvicorn)
-  test         Run test suite (pytest)
-  format       Format and lint code (ruff)
-  shell        Enter project shell
-
-HELP
-    ;;
-esac
-```
-
-## Error Handling
-
-### Missing AGENTS.md
-
-If `tools/AGENTS.md` not found:
-
-1. **Graceful Degradation**: Use intelligent defaults based on project detection
-2. **Notify User**: Warn that AGENTS.md should be created for consistency
-3. **Suggest Creation**: Recommend running agents-md:create skill first
-
-```text
-WARNING: tools/AGENTS.md not found. Using detected configuration.
-
-For better consistency, create AGENTS.md first:
-  Run: agents-md:create skill or create manually
-```
-
-### No Entry Point Detected
-
-If no server entry point found:
-
-1. **Set UVICORN_ENTRY to empty string**
-2. **Implement up command with clear error**
-3. **Provide guidance in error message**
-
-```bash
-if [ -n "$UVICORN_ENTRY" ]; then
-  # Start server
-else
-  echo "ERROR: No dev server configured. Edit tools/dev.sh:"
-  echo "  1. Set UVICORN_ENTRY to your FastAPI app (e.g., 'src.main:app')"
-  echo "  2. Or set IS_DJANGO=true for Django projects"
-  exit 1
-fi
-```
-
-### Permission Issues
-
-If cannot write or chmod:
-
-1. **Check directory permissions**: `ls -la tools/`
-2. **Suggest fix**: `chmod +w tools/`
-3. **Fall back**: Display content for manual creation
-
-### Emoji Detection
-
-If existing file has emojis:
-
-1. **Remove ALL emojis** during generation
-2. **Notify user** of removal
-3. **Explain**: Token efficiency requirement from AGENTS.md
-
-```text
-NOTE: Removed emojis from output (AGENTS.md token efficiency rule).
-  Before: echo "🚀 Starting..."
-  After:  echo "Starting..."
-```
-
-## Quality Gates
-
-Before completion, ensure ALL:
-
-1. tools/dev.sh created and executable
-2. NO emojis in any output (grep verification)
-3. All commands have error handling
-4. Binary existence checks use `command -v`
-5. Environment variables have defaults
-6. Help text lists only implemented commands
-7. Arguments passed through correctly (${@:2})
-8. Heredoc uses single quotes (prevents expansion)
-9. set -euo pipefail at top (fail fast)
-10. Shebang is #!/usr/bin/env bash
-11. Backup created if file existed
-12. Smoke tests pass (help, invalid command)
-13. Follows AGENTS.md patterns exactly
-14. Line endings are LF
-
-## Linting & Markdown Best Practices
-
-### Separate Linting for Markdown
-
-When projects have markdown files, adopt the following strategy to avoid noise during regular development:
-
-#### Rationale
-- Markdown linting errors can be numerous and frequent
-- Regular CI linting should exclude markdown to avoid blocking developers
-- Markdown checks should be run selectively when actually fixing documentation
-
-#### Implementation Pattern
-
-**Default `lint` command** (excludes markdown):
-```bash
-lint)
-  echo "Running linters excluding markdown..."
-  if command -v tox >/dev/null 2>&1; then
-    tox -e ruff,mypy,shellcheck,shfmt
-  else
-    echo "ERROR: tox not found."
-    exit 1
-  fi
-  ;;
-```
-
-**Separate `mdlint` command** (markdown only):
-```bash
-mdlint)
-  echo "Running markdown linter (tox -e mdlint)..."
-  if command -v tox >/dev/null 2>&1; then
-    tox -e mdlint "${@:2}"
-  else
-    echo "ERROR: tox not found."
-    exit 1
-  fi
-  ;;
-```
-
-#### Usage Examples
-```bash
-# Regular linting (skips markdown)
-./tools/dev.sh lint
-
-# Check markdown when needed
-./tools/dev.sh mdlint
-
-# Format Python code
-./tools/dev.sh format
-```
-
-#### Update Help Text
-List both commands in help:
-```
-Commands:
-  lint         Run linters (ruff, mypy, shellcheck) - excludes markdown
-  mdlint       Run markdown linter separately (tox -e mdlint)
-  format       Format and lint Python code (tox -e ruff)
-```
-
-## Execution Workflow
-
-When this skill is invoked:
-
-1. **Analyze** project (read AGENTS.md, pyproject.toml, scan structure)
-2. **Extract** configuration values (Phase 0-1)
-3. **Generate** tools/dev.sh with proper template (Phase 2)
-4. **Validate** output against all quality gates (Phase 3)
-5. **Report** summary with next steps (Phase 4)
-
-**Output**:
-- Executable tools/dev.sh file
-- Configuration summary
-- Available commands
-- Next steps for usage
-- Compliance confirmation (no emojis, follows AGENTS.md)
-
-## Real-World Example
-
-### Before (Missing dev.sh)
-
-```bash
-$ ls -la tools/
-total 16
-drwxr-xr-x 2 user user 4096 Jan 01 10:00 .
-drwxr-xr-x 8 user user 4096 Jan 01 10:00 ..
--rw-r--r-- 1 user user 4873 Jan 01 10:00 AGENTS.md
-```
-
-### After (Skill Execution)
-
-```bash
-$ ls -la tools/
-total 24
-drwxr-xr-x 2 user user 4096 Jan 01 10:05 .
-drwxr-xr-x 8 user user 4096 Jan 01 10:00 ..
--rw-r--r-- 1 user user 4873 Jan 01 10:00 AGENTS.md
--rwxr-xr-x 1 user user 2077 Jan 01 10:05 dev.sh
-
-$ ./tools/dev.sh help
-Usage: ./tools/dev.sh <command>
-
-Commands:
-  up           Start dev server (uvicorn on :8000)
-  test         Run test suite (pytest)
-  format       Format and lint code (tox -e ruff)
-  shell        Enter project shell
-  cli          Start interactive CLI
-
-$ ./tools/dev.sh up
-Starting dev server...
-INFO:     Uvicorn running on http://0.0.0.0:8000
-```
-
-## Usage Notes
-
-### When to Use This Skill
-
-- New project needs developer workflow automation
-- Existing project missing tools/dev.sh
-- tools/AGENTS.md updated, need to regenerate dev.sh
-- Standardizing workflow across multiple projects
-
-### When NOT to Use This Skill
-
-- Non-Python projects (JavaScript, Rust, Go)
-- Projects with complex multi-service orchestration
-- Projects requiring custom workflow tools
-- When tools/dev.sh has significant custom commands
-
-### Customization After Generation
-
-Users can modify generated file:
-
-- Add custom commands (db, worker, deploy)
-- Adjust default values (ports, paths)
-- Add project-specific env var exports
-- Include additional validation checks
-
-## Command
-
-**When invoked, IMMEDIATELY read tools/AGENTS.md and pyproject.toml, analyze project structure, and EXECUTE the dev.sh generation workflow following all protocols above.**
-
-Start with Phase 0 analysis and announce configuration before writing files. Ensure STRICT compliance with AGENTS.md golden rules, especially NO EMOJIS.
+## Known risks
+
+Templates in `references/templates.md` carry through unchanged from the
+previous SKILL.md revision. Two hardcoded T1 values remain:
+
+- `DEFAULT_DATASET=./data`
+- `CLI_ENTRY=src/backend/cli/app.py`
+
+The generator must override both from `tools/AGENTS.md` (SSOT) when present.
+Flagged for a follow-up issue — do not silently change template defaults in
+this refactor PR.
+
+## References
+
+- `references/help.md` — verbatim usage block printed on `-h`/`--help`/`help`.
+- `references/preflight-and-analysis.md` — Phase 0–1 analysis and config extraction.
+- `references/generation-protocol.md` — Phase 2–4 generation, validation, quality gates, report.
+- `references/templates.md` — T1/T2/T3 templates and selection rubric.
+- `references/options.md` — configuration variable + runtime-override reference table.
+- `references/linting-strategy.md` — `lint` vs `mdlint` rationale and snippets.
+- `references/error-handling.md` — graceful degradation rules and error text.
+- `references/examples.md` — before/after, when to use vs not, customization notes.

--- a/claude/skills/dev-sh-generator/references/error-handling.md
+++ b/claude/skills/dev-sh-generator/references/error-handling.md
@@ -54,8 +54,15 @@ If existing file has emojis:
 2. **Notify user** of removal
 3. **Explain**: Token efficiency requirement from AGENTS.md
 
+예시 — 사용자가 작성한 원본 라인에 U+1F680 (ROCKET) 글리프가 있었다면:
+
 ```text
 NOTE: Removed emojis from output (AGENTS.md token efficiency rule).
-  Before: echo "Starting..."
+  Before: echo "<U+1F680> Starting..."
   After:  echo "Starting..."
 ```
+
+`<U+1F680>` 표기는 원본 글리프를 코드포인트 이름으로 가리키는 것이며,
+스킬 자체 문서는 CLAUDE.md "No emojis anywhere" 룰을 지키기 위해 리터럴
+이모지를 포함하지 않는다. 다른 모든 코드포인트 (U+1F600~U+1FAFF /
+U+2600~U+27BF) 도 동일한 방식으로 검출·제거한다.

--- a/claude/skills/dev-sh-generator/references/error-handling.md
+++ b/claude/skills/dev-sh-generator/references/error-handling.md
@@ -1,0 +1,61 @@
+# Graceful degradation rules + actionable error messages
+
+Every failure path must produce a message that tells the user what to do next.
+Never silently fall back, never overwrite the user's existing `tools/dev.sh`
+without a backup.
+
+## Missing AGENTS.md
+
+If `tools/AGENTS.md` not found:
+
+1. **Graceful Degradation**: Use intelligent defaults based on project detection
+2. **Notify User**: Warn that AGENTS.md should be created for consistency
+3. **Suggest Creation**: Recommend running agents-md:create skill first
+
+```text
+WARNING: tools/AGENTS.md not found. Using detected configuration.
+
+For better consistency, create AGENTS.md first:
+  Run: agents-md:create skill or create manually
+```
+
+## No Entry Point Detected
+
+If no server entry point found:
+
+1. **Set UVICORN_ENTRY to empty string**
+2. **Implement up command with clear error**
+3. **Provide guidance in error message**
+
+```bash
+if [ -n "$UVICORN_ENTRY" ]; then
+  # Start server
+else
+  echo "ERROR: No dev server configured. Edit tools/dev.sh:"
+  echo "  1. Set UVICORN_ENTRY to your FastAPI app (e.g., 'src.main:app')"
+  echo "  2. Or set IS_DJANGO=true for Django projects"
+  exit 1
+fi
+```
+
+## Permission Issues
+
+If cannot write or chmod:
+
+1. **Check directory permissions**: `ls -la tools/`
+2. **Suggest fix**: `chmod +w tools/`
+3. **Fall back**: Display content for manual creation
+
+## Emoji Detection
+
+If existing file has emojis:
+
+1. **Remove ALL emojis** during generation
+2. **Notify user** of removal
+3. **Explain**: Token efficiency requirement from AGENTS.md
+
+```text
+NOTE: Removed emojis from output (AGENTS.md token efficiency rule).
+  Before: echo "Starting..."
+  After:  echo "Starting..."
+```

--- a/claude/skills/dev-sh-generator/references/examples.md
+++ b/claude/skills/dev-sh-generator/references/examples.md
@@ -1,0 +1,63 @@
+# Before/after example + scope boundaries
+
+## Real-World Example
+
+### Before (Missing dev.sh)
+
+```bash
+$ ls -la tools/
+total 16
+drwxr-xr-x 2 user user 4096 Jan 01 10:00 .
+drwxr-xr-x 8 user user 4096 Jan 01 10:00 ..
+-rw-r--r-- 1 user user 4873 Jan 01 10:00 AGENTS.md
+```
+
+### After (Skill Execution)
+
+```bash
+$ ls -la tools/
+total 24
+drwxr-xr-x 2 user user 4096 Jan 01 10:05 .
+drwxr-xr-x 8 user user 4096 Jan 01 10:00 ..
+-rw-r--r-- 1 user user 4873 Jan 01 10:00 AGENTS.md
+-rwxr-xr-x 1 user user 2077 Jan 01 10:05 dev.sh
+
+$ ./tools/dev.sh help
+Usage: ./tools/dev.sh <command>
+
+Commands:
+  up           Start dev server (uvicorn on :8000)
+  test         Run test suite (pytest)
+  format       Format and lint code (tox -e ruff)
+  shell        Enter project shell
+  cli          Start interactive CLI
+
+$ ./tools/dev.sh up
+Starting dev server...
+INFO:     Uvicorn running on http://0.0.0.0:8000
+```
+
+## Usage Notes
+
+### When to Use This Skill
+
+- New project needs developer workflow automation
+- Existing project missing tools/dev.sh
+- tools/AGENTS.md updated, need to regenerate dev.sh
+- Standardizing workflow across multiple projects
+
+### When NOT to Use This Skill
+
+- Non-Python projects (JavaScript, Rust, Go)
+- Projects with complex multi-service orchestration
+- Projects requiring custom workflow tools
+- When tools/dev.sh has significant custom commands
+
+### Customization After Generation
+
+Users can modify generated file:
+
+- Add custom commands (db, worker, deploy)
+- Adjust default values (ports, paths)
+- Add project-specific env var exports
+- Include additional validation checks

--- a/claude/skills/dev-sh-generator/references/generation-protocol.md
+++ b/claude/skills/dev-sh-generator/references/generation-protocol.md
@@ -1,0 +1,219 @@
+# Phase 2–4: Generate tools/dev.sh, validate against quality gates, emit verdict report
+
+## Phase 2: Generate tools/dev.sh (SEQUENTIAL)
+
+1. **Create Backup** (if existing file)
+
+   ```bash
+   if [ -f tools/dev.sh ]; then
+     cp tools/dev.sh "tools/dev.sh.backup.$(date +%Y%m%d_%H%M%S)"
+   fi
+   ```
+
+2. **Write tools/dev.sh**
+
+   Use template structure (pick T1/T2/T3 from `references/templates.md`):
+
+   ```bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+
+   # Configuration (extracted from project)
+   PY_RUN="..."
+   PY_TEST="..."
+   UVICORN_ENTRY="..."
+   USE_ALEMBIC=false
+   IS_DJANGO=false
+   MANAGE_PY="manage.py"
+   DEFAULT_DATASET="./data"
+   CLI_ENTRY="..."
+
+   cmd="${1:-help}"
+
+   case "$cmd" in
+     up)
+       # Server startup logic
+       ;;
+     test)
+       # Test execution logic
+       ;;
+     fmt|format)
+       # Format/lint logic
+       ;;
+     shell)
+       # Shell entry logic
+       ;;
+     cli)
+       # CLI launch logic (only if CLI_ENTRY exists)
+       ;;
+     *)
+       # Help text
+       ;;
+   esac
+   ```
+
+3. **Command Implementation Rules**
+
+   **up command**:
+   - NO emojis in echo statements (violates AGENTS.md token efficiency)
+   - Check IS_DJANGO first, then USE_ALEMBIC
+   - Export APP_ENV and DATASET before uvicorn
+   - Use --reload for development
+   - Bind to 0.0.0.0:8000 for Docker compatibility
+   - Exit 1 with clear message if no entry point
+
+   **test command**:
+   - Pass through additional arguments: `$PY_TEST "${@:2}"`
+   - Keep output quiet by default (-q flag)
+   - NO emoji in echo
+
+   **fmt/format command**:
+   - Check for tox first: `command -v tox`
+   - Use `tox -e ruff` as default
+   - Provide install instructions if missing
+   - NO emoji in echo
+
+   **lint command**:
+   - Run linters excluding markdown: `tox -e ruff,mypy,shellcheck,shfmt`
+   - Covers: ruff (Python format/lint), mypy (type check), shellcheck (bash), shfmt (bash format)
+   - Markdown linting available separately via `mdlint` command
+   - Rationale: Markdown errors can be numerous; separate for selective use
+   - NO emoji in echo
+
+   **mdlint command** (optional, separate):
+   - Only include if project has markdown files
+   - Run markdown linter: `tox -e mdlint "${@:2}"`
+   - Allows users to run markdown checks on-demand
+   - NO emoji in echo
+
+   **shell command**:
+   - Check for uv: `command -v uv`
+   - Use `exec` to replace shell process
+   - Fall back with clear error
+   - NO emoji in echo
+
+   **cli command**:
+   - Only include if CLI_ENTRY is non-empty
+   - Pass through all arguments: `"${@:2}"`
+   - Use $PY_RUN to execute
+   - NO emoji in echo
+
+   **help (default)**:
+   - Use heredoc for clean formatting
+   - List only implemented commands
+   - Provide examples with env var overrides
+   - NO emojis (strict compliance with AGENTS.md)
+   - Keep ASCII-only for maximum compatibility
+
+4. **Set Permissions**
+
+   ```bash
+   chmod +x tools/dev.sh
+   ```
+
+## Phase 3: Validation (ALWAYS)
+
+Verify ALL:
+
+- [ ] tools/dev.sh created successfully
+- [ ] File is executable (chmod +x applied)
+- [ ] NO emojis in any echo or cat statements
+- [ ] All variables have default values
+- [ ] Error handling checks for missing binaries
+- [ ] Heredoc properly formatted (no tabs before HELP)
+- [ ] Case statement has default/help handler
+- [ ] Commands match AGENTS.md specification
+- [ ] Backup created if file existed
+- [ ] Line endings are LF (not CRLF)
+
+**Linting**:
+
+```bash
+# Shell syntax check
+bash -n tools/dev.sh
+
+# Shellcheck (if available)
+shellcheck tools/dev.sh 2>/dev/null || echo "shellcheck not available"
+
+# Check for emojis (MUST be zero)
+grep -P '[\x{1F300}-\x{1F9FF}]' tools/dev.sh && echo "FAIL: Emojis found" || echo "PASS: No emojis"
+```
+
+**Smoke Tests**:
+
+```bash
+# Help command works
+./tools/dev.sh help
+
+# Test command handles args
+./tools/dev.sh test --help
+
+# Invalid command shows help
+./tools/dev.sh invalid 2>&1 | grep -q "Usage:"
+```
+
+## Quality Gates
+
+Before completion, ensure ALL:
+
+1. tools/dev.sh created and executable
+2. NO emojis in any output (grep verification)
+3. All commands have error handling
+4. Binary existence checks use `command -v`
+5. Environment variables have defaults
+6. Help text lists only implemented commands
+7. Arguments passed through correctly (${@:2})
+8. Heredoc uses single quotes (prevents expansion)
+9. set -euo pipefail at top (fail fast)
+10. Shebang is #!/usr/bin/env bash
+11. Backup created if file existed
+12. Smoke tests pass (help, invalid command)
+13. Follows AGENTS.md patterns exactly
+14. Line endings are LF
+
+## Phase 4: Report (ALWAYS)
+
+Provide summary:
+
+1. **File Status**
+   - Created: tools/dev.sh (executable)
+   - Backup: tools/dev.sh.backup.TIMESTAMP (if applicable)
+
+2. **Configuration Applied**
+
+   ```
+   PY_RUN: uv run
+   PY_TEST: uv run pytest -q
+   UVICORN_ENTRY: src.backend.main:app
+   USE_ALEMBIC: false
+   CLI_ENTRY: src/backend/cli/app.py
+   ```
+
+3. **Available Commands**
+   - up: Start development server
+   - test: Run test suite
+   - format: Format and lint code
+   - shell: Enter project shell
+   - cli: Launch interactive CLI (if applicable)
+
+4. **Next Steps**
+
+   ```bash
+   # Test the script
+   ./tools/dev.sh help
+
+   # Start development
+   ./tools/dev.sh up
+
+   # Run tests
+   ./tools/dev.sh test
+
+   # Format code
+   ./tools/dev.sh format
+   ```
+
+5. **Compliance Check**
+   - [ ] No emojis (token efficiency)
+   - [ ] Follows AGENTS.md patterns
+   - [ ] All commands idempotent
+   - [ ] Error messages actionable

--- a/claude/skills/dev-sh-generator/references/help.md
+++ b/claude/skills/dev-sh-generator/references/help.md
@@ -1,0 +1,63 @@
+# dev-sh-generator — Help
+
+## Synopsis
+
+```
+dev-sh-generator
+```
+
+Generate or regenerate a project-specific `tools/dev.sh` task runner that
+follows the patterns defined in `tools/AGENTS.md` (the SSOT for this skill).
+
+## Description
+
+Analyzes the current Python/FastAPI/Django project, extracts the configuration
+required to drive a `tools/dev.sh` task runner, picks the matching template,
+and writes an executable `tools/dev.sh` to the repo. The generator is strict
+about the AGENTS.md golden rules — in particular, NO EMOJIS anywhere in the
+generated script.
+
+## Options / Configuration variables
+
+See `references/options.md` for the full env-var and configuration-variable
+reference table (`PY_RUN`, `PY_TEST`, `UVICORN_ENTRY`, `USE_ALEMBIC`,
+`IS_DJANGO`, `MANAGE_PY`, `DEFAULT_DATASET`, `CLI_ENTRY`, plus runtime
+overrides `APP_ENV`, `DATASET`, `DJANGO_SETTINGS_MODULE`).
+
+## Workflow
+
+1. Analyze project — read `tools/AGENTS.md`, `pyproject.toml`, scan structure.
+   See `references/preflight-and-analysis.md`.
+2. Generate `tools/dev.sh` using the matching template (T1/T2/T3).
+   See `references/generation-protocol.md` and `references/templates.md`.
+3. Validate against quality gates (no emojis, executable, syntax-clean).
+   See `references/generation-protocol.md`.
+4. Report verdict with template choice + applied configuration.
+
+Stops on first failure — any phase failure halts the chain.
+
+## Examples
+
+```bash
+# Run inside a project root that has tools/AGENTS.md
+./tools/dev.sh help            # exercise the generated script after run
+./tools/dev.sh up              # start dev server
+./tools/dev.sh test -k api     # forward args to pytest
+DATASET=/data ./tools/dev.sh up
+```
+
+## Stop conditions
+
+- Missing `tools/AGENTS.md` → warn, fall back to detected defaults.
+  See `references/error-handling.md`.
+- No detectable server entry point → write `up` with an actionable error.
+- Permission issues on `tools/` → display content for manual creation.
+- Emojis present in any pre-existing file → strip and notify user.
+
+## See also
+
+- `references/options.md` — configuration variable reference
+- `references/templates.md` — T1 (FastAPI+uv), T2 (Django+poetry), T3 (FastAPI+alembic)
+- `references/linting-strategy.md` — why `lint` is split from `mdlint`
+- `references/examples.md` — before/after, scope boundaries
+- `tools/AGENTS.md` — SSOT for the generated commands and conventions

--- a/claude/skills/dev-sh-generator/references/linting-strategy.md
+++ b/claude/skills/dev-sh-generator/references/linting-strategy.md
@@ -1,0 +1,65 @@
+# Why markdown linting is split from default lint
+
+## Separate Linting for Markdown
+
+When projects have markdown files, adopt the following strategy to avoid noise during regular development:
+
+### Rationale
+
+- Markdown linting errors can be numerous and frequent
+- Regular CI linting should exclude markdown to avoid blocking developers
+- Markdown checks should be run selectively when actually fixing documentation
+
+### Implementation Pattern
+
+**Default `lint` command** (excludes markdown):
+
+```bash
+lint)
+  echo "Running linters excluding markdown..."
+  if command -v tox >/dev/null 2>&1; then
+    tox -e ruff,mypy,shellcheck,shfmt
+  else
+    echo "ERROR: tox not found."
+    exit 1
+  fi
+  ;;
+```
+
+**Separate `mdlint` command** (markdown only):
+
+```bash
+mdlint)
+  echo "Running markdown linter (tox -e mdlint)..."
+  if command -v tox >/dev/null 2>&1; then
+    tox -e mdlint "${@:2}"
+  else
+    echo "ERROR: tox not found."
+    exit 1
+  fi
+  ;;
+```
+
+### Usage Examples
+
+```bash
+# Regular linting (skips markdown)
+./tools/dev.sh lint
+
+# Check markdown when needed
+./tools/dev.sh mdlint
+
+# Format Python code
+./tools/dev.sh format
+```
+
+### Update Help Text
+
+List both commands in help:
+
+```
+Commands:
+  lint         Run linters (ruff, mypy, shellcheck) - excludes markdown
+  mdlint       Run markdown linter separately (tox -e mdlint)
+  format       Format and lint Python code (tox -e ruff)
+```

--- a/claude/skills/dev-sh-generator/references/options.md
+++ b/claude/skills/dev-sh-generator/references/options.md
@@ -1,0 +1,33 @@
+# Configuration variable reference table
+
+These variables drive template generation. `tools/AGENTS.md` is the SSOT —
+values declared there override any heuristic detection. Phase 0–1
+(`references/preflight-and-analysis.md`) builds this map; Phase 2
+(`references/generation-protocol.md`) writes the values into `tools/dev.sh`.
+
+## Generator-side variables (baked into tools/dev.sh)
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `PY_RUN` | Python execution command driving every subcommand. | `uv run` if `uv.lock`; `poetry run` if `poetry.lock`; else `python` |
+| `PY_TEST` | Full test invocation, including `-q`. Receives forwarded args via `"${@:2}"`. | `$PY_RUN pytest -q` |
+| `UVICORN_ENTRY` | FastAPI/Uvicorn import path, e.g. `src.backend.main:app`. Empty disables the `up` server path. | `""` (forces actionable error if empty) |
+| `USE_ALEMBIC` | When `true`, `up` runs `alembic upgrade head` before uvicorn. | `false` |
+| `IS_DJANGO` | When `true`, `up` runs `manage.py migrate` + `manage.py runserver`. | `false` |
+| `MANAGE_PY` | Path to Django `manage.py`. Only used when `IS_DJANGO=true`. | `manage.py` |
+| `DEFAULT_DATASET` | Default dataset path exported as `DATASET` for the FastAPI `up` path. | `./data` (T1 hardcoded — see SKILL.md Known risks) |
+| `CLI_ENTRY` | Path to interactive CLI script. Empty omits the `cli` subcommand entirely. | `src/backend/cli/app.py` for T1, `""` for T2/T3 |
+
+## Runtime overrides (set by the user when invoking tools/dev.sh)
+
+| Override | Description | Default |
+| --- | --- | --- |
+| `APP_ENV` | Selects FastAPI runtime profile. Exported only by the `up` path. | `development` |
+| `DATASET` | Overrides `DEFAULT_DATASET` for a single `up` invocation. | value of `DEFAULT_DATASET` |
+| `DJANGO_SETTINGS_MODULE` | Selects Django settings module for `up`. Exported only when `IS_DJANGO=true`. | `config.settings.dev` |
+
+## Forwarding rule
+
+The generator must emit `"${@:2}"` (not `$@`) for `test`, `cli`, and `mdlint`
+so that the leading subcommand is stripped before forwarding. See
+`references/generation-protocol.md` → "Command Implementation Rules".

--- a/claude/skills/dev-sh-generator/references/preflight-and-analysis.md
+++ b/claude/skills/dev-sh-generator/references/preflight-and-analysis.md
@@ -1,0 +1,96 @@
+# Phase 0–1: Detect project type, extract config from AGENTS.md + pyproject.toml
+
+This file covers the read-only analysis stage. No files are written here.
+`tools/AGENTS.md` is the SSOT — any value present there wins over detection
+heuristics.
+
+## Phase 0: Analysis (ALWAYS)
+
+Execute BEFORE generating file:
+
+1. **Read tools/AGENTS.md**
+
+   ```bash
+   # Verify AGENTS.md exists
+   test -f tools/AGENTS.md && echo "Found" || echo "Missing"
+   ```
+
+   Extract from AGENTS.md:
+   - Python runner preference (PY_RUN)
+   - Test runner configuration (PY_TEST)
+   - Server entry point (UVICORN_ENTRY)
+   - Migration strategy (USE_ALEMBIC, IS_DJANGO)
+   - CLI entry path
+   - Format/lint commands
+
+2. **Scan Project Structure**
+
+   ```bash
+   # Check dependency management
+   ls -la pyproject.toml uv.lock poetry.lock requirements.txt 2>/dev/null
+
+   # Find entry points
+   find src -name "main.py" -o -name "app.py" 2>/dev/null
+
+   # Check for CLI
+   find src -path "*/cli/*.py" 2>/dev/null
+   ```
+
+3. **Read pyproject.toml**
+
+   Extract:
+   - Project name
+   - Python version requirements
+   - Dependencies (fastapi, django, uvicorn)
+   - Dev dependencies (pytest, tox, ruff)
+   - Package structure (src layout)
+
+4. **Check Existing tools/dev.sh**
+
+   If exists:
+   - Create timestamped backup
+   - Note custom commands to preserve
+   - Identify deviations from standard
+
+Output: Configuration map with all detected values.
+
+## Phase 1: Configuration Extraction (ALWAYS)
+
+Build configuration from analysis. Priority order is strict — `tools/AGENTS.md`
+always wins.
+
+```bash
+# Python Runner Priority:
+# 1. AGENTS.md specification
+# 2. Detected lock file (uv.lock -> "uv run", poetry.lock -> "poetry run")
+# 3. Default to "python"
+
+# Test Runner Priority:
+# 1. AGENTS.md specification
+# 2. pyproject.toml [tool.pytest] configuration
+# 3. Default to "$PY_RUN pytest -q"
+
+# Server Entry Priority:
+# 1. AGENTS.md specification
+# 2. Search for FastAPI app instance in src/
+# 3. Search for Django settings
+# 4. Leave empty if not found
+
+# CLI Entry Priority:
+# 1. AGENTS.md specification
+# 2. Search for src/*/cli/*.py files
+# 3. Omit cli command if not found
+```
+
+Required Variables (passed downstream to Phase 2):
+
+- `PY_RUN`: Python execution command
+- `PY_TEST`: Test execution command
+- `UVICORN_ENTRY`: FastAPI/Uvicorn entry point (empty string if none)
+- `USE_ALEMBIC`: Boolean for Alembic migrations
+- `IS_DJANGO`: Boolean for Django projects
+- `MANAGE_PY`: Django manage.py path
+- `DEFAULT_DATASET`: Default data directory path
+- `CLI_ENTRY`: CLI script path (empty string if none)
+
+See `references/options.md` for the human-facing description of each variable.

--- a/claude/skills/dev-sh-generator/references/templates.md
+++ b/claude/skills/dev-sh-generator/references/templates.md
@@ -1,0 +1,231 @@
+# Reference templates by stack. Selection: uv.lock → T1, Django → T2, alembic.ini → T3
+
+> Note: Template T1 hardcodes `DEFAULT_DATASET=./data` and
+> `CLI_ENTRY=src/backend/cli/app.py` — see "Known risks" in `SKILL.md`. The
+> generator must override these from `tools/AGENTS.md` when present.
+
+## Selection rubric
+
+| Detect | Pick |
+| --- | --- |
+| `uv.lock` present + FastAPI + no alembic | T1 |
+| Django (`manage.py` or `IS_DJANGO=true` in AGENTS.md) | T2 |
+| `alembic.ini` present (with or without `uv.lock`) | T3 |
+
+If multiple match, AGENTS.md wins. If nothing matches, fall back to T1 with
+empty `UVICORN_ENTRY` and let the `up` command emit an actionable error
+(see `references/error-handling.md`).
+
+## Template 1: FastAPI with uv
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PY_RUN="uv run"
+PY_TEST="uv run pytest -q"
+UVICORN_ENTRY="src.backend.main:app"
+USE_ALEMBIC=false
+IS_DJANGO=false
+MANAGE_PY="manage.py"
+DEFAULT_DATASET="./data"
+CLI_ENTRY="src/backend/cli/app.py"
+
+cmd="${1:-help}"
+
+case "$cmd" in
+  up)
+    echo "Starting dev server..."
+    if [ -n "$UVICORN_ENTRY" ]; then
+      APP_ENV=${APP_ENV:-development} DATASET=${DATASET:-"$DEFAULT_DATASET"} \
+      $PY_RUN uvicorn "$UVICORN_ENTRY" --reload --host 0.0.0.0 --port 8000
+    else
+      echo "ERROR: No dev server configured. Edit tools/dev.sh to add entry point."
+      exit 1
+    fi
+    ;;
+
+  test)
+    echo "Running tests..."
+    $PY_TEST "${@:2}"
+    ;;
+
+  fmt|format)
+    echo "Formatting code (tox -e ruff)..."
+    if command -v tox >/dev/null 2>&1; then
+      tox -e ruff
+    else
+      echo "ERROR: tox not found. Install: uv pip install tox"
+      exit 1
+    fi
+    ;;
+
+  shell)
+    echo "Entering project shell..."
+    if command -v uv >/dev/null 2>&1; then
+      exec uv run bash
+    else
+      echo "ERROR: uv not found. Activate virtualenv manually."
+      exit 1
+    fi
+    ;;
+
+  cli)
+    echo "Starting interactive CLI..."
+    $PY_RUN python "$CLI_ENTRY" "${@:2}"
+    ;;
+
+  *)
+    cat <<'HELP'
+Usage: ./tools/dev.sh <command>
+
+Commands:
+  up           Start dev server (uvicorn on :8000)
+  test         Run test suite (pytest)
+  format       Format and lint code (tox -e ruff)
+  shell        Enter project shell
+  cli          Start interactive CLI
+
+Examples:
+  ./tools/dev.sh up
+  ./tools/dev.sh test -k test_api
+  DATASET=/custom/path ./tools/dev.sh up
+  APP_ENV=production ./tools/dev.sh up
+
+HELP
+    ;;
+esac
+```
+
+## Template 2: Django with Poetry
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PY_RUN="poetry run"
+PY_TEST="poetry run pytest -q"
+UVICORN_ENTRY=""
+USE_ALEMBIC=false
+IS_DJANGO=true
+MANAGE_PY="manage.py"
+DEFAULT_DATASET="./data"
+CLI_ENTRY=""
+
+cmd="${1:-help}"
+
+case "$cmd" in
+  up)
+    echo "Starting Django dev server..."
+    export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-"config.settings.dev"}
+    $PY_RUN python "$MANAGE_PY" migrate
+    $PY_RUN python "$MANAGE_PY" runserver 0.0.0.0:8000
+    ;;
+
+  test)
+    echo "Running tests..."
+    $PY_TEST "${@:2}"
+    ;;
+
+  fmt|format)
+    echo "Formatting code (black)..."
+    if command -v poetry >/dev/null 2>&1; then
+      poetry run black .
+    else
+      echo "ERROR: poetry not found. Install: pip install poetry"
+      exit 1
+    fi
+    ;;
+
+  shell)
+    echo "Entering Django shell..."
+    $PY_RUN python "$MANAGE_PY" shell
+    ;;
+
+  *)
+    cat <<'HELP'
+Usage: ./tools/dev.sh <command>
+
+Commands:
+  up           Start Django dev server (migrations + runserver)
+  test         Run test suite (pytest)
+  format       Format code (black)
+  shell        Enter Django shell
+
+Examples:
+  ./tools/dev.sh up
+  DJANGO_SETTINGS_MODULE=config.settings.prod ./tools/dev.sh up
+
+HELP
+    ;;
+esac
+```
+
+## Template 3: FastAPI with Alembic
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PY_RUN="uv run"
+PY_TEST="uv run pytest -q"
+UVICORN_ENTRY="src.main:app"
+USE_ALEMBIC=true
+IS_DJANGO=false
+MANAGE_PY="manage.py"
+DEFAULT_DATASET="./data"
+CLI_ENTRY=""
+
+cmd="${1:-help}"
+
+case "$cmd" in
+  up)
+    echo "Starting dev server..."
+    if $USE_ALEMBIC; then
+      echo "Running Alembic migrations..."
+      $PY_RUN alembic upgrade head
+    fi
+    if [ -n "$UVICORN_ENTRY" ]; then
+      APP_ENV=${APP_ENV:-development} \
+      $PY_RUN uvicorn "$UVICORN_ENTRY" --reload --host 0.0.0.0 --port 8000
+    else
+      echo "ERROR: No dev server configured."
+      exit 1
+    fi
+    ;;
+
+  test)
+    echo "Running tests..."
+    $PY_TEST "${@:2}"
+    ;;
+
+  fmt|format)
+    echo "Formatting code (ruff)..."
+    if command -v ruff >/dev/null 2>&1; then
+      ruff format .
+      ruff check . --fix
+    else
+      echo "ERROR: ruff not found. Install: uv pip install ruff"
+      exit 1
+    fi
+    ;;
+
+  shell)
+    echo "Entering project shell..."
+    exec uv run bash
+    ;;
+
+  *)
+    cat <<'HELP'
+Usage: ./tools/dev.sh <command>
+
+Commands:
+  up           Start dev server (alembic + uvicorn)
+  test         Run test suite (pytest)
+  format       Format and lint code (ruff)
+  shell        Enter project shell
+
+HELP
+    ;;
+esac
+```


### PR DESCRIPTION
## Summary

`dev-sh-generator` SKILL.md **764 → 98 줄** (Check 1 FAIL→PASS).

- 8 \`references/\` 파일로 분리 (~931 줄 분산)
- Help flag, Options 포인터, stop-on-failure, \`[OK]\`/\`[FAIL]\` verdict, Known Risks 추가

## Why

\`/skill:check\` 자동 감사(#427)에서 detected: POOR (2/10 PASS, 1 WARN, 7 FAIL).
- 764 lines (FAIL threshold 5배)
- references/ 부재
- help/options/verdict 부재
- Phase 명명 (Step 미사용), stop-on-error 미정의
- T1 템플릿 하드코딩 (\`DEFAULT_DATASET=./data\`, \`CLI_ENTRY=src/backend/cli/app.py\`)

## Files

| File | Lines | Role |
|------|------:|------|
| \`SKILL.md\` | 98 | 워크플로 phases + UX |
| \`references/help.md\` | 63 | verbatim 사용법 |
| \`references/preflight-and-analysis.md\` | 96 | Phase 0–1 |
| \`references/generation-protocol.md\` | 219 | Phase 2–4 |
| \`references/templates.md\` | 231 | T1/T2/T3 + 선택 rubric |
| \`references/options.md\` | 33 | env vars 표 |
| \`references/linting-strategy.md\` | 65 | lint vs mdlint 분리 |
| \`references/error-handling.md\` | 61 | 실패 분기 |
| \`references/examples.md\` | 63 | before/after |

## SKILL.md 새 섹션

- \`## Help\` — 헬프 인자 분기
- \`## Options\` — \`references/options.md\` 포인터 (테이블은 references)
- \`## Workflow (stop on first failure ...)\` — Phase 1–4 한 줄씩 references 인용
- \`## Output\` — \`[OK]/[FAIL]\` verdict + Next hint
- \`## Known risks\` — T1 하드코딩 값 명시적으로 플래그 (이 PR 무수정, follow-up 권장)

## Follow-up

- [ ] T1 템플릿 \`DEFAULT_DATASET=./data\` + \`CLI_ENTRY=src/backend/cli/app.py\` 매개변수화 (별도 이슈)
- [ ] \`/skill-check claude/skills/dev-sh-generator/SKILL.md\` 재실행 — POOR→GOOD/EXCELLENT 기대

## Test plan

- [x] \`wc -l SKILL.md\` 98 줄
- [x] Frontmatter (allowed-tools 포함) 보존
- [x] 한국어 trigger phrase 유지
- [x] \`tools/AGENTS.md\` SSOT 멘션 보존 (SKILL.md + 3개 ref 파일)
- [x] pre-commit 통과

Closes #461
🤖 Generated with [Claude Code](https://claude.com/claude-code)