### PR TITLE
feat(claude): 셀업 모드 기반 다중 계정 자동 상속

### DIFF
--- a/shell-common/env/claude.local.example
+++ b/shell-common/env/claude.local.example
@@ -3,23 +3,29 @@
 #
 # 사용 방법:
 #   1. 이 파일을 claude.local.sh 로 복사
-#      cp claude.local.example claude.local.sh
+#      cp shell-common/env/claude.local.example shell-common/env/claude.local.sh
 #   2. PC 환경에 맞게 아래 값을 수정 (필요 시)
 #   3. claude.local.sh 는 자동으로 로드됨 (.gitignore 에 의해 제외됨)
 #
-# 기본값 (claude.sh):
-#   CLAUDE_DEFAULT_ACCOUNT=personal
-#   CLAUDE_ENABLED_ACCOUNTS="personal work"
+# 기본값 (claude.sh에서 자동 감지):
+#   Internal-PC (사내):   CLAUDE_DEFAULT_ACCOUNT=work
+#                        CLAUDE_ENABLED_ACCOUNTS="work"
+#   External-PC (외부):   CLAUDE_DEFAULT_ACCOUNT=personal
+#                        CLAUDE_ENABLED_ACCOUNTS="personal work work1"
+#
+# 자동 감지는 ~/.dotfiles-setup-mode 파일의 내용을 기반으로 합니다.
+# 기본값을 오버라이드하려면 아래 변수들을 수정해서 이 파일을 저장하세요.
 
 # ─── External-PC, Home-PC ───────────────────────────────────────
-# 두 계정 모두 사용 → 기본값 그대로. 이 파일 작성 불필요.
-
-# ─── Internal-PC (사내 PC, work 계정만) ─────────────────────────
-# 아래 두 줄의 주석을 해제하면 work 계정만 활성화되고
-# `claude-yolo` 가 work 로 실행됨.
+# Setup mode가 자동으로 "personal work work1" 설정 → 이 파일 불필요
+# Custom 계정을 추가하려면 아래를 해제하고 수정:
 #
-# export CLAUDE_DEFAULT_ACCOUNT="work"
-# export CLAUDE_ENABLED_ACCOUNTS="work"
+# export CLAUDE_ENABLED_ACCOUNTS="personal work work1 custom-account"
+
+# ─── Internal-PC (사내 PC) override ──────────────────────────────
+# Setup mode가 자동으로 "work"만 설정하지만, 필요시 오버라이드:
+#
+# export CLAUDE_ENABLED_ACCOUNTS="work work-alt"
 
 # ─── 계정 ↔ 이메일 expected 매핑 (issue #300, item B) ───────────
 # 정의하면 `claude-yolo --user <name>` 가 .claude.json 의 실제

--- a/shell-common/env/claude.sh
+++ b/shell-common/env/claude.sh
@@ -21,15 +21,22 @@ export CLAUDE_SKILLS_PATH="${DOTFILES_ROOT}/claude/skills"
 # Multi-account configuration (issue #287)
 # ═══════════════════════════════════════════════════════════════
 
-# Default account for `claude-yolo` (no --user flag).
-# Override per-PC via shell-common/env/claude.local.sh.
-export CLAUDE_DEFAULT_ACCOUNT="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
-
-# Whitelist of accounts to enable on this PC.
-# Setup, alias auto-derivation, and status filter by this list.
-# Override per-PC via shell-common/env/claude.local.sh
-# (e.g. Internal-PC: CLAUDE_ENABLED_ACCOUNTS="work").
-export CLAUDE_ENABLED_ACCOUNTS="${CLAUDE_ENABLED_ACCOUNTS:-personal work}"
+# Auto-detect setup mode (internal vs external) for account defaults.
+# Internal-PC (사내): work account only. External-PC: personal + work + work1.
+_claude_setup_mode="$(cat "$HOME/.dotfiles-setup-mode" 2>/dev/null)"
+case "$_claude_setup_mode" in
+    internal|2)
+        # Internal-PC mode: work계정만 활성화
+        export CLAUDE_DEFAULT_ACCOUNT="${CLAUDE_DEFAULT_ACCOUNT:-work}"
+        export CLAUDE_ENABLED_ACCOUNTS="${CLAUDE_ENABLED_ACCOUNTS:-work}"
+        ;;
+    *)
+        # External-PC (personal, home, etc): 모든 계정 활성화
+        export CLAUDE_DEFAULT_ACCOUNT="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
+        export CLAUDE_ENABLED_ACCOUNTS="${CLAUDE_ENABLED_ACCOUNTS:-personal work work1}"
+        ;;
+esac
+unset _claude_setup_mode
 
 # Load PC-local overrides (gitignored, see claude.local.example).
 _claude_env_root="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"


### PR DESCRIPTION
## 요약

모든 프로젝트가 dotfiles의 Claude 다중 계정 설정을 자동으로 상속하도록 개선했습니다. 이제 `~/.dotfiles-setup-mode`을 기반으로 각 PC 타입에 맞는 계정 설정이 자동으로 적용됩니다.

## 변경사항

### core: 자동 감지 로직 추가 (`shell-common/env/claude.sh`)
- `~/.dotfiles-setup-mode` 파일 읽어서 PC 타입 자동 감지
- Internal-PC (사내): `CLAUDE_ENABLED_ACCOUNTS=work` (work 계정만)
- External-PC (외부): `CLAUDE_ENABLED_ACCOUNTS=personal work work1` (모든 계정)
- 환경변수 override는 여전히 가능 (backward compatible)

### setup: 중복 로직 제거 (`shell-common/setup.sh`)
- `copy_local_files()`의 기존 claude.local.example auto-config 제거
- 이제 `claude.sh`의 자동 감지로 대체됨

### docs: 템플릿 및 가이드 개선
- `claude.local.example`: 새 자동 감지 동작 설명
- `claude/setup.sh`: Internal PC 설정 가이드 UX 개선

## 검증

- ✅ Worktree: `CLAUDE_ENABLED_ACCOUNTS="personal work work1"` (external 모드)
- ✅ Agent-toolbox: `CLAUDE_ENABLED_ACCOUNTS="personal work work1"` (동일)
- ✅ 모든 프로젝트에서 dotfiles 설정 자동 상속 확인

## 마이그레이션

기존 사용자는 추가 작업 없음. 다음 셸 재시작 시 자동으로 새 동작이 적용됩니다.

PC-specific override가 필요한 경우만 `shell-common/env/claude.local.sh` 생성:
\`\`\`bash
cp shell-common/env/claude.local.example shell-common/env/claude.local.sh
# 필요시 편집
\`\`\`