### PR TITLE
chore(skill): gh:issue-read — add options table to Step 1

### DIFF
--- a/claude/skills/gh-issue-read/SKILL.md
+++ b/claude/skills/gh-issue-read/SKILL.md
@@ -30,6 +30,11 @@ Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 
 Positional args: `<issue-number> [remote]`.
 
+| Arg | Description | Default | Required |
+|-----|-------------|---------|----------|
+| `<issue-number>` | GitHub issue number to fetch | — | Yes |
+| `[remote]` | Git remote name whose repo owns the issue | `origin` | No |
+
 - `issue-number` — required, positive integer. Missing/invalid → print
   usage pointer (`Run /gh-issue-read -h for usage.`) and stop.
 - `remote` — default `origin`. Resolve `TARGET_REPO=<owner>/<repo>` via


### PR DESCRIPTION
## Summary
- Add options table to `gh:issue-read` SKILL.md Step 1, mirroring the existing table in `references/help.md`

## Changes
- `claude/skills/gh-issue-read/SKILL.md`: add `| Arg | Description | Default | Required |` table to Step 1 (lines 33-36); file grows 85→90 lines, still within the 100-line AGENTS.md limit

## Test plan
- [x] shellcheck: OK (no shell code changed)
- [x] No emoji present in SKILL.md (ai-metrics line was already clean)
- [x] File line count: 90 (under 100-line limit)

## Related
Closes #477

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~2 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~2 min
<\!-- /ai-metrics:gh-pr -->

</details>
