### PR TITLE
fix(claude): export settings.local.json env in claude_yolo

### DIFF
--- a/docs/setup/internal-pc.md
+++ b/docs/setup/internal-pc.md
@@ -40,6 +40,21 @@ $EDITOR claude/settings.local.json
 
 `<EMPLOYEE_ID>` 자리에 본인 사번을 채운다.
 
+## env 블록은 어떻게 claude 프로세스에 도달하는가
+
+두 경로가 동시에 활성화돼 있다 — defense-in-depth:
+
+1. **Claude Code 본체**가 `~/.claude/settings.local.json` 의 `env` 블록을 읽어 자기
+   서브프로세스에 주입. 정상 동작 시 이 경로만으로 충분.
+2. **`claude_yolo`** (shell-common/tools/integrations/claude.sh) 가 같은 파일을
+   `jq` 로 파싱하여 셸 레벨에서 `export` 한 뒤 `command claude` 실행. Claude Code
+   특정 버전이 (1) 경로를 무시하더라도 `claude-yolo` 는 게이트웨이로 정상 연결된다.
+
+(2) 경로는 `_claude_yolo_export_settings_env` 헬퍼가 담당하며, jq 미설치 / 파일
+부재 / env 블록 부재 / JSON 파싱 실패 모두 silent no-op (회귀 0). 단위
+테스트는 `tests/bats/integrations/claude_accounts.bats` 의 "settings.local.json
+env block exports to shell process" 등.
+
 ## 보안 경고
 
 1. **`claude/settings.local.json`은 절대 커밋되지 않는다** — `.gitignore`로 untracked. 의심되면:
@@ -77,7 +92,12 @@ cat ~/.dotfiles-setup-mode    # internal
 ls -la ~/.claude/settings.local.json
 # → ~/.claude/settings.local.json -> /home/<user>/dotfiles/claude/settings.local.json
 
-# env 적용 확인 — claude-yolo 시작 직후 통신 차단되면 게이트웨이 설정이 안 들어간 것
+# env 적용 확인 — 정상이면 사내 게이트웨이로 바로 연결됨.
+# 만약 `Failed to connect to api.anthropic.com` 가 뜬다면:
+#   1) `jq .env ~/.claude/settings.local.json` 으로 env 블록 유효성 확인
+#   2) 새 셸 (`exec zsh`) 에서 `env | grep ANTHROPIC_` 출력 확인 —
+#      claude_yolo 가 셸 레벨로 export 했으면 6 줄이 보여야 함
+#   3) 둘 다 정상인데도 실패면 사내 게이트웨이/방화벽 이슈
 claude-yolo
 ```
 

--- a/docs/setup/internal-pc.md
+++ b/docs/setup/internal-pc.md
@@ -95,8 +95,12 @@ ls -la ~/.claude/settings.local.json
 # env 적용 확인 — 정상이면 사내 게이트웨이로 바로 연결됨.
 # 만약 `Failed to connect to api.anthropic.com` 가 뜬다면:
 #   1) `jq .env ~/.claude/settings.local.json` 으로 env 블록 유효성 확인
-#   2) 새 셸 (`exec zsh`) 에서 `env | grep ANTHROPIC_` 출력 확인 —
-#      claude_yolo 가 셸 레벨로 export 했으면 6 줄이 보여야 함
+#   2) 헬퍼가 실제로 export 하는지 *subshell 내부* 에서 확인:
+#        ( _claude_yolo_export_settings_env ~/.claude && env | grep '^ANTHROPIC_' )
+#      6 줄이 보여야 정상. 0 줄이면 jq 미설치 또는 헬퍼 미로드 (`. shell-common/...`).
+#      subshell 밖 (`env | grep ANTHROPIC_`) 은 항상 0 줄이 정상 — claude_yolo 가
+#      `( ... )` 로 격리하여 사용자 셸을 오염시키지 않기 때문 (특히
+#      `NODE_TLS_REJECT_UNAUTHORIZED=0` 누수 방지).
 #   3) 둘 다 정상인데도 실패면 사내 게이트웨이/방화벽 이슈
 claude-yolo
 ```

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -402,6 +402,40 @@ clskip() {
 
 alias claude-skip='claude --dangerously-skip-permissions'
 
+# _claude_yolo_export_settings_env — propagate settings.local.json `env` block
+# to the shell process so `claude` inherits it via the normal env path. Some
+# Claude Code releases do not apply the settings.local.json env block to the
+# spawned child, so the gateway URL / auth headers configured there silently
+# never reach the request layer (symptom: `Failed to connect to
+# api.anthropic.com` on a Samsung-internal PC even with a fully-correct
+# settings.local.json). This helper is the belt-and-suspenders fix: jq-read
+# the env block and `export` each key. Idempotent, silent, no-op when jq or
+# the file is missing.
+#
+# Parameters:
+#   $1: Claude config dir (e.g. ~/.claude or ~/.claude-work)
+#
+# Why eval is safe here: settings.local.json is gitignored and user-owned;
+# its contents are already trusted by Claude Code itself. `@sh` quoting on
+# the value handles embedded newlines and shell metacharacters.
+_claude_yolo_export_settings_env() {
+    _cysee_dir="$1"
+    [ -n "$_cysee_dir" ] || return 0
+    _cysee_file="$_cysee_dir/settings.local.json"
+    [ -f "$_cysee_file" ] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    _cysee_exports=$(jq -r '
+        .env // {}
+        | to_entries[]
+        | "export \(.key)=\(.value | tostring | @sh)"
+    ' "$_cysee_file" 2>/dev/null)
+
+    [ -n "$_cysee_exports" ] && eval "$_cysee_exports"
+
+    unset _cysee_dir _cysee_file _cysee_exports
+}
+
 # claude_yolo — 다중 계정 dispatcher (issue #287, Phase 1).
 #
 # Usage:
@@ -503,7 +537,15 @@ claude_yolo() {
         CLAUDE_SKILLS_SYNC_QUIET=1 claude_skills_sync || true
     fi
 
-    CLAUDE_CONFIG_DIR="$_cy_config_dir" command claude --dangerously-skip-permissions "$@"
+    # Apply settings.local.json env block at the shell level too — works
+    # around Claude Code releases where the env block isn't propagated to
+    # the spawned process. The subshell isolates exports so the caller's
+    # shell env (which may persist after `claude-yolo` exits) is not
+    # polluted with e.g. NODE_TLS_REJECT_UNAUTHORIZED=0.
+    (
+        _claude_yolo_export_settings_env "$_cy_config_dir"
+        CLAUDE_CONFIG_DIR="$_cy_config_dir" command claude --dangerously-skip-permissions "$@"
+    )
 }
 
 # _claude_restore_if_reset — auto-restore .claude.json from sealed snapshot

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -419,21 +419,29 @@ alias claude-skip='claude --dangerously-skip-permissions'
 # its contents are already trusted by Claude Code itself. `@sh` quoting on
 # the value handles embedded newlines and shell metacharacters.
 _claude_yolo_export_settings_env() {
-    _cysee_dir="$1"
+    local _cysee_dir="${1:-}"
     [ -n "$_cysee_dir" ] || return 0
-    _cysee_file="$_cysee_dir/settings.local.json"
+    local _cysee_file="$_cysee_dir/settings.local.json"
     [ -f "$_cysee_file" ] || return 0
     command -v jq >/dev/null 2>&1 || return 0
 
+    # Declare and assign separately to avoid SC2155 (local + command
+    # substitution masks the substitution's exit status). The colleague
+    # PR #576 fixed the same pattern elsewhere in setup.sh.
+    local _cysee_exports
     _cysee_exports=$(jq -r '
         .env // {}
         | to_entries[]
         | "export \(.key)=\(.value | tostring | @sh)"
     ' "$_cysee_file" 2>/dev/null)
 
-    [ -n "$_cysee_exports" ] && eval "$_cysee_exports"
-
-    unset _cysee_dir _cysee_file _cysee_exports
+    # Explicit `return 0` — without it, the final `[ -n "" ] && ...` short-
+    # circuits with exit 1 when the env block is absent / malformed, which
+    # would propagate to callers expecting silent no-op.
+    if [ -n "$_cysee_exports" ]; then
+        eval "$_cysee_exports"
+    fi
+    return 0
 }
 
 # claude_yolo — 다중 계정 dispatcher (issue #287, Phase 1).

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -1265,3 +1265,117 @@ run_with_fake_ssot() {
     nested=$(find "$HOME/.claude-personal/.sync-backup/" -name 'cli-dev-pre-sync-20260101000000' 2>/dev/null | wc -l)
     [ "$nested" -eq 1 ]
 }
+
+# ---------- _claude_yolo_export_settings_env: gateway env propagation ----------
+
+@test "bash: settings.local.json env block exports to shell process" {
+    mkdir -p "$HOME/.claude-test"
+    cat > "$HOME/.claude-test/settings.local.json" <<'JSON'
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://gw.example.local:8090",
+    "ANTHROPIC_AUTH_TOKEN": "",
+    "ANTHROPIC_MODEL": "TestModel-7B",
+    "NODE_TLS_REJECT_UNAUTHORIZED": 0,
+    "ANTHROPIC_CUSTOM_HEADERS": "x-foo: bar\nx-baz: qux",
+    "GH_PR_REPLY_AUTO_APPROVE_REPOS": "owner/repo"
+  }
+}
+JSON
+
+    run_in_bash '
+        unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_MODEL \
+              NODE_TLS_REJECT_UNAUTHORIZED ANTHROPIC_CUSTOM_HEADERS \
+              GH_PR_REPLY_AUTO_APPROVE_REPOS
+        _claude_yolo_export_settings_env "$HOME/.claude-test"
+        printf "BASE=[%s]\nTOKEN=[%s]\nMODEL=[%s]\nTLS=[%s]\nHEADERS=[%s]\nREPOS=[%s]\n" \
+            "${ANTHROPIC_BASE_URL}" "${ANTHROPIC_AUTH_TOKEN}" "${ANTHROPIC_MODEL}" \
+            "${NODE_TLS_REJECT_UNAUTHORIZED}" "${ANTHROPIC_CUSTOM_HEADERS}" \
+            "${GH_PR_REPLY_AUTO_APPROVE_REPOS}"
+    '
+    assert_success
+    assert_output --partial "BASE=[http://gw.example.local:8090]"
+    assert_output --partial "TOKEN=[]"
+    assert_output --partial "MODEL=[TestModel-7B]"
+    assert_output --partial "TLS=[0]"
+    # ANTHROPIC_CUSTOM_HEADERS has an embedded newline — assert both halves.
+    assert_output --partial "HEADERS=[x-foo: bar"
+    assert_output --partial "x-baz: qux]"
+    assert_output --partial "REPOS=[owner/repo]"
+}
+
+@test "bash: _claude_yolo_export_settings_env silent no-op when file missing" {
+    # No settings.local.json under the test dir.
+    mkdir -p "$HOME/.claude-empty"
+
+    run_in_bash '
+        unset ANTHROPIC_BASE_URL
+        _claude_yolo_export_settings_env "$HOME/.claude-empty"
+        echo "exit=$?"
+        echo "BASE=[${ANTHROPIC_BASE_URL-<unset>}]"
+    '
+    assert_success
+    assert_output --partial "exit=0"
+    assert_output --partial "BASE=[<unset>]"
+}
+
+@test "bash: _claude_yolo_export_settings_env silent no-op when env block absent" {
+    mkdir -p "$HOME/.claude-noenv"
+    echo '{"permissions": {"allow": []}}' > "$HOME/.claude-noenv/settings.local.json"
+
+    run_in_bash '
+        unset ANTHROPIC_BASE_URL
+        _claude_yolo_export_settings_env "$HOME/.claude-noenv"
+        echo "exit=$?"
+        echo "BASE=[${ANTHROPIC_BASE_URL-<unset>}]"
+    '
+    assert_success
+    assert_output --partial "exit=0"
+    assert_output --partial "BASE=[<unset>]"
+}
+
+@test "bash: _claude_yolo_export_settings_env in subshell does not leak to caller" {
+    # claude_yolo wraps the helper + `command claude` in (...) precisely
+    # so that NODE_TLS_REJECT_UNAUTHORIZED=0 (security-relaxing) and the
+    # gateway URL do not persist in the caller's interactive shell.
+    mkdir -p "$HOME/.claude-iso"
+    cat > "$HOME/.claude-iso/settings.local.json" <<'JSON'
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://iso.example.local:8090",
+    "NODE_TLS_REJECT_UNAUTHORIZED": 0
+  }
+}
+JSON
+
+    run_in_bash '
+        unset ANTHROPIC_BASE_URL NODE_TLS_REJECT_UNAUTHORIZED
+        (
+            _claude_yolo_export_settings_env "$HOME/.claude-iso"
+            echo "INSIDE_BASE=[${ANTHROPIC_BASE_URL}]"
+            echo "INSIDE_TLS=[${NODE_TLS_REJECT_UNAUTHORIZED}]"
+        )
+        echo "OUTSIDE_BASE=[${ANTHROPIC_BASE_URL-<unset>}]"
+        echo "OUTSIDE_TLS=[${NODE_TLS_REJECT_UNAUTHORIZED-<unset>}]"
+    '
+    assert_success
+    assert_output --partial "INSIDE_BASE=[http://iso.example.local:8090]"
+    assert_output --partial "INSIDE_TLS=[0]"
+    assert_output --partial "OUTSIDE_BASE=[<unset>]"
+    assert_output --partial "OUTSIDE_TLS=[<unset>]"
+}
+
+@test "bash: _claude_yolo_export_settings_env silent no-op on malformed JSON" {
+    mkdir -p "$HOME/.claude-bad"
+    echo '{invalid json' > "$HOME/.claude-bad/settings.local.json"
+
+    run_in_bash '
+        unset ANTHROPIC_BASE_URL
+        _claude_yolo_export_settings_env "$HOME/.claude-bad"
+        echo "exit=$?"
+        echo "BASE=[${ANTHROPIC_BASE_URL-<unset>}]"
+    '
+    assert_success
+    assert_output --partial "exit=0"
+    assert_output --partial "BASE=[<unset>]"
+}


### PR DESCRIPTION
## Summary
- `claude-yolo`가 `settings.local.json`의 `env` 블록을 셸 레벨로 export 한 뒤 `command claude`를 띄우도록 변경 — Claude Code 본체가 env를 전파하지 않는 버전에서도 사내 게이트웨이 우회가 동작.
- jq + `@sh` quoting + subshell isolation으로 보안 회귀 0 (특히 `NODE_TLS_REJECT_UNAUTHORIZED=0`이 사용자 인터랙티브 셸로 새지 않음).
- bats 회귀 테스트 5개 추가.

## Background

`docs/setup/internal-pc.md` 스펙 그대로 `~/.claude/settings.local.json`에 사내 게이트웨이 env 블록을 넣어도, Claude Code v2.1.126에서 사용자 인터랙티브 PC가 `api.anthropic.com`을 때리고 실패:

```
Unable to connect to Anthropic services
Failed to connect to api.anthropic.com: ERR_BAD_REQUEST
```

`jq . ~/.claude/settings.local.json`은 정상, 심볼릭 링크도 SSOT를 가리킴. Claude Code 본체가 settings.local.json의 `env` 블록을 spawn된 자식 프로세스로 전파하지 못하는 회귀로 보임 — 사용자/사내 PC 차원에서 단일 release에 묶일 수 없으니 dotfiles에서 defense-in-depth를 깔아둠.

## Approach

### 1. 새 헬퍼 — `_claude_yolo_export_settings_env <config-dir>`

`shell-common/tools/integrations/claude.sh` 에 추가. 동작:

```sh
jq -r '
    .env // {}
    | to_entries[]
    | "export \(.key)=\(.value | tostring | @sh)"
' "$_cysee_file" | eval
```

- `tostring`: `NODE_TLS_REJECT_UNAUTHORIZED: 0` (number) → `"0"` (env var는 항상 문자열)
- `@sh`: `ANTHROPIC_CUSTOM_HEADERS`의 임베디드 newline 안전 보존, 셸 메타문자 escape
- eval 안전성: `settings.local.json`은 gitignored + user-owned + Claude Code 본체도 이미 신뢰하는 파일. `@sh` quoting으로 injection 차단.

### 2. `claude_yolo` 호출부를 subshell로 래핑

```sh
(
    _claude_yolo_export_settings_env "$_cy_config_dir"
    CLAUDE_CONFIG_DIR="$_cy_config_dir" command claude --dangerously-skip-permissions "$@"
)
```

이유: `NODE_TLS_REJECT_UNAUTHORIZED=0`이 사용자의 인터랙티브 셸에 남으면 이후 `curl`/`node` 호출 모두 TLS 검증을 건너뜀. subshell이 export 스코프를 claude 호출에만 한정.

### 3. Silent no-op for all failure modes

`<config-dir>` 부재, `settings.local.json` 부재, `jq` 부재, 파싱 실패, env 블록 부재 모두 exit 0으로 조용히 통과 — 기존 claude_yolo 동작에 회귀 도입 없음.

## Test plan

### 자동 (bats, `tests/bats/integrations/claude_accounts.bats`)
- [x] `settings.local.json env block exports to shell process` — 6 필드 happy path, 임베디드 newline 포함
- [x] `silent no-op when file missing`
- [x] `silent no-op when env block absent`
- [x] `silent no-op on malformed JSON`
- [x] `in subshell does not leak to caller` — isolation 계약 검증

```sh
tests/bats/lib/bats-core/bin/bats \
    --filter '_claude_yolo_export_settings_env|env block exports to shell' \
    tests/bats/integrations/claude_accounts.bats
# → 5/5 PASS
```

### 사내 PC 재검증 (이 PR의 핵심)
- [ ] `cd ~/dotfiles && git pull` 후 `exec zsh`
- [ ] `claude-yolo` 실행 → 사내 게이트웨이로 연결 (api.anthropic.com 에러 사라짐)
- [ ] claude 종료 후 사용자 셸에서 `env | grep ANTHROPIC_` → **출력 0줄** (subshell isolation 확인)
- [ ] claude 종료 후 사용자 셸에서 `echo $NODE_TLS_REJECT_UNAUTHORIZED` → 빈 출력

## Files

| 파일 | 변경 |
|---|---|
| `shell-common/tools/integrations/claude.sh` | 헬퍼 추가 + claude_yolo 호출부 subshell 래핑 (+44/-2) |
| `tests/bats/integrations/claude_accounts.bats` | 회귀 테스트 5개 (+114) |
| `docs/setup/internal-pc.md` | dual-path 동작 설명 + 검증 절차 업데이트 (+22) |

## Related

별도 이슈 없음 — v2.1.126 회귀를 직접 검증한 사내 PC 세션에서 발견. 향후 Claude Code 본체가 env 블록 전파를 복구하면 본 PR의 셸 레벨 export는 redundant defense-in-depth로 남음 (둘 다 동시 활성, 동일 결과, 충돌 없음).

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~2 h · 🤖 ~25 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~2 h · 🤖 ~25 min
<!-- /ai-metrics:gh-pr -->

</details>
