### PR TITLE
test(gwt): #692 oh-my-zsh alias shadowing regression test

### DIFF
--- a/tests/bats/functions/git_worktree_alias_shadow.bats
+++ b/tests/bats/functions/git_worktree_alias_shadow.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_worktree_alias_shadow.bats
+# Regression test for issue #692 — oh-my-zsh git plugin declares
+# `alias gwt='git worktree'`, which shadows dotfiles' gwt() function because
+# zsh/bash command parsing resolves aliases before functions.
+#
+# The fix lives in shell-common/functions/git_worktree.sh (line 9):
+#     unalias gwt 2>/dev/null || true
+# placed right after the interactive guard and before the function body.
+#
+# This test pre-declares the conflicting alias before sourcing dotfiles, then
+# verifies `type gwt` reports a function — proving the unalias guard removes
+# the shadowing alias regardless of plugin load order.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "alias-shadow: pre-existing 'alias gwt=git worktree' removed when dotfiles loads (bash)" {
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        shopt -s expand_aliases
+        alias gwt='git worktree'
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        type gwt
+    "
+    assert_success
+    assert_output --partial "is a function"
+    refute_output --partial "aliased to"
+}
+
+@test "alias-shadow: pre-existing 'alias gwt=git worktree' removed when dotfiles loads (zsh)" {
+    run zsh -f -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
+        export HOME='${HOME}'
+        export ZDOTDIR='${HOME}'
+        export TERM=dumb
+        alias gwt='git worktree'
+        source '${DOTFILES_ROOT}/zsh/main.zsh'
+        whence -w gwt
+    "
+    assert_success
+    assert_output --partial "gwt: function"
+    refute_output --partial "gwt: alias"
+}
+
+@test "alias-shadow: 'gwt help' invokes dotfiles function (not the shadowed git native) in bash" {
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        shopt -s expand_aliases
+        alias gwt='git worktree'
+        source '${DOTFILES_ROOT}/bash/main.bash'
+        gwt help
+    "
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}
+
+@test "alias-shadow: 'gwt help' invokes dotfiles function (not the shadowed git native) in zsh" {
+    run zsh -f -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export DOTFILES_ROOT_NO_CANONICALIZE=1
+        export HOME='${HOME}'
+        export ZDOTDIR='${HOME}'
+        export TERM=dumb
+        alias gwt='git worktree'
+        source '${DOTFILES_ROOT}/zsh/main.zsh'
+        gwt help
+    "
+    assert_success
+    assert_output --partial "Usage: gwt help"
+}

--- a/tests/bats/functions/git_worktree_alias_shadow.bats
+++ b/tests/bats/functions/git_worktree_alias_shadow.bats
@@ -11,6 +11,13 @@
 # This test pre-declares the conflicting alias before sourcing dotfiles, then
 # verifies `type gwt` reports a function — proving the unalias guard removes
 # the shadowing alias regardless of plugin load order.
+#
+# Note on `eval 'gwt help'` in the dispatch tests below: in `bash -c` / `zsh -c`
+# the whole script string is parsed before any runtime `alias` command takes
+# effect, so a plain `gwt help` is never alias-expanded — the test would pass
+# even with a broken unalias guard (false positive, PR #693 review). `eval`
+# forces a runtime re-parse at the point where the alias *is* registered, so
+# only a working guard prevents the alias from expanding to `git worktree`.
 
 load '../test_helper'
 
@@ -72,7 +79,7 @@ teardown() {
         shopt -s expand_aliases
         alias gwt='git worktree'
         source '${DOTFILES_ROOT}/bash/main.bash'
-        gwt help
+        eval 'gwt help'
     "
     assert_success
     assert_output --partial "Usage: gwt help"
@@ -90,7 +97,7 @@ teardown() {
         export TERM=dumb
         alias gwt='git worktree'
         source '${DOTFILES_ROOT}/zsh/main.zsh'
-        gwt help
+        eval 'gwt help'
     "
     assert_success
     assert_output --partial "Usage: gwt help"


### PR DESCRIPTION
## Summary
- 이슈 #692 검증 항목 #4 의 갭 — oh-my-zsh git 플러그인의 `alias gwt='git worktree'` 가 dotfiles `gwt()` 함수를 셰도하는 회귀를 잡는 bats 회귀 테스트를 추가했다.
- 본 픽스 (`shell-common/functions/git_worktree.sh:9` 의 `unalias gwt 2>/dev/null || true`) 는 이미 commit 2a50305 (Apr 8) 부터 존재. 이 PR 은 그 가드가 다시 깨지지 않도록 테스트로 잠근다.

## Changes
- `tests/bats/functions/git_worktree_alias_shadow.bats` (97 lines, 4 cases):
  - bash 에서 사전 `alias gwt='git worktree'` 깐 뒤 dotfiles 를 source — `type gwt` 가 function 으로 잡히는지.
  - zsh 에서 동일 — `whence -w gwt` 가 `gwt: function` 인지 + `gwt: alias` 아닌지.
  - bash/zsh 모두 `gwt help` 가 dotfiles 의 `Usage: gwt help` 텍스트를 출력 (git 네이티브 `unknown subcommand` 가 아님).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_alias_shadow.bats` → 4/4 통과.
- [x] 형제 테스트 (`git_worktree_help.bats`) 22/22 통과 — 회귀 없음.
- [x] `tox -e ruff,shellcheck,shfmt` 통과 (pre-push lint guard).
- [ ] CI green.

## Related
Closes #692

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
