### PR TITLE
docs(guard): align CLAUDE.md + sh:check refs with FORCE_INIT-aware guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ source "${SHELL_COMMON}/path/to/file.sh"
 
 **Interactive guard** — every file that produces output must start with:
 ```bash
-case $- in *i*) ;; *) return 0 ;; esac
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 ```
 
 **No direct writes to `~/.bashrc`** — use symlinks via `setup.sh`.

--- a/claude/skills/sh-check/references/checks.md
+++ b/claude/skills/sh-check/references/checks.md
@@ -37,7 +37,7 @@ or any file whose first few lines call `local`/`alias` without an `exec`
 context) must start with:
 
 ```sh
-case $- in *i*) ;; *) return 0 ;; esac
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 ```
 
 | Result | When |

--- a/claude/skills/sh-check/references/help.md
+++ b/claude/skills/sh-check/references/help.md
@@ -12,7 +12,7 @@ What it checks (10 criteria, modeled on git_worktree.sh):
 
   Structure (1–5)
     1. Shebang + POSIX Hygiene   — #!/bin/sh, [ ], >/dev/null 2>&1
-    2. Interactive Guard         — case $- in *i*) ;; *) return 0 ;; esac
+    2. Interactive Guard         — case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
     3. Section Anatomy           — # ====== headers + Usage: + Args:
     4. Naming Convention         — _prefix private, snake_case
     5. ZSH Compat Guard          — emulate -L sh in cross-shell functions

--- a/claude/skills/sh-check/references/report-template.md
+++ b/claude/skills/sh-check/references/report-template.md
@@ -31,7 +31,7 @@ Verdict: GOOD — production-ready, minor polish needed
 
 ### Next Actions
 1. [WARN #2] Add interactive guard at top of file:
-     case $- in *i*) ;; *) return 0 ;; esac
+     case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
    Run /sh:check again after fix to verify.
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to PR #497 — applies the same FORCE_INIT-aware guard pattern
upgrade to **4 documentation/example references** that were missed
when PR #497 upgraded 116 sourced .sh files.

## Files updated (1-line change each)

| File | Role |
|------|------|
| `CLAUDE.md` (line 80) | Project canonical "Interactive guard" definition |
| `claude/skills/sh-check/references/checks.md` | `/sh:check` Criterion #2 example code |
| `claude/skills/sh-check/references/help.md` | `/sh:check --help` quick-reference list |
| `claude/skills/sh-check/references/report-template.md` | `/sh:check` Next Actions example |

All four contained the **OLD** simple guard as canonical / example text:

```sh
case $- in *i*) ;; *) return 0 ;; esac
```

Now updated to the **NEW** FORCE_INIT-aware form that matches PR #497:

```sh
case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
```

## Why follow-up matters

Without these doc updates:

- New developers reading `CLAUDE.md` would copy the old pattern, then
  break bats tests / CI workflows the same way PR #497's first commit
  did (issue caught in CI run 25601743398).
- `/sh:check` audits on **all 116 files PR #497 upgraded** would
  report `FAIL #2 — Interactive Guard` because the audit criterion
  still expects the old pattern.
- Future contributors using the `/sh:check` Next Actions snippet to
  fix Criterion #2 violations would re-introduce the simple pattern.

## What's NOT in this PR

- No `.sh` file changes — those are already on main via PR #497.
- No new content, just a literal one-line text replacement per file.

## Test plan

- [ ] CI: lint check
- [ ] Manual: `grep -r 'case $- in \*i\*) ;; \*) return 0' shell-common/`
      should now return zero matches (all sourced files use the
      FORCE_INIT-aware form).
- [ ] Manual: `/sh:check shell-common/functions/git_worktree.sh`
      should report PASS (or N/A) for Criterion #2 — not FAIL.

(part of #428)

🤖 Generated with [Claude Code](https://claude.com/claude-code)