### PR TITLE
feat(gh-pr): #614 hard-fail when stacked parent PR is not OPEN (F-4)

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -35,6 +35,7 @@ body. Push the branch if needed. Return the PR URL.
 | `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
 
 `--no-stack` and `--base` are mutually exclusive — see Step 1a exit codes.
+Auto-detected parent PR must be `OPEN` — refuses (rc=5) otherwise.
 
 ## Step 1: Parse Args, Resolve Base Branch, Gather State
 
@@ -43,11 +44,14 @@ Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 ### Step 1a: Parse args + resolve base via stacked-PR detection
 
 Read `references/stacked-pr.md` and paste the SSOT functions
-(`parse_stacked_args`, `is_stacked_pr_repo`, `find_parent_pr_candidates`)
-and the dispatch block ("How Step 1 of SKILL.md ties it together")
-verbatim. They bind `BASE_BRANCH`, `PARENT_PR`, and `ISSUE_NUMBER`, and
-they exit on bad input — `rc=2` for mutually-exclusive flags, `rc=3`
-for a bad `--base` value. Abort without pushing on either.
+(`parse_stacked_args`, `is_stacked_pr_repo`, `find_parent_pr_candidates`,
+`assert_parent_pr_open`) and the dispatch block ("How Step 1 of
+SKILL.md ties it together") verbatim. They bind `BASE_BRANCH`,
+`PARENT_PR`, and `ISSUE_NUMBER`, and they exit on bad input — `rc=2`
+for mutually-exclusive flags, `rc=3` for a bad `--base` value, `rc=5`
+when the auto-detected parent PR is no longer `OPEN` (stacking refuses
+on closed/merged parents — recovery hint: reopen the parent or rerun
+with `--no-stack`). Abort without pushing on any of them.
 
 ### Step 1b: Gather range + push state (parallel)
 

--- a/claude/skills/gh-pr/references/constraints.md
+++ b/claude/skills/gh-pr/references/constraints.md
@@ -25,6 +25,16 @@ never auto-stack on a repo that does not match `is_stacked_pr_repo`,
 and never silently downgrade to the default branch when the user
 explicitly passed `--base`.
 
+## Parent PR state (stacked auto-detect)
+
+When Stage 2 of `references/stacked-pr.md` selects a parent PR for
+stacking, the parent's GitHub state **must** be `OPEN`. Re-check via
+`gh pr view <N> --json state` right before the base branch decision is
+committed (see `assert_parent_pr_open`). Closed or merged parents abort
+with rc=5 plus a one-line recovery hint — never silently fall back to
+the default branch, since that would change the PR's meaning without
+asking the user.
+
 ## AI footers
 
 Never include `🤖 Generated with` or any "Claude Code" footer in the PR

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -236,7 +236,7 @@ agent-toolbox `github-workflow` driver — both drivers share the gate.
 # Helper — fetch the parent PR's state. Overridable in tests via
 # FAKE_PARENT_STATE so bats does not need a live `gh`.
 _gh_pr_default_parent_state() {
-    local _pr="$1"
+    local _pr="${1:-}"
     if [ -n "${FAKE_PARENT_STATE+set}" ]; then
         printf '%s\n' "$FAKE_PARENT_STATE"
         return 0
@@ -246,7 +246,7 @@ _gh_pr_default_parent_state() {
 
 # Returns 0 when state == OPEN, 5 otherwise (with recovery hint on stderr).
 assert_parent_pr_open() {
-    local _pr="$1" _state
+    local _pr="${1:-}" _state
     _state=$(_gh_pr_default_parent_state "$_pr")
     if [ "$_state" != "OPEN" ]; then
         printf 'gh:pr: parent PR #%s state=%s — stacking requires OPEN parent.\n' \

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -223,6 +223,45 @@ EOF
 }
 ```
 
+## Parent state pre-check — `assert_parent_pr_open`
+
+`find_parent_pr_candidates` already filters by `--state open`, but there
+is a TOCTOU window between Stage 2 and `gh pr create` (Step 5) where the
+parent can be merged or closed. The guard below re-reads the parent
+state right before the base branch decision is committed and aborts
+with **rc=5** when it is no longer `OPEN`. Same invariant as the
+agent-toolbox `github-workflow` driver — both drivers share the gate.
+
+```sh
+# Helper — fetch the parent PR's state. Overridable in tests via
+# FAKE_PARENT_STATE so bats does not need a live `gh`.
+_gh_pr_default_parent_state() {
+    local _pr="$1"
+    if [ -n "${FAKE_PARENT_STATE+set}" ]; then
+        printf '%s\n' "$FAKE_PARENT_STATE"
+        return 0
+    fi
+    gh pr view "$_pr" --json state -q .state 2>/dev/null
+}
+
+# Returns 0 when state == OPEN, 5 otherwise (with recovery hint on stderr).
+assert_parent_pr_open() {
+    local _pr="$1" _state
+    _state=$(_gh_pr_default_parent_state "$_pr")
+    if [ "$_state" != "OPEN" ]; then
+        printf 'gh:pr: parent PR #%s state=%s — stacking requires OPEN parent.\n' \
+            "$_pr" "${_state:-UNKNOWN}" >&2
+        printf 'Next: reopen parent, or run with --no-stack.\n' >&2
+        return 5
+    fi
+    return 0
+}
+```
+
+Single API call (`gh pr view --json state`) per stacked-PR invocation —
+0 overhead in the solo / non-stacked path because the helper only runs
+inside the 1-candidate branch of the Stage-2 dispatch.
+
 ## How Step 1 of `SKILL.md` ties it together
 
 ```sh
@@ -244,6 +283,7 @@ case "$STACK_MODE" in
                 1)
                     PARENT_PR="${CANDIDATES%%:*}"
                     BASE_BRANCH="${CANDIDATES#*:}"
+                    assert_parent_pr_open "$PARENT_PR" || return $?
                     printf 'Stacking on PR #%s (auto-detected)\n' "$PARENT_PR" ;;
                 *)
                     # 2+ candidates — bash cannot prompt safely (Claude Code is
@@ -288,6 +328,22 @@ hatch flag (`--base <branch>` or `--no-stack`). This avoids hanging on
 | `--base release/v2.0` | `/gh-pr --base release/v2.0` | arbitrary branch forced |
 | Mutually-exclusive flags | `/gh-pr --no-stack --base main` | rc=2, abort |
 | Bad `--base` value | `/gh-pr --base` (missing arg) | rc=3, abort |
+| Parent state ≠ OPEN | `/gh-pr` (auto-detected parent CLOSED/MERGED) | rc=5, abort with recovery hint |
 
-The 8 rows above are the regression contract — every change to the
+The 9 rows above are the regression contract — every change to the
 detection logic must keep them green.
+
+## Exit codes (Step 1a dispatch)
+
+| rc | Meaning |
+|---|---|
+| 0 | Base branch resolved; proceed to Step 1b. |
+| 2 | `--no-stack` and `--base` were both passed (mutually exclusive). |
+| 3 | `--base` was passed without a branch value. |
+| 4 | Stage 2 produced 2+ parent candidates — AI executor must ask the user. |
+| 5 | Auto-detected parent PR is not `OPEN` — stacking refused. |
+
+rc=4 (ambiguous parent) and rc=5 (parent-not-open) are semantically
+distinct — both block the dispatch but only rc=5 means "the parent is
+no longer a valid stacking target". Treat them separately when wiring
+recovery hints.

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -139,3 +139,25 @@ find_parent_pr_candidates() {
 $_candidates
 EOF
 }
+
+# ── Parent state pre-check (F-4) ───────────────────────────────────────
+_gh_pr_default_parent_state() {
+    local _pr="$1"
+    if [ -n "${FAKE_PARENT_STATE+set}" ]; then
+        printf '%s\n' "$FAKE_PARENT_STATE"
+        return 0
+    fi
+    gh pr view "$_pr" --json state -q .state 2>/dev/null
+}
+
+assert_parent_pr_open() {
+    local _pr="$1" _state
+    _state=$(_gh_pr_default_parent_state "$_pr")
+    if [ "$_state" != "OPEN" ]; then
+        printf 'gh:pr: parent PR #%s state=%s — stacking requires OPEN parent.\n' \
+            "$_pr" "${_state:-UNKNOWN}" >&2
+        printf 'Next: reopen parent, or run with --no-stack.\n' >&2
+        return 5
+    fi
+    return 0
+}

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -142,7 +142,7 @@ EOF
 
 # ── Parent state pre-check (F-4) ───────────────────────────────────────
 _gh_pr_default_parent_state() {
-    local _pr="$1"
+    local _pr="${1:-}"
     if [ -n "${FAKE_PARENT_STATE+set}" ]; then
         printf '%s\n' "$FAKE_PARENT_STATE"
         return 0
@@ -151,7 +151,7 @@ _gh_pr_default_parent_state() {
 }
 
 assert_parent_pr_open() {
-    local _pr="$1" _state
+    local _pr="${1:-}" _state
     _state=$(_gh_pr_default_parent_state "$_pr")
     if [ "$_state" != "OPEN" ]; then
         printf 'gh:pr: parent PR #%s state=%s — stacking requires OPEN parent.\n' \

--- a/tests/bats/skills/gh_pr_stacked_detect.bats
+++ b/tests/bats/skills/gh_pr_stacked_detect.bats
@@ -4,7 +4,7 @@
 #   claude/skills/gh-pr/references/stacked-pr.md
 # Source-of-truth fixture: _fixtures/gh_pr_stacked_detect.sh.
 #
-# 8-case compatibility matrix (issue #615 trimmed the prior 9-case set):
+# 9-case compatibility matrix (issue #614 re-added case 9 for parent state):
 #   1. dotfiles solo (no stacked signals)        → Stage 1 fail, base=default
 #   2. AgentToolbox parent unique                → Stage 1+2, 1 candidate
 #   3. AgentToolbox parent ambiguous             → Stage 1+2, 2+ candidates
@@ -13,6 +13,7 @@
 #   6. --base <branch> override                  → mode=base
 #   7. Mutually-exclusive flags (--no-stack + --base) → rc=2 abort
 #   8. --base (missing arg)                      → rc=3 abort
+#   9. Auto-detected parent state ≠ OPEN          → rc=5 abort + hint
 
 load '../test_helper'
 
@@ -25,7 +26,7 @@ setup() {
 
 teardown() {
     [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] && rm -rf "$REPO_ROOT"
-    unset FAKE_OPEN_PRS FAKE_ANCESTOR_REFS FAKE_NONDEFAULT_REFS
+    unset FAKE_OPEN_PRS FAKE_ANCESTOR_REFS FAKE_NONDEFAULT_REFS FAKE_PARENT_STATE
     unset STACK_MODE STACK_BASE ISSUE_NUMBER
     teardown_isolated_home
 }
@@ -155,6 +156,30 @@ teardown() {
     run parse_stacked_args --base
     [ "$status" -eq 3 ]
     assert_output --partial 'requires a branch name'
+}
+
+# ── Compatibility matrix #9: parent state guard (F-4) ─────────────────
+@test "matrix-9: parent state OPEN → assert_parent_pr_open succeeds silently" {
+    FAKE_PARENT_STATE=OPEN
+    run assert_parent_pr_open 201
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "matrix-9: parent state CLOSED → rc=5 with recovery hint on stderr" {
+    FAKE_PARENT_STATE=CLOSED
+    run assert_parent_pr_open 201
+    [ "$status" -eq 5 ]
+    assert_output --partial 'parent PR #201 state=CLOSED'
+    assert_output --partial 'stacking requires OPEN parent'
+    assert_output --partial '--no-stack'
+}
+
+@test "matrix-9: parent state MERGED → rc=5 with recovery hint" {
+    FAKE_PARENT_STATE=MERGED
+    run assert_parent_pr_open 201
+    [ "$status" -eq 5 ]
+    assert_output --partial 'state=MERGED'
 }
 
 # ── Legacy positional issue arg still parsed ──────────────────────────


### PR DESCRIPTION
## Summary
- `gh:pr` stacked auto-detect now hard-fails when the parent PR is not `OPEN`, matching the agent-toolbox `github-workflow` invariant (#611 F-4 asymmetry closed).
- 새 `assert_parent_pr_open` 헬퍼가 Stage 2 1-candidate 분기에서 `gh pr view --json state` 를 한 번 호출 → 닫혀 있으면 rc=5 + recovery hint 로 종료.
- TOCTOU 보호: `find_parent_pr_candidates` 가 `--state open` 으로 필터링한 직후라도 `gh pr create` 직전 closure/merge 가 발생할 수 있다는 시나리오 차단.

## Changes
- **`claude/skills/gh-pr/references/stacked-pr.md`** — `_gh_pr_default_parent_state` + `assert_parent_pr_open` 헬퍼 추가, 1-candidate 디스패치 분기에 가드 삽입, compatibility matrix 8→9 행 확장, rc-code 표 신설 (rc=4 ambiguous-parent 와 rc=5 parent-not-open 분리 명시).
- **`claude/skills/gh-pr/SKILL.md`** — Step 1a 설명에 `assert_parent_pr_open` + rc=5 추가, Options 표 아래에 "Auto-detected parent PR must be OPEN — refuses (rc=5) otherwise." 한 줄.
- **`claude/skills/gh-pr/references/constraints.md`** — "Parent PR state" 섹션 추가 (closed/merged → rc=5, 절대 silent fallback 금지).
- **`tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh`** — 헬퍼 미러 + `FAKE_PARENT_STATE` 테스트 override.
- **`tests/bats/skills/gh_pr_stacked_detect.bats`** — matrix-9 케이스 3건 (OPEN silent pass / CLOSED rc=5+hint / MERGED rc=5).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_stacked_detect.bats` — 21/21 통과 (기존 18 + 신규 3).
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/` — 151/152 통과. 1 실패 (`gh_disable_ai_metrics` doc-guard against `gh-issue-create/SKILL.md`) 는 이 PR 의 범위 밖 사전-존재 실패.
- [x] `tox -e ruff,shellcheck,shfmt` — clean (lint guard 통과).
- [x] `shellcheck tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh` — clean.

## Related
Closes #614

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
