### PR TITLE
feat(gh-pr): #616 multi-stack abort matches agent-toolbox (F-6)

### DIFF
--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -261,8 +261,9 @@ _gh_pr_default_parent_state() {
         return 0
     fi
     _delim=$(printf '\001')   # ASCII SOH — never appears in PR bodies
+    # shellcheck disable=SC2016  # $d is a jq variable (--arg d), not shell
     _meta=$(gh pr view "$_pr" --json state,body \
-        --jq '"\(.state)\(.body)"' 2>/dev/null)
+        --jq --arg d "$_delim" '.state + $d + .body' 2>/dev/null)
     _GH_PR_PARENT_BODY_CACHE="${_meta#*"$_delim"}"
     printf '%s\n' "${_meta%%"$_delim"*}"
 }
@@ -297,9 +298,12 @@ assert_parent_pr_open() {
 }
 
 # Returns 0 when the parent body has no "Depends on #N" line, 6 otherwise.
-# The regex matches both dotfiles "## Related — Depends on #N" PR bodies
-# and agent-toolbox "\n\nDepends on #N" trailers; case-insensitive so
-# variants from external tools are also caught.
+# The `^[[:space:]]*` anchor is intentional: it matches dotfiles `## Related`
+# section bodies (where "Depends on #N" sits on its own line under the
+# header) and agent-toolbox "\n\nDepends on #N" trailers, but deliberately
+# refuses inline prose like "This change Depends on #100 indirectly" —
+# matrix-10 case 6 pins that no-false-positive contract. Case-insensitive
+# so variants from external tools are also caught.
 assert_parent_pr_not_stacked() {
     local _pr="${1:-}" _body
     _body=$(_gh_pr_default_parent_body "$_pr")

--- a/claude/skills/gh-pr/references/stacked-pr.md
+++ b/claude/skills/gh-pr/references/stacked-pr.md
@@ -223,25 +223,64 @@ EOF
 }
 ```
 
-## Parent state pre-check — `assert_parent_pr_open`
+## Parent state + stack pre-check — `assert_parent_pr_open` + `assert_parent_pr_not_stacked`
 
-`find_parent_pr_candidates` already filters by `--state open`, but there
-is a TOCTOU window between Stage 2 and `gh pr create` (Step 5) where the
-parent can be merged or closed. The guard below re-reads the parent
-state right before the base branch decision is committed and aborts
-with **rc=5** when it is no longer `OPEN`. Same invariant as the
-agent-toolbox `github-workflow` driver — both drivers share the gate.
+`find_parent_pr_candidates` already filters by `--state open`, but two
+hazards remain:
+
+- **TOCTOU on state** — between Stage 2 and `gh pr create` (Step 5) the
+  parent can be merged or closed (#614 / F-4).
+- **Multi-stack drift** — if the auto-detected parent is itself stacked
+  on another PR (its body carries a `Depends on #N` line), accepting it
+  silently produces a 2+-deep stack. agent-toolbox declares 1-stack-only
+  as an invariant (`scripts/stacked_closes_rollup.py` defers the rollup
+  on multi-stack); dotfiles must match (#616 / F-6).
+
+The two guards below re-read the parent's state **and** body right
+before the base branch decision is committed and abort with:
+
+| rc | Reason |
+|---|---|
+| 5 | state ≠ `OPEN` — stacking requires an open parent. |
+| 6 | parent body has `Depends on #N` — multi-stack refused. |
+
+Both pieces of metadata are fetched in a **single** `gh pr view --json
+state,body` call. The body is cached in `$_GH_PR_PARENT_BODY_CACHE` so
+the second assertion reads it without a second API call (F-6-2: zero
+additional API cost relative to the F-4 baseline).
 
 ```sh
-# Helper — fetch the parent PR's state. Overridable in tests via
-# FAKE_PARENT_STATE so bats does not need a live `gh`.
+# Combined fetch — state + body in one `gh pr view`. Output: state.
+# Side effect: body is stashed in $_GH_PR_PARENT_BODY_CACHE for the
+# stacked-body guard below. Overridable in tests via FAKE_PARENT_STATE
+# (state-only callers; existing F-4 fixtures) and FAKE_PARENT_BODY.
 _gh_pr_default_parent_state() {
-    local _pr="${1:-}"
+    local _pr="${1:-}" _meta _delim
     if [ -n "${FAKE_PARENT_STATE+set}" ]; then
         printf '%s\n' "$FAKE_PARENT_STATE"
         return 0
     fi
-    gh pr view "$_pr" --json state -q .state 2>/dev/null
+    _delim=$(printf '\001')   # ASCII SOH — never appears in PR bodies
+    _meta=$(gh pr view "$_pr" --json state,body \
+        --jq '"\(.state)\(.body)"' 2>/dev/null)
+    _GH_PR_PARENT_BODY_CACHE="${_meta#*"$_delim"}"
+    printf '%s\n' "${_meta%%"$_delim"*}"
+}
+
+# Helper — returns the parent body. Prefers the cache populated by
+# _gh_pr_default_parent_state above; falls back to a direct fetch (or
+# FAKE_PARENT_BODY in tests) when called in isolation.
+_gh_pr_default_parent_body() {
+    local _pr="${1:-}"
+    if [ -n "${_GH_PR_PARENT_BODY_CACHE+set}" ]; then
+        printf '%s' "$_GH_PR_PARENT_BODY_CACHE"
+        return 0
+    fi
+    if [ -n "${FAKE_PARENT_BODY+set}" ]; then
+        printf '%s' "$FAKE_PARENT_BODY"
+        return 0
+    fi
+    gh pr view "$_pr" --json body -q .body 2>/dev/null
 }
 
 # Returns 0 when state == OPEN, 5 otherwise (with recovery hint on stderr).
@@ -256,11 +295,27 @@ assert_parent_pr_open() {
     fi
     return 0
 }
+
+# Returns 0 when the parent body has no "Depends on #N" line, 6 otherwise.
+# The regex matches both dotfiles "## Related — Depends on #N" PR bodies
+# and agent-toolbox "\n\nDepends on #N" trailers; case-insensitive so
+# variants from external tools are also caught.
+assert_parent_pr_not_stacked() {
+    local _pr="${1:-}" _body
+    _body=$(_gh_pr_default_parent_body "$_pr")
+    if printf '%s' "$_body" | grep -qiE '^[[:space:]]*Depends[[:space:]]+on[[:space:]]+#[0-9]+'; then
+        printf 'gh:pr: parent PR #%s is already stacked — multi-stack not supported.\n' \
+            "$_pr" >&2
+        printf 'Next: merge/squash parent first, or use --no-stack / --base <branch>.\n' >&2
+        return 6
+    fi
+    return 0
+}
 ```
 
-Single API call (`gh pr view --json state`) per stacked-PR invocation —
-0 overhead in the solo / non-stacked path because the helper only runs
-inside the 1-candidate branch of the Stage-2 dispatch.
+Single API call (`gh pr view --json state,body`) per stacked-PR
+invocation — 0 overhead in the solo / non-stacked path because the
+helpers only run inside the 1-candidate branch of the Stage-2 dispatch.
 
 ## How Step 1 of `SKILL.md` ties it together
 
@@ -284,6 +339,7 @@ case "$STACK_MODE" in
                     PARENT_PR="${CANDIDATES%%:*}"
                     BASE_BRANCH="${CANDIDATES#*:}"
                     assert_parent_pr_open "$PARENT_PR" || return $?
+                    assert_parent_pr_not_stacked "$PARENT_PR" || return $?
                     printf 'Stacking on PR #%s (auto-detected)\n' "$PARENT_PR" ;;
                 *)
                     # 2+ candidates — bash cannot prompt safely (Claude Code is
@@ -329,8 +385,9 @@ hatch flag (`--base <branch>` or `--no-stack`). This avoids hanging on
 | Mutually-exclusive flags | `/gh-pr --no-stack --base main` | rc=2, abort |
 | Bad `--base` value | `/gh-pr --base` (missing arg) | rc=3, abort |
 | Parent state ≠ OPEN | `/gh-pr` (auto-detected parent CLOSED/MERGED) | rc=5, abort with recovery hint |
+| Parent already stacked | `/gh-pr` (auto-detected parent body has `Depends on #N`) | rc=6, abort with recovery hint |
 
-The 9 rows above are the regression contract — every change to the
+The 10 rows above are the regression contract — every change to the
 detection logic must keep them green.
 
 ## Exit codes (Step 1a dispatch)
@@ -342,8 +399,12 @@ detection logic must keep them green.
 | 3 | `--base` was passed without a branch value. |
 | 4 | Stage 2 produced 2+ parent candidates — AI executor must ask the user. |
 | 5 | Auto-detected parent PR is not `OPEN` — stacking refused. |
+| 6 | Auto-detected parent PR is itself already stacked — multi-stack refused. |
 
-rc=4 (ambiguous parent) and rc=5 (parent-not-open) are semantically
-distinct — both block the dispatch but only rc=5 means "the parent is
-no longer a valid stacking target". Treat them separately when wiring
-recovery hints.
+rc=4 (ambiguous parent), rc=5 (parent-not-open), and rc=6
+(multi-stack-refused) are semantically distinct — all three block the
+dispatch, but only rc=5/6 mean "the parent is no longer a valid
+stacking target". Treat them separately when wiring recovery hints.
+rc=6 mirrors agent-toolbox's 1-stack-only invariant (`scripts/
+stacked_closes_rollup.py` defers the rollup on multi-stack) so both
+drivers refuse the same configuration symmetrically.

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -140,14 +140,35 @@ $_candidates
 EOF
 }
 
-# ── Parent state pre-check (F-4) ───────────────────────────────────────
+# ── Parent state + stack pre-check (F-4 / F-6) ─────────────────────────
+# Single combined fetch of state + body. Tests inject state via
+# FAKE_PARENT_STATE (existing) and body via FAKE_PARENT_BODY (new).
+# The body is stashed in $_GH_PR_PARENT_BODY_CACHE so the stacked-body
+# guard below can reuse it without a second API call.
 _gh_pr_default_parent_state() {
-    local _pr="${1:-}"
+    local _pr="${1:-}" _meta _delim
     if [ -n "${FAKE_PARENT_STATE+set}" ]; then
         printf '%s\n' "$FAKE_PARENT_STATE"
         return 0
     fi
-    gh pr view "$_pr" --json state -q .state 2>/dev/null
+    _delim=$(printf '\001')
+    _meta=$(gh pr view "$_pr" --json state,body \
+        --jq '"\(.state)\(.body)"' 2>/dev/null)
+    _GH_PR_PARENT_BODY_CACHE="${_meta#*"$_delim"}"
+    printf '%s\n' "${_meta%%"$_delim"*}"
+}
+
+_gh_pr_default_parent_body() {
+    local _pr="${1:-}"
+    if [ -n "${_GH_PR_PARENT_BODY_CACHE+set}" ]; then
+        printf '%s' "$_GH_PR_PARENT_BODY_CACHE"
+        return 0
+    fi
+    if [ -n "${FAKE_PARENT_BODY+set}" ]; then
+        printf '%s' "$FAKE_PARENT_BODY"
+        return 0
+    fi
+    gh pr view "$_pr" --json body -q .body 2>/dev/null
 }
 
 assert_parent_pr_open() {
@@ -158,6 +179,18 @@ assert_parent_pr_open() {
             "$_pr" "${_state:-UNKNOWN}" >&2
         printf 'Next: reopen parent, or run with --no-stack.\n' >&2
         return 5
+    fi
+    return 0
+}
+
+assert_parent_pr_not_stacked() {
+    local _pr="${1:-}" _body
+    _body=$(_gh_pr_default_parent_body "$_pr")
+    if printf '%s' "$_body" | grep -qiE '^[[:space:]]*Depends[[:space:]]+on[[:space:]]+#[0-9]+'; then
+        printf 'gh:pr: parent PR #%s is already stacked — multi-stack not supported.\n' \
+            "$_pr" >&2
+        printf 'Next: merge/squash parent first, or use --no-stack / --base <branch>.\n' >&2
+        return 6
     fi
     return 0
 }

--- a/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh
@@ -152,8 +152,9 @@ _gh_pr_default_parent_state() {
         return 0
     fi
     _delim=$(printf '\001')
+    # shellcheck disable=SC2016  # $d is a jq variable (--arg d), not shell
     _meta=$(gh pr view "$_pr" --json state,body \
-        --jq '"\(.state)\(.body)"' 2>/dev/null)
+        --jq --arg d "$_delim" '.state + $d + .body' 2>/dev/null)
     _GH_PR_PARENT_BODY_CACHE="${_meta#*"$_delim"}"
     printf '%s\n' "${_meta%%"$_delim"*}"
 }

--- a/tests/bats/skills/gh_pr_stacked_detect.bats
+++ b/tests/bats/skills/gh_pr_stacked_detect.bats
@@ -4,7 +4,7 @@
 #   claude/skills/gh-pr/references/stacked-pr.md
 # Source-of-truth fixture: _fixtures/gh_pr_stacked_detect.sh.
 #
-# 9-case compatibility matrix (issue #614 re-added case 9 for parent state):
+# 10-case compatibility matrix (issue #616 added case 10 for multi-stack):
 #   1. dotfiles solo (no stacked signals)        → Stage 1 fail, base=default
 #   2. AgentToolbox parent unique                → Stage 1+2, 1 candidate
 #   3. AgentToolbox parent ambiguous             → Stage 1+2, 2+ candidates
@@ -14,6 +14,7 @@
 #   7. Mutually-exclusive flags (--no-stack + --base) → rc=2 abort
 #   8. --base (missing arg)                      → rc=3 abort
 #   9. Auto-detected parent state ≠ OPEN          → rc=5 abort + hint
+#  10. Auto-detected parent already stacked       → rc=6 abort + hint
 
 load '../test_helper'
 
@@ -27,6 +28,7 @@ setup() {
 teardown() {
     [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] && rm -rf "$REPO_ROOT"
     unset FAKE_OPEN_PRS FAKE_ANCESTOR_REFS FAKE_NONDEFAULT_REFS FAKE_PARENT_STATE
+    unset FAKE_PARENT_BODY _GH_PR_PARENT_BODY_CACHE
     unset STACK_MODE STACK_BASE ISSUE_NUMBER
     teardown_isolated_home
 }
@@ -180,6 +182,63 @@ teardown() {
     run assert_parent_pr_open 201
     [ "$status" -eq 5 ]
     assert_output --partial 'state=MERGED'
+}
+
+# ── Compatibility matrix #10: multi-stack guard (F-6, issue #616) ─────
+@test "matrix-10: parent body without Depends → assert_parent_pr_not_stacked succeeds" {
+    FAKE_PARENT_BODY='## Summary
+Normal single-stack PR body. No Depends trailer here.'
+    run assert_parent_pr_not_stacked 201
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "matrix-10: parent body empty → assert_parent_pr_not_stacked succeeds" {
+    FAKE_PARENT_BODY=''
+    run assert_parent_pr_not_stacked 201
+    assert_success
+}
+
+@test "matrix-10: parent body with 'Depends on #100' → rc=6 with recovery hint" {
+    FAKE_PARENT_BODY='## Summary
+Adds widget X.
+
+## Related
+Depends on #100'
+    run assert_parent_pr_not_stacked 201
+    [ "$status" -eq 6 ]
+    assert_output --partial 'parent PR #201 is already stacked'
+    assert_output --partial 'multi-stack not supported'
+    assert_output --partial '--no-stack'
+    assert_output --partial '--base'
+}
+
+@test "matrix-10: parent body with lowercase 'depends on #N' → rc=6 (case-insensitive)" {
+    FAKE_PARENT_BODY='depends on #42'
+    run assert_parent_pr_not_stacked 201
+    [ "$status" -eq 6 ]
+}
+
+@test "matrix-10: parent body with leading whitespace before Depends → rc=6" {
+    FAKE_PARENT_BODY='   Depends on #77'
+    run assert_parent_pr_not_stacked 201
+    [ "$status" -eq 6 ]
+}
+
+@test "matrix-10: 'Depends on' as inline prose (not line-start) → rc=0 (no false positive)" {
+    FAKE_PARENT_BODY='This change Depends on #100 indirectly but is not stacked.'
+    run assert_parent_pr_not_stacked 201
+    assert_success
+}
+
+@test "matrix-10: body cache from assert_parent_pr_open reused (zero extra API)" {
+    # Simulate the dispatcher path: state-helper populates the cache, then
+    # the body-guard reads it without a second fetch. We assert this by
+    # leaving FAKE_PARENT_BODY unset — only the cache should carry it.
+    _GH_PR_PARENT_BODY_CACHE='Depends on #999'
+    run assert_parent_pr_not_stacked 201
+    [ "$status" -eq 6 ]
+    assert_output --partial '#201 is already stacked'
 }
 
 # ── Legacy positional issue arg still parsed ──────────────────────────


### PR DESCRIPTION
## Summary
- Adds the multi-stack abort guard requested in #611 / F-6 so dotfiles `gh:pr` matches agent-toolbox's 1-stack-only invariant.
- New rc=6 from `assert_parent_pr_not_stacked` aborts auto-detect when the ancestor PR is itself stacked (its body trailer carries `Depends on #N`).
- Zero additional API cost — body fetched alongside state in the existing F-4 `gh pr view` call and cached in `$_GH_PR_PARENT_BODY_CACHE`.

## Changes
- `claude/skills/gh-pr/references/stacked-pr.md` — merge state+body fetch into `_gh_pr_default_parent_state` (SOH-delimited single `gh pr view --json state,body`); add `_gh_pr_default_parent_body` cache reader; add `assert_parent_pr_not_stacked` regex guard (`^[[:space:]]*Depends[[:space:]]+on[[:space:]]+#[0-9]+`, case-insensitive); wire it into the 1-candidate dispatch branch after `assert_parent_pr_open`. Compatibility matrix grows to 10 rows; rc table gains rc=6 with cross-driver rationale.
- `tests/bats/skills/_fixtures/gh_pr_stacked_detect.sh` — mirror the SSOT updates (combined state-body fetcher + body cache + new assertion) verbatim so the bats suite catches drift.
- `tests/bats/skills/gh_pr_stacked_detect.bats` — add 7 matrix-10 cases: success on empty body, success on body without trailer, rc=6 on `Depends on #N`, case-insensitive variant, leading whitespace, no false positive for inline prose, and cache-reuse path (asserts no extra API call when state-helper populated the cache).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_stacked_detect.bats` → 28/28 (19 existing + 7 new + 2 legacy).
- [x] `tox -e shellcheck` clean (bash/ scope; fixture also passes `shellcheck -x -e SC1090,SC1091` directly).
- [x] `tox -e shfmt` clean.
- [x] Lint guard against `main` (Step 4.5): tox ruff + shellcheck + shfmt all green.

## Related
Closes #616

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
