### PR TITLE
fix(claude): #571 internal setup handles legacy bind-mount

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -525,8 +525,9 @@ _migrate_legacy_plugin_paths
 _check_socat_for_sandbox
 
 # Single-account symlink helper for internal-PC mode (issue #571, F-1).
-# Idempotent: correct target → no-op; wrong target → recreate; existing
-# regular file/dir → timestamped backup then symlink.
+# Idempotent: correct target → no-op; wrong target → recreate; legacy
+# bind-mount → unmount + symlink; existing regular file/dir → timestamped
+# backup then symlink.
 _single_account_ensure_link() {
     local src="$1" tgt="$2"
     if [ -L "$tgt" ]; then
@@ -536,6 +537,22 @@ _single_account_ensure_link() {
         fi
         rm -f "$tgt"
         log_warning "  symlink target mismatch — recreating: $tgt"
+    elif _is_mounted "$tgt"; then
+        # Legacy multi-account-era bind mount surviving on a single-account
+        # internal PC. `mv` would fail with EBUSY because the kernel refuses
+        # to rename a mount point. Unmount first, then fall through to the
+        # normal `ln -s` path below. The mount source typically already
+        # points at the same dotfiles SSOT, so the swap is content-neutral.
+        log_warning "  bind-mount detected at $tgt — unmounting (sudo may prompt)"
+        if ! sudo umount "$tgt"; then
+            log_error "  unmount 실패: $tgt"
+            log_error "  수동 복구: sudo umount '$tgt' && rmdir '$tgt' && ./setup.sh"
+            return 1
+        fi
+        log_dim "  ✓ unmounted: $tgt"
+        # The bind mask is gone; the empty underlying directory is back.
+        # Remove it so the symlink below can take its place.
+        rmdir "$tgt" 2>/dev/null || true
     elif [ -e "$tgt" ]; then
         local backup="${tgt}.backup.$(date +%Y%m%d%H%M%S)"
         mv "$tgt" "$backup" || {


### PR DESCRIPTION
## Summary

- `_single_account_ensure_link` 가 internal 모드에서 `~/.claude/skills`, `~/.claude/docs` 를 `mv` 백업하려다 EBUSY 로 실패하던 버그 수정.
- 원인: multi-account 시대에 설정된 bind mount 가 그대로 남아 있는 PC 에서, 커널이 mount point 의 rename 을 거부 → `mv` 실패 → verify 루프 abort.
- 처리: `_is_mounted` 로 감지 후 `sudo umount` + `rmdir` 하여 일반 symlink 경로로 fall-through.
- bind mount source 가 보통 같은 dotfiles SSOT 를 가리키므로 콘텐츠 측면 변화 없음.

## Repro (before this fix)

Multi-account 셋업이 한 번 적용된 적 있는 PC 에서:

```
$ ./setup.sh
# (1) Public  (2) Internal  (3) External
> 2
...
mv: cannot move '/home/.../.claude/skills' to '/home/.../.claude/skills.backup.X':
    Device or resource busy
❌ backup failed: /home/.../.claude/skills → /home/.../.claude/skills.backup.X
mv: cannot move '/home/.../.claude/docs' ... : Device or resource busy
❌ backup failed: /home/.../.claude/docs → /home/.../.claude/docs.backup.X
...
❌ ~/.claude/skills 심볼릭 링크 생성 실패
```

## Fix

`claude/setup.sh` `_single_account_ensure_link`:

```bash
elif _is_mounted "$tgt"; then
    log_warning "  bind-mount detected at $tgt — unmounting (sudo may prompt)"
    if \! sudo umount "$tgt"; then
        log_error "  unmount 실패: $tgt"
        log_error "  수동 복구: sudo umount '$tgt' && rmdir '$tgt' && ./setup.sh"
        return 1
    fi
    log_dim "  ✓ unmounted: $tgt"
    rmdir "$tgt" 2>/dev/null || true
```

## Cases unchanged

- Fresh internal install (no prior data): `_is_mounted` 가 false → 기존 `mv` 백업 분기로 fall-through (사실은 거기도 안 들어감 — 디렉토리 자체가 없음 → 바로 `ln -s`).
- 반복 internal install (이미 symlink): 첫 분기 `[ -L "$tgt" ]` no-op.
- External / public PC (multi-account): `_setup_mode \!= internal` → 이 helper 자체에 안 들어감.

## Test plan

- [ ] 사내 PC (legacy bind-mount 잔존) 에서 `./setup.sh` → option 2 선택 → sudo 한 번 prompt → 완료 메시지 확인
- [ ] `readlink ~/.claude/skills` 가 `…/dotfiles/claude/skills` 출력 확인
- [ ] `findmnt ~/.claude/skills` 출력 없음 (bind mount 사라짐) 확인
- [ ] `~/.claude/docs`, `~/.claude/projects/GLOBAL/memory`, `~/.claude/plugins` 도 동일 symlink 확인
- [ ] `bash -n claude/setup.sh` 통과 (검증됨)
- [ ] 이미 symlink 상태에서 한 번 더 `./setup.sh` 실행 (idempotency) — no-op

## Follow-up

bind-mount + symlink 혼합 구조 자체를 symlink 으로 통일하는 안은 별도 이슈로 등록 예정 (외부 PC 다중 계정 검증이 필요해 분리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)