### PR TITLE
feat(skills): add help-flag pattern to 12 skills (#427 PR A)

### DIFF
--- a/claude/skills/agents-md-check/SKILL.md
+++ b/claude/skills/agents-md-check/SKILL.md
@@ -12,6 +12,10 @@ allowed-tools: Read, Glob, Grep, Bash
 
 # AGENTS.md Compliance Auditor
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 ## Role
 
 You are an AGENTS.md quality auditor. Read the target file completely, evaluate

--- a/claude/skills/agents-md-check/references/help.md
+++ b/claude/skills/agents-md-check/references/help.md
@@ -1,0 +1,34 @@
+# skill:agents-md-check — Help
+
+## Synopsis
+
+```
+/agents-md:check [path]
+```
+
+## Description
+
+Audit an existing `AGENTS.md` file for compliance with project documentation
+standards. Reports pass/fail/warn per criterion with concrete improvement
+suggestions. Do NOT use for `CLAUDE.md` orchestrator files — use
+`skill:claude-md-check` instead.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `path` | Explicit path to the `AGENTS.md` to audit. | Auto-detect in cwd |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/agents-md:check
+/agents-md:check ./docs/AGENTS.md
+/agents-md:check -h
+```
+
+## Stop conditions
+
+- No `AGENTS.md` found at the resolved path — list candidates and ask which to check.
+- Target is a `CLAUDE.md` orchestrator file — redirect to `skill:claude-md-check`.

--- a/claude/skills/agents-md-create/SKILL.md
+++ b/claude/skills/agents-md-create/SKILL.md
@@ -11,6 +11,10 @@ allowed-tools: Read, Glob, Grep, Write, Bash
 
 # AGENTS.md Creator
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 ## Workflow
 
 ### Phase 0: Discover (always run first)

--- a/claude/skills/agents-md-create/references/help.md
+++ b/claude/skills/agents-md-create/references/help.md
@@ -1,0 +1,34 @@
+# skill:agents-md-create — Help
+
+## Synopsis
+
+```
+/agents-md:create [path]
+```
+
+## Description
+
+Create a new `AGENTS.md` documentation system for a project from scratch.
+Generates a root `AGENTS.md` and nested files as needed, sized by project
+classification (small / medium / large). Distinct from `skill:agents-md-refactor`
+(existing file) and `skill:agents-md-check` (audit only).
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `path` | Target directory to write `AGENTS.md` into. | Current working directory |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/agents-md:create
+/agents-md:create ./packages/api
+/agents-md:create -h
+```
+
+## Stop conditions
+
+- An `AGENTS.md` already exists at the target — recommend `skill:agents-md-refactor` instead.
+- Project type cannot be classified — ask the user for clarification before writing.

--- a/claude/skills/ai-worktree-spawn/SKILL.md
+++ b/claude/skills/ai-worktree-spawn/SKILL.md
@@ -11,6 +11,10 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # AI Worktree Spawn
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 Create an isolated git worktree so this AI agent can work without interfering
 with other agents running in the same repository.
 

--- a/claude/skills/ai-worktree-spawn/references/help.md
+++ b/claude/skills/ai-worktree-spawn/references/help.md
@@ -1,0 +1,38 @@
+# skill:ai-worktree-spawn — Help
+
+## Synopsis
+
+```
+/ai-worktree:spawn [--ai <name>] [--task <slug>] [--base <ref>] [<branch>]
+```
+
+## Description
+
+Create an isolated git worktree workspace for the current AI coding agent so
+it can work in parallel without interfering with other agents in the same
+repository. Detects the active agent, picks the next free index, and creates
+a worktree at `../<project>-<agent>-<N>` on a `wt/<agent>/<N>` branch.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ai <name>` | Override the detected AI agent name. | Auto-detect (`$AI_AGENT_NAME`, env vars, then `agent`) |
+| `--task <slug>` | Append a task slug to the branch name (Korean is translated to English kebab-case). | — |
+| `--base <ref>` | Base ref for the new branch. | `origin/main` > `main`/`master` > current HEAD |
+| `<branch>` | Use this explicit branch name instead of `wt/<agent>/<N>`. | Auto-generated |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/ai-worktree:spawn
+/ai-worktree:spawn --task "login feature"
+/ai-worktree:spawn --ai claude --base origin/develop
+```
+
+## Stop conditions
+
+- Caller is already inside a worktree — refuse and ask the user to exit first.
+- Parent directory is not writable.
+- `git worktree add` fails — surface the error and do not log a partial creation.

--- a/claude/skills/claude-md-create/SKILL.md
+++ b/claude/skills/claude-md-create/SKILL.md
@@ -14,6 +14,10 @@ compatibility:
 
 # CLAUDE.md Orchestrator Creator
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 ## Workflow
 
 ### Phase 0: Discover (always run first)

--- a/claude/skills/claude-md-create/references/help.md
+++ b/claude/skills/claude-md-create/references/help.md
@@ -1,0 +1,34 @@
+# skill:claude-md-create — Help
+
+## Synopsis
+
+```
+/claude-md-create [path]
+```
+
+## Description
+
+Create a `CLAUDE.md` orchestrator file for an AI agent framework from scratch.
+Defines roles, commands, permissions, and delegation patterns sized by
+framework scale (simple / standard / large). Distinct from `skill:claude-md-check`
+(audit only).
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `path` | Target directory to write `CLAUDE.md` into. | Current working directory |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/claude-md-create
+/claude-md-create ./my-agent-framework
+/claude-md-create -h
+```
+
+## Stop conditions
+
+- A `CLAUDE.md` already exists at the target — confirm overwrite before proceeding.
+- Discover phase (Phase 0) cannot extract domain / agent list — ask the user before writing.

--- a/claude/skills/devx-excalidraw-diagram/SKILL.md
+++ b/claude/skills/devx-excalidraw-diagram/SKILL.md
@@ -5,6 +5,10 @@ description: Create Excalidraw diagram JSON files that make visual arguments. Tr
 
 # Excalidraw Diagram Creator
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 Generate `.excalidraw` JSON files that **argue visually**, not just display information.
 
 **Setup:** See `README.md` for renderer setup and dependencies.

--- a/claude/skills/devx-excalidraw-diagram/references/help.md
+++ b/claude/skills/devx-excalidraw-diagram/references/help.md
@@ -1,0 +1,34 @@
+# skill:devx-excalidraw-diagram — Help
+
+## Synopsis
+
+```
+/devx:excalidraw-diagram <topic-or-spec>
+```
+
+## Description
+
+Create `.excalidraw` JSON files that make a visual argument about a workflow,
+architecture, or concept — not just label boxes. Each major concept must use a
+different visual pattern (fan-out, convergence, tree, timeline, etc.). Output
+is rendered to PNG via the bundled `render_excalidraw.py` for validation.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<topic-or-spec>` | The concept, system, or workflow to visualize. | — |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/devx:excalidraw-diagram "OAuth refresh-token flow"
+/devx:excalidraw-diagram "monorepo build graph for our 6 services"
+/devx:excalidraw-diagram -h
+```
+
+## Stop conditions
+
+- Topic is too vague to map onto a visual pattern — ask for clarification before generating JSON.
+- Renderer dependencies (uv / Python) unavailable — surface setup steps from `README.md`.

--- a/claude/skills/devx-schedule/SKILL.md
+++ b/claude/skills/devx-schedule/SKILL.md
@@ -12,6 +12,10 @@ description: >-
 
 # devx:schedule — Deferred Skill Executor
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 > **Claude Code only** — requires the `CronCreate` tool, which is part of the
 > Claude Code harness. Other CLIs (Codex, Gemini, etc.) lack a comparable
 > session-spawn scheduler, so this skill cannot run there.

--- a/claude/skills/devx-schedule/references/help.md
+++ b/claude/skills/devx-schedule/references/help.md
@@ -1,0 +1,35 @@
+# skill:devx-schedule — Help
+
+## Synopsis
+
+```
+/devx:schedule [--time M] "<command>"
+/devx:schedule [--time M] /skill-name [args...]
+```
+
+## Description
+
+Schedule a skill or command to run after a specified delay using the
+`CronCreate` tool. Claude Code only — Codex and Gemini CLIs lack a comparable
+session-spawn scheduler.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--time M` | Delay in minutes (positive integer). | `5` |
+| `<command>` | Skill invocation or natural-language task to run after the delay. | — |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/devx:schedule --time 10 "/gh-pr-reply 350"
+/devx:schedule /gh-pr-resolve-conflict 351
+/devx:schedule --time 3 "PR #200 리뷰 코멘트 처리해"
+```
+
+## Stop conditions
+
+- `CronCreate` tool is unavailable (non-Claude-Code harness) — refuse and explain.
+- `--time` is not a positive integer — fall back to default `5` and warn the user.

--- a/claude/skills/devx-visualize/SKILL.md
+++ b/claude/skills/devx-visualize/SKILL.md
@@ -19,6 +19,10 @@ metadata:
 
 # Visualize
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 Turn any idea, data, or content into a stunning single-file HTML visualization.
 
 ## After Creating a File

--- a/claude/skills/devx-visualize/references/help.md
+++ b/claude/skills/devx-visualize/references/help.md
@@ -1,0 +1,34 @@
+# skill:devx-visualize — Help
+
+## Synopsis
+
+```
+/devx:visualize [<file-or-content>]
+```
+
+## Description
+
+Create beautiful, self-contained HTML visualizations from any content or idea
+— slide decks, dashboards, infographics, flowcharts, timelines, posters, and
+more. Writes a single `.html` file, auto-opens it via `xdg-open` (Linux/WSL)
+or `open` (macOS), and returns a `file://` URL.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<file-or-content>` | Path to a source file, pasted content, or a topic to visualize. | Use conversation context |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/devx:visualize /path/to/notes.md
+/devx:visualize "Q2 product roadmap with 4 epics and 12 stories"
+/devx:visualize -h
+```
+
+## Stop conditions
+
+- Format is ambiguous — run the Auto-Recommend workflow (see `references/type-rules.md`) and wait for confirmation.
+- Required skeleton (`references/skeleton.md`) cannot be loaded — surface the error before writing HTML.

--- a/claude/skills/dissect-builtin/SKILL.md
+++ b/claude/skills/dissect-builtin/SKILL.md
@@ -11,6 +11,10 @@ description: >-
 
 # Dissect Built-in Skill
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 Analyze a Claude Code built-in skill and produce structured documentation in Korean.
 
 ## Usage

--- a/claude/skills/dissect-builtin/references/help.md
+++ b/claude/skills/dissect-builtin/references/help.md
@@ -1,0 +1,34 @@
+# skill:dissect-builtin — Help
+
+## Synopsis
+
+```
+/dissect-builtin <skill-name>
+```
+
+## Description
+
+Analyze a Claude Code built-in skill and produce structured Korean documentation.
+Loads the target skill's prompt via the Skill tool, then writes `README.md`
+(Korean analysis) and `PROMPT.md` (verbatim original prompt) into
+`claude/built-in-skills/<skill-name>/`.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<skill-name>` | Name of the built-in skill to dissect (e.g. `simplify`, `loop`). | — |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/dissect-builtin simplify
+/dissect-builtin loop
+/dissect-builtin -h
+```
+
+## Stop conditions
+
+- Target skill is not a built-in (Skill tool load fails) — inform the user and suggest alternatives.
+- Output filename `SKILL.md` is requested — refuse (conflicts with Claude Code skill loading).

--- a/claude/skills/internal-comms/SKILL.md
+++ b/claude/skills/internal-comms/SKILL.md
@@ -9,6 +9,10 @@ description: >-
 license: Complete terms in LICENSE.txt
 ---
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 ## When to use this skill
 To write internal communications, use this skill for:
 - 3P updates (Progress, Plans, Problems)

--- a/claude/skills/internal-comms/SKILL.md
+++ b/claude/skills/internal-comms/SKILL.md
@@ -9,6 +9,8 @@ description: >-
 license: Complete terms in LICENSE.txt
 ---
 
+# Internal Communications
+
 ## Help
 
 If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.

--- a/claude/skills/internal-comms/references/help.md
+++ b/claude/skills/internal-comms/references/help.md
@@ -1,0 +1,35 @@
+# skill:internal-comms — Help
+
+## Synopsis
+
+```
+/internal-comms <comms-type> [topic]
+```
+
+## Description
+
+Write internal communications in the formats the company uses — 3P updates,
+company newsletters, FAQ responses, status reports, leadership updates,
+project updates, and incident reports. Loads the matching guideline file
+from `examples/` and follows its formatting and tone rules.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<comms-type>` | Communication type: `3p`, `newsletter`, `faq`, `general`, etc. | Inferred from request |
+| `[topic]` | Subject matter or source content for the comms. | — |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/internal-comms 3p "this week's progress on auth migration"
+/internal-comms newsletter "Q2 launch recap"
+/internal-comms faq "common questions about the new pricing"
+```
+
+## Stop conditions
+
+- Communication type does not match any guideline in `examples/` — ask for clarification or pick `examples/general-comms.md`.
+- Source material is missing — request the underlying notes / data before drafting.

--- a/claude/skills/write-blog-dev-learnings/SKILL.md
+++ b/claude/skills/write-blog-dev-learnings/SKILL.md
@@ -16,6 +16,10 @@ description: >-
 
 # Developer Blog Writer — "삽질 블로그"
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 You are a developer blog ghostwriter who turns painful debugging stories into entertaining, educational posts that teammates actually want to read. Your posts live in `~/para/archive/playbook/docs/dev-learnings/`.
 
 ## Why This Matters

--- a/claude/skills/write-blog-dev-learnings/references/help.md
+++ b/claude/skills/write-blog-dev-learnings/references/help.md
@@ -1,0 +1,35 @@
+# skill:write-blog-dev-learnings — Help
+
+## Synopsis
+
+```
+/write-blog-dev-learnings "<topic-hint>"
+```
+
+## Description
+
+Write entertaining Korean developer blog posts about debugging war stories,
+production incidents, and technical gotchas. Saves to
+`~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`. Narrative arc:
+고통 → 삽질 → 깨달음 → 해결. Do NOT use for formal RCA documents (use
+`skill:write-rca`), API docs, or README files.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `"<topic-hint>"` | Topic summary, specific incident, or vague pointer ("오늘 삽질한 거"). | — |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/write-blog-dev-learnings "지금까지 너와 작업한 내용"
+/write-blog-dev-learnings "오늘 redis sed injection 삽질"
+/write-blog-dev-learnings "WSL systemd 감지 문제"
+```
+
+## Stop conditions
+
+- Conversation does not contain enough detail and the user gives no topic — interview the user for symptoms, attempts, root cause, and fix before writing.
+- Topic better fits an RCA or non-narrative doc — redirect to `skill:write-rca` or the appropriate skill.

--- a/claude/skills/write-release-note/SKILL.md
+++ b/claude/skills/write-release-note/SKILL.md
@@ -6,6 +6,10 @@ allowed-tools: Read, Bash, Grep, Glob, Write, Edit
 
 # Release Notes 작성
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 ## 목적
 
 git 히스토리를 분석해 **사용자 관점**의 릴리즈 노트를 생성한다.

--- a/claude/skills/write-release-note/references/help.md
+++ b/claude/skills/write-release-note/references/help.md
@@ -1,0 +1,36 @@
+# skill:write-release-note — Help
+
+## Synopsis
+
+```
+/write:release-note [<anchor-ref>] [<head-ref>]
+```
+
+## Description
+
+Generate structured Korean release notes from git history between two
+releases. Finds anchor commits, collects commits in the `<anchor>..HEAD`
+range, categorizes by conventional-commit prefix, groups related commits
+into user-facing themes, and writes the result in the project's existing
+release-notes format (or the default template if none exists).
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<anchor-ref>` | Previous release boundary (tag, commit hash, or branch). | Auto-detect: latest tag → previous release-note commit → ask user |
+| `<head-ref>` | Upper bound of the commit range. | `HEAD` |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/write:release-note
+/write:release-note v1.2.0
+/write:release-note v1.2.0 v1.3.0
+```
+
+## Stop conditions
+
+- No git tags and no prior release notes — ask the user for the start commit before collecting.
+- Non-conventional commits present — call them out (do not silently drop) and group them under a fallback section.

--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -13,6 +13,10 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 
 # write-task-history
 
+## Help
+
+If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
 Document completed work from the current conversation into a daily task history file,
 producing JIRA ticket and git PR formats that can be directly copy-pasted.
 

--- a/claude/skills/write-task-history/references/help.md
+++ b/claude/skills/write-task-history/references/help.md
@@ -1,0 +1,35 @@
+# skill:write-task-history — Help
+
+## Synopsis
+
+```
+/write-task-history ["<optional description>"]
+```
+
+## Description
+
+Write task history from the current conversation to a daily task-list file.
+Generates two copy-paste-ready formats: a JIRA ticket (plain text with `>` /
+`-` symbols) and a git PR description (markdown). Writes to
+`$TASK_HISTORY_DIR` or `~/para/archive/playbook/docs/task-history/`, then
+auto-commits the file in its host repository.
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `"<optional description>"` | Extra context to supplement conversation analysis. | — |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/write-task-history
+/write-task-history "fix symlink bug + PR #33 merged"
+/write-task-history -h
+```
+
+## Stop conditions
+
+- Conversation contains no concrete actions to record — ask the user to describe what was done.
+- Target directory cannot be created or is read-only — surface the error before generating output.


### PR DESCRIPTION
## Summary

#427 GOOD-tier 일괄 처리 — **PR A: Help flag 통일**.

12개 스킬에 `## Help` 섹션 + `references/help.md` 추가. 사용자가 슬래시 호출 시
`-h`/`--help`/`help` 인자로 즉시 사용법 확인 가능.

> **부분 클로저** — 각 이슈의 다른 audit findings (line count, verdict, options 등)
> 은 후속 PR (PR B/C/D) 에서 처리. 본 PR 은 Check 6 (Help Flag Pattern) 만
> FAIL→PASS 로 전환.

| Skill | Issue | SKILL.md Δ | help.md |
|-------|-------|----------:|--------:|
| `agents-md:check` | #453 | +4 | 34 줄 |
| `agents-md:create` | #454 | +4 | 34 줄 |
| `ai-worktree:spawn` | #456 | +4 | 38 줄 |
| `claude-md-create` | #459 | +4 | 34 줄 |
| `devx:excalidraw-diagram` | #462 | +4 | 34 줄 |
| `devx:schedule` | #466 | +4 | 35 줄 |
| `devx:visualize` | #470 | +4 | 34 줄 |
| `dissect-builtin` | #471 | +4 | 34 줄 |
| `internal-comms` | #484 | +4 | 35 줄 |
| `write-blog-dev-learnings` | #492 | +4 | 35 줄 |
| `write:release-note` | #495 | +4 | 36 줄 |
| `write:task-history` | #496 | +4 | 35 줄 |
| **합계** | 12 issues | **+48** | **+418** |

## Pattern (모두 동일)

각 `SKILL.md` 에 H1 바로 아래 4줄 삽입:

```markdown
## Help

If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
```

각 `references/help.md` 는 ~30-40 줄: Synopsis / Description / Arguments 표 /
Examples / Stop conditions. 본문 이모지 없음.

## Notes

- `internal-comms/SKILL.md` 는 H1 부재 — `## Help` 가 첫 콘텐츠 섹션이 됨.
- 6개 스킬은 신규 `references/` 디렉토리 생성, 다른 6개는 기존 `references/` 에 추가.

## Test plan

- [x] 12개 SKILL.md 모두 `## Help` 1회 존재
- [x] 12개 `references/help.md` 신규 생성
- [x] frontmatter 변경 없음
- [x] pre-commit 통과
- [ ] 머지 후 `/skill:check` 12개 재실행 — Check 6 (Help Flag Pattern) FAIL→PASS 기대

## Related

부분 클로저이므로 `Refs` 만 — 이슈는 후속 PR 들과 합쳐서 닫음.

Refs #453 #454 #456 #459 #462 #466 #470 #471 #484 #492 #495 #496 #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)