### PR TITLE
chore(lint): mdlint 전체 제거 (tox / CI / docs / lint guard)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,3 @@ jobs:
           else
             echo "shellcheck not available, skipping"
           fi
-
-      - name: Check markdown
-        run: |
-          if command -v markdownlint >/dev/null 2>&1; then
-            echo "Running markdownlint..."
-            markdownlint tests/README.md docs/abc-review-C.md || true
-          else
-            echo "markdownlint not available, skipping"
-          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,6 @@ All managed by `shell-common/setup.sh` (environment menu: public / internal / ex
 - **Linting (All)**: `tox` (Runs ruff, mypy, shellcheck, shfmt).
 - **Linting (Python)**: `tox -e ruff` (fixes), `tox -e mypy`.
 - **Linting (Bash)**: `tox -e shellcheck`, `tox -e shfmt` (formats).
-- **Note**: Markdown linting (mdlint) is DISABLED. Do NOT perform markdown lint checks automatically.
 - **Testing**: `./tests/test`, `pytest tests/`, manual validation via `shell-common/tools/custom/demo_ux.sh`.
 
 # Golden Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,6 @@ pytest tests/integration/test_help_topics.py -v  # Single pytest file
 shell-common/tools/custom/demo_ux.sh
 ```
 
-Markdown linting (`tox -e mdlint`) is **disabled** — do not run it.
-
 ## Architecture
 
 This repo is a modular dotfiles system. Shell config is split into three layers:

--- a/claude/skills/gh-issue-create/references/templates/chore.md
+++ b/claude/skills/gh-issue-create/references/templates/chore.md
@@ -10,7 +10,7 @@
 chore[(<scope>)]: <한 줄 요약>
 ```
 
-예) `chore(tox): mdlint envlist 비활성화`
+예) `chore(deps): pylint 3.3.x 핀 업데이트`
 
 ## 본문 골격
 

--- a/claude/skills/gh-pr/references/lint-guard.md
+++ b/claude/skills/gh-pr/references/lint-guard.md
@@ -32,9 +32,9 @@ _gh_pr_lint_run "$BASE_BRANCH" || {
 The guard picks tools in this order, top-down:
 
 1. **tox** — `tox.ini` exists and declares at least one of these envs:
-   `[testenv:ruff]`, `[testenv:mdlint]`, `[testenv:shellcheck]`,
-   `[testenv:shfmt]`, `[testenv:actionlint]`. Runs `tox -e <list>` with
-   only the envs that are actually declared.
+   `[testenv:ruff]`, `[testenv:shellcheck]`, `[testenv:shfmt]`,
+   `[testenv:actionlint]`. Runs `tox -e <list>` with only the envs that
+   are actually declared.
 2. **shellcheck** — `command -v shellcheck` succeeds **and** the changed
    file set contains at least one `*.sh`. Runs
    `shellcheck -x -S warning <changed-sh-files>`.

--- a/shell-common/functions/gh_pr_lint.sh
+++ b/shell-common/functions/gh_pr_lint.sh
@@ -31,15 +31,15 @@ _gh_pr_lint__log() {
 _gh_pr_lint__has_tox_envs() {
     # tox.ini exists AND declares at least one of the lint envs we recognise.
     [ -f tox.ini ] || return 1
-    grep -qE '^\[testenv:(ruff|mdlint|shellcheck|shfmt|actionlint)\]' tox.ini
+    grep -qE '^\[testenv:(ruff|shellcheck|shfmt|actionlint)\]' tox.ini
 }
 
 _gh_pr_lint__tox_env_list() {
     # Print a comma-separated list of declared lint envs in tox.ini, in
-    # priority order (ruff, mdlint, shellcheck, shfmt, actionlint).
+    # priority order (ruff, shellcheck, shfmt, actionlint).
     [ -f tox.ini ] || return 0
     _envs=""
-    for _e in ruff mdlint shellcheck shfmt actionlint; do
+    for _e in ruff shellcheck shfmt actionlint; do
         if grep -qE "^\[testenv:$_e\]" tox.ini; then
             _envs="${_envs:+$_envs,}$_e"
         fi

--- a/tools/dev.sh
+++ b/tools/dev.sh
@@ -156,17 +156,6 @@ case "$cmd" in
     fi
     ;;
 
-  mdlint)
-    echo "Running markdown linter (tox -e mdlint)..."
-    if command -v tox >/dev/null 2>&1; then
-      tox -e mdlint "${@:2}"
-      EXIT_CODE=$?
-    else
-      echo "ERROR: tox not found. Install: uv pip install tox"
-      EXIT_CODE=1
-    fi
-    ;;
-
   lint-helpfunc)
     echo "Checking help function integrity (*help)..."
     echo ""
@@ -220,8 +209,7 @@ Usage: ./tools/dev.sh <command>
 Commands:
   test            Run test suite (tests/test)
   format          Format and lint Python code (tox -e ruff)
-  lint            Run linters (ruff, mypy, shellcheck) - excludes markdown
-  mdlint          Run markdown linter separately (tox -e mdlint)
+  lint            Run linters (ruff, mypy, shellcheck, shfmt)
   lint-helpfunc   Check help functions are registered in HELP_DESCRIPTIONS
   lint-deadcode   Check for unused internal functions (_*) in shell-common/functions
   setup           Run setup script (symlinks only)
@@ -234,7 +222,6 @@ Examples:
   ./tools/dev.sh test -k test_bash
   ./tools/dev.sh format
   ./tools/dev.sh lint
-  ./tools/dev.sh mdlint
   ./tools/dev.sh lint-helpfunc
   ./tools/dev.sh lint-deadcode
   ./tools/dev.sh setup

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # tox.ini: Python 프로젝트의 테스트 및 코드 품질 검사를 위한 Tox 설정 파일
 
 [tox]
-envlist = ruff, mypy, mdlint, shellcheck, shfmt
+envlist = ruff, mypy, shellcheck, shfmt
 # 프로젝트를 설치 가능한 배포판(sdist/bdist)으로 빌드하는 것을 건너뜁니다.
 skipsdist = true
 # 시스템에 없는 파이썬 인터프리터를 건너뜁니다.
@@ -18,7 +18,6 @@ passenv = PATH
 allowlist_externals =
     pylint
     mypy
-    markdownlint
     pylint-exit
     pytest
     shellcheck
@@ -73,13 +72,6 @@ commands = black {env:target_dir}
 description = Run mypy type checker
 deps = .[dev]
 commands = mypy {env:target_dir}
-
-
-[testenv:mdlint]
-description = Run markdownlint to check markdown files
-skip_install = true
-allowlist_externals = markdownlint
-commands = markdownlint {env:target_dir}/**/*.md
 
 
 [testenv:shellcheck]


### PR DESCRIPTION
## Summary
- mdlint(markdownlint) 검사를 더 이상 사용하지 않기로 결론 → 레포 전체에서 흔적 제거
- disable 마커가 아니라 설정 자체를 삭제 — `gh_pr_lint.sh` 가 `tox.ini` 의 `[testenv:mdlint]` 를 자동 감지해 PR 가드를 막던 #598 마찰 해소
- 영향 범위: `tox` envlist, CI workflow, dev 스크립트, docs, lint guard, 관련 skill 참조

## Changes
- `tox.ini`: envlist / allowlist_externals / `[testenv:mdlint]` 블록 제거
- `CLAUDE.md` / `AGENTS.md`: "mdlint disabled" 안내 줄 삭제
- `tools/dev.sh`: `mdlint)` case / usage / 예시 삭제
- `.github/workflows/test.yml`: `markdownlint` 자동 실행 블록 삭제
- `shell-common/functions/gh_pr_lint.sh`: 정규식 / 주석 / loop 의 `mdlint` 토큰 제거
- `claude/skills/gh-pr/references/lint-guard.md`: env 후보에서 `[testenv:mdlint]` 제거
- `claude/skills/gh-issue-create/references/templates/chore.md`: 옛 예시 교체

## Test plan
- [x] `tox -l` 출력에 `mdlint` 미포함 확인
- [x] `tox -e shellcheck,shfmt-check` 통과 (lint guard tox run 도 ruff/shellcheck/shfmt 통과)
- [x] `bash tools/dev.sh` usage 에 `mdlint` 미노출
- [x] 레포 전체 `mdlint|markdownlint` grep 0 매치 (vendored `tests/bats/lib/` 제외)
- [ ] CI Test Suite 그린 확인 (post-push)

## Related
Closes #600

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~0.5 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~0.5 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
