### PR TITLE
refactor(claude): #575 unify skills/docs storage as directory symlinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `
 
 ### Claude Code Integration
 
-`claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` directory is bind-mounted to `~/.claude/skills/` (not symlinked).
+`claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` and `claude/docs/` directories are also symlinked (directory-level) into each account's `~/.claude*/skills` and `~/.claude*/docs` — the same scheme in every setup mode (#575).
 
 ## Critical Rules
 

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 Claude Code CLI 설정, 스킬, 자동화 관리.  
-Dependencies: Claude Code CLI, jq, sudo
+Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 ---
 
@@ -15,7 +15,7 @@ Dependencies: Claude Code CLI, jq, sudo
 
 | 도구 | 경로 | 연결 방식 | 신규 스킬 자동 반영 |
 |------|------|-----------|---------------------|
-| **Claude Code** (각 계정) | `~/.claude-personal/skills/<name>` → `dotfiles/claude/skills/<name>` | 개별 skill symlink | ❌ setup 재실행 필요 |
+| **Claude Code** (모든 모드) | `~/.claude*/skills` → `dotfiles/claude/skills` | 디렉토리 symlink (#575) | ✅ 즉시 |
 | **Gemini CLI** | `~/.gemini/skills` → `dotfiles/claude/skills` | 디렉토리 symlink | ✅ 즉시 |
 | **Codex** | `~/.codex/skills/<name>` → `dotfiles/claude/skills/<name>/` | 개별 skill symlink | ❌ setup 재실행 필요 |
 
@@ -23,7 +23,7 @@ Dependencies: Claude Code CLI, jq, sudo
 
 | 도구 | 담당 스크립트 / 함수 | 트리거 |
 |------|----------------------|--------|
-| Claude Code (각 계정) | `shell-common/tools/integrations/claude.sh` → `_claude_dir_sync_one()` | `./claude/setup.sh` |
+| Claude Code (각 계정) | `shell-common/tools/integrations/claude.sh` → `_claude_account_setup_one()` | `./claude/setup.sh` |
 | Gemini CLI | `claude/setup.sh` → `_setup_gemini_skills_symlink()` | `./claude/setup.sh` |
 | Codex | `scripts/setup-skills-ssot.sh` → `link_skills_individual_codex()` | `./setup.sh` 또는 `./scripts/setup-skills-ssot.sh` |
 
@@ -36,15 +36,17 @@ Dependencies: Claude Code CLI, jq, sudo
 ./setup.sh
 ```
 
+Claude Code 의 skills/ 는 디렉토리 symlink 라 SSOT 에 새 스킬 디렉토리만 추가하면 setup 재실행 없이 즉시 보인다 (#575).
+
 ### 연결 방식이 다른 이유
 
 - **Gemini**: 커스텀 전용 디렉토리 → 디렉토리 symlink가 가장 단순
 - **Codex**: `.system/`(내장 5개) 보존 필요 → 개별 symlink로 내장/커스텀 분리
-- **Claude Code**: 다중 계정별 독립 디렉토리 → 개별 symlink (`_claude_dir_sync_one`)
+- **Claude Code**: 옵션 1·2·3 모두 디렉토리 symlink. `_claude_account_setup_one` 한 곳에서 처리하며, 이전의 bind-mount (#287) 와 per-skill symlink (#342) 는 #575 에서 제거됨.
 
 ### 절대 하지 말 것
 
-- `~/.claude-personal/skills/`, `~/.gemini/skills/`, `~/.codex/skills/` 직접 편집 금지
+- `~/.claude*/skills/`, `~/.gemini/skills/`, `~/.codex/skills/` 직접 편집 금지
 - 스킬은 반드시 SSOT인 `dotfiles/claude/skills/`에만 생성/수정
 - Codex `.system/` 디렉토리 삭제 금지 (Codex 내장 스킬)
 
@@ -55,21 +57,26 @@ Dependencies: Claude Code CLI, jq, sudo
 ```bash
 # 외부 PC (옵션 1, 3) — 멀티-계정
 ~/.claude-personal/settings.json         -> dotfiles/claude/settings.json
-~/.claude-personal/settings.local.json   -> dotfiles/claude/settings.local.json
 ~/.claude-personal/statusline-command.sh -> dotfiles/claude/statusline-command.sh
-~/.claude-personal/skills/<name>         -> dotfiles/claude/skills/<name>   (per-skill)
-~/.claude-personal/docs/<name>           -> dotfiles/claude/docs/<name>     (per-doc)
+~/.claude-personal/skills                -> dotfiles/claude/skills          (dir symlink, #575)
+~/.claude-personal/docs                  -> dotfiles/claude/docs            (dir symlink, #575)
+~/.claude-personal/plugins               -> ~/.claude-shared/plugins
+~/.claude-personal/projects/GLOBAL/memory -> dotfiles/claude/global-memory
 
 # 사내 PC (옵션 2) — 단일 계정 (issue #571)
 ~/.claude/settings.json                  -> dotfiles/claude/settings.json
-~/.claude/settings.local.json            -> dotfiles/claude/settings.local.json
 ~/.claude/statusline-command.sh          -> dotfiles/claude/statusline-command.sh
-~/.claude/skills                         -> dotfiles/claude/skills           (dir symlink)
+~/.claude/skills                         -> dotfiles/claude/skills          (dir symlink)
+~/.claude/docs                           -> dotfiles/claude/docs            (dir symlink)
+~/.claude/plugins                        -> ~/.claude-shared/plugins
+~/.claude/projects/GLOBAL/memory         -> dotfiles/claude/global-memory
 
 # 모든 환경 공통
-~/.gemini/skills                         -> dotfiles/claude/skills           (dir symlink)
+~/.gemini/skills                         -> dotfiles/claude/skills          (dir symlink)
 ~/.codex/skills/<name>                   -> dotfiles/claude/skills/<name>/  (per-skill)
 ```
+
+기존 PC 에 남아 있는 `/etc/sudoers.d/claude-{skills,docs}-mount-*` 파일은 #575 이후로 사용처가 없다. `claude/setup.sh` 실행 시 잔존 파일이 감지되면 수동 삭제 명령을 안내한다.
 
 `settings.json` — **tracked SSOT** (#584). 동일한 파일이 Home/External/Internal 모두에서 `~/.claude/settings.json` 으로 심볼릭링크됨.
 `~/.claude/settings.local.json` — out-of-repo, gitignored, Internal PC 1회 손수 작성. 사번 헤더 / 사내 `ANTHROPIC_*` 가 들어가며 Claude Code 가 settings.json 과 native merge. `claude/setup.sh` 가 Internal 모드 종료 직전 copy-paste heredoc 안내 출력 (#584).

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -354,40 +354,45 @@ _setup_gemini_skills_symlink() {
     log_dim "✓ ${HOME}/.gemini/skills SSOT 연결 완료"
 }
 
-_setup_bind_mount_sudoers() {
-    local sudoers_file="$1"
-    local description="$2"
-    local source="$3"
-    local target="$4"
+# _print_stale_bind_mount_sudoers_hint — surface stale /etc/sudoers.d/
+# files left over from the pre-#575 bind-mount design.
+#
+# Issue #575 removed _setup_bind_mount_sudoers and the entire bind-mount
+# integration in favour of directory-level symlinks. Existing PCs may
+# still carry sudoers entries from the prior layout — they no longer
+# match anything in the setup and only widen the sudoers surface, so
+# point the user at them. Cleanup is left manual on purpose because
+# rm under /etc/sudoers.d/ needs sudo and we don't want to prompt
+# from setup.sh.
+_print_stale_bind_mount_sudoers_hint() {
+    local sudoers_glob='/etc/sudoers.d/claude-skills-mount-* /etc/sudoers.d/claude-docs-mount-*'
+    local found=""
+    # shellcheck disable=SC2086  # glob intentionally unquoted
+    for _f in $sudoers_glob; do
+        [ -f "$_f" ] || continue
+        found="${found}  $_f
+"
+    done
 
-    [ -d "$source" ] || return 0
+    [ -n "$found" ] || return 0
 
-    log_info "$description 디렉토리 bind mount sudoers 설정"
-    if [ -f "$sudoers_file" ] && sudo grep -qF "$source" "$sudoers_file" 2>/dev/null; then
-        log_dim "✓ sudoers 설정이 이미 존재합니다"
-        return 0
-    fi
-    [ -f "$sudoers_file" ] && log_info "sudoers 경로가 변경되었습니다. 재생성합니다: $sudoers_file"
+    echo ""
+    ux_section "Stale bind-mount sudoers (issue #575)"
+    ux_info "Issue #575 retired bind-mount for Claude skills/docs in favour of"
+    ux_info "a single directory symlink. The sudoers files below were created"
+    ux_info "by an earlier dotfiles version and no longer have a matching"
+    ux_info "consumer — they only widen the sudoers surface. Remove them"
+    ux_info "manually when convenient (requires sudo):"
+    echo ""
+    printf '%s' "$found"
+    echo ""
+    ux_bullet "Quick command:"
+    cat <<'EOF'
 
-    if ! cat << EOF | sudo tee "$sudoers_file" > /dev/null
-# Allow passwordless bind mount for Claude Code $description directory
-# Created by dotfiles/claude/setup.sh
-${USER} ALL=(ALL) NOPASSWD: /bin/mount --bind ${source} ${target}
-${USER} ALL=(ALL) NOPASSWD: /usr/bin/mount --bind ${source} ${target}
-${USER} ALL=(ALL) NOPASSWD: /bin/umount ${target}
-${USER} ALL=(ALL) NOPASSWD: /usr/bin/umount ${target}
+    sudo rm -f /etc/sudoers.d/claude-skills-mount-* \
+               /etc/sudoers.d/claude-docs-mount-*
+
 EOF
-    then
-        log_error "$description sudoers 파일 생성 실패"
-        return 1
-    fi
-
-    if sudo chmod 440 "$sudoers_file"; then
-        log_dim "✓ $description sudoers 설정 완료"
-    else
-        log_error "$description sudoers 파일 권한 설정 실패"
-        return 1
-    fi
 }
 
 # _print_internal_local_env_guidance — Internal-PC one-time hand-edit guide.
@@ -619,30 +624,23 @@ if [ "$_setup_mode" = "internal" ]; then
 
     _print_internal_local_env_guidance
 
+    # Surface stale /etc/sudoers.d/claude-{skills,docs}-mount-* files left
+    # behind from any prior multi-account install on this box.
+    _print_stale_bind_mount_sudoers_hint
+
     exit 0
 fi
 
 # 활성 계정 목록을 한 번만 조회하여 재사용 (PR #292 review 반영)
 ENABLED_ACCOUNTS=$(_claude_resolve_account --list)
 
-# 활성화된 계정마다 sudoers 등록 + setup
+# 활성화된 계정마다 symlink 셋업 (#575: bind-mount sudoers 제거됨).
+# CLAUDE_SKIP_SUDOERS / CLAUDE_SKIP_BIND_MOUNT 환경 변수는 더 이상 어떤
+# 동작도 게이트하지 않지만, 기존 테스트 하니스가 셋팅한 채로 들어와도
+# 무해하다.
 for acct in $ENABLED_ACCOUNTS; do
     cdir=$(_claude_resolve_account "$acct")
     log_info "Account: $acct → $cdir"
-
-    if [ "${CLAUDE_SKIP_SUDOERS:-0}" != "1" ]; then
-        _setup_bind_mount_sudoers \
-            "/etc/sudoers.d/claude-skills-mount-${acct}" \
-            "Skills (${acct})" \
-            "$CLAUDE_SKILLS_SOURCE" \
-            "${cdir}/skills"
-        _setup_bind_mount_sudoers \
-            "/etc/sudoers.d/claude-docs-mount-${acct}" \
-            "Docs (${acct})" \
-            "$CLAUDE_DOCS_SOURCE" \
-            "${cdir}/docs"
-    fi
-
     _claude_account_setup_one "$acct" "$cdir"
 done
 
@@ -650,7 +648,7 @@ done
 log_debug "\n--- 심볼릭 링크 확인 ---"
 for acct in $ENABLED_ACCOUNTS; do
     cdir=$(_claude_resolve_account "$acct")
-    for link in settings.json statusline-command.sh plugins projects/GLOBAL/memory; do
+    for link in settings.json statusline-command.sh skills docs plugins projects/GLOBAL/memory; do
         if [ -L "${cdir}/${link}" ]; then
             log_dim "✓ ${acct}/${link} 심볼릭 링크 확인됨"
         else
@@ -673,6 +671,12 @@ ux_section "다음 단계"
 ux_bullet "쉘 재시작 후 진단: ${UX_BOLD}claude-accounts status${UX_RESET}"
 ux_bullet "처음 사용: ${UX_BOLD}claude-yolo${UX_RESET} (브라우저로 ${CLAUDE_DEFAULT_ACCOUNT} 로그인)"
 ux_bullet "다른 계정: ${UX_BOLD}claude-yolo --user <name>${UX_RESET} 또는 ${UX_BOLD}claude-yolo-<name>${UX_RESET}"
+
+# Surface stale /etc/sudoers.d/claude-{skills,docs}-mount-* files left
+# behind from the pre-#575 bind-mount layout. Cleanup is manual on
+# purpose so setup.sh never has to prompt for sudo.
+_print_stale_bind_mount_sudoers_hint
+
 echo ""
 
 exit 0

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -20,7 +20,7 @@
 #     발생하는 것을 막는 용도. 한 줄에 하나의 skill 디렉토리 이름, '#' 으로 시작하는
 #     주석과 빈 줄은 무시됨. 파일이 없거나 모두 비어 있으면 종전대로 전체 연결.
 #
-# ~/.claude/skills 는 claude/setup.sh (bind mount) 가 관리
+# ~/.claude*/skills 는 claude/setup.sh 가 디렉토리 symlink 로 관리 (#575)
 
 # --- Constants ---
 

--- a/shell-common/env/claude.sh
+++ b/shell-common/env/claude.sh
@@ -1,23 +1,12 @@
 #!/bin/sh
 # shell-common/env/claude.sh
 # Claude Code environment variables
-# Auto-mount configuration for Claude Code directories
 
-# Legacy auto-mount of ~/.claude/{skills,docs}. After multi-account
-# migration (issue #287), ~/.claude/ is the empty guard directory and
-# bind mounts go to ~/.claude-{personal,work}/{skills,docs} via
-# claude_accounts_init. Disable legacy auto-mount when migrated state
-# is detected so we don't mount onto the guard dir.
+# Skills/docs are exposed to each Claude Code account as a single
+# directory symlink (issue #575) — no bind-mount, no per-skill sync,
+# no auto-mount env vars. See claude/AGENTS.md for the layout.
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
-
-if [ -d "$HOME/.claude-personal" ] || [ -d "$HOME/.claude-work" ]; then
-    export CLAUDE_AUTO_MOUNT_SKILLS=0
-    export CLAUDE_AUTO_MOUNT_DOCS=0
-else
-    export CLAUDE_AUTO_MOUNT_SKILLS=1
-    export CLAUDE_AUTO_MOUNT_DOCS=1
-fi
 
 # AI tool for documentation generation
 # Options: claude (default), gemini, codex, or any CLI tool accepting -p/--prompt

--- a/shell-common/functions/claude_plugins_help.sh
+++ b/shell-common/functions/claude_plugins_help.sh
@@ -86,8 +86,8 @@ _claude_plugins_help_rows_structure() {
 }
 
 _claude_plugins_help_rows_git() {
-    ux_info "All documentation is mounted and automatically git-tracked:"
-    ux_bullet "User location: ${UX_INFO}~/.claude/docs${UX_RESET} (via bind mount)"
+    ux_info "All documentation is symlinked to the SSOT and automatically git-tracked:"
+    ux_bullet "User location: ${UX_INFO}~/.claude/docs${UX_RESET} (directory symlink, #575)"
     ux_bullet "Git source: ${UX_INFO}~/dotfiles/claude/docs${UX_RESET}"
     ux_bullet "Changes are version-controlled and shareable across machines"
 }

--- a/shell-common/functions/dot_help.sh
+++ b/shell-common/functions/dot_help.sh
@@ -26,9 +26,8 @@ fi
 _dot_help_summary() {
     ux_info "Usage: dot-help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "overview: project pillars (SOLID, cross-platform, mounts)"
+    ux_bullet_sub "overview: project pillars (SOLID, cross-platform, skills SSOT)"
     ux_bullet_sub "setup: setup.sh | maintenance | diagnostics"
-    ux_bullet_sub "mounts: claude bind mounts status"
     ux_bullet_sub "features: shell separation | UX | help | git | skills"
     ux_bullet_sub "commands: my-help | src | dot | ux-help"
     ux_bullet_sub "docs: SETUP_GUIDE | AGENTS | UX_GUIDELINES"
@@ -39,7 +38,6 @@ _dot_help_list_sections() {
     ux_bullet "sections"
     ux_bullet_sub "overview"
     ux_bullet_sub "setup"
-    ux_bullet_sub "mounts"
     ux_bullet_sub "features"
     ux_bullet_sub "commands"
     ux_bullet_sub "docs"
@@ -49,7 +47,7 @@ _dot_help_rows_overview() {
     ux_bullet "SOLID-based shell configuration separation (bash/zsh)"
     ux_bullet "Cross-platform support (Windows WSL, macOS, Linux)"
     ux_bullet "Environment-aware setup (Internal/External PC)"
-    ux_bullet "Automated Claude Code skills bind mounting"
+    ux_bullet "Claude Code skills SSOT via directory symlink (no sudo, #575)"
 }
 
 _dot_help_rows_setup() {
@@ -68,7 +66,7 @@ _dot_help_rows_features() {
     ux_numbered 2 "UX guidelines: Consistent color and formatting"
     ux_numbered 3 "Help system: Type help or [function]-help for info"
     ux_numbered 4 "Git attributes: Automatic CRLF/LF line ending management"
-    ux_numbered 5 "Skills integration: Claude Code tools auto-mounted"
+    ux_numbered 5 "Skills integration: SSOT exposed as directory symlinks (#575)"
 }
 
 _dot_help_rows_commands() {

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -66,8 +66,8 @@ fi
 _mount_help_summary() {
     ux_info "Usage: mount-help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "description: manage bind mounts for Claude environment"
-    ux_bullet_sub "commands: addmnt | show-mnt | claude-mount-all"
+    ux_bullet_sub "description: generic bind mount helpers"
+    ux_bullet_sub "commands: addmnt | show-mnt"
     ux_bullet_sub "info: per-command --help references"
     ux_bullet_sub "notes: sudo & sudoers configuration"
     ux_bullet_sub "details: mount-help <section>  (example: mount-help commands)"
@@ -82,13 +82,12 @@ _mount_help_list_sections() {
 }
 
 _mount_help_rows_description() {
-    ux_info "Manage bind mounts for Claude environment (skills, agents, etc.)"
+    ux_info "Generic bind mount helpers (Claude skills/docs now use directory symlinks, #575)"
 }
 
 _mount_help_rows_commands() {
     ux_bullet "addmnt <source> <target>    Create bind mount"
     ux_bullet "show-mnt [path]             Display mount status"
-    ux_bullet "claude-mount-all            Mount all Claude directories (skills, agents, docs)"
 }
 
 _mount_help_rows_info() {
@@ -144,12 +143,11 @@ mount_help() {
 Mount Management Commands
 
 Description:
-  Manage bind mounts for Claude environment
+  Generic bind mount helpers (Claude skills/docs use directory symlinks, #575)
 
 Available Commands:
   addmnt <source> <target>       Create bind mount
   show-mnt [path]                Display mount status
-  claude-mount-all               Mount all Claude directories (skills, docs)
 
 Notes:
   - Requires sudo for mount operations

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -629,7 +629,16 @@ _claude_ensure_symlink() {
             return 1
         fi
         ux_success "  ✓ unmounted: $_ces_tgt"
-        rmdir "$_ces_tgt" 2>/dev/null || true
+        # Three post-umount states: (a) dir already gone, (b) empty
+        # backing dir, (c) non-empty backing dir hiding user data.
+        # Try rmdir for (b), and if (c) reveals a populated directory,
+        # back it up so `ln -s` below has a clear slot (the next elif
+        # would be skipped because this branch already matched).
+        if [ -e "$_ces_tgt" ] && ! rmdir "$_ces_tgt" 2>/dev/null; then
+            _ces_backup="${_ces_tgt}-$(date +%Y%m%d%H%M%S)-original"
+            ux_warning "  backing up revealed directory: $_ces_tgt → $_ces_backup"
+            mv "$_ces_tgt" "$_ces_backup" || return 1
+        fi
     elif [ -e "$_ces_tgt" ]; then
         # Backup naming matches claude/setup.sh:100 legacy convention
         # so users with a mixed-version setup see one consistent format.
@@ -661,8 +670,9 @@ _claude_ensure_symlink() {
 # (#287) 는 모두 이 함수 하나로 대체됐고, 새 skill 은 setup 재실행 없이
 # 즉시 반영된다.
 _claude_account_setup_one() {
-    _caso_acct="$1"
-    _caso_cdir="$2"
+    # ${VAR:-} for set -u safety (gemini review on PR #590).
+    _caso_acct="${1:-}"
+    _caso_cdir="${2:-}"
     ux_section "Account: $_caso_acct ($_caso_cdir)"
 
     mkdir -p "$_caso_cdir"
@@ -764,6 +774,11 @@ claude_accounts_status() {
         for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory skills docs; do
             if [ -L "$_cas_cdir/$_cas_link" ]; then
                 echo "  $_cas_link: symlink ✓"
+            elif [ "$_cas_link" = "settings.local.json" ] && [ -f "$_cas_cdir/$_cas_link" ]; then
+                # settings.local.json is a per-PC hand-created regular
+                # file (#584), never a symlink — report it as present
+                # rather than missing (gemini review on PR #590).
+                echo "  $_cas_link: regular file ✓"
             else
                 echo "  $_cas_link: ✗ missing"
             fi

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -10,10 +10,12 @@
 #
 # Use: clinstall (runs official native installer)
 # Use: delete_claude (uninstall and clean)
-
-# ═══════════════════════════════════════════════════════════════
-# Mount management functions (loaded from shell-common/functions/mount.sh)
-# ═══════════════════════════════════════════════════════════════
+#
+# Storage layout: skills/, docs/ are exposed to Claude Code via a single
+# top-level directory symlink per account (issue #575). The legacy bind-
+# mount path (#287) and the interim per-skill symlink path (#342, #344)
+# were removed in favour of one symlink that mirrors the SSOT atomically
+# and survives reboot without sudoers entries.
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
@@ -188,158 +190,6 @@ claude_edit_settings() {
 }
 
 # ═══════════════════════════════════════════════════════════════
-# Claude Code Skills Directory Bind Mount
-# ═══════════════════════════════════════════════════════════════
-
-claude_mount_skills() {
-    local skills_source="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills"
-    local skills_target="$HOME/.claude/skills"
-
-    # Check if source directory exists
-    if [ ! -d "$skills_source" ]; then
-        return 0
-    fi
-
-    # Create target directory if not exists
-    if [ ! -d "$skills_target" ]; then
-        mkdir -p "$skills_target"
-    fi
-
-    # Check if already mounted (using unified _is_mounted function if available)
-    if declare -f _is_mounted >/dev/null 2>&1; then
-        _is_mounted "$skills_target" && return 0
-    else
-        # Fallback: Check if already mounted using findmnt
-        if command -v findmnt > /dev/null 2>&1; then
-            findmnt "$skills_target" > /dev/null 2>&1 && return 0
-        else
-            # Final fallback to mount command
-            mount | grep -q "on ${skills_target} " && return 0
-        fi
-    fi
-
-    # Perform bind mount (will prompt for sudo password if needed)
-    if sudo mount --bind "$skills_source" "$skills_target" 2>/dev/null; then
-        return 0
-    else
-        # Silent fail - don't spam errors on every shell startup
-        return 1
-    fi
-}
-
-# NOTE: Auto-mount functionality removed from shell init to prevent sudo prompts
-# during shell startup. Use explicit functions instead:
-#   claude_mount_skills   - Mount skills directory
-#   claude_mount_docs     - Mount docs directory
-
-# ═══════════════════════════════════════════════════════════════
-# Claude Code Documentation Directory Bind Mount
-# ═══════════════════════════════════════════════════════════════
-
-claude_mount_docs() {
-    local docs_source="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/docs"
-    local docs_target="$HOME/.claude/docs"
-
-    # Check if source directory exists
-    if [ ! -d "$docs_source" ]; then
-        return 0
-    fi
-
-    # Create target directory if not exists
-    if [ ! -d "$docs_target" ]; then
-        mkdir -p "$docs_target"
-    fi
-
-    # Check if already mounted (using unified _is_mounted function if available)
-    if declare -f _is_mounted >/dev/null 2>&1; then
-        _is_mounted "$docs_target" && return 0
-    else
-        # Fallback: Check if already mounted using findmnt
-        if command -v findmnt > /dev/null 2>&1; then
-            findmnt "$docs_target" > /dev/null 2>&1 && return 0
-        else
-            # Final fallback to mount command
-            mount | grep -q "on ${docs_target} " && return 0
-        fi
-    fi
-
-    # Perform bind mount (will prompt for sudo password if needed)
-    if sudo mount --bind "$docs_source" "$docs_target" 2>/dev/null; then
-        return 0
-    else
-        # Silent fail - don't spam errors on every shell startup
-        return 1
-    fi
-}
-
-# NOTE: Auto-mount is controlled by environment variables:
-#   CLAUDE_AUTO_MOUNT_SKILLS=1
-#   CLAUDE_AUTO_MOUNT_DOCS=1
-# This repository sets defaults in shell-common/env/claude.sh.
-# Requires passwordless sudoers configured by dotfiles/claude/setup.sh
-
-# ═══════════════════════════════════════════════════════════════
-# Claude Code Mount All Helper
-# ═══════════════════════════════════════════════════════════════
-
-# Mount all Claude directories at once (for manual initialization)
-claude_mount_all() {
-    ux_header "Claude Code Directory Mounts"
-
-    local mounted_count=0
-    local failed_count=0
-
-    # Try mounting skills
-    ux_info "Mounting skills directory..."
-    if claude_mount_skills; then
-        ux_success "skills directory mounted"
-        mounted_count=$((mounted_count + 1))
-    else
-        ux_warning "skills directory mount failed or already mounted"
-        failed_count=$((failed_count + 1))
-    fi
-
-    # Try mounting docs
-    ux_info "Mounting docs directory..."
-    if claude_mount_docs; then
-        ux_success "docs directory mounted"
-        mounted_count=$((mounted_count + 1))
-    else
-        ux_warning "docs directory mount failed or already mounted"
-        failed_count=$((failed_count + 1))
-    fi
-
-    echo ""
-    ux_section "Summary"
-    echo "Successfully mounted: $mounted_count"
-    echo "Failed or already mounted: $failed_count"
-}
-
-alias claude-mount-all='claude_mount_all'
-alias claude-mount-skills='claude_mount_skills'
-alias claude-mount-docs='claude_mount_docs'
-
-# Auto-mount configuration via environment variables
-# Set to "1" to enable auto-mounting in interactive shells
-# Example: export CLAUDE_AUTO_MOUNT_SKILLS=1
-_claude_try_auto_mount() {
-    case "$-" in
-        *i*) ;;
-        *) return 0 ;;
-    esac
-
-    if [ "${CLAUDE_AUTO_MOUNT_SKILLS:-0}" = "1" ]; then
-        claude_mount_skills >/dev/null 2>&1 || true
-    fi
-
-    if [ "${CLAUDE_AUTO_MOUNT_DOCS:-0}" = "1" ]; then
-        claude_mount_docs >/dev/null 2>&1 || true
-    fi
-}
-
-_claude_try_auto_mount
-
-# ═══════════════════════════════════════════════════════════════
 # Claude Code Marketplace Plugins Management
 # ═══════════════════════════════════════════════════════════════
 
@@ -459,14 +309,16 @@ _claude_yolo_export_settings_env() {
 # 4. CLAUDE_CONFIG_DIR 환경 주입 + command claude --dangerously-skip-permissions
 claude_yolo() {
     _cy_account="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
-    _cy_no_sync=0
 
     # zsh disables word-splitting; emulate sh inside this function.
     if [ -n "${ZSH_VERSION:-}" ]; then
         emulate -L sh
     fi
 
-    # --user / --no-sync 가로채고 나머지는 위치 인자로 보존 (POSIX 안전)
+    # --user 가로채고 나머지는 위치 인자로 보존 (POSIX 안전).
+    # --no-sync 는 #575 에서 skills/docs 가 디렉토리 symlink 가 되며 사라짐
+    # — 쉘 시작마다 동기화할 항목이 더 이상 없다. 알 수 없는 인자는
+    # claude 본체로 그대로 전달된다.
     set -- "$@" "__CY_END__"
     while [ "$1" != "__CY_END__" ]; do
         case "$1" in
@@ -476,10 +328,6 @@ claude_yolo() {
                 ;;
             --user=*)
                 _cy_account="${1#--user=}"
-                shift
-                ;;
-            --no-sync)
-                _cy_no_sync=1
                 shift
                 ;;
             *)
@@ -536,14 +384,6 @@ claude_yolo() {
     # Opt-in via CLAUDE_ACCOUNT_EMAIL_<account>; silent unless the mapping
     # AND a populated .claude.json AND a mismatch are all present.
     _claude_validate_login "$_cy_config_dir" "$_cy_account"
-
-    # Pre-launch skills/docs sync (issue #342). Silent when in-sync; emits
-    # one line per action when something changed (so the user sees newly
-    # added skills landing without having to run `claude-accounts
-    # skills-sync` themselves). Opt out with `claude-yolo --no-sync ...`.
-    if [ "$_cy_no_sync" = "0" ]; then
-        CLAUDE_SKILLS_SYNC_QUIET=1 claude_skills_sync || true
-    fi
 
     # Apply settings.local.json env block at the shell level too — works
     # around Claude Code releases where the env block isn't propagated to
@@ -765,6 +605,7 @@ _claude_expected_email() {
 # _claude_ensure_symlink — 멱등 symlink 생성.
 # - 없음 → 생성
 # - 같은 target 의 symlink → skip (출력 "already")
+# - bind-mount → sudo umount 후 재생성 (issue #575 마이그레이션 경로)
 # - 다른 file/dir → timestamped backup 후 재생성
 _claude_ensure_symlink() {
     _ces_src="$1"
@@ -778,6 +619,17 @@ _claude_ensure_symlink() {
         fi
         ux_warning "  symlink target mismatch — recreating: $_ces_tgt"
         rm "$_ces_tgt"
+    elif _is_mounted "$_ces_tgt" 2>/dev/null; then
+        # Legacy bind-mount survivor from the #287/#342-era multi-account
+        # layout. The kernel refuses `mv` on a mount point, so unmount
+        # first and then fall through to the normal `ln -s` path.
+        ux_warning "  bind-mount detected at $_ces_tgt — unmounting (sudo may prompt)"
+        if ! sudo umount "$_ces_tgt"; then
+            ux_error "  unmount failed: $_ces_tgt"
+            return 1
+        fi
+        ux_success "  ✓ unmounted: $_ces_tgt"
+        rmdir "$_ces_tgt" 2>/dev/null || true
     elif [ -e "$_ces_tgt" ]; then
         # Backup naming matches claude/setup.sh:100 legacy convention
         # so users with a mixed-version setup see one consistent format.
@@ -790,240 +642,24 @@ _claude_ensure_symlink() {
     ux_success "  created symlink: $_ces_tgt → $_ces_src"
 }
 
-# _claude_ensure_bind_mount — 멱등 bind mount.
-# - 이미 마운트됨 → skip
-# - 안 됨 → sudo mount --bind (sudoers 등록 전제)
-_claude_ensure_bind_mount() {
-    _cebm_src="$1"
-    _cebm_tgt="$2"
-
-    [ -d "$_cebm_src" ] || {
-        ux_warning "  bind mount source missing: $_cebm_src"
-        return 1
-    }
-
-    mkdir -p "$_cebm_tgt"
-
-    if _is_mounted "$_cebm_tgt"; then
-        ux_info "  ✓ already mounted: $_cebm_tgt"
-        return 0
-    fi
-
-    if sudo mount --bind "$_cebm_src" "$_cebm_tgt" 2>/dev/null; then
-        ux_success "  bind mount: $_cebm_tgt ← $_cebm_src"
-    else
-        ux_error "  bind mount failed: $_cebm_tgt (check sudoers)"
-        return 1
-    fi
-}
-
-# _claude_dir_sync_one — per-account, per-dir symlink sync (issue #342).
+# _claude_dir_sync_one / _claude_count_dir_sync / claude_skills_sync —
+# REMOVED (issue #575).
 #
-# Replaces the bind-mount design: each SSOT entry under
-# "${DOTFILES_ROOT}/claude/<name>" gets an individual symlink under
-# "<cdir>/<name>/<entry>". No sudo, persists across reboot, drift visible
-# via plain `ls -la` / `find -type l`.
+# These used to maintain per-skill / per-doc symlinks under
+# "<cdir>/skills/" and "<cdir>/docs/" as a sudo-free replacement for the
+# legacy bind-mount design (#342, #344). Issue #575 collapses that into
+# a single top-level symlink — "<cdir>/skills" / "<cdir>/docs" — so
+# per-entry sync is no longer needed; the SSOT is reflected atomically
+# and new skills appear instantly without re-running setup. The
+# `claude-skills-sync` alias and `claude-accounts skills-sync`
+# sub-command went away with them.
+
+# _claude_account_setup_one — 단일 계정의 link 멱등 셋업.
 #
-# Args: <cdir> <name>   e.g. "$HOME/.claude-personal" "skills"
-#
-# Behavior (idempotent):
-# 1. Each SSOT entry → ensured as symlink. Real-dir collision → backed up
-#    to "<cdir>/.sync-backup/<name>/<entry>-pre-sync-<TS>". Stale symlink
-#    (wrong target) → replaced.
-# 2. Orphan cleanup: entries in target with no SSOT match. Symlinks →
-#    auto-removed. Real dirs → backed up to
-#    "<cdir>/.sync-backup/<name>/<entry>-orphan-<TS>" (never auto-deleted;
-#    preserves any user data the user dropped here).
-# 3. Pre-step migration: any pre-existing legacy backup at
-#    "<cdir>/<name>/*-pre-sync-*" / "*-orphan-*" (created by older
-#    versions of this function) is moved to "<cdir>/.sync-backup/<name>/"
-#    so the Claude Code skill scanner stops indexing backups as skills
-#    (issue #344). Idempotent — no-op once migrated.
-#
-# Backup location rationale (issue #344): the Claude Code skill scanner
-# treats every directory under "<cdir>/skills/" as a skill candidate, so
-# placing backups inside "<cdir>/skills/" caused duplicate skills like
-# "cli-dev" + "cli-dev-pre-sync-<TS>" to appear in available-skills.
-# "<cdir>/.sync-backup/<name>/" sits outside the scanner's view while
-# remaining co-located for easy `ls`-driven discovery.
-#
-# Side effect (return globals — POSIX sh has no array returns):
-#   _CLAUDE_DIR_SYNC_LAST_CHANGED — number of mutating actions
-#   _CLAUDE_DIR_SYNC_LAST_LINKED  — symlinks pointing at correct SSOT entry
-#   _CLAUDE_DIR_SYNC_LAST_SOURCE  — total SSOT entries
-#
-# Silent (no output) when fully in-sync. Otherwise emits one line per action.
-_claude_dir_sync_one() {
-    _cdso_cdir="$1"
-    _cdso_name="$2"
-    # Fallback parity with claude_mount_skills/claude_init in this file: if
-    # the function is invoked before the dotfiles env loader runs (or in a
-    # crippled login shell), don't construct paths starting at /.
-    _cdso_src_root="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/$_cdso_name"
-    _cdso_tgt_root="$_cdso_cdir/$_cdso_name"
-    _cdso_backup_root="$_cdso_cdir/.sync-backup/$_cdso_name"
-    _CLAUDE_DIR_SYNC_LAST_CHANGED=0
-    _CLAUDE_DIR_SYNC_LAST_LINKED=0
-    _CLAUDE_DIR_SYNC_LAST_SOURCE=0
-
-    if [ ! -d "$_cdso_src_root" ]; then
-        return 0
-    fi
-
-    mkdir -p "$_cdso_tgt_root"
-    _cdso_ts=$(date +%Y%m%d%H%M%S)
-
-    # Pre-step: migrate legacy backups out of the scanner's view (issue #344).
-    # Older versions placed *-pre-sync-* / *-orphan-* directly under
-    # "<cdir>/<name>/", which Claude Code indexed as duplicate skills.
-    # Idempotent: only moves entries that still live in the legacy location.
-    for _cdso_legacy in "$_cdso_tgt_root"/*-pre-sync-* "$_cdso_tgt_root"/*-orphan-*; do
-        [ -e "$_cdso_legacy" ] || [ -L "$_cdso_legacy" ] || continue
-        mkdir -p "$_cdso_backup_root"
-        _cdso_legacy_name=$(basename "$_cdso_legacy")
-        if mv "$_cdso_legacy" "$_cdso_backup_root/$_cdso_legacy_name"; then
-            ux_info "  $_cdso_name/$_cdso_legacy_name: migrated legacy backup → .sync-backup/$_cdso_name/"
-            _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
-        fi
-    done
-
-    # Pass 1: ensure each SSOT entry has matching symlink
-    for _cdso_src in "$_cdso_src_root"/*/; do
-        [ -d "$_cdso_src" ] || continue
-        _cdso_basename=$(basename "$_cdso_src")
-        _CLAUDE_DIR_SYNC_LAST_SOURCE=$((_CLAUDE_DIR_SYNC_LAST_SOURCE + 1))
-        _cdso_src_canon="$_cdso_src_root/$_cdso_basename"
-        _cdso_tgt="$_cdso_tgt_root/$_cdso_basename"
-
-        if [ -L "$_cdso_tgt" ]; then
-            _cdso_current=$(readlink "$_cdso_tgt")
-            if [ "$_cdso_current" = "$_cdso_src_canon" ]; then
-                _CLAUDE_DIR_SYNC_LAST_LINKED=$((_CLAUDE_DIR_SYNC_LAST_LINKED + 1))
-                continue
-            fi
-            ux_info "  $_cdso_name/$_cdso_basename: replacing stale symlink"
-            rm "$_cdso_tgt"
-        elif [ -e "$_cdso_tgt" ]; then
-            mkdir -p "$_cdso_backup_root"
-            _cdso_backup="$_cdso_backup_root/${_cdso_basename}-pre-sync-${_cdso_ts}"
-            ux_warning "  $_cdso_name/$_cdso_basename: backing up real dir → .sync-backup/$_cdso_name/$(basename "$_cdso_backup")"
-            mv "$_cdso_tgt" "$_cdso_backup"
-        fi
-
-        if ln -s "$_cdso_src_canon" "$_cdso_tgt"; then
-            ux_success "  $_cdso_name/$_cdso_basename: linked"
-            _CLAUDE_DIR_SYNC_LAST_LINKED=$((_CLAUDE_DIR_SYNC_LAST_LINKED + 1))
-            _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
-        else
-            ux_error "  $_cdso_name/$_cdso_basename: ln -s failed"
-        fi
-    done
-
-    # Pass 2: orphan cleanup — entries in target that no longer match SSOT.
-    # The *-pre-sync-* / *-orphan-* skip is defensive: backups now live in
-    # .sync-backup/<name>/ (issue #344) so should never appear here, but
-    # the guard remains in case a leftover somehow lands in the scan dir.
-    for _cdso_entry in "$_cdso_tgt_root"/*; do
-        [ -e "$_cdso_entry" ] || [ -L "$_cdso_entry" ] || continue
-        _cdso_ename=$(basename "$_cdso_entry")
-        case "$_cdso_ename" in
-            *-pre-sync-*|*-orphan-*) continue ;;
-        esac
-        [ -d "$_cdso_src_root/$_cdso_ename" ] && continue
-
-        if [ -L "$_cdso_entry" ]; then
-            if rm "$_cdso_entry"; then
-                ux_info "  $_cdso_name/$_cdso_ename: removed orphan symlink"
-                _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
-            fi
-        else
-            mkdir -p "$_cdso_backup_root"
-            _cdso_obackup="$_cdso_backup_root/${_cdso_ename}-orphan-${_cdso_ts}"
-            if mv "$_cdso_entry" "$_cdso_obackup"; then
-                ux_warning "  $_cdso_name/$_cdso_ename: orphan dir → .sync-backup/$_cdso_name/$(basename "$_cdso_obackup")"
-                _CLAUDE_DIR_SYNC_LAST_CHANGED=$((_CLAUDE_DIR_SYNC_LAST_CHANGED + 1))
-            fi
-        fi
-    done
-}
-
-# _claude_count_dir_sync — print "<linked>|<source>" counts for one
-# account/dirname. Used by claude_accounts_status to display drift ratio.
-# Read-only; never mutates.
-_claude_count_dir_sync() {
-    _ccds_cdir="$1"
-    _ccds_name="$2"
-    # Same fallback as _claude_dir_sync_one — must agree, otherwise the
-    # ratio would lie about a sync that did happen.
-    _ccds_src_root="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/$_ccds_name"
-    _ccds_tgt_root="$_ccds_cdir/$_ccds_name"
-
-    _ccds_source=0
-    if [ -d "$_ccds_src_root" ]; then
-        for _ccds_s in "$_ccds_src_root"/*/; do
-            [ -d "$_ccds_s" ] || continue
-            _ccds_source=$((_ccds_source + 1))
-        done
-    fi
-
-    _ccds_linked=0
-    if [ -d "$_ccds_tgt_root" ]; then
-        for _ccds_t in "$_ccds_tgt_root"/*; do
-            [ -L "$_ccds_t" ] || continue
-            _ccds_n=$(basename "$_ccds_t")
-            [ -d "$_ccds_src_root/$_ccds_n" ] || continue
-            _ccds_real=$(readlink "$_ccds_t")
-            if [ "$_ccds_real" = "$_ccds_src_root/$_ccds_n" ]; then
-                _ccds_linked=$((_ccds_linked + 1))
-            fi
-        done
-    fi
-
-    echo "$_ccds_linked|$_ccds_source"
-}
-
-# claude_skills_sync — public entry: sync skills + docs across all enabled
-# accounts via per-skill symlinks. Replaces the legacy bind-mount approach
-# (issue #342). Idempotent — second run reports "no changes".
-#
-# Quiet mode: set CLAUDE_SKILLS_SYNC_QUIET=1 to suppress header/summary
-# (per-action output is preserved so changes remain visible).
-claude_skills_sync() {
-    if [ -n "${ZSH_VERSION:-}" ]; then
-        emulate -L sh
-    fi
-
-    if [ -z "${CLAUDE_SKILLS_SYNC_QUIET:-}" ]; then
-        ux_header "Claude Skills Sync"
-    fi
-
-    _css_total=0
-    for _css_acct in $(_claude_resolve_account --list); do
-        _css_cdir=$(_claude_resolve_account "$_css_acct")
-        [ -d "$_css_cdir" ] || continue
-
-        if [ -z "${CLAUDE_SKILLS_SYNC_QUIET:-}" ]; then
-            ux_section "Account: $_css_acct ($_css_cdir)"
-        fi
-
-        _claude_dir_sync_one "$_css_cdir" skills
-        _css_total=$((_css_total + _CLAUDE_DIR_SYNC_LAST_CHANGED))
-        _claude_dir_sync_one "$_css_cdir" docs
-        _css_total=$((_css_total + _CLAUDE_DIR_SYNC_LAST_CHANGED))
-    done
-
-    if [ "$_css_total" -eq 0 ]; then
-        if [ -z "${CLAUDE_SKILLS_SYNC_QUIET:-}" ]; then
-            ux_info "(no changes — skills/docs already in sync)"
-        fi
-    else
-        ux_success "skills/docs sync: $_css_total change(s)"
-    fi
-    return 0
-}
-alias claude-skills-sync='claude_skills_sync'
-
-# _claude_account_setup_one — 단일 계정의 link/sync 멱등 셋업.
+# skills/ 와 docs/ 는 SSOT 디렉토리 자체로의 단일 symlink 다 (issue #575).
+# 이전의 per-skill symlink (`_claude_dir_sync_one`, #342) 와 bind-mount
+# (#287) 는 모두 이 함수 하나로 대체됐고, 새 skill 은 setup 재실행 없이
+# 즉시 반영된다.
 _claude_account_setup_one() {
     _caso_acct="$1"
     _caso_cdir="$2"
@@ -1039,13 +675,8 @@ _claude_account_setup_one() {
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/statusline-command.sh"  "$_caso_cdir/statusline-command.sh"
     _claude_ensure_symlink "$HOME/.claude-shared/plugins"                   "$_caso_cdir/plugins"
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/global-memory"          "$_caso_cdir/projects/GLOBAL/memory"
-
-    # Per-skill / per-doc symlinks (issue #342). Replaces the legacy bind
-    # mount: no sudo, persists across reboot, no silent regression when
-    # mount drops. CLAUDE_SKIP_BIND_MOUNT is preserved as a no-op for
-    # backward compat with existing test harnesses.
-    _claude_dir_sync_one "$_caso_cdir" skills
-    _claude_dir_sync_one "$_caso_cdir" docs
+    _claude_ensure_symlink "${DOTFILES_ROOT}/claude/skills"                 "$_caso_cdir/skills"
+    _claude_ensure_symlink "${DOTFILES_ROOT}/claude/docs"                   "$_caso_cdir/docs"
 }
 
 # _claude_status_show_oauth — append OAuth binding (email/org) to the
@@ -1130,27 +761,11 @@ claude_accounts_status() {
             echo "                → Run: claude-yolo --user $_cas_acct"
         fi
 
-        for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory; do
+        for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory skills docs; do
             if [ -L "$_cas_cdir/$_cas_link" ]; then
                 echo "  $_cas_link: symlink ✓"
             else
                 echo "  $_cas_link: ✗ missing"
-            fi
-        done
-
-        # Skills/docs sync ratio (issue #342) — replaces the legacy bind
-        # mount status. `linked/source ✓` when fully synced, `(drift)`
-        # marker + recovery hint when partial.
-        for _cas_dir in skills docs; do
-            _cas_ratio=$(_claude_count_dir_sync "$_cas_cdir" "$_cas_dir")
-            _cas_linked=${_cas_ratio%|*}
-            _cas_source=${_cas_ratio#*|}
-            if [ "$_cas_source" -eq 0 ]; then
-                echo "  $_cas_dir: source missing ✗"
-            elif [ "$_cas_linked" -eq "$_cas_source" ]; then
-                echo "  $_cas_dir: $_cas_linked/$_cas_source ✓"
-            else
-                echo "  $_cas_dir: $_cas_linked/$_cas_source ⚠️  (run: claude-accounts skills-sync)"
             fi
         done
         echo ""
@@ -1447,10 +1062,9 @@ _claude_accounts_help() {
     ux_info "Usage: claude-accounts [<subcommand>]"
     ux_info ""
     ux_info "Subcommands:"
-    ux_info "  status        (default) Show all accounts: path/credentials/symlinks/sync"
+    ux_info "  status        (default) Show all accounts: path/credentials/symlinks"
     ux_info "  list          List enabled accounts"
     ux_info "  setup         Idempotent setup (creates dirs + symlinks)"
-    ux_info "  skills-sync   Re-sync skills/docs symlinks across all enabled accounts"
     ux_info "  migrate       One-time migration: ~/.claude → ~/.claude-personal (Home-PC)"
     ux_info "  rollback [<acct>]  Reverse of migrate: ~/.claude-<acct> → ~/.claude (issue #571)"
     ux_info "  -h|--help     This help"
@@ -1466,7 +1080,6 @@ claude_accounts() {
         status)         claude_accounts_status ;;
         list)           _claude_resolve_account --list ;;
         setup)          claude_accounts_init ;;
-        skills-sync)    claude_skills_sync ;;
         migrate)        claude_accounts_migrate ;;
         rollback)       shift; claude_accounts_rollback "$@" ;;
         -h|--help|help) _claude_accounts_help ;;

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -196,19 +196,60 @@ LOCAL
 
 # ---------- Task 5: account setup ----------
 
-@test "bash: _claude_account_setup_one creates symlinks (skips bind mount)" {
-    # bind mount needs sudo; skip via env var
+@test "bash: _claude_account_setup_one creates directory-level symlinks (issue #575)" {
     mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
     mkdir -p "$HOME/.claude-shared/plugins"
 
-    run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 _claude_account_setup_one personal '$HOME/.claude-personal'"
+    run_in_bash "_claude_account_setup_one personal '$HOME/.claude-personal'"
     assert_success
 
     [ -L "$HOME/.claude-personal/settings.json" ]
-    [ -L "$HOME/.claude-personal/settings.local.json" ]
     [ -L "$HOME/.claude-personal/statusline-command.sh" ]
     [ -L "$HOME/.claude-personal/plugins" ]
     [ -L "$HOME/.claude-personal/projects/GLOBAL/memory" ]
+    # Issue #575: skills/docs are single directory-level symlinks to the
+    # SSOT — no more per-skill entries, no more bind mount.
+    [ -L "$HOME/.claude-personal/skills" ]
+    [ -L "$HOME/.claude-personal/docs" ]
+    [ "$(readlink "$HOME/.claude-personal/skills")" = "${DOTFILES_ROOT}/claude/skills" ]
+    [ "$(readlink "$HOME/.claude-personal/docs")" = "${DOTFILES_ROOT}/claude/docs" ]
+    # settings.local.json is intentionally a per-PC hand-created regular
+    # file (#584) — never a dotfiles symlink.
+    [ ! -L "$HOME/.claude-personal/settings.local.json" ]
+}
+
+@test "bash: _claude_account_setup_one unmounts a legacy bind mount on skills (issue #575 migration)" {
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
+    mkdir -p "$HOME/.claude-shared/plugins"
+    # Simulate a Home-PC that came up under the #287 bind-mount layout:
+    # ~/.claude-personal/skills/ exists as a real (would-be-mounted) dir.
+    mkdir -p "$HOME/.claude-personal/skills"
+
+    fake_bin="$HOME/fake-bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/findmnt" <<SH
+#!/usr/bin/env bash
+[ "\$1" = "$HOME/.claude-personal/skills" ] && exit 0
+exit 1
+SH
+    chmod +x "$fake_bin/findmnt"
+    cat > "$fake_bin/sudo" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "umount" ]; then
+    printf '%s\n' "$2" >> "$HOME/fake-umount.log"
+    rmdir -- "$2" 2>/dev/null || true
+    exit 0
+fi
+exit 1
+SH
+    chmod +x "$fake_bin/sudo"
+
+    run_in_bash "export PATH=\"$fake_bin:\$PATH\"; _claude_account_setup_one personal '$HOME/.claude-personal'"
+    assert_success
+    assert_output --partial "bind-mount detected at $HOME/.claude-personal/skills"
+    [ -L "$HOME/.claude-personal/skills" ]
+    [ "$(readlink "$HOME/.claude-personal/skills")" = "${DOTFILES_ROOT}/claude/skills" ]
+    grep -qF "$HOME/.claude-personal/skills" "$HOME/fake-umount.log"
 }
 
 @test "bash: claude_accounts_init creates only ENABLED account dirs" {
@@ -916,10 +957,13 @@ JSON
     refute_output --partial "Account mismatch"
 }
 
-# ---------- Issue #342: skills/docs sync via per-skill symlinks ----------
+# ---------- Issue #575: skills/docs via directory-level symlinks ----------
 #
-# Replaces the legacy bind mount with idempotent per-skill symlinks. Five
-# acceptance scenarios from the issue + status ratio + sub-command wiring.
+# Issue #575 replaced both the legacy bind mount (#287) and the interim
+# per-skill symlinks (#342/#344) with a single directory-level symlink
+# per account: `~/.claude*/skills` → `dotfiles/claude/skills`. New skills
+# appear instantly without re-running setup, no sudo needed, no drift to
+# track.
 
 # Stage a FAKE_DOTFILES_ROOT under $HOME with skills/<name>/SKILL.md fixtures.
 # bash/main.bash unconditionally re-derives DOTFILES_ROOT from its own path
@@ -943,187 +987,91 @@ run_with_fake_ssot() {
     run_in_bash "export DOTFILES_ROOT='$FAKE_DOTFILES_ROOT'; $1"
 }
 
-@test "issue #342: empty target → SSOT skills become symlinks" {
-    _seed_ssot_skills alpha beta gamma
-    mkdir -p "$HOME/.claude-personal"
-
-    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal _claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    for s in alpha beta gamma; do
-        [ -L "$HOME/.claude-personal/skills/$s" ]
-        [ "$(readlink "$HOME/.claude-personal/skills/$s")" = "$FAKE_DOTFILES_ROOT/claude/skills/$s" ]
-    done
-}
-
-@test "issue #342: real-dir collision is backed up to *-pre-sync-* and replaced" {
-    _seed_ssot_skills cli-dev
-    mkdir -p "$HOME/.claude-personal/skills/cli-dev"
-    echo "stale-content" > "$HOME/.claude-personal/skills/cli-dev/local-file.md"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    [ -L "$HOME/.claude-personal/skills/cli-dev" ]
-    # Backup directory present (under .sync-backup/, issue #344) with the
-    # user's local file preserved.
-    local_backup=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"cli-dev-pre-sync-* 2>/dev/null | head -1)
-    [ -n "$local_backup" ]
-    [ -f "$local_backup/local-file.md" ]
-    # Issue #344: backup must NOT live alongside the skill in skills/.
-    ! ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* >/dev/null 2>&1
-}
-
-@test "issue #342: stale symlink (wrong target) is replaced with correct one" {
-    _seed_ssot_skills cli-dev
-    mkdir -p "$HOME/.claude-personal/skills" "$HOME/elsewhere/cli-dev"
-    ln -s "$HOME/elsewhere/cli-dev" "$HOME/.claude-personal/skills/cli-dev"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    [ -L "$HOME/.claude-personal/skills/cli-dev" ]
-    [ "$(readlink "$HOME/.claude-personal/skills/cli-dev")" = "$FAKE_DOTFILES_ROOT/claude/skills/cli-dev" ]
-}
-
-@test "issue #342: orphan symlink (no SSOT match) is auto-removed" {
-    _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal/skills" "$HOME/leftover"
-    ln -s "$HOME/leftover" "$HOME/.claude-personal/skills/removed-skill"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    [ ! -e "$HOME/.claude-personal/skills/removed-skill" ]
-    [ ! -L "$HOME/.claude-personal/skills/removed-skill" ]
-}
-
-@test "issue #342: orphan REAL dir is backed up to *-orphan-*, never deleted" {
-    _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal/skills/user-data-dont-touch"
-    echo "important" > "$HOME/.claude-personal/skills/user-data-dont-touch/keep.txt"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    [ ! -d "$HOME/.claude-personal/skills/user-data-dont-touch" ]
-    # Backup lives under .sync-backup/ (issue #344), not skills/.
-    orphan_backup=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"user-data-dont-touch-orphan-* 2>/dev/null | head -1)
-    [ -n "$orphan_backup" ]
-    [ -f "$orphan_backup/keep.txt" ]
-    grep -q "important" "$orphan_backup/keep.txt"
-    # Issue #344: orphan backup must NOT pollute the skill scanner directory.
-    ! ls -d "$HOME/.claude-personal/skills/"user-data-dont-touch-orphan-* >/dev/null 2>&1
-}
-
-@test "issue #342: second run is a no-op (idempotent — 0 changes)" {
+@test "issue #575: claude_accounts_init creates directory-level skills/docs symlinks" {
     _seed_ssot_skills alpha beta
-    mkdir -p "$HOME/.claude-personal"
+    mkdir -p "$HOME/.claude-shared/plugins"
 
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "FIRST_CHANGED=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
+    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init'
     assert_success
-    assert_output --partial "FIRST_CHANGED=2"
 
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "SECOND_CHANGED=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
-    assert_success
-    assert_output --partial "SECOND_CHANGED=0"
+    [ -L "$HOME/.claude-personal/skills" ]
+    [ -L "$HOME/.claude-personal/docs" ]
+    [ "$(readlink "$HOME/.claude-personal/skills")" = "$FAKE_DOTFILES_ROOT/claude/skills" ]
+    [ "$(readlink "$HOME/.claude-personal/docs")" = "$FAKE_DOTFILES_ROOT/claude/docs" ]
+    # New skills appear via the symlink without a follow-up run.
+    [ -d "$HOME/.claude-personal/skills/alpha" ]
+    [ -f "$HOME/.claude-personal/skills/alpha/SKILL.md" ]
 }
 
-@test "issue #342: claude-skills-sync alias triggers sync across enabled accounts" {
+@test "issue #575: new skill added to SSOT is visible immediately (no setup re-run)" {
     _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal" "$HOME/.claude-work"
+    mkdir -p "$HOME/.claude-shared/plugins"
 
-    run_with_fake_ssot 'shopt -s expand_aliases; eval "claude-skills-sync"'
+    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init'
     assert_success
-    [ -L "$HOME/.claude-personal/skills/alpha" ]
-    [ -L "$HOME/.claude-work/skills/alpha" ]
+
+    # Drop a new skill into the SSOT after setup ran.
+    mkdir -p "$FAKE_DOTFILES_ROOT/claude/skills/just-added"
+    printf -- '---\nname: just-added\ndescription: post-setup skill\n---\n' \
+        > "$FAKE_DOTFILES_ROOT/claude/skills/just-added/SKILL.md"
+
+    [ -f "$HOME/.claude-personal/skills/just-added/SKILL.md" ]
 }
 
-@test "issue #342: claude-accounts skills-sync sub-command works" {
+@test "issue #575: real-dir collision at skills/ is backed up and replaced with symlink" {
     _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal"
+    mkdir -p "$HOME/.claude-shared/plugins"
+    # Simulate a user with a pre-existing real skills directory (e.g.
+    # leftover from the #342 per-skill era full of stale symlinks).
+    mkdir -p "$HOME/.claude-personal/skills/leftover"
+    echo "user-data" > "$HOME/.claude-personal/skills/leftover/notes.md"
 
-    run_with_fake_ssot 'shopt -s expand_aliases; eval "claude-accounts skills-sync"'
+    run_with_fake_ssot '_claude_account_setup_one personal "$HOME/.claude-personal"'
     assert_success
-    [ -L "$HOME/.claude-personal/skills/alpha" ]
+
+    [ -L "$HOME/.claude-personal/skills" ]
+    [ "$(readlink "$HOME/.claude-personal/skills")" = "$FAKE_DOTFILES_ROOT/claude/skills" ]
+    # The previous real directory is preserved via the legacy
+    # `*-YYYYMMDDHHMMSS-original` backup convention so user-dropped data
+    # is never lost.
+    backup=$(ls -d "$HOME/.claude-personal/skills-"*-original 2>/dev/null | head -1)
+    [ -n "$backup" ]
+    grep -q "user-data" "$backup/leftover/notes.md"
 }
 
-@test "issue #342: second claude-skills-sync prints (no changes)" {
+@test "issue #575: second _claude_account_setup_one is idempotent for skills/docs" {
     _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal" "$HOME/.claude-work"
+    mkdir -p "$HOME/.claude-shared/plugins"
 
-    run_with_fake_ssot 'claude_skills_sync >/dev/null; claude_skills_sync'
+    run_with_fake_ssot '_claude_account_setup_one personal "$HOME/.claude-personal"'
     assert_success
-    assert_output --partial "no changes"
+
+    run_with_fake_ssot '_claude_account_setup_one personal "$HOME/.claude-personal"'
+    assert_success
+    assert_output --partial "already linked"
+
+    [ -L "$HOME/.claude-personal/skills" ]
+    [ -L "$HOME/.claude-personal/docs" ]
+    # No backups created on the second run — symlinks were already correct.
+    [ -z "$(ls -d "$HOME/.claude-personal/skills-"*-original 2>/dev/null)" ]
+    [ -z "$(ls -d "$HOME/.claude-personal/docs-"*-original 2>/dev/null)" ]
 }
 
-@test "issue #342: claude_accounts_status shows skills sync ratio" {
-    _seed_ssot_skills alpha beta
-    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init >/dev/null && CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
-    assert_success
-    assert_output --partial "skills: 2/2 ✓"
-}
-
-@test "issue #342: claude_accounts_status flags drift when symlinks missing" {
-    _seed_ssot_skills alpha beta gamma
-    # Set up only one of three symlinks → ratio shows 1/3 with drift marker.
-    mkdir -p "$HOME/.claude-personal/skills"
-    ln -s "$FAKE_DOTFILES_ROOT/claude/skills/alpha" "$HOME/.claude-personal/skills/alpha"
-
-    run_with_fake_ssot 'CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
-    assert_success
-    assert_output --partial "skills: 1/3"
-    assert_output --partial "claude-accounts skills-sync"
-}
-
-@test "issue #342: claude_yolo --no-sync skips auto-sync" {
-    _setup_claude_mock
-    _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal"
-
-    run_with_fake_ssot "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --no-sync"
-    assert_success
-    [ ! -e "$HOME/.claude-personal/skills/alpha" ]
-}
-
-@test "issue #342: claude_yolo auto-syncs by default" {
-    _setup_claude_mock
-    _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal"
-
-    run_with_fake_ssot "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
-    assert_success
-    [ -L "$HOME/.claude-personal/skills/alpha" ]
-}
-
-@test "issue #342: claude-accounts help mentions skills-sync sub-command" {
+@test "issue #575: claude-accounts no longer exposes the skills-sync subcommand" {
     run_in_bash 'shopt -s expand_aliases; eval "claude-accounts -h"'
     assert_success
-    assert_output --partial "skills-sync"
+    refute_output --partial "skills-sync"
 }
 
-@test "issue #342: re-running sync does NOT nest pre-sync backups" {
-    _seed_ssot_skills cli-dev
-    mkdir -p "$HOME/.claude-personal/skills/cli-dev"
-    echo "first-run-content" > "$HOME/.claude-personal/skills/cli-dev/x.md"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-    # Sleep 1 to ensure a new TS would differ; then run again — Pass 2 must
-    # skip *-pre-sync-* entries so they don't get -orphan- nested.
-    sleep 1
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    # Backups land under .sync-backup/ (issue #344). Exactly one backup,
-    # no nested -orphan- chain.
-    backups=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"cli-dev-pre-sync-* 2>/dev/null | wc -l)
-    [ "$backups" -eq 1 ]
-    nested=$(ls -d "$HOME/.claude-personal/.sync-backup/skills/"cli-dev-pre-sync-*-orphan-* 2>/dev/null | wc -l)
-    [ "$nested" -eq 0 ]
-    # And nothing leaks back into the scan dir.
-    leaked=$(ls -d "$HOME/.claude-personal/skills/"cli-dev-pre-sync-* 2>/dev/null | wc -l)
-    [ "$leaked" -eq 0 ]
+@test "issue #575: claude_skills_sync, _claude_dir_sync_one, claude-mount-* are gone" {
+    run_in_bash 'declare -F claude_skills_sync claude_mount_skills claude_mount_docs claude_mount_all _claude_dir_sync_one _claude_count_dir_sync _claude_ensure_bind_mount 2>&1 || true'
+    refute_output --partial "claude_skills_sync"
+    refute_output --partial "claude_mount_skills"
+    refute_output --partial "claude_mount_docs"
+    refute_output --partial "claude_mount_all"
+    refute_output --partial "_claude_dir_sync_one"
+    refute_output --partial "_claude_count_dir_sync"
+    refute_output --partial "_claude_ensure_bind_mount"
 }
 
 # ---------- Issue #500: setup.sh / migrate 자동화 갭 보강 ----------
@@ -1196,75 +1144,10 @@ run_with_fake_ssot() {
     [ ! -f "$HOME/.claude-personal/.claude.json.preserved-by-migrate" ]
 }
 
-# ---------- Issue #344: backups outside the skill scanner ----------
-
-@test "issue #344: skills/ stays free of *-pre-sync-* / *-orphan-* siblings" {
-    _seed_ssot_skills alpha
-    # Trigger BOTH backup branches: real-dir collision (Pass 1) and
-    # orphan real dir (Pass 2).
-    mkdir -p "$HOME/.claude-personal/skills/alpha"          # collision
-    echo "x" > "$HOME/.claude-personal/skills/alpha/x.md"
-    mkdir -p "$HOME/.claude-personal/skills/orphan-real"    # orphan
-    echo "y" > "$HOME/.claude-personal/skills/orphan-real/y.md"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    # The scan-visible directory contains only real SSOT-linked skills.
-    # Anything matching the backup naming convention is a regression of
-    # the issue #344 symptom (duplicate "<name>-pre-sync-<TS>" skills in
-    # available-skills).
-    leaked_pre=$(find "$HOME/.claude-personal/skills/" -maxdepth 1 -name '*-pre-sync-*' 2>/dev/null | wc -l)
-    leaked_orphan=$(find "$HOME/.claude-personal/skills/" -maxdepth 1 -name '*-orphan-*' 2>/dev/null | wc -l)
-    [ "$leaked_pre" -eq 0 ]
-    [ "$leaked_orphan" -eq 0 ]
-
-    # And both backup payloads are recoverable from .sync-backup/.
-    [ -d "$HOME/.claude-personal/.sync-backup/skills" ]
-    [ "$(find "$HOME/.claude-personal/.sync-backup/skills/" -maxdepth 1 -name '*-pre-sync-*' | wc -l)" -ge 1 ]
-    [ "$(find "$HOME/.claude-personal/.sync-backup/skills/" -maxdepth 1 -name '*-orphan-*' | wc -l)" -ge 1 ]
-}
-
-@test "issue #344: legacy backups in skills/ are migrated to .sync-backup/" {
-    _seed_ssot_skills alpha
-    # Simulate a user already on the buggy version: legacy backups sit
-    # inside the scan dir from a previous run.
-    mkdir -p "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000"
-    echo "legacy-pre" > "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000/SKILL.md"
-    mkdir -p "$HOME/.claude-personal/skills/agents-md-orphan-20260101000000"
-    echo "legacy-orphan" > "$HOME/.claude-personal/skills/agents-md-orphan-20260101000000/SKILL.md"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills'
-    assert_success
-
-    # Legacy entries are gone from the scan dir.
-    [ ! -e "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000" ]
-    [ ! -e "$HOME/.claude-personal/skills/agents-md-orphan-20260101000000" ]
-
-    # And recoverable from .sync-backup/, content intact.
-    [ -d "$HOME/.claude-personal/.sync-backup/skills/cli-dev-pre-sync-20260101000000" ]
-    [ -d "$HOME/.claude-personal/.sync-backup/skills/agents-md-orphan-20260101000000" ]
-    grep -q "legacy-pre" "$HOME/.claude-personal/.sync-backup/skills/cli-dev-pre-sync-20260101000000/SKILL.md"
-    grep -q "legacy-orphan" "$HOME/.claude-personal/.sync-backup/skills/agents-md-orphan-20260101000000/SKILL.md"
-}
-
-@test "issue #344: legacy-backup migration is idempotent (second run is no-op)" {
-    _seed_ssot_skills alpha
-    mkdir -p "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000"
-    echo "x" > "$HOME/.claude-personal/skills/cli-dev-pre-sync-20260101000000/SKILL.md"
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "FIRST=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
-    assert_success
-    assert_output --partial "FIRST=2"   # 1 migration + 1 alpha link
-
-    run_with_fake_ssot '_claude_dir_sync_one "$HOME/.claude-personal" skills; echo "SECOND=$_CLAUDE_DIR_SYNC_LAST_CHANGED"'
-    assert_success
-    assert_output --partial "SECOND=0"
-
-    # Backup directory not double-nested by the second run.
-    nested=$(find "$HOME/.claude-personal/.sync-backup/" -name 'cli-dev-pre-sync-20260101000000' 2>/dev/null | wc -l)
-    [ "$nested" -eq 1 ]
-}
+# Issue #344 (per-skill backup scanner pollution) is no longer reachable
+# under #575 — skills/ is a single directory symlink with no per-entry
+# backups in scanner view. Tests that exercised the legacy path were
+# removed with `_claude_dir_sync_one`.
 
 # ---------- _claude_yolo_export_settings_env: gateway env propagation ----------
 


### PR DESCRIPTION
## Summary
- 옵션 1·2·3 (public / internal / external) 모든 PC 에서 `skills/` 와 `docs/` 를 단일 디렉토리 symlink 로 통일 — bind-mount (#287) 와 per-skill symlink (#342/#344) 두 갈래 코드 경로 제거.
- sudoers / `sudo mount --bind` 의존이 사라져 setup 단순화 + 보안 표면 축소 + 새 SSOT 스킬이 setup 재실행 없이 즉시 보임.
- 기존 PC 에 남은 bind-mount 도 `_claude_ensure_symlink` 의 마이그레이션 분기에서 자동 unmount → symlink 로 교체.

## Changes
- `shell-common/tools/integrations/claude.sh`: `_claude_account_setup_one` 가 `skills`/`docs` 를 디렉토리 symlink 로 잇도록 변경. `_claude_ensure_symlink` 에 bind-mount 감지 + `sudo umount` 후 재링크 분기 추가. `claude_mount_skills/_docs/_all`, `_claude_try_auto_mount`, `_claude_ensure_bind_mount`, `_claude_dir_sync_one`, `_claude_count_dir_sync`, `claude_skills_sync`, `claude-skills-sync` alias, `claude-accounts skills-sync` 서브커맨드, `claude_yolo --no-sync` 옵션 일괄 삭제. `claude_accounts_status` 가 skills/docs 도 단일 `symlink ✓` 형식으로 보고하도록 갱신.
- `claude/setup.sh`: `_setup_bind_mount_sudoers` 와 다중 계정 루프 안의 두 호출 제거. `_print_stale_bind_mount_sudoers_hint` 추가 — internal/multi-account 양쪽 종료 직전 `/etc/sudoers.d/claude-{skills,docs}-mount-*` 잔존 파일 수동 정리 안내. 검증 루프에 `skills`, `docs` 추가.
- `shell-common/env/claude.sh`: `CLAUDE_AUTO_MOUNT_*` 환경 변수 블록 삭제 — 더 이상 게이트할 동작 없음.
- `shell-common/functions/{mount,dot_help,claude_plugins_help}.sh`, `scripts/setup-skills-ssot.sh`: 도움말 / 주석에서 stale bind-mount 표현 제거.
- `CLAUDE.md`, `claude/AGENTS.md`: storage 레이아웃 섹션을 모든 모드 디렉토리 symlink 로 갱신, sudo 의존성 제거 명시.
- `tests/bats/integrations/claude_accounts.bats`: `_claude_account_setup_one` 테스트 갱신, #342/#344 (per-skill symlink, 백업 폴루션) 섹션 제거. 6 건의 #575 신규 케이스 추가 — 디렉토리 symlink 생성, 새 스킬 즉시 가시화, real-dir collision backup-and-replace, idempotency, 사라진 CLI 표면 회귀 가드, bind-mount → symlink 마이그레이션.

## Test plan
- [x] `bats tests/bats/integrations/claude_accounts.bats` — 6 신규 #575 케이스 통과, 모든 관련 회귀(#571 internal bind-mount 마이그레이션, #554, #294, #287 multi-account, #300-A/B/C) 통과. 잔존 실패 11 건은 `main` 에서도 동일하게 발생하는 환경 오염 / 기존 #584 SSOT 이슈와 무관.
- [x] `tox -e shellcheck`, `tox -e shfmt` clean.
- [x] `bash -n` 통과: claude/setup.sh, shell-common/tools/integrations/claude.sh, shell-common/env/claude.sh, shell-common/functions/mount.sh.
- [ ] 외부 PC (`CLAUDE_ENABLED_ACCOUNTS="personal work"`) 실기 검증: `./setup.sh` → `claude-yolo`, `claude-yolo --user work` 정상 기동.
- [ ] 사내 internal PC 실기 검증: `./setup.sh` (`~/.dotfiles-setup-mode=internal`) → `claude-yolo` 정상 기동, `~/.claude/skills`, `~/.claude/docs` 가 디렉토리 symlink.
- [ ] bind-mount 잔존 PC: 기존 `/etc/sudoers.d/claude-{skills,docs}-mount-*` 가 setup 종료 시 cleanup hint 출력. 수동 `sudo rm` 후 재실행 시 hint 사라짐.

## Related
Closes #575

---
<details>
<summary>🤖 AI Metrics · 📊 ~16000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~16000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
