### PR TITLE
fix(setup): #586 propagate base.json via .vscode/sync-push.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,17 @@
 
 set -e
 
+# Load UX library so user-facing messages stay consistent (mirrors install.sh).
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UX_LIB_SCRIPT="${DOTFILES_DIR}/shell-common/tools/ux_lib/ux_lib.sh"
+if [ -f "${UX_LIB_SCRIPT}" ]; then
+    # shellcheck source=/dev/null
+    source "${UX_LIB_SCRIPT}"
+else
+    echo "CRITICAL ERROR: UX library script not found at ${UX_LIB_SCRIPT}. Exiting." >&2
+    exit 1
+fi
+
 # Run setup scripts for shell-common, bash, zsh, git, claude, and vscode-extensions
 ./shell-common/setup.sh
 ./bash/setup.sh
@@ -30,7 +41,7 @@ set -e
 ./vscode-extensions/setup.sh
 # Propagate .vscode/base.json (SSOT) to the live VS Code User settings.json (#586).
 # Non-fatal: sync-push exits 1 when VS Code is absent on this host.
-./.vscode/sync-push.sh || echo "Warning: .vscode/sync-push.sh 건너뜀 (VS Code 미설치 또는 환경 미감지). 필요 시 수동 실행."
+./.vscode/sync-push.sh || ux_warning ".vscode/sync-push.sh 건너뜀 (VS Code 미설치 또는 환경 미감지). 필요 시 수동 실행."
 ./ssh/setup.sh
 ./gh/setup.sh
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,9 @@ set -e
 ./gemini/setup.sh
 ./scripts/setup-skills-ssot.sh
 ./vscode-extensions/setup.sh
+# Propagate .vscode/base.json (SSOT) to the live VS Code User settings.json (#586).
+# Non-fatal: sync-push exits 1 when VS Code is absent on this host.
+./.vscode/sync-push.sh || echo "Warning: .vscode/sync-push.sh 건너뜀 (VS Code 미설치 또는 환경 미감지). 필요 시 수동 실행."
 ./ssh/setup.sh
 ./gh/setup.sh
 


### PR DESCRIPTION
## Summary

- `setup.sh` 가 `.vscode/sync-push.sh` 를 호출하지 않아 PR #563 의 fix (`python.terminal.activateEnvironment: false`) 가 SSOT `.vscode/base.json` 에만 머물고 실제 VS Code User `settings.json` 까지 전파되지 않던 propagation gap 을 해결.
- `vscode-extensions/setup.sh` 직후 `./.vscode/sync-push.sh` 호출을 추가하되, `|| echo "Warning: ..."` 으로 non-fatal 처리하여 VS Code 미설치/미감지 환경(macOS native, VS Code 없는 Linux)에서도 setup 전체가 중단되지 않도록 가드.
- 결과: `./setup.sh` 1회 실행으로 base.json 의 핵심 terminal 설정이 live settings 까지 일관 전파. 사용자가 수동으로 sync-push 를 기억할 필요 없음.

## Commits

- `92abfff` fix(setup): #586 propagate base.json via .vscode/sync-push.sh

## Test plan

- [x] `bash -n setup.sh` — syntax OK
- [x] `shellcheck setup.sh` — no warnings
- [x] Live test: 현 PC 에서 `./.vscode/sync-push.sh` 실행 → `/mnt/c/Users/bwyoon/AppData/Roaming/Code/User/settings.json` 갱신 → `python.terminal.activateEnvironment=false`, `python.terminal.useEnvFile=true` 확인. backup `settings.json.backup.20260513_134046` 자동 생성.
- [x] Lint guard (`GH_PR_LINT_TOOLS=shellcheck,ruff,shfmt`, mdlint 는 CLAUDE.md 에 disabled 명시) — shellcheck PASS.
- [ ] 사용자 측 VS Code 재시작 후 신규 터미널 5회 이상 — `SERAPH%` 미노출, `source .venv/bin/activate` 자동 호출 없음, 자동 `zsh` 재스폰 없음.
- [ ] `~/.vscode-server/data/logs/<신규 세션>/exthost*/ms-python*/` 에 신규 `Send text to terminal: source .../.venv/bin/activate` 기록 부재 확인.
- [ ] VS Code 미설치 환경 (예: 사내 PC) 에서 `./setup.sh` 실행 시 Warning 출력 + 다른 setup 단계 정상 완료 확인.

## Scope notes

- 이슈 #586 의 권고안 A 단독 채택 (D: drift 경고는 별도 이슈로 분리).
- C 안 (jq-based merge mode for sync-push) 및 E 안 (workspace-scoped `.vscode/settings.json`) 은 정책 변경 필요로 미적용.
- `set -e` 호환: `||` 로 short-circuit 하여 sync-push 실패가 후속 `ssh/setup.sh`, `gh/setup.sh` 를 막지 않음.

Closes #586

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
