### PR TITLE
feat(gh-pr-review): #637 add external-AI second-opinion PR review skill

### DIFF
--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -59,7 +59,10 @@ Resolve:
   .number` on the current branch. Neither available → exit 1 with
   `No PR found for current branch; pass PR number explicitly`.
 
-Reject unknown flags eagerly so typos exit fast.
+Reject unknown flags eagerly so typos exit fast. Each value-taking
+flag (`--ai`, `--review`, `--user`) must check `[ $# -lt 2 ]` before
+the `shift 2`, exiting 2 with `missing value for <flag>` so a trailing
+flag without its value never reads past the end of argv.
 
 ## Step 2: Pre-flight
 
@@ -140,7 +143,7 @@ inline guard pattern, identical to `gh-pr-reply` Step 7:
 
 ```sh
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-RAW_BYTES=$(stat -c%s "$PROMPT_FILE")
+RAW_BYTES=$(wc -c < "$PROMPT_FILE")
 TOKENS_RAW=$(( RAW_BYTES / 4 ))
 TOKENS=$(( (TOKENS_RAW + 250) / 500 * 500 ))
 [ "$TOKENS" -lt 1000 ] && TOKENS=1000

--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: gh:pr-review
+description: >-
+  Delegate a GitHub PR's review to an external AI CLI (codex, gemini,
+  or claude) for a second opinion. Streams the external CLI's findings
+  to stdout and posts them as a PR comment by default. Does NOT submit
+  a decision (no approve / request-changes) — that is gh:pr-approve's
+  job, and replying to individual review comments is gh:pr-reply's. Use
+  for /gh-pr-review, /gh:pr-review, "PR 99 코덱스에 리뷰 시켜",
+  "gemini 한테 2차 의견 받아", "second-opinion review on PR 42".
+  Accepts `--ai <codex|gemini|claude>` (required), `--review <preset>`,
+  `--user <name>` (claude only), `--no-post-comment`, and `<PR#>
+  [remote]` positional args. `-h`/`--help`/`help` prints usage.
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# gh:pr-review — Delegate PR Review to an External AI CLI
+
+## Role
+
+Gather a second-opinion code review on a GitHub PR from one of three
+external AI CLIs (`codex` / `gemini` / `claude`). Stream the output to
+the user, post it as a PR comment by default, and **stop there** — no
+decision (approve / request-changes) and no per-comment replies. Those
+belong to the sister skills `gh:pr-approve` and `gh:pr-reply`.
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Parse Flags + Resolve Target
+
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 7.
+
+Positional args (in this order): `<pr-number>` (optional — auto-detect
+from current branch when omitted) and `<remote>` (default `origin`).
+Flags may appear anywhere:
+
+- `--ai <codex|gemini|claude>` — **required**. Unknown value → exit 2
+  with `Unknown --ai value: '<x>' (allowed: codex, gemini, claude)`.
+- `--review <preset>` — optional. Default `default`. Normalize KR
+  aliases per `references/review-presets.md` § "Normalization rules";
+  unknown values → exit 2 with the allowed-enum stderr message.
+- `--user <name>` — optional, `--ai claude` only. Combined with any
+  other `--ai` value → exit 2 with `--user is only valid with --ai
+  claude (codex/gemini have no multi-account routing)`. The account
+  name flows through `_claude_resolve_account` (see
+  `references/ai-cli-invocation.md` § `--ai claude --user <name>`);
+  unknown name → exit 1.
+- `--no-post-comment` — optional. Skips the PR comment in Step 6.
+
+Resolve:
+
+- `TARGET_REPO` from `git remote get-url <remote>` (or
+  `gh repo view --json nameWithOwner -q .nameWithOwner`). Missing
+  remote → list `git remote -v` and stop (exit 1).
+- `PR_NUMBER`: explicit arg, else `gh pr view --json number -q
+  .number` on the current branch. Neither available → exit 1 with
+  `No PR found for current branch; pass PR number explicitly`.
+
+Reject unknown flags eagerly so typos exit fast.
+
+## Step 2: Pre-flight
+
+Run these checks in parallel before doing any expensive work:
+
+- PR state must be `OPEN` AND not draft. Closed / merged / draft →
+  exit 1 with `PR #<N> is <state>; aborting`.
+- `command -v <ai-bin>` for the chosen `--ai` value. Missing →
+  exit 1 with `Required CLI '<name>' not found in PATH`.
+- `gh auth status` returns 0. Failing → exit 1 with the gh error line.
+
+**CI status is intentionally NOT a gate.** Opinion collection works
+regardless of failing CI — sometimes that is the reason the user
+wants a second opinion in the first place.
+
+Self-authored PRs are also allowed: no decision is submitted, so the
+GitHub server-side self-approve block is irrelevant.
+
+## Step 3: Load Review Preset
+
+Read `references/review-presets.md`. Build the prompt as:
+
+```text
+<common-prompt-prefix>
+
+<preset-body for the resolved enum>
+```
+
+The normalized enum is one of `default`, `quick`, `thorough`,
+`security`, `performance`. If a KR alias was passed, the normalization
+has already happened in Step 1.
+
+## Step 4: Fetch Review Material
+
+Decide path by diff size:
+
+```sh
+gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json additions,deletions
+```
+
+When `additions + deletions ≥ 800`, follow the subagent delegation
+pattern documented in
+`claude/skills/gh-pr-approve/references/large-diff-delegation.md`.
+Inline path otherwise:
+
+```sh
+gh pr diff "$PR_NUMBER" --repo "$TARGET_REPO"
+```
+
+Append the diff to the prompt under a clearly delimited section per
+`references/ai-cli-invocation.md` § "stdin payload shape". Write the
+combined `(prompt + diff)` to a temp file `PROMPT_FILE` — the external
+CLI receives it on stdin so argv length and quoting are not concerns.
+
+## Step 5: Dispatch to External CLI
+
+Run one of the three commands from `references/ai-cli-invocation.md`,
+selected by the resolved `--ai` value. For `--ai claude --user
+<name>`, source the helper and inject `CLAUDE_CONFIG_DIR` exactly as
+documented there. Stream stdout to the user's terminal verbatim — no
+reformatting, no summarization, no truncation.
+
+Non-zero exit from the external CLI → quote the first stderr line and
+exit 1. Do not post a PR comment in that case; partial output is
+discarded.
+
+## Step 6: Post PR Comment (default ON)
+
+Skip when `--no-post-comment` is set OR when
+`GH_DISABLE_AI_METRICS=1` (issue #399). The opt-out skips the entire
+PR comment — not just the ai-metrics footer — because the AI-review
+body and the metrics footer ship together. The stdout output is
+unaffected by either skip path.
+
+Build the comment body per `references/post-comment.md` (collapsed
+`<details>` wrapper + verbatim CLI stdout + ai-metrics footer). The
+inline guard pattern, identical to `gh-pr-reply` Step 7:
+
+```sh
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+RAW_BYTES=$(stat -c%s "$PROMPT_FILE")
+TOKENS_RAW=$(( RAW_BYTES / 4 ))
+TOKENS=$(( (TOKENS_RAW + 250) / 500 * 500 ))
+[ "$TOKENS" -lt 1000 ] && TOKENS=1000
+# HUMAN_H baseline per preset — see references/post-comment.md § "Human time baseline".
+
+if [ "$NO_POST_COMMENT" = "1" ]; then
+    : # PR comment skipped via --no-post-comment.
+elif [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # PR comment skipped via GH_DISABLE_AI_METRICS — stdout still shown.
+else
+    gh pr comment "$PR_NUMBER" --repo "$TARGET_REPO" --body-file "$BODY_FILE" \
+        || echo "[WARN] PR comment post failed — output retained on stdout"
+fi
+```
+
+Soft-fail: a non-zero exit from `gh pr comment` prints the `[WARN]`
+line and continues to Step 7 with exit 0. The user already has the AI
+output in their terminal.
+
+## Step 7: Report
+
+Print exactly one line on success:
+
+```text
+[OK] PR #<N> reviewed by <ai> (--review=<preset>) — comment: <URL or skipped>
+```
+
+`<URL or skipped>` is the comment URL on success, `skipped (--no-post-comment)`
+when the flag was set, `skipped (GH_DISABLE_AI_METRICS=1)` when the env
+var was set, or `[WARN] post failed` when the soft-fail branch ran.
+
+## Constraints
+
+- **Never submit a decision.** `gh pr review --approve` and
+  `--request-changes` are out of scope. This skill collects opinions
+  only; the human (or `gh:pr-approve`) decides.
+- **Never reply to individual review comments.** That is `gh:pr-reply`'s
+  job. This skill writes one aggregate comment per invocation.
+- **Never run multiple AI CLIs in one invocation.** Single `--ai`
+  value; rerun the command N times for an N-way comparison.
+- **Never accept free-text `--review`.** Closed enum + KR aliases only.
+  Typos exit 2 cleanly.
+- **Never reformat the external AI's stdout.** The user wants raw
+  output to judge for themselves.
+- **Never block self-authored PRs.** No decision is submitted; the
+  self-approve restriction does not apply.
+- **Never edit the PR body.** Use `gh pr comment` (append) — `gh pr
+  edit --body` silently exits 1 on repos with classic Projects
+  attached (issue #326 Bug B). If a future iteration needs body
+  mutation, route through `_gh_pr_edit_safe_body` per CLAUDE.md.
+- **Never log the external CLI's stderr to a PR comment.** Stderr is
+  only used to derive the error-message first line on non-zero exit.
+- Honor `GH_DISABLE_AI_METRICS=1` consistently with sister skills:
+  skip the entire PR comment (not just the footer).

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -1,0 +1,145 @@
+# AI CLI Invocation — for gh:pr-review
+
+Maps the three supported `--ai` values to concrete CLI commands. The
+prompt (built from `references/review-presets.md`) is passed via
+**stdin**; the PR diff is appended to that same stdin payload. None of
+the three CLIs receive the prompt as a single argv string — argv has
+length limits and quoting hazards, stdin doesn't.
+
+## PATH pre-flight
+
+Before dispatch, every invocation must check:
+
+```sh
+command -v "$AI_BIN" >/dev/null 2>&1 || {
+    printf "Required CLI '%s' not found in PATH\n" "$AI_BIN" >&2
+    exit 1
+}
+```
+
+`AI_BIN` is the literal command name: `codex`, `gemini`, or `claude`.
+
+## stdin payload shape
+
+All three CLIs receive the same byte stream on stdin:
+
+```text
+<common-prompt-prefix-from-review-presets.md>
+
+<preset-body-for-selected-enum>
+
+--- PR DIFF (PR #<N>, repo <TARGET_REPO>, base <base> → head <head>) ---
+<output of `gh pr diff <N> --repo <TARGET_REPO>`>
+--- END PR DIFF ---
+```
+
+Large diffs follow the same delegation pattern as
+`gh-pr-approve/references/large-diff-delegation.md`. When `additions +
+deletions ≥ 800`, dispatch an Explore subagent to pre-classify
+candidate findings instead of streaming the full diff into the
+external CLI's context.
+
+## `--ai codex`
+
+```sh
+codex exec --color=never < "$PROMPT_FILE"
+```
+
+Why `codex exec` instead of `codex review --base <branch>`:
+
+- `codex review` auto-builds its own prompt and diff context — we lose
+  control over the preset/lens dimensions defined in
+  `references/review-presets.md`.
+- `codex exec` accepts our prompt + diff verbatim on stdin, so all
+  three CLIs see identical inputs and outputs stay comparable.
+
+`--color=never` keeps the output free of ANSI escapes so the PR
+comment renders cleanly. The CLI's exit code propagates; non-zero →
+quote the first stderr line and exit 1.
+
+## `--ai gemini`
+
+```sh
+gemini -p "$(cat "$PROMPT_FILE")"
+```
+
+Gemini's `-p` flag takes the prompt as a single argument; the PR diff
+in `$PROMPT_FILE` is therefore inlined. Model selection (`-m
+<model>`) intentionally falls back to the user's environment default;
+add a `--gemini-model` flag in a future iteration only if users
+report drift between defaults.
+
+Stderr policy is identical to codex: non-zero exit → first stderr line
+to caller, exit 1.
+
+## `--ai claude` (no `--user`)
+
+```sh
+claude -p "$(cat "$PROMPT_FILE")"
+```
+
+The skill inherits whatever `CLAUDE_CONFIG_DIR` the calling shell has
+set. If the user is inside `claude-yolo --user work`, that `work`
+account is preserved automatically — no forced `personal` default.
+
+## `--ai claude --user <name>`
+
+Routes through the SSOT helper `_claude_resolve_account` (defined in
+`shell-common/tools/integrations/claude.sh`) so the resolution path
+is identical to `claude-yolo --user <name>`.
+
+```sh
+# Source the helper if not already in scope (login shells already source it).
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/tools/integrations/claude.sh"
+
+CFG_DIR=$(_claude_resolve_account "$USER_ACCOUNT") || {
+    ALLOWED=$(_claude_resolve_account --list | tr '\n' ' ')
+    printf "Unknown claude account: '%s' (allowed: %s)\n" \
+           "$USER_ACCOUNT" "$ALLOWED" >&2
+    exit 1
+}
+
+CLAUDE_CONFIG_DIR="$CFG_DIR" claude -p "$(cat "$PROMPT_FILE")"
+```
+
+- The whitelist comes from `CLAUDE_ENABLED_ACCOUNTS`; the helper
+  enforces the safe-identifier regex (`^[a-z][a-z0-9_-]*$`). No
+  injection surface from the user-supplied account name.
+- The `CFG_DIR` directory must exist — if missing, exit 1 with the
+  same message style `claude-yolo` uses.
+
+### Cross-AI `--user` rejection
+
+```sh
+if [ -n "$USER_ACCOUNT" ] && [ "$AI" != "claude" ]; then
+    echo "--user is only valid with --ai claude (codex/gemini have no multi-account routing)" >&2
+    exit 2
+fi
+```
+
+Silent ignore is rejected on purpose: a user who typed `--user work`
+expects a `work` account, and running anything else would create a
+trust gap between intent and execution.
+
+### Internal-PC behavior
+
+On internal PCs (`~/.dotfiles-setup-mode == internal`),
+`claude-yolo` short-circuits multi-account routing and uses
+`$HOME/.claude` directly. This skill does **not** replicate that
+branch — internal PCs typically have an empty
+`CLAUDE_ENABLED_ACCOUNTS`, so `_claude_resolve_account` naturally
+rejects any `--user <name>`. The cleanest user experience there is to
+omit `--user` and let the current shell's `CLAUDE_CONFIG_DIR` win.
+
+## Common error mapping
+
+| Condition | Exit | stderr |
+|-----------|------|--------|
+| `--ai` missing | 2 | `missing required flag: --ai <codex\|gemini\|claude>` |
+| `--ai` unknown | 2 | `Unknown --ai value: '<x>' (allowed: codex, gemini, claude)` |
+| `--user` with codex/gemini | 2 | `--user is only valid with --ai claude (codex/gemini have no multi-account routing)` |
+| `--user <bogus>` with claude | 1 | `Unknown claude account: '<bogus>' (allowed: ...)` |
+| AI CLI not on PATH | 1 | `Required CLI '<name>' not found in PATH` |
+| AI CLI non-zero exit | 1 | first line of CLI's stderr, quoted |
+| PR closed / merged / draft | 1 | `PR #<N> is <state>; aborting` |
+| `gh pr comment` post failed | 0 | `[WARN] PR comment post failed — output retained on stdout` (soft fail) |

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -60,14 +60,14 @@ quote the first stderr line and exit 1.
 ## `--ai gemini`
 
 ```sh
-gemini -p "$(cat "$PROMPT_FILE")"
+gemini -p < "$PROMPT_FILE"
 ```
 
-Gemini's `-p` flag takes the prompt as a single argument; the PR diff
-in `$PROMPT_FILE` is therefore inlined. Model selection (`-m
-<model>`) intentionally falls back to the user's environment default;
-add a `--gemini-model` flag in a future iteration only if users
-report drift between defaults.
+`gemini -p` reads its prompt from stdin when no argv string follows,
+keeping the payload off argv entirely (no `ARG_MAX` exposure, no
+quoting hazard). Model selection (`-m <model>`) intentionally falls
+back to the user's environment default; add a `--gemini-model` flag
+in a future iteration only if users report drift between defaults.
 
 Stderr policy is identical to codex: non-zero exit → first stderr line
 to caller, exit 1.
@@ -75,12 +75,14 @@ to caller, exit 1.
 ## `--ai claude` (no `--user`)
 
 ```sh
-claude -p "$(cat "$PROMPT_FILE")"
+claude -p < "$PROMPT_FILE"
 ```
 
-The skill inherits whatever `CLAUDE_CONFIG_DIR` the calling shell has
-set. If the user is inside `claude-yolo --user work`, that `work`
-account is preserved automatically — no forced `personal` default.
+Same stdin pattern as the gemini invocation — `claude -p` reads from
+stdin when no argv prompt is supplied. The skill inherits whatever
+`CLAUDE_CONFIG_DIR` the calling shell has set. If the user is inside
+`claude-yolo --user work`, that `work` account is preserved
+automatically — no forced `personal` default.
 
 ## `--ai claude --user <name>`
 
@@ -99,7 +101,7 @@ CFG_DIR=$(_claude_resolve_account "$USER_ACCOUNT") || {
     exit 1
 }
 
-CLAUDE_CONFIG_DIR="$CFG_DIR" claude -p "$(cat "$PROMPT_FILE")"
+CLAUDE_CONFIG_DIR="$CFG_DIR" claude -p < "$PROMPT_FILE"
 ```
 
 - The whitelist comes from `CLAUDE_ENABLED_ACCOUNTS`; the helper

--- a/claude/skills/gh-pr-review/references/help.md
+++ b/claude/skills/gh-pr-review/references/help.md
@@ -1,0 +1,115 @@
+# gh:pr-review — Help
+
+Delegate a GitHub PR's review to an external AI CLI (`codex`, `gemini`,
+or `claude`) for a **second opinion**. Output is written to stdout and
+posted as a PR comment by default. **No decision (approve /
+request-changes) is submitted** — see `gh-pr-approve` for that.
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | PR number, or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `99` |
+| 2 | remote name | `origin` | Git remote for the target repo |
+
+### Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--ai <codex\|gemini\|claude>` | yes | External AI CLI to delegate the review to. Single value — no CSV. |
+| `--review <preset>` | no | Review depth/lens enum. Default `default`. See below. |
+| `--user <name>` | no | `--ai claude` only. Multi-account routing via `_claude_resolve_account` (e.g. `personal`, `work`, `work1`). |
+| `--no-post-comment` | no | Skip the automatic PR comment; only print to stdout. |
+
+## `--review` enum
+
+Closed enum — free-text values are rejected. Korean aliases normalize to
+the English enum before dispatch.
+
+| enum | KR alias | Lens |
+|------|----------|------|
+| `default` | `보통` | 7-dim balance: correctness · conventions · security · performance · tests · docs · backward-compat |
+| `quick` | `간단` | BLOCKER-only quick scan (correctness + security) |
+| `thorough` | `꼼꼼` / `꼼꼼하게` | 7-dim + architecture trade-offs + test-coverage gaps + adjacent-system impact |
+| `security` | `보안` | Security lens — injection, secrets, authz, supply chain |
+| `performance` | `성능` | Performance lens — N+1, hot-loop I/O, allocation, caching |
+
+## `--user` (claude only)
+
+Multi-account routing for `--ai claude`. Reuses the SSOT helper
+`_claude_resolve_account` (the same one `claude-yolo --user <name>`
+calls) so `--user work` runs `CLAUDE_CONFIG_DIR=$HOME/.claude-work
+claude -p ...`.
+
+- Default: when omitted, the **current shell's `CLAUDE_CONFIG_DIR` is
+  preserved** — no forced `personal`. Calling `/gh-pr-review --ai
+  claude 99` from inside a `claude-yolo --user work` shell continues to
+  use the `work` account.
+- `--user` with `--ai codex` or `--ai gemini` is **rejected (exit 2)** —
+  those CLIs have no multi-account routing mechanism, so silently
+  ignoring would risk hiding an intent mismatch.
+- Unknown account names fall through `_claude_resolve_account` and exit
+  1 with `Unknown claude account: '<name>' (allowed: <list>)`. The
+  allowed list comes from `CLAUDE_ENABLED_ACCOUNTS`.
+
+## Usage
+
+- `/gh-pr-review --ai codex 99` — codex review of PR #99 (default preset)
+- `/gh-pr-review --ai gemini --review thorough 99` — gemini, thorough preset
+- `/gh-pr-review --ai claude --review 꼼꼼 99` — claude, KR alias → thorough
+- `/gh-pr-review --ai claude --user work 99` — claude as `work` account
+- `/gh-pr-review --ai claude --user work1 --review 보안 99` — work1 + security
+- `/gh-pr-review --ai codex --no-post-comment 99` — stdout only, no PR comment
+- `/gh-pr-review --ai codex 99 upstream` — PR #99 on `upstream`'s repo
+- `/gh-pr-review --ai gemini` — auto-detect PR from current branch
+- `/gh-pr-review -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Parse flags + resolve PR number / `TARGET_REPO` / external CLI PATH.
+2. Pre-flight: refuse closed/merged/draft PRs. CI status is **not** a
+   gate — opinion collection works regardless of CI.
+3. Load the `--review` preset's prompt template from
+   `references/review-presets.md`.
+4. Fetch `gh pr diff <N>` + PR metadata. Large diffs reuse
+   `gh-pr-approve`'s subagent delegation pattern.
+5. Dispatch to the chosen external CLI per
+   `references/ai-cli-invocation.md` — stdin gets `(prompt + diff)`.
+6. Stream the external CLI's stdout verbatim to your terminal. Unless
+   `--no-post-comment` is set, also post it as a PR comment per
+   `references/post-comment.md` (collapsed `<details>` wrapper + ai-metrics
+   footer).
+7. Print a one-line confirmation: `[OK] PR #<N> reviewed by <ai>
+   (--review=<preset>) — comment: <URL or skipped>`.
+
+## What the skill will NOT do
+
+- Submit `gh pr review --approve` / `--request-changes`. Opinion
+  collection only — `gh-pr-approve` is the decision skill.
+- Reply to individual review comments — that's `gh-pr-reply`.
+- Run multiple AI CLIs in parallel. Single `--ai` value; rerun the
+  command N times for an N-way comparison.
+- Accept a free-text `--review` value. Closed enum only (KR aliases
+  allowed).
+- Reformat or summarize the external AI's stdout — the user wants raw
+  AI output to judge for themselves.
+- Block self-authored PRs. No decision is submitted, so the
+  self-approve restriction does not apply.
+
+## Exit codes
+
+| Code | Cause |
+|------|-------|
+| 0 | Review completed and (optionally) commented on the PR. |
+| 0 | PR comment post failed but stdout still has the AI output (soft fail with `[WARN]`). |
+| 1 | External CLI missing on `$PATH`, external CLI returned non-zero, PR auto-detect failed, unknown `--user` account, or `gh` not authenticated. |
+| 2 | Argument error: missing `--ai`, unknown `--ai` value, unknown `--review` value, `--user` with non-claude `--ai`. |
+
+## Good vs. bad invocation
+
+- **Good**: `/gh-pr-review --ai codex 99` — gather a 2nd opinion on PR #99.
+- **Good**: `/gh-pr-review --ai gemini --review security 99` — security-focused lens.
+- **Good**: chained `/gh-pr-review --ai codex 99` then `/gh-pr-review --ai gemini 99` — three-way comparison.
+- **Bad**: `/gh-pr-review --ai codex --user work 99` — exits 2 (`--user` is claude-only).
+- **Bad**: `/gh-pr-review --ai claude --review "꼼꼼하게 봐줘" 99` — exits 2 (free text rejected; use `꼼꼼` alias).
+- **Bad**: `/gh-pr-review --ai chatgpt 99` — exits 2 (unknown AI).

--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -1,0 +1,134 @@
+# PR Comment Body Format — for gh:pr-review
+
+The external AI's stdout is preserved **verbatim** — no reformatting,
+no summarization. It is wrapped in a collapsed `<details>` block so
+the PR conversation stays readable for skimmers, plus an ai-metrics
+footer that matches the dotfiles SSOT (#317 / PR #320).
+
+## Body template
+
+```markdown
+<details>
+<summary>🤖 AI Review · <AI_NAME> · --review=<PRESET></summary>
+
+<!-- ai-review:<AI_NAME> -->
+<verbatim stdout from external CLI>
+<!-- /ai-review:<AI_NAME> -->
+
+</details>
+
+---
+<details>
+<summary>🤖 AI Metrics · 📊 ~<TOKENS> tokens · 👤 ~<HUMAN_H> h · 🤖 ~<ELAPSED> min</summary>
+
+<!-- ai-metrics:gh-pr-review -->
+📊 ~<TOKENS> tokens · 👤 ~<HUMAN_H> h · 🤖 ~<ELAPSED> min
+<!-- /ai-metrics:gh-pr-review -->
+
+</details>
+```
+
+Substitutions:
+
+| Token | Source |
+|-------|--------|
+| `<AI_NAME>` | The `--ai` argument value (`codex` / `gemini` / `claude`). |
+| `<PRESET>` | The normalized `--review` enum (after KR-alias mapping). |
+| `<TOKENS>` | Estimated prompt tokens, rounded to the nearest 500. Minimum 1 000. |
+| `<HUMAN_H>` | Baseline human-review hours. See "Human time baseline" below. |
+| `<ELAPSED>` | `(($(date +%s) - START_TS) / 60))`. |
+
+## Emoji exception scope
+
+CLAUDE.md restricts emoji to the `ai-metrics` footer block. This skill
+introduces a sibling marker `<!-- ai-review:<ai> -->` that mirrors the
+same `<details>` + glyph pattern. Treat the new marker as a **scoped
+extension** of the existing exception:
+
+- 🤖 in `<summary>` line — allowed (same role as the existing
+  ai-metrics summary glyph).
+- All other emoji — still forbidden everywhere.
+
+If the CLAUDE.md SSOT needs updating, do it in the same PR that lands
+this skill so the rule and the artifact ship together.
+
+## Posting via `gh pr comment`
+
+```sh
+gh pr comment "$PR_NUMBER" --repo "$TARGET_REPO" --body-file "$BODY_FILE"
+```
+
+Use `--body-file` (not `--body "..."`) because the verbatim AI output
+may contain shell metacharacters, backticks, and multi-line content.
+A here-doc-built temp file isolates the substitution surface.
+
+### Why not `gh pr edit --body`
+
+This skill **appends a comment**, never edits the PR body. Editing
+the body would clobber the author's description and (as noted in
+issue #326 Bug B) silently exit 1 on repos with classic Projects
+attached. `gh pr comment` has no such failure mode.
+
+## Soft-fail on post failure
+
+```sh
+if ! gh pr comment "$PR_NUMBER" --repo "$TARGET_REPO" --body-file "$BODY_FILE"; then
+    echo "[WARN] PR comment post failed — output retained on stdout"
+    # exit 0 — stdout already has the AI output for the user.
+fi
+```
+
+Mirrors `gh-pr-reply`'s ai-metrics soft-fail pattern: a network blip or
+transient gh API error must not throw away the AI output already
+streamed to the user's terminal.
+
+## `GH_DISABLE_AI_METRICS=1` opt-out
+
+When the env var is set, **skip the entire comment post** — including
+the AI review body, not just the metrics footer. Rationale: the
+metrics footer is the ai-cost contract; opting out implies the user
+does not want ai-cost evidence on the PR thread. The stdout output is
+unaffected.
+
+```sh
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # PR comment skipped via GH_DISABLE_AI_METRICS — stdout still shown.
+else
+    gh pr comment "$PR_NUMBER" --repo "$TARGET_REPO" --body-file "$BODY_FILE" \
+      || echo "[WARN] PR comment post failed — output retained on stdout"
+fi
+```
+
+This matches the policy other ai-metrics-emitting skills use
+(`gh-pr-reply`, `gh-pr-approve`, `gh-issue-flow`).
+
+## Human time baseline
+
+`<HUMAN_H>` is a rough estimate of how long a human reviewer would
+spend producing the equivalent finding set. Defaults by preset:
+
+| Preset | Baseline (h) |
+|--------|--------------|
+| `default` | 1.0 |
+| `quick` | 0.3 |
+| `thorough` | 2.5 |
+| `security` | 1.5 |
+| `performance` | 1.5 |
+
+Adjust upward by 0.5 h per +500 diff lines beyond the first 500. These
+are calibration starting points, not gospel — tighten when
+`docs/.ssot/metrics-baseline.md` (if introduced) supersedes them.
+
+## Token estimation
+
+```sh
+# Sum prompt template + diff bytes, divide by 4, round to nearest 500.
+RAW_BYTES=$(stat -c%s "$PROMPT_FILE")
+TOKENS_RAW=$(( RAW_BYTES / 4 ))
+TOKENS=$(( (TOKENS_RAW + 250) / 500 * 500 ))
+[ "$TOKENS" -lt 1000 ] && TOKENS=1000
+```
+
+The 4-bytes-per-token heuristic is conservative for English/Korean
+mixed PR bodies. Refine when a tokenizer-backed metric becomes part
+of the repo SSOT.

--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -123,7 +123,7 @@ are calibration starting points, not gospel — tighten when
 
 ```sh
 # Sum prompt template + diff bytes, divide by 4, round to nearest 500.
-RAW_BYTES=$(stat -c%s "$PROMPT_FILE")
+RAW_BYTES=$(wc -c < "$PROMPT_FILE")
 TOKENS_RAW=$(( RAW_BYTES / 4 ))
 TOKENS=$(( (TOKENS_RAW + 250) / 500 * 500 ))
 [ "$TOKENS" -lt 1000 ] && TOKENS=1000

--- a/claude/skills/gh-pr-review/references/review-presets.md
+++ b/claude/skills/gh-pr-review/references/review-presets.md
@@ -1,0 +1,172 @@
+# Review Presets — SSOT for gh:pr-review
+
+`--review` is a **closed enum**. Free-text input is rejected; Korean
+aliases normalize to the English enum before dispatch. The same prompt
+template is fed to all three CLIs (`codex` / `gemini` / `claude`) so
+their outputs are comparable side-by-side.
+
+## Enum + Korean alias table
+
+| enum | KR alias | One-line description |
+|------|----------|----------------------|
+| `default` | `보통` | Balanced 7-dimension review (this skill's default). |
+| `quick` | `간단` | BLOCKER-only fast scan; correctness + security. |
+| `thorough` | `꼼꼼` / `꼼꼼하게` | 7-dim + architecture + coverage gaps + adjacent-system impact. |
+| `security` | `보안` | Security lens (injection, secrets, authz, supply chain). |
+| `performance` | `성능` | Performance lens (N+1, hot-loop I/O, alloc, caching). |
+
+### Normalization rules
+
+1. Trim surrounding whitespace.
+2. If the value matches a KR alias exactly (case-sensitive), replace it
+   with the corresponding English enum.
+3. Compare against the English enum set `{default, quick, thorough,
+   security, performance}`.
+4. No match → exit 2 with stderr:
+   ```text
+   Unknown --review value: '<input>'
+   Allowed: default | quick | thorough | security | performance
+   Korean aliases: 보통 | 간단 | 꼼꼼 (꼼꼼하게) | 보안 | 성능
+   ```
+
+Do **not** attempt partial-match, fuzzy-match, or English
+case-insensitive fallback. The intent is to keep the surface area
+flat — typos exit fast and re-run cleanly.
+
+## Common prompt prefix (all presets)
+
+Every preset prepends this prefix so the receiving CLI knows the shape
+of the expected output:
+
+```text
+You are reviewing a GitHub pull request as a second-opinion reviewer.
+You DO NOT submit a decision (no approve / request-changes) — the
+human and the primary reviewer handle that. Your job is to surface
+specific, actionable findings.
+
+Classification (use these exact labels for every finding):
+  - BLOCKER   — would break or regress if merged as-is.
+  - FOLLOW-UP — non-blocking quality issue worth tracking.
+  - PRAISE    — concrete diff location worth highlighting.
+
+Format (one line per finding):
+  [BLOCKER|FOLLOW-UP|PRAISE] <path>:<line> — <one-sentence reason>
+
+Reply in the dominant language of the PR diff (Korean if the diff is
+Korean-dominant, otherwise English). Be concise; no preamble; do not
+restate the diff.
+```
+
+The PR diff is appended after the prefix as raw stdin payload. The
+external CLI sees `<prefix>\n\n<preset-body>\n\n<diff>`.
+
+## `default` (balanced 7-dimension)
+
+```text
+Review across 7 dimensions in balance. Skip categories the diff does
+not exercise. Flag concrete file:line items only.
+
+1. Correctness — does the code do what the PR title/body claims?
+2. Conventions — naming, file location, error-handling idioms match
+   surrounding code (CLAUDE.md / AGENTS.md if present).
+3. Security — input validation, shell-injection, hardcoded secrets,
+   unsafe eval, missing authn/z.
+4. Performance — N+1, unnecessary I/O in hot loops, missing caching.
+5. Tests — new paths covered? Absence of tests for new logic is usually
+   a BLOCKER.
+6. Docs / comments — public API changes without doc updates, stale
+   references, lies in comments.
+7. Backward compatibility — breaking API/CLI/config changes flagged?
+   Migration path documented?
+```
+
+## `quick` (BLOCKER-only fast scan)
+
+```text
+Quick first-pass scan. ONLY surface BLOCKER findings — items that
+would break or regress if merged as-is. Skip PRAISE entirely. Limit
+FOLLOW-UP to at most 2 items where the harm is obvious.
+
+Focus on:
+- Correctness regressions (logic bugs, off-by-one, wrong condition).
+- Security (shell injection, hardcoded secrets, unsafe eval, missing
+  input validation).
+
+Do NOT flag style, naming, or doc nits — those belong in a thorough
+pass. Target output length: under 200 words.
+```
+
+## `thorough` (deep dive)
+
+```text
+Deep-dive review. Cover the 7 dimensions from the default preset, AND
+add:
+
+8. Architecture trade-offs — does the chosen abstraction fit the
+   problem? Are there cheaper alternatives that achieve the same goal?
+9. Test coverage gaps — which branches/edge cases are not exercised
+   even when there ARE tests? Be specific: list the missing scenarios.
+10. Adjacent-system impact — what other modules / scripts / docs
+    depend on changed surface area? Are those callers updated?
+11. Migration / rollout — if behavior changes silently, how would a
+    user notice? Is there a feature flag or version gate?
+
+Be exhaustive. PRAISE concrete diff locations worth highlighting.
+```
+
+## `security` (security lens)
+
+```text
+Security-focused review. Other dimensions are out of scope for THIS
+invocation — the caller will run a separate review for correctness,
+performance, etc.
+
+Look for:
+- Injection (shell, SQL, command, prompt) at any user-controlled input.
+- Hardcoded secrets, tokens, credentials in code, tests, or examples.
+- Authn/authz — missing checks, broken access control, privilege
+  escalation paths.
+- Supply chain — new dependencies, pinned versions, install-script
+  integrity (signed-by, checksums).
+- Data handling — PII logging, unredacted error messages, insecure
+  defaults.
+- Crypto — homerolled primitives, weak algorithms, missing nonce/IV.
+- Race conditions on filesystem (TOCTOU), env var injection, signal
+  handling.
+
+Classify each finding as BLOCKER (exploitable) or FOLLOW-UP (defense
+in depth). PRAISE specific security-positive patterns when present.
+```
+
+## `performance` (performance lens)
+
+```text
+Performance-focused review. Other dimensions are out of scope for
+THIS invocation — the caller will run a separate review for
+correctness, security, etc.
+
+Look for:
+- N+1 patterns (DB, API, filesystem).
+- Unnecessary I/O inside hot loops (fork, exec, network, disk).
+- Allocation hotspots — repeated string concatenation, large buffers
+  in loops, missing pre-sizing.
+- Missing caching on expensive idempotent calls.
+- Synchronous calls that should be batched / pipelined.
+- Algorithmic complexity worse than necessary (O(n²) where O(n log n)
+  fits, etc.).
+
+Quantify when possible: "executes ~N times per request" or "scales
+linearly with X". Flag only concrete wins — avoid premature
+optimization theatre. Classify each finding as BLOCKER (production
+hot path) or FOLLOW-UP (visible only at scale).
+```
+
+## Why a closed enum
+
+- Output comparability across 3 CLIs requires identical prompts.
+- Free-text values widen the prompt-injection surface — PR body and
+  diff already flow into the AI, but the depth/lens dimension is a
+  *control* path and stays closed.
+- The five enums cover the practical review depths users actually want;
+  adding a sixth is cheap (one section here) — but should require
+  evidence that the existing five are insufficient.

--- a/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh
+# Source-of-truth mirror for the Step 1 arg-parsing + Step 3 preset-
+# normalization logic documented in claude/skills/gh-pr-review/SKILL.md
+# and claude/skills/gh-pr-review/references/review-presets.md.
+#
+# The skill body itself runs inside a Claude session, but its argument
+# contract is a flat POSIX-style state machine that can be tested in
+# isolation. Keep this file in sync with the SKILL — if either the SKILL
+# or references/review-presets.md changes, mirror the change here so the
+# bats suite catches drift.
+
+# gh_pr_review_parse — parses the same arg surface as the skill.
+# Echoes one key=value per line on success; writes errors to stderr.
+# Exit codes mirror the skill:
+#   0 — parsed ok
+#   1 — runtime failure (unknown --user account; not produced here —
+#       account whitelist resolution is left to the live helper)
+#   2 — argument error (missing --ai, unknown --ai, unknown --review,
+#       --user with non-claude --ai)
+gh_pr_review_parse() {
+    local ai=""
+    local review="default"
+    local user=""
+    local post_comment=1
+    local pr=""
+    local remote="origin"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --ai)
+            ai="$2"
+            shift 2
+            ;;
+        --ai=*)
+            ai="${1#--ai=}"
+            shift
+            ;;
+        --review)
+            review="$2"
+            shift 2
+            ;;
+        --review=*)
+            review="${1#--review=}"
+            shift
+            ;;
+        --user)
+            user="$2"
+            shift 2
+            ;;
+        --user=*)
+            user="${1#--user=}"
+            shift
+            ;;
+        --no-post-comment)
+            post_comment=0
+            shift
+            ;;
+        -h | --help | help)
+            echo "help_requested=1"
+            return 0
+            ;;
+        --*)
+            echo "Unknown flag: $1" >&2
+            return 2
+            ;;
+        *)
+            if [ -z "$pr" ]; then
+                pr="$1"
+            elif [ "$remote" = "origin" ]; then
+                remote="$1"
+            else
+                echo "Unexpected positional arg: $1" >&2
+                return 2
+            fi
+            shift
+            ;;
+        esac
+    done
+
+    # --ai is required.
+    if [ -z "$ai" ]; then
+        echo "missing required flag: --ai <codex|gemini|claude>" >&2
+        return 2
+    fi
+
+    # --ai must be one of the three allowed values.
+    case "$ai" in
+    codex | gemini | claude) ;;
+    *)
+        echo "Unknown --ai value: '$ai' (allowed: codex, gemini, claude)" >&2
+        return 2
+        ;;
+    esac
+
+    # --user is claude-only.
+    if [ -n "$user" ] && [ "$ai" != "claude" ]; then
+        echo "--user is only valid with --ai claude (codex/gemini have no multi-account routing)" >&2
+        return 2
+    fi
+
+    # Normalize --review (KR aliases → English enum).
+    case "$review" in
+    보통) review="default" ;;
+    간단) review="quick" ;;
+    꼼꼼 | 꼼꼼하게) review="thorough" ;;
+    보안) review="security" ;;
+    성능) review="performance" ;;
+    esac
+
+    case "$review" in
+    default | quick | thorough | security | performance) ;;
+    *)
+        cat >&2 <<EOF
+Unknown --review value: '$review'
+Allowed: default | quick | thorough | security | performance
+Korean aliases: 보통 | 간단 | 꼼꼼 (꼼꼼하게) | 보안 | 성능
+EOF
+        return 2
+        ;;
+    esac
+
+    echo "ai=$ai"
+    echo "review=$review"
+    echo "user=$user"
+    echo "post_comment=$post_comment"
+    echo "pr=$pr"
+    echo "remote=$remote"
+    return 0
+}

--- a/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh
@@ -29,6 +29,10 @@ gh_pr_review_parse() {
     while [ "$#" -gt 0 ]; do
         case "$1" in
         --ai)
+            if [ "$#" -lt 2 ]; then
+                echo "missing value for --ai" >&2
+                return 2
+            fi
             ai="$2"
             shift 2
             ;;
@@ -37,6 +41,10 @@ gh_pr_review_parse() {
             shift
             ;;
         --review)
+            if [ "$#" -lt 2 ]; then
+                echo "missing value for --review" >&2
+                return 2
+            fi
             review="$2"
             shift 2
             ;;
@@ -45,6 +53,10 @@ gh_pr_review_parse() {
             shift
             ;;
         --user)
+            if [ "$#" -lt 2 ]; then
+                echo "missing value for --user" >&2
+                return 2
+            fi
             user="$2"
             shift 2
             ;;

--- a/tests/bats/skills/gh_disable_ai_metrics.bats
+++ b/tests/bats/skills/gh_disable_ai_metrics.bats
@@ -39,6 +39,7 @@ SKILLS_REQUIRING_GUARD=(
     "gh-commit"
     "gh-pr-reply"
     "gh-pr-approve"
+    "gh-pr-review"
     "gh-pr-merge"
     "gh-pr-merge-emergency"
     "gh-pr-resolve-conflict"

--- a/tests/bats/skills/gh_pr_review_arg_parse.bats
+++ b/tests/bats/skills/gh_pr_review_arg_parse.bats
@@ -57,6 +57,24 @@ teardown() {
     assert_output --partial "ai=claude"
 }
 
+@test "ai: --ai at end of argv (no value) → exit 2 + 'missing value'" {
+    run gh_pr_review_parse --ai
+    assert_failure 2
+    assert_output --partial "missing value for --ai"
+}
+
+@test "review: --review at end of argv (no value) → exit 2" {
+    run gh_pr_review_parse --ai codex --review
+    assert_failure 2
+    assert_output --partial "missing value for --review"
+}
+
+@test "user: --user at end of argv (no value) → exit 2" {
+    run gh_pr_review_parse --ai claude --user
+    assert_failure 2
+    assert_output --partial "missing value for --user"
+}
+
 # ---- --review enum + KR alias ---------------------------------------------
 
 @test "review: default when omitted" {

--- a/tests/bats/skills/gh_pr_review_arg_parse.bats
+++ b/tests/bats/skills/gh_pr_review_arg_parse.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_review_arg_parse.bats
+# Verify the Step 1 arg-parsing + Step 3 preset-normalization logic
+# documented in claude/skills/gh-pr-review/SKILL.md.
+# Source-of-truth fixture: _fixtures/gh_pr_review_arg_parse.sh.
+#
+# Covers issue #637's Acceptance Criteria:
+#   - --ai required, single value, allowed enum
+#   - --review default, allowed enum, KR alias normalization, exit 2 on unknown
+#   - --user is claude-only (cross-AI rejection)
+#   - --no-post-comment flag
+#   - help passthrough (-h / --help / help)
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---- --ai gate -------------------------------------------------------------
+
+@test "ai: missing --ai → exit 2 + 'missing required flag'" {
+    run gh_pr_review_parse 99
+    assert_failure 2
+    assert_output --partial "missing required flag: --ai"
+}
+
+@test "ai: unknown --ai value → exit 2 + allowed list" {
+    run gh_pr_review_parse --ai chatgpt 99
+    assert_failure 2
+    assert_output --partial "Unknown --ai value: 'chatgpt'"
+    assert_output --partial "allowed: codex, gemini, claude"
+}
+
+@test "ai: --ai codex → ok, ai=codex" {
+    run gh_pr_review_parse --ai codex 99
+    assert_success
+    assert_output --partial "ai=codex"
+    assert_output --partial "pr=99"
+}
+
+@test "ai: --ai=gemini (= form) → ok, ai=gemini" {
+    run gh_pr_review_parse --ai=gemini 99
+    assert_success
+    assert_output --partial "ai=gemini"
+}
+
+@test "ai: --ai claude → ok, ai=claude" {
+    run gh_pr_review_parse --ai claude 99
+    assert_success
+    assert_output --partial "ai=claude"
+}
+
+# ---- --review enum + KR alias ---------------------------------------------
+
+@test "review: default when omitted" {
+    run gh_pr_review_parse --ai codex 99
+    assert_success
+    assert_output --partial "review=default"
+}
+
+@test "review: explicit --review thorough → ok" {
+    run gh_pr_review_parse --ai codex --review thorough 99
+    assert_success
+    assert_output --partial "review=thorough"
+}
+
+@test "review: KR alias 보통 → default" {
+    run gh_pr_review_parse --ai codex --review 보통 99
+    assert_success
+    assert_output --partial "review=default"
+}
+
+@test "review: KR alias 간단 → quick" {
+    run gh_pr_review_parse --ai codex --review 간단 99
+    assert_success
+    assert_output --partial "review=quick"
+}
+
+@test "review: KR alias 꼼꼼 → thorough" {
+    run gh_pr_review_parse --ai codex --review 꼼꼼 99
+    assert_success
+    assert_output --partial "review=thorough"
+}
+
+@test "review: KR alias 꼼꼼하게 → thorough" {
+    run gh_pr_review_parse --ai claude --review 꼼꼼하게 99
+    assert_success
+    assert_output --partial "review=thorough"
+}
+
+@test "review: KR alias 보안 → security" {
+    run gh_pr_review_parse --ai gemini --review 보안 99
+    assert_success
+    assert_output --partial "review=security"
+}
+
+@test "review: KR alias 성능 → performance" {
+    run gh_pr_review_parse --ai gemini --review 성능 99
+    assert_success
+    assert_output --partial "review=performance"
+}
+
+@test "review: unknown --review value → exit 2 + allowed enum" {
+    run gh_pr_review_parse --ai codex --review unknown 99
+    assert_failure 2
+    assert_output --partial "Unknown --review value: 'unknown'"
+    assert_output --partial "Allowed: default | quick | thorough | security | performance"
+    assert_output --partial "Korean aliases"
+}
+
+@test "review: free-text rejected even when it 'sounds' valid" {
+    # The skill explicitly rejects free text — only the 5 enum +
+    # 5 KR aliases above pass.
+    run gh_pr_review_parse --ai claude --review "꼼꼼하게 봐줘" 99
+    assert_failure 2
+    assert_output --partial "Unknown --review value"
+}
+
+# ---- --user gate (claude-only) --------------------------------------------
+
+@test "user: --user with --ai codex → exit 2 (cross-AI rejected)" {
+    run gh_pr_review_parse --ai codex --user work 99
+    assert_failure 2
+    assert_output --partial "--user is only valid with --ai claude"
+}
+
+@test "user: --user with --ai gemini → exit 2 (cross-AI rejected)" {
+    run gh_pr_review_parse --ai gemini --user work 99
+    assert_failure 2
+    assert_output --partial "--user is only valid with --ai claude"
+}
+
+@test "user: --user work with --ai claude → ok, user=work" {
+    run gh_pr_review_parse --ai claude --user work 99
+    assert_success
+    assert_output --partial "user=work"
+}
+
+@test "user: --user omitted → empty (preserve current shell CLAUDE_CONFIG_DIR)" {
+    run gh_pr_review_parse --ai claude 99
+    assert_success
+    assert_output --partial "user="
+    refute_output --partial "user=personal"
+}
+
+# ---- --no-post-comment + positional args ---------------------------------
+
+@test "post-comment: default ON (post_comment=1)" {
+    run gh_pr_review_parse --ai codex 99
+    assert_success
+    assert_output --partial "post_comment=1"
+}
+
+@test "post-comment: --no-post-comment flag → post_comment=0" {
+    run gh_pr_review_parse --ai codex --no-post-comment 99
+    assert_success
+    assert_output --partial "post_comment=0"
+}
+
+@test "positional: pr-number + remote → pr=99, remote=upstream" {
+    run gh_pr_review_parse --ai codex 99 upstream
+    assert_success
+    assert_output --partial "pr=99"
+    assert_output --partial "remote=upstream"
+}
+
+@test "positional: remote defaults to origin" {
+    run gh_pr_review_parse --ai codex 99
+    assert_success
+    assert_output --partial "remote=origin"
+}
+
+# ---- help passthrough -----------------------------------------------------
+
+@test "help: -h short flag → help_requested=1, no parse" {
+    run gh_pr_review_parse -h
+    assert_success
+    assert_output "help_requested=1"
+}
+
+@test "help: --help long flag → help_requested=1" {
+    run gh_pr_review_parse --help
+    assert_success
+    assert_output "help_requested=1"
+}
+
+@test "help: 'help' literal → help_requested=1" {
+    run gh_pr_review_parse help
+    assert_success
+    assert_output "help_requested=1"
+}


### PR DESCRIPTION
## Summary
- 신규 스킬 `gh-pr-review` 추가 — 외부 AI CLI(`codex` / `gemini` / `claude`)에게 PR 리뷰를 위임해 stdout + PR 코멘트로 2차 의견을 수집한다.
- **결정(approve / request-changes)은 내리지 않음** — `gh-pr-approve`(결정) / `gh-pr-reply`(응답)와 별개의 제3 자매 스킬로 자리잡는다.
- 5-enum closed `--review` preset + KR alias, `--user` 멀티-계정 라우팅(claude 전용), `<details>` 래퍼 + ai-metrics footer 포함.

## Changes
- `claude/skills/gh-pr-review/SKILL.md` (197): 7-step flow — arg parse → preflight → preset load → diff fetch (large-diff Explore 위임 재사용) → CLI dispatch → PR comment → report. inline `GH_DISABLE_AI_METRICS:-0` guard 포함.
- `claude/skills/gh-pr-review/references/help.md` (115): arg/flag 표, KR alias 매핑, `--user` semantics, exit-code matrix, good/bad invocation 예시.
- `claude/skills/gh-pr-review/references/ai-cli-invocation.md` (145): codex/gemini/claude command shape (stdin payload), `_claude_resolve_account` SSOT 통합, cross-AI `--user` 거부 규칙, error-code 매핑.
- `claude/skills/gh-pr-review/references/review-presets.md` (172): 5-enum 프롬프트 템플릿 SSOT (default/quick/thorough/security/performance), KR alias normalization (보통/간단/꼼꼼/꼼꼼하게/보안/성능), common prompt prefix.
- `claude/skills/gh-pr-review/references/post-comment.md` (134): `<details>` 래퍼 body template, `GH_DISABLE_AI_METRICS=1` opt-out scope, soft-fail policy, human-h baseline per preset.
- `tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh` (130): Step 1 arg parse + Step 3 KR normalization POSIX mirror. SKILL/references 변경 시 동기화 필수.
- `tests/bats/skills/gh_pr_review_arg_parse.bats` (198, **26 tests green**): `--ai` gate, KR alias 매핑, `--user` cross-AI 거부, `--no-post-comment`, positional args, help passthrough.
- `tests/bats/skills/gh_disable_ai_metrics.bats`: `SKILLS_REQUIRING_GUARD` 목록에 `gh-pr-review` 추가 (issue #399 doc-guard 일관성).

## 설계 결정

- **`--review` closed enum**: 자유 텍스트 거부 — 3종 CLI 간 출력 비교성 보장 + prompt-injection 표면 최소화. KR alias 5종은 normalization 후 enum 으로 치환.
- **`--user` claude 전용**: cross-AI 조합(`--ai codex --user X`)은 silent ignore 대신 exit 2 로 거부. silent ignore 는 사용자가 의도한 계정과 실제 실행이 어긋날 위험. 미지정 시 현재 셸의 `CLAUDE_CONFIG_DIR` 유지 (강제 personal 아님).
- **self-PR 허용**: 결정 미제출이므로 GitHub server-side self-approve block 과 무관.
- **`codex exec` 채택** (vs `codex review --base`): 3종 CLI 가 동일 stdin payload 를 받아 출력 비교 가능성 확보 (Open Question Q2 해소).
- **`GH_DISABLE_AI_METRICS=1` 시 PR 코멘트 전체 skip**: footer 만 빼는 것이 아님 — review body 와 metrics footer 가 함께 ship 되므로 opt-out 의미가 "ai 비용 흔적을 남기지 않겠다"임.

## Test plan
- [ ] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_review_arg_parse.bats` — 26/26 통과 확인.
- [ ] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_disable_ai_metrics.bats` — `gh-pr-review` 가 `SKILLS_REQUIRING_GUARD` 에 포함된 채 동작 확인.
- [ ] `shellcheck -x -e SC1090,SC1091 tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh` — clean.
- [ ] `shfmt -d -i 4 tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh tests/bats/skills/gh_pr_review_arg_parse.bats` — diff 없음.
- [ ] `/gh-pr-review -h` 가 references/help.md 를 verbatim 출력하고 종료한다. 다른 API 호출 없음.
- [ ] `/gh-pr-review --ai codex 99` 가 codex exec 를 호출하고 stdout 에 결과를 출력한 뒤 PR 코멘트를 자동 게시한다.
- [ ] `/gh-pr-review --ai gemini --review thorough 99` 가 thorough 프리셋을 사용한다.
- [ ] `/gh-pr-review --ai claude --review 꼼꼼 99` 가 thorough 로 정규화되어 동일하게 동작한다.
- [ ] `/gh-pr-review --ai codex --review unknown 99` → exit 2 + 허용 enum 목록.
- [ ] `/gh-pr-review --ai codex --no-post-comment 99` → stdout only, PR 코멘트 게시 안 함.
- [ ] `/gh-pr-review --ai claude --user work 99` → `CLAUDE_CONFIG_DIR=$HOME/.claude-work claude -p ...` 으로 실행.
- [ ] `/gh-pr-review --ai claude 99` (--user 생략) → 현재 셸의 `CLAUDE_CONFIG_DIR` 그대로 사용.
- [ ] `/gh-pr-review --ai codex --user work 99` → exit 2 + cross-AI 거부 메시지.
- [ ] `/gh-pr-review --ai claude --user bogus 99` → exit 1 + Unknown claude account 메시지.
- [ ] `--ai` 누락 / 알 수 없는 `--ai` 값 → exit 2.
- [ ] 외부 CLI PATH 미존재 시 fail-fast.
- [ ] Closed / merged / draft PR → stop + 안내.
- [ ] `GH_DISABLE_AI_METRICS=1` 시 PR 코멘트 전체 skip (stdout 은 그대로).

## Open Questions 처리

- Q1 (emoji footer 예외 확장): `post-comment.md` 에서 `<!-- ai-review:* -->` 를 ai-metrics 의 scoped extension 으로 명문화. CLAUDE.md SSOT 갱신은 필요 시 follow-up.
- Q2 (codex review vs exec): `codex exec` 채택 — 3종 CLI 가 동일 stdin payload 를 받아 출력 비교성 보장.
- Q3 (gemini -m): MVP 는 환경 default 사용; `--gemini-model` 별도 이슈로 분리.
- Q4 (다국어): "PR diff dominant language" 자동 추론, `--lang` flag 는 follow-up.

## Related
Closes #637

---
<details>
<summary>🤖 AI Metrics · 📊 ~15000 tokens · 👤 ~8 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~15000 tokens · 👤 ~8 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
