### PR TITLE
feat(gwt-spawn): #650 grammar redesign — drop positional name, add --wt-name + --prompt

### DIFF
--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -82,11 +82,15 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
 - **Supervisor 격리**: `claude` background supervisor 는 `CLAUDE_CONFIG_DIR` 단위.
   multi-account 환경에서는 계정마다 별도 view — `claude-yolo --user work agents`.
 - **main/master 가드 제거 (#647)**: `claude-yolo` 는 main 위에서도 그대로 실행된다.
-  격리가 필요하면 `gwt spawn --launch --ai claude <task>` 가 SSOT — 자동
-  `scratch/*` 분기, `CLAUDE_YOLO_STAY` env, read-only 화이트리스트의 누적
-  복잡도가 같이 사라졌다.
-- **Worktree dispatch**: `gwt spawn --launch --bg [task]` (claude 전용) 로
-  worktree 생성 → cd → `claude_yolo --bg "<task>"` 일괄 실행. `--user` 와 조합 가능.
+  격리가 필요하면 `gwt spawn --launch --ai claude --wt-name <slug>` 가 SSOT —
+  자동 `scratch/*` 분기, `CLAUDE_YOLO_STAY` env, read-only 화이트리스트의
+  누적 복잡도가 같이 사라졌다.
+- **Worktree dispatch (#650 grammar)**: `gwt spawn --launch --bg --wt-name
+  <slug> [--prompt <text...>]` (claude 전용) 로 worktree 생성 → cd →
+  `claude_yolo --bg "<prompt>"` 일괄 실행. `--user` 와 조합 가능.
+  `--prompt` 없이 `--bg` 단독 호출 시 `--bg ''` 로 dispatch — Agent View
+  진입 후 `claude agents` 에서 입력. `--bg` 없이 `--prompt` 만 주면
+  `claude_yolo "<prompt>"` 로 TUI 첫 메시지로 전달.
 
 # Cheatsheet & Pitfalls
 

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1392,45 +1392,48 @@ _gwt_yolo_command() {
 
 # ============================================================================
 # Worktree spawn — auto-index, auto-branch, log
-# Usage: git_worktree_spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--ai <agent>] [--user <account>]
+# Grammar (#650): option-only; --wt-name is required, --prompt is trailing.
+# Usage: git_worktree_spawn [OPTIONS] --wt-name <slug> [--prompt <text...>]
 # ============================================================================
 _git_worktree_spawn_show_help() {
     ux_header "gwt spawn - create a named worktree"
-    ux_info "Usage: gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch] [--ai <agent>] [--user <account>] [--bg [task]]"
+    ux_info "Usage: gwt spawn [OPTIONS] --wt-name <slug> [--prompt <text...>]"
     ux_info ""
-    ux_info "Arguments:"
-    ux_info "  <name>           Free-form worktree name (required)."
-    ux_info "                   Safe chars only: no '/', no spaces, no leading dash."
+    ux_info "Required:"
+    ux_info "  --wt-name <slug> Worktree name. Safe chars only:"
+    ux_info "                   no '/', no spaces, no leading dash."
     ux_info "                   Examples: issue-11, login-fix, feature-x"
-    ux_info "  --task <slug>    Add task slug to branch name"
+    ux_info ""
+    ux_info "Optional (order-independent):"
     ux_info "  --base <ref>     Base branch/commit (default: origin/main)"
     ux_info "  --tmux           Auto-create tmux session/window with 3-pane layout"
-    ux_info "  --launch         cd into the new worktree and run <agent>-yolo in the"
-    ux_info "                   current shell. Mutually exclusive with --tmux."
-    ux_info "  --ai <agent>     AI agent for --tmux pane or --launch (default: claude)"
-    ux_info "                   Known: claude, codex, gemini, opencode, cursor, copilot"
-    ux_info "                   Window name and 'yolo' command follow --ai,"
-    ux_info "                   so worktree <name> can be any free-form slug."
-    ux_info "  --user <account> Claude account for --tmux/--launch (issue #295)."
-    ux_info "                   Only valid with --ai claude (others lack multi-account)."
-    ux_info "                   Default: \$CLAUDE_DEFAULT_ACCOUNT (no --user appended)."
-    ux_info "  --bg [task]      Dispatch claude in background mode (Agent View, #640)."
+    ux_info "  --launch         cd into the new worktree and run the agent's yolo"
+    ux_info "                   command in the current shell."
+    ux_info "                   Mutually exclusive with --tmux."
+    ux_info "  --bg             Dispatch claude in background mode (Agent View, #640)."
     ux_info "                   Requires --launch or --tmux. Only with --ai claude."
-    ux_info "                   Optional positional task string consumed if it does"
-    ux_info "                   not start with '-'; missing/empty defers to claude's"
-    ux_info "                   own \"task too short\" error."
+    ux_info "  --ai <agent>     AI agent (default: claude)."
+    ux_info "                   Known: claude, codex, gemini, opencode, cursor, copilot"
+    ux_info "  --user <account> Claude account for --tmux/--launch (issue #295)."
+    ux_info "                   Only valid with --ai claude."
+    ux_info ""
+    ux_info "Trailing (must be LAST if used):"
+    ux_info "  --prompt <text...>"
+    ux_info "                   Initial task for the AI. All remaining tokens are"
+    ux_info "                   joined with single spaces. No quotes needed."
     ux_info ""
     ux_info "Examples:"
-    ux_info "  gwt spawn issue-11                           # ../<proj>-issue-11-1  wt/issue-11/1"
-    ux_info "  gwt spawn login-fix --task auth              # ../<proj>-login-fix-1 wt/login-fix/1-auth"
-    ux_info "  gwt spawn issue-11 --tmux                    # tmux window 'claude' runs 'claude-yolo'"
-    ux_info "  gwt spawn issue-11 --tmux --ai codex         # tmux window 'codex'  runs 'codex-yolo'"
-    ux_info "  gwt spawn feat --launch                      # cd into new worktree + claude-yolo"
-    ux_info "  gwt spawn feat --launch --ai codex           # cd + codex-yolo"
-    ux_info "  gwt spawn feat --launch --user work          # cd + claude-yolo --user work"
-    ux_info "  gwt spawn feat --tmux   --user work          # tmux window runs 'claude-yolo --user work'"
-    ux_info "  gwt spawn issue-100 --launch --bg            # cd + claude-yolo --bg ''"
-    ux_info "  gwt spawn issue-200 --launch --user work --bg \"fix login\"  # bg task to work account"
+    ux_info "  gwt spawn --wt-name issue-11"
+    ux_info "  gwt spawn --launch --wt-name issue-11"
+    ux_info "  gwt spawn --launch --ai claude --user work --wt-name issue-717 --prompt 이슈 717 요약해"
+    ux_info "  gwt spawn --launch --bg --wt-name issue-718"
+    ux_info "  gwt spawn --launch --bg --wt-name issue-718 --prompt 오늘의 날씨 검색해"
+    ux_info "  gwt spawn --tmux   --user work --wt-name feat-x"
+    ux_info ""
+    ux_info "Removed (#650):"
+    ux_info "  Positional <name>     -> use --wt-name <slug>"
+    ux_info "  --task <slug>         -> removed (branch-suffix dropped)"
+    ux_info "  --bg <task>           -> use --prompt <text...>"
 }
 
 git_worktree_spawn() {
@@ -1439,35 +1442,86 @@ git_worktree_spawn() {
         emulate -L sh
     fi
 
-    local task="" base="" name="" use_tmux=0 use_launch=0 use_bg=0 bg_task="" agent="claude" account=""
+    local base="" name="" use_tmux=0 use_launch=0 use_bg=0 \
+          agent="claude" account="" prompt="" prompt_set=0 prompt_warned=0
 
-    # Parse arguments
+    # Parse arguments. New grammar (#650): option-only; --wt-name is the
+    # required name, --prompt is the trailing AI initial-task flag that
+    # consumes every remaining token.
     while [ $# -gt 0 ]; do
+        # Once --prompt has fired, every subsequent token (including
+        # things that look like flags) becomes part of the prompt text
+        # (AC-9). AC-10: warn ONCE if a recognized flag is absorbed so
+        # the user knows their flag did not take effect.
+        if [ "$prompt_set" = 1 ]; then
+            case "$1" in
+                --launch|--tmux|--bg|--ai|--user|--base|--wt-name|--task|--prompt|-h|--help)
+                    if [ "$prompt_warned" = 0 ]; then
+                        ux_warning "Token '$1' after --prompt is consumed as prompt text (use quotes if intentional)" >&2
+                        prompt_warned=1
+                    fi
+                    ;;
+            esac
+            if [ -z "$prompt" ]; then
+                prompt="$1"
+            else
+                prompt="$prompt $1"
+            fi
+            shift
+            continue
+        fi
+
         case "$1" in
             -h|--help)
                 _git_worktree_spawn_show_help
                 return 0
                 ;;
-            --task) task="$2"; shift 2 ;;
-            --base) base="$2"; shift 2 ;;
-            --ai) agent="$2"; shift 2 ;;
-            --user) account="$2"; shift 2 ;;
+            --wt-name)
+                if [ $# -lt 2 ] || [ -z "${2-}" ]; then
+                    ux_error "--wt-name requires a value"
+                    return 1
+                fi
+                name="$2"; shift 2
+                ;;
+            --base)
+                if [ $# -lt 2 ]; then
+                    ux_error "--base requires a value"; return 1
+                fi
+                base="$2"; shift 2
+                ;;
+            --ai)
+                if [ $# -lt 2 ]; then
+                    ux_error "--ai requires a value"; return 1
+                fi
+                agent="$2"; shift 2
+                ;;
+            --user)
+                if [ $# -lt 2 ]; then
+                    ux_error "--user requires a value"; return 1
+                fi
+                account="$2"; shift 2
+                ;;
             --tmux) use_tmux=1; shift ;;
             --launch) use_launch=1; shift ;;
             --bg)
-                # Agent View background dispatch (#640). Passes through to
-                # `claude --bg "<task>"`. The next positional arg, if it
-                # exists and is not another flag, is consumed as the task
-                # string; otherwise we pass an empty string and let claude
-                # itself emit the "task too short" error.
+                # Boolean since #650 — the optional positional task was
+                # removed in favor of --prompt. AC-11.
                 use_bg=1
                 shift
-                if [ $# -gt 0 ]; then
-                    case "$1" in
-                        -*|"") ;;
-                        *) bg_task="$1"; shift ;;
-                    esac
-                fi
+                ;;
+            --prompt)
+                # All remaining tokens become the prompt text (AC-9).
+                prompt_set=1
+                shift
+                ;;
+            --task)
+                # Hard-break migration error (#650 / AC-7). The branch-
+                # suffix feature was removed; if the user wanted an AI
+                # initial prompt they want --prompt now.
+                ux_error "--task flag has been removed (branch-suffix feature dropped)."
+                ux_info  "For AI initial prompt use --prompt:"
+                ux_info  "  gwt spawn --wt-name <slug> --prompt <text...>"
+                return 1
                 ;;
             -*)
                 ux_error "Unknown option: $1"
@@ -1476,23 +1530,30 @@ git_worktree_spawn() {
                 return 1
                 ;;
             *)
-                if [ -n "$name" ]; then
-                    ux_error "Multiple names given: '$name', '$1' (only one allowed)"
-                    echo ""
-                    _git_worktree_spawn_show_help
-                    return 1
-                fi
-                name="$1"
+                # Hard-break migration error (#650 / AC-6). Build a
+                # corrected suggestion that carries any flags the user
+                # had already typed forward, with --wt-name appended at
+                # the end so it is unambiguous.
+                local _gwt_bad_name="$1"
                 shift
+                local _gwt_hint_flags=""
+                while [ $# -gt 0 ]; do
+                    _gwt_hint_flags="$_gwt_hint_flags $1"
+                    shift
+                done
+                ux_error "Positional <name> is no longer supported."
+                ux_info  "Use --wt-name <slug>:"
+                ux_info  "  gwt spawn${_gwt_hint_flags} --wt-name ${_gwt_bad_name}"
+                return 1
                 ;;
         esac
     done
 
-    # Name is required
+    # --wt-name is required
     if [ -z "$name" ]; then
         ux_error "<name> is required"
         echo ""
-        _git_worktree_spawn_show_help
+        ux_info "Hint: use --wt-name <slug>"
         return 1
     fi
 
@@ -1593,17 +1654,12 @@ git_worktree_spawn() {
 
     # Branch name + path must both be unique. A previous teardown may leave a
     # branch (e.g., --keep-branch), so don't rely on directory scan alone.
-    local wt_path branch slug=""
-    if [ -n "$task" ]; then
-        slug=$(printf '%s' "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-30)
-    fi
+    # Branch suffix (--task) was removed in #650, so the branch is always
+    # `wt/<name>/<index>`.
+    local wt_path branch
     while :; do
         wt_path="${parent}/${project}-${name}-${next_index}"
-        if [ -n "$slug" ]; then
-            branch="wt/${name}/${next_index}-${slug}"
-        else
-            branch="wt/${name}/${next_index}"
-        fi
+        branch="wt/${name}/${next_index}"
 
         if [ -d "$wt_path" ]; then
             next_index=$((next_index + 1))
@@ -1642,13 +1698,11 @@ git_worktree_spawn() {
 
     # --- Optional tmux integration ---
     if [ "$use_tmux" = 1 ]; then
-        if [ "$use_bg" = 1 ]; then
-            _tmux_add_agent_window "$project" "$agent" "$wt_path" "$account" "$bg_task"
-            ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo${account:+ --user $account} --bg)"
-        else
-            _tmux_add_agent_window "$project" "$agent" "$wt_path" "$account"
-            ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo${account:+ --user $account})"
-        fi
+        # New 6-arg signature (#650): pass use_bg + prompt as a pair so the
+        # window can decide whether to wrap in --bg or pass the prompt as a
+        # plain TUI first-message.
+        _tmux_add_agent_window "$project" "$agent" "$wt_path" "$account" "$use_bg" "$prompt"
+        ux_info "  tmux:   session '$project', window '$agent' (runs ${agent}-yolo${account:+ --user $account}$([ "$use_bg" = 1 ] && printf ' --bg'))"
         if [ -z "$TMUX" ]; then
             tmux attach -t "$project"
         else
@@ -1667,14 +1721,24 @@ git_worktree_spawn() {
             ux_info "Supported with --launch: $(_gwt_yolo_command --list)"
             return 1
         fi
+        # Behavior matrix (#650):
+        #   --bg                -> claude_yolo --bg ''
+        #   --bg --prompt X Y   -> claude_yolo --bg 'X Y'
+        #   --prompt X Y        -> claude_yolo 'X Y'
+        #   (none)              -> claude_yolo
+        # The prompt-only path is currently scoped to claude (matches the
+        # rest of the multi-account / Agent View story); other agents'
+        # first-message conventions land in a follow-up (issue body
+        # "Out of scope").
         if [ "$use_bg" = 1 ]; then
-            # `--bg "<task>"` is the Agent View background-dispatch flag.
-            # Pass via separate args so the task string's spaces/quotes
-            # survive `eval` intact (#640).
-            local bg_task_escaped
-            # Single-quote-safe escape: ' → '\''
-            bg_task_escaped=$(printf '%s' "$bg_task" | sed "s/'/'\\\\''/g")
-            launch_cmd="$launch_cmd --bg '$bg_task_escaped'"
+            # Single-quote-safe escape: ' -> '\''
+            local prompt_escaped
+            prompt_escaped=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
+            launch_cmd="$launch_cmd --bg '$prompt_escaped'"
+        elif [ -n "$prompt" ] && [ "$agent" = "claude" ]; then
+            local prompt_escaped
+            prompt_escaped=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
+            launch_cmd="$launch_cmd '$prompt_escaped'"
         fi
         ux_info "  launch: cd \"$wt_path\" && $launch_cmd"
         cd "$wt_path" || { ux_error "Cannot cd to $wt_path"; return 1; }

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1484,19 +1484,23 @@ git_worktree_spawn() {
                 name="$2"; shift 2
                 ;;
             --base)
-                if [ $# -lt 2 ]; then
+                # `[ "${2#-}" != "$2" ]` rejects a next token that starts
+                # with `-` so a stray `--base --launch` does not silently
+                # absorb the following flag as the base value (PR #652
+                # gemini-code-assist review).
+                if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
                     ux_error "--base requires a value"; return 1
                 fi
                 base="$2"; shift 2
                 ;;
             --ai)
-                if [ $# -lt 2 ]; then
+                if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
                     ux_error "--ai requires a value"; return 1
                 fi
                 agent="$2"; shift 2
                 ;;
             --user)
-                if [ $# -lt 2 ]; then
+                if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
                     ux_error "--user requires a value"; return 1
                 fi
                 account="$2"; shift 2
@@ -1543,7 +1547,7 @@ git_worktree_spawn() {
                 done
                 ux_error "Positional <name> is no longer supported."
                 ux_info  "Use --wt-name <slug>:"
-                ux_info  "  gwt spawn${_gwt_hint_flags} --wt-name ${_gwt_bad_name}"
+                ux_info  "  gwt spawn${_gwt_hint_flags} --wt-name '${_gwt_bad_name}'"
                 return 1
                 ;;
         esac
@@ -1730,14 +1734,17 @@ git_worktree_spawn() {
         # rest of the multi-account / Agent View story); other agents'
         # first-message conventions land in a follow-up (issue body
         # "Out of scope").
-        if [ "$use_bg" = 1 ]; then
-            # Single-quote-safe escape: ' -> '\''
-            local prompt_escaped
+        # Single-quote-safe escape: ' -> '\''. Computed once and
+        # reused so SC2155 (local + command-substitution) cannot mask
+        # the sed exit status (PR #652 gemini-code-assist review).
+        local prompt_escaped
+        prompt_escaped=""
+        if [ -n "$prompt" ]; then
             prompt_escaped=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
+        fi
+        if [ "$use_bg" = 1 ]; then
             launch_cmd="$launch_cmd --bg '$prompt_escaped'"
         elif [ -n "$prompt" ] && [ "$agent" = "claude" ]; then
-            local prompt_escaped
-            prompt_escaped=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
             launch_cmd="$launch_cmd '$prompt_escaped'"
         fi
         ux_info "  launch: cd \"$wt_path\" && $launch_cmd"

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -58,13 +58,16 @@ _tmux_add_agent_window() {
     fi
     # Single-quote-escape any prompt text so tmux send-keys passes it
     # through verbatim through the eventual `eval` inside the agent yolo.
-    if [ "$agent" = "claude" ] && [ "$use_bg" = 1 ]; then
-        local _ts_p_esc
+    # Computed once and reused so SC2155 (local + command-substitution)
+    # cannot mask the sed exit status (PR #652 gemini-code-assist review).
+    local _ts_p_esc
+    _ts_p_esc=""
+    if [ -n "$prompt" ]; then
         _ts_p_esc=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
+    fi
+    if [ "$agent" = "claude" ] && [ "$use_bg" = 1 ]; then
         yolo="${yolo} --bg '${_ts_p_esc}'"
     elif [ "$agent" = "claude" ] && [ -n "$prompt" ]; then
-        local _ts_p_esc
-        _ts_p_esc=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
         yolo="${yolo} '${_ts_p_esc}'"
     fi
 

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -29,7 +29,7 @@ _ts_known_agent() {
     esac
 }
 
-# _tmux_add_agent_window <session> <agent> <dir> [account] [bg_task]
+# _tmux_add_agent_window <session> <agent> <dir> [account] [use_bg] [prompt]
 # Add a 3-pane window to a tmux session (creates session if needed).
 # Layout: LEFT (agent-yolo) | RIGHT-TOP / RIGHT-BOTTOM
 #
@@ -38,27 +38,34 @@ _ts_known_agent() {
 # `claude-yolo`. Other agents have no multi-account support so the value is
 # ignored — the caller is responsible for rejecting that combination.
 #
-# Optional 5th arg `bg_task` (issue #640): when non-null and agent=claude,
-# append `--bg "<bg_task>"` so Agent View picks up the dispatched session.
-# An empty bg_task is allowed — the caller's intent is "dispatch in
-# background, let claude itself emit a task-too-short error if needed".
-# Other agents lack a --bg flag and the caller must reject the combination.
+# Optional 5th arg `use_bg` (issue #640, signature changed in #650):
+# when "1" and agent=claude, append `--bg "<prompt>"` so Agent View picks up
+# the dispatched session. Empty prompt yields `--bg ''` and lets claude itself
+# emit any task-too-short error. Other agents lack a --bg flag and the
+# caller must reject the combination.
+#
+# Optional 6th arg `prompt` (issue #650): the AI initial-task text. If
+# `use_bg` is 1, the prompt becomes the --bg payload. Otherwise (claude
+# only) it is appended as the first positional arg so claude TUI opens
+# with that text as the first message.
 _tmux_add_agent_window() {
-    local session="$1" agent="$2" dir="$3" account="${4-}" bg_task="${5-}"
+    local session="$1" agent="$2" dir="$3" account="${4-}" use_bg="${5-0}" prompt="${6-}"
     local yolo win
     if [ "$agent" = "claude" ] && [ -n "$account" ]; then
         yolo="${agent}-yolo --user ${account}"
     else
         yolo="${agent}-yolo"
     fi
-    # Background dispatch passthrough (#640). Single-quote-escape the task
-    # string so tmux send-keys passes it through verbatim. The "$#" check
-    # distinguishes "no 5th arg" (no --bg) from "5th arg present, empty"
-    # (--bg with empty task).
-    if [ "$agent" = "claude" ] && [ "$#" -ge 5 ]; then
-        local _ts_bg_esc
-        _ts_bg_esc=$(printf '%s' "$bg_task" | sed "s/'/'\\\\''/g")
-        yolo="${yolo} --bg '${_ts_bg_esc}'"
+    # Single-quote-escape any prompt text so tmux send-keys passes it
+    # through verbatim through the eventual `eval` inside the agent yolo.
+    if [ "$agent" = "claude" ] && [ "$use_bg" = 1 ]; then
+        local _ts_p_esc
+        _ts_p_esc=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
+        yolo="${yolo} --bg '${_ts_p_esc}'"
+    elif [ "$agent" = "claude" ] && [ -n "$prompt" ]; then
+        local _ts_p_esc
+        _ts_p_esc=$(printf '%s' "$prompt" | sed "s/'/'\\\\''/g")
+        yolo="${yolo} '${_ts_p_esc}'"
     fi
 
     if tmux has-session -t "=$session" 2>/dev/null; then

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -57,7 +57,7 @@ teardown() {
     # The key assertion: an unknown agent must produce a helpful error.
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --tmux --ai notarealagent 2>&1
+        git_worktree_spawn --wt-name issue-xyz --tmux --ai notarealagent 2>&1
     "
     assert_failure
     assert_output --partial "Unknown agent: notarealagent"
@@ -85,7 +85,7 @@ teardown() {
 @test "bash: spawn rejects --tmux and --launch together" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --tmux --launch 2>&1
+        git_worktree_spawn --wt-name issue-xyz --tmux --launch 2>&1
     "
     assert_failure
     assert_output --partial "mutually exclusive"
@@ -94,7 +94,7 @@ teardown() {
 @test "zsh: spawn rejects --tmux and --launch together" {
     run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --tmux --launch 2>&1
+        git_worktree_spawn --wt-name issue-xyz --tmux --launch 2>&1
     "
     assert_failure
     assert_output --partial "mutually exclusive"
@@ -103,7 +103,7 @@ teardown() {
 @test "bash: spawn rejects unknown agent when --launch is used" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --ai notarealagent 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --ai notarealagent 2>&1
     "
     assert_failure
     assert_output --partial "Unknown agent: notarealagent"
@@ -112,7 +112,7 @@ teardown() {
 @test "zsh: spawn rejects unknown agent when --launch is used" {
     run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --ai notarealagent 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --ai notarealagent 2>&1
     "
     assert_failure
     assert_output --partial "Unknown agent: notarealagent"
@@ -128,7 +128,7 @@ teardown() {
     run_in_bash "
         cd '$FAKE_REPO' || exit 1
         git branch wt/feat/1
-        git_worktree_spawn feat 2>&1
+        git_worktree_spawn --wt-name feat 2>&1
         git show-ref --verify --quiet refs/heads/wt/feat/2 && echo BRANCH2_OK
         [ -d '$TEST_TEMP_HOME/fake-main-feat-2' ] && echo PATH2_OK
     "
@@ -276,7 +276,7 @@ teardown() {
 @test "bash: spawn rejects --user without --tmux or --launch" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --user work 2>&1
+        git_worktree_spawn --wt-name issue-xyz --user work 2>&1
     "
     assert_failure
     assert_output --partial "--user requires --tmux or --launch"
@@ -285,7 +285,7 @@ teardown() {
 @test "bash: spawn rejects --user with non-claude agent (--launch)" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --ai codex --user work 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --ai codex --user work 2>&1
     "
     assert_failure
     assert_output --partial "--user is only supported with --ai claude"
@@ -294,7 +294,7 @@ teardown() {
 @test "bash: spawn rejects --user with non-claude agent (--tmux)" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --tmux --ai gemini --user work 2>&1
+        git_worktree_spawn --wt-name issue-xyz --tmux --ai gemini --user work 2>&1
     "
     assert_failure
     assert_output --partial "--user is only supported with --ai claude"
@@ -305,7 +305,7 @@ teardown() {
     # same "Available: ..." hint as `claude_yolo --user xyz` would print.
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --user nonexistent-account 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --user nonexistent-account 2>&1
     "
     assert_failure
     assert_output --partial "Unknown account: nonexistent-account"
@@ -315,7 +315,7 @@ teardown() {
 @test "zsh: spawn rejects unknown account with helpful list" {
     run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --user nonexistent-account 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --user nonexistent-account 2>&1
     "
     assert_failure
     assert_output --partial "Unknown account: nonexistent-account"
@@ -324,7 +324,7 @@ teardown() {
 @test "zsh: spawn rejects --user with non-claude agent" {
     run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --ai codex --user work 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --ai codex --user work 2>&1
     "
     assert_failure
     assert_output --partial "--user is only supported with --ai claude"
@@ -355,7 +355,7 @@ teardown() {
     # the typo loudly.
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --bg 2>&1
+        git_worktree_spawn --wt-name issue-xyz --bg 2>&1
     "
     assert_failure
     assert_output --partial "--bg requires --launch or --tmux"
@@ -365,7 +365,7 @@ teardown() {
     # Multi-agent guard: only claude has Agent View / --bg today.
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --launch --ai codex --bg 2>&1
+        git_worktree_spawn --wt-name issue-xyz --launch --ai codex --bg 2>&1
     "
     assert_failure
     assert_output --partial "--bg is only supported with --ai claude"
@@ -374,7 +374,7 @@ teardown() {
 @test "zsh: spawn rejects --bg without --launch or --tmux" {
     run_in_zsh "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn issue-xyz --bg 2>&1
+        git_worktree_spawn --wt-name issue-xyz --bg 2>&1
     "
     assert_failure
     assert_output --partial "--bg requires --launch or --tmux"
@@ -397,7 +397,7 @@ teardown() {
             for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
             printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
         }
-        git_worktree_spawn issue-bgempty --launch --bg >/dev/null 2>&1
+        git_worktree_spawn --wt-name issue-bgempty --launch --bg >/dev/null 2>&1
         cat \"\$MARKER\"
     "
     assert_success
@@ -405,7 +405,7 @@ teardown() {
     assert_output "|--bg|"
 }
 
-@test "bash: spawn --launch --bg with task passes the task string through" {
+@test "bash: spawn --launch --bg --prompt passes the joined prompt through (#650)" {
     run_in_bash "
         cd '$FAKE_REPO' || exit 1
         MARKER='$TEST_TEMP_HOME/spawn-bg-task-marker'
@@ -415,12 +415,12 @@ teardown() {
             for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
             printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
         }
-        git_worktree_spawn issue-bgtask --launch --bg 'fix login flow' >/dev/null 2>&1
+        git_worktree_spawn --launch --bg --wt-name issue-bgtask --prompt fix login flow >/dev/null 2>&1
         cat \"\$MARKER\"
     "
     assert_success
-    # The task string survives shell quoting through eval — 2 args, second
-    # carries spaces verbatim.
+    # --prompt joins remaining tokens with single spaces — survives eval as
+    # a single argv element to claude_yolo.
     assert_output "|--bg|fix login flow"
 }
 
@@ -439,7 +439,7 @@ teardown() {
             for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
             printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
         }
-        git_worktree_spawn issue-bgwork --launch --user work --bg >/dev/null 2>&1
+        git_worktree_spawn --wt-name issue-bgwork --launch --user work --bg >/dev/null 2>&1
         cat \"\$MARKER\"
     "
     assert_success
@@ -458,10 +458,198 @@ teardown() {
             for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
             printf '%s\n' \"[\$_cy_recorded]\" > \"\$MARKER\"
         }
-        git_worktree_spawn issue-nobg --launch >/dev/null 2>&1
+        git_worktree_spawn --wt-name issue-nobg --launch >/dev/null 2>&1
         cat \"\$MARKER\"
     "
     assert_success
     # Empty arg list — claude_yolo invoked with zero extra args.
     assert_output "[]"
+}
+
+# ---------------------------------------------------------------------------
+# Issue #650: option-only grammar — --wt-name (required), --prompt (trailing),
+# hard-break removal of positional <name>, --task, and --bg's optional task.
+# Each test maps to one AC in the issue body.
+# ---------------------------------------------------------------------------
+
+@test "bash: AC-1 spawn --launch --wt-name issue-11 succeeds (option-only call)" {
+    # End-to-end smoke that the new grammar is recognized at all.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-ac1-marker'
+        export MARKER
+        claude_yolo() { printf 'called\n' > \"\$MARKER\"; }
+        git_worktree_spawn --launch --wt-name issue-11 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output --partial "called"
+}
+
+@test "bash: AC-2 spawn --launch --user --prompt joins trailing tokens (#650)" {
+    # AC-2 + AC-9 path together: --prompt joins all remaining tokens with
+    # single spaces, threads through --user, and lands on claude_yolo as a
+    # single argv element.
+    run_in_bash "
+        mkdir -p '$HOME/.claude-work1'
+        export CLAUDE_ENABLED_ACCOUNTS='personal work1'
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-ac2-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --ai claude --user work1 --wt-name issue-717 \
+            --prompt 이슈 717 내용 읽고 요약해. >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--user|work1|이슈 717 내용 읽고 요약해."
+}
+
+@test "bash: AC-3 spawn --launch --bg without --prompt sends empty payload" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-ac3-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --bg --wt-name issue-718 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--bg|"
+}
+
+@test "bash: AC-4 spawn --launch --bg --prompt threads multi-token prompt to --bg" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-ac4-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --bg --ai claude --wt-name issue-718 \
+            --prompt 오늘의 날씨 검색해 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--bg|오늘의 날씨 검색해"
+}
+
+@test "bash: AC-6 hard-break — positional <name> errors with --wt-name fix-it" {
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-11 --launch 2>&1
+    "
+    assert_failure
+    assert_output --partial "Positional <name> is no longer supported."
+    assert_output --partial "--wt-name issue-11"
+    assert_output --partial "--launch"
+}
+
+@test "bash: AC-7 hard-break — --task errors with --prompt fix-it" {
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn --wt-name foo --task auth 2>&1
+    "
+    assert_failure
+    assert_output --partial "--task flag has been removed"
+    assert_output --partial "--prompt"
+}
+
+@test "bash: AC-8 missing --wt-name errors cleanly" {
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn --launch 2>&1
+    "
+    assert_failure
+    assert_output --partial "<name> is required"
+    assert_output --partial "--wt-name"
+}
+
+@test "bash: AC-10 token after --prompt that looks like a flag triggers warning" {
+    # `--launch` after `--prompt` is absorbed into prompt text. The warning
+    # is emitted ONCE on stderr; the spawn still succeeds.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-ac10-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        # Provide --launch BEFORE --prompt so dispatch happens; the
+        # second --launch is the one that should be absorbed.
+        git_worktree_spawn --launch --wt-name issue-ac10 \
+            --prompt do thing --launch then more 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output --partial "consumed as prompt text"
+    assert_output --partial "|do thing --launch then more"
+}
+
+@test "bash: AC-11 --bg consumes no positional task — bare token errors as positional" {
+    # --bg is a pure boolean now; the next non-flag token (foo) hits the
+    # AC-6 positional guard rather than being silently swallowed.
+    run_in_bash "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn --launch --bg foo --wt-name issue-bg11 2>&1
+    "
+    assert_failure
+    assert_output --partial "Positional <name> is no longer supported."
+}
+
+@test "zsh: AC-6 hard-break — positional <name> errors under zsh" {
+    run_in_zsh "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn issue-11 --launch 2>&1
+    "
+    assert_failure
+    assert_output --partial "Positional <name> is no longer supported."
+}
+
+@test "zsh: AC-7 hard-break — --task errors under zsh" {
+    run_in_zsh "
+        cd '${DOTFILES_ROOT}' || exit 1
+        git_worktree_spawn --wt-name foo --task auth 2>&1
+    "
+    assert_failure
+    assert_output --partial "--task flag has been removed"
+}
+
+@test "bash: spawn --help mentions --wt-name and --prompt (#650)" {
+    run_in_bash 'git_worktree_spawn --help'
+    assert_success
+    assert_output --partial "--wt-name"
+    assert_output --partial "--prompt"
+    assert_output --partial "Removed (#650)"
+}
+
+@test "bash: spawn --launch --prompt without --bg passes prompt as TUI first message" {
+    # Behavior matrix: --prompt without --bg → claude_yolo 'X Y' (no --bg).
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-prompt-only-marker'
+        export MARKER
+        claude_yolo() {
+            local _cy_recorded=''
+            for _a in \"\$@\"; do _cy_recorded=\"\${_cy_recorded}|\$_a\"; done
+            printf '%s\n' \"\$_cy_recorded\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --wt-name issue-tui --prompt hello world >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    # Single positional arg, no --bg.
+    assert_output "|hello world"
 }

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -551,7 +551,9 @@ teardown() {
     "
     assert_failure
     assert_output --partial "Positional <name> is no longer supported."
-    assert_output --partial "--wt-name issue-11"
+    # The name in the fix-it hint is single-quoted (PR #652 review:
+    # copy-paste safe with paths/names that contain spaces).
+    assert_output --partial "--wt-name 'issue-11'"
     assert_output --partial "--launch"
 }
 


### PR DESCRIPTION
## Summary
- `gwt spawn` 그래머를 option-only로 재설계 — 위치 인자 `<name>`와 `--task <slug>`를 제거하고 `--wt-name <slug>` (required) + `--prompt <text...>` (trailing) 도입.
- `--bg`는 boolean으로 단순화. AI 초기 메시지는 `--prompt`로 분리되어 호출 순서·자동화 친화성 확보.
- 마지막 토큰이 가장 자주 바뀌는 사용자 패턴(`--prompt` trailing-join)에 정렬, hard-break 마이그레이션 에러로 잘못된 호출을 정확한 fix-it 명령으로 안내.

## Changes
- `shell-common/functions/git_worktree.sh`
  - help 전면 재작성: Required / Optional / Trailing / Removed 섹션 구분, 새 예시 6종.
  - parser 재작성: `--wt-name`/`--prompt` 추가, 위치인자/`--task` 제거, `--bg`의 optional-positional 제거. `--prompt` 이후 모든 토큰을 단일 공백 join (AC-9). 흡수된 토큰이 known-flag면 stderr에 1회 warning (AC-10).
  - dispatch: behavior matrix 그대로 구현 — `--bg`가 있으면 `--bg "<prompt>"`, 없고 `--prompt`만 있으면 `claude_yolo "<prompt>"` (TUI 첫 메시지).
  - branch suffix 로직 (`--task → slug`) 제거 — 항상 `wt/<name>/<index>`.
- `shell-common/functions/tmux_spawn.sh`
  - `_tmux_add_agent_window` 시그니처를 `(bg_task)`에서 `(use_bg, prompt)`로 분리. 기존 호출부 모두 갱신.
- `shell-common/AGENTS.md`
  - Agent View dispatch 섹션을 신문법으로 갱신, `--prompt` only / `--bg` only / 조합 케이스 3종 명시.
- `tests/bats/functions/git_worktree_spawn.bats`
  - 기존 위치-인자 호출 모두 `--wt-name`으로 마이그레이션 (sed 일괄).
  - `--bg 'fix login flow'` → `--bg --prompt fix login flow`로 갱신.
  - AC-1~AC-4, AC-6~AC-8, AC-10, AC-11 신규 회귀 + zsh 미러. 총 59 테스트 통과 (기존 46 + 신규 13).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_spawn.bats` → 59/59 통과
- [x] `bash -n` 구문 점검 — git_worktree.sh, tmux_spawn.sh OK
- [x] `shellcheck -x` — 신규 경고 0개 (기존 SC2002/SC2059 pre-existing only)
- [x] `tox -e ruff,shellcheck,shfmt` — 전 항목 OK (pre-push lint guard 통과)
- [ ] 수동 시나리오 (AC-1~AC-11):
  - [ ] `gwt spawn --launch --wt-name issue-11`
  - [ ] `gwt spawn --launch --ai claude --user work1 --wt-name issue-717 --prompt 이슈 717 요약해`
  - [ ] `gwt spawn --launch --bg --wt-name issue-718`
  - [ ] `gwt spawn --launch --bg --wt-name issue-718 --prompt 오늘의 날씨 검색해`
  - [ ] `gwt spawn issue-old --launch` → 위치-인자 마이그레이션 에러 + fix-it 명령
  - [ ] `gwt spawn --wt-name foo --task auth` → `--task` removed 마이그레이션 에러

## Related
Closes #650

---
<details>
<summary>🤖 AI Metrics · 📊 ~10500 tokens · 👤 ~4 h · 🤖 ~32 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~10500 tokens · 👤 ~4 h · 🤖 ~32 min
<!-- /ai-metrics:gh-pr -->

</details>
