### PR TITLE
fix(vscode): disable python terminal auto-activate

### DIFF
--- a/.vscode/base.json
+++ b/.vscode/base.json
@@ -73,6 +73,7 @@
     "explorer.confirmPasteNative": false,
     "cSpell.userWords": ["pkstock", "smtm"],
     "python.analysis.typeCheckingMode": "strict",
+    "python.terminal.activateEnvironment": false,
     "python.terminal.useEnvFile": true,
     "notebook.output.wordWrap": true,
     "jupyter.askForKernelRestart": false,


### PR DESCRIPTION
## Summary
- `.vscode/base.json`에 `python.terminal.activateEnvironment: false` 추가로 VSCode Python 확장의 자동 venv 활성화 비활성화

## Changes
- vscode: `python.terminal.activateEnvironment: false` 설정 추가 — Python 확장이 신규 터미널마다 `.venv/bin/activate`를 자동 실행하던 것을 방지

## Test plan
- [ ] VSCode에서 dotfiles workspace 열기
- [ ] 신규 터미널 생성 반복 (5회 이상)
- [ ] `source .venv/bin/activate` + `zsh` 에코 없이 바로 dotfiles 프롬프트만 표시되는지 확인

## Related
Closes #563

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~3 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~3 min
<\!-- /ai-metrics:gh-pr -->

</details>
