### PR TITLE
docs(ssot): #566 extract dispatcher pattern SSOT

### DIFF
--- a/docs/.ssot/README.md
+++ b/docs/.ssot/README.md
@@ -15,6 +15,7 @@
 | 파일 | 정책 영역 |
 |------|-----------|
 | [`command-guidelines.md`](./command-guidelines.md) | 명령어 / help 인터페이스, 출력 정책, row 함수 SSOT 패턴 |
+| [`command-design-pattern.md`](./command-design-pattern.md) | dispatcher + private sub-function 구조, Type 2A/2B, passthrough 규칙, SOLID |
 | [`env-vars.md`](./env-vars.md) | cross-skill / cross-tool env var 카탈로그 |
 | [`github-project-board.md`](./github-project-board.md) | GitHub Project v2 보드 운영 규칙, closing keyword 정책 |
 | [`commit-message-standard.md`](./commit-message-standard.md) | 브랜치 명명·커밋 메시지·work_log 자동화 |

--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -1,0 +1,260 @@
+# Shell Command Design Pattern
+
+## 목적
+
+`shell-common/functions/*.sh`의 함수형 명령어를 일관된 **dispatcher + private sub-function** 구조로 작성하기 위한 내부 아키텍처 SSOT다.
+
+사용자 표면(`*-help` 출력 형식·15줄 정책·`ux_bullet` 계층 등)은 [`command-guidelines.md`](./command-guidelines.md)가 정의한다. 이 문서는 그 아래 layer — 명령어의 **내부 구조**를 다룬다.
+
+## 적용 범위
+
+- `shell-common/functions/*.sh` 내 모든 함수형 명령어
+- 단일 동작 함수(simple function) 및 멀티 서브커맨드 함수(dispatcher) 모두
+- `bash/`, `zsh/` 로더에서 alias로 노출되는 public 진입점
+
+## 1. 명명 규칙
+
+| 대상 | 규칙 | 예시 |
+|------|------|------|
+| Public 함수 (dispatcher/main) | `snake_case` | `git_branch`, `git_worktree` |
+| Private sub-function | `_<prefix>_<verb>` | `_gb_clean_local`, `_gwt_help_rows_add` |
+| Public alias (user-facing) | `dash-form` | `gb`, `gwt`, `git-clean-local` (deprecated) |
+| Help 함수 (inline) | `_<prefix>_help` | `_gb_help` |
+| Help 함수 (standalone) | `<topic>_help` + alias `<topic>-help` | `gwt_help` / `gwt-help` |
+
+## 2. Command 유형 결정 기준
+
+```
+단일 동작? ──Yes──> Type 1: Simple Function
+     │
+     No
+     │
+서브커맨드 분리가 필요?
+     │
+     ├── 서브커맨드가 동사(verb) 형태 (add/list/spawn/teardown)
+     │        └──> Type 2A: Positional Dispatcher (gwt 패턴)
+     │
+     └── 서브커맨드가 기존 flag(-D)에 중첩되거나
+         원래 명령의 flag passthrough를 유지해야 할 때
+                  └──> Type 2B: Flag-triggered Dispatcher (gb 패턴)
+```
+
+## 3. Type 1: Simple Function
+
+단일 책임 함수. dispatcher 없이 직접 구현한다.
+
+```sh
+example_setup() {
+    # 구현
+}
+
+alias example-setup='example_setup'
+```
+
+- Help는 `example-help` (별도 help 함수)로 등록한다.
+- Help 표준은 [`command-guidelines.md`](./command-guidelines.md) 참조.
+
+## 4. Type 2A: Positional Dispatcher (gwt 패턴)
+
+서브커맨드가 **동사 형태 positional arg**인 경우.
+
+### 구조 템플릿
+
+```sh
+# Private sub-functions
+_<prefix>_<verb>() {
+    # 구현
+}
+
+_<prefix>_<verb2>() {
+    # 구현
+}
+
+# Dispatcher
+<topic>() {
+    case "${1:-}" in
+        <verb>)   shift; _<prefix>_<verb> "$@" ;;
+        <verb2>)  shift; _<prefix>_<verb2> "$@" ;;
+        -h|--help|help|"")
+            ux_error "Usage: <alias> <command> [args...]"
+            ux_info "Run: <alias>-help"
+            return 1
+            ;;
+        *)
+            ux_error "Unknown command: $1"
+            ux_info "Run: <alias>-help"
+            return 1
+            ;;
+    esac
+}
+
+alias <alias>='<topic>'
+```
+
+### 참조 구현: `gwt`
+
+파일: `shell-common/functions/git_worktree.sh`
+
+```sh
+gwt() {
+    case "${1:-}" in
+        add)      shift; git_worktree_add "$@" ;;
+        list|ls)  shift; git_worktree_list "$@" ;;
+        spawn)    shift; git_worktree_spawn "$@" ;;
+        teardown) shift; git_worktree_teardown "$@" ;;
+        -h|--help|help|"")
+            ux_error "Usage: gwt <command> [args...]"
+            ux_info "Run: gwt-help"
+            return 1 ;;
+        *)
+            ux_error "Unknown command: $1"
+            ux_info "Run: gwt-help"
+            return 1 ;;
+    esac
+}
+```
+
+## 5. Type 2B: Flag-triggered Dispatcher (gb 패턴)
+
+기존 flag(`-D`, `-f` 등)에 서브타입을 **중첩**하는 형태. 기존 명령의 **passthrough를 보존**해야 할 때 사용한다.
+
+### 구조 템플릿
+
+```sh
+# Inline help (5줄 이내)
+_<prefix>_help() {
+    ux_info "Usage: <alias> [-FLAG <subtype>] [native-flags...]"
+    ux_bullet "sub-commands"
+    ux_bullet_sub "<alias> -FLAG <subtype1>    설명"
+    ux_bullet_sub "<alias> -FLAG <subtype2>    설명"
+    ux_bullet_sub "<alias> [flags]             passthrough to <underlying-cmd>"
+}
+
+# Private sub-functions
+_<prefix>_<subtype1>() { :; }
+_<prefix>_<subtype2>() { :; }
+
+# Dispatcher
+<topic>() {
+    case "$1" in
+        -FLAG)
+            case "$2" in
+                <subtype1>) shift 2; _<prefix>_<subtype1> "$@" ;;
+                <subtype2>) shift 2; _<prefix>_<subtype2> "$@" ;;
+                *)          <underlying-cmd> -FLAG "$@" ;;
+            esac
+            ;;
+        -h|--help|help) _<prefix>_help ;;
+        *)              <underlying-cmd> "$@" ;;
+    esac
+}
+
+alias <alias>='<topic>'
+```
+
+### 참조 구현: `gb`
+
+파일: `shell-common/functions/git.sh`
+
+```sh
+_gb_help() {
+    ux_info "Usage: gb [-D local] [-D remote [<remote>]] [git-branch-flags...]"
+    ux_bullet "sub-commands"
+    ux_bullet_sub "gb -D local               delete local branches (keeps: main + current + keywords)"
+    ux_bullet_sub "gb -D remote [<remote>]   delete remote-tracking branches (default: origin, keeps: main/master)"
+    ux_bullet_sub "gb [flags]                passthrough to git --no-pager branch"
+}
+
+git_branch() {
+    case "$1" in
+        -D)
+            case "$2" in
+                local)  shift 2; _gb_clean_local "$@" ;;
+                remote) shift 2; _gb_clean_remote "$@" ;;
+                *)      git --no-pager branch -D "$@" ;;
+            esac
+            ;;
+        -h|--help|help) _gb_help ;;
+        *)              git --no-pager branch "$@" ;;
+    esac
+}
+
+alias gb='git_branch'
+```
+
+## 6. Passthrough 규칙
+
+| 상황 | 처리 |
+|------|------|
+| 알 수 없는 서브커맨드 (Type 2A) | `ux_error + return 1` — passthrough 없음 |
+| 알 수 없는 flag (Type 2B) | underlying command로 passthrough |
+| flag 뒤 알 수 없는 subtype (Type 2B) | underlying command로 passthrough |
+| `-h/--help/help` | 항상 inline help 표시 |
+
+**이유**: Type 2A는 완전히 새로운 인터페이스이므로 오타를 차단해야 한다. Type 2B는 기존 명령의 확장이므로 미처리 케이스를 원본으로 위임해야 한다.
+
+## 7. Help 통합 전략
+
+| Help 유형 | 언제 사용 | 구현 위치 |
+|-----------|-----------|-----------|
+| Inline help (`_<prefix>_help`) | Type 2B, 또는 sub-command 수 3개 이하 | dispatcher 파일 내 |
+| Standalone help (`<topic>_help` + `<topic>-help`) | Type 2A, 또는 sub-command 수 4개 이상 | 별도 `*_help.sh` 파일 |
+
+[`command-guidelines.md`](./command-guidelines.md)의 help 표준(15줄 이내, `ux_bullet`/`ux_bullet_sub`, `--all`/`<section>` 분리)은 standalone help에 완전 적용된다.
+
+## 8. Deprecated Alias 전략
+
+기존 명령을 dispatcher 아래로 통합할 때, 하위 호환을 위해 thin wrapper alias를 유지한다.
+
+```sh
+alias git-clean-local='gb -D local'   # deprecated
+alias gprune='gb -D remote'           # deprecated
+```
+
+- deprecated alias는 `# deprecated` 인라인 코멘트만 붙인다.
+- deprecated alias 제거 시점은 별도 이슈로 결정한다.
+
+## 9. SOLID 준수 기준
+
+| 원칙 | 적용 방식 |
+|------|-----------|
+| **SRP** | dispatcher는 dispatch만 / private sub-function은 구현만 |
+| **OCP** | 신규 sub-command = case 항목 추가만, 기존 코드 무변경 |
+| **LSP** | passthrough로 기존 호출자 완전 호환 |
+| **ISP** | private sub-function 간 상호 의존 없음 |
+| **DIP** | `ux_*` 추상화 사용, 직접 `echo`/`printf` 금지 |
+| **SSOT** | protected_keywords, default 값, 보호 브랜치 목록 — 각 함수 내 단일 정의 |
+
+## 10. 테스트 요구사항
+
+```bats
+@test "<topic>: dispatcher function exists" { ... }
+@test "<topic>: private sub-function <verb> exists" { ... }
+@test "<topic>: alias <alias> maps to dispatcher" { ... }
+@test "<topic>: -h shows help" { ... }
+@test "<topic>: unknown sub-command returns error (Type 2A)" { ... }
+@test "<topic>: unknown flag passes through (Type 2B)" { ... }
+```
+
+- bash/zsh 모두에서 실행
+- shellcheck/shfmt 통과 필수
+
+## 11. 변경 절차
+
+1. 이 문서를 먼저 검토하여 Type 결정
+2. private sub-function 먼저 작성 + 단위 테스트
+3. dispatcher 작성 + passthrough 케이스 확인
+4. help 통합 (`_help` inline 또는 별도 `*-help.sh`)
+5. deprecated alias 정리
+6. shellcheck/shfmt/bats 통과 확인
+7. PR body에 SOLID 준수 근거 표 포함
+
+## 12. 참조
+
+- [`command-guidelines.md`](./command-guidelines.md) — Help interface SSOT (사용자 표면)
+- `shell-common/tools/ux_lib/UX_GUIDELINES.md` — UX output rules
+- `shell-common/functions/git_worktree.sh` — Type 2A 참조 구현 (gwt)
+- `shell-common/functions/git.sh` — Type 2B 참조 구현 (gb)
+- Issue #558 — gb 통합 설계 근거
+- PR #559 — gb 구현 검증
+- Issue #566 — 본 문서 추출 근거

--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -58,7 +58,7 @@ alias example-setup='example_setup'
 
 서브커맨드가 **동사 형태 positional arg**인 경우.
 
-### 구조 템플릿
+### 구조 템플릿 (Type 2A)
 
 ```sh
 # Private sub-functions
@@ -118,7 +118,7 @@ gwt() {
 
 기존 flag(`-D`, `-f` 등)에 서브타입을 **중첩**하는 형태. 기존 명령의 **passthrough를 보존**해야 할 때 사용한다.
 
-### 구조 템플릿
+### 구조 템플릿 (Type 2B)
 
 ```sh
 # Inline help (5줄 이내)

--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -136,12 +136,12 @@ _<prefix>_<subtype2>() { :; }
 
 # Dispatcher
 <topic>() {
-    case "$1" in
+    case "${1:-}" in
         -FLAG)
-            case "$2" in
+            case "${2:-}" in
                 <subtype1>) shift 2; _<prefix>_<subtype1> "$@" ;;
                 <subtype2>) shift 2; _<prefix>_<subtype2> "$@" ;;
-                *)          <underlying-cmd> -FLAG "$@" ;;
+                *)          <underlying-cmd> "$@" ;;
             esac
             ;;
         -h|--help|help) _<prefix>_help ;;
@@ -151,6 +151,8 @@ _<prefix>_<subtype2>() { :; }
 
 alias <alias>='<topic>'
 ```
+
+`<underlying-cmd> "$@"` (not `<underlying-cmd> -FLAG "$@"`): when 알 수 없는 subtype 가 들어오면 `"$@"` 가 이미 원본 `-FLAG <subtype>` 을 갖고 있어 그대로 위임하면 된다. 중복 `-FLAG` 를 추가하지 않는다.
 
 ### 참조 구현: `gb`
 
@@ -166,12 +168,12 @@ _gb_help() {
 }
 
 git_branch() {
-    case "$1" in
+    case "${1:-}" in
         -D)
-            case "$2" in
+            case "${2:-}" in
                 local)  shift 2; _gb_clean_local "$@" ;;
                 remote) shift 2; _gb_clean_remote "$@" ;;
-                *)      git --no-pager branch -D "$@" ;;
+                *)      git --no-pager branch "$@" ;;
             esac
             ;;
         -h|--help|help) _gb_help ;;

--- a/docs/.ssot/command-guidelines.md
+++ b/docs/.ssot/command-guidelines.md
@@ -54,15 +54,18 @@
 - row 데이터 정의와 화면 조립 로직을 분리한다.
 - 섹션 추가 시 row 함수만 추가하고 renderer에 조립한다.
 
-## 네이밍 규칙
+## 네이밍 규칙 (help 함수)
 
 - 함수명: snake_case (`git_help`, `gwt_help`)
 - 내부 helper: `_` 접두사 (`_git_help_rows_stash`)
 - alias: dash-form (`git-help`, `gwt-help`)
 
-## 멀티 커맨드 함수형 CLI 규칙
+명령어 자체의 dispatcher / private sub-function 네이밍은 [`command-design-pattern.md`](./command-design-pattern.md) §1 참조.
 
-- `gwt` 같은 멀티 커맨드 함수도 help 표준은 동일하게 적용한다.
+## 멀티 커맨드 함수형 CLI
+
+`gwt` 같은 멀티 커맨드 함수의 dispatcher 구조 자체는 [`command-design-pattern.md`](./command-design-pattern.md) §4–§7가 정의한다. 이 문서는 그 위에서 help 출력 규칙만 다룬다:
+
 - 사용자 안내는 `gwt-help [section]`을 canonical로 사용한다.
 - 구형 help 진입점(예: `gwt help`, `gwt spawn help`) 유지 여부는 명시적으로 결정하고 테스트로 고정한다.
 

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -84,12 +84,12 @@ _gb_help() {
 }
 
 git_branch() {
-    case "$1" in
+    case "${1:-}" in
         -D)
-            case "$2" in
+            case "${2:-}" in
                 local)  shift 2; _gb_clean_local "$@" ;;
                 remote) shift 2; _gb_clean_remote "$@" ;;
-                *)      git --no-pager branch -D "$@" ;;
+                *)      git --no-pager branch "$@" ;;
             esac
             ;;
         -h|--help|help)


### PR DESCRIPTION
## Summary
- 신규 `docs/.ssot/command-design-pattern.md` — dispatcher + private sub-function 구조 SSOT (이슈 #566 본문 추출)
- `command-guidelines.md` 중복 정리: dispatcher 네이밍·멀티 커맨드 절을 신규 문서로 위임, 본 문서는 help UX 표준만 유지
- `docs/.ssot/README.md` 인덱스에 새 SSOT 한 줄 추가

## Changes
- **3af7bff** `docs(ssot): #566 extract dispatcher pattern to command-design-pattern.md`
  - 신규 SSOT: Type 1 (Simple) / 2A (Positional, gwt) / 2B (Flag-triggered, gb) 분류, passthrough 규칙, SOLID 매핑, bats 테스트 체크리스트, 변경 절차
  - `command-guidelines.md`: 네이밍 절을 "help 함수" 한정으로 좁히고 cross-ref 추가, 멀티 커맨드 절은 dispatcher 구조를 신규 문서로 위임 + help 출력 규칙만 보존
  - `README.md` 인덱스 표에 한 줄 추가
- **a3cd4c4** `style(ssot): dedup 구조 템플릿 headers (part of #566)`
  - MD024 mdlint warning 제거: `### 구조 템플릿` → `(Type 2A)` / `(Type 2B)` suffix

## Design rationale (issue 본문에서 결정한 내용)
- 두 문서를 한 파일로 합치지 않은 이유:
  - 관심사 축이 다름 — `command-guidelines.md` = 사용자 표면 (help UX), `command-design-pattern.md` = 내부 아키텍처
  - 크기 균형 — 합치면 360+줄로 비대해져 PR #570 의 슬림화 방향과 역행
  - 라우팅 효율 — AGENTS.md 가 "help UX 어디?" vs "dispatcher 구조 어디?" 를 별도 파일로 분기 가능

## Test plan
- [x] `markdownlint` (변경 파일 3개 한정) — clean
- [x] `pytest tests/integration/test_help_compact_policy.py` — 684/684 pass
- [x] `git diff main..HEAD --stat` — `docs/.ssot/*` 3 files only
- [x] 두 문서가 cross-ref 로 명시적 연결 (`command-guidelines.md` §네이밍/§멀티커맨드 → `command-design-pattern.md` §1/§4–§7)
- [ ] CI green

## Lint guard note
mdlint 은 `CLAUDE.md` 에서 명시적으로 disabled. 기존 `AGENTS.md` / `bash/AGENTS.md` 등 pre-existing mdlint 실패는 본 PR 무관. `tox -e ruff` 는 통과.

## Related
Closes #566

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~1 h · 🤖 ~2 min</summary>

<\!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~1 h · 🤖 ~2 min
<\!-- /ai-metrics:gh-pr -->

</details>
