### PR TITLE
feat(claude-yolo): #640 Agent View read-only bypass + gwt spawn --bg

### DIFF
--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -34,16 +34,6 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
 - **DON'T**: raw `echo`/`printf`
 - **Exception**: ux_lib 미로드 시 단순 에러는 `echo ... >&2`
 
-## Module Organization
-
-- `env/` — `export` 만, 함수 금지
-- `aliases/` — `alias` 만, 복잡 로직 금지
-- `functions/` — 유틸 함수, help 시스템
-- `tools/integrations/` — 3rd-party 도구 자동 sourcing 래퍼
-- `tools/custom/` — 명시적 실행 스크립트 (자동 sourcing 안 됨)
-- `tools/ux_lib/` — UX 라이브러리 (loader 가 가장 먼저 source)
-- `projects/` — 프로젝트별 유틸 (finrx, dmc, smithery)
-
 ## Naming
 
 - 파일: `snake_case.sh` · 함수: `snake_case` 또는 `tool_command`
@@ -86,6 +76,15 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
    카테고리: `development`, `devops`, `ai`, `cli`, `config`, `docs`, `system`, `meta`
 
 참조 예시: `npm.sh` + `npm_help.sh` + `my_help.sh` 의 npm 항목
+
+# Agent View 와 Multi-account 통합 (#640)
+
+- **Supervisor 격리**: `claude` background supervisor 는 `CLAUDE_CONFIG_DIR` 단위.
+  multi-account 환경에서는 계정마다 별도 view — `claude-yolo --user work agents`.
+- **Read-only bypass**: `claude-yolo {agents|attach|logs|stop|kill|respawn|rm}` 은
+  main 위에서도 `scratch/*` 미생성. opt-in 아님, 자동 적용.
+- **Worktree dispatch**: `gwt spawn --launch --bg [task]` (claude 전용) 로
+  worktree 생성 → cd → `claude_yolo --bg "<task>"` 일괄 실행. `--user` 와 조합 가능.
 
 # Cheatsheet & Pitfalls
 

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1396,7 +1396,7 @@ _gwt_yolo_command() {
 # ============================================================================
 _git_worktree_spawn_show_help() {
     ux_header "gwt spawn - create a named worktree"
-    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--ai <agent>] [--user <account>]"
+    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--ai <agent>] [--user <account>] [--bg [task]]"
     ux_info ""
     ux_info "Arguments:"
     ux_info "  <name>           Free-form worktree name (required)."
@@ -1414,6 +1414,11 @@ _git_worktree_spawn_show_help() {
     ux_info "  --user <account> Claude account for --tmux/--launch (issue #295)."
     ux_info "                   Only valid with --ai claude (others lack multi-account)."
     ux_info "                   Default: \$CLAUDE_DEFAULT_ACCOUNT (no --user appended)."
+    ux_info "  --bg [task]      Dispatch claude in background mode (Agent View, #640)."
+    ux_info "                   Requires --launch or --tmux. Only with --ai claude."
+    ux_info "                   Optional positional task string consumed if it does"
+    ux_info "                   not start with '-'; missing/empty defers to claude's"
+    ux_info "                   own \"task too short\" error."
     ux_info ""
     ux_info "Examples:"
     ux_info "  gwt spawn issue-11                           # ../<proj>-issue-11-1  wt/issue-11/1"
@@ -1424,6 +1429,8 @@ _git_worktree_spawn_show_help() {
     ux_info "  gwt spawn feat --launch --ai codex           # cd + codex-yolo"
     ux_info "  gwt spawn feat --launch --user work          # cd + claude-yolo --user work"
     ux_info "  gwt spawn feat --tmux   --user work          # tmux window runs 'claude-yolo --user work'"
+    ux_info "  gwt spawn issue-100 --launch --bg            # cd + claude-yolo --bg ''"
+    ux_info "  gwt spawn issue-200 --launch --user work --bg \"fix login\"  # bg task to work account"
 }
 
 git_worktree_spawn() {
@@ -1432,7 +1439,7 @@ git_worktree_spawn() {
         emulate -L sh
     fi
 
-    local task="" base="" name="" use_tmux=0 use_launch=0 agent="claude" account=""
+    local task="" base="" name="" use_tmux=0 use_launch=0 use_bg=0 bg_task="" agent="claude" account=""
 
     # Parse arguments
     while [ $# -gt 0 ]; do
@@ -1447,6 +1454,21 @@ git_worktree_spawn() {
             --user) account="$2"; shift 2 ;;
             --tmux) use_tmux=1; shift ;;
             --launch) use_launch=1; shift ;;
+            --bg)
+                # Agent View background dispatch (#640). Passes through to
+                # `claude --bg "<task>"`. The next positional arg, if it
+                # exists and is not another flag, is consumed as the task
+                # string; otherwise we pass an empty string and let claude
+                # itself emit the "task too short" error.
+                use_bg=1
+                shift
+                if [ $# -gt 0 ]; then
+                    case "$1" in
+                        -*|"") ;;
+                        *) bg_task="$1"; shift ;;
+                    esac
+                fi
+                ;;
             -*)
                 ux_error "Unknown option: $1"
                 echo ""
@@ -1488,6 +1510,21 @@ git_worktree_spawn() {
         ux_error "--tmux and --launch are mutually exclusive"
         echo ""
         _git_worktree_spawn_show_help
+        return 1
+    fi
+
+    # --bg dispatches the agent in background mode, so it needs --launch or
+    # --tmux to actually run something. Without either, the worktree is
+    # created but nothing is dispatched (#640).
+    if [ "$use_bg" = 1 ] && [ "$use_tmux" != 1 ] && [ "$use_launch" != 1 ]; then
+        ux_error "--bg requires --launch or --tmux"
+        return 1
+    fi
+
+    # --bg currently only wires through claude (the only agent with Agent
+    # View / background dispatch). Other agents have no equivalent flag.
+    if [ "$use_bg" = 1 ] && [ "$agent" != "claude" ]; then
+        ux_error "--bg is only supported with --ai claude (got: --ai $agent)"
         return 1
     fi
 
@@ -1605,8 +1642,13 @@ git_worktree_spawn() {
 
     # --- Optional tmux integration ---
     if [ "$use_tmux" = 1 ]; then
-        _tmux_add_agent_window "$project" "$agent" "$wt_path" "$account"
-        ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo${account:+ --user $account})"
+        if [ "$use_bg" = 1 ]; then
+            _tmux_add_agent_window "$project" "$agent" "$wt_path" "$account" "$bg_task"
+            ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo${account:+ --user $account} --bg)"
+        else
+            _tmux_add_agent_window "$project" "$agent" "$wt_path" "$account"
+            ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo${account:+ --user $account})"
+        fi
         if [ -z "$TMUX" ]; then
             tmux attach -t "$project"
         else
@@ -1624,6 +1666,15 @@ git_worktree_spawn() {
             ux_error "No --launch yolo command for agent: $agent"
             ux_info "Supported with --launch: $(_gwt_yolo_command --list)"
             return 1
+        fi
+        if [ "$use_bg" = 1 ]; then
+            # `--bg "<task>"` is the Agent View background-dispatch flag.
+            # Pass via separate args so the task string's spaces/quotes
+            # survive `eval` intact (#640).
+            local bg_task_escaped
+            # Single-quote-safe escape: ' → '\''
+            bg_task_escaped=$(printf '%s' "$bg_task" | sed "s/'/'\\\\''/g")
+            launch_cmd="$launch_cmd --bg '$bg_task_escaped'"
         fi
         ux_info "  launch: cd \"$wt_path\" && $launch_cmd"
         cd "$wt_path" || { ux_error "Cannot cd to $wt_path"; return 1; }

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -29,7 +29,7 @@ _ts_known_agent() {
     esac
 }
 
-# _tmux_add_agent_window <session> <agent> <dir> [account]
+# _tmux_add_agent_window <session> <agent> <dir> [account] [bg_task]
 # Add a 3-pane window to a tmux session (creates session if needed).
 # Layout: LEFT (agent-yolo) | RIGHT-TOP / RIGHT-BOTTOM
 #
@@ -37,13 +37,28 @@ _ts_known_agent() {
 # left pane runs `claude-yolo --user <account>` instead of plain
 # `claude-yolo`. Other agents have no multi-account support so the value is
 # ignored — the caller is responsible for rejecting that combination.
+#
+# Optional 5th arg `bg_task` (issue #640): when non-null and agent=claude,
+# append `--bg "<bg_task>"` so Agent View picks up the dispatched session.
+# An empty bg_task is allowed — the caller's intent is "dispatch in
+# background, let claude itself emit a task-too-short error if needed".
+# Other agents lack a --bg flag and the caller must reject the combination.
 _tmux_add_agent_window() {
-    local session="$1" agent="$2" dir="$3" account="${4-}"
+    local session="$1" agent="$2" dir="$3" account="${4-}" bg_task="${5-}"
     local yolo win
     if [ "$agent" = "claude" ] && [ -n "$account" ]; then
         yolo="${agent}-yolo --user ${account}"
     else
         yolo="${agent}-yolo"
+    fi
+    # Background dispatch passthrough (#640). Single-quote-escape the task
+    # string so tmux send-keys passes it through verbatim. The "$#" check
+    # distinguishes "no 5th arg" (no --bg) from "5th arg present, empty"
+    # (--bg with empty task).
+    if [ "$agent" = "claude" ] && [ "$#" -ge 5 ]; then
+        local _ts_bg_esc
+        _ts_bg_esc=$(printf '%s' "$bg_task" | sed "s/'/'\\\\''/g")
+        yolo="${yolo} --bg '${_ts_bg_esc}'"
     fi
 
     if tmux has-session -t "=$session" 2>/dev/null; then

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -305,7 +305,12 @@ _claude_yolo_export_settings_env() {
 # 동작:
 # 1. POSIX 안전 인자 재구성 (sentinel 패턴, eval 없음)
 # 2. 계정 → CLAUDE_CONFIG_DIR 해석 (SSOT: _claude_resolve_account)
-# 3. main/master 브랜치 가드 (기존 동작 유지) — bypass: CLAUDE_YOLO_STAY=1
+# 3. main/master 브랜치 가드 (기존 동작 유지)
+#    bypass:
+#      - CLAUDE_YOLO_STAY=1
+#      - Agent View read-only 서브커맨드 (#640):
+#        agents|attach|logs|stop|kill|respawn|rm — 파일 편집이 없는 명령이라
+#        scratch/* 브랜치를 만들면 worktree 노이즈만 발생.
 # 4. CLAUDE_CONFIG_DIR 환경 주입 + command claude --dangerously-skip-permissions
 claude_yolo() {
     _cy_account="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
@@ -362,8 +367,19 @@ claude_yolo() {
         return 1
     }
 
+    # Agent View read-only 서브커맨드 화이트리스트 (#640).
+    # `claude agents/attach/logs/stop/kill/respawn/rm` 은 파일 편집을 하지
+    # 않으므로 main 위에서도 scratch/* 브랜치를 만들 필요가 없다. main-guard
+    # 가 발동하면 코드 변경 0줄짜리 명령에 worktree 만 더러워진다.
+    _cy_is_readonly_cmd=0
+    case "${1:-}" in
+        agents|attach|logs|stop|kill|respawn|rm)
+            _cy_is_readonly_cmd=1
+            ;;
+    esac
+
     # main/master 브랜치 가드 (기존 로직 보존)
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [ "$_cy_is_readonly_cmd" -eq 0 ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         _cy_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
         case "$_cy_branch" in
             main|master)

--- a/tests/bats/functions/claude_yolo.bats
+++ b/tests/bats/functions/claude_yolo.bats
@@ -50,6 +50,9 @@ _setup_fake_repo_on_main() {
 }
 
 # Run claude_yolo in bash with the shim on PATH and CWD at a given path.
+# Extra positional args after $cwd are eval'd as setup lines (e.g.
+# `export CLAUDE_YOLO_STAY=1`). Optional yolo args are forwarded via
+# the YOLO_ARGS env var so call sites can pass `agents`, `attach <id>`, etc.
 _run_yolo_bash() {
     local cwd="$1"
     shift
@@ -58,6 +61,7 @@ _run_yolo_bash() {
         export SHELL_COMMON='${SHELL_COMMON}'
         export DOTFILES_FORCE_INIT=1
         export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
         export HOME='${HOME}'
         export TERM=dumb
         export PATH='${PATH}'
@@ -65,7 +69,7 @@ _run_yolo_bash() {
         $*
         source '${DOTFILES_ROOT}/bash/main.bash'
         cd '${cwd}'
-        claude_yolo
+        claude_yolo \${YOLO_ARGS:-}
     "
 }
 
@@ -126,4 +130,89 @@ _run_yolo_bash() {
     assert_success
     run cat "$MARKER"
     assert_output "no-branch"
+}
+
+# --- Agent View read-only bypass (#640) ---
+
+@test "bash: claude_yolo agents on main skips scratch auto-switch" {
+    # `claude agents` is a read-only Agent View command; the main-guard
+    # creating a scratch/* branch would just leave worktree noise.
+    _run_yolo_bash "$REPO" "export YOLO_ARGS=agents"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo attach on main skips scratch auto-switch" {
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='attach abc123'"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo logs on main skips scratch auto-switch" {
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='logs abc123'"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo stop on main skips scratch auto-switch" {
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='stop abc123'"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo respawn on main skips scratch auto-switch" {
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='respawn abc123'"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo rm on main skips scratch auto-switch" {
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='rm abc123'"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo kill on main skips scratch auto-switch" {
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='kill abc123'"
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
+}
+
+@test "bash: claude_yolo with non-readonly subcommand still auto-switches" {
+    # Regression guard: non-whitelisted args (e.g. `--bg "task"`) must NOT
+    # bypass the main-guard. Only the read-only set is special-cased.
+    _run_yolo_bash "$REPO" "export YOLO_ARGS='--bg something'"
+    assert_success
+    run cat "$MARKER"
+    assert_output --regexp '^scratch/[0-9]{4}-[0-9]{6}$'
+}
+
+@test "zsh: claude_yolo agents on main skips scratch auto-switch" {
+    # zsh path matters because emulate -L sh inside claude_yolo guarantees
+    # POSIX word-splitting; the bypass branch must work there too.
+    run zsh --no-rcs -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
+        export HOME='${HOME}'
+        export ZDOTDIR='${HOME}'
+        export TERM=dumb
+        export PATH='${PATH}'
+        export MARKER='${MARKER}'
+        source '${DOTFILES_ROOT}/zsh/main.zsh'
+        cd '${REPO}'
+        claude_yolo agents
+    "
+    assert_success
+    run cat "$MARKER"
+    assert_output "main"
 }

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -329,3 +329,139 @@ teardown() {
     assert_failure
     assert_output --partial "--user is only supported with --ai claude"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #640: --bg flag passes through to `claude --bg "<task>"`. Worktree
+# is created then the agent's yolo command is dispatched in background
+# mode so Agent View (`claude-yolo agents`) can see the session.
+# ---------------------------------------------------------------------------
+
+@test "bash: spawn --help mentions --bg flag" {
+    run_in_bash 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--bg"
+    assert_output --partial "Agent View"
+}
+
+@test "zsh: spawn --help mentions --bg flag" {
+    run_in_zsh 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--bg"
+}
+
+@test "bash: spawn rejects --bg without --launch or --tmux" {
+    # --bg only makes sense when something is being dispatched. Without
+    # --launch/--tmux the worktree is created but nothing runs, so flag
+    # the typo loudly.
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --bg 2>&1
+    "
+    assert_failure
+    assert_output --partial "--bg requires --launch or --tmux"
+}
+
+@test "bash: spawn rejects --bg with --ai codex" {
+    # Multi-agent guard: only claude has Agent View / --bg today.
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --launch --ai codex --bg 2>&1
+    "
+    assert_failure
+    assert_output --partial "--bg is only supported with --ai claude"
+}
+
+@test "zsh: spawn rejects --bg without --launch or --tmux" {
+    run_in_zsh "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-xyz --bg 2>&1
+    "
+    assert_failure
+    assert_output --partial "--bg requires --launch or --tmux"
+}
+
+@test "bash: spawn --launch --bg dispatches claude_yolo --bg with empty task" {
+    # End-to-end check via a fake claude_yolo shim. When --bg is given with
+    # no task arg, the wrapper passes an empty string and lets claude itself
+    # complain if needed. The marker uses '|' between args so word-splitting
+    # cannot collapse `--bg` + empty string into a single token.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-bg-marker'
+        export MARKER
+        # Shadow claude_yolo with a recorder. _gwt_yolo_command returns the
+        # literal 'claude_yolo', so once we redefine the function, eval'd
+        # launch_cmd will dispatch into the recorder.
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn issue-bgempty --launch --bg >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    # 2 args: '--bg' and '' (empty). Pipe delimiter preserves the empty arg.
+    assert_output "|--bg|"
+}
+
+@test "bash: spawn --launch --bg with task passes the task string through" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-bg-task-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn issue-bgtask --launch --bg 'fix login flow' >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    # The task string survives shell quoting through eval — 2 args, second
+    # carries spaces verbatim.
+    assert_output "|--bg|fix login flow"
+}
+
+@test "bash: spawn --launch --user work --bg threads account through" {
+    # AC-6 path: --user work + --bg → claude_yolo --user work --bg ''.
+    # Stand up the work account dir so _claude_resolve_account succeeds.
+    run_in_bash "
+        mkdir -p '$HOME/.claude-work' '$HOME/.claude-personal'
+        # Space-separated whitelist (see claude.sh _claude_resolve_account).
+        export CLAUDE_ENABLED_ACCOUNTS='personal work'
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-bg-user-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn issue-bgwork --launch --user work --bg >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    # 4 args: '--user', 'work', '--bg', ''
+    assert_output "|--user|work|--bg|"
+}
+
+@test "bash: spawn without --bg still dispatches plain claude_yolo" {
+    # Regression guard: default --launch path must NOT silently grow --bg.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-no-bg-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"[\$_cy_recorded]\" > \"\$MARKER\"
+        }
+        git_worktree_spawn issue-nobg --launch >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    # Empty arg list — claude_yolo invoked with zero extra args.
+    assert_output "[]"
+}


### PR DESCRIPTION
## Summary
- `claude_yolo`의 main-브랜치 가드가 Agent View read-only 서브커맨드(agents·attach·logs·stop·kill·respawn·rm)에서 `scratch/*` 브랜치를 만들지 않도록 화이트리스트 분기를 추가.
- `gwt spawn` 에 `--bg [task]` 플래그를 도입해 worktree 생성 → cd → `claude_yolo --bg "<task>"` 일괄 dispatch (claude 전용, `--launch` / `--tmux` 와 조합). `--user` 와도 결합.
- 회귀 보호용 bats 18개 + `shell-common/AGENTS.md` 통합 패턴 절(6 줄) 추가, 100-line 한도 준수.

## Changes
- **shell-common/tools/integrations/claude.sh** — `claude_yolo` 본문에 read-only 서브커맨드 화이트리스트(`_cy_is_readonly_cmd`) 분기. 헤더 주석에 새 bypass 경로 명시.
- **shell-common/functions/git_worktree.sh** — `gwt spawn` 인자 파서에 `--bg [task]` 추가, `--launch` 경로에서 single-quote-escape 후 `--bg '<task>'` 를 launch_cmd 에 append. `--tmux` 경로는 5번째 인자로 패스. `--bg` 가 `--launch`/`--tmux` 없으면 거절, non-claude agent 와 결합 시 거절. help/예시 갱신.
- **shell-common/functions/tmux_spawn.sh** — `_tmux_add_agent_window` 가 선택적 5번째 인자 `bg_task` 를 받아 claude 전용으로 `--bg '<task>'` append (빈 task 도 허용 — 본체가 자체 검증).
- **tests/bats/functions/claude_yolo.bats** — read-only bypass 7 개(agents/attach/logs/stop/respawn/rm/kill) + non-readonly regression guard + zsh smoke = 9 cases. `_run_yolo_bash` 에 `DOTFILES_ROOT_NO_CANONICALIZE=1` 추가해 worktree 코드가 실제로 실행되도록 보정.
- **tests/bats/functions/git_worktree_spawn.bats** — `--bg` 헬프 가시성 + `--launch`/`--tmux` 없는 거절 + non-claude 거절 + 빈 task dispatch + 스페이스 포함 task dispatch + `--user work --bg` 조합 + 기본 경로 회귀 = 9 cases. pipe-delimited marker 로 empty-string arg 와 word-splitting 충돌 방지.
- **shell-common/AGENTS.md** — "Agent View 와 Multi-account 통합 (#640)" 절 6 줄 추가, 중복된 Module Organization 서브섹션을 Quick Reference Table 로 통합해 99 줄 유지.

## Test plan
- [x] `tests/bats/functions/claude_yolo.bats` (17/17 통과 — 기존 8 + 신규 9)
- [x] `tests/bats/functions/git_worktree_spawn.bats` (46/46 통과 — 기존 37 + 신규 9)
- [x] 전체 `tests/bats/functions/` 485 cases 통과 (회귀 0)
- [x] `tox -e ruff,shellcheck,shfmt` (gh:pr lint guard 경유) 통과
- [ ] 수동: `git switch main && claude-yolo agents` — scratch/* 미생성 확인
- [ ] 수동: `gwt spawn --launch --bg "fix login"` — claude --bg 호출 확인 후 `claude-yolo agents` 에 세션 표시

## Related
Closes #640

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
