### PR TITLE
chore(claude): #555 settings.local.json SSOT 통합

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -43,13 +43,16 @@ Or configure in `settings.json` (line 174):
 
 ## Configuration Files
 
-Settings are managed via symlinks and bind mount:
+Settings are managed via symlinks (per-skill / per-doc symlinks for
+the skills/ and docs/ directories — issue #342 replaced the legacy
+bind-mount design):
 
 ```bash
-~/.claude/settings.json -> ~/dotfiles/claude/settings.json (symlink)
-~/.claude/settings.local.json -> ~/dotfiles/claude/settings.local.json (symlink)
-~/.claude/statusline-command.sh -> ~/dotfiles/claude/statusline-command.sh (symlink)
-~/.claude/skills <- ~/dotfiles/claude/skills (bind mount)
+~/.claude-personal/settings.json         -> ~/dotfiles/claude/settings.json
+~/.claude-personal/settings.local.json   -> ~/dotfiles/claude/settings.local.json
+~/.claude-personal/statusline-command.sh -> ~/dotfiles/claude/statusline-command.sh
+~/.claude-personal/skills/<name>         -> ~/dotfiles/claude/skills/<name>   (per-skill)
+~/.claude-personal/docs/<name>           -> ~/dotfiles/claude/docs/<name>     (per-doc)
 ```
 
 `settings.local.json` carries the env block (e.g. `GH_PR_REPLY_AUTO_APPROVE_REPOS`)

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -47,9 +47,14 @@ Settings are managed via symlinks and bind mount:
 
 ```bash
 ~/.claude/settings.json -> ~/dotfiles/claude/settings.json (symlink)
+~/.claude/settings.local.json -> ~/dotfiles/claude/settings.local.json (symlink)
 ~/.claude/statusline-command.sh -> ~/dotfiles/claude/statusline-command.sh (symlink)
 ~/.claude/skills <- ~/dotfiles/claude/skills (bind mount)
 ```
+
+`settings.local.json` carries the env block (e.g. `GH_PR_REPLY_AUTO_APPROVE_REPOS`)
+shared across all of the user's machines via the dotfiles SSOT — distinct
+from `settings.json` which is gitignored / per-machine.
 
 ## Setup Script (setup.sh)
 

--- a/claude/settings.local.json
+++ b/claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles"
+  }
+}

--- a/claude/settings.template.json
+++ b/claude/settings.template.json
@@ -1,7 +1,4 @@
 {
-  "env": {
-    "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles"
-  },
   "permissions": {
     "allow": [
       "Edit(**/test_*.py)",

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -137,6 +137,52 @@ _migrate_legacy_statusline_command() {
     fi
 }
 
+# Auto-remove duplicate env block from settings.json (issue #555 follow-up,
+# PR #557 review C1). The env SSOT moved to settings.local.json; users who
+# previously hand-merged the env block into their per-machine settings.json
+# would otherwise end up with duplicate definitions, defeating the SSOT
+# intent. Idempotent — only mutates when both files carry an env block,
+# always backs up, and restores on failure.
+_migrate_remove_duplicate_env_from_settings() {
+    local source_file="$CLAUDE_SETTINGS_SOURCE"
+    local local_file="${CLAUDE_DOTFILES}/settings.local.json"
+
+    [ -f "$source_file" ] || return 0
+    [ -f "$local_file" ] || return 0
+    if ! command -v jq >/dev/null 2>&1; then
+        log_warning "jq 미설치 — settings.json env 자동 마이그레이션 건너뜀"
+        return 0
+    fi
+
+    # Skip when settings.json carries no env block.
+    jq -e '.env? | type == "object"' "$source_file" >/dev/null 2>&1 || return 0
+    # Skip when settings.local.json carries no env block (nothing to consolidate to).
+    jq -e '.env? | type == "object"' "$local_file"  >/dev/null 2>&1 || return 0
+
+    local backup
+    backup="${source_file}.pre-env-migration-$(date +%Y%m%d%H%M%S)"
+    if ! cp "$source_file" "$backup"; then
+        log_warning "settings.json env 마이그레이션: 백업 실패 → skip"
+        return 0
+    fi
+
+    local tmp
+    tmp=$(mktemp "${source_file}.XXXXXX") || {
+        log_warning "settings.json env 마이그레이션: 임시 파일 생성 실패 → skip"
+        rm -f "$backup"
+        return 0
+    }
+
+    if jq 'del(.env)' "$source_file" > "$tmp" && mv "$tmp" "$source_file"; then
+        log_warning "settings.json: env 블록 제거됨 (SSOT 가 settings.local.json 으로 이동)"
+        log_warning "  backup: $backup"
+    else
+        rm -f "$tmp"
+        log_warning "settings.json env 마이그레이션 실패 — 원본 복원: $backup"
+        mv "$backup" "$source_file"
+    fi
+}
+
 # Auto-migrate legacy Claude Code plugin paths (issue #340).
 #
 # Claude Code recently moved its plugin storage from
@@ -368,6 +414,11 @@ fi
 # downstream symlink uses it (issue #300, item A). Idempotent — only acts
 # on the exact PR #292 legacy literal, otherwise no-op.
 _migrate_legacy_statusline_command
+
+# Auto-remove duplicate env block from settings.json (issue #555 follow-up,
+# PR #557 review C1). Idempotent — only acts when both settings.json and
+# settings.local.json carry an env block, otherwise no-op.
+_migrate_remove_duplicate_env_from_settings
 
 # Auto-install gh-issue-flow Stop hook (issue #383). Idempotent — only adds
 # the entry when it's missing AND no conflicting Stop hook is configured.

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -7,10 +7,11 @@
 #
 # SPECIAL INITIALIZATION (why this file is REQUIRED):
 #   1. Creates ~/.claude/settings.json symlink (Claude Code settings)
-#   2. Creates ~/.claude/statusline-command.sh symlink (status line script)
-#   3. Creates ~/.claude/skills symlink (custom skills directory)
-#   4. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
-#   5. Verifies ~/.claude directory structure
+#   2. Creates ~/.claude/settings.local.json symlink (env / per-user overrides)
+#   3. Creates ~/.claude/statusline-command.sh symlink (status line script)
+#   4. Creates ~/.claude/skills symlink (custom skills directory)
+#   5. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
+#   6. Verifies ~/.claude directory structure
 #
 # These files/directories are version-controlled in dotfiles and should
 # be managed via symbolic links for consistency across machines.
@@ -425,7 +426,7 @@ done
 log_debug "\n--- 심볼릭 링크 확인 ---"
 for acct in $ENABLED_ACCOUNTS; do
     cdir=$(_claude_resolve_account "$acct")
-    for link in settings.json statusline-command.sh plugins projects/GLOBAL/memory; do
+    for link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory; do
         if [ -L "${cdir}/${link}" ]; then
             log_dim "✓ ${acct}/${link} 심볼릭 링크 확인됨"
         else

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -911,6 +911,7 @@ _claude_account_setup_one() {
     mkdir -p "$_caso_cdir/projects/GLOBAL"
 
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/settings.json"          "$_caso_cdir/settings.json"
+    _claude_ensure_symlink "${DOTFILES_ROOT}/claude/settings.local.json"    "$_caso_cdir/settings.local.json"
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/statusline-command.sh"  "$_caso_cdir/statusline-command.sh"
     _claude_ensure_symlink "$HOME/.claude-shared/plugins"                   "$_caso_cdir/plugins"
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/global-memory"          "$_caso_cdir/projects/GLOBAL/memory"
@@ -1005,7 +1006,7 @@ claude_accounts_status() {
             echo "                → Run: claude-yolo --user $_cas_acct"
         fi
 
-        for _cas_link in settings.json statusline-command.sh plugins projects/GLOBAL/memory; do
+        for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory; do
             if [ -L "$_cas_cdir/$_cas_link" ]; then
                 echo "  $_cas_link: symlink ✓"
             else

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -137,6 +137,7 @@ LOCAL
     assert_success
 
     [ -L "$HOME/.claude-personal/settings.json" ]
+    [ -L "$HOME/.claude-personal/settings.local.json" ]
     [ -L "$HOME/.claude-personal/statusline-command.sh" ]
     [ -L "$HOME/.claude-personal/plugins" ]
     [ -L "$HOME/.claude-personal/projects/GLOBAL/memory" ]


### PR DESCRIPTION
## Summary
- `~/.claude/settings.local.json` 의 env 블록을 dotfiles SSOT (`~/dotfiles/claude/settings.local.json`) 로 승격. git 추적 + symlink 체계로 모든 머신에서 동일 적용.
- `setup.sh` / `_claude_account_setup_one` 가 신규 symlink 를 멱등 설치하고 `claude_accounts_status` 가 검증.
- `settings.template.json` 의 env 블록은 제거 — SSOT 가 `settings.local.json` 단일 파일로 수렴.

## Changes
- **`claude/settings.local.json` (신규, 트래킹)** — env 블록 SSOT.
  ```json
  { "env": { "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles" } }
  ```
- **`shell-common/tools/integrations/claude.sh`** —
  `_claude_account_setup_one` 에 `_claude_ensure_symlink ".../settings.local.json"` 한 줄 추가, `claude_accounts_status` 검증 루프에도 `settings.local.json` 추가.
- **`claude/setup.sh`** — verify-links 루프 (`for link in settings.json settings.local.json statusline-command.sh ...`) + 최상단 docstring 항목 추가.
- **`claude/settings.template.json`** — env 블록 제거 (template 와 SSOT 가 분기되지 않게).
- **`claude/AGENTS.md`** — Configuration Files 섹션에 `settings.local.json` symlink 라인 추가 + 1-line 설명 (machine-shared SSOT vs gitignored per-machine 차이 명시).
- **`tests/bats/integrations/claude_accounts.bats`** — `_claude_account_setup_one` 테스트에 `[ -L .../settings.local.json ]` assertion 1줄 추가.

## Test plan
- [x] `bats tests/bats/integrations/claude_accounts.bats` — 85/86 PASS. 1건 실패는 `#342 second claude-skills-sync prints (no changes)` 로 origin/main 에서도 동일하게 fail 하는 기존 회귀, 본 PR 미관련.
- [ ] 본 PR merge 후 `git pull` + `./setup.sh` 1회로 `~/.claude-personal/settings.local.json -> ~/dotfiles/claude/settings.local.json` symlink 자동 생성 확인.
- [ ] 새 Claude Code 세션 시작 후 `env | grep GH_PR_REPLY_AUTO_APPROVE_REPOS` → 값 등장.
- [ ] `/gh-pr-reply <PR>` Step 8 G1 가드가 통과 → solo-repo auto-approve 동작.
- [ ] 다른 머신 (외부/회사 PC) 에서도 동일 절차 수행 시 동일 상태로 수렴.

## Per-machine cleanup (gitignored, 본 PR 범위 밖)
이번 머신에서 SSOT 패턴 정합성 회복을 위해 이미 적용:
- `~/dotfiles/claude/settings.json` 의 env 블록 제거 (gitignored, drift 방지).
- `~/.claude/settings.local.json` regular file → `~/.claude/settings.local.json.bak-2026-05-11` 백업.
- `~/.claude-personal/settings.local.json` → `~/dotfiles/claude/settings.local.json` symlink 생성 (target 은 본 PR merge 후 resolve).

다른 머신은 PR merge → `git pull` → `./setup.sh` 1회로 동일 상태 도달.

## Lint guard 우회 사유
이 PR 에서 변경한 markdown (`claude/AGENTS.md`) 은 lint clean 이지만, `tox -e mdlint` 가 자동으로 모든 `*.md` 를 검사하면서 본 PR 미관련 `zsh/AGENTS.md` 의 기존 `MD025/MD022` 위반들로 fail. `CLAUDE.md` 에 명시적으로 "Markdown linting (`tox -e mdlint`) is **disabled** — do not run it." 가이드가 있어 `GH_PR_LINT_BYPASS=1` 우회.

## Related
Closes #555

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~0.75 h · 🤖 ~0 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~0.75 h · 🤖 ~0 min
<\!-- /ai-metrics:gh-pr -->

</details>
