### PR TITLE
refactor(skills): rename write-blog-dev-learnings to write:blog-dev-learnings

### DIFF
--- a/claude/skills/write-blog-dev-learnings/SKILL.md
+++ b/claude/skills/write-blog-dev-learnings/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: write-blog-dev-learnings
+name: write:blog-dev-learnings
 description: >-
   Write entertaining Korean developer blog posts about debugging war stories,
   production incidents, and technical gotchas. Saves to
@@ -144,9 +144,9 @@ Step-by-step으로 구체적으로. 코드블록 필수.
 The user runs this skill from **any project directory** via Claude Code TUI:
 
 ```
-/write-blog-dev-learnings "지금까지 너와 작업한 내용"
-/write-blog-dev-learnings "오늘 redis sed injection 삽질"
-/write-blog-dev-learnings "WSL systemd 감지 문제"
+/write:blog-dev-learnings "지금까지 너와 작업한 내용"
+/write:blog-dev-learnings "오늘 redis sed injection 삽질"
+/write:blog-dev-learnings "WSL systemd 감지 문제"
 ```
 
 The quoted text is the **topic hint**. It can be:

--- a/claude/skills/write-blog-dev-learnings/references/help.md
+++ b/claude/skills/write-blog-dev-learnings/references/help.md
@@ -1,9 +1,9 @@
-# skill:write-blog-dev-learnings — Help
+# write:blog-dev-learnings — Help
 
 ## Synopsis
 
 ```
-/write-blog-dev-learnings "<topic-hint>"
+/write:blog-dev-learnings "<topic-hint>"
 ```
 
 ## Description
@@ -24,9 +24,9 @@ production incidents, and technical gotchas. Saves to
 ## Examples
 
 ```
-/write-blog-dev-learnings "지금까지 너와 작업한 내용"
-/write-blog-dev-learnings "오늘 redis sed injection 삽질"
-/write-blog-dev-learnings "WSL systemd 감지 문제"
+/write:blog-dev-learnings "지금까지 너와 작업한 내용"
+/write:blog-dev-learnings "오늘 redis sed injection 삽질"
+/write:blog-dev-learnings "WSL systemd 감지 문제"
 ```
 
 ## Stop conditions

--- a/claude/skills/write-insight/SKILL.md
+++ b/claude/skills/write-insight/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   note from conversation evidence (PRs, commits, review threads, repro steps)
   instead of asking the user to restate context. Decline topics that belong in
   `docs/technic/`, `docs/standards/`, `docs/feature/`, or `claude/skills/`.
-  Do not use this for narrative "삽질" posts (`write-blog-dev-learnings`), formal
+  Do not use this for narrative "삽질" posts (`write:blog-dev-learnings`), formal
   postmortems (`write:rca`), or JIRA/PR draft summaries (`write:task-history`).
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---

--- a/claude/skills/write-insight/references/help.md
+++ b/claude/skills/write-insight/references/help.md
@@ -30,7 +30,7 @@ PR / commit / file:line). Also updates `docs/learnings/README.md` index.
 
 ## Related skills
 
-- `write-blog-dev-learnings` — narrative "삽질" blog posts in `~/para/archive/`
+- `write:blog-dev-learnings` — narrative "삽질" blog posts in `~/para/archive/`
 - `write:rca` — formal RCA / postmortem (Jekyll)
 - `write:task-history` — JIRA / PR description drafting from session work
 

--- a/claude/skills/write-insight/references/routing.md
+++ b/claude/skills/write-insight/references/routing.md
@@ -26,7 +26,7 @@ write-insight to cover them.
 
 | Skill | Output target | Use it when |
 |---|---|---|
-| `write-blog-dev-learnings` | `~/para/archive/playbook/docs/dev-learnings/` | User wants a narrative "삽질" blog post in entertaining tone |
+| `write:blog-dev-learnings` | `~/para/archive/playbook/docs/dev-learnings/` | User wants a narrative "삽질" blog post in entertaining tone |
 | `write:rca` | `~/para/archive/rca-knowledge/` | User wants a formal RCA / postmortem with Jekyll frontmatter |
 | `write:task-history` | daily task list file | User wants JIRA ticket text or PR description draft from session work |
 


### PR DESCRIPTION
## Summary
- `write-blog-dev-learnings` 스킬의 `name:` frontmatter를 `write:blog-dev-learnings`으로 변경
- 명명 규칙을 `plugin:skill-name` 콜론 구분자 형식으로 통일 (devx:*, gh:* 등과 일치)
- 디렉터리 이름은 변경 없음 (`devx-reverse-engineering-analysis` 패턴 준수)

## Changes
- `write-blog-dev-learnings/SKILL.md`: `name:` frontmatter + 호출 예시 업데이트
- `write-blog-dev-learnings/references/help.md`: 헤딩, synopsis, 예시 업데이트
- `write-insight/SKILL.md`: 크로스 레퍼런스 업데이트
- `write-insight/references/help.md`: 관련 스킬 링크 업데이트
- `write-insight/references/routing.md`: 라우팅 테이블 업데이트

## Test plan
- [ ] `Skill` 도구로 `write:blog-dev-learnings` 호출 시 정상 로드 확인
- [ ] `grep -r "write-blog-dev-learnings" .` 결과 없음 확인

## Related
Closes #547

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~2 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~2 min
<\!-- /ai-metrics:gh-pr -->

</details>
