### PR TITLE
fix(gh-pr-approve): #666 surface log fallback when usage.jsonl lacks .result/.error

### DIFF
--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -423,17 +423,30 @@ _gh_pr_approve_status_single() {
     # one glance away instead of one tail|grep away.
     case "$_state" in
     failed:approving)
-        local _usage _failure
+        local _usage _failure _log_fallback
         _usage="$_dir/usage.jsonl"
+        _failure=""
         if [ -f "$_usage" ] && [ -s "$_usage" ] && command -v jq >/dev/null 2>&1; then
             _failure="$(jq -rs '
                 map(select((.is_error? // false) or ((.tracking? // "") == "cli_failed")))
                 | last
                 | (.result? // .error? // empty)
             ' "$_usage" 2>/dev/null)"
-            if [ -n "$_failure" ]; then
-                ux_table_row "Failure" "$_failure"
+        fi
+        # Fallback: usage.jsonl may omit .result/.error for adapters that
+        # only record lightweight metadata (claude-cli cli_failed case).
+        # The raw CLI dump in <pr-dir>/log carries the actual error in
+        # its final {"type":"result","is_error":true,"result":"…"} line.
+        if [ -z "$_failure" ] && [ -f "$_log" ] && command -v jq >/dev/null 2>&1; then
+            _log_fallback="$(grep '"is_error":true' "$_log" 2>/dev/null \
+                | tail -1 \
+                | jq -r '.result // .error // empty' 2>/dev/null)"
+            if [ -n "$_log_fallback" ]; then
+                _failure="$_log_fallback"
             fi
+        fi
+        if [ -n "$_failure" ]; then
+            ux_table_row "Failure" "$_failure"
         fi
         ;;
     esac

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -704,6 +704,56 @@ EOF
     refute_output --partial "Failure"
 }
 
+@test "status <N>: failed:approving falls back to log when usage.jsonl lacks .result (issue #666)" {
+    # claude-cli mid-run crashes (e.g. ECONNRESET) leave usage.jsonl with
+    # only metadata — no .result/.error. The actual error message lives
+    # in the raw CLI log's final is_error:true JSON dump. status must
+    # surface that fallback instead of silently skipping the Failure row.
+    _seed_pr_state 603 "failed:approving" "" "9999999"
+    local _state_dir="$HOME/.local/state/gh-pr-approve/fake-main/603"
+    local _usage="$_state_dir/usage.jsonl"
+    local _log="$_state_dir/log"
+    cat >"$_usage" <<'EOF'
+{"ai":"claude","ts":"2026-05-15T21:16:01+09:00","label":"/gh-pr-approve 603","exit_code":1,"tracking":"cli_failed"}
+EOF
+    cat >"$_log" <<'EOF'
+some streaming preamble line
+{"type":"result","is_error":true,"api_error_status":null,"duration_ms":601039,"result":"API Error: Unable to connect to API (ECONNRESET)"}
+EOF
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 603"
+    assert_success
+    assert_output --partial "Failure"
+    assert_output --partial "API Error: Unable to connect to API (ECONNRESET)"
+}
+
+@test "status <N>: failed:approving — usage.jsonl .result wins over log fallback (issue #666)" {
+    # Regression guard for codex/gemini adapters that DO populate
+    # usage.jsonl with .result — the log fallback must not override it.
+    # Pad the log so the is_error JSON dump is NOT in the last 5 lines;
+    # otherwise the `tail -5 log` block in status would echo the sentinel
+    # into output and confuse a naive refute_output check.
+    _seed_pr_state 604 "failed:approving" "" "9999999"
+    local _state_dir="$HOME/.local/state/gh-pr-approve/fake-main/604"
+    local _usage="$_state_dir/usage.jsonl"
+    local _log="$_state_dir/log"
+    cat >"$_usage" <<'EOF'
+{"ai":"codex","ts":"2026-05-15T21:16:01+09:00","label":"/gh-pr-approve 604","is_error":true,"result":"Primary failure from usage.jsonl"}
+EOF
+    cat >"$_log" <<'EOF'
+{"type":"result","is_error":true,"result":"sentinel-log-fallback-666"}
+pad-line-1
+pad-line-2
+pad-line-3
+pad-line-4
+pad-line-5
+pad-line-6
+EOF
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve status 604"
+    assert_success
+    assert_output --partial "Primary failure from usage.jsonl"
+    refute_output --partial "sentinel-log-fallback-666"
+}
+
 # ---------------------------------------------------------------------------
 # dispatcher: 'status' / 'prune' must not be parsed as a PR number
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_gh_pr_approve_status` 의 `failed:approving` 분기에 log 파일 폴백을 추가해, `usage.jsonl` 이 `.result`/`.error` 를 갖고 있지 않은 케이스 (claude-cli mid-run `ECONNRESET` 등) 에서도 Failure 행에 원인 메시지를 노출한다.
- bats 회귀 테스트 2건 추가 — (1) log 폴백이 실제로 fire 하는 path, (2) usage.jsonl 의 `.result` 가 있을 때 폴백이 그것을 덮어쓰지 않는 precedence 보호.

## Background

`gh-pr-approve status <PR>` 가 `failed:approving` 상태일 때, 사용자에게 즉시 원인을 알려주기 위해 `Failure: …` 행을 노출하도록 설계되어 있었다. 하지만 노출 로직 (`gh_pr_approve.sh:424-439`) 이 `usage.jsonl` 만 보고 있어서, claude-cli 가 `ECONNRESET` 등으로 mid-run 에 죽는 가장 흔한 케이스에서는 silent skip 되었다. 이 경우 진짜 원인은 raw CLI dump (`<pr-dir>/log`) 의 마지막 `"is_error":true` JSON 행에만 남아있어, 사용자가 직접 `grep | tail -1 | jq` 를 돌려야 했다.

`<pr-dir>/usage.jsonl` 과 `<pr-dir>/log` 의 책임:

| 파일 | 용도 | 실패 원문 포함? |
|------|------|------------------|
| `usage.jsonl` | worker 메타데이터 (`ai`, `ts`, `exit_code`, `tracking`) | 어댑터별로 다름 — claude-cli `cli_failed` 케이스에서는 비어있음 |
| `log` | CLI 의 raw stdout/stderr — 마지막에 `{"type":"result","is_error":true,"result":"…"}` JSON dump | 항상 있음 (CLI 가 죽기 직전 출력) |

## Changes

### `shell-common/functions/gh_pr_approve.sh`
- `failed:approving` 분기에 log 폴백 추가:
  - 1차: `usage.jsonl` 에서 `jq -rs '... | (.result? // .error? // empty)'` 시도 (기존 로직 유지).
  - 2차: 1차 결과가 비어있으면 `<pr-dir>/log` 에서 `grep '"is_error":true' | tail -1 | jq -r '.result // .error // empty'` 폴백.
  - 둘 다 비면 기존처럼 행 자체를 silent skip (false-positive 행 방지).
- `usage.jsonl` 에 값이 있으면 그대로 우선 — codex/gemini 어댑터 경로 비회귀.

### `tests/bats/functions/gh_pr_approve.bats`
새 시나리오 2건 추가 (이슈 #666 섹션):
1. `failed:approving falls back to log when usage.jsonl lacks .result` — fixture: `usage.jsonl` 은 `{"tracking":"cli_failed"}` 메타만, `log` 에는 `is_error:true` JSON. Expectation: Failure 행에 log 의 메시지 노출.
2. `failed:approving — usage.jsonl .result wins over log fallback` — fixture: 양쪽 모두 메시지 있음. Expectation: `usage.jsonl` 값 노출, log 의 sentinel 은 (tail -5 영역 밖에 배치) Failure 행에 노출되지 않음.

## Test plan

- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_approve.bats` — 80/80 pass (78 pre-existing + 2 new).
- [x] `shellcheck shell-common/functions/gh_pr_approve.sh` — 수정 영역(424-453) 경고 없음. 기존 SC2002 (line 367) 은 무관/사전 존재.
- [x] `tox -e ruff,shellcheck,shfmt` — green (pre-push lint guard 통과).
- [ ] (선택) 실제 #726 디렉토리에서 `gh-pr-approve status 726` 수동 재실행 — Failure 행에 `API Error: Unable to connect to API (ECONNRESET)` 표시되는지 확인.

Closes #666


---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
