### PR TITLE
fix(zsh): disable p10k instant prompt — frozen prompt in worktree shells

### DIFF
--- a/zsh/app/p10k.zsh
+++ b/zsh/app/p10k.zsh
@@ -1738,7 +1738,7 @@
   #   - verbose: Enable instant prompt and print a warning when detecting console output during
   #              zsh initialization. Choose this if you've never tried instant prompt, haven't
   #              seen the warning, or if you are unsure what this all means.
-  typeset -g POWERLEVEL9K_INSTANT_PROMPT=verbose
+  typeset -g POWERLEVEL9K_INSTANT_PROMPT=off
 
   # Hot reload allows you to change POWERLEVEL9K options after Powerlevel10k has been initialized.
   # For example, you can type POWERLEVEL9K_BACKGROUND=red and see your prompt turn red. Hot reload

--- a/zsh/app/p10k.zsh
+++ b/zsh/app/p10k.zsh
@@ -1738,6 +1738,11 @@
   #   - verbose: Enable instant prompt and print a warning when detecting console output during
   #              zsh initialization. Choose this if you've never tried instant prompt, haven't
   #              seen the warning, or if you are unsure what this all means.
+  # Forced to `off` (PR #696): instant prompt's placeholder precmd raced
+  # with `gwt spawn --launch` (`cd → term_rename --persist → claude_yolo`),
+  # leaving `_p9k_do_nothing` as the only precmd hook and freezing the
+  # prompt at the spawn-time directory. Do NOT flip back to `verbose`
+  # without addressing the worktree-shell init race first.
   typeset -g POWERLEVEL9K_INSTANT_PROMPT=off
 
   # Hot reload allows you to change POWERLEVEL9K options after Powerlevel10k has been initialized.

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -3,9 +3,17 @@ if [[ "${DOTFILES_KEEP_NOUNSET:-0}" != "1" ]]; then
   unsetopt nounset
 fi
 
-# Suppress dotfiles init message to avoid Powerlevel10k instant prompt warnings
-# (Console output after instant prompt causes prompt jump)
+# Suppress `dotfiles_init_summary` (defined in zsh/main.zsh) — keep the
+# interactive shell quiet on every startup. Originally introduced to
+# silence Powerlevel10k instant-prompt warnings; instant prompt itself
+# is now off (PR #696, see zsh/app/p10k.zsh INSTANT_PROMPT=off) but the
+# suppression is retained as a general preference.
 export DOTFILES_SUPPRESS_MESSAGE=1
+
+# Instant prompt is intentionally disabled — the standard
+# `source ~/.cache/p10k-instant-prompt-*.zsh` block was removed in
+# PR #696 (worktree shell prompt freeze). Do NOT re-add it without
+# first fixing the race documented at zsh/app/p10k.zsh INSTANT_PROMPT=off.
 
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -7,13 +7,6 @@ fi
 # (Console output after instant prompt causes prompt jump)
 export DOTFILES_SUPPRESS_MESSAGE=1
 
-# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
-# Initialization code that may require console input (password prompts, [y/n]
-# confirmations, etc.) must go above this block; everything else may go below.
-if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-fi
-
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
 


### PR DESCRIPTION
## Summary
- p10k 의 `_p9k_setup` 마무리와 `gwt spawn --launch` (`cd → term_rename --persist → claude_yolo` 의 `emulate -L sh` + subshell) 사이 init race 로 인해 `_p9k_precmd` 가 `precmd_functions` 에 등록되지 못해 prompt 가 spawn 이전 디렉터리로 영구 frozen 되던 증상 해결.
- `POWERLEVEL9K_INSTANT_PROMPT` 을 `verbose` → `off` 로 전환, zshrc 의 instant prompt 캐시 source 블록 제거. shell 시작 시점에 placeholder precmd 단계를 거치지 않도록 race window 자체를 제거.
- Trade-off: 첫 prompt 가 zshrc 완전 로드 후에 그려져 ~100–300ms 늦어짐. 워크트리 spawn 직후에도 prompt 가 항상 실제 PWD 와 일치하므로 디버깅 시 혼란 zero.

## Changes
- `zsh/app/p10k.zsh`: `POWERLEVEL9K_INSTANT_PROMPT=verbose` → `off`. p10k 의 instant prompt placeholder (`_p9k_do_nothing`) 가 더 이상 등록되지 않고, zshrc 가 완전히 로드된 후 첫 prompt 가 그려짐.
- `zsh/zshrc`: 상단의 `${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh` source 블록 (7줄) 제거. instant prompt off 와 일관된 정리.

## Test plan
- [x] `shellcheck` (tox -e shellcheck) 통과
- [x] Fresh `zsh -ic` 에서 `precmd_functions` 검사 — `_p9k_precmd` 가 array 에 등록되어 있고 `omz_termsupport_precmd`, `_zsh_autosuggest_start`, `_codex_periodic_auto_sync` 등 dotfiles 의 다른 hook 들도 모두 살아있음을 확인
- [x] 워크트리 cd 시 `%~` 가 실제 PWD (`~/dotfiles-issue-687`) 로 정확히 갱신, 메인 repo 회귀 시 `~/dotfiles` 로 정상 복귀 확인
- [ ] 양 PC (외부 / 사내) 에서 `rm -f ~/.cache/p10k-instant-prompt-*.zsh* ~/.cache/p10k-dump-*.zsh*` + 새 터미널로 stale 캐시 정리 후, `gwt spawn test --launch` 흐름에서 prompt 가 worktree 디렉터리로 정확히 표시되는지 확인

## Diagnostic SSOT
p10k frozen prompt 진단의 single source of truth 는 `print -lr -- $precmd_functions` 한 줄. `_p9k_do_nothing` 만 살아있고 `_p9k_precmd` 가 array 에서 빠진 패턴 = init race. `functions _p9k_precmd` 로는 *defined* 인데 array 에 없는 게 결정타.

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
