### PR TITLE
feat(gh-discussion-create): #617 Conversation -> Ideas RFC Discussion skill

### DIFF
--- a/claude/skills/gh-discussion-create/SKILL.md
+++ b/claude/skills/gh-discussion-create/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: gh:discussion-create
+description: >-
+  Save the current conversation as a GitHub Discussion (default category
+  `Ideas`, RFC-shaped body). Use when the user runs /gh:discussion-create,
+  /gh-discussion-create, asks "이 대화 RFC 로 등록", "Ideas Discussion 으로
+  남겨", "이 토론 깃허브 디스커션으로", or wants the chat preserved as a
+  pre-decision RFC instead of a to-do issue. Drafts an Open-Questions-
+  forward body (TL;DR + Why + Options + Alternatives + Open Questions),
+  posts it via the `createDiscussion` GraphQL mutation, and prints the
+  Discussion URL. Sister skill of [[gh-issue-create]] — same conversation
+  capture quality, different lifecycle target. Refuses when the
+  conversation already represents a decided to-do unless
+  `--force-discussion` is set; suggests `/gh-issue-create` instead.
+  Accepts an optional remote name (e.g. `/gh-discussion-create upstream`)
+  to target a different remote's repo, an optional `[category]` flag to
+  pick `Ideas` (default) / `Q&A` / `Announcements` / `Lessons`, and
+  `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Grep
+---
+
+# gh:discussion-create — Conversation -> Ideas Discussion
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Role
+
+Convert the current chat into a well-structured GitHub Discussion on the
+target repo, defaulting to the `Ideas` (RFC) category. Execute
+immediately without confirmation once the routing guard passes. Print
+only the Discussion URL at the end.
+
+This is the sister skill of `gh:issue-create`: same "preserve detail,
+do not over-compress" contract, but the body emphasises **Open
+Questions** instead of Acceptance Criteria, and the lifecycle target is
+the Discussions forum — not the Issues to-do tracker.
+
+## Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `[remote]` (positional) | Git remote whose repo will own the Discussion. | `origin` |
+| `[category]` (positional) | Discussion category. Case-insensitive match against the repo's category list. Allowed: `Ideas`, `Q&A`, `Announcements`, `Lessons`. | `Ideas` |
+| `--force-discussion` | Bypass the routing guard (Step 2.1) when you know the chat is RFC-shaped despite a decided tone. | off |
+| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+
+The two positional args are order-insensitive when one is clearly a
+category (e.g. `Q&A`, `Ideas`); otherwise the first non-flag positional
+is treated as the remote.
+
+## Step 1: Detect Repo Context
+
+Record `START_TS=$(date +%s)` for the ai-metrics footer in Step 4.
+Parse the positional args and flags above. Confirm we are in a git repo
+(`git rev-parse --show-toplevel`) and resolve `TARGET_REPO=<owner>/<repo>`
+via the chosen remote — substeps in
+[`references/repo-resolution.md`](references/repo-resolution.md).
+Never silently fall back to `origin` when the user-supplied remote is
+missing.
+
+## Step 2: Classify the Conversation
+
+Pick exactly one category. Default to `Ideas`. The four categories and
+when to pick each are listed in
+[`references/category-table.md`](references/category-table.md), which
+mirrors the SSOT in `docs/.ssot/discussions-policy.md`.
+
+If the user passed `[category]` explicitly, honour it — but still run
+the routing guard in Step 2.1; user intent does not bypass the
+"decided to-do" warning, only the body shape changes.
+
+## Step 2.1: Routing Guard (Issue-vs-Discussion)
+
+Per the SSOT routing decision tree (operating principle #1: "Issue is
+default"), reject the chat when it represents a **decided to-do** —
+the right destination is `/gh-issue-create`, not a Discussion. Apply
+the trigger signals in
+[`references/scope-guard.md`](references/scope-guard.md):
+
+- "decided to-do" signals matched -> stop with the suggestion in
+  `scope-guard.md` -> "Refusal format". The user can re-run with
+  `--force-discussion` to override.
+- ambiguous-noun-list / ≥3-component-mix signals matched -> emit the
+  same 1~2 line clarification as `gh:issue-create`'s clarification
+  guide; do not call the mutation until the user answers.
+- Otherwise -> no-op, continue to Step 3.
+
+This is the load-bearing requirement F-3 + F-4 from issue #617 — never
+disable it without a SSOT update.
+
+## Step 3: Draft the Discussion Body
+
+Use the body skeleton in
+[`references/rfc-template.md`](references/rfc-template.md). Write in
+the conversation language (Korean chat -> Korean body). **Do NOT
+over-compress** — preserve file paths, command outputs, decisions,
+trade-offs, and the discussion log. A 200-line RFC is fine, just like
+a 200-line `feat` issue is fine.
+
+For non-`Ideas` categories, swap the template per
+`references/rfc-template.md` -> "Category variants".
+
+## Step 3.5: Compute AI Metrics
+
+Read `gh-issue-create`'s
+[`references/metrics-baseline.md`](../gh-issue-create/references/metrics-baseline.md)
+and bind `TOKENS`, `HUMAN_H`, `ELAPSED` for Step 4. Inputs: `START_TS`
+from Step 1, the chosen category, the drafted title + body. For
+`Ideas` (RFC), treat the size heuristic the same way as `feat` —
+small / medium / large by component count and architectural footprint.
+
+## Step 4: Create the Discussion
+
+Source the helper and call the three lookups + mutation in order. The
+helper file lives at
+`shell-common/functions/gh_discussion.sh`.
+Full bash block in
+[`references/create-cmd.md`](references/create-cmd.md) — paste it
+verbatim. It handles the `mktemp` body file, the
+`GH_DISABLE_AI_METRICS=1` short-circuit (issue #399 parity), the
+ai-metrics footer printf, and the three GraphQL calls
+(`_gh_discussion_repo_id`, `_gh_discussion_category_id`,
+`_gh_discussion_create`).
+
+확인 질문하지 말고 즉시 실행.
+
+## Step 5: Report
+
+성공 시:
+
+```
+[OK] Discussion (<category>): <url>
+Next: /gh-discussion-convert <discussion-number>   # when decision lands
+```
+
+실패 시 — 첫 stderr 줄을 그대로 인용:
+
+```
+[FAIL] <gh stderr first line>
+Next: <recovery — e.g. enable Discussions in repo settings, gh auth refresh>
+```
+
+Routing-guard refusal (Step 2.1) prints its own message from
+`references/scope-guard.md` and skips Steps 3-5.
+
+## Constraints
+
+- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
+- 사용자 지정 remote 가 없으면 즉시 실패 (gh:issue-create 와 동일).
+- `Ideas` 외 카테고리에서도 routing guard 는 동일하게 작동. 본문 골격만
+  교체된다.
+- discussion log 를 2~3 줄로 압축 금지 — Discussion 은 future-self 검색의
+  1 차 SSOT 다.
+- `--force-discussion` 은 가드 우회 전용. SSOT 업데이트 없이 가드 자체를
+  제거하지 말 것.
+- "should I create it?" 같은 확인 질문 금지.
+- 카테고리 ID 캐시 도입 금지 — `references/cache-decision.md` 참고.

--- a/claude/skills/gh-discussion-create/references/cache-decision.md
+++ b/claude/skills/gh-discussion-create/references/cache-decision.md
@@ -1,0 +1,52 @@
+# Decision — No Disk Cache for Repo / Category IDs
+
+Issue #617 Open Question:
+> 카테고리 ID 캐시 위치 — `.cache/gh-discussions-categories.json` vs
+> 매 호출 fetch (refresh 비용 vs staleness).
+
+**Decision (2026-05-14): no cache. Look up both IDs every invocation.**
+
+## Reasons
+
+1. **The lookup is one cheap GraphQL call.** `discussionCategories(first: 25)`
+   returns < 1 KB and is well under the GitHub API rate-limit budget the
+   rest of the gh-* skill family already consumes. A single skill
+   invocation that posts a Discussion makes ~3 API calls today (repo ID,
+   category list, mutation). Caching saves at most one of those — the
+   marginal latency saving is below the cache-coherence overhead.
+
+2. **Staleness is a silent footgun.** If the user renames or deletes a
+   category in repo settings, a stale cache would either post into the
+   wrong category (rename) or fail with a confusing "category ID not
+   found" error (delete). Both are worse than the no-cache baseline of
+   one extra round-trip.
+
+3. **No multi-second startup cost.** The skill is invoked from an
+   interactive Claude Code session — wall-clock budget is minutes, not
+   milliseconds. A 200ms saving per call is invisible in that context.
+
+4. **YAGNI for solo-dev workflow.** This repo (`dEitY719/dotfiles`) is
+   a single-developer environment. Multi-user concurrency does not
+   justify the extra complexity.
+
+## Reverse criteria
+
+Reopen this decision when **any one** of the following becomes true:
+
+- Skill invocation rate climbs above ~10/day (e.g. CI agent posting
+  routine Lessons), making the cumulative API spend non-trivial.
+- GitHub introduces a per-repo cap on Discussions metadata reads that
+  the helper starts hitting.
+- The category list grows past 25 (the GraphQL `first: 25` would need
+  pagination), at which point caching the resolved ID becomes
+  meaningfully cheaper than re-paginating.
+
+Until then, the helper does the obvious thing: fetch on every call.
+
+## Why this lives here
+
+The Open Question was raised in issue #617's body. Capturing the
+decision next to the code that implements it (the `_gh_discussion_*`
+helpers and `Step 4` create command) keeps the rationale discoverable
+when a future maintainer asks "why is there no cache?" — instead of
+relying on the closed issue thread alone.

--- a/claude/skills/gh-discussion-create/references/category-table.md
+++ b/claude/skills/gh-discussion-create/references/category-table.md
@@ -1,0 +1,29 @@
+# Discussion Category Selection
+
+Mirrors the SSOT in `docs/.ssot/discussions-policy.md` -> "카테고리
+매트릭스". When the SSOT changes, update this file in lock-step.
+
+## Categories
+
+| Category | When to pick | Default body skeleton |
+|---|---|---|
+| `Ideas` (default) | "할까말까", RFC, design exploration. The dominant case for this skill. | RFC template (TL;DR + Why + Goals/Non-Goals + Requirements + Design + Alternatives + Open Questions) |
+| `Q&A` | Self-referential "왜 X 를 Y 방식으로 했지?" or external questions. | Q (1-line) + Context + Best answer so far + Follow-up |
+| `Announcements` | SSOT/policy change broadcasts. Transient. | Announcement (1-2 lines) + Background + Effective date + Links |
+| `Lessons` | Reusable learnings (YouTube/문서/PR 회고). Discussion-first per SSOT — files in `docs/learnings/` are a later promotion. | Source link + Summary + Key takeaways + When to revisit |
+
+The body skeleton variants live in
+[`rfc-template.md`](rfc-template.md) -> "Category variants".
+
+## Fallback rule
+
+If the conversation does not match any category cleanly, default to
+`Ideas`. RFC bodies tolerate ambiguity better than the other three —
+Open Questions captures uncertainty without forcing a structure that
+does not exist yet.
+
+## Out of scope
+
+Auto-categorisation (NLP-style) is **not** a goal. The user calling
+`/gh-discussion-create` with no `[category]` arg has implicitly chosen
+`Ideas`. If they want a different category, they pass it.

--- a/claude/skills/gh-discussion-create/references/create-cmd.md
+++ b/claude/skills/gh-discussion-create/references/create-cmd.md
@@ -1,0 +1,65 @@
+# gh:discussion-create — Step 4 Create Command
+
+Detail companion to SKILL.md Step 4. Writes the drafted body to a temp
+file, appends the ai-metrics footer (unless `GH_DISABLE_AI_METRICS=1`),
+and runs the three GraphQL calls via `gh_discussion.sh`.
+
+`$TOKENS`, `$HUMAN_H`, `$ELAPSED` come from Step 3.5.
+`$TARGET_REPO` is set in Step 1, split into `$_owner` / `$_repo` here.
+`$CATEGORY` defaults to `Ideas` per Step 2 (case-insensitive match
+against the repo's category list).
+`$TITLE` is drafted in Step 3.
+
+```bash
+# shellcheck disable=SC1091
+. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"
+
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write drafted body to "$BODY" ...
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-discussion-create -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-discussion-create -->\n\n</details>\n' \
+      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+fi
+
+_owner="${TARGET_REPO%%/*}"
+_repo="${TARGET_REPO##*/}"
+
+REPO_ID=$(_gh_discussion_repo_id "$_owner" "$_repo") || exit 1
+CATEGORY_ID=$(_gh_discussion_category_id "$_owner" "$_repo" "$CATEGORY") || exit 1
+URL=$(_gh_discussion_create "$REPO_ID" "$CATEGORY_ID" "$TITLE" "$BODY") || exit 1
+
+printf '%s\n' "$URL"
+```
+
+확인 질문하지 말고 즉시 실행.
+
+## ai-metrics footer note
+
+The four emoji glyphs in the printf above (`🤖 📊 👤`) are the
+ai-metrics footer exception defined in `CLAUDE.md`. The exception
+covers exactly this `<details>` wrapper plus the
+`<!-- ai-metrics:gh-discussion-create -->` block. The exception does
+not extend anywhere else in this skill or the helper.
+
+## Why three calls instead of one mutation
+
+`createDiscussion` requires a `repositoryId` and a `categoryId`, both
+of which are **node IDs** (opaque base64 strings), not the
+human-readable `owner/repo` and `Ideas` strings the user works with.
+GitHub's REST API exposes neither write path nor a single "create by
+slug" shortcut — the lookups must happen first. Splitting them into
+three helper calls keeps the failure modes distinct:
+
+- repo lookup fails -> network/auth/missing repo
+- category lookup fails -> Discussions disabled or category typo
+- mutation fails -> permission, validation, or partial outage
+
+Each branch yields a different remediation hint.
+
+## Why no category-ID disk cache
+
+See [`cache-decision.md`](cache-decision.md). Short version: one
+GraphQL call per skill invocation is cheap; a stale cache after the
+user renames a category would be a silent posting bug.

--- a/claude/skills/gh-discussion-create/references/help.md
+++ b/claude/skills/gh-discussion-create/references/help.md
@@ -1,0 +1,85 @@
+# gh:discussion-create — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | remote-name **or** category, or `-h`/`--help`/`help` | `origin` / `Ideas` | First non-flag positional. If it is one of `Ideas`, `Q&A`, `Announcements`, `Lessons`, treated as the category. Otherwise treated as the remote name. |
+| 2 | the other one (remote or category) | (see above) | Second positional resolves whichever slot is still empty. |
+
+Examples:
+
+- `/gh-discussion-create` — `Ideas` Discussion on `origin`'s repo
+- `/gh-discussion-create upstream` — `Ideas` Discussion on `upstream`'s repo
+- `/gh-discussion-create Q&A` — `Q&A` Discussion on `origin`'s repo
+- `/gh-discussion-create upstream Lessons` — `Lessons` Discussion on `upstream`
+- `/gh-discussion-create -h` / `--help` / `help` — print this help
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force-discussion` | off | Bypass the routing guard (Step 2.1) when the chat looks like a decided to-do but is actually RFC-shaped. The guard's reasoning is still printed once for the audit trail. |
+
+## Env Vars
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GH_DISABLE_AI_METRICS=1` | off | Skip the ai-metrics footer in the Discussion body. Mirrors the same env var honoured by `gh:issue-create` and the rest of the gh-* skill family (issue #399). |
+
+## What the skill does
+
+1. Confirms a git repo context and resolves `owner/repo` from the
+   target remote's URL. Fails fast (no silent `origin` fallback) if
+   the remote does not exist.
+2. Picks a Discussion **category** — defaults to `Ideas` (RFC).
+3. Runs the **routing guard**: refuses when the chat looks like a
+   decided to-do (suggests `/gh-issue-create` instead). Override with
+   `--force-discussion`.
+4. Drafts an RFC-shaped body (TL;DR + Why + Goals/Non-Goals + Options
+   + Alternatives + Open Questions). Q&A / Announcements / Lessons
+   categories swap the body skeleton.
+5. Looks up the repository node ID and category ID via GraphQL
+   (`gh_discussion.sh`).
+6. POSTs `createDiscussion` and prints the Discussion URL.
+
+## Title format
+
+Conventional commit-ish: `<type>[(<scope>)]: <한 줄 요약>`. For RFC
+Discussions the type is usually `feat` or `refactor`. `Q&A` titles are
+phrased as the question itself. `Announcements` titles start with
+`announce: ...`. `Lessons` titles start with `lesson: ...`.
+
+## Detail preservation
+
+Same contract as `gh:issue-create`: do NOT over-compress. The
+Discussion is reused later by `gh:discussion-convert` to seed an
+issue body, by future-self search, and by `docs/learnings/` promotion
+(Lessons category). Preserve:
+
+- concrete file paths and line references
+- command outputs and error logs
+- decisions and the reasoning behind them
+- discussion log — never collapse to 2~3 bullets
+
+A 200-line Discussion body is fine if the conversation warranted it.
+
+## What the skill will NOT do
+
+- Auto-create Discussion categories (the API does not allow it; the
+  user must create categories in repo settings first).
+- Apply the routing guard to user requests that already include
+  `--force-discussion` (the override is the contract).
+- Cache category IDs to disk — the lookup is one cheap GraphQL call;
+  staleness risk > savings. See `references/cache-decision.md`.
+- Fall back to `origin` when the user-specified remote is missing.
+- Ask "should I create it?" — running the skill is the confirmation.
+- Truncate or summarise the conversation log.
+
+## Related skills
+
+- [[gh-issue-create]] — sister skill for to-do Issues.
+- [[gh-discussion-convert]] — Discussion -> Issue conversion + back-link.
+- [[gh-issue-create-as-discussion]] — `--as-discussion` routing flag on
+  the issue-create entry point (separate issue).
+- SSOT: `docs/.ssot/discussions-policy.md` (issue #612).

--- a/claude/skills/gh-discussion-create/references/repo-resolution.md
+++ b/claude/skills/gh-discussion-create/references/repo-resolution.md
@@ -1,0 +1,53 @@
+# gh:discussion-create — Repo resolution
+
+Detailed procedure for Step 1 "Detect Repo Context" — remote validation
+and `owner/repo` extraction. SKILL.md keeps only the workflow; this
+file holds the substeps and error-message shape. Mirrors
+`gh-issue-create/references/repo-resolution.md` so behaviour stays
+consistent across the gh-* skill family.
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we are in a git repo.
+
+2. Determine the target remote:
+   - If a non-flag positional that does NOT match a known category
+     (`Ideas`, `Q&A`, `Announcements`, `Lessons`) was passed, use it
+     as the remote name.
+   - Otherwise default to `origin`.
+
+3. Validate the remote and resolve owner/repo:
+
+   ```bash
+   git remote get-url <remote-name>
+   ```
+
+   If this fails, list available remotes (`git remote -v`) and stop
+   with an error like:
+
+   ```
+   Error: remote '<remote-name>' not found. Available remotes:
+   origin    https://github.com/user/repo.git (fetch)
+   upstream  https://github.com/org/repo.git  (fetch)
+   ```
+
+4. Extract `owner/repo` from the remote URL returned in step 3:
+
+   - `https://github.com/<owner>/<repo>.git` -> `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git`     -> `<owner>/<repo>`
+
+Store the resolved `owner/repo` as `TARGET_REPO` for use in Step 4 of
+the main workflow.
+
+## Failure rule
+
+If the user-specified remote does not exist, fail immediately with the
+list of available remotes. **Do not** fall back to `origin` silently —
+that masks typos and posts Discussions in the wrong repo.
+
+## Why this lives in a separate file
+
+The skill body keeps the workflow scannable. The remote-validation
+detail is shared with `gh:issue-create` and (eventually)
+`gh:discussion-convert`; centralising the contract here lets each
+skill summarise it in two lines while linking to one source of truth.

--- a/claude/skills/gh-discussion-create/references/rfc-template.md
+++ b/claude/skills/gh-discussion-create/references/rfc-template.md
@@ -1,0 +1,129 @@
+# Discussion Body Templates
+
+Default category is `Ideas` — use the RFC skeleton. Other categories
+have their own variants in the second half of this file.
+
+## Title format
+
+| Category | Format | Example |
+|---|---|---|
+| `Ideas` | `<type>[(<scope>)]: <한 줄 요약>` | `feat(gh-discussion-create): 대화 -> Ideas RFC Discussion` |
+| `Q&A` | `<질문 한 줄>` (no prefix) | `왜 gh:discussion-create 는 카테고리 ID 를 캐시하지 않는가?` |
+| `Announcements` | `announce: <한 줄 요약>` | `announce: discussions-policy 도입 (#612)` |
+| `Lessons` | `lesson: <한 줄 요약>` | `lesson: GraphQL createDiscussion 권한 요구사항` |
+
+## Ideas — RFC body skeleton (default)
+
+Mirrors `gh-issue-create/references/templates/feat.md` but moves
+**Open Questions** to a more prominent slot and drops Acceptance
+Criteria (RFC has not committed to the work yet).
+
+```markdown
+## TL;DR
+<1~3 lines — what is being explored and why now>
+
+## 배경 (Why / Context)
+<motivation, current pain, link to triggering chats / SSOT>
+
+## Goals / Non-Goals
+### Goals
+-
+### Non-Goals
+-
+
+## 옵션 / Trade-offs
+<핵심 의사결정 후보들. 각 옵션마다 pro/con 명시.>
+- 옵션 A: ...
+  - pro: ...
+  - con: ...
+- 옵션 B: ...
+
+## 대안 (Alternatives Considered)
+| 대안 | 거절 사유 (현재 시점) |
+|---|---|
+|  |  |
+
+## Open Questions
+<RFC 의 핵심. 답이 정해지면 Discussion -> Issue convert.>
+-
+
+## 영향 범위 (Impact, 예상)
+<수정 대상 파일·인접 시스템·마이그레이션 가능성. RFC 단계라 추정 OK.>
+
+## Dependencies
+- 선행: <issue 또는 다른 Discussion>
+- 동격: <관련 RFC 들>
+
+## References
+- 관련 파일·이슈·PR·외부 문서
+- SSOT: docs/.ssot/discussions-policy.md (#612)
+```
+
+## Category variants
+
+### Q&A — body skeleton
+
+```markdown
+## 질문
+<재진술 — 제목보다 1~2 줄 더 풀어서.>
+
+## Context
+<왜 이 질문이 나왔나, 어떤 코드/결정이 트리거인가.>
+
+## 현재까지 알고 있는 것
+- <부분 답·관련 코드 링크·이미 시도한 검색>
+
+## 후속 (Optional)
+<답이 나오면 어디로 정리할지 — docs/learnings, SSOT 갱신, follow-up issue 등.>
+```
+
+### Announcements — body skeleton
+
+```markdown
+## 요약
+<1~2 줄 — 무엇이 바뀌었나.>
+
+## 배경
+<왜 변경했나. 근거 issue/PR 링크.>
+
+## 효력 발생
+- 적용 시점: <YYYY-MM-DD 또는 PR merge 시점>
+- 영향 범위: <어떤 워크플로우·스킬·문서가 바뀌나>
+
+## Action Items
+- [ ] <필요한 후속 작업이 있다면 체크리스트로>
+
+## References
+- 근거: #<N>
+- 관련 SSOT: <경로>
+```
+
+### Lessons — body skeleton
+
+`docs/.ssot/discussions-policy.md` -> "Lessons 카테고리 운영" 에 따르면
+Lessons 는 Discussion-first 다. 짧은 단편 노트는 파일 없이 Discussion
+만 유지한다 — 본문 상단에 출처를 둔다.
+
+```markdown
+## 출처
+- <영상 URL / 문서 링크 / 강연 메모 — 1~2 줄>
+
+## 핵심 요약
+<3~5 줄. "결국 이거 한 줄" 이 무엇인가.>
+
+## 재사용 포인트
+- <언제 다시 꺼낼만한가 — 패턴, 체크리스트, cheat sheet 항목>
+- <언제 안 꺼내도 되는가>
+
+## 본문 / 노트
+<자유 형식. 코드 스니펫·인용·자기 메모 모두 OK.>
+
+## 후속 (Optional)
+<docs/learnings/ 로 승격할 임계치에 도달했나? — 본문/댓글 ≥ 300 줄,
+3 회 이상 외부 참조, 또는 cheat sheet 형태로 재방문 빈도 高.>
+```
+
+## Detail-preservation contract
+
+본문 골격은 **틀**일 뿐이다. 실제 본문은 대화 detail 을 잃지 않도록
+풀어쓴다 — 200 줄 RFC 도 정상이다. `gh:issue-create` 와 동일한 정책.

--- a/claude/skills/gh-discussion-create/references/scope-guard.md
+++ b/claude/skills/gh-discussion-create/references/scope-guard.md
@@ -1,0 +1,86 @@
+# Routing Guard — Issue vs Discussion
+
+Step 2.1 safety net. Implements requirements F-3 + F-4 from issue #617:
+prevent the `Ideas` Discussion bucket from accumulating decided to-do
+items that should have been Issues, and surface ambiguity before the
+mutation runs.
+
+The SSOT principle is `docs/.ssot/discussions-policy.md` -> "운영 원칙
+4 개조" #1: **Issue is default**. Discussion is for items that are too
+early (RFC) or too late (announcement / lesson) to be tracked as
+Issues.
+
+## Trigger signals (decided-to-do)
+
+If **any** of the following match the conversation, treat the chat as
+a decided to-do and refuse with the format below. The user can override
+with `--force-discussion`.
+
+1. **Acceptance criteria are concrete and time-bound** — checklist with
+   filenames, test names, or "by Friday" / "this week" / "before merge"
+   markers.
+2. **Implementation plan is finalised** — concrete file paths, function
+   names, or commit messages drafted in the chat.
+3. **Stakeholder/assignee already named** — "I will do this" / "@user
+   takes this" / explicit ownership decided.
+4. **PR/branch already exists or is implied next** — "let's open a PR"
+   / "I'll push the branch" / "after merge".
+
+## Trigger signals (ambiguous — clarify, do not refuse)
+
+If the chat is RFC-shaped but **scope** is unclear, emit a short
+clarification before calling the mutation. Mirrors
+`gh-issue-create/references/clarification.md` triggers:
+
+1. **동사 없는 명사 나열** — e.g. "사용자 관리 기능", "결제 시스템".
+2. **컴포넌트 ≥ 3 혼재** — backend/frontend/CLI/skill all in one chat.
+3. **Open Questions are missing** — every paragraph is a definitive
+   statement. Discussions thrive on Open Questions; if the chat has
+   none, ask the user to add one before posting.
+
+## Refusal format (decided-to-do match)
+
+```
+이 대화는 결정된 to-do 로 보입니다 — Discussion 보다 Issue 가 적합합니다.
+
+근거:
+  - <signal that matched, e.g. "Acceptance criteria 5 개가 파일 경로로 명시됨">
+  - <second signal if any>
+
+권장:
+  /gh-issue-create
+
+그래도 Discussion 으로 등록하려면:
+  /gh-discussion-create --force-discussion
+```
+
+After printing this, **stop** — do not call the mutation. Skip Steps
+3-5 entirely. The user re-runs with the suggested command if they
+agree, or with `--force-discussion` if they disagree.
+
+## Clarification format (ambiguous match)
+
+```
+Discussion 등록 전에 한 가지만 확인:
+- 이 RFC 의 핵심 Open Question 한 줄로 정리하면 무엇인가요?
+```
+
+Wait for the user to answer; do not call the mutation until they do.
+Once answered, fold the answer into the body's "Open Questions"
+section verbatim.
+
+## No match -> no-op
+
+If neither set of signals matches, this guide is silent. Continue to
+Step 3.
+
+## Why this guard is load-bearing
+
+Without it, the SSOT routing principle erodes within weeks: every
+"I am about to code X" chat would land in `Ideas`, the kanban-board-
+free Discussions forum would silently become the de-facto issue
+tracker, and `gh:discussion-convert`'s back-link audit chain would lose
+its meaning. The guard is the mechanical enforcement of operating
+principle #1.
+
+If you are tempted to remove it, update `discussions-policy.md` first.

--- a/shell-common/functions/gh_discussion.sh
+++ b/shell-common/functions/gh_discussion.sh
@@ -39,17 +39,8 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-_gh_discussion__require_args() {
-    # _gh_discussion__require_args <expected-count> <fn-name> <usage-tail>
-    if [ "$1" -ne "$2" ]; then
-        printf '[gh-discussion] usage: %s %s\n' "$3" "$4" >&2
-        return 2
-    fi
-    return 0
-}
-
 _gh_discussion_repo_id() {
-    local _owner="$1" _repo="$2"
+    local _owner="${1:-}" _repo="${2:-}"
     if [ -z "$_owner" ] || [ -z "$_repo" ]; then
         printf '[gh-discussion] usage: _gh_discussion_repo_id <owner> <repo>\n' >&2
         return 2
@@ -86,7 +77,7 @@ _gh_discussion_repo_id() {
 }
 
 _gh_discussion_category_id() {
-    local _owner="$1" _repo="$2" _category="$3"
+    local _owner="${1:-}" _repo="${2:-}" _category="${3:-}"
     if [ -z "$_owner" ] || [ -z "$_repo" ] || [ -z "$_category" ]; then
         printf '[gh-discussion] usage: _gh_discussion_category_id <owner> <repo> <category>\n' >&2
         return 2
@@ -150,7 +141,7 @@ _gh_discussion_category_id() {
 }
 
 _gh_discussion_create() {
-    local _repo_id="$1" _category_id="$2" _title="$3" _body_file="$4"
+    local _repo_id="${1:-}" _category_id="${2:-}" _title="${3:-}" _body_file="${4:-}"
     if [ -z "$_repo_id" ] || [ -z "$_category_id" ] || [ -z "$_title" ] ||
         [ -z "$_body_file" ]; then
         printf '[gh-discussion] usage: _gh_discussion_create <repo-id> <category-id> <title> <body-file>\n' >&2
@@ -160,9 +151,6 @@ _gh_discussion_create() {
         printf '[gh-discussion] body-file not found: %s\n' "$_body_file" >&2
         return 2
     fi
-
-    local _body
-    _body=$(cat "$_body_file") || return 1
 
     local _err _url
     _err=$(mktemp) || return 1
@@ -187,7 +175,7 @@ _gh_discussion_create() {
         -f repoId="$_repo_id" \
         -f categoryId="$_category_id" \
         -f title="$_title" \
-        -f body="$_body" \
+        -f "body=@$_body_file" \
         --jq '.data.createDiscussion.discussion.url' 2>"$_err")
     local _rc=$?
 

--- a/shell-common/functions/gh_discussion.sh
+++ b/shell-common/functions/gh_discussion.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_discussion.sh
+# GraphQL wrappers for the GitHub Discussions write API. The REST endpoints
+# for Discussions are read-only — `createDiscussion` and friends only exist
+# in GraphQL — so this helper centralises the mutation + the lookup chain
+# (repository ID -> category ID) the mutation depends on.
+#
+# Background (issue #617):
+# `gh:discussion-create` and `gh:discussion-convert` both need the same
+# three primitives: resolve a repository node ID, resolve a Discussion
+# category node ID by name, and POST a `createDiscussion` mutation. Keeping
+# the GraphQL strings inside one helper lets the skill stay focused on
+# conversation routing while the contract with GitHub's API lives in one
+# auditable file.
+#
+# Usage:
+#   _gh_discussion_repo_id     <owner> <repo>
+#       Print the repository node ID on stdout. Exit non-zero on lookup
+#       failure (network, auth, or missing repo).
+#
+#   _gh_discussion_category_id <owner> <repo> <category-name>
+#       Print the matching Discussion category node ID on stdout. Exit 1
+#       when Discussions are disabled on the repo (empty list returned),
+#       exit 2 when the category name does not resolve.
+#
+#   _gh_discussion_create      <repo-id> <category-id> <title> <body-file>
+#       POST createDiscussion. Print the Discussion URL on stdout. Exit
+#       non-zero on mutation failure (auth, validation, network).
+#
+# Repo node ID and category ID lookups are cheap enough to do per call —
+# do not introduce a disk cache (see references/cache-decision in the
+# accompanying skill) until a profile shows it matters.
+#
+# Failure policy: every helper writes a single `[gh-discussion] <reason>`
+# line to stderr and returns a non-zero exit code so the caller can
+# present the user with an actionable message. Helpers never call
+# `exit` — they `return` so a sourced caller stays in the same shell.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+_gh_discussion__require_args() {
+    # _gh_discussion__require_args <expected-count> <fn-name> <usage-tail>
+    if [ "$1" -ne "$2" ]; then
+        printf '[gh-discussion] usage: %s %s\n' "$3" "$4" >&2
+        return 2
+    fi
+    return 0
+}
+
+_gh_discussion_repo_id() {
+    local _owner="$1" _repo="$2"
+    if [ -z "$_owner" ] || [ -z "$_repo" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_repo_id <owner> <repo>\n' >&2
+        return 2
+    fi
+
+    local _err _id
+    _err=$(mktemp) || return 1
+
+    # GraphQL variables ($owner, $repo) are NOT shell vars — they are bound
+    # via the -f flags below, so single quotes are intended.
+    # Variables: $owner String!, $repo String!
+    # shellcheck disable=SC2016
+    _id=$(gh api graphql \
+        -f query='
+          query($owner: String!, $repo: String!) {
+            repository(owner: $owner, name: $repo) { id }
+          }' \
+        -f owner="$_owner" -f repo="$_repo" \
+        --jq '.data.repository.id' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ] || [ -z "$_id" ] || [ "$_id" = "null" ]; then
+        printf '[gh-discussion] repository lookup failed for %s/%s\n' \
+            "$_owner" "$_repo" >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+
+    rm -f "$_err"
+    printf '%s\n' "$_id"
+}
+
+_gh_discussion_category_id() {
+    local _owner="$1" _repo="$2" _category="$3"
+    if [ -z "$_owner" ] || [ -z "$_repo" ] || [ -z "$_category" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_category_id <owner> <repo> <category>\n' >&2
+        return 2
+    fi
+
+    local _err _list
+    _err=$(mktemp) || return 1
+
+    # Pull every category in one shot (repos rarely have > 10) and let jq
+    # match by name. Doing the filter client-side keeps the GraphQL string
+    # short and avoids edge cases around case sensitivity in the API.
+    # Variables: $owner String!, $repo String!
+    # shellcheck disable=SC2016
+    _list=$(gh api graphql \
+        -f query='
+          query($owner: String!, $repo: String!) {
+            repository(owner: $owner, name: $repo) {
+              discussionCategories(first: 25) {
+                nodes { id name }
+              }
+            }
+          }' \
+        -f owner="$_owner" -f repo="$_repo" \
+        --jq '.data.repository.discussionCategories.nodes' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ]; then
+        printf '[gh-discussion] category lookup failed for %s/%s\n' \
+            "$_owner" "$_repo" >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+    rm -f "$_err"
+
+    # Empty list -> Discussions feature disabled on the repo. Distinct
+    # exit code (1) so the skill can show the "enable in repo settings"
+    # hint without confusing it with a missing category.
+    if [ -z "$_list" ] || [ "$_list" = "null" ] || [ "$_list" = "[]" ]; then
+        printf '[gh-discussion] Discussions not enabled on %s/%s — enable in repo settings -> Features\n' \
+            "$_owner" "$_repo" >&2
+        return 1
+    fi
+
+    local _id
+    _id=$(printf '%s' "$_list" |
+        jq -r --arg name "$_category" \
+            '.[] | select((.name | ascii_downcase) == ($name | ascii_downcase)) | .id' |
+        head -n 1)
+
+    if [ -z "$_id" ]; then
+        printf '[gh-discussion] category "%s" not found on %s/%s; available:\n' \
+            "$_category" "$_owner" "$_repo" >&2
+        printf '%s' "$_list" | jq -r '.[].name | "  - " + .' >&2
+        return 2
+    fi
+
+    printf '%s\n' "$_id"
+}
+
+_gh_discussion_create() {
+    local _repo_id="$1" _category_id="$2" _title="$3" _body_file="$4"
+    if [ -z "$_repo_id" ] || [ -z "$_category_id" ] || [ -z "$_title" ] ||
+        [ -z "$_body_file" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_create <repo-id> <category-id> <title> <body-file>\n' >&2
+        return 2
+    fi
+    if [ ! -f "$_body_file" ]; then
+        printf '[gh-discussion] body-file not found: %s\n' "$_body_file" >&2
+        return 2
+    fi
+
+    local _body
+    _body=$(cat "$_body_file") || return 1
+
+    local _err _url
+    _err=$(mktemp) || return 1
+
+    # GraphQL variables ($repoId, $categoryId, $title, $body) are NOT shell
+    # vars — they are bound via the -f flags below, so single quotes are
+    # intended.
+    # Variables: $repoId ID!, $categoryId ID!, $title String!, $body String!
+    # shellcheck disable=SC2016
+    _url=$(gh api graphql \
+        -f query='
+          mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+            createDiscussion(input: {
+              repositoryId: $repoId,
+              categoryId:   $categoryId,
+              title:        $title,
+              body:         $body
+            }) {
+              discussion { url }
+            }
+          }' \
+        -f repoId="$_repo_id" \
+        -f categoryId="$_category_id" \
+        -f title="$_title" \
+        -f body="$_body" \
+        --jq '.data.createDiscussion.discussion.url' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ] || [ -z "$_url" ] || [ "$_url" = "null" ]; then
+        printf '[gh-discussion] createDiscussion mutation failed\n' >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+
+    rm -f "$_err"
+    printf '%s\n' "$_url"
+}

--- a/tests/bats/functions/gh_discussion.bats
+++ b/tests/bats/functions/gh_discussion.bats
@@ -1,0 +1,295 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_discussion.bats
+# Unit tests for _gh_discussion_repo_id / _gh_discussion_category_id /
+# _gh_discussion_create — the GraphQL wrappers used by the
+# `gh:discussion-create` skill (issue #617).
+#
+# Network is never touched. A fake `gh` shim on PATH dispatches by
+# inspecting the GraphQL query string for keywords ("repository(...){ id }",
+# "discussionCategories", "createDiscussion") and emits the JSON the helper
+# would have received, post-`--jq`. Mirrors the gh_pr_edit_safe.bats pattern.
+#
+# Per project memory feedback_no_live_api_for_smoke_test, no smoke-test path
+# hits the real GitHub API.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    _setup_fake_gh
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Fake `gh` shim
+#
+# FAKE_GH_MODE controls behaviour:
+#   ok                     — every call succeeds with sensible defaults
+#   repo_fail              — repository lookup returns auth error (exit 1)
+#   discussions_disabled   — discussionCategories returns []
+#   category_missing       — list has Ideas/Q&A but not the requested one
+#   mutation_fail          — repo + category succeed, createDiscussion exits 1
+#
+# A scratch log records every call for assertion: $TEST_TEMP_HOME/gh.log
+# ---------------------------------------------------------------------------
+_setup_fake_gh() {
+    STUB_BIN="$TEST_TEMP_HOME/bin"
+    mkdir -p "$STUB_BIN"
+    GH_LOG="$TEST_TEMP_HOME/gh.log"
+    : >"$GH_LOG"
+    cat >"$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+# Record the invocation for inspection.
+{ printf 'gh'; for a in "$@"; do printf ' %q' "$a"; done; printf '\n'; } \
+    >>"$GH_LOG"
+
+mode="${FAKE_GH_MODE:-ok}"
+
+# All real calls are `gh api graphql -f query=... -f var=val ... [--jq EXPR]`.
+# Pull the query body out of argv so we can dispatch on keywords.
+query=""
+for a in "$@"; do
+    case "$a" in
+        query=*) query="${a#query=}" ;;
+    esac
+done
+
+# Repo node ID lookup
+if [[ "$query" == *"repository(owner: "*"){ id }"* ]] \
+    || [[ "$query" == *"repository(owner: \$owner, name: \$repo) { id }"* ]]; then
+    case "$mode" in
+        repo_fail)
+            echo "GraphQL: Could not resolve to a Repository" >&2
+            exit 1
+            ;;
+        *)
+            # The helper's --jq '.data.repository.id' would extract this value.
+            echo "R_kgDOFAKE_REPO_ID"
+            exit 0
+            ;;
+    esac
+fi
+
+# Category list lookup
+if [[ "$query" == *"discussionCategories(first: 25)"* ]]; then
+    case "$mode" in
+        discussions_disabled)
+            # Helper checks for "[]" / "null" / empty.
+            echo "[]"
+            exit 0
+            ;;
+        category_missing)
+            # No "Ideas" entry; helper's jq filter returns empty.
+            echo '[{"id":"DIC_aaa","name":"Q&A"},{"id":"DIC_bbb","name":"Lessons"}]'
+            exit 0
+            ;;
+        *)
+            echo '[{"id":"DIC_kIDEAS","name":"Ideas"},{"id":"DIC_kQA","name":"Q&A"},{"id":"DIC_kANN","name":"Announcements"},{"id":"DIC_kLES","name":"Lessons"}]'
+            exit 0
+            ;;
+    esac
+fi
+
+# createDiscussion mutation
+if [[ "$query" == *"createDiscussion(input:"* ]]; then
+    case "$mode" in
+        mutation_fail)
+            echo "GraphQL: Resource not accessible by integration" >&2
+            exit 1
+            ;;
+        *)
+            echo "https://github.com/fake/repo/discussions/123"
+            exit 0
+            ;;
+    esac
+fi
+
+# Unknown call — fail loudly so we notice missed mock paths.
+echo "fake-gh: unhandled call: $*" >&2
+exit 99
+GH
+    chmod +x "$STUB_BIN/gh"
+}
+
+# Run a snippet in bash with the shim on PATH and the helper sourced.
+_run_helper() {
+    local mode="$1" snippet="$2"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:${PATH}'
+        export FAKE_GH_MODE='${mode}'
+        export GH_LOG='${GH_LOG}'
+        . '${DOTFILES_ROOT}/shell-common/functions/gh_discussion.sh'
+        ${snippet}
+        echo \"rc=\$?\"
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Loading: helpers exist after sourcing
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_discussion_repo_id exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_repo_id >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_discussion_category_id exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_category_id >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_discussion_create exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_create >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_discussion_repo_id exists" {
+    run_in_zsh '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                typeset -f _gh_discussion_repo_id >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+@test "repo_id: missing args returns 2" {
+    _run_helper ok '_gh_discussion_repo_id 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_repo_id"
+}
+
+@test "category_id: missing args returns 2" {
+    _run_helper ok '_gh_discussion_category_id fake 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_category_id"
+}
+
+@test "create: missing args returns 2" {
+    _run_helper ok '_gh_discussion_create REPO CAT 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_create"
+}
+
+@test "create: missing body-file returns 2" {
+    _run_helper ok '_gh_discussion_create REPO CAT "title" /nonexistent/abc.txt 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "body-file not found"
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: each helper succeeds
+# ---------------------------------------------------------------------------
+
+@test "repo_id: ok mode prints node ID and rc=0" {
+    _run_helper ok '_gh_discussion_repo_id fake repo'
+    assert_output --partial "R_kgDOFAKE_REPO_ID"
+    assert_output --partial "rc=0"
+}
+
+@test "category_id: ok mode picks Ideas (case-insensitive)" {
+    _run_helper ok '_gh_discussion_category_id fake repo ideas'
+    assert_output --partial "DIC_kIDEAS"
+    assert_output --partial "rc=0"
+}
+
+@test "category_id: ok mode resolves Q&A" {
+    _run_helper ok "_gh_discussion_category_id fake repo 'Q&A'"
+    assert_output --partial "DIC_kQA"
+    assert_output --partial "rc=0"
+}
+
+@test "create: ok mode prints discussion URL" {
+    _run_helper ok "
+        BF=\$(mktemp); printf 'body content' > \"\$BF\"
+        _gh_discussion_create R_kgDO DIC_k 'My RFC title' \"\$BF\"
+        _rc=\$?
+        rm -f \"\$BF\"
+        ( exit \$_rc )
+    "
+    assert_output --partial "https://github.com/fake/repo/discussions/123"
+    assert_output --partial "rc=0"
+    # Mutation issued exactly once.
+    run grep -c 'createDiscussion' "$GH_LOG"
+    assert_output "1"
+}
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+@test "repo_id: repo_fail mode returns 1 with stderr trace" {
+    _run_helper repo_fail '_gh_discussion_repo_id fake repo 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "repository lookup failed for fake/repo"
+    assert_output --partial "Could not resolve to a Repository"
+}
+
+@test "category_id: discussions_disabled returns 1 with enable hint" {
+    _run_helper discussions_disabled '_gh_discussion_category_id fake repo Ideas 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "Discussions not enabled on fake/repo"
+    assert_output --partial "enable in repo settings"
+}
+
+@test "category_id: category_missing returns 2 with available list" {
+    _run_helper category_missing '_gh_discussion_category_id fake repo Ideas 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial 'category "Ideas" not found on fake/repo'
+    # Available categories are listed for the user.
+    assert_output --partial "Q&A"
+    assert_output --partial "Lessons"
+}
+
+@test "create: mutation_fail returns 1 with stderr trace" {
+    _run_helper mutation_fail "
+        BF=\$(mktemp); printf 'x' > \"\$BF\"
+        _gh_discussion_create R_kgDO DIC_k 'title' \"\$BF\" 2>&1
+        _rc=\$?
+        rm -f \"\$BF\"
+        ( exit \$_rc )
+    "
+    assert_output --partial "rc=1"
+    assert_output --partial "createDiscussion mutation failed"
+    assert_output --partial "Resource not accessible by integration"
+}
+
+# ---------------------------------------------------------------------------
+# GraphQL query shape — verify the mutation sends the expected variables
+# ---------------------------------------------------------------------------
+
+@test "create: invocation includes repoId/categoryId/title/body variables" {
+    _run_helper ok "
+        BF=\$(mktemp); printf 'hello world' > \"\$BF\"
+        _gh_discussion_create R_kgDO_TEST DIC_kTEST 'Test title' \"\$BF\"
+        _rc=\$?
+        rm -f \"\$BF\"
+        ( exit \$_rc )
+    "
+    assert_output --partial "rc=0"
+    # All four named -f variables present in the recorded invocation.
+    run grep -c 'repoId=R_kgDO_TEST' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'categoryId=DIC_kTEST' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'title=Test\\ title' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'body=hello\\ world' "$GH_LOG"
+    assert_output "1"
+}

--- a/tests/bats/functions/gh_discussion.bats
+++ b/tests/bats/functions/gh_discussion.bats
@@ -284,12 +284,15 @@ _run_helper() {
     "
     assert_output --partial "rc=0"
     # All four named -f variables present in the recorded invocation.
+    # The body is passed as `-f body=@<file>` so gh reads the file at
+    # call time (no shell allocation), so the recorded arg shows the
+    # `@<path>` reference, not the file's contents (PR #624 review).
     run grep -c 'repoId=R_kgDO_TEST' "$GH_LOG"
     assert_output "1"
     run grep -c 'categoryId=DIC_kTEST' "$GH_LOG"
     assert_output "1"
     run grep -c 'title=Test\\ title' "$GH_LOG"
     assert_output "1"
-    run grep -c 'body=hello\\ world' "$GH_LOG"
+    run grep -cE 'body=@[^ ]+' "$GH_LOG"
     assert_output "1"
 }


### PR DESCRIPTION
## Summary
- 신규 스킬 `gh:discussion-create` 추가 — 현재 Claude Code 대화를 GitHub Discussions(`Ideas` 기본)로 등록하는 `gh:issue-create` 의 자매 스킬.
- GraphQL `createDiscussion` 헬퍼 (`shell-common/functions/gh_discussion.sh`) — `gh:discussion-convert` 와 공유 예정. Discussions REST 는 read-only 이므로 write 는 GraphQL 만 가능.
- 17개 fake-shim bats 테스트로 GraphQL 호출 형태·실패 분기·variable shape 회귀 가드. 라이브 API 호출 없음.

## Changes
- `shell-common/functions/gh_discussion.sh`: `_gh_discussion_repo_id` / `_gh_discussion_category_id` / `_gh_discussion_create` 세 헬퍼. 별도 exit code 로 "Discussions 비활성화 repo" 와 "카테고리 미존재" 를 구분해 skill 이 actionable 한 안내 메시지를 출력할 수 있게 함.
- `claude/skills/gh-discussion-create/SKILL.md` + 7 references: progressive-disclosure 구조. Step 2.1 routing guard 가 결정된 to-do 대화는 `--force-discussion` 없이 거부 (issue #617 의 F-3 + F-4). 본문 템플릿은 Acceptance Criteria 대신 **Open Questions** 부각.
- `claude/skills/gh-discussion-create/references/cache-decision.md`: issue #617 의 Open Question (카테고리 ID 캐시 위치) 에 대한 결정 — **캐시하지 않음**. GraphQL 1회 호출 비용 < staleness footgun. reverse criteria (10/day 이상 호출 / 카테고리 25개 이상 등) 에 도달하면 재검토.
- `tests/bats/functions/gh_discussion.bats`: 17 케이스 — bash/zsh 로딩, 인자 검증, 세 헬퍼의 happy path, Discussions 비활성화 / 카테고리 부재 / mutation 실패 분기, GraphQL `-f` variable shape 검증 (`repoId=...`, `categoryId=...`, `title=...`, `body=...`).

## Test plan
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_discussion.sh` — pass
- [x] `shfmt -i 4 -ci shell-common/functions/gh_discussion.sh` — pass
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_discussion.bats` — 17/17 pass
- [x] `tox -e ruff,shellcheck,shfmt` (lint guard) — pass
- [ ] (수동) live repo 에서 `/gh-discussion-create` 호출 시 Ideas Discussion 정상 등록되는지 smoke (smoke-test 는 별도 follow-up; live API 호출은 본 PR 범위 외)
- [ ] (수동) `--force-discussion` 없이 결정된 to-do 대화에서 호출 시 routing guard 가 거부 메시지 출력하는지 확인

## Related
Closes #617

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
