### PR TITLE
refactor(skill:project-setup): references/ + dedup SSOT (#487)

### DIFF
--- a/claude/skills/project-setup/SKILL.md
+++ b/claude/skills/project-setup/SKILL.md
@@ -7,19 +7,19 @@ description: >-
 allowed-tools: Write, Bash, Read, Glob
 ---
 
-# Project Setup Skill
+# project-setup
 
-## Role
+## Help
 
-You are a Python Project Configuration Specialist. Initialize Python projects with standardized, production-ready configuration files for linting, testing, and formatting.
+If args is `-h` / `--help` / `help`, read `references/help.md` verbatim and stop.
 
-## Purpose
+## Role & Purpose
 
-Automate the creation of essential Python project configuration files, ensuring consistency across projects and reducing manual setup time. Provide a standardized development environment with best practices for code quality, testing, and documentation.
+Python project configuration specialist. Generates the three standard
+config files (`.markdownlint.json`, `tox.ini`, `pyproject.toml`) with
+project-specific placeholders resolved from git config and the directory name.
 
 ## Trigger Scenarios
-
-Use this skill when users request:
 
 - "Initialize Python project configuration"
 - "Set up a new Python project"
@@ -28,510 +28,54 @@ Use this skill when users request:
 - "Python 프로젝트 환경 구축해"
 - "tox.ini, pyproject.toml 생성해줘"
 
-## Configuration Files Generated
+## Options
 
-This skill creates three critical configuration files:
+See `references/options.md` for the full flag table — `PROJECT_NAME`
+override, `--force`, `--dry-run`, `-h`/`--help`/`help`.
 
-1. **.markdownlint.json** - Markdown linting rules
-2. **tox.ini** - Test automation and quality checks (ruff, mypy, shellcheck, shfmt, mdlint)
-3. **pyproject.toml** - Project metadata, dependencies, and tool configuration
+## Workflow (stop on first failure — any Step failure halts the chain)
 
-## Implementation Protocol
+1. **Step 1 Discover** — read repo state, detect existing configs, extract
+   git author info. See `references/phases-detail.md` → Step 1.
+2. **Step 2 Plan** — propose which templates apply, what gets backed up,
+   placeholder values. If `--dry-run`, stop here. See `phases-detail.md` → Step 2.
+3. **Step 3 Backup** — copy existing files to `.bak.<timestamp>`.
+   See `phases-detail.md` → Step 3.
+4. **Step 4 Apply Templates** — write the three templates with placeholders
+   resolved. Templates live in `references/templates.md` (single SSOT —
+   no duplication).
+5. **Step 5 Validate** — verify JSON / INI / TOML parses and no `{{...}}`
+   placeholders remain. See `phases-detail.md` → Step 5.
+6. **Step 6 Report** — emit verdict + next-action hint.
 
-### Phase 0: Analysis (ALWAYS)
+Error / degradation branches: see `references/error-handling.md`.
 
-Execute BEFORE creating any files:
+## Output
 
-1. **Verify Current Directory**
+Success:
 
-   ```bash
-   # Check current location
-   pwd
+```
+[OK] project-setup — <n> files created, <m> backed up
+  files:
+    .markdownlint.json
+    tox.ini
+    pyproject.toml
+  validation: <n> linters passed
 
-   # List existing files
-   ls -la
-   ```
-
-2. **Check Existing Configuration**
-
-   - Scan for existing `.markdownlint.json`, `tox.ini`, `pyproject.toml`
-   - Identify conflicts and backup needs
-   - Determine project name from directory
-
-3. **Extract Git Configuration**
-
-   ```bash
-   # Get author information
-   git config user.name
-   git config user.email
-   ```
-
-4. **Plan File Creation**
-
-   - List files to be created
-   - Identify placeholders to replace
-   - Determine backup strategy for existing files
-
-Output: Project context, git config values, file creation plan
-
-### Phase 1: Backup Existing Files (CONDITIONAL)
-
-Execute ONLY if files already exist:
-
-1. **Backup Strategy**
-
-   ```bash
-   # Backup existing files with timestamp
-   cp .markdownlint.json .markdownlint.json.backup.$(date +%Y%m%d_%H%M%S)
-   cp tox.ini tox.ini.backup.$(date +%Y%m%d_%H%M%S)
-   cp pyproject.toml pyproject.toml.backup.$(date +%Y%m%d_%H%M%S)
-   ```
-
-2. **Inform User**
-
-   - Notify about backups created
-   - List backup file locations
-
-### Phase 2: Generate Configuration Files (SEQUENTIAL)
-
-Execute in order:
-
-1. **Create .markdownlint.json**
-
-   ```json
-   {
-     "default": true,
-     "MD013": false,
-     "MD033": false
-   }
-   ```
-
-2. **Create tox.ini**
-
-   Standard template with environments:
-   - ruff: Code formatting and linting
-   - mypy: Type checking
-   - mdlint: Markdown linting
-   - shellcheck: Shell script checking
-   - shfmt: Shell script formatting
-   - py310, py311, py312, py313: Multi-version testing
-
-3. **Create pyproject.toml**
-
-   Replace dynamic placeholders:
-   - `{{PROJECT_NAME}}`: Directory name or user-provided name
-   - `{{AUTHOR_NAME}}`: From `git config user.name` or "Your Name"
-   - `{{AUTHOR_EMAIL}}`: From `git config user.email` or "your.email@example.com"
-
-### Phase 3: Validation (ALWAYS)
-
-Verify ALL:
-
-- [ ] .markdownlint.json created and valid JSON
-- [ ] tox.ini created with all required environments
-- [ ] pyproject.toml created with correct placeholder replacements
-- [ ] All files have proper permissions (readable)
-- [ ] Project name matches directory or user input
-- [ ] Git config values correctly extracted and applied
-
-### Phase 4: Report (ALWAYS)
-
-Provide summary:
-
-1. **Files Created**
-
-   - List all created files with paths
-   - Show placeholder values used
-
-2. **Next Steps**
-
-   ```bash
-   # Install dependencies
-   pip install -e .[dev]
-
-   # Run quality checks
-   tox -e ruff
-   tox -e mypy
-   tox -e mdlint
-   ```
-
-3. **Configuration Details**
-
-   - Project name detected
-   - Author information applied
-   - Available tox environments
-
-## Configuration Templates
-
-### Template 1: .markdownlint.json
-
-```json
-{
-  "default": true,
-  "MD013": false,
-  "MD033": false
-}
+Next: tox -e ruff && tox -e mypy
 ```
 
-**Purpose**: Markdown linting configuration
+Failure:
 
-- `default: true`: Enable all rules by default
-- `MD013: false`: Disable line length limit
-- `MD033: false`: Allow inline HTML
-
-### Template 2: tox.ini
-
-```ini
-[tox]
-envlist = ruff, mypy, mdlint, shellcheck, shfmt
-skipsdist = true
-skip_missing_interpreters = true
-
-[testenv]
-usedevelop = false
-deps = .[dev]
-setenv =
-    target_dir = .
-passenv = PATH
-allowlist_externals =
-    pylint
-    mypy
-    markdownlint
-    pylint-exit
-    pytest
-    shellcheck
-    shfmt
-
-[testenv:lint]
-description = Run pylint to check code style and quality
-deps =
-    .[dev]
-commands =
-    pylint {env:target_dir}
-    ruff check {env:target_dir}
-
-[testenv:ruff]
-allowlist_externals = ruff
-description = Run ruff to format code and apply auto-fixes
-deps = .[dev]
-commands =
-    ruff format {env:target_dir}
-    ruff check {env:target_dir} --fix
-
-[testenv:black]
-description = Run black code formatter
-deps =
-    black
-    black[jupyter]
-commands = black {env:target_dir}
-
-[testenv:mypy]
-description = Run mypy type checker
-deps = .[dev]
-commands = mypy {env:target_dir}
-
-[testenv:mdlint]
-description = Run markdownlint to check markdown files
-skip_install = true
-allowlist_externals = markdownlint
-commands = markdownlint {env:target_dir}/**/*.md
-
-[testenv:shellcheck]
-description = Run shellcheck on bash scripts
-skip_install = true
-allowlist_externals =
-    bash
-    find
-    shellcheck
-    xargs
-commands = bash -c 'find bash -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck -x -e SC1090,SC1091'
-
-[testenv:shfmt]
-description = Check shell script formatting with shfmt
-skip_install = true
-deps =
-commands =
-    shfmt -w -i 4 bash/
-
-[testenv:shfmt-check]
-description = Check shell script formatting with shfmt
-skip_install = true
-deps =
-commands =
-    shfmt -d -i 4 bash/
-
-[testenv:py310]
-basepython = python3.10
-commands = pytest
-
-[testenv:py311]
-basepython = python3.11
-commands = pytest
-
-[testenv:py312]
-basepython = python3.12
-commands = pytest
-
-[testenv:py313]
-basepython = python3.13
-commands = pytest
+```
+[FAIL] project-setup — Step <n>: <reason>
 ```
 
-**Purpose**: Test automation and quality orchestration
-
-**Key Environments**:
-
-- `ruff`: Auto-format and fix code issues
-- `mypy`: Static type checking
-- `mdlint`: Markdown linting
-- `shellcheck`: Shell script validation
-- `shfmt`: Shell script formatting
-- `py310-py313`: Multi-version testing
-
-### Template 3: pyproject.toml
-
-```toml
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
-
-[project]
-requires-python = ">=3.10"
-version = "0.1.0"
-name = "{{PROJECT_NAME}}"
-description = "Project description here."
-authors = [{ name = "{{AUTHOR_NAME}}", email = "{{AUTHOR_EMAIL}}" }]
-dependencies = [
-    "rich>=14.1.0",
-]
-
-[dependency-groups]
-dev = ["ruff", "mypy", "pylint-exit", "pytest", "pytest-mock", "tox>=4.26.0"]
-
-[project.optional-dependencies]
-dev = [
-    "types-toml",
-    "types-requests",
-    "types-PyYAML",
-]
-
-[tool.setuptools]
-packages = []
-
-[tool.pytest.ini_options]
-pythonpath = ["."]
-testpaths = ["tests"]
-
-[tool.black]
-line-length = 120
-target-version = ['py310', 'py311', "py312", "py313"]
-skip-string-normalization = false
-exclude = '\.git|\.mypy_cache|\.tox|\.nox|\.venv|build|dist'
-
-[tool.isort]
-profile = "black"
-
-[tool.pylint]
-max-line-length = 120
-ignore = [".venv", ".tox", ".vscode", ".git", "build"]
-disable = ["R", "C", "W1203"]
-
-[tool.mypy]
-files = ["./"]
-strict = true
-disallow_untyped_defs = false
-disallow_untyped_calls = false
-exclude = '(?x)( \.venv/ | \.tox/ | \.vscode/ | \.git/ | build/ | config/tox/ | tests )'
-
-[tool.ruff]
-line-length = 120
-target-version = "py310"
-exclude = [".git", ".mypy_cache", ".tox", ".nox", ".venv", "build", "dist", ".vscode"]
-
-[tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP"]
-ignore = ["G004"]
-
-[tool.ruff.format]
-quote-style = "double"
-```
-
-**Dynamic Placeholders**:
-
-- `{{PROJECT_NAME}}`: Replaced with directory name
-- `{{AUTHOR_NAME}}`: Replaced with git config user.name
-- `{{AUTHOR_EMAIL}}`: Replaced with git config user.email
-
-**Purpose**: Project metadata and tool configuration
-
-**Tool Configurations**:
-
-- `ruff`: Line length 120, Python 3.10+ target
-- `mypy`: Strict mode with some relaxations
-- `pytest`: Test discovery in tests/ directory
-- `black`: 120 char lines, multi-version support
-
-## Error Handling
-
-### Missing Git Configuration
-
-If git config not found:
-
-```bash
-# Fallback values
-AUTHOR_NAME="Your Name"
-AUTHOR_EMAIL="your.email@example.com"
-```
-
-Notify user:
-
-```text
-Git config not found. Using default values:
-- Author: Your Name
-- Email: your.email@example.com
-
-To update, run:
-  git config --global user.name "Your Name"
-  git config --global user.email "your.email@example.com"
-```
-
-### Files Already Exist
-
-Strategy:
-
-1. Create backups with timestamp
-2. Notify user of backup locations
-3. Overwrite with new configuration
-4. Provide rollback instructions
-
-### Invalid Project Name
-
-If directory name contains invalid characters:
-
-1. Sanitize name (replace spaces/special chars with underscores)
-2. Notify user of sanitization
-3. Suggest manual update if needed
-
-### Write Permission Issues
-
-If cannot write files:
-
-1. Check permissions: `ls -la .`
-2. Suggest: `chmod +w .`
-3. Fall back to displaying content for manual creation
-
-## Real-World Example
-
-### Before (Empty Directory)
-
-```bash
-$ pwd
-/home/user/projects/my-awesome-tool
-
-$ ls -la
-total 8
-drwxr-xr-x 2 user user 4096 Jan 01 18:00 .
-drwxr-xr-x 5 user user 4096 Jan 01 18:00 ..
-```
-
-### After (Skill Execution)
-
-```bash
-$ ls -la
-total 20
-drwxr-xr-x 2 user user 4096 Jan 01 18:05 .
-drwxr-xr-x 5 user user 4096 Jan 01 18:00 ..
--rw-r--r-- 1 user user   67 Jan 01 18:05 .markdownlint.json
--rw-r--r-- 1 user user 2048 Jan 01 18:05 tox.ini
--rw-r--r-- 1 user user 3500 Jan 01 18:05 pyproject.toml
-```
-
-### Generated Content Example
-
-**pyproject.toml** (with placeholders replaced):
-
-```toml
-[project]
-name = "my-awesome-tool"
-authors = [{ name = "John Doe", email = "john@example.com" }]
-```
-
-### Next Steps After Setup
-
-```bash
-# Create virtual environment
-python -m venv .venv
-source .venv/bin/activate  # or `.venv\Scripts\activate` on Windows
-
-# Install project with dev dependencies
-pip install -e .[dev]
-
-# Run quality checks
-tox -e ruff      # Format code
-tox -e mypy      # Type check
-tox -e mdlint    # Lint markdown
-
-# Run tests (after creating tests/)
-tox -e py312
-```
-
-## Execution Workflow
-
-When this skill is invoked:
-
-1. **Analyze** current directory and git config (Phase 0)
-2. **Backup** existing files if present (Phase 1)
-3. **Generate** all three configuration files (Phase 2)
-4. **Validate** file creation and content (Phase 3)
-5. **Report** summary and next steps (Phase 4)
-
-**Output**:
-
-- Files created with paths
-- Placeholder values used
-- Backup locations (if any)
-- Next steps for project setup
-
-## Quality Gates
-
-Before completion, ensure ALL:
-
-1. All three files created successfully
-2. JSON syntax valid in .markdownlint.json
-3. INI syntax valid in tox.ini
-4. TOML syntax valid in pyproject.toml
-5. Placeholders replaced correctly
-6. Git config extracted or defaults applied
-7. Backups created if files existed
-8. User notified of all actions
-9. Next steps provided
-
-## Usage Notes
-
-### When to Use This Skill
-
-- Starting a new Python project
-- Standardizing an existing project
-- Setting up quality checks and testing
-- Creating consistent development environment
-
-### When NOT to Use This Skill
-
-- Non-Python projects (JavaScript, Go, etc.)
-- Projects with existing custom configurations you want to preserve
-- Simple scripts that don't need full project setup
-
-### Customization After Generation
-
-Users can modify generated files:
-
-- Add more dependencies in pyproject.toml
-- Enable/disable tox environments
-- Adjust tool settings (line length, etc.)
-- Add custom markdown linting rules
-
-## Command
-
-**When invoked, IMMEDIATELY analyze the current directory, extract git configuration, and EXECUTE the project setup workflow following all protocols above.**
-
-Start with Phase 0 analysis and announce the plan before creating any files.
+## References
+
+- `references/help.md` — verbatim usage on `-h` / `--help` / `help`
+- `references/options.md` — option / flag table
+- `references/phases-detail.md` — Step 1–5 detailed instructions
+- `references/templates.md` — `.markdownlint.json` / `tox.ini` / `pyproject.toml` (single SSOT)
+- `references/error-handling.md` — graceful degradation branches
+- `references/example.md` — real-world before / after

--- a/claude/skills/project-setup/SKILL.md
+++ b/claude/skills/project-setup/SKILL.md
@@ -38,14 +38,14 @@ override, `--force`, `--dry-run`, `-h`/`--help`/`help`.
 1. **Step 1 Discover** — read repo state, detect existing configs, extract
    git author info. See `references/phases-detail.md` → Step 1.
 2. **Step 2 Plan** — propose which templates apply, what gets backed up,
-   placeholder values. If `--dry-run`, stop here. See `phases-detail.md` → Step 2.
+   placeholder values. If `--dry-run`, stop here. See `references/phases-detail.md` → Step 2.
 3. **Step 3 Backup** — copy existing files to `.bak.<timestamp>`.
-   See `phases-detail.md` → Step 3.
+   See `references/phases-detail.md` → Step 3.
 4. **Step 4 Apply Templates** — write the three templates with placeholders
    resolved. Templates live in `references/templates.md` (single SSOT —
    no duplication).
 5. **Step 5 Validate** — verify JSON / INI / TOML parses and no `{{...}}`
-   placeholders remain. See `phases-detail.md` → Step 5.
+   placeholders remain. See `references/phases-detail.md` → Step 5.
 6. **Step 6 Report** — emit verdict + next-action hint.
 
 Error / degradation branches: see `references/error-handling.md`.

--- a/claude/skills/project-setup/references/error-handling.md
+++ b/claude/skills/project-setup/references/error-handling.md
@@ -33,7 +33,7 @@ Default behavior (no `--force`):
 1. Create timestamped backups in Step 3 (`.bak.YYYYmmdd_HHMMSS`).
 2. Notify the user of backup locations.
 3. Overwrite with the new templates.
-4. Provide rollback instructions (`mv .markdownlint.json.backup.<ts> .markdownlint.json`).
+4. Provide rollback instructions (`mv .markdownlint.json.bak.<ts> .markdownlint.json`).
 
 With `--force`: same flow — backups are still created, but no prompt is issued.
 

--- a/claude/skills/project-setup/references/error-handling.md
+++ b/claude/skills/project-setup/references/error-handling.md
@@ -1,0 +1,63 @@
+# project-setup — Error Handling
+
+Graceful degradation branches. None of these continue silently — each either
+recovers with a fallback (and notifies the user) or halts with `[FAIL]`.
+
+## Missing Git Configuration
+
+If `git config user.name` / `user.email` is empty, fall back:
+
+```bash
+AUTHOR_NAME="Your Name"
+AUTHOR_EMAIL="your.email@example.com"
+```
+
+Notify the user:
+
+```text
+Git config not found. Using default values:
+- Author: Your Name
+- Email: your.email@example.com
+
+To update, run:
+  git config --global user.name "Your Name"
+  git config --global user.email "your.email@example.com"
+```
+
+This is **recoverable** — proceed with the fallback, do not halt.
+
+## Files Already Exist
+
+Default behavior (no `--force`):
+
+1. Create timestamped backups in Step 3 (`.bak.YYYYmmdd_HHMMSS`).
+2. Notify the user of backup locations.
+3. Overwrite with the new templates.
+4. Provide rollback instructions (`mv .markdownlint.json.backup.<ts> .markdownlint.json`).
+
+With `--force`: same flow — backups are still created, but no prompt is issued.
+
+## Invalid Project Name
+
+If the directory name contains characters outside `[A-Za-z0-9_-]`:
+
+1. Sanitize: replace spaces and special chars with `_`.
+2. Notify the user that sanitization occurred.
+3. Suggest a manual edit in `pyproject.toml` if the sanitized name is undesirable.
+
+## Write Permission Issues
+
+If a write fails (read-only directory, missing perms):
+
+1. Run `ls -la .` to confirm permissions.
+2. Suggest `chmod +w .`.
+3. Fall back to displaying the template content for manual creation.
+4. Halt with `[FAIL]` — do not partially write.
+
+## Validation Failures (Step 5)
+
+If JSON / INI / TOML syntax is invalid, or `{{...}}` placeholders remain:
+
+1. Do NOT delete the file — leave it for inspection.
+2. Halt with `[FAIL] project-setup — Step 5: <file> failed <parser> validation`.
+3. Point user at `.bak.<timestamp>` for rollback.

--- a/claude/skills/project-setup/references/example.md
+++ b/claude/skills/project-setup/references/example.md
@@ -1,0 +1,52 @@
+# project-setup — Real-World Example
+
+## Before (empty directory)
+
+```bash
+$ pwd
+/home/user/projects/my-awesome-tool
+
+$ ls -la
+total 8
+drwxr-xr-x 2 user user 4096 Jan 01 18:00 .
+drwxr-xr-x 5 user user 4096 Jan 01 18:00 ..
+```
+
+## After skill execution
+
+```bash
+$ ls -la
+total 20
+drwxr-xr-x 2 user user 4096 Jan 01 18:05 .
+drwxr-xr-x 5 user user 4096 Jan 01 18:00 ..
+-rw-r--r-- 1 user user   67 Jan 01 18:05 .markdownlint.json
+-rw-r--r-- 1 user user 2048 Jan 01 18:05 tox.ini
+-rw-r--r-- 1 user user 3500 Jan 01 18:05 pyproject.toml
+```
+
+## Generated `pyproject.toml` (placeholders resolved)
+
+```toml
+[project]
+name = "my-awesome-tool"
+authors = [{ name = "John Doe", email = "john@example.com" }]
+```
+
+## Next steps after setup
+
+```bash
+# Create virtual environment
+python -m venv .venv
+source .venv/bin/activate   # or `.venv\Scripts\activate` on Windows
+
+# Install project with dev dependencies
+pip install -e .[dev]
+
+# Run quality checks
+tox -e ruff      # Format code
+tox -e mypy      # Type check
+tox -e mdlint    # Lint markdown
+
+# Run tests (after creating tests/)
+tox -e py312
+```

--- a/claude/skills/project-setup/references/help.md
+++ b/claude/skills/project-setup/references/help.md
@@ -1,0 +1,46 @@
+# project-setup — Usage
+
+## Synopsis
+
+```
+project-setup [PROJECT_NAME] [--force] [--dry-run]
+project-setup -h | --help | help
+```
+
+Initialize a Python project with standard configuration files:
+`.markdownlint.json`, `tox.ini`, `pyproject.toml`.
+
+## Options
+
+| Option           | Description                                                          | Default                  |
+|------------------|----------------------------------------------------------------------|--------------------------|
+| `PROJECT_NAME`   | Override project name (used in `pyproject.toml`).                    | Current directory name   |
+| `--force`        | Overwrite existing config files without prompting (still backs up).  | off (back up, then write) |
+| `--dry-run`      | Show the plan without creating, backing up, or writing files.        | off                      |
+| `-h`, `--help`, `help` | Print this usage and exit.                                     | —                        |
+
+## Examples
+
+```bash
+# Initialize in current directory using directory name
+project-setup
+
+# Override project name
+project-setup my-awesome-tool
+
+# Preview only — no files touched
+project-setup --dry-run
+
+# Force-overwrite existing configs (backups still created)
+project-setup --force
+```
+
+## Stop conditions
+
+- `-h` / `--help` / `help` → print this page and exit.
+- Step 1 fails (cannot read directory / git config) → halt with `[FAIL]`.
+- Step 3 backup write fails → halt with `[FAIL]`, do not proceed to template write.
+- Step 4 template write fails → halt with `[FAIL]`, recommend restoring `.bak` files.
+- Step 5 validation fails → halt with `[FAIL]`, leave files in place for inspection.
+
+Workflow halts on the FIRST failing step — no silent continuation.

--- a/claude/skills/project-setup/references/options.md
+++ b/claude/skills/project-setup/references/options.md
@@ -1,0 +1,18 @@
+# project-setup — Options
+
+| Option           | Description                                                          | Default                  |
+|------------------|----------------------------------------------------------------------|--------------------------|
+| `PROJECT_NAME`   | Override project name. Replaces `{{PROJECT_NAME}}` in `pyproject.toml`. Sanitized: spaces and special chars → `_`. | Current directory name   |
+| `--force`        | Overwrite existing config files. Backups are still created in Step 3. | off                      |
+| `--dry-run`      | Print the plan (which files would be created / backed up / overwritten) without performing any write. | off                      |
+| `-h`, `--help`, `help` | Print `references/help.md` verbatim and exit. Takes precedence over all other args. | —             |
+
+## Placeholder resolution
+
+The author fields in `pyproject.toml` use git config — see Step 1 in `phases-detail.md`.
+
+| Placeholder         | Source                  | Fallback                    |
+|---------------------|-------------------------|-----------------------------|
+| `{{PROJECT_NAME}}`  | argv or directory name  | sanitized directory name    |
+| `{{AUTHOR_NAME}}`   | `git config user.name`  | `Your Name`                 |
+| `{{AUTHOR_EMAIL}}`  | `git config user.email` | `your.email@example.com`    |

--- a/claude/skills/project-setup/references/options.md
+++ b/claude/skills/project-setup/references/options.md
@@ -9,7 +9,7 @@
 
 ## Placeholder resolution
 
-The author fields in `pyproject.toml` use git config — see Step 1 in `phases-detail.md`.
+The author fields in `pyproject.toml` use `git` config — see Step 1 in `references/phases-detail.md`.
 
 | Placeholder         | Source                  | Fallback                    |
 |---------------------|-------------------------|-----------------------------|

--- a/claude/skills/project-setup/references/phases-detail.md
+++ b/claude/skills/project-setup/references/phases-detail.md
@@ -26,7 +26,7 @@ Read repo state and detect existing configs. Execute BEFORE creating anything.
    git config user.email
    ```
 
-   If missing → see `error-handling.md` → Missing Git Configuration.
+   If missing → see `references/error-handling.md` → Missing `Git` Configuration.
 
 **Output:** project context, git config values, list of pre-existing files.
 
@@ -46,10 +46,10 @@ Propose changes before touching disk.
 Run ONLY if files already exist (otherwise skip silently).
 
 ```bash
-TS=$(date +%Y%m%d_%H%M%S)
-[ -f .markdownlint.json ] && cp .markdownlint.json ".markdownlint.json.backup.${TS}"
-[ -f tox.ini ]            && cp tox.ini "tox.ini.backup.${TS}"
-[ -f pyproject.toml ]     && cp pyproject.toml "pyproject.toml.backup.${TS}"
+TS=$(python3 -c 'import datetime; print(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))')
+[ -f .markdownlint.json ] && cp .markdownlint.json ".markdownlint.json.bak.${TS}"
+[ -f tox.ini ]            && cp tox.ini "tox.ini.bak.${TS}"
+[ -f pyproject.toml ]     && cp pyproject.toml "pyproject.toml.bak.${TS}"
 ```
 
 If any `cp` fails → halt with `[FAIL]` before any template write.
@@ -65,7 +65,7 @@ Write the three templates from `templates.md` in order:
    - `{{AUTHOR_NAME}}` ← `git config user.name` or `Your Name`.
    - `{{AUTHOR_EMAIL}}` ← `git config user.email` or `your.email@example.com`.
 
-Templates live in `templates.md` — single SSOT, do not redeclare here.
+Templates live in `references/templates.md` — single SSOT, do not redeclare here.
 
 ## Step 5 — Validate
 
@@ -73,7 +73,11 @@ Verify each file before reporting success:
 
 - `.markdownlint.json` parses as JSON (e.g. `python -m json.tool < .markdownlint.json`).
 - `tox.ini` parses as INI (e.g. `python -c "import configparser; configparser.ConfigParser().read('tox.ini')"`).
-- `pyproject.toml` parses as TOML (e.g. `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`).
+- `pyproject.toml` parses as TOML — use the project's installed parser
+  (Python 3.11+ ships `tomllib`; for 3.10 fall back to `tomli` via
+  `python -c "import tomli; tomli.load(open('pyproject.toml','rb'))"`).
+  This skill targets the project's declared minimum Python version, so do
+  not hardcode `tomllib`.
 - All `{{...}}` placeholders are gone from `pyproject.toml`.
 - Files are readable (`test -r`).
 

--- a/claude/skills/project-setup/references/phases-detail.md
+++ b/claude/skills/project-setup/references/phases-detail.md
@@ -1,0 +1,85 @@
+# project-setup — Step Details
+
+Each step halts the chain on failure (`[FAIL]` verdict, no silent continuation).
+
+## Step 1 — Discover
+
+Read repo state and detect existing configs. Execute BEFORE creating anything.
+
+1. **Verify current directory**
+
+   ```bash
+   pwd
+   ls -la
+   ```
+
+2. **Check existing configuration**
+
+   - Scan for existing `.markdownlint.json`, `tox.ini`, `pyproject.toml`.
+   - Identify conflicts and backup needs.
+   - Determine project name from directory (or argv override).
+
+3. **Extract git configuration**
+
+   ```bash
+   git config user.name
+   git config user.email
+   ```
+
+   If missing → see `error-handling.md` → Missing Git Configuration.
+
+**Output:** project context, git config values, list of pre-existing files.
+
+## Step 2 — Plan
+
+Propose changes before touching disk.
+
+- Which of the three templates apply (always all three unless `--force` is off
+  and the file is identical to the template).
+- What gets backed up (every existing file gets a `.bak.<timestamp>` copy).
+- Placeholder values to substitute (`{{PROJECT_NAME}}`, `{{AUTHOR_NAME}}`,
+  `{{AUTHOR_EMAIL}}`).
+- Print the plan; if `--dry-run`, stop here with `[OK] project-setup — dry-run`.
+
+## Step 3 — Backup
+
+Run ONLY if files already exist (otherwise skip silently).
+
+```bash
+TS=$(date +%Y%m%d_%H%M%S)
+[ -f .markdownlint.json ] && cp .markdownlint.json ".markdownlint.json.backup.${TS}"
+[ -f tox.ini ]            && cp tox.ini "tox.ini.backup.${TS}"
+[ -f pyproject.toml ]     && cp pyproject.toml "pyproject.toml.backup.${TS}"
+```
+
+If any `cp` fails → halt with `[FAIL]` before any template write.
+
+## Step 4 — Apply Templates
+
+Write the three templates from `templates.md` in order:
+
+1. `.markdownlint.json` — verbatim from `templates.md`.
+2. `tox.ini` — verbatim from `templates.md`.
+3. `pyproject.toml` — substitute placeholders:
+   - `{{PROJECT_NAME}}` ← argv override or sanitized directory name.
+   - `{{AUTHOR_NAME}}` ← `git config user.name` or `Your Name`.
+   - `{{AUTHOR_EMAIL}}` ← `git config user.email` or `your.email@example.com`.
+
+Templates live in `templates.md` — single SSOT, do not redeclare here.
+
+## Step 5 — Validate
+
+Verify each file before reporting success:
+
+- `.markdownlint.json` parses as JSON (e.g. `python -m json.tool < .markdownlint.json`).
+- `tox.ini` parses as INI (e.g. `python -c "import configparser; configparser.ConfigParser().read('tox.ini')"`).
+- `pyproject.toml` parses as TOML (e.g. `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`).
+- All `{{...}}` placeholders are gone from `pyproject.toml`.
+- Files are readable (`test -r`).
+
+Any failure → halt with `[FAIL]`, leave files in place, point user at backups.
+
+## Step 6 — Report
+
+Print the success verdict from the main `SKILL.md` Output section, then the
+next-action hint: `Next: tox -e ruff && tox -e mypy`.

--- a/claude/skills/project-setup/references/templates.md
+++ b/claude/skills/project-setup/references/templates.md
@@ -1,0 +1,190 @@
+# project-setup — Templates (SSOT)
+
+Single source of truth for the three configuration files. The main `SKILL.md`
+and `phases-detail.md` reference this file — do not duplicate these blocks
+elsewhere.
+
+## 1. `.markdownlint.json`
+
+**When to use:** every project. Disables `MD013` (line length) and `MD033`
+(inline HTML) while keeping all other rules at defaults.
+
+```json
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false
+}
+```
+
+## 2. `tox.ini`
+
+**When to use:** every project. Provides `ruff`, `mypy`, `mdlint`,
+`shellcheck`, `shfmt`, and `py310`–`py313` environments.
+
+```ini
+[tox]
+envlist = ruff, mypy, mdlint, shellcheck, shfmt
+skipsdist = true
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = false
+deps = .[dev]
+setenv =
+    target_dir = .
+passenv = PATH
+allowlist_externals =
+    pylint
+    mypy
+    markdownlint
+    pylint-exit
+    pytest
+    shellcheck
+    shfmt
+
+[testenv:lint]
+description = Run pylint to check code style and quality
+deps =
+    .[dev]
+commands =
+    pylint {env:target_dir}
+    ruff check {env:target_dir}
+
+[testenv:ruff]
+allowlist_externals = ruff
+description = Run ruff to format code and apply auto-fixes
+deps = .[dev]
+commands =
+    ruff format {env:target_dir}
+    ruff check {env:target_dir} --fix
+
+[testenv:black]
+description = Run black code formatter
+deps =
+    black
+    black[jupyter]
+commands = black {env:target_dir}
+
+[testenv:mypy]
+description = Run mypy type checker
+deps = .[dev]
+commands = mypy {env:target_dir}
+
+[testenv:mdlint]
+description = Run markdownlint to check markdown files
+skip_install = true
+allowlist_externals = markdownlint
+commands = markdownlint {env:target_dir}/**/*.md
+
+[testenv:shellcheck]
+description = Run shellcheck on bash scripts
+skip_install = true
+allowlist_externals =
+    bash
+    find
+    shellcheck
+    xargs
+commands = bash -c 'find bash -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck -x -e SC1090,SC1091'
+
+[testenv:shfmt]
+description = Check shell script formatting with shfmt
+skip_install = true
+deps =
+commands =
+    shfmt -w -i 4 bash/
+
+[testenv:shfmt-check]
+description = Check shell script formatting with shfmt
+skip_install = true
+deps =
+commands =
+    shfmt -d -i 4 bash/
+
+[testenv:py310]
+basepython = python3.10
+commands = pytest
+
+[testenv:py311]
+basepython = python3.11
+commands = pytest
+
+[testenv:py312]
+basepython = python3.12
+commands = pytest
+
+[testenv:py313]
+basepython = python3.13
+commands = pytest
+```
+
+## 3. `pyproject.toml`
+
+**When to use:** every project. Replace `{{PROJECT_NAME}}`, `{{AUTHOR_NAME}}`,
+`{{AUTHOR_EMAIL}}` per Step 4 in `phases-detail.md`.
+
+```toml
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+requires-python = ">=3.10"
+version = "0.1.0"
+name = "{{PROJECT_NAME}}"
+description = "Project description here."
+authors = [{ name = "{{AUTHOR_NAME}}", email = "{{AUTHOR_EMAIL}}" }]
+dependencies = [
+    "rich>=14.1.0",
+]
+
+[dependency-groups]
+dev = ["ruff", "mypy", "pylint-exit", "pytest", "pytest-mock", "tox>=4.26.0"]
+
+[project.optional-dependencies]
+dev = [
+    "types-toml",
+    "types-requests",
+    "types-PyYAML",
+]
+
+[tool.setuptools]
+packages = []
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[tool.black]
+line-length = 120
+target-version = ['py310', 'py311', "py312", "py313"]
+skip-string-normalization = false
+exclude = '\.git|\.mypy_cache|\.tox|\.nox|\.venv|build|dist'
+
+[tool.isort]
+profile = "black"
+
+[tool.pylint]
+max-line-length = 120
+ignore = [".venv", ".tox", ".vscode", ".git", "build"]
+disable = ["R", "C", "W1203"]
+
+[tool.mypy]
+files = ["./"]
+strict = true
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+exclude = '(?x)( \.venv/ | \.tox/ | \.vscode/ | \.git/ | build/ | config/tox/ | tests )'
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+exclude = [".git", ".mypy_cache", ".tox", ".nox", ".venv", "build", "dist", ".vscode"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP"]
+ignore = ["G004"]
+
+[tool.ruff.format]
+quote-style = "double"
+```

--- a/claude/skills/project-setup/references/templates.md
+++ b/claude/skills/project-setup/references/templates.md
@@ -1,7 +1,7 @@
 # project-setup — Templates (SSOT)
 
 Single source of truth for the three configuration files. The main `SKILL.md`
-and `phases-detail.md` reference this file — do not duplicate these blocks
+and `references/phases-detail.md` reference this file — do not duplicate these blocks
 elsewhere.
 
 ## 1. `.markdownlint.json`
@@ -121,7 +121,7 @@ commands = pytest
 ## 3. `pyproject.toml`
 
 **When to use:** every project. Replace `{{PROJECT_NAME}}`, `{{AUTHOR_NAME}}`,
-`{{AUTHOR_EMAIL}}` per Step 4 in `phases-detail.md`.
+`{{AUTHOR_EMAIL}}` per Step 4 in `references/phases-detail.md`.
 
 ```toml
 [build-system]


### PR DESCRIPTION
## Summary

\`project-setup\` SKILL.md **537 → 81 줄** (Check 1 FAIL→PASS).

- 6 \`references/\` 파일로 분리
- \`.markdownlint.json\` 템플릿 중복 (L101-107 + L168-173) → 단일 SSOT (\`references/templates.md\`)
- Phase 0–4 → Step 1–6 리네임, stop-on-failure 정책 추가
- Help flag, Options 포인터, \`[OK]\`/\`[FAIL]\` verdict, Next-action hint 추가

## Why

\`/skill:check\` 자동 감사(#427)에서 detected: POOR (2/10 PASS, 2 WARN, 6 FAIL).
가장 중요한 정정은 **`.markdownlint.json` 템플릿 SSOT 위반** — 본문에 2회 중복.

## Files

| File | Lines | Role |
|------|------:|------|
| \`SKILL.md\` | 81 | 워크플로 phases + UX |
| \`references/help.md\` | 46 | verbatim 사용법 |
| \`references/phases-detail.md\` | 85 | Step 1–5 상세 |
| \`references/templates.md\` | 190 | 3개 템플릿 단일 SSOT |
| \`references/options.md\` | 18 | env var 표 |
| \`references/error-handling.md\` | 63 | 실패 분기 |
| \`references/example.md\` | 52 | before/after |

## Phase → Step 매핑

| Before | After |
|--------|-------|
| Phase 0 Analysis | Step 1 Discover |
| (Plan portion of Phase 0) | Step 2 Plan |
| Phase 1 Backup | Step 3 Backup |
| Phase 2 Generate | Step 4 Apply Templates |
| Phase 3 Validation | Step 5 Validate |
| Phase 4 Report | Step 6 Report |

## Test plan

- [x] \`wc -l SKILL.md\` 81 줄
- [x] Frontmatter (\`allowed-tools\` 포함) 보존
- [x] 한국어 trigger phrase 유지
- [x] \`.markdownlint.json\` 템플릿 단일 SSOT (\`references/templates.md\` § 1) — 본문 중복 0
- [x] pre-commit 통과
- [ ] 머지 후 \`/skill-check claude/skills/project-setup/SKILL.md\` 재실행 — POOR→GOOD/EXCELLENT 기대

Closes #487
🤖 Generated with [Claude Code](https://claude.com/claude-code)