### PR TITLE
feat(gwt-spawn): #675 --launch 시 term-rename --persist 자동 발사

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1443,7 +1443,7 @@ git_worktree_spawn() {
     fi
 
     local base="" name="" use_tmux=0 use_launch=0 use_bg=0 \
-          agent="claude" account="" prompt="" prompt_set=0 prompt_warned=0
+          agent="claude" ai_set=0 account="" prompt="" prompt_set=0 prompt_warned=0
 
     # Parse arguments. New grammar (#650): option-only; --wt-name is the
     # required name, --prompt is the trailing AI initial-task flag that
@@ -1497,7 +1497,7 @@ git_worktree_spawn() {
                 if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
                     ux_error "--ai requires a value"; return 1
                 fi
-                agent="$2"; shift 2
+                agent="$2"; ai_set=1; shift 2
                 ;;
             --user)
                 if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
@@ -1749,6 +1749,26 @@ git_worktree_spawn() {
         fi
         ux_info "  launch: cd \"$wt_path\" && $launch_cmd"
         cd "$wt_path" || { ux_error "Cannot cd to $wt_path"; return 1; }
+        # Label the VSCode tab with "(<agent>) <wt-name>" so multiple
+        # spawned worktrees are distinguishable at a glance (issue #675).
+        # --persist installs a precmd hook in the caller's shell that
+        # re-emits OSC 0 before every prompt — so after the agent exits
+        # and the user is left at the worktree's shell, the label sticks
+        # (term_rename.sh design from #672). When --ai was not typed by
+        # the user, the "(<agent>) " prefix is dropped per the issue's
+        # edge-case spec — even though `agent` itself always defaults to
+        # `claude`, the prefix is treated as a "user-explicitly-asked-
+        # to-disambiguate" signal. Guarded by command -v so the spawn
+        # still works if term_rename.sh somehow isn't loaded.
+        if command -v term_rename >/dev/null 2>&1; then
+            local _gwt_label
+            if [ "$ai_set" = 1 ]; then
+                _gwt_label="(${agent}) ${name}"
+            else
+                _gwt_label="$name"
+            fi
+            term_rename --persist "$_gwt_label"
+        fi
         eval "$launch_cmd"
     else
         ux_info ""

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1443,7 +1443,7 @@ git_worktree_spawn() {
     fi
 
     local base="" name="" use_tmux=0 use_launch=0 use_bg=0 \
-          agent="claude" ai_set=0 account="" prompt="" prompt_set=0 prompt_warned=0
+          agent="claude" account="" prompt="" prompt_set=0 prompt_warned=0
 
     # Parse arguments. New grammar (#650): option-only; --wt-name is the
     # required name, --prompt is the trailing AI initial-task flag that
@@ -1497,7 +1497,7 @@ git_worktree_spawn() {
                 if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
                     ux_error "--ai requires a value"; return 1
                 fi
-                agent="$2"; ai_set=1; shift 2
+                agent="$2"; shift 2
                 ;;
             --user)
                 if [ $# -lt 2 ] || [ -z "${2-}" ] || [ "${2#-}" != "$2" ]; then
@@ -1754,20 +1754,14 @@ git_worktree_spawn() {
         # --persist installs a precmd hook in the caller's shell that
         # re-emits OSC 0 before every prompt — so after the agent exits
         # and the user is left at the worktree's shell, the label sticks
-        # (term_rename.sh design from #672). When --ai was not typed by
-        # the user, the "(<agent>) " prefix is dropped per the issue's
-        # edge-case spec — even though `agent` itself always defaults to
-        # `claude`, the prefix is treated as a "user-explicitly-asked-
-        # to-disambiguate" signal. Guarded by command -v so the spawn
-        # still works if term_rename.sh somehow isn't loaded.
+        # (term_rename.sh design from #672). The "(<agent>)" prefix is
+        # always included — even when the user did not type --ai — because
+        # the program actually runs the default agent (claude) in that
+        # case, so the label must match the actual behavior (PR #676
+        # review). Guarded by command -v so the spawn still works if
+        # term_rename.sh somehow isn't loaded.
         if command -v term_rename >/dev/null 2>&1; then
-            local _gwt_label
-            if [ "$ai_set" = 1 ]; then
-                _gwt_label="(${agent}) ${name}"
-            else
-                _gwt_label="$name"
-            fi
-            term_rename --persist "$_gwt_label"
+            term_rename --persist "(${agent}) ${name}"
         fi
         eval "$launch_cmd"
     else

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -681,9 +681,10 @@ teardown() {
     assert_output "|--persist|(claude) pr-719"
 }
 
-@test "bash: #675 spawn --launch without --ai drops the '(<agent>)' prefix" {
-    # Edge case from issue body: --ai unspecified ⇒ label is just <wt-name>,
-    # even though `agent` itself defaults to claude internally.
+@test "bash: #675 spawn --launch without --ai still includes '(claude)' prefix (default)" {
+    # PR #676 review correction: --ai unspecified ⇒ program actually runs
+    # claude (the default), so the label must reflect that real behavior.
+    # Earlier draft dropped the prefix in this case; user feedback fixed it.
     run_in_bash "
         cd '$FAKE_REPO' || exit 1
         MARKER='$TEST_TEMP_HOME/spawn-trn-noai-marker'
@@ -698,7 +699,7 @@ teardown() {
         cat \"\$MARKER\"
     "
     assert_success
-    assert_output "|--persist|pr-720"
+    assert_output "|--persist|(claude) pr-720"
 }
 
 @test "bash: #675 spawn --launch --ai gemini emits '(gemini) <wt-name>'" {

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -655,3 +655,105 @@ teardown() {
     # Single positional arg, no --bg.
     assert_output "|hello world"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #675: --launch auto-emits term-rename --persist so the VSCode tab
+# shows "(<agent>) <wt-name>" while the spawned worktree's shell is active.
+# Shadow term_rename with a recorder; the real implementation's OSC printf
+# is harmless under `>/dev/null` redirection inside run_in_bash.
+# ---------------------------------------------------------------------------
+
+@test "bash: #675 spawn --launch --ai claude emits term-rename '(claude) <wt-name>'" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-trn-claude-marker'
+        export MARKER
+        claude_yolo() { :; }
+        term_rename() {
+            local _trn=''
+            for _a in \"\$@\"; do _trn=\"\${_trn}|\$_a\"; done
+            printf '%s\n' \"\$_trn\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --ai claude --wt-name pr-719 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--persist|(claude) pr-719"
+}
+
+@test "bash: #675 spawn --launch without --ai drops the '(<agent>)' prefix" {
+    # Edge case from issue body: --ai unspecified ⇒ label is just <wt-name>,
+    # even though `agent` itself defaults to claude internally.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-trn-noai-marker'
+        export MARKER
+        claude_yolo() { :; }
+        term_rename() {
+            local _trn=''
+            for _a in \"\$@\"; do _trn=\"\${_trn}|\$_a\"; done
+            printf '%s\n' \"\$_trn\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --wt-name pr-720 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--persist|pr-720"
+}
+
+@test "bash: #675 spawn --launch --ai gemini emits '(gemini) <wt-name>'" {
+    # Non-claude agent — confirms the prefix uses whatever the user typed,
+    # not the default.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-trn-gemini-marker'
+        export MARKER
+        gemini_yolo() { :; }
+        term_rename() {
+            local _trn=''
+            for _a in \"\$@\"; do _trn=\"\${_trn}|\$_a\"; done
+            printf '%s\n' \"\$_trn\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --ai gemini --wt-name pr-721 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--persist|(gemini) pr-721"
+}
+
+@test "bash: #675 spawn without --launch does NOT emit term-rename" {
+    # Worktree-only path: no agent dispatch, no label emit. The marker file
+    # must remain untouched (absent).
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-trn-no-launch-marker'
+        export MARKER
+        term_rename() {
+            local _trn=''
+            for _a in \"\$@\"; do _trn=\"\${_trn}|\$_a\"; done
+            printf '%s\n' \"\$_trn\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --wt-name pr-722 >/dev/null 2>&1
+        if [ -e \"\$MARKER\" ]; then echo MARKER_PRESENT; else echo NO_MARKER; fi
+    "
+    assert_success
+    assert_output "NO_MARKER"
+}
+
+@test "zsh: #675 spawn --launch --ai claude emits term-rename under zsh" {
+    run_in_zsh "
+        cd '$FAKE_REPO' || exit 1
+        MARKER='$TEST_TEMP_HOME/spawn-trn-zsh-marker'
+        export MARKER
+        claude_yolo() { :; }
+        term_rename() {
+            local _trn=''
+            for _a in \"\$@\"; do _trn=\"\${_trn}|\$_a\"; done
+            printf '%s\n' \"\$_trn\" > \"\$MARKER\"
+        }
+        git_worktree_spawn --launch --ai claude --wt-name pr-723 >/dev/null 2>&1
+        cat \"\$MARKER\"
+    "
+    assert_success
+    assert_output "|--persist|(claude) pr-723"
+}


### PR DESCRIPTION
## Summary

- `gwt spawn --launch` 진입점에서 `cd "$wt_path"` 직후 `term-rename --persist "(<agent>) <wt-name>"` 를 자동 호출하도록 추가 (issue #675).
- 옵션 파서에 `ai_set` 플래그 신설 — 사용자가 `--ai` 를 명시적으로 입력한 경우와 default fallback (`agent="claude"`) 을 구분. 명시한 경우만 `(<agent>)` 접두사를 라벨에 포함, 미지정 시 라벨은 `<wt-name>` 만 표시 (이슈 본문 edge-case 명세).
- `term_rename` 호출은 `command -v` 가드로 보호 — 함수 미로드 시에도 spawn 동작 자체는 영향 없음.
- `--persist` hook 은 caller shell 의 `precmd_functions` / `PROMPT_COMMAND` 에 설치되므로, agent 종료 후 워크트리 셸 프롬프트로 복귀 시 탭 라벨이 다시 적용됨 (#672 의 hook 순서 설계 그대로 활용).

## 동작 매트릭스

| 호출 | 발사되는 명령 |
|------|--------------|
| `gwt spawn --launch --ai claude --wt-name pr-719` | `term-rename --persist "(claude) pr-719"` |
| `gwt spawn --launch --ai gemini --wt-name pr-721` | `term-rename --persist "(gemini) pr-721"` |
| `gwt spawn --launch --wt-name pr-720` (no `--ai`) | `term-rename --persist "pr-720"` |
| `gwt spawn --wt-name pr-722` (no `--launch`) | (no-op — emit 자체가 없음) |

## 선결 결정 노트

이슈 본문의 (A)/(B)/(C) trade-off — VSCode `${sequence}` 설정 및 `omz_termsupport` 정책 — 는 사용자 환경 설정 범위이며 이번 변경은 그 중 어느 것을 택하더라도 동작하는 **최소 코드 변경만** 포함한다. 사용자가 `${sequence}` 를 켜면 즉시 `(claude) pr-719` 형태의 라벨이 보이고, 끈 상태에서는 OSC 자체는 발사되지만 VSCode 가 무시한다 (term_rename.sh 의 기존 contract 와 동일).

## Test plan

- [x] `tests/bats/functions/git_worktree_spawn.bats` 5건 신규: claude 명시 / claude 미명시 / gemini / `--launch` 미지정 / zsh 변형.
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_spawn.bats` — 64/64 PASS.
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/term_rename.bats` — 15/15 PASS (회귀 확인).
- [ ] 수동: VSCode `settings.json` 에 `terminal.integrated.tabs.title=${sequence}` 를 다시 켜고 `gwt spawn --launch --ai claude --wt-name issue-675-test` 후 탭 라벨이 `(claude) issue-675-test` 로 보이는지 육안 확인.

Closes #675

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~4 h · 🤖 ~12 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~4 h · 🤖 ~12 min
<!-- /ai-metrics:gh-pr -->

</details>
