### PR TITLE
fix(claude/setup): force-init guard bypass + move statusline backup (#554)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ __pycache__/
 
 # Claude Code personal settings (user-specific, environment-dependent)
 claude/settings.json
+# Migration backups carry the same secrets as the source — keep them out of
+# the tree even when the migration helper happens to write here (issue #554).
+claude/settings.json.*
 .claude/
 
 # VS Code settings (bidirectional sync system, PC-specific)

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -109,8 +109,16 @@ _migrate_legacy_statusline_command() {
     current=$(jq -r '.statusLine?.command? // empty' "$source_file" 2>/dev/null)
     [ "$current" = "$legacy_literal" ] || return 0
 
+    # 백업은 dotfiles tree 밖에 둔다 (issue #554). 과거 ${source_file}.* 로
+    # 두면 settings.json 안의 평문 토큰(사내 ANTHROPIC_AUTH_TOKEN 등)이
+    # untracked 파일로 노출돼 `git add -A` 1번에 push 될 위험이 있다.
+    local backup_dir="${HOME}/.claude-backups"
+    if ! mkdir -p "$backup_dir"; then
+        log_error "백업 디렉토리 생성 실패: $backup_dir — 마이그레이션 중단"
+        return 1
+    fi
     local backup
-    backup="${source_file}.pre-statusline-fix-$(date +%Y%m%d%H%M%S)"
+    backup="${backup_dir}/settings.json.pre-statusline-fix-$(date +%Y%m%d%H%M%S)"
     if ! cp "$source_file" "$backup"; then
         log_error "settings.json 백업 실패: $backup — 마이그레이션 중단"
         return 1
@@ -372,9 +380,16 @@ _migrate_legacy_statusline_command
 # the entry when it's missing AND no conflicting Stop hook is configured.
 _migrate_install_gh_issue_flow_stop_hook
 
-# 다중 계정 함수 source (env + integration)
-. "$DOTFILES_ROOT/shell-common/env/claude.sh"
-. "$DOTFILES_ROOT/shell-common/tools/integrations/claude.sh"
+# 다중 계정 함수 source (env + integration).
+# 두 파일은 함수 정의 앞에 단순 interactive guard(`case $- in *i*) ;; *)
+# [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac`)를 가지므로,
+# ./setup.sh 가 비대화형으로 호출됐을 때 함수 정의가 스킵된다.
+# 결과적으로 _claude_has_unmigrated_data / _claude_resolve_account 가
+# 미정의로 떨어져 다중 계정 루프(line 404)가 silent skip 됨 (issue #554).
+# 가드 자체는 단순 형태를 유지해야 하므로(`bats/CI` 호환), source 직전
+# prefix 형태로 FORCE_INIT 신호를 한 줄만 켠다.
+DOTFILES_FORCE_INIT=1 . "$DOTFILES_ROOT/shell-common/env/claude.sh"
+DOTFILES_FORCE_INIT=1 . "$DOTFILES_ROOT/shell-common/tools/integrations/claude.sh"
 
 # 마이그레이션 미수행 가드는 mkdir 보다 먼저 — 그래야 stale ~/.claude 가
 # 가드 디렉토리 생성으로 가려지지 않는다. SSOT: _claude_has_unmigrated_data

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -385,7 +385,7 @@ _migrate_install_gh_issue_flow_stop_hook
 # [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac`)를 가지므로,
 # ./setup.sh 가 비대화형으로 호출됐을 때 함수 정의가 스킵된다.
 # 결과적으로 _claude_has_unmigrated_data / _claude_resolve_account 가
-# 미정의로 떨어져 다중 계정 루프(line 404)가 silent skip 됨 (issue #554).
+# 미정의로 떨어져 다중 계정 루프(line 419)가 silent skip 됨 (issue #554).
 # 가드 자체는 단순 형태를 유지해야 하므로(`bats/CI` 호환), source 직전
 # prefix 형태로 FORCE_INIT 신호를 한 줄만 켠다.
 DOTFILES_FORCE_INIT=1 . "$DOTFILES_ROOT/shell-common/env/claude.sh"

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -519,8 +519,9 @@ MOCK
 # ---------- Task 11: claude/setup.sh integration ----------
 
 # Stage an isolated DOTFILES_ROOT under $TEST_TEMP_HOME so setup.sh's writes
-# (settings.json migration, *.pre-statusline-fix-* backup files) land in a
-# throwaway tree instead of the version-controlled checkout (issue #303).
+# (settings.json migration) land in a throwaway tree instead of the
+# version-controlled checkout (issue #303). Backup files now live under
+# $HOME/.claude-backups (issue #554) — also throwaway since $HOME is isolated.
 _setup_sh_prereqs() {
     setup_isolated_dotfiles_root
 }
@@ -591,8 +592,9 @@ _setup_sh_prereqs() {
 # These tests overwrite settings.json with a fixture that triggers (or
 # avoids triggering) the item-A migration. Since _setup_sh_prereqs now
 # stages an isolated DOTFILES_ROOT under $TEST_TEMP_HOME (issue #303),
-# fixture writes and any *.pre-statusline-fix-* backup files setup.sh
-# produces are torn down with $TEST_TEMP_HOME — no save/restore needed.
+# fixture writes are torn down with $TEST_TEMP_HOME — no save/restore needed.
+# Backup files since issue #554 land in $HOME/.claude-backups/, which is
+# also under the isolated $TEST_TEMP_HOME.
 _use_settings_fixture() {
     cat > "${DOTFILES_ROOT}/claude/settings.json" <<JSON
 {
@@ -615,8 +617,10 @@ JSON
 
     cmd=$(jq -r '.statusLine.command' "${DOTFILES_ROOT}/claude/settings.json")
     [ "$cmd" = '${HOME}/dotfiles/claude/statusline-command.sh' ]
-    # Backup file present alongside the source.
-    ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-[0-9]{14}'
+    # Backup file lives in $HOME/.claude-backups, NOT in the dotfiles tree
+    # (issue #554). Asserting both rules keeps a regression visible.
+    ls "$HOME/.claude-backups/" | grep -qE 'settings\.json\.pre-statusline-fix-[0-9]{14}'
+    ! ls "${DOTFILES_ROOT}/claude/" 2>/dev/null | grep -qE 'settings\.json\.pre-statusline-fix-'
 }
 
 @test "issue #300-A: setup.sh leaves already-migrated statusLine.command alone" {
@@ -628,8 +632,10 @@ JSON
     assert_success
     refute_output --partial "자동 마이그레이션 완료"
 
-    # No backup spawned for a no-op run.
-    ! ls "${DOTFILES_ROOT}/claude/" | grep -qE 'settings\.json\.pre-statusline-fix-'
+    # No backup spawned for a no-op run — check both the legacy in-tree
+    # location and the new $HOME/.claude-backups location (issue #554).
+    ! ls "${DOTFILES_ROOT}/claude/" 2>/dev/null | grep -qE 'settings\.json\.pre-statusline-fix-'
+    ! ls "$HOME/.claude-backups/" 2>/dev/null | grep -qE 'settings\.json\.pre-statusline-fix-'
 }
 
 @test "issue #300-A: setup.sh preserves user-customised statusLine.command" {
@@ -643,6 +649,38 @@ JSON
 
     cmd=$(jq -r '.statusLine.command' "${DOTFILES_ROOT}/claude/settings.json")
     [ "$cmd" = "$HOME/bin/my-custom-statusline.sh" ]
+}
+
+# ---------- Regression: issue #554 ----------
+#
+# claude/setup.sh sources shell-common/{env,tools/integrations}/claude.sh
+# to load _claude_resolve_account / _claude_has_unmigrated_data. Both files
+# carry an interactive guard that early-returns under non-interactive
+# bash unless DOTFILES_FORCE_INIT is set. When ./setup.sh is invoked by an
+# end user (no env override), the guard skipped the function definitions,
+# producing "command not found" errors and a silently empty
+# ENABLED_ACCOUNTS — the entire multi-account install loop was skipped.
+#
+# run_in_bash always exports DOTFILES_FORCE_INIT=1, so this test
+# deliberately bypasses it to mimic the real-user invocation path.
+
+@test "regression #554: claude/setup.sh defines multi-account helpers without DOTFILES_FORCE_INIT" {
+    _setup_sh_prereqs
+
+    # No DOTFILES_FORCE_INIT, no DOTFILES_TEST_MODE — mirror the real
+    # ./setup.sh invocation as seen on a fresh PC.
+    run bash --noprofile --norc -c "
+        unset DOTFILES_FORCE_INIT
+        unset DOTFILES_TEST_MODE
+        export HOME='$HOME'
+        export TERM=dumb
+        CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 \
+            bash '${DOTFILES_ROOT}/claude/setup.sh'
+    "
+    assert_success
+    refute_output --partial "_claude_has_unmigrated_data: command not found"
+    refute_output --partial "_claude_resolve_account: command not found"
+    refute_output --partial "command not found"
 }
 
 # ---------- Issue #300, item C: claude_accounts_status shows oauth binding ----------


### PR DESCRIPTION
## Summary
- `./setup.sh` 비대화형 실행 시 multi-account 셋업 루프가 silent skip 되던 회귀를 차단 — `claude/setup.sh` 가 `shell-common/{env,tools/integrations}/claude.sh` 를 source 할 때 `DOTFILES_FORCE_INIT=1` prefix 한 줄을 켜 interactive guard 의 early-return 을 우회.
- statusLine 마이그레이션 백업 파일을 dotfiles tree 밖 `${HOME}/.claude-backups/` 로 이전 + `.gitignore` 에 `claude/settings.json.*` glob 추가 — 백업 안에 들어있던 사내망 `ANTHROPIC_AUTH_TOKEN` 평문이 untracked 로 노출돼 `git add -A` 한 번에 push 될 위험을 차단.
- bats 회귀 테스트 추가 (`regression #554`) — `DOTFILES_FORCE_INIT` 미설정 상태의 비대화형 setup.sh 실행에서 `command not found` 0건임을 검증해 동일 패턴(PR #497 회귀와 같은 류) 재발을 잡는다.

## Changes
- `claude/setup.sh:380-396` — 두 source 라인에 `DOTFILES_FORCE_INIT=1` prefix. 영향 범위를 해당 두 줄로 한정해 setup.sh 전역 동작은 그대로 유지. 주석으로 회귀 차단 의도를 명시 (`issue #554`).
- `claude/setup.sh:112-122` — `_migrate_legacy_statusline_command` 백업 경로를 `${source_file}.pre-statusline-fix-<ts>` → `${HOME}/.claude-backups/settings.json.pre-statusline-fix-<ts>` 로 변경. `mkdir -p` 실패 시 정상 에러 경로 유지.
- `.gitignore:28-30` — `claude/settings.json.*` glob 추가. 미래 누군가 백업 경로를 다시 dotfiles tree 안으로 옮기더라도 토큰이 push 되지 않도록 이중 방어.
- `tests/bats/integrations/claude_accounts.bats` — (1) `issue #300-A` rewrite 테스트: 백업 위치 어서션을 `$HOME/.claude-backups/` 로 갱신하고 dotfiles tree 가 깨끗함을 함께 확인. (2) `issue #300-A` no-op 테스트: 두 경로 모두에서 백업 부재 확인. (3) 신규 `regression #554` 테스트: 비대화형 bash 에서 `DOTFILES_FORCE_INIT` / `DOTFILES_TEST_MODE` 둘 다 unset 한 상태로 `claude/setup.sh` 를 돌려 `command not found` 0건을 검증.

## Test plan
- [x] `tox -e shellcheck` — OK
- [x] `tox -e shfmt` — OK
- [x] 수동 smoke test: 격리된 `$HOME` + `unset DOTFILES_FORCE_INIT DOTFILES_TEST_MODE` 로 `claude/setup.sh` 실행 → `command not found` 0건, `활성 계정: personal work`, `Account: personal/work` 루프 모두 실행, 백업 파일이 `$HOME/.claude-backups/` 에 생성.
- [ ] CI: bats 스위트 통과 (`tests/bats/integrations/claude_accounts.bats` 의 issue #300-A 갱신본 + 신규 `regression #554`).
- [ ] CI: `tox` 통합 통과.
- [ ] 실제 사내 PC 에서 `./setup.sh` 재실행 후 `claude/settings.json.pre-statusline-fix-*` 가 dotfiles tree 에 나타나지 않는지 확인 (이미 노출된 사내 토큰은 별도 폐기/회전 필요).

## Related
Fixes #554

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~2 h · 🤖 ~1 min
<\!-- /ai-metrics:gh-pr -->

</details>
