### PR TITLE
refactor(integrations): #424 batch B — guard, POSIX, env-var fallbacks

### DIFF
--- a/git/hooks/checks/library_purity_check.sh
+++ b/git/hooks/checks/library_purity_check.sh
@@ -47,8 +47,9 @@ check_library_purity() {
             }
             # Skip alias definitions — `alias foo='pip install ...'` is NOT
             # a top-level installation; it only runs when the alias is invoked.
+            # Allow hyphens so dash-form aliases like `uv-install` match too.
             if (depth==0 && line ~ install_ere &&
-                line !~ /^[[:space:]]*alias[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=/) {
+                line !~ /^[[:space:]]*alias[[:space:]]+[A-Za-z_][A-Za-z0-9_-]*=/) {
                 printf "INSTALL:%d:%s\n", NR, line
             }
         }

--- a/git/hooks/checks/library_purity_check.sh
+++ b/git/hooks/checks/library_purity_check.sh
@@ -45,7 +45,10 @@ check_library_purity() {
                 line !~ /^[[:space:]]*(main|[a-z_][a-z0-9_]*_main)[[:space:]]*\(\)[[:space:]]*\{/) {
                 printf "MAIN_CALL:%d:%s\n", NR, line
             }
-            if (depth==0 && line ~ install_ere) {
+            # Skip alias definitions — `alias foo='pip install ...'` is NOT
+            # a top-level installation; it only runs when the alias is invoked.
+            if (depth==0 && line ~ install_ere &&
+                line !~ /^[[:space:]]*alias[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=/) {
                 printf "INSTALL:%d:%s\n", NR, line
             }
         }

--- a/shell-common/tools/integrations/jetbrain.sh
+++ b/shell-common/tools/integrations/jetbrain.sh
@@ -1,8 +1,50 @@
-#!/bin/bash
-# shell-common/tools/external/jetbrain.sh
-# External application launcher configuration
+#!/bin/sh
+# shell-common/tools/integrations/jetbrain.sh
+# JetBrains IDE launcher aliases (POSIX-compatible).
+#
+# Path resolution order for `pycharm`:
+#   1. $PYCHARM_BIN   (explicit override, e.g. `export PYCHARM_BIN=~/bin/pycharm`)
+#   2. $JETBRAIN_HOME/pycharm-*/bin/pycharm (auto-discover most recent version)
+#   3. ~/application/pycharm-2025.2.0.1/bin/pycharm (legacy hard-coded default)
 
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-# $HOME/dotfiles/shell-common/tools/external/jetbrain.sh
+_jetbrain_resolve_pycharm() {
+    if [ -n "${PYCHARM_BIN-}" ]; then
+        printf "%s" "$PYCHARM_BIN"
+        return 0
+    fi
+    _jb_home="${JETBRAIN_HOME:-$HOME/application}"
+    # Pick the most recent pycharm-* directory if any exists.
+    for _jb_dir in "$_jb_home"/pycharm-*; do
+        if [ -x "$_jb_dir/bin/pycharm" ]; then
+            printf "%s" "$_jb_dir/bin/pycharm"
+            unset _jb_home _jb_dir
+            return 0
+        fi
+    done
+    unset _jb_home _jb_dir
+    printf "%s" "$HOME/application/pycharm-2025.2.0.1/bin/pycharm"
+}
 
-alias pycharm='~/application/pycharm-2025.2.0.1/bin/pycharm'
+# Lazy resolution: re-evaluated on each invocation so a later $PYCHARM_BIN
+# export still takes effect without re-sourcing this file.
+pycharm() {
+    _jb_bin=$(_jetbrain_resolve_pycharm)
+    if [ ! -x "$_jb_bin" ]; then
+        if type ux_warning >/dev/null 2>&1; then
+            ux_warning "pycharm binary not found at: $_jb_bin"
+            ux_info "Set \$PYCHARM_BIN or install under \$JETBRAIN_HOME (default ~/application)."
+        else
+            printf 'pycharm: binary not found at %s\n' "$_jb_bin" >&2
+            # shellcheck disable=SC2016 # literal var names shown to the user
+            printf 'Set $PYCHARM_BIN or install under $JETBRAIN_HOME (default ~/application).\n' >&2
+        fi
+        unset _jb_bin
+        return 1
+    fi
+    "$_jb_bin" "$@"
+    _jb_rc=$?
+    unset _jb_bin
+    return "$_jb_rc"
+}

--- a/shell-common/tools/integrations/jetbrain.sh
+++ b/shell-common/tools/integrations/jetbrain.sh
@@ -16,14 +16,21 @@ _jetbrain_resolve_pycharm() {
     fi
     _jb_home="${JETBRAIN_HOME:-$HOME/application}"
     # Pick the most recent pycharm-* directory if any exists.
+    # Globs expand alphabetically, so iterate and keep the LAST match —
+    # `pycharm-2025.2.0.1` beats `pycharm-2024.1` that way. First-match would
+    # pin us to the oldest version on disk (gemini PR #520 review).
+    _jb_found=""
     for _jb_dir in "$_jb_home"/pycharm-*; do
         if [ -x "$_jb_dir/bin/pycharm" ]; then
-            printf "%s" "$_jb_dir/bin/pycharm"
-            unset _jb_home _jb_dir
-            return 0
+            _jb_found="$_jb_dir/bin/pycharm"
         fi
     done
-    unset _jb_home _jb_dir
+    if [ -n "$_jb_found" ]; then
+        printf "%s" "$_jb_found"
+        unset _jb_home _jb_dir _jb_found
+        return 0
+    fi
+    unset _jb_home _jb_dir _jb_found
     printf "%s" "$HOME/application/pycharm-2025.2.0.1/bin/pycharm"
 }
 

--- a/shell-common/tools/integrations/obsidian.sh
+++ b/shell-common/tools/integrations/obsidian.sh
@@ -1,8 +1,48 @@
-#!/bin/bash
-# shell-common/tools/external/obsidian.sh
-# External application launcher configuration
+#!/bin/sh
+# shell-common/tools/integrations/obsidian.sh
+# Obsidian launcher (POSIX-compatible).
+#
+# Path resolution order for `obsidian`:
+#   1. $OBSIDIAN_BIN   (explicit override)
+#   2. Latest Obsidian-*.AppImage under $OBSIDIAN_HOME (default ~/application)
+#   3. ~/application/Obsidian-1.8.10.AppImage (legacy hard-coded default)
 
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-# ~/dotfiles/shell-common/tools/external/obsidian.sh
+_obsidian_resolve_bin() {
+    if [ -n "${OBSIDIAN_BIN-}" ]; then
+        printf "%s" "$OBSIDIAN_BIN"
+        return 0
+    fi
+    _ob_home="${OBSIDIAN_HOME:-$HOME/application}"
+    # Pick any Obsidian-*.AppImage in the home directory.
+    for _ob_app in "$_ob_home"/Obsidian-*.AppImage; do
+        if [ -x "$_ob_app" ]; then
+            printf "%s" "$_ob_app"
+            unset _ob_home _ob_app
+            return 0
+        fi
+    done
+    unset _ob_home _ob_app
+    printf "%s" "$HOME/application/Obsidian-1.8.10.AppImage"
+}
 
-alias obsidian='~/application/Obsidian-1.8.10.AppImage'
+obsidian() {
+    _ob_bin=$(_obsidian_resolve_bin)
+    if [ ! -x "$_ob_bin" ]; then
+        if type ux_warning >/dev/null 2>&1; then
+            ux_warning "obsidian binary not found at: $_ob_bin"
+            ux_info "Set \$OBSIDIAN_BIN or place AppImage under \$OBSIDIAN_HOME (default ~/application)."
+        else
+            printf 'obsidian: binary not found at %s\n' "$_ob_bin" >&2
+            # shellcheck disable=SC2016 # literal var names shown to the user
+            printf 'Set $OBSIDIAN_BIN or place AppImage under $OBSIDIAN_HOME (default ~/application).\n' >&2
+        fi
+        unset _ob_bin
+        return 1
+    fi
+    "$_ob_bin" "$@"
+    _ob_rc=$?
+    unset _ob_bin
+    return "$_ob_rc"
+}

--- a/shell-common/tools/integrations/obsidian.sh
+++ b/shell-common/tools/integrations/obsidian.sh
@@ -15,15 +15,21 @@ _obsidian_resolve_bin() {
         return 0
     fi
     _ob_home="${OBSIDIAN_HOME:-$HOME/application}"
-    # Pick any Obsidian-*.AppImage in the home directory.
+    # Pick the latest Obsidian-*.AppImage. Globs expand alphabetically — keep
+    # the LAST executable match so `Obsidian-1.8.10` wins over `Obsidian-1.7.0`
+    # (gemini PR #520 review).
+    _ob_found=""
     for _ob_app in "$_ob_home"/Obsidian-*.AppImage; do
         if [ -x "$_ob_app" ]; then
-            printf "%s" "$_ob_app"
-            unset _ob_home _ob_app
-            return 0
+            _ob_found="$_ob_app"
         fi
     done
-    unset _ob_home _ob_app
+    if [ -n "$_ob_found" ]; then
+        printf "%s" "$_ob_found"
+        unset _ob_home _ob_app _ob_found
+        return 0
+    fi
+    unset _ob_home _ob_app _ob_found
     printf "%s" "$HOME/application/Obsidian-1.8.10.AppImage"
 }
 

--- a/shell-common/tools/integrations/pip.sh
+++ b/shell-common/tools/integrations/pip.sh
@@ -1,6 +1,10 @@
-#!/bin/bash
-# shell-common/tools/external/pip.sh
-# Python package management utilities
+#!/bin/sh
+# shell-common/tools/integrations/pip.sh
+# Python package management utilities (POSIX-compatible alias module).
+# Help: `pp-help` (defined in shell-common/functions/pp_help.sh) lists all
+# pp_*/code_*/test_*/docs_* aliases below.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 # Python Package Management
 # alias pp_freeze: pyproject.toml에서 프로젝트 이름을 읽어와 pip freeze 목록에서 제외하고, -e .을 추가하여 requirements.txt를 생성하는 명령어입니다.

--- a/shell-common/tools/integrations/python.sh
+++ b/shell-common/tools/integrations/python.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # shell-common/tools/integrations/python.sh
-
+# Python venv aliases (POSIX-compatible).
+# Help: `py-help` (defined in shell-common/functions/py_help.sh) lists the
+# create/activate/deactivate venv shortcuts below.
+#
 # NOTE: $HOME/.local/bin PATH is managed by env/path.sh (SSOT)
 
 # Python Virtual Environment

--- a/shell-common/tools/integrations/uv.sh
+++ b/shell-common/tools/integrations/uv.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
-# shell-common/tools/external/uv.sh
-# Auto-generated from bash/app/uv.bash
+#!/bin/sh
+# shell-common/tools/integrations/uv.sh
+# uv (Python package manager) aliases (POSIX-compatible).
+# Help: `uv-help` (defined in shell-common/functions/package_managers_help.sh)
+# lists every uv* alias below.
 
-# bash/app/uv.bash  (정리판)
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 # ── 기본 동사 규칙 ──────────────────────────────────────────────
 # uvi : install (툴 설치)
@@ -33,8 +35,11 @@ alias uvr='uv pip sync requirements.txt'
 alias uvcheck='uv pip check'
 
 # (6) uv-install 함수 (shell-common/tools/custom/install_uv.sh 호출)
-uv-install() {
+# POSIX requires function names match [a-zA-Z_][a-zA-Z0-9_]*; expose the dashed
+# form as an alias to keep the same user-facing command name.
+uv_install() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_uv.sh"
 }
+alias uv-install='uv_install'
 
-# (7) 도움말(프로젝트 관례 안내)
+# (7) 도움말: `uv-help` (registered in package_managers_help.sh)


### PR DESCRIPTION
## Summary

Batch B of the #424 `sh:check` audit follow-up — covers the 5 integration files (`shell-common/tools/integrations/`).

## Changes (per file)

- **jetbrain.sh** (closes #447): hard-coded pycharm path → `pycharm()` function with lazy resolution via `$PYCHARM_BIN` → `$JETBRAIN_HOME/pycharm-*` → legacy default. Emits a `ux_warning` + override hint when no binary is found.
- **obsidian.sh** (closes #449): same lazy-resolution pattern via `$OBSIDIAN_BIN` → `$OBSIDIAN_HOME/Obsidian-*.AppImage` → legacy default.
- **pip.sh** (closes #450): `bash` → POSIX shebang; alias body untouched; add `Help: pp-help` pointer comment.
- **python.sh** (closes #451): add `Help: py-help` pointer comment (guard + shebang already in place).
- **uv.sh** (closes #452): `bash` → POSIX shebang. Rename POSIX-illegal `uv-install()` → `uv_install()` and re-expose the dash form as `alias uv-install='uv_install'` (same convention as `nvm.sh`). Add `Help: uv-help` pointer comment.

Cross-cutting: all five files get the FORCE_INIT-aware interactive guard and a normalized header path comment (the `external/` paths were stale from the pre-rename era).

## Hook bug-fix bundled

`git/hooks/checks/library_purity_check.sh` was flagging `alias pp_install='pip install ...'` as a top-level installation. The hook now skips lines matching `^[[:space:]]*alias[[:space:]]+<name>=` so alias definitions are no longer mistaken for runtime installs. Real top-level `pip install …` outside an alias is still caught.

## Test plan

- [x] `shellcheck -x -s sh` on all five files — clean.
- [x] `bash`/`zsh` source-smoke with `DOTFILES_FORCE_INIT=1` — both pass on all five files.
- [x] Direct functional probe of `check_library_purity` on the patched `pip.sh` — rc=0 (no false positive).
- [x] Same probe against a synthetic file with a real top-level `pip install` — still flagged. (verified via local awk run)

Closes #447, #449, #450, #451, #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)