### PR TITLE
refactor(claude-yolo): #647 main/master scratch/* 자동 분기 가드 제거

### DIFF
--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -81,9 +81,10 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
 
 - **Supervisor 격리**: `claude` background supervisor 는 `CLAUDE_CONFIG_DIR` 단위.
   multi-account 환경에서는 계정마다 별도 view — `claude-yolo --user work agents`.
-- **main/master 가드 제거 (#647)**: `claude-yolo` 는 main 위에서도 그대로 실행
-  된다. 격리가 필요하면 `gwt spawn --launch --ai claude <task>` 가 SSOT —
-  자동 `scratch/*` 분기 + read-only 화이트리스트 누적 복잡도가 같이 사라졌다.
+- **main/master 가드 제거 (#647)**: `claude-yolo` 는 main 위에서도 그대로 실행된다.
+  격리가 필요하면 `gwt spawn --launch --ai claude <task>` 가 SSOT — 자동
+  `scratch/*` 분기, `CLAUDE_YOLO_STAY` env, read-only 화이트리스트의 누적
+  복잡도가 같이 사라졌다.
 - **Worktree dispatch**: `gwt spawn --launch --bg [task]` (claude 전용) 로
   worktree 생성 → cd → `claude_yolo --bg "<task>"` 일괄 실행. `--user` 와 조합 가능.
 

--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -81,8 +81,9 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
 
 - **Supervisor 격리**: `claude` background supervisor 는 `CLAUDE_CONFIG_DIR` 단위.
   multi-account 환경에서는 계정마다 별도 view — `claude-yolo --user work agents`.
-- **Read-only bypass**: `claude-yolo {agents|attach|logs|stop|kill|respawn|rm}` 은
-  main 위에서도 `scratch/*` 미생성. opt-in 아님, 자동 적용.
+- **main/master 가드 제거 (#647)**: `claude-yolo` 는 main 위에서도 그대로 실행
+  된다. 격리가 필요하면 `gwt spawn --launch --ai claude <task>` 가 SSOT —
+  자동 `scratch/*` 분기 + read-only 화이트리스트 누적 복잡도가 같이 사라졌다.
 - **Worktree dispatch**: `gwt spawn --launch --bg [task]` (claude 전용) 로
   worktree 생성 → cd → `claude_yolo --bg "<task>"` 일괄 실행. `--user` 와 조합 가능.
 

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -307,8 +307,8 @@ _claude_yolo_export_settings_env() {
 # 2. 계정 → CLAUDE_CONFIG_DIR 해석 (SSOT: _claude_resolve_account)
 # 3. CLAUDE_CONFIG_DIR 환경 주입 + command claude --dangerously-skip-permissions
 #
-# main/master 자동 scratch/* 가드는 #647 에서 제거됨 — 격리 워크플로는
-# `gwt spawn --launch --ai claude <task>` 가 SSOT.
+# main/master 자동 scratch/* 가드 + CLAUDE_YOLO_STAY env 는 #647 에서 제거됨 —
+# 격리 워크플로는 `gwt spawn --launch --ai claude <task>` 가 SSOT.
 claude_yolo() {
     _cy_account="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
 

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -305,13 +305,10 @@ _claude_yolo_export_settings_env() {
 # 동작:
 # 1. POSIX 안전 인자 재구성 (sentinel 패턴, eval 없음)
 # 2. 계정 → CLAUDE_CONFIG_DIR 해석 (SSOT: _claude_resolve_account)
-# 3. main/master 브랜치 가드 (기존 동작 유지)
-#    bypass:
-#      - CLAUDE_YOLO_STAY=1
-#      - Agent View read-only 서브커맨드 (#640):
-#        agents|attach|logs|stop|kill|respawn|rm — 파일 편집이 없는 명령이라
-#        scratch/* 브랜치를 만들면 worktree 노이즈만 발생.
-# 4. CLAUDE_CONFIG_DIR 환경 주입 + command claude --dangerously-skip-permissions
+# 3. CLAUDE_CONFIG_DIR 환경 주입 + command claude --dangerously-skip-permissions
+#
+# main/master 자동 scratch/* 가드는 #647 에서 제거됨 — 격리 워크플로는
+# `gwt spawn --launch --ai claude <task>` 가 SSOT.
 claude_yolo() {
     _cy_account="${CLAUDE_DEFAULT_ACCOUNT:-personal}"
 
@@ -366,31 +363,6 @@ claude_yolo() {
         ux_info  "Run: claude-accounts setup"
         return 1
     }
-
-    # Agent View read-only 서브커맨드 화이트리스트 (#640).
-    # `claude agents/attach/logs/stop/kill/respawn/rm` 은 파일 편집을 하지
-    # 않으므로 main 위에서도 scratch/* 브랜치를 만들 필요가 없다. main-guard
-    # 가 발동하면 코드 변경 0줄짜리 명령에 worktree 만 더러워진다.
-    _cy_is_readonly_cmd=0
-    case "${1:-}" in
-        agents|attach|logs|stop|kill|respawn|rm)
-            _cy_is_readonly_cmd=1
-            ;;
-    esac
-
-    # main/master 브랜치 가드 (기존 로직 보존)
-    if [ "$_cy_is_readonly_cmd" -eq 0 ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        _cy_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-        case "$_cy_branch" in
-            main|master)
-                if [ -z "${CLAUDE_YOLO_STAY:-}" ]; then
-                    _cy_new_branch="scratch/$(date +%m%d-%H%M%S)"
-                    ux_warning "main 브랜치 감지 → ${_cy_new_branch} 로 전환 (bypass: CLAUDE_YOLO_STAY=1)"
-                    git switch -c "$_cy_new_branch" || return 1
-                fi
-                ;;
-        esac
-    fi
 
     # Pre-launch .claude.json integrity guard (issue #294).
     # See _claude_restore_if_reset for the heuristic and rationale.

--- a/tests/bats/functions/claude_yolo.bats
+++ b/tests/bats/functions/claude_yolo.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 # tests/bats/functions/claude_yolo.bats
-# Test claude_yolo function: exists, alias maps correctly, and the
-# main-branch auto-switch behavior works. Uses a PATH-prepended shim
-# so `command claude ...` hits a fake binary that records the
-# current branch instead of invoking the real claude CLI.
+# Test claude_yolo function: exists, alias maps correctly, and main-branch
+# pass-through behavior (issue #647 — main/master auto-switch guard removed).
+# Uses a PATH-prepended shim so `command claude ...` hits a fake binary that
+# records the current branch instead of invoking the real claude CLI.
 
 load '../test_helper'
 
@@ -50,9 +50,8 @@ _setup_fake_repo_on_main() {
 }
 
 # Run claude_yolo in bash with the shim on PATH and CWD at a given path.
-# Extra positional args after $cwd are eval'd as setup lines (e.g.
-# `export CLAUDE_YOLO_STAY=1`). Optional yolo args are forwarded via
-# the YOLO_ARGS env var so call sites can pass `agents`, `attach <id>`, etc.
+# Optional yolo args are forwarded via the YOLO_ARGS env var so call sites
+# can pass `agents`, `attach <id>`, etc.
 _run_yolo_bash() {
     local cwd="$1"
     shift
@@ -99,17 +98,13 @@ _run_yolo_bash() {
     assert_output --partial "claude_yolo"
 }
 
-# --- auto-switch behavior ---
+# --- branch pass-through behavior (issue #647: no auto-switch on main) ---
 
-@test "bash: claude_yolo on main auto-switches to scratch/* then invokes claude" {
+@test "bash: claude_yolo on main stays on main (no scratch/* auto-switch)" {
+    # #647: main/master guard removed — `gwt spawn --launch --ai claude <task>`
+    # is the SSOT for isolation. main itself is a legitimate context for
+    # read-only / exploratory runs.
     _run_yolo_bash "$REPO"
-    assert_success
-    run cat "$MARKER"
-    assert_output --regexp '^scratch/[0-9]{4}-[0-9]{6}$'
-}
-
-@test "bash: claude_yolo on main with CLAUDE_YOLO_STAY=1 stays on main" {
-    _run_yolo_bash "$REPO" "export CLAUDE_YOLO_STAY=1"
     assert_success
     run cat "$MARKER"
     assert_output "main"
@@ -132,71 +127,9 @@ _run_yolo_bash() {
     assert_output "no-branch"
 }
 
-# --- Agent View read-only bypass (#640) ---
-
-@test "bash: claude_yolo agents on main skips scratch auto-switch" {
-    # `claude agents` is a read-only Agent View command; the main-guard
-    # creating a scratch/* branch would just leave worktree noise.
-    _run_yolo_bash "$REPO" "export YOLO_ARGS=agents"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo attach on main skips scratch auto-switch" {
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='attach abc123'"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo logs on main skips scratch auto-switch" {
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='logs abc123'"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo stop on main skips scratch auto-switch" {
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='stop abc123'"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo respawn on main skips scratch auto-switch" {
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='respawn abc123'"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo rm on main skips scratch auto-switch" {
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='rm abc123'"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo kill on main skips scratch auto-switch" {
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='kill abc123'"
-    assert_success
-    run cat "$MARKER"
-    assert_output "main"
-}
-
-@test "bash: claude_yolo with non-readonly subcommand still auto-switches" {
-    # Regression guard: non-whitelisted args (e.g. `--bg "task"`) must NOT
-    # bypass the main-guard. Only the read-only set is special-cased.
-    _run_yolo_bash "$REPO" "export YOLO_ARGS='--bg something'"
-    assert_success
-    run cat "$MARKER"
-    assert_output --regexp '^scratch/[0-9]{4}-[0-9]{6}$'
-}
-
-@test "zsh: claude_yolo agents on main skips scratch auto-switch" {
+@test "zsh: claude_yolo on main stays on main" {
     # zsh path matters because emulate -L sh inside claude_yolo guarantees
-    # POSIX word-splitting; the bypass branch must work there too.
+    # POSIX word-splitting; the pass-through must work there too.
     run zsh --no-rcs -c "
         export DOTFILES_ROOT='${DOTFILES_ROOT}'
         export SHELL_COMMON='${SHELL_COMMON}'
@@ -210,7 +143,7 @@ _run_yolo_bash() {
         export MARKER='${MARKER}'
         source '${DOTFILES_ROOT}/zsh/main.zsh'
         cd '${REPO}'
-        claude_yolo agents
+        claude_yolo
     "
     assert_success
     run cat "$MARKER"

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -468,7 +468,7 @@ JSON
     # Live file has been reset to first-start placeholder (50B-ish).
     printf '{"firstStartTime":"y"}' > "$HOME/.claude-personal/.claude.json"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     assert_output --partial "Restored"
     grep -q "oauthAccount" "$HOME/.claude-personal/.claude.json"
@@ -489,7 +489,7 @@ JSON
     printf '{"firstStartTime":"y","oauthAccount":{"e":"snapshot@b"},"migrationVersion":5}' \
         > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     refute_output --partial "Restored"
     grep -q "live@b" "$HOME/.claude-personal/.claude.json"
@@ -501,7 +501,7 @@ JSON
     # First-start placeholder, but no migrate snapshot — fresh PC.
     printf '{"firstStartTime":"x"}' > "$HOME/.claude-personal/.claude.json"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     refute_output --partial "Restored"
     # Live file untouched.
@@ -516,7 +516,7 @@ JSON
     printf '{"oauthAccount":{"e":"OLD@b"},"migrationVersion":1}' \
         > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     refute_output --partial "Restored"
     grep -q '"a@b"' "$HOME/.claude-personal/.claude.json"
@@ -571,7 +571,7 @@ MOCK
 @test "bash: claude_yolo defaults to personal account" {
     _setup_claude_mock
     mkdir -p "$HOME/.claude-personal"
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     assert_output --partial "CLAUDE_CONFIG_DIR=$HOME/.claude-personal"
 }
@@ -579,7 +579,7 @@ MOCK
 @test "bash: claude_yolo --user work routes to work" {
     _setup_claude_mock
     mkdir -p "$HOME/.claude-work"
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user work"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo --user work"
     assert_success
     assert_output --partial "CLAUDE_CONFIG_DIR=$HOME/.claude-work"
 }
@@ -587,7 +587,7 @@ MOCK
 @test "bash: claude_yolo --user=work syntax also works" {
     _setup_claude_mock
     mkdir -p "$HOME/.claude-work"
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user=work"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo --user=work"
     assert_success
     assert_output --partial "CLAUDE_CONFIG_DIR=$HOME/.claude-work"
 }
@@ -595,14 +595,14 @@ MOCK
 @test "bash: claude_yolo passes extra args through to claude" {
     _setup_claude_mock
     mkdir -p "$HOME/.claude-work"
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user work --resume foo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo --user work --resume foo"
     assert_success
     assert_output --partial "ARGS=--dangerously-skip-permissions --resume foo"
 }
 
 @test "bash: claude_yolo --user xyz fails with available list" {
     _setup_claude_mock
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user xyz"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo --user xyz"
     assert_failure
     assert_output --partial "Unknown account: xyz"
     assert_output --partial "Available"
@@ -611,7 +611,7 @@ MOCK
 @test "bash: claude_yolo errors when account dir missing" {
     _setup_claude_mock
     rm -rf "$HOME/.claude-work"
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user work"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo --user work"
     assert_failure
     assert_output --partial "Account directory missing"
     assert_output --partial "claude-accounts setup"
@@ -620,7 +620,7 @@ MOCK
 @test "bash: claude_yolo respects CLAUDE_DEFAULT_ACCOUNT=work (Internal-PC)" {
     _setup_claude_mock
     mkdir -p "$HOME/.claude-work"
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_DEFAULT_ACCOUNT=work CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_DEFAULT_ACCOUNT=work claude_yolo"
     assert_success
     assert_output --partial "CLAUDE_CONFIG_DIR=$HOME/.claude-work"
 }
@@ -942,7 +942,7 @@ JSON
     printf '{"oauthAccount":{"emailAddress":"alice@example.com"}}' \
         > "$HOME/.claude-personal/.claude.json"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 CLAUDE_ACCOUNT_EMAIL_personal=alice@example.com claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_ACCOUNT_EMAIL_personal=alice@example.com claude_yolo"
     assert_success
     refute_output --partial "Account mismatch"
 }
@@ -953,7 +953,7 @@ JSON
     printf '{"oauthAccount":{"emailAddress":"personal@gmail.com"}}' \
         > "$HOME/.claude-work/.claude.json"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 CLAUDE_ACCOUNT_EMAIL_work=work@corp.com claude_yolo --user work"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_ACCOUNT_EMAIL_work=work@corp.com claude_yolo --user work"
     assert_success
     assert_output --partial "Account mismatch on 'work'"
     assert_output --partial "expected: work@corp.com"
@@ -967,7 +967,7 @@ JSON
     printf '{"oauthAccount":{"emailAddress":"anyone@anywhere.com"}}' \
         > "$HOME/.claude-work/.claude.json"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo --user work"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo --user work"
     assert_success
     refute_output --partial "Account mismatch"
 }
@@ -1126,7 +1126,7 @@ run_with_fake_ssot() {
     printf '{"firstStartTime":"x","oauthAccount":{"e":"a@b"},"migrationVersion":5}' \
         > "$HOME/.claude-personal/.claude.json.preserved-by-migrate"
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     assert_output --partial "missing .claude.json"
     assert_output --partial "Restored"
@@ -1140,7 +1140,7 @@ run_with_fake_ssot() {
     mkdir -p "$HOME/.claude-personal"
     # snapshot 도 없는 fresh PC — 기존 동작 유지 (silent return).
 
-    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; CLAUDE_YOLO_STAY=1 claude_yolo"
+    run_in_bash "export PATH=\"$HOME/bin:\$PATH\"; claude_yolo"
     assert_success
     refute_output --partial "Restored"
     refute_output --partial "missing .claude.json"


### PR DESCRIPTION
## Summary
- `claude-yolo` 가 main/master 위에서 자동으로 `scratch/MMDD-HHMMSS` 브랜치를 만들던 가드를 제거.
- 격리는 `gwt spawn --launch --ai claude <task>` 가 SSOT 이므로 중복 정책 + #640 read-only 화이트리스트도 의미가 사라져 함께 정리.
- main 위 read-only/탐색 실행마다 `CLAUDE_YOLO_STAY=1` prefix 가 필요한 마찰도 같이 사라진다.

## Changes
- `shell-common/tools/integrations/claude.sh` (refactor): `_cy_is_readonly_cmd` 로컬, `case _cy_branch in main|master` 분기, `git switch -c scratch/$(date +%m%d-%H%M%S)` 블록을 모두 제거. `claude_yolo()` 위 docstring 의 "3. main/master 브랜치 가드" 항목과 bypass / #640 설명도 삭제하고 `#647 에서 제거됨` 한 줄 메모로 대체.
- `tests/bats/functions/claude_yolo.bats` (test): 자동 분기 lock 케이스를 "stays on main" 으로 의미 반전. `CLAUDE_YOLO_STAY=1` 케이스, #640 read-only bypass 7 케이스(bash) + 1 케이스(zsh), non-readonly subcommand 회귀 가드를 모두 삭제.
- `tests/bats/integrations/claude_accounts.bats` (test): 16 곳의 `CLAUDE_YOLO_STAY=1` prefix 제거 — 가드가 없으니 더 이상 필요 없음.
- `shell-common/AGENTS.md` (docs): "Agent View 와 Multi-account 통합 (#640)" 섹션의 Read-only bypass 항목을 #647 가드 제거 안내로 교체.

`docs/superpowers/{specs,plans}/2026-05-04-claude-multi-account-*.md` 의 히스토리 스냅샷은 의도적으로 그대로 둔다 (이슈 본문 "안 건드림" 항목).

## Test plan
- [x] `bash -n` / `zsh -n shell-common/tools/integrations/claude.sh` — 구문 OK.
- [x] `tox -e ruff,shellcheck,shfmt` (lint guard 경유) — 통과.
- [x] `bats tests/bats/functions/claude_yolo.bats` — 8/8 통과.
- [x] `bats tests/bats/integrations/claude_accounts.bats` — 92/96 통과 (실패 4 건은 issue #647 무관, 사전 존재 — pristine HEAD 에서 동일하게 재현 확인).
- [ ] 수동 — main checkout 상태에서 `claude-yolo` 실행 시 그대로 main 에서 dispatch 되는지 + `claude-yolo agents` / `claude-yolo --user work` 도 회귀 없는지.

## Related
Closes #647

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
