### PR TITLE
feat(skills): #535 emoji 검사 Check 11 + ai-metrics footer 복원

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -109,7 +109,15 @@ else
 | 커밋 시간 (gh-commit) | ~$ELAPSED min |
 | 토큰 | ~$TOKENS |
 
-<!-- ai-metrics:gh-commit tokens=$TOKENS ai_min=$ELAPSED -->"
+---
+<details>
+<summary>🤖 AI Metrics · 📊 ~$TOKENS tokens · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-commit -->
+📊 ~$TOKENS tokens · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-commit -->
+
+</details>"
 fi
 ```
 

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -167,7 +167,15 @@ else
 
 예상 사람 시간: ~$HUMAN_H h · 토큰: ~$TOKENS
 
-<!-- ai-metrics:gh-issue-flow tokens=$TOKENS human_h=$HUMAN_H ai_min=$ELAPSED -->"
+---
+<details>
+<summary>🤖 AI Metrics · 📊 ~$TOKENS tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-issue-flow -->
+📊 ~$TOKENS tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-issue-flow -->
+
+</details>"
 fi
 ```
 

--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -103,7 +103,15 @@ if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
 else
     gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
       -X POST \
-      -f body="<!-- ai-metrics:gh-pr-approve ai_min=$ELAPSED -->
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-approve -->
+🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-approve -->
+
+</details>
 PR 리뷰: ~$ELAPSED min"
 fi
 ```

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -152,7 +152,15 @@ if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
 else
     gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
       -X POST \
-      -f body="<!-- ai-metrics:gh-pr-merge tokens=${TOKENS:-2000} human_h=0.25 ai_min=$ELAPSED -->
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-2000} tokens · 👤 ~0.25 h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-merge -->
+📊 ~${TOKENS:-2000} tokens · 👤 ~0.25 h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-merge -->
+
+</details>
 PR merge: ~$ELAPSED min"
 fi
 ```

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -101,7 +101,15 @@ if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
 else
     gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
       -X POST \
-      -f body="<!-- ai-metrics:gh-pr-reply tokens=${TOKENS:-5000} human_h=$HUMAN_H ai_min=$ELAPSED -->
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-5000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-reply -->
+📊 ~${TOKENS:-5000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-reply -->
+
+</details>
 리뷰 답변: ~$ELAPSED min · 사람: ~$HUMAN_H h ($COMMENT_COUNT comments × 0.25 h)"
 fi
 ```

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -138,7 +138,15 @@ if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
 else
     gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
       -X POST \
-      -f body="<!-- ai-metrics:gh-pr-resolve-conflict tokens=${TOKENS:-3000} human_h=$HUMAN_H ai_min=$ELAPSED -->
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-3000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-resolve-conflict -->
+📊 ~${TOKENS:-3000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-resolve-conflict -->
+
+</details>
 컨플릭트 해결: ~$ELAPSED min · 사람: ~$HUMAN_H h ($CONFLICT_FILES files × 0.5 h)"
 fi
 ```

--- a/claude/skills/skill-check/SKILL.md
+++ b/claude/skills/skill-check/SKILL.md
@@ -24,16 +24,19 @@ If the argument is `help`, read `references/help.md` and output its content verb
 If the user specifies a path, use it. Otherwise search for SKILL.md from the
 current directory.
 
-## Step 2: Run Ten Checks
+## Step 2: Run Eleven Checks
 
-Read `references/checks.md` for all 10 check definitions and PASS/WARN/FAIL/N/A criteria.
+Read `references/checks.md` for all 11 check definitions and PASS/WARN/FAIL/N/A criteria.
 Assign one result per check. Audit-only — never stop on failure; report every check (`skill:check` is read-only and must produce a full report).
 
 **Checks 1–5: Structure**
 Line Count · Progressive Disclosure · Frontmatter Validity · References Directory · Output Report
 
-**Checks 6–10: UX Quality**
-Help Flag Pattern · Step Structure · Options Documentation · Verdict Output · Next-action Hint
+**Checks 6–11: UX Quality**
+Help Flag Pattern · Step Structure · Options Documentation · Verdict Output · Next-action Hint · No Emojis
+
+Check 11 (No Emojis) consults `references/allowed-emoji-skills.txt` —
+audited skill names that appear in that file resolve to `[N/A] allowlisted`.
 
 ## Step 3: Output the Report
 

--- a/claude/skills/skill-check/references/allowed-emoji-skills.txt
+++ b/claude/skills/skill-check/references/allowed-emoji-skills.txt
@@ -1,0 +1,5 @@
+# Skills permitted to contain emojis (one per line).
+# Each entry must have a rationale comment.
+# Adding a new entry requires updating Check 11 rationale.
+
+gh-add-ai-metrics    # ai-metrics footer SSOT — CLAUDE.md exception (#317 F-2, PR #320, #367)

--- a/claude/skills/skill-check/references/checks.md
+++ b/claude/skills/skill-check/references/checks.md
@@ -67,3 +67,28 @@ PASS — success report includes next steps, follow-up commands, or teardown
 WARN — partial guidance (mentions what comes next but no concrete commands)
 FAIL — output ends without any guidance on what to do next
 N/A — skill is terminal (no natural follow-up action exists)
+
+### Check 11: No Emojis
+PASS — no emoji glyphs in SKILL.md body or `references/*.md`
+FAIL — emoji present AND skill name NOT in `references/allowed-emoji-skills.txt`
+N/A — skill name IS in allowlist (`[N/A] allowlisted in references/allowed-emoji-skills.txt`)
+WARN — allowlist file missing (degrade rather than block; skill:check stays read-only)
+
+Rationale: CLAUDE.md "No emojis anywhere" policy with one exception — the
+`ai-metrics` footer's `📊 👤 🤖` glyphs inside `<details>` / `<!-- ai-metrics -->`
+blocks (#317 F-2, PR #320, #367 wrapper).
+
+Detection: grep for codepoints in the ranges `U+1F300-U+1FAFF` (pictographic
+extended) and `U+2600-U+27BF` (misc symbols & dingbats). Range is intentionally
+narrower than "all emoji" to avoid false positives on BMP symbols (✓ ✗ etc).
+
+Skill name resolution: take frontmatter `name:` colon form and convert to
+hyphen form (`gh:add-ai-metrics` → `gh-add-ai-metrics`), or fall back to the
+directory basename when frontmatter `name:` is absent.
+
+Allowlist: `claude/skills/skill-check/references/allowed-emoji-skills.txt` —
+one skill name per line, `#` comments allowed, blank lines ignored. Each
+entry must carry an inline rationale comment.
+
+FAIL output: list up to 5 matched files+lines and append the guidance
+`Remove emoji or add to references/allowed-emoji-skills.txt with rationale`.

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -18,15 +18,16 @@ References dir: <exists / missing>
 | 5 | Output Report Defined        | PASS   | template in Step 3              |
 
 ### UX Quality Checks
-| # | Check                        | Result | Notes                                 |
-|---|------------------------------|--------|---------------------------------------|
-| 6 | Help Flag Pattern            | PASS   | -h/--help → references/help.md        |
-| 7 | Step Structure               | WARN   | steps present but no stop-on-error    |
-| 8 | Options Documentation        | N/A    | skill takes no arguments              |
-| 9 | Verdict Output               | FAIL   | output ends without [OK]/[FAIL]       |
-|10 | Next-action Hint             | PASS   | teardown shown in success report      |
+| #  | Check                        | Result | Notes                                 |
+|----|------------------------------|--------|---------------------------------------|
+| 6  | Help Flag Pattern            | PASS   | -h/--help → references/help.md        |
+| 7  | Step Structure               | WARN   | steps present but no stop-on-error    |
+| 8  | Options Documentation        | N/A    | skill takes no arguments              |
+| 9  | Verdict Output               | FAIL   | output ends without [OK]/[FAIL]       |
+| 10 | Next-action Hint             | PASS   | teardown shown in success report      |
+| 11 | No Emojis                    | PASS   | no emoji glyphs in body or references |
 
-Score: 5/9 checks passed (2 warnings, 2 fails, 1 N/A)
+Score: 6/10 checks passed (2 warnings, 2 fails, 1 N/A)
 Verdict: POOR — significant gaps, major rework needed
 
 ## Issues & Improvements

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -28,7 +28,7 @@ References dir: <exists / missing>
 | 11 | No Emojis                    | PASS   | no emoji glyphs in body or references |
 
 Score: 6/10 checks passed (2 warnings, 2 fails, 1 N/A)
-Verdict: POOR — significant gaps, major rework needed
+Verdict: NEEDS WORK — fix FAIL items before shipping
 
 ## Issues & Improvements
 


### PR DESCRIPTION
## Summary

- **Part 1 — ai-metrics footer SSOT 정렬 (6 skills)**: `gh-issue-flow`, `gh-pr-merge`, `gh-pr-reply`, `gh-pr-approve`, `gh-pr-resolve-conflict`, `gh-commit` 의 ai-metrics 코멘트가 bare `<!-- ai-metrics:* -->` HTML 코멘트만 출력하던 회귀를 복구. SSOT (`gh-add-ai-metrics/references/footer-detection.md` 라인 58·78) 형식대로 `<details><summary>🤖 AI Metrics …</summary>` 래퍼 + visible `📊 ~tokens · 👤 ~h · 🤖 ~min` 라인 추가.
- **Part 2 — `skill:check` Check 11 (No Emojis) + allowlist 신규**: `claude/skills/skill-check/references/checks.md` 에 PASS/FAIL/N/A/WARN 규칙 + emoji 검출 Unicode range (`U+1F300-U+1FAFF`, `U+2600-U+27BF`) 정의. `references/allowed-emoji-skills.txt` 별도 SSOT config 파일로 예외 관리 — 첫 entry 는 `gh-add-ai-metrics` (CLAUDE.md #317 F-2 예외).
- **Part 3 — sync**: `SKILL.md` Step 2 카운트 (`Run Ten Checks` → `Run Eleven Checks`), 섹션 헤더 (`Checks 6–10` → `Checks 6–11`), `references/report-template.md` Check 11 행 + Score 분모 (5/9 → 6/10) 동기 갱신.
- **Issue #403 호환**: `gh-pr-approve` (ai_min 만) 와 `gh-commit` (tokens + ai_min, no human_h) 은 false TOKENS/HUMAN_H 주입 없이 partial-data SSOT 형식 유지.

## Test plan

- [x] `grep -E '<!-- ai-metrics(:[a-zA-Z0-9_-]+)? -->'` 가 6개 변경 파일 모두에서 매치 (detection regex 호환성)
- [x] `<summary>🤖 AI Metrics` 가 6개 변경 파일 모두에 존재
- [x] `gh_disable_ai_metrics.bats` — `GH_DISABLE_AI_METRICS` 분기 doc-guard 통과 (`gh-issue-create` 의 pre-existing 실패 #1 는 본 PR 범위 외)
- [x] `gh_pr_reply_auto_approve.bats` — 15/15 PASS
- [x] `gh_pr_merge_board_gate.bats` — 5/5 PASS
- [x] `./tests/test` pytest 1013/1013 PASS (pre-existing 1 fail 외)
- [ ] PR merge 후 다음 새로 생성되는 PR/Issue 의 ai-metrics footer 가 visible emoji 라인으로 렌더
- [ ] `skill:check claude/skills/gh-add-ai-metrics/` 실행 결과 Check 11 = `[N/A] allowlisted`

Closes #535

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~8 h · 🤖 ~36 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~8 h · 🤖 ~36 min
<!-- /ai-metrics:gh-pr -->

</details>
