### PR TITLE
refactor(custom): #424 batch C — uninstall_* hardening sweep

### DIFF
--- a/shell-common/tools/custom/uninstall_codex.sh
+++ b/shell-common/tools/custom/uninstall_codex.sh
@@ -1,20 +1,43 @@
 #!/bin/bash
-# mytool/uninstall_codex.sh
+# shell-common/tools/custom/uninstall_codex.sh
 # Codex CLI 제거 스크립트 (대화형)
 
 set -e
 
-# Initialize common tools environment
+usage() {
+    cat <<'EOF'
+Uninstall Codex CLI (@openai/codex) installed as a global npm package.
 
+Usage:
+  uninstall_codex.sh [-h|--help|help] [--dry-run]
+
+Options:
+  -h, --help     Show this help and exit.
+  --dry-run      Print the actions without modifying the system.
+
+Verification (after uninstall):
+  npm list -g --depth=0
+EOF
+}
+
+# Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
-# Main script
+DRY_RUN=0
+case "${1:-}" in
+    help|-h|--help) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    "") ;;
+    *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
+esac
+
 main() {
     clear
     ux_header "Codex CLI Uninstaller"
     ux_info "This script uninstalls the '@openai/codex' global npm package."
     echo ""
     ux_warning "This is a destructive action and will remove the package from your system."
+    [ "$DRY_RUN" = "1" ] && ux_info "(dry-run mode: no commands will execute)"
     echo ""
 
     local codex_package="@openai/codex"
@@ -31,35 +54,37 @@ main() {
     if ! ux_require "npm"; then exit 1; fi
     ux_success "npm is installed."
     echo ""
-    
+
     # ========================================
     # Step 2: Uninstall Codex CLI
     # ========================================
     ux_step "2/2" "Uninstalling ${codex_package}..."
-    if ! command -v codex &>/dev/null; then
+    if ! have_command codex; then
         ux_success "Codex CLI does not appear to be installed. Nothing to do."
+    elif [ "$DRY_RUN" = "1" ]; then
+        ux_info "[dry-run] npm uninstall -g ${codex_package}"
     else
         if ! ux_with_spinner "Uninstalling ${codex_package} via npm" npm uninstall -g "$codex_package"; then
             ux_error "Uninstallation failed. Please check the errors above."
             exit 1
         fi
     fi
-    
+
     # ========================================
     # Completion
     # ========================================
     echo ""
-    ux_header "✅ Codex CLI Uninstallation Complete!"
-    if command -v codex &>/dev/null; then
+    ux_header "Codex CLI Uninstallation Complete"
+    if have_command codex; then
         ux_warning "The 'codex' command still exists. You may need to check your PATH or restart your shell."
     else
         ux_success "The 'codex' command has been successfully removed."
     fi
     echo ""
-    ux_info "To see your remaining global packages, run: ${UX_PRIMARY}npm list -g --depth=0${UX_RESET}"
+    ux_info "Next: npm list -g --depth=0"
     echo ""
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     main "$@"
 fi

--- a/shell-common/tools/custom/uninstall_codex.sh
+++ b/shell-common/tools/custom/uninstall_codex.sh
@@ -24,12 +24,14 @@ EOF
 source "$(dirname "$0")/init.sh" || exit 1
 
 DRY_RUN=0
-case "${1:-}" in
-    help|-h|--help) usage; exit 0 ;;
-    --dry-run) DRY_RUN=1 ;;
-    "") ;;
-    *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        help|-h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1 ;;
+        *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+    shift
+done
 
 main() {
     clear
@@ -74,11 +76,21 @@ main() {
     # Completion
     # ========================================
     echo ""
+    local removal_failures=0
     ux_header "Codex CLI Uninstallation Complete"
     if have_command codex; then
-        ux_warning "The 'codex' command still exists. You may need to check your PATH or restart your shell."
+        ux_warning "The 'codex' command still exists."
+        ux_info "You may need to check your PATH or restart your shell."
+        removal_failures=$((removal_failures + 1))
     else
         ux_success "The 'codex' command has been successfully removed."
+    fi
+
+    if [ "$removal_failures" -eq 0 ]; then
+        ux_success "All removal steps completed cleanly."
+    else
+        ux_warning "Completed with $removal_failures non-fatal warning(s)."
+        ux_info "See output above for details."
     fi
     echo ""
     ux_info "Next: npm list -g --depth=0"

--- a/shell-common/tools/custom/uninstall_docker.sh
+++ b/shell-common/tools/custom/uninstall_docker.sh
@@ -1,14 +1,43 @@
 #!/bin/bash
-# mytool/uninstall_docker.sh
+# shell-common/tools/custom/uninstall_docker.sh
 # WSL Docker 제거 스크립트 (대화형)
 
 set -e
 
-# Initialize common tools environment
+usage() {
+    cat <<'EOF'
+Uninstall Docker Engine, CLI, and Compose (with optional data purge).
 
+Usage:
+  uninstall_docker.sh [-h|--help|help] [--dry-run] [--purge|--keep-data]
+
+Options:
+  -h, --help     Show this help and exit.
+  --dry-run      Print actions without executing them.
+  --purge        Pre-answer "yes" to "Completely purge all Docker data".
+  --keep-data    Pre-answer "no" (default behaviour anyway).
+
+Verification (after uninstall):
+  command -v docker  # expected: not found
+EOF
+}
+
+# Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
-# Main script
+DRY_RUN=0
+FORCE_PURGE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        help|-h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1 ;;
+        --purge) FORCE_PURGE="y" ;;
+        --keep-data) FORCE_PURGE="n" ;;
+        *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
 main() {
     clear
     ux_header "Docker Uninstaller"
@@ -16,6 +45,8 @@ main() {
     echo ""
     ux_warning "This is a destructive action that will remove Docker packages from your system."
     ux_error "A full purge will also delete all images, containers, volumes, and networks."
+    [ "$DRY_RUN" = "1" ] && ux_info "(dry-run mode: no commands will execute)"
+    [ -n "$FORCE_PURGE" ] && ux_info "(pre-answer for purge prompt: $FORCE_PURGE)"
     echo ""
 
     if ! ux_confirm "Are you sure you want to proceed with Docker uninstallation?" "n"; then
@@ -29,32 +60,52 @@ main() {
         ux_error "Sudo privileges are required. Aborting."
         exit 1
     fi
-    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done &> /dev/null &
+    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done >/dev/null 2>&1 &
     local sudo_keep_alive_pid=$!
     trap 'kill "$sudo_keep_alive_pid" 2>/dev/null' EXIT
 
     local docker_packages=(
-        docker-ce docker-ce-cli containerd.io 
+        docker-ce docker-ce-cli containerd.io
         docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
     )
+
+    local removal_failures=0
+    local purge_choice="$FORCE_PURGE"
 
     # ========================================
     # Step 1: Uninstall Docker packages
     # ========================================
     ux_step "1/3" "Uninstalling Docker packages..."
-    if ux_confirm "Completely purge all Docker data (images, volumes, configs)?" "n"; then
-        ux_warning "PURGING all Docker data..."
-        if ! ux_with_spinner "Purging packages and data" sudo apt-get -y purge "${docker_packages[@]}"; then
-            ux_warning "Could not purge all packages. They may not have been installed."
+    if [ -z "$purge_choice" ]; then
+        if ux_confirm "Completely purge all Docker data (images, volumes, configs)?" "n"; then
+            purge_choice="y"
+        else
+            purge_choice="n"
         fi
-        ux_info "Also removing docker data directories..."
-        sudo rm -rf /var/lib/docker
-        sudo rm -rf /var/lib/containerd
-        ux_success "Docker data directories removed."
+    fi
+
+    if [ "$purge_choice" = "y" ]; then
+        ux_warning "PURGING all Docker data..."
+        if [ "$DRY_RUN" = "1" ]; then
+            ux_info "[dry-run] sudo apt-get -y purge ${docker_packages[*]}"
+            ux_info "[dry-run] sudo rm -rf /var/lib/docker /var/lib/containerd"
+        elif ! ux_with_spinner "Purging packages and data" sudo apt-get -y purge "${docker_packages[@]}"; then
+            ux_warning "Could not purge all packages. They may not have been installed."
+            removal_failures=$((removal_failures + 1))
+        fi
+        if [ "$DRY_RUN" != "1" ]; then
+            ux_info "Also removing docker data directories..."
+            sudo rm -rf /var/lib/docker
+            sudo rm -rf /var/lib/containerd
+            ux_success "Docker data directories removed."
+        fi
     else
         ux_info "Performing a standard removal of Docker packages (keeping data)..."
-        if ! ux_with_spinner "Removing apt packages" sudo apt-get -y remove "${docker_packages[@]}"; then
+        if [ "$DRY_RUN" = "1" ]; then
+            ux_info "[dry-run] sudo apt-get -y remove ${docker_packages[*]}"
+        elif ! ux_with_spinner "Removing apt packages" sudo apt-get -y remove "${docker_packages[@]}"; then
             ux_warning "Could not remove all docker packages. They may not have been installed."
+            removal_failures=$((removal_failures + 1))
         fi
     fi
     echo ""
@@ -64,9 +115,14 @@ main() {
     # ========================================
     ux_step "2/3" "Removing Docker repository..."
     if ux_confirm "Remove the Docker APT repository and GPG key?" "y"; then
-        [ -f /etc/apt/sources.list.d/docker.list ] && sudo rm -f /etc/apt/sources.list.d/docker.list && ux_success "Removed docker.list."
-        [ -f /etc/apt/keyrings/docker.gpg ] && sudo rm -f /etc/apt/keyrings/docker.gpg && ux_success "Removed docker.gpg."
-        ux_with_spinner "Updating apt cache" sudo apt-get update -qq
+        if [ "$DRY_RUN" = "1" ]; then
+            ux_info "[dry-run] sudo rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.gpg"
+            ux_info "[dry-run] sudo apt-get update -qq"
+        else
+            [ -f /etc/apt/sources.list.d/docker.list ] && sudo rm -f /etc/apt/sources.list.d/docker.list && ux_success "Removed docker.list."
+            [ -f /etc/apt/keyrings/docker.gpg ] && sudo rm -f /etc/apt/keyrings/docker.gpg && ux_success "Removed docker.gpg."
+            ux_with_spinner "Updating apt cache" sudo apt-get update -qq
+        fi
     else
         ux_info "Skipped removing Docker repository."
     fi
@@ -76,12 +132,15 @@ main() {
     # Step 3: Remove docker group
     # ========================================
     ux_step "3/3" "Removing docker group..."
-    if getent group docker > /dev/null; then
+    if getent group docker >/dev/null 2>&1; then
         if ux_confirm "Remove the 'docker' user group?" "n"; then
-            if sudo groupdel docker; then
+            if [ "$DRY_RUN" = "1" ]; then
+                ux_info "[dry-run] sudo groupdel docker"
+            elif sudo groupdel docker; then
                 ux_success "Removed 'docker' group."
             else
                 ux_warning "Failed to remove 'docker' group. Is any user still a member?"
+                removal_failures=$((removal_failures + 1))
             fi
         fi
     fi
@@ -94,15 +153,23 @@ main() {
     # ========================================
     # Completion
     # ========================================
-    ux_header "✅ Docker Uninstallation Complete!"
-    if command -v docker &> /dev/null; then
+    ux_header "Docker Uninstallation Complete"
+    if have_command docker; then
         ux_warning "The 'docker' command still exists. You may need to check your PATH or restart your shell."
+        removal_failures=$((removal_failures + 1))
     else
         ux_success "The 'docker' command has been successfully removed."
     fi
+    if [ "$removal_failures" -eq 0 ]; then
+        ux_success "All removal steps completed cleanly."
+    else
+        ux_warning "Completed with $removal_failures non-fatal warning(s) — see output above."
+    fi
+    echo ""
+    ux_info "Next: command -v docker  # expected: not found"
     echo ""
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     main "$@"
 fi

--- a/shell-common/tools/custom/uninstall_gemini.sh
+++ b/shell-common/tools/custom/uninstall_gemini.sh
@@ -1,20 +1,43 @@
 #!/bin/bash
-# mytool/uninstall_gemini.sh
+# shell-common/tools/custom/uninstall_gemini.sh
 # Gemini CLI 제거 스크립트 (대화형)
 
 set -e
 
-# Initialize common tools environment
+usage() {
+    cat <<'EOF'
+Uninstall Gemini CLI (@google/gemini-cli) installed as a global npm package.
 
+Usage:
+  uninstall_gemini.sh [-h|--help|help] [--dry-run]
+
+Options:
+  -h, --help     Show this help and exit.
+  --dry-run      Print the actions without modifying the system.
+
+Verification (after uninstall):
+  npm list -g --depth=0
+EOF
+}
+
+# Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
-# Main script
+DRY_RUN=0
+case "${1:-}" in
+    help|-h|--help) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    "") ;;
+    *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
+esac
+
 main() {
     clear
     ux_header "Gemini CLI Uninstaller"
     ux_info "This script uninstalls the '@google/gemini-cli' global npm package."
     echo ""
     ux_warning "This is a destructive action that will remove the package from your system."
+    [ "$DRY_RUN" = "1" ] && ux_info "(dry-run mode: no commands will execute)"
     echo ""
 
     local gemini_package="@google/gemini-cli"
@@ -31,35 +54,37 @@ main() {
     if ! ux_require "npm"; then exit 1; fi
     ux_success "npm is installed."
     echo ""
-    
+
     # ========================================
     # Step 2: Uninstall Gemini CLI
     # ========================================
     ux_step "2/2" "Uninstalling ${gemini_package}..."
-    if ! command -v gemini &>/dev/null; then
+    if ! have_command gemini; then
         ux_success "Gemini CLI does not appear to be installed. Nothing to do."
+    elif [ "$DRY_RUN" = "1" ]; then
+        ux_info "[dry-run] npm uninstall -g ${gemini_package}"
     else
         if ! ux_with_spinner "Uninstalling ${gemini_package} via npm" npm uninstall -g "$gemini_package"; then
             ux_error "Uninstallation failed. Please check the errors above."
             exit 1
         fi
     fi
-    
+
     # ========================================
     # Completion
     # ========================================
     echo ""
-    ux_header "✅ Gemini CLI Uninstallation Complete!"
-    if command -v gemini &>/dev/null; then
+    ux_header "Gemini CLI Uninstallation Complete"
+    if have_command gemini; then
         ux_warning "The 'gemini' command still exists. You may need to check your PATH or restart your shell."
     else
         ux_success "The 'gemini' command has been successfully removed."
     fi
     echo ""
-    ux_info "To see your remaining global packages, run: ${UX_PRIMARY}npm list -g --depth=0${UX_RESET}"
+    ux_info "Next: npm list -g --depth=0"
     echo ""
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     main "$@"
 fi

--- a/shell-common/tools/custom/uninstall_gemini.sh
+++ b/shell-common/tools/custom/uninstall_gemini.sh
@@ -24,12 +24,14 @@ EOF
 source "$(dirname "$0")/init.sh" || exit 1
 
 DRY_RUN=0
-case "${1:-}" in
-    help|-h|--help) usage; exit 0 ;;
-    --dry-run) DRY_RUN=1 ;;
-    "") ;;
-    *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        help|-h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1 ;;
+        *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+    shift
+done
 
 main() {
     clear
@@ -74,11 +76,21 @@ main() {
     # Completion
     # ========================================
     echo ""
+    local removal_failures=0
     ux_header "Gemini CLI Uninstallation Complete"
     if have_command gemini; then
-        ux_warning "The 'gemini' command still exists. You may need to check your PATH or restart your shell."
+        ux_warning "The 'gemini' command still exists."
+        ux_info "You may need to check your PATH or restart your shell."
+        removal_failures=$((removal_failures + 1))
     else
         ux_success "The 'gemini' command has been successfully removed."
+    fi
+
+    if [ "$removal_failures" -eq 0 ]; then
+        ux_success "All removal steps completed cleanly."
+    else
+        ux_warning "Completed with $removal_failures non-fatal warning(s)."
+        ux_info "See output above for details."
     fi
     echo ""
     ux_info "Next: npm list -g --depth=0"

--- a/shell-common/tools/custom/uninstall_npm.sh
+++ b/shell-common/tools/custom/uninstall_npm.sh
@@ -18,7 +18,7 @@ Options:
                   and ~/.npmrc.
 
 Verification (after uninstall):
-  hash -r && command -v node && command -v npm
+  hash -r && command -v node && command -v npm  # expected: not found
 EOF
 }
 

--- a/shell-common/tools/custom/uninstall_npm.sh
+++ b/shell-common/tools/custom/uninstall_npm.sh
@@ -1,14 +1,42 @@
 #!/bin/bash
-# mytool/uninstall_npm.sh
+# shell-common/tools/custom/uninstall_npm.sh
 # Node.js & npm 제거 스크립트 (대화형)
 
 set -e
 
-# Initialize common tools environment
+usage() {
+    cat <<'EOF'
+Uninstall apt-installed Node.js / npm and optionally their user config.
 
+Usage:
+  uninstall_npm.sh [-h|--help|help] [--dry-run] [--keep-config]
+
+Options:
+  -h, --help      Show this help and exit.
+  --dry-run       Print actions without executing them.
+  --keep-config   Skip the prompts that remove ~/.npm-global, ~/.npm,
+                  and ~/.npmrc.
+
+Verification (after uninstall):
+  hash -r && command -v node && command -v npm
+EOF
+}
+
+# Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
-# Main script
+DRY_RUN=0
+KEEP_CONFIG=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        help|-h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1 ;;
+        --keep-config) KEEP_CONFIG=1 ;;
+        *) ux_error "Unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
 main() {
     clear
     ux_header "Node.js & npm Uninstaller"
@@ -16,6 +44,8 @@ main() {
     echo ""
     ux_warning "This is a destructive action."
     ux_error "This can also remove your global npm packages and configuration files."
+    [ "$DRY_RUN" = "1" ] && ux_info "(dry-run mode: no commands will execute)"
+    [ "$KEEP_CONFIG" = "1" ] && ux_info "(--keep-config: skipping config removal prompts)"
     echo ""
 
     if ! ux_confirm "Are you sure you want to uninstall the Node.js and npm apt packages?" "n"; then
@@ -29,22 +59,29 @@ main() {
         ux_error "Sudo privileges are required. Aborting."
         exit 1
     fi
-    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done &> /dev/null &
+    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done >/dev/null 2>&1 &
     local sudo_keep_alive_pid=$!
     trap 'kill "$sudo_keep_alive_pid" 2>/dev/null' EXIT
+
+    local removal_failures=0
 
     # ========================================
     # Step 1: Remove Node.js & npm packages
     # ========================================
     ux_step "1/3" "Uninstalling Node.js and npm packages..."
-    if ! ux_with_spinner "Removing nodejs and npm apt packages" sudo apt-get remove -y nodejs npm; then
+    if [ "$DRY_RUN" = "1" ]; then
+        ux_info "[dry-run] sudo apt-get remove -y nodejs npm"
+    elif ! ux_with_spinner "Removing nodejs and npm apt packages" sudo apt-get remove -y nodejs npm; then
         ux_warning "Could not remove nodejs and npm packages. They may not have been installed."
+        removal_failures=$((removal_failures + 1))
     else
         ux_success "Node.js and npm packages removed."
     fi
-    
+
     if ux_confirm "Run 'apt-get autoremove' to clean up unused dependencies?" "y"; then
-        if ! ux_with_spinner "Autoremoving unused dependencies" sudo apt-get autoremove -y; then
+        if [ "$DRY_RUN" = "1" ]; then
+            ux_info "[dry-run] sudo apt-get autoremove -y"
+        elif ! ux_with_spinner "Autoremoving unused dependencies" sudo apt-get autoremove -y; then
             ux_warning "apt autoremove failed."
         fi
     fi
@@ -54,17 +91,33 @@ main() {
     # Step 2: Clean npm configuration
     # ========================================
     ux_step "2/3" "Cleaning up npm configuration and data..."
-    if [ -d "$HOME/.npm-global" ] && ux_confirm "Remove user-level global packages directory (~/.npm-global)?" "n"; then
-        rm -rf "$HOME/.npm-global"
-        ux_success "Removed ~/.npm-global directory."
-    fi
-    if [ -d "$HOME/.npm" ] && ux_confirm "Remove npm cache directory (~/.npm)?" "n"; then
-        rm -rf "$HOME/.npm"
-        ux_success "Removed ~/.npm directory."
-    fi
-    if [ -f "$HOME/.npmrc" ] && ux_confirm "Remove npm configuration file (~/.npmrc)?" "n"; then
-        rm -f "$HOME/.npmrc"
-        ux_success "Removed ~/.npmrc file."
+    if [ "$KEEP_CONFIG" = "1" ]; then
+        ux_info "Skipping config removal (--keep-config)."
+    else
+        if [ -d "$HOME/.npm-global" ] && ux_confirm "Remove user-level global packages directory (~/.npm-global)?" "n"; then
+            if [ "$DRY_RUN" = "1" ]; then
+                ux_info "[dry-run] rm -rf $HOME/.npm-global"
+            else
+                rm -rf "$HOME/.npm-global"
+                ux_success "Removed ~/.npm-global directory."
+            fi
+        fi
+        if [ -d "$HOME/.npm" ] && ux_confirm "Remove npm cache directory (~/.npm)?" "n"; then
+            if [ "$DRY_RUN" = "1" ]; then
+                ux_info "[dry-run] rm -rf $HOME/.npm"
+            else
+                rm -rf "$HOME/.npm"
+                ux_success "Removed ~/.npm directory."
+            fi
+        fi
+        if [ -f "$HOME/.npmrc" ] && ux_confirm "Remove npm configuration file (~/.npmrc)?" "n"; then
+            if [ "$DRY_RUN" = "1" ]; then
+                ux_info "[dry-run] rm -f $HOME/.npmrc"
+            else
+                rm -f "$HOME/.npmrc"
+                ux_success "Removed ~/.npmrc file."
+            fi
+        fi
     fi
     echo ""
 
@@ -72,11 +125,12 @@ main() {
     # Step 3: Verify uninstallation
     # ========================================
     ux_step "3/3" "Verifying uninstallation..."
-    if command -v node &>/dev/null || command -v npm &>/dev/null; then
+    if have_command node || have_command npm; then
         ux_warning "A 'node' or 'npm' command still exists."
         ux_info "This could be from NVM or another installation method. Check your PATH."
         command -v node || true
         command -v npm || true
+        removal_failures=$((removal_failures + 1))
     else
         ux_success "Node.js and npm have been successfully removed from apt."
     fi
@@ -89,10 +143,17 @@ main() {
     # Completion
     # ========================================
     echo ""
-    ux_header "✅ Node.js & npm Uninstallation Complete!"
+    ux_header "Node.js & npm Uninstallation Complete"
+    if [ "$removal_failures" -eq 0 ]; then
+        ux_success "All removal steps completed cleanly."
+    else
+        ux_warning "Completed with $removal_failures non-fatal warning(s) — see output above."
+    fi
+    echo ""
+    ux_info "Next: hash -r && command -v node && command -v npm"
     echo ""
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     main "$@"
 fi


### PR DESCRIPTION
## Summary

Batch C of the #424 `sh:check` audit follow-up — uniform hardening of the four `shell-common/tools/custom/uninstall_*.sh` scripts.

## Cross-cutting changes (all 4 files)

- **argparse + help**: top-level `usage()` plus `-h|--help|help` and `--dry-run`. `uninstall_npm.sh` adds `--keep-config`; `uninstall_docker.sh` adds `--purge|--keep-data`. Unknown args → exit 2.
- **POSIX redirects**: `&>/dev/null` → `>/dev/null 2>&1`.
- **Project helper**: `command -v X &>/dev/null` → `have_command X` (from init.sh).
- **Emoji removal**: `✅` glyph removed from completion headers per CLAUDE.md.
- **Structured verdict**: `removal_failures` counter at the end — `ux_success` when zero, `ux_warning` with the count otherwise.
- **`Next:` hint**: standardized via `ux_info`.
- **Foot-guard**: `[ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]` → `[ "${BASH_SOURCE[0]:-$0}" = "$0" ]` (fixes shellcheck SC2128).

Default interactive behaviour is unchanged — new options are purely additive.

## Test plan

- [x] `shellcheck -x` on all four files — clean.
- [x] `bash uninstall_<name>.sh -h` prints structured help on all four.

Closes #443, #444, #445, #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)