### PR TITLE
refactor(custom): #424 batch D — debug/analyze/confluence hardening

### DIFF
--- a/scripts/debug_pip_config.sh
+++ b/scripts/debug_pip_config.sh
@@ -1,119 +1,136 @@
 #!/bin/bash
 # scripts/debug_pip_config.sh
-# Comprehensive pip configuration diagnosis script
-# Usage: ./scripts/debug_pip_config.sh
+# Comprehensive pip configuration diagnosis script.
 
 set -e
 
-echo "════════════════════════════════════════════════════════════"
-echo "PIP CONFIGURATION DEBUG REPORT"
-echo "════════════════════════════════════════════════════════════"
-echo ""
+usage() {
+    cat <<'EOF'
+Diagnose pip's configuration: env vars, config file locations, symlinks,
+proxy state, and runtime version.
 
-echo "📋 1. PIP ENVIRONMENT VARIABLES"
-echo "─────────────────────────────────────────────────────────────"
-echo "PIP_CONFIG_FILE=${PIP_CONFIG_FILE:-<not set>}"
-echo ""
+Usage:
+  scripts/debug_pip_config.sh [-h|--help|help]
 
-echo "📂 2. PIP CONFIG FILES LOCATION & PRIORITY"
-echo "─────────────────────────────────────────────────────────────"
-echo "Checking pip config file locations (in priority order):"
-echo ""
+Options:
+  -h, --help    Show this help and exit.
 
-# Priority order for pip config files
+The script takes no positional arguments.
+EOF
+}
+
+# Reject unknown / positional args; `--help` shortcuts straight to usage.
+case "${1:-}" in
+    "") ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) printf 'Error: unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+esac
+
+# Best-effort source of the project ux_lib so output is consistent with the
+# rest of dotfiles. Fall back to plain echo if ux_lib is not reachable
+# (e.g. running this script outside the repo).
+_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+_REPO_ROOT=$(cd "${_SCRIPT_DIR}/.." && pwd)
+_UX_LIB="${_REPO_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+if [ -f "$_UX_LIB" ]; then
+    # shellcheck source=/dev/null
+    . "$_UX_LIB"
+else
+    ux_header() { echo "=== $* ==="; }
+    ux_section() { echo "-- $* --"; }
+    ux_info() { echo "$*"; }
+    ux_success() { echo "[OK] $*"; }
+    ux_warning() { echo "[WARN] $*"; }
+    ux_error() { echo "[ERROR] $*" >&2; }
+    ux_bullet() { echo "  - $*"; }
+fi
+unset _SCRIPT_DIR _REPO_ROOT _UX_LIB
+
+ux_header "PIP CONFIGURATION DEBUG REPORT"
+
+ux_section "1. PIP ENVIRONMENT VARIABLES"
+ux_bullet "PIP_CONFIG_FILE=${PIP_CONFIG_FILE:-<not set>}"
+
+ux_section "2. PIP CONFIG FILES LOCATION & PRIORITY"
+ux_info "Checking pip config file locations (in priority order):"
+
 config_paths=(
-    "$PIP_CONFIG_FILE"  # Environment variable override
-    "$HOME/.pip/pip.conf"  # Legacy location
-    "$HOME/.config/pip/pip.conf"  # XDG location (newer)
-    "/etc/pip/pip.conf"  # System location
-    "/usr/local/etc/pip/pip.conf"  # System location (alternative)
+    "$PIP_CONFIG_FILE"
+    "$HOME/.pip/pip.conf"
+    "$HOME/.config/pip/pip.conf"
+    "/etc/pip/pip.conf"
+    "/usr/local/etc/pip/pip.conf"
 )
 
 for i in "${!config_paths[@]}"; do
     path="${config_paths[$i]}"
     if [ -n "$path" ]; then
         if [ -f "$path" ]; then
-            echo "✓ [$((i+1))] EXISTS: $path"
+            ux_success "[$((i+1))] EXISTS: $path"
         else
-            echo "  [$((i+1))] missing: $path"
+            ux_bullet "[$((i+1))] missing: $path"
         fi
     fi
 done
-echo ""
 
-echo "📄 3. ACTUAL PIP CONFIG FILE CONTENTS"
-echo "─────────────────────────────────────────────────────────────"
+ux_section "3. ACTUAL PIP CONFIG FILE CONTENTS"
 
 if [ -f "$HOME/.pip/pip.conf" ]; then
-    echo "📌 ~/.pip/pip.conf (LEGACY - may override ~/.config/pip/pip.conf)"
-    echo "───"
+    # shellcheck disable=SC2088 # tilde is a display label, not a literal path
+    ux_info "~/.pip/pip.conf (LEGACY — may override ~/.config/pip/pip.conf)"
     cat "$HOME/.pip/pip.conf"
-    echo ""
 else
-    echo "✓ ~/.pip/pip.conf does NOT exist"
-    echo ""
+    # shellcheck disable=SC2088
+    ux_success "~/.pip/pip.conf does NOT exist"
 fi
 
 if [ -f "$HOME/.config/pip/pip.conf" ]; then
-    echo "📌 ~/.config/pip/pip.conf (XDG - newer standard)"
-    echo "───"
+    # shellcheck disable=SC2088
+    ux_info "~/.config/pip/pip.conf (XDG — newer standard)"
     cat "$HOME/.config/pip/pip.conf"
-    echo ""
 else
-    echo "❌ ~/.config/pip/pip.conf does NOT exist"
-    echo ""
+    # shellcheck disable=SC2088
+    ux_warning "~/.config/pip/pip.conf does NOT exist"
 fi
 
-echo "🔗 4. SYMLINK STATUS"
-echo "─────────────────────────────────────────────────────────────"
+ux_section "4. SYMLINK STATUS"
 if [ -L "$HOME/.config/pip/pip.conf" ]; then
     target=$(readlink "$HOME/.config/pip/pip.conf")
-    echo "✓ Symlink exists: $HOME/.config/pip/pip.conf"
-    echo "  Target: $target"
-    echo "  Target exists: $([ -f "$target" ] && echo 'YES' || echo 'NO')"
+    ux_success "Symlink exists: $HOME/.config/pip/pip.conf"
+    ux_bullet "Target: $target"
+    if [ -f "$target" ]; then
+        ux_bullet "Target exists: YES"
+    else
+        ux_bullet "Target exists: NO"
+    fi
 else
-    echo "❌ NOT a symlink: $HOME/.config/pip/pip.conf"
+    ux_warning "NOT a symlink: $HOME/.config/pip/pip.conf"
 fi
-echo ""
 
-echo "⚙️  5. PIP CONFIG LIST (what pip actually uses)"
-echo "─────────────────────────────────────────────────────────────"
-pip config list
-echo ""
+ux_section "5. PIP CONFIG LIST (what pip actually uses)"
+pip config list || ux_warning "pip config list failed"
 
-echo "🧪 6. PIP DEBUG MODE (see which config file pip loads)"
-echo "─────────────────────────────────────────────────────────────"
-echo "Running: pip config list --verbose"
-echo ""
-pip config list --verbose 2>&1 | head -20
-echo ""
+ux_section "6. PIP DEBUG MODE (see which config file pip loads)"
+ux_info "Running: pip config list --verbose"
+pip config list --verbose 2>&1 | head -20 || true
 
-echo "🔍 7. PIP SEARCH PATH TEST"
-echo "─────────────────────────────────────────────────────────────"
-echo "Testing if pip can find packages in configured repo:"
-pip search tox 2>&1 | head -20 || echo "⚠️  pip search command failed (may be expected)"
-echo ""
+ux_section "7. PIP SEARCH PATH TEST"
+ux_info "Testing if pip can find packages in configured repo:"
+pip search tox 2>&1 | head -20 || ux_warning "pip search command failed (may be expected)"
 
-echo "🌐 8. PROXY & NETWORK"
-echo "─────────────────────────────────────────────────────────────"
-echo "http_proxy=${http_proxy:-<not set>}"
-echo "https_proxy=${https_proxy:-<not set>}"
-echo "HTTP_PROXY=${HTTP_PROXY:-<not set>}"
-echo "HTTPS_PROXY=${HTTPS_PROXY:-<not set>}"
-echo ""
+ux_section "8. PROXY & NETWORK"
+ux_bullet "http_proxy=${http_proxy:-<not set>}"
+ux_bullet "https_proxy=${https_proxy:-<not set>}"
+ux_bullet "HTTP_PROXY=${HTTP_PROXY:-<not set>}"
+ux_bullet "HTTPS_PROXY=${HTTPS_PROXY:-<not set>}"
 
-echo "📝 9. PYTHON & PIP VERSION"
-echo "─────────────────────────────────────────────────────────────"
-python --version
-pip --version
-echo ""
+ux_section "9. PYTHON & PIP VERSION"
+python --version || ux_warning "python --version failed"
+pip --version || ux_warning "pip --version failed"
 
-echo "💾 10. PYENV STATUS"
-echo "─────────────────────────────────────────────────────────────"
-echo "PYENV_VERSION=${PYENV_VERSION:-<not set>}"
-pyenv version
-echo ""
+ux_section "10. PYENV STATUS"
+ux_bullet "PYENV_VERSION=${PYENV_VERSION:-<not set>}"
+pyenv version 2>/dev/null || ux_warning "pyenv not available"
 
-echo "════════════════════════════════════════════════════════════"
-echo "END OF DEBUG REPORT"
-echo "════════════════════════════════════════════════════════════"
+ux_header "END OF DEBUG REPORT"
+ux_info "Next: pip config edit  # to fix any config mismatch surfaced above"

--- a/shell-common/tools/custom/analyze_bash_scripts.sh
+++ b/shell-common/tools/custom/analyze_bash_scripts.sh
@@ -1,12 +1,35 @@
 #!/bin/bash
+# shell-common/tools/custom/analyze_bash_scripts.sh
+# Scan a directory of bash files and emit a Markdown summary of all
+# aliases and functions defined within.
 
-# ==============================================================================
-# Bash Script Analyzer: alias 및 function 정의를 파싱하여 매뉴얼 생성
-# (LC_ALL=C 추가 및 파서 재수정)
-# ==============================================================================
+# zsh-compat: this script uses bash arrays + mapfile + ((...)); when sourced
+# from zsh, drop into strict POSIX-sh emulation to keep the syntax legal.
+[ -n "${ZSH_VERSION-}" ] && emulate -L sh
 
 # 일관된 정규식 및 정렬 동작을 위해 로케일을 C로 설정
 export LC_ALL=C
+
+usage() {
+    cat <<'EOF'
+Analyze a directory of bash files and print a Markdown summary of every
+alias and function defined within.
+
+Usage:
+  analyze_bash_scripts.sh [-h|--help|help] <directory>
+
+Arguments:
+  <directory>    Directory to scan recursively (skips */lib/* paths).
+
+Examples:
+  analyze_bash_scripts.sh ~/dotfiles/shell-common
+  analyze_bash_scripts.sh ./bash
+EOF
+}
+
+# Initialize common tools environment (ux_lib + have_command)
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/init.sh" || exit 1
 
 # 전역 변수 초기화
 declare -A ALL_ALIASES
@@ -14,21 +37,10 @@ declare -A ALL_FUNCTIONS
 TOTAL_ALIAS_COUNT=0
 TOTAL_FUNCTION_COUNT=0
 
-# ==============================================================================
-# 함수 정의
-# ==============================================================================
-
-usage() {
-    echo "사용법: $0 <bash_files_directory>"
-    echo "예시: $0 ~/my_bash_config"
-    return 1
-}
-
 # alias 정의를 파싱하고 전역 변수에 업데이트하는 함수
 parse_aliases() {
     local file_path="$1"
     local alias_names
-    # grep의 정규식을 수정하여 '..', '~' 같은 다양한 alias 이름을 올바르게 처리
     mapfile -t alias_names < <(grep -E '^\s*alias\s+.*=' "$file_path" | grep -v '^\s*#' | sed -E 's/^\s*alias\s+([^=]+)=.*/\1/')
 
     for alias_name in "${alias_names[@]}"; do
@@ -56,50 +68,46 @@ parse_functions() {
 
 # 결과 출력 함수
 print_results() {
-    echo "---"
-    echo "## Bash 매뉴얼 요약"
-    echo "---"
-    echo ""
-    echo "총 alias 개수: **$TOTAL_ALIAS_COUNT**"
-    echo "총 function 개수: **$TOTAL_FUNCTION_COUNT**"
-    echo ""
+    ux_header "Bash Script Inventory"
+    ux_bullet "Total aliases: $TOTAL_ALIAS_COUNT"
+    ux_bullet "Total functions: $TOTAL_FUNCTION_COUNT"
 
-    echo "### Alias 목록"
+    ux_section "Alias 목록"
     if [[ ${#ALL_ALIASES[@]} -eq 0 ]]; then
-        echo "  (발견된 alias 없음)"
+        ux_info "(발견된 alias 없음)"
     else
         printf "  - %s\n" "${!ALL_ALIASES[@]}" | sort
     fi
-    echo ""
 
-    echo "### Function 목록"
+    ux_section "Function 목록"
     if [[ ${#ALL_FUNCTIONS[@]} -eq 0 ]]; then
-        echo "  (발견된 function 없음)"
+        ux_info "(발견된 function 없음)"
     else
         printf "  - %s\n" "${!ALL_FUNCTIONS[@]}" | sort
     fi
-    echo ""
-    echo "---"
 }
 
-# ==============================================================================
-# 메인 로직
-# ==============================================================================
-
 main() {
-    if [[ -z "${1:-}" ]]; then
-        usage
-    fi
+    case "${1:-}" in
+        -h|--help|help) usage; exit 0 ;;
+        "") ux_error "Missing argument: <directory>"; usage >&2; exit 2 ;;
+    esac
 
     local TARGET_DIR="$1"
 
     if [[ ! -d "$TARGET_DIR" ]]; then
-        echo "오류: '$TARGET_DIR' 디렉토리를 찾을 수 없습니다."
-        usage
+        ux_error "Directory not found: $TARGET_DIR"
+        exit 1
     fi
 
     local sh_files
     mapfile -t sh_files < <(find "$TARGET_DIR" -type f -name "*.sh" -not -path '*/lib/*')
+
+    local files_scanned=${#sh_files[@]}
+    if [ "$files_scanned" -eq 0 ]; then
+        ux_warning "No .sh files found under: $TARGET_DIR"
+        exit 0
+    fi
 
     for sh_file in "${sh_files[@]}"; do
         parse_aliases "$sh_file"
@@ -107,8 +115,14 @@ main() {
     done
 
     print_results
+    ux_section "Summary"
+    ux_bullet "state: ok"
+    ux_bullet "files_scanned: $files_scanned"
+    ux_bullet "aliases: $TOTAL_ALIAS_COUNT"
+    ux_bullet "functions: $TOTAL_FUNCTION_COUNT"
+    ux_info "Next: pipe this output into a manual or diff against the previous run"
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     main "$@"
 fi

--- a/shell-common/tools/custom/make_confluence.sh
+++ b/shell-common/tools/custom/make_confluence.sh
@@ -1,14 +1,36 @@
 #!/bin/bash
-# make_confluence.sh - Transform markdown to Confluence-formatted guides
-#
-# Reads technical markdown and converts to Confluence guide format with:
-# - Problem/Solution/Results structure
-# - TL;DR (3-line executive summary)
-# - Difficulty rating (⭐ 1-5)
-# - Git metadata (author, date)
-# - Category organization
+# shell-common/tools/custom/make_confluence.sh
+# Transform a technical markdown document into a Confluence-formatted guide.
+
+# zsh-compat: this script uses bash-only [[ ]], `local`, and process
+# substitution; drop into strict POSIX-sh emulation when sourced from zsh.
+[ -n "${ZSH_VERSION-}" ] && emulate -L sh
 
 set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Transform a technical markdown document into a Confluence-formatted guide
+with Problem / Solution / Results structure plus TL;DR and metadata.
+
+Usage:
+  make_confluence.sh [-h|--help|help] <input.md> [--category <name>]
+
+Arguments:
+  <input.md>             Source markdown file (required).
+
+Options:
+  -h, --help             Show this help and exit.
+  --category <name>      Override the auto-detected category.
+
+Output:
+  ${RCA_KNOWLEDGE:-~/para/archive/playbook}/docs/confluence-guides/<cat>/<date>-<slug>.md
+EOF
+}
+
+# Initialize common tools environment (ux_lib + have_command)
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/init.sh" || exit 1
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Configuration
@@ -51,22 +73,18 @@ get_category() {
     local file="$1"
     local override="$2"
 
-    # 1. Check override flag
     if [ -n "$override" ]; then
         echo "$override"
         return 0
     fi
 
-    # 2. Try to extract from directory structure
-    # docs/technic/testing/ → testing
-    # playbook/docs/analysis/infrastructure/ → infrastructure
-    local path_category=$(echo "$file" | sed -n 's/.*\/\(testing\|infrastructure\|documentation\|performance\|security\|communication\|training\|other\)\/.*$/\1/p')
+    local path_category
+    path_category=$(echo "$file" | sed -n 's/.*\/\(testing\|infrastructure\|documentation\|performance\|security\|communication\|training\|other\)\/.*$/\1/p')
     if [ -n "$path_category" ]; then
         echo "$path_category"
         return 0
     fi
 
-    # 3. Default
     echo "other"
 }
 
@@ -75,14 +93,12 @@ extract_section() {
     local file="$1"
     local section_pattern="$2"
 
-    # Find lines between matching heading and next heading
     awk -v pattern="$section_pattern" '
         BEGIN { in_section = 0 }
         /^## / {
             if (in_section) {
                 exit
             }
-            # Match pattern (case-insensitive, supports Korean and English)
             if ($0 ~ tolower(pattern) || $0 ~ pattern) {
                 in_section = 1
                 next
@@ -92,17 +108,16 @@ extract_section() {
     ' "$file" 2>/dev/null | head -n 10
 }
 
-# Estimate difficulty from file characteristics
+# Estimate difficulty from file characteristics.
+# Output stars are embedded in the generated markdown (user-facing content),
+# not in the script's own UX output — exempt from the no-emoji rule.
 estimate_difficulty() {
     local file="$1"
+    local code_blocks
+    code_blocks=$(grep -c '```' "$file" 2>/dev/null || echo 0)
+    local lines
+    lines=$(wc -l <"$file")
 
-    # Count code blocks
-    local code_blocks=$(grep -c '```' "$file" 2>/dev/null || echo 0)
-
-    # Count lines
-    local lines=$(wc -l <"$file")
-
-    # Simple heuristic
     if [ "$code_blocks" -ge 5 ]; then
         echo "⭐⭐⭐⭐⭐"
     elif [ "$code_blocks" -ge 3 ]; then
@@ -116,80 +131,68 @@ estimate_difficulty() {
     fi
 }
 
-# Generate TL;DR (3 lines, each ≤15 words)
-generate_tldr() {
-    local file="$1"
-
-    # For now, extract first paragraph from Problem and Results sections
-    local problem_text=$(extract_section "$file" "Problem\|Issue" | head -n1 | sed 's/^ *//')
-    local results_text=$(extract_section "$file" "Results\|Outcome" | head -n1 | sed 's/^ *//')
-
-    # Simple 3-line summary
-    cat <<EOF
-- ${problem_text:0:80}...
-- Key technical insight from solution
-- Applicable to most projects
-EOF
-}
-
 # ═══════════════════════════════════════════════════════════════════════════
 # Main Logic
 # ═══════════════════════════════════════════════════════════════════════════
 
 main() {
+    case "${1:-}" in
+        -h|--help|help) usage; exit 0 ;;
+        "") ux_error "Missing argument: <input.md>"; usage >&2; exit 2 ;;
+    esac
+
     local input_file="$1"
+    shift
     local category_override=""
 
-    # Parse arguments
-    while [ $# -gt 1 ]; do
-        shift
+    while [ $# -gt 0 ]; do
         case "$1" in
             --category)
+                if [ -z "${2:-}" ]; then
+                    ux_error "--category requires an argument"
+                    usage >&2
+                    exit 2
+                fi
                 category_override="$2"
                 shift 2
+                ;;
+            *)
+                ux_error "Unknown argument: $1"
+                usage >&2
+                exit 2
                 ;;
         esac
     done
 
-    # Validate input
     if [ ! -f "$input_file" ]; then
-        echo "Error: File not found: $input_file" >&2
+        ux_error "File not found: $input_file"
         return 1
     fi
 
-    # Extract metadata
     local title
     title=$(get_title "$input_file")
-
     local author
     author=$(get_git_author "$input_file")
-
     local date
     date=$(get_git_date "$input_file")
-
     local category
     category=$(get_category "$input_file" "$category_override")
-
     local difficulty
     difficulty=$(estimate_difficulty "$input_file")
-
     local slug
     slug=$(title_to_slug "$title")
 
-    echo "=== Confluence Guide Generator ==="
-    echo "Input:      $input_file"
-    echo "Title:      $title"
-    echo "Author:     $author"
-    echo "Date:       $date"
-    echo "Category:   $category"
-    echo "Difficulty: $difficulty"
-    echo "Slug:       $slug"
-    echo ""
+    ux_header "Confluence Guide Generator"
+    ux_bullet "Input:      $input_file"
+    ux_bullet "Title:      $title"
+    ux_bullet "Author:     $author"
+    ux_bullet "Date:       $date"
+    ux_bullet "Category:   $category"
+    ux_bullet "Difficulty: $difficulty"
+    ux_bullet "Slug:       $slug"
 
-    # Extract sections - get content after main heading
-    echo "Extracting sections..."
+    ux_info "Extracting sections..."
 
-    # For now, extract first few substantial paragraphs as overview
     local overview_section
     overview_section=$(sed -n '/^# /,/^## /p' "$input_file" | tail -n +2 | head -n 5 | grep -v '^##' || echo "Technical documentation")
 
@@ -199,17 +202,12 @@ main() {
     local results_section
     results_section=$(grep -A 3 "성과\|Results\|효과\|Benefits" "$input_file" | head -n 5 || echo "Performance improved")
 
-    # Create output directory
     local output_dir="${OUTPUT_BASE}/${category}"
     mkdir -p "$output_dir"
 
-    # Generate output filename
     local output_file="${output_dir}/${date}-${slug}.md"
+    ux_info "Generating: $output_file"
 
-    echo "Generating: $output_file"
-    echo ""
-
-    # Write output
     cat >"$output_file" <<EOF
 # ${title}
 
@@ -231,15 +229,19 @@ ${implementation_section}
 ${results_section}
 
 ## 적용 범위 (Applicability)
-- ✓ 소프트웨어 개발 환경
-- ✓ 성능 최적화 필요 시
-- ✓ 팀 전체 적용 가능
+- [x] 소프트웨어 개발 환경
+- [x] 성능 최적화 필요 시
+- [x] 팀 전체 적용 가능
 
 ---
 *Generated by make-confluence | Source: $(basename "$input_file")*
 EOF
 
-    echo "✓ Guide generated: $output_file"
+    ux_section "Summary"
+    ux_bullet "state: ok"
+    ux_bullet "output: $output_file"
+    ux_success "Guide generated"
+    ux_info "Next: cat \"$output_file\""
     return 0
 }
 
@@ -247,6 +249,6 @@ EOF
 # Direct Execution Guard
 # ═══════════════════════════════════════════════════════════════════════════
 
-if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     main "$@"
 fi


### PR DESCRIPTION
## Summary

Batch D of the #424 `sh:check` audit follow-up — covers `scripts/debug_pip_config.sh` and the two custom helpers `analyze_bash_scripts.sh` / `make_confluence.sh`.

## Cross-cutting changes (all 3 files)

- **argparse + help**: top-level `usage()` plus `-h|--help|help` with Usage/Args/Options/Examples blocks. Unknown / missing required args → `exit 2`.
- **ux_lib**: source the project ux_lib (via `init.sh` under `shell-common/`, via best-effort load + plain-echo fallback under `scripts/`). Raw `echo "=== ... ==="` / `echo "✓ ..."` blocks replaced with `ux_header` / `ux_section` / `ux_bullet` / `ux_success` / `ux_info`.
- **Structured tail**: `Summary` block (state / counters / output path) plus a concrete `Next:` action hint at the end.
- **Foot-guard**: `[ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "$BASH_SOURCE" ]` → `[ "${BASH_SOURCE[0]:-$0}" = "$0" ]` (clears SC2128).

## Per-file specifics

- **`scripts/debug_pip_config.sh`** (closes #429): all 10 sections converted to ux_section/ux_bullet/ux_success/ux_warning. Tilde-display labels kept literal with `# shellcheck disable=SC2088`. Final hint: `pip config edit`.
- **`analyze_bash_scripts.sh`** (closes #441): zsh-compat guard (`emulate -L sh`). Fixed the broken `usage(); $1 access` flow. Added `files_scanned/aliases/functions` counters.
- **`make_confluence.sh`** (closes #442): zsh-compat guard. Validate `$#` before `$1` access. Reject unknown options with `exit 2`. The `⭐` stars in `estimate_difficulty` stay because they are embedded in the *generated* markdown artifact, not the script's own UX output.

## Test plan

- [x] `shellcheck -x` on all three files — clean.
- [x] `<script> -h` prints structured help on each.
- [x] `<script>` with missing required arg → exit 2.
- [x] `analyze_bash_scripts.sh shell-common/aliases` → 142 aliases, 11 functions.

Closes #429, #441, #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)