### PR TITLE
fix(claude): force setup-mode defaults to overwrite stale env

### DIFF
--- a/shell-common/env/claude.sh
+++ b/shell-common/env/claude.sh
@@ -23,17 +23,20 @@ export CLAUDE_SKILLS_PATH="${DOTFILES_ROOT}/claude/skills"
 
 # Auto-detect setup mode (internal vs external) for account defaults.
 # Internal-PC (사내): work account only. External-PC: personal + work + work1.
+#
+# Unconditional assignment: setup-mode is the single source of truth, so
+# we overwrite any stale value inherited from a prior shell-init cycle.
+# Per-PC overrides happen below via claude.local.sh, which is sourced
+# AFTER this block and can freely reassign these vars.
 _claude_setup_mode="$(cat "$HOME/.dotfiles-setup-mode" 2>/dev/null)"
 case "$_claude_setup_mode" in
     internal|2)
-        # Internal-PC mode: work계정만 활성화
-        export CLAUDE_DEFAULT_ACCOUNT="${CLAUDE_DEFAULT_ACCOUNT:-work}"
-        export CLAUDE_ENABLED_ACCOUNTS="${CLAUDE_ENABLED_ACCOUNTS:-work}"
+        export CLAUDE_DEFAULT_ACCOUNT="work"
+        export CLAUDE_ENABLED_ACCOUNTS="work"
         ;;
     *)
-        # External-PC (personal, home, etc): 모든 계정 활성화
-        export CLAUDE_DEFAULT_ACCOUNT="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
-        export CLAUDE_ENABLED_ACCOUNTS="${CLAUDE_ENABLED_ACCOUNTS:-personal work work1}"
+        export CLAUDE_DEFAULT_ACCOUNT="personal"
+        export CLAUDE_ENABLED_ACCOUNTS="personal work work1"
         ;;
 esac
 unset _claude_setup_mode

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -90,13 +90,13 @@ LOCAL
 @test "bash: resolve --list-all returns same as --list (deprecated alias, issue #568)" {
     run_in_bash '_claude_resolve_account --list-all | tr "\n" " "'
     assert_success
-    assert_output "personal work "
+    assert_output "personal work work1 "
 }
 
 @test "bash: resolve --list returns ENABLED accounts only (default)" {
     run_in_bash '_claude_resolve_account --list | tr "\n" " "'
     assert_success
-    assert_output "personal work "
+    assert_output "personal work work1 "
 }
 
 @test "bash: resolve --list filters by CLAUDE_ENABLED_ACCOUNTS=work" {
@@ -108,7 +108,7 @@ LOCAL
 @test "zsh: resolve --list works under zsh (POSIX parity smoke test)" {
     run_in_zsh '_claude_resolve_account --list | tr "\n" " "'
     assert_success
-    assert_output "personal work "
+    assert_output "personal work work1 "
 }
 
 # ---------- issue #568: convention-based dispatcher ----------
@@ -532,7 +532,7 @@ JSON
 @test "bash: claude-accounts list shows enabled accounts" {
     run_in_bash 'shopt -s expand_aliases; eval "claude-accounts list" | tr "\n" " "'
     assert_success
-    assert_output "personal work "
+    assert_output "personal work work1 "
 }
 
 @test "bash: claude-accounts (no arg) defaults to status" {

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -20,10 +20,10 @@ teardown() {
     assert_output "personal"
 }
 
-@test "bash: CLAUDE_ENABLED_ACCOUNTS defaults to 'personal work'" {
+@test "bash: CLAUDE_ENABLED_ACCOUNTS defaults to 'personal work work1' (external mode)" {
     run_in_bash 'echo "$CLAUDE_ENABLED_ACCOUNTS"'
     assert_success
-    assert_output "personal work"
+    assert_output "personal work work1"
 }
 
 @test "zsh: CLAUDE_DEFAULT_ACCOUNT defaults to personal" {
@@ -32,10 +32,25 @@ teardown() {
     assert_output "personal"
 }
 
-@test "zsh: CLAUDE_ENABLED_ACCOUNTS defaults to 'personal work'" {
+@test "zsh: CLAUDE_ENABLED_ACCOUNTS defaults to 'personal work work1' (external mode)" {
     run_in_zsh 'echo "$CLAUDE_ENABLED_ACCOUNTS"'
     assert_success
-    assert_output "personal work"
+    assert_output "personal work work1"
+}
+
+@test "bash: internal setup-mode → CLAUDE_ENABLED_ACCOUNTS='work'" {
+    echo "internal" > "$HOME/.dotfiles-setup-mode"
+    run_in_bash 'echo "$CLAUDE_DEFAULT_ACCOUNT|$CLAUDE_ENABLED_ACCOUNTS"'
+    assert_success
+    assert_output "work|work"
+}
+
+@test "bash: stale CLAUDE_ENABLED_ACCOUNTS is overwritten by setup-mode default" {
+    # Regression for the d36ac3a stale-env trap: ${VAR:-default} preserved
+    # a previously-exported value across shell re-init. Setup-mode must win.
+    run_in_bash 'export CLAUDE_ENABLED_ACCOUNTS="stale leftover"; source "${DOTFILES_ROOT}/shell-common/env/claude.sh"; echo "$CLAUDE_ENABLED_ACCOUNTS"'
+    assert_success
+    assert_output "personal work work1"
 }
 
 @test "bash: claude.local.sh exports win over claude.sh defaults" {


### PR DESCRIPTION
## 요약

- d36ac3a 의 자동 감지 분기가 `${VAR:-default}` 패턴을 써서, 이전 셸-init 사이클에서 export 됐던 stale `CLAUDE_ENABLED_ACCOUNTS` 가 새 기본값을 덮지 못하던 함정 수정.
- External-PC 에서 d36ac3a 이전(`personal work` 기본값) 으로 한 번 source 된 셸이 셸 완전 재시작 없이는 `work1` 을 활성화하지 못하던 회귀 해결.
- setup-mode 를 단일 진실 소스로 두고 무조건 export, override 책임은 그 뒤에 source 되는 `claude.local.sh` 에 일임.

## Changes

- `shell-common/env/claude.sh`: `internal|2` / `*` 두 분기 모두 `${VAR:-default}` 제거 → setup-mode 기반 무조건 할당. 주석에 "setup-mode is SSOT, claude.local.sh overrides after" 의도 명시.
- `tests/bats/integrations/claude_accounts.bats`:
  - 기본값 `"personal work"` 을 expect 하던 두 케이스 (bash/zsh) 를 새 기본값 `"personal work work1"` 으로 갱신 — d36ac3a 가 같이 갱신했어야 했지만 누락됐던 부분.
  - 회귀 케이스 두 개 추가: `internal` setup-mode → `"work"`, stale 값 export 된 상태에서 재-source → 새 기본값으로 덮어써짐.

## Test plan

- [x] 깨끗한 셸 + `setup-mode=external` → `CLAUDE_ENABLED_ACCOUNTS=personal work work1` (시뮬레이션 검증)
- [x] 깨끗한 셸 + `setup-mode=internal` → `CLAUDE_ENABLED_ACCOUNTS=work` (시뮬레이션 검증)
- [x] stale `CLAUDE_ENABLED_ACCOUNTS="stale leftover"` export 후 재-source → `personal work work1` 로 덮어써짐 (시뮬레이션 검증)
- [x] `claude.local.sh` 가 export override 지정 시 그 값이 최종 (시뮬레이션 검증)
- [x] `shellcheck shell-common/env/claude.sh` exit 0
- [ ] 머지 후 `~/dotfiles` 동기화된 셸에서 `claude-accounts list` → `personal` / `work` / `work1`
- [ ] CI: `tests/bats/integrations/claude_accounts.bats` 신규 케이스 포함 전체 통과

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
