### PR TITLE
fix(stop-guard): #607 recognize <command-name> wrapped slash command

### DIFF
--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -90,9 +90,15 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
 # read by the model) are layered separately in `_iter_text_blocks(...,
 # include_tool_results=False)`.
 _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
-    r"(?m)"
-    r"(?:^\s*/gh[-:]issue-flow\b"
-    r"|<command-name>\s*/gh[-:]issue-flow\s*</command-name>)"
+    r"""
+    (?m)                                                    # multiline: ^ matches each line start
+    (?:
+        ^\s*/gh[-:]issue-flow\b                             # raw slash command at line start
+        |
+        <command-name>\s*/gh[-:]issue-flow\s*</command-name>  # Claude Code wrapped form
+    )
+    """,
+    re.VERBOSE,
 )
 FLOW_SKILL_NAMES: set[str] = {"gh-issue-flow", "gh:issue-flow"}
 

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -67,11 +68,31 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
     "gh-issue-flow stopped at step",
 )
 
-# Tokens that mark the *start* of a gh-issue-flow chain. Either the user
-# typed `/gh-issue-flow ...` or the assistant invoked `Skill(gh-issue-flow)`.
-FLOW_START_TOKENS: tuple[str, ...] = (
-    "/gh-issue-flow",
-    "/gh:issue-flow",
+# Regex that marks the *start* of a gh-issue-flow chain in a user message.
+# Matches two real-world forms that user-typed slash commands take in Claude
+# Code transcripts (issues #607 / #609):
+#
+#   (a) Raw `/gh-issue-flow ...` (or colon form `/gh:issue-flow ...`) at the
+#       start of a line — historical fixture form, still valid for tests
+#       and for users who paste the command into a longer message.
+#   (b) The `<command-name>/gh-issue-flow</command-name>` (or colon form)
+#       wrapper that Claude Code emits when a user invokes the slash
+#       command interactively. The user message also contains
+#       `<command-message>` / `<command-args>` siblings, but matching the
+#       `<command-name>` tag alone is sufficient and the most stable
+#       anchor across CLI versions.
+#
+# The `(?m)^\s*` prefix on the raw branch restricts matching to line
+# starts so a mid-sentence mention like "I was reading about
+# /gh-issue-flow..." stays out — preserved from the prior
+# `lstrip().startswith()` behavior, now expressed per-line.
+# False-positive guards for `tool_result` payloads (e.g. SKILL.md being
+# read by the model) are layered separately in `_iter_text_blocks(...,
+# include_tool_results=False)`.
+_USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
+    r"(?m)"
+    r"(?:^\s*/gh[-:]issue-flow\b"
+    r"|<command-name>\s*/gh[-:]issue-flow\s*</command-name>)"
 )
 FLOW_SKILL_NAMES: set[str] = {"gh-issue-flow", "gh:issue-flow"}
 
@@ -182,9 +203,12 @@ def _find_flow_boundary(messages: list[dict[str, Any]]) -> int:
     Boundary signals (role-restricted to avoid false positives from file
     content read into tool_result blocks — see PR #386 review feedback):
       - assistant message: tool_use of Skill(gh-issue-flow | gh:issue-flow)
-      - user message: text content begins with /gh-issue-flow or /gh:issue-flow
-        (tool_result blocks excluded so a file mentioning the command does
-        not trip the boundary)
+      - user message: text content matches `_USER_BOUNDARY_RE`, which
+        recognizes both the raw `/gh-issue-flow ...` form (line start) and
+        the `<command-name>/gh-issue-flow</command-name>` wrapper Claude
+        Code emits when the user invokes the slash command interactively
+        (issues #607 / #609). `tool_result` blocks are excluded so a file
+        mentioning the command does not trip the boundary.
     """
     for i in range(len(messages) - 1, -1, -1):
         msg = _message_payload(messages[i])
@@ -195,10 +219,8 @@ def _find_flow_boundary(messages: list[dict[str, Any]]) -> int:
                     return i
         elif role == "user":
             for text in _iter_text_blocks(msg, include_tool_results=False):
-                stripped = text.lstrip()
-                for tok in FLOW_START_TOKENS:
-                    if stripped.startswith(tok):
-                        return i
+                if _USER_BOUNDARY_RE.search(text):
+                    return i
     return -1
 
 

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -516,3 +516,157 @@ def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None
     assert result.stdout.strip() == ""
     assert "Step 3 terminal marker" in result.stderr
     assert "sub_skills_seen=5/5" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Wrapped slash-command boundary (issues #607 / #609)
+#
+# When a user invokes `/gh-issue-flow N` interactively, Claude Code does not
+# place the raw command in the transcript. Instead it writes a multi-line
+# user message of the form:
+#
+#     <command-message>gh-issue-flow</command-message>
+#     <command-name>/gh-issue-flow</command-name>
+#     <command-args>N</command-args>
+#     Base directory for this skill: .../skills/gh-issue-flow
+#     # gh:issue-flow — Issue → PR composition
+#     ...(SKILL.md body)...
+#     ARGUMENTS: N
+#
+# The pre-#607 boundary detector used `lstrip().startswith("/gh-issue-flow")`,
+# which never matched this wrapped form — so every Stop event in a real
+# `/gh-issue-flow` session fell through to fail-open and the chain stopped
+# the moment the model emitted any prose between sub-skills. These fixtures
+# reproduce the actual transcript form and pin down the regression.
+# ---------------------------------------------------------------------------
+
+
+def _user_slash_command(skill_name: str, args: str) -> dict[str, Any]:
+    """Build a user message in the format Claude Code writes to transcripts.
+
+    Mirrors the `<command-message>/<command-name>/<command-args>` triple
+    plus the SKILL.md body that follows when the user invokes a slash
+    command interactively. The fixture reproduces enough of the real
+    transcript shape to drive boundary detection without bloating the
+    test payload with a full SKILL.md.
+    """
+    content = (
+        f"<command-message>{skill_name}</command-message>\n"
+        f"<command-name>/{skill_name}</command-name>\n"
+        f"<command-args>{args}</command-args>\n"
+        f"Base directory for this skill: /tmp/skills/{skill_name}\n"
+        f"# {skill_name}\n"
+        f"ARGUMENTS: {args}\n"
+    )
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
+def test_wrapped_slash_command_recognized_as_flow_start(tmp_path: Path) -> None:
+    """`<command-name>/gh-issue-flow</command-name>` must mark a boundary."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_slash_command("gh-issue-flow", "457"),
+            _assistant_skill("gh-issue-implement", "457 direct origin --no-next-hint"),
+            _assistant_text("gh:issue-implement #457 complete\n  Tests: 12 passed"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        "Hook must recognize the <command-name>/gh-issue-flow</command-name> "
+        f"wrapped form as a flow boundary. stdout={result.stdout!r}"
+    )
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-commit" in decision["reason"]
+    assert "Step 2.2" in decision["reason"]
+
+
+def test_wrapped_slash_command_colon_namespace_recognized(tmp_path: Path) -> None:
+    """The colon-namespace form `<command-name>/gh:issue-flow</command-name>`
+    must also be recognized — Claude Code occasionally emits either form
+    depending on how the skill is registered.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_slash_command("gh:issue-flow", "457"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-pr" in decision["reason"]
+    assert "Step 2.3" in decision["reason"]
+
+
+def test_wrapped_command_inside_tool_result_does_not_trigger(tmp_path: Path) -> None:
+    """A `<command-name>/gh-issue-flow</command-name>` substring landing in
+    a tool_result block (e.g. the model reads a doc that quotes Claude
+    Code's wrapping format) must NOT be treated as a real invocation —
+    the existing `include_tool_results=False` guard still applies to the
+    new regex matcher.
+    """
+    wrapped_inside_doc = (
+        "Example: when a user types /gh-issue-flow N, the transcript looks like\n"
+        "\n"
+        "    <command-name>/gh-issue-flow</command-name>\n"
+        "    <command-args>N</command-args>\n"
+        "\n"
+        "and the hook treats that as the flow start.\n"
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("can you read the docs about the gh-issue-flow stop hook?"),
+            _user_tool_result(wrapped_inside_doc),
+            _assistant_text("Sure — the hook ..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        "Hook treated <command-name> string inside a tool_result as a real "
+        f"slash-command invocation. stdout={result.stdout!r}"
+    )
+
+
+def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
+    tmp_path: Path,
+) -> None:
+    """End-to-end shape of the production regression in #607 / #609:
+
+    user invokes /gh-issue-flow → Claude Code wraps it in <command-name>
+    tags → assistant invokes Skill(gh-issue-implement) → assistant emits
+    a self-authored success summary and tries to stop. The hook must
+    block and route the model to Step 2.2.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_slash_command("gh-issue-flow", "457"),
+            _assistant_skill("gh-issue-implement", "457 direct origin --no-next-hint"),
+            _assistant_text(
+                "gh:issue-implement complete for #457.\n\n"
+                "Summary\n"
+                "  Issue:        #457 feat(db): index strategy\n"
+                "  Mode:         direct\n"
+                "  Files:        1 new\n"
+                "  Tests:        12 passed\n\n"
+                "[ai-metrics:gh-issue-implement] ~7 min — will be included "
+                "in gh-commit metrics\n"
+            ),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    reason = decision["reason"]
+    assert "Step 2.2" in reason
+    assert "gh-commit" in reason
+    assert "1/5" in reason


### PR DESCRIPTION
## Summary
- `/gh-issue-flow` Stop hook 가드 #3 가 4차 fail-open — `_find_flow_boundary` 가 Claude Code 의 `<command-name>` 래핑 슬래시 명령을 인식하지 못해, production `/gh-issue-flow` Stop event 가 전부 fail-open 으로 빠지던 회귀 (#333 → #383 → 본 PR) 를 regex 매칭으로 해소.
- 동일 원인을 별도 보고한 #607 · #609 를 함께 closes. #608 의 3-layer 설계 중 L1 (boundary detection) 만 본 PR 범위. L2 (state file) / L3 (heartbeat cron) 는 본 fix 후 회귀가 재발할 경우 follow-up.
- 실제 Claude Code transcript 형식을 그대로 재현하는 4 건의 회귀 fixture 추가 — 기존 raw `/gh-issue-flow 42` fixture 만 있던 CI 가 production fail-open 을 잡지 못한 이유 자체를 가드.

## Changes
- `claude/hooks/gh_issue_flow_stop_guard.py` — `FLOW_START_TOKENS` 튜플 + `lstrip().startswith()` 루프를 `_USER_BOUNDARY_RE` 컴파일 regex 로 교체. raw `/gh[-:]issue-flow` (줄 시작) 과 `<command-name>/gh[-:]issue-flow</command-name>` 래핑 두 surface 를 OR 매칭, `(?m)^\s*` 로 mid-sentence 멘션은 제외, `include_tool_results=False` 가드는 그대로 유지.
- `tests/integration/test_gh_issue_flow_stop_guard.py` — `_user_slash_command(...)` helper 추가 + 4 건 신규 테스트:
  - `test_wrapped_slash_command_recognized_as_flow_start` — 본 회귀의 정상 인식.
  - `test_wrapped_slash_command_colon_namespace_recognized` — 콜론 네임스페이스 변형.
  - `test_wrapped_command_inside_tool_result_does_not_trigger` — tool_result 안의 같은 substring 은 false-positive 가드.
  - `test_wrapped_command_full_session_blocks_with_step_2_2_reason` — Step 2.1 직후 self-authored summary 가 emit 된 production 회귀 shape 그대로 reproduce.

## Test plan
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py` — 29/29 passed (기존 25 + 신규 4).
- [x] `tox -e ruff -e mypy` — 둘 다 clean.
- [x] `tox -e shellcheck -e shfmt` (lint guard 경유) — clean.
- [x] Direct reproduction: #607 본문의 5-line 재현 스니펫 (`<command-message>/<command-name>/<command-args>` + `ARGUMENTS:`) 으로 `_find_flow_boundary` 가 `0` 반환 (이전엔 `-1`).
- [ ] Production live verification — 머지 후 한 세션에서 `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1` 으로 `/gh-issue-flow <N>` 실행하여 trace 가 `boundary>=0` + `decision=block` 을 실제로 emit 하는지 1 회 확인 (#609 의 D 항목).

## Related
Closes #607
Closes #609
(part of #608 — L1 only; L2/L3 는 follow-up)

---
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~1 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~1 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
