### PR TITLE
feat(gh-pr-approve): teardown timestamp + --auto-prune flag for status

### DIFF
--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -364,7 +364,7 @@ _gh_pr_approve_status_single() {
     fi
 
     # Worktree presence.
-    _wt_removed_at="$(cat "$_dir/worktree_removed_at" 2>/dev/null || printf '')"
+    _wt_removed_at="$(cat "$_dir/worktree_removed_at" 2>/dev/null | tr -d '\n')"
     if [ -n "$_wt" ]; then
         if [ -d "$_wt" ]; then
             _wt_state="$_wt (present)"
@@ -462,6 +462,10 @@ _gh_pr_approve_status() {
     while [ $# -gt 0 ]; do
         case "$1" in
         --auto-prune) _auto_prune=1 ;;
+        -*)
+            ux_error "gh-pr-approve status: unknown option '$1'"
+            return 1
+            ;;
         *)
             if [ -n "$_pr_arg" ]; then
                 ux_error "gh-pr-approve status: only one PR number accepted"
@@ -472,6 +476,10 @@ _gh_pr_approve_status() {
         esac
         shift
     done
+    if [ "$_auto_prune" = "1" ] && [ -z "$_pr_arg" ]; then
+        ux_error "gh-pr-approve status: --auto-prune requires a PR number"
+        return 1
+    fi
     if [ -n "$_pr_arg" ]; then
         _gh_pr_approve_status_single "$_pr_arg" "$_auto_prune"
         return $?

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -295,11 +295,12 @@ _gh_pr_approve_verdict() {
 # Input: <pr-num> with optional leading '#'.
 _gh_pr_approve_status_single() {
     local _arg="$1"
-    local _pr _dir _state _pid _wt _pid_state _wt_state
+    local _pr _dir _state _pid _wt _pid_state _wt_state _auto_prune _wt_removed_at
     local _pr_state_raw _pr_state _pr_decision _pr_date _pr_info
     local _flags _flags_state _log _log_mtime _etime
     local _verdict_out _verdict_text _action_text _name
 
+    _auto_prune="${2:-0}"
     _pr="${_arg#\#}"
     case "$_pr" in
     '' | *[!0-9]*)
@@ -363,9 +364,12 @@ _gh_pr_approve_status_single() {
     fi
 
     # Worktree presence.
+    _wt_removed_at="$(cat "$_dir/worktree_removed_at" 2>/dev/null || printf '')"
     if [ -n "$_wt" ]; then
         if [ -d "$_wt" ]; then
             _wt_state="$_wt (present)"
+        elif [ -n "$_wt_removed_at" ]; then
+            _wt_state="$_wt (absent, removed $_wt_removed_at)"
         else
             _wt_state="$_wt (absent)"
         fi
@@ -442,18 +446,34 @@ EOF
     ux_info ""
     ux_table_row "Verdict" "$_verdict_text"
     ux_table_row "Next action" "$_action_text"
+
+    # Auto-prune: when --auto-prune passed and state=done + worktree absent.
+    if [ "$_auto_prune" = "1" ] && [ "$_state" = "done" ] && [ -n "$_wt" ] && [ ! -d "$_wt" ]; then
+        ux_info "State=done + worktree=absent — auto-pruning #$_pr..."
+        _gh_pr_approve_prune_scoped "$(dirname "$_dir")" 0 "$_name" "$_pr"
+    fi
 }
 
 # List all known gh-pr-approve entries for the current repo, OR diagnose a
 # single PR if exactly one positional arg is given. Multiple positional args
 # are rejected (single-PR diagnostic only).
 _gh_pr_approve_status() {
-    if [ $# -gt 1 ]; then
-        ux_error "gh-pr-approve status: only one PR number accepted (got $#)"
-        return 1
-    fi
-    if [ -n "${1:-}" ]; then
-        _gh_pr_approve_status_single "$1"
+    local _auto_prune=0 _pr_arg=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        --auto-prune) _auto_prune=1 ;;
+        *)
+            if [ -n "$_pr_arg" ]; then
+                ux_error "gh-pr-approve status: only one PR number accepted"
+                return 1
+            fi
+            _pr_arg="$1"
+            ;;
+        esac
+        shift
+    done
+    if [ -n "$_pr_arg" ]; then
+        _gh_pr_approve_status_single "$_pr_arg" "$_auto_prune"
         return $?
     fi
 
@@ -1109,6 +1129,8 @@ _gh_pr_approve_worker() {
         _ai_usage_summary "$_usage_log" "Token Usage (PR #$_pr — teardown failed)"
         return 1
     fi
+    printf '%s\n' "$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S%z')" \
+        >"$_dir/worktree_removed_at"
 
     _gh_pr_approve_set_state "$_dir" "done"
     printf '[gh-pr-approve-worker] done pr=#%s end=%s\n' "$_pr" "$(date -Iseconds 2>/dev/null || date)"


### PR DESCRIPTION
## Summary
- Record `worktree_removed_at` timestamp in state dir after teardown, so `status` can show when the directory was deleted
- Add `--auto-prune` flag to `status <N>`: auto-prunes the state entry when `state=done` + worktree absent, removing the need for a manual `prune` step

## Changes
- `gh_pr_approve.sh`: write `worktree_removed_at=<ISO8601>` to state dir immediately after `gwt teardown --force` succeeds (#532)
- `gh_pr_approve.sh`: read `worktree_removed_at` in `_gh_pr_approve_status_single()` and display `(absent, removed <ts>)` when present (#532)
- `gh_pr_approve.sh`: parse `--auto-prune` flag in `_gh_pr_approve_status()`, pass to `_gh_pr_approve_status_single()`, call `_gh_pr_approve_prune_scoped` when `done + absent` (#533)

## Test plan
- [ ] Run `gh-pr-approve status <N>` on a done PR after teardown — Worktree row shows `(absent, removed 2026-05-11T…)`
- [ ] Run `gh-pr-approve status <N> --auto-prune` on a done+absent PR — state dir removed, success message shown
- [ ] Run `gh-pr-approve status <N>` (no flag) on done+absent — no auto-prune side effect
- [ ] All 1013 existing tests pass (confirmed locally)

## Related
Closes #532
Closes #533

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~3 h · 🤖 ~21 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~3 h · 🤖 ~21 min
<\!-- /ai-metrics:gh-pr -->

</details>
