### PR TITLE
fix(claude/setup): #589 canonicalize DOTFILES_ROOT to main worktree

### DIFF
--- a/bash/main.bash
+++ b/bash/main.bash
@@ -57,6 +57,20 @@ fi
 _BASH_SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 _BASH_SCRIPT_DIR="$(dirname "$_BASH_SCRIPT_PATH")"
 DOTFILES_ROOT="${_BASH_SCRIPT_DIR%/bash}"
+
+# Canonicalize to the main worktree (issue #589). When the loader is sourced
+# inside a linked worktree, ${DOTFILES_ROOT} would otherwise point at the
+# worktree path and bleed into ~/.claude-*/ symlinks created by
+# claude_accounts_init. The helper is source-from-candidate-path safe — the
+# function does not depend on DOTFILES_ROOT already being canonical.
+_dotfiles_root_resolver="${DOTFILES_ROOT}/shell-common/functions/dotfiles_root.sh"
+if [ -r "$_dotfiles_root_resolver" ]; then
+    # shellcheck source=../shell-common/functions/dotfiles_root.sh
+    . "$_dotfiles_root_resolver"
+    _dotfiles_root_canonicalize
+fi
+unset _dotfiles_root_resolver
+
 export DOTFILES_ROOT
 SHELL_COMMON="${DOTFILES_ROOT}/shell-common"
 export SHELL_COMMON

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -26,6 +26,25 @@
 # Initialize DOTFILES_ROOT
 _SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
+
+# Canonicalize to the main worktree (issue #589). When invoked from a
+# linked worktree, the script path resolves to <worktree>/claude/setup.sh
+# and DOTFILES_ROOT becomes the worktree — that path would then be baked
+# into every ~/.claude-*/ symlink we create below. Falling through to the
+# worktree path is acceptable if the helper is missing (no regression).
+_CLAUDE_DOTFILES_RESOLVER="${DOTFILES_ROOT}/shell-common/functions/dotfiles_root.sh"
+if [ -r "$_CLAUDE_DOTFILES_RESOLVER" ]; then
+    # shellcheck source=../shell-common/functions/dotfiles_root.sh
+    source "$_CLAUDE_DOTFILES_RESOLVER"
+    _CLAUDE_CANONICAL=$(_resolve_dotfiles_root_canonical "$DOTFILES_ROOT")
+    if [ -n "$_CLAUDE_CANONICAL" ] && [ "$_CLAUDE_CANONICAL" != "$DOTFILES_ROOT" ]; then
+        echo "[claude/setup.sh] 워크트리 감지 — 메인 워크트리로 전환: $_CLAUDE_CANONICAL" >&2
+        DOTFILES_ROOT="$_CLAUDE_CANONICAL"
+    fi
+    unset _CLAUDE_CANONICAL
+fi
+unset _CLAUDE_DOTFILES_RESOLVER
+
 CLAUDE_DOTFILES="${DOTFILES_ROOT}/claude"
 
 # Home directory locations

--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,26 @@ set -e
 
 # Load UX library so user-facing messages stay consistent (mirrors install.sh).
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Canonicalize to the main worktree (issue #589). Running ./setup.sh from a
+# linked worktree would otherwise bake the worktree path into every
+# ~/.claude-*/{settings.json, statusline-command.sh, skills, docs, ...}
+# symlink. When the worktree is later removed those symlinks dangle and
+# Claude Code silently reverts to defaults (no statusline, no hooks).
+_DOTFILES_RESOLVER="${DOTFILES_DIR}/shell-common/functions/dotfiles_root.sh"
+if [ -r "$_DOTFILES_RESOLVER" ]; then
+    # shellcheck source=shell-common/functions/dotfiles_root.sh
+    source "$_DOTFILES_RESOLVER"
+    _CANONICAL=$(_resolve_dotfiles_root_canonical "$DOTFILES_DIR")
+    if [ -n "$_CANONICAL" ] && [ "$_CANONICAL" != "$DOTFILES_DIR" ]; then
+        echo "[setup.sh] 워크트리에서 실행됨 — 메인 워크트리로 전환: $_CANONICAL" >&2
+        cd "$_CANONICAL"
+        DOTFILES_DIR="$_CANONICAL"
+    fi
+    unset _CANONICAL
+fi
+unset _DOTFILES_RESOLVER
+
 UX_LIB_SCRIPT="${DOTFILES_DIR}/shell-common/tools/ux_lib/ux_lib.sh"
 if [ -f "${UX_LIB_SCRIPT}" ]; then
     # shellcheck source=/dev/null

--- a/shell-common/functions/dotfiles_root.sh
+++ b/shell-common/functions/dotfiles_root.sh
@@ -60,12 +60,24 @@ _resolve_dotfiles_root_canonical() {
         return 0
     fi
 
+    # Compare --git-dir with --git-common-dir to safely detect *linked
+    # worktrees only*. They differ only when the checkout is a linked
+    # worktree of either a main repo or a submodule. They are equal for:
+    #   - main worktree of a regular repo (.git == .git)
+    #   - main checkout of a submodule (.git/modules/<sub> == itself)
+    # In the equal case dirname walks to .git/modules (wrong target),
+    # so short-circuit and return the candidate untouched. Reported by
+    # gemini-code-assist on PR #593.
+    _rdrc_git_dir=$(git -C "$_rdrc_candidate" rev-parse --git-dir 2>/dev/null) || {
+        echo "$_rdrc_candidate"
+        return 0
+    }
     _rdrc_common=$(git -C "$_rdrc_candidate" rev-parse --git-common-dir 2>/dev/null) || {
         echo "$_rdrc_candidate"
         return 0
     }
 
-    if [ -z "$_rdrc_common" ]; then
+    if [ -z "$_rdrc_common" ] || [ "$_rdrc_git_dir" = "$_rdrc_common" ]; then
         echo "$_rdrc_candidate"
         return 0
     fi

--- a/shell-common/functions/dotfiles_root.sh
+++ b/shell-common/functions/dotfiles_root.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# shell-common/functions/dotfiles_root.sh
+#
+# Canonicalize $DOTFILES_ROOT so it always resolves to the MAIN git worktree,
+# never a linked worktree. Issue #589.
+#
+# Why: claude/setup.sh and claude_accounts_init evaluate ${DOTFILES_ROOT} at
+# call time and embed that literal path into ~/.claude-*/{settings.json,
+# statusline-command.sh, skills, docs, ...} symlinks. If setup.sh is invoked
+# from a linked worktree, those symlinks point at the worktree path. When
+# the worktree is removed later, the symlinks dangle → Claude Code silently
+# falls back to default settings (no statusline, no hooks, no plugins). The
+# user sees "왜 안 되지" with no error message.
+#
+# Strategy: when called inside a linked worktree, walk back to the main
+# worktree via `git rev-parse --git-common-dir`. Pure POSIX, no bash-isms.
+
+# Sourced both by interactive shells (loaders) and by non-interactive
+# setup.sh runs. The interactive guard pattern is intentionally absent so
+# setup.sh can rely on the function being defined even without
+# DOTFILES_FORCE_INIT — there is no observable output until the function
+# is invoked.
+
+# _resolve_dotfiles_root_canonical CANDIDATE
+#
+# Echo the canonical (main-worktree) directory that should be used as
+# $DOTFILES_ROOT, given CANDIDATE as the script-derived starting point.
+#
+# Behavior:
+#   - CANDIDATE empty/missing → echo "$CANDIDATE" (no-op).
+#   - DOTFILES_ROOT_NO_CANONICALIZE=1 in env → echo "$CANDIDATE" (escape
+#     hatch for users intentionally testing a worktree's dotfiles).
+#   - git unavailable → echo "$CANDIDATE" (minimal hosts).
+#   - CANDIDATE is not a git worktree → echo "$CANDIDATE".
+#   - CANDIDATE is the MAIN worktree → echo "$CANDIDATE".
+#   - CANDIDATE is a linked worktree → echo the resolved main worktree path.
+#
+# Always returns 0 — a probing failure must fall back to CANDIDATE so this
+# helper can never break a shell that was working before.
+_resolve_dotfiles_root_canonical() {
+    _rdrc_candidate="${1:-}"
+
+    if [ -z "$_rdrc_candidate" ]; then
+        echo ""
+        return 0
+    fi
+
+    if [ ! -d "$_rdrc_candidate" ]; then
+        echo "$_rdrc_candidate"
+        return 0
+    fi
+
+    if [ "${DOTFILES_ROOT_NO_CANONICALIZE:-0}" = "1" ]; then
+        echo "$_rdrc_candidate"
+        return 0
+    fi
+
+    if ! command -v git >/dev/null 2>&1; then
+        echo "$_rdrc_candidate"
+        return 0
+    fi
+
+    _rdrc_common=$(git -C "$_rdrc_candidate" rev-parse --git-common-dir 2>/dev/null) || {
+        echo "$_rdrc_candidate"
+        return 0
+    }
+
+    if [ -z "$_rdrc_common" ]; then
+        echo "$_rdrc_candidate"
+        return 0
+    fi
+
+    case "$_rdrc_common" in
+        /*) ;;
+        *) _rdrc_common="$_rdrc_candidate/$_rdrc_common" ;;
+    esac
+
+    _rdrc_main=$(dirname "$_rdrc_common" 2>/dev/null)
+    if [ -z "$_rdrc_main" ] || [ ! -d "$_rdrc_main" ]; then
+        echo "$_rdrc_candidate"
+        return 0
+    fi
+
+    _rdrc_main=$(cd "$_rdrc_main" 2>/dev/null && pwd) || {
+        echo "$_rdrc_candidate"
+        return 0
+    }
+
+    echo "$_rdrc_main"
+}
+
+# _dotfiles_root_canonicalize
+#
+# In-place: re-export $DOTFILES_ROOT (and $SHELL_COMMON) from a worktree
+# path to the canonical main-worktree path. No-op if already canonical or
+# if DOTFILES_ROOT is unset. Always returns 0 — a downgrade-safe wrapper
+# loaders can call unconditionally.
+_dotfiles_root_canonicalize() {
+    [ -n "${DOTFILES_ROOT:-}" ] || return 0
+    _drc_resolved=$(_resolve_dotfiles_root_canonical "$DOTFILES_ROOT")
+    if [ -n "$_drc_resolved" ] && [ "$_drc_resolved" != "$DOTFILES_ROOT" ]; then
+        DOTFILES_ROOT="$_drc_resolved"
+        export DOTFILES_ROOT
+        SHELL_COMMON="${DOTFILES_ROOT}/shell-common"
+        export SHELL_COMMON
+    fi
+    return 0
+}

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -1072,6 +1072,131 @@ claude_accounts_rollback() {
     ux_info "  3. claude-yolo  (no --user flag; multi-account dispatch is bypassed)"
 }
 
+# claude_accounts_repair — one-shot cleanup for worktree-tainted symlinks
+# (issue #589, Option C).
+#
+# Walks every ~/.claude-* directory and ~/.claude/ and rebinds symlinks
+# whose target either (a) dangles or (b) lives outside the canonical
+# DOTFILES_ROOT/claude/ subtree, to the equivalent path under the
+# canonical root. Idempotent — clean PCs see "nothing to repair".
+#
+# Why this exists in addition to the loader/setup canonicalization: those
+# guards prevent FUTURE breakage. Pre-existing PCs that already ran
+# setup from a (now-deleted) worktree carry dangling symlinks today;
+# `claude_accounts_repair` is the explicit recovery command.
+#
+# Scope: only touches symlinks whose name matches the well-known set
+# created by `_claude_account_setup_one`:
+#   settings.json, statusline-command.sh, skills, docs,
+#   projects/GLOBAL/memory
+# `plugins` is intentionally excluded — it points at ~/.claude-shared/
+# (not DOTFILES_ROOT), so the worktree-bleed regression cannot reach it.
+#
+# Usage:
+#   claude-accounts repair          # actually fix
+#   claude-accounts repair --dry-run  # report only, no mutation
+claude_accounts_repair() {
+    _car_dry=0
+    if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+        _car_dry=1
+    fi
+
+    ux_header "claude-accounts repair — rebind worktree-tainted symlinks (issue #589)"
+
+    if [ -z "${DOTFILES_ROOT:-}" ]; then
+        ux_error "DOTFILES_ROOT unset — re-source ~/.bashrc / ~/.zshrc first"
+        return 1
+    fi
+
+    _car_root="$DOTFILES_ROOT"
+    _car_claude_src="${_car_root}/claude"
+    if [ ! -d "$_car_claude_src" ]; then
+        ux_error "Canonical claude dir missing: $_car_claude_src"
+        ux_info  "  Run ./setup.sh from the main worktree first."
+        return 1
+    fi
+
+    ux_info "Canonical DOTFILES_ROOT: $_car_root"
+    if [ "$_car_dry" = "1" ]; then
+        ux_info "Mode: dry-run (no files will be modified)"
+    fi
+
+    # Account dirs to scan: ~/.claude/ + every ~/.claude-* directory.
+    _car_repaired=0
+    _car_skipped=0
+
+    for _car_dir in "$HOME/.claude" "$HOME"/.claude-*; do
+        [ -d "$_car_dir" ] || continue
+        # Glob fallthrough on systems with no ~/.claude-* dirs at all
+        # (the literal pattern survives) — skip it.
+        case "$_car_dir" in
+            "$HOME/.claude-"\*) continue ;;
+        esac
+
+        # Each (relative_path, canonical_source) pair.
+        # POSIX sh has no arrays; use a here-doc-driven loop instead.
+        while IFS='|' read -r _car_rel _car_canon; do
+            [ -n "$_car_rel" ] || continue
+            _car_link="${_car_dir}/${_car_rel}"
+
+            # Only touch symlinks; regular files / dirs are user data.
+            [ -L "$_car_link" ] || continue
+
+            _car_target=$(readlink "$_car_link" 2>/dev/null || true)
+            _car_needs_fix=0
+
+            # Case 1: dangling — readlink target does not resolve.
+            if [ ! -e "$_car_link" ]; then
+                _car_needs_fix=1
+            fi
+            # Case 2: target points outside the canonical claude subtree.
+            #         (caught even when the worktree path happens to still
+            #         exist, e.g. user hasn't deleted it yet)
+            case "$_car_target" in
+                "$_car_canon") : ;;                          # already canonical
+                "${_car_root}/claude/"*) : ;;                # canonical subtree
+                *) _car_needs_fix=1 ;;
+            esac
+
+            if [ "$_car_needs_fix" = "0" ]; then
+                _car_skipped=$((_car_skipped + 1))
+                continue
+            fi
+
+            ux_warning "  rebind: $_car_link"
+            ux_info    "    from: $_car_target"
+            ux_info    "    to:   $_car_canon"
+            if [ "$_car_dry" = "0" ]; then
+                rm -f "$_car_link" || {
+                    ux_error "    rm failed — skipping"
+                    continue
+                }
+                mkdir -p "$(dirname "$_car_link")"
+                if ln -s "$_car_canon" "$_car_link"; then
+                    _car_repaired=$((_car_repaired + 1))
+                else
+                    ux_error "    ln -s failed — symlink missing now, manual recovery needed"
+                fi
+            else
+                _car_repaired=$((_car_repaired + 1))
+            fi
+        done <<EOF
+settings.json|${_car_claude_src}/settings.json
+statusline-command.sh|${_car_claude_src}/statusline-command.sh
+skills|${_car_claude_src}/skills
+docs|${_car_claude_src}/docs
+projects/GLOBAL/memory|${_car_claude_src}/global-memory
+EOF
+    done
+
+    if [ "$_car_dry" = "1" ]; then
+        ux_info "Dry-run summary: would repair $_car_repaired symlink(s); $_car_skipped already canonical."
+        ux_info "Run without --dry-run to apply."
+    else
+        ux_success "Repair complete: $_car_repaired rebound, $_car_skipped already canonical."
+    fi
+}
+
 _claude_accounts_help() {
     ux_header "claude-accounts — Claude Code multi-account management"
     ux_info "Usage: claude-accounts [<subcommand>]"
@@ -1082,11 +1207,13 @@ _claude_accounts_help() {
     ux_info "  setup         Idempotent setup (creates dirs + symlinks)"
     ux_info "  migrate       One-time migration: ~/.claude → ~/.claude-personal (Home-PC)"
     ux_info "  rollback [<acct>]  Reverse of migrate: ~/.claude-<acct> → ~/.claude (issue #571)"
+    ux_info "  repair [--dry-run] Rebind dangling/worktree-tainted symlinks (issue #589)"
     ux_info "  -h|--help     This help"
     ux_info ""
     ux_info "Env vars:"
     ux_info "  CLAUDE_DEFAULT_ACCOUNT     Default for \`claude-yolo\` (default: personal)"
     ux_info "  CLAUDE_ENABLED_ACCOUNTS    Whitelist (default: 'personal work')"
+    ux_info "  DOTFILES_ROOT_NO_CANONICALIZE=1  Skip worktree canonicalization (issue #589 escape hatch)"
     ux_info "  Override per-PC in shell-common/env/claude.local.sh"
 }
 
@@ -1097,6 +1224,7 @@ claude_accounts() {
         setup)          claude_accounts_init ;;
         migrate)        claude_accounts_migrate ;;
         rollback)       shift; claude_accounts_rollback "$@" ;;
+        repair)         shift; claude_accounts_repair "$@" ;;
         -h|--help|help) _claude_accounts_help ;;
         *)              ux_error "Unknown subcommand: $1"; _claude_accounts_help; return 1 ;;
     esac

--- a/tests/bats/functions/dotfiles_root.bats
+++ b/tests/bats/functions/dotfiles_root.bats
@@ -62,6 +62,23 @@ teardown() {
     assert_output ""
 }
 
+# Regression: a submodule checkout has --git-dir == --git-common-dir
+# (both point at <parent>/.git/modules/<sub>), so walking `dirname` would
+# falsely land on .git/modules — not a worktree. Helper must return the
+# submodule path unchanged. Caught by gemini-code-assist on PR #593.
+@test "_resolve_dotfiles_root_canonical: submodule checkout returns candidate (not .git/modules)" {
+    PARENT="$SCRATCH/parent"
+    mkdir -p "$PARENT"
+    (cd "$PARENT" && git init -q -b main && \
+        git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init && \
+        git -c protocol.file.allow=always submodule add -q "$MAIN" sub)
+    SUB="$PARENT/sub"
+
+    run bash -c ". '$HELPER' && _resolve_dotfiles_root_canonical '$SUB'"
+    assert_success
+    assert_output "$SUB"
+}
+
 @test "_resolve_dotfiles_root_canonical: DOTFILES_ROOT_NO_CANONICALIZE=1 disables resolution" {
     run env DOTFILES_ROOT_NO_CANONICALIZE=1 bash -c \
         ". '$HELPER' && _resolve_dotfiles_root_canonical '$WT'"

--- a/tests/bats/functions/dotfiles_root.bats
+++ b/tests/bats/functions/dotfiles_root.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/bats/functions/dotfiles_root.bats
+#
+# Unit tests for shell-common/functions/dotfiles_root.sh — the worktree
+# canonicalization helper that prevents ~/.claude-*/ symlinks from getting
+# baked with a linked-worktree path that goes dangling on worktree removal
+# (issue #589).
+#
+# A scratch git repo + worktree is built in $TEST_TEMP_HOME per test so we
+# never depend on the dotfiles repo's own worktrees.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    SCRATCH="$TEST_TEMP_HOME/scratch"
+    MAIN="$SCRATCH/main"
+    WT="$SCRATCH/wt"
+    mkdir -p "$MAIN"
+    (cd "$MAIN" && git init -q -b main && \
+        git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init && \
+        git worktree add -q -b feat "$WT" >/dev/null 2>&1)
+
+    HELPER="$_BATS_REAL_DOTFILES_ROOT/shell-common/functions/dotfiles_root.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# _resolve_dotfiles_root_canonical
+# ---------------------------------------------------------------------------
+
+@test "_resolve_dotfiles_root_canonical: main worktree path is returned unchanged" {
+    run bash -c ". '$HELPER' && _resolve_dotfiles_root_canonical '$MAIN'"
+    assert_success
+    assert_output "$MAIN"
+}
+
+@test "_resolve_dotfiles_root_canonical: linked worktree resolves to main" {
+    run bash -c ". '$HELPER' && _resolve_dotfiles_root_canonical '$WT'"
+    assert_success
+    assert_output "$MAIN"
+}
+
+@test "_resolve_dotfiles_root_canonical: non-git path is returned unchanged" {
+    run bash -c ". '$HELPER' && _resolve_dotfiles_root_canonical '$TEST_TEMP_HOME'"
+    assert_success
+    assert_output "$TEST_TEMP_HOME"
+}
+
+@test "_resolve_dotfiles_root_canonical: missing path is returned unchanged" {
+    run bash -c ". '$HELPER' && _resolve_dotfiles_root_canonical '/no/such/dir'"
+    assert_success
+    assert_output "/no/such/dir"
+}
+
+@test "_resolve_dotfiles_root_canonical: empty candidate yields empty output" {
+    run bash -c ". '$HELPER' && _resolve_dotfiles_root_canonical ''"
+    assert_success
+    assert_output ""
+}
+
+@test "_resolve_dotfiles_root_canonical: DOTFILES_ROOT_NO_CANONICALIZE=1 disables resolution" {
+    run env DOTFILES_ROOT_NO_CANONICALIZE=1 bash -c \
+        ". '$HELPER' && _resolve_dotfiles_root_canonical '$WT'"
+    assert_success
+    assert_output "$WT"
+}
+
+# ---------------------------------------------------------------------------
+# _dotfiles_root_canonicalize (in-place re-export)
+# ---------------------------------------------------------------------------
+
+@test "_dotfiles_root_canonicalize: worktree path is rewritten to main" {
+    run bash -c "
+        export DOTFILES_ROOT='$WT'
+        export SHELL_COMMON='$WT/shell-common'
+        . '$HELPER'
+        _dotfiles_root_canonicalize
+        echo \"\$DOTFILES_ROOT|\$SHELL_COMMON\"
+    "
+    assert_success
+    assert_output "$MAIN|$MAIN/shell-common"
+}
+
+@test "_dotfiles_root_canonicalize: main path is left untouched" {
+    run bash -c "
+        export DOTFILES_ROOT='$MAIN'
+        export SHELL_COMMON='$MAIN/shell-common'
+        . '$HELPER'
+        _dotfiles_root_canonicalize
+        echo \"\$DOTFILES_ROOT|\$SHELL_COMMON\"
+    "
+    assert_success
+    assert_output "$MAIN|$MAIN/shell-common"
+}
+
+@test "_dotfiles_root_canonicalize: unset DOTFILES_ROOT is a no-op" {
+    run bash -c "
+        unset DOTFILES_ROOT SHELL_COMMON
+        . '$HELPER'
+        _dotfiles_root_canonicalize
+        echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output "rc=0"
+}

--- a/tests/bats/integrations/claude_accounts_repair.bats
+++ b/tests/bats/integrations/claude_accounts_repair.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# tests/bats/integrations/claude_accounts_repair.bats
+#
+# `claude_accounts_repair` is the one-shot cleanup helper for
+# worktree-tainted ~/.claude-*/ symlinks (issue #589, Option C).
+#
+# Strategy: build a fake "worktree path was rm -rf'd" scenario inside
+# $TEST_TEMP_HOME by laying down symlinks under ~/.claude-personal/ that
+# point at a non-existent /tmp path. Run the repair and assert the
+# symlinks now point at ${DOTFILES_ROOT}/claude/.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+
+    # Stand up a fake "worktree path" that does not exist on disk —
+    # mirrors the post-`git worktree remove` state described in #589.
+    FAKE_WT="/tmp/dotfiles-fake-worktree-DOES-NOT-EXIST"
+
+    # ~/.claude-personal/ with the well-known symlink set.
+    PERSONAL="$HOME/.claude-personal"
+    mkdir -p "$PERSONAL/projects/GLOBAL"
+    ln -s "$FAKE_WT/claude/settings.json"          "$PERSONAL/settings.json"
+    ln -s "$FAKE_WT/claude/statusline-command.sh"  "$PERSONAL/statusline-command.sh"
+    ln -s "$FAKE_WT/claude/skills"                 "$PERSONAL/skills"
+    ln -s "$FAKE_WT/claude/docs"                   "$PERSONAL/docs"
+    ln -s "$FAKE_WT/claude/global-memory"          "$PERSONAL/projects/GLOBAL/memory"
+
+    # Also stage a "canonical" symlink on ~/.claude-work to prove
+    # `repair` leaves clean entries alone.
+    WORK="$HOME/.claude-work"
+    mkdir -p "$WORK"
+    ln -s "$DOTFILES_ROOT/claude/settings.json" "$WORK/settings.json"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# repair (apply) — dangling symlinks rebound to canonical DOTFILES_ROOT
+# ---------------------------------------------------------------------------
+
+@test "claude_accounts_repair: rebinds dangling settings.json to canonical root" {
+    run_in_bash 'claude_accounts_repair >/dev/null 2>&1; readlink "$HOME/.claude-personal/settings.json"'
+    assert_success
+    assert_output "$DOTFILES_ROOT/claude/settings.json"
+}
+
+@test "claude_accounts_repair: rebinds dangling skills (directory symlink) too" {
+    run_in_bash 'claude_accounts_repair >/dev/null 2>&1; readlink "$HOME/.claude-personal/skills"'
+    assert_success
+    assert_output "$DOTFILES_ROOT/claude/skills"
+}
+
+@test "claude_accounts_repair: rebinds nested projects/GLOBAL/memory" {
+    run_in_bash 'claude_accounts_repair >/dev/null 2>&1; readlink "$HOME/.claude-personal/projects/GLOBAL/memory"'
+    assert_success
+    assert_output "$DOTFILES_ROOT/claude/global-memory"
+}
+
+@test "claude_accounts_repair: leaves an already-canonical symlink alone" {
+    run_in_bash 'claude_accounts_repair >/dev/null 2>&1; readlink "$HOME/.claude-work/settings.json"'
+    assert_success
+    assert_output "$DOTFILES_ROOT/claude/settings.json"
+}
+
+@test "claude_accounts_repair: reports skipped count for canonical entries" {
+    run_in_bash 'claude_accounts_repair 2>&1'
+    assert_success
+    assert_output --partial "already canonical"
+}
+
+# ---------------------------------------------------------------------------
+# repair --dry-run — reports without mutating
+# ---------------------------------------------------------------------------
+
+@test "claude_accounts_repair --dry-run: keeps the dangling symlink in place" {
+    run_in_bash 'claude_accounts_repair --dry-run >/dev/null 2>&1; readlink "$HOME/.claude-personal/settings.json"'
+    assert_success
+    # Original target is untouched in dry-run.
+    refute_output "$DOTFILES_ROOT/claude/settings.json"
+    assert_output --partial "dotfiles-fake-worktree-DOES-NOT-EXIST"
+}
+
+@test "claude_accounts_repair --dry-run: mentions dry-run mode in output" {
+    run_in_bash 'claude_accounts_repair --dry-run 2>&1'
+    assert_success
+    assert_output --partial "Mode: dry-run"
+    assert_output --partial "would repair"
+}
+
+# ---------------------------------------------------------------------------
+# Idempotency — second run is a no-op
+# ---------------------------------------------------------------------------
+
+@test "claude_accounts_repair: second run is a no-op (everything canonical)" {
+    run_in_bash '
+        claude_accounts_repair >/dev/null 2>&1
+        claude_accounts_repair 2>&1 | grep -E "0 rebound|Repair complete"
+    '
+    assert_success
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -97,13 +97,20 @@ setup_isolated_dotfiles_root() {
     export SHELL_COMMON="$iso_root/shell-common"
 }
 
-# Run a command in bash subprocess with dotfiles loaded
+# Run a command in bash subprocess with dotfiles loaded.
+#
+# DOTFILES_ROOT_NO_CANONICALIZE=1 bypasses the worktree-canonicalization
+# helper (issue #589) that bash/main.bash and zsh/main.zsh would otherwise
+# use to rewrite ${DOTFILES_ROOT} from this worktree's path back to the
+# main repo. Tests need to exercise the worktree's code, not whatever
+# is installed at ~/dotfiles.
 run_in_bash() {
     run bash --noprofile --norc -c "
         export DOTFILES_ROOT='${DOTFILES_ROOT}'
         export SHELL_COMMON='${SHELL_COMMON}'
         export DOTFILES_FORCE_INIT=1
         export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
         export HOME='${HOME}'
         export TERM=dumb
         source '${DOTFILES_ROOT}/bash/main.bash'
@@ -118,6 +125,7 @@ run_in_zsh() {
         export SHELL_COMMON='${SHELL_COMMON}'
         export DOTFILES_FORCE_INIT=1
         export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
         export HOME='${HOME}'
         export ZDOTDIR='${HOME}'
         export TERM=dumb

--- a/zsh/main.zsh
+++ b/zsh/main.zsh
@@ -35,6 +35,16 @@ if [ -z "$DOTFILES_ROOT" ]; then
     fi
 fi
 
+# Canonicalize to the main worktree (issue #589). Same rationale as
+# bash/main.bash — when sourced from a linked worktree, DOTFILES_ROOT
+# would otherwise leak that path into ~/.claude-*/ symlinks.
+_dotfiles_root_resolver="${DOTFILES_ROOT}/shell-common/functions/dotfiles_root.sh"
+if [ -r "$_dotfiles_root_resolver" ]; then
+    . "$_dotfiles_root_resolver"
+    _dotfiles_root_canonicalize
+fi
+unset _dotfiles_root_resolver
+
 # Set derived paths (unified with bash via consistent path resolution)
 SHELL_COMMON="${DOTFILES_ROOT}/shell-common"
 ZSH_DOTFILES="${DOTFILES_ROOT}/zsh"


### PR DESCRIPTION
## Summary
- `${DOTFILES_ROOT}`가 워크트리 경로로 평가될 때 `~/.claude-*/`의 5종 심볼릭이 워크트리 경로로 박혀 워크트리 삭제 후 dangling → Claude Code가 default 로 fallback (statusline/hooks/플러그인 미동작) 되는 silent regression 수정.
- 메인 워크트리 정규화 헬퍼(`_resolve_dotfiles_root_canonical`)를 4개 진입점(`bash/main.bash`, `zsh/main.zsh`, `setup.sh`, `claude/setup.sh`)에 wiring — 향후 재발 방지.
- 이미 dangling 된 PC를 위한 1회 복구 명령 `claude-accounts repair [--dry-run]` 신설.

## Changes
- `shell-common/functions/dotfiles_root.sh` — `git rev-parse --git-common-dir` 로 워크트리 → 메인 워크트리 경로 환원. 순수 POSIX, fallback-safe. Escape hatch: `DOTFILES_ROOT_NO_CANONICALIZE=1`.
- `bash/main.bash` / `zsh/main.zsh` — 초기 `DOTFILES_ROOT` 계산 직후 헬퍼 source + `_dotfiles_root_canonicalize` 호출.
- `setup.sh` (top-level) — 워크트리에서 호출되면 메인 워크트리로 `cd` 한 뒤 후속 sub-script 호출. stderr 에 전환 사실을 출력해 사용자가 인지 가능.
- `claude/setup.sh` — defense-in-depth, 직접 호출 케이스(`./claude/setup.sh`) 도 보호.
- `shell-common/tools/integrations/claude.sh` — `claude_accounts_repair` 추가 (`~/.claude-*/` 의 5종 잘 알려진 심볼릭만 대상; 멱등; `--dry-run` 지원). `claude_accounts` dispatcher 와 help 에 `repair` 등록.
- `tests/bats/test_helper.bash` — `run_in_bash` / `run_in_zsh` 에 `DOTFILES_ROOT_NO_CANONICALIZE=1` 추가. 그렇지 않으면 워크트리에서 실행되는 bats 가 설치본(`~/dotfiles`) 코드를 검증하게 되어 PR 코드를 못 본다.
- 신규 bats 테스트: `tests/bats/functions/dotfiles_root.bats` (9 cases — 정규화 헬퍼 동작/escape hatch/edge case), `tests/bats/integrations/claude_accounts_repair.bats` (8 cases — 복구 함수 + dry-run + 멱등성).

## Test plan
- [x] 신규 bats 17/17 통과 (helper + repair).
- [x] 전체 bats suite 533/533 통과 — 회귀 없음.
- [x] `shellcheck` clean: 수정/신규 셸 스크립트 전부.
- [x] `shfmt -d -i 4 bash/main.bash` clean (tox 의 shfmt 스코프).
- [x] 수동 smoke: `/tmp/dr-smoke/{main,wt}` 임시 worktree 로 헬퍼 5종 케이스 검증.
- [ ] (post-merge) Internal/External PC 양쪽에서 `git worktree add ../wt-test some-branch && cd ../wt-test && ./setup.sh` 시 stderr "메인 워크트리로 전환" 메시지 + `~/.claude-*/settings.json` 메인 경로 확인.

## Related
Closes #589

---
<details>
<summary>🤖 AI Metrics · 📊 ~8500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~8500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
