### PR TITLE
fix(internal-mode): #687 settings.json 실파일 시드로 deep-merge 디자인 폐기

### DIFF
--- a/aws/AGENTS.md
+++ b/aws/AGENTS.md
@@ -10,7 +10,7 @@
 |---|---|
 | `aws.local.example` | 쉘 env 템플릿 (`AWS_CA_BUNDLE`, `AWS_REGION`, `CLAUDE_CODE_USE_BEDROCK`, `ANTHROPIC_BEDROCK_BASE_URL`) |
 | `aws-config.example` | `~/.aws/config` 템플릿 (dspublic SSO + role + region) |
-| `setup.sh` | internal 모드일 때만 위 두 파일에서 `aws.local.sh` / `~/.aws/config` / `~/.claude/settings.local.json` 시드 |
+| `setup.sh` | internal 모드일 때만: `aws.local.sh` / `~/.aws/config` 시드 + `~/.claude/settings.json` 을 dotfiles SSOT + Bedrock 오버레이 jq 머지 결과 **실파일**로 작성 (#687) |
 | `install-otel-managed-settings.sh` | `aws sso login` 선행 후 사용자가 명시 실행. `/etc/claude-code/managed-settings.json` 생성 (sudo) |
 | `diagnose.sh` | Read-only 진단. 5 단계 부트스트랩이 빠짐없이 적용됐는지 PASS/FAIL/WARN 으로 보고. 파일 수정 없음 |
 | `README.md` | 사람-운영자용 5단계 워크스루 (≤150 줄) |
@@ -20,7 +20,9 @@
 
 - AWS Bedrock 쉘 env 의 **유일한 source**: `aws/aws.local.sh` (gitignored, `*.local.sh` 글로벌 패턴).
 - AWS SSO config 의 **유일한 source**: `~/.aws/config`. 호스트별 오버라이드가 필요하면 `aws/aws-config.local` (gitignored).
-- Claude Code 모델 매핑의 **유일한 source**: `~/.claude/settings.local.json`. Repo 내 SSOT 템플릿은 `claude/settings.local.bedrock.example`.
+- Claude Code 사내-모드 settings 의 **유일한 source** (#687): `~/.claude/settings.json` (실파일, symlink 아님). Repo 내 SSOT 는 두 파일 합성:
+  - `claude/settings.json` — 모든 PC 공용 베이스 (hooks/statusLine/enabledPlugins/...)
+  - `claude/settings.bedrock-overlay.example` — 사내 모드 한정 Bedrock 모델 매핑 (env/model/availableModels/modelOverrides/awsAuthRefresh)
 - OTel managed-settings 의 **유일한 source**: `/etc/claude-code/managed-settings.json` (시스템 경로). 동적 값(`user.id`) 은 STS 콜러에서 채움.
 
 `bash/main.bash` / `zsh/main.zsh` 는 **수정하지 않는다**. 두 로더는 이미 `shell-common/env/*.sh` 를 자동 source 하므로 `shell-common/env/aws.sh` 가 자동 픽업된다.
@@ -29,10 +31,15 @@
 
 ```
 ./setup.sh                       (루트 오케스트레이터)
+  ├─ ./claude/setup.sh           (모든 모드 — internal 분기는 settings.json symlink skip, #687)
   └─ ./aws/setup.sh              (internal 모드일 때만 동작)
         ├─ aws.local.sh          시드 (없을 때만)
         ├─ ~/.aws/config         시드 (없을 때만)
-        └─ ~/.claude/settings.local.json  jq 머지 (모델 매핑만)
+        ├─ ~/.claude/settings.json  jq deep-merge → 실파일 (#687)
+        │    base    = claude/settings.json (커밋된 SSOT)
+        │    overlay = claude/settings.bedrock-overlay.example
+        │    existing = 사용자 편집이 있으면 보존 (gateway 키는 strip)
+        └─ ~/.claude/settings.local.json → deprecated (#687) — 잔존 시 안내만
 
 사용자 수동 실행:
   aws sso login                  (브라우저 OAuth)
@@ -40,9 +47,9 @@
   ./aws/diagnose.sh              (선택, read-only 점검)
 ```
 
-## settings.local.json 머지 정책 (#677 O-1 broadened)
+## settings.json 머지 정책 (#687, #677 O-1 계승)
 
-`_merge_claude_settings_local` 는 Bedrock 와 양립 불가한 레거시 사내-게이트웨이 env 키를 머지 중 **자동 제거**한다. 대상 키:
+`_merge_claude_settings_json` 는 `base * overlay * existing` 순서로 jq deep-merge 하며, **existing (사용자 편집) 이 최우선**이다. 머지 직전에 Bedrock 와 양립 불가한 레거시 사내-게이트웨이 env 키를 existing 측에서 자동 strip:
 
 - `env.ANTHROPIC_BASE_URL`
 - `env.ANTHROPIC_AUTH_TOKEN`
@@ -51,6 +58,12 @@
 - `env.NODE_TLS_REJECT_UNAUTHORIZED`
 
 URL 패턴 (`a2g.samsungds.net`) 매칭은 호스트 리브랜드 (`cloud.dtgpt.samsungds.net`) 에 깨졌으므로 **키 이름**을 기준으로 한다. 사용자가 의도적으로 게이트웨이 모드를 쓰려면 `aws/setup.sh` 자체를 호출하지 말아야 한다 (= external 모드). 원본은 타임스탬프 백업 (`*.bedrock-merge-backup.*`) 에 보존된다.
+
+기존 설치(`~/.claude/settings.json` symlink) 에서 #687 로 마이그레이션하는 경우 `_merge_claude_settings_json` 가 symlink 를 자동 해제하고 실파일로 전환한다. claude/setup.sh 의 internal 분기는 settings.json symlink 를 더 이상 생성하지 않아 (#687) 새 설치 흐름에서도 충돌 없음.
+
+## 왜 settings.local.json 디자인을 폐기했나 (#687)
+
+Claude Code 공식 docs 는 `settings.json` + `settings.local.json` 의 `env` 객체가 deep-merge 된다고 명시한다. 그러나 사용자 환경 (사내 PC) 에서 실제로는 `settings.local.json.env.ANTHROPIC_DEFAULT_SONNET_MODEL` 이 런타임에 적용되지 않아 Claude Code 가 기본 매핑 (`apac.anthropic.claude-sonnet-4-5-*`) 으로 폴백 → 400 invalid model 에러가 났다. 원인은 추적 중이지만, 동료의 단일 `settings.json` 형태 (모든 키가 한 파일) 에서는 동작 확인. 그래서 dotfiles 의 SSOT 디자인 자체를 단일 파일 머지 결과로 바꾼 것 — 외부 PC 의 symlink 디자인은 그대로.
 
 ## 외부 PC 안전망
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -35,7 +35,7 @@ Step 2 (`aws/aws.local.sh` 편집) 는 보통 건너뜁니다.
 |---|---|
 | `aws/aws.local.sh` | 쉘 env (`AWS_CA_BUNDLE`, `AWS_REGION`, `CLAUDE_CODE_USE_BEDROCK`, `ANTHROPIC_BEDROCK_BASE_URL`) |
 | `~/.aws/config` | AWS SSO 진입점 (account 518692946118, role AWSPS-AICoding-SLSI) |
-| `~/.claude/settings.local.json` | Claude Code 모델 매핑 (sonnet/haiku/opus → Bedrock IDs) |
+| `~/.claude/settings.json` (실파일, #687) | Claude Code 모델 매핑 (sonnet/haiku/opus → Bedrock IDs) — dotfiles SSOT + Bedrock 오버레이의 jq deep-merge 결과 |
 
 이 단계에서 사용자가 직접 copy-paste 할 내용은 **없습니다**.
 
@@ -91,27 +91,28 @@ Read-only. 위 1~5 단계가 빠짐없이 적용됐는지 PASS/FAIL/WARN 으로 
 | `aws/aws-config.example` | (커밋됨) | **절대 X** — 다른 SSO 가 필요하면 `aws-config.local` 작성 |
 | `aws/aws-config.local` | (사용자) | 다른 SSO account/role 쓸 때만 (옵션) |
 | `~/.aws/config` | `./setup.sh` 자동 | 직접 편집보다 `aws-config.local` 권장 |
-| `claude/settings.local.bedrock.example` | (커밋됨) | **절대 X** — 템플릿입니다. |
-| `~/.claude/settings.local.json` | `./setup.sh` jq 머지 | 추가 키만 직접 추가 (기존 키 보존됨) |
+| `claude/settings.json` | (커밋됨, 모든 PC 공유 SSOT) | **절대 X** — 외부 PC 는 symlink, 사내 PC 는 머지 base |
+| `claude/settings.bedrock-overlay.example` | (커밋됨, 사내 모드 한정) | **절대 X** — 템플릿입니다 (#687) |
+| `~/.claude/settings.json` (#687) | 외부 PC: dotfiles symlink / 사내 PC: `./setup.sh` jq 머지 결과 실파일 | 사내 PC: 추가 키만 직접 추가 (기존 키 보존, gateway 키는 strip) |
 | `/etc/claude-code/managed-settings.json` | OTel installer 자동 | **절대 직접 편집 X** — installer 재실행 |
 
 ## 역인덱스 — "X 를 하고 싶다"
 
 - **Bedrock region 변경** → `aws/aws.local.sh` 의 `AWS_REGION` (그리고 endpoint 도 같이 바꿔야 함)
 - **다른 SSO account 사용** → `aws/aws-config.local` 작성 (gitignored)
-- **모델 추가 등록** → `~/.claude/settings.local.json` 의 `availableModels` + `modelOverrides`
+- **모델 추가 등록** → `claude/settings.bedrock-overlay.example` 의 `availableModels` + `modelOverrides` 수정 후 사내 PC 에서 `./aws/setup.sh` 재실행. 단발성 사용자 변경이면 `~/.claude/settings.json` 직접 편집해도 머지에서 보존됨 (existing 우선)
 - **OTel collector 주소 변경** → `aws/install-otel-managed-settings.sh` 의 `OTEL_ENDPOINT_HOST` 수정 후 재실행
 - **사내 게이트웨이(a2g) 와 병행** → 불가. 둘 중 하나만 활성 (#677 O-1)
 
 ## 사내 공식 진단(`diagnose_linux.sh`) 결과 해석
 
-`curl ... diagnose_linux.sh | bash` 로 실행하는 **사내 공식** 진단은 dotfiles 의 파일 배치 (aws.local.sh / settings.local.json) 를 모르기 때문에 다음 항목들이 항상 FAIL/WARN 으로 보고된다. **모두 정상이고 무시해도 된다**.
+`curl ... diagnose_linux.sh | bash` 로 실행하는 **사내 공식** 진단은 dotfiles 의 파일 배치를 모르기 때문에 다음 항목들이 항상 FAIL/WARN 으로 보고된다. **모두 정상이고 무시해도 된다**.
 
 | 항목 | 사내 진단 메시지 | 실제 상태 | 이유 |
 |---|---|---|---|
 | 1-1) NODE_EXTRA_CA_CERTS bashrc 미등록 | `[FAIL] ~/.bashrc에 NODE_EXTRA_CA_CERTS 미등록` | OK — 환경변수 자체는 PASS | dotfiles 는 `shell-common/env/security.local.sh` 가 export. bashrc 자체에는 export 라인이 없다. |
 | 2-3) AWS_CA_BUNDLE / CLAUDE_CODE_USE_BEDROCK / ANTHROPIC_BEDROCK_BASE_URL bashrc 미등록 | `[FAIL] ~/.bashrc에 ... 미등록 → 영구 설정 안 됨` | OK — 모두 런타임 PASS | dotfiles 는 `aws/aws.local.sh` (`*.local.sh` 글로벌 패턴으로 gitignored) 가 export. bashrc 가 dotfiles 로더를 source 하므로 새 쉘에서도 그대로 살아난다. |
-| 2-6) settings.json model / env / availableModels / modelOverrides / awsAuthRefresh 미설정 | 다수 FAIL/WARN | OK — `~/.claude/settings.local.json` 에 있음 | `claude/settings.json` 은 외부 PC 와 공유하는 **커밋 SSOT**. Bedrock 모델 매핑은 PC-specific 이므로 의도적으로 `settings.local.json` (gitignored) 에 둔다. Claude Code 가 런타임에 두 파일을 머지한다. |
+| 2-6) settings.json model / env / availableModels / modelOverrides / awsAuthRefresh — 사내 진단이 #687 이전 분리 디자인을 가정해 (`settings.local.json` 우선) 보고했음 | (구버전) 다수 FAIL/WARN | OK — #687 이후 모두 `~/.claude/settings.json` (실파일) 한 곳에 있음 | Bedrock 모델 매핑이 settings.local.json 의 deep-merge 에 의존하던 시절(#677) 의 미스매치는 해소됨. 이제 사내 진단의 settings.json 검사 자체가 통과한다. |
 
 정확한 진단을 원하면 dotfiles-aware 인 로컬 진단을 쓰면 된다:
 
@@ -119,7 +120,7 @@ Read-only. 위 1~5 단계가 빠짐없이 적용됐는지 PASS/FAIL/WARN 으로 
 ./aws/diagnose.sh
 ```
 
-(`aws/aws.local.sh`, `shell-common/env/security.local.sh`, `~/.claude/settings.local.json` 까지 모두 인지한다.)
+(`aws/aws.local.sh`, `shell-common/env/security.local.sh`, `~/.claude/settings.json` 까지 모두 인지한다. settings.local.json 잔존 시 deprecation 안내, #687.)
 
 ## 트러블슈팅
 
@@ -129,9 +130,10 @@ Read-only. 위 1~5 단계가 빠짐없이 적용됐는지 PASS/FAIL/WARN 으로 
 | `./aws/install-otel-managed-settings.sh: aws sts get-caller-identity failed` | 위와 동일 | `aws sso login` 먼저 |
 | 외부 PC 에서 `./aws/setup.sh` 가 아무 것도 안 함 | 의도된 동작 — `_dotfiles_setup_mode != internal` | 정상 |
 | `cat ~/.dotfiles-setup-mode` 가 `internal` 인데도 skip | 파일에 공백/개행 섞임 | `echo internal > ~/.dotfiles-setup-mode` |
-| `availableModels` 에 opus 가 안 보임 | settings.local.json 머지 실패 | `~/.claude/settings.local.json` 확인, 필요시 백업 (`*.bedrock-merge-backup.*`) 복원 후 재실행 |
+| `availableModels` 에 opus 가 안 보임 | settings.json 머지 실패 (#687) | `~/.claude/settings.json` 확인, 필요시 백업 (`*.bedrock-merge-backup.*`) 복원 후 `./aws/setup.sh` 재실행 |
+| `400 The provided model identifier is invalid` (`apac.anthropic.claude-sonnet-4-5-*`) | settings.json 의 `env.ANTHROPIC_DEFAULT_SONNET_MODEL` 미적용 — 옛 settings.local.json 분리 디자인의 deep-merge 가 사용자 환경에서 안 통한 사례 (#687) | `./aws/setup.sh` 재실행. ~/.claude/settings.json 이 dotfiles base + Bedrock 오버레이 머지 결과 실파일로 작성된다 (symlink 자동 해제). `./aws/diagnose.sh` 의 `2-6) env.ANTHROPIC_DEFAULT_SONNET_MODEL` PASS 확인. |
 | OTel collector 도달 실패 | `10.172.25.203:80` 비도달 (VPN/방화벽) | 사내망 연결 확인. installer 자체는 성공 — 런타임 별 문제. |
-| Claude Code 가 "not login" 으로 떨어짐 | settings.local.json 에 레거시 사내 게이트웨이 env (`ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL`/`ANTHROPIC_CUSTOM_HEADERS`/`NODE_TLS_REJECT_UNAUTHORIZED`) 잔존 — Bedrock 와 양립 불가 (#677 O-1) | `./aws/setup.sh` 재실행. 위 5 개 키는 머지 중 자동 제거되고 원본은 `*.bedrock-merge-backup.<timestamp>` 로 보존됨. 사전 점검은 `./aws/diagnose.sh` 의 `2-6)` 항목 |
+| Claude Code 가 "not login" 으로 떨어짐 | settings.json 에 레거시 사내 게이트웨이 env (`ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL`/`ANTHROPIC_CUSTOM_HEADERS`/`NODE_TLS_REJECT_UNAUTHORIZED`) 잔존 — Bedrock 와 양립 불가 (#677 O-1) | `./aws/setup.sh` 재실행. 위 5 개 키는 머지 중 자동 제거되고 원본은 `*.bedrock-merge-backup.<timestamp>` 로 보존됨. 사전 점검은 `./aws/diagnose.sh` 의 `2-6)` 항목 |
 | `[FAIL] AWS_CA_BUNDLE 파일 없음: /usr/local/share/ca-certificates/samsungsemi-prx.com.crt` | 옛 템플릿이 가리키던 경로에 cert 가 없음 (Ubuntu 가 `update-ca-certificates` 로 `/etc/ssl/certs/ca-certificates.crt` 에만 머지한 경우) | 한 줄로 교체: `sed -i 's\|^export AWS_CA_BUNDLE=.*\|export AWS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt\|' aws/aws.local.sh` 후 새 쉘. `./aws/setup.sh` 가 재실행 시 동일 경고를 띄운다. |
 
 ## 참고

--- a/aws/README.md
+++ b/aws/README.md
@@ -120,7 +120,7 @@ Read-only. 위 1~5 단계가 빠짐없이 적용됐는지 PASS/FAIL/WARN 으로 
 ./aws/diagnose.sh
 ```
 
-(`aws/aws.local.sh`, `shell-common/env/security.local.sh`, `~/.claude/settings.json` 까지 모두 인지한다. settings.local.json 잔존 시 deprecation 안내, #687.)
+(`aws/aws.local.sh`, `shell-common/env/security.local.sh`, `~/.claude/settings.json` 까지 모두 인지한다. `~/.claude/settings.local.json` 은 `aws/setup.sh` 가 자동 archive 처리, #687.)
 
 ## 트러블슈팅
 

--- a/aws/diagnose.sh
+++ b/aws/diagnose.sh
@@ -372,22 +372,30 @@ else
 fi
 
 # ============================================================
-header "2-6) 모델 정보 (~/.claude/settings.json / settings.local.json)"
+header "2-6) 모델 정보 (~/.claude/settings.json) — #687"
 # ============================================================
 
-# 사용자는 settings.local.json 에 모델 매핑을 머지한다 (#677 F-7).
-# settings.json 은 SSOT 로 커밋되어 있어 모델 매핑이 비어 있을 수 있다.
-CLAUDE_SETTINGS_LOCAL="$HOME/.claude/settings.local.json"
+# #687: settings.local.json 의 deep-merge 가 사용자 환경에서 신뢰 불가하므로
+# 모든 Bedrock 키는 ~/.claude/settings.json 으로 통합됐다. aws/setup.sh 가
+# dotfiles SSOT (claude/settings.json) + Bedrock 오버레이를
+# (claude/settings.bedrock-overlay.example) jq deep-merge 한 실파일로 시드한다.
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+CLAUDE_SETTINGS_LOCAL="$HOME/.claude/settings.local.json"
 SETTINGS_FILE=""
-if [ -f "$CLAUDE_SETTINGS_LOCAL" ]; then
-  SETTINGS_FILE="$CLAUDE_SETTINGS_LOCAL"
-  pass "~/.claude/settings.local.json 파일 존재"
-elif [ -f "$CLAUDE_SETTINGS" ]; then
+if [ -f "$CLAUDE_SETTINGS" ]; then
+  if [ -L "$CLAUDE_SETTINGS" ]; then
+    fail "~/.claude/settings.json 이 symlink 입니다 (#687 마이그레이션 미완료) → ./aws/setup.sh 재실행"
+  else
+    pass "~/.claude/settings.json 실파일 존재 (#687)"
+  fi
   SETTINGS_FILE="$CLAUDE_SETTINGS"
-  warn "settings.local.json 없음 — settings.json 으로 폴백 (Bedrock 매핑은 보통 .local 에 있음)"
 else
-  fail "~/.claude/settings*.json 파일 없음 → ./aws/setup.sh 미수행"
+  fail "~/.claude/settings.json 파일 없음 → ./setup.sh 와 ./aws/setup.sh 미수행"
+fi
+
+if [ -f "$CLAUDE_SETTINGS_LOCAL" ]; then
+  warn "~/.claude/settings.local.json 잔존 — #687 부터 deprecated. 백업 후 삭제 권장:"
+  warn "  mv \"$CLAUDE_SETTINGS_LOCAL\" \"${CLAUDE_SETTINGS_LOCAL}.deprecated-687.\$(date +%Y%m%d%H%M%S)\""
 fi
 
 if [ -n "$SETTINGS_FILE" ]; then
@@ -408,6 +416,23 @@ if [ -n "$SETTINGS_FILE" ]; then
     fi
 
     SETTINGS_JSON=$(jq '.' "$SETTINGS_FILE" 2>/dev/null || echo "{}")
+
+    # #687: Bedrock 모델 매핑 env 키가 settings.json 에 실제로 들어있는지
+    # 검증. settings.local.json 시절에는 deep-merge 시점에 누락되는 사례가
+    # 있었지만 이제는 settings.json 한 곳에서 직접 확인 가능.
+    SONNET=$(echo "$SETTINGS_JSON" | jq -r '.env.ANTHROPIC_DEFAULT_SONNET_MODEL // empty' 2>/dev/null)
+    if [ -n "$SONNET" ]; then
+      pass "env.ANTHROPIC_DEFAULT_SONNET_MODEL 설정됨: ${SONNET}"
+    else
+      fail "env.ANTHROPIC_DEFAULT_SONNET_MODEL 미설정 → 사내 PC에서 400 invalid model 위험 (#687)"
+    fi
+
+    HAIKU=$(echo "$SETTINGS_JSON" | jq -r '.env.ANTHROPIC_DEFAULT_HAIKU_MODEL // empty' 2>/dev/null)
+    if [ -n "$HAIKU" ]; then
+      pass "env.ANTHROPIC_DEFAULT_HAIKU_MODEL 설정됨: ${HAIKU}"
+    else
+      warn "env.ANTHROPIC_DEFAULT_HAIKU_MODEL 미설정"
+    fi
 
     # Bedrock 모드는 CLAUDE_CODE_USE_BEDROCK 를 쉘 env 한 곳에서만 SSOT 로
     # 가진다 (#677 F-7.3). settings.json 에 중복 명시되어 있다면 정보로만 보고.

--- a/aws/diagnose.sh
+++ b/aws/diagnose.sh
@@ -394,8 +394,11 @@ else
 fi
 
 if [ -f "$CLAUDE_SETTINGS_LOCAL" ]; then
-  warn "~/.claude/settings.local.json 잔존 — #687 부터 deprecated. 백업 후 삭제 권장:"
-  warn "  mv \"$CLAUDE_SETTINGS_LOCAL\" \"${CLAUDE_SETTINGS_LOCAL}.deprecated-687.\$(date +%Y%m%d%H%M%S)\""
+  fail "~/.claude/settings.local.json 잔존 — #687 부터 deprecated → ./aws/setup.sh 재실행 시 자동 archive 됨 (mv → *.deprecated-687.<ts>)"
+fi
+# Archive 흔적 (deprecated backup) 이 있으면 정상 마이그레이션 완료를 알린다.
+if ls "${CLAUDE_SETTINGS_LOCAL}".deprecated-687.* >/dev/null 2>&1; then
+  pass "settings.local.json 마이그레이션 완료 (#687 deprecated archive 존재)"
 fi
 
 if [ -n "$SETTINGS_FILE" ]; then
@@ -434,11 +437,23 @@ if [ -n "$SETTINGS_FILE" ]; then
       warn "env.ANTHROPIC_DEFAULT_HAIKU_MODEL 미설정"
     fi
 
-    # Bedrock 모드는 CLAUDE_CODE_USE_BEDROCK 를 쉘 env 한 곳에서만 SSOT 로
-    # 가진다 (#677 F-7.3). settings.json 에 중복 명시되어 있다면 정보로만 보고.
+    # #685 / #687 보강: settings.json env 에 CLAUDE_CODE_USE_BEDROCK + AWS_REGION
+    # 직접 명시 (사내 가이드 2-6 요구). aws/aws.local.sh 의 shell env 와 중복이지만
+    # Claude Code 가 자체 env 적용 경로로 두 키를 읽는 사례가 있어 양쪽에 둔다.
     USE_BR=$(echo "$SETTINGS_JSON" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK // empty' 2>/dev/null)
     if [ "$USE_BR" = "1" ]; then
-      pass "settings 의 env.CLAUDE_CODE_USE_BEDROCK=1 (쉘 env 와 중복이지만 안전)"
+      pass "settings 의 env.CLAUDE_CODE_USE_BEDROCK=1 (가이드 2-6 충족)"
+    else
+      fail "settings 의 env.CLAUDE_CODE_USE_BEDROCK 누락 → 가이드 2-6 미충족 (#685)"
+    fi
+
+    AWS_REG=$(echo "$SETTINGS_JSON" | jq -r '.env.AWS_REGION // empty' 2>/dev/null)
+    if [ "$AWS_REG" = "ap-northeast-2" ]; then
+      pass "settings 의 env.AWS_REGION=ap-northeast-2 (가이드 2-6 충족)"
+    elif [ -n "$AWS_REG" ]; then
+      warn "settings 의 env.AWS_REGION 값이 가이드 기본값(ap-northeast-2)과 다름: ${AWS_REG}"
+    else
+      fail "settings 의 env.AWS_REGION 누락 → 가이드 2-6 미충족 (#685)"
     fi
 
     # model 확인

--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -126,15 +126,23 @@ _merge_claude_settings_json() {
     [ -d "$_tgt_dir" ] || mkdir -p "$_tgt_dir"
 
     # symlink → 실파일 전환 (#687 마이그레이션 fallback). symlink 가 가리키는
-    # 내용은 보존되어야 하므로 cp -L 로 실파일 복사 후 symlink 자체를 제거한다.
+    # 내용은 보존되어야 하므로 cp -L 로 실파일 복사 후 atomic mv 로 교체한다.
+    # broken (dangling) symlink 인 경우 cp -L 가 실패하므로, 사전 분기로 단순
+    # 제거 후 아래 first-time create 분기로 떨어진다 (#689 review — gemini Rule 1+2,
+    # codex P2 #4: broken symlink 복구 경로). atomicity: 정상 symlink 분기는
+    # mv -f 한 번으로 끝내 cp+rm+mv 3단계 중 rm 을 제거.
     if [ -L "$_tgt" ]; then
         _link_dst=$(readlink "$_tgt")
-        ux_warning "기존 ~/.claude/settings.json 이 symlink (→ $_link_dst). 실파일로 전환합니다 (#687)."
-        _tmp_resolved=$(mktemp)
-        cp -L "$_tgt" "$_tmp_resolved"
-        rm -f "$_tgt"
-        mv "$_tmp_resolved" "$_tgt"
-        chmod 0600 "$_tgt"
+        if [ -e "$_tgt" ]; then
+            ux_warning "기존 ~/.claude/settings.json 이 symlink (→ $_link_dst). 실파일로 전환합니다 (#687)."
+            _tmp_resolved=$(mktemp)
+            cp -L "$_tgt" "$_tmp_resolved"
+            mv -f "$_tmp_resolved" "$_tgt"
+            chmod 0600 "$_tgt"
+        else
+            ux_warning "기존 ~/.claude/settings.json 이 깨진 symlink (→ $_link_dst, 대상 부재). 제거 후 새로 시드합니다 (#687/#689)."
+            rm -f "$_tgt"
+        fi
     fi
 
     if [ ! -f "$_tgt" ]; then

--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -205,17 +205,24 @@ _merge_claude_settings_json() {
     fi
 }
 
-# Deprecation 안내 (#687): 옛 머지 결과인 ~/.claude/settings.local.json 은
+# 자동 archive (#687, 보강): 옛 머지 결과인 ~/.claude/settings.local.json 은
 # 이제 사용되지 않는다. Claude Code 의 settings.local.json deep-merge 가
 # 사용자 환경에서 신뢰 불가하므로 모든 키는 settings.json 으로 통합됐다.
-_warn_legacy_settings_local() {
+# 사용자가 잊어도 회귀하지 않도록 mv 로 timestamp suffix 백업까지 자동 수행
+# (#688 codex / #686 Opus-personal 권고). 백업 파일은 보존되므로 복구 가능.
+_archive_legacy_settings_local() {
     _legacy="$HOME/.claude/settings.local.json"
     [ -f "$_legacy" ] || return 0
-    ux_warning "$_legacy 는 #687 이후 deprecated 입니다."
-    ux_bullet "Claude Code 가 settings.json + .local 을 deep-merge 한다고 문서화돼 있지만,"
-    ux_bullet "실제 사용자 환경에서 env 객체가 정상 머지되지 않는 사례가 확인됐습니다."
-    ux_bullet "이 파일을 백업 후 삭제 권장:"
-    ux_bullet "  mv \"$_legacy\" \"${_legacy}.deprecated-687.\$(date +%Y%m%d%H%M%S)\""
+    _legacy_bak="${_legacy}.deprecated-687.$(date +%Y%m%d%H%M%S)"
+    if mv "$_legacy" "$_legacy_bak"; then
+        ux_success "Archived legacy settings.local.json (#687):"
+        ux_bullet "  $_legacy"
+        ux_bullet "  → $_legacy_bak"
+        ux_bullet "Claude Code 의 deep-merge 가 사용자 환경에서 신뢰 불가하므로 본 파일은 더 이상 사용되지 않습니다."
+    else
+        ux_warning "settings.local.json archive 실패: $_legacy"
+        ux_bullet "수동 처리: mv \"$_legacy\" \"$_legacy_bak\""
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -274,7 +281,7 @@ _merge_claude_settings_json \
     "${DOTFILES_DIR}/claude/settings.bedrock-overlay.example" \
     "$HOME/.claude/settings.json"
 
-_warn_legacy_settings_local
+_archive_legacy_settings_local
 
 # ---------------------------------------------------------------------------
 # F-8: OTel installer guidance (do NOT auto-run — needs sudo + sso login)

--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
-# aws/setup.sh — Internal-PC AWS Bedrock + Claude bootstrap (issue #677).
+# aws/setup.sh — Internal-PC AWS Bedrock + Claude bootstrap (issue #677, #687).
 #
 # Idempotent: re-runs preserve user edits to aws.local.sh / ~/.aws/config
-# / ~/.claude/settings.local.json.
+# / ~/.claude/settings.json (real file, NOT symlink in internal mode).
+#
+# #687 fix: Claude Code 의 settings.json ↔ settings.local.json 사이에서
+# .env 객체 deep-merge 가 사용자 환경에서 실제로 적용되지 않는 사례가 확인
+# 됐다 (ANTHROPIC_DEFAULT_SONNET_MODEL 미반영 → 400 invalid model). 그래서
+# 사내 모드 한정으로 ~/.claude/settings.json 자체를 dotfiles SSOT
+# (claude/settings.json) + Bedrock 오버레이 (claude/settings.bedrock-overlay.example)
+# 를 jq deep-merge 한 실파일로 시드한다. 외부 PC 는 영향 없음 — symlink
+# 그대로 유지 (claude/setup.sh 외부 분기).
 #
 # External/public PCs: this script is a no-op (mode gate at top).
 #
@@ -73,44 +81,79 @@ _seed_file() {
     ux_success "Created: $_dst (mode $_mode)"
 }
 
-# _merge_claude_settings_local <template> <target>
-# Idempotent jq merge: adds template keys missing from target, preserves
-# existing user values. Detects the Samsung a2g gateway block and warns
-# instead of merging (Bedrock + a2g are mutually exclusive — issue #677 O-1).
-_merge_claude_settings_local() {
-    _tpl="$1"
-    _tgt="$2"
+# _merge_claude_settings_json <base> <overlay> <target>
+# Internal-mode 한정: ~/.claude/settings.json 을 dotfiles SSOT (base) +
+# Bedrock 오버레이 (overlay) 의 jq deep-merge 결과 실파일로 시드한다.
+# 외부 PC 의 symlink 디자인은 claude/setup.sh 외부 분기에서 유지된다.
+#
+# 머지 우선순위 (낮음 → 높음): base < overlay < existing_real
+#   - base: dotfiles 가 commit 한 모든 PC 공용 키 (hooks/statusLine/...)
+#   - overlay: 사내 모드 한정 Bedrock 모델 매핑 (model/availableModels/...)
+#   - existing_real: 사용자가 ~/.claude/settings.json 을 직접 편집한 경우
+#     해당 변경을 보존 (overlay 보다 우선). 단 legacy gateway env 키는
+#     머지 전 strip 된다 (Bedrock 와 양립 불가, #677 O-1).
+#
+# Symlink 처리 (#687): target 이 dotfiles base 를 가리키는 symlink 면 풀고
+# 실파일로 전환한다. 이는 claude/setup.sh 의 external 분기 호환을 위해
+# 일단 symlink 가 생성된 뒤 사내 분기에서 다시 풀어내는 흐름이 아니라,
+# claude/setup.sh 의 internal 분기 자체가 settings.json 처리를 위임한
+# 결과다 — claude/setup.sh:internal 은 settings.json symlink 를 만들지 않는다.
+# 그래도 과거 설치(symlink) 에서 #687 로 마이그레이션하는 사용자를 위한
+# fallback 으로 symlink 자동 변환을 남겨둔다.
+_merge_claude_settings_json() {
+    _base="$1"
+    _overlay="$2"
+    _tgt="$3"
 
-    if [ ! -f "$_tpl" ]; then
-        ux_error "Template missing: $_tpl"
+    if [ ! -f "$_base" ]; then
+        ux_error "Base settings missing: $_base"
+        return 1
+    fi
+    if [ ! -f "$_overlay" ]; then
+        ux_error "Overlay template missing: $_overlay"
         return 1
     fi
 
     if ! command -v jq >/dev/null 2>&1; then
-        ux_warning "jq 미설치 — settings.local.json 자동 머지 건너뜀."
-        ux_bullet "수동으로 다음 파일 내용을 ~/.claude/settings.local.json 에 머지하세요:"
-        ux_bullet "  $_tpl"
+        ux_warning "jq 미설치 — settings.json 자동 머지 건너뜀."
+        ux_bullet "다음 두 파일을 수동으로 머지해 ~/.claude/settings.json 에 작성하세요:"
+        ux_bullet "  base   : $_base"
+        ux_bullet "  overlay: $_overlay"
         return 0
     fi
 
     _tgt_dir="$(dirname "$_tgt")"
     [ -d "$_tgt_dir" ] || mkdir -p "$_tgt_dir"
 
-    if [ ! -f "$_tgt" ]; then
-        # First-time create — drop the _comment scaffolding field so the
-        # live file stays clean.
-        jq 'del(._comment)' "$_tpl" > "$_tgt"
+    # symlink → 실파일 전환 (#687 마이그레이션 fallback). symlink 가 가리키는
+    # 내용은 보존되어야 하므로 cp -L 로 실파일 복사 후 symlink 자체를 제거한다.
+    if [ -L "$_tgt" ]; then
+        _link_dst=$(readlink "$_tgt")
+        ux_warning "기존 ~/.claude/settings.json 이 symlink (→ $_link_dst). 실파일로 전환합니다 (#687)."
+        _tmp_resolved=$(mktemp)
+        cp -L "$_tgt" "$_tmp_resolved"
+        rm -f "$_tgt"
+        mv "$_tmp_resolved" "$_tgt"
         chmod 0600 "$_tgt"
-        ux_success "Created: $_tgt"
+    fi
+
+    if [ ! -f "$_tgt" ]; then
+        # First-time create — base * overlay (existing 없음). _comment 제거.
+        _tmp_new=$(mktemp)
+        if jq -s '(.[0]) * (.[1] | del(._comment?))' "$_base" "$_overlay" > "$_tmp_new"; then
+            mv "$_tmp_new" "$_tgt"
+            chmod 0600 "$_tgt"
+            ux_success "Created: $_tgt (base + overlay)"
+        else
+            ux_error "jq merge failed — check JSON in $_base / $_overlay"
+            rm -f "$_tmp_new"
+            return 1
+        fi
         return 0
     fi
 
-    # Detect leftover Samsung internal-gateway env keys. The earlier narrow
-    # `a2g.samsungds.net` URL check missed the `cloud.dtgpt.samsungds.net`
-    # rebrand and produced a half-merged broken state ("not login"). These
-    # keys are mutually exclusive with Bedrock (#677 O-1) and have no
-    # purpose under CLAUDE_CODE_USE_BEDROCK=1, so the merge strips them.
-    # The backup below preserves the user's previous content verbatim.
+    # Legacy 사내 게이트웨이 env 키 검출 (Bedrock 와 양립 불가, #677 O-1).
+    # 키 이름 기반이라 host rebrand (a2g → cloud.dtgpt) 에 강건.
     _gateway_keys=$(jq -r '
         .env // {}
         | keys_unsorted[]
@@ -123,16 +166,9 @@ _merge_claude_settings_local() {
         ux_bullet "머지 중 위 키들을 제거합니다. 원본은 백업 파일에 보존됩니다."
     fi
 
-    # Merge: target wins on conflicts (preserve user edits), but the
-    # mutually-exclusive gateway keys are stripped from the target side
-    # first. Template keys only fill gaps. _comment is dropped during the
-    # merge.
-    #
-    # Atomicity: render to a temp file, compare with the live target via
-    # cmp -s, and only when contents differ do we mv the live file aside
-    # as a timestamped backup and mv the new file into place. This avoids
-    # accumulating identical backups on every idempotent re-run, and the
-    # final mv is atomic on POSIX (same-filesystem rename).
+    # Deep merge: base * overlay * (existing - legacy gateway keys).
+    # 사용자 편집이 가장 우선 — 사내 PC 에서 ~/.claude/settings.json 을 직접
+    # 손대지 않는 게 정상이지만, 손댄 경우 보존된다. _comment 는 머지에서 항상 제거.
     _tmp_merged=$(mktemp)
     if jq -s '
         def _strip_gateway:
@@ -146,10 +182,11 @@ _merge_claude_settings_local() {
                 )
             else .
             end;
-        (.[0] | del(._comment?)) as $tpl
-        | (.[1] | _strip_gateway) as $cur
-        | $tpl * $cur
-    ' "$_tpl" "$_tgt" > "$_tmp_merged"; then
+        (.[0])                          as $base
+        | (.[1] | del(._comment?))      as $overlay
+        | (.[2] | _strip_gateway)       as $existing
+        | $base * $overlay * $existing
+    ' "$_base" "$_overlay" "$_tgt" > "$_tmp_merged"; then
         if cmp -s "$_tgt" "$_tmp_merged"; then
             rm -f "$_tmp_merged"
             ux_success "Preserved (already up to date): $_tgt"
@@ -162,10 +199,23 @@ _merge_claude_settings_local() {
             ux_bullet "Backup: $_backup"
         fi
     else
-        ux_error "jq merge failed — check syntax in $_tgt"
+        ux_error "jq merge failed — check JSON in $_base / $_overlay / $_tgt"
         rm -f "$_tmp_merged"
         return 1
     fi
+}
+
+# Deprecation 안내 (#687): 옛 머지 결과인 ~/.claude/settings.local.json 은
+# 이제 사용되지 않는다. Claude Code 의 settings.local.json deep-merge 가
+# 사용자 환경에서 신뢰 불가하므로 모든 키는 settings.json 으로 통합됐다.
+_warn_legacy_settings_local() {
+    _legacy="$HOME/.claude/settings.local.json"
+    [ -f "$_legacy" ] || return 0
+    ux_warning "$_legacy 는 #687 이후 deprecated 입니다."
+    ux_bullet "Claude Code 가 settings.json + .local 을 deep-merge 한다고 문서화돼 있지만,"
+    ux_bullet "실제 사용자 환경에서 env 객체가 정상 머지되지 않는 사례가 확인됐습니다."
+    ux_bullet "이 파일을 백업 후 삭제 권장:"
+    ux_bullet "  mv \"$_legacy\" \"${_legacy}.deprecated-687.\$(date +%Y%m%d%H%M%S)\""
 }
 
 # ---------------------------------------------------------------------------
@@ -217,11 +267,14 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# F-7: ~/.claude/settings.local.json — model mapping merge
+# F-7: ~/.claude/settings.json — base + Bedrock overlay deep-merge (#687)
 # ---------------------------------------------------------------------------
-_merge_claude_settings_local \
-    "${DOTFILES_DIR}/claude/settings.local.bedrock.example" \
-    "$HOME/.claude/settings.local.json"
+_merge_claude_settings_json \
+    "${DOTFILES_DIR}/claude/settings.json" \
+    "${DOTFILES_DIR}/claude/settings.bedrock-overlay.example" \
+    "$HOME/.claude/settings.json"
+
+_warn_legacy_settings_local
 
 # ---------------------------------------------------------------------------
 # F-8: OTel installer guidance (do NOT auto-run — needs sudo + sso login)

--- a/claude/settings.bedrock-overlay.example
+++ b/claude/settings.bedrock-overlay.example
@@ -1,8 +1,10 @@
 {
-  "_comment": "Bedrock overlay for ~/.claude/settings.json (internal-PC mode only). aws/setup.sh deep-merges (base * overlay * existing) into ~/.claude/settings.json as a REAL file (NOT symlink) — see #687. The split between this overlay and dotfiles claude/settings.json keeps external-PC SSOT untouched. CLAUDE_CODE_USE_BEDROCK and AWS_REGION are deliberately NOT here (single SSOT = aws/aws.local.sh shell env, #677 F-7.3).",
+  "_comment": "Bedrock overlay for ~/.claude/settings.json (internal-PC mode only). aws/setup.sh deep-merges (base * overlay * existing) into ~/.claude/settings.json as a REAL file (NOT symlink) — see #687. The split between this overlay and dotfiles claude/settings.json keeps external-PC SSOT untouched. CLAUDE_CODE_USE_BEDROCK and AWS_REGION are duplicated here (in addition to aws/aws.local.sh shell env) because the internal company guide section 2-6 requires them in settings.json env — #685 acceptance. The shell env in aws.local.sh stays as the OS-level SSOT for shells that source it before Claude Code starts. model is pinned to the direct Bedrock ID (not the 'sonnet' alias) to avoid the v2.1.144 alias fallback to apac.anthropic.claude-sonnet-4-5-* — see #686/#688 hypothesis B.",
   "env": {
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "global.anthropic.claude-sonnet-4-6",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "AWS_REGION": "ap-northeast-2"
   },
   "availableModels": [
     "sonnet",
@@ -10,7 +12,7 @@
     "claude-opus-4-7",
     "claude-opus-4-6"
   ],
-  "model": "sonnet",
+  "model": "global.anthropic.claude-opus-4-7",
   "modelOverrides": {
     "claude-opus-4-7": "global.anthropic.claude-opus-4-7",
     "claude-opus-4-6": "global.anthropic.claude-opus-4-6-v1"

--- a/claude/settings.bedrock-overlay.example
+++ b/claude/settings.bedrock-overlay.example
@@ -1,5 +1,5 @@
 {
-  "_comment": "Bedrock model mapping template. aws/setup.sh merges only the keys that are missing from ~/.claude/settings.local.json — your existing keys are preserved. CLAUDE_CODE_USE_BEDROCK and AWS_REGION are deliberately NOT here (single SSOT = aws/aws.local.sh shell env). See #677 F-7.3.",
+  "_comment": "Bedrock overlay for ~/.claude/settings.json (internal-PC mode only). aws/setup.sh deep-merges (base * overlay * existing) into ~/.claude/settings.json as a REAL file (NOT symlink) — see #687. The split between this overlay and dotfiles claude/settings.json keeps external-PC SSOT untouched. CLAUDE_CODE_USE_BEDROCK and AWS_REGION are deliberately NOT here (single SSOT = aws/aws.local.sh shell env, #677 F-7.3).",
   "env": {
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "global.anthropic.claude-sonnet-4-6",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0"

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -13,10 +13,13 @@
 #   5. Creates ~/.claude/projects/GLOBAL/memory symlink (global memory)
 #   6. Verifies ~/.claude directory structure
 #
-# Internal mode 에서 ~/.claude/settings.local.json 은 aws/setup.sh 가
-# claude/settings.local.bedrock.example 을 기반으로 jq 머지한다 (#677 F-7).
-# 본 스크립트는 그 파일을 직접 생성하지 않는다 (#683 F-2 에서 자동
-# 생성 분기 제거 — 게이트웨이 경로 폐기와 자기상충 흐름 정리).
+# Internal mode 에서 ~/.claude/settings.json 은 aws/setup.sh 가 dotfiles
+# SSOT (claude/settings.json) + Bedrock 오버레이
+# (claude/settings.bedrock-overlay.example) 를 jq deep-merge 한 결과
+# 실파일로 시드한다 (#687, 이전 #677 F-7 의 settings.local.json 분리 디자인
+# 폐기). 본 스크립트는 internal 분기에서 settings.json symlink 를
+# 만들지 않는다. ~/.claude/settings.local.json 은 #683 F-2 이후 본 스크립트가
+# 생성하지 않으며, #687 이후엔 aws/setup.sh 도 만들지 않고 잔존 시 안내만 한다.
 #
 # These files/directories are version-controlled in dotfiles and should
 # be managed via symbolic links for consistency across machines.
@@ -467,15 +470,17 @@ EOF
 }
 
 # Note: 이전에 있던 `_print_internal_local_env_guidance` 는 #683 F-2 에서 제거.
-# 사내 PC 의 settings.local.json 은 `aws/setup.sh` 가 Bedrock 템플릿
-# (claude/settings.local.bedrock.example) 으로 jq-머지한다 (#677 F-7).
+# 사내 PC 의 settings 는 `aws/setup.sh` 가 dotfiles SSOT (claude/settings.json)
+# + Bedrock 오버레이 (claude/settings.bedrock-overlay.example) 를 jq deep-merge
+# 해 ~/.claude/settings.json 실파일로 작성한다 (#687, 이전 #677 F-7 의
+# settings.local.json 분리 디자인 폐기).
 #
 # 함께 deprecate 된 env 키 (게이트웨이 path 전용, Bedrock 와 양립 불가 — #677 O-1):
 #   - ANTHROPIC_BASE_URL  (was: http://cloud.dtgpt.samsungds.net/llm)
 #   - ANTHROPIC_AUTH_TOKEN (was: placeholder "your-dt-api-key")
 #   - ANTHROPIC_MODEL      (was: "Qwen3.6-27B")
-# 위 3 키는 더 이상 settings.local.json 으로 주입되지 않는다. 같은 ./setup.sh 안
-# 에서 aws/setup.sh 가 즉시 strip 하던 자기상충 흐름도 같이 정리됨.
+# 위 3 키는 더 이상 주입되지 않으며, ~/.claude/settings.json 에 잔존해도
+# aws/setup.sh 가 머지 중 자동 strip 한다.
 
 # --- Main Script Logic (issue #287, Phase 1: multi-account) ---
 
@@ -591,15 +596,23 @@ _single_account_ensure_link() {
     log_info "  symlink: $tgt → $src"
 }
 
-# Internal-PC single-account branch (issue #571, F-1; updated for #584, #683).
+# Internal-PC single-account branch (issue #571, F-1; updated for #584, #683, #687).
 # Direct-symlink the dotfiles SSOT into ~/.claude/ — no claude-accounts,
-# no ~/.claude-personal, no ~/.claude-work. ~/.claude/settings.local.json
-# 은 aws/setup.sh 가 Bedrock 템플릿으로 jq-머지한다 (#677 F-7) — 본 분기는
-# 더 이상 그 파일을 만들지 않는다 (#683 F-2).
+# no ~/.claude-personal, no ~/.claude-work.
+#
+# #687: settings.json 은 더 이상 symlink 가 아니다. aws/setup.sh 가
+# dotfiles SSOT (claude/settings.json) + Bedrock 오버레이를 jq deep-merge
+# 한 결과를 ~/.claude/settings.json 에 실파일로 작성한다. Claude Code 의
+# settings.local.json deep-merge 가 사용자 환경에서 신뢰 불가하기 때문
+# (실측 사례: ANTHROPIC_DEFAULT_SONNET_MODEL 미반영 → 400 invalid model).
+# 그래서 본 분기에서는 settings.json 처리를 aws/setup.sh 에 위임한다.
+# settings.local.json 은 #683 F-2 부터 본 분기가 만들지 않으며, #687 부터는
+# aws/setup.sh 도 만들지 않고 기존 파일이 있으면 deprecation 안내만 한다.
 if [ "$_setup_mode" = "internal" ]; then
     log_info "Internal PC mode — single-account setup (skipping claude-accounts)"
 
-    _single_account_ensure_link "$CLAUDE_SETTINGS_SOURCE"               "$HOME_SETTINGS"
+    # settings.json 처리는 aws/setup.sh 가 책임진다 (#687). 본 분기는 이
+    # 파일에 손대지 않아 aws/setup.sh 가 작성한 실파일이 보존된다.
     _single_account_ensure_link "$CLAUDE_STATUSLINE_SOURCE"             "$HOME_STATUSLINE"
     _single_account_ensure_link "$CLAUDE_SKILLS_SOURCE"                 "$HOME_SKILLS"
     _single_account_ensure_link "$CLAUDE_DOCS_SOURCE"                   "$HOME_DOCS"
@@ -607,10 +620,11 @@ if [ "$_setup_mode" = "internal" ]; then
     _single_account_ensure_link "$HOME/.claude-shared/plugins"          "$HOME/.claude/plugins"
 
     # --- Verify Links (single-account) ---
-    # settings.local.json is intentionally absent from this list — it is a
-    # regular file the user hand-creates (#584), not a dotfiles symlink.
+    # settings.json is intentionally absent from this list — aws/setup.sh
+    # writes it as a regular file (#687). settings.local.json is also
+    # absent — deprecated (#687) and never a dotfiles symlink (#584).
     log_debug "\n--- 심볼릭 링크 확인 (internal/single-account) ---"
-    for link in settings.json statusline-command.sh skills docs plugins projects/GLOBAL/memory; do
+    for link in statusline-command.sh skills docs plugins projects/GLOBAL/memory; do
         if [ -L "$HOME/.claude/$link" ]; then
             log_dim "✓ ~/.claude/$link 심볼릭 링크 확인됨"
         else

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -607,7 +607,8 @@ _single_account_ensure_link() {
 # (실측 사례: ANTHROPIC_DEFAULT_SONNET_MODEL 미반영 → 400 invalid model).
 # 그래서 본 분기에서는 settings.json 처리를 aws/setup.sh 에 위임한다.
 # settings.local.json 은 #683 F-2 부터 본 분기가 만들지 않으며, #687 부터는
-# aws/setup.sh 도 만들지 않고 기존 파일이 있으면 deprecation 안내만 한다.
+# aws/setup.sh 도 만들지 않고 기존 파일이 있으면 timestamp suffix 백업으로
+# 자동 archive 한다 (mv → *.deprecated-687.<ts>).
 if [ "$_setup_mode" = "internal" ]; then
     log_info "Internal PC mode — single-account setup (skipping claude-accounts)"
 


### PR DESCRIPTION
## Summary

- 사내 PC 에서 `settings.json` + `settings.local.json` 의 **deep-merge 가 실제로 적용되지 않아** `ANTHROPIC_DEFAULT_SONNET_MODEL` 이 누락 → `400 The provided model identifier is invalid (apac.anthropic.claude-sonnet-4-5-*)` 에러가 났음.
- `aws/setup.sh` 가 dotfiles SSOT (`claude/settings.json`) + Bedrock 오버레이 (`claude/settings.bedrock-overlay.example`) 를 `jq` deep-merge 한 결과를 `~/.claude/settings.json` **실파일** 로 시드하도록 디자인 변경. 동료의 단일 `settings.json` 형태와 구조 일치.
- 외부 PC 영향 0 — `claude/setup.sh` external 분기의 symlink 디자인 유지. internal 분기에서만 `settings.json` symlink 라인 제거하고 `aws/setup.sh` 에 위임.

## 배경 — 왜 `settings.local.json` 디자인을 폐기했나

Claude Code 공식 docs ([settings precedence](https://code.claude.com/docs/en/settings.md)) 는 `objects are deep-merged` 라고 명시한다. 그러나 사용자 환경(사내 PC, Claude Code v2.1.144, Bedrock 모드)에서 실측 결과 `settings.local.json.env.ANTHROPIC_DEFAULT_SONNET_MODEL` 이 런타임에 적용되지 않아 Claude Code 가 기본 매핑(`apac.anthropic.claude-sonnet-4-5-*`)으로 폴백 → 400 invalid. 동료의 단일 `~/.claude/settings.json` (모든 키가 한 파일) 에서는 정상. 그래서 dotfiles SSOT 자체를 단일 파일 머지 결과로 바꿨다.

## 변경 내용 (커밋 1개 — ce3500e)

| 파일 | 변경 |
|---|---|
| `aws/setup.sh` | `_merge_claude_settings_local` → `_merge_claude_settings_json`. base * overlay * existing 순서로 jq deep-merge (existing 최우선), legacy gateway 키는 머지 전 strip (#677 O-1 계승), 기존 symlink 자동 해제 → 실파일 전환 |
| `claude/setup.sh` | internal 분기에서 `settings.json` symlink 생성 라인 제거 (aws/setup.sh 에 위임). verify 루프도 `settings.json` 제외 |
| `claude/settings.local.bedrock.example` → `claude/settings.bedrock-overlay.example` | rename + `_comment` 갱신 (역할 = settings.json 오버레이) |
| `aws/diagnose.sh` | 2-6) 검사를 `settings.json` 기준으로 변경. symlink 면 FAIL (#687 마이그레이션 미완료), `settings.local.json` 잔존 시 deprecation WARN, `env.ANTHROPIC_DEFAULT_SONNET_MODEL` 존재 여부 직접 검증 |
| `aws/AGENTS.md` / `aws/README.md` | SSOT 표 / 실행 흐름 / 머지 정책 / 트러블슈팅 / 사내 진단 해석 갱신 |

머지 시뮬레이션 결과: env 에 `GH_PR_REPLY_AUTO_APPROVE_REPOS` + `ANTHROPIC_DEFAULT_SONNET_MODEL` + `ANTHROPIC_DEFAULT_HAIKU_MODEL` 모두, hooks/statusLine/enabledPlugins 보존, 모델 매핑 추가. 동료 settings.json 구조와 일치.

## 외부 PC 영향 분석

- `claude/setup.sh` external 분기: 변경 없음 (settings.json symlink 그대로).
- dotfiles `claude/settings.json` 자체: 변경 없음 (외부 PC 가 그대로 symlink 로 참조).
- `aws/setup.sh`: setup-mode != internal 이면 즉시 no-op (기존 gate 그대로).
- 새 파일 `claude/settings.bedrock-overlay.example`: 외부 PC 에서는 어떤 코드도 이 파일을 읽지 않음.

## Test plan

- [ ] 사내 PC 에서 `./aws/setup.sh` 실행 → `[OK] Merged Bedrock keys into: ~/.claude/settings.json` + `Backup: ...bedrock-merge-backup.<ts>` 출력
- [ ] `ls -la ~/.claude/settings.json` 이 **실파일** (symlink 아님). `~/.claude/settings.json.bedrock-merge-backup.<ts>` 존재
- [ ] `jq '.env.ANTHROPIC_DEFAULT_SONNET_MODEL' ~/.claude/settings.json` 가 `"global.anthropic.claude-sonnet-4-6"` 출력
- [ ] `claude` 실행 → `/status` 에서 API provider = Amazon Bedrock + 400 invalid 에러 사라짐
- [ ] `./aws/diagnose.sh` 의 `2-6) 모델 정보` 섹션이 PASS (특히 `env.ANTHROPIC_DEFAULT_SONNET_MODEL` PASS, `~/.claude/settings.json 실파일 존재` PASS)
- [ ] `~/.claude/settings.local.json` 잔존 시 WARN 출력 (deprecation 안내) 확인
- [ ] 외부 PC 에서 `./setup.sh` 재실행 → `~/.claude/settings.json` 이 여전히 dotfiles 로 symlink (영향 0 검증)

## References

- 분석 이슈: #687
- 직전 베이스: #677 (사내 PC AWS Bedrock 부트스트랩), #683/#684 (게이트웨이 env 자동 주입 제거)
- legacy gateway 키 strip 룰: #677 O-1 (계승, URL 패턴 → 키 이름 매칭)

Closes #687

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~2 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~2 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
