### PR TITLE
fix(claude): #598 remove model key from settings.json SSOT

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,7 +2,6 @@
   "env": {
     "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles"
   },
-  "model": "haiku",
   "statusLine": {
     "type": "command",
     "command": "${HOME}/dotfiles/claude/statusline-command.sh"


### PR DESCRIPTION
## Summary

- `claude/settings.json` SSOT (#584) 에서 `"model"` 키를 제거하여 매 세션 발생하던 phantom modification drift 를 차단.
- PC별 모델 강제는 기존 `claude/settings.local.json` (gitignored) 채널을 그대로 사용 — Claude Code 의 native deep merge.

## Changes

- `claude/settings.json`: `"model": "haiku"` 한 줄 삭제. 그 외 키 순서·내용 변화 없음. 결과 diff = exactly 1 line deletion.

## Test plan

- [ ] 머지 후 `git pull` → `git status` 깨끗 (`claude/settings.json` 미표시).
- [ ] Claude Code 세션 진입 + `/model` default 선택 → working-tree 여전히 깨끗 유지.
- [ ] `/model haiku` 등 명시 선택 시 의도된 mutation 으로 정상 표시 (expected drift, user action).
- [ ] `claude/settings.local.json` 에 `"model": "haiku"` 추가 → Claude Code 가 deep merge 로 정상 적용 (base 의 `hooks`/`env`/`statusLine`/`enabledPlugins` 영향 없음).

## Related

Closes #598

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
