### PR TITLE
chore(skill): write:insight — apply /skill:check improvements

### DIFF
--- a/claude/skills/write-insight/SKILL.md
+++ b/claude/skills/write-insight/SKILL.md
@@ -18,6 +18,13 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 If the argument is `help`, read `references/help.md` and output it verbatim, then stop.
 
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<topic-hint>` | 후보 인사이트를 한정할 자유 텍스트 힌트 (예: `git-crypt worktree`) | 없음 — 후보 1–3개 제안 |
+| `-h` / `--help` / `help` | `references/help.md` 출력 후 종료 | — |
+
 ## Role
 
 Capture one reusable insight from the current chat as a short Korean note in
@@ -74,15 +81,17 @@ If the insight is cross-session reusable, ask: `memory/reference_learnings_<slug
 
 ## Step 8: Report
 
-Output exactly two lines, no preamble, no recap:
+Output exactly two lines, no preamble, no recap — first line is the structured
+verdict, second line is the explicit `Next:` follow-up hint:
 
 ```
-docs/learnings/<slug>.md (<N> lines)
-<one-line summary — the same hook used in README index>
+[OK] file=docs/learnings/<slug>.md lines=<N> summary=<one-line summary — same hook used in README index>
+Next: review the file, then optionally /write:insight again for remaining candidates
 ```
 
 ## Constraints
 
+- **Stop on any step failure** — Steps 1–8 are sequential; on the first error stop and report the failing step, do not proceed silently.
 - **Korean body, English headings** — note is for human teammates per README's language policy.
 - **No abstract generalities** — no PR/commit/file:line link → reject. Back to Step 4 or decline.
 - **Don't paraphrase the README** — re-read every run; if rules conflict, README wins.

--- a/claude/skills/write-insight/SKILL.md
+++ b/claude/skills/write-insight/SKILL.md
@@ -85,7 +85,7 @@ Output exactly two lines, no preamble, no recap — first line is the structured
 verdict, second line is the explicit `Next:` follow-up hint:
 
 ```
-[OK] file=docs/learnings/<slug>.md lines=<N> summary=<one-line summary — same hook used in README index>
+[OK] file=docs/learnings/<slug>.md lines=<N> summary="<one-line hook — same lead used in README index>"
 Next: review the file, then optionally /write:insight again for remaining candidates
 ```
 


### PR DESCRIPTION
## Summary
- `claude/skills/write-insight/SKILL.md` 의 `/skill:check` 감사(GOOD 7/10, 1 FAIL · 2 WARN)에 따라 verdict / options / next-action / stop-on-error 보강

## Changes
- **Step 8 verdict (Check 9 FAIL)**: 자유형 두 줄 → 구조화된 `[OK] file=docs/learnings/<slug>.md lines=<N> summary=<...>`
- **Arguments table (Check 8 WARN)**: `<topic-hint>` (선택) / `-h|--help|help` 를 표 형태로 SKILL.md 본문에 명시
- **Next-action hint (Check 10 WARN)**: 두 줄 룰을 유지하면서 두 번째 줄이 `Next: review the file, then optionally /write:insight again for remaining candidates`
- **Stop-on-error (Check 7 WARN)**: Constraints 에 "Steps 1–8 은 순차, 첫 에러에서 즉시 중단" 명문화
- 줄 수: 91 → 100 (AGENTS.md 100 줄 한도 유지)

## Test plan
- [ ] `tox -e ruff -e shellcheck -e shfmt` (변경 파일은 `.md` 1개라 lint 영향 없음, mdlint 는 CLAUDE.md 에서 비활성)
- [ ] `/skill:check claude/skills/write-insight/SKILL.md` — 1 FAIL · 2 WARN 해소되어 PASS 비율 증가 확인
- [ ] 다음 `/write:insight` 실행 시 Step 8 출력이 `[OK] file=... lines=... summary=...` + `Next: ...` 형식인지 시각 확인

## Related
Closes #493
