### PR TITLE
feat(gh-issue-create): #619 add --as-discussion routing flag

### DIFF
--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -15,7 +15,10 @@ description: >-
   target repo ships a `.gh-issue-defaults.yml`, default labels and a
   milestone are auto-applied per that file (Step 2.5); pass
   `--no-auto-labels` to opt out or `--auto-label-debug` for the dispatch
-  trace. Accepts `-h`/`--help`/`help` to print usage.
+  trace. Pass `--as-discussion <category>` (`Ideas` / `Q&A` /
+  `Announcements` / `Lessons`) to route the same conversation to
+  [[gh-discussion-create]] without re-running a different skill (#619).
+  Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
 ---
 
@@ -41,6 +44,7 @@ number + URL at the end.
 | `--auto-label-debug` | Verbose stderr trace of Stage-1 detection and the kept/dropped label sets. | off |
 | `--label <name>` | User label, union with Step 2.5 auto-labels. Repeatable. | — |
 | `--assignee @me` | Only added when the user explicitly asks. | off |
+| `--as-discussion <category>` | Route to [[gh-discussion-create]] instead of creating an Issue. Category is one of `Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive). Skips Step 2.5 (auto-labels) and Step 4's `gh issue create` — Discussions do not carry labels/milestones. `--label` / `--assignee` flags, if also passed, are ignored with a 1-line warning. | off |
 | `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
 | `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
 
@@ -52,6 +56,22 @@ positional remote arg and the flags above. Confirm we're in a git repo
 via the remote — full substeps in `references/repo-resolution.md`.
 Never silently fall back to `origin` when the user-supplied remote is
 missing.
+
+### Step 1.1: `--as-discussion` parse
+
+If `--as-discussion <category>` is present, bind `DISCUSSION_MODE=1` and
+`CATEGORY=<value>`. Validate `<value>` against the allow-list
+`Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive); on
+mismatch, print the four allowed values and **exit 3** without calling
+any API. When `DISCUSSION_MODE=1` and the user also supplied `--label`
+or `--assignee`, emit a 1-line warning to stderr and drop those flags
+(Discussions do not carry labels/assignees):
+
+```
+[gh-issue-create] --as-discussion: dropping --label/--assignee (Discussions do not carry these)
+```
+
+When `DISCUSSION_MODE` is unset the legacy issue path is unchanged.
 
 ## Step 2: Classify the Conversation
 
@@ -68,11 +88,14 @@ Apply `references/clarification.md` trigger signals (동사 없는 명사 나열
 
 ## Step 2.5: Auto-labels + Milestone (opt-in via SSOT)
 
-Skip entirely when `--no-auto-labels` is set. Otherwise read
-`references/auto-labels.md` and follow verbatim (Stage-1 signal →
-SSOT load → label union → `gh label list` validation → milestone
-resolution). Stash kept labels + milestone for Step 4.
-`--auto-label-debug` emits the Stage-1 trace per the same reference.
+Skip entirely when `--no-auto-labels` **or** `DISCUSSION_MODE=1` is set.
+Discussions do not carry labels or milestones (#619 F-3) — running the
+auto-label dispatch and then discarding the result would be wasteful
+and noisy. Otherwise read `references/auto-labels.md` and follow
+verbatim (Stage-1 signal → SSOT load → label union → `gh label list`
+validation → milestone resolution). Stash kept labels + milestone for
+Step 4. `--auto-label-debug` emits the Stage-1 trace per the same
+reference.
 
 ## Step 3: Draft the Issue Body
 
@@ -81,6 +104,12 @@ resolution). Stash kept labels + milestone for Step 4.
 작성하고 (한국어 대화 → 한국어 이슈) **over-compress 금지** — 파일
 경로·명령 출력·결정·근거를 그대로 유지한다. 200 줄짜리 이슈도 정상.
 
+When `DISCUSSION_MODE=1`, swap the Acceptance Criteria section for an
+**Open Questions** section and use the matching skeleton from
+[[gh-discussion-create]]'s `references/rfc-template.md`
+(Ideas/Q&A/Announcements/Lessons variants). All other detail-preservation
+rules remain identical — Discussions are not a license to compress.
+
 ## Step 3.5: Compute AI Metrics
 
 Read `references/metrics-baseline.md` and bind `TOKENS`, `HUMAN_H`,
@@ -88,29 +117,47 @@ Read `references/metrics-baseline.md` and bind `TOKENS`, `HUMAN_H`,
 Step 2, the drafted title + body. For `feat`, infer size (small /
 medium / large) from the conversation scope.
 
-## Step 4: Create the Issue
+## Step 4: Create the Issue (or Discussion)
 
-Read `references/create-cmd.md` and paste the bash block verbatim — it
-handles the `mktemp` body file, `GH_DISABLE_AI_METRICS=1` short-circuit
-(issue #399), the ai-metrics footer printf, and `gh issue create` with
-`LABEL_ARGS` / `MILESTONE_ARGS` from Step 2.5.
+Read `references/create-cmd.md` and paste the matching bash block
+verbatim:
+
+- **Issue path** (default, `DISCUSSION_MODE` unset) — `mktemp` body
+  file, `GH_DISABLE_AI_METRICS=1` short-circuit (issue #399),
+  ai-metrics footer printf, and `gh issue create` with `LABEL_ARGS` /
+  `MILESTONE_ARGS` from Step 2.5.
+- **Discussion path** (`DISCUSSION_MODE=1`) — same body file +
+  ai-metrics footer, then source
+  `shell-common/functions/gh_discussion.sh` and run the three lookups
+  (`_gh_discussion_repo_id`, `_gh_discussion_category_id`,
+  `_gh_discussion_create`). Print the Discussion URL instead of an
+  issue URL. If the helper is missing, fail with
+  `[FAIL] gh-discussion helper not found at $DOTFILES_ROOT/shell-common/functions/gh_discussion.sh`
+  and exit 1.
 
 확인 질문하지 말고 즉시 실행.
 
 ## Step 5: Report
 
-성공 시:
+Issue 경로 성공 시:
 
 ```
 [OK] Issue: #123, URL: https://github.com/owner/repo/issues/123
 Next: /gh:issue-implement 123
 ```
 
-실패 시 (gh stderr 그대로 첫 줄에 인용):
+Discussion 경로 (`DISCUSSION_MODE=1`) 성공 시 — Discussion URL 만 출력:
 
 ```
-[FAIL] <gh stderr first line>
-Next: <recovery step — e.g. `gh auth login`, fix `.gh-issue-defaults.yml`>
+[OK] Discussion (<category>): https://github.com/owner/repo/discussions/45
+Next: /gh-discussion-convert 45   # when decision lands
+```
+
+실패 시 (gh stderr 또는 helper stderr 첫 줄을 인용):
+
+```
+[FAIL] <stderr first line>
+Next: <recovery step — e.g. `gh auth login`, fix `.gh-issue-defaults.yml`, enable Discussions in repo settings>
 ```
 
 ## Constraints
@@ -121,5 +168,13 @@ Next: <recovery step — e.g. `gh auth login`, fix `.gh-issue-defaults.yml`>
   통과한 라벨만 유지 — 미존재 라벨 자동 생성 금지.
 - 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
 - 사용자 지정 remote 가 없으면 즉시 실패.
-- discussion log 를 2~3줄로 압축하지 말 것.
+- discussion log 를 2~3줄로 압축하지 말 것. `DISCUSSION_MODE=1`
+  경로에서도 동일하게 적용된다 — Discussion 본문은 future-self 검색의
+  SSOT 다.
+- `--as-discussion` 는 명시적 사용자 의도 전용. AI 가 "이건 Discussion
+  같음" 자동 판정해서 분기하지 말 것 (#619 Non-Goal). 잘못된 분기 =
+  SSOT 분산.
+- `--as-discussion` + `--label` / `--assignee` 동시 사용 시 후자를
+  버리고 경고 1줄. `DISCUSSION_MODE=1` 일 때 Step 2.5 와 `gh issue
+  create` 둘 다 우회.
 - "should I create it?" 같은 확인 질문 금지.

--- a/claude/skills/gh-issue-create/references/create-cmd.md
+++ b/claude/skills/gh-issue-create/references/create-cmd.md
@@ -2,13 +2,18 @@
 
 Detail companion to SKILL.md Step 4. Writes the drafted body to a temp
 file, appends the ai-metrics footer (unless `GH_DISABLE_AI_METRICS=1`),
-and calls `gh issue create`.
+and calls either `gh issue create` (default) or the
+`_gh_discussion_*` helpers (`DISCUSSION_MODE=1`, #619).
 
 `$TOKENS`, `$HUMAN_H`, `$ELAPSED` come from Step 3.5.
 `LABEL_ARGS` / `MILESTONE_ARGS` are the arrays Step 2.5 prepared (one
 `--label <name>` per kept label; `--milestone <title>` if resolved).
 Both are empty when Step 2.5 was skipped — the `gh issue create`
-invocation degrades to its original form.
+invocation degrades to its original form. When `DISCUSSION_MODE=1`,
+Step 2.5 is skipped unconditionally, so both arrays are empty and the
+Discussion branch ignores them.
+
+## Issue path (default)
 
 ```bash
 BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
@@ -28,9 +33,52 @@ gh issue create --repo "$TARGET_REPO" --title "<title>" --body-file "$BODY" \
 `--no-auto-labels` was set, in which case Step 2.5 is bypassed and the
 user's labels pass straight through `LABEL_ARGS` from Step 1.
 
+## Discussion path (`DISCUSSION_MODE=1`)
+
+Triggered by `--as-discussion <category>` from Step 1.1. Sources the
+shared helper used by [[gh-discussion-create]] and calls the three
+GraphQL primitives in order. `$CATEGORY` was validated in Step 1.1
+against `Ideas` / `Q&A` / `Announcements` / `Lessons` — no extra
+validation here.
+
+```bash
+# Fail fast if the helper file is missing (skill installed but
+# helper not yet symlinked into shell-common/).
+if [ ! -r "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh" ]; then
+    printf '[FAIL] gh-discussion helper not found at %s/shell-common/functions/gh_discussion.sh\n' \
+      "$DOTFILES_ROOT" >&2
+    printf 'Next: install gh-discussion-create skill first.\n' >&2
+    exit 1
+fi
+# shellcheck disable=SC1091
+. "$DOTFILES_ROOT/shell-common/functions/gh_discussion.sh"
+
+BODY=$(mktemp) && trap 'rm -f "$BODY"' EXIT
+# ... write Open-Questions-forward body to "$BODY" (Step 3 sets shape) ...
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
+else
+    printf '\n---\n<details>\n<summary>🤖 AI Metrics · 📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min</summary>\n\n<!-- ai-metrics:gh-issue-create -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-issue-create -->\n\n</details>\n' \
+      "$TOKENS" "$HUMAN_H" "$ELAPSED" "$TOKENS" "$HUMAN_H" "$ELAPSED" >> "$BODY"
+fi
+
+_owner="${TARGET_REPO%%/*}"
+_repo="${TARGET_REPO##*/}"
+
+REPO_ID=$(_gh_discussion_repo_id "$_owner" "$_repo") || exit 1
+CATEGORY_ID=$(_gh_discussion_category_id "$_owner" "$_repo" "$CATEGORY") || exit 1
+URL=$(_gh_discussion_create "$REPO_ID" "$CATEGORY_ID" "$TITLE" "$BODY") || exit 1
+
+printf '[OK] Discussion (%s): %s\n' "$CATEGORY" "$URL"
+```
+
+The three helper calls match [[gh-discussion-create]]'s
+`references/create-cmd.md` byte-for-byte — keep them in lock-step. If
+the helper ever changes signature, update both skills together.
+
 확인 질문하지 말고 즉시 실행.
 
 The four emoji glyphs in the printf above (`<U+1F916> <U+1F4CA> <U+1F464>`) are
 the ai-metrics footer exception defined in `CLAUDE.md` — the `<details>`
-wrapper + `<!-- ai-metrics -->` block. The exception does not extend
-anywhere else in this skill.
+wrapper + `<!-- ai-metrics -->` (or `<!-- ai-metrics:gh-issue-create -->`)
+block. The exception does not extend anywhere else in this skill.

--- a/claude/skills/gh-issue-create/references/help.md
+++ b/claude/skills/gh-issue-create/references/help.md
@@ -12,6 +12,7 @@
 |------|---------|-------------|
 | `--no-auto-labels` | off | Skip Step 2.5 — never auto-attach labels/milestones from `.gh-issue-defaults.yml`. User-supplied `--label` flags still apply. |
 | `--auto-label-debug` | off | Print Stage-1 detection trace plus kept/dropped label sets to stderr before issue creation. |
+| `--as-discussion <category>` | off | Route to [[gh-discussion-create]] instead of creating an Issue. `<category>` is one of `Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive). Skips Step 2.5 entirely; `--label` / `--assignee` are ignored with a 1-line warning. Invalid category exits 3 without calling any API. |
 
 ## Usage
 
@@ -19,6 +20,8 @@
 - `/gh-issue-create upstream` — create issue on the `upstream` remote's repo
 - `/gh-issue-create --no-auto-labels` — skip the SSOT auto-label step
 - `/gh-issue-create --auto-label-debug` — verbose label-dispatch trace
+- `/gh-issue-create --as-discussion Ideas` — route the same conversation to [[gh-discussion-create]] (RFC body, Ideas category)
+- `/gh-issue-create upstream --as-discussion Q&A` — Q&A Discussion on the `upstream` remote's repo
 - `/gh-issue-create -h` / `--help` / `help` — print this help
 
 ## What the skill does
@@ -81,3 +84,18 @@ A 200-line issue is fine if the conversation warranted it.
 - Ask "should I create it?" — running the skill is the confirmation.
 - Rely on implicit repo detection — always passes `--repo "$TARGET_REPO"`.
 - Truncate or summarize the conversation log.
+- Auto-detect whether the chat is RFC-shaped and route to a Discussion
+  on its own. `--as-discussion` requires an explicit user request
+  (#619 Non-Goal: no AI auto-judgement).
+- Apply labels or assignees on the Discussion path — those are an
+  Issue-only concept. Mixing `--as-discussion` with `--label` /
+  `--assignee` drops the latter with a 1-line warning.
+
+## Error cases
+
+- `--as-discussion Foo` (not one of `Ideas` / `Q&A` / `Announcements` /
+  `Lessons`) → print the four allowed values and exit 3 without any
+  API call.
+- `--as-discussion <category>` when
+  `shell-common/functions/gh_discussion.sh` is missing → print
+  `Install gh-discussion-create skill first.` and exit 1.

--- a/tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh
@@ -24,6 +24,11 @@
 #   $4 — comma-separated labels that exist on the target repo (mock)
 #   $5 — "1" if --no-auto-labels, "0" otherwise
 #
+#   Env: $DISCUSSION_MODE — "1" when --as-discussion was set in Step 1.1
+#                          (#619). Forces Step 2.5 to skip entirely and
+#                          drops any user labels with no warning here
+#                          (the SKILL warns once in Step 1.1).
+#
 # Stdout: final kept labels, one per line, in dispatch order
 #         (static first, then prefix-mapped, then user labels), de-duped.
 # Stderr: one `auto-labels: label '<x>' not found ...` line per dropped.
@@ -34,6 +39,16 @@ gh_issue_create_compose_labels() {
     _user_csv="$3"
     _existing_csv="$4"
     _no_auto="$5"
+
+    # --as-discussion (#619) skips Step 2.5 entirely AND drops user
+    # labels — Discussions do not carry labels. The SKILL emits the
+    # 1-line warning once in Step 1.1; the composer is silent here so
+    # callers can distinguish "label dropped due to missing repo label"
+    # from "label dropped due to Discussion mode" by checking
+    # $DISCUSSION_MODE in the caller.
+    if [ "${DISCUSSION_MODE:-0}" = "1" ]; then
+        return 0
+    fi
 
     # User labels are unconditional unless --no-auto-labels is set, in
     # which case Step 2.5 is skipped and only user labels remain.

--- a/tests/bats/skills/gh_issue_create_auto_labels.bats
+++ b/tests/bats/skills/gh_issue_create_auto_labels.bats
@@ -111,3 +111,25 @@ YAML
     [[ "$stderr" == *"auto-labels: label 'documentation' not found"* ]]
     [[ "$stderr" != *"label 'skill' not found"* ]]
 }
+
+# ── Row 8 (issue #619) ───────────────────────────────────────────────
+@test "auto-labels: DISCUSSION_MODE=1 skips Step 2.5 entirely" {
+    # --as-discussion routes to gh-discussion-create; Discussions do
+    # not carry labels, so the composer must short-circuit to empty
+    # even when user labels were passed and the SSOT defines feat→feat.
+    DISCUSSION_MODE=1 run gh_issue_create_compose_labels \
+        "$DOTFILES_YML" feat "skill" "$DOTFILES_EXISTING" 0
+    assert_success
+    assert_output ''
+}
+
+@test "auto-labels: DISCUSSION_MODE=0 leaves existing dispatch unchanged" {
+    # Regression guard for #619 — explicit DISCUSSION_MODE=0 must not
+    # alter the legacy behaviour. Same input as Row 3 (feat + 'skill').
+    DISCUSSION_MODE=0 run gh_issue_create_compose_labels \
+        "$DOTFILES_YML" feat "skill" "$DOTFILES_EXISTING" 0
+    assert_success
+    assert_line --index 0 'feat'
+    assert_line --index 1 'skill'
+    [ "${#lines[@]}" -eq 2 ]
+}


### PR DESCRIPTION
## Summary
- `gh-issue-create` 에 `--as-discussion <category>` 라우팅 플래그 추가. 사용자가 대화 capture 도중에 "이건 RFC 야" 라고 판단했을 때 같은 진입점에서 `gh-discussion-create` 로 분기 (#619).
- `DISCUSSION_MODE=1` 일 때 Step 2.5 (auto-labels) + Step 4 (`gh issue create`) 우회. Discussion 은 라벨·마일스톤 개념이 없으므로 composer 가 short-circuit + 1줄 경고로 사용자 `--label` / `--assignee` 를 drop.
- Acceptance criteria F-1..F-4 + NF-1 모두 충족. bats 9/9 통과 (기존 7 rows 회귀 0 + 신규 DISCUSSION_MODE 2 rows).

## Changes
- `claude/skills/gh-issue-create/SKILL.md` — frontmatter description, Options 표, Step 1.1 (`--as-discussion` parse + 카테고리 검증, 잘못된 값 exit 3), Step 2.5 (DISCUSSION_MODE 시 skip), Step 3 (Open Questions 본문 골격 전환), Step 4 (helper dispatch), Step 5 (Discussion URL 출력), Constraints 추가.
- `claude/skills/gh-issue-create/references/help.md` — 플래그 row, usage 예제 2 종, "will NOT do" 2 항 (AI 자동 판정 금지 + Discussion 라벨 부착 금지), Error cases 섹션.
- `claude/skills/gh-issue-create/references/create-cmd.md` — Discussion 경로 bash 블록 추가. `shell-common/functions/gh_discussion.sh` 소싱 후 `_gh_discussion_repo_id` → `_gh_discussion_category_id` → `_gh_discussion_create` 3-step. `gh-discussion-create` 의 `create-cmd.md` 와 byte-for-byte 일치 (helper 시그니처 변경 시 lock-step 유지).
- `tests/bats/skills/_fixtures/gh_issue_create_auto_labels.sh` — composer 가 `$DISCUSSION_MODE` 환경 변수 인식. `=1` 일 때 즉시 빈 출력으로 short-circuit (5-arg public 인터페이스 변경 없음).
- `tests/bats/skills/gh_issue_create_auto_labels.bats` — Row 8 (DISCUSSION_MODE=1 → empty), Row 9 (DISCUSSION_MODE=0 회귀 가드: Row 3 와 동일 결과).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_issue_create_auto_labels.bats` → 9/9 ok
- [x] `tox -e shellcheck shfmt ruff mypy` → all green
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/` → 161 total, only pre-existing test 76 (doc-guard) fails on baseline HEAD — not introduced by this PR
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/` → 443 total, 3 pre-existing failures (claude_stop_hook, git_worktree prune, status help) — also baseline-red
- [x] Lint guard (`shell-common/functions/gh_pr_lint.sh` + `tox -e ruff,shellcheck,shfmt`) → passes pre-push
- [ ] (manual) `/gh-issue-create --as-discussion Ideas` on a test repo with Discussions enabled — confirm Discussion URL printed + label `--label` flags dropped with warning
- [ ] (manual) `/gh-issue-create --as-discussion Foo` → exit 3 with category list (no API call)

## Related
Closes #619


---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
