### PR TITLE
feat(skill): #673 add /gh:pr-resolve-ci-fail — CI fail 라벨 PR 1-shot 해결

### DIFF
--- a/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: gh:pr-resolve-ci-fail
+description: >-
+  Resolve a GitHub PR's CI failure: fetch failing check logs, fix the cause
+  locally, run local lint/test, commit and push (never force), then remove
+  the `CI fail` label as the **last** step so reviewers can re-approve. Use
+  when the user runs /gh:pr-resolve-ci-fail, /gh-pr-resolve-ci-fail, or asks
+  "PR CI fail 해결", "CI fail 라벨 떼줘", "PR CI 빨간 거 고쳐". Refuses on the
+  default branch, refuses `--force` / `--force-with-lease`, refuses to push
+  when local lint/test is red (CI infinite-loop guard). Sister skill of
+  [[gh-pr-resolve-conflict]] — different verb and risk profile, same
+  PR-lifecycle slot. Accepts `[pr-number] [remote] [--wait <seconds>]
+  [--label-variant <input>]`; defaults to the PR attached to the current
+  branch. Accepts `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+# gh:pr-resolve-ci-fail — CI Failure Resolution
+
+## Help
+
+Arg #1 `-h`/`--help`/`help` → read `references/help.md` verbatim, stop. No API calls.
+
+## Step 1: Parse Args + Preflight
+
+Record `START_TS=$(date +%s)` immediately for Step 7.
+
+Positional: `[pr-number] [remote]`. Flags: `--wait <seconds>` (opt-in,
+default off), `--label-variant <input>` (override canonical label).
+
+- `pr-number` omitted → auto-detect via `gh pr view --json
+  number,state,headRefName` on current branch. No PR → stop.
+- `remote` default `origin`. Missing → `git remote -v` and stop.
+- `--label-variant` normalized via `references/label-normalization.md`; unknown → fail-fast.
+
+State `OPEN` required. Hard preconditions in `references/safety.md` →
+"Preconditions". Capture `BACKUP_SHA=$(git rev-parse HEAD)` for recovery.
+
+## Step 2: Fetch Failing Checks
+
+`gh pr checks <N> --required --json name,state,workflow,link`, filter
+`state == FAILURE`. All green → `[OK] no failing checks — nothing to
+resolve.` and stop. Filter rubric + in-progress carveout in
+`references/ci-log-analysis.md` → "Step 2".
+
+## Step 3: Fetch + Analyze Logs
+
+Resolve each failing workflow's latest `RUN_ID`, dump `gh run view
+<id> --log-failed`, identify the root cause. Parsing rubric +
+common patterns (lint / type / test / build) in
+`references/ci-log-analysis.md` → "Step 3 — Log triage". No
+identifiable fix → surface log and stop. **Never** blind-retry.
+
+## Step 4: Fix Locally + Validate
+
+Edit failing files per Step 3, then run the same lint/test command CI
+ran (NF-3 — CI infinite-loop guard; detection heuristic in
+`references/safety.md` → "Local validation gate"). Still red → stop with
+`[FAIL] local checks failed — fix before push`. **Do not push.**
+
+## Step 5: Commit + Push (no force)
+
+Inline commit (do NOT delegate to `gh:commit` — composition re-prompt).
+Title `fix(ci): <summary> (#<PR_NUMBER>)`. Fast-forward push only —
+**no `--force`, no `--force-with-lease`**. Rejected → surface
+divergence and stop; **label is NOT yet removed**. Exact commands +
+divergence message in `references/safety.md` → "Step 5 push".
+
+## Step 6: Optional CI Green Wait (`--wait`)
+
+`--wait <seconds>` passed → poll `gh pr checks --required` every 30 s
+until green or timeout. Timeout → `[WARN] CI still pending after
+<N>s — proceeding to label removal.` Without flag, skip. Polling loop
+in `references/ci-log-analysis.md` → "Step 6 wait".
+
+## Step 7: Remove `CI fail` Label + Report
+
+**Invariant** — last mutation. Step 5 push failed → this step does NOT
+run (label stays so reviewers know CI is still red). Canonical label
+name from `references/label-normalization.md`.
+
+REST DELETE: `gh api -X DELETE
+"repos/{owner}/{repo}/issues/<N>/labels/CI%20fail"` (URL-encode space;
+404 = absent → soft-fail). **Do not** use `gh pr edit --remove-label` —
+classic-Projects silent-fail issue same as `gh:pr-resolve-conflict` Step
+5 (#326 Bug B). Full block + ai-metrics comment in
+`references/safety.md` → "Step 7".
+
+Report: `[OK] PR #<N> CI 복구 완료 · 라벨 제거됨 · <sha> push 됨.`
+followed by `Next: /gh-pr-reply <N>  # CI 그린 확인 후 리뷰어 회신`.
+
+## Constraints
+
+- Never `--force` / `--force-with-lease`. Fast-forward only.
+- Never run on the default branch.
+- Never push when local lint/test is red.
+- Never remove the label before push succeeds.
+- Never auto-create labels (missing label → soft-fail).
+- Never auto-stash. Clean tree required.
+- Never delegate to `gh:commit` (re-prompt inside composition).

--- a/claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md
@@ -40,15 +40,30 @@ keep YAGNI until a real ask appears.
 
 ## Step 3 — Log triage
 
-For each failing workflow from Step 2:
+`HEAD_REF` is already bound in SKILL.md Step 1 (from the initial
+`gh pr view --json number,state,headRefName` call) — reuse it,
+do not re-fetch.
+
+Fetch the recent run list **once** for the branch, then jq-filter
+per failing workflow inside the loop:
 
 ```bash
-HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json headRefName --jq '.headRefName')
-RUN_ID=$(gh run list --repo "$TARGET_REPO" --branch "$HEAD_REF" \
-    --workflow "<workflow-name>" --limit 1 \
-    --json databaseId --jq '.[0].databaseId')
-gh run view "$RUN_ID" --repo "$TARGET_REPO" --log-failed
+# Pre-fetch once: most recent run for each workflow on this branch.
+RUNS_JSON=$(gh run list --branch "$HEAD_REF" --limit 50 \
+    --json databaseId,workflowName,headSha)
+
+# In the per-failing-workflow loop:
+for WF_NAME in $FAILING_WORKFLOWS; do
+    RUN_ID=$(printf '%s' "$RUNS_JSON" \
+        | jq -r --arg n "$WF_NAME" \
+            '[.[] | select(.workflowName==$n)] | .[0].databaseId')
+    gh run view "$RUN_ID" --log-failed
+done
 ```
+
+One `gh run list` call instead of N. Cuts network/process overhead
+when several workflows fail at once. `gh run view` does not accept
+`--repo`; rely on cwd-based repo detection.
 
 ### Common failure patterns
 

--- a/claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md
@@ -1,0 +1,108 @@
+# gh:pr-resolve-ci-fail — CI Log Analysis
+
+Detail companion for SKILL.md Steps 2, 3, and 6.
+
+## Step 2 — Fetch failing checks
+
+```bash
+gh pr checks "$PR_NUMBER" --repo "$TARGET_REPO" --required \
+    --json name,state,workflow,link \
+    --jq '[.[] | select(.state=="FAILURE")]'
+```
+
+### Filter rules
+
+- `--required` — only required checks count. Non-required can stay red
+  without blocking re-Approve, so this skill ignores them by default.
+- `state == FAILURE` — explicit. `CANCELLED` and `TIMED_OUT` are
+  treated separately (see in-progress carveout).
+- Empty result → `[OK] no failing checks — nothing to resolve.` Exit
+  success.
+
+### In-progress carveout
+
+If any check is `IN_PROGRESS` or `PENDING` when this skill runs, the
+"all green" signal is unreliable. Print a 1-line warning and continue:
+
+```
+[WARN] <N> required checks still in progress — treating as green for now.
+       If they go red after push, re-run /gh-pr-resolve-ci-fail.
+```
+
+This is intentional — we'd rather get a fix queued than block on
+flaky CI scheduling.
+
+### Non-required policy
+
+If the user truly wants non-required checks treated as failures, they
+pass them explicitly. v1 of this skill does not expose that switch —
+keep YAGNI until a real ask appears.
+
+## Step 3 — Log triage
+
+For each failing workflow from Step 2:
+
+```bash
+HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json headRefName --jq '.headRefName')
+RUN_ID=$(gh run list --repo "$TARGET_REPO" --branch "$HEAD_REF" \
+    --workflow "<workflow-name>" --limit 1 \
+    --json databaseId --jq '.[0].databaseId')
+gh run view "$RUN_ID" --repo "$TARGET_REPO" --log-failed
+```
+
+### Common failure patterns
+
+Walk the log tail (last ~80 lines is usually enough; full log only if
+the failure is upstream of a cascade):
+
+| Pattern | Signal in log | Fix scope |
+|---|---|---|
+| Lint failure | `error  ...  prefer-const`, `Use \`...\``, ESLint/Ruff/shellcheck output | Edit reported files at reported lines |
+| Type check | `error TS2345`, `mypy: error:`, `Argument of type ...` | Edit reported files, possibly add type annotations |
+| Test failure | `FAIL `, `Test failed:`, `AssertionError`, `expect(...).toBe(...)` | Edit either the test or the implementation — read the assertion first |
+| Build failure | `Cannot find module`, `Module not found`, `npm ERR!`, `bash: ...: command not found` | Often `package.json` / lockfile / env. Investigate before assuming code |
+| Format check | `Code would be reformatted`, `prettier --check failed`, `shfmt -d` | Run formatter locally and re-commit |
+
+### Heuristic for "no identifiable fix"
+
+If the log shows:
+
+- a Docker pull failure (`unauthorized: authentication required`),
+- a network timeout (`dial tcp ... i/o timeout`),
+- an OOM kill (`exit code 137`),
+- a flaky test that passes locally,
+
+→ surface the log to the user and **stop**. These are not code defects;
+re-running the workflow is the right move, and this skill refuses to
+push an unrelated commit just to trigger a re-run.
+
+## Step 6 — `--wait` polling loop
+
+```bash
+WAIT_SECONDS="$1"   # from --wait flag
+ELAPSED=0
+INTERVAL=30
+while [ "$ELAPSED" -lt "$WAIT_SECONDS" ]; do
+    PENDING=$(gh pr checks "$PR_NUMBER" --repo "$TARGET_REPO" --required \
+        --json state --jq '[.[] | select(.state=="IN_PROGRESS" or .state=="PENDING" or .state=="FAILURE")] | length')
+    [ "$PENDING" -eq 0 ] && break
+    sleep "$INTERVAL"
+    ELAPSED=$(( ELAPSED + INTERVAL ))
+done
+
+if [ "$PENDING" -gt 0 ]; then
+    echo "[WARN] CI still pending after ${WAIT_SECONDS}s — proceeding to label removal."
+fi
+```
+
+### Why the warn-and-proceed default
+
+The user opted in to `--wait`, so they accept the race condition that
+the label might come off while CI is still going. The alternative
+(refusing to remove the label on timeout) would defeat the purpose of
+the skill, which is to unblock reviewer re-approval.
+
+If they want strict "only on green", they can omit `--wait` and run
+the skill twice: once to push, once after CI is confirmed green to
+remove the label (Step 5 push will no-op the second time since the
+fix is already pushed).

--- a/claude/skills/gh-pr-resolve-ci-fail/references/help.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/help.md
@@ -1,0 +1,88 @@
+# gh:pr-resolve-ci-fail — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<pr-number>` or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `803` |
+| 2 | remote-name | `origin` | Git remote whose repo owns the PR |
+| flag | `--wait <seconds>` | off | Opt-in: poll CI green before label removal |
+| flag | `--label-variant <input>` | `CI fail` | Override canonical label (normalized via `references/label-normalization.md`) |
+
+## Usage
+
+```
+/gh-pr-resolve-ci-fail              # PR attached to current branch, origin
+/gh-pr-resolve-ci-fail 803          # explicit PR, origin
+/gh-pr-resolve-ci-fail 803 upstream # explicit PR, upstream remote
+/gh-pr-resolve-ci-fail 803 --wait 300       # wait up to 5 min for CI green before label removal
+/gh-pr-resolve-ci-fail --label-variant "CI fial"  # accept user's typo, normalize internally
+/gh-pr-resolve-ci-fail -h           # this help
+```
+
+## When to use this skill
+
+- A PR has a `CI fail` label (or variant) blocking re-Approve.
+- Required CI checks are red and you've identified the cause is a fixable
+  code defect (not flake).
+- You want to stay on the no-force-push policy track — this skill refuses
+  `--force` and `--force-with-lease`.
+
+## When NOT to use
+
+- CI red because of flake / infra outage. Re-run the workflow, don't
+  open a code fix.
+- Merge conflict on the PR (use `/gh-pr-resolve-conflict` instead).
+- Review comments need replies (use `/gh-pr-reply` after CI green).
+- You want to admin-bypass and merge without fixing CI
+  (use `/gh-pr-merge-emergency` with audit trail).
+- You're on the repo's default branch — refuses, check out the PR's
+  head branch first.
+
+## What the skill does
+
+1. Parses args. Auto-detects the PR from the current branch if omitted.
+2. Prints a **backup SHA** so `git reset --hard <sha>` can undo edits.
+3. Refuses if working tree is dirty (unrelated edits may be in flight).
+4. Fetches failing required checks via `gh pr checks --required`.
+5. For each failure: dumps `gh run view --log-failed`, identifies cause.
+6. Edits failing files, runs the same lint/test command CI ran.
+7. Local lint/test still red → stops (CI infinite-loop guard).
+8. Commits `fix(ci): <summary> (#<PR_NUMBER>)` and `git push` (no force).
+9. Optionally polls CI green if `--wait <seconds>` was passed.
+10. Removes the `CI fail` label via REST DELETE (last step, soft-fail).
+
+## Safety
+
+- **No force-push** — `--force` and `--force-with-lease` both refused.
+  Fast-forward only. Rebased history would require `gh:pr-resolve-conflict`.
+- **Local validation gate** — push only runs after the same lint/test
+  command CI ran exits 0 locally. Stops the "push → CI red → fix → push
+  → CI red" infinite loop.
+- **Label is the LAST mutation** — push must succeed before the label
+  comes off. Premature removal misleads reviewers into re-approving red.
+- **No auto-stash** — working tree must be clean. The user's local
+  edits may be unrelated context the skill shouldn't touch.
+- **No blind retry** — if log analysis can't identify a concrete fix,
+  the skill surfaces the log and stops.
+
+## What this skill will NOT do
+
+- Force-push (`--force` or `--force-with-lease`). Non-negotiable.
+- Run on the repo's default branch.
+- Auto-create the `CI fail` label if missing — soft-fail with a warning.
+- Auto-stash a dirty working tree.
+- Push when local lint/test fails.
+- Delegate the commit step to `gh:commit` — inline commit only, to
+  avoid re-prompts inside a composition.
+- Resolve merge conflicts (that's `/gh-pr-resolve-conflict`).
+- Reply to review comments (that's `/gh-pr-reply` after CI green).
+
+## Related skills
+
+- `gh:pr-resolve-conflict` — sister skill, rebase-resolves a base-moved
+  PR conflict warning. Different verb (rebase vs read-logs-and-edit).
+- `gh:pr-reply` — reply to PR review comments after CI is green.
+- `gh:pr-approve` — review and approve a PR (after CI green).
+- `gh:pr-merge` — merge an already-clean PR (rebase/squash/merge).
+- `gh:pr-merge-emergency` — admin-bypass merge with audit trail.

--- a/claude/skills/gh-pr-resolve-ci-fail/references/label-normalization.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/label-normalization.md
@@ -1,0 +1,65 @@
+# gh:pr-resolve-ci-fail — Label Normalization
+
+F-7 SSOT: variant inputs that the operator (or a typo-prone teammate)
+might pass via `--label-variant <input>` map to the canonical GitHub
+label `CI fail`. The skill uses this table to:
+
+1. Reject obviously-wrong inputs (`bug`, `enhancement`, etc.) up front
+   with a fail-fast message that prints the canonical name and table.
+2. Tolerate case / spacing / common typos without forcing the user to
+   memorize the exact label string.
+
+## Variant → Canonical
+
+| Input variant | Canonical |
+|---|---|
+| `CI fail` | `CI fail` |
+| `ci fail` | `CI fail` |
+| `CI Fail` | `CI fail` |
+| `ci-fail`, `CI-fail`, `CI-Fail` | `CI fail` |
+| `ci_fail`, `CI_fail`, `CI_Fail` | `CI fail` |
+| `CI fial`, `ci fial`, `CI Fial` (typo: `fial` ↔ `fail`) | `CI fail` |
+| `CI failed`, `ci failed` (past tense slip) | `CI fail` |
+| `ci/fail`, `CI/fail` (slash) | `CI fail` |
+
+## Lookup procedure
+
+1. Lower-case the input, strip leading/trailing whitespace.
+2. Replace `-`, `_`, `/` with a single space.
+3. Collapse runs of whitespace to one space.
+4. Match against the lower-cased canonical form `ci fail`.
+5. Apply the typo carveout: replace `fial` → `fail` once before matching.
+6. Past-tense carveout: trim trailing `ed` once before matching.
+
+If steps 1-6 produce `ci fail` → canonical = `CI fail`. Otherwise →
+fail-fast.
+
+## Fail-fast message
+
+```
+[FAIL] unknown label-variant '<input>' — expected one of the variants below.
+Canonical label: CI fail
+
+Accepted variants:
+  CI fail, ci fail, CI Fail
+  ci-fail, ci_fail, ci/fail (and case variations)
+  CI fial (typo), CI failed (past tense)
+
+Pass --label-variant '<variant>' or omit the flag to use 'CI fail'.
+```
+
+## Why a separate file (not inline in SKILL.md)
+
+The table is content (data), not workflow (procedure). Progressive
+Disclosure (skill:check Check 2) says workflow phases stay in SKILL.md
+and detail moves to `references/`. The table will also grow over time
+as new variants appear in the wild — keeping it here means SKILL.md
+doesn't churn for label-name additions.
+
+## Future: external SSOT yaml
+
+Open Question from issue #673: should this table move to
+`.gh-pr-labels.yml` at the repo root so AgentToolbox / dotfiles / etc.
+can each declare their own label conventions? Defer until a second
+repo with different label naming actually appears. KISS — internal
+table is fine for v1.

--- a/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
@@ -1,0 +1,149 @@
+# gh:pr-resolve-ci-fail — Safety Nets
+
+Detail companion for SKILL.md Steps 1, 4, 5, and 7.
+
+## Preconditions (Step 1)
+
+Run as a parallel batch. Any failure → stop with the matching message.
+
+| Check | How | Fail message |
+|---|---|---|
+| Inside a git repo | `git rev-parse --show-toplevel` | `[FAIL] not inside a git repo` |
+| Not on default branch | Compare `git rev-parse --abbrev-ref HEAD` against `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` | `[FAIL] refuses on default branch (<DEFAULT>) — check out the PR's head branch first` |
+| Working tree clean | `git status --porcelain` empty | `[FAIL] working tree dirty — commit/stash your edits first; this skill never auto-stashes` |
+| No in-progress rebase / merge / cherry-pick | `git rev-parse --git-path rebase-merge` / `rebase-apply` / `MERGE_HEAD` / `CHERRY_PICK_HEAD` / `REVERT_HEAD` all absent | `[FAIL] in-progress <name> at <marker> — finish or abort first` |
+
+### Why no auto-stash
+
+Sister skill `gh-pr-resolve-conflict` does auto-stash because rebase
+controls the entire working tree. This skill **edits the working tree
+itself** in Step 4, so an auto-stash would silently drop the user's
+unrelated edits onto the stash list and then pop them onto our CI fix
+commit. The safer default is to demand a clean tree.
+
+## Local validation gate (Step 4)
+
+The "infinite loop" risk: push fix → CI still red → fix → push → CI
+still red → … The mitigation is to run the same command CI ran
+locally, before pushing, and stop on red.
+
+### Detection heuristic for "what CI ran"
+
+Read the failing workflow's YAML (`gh api repos/.../contents/.github/workflows/<file>`)
+and extract the `run:` line from the step that failed. If parsing the
+YAML is too fragile, fall back to the project's conventional commands
+in order:
+
+1. `tox` (if `tox.ini` exists at repo root) — dotfiles convention.
+2. `./tests/test` (if exists) — dotfiles convention.
+3. `pytest` (if `pyproject.toml` has `[tool.pytest]`).
+4. `npm test` / `pnpm test` / `yarn test` (if `package.json` exists).
+5. `ruff check && ruff format --check` (if Python project).
+6. `shellcheck` + `shfmt -d` (if shell-heavy project).
+
+If none match, print:
+
+```
+[WARN] cannot infer local lint/test command — run CI's command manually and re-invoke.
+```
+
+and stop. Better to ask the user than to push blind.
+
+### Stop message on red
+
+```
+[FAIL] local checks failed — fix before push.
+
+<command output>
+
+Re-run this skill once local checks pass.
+```
+
+Do not push. Do not remove the label. Step 5 must be reached with
+green local checks.
+
+## Step 5 push
+
+```bash
+git add -A
+git commit -m "fix(ci): <one-line summary> (#$PR_NUMBER)"
+git push "$REMOTE" HEAD
+```
+
+### Why no `--force-with-lease`
+
+This skill only fast-forwards. If the upstream has new commits
+(someone pushed to the same branch while we worked), we want the push
+to be **rejected**, not silently overwrite the colleague's work.
+
+### Push-rejected message
+
+```
+[FAIL] push rejected by upstream — someone pushed to this branch while you worked.
+
+Recovery:
+  git fetch <REMOTE>
+  git log --oneline HEAD..<REMOTE>/<HEAD_REF>
+  # decide whether to merge those in or rebase onto them, then re-run
+
+Backup of pre-Step-4 HEAD: $BACKUP_SHA
+  git reset --hard $BACKUP_SHA     # discard the local CI fix entirely
+```
+
+The label is NOT removed. Reviewers should still see CI red until the
+push lands.
+
+## Step 7 label removal + ai-metrics
+
+The label-removal block uses REST DELETE (not `gh pr edit
+--remove-label`) for the same classic-Projects silent-fail issue
+documented in `gh-pr-resolve-conflict` (#326 Bug B).
+
+```bash
+gh api -X DELETE "repos/{owner}/{repo}/issues/$PR_NUMBER/labels/CI%20fail" \
+    --repo "$TARGET_REPO" \
+    >/dev/null 2>&1 \
+  && echo "[OK] \`CI fail\` 라벨 제거됨 — 동료 재-Approve 흐름 해제" \
+  || echo "[WARN] \`CI fail\` 라벨 제거 실패 (이미 없거나 권한 없음 — 수동 제거 필요할 수 있음)"
+```
+
+`{owner}/{repo}` literal with `--repo "$TARGET_REPO"` lets `gh api`
+handle both URL and `owner/repo` forms safely. URL-encode any space
+or special char in the label name (e.g. `CI%20fail`).
+
+### ai-metrics PR comment (soft-fail)
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" -X POST \
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-3000} tokens · 👤 ~2 h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-resolve-ci-fail -->
+📊 ~${TOKENS:-3000} tokens · 👤 ~2 h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-resolve-ci-fail -->
+
+</details>
+CI fail 해결: ~$ELAPSED min · 사람: ~2 h" \
+      >/dev/null 2>&1 \
+      || echo "[WARN] ai-metrics comment failed — continuing."
+fi
+```
+
+- `${TOKENS:-3000}` — caller may pre-export an estimate; default 3000.
+- `~2 h` — `fix` lookup from `gh-issue-create/references/metrics-baseline.md`.
+- soft-fail: comment failure does NOT block the success report.
+
+## Recovery cheat-sheet (final report appendix)
+
+```
+If something went wrong:
+  git reset --hard $BACKUP_SHA     # discard local CI fix entirely
+  git reflog                        # find any lost ref
+  gh pr view <N> --json labels     # confirm label state
+  gh pr edit <N> --add-label "CI fail"  # manually re-add if needed
+```

--- a/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
@@ -101,15 +101,15 @@ documented in `gh-pr-resolve-conflict` (#326 Bug B).
 
 ```bash
 gh api -X DELETE "repos/{owner}/{repo}/issues/$PR_NUMBER/labels/CI%20fail" \
-    --repo "$TARGET_REPO" \
     >/dev/null 2>&1 \
   && echo "[OK] \`CI fail\` 라벨 제거됨 — 동료 재-Approve 흐름 해제" \
   || echo "[WARN] \`CI fail\` 라벨 제거 실패 (이미 없거나 권한 없음 — 수동 제거 필요할 수 있음)"
 ```
 
-`{owner}/{repo}` literal with `--repo "$TARGET_REPO"` lets `gh api`
-handle both URL and `owner/repo` forms safely. URL-encode any space
-or special char in the label name (e.g. `CI%20fail`).
+`{owner}/{repo}` placeholders are auto-resolved by `gh api` from the
+current working directory's git remote (or `GH_REPO` if set), so no
+`--repo` flag is needed — `gh api` does not accept `--repo` (#658).
+URL-encode any space or special char in the label name (e.g. `CI%20fail`).
 
 ### ai-metrics PR comment (soft-fail)
 
@@ -118,7 +118,7 @@ ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
 if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
     : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
 else
-    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" -X POST \
+    gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/comments" -X POST \
       -f body="---
 <details>
 <summary>🤖 AI Metrics · 📊 ~${TOKENS:-3000} tokens · 👤 ~2 h · 🤖 ~$ELAPSED min</summary>

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -7,8 +7,10 @@ description: >-
   /gh-pr-resolve-conflict, or asks "PR conflict 해결", "base 변경됐는데 rebase
   해줘", "리베이스로 컨플릭트 풀어". Refuses to run on the default branch,
   refuses plain `--force`, and never auto-guesses conflict content — the
-  user drives each resolution. Accepts `[pr-number] [remote]`; defaults to
-  the PR attached to the current branch. Accepts `-h`/`--help`/`help`.
+  user drives each resolution. Sister skill of [[gh-pr-resolve-ci-fail]] —
+  different verb (rebase-resolve vs read-logs-and-edit) for the same
+  PR-lifecycle slot. Accepts `[pr-number] [remote]`; defaults to the PR
+  attached to the current branch. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---
 

--- a/claude/skills/gh-pr-resolve-conflict/references/help.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/help.md
@@ -72,6 +72,9 @@
 
 ## Related skills
 
+- `gh:pr-resolve-ci-fail` — sister skill, resolves a `CI fail` label
+  by reading failing check logs and pushing a fix. Different verb
+  (read-logs-and-edit vs rebase) for the same PR-lifecycle slot.
 - `gh:pr-merge` — merge an already-clean PR (rebase/squash/merge).
 - `gh:pr-merge-emergency` — admin-bypass merge with audit trail.
 - `gh:pr` — create a PR from the current branch.


### PR DESCRIPTION
## Summary

신규 스킬 `gh:pr-resolve-ci-fail` 추가 — `CI fail` 라벨이 붙은 PR 을 받아서 (1) 실패한 워크플로 로그를 읽고 (2) 원인 수정 + 로컬 lint/test 검증, (3) fast-forward push, (4) `CI fail` 라벨 제거를 1-shot 으로 처리해 동료의 재-Approve 흐름을 자동으로 풀어준다. 사용자의 반복 prompt ("PR #N 검토하고 CI fail 해결해. 그리고 라벨 삭제해.") 를 스킬화한 것.

## Highlights

### 1. 신규 스킬 — `gh:pr-resolve-ci-fail`

| 파일 | 줄수 | 역할 |
|---|---|---|
| `claude/skills/gh-pr-resolve-ci-fail/SKILL.md` | 100 | 7-step 워크플로 본문 (progressive disclosure) |
| `references/help.md` | 88 | `-h`/`--help` 출력 SSOT |
| `references/label-normalization.md` | 65 | F-7 변형→정식 매핑 (`CI fial` 같은 오타도 `CI fail` 로 해석) |
| `references/ci-log-analysis.md` | 108 | Step 2/3/6 — `gh pr checks --required`, `gh run view --log-failed` 분석 rubric, `--wait` 폴링 |
| `references/safety.md` | 149 | Step 1/4/5/7 — preconditions, 로컬 validation gate, push 정책, 라벨 제거 + ai-metrics |

### 2. 핵심 invariants (Constraints 섹션)

- **force-push 금지** — `--force` 와 `--force-with-lease` 둘 다 거부. fast-forward only.
- **로컬 lint/test 통과 후에만 push** — CI 무한 루프 (push → 빨강 → fix → push → 빨강…) 방지 (NF-3).
- **라벨 제거가 반드시 마지막 단계** — push 실패 시 라벨 미제거 (동료가 빨간 CI 를 보고도 re-Approve 하는 사고 방지).
- **auto-stash 금지** — 사용자의 로컬 변경은 무관한 컨텍스트일 수 있음. 더러운 트리는 fail-fast.
- **default branch 거부** — `gh:pr-resolve-conflict` 와 동일 가드.
- **`gh:commit` 위임 금지** — 인라인 commit. composition 내에서 재-prompt 회피.

### 3. Sister-skill cross-link

`gh:pr-resolve-conflict` SKILL.md description + Related skills 섹션 양쪽에 sister-skill 명시. 두 스킬의 verb / risk profile 비교:

| 관점 | `gh:pr-resolve-conflict` | `gh:pr-resolve-ci-fail` |
|---|---|---|
| 트리거 | merge conflict | CI red |
| 핵심 동작 | rebase + `--force-with-lease` | read logs → edit → 일반 push |
| 위험 | git history 재작성 | 일반 커밋 (non-destructive) |
| 라벨 처리 | `conflict` 제거 | `CI fail` 제거 |

### 4. 거절된 통폐합 대안

이슈 #673 본문에 기록된 의사결정 트레일:

| 대안 | 거절 사유 |
|---|---|
| `gh:pr-resolve --type <conflict\|ci-fail\|...>` | verb / risk / 개입 지점이 본질적으로 다름. SKILL.md description trigger 정확도 저하. |
| `gh:ci-fail` (PR 중심 아님) | `gh:pr-*` 군 일관성 파괴. PR 컨텍스트가 본질. |
| 라벨 제거를 별도 스킬로 | 라벨 제거가 워크플로 본질적 마지막 단계 — 분리 시 F-6 invariant 약화. |

## Test plan

- [x] `tox -e ruff,shellcheck,shfmt` PASS (pre-push lint guard 통과)
- [x] `wc -l` SKILL.md = 100 (skill:check Check 1 PASS 경계)
- [x] 11/12 skill:check 항목 PASS (Check 11 emoji 는 ai-metrics footer 시스템 패턴 — sister skill 과 동일 상태)
- [ ] 실제 PR 에서 `CI fail` 라벨 시나리오 1회 dry-run 검증 (별도 follow-up)
- [ ] 라벨 정규화 표 → `CI fial` 입력이 `CI fail` 로 매핑되는지 통합 테스트

Closes #673

---
<details>
<summary>🤖 AI Metrics · 📊 ~8000 tokens · 👤 ~8 h · 🤖 ~11 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~8000 tokens · 👤 ~8 h · 🤖 ~11 min
<!-- /ai-metrics:gh-pr -->

</details>
