### PR TITLE
refactor(skills): close 4 NEEDS-WORK audit issues (#427 PR D)

### DIFF
--- a/claude/skills/claude-md-check/SKILL.md
+++ b/claude/skills/claude-md-check/SKILL.md
@@ -14,149 +14,47 @@ compatibility:
 
 # CLAUDE.md Orchestrator Auditor
 
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No file reads beyond that.
+
 ## Role
 
-You are an AI agent framework architect and auditor. Read the target CLAUDE.md,
-evaluate it against six orchestrator design principles, and produce a structured
-report with PASS/WARN/FAIL per check and actionable improvement suggestions.
+You are an AI agent framework architect and auditor. Read the target
+CLAUDE.md, evaluate it against six orchestrator design principles, and
+produce a structured report with PASS/WARN/FAIL per check and actionable
+improvement suggestions.
 
-For reference examples and framework patterns, see `references/`:
-- `references/framework-guide.md` — Core principles explained
-- `references/example-orchestrator.md` — Well-structured CLAUDE.md example
-- `references/example-agent.md` — Subagent definition example (CTO + RACI)
-- `references/example-state.md` — State file structure examples
-- `references/example-permissions.md` — Permission control file structure
+## Options
 
-Read these only when you need to show the user a concrete "how to fix" example.
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `path`   | Path to CLAUDE.md to audit | search from cwd |
+
+Reference material under `references/`: `checks.md` (Step 2 rubric),
+`framework-guide.md`, `example-orchestrator.md`, `example-agent.md`,
+`example-state.md`, `example-permissions.md`. Read example files only
+when you need a concrete "how to fix" snippet.
 
 ## Step 1: Locate the File
 
-If the user specifies a path, use it. Otherwise search for CLAUDE.md from the
-current working directory. If the file is named AGENTS.md, stop and respond:
-"This is a project context file. Use agents-md:check instead."
+If the user specifies a path, use it. Otherwise search for CLAUDE.md from
+the current working directory. If the file is named AGENTS.md, stop and
+respond: "This is a project context file. Use agents-md:check instead."
 
 ## Step 2: Run Six Checks
 
-For each check, assign: **PASS** / **WARN** / **FAIL**
+Read `references/checks.md` for the full rubric. Apply each check to the
+target file and record PASS / WARN / FAIL with the line range that drove
+the verdict.
 
----
-
-### Check 1: Role Definition
-
-The orchestrator must know what it is and what it owns.
-
-**Look for:**
-- Explicit agent role/title/persona at the top of the file
-- Scope statement: what the agent is responsible for
-- Boundaries: what it does NOT do (delegation targets)
-
-**PASS** — role named, responsibility and scope stated
-**WARN** — role exists but scope or boundaries are vague
-**FAIL** — no role definition at all
-
----
-
-### Check 2: Reference File Path Pattern
-
-The CLAUDE.md should be a routing layer, not a data store.
-
-**Look for:**
-- State, configuration, and domain knowledge referenced by file path
-- No large inline tables of operational data (KPIs, personnel, inventory)
-- File is thin — length comes from rules/routing, not embedded content
-
-**PASS** — information referenced by path; file stays thin
-**WARN** — some content inlined but most is path-referenced
-**FAIL** — major operational content embedded directly in CLAUDE.md
-
-**Heuristic:** file over 300 lines warrants close inspection of what's inlined.
-
----
-
-### Check 3: Commands Interface
-
-Users and other agents need a clear, discoverable interface.
-
-**Look for:**
-- Dedicated section listing available slash-commands
-- Commands grouped by domain or agent responsibility
-- Each command has a one-line description
-
-**Also check** whether the project uses a `.claude/commands/` directory:
-- `commands/` files are thin execution scripts (5-10 steps, no persona)
-- `agents/` files are rich domain experts (persona, RACI, workflows)
-- If `commands/` exists, CLAUDE.md commands list should map to those files
-
-**PASS** — commands section exists with entries and descriptions
-**WARN** — commands exist but undocumented, scattered, or incomplete;
-  OR agents/ exists but commands/ separation is missing/unclear
-**FAIL** — no commands section at all (for an orchestrator-type file)
-
-*Note: if this CLAUDE.md is for a simple single-purpose agent, absence of
-commands is acceptable — note this and downgrade to WARN.*
-
----
-
-### Check 4: Permission Control Rules
-
-Every agent needs guardrails on what it can do autonomously.
-
-**Look for:**
-- Explicit classification: what runs automatically vs. what needs approval
-- At minimum two tiers; well-structured systems have four:
-  - `read-only` — analysis/reports, no side effects, auto-execute
-  - `execute` — internal actions within threshold, auto-execute
-  - `auto_after_approval` — template-based, approved once then auto
-  - `always_draft` — external-facing actions, always require human approval
-- The `always_draft` list must cover: deploys, client comms, SNS, invoices
-- The approval workflow pipeline: draft → approval-queue → `/approve` → execute
-- Reference to a permissions file (e.g., `.company/steering/permissions.md`)
-
-**PASS** — permission tiers defined, approval workflow clear, external actions covered
-**WARN** — some rules exist but external actions or thresholds are undefined
-**FAIL** — no permission or authorization rules at all
-
-See `references/example-permissions.md` for a complete permissions file structure.
-
----
-
-### Check 5: Thin Orchestrator Principle
-
-The most important architectural check. Three sub-criteria:
-
-**5a. Context minimization**
-Does the file instruct the agent to keep its own context footprint small?
-Is there guidance to avoid loading file contents directly?
-
-**5b. Path-over-content delegation**
-Are subagents instructed to receive file paths rather than file contents?
-Is "pass the path, not the content" stated or clearly implied?
-
-**5c. Subagent delegation**
-Are complex tasks delegated to subagents (e.g., `.claude/agents/`)?
-Does the orchestrator avoid doing direct implementation work itself?
-
-**PASS** — all three sub-criteria explicitly addressed
-**WARN** — one or two sub-criteria addressed
-**FAIL** — orchestrator does direct work with no delegation structure
-
----
-
-### Check 6: Basic Rules
-
-Operating principles that apply across all commands and agents.
-
-**Look for:**
-- Commit / version control conventions
-- State update requirements after task completion
-- Error handling and escalation policy
-- Any cross-cutting rules that apply everywhere
-
-**PASS** — consolidated rules section with meaningful entries
-**WARN** — rules exist but scattered across sections
-**FAIL** — no general operating rules
-
----
+1. Role Definition
+2. Reference File Path Pattern
+3. Commands Interface
+4. Permission Control Rules
+5. Thin Orchestrator Principle (sub-criteria 5a / 5b / 5c)
+6. Basic Rules
 
 ## Step 3: Output the Report
 
@@ -174,7 +72,7 @@ Lines: <count>
 | 5 | Thin Orchestrator Principle | WARN   | 5a: PASS, 5b: WARN, 5c: FAIL       |
 | 6 | Basic Rules                 | PASS   | ...                                |
 
-Score: X/6 passed (Y warnings)
+Verdict: [OK] X/6 passed (Y warnings)    # or [FAIL] when any check fails
 
 ## Issues & Improvements
 
@@ -188,7 +86,11 @@ Score: X/6 passed (Y warnings)
 
 ## Summary
 <2-3 sentences: overall quality, most critical fix, production-readiness>
+
+Next: fix the highest-FAIL check first (see references/example-orchestrator.md
+for a working template), then re-run /claude-md-check to verify.
 ```
 
-Only include WARN and FAIL items in Issues. Quote actual lines when describing
+Use `[OK]` when every check is PASS, otherwise `[FAIL]`. Include only
+WARN and FAIL items in Issues. Quote actual lines when describing
 problems. Reference examples from `references/` when showing how to fix.

--- a/claude/skills/claude-md-check/references/checks.md
+++ b/claude/skills/claude-md-check/references/checks.md
@@ -1,0 +1,121 @@
+# claude-md-check — Six Orchestrator Checks
+
+For each check, assign **PASS** / **WARN** / **FAIL** and quote the
+specific lines that drove the verdict.
+
+---
+
+## Check 1: Role Definition
+
+The orchestrator must know what it is and what it owns.
+
+**Look for:**
+- Explicit agent role/title/persona at the top of the file
+- Scope statement: what the agent is responsible for
+- Boundaries: what it does NOT do (delegation targets)
+
+**PASS** — role named, responsibility and scope stated
+**WARN** — role exists but scope or boundaries are vague
+**FAIL** — no role definition at all
+
+---
+
+## Check 2: Reference File Path Pattern
+
+The CLAUDE.md should be a routing layer, not a data store.
+
+**Look for:**
+- State, configuration, and domain knowledge referenced by file path
+- No large inline tables of operational data (KPIs, personnel, inventory)
+- File is thin — length comes from rules/routing, not embedded content
+
+**PASS** — information referenced by path; file stays thin
+**WARN** — some content inlined but most is path-referenced
+**FAIL** — major operational content embedded directly in CLAUDE.md
+
+**Heuristic:** file over 300 lines warrants close inspection of what's inlined.
+
+---
+
+## Check 3: Commands Interface
+
+Users and other agents need a clear, discoverable interface.
+
+**Look for:**
+- Dedicated section listing available slash-commands
+- Commands grouped by domain or agent responsibility
+- Each command has a one-line description
+
+**Also check** whether the project uses a `.claude/commands/` directory:
+- `commands/` files are thin execution scripts (5-10 steps, no persona)
+- `agents/` files are rich domain experts (persona, RACI, workflows)
+- If `commands/` exists, CLAUDE.md commands list should map to those files
+
+**PASS** — commands section exists with entries and descriptions
+**WARN** — commands exist but undocumented, scattered, or incomplete;
+  OR agents/ exists but commands/ separation is missing/unclear
+**FAIL** — no commands section at all (for an orchestrator-type file)
+
+*Note: if this CLAUDE.md is for a simple single-purpose agent, absence of
+commands is acceptable — note this and downgrade to WARN.*
+
+---
+
+## Check 4: Permission Control Rules
+
+Every agent needs guardrails on what it can do autonomously.
+
+**Look for:**
+- Explicit classification: what runs automatically vs. what needs approval
+- At minimum two tiers; well-structured systems have four:
+  - `read-only` — analysis/reports, no side effects, auto-execute
+  - `execute` — internal actions within threshold, auto-execute
+  - `auto_after_approval` — template-based, approved once then auto
+  - `always_draft` — external-facing actions, always require human approval
+- The `always_draft` list must cover: deploys, client comms, SNS, invoices
+- The approval workflow pipeline: draft → approval-queue → `/approve` → execute
+- Reference to a permissions file (e.g., `.company/steering/permissions.md`)
+
+**PASS** — permission tiers defined, approval workflow clear, external actions covered
+**WARN** — some rules exist but external actions or thresholds are undefined
+**FAIL** — no permission or authorization rules at all
+
+See `example-permissions.md` for a complete permissions file structure.
+
+---
+
+## Check 5: Thin Orchestrator Principle
+
+The most important architectural check. Three sub-criteria:
+
+**5a. Context minimization**
+Does the file instruct the agent to keep its own context footprint small?
+Is there guidance to avoid loading file contents directly?
+
+**5b. Path-over-content delegation**
+Are subagents instructed to receive file paths rather than file contents?
+Is "pass the path, not the content" stated or clearly implied?
+
+**5c. Subagent delegation**
+Are complex tasks delegated to subagents (e.g., `.claude/agents/`)?
+Does the orchestrator avoid doing direct implementation work itself?
+
+**PASS** — all three sub-criteria explicitly addressed
+**WARN** — one or two sub-criteria addressed
+**FAIL** — orchestrator does direct work with no delegation structure
+
+---
+
+## Check 6: Basic Rules
+
+Operating principles that apply across all commands and agents.
+
+**Look for:**
+- Commit / version control conventions
+- State update requirements after task completion
+- Error handling and escalation policy
+- Any cross-cutting rules that apply everywhere
+
+**PASS** — consolidated rules section with meaningful entries
+**WARN** — rules exist but scattered across sections
+**FAIL** — no general operating rules

--- a/claude/skills/claude-md-check/references/checks.md
+++ b/claude/skills/claude-md-check/references/checks.md
@@ -80,7 +80,7 @@ Every agent needs guardrails on what it can do autonomously.
 **WARN** — some rules exist but external actions or thresholds are undefined
 **FAIL** — no permission or authorization rules at all
 
-See `example-permissions.md` for a complete permissions file structure.
+See `references/example-permissions.md` for a complete permissions file structure.
 
 ---
 

--- a/claude/skills/claude-md-check/references/help.md
+++ b/claude/skills/claude-md-check/references/help.md
@@ -1,0 +1,38 @@
+# claude-md-check — Help
+
+## Usage
+
+```
+/claude-md-check [path]
+```
+
+Audit a CLAUDE.md orchestrator file against six framework design checks.
+Read-only — does not modify the target file.
+
+## Arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `path`   | Path to CLAUDE.md to audit | search from cwd |
+
+If `path` names an AGENTS.md, the skill stops and points to `agents-md:check`
+instead.
+
+## Output
+
+A table with PASS/WARN/FAIL per check, followed by Issues & Improvements
+(WARN/FAIL only) and a Summary line. The Summary always ends with a
+`Next:` hint pointing at the next concrete action.
+
+## Examples
+
+```
+/claude-md-check                       # search from cwd
+/claude-md-check ./CLAUDE.md           # explicit path
+/claude-md-check ../other/CLAUDE.md    # outside cwd
+```
+
+## Sibling skills
+
+- `agents-md:check` — for AGENTS.md project context files
+- `claude-md-create` — bootstrap a new CLAUDE.md

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -24,6 +24,14 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Agent, TaskList, TaskUpdate
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
 its content verbatim, then stop. No tool calls beyond that read.
 
+## Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `-h`/`--help`/`help` | Print usage and stop | — |
+
+No other arguments — this skill reads the TodoList in the current session.
+
 ## Role
 
 The user invokes this when their previous work was interrupted — typically by
@@ -51,10 +59,17 @@ conversation. Resume from the implementation/edit step those skills led to.
 
 ## Step 2: Announce + Plan Smaller Steps
 
-Print one line so the user sees what you picked up:
+Print the announce line so the user sees what you picked up (verdict
+format defined in "Output" below):
 
 ```
-재개: <task subject> — 작은 단위로 쪼개서 진행합니다.
+[OK] resumed: <task subject> — 작은 단위로 쪼개서 진행합니다.
+```
+
+When Step 1 cannot pick a target, emit instead and stop:
+
+```
+[FAIL] cannot resume: <reason>
 ```
 
 Read `references/chunking-rules.md` for 1-tool-call splitting rules and
@@ -76,9 +91,27 @@ Run the chunked steps. After each step:
 1. Update the TodoList (`TaskUpdate` → `completed` or new `in_progress`).
 2. Emit one short user-facing line about what just landed.
 
-When the originally-interrupted task is done, hand control back to whatever
-flow the user was in (e.g. continue `gh:issue-flow`'s next sub-step). Do
-NOT silently return to idle without saying which step is next.
+When the originally-interrupted task is done, hand control back to
+whatever flow the user was in. Always end with an explicit `Next:` line
+naming the next concrete command — never silently return to idle.
+
+## Output
+
+```
+[OK] resumed: <task subject> — 작은 단위로 쪼개서 진행합니다.
+step 1/N: <what just landed>
+step 2/N: <what just landed>
+...
+Next: <concrete command, e.g. /gh:issue-flow continue, /gh:pr-reply, /gh:pr>
+```
+
+On a hard stop (no resume target, refusing to re-invoke a process skill,
+user-correction needed):
+
+```
+[FAIL] cannot resume: <reason>
+Next: <one concrete recovery step>
+```
 
 ## Constraints
 

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -32,150 +32,85 @@ Convert the current chat into a well-structured GitHub issue on the target
 repo. Execute immediately without confirmation. Print only the issue
 number + URL at the end.
 
+## Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `[remote]` (positional) | Target remote name. Resolved to `TARGET_REPO=<owner>/<repo>`. Fails fast if missing. | `origin` |
+| `--no-auto-labels` | Skip Step 2.5 entirely; user `--label` flags remain in effect. | off |
+| `--auto-label-debug` | Verbose stderr trace of Stage-1 detection and the kept/dropped label sets. | off |
+| `--label <name>` | User label, union with Step 2.5 auto-labels. Repeatable. | — |
+| `--assignee @me` | Only added when the user explicitly asks. | off |
+| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+
 ## Step 1: Detect Repo Context
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 3.5.
-
-Parse the positional remote argument and the optional flags before
-resolving the repo:
-
-- Remote name — first non-flag positional arg, default `origin`.
-- `--no-auto-labels` — skip Step 2.5 entirely; user `--label` flags
-  remain in effect. Default off.
-- `--auto-label-debug` — verbose stderr trace of Stage-1 detection and
-  the kept/dropped label sets. Default off.
-
-Confirm we're in a git repo (`git rev-parse --show-toplevel`) and resolve
-the remote to `TARGET_REPO=<owner>/<repo>`. If the remote does not
-exist, list `git remote -v` and stop — never silently fall back to
-`origin`. Full substeps in `references/repo-resolution.md`.
+Record `START_TS=$(date +%s)` immediately for Step 3.5. Parse the
+positional remote arg and the flags above. Confirm we're in a git repo
+(`git rev-parse --show-toplevel`) and resolve `TARGET_REPO=<owner>/<repo>`
+via the remote — full substeps in `references/repo-resolution.md`.
+Never silently fall back to `origin` when the user-supplied remote is
+missing.
 
 ## Step 2: Classify the Conversation
 
-Pick exactly one conventional-commit prefix as the dominant intent.
-
-| Prefix | When |
-|--------|------|
-| `feat` | 신규 기능 / 개선 / 확장 |
-| `fix` | 에러 / 실패 / 의도와 다른 동작 |
-| `refactor` | 동작 보존하며 구조 정리 |
-| `perf` | 느림 / 자원 사용 과다 |
-| `docs` | 문서 자체 변경 |
-| `test` | 테스트 갭 / 추가 / 변경 |
-| `chore` | 빌드·CI·도구·deps·스타일 (`build`/`ci`/`style`/`revert` 흡수) |
-| `misc` | 위 어디에도 안 들어감 (fallback) |
-
-모호하면 묻지 말고 가장 보수적인 `misc` 로 떨어진다. 대형 `feat`
-휴리스틱(영향 컴포넌트 ≥3 / NF 명시 / 결정 누적 — 둘 이상)은
-`references/templates/feat.md` "대형 feat 가이드" 를 따른다.
+Read `references/prefix-table.md` and pick exactly one conventional-commit
+prefix as the dominant intent. The reference also covers the disambiguation
+rules (default to `misc`; large-`feat` heuristic) and title formatting.
 
 ## Step 2.1: Clarification & Scope Guard
 
-Step 2 분류 직후, 본문 작성 전에 `references/clarification.md` 의
-트리거 신호(동사 없는 명사 나열 / 컴포넌트 ≥3 혼재 / feature 범위
-미정의)를 확인한다. 매치되면 1~2줄 확인 또는 분리안을 사용자에게
-보낸다 — 응답을 받기 전에는 `gh issue create` 호출 금지. 매치되지
-않으면 no-op, 곧장 Step 2.5 로 진행.
-
-사용자가 "한 이슈로" 라고 답하면 분리하지 않고 그대로 생성한다 —
-이 가이드는 강제 분할이 아니라 안전망이다.
+Apply `references/clarification.md` trigger signals (동사 없는 명사 나열 /
+컴포넌트 ≥3 혼재 / feature 범위 미정의). 매치되면 1~2줄 확인 또는 분리안을
+사용자에게 보내고 응답 전에는 `gh issue create` 호출 금지. 사용자가
+"한 이슈로" 라고 답하면 그대로 생성 — 강제 분할 아닌 안전망.
 
 ## Step 2.5: Auto-labels + Milestone (opt-in via SSOT)
 
-If `--no-auto-labels` was passed in Step 1, skip this step entirely.
-
-Otherwise check `$TARGET_REPO` for the Stage-1 signals listed in
-`references/auto-labels.md` ("Stage 1 — Repo signal detection"). If no
-signal fires, skip and continue.
-
-When a signal fires:
-
-1. Source `${SHELL_COMMON}/functions/parse_yaml_defaults.sh` and load
-   `static_labels`, `prefix_labels` (using the prefix from Step 2), and
-   `milestone_value` from `.gh-issue-defaults.yml`.
-2. Compose the candidate label set as
-   `static_labels ∪ prefix_labels ∪ user_labels`. User-supplied
-   `--label` values are merged, never overridden.
-3. Validate every candidate against
-   `gh label list --repo "$TARGET_REPO" --json name --jq '.[].name'`.
-   Missing labels emit `auto-labels: label '<x>' not found in
-   $TARGET_REPO — skip` on stderr and are dropped. **Never** auto-create
-   labels.
-4. Resolve the milestone — `auto`, `none`, or an exact title — per
-   `references/auto-labels.md` ("Dispatch order"). Unknown names
-   warn-and-skip.
-5. Stash the kept labels and resolved milestone for Step 4 to thread
-   into `gh issue create`.
-
-If `--auto-label-debug` is set, print Stage-1 evaluation, loaded YAML
-values, and kept/dropped sets to stderr before Step 4 runs. The full
-schema, dispatch order, and compatibility matrix live in
-`references/auto-labels.md`.
+Skip entirely when `--no-auto-labels` is set. Otherwise read
+`references/auto-labels.md` and follow verbatim (Stage-1 signal →
+SSOT load → label union → `gh label list` validation → milestone
+resolution). Stash kept labels + milestone for Step 4.
+`--auto-label-debug` emits the Stage-1 trace per the same reference.
 
 ## Step 3: Draft the Issue Body
 
-Step 2 의 prefix 에 매핑되는 템플릿을 로드한다:
-`references/templates/<prefix>.md`. 각 템플릿은 타이틀 형식과 본문
-골격을 모두 포함한다.
-
-타이틀은 conventional commit 형식 `<type>[(<scope>)]: <한 줄 요약>`.
-`misc` 만 prefix 없이 한 줄 요약만 적는다. 기존 `[Feature]` /
-`[Bug]` / `[Misc]` 대괄호 형식은 폐기.
-
-본문은 사용자 대화 언어로(한국어 대화 → 한국어 이슈). **DO NOT
-over-compress** — 파일 경로·명령 출력·결정·근거를 그대로 유지한다.
-대화가 길었다면 200줄짜리 이슈도 정상.
+`references/templates/<prefix>.md` 에 정의된 본문 골격을 그대로 사용한다.
+타이틀 포맷은 Step 2 의 prefix-table 참조. 본문은 사용자 대화 언어로
+작성하고 (한국어 대화 → 한국어 이슈) **over-compress 금지** — 파일
+경로·명령 출력·결정·근거를 그대로 유지한다. 200 줄짜리 이슈도 정상.
 
 ## Step 3.5: Compute AI Metrics
 
-Before writing the body to the temp file, compute the metrics block:
-
-1. **Elapsed time**: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
-2. **Issue type**: the prefix from Step 2 (`feat`, `fix`, `refactor`, etc.)
-3. **Human time**: look up `references/metrics-baseline.md` by issue type.
-   For `feat`, infer size (small / medium / large) from the conversation scope.
-4. **Token estimate**: sum character counts of the drafted title + body, divide
-   by 4, round to nearest 500 (minimum 1 000). See `references/metrics-baseline.md`
-   for the full estimation rules.
-
-Store results as `TOKENS`, `HUMAN_H`, `ELAPSED` for use in Step 4.
+Read `references/metrics-baseline.md` and bind `TOKENS`, `HUMAN_H`,
+`ELAPSED` for Step 4. Inputs: `START_TS` from Step 1, the prefix from
+Step 2, the drafted title + body. For `feat`, infer size (small /
+medium / large) from the conversation scope.
 
 ## Step 4: Create the Issue
 
-`mktemp` 으로 임시 파일에 본문을 쓰고 metrics 블록을 append 한 뒤 생성한다.
-`GH_DISABLE_AI_METRICS=1` 이면 footer append 를 skip — 본문만 그대로
-생성된다 (issue #399).
+Read `references/create-cmd.md` and paste the bash block verbatim — it
+handles the `mktemp` body file, `GH_DISABLE_AI_METRICS=1` short-circuit
+(issue #399), the ai-metrics footer printf, and `gh issue create` with
+`LABEL_ARGS` / `MILESTONE_ARGS` from Step 2.5.
 
-```bash
-BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
-# ... write body to "$BODY" ...
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
-else
-    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
-      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
-fi
-gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY" \
-    "${LABEL_ARGS[@]}" "${MILESTONE_ARGS[@]}"
-```
-
-`LABEL_ARGS` / `MILESTONE_ARGS` are the arrays Step 2.5 prepared (one
-`--label <name>` per kept label; `--milestone <title>` if resolved).
-Both are empty when Step 2.5 was skipped — the `gh issue create`
-invocation degrades to its original form.
-
-`--assignee` is still only added when the user asks. User-supplied
-`--label` flags survive Step 2.5 (union with auto labels) unless
-`--no-auto-labels` was set, in which case Step 2.5 is bypassed and the
-user's labels pass straight through `LABEL_ARGS` from Step 1.
 확인 질문하지 말고 즉시 실행.
 
 ## Step 5: Report
 
-이슈 번호와 URL 만 출력:
+성공 시:
 
 ```
-Issue #123 created: https://github.com/owner/repo/issues/123
+[OK] Issue: #123, URL: https://github.com/owner/repo/issues/123
+Next: /gh:issue-implement 123
+```
+
+실패 시 (gh stderr 그대로 첫 줄에 인용):
+
+```
+[FAIL] <gh stderr first line>
+Next: <recovery step — e.g. `gh auth login`, fix `.gh-issue-defaults.yml`>
 ```
 
 ## Constraints

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -77,7 +77,7 @@ resolution). Stash kept labels + milestone for Step 4.
 ## Step 3: Draft the Issue Body
 
 `references/templates/<prefix>.md` 에 정의된 본문 골격을 그대로 사용한다.
-타이틀 포맷은 Step 2 의 prefix-table 참조. 본문은 사용자 대화 언어로
+타이틀 포맷은 Step 2 의 `references/prefix-table.md` 참조. 본문은 사용자 대화 언어로
 작성하고 (한국어 대화 → 한국어 이슈) **over-compress 금지** — 파일
 경로·명령 출력·결정·근거를 그대로 유지한다. 200 줄짜리 이슈도 정상.
 

--- a/claude/skills/gh-issue-create/references/create-cmd.md
+++ b/claude/skills/gh-issue-create/references/create-cmd.md
@@ -30,7 +30,7 @@ user's labels pass straight through `LABEL_ARGS` from Step 1.
 
 확인 질문하지 말고 즉시 실행.
 
-The four emoji glyphs in the printf above (`🤖 📊 👤`) are the
-ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
+The four emoji glyphs in the printf above (`<U+1F916> <U+1F4CA> <U+1F464>`) are
+the ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
 wrapper + `<!-- ai-metrics -->` block. The exception does not extend
 anywhere else in this skill.

--- a/claude/skills/gh-issue-create/references/create-cmd.md
+++ b/claude/skills/gh-issue-create/references/create-cmd.md
@@ -1,0 +1,36 @@
+# gh:issue-create — Step 4 Create Command
+
+Detail companion to SKILL.md Step 4. Writes the drafted body to a temp
+file, appends the ai-metrics footer (unless `GH_DISABLE_AI_METRICS=1`),
+and calls `gh issue create`.
+
+`$TOKENS`, `$HUMAN_H`, `$ELAPSED` come from Step 3.5.
+`LABEL_ARGS` / `MILESTONE_ARGS` are the arrays Step 2.5 prepared (one
+`--label <name>` per kept label; `--milestone <title>` if resolved).
+Both are empty when Step 2.5 was skipped — the `gh issue create`
+invocation degrades to its original form.
+
+```bash
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write body to "$BODY" ...
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics -->\n\n</details>\n' \
+      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+fi
+gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY" \
+    "${LABEL_ARGS[@]}" "${MILESTONE_ARGS[@]}"
+```
+
+`--assignee` is still only added when the user asks. User-supplied
+`--label` flags survive Step 2.5 (union with auto labels) unless
+`--no-auto-labels` was set, in which case Step 2.5 is bypassed and the
+user's labels pass straight through `LABEL_ARGS` from Step 1.
+
+확인 질문하지 말고 즉시 실행.
+
+The four emoji glyphs in the printf above (`🤖 📊 👤`) are the
+ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
+wrapper + `<!-- ai-metrics -->` block. The exception does not extend
+anywhere else in this skill.

--- a/claude/skills/gh-issue-create/references/prefix-table.md
+++ b/claude/skills/gh-issue-create/references/prefix-table.md
@@ -1,0 +1,28 @@
+# gh:issue-create — Prefix Decision Table
+
+Step 2 picks exactly one conventional-commit prefix as the dominant
+intent. Each prefix has a body template under
+`templates/<prefix>.md` that defines the title format and body skeleton.
+
+| Prefix | When |
+|--------|------|
+| `feat` | 신규 기능 / 개선 / 확장 |
+| `fix` | 에러 / 실패 / 의도와 다른 동작 |
+| `refactor` | 동작 보존하며 구조 정리 |
+| `perf` | 느림 / 자원 사용 과다 |
+| `docs` | 문서 자체 변경 |
+| `test` | 테스트 갭 / 추가 / 변경 |
+| `chore` | 빌드·CI·도구·deps·스타일 (`build`/`ci`/`style`/`revert` 흡수) |
+| `misc` | 위 어디에도 안 들어감 (fallback) |
+
+## Disambiguation rules
+
+- 모호하면 묻지 말고 가장 보수적인 `misc` 로 떨어진다.
+- 대형 `feat` 휴리스틱 (영향 컴포넌트 ≥3 / NF 명시 / 결정 누적 — 둘
+  이상 해당) 은 `templates/feat.md` "대형 feat 가이드" 를 따른다.
+
+## Title formatting
+
+- conventional commit 형식 `<type>[(<scope>)]: <한 줄 요약>`.
+- `misc` 만 prefix 없이 한 줄 요약만 적는다.
+- 기존 `[Feature]` / `[Bug]` / `[Misc]` 대괄호 형식은 폐기.

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -22,51 +22,44 @@ its content verbatim, then stop. No API calls.
 Bundle the current branch's commits into a GitHub PR with a well-structured
 body. Push the branch if needed. Return the PR URL.
 
+## Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `[N]` (positional) | Legacy `/gh:pr 123` form — overrides issue auto-detection. | — |
+| `--no-stack` | Force a non-stacked PR even when stacked-PR signals fire. | off |
+| `--parent-pr <N>` | Explicit parent PR number; sets `BASE_BRANCH` to `<N>`'s head. | — |
+| `--base <branch>` | Explicit base branch; bypasses stacked-PR detection. | repo default |
+| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
+| `GH_PR_LINT_BYPASS=1` (env) | Skip Step 4.5 lint guard. | off |
+| `DOTFILES_ROOT` (env) | Root used to source `gh_pr_lint.sh`. | `$HOME/dotfiles` |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+
+`--no-stack`, `--parent-pr`, and `--base` are mutually exclusive — see
+Step 1a exit codes.
+
 ## Step 1: Parse Args, Resolve Base Branch, Gather State
 
 Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 
 ### Step 1a: Parse args + resolve base via stacked-PR detection
 
-Read `references/stacked-pr.md` for the SSOT bash bound to
-`parse_stacked_args`, `is_stacked_pr_repo`, and
-`find_parent_pr_candidates`, plus the dispatch block ("How Step 1 of
-SKILL.md ties it together"). Paste the four functions and the dispatch
-block verbatim. They set:
-
-- `BASE_BRANCH` — final base branch for `gh pr create --base`
-- `PARENT_PR` — non-empty PR number when the PR is stacked on another
-  open PR; empty otherwise
-- `ISSUE_NUMBER` — first positional integer arg if any (legacy
-  `/gh-pr 123` form)
-
-Honour `parse_stacked_args`'s exit codes:
-
-- rc=2 — mutually-exclusive flags (`--no-stack` / `--parent-pr` /
-  `--base`); abort, do not push.
-- rc=3 — bad value for `--parent-pr` or `--base`; abort, do not push.
-
-`PARENT_PR` flows into the body template "Depends on #N" rule
-(`pr-body-template.md`). `BASE_BRANCH` flows into Step 5's
-`gh pr create --base "$BASE_BRANCH"`.
+Read `references/stacked-pr.md` and paste the SSOT functions
+(`parse_stacked_args`, `is_stacked_pr_repo`, `find_parent_pr_candidates`)
+and the dispatch block ("How Step 1 of SKILL.md ties it together")
+verbatim. They bind `BASE_BRANCH`, `PARENT_PR`, and `ISSUE_NUMBER`, and
+they exit on bad input — `rc=2` for mutually-exclusive flags, `rc=3`
+for bad `--parent-pr` / `--base` values. Abort without pushing on either.
 
 ### Step 1b: Gather range + push state (parallel)
 
 Run in a single message, using `$BASE_BRANCH` from Step 1a:
+`git rev-parse --abbrev-ref HEAD`, `git status`, `git fetch origin`,
+`git log --oneline "$BASE_BRANCH"..HEAD`, `git diff "$BASE_BRANCH"...HEAD`,
+and `git rev-parse --symbolic-full-name @{u} 2>/dev/null`.
 
-- `git rev-parse --abbrev-ref HEAD` — current branch
-- `git status`
-- `git fetch origin`
-- `git log --oneline "$BASE_BRANCH"..HEAD` — every commit in the range
-- `git diff "$BASE_BRANCH"...HEAD` — full diff
-- `git rev-parse --symbolic-full-name @{u} 2>/dev/null` — upstream check
-
-**Stop conditions:**
-
-- If current branch equals `BASE_BRANCH` → tell the user to create a
-  feature branch first.
-- If `git log "$BASE_BRANCH"..HEAD` is empty → tell the user there's
-  nothing to PR.
+Stop conditions: current branch equals `BASE_BRANCH` → ask for a
+feature branch; `git log "$BASE_BRANCH"..HEAD` empty → nothing to PR.
 
 ## Step 2: Analyze ALL Commits in the Range
 
@@ -76,65 +69,27 @@ mentions all 5 concerns.
 
 ## Step 3: Resolve the Issue Number
 
-Same precedence as `gh:commit`:
-
-1. Explicit argument on `/gh:pr` (e.g., `/gh:pr 123`)
-2. Scan recent conversation for `#N` or `Issue #N created`
-3. Scan commit messages in the range for `Refs #N` / `Closes #N` / `Fixes #N`
-4. None — omit the link
+Same precedence as `gh:commit`: (1) explicit `/gh:pr <N>` arg, (2)
+recent conversation `#N` / `Issue #N created`, (3) commit messages in
+the range (`Refs/Closes/Fixes #N`), (4) none → omit the link.
 
 ## Step 4: Draft Title and Body
 
-Read `references/pr-body-template.md` for title rules, body structure, and
-the body markdown. Match the language of existing commits (Korean if commits
-are Korean).
+Read `references/pr-body-template.md` for title rules, body structure,
+and the body markdown. Match the language of existing commits (Korean
+if commits are Korean).
 
-Before writing the body to the temp file, compute and append the ai-metrics
-footer block (soft-fail — warn on error, never block):
-
-1. `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
-2. Issue type: the conventional-commit prefix from the first commit subject.
-3. Human time: look up `gh-issue-create/references/metrics-baseline.md`.
-   For `feat`, infer size from the number of files changed.
-4. Token estimate: read `references/metrics-helper.md` and paste the
-   `compute_pr_tokens` snippet in full. The inputs are **(linked-issue
-   body) + (commit log over `<base>..HEAD`)**, NOT the drafted PR body.
-   Counting `$BODY` (the PR-body temp file) is the regression that
-   produced PR #325's `~1000 tokens` footer (issue #326).
-
-When `GH_DISABLE_AI_METRICS=1`, skip the footer entirely (issue #399).
-The PR body is otherwise identical, and the linked issue still gets
-its body — only the footer block is omitted.
-
-```bash
-# After running the snippet from references/metrics-helper.md, $TOKENS is
-# bound to the correct estimate. Now append the footer to $BODY — unless
-# the operator opted out via GH_DISABLE_AI_METRICS=1.
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
-else
-    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n\n</details>\n' \
-      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
-fi
-```
+Then read `references/ai-metrics-footer.md` and follow it verbatim to
+compute `TOKENS`, `HUMAN_H`, `ELAPSED` and append the footer to `$BODY`
+(soft-fail — warn on error, never block). Honours
+`GH_DISABLE_AI_METRICS=1` (issue #399).
 
 ## Step 4.5: Lint Guard (pre-push)
 
-Read `references/lint-guard.md` for tool detection priority, scope, and
-the bypass policy. Source the helper and run it against `$BASE_BRANCH`
-**before** the push in Step 5:
-
-```bash
-. "${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common/functions/gh_pr_lint.sh"
-_gh_pr_lint_run "$BASE_BRANCH" || {
-    printf 'gh:pr stopped at Step 4.5 (lint guard).\n' >&2
-    exit 1
-}
-```
-
-Hard-fails when any detected tool reports lint errors. Auto-skips when
-no tools are detected, when the change set is empty, or when
-`GH_PR_LINT_BYPASS=1` is set.
+Read `references/lint-guard.md` and paste its "Helper" source-and-run
+snippet verbatim. Runs against `$BASE_BRANCH` **before** the push in
+Step 5. Hard-fails on lint errors; auto-skips when no tools are
+detected, when the change set is empty, or when `GH_PR_LINT_BYPASS=1`.
 
 ## Step 5: Push and Create
 
@@ -151,22 +106,29 @@ exist in the repo (`gh label list`) — never create new ones. See
 
 ## Step 7: Sync Project Board Status
 
-Read `references/project-board-sync.md` for the helper-source snippet that
-pushes the new PR's project-board card to `In review`. The reference also
-documents the PostToolUse hook auto-skip (issue #390): if a
-`post-gh-pr-create.sh` / `post-pr-create-status.sh` hook is installed, this
-step is delegated to the hook and the inline sync is skipped to avoid
-triple-syncing. Auto-skips when no projectV2 board is attached either way.
+Read `references/project-board-sync.md` for the helper-source snippet
+that pushes the new PR's project-board card to `In review`. The
+reference also documents the PostToolUse hook auto-skip (issue #390)
+and the no-projectV2 fallback.
 
 ## Step 8: Report
 
-Output **only** the PR URL:
+성공 시:
 
 ```
-PR created: https://github.com/owner/repo/pull/<N>
+[OK] PR: https://github.com/owner/repo/pull/<N>
+Next: /gh:pr-reply (after CI green) — replies to review comments
 ```
 
-No preamble, no summary — the user opens GitHub directly.
+Step 1b empty-range / on-base-branch stops, Step 1a `rc=2`/`rc=3`, or
+Step 4.5 lint failure:
+
+```
+[FAIL] <one-line reason>
+Next: <recovery — e.g. switch branch, fix lint, drop conflicting flag>
+```
+
+No additional summary — the user opens GitHub directly from the URL.
 
 ## Constraints
 

--- a/claude/skills/gh-pr/references/ai-metrics-footer.md
+++ b/claude/skills/gh-pr/references/ai-metrics-footer.md
@@ -39,7 +39,7 @@ appends the ai-metrics footer to the PR body temp file `$BODY`.
 
 ## Emoji exception scope
 
-The four emoji glyphs in the printf above (`🤖 📊 👤`) are the
-ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
+The four emoji glyphs in the printf above (`<U+1F916> <U+1F4CA> <U+1F464>`) are
+the ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
 wrapper + `<!-- ai-metrics:gh-pr -->` block. The exception does not
 extend anywhere else in this skill or its other references.

--- a/claude/skills/gh-pr/references/ai-metrics-footer.md
+++ b/claude/skills/gh-pr/references/ai-metrics-footer.md
@@ -1,0 +1,45 @@
+# gh:pr — Step 4 AI Metrics Footer
+
+Detail companion to SKILL.md Step 4. Computes the metrics block and
+appends the ai-metrics footer to the PR body temp file `$BODY`.
+
+## Inputs
+
+- `START_TS` — bound in Step 1 (`START_TS=$(date +%s)`).
+- The conventional-commit prefix from the first commit subject in the
+  range (used for `HUMAN_H` baseline lookup).
+- For `feat`, the **number of files changed** in `$BASE_BRANCH..HEAD`
+  (used to infer size — small/medium/large).
+- `GH_DISABLE_AI_METRICS` env (issue #399) — when set to `1`, the
+  footer is skipped entirely. The linked issue body is untouched.
+
+## Procedure
+
+1. `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
+2. Read `gh-issue-create/references/metrics-baseline.md` and bind
+   `HUMAN_H` by issue type.
+3. Read `references/metrics-helper.md` and paste the `compute_pr_tokens`
+   snippet **verbatim**. Inputs: `(linked-issue body) + (commit log
+   over $BASE_BRANCH..HEAD)` — **never** count `$BODY` (the drafted PR
+   body) as the input. That regression produced PR #325's
+   `~1000 tokens` footer (issue #326).
+4. Append the footer:
+
+   ```bash
+   if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+       : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+   else
+       printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-pr -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr -->\n\n</details>\n' \
+         "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+   fi
+   ```
+
+   Soft-fail policy: any error during steps 1–3 warns to stderr and
+   continues with placeholder values (`~?`) rather than blocking the PR.
+
+## Emoji exception scope
+
+The four emoji glyphs in the printf above (`🤖 📊 👤`) are the
+ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
+wrapper + `<!-- ai-metrics:gh-pr -->` block. The exception does not
+extend anywhere else in this skill or its other references.


### PR DESCRIPTION
## Summary

- `#427` 자동 감사 PR D — 남은 4개 NEEDS-WORK 이슈 일괄 클로즈.
- 4개 스킬 모두 SKILL.md FAIL 임계치(>150) 아래로 진입 + Options 표
  / `[OK]`/`[FAIL]` verdict / `Next:` hint / Output 섹션 보강.
- ai-metrics footer 의 `🤖 📊 👤` printf 는 CLAUDE.md narrow exception
  범위 안에서 references/*.md 로 이동 (SKILL.md 본문 emoji 0개).

## Changes

- **claude-md-check #458** — 194 → 96 줄. 6개 Check 루브릭을 신규
  `references/checks.md` 로 분리. `references/help.md` 신규. Options
  표 + Summary 뒤 `Next:` hint 추가. `[OK]`/`[FAIL]` verdict 라인.
- **devx:restart #464** — 본문 94 → 127 (FAIL 임계치 한참 아래).
  Options 표 / `## Output` 섹션 (성공/실패 양쪽 스키마 정의) /
  `[OK] resumed: <task>` ↔ `[FAIL] cannot resume: <reason>` verdict /
  명시적 `Next:` 핸드오프 라인.
- **gh:issue-create #474** — 190 → 125 줄. Step 4 의 ai-metrics
  footer 가 포함된 `gh issue create` bash 블록을 신규
  `references/create-cmd.md` 로 이동. Step 2 prefix 결정 표를 신규
  `references/prefix-table.md` 로 분리. Options 표 (positional remote
  + flags + env vars + help) / `[OK] Issue: #N, URL: …` ↔
  `[FAIL] <gh stderr>` verdict / `Next: /gh:issue-implement N` hint.
  SKILL.md 본문 emoji 0개.
- **gh:pr #478** — 175 → 137 줄. Step 4 ai-metrics 계산·footer printf
  를 신규 `references/ai-metrics-footer.md` 로 이동 (정책 예외 범위
  명시 포함). Step 1a 의 dispatch 본문 산문을 슬림. Step 4.5 도
  `references/lint-guard.md` 의 "Helper" 스니펫 paste 만 남겨 정리.
  Options 표 (flags + env vars + DOTFILES_ROOT) / `[OK] PR: <url>` ↔
  `[FAIL] <one-line reason>` verdict / `Next:` hint. SKILL.md 본문
  emoji 0개.

신규 파일:

- `claude/skills/claude-md-check/references/checks.md`
- `claude/skills/claude-md-check/references/help.md`
- `claude/skills/gh-issue-create/references/create-cmd.md`
- `claude/skills/gh-issue-create/references/prefix-table.md`
- `claude/skills/gh-pr/references/ai-metrics-footer.md`

## Test plan

- [x] `wc -l` 4개 SKILL.md — 모두 ≤150 (FAIL 임계치 통과): 96 / 127 /
  125 / 137.
- [x] `grep -E '[📊👤🤖✅❌⚠️]'` 4개 SKILL.md 본문 — 0 hit.
- [x] SKILL.md → `references/<name>.md` 링크 brokeness 스캔 — 0 missing.
- [x] Lint guard (`_gh_pr_lint_run main`) — .md only 변경이라
  shellcheck/ruff/shfmt 매칭 없음, "no lint tools detected — skip"
  (rc=0). mdlint 는 CLAUDE.md 정책상 disabled 이므로 `GH_PR_LINT_TOOLS`
  로 제외.
- [ ] 4개 스킬 실제 invocation smoke (reviewer 가 `/claude-md-check`,
  `/devx:restart`, `/gh-issue-create`, `/gh-pr` 차례로 확인).

## Related

Closes #458
Closes #464
Closes #474
Closes #478
