### PR TITLE
docs(git-help): expand grs with --staged restore variant

### DIFF
--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -42,7 +42,8 @@ _git_help_rows_basic() {
     ux_table_row "gpl" "git pull" "Pull from remote"
     ux_table_row "gco" "git checkout" "Checkout branch/commit"
     ux_table_row "gd" "git diff" "Show changes"
-    ux_table_row "grs" "git restore" "Discard changes in file"
+    ux_table_row "grs <file>" "git restore <file>" "Discard working dir changes"
+    ux_table_row "grs --staged <file>" "git restore --staged <file>" "Unstage file (undo git add)"
     ux_table_row "gb" "git branch" "List branches"
     ux_table_row "grmc" "git rm --cached" "Unstage, keep file"
 }

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -42,8 +42,8 @@ _git_help_rows_basic() {
     ux_table_row "gpl" "git pull" "Pull from remote"
     ux_table_row "gco" "git checkout" "Checkout branch/commit"
     ux_table_row "gd" "git diff" "Show changes"
-    ux_table_row "grs <file>" "git restore <file>" "Discard working dir changes"
-    ux_table_row "grs --staged <file>" "git restore --staged <file>" "Unstage file (undo git add)"
+    ux_table_row "grs" "git restore <file>" "Discard working dir changes"
+    ux_table_row "grs --staged" "git restore --staged <file>" "Unstage file (undo git add)"
     ux_table_row "gb" "git branch" "List branches"
     ux_table_row "grmc" "git rm --cached" "Unstage, keep file"
 }


### PR DESCRIPTION
## Summary
- `git-help basic` 섹션의 `grs` 항목을 두 행으로 확장해 `git restore --staged <file>` 변형을 추가

## Changes
- git-help: `grs` 단일 항목(`git restore`)을 두 행으로 분리 — `grs <file>` (working dir 변경 취소)와 `grs --staged <file>` (staged 취소) 각각 명시

## Test plan
- [ ] `git-help basic` 실행 → `grs <file>`과 `grs --staged <file>` 두 행 모두 출력 확인
- [ ] `git-help --all` 실행 → basic 섹션 내 동일 출력 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~3 min
<\!-- /ai-metrics:gh-pr -->

</details>
