### PR TITLE
refactor(gh-pr): #615 drop --parent-pr manual flag (KISS, F-5)

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -28,15 +28,13 @@ body. Push the branch if needed. Return the PR URL.
 |----------|-------------|---------|
 | `[N]` (positional) | Legacy `/gh:pr 123` form — overrides issue auto-detection. | — |
 | `--no-stack` | Force a non-stacked PR even when stacked-PR signals fire. | off |
-| `--parent-pr <N>` | Explicit parent PR number; sets `BASE_BRANCH` to `<N>`'s head. | — |
 | `--base <branch>` | Explicit base branch; bypasses stacked-PR detection. | repo default |
 | `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
 | `GH_PR_LINT_BYPASS=1` (env) | Skip Step 4.5 lint guard. | off |
 | `DOTFILES_ROOT` (env) | Root used to source `gh_pr_lint.sh`. | `$HOME/dotfiles` |
 | `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
 
-`--no-stack`, `--parent-pr`, and `--base` are mutually exclusive — see
-Step 1a exit codes.
+`--no-stack` and `--base` are mutually exclusive — see Step 1a exit codes.
 
 ## Step 1: Parse Args, Resolve Base Branch, Gather State
 
@@ -49,7 +47,7 @@ Read `references/stacked-pr.md` and paste the SSOT functions
 and the dispatch block ("How Step 1 of SKILL.md ties it together")
 verbatim. They bind `BASE_BRANCH`, `PARENT_PR`, and `ISSUE_NUMBER`, and
 they exit on bad input — `rc=2` for mutually-exclusive flags, `rc=3`
-for bad `--parent-pr` / `--base` values. Abort without pushing on either.
+for a bad `--base` value. Abort without pushing on either.
 
 ### Step 1b: Gather range + push state (parallel)
 

--- a/claude/skills/gh-pr/references/constraints.md
+++ b/claude/skills/gh-pr/references/constraints.md
@@ -17,14 +17,13 @@ The base branch is decided in Step 1a (`references/stacked-pr.md`):
    repo has no stacked-PR signals — solo / non-stacked workflow.
 2. Auto-detected parent PR's head ref when the repo opts into stacked
    PRs *and* exactly one open PR is an ancestor of HEAD.
-3. The user-supplied target when one of `--no-stack` / `--parent-pr <N>`
-   / `--base <branch>` was passed (mutually exclusive — combining any
-   two aborts).
+3. The user-supplied target when one of `--no-stack` / `--base <branch>`
+   was passed (mutually exclusive — combining the two aborts).
 
 Never target any base outside those three sources. In particular,
 never auto-stack on a repo that does not match `is_stacked_pr_repo`,
 and never silently downgrade to the default branch when the user
-explicitly passed `--parent-pr` or `--base`.
+explicitly passed `--base`.
 
 ## AI footers
 

--- a/claude/skills/gh-pr/references/help.md
+++ b/claude/skills/gh-pr/references/help.md
@@ -11,7 +11,6 @@
 | Flag | Effect |
 |---|---|
 | `--no-stack` | force base = repo default branch, skip auto-detect |
-| `--parent-pr <N>` | force stack on PR #N (base = #N's head ref, body adds `Depends on #N`) |
 | `--base <branch>` | force base = `<branch>` (any branch name) |
 
 Auto-detect (default) is a no-op on solo / non-stacked repos. See
@@ -23,7 +22,6 @@ Auto-detect (default) is a no-op on solo / non-stacked repos. See
   Resolves base via auto-detect (default branch on solo repos).
 - `/gh-pr 123` — same, force-link to issue `#123`.
 - `/gh-pr --no-stack` — auto-detect off, base = default branch.
-- `/gh-pr --parent-pr 201` — auto-detect off, stack on PR #201.
 - `/gh-pr --base release/v2.0` — auto-detect off, custom base branch.
 - `/gh-pr -h` / `--help` / `help` — print this help.
 
@@ -55,13 +53,12 @@ $ /gh-pr                        →  "Stacking on PR #201 (auto-detected)"
 
 # Auto-detect was wrong — escape hatch
 $ /gh-pr --no-stack             →  base=main forced
-$ /gh-pr --parent-pr 205        →  base=PR #205 head
 $ /gh-pr --base release/v2.0    →  base=release/v2.0
 ```
 
 ## What the skill does
 
-1. Parses args (`--no-stack` / `--parent-pr` / `--base`), then resolves
+1. Parses args (`--no-stack` / `--base`), then resolves
    the base branch via the stacked-PR auto-detect flow (see
    `references/stacked-pr.md`). Fetches `origin` to make sure the range
    is computed against up-to-date refs.
@@ -87,8 +84,7 @@ $ /gh-pr --base release/v2.0    →  base=release/v2.0
 - Force-push without explicit user approval.
 - Run auto-stack detection on a repo without stacked-PR signals — solo
   repos always default to the repo's default branch.
-- Combine `--no-stack` / `--parent-pr` / `--base` (mutually exclusive,
-  rc=2 abort).
+- Combine `--no-stack` / `--base` (mutually exclusive, rc=2 abort).
 - Mutate parent PR bodies — cross-PR rollup is the downstream repo's
   job (e.g. AgentToolbox `stacked-closes-rollup.yml`).
 - Include the `🤖 Generated with Claude Code` footer unless the repo
@@ -108,5 +104,5 @@ $ /gh-pr --base release/v2.0    →  base=release/v2.0
 - **Good**: Hotfix landing on a release branch, `/gh-pr --base release/v2.0`.
 - **Bad**: running on `main` — skill stops with "create a feature branch first".
 - **Bad**: running with an empty `<base>..HEAD` — skill stops with "nothing to PR".
-- **Bad**: `/gh-pr --no-stack --parent-pr 5` — flags are mutually
+- **Bad**: `/gh-pr --no-stack --base main` — flags are mutually
   exclusive, skill aborts before push.

--- a/claude/skills/gh-pr/references/pr-body-template.md
+++ b/claude/skills/gh-pr/references/pr-body-template.md
@@ -47,8 +47,8 @@ Closes #<N>
 
 ### Stacked-PR `Depends on` insertion
 
-When Step 1a set `PARENT_PR` (auto-detected or `--parent-pr <N>` was
-passed), insert a `Depends on #<PARENT_PR>` line into the
+When Step 1a set `PARENT_PR` (auto-detected from a single ancestor
+open PR), insert a `Depends on #<PARENT_PR>` line into the
 `## Related` section, alongside `Closes #<N>` / `Refs #<N>` if any:
 
 ```markdown

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -289,5 +289,5 @@ hatch flag (`--base <branch>` or `--no-stack`). This avoids hanging on
 | Mutually-exclusive flags | `/gh-pr --no-stack --base main` | rc=2, abort |
 | Bad `--base` value | `/gh-pr --base` (missing arg) | rc=3, abort |
 
-The 7 rows above are the regression contract — every change to the
+The 8 rows above are the regression contract — every change to the
 detection logic must keep them green.

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -17,8 +17,7 @@ behavioural change.
 1. The user types `/gh-pr` once. Flags exist only as escape hatches.
 2. Backwards-compat is unconditional. No repo signal → auto-detect
    never fires. dotfiles solo workflow is unchanged.
-3. Auto-detect can be overridden when wrong (`--no-stack`, `--parent-pr`,
-   `--base`).
+3. Auto-detect can be overridden when wrong (`--no-stack`, `--base`).
 4. dotfiles never mutates the parent PR body. Cross-PR rollup is the
    downstream repo's concern (e.g. AgentToolbox's
    `stacked-closes-rollup.yml` workflow).
@@ -54,8 +53,8 @@ behavioural change.
    └─ 2+ candidates → dispatch returns rc=4 + candidate list on stderr
        (bash is non-interactive in Claude Code — `read` would hang).
        The AI executor asks the user via the platform's question
-       primitive, then re-invokes `gh:pr` with `--parent-pr <N>` /
-       `--base <branch>` / `--no-stack` based on the answer.
+       primitive, then re-invokes `gh:pr` with `--base <branch>` /
+       `--no-stack` based on the answer.
 ```
 
 ## Manual override (escape hatches)
@@ -63,11 +62,10 @@ behavioural change.
 | Flag | Semantics |
 |---|---|
 | `--no-stack` | skip auto-detect entirely, BASE_BRANCH=$DEFAULT_BRANCH |
-| `--parent-pr <N>` | skip auto-detect, BASE_BRANCH=head ref of PR #N, PARENT_PR=N |
 | `--base <branch>` | skip auto-detect, BASE_BRANCH=<branch>, PARENT_PR= |
 
-The three flags are mutually exclusive. Combining any two → rc=2 with
-an explanatory message; the skill aborts before any push.
+The two flags are mutually exclusive. Combining them → rc=2 with an
+explanatory message; the skill aborts before any push.
 
 ## Stage 1 — `is_stacked_pr_repo`
 
@@ -103,14 +101,12 @@ none of these is treated as solo / non-stacked.
 
 ```sh
 # Reads positional args + flags from $@. Sets globals:
-#   STACK_MODE     — auto | no-stack | parent-pr | base
-#   STACK_PARENT   — PR number when STACK_MODE=parent-pr
+#   STACK_MODE     — auto | no-stack | base
 #   STACK_BASE     — branch name when STACK_MODE=base
 #   ISSUE_NUMBER   — first positional integer (legacy "/gh-pr 123" link)
 # Returns 0 on success, 2 on mutually-exclusive violation, 3 on bad value.
 parse_stacked_args() {
     STACK_MODE=auto
-    STACK_PARENT=
     STACK_BASE=
     ISSUE_NUMBER=
     local _flags_seen=0
@@ -121,21 +117,6 @@ parse_stacked_args() {
                 _flags_seen=$((_flags_seen + 1))
                 STACK_MODE=no-stack
                 shift
-                ;;
-            --parent-pr)
-                _flags_seen=$((_flags_seen + 1))
-                STACK_MODE=parent-pr
-                if [ $# -lt 2 ]; then
-                    printf 'gh:pr: --parent-pr requires a PR number\n' >&2
-                    return 3
-                fi
-                STACK_PARENT="$2"
-                if ! printf '%s' "${STACK_PARENT-}" | grep -qE '^[1-9][0-9]*$'; then
-                    printf 'gh:pr: --parent-pr requires a positive integer (got %s)\n' \
-                        "${STACK_PARENT:-<empty>}" >&2
-                    return 3
-                fi
-                shift 2
                 ;;
             --base)
                 _flags_seen=$((_flags_seen + 1))
@@ -162,7 +143,7 @@ parse_stacked_args() {
     done
 
     if [ "$_flags_seen" -gt 1 ]; then
-        printf 'gh:pr: --no-stack / --parent-pr / --base are mutually exclusive\n' >&2
+        printf 'gh:pr: --no-stack / --base are mutually exclusive\n' >&2
         return 2
     fi
 
@@ -252,9 +233,6 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 case "$STACK_MODE" in
     no-stack)
         BASE_BRANCH="$DEFAULT_BRANCH" ; PARENT_PR= ;;
-    parent-pr)
-        PARENT_PR="$STACK_PARENT"
-        BASE_BRANCH=$(gh pr view "$PARENT_PR" --json headRefName -q .headRefName) ;;
     base)
         BASE_BRANCH="$STACK_BASE" ; PARENT_PR= ;;
     auto)
@@ -273,10 +251,10 @@ case "$STACK_MODE" in
                     # candidate set and exit the auto branch with both vars
                     # unset; the AI executor handles the choice via the
                     # platform's question primitive (e.g. AskUserQuestion in
-                    # Claude Code) and re-runs the case for `parent-pr` /
-                    # `base` / `no-stack` based on the user's reply.
+                    # Claude Code) and re-runs the case for `base` /
+                    # `no-stack` based on the user's reply.
                     printf 'Multiple parent candidates:\n%s\n' "$CANDIDATES" >&2
-                    printf 'gh:pr: ambiguous parent — ask user, then re-invoke with --parent-pr / --base / --no-stack\n' >&2
+                    printf 'gh:pr: ambiguous parent — ask user, then re-invoke with --base / --no-stack\n' >&2
                     return 4
                     ;;
             esac
@@ -295,8 +273,8 @@ When the dispatch returns rc=4 (ambiguous parent), the AI executor — not
 the shell — must surface the candidate list to the user via the
 platform's question primitive (e.g. `AskUserQuestion` in Claude Code).
 Once the user picks one, re-invoke `gh:pr` with the matching escape
-hatch flag (`--parent-pr <N>`, `--base <branch>`, or `--no-stack`).
-This avoids hanging on `read` in non-interactive runtimes.
+hatch flag (`--base <branch>` or `--no-stack`). This avoids hanging on
+`read` in non-interactive runtimes.
 
 ## Compatibility matrix (what the bats suite must keep covering)
 
@@ -307,10 +285,9 @@ This avoids hanging on `read` in non-interactive runtimes.
 | AgentToolbox parent ambiguous | `/gh-pr` | Stage 1 pass + 2+ cand → 1× prompt |
 | AgentToolbox no parent | `/gh-pr` | Stage 1 pass + 0 cand → base=default |
 | `--no-stack` override | `/gh-pr --no-stack` | base=default forced, no Stage 2 |
-| `--parent-pr 99` | `/gh-pr --parent-pr 99` | base=PR #99 head forced |
 | `--base release/v2.0` | `/gh-pr --base release/v2.0` | arbitrary branch forced |
-| Mutually-exclusive flags | `/gh-pr --no-stack --parent-pr 5` | rc=2, abort |
-| Bad `--parent-pr` value | `/gh-pr --parent-pr abc` | rc=3, abort |
+| Mutually-exclusive flags | `/gh-pr --no-stack --base main` | rc=2, abort |
+| Bad `--base` value | `/gh-pr --base` (missing arg) | rc=3, abort |
 
-The 9 rows above are the regression contract — every change to the
+The 7 rows above are the regression contract — every change to the
 detection logic must keep them green.

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -37,7 +37,6 @@ is_stacked_pr_repo() {
 # ── Argument parsing ───────────────────────────────────────────────────
 parse_stacked_args() {
     STACK_MODE=auto
-    STACK_PARENT=
     STACK_BASE=
     ISSUE_NUMBER=
     local _flags_seen=0
@@ -48,21 +47,6 @@ parse_stacked_args() {
                 _flags_seen=$((_flags_seen + 1))
                 STACK_MODE=no-stack
                 shift
-                ;;
-            --parent-pr)
-                _flags_seen=$((_flags_seen + 1))
-                STACK_MODE=parent-pr
-                if [ $# -lt 2 ]; then
-                    printf 'gh:pr: --parent-pr requires a PR number\n' >&2
-                    return 3
-                fi
-                STACK_PARENT="$2"
-                if ! printf '%s' "${STACK_PARENT-}" | grep -qE '^[1-9][0-9]*$'; then
-                    printf 'gh:pr: --parent-pr requires a positive integer (got %s)\n' \
-                        "${STACK_PARENT:-<empty>}" >&2
-                    return 3
-                fi
-                shift 2
                 ;;
             --base)
                 _flags_seen=$((_flags_seen + 1))
@@ -89,7 +73,7 @@ parse_stacked_args() {
     done
 
     if [ "$_flags_seen" -gt 1 ]; then
-        printf 'gh:pr: --no-stack / --parent-pr / --base are mutually exclusive\n' >&2
+        printf 'gh:pr: --no-stack / --base are mutually exclusive\n' >&2
         return 2
     fi
 

--- a/tests/bats/skills/gh_pr_stacked_detect.bats
+++ b/tests/bats/skills/gh_pr_stacked_detect.bats
@@ -4,7 +4,7 @@
 #   claude/skills/gh-pr/references/stacked-pr.md
 # Source-of-truth fixture: _fixtures/gh_pr_stacked_detect.sh.
 #
-# 7-case compatibility matrix (issue #615 trimmed the prior 9-case set):
+# 8-case compatibility matrix (issue #615 trimmed the prior 9-case set):
 #   1. dotfiles solo (no stacked signals)        → Stage 1 fail, base=default
 #   2. AgentToolbox parent unique                → Stage 1+2, 1 candidate
 #   3. AgentToolbox parent ambiguous             → Stage 1+2, 2+ candidates

--- a/tests/bats/skills/gh_pr_stacked_detect.bats
+++ b/tests/bats/skills/gh_pr_stacked_detect.bats
@@ -4,16 +4,15 @@
 #   claude/skills/gh-pr/references/stacked-pr.md
 # Source-of-truth fixture: _fixtures/gh_pr_stacked_detect.sh.
 #
-# 9-case compatibility matrix from issue #394:
+# 7-case compatibility matrix (issue #615 trimmed the prior 9-case set):
 #   1. dotfiles solo (no stacked signals)        → Stage 1 fail, base=default
 #   2. AgentToolbox parent unique                → Stage 1+2, 1 candidate
 #   3. AgentToolbox parent ambiguous             → Stage 1+2, 2+ candidates
 #   4. AgentToolbox no parent (root issue)       → Stage 1 pass, 0 candidates
 #   5. --no-stack override                       → mode=no-stack
-#   6. --parent-pr <N> override                  → mode=parent-pr
-#   7. --base <branch> override                  → mode=base
-#   8. Mutually-exclusive flags                  → rc=2 abort
-#   9. --parent-pr <bad>                         → rc=3 abort
+#   6. --base <branch> override                  → mode=base
+#   7. Mutually-exclusive flags (--no-stack + --base) → rc=2 abort
+#   8. --base (missing arg)                      → rc=3 abort
 
 load '../test_helper'
 
@@ -27,7 +26,7 @@ setup() {
 teardown() {
     [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] && rm -rf "$REPO_ROOT"
     unset FAKE_OPEN_PRS FAKE_ANCESTOR_REFS FAKE_NONDEFAULT_REFS
-    unset STACK_MODE STACK_PARENT STACK_BASE ISSUE_NUMBER
+    unset STACK_MODE STACK_BASE ISSUE_NUMBER
     teardown_isolated_home
 }
 
@@ -137,32 +136,25 @@ teardown() {
     [ "$STACK_MODE" = "no-stack" ]
 }
 
-# ── Compatibility matrix #6: --parent-pr <N> ──────────────────────────
-@test "matrix-6: --parent-pr 201 → STACK_MODE=parent-pr, STACK_PARENT=201" {
-    parse_stacked_args --parent-pr 201
-    [ "$STACK_MODE" = "parent-pr" ]
-    [ "$STACK_PARENT" = "201" ]
-}
-
-# ── Compatibility matrix #7: --base <branch> ──────────────────────────
-@test "matrix-7: --base release/v2.0 → STACK_MODE=base, STACK_BASE=release/v2.0" {
+# ── Compatibility matrix #6: --base <branch> ──────────────────────────
+@test "matrix-6: --base release/v2.0 → STACK_MODE=base, STACK_BASE=release/v2.0" {
     parse_stacked_args --base release/v2.0
     [ "$STACK_MODE" = "base" ]
     [ "$STACK_BASE" = "release/v2.0" ]
 }
 
-# ── Compatibility matrix #8: mutually-exclusive flags ─────────────────
-@test "matrix-8: --no-stack --parent-pr 5 → rc=2 with explanatory message" {
-    run parse_stacked_args --no-stack --parent-pr 5
+# ── Compatibility matrix #7: mutually-exclusive flags ─────────────────
+@test "matrix-7: --no-stack --base main → rc=2 with explanatory message" {
+    run parse_stacked_args --no-stack --base main
     [ "$status" -eq 2 ]
     assert_output --partial 'mutually exclusive'
 }
 
-# ── Compatibility matrix #9: bad --parent-pr value ────────────────────
-@test "matrix-9: --parent-pr abc → rc=3 with explanatory message" {
-    run parse_stacked_args --parent-pr abc
+# ── Compatibility matrix #8: --base missing branch arg ────────────────
+@test "matrix-8: --base (no arg) → rc=3 with explanatory message" {
+    run parse_stacked_args --base
     [ "$status" -eq 3 ]
-    assert_output --partial 'requires a positive integer'
+    assert_output --partial 'requires a branch name'
 }
 
 # ── Legacy positional issue arg still parsed ──────────────────────────


### PR DESCRIPTION
## Summary
- `gh:pr` 의 수동 escape hatch `--parent-pr <N>` CLI 플래그를 제거 — 실제 운영에서 사용 0건이라 자동 감지(Stage-1/Stage-2) + `--no-stack` / `--base` 만으로 충분 (KISS).
- mutually-exclusive 규칙을 3자 → 2자 (`--no-stack` ↔ `--base`) 로 단순화.
- 자동 감지의 1-candidate 시 `PARENT_PR` 바인딩 및 `Depends on #N` 본문 삽입은 **변경 없음** — `--parent-pr` 만 제거.

## Changes
- `claude/skills/gh-pr/SKILL.md`: Options 표에서 `--parent-pr` 행 삭제, mutually-exclusive 안내를 2자 규칙으로 축소, rc=3 설명에서 `--parent-pr` 언급 제거.
- `claude/skills/gh-pr/references/help.md`: 표·예시·"What the skill does"/"will NOT do"·Good/Bad 케이스 전부 정리.
- `claude/skills/gh-pr/references/constraints.md`: base-branch 결정 3-source 설명에서 `--parent-pr` 제거.
- `claude/skills/gh-pr/references/pr-body-template.md`: `Depends on` 삽입 조건 문구를 "auto-detected from a single ancestor open PR" 로 정정.
- `claude/skills/gh-pr/references/stacked-pr.md`: SSOT `parse_stacked_args` 의 `--parent-pr` 분기 + `STACK_PARENT` 전역 + dispatch `parent-pr)` arm 제거, rc=4 안내 메시지·comp-matrix(9→7행) 동기 업데이트.
- `tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh`: SSOT 미러 — 동일한 parser 변경 반영.
- `tests/bats/skills/gh_pr_stacked_detect.bats`: `matrix-6/--parent-pr` 와 `matrix-9/bad value` 삭제, `matrix-7` 을 `--no-stack --base main` rc=2 케이스로 재구성, `matrix-8` 을 `--base` 누락 rc=3 케이스로 신설, 매트릭스 주석 7-case 로 업데이트.

## Test plan
- [x] `git grep '--parent-pr' claude/skills/gh-pr/ tests/bats/skills/` → 0건 (acceptance criterion #1).
- [x] `bats tests/bats/skills/gh_pr_stacked_detect.bats` 18/18 PASS.
- [x] 전체 bats skills suite 149/149 PASS — 다른 skill 회귀 없음.
- [x] `tox -e shellcheck`, `tox -e shfmt` OK.
- [ ] (수동) 사용자가 옛 습관으로 `--parent-pr 123` 전달 시 CLI unknown-option 으로 종료 — 별도 친절 메시지 없음 (KISS, 이슈 본문의 Error Cases 그대로).

## Related
Closes #615

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
