### PR TITLE
fix(gh-workers): migrate gwt spawn callers to --wt-name (#650 follow-up)

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -984,7 +984,7 @@ _gh_flow_worker() {
     local _wt_before _wt_after
     _gh_flow_set_state "$_dir" "spawning"
     _wt_before=$(git worktree list --porcelain 2>/dev/null | awk '$1=="worktree"{print $2}')
-    if ! gwt spawn "$_spawn_name"; then
+    if ! gwt spawn --wt-name "$_spawn_name"; then
         _gh_flow_set_state "$_dir" "failed:spawning"
         printf '[gh-flow-worker] gwt spawn failed\n' >&2
         return 1

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -983,14 +983,14 @@ _gh_flow_worker() {
     # branch-naming convention (previously: parsing `wt/<name>/<idx>`).
     local _wt_before _wt_after
     _gh_flow_set_state "$_dir" "spawning"
-    _wt_before=$(git worktree list --porcelain 2>/dev/null | awk '$1=="worktree"{print $2}')
+    _wt_before=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
     if ! gwt spawn --wt-name "$_spawn_name"; then
         _gh_flow_set_state "$_dir" "failed:spawning"
         printf '[gh-flow-worker] gwt spawn failed\n' >&2
         return 1
     fi
 
-    _wt_after=$(git worktree list --porcelain 2>/dev/null | awk '$1=="worktree"{print $2}')
+    _wt_after=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
     _worktree=$(comm -13 \
         <(printf '%s\n' "$_wt_before" | sort) \
         <(printf '%s\n' "$_wt_after" | sort) |

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -1301,7 +1301,7 @@ _gh_pr_approve_worker() {
     local _wt_before
     _gh_pr_approve_set_state "$_dir" "spawning"
     _wt_before=$(_gh_pr_approve_worktree_paths)
-    if ! gwt spawn "$_spawn_name"; then
+    if ! gwt spawn --wt-name "$_spawn_name"; then
         _gh_pr_approve_set_state "$_dir" "failed:spawning"
         printf '[gh-pr-approve-worker] gwt spawn failed\n' >&2
         return 1

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -389,7 +389,7 @@ _gh_pr_reply_worker() {
     local _wt_before _wt_after
     _gh_pr_reply_set_state "$_dir" "spawning"
     _wt_before=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
-    if ! gwt spawn "$_spawn_name"; then
+    if ! gwt spawn --wt-name "$_spawn_name"; then
         _gh_pr_reply_set_state "$_dir" "failed:spawning"
         printf '[gh-pr-reply-worker] gwt spawn failed\n' >&2
         return 1


### PR DESCRIPTION
## Summary
- ea29fea (`feat(gwt-spawn): #650 grammar redesign`) hard-broke the positional `<name>` argument of `gwt spawn`, but the three internal workers that call `gwt spawn` were left on the old grammar — every fresh `gh-pr-approve` / `gh-pr-reply` / `gh-flow` run dies at the spawn step with "Positional <name> is no longer supported" and leaves a `failed:spawning` state file.
- 호출부 3개를 새 옵션 그래머 (`gwt spawn --wt-name "$_spawn_name"`) 로 마이그레이션. 동작·브랜치 명명 (`wt/<name>/<idx>`) 은 동일하게 유지.

## Changes
- `shell-common/functions/gh_pr_approve.sh:1304` — `gwt spawn "$_spawn_name"` → `gwt spawn --wt-name "$_spawn_name"`
- `shell-common/functions/gh_pr_reply.sh:392` — 동일
- `shell-common/functions/gh_flow.sh:987` — 동일

세 호출부 모두 1줄 surgical 수정. self-identification 경로 (`_locate_own_worktree` / `comm -13`) 는 새 parser 에서도 `wt/<name>/<idx>` 명명 규칙이 보존되어 변경 불필요.

## Test plan
- [x] `shellcheck -x shell-common/functions/gh_pr_approve.sh shell-common/functions/gh_pr_reply.sh shell-common/functions/gh_flow.sh` — baseline 과 동일 (pre-existing SC2002 외 신규 경고 없음)
- [x] `tox -e ruff,shellcheck,shfmt` (lint guard 통과)
- [ ] `gh-pr-approve <open-pr>` 실행 → `spawning` 후 `worktree=...` 진행, log 에 "Positional <name>" 메시지 없음
- [ ] `gh-pr-reply <pr>` 동일하게 spawn 정상
- [ ] `gh-flow <issue>` 동일하게 spawn 정상
- [ ] (follow-up 별도 이슈) worker bats 에 `gwt` mock 도입해 회귀 lock

## 회복 절차 (기존 stuck state 처리)
이미 `failed:spawning` 으로 박힌 PR/issue 디렉토리는 `gh-pr-approve prune <N>` (또는 해당 worker 의 prune) 으로 정리 후 재실행.

## Related
Fixes #654

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
