### PR TITLE
feat(gh-pr-resolve-conflict): sync PR card to In review after rebase

### DIFF
--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -125,6 +125,28 @@ Step 1 의 `TARGET_REPO` 는 `git remote get-url` 결과(URL 형태)일 수
 If the label is absent, the `||` branch absorbs the 404 as a soft-fail
 warning (idempotent).
 
+**보드 status `In review` 복귀** (soft-fail — `mergeable == MERGEABLE` 인 경우에만):
+
+`changes-requested` → fix push → 카드가 `In progress` 또는 `Changes requested` 에
+머무는 흐름을 자동으로 끊어 리뷰어 큐 (`In review`) 로 되돌린다. 신규 PR
+단계의 conflict (카드가 이미 `In review` / `Approved` / `Done`) 는
+`--only-from` 가드가 막아 후퇴시키지 않는다. 자세한 lifecycle 근거는 issue #591.
+
+```bash
+if [ "$mergeable" = "MERGEABLE" ]; then
+    . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null \
+      && _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+            --only-from "In progress,Changes requested" \
+      && echo "[OK] PR 카드 \`In review\` 로 복귀됨" \
+      || echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+fi
+```
+
+`GH_PROJECT_STATUS_SYNC=0` opt-out 은 helper 자체가 흡수한다. projectV2
+보드가 없는 레포는 helper 가 silent 0 반환. `--only-from` 의 missing column
+은 helper 가 silently skip 하므로 `Changes requested` 컬럼 없는 보드와도
+호환된다.
+
 After the report, post a PR comment with ai-metrics (soft-fail — warn on
 error, never block). `CONFLICT_FILES` is the count of files that had
 `UU`/`AA`/`DU` conflicts in Step 3. When `GH_DISABLE_AI_METRICS=1`,

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -133,7 +133,7 @@ warning (idempotent).
 `--only-from` 가드가 막아 후퇴시키지 않는다. 자세한 lifecycle 근거는 issue #591.
 
 ```bash
-if [ "$mergeable" = "MERGEABLE" ]; then
+if [ "$MERGEABLE" = "MERGEABLE" ]; then
     . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null \
       && _gh_project_status_sync pr "$PR_NUMBER" "In review" \
             --only-from "In progress,Changes requested" \


### PR DESCRIPTION
## Summary
- `/gh-pr-resolve-conflict` Step 5 의 mergeable 확인 직후, 보드 status `In review` 복귀 블록을 추가.
- 리뷰어가 changes-requested 를 낸 뒤 작성자가 fix push 한 흐름에서 PR 카드가 `In progress` 또는 `Changes requested` 에 그대로 남아 리뷰 큐로 돌아오지 못하던 문제를 자동화.
- `--only-from "In progress,Changes requested"` 가드로 lifecycle 역행 (신규 PR conflict 의 `In review`/`Approved`/`Done` 카드 후퇴) 차단.

## Changes
- `claude/skills/gh-pr-resolve-conflict/SKILL.md` Step 5 (Verify Mergeable + Report) 의 conflict-label 제거 블록 직후, ai-metrics 블록 직전에 보드 sync 스니펫 추가.
  - `mergeable == MERGEABLE` 일 때만 동작 (CONFLICTING / BEHIND 일 때는 호출하지 않음).
  - `_gh_project_status_sync pr "$PR_NUMBER" "In review" --only-from "In progress,Changes requested"` 호출.
  - helper sourcing 실패 / projectV2 보드 없음 / `GH_PROJECT_STATUS_SYNC=0` 는 모두 helper 가 silently 흡수 — soft-fail.
  - `Changes requested` 컬럼이 없는 보드도 helper 의 missing-column skip 으로 호환.

## Test plan
- [ ] mergeable=MERGEABLE 이고 카드가 `In progress` 또는 `Changes requested` → 카드가 `In review` 로 이동, `[OK] PR 카드 \`In review\` 로 복귀됨` 로그.
- [ ] 카드가 이미 `In review` / `Approved` / `Done` → helper 가 only-from skip 로그만 출력, 카드 후퇴 없음.
- [ ] projectV2 보드 없는 레포 → helper 가 silent 0 반환, 보고 결과 영향 없음.
- [ ] `GH_PROJECT_STATUS_SYNC=0` → 호출 자체 skip, Step 5 final report 정상.
- [ ] helper sourcing 실패 → `[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음` 1 줄 출력, calling skill final report 정상 진행.
- [ ] mergeable=CONFLICTING / BEHIND → 보드 sync 블록 자체가 실행되지 않음 (conflict-label 제거와 동일 가드 재사용).

## Related
Closes #591

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~1 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~1 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
