### PR TITLE
fix(claude): #571 load mount helper

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -10,8 +10,9 @@
 #   2. Creates ~/.claude/settings.local.json symlink (env / per-user overrides)
 #   3. Creates ~/.claude/statusline-command.sh symlink (status line script)
 #   4. Creates ~/.claude/skills symlink (custom skills directory)
-#   5. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
-#   6. Verifies ~/.claude directory structure
+#   5. Creates ~/.claude/docs symlink (custom docs directory)
+#   6. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
+#   7. Verifies ~/.claude directory structure
 #
 # These files/directories are version-controlled in dotfiles and should
 # be managed via symbolic links for consistency across machines.
@@ -49,19 +50,6 @@ else
     exit 1
 fi
 
-# Load mount utilities (provides _is_mounted).
-# mount.sh carries the standard interactive guard (`case $- in *i*) ...`), so
-# under non-interactive `./setup.sh` the file would `return 0` before defining
-# any functions. Force-init matches the same pattern already used below for
-# `shell-common/env/claude.sh` and `tools/integrations/claude.sh`.
-MOUNT_LIB="${DOTFILES_ROOT}/shell-common/functions/mount.sh"
-if [ -f "$MOUNT_LIB" ]; then
-    DOTFILES_FORCE_INIT=1 . "$MOUNT_LIB"
-else
-    echo "Error: Mount library not found at $MOUNT_LIB"
-    exit 1
-fi
-
 # --- Logging Compatibility Functions ---
 
 log_info() { ux_info "$1"; }
@@ -77,6 +65,23 @@ log_warning() { ux_warning "$1"; }
 log_error_and_exit() {
     log_critical "$1"
 }
+
+# Load mount utilities (provides _is_mounted).
+#
+# shell-common/functions/mount.sh has the standard interactive guard:
+#   case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+# setup.sh is normally invoked non-interactively, so force the function
+# definitions to load here just like the claude env/integration sources below.
+MOUNT_LIB="${DOTFILES_ROOT}/shell-common/functions/mount.sh"
+if [ -f "$MOUNT_LIB" ]; then
+    DOTFILES_FORCE_INIT=1 . "$MOUNT_LIB"
+else
+    log_error_and_exit "Mount library not found at $MOUNT_LIB"
+fi
+
+if ! declare -f _is_mounted >/dev/null 2>&1; then
+    log_error_and_exit "Mount library did not define _is_mounted: $MOUNT_LIB"
+fi
 
 # --- Functions ---
 
@@ -558,7 +563,8 @@ _single_account_ensure_link() {
         # Remove it so the symlink below can take its place.
         rmdir "$tgt" 2>/dev/null || true
     elif [ -e "$tgt" ]; then
-        local backup="${tgt}.backup.$(date +%Y%m%d%H%M%S)"
+        local backup
+        backup="${tgt}.backup.$(date +%Y%m%d%H%M%S)"
         mv "$tgt" "$backup" || {
             log_error "backup failed: $tgt → $backup"
             return 1
@@ -590,11 +596,11 @@ if [ "$_setup_mode" = "internal" ]; then
 
     # --- Verify Links (single-account) ---
     log_debug "\n--- 심볼릭 링크 확인 (internal/single-account) ---"
-    for link in settings.json settings.local.json statusline-command.sh skills plugins projects/GLOBAL/memory; do
+    for link in settings.json settings.local.json statusline-command.sh skills docs plugins projects/GLOBAL/memory; do
         if [ -L "$HOME/.claude/$link" ]; then
             log_dim "✓ ~/.claude/$link 심볼릭 링크 확인됨"
         else
-            log_error_and_exit "~/.claude/$link 심볼릭 링크 생성 실패"
+            log_error_and_exit "$HOME/.claude/$link 심볼릭 링크 생성 실패"
         fi
     done
 

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -765,6 +765,71 @@ JSON
     refute_output --partial "command not found"
 }
 
+@test "regression #571: internal setup defines mount helper without DOTFILES_FORCE_INIT" {
+    _setup_sh_prereqs
+    echo "internal" > "$HOME/.dotfiles-setup-mode"
+
+    # No DOTFILES_FORCE_INIT — mirror the failing internal-PC invocation path.
+    run bash --noprofile --norc -c "
+        unset DOTFILES_FORCE_INIT
+        unset DOTFILES_TEST_MODE
+        export HOME='$HOME'
+        export TERM=dumb
+        CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 \
+            bash '${DOTFILES_ROOT}/claude/setup.sh'
+    "
+    assert_success
+    refute_output --partial "_is_mounted: command not found"
+    refute_output --partial "command not found"
+    [ -L "$HOME/.claude/skills" ]
+    [ -L "$HOME/.claude/docs" ]
+}
+
+@test "regression #571: internal setup unmounts legacy skills/docs bind mounts" {
+    _setup_sh_prereqs
+    echo "internal" > "$HOME/.dotfiles-setup-mode"
+    mkdir -p "$HOME/.claude/skills" "$HOME/.claude/docs"
+
+    fake_bin="$HOME/fake-bin"
+    mkdir -p "$fake_bin"
+
+    cat > "$fake_bin/findmnt" <<SH
+#!/usr/bin/env bash
+case "\$1" in
+    "$HOME/.claude/skills"|"$HOME/.claude/docs") exit 0 ;;
+    *) exit 1 ;;
+esac
+SH
+    chmod +x "$fake_bin/findmnt"
+
+    cat > "$fake_bin/sudo" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "umount" ]; then
+    printf '%s\n' "$2" >> "$HOME/fake-umount.log"
+    exit 0
+fi
+exit 1
+SH
+    chmod +x "$fake_bin/sudo"
+
+    run bash --noprofile --norc -c "
+        unset DOTFILES_FORCE_INIT
+        unset DOTFILES_TEST_MODE
+        export HOME='$HOME'
+        export TERM=dumb
+        export PATH='$fake_bin':\$PATH
+        CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 \
+            bash '${DOTFILES_ROOT}/claude/setup.sh'
+    "
+    assert_success
+    assert_output --partial "bind-mount detected at $HOME/.claude/skills"
+    assert_output --partial "bind-mount detected at $HOME/.claude/docs"
+    [ "$(cat "$HOME/fake-umount.log")" = "$HOME/.claude/skills
+$HOME/.claude/docs" ]
+    [ -L "$HOME/.claude/skills" ]
+    [ -L "$HOME/.claude/docs" ]
+}
+
 # ---------- Issue #300, item C: claude_accounts_status shows oauth binding ----------
 
 @test "issue #300-C: claude_accounts_status prints email/org from .claude.json" {


### PR DESCRIPTION
## Summary
- internal PC setup에서 mount helper가 비대화형 실행 때 누락되는 회귀를 수정했습니다.
- legacy `~/.claude/{skills,docs}` bind mount를 symlink로 전환하는 경로를 테스트로 고정했습니다.

## Changes
- `claude/setup.sh`: `mount.sh`를 `DOTFILES_FORCE_INIT=1`로 로드하고 `_is_mounted` 누락 시 즉시 실패하도록 했습니다.
- `claude/setup.sh`: single-account verify 목록에 `docs`를 포함하고 shellcheck 경고를 정리했습니다.
- `tests/bats/integrations/claude_accounts.bats`: missing helper와 legacy bind mount unmount 경로를 회귀 테스트로 추가했습니다.

## Test plan
- [x] `bash -n claude/setup.sh`
- [x] `shellcheck claude/setup.sh`
- [x] `tests/bats/lib/bats-core/bin/bats --filter 'regression #571' tests/bats/integrations/claude_accounts.bats`
- [x] `env -u CLAUDE_ENABLED_ACCOUNTS -u CLAUDE_DEFAULT_ACCOUNT tests/bats/lib/bats-core/bin/bats tests/bats/integrations/claude_accounts.bats`
- [x] `tox -e ruff,mypy,shellcheck,shfmt`
- [x] full `tox` attempted; existing `mdlint` target fails despite project instruction that markdown linting is disabled

## Related
Fixes #571

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
