### PR TITLE
refactor(claude): #568 convention-based multi-account dispatcher

### DIFF
--- a/shell-common/env/claude.local.example
+++ b/shell-common/env/claude.local.example
@@ -29,3 +29,26 @@
 #
 # export CLAUDE_ACCOUNT_EMAIL_personal="alice@gmail.com"
 # export CLAUDE_ACCOUNT_EMAIL_work="alice@corp.com"
+
+# ─── 추가 work 계정 (issue #568, convention-based) ──────────────
+# 회사 계정이 둘 이상이거나 사내 워크스페이스가 분리된 환경에서
+# work1 / work-eng / work-fin 같은 임의 이름을 추가할 수 있다.
+# 아래 패턴을 따른다 — 코드 수정 불필요, 환경변수 한 줄로 끝.
+#
+#   1) CLAUDE_ENABLED_ACCOUNTS 에 단어 추가 (필수)
+#      → ~/.claude-<name>/ 디렉터리가 자동 생성·심링크 셋업됨
+#      → `claude-yolo --user <name>` 와 alias `claude-yolo-<name>` 자동 등록
+#
+#   2) CLAUDE_ACCOUNT_EMAIL_<name> 매핑 (권장)
+#      → 잘못된 Google 계정으로 OAuth 로그인되는 트랩 방지
+#
+# 이름 규칙: ^[a-z][a-z0-9_-]*$ (소문자 시작, 소문자·숫자·하이픈·언더스코어).
+#
+# 예시 — work1 활성화:
+#
+# export CLAUDE_ENABLED_ACCOUNTS="personal work work1"
+# export CLAUDE_ACCOUNT_EMAIL_work1="myname@corp2.com"
+#
+# 셸 재시작 후 다음 명령으로 디렉터리·심링크 셋업 + 첫 로그인:
+#   claude-accounts setup
+#   claude-yolo --user work1     # 또는 alias: claude-yolo-work1

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -624,9 +624,20 @@ _claude_resolve_account() {
         --list|--list-all)
             # --list-all 은 issue #568 에서 --list 로 통합. 외부 사용자
             # 보호용 호환 alias — 향후 메이저 버전에서 제거 가능.
+            # 검증을 인라인으로 — 재귀 호출 시 ENABLED 가 "--list" 같은
+            # 플래그 토큰을 포함하면 무한 재귀에 빠질 수 있고, 재귀는
+            # O(N²) 비용을 만든다 (gemini review on PR #569).
+            # ${VAR:-} 로 set -u 환경에서 unbound 회피.
             # shellcheck disable=SC2086  # intentional word-split for POSIX list iteration
-            for _cra_acct in $CLAUDE_ENABLED_ACCOUNTS; do
-                _claude_resolve_account "$_cra_acct" >/dev/null 2>&1 && echo "$_cra_acct"
+            for _cra_acct in ${CLAUDE_ENABLED_ACCOUNTS:-}; do
+                case "$_cra_acct" in
+                    [a-z]*) ;;
+                    *) continue ;;
+                esac
+                case "$_cra_acct" in
+                    *[!a-z0-9_-]*) continue ;;
+                esac
+                echo "$_cra_acct"
             done
             return 0
             ;;
@@ -644,7 +655,7 @@ _claude_resolve_account() {
     # ENABLED whitelist check — unknown names fail even if regex-valid.
     # Preserves the "Unknown account: xyz" path in claude_yolo for typos.
     # shellcheck disable=SC2086  # intentional word-split for POSIX list iteration
-    for _cra_acct in $CLAUDE_ENABLED_ACCOUNTS; do
+    for _cra_acct in ${CLAUDE_ENABLED_ACCOUNTS:-}; do
         if [ "$_cra_acct" = "$1" ]; then
             echo "$HOME/.claude-$1"
             return 0
@@ -1076,8 +1087,9 @@ _claude_has_unmigrated_data() {
     if [ -n "${ZSH_VERSION:-}" ]; then
         emulate -L sh
     fi
+    # ${VAR:-} for set -u safety (gemini review on PR #569).
     # shellcheck disable=SC2086  # intentional word-split for POSIX list iteration
-    for _chud_acct in $CLAUDE_ENABLED_ACCOUNTS; do
+    for _chud_acct in ${CLAUDE_ENABLED_ACCOUNTS:-}; do
         [ -d "$HOME/.claude-$_chud_acct" ] && return 1
     done
 

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -594,13 +594,24 @@ alias claude-yolo='claude_yolo'
 # Multi-account configuration (issue #287)
 # ═══════════════════════════════════════════════════════════════
 
-# _claude_resolve_account — 계정 매핑 SSOT (case dispatcher).
+# _claude_resolve_account — 계정 매핑 SSOT (convention-based, issue #568).
 # Usage:
-#   _claude_resolve_account <name>     → echo CONFIG_DIR (exit 0) or fail (exit 1)
-#   _claude_resolve_account --list     → echo enabled accounts (one per line)
-#   _claude_resolve_account --list-all → echo all defined accounts (debug)
+#   _claude_resolve_account <name>     → echo "$HOME/.claude-<name>" when
+#                                        <name> is in CLAUDE_ENABLED_ACCOUNTS
+#                                        and passes the safe-identifier
+#                                        regex. return 1 otherwise.
+#   _claude_resolve_account --list     → echo ENABLED accounts (one per line)
+#                                        that pass the safe-identifier regex.
+#   _claude_resolve_account --list-all → deprecated; same as --list. Kept
+#                                        for back-compat with external
+#                                        scripts that may still call it.
 #
-# 새 계정 추가 시 case 한 줄 + --list-all 한 단어만 추가.
+# 새 계정 추가 = claude.local.sh 의 CLAUDE_ENABLED_ACCOUNTS 에 단어 추가
+# 만으로 끝. 코드 수정 불필요. 디렉터리는 자동으로 ~/.claude-<name>.
+#
+# Safe-identifier regex: ^[a-z][a-z0-9_-]*$
+# - 첫 글자 소문자, 뒤로 소문자·숫자·하이픈·언더스코어.
+# - alias 명·env-var 접미사·디렉터리명 셋 다 안전하게 쓰일 식별자.
 _claude_resolve_account() {
     # zsh disables word-splitting by default; emulate sh inside this function
     # so `for x in $LIST` behaves identically to bash/dash. (See MEMORY.md
@@ -610,19 +621,36 @@ _claude_resolve_account() {
     fi
 
     case "$1" in
-        --list)
+        --list|--list-all)
+            # --list-all 은 issue #568 에서 --list 로 통합. 외부 사용자
+            # 보호용 호환 alias — 향후 메이저 버전에서 제거 가능.
             # shellcheck disable=SC2086  # intentional word-split for POSIX list iteration
             for _cra_acct in $CLAUDE_ENABLED_ACCOUNTS; do
                 _claude_resolve_account "$_cra_acct" >/dev/null 2>&1 && echo "$_cra_acct"
             done
+            return 0
             ;;
-        --list-all)
-            echo "personal work"
-            ;;
-        personal) echo "$HOME/.claude-personal" ;;
-        work)     echo "$HOME/.claude-work" ;;
-        *)        return 1 ;;
     esac
+
+    # name validation: must start with lowercase letter, rest [a-z0-9_-]
+    case "$1" in
+        [a-z]*) ;;
+        *) return 1 ;;
+    esac
+    case "$1" in
+        *[!a-z0-9_-]*) return 1 ;;
+    esac
+
+    # ENABLED whitelist check — unknown names fail even if regex-valid.
+    # Preserves the "Unknown account: xyz" path in claude_yolo for typos.
+    # shellcheck disable=SC2086  # intentional word-split for POSIX list iteration
+    for _cra_acct in $CLAUDE_ENABLED_ACCOUNTS; do
+        if [ "$_cra_acct" = "$1" ]; then
+            echo "$HOME/.claude-$1"
+            return 0
+        fi
+    done
+    return 1
 }
 
 # _claude_expected_email <account-name> — expected oauth email lookup.
@@ -1039,10 +1067,20 @@ claude_accounts_status() {
 # Returns 0 (true) if migration is needed, 1 (false) otherwise.
 # Tolerates empty bind-mount leftovers (skills/, docs/) — those are not
 # user data, just unmounted dirs from the legacy layout.
+#
+# Migration-done check iterates CLAUDE_ENABLED_ACCOUNTS (issue #568) so
+# adding work1 / work-eng / etc. via env doesn't need a code edit here.
 _claude_has_unmigrated_data() {
     [ -d "$HOME/.claude" ] || return 1
-    [ -d "$HOME/.claude-personal" ] && return 1
-    [ -d "$HOME/.claude-work" ] && return 1
+
+    if [ -n "${ZSH_VERSION:-}" ]; then
+        emulate -L sh
+    fi
+    # shellcheck disable=SC2086  # intentional word-split for POSIX list iteration
+    for _chud_acct in $CLAUDE_ENABLED_ACCOUNTS; do
+        [ -d "$HOME/.claude-$_chud_acct" ] && return 1
+    done
+
     [ -e "$HOME/.claude/.credentials.json" ] && return 0
     [ -d "$HOME/.claude/projects" ] && return 0
     [ -d "$HOME/.claude/sessions" ] && return 0

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -146,6 +146,24 @@ LOCAL
     assert_output "$HOME/.claude-work1"
 }
 
+@test "bash: resolve --list does NOT infinite-recurse on flag-shaped ENABLED token (PR #569 review)" {
+    # Regression: an earlier draft of the --list branch called
+    # _claude_resolve_account recursively, which would loop forever if
+    # CLAUDE_ENABLED_ACCOUNTS happened to contain --list / --list-all.
+    # The inline-validation rewrite must drop such tokens silently.
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="personal --list work" _claude_resolve_account --list | tr "\n" " "'
+    assert_success
+    assert_output "personal work "
+}
+
+@test "bash: resolve --list survives empty ENABLED under set -u (PR #569 review)" {
+    # Regression for the ${VAR:-} hardening — calling --list without
+    # CLAUDE_ENABLED_ACCOUNTS exported must not abort under set -u.
+    run_in_bash 'unset CLAUDE_ENABLED_ACCOUNTS; set -u; _claude_resolve_account --list'
+    assert_success
+    assert_output ""
+}
+
 # ---------- Task 4: ensure helpers (idempotency) ----------
 
 @test "bash: _claude_ensure_symlink creates new symlink" {

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -72,10 +72,10 @@ LOCAL
     refute_output --partial "/"
 }
 
-@test "bash: resolve --list-all returns 'personal work'" {
-    run_in_bash '_claude_resolve_account --list-all'
+@test "bash: resolve --list-all returns same as --list (deprecated alias, issue #568)" {
+    run_in_bash '_claude_resolve_account --list-all | tr "\n" " "'
     assert_success
-    assert_output "personal work"
+    assert_output "personal work "
 }
 
 @test "bash: resolve --list returns ENABLED accounts only (default)" {
@@ -94,6 +94,56 @@ LOCAL
     run_in_zsh '_claude_resolve_account --list | tr "\n" " "'
     assert_success
     assert_output "personal work "
+}
+
+# ---------- issue #568: convention-based dispatcher ----------
+
+@test "bash: resolve work1 returns ~/.claude-work1 when ENABLED contains work1" {
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="personal work work1" _claude_resolve_account work1'
+    assert_success
+    assert_output "$HOME/.claude-work1"
+}
+
+@test "bash: resolve work1 fails when ENABLED omits it" {
+    run_in_bash '_claude_resolve_account work1'
+    assert_failure
+    refute_output --partial "/"
+}
+
+@test "bash: resolve --list includes work1 when ENABLED contains work1" {
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="personal work work1" _claude_resolve_account --list | tr "\n" " "'
+    assert_success
+    assert_output "personal work work1 "
+}
+
+@test "bash: resolve rejects uppercase name (Work)" {
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="Work" _claude_resolve_account Work'
+    assert_failure
+    refute_output --partial "/"
+}
+
+@test "bash: resolve rejects digit-leading name (1work)" {
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="1work" _claude_resolve_account 1work'
+    assert_failure
+    refute_output --partial "/"
+}
+
+@test "bash: resolve rejects special-char name (foo\$bar)" {
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="foo\$bar" _claude_resolve_account "foo\$bar"'
+    assert_failure
+    refute_output --partial "/"
+}
+
+@test "bash: resolve --list silently skips invalid tokens in ENABLED" {
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="personal Work work" _claude_resolve_account --list | tr "\n" " "'
+    assert_success
+    assert_output "personal work "
+}
+
+@test "zsh: resolve work1 routes under zsh (POSIX parity)" {
+    run_in_zsh 'CLAUDE_ENABLED_ACCOUNTS="personal work work1" _claude_resolve_account work1'
+    assert_success
+    assert_output "$HOME/.claude-work1"
 }
 
 # ---------- Task 4: ensure helpers (idempotency) ----------
@@ -164,6 +214,19 @@ LOCAL
     run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 claude_accounts_init'
     assert_failure
     assert_output --partial "claude-accounts migrate"
+}
+
+@test "bash: claude_accounts_init treats ~/.claude-work1 as 'already migrated' when work1 is ENABLED (issue #568)" {
+    # Convention-based refactor: the migration guard must iterate
+    # CLAUDE_ENABLED_ACCOUNTS, not a hardcoded personal/work pair.
+    # Otherwise adding work1 to ENABLED would re-trigger the migrate
+    # prompt every shell startup.
+    mkdir -p "$HOME/.claude" "$HOME/.claude-work1"
+    echo '{"fake":"creds"}' > "$HOME/.claude/.credentials.json"
+
+    run_in_bash 'CLAUDE_ENABLED_ACCOUNTS="personal work work1" CLAUDE_SKIP_BIND_MOUNT=1 claude_accounts_init'
+    assert_success
+    refute_output --partial "claude-accounts migrate"
 }
 
 @test "bash: claude_accounts_init tolerates empty skills/docs leftovers" {


### PR DESCRIPTION
## Summary

- `_claude_resolve_account` 의 hardcoded case dispatcher 를 convention-based 매핑 (`name` → `~/.claude-<name>`) 으로 리팩토링. 새 계정 추가가 `claude.local.sh` 의 `CLAUDE_ENABLED_ACCOUNTS` 환경변수 한 단어 추가만으로 완료됨 (코드 수정 불필요).
- 안전한 식별자 regex (`^[a-z][a-z0-9_-]*$`) + `CLAUDE_ENABLED_ACCOUNTS` 화이트리스트 두 단계 검증으로 unknown name 거부 동작 보존.
- work1 / work-eng 같은 추가 work 계정을 PC 별로 손쉽게 활성화 — 가이드는 issue #568 본문 참조.

## Changes

- **`shell-common/tools/integrations/claude.sh`**: `_claude_resolve_account` 가 case 문 대신 regex + ENABLED 화이트리스트로 동작. `--list-all` 은 `--list` 와 동일 동작 (deprecated, back-compat alias). `_claude_has_unmigrated_data` 는 `CLAUDE_ENABLED_ACCOUNTS` 를 루프 돌며 마이그레이션 여부 판단 — work1 같은 신규 계정 디렉터리 존재만으로 "이미 마이그됨" 인식.
- **`shell-common/env/claude.local.example`**: "추가 work 계정 (issue #568, convention-based)" 섹션 신설. work1 활성화 패턴 (CLAUDE_ENABLED_ACCOUNTS + CLAUDE_ACCOUNT_EMAIL_work1 + setup 명령) 을 주석 예시로 제공.
- **`tests/bats/integrations/claude_accounts.bats`**: 8건 신규 테스트
  - work1 dispatch (ENABLED 포함/미포함 둘 다)
  - `--list` 가 work1 포함 시 3줄 echo
  - 입력 검증 (`Work` / `1work` / `foo$bar` 거부)
  - invalid token 이 ENABLED 에 섞여도 `--list` 가 silently skip
  - zsh 환경 work1 dispatch (POSIX parity)
  - `_claude_has_unmigrated_data` 가 ENABLED 루프로 work1 인식

## Test plan

- [x] `tests/bats/integrations/claude_accounts.bats` — 95/96 pass (실패 1건은 pre-existing issue #342 의 별개 테스트, `git stash` 로 refactor 전 동일하게 실패함 확인)
- [x] `tests/bats/functions/claude_yolo.bats` — 8/8 pass
- [x] `tox -e shellcheck` — OK
- [x] `tox -e shfmt` — OK
- [ ] (수동) 머지 후 본인 PC 에서 `claude.local.sh` 에 `CLAUDE_ENABLED_ACCOUNTS="personal work work1"` 추가 → `exec zsh && claude-accounts setup && claude-yolo --user work1` 로 work1 활성화 확인

## Related

Closes #568
