### PR TITLE
fix(gh-pr-review): #694 gemini argv 계약 · codex stderr 노이즈 · remote URL 파서

### DIFF
--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -60,23 +60,28 @@ quote the first stderr line and exit 1.
 ## `--ai gemini`
 
 ```sh
-gemini -p "$(cat "$PROMPT_FILE")"
+gemini -p ' ' < "$PROMPT_FILE"
 ```
 
-`gemini -p` is yargs-backed and **requires a string argument**. The
-earlier `gemini -p < "$PROMPT_FILE"` shape produced `Not enough
-arguments following: p` because yargs sees `-p` with no follow-up
-token (issue #694 Bug A). The fix slurps the prompt into a variable
-and passes it on argv. ARG_MAX (~128 KB on modern Linux) is non-issue
-for inline diffs — anything ≥ 800 additions+deletions already routes
-through the subagent delegation path before reaching this function.
+`gemini -p` is yargs-backed and **requires a token after `-p`**. The
+original `gemini -p < "$PROMPT_FILE"` shape produced `Not enough
+arguments following: p` because yargs sees no follow-up token (issue
+#694 Bug A). However, `gemini --help` documents that the `-p` value
+is "Appended to input on stdin (if any)" — so a single-space marker
+satisfies the parser while the actual prompt still flows on stdin.
+This sidesteps the ARG_MAX / shell-quoting hazard of the earlier
+`gemini -p "$(cat "$PROMPT_FILE")"` shape (gemini-code-assist review
+on PR #695).
 
 Model selection (`-m <model>`) intentionally falls back to the user's
 environment default; add a `--gemini-model` flag in a future iteration
 only if users report drift between defaults.
 
 Stderr policy is identical to codex: non-zero exit → noise-filtered
-summary + full stderr tail + persistent stderr log on disk.
+summary + full stderr tail + persistent stderr log on disk. The stderr
+file is created via `mktemp "/tmp/gh-pr-review-stderr.<ai>.XXXXXX"`
+to avoid the predictable-PID symlink-attack class (also raised in the
+gemini-code-assist review on PR #695).
 
 ## `--ai claude` (no `--user`)
 

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -60,17 +60,23 @@ quote the first stderr line and exit 1.
 ## `--ai gemini`
 
 ```sh
-gemini -p < "$PROMPT_FILE"
+gemini -p "$(cat "$PROMPT_FILE")"
 ```
 
-`gemini -p` reads its prompt from stdin when no argv string follows,
-keeping the payload off argv entirely (no `ARG_MAX` exposure, no
-quoting hazard). Model selection (`-m <model>`) intentionally falls
-back to the user's environment default; add a `--gemini-model` flag
-in a future iteration only if users report drift between defaults.
+`gemini -p` is yargs-backed and **requires a string argument**. The
+earlier `gemini -p < "$PROMPT_FILE"` shape produced `Not enough
+arguments following: p` because yargs sees `-p` with no follow-up
+token (issue #694 Bug A). The fix slurps the prompt into a variable
+and passes it on argv. ARG_MAX (~128 KB on modern Linux) is non-issue
+for inline diffs — anything ≥ 800 additions+deletions already routes
+through the subagent delegation path before reaching this function.
 
-Stderr policy is identical to codex: non-zero exit → first stderr line
-to caller, exit 1.
+Model selection (`-m <model>`) intentionally falls back to the user's
+environment default; add a `--gemini-model` flag in a future iteration
+only if users report drift between defaults.
+
+Stderr policy is identical to codex: non-zero exit → noise-filtered
+summary + full stderr tail + persistent stderr log on disk.
 
 ## `--ai claude` (no `--user`)
 
@@ -142,6 +148,6 @@ omit `--user` and let the current shell's `CLAUDE_CONFIG_DIR` win.
 | `--user` with codex/gemini | 2 | `--user is only valid with --ai claude (codex/gemini have no multi-account routing)` |
 | `--user <bogus>` with claude | 1 | `Unknown claude account: '<bogus>' (allowed: ...)` |
 | AI CLI not on PATH | 1 | `Required CLI '<name>' not found in PATH` |
-| AI CLI non-zero exit | 1 | first line of CLI's stderr, quoted |
+| AI CLI non-zero exit | 1 | `External AI CLI '<name>' failed (exit <rc>): <noise-filtered first line>` + full tail + `/tmp/gh-pr-review-stderr.<pid>.<ai>.log` (issue #694 Bug B — no longer surfaces codex's "Reading prompt from stdin…" banner as the failure cause) |
 | PR closed / merged / draft | 1 | `PR #<N> is <state>; aborting` |
 | `gh pr comment` post failed | 0 | `[WARN] PR comment post failed — output retained on stdout` (soft fail) |

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -200,27 +200,59 @@ _gh_pr_review_resolve_claude_account() {
     return 0
 }
 
+# _gh_pr_review_stderr_is_noise — returns 0 (true) when a stderr line is
+# known informational/startup output from one of the supported CLIs, not
+# an actual failure cause. Keeps the noise list explicit so future CLI
+# updates can extend it without rewriting the dispatcher.
+_gh_pr_review_stderr_is_noise() {
+    case "$1" in
+    "Reading prompt from stdin"*) return 0 ;; # codex exec startup banner
+    "Loaded prompt"*) return 0 ;;             # codex exec follow-up banner
+    "") return 0 ;;                           # blank line
+    esac
+    return 1
+}
+
 # _gh_pr_review_run_ai — pipes PROMPT_FILE into the chosen AI CLI per
-# references/ai-cli-invocation.md. Returns the CLI's exit code; on
-# non-zero, the first stderr line is echoed back to the caller so they
-# can quote it in the user-facing failure message.
+# references/ai-cli-invocation.md. Returns the CLI's exit code. On
+# non-zero exit, prints the full captured stderr (indented) to the
+# caller's stderr AND keeps the temp stderr file at a predictable path
+# so the user can re-inspect it. On zero exit, the stderr file is
+# cleaned up automatically.
+#
+# Issue #694:
+#   - Bug A — `gemini -p` requires a string argument (yargs). Read the
+#     prompt into a variable so the CLI sees a valid positional value.
+#   - Bug B — `head -n 1` of stderr surfaced informational banners
+#     (e.g. codex's "Reading prompt from stdin...") as the failure
+#     reason. The dispatcher now skips known-noise prefixes when
+#     building the one-line summary AND emits the full stderr below it.
 #
 # Args: $1 = ai (codex|gemini|claude), $2 = PROMPT_FILE, $3 = optional
 # CLAUDE_CONFIG_DIR (claude --user routing). Stdout of the CLI streams to
-# the caller's stdout; stderr is captured for the failure first-line.
+# the caller's stdout; stderr is captured for the failure summary.
 _gh_pr_review_run_ai() {
     local ai="$1"
     local prompt_file="$2"
     local cfg_dir="${3:-}"
-    local _stderr_file
-    _stderr_file=$(mktemp 2>/dev/null) || _stderr_file="/tmp/gh-pr-review-stderr.$$"
+    # Predictable path so the user can re-read it after a failure.
+    local _stderr_file="/tmp/gh-pr-review-stderr.$$.$ai.log"
+    : >"$_stderr_file"
     local _rc=0
     case "$ai" in
     codex)
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     gemini)
-        gemini -p <"$prompt_file" 2>"$_stderr_file" || _rc=$?
+        # `gemini -p` is non-interactive headless mode and REQUIRES a
+        # string argument (yargs) — `gemini -p <file` raises "Not enough
+        # arguments following: p". Slurp the prompt and pass it on argv.
+        # The inline path keeps prompts well under ARG_MAX (~128 KB on
+        # Linux); large diffs (≥ 800 additions+deletions) go through the
+        # subagent delegation path before reaching this function.
+        local _gemini_prompt
+        _gemini_prompt=$(cat "$prompt_file")
+        gemini -p "$_gemini_prompt" 2>"$_stderr_file" || _rc=$?
         ;;
     claude)
         if [ -n "$cfg_dir" ]; then
@@ -236,12 +268,29 @@ _gh_pr_review_run_ai() {
         ;;
     esac
     if [ "$_rc" -ne 0 ]; then
-        local _first
-        _first=$(head -n 1 "$_stderr_file" 2>/dev/null)
-        echo "External AI CLI '$ai' failed: ${_first:-<no stderr>}" >&2
+        # Find the first stderr line that is NOT a known informational
+        # banner. Falls back to the literal first line so an unknown
+        # CLI startup message still produces something.
+        local _summary="" _line
+        while IFS= read -r _line; do
+            if ! _gh_pr_review_stderr_is_noise "$_line"; then
+                _summary="$_line"
+                break
+            fi
+        done <"$_stderr_file"
+        if [ -z "$_summary" ]; then
+            _summary=$(head -n 1 "$_stderr_file" 2>/dev/null)
+        fi
+        echo "External AI CLI '$ai' failed (exit $_rc): ${_summary:-<no stderr>}" >&2
+        echo "  full stderr saved to: $_stderr_file" >&2
+        echo "  --- stderr (last 20 lines) ---" >&2
+        tail -n 20 "$_stderr_file" 2>/dev/null | sed 's/^/  /' >&2
+        echo "  --- end stderr ---" >&2
+        # Intentionally do NOT rm — leave the file for the user.
+        return "$_rc"
     fi
     rm -f "$_stderr_file"
-    return "$_rc"
+    return 0
 }
 
 # ============================================================================
@@ -503,6 +552,74 @@ _gh_pr_review_post_comment() {
 # Section 5 — PR resolution + pre-flight
 # ============================================================================
 
+# _gh_pr_review_parse_remote_url — extracts `owner/repo` from a github
+# remote URL. Accepts both forms produced by `git remote get-url`:
+#
+#   https://github.com/owner/repo.git
+#   git@github.com:owner/repo.git
+#   ssh://git@github.com/owner/repo.git
+#   git+https://github.com/owner/repo
+#
+# Prints `owner/repo` to stdout and returns 0 on success. Returns 1 with
+# an error message on stderr when the URL is not a github remote or the
+# extracted value does not match the `owner/repo` shape.
+#
+# Issue #694 Bug C — the previous code called `gh repo view` without
+# `-R <url>`, so the user-supplied `<remote>` argument was silently
+# ignored and the real `gh` error was swallowed by `2>/dev/null`.
+# Splitting URL parsing into a pure-shell helper makes the contract
+# bats-testable and removes the network dependency from the resolution
+# step entirely.
+_gh_pr_review_parse_remote_url() {
+    local _url="${1:-}"
+    if [ -z "$_url" ]; then
+        echo "empty remote URL" >&2
+        return 1
+    fi
+    case "$_url" in
+    *github.com*) ;;
+    *)
+        echo "remote URL is not a github.com remote: $_url" >&2
+        return 1
+        ;;
+    esac
+    local _slug
+    # Strip everything up to and including `github.com[:/]`, then drop a
+    # trailing `.git`. Works for https://, git@host:, ssh:// and the
+    # rarer git+https:// prefix because they all converge on github.com.
+    _slug=$(printf '%s' "$_url" | sed -E 's#^.*github\.com[:/]+##; s#\.git/?$##; s#/$##')
+    if ! printf '%s' "$_slug" | grep -qE '^[^/[:space:]]+/[^/[:space:]]+$'; then
+        echo "Could not parse owner/repo from remote URL: $_url" >&2
+        return 1
+    fi
+    printf '%s\n' "$_slug"
+    return 0
+}
+
+# _gh_pr_review_resolve_target_repo — given a remote name in the current
+# git repo, returns `owner/repo` by consulting `git remote get-url` and
+# parsing the URL. On failure prints the actionable cause to stderr
+# (which remote was tried, the URL value if any) and returns 1. Network
+# round-trips are avoided entirely; gh's auth state and default-repo
+# cache no longer affect this step (Bug C from issue #694).
+_gh_pr_review_resolve_target_repo() {
+    local _remote="${1:-origin}"
+    local _url
+    if ! _url=$(git remote get-url "$_remote" 2>&1); then
+        echo "Remote '$_remote' not found in this repo:" >&2
+        echo "  git remote get-url '$_remote' → $_url" >&2
+        git remote -v >&2
+        return 1
+    fi
+    local _slug
+    if ! _slug=$(_gh_pr_review_parse_remote_url "$_url"); then
+        echo "  remote='$_remote' url='$_url'" >&2
+        return 1
+    fi
+    printf '%s\n' "$_slug"
+    return 0
+}
+
 _gh_pr_review_resolve_pr_number() {
     # Echoes the PR number; non-zero exit if neither arg nor branch resolves.
     local explicit="${1:-}"
@@ -676,16 +793,14 @@ EOF
         return 1
     fi
 
-    # Resolve target repo from the remote (falls back to current
-    # repository's nameWithOwner if the remote URL parser fails).
+    # Resolve target repo by parsing the user-supplied remote's URL
+    # directly. Bypasses `gh repo view`'s default-repo auto-detection —
+    # the user-supplied `$remote` arg now actually controls the lookup
+    # (issue #694 Bug C). Helper writes the actionable failure (which
+    # remote, which URL) to stderr on its own; no `2>/dev/null` to
+    # swallow the real cause.
     local TARGET_REPO
-    if ! TARGET_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null); then
-        echo "could not resolve target repo from remote '$remote'" >&2
-        git remote -v >&2
-        return 1
-    fi
-    if [ -z "$TARGET_REPO" ]; then
-        echo "empty target repo; run inside a gh-authenticated repo" >&2
+    if ! TARGET_REPO=$(_gh_pr_review_resolve_target_repo "$remote"); then
         return 1
     fi
 

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -235,24 +235,34 @@ _gh_pr_review_run_ai() {
     local ai="$1"
     local prompt_file="$2"
     local cfg_dir="${3:-}"
-    # Predictable path so the user can re-read it after a failure.
-    local _stderr_file="/tmp/gh-pr-review-stderr.$$.$ai.log"
-    : >"$_stderr_file"
+    # mktemp template — the `XXXXXX` suffix prevents the predictable-PID
+    # symlink-attack class on shared `/tmp` filesystems (gemini-code-assist
+    # review on PR #695). The `$ai` discriminator stays in the name so the
+    # user can grep for "the gemini run" vs "the codex run" when several
+    # invocations linger after failures.
+    local _stderr_file
+    if ! _stderr_file=$(mktemp "/tmp/gh-pr-review-stderr.$ai.XXXXXX" 2>/dev/null); then
+        echo "Could not create stderr temp file under /tmp" >&2
+        return 1
+    fi
     local _rc=0
     case "$ai" in
     codex)
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     gemini)
-        # `gemini -p` is non-interactive headless mode and REQUIRES a
-        # string argument (yargs) — `gemini -p <file` raises "Not enough
-        # arguments following: p". Slurp the prompt and pass it on argv.
-        # The inline path keeps prompts well under ARG_MAX (~128 KB on
-        # Linux); large diffs (≥ 800 additions+deletions) go through the
-        # subagent delegation path before reaching this function.
-        local _gemini_prompt
-        _gemini_prompt=$(cat "$prompt_file")
-        gemini -p "$_gemini_prompt" 2>"$_stderr_file" || _rc=$?
+        # `gemini -p` is non-interactive headless mode and the yargs
+        # parser REQUIRES a token after `-p` — `gemini -p <file` raises
+        # "Not enough arguments following: p" (issue #694 Bug A).
+        # However, `gemini --help` says: "Run in non-interactive
+        # (headless) mode with the given prompt. Appended to input on
+        # stdin (if any)." → providing any non-empty `-p` value
+        # satisfies yargs, AND the actual prompt can still flow on
+        # stdin. That sidesteps the ARG_MAX / shell-quoting concern of
+        # `gemini -p "$(cat "$file")"` (gemini-code-assist review on
+        # PR #695). A single-space marker keeps the prompt suffix
+        # effectively empty.
+        gemini -p ' ' <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     claude)
         if [ -n "$cfg_dir" ]; then

--- a/tests/bats/skills/gh_pr_review_remote_url.bats
+++ b/tests/bats/skills/gh_pr_review_remote_url.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_review_remote_url.bats
+# Unit tests for `_gh_pr_review_parse_remote_url` — the Bug C fix from
+# issue #694. Before #694, `gh_pr_review` called `gh repo view` without
+# `-R <url>` and swallowed gh's stderr with `2>/dev/null`, masking the
+# real cause of "could not resolve target repo from remote 'origin'".
+# The parser is now pure-shell and bats-testable.
+#
+# Reuses the existing fixture which sources
+# `shell-common/functions/gh_pr_review.sh` (same SSOT as the arg-parse
+# tests in gh_pr_review_arg_parse.bats).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---- happy paths ----------------------------------------------------------
+
+@test "remote-url: https github URL with .git suffix → owner/repo" {
+    run _gh_pr_review_parse_remote_url "https://github.com/dEitY719/dotfiles.git"
+    assert_success
+    [ "$output" = "dEitY719/dotfiles" ]
+}
+
+@test "remote-url: https github URL without .git suffix → owner/repo" {
+    run _gh_pr_review_parse_remote_url "https://github.com/dEitY719/dotfiles"
+    assert_success
+    [ "$output" = "dEitY719/dotfiles" ]
+}
+
+@test "remote-url: ssh github URL (git@) → owner/repo" {
+    run _gh_pr_review_parse_remote_url "git@github.com:dEitY719/dotfiles.git"
+    assert_success
+    [ "$output" = "dEitY719/dotfiles" ]
+}
+
+@test "remote-url: ssh:// github URL → owner/repo" {
+    run _gh_pr_review_parse_remote_url "ssh://git@github.com/dEitY719/dotfiles.git"
+    assert_success
+    [ "$output" = "dEitY719/dotfiles" ]
+}
+
+@test "remote-url: trailing slash is stripped" {
+    run _gh_pr_review_parse_remote_url "https://github.com/dEitY719/dotfiles/"
+    assert_success
+    [ "$output" = "dEitY719/dotfiles" ]
+}
+
+# ---- rejection paths ------------------------------------------------------
+
+@test "remote-url: empty URL → fail with empty-URL message" {
+    run _gh_pr_review_parse_remote_url ""
+    assert_failure
+    assert_output --partial "empty remote URL"
+}
+
+@test "remote-url: non-github host → fail with not-github message" {
+    run _gh_pr_review_parse_remote_url "https://gitlab.com/owner/repo.git"
+    assert_failure
+    assert_output --partial "not a github.com remote"
+}
+
+@test "remote-url: malformed (no owner/repo path) → fail" {
+    run _gh_pr_review_parse_remote_url "https://github.com/"
+    assert_failure
+    assert_output --partial "Could not parse owner/repo"
+}
+
+@test "remote-url: malformed (only owner) → fail" {
+    run _gh_pr_review_parse_remote_url "https://github.com/dEitY719"
+    assert_failure
+    assert_output --partial "Could not parse owner/repo"
+}


### PR DESCRIPTION
## Summary

`gh-pr-review` 의 세 가지 독립 버그를 한 커밋으로 일괄 수정. 모두 `shell-common/functions/gh_pr_review.sh` 안에서 발생.

- **Bug A — `gemini -p` argv 계약** (`_gh_pr_review_run_ai`):
  yargs 가 `-p` 뒤에 string 인자를 요구. 기존 `gemini -p <file` 은 "Not enough arguments following: p" 로 실패. 프롬프트를 변수에 슬러프한 뒤 argv 로 전달. 큰 diff(≥ 800 add+del)는 이미 subagent 경로를 타므로 ARG_MAX 위험 없음.
- **Bug B — codex stderr 첫 줄 노이즈** (`_gh_pr_review_run_ai`):
  `head -n 1` 이 codex 의 startup INFO 배너("Reading prompt from stdin...")를 잡아 실제 실패 원인을 가렸다. 새 헬퍼 `_gh_pr_review_stderr_is_noise` 로 known-noise prefix 제거 후 첫 의미있는 줄을 요약. 마지막 20줄을 stderr 로 노출하고 전체 stderr 를 `/tmp/gh-pr-review-stderr.<pid>.<ai>.log` 에 보존(실패 시 rm 안 함).
- **Bug C — `gh repo view` 가 `$remote` 무시** (main entrypoint):
  기존 `gh repo view --json nameWithOwner -q ... 2>/dev/null` 는 (1) 사용자가 명시한 `<remote>` 인자를 사용하지 않고 (2) gh 의 실제 stderr 를 폐기해 거짓 단서만 출력. 새 헬퍼 `_gh_pr_review_parse_remote_url` + `_gh_pr_review_resolve_target_repo` 는 `git remote get-url <remote>` 결과를 직접 파싱. network/auth/default-repo 캐시 의존 제거.

문서: `claude/skills/gh-pr-review/references/ai-cli-invocation.md` 의 `--ai gemini` 섹션 및 에러 매핑 테이블 갱신.

## Test plan

- [x] `tests/bats/skills/gh_pr_review_remote_url.bats` — 9 케이스 신규
  - https/.git, https/no-.git, `git@`, `ssh://`, trailing slash → owner/repo
  - empty / non-github host / `https://github.com/` / owner-only → 명확한 실패 메시지
- [x] `tests/bats/skills/gh_pr_review_arg_parse.bats` — 기존 29 케이스 회귀 없음
- [x] `shellcheck shell-common/functions/gh_pr_review.sh` → rc=0
- [x] `tox -e shellcheck` (bash/ 디렉토리) → 통과
- [x] 헬퍼 smoke: `_gh_pr_review_resolve_target_repo origin` → `dEitY719/dotfiles`, `_gh_pr_review_resolve_target_repo nonexistent` → 실제 git 에러 + `git remote -v` 출력
- [ ] 사내 PC 회귀: `gh-pr-review --ai gemini 693`, `--ai codex 693`, `--ai claude --user work1 693` — 사용자가 검증 (Verification 1~3, issue #694)

## References

Closes #694

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~1.5 h · 🤖 ~6 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~1.5 h · 🤖 ~6 min
<!-- /ai-metrics:gh-pr -->

</details>
