### PR TITLE
feat(gh-pr-reply): #622 codify 4 patterns from AgentToolbox#655

### DIFF
--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -41,7 +41,11 @@ Also capture `TARGET_REPO` via `gh repo view --json nameWithOwner -q .nameWithOw
 ## Step 2: Fetch All Review Comments
 
 Read `references/comment-fetching.md` for the three API endpoints, field
-extraction, and dedup rule. Fetch all three; filter out already-replied threads.
+extraction, and dedup rule. Fetch all three; filter out already-replied
+threads. Bot service notices (quota / rate-limit / outage) — whether
+posted as review summaries OR as conversation comments — follow the
+"Bot service notices" section in the same reference: classify as
+service-notice, single-line ack in Step 5, count separately in Step 7.
 
 ## Step 2.5: Early Exit — No Unaddressed Comments
 
@@ -74,8 +78,12 @@ like `fix(review): address X as suggested in PR #123 review`. Never
 including declined ones and bot comments.**
 
 Read `references/reply-templates.md` for POST command shapes (inline thread
-vs top-level) and the four body templates (Accepted / Accepted-with-modification
-/ Declined / Question). Reply in the reviewer's language.
+vs top-level), the four body templates (Accepted / Accepted-with-modification
+/ Declined / Question), the "Long-body fallback" pattern (review body
+> 500 chars → cite by review id instead of verbatim blockquote), and the
+"Consolidated table reply" template (single review body with N ≥ 3
+independent items → one table reply, not N separate ones). Reply in the
+reviewer's language.
 
 ## Step 6: Push the Fix Commits
 
@@ -86,7 +94,11 @@ asked) and report new commit SHAs alongside the reply summary.
 
 Print the summary table per `references/final-summary.md` showing
 Accepted / Declined / Answered counts, commit SHAs, and any skipped
-already-replied comments.
+already-replied comments. After the table, run the "Lingering
+`CHANGES_REQUESTED` nudge" check from the same reference: re-query
+`gh pr view --json reviewDecision`, and if still `CHANGES_REQUESTED`,
+emit the one-line nudge so the user knows replies + fixes alone do
+not clear the review block — the reviewer must re-review.
 
 After printing the report, post a PR comment with ai-metrics (soft-fail —
 warn on error, never block). `COMMENT_COUNT` is the number of comments

--- a/claude/skills/gh-pr-reply/references/comment-fetching.md
+++ b/claude/skills/gh-pr-reply/references/comment-fetching.md
@@ -80,11 +80,17 @@ through the normal Accept / Decline classification.
 
 **Handling.** Service notices still get a reply (the politeness contract
 is non-negotiable) but use a single-line ack — there is nothing to
-accept, decline, or answer. Suggested ack body:
+accept, decline, or answer. Suggested ack body (translate to the
+reviewer's language per the top-of-file rule in `reply-templates.md` —
+the example below is English):
 
 ```
 Acknowledged — service notice, no code-review content to address.
 ```
+
+Korean equivalent: `확인했습니다 — 서비스 알림, 코드 리뷰 내용 없음.`
+Match the reviewer's language exactly; this is a template, not a fixed
+string.
 
 Note these in the Step 7 report as `Acknowledged (bot service notice):`
 so the user can see the bot was not silently ignored. Do NOT skip

--- a/claude/skills/gh-pr-reply/references/comment-fetching.md
+++ b/claude/skills/gh-pr-reply/references/comment-fetching.md
@@ -51,10 +51,41 @@ Handle each review summary as follows:
 - **Actionable content** (reviewer wrote a critical concern in the summary
   body itself, not just linking to inline comments): post a new top-level
   issue comment that blockquotes the review summary and addresses it, using
-  the top-level reply shape from `reply-templates.md`.
+  the top-level reply shape from `reply-templates.md`. For long bodies
+  (>500 chars) or N ≥ 3 bundled items, see the Long-body fallback and
+  Consolidated table reply templates in `reply-templates.md`.
 - **Meta content** (summary just recaps the inline comments, or is a service
   notice like "your repo doesn't have access to X"): no reply needed; note
   it in the Step 7 report as "skipped (meta summary)".
 
 Judgment: if deleting the summary would lose information not already
 captured in an inline comment, it is actionable.
+
+## Bot service notices
+
+Bots scatter "service" output across both `/pulls/<N>/reviews` and
+`/issues/<N>/comments`, so the meta-content rule above applies to BOTH
+endpoints — not just reviews. Examples seen in the wild:
+
+- gemini-code-assist quota-exhausted notice posted as a conversation
+  comment (`/issues/<N>/comments`, AgentToolbox#655 run).
+- sourcery-ai "rate limited" or "service unavailable" comment.
+- copilot trial-expired notice.
+
+**Classification.** A bot comment is a *service notice* when it carries no
+code-review content — it announces the bot's own availability (quota,
+rate-limit, outage, trial state, repo access) instead of evaluating the
+diff. Code-review nits from the same bot are NOT service notices and go
+through the normal Accept / Decline classification.
+
+**Handling.** Service notices still get a reply (the politeness contract
+is non-negotiable) but use a single-line ack — there is nothing to
+accept, decline, or answer. Suggested ack body:
+
+```
+Acknowledged — service notice, no code-review content to address.
+```
+
+Note these in the Step 7 report as `Acknowledged (bot service notice):`
+so the user can see the bot was not silently ignored. Do NOT skip
+silently and do NOT route them through the four-class rubric.

--- a/claude/skills/gh-pr-reply/references/final-summary.md
+++ b/claude/skills/gh-pr-reply/references/final-summary.md
@@ -24,3 +24,30 @@ PR #123 review comments processed: 5 total
 If any comments were skipped as "already replied", list them at the
 bottom under a `Skipped (already replied):` header with the comment IDs
 or short bodies, so the user can verify nothing was silently ignored.
+
+## Lingering `CHANGES_REQUESTED` nudge
+
+Replying to comments and pushing fixes does NOT clear the PR's
+`reviewDecision` — GitHub only flips that flag when the reviewer
+explicitly re-reviews. After printing the table above, query the PR
+state once more and emit a one-line nudge if the decision is still
+`CHANGES_REQUESTED`. Without this, the user can mistake "all comments
+replied to" for "PR ready to merge".
+
+```bash
+REVIEW_DECISION=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
+  --json reviewDecision -q .reviewDecision 2>/dev/null)
+
+if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
+  printf '\n  -> PR is still CHANGES_REQUESTED — reviewer must re-review.\n'
+  printf '     Optional: gh pr review %s --request <reviewer>\n' "$PR_NUMBER"
+fi
+```
+
+Soft-fail: if the `gh pr view` call errors (network blip, missing
+scope), skip the nudge silently — the main summary already printed.
+This check is independent of Step 8 (Solo-Repo Auto-Approve), whose
+G4 guard explicitly refuses to auto-approve when `reviewDecision ==
+CHANGES_REQUESTED`. Validated on PR
+`dev-team-404/AgentToolbox#655` — the lingering CR state was the
+exact gap that the run surfaced.

--- a/claude/skills/gh-pr-reply/references/reply-templates.md
+++ b/claude/skills/gh-pr-reply/references/reply-templates.md
@@ -47,6 +47,8 @@ up to read the original, and the reply stays scannable:
 
 ```bash
 # Body length threshold: 500 chars. Above that, cite by id instead of quoting.
+# HEADER text below is English; translate to the reviewer's language
+# (e.g. Korean: "Re: 리뷰 #<review_id> — Blocker <N>건 + Suggestion <M>건").
 if [ "${#ORIGINAL_BODY}" -gt 500 ]; then
   HEADER="Re: review #<review_id> — <N> Blockers + <M> Suggestions"
   gh api "repos/<owner>/<repo>/issues/<N>/comments" \
@@ -68,7 +70,9 @@ fi
 `<review_id>` is the `id` field returned by `/pulls/<N>/reviews`. `<N>` /
 `<M>` counts come from the Step 3 classification (BLOCKER + Suggestion
 labels are an example taxonomy — match whatever vocabulary the reviewer
-used). Validated on PR `dev-team-404/AgentToolbox#655` review
+used). The `HEADER` literal is a translatable template, not a fixed
+English string — the top-of-file language rule overrides it. Validated
+on PR `dev-team-404/AgentToolbox#655` review
 `pullrequestreview-4286773211` (~3 000-char body, 7 BLOCKER + 3
 Suggestion) — reviewer approved on re-review and praised the format.
 
@@ -122,7 +126,9 @@ For N ≤ 2 items, or for inline comments anchored to specific lines,
 use the per-item templates above — do NOT force a table.
 
 **Body template** (replace `B`/`S` labels with the reviewer's
-taxonomy; match the reviewer's language):
+taxonomy; match the reviewer's language — the column headers, verdict
+keywords, and footer label below are Korean because the AgentToolbox#655
+validation reviewer was Korean-speaking; translate per top-of-file rule):
 
 ```
 Re: review #<review_id> — <N> Blockers + <M> Suggestions
@@ -136,6 +142,10 @@ Re: review #<review_id> — <N> Blockers + <M> Suggestions
 
 전체 fix commit: <short-sha>
 ```
+
+English column equivalents: `| # | Item | Verdict | Resolution |` with
+footer `Aggregate fix commit: <short-sha>`. Pick the language that
+matches the reviewer; do not mix.
 
 Every row must land in exactly one of: Accepted / Accepted-w-mod /
 Declined / Answered. The aggregate commit short-SHA on the trailing

--- a/claude/skills/gh-pr-reply/references/reply-templates.md
+++ b/claude/skills/gh-pr-reply/references/reply-templates.md
@@ -38,6 +38,40 @@ The same pattern applies when replying to a review summary from
 `/pulls/<N>/reviews`: there is no per-review reply endpoint, so post a
 top-level issue comment that blockquotes the review body and addresses it.
 
+### Long-body fallback (review body > 500 chars)
+
+Verbatim `> `-prefixed quoting becomes unreadable for long review bodies
+(multi-blocker reviews routinely exceed 3 000 chars). Skip the blockquote
+and lead the reply with a citation header instead — reviewers can scroll
+up to read the original, and the reply stays scannable:
+
+```bash
+# Body length threshold: 500 chars. Above that, cite by id instead of quoting.
+if [ "${#ORIGINAL_BODY}" -gt 500 ]; then
+  HEADER="Re: review #<review_id> — <N> Blockers + <M> Suggestions"
+  gh api "repos/<owner>/<repo>/issues/<N>/comments" \
+    -X POST \
+    -f body="$HEADER
+
+<reply text>"
+else
+  # short bodies → keep the verbatim blockquote pattern above
+  QUOTED=$(printf '%s\n' "$ORIGINAL_BODY" | sed 's/^/> /')
+  gh api "repos/<owner>/<repo>/issues/<N>/comments" \
+    -X POST \
+    -f body="$QUOTED
+
+<reply text>"
+fi
+```
+
+`<review_id>` is the `id` field returned by `/pulls/<N>/reviews`. `<N>` /
+`<M>` counts come from the Step 3 classification (BLOCKER + Suggestion
+labels are an example taxonomy — match whatever vocabulary the reviewer
+used). Validated on PR `dev-team-404/AgentToolbox#655` review
+`pullrequestreview-4286773211` (~3 000-char body, 7 BLOCKER + 3
+Suggestion) — reviewer approved on re-review and praised the format.
+
 ## Reply body templates
 
 ### Accepted
@@ -65,6 +99,50 @@ docs, other PR, or file that justifies the current design>.
 ```
 <direct answer>. <optional: link to file:line for reference>.
 ```
+
+### Consolidated table reply (N ≥ 3 items in one review body)
+
+Fires when a single review body bundles multiple independent items
+(e.g. body-only review with 3+ Blockers, or a mix of Blockers and
+Suggestions with no inline anchors). Posting four separate top-level
+comments fragments the conversation; consolidating into one tabular
+reply keeps the thread linear and lets the reviewer scan
+item-by-item.
+
+**Trigger conditions** (all must hold):
+
+1. The source is a single `/pulls/<N>/reviews` summary or a single
+   `/issues/<N>/comments` entry — NOT four separate inline comments.
+2. The body contains N ≥ 3 independently actionable items
+   (Blockers / Suggestions / Questions, in any mix).
+3. The items are short enough that a one-line "수정" / "Resolution"
+   column per row stays readable.
+
+For N ≤ 2 items, or for inline comments anchored to specific lines,
+use the per-item templates above — do NOT force a table.
+
+**Body template** (replace `B`/`S` labels with the reviewer's
+taxonomy; match the reviewer's language):
+
+```
+Re: review #<review_id> — <N> Blockers + <M> Suggestions
+
+| # | 항목 | 판정 | 수정 |
+|---|------|------|------|
+| B1 | <one-line summary of blocker 1> | Accepted | <short-sha> — <what changed> |
+| B2 | <one-line summary of blocker 2> | Declined | <reason tied to code> |
+| ... | ... | ... | ... |
+| S1 | <one-line summary of suggestion 1> | Accepted | <short-sha> — <what changed> |
+
+전체 fix commit: <short-sha>
+```
+
+Every row must land in exactly one of: Accepted / Accepted-w-mod /
+Declined / Answered. The aggregate commit short-SHA on the trailing
+line lets the reviewer jump to the diff once instead of N times.
+Validated on PR `dev-team-404/AgentToolbox#655` review
+`pullrequestreview-4286773211` — table reply id `4446821878`, fix
+commit `1ffff97`, reviewer subsequently approved on re-review.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- `claude/skills/gh-pr-reply` 의 SSOT 4 항목 (G1–G4) 을 보강. AgentToolbox#655 리뷰 응답 run 에서 휴리스틱으로만 작동했던 패턴들을 문서화.
- Run 메타데이터 (PR `dev-team-404/AgentToolbox#655`, 약 3000자 review body, 7 BLOCKER + 3 Suggestion, 리뷰어가 consolidated table 포맷에 APPROVED 재리뷰) 을 reference 안에 인용해 향후 유사 상황의 evidence 로 활용.

## Changes
- `references/reply-templates.md` — **G1**: Consolidated table reply 템플릿 추가 (단일 review body N≥3 항목 트리거). **G2**: long-body fallback (>500자 → verbatim blockquote 대신 `Re: review #<id>` 인용 헤더).
- `references/comment-fetching.md` — **G3**: meta-content 분류 규칙을 `/issues/N/comments` 로 확장. "Bot service notices" 섹션 신설 (gemini quota / sourcery rate-limit / copilot trial 류 → 한 줄 ack 통일, 침묵 skip 금지).
- `references/final-summary.md` — **G4**: `gh pr view --json reviewDecision` 재조회 후 `CHANGES_REQUESTED` 잔존 시 한 줄 nudge 출력 절차 추가. soft-fail.
- `SKILL.md` — Step 2 / Step 5 / Step 7 에 새 reference 섹션 포인터 삽입.

## Test plan
- [ ] `tox -e ruff,shellcheck,shfmt` 통과 (Step 4.5 lint guard) — already green pre-push.
- [ ] 다음 `/gh:pr-reply` run 에서 reply-templates.md 의 Consolidated table 발동 조건이 명확히 분류됨을 수동 확인.
- [ ] long-body (>500자) review body 케이스에서 verbatim blockquote 대신 인용 헤더로 reply 가 생성되는지 확인.
- [ ] bot service notice (quota 알림 등) 가 `/issues/N/comments` 에서 와도 한 줄 ack 로 처리됨을 확인.
- [ ] CR 잔존 PR 에서 Step 7 nudge 가 정확히 1줄 출력되는지 확인.

## Related
Closes #622

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
