### PR TITLE
fix(gh-pr-approve): #639 prune --force ghost failed state 정리

### DIFF
--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -687,6 +687,7 @@ _gh_pr_approve_prune() {
                         _torn_down=$((_torn_down + 1))
                     else
                         ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
+                        ux_bullet_sub "manual fix: cd $_wt && gwt teardown --force && gh-pr-approve prune --force $_pr"
                     fi
                 else
                     # Ghost: worktree dir already gone (e.g. teardown crashed

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -679,19 +679,31 @@ _gh_pr_approve_prune() {
             ;;
         failed:*)
             _failed=$((_failed + 1))
-            if [ "$_force" = "1" ] && [ -n "$_wt" ] && [ -d "$_wt" ]; then
-                ux_warning "#$_pr $_state — tearing down $_wt"
-                if (cd "$_wt" && gwt teardown --force); then
+            if [ "$_force" = "1" ]; then
+                if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+                    ux_warning "#$_pr $_state — tearing down $_wt"
+                    if (cd "$_wt" && gwt teardown --force); then
+                        rm -rf "$_entry"
+                        _torn_down=$((_torn_down + 1))
+                    else
+                        ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
+                    fi
+                else
+                    # Ghost: worktree dir already gone (e.g. teardown crashed
+                    # after rm but before state cleanup, or spawn died before
+                    # ever creating one). Nothing on disk to tear down — the
+                    # safe cleanup is to drop the orphan state entry. See #639.
+                    ux_warning "#$_pr $_state — worktree absent, removing stale state"
                     rm -rf "$_entry"
                     _torn_down=$((_torn_down + 1))
-                else
-                    ux_error "  gwt teardown failed for $_wt; leaving state dir intact"
                 fi
             else
                 ux_warning "#$_pr $_state"
                 if [ -n "$_wt" ] && [ -d "$_wt" ]; then
                     ux_bullet_sub "worktree: $_wt"
                     ux_bullet_sub "cleanup: cd $_wt && gwt teardown --force"
+                else
+                    ux_bullet_sub "ghost state (worktree absent) — pass --force to remove"
                 fi
             fi
             ;;

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -420,6 +420,44 @@ _seed_pr_state() {
     assert_output --partial "gwt teardown"
 }
 
+# Regression: prune --force on a "ghost" state — failed:tearing-down where the
+# worktree dir has already been deleted (e.g. teardown crashed after rm but
+# before state cleanup). Prior to #639 the --force branch's [ -d "$_wt" ]
+# guard rejected this case, leaving state dirs permanently stuck across runs.
+@test "prune --force: ghost failed:tearing-down (wt path missing) — state removed" {
+    _seed_pr_state 617 "failed:tearing-down" "$TEST_TEMP_HOME/pr-617-gone" "12345"
+    [ ! -d "$TEST_TEMP_HOME/pr-617-gone" ]
+
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune --force"
+    assert_success
+    assert_output --partial "#617"
+    assert_output --partial "worktree absent"
+    assert_output --partial "torn down 1"
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/617" ]
+}
+
+@test "prune --force: ghost failed:* (empty worktree.path) — state removed" {
+    _seed_pr_state 618 "failed:spawning" "" "12345"
+
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune --force"
+    assert_success
+    assert_output --partial "#618"
+    assert_output --partial "worktree absent"
+    [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/618" ]
+}
+
+@test "prune (no --force): ghost failed:* prints the ghost hint, keeps state" {
+    _seed_pr_state 619 "failed:tearing-down" "$TEST_TEMP_HOME/pr-619-gone" "12345"
+    [ ! -d "$TEST_TEMP_HOME/pr-619-gone" ]
+
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune"
+    assert_success
+    assert_output --partial "#619"
+    assert_output --partial "ghost state"
+    assert_output --partial "--force"
+    [ -d "$HOME/.local/state/gh-pr-approve/fake-main/619" ]
+}
+
 @test "prune: empty state tree — 'nothing to prune' and exits 0" {
     run_in_bash "cd '$FAKE_REPO' && gh_pr_approve prune"
     assert_success


### PR DESCRIPTION
## Summary
- `gh-pr-approve prune --force` 가 worktree 디렉토리가 이미 사라진 `failed:*` state(ghost) 를 무시하고 영구 잔존시키는 버그 수정.
- `failed:*` 분기를 두 갈래(worktree 존재 / 부재)로 분리해 ghost 케이스는 state 디렉토리만 삭제하도록 함.
- non-`--force` 경로에는 "ghost state — pass --force to remove" 힌트를 추가해 다음 액션을 명시.

## Changes
- `shell-common/functions/gh_pr_approve.sh`: `_gh_pr_approve_prune` 의 `failed:*` 분기를 재구조화. `--force` + worktree 존재 → 기존처럼 `gwt teardown`. `--force` + worktree 부재 → state 디렉토리 삭제 + `_torn_down` 카운트 증가. 비-force 경로는 ghost 안내 힌트만 출력하고 state 보존.
- `tests/bats/functions/gh_pr_approve.bats`: 회귀 가드 3개 추가 — (1) `failed:tearing-down` + worktree 경로가 디스크에 없음 + `--force` → state 제거 + `torn down 1`, (2) `failed:spawning` + 빈 `worktree.path` + `--force` → state 제거, (3) `--force` 없이 ghost → state 보존 + "ghost state" 힌트.

## Test plan
- [x] `bats tests/bats/functions/gh_pr_approve.bats` — 78개 전부 통과 (신규 3개 포함).
- [x] `tox -e shellcheck` / `tox -e shfmt` — 통과.
- [x] `tox -e ruff` — 통과 (lint guard 경로).
- [ ] 운영 환경(잔존 `failed:tearing-down` ghost state 가 있는 repo)에서 `gh-pr-approve prune --force` 한 번 돌려 ghost 5건이 실제로 정리되는지 확인.

## Related
Closes #639

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
