### PR TITLE
feat(gh-pr-reply): #627 add Step 6.5 board sync (In review 복귀)

### DIFF
--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -90,6 +90,44 @@ reviewer's language.
 If any fixes were committed: `git push` (never force-push unless the user
 asked) and report new commit SHAs alongside the reply summary.
 
+Track the push outcome in `PUSHED_FIXES` (count of new commit SHAs that
+landed on the remote branch in this step). Step 6.5 reads this variable
+to decide whether to move the PR card. When no fixes were committed
+(all comments were DECLINE / QUESTION) or `git push` is skipped, set
+`PUSHED_FIXES=0` so Step 6.5 becomes a no-op.
+
+## Step 6.5: Sync Project Board (`In review` 복귀)
+
+If Step 6 actually pushed at least one fix commit (i.e. `PUSHED_FIXES > 0`,
+new SHAs created on the remote branch), push the PR card back to
+`In review` so reviewers see it in their queue. Mirrors the
+`/gh-pr-resolve-conflict` Step 5 pattern (issue #591) so both flows
+share one board-recovery surface.
+
+Skips when `PUSHED_FIXES == 0` (all comments DECLINE / QUESTION — no
+push happened, so the card lifecycle has not changed and there is
+nothing to recover). The `--only-from "In progress,Changes requested"`
+guard makes the call a no-op for cards already at `In review` /
+`Approved` / `Done`, so re-running on an already-recovered card never
+demotes status.
+
+Soft-fail — warn on any error, never block the Step 7 report.
+
+```bash
+if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
+    . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null \
+      && _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+            --only-from "In progress,Changes requested" \
+      && echo "[OK] PR 카드 \`In review\` 로 복귀됨" \
+      || echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+fi
+```
+
+`GH_PROJECT_STATUS_SYNC=0` opt-out is absorbed by the helper itself.
+projectV2 보드가 없는 레포는 helper 가 silent 0 반환. `--only-from`
+의 missing column 은 helper 가 silently skip 하므로 `Changes requested`
+컬럼 없는 보드와도 호환된다.
+
 ## Step 7: Report
 
 Print the summary table per `references/final-summary.md` showing

--- a/tests/bats/skills/_fixtures/gh_pr_reply_board_sync.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_reply_board_sync.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_reply_board_sync.sh
+# Source-of-truth mirror for the Step 6.5 board-sync (`In review` 복귀)
+# snippet documented in claude/skills/gh-pr-reply/SKILL.md.
+#
+# The skill itself runs inside a Claude session, but the gate is a
+# small POSIX block that can be tested in isolation: given the number
+# of fixes pushed in Step 6 and a stub helper, does Step 6.5 call the
+# helper (push happened) or no-op silently (no push)?
+#
+# Keep this file in sync with SKILL.md Step 6.5. If the skill block
+# changes, mirror the change here so the bats suite catches drift.
+
+# Stand-in for _gh_project_status_sync. The real helper lives in
+# shell-common/functions/gh_project_status.sh; tests inject behaviour
+# via FAKE_HELPER_RC and FAKE_HELPER_LOG. Records its full argv so
+# assertions can verify the `--only-from` guard arg shape.
+_gh_project_status_sync() {
+    : "${FAKE_HELPER_LOG:?FAKE_HELPER_LOG must be set by the test}"
+    printf 'helper called args=%s\n' "$*" >>"$FAKE_HELPER_LOG"
+    return "${FAKE_HELPER_RC-0}"
+}
+
+# Mirrors SKILL.md Step 6.5 verbatim. Any change here must propagate to
+# the SKILL.md block, and vice versa. Always returns 0 (soft-fail policy).
+gh_pr_reply_board_sync_step65() {
+    local PR_NUMBER="$1" PUSHED_FIXES="$2"
+
+    # Gate: only fire when at least one fix commit actually pushed.
+    # When PUSHED_FIXES == 0 (all comments DECLINE / QUESTION) the card
+    # lifecycle did not change, so there is nothing to recover.
+    if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
+        if _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+            --only-from "In progress,Changes requested"; then
+            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
+        else
+            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+        fi
+    fi
+
+    return 0
+}

--- a/tests/bats/skills/gh_pr_reply_board_sync.bats
+++ b/tests/bats/skills/gh_pr_reply_board_sync.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_reply_board_sync.bats
+# Verify the Step 6.5 board-sync (`In review` 복귀) gate documented in
+#   claude/skills/gh-pr-reply/SKILL.md  (Step 6.5)
+# Source-of-truth fixture: _fixtures/gh_pr_reply_board_sync.sh.
+#
+# Five cases drawn from issue #627's acceptance criteria:
+#   1. push happened (PUSHED_FIXES > 0)            → helper called + audit OK line
+#   2. no push (PUSHED_FIXES == 0)                 → silent no-op
+#   3. PUSHED_FIXES unset                          → silent no-op (default 0)
+#   4. helper returns 2 (already In review etc.)   → WARN line, rc=0 (soft-fail)
+#   5. argv carries --only-from "In progress,Changes requested" guard
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    FAKE_HELPER_LOG="$(mktemp)"
+    export FAKE_HELPER_LOG
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_reply_board_sync.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+    [ -n "$FAKE_HELPER_LOG" ] && rm -f "$FAKE_HELPER_LOG"
+    unset FAKE_HELPER_LOG FAKE_HELPER_RC
+}
+
+@test "board-sync: PUSHED_FIXES>0 → helper called, OK line" {
+    run gh_pr_reply_board_sync_step65 663 2
+    assert_success
+    assert_output --partial 'In review'
+    assert_output --partial '[OK] PR'
+    run cat "$FAKE_HELPER_LOG"
+    assert_output --partial 'helper called'
+    assert_output --partial 'args=pr 663 In review --only-from In progress,Changes requested'
+}
+
+@test "board-sync: PUSHED_FIXES=0 → silent no-op" {
+    run gh_pr_reply_board_sync_step65 663 0
+    assert_success
+    refute_output --partial '[OK]'
+    refute_output --partial '[WARN]'
+    run cat "$FAKE_HELPER_LOG"
+    refute_output --partial 'helper called'
+}
+
+@test "board-sync: PUSHED_FIXES unset → silent no-op (default 0)" {
+    run gh_pr_reply_board_sync_step65 663 ""
+    assert_success
+    refute_output --partial '[OK]'
+    refute_output --partial '[WARN]'
+    run cat "$FAKE_HELPER_LOG"
+    refute_output --partial 'helper called'
+}
+
+@test "board-sync: helper rc=2 → WARN line, rc=0 (soft-fail)" {
+    FAKE_HELPER_RC=2
+    run gh_pr_reply_board_sync_step65 663 1
+    assert_success
+    assert_output --partial '[WARN] 보드 sync 실패'
+    refute_output --partial '[OK] PR'
+    run cat "$FAKE_HELPER_LOG"
+    assert_output --partial 'helper called'
+}
+
+@test "board-sync: argv carries --only-from guard (regression: don't demote cards already past In review)" {
+    # The `--only-from "In progress,Changes requested"` filter is the
+    # safety belt that prevents accidentally demoting cards already at
+    # `In review` / `Approved` / `Done`. Drop it and a re-run after
+    # approval would push the card backwards.
+    run gh_pr_reply_board_sync_step65 663 5
+    assert_success
+    run cat "$FAKE_HELPER_LOG"
+    assert_output --partial '--only-from In progress,Changes requested'
+}


### PR DESCRIPTION
## Summary
- `/gh-pr-reply` 가 fix commit 을 push 한 뒤 PR 카드가 `In progress` / `Changes requested` 에 그대로 머물러 동료 리뷰어 큐 (`In review`) 에서 사라지는 흐름을 끊는다.
- `/gh-pr-resolve-conflict` Step 5 와 동일한 `_gh_project_status_sync` 호출 패턴을 `gh-pr-reply` 에도 도입해 board-recovery 표면을 두 스킬이 공유한다.

## Changes
- `claude/skills/gh-pr-reply/SKILL.md` — Step 6 에 `PUSHED_FIXES` 추적 명시; 새로 Step 6.5 (보드 `In review` 복귀) 삽입. `--only-from "In progress,Changes requested"` 가드로 이미 `In review` / `Approved` / `Done` 인 카드는 후퇴시키지 않음. soft-fail.
- `tests/bats/skills/_fixtures/gh_pr_reply_board_sync.sh` — Step 6.5 게이트의 SSOT fixture (stub helper + 게이트 함수).
- `tests/bats/skills/gh_pr_reply_board_sync.bats` — 5 케이스: push>0 → helper 호출, push=0 / unset → 무동작, helper rc=2 → WARN+rc=0, `--only-from` 가드 인자 회귀.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_reply_board_sync.bats` → 5/5 PASS
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_reply_auto_approve.bats` → 15/15 PASS (회귀 없음)
- [x] `tox -e ruff,shellcheck,shfmt` 통과 (pre-push 가드)
- [ ] CI green
- [ ] 실제 PR 리뷰 흐름에서 fix push → 카드 `In review` 자동 복귀 1회 검증

## Related
Closes #627

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
