### PR TITLE
fix(stop-guard): #608 fix SKILL prompt terminal-marker false-match

### DIFF
--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -39,11 +39,22 @@ from typing import Any
 _TRACE_ENABLED: bool = os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_TRACE") == "1"
 
 
-def _trace(message: str) -> None:
-    """Emit a `[stop-guard]` trace line on stderr when trace mode is on."""
+def _trace(message: str, *, layer: str | None = None) -> None:
+    """Emit a `[stop-guard]` trace line on stderr when trace mode is on.
+
+    `layer` is the protection layer the trace belongs to (issue #608
+    Acceptance Criteria: standardize trace fields):
+      - `L1`   — boundary detection (`_find_flow_boundary`)
+      - `L1.5` — terminal-marker / sub-skill scan (`_scan_after_boundary`)
+      - `L2`   — state file (`.claude/.gh-issue-flow-state.json`, future)
+      - `L3`   — heartbeat cron (`CronCreate(durable=true)`, future)
+    The tag is appended (not prepended) so existing substring-based test
+    assertions like `"[stop-guard] allow:"` keep matching.
+    """
     if _TRACE_ENABLED:
         try:
-            print(f"[stop-guard] {message}", file=sys.stderr, flush=True)
+            tag = f" layer={layer}" if layer else ""
+            print(f"[stop-guard] {message}{tag}", file=sys.stderr, flush=True)
         except OSError:
             pass
 
@@ -69,23 +80,25 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
 )
 
 # Regex that marks the *start* of a gh-issue-flow chain in a user message.
-# Matches two real-world forms that user-typed slash commands take in Claude
-# Code transcripts (issues #607 / #609):
+# Matches four real-world forms that user-typed slash commands take in Claude
+# Code transcripts (issues #607 / #609 / #608):
 #
 #   (a) Raw `/gh-issue-flow ...` (or colon form `/gh:issue-flow ...`) at the
 #       start of a line — historical fixture form, still valid for tests
 #       and for users who paste the command into a longer message.
 #   (b) The `<command-name>/gh-issue-flow</command-name>` (or colon form)
 #       wrapper that Claude Code emits when a user invokes the slash
-#       command interactively. The user message also contains
-#       `<command-message>` / `<command-args>` siblings, but matching the
-#       `<command-name>` tag alone is sufficient and the most stable
-#       anchor across CLI versions.
+#       command interactively.
+#   (c) The `Base directory for this skill: …/gh-issue-flow` marker line
+#       Claude Code emits when expanding a slash command into the
+#       SKILL.md prompt (issue #608 — defense in depth against future
+#       wrapper format drift; matches the resolved skill base path).
+#   (d) The SKILL.md H1 line `# gh:issue-flow — Issue → PR composition`
+#       (issue #608 — second wrapper-independent anchor, useful if the
+#       `<command-name>` / `Base directory` lines ever stop being emitted).
 #
-# The `(?m)^\s*` prefix on the raw branch restricts matching to line
-# starts so a mid-sentence mention like "I was reading about
-# /gh-issue-flow..." stays out — preserved from the prior
-# `lstrip().startswith()` behavior, now expressed per-line.
+# The `(?m)` prefix anchors `^` to per-line starts so a mid-sentence
+# mention like "I was reading about /gh-issue-flow..." stays out.
 # False-positive guards for `tool_result` payloads (e.g. SKILL.md being
 # read by the model) are layered separately in `_iter_text_blocks(...,
 # include_tool_results=False)`.
@@ -93,9 +106,13 @@ _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
     r"""
     (?m)                                                    # multiline: ^ matches each line start
     (?:
-        ^\s*/gh[-:]issue-flow\b                             # raw slash command at line start
+        ^\s*/gh[-:]issue-flow\b                             # (a) raw slash command
         |
-        <command-name>\s*/gh[-:]issue-flow\s*</command-name>  # Claude Code wrapped form
+        <command-name>\s*/gh[-:]issue-flow\s*</command-name>  # (b) Claude Code wrapped form
+        |
+        ^Base\s+directory\s+for\s+this\s+skill:\s*\S*/gh-issue-flow\b  # (c) skill base dir
+        |
+        ^\#\s+gh:issue-flow\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d) SKILL.md H1
     )
     """,
     re.VERBOSE,
@@ -103,17 +120,17 @@ _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
 FLOW_SKILL_NAMES: set[str] = {"gh-issue-flow", "gh:issue-flow"}
 
 
-def _allow(trace_reason: str = "") -> int:
+def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:
     """Allow the stop. Hook protocol: silent stdout + exit 0."""
     if trace_reason:
-        _trace(f"allow: {trace_reason}")
+        _trace(f"allow: {trace_reason}", layer=layer)
     return 0
 
 
-def _block(reason: str) -> int:
+def _block(reason: str, *, layer: str | None = None) -> int:
     """Block the stop with a directive shown to the model."""
     json.dump({"decision": "block", "reason": reason}, sys.stdout)
-    _trace("block: gh-issue-flow incomplete — re-prompting model")
+    _trace("block: gh-issue-flow incomplete — re-prompting model", layer=layer)
     return 0
 
 
@@ -121,12 +138,14 @@ def _iter_text_blocks(message: dict[str, Any], include_tool_results: bool = True
     """Return all text-bearing chunks in a message's content array.
 
     `include_tool_results` gates whether tool_result blocks contribute their
-    text. Boundary detection (Step 1) sets it to False because a tool_result
-    can carry arbitrary file contents — if a file the model reads happens to
-    contain "/gh-issue-flow", the substring would otherwise falsely mark a
-    flow boundary in an unrelated session. Terminal-marker scanning
-    (Step 2) keeps it True so a sub-skill's stdout that prints the Step 3
-    "complete (#N)" line still counts.
+    text. Both boundary detection and terminal-marker scanning set it to
+    False — a tool_result can carry arbitrary file contents (e.g. SKILL.md
+    being read by the model), and substrings inside such payloads must not
+    influence flow detection. In particular, the SKILL.md Step 3 template
+    literally contains the lines `gh:issue-flow complete (#<N>)` and
+    `gh:issue-flow stopped at step <i>/5` as instructions; if those were
+    visible to the terminal scan via tool_result, every Read of SKILL.md
+    during a flow would falsely flag completion (issue #608, layer L1.5).
     """
     parts: list[str] = []
     content = message.get("content")
@@ -235,14 +254,32 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
 
     Returns (terminal_seen, ordered_distinct_sub_skill_invocations).
     Sub-skill names are normalized to the hyphen form for comparison.
+
+    Issue #608 (layer L1.5) — terminal-marker scan is restricted to
+    `role=assistant` text blocks, with `include_tool_results=False`,
+    and the boundary message itself is skipped (`start + 1`). The
+    motivation: the SKILL.md body (delivered as a `role=user` text
+    block when Claude Code expands a slash command) literally contains
+    the lines
+        gh:issue-flow complete (#<N>)
+        gh:issue-flow stopped at step <i>/5
+    as Step 3 *instructions*. Without this restriction the scan would
+    false-match those template lines and fail-open on every real
+    `/gh-issue-flow` invocation, defeating the harness guard. Sub-skill
+    invocation tracking is already restricted to assistant `tool_use`
+    blocks (`_iter_skill_uses` only inspects that block type), so the
+    skill counter is unaffected — only the terminal-marker scan
+    narrows.
     """
     terminal = False
     seen: list[str] = []
-    for entry in messages[start:]:
+    for entry in messages[start + 1 :]:
         msg = _message_payload(entry)
-        for text in _iter_text_blocks(msg):
-            if any(pat in text for pat in TERMINAL_PATTERNS):
-                terminal = True
+        role = msg.get("role")
+        if role == "assistant":
+            for text in _iter_text_blocks(msg, include_tool_results=False):
+                if any(pat in text for pat in TERMINAL_PATTERNS):
+                    terminal = True
         for skill in _iter_skill_uses(msg):
             if skill not in SUB_SKILL_NAMES:
                 continue
@@ -292,16 +329,17 @@ def main() -> int:
 
     boundary = _find_flow_boundary(messages)
     if boundary < 0:
-        return _allow("no gh-issue-flow boundary in transcript")
+        return _allow("no gh-issue-flow boundary in transcript", layer="L1")
 
     terminal, seen = _scan_after_boundary(messages, boundary)
     if _TRACE_ENABLED:
         _trace(
             f"boundary={boundary} sub_skills_seen={len(seen)}/{len(EXPECTED_CHAIN)} "
-            f"({','.join(seen) if seen else 'none'}) terminal={terminal}"
+            f"({','.join(seen) if seen else 'none'}) terminal={terminal}",
+            layer="L1.5",
         )
     if terminal:
-        return _allow("Step 3 terminal marker present — flow finished")
+        return _allow("Step 3 terminal marker present — flow finished", layer="L1.5")
 
     next_label = _next_step_label(seen)
     reason = (
@@ -315,7 +353,7 @@ def main() -> int:
         f"5 sub-skills are already done, the Step 3 success/failure report "
         f"verbatim per the SKILL.md template)."
     )
-    return _block(reason)
+    return _block(reason, layer="L1.5")
 
 
 if __name__ == "__main__":

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -110,7 +110,7 @@ _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
         |
         <command-name>\s*/gh[-:]issue-flow\s*</command-name>  # (b) Claude Code wrapped form
         |
-        ^Base\s+directory\s+for\s+this\s+skill:\s*\S*/gh-issue-flow\b  # (c) skill base dir
+        ^Base\s+directory\s+for\s+this\s+skill:\s+.*gh-issue-flow\b  # (c) skill base dir
         |
         ^\#\s+gh:issue-flow\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d) SKILL.md H1
     )
@@ -134,18 +134,22 @@ def _block(reason: str, *, layer: str | None = None) -> int:
     return 0
 
 
-def _iter_text_blocks(message: dict[str, Any], include_tool_results: bool = True) -> list[str]:
+def _iter_text_blocks(message: dict[str, Any], include_tool_results: bool = False) -> list[str]:
     """Return all text-bearing chunks in a message's content array.
 
     `include_tool_results` gates whether tool_result blocks contribute their
-    text. Both boundary detection and terminal-marker scanning set it to
-    False — a tool_result can carry arbitrary file contents (e.g. SKILL.md
-    being read by the model), and substrings inside such payloads must not
-    influence flow detection. In particular, the SKILL.md Step 3 template
-    literally contains the lines `gh:issue-flow complete (#<N>)` and
-    `gh:issue-flow stopped at step <i>/5` as instructions; if those were
-    visible to the terminal scan via tool_result, every Read of SKILL.md
-    during a flow would falsely flag completion (issue #608, layer L1.5).
+    text. Default is `False` — a tool_result can carry arbitrary file
+    contents (e.g. SKILL.md being read by the model), and substrings
+    inside such payloads must not influence flow detection. Both
+    boundary detection and terminal-marker scanning rely on the default;
+    no caller in this module passes `True`. The parameter is kept (rather
+    than removed) so future callers needing inclusive scans can opt in
+    explicitly, but the safe default is now the default. In particular,
+    the SKILL.md Step 3 template literally contains the lines
+    `gh:issue-flow complete (#<N>)` and `gh:issue-flow stopped at step
+    <i>/5` as instructions; if those were visible to the terminal scan
+    via tool_result, every Read of SKILL.md during a flow would falsely
+    flag completion (issue #608, layer L1.5; PR #635 review tightening).
     """
     parts: list[str] = []
     content = message.get("content")

--- a/claude/skills/gh-issue-flow/references/stop-guard.md
+++ b/claude/skills/gh-issue-flow/references/stop-guard.md
@@ -43,20 +43,40 @@ On every Stop event:
    - stdin is empty / not JSON / not a dict
    - `stop_hook_active == true` (we already blocked once in this chain)
    - `transcript_path` missing or unreadable
-3. Walk the transcript JSONL backwards to find the most recent
-   gh-issue-flow boundary — either the user typed `/gh-issue-flow` or
-   the assistant invoked `Skill(gh-issue-flow)`.
-4. From that boundary forward, scan all assistant text for any
-   terminal Step 3 marker:
+3. **L1 — Boundary detection.** Walk the transcript JSONL backwards to
+   find the most recent gh-issue-flow start. Four boundary surfaces
+   are matched (defense in depth against Claude Code wrapper drift):
+   - assistant `Skill(gh-issue-flow)` tool_use
+   - user text starting with `/gh-issue-flow` (or `/gh:issue-flow`)
+     at a line start
+   - user text containing `<command-name>/gh-issue-flow</command-name>`
+     (or colon namespace form) — the wrapper Claude Code emits for
+     interactively-typed slash commands (#607)
+   - user text containing the SKILL prompt markers
+     `Base directory for this skill: …/gh-issue-flow` or the H1 line
+     `# gh:issue-flow — Issue → PR composition` (#608, defensive
+     anchors for future wrapper variants)
+4. **L1.5 — Terminal-marker scan.** From the message *after* the
+   boundary, scan only `role=assistant` text blocks (not `tool_result`,
+   not user-role text) for any Step 3 terminal marker:
    - `gh:issue-flow complete (#`
    - `gh:issue-flow stopped at step`
    - (and the hyphen variants)
+   This narrow scope is load-bearing. The SKILL.md body, delivered as
+   a `role=user` text block when a slash command expands, literally
+   contains those marker strings as Step 3 *instructions*. Scanning
+   user text would silently false-match every real invocation and
+   fail-open the hook (issue #608, 5th regression).
 5. If no terminal marker is present, count the distinct sub-skill
    `Skill()` invocations after the boundary and pick the *next* one
    in the canonical chain.
 6. Emit `{"decision":"block","reason":"…"}` on stdout. The `reason`
    tells the model exactly which Skill() call to make next, with the
    "no conversational text" rule restated.
+
+When `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1`, each decision logs a
+`[stop-guard] … layer=L1|L1.5` line on stderr so the layer
+attribution is greppable in post-mortems.
 
 ## Safety rails
 
@@ -99,5 +119,13 @@ Re-install via `./setup.sh` to restore the default behaviour.
   with a reason naming the next sub-skill
 - complete transcript (terminal Step 3 marker present) → allow
 - `stop_hook_active == true` → allow regardless of mid-flow state
+- L1 boundary surfaces (#608): raw slash, `<command-name>` wrapper,
+  `Base directory for this skill: …/gh-issue-flow`, and the H1 line —
+  positive + false-positive (inside `tool_result`) variants for each
+- L1.5 (#608, root cause of 5th regression): a real `/gh-issue-flow`
+  invocation whose user message includes the SKILL prompt body
+  (which literally quotes the Step 3 template) must still **block**
+  the mid-chain stop. A defensive variant covers the case where the
+  model reads `gh_issue_flow_stop_guard.py` itself inside the flow.
 
 Run: `pytest tests/integration/test_gh_issue_flow_stop_guard.py -v`.

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -670,3 +670,361 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
     assert "Step 2.2" in reason
     assert "gh-commit" in reason
     assert "1/5" in reason
+
+
+# ---------------------------------------------------------------------------
+# Issue #608 — L1 boundary expansion (surfaces c, d) + L1.5 scan-scope fix
+#
+# Two motivations layered together:
+#
+# 1. **L1 (defense-in-depth boundary surfaces).** Add the `Base directory
+#    for this skill: …/gh-issue-flow` marker line and the SKILL.md H1
+#    `# gh:issue-flow — Issue → PR composition` as additional boundary
+#    anchors so the hook keeps working even if Claude Code ever changes
+#    the `<command-name>` wrapper format (preserves chain protection
+#    across CLI version drift).
+# 2. **L1.5 (terminal-scan scope).** The 5th regression on this issue's
+#    own ancestor (#383 → #607 → #608) was *not* a missing boundary —
+#    it was that `_scan_after_boundary` matched `TERMINAL_PATTERNS`
+#    against the SKILL.md body delivered as a `role=user` text block.
+#    The template literally contains the lines
+#        gh:issue-flow complete (#<N>)
+#        gh:issue-flow stopped at step <i>/5
+#    as Step 3 instructions, so the scan saw a terminal marker before
+#    any sub-skill ran and fail-opened every invocation. Restricting
+#    the scan to `role=assistant` text (excluding the boundary message
+#    itself) fixes the false-match. These tests pin the fix down.
+# ---------------------------------------------------------------------------
+
+
+# Two literal lines that the real SKILL.md prompt body contains as Step 3
+# template instructions. If the hook's terminal scan ever regresses back
+# to reading user-role text, either line will trip a false `terminal=True`.
+_SKILL_TEMPLATE_FALSE_POSITIVE = (
+    "## Step 3: Report\n"
+    "\n"
+    "If all steps succeeded:\n"
+    "```\n"
+    "gh:issue-flow complete (#<N>)\n"
+    "  [OK] Step 1: gh:issue-implement\n"
+    "```\n"
+    "If a step failed:\n"
+    "```\n"
+    "gh:issue-flow stopped at step <i>/5 (<skill-name>)\n"
+    "```\n"
+)
+
+
+def _user_skill_base_dir_marker(skill_name: str = "gh-issue-flow") -> dict[str, Any]:
+    """User message containing only the `Base directory for this skill:` line.
+
+    Mirrors the line Claude Code emits when expanding a slash command,
+    isolated so the test exercises surface (c) without depending on the
+    `<command-name>` wrapper also being present.
+    """
+    content = f"Base directory for this skill: /home/user/.claude/skills/{skill_name}\n"
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
+def _user_skill_h1_marker() -> dict[str, Any]:
+    """User message containing only the SKILL.md H1 header line.
+
+    Exercises surface (d) — the H1 anchor — in isolation.
+    """
+    content = "# gh:issue-flow — Issue → PR composition\n"
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
+def test_base_dir_marker_recognized_as_flow_start(tmp_path: Path) -> None:
+    """Surface (c): `Base directory for this skill: …/gh-issue-flow` marks the flow."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_skill_base_dir_marker(),
+            _assistant_skill("gh-issue-implement", "608 direct origin --no-next-hint"),
+            _assistant_text("gh:issue-implement #608 complete\n  Tests: 12 passed"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        "Hook must recognize 'Base directory for this skill: …/gh-issue-flow' "
+        f"as a flow boundary. stdout={result.stdout!r}"
+    )
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "Step 2.2" in decision["reason"]
+
+
+def test_base_dir_marker_does_not_match_unrelated_skill(tmp_path: Path) -> None:
+    """Surface (c) only matches when the path ends with gh-issue-flow.
+
+    False-positive guard: a base-directory line for some *other* skill
+    (e.g. `gh-issue-implement` or `gh-issue-flow-archive`) must not be
+    treated as a gh-issue-flow boundary.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            # Different skill — no boundary expected.
+            _user_skill_base_dir_marker(skill_name="gh-issue-implement"),
+            _assistant_text("ok, working on something else"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"Hook treated a non-gh-issue-flow skill base directory as a flow boundary. stdout={result.stdout!r}"
+    )
+
+
+def test_skill_h1_marker_recognized_as_flow_start(tmp_path: Path) -> None:
+    """Surface (d): the SKILL.md H1 line marks the flow boundary."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_skill_h1_marker(),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "Step 2.3" in decision["reason"]
+    assert "gh-pr" in decision["reason"]
+
+
+def test_skill_h1_mid_sentence_does_not_match(tmp_path: Path) -> None:
+    """Surface (d) requires the H1 to occupy its own line.
+
+    A mid-sentence quote like "the file starts with # gh:issue-flow — Issue
+    → PR composition and ..." must not trip the boundary.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text(
+                "I was reading the source — it has the line "
+                "# gh:issue-flow — Issue → PR composition embedded in a paragraph."
+            ),
+            _assistant_text("ok"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"Hook treated a mid-sentence H1 mention as a flow boundary. stdout={result.stdout!r}"
+    )
+
+
+def test_base_dir_marker_inside_tool_result_does_not_trigger(tmp_path: Path) -> None:
+    """False-positive guard: `Base directory for this skill: …` inside a
+    `tool_result` block (e.g. the model reads a doc that quotes the
+    line) must not be treated as a real invocation.
+    """
+    doc_excerpt = (
+        "Each skill invocation begins with a banner like\n"
+        "    Base directory for this skill: /home/user/.claude/skills/gh-issue-flow\n"
+        "which the hook detects as a boundary.\n"
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("can you read the stop-guard docs?"),
+            _user_tool_result(doc_excerpt),
+            _assistant_text("Sure — here's a summary."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"Hook treated a `Base directory` line inside tool_result as a flow boundary. stdout={result.stdout!r}"
+    )
+
+
+def test_skill_h1_inside_tool_result_does_not_trigger(tmp_path: Path) -> None:
+    """False-positive guard for surface (d) — H1 line inside a tool_result."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("explain the gh-issue-flow SKILL.md"),
+            _user_tool_result(
+                "# gh:issue-flow — Issue → PR composition\n\n(rest of SKILL.md body that the model just read)\n"
+            ),
+            _assistant_text("It chains 5 sub-skills..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"Hook treated an H1 line inside tool_result as a flow boundary. stdout={result.stdout!r}"
+    )
+
+
+def test_skill_template_text_in_user_message_does_not_false_terminate(
+    tmp_path: Path,
+) -> None:
+    """L1.5 (issue #608 root cause): SKILL.md template lines literally
+    containing `gh:issue-flow complete (#<N>)` and `gh:issue-flow stopped
+    at step <i>/5` must NOT count as a terminal marker.
+
+    Reproduction of the 5th regression: when a user types
+    `/gh-issue-flow N`, Claude Code expands the SKILL.md body inline as
+    a `role=user` text block. The body contains the Step 3 template
+    *as instructions*. Before this fix, `_scan_after_boundary` saw the
+    template text, set `terminal=True`, and the hook fail-opened on
+    every real invocation. The fix restricts the terminal scan to
+    `role=assistant` text blocks. This fixture is the production-shape
+    transcript that must still produce a `block` decision.
+    """
+    # User message contains BOTH the wrapped slash command (boundary)
+    # AND the SKILL.md Step 3 template lines (would-be false-terminator).
+    boundary_with_template = (
+        "<command-message>gh-issue-flow</command-message>\n"
+        "<command-name>/gh-issue-flow</command-name>\n"
+        "<command-args>608</command-args>\n"
+        "Base directory for this skill: /home/user/.claude/skills/gh-issue-flow\n"
+        "\n"
+        "# gh:issue-flow — Issue → PR composition\n"
+        "\n" + _SKILL_TEMPLATE_FALSE_POSITIVE + "ARGUMENTS: 608\n"
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {
+                "type": "user",
+                "message": {"role": "user", "content": boundary_with_template},
+            },
+            _assistant_skill("gh-issue-implement", "608 direct origin --no-next-hint"),
+            _assistant_text("gh:issue-implement #608 complete\n  Files: 2 changed\n  Tests: 32 passed"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        "Hook fail-opened on a real /gh-issue-flow invocation — the SKILL.md "
+        "template text in the user message false-matched TERMINAL_PATTERNS. "
+        f"stdout={result.stdout!r}"
+    )
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "Step 2.2" in decision["reason"]
+    assert "gh-commit" in decision["reason"]
+    assert "1/5" in decision["reason"]
+
+
+def test_skill_template_text_in_tool_result_does_not_false_terminate(
+    tmp_path: Path,
+) -> None:
+    """L1.5 variant: model reads the SKILL.md or hook source as a
+    tool_result during a real flow → must still block.
+
+    Defensive check: even if a `Read`/`Bash` tool surfaces the
+    TERMINAL_PATTERNS strings inside a `tool_result` block during an
+    active chain, the terminal scan must not be tricked into allowing
+    the stop. With the assistant-only scope, tool_result blocks (which
+    live inside `role=user` messages per the Anthropic content-block
+    model) are excluded automatically.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 608"),
+            _assistant_skill("gh-issue-implement"),
+            # Model reads the hook source while inside the flow.
+            _user_tool_result(
+                "TERMINAL_PATTERNS: tuple[str, ...] = (\n"
+                '    "gh:issue-flow complete (#",\n'
+                '    "gh:issue-flow stopped at step",\n'
+                "    ...\n"
+                ")\n"
+            ),
+            _assistant_text("Now committing...\n"),  # No real terminal marker.
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        "Hook fail-opened — tool_result containing the TERMINAL_PATTERNS "
+        f"source text was treated as a real terminal report. stdout={result.stdout!r}"
+    )
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "1/5" in decision["reason"]
+
+
+def test_real_terminal_marker_in_assistant_text_still_allows_stop(
+    tmp_path: Path,
+) -> None:
+    """L1.5 must not over-correct: a real assistant-authored Step 3
+    report MUST still terminate the scan and allow the stop.
+
+    Pairs with the false-positive tests above — guards against an
+    accidental "block everything forever" regression.
+    """
+    boundary_with_template = (
+        "<command-name>/gh-issue-flow</command-name>\n"
+        "Base directory for this skill: /home/user/.claude/skills/gh-issue-flow\n" + _SKILL_TEMPLATE_FALSE_POSITIVE
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {
+                "type": "user",
+                "message": {"role": "user", "content": boundary_with_template},
+            },
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr"),
+            _assistant_skill("devx-schedule"),
+            _assistant_skill("gh-pr-resolve-conflict"),
+            # Real Step 3 success report — assistant role, real terminal marker.
+            _assistant_text("gh:issue-flow complete (#608)\n  PR URL: https://x/pull/9"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        "Hook blocked a properly-completed flow — assistant-authored Step 3 "
+        f"terminal marker was not recognized. stdout={result.stdout!r}"
+    )
+
+
+def test_trace_emits_layer_field_for_block(tmp_path: Path) -> None:
+    """Issue #608 acceptance criteria: trace lines carry a `layer=...`
+    field so multi-layer fix attribution is greppable."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 608"),
+            _assistant_skill("gh-issue-implement"),
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_ISSUE_FLOW_STOP_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    # The summary line (boundary + sub-skill count) is layer L1.5.
+    assert "layer=L1.5" in result.stderr, f"Expected layer=L1.5 in trace output, got stderr={result.stderr!r}"
+
+
+def test_trace_emits_layer_field_for_no_boundary_allow(tmp_path: Path) -> None:
+    """Allow path on the L1 (boundary) side must also tag itself."""
+    transcript = _write_transcript(
+        tmp_path,
+        [_user_text("hello world, no flow here")],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_ISSUE_FLOW_STOP_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert "layer=L1" in result.stderr, (
+        f"Expected layer=L1 on the no-boundary allow trace, got stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary
- `_scan_after_boundary` 가 SKILL 프롬프트 본문에 박혀 있는 Step 3 템플릿 텍스트(`gh:issue-flow complete (#<N>)` / `gh:issue-flow stopped at step <i>/5`)를 terminal marker 로 false-match 해 모든 실 invocation 에서 fail-open 되던 5차 회귀(#383 → #607 → #608)를 차단.
- 스캔 범위를 `role=assistant` 텍스트 블록으로 한정하고 boundary 메시지 자체는 스킵해 회귀 원인을 mechanically 제거.
- 향후 Claude Code wrapper 포맷 변경 대비로 boundary 감지에 두 개의 새 surface 추가(`Base directory for this skill: …/gh-issue-flow`, SKILL.md H1 `# gh:issue-flow — Issue → PR composition`).

## Changes
- `claude/hooks/gh_issue_flow_stop_guard.py`
  - L1: `_USER_BOUNDARY_RE` 에 surface (c) `Base directory for this skill: …/gh-issue-flow` 와 (d) SKILL.md H1 line 추가 — 둘 다 line-start anchor 라 mid-sentence quote 와 tool_result payload 는 매치하지 않음.
  - L1.5: `_scan_after_boundary` 가 boundary 다음 메시지부터 `role=assistant` 텍스트 블록만 검사(`include_tool_results=False`). sub-skill counting 은 `_iter_skill_uses` 가 이미 assistant `tool_use` 블록 전용이라 그대로 유지.
  - Trace: `_trace` / `_allow` / `_block` 에 keyword-only `layer=` 인자 추가. 기존 substring assertion(`[stop-guard] allow:`) 호환 유지를 위해 라벨은 라인 끝에 append.
  - `_iter_text_blocks` 의 docstring 을 새 정책(terminal scan 도 `include_tool_results=False`)에 맞게 갱신.

- `claude/skills/gh-issue-flow/references/stop-guard.md`
  - Step 3/4 설명을 L1 (boundary detection) / L1.5 (terminal-marker scan) 로 명시 분리, 4 개 boundary surface 와 L1.5 의 scope 제약을 문서화.
  - 테스트 목록에 L1 surface (c)/(d) 와 L1.5 root-cause regression case 추가.
  - `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1` trace 의 `layer=L1|L1.5` 필드 설명.

- `tests/integration/test_gh_issue_flow_stop_guard.py` (+358 lines, +11 cases)
  - L1 surface (c) positive + non-`gh-issue-flow` skill 의 base-dir line false-positive guard.
  - L1 surface (d) positive + mid-sentence H1 quote false-positive guard.
  - 양 surface 모두에 대해 `tool_result` 내부 인용 false-positive guard 1 건씩.
  - **L1.5 핵심 회귀 케이스**: 실 `/gh-issue-flow` 의 user message 가 SKILL 본문(Step 3 템플릿 포함)을 그대로 들고 있는 production-shape transcript — 반드시 `block` decision.
  - L1.5 defensive variant: 모델이 flow 도중 hook 의 source 자체를 `Read` 했을 때(`TERMINAL_PATTERNS` literal 이 tool_result 에 등장) 여전히 block.
  - L1.5 over-correction guard: 진짜 assistant-authored Step 3 report 는 여전히 종결로 인식해 stop 허용.
  - Trace 출력에 `layer=L1` / `layer=L1.5` 가 노출되는지 2 건 assertion.

## Test plan
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py` — 40 passed (29 baseline + 11 new)
- [x] `tox -e ruff` — clean
- [x] `tox -e mypy` — Success: no issues found in 5 source files
- [x] `tox -e shellcheck` — OK
- [x] `tox -e shfmt` — OK
- [x] `_gh_pr_lint_run main` (Step 4.5 gh:pr lint guard) — tox passed
- [ ] 실 `/gh-issue-flow <test-issue>` smoke 1 회 — mid-chain stop 없이 5 sub-skill 모두 진행하는지 확인 (PR 머지 전 reviewer 가 한 번 돌려보면 됨).

## Phase 범위 / 후속

이슈 본문이 명시한 "각 Phase 가 독립적으로 의미 있는 안전망 강화이므로 PR 을 3개로 분리해도 OK" 정책을 따라 **Phase 1 (L1 expansion + L1.5 root-cause fix)** 만 본 PR 로 머지. 메모리 노트가 지목한 5차 회귀의 actual mechanism 이 L1.5 (terminal-scan scope) 였으므로 우선순위가 가장 높음.

후속 PR 로 분리:
- Phase 2 — L2 `.claude/.gh-issue-flow-state.json` 인플라이트 state file (SKILL.md lifecycle + hook 우선분기).
- Phase 3 — L3 `CronCreate(durable=true)` 90s heartbeat + SKILL.md "Continue mode" 진입점.
- Composition skill 일반화 — `expected_chain` 만 다른 generic L1+L2+L3 helper.

## Related
Closes #608

---
<details>
<summary>🤖 AI Metrics · 📊 ~9000 tokens · 👤 ~3 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~3 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
