### PR TITLE
refactor(gcp): gcp_* family → gcp <verb> Type 2A dispatcher 통합

### DIFF
--- a/shell-common/functions/gcp.sh
+++ b/shell-common/functions/gcp.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+# shell-common/functions/gcp.sh
+#
+# Type 2A dispatcher for the gcp_* cherry-pick family. See
+# docs/.ssot/command-design-pattern.md §4 (Type 2A) and §1 (naming).
+#
+# Public surface:
+#   gcp scan   [base] [src] [--author=<name|all>]
+#   gcp theirs <commit>...
+#   gcp ours   <commit>...
+#   gcp author <range> [author]
+#   gcp pick   <commit>...
+#   gcp [-h | --help | help [section|--list|--all]]
+#
+# Deprecated backward-compat (Phase 1 — issue #697):
+#   gcp_scan / gcp-scan / gcp_theirs / gcp_ours / gcp_author  → 'gcp <verb>'
+#   gcp <committish>                                          → 'gcp pick'
+#                                                              + ux_warning
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# ----------------------------------------------------------------------------
+# Heuristic: $1 is a resolvable commit-ish. Used by the bare-form
+# `gcp <committish>` bridge so muscle-memory keeps working with a deprecation
+# warning. rev-parse handles HEAD~3, branch^, abbreviated SHAs, refs, etc. —
+# regex hex matching alone would miss those.
+# ----------------------------------------------------------------------------
+_gcp_committish_p() {
+    [ -n "${1-}" ] || return 1
+    git rev-parse --verify "$1^{commit}" >/dev/null 2>&1
+}
+
+# ----------------------------------------------------------------------------
+# Internal: cherry-pick with optional -X <strategy>. SSOT for theirs/ours so
+# the two wrappers stay one-liners (Type 2A §9 SRP).
+# Args: <strategy:""|theirs|ours> <commit>...
+# ----------------------------------------------------------------------------
+_gcp_strategy_pick() {
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+    local strategy="$1"
+    shift
+
+    if [ $# -eq 0 ]; then
+        local cmd_name="gcp pick"
+        local desc="Cherry-pick one or more commits"
+        if [ -n "$strategy" ]; then
+            cmd_name="gcp $strategy"
+            desc="Cherry-pick with '$strategy' conflict strategy"
+        fi
+        ux_usage "$cmd_name" "<commit-id> [commit-id2] ..." "$desc"
+        ux_bullet "$cmd_name abc1234"
+        [ -n "$strategy" ] && ux_warning "Conflicts will use $strategy changes"
+        return 1
+    fi
+
+    local commit failed=0
+    for commit in "$@"; do
+        if [ -n "$strategy" ]; then
+            if git cherry-pick -X "$strategy" "$commit"; then
+                ux_success "Cherry-pick (-X $strategy) succeeded: $commit"
+            else
+                ux_error "Cherry-pick (-X $strategy) failed: $commit"
+                failed=1
+                break
+            fi
+        else
+            if git cherry-pick "$commit"; then
+                ux_success "Cherry-pick succeeded: $commit"
+            else
+                ux_error "Cherry-pick failed: $commit"
+                failed=1
+                break
+            fi
+        fi
+    done
+    return $failed
+}
+
+_gcp_pick()   { _gcp_strategy_pick "" "$@"; }
+_gcp_theirs() { _gcp_strategy_pick "theirs" "$@"; }
+_gcp_ours()   { _gcp_strategy_pick "ours" "$@"; }
+
+# ----------------------------------------------------------------------------
+# Cherry-pick all commits by <author> in <range>. Default author is dEitY719
+# (matches the SSOT in _gcp_scan / gcp_scan.sh).
+# ----------------------------------------------------------------------------
+_gcp_author() {
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+    local commit_range="${1-}"
+    local author="${2:-dEitY719}"
+
+    if [ -z "$commit_range" ]; then
+        ux_usage "gcp author" "<commit-range> [author-name]" "Cherry-pick commits by specific author"
+        ux_bullet "gcp author 751e304..7ffcbd4"
+        ux_bullet "gcp author 751e304..7ffcbd4 dEitY719"
+        ux_warning "Format: <start>..<end> or <start>^..<end>"
+        return 1
+    fi
+
+    local commits
+    commits=$(git log --author="$author" --no-merges --reverse --pretty=format:"%h" "$commit_range" 2>/dev/null)
+
+    if [ -z "$commits" ]; then
+        ux_error "No commits found by '$author' in range $commit_range"
+        return 1
+    fi
+
+    ux_info "Cherry-picking commits by '$author' in range $commit_range:"
+    echo "$commits"
+    echo ""
+    echo "$commits" | xargs git cherry-pick
+}
+
+# ----------------------------------------------------------------------------
+# Help — standalone, mirrors gwt_help's section/list/full structure.
+# ----------------------------------------------------------------------------
+_gcp_help_summary() {
+    ux_info "Usage: gcp help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "scan    gcp scan [base] [src] [--author=<name|all>]   compare & cherry-pick missing commits"
+    ux_bullet_sub "theirs  gcp theirs <commit>...                         cherry-pick with -X theirs (incoming wins)"
+    ux_bullet_sub "ours    gcp ours <commit>...                           cherry-pick with -X ours (current wins)"
+    ux_bullet_sub "author  gcp author <range> [author]                    cherry-pick commits by author"
+    ux_bullet_sub "pick    gcp pick <commit>...                           bare cherry-pick (one or more)"
+    ux_bullet_sub "details gcp help <section>  (example: gcp help scan)"
+}
+
+_gcp_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "scan"
+    ux_bullet_sub "theirs"
+    ux_bullet_sub "ours"
+    ux_bullet_sub "author"
+    ux_bullet_sub "pick"
+}
+
+_gcp_help_rows_scan() {
+    ux_table_row "syntax" "gcp scan [base] [src] [--author=<name|all>]" "Compare & pick missing commits"
+    ux_table_row "default" "main <- upstream/main, author=dEitY719" "Filter by author by default"
+    ux_table_row "--author=all" "show all authors" "Bypass filter"
+    ux_table_row "behavior" "detects duplicates (same subject in base)" "Skips already-applied commits"
+    ux_table_row "behavior" "contiguous range -> bulk cherry-pick" "Non-contiguous -> individual"
+}
+
+_gcp_help_rows_theirs() {
+    ux_table_row "syntax" "gcp theirs <commit>..." "Cherry-pick with -X theirs"
+    ux_table_row "conflict" "incoming (cherry-picked) changes win" ""
+}
+
+_gcp_help_rows_ours() {
+    ux_table_row "syntax" "gcp ours <commit>..." "Cherry-pick with -X ours"
+    ux_table_row "conflict" "current branch changes win" ""
+}
+
+_gcp_help_rows_author() {
+    ux_table_row "syntax" "gcp author <range> [author]" "Cherry-pick commits by author"
+    ux_table_row "default author" "dEitY719" ""
+    ux_table_row "range format" "<start>..<end> or <start>^..<end>" ""
+}
+
+_gcp_help_rows_pick() {
+    ux_table_row "syntax" "gcp pick <commit>..." "Bare cherry-pick (one or more)"
+    ux_table_row "note" "replaces deprecated bare 'gcp <commit>'" "bare form bridges with deprecation warning"
+}
+
+_gcp_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gcp_help_section_rows() {
+    case "$1" in
+        scan)    _gcp_help_rows_scan ;;
+        theirs)  _gcp_help_rows_theirs ;;
+        ours)    _gcp_help_rows_ours ;;
+        author)  _gcp_help_rows_author ;;
+        pick)    _gcp_help_rows_pick ;;
+        *)
+            ux_error "Unknown gcp help section: $1"
+            ux_info "Try: gcp help --list"
+            return 1
+            ;;
+    esac
+}
+
+_gcp_help_full() {
+    ux_header "Git Cherry-Pick Commands"
+    _gcp_help_render_section "Scan"   _gcp_help_rows_scan
+    _gcp_help_render_section "Theirs" _gcp_help_rows_theirs
+    _gcp_help_render_section "Ours"   _gcp_help_rows_ours
+    _gcp_help_render_section "Author" _gcp_help_rows_author
+    _gcp_help_render_section "Pick"   _gcp_help_rows_pick
+}
+
+gcp_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _gcp_help_summary
+            ;;
+        --list|list|section|sections)
+            _gcp_help_list_sections
+            ;;
+        --all|all)
+            _gcp_help_full
+            ;;
+        *)
+            _gcp_help_section_rows "$1"
+            ;;
+    esac
+}
+
+# ----------------------------------------------------------------------------
+# gcp — dispatcher (Type 2A). _gcp_scan is defined in gcp_scan.sh; the loader
+# sources both files alphabetically (gcp.sh -> gcp_scan.sh) so the function
+# is in scope by the time a user types 'gcp scan'.
+# ----------------------------------------------------------------------------
+gcp() {
+    case "${1:-}" in
+        scan)    shift; _gcp_scan   "$@" ;;
+        theirs)  shift; _gcp_theirs "$@" ;;
+        ours)    shift; _gcp_ours   "$@" ;;
+        author)  shift; _gcp_author "$@" ;;
+        pick)    shift; _gcp_pick   "$@" ;;
+        -h|--help|help|"")
+            [ $# -gt 0 ] && shift
+            gcp_help "$@"
+            ;;
+        *)
+            if _gcp_committish_p "$1"; then
+                ux_warning "Deprecated: bare 'gcp <commit>' will be removed in a future release."
+                ux_info    "Use: gcp pick $*"
+                _gcp_pick "$@"
+            else
+                ux_error "Unknown command: $1"
+                ux_info  "Run: gcp help"
+                return 1
+            fi
+            ;;
+    esac
+}
+
+# Deprecated backward-compat aliases (Phase 1 — see issue #697 "Out of Scope")
+alias gcp_scan='gcp scan'
+alias gcp-scan='gcp scan'
+alias gcp_theirs='gcp theirs'
+alias gcp_ours='gcp ours'
+alias gcp_author='gcp author'
+alias gcp-help='gcp_help'

--- a/shell-common/functions/gcp.sh
+++ b/shell-common/functions/gcp.sh
@@ -31,6 +31,24 @@ _gcp_committish_p() {
 }
 
 # ----------------------------------------------------------------------------
+# Family-shared pre-flight: refuse to start a new cherry-pick while one is
+# already in progress, and tell the user how to recover. SSOT for the check
+# `_gcp_scan` introduced inline (gcp_scan.sh) — other verbs reuse the same
+# helper so the warning + recovery hint are identical across the family.
+# Returns 1 (and emits the recovery hint) when a cherry-pick is in progress;
+# 0 otherwise. PR #698 review feedback (gemini-code-assist).
+# ----------------------------------------------------------------------------
+_gcp_assert_no_cherry_pick() {
+    git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 || return 0
+    ux_error "Cherry-pick currently in progress!"
+    ux_info  "Resolve first with one of:"
+    ux_bullet "git cherry-pick --continue   # after fixing conflicts"
+    ux_bullet "git cherry-pick --skip       # to drop the current commit"
+    ux_bullet "git cherry-pick --abort      # to cancel"
+    return 1
+}
+
+# ----------------------------------------------------------------------------
 # Internal: cherry-pick with optional -X <strategy>. SSOT for theirs/ours so
 # the two wrappers stay one-liners (Type 2A §9 SRP).
 # Args: <strategy:""|theirs|ours> <commit>...
@@ -55,6 +73,8 @@ _gcp_strategy_pick() {
         return 1
     fi
 
+    _gcp_assert_no_cherry_pick || return 1
+
     local commit failed=0
     for commit in "$@"; do
         if [ -n "$strategy" ]; then
@@ -62,6 +82,7 @@ _gcp_strategy_pick() {
                 ux_success "Cherry-pick (-X $strategy) succeeded: $commit"
             else
                 ux_error "Cherry-pick (-X $strategy) failed: $commit"
+                ux_info  "Resolve with: git cherry-pick --continue | --skip | --abort"
                 failed=1
                 break
             fi
@@ -70,6 +91,7 @@ _gcp_strategy_pick() {
                 ux_success "Cherry-pick succeeded: $commit"
             else
                 ux_error "Cherry-pick failed: $commit"
+                ux_info  "Resolve with: git cherry-pick --continue | --skip | --abort"
                 failed=1
                 break
             fi
@@ -101,6 +123,8 @@ _gcp_author() {
         return 1
     fi
 
+    _gcp_assert_no_cherry_pick || return 1
+
     local commits
     commits=$(git log --author="$author" --no-merges --reverse --pretty=format:"%h" "$commit_range" 2>/dev/null)
 
@@ -112,7 +136,11 @@ _gcp_author() {
     ux_info "Cherry-picking commits by '$author' in range $commit_range:"
     echo "$commits"
     echo ""
-    echo "$commits" | xargs git cherry-pick
+    # Word-splitting on $commits is intentional — newline-separated SHAs
+    # become separate args to _gcp_pick, which then drives the per-commit
+    # success/failure UX + recovery hint loop (PR #698 review).
+    # shellcheck disable=SC2086
+    _gcp_pick $commits
 }
 
 # ----------------------------------------------------------------------------

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -2,11 +2,15 @@
 # shell-common/functions/gcp_scan.sh
 #
 # Portable cherry-pick scanner - works in bash, zsh, and other POSIX shells
-# Intelligently identifies and cherry-picks missing commits
+# Intelligently identifies and cherry-picks missing commits.
 #
-# Usage:
-#   gcp_scan [--author=<name|all>]         # defaults: main <- upstream/main, author=dEitY719
-#   gcp_scan develop origin --author=all   # custom branches + show all commits
+# Exposed via the gcp dispatcher (Type 2A — see gcp.sh and
+# docs/.ssot/command-design-pattern.md §4):
+#
+#   gcp scan [base] [src] [--author=<name|all>]
+#
+# The deprecated 'gcp_scan' / 'gcp-scan' forms remain available as aliases
+# (defined in gcp.sh) for backward compatibility — issue #697.
 #
 # Note: git cherry marks commits as:
 #   '+' = present in source, missing in base (will be cherry-picked)
@@ -25,7 +29,7 @@ _gcp_scan_is_empty_cherry_pick() {
     return 0
 }
 
-gcp_scan() {
+_gcp_scan() {
     # zsh compatibility: emulate POSIX sh to ensure consistent behavior
     if [ -n "${ZSH_VERSION-}" ]; then
         emulate -L sh
@@ -385,5 +389,5 @@ EOF
     fi
 }
 
-# Quick shorthand for gcp_scan
-alias gcp-scan='gcp_scan'
+# Note: 'gcp_scan' / 'gcp-scan' aliases live in gcp.sh and route through
+# the dispatcher (issue #697). Do not add them here.

--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -12,7 +12,7 @@ _git_help_summary() {
     ux_bullet_sub "upstream: gupa | gupdel | glum | glub"
     ux_bullet_sub "branch: gset-main | gset-dev | gset | gb -D local | gb -D remote"
     ux_bullet_sub "stash: git stash list | show -p | pop | apply | drop"
-    ux_bullet_sub "pick: gcp | gcp_theirs | gcp_ours | gcp_author | gcp_scan"
+    ux_bullet_sub "pick: gcp scan | gcp theirs | gcp ours | gcp author | gcp pick"
     ux_bullet_sub "special: gpf_dev_server | gpfu"
     ux_bullet_sub "lfs: git_lfs_install | glfs"
     ux_bullet_sub "ssh: git_ssh_check | git_ssh_setup"
@@ -88,11 +88,12 @@ _git_help_rows_stash() {
 }
 
 _git_help_rows_pick() {
-    ux_table_row "gcp" "gcp <commit>..." "Cherry-pick commits"
-    ux_table_row "gcp_theirs" "gcp_theirs <commit>..." "Cherry-pick with -X theirs (incoming)"
-    ux_table_row "gcp_ours" "gcp_ours <commit>..." "Cherry-pick with -X ours (current)"
-    ux_table_row "gcp_author" "gcp_author <range> [author]" "Cherry-pick by author"
-    ux_table_row "gcp_scan" "gcp_scan [base] [src] [--author=<name|all>]" "Compare & pick missing (default: main <- upstream/main, author=dEitY719)"
+    ux_table_row "gcp pick" "gcp pick <commit>..." "Cherry-pick commits"
+    ux_table_row "gcp theirs" "gcp theirs <commit>..." "Cherry-pick with -X theirs (incoming)"
+    ux_table_row "gcp ours" "gcp ours <commit>..." "Cherry-pick with -X ours (current)"
+    ux_table_row "gcp author" "gcp author <range> [author]" "Cherry-pick by author"
+    ux_table_row "gcp scan" "gcp scan [base] [src] [--author=<name|all>]" "Compare & pick missing (default: main <- upstream/main, author=dEitY719)"
+    ux_table_row "gcp -h" "gcp help [section]" "Show gcp sub-command help"
 }
 
 _git_help_rows_special() {
@@ -111,8 +112,8 @@ _git_help_rows_ssh() {
 }
 
 _git_help_notes_pick_strategy() {
-    ux_bullet "gcp_theirs: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_WARNING}incoming(cherry-pick되는 커밋의 변경)${UX_RESET} 선택"
-    ux_bullet "gcp_ours: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_SUCCESS}current branch(현재 브랜치의 변경)${UX_RESET} 선택"
+    ux_bullet "gcp theirs: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_WARNING}incoming(cherry-pick되는 커밋의 변경)${UX_RESET} 선택"
+    ux_bullet "gcp ours: ${UX_ERROR}Conflict${UX_RESET} 발생시 ${UX_SUCCESS}current branch(현재 브랜치의 변경)${UX_RESET} 선택"
 }
 
 _git_help_render_section() {

--- a/shell-common/tools/integrations/git.sh
+++ b/shell-common/tools/integrations/git.sh
@@ -172,79 +172,10 @@ gupdel() {
     fi
 }
 
-# Internal: cherry-pick with optional strategy (-X theirs / -X ours)
-_git_cherry_pick() {
-    local strategy="$1"
-    shift
-
-    if [ $# -eq 0 ]; then
-        local cmd_name="gcp"
-        local desc="Cherry-pick one or more commits"
-        local flag_info=""
-        if [ -n "$strategy" ]; then
-            cmd_name="gcp_${strategy}"
-            desc="Cherry-pick with '${strategy}' conflict strategy"
-            flag_info=" -X ${strategy}"
-        fi
-        ux_usage "$cmd_name" "<commit-id> [commit-id2] ..." "$desc"
-        ux_bullet "$cmd_name abc1234"
-        [ -n "$strategy" ] && ux_warning "Conflicts will use ${strategy} changes"
-        return 1
-    fi
-
-    local failed=0
-    for commit in "$@"; do
-        if [ -n "$strategy" ]; then
-            if git cherry-pick -X "$strategy" "$commit"; then
-                ux_success "Cherry-pick${flag_info:-} succeeded: $commit"
-            else
-                ux_error "Cherry-pick${flag_info:-} failed: $commit"
-                failed=1
-                break
-            fi
-        else
-            if git cherry-pick "$commit"; then
-                ux_success "Cherry-pick succeeded: $commit"
-            else
-                ux_error "Cherry-pick failed: $commit"
-                failed=1
-                break
-            fi
-        fi
-    done
-
-    return $failed
-}
-
-gcp() { _git_cherry_pick "" "$@"; }
-gcp_theirs() { _git_cherry_pick "theirs" "$@"; }
-gcp_ours() { _git_cherry_pick "ours" "$@"; }
-
-gcp_author() {
-    local commit_range="$1"
-    local author="${2:-dEitY719}"
-
-    if [ -z "$commit_range" ]; then
-        ux_usage "gcp_author" "<commit-range> [author-name]" "Cherry-pick commits by specific author"
-        ux_bullet "gcp_author 751e304..7ffcbd4"
-        ux_bullet "gcp_author 751e304..7ffcbd4 dEitY719"
-        ux_warning "Format: <start>..<end> or <start>^..<end>"
-        return 1
-    fi
-
-    local commits
-    commits=$(git log --author="$author" --no-merges --reverse --pretty=format:"%h" "$commit_range" 2>/dev/null)
-
-    if [ -z "$commits" ]; then
-        ux_error "No commits found by '$author' in range $commit_range"
-        return 1
-    fi
-
-    ux_info "Cherry-picking commits by '$author' in range $commit_range:"
-    echo "$commits"
-    echo ""
-    echo "$commits" | xargs git cherry-pick
-}
+# Cherry-pick family (gcp / gcp_theirs / gcp_ours / gcp_author) moved to
+# shell-common/functions/gcp.sh under the Type 2A dispatcher. See
+# docs/.ssot/command-design-pattern.md §4 and issue #697. Loading these here
+# would shadow the dispatcher (integrations/ is sourced after functions/).
 
 glub() {
     local branch="${1:-main}"

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gcp.bats
+# Tests for issue #697 — gcp_* family unified under the 'gcp <verb>' Type 2A
+# dispatcher (docs/.ssot/command-design-pattern.md §4).
+#
+# Behavior under test:
+#   - 'gcp' is a function (dispatcher), not the bash-only integrations version.
+#   - Private sub-functions _gcp_scan/_gcp_theirs/_gcp_ours/_gcp_author/_gcp_pick
+#     exist and are wired through the dispatcher.
+#   - Help is reachable as 'gcp', 'gcp -h', 'gcp --help', 'gcp help',
+#     'gcp help <section>', 'gcp help --list', 'gcp help --all'.
+#   - The deprecated forms 'gcp_scan', 'gcp-scan', 'gcp_theirs', 'gcp_ours',
+#     'gcp_author' still work as aliases routing through 'gcp <verb>'.
+#   - 'gcp <unknown-verb>' returns 1 with 'Run: gcp help' hint (Type 2A §6).
+#   - 'gcp <committish>' is bridged to 'gcp pick' with a deprecation warning.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Function / alias existence
+# ---------------------------------------------------------------------------
+
+@test "bash: gcp dispatcher function exists" {
+    run_in_bash 'declare -f gcp >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_scan private function exists" {
+    run_in_bash 'declare -f _gcp_scan >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_theirs private function exists" {
+    run_in_bash 'declare -f _gcp_theirs >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_ours private function exists" {
+    run_in_bash 'declare -f _gcp_ours >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_author private function exists" {
+    run_in_bash 'declare -f _gcp_author >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_pick private function exists" {
+    run_in_bash 'declare -f _gcp_pick >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: gcp_help standalone help exists" {
+    run_in_bash 'declare -f gcp_help >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: gcp_scan alias maps to 'gcp scan'" {
+    run_in_bash 'alias gcp_scan'
+    assert_success
+    assert_output --partial "gcp scan"
+}
+
+@test "bash: gcp-scan alias maps to 'gcp scan'" {
+    run_in_bash 'alias gcp-scan'
+    assert_success
+    assert_output --partial "gcp scan"
+}
+
+@test "bash: gcp_theirs alias maps to 'gcp theirs'" {
+    run_in_bash 'alias gcp_theirs'
+    assert_success
+    assert_output --partial "gcp theirs"
+}
+
+@test "bash: gcp_ours alias maps to 'gcp ours'" {
+    run_in_bash 'alias gcp_ours'
+    assert_success
+    assert_output --partial "gcp ours"
+}
+
+@test "bash: gcp_author alias maps to 'gcp author'" {
+    run_in_bash 'alias gcp_author'
+    assert_success
+    assert_output --partial "gcp author"
+}
+
+@test "bash: gcp-help alias maps to gcp_help" {
+    run_in_bash 'alias gcp-help'
+    assert_success
+    assert_output --partial "gcp_help"
+}
+
+# ---------------------------------------------------------------------------
+# Help entry points
+# ---------------------------------------------------------------------------
+
+@test "help: bare 'gcp' invocation shows help (no error)" {
+    run_in_bash 'gcp'
+    assert_success
+    assert_output --partial "Usage: gcp help"
+}
+
+@test "help: 'gcp -h' shows help" {
+    run_in_bash 'gcp -h'
+    assert_success
+    assert_output --partial "Usage: gcp help"
+}
+
+@test "help: 'gcp --help' shows help" {
+    run_in_bash 'gcp --help'
+    assert_success
+    assert_output --partial "Usage: gcp help"
+}
+
+@test "help: 'gcp help' shows help" {
+    run_in_bash 'gcp help'
+    assert_success
+    assert_output --partial "Usage: gcp help"
+}
+
+@test "help: 'gcp help scan' shows section detail" {
+    run_in_bash 'gcp help scan'
+    assert_success
+    assert_output --partial "scan"
+}
+
+@test "help: 'gcp help --list' lists sections" {
+    run_in_bash 'gcp help --list'
+    assert_success
+    assert_output --partial "scan"
+    assert_output --partial "theirs"
+    assert_output --partial "ours"
+    assert_output --partial "author"
+    assert_output --partial "pick"
+}
+
+@test "help: summary lists all 5 verbs" {
+    run_in_bash 'gcp help'
+    assert_output --partial "scan"
+    assert_output --partial "theirs"
+    assert_output --partial "ours"
+    assert_output --partial "author"
+    assert_output --partial "pick"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatcher behavior
+# ---------------------------------------------------------------------------
+
+@test "dispatch: unknown sub-command returns error + 'Run: gcp help' hint" {
+    run_in_bash 'gcp definitely-not-a-verb'
+    assert_failure
+    assert_output --partial "Unknown command"
+    assert_output --partial "Run: gcp help"
+}
+
+@test "dispatch: 'gcp pick' (no args) prints usage and returns 1" {
+    run_in_bash 'gcp pick'
+    assert_failure
+    assert_output --partial "gcp pick"
+}
+
+@test "dispatch: 'gcp theirs' (no args) prints usage and returns 1" {
+    run_in_bash 'gcp theirs'
+    assert_failure
+    assert_output --partial "gcp theirs"
+}
+
+@test "dispatch: 'gcp author' (no args) prints usage and returns 1" {
+    run_in_bash 'gcp author'
+    assert_failure
+    assert_output --partial "gcp author"
+}
+
+# ---------------------------------------------------------------------------
+# Bare-form deprecation bridge: 'gcp <committish>' -> '_gcp_pick' + warning
+# ---------------------------------------------------------------------------
+
+@test "dispatch: bare committish triggers deprecation bridge" {
+    # Stub `git cherry-pick` so the deprecation warning fires inside the
+    # dispatcher but the actual cherry-pick is a no-op — keeps the working
+    # tree clean across test runs (no leftover CHERRY_PICK_HEAD state).
+    # `git rev-parse` (used by _gcp_committish_p) must still pass through to
+    # the real git so the heuristic correctly classifies HEAD as commit-ish.
+    run_in_bash '
+        cd "$DOTFILES_ROOT"
+        git() {
+            if [ "$1" = "cherry-pick" ]; then
+                echo "stubbed: git cherry-pick $*" >&2
+                return 1
+            fi
+            command git "$@"
+        }
+        gcp "$(command git rev-parse HEAD)"
+    '
+    assert_output --partial "Deprecated: bare 'gcp <commit>'"
+    assert_output --partial "Use: gcp pick"
+}
+
+@test "dispatch: non-committish unknown arg does NOT bridge to pick" {
+    run_in_bash 'cd "$DOTFILES_ROOT" && gcp not-a-real-commit-or-verb'
+    assert_failure
+    assert_output --partial "Unknown command"
+    refute_output --partial "Deprecated:"
+}
+
+# ---------------------------------------------------------------------------
+# Loader sanity: tools/integrations/git.sh no longer defines gcp
+# (would shadow the dispatcher since integrations/ loads after functions/)
+# ---------------------------------------------------------------------------
+
+@test "loader: 'gcp' resolves to the dispatcher in shell-common/functions/gcp.sh" {
+    run_in_bash 'declare -f gcp | head -1'
+    assert_success
+    assert_output --partial "gcp"
+}
+
+@test "loader: tools/integrations/git.sh no longer declares the gcp family" {
+    run grep -E '^(gcp|gcp_theirs|gcp_ours|gcp_author|_git_cherry_pick) *\(\)' \
+        "${DOTFILES_ROOT}/shell-common/tools/integrations/git.sh"
+    assert_failure
+}

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -213,6 +213,84 @@ teardown() {
     assert_output --partial "Use: gcp pick"
 }
 
+@test "preflight: _gcp_assert_no_cherry_pick aborts when CHERRY_PICK_HEAD exists (PR #698)" {
+    # Stub git so rev-parse --verify CHERRY_PICK_HEAD returns 0 (i.e. a
+    # cherry-pick is in progress). The helper must emit the recovery hint
+    # AND return 1 — used by _gcp_strategy_pick / _gcp_author / _gcp_pick.
+    run_in_bash '
+        cd "$DOTFILES_ROOT"
+        git() {
+            case " $* " in
+                *" CHERRY_PICK_HEAD "*) return 0 ;;
+            esac
+            command git "$@"
+        }
+        _gcp_assert_no_cherry_pick
+        echo "rc=$?"
+    '
+    assert_output --partial "Cherry-pick currently in progress"
+    assert_output --partial "git cherry-pick --continue"
+    assert_output --partial "git cherry-pick --abort"
+    assert_output --partial "rc=1"
+}
+
+@test "preflight: _gcp_strategy_pick refuses to start when cherry-pick in progress (PR #698)" {
+    run_in_bash '
+        cd "$DOTFILES_ROOT"
+        git() {
+            case " $* " in
+                *" CHERRY_PICK_HEAD "*) return 0 ;;
+            esac
+            command git "$@"
+        }
+        _gcp_strategy_pick "" abc1234
+        echo "rc=$?"
+    '
+    assert_output --partial "Cherry-pick currently in progress"
+    assert_output --partial "rc=1"
+}
+
+@test "preflight: _gcp_author refuses to start when cherry-pick in progress (PR #698)" {
+    run_in_bash '
+        cd "$DOTFILES_ROOT"
+        git() {
+            case " $* " in
+                *" CHERRY_PICK_HEAD "*) return 0 ;;
+            esac
+            command git "$@"
+        }
+        _gcp_author "abc..def" someone
+        echo "rc=$?"
+    '
+    assert_output --partial "Cherry-pick currently in progress"
+    assert_output --partial "rc=1"
+}
+
+@test "preflight: _gcp_strategy_pick emits recovery hint on conflict (PR #698)" {
+    # Stub git so cherry-pick returns 1 (conflict). rev-parse must still
+    # pass through (the helper uses it for the pre-flight check, which
+    # should NOT trip for the stubbed CHERRY_PICK_HEAD case).
+    run_in_bash '
+        cd "$DOTFILES_ROOT"
+        git() {
+            case "$1" in
+                cherry-pick) return 1 ;;
+                rev-parse)
+                    case " $* " in
+                        *" CHERRY_PICK_HEAD "*) return 1 ;;
+                    esac
+                    command git "$@" ;;
+                *) command git "$@" ;;
+            esac
+        }
+        _gcp_pick abc1234
+        echo "rc=$?"
+    '
+    assert_output --partial "Cherry-pick failed"
+    assert_output --partial "Resolve with: git cherry-pick --continue"
+    assert_output --partial "rc=1"
+}
+
 @test "dispatch: non-committish unknown arg does NOT bridge to pick" {
     run_in_bash 'cd "$DOTFILES_ROOT" && gcp not-a-real-commit-or-verb'
     assert_failure


### PR DESCRIPTION
## Summary
- `gcp_scan / gcp_theirs / gcp_ours / gcp_author` 와 bare `gcp <commit>` 가 underscore + bare 혼재 형태로 노출돼 명명 일관성이 없고 학습해야 할 entry-point 가 5개나 됨.
- `gcp_theirs / gcp_ours / gcp_author` 는 `shell-common/tools/integrations/git.sh` 의 `[ -n "$BASH" ] || return 0` 가드로 인해 **bash-only** — zsh 사용자는 `gcp_scan` 외에는 family 자체를 쓸 수 없는 비대칭 상태.
- `docs/.ssot/command-design-pattern.md` §4 Type 2A (`gwt` 참조 구현) 패턴으로 `gcp` 를 dispatcher 로 승격하고 family 전체를 통합 — bash + zsh 양쪽에서 5개 verb 모두 동작. 6개 deprecated alias 로 backward-compat 유지.

## Changes
- **`shell-common/functions/gcp.sh` (신규, 252 lines)** — Type 2A dispatcher + 5개 verb (`scan / theirs / ours / author / pick`) + standalone `gcp_help` (gwt_help 미러 — summary / `--list` / `--all` / `<section>`). 모두 POSIX sh 호환.
  - `_gcp_strategy_pick` 으로 theirs/ours SSOT 공유 (SRP §9).
  - `_gcp_committish_p` 휴리스틱은 `git rev-parse --verify "$1^{commit}"` 으로 실증 — regex hex 매칭은 `HEAD~3`, `branch^` 같은 ref 표현을 놓치므로 채택하지 않음.
  - bare `gcp <committish>` → `_gcp_pick` 위임 + `ux_warning` 으로 deprecation 안내. `gcp <unknown-verb>` 는 Type 2A §6 대로 `ux_error + return 1`.
  - 6개 deprecated alias (`gcp_scan / gcp-scan / gcp_theirs / gcp_ours / gcp_author / gcp-help`) 로 backward-compat 유지.
- **`shell-common/functions/gcp_scan.sh`** — `gcp_scan()` → `_gcp_scan()` rename (dispatcher 가 호출하는 private 형태). `alias gcp-scan='gcp_scan'` 제거 — 동일 alias 가 gcp.sh 에서 dispatcher 경유로 재정의됨. 헤더 주석을 새 진입점 (`gcp scan`) 기준으로 갱신.
- **`shell-common/tools/integrations/git.sh`** — `_git_cherry_pick / gcp / gcp_theirs / gcp_ours / gcp_author` 73줄 블록 제거. 로더 순서상 integrations/ 가 functions/ 보다 뒤에 source 되므로, 남겨두면 dispatcher 를 shadow 하는 회귀가 발생. SSOT 는 이제 gcp.sh.
- **`shell-common/functions/git_help.sh`** — `_git_help_summary` pick 한 줄, `_git_help_rows_pick` 표, `_git_help_notes_pick_strategy` 모두 verb 형식 (`gcp scan | gcp theirs | gcp ours | gcp author | gcp pick`) 으로 갱신. `gcp -h` 안내 행 추가.
- **`tests/bats/functions/gcp.bats` (신규, 28 tests)** — dispatcher / private function / 6개 alias / 5종 help 진입점 (`gcp / -h / --help / help / help <section> / help --list`) / unknown-verb error / bare-committish bridge / loader sanity 회귀 방지.
  - bridge 테스트는 `git cherry-pick` 을 함수 stub 으로 차단해 실제 repo 의 `CHERRY_PICK_HEAD` 상태를 오염시키지 않음 (rev-parse 는 그대로 통과시켜 휴리스틱은 검증).

## SOLID 근거 (`command-design-pattern.md` §9)
| 원칙 | 적용 |
|------|------|
| SRP | dispatcher 는 dispatch only / `_gcp_*` 는 구현 only / `gcp_help` 는 help only |
| OCP | verb 추가 = case 항목 + `_gcp_help_rows_<verb>` 만, 기존 코드 무변경 |
| LSP | deprecated alias 로 기존 호출자 100% 호환 |
| ISP | 5개 `_gcp_*` 함수 간 상호 의존 없음 (`_gcp_strategy_pick` 만 theirs/ours 의 SSOT 공유 layer) |
| DIP | `ux_*` 추상화만 사용 |
| SSOT | default author/base/source 가 각 `_gcp_*` 함수 내 단일 정의 |

## Test plan
- [x] `tests/bats/functions/gcp.bats` — 28/28 passes (dispatcher / private functions / aliases / help entry points / unknown-verb error / committish bridge with stubbed cherry-pick / loader sanity).
- [x] `tests/bats/functions/git.bats` + `git_worktree_help.bats` — 39/39 passes (no regression).
- [x] `tox -e ruff,shellcheck,shfmt` — green.
- [x] bash + zsh 양쪽에서 `gcp help`, `gcp scan`, `gcp_scan` (deprecated alias), `gwt help`, `git_help pick` smoke 확인.
- [ ] (post-merge) 실제 cherry-pick 워크플로에서 `gcp scan` / `gcp pick <sha>` / deprecated `gcp <sha>` 사용 검증.

## Related
Closes #697

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
