### PR TITLE
refactor(gb): git_branch dispatcher — gb -D local|remote 통합

### DIFF
--- a/shell-common/aliases/git.sh
+++ b/shell-common/aliases/git.sh
@@ -29,7 +29,7 @@ alias gl2='git log --graph --decorate --date=short --abbrev-commit --pretty=onel
 alias glref='git log ref/main --oneline'         # ref 원격 main 브랜치 한줄 로그
 
 # Git branch/checkout
-alias gb='git --no-pager branch'                 # 브랜치 목록 (pager 비활성화)
+# gb is defined as git_branch() in functions/git.sh (gb -D local|remote dispatcher)
 alias gbv='git branch -vv'                       # 브랜치 상세 정보 (upstream 연결 상태 확인)
 alias gco='git checkout'                         # 체크아웃 (브랜치 이동 등)
 

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -55,7 +55,7 @@ _gb_clean_remote() {
 
     # Capture branch list once, reuse for count and iteration
     local branches
-    branches=$(git branch -r | grep "^[[:space:]]*$remote/" | grep -v "^[[:space:]]*$remote/main" | sed 's/^[[:space:]]*//')
+    branches=$(git branch -r | grep "^[[:space:]]*$remote/" | grep -v "^[[:space:]]*$remote/main" | grep -v "^[[:space:]]*$remote/master" | grep -v "-> " | sed 's/^[[:space:]]*//')
 
     local branch_count
     branch_count=$(printf '%s\n' "$branches" | grep -c . 2>/dev/null || echo 0)
@@ -79,7 +79,7 @@ _gb_help() {
     ux_info "Usage: gb [-D local] [-D remote [<remote>]] [git-branch-flags...]"
     ux_bullet "sub-commands"
     ux_bullet_sub "gb -D local               delete local branches (keeps: main + current + keywords)"
-    ux_bullet_sub "gb -D remote [<remote>]   delete remote branches (default: origin, keeps: main)"
+    ux_bullet_sub "gb -D remote [<remote>]   delete remote-tracking branches (default: origin, keeps: main/master)"
     ux_bullet_sub "gb [flags]                passthrough to git --no-pager branch"
 }
 
@@ -144,7 +144,7 @@ _gb_clean_local() {
     while IFS= read -r branch; do
         [ -n "$branch" ] || continue
 
-        if [ "$branch" = "main" ] || [ "$branch" = "$current_branch" ]; then
+        if [ "$branch" = "main" ] || [ "$branch" = "master" ] || [ "$branch" = "$current_branch" ]; then
             continue
         fi
 

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -47,16 +47,11 @@ git_log_upstream() {
 }
 
 # ============================================================================
-# Prune remote branches (except main)
+# gb — unified branch management dispatcher
+# Usage: gb [-D local] [-D remote [<remote>]] [git-branch-flags...]
 # ============================================================================
-git_prune_remote() {
-    if [ -z "$1" ]; then
-        ux_error "Usage: gprune <remote-name>"
-        ux_error "Example: gprune origin"
-        return 1
-    fi
-
-    local remote="$1"
+_gb_clean_remote() {
+    local remote="${1:-origin}"
 
     # Capture branch list once, reuse for count and iteration
     local branches
@@ -80,6 +75,30 @@ git_prune_remote() {
     ux_success "Done!"
 }
 
+_gb_help() {
+    ux_info "Usage: gb [-D local] [-D remote [<remote>]] [git-branch-flags...]"
+    ux_bullet "sub-commands"
+    ux_bullet_sub "gb -D local               delete local branches (keeps: main + current + keywords)"
+    ux_bullet_sub "gb -D remote [<remote>]   delete remote branches (default: origin, keeps: main)"
+    ux_bullet_sub "gb [flags]                passthrough to git --no-pager branch"
+}
+
+git_branch() {
+    case "$1" in
+        -D)
+            case "$2" in
+                local)  shift 2; _gb_clean_local "$@" ;;
+                remote) shift 2; _gb_clean_remote "$@" ;;
+                *)      git --no-pager branch -D "$@" ;;
+            esac
+            ;;
+        -h|--help|help)
+            _gb_help ;;
+        *)
+            git --no-pager branch "$@" ;;
+    esac
+}
+
 # ============================================================================
 # Git configuration setup
 # ============================================================================
@@ -101,9 +120,9 @@ git_setup_auto_remote() {
 git_setup_auto_remote >/dev/null 2>&1 || true
 
 # ============================================================================
-# Clean all local branches except main and current branch
+# Private sub-function: clean local branches (called via gb -D local)
 # ============================================================================
-git_clean_local() {
+_gb_clean_local() {
     # zsh compatibility: emulate POSIX sh to ensure word splitting on unquoted vars
     if [ -n "${ZSH_VERSION-}" ]; then
         emulate -L sh
@@ -192,5 +211,8 @@ EOF
 alias git-log='git_log'
 alias gl='git-log'
 alias git-log-upstream='git_log_upstream'
-alias git-prune-remote='git_prune_remote'
-alias git-clean-local='git_clean_local'
+alias gb='git_branch'
+# Deprecated wrappers — prefer gb -D local / gb -D remote
+alias git-clean-local='gb -D local'
+alias gprune='gb -D remote'
+alias git-prune-remote='gb -D remote'

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -74,8 +74,8 @@ _git_help_rows_branch() {
     ux_table_row "gset-main" "set-upstream main" "Track origin/main"
     ux_table_row "gset-dev" "set-upstream dev" "Track origin/dev"
     ux_table_row "gset" "gset [branch]" "Track origin/[branch]"
-    ux_table_row "gb -D local" "git_branch -D local" "Delete local branches (keeps: main + current + keywords)"
-    ux_table_row "gb -D remote [<r>]" "git_branch -D remote" "Delete remote branches (default: origin, keeps: main)"
+    ux_table_row "gb -D local" "git_branch -D local" "Delete local branches (keeps: main/master + current + keywords)"
+    ux_table_row "gb -D remote [<r>]" "git_branch -D remote" "Delete remote-tracking branches (default: origin, keeps: main/master)"
     ux_table_row "gb -h" "git_branch --help" "Show gb sub-command help"
 }
 

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -10,7 +10,7 @@ _git_help_summary() {
     ux_bullet_sub "sync: gf | gfu | gfa | gsw | gr"
     ux_bullet_sub "logs: gl | gl1 | gl2 | glref"
     ux_bullet_sub "upstream: gupa | gupdel | glum | glub"
-    ux_bullet_sub "branch: gset-main | gset-dev | gset | gprune | git-clean-local"
+    ux_bullet_sub "branch: gset-main | gset-dev | gset | gb -D local | gb -D remote"
     ux_bullet_sub "stash: git stash list | show -p | pop | apply | drop"
     ux_bullet_sub "pick: gcp | gcp_theirs | gcp_ours | gcp_author | gcp_scan"
     ux_bullet_sub "special: gpf_dev_server | gpfu"
@@ -74,8 +74,9 @@ _git_help_rows_branch() {
     ux_table_row "gset-main" "set-upstream main" "Track origin/main"
     ux_table_row "gset-dev" "set-upstream dev" "Track origin/dev"
     ux_table_row "gset" "gset [branch]" "Track origin/[branch]"
-    ux_table_row "gprune" "git-prune-remote <remote>" "Delete all branches except main"
-    ux_table_row "git-clean-local" "git_clean_local" "Delete local branches (keeps: main + current)"
+    ux_table_row "gb -D local" "git_branch -D local" "Delete local branches (keeps: main + current + keywords)"
+    ux_table_row "gb -D remote [<r>]" "git_branch -D remote" "Delete remote branches (default: origin, keeps: main)"
+    ux_table_row "gb -h" "git_branch --help" "Show gb sub-command help"
 }
 
 _git_help_rows_stash() {

--- a/tests/bats/functions/git.bats
+++ b/tests/bats/functions/git.bats
@@ -26,14 +26,26 @@ teardown() {
     assert_output --partial "ok"
 }
 
-@test "bash: git_prune_remote function exists" {
-    run_in_bash 'declare -f git_prune_remote >/dev/null && echo ok'
+@test "bash: git_branch function exists" {
+    run_in_bash 'declare -f git_branch >/dev/null && echo ok'
     assert_success
     assert_output --partial "ok"
 }
 
-@test "bash: git_clean_local function exists" {
-    run_in_bash 'declare -f git_clean_local >/dev/null && echo ok'
+@test "bash: _gb_clean_local function exists" {
+    run_in_bash 'declare -f _gb_clean_local >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gb_clean_remote function exists" {
+    run_in_bash 'declare -f _gb_clean_remote >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: gb alias maps to git_branch" {
+    run_in_bash 'alias gb | grep -q git_branch && echo ok'
     assert_success
     assert_output --partial "ok"
 }


### PR DESCRIPTION
## Summary
- `gb`를 `git --no-pager branch` alias에서 `git_branch()` function으로 승격하여 dispatcher 역할을 부여
- `gb -D local` / `gb -D remote [<remote>]` sub-command로 기존 `git-clean-local`·`gprune` 통합
- `gwt`와 동일한 dispatcher + private sub-function 패턴으로 인터페이스 일관성 확보

## Changes
- `shell-common/functions/git.sh`: `git_prune_remote()` → `_gb_clean_remote()`, `git_clean_local()` → `_gb_clean_local()`, `git_branch()` dispatcher 추가, deprecated 래퍼 alias 정리
- `shell-common/aliases/git.sh`: `gb='git --no-pager branch'` 제거 (functions/git.sh의 `alias gb='git_branch'`로 이전)
- `shell-common/functions/git_help.sh`: branch 섹션에 `gb -D local|remote` 인터페이스 반영
- `tests/bats/functions/git.bats`: `git_branch`, `_gb_clean_local`, `_gb_clean_remote` function 존재 테스트 + `gb` alias 매핑 테스트로 교체

## Test plan
- [x] `tox -e ruff,shellcheck,shfmt` 통과
- [x] `bash -n` 신택스 체크 통과
- [x] `gb -l` passthrough 동작 확인 (함수 로드 후)
- [ ] `gb -D local` 실제 브랜치 정리 동작 수동 확인
- [ ] `gb -D remote origin` 원격 브랜치 정리 동작 수동 확인
- [ ] zsh에서 동일하게 동작 확인

## Related
Closes #558

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~4 h h · 🤖 ~2 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~4 h h · 🤖 ~2 min
<\!-- /ai-metrics:gh-pr -->

</details>
