### PR TITLE
feat(skill): #658 add /devx:exception-merge-checklist 10-point pre-merge audit

### DIFF
--- a/claude/skills/devx-exception-merge-checklist/SKILL.md
+++ b/claude/skills/devx-exception-merge-checklist/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: devx:exception-merge-checklist
+description: >-
+  Run a 10-point read-only sanity check on a GitHub PR right before a
+  merge on the "exception track" (CI green but hand-merged with extra
+  scrutiny). Detects hidden regressions that ordinary CI gates miss:
+  mid-rebase broken commits, OpenAPI lock drift, YAML indent breakage,
+  over-scoped prettier writes, and missing test mocks for new framework
+  calls (`cookies()` / `headers()` / `new NextRequest(`). Use when the
+  user runs /devx:exception-merge-checklist,
+  /devx-exception-merge-checklist, or asks "예외 트랙 머지 전 점검", "PR
+  머지 직전 회귀 체크", "exception PR pre-merge audit". Read-only by
+  default; `--auto-fix` only stages C8 / C9 fixes (no commit). Accepts
+  `[<PR#>] [--skip-bisect] [--auto-fix] [--build-cmd <cmd>]` and
+  `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Grep, Glob, Edit
+---
+
+# devx:exception-merge-checklist — Pre-merge 10-point sanity check
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Parse Args + Resolve PR
+
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
+
+Positional: `[<PR#>]`. Optional flags: `--skip-bisect`, `--auto-fix`,
+`--build-cmd <cmd>`. Full table in `references/help.md`.
+
+- `<PR#>` omitted → auto-detect via `gh pr view --json
+  number,headRefName,baseRefName,url` on the current branch. No PR
+  for the branch → exit 3.
+- Resolve `TARGET_REPO=<owner>/<repo>` via `git remote get-url origin`
+  (parse `https://github.com/<o>/<r>.git` or
+  `git@github.com:<o>/<r>.git`). Missing remote → `git remote -v` and
+  stop with exit 2.
+- Bad / unknown flag → usage pointer and stop with exit 2.
+
+## Step 2: Run 10 Checks
+
+Read `references/checks.md` for the full definition of each check
+(pass condition, command, recovery hint, rationale). Run C1–C5 and
+C7–C10 in parallel; C6 is the only serial check because it walks
+each commit. **No fail-fast** — every check runs to completion so
+the report shows the full picture in one pass.
+
+Each check returns one of `PASS` / `WARN` / `FAIL` / `N/A`. C6 is
+fully opt-out via `--skip-bisect`. C7–C10 are **not** opt-outable —
+they are the core regression detectors derived from the 2026-05-16
+PR #727 retrospective (six concrete regressions, mapped one-to-one
+to checks in `references/checks.md`).
+
+## Step 3: Render Report
+
+Read `references/report-template.md` for the exact format. The
+report has the PR header, two tables (Gating C1–C5 + Regression
+C6–C10), a Score line, a Verdict line, and a Recovery Actions
+section with one bullet per WARN / FAIL (PASS / N/A produce no
+bullet). Do NOT prepend filler prose.
+
+## Step 4: Optional Auto-fix (`--auto-fix` only)
+
+Only when `--auto-fix` is set AND the report shows at least one
+deterministic FAIL among C8 (`.openapi-lock` regenerate via
+`bash scripts/update-openapi-lock.sh`, then re-verify
+`sha256sum -c`) or C9 (`bunx prettier --write` on the exact files
+reported, scoped to `*.md` / `*.json` / `*.yml` / `*.yaml` only).
+All other FAILs require human judgment and are never auto-fixed.
+
+After fixes, `git add` the touched files only and stop. **Never run
+`git commit`** — the user invokes `/gh:commit` separately so the
+commit message is human-authored. Print the staged file list and a
+hint pointing to `/gh-commit`.
+
+## Step 5: AI Metrics Footer
+
+Read `references/metrics-footer.md` for the comment format and
+soft-fail policy. The footer is posted as a PR comment (not a body
+edit) so it never conflicts with the per-step metric blocks written
+by other skills. `GH_DISABLE_AI_METRICS=1` skips this step entirely
+(issue #399 contract).
+
+## Constraints
+
+- **Read-only default.** Never merge, approve, push, or edit PR
+  body / labels. Only `--auto-fix` mutates, and only as far as
+  `git add`.
+- **No fail-fast.** All 10 checks run. Aggregating in one pass is
+  the whole point of the skill.
+- **C6 opt-out via `--skip-bisect` only.** C7–C10 are not
+  opt-outable — that would re-open the regression gap.
+- **Exit codes**: `0` (all PASS or only WARN) / `1` (≥ 1 FAIL) /
+  `2` (bad args, missing remote) / `3` (no PR detected).
+- **Never silently switch the build command.** If `--build-cmd` is
+  not given and `bun run build` does not exist in the repo, mark
+  C6 `N/A` with the reason — do NOT guess `npm test`.
+- **Never auto-commit.** `--auto-fix` stages only.

--- a/claude/skills/devx-exception-merge-checklist/references/checks.md
+++ b/claude/skills/devx-exception-merge-checklist/references/checks.md
@@ -1,0 +1,315 @@
+# devx:exception-merge-checklist — 10 Checks
+
+Each check below is the SSOT for one row in the report. Format:
+
+- **Pass condition** — the exact predicate
+- **Command** — runnable shell that produces the verdict
+- **Recovery hint** — the bullet emitted in the Recovery Actions
+  section when the row is WARN or FAIL
+- **Rationale** — the historical regression (from the 2026-05-16
+  AgentToolbox PR #727 retrospective) that motivates this check
+
+Run order: C1–C5 and C7–C10 are independent and run in parallel.
+C6 walks every commit and is serial. No fail-fast — every check
+runs to completion.
+
+---
+
+## Gating Checks (C1–C5)
+
+### C1 — linked SSOT issue
+
+**Pass when** PR body contains `Closes #<N>` (or `Resolves #<N>` /
+`Fixes #<N>`) AND issue `<N>` exists and is `OPEN`. `Refs #<N>` is
+WARN-not-FAIL because the relation exists but the merge will not
+auto-close the issue.
+
+**Command**
+
+```sh
+gh pr view "$PR" --repo "$TARGET_REPO" --json body --jq .body \
+  | grep -oE '(Closes|Resolves|Fixes|Refs) #[0-9]+' \
+  | head -n 1
+# For each match, verify with:
+gh issue view "$N" --repo "$TARGET_REPO" --json state --jq .state
+```
+
+**Recovery hint** — `PR body 에 \`Closes #<SSOT-issue>\` 추가`
+
+**Rationale** — Exception-track PRs often start as a hand-merge
+hotfix and skip the issue-first rule. Without `Closes`, the SSOT
+issue stays OPEN after merge and the parent-issue / milestone
+rollup breaks. Detected manually in PR #727.
+
+### C2 — parent issue
+
+**Pass when** the SSOT issue from C1 has a parent in either form:
+(a) body line matching `Parent: #<M>` or `Parent issue: #<M>`,
+(b) GitHub-native sub-issue relation present (queryable via
+`issues/<N>/sub_issues`). N/A when C1 itself is FAIL.
+
+**Command**
+
+```sh
+gh issue view "$N" --repo "$TARGET_REPO" --json body --jq .body \
+  | grep -oE 'Parent( issue)?: #[0-9]+'
+# OR:
+gh api "repos/$TARGET_REPO/issues/$N" --jq '.sub_issues_summary // empty'
+```
+
+**Recovery hint** — `SSOT issue #<N> body 에 \`Parent: #<M>\` 추가
+하거나 GitHub UI 에서 sub-issue 로 연결`
+
+**Rationale** — Exception-track PRs frequently lack the epic /
+parent link, breaking the project-board hierarchy rollup. This
+check makes the missing link visible at merge time instead of at
+sprint review.
+
+### C3 — mergeable
+
+**Pass when** `gh pr view --json mergeable` returns exactly
+`MERGEABLE`. `UNKNOWN` is WARN (GitHub is still computing — retry
+once after 5 s). `CONFLICTING` is FAIL.
+
+**Command**
+
+```sh
+gh pr view "$PR" --repo "$TARGET_REPO" --json mergeable --jq .mergeable
+```
+
+**Recovery hint** — `/gh:pr-resolve-conflict <PR#>`
+
+**Rationale** — Standard mergeability check; lumped in here so the
+single audit pass covers everything that would block the merge.
+
+### C4 — all CI green
+
+**Pass when** every entry in `statusCheckRollup` has
+`conclusion == SUCCESS`. Any `FAILURE`, `CANCELLED`, `TIMED_OUT`,
+or `ACTION_REQUIRED` → FAIL. `PENDING` / `IN_PROGRESS` / `QUEUED`
+→ WARN (CI still running).
+
+**Command**
+
+```sh
+gh pr view "$PR" --repo "$TARGET_REPO" \
+  --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion != "SUCCESS")
+        | "\(.name)\t\(.conclusion // .status)"'
+```
+
+**Recovery hint** — print each failing job's name and:
+`gh run rerun --failed --job <id>` (or PR re-push for required
+re-runs).
+
+**Rationale** — Exception track means "CI green but hand-merge",
+so this should normally pass. When it does not, the audit catches
+a regression that would otherwise be missed in the rush to merge.
+
+### C5 — review APPROVED
+
+**Pass when** `reviewDecision == APPROVED`. Empty string on a repo
+with no branch protection on `baseRefName` → WARN (mirrors
+`gh:pr-merge`'s solo-repo logic). `REVIEW_REQUIRED` /
+`CHANGES_REQUESTED` → FAIL.
+
+**Command**
+
+```sh
+gh pr view "$PR" --repo "$TARGET_REPO" \
+  --json reviewDecision,baseRefName --jq '[.reviewDecision, .baseRefName]'
+# Then, on empty reviewDecision:
+gh api "repos/$TARGET_REPO/branches/$BASE/protection" >/dev/null 2>&1 \
+  && echo PROTECTED || echo UNPROTECTED
+```
+
+**Recovery hint** — name the missing reviewer(s) and suggest
+`/gh:pr-approve <PR#>` for an automated approve flow.
+
+**Rationale** — Same gate `gh:pr-merge` uses; surfaced here so the
+single audit shows all blockers in one pass.
+
+---
+
+## Regression Detectors (C6–C10)
+
+These are the value-add. Each one catches a specific regression
+that escaped ordinary CI in the 2026-05-16 PR #727 incident
+(referenced as RX in the rationale lines).
+
+### C6 — bisect-safe (per-commit build)
+
+**Pass when** `git rebase --exec '<build-cmd>' <base>..HEAD`
+exits 0 at every commit. `N/A` when `--skip-bisect` is set (the
+report shows `N/A (--skip-bisect)`). Default `<build-cmd>` is
+`bun run build`; override with `--build-cmd`.
+
+**Command**
+
+```sh
+BASE=$(gh pr view "$PR" --repo "$TARGET_REPO" --json baseRefName --jq .baseRefName)
+git fetch origin "$BASE"
+# Run in a throwaway worktree so HEAD is not disturbed:
+git worktree add --detach .audit-bisect HEAD
+( cd .audit-bisect &&
+  git rebase --exec "$BUILD_CMD" "origin/$BASE" )
+RC=$?
+git worktree remove --force .audit-bisect
+```
+
+**Recovery hint** — print the failing commit SHA and:
+```
+git rebase -i <base>..HEAD
+# mark the bad commit `edit`, fix the source, then
+git rebase --continue
+```
+
+**Rationale (R1)** — PR #727 had commit `104f802` with a conflict
+marker still embedded in source. HEAD built cleanly because a
+later commit overwrote the file, but `git bisect` would step into
+the broken commit and falsely accuse it of a different bug.
+`--skip-bisect` is allowed only when the merge target is configured
+for squash-merge — squashing destroys intermediate commits, so
+their build state never reaches `main`.
+
+### C7 — openapi.yaml parses
+
+**Pass when** a Prism mock server boots within 30 s on the PR's
+`openapi.yaml`. N/A when the repo does not contain `openapi.yaml`
+or a `*.openapi.yaml` glob.
+
+**Command**
+
+```sh
+# Find a free port to avoid colliding with the user's dev server:
+PORT=$(comm -23 <(seq 4010 4099) \
+                <(ss -tan | awk 'NR>1 {split($4,a,":"); print a[length(a)]}' | sort -u) \
+        | head -n 1)
+timeout 30 bunx @stoplight/prism-cli mock openapi.yaml --port "$PORT" \
+  >.audit-prism.log 2>&1 &
+PID=$!
+# Wait for "listening" or timeout:
+for _ in $(seq 1 30); do
+  grep -q 'listening' .audit-prism.log && break
+  sleep 1
+done
+kill "$PID" 2>/dev/null || true
+grep -q 'listening' .audit-prism.log
+```
+
+**Recovery hint** — print the first 5 non-empty lines of
+`.audit-prism.log` (includes the line number Prism rejected) and:
+`open openapi.yaml:<line>` to fix the indent / schema error.
+
+**Rationale (R3)** — PR #727 introduced a YAML indent bug at
+`openapi.yaml:1437`. The CI contract-test job timed out (because
+Prism never reached "listening") and the failure mode looked like
+test flake. Catching it here as a parse failure pinpoints the
+exact line.
+
+### C8 — `.openapi-lock` matches
+
+**Pass when** `sha256sum -c .openapi-lock` exits 0. N/A when the
+repo does not have `.openapi-lock` (not an openapi-bound project).
+
+**Command**
+
+```sh
+[ -f .openapi-lock ] || exit_na
+sha256sum -c .openapi-lock
+```
+
+**Recovery hint** — `bash scripts/update-openapi-lock.sh` (or
+`make openapi-lock`) and commit the regenerated `.openapi-lock`.
+`--auto-fix` automates the regenerate + `git add` (no commit).
+
+**Rationale (R2)** — PR #727 had `build:spec` overwrite a
+placeholder OpenAPI doc and never regenerate `.openapi-lock`, so
+production deploys would fetch a spec whose sha did not match the
+lockfile. Fixed in commit `2452e07` amend after the fact.
+
+### C9 — prettier scope clean
+
+**Pass when** `prettier --check` succeeds on the changed
+`*.md` / `*.json` / `*.yml` / `*.yaml` files in the PR diff. Source
+code (`*.ts` / `*.tsx` / `*.js`) is intentionally excluded — the
+regression here is over-formatting docs, not code.
+
+**Command**
+
+```sh
+BASE=$(gh pr view "$PR" --repo "$TARGET_REPO" --json baseRefName --jq .baseRefName)
+git fetch origin "$BASE"
+CHANGED=$(git diff --name-only "origin/$BASE..HEAD" -- \
+  '*.md' '*.json' '*.yml' '*.yaml' \
+  | tr '\n' ' ')
+[ -n "$CHANGED" ] || exit_na
+bunx prettier --check $CHANGED
+```
+
+**Recovery hint** — list the offending files and:
+`bunx prettier --write <files>`. `--auto-fix` automates the rewrite
++ `git add` (no commit).
+
+**Rationale (R5)** — PR #727 ran `bunx prettier --write '**/*'`,
+which touched 45 files outside the PR's actual scope. Reviewers
+had to manually revert 38 of them. Scoping the check to changed
+files only catches the over-write before it ships.
+
+### C10 — test mocks complete
+
+**Pass when** every NEW `cookies()`, `headers()`, or
+`new NextRequest(` call introduced in the PR diff (under
+`apps/**/*.ts` and `apps/**/*.tsx`) has a matching mock in a test
+file in the same PR diff. The heuristic is: for each prod-file
+match, expect a corresponding `vi.mock('next/headers'`,
+`vi.mocked(cookies)`, or `new NextRequest(` in a `*.test.ts(x)` /
+`*.spec.ts(x)` file within the same PR.
+
+**Command**
+
+```sh
+BASE=$(gh pr view "$PR" --repo "$TARGET_REPO" --json baseRefName --jq .baseRefName)
+git fetch origin "$BASE"
+# Prod-side new calls:
+PROD=$(git diff "origin/$BASE..HEAD" -- \
+        'apps/**/*.ts' 'apps/**/*.tsx' \
+        ':!**/*.test.*' ':!**/*.spec.*' \
+        | grep -E '^\+.*(cookies\(\)|headers\(\)|new NextRequest\()')
+# Test-side mocks added in same PR:
+TEST=$(git diff "origin/$BASE..HEAD" -- \
+        '**/*.test.ts' '**/*.test.tsx' '**/*.spec.ts' '**/*.spec.tsx' \
+        | grep -E "^\+.*(vi\.mock\('next/headers'|vi\.mocked\((cookies|headers)\)|new NextRequest\()")
+[ -z "$PROD" ] || [ -n "$TEST" ]
+```
+
+**Recovery hint** — list the prod-side files whose new call has no
+matching test mock and emit a copy-paste template:
+
+```ts
+import { vi } from 'vitest';
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => ({ get: vi.fn() })),
+  headers: vi.fn(() => new Headers()),
+}));
+```
+
+**Rationale (R6)** — PR #727 added 5 production-path `cookies()`
+calls without updating `page.redirect.test.ts`'s mocks. The
+failing tests looked like flake until commit `d019963` added the
+missing mocks. The heuristic is intentionally false-positive-prone
+— a WARN here is much cheaper than missing the regression.
+
+---
+
+## Result aggregation
+
+After all 10 checks run, classify the overall outcome:
+
+| FAIL count | Verdict line |
+|------------|---------------|
+| 0 | `safe to merge` (exit 0) |
+| ≥ 1 | `N FAIL, M WARN — NOT safe to merge` (exit 1) |
+
+WARN alone never blocks. The user decides whether to treat WARNs
+as merge-blocking on a case-by-case basis.

--- a/claude/skills/devx-exception-merge-checklist/references/checks.md
+++ b/claude/skills/devx-exception-merge-checklist/references/checks.md
@@ -181,14 +181,17 @@ or a `*.openapi.yaml` glob.
 **Command**
 
 ```sh
-# Find a free port to avoid colliding with the user's dev server:
-PORT=$(comm -23 <(seq 4010 4099) \
-                <(ss -tan | awk 'NR>1 {split($4,a,":"); print a[length(a)]}' | sort -u) \
-        | head -n 1)
-timeout 30 bunx @stoplight/prism-cli mock openapi.yaml --port "$PORT" \
+# Find a free port (portable: lsof works on Linux + macOS + BSD;
+# ss / netstat / `timeout` are GNU-only and unsafe across systems).
+for p in $(seq 4010 4099); do
+  lsof -nP -iTCP:"$p" -sTCP:LISTEN >/dev/null 2>&1 || { PORT=$p; break; }
+done
+: "${PORT:=4010}"   # last-resort fallback when the range is fully occupied
+# Background-launch Prism; the poll-loop below is the 30 s timeout
+# (intentionally replacing GNU `timeout` for macOS/BSD portability).
+bunx @stoplight/prism-cli mock openapi.yaml --port "$PORT" \
   >.audit-prism.log 2>&1 &
 PID=$!
-# Wait for "listening" or timeout:
 for _ in $(seq 1 30); do
   grep -q 'listening' .audit-prism.log && break
   sleep 1
@@ -271,16 +274,19 @@ match, expect a corresponding `vi.mock('next/headers'`,
 ```sh
 BASE=$(gh pr view "$PR" --repo "$TARGET_REPO" --json baseRefName --jq .baseRefName)
 git fetch origin "$BASE"
-# Prod-side new calls:
-PROD=$(git diff "origin/$BASE..HEAD" -- \
+# Pipe-stream both diffs to avoid capturing potentially-large
+# output into shell variables (ARG_MAX / memory concerns).
+# C10 passes when either no prod-side new framework call was
+# introduced, OR a matching mock was also added in the same PR.
+if git diff "origin/$BASE..HEAD" -- \
         'apps/**/*.ts' 'apps/**/*.tsx' \
         ':!**/*.test.*' ':!**/*.spec.*' \
-        | grep -E '^\+.*(cookies\(\)|headers\(\)|new NextRequest\()')
-# Test-side mocks added in same PR:
-TEST=$(git diff "origin/$BASE..HEAD" -- \
-        '**/*.test.ts' '**/*.test.tsx' '**/*.spec.ts' '**/*.spec.tsx' \
-        | grep -E "^\+.*(vi\.mock\('next/headers'|vi\.mocked\((cookies|headers)\)|new NextRequest\()")
-[ -z "$PROD" ] || [ -n "$TEST" ]
+   | grep -qE '^\+.*(cookies\(\)|headers\(\)|new NextRequest\()'; then
+    git diff "origin/$BASE..HEAD" -- \
+            '**/*.test.ts' '**/*.test.tsx' '**/*.spec.ts' '**/*.spec.tsx' \
+       | grep -qE "^\+.*(vi\.mock\('next/headers'|vi\.mocked\((cookies|headers)\)|new NextRequest\()" \
+       || exit 1
+fi
 ```
 
 **Recovery hint** — list the prod-side files whose new call has no

--- a/claude/skills/devx-exception-merge-checklist/references/help.md
+++ b/claude/skills/devx-exception-merge-checklist/references/help.md
@@ -1,0 +1,90 @@
+# devx:exception-merge-checklist — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<PR#>` or `-h`/`--help`/`help` | auto-detect | GitHub PR number. When omitted, the skill resolves the PR attached to the current branch via `gh pr view`. |
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--skip-bisect` | Skip C6 (commit-by-commit build). Use when the merge target is squash-merge (intermediate commits are discarded). C6 is reported as `N/A` with a one-line reason. |
+| `--auto-fix` | After the report, run deterministic fixes for C8 (`.openapi-lock` regenerate) and C9 (`prettier --write` on changed-only files) and stage them with `git add`. **Never commits.** All other FAILs require human decisions. |
+| `--build-cmd <cmd>` | Override the C6 per-commit verification command. Default is `bun run build`. Quote the value if it contains spaces. |
+
+## Usage
+
+- `/devx:exception-merge-checklist 727` — full audit on PR #727
+- `/devx:exception-merge-checklist` — auto-detect PR on current branch
+- `/devx:exception-merge-checklist 727 --skip-bisect` — skip C6 (squash-merge target)
+- `/devx:exception-merge-checklist 727 --auto-fix` — audit, then stage C8/C9 fixes
+- `/devx:exception-merge-checklist 727 --build-cmd "npm run build && npm test"` — alt build
+- `/devx:exception-merge-checklist -h` / `--help` / `help` — print this help
+
+## What the skill checks
+
+The audit splits into two groups. **Gating checks (C1–C5)** verify PR
+metadata and CI state that ordinary review covers — fast,
+metadata-only. **Regression detectors (C6–C10)** are the value-add of
+this skill: they catch the six specific regressions that bypassed CI
+in the 2026-05-16 AgentToolbox PR #727 incident.
+
+### Gating Checks
+
+| # | Name | Pass when |
+|---|------|-----------|
+| C1 | linked SSOT issue | PR body has `Closes #N` (or `Refs #N`) and that issue exists |
+| C2 | parent issue | The SSOT issue's body links a parent (`Parent: #M` or sub-issue relation) |
+| C3 | mergeable | `gh pr view --json mergeable` returns `MERGEABLE` |
+| C4 | all CI green | Every `statusCheckRollup.conclusion` is `SUCCESS` |
+| C5 | review APPROVED | `reviewDecision == APPROVED` |
+
+### Regression Detectors
+
+| # | Name | Pass when |
+|---|------|-----------|
+| C6 | bisect-safe | `git rebase --exec '<build-cmd>' <base>..HEAD` succeeds at every commit |
+| C7 | openapi.yaml parses | Prism mock starts within 30 s on `openapi.yaml` |
+| C8 | `.openapi-lock` matches | `sha256sum -c .openapi-lock` exits 0 |
+| C9 | prettier scope clean | `prettier --check` passes on the PR's changed md/json/yml/yaml only |
+| C10 | test mocks complete | Every new `cookies()` / `headers()` / `new NextRequest(` call in the diff has a corresponding mock in the same PR |
+
+Full criteria, exact commands, recovery hints, and the historical
+regression each one catches live in `references/checks.md`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All PASS, or only WARN (no FAIL) — safe to merge |
+| 1 | ≥ 1 FAIL — NOT safe to merge; see Recovery Actions |
+| 2 | Bad args (unknown flag, missing remote, invalid PR number) |
+| 3 | No PR detected for the current branch and no PR# argument given |
+
+## What the skill will NOT do
+
+- Merge, approve, push, or comment beyond the metrics footer.
+- Edit PR body, labels, or assignees.
+- Run `git commit` even with `--auto-fix` — only `git add`.
+- Fall back to a different build command when `--build-cmd` is wrong.
+- Skip C7–C10. Those are the regression detectors and must run.
+- Fail-fast. All 10 checks complete so the user sees the full report.
+
+## When to use which skill
+
+| Situation | Skill |
+|-----------|-------|
+| Pre-merge sanity on an exception-track PR (hand-merge with extra scrutiny) | `devx:exception-merge-checklist` |
+| Normal PR review and approve flow | `gh:pr-approve` |
+| Merge an already-approved PR | `gh:pr-merge` |
+| Resolve conflicts before merging | `gh:pr-resolve-conflict` |
+| Bypass approval for incident/hotfix with audit | `gh:pr-merge-emergency` |
+
+## Sister skill
+
+`/devx:pr-to-ssot-issue` is the planned entry-track counterpart —
+turn a finished PR into an SSOT issue with the same metadata
+contract that C1 / C2 check. Tracked separately (not yet
+implemented at the time of this skill's introduction).

--- a/claude/skills/devx-exception-merge-checklist/references/metrics-footer.md
+++ b/claude/skills/devx-exception-merge-checklist/references/metrics-footer.md
@@ -52,10 +52,21 @@ Skip the comment entirely (no warning, no log) when either of:
 
 ## Post mechanics
 
+Write the rendered body to a temp file, then POST via `gh api`
+with the `{owner}/{repo}` placeholder + explicit `--repo` flag
+(safe parsing when `TARGET_REPO` was originally a URL) and
+`-F body=@FILE` (capital `F` reads the file directly — the
+lowercase `-f` form leaks the literal path into the body; see
+dotfiles MEMORY "gh:discussion-create body-file 회귀"):
+
 ```sh
-gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+BODY_FILE=$(mktemp) && trap 'rm -f "$BODY_FILE"' EXIT
+printf '%s' "$BODY" > "$BODY_FILE"
+
+gh api "/repos/{owner}/{repo}/issues/$PR_NUMBER/comments" \
+  --repo "$TARGET_REPO" \
   -X POST \
-  -f body="$(printf '%s' "$BODY")" \
+  -F body=@"$BODY_FILE" \
   >/dev/null 2>&1 \
   && echo "[OK] ai-metrics comment posted" \
   || echo "[WARN] ai-metrics comment failed — continuing."

--- a/claude/skills/devx-exception-merge-checklist/references/metrics-footer.md
+++ b/claude/skills/devx-exception-merge-checklist/references/metrics-footer.md
@@ -1,0 +1,92 @@
+# devx:exception-merge-checklist — AI Metrics Footer
+
+The skill posts a soft-fail ai-metrics comment on the audited PR
+after Step 4. The footer follows the SSOT format established in
+PR #320 and re-used by every `gh:*` and `devx:*` skill that
+operates on a PR.
+
+## When NOT to post
+
+Skip the comment entirely (no warning, no log) when either of:
+
+- `GH_DISABLE_AI_METRICS=1` (issue #399 contract — same env var
+  honored by `gh:issue-implement`, `gh:commit`, `gh:pr`,
+  `gh:pr-merge`, etc.)
+- The skill exited with code 2 (bad args) or 3 (no PR detected) —
+  there is nothing to attach the comment to.
+
+## Comment body template
+
+```markdown
+### devx:exception-merge-checklist 완료
+
+| Group | Result |
+|-------|--------|
+| Gating (C1–C5) | <P_GATE>/5 PASS, <W_GATE> WARN, <F_GATE> FAIL |
+| Regression detectors (C6–C10) | <P_REGR>/5 PASS, <W_REGR> WARN, <F_REGR> FAIL, <N_REGR> N/A |
+| **Verdict** | **<VERDICT_LINE>** |
+
+예상 사람 시간: ~<HUMAN_H> h (수동 점검 대비 절약) · 토큰: ~<TOKENS>
+
+---
+<details>
+<summary>🤖 AI Metrics · 📊 ~<TOKENS> tokens · 👤 ~<HUMAN_H> h · 🤖 ~<ELAPSED> min</summary>
+
+<!-- ai-metrics:devx-exception-merge-checklist -->
+📊 ~<TOKENS> tokens · 👤 ~<HUMAN_H> h · 🤖 ~<ELAPSED> min
+<!-- /ai-metrics:devx-exception-merge-checklist -->
+
+</details>
+```
+
+## Field derivation
+
+| Field | Source |
+|-------|--------|
+| `ELAPSED` | `$(( ($(date +%s) - START_TS) / 60 ))` — minutes since Step 1 |
+| `TOKENS` | character count of all `gh` JSON outputs read in Step 2 (`gh pr view`, `gh issue view`, `gh api` calls) divided by 4, rounded to nearest 500, minimum 1000 |
+| `HUMAN_H` | flat 0.75 — the baseline cost of running the 10-check audit by hand (the 2026-05-16 retrospective measured 1.5 h for 6 sequential discoveries; the audit short-circuits that by running all 10 in parallel) |
+| `P_GATE`, `W_GATE`, `F_GATE` | PASS / WARN / FAIL counts from C1–C5 |
+| `P_REGR`, `W_REGR`, `F_REGR`, `N_REGR` | PASS / WARN / FAIL / N/A counts from C6–C10 |
+| `VERDICT_LINE` | `safe to merge` or `N FAIL, M WARN — NOT safe to merge` from Step 3 |
+
+## Post mechanics
+
+```sh
+gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+  -X POST \
+  -f body="$(printf '%s' "$BODY")" \
+  >/dev/null 2>&1 \
+  && echo "[OK] ai-metrics comment posted" \
+  || echo "[WARN] ai-metrics comment failed — continuing."
+```
+
+Soft-fail policy: a failed POST never changes the skill's exit
+code. The audit verdict (Step 3) is the user-facing contract; the
+metrics comment is observability for the team dashboard.
+
+## Why a comment, not a body edit
+
+`gh:pr` writes the per-step metric block into the PR **body** via
+`gh pr edit --body-file`. This skill posts as a **comment** for
+three reasons:
+
+1. The audit runs many times on the same PR (every push triggers
+   the user to re-run); a comment thread preserves the history of
+   each pass, whereas a body edit would overwrite the last result.
+2. Body edits go through `_gh_pr_edit_safe_body` to dodge the
+   classic-projects silent-fail (issue #326 Bug B). A comment POST
+   has no such trap.
+3. The PR body already carries multiple `<!-- ai-metrics:* -->`
+   blocks from earlier skills (`gh:pr`, `gh:pr-resolve-conflict`,
+   etc.); a new block per audit run would either bloat the body
+   or require an in-place replace flow that this skill does not
+   need.
+
+## Idempotency
+
+The comment is NOT deduplicated. Each invocation posts a fresh
+comment. This is deliberate — re-running the audit after a fix is
+a separate event, and the team dashboard counts each run as one
+data point. If a future need arises to coalesce repeated audits,
+add a `--once` flag rather than changing the default.

--- a/claude/skills/devx-exception-merge-checklist/references/metrics-footer.md
+++ b/claude/skills/devx-exception-merge-checklist/references/metrics-footer.md
@@ -52,19 +52,24 @@ Skip the comment entirely (no warning, no log) when either of:
 
 ## Post mechanics
 
-Write the rendered body to a temp file, then POST via `gh api`
-with the `{owner}/{repo}` placeholder + explicit `--repo` flag
-(safe parsing when `TARGET_REPO` was originally a URL) and
-`-F body=@FILE` (capital `F` reads the file directly — the
-lowercase `-f` form leaks the literal path into the body; see
-dotfiles MEMORY "gh:discussion-create body-file 회귀"):
+Write the rendered body to a temp file, then POST via `gh api`.
+Two safety choices in the command below:
+
+- **`{owner}/{repo}` placeholder** in the URL — `gh api` auto-fills
+  it from the current working directory's git remote, so the call
+  works regardless of whether `TARGET_REPO` was stored as
+  `owner/repo` or as a full URL (`gh api` itself does NOT accept a
+  `--repo` flag — that flag is for `gh pr` / `gh issue`).
+- **`-F body=@FILE`** (capital `F`) reads the file directly. The
+  lowercase `-f body=@FILE` is a known regression that posts the
+  literal path string instead of the file contents (see dotfiles
+  MEMORY "gh:discussion-create body-file 회귀").
 
 ```sh
 BODY_FILE=$(mktemp) && trap 'rm -f "$BODY_FILE"' EXIT
 printf '%s' "$BODY" > "$BODY_FILE"
 
 gh api "/repos/{owner}/{repo}/issues/$PR_NUMBER/comments" \
-  --repo "$TARGET_REPO" \
   -X POST \
   -F body=@"$BODY_FILE" \
   >/dev/null 2>&1 \

--- a/claude/skills/devx-exception-merge-checklist/references/report-template.md
+++ b/claude/skills/devx-exception-merge-checklist/references/report-template.md
@@ -1,0 +1,107 @@
+# devx:exception-merge-checklist — Report Template
+
+Use this exact format when printing the Step 3 audit report.
+
+```
+## devx:exception-merge-checklist Report
+PR:    #<N> — <title>
+URL:   <pr-url>
+Base:  <baseRefName> @ <base-sha>
+Head:  <headRefName> @ <head-sha>
+Build: <build-cmd>   (default | --build-cmd)
+
+### Gating Checks
+| #  | Check                       | Result | Notes                            |
+|----|-----------------------------|--------|----------------------------------|
+| C1 | linked SSOT issue           | PASS   | Closes #<N>                      |
+| C2 | parent issue                | WARN   | sub-issue relation missing       |
+| C3 | mergeable                   | PASS   | MERGEABLE                        |
+| C4 | all CI green                | PASS   | 12/12 checks SUCCESS             |
+| C5 | review APPROVED             | PASS   | 1 approval, branch protected     |
+
+### Regression Detectors
+| #  | Check                       | Result | Notes                            |
+|----|-----------------------------|--------|----------------------------------|
+| C6 | bisect-safe                 | FAIL   | broken at 104f802                |
+| C7 | openapi.yaml parses         | PASS   | Prism boot 3.2s                  |
+| C8 | .openapi-lock matches       | FAIL   | sha mismatch — regenerate        |
+| C9 | prettier scope clean        | FAIL   | 45 files outside diff scope      |
+|C10 | test mocks complete         | WARN   | 3 cookies() calls, no new mocks  |
+
+Score: 5/10 passed (3 WARN, 3 FAIL, 0 N/A)
+Verdict: 3 FAIL, 3 WARN — NOT safe to merge
+
+### Recovery Actions
+1. [WARN C2] SSOT issue #N body 에 `Parent: #M` 추가하거나 GitHub UI 에서
+   sub-issue 로 연결.
+2. [FAIL C6] 깨진 commit: 104f802
+     git rebase -i origin/main..HEAD
+     # mark 104f802 as `edit`, fix conflict marker, then `git rebase --continue`
+3. [FAIL C8] .openapi-lock drift:
+     bash scripts/update-openapi-lock.sh
+     git add .openapi-lock
+   Or run `/devx-exception-merge-checklist <PR#> --auto-fix` to auto-stage.
+4. [FAIL C9] 45 files outside the PR's intended scope. Affected:
+     apps/web/README.md
+     docs/*.md (38 files)
+     ...
+     bunx prettier --write <listed-files>
+5. [WARN C10] New cookies() calls without test mocks in:
+     apps/web/app/(auth)/page.tsx:24
+     apps/web/app/dashboard/route.ts:11
+   Add to a matching .test.ts in the same PR:
+     import { vi } from 'vitest';
+     vi.mock('next/headers', () => ({
+       cookies: vi.fn(() => ({ get: vi.fn() })),
+     }));
+
+Re-run `/devx-exception-merge-checklist <PR#>` after fixes.
+```
+
+## Verdict computation
+
+- `0 FAIL` → `safe to merge` → exit code 0
+- `≥ 1 FAIL` → `<F> FAIL, <W> WARN — NOT safe to merge` → exit code 1
+
+WARN alone is never a merge blocker. The user judges whether a
+specific WARN is acceptable for the PR at hand (e.g. C2 missing
+parent on a one-off hotfix may be intentional).
+
+## Notes column rules
+
+- ≤ 40 characters — must fit a standard terminal.
+- For PASS rows: a one-glance summary of the observed value
+  (`MERGEABLE`, `12/12 checks SUCCESS`, `1 approval, branch protected`).
+- For WARN / FAIL rows: the dominant symptom (`sha mismatch — regenerate`,
+  `broken at <short-sha>`, `45 files outside diff scope`).
+- For N/A rows: the reason (`--skip-bisect`, `no openapi.yaml`,
+  `no apps/ tree`).
+
+## Recovery Actions rules
+
+- **One bullet per WARN / FAIL.** PASS and N/A produce no bullet.
+- Each bullet starts with `[<LEVEL> C<N>]` so the user can map
+  back to the table row.
+- Each bullet must be **actionable** — paste the exact command or
+  code snippet to fix the symptom. Vague guidance ("review the
+  CI logs") is worse than no bullet.
+- For C6 FAIL: print the failing commit SHA explicitly so the
+  user does not have to re-run the audit to find it.
+- For C9 FAIL: list the offending files (truncate to 10 with a
+  `... (N more)` suffix when longer).
+- For C10 WARN: emit a copy-paste mock template (see
+  `references/checks.md` C10 recovery hint).
+- End the Recovery Actions section with one line:
+  `Re-run \`/devx-exception-merge-checklist <PR#>\` after fixes.`
+
+## Output rules
+
+- Tables use exactly the columns shown: `#`, `Check`, `Result`,
+  `Notes`. No extra columns.
+- Result column values are uppercase: `PASS` / `WARN` / `FAIL` /
+  `N/A`.
+- Do NOT add filler prose ("the PR looks great!") — the Verdict
+  line already classifies overall safety.
+- If `Score = 10/10` (no WARN, no FAIL), the Recovery Actions
+  section reads exactly:
+  `No actions required.`

--- a/claude/skills/skill-check/references/allowed-emoji-skills.txt
+++ b/claude/skills/skill-check/references/allowed-emoji-skills.txt
@@ -2,4 +2,5 @@
 # Each entry must have a rationale comment.
 # Adding a new entry requires updating Check 11 rationale.
 
-gh-add-ai-metrics    # ai-metrics footer SSOT — CLAUDE.md exception (#317 F-2, PR #320, #367)
+gh-add-ai-metrics                    # ai-metrics footer SSOT — CLAUDE.md exception (#317 F-2, PR #320, #367)
+devx-exception-merge-checklist       # ai-metrics footer in references/metrics-footer.md per #317 F-2 SSOT (issue #658)


### PR DESCRIPTION
## Summary
- 신규 스킬 `/devx:exception-merge-checklist` — 예외 트랙 PR (CI green + 수동 머지) 직전 10-point sanity audit 도입
- 2026-05-16 AgentToolbox PR #727 회고에서 확인된 6종 회귀를 단일 audit pass 로 retroactive 감지
- read-only default + `--auto-fix` 는 C8 / C9 만 git add 까지 (commit 은 사람이 `/gh-commit` 분리 수행)

## Changes
- `claude/skills/devx-exception-merge-checklist/SKILL.md` (100 lines) — 5 step skill (Help / Parse Args + PR resolve / 10 checks / Render report / Optional auto-fix / AI metrics footer), exit codes 0–3, constraints
- `references/help.md` — 인자/플래그 표, 사용 예, 10-check 요약, exit code 표
- `references/checks.md` — 10 checks 의 정본 (pass condition, command, recovery hint, rationale + 회귀 매핑 R1–R6)
- `references/report-template.md` — 보고서 출력 양식 (두 테이블 + Score + Verdict + Recovery Actions)
- `references/metrics-footer.md` — ai-metrics PR 코멘트 템플릿 + `GH_DISABLE_AI_METRICS` soft-fail 정책 + 본문 edit 대신 comment 선택 이유
- `claude/skills/skill-check/references/allowed-emoji-skills.txt` — 신규 스킬을 ai-metrics 이모지 allowlist 에 등록 (CLAUDE.md #317 F-2 / PR #320 SSOT)

회귀 매핑 (issue body 의 6종 회귀 → 검사):
- R1 (mid-rebase broken commit `104f802`) → C6 (bisect-safe per-commit build)
- R2 (`.openapi-lock` sha drift) → C8 (`sha256sum -c`)
- R3 (`openapi.yaml` indent at line 1437) → C7 (Prism mock boot)
- R4 (Next.js 15 RouteHandler signature) → C4 (CI 가 TS compile 로 잡음; 별도 dedicated check 미설정)
- R5 (`prettier --write '**/*'` over-scope) → C9 (diff-scoped prettier --check)
- R6 (`cookies()` mock 누락) → C10 (PR diff 내 mock 휴리스틱 매칭)

## Test plan
- [ ] `/devx-exception-merge-checklist --help` 가 `references/help.md` 를 verbatim 출력
- [ ] `/skill:check claude/skills/devx-exception-merge-checklist/SKILL.md` → EXCELLENT (10/10, 1 N/A — emoji allowlisted)
- [ ] 다른 repo (예: AgentToolbox) 에서 `/devx-exception-merge-checklist <PR#>` 실행해 PR 본문/CI/리뷰 메타 fetch 가 동작하는지 smoke test
- [ ] PR #727 회고 시나리오 재구성으로 R1–R6 각각이 C6/C7/C8/C9/C10 (R4 는 C4) 로 감지되는지 회귀 테스트
- [ ] `--auto-fix` 실행 시 `.openapi-lock` 재생성 / prettier 재포맷 후 `git add` 까지만 수행하고 commit 안 함을 확인
- [ ] `GH_DISABLE_AI_METRICS=1` 환경에서 Step 5 의 ai-metrics 코멘트가 완전히 스킵됨

## Related
Closes #658

---
<details>
<summary>🤖 AI Metrics · 📊 ~9000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
