### PR TITLE
feat(ai-usage): #651 retry transient API errors (ECONNRESET 등) in claude branch

### DIFF
--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -154,11 +154,22 @@ _ai_usage_run() {
             # CLI exit code. Workers rely on a non-zero return to flip
             # state to failed:*, so propagate is_error as exit 1.
             _is_error=$(jq -r '.is_error // false' <"$_tmp" 2>/dev/null)
-            _result=$(jq -r '.result // ""' <"$_tmp" 2>/dev/null)
 
             # Echo just the human-readable result so the worker's log stays
             # legible. The full JSON lives in usage.jsonl for diagnostics.
-            printf '%s\n' "$_result"
+            # Only capture `_result` into a shell variable on the error
+            # path — that's where the transient classifier needs it.
+            # Successful responses can be very large (full assistant
+            # output); streaming them straight to stdout avoids buffering
+            # the whole payload into a shell variable and the ARG_MAX
+            # risk that would create if something later passed it on
+            # the command line. (gemini-code-assist review on PR #653.)
+            if [ "$_is_error" = "true" ]; then
+                _result=$(jq -r '.result // ""' <"$_tmp" 2>/dev/null)
+                printf '%s\n' "$_result"
+            else
+                jq -r '.result // ""' <"$_tmp" 2>/dev/null
+            fi
 
             # Append a compact, jq-friendly record. Keep usage/modelUsage
             # nested so per-model cost can be broken out later if needed.

--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -49,6 +49,25 @@ _ai_usage_now() {
     date -Iseconds 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+# Classify a claude `.result` string as a transient network error worth
+# retrying. Pattern set comes from issue #651 (PR #726 retrospective):
+# ECONNRESET / ETIMEDOUT / EHOSTUNREACH / EAI_AGAIN are libuv/Node socket
+# errors surfaced by the proxy stack; "fetch failed" is the upstream JS
+# fetch wrapper's terse error. All four are routinely seen on the
+# Samsung internal LLM gateway and clear on a 2-4 s backoff. Permanent
+# errors (auth, 4xx, model not found) do NOT match — the caller stays
+# fail-closed on those, matching pre-retry behaviour.
+_ai_usage_is_transient() {
+    case "$1" in
+    *ECONNRESET* | *ETIMEDOUT* | *EHOSTUNREACH* | *EAI_AGAIN* | *"fetch failed"*)
+        return 0
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # Public: run one AI prompt and append a usage record to <log>
 # ---------------------------------------------------------------------------
@@ -89,66 +108,92 @@ _ai_usage_run() {
 
     case "$_ai" in
     claude)
-        # Capture JSON to a tempfile so we can both (a) print the human
-        # result to the worker log and (b) parse usage. Stderr passes
-        # through untouched — claude prints diagnostic noise there and
-        # we want the worker log to still see it.
-        _tmp=$(mktemp -t ai_usage.XXXXXX) || {
-            printf '[ai-usage] mktemp failed; running without tracking\n' >&2
-            claude --dangerously-skip-permissions -p "$_prompt"
-            return $?
-        }
+        # Issue #651: when the assistant returns `is_error: true` with a
+        # transient network result (ECONNRESET etc.), retry up to
+        # AI_USAGE_RETRY_TRANSIENT_MAX (default 2) times with exponential
+        # backoff. Each attempt writes its own usage.jsonl record so
+        # cost tracking stays accurate. Set max=0 to restore the
+        # pre-#651 fail-closed-on-first-error behaviour.
+        local _attempt=0
+        local _max=${AI_USAGE_RETRY_TRANSIENT_MAX:-2}
+        local _base=${AI_USAGE_RETRY_SLEEP_BASE:-1}
+        local _result _sleep_secs
+        while :; do
+            # Capture JSON to a tempfile so we can both (a) print the human
+            # result to the worker log and (b) parse usage. Stderr passes
+            # through untouched — claude prints diagnostic noise there and
+            # we want the worker log to still see it.
+            _tmp=$(mktemp -t ai_usage.XXXXXX) || {
+                printf '[ai-usage] mktemp failed; running without tracking\n' >&2
+                claude --dangerously-skip-permissions -p "$_prompt"
+                return $?
+            }
 
-        claude --dangerously-skip-permissions -p "$_prompt" --output-format json >"$_tmp"
-        _ec=$?
+            # Per-attempt timestamp so retry records sort correctly.
+            _now=$(_ai_usage_now)
 
-        # If the CLI itself crashed (network, auth, etc.) we have no
-        # JSON to parse. Still record the failure so the summary's
-        # invocation count includes it, then echo whatever stdout
-        # produced (likely an error message).
-        if [ "$_ec" -ne 0 ] || ! [ -s "$_tmp" ]; then
-            printf '{"ai":"claude","ts":"%s","label":%s,"exit_code":%d,"tracking":"cli_failed"}\n' \
-                "$_now" \
-                "$(printf '%s' "$_label" | jq -Rsc . 2>/dev/null || printf '"%s"' "$_label")" \
-                "$_ec" >>"$_log"
-            cat "$_tmp" 2>/dev/null
+            claude --dangerously-skip-permissions -p "$_prompt" --output-format json >"$_tmp"
+            _ec=$?
+
+            # If the CLI itself crashed (network, auth, etc.) we have no
+            # JSON to parse. Still record the failure so the summary's
+            # invocation count includes it, then echo whatever stdout
+            # produced (likely an error message). Don't retry CLI-level
+            # crashes — they're usually auth/config, not transient.
+            if [ "$_ec" -ne 0 ] || ! [ -s "$_tmp" ]; then
+                printf '{"ai":"claude","ts":"%s","label":%s,"exit_code":%d,"tracking":"cli_failed"}\n' \
+                    "$_now" \
+                    "$(printf '%s' "$_label" | jq -Rsc . 2>/dev/null || printf '"%s"' "$_label")" \
+                    "$_ec" >>"$_log"
+                cat "$_tmp" 2>/dev/null
+                rm -f "$_tmp"
+                return $_ec
+            fi
+
+            # is_error reflects "the assistant failed", separate from the
+            # CLI exit code. Workers rely on a non-zero return to flip
+            # state to failed:*, so propagate is_error as exit 1.
+            _is_error=$(jq -r '.is_error // false' <"$_tmp" 2>/dev/null)
+            _result=$(jq -r '.result // ""' <"$_tmp" 2>/dev/null)
+
+            # Echo just the human-readable result so the worker's log stays
+            # legible. The full JSON lives in usage.jsonl for diagnostics.
+            printf '%s\n' "$_result"
+
+            # Append a compact, jq-friendly record. Keep usage/modelUsage
+            # nested so per-model cost can be broken out later if needed.
+            jq -c \
+                --arg ts "$_now" \
+                --arg label "$_label" \
+                '{
+                    ai: "claude",
+                    ts: $ts,
+                    label: $label,
+                    session_id: .session_id,
+                    is_error: (.is_error // false),
+                    num_turns: (.num_turns // 0),
+                    duration_ms: (.duration_ms // 0),
+                    duration_api_ms: (.duration_api_ms // 0),
+                    total_cost_usd: (.total_cost_usd // 0),
+                    usage: (.usage // {}),
+                    modelUsage: (.modelUsage // {})
+                }' <"$_tmp" >>"$_log" 2>/dev/null
+
             rm -f "$_tmp"
-            return $_ec
-        fi
 
-        # is_error reflects "the assistant failed", separate from the
-        # CLI exit code. Workers rely on a non-zero return to flip
-        # state to failed:*, so propagate is_error as exit 1.
-        _is_error=$(jq -r '.is_error // false' <"$_tmp" 2>/dev/null)
-
-        # Echo just the human-readable result so the worker's log stays
-        # legible. The full JSON lives in usage.jsonl for diagnostics.
-        jq -r '.result // ""' <"$_tmp" 2>/dev/null
-
-        # Append a compact, jq-friendly record. Keep usage/modelUsage
-        # nested so per-model cost can be broken out later if needed.
-        jq -c \
-            --arg ts "$_now" \
-            --arg label "$_label" \
-            '{
-                ai: "claude",
-                ts: $ts,
-                label: $label,
-                session_id: .session_id,
-                is_error: (.is_error // false),
-                num_turns: (.num_turns // 0),
-                duration_ms: (.duration_ms // 0),
-                duration_api_ms: (.duration_api_ms // 0),
-                total_cost_usd: (.total_cost_usd // 0),
-                usage: (.usage // {}),
-                modelUsage: (.modelUsage // {})
-            }' <"$_tmp" >>"$_log" 2>/dev/null
-
-        rm -f "$_tmp"
-        if [ "$_is_error" = "true" ]; then
-            return 1
-        fi
-        return 0
+            if [ "$_is_error" = "true" ]; then
+                if _ai_usage_is_transient "$_result" && [ "$_attempt" -lt "$_max" ]; then
+                    _attempt=$((_attempt + 1))
+                    _sleep_secs=$((_base * (1 << _attempt)))
+                    printf '[ai-usage] transient error (attempt %d/%d) — retrying in %ds: %s\n' \
+                        "$_attempt" "$_max" "$_sleep_secs" "$_result" >&2
+                    sleep "$_sleep_secs"
+                    continue
+                fi
+                return 1
+            fi
+            return 0
+        done
         ;;
     codex)
         _tmp=$(mktemp -t ai_usage_codex.XXXXXX) || {

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -1,0 +1,269 @@
+#!/usr/bin/env bats
+# tests/bats/functions/ai_usage.bats
+# Unit tests for _ai_usage_run's transient-error retry (issue #651).
+#
+# Background: PR #726's worker burned $0.28 / 14 turns because a single
+# ECONNRESET from the proxy was treated as a permanent failure. The fix
+# wraps the claude branch in a retry loop that classifies API errors
+# matching ECONNRESET/ETIMEDOUT/EHOSTUNREACH/EAI_AGAIN/"fetch failed" as
+# transient and retries up to AI_USAGE_RETRY_TRANSIENT_MAX times.
+#
+# Strategy: stub `claude` via PATH so each invocation reads
+# $CLAUDE_ATTEMPT_COUNTER, increments it, and emits the JSON staged
+# under $CLAUDE_RESPONSES_DIR/attempt<N>.json (last file is reused if
+# the counter overshoots). Tests verify return code, retry count, and
+# usage.jsonl record cardinality. AI_USAGE_RETRY_SLEEP_BASE=0 keeps
+# sleeps at zero so tests are fast.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    _setup_claude_stub
+}
+
+teardown() {
+    teardown_isolated_home
+    unset AI_USAGE_RETRY_TRANSIENT_MAX AI_USAGE_RETRY_SLEEP_BASE
+}
+
+# Stage a PATH directory with a stubbed `claude` that replays canned
+# JSON responses from $CLAUDE_RESPONSES_DIR. The stub bumps a counter
+# file on each invocation so a test can assert "called N times".
+_setup_claude_stub() {
+    STUB_BIN="$TEST_TEMP_HOME/stub-bin"
+    CLAUDE_RESPONSES_DIR="$TEST_TEMP_HOME/claude-responses"
+    CLAUDE_ATTEMPT_COUNTER="$TEST_TEMP_HOME/claude-attempts"
+    USAGE_LOG="$TEST_TEMP_HOME/usage.jsonl"
+    mkdir -p "$STUB_BIN" "$CLAUDE_RESPONSES_DIR"
+    : >"$CLAUDE_ATTEMPT_COUNTER"
+
+    cat >"$STUB_BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+# Stub claude — replay $CLAUDE_RESPONSES_DIR/attempt<N>.json based on
+# the counter in $CLAUDE_ATTEMPT_COUNTER. The shape we emit matches
+# what `claude --output-format json` would produce.
+n=$(cat "$CLAUDE_ATTEMPT_COUNTER" 2>/dev/null)
+n=$((${n:-0} + 1))
+printf '%s\n' "$n" >"$CLAUDE_ATTEMPT_COUNTER"
+
+response="$CLAUDE_RESPONSES_DIR/attempt${n}.json"
+if [ ! -f "$response" ]; then
+    # Fall back to the highest-numbered response so "more retries than
+    # staged JSON" reuses the last canned answer.
+    response=$(ls "$CLAUDE_RESPONSES_DIR"/attempt*.json 2>/dev/null | sort -V | tail -1)
+fi
+cat "$response"
+exit 0
+STUB
+    chmod +x "$STUB_BIN/claude"
+}
+
+# Stage a fake claude JSON response for attempt N.
+#   _stage_response <n> transient|permanent|success
+_stage_response() {
+    local n="$1" kind="$2"
+    local file="$CLAUDE_RESPONSES_DIR/attempt${n}.json"
+    case "$kind" in
+    transient)
+        cat >"$file" <<'JSON'
+{"is_error":true,"result":"API Error: Unable to connect to API (ECONNRESET)","num_turns":0,"duration_ms":1500,"duration_api_ms":1500,"total_cost_usd":0,"session_id":"sess-transient","usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"modelUsage":{}}
+JSON
+        ;;
+    permanent)
+        cat >"$file" <<'JSON'
+{"is_error":true,"result":"Authentication failed: invalid API key","num_turns":1,"duration_ms":500,"duration_api_ms":500,"total_cost_usd":0,"session_id":"sess-permanent","usage":{"input_tokens":5,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"modelUsage":{}}
+JSON
+        ;;
+    success)
+        cat >"$file" <<'JSON'
+{"is_error":false,"result":"ok","num_turns":2,"duration_ms":2000,"duration_api_ms":1900,"total_cost_usd":0.01,"session_id":"sess-ok","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"modelUsage":{"claude-3-5-sonnet":{}}}
+JSON
+        ;;
+    esac
+}
+
+# Run _ai_usage_run with the stubbed claude on PATH, retry sleep
+# disabled (AI_USAGE_RETRY_SLEEP_BASE=0), and the given env vars.
+#   _run_ai_usage [max-retries] [extra exports]
+_run_ai_usage() {
+    local max="${1:-2}"
+    local extra="${2:-}"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:/usr/bin:/bin'
+        export CLAUDE_RESPONSES_DIR='${CLAUDE_RESPONSES_DIR}'
+        export CLAUDE_ATTEMPT_COUNTER='${CLAUDE_ATTEMPT_COUNTER}'
+        export AI_USAGE_RETRY_TRANSIENT_MAX='${max}'
+        export AI_USAGE_RETRY_SLEEP_BASE=0
+        ${extra}
+        . '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh'
+        _ai_usage_run claude '${USAGE_LOG}' 'test-label' 'fake-prompt'
+        echo \"rc=\$?\"
+    "
+}
+
+_attempt_count() {
+    cat "$CLAUDE_ATTEMPT_COUNTER" 2>/dev/null || echo 0
+}
+
+_usage_record_count() {
+    if [ -s "$USAGE_LOG" ]; then
+        wc -l <"$USAGE_LOG" | tr -d ' '
+    else
+        echo 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Classifier — exposed so other call sites can grow their own retry
+# loops without re-deriving the pattern set.
+# ---------------------------------------------------------------------------
+
+@test "classifier: ECONNRESET is transient" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'API Error: Unable to connect to API (ECONNRESET)' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
+@test "classifier: ETIMEDOUT is transient" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'fetch failed: ETIMEDOUT' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
+@test "classifier: EAI_AGAIN is transient" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'getaddrinfo EAI_AGAIN api.anthropic.com' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
+@test "classifier: 'fetch failed' alone is transient" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'API Error: fetch failed' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
+@test "classifier: auth error is NOT transient" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 if _ai_usage_is_transient 'Authentication failed: invalid API key'; \
+                 then echo transient; else echo permanent; fi"
+    assert_success
+    assert_output --partial "permanent"
+}
+
+@test "classifier: empty string is NOT transient" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 if _ai_usage_is_transient ''; \
+                 then echo transient; else echo permanent; fi"
+    assert_success
+    assert_output --partial "permanent"
+}
+
+# ---------------------------------------------------------------------------
+# Retry loop — the issue #651 fix.
+# ---------------------------------------------------------------------------
+
+@test "retry: ECONNRESET twice then success → rc=0, claude called 3 times" {
+    _stage_response 1 transient
+    _stage_response 2 transient
+    _stage_response 3 success
+
+    _run_ai_usage 2
+
+    assert_output --partial "rc=0"
+    [ "$(_attempt_count)" -eq 3 ]
+    # Each attempt appends one record (2 errors + 1 success).
+    [ "$(_usage_record_count)" -eq 3 ]
+}
+
+@test "retry: single ECONNRESET then success → rc=0, called 2 times" {
+    _stage_response 1 transient
+    _stage_response 2 success
+
+    _run_ai_usage 2
+
+    assert_output --partial "rc=0"
+    [ "$(_attempt_count)" -eq 2 ]
+    [ "$(_usage_record_count)" -eq 2 ]
+}
+
+@test "retry: max=0 disables retry (pre-#651 behaviour)" {
+    _stage_response 1 transient
+    _stage_response 2 success
+
+    _run_ai_usage 0
+
+    # rc=1 because is_error=true and no retry → first record's error
+    # propagates as exit 1, identical to pre-#651 behaviour.
+    assert_output --partial "rc=1"
+    [ "$(_attempt_count)" -eq 1 ]
+    [ "$(_usage_record_count)" -eq 1 ]
+}
+
+@test "retry: permanent error is NOT retried" {
+    _stage_response 1 permanent
+    _stage_response 2 success
+
+    _run_ai_usage 2
+
+    # Auth failure doesn't match the transient pattern → first attempt
+    # returns 1 immediately, success.json on attempt 2 is never read.
+    assert_output --partial "rc=1"
+    [ "$(_attempt_count)" -eq 1 ]
+    [ "$(_usage_record_count)" -eq 1 ]
+}
+
+@test "retry: exhausts max retries → rc=1 with full attempt budget" {
+    # All attempts return transient → loop hits the budget and returns
+    # the final is_error as failure. claude is called max+1 times
+    # (initial attempt + max retries).
+    _stage_response 1 transient
+    _stage_response 2 transient
+    _stage_response 3 transient
+
+    _run_ai_usage 2
+
+    assert_output --partial "rc=1"
+    [ "$(_attempt_count)" -eq 3 ]
+    [ "$(_usage_record_count)" -eq 3 ]
+}
+
+@test "retry: success on first attempt → no retry, 1 record" {
+    _stage_response 1 success
+
+    _run_ai_usage 2
+
+    assert_output --partial "rc=0"
+    [ "$(_attempt_count)" -eq 1 ]
+    [ "$(_usage_record_count)" -eq 1 ]
+}
+
+@test "retry: each retry writes its own usage.jsonl record (cost tracking preserved)" {
+    # The issue's main constraint: retries must not silently drop their
+    # cost records — the worker still needs to see every API call in
+    # usage.jsonl so the summary's `claude.total_cost_usd` adds up.
+    _stage_response 1 transient
+    _stage_response 2 success
+
+    _run_ai_usage 2
+
+    assert_output --partial "rc=0"
+    # 2 records. Both must have session_id (which proves jq parsed them
+    # rather than falling through to the cli_failed shim).
+    [ "$(jq -s 'length' "$USAGE_LOG")" = "2" ]
+    [ "$(jq -s '[.[] | select(.session_id != null)] | length' "$USAGE_LOG")" = "2" ]
+}

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -51,7 +51,14 @@ response="$CLAUDE_RESPONSES_DIR/attempt${n}.json"
 if [ ! -f "$response" ]; then
     # Fall back to the highest-numbered response so "more retries than
     # staged JSON" reuses the last canned answer.
-    response=$(ls "$CLAUDE_RESPONSES_DIR"/attempt*.json 2>/dev/null | sort -V | tail -1)
+    #
+    # Plain `sort` (not `sort -V`) — `-V` is a GNU extension and the
+    # default `sort` on BSD/macOS does not ship it. Tests stage at most
+    # single-digit attempt indices (attempt1..attempt9), so plain
+    # lexicographic order is correct here. Parameter-expansion fallback
+    # protects against the glob expanding to nothing on a malformed run.
+    response=$(ls "$CLAUDE_RESPONSES_DIR"/attempt*.json 2>/dev/null | sort | tail -1)
+    response=${response:-""}
 fi
 cat "$response"
 exit 0


### PR DESCRIPTION
## Summary
- claude branch의 `_ai_usage_run`이 `is_error: true` 응답을 만나면 무조건 fail-close 하던 동작을 고쳐서, 프록시 환경에서 흔한 ECONNRESET 등 transient 네트워크 에러는 자동 재시도하도록 함
- PR #726 회고에서 단 한 번의 ECONNRESET 으로 14턴/$0.28 분량 컨텍스트가 날아갔던 패턴을 재발 방지
- 기존 의미적 실패(인증 오류, 4xx 등)는 그대로 fail-close — 가시적 동작 변화는 transient 에러에만 한정

## Changes
- `shell-common/functions/ai_usage.sh`
  - `_ai_usage_is_transient()` 분류기 추가. case-glob 으로 `ECONNRESET` / `ETIMEDOUT` / `EHOSTUNREACH` / `EAI_AGAIN` / `"fetch failed"` 5종 매칭. 인증/4xx 등 영구 실패는 미매칭 → 기존 fail-close 경로 유지.
  - claude 분기에 `while :` 재시도 루프 도입. 최대 시도 횟수는 `AI_USAGE_RETRY_TRANSIENT_MAX` (기본 2), 백오프는 `AI_USAGE_RETRY_SLEEP_BASE * (1 << attempt)` 초 (기본 2s, 4s).
  - 각 시도는 별도 `usage.jsonl` 레코드를 append — 비용 트래킹은 그대로 유지. 시도별 `ts` 도 매번 갱신.
  - `AI_USAGE_RETRY_TRANSIENT_MAX=0` 으로 설정 시 #651 이전 동작 그대로 복원 (회로 차단용).
  - CLI 레벨 크래시(`_ec != 0` 또는 JSON 부재) 는 재시도하지 않음 — 인증/설정 문제일 가능성이 높아 보수적으로 즉시 반환.

- `tests/bats/functions/ai_usage.bats` (신규, 13 케이스)
  - PATH 스텁으로 `claude` 를 가짜 응답으로 교체. 각 시도별 응답 JSON 을 `attempt<N>.json` 파일로 스테이지하고 카운터로 회수.
  - 분류기 6 케이스: ECONNRESET / ETIMEDOUT / EAI_AGAIN / "fetch failed" → transient, 인증 오류 / 빈 문자열 → permanent.
  - 재시도 7 케이스: 2회 transient → 성공, 1회 transient → 성공, max=0 비활성화, 영구 오류는 재시도 안함, 예산 소진, 첫 시도 성공, usage.jsonl 레코드 카디널리티 보존(`session_id` 모두 살아있음).

## Test plan
- [x] 신규 `tests/bats/functions/ai_usage.bats` 13/13 통과
- [x] 회귀 — 호출자 측 `gh_pr_approve.bats` + `gh_pr_reply.bats` + `gh_flow.bats` + `ai_usage.bats` 170/170 통과
- [x] `shellcheck shell-common/functions/ai_usage.sh` 클린
- [x] `tox -e shellcheck,shfmt,ruff` (lint guard 경유) 통과
- [ ] CI green 확인 후 머지

## Related
Closes #651

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
