### PR TITLE
fix(opencode): replace NBSP with space in internal configs

### DIFF
--- a/opencode/opencode.json.internal
+++ b/opencode/opencode.json.internal
@@ -1,25 +1,25 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "S/W혁신팀": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "Qwen3.6-27B",
-      "options": {
-        "baseURL": "http://a2g.samsungds.net:8090/v1",
-        "headers": {
-          "x-service-id": "coding-agent-model-service",
-          "x-user-id": "byoungwoo.yoon"
-        }
-      },
-      "models": {
-        "Qwen3.6-27B": {
-          "name": "Qwen3.6-27B",
-          "limit": {
-            "context": 200000,
-            "output": 65536
-          }
-        }
-      }
-    }
-  }
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "S/W혁신팀": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Qwen3.6-27B",
+      "options": {
+        "baseURL": "http://a2g.samsungds.net:8090/v1",
+        "headers": {
+          "x-service-id": "coding-agent-model-service",
+          "x-user-id": "byoungwoo.yoon"
+        }
+      },
+      "models": {
+        "Qwen3.6-27B": {
+          "name": "Qwen3.6-27B",
+          "limit": {
+            "context": 200000,
+            "output": 65536
+          }
+        }
+      }
+    }
+  }
 }

--- a/opencode/opencode.json.internal-a2g
+++ b/opencode/opencode.json.internal-a2g
@@ -1,25 +1,25 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "S/W혁신팀": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "Qwen3.6-27B",
-      "options": {
-        "baseURL": "http://a2g.samsungds.net:8090/v1",
-        "headers": {
-          "x-service-id": "coding-agent-model-service",
-          "x-user-id": "byoungwoo.yoon"
-        }
-      },
-      "models": {
-        "Qwen3.6-27B": {
-          "name": "Qwen3.6-27B",
-          "limit": {
-            "context": 200000,
-            "output": 65536
-          }
-        }
-      }
-    }
-  }
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "S/W혁신팀": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Qwen3.6-27B",
+      "options": {
+        "baseURL": "http://a2g.samsungds.net:8090/v1",
+        "headers": {
+          "x-service-id": "coding-agent-model-service",
+          "x-user-id": "byoungwoo.yoon"
+        }
+      },
+      "models": {
+        "Qwen3.6-27B": {
+          "name": "Qwen3.6-27B",
+          "limit": {
+            "context": 200000,
+            "output": 65536
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `opencode/opencode.json.internal` and `opencode/opencode.json.internal-a2g` carried 23 NBSP (U+00A0) characters in their indentation, left over from a rich-text paste.
- NBSP renders like a normal space in most editors, but JSON / JSONC parsers reject it as `InvalidSymbol`.
- Sed-replace every `0xC2 0xA0` byte pair with a regular `0x20` space. String values (Korean provider name `S/W혁신팀`, `baseURL`, headers, `x-user-id`) are untouched.

## Symptom
On the internal PC, after `oc-profile a2g` (or with the default a2g symlink) running `opencode-yolo`:

```
Config file at ~/.config/opencode/opencode.json is not valid JSON(C):
InvalidSymbol at line 2, column 1
InvalidSymbol at line 3, column 1
InvalidSymbol at line 4, column 1
...
```

`jq -e . opencode.json.internal-a2g` also fails with `parse error: Invalid numeric literal at line 2, column 3` (the NBSP byte sequence sitting where the parser expects whitespace or a token).

## Verification
- `jq -e . opencode/opencode.json.internal` → parses cleanly
- `jq -e . opencode/opencode.json.internal-a2g` → parses cleanly
- `diff -s` confirms the two files remain byte-identical to each other (consistent with #579)
- Diff is 46 insertions / 46 deletions for each file — only whitespace byte values change, structure is preserved

## Test plan
- [ ] On internal PC: pull main, run `opencode-yolo` → no JSONC parse error
- [ ] `oc-profile a2g` then `opencode --version` → loads a2g config
- [ ] No regression on external/home modes (those files were untouched)

## Related
- #579 introduced the .internal = .internal-a2g aliasing but copied the corrupted content as-is.
- #580 cleans up the now-orphaned `oc-profile dtgpt` branch (independent change).

Co-Authored-By: Claude Opus 4.7 (1M context)