### PR TITLE
feat(ai-usage): #678 classify "Stream idle timeout" as transient

### DIFF
--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -50,16 +50,22 @@ _ai_usage_now() {
 }
 
 # Classify a claude `.result` string as a transient network error worth
-# retrying. Pattern set comes from issue #651 (PR #726 retrospective):
+# retrying. Pattern set comes from issue #651 (PR #726 retrospective)
+# and issue #678 (PR #829 retrospective):
 # ECONNRESET / ETIMEDOUT / EHOSTUNREACH / EAI_AGAIN are libuv/Node socket
 # errors surfaced by the proxy stack; "fetch failed" is the upstream JS
-# fetch wrapper's terse error. All four are routinely seen on the
-# Samsung internal LLM gateway and clear on a 2-4 s backoff. Permanent
-# errors (auth, 4xx, model not found) do NOT match — the caller stays
-# fail-closed on those, matching pre-retry behaviour.
+# fetch wrapper's terse error. "Stream idle timeout" / "partial response
+# received" arrive together when the proxy-gateway SSE keepalive drops
+# mid-stream — same transient class, different signature. Both halves of
+# that message are listed so a future format tweak on either side still
+# matches. All are routinely seen on the Samsung internal LLM gateway
+# and clear on a 2-4 s backoff. Permanent errors (auth, 4xx, model not
+# found) do NOT match — the caller stays fail-closed on those, matching
+# pre-retry behaviour.
 _ai_usage_is_transient() {
     case "$1" in
-    *ECONNRESET* | *ETIMEDOUT* | *EHOSTUNREACH* | *EAI_AGAIN* | *"fetch failed"*)
+    *ECONNRESET* | *ETIMEDOUT* | *EHOSTUNREACH* | *EAI_AGAIN* \
+        | *"fetch failed"* | *"Stream idle timeout"* | *"partial response received"*)
         return 0
         ;;
     *)

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -164,6 +164,35 @@ _usage_record_count() {
     assert_output --partial "transient"
 }
 
+# Issue #678 (PR #829 retrospective): the Anthropic CLI surfaces a
+# mid-stream proxy disconnect as the exact phrase below. Both halves
+# ("Stream idle timeout" and "partial response received") must match
+# independently so a future format tweak on either side still retries.
+
+@test "classifier: 'Stream idle timeout - partial response received' is transient (#678)" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'API Error: Stream idle timeout - partial response received' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
+@test "classifier: 'Stream idle timeout' alone is transient (#678)" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'API Error: Stream idle timeout' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
+@test "classifier: 'partial response received' alone is transient (#678)" {
+    run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
+                 _ai_usage_is_transient 'upstream error: partial response received' && \
+                 echo transient"
+    assert_success
+    assert_output --partial "transient"
+}
+
 @test "classifier: auth error is NOT transient" {
     run bash -c ". '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh' && \
                  if _ai_usage_is_transient 'Authentication failed: invalid API key'; \


### PR DESCRIPTION
## Summary
- `_ai_usage_is_transient` 의 transient 패턴 집합에 `"Stream idle timeout"` 과 `"partial response received"` 를 추가해, 사내 LLM 게이트웨이의 SSE keepalive mid-stream 끊김(#651 와 같은 클래스, 다른 시그니처) 에서도 자동 재시도가 작동하도록 한다.
- 동일 분류에 대한 bats 회귀 케이스 3건 (조합 + 각 절반 독립) 을 추가해 향후 메시지 포맷이 한 쪽만 바뀌어도 매칭이 깨지지 않도록 고정.

## Changes
- `shell-common/functions/ai_usage.sh` — `_ai_usage_is_transient` 의 `case` 패턴 라인을 두 substring 으로 확장하고, 주석 블록에 #678 / PR #829 회고 맥락 + Stream idle timeout 의 SSE keepalive 원인을 명시.
- `tests/bats/functions/ai_usage.bats` — 기존 #651 classifier 블록 뒤에 `"Stream idle timeout - partial response received"` / `"Stream idle timeout"` 단독 / `"partial response received"` 단독 3건의 bats 케이스 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/ai_usage.bats` — 16/16 pass (classifier 9 + retry 7).
- [x] `shellcheck shell-common/functions/ai_usage.sh` — clean.
- [x] `tox -e ruff,shellcheck,shfmt` — clean (lint guard).
- [ ] PR #829 와 같은 시그니처가 다시 발생할 경우 `usage.jsonl` 에 attempt #1, #2 두 record 가 적재되는지 후속 worker 에서 확인.

## Related
Closes #678

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~0.5 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~0.5 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
