### PR TITLE
refactor(shell): #424 batch A — guard/shebang sweep follow-up

### DIFF
--- a/shell-common/aliases/disk_usage.sh
+++ b/shell-common/aliases/disk_usage.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # shell-common/aliases/disk_usage.sh
-# Disk-usage aliases (POSIX-compatible)
+# Disk-usage aliases (POSIX-shell compatible)
 # Shared between bash and zsh
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac

--- a/shell-common/aliases/disk_usage.sh
+++ b/shell-common/aliases/disk_usage.sh
@@ -1,4 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+
+# shell-common/aliases/disk_usage.sh
+# Disk-usage aliases (POSIX-compatible)
+# Shared between bash and zsh
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 # 현재 디렉토리 전체 크기 요약
 alias dus='du -sh .'

--- a/shell-common/env/editor.sh
+++ b/shell-common/env/editor.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# editor.bash
+# shell-common/env/editor.sh
 # 에디터 관련 환경 변수 설정
 
 # 기본 에디터 설정


### PR DESCRIPTION
## Summary

Batch A of the #424 `sh:check` audit follow-up — covers 5 sub-issues for `shell-common/aliases/*` and `shell-common/env/editor.sh`.

After the broad guard sweep in `1d138ec` (#497) + `faa4b1d` (FORCE_INIT-aware guard), three of the five sub-issues are already substantively fixed at file level. Only two files needed a surgical touch-up here.

## Changes

- `shell-common/aliases/disk_usage.sh` (closes #431): bash→POSIX shebang + interactive guard with `DOTFILES_FORCE_INIT` escape hatch. Body was already POSIX-clean (alias-only).
- `shell-common/env/editor.sh` (closes #434): stale `# editor.bash` header comment updated to `# shell-common/env/editor.sh` to reflect the bash→sh migration. Guard + shebang were already in place.

## Issues silently resolved by prior sweeps

These were closed by `faa4b1d`'s 116-file guard sweep — verified current files contain both `#\!/bin/sh` and the FORCE_INIT-aware guard, satisfying the audit's `FAIL F#1`/`FAIL F#2`:

- #430 `shell-common/aliases/claude_plugins.sh`
- #432 `shell-common/aliases/mytool.sh`
- #433 `shell-common/aliases/system.sh`

## Test plan

- [x] `tox -e shellcheck` — PASS
- [x] `git diff` reviewed for stray edits

Closes #430, #431, #432, #433, #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)