### PR TITLE
feat(gwt): #605 activate help entry points + disambiguate remove/prune

### DIFF
--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -76,7 +76,7 @@ _<prefix>_<verb2>() {
         <verb>)   shift; _<prefix>_<verb> "$@" ;;
         <verb2>)  shift; _<prefix>_<verb2> "$@" ;;
         -h|--help|help|"")
-            shift 2>/dev/null || true
+            [ $# -gt 0 ] && shift
             <topic>_help "$@"   # standalone help, also reachable via <alias>-help
             ;;
         *)
@@ -108,7 +108,7 @@ gwt() {
         spawn)    shift; git_worktree_spawn "$@" ;;
         teardown) shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
-            shift 2>/dev/null || true
+            [ $# -gt 0 ] && shift
             gwt_help "$@" ;;
         *)
             ux_error "Unknown command: $1"

--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -76,13 +76,12 @@ _<prefix>_<verb2>() {
         <verb>)   shift; _<prefix>_<verb> "$@" ;;
         <verb2>)  shift; _<prefix>_<verb2> "$@" ;;
         -h|--help|help|"")
-            ux_error "Usage: <alias> <command> [args...]"
-            ux_info "Run: <alias>-help"
-            return 1
+            shift 2>/dev/null || true
+            <topic>_help "$@"   # standalone help, also reachable via <alias>-help
             ;;
         *)
             ux_error "Unknown command: $1"
-            ux_info "Run: <alias>-help"
+            ux_info "Run: <alias> help"
             return 1
             ;;
     esac
@@ -90,6 +89,12 @@ _<prefix>_<verb2>() {
 
 alias <alias>='<topic>'
 ```
+
+`-h|--help|help|""` invokes `<topic>_help` directly (no `return 1`) so users
+discover help through the natural entry point (`gwt`, `gwt -h`, `gwt help
+spawn`) instead of being told to learn a separate `<alias>-help` form. Passing
+`"$@"` forwards a section name (`<alias> help spawn` → `<topic>_help spawn`).
+The `<alias>-help` alias is preserved as a backward-compatible shortcut.
 
 ### 참조 구현: `gwt`
 
@@ -103,12 +108,11 @@ gwt() {
         spawn)    shift; git_worktree_spawn "$@" ;;
         teardown) shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
-            ux_error "Usage: gwt <command> [args...]"
-            ux_info "Run: gwt-help"
-            return 1 ;;
+            shift 2>/dev/null || true
+            gwt_help "$@" ;;
         *)
             ux_error "Unknown command: $1"
-            ux_info "Run: gwt-help"
+            ux_info "Run: gwt help"
             return 1 ;;
     esac
 }
@@ -203,6 +207,8 @@ alias gb='git_branch'
 | Standalone help (`<topic>_help` + `<topic>-help`) | Type 2A, 또는 sub-command 수 4개 이상 | 별도 `*_help.sh` 파일 |
 
 [`command-guidelines.md`](./command-guidelines.md)의 help 표준(15줄 이내, `ux_bullet`/`ux_bullet_sub`, `--all`/`<section>` 분리)은 standalone help에 완전 적용된다.
+
+Type 2A 의 `-h|--help|help|""` 케이스는 `<topic>_help "$@"` 를 직접 호출한다. `<alias>-help` alias 는 backward-compat 단축형으로 동시 제공한다 (예: `gwt help spawn` ≡ `gwt-help spawn`).
 
 ## 8. Deprecated Alias 전략
 

--- a/docs/.ssot/command-guidelines.md
+++ b/docs/.ssot/command-guidelines.md
@@ -66,8 +66,8 @@
 
 `gwt` 같은 멀티 커맨드 함수의 dispatcher 구조 자체는 [`command-design-pattern.md`](./command-design-pattern.md) §4–§7가 정의한다. 이 문서는 그 위에서 help 출력 규칙만 다룬다:
 
-- 사용자 안내는 `gwt-help [section]`을 canonical로 사용한다.
-- 구형 help 진입점(예: `gwt help`, `gwt spawn help`) 유지 여부는 명시적으로 결정하고 테스트로 고정한다.
+- 사용자 안내는 `gwt help [section]`을 canonical로 사용하고, `gwt-help` alias 는 backward-compat 단축형으로 동등 제공한다.
+- `<alias> -h|--help|help|""` 는 canonical `<topic>-help` 와 동등한 진입점이며 두 형태 모두 테스트로 고정한다 (예: `gwt`, `gwt -h`, `gwt --help`, `gwt help`, `gwt help <section>`).
 
 ## 테스트 체크리스트
 

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -13,16 +13,16 @@ unalias gwt 2>/dev/null || true
 # Usage: gwt-help [section]
 # ============================================================================
 _gwt_help_summary() {
-    ux_info "Usage: gwt-help [section|--list|--all]"
+    ux_info "Usage: gwt help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "add: gwt add <path> [branch] [start]"
-    ux_bullet_sub "list: gwt list | gwt ls [--quick|--remote]"
-    ux_bullet_sub "remove: gwt remove <path|agent|all> [--force]"
-    ux_bullet_sub "prune: gwt prune"
-    ux_bullet_sub "spawn: gwt spawn <name> [--task slug] [--base ref] [--tmux|--launch] [--user account]"
-    ux_bullet_sub "status: gwt status [<name>]"
-    ux_bullet_sub "teardown: gwt teardown [--force] [--keep-branch]"
-    ux_bullet_sub "details: gwt-help <section> (example: gwt-help spawn)"
+    ux_bullet_sub "add      gwt add <path> [branch] [start]              create worktree"
+    ux_bullet_sub "list     gwt list|ls [--quick|--remote]               list worktrees"
+    ux_bullet_sub "remove   gwt remove <path|name|all> [--force]         delete worktree dir + branch"
+    ux_bullet_sub "prune    gwt prune                                    clean stale .git/worktrees/ refs (no path)"
+    ux_bullet_sub "spawn    gwt spawn <name> [--task|--base|--tmux|...]  create named worktree (AI workflow)"
+    ux_bullet_sub "status   gwt status [<name>]                          per-worktree diagnostic"
+    ux_bullet_sub "teardown gwt teardown [--force] [--keep-branch]       cleanup current/all worktree(s)"
+    ux_bullet_sub "details  gwt help <section> (example: gwt help spawn)"
 }
 
 _gwt_help_list_sections() {
@@ -46,7 +46,7 @@ _gwt_help_rows_list() {
     ux_table_row "default" "PATH/BRANCH/STATE/AGE/NEXT columns" "Local signals (no network)"
     ux_table_row "--quick" "path/commit/branch only" "Legacy output"
     ux_table_row "--remote" "Adds PR state via batched gh CLI call" "One network call regardless of N"
-    ux_table_row "states" "dirty/ahead/pr-open/pr-merged/merged/..." "See 'gwt-help status' for full list"
+    ux_table_row "states" "dirty/ahead/pr-open/pr-merged/merged/..." "See 'gwt help status' for full list"
 }
 
 _gwt_help_rows_status() {
@@ -117,8 +117,8 @@ _gwt_help_section_rows() {
             _gwt_help_rows_teardown
             ;;
         *)
-            ux_error "Unknown gwt-help section: $1"
-            ux_info "Try: gwt-help --list"
+            ux_error "Unknown gwt help section: $1"
+            ux_info "Try: gwt help --list"
             return 1
             ;;
     esac
@@ -159,21 +159,20 @@ gwt_help() {
 # ============================================================================
 gwt() {
     case "${1:-}" in
-        add)      shift; git_worktree_add "$@" ;;
-        list|ls)  shift; git_worktree_list "$@" ;;
+        add)       shift; git_worktree_add "$@" ;;
+        list|ls)   shift; git_worktree_list "$@" ;;
         remove|rm) shift; git_worktree_remove "$@" ;;
-        prune)    shift; git_worktree_prune "$@" ;;
-        spawn)    shift; git_worktree_spawn "$@" ;;
-        status)   shift; git_worktree_status "$@" ;;
-        teardown) shift; git_worktree_teardown "$@" ;;
+        prune)     shift; git_worktree_prune "$@" ;;
+        spawn)     shift; git_worktree_spawn "$@" ;;
+        status)    shift; git_worktree_status "$@" ;;
+        teardown)  shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
-            ux_error "Usage: gwt <command> [args...]"
-            ux_info "Run: gwt-help"
-            return 1
+            shift 2>/dev/null || true
+            gwt_help "$@"
             ;;
         *)
             ux_error "Unknown command: $1"
-            ux_info "Run: gwt-help"
+            ux_info "Run: gwt help"
             return 1
             ;;
     esac
@@ -1058,11 +1057,11 @@ git_worktree_prune() {
             -h|--help)
                 ux_header "gwt prune - remove stale worktree refs"
                 ux_info "Usage: gwt prune [-n|--dry-run] [-v|--verbose] [--expire <when>]"
-                ux_info "  Removes .git/worktrees/<name>/ entries whose path is missing."
-                ux_info "  Does NOT take a path argument."
-                ux_info "  Targeted removal:"
-                ux_bullet "gwt remove <path>      # remove a specific worktree"
-                ux_bullet "gwt teardown           # remove the worktree you're inside"
+                ux_info "  Touches .git/worktrees/ metadata ONLY (no path argument)."
+                ux_info "  Removes admin-dir entries whose worktree dir is already gone."
+                ux_info "  To delete an actual worktree dir + branch, use:"
+                ux_bullet "gwt remove <path|name>  # remove a specific worktree"
+                ux_bullet "gwt teardown            # remove the worktree you're inside"
                 return 0
                 ;;
             -n|--dry-run|-v|--verbose) ;;
@@ -1106,6 +1105,10 @@ git_worktree_remove() {
             ux_info "             removes ALL worktrees matching *-<name>-*"
             ux_info "  all        remove ALL non-main worktrees"
             ux_info "  --force    force remove + force delete unmerged branch"
+            ux_info ""
+            ux_info "  Deletes the actual worktree directory + branch."
+            ux_info "  To clean stale .git/worktrees/ registry entries (when the"
+            ux_info "  directory was already deleted), use: gwt prune"
             return 0
             ;;
         "")
@@ -1117,6 +1120,19 @@ git_worktree_remove() {
     local target="$1"
     local force=false
     [ "${2:-}" = "--force" ] && force=true
+
+    # First arg is a flag (e.g. `gwt remove --force`) — user forgot the path/name.
+    # Without this guard, `--force` would be misinterpreted as a worktree name
+    # and yield a confusing "No worktree found: --force" error.
+    case "$target" in
+        -*)
+            ux_error "Missing <path|name|all>. Got flag: $target"
+            ux_info "Did you mean:"
+            ux_bullet "gwt remove all $target          # apply '$target' to all worktrees"
+            ux_bullet "gwt remove <path|name> $target  # apply '$target' to a specific one"
+            return 1
+            ;;
+    esac
 
     # "all" — remove every non-main worktree
     if [ "$target" = "all" ]; then

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -167,7 +167,7 @@ gwt() {
         status)    shift; git_worktree_status "$@" ;;
         teardown)  shift; git_worktree_teardown "$@" ;;
         -h|--help|help|"")
-            shift 2>/dev/null || true
+            [ $# -gt 0 ] && shift
             gwt_help "$@"
             ;;
         *)
@@ -1130,6 +1130,14 @@ git_worktree_remove() {
             ux_info "Did you mean:"
             ux_bullet "gwt remove all $target          # apply '$target' to all worktrees"
             ux_bullet "gwt remove <path|name> $target  # apply '$target' to a specific one"
+            return 1
+            ;;
+        *[*?]*)
+            # Wildcards in `target` are confusing UX even when quoted-glob rules
+            # render them inert in the for-loop below — refuse explicitly and
+            # point the user at the canonical batch entry point.
+            ux_error "Wildcards ('*', '?') are not allowed in target: $target"
+            ux_info "Use 'gwt remove all' for batch removal."
             return 1
             ;;
     esac

--- a/tests/bats/functions/git_worktree_help.bats
+++ b/tests/bats/functions/git_worktree_help.bats
@@ -120,6 +120,22 @@ teardown() {
     assert_output --partial "gwt remove <path|name> --force"
 }
 
+@test "remove: wildcard '*' in target is refused (defense-in-depth, gemini #606)" {
+    # Even though the for-loop uses quoted globbing that renders '*' inert
+    # in practice, accepting wildcards is confusing UX. Reject explicitly
+    # and direct the user at the canonical batch entry point.
+    run_in_bash "gwt remove '*' 2>&1"
+    assert_failure
+    assert_output --partial "Wildcards"
+    assert_output --partial "gwt remove all"
+}
+
+@test "remove: wildcard '?' in target is refused" {
+    run_in_bash "gwt remove 'a?b' 2>&1"
+    assert_failure
+    assert_output --partial "Wildcards"
+}
+
 # ---------------------------------------------------------------------------
 # Backward compatibility: gwt-help alias still defined
 #

--- a/tests/bats/functions/git_worktree_help.bats
+++ b/tests/bats/functions/git_worktree_help.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_worktree_help.bats
+# Tests for issue #605 — gwt help entry-point activation + remove/prune
+# disambiguation.
+#
+# Behavior under test:
+#   - `gwt`, `gwt -h`, `gwt --help`, `gwt help` all show the standalone help
+#     instead of an error + hint (previous behavior returned 1).
+#   - `gwt help <section>` forwards to `gwt_help <section>` and shows the
+#     section detail (equivalent to `gwt-help <section>`).
+#   - The summary distinguishes `remove` (deletes worktree dir + branch)
+#     from `prune` (cleans stale .git/worktrees/ entries only).
+#   - `gwt remove -h` and `gwt prune -h` cross-reference each other.
+#   - `gwt remove --force` (path/name omitted) shows a clear
+#     "Missing <path|name|all>" error instead of misinterpreting `--force`
+#     as a worktree name.
+#   - `gwt-help` alias still works (backward compat).
+#   - Unknown command hint points to `gwt help` (not legacy `gwt-help`).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Help entry points: gwt / gwt -h / gwt --help / gwt help
+# ---------------------------------------------------------------------------
+
+@test "help: bare 'gwt' invocation shows help (no error)" {
+    run_in_bash "gwt"
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}
+
+@test "help: 'gwt -h' shows help" {
+    run_in_bash "gwt -h"
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}
+
+@test "help: 'gwt --help' shows help" {
+    run_in_bash "gwt --help"
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}
+
+@test "help: 'gwt help' shows help" {
+    run_in_bash "gwt help"
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}
+
+@test "help: 'gwt help <section>' shows section detail" {
+    run_in_bash "gwt help spawn"
+    assert_success
+    assert_output --partial "spawn"
+}
+
+@test "help: 'gwt help --list' lists sections" {
+    run_in_bash "gwt help --list"
+    assert_success
+    assert_output --partial "spawn"
+    assert_output --partial "teardown"
+}
+
+# ---------------------------------------------------------------------------
+# Summary disambiguates remove vs prune
+# ---------------------------------------------------------------------------
+
+@test "help: summary says remove deletes worktree dir + branch" {
+    run_in_bash "gwt help"
+    assert_success
+    assert_output --partial "remove"
+    assert_output --partial "delete worktree dir + branch"
+}
+
+@test "help: summary says prune cleans stale .git/worktrees/ refs" {
+    run_in_bash "gwt help"
+    assert_success
+    assert_output --partial "prune"
+    assert_output --partial "stale .git/worktrees/ refs"
+}
+
+# ---------------------------------------------------------------------------
+# remove/prune -h cross-references
+# ---------------------------------------------------------------------------
+
+@test "help: 'gwt remove -h' cross-references gwt prune" {
+    run_in_bash "gwt remove -h"
+    assert_success
+    assert_output --partial "gwt prune"
+}
+
+@test "help: 'gwt prune -h' cross-references gwt remove" {
+    run_in_bash "gwt prune -h"
+    assert_success
+    assert_output --partial "gwt remove"
+}
+
+# ---------------------------------------------------------------------------
+# 'gwt remove --force' (flag as first arg) — error message clarity
+# ---------------------------------------------------------------------------
+
+@test "remove: flag as first arg shows Missing <path|name|all> error" {
+    run_in_bash "gwt remove --force 2>&1"
+    assert_failure
+    assert_output --partial "Missing <path|name|all>"
+    refute_output --partial "No worktree found: --force"
+}
+
+@test "remove: flag as first arg suggests corrective forms" {
+    run_in_bash "gwt remove --force 2>&1"
+    assert_failure
+    assert_output --partial "gwt remove all --force"
+    assert_output --partial "gwt remove <path|name> --force"
+}
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: gwt-help alias still defined
+#
+# bash `--noprofile --norc -c` runs non-interactively and parses the entire
+# `-c` string with alias expansion off, so we cannot invoke `gwt-help`
+# directly in this harness — we verify the alias is defined and that the
+# function it points at (`gwt_help`) is reachable. In actual user-
+# interactive bash, `expand_aliases` is on and `gwt-help` works as before.
+# ---------------------------------------------------------------------------
+
+@test "compat: 'gwt-help' alias is defined" {
+    run_in_bash "alias gwt-help"
+    assert_success
+    assert_output --partial "gwt_help"
+}
+
+@test "compat: gwt_help function is reachable in bash" {
+    run_in_bash "gwt_help"
+    assert_success
+    assert_output --partial "sections"
+}
+
+@test "compat: gwt_help function accepts section arg in bash" {
+    run_in_bash "gwt_help spawn"
+    assert_success
+    assert_output --partial "spawn"
+}
+
+# ---------------------------------------------------------------------------
+# Unknown command hint
+# ---------------------------------------------------------------------------
+
+@test "dispatch: unknown command hint points to 'gwt help'" {
+    run_in_bash "gwt bogus 2>&1"
+    assert_failure
+    assert_output --partial "Unknown command: bogus"
+    assert_output --partial "Run: gwt help"
+}
+
+# ---------------------------------------------------------------------------
+# Same behavior under zsh
+# ---------------------------------------------------------------------------
+
+@test "zsh: bare 'gwt' shows help" {
+    run_in_zsh "gwt"
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}
+
+@test "zsh: 'gwt help spawn' shows section detail" {
+    run_in_zsh "gwt help spawn"
+    assert_success
+    assert_output --partial "spawn"
+}
+
+@test "zsh: 'gwt remove --force' shows missing-path error" {
+    run_in_zsh "gwt remove --force 2>&1"
+    assert_failure
+    assert_output --partial "Missing <path|name|all>"
+}
+
+@test "zsh: 'gwt-help' alias still works" {
+    run_in_zsh "gwt-help"
+    assert_success
+    assert_output --partial "sections"
+}


### PR DESCRIPTION
## Summary

- `gwt -h` / `gwt --help` / `gwt help` / `gwt` (인자 없음) 이 **에러 + hint** 대신 `gwt_help` 를 직접 호출 — `gwt-help` 라는 별도 진입점을 새로 학습할 필요 없음.
- `gwt help <section>` (예: `gwt help spawn`) 으로 섹션별 상세도 진입 가능 (`gwt-help <section>` 과 동치).
- `gwt-help` summary 한 줄당 "무엇을 지우는지" 명시 → `remove` (worktree 디렉터리+브랜치 삭제) ↔ `prune` (`.git/worktrees/` admin-dir 의 stale 엔트리만 청소) 혼동 제거.
- `gwt remove --force` (경로 없이) 호출 시 `--force` 를 worktree name 으로 해석하던 혼란스러운 에러를 `Missing <path|name|all>` 안내로 교체.
- SSOT 2종 (`command-design-pattern.md`, `command-guidelines.md`) 을 같이 갱신해 Type 2A dispatcher 의 `-h|--help|help|""` 처리 방식이 표준으로 박힘.

## Changes

- `shell-common/functions/git_worktree.sh`:
  - `gwt()` dispatcher: `-h|--help|help|""` → `gwt_help "$@"` 직접 호출. 인자 forwarding 으로 `gwt help spawn ≡ gwt_help spawn`.
  - `_gwt_help_summary`: column-aligned 테이블 + 각 sub-command 옆에 "무엇을 지우는지/만드는지" 한 줄 설명. `Usage:` 도 `gwt-help` → `gwt help` 로 변경 (canonical 우선 안내).
  - `git_worktree_remove`: `case "$target" in -*)` guard 추가 — 첫 인자가 flag 일 때 `Missing <path|name|all>. Got flag: $target` + 교정 제안 (`gwt remove all $target` / `gwt remove <path|name> $target`).
  - `gwt remove -h` / `gwt prune -h`: 상호 cross-reference 보강 (remove 의 `-h` 에 prune 으로 가는 경로, prune 의 `-h` 에 remove 로 가는 경로 추가).
  - Unknown command / unknown section 에러의 hint 도 `Run: gwt help` 로 통일 (alias `gwt-help` 자체는 backward-compat 으로 그대로 유지).
- `docs/.ssot/command-design-pattern.md`: §4 Type 2A 템플릿 (`-h|--help|help|""` → `<topic>_help "$@"` 호출) + 의도 설명 단락 + §7 끝에 "Type 2A 의 dual entry-point" 한 줄.
- `docs/.ssot/command-guidelines.md`: §"멀티 커맨드 함수형 CLI" 미결정 항목을 "`<alias> {-h, --help, help, ""}` 는 canonical `<topic>-help` 와 동등한 진입점이며 두 형태 모두 테스트로 고정한다" 로 확정.
- `tests/bats/functions/git_worktree_help.bats` (신규, 20 케이스):
  - 진입점 5종 (`gwt`, `gwt -h`, `gwt --help`, `gwt help`, `gwt help <section>`) — bash + zsh
  - summary 의 remove/prune disambiguation, 각 `-h` 의 cross-reference 검증
  - `gwt remove --force` flag-as-name guard (bash + zsh)
  - `gwt-help` alias backward-compat (alias 정의 + `gwt_help` 함수 도달 가능성, zsh 에서는 실제 호출)
  - 잘못된 sub-command → `Run: gwt help` 로 hint 가 바뀐 것 확인

## Test plan

- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_help.bats` — 20/20 pass
- [x] `tox -e ruff,shellcheck,shfmt` — all green (PR lint guard)
- [x] `pytest tests/integration/test_help_compact_policy.py -k gwt_help` — 60/60 pass (15-line policy + template + section equivalence 모두 통과)
- [x] 수동 smoke (격리 bash): `gwt`, `gwt -h`, `gwt --help`, `gwt help`, `gwt help spawn`, `gwt help --list`, `gwt remove -h`, `gwt prune -h`, `gwt remove --force`, `gwt-help` 모두 의도대로 동작
- [ ] CI 그린 확인 (post-push)

## Related

Closes #605

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~1.5 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~1.5 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
