### PR TITLE
feat(gh-discussion-convert): #618 Discussion -> Issue convert skill

### DIFF
--- a/claude/skills/gh-discussion-convert/SKILL.md
+++ b/claude/skills/gh-discussion-convert/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: gh:discussion-convert
+description: >-
+  Promote a decided `Ideas` Discussion into a tracked Issue by emulating
+  GitHub's UI `Convert to issue` flow — creates the Issue with an
+  `Originated from discussion #<N>` backlink, posts a `Linked to issue
+  #<M>` comment back on the Discussion, locks the Discussion (reason
+  Resolved), closes it, and moves the new Issue card to `In progress`
+  on the project board. Use when the user runs /gh:discussion-convert,
+  /gh-discussion-convert, asks "Discussion #N 결정났으니 issue 로
+  승격", "RFC 결정 — convert 해줘", or wants the 4-step variant from
+  `discussions-policy.md` (#612) automated end-to-end. Sister skill of
+  [[gh-discussion-create]]; reuses the same `gh_discussion.sh` helpers.
+  Idempotent — re-running on a Discussion that was already converted
+  prints the existing issue URL and exits 0. Refuses non-`Ideas`
+  categories unless `--force-category` is set. Accepts `<N>` plus
+  optional `[remote]`, and `--no-comment` / `--no-lock` /
+  `--no-board-sync` / `--no-close` to skip the optional steps.
+  `-h`/`--help`/`help` prints usage.
+allowed-tools: Bash, Read, Grep
+---
+
+# gh:discussion-convert — Decided Ideas Discussion -> Issue
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Role
+
+Automate the 4-step `Discussion -> Issue` 변환 규약 from
+`docs/.ssot/discussions-policy.md` (#612). The native UI button is the
+only first-party path GitHub exposes — there is no public REST or
+GraphQL `convertDiscussion` mutation as of 2026-05. This skill emulates
+the UI path via four primitive mutations (`createIssue` +
+`addDiscussionComment` + `closeDiscussion` + `lockLockable`) plus a
+board-status sync, all wired together so the policy's bidirectional
+backlink invariant (operating principle #4) never gets dropped.
+
+Print the new Issue URL at the end. Idempotent — see Step 4.
+
+## Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `<discussion-number>` (positional, required) | Positive integer. | — |
+| `[remote]` (positional) | Git remote whose repo owns the Discussion + new Issue. | `origin` |
+| `--no-comment` | Skip the `Linked to issue #<M>` backlink comment on the Discussion. | off |
+| `--no-lock` | Skip the `Lock conversation` step. | off |
+| `--no-close` | Skip the close step (Discussion stays open). | off |
+| `--no-board-sync` | Skip the `In progress` Status transition on the project board. | off |
+| `--force-category` | Bypass the Step 3 `Ideas`-only guard. | off |
+| `GH_DISABLE_AI_METRICS=1` (env) | Suppress ai-metrics handling (parity with [[gh-discussion-create]]). | off |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+
+## Step 1: Detect Repo Context
+
+Record `START_TS=$(date +%s)` for elapsed-time reporting. Parse the
+positional args and flags above. Confirm we are in a git repo
+(`git rev-parse --show-toplevel`) and resolve
+`TARGET_REPO=<owner>/<repo>` via the chosen remote — substeps in
+[`references/repo-resolution.md`](references/repo-resolution.md).
+Never silently fall back to `origin` when the user-supplied remote
+is missing.
+
+## Step 2: Fetch the Discussion
+
+Source `shell-common/functions/gh_discussion.sh` and call
+`_gh_discussion_fetch "$_owner" "$_repo" "$N"`. Capture the JSON to
+a temp file and read these fields with `jq`:
+
+- `.id` (node ID — needed for comment / close / lock mutations)
+- `.number`, `.title`, `.body`, `.url`
+- `.category`, `.closed`, `.locked`
+
+Fetch failure -> abort with the helper's stderr trace.
+
+## Step 3: Category Guard
+
+If `.category != "Ideas"` and `--force-category` is not set, refuse:
+
+```
+Discussion #<N> 카테고리가 '<X>' 입니다 — 정책상 Ideas 만 변환합니다.
+근거: docs/.ssot/discussions-policy.md -> "운영 원칙 4 개조" #2.
+강제 변환하려면: /gh-discussion-convert <N> --force-category
+```
+
+Exit 1. Skip Steps 4-8 entirely. Operating principle #2 ("결정되면
+즉시 Issue convert") refers specifically to the Ideas bucket; other
+categories have different lifecycles (Announcements = transient,
+Lessons = Discussion-first, Q&A = answered-not-converted) and must
+not be silently coerced into the Issue tracker.
+
+## Step 4: Idempotency Check
+
+Search for an Issue whose body already contains the backlink marker:
+
+```bash
+EXISTING=$(gh issue list --repo "$TARGET_REPO" --state all --search \
+    "in:body \"Originated from discussion #${N}\"" \
+    --json number,url --limit 1 --jq '.[0]')
+```
+
+If `$EXISTING` is non-empty, print the existing issue URL and exit 0
+with `[OK] Discussion #<N> already converted to <issue-url>`. This
+preserves NF-1 (idempotency) even when the previous run posted a
+comment / locked / closed and the user re-invokes the skill.
+
+Step 4 happens BEFORE any mutation; a re-run never creates a second
+issue.
+
+## Step 5: Create the Issue
+
+Build the Issue body as backlink + a newline + the original Discussion
+body (verbatim, including the source's ai-metrics footer — we are not
+the author of that footer, so we preserve it as-is):
+
+```
+Originated from discussion #<N>
+
+<original discussion body>
+```
+
+Title: the Discussion title verbatim (preserve the conventional-commit
+prefix). Create via `gh issue create --repo "$TARGET_REPO" --title ...
+--body-file ...`. Capture the printed URL and extract `<M>`.
+
+`gh issue create` is preferred over a raw `createIssue` GraphQL call
+because it handles the owner -> repository node ID lookup, default
+assignee + label policy, and prints a stable URL. Fits the existing
+gh-* skill family.
+
+## Step 6: Board Sync (skip with `--no-board-sync`)
+
+```
+_gh_project_status_sync issue <M> "In progress" --only-from "Backlog,Ready"
+```
+
+The helper is a no-op on repos without a project board attached. The
+`--only-from` whitelist prevents bouncing already-progressed cards
+back. Reuses the same pattern as `gh:issue-implement` Step 3.4.
+
+## Step 7: Post Backlink Comment (skip with `--no-comment`)
+
+Compose the body:
+
+```
+Linked to issue #<M> -- decision tracked there.
+```
+
+Write it to a temp file and call `_gh_discussion_comment "$DISC_ID"
+"$BODY_FILE"`. Mutation failure here is non-fatal — print a warning
+but continue. The bidirectional backlink is best-effort once the
+forward link (issue body -> discussion) is already on the Issue.
+
+## Step 8: Close + Lock the Discussion
+
+In order:
+
+1. If `.closed != true` and `--no-close` is not set:
+   `_gh_discussion_close "$DISC_ID" RESOLVED`.
+2. If `.locked != true` and `--no-lock` is not set:
+   `_gh_discussion_lock "$DISC_ID"`.
+
+Both calls are best-effort — failures emit a warning but do not roll
+back the new Issue (the policy invariant "Issue must exist with
+backlink" is already satisfied by Steps 5 + 7).
+
+확인 질문하지 말고 즉시 실행.
+
+## Step 9: Report
+
+Print exactly one line on success:
+
+```
+[OK] Discussion #<N> -> Issue #<M>: <issue-url>
+```
+
+Append a single-line summary of optional steps applied / skipped so
+the user can tell at a glance which side-effects ran:
+
+```
+  steps: comment=<on|off|skip>, lock=<on|off|skip>, close=<on|off|skip>, board=<synced|skipped>
+```
+
+On failure -- show the failing step name and quote the first stderr
+line from the helper, mirroring the format used by
+[[gh-discussion-create]] Step 5.
+
+## Constraints
+
+- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
+- 사용자 지정 remote 가 없으면 즉시 실패. Silent `origin` fallback 금지.
+- Non-Ideas 카테고리는 정책상 변환 대상이 아니다. `--force-category`
+  는 SSOT 갱신 없이 가드 자체를 제거하는 것이 아니라 1 회용 우회 전용.
+- Steps 5 (createIssue) 이후 mutation 들 (6/7/8) 은 best-effort.
+  하나 실패해도 새 Issue 는 이미 backlink 를 가진 채 존재하므로
+  롤백 시도 금지 — 사람이 보강하도록 경고만 출력한다.
+- 두 번 호출해도 새 Issue 가 두 개 생기지 않는다 (Step 4 idempotency
+  check). 단, Discussion 본문이 backlink 마커 인덱싱 전에 호출되면
+  중복이 가능 — 그래도 인간 검토가 마지막 방어선.
+- "should I convert?" 같은 확인 질문 금지. Skill 실행이 컨펌이다.

--- a/claude/skills/gh-discussion-convert/SKILL.md
+++ b/claude/skills/gh-discussion-convert/SKILL.md
@@ -99,8 +99,15 @@ Search for an Issue whose body already contains the backlink marker:
 ```bash
 EXISTING=$(gh issue list --repo "$TARGET_REPO" --state all --search \
     "in:body \"Originated from discussion #${N}\"" \
-    --json number,url --limit 1 --jq '.[0]')
+    --json number,url --limit 1 --jq '.[0].url // empty')
 ```
+
+`// empty` is load-bearing: without it, `jq '.[0].url'` on an empty
+result array prints the literal string `null`, which `[ -n "$EXISTING" ]`
+treats as non-empty — the skill would then claim "already converted"
+on every first invocation. With `// empty`, `$EXISTING` is the empty
+string when no match exists, so the standard `[ -n ... ]` test in
+`convert-cmd.md` Step 4 works correctly.
 
 If `$EXISTING` is non-empty, print the existing issue URL and exit 0
 with `[OK] Discussion #<N> already converted to <issue-url>`. This

--- a/claude/skills/gh-discussion-convert/references/convert-cmd.md
+++ b/claude/skills/gh-discussion-convert/references/convert-cmd.md
@@ -1,0 +1,121 @@
+# gh:discussion-convert — Step 5-8 Convert Command
+
+Detail companion to SKILL.md Steps 5 through 8. Reads the JSON
+captured in Step 2 (the `_gh_discussion_fetch` output) and runs the
+emulated convert sequence in order.
+
+Inputs bound by the caller:
+
+- `$TARGET_REPO`        — `owner/repo` from Step 1
+- `$N`                  — Discussion number (positional arg)
+- `$DISC_JSON`          — path to the temp file holding the JSON from
+                          `_gh_discussion_fetch`
+- `$OPT_NO_COMMENT`     — `1` if `--no-comment` was passed
+- `$OPT_NO_LOCK`        — `1` if `--no-lock` was passed
+- `$OPT_NO_CLOSE`       — `1` if `--no-close` was passed
+- `$OPT_NO_BOARD_SYNC`  — `1` if `--no-board-sync` was passed
+
+```bash
+# shellcheck disable=SC1091
+. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"
+# shellcheck disable=SC1091
+. "$DOTFILES_ROOT/shell-common/functions/gh_project_status.sh"
+
+DISC_ID=$(jq -r '.id'     "$DISC_JSON")
+DTITLE=$(jq -r '.title'   "$DISC_JSON")
+DCAT=$(jq -r '.category'  "$DISC_JSON")
+DCLOSED=$(jq -r '.closed' "$DISC_JSON")
+DLOCKED=$(jq -r '.locked' "$DISC_JSON")
+
+# Step 3 — category guard (done by caller; this file assumes pass).
+
+# Step 4 — idempotency check.
+EXISTING=$(gh issue list --repo "$TARGET_REPO" --state all \
+    --search "in:body \"Originated from discussion #${N}\"" \
+    --json number,url --limit 1 --jq '.[0].url')
+if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+    printf '[OK] Discussion #%s already converted to %s\n' "$N" "$EXISTING"
+    exit 0
+fi
+
+# Step 5 — create the issue with the backlink prepended.
+ISSUE_BODY=$(mktemp) && trap 'rm -f "$ISSUE_BODY"' EXIT
+printf 'Originated from discussion #%s\n\n' "$N" >"$ISSUE_BODY"
+jq -r '.body' "$DISC_JSON" >>"$ISSUE_BODY"
+
+ISSUE_URL=$(gh issue create --repo "$TARGET_REPO" \
+    --title "$DTITLE" --body-file "$ISSUE_BODY")
+ISSUE_NUMBER="${ISSUE_URL##*/}"
+
+# Step 6 — board sync (best-effort).
+if [ "${OPT_NO_BOARD_SYNC:-0}" != "1" ]; then
+    _gh_project_status_sync issue "$ISSUE_NUMBER" "In progress" \
+        --only-from "Backlog,Ready" || true
+fi
+
+# Step 7 — backlink comment on the discussion (best-effort).
+if [ "${OPT_NO_COMMENT:-0}" != "1" ]; then
+    CBODY=$(mktemp)
+    printf 'Linked to issue #%s -- decision tracked there.\n' \
+        "$ISSUE_NUMBER" >"$CBODY"
+    _gh_discussion_comment "$DISC_ID" "$CBODY" >/dev/null \
+        || printf '[WARN] discussion comment failed -- continuing\n' >&2
+    rm -f "$CBODY"
+fi
+
+# Step 8 — close + lock (best-effort, conditional on current state).
+if [ "${OPT_NO_CLOSE:-0}" != "1" ] && [ "$DCLOSED" != "true" ]; then
+    _gh_discussion_close "$DISC_ID" RESOLVED >/dev/null \
+        || printf '[WARN] discussion close failed -- continuing\n' >&2
+fi
+if [ "${OPT_NO_LOCK:-0}" != "1" ] && [ "$DLOCKED" != "true" ]; then
+    _gh_discussion_lock "$DISC_ID" >/dev/null \
+        || printf '[WARN] discussion lock failed -- continuing\n' >&2
+fi
+
+printf '[OK] Discussion #%s -> Issue #%s: %s\n' \
+    "$N" "$ISSUE_NUMBER" "$ISSUE_URL"
+```
+
+확인 질문하지 말고 즉시 실행.
+
+## Why four primitive mutations instead of one
+
+`Convert to issue` lives only in the GitHub UI as of 2026-05. There
+is no documented REST endpoint and the GraphQL schema does not expose
+a `convertDiscussion` mutation. Until GitHub ships one, the
+combination of `createIssue` + `addDiscussionComment` +
+`closeDiscussion` + `lockLockable` reproduces every observable
+side-effect of the native convert flow except the "transferred to
+issue" UI banner. The lost banner is acceptable; the policy
+invariants it visualises (close + bidirectional backlink + lock) are
+still mechanically enforced here.
+
+## Why `gh issue create` instead of GraphQL `createIssue`
+
+The Issue mutation needs `repositoryId` (a node ID), default labels,
+default assignee, and milestone handling — all of which `gh issue
+create` resolves from `owner/repo` automatically and prints a stable
+URL we can scrape for the issue number. A raw `createIssue` GraphQL
+call would force this skill to re-implement that resolution chain,
+duplicating logic that already lives in `gh:issue-create` /
+`gh:issue-implement`.
+
+## Why best-effort on Steps 6 / 7 / 8
+
+The SSOT invariant is "decided Discussion -> tracked Issue with
+backlink". Step 5 alone satisfies that contract. Steps 6 / 7 / 8 are
+ergonomic helpers (board hygiene, reverse backlink, locked forum).
+Rolling back the new Issue when one of them flakes would leave the
+user in a worse state — Discussion still open, no Issue, work lost.
+We warn and keep going.
+
+## Idempotency mechanics
+
+Step 4's `gh issue list --search "in:body ..."` relies on GitHub's
+search indexer, which lags writes by a few seconds. The race window
+where two near-simultaneous `gh:discussion-convert` invocations could
+both miss the index and create duplicate Issues is real but tiny;
+human review at the Issue list is the last defense. We do not block
+the skill on a sleep-and-recheck because the realistic call pattern
+is one human running the skill once.

--- a/claude/skills/gh-discussion-convert/references/convert-cmd.md
+++ b/claude/skills/gh-discussion-convert/references/convert-cmd.md
@@ -30,21 +30,35 @@ DLOCKED=$(jq -r '.locked' "$DISC_JSON")
 # Step 3 — category guard (done by caller; this file assumes pass).
 
 # Step 4 — idempotency check.
+# `// empty` keeps EXISTING the empty string when the array is empty;
+# without it jq prints the literal "null" which [ -n ... ] treats as
+# non-empty, breaking first-run conversion (PR #628 gemini review).
 EXISTING=$(gh issue list --repo "$TARGET_REPO" --state all \
     --search "in:body \"Originated from discussion #${N}\"" \
-    --json number,url --limit 1 --jq '.[0].url')
-if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+    --json number,url --limit 1 --jq '.[0].url // empty')
+if [ -n "$EXISTING" ]; then
     printf '[OK] Discussion #%s already converted to %s\n' "$N" "$EXISTING"
     exit 0
 fi
 
-# Step 5 — create the issue with the backlink prepended.
-ISSUE_BODY=$(mktemp) && trap 'rm -f "$ISSUE_BODY"' EXIT
+# Step 5 — create the issue with the backlink prepended. The trap
+# registered up front covers both ISSUE_BODY and the later CBODY (set
+# only when --no-comment is off) so neither temp file leaks if a
+# subsequent step exits early or the process is interrupted.
+ISSUE_BODY=$(mktemp)
+trap 'rm -f "$ISSUE_BODY" "${CBODY:-}"' EXIT
 printf 'Originated from discussion #%s\n\n' "$N" >"$ISSUE_BODY"
 jq -r '.body' "$DISC_JSON" >>"$ISSUE_BODY"
 
 ISSUE_URL=$(gh issue create --repo "$TARGET_REPO" \
     --title "$DTITLE" --body-file "$ISSUE_BODY")
+# Abort BEFORE Steps 6/7/8 if creation failed — mutating the Discussion
+# without an Issue to back-link to violates the SSOT chain documented in
+# error-cases.md and discussions-policy.md operating principle #4.
+if [ -z "$ISSUE_URL" ]; then
+    printf '[FAIL] Step 5: gh issue create failed -- aborting before mutating the Discussion.\n' >&2
+    exit 1
+fi
 ISSUE_NUMBER="${ISSUE_URL##*/}"
 
 # Step 6 — board sync (best-effort).
@@ -54,13 +68,13 @@ if [ "${OPT_NO_BOARD_SYNC:-0}" != "1" ]; then
 fi
 
 # Step 7 — backlink comment on the discussion (best-effort).
+# CBODY is cleaned up by the EXIT trap registered at Step 5.
 if [ "${OPT_NO_COMMENT:-0}" != "1" ]; then
     CBODY=$(mktemp)
     printf 'Linked to issue #%s -- decision tracked there.\n' \
         "$ISSUE_NUMBER" >"$CBODY"
     _gh_discussion_comment "$DISC_ID" "$CBODY" >/dev/null \
         || printf '[WARN] discussion comment failed -- continuing\n' >&2
-    rm -f "$CBODY"
 fi
 
 # Step 8 — close + lock (best-effort, conditional on current state).

--- a/claude/skills/gh-discussion-convert/references/error-cases.md
+++ b/claude/skills/gh-discussion-convert/references/error-cases.md
@@ -1,0 +1,102 @@
+# gh:discussion-convert — Error Cases
+
+Detailed error-handling matrix. SKILL.md keeps the happy-path
+workflow scannable; the failure modes belong here.
+
+## Step 1 — Repo resolution
+
+| Trigger | User-facing output | Exit |
+|---------|--------------------|------|
+| Not inside a git repo | `Error: not inside a git repository` | 1 |
+| Specified remote does not exist | List of available remotes via `git remote -v` + `Error: remote '<name>' not found.` | 1 |
+| Remote URL is not GitHub | `Error: remote '<name>' is not a GitHub repository: <url>` | 1 |
+
+Never fall back to `origin` silently — that masks typos and posts
+into the wrong repo (mirrors `gh-discussion-create` failure rule).
+
+## Step 2 — Fetch
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| Discussion number not an integer | `[gh-discussion] discussion number must be a positive integer` | 2 |
+| Discussion #N does not exist on repo | `[gh-discussion] discussion #N not found on owner/repo` + stderr trace | 1 |
+| Auth failure | First stderr line from `gh api graphql` quoted verbatim | 1 |
+
+## Step 3 — Category guard
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| Discussion category is not `Ideas` and `--force-category` not set | `Discussion #N 카테고리가 '<X>' 입니다 — 정책상 Ideas 만 변환합니다. ...` (multiline refusal per SKILL.md Step 3) | 1 |
+
+The refusal text intentionally cites
+`docs/.ssot/discussions-policy.md` operating principle #2 so the
+audit trail explains the policy decision, not just the mechanical
+rejection.
+
+## Step 4 — Idempotency
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| Existing Issue with backlink found | `[OK] Discussion #N already converted to <url>` | 0 |
+| `gh issue list --search` fails (rate limit / auth) | Warn `[WARN] idempotency search failed -- proceeding may create a duplicate Issue` + continue | — |
+
+The skill prefers a possible duplicate over blocking the user when
+search itself fails — humans can dedupe; a silent abort would leave
+no Issue at all.
+
+## Step 5 — Issue creation
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| `gh issue create` fails | First stderr line quoted + `[FAIL] Step 5: gh issue create -- aborting before mutating the Discussion.` | 1 |
+| Title exceeds GitHub's 256-char limit | Caller-side check: truncate to 250 chars + `...` and emit `[WARN] title truncated to fit GitHub limit` | — |
+
+Crucially, Steps 6 / 7 / 8 are NOT run when Step 5 fails. Mutating
+the Discussion (close / lock / comment) without a new Issue would
+violate the policy invariant. Abort cleanly instead.
+
+## Step 6 — Board sync
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| Repo has no project board attached | Helper is a no-op, no output | — |
+| Status field has no `In progress` option | Helper warns once and exits 0 | — |
+| Mutation fails (rate limit, etc.) | Helper warns; skill continues to Step 7 | — |
+
+Board sync is the most flake-prone step in this skill; it is
+deliberately best-effort.
+
+## Step 7 — Backlink comment
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| `addDiscussionComment` fails | `[WARN] discussion comment failed -- continuing` + stderr trace | — |
+
+The Issue already carries the forward backlink (Step 5), so the
+reverse comment is best-effort. The user can paste it manually if
+the mutation keeps failing.
+
+## Step 8 — Close + Lock
+
+| Trigger | Output | Exit |
+|---------|--------|------|
+| `closeDiscussion` fails | `[WARN] discussion close failed -- continuing` + stderr trace | — |
+| `lockLockable` fails | `[WARN] discussion lock failed -- continuing` + stderr trace | — |
+| Discussion is already closed (`.closed == true`) | Skip the close mutation; report `close=skip` in Step 9 | — |
+| Discussion is already locked (`.locked == true`) | Skip the lock mutation; report `lock=skip` in Step 9 | — |
+
+The pre-state checks prevent a "no-op mutation" stderr noise when
+the user re-runs the skill against a Discussion that was previously
+closed and locked by hand.
+
+## Auth failures (any step)
+
+If `gh api graphql` returns `HTTP 401` or the body contains
+`Bad credentials`, suggest:
+
+```
+[FAIL] GitHub auth failed -- run `gh auth refresh` and retry.
+```
+
+Map this consistently across all steps so the user sees one
+recovery hint regardless of where the auth failure surfaced.

--- a/claude/skills/gh-discussion-convert/references/help.md
+++ b/claude/skills/gh-discussion-convert/references/help.md
@@ -1,0 +1,94 @@
+# gh:discussion-convert — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<discussion-number>` **or** `-h`/`--help`/`help` | (required) | Positive integer — the Ideas Discussion to convert. |
+| 2 | `[remote]` | `origin` | Git remote whose repo owns the Discussion and the new Issue. |
+
+Examples:
+
+- `/gh-discussion-convert 42` — convert Discussion #42 on `origin`.
+- `/gh-discussion-convert 42 upstream` — convert on `upstream`.
+- `/gh-discussion-convert 42 --no-comment --no-lock` — create the
+  Issue with the backlink only; leave the Discussion open and silent.
+- `/gh-discussion-convert -h` / `--help` / `help` — print this help.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--no-comment` | off | Skip Step 7 (`Linked to issue #<M>` comment back on the Discussion). The reverse backlink is then human-maintained. |
+| `--no-lock` | off | Skip Step 8.2 (`Lock conversation` with reason Resolved). |
+| `--no-close` | off | Skip Step 8.1 (`closeDiscussion` mutation). Use when the Discussion should stay open for follow-up. |
+| `--no-board-sync` | off | Skip Step 6 (`In progress` Status transition on the project board). |
+| `--force-category` | off | Bypass the Step 3 `Ideas`-only guard. Required to convert Q&A / Announcements / Lessons Discussions — policy normally forbids it. |
+
+## Env Vars
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GH_DISABLE_AI_METRICS=1` | off | Suppress ai-metrics handling (parity with `gh:discussion-create`). |
+| `GH_PROJECT_STATUS_SYNC=0` | on | Skip board sync globally (honored by the underlying `_gh_project_status_sync` helper). |
+
+## What the skill does
+
+1. Confirms a git repo context and resolves `owner/repo` from the
+   target remote.
+2. Fetches the Discussion via `_gh_discussion_fetch` (single GraphQL
+   call) and extracts node ID + body + category + locked/closed state.
+3. **Category guard** — refuses non-`Ideas` Discussions unless
+   `--force-category` is set. Override is one-shot, not a policy
+   change.
+4. **Idempotency check** — searches existing Issues for a body match
+   on `Originated from discussion #<N>`. If found, prints the existing
+   Issue URL and exits 0 without mutating anything.
+5. Creates the new Issue with the backlink prepended to the original
+   Discussion body, preserving the conventional-commit title.
+6. Moves the new Issue card to `In progress` on the project board
+   (best-effort; no-op on repos without a board).
+7. Posts a `Linked to issue #<M> -- decision tracked there.` comment
+   back on the Discussion.
+8. Closes the Discussion (`closeDiscussion` reason RESOLVED) and locks
+   it (`lockLockable` reason RESOLVED).
+
+Steps 6 / 7 / 8 are best-effort — Step 5 alone satisfies the policy
+invariant that the new Issue must carry the backlink.
+
+## Bidirectional-backlink contract
+
+`docs/.ssot/discussions-policy.md` operating principle #4 mandates
+two-way links between the converted Discussion and the new Issue.
+This skill enforces that contract mechanically:
+
+- **Issue -> Discussion**: Step 5 prepends `Originated from
+  discussion #<N>` to the Issue body. This direction is **not
+  optional** — there is no flag to disable it.
+- **Discussion -> Issue**: Step 7 adds `Linked to issue #<M>` as a
+  comment. This direction can be disabled with `--no-comment` when
+  the user prefers to maintain it manually (e.g. consolidating
+  multiple converted Discussions into one tracking comment).
+
+## What the skill will NOT do
+
+- Convert non-`Ideas` Discussions without `--force-category` — by
+  policy, Announcements / Q&A / Lessons have different lifecycles.
+- Try to use a hypothetical `convertDiscussion` REST or GraphQL
+  endpoint — none exists as of 2026-05. The skill emulates the UI
+  flow via four primitive mutations.
+- Roll back the new Issue if a later step fails. Once the Issue
+  carries the backlink (Step 5), the SSOT chain is intact; lock /
+  close / comment failures are warnings, not aborts.
+- Create a duplicate Issue when run twice (Step 4 idempotency check).
+- Re-categorise the Discussion or move it to another repo.
+- Fall back to `origin` when the user-specified remote is missing.
+- Ask "should I convert?" — running the skill is the confirmation.
+
+## Related skills
+
+- [[gh-discussion-create]] — sister skill that creates the Discussion
+  in the first place. Same helper module (`gh_discussion.sh`).
+- [[gh-issue-create]] — default destination for to-do items; preferred
+  over Discussion when the chat is already a decided to-do.
+- SSOT: `docs/.ssot/discussions-policy.md` (#612).

--- a/claude/skills/gh-discussion-convert/references/repo-resolution.md
+++ b/claude/skills/gh-discussion-convert/references/repo-resolution.md
@@ -1,0 +1,52 @@
+# gh:discussion-convert — Repo resolution
+
+Detailed procedure for Step 1 "Detect Repo Context". Mirrors
+[`gh-discussion-create/references/repo-resolution.md`](../../gh-discussion-create/references/repo-resolution.md)
+so all gh-discussion-* skills behave identically.
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we are in a git repo.
+
+2. Determine the target remote:
+   - If a second non-flag positional was passed (after the discussion
+     number), treat it as the remote name.
+   - Otherwise default to `origin`.
+
+3. Validate the remote and resolve owner/repo:
+
+   ```bash
+   git remote get-url <remote-name>
+   ```
+
+   If this fails, list available remotes (`git remote -v`) and stop
+   with an error like:
+
+   ```
+   Error: remote '<remote-name>' not found. Available remotes:
+   origin    https://github.com/user/repo.git (fetch)
+   upstream  https://github.com/org/repo.git  (fetch)
+   ```
+
+4. Extract `owner/repo` from the remote URL returned in step 3:
+
+   - `https://github.com/<owner>/<repo>.git` -> `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git`     -> `<owner>/<repo>`
+
+Store the resolved `owner/repo` as `TARGET_REPO`. Split into
+`_owner="${TARGET_REPO%%/*}"` and `_repo="${TARGET_REPO##*/}"` for the
+GraphQL helpers in `gh_discussion.sh`.
+
+## Failure rule
+
+If the user-specified remote does not exist, fail immediately with
+the list of available remotes. **Do not** fall back to `origin`
+silently — that masks typos and converts a Discussion in the wrong
+repo, splintering the SSOT chain across forks.
+
+## Why this lives in a separate file
+
+Same reason as the create-side skill: the workflow stays scannable in
+SKILL.md while the remote-validation detail lives in one place that
+all gh-discussion-* skills can link to. Update both at once — they
+must stay byte-equivalent in substance.

--- a/shell-common/functions/gh_discussion.sh
+++ b/shell-common/functions/gh_discussion.sh
@@ -6,13 +6,15 @@
 # in GraphQL — so this helper centralises the mutation + the lookup chain
 # (repository ID -> category ID) the mutation depends on.
 #
-# Background (issue #617):
+# Background (issue #617, #618):
 # `gh:discussion-create` and `gh:discussion-convert` both need the same
-# three primitives: resolve a repository node ID, resolve a Discussion
-# category node ID by name, and POST a `createDiscussion` mutation. Keeping
-# the GraphQL strings inside one helper lets the skill stay focused on
-# conversation routing while the contract with GitHub's API lives in one
-# auditable file.
+# three create-side primitives: resolve a repository node ID, resolve a
+# Discussion category node ID by name, and POST a `createDiscussion`
+# mutation. `gh:discussion-convert` additionally needs to fetch an
+# existing Discussion and to close / lock / comment on it. Keeping all
+# Discussion GraphQL strings in one helper lets the skills stay focused
+# on conversation routing while the contract with GitHub's API lives in
+# one auditable file.
 #
 # Usage:
 #   _gh_discussion_repo_id     <owner> <repo>
@@ -27,6 +29,24 @@
 #   _gh_discussion_create      <repo-id> <category-id> <title> <body-file>
 #       POST createDiscussion. Print the Discussion URL on stdout. Exit
 #       non-zero on mutation failure (auth, validation, network).
+#
+#   _gh_discussion_fetch       <owner> <repo> <number>
+#       Print a JSON object on stdout with keys: id, number, title, body,
+#       url, locked, closed, category (flattened from category.name).
+#       Exit 1 on lookup failure or when the discussion does not exist.
+#
+#   _gh_discussion_comment     <discussion-node-id> <body-file>
+#       POST addDiscussionComment. Print the comment URL on stdout.
+#       Exit non-zero on mutation failure.
+#
+#   _gh_discussion_close       <discussion-node-id> [reason]
+#       POST closeDiscussion. `reason` defaults to RESOLVED; allowed
+#       values: RESOLVED, OUTDATED, DUPLICATE. Print "closed" on success.
+#       Exit non-zero on mutation failure.
+#
+#   _gh_discussion_lock        <discussion-node-id>
+#       POST lockLockable (reason RESOLVED). Print "locked" on success.
+#       Exit non-zero on mutation failure.
 #
 # Repo node ID and category ID lookups are cheap enough to do per call —
 # do not introduce a disk cache (see references/cache-decision in the
@@ -190,4 +210,192 @@ _gh_discussion_create() {
 
     rm -f "$_err"
     printf '%s\n' "$_url"
+}
+
+_gh_discussion_fetch() {
+    local _owner="${1:-}" _repo="${2:-}" _num="${3:-}"
+    if [ -z "$_owner" ] || [ -z "$_repo" ] || [ -z "$_num" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_fetch <owner> <repo> <number>\n' >&2
+        return 2
+    fi
+    case "$_num" in
+        '' | *[!0-9]*)
+            printf '[gh-discussion] discussion number must be a positive integer\n' >&2
+            return 2
+            ;;
+    esac
+
+    local _err _json
+    _err=$(mktemp) || return 1
+
+    # GraphQL variables ($owner, $repo, $num) are NOT shell vars — single
+    # quotes around the query are intended.
+    # Variables: $owner String!, $repo String!, $num Int!
+    # shellcheck disable=SC2016
+    _json=$(gh api graphql \
+        -f query='
+          query($owner: String!, $repo: String!, $num: Int!) {
+            repository(owner: $owner, name: $repo) {
+              discussion(number: $num) {
+                id
+                number
+                title
+                body
+                url
+                locked
+                closed
+                category { name }
+              }
+            }
+          }' \
+        -f owner="$_owner" -f repo="$_repo" -F "num=$_num" \
+        --jq '.data.repository.discussion' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ] || [ -z "$_json" ] || [ "$_json" = "null" ]; then
+        printf '[gh-discussion] discussion #%s not found on %s/%s\n' \
+            "$_num" "$_owner" "$_repo" >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+
+    rm -f "$_err"
+    # Flatten category.name -> category for ergonomic jq downstream.
+    printf '%s' "$_json" | jq -c '. + {category: .category.name}'
+}
+
+_gh_discussion_comment() {
+    local _disc_id="${1:-}" _body_file="${2:-}"
+    if [ -z "$_disc_id" ] || [ -z "$_body_file" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_comment <discussion-id> <body-file>\n' >&2
+        return 2
+    fi
+    if [ ! -f "$_body_file" ]; then
+        printf '[gh-discussion] body-file not found: %s\n' "$_body_file" >&2
+        return 2
+    fi
+
+    local _err _url
+    _err=$(mktemp) || return 1
+
+    # Variables: $discId ID!, $body String!
+    # shellcheck disable=SC2016
+    _url=$(gh api graphql \
+        -f query='
+          mutation($discId: ID!, $body: String!) {
+            addDiscussionComment(input: {
+              discussionId: $discId,
+              body:         $body
+            }) {
+              comment { url }
+            }
+          }' \
+        -f discId="$_disc_id" \
+        -f "body=@$_body_file" \
+        --jq '.data.addDiscussionComment.comment.url' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ] || [ -z "$_url" ] || [ "$_url" = "null" ]; then
+        printf '[gh-discussion] addDiscussionComment mutation failed\n' >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+
+    rm -f "$_err"
+    printf '%s\n' "$_url"
+}
+
+_gh_discussion_close() {
+    local _disc_id="${1:-}" _reason="${2:-RESOLVED}"
+    if [ -z "$_disc_id" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_close <discussion-id> [reason]\n' >&2
+        return 2
+    fi
+    case "$_reason" in
+        RESOLVED | OUTDATED | DUPLICATE) ;;
+        *)
+            printf '[gh-discussion] close reason must be RESOLVED, OUTDATED, or DUPLICATE (got: %s)\n' \
+                "$_reason" >&2
+            return 2
+            ;;
+    esac
+
+    local _err _state
+    _err=$(mktemp) || return 1
+
+    # Variables: $discId ID!, $reason DiscussionCloseReason!
+    # shellcheck disable=SC2016
+    _state=$(gh api graphql \
+        -f query='
+          mutation($discId: ID!, $reason: DiscussionCloseReason!) {
+            closeDiscussion(input: {
+              discussionId: $discId,
+              reason:       $reason
+            }) {
+              discussion { closed }
+            }
+          }' \
+        -f discId="$_disc_id" \
+        -f reason="$_reason" \
+        --jq '.data.closeDiscussion.discussion.closed' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ] || [ "$_state" != "true" ]; then
+        printf '[gh-discussion] closeDiscussion mutation failed\n' >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+
+    rm -f "$_err"
+    printf 'closed\n'
+}
+
+_gh_discussion_lock() {
+    local _disc_id="${1:-}"
+    if [ -z "$_disc_id" ]; then
+        printf '[gh-discussion] usage: _gh_discussion_lock <discussion-id>\n' >&2
+        return 2
+    fi
+
+    local _err _state
+    _err=$(mktemp) || return 1
+
+    # lockLockable accepts any Lockable (Issue, PR, Discussion). Reason
+    # RESOLVED matches the policy in docs/.ssot/discussions-policy.md.
+    # Variables: $id ID!
+    # shellcheck disable=SC2016
+    _state=$(gh api graphql \
+        -f query='
+          mutation($id: ID!) {
+            lockLockable(input: {
+              lockableId: $id,
+              lockReason: RESOLVED
+            }) {
+              lockedRecord { locked }
+            }
+          }' \
+        -f id="$_disc_id" \
+        --jq '.data.lockLockable.lockedRecord.locked' 2>"$_err")
+    local _rc=$?
+
+    if [ "$_rc" -ne 0 ] || [ "$_state" != "true" ]; then
+        printf '[gh-discussion] lockLockable mutation failed\n' >&2
+        if [ -s "$_err" ]; then
+            sed 's/^/[gh-discussion] /' "$_err" >&2
+        fi
+        rm -f "$_err"
+        return 1
+    fi
+
+    rm -f "$_err"
+    printf 'locked\n'
 }

--- a/tests/bats/functions/gh_discussion.bats
+++ b/tests/bats/functions/gh_discussion.bats
@@ -2,7 +2,10 @@
 # tests/bats/functions/gh_discussion.bats
 # Unit tests for _gh_discussion_repo_id / _gh_discussion_category_id /
 # _gh_discussion_create — the GraphQL wrappers used by the
-# `gh:discussion-create` skill (issue #617).
+# `gh:discussion-create` skill (issue #617) — and for
+# _gh_discussion_fetch / _gh_discussion_comment / _gh_discussion_close /
+# _gh_discussion_lock — the convert-side wrappers used by
+# `gh:discussion-convert` (issue #618).
 #
 # Network is never touched. A fake `gh` shim on PATH dispatches by
 # inspecting the GraphQL query string for keywords ("repository(...){ id }",
@@ -32,6 +35,8 @@ teardown() {
 #   discussions_disabled   — discussionCategories returns []
 #   category_missing       — list has Ideas/Q&A but not the requested one
 #   mutation_fail          — repo + category succeed, createDiscussion exits 1
+#   fetch_missing          — discussion(number: $num) returns null
+#   convert_mutation_fail  — fetch ok, comment/close/lock mutations all fail
 #
 # A scratch log records every call for assertion: $TEST_TEMP_HOME/gh.log
 # ---------------------------------------------------------------------------
@@ -102,6 +107,68 @@ if [[ "$query" == *"createDiscussion(input:"* ]]; then
             ;;
         *)
             echo "https://github.com/fake/repo/discussions/123"
+            exit 0
+            ;;
+    esac
+fi
+
+# Fetch a single Discussion (convert-side helper)
+if [[ "$query" == *"discussion(number: \$num)"* ]]; then
+    case "$mode" in
+        fetch_missing)
+            # GraphQL returns null for the discussion field; helper's --jq
+            # surfaces the empty string, which the helper treats as missing.
+            exit 0
+            ;;
+        *)
+            # Mirror the real --jq '.data.repository.discussion' output:
+            # category is the nested {name} object; the helper's
+            # subsequent jq step flattens it to a string.
+            cat <<'JSON'
+{"id":"D_kgDOFAKEDISC","number":42,"title":"feat: convert me","body":"original body","url":"https://github.com/fake/repo/discussions/42","locked":false,"closed":false,"category":{"name":"Ideas"}}
+JSON
+            exit 0
+            ;;
+    esac
+fi
+
+# addDiscussionComment mutation
+if [[ "$query" == *"addDiscussionComment(input:"* ]]; then
+    case "$mode" in
+        convert_mutation_fail)
+            echo "GraphQL: Could not resolve to a node" >&2
+            exit 1
+            ;;
+        *)
+            echo "https://github.com/fake/repo/discussions/42#discussioncomment-99"
+            exit 0
+            ;;
+    esac
+fi
+
+# closeDiscussion mutation
+if [[ "$query" == *"closeDiscussion(input:"* ]]; then
+    case "$mode" in
+        convert_mutation_fail)
+            echo "GraphQL: Permission denied" >&2
+            exit 1
+            ;;
+        *)
+            echo "true"
+            exit 0
+            ;;
+    esac
+fi
+
+# lockLockable mutation
+if [[ "$query" == *"lockLockable(input:"* ]]; then
+    case "$mode" in
+        convert_mutation_fail)
+            echo "GraphQL: Resource locked" >&2
+            exit 1
+            ;;
+        *)
+            echo "true"
             exit 0
             ;;
     esac
@@ -294,5 +361,208 @@ _run_helper() {
     run grep -c 'title=Test\\ title' "$GH_LOG"
     assert_output "1"
     run grep -cE 'body=@[^ ]+' "$GH_LOG"
+    assert_output "1"
+}
+
+# ---------------------------------------------------------------------------
+# Convert-side helpers (issue #618)
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_discussion_fetch exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_fetch >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_discussion_comment exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_comment >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_discussion_close exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_close >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gh_discussion_lock exists" {
+    run_in_bash '. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"; \
+                 declare -f _gh_discussion_lock >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# Argument validation
+
+@test "fetch: missing args returns 2" {
+    _run_helper ok '_gh_discussion_fetch fake 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_fetch"
+}
+
+@test "fetch: non-integer number returns 2" {
+    _run_helper ok '_gh_discussion_fetch fake repo abc 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "discussion number must be a positive integer"
+}
+
+@test "comment: missing args returns 2" {
+    _run_helper ok '_gh_discussion_comment 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_comment"
+}
+
+@test "comment: missing body-file returns 2" {
+    _run_helper ok '_gh_discussion_comment D_ID /nonexistent/file 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "body-file not found"
+}
+
+@test "close: missing args returns 2" {
+    _run_helper ok '_gh_discussion_close 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_close"
+}
+
+@test "close: invalid reason returns 2" {
+    _run_helper ok '_gh_discussion_close D_ID NOT_A_REASON 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "close reason must be RESOLVED, OUTDATED, or DUPLICATE"
+}
+
+@test "lock: missing args returns 2" {
+    _run_helper ok '_gh_discussion_lock 2>&1'
+    assert_output --partial "rc=2"
+    assert_output --partial "usage: _gh_discussion_lock"
+}
+
+# Happy path
+
+@test "fetch: ok mode flattens category.name -> category" {
+    _run_helper ok '_gh_discussion_fetch fake repo 42'
+    assert_output --partial '"category":"Ideas"'
+    assert_output --partial '"number":42'
+    assert_output --partial '"id":"D_kgDOFAKEDISC"'
+    assert_output --partial "rc=0"
+}
+
+@test "fetch: ok mode includes locked/closed state for caller dispatch" {
+    _run_helper ok '_gh_discussion_fetch fake repo 42'
+    assert_output --partial '"locked":false'
+    assert_output --partial '"closed":false'
+    assert_output --partial "rc=0"
+}
+
+@test "comment: ok mode prints comment URL" {
+    _run_helper ok "
+        BF=\$(mktemp); printf 'Linked to issue #99' > \"\$BF\"
+        _gh_discussion_comment D_ID \"\$BF\"
+        _rc=\$?
+        rm -f \"\$BF\"
+        ( exit \$_rc )
+    "
+    assert_output --partial "discussioncomment-99"
+    assert_output --partial "rc=0"
+    run grep -c 'addDiscussionComment' "$GH_LOG"
+    assert_output "1"
+}
+
+@test "close: ok mode reports 'closed' and uses RESOLVED reason by default" {
+    _run_helper ok '_gh_discussion_close D_ID'
+    assert_output --partial "closed"
+    assert_output --partial "rc=0"
+    # Default reason RESOLVED must appear in the recorded gh args.
+    run grep -c 'reason=RESOLVED' "$GH_LOG"
+    assert_output "1"
+}
+
+@test "close: ok mode honours explicit OUTDATED reason" {
+    _run_helper ok '_gh_discussion_close D_ID OUTDATED'
+    assert_output --partial "rc=0"
+    run grep -c 'reason=OUTDATED' "$GH_LOG"
+    assert_output "1"
+}
+
+@test "lock: ok mode reports 'locked' and uses RESOLVED in the query" {
+    _run_helper ok '_gh_discussion_lock D_ID'
+    assert_output --partial "locked"
+    assert_output --partial "rc=0"
+    # The reason RESOLVED is hard-coded in the GraphQL string (not -f),
+    # so look for it inside the recorded query argument.
+    run grep -c 'lockLockable' "$GH_LOG"
+    assert_output "1"
+}
+
+# Failure modes
+
+@test "fetch: fetch_missing returns 1 with not-found hint" {
+    _run_helper fetch_missing '_gh_discussion_fetch fake repo 42 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "discussion #42 not found on fake/repo"
+}
+
+@test "comment: convert_mutation_fail returns 1 with stderr trace" {
+    _run_helper convert_mutation_fail "
+        BF=\$(mktemp); printf 'x' > \"\$BF\"
+        _gh_discussion_comment D_ID \"\$BF\" 2>&1
+        _rc=\$?
+        rm -f \"\$BF\"
+        ( exit \$_rc )
+    "
+    assert_output --partial "rc=1"
+    assert_output --partial "addDiscussionComment mutation failed"
+    assert_output --partial "Could not resolve to a node"
+}
+
+@test "close: convert_mutation_fail returns 1 with stderr trace" {
+    _run_helper convert_mutation_fail '_gh_discussion_close D_ID 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "closeDiscussion mutation failed"
+    assert_output --partial "Permission denied"
+}
+
+@test "lock: convert_mutation_fail returns 1 with stderr trace" {
+    _run_helper convert_mutation_fail '_gh_discussion_lock D_ID 2>&1'
+    assert_output --partial "rc=1"
+    assert_output --partial "lockLockable mutation failed"
+    assert_output --partial "Resource locked"
+}
+
+# GraphQL invocation shape
+
+@test "comment: invocation passes discId variable and body file ref" {
+    _run_helper ok "
+        BF=\$(mktemp); printf 'hello' > \"\$BF\"
+        _gh_discussion_comment D_TEST \"\$BF\"
+        _rc=\$?
+        rm -f \"\$BF\"
+        ( exit \$_rc )
+    "
+    assert_output --partial "rc=0"
+    run grep -c 'discId=D_TEST' "$GH_LOG"
+    assert_output "1"
+    # Body is streamed from a file via -f body=@<path>, mirroring the
+    # createDiscussion pattern (PR #624 review note).
+    run grep -cE 'body=@[^ ]+' "$GH_LOG"
+    assert_output "1"
+}
+
+@test "close: invocation passes discId and reason variables" {
+    _run_helper ok '_gh_discussion_close D_TEST RESOLVED'
+    assert_output --partial "rc=0"
+    run grep -c 'discId=D_TEST' "$GH_LOG"
+    assert_output "1"
+    run grep -c 'reason=RESOLVED' "$GH_LOG"
+    assert_output "1"
+}
+
+@test "lock: invocation passes the lockable node id" {
+    _run_helper ok '_gh_discussion_lock D_TEST'
+    assert_output --partial "rc=0"
+    run grep -c 'id=D_TEST' "$GH_LOG"
     assert_output "1"
 }


### PR DESCRIPTION
## Summary
- Adds `/gh:discussion-convert` skill — automates the 4-step Discussion -> Issue 변환 규약 from `docs/.ssot/discussions-policy.md` (#612). The most error-prone step (forgetting the bidirectional backlink) is now mechanically enforced.
- No public GitHub `convertDiscussion` API exists as of 2026-05; the skill emulates the UI flow via `createIssue` + `addDiscussionComment` + `closeDiscussion` + `lockLockable` + project-board sync.
- Idempotent — re-running on an already-converted Discussion exits 0 with the existing Issue URL.

## Changes
- `shell-common/functions/gh_discussion.sh` — adds 4 GraphQL helpers (`_gh_discussion_fetch` / `_gh_discussion_comment` / `_gh_discussion_close` / `_gh_discussion_lock`) sharing the auditable-GraphQL-strings-in-one-file pattern with the create-side helpers from #617. `closeDiscussion` reasons validated client-side (RESOLVED / OUTDATED / DUPLICATE); `lockLockable` bakes in `lockReason: RESOLVED` to match the policy.
- `claude/skills/gh-discussion-convert/` — progressive-disclosure skill (SKILL.md + 4 references: help / repo-resolution / convert-cmd / error-cases). Category guard refuses non-`Ideas` Discussions per policy operating principle #2; `--force-category` is a one-shot override. Step 4 idempotency check searches the Issue tracker for `Originated from discussion #N` before any mutation, so re-runs never duplicate. Steps 6/7/8 (board sync / backlink comment / close+lock) are best-effort with warnings — once Step 5 creates the Issue with the forward backlink, the SSOT chain is intact even if later flake.
- `tests/bats/functions/gh_discussion.bats` — extends the existing #617 suite with 24 new fake-shim tests (41/41 pass total). Covers argument validation for all 4 helpers, happy paths including `category.name` flattening + locked/closed surfacing, `fetch_missing` + `convert_mutation_fail` failure modes, and GraphQL variable shape (`discId` / `reason` / `body=@file`). No live API per `feedback_no_live_api_for_smoke_test`.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_discussion.bats` — 41/41 pass
- [x] Helpers load in both bash and zsh (`declare -f` / `typeset -f` verified for all 4)
- [x] `tox -e ruff,shellcheck,shfmt` — clean (pre-push lint guard)
- [ ] Manual smoke after merge: pick a closed Ideas Discussion (e.g. an old #612-era thread) and run `/gh-discussion-convert <N> --no-comment --no-lock --no-close` against a sandbox repo to confirm the Issue-creation half end-to-end without mutating live state
- [ ] Manual smoke: run twice in a row on the same Discussion to confirm idempotency (second run prints existing Issue URL and exits 0)

## Related
Closes #618

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
