### PR TITLE
fix(internal-mode): #683 사내 게이트웨이 env 자동 주입 제거 (Bedrock 단일 경로)

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -469,9 +469,13 @@ EOF
 # Note: 이전에 있던 `_print_internal_local_env_guidance` 는 #683 F-2 에서 제거.
 # 사내 PC 의 settings.local.json 은 `aws/setup.sh` 가 Bedrock 템플릿
 # (claude/settings.local.bedrock.example) 으로 jq-머지한다 (#677 F-7).
-# 게이트웨이 path (`cloud.dtgpt.samsungds.net` + `Qwen3.6-27B`) 는 Bedrock 과
-# 양립 불가하며 (#677 O-1), 같은 ./setup.sh 안에서 aws/setup.sh 가 즉시 strip
-# 하는 자기상충 흐름이었음.
+#
+# 함께 deprecate 된 env 키 (게이트웨이 path 전용, Bedrock 와 양립 불가 — #677 O-1):
+#   - ANTHROPIC_BASE_URL  (was: http://cloud.dtgpt.samsungds.net/llm)
+#   - ANTHROPIC_AUTH_TOKEN (was: placeholder "your-dt-api-key")
+#   - ANTHROPIC_MODEL      (was: "Qwen3.6-27B")
+# 위 3 키는 더 이상 settings.local.json 으로 주입되지 않는다. 같은 ./setup.sh 안
+# 에서 aws/setup.sh 가 즉시 strip 하던 자기상충 흐름도 같이 정리됨.
 
 # --- Main Script Logic (issue #287, Phase 1: multi-account) ---
 
@@ -628,8 +632,9 @@ if [ "$_setup_mode" = "internal" ]; then
 
     # settings.local.json 의 Bedrock 모델 매핑은 aws/setup.sh 가 책임진다 (#677 F-7).
     # 이전의 _print_internal_local_env_guidance 호출은 #683 F-2 에서 제거됨 —
-    # 같은 ./setup.sh 안에서 게이트웨이 블록을 만들고 곧바로 aws/setup.sh 가
-    # strip 하던 자기상충 흐름을 정리.
+    # 같은 ./setup.sh 안에서 게이트웨이 블록 (env: ANTHROPIC_BASE_URL /
+    # ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL) 을 만들고 곧바로 aws/setup.sh
+    # 가 strip 하던 자기상충 흐름을 정리. 위 3 env 키는 모두 deprecate.
 
     # Surface stale /etc/sudoers.d/claude-{skills,docs}-mount-* files left
     # behind from any prior multi-account install on this box.

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -12,9 +12,11 @@
 #   4. Creates ~/.claude/docs symlink (custom docs directory)
 #   5. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
 #   6. Verifies ~/.claude directory structure
-#   7. On Internal mode: prints copy-paste guidance for hand-creating
-#      ~/.claude/settings.local.json with the Samsung gateway env block (#584).
-#      That file is gitignored / out-of-repo so secrets never reach GitHub.
+#
+# Internal mode 에서 ~/.claude/settings.local.json 은 aws/setup.sh 가
+# claude/settings.local.bedrock.example 을 기반으로 jq 머지한다 (#677 F-7).
+# 본 스크립트는 그 파일을 직접 생성하지 않는다 (#683 F-2 에서 자동
+# 생성 분기 제거 — 게이트웨이 경로 폐기와 자기상충 흐름 정리).
 #
 # These files/directories are version-controlled in dotfiles and should
 # be managed via symbolic links for consistency across machines.
@@ -464,63 +466,12 @@ _print_stale_bind_mount_sudoers_hint() {
 EOF
 }
 
-# _print_internal_local_env_guidance — Internal-PC auto-create settings.local.json.
-#
-# Why this exists: the shared claude/settings.json SSOT (#584) cannot carry
-# the ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL env vars,
-# because those values point at cloud.dtgpt.samsungds.net which is
-# unreachable from External/Home and would break Claude Code on those PCs.
-# Instead the Internal-only env block lives in a per-PC, out-of-repo file
-# at ~/.claude/settings.local.json. Claude Code merges it with the shared
-# settings.json natively at launch time.
-#
-# Idempotent: when the file already has a real ANTHROPIC_AUTH_TOKEN
-# (anything other than the literal placeholder), this function prints a
-# single success line and returns. Only an absent or placeholder-only
-# file triggers auto-creation.
-_print_internal_local_env_guidance() {
-    local target="$HOME/.claude/settings.local.json"
-    local placeholder="your-dt-api-key"
-    local current_token=""
-
-    if [ -f "$target" ] && command -v jq >/dev/null 2>&1; then
-        current_token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN // empty' "$target" 2>/dev/null)
-    fi
-
-    if [ -n "$current_token" ] && [ "$current_token" != "$placeholder" ]; then
-        ux_success "Internal env already configured: $target"
-        return 0
-    fi
-
-    # Auto-create settings.local.json with placeholder
-    mkdir -p "$(dirname "$target")"
-    cat > "$target" <<'EOF'
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "http://cloud.dtgpt.samsungds.net/llm",
-    "ANTHROPIC_AUTH_TOKEN": "your-dt-api-key",
-    "ANTHROPIC_MODEL": "Qwen3.6-27B"
-  }
-}
-EOF
-
-    echo ""
-    ux_section "Internal Claude env (auto-created)"
-    ux_success "settings.local.json created: $target"
-    ux_info "Claude Code automatically merges it with settings.json on every"
-    ux_info "launch. The file is gitignored, so your token never reaches GitHub."
-    echo ""
-    ux_warning "Replace \"$placeholder\" with the real token issued by the"
-    ux_warning "internal LLM gateway team. Until you do, Claude Code on this PC"
-    ux_warning "will get HTTP 401 from the gateway."
-    echo ""
-    ux_bullet "Edit the file:"
-    ux_bullet "  ${UX_BOLD}vim $target${UX_RESET}"
-    echo ""
-    ux_bullet "Verify after editing:"
-    ux_bullet "  ${UX_BOLD}jq -e .env.ANTHROPIC_AUTH_TOKEN $target${UX_RESET}"
-    echo ""
-}
+# Note: 이전에 있던 `_print_internal_local_env_guidance` 는 #683 F-2 에서 제거.
+# 사내 PC 의 settings.local.json 은 `aws/setup.sh` 가 Bedrock 템플릿
+# (claude/settings.local.bedrock.example) 으로 jq-머지한다 (#677 F-7).
+# 게이트웨이 path (`cloud.dtgpt.samsungds.net` + `Qwen3.6-27B`) 는 Bedrock 과
+# 양립 불가하며 (#677 O-1), 같은 ./setup.sh 안에서 aws/setup.sh 가 즉시 strip
+# 하는 자기상충 흐름이었음.
 
 # --- Main Script Logic (issue #287, Phase 1: multi-account) ---
 
@@ -554,10 +505,9 @@ _migrate_install_gh_issue_flow_stop_hook
 DOTFILES_FORCE_INIT=1 . "$DOTFILES_ROOT/shell-common/env/claude.sh"
 DOTFILES_FORCE_INIT=1 . "$DOTFILES_ROOT/shell-common/tools/integrations/claude.sh"
 
-# settings.local.json 은 더 이상 dotfiles 가 관리하지 않습니다 (#584).
-# Internal-PC 사용자는 ~/.claude/settings.local.json 을 한 번 손수 생성;
-# Claude Code 가 settings.json 과 자동 merge 합니다.
-# Internal 모드 종료 직전 _print_internal_local_env_guidance 가 안내 출력.
+# settings.local.json 은 dotfiles 가 직접 관리하지 않는다 (#584).
+# Internal-PC 의 Bedrock 모델 매핑은 aws/setup.sh 가 Bedrock 템플릿으로
+# jq-머지한다 (#677 F-7). 이전 게이트웨이 자동 생성 분기는 #683 F-2 에서 제거.
 
 # Setup-mode SSOT read (issue #571). Reuses the _dotfiles_setup_mode
 # helper sourced from shell-common/tools/integrations/claude.sh (line
@@ -637,11 +587,11 @@ _single_account_ensure_link() {
     log_info "  symlink: $tgt → $src"
 }
 
-# Internal-PC single-account branch (issue #571, F-1; updated for #584).
+# Internal-PC single-account branch (issue #571, F-1; updated for #584, #683).
 # Direct-symlink the dotfiles SSOT into ~/.claude/ — no claude-accounts,
-# no ~/.claude-personal, no ~/.claude-work. The Samsung gateway env block
-# lives in a hand-created ~/.claude/settings.local.json (out-of-repo);
-# _print_internal_local_env_guidance below walks the user through it.
+# no ~/.claude-personal, no ~/.claude-work. ~/.claude/settings.local.json
+# 은 aws/setup.sh 가 Bedrock 템플릿으로 jq-머지한다 (#677 F-7) — 본 분기는
+# 더 이상 그 파일을 만들지 않는다 (#683 F-2).
 if [ "$_setup_mode" = "internal" ]; then
     log_info "Internal PC mode — single-account setup (skipping claude-accounts)"
 
@@ -676,7 +626,10 @@ if [ "$_setup_mode" = "internal" ]; then
     ux_bullet "실행: ${UX_BOLD}claude-yolo${UX_RESET} (멀티 계정 우회됨)"
     echo ""
 
-    _print_internal_local_env_guidance
+    # settings.local.json 의 Bedrock 모델 매핑은 aws/setup.sh 가 책임진다 (#677 F-7).
+    # 이전의 _print_internal_local_env_guidance 호출은 #683 F-2 에서 제거됨 —
+    # 같은 ./setup.sh 안에서 게이트웨이 블록을 만들고 곧바로 aws/setup.sh 가
+    # strip 하던 자기상충 흐름을 정리.
 
     # Surface stale /etc/sudoers.d/claude-{skills,docs}-mount-* files left
     # behind from any prior multi-account install on this box.

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -110,22 +110,14 @@ copy_local_files() {
         # Environment-specific handling
         case "$environment" in
             internal)
-                # Internal company PC: copy ALL .local.example files
+                # Internal company PC: copy ALL .local.example files.
+                # Bedrock 으로 통일된 #677 이후, claude.local.sh 에 사내 게이트웨이
+                # ANTHROPIC_BASE_URL/AUTH_TOKEN/MODEL 을 inject 하지 않는다 (#683 F-1).
+                # CLAUDE_ENABLED_ACCOUNTS 도 shell-common/env/claude.sh 가 setup-mode
+                # 기준으로 "work" (single-account) 를 SSOT 로 export 하므로 여기서
+                # 덮어쓰지 않는다.
                 cp "$example_file" "$local_file"
                 ux_success "Created: ${local_file#"$SHELL_COMMON_DIR"/}"
-
-                # Internal-specific: Auto-enable work1 and inject ANTHROPIC_* env vars into claude.local.sh
-                if [ "$basename_file" = "claude.local.example" ]; then
-                    cat >> "$local_file" <<'EOF'
-
-# ─── Internal PC: Auto-configured for Samsung gateway ──────────────────────
-export CLAUDE_ENABLED_ACCOUNTS="personal work"
-export ANTHROPIC_BASE_URL="http://cloud.dtgpt.samsungds.net/llm"
-export ANTHROPIC_AUTH_TOKEN="your-dt-api-key"
-export ANTHROPIC_MODEL="Qwen3.6-27B"
-EOF
-                    ux_info "  + Configured: ANTHROPIC_* env vars for Internal gateway"
-                fi
                 ;;
             external)
                 # External company PC (VPN): skip proxy.local.example


### PR DESCRIPTION
## Summary
- `internal` 모드 부트스트랩의 두 곳에서 사내 게이트웨이 env (`ANTHROPIC_BASE_URL=cloud.dtgpt.samsungds.net` / `ANTHROPIC_AUTH_TOKEN=your-dt-api-key` / `ANTHROPIC_MODEL=Qwen3.6-27B`) 를 자동 주입하던 코드를 제거. #677 의 Bedrock 단일 경로 정책과 일치시킴.
- F-1 (`shell-common/setup.sh`): claude.local.sh 에 게이트웨이 export 4 줄을 append 하던 if-block 전체 삭제. shell-level `ANTHROPIC_MODEL=Qwen3.6-27B` 누수가 `claude` 부팅 시 "400 invalid model identifier" 의 직접 원인이었음.
- F-2 (`claude/setup.sh`): `_print_internal_local_env_guidance` (함수+호출부) 삭제. 같은 `./setup.sh` 안에서 settings.local.json 에 게이트웨이 블록을 쓰고 직후 `aws/setup.sh` 의 `_merge_claude_settings_local` 가 strip 하던 자기상충 흐름 해소.

## Changes
- `shell-common/setup.sh:117-128`: `if [ "$basename_file" = "claude.local.example" ]; then ... fi` 11 줄 + 후속 `ux_info` 1 줄 삭제. 제거된 export: `CLAUDE_ENABLED_ACCOUNTS="personal work"` (← `shell-common/env/claude.sh:35` 의 single-account SSOT 와 모순), `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`. 새 코멘트로 의도 SSOT 명시.
- `claude/setup.sh:467-525`: `_print_internal_local_env_guidance` 함수 전체 삭제 (heredoc 로 게이트웨이 블록을 settings.local.json 에 작성하던 로직).
- `claude/setup.sh:629`: 위 함수의 호출 한 줄 삭제 + 인접 코멘트로 SSOT (Bedrock 머지는 aws/setup.sh 책임) 갱신.
- `claude/setup.sh:15-17, 508-510, 590-594`: "Samsung gateway env block" 언급한 3 곳의 stale 코멘트 갱신 — Bedrock-via-aws/setup.sh 가 정식 경로임을 명시.

## Test plan
- [ ] 사내 PC: `git pull origin main` → `./setup.sh` (internal 모드) → `exec bash` → `env | grep -E '^ANTHROPIC_(BASE_URL|AUTH_TOKEN|MODEL)='` 결과가 비어 있음
- [ ] 같은 PC: `env | grep ANTHROPIC_BEDROCK_BASE_URL` 가 정상 출력 (Bedrock 경로는 영향 없음)
- [ ] `./setup.sh` 출력에 "Configured: ANTHROPIC_* env vars for Internal gateway" 줄이 더 이상 나오지 않음
- [ ] `./setup.sh` 출력에 "Internal Claude env (auto-created)" 섹션 + "Replace your-dt-api-key" 경고가 더 이상 나오지 않음
- [ ] `./setup.sh` 출력에서 aws/setup.sh 의 "Legacy gateway env keys detected" 경고가 깨끗한 PC 에서는 등장하지 않음 (자기상충 자체 사라짐)
- [ ] `./aws/diagnose.sh` 결과 `2-6) 레거시 gateway env 키 없음` PASS
- [ ] `claude` 부팅 시 모델 ID 가 `Qwen3.6-27B` 가 아님 (model ID region-prefix 문제는 #683 F-3 별도)
- [ ] external / public 모드: 동일 ./setup.sh 흐름이 변동 없이 통과 (본 PR 의 두 변경 모두 internal 분기 한정)
- [ ] `shellcheck shell-common/setup.sh claude/setup.sh` clean
- [ ] `tox -e shellcheck` (project bash/ 한정) OK

## Related
Closes #683

## 후속 (별도 PR/이슈)
- #683 **F-3**: `claude/settings.local.bedrock.example` 의 model ID prefix 가 `global.*` 인데 ap-northeast-2 Bedrock 에서는 `apac.*` 만 접근 가능 (사용자 PC 에서 `apac.anthropic.claude-sonnet-4-20250514-v1:0` 가 valid 한 것으로 확인). region-aware 한 값으로 교체 필요.
- #683 **F-4**: `scripts/verify-config-files.sh:118-123` 의 `tokenchk` 가 Bedrock 모드 미인지 — `ANTHROPIC_AUTH_TOKEN` placeholder 경고 false-fire.
- #683 **F-5**: OpenCode 도 게이트웨이 path 만 시드 — Bedrock-aware 템플릿 부재.
- `shell-common/setup.sh:140-148` 의 external 분기 `CLAUDE_ENABLED_ACCOUNTS="personal work work1"` 는 `claude.sh:39` 의 default 와 동일한 redundant 라인 — 별도 cleanup.

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~8 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~8 min
<!-- /ai-metrics:gh-pr -->

</details>
