### PR TITLE
refactor(opencode): drop oc-profile dtgpt branch

### DIFF
--- a/shell-common/tools/integrations/opencode.sh
+++ b/shell-common/tools/integrations/opencode.sh
@@ -104,9 +104,9 @@ _opencode_help_summary() {
     ux_bullet_sub "setup: install-opencode | opencode-verify | uninstall-opencode"
     ux_bullet_sub "utils: bunx oh-my-opencode install | install-bun | bun-help"
     ux_bullet_sub "env: home/public | external | internal"
-    ux_bullet_sub "profile: oc-profile dtgpt | oc-profile a2g"
+    ux_bullet_sub "profile: oc-profile a2g"
     ux_bullet_sub "config: \$OPENCODE_CONFIG_FILE | opencode-edit"
-    ux_bullet_sub "models: Home | External | DTGPT | A2G"
+    ux_bullet_sub "models: Home | External | A2G"
     ux_bullet_sub "usage: opencode | opencode --help | opencode --version"
     ux_bullet_sub "trouble: install-opencode | opencode-verify | uninstall-opencode"
     ux_bullet_sub "details: opencode-help <section>  (example: opencode-help profile)"
@@ -142,7 +142,6 @@ _opencode_help_rows_env() {
 }
 
 _opencode_help_rows_profile() {
-    ux_bullet "${UX_PRIMARY}oc-profile dtgpt${UX_RESET}     : DTGPT  (cloud.dtgpt.samsungds.net)"
     ux_bullet "${UX_PRIMARY}oc-profile a2g${UX_RESET}       : A2G    (a2g.samsungds.net) — Thinking models"
 }
 
@@ -154,7 +153,6 @@ _opencode_help_rows_config() {
 _opencode_help_rows_models() {
     ux_bullet "Home       : OpenCode defaults"
     ux_bullet "External   : gpt-oss-20b"
-    ux_bullet "DTGPT      : GLM4.7, Kimi-K2.5, MiniMax-M2.1"
     ux_bullet "A2G        : GLM-5-Thinking, Qwen3.5-Thinking, Kimi-K2.5-Thinking"
 }
 
@@ -219,16 +217,12 @@ oc_profile() {
     local dotfiles_root="${DOTFILES_ROOT:-$HOME/dotfiles}"
 
     case "$profile" in
-        dtgpt)
-            local src="$dotfiles_root/opencode/opencode.json.internal"
-            ;;
         a2g)
             local src="$dotfiles_root/opencode/opencode.json.internal-a2g"
             ;;
         *)
-            ux_usage "oc-profile" "<dtgpt|a2g>" "Switch OpenCode internal profile"
-            ux_bullet "  dtgpt : DTGPT  (cloud.dtgpt.samsungds.net) — GLM4.7, Kimi-K2.5, MiniMax-M2.1"
-            ux_bullet "  a2g   : A2G    (a2g.samsungds.net)         — GLM-5-Thinking, Kimi-K2.5-Thinking"
+            ux_usage "oc-profile" "<a2g>" "Switch OpenCode internal profile"
+            ux_bullet "  a2g   : A2G    (a2g.samsungds.net) — GLM-5-Thinking, Kimi-K2.5-Thinking"
             return 1
             ;;
     esac


### PR DESCRIPTION
## Summary
- Remove the `dtgpt` branch from `oc_profile()` in `shell-common/tools/integrations/opencode.sh`.
- `oc-profile` now accepts a single argument: `a2g`.
- Help text (`opencode-help` summary, profile rows, models rows) and the inline usage message are updated to match.

## Why
After #579 merged, `opencode.json.internal` became an alias of the a2g content. The `oc-profile dtgpt` branch still pointed at `opencode.json.internal`, so calling `oc-profile dtgpt` would silently load the a2g config — a misleading no-op. Removing the branch makes the tool honest about what it supports today.

If a separate `dtgpt` profile is reintroduced later, it should ship with its own dedicated source file (e.g. `opencode.json.internal-dt`) and a new `dtgpt)` case wired to that file.

## Test plan
- [ ] `bash -n shell-common/tools/integrations/opencode.sh` — syntax OK (verified locally)
- [ ] `grep -i dtgpt shell-common/tools/integrations/opencode.sh` — returns nothing (verified locally)
- [ ] `oc-profile` with no args prints usage showing only `a2g`
- [ ] `oc-profile a2g` switches `~/.config/opencode/opencode.json` to `opencode.json.internal-a2g`
- [ ] `oc-profile dtgpt` now falls into the `*)` default branch and exits 1 with usage hint
- [ ] `opencode-help profile` and `opencode-help models` no longer list dtgpt / DTGPT

Co-Authored-By: Claude Opus 4.7 (1M context)