### PR TITLE
fix(claude): #571 _is_mounted regression on internal-PC setup

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -49,10 +49,14 @@ else
     exit 1
 fi
 
-# Load mount utilities (provides _is_mounted)
+# Load mount utilities (provides _is_mounted).
+# mount.sh carries the standard interactive guard (`case $- in *i*) ...`), so
+# under non-interactive `./setup.sh` the file would `return 0` before defining
+# any functions. Force-init matches the same pattern already used below for
+# `shell-common/env/claude.sh` and `tools/integrations/claude.sh`.
 MOUNT_LIB="${DOTFILES_ROOT}/shell-common/functions/mount.sh"
 if [ -f "$MOUNT_LIB" ]; then
-    source "$MOUNT_LIB"
+    DOTFILES_FORCE_INIT=1 . "$MOUNT_LIB"
 else
     echo "Error: Mount library not found at $MOUNT_LIB"
     exit 1

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -3,6 +3,51 @@
 # Mount management functions following SOLID principles
 # Single Responsibility: addmnt() mounts, show_mnt() displays status
 
+# Pure utility functions live ABOVE the interactive guard.
+# Rationale: the guard exists to suppress *output* on non-interactive
+# sourcers, but `_check_command` and `_is_mounted` produce no output
+# and have no side effects. Keeping them above the guard lets
+# non-interactive scripts (e.g., claude/setup.sh) call them without
+# setting DOTFILES_FORCE_INIT=1 — which would otherwise force every
+# alias / help function in this file to load unnecessarily.
+
+# Validate that required command exists
+# Single Responsibility: Check availability of a command
+_check_command() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        return 1
+    fi
+    return 0
+}
+
+# Check if a path is mounted
+# Single Responsibility: Only check if path is mounted
+# Parameters:
+#   $1: mount path to check (required)
+# Returns: 0 if mounted, 1 if not mounted
+_is_mounted() {
+    local mount_path="$1"
+
+    # Validate input
+    if [ -z "$mount_path" ]; then
+        return 1
+    fi
+
+    # Expand home directory if present
+    mount_path="${mount_path/#\~/$HOME}"
+
+    # Use findmnt if available (faster, more reliable)
+    if _check_command findmnt; then
+        findmnt "$mount_path" >/dev/null 2>&1
+        return $?
+    fi
+
+    # Fallback to mount command
+    mount | grep -q "on ${mount_path} " 2>/dev/null
+    return $?
+}
+
 # Load UX library if not already loaded (bash/zsh compatible)
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
@@ -131,42 +176,7 @@ HELP
 
 alias mount-help='mount_help'
 
-# Validate that required command exists
-# Single Responsibility: Check availability of a command
-_check_command() {
-    local cmd="$1"
-    if ! command -v "$cmd" >/dev/null 2>&1; then
-        return 1
-    fi
-    return 0
-}
-
-# Check if a path is mounted
-# Single Responsibility: Only check if path is mounted
-# Parameters:
-#   $1: mount path to check (required)
-# Returns: 0 if mounted, 1 if not mounted
-_is_mounted() {
-    local mount_path="$1"
-
-    # Validate input
-    if [ -z "$mount_path" ]; then
-        return 1
-    fi
-
-    # Expand home directory if present
-    mount_path="${mount_path/#\~/$HOME}"
-
-    # Use findmnt if available (faster, more reliable)
-    if _check_command findmnt; then
-        findmnt "$mount_path" >/dev/null 2>&1
-        return $?
-    fi
-
-    # Fallback to mount command
-    mount | grep -q "on ${mount_path} " 2>/dev/null
-    return $?
-}
+# (_check_command and _is_mounted are defined above the interactive guard.)
 
 # Internal: Show help for mount_add function (use _mount_add_help_ prefix for internal functions)
 _mount_add_help() {


### PR DESCRIPTION
## Summary
- ac8b70c가 의도한 internal-PC bind-mount 처리 분기가 실제로는 동작하지 않던 회귀를 잡습니다.
- 즉시 unblock(force-init) + 구조적 재발 방지(순수 유틸을 가드 위로 hoist) — 두 커밋을 함께 묶어 사내 PC에서 한 번에 검증할 수 있게 했습니다.
- 인터랙티브/비인터랙티브 양쪽 모두 zero regression 검증 완료.

## Background

ac8b70c는 `claude/setup.sh`의 internal-PC 단일계정 모드에서 legacy bind-mount(`~/.claude/skills`, `~/.claude/docs`)를 만나면 `mv` EBUSY로 실패하는 문제를 고치려고 했습니다. 새 분기는 `_is_mounted "$tgt"` 로 가드 처리를 했지만, 사내 PC에서 재검증 시 동일 EBUSY가 그대로 재발했습니다.

```text
./claude/setup.sh: line 540: _is_mounted: command not found
mv: cannot move '/home/.../.claude/skills' to '...backup.X': Device or resource busy
❌ ~/.claude/skills 심볼릭 링크 생성 실패
```

근본 원인: `shell-common/functions/mount.sh`는 표준 인터랙티브 가드를 갖고 있어서

```sh
case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
```

`./setup.sh` 처럼 비인터랙티브로 source 되면 함수 정의 전에 `return 0` 됩니다. ac8b70c의 commit message는 "already sourced at the top of this file" 이라고 단정했지만 실제 등록 여부는 검증되지 않았던 케이스입니다.

## Changes

### `ac44423` — `claude/setup.sh` force-init (즉시 unblock)

`source "$MOUNT_LIB"` → `DOTFILES_FORCE_INIT=1 . "$MOUNT_LIB"`. 같은 파일 477-478줄에서 `shell-common/env/claude.sh`와 `tools/integrations/claude.sh`에 이미 쓰던 idiom과 통일. 한 줄짜리 안전 수정.

### `0301144` — `shell-common/functions/mount.sh` 순수 유틸을 가드 위로 hoist (구조적 수정)

`_check_command`와 `_is_mounted`는 출력이 없고 부수효과가 없는 순수 boolean 검사. 가드는 *출력* 보호용이므로 두 함수가 가드 대상이 되는 건 incidental이고, 그 자체가 footgun이었음. 두 함수를 가드 위로 이동하여 비인터랙티브 sourcer가 `DOTFILES_FORCE_INIT=1` 마법어를 몰라도 사용 가능. 가드는 여전히 `mount_add`, `mount_help`, alias, `claude-mount-all` 등 출력/별칭 코드는 보호.

`ac44423`은 0301144 이후 strict redundant defense-in-depth로 남겨두었습니다 — 두 커밋 중 하나가 향후 잘못 revert돼도 다른 한쪽이 회귀를 막습니다.

## Test plan

### 자동 검증 (이미 통과)
- [x] `bash -n` / `sh -n` syntax 모두 OK
- [x] 비인터랙티브 + 평범한 `source`: `_is_mounted` defined, `mount_add` NOT defined (가드 정상)
- [x] 비인터랙티브 + `DOTFILES_FORCE_INIT=1`: 전체 함수 정의됨 (기존 동작 유지)
- [x] 인터랙티브 셸 (`bash -i`): 전체 함수 정의됨 (기존 동작 유지)
- [x] `tox -e shellcheck,shfmt,ruff`: 모두 PASS

### 사내 PC 재검증 (이 PR의 핵심 검증 — 머지 후 수행)
- [ ] `cd ~/dotfiles && git pull` 후 `./claude/setup.sh`
- [ ] `bind-mount detected at ~/.claude/skills — unmounting (sudo may prompt)` 출력 확인
- [ ] sudo 패스워드 입력 → umount 성공 → 심볼릭 링크 생성 완료
- [ ] `~/.claude/docs`도 동일 흐름
- [ ] `ls -la ~/.claude/skills ~/.claude/docs` 가 dotfiles SSOT로 향하는 symlink로 표시

## Related

회귀 follow-up of #571 (이미 closed). ac8b70c가 의도한 fix를 실제로 동작하게 만드는 후속 패치. 새 이슈는 추적 단순화를 위해 별도로 열지 않았습니다.

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
