### PR TITLE
feat(claude): add ANTHROPIC vars to local example

### DIFF
--- a/claude/settings.local.example.json
+++ b/claude/settings.local.example.json
@@ -1,5 +1,8 @@
 {
   "env": {
+    "ANTHROPIC_BASE_URL": "http://cloud.dtgpt.samsungds.net/llm",
+    "ANTHROPIC_AUTH_TOKEN": "your-dt-api-key",
+    "ANTHROPIC_MODEL": "Qwen3.6-27B",
     "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles"
   }
 }


### PR DESCRIPTION
## Summary
Extend `claude/settings.local.example.json` from a 1-key template to a 4-key template that mirrors the actual shape of an internal-PC `settings.local.json` — three `ANTHROPIC_*` env vars + the existing `GH_PR_REPLY_AUTO_APPROVE_REPOS`.

## Why
`claude/settings.local.example.json` is the SSOT template that `claude/setup.sh` bootstraps into the gitignored per-machine `claude/settings.local.json`. On internal PCs, that live file holds the Samsung internal Anthropic gateway config (BASE_URL, AUTH_TOKEN, MODEL). Before this change the example only carried `GH_PR_REPLY_AUTO_APPROVE_REPOS`, so anyone bootstrapping a fresh internal machine had to look elsewhere (another machine, a Slack thread, etc.) to find the dtgpt endpoint shape.

This also unblocks the `gh:pr-reply` skill's Step 8 auto-approve guard `G1` — once the example is bootstrapped, `GH_PR_REPLY_AUTO_APPROVE_REPOS=dEitY719/dotfiles` is present in the environment.

## Placeholder pattern (consistency with PR #582)
`ANTHROPIC_AUTH_TOKEN` ships as the literal string `your-dt-api-key`. Users hand-edit their per-machine `settings.local.json` after bootstrap — same "manual edit per machine" pattern that PR #582 established for `opencode.json.internal` with the `your-knox-id` placeholder. No `.env` indirection, per the feedback that `.env` flows have been brittle in this repo.

`settings.local.json` itself remains gitignored, so the placeholder never leaks into a real config on any machine that has already been set up.

## Verification
- `jq -e . claude/settings.local.example.json` → parses cleanly
- Diff: 3 insertions (just the three ANTHROPIC lines)
- No changes to `setup.sh` or any non-example file

## Test plan
- [ ] On a fresh machine: clone, run `./setup.sh`, observe `~/.claude/settings.local.json` symlink created from the new 4-key example
- [ ] Hand-edit `your-dt-api-key` to the real token, start Claude Code — internal endpoint reachable
- [ ] `gh:pr-reply` Step 8 G1 guard now passes (`GH_PR_REPLY_AUTO_APPROVE_REPOS` is set)

Co-Authored-By: Claude Opus 4.7 (1M context)