### PR TITLE
fix(term-rename): #667 persist hook 을 append 로 — omz_termsupport 회귀 수정

### DIFF
--- a/shell-common/functions/term_rename.sh
+++ b/shell-common/functions/term_rename.sh
@@ -18,6 +18,11 @@ _term_rename_persist() {
 }
 
 _term_rename_install_hook() {
+    # Hook is APPENDED, not prepended. Reason: oh-my-zsh's
+    # omz_termsupport_precmd (and similar prompt-side title emitters in p10k
+    # / starship / vte) sit inside precmd_functions and emit OSC 0/2 with
+    # `user@host:cwd` on every prompt. Whichever hook fires LAST wins the
+    # tab label, so our re-emit must run last.
     # Inject the hook name via ${_hook} so the literal snake_case identifier
     # never appears inside a quoted string — silences the repo's naming check
     # (git/hooks/checks/naming_check.sh) that flags snake_case in user-facing
@@ -32,7 +37,7 @@ _term_rename_install_hook() {
             *"${_hook}"*) return 0 ;;
         esac
         if [ -n "${PROMPT_COMMAND-}" ]; then
-            PROMPT_COMMAND="${_hook}; ${PROMPT_COMMAND}"
+            PROMPT_COMMAND="${PROMPT_COMMAND}; ${_hook}"
         else
             PROMPT_COMMAND="${_hook}"
         fi
@@ -46,7 +51,7 @@ _term_rename_install_hook() {
             typeset -ga precmd_functions
             case " ${precmd_functions[*]-} " in
                 *" ${_hook} "*) : ;;
-                *) precmd_functions=("${_hook}" "${precmd_functions[@]}") ;;
+                *) precmd_functions=("${precmd_functions[@]}" "${_hook}") ;;
             esac
         '
         return 0

--- a/shell-common/functions/term_rename.sh
+++ b/shell-common/functions/term_rename.sh
@@ -32,10 +32,14 @@ _term_rename_install_hook() {
     # inside quoted strings. Same pattern as cp_wdown.sh:`local _name=cp_wdown`.
     local _hook
     _hook=_term_rename_persist
+    # Strip any existing occurrence first so install is idempotent AND
+    # always lands the hook at the tail. A plain dedup-and-skip would leave
+    # a previously-prepended hook stuck at the front (the exact failure
+    # mode in shell sessions that loaded the pre-#672 buggy version),
+    # making `--persist` look fixed in fresh sessions but inert in
+    # existing ones (gemini-code-assist on PR #672).
+    _term_rename_remove_hook
     if [ -n "${BASH_VERSION-}" ]; then
-        case "${PROMPT_COMMAND-}" in
-            *"${_hook}"*) return 0 ;;
-        esac
         if [ -n "${PROMPT_COMMAND-}" ]; then
             PROMPT_COMMAND="${PROMPT_COMMAND}; ${_hook}"
         else
@@ -45,14 +49,11 @@ _term_rename_install_hook() {
     fi
     if [ -n "${ZSH_VERSION-}" ]; then
         # zsh array syntax wrapped in eval so bash never tries to parse it.
-        # typeset -ga is a no-op when precmd_functions already exists; it
-        # only matters when sourced before zsh's add-zsh-hook plumbing.
+        # typeset -ga guarantees precmd_functions exists as a global array
+        # even when sourced before zsh's add-zsh-hook plumbing.
         eval '
             typeset -ga precmd_functions
-            case " ${precmd_functions[*]-} " in
-                *" ${_hook} "*) : ;;
-                *) precmd_functions=("${precmd_functions[@]}" "${_hook}") ;;
-            esac
+            precmd_functions=("${precmd_functions[@]}" "${_hook}")
         '
         return 0
     fi


### PR DESCRIPTION
## Summary

- PR #668 (#667 구현, 머지 commit `f4582df`) 머지 후 검증에서 `term-rename --persist <name>` 가 동작하지 않음을 발견.
- 원인: `_term_rename_persist` 가 `precmd_functions` / `PROMPT_COMMAND` 앞쪽에 prepend 되어 있어, 같은 hook 배열 뒤쪽의 oh-my-zsh `omz_termsupport_precmd` 가 매 프롬프트마다 `user@host:cwd` OSC 를 발사하며 우리 OSC 를 덮어씀. 일회성 `term-rename pr-668` 도 동일 이유로 무력화.
- Fix: hook 을 append 로 변경 → 마지막 emitter 가 되도록 보장.

## Changes

- `shell-common/functions/term_rename.sh` — `_term_rename_install_hook`
  - bash 분기: `PROMPT_COMMAND="${_hook}; ${PROMPT_COMMAND}"` → `PROMPT_COMMAND="${PROMPT_COMMAND}; ${_hook}"`
  - zsh 분기: `precmd_functions=("${_hook}" "${precmd_functions[@]}")` → `precmd_functions=("${precmd_functions[@]}" "${_hook}")`
  - 의도 주석 6줄 추가 — omz_termsupport / p10k / starship / vte 등 prompt-side OSC emitter 와 공존하려면 hook 이 마지막에 실행되어야 한다는 근거 명시 (재발 방지).

## Test plan

- [x] 격리 `zsh -i` 에서 검증 — `precmd_functions` 마지막 원소가 `_term_rename_persist`. omz_termsupport_precmd 가 6번째, 우리 hook 이 11번째 → 매 프롬프트마다 우리 OSC 가 가장 늦게 발사.
- [x] tox 기반 lint guard (ruff / shellcheck / shfmt) 통과.
- [ ] 사용자 인터랙티브 셸에서 `source shell-common/functions/term_rename.sh && term-rename --persist pr-668` → 탭 라벨이 `bwyoon@SERPH:~/dotfiles…` → `pr-668` 로 변경 후 빈 엔터 반복에도 유지되는지 육안 확인.
- [ ] `term-rename --clear` → hook 제거 정상 (`tests/bats/functions/term_rename.bats` 의 기존 sed 패턴이 trailing 형식까지 처리하므로 회귀 없음).

## Related

Fixes #667

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
