### PR TITLE
feat(skill): #644 helper-fallback NF-1 — [ -r ] 가드 + || true

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -137,8 +137,12 @@ fix commit would bounce it back to `In progress`.
 Skip the board sync entirely when no issue footer was written.
 
 ```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-_gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog
+# helper-fallback NF-1 (#644): silent-skip when helper missing.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    _gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog || true
+fi
 ```
 
 If the repo has no projectV2 board (auto-detected) the helper silently

--- a/claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
@@ -15,8 +15,12 @@ to `Done`. Repeating the sync on an already-`Done` card is harmless.
 Source the shared helper, then call it with the merged PR number:
 
 ```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-_gh_project_status_sync pr <PR_NUMBER> "Done"
+# helper-fallback NF-1 (#644): silent-skip when helper missing.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    _gh_project_status_sync pr <PR_NUMBER> "Done" || true
+fi
 ```
 
 ## Behavior

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -69,24 +69,29 @@ on the team's projectV2 board column.
 
 ```bash
 # Reuse the SSOT query helper — never inline a fresh GraphQL block.
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
+# helper-fallback NF-1 (#644): silent-skip when helper missing; never hard-fail.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
 
-# Operator escape hatch: GH_PR_MERGE_SKIP_BOARD_CHECK=1
-# Use for in-transition repos or one-shot ops (also leaves an audit signal:
-# any reviewer can re-run gh-pr-merge without the env var to verify).
-if [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
-    BOARD_STATUS=$(GH_REPO="$TARGET_REPO" \
-        _gh_project_status_query_current pr "$PR_NUMBER" 2>/dev/null)
+    # Operator escape hatch: GH_PR_MERGE_SKIP_BOARD_CHECK=1
+    # Use for in-transition repos or one-shot ops (also leaves an audit signal:
+    # any reviewer can re-run gh-pr-merge without the env var to verify).
+    if [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
+        BOARD_STATUS=$(GH_REPO="$TARGET_REPO" \
+            _gh_project_status_query_current pr "$PR_NUMBER" 2>/dev/null || true)
 
-    # Empty result = no projectV2 attached OR no read access.
-    # Auto-skip in both cases — the merge gate is opt-in by board attachment.
-    if [ -n "$BOARD_STATUS" ] && [ "$BOARD_STATUS" != "Approved" ]; then
-        echo "Refusing to merge PR #$PR_NUMBER — board Status is \"$BOARD_STATUS\", required \"Approved\"."
-        echo "  Have a teammate move the card to Approved, or use /gh-pr-merge-emergency for admin bypass."
-        echo "  One-shot escape: GH_PR_MERGE_SKIP_BOARD_CHECK=1 /gh-pr-merge $PR_NUMBER"
-        exit 2
+        # Empty result = no projectV2 attached OR no read access.
+        # Auto-skip in both cases — the merge gate is opt-in by board attachment.
+        if [ -n "$BOARD_STATUS" ] && [ "$BOARD_STATUS" != "Approved" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER — board Status is \"$BOARD_STATUS\", required \"Approved\"."
+            echo "  Have a teammate move the card to Approved, or use /gh-pr-merge-emergency for admin bypass."
+            echo "  One-shot escape: GH_PR_MERGE_SKIP_BOARD_CHECK=1 /gh-pr-merge $PR_NUMBER"
+            exit 2
+        fi
     fi
 fi
+# helper missing → board approval gate is silently skipped (NF-1).
 ```
 
 Failure modes:
@@ -121,21 +126,23 @@ gating rationale. Two reconciliations run after a successful merge:
     card stayed at `Approved`):
 
 ```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done"
-```
+# helper-fallback NF-1 (#644): silent-skip when helper missing.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
 
-(b) Linked Issue cards from `closingIssuesReferences` → `Done`
-    (boosts the best-effort `Item closed` builtin per #250). Use the
-    `_gh_pr_closing_issue_numbers` helper instead of
-    `gh pr view --json closingIssuesReferences` — older `gh` (≤ 2.45)
-    rejects that field with "Unknown JSON field" (#264):
-
-```bash
-for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO"); do
-    GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
-        --only-from "Backlog,In progress,In review"
-done
+    # (b) Linked Issue cards from `closingIssuesReferences` → `Done`
+    #     (boosts the best-effort `Item closed` builtin per #250). Use the
+    #     `_gh_pr_closing_issue_numbers` helper instead of
+    #     `gh pr view --json closingIssuesReferences` — older `gh` (≤ 2.45)
+    #     rejects that field with "Unknown JSON field" (#264):
+    for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO" 2>/dev/null || true); do
+        GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
+            --only-from "Backlog,In progress,In review" || true
+    done
+fi
+# helper missing → both reconciliations silently skipped (NF-1).
 ```
 
 Both helpers auto-detect repos without a projectV2 attachment and

--- a/claude/skills/gh-pr-merge/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge/references/project-board-sync.md
@@ -15,8 +15,12 @@ the merge report — the helper logs to stderr and returns 0.
 ## (1) PR card → `Done`
 
 ```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done"
+# helper-fallback NF-1 (#644): silent-skip when helper missing.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
+fi
 ```
 
 `Done` is the terminal PR state after merge, regardless of which
@@ -49,9 +53,12 @@ query, which is supported across all `gh` versions that ship the
 `api graphql` subcommand.
 
 ```bash
-for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO"); do
+# Wrap inside the same [ -r "$_HELPER" ] block from step (1) so the closing-issue
+# helper is only called after the source succeeded. With the helper missing the
+# entire reconciliation is silently skipped (NF-1).
+for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO" 2>/dev/null || true); do
     GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
-        --only-from "Backlog,In progress,In review"
+        --only-from "Backlog,In progress,In review" || true
 done
 ```
 

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -115,11 +115,18 @@ Soft-fail — warn on any error, never block the Step 7 report.
 
 ```bash
 if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
-    . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null \
-      && _gh_project_status_sync pr "$PR_NUMBER" "In review" \
-            --only-from "In progress,Changes requested" \
-      && echo "[OK] PR 카드 \`In review\` 로 복귀됨" \
-      || echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+    # helper-fallback NF-1 (#644): silent-skip when helper missing.
+    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        . "$_HELPER"
+        if _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+                --only-from "In progress,Changes requested"; then
+            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
+        else
+            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+        fi
+    fi
+    # helper missing → board sync silently skipped (NF-1).
 fi
 ```
 

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -61,12 +61,16 @@ still refusing to drag `Done` Issues backwards if a closed PR is re-opened (#309
 Source the shared helper, then call it with the new PR number:
 
 ```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null
-_gh_project_status_sync pr "$PR_NUMBER" "In review"
-for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO"); do
-    _gh_project_status_sync issue "$_issue" "In progress" \
-        --only-from "Backlog,Ready,In review"
-done
+# helper-fallback NF-1 (#644): silent-skip when helper missing.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
+    for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
+        _gh_project_status_sync issue "$_issue" "In progress" \
+            --only-from "Backlog,Ready,In review" || true
+    done
+fi
 ```
 
 `GH_REPO` must be `owner/repo` (e.g. `dEitY719/dotfiles`). If unavailable,

--- a/tests/bats/skills/_fixtures/helper_fallback_nf1.sh
+++ b/tests/bats/skills/_fixtures/helper_fallback_nf1.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/helper_fallback_nf1.sh
+# Source-of-truth mirror for the canonical F-2 helper-fallback pattern
+# documented in issue #644 and applied across:
+#   claude/skills/gh-pr-merge/SKILL.md           (Step 2-B, Step 4)
+#   claude/skills/gh-commit/SKILL.md             (Step 5)
+#   claude/skills/gh-pr-reply/SKILL.md           (Step 6.5)
+#   claude/skills/gh-pr/references/project-board-sync.md
+#   claude/skills/gh-pr-merge/references/project-board-sync.md
+#   claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
+#
+# Tests inject SHELL_COMMON pointing at a real fixture dir (helper present)
+# or a non-existent dir (helper missing). The wrapper must:
+#   - call _gh_project_status_sync when helper is readable
+#   - silently skip (no command-not-found) when helper is missing
+#   - never abort the calling skill on either branch (NF-1 guarantee)
+
+# Mirrors the canonical F-2 block. Keep this in sync with the SKILL.md
+# edits made for issue #644.
+nf1_canonical_block() {
+    local _PR="$1"
+    local _STATE="$2"
+
+    local _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        # shellcheck disable=SC1090
+        . "$_HELPER"
+        _gh_project_status_sync pr "$_PR" "$_STATE" || true
+        echo "BLOCK_RAN sync_called"
+    fi
+    echo "BLOCK_COMPLETED"
+}
+
+# Synthesise a minimal helper file at the given path. Defines a stub
+# _gh_project_status_sync that records its call and returns 0.
+nf1_install_fake_helper() {
+    local _path="$1"
+    mkdir -p "$(dirname "$_path")"
+    cat >"$_path" <<'EOF'
+_gh_project_status_sync() {
+    printf 'fake-helper invoked with: %s\n' "$*" >&2
+    return 0
+}
+EOF
+}

--- a/tests/bats/skills/helper_fallback_nf1.bats
+++ b/tests/bats/skills/helper_fallback_nf1.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# tests/bats/skills/helper_fallback_nf1.bats
+# Smoke test for issue #644 — helper-fallback NF-1.
+#
+# Verifies the canonical `[ -r ]` guard + `|| true` block applied to all
+# helper source points across:
+#   gh-pr-merge / gh-pr / gh-pr-reply / gh-pr-merge-emergency / gh-commit
+# behaves correctly under both helper-present and helper-missing
+# (e.g. agent-toolbox / cross-project skill copy) environments.
+#
+# Acceptance criteria mapped from issue #644:
+#   - SHELL_COMMON pointing at an empty dir → no `command not found`,
+#     silent skip, calling skill continues.
+#   - SHELL_COMMON pointing at a populated dir → helper sourced,
+#     _gh_project_status_sync invoked.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/helper_fallback_nf1.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset SHELL_COMMON
+}
+
+@test "helper present → block runs sync and continues" {
+    local helper_dir="$TEST_TEMP_HOME/sc/functions"
+    nf1_install_fake_helper "$helper_dir/gh_project_status.sh"
+    export SHELL_COMMON="$TEST_TEMP_HOME/sc"
+
+    run nf1_canonical_block 644 "Done"
+    assert_success
+    assert_output --partial "BLOCK_RAN sync_called"
+    assert_output --partial "BLOCK_COMPLETED"
+}
+
+@test "helper missing (SHELL_COMMON=/tmp/empty equivalent) → silent skip, no command-not-found" {
+    # NF-1 core guarantee from issue #644: skill body keeps running.
+    export SHELL_COMMON="$TEST_TEMP_HOME/empty-sc"
+    [ ! -e "$SHELL_COMMON/functions/gh_project_status.sh" ] || {
+        echo "precondition violated: fake SHELL_COMMON should not contain helper" >&2
+        return 1
+    }
+
+    run nf1_canonical_block 644 "Done"
+    assert_success
+    refute_output --partial "BLOCK_RAN sync_called"
+    refute_output --partial "command not found"
+    refute_output --partial "_gh_project_status_sync"
+    assert_output --partial "BLOCK_COMPLETED"
+}
+
+@test "helper missing, SHELL_COMMON unset → fallback path also silent-skips" {
+    # When SHELL_COMMON is unset the canonical block falls back to
+    # $HOME/dotfiles/shell-common. Under bats isolation HOME is a fresh
+    # tmpdir, so that path is absent — the [ -r ] guard must still hold.
+    unset SHELL_COMMON
+
+    run nf1_canonical_block 644 "Done"
+    assert_success
+    refute_output --partial "BLOCK_RAN sync_called"
+    refute_output --partial "command not found"
+    assert_output --partial "BLOCK_COMPLETED"
+}
+
+@test "fixture mirrors the SKILL.md canonical pattern verbatim (drift guard)" {
+    # If this test fails, the F-2 canonical pattern in one of the SKILL.md
+    # files has drifted from the fixture in
+    # tests/bats/skills/_fixtures/helper_fallback_nf1.sh.  Re-sync both.
+    local fixture="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/helper_fallback_nf1.sh"
+    run grep -F 'if [ -r "$_HELPER" ]; then' "$fixture"
+    assert_success
+
+    # Spot-check that each updated SKILL.md/reference also carries the guard.
+    local f
+    for f in \
+        "claude/skills/gh-pr-merge/SKILL.md" \
+        "claude/skills/gh-pr-merge/references/project-board-sync.md" \
+        "claude/skills/gh-commit/SKILL.md" \
+        "claude/skills/gh-pr-reply/SKILL.md" \
+        "claude/skills/gh-pr/references/project-board-sync.md" \
+        "claude/skills/gh-pr-merge-emergency/references/project-board-sync.md"; do
+        run grep -F 'if [ -r "$_HELPER" ]; then' "${_BATS_REAL_DOTFILES_ROOT}/$f"
+        assert_success
+    done
+}


### PR DESCRIPTION
## Summary
- #611 의 F-2 helper-fallback 패턴이 dotfiles 측에 절반만 적용된 상태였고, helper 미존재 환경(예: agent-toolbox / cross-project skill 복사 / `SHELL_COMMON=/tmp/empty`)에서 `_gh_project_status_sync` 가 `command not found` 로 hard-fail 하던 NF-1 위반을 수정.
- 모든 helper source 지점에 `[ -r ]` 가드 + 함수 호출에 `|| true` 의 canonical F-2 패턴을 적용. 5개 SKILL + 3개 reference doc 갱신 + bats smoke test (drift-guard 포함) 추가.
- dotfiles 표준 환경 (helper 존재) 에서 회귀 0 — 기존 199 개 skill bats 전부 통과 + tox(ruff/shellcheck/shfmt) 통과.

## Changes
- `claude/skills/gh-pr-merge/SKILL.md` — Step 2-B (board approval gate, line 70+) + Step 4 (post-merge `Done` sync, line 124+) 두 helper source 지점에 `[ -r ]` 가드 적용. 닫힌 issue 카드 `Done` 전이 루프도 동일 가드 안으로 이동.
- `claude/skills/gh-commit/SKILL.md` — Step 5 의 issue → `In progress` 전이 (line 140) 에 `[ -r ]` 가드 적용.
- `claude/skills/gh-pr-reply/SKILL.md` — Step 6.5 의 PR 카드 `In review` 복귀 (line 117) 를 `[ -r ]` 가드 + `if/else` 로 재작성. 기존 `&& ... || ...` chain 의 단락 평가 미스(audit OK 가 helper 성공 여부 대신 source 결과를 반영하던 코너 케이스)도 같이 정리.
- `claude/skills/gh-pr/references/project-board-sync.md` — 문서 SSOT 예시도 canonical 패턴으로 통일.
- `claude/skills/gh-pr-merge/references/project-board-sync.md` — 동상.
- `claude/skills/gh-pr-merge-emergency/references/project-board-sync.md` — 동상.
- `tests/bats/skills/_fixtures/helper_fallback_nf1.sh` — 신규 fixture. canonical F-2 block 의 source-of-truth mirror + fake helper installer.
- `tests/bats/skills/helper_fallback_nf1.bats` — 신규 bats. 4 케이스: helper present → sync 호출, helper missing (`SHELL_COMMON=/tmp/empty`) → silent skip, `SHELL_COMMON` unset → fallback path 도 silent skip, 그리고 SKILL.md / fixture drift-guard.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/helper_fallback_nf1.bats` — 4/4 통과.
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/` — 199/199 통과 (신규 4 + 기존 195, 회귀 0).
- [x] `tox -e shellcheck,shfmt,ruff` — 모두 통과 (lint guard 포함).
- [ ] CI green (full `./tests/test` 포함).
- [ ] 사후 검증: `SHELL_COMMON=/tmp/empty bash -c 'set -e; ...board sync block...'` 가 `command not found` 없이 0 으로 종료.

## Related
Closes #644

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~8 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~8 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
