### PR TITLE
refactor(skills): make-jira → jira:report, make-confluence → confluence:page

### DIFF
--- a/claude/skills/confluence-page/README.md
+++ b/claude/skills/confluence-page/README.md
@@ -1,18 +1,18 @@
-# make-confluence Skill
+# confluence:page Skill
 
 Transform markdown technical documentation into Confluence-formatted guides.
 
 ## Quick Start
 
 ```bash
-# Convert markdown file to Confluence guide
-/make-confluence docs/technic/parallel-testing-with-xdist.md
+# Convert markdown file to Confluence page
+/confluence:page docs/technic/parallel-testing-with-xdist.md
 
 # Specify category explicitly
-/make-confluence docs/analysis/docker-optimization.md --category infrastructure
+/confluence:page docs/analysis/docker-optimization.md --category infrastructure
 
 # Batch process directory
-/make-confluence docs/technic/ --category testing
+/confluence:page docs/technic/ --category testing
 ```
 
 ## How It Works
@@ -92,7 +92,7 @@ Output location:
 
 ## Next Steps
 
-- Integration with `/make-jira` for weekly reports
+- Integration with `/jira:report` for weekly reports
 - Automation of technical documentation pipeline
 - Confluence API publishing (Phase P3)
 - Metadata registry in `rca-knowledge/_index.json`

--- a/claude/skills/confluence-page/SKILL.md
+++ b/claude/skills/confluence-page/SKILL.md
@@ -1,23 +1,23 @@
 ---
-name: make-confluence
+name: confluence:page
 description: >-
   Transform markdown technical documentation into Confluence-formatted guides
   with structured problem-solution-results format.
 ---
 
-# make-confluence
+# confluence:page
 
 ## Invocation
 
 ```bash
-# Generate Confluence guide from markdown file
-/make-confluence docs/technic/parallel-testing-with-xdist.md
+# Generate Confluence page from markdown file
+/confluence:page docs/technic/parallel-testing-with-xdist.md
 
 # Specify category
-/make-confluence docs/analysis/docker-optimization.md --category infrastructure
+/confluence:page docs/analysis/docker-optimization.md --category infrastructure
 
 # Generate for all docs in directory
-/make-confluence docs/technic/
+/confluence:page docs/technic/
 ```
 
 ## What It Does

--- a/claude/skills/confluence-page/instructions.md
+++ b/claude/skills/confluence-page/instructions.md
@@ -1,4 +1,4 @@
-# make-confluence: Detailed Implementation Instructions
+# confluence:page: Detailed Implementation Instructions
 
 ## Overview
 

--- a/claude/skills/jira-report/README.md
+++ b/claude/skills/jira-report/README.md
@@ -1,4 +1,4 @@
-# make-jira Skill
+# jira:report Skill
 
 Generate comprehensive weekly Jira reports from work log entries.
 
@@ -6,13 +6,13 @@ Generate comprehensive weekly Jira reports from work log entries.
 
 ```bash
 # Generate current week's report
-/make-jira
+/jira:report
 
 # Generate specific week
-/make-jira --week 2026-W05
+/jira:report --week 2026-W05
 
 # Generate for specific Jira key
-/make-jira SWINNOTEAM-906
+/jira:report SWINNOTEAM-906
 ```
 
 ## How It Works
@@ -63,6 +63,6 @@ Generate comprehensive weekly Jira reports from work log entries.
 
 ## Next Steps
 
-- Integration with `/make-confluence` for technical documentation generation
+- Integration with `/confluence:page` for technical documentation generation
 - LLM-based summarization of achievements
 - Automated index updates in `rca-knowledge/_index.json`

--- a/claude/skills/jira-report/SKILL.md
+++ b/claude/skills/jira-report/SKILL.md
@@ -1,22 +1,22 @@
 ---
-name: make-jira
+name: jira:report
 description: >-
   Generate comprehensive weekly Jira reports from work logs.
 ---
 
-# make-jira
+# jira:report
 
 ## Invocation
 
 ```bash
 # Generate current week's report
-/make-jira
+/jira:report
 
 # Generate specific week
-/make-jira --week 2026-W05
+/jira:report --week 2026-W05
 
 # Generate report for specific Jira key only
-/make-jira SWINNOTEAM-906
+/jira:report SWINNOTEAM-906
 ```
 
 ## What It Does
@@ -52,7 +52,7 @@ Work Log
 
 - **Primary**: `~/work_log.txt` (work log entries with timestamps, Jira keys, hours)
 - **Secondary**: `git log` output (commit messages for context)
-- **Optional**: `.claude/skills/make-jira/templates/` (customization)
+- **Optional**: `.claude/skills/jira-report/templates/` (customization)
 
 ## Success Criteria
 

--- a/claude/skills/jira-report/SKILL.md
+++ b/claude/skills/jira-report/SKILL.md
@@ -52,7 +52,7 @@ Work Log
 
 - **Primary**: `~/work_log.txt` (work log entries with timestamps, Jira keys, hours)
 - **Secondary**: `git log` output (commit messages for context)
-- **Optional**: `.claude/skills/jira-report/templates/` (customization)
+- **Optional**: `templates/` (customization)
 
 ## Success Criteria
 

--- a/claude/skills/jira-report/instructions.md
+++ b/claude/skills/jira-report/instructions.md
@@ -1,4 +1,4 @@
-# make-jira: Detailed Implementation Instructions
+# jira:report: Detailed Implementation Instructions
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- `make-jira` 스킬을 `jira:report`으로, `make-confluence` 스킬을 `confluence:page`로 rename
- 기존 `jira:create`, `jira:read`와 일관된 네임스페이스(`jira:*`, `confluence:*`)로 통합
- 동작 변경 없음 — 디렉터리명, `SKILL.md name:` 필드, README/instructions 제목만 수정

## Changes
- `claude/skills/make-jira → jira-report`: 디렉터리 rename + SKILL.md/README/instructions 이름 일괄 수정
- `claude/skills/make-confluence → confluence-page`: 디렉터리 rename + SKILL.md/README/instructions 이름 일괄 수정
- 두 스킬 간 교차 참조 (`/make-jira ↔ /make-confluence`) → 새 이름으로 갱신

## Test plan
- [ ] `/jira:report` 호출 → 스킬 정상 로드
- [ ] `/confluence:page` 호출 → 스킬 정상 로드
- [ ] 시스템 리마인더에서 새 이름(`jira:report`, `confluence:page`)으로 표시 확인

## Related
Closes #542

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~4 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
