### PR TITLE
feat(git-hooks): #708 upstream-push leak guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `
 
 `git/` manages a 2-tier hook system. Config SSOT is `git/config/hook-config.sh`. Debug with `GIT_HOOKS_DEBUG=1 git commit -m "msg"`. Test with `bash git/tests/test_hooks.sh`.
 
+`git/hooks/pre-push` runs a protected-branch check plus an upstream leak guard (SSOT: `git/config/pre-push-rules.sh`). The leak guard is inert until you export `UPSTREAM_REMOTES_ERE` and `LEAK_PATTERNS_ERE`; see `git/AGENTS.md` for the activation snippet and escape hatches.
+
 ### Claude Code Integration
 
 `claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` and `claude/docs/` directories are also symlinked (directory-level) into each account's `~/.claude*/skills` and `~/.claude*/docs` — the same scheme in every setup mode (#575).

--- a/git/AGENTS.md
+++ b/git/AGENTS.md
@@ -22,11 +22,34 @@
 - Prefer `bash git/tests/test_hooks.sh` for integration-level verification of the 2-tier hook system.
 - If a change targets repository-wide policy (naming, shebang, UX rules), also run `tox -e shellcheck`.
 
+# Upstream Push Leak Guard
+
+`hooks/pre-push` runs a second layer after the protected-branch check: when
+the push target URL matches `UPSTREAM_REMOTES_ERE`, it scans the push range
+(commit messages + added/modified file contents) against `LEAK_PATTERNS_ERE`
+and blocks the push on any match.
+
+Both variables default to the empty string, so the mechanism is inert until
+the user opts in. Activate by exporting in your shell rc or a gitignored
+local file:
+
+```sh
+export UPSTREAM_REMOTES_ERE='github\.com[:/]<owner>/<repo>(\.git)?$'
+export LEAK_PATTERNS_ERE='<your-private-host>\.example\.com|/your-private-overlay/'
+```
+
+Escape hatches: `SKIP_PRE_PUSH=1` (whole hook), `SKIP_LEAK_GUARD=1` (this
+layer only — protected-branch check still runs). SSOT lives in
+`config/pre-push-rules.sh`; regression tests in `test/test-pre-push.sh`
+(T-1..T-7).
+
 # Context Map
 
 - **[Hook Setup Script](./setup.sh)** — Symlinks and hook installation logic (called by root `./setup.sh`)
 - **[Global Hook](./global-hooks/pre-commit)** — User-level hook wrapper (`core.hooksPath`)
 - **[Project Hook](./hooks/pre-commit)** — Project-level runner that delegates to checks
+- **[Pre-push Hook](./hooks/pre-push)** — Protected-branch + upstream leak-guard layers
 - **[Hook Checks](./hooks/checks)** — Modular checks executed by the project hook
 - **[Hook Configuration](./config/hook-config.sh)** — Regex patterns, thresholds, and shared constants
+- **[Pre-push Rules](./config/pre-push-rules.sh)** — Protected branches + leak-guard SSOT
 - **[Git Docs](./doc/README.md)** — Hook workflow and SSH setup guides

--- a/git/config/pre-push-rules.sh
+++ b/git/config/pre-push-rules.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-# Pre-push validation rules
+# Pre-push validation rules (SSOT)
 # Used by: git/hooks/pre-push
-# Purpose: Prevent accidental pushes to protected branches
+# Purpose:
+#   1. Prevent accidental pushes to protected branches.
+#   2. Prevent leaks of user-supplied "internal" patterns when pushing to a
+#      remote identified as upstream (e.g. a public OSS mirror).
+#
+# shellcheck disable=SC2034
+# (Variables in this file are consumed by the pre-push hook that sources it.)
 
 # ============================================
 # PROTECTED BRANCHES (cannot push directly)
@@ -29,4 +35,37 @@ MSG_HINT_FIX="
    3. Push to feature branch: git push origin feature/your-feature
    4. Create a pull request on GitHub/GitLab
    5. Merge via pull request (not direct push)
+"
+
+# ============================================
+# UPSTREAM PUSH LEAK GUARD (F-1, F-2, F-4, F-7)
+# ============================================
+# The leak guard runs only when the push target's remote URL matches
+# UPSTREAM_REMOTES_ERE. This lets the same dotfiles checkout live in
+# multiple remotes — push to your private mirror flows unimpeded, push to
+# the public upstream is scanned for user-supplied "internal" patterns.
+#
+# Both variables default to the empty string. Empty means the mechanism is
+# present but inert — no upstream is identified and no pattern is enforced
+# until the user opts in by exporting these. This keeps the OSS default
+# value-free; the *values* live in the user's environment, not in the repo.
+#
+# Example (e.g. in ~/.zshrc, ~/.bashrc, or a gitignored local rc):
+#
+#   export UPSTREAM_REMOTES_ERE='github\.com[:/]<owner>/<repo>(\.git)?$'
+#   export LEAK_PATTERNS_ERE='<your-private-host>\.example\.com|/your-private-overlay/'
+#
+UPSTREAM_REMOTES_ERE="${UPSTREAM_REMOTES_ERE-}"
+LEAK_PATTERNS_ERE="${LEAK_PATTERNS_ERE-}"
+
+# ============================================
+# ERROR MESSAGES — leak guard layer
+# ============================================
+MSG_LEAK_BLOCKED="Upstream push blocked: internal-pattern match detected"
+MSG_LEAK_HINT="
+To fix this:
+   1. Inspect: git log <range> -p | grep -nE \"\${LEAK_PATTERNS_ERE}\"
+   2. Squash / amend / drop the offending commit, then re-push.
+   3. (Emergency) SKIP_LEAK_GUARD=1 git push <remote> <branch>
+      Use only when you have manually verified the diff is safe.
 "

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -1,9 +1,20 @@
 #!/bin/bash
-# Git pre-push hook: Prevent direct pushes to protected branches
-# Installed: git config core.hooksPath git/hooks
-# Enforces: PR-based workflow (no direct pushes to main/release)
+# Git pre-push hook
 #
-# Skip this hook: SKIP_PRE_PUSH=1 git push origin main
+# Two layers, evaluated per ref:
+#   1. Protected-branch block (PROTECTED_BRANCHES from pre-push-rules.sh).
+#   2. Upstream leak guard — when the push target's URL matches
+#      UPSTREAM_REMOTES_ERE, scan commit messages + added/modified file
+#      contents in the push range against LEAK_PATTERNS_ERE.
+#
+# Skip flags (each is one off-switch — usable independently):
+#   SKIP_PRE_PUSH=1     bypass the entire hook (both layers)
+#   SKIP_LEAK_GUARD=1   bypass only layer #2 (PROTECTED_BRANCHES still runs)
+#
+# Hook protocol (git push pre-push):
+#   $1 = remote name (e.g. "origin")
+#   $2 = remote URL  (e.g. "https://github.com/owner/repo.git")
+#   stdin lines: "<local_ref> <local_sha> <remote_ref> <remote_sha>"
 
 set -o errexit
 set -o pipefail
@@ -13,37 +24,157 @@ if [ "${SKIP_PRE_PUSH:-0}" = "1" ]; then
     exit 0
 fi
 
+# git push hook protocol — capture remote identity for leak guard
+REMOTE_NAME="${1:-}"
+REMOTE_URL="${2:-}"
+
 # Get hook directory and import rules
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=/dev/null
 source "${HOOK_DIR}/../config/pre-push-rules.sh" || exit 0
 
+ZERO_SHA="0000000000000000000000000000000000000000"
+
 # ============================================
-# MAIN HOOK LOGIC
+# Leak guard activation decision (F-1)
+# ============================================
+# Active only when ALL of these are true:
+#   - SKIP_LEAK_GUARD is not set to 1.
+#   - UPSTREAM_REMOTES_ERE is non-empty (someone has declared an upstream).
+#   - LEAK_PATTERNS_ERE is non-empty   (someone has declared what is sensitive).
+#   - The push target URL matches UPSTREAM_REMOTES_ERE.
+# If any is false, the guard is inert — no scanning, no overhead. This is
+# the "Error Cases" behaviour spelt out in the issue: empty pattern or no
+# matching URL silently disables the guard.
+LEAK_GUARD_ACTIVE=0
+if [ "${SKIP_LEAK_GUARD:-0}" != "1" ] \
+    && [ -n "${UPSTREAM_REMOTES_ERE}" ] \
+    && [ -n "${LEAK_PATTERNS_ERE}" ] \
+    && [ -n "${REMOTE_URL}" ]; then
+    if printf '%s' "${REMOTE_URL}" | grep -qE "${UPSTREAM_REMOTES_ERE}"; then
+        LEAK_GUARD_ACTIVE=1
+    fi
+fi
+
+# ============================================
+# Helpers
 # ============================================
 
-# Pre-push receives refs from stdin
-# Format: <local ref> <local sha> <remote ref> <remote sha>
-# Example: refs/heads/main abc123... refs/heads/main def456...
+# Resolve the commit range to scan for a single ref entry.
+# When pushing a fresh branch (remote_sha = ZERO_SHA) we fall back to the
+# merge-base against <remote>/main (then master). This is Open Question Q3
+# resolved as (b): bounded, fast, and accurate against what is actually
+# new on this side of the upstream.
+_resolve_scan_range() {
+    local local_sha="$1"
+    local remote_sha="$2"
+    local base branch
+
+    if [ "${remote_sha}" != "${ZERO_SHA}" ]; then
+        printf '%s' "${remote_sha}..${local_sha}"
+        return 0
+    fi
+
+    for branch in main master; do
+        if base=$(git merge-base "${REMOTE_NAME}/${branch}" "${local_sha}" 2>/dev/null); then
+            if [ -n "${base}" ]; then
+                printf '%s' "${base}..${local_sha}"
+                return 0
+            fi
+        fi
+    done
+
+    # No tracking branch available — scan just the tip commit so we still
+    # catch obvious leaks instead of walking the full history.
+    # `<sha>^!` is git shorthand for "just this commit, exclude parents".
+    printf '%s' "${local_sha}^!"
+}
+
+# Scan a commit range for leak patterns. Returns 0 if clean, 1 if a match
+# was reported. Failures of git plumbing are treated fail-open (with stderr
+# warning) so a guard bug never blocks a legitimate push.
+_leak_scan_range() {
+    local range="$1"
+    local commits commit_count violated=0
+    local commit_hash msg_match file files file_match
+
+    commit_count=$(git log --pretty=oneline "${range}" 2>/dev/null | wc -l | tr -d ' \n')
+    if [ "${commit_count:-0}" -gt 100 ] 2>/dev/null; then
+        # NF-1 Q4 (a): proceed but warn — KISS over hard cutoff.
+        echo "[leak-guard] WARN: scanning ${commit_count} commits — hook may exceed 200ms budget" >&2
+    fi
+
+    if ! commits=$(git log --format='%H' "${range}" 2>/dev/null); then
+        echo "[leak-guard] WARN: git log failed for range '${range}' — skipping scan (fail-open)" >&2
+        return 0
+    fi
+
+    while IFS= read -r commit_hash; do
+        [ -z "${commit_hash}" ] && continue
+
+        # Commit message scan
+        msg_match=$(git log -1 --format='%B' "${commit_hash}" 2>/dev/null \
+            | grep -nE "${LEAK_PATTERNS_ERE}" || true)
+        if [ -n "${msg_match}" ]; then
+            echo "${MSG_LEAK_BLOCKED}"
+            echo "  commit: ${commit_hash}"
+            echo "  source: <commit message>"
+            printf '%s\n' "${msg_match}" | while IFS= read -r line; do
+                echo "    ${line}"
+            done
+            violated=1
+        fi
+
+        # Added/Modified/Copied/Renamed files — scan content at this commit.
+        if ! files=$(git diff-tree --no-commit-id --name-only --diff-filter=ACMRT -r "${commit_hash}" 2>/dev/null); then
+            files=""
+        fi
+        while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+            file_match=$(git show "${commit_hash}:${file}" 2>/dev/null \
+                | grep -nE --binary-files=without-match "${LEAK_PATTERNS_ERE}" \
+                || true)
+            if [ -n "${file_match}" ]; then
+                echo "${MSG_LEAK_BLOCKED}"
+                echo "  commit: ${commit_hash}"
+                echo "  source: ${file}"
+                printf '%s\n' "${file_match}" | while IFS= read -r line; do
+                    echo "    ${line}"
+                done
+                violated=1
+            fi
+        done <<<"${files}"
+    done <<<"${commits}"
+
+    if [ ${violated} -eq 1 ]; then
+        echo "${MSG_LEAK_HINT}"
+        return 1
+    fi
+    return 0
+}
+
+# ============================================
+# Main loop — per-ref evaluation
+# ============================================
+
+exit_code=0
 
 while read -r local_ref local_sha remote_ref remote_sha; do
-    # Extract branch name from local_ref (refs/heads/main → main)
+    # Extract branch name from local_ref (refs/heads/main -> main)
     local_branch="${local_ref#refs/heads/}"
 
-    # Check if branch is protected
+    # ----- Layer 1: PROTECTED_BRANCHES (unchanged) -----
     is_protected=0
     for protected in "${PROTECTED_BRANCHES[@]}"; do
         # Handle wildcard patterns (e.g., release/*)
         if [[ "$protected" == *"*" ]]; then
-            # Convert glob to regex: release/* → release/.*
             pattern="${protected//\*/.*}"
             if [[ "$local_branch" =~ ^${pattern}$ ]]; then
                 is_protected=1
                 break
             fi
         else
-            # Exact match
             if [ "$local_branch" = "$protected" ]; then
                 is_protected=1
                 break
@@ -51,7 +182,6 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi
     done
 
-    # If protected, reject the push
     if [ $is_protected -eq 1 ]; then
         echo ""
         echo "🚫 $MSG_PROTECTED_BRANCH: '$local_branch'"
@@ -60,6 +190,23 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         echo "$MSG_HINT_FIX"
         exit 1
     fi
+
+    # ----- Layer 2: upstream leak guard (new) -----
+    if [ ${LEAK_GUARD_ACTIVE} -eq 1 ]; then
+        # Branch delete: nothing on the local side to scan.
+        if [ "${local_sha}" = "${ZERO_SHA}" ]; then
+            continue
+        fi
+        # No-op push: already-pushed sha, no new commits to scan.
+        if [ "${local_sha}" = "${remote_sha}" ]; then
+            continue
+        fi
+
+        range=$(_resolve_scan_range "${local_sha}" "${remote_sha}")
+        if ! _leak_scan_range "${range}"; then
+            exit_code=1
+        fi
+    fi
 done
 
-exit 0
+exit ${exit_code}

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -99,15 +99,16 @@ _leak_scan_range() {
     local commits commit_count violated=0
     local commit_hash msg_match file files file_match
 
-    commit_count=$(git log --pretty=oneline "${range}" 2>/dev/null | wc -l | tr -d ' \n')
-    if [ "${commit_count:-0}" -gt 100 ] 2>/dev/null; then
-        # NF-1 Q4 (a): proceed but warn — KISS over hard cutoff.
-        echo "[leak-guard] WARN: scanning ${commit_count} commits — hook may exceed 200ms budget" >&2
-    fi
-
+    # Single `git log` call — fetch the SHA list and derive the count from it
+    # (review #710 nit: avoid the second `git log | wc -l` fork).
     if ! commits=$(git log --format='%H' "${range}" 2>/dev/null); then
         echo "[leak-guard] WARN: git log failed for range '${range}' — skipping scan (fail-open)" >&2
         return 0
+    fi
+    commit_count=$(printf '%s' "${commits}" | grep -c '^' || true)
+    if [ "${commit_count:-0}" -gt 100 ] 2>/dev/null; then
+        # NF-1 Q4 (a): proceed but warn — KISS over hard cutoff.
+        echo "[leak-guard] WARN: scanning ${commit_count} commits — hook may exceed 200ms budget" >&2
     fi
 
     while IFS= read -r commit_hash; do
@@ -132,9 +133,12 @@ _leak_scan_range() {
         fi
         while IFS= read -r file; do
             [ -z "${file}" ] && continue
-            file_match=$(git show "${commit_hash}:${file}" 2>/dev/null \
-                | grep -nE --binary-files=without-match "${LEAK_PATTERNS_ERE}" \
-                || true)
+            # `git grep -h -I` performs the search in-process and strips both
+            # the tree prefix and the path prefix from the output, leaving
+            # the same `<line>:<content>` shape grep -n produced. `-I` skips
+            # binary blobs (replaces the prior `--binary-files=without-match`).
+            file_match=$(git grep -h -nE -I "${LEAK_PATTERNS_ERE}" \
+                "${commit_hash}" -- "${file}" 2>/dev/null || true)
             if [ -n "${file_match}" ]; then
                 echo "${MSG_LEAK_BLOCKED}"
                 echo "  commit: ${commit_hash}"

--- a/git/test/test-pre-push.sh
+++ b/git/test/test-pre-push.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
 # Test suite for pre-push hook
-# Tests protected branch detection logic
+#
+# Covers two layers:
+#   1. Protected-branch detection (pure logic — sources pre-push-rules.sh).
+#   2. Upstream leak guard (T-1 .. T-7 from issue #708) — invokes the real
+#      hook against a throwaway git repo with synthetic stdin / argv.
+#
+# Fixtures use generic placeholder strings (example.internal, /home/.*/
+# private-overlay/) — no real internal identifiers ever appear in this file.
 
 set -o errexit
 set -o pipefail
 
-# Import rules
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/config/pre-push-rules.sh"
 
+HOOK="${SCRIPT_DIR}/hooks/pre-push"
+ZERO_SHA="0000000000000000000000000000000000000000"
+
 # ============================================
-# TEST CASES
+# LAYER 1 — PROTECTED_BRANCHES (pure logic)
 # ============================================
 
 run_test() {
@@ -49,6 +60,208 @@ run_test() {
 }
 
 # ============================================
+# LAYER 2 — LEAK GUARD (T-1 .. T-7)
+# ============================================
+
+# Fixture: tiny git repo with one commit. Caller mutates from there.
+_setup_repo() {
+    local dir
+    dir=$(mktemp -d -t leak-guard-test.XXXXXX)
+    git -C "$dir" init -q
+    git -C "$dir" config user.email "leak-test@example.com"
+    git -C "$dir" config user.name "leak-test"
+    git -C "$dir" config commit.gpgsign false
+    echo "seed" >"$dir/seed.txt"
+    git -C "$dir" add seed.txt
+    git -C "$dir" -c core.hooksPath=/dev/null commit -q -m "seed"
+    printf '%s' "$dir"
+}
+
+# Invoke the real hook against the given repo. Returns the hook's exit
+# code and captures stdout+stderr in $LEAK_OUT.
+_invoke_hook() {
+    local dir="$1" remote_name="$2" remote_url="$3"
+    local local_sha remote_sha rc out
+    local_sha=$(git -C "$dir" rev-parse HEAD)
+    remote_sha="${4:-$ZERO_SHA}"
+
+    set +e
+    out=$(cd "$dir" \
+        && printf 'refs/heads/test %s refs/heads/test %s\n' "$local_sha" "$remote_sha" \
+        | "$HOOK" "$remote_name" "$remote_url" 2>&1)
+    rc=$?
+    set -e
+    LEAK_OUT="$out"
+    return "$rc"
+}
+
+_assert_eq() {
+    local name="$1" want="$2" got="$3"
+    if [ "$want" = "$got" ]; then
+        echo "✓ $name"
+        return 0
+    fi
+    echo "✗ $name"
+    echo "    want: $want"
+    echo "    got:  $got"
+    [ -n "${LEAK_OUT:-}" ] && echo "    out:  ${LEAK_OUT}"
+    return 1
+}
+
+# Common env for leak-guard tests — generic placeholder values only.
+# UPSTREAM_REMOTES_ERE picks any github.com URL; LEAK_PATTERNS_ERE picks
+# two placeholder patterns that should never appear in real OSS code.
+_LEAK_UPSTREAM_ERE='github\.com[:/].+/.+(\.git)?$'
+_LEAK_PATTERNS_ERE='example\.internal|/private-overlay/'
+
+_t1_origin_push_with_pattern_passes() {
+    local dir
+    dir=$(_setup_repo)
+    echo "leak: example.internal endpoint" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq -m "add leak content"
+
+    set +e
+    UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        _invoke_hook "$dir" origin "ssh://git@private-mirror.example/foo/bar.git"
+    local rc=$?
+    set -e
+    rm -rf "$dir"
+    _assert_eq "T-1 origin push with pattern -> exit 0 (guard inactive)" 0 "$rc"
+}
+
+_t2_upstream_push_no_pattern_passes() {
+    local dir
+    dir=$(_setup_repo)
+    echo "plain content, nothing sensitive" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq -m "clean change"
+
+    set +e
+    UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        _invoke_hook "$dir" upstream "https://github.com/owner/repo.git"
+    local rc=$?
+    set -e
+    rm -rf "$dir"
+    _assert_eq "T-2 upstream push no pattern -> exit 0" 0 "$rc"
+}
+
+_t3_upstream_push_pattern_in_commit_message_blocks() {
+    local dir
+    dir=$(_setup_repo)
+    echo "harmless line" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq \
+        -m "wip: probe example.internal endpoint"
+
+    set +e
+    UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        _invoke_hook "$dir" upstream "https://github.com/owner/repo.git"
+    local rc=$?
+    set -e
+
+    local rc_ok=0
+    if [ "$rc" -eq 1 ] \
+        && printf '%s' "$LEAK_OUT" | grep -q "Upstream push blocked" \
+        && printf '%s' "$LEAK_OUT" | grep -q "<commit message>" \
+        && printf '%s' "$LEAK_OUT" | grep -q "example.internal"; then
+        rc_ok=1
+    fi
+    rm -rf "$dir"
+    _assert_eq "T-3 pattern in commit message -> exit 1 + diagnostic" 1 "$rc_ok"
+}
+
+_t4_upstream_push_pattern_in_diff_blocks() {
+    local dir
+    dir=$(_setup_repo)
+    echo "OVERLAY_PATH=/home/user/private-overlay/skills" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq -m "ordinary subject"
+
+    set +e
+    UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        _invoke_hook "$dir" upstream "https://github.com/owner/repo.git"
+    local rc=$?
+    set -e
+
+    local rc_ok=0
+    if [ "$rc" -eq 1 ] \
+        && printf '%s' "$LEAK_OUT" | grep -q "Upstream push blocked" \
+        && printf '%s' "$LEAK_OUT" | grep -q "seed.txt" \
+        && printf '%s' "$LEAK_OUT" | grep -q "/private-overlay/"; then
+        rc_ok=1
+    fi
+    rm -rf "$dir"
+    _assert_eq "T-4 pattern in file diff -> exit 1 + diagnostic" 1 "$rc_ok"
+}
+
+_t5_skip_leak_guard_escape_hatch() {
+    local dir
+    dir=$(_setup_repo)
+    echo "leak: example.internal" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq -m "would normally block"
+
+    set +e
+    SKIP_LEAK_GUARD=1 \
+        UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        _invoke_hook "$dir" upstream "https://github.com/owner/repo.git"
+    local rc=$?
+    set -e
+    rm -rf "$dir"
+    _assert_eq "T-5 SKIP_LEAK_GUARD=1 -> exit 0" 0 "$rc"
+}
+
+_t6_skip_pre_push_escape_hatch() {
+    local dir
+    dir=$(_setup_repo)
+    echo "leak: example.internal" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq -m "would normally block"
+
+    set +e
+    SKIP_PRE_PUSH=1 \
+        UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        _invoke_hook "$dir" upstream "https://github.com/owner/repo.git"
+    local rc=$?
+    set -e
+    rm -rf "$dir"
+    _assert_eq "T-6 SKIP_PRE_PUSH=1 -> exit 0 (whole hook skipped)" 0 "$rc"
+}
+
+_t7_protected_branch_takes_priority() {
+    # Protected-branch check runs before the leak guard within the same ref
+    # iteration. Pushing `main` with a leak should be blocked by layer 1
+    # (exit 1) with the protected-branch message, not the leak message.
+    local dir
+    dir=$(_setup_repo)
+    git -C "$dir" branch -m main 2>/dev/null || git -C "$dir" checkout -qb main
+    echo "leak: example.internal" >>"$dir/seed.txt"
+    git -C "$dir" -c core.hooksPath=/dev/null commit -aq -m "main with leak"
+
+    local local_sha rc out
+    local_sha=$(git -C "$dir" rev-parse HEAD)
+
+    set +e
+    out=$(cd "$dir" \
+        && UPSTREAM_REMOTES_ERE="$_LEAK_UPSTREAM_ERE" \
+        LEAK_PATTERNS_ERE="$_LEAK_PATTERNS_ERE" \
+        printf 'refs/heads/main %s refs/heads/main %s\n' "$local_sha" "$ZERO_SHA" \
+        | "$HOOK" upstream "https://github.com/owner/repo.git" 2>&1)
+    rc=$?
+    set -e
+
+    local rc_ok=0
+    if [ "$rc" -eq 1 ] \
+        && printf '%s' "$out" | grep -q "protected branch"; then
+        rc_ok=1
+    fi
+    rm -rf "$dir"
+    LEAK_OUT="$out"
+    _assert_eq "T-7 protected-branch wins over leak guard" 1 "$rc_ok"
+}
+
+# ============================================
 # RUN TESTS
 # ============================================
 
@@ -59,7 +272,6 @@ echo ""
 
 all_passed=1
 
-# Test protected branches
 echo "Testing protected branches (should be BLOCKED):"
 run_test "main" "BLOCKED" || all_passed=0
 run_test "master" "BLOCKED" || all_passed=0
@@ -75,6 +287,16 @@ run_test "develop" "ALLOWED" || all_passed=0
 run_test "bugfix/urgent" "ALLOWED" || all_passed=0
 run_test "hotfix/security" "ALLOWED" || all_passed=0
 run_test "test/experiment" "ALLOWED" || all_passed=0
+
+echo ""
+echo "Testing leak guard (T-1 .. T-7):"
+_t1_origin_push_with_pattern_passes || all_passed=0
+_t2_upstream_push_no_pattern_passes || all_passed=0
+_t3_upstream_push_pattern_in_commit_message_blocks || all_passed=0
+_t4_upstream_push_pattern_in_diff_blocks || all_passed=0
+_t5_skip_leak_guard_escape_hatch || all_passed=0
+_t6_skip_pre_push_escape_hatch || all_passed=0
+_t7_protected_branch_takes_priority || all_passed=0
 
 echo ""
 if [ $all_passed -eq 1 ]; then


### PR DESCRIPTION
## Summary
- `git/hooks/pre-push` 에 두 번째 레이어 — upstream-push leak guard — 를 추가한다. 사용자가 export 한 `UPSTREAM_REMOTES_ERE` 와 push 대상 remote URL 이 매치할 때만 활성화되며, push range 의 commit message + 추가/수정 파일 내용을 `LEAK_PATTERNS_ERE` 로 스캔해 매치 시 push 를 차단한다.
- OSS-safe 기본값: 두 ERE 모두 빈 문자열. 메커니즘만 제공하고 *값* 은 사용자 환경에서 export 로 주입 — 사내 도메인·식별자가 코드/주석/테스트/문서 어디에도 박혀 있지 않다.
- 회귀 테스트 T-1..T-7 + 성능 측정 (NF-1, 19ms) + AGENTS.md / CLAUDE.md 갱신 한 묶음.

## Changes
- `git/config/pre-push-rules.sh` — leak guard SSOT 추가 (`UPSTREAM_REMOTES_ERE`, `LEAK_PATTERNS_ERE`, `MSG_LEAK_BLOCKED`, `MSG_LEAK_HINT`). 두 ERE 의 기본값은 빈 문자열, 활성화 예시는 주석으로만 표기.
- `git/hooks/pre-push` — push protocol 의 `$1` (remote name) / `$2` (remote URL) 을 캡처해 `UPSTREAM_REMOTES_ERE` 매치 여부로 leak guard 활성화 결정. push range 는 일반 케이스 `<remote_sha>..<local_sha>`, 신규 브랜치는 `merge-base <remote>/main..<local_sha>` (실패 시 `<sha>^!` 단일 커밋 fallback). commit message + `--diff-filter=ACMRT` 파일 내용을 스캔하고, 차단 시 `(commit hash, source, 매치된 라인)` 을 출력.
- `SKIP_LEAK_GUARD=1` escape hatch 추가 (PROTECTED_BRANCHES 검사는 유지). 기존 `SKIP_PRE_PUSH=1` 동작은 무회귀.
- `git/test/test-pre-push.sh` — T-1..T-7 통합 테스트 추가. fixture 는 generic placeholder (`example.internal`, `/private-overlay/`) 만 사용. 기존 PROTECTED_BRANCHES unit test 와 공존.
- `git/AGENTS.md` — "Upstream Push Leak Guard" 섹션 1개 + Context Map 에 pre-push 경로 2줄 추가. 활성화 예시는 `<owner>/<repo>` / `<your-private-host>` placeholder.
- `CLAUDE.md` — Git Hooks 항목에 1줄 reference.

## Open Questions — 본문 권장값으로 결정
- Q1 → `git/config/pre-push-rules.sh` 확장 (별도 파일 분리 X).
- Q2 → escape hatch only (option C). 라인 마커 옵션은 false positive 빈도가 누적되면 후속 이슈에서.
- Q3 → 신규 브랜치 push range fallback: `merge-base <remote>/main..<local_sha>`; main/master 모두 실패 시 `<local_sha>^!` 단일 커밋 (full history 스캔 회피 — 19초 → 19ms).
- Q4 → 100 commits 초과 시 stderr 경고 + 진행. 하드 컷오프는 두지 않음.
- Q5 → OSS 디폴트는 빈 문자열. 사내 도메인 예시는 generic placeholder 로 표기.

## Test plan
- [x] `bash git/test/test-pre-push.sh` — PROTECTED_BRANCHES 11건 + T-1..T-7 leak guard 7건 전부 green.
- [x] `tox -e shellcheck` / `tox -e shfmt` / `tox -e ruff` / `tox -e mypy` — 전부 OK.
- [x] `shellcheck -x -e SC1090,SC1091 git/hooks/pre-push git/config/pre-push-rules.sh git/test/test-pre-push.sh` — clean.
- [x] NF-1 성능: 단일 commit 신규 브랜치 push 시뮬레이션 19ms (목표 ≤ 200ms).
- [x] `./tests/test` — 1008 passed, 20 failed; 실패 20건은 baseline 에서도 동일하게 fail 하는 `gc_help` pre-existing 회귀로 본 PR 무관.

## Related
Closes #708

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~4 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~4 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
