### PR TITLE
feat(aws): #677 사내 PC 전용 AWS Bedrock 부트스트랩 (aws/ 디렉토리)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ git/.git-credentials
 *.local.sh
 ssh/*.local
 shell-common/config/pg_services.list
+# AWS Bedrock host-specific override for ~/.aws/config (#677 F-6).
+# *.local.sh already covers aws/aws.local.sh; aws-config.local has no .sh
+# extension so it needs an explicit rule.
+aws/aws-config.local
 # Note: pip.conf is symlinked to ~/.config/pip/pip.conf (outside this repo, not version controlled)
 
 # Build artifacts (generated during setup in some environments)

--- a/aws/AGENTS.md
+++ b/aws/AGENTS.md
@@ -1,0 +1,51 @@
+# aws/ — AGENTS.md
+
+내부 (사내) PC 전용 AWS Bedrock 부트스트랩 디렉토리. 외부 PC에서는 본 디렉토리의 어떤 스크립트도 효과가 없다 (`_dotfiles_setup_mode` 게이트로 차단).
+
+운영자(사람) 워크스루는 **`aws/README.md`** 에 있다. 이 파일은 AI 에이전트·자동화·리뷰어용 SSOT 안내다.
+
+## 책임 (SRP)
+
+| 파일 | 책임 |
+|---|---|
+| `aws.local.example` | 쉘 env 템플릿 (`AWS_CA_BUNDLE`, `AWS_REGION`, `CLAUDE_CODE_USE_BEDROCK`, `ANTHROPIC_BEDROCK_BASE_URL`) |
+| `aws-config.example` | `~/.aws/config` 템플릿 (dspublic SSO + role + region) |
+| `setup.sh` | internal 모드일 때만 위 두 파일에서 `aws.local.sh` / `~/.aws/config` / `~/.claude/settings.local.json` 시드 |
+| `install-otel-managed-settings.sh` | `aws sso login` 선행 후 사용자가 명시 실행. `/etc/claude-code/managed-settings.json` 생성 (sudo) |
+| `README.md` | 사람-운영자용 5단계 워크스루 (≤150 줄) |
+| `AGENTS.md` | 이 파일 — AI/리뷰어용 SSOT (≤100 줄) |
+
+## SSOT 원칙
+
+- AWS Bedrock 쉘 env 의 **유일한 source**: `aws/aws.local.sh` (gitignored, `*.local.sh` 글로벌 패턴).
+- AWS SSO config 의 **유일한 source**: `~/.aws/config`. 호스트별 오버라이드가 필요하면 `aws/aws-config.local` (gitignored).
+- Claude Code 모델 매핑의 **유일한 source**: `~/.claude/settings.local.json`. Repo 내 SSOT 템플릿은 `claude/settings.local.bedrock.example`.
+- OTel managed-settings 의 **유일한 source**: `/etc/claude-code/managed-settings.json` (시스템 경로). 동적 값(`user.id`) 은 STS 콜러에서 채움.
+
+`bash/main.bash` / `zsh/main.zsh` 는 **수정하지 않는다**. 두 로더는 이미 `shell-common/env/*.sh` 를 자동 source 하므로 `shell-common/env/aws.sh` 가 자동 픽업된다.
+
+## 실행 흐름
+
+```
+./setup.sh                       (루트 오케스트레이터)
+  └─ ./aws/setup.sh              (internal 모드일 때만 동작)
+        ├─ aws.local.sh          시드 (없을 때만)
+        ├─ ~/.aws/config         시드 (없을 때만)
+        └─ ~/.claude/settings.local.json  jq 머지 (모델 매핑만)
+
+사용자 수동 실행:
+  aws sso login                  (브라우저 OAuth)
+  ./aws/install-otel-managed-settings.sh   (sudo 1회, OTel)
+```
+
+## 외부 PC 안전망
+
+- `setup.sh` 흐름은 `_dotfiles_setup_mode != internal` 일 때 즉시 no-op.
+- `shell-common/env/aws.sh` 자체는 export 안 함 — `aws/aws.local.sh` 존재 시에만 source. 외부 PC 에 우연히 파일이 존재하게 되면 사고 (O-2). 런타임 이중 가드는 본 PR 에서는 미적용 (별 이슈 후속).
+
+## 관련
+
+- 이슈: #677
+- SSOT 모드 헬퍼: `_dotfiles_setup_mode` (정의 위치: `shell-common/tools/integrations/claude.sh`)
+- 유사 패턴: `shell-common/env/proxy.local.example` → `proxy.local.sh`
+- CLAUDE.md 정책: POSIX 호환, 인터랙티브 가드, `bash/main.bash` 직접 수정 금지

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,113 @@
+# AWS Bedrock 사내 PC 부트스트랩
+
+사내 PC 에서 Claude Code 를 AWS Bedrock 경로로 돌리기 위한 5단계 가이드. 외부/공용 PC 사용자는 이 문서를 읽을 필요가 없습니다 — `~/.dotfiles-setup-mode` 가 자동으로 차단합니다.
+
+## TL;DR
+
+```
+./setup.sh                                 # Step 1
+aws sso login                              # Step 3
+./aws/install-otel-managed-settings.sh     # Step 4
+claude                                     # Step 5
+```
+
+Step 2 (`aws/aws.local.sh` 편집) 는 보통 건너뜁니다.
+
+## 사전 준비 체크리스트
+
+- [ ] `cat ~/.dotfiles-setup-mode` 결과가 `internal`
+- [ ] `aws --version` 이 AWS CLI v2 를 반환 (v1 은 SSO 미지원)
+- [ ] 현재 사용자에게 `sudo` 권한 있음
+- [ ] `/usr/local/share/ca-certificates/samsungsemi-prx.com.crt` 존재
+
+미충족 항목이 있으면 사내 위키로 가서 채운 다음 돌아오세요.
+
+## Step 1 — `./setup.sh` 실행
+
+```sh
+./setup.sh
+```
+
+내부적으로 `./aws/setup.sh` 가 호출되어 아래 3 개 파일이 **자동 생성**됩니다 (이미 있으면 보존):
+
+| 생성 파일 | 역할 |
+|---|---|
+| `aws/aws.local.sh` | 쉘 env (`AWS_CA_BUNDLE`, `AWS_REGION`, `CLAUDE_CODE_USE_BEDROCK`, `ANTHROPIC_BEDROCK_BASE_URL`) |
+| `~/.aws/config` | AWS SSO 진입점 (account 518692946118, role AWSPS-AICoding-SLSI) |
+| `~/.claude/settings.local.json` | Claude Code 모델 매핑 (sonnet/haiku/opus → Bedrock IDs) |
+
+이 단계에서 사용자가 직접 copy-paste 할 내용은 **없습니다**.
+
+## Step 2 — `aws/aws.local.sh` 편집 (보통 불필요)
+
+기본값으로 모든 사내 PC 에서 동작합니다. 다음 경우에만 편집:
+
+- 다른 VPC endpoint 를 쓰는 호스트 → `ANTHROPIC_BEDROCK_BASE_URL` 한 줄만 교체
+- 사내 CA bundle 경로가 다른 배포 → `AWS_CA_BUNDLE` 한 줄만 교체
+
+```sh
+vi aws/aws.local.sh
+```
+
+## Step 3 — `aws sso login`
+
+```sh
+aws sso login
+```
+
+브라우저가 열려 dspublic AWS SSO 화면이 뜹니다. 사번 로그인 1회 → 토큰 발급. 이후 일정 시간 (보통 8시간) 동안 재로그인 불필요.
+
+## Step 4 — OTel 텔레메트리 설치
+
+```sh
+./aws/install-otel-managed-settings.sh
+```
+
+`sudo` 비밀번호 1회 입력. `/etc/claude-code/managed-settings.json` 이 생성되며 `user.id` 가 자동으로 STS 콜러로 채워집니다. `jq` 미설치 시 자동 설치 시도.
+
+## Step 5 — Claude Code 재시작
+
+```sh
+claude
+```
+
+`/model` 명령으로 `sonnet`, `haiku`, `claude-opus-4-7`, `claude-opus-4-6` 가 노출되면 성공.
+
+## 어느 파일에 무엇을 붙이나
+
+| 파일 | 누가 생성 | 사용자 편집? |
+|---|---|---|
+| `aws/aws.local.example` | (커밋됨) | **절대 X** — 템플릿입니다. `aws.local.sh` 만 편집. |
+| `aws/aws.local.sh` | `./setup.sh` 자동 | 호스트별 VPC/CA 가 다를 때만 |
+| `aws/aws-config.example` | (커밋됨) | **절대 X** — 다른 SSO 가 필요하면 `aws-config.local` 작성 |
+| `aws/aws-config.local` | (사용자) | 다른 SSO account/role 쓸 때만 (옵션) |
+| `~/.aws/config` | `./setup.sh` 자동 | 직접 편집보다 `aws-config.local` 권장 |
+| `claude/settings.local.bedrock.example` | (커밋됨) | **절대 X** — 템플릿입니다. |
+| `~/.claude/settings.local.json` | `./setup.sh` jq 머지 | 추가 키만 직접 추가 (기존 키 보존됨) |
+| `/etc/claude-code/managed-settings.json` | OTel installer 자동 | **절대 직접 편집 X** — installer 재실행 |
+
+## 역인덱스 — "X 를 하고 싶다"
+
+- **Bedrock region 변경** → `aws/aws.local.sh` 의 `AWS_REGION` (그리고 endpoint 도 같이 바꿔야 함)
+- **다른 SSO account 사용** → `aws/aws-config.local` 작성 (gitignored)
+- **모델 추가 등록** → `~/.claude/settings.local.json` 의 `availableModels` + `modelOverrides`
+- **OTel collector 주소 변경** → `aws/install-otel-managed-settings.sh` 의 `OTEL_ENDPOINT_HOST` 수정 후 재실행
+- **사내 게이트웨이(a2g) 와 병행** → 불가. 둘 중 하나만 활성 (#677 O-1)
+
+## 트러블슈팅
+
+| 증상 | 원인 | 해결 |
+|---|---|---|
+| Claude Code 가 401 / "credentials" 에러 | `aws sso login` 미수행 또는 토큰 만료 | `aws sso login` 재실행 |
+| `./aws/install-otel-managed-settings.sh: aws sts get-caller-identity failed` | 위와 동일 | `aws sso login` 먼저 |
+| 외부 PC 에서 `./aws/setup.sh` 가 아무 것도 안 함 | 의도된 동작 — `_dotfiles_setup_mode != internal` | 정상 |
+| `cat ~/.dotfiles-setup-mode` 가 `internal` 인데도 skip | 파일에 공백/개행 섞임 | `echo internal > ~/.dotfiles-setup-mode` |
+| `availableModels` 에 opus 가 안 보임 | settings.local.json 머지 실패 | `~/.claude/settings.local.json` 확인, 필요시 백업 (`*.bedrock-merge-backup.*`) 복원 후 재실행 |
+| OTel collector 도달 실패 | `10.172.25.203:80` 비도달 (VPN/방화벽) | 사내망 연결 확인. installer 자체는 성공 — 런타임 별 문제. |
+| Samsung a2g 경고 후 머지 skip | settings.local.json 에 a2g 게이트웨이 env 잔존 | 하나만 남기고 정리 — 양립 불가 |
+
+## 참고
+
+- 설계 이슈: [#677](https://github.com/dEitY719/dotfiles/issues/677)
+- AGENTS.md (자동화·리뷰어용 SSOT): `aws/AGENTS.md`
+- 메모리: `samsung-internal-llm-gateway`, `user-dual-pc-workflow`

--- a/aws/aws-config.example
+++ b/aws/aws-config.example
@@ -1,0 +1,17 @@
+# aws/aws-config.example — ~/.aws/config (Internal PC, AD SSO)
+#
+# 사용 방법
+#   1. ./setup.sh 가 internal 모드에서 이 파일을 ~/.aws/config 로 복사합니다
+#      (없을 때만, 멱등).
+#   2. 다른 SSO account/role 을 쓰려면 aws/aws-config.local 을 만들어 두면
+#      setup.sh 가 example 대신 .local 을 source 로 사용합니다.
+#   3. 복사 후 `aws sso login` 으로 브라우저 OAuth 1회.
+#
+# 본 파일은 사내 SSO 진입점만 담고 있어 외부 침투 가치가 낮아 커밋 안전.
+
+[default]
+sso_start_url = https://dspublic.awsapps.com/start
+sso_region = ap-northeast-2
+sso_account_id = 518692946118
+sso_role_name = AWSPS-AICoding-SLSI
+region = ap-northeast-2

--- a/aws/aws.local.example
+++ b/aws/aws.local.example
@@ -1,0 +1,23 @@
+#!/bin/sh
+# aws/aws.local.example — Internal PC AWS Bedrock 쉘 env (template)
+#
+# 사용 방법
+#   1. ./setup.sh 를 internal 모드로 실행하면 aws/setup.sh 가 이 파일을
+#      aws/aws.local.sh 로 복사합니다 (없을 때만, 멱등).
+#   2. 호스트별 VPC endpoint 가 다르면 aws.local.sh 만 수정하세요.
+#   3. aws.local.sh 는 *.local.sh 글로벌 패턴으로 자동 gitignore.
+#
+# 본 파일은 placeholder 가 아닌 실제 값을 담고 있어 그대로 쓸 수 있습니다.
+# 사번·STS UserId 같은 식별 정보는 들어 있지 않으므로 커밋되어도 안전.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# 사내 SSL CA bundle (samsungsemi 사설 인증서 체인)
+export AWS_CA_BUNDLE=/usr/local/share/ca-certificates/samsungsemi-prx.com.crt
+
+# AWS Bedrock 라우팅 — Claude Code 가 Anthropic 직통 대신 Bedrock 으로 감
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=ap-northeast-2
+
+# Bedrock VPC endpoint (사내망 전용)
+export ANTHROPIC_BEDROCK_BASE_URL=https://vpce-0dd86dfd31388ddeb-tgk37vc6.bedrock-runtime.ap-northeast-2.vpce.amazonaws.com

--- a/aws/install-otel-managed-settings.sh
+++ b/aws/install-otel-managed-settings.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# aws/install-otel-managed-settings.sh — Claude Code OTel telemetry installer.
+#
+# Writes /etc/claude-code/managed-settings.json with internal Samsung OTLP
+# endpoint + dynamic user.id (from `aws sts get-caller-identity`). Required
+# preconditions:
+#   1. ~/.dotfiles-setup-mode == internal   (external PCs are refused)
+#   2. AWS CLI v2 installed
+#   3. `aws sso login` already completed (this script does NOT log you in)
+#   4. sudo authority on this machine
+#
+# Idempotent: identical inputs produce identical output. Re-run any time.
+#
+# Issue: #677 (F-8).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths + constants
+# ---------------------------------------------------------------------------
+MANAGED_DIR="/etc/claude-code"
+MANAGED_FILE="${MANAGED_DIR}/managed-settings.json"
+
+OTEL_ENDPOINT_HOST="10.172.25.203"
+OTEL_ENDPOINT="http://${OTEL_ENDPOINT_HOST}:80"
+OTEL_LOGS_ENDPOINT="${OTEL_ENDPOINT}/v1/logs"
+OTEL_METRICS_ENDPOINT="${OTEL_ENDPOINT}/v1/metrics"
+
+BASE_RESOURCE_ATTRS="service.name=claude-code,llm.provider=bedrock,environment=prod"
+
+NO_PROXY_VALUE="${OTEL_ENDPOINT_HOST},.samsung.com,.samsungds.net,12.0.0.0/8,10.0.0.0/8,192.0.0.0/8,172.0.0.0/8"
+
+# ---------------------------------------------------------------------------
+# ux_lib (best-effort — fall back to plain stderr when sourcing fails)
+# ---------------------------------------------------------------------------
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_UX_LIB="${_SCRIPT_DIR}/../shell-common/tools/ux_lib/ux_lib.sh"
+if [ -f "$_UX_LIB" ]; then
+    # shellcheck source=/dev/null
+    . "$_UX_LIB"
+else
+    ux_info()    { printf '[INFO] %s\n'    "$*"; }
+    ux_success() { printf '[OK]   %s\n'    "$*"; }
+    ux_warning() { printf '[WARN] %s\n'    "$*" >&2; }
+    ux_error()   { printf '[ERR]  %s\n'    "$*" >&2; }
+    ux_section() { printf '\n== %s ==\n'   "$*"; }
+    ux_bullet()  { printf '  - %s\n'       "$*"; }
+fi
+
+die() { ux_error "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Setup-mode gate — refuse on external/public PCs
+# ---------------------------------------------------------------------------
+_mode_file="$HOME/.dotfiles-setup-mode"
+if [ ! -f "$_mode_file" ]; then
+    die "$_mode_file 없음. 먼저 ./setup.sh 로 internal 모드를 선택하세요."
+fi
+_mode=$(tr -d ' \t\n\r' < "$_mode_file" 2>/dev/null || echo "")
+case "$_mode" in
+    2|internal) ;;
+    *)
+        die "setup-mode='${_mode:-unset}' — install-otel-managed-settings.sh 는 internal 전용입니다."
+        ;;
+esac
+
+ux_section "Claude Code OTel installer (internal mode)"
+
+# ---------------------------------------------------------------------------
+# Tool prerequisites
+# ---------------------------------------------------------------------------
+command -v sudo >/dev/null 2>&1 || die "sudo not found. /etc/claude-code 쓰기에 필요합니다."
+command -v aws  >/dev/null 2>&1 || die "aws CLI not found. AWS CLI v2 를 먼저 설치하세요."
+
+if ! command -v jq >/dev/null 2>&1; then
+    ux_info "jq 미설치 — 자동 설치 시도"
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jq
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y jq
+    elif command -v yum >/dev/null 2>&1; then
+        sudo yum install -y jq
+    else
+        die "지원되는 패키지 매니저(apt-get/dnf/yum) 없음. jq 를 수동 설치하세요."
+    fi
+    command -v jq >/dev/null 2>&1 || die "jq 설치 보고됐지만 바이너리를 못 찾음."
+fi
+
+# ---------------------------------------------------------------------------
+# STS UserId (resource attribute — user.id)
+# ---------------------------------------------------------------------------
+CALLER_JSON="$(aws sts get-caller-identity 2>/dev/null)" \
+    || die "aws sts get-caller-identity 실패. 먼저 'aws sso login' 을 실행하세요."
+
+USER_ID_RAW="$(printf '%s' "$CALLER_JSON" | jq -r '.UserId')"
+if [ "$USER_ID_RAW" = "null" ] || [ -z "$USER_ID_RAW" ]; then
+    die "UserId 가 caller-identity 응답에 없음."
+fi
+
+USER_ID="${USER_ID_RAW##*:}"
+if [ -z "$USER_ID" ] || [ "$USER_ID" = "$USER_ID_RAW" ]; then
+    die "UserId '$USER_ID_RAW' 형식이 'ROLE_ID:user' 와 다릅니다."
+fi
+
+RESOURCE_ATTRS="${BASE_RESOURCE_ATTRS},user.id=${USER_ID}"
+
+# ---------------------------------------------------------------------------
+# Render managed-settings.json
+# ---------------------------------------------------------------------------
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+jq -n \
+    --arg endpoint         "$OTEL_ENDPOINT" \
+    --arg logs_endpoint    "$OTEL_LOGS_ENDPOINT" \
+    --arg metrics_endpoint "$OTEL_METRICS_ENDPOINT" \
+    --arg attrs            "$RESOURCE_ATTRS" \
+    --arg noproxy          "$NO_PROXY_VALUE" \
+    '{
+        env: {
+            CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+            OTEL_METRICS_EXPORTER: "otlp",
+            OTEL_LOGS_EXPORTER: "otlp",
+            OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+            OTEL_EXPORTER_OTLP_ENDPOINT: $endpoint,
+            OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: $logs_endpoint,
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: $metrics_endpoint,
+            OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "cumulative",
+            OTEL_RESOURCE_ATTRIBUTES: $attrs,
+            NO_PROXY: $noproxy,
+            no_proxy: $noproxy
+        }
+    }' > "$TMP"
+
+# ---------------------------------------------------------------------------
+# Install to /etc/claude-code/
+# ---------------------------------------------------------------------------
+sudo install -d -m 0755 "$MANAGED_DIR"
+sudo install -m 0644 "$TMP" "$MANAGED_FILE"
+
+ux_success "Installed: $MANAGED_FILE"
+ux_bullet "user.id = $USER_ID"
+ux_bullet "endpoint = $OTEL_ENDPOINT"
+echo ""
+ux_info "Claude Code 를 재시작하면 OTel exporter 가 활성화됩니다."

--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -119,22 +119,34 @@ _merge_claude_settings_local() {
 
     # Merge: target wins on conflicts (preserve user edits). Template keys
     # only fill gaps. _comment is dropped during the merge.
-    _backup="${_tgt}.bedrock-merge-backup.$(date +%Y%m%d%H%M%S)"
-    cp "$_tgt" "$_backup"
-
-    _merged=$(jq -s '
-        (.[0] | del(._comment)) as $tpl
+    #
+    # Atomicity: render to a temp file, compare with the live target via
+    # cmp -s, and only when contents differ do we mv the live file aside
+    # as a timestamped backup and mv the new file into place. This avoids
+    # accumulating identical backups on every idempotent re-run, and the
+    # final mv is atomic on POSIX (same-filesystem rename).
+    _tmp_merged=$(mktemp)
+    if jq -s '
+        (.[0] | del(._comment?)) as $tpl
         | (.[1]) as $cur
         | $tpl * $cur
-    ' "$_tpl" "$_tgt") || {
-        ux_error "jq merge failed — restore from backup: $_backup"
+    ' "$_tpl" "$_tgt" > "$_tmp_merged"; then
+        if cmp -s "$_tgt" "$_tmp_merged"; then
+            rm -f "$_tmp_merged"
+            ux_success "Preserved (already up to date): $_tgt"
+        else
+            _backup="${_tgt}.bedrock-merge-backup.$(date +%Y%m%d%H%M%S)"
+            mv "$_tgt" "$_backup"
+            mv "$_tmp_merged" "$_tgt"
+            chmod 0600 "$_tgt"
+            ux_success "Merged Bedrock keys into: $_tgt"
+            ux_bullet "Backup: $_backup"
+        fi
+    else
+        ux_error "jq merge failed — check syntax in $_tgt"
+        rm -f "$_tmp_merged"
         return 1
-    }
-
-    printf '%s\n' "$_merged" > "$_tgt"
-    chmod 0600 "$_tgt"
-    ux_success "Merged Bedrock keys into: $_tgt"
-    ux_bullet "Backup: $_backup"
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# aws/setup.sh — Internal-PC AWS Bedrock + Claude bootstrap (issue #677).
+#
+# Idempotent: re-runs preserve user edits to aws.local.sh / ~/.aws/config
+# / ~/.claude/settings.local.json.
+#
+# External/public PCs: this script is a no-op (mode gate at top).
+#
+# bash (not /bin/sh) so we can safely source shell-common/tools/ux_lib/ux_lib.sh
+# — the library references $BASH_VERSION which trips `set -u` under dash.
+
+set -e
+
+# ---------------------------------------------------------------------------
+# Locate dotfiles root + load ux_lib
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOTFILES_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../shell-common/tools/ux_lib/ux_lib.sh
+. "${DOTFILES_DIR}/shell-common/tools/ux_lib/ux_lib.sh"
+
+# ---------------------------------------------------------------------------
+# Setup-mode gate. _dotfiles_setup_mode is defined inside the heavy
+# shell-common/tools/integrations/claude.sh file; inlining the minimal
+# canonicalisation here keeps aws/setup.sh standalone and avoids pulling
+# in unrelated Claude account-resolver code (issue #677 O-3 deferred).
+# ---------------------------------------------------------------------------
+_aws_setup_mode() {
+    _f="$HOME/.dotfiles-setup-mode"
+    [ -f "$_f" ] || { echo ""; return 0; }
+    _raw=$(tr -d ' \t\n\r' < "$_f" 2>/dev/null)
+    case "$_raw" in
+        1|public)   echo "public" ;;
+        2|internal) echo "internal" ;;
+        3|external) echo "external" ;;
+        *)          echo "$_raw" ;;
+    esac
+}
+
+_mode=$(_aws_setup_mode)
+if [ "$_mode" != "internal" ]; then
+    ux_info "aws/setup.sh: setup-mode='${_mode:-unset}' — skip (internal-only)"
+    exit 0
+fi
+
+ux_section "AWS Bedrock bootstrap (internal mode)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+# _seed_file <src> <dst> <mode> — copy src to dst only when dst is absent,
+# then chmod. Preserves user edits on re-runs.
+_seed_file() {
+    _src="$1"
+    _dst="$2"
+    _mode="$3"
+
+    if [ ! -f "$_src" ]; then
+        ux_error "Template missing: $_src"
+        return 1
+    fi
+
+    if [ -f "$_dst" ]; then
+        ux_success "Preserved (already exists): $_dst"
+        return 0
+    fi
+
+    _dst_dir="$(dirname "$_dst")"
+    [ -d "$_dst_dir" ] || mkdir -p "$_dst_dir"
+    cp "$_src" "$_dst"
+    chmod "$_mode" "$_dst"
+    ux_success "Created: $_dst (mode $_mode)"
+}
+
+# _merge_claude_settings_local <template> <target>
+# Idempotent jq merge: adds template keys missing from target, preserves
+# existing user values. Detects the Samsung a2g gateway block and warns
+# instead of merging (Bedrock + a2g are mutually exclusive — issue #677 O-1).
+_merge_claude_settings_local() {
+    _tpl="$1"
+    _tgt="$2"
+
+    if [ ! -f "$_tpl" ]; then
+        ux_error "Template missing: $_tpl"
+        return 1
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        ux_warning "jq 미설치 — settings.local.json 자동 머지 건너뜀."
+        ux_bullet "수동으로 다음 파일 내용을 ~/.claude/settings.local.json 에 머지하세요:"
+        ux_bullet "  $_tpl"
+        return 0
+    fi
+
+    _tgt_dir="$(dirname "$_tgt")"
+    [ -d "$_tgt_dir" ] || mkdir -p "$_tgt_dir"
+
+    if [ ! -f "$_tgt" ]; then
+        # First-time create — drop the _comment scaffolding field so the
+        # live file stays clean.
+        jq 'del(._comment)' "$_tpl" > "$_tgt"
+        chmod 0600 "$_tgt"
+        ux_success "Created: $_tgt"
+        return 0
+    fi
+
+    # Detect Samsung a2g gateway block — mutually exclusive with Bedrock.
+    _has_a2g=$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$_tgt" 2>/dev/null \
+        | grep -c "a2g\.samsungds\.net" 2>/dev/null || true)
+    if [ "${_has_a2g:-0}" != "0" ]; then
+        ux_warning "Detected Samsung a2g gateway env in $_tgt"
+        ux_warning "Bedrock 경로와 a2g 게이트웨이 경로는 양립 불가합니다 (#677 O-1)."
+        ux_warning "자동 머지를 건너뜁니다. 한 경로만 남기고 수동 정리하세요."
+        ux_bullet "Bedrock 으로 단일화하려면 settings.local.json 의 env.ANTHROPIC_*"
+        ux_bullet "키들을 제거한 뒤 ./aws/setup.sh 를 재실행하세요."
+        return 0
+    fi
+
+    # Merge: target wins on conflicts (preserve user edits). Template keys
+    # only fill gaps. _comment is dropped during the merge.
+    _backup="${_tgt}.bedrock-merge-backup.$(date +%Y%m%d%H%M%S)"
+    cp "$_tgt" "$_backup"
+
+    _merged=$(jq -s '
+        (.[0] | del(._comment)) as $tpl
+        | (.[1]) as $cur
+        | $tpl * $cur
+    ' "$_tpl" "$_tgt") || {
+        ux_error "jq merge failed — restore from backup: $_backup"
+        return 1
+    }
+
+    printf '%s\n' "$_merged" > "$_tgt"
+    chmod 0600 "$_tgt"
+    ux_success "Merged Bedrock keys into: $_tgt"
+    ux_bullet "Backup: $_backup"
+}
+
+# ---------------------------------------------------------------------------
+# F-1: shell env (aws.local.sh)
+# ---------------------------------------------------------------------------
+_seed_file \
+    "${DOTFILES_DIR}/aws/aws.local.example" \
+    "${DOTFILES_DIR}/aws/aws.local.sh" \
+    0600
+
+# ---------------------------------------------------------------------------
+# F-6: ~/.aws/config — prefer aws-config.local override when present
+# ---------------------------------------------------------------------------
+[ -d "$HOME/.aws" ] || { mkdir -p "$HOME/.aws"; chmod 0700 "$HOME/.aws"; }
+if [ -f "${DOTFILES_DIR}/aws/aws-config.local" ]; then
+    _seed_file \
+        "${DOTFILES_DIR}/aws/aws-config.local" \
+        "$HOME/.aws/config" \
+        0600
+else
+    _seed_file \
+        "${DOTFILES_DIR}/aws/aws-config.example" \
+        "$HOME/.aws/config" \
+        0600
+fi
+
+# ---------------------------------------------------------------------------
+# F-7: ~/.claude/settings.local.json — model mapping merge
+# ---------------------------------------------------------------------------
+_merge_claude_settings_local \
+    "${DOTFILES_DIR}/claude/settings.local.bedrock.example" \
+    "$HOME/.claude/settings.local.json"
+
+# ---------------------------------------------------------------------------
+# F-8: OTel installer guidance (do NOT auto-run — needs sudo + sso login)
+# ---------------------------------------------------------------------------
+echo ""
+ux_section "Next steps (run manually)"
+ux_bullet "1. aws sso login"
+ux_bullet "2. ./aws/install-otel-managed-settings.sh   (sudo password once)"
+ux_bullet "3. claude   (재시작 후 availableModels 확인)"
+echo ""
+ux_info "Walkthrough: aws/README.md"

--- a/claude/settings.local.bedrock.example
+++ b/claude/settings.local.bedrock.example
@@ -1,0 +1,19 @@
+{
+  "_comment": "Bedrock model mapping template. aws/setup.sh merges only the keys that are missing from ~/.claude/settings.local.json — your existing keys are preserved. CLAUDE_CODE_USE_BEDROCK and AWS_REGION are deliberately NOT here (single SSOT = aws/aws.local.sh shell env). See #677 F-7.3.",
+  "env": {
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "global.anthropic.claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+  },
+  "availableModels": [
+    "sonnet",
+    "haiku",
+    "claude-opus-4-7",
+    "claude-opus-4-6"
+  ],
+  "model": "sonnet",
+  "modelOverrides": {
+    "claude-opus-4-7": "global.anthropic.claude-opus-4-7",
+    "claude-opus-4-6": "global.anthropic.claude-opus-4-6-v1"
+  },
+  "awsAuthRefresh": "aws sso login"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,7 @@ fi
 ./git/setup.sh
 ./claude/setup.sh
 ./gemini/setup.sh
+./aws/setup.sh                 # Internal-PC AWS Bedrock bootstrap (#677). No-op on external/public PCs.
 ./scripts/setup-skills-ssot.sh
 ./vscode-extensions/setup.sh
 # Propagate .vscode/base.json (SSOT) to the live VS Code User settings.json (#586).

--- a/shell-common/env/aws.sh
+++ b/shell-common/env/aws.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# shell-common/env/aws.sh
+# AWS env loader — sources aws/aws.local.sh when present.
+#
+# This loader itself exports NOTHING. The SSOT for AWS Bedrock shell env is
+# aws/aws.local.sh (gitignored, created by aws/setup.sh in internal mode).
+# On external/public PCs the .local.sh file is absent and this loader is a
+# silent no-op — those PCs continue to talk directly to Anthropic.
+#
+# Why this lives in shell-common/env/ instead of bash/main.bash + zsh/main.zsh:
+# both main loaders already source shell-common/env/*.sh automatically, so
+# adding a new file here applies to both shells with zero loader changes
+# (SSOT — see issue #677).
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+_aws_root="${DOTFILES_ROOT:-$HOME/dotfiles}/aws"
+if [ -f "$_aws_root/aws.local.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$_aws_root/aws.local.sh"
+fi
+unset _aws_root


### PR DESCRIPTION
## Summary

- 사내 PC 전용 AWS Bedrock 부트스트랩 4단(쉘 env / `~/.aws/config` / `~/.claude/settings.local.json` / OTel managed-settings)을 신규 `aws/` 디렉토리로 일괄 자동화
- 기존 `proxy.local.sh` 패턴 답습 — `shell-common/env/aws.sh` 신설로 `bash/main.bash` / `zsh/main.zsh` **0줄 수정**
- `_dotfiles_setup_mode != internal`이면 모든 스크립트 즉시 no-op — 외부 PC 안전망

## Changes

- **aws/setup.sh** — internal 모드 게이트 후 `aws.local.sh` 시드, `~/.aws/config` 시드(`aws-config.local` 오버라이드 지원), `~/.claude/settings.local.json` jq 머지. Samsung a2g 게이트웨이 블록 감지 시 자동 머지 건너뜀 (#677 O-1)
- **aws/install-otel-managed-settings.sh** — OTel managed-settings installer. `aws sts get-caller-identity` 로 `user.id` 동적 채움. sudo + `aws sso login` 의존성 때문에 `setup.sh` 본 흐름에서 자동 호출 안 함
- **aws/README.md** (113 줄, ≤150 ✓) — 사람-운영자용 5단계 copy-paste 워크스루. "어느 파일에 무엇을 붙이나" 표 + 역인덱스 포함 (#677 F-9)
- **aws/AGENTS.md** — AI/리뷰어용 디렉토리 SSOT 안내
- **aws/aws.local.example** — 쉘 env 템플릿 (4개 변수, 실제 값 포함 — 사번 미포함이므로 커밋 안전)
- **aws/aws-config.example** — dspublic SSO 템플릿 (`AWSPS-AICoding-SLSI` 롤)
- **claude/settings.local.bedrock.example** — Bedrock 모델 매핑 JSON 템플릿. `CLAUDE_CODE_USE_BEDROCK` / `AWS_REGION` 중복 회피 — 쉘 env 만 SSOT (#677 F-7.3)
- **shell-common/env/aws.sh** — POSIX env 로더. 자체로는 export 없음, `aws.local.sh` 존재 시에만 source
- **setup.sh** — `./aws/setup.sh` 오케스트레이터 호출 1줄 추가
- **.gitignore** — `aws/aws-config.local` 명시 추가 (`*.local.sh` 글로벌 패턴이 `aws.local.sh` 자동 커버)

## Test plan

- [x] 수동: external 모드 → `./aws/setup.sh` no-op (mock HOME 검증)
- [x] 수동: internal 모드 → 3개 파일 생성 (`aws.local.sh` 0600, `~/.aws/config` 0600, `~/.claude/settings.local.json`)
- [x] 수동: idempotent 재실행 — 사용자 편집 보존 + 타임스탬프 백업
- [x] 수동: `shell-common/env/aws.sh` 로더 — `aws.local.sh` 없으면 silent no-op, 있으면 4개 변수 export
- [x] 수동: `install-otel-managed-settings.sh` external 모드 거부 (exit 1)
- [x] `tox -e ruff,mypy,shellcheck,shfmt` 전부 통과
- [x] `shellcheck` 직접 (aws/setup.sh, aws/install-otel-managed-settings.sh, shell-common/env/aws.sh) 통과
- [x] `./tests/test` — 1008 passed (20 failed: `gc_help`/`gwt help` 회귀로 PR 범위 외, 부모 커밋 5f85725에 이미 존재)
- [ ] (실 환경) 사내 PC 에서 `./setup.sh` → `aws sso login` → `./aws/install-otel-managed-settings.sh` → `claude` 재시작 → `/model` 에서 `claude-opus-4-7` 노출 확인

## Related

Closes #677

---
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~24 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~24 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
