### PR TITLE
fix(term_rename): emulate -L sh 컨텍스트 array truncation — frozen prompt root cause

### DIFF
--- a/shell-common/functions/term_rename.sh
+++ b/shell-common/functions/term_rename.sh
@@ -51,7 +51,13 @@ _term_rename_install_hook() {
         # zsh array syntax wrapped in eval so bash never tries to parse it.
         # typeset -ga guarantees precmd_functions exists as a global array
         # even when sourced before zsh's add-zsh-hook plumbing.
+        # emulate -L zsh: the caller may be running under `emulate -L sh`
+        # (e.g. git_worktree_spawn during `gwt spawn --launch`). Without this,
+        # `${precmd_functions[@]}` resolves to only the first array element
+        # under sh emulation, silently truncating the array and dropping
+        # `_p9k_precmd` — causing the frozen-prompt regression (#907).
         eval '
+            emulate -L zsh
             typeset -ga precmd_functions
             precmd_functions=("${precmd_functions[@]}" "${_hook}")
         '
@@ -74,7 +80,11 @@ _term_rename_remove_hook() {
         return 0
     fi
     if [ -n "${ZSH_VERSION-}" ]; then
-        eval 'precmd_functions=("${(@)precmd_functions:#'"${_hook}"'}")'
+        # See _term_rename_install_hook for the emulate-L-zsh rationale. The
+        # `${(@)arr:#PATTERN}` filter flag is zsh-only and collapses the array
+        # to its first element under sh emulation — same frozen-prompt
+        # truncation (#907).
+        eval 'emulate -L zsh; precmd_functions=("${(@)precmd_functions:#'"${_hook}"'}")'
         return 0
     fi
 }
@@ -84,7 +94,11 @@ _term_rename_set_persist_name() {
     # global with typeset -g. bash assignments at function scope are already
     # global without a `local` declaration.
     if [ -n "${ZSH_VERSION-}" ]; then
-        eval 'typeset -g _TERM_RENAME_PERSIST_NAME="$1"'
+        # emulate -L zsh: same caller-emulation defence as the precmd
+        # mutators above. Belt-and-braces — typeset -g would still resolve to
+        # zsh's builtin under sh emulation, but parameter expansion of "$1"
+        # follows whichever emulation is active.
+        eval 'emulate -L zsh; typeset -g _TERM_RENAME_PERSIST_NAME="$1"'
         return 0
     fi
     _TERM_RENAME_PERSIST_NAME="$1"

--- a/shell-common/functions/term_rename.sh
+++ b/shell-common/functions/term_rename.sh
@@ -83,8 +83,14 @@ _term_rename_remove_hook() {
         # See _term_rename_install_hook for the emulate-L-zsh rationale. The
         # `${(@)arr:#PATTERN}` filter flag is zsh-only and collapses the array
         # to its first element under sh emulation — same frozen-prompt
-        # truncation (#907).
-        eval 'emulate -L zsh; precmd_functions=("${(@)precmd_functions:#'"${_hook}"'}")'
+        # truncation (#907). Multi-line + late-binding (eval expands ${_hook}
+        # in the function's local scope) mirrors _term_rename_install_hook
+        # style for consistency (PR #712 gemini-code-assist review).
+        eval '
+            emulate -L zsh
+            typeset -ga precmd_functions
+            precmd_functions=("${(@)precmd_functions:#${_hook}}")
+        '
         return 0
     fi
 }
@@ -97,8 +103,12 @@ _term_rename_set_persist_name() {
         # emulate -L zsh: same caller-emulation defence as the precmd
         # mutators above. Belt-and-braces — typeset -g would still resolve to
         # zsh's builtin under sh emulation, but parameter expansion of "$1"
-        # follows whichever emulation is active.
-        eval 'emulate -L zsh; typeset -g _TERM_RENAME_PERSIST_NAME="$1"'
+        # follows whichever emulation is active. Multi-line for stylistic
+        # consistency with install/remove (PR #712 gemini-code-assist review).
+        eval '
+            emulate -L zsh
+            typeset -g _TERM_RENAME_PERSIST_NAME="$1"
+        '
         return 0
     fi
     _TERM_RENAME_PERSIST_NAME="$1"

--- a/tests/bats/functions/term_rename.bats
+++ b/tests/bats/functions/term_rename.bats
@@ -163,3 +163,91 @@ teardown() {
     assert_success
     assert_output --partial "hook=cleared"
 }
+
+# ---------------------------------------------------------------------------
+# #907 regression: caller under `emulate -L sh` must not truncate
+# precmd_functions. Without the in-eval `emulate -L zsh` guard, the
+# `${(@)arr:#PAT}` filter and `${arr[@]}` expansion collapse to the array's
+# first element under sh emulation, dropping `_p9k_precmd` and freezing the
+# prompt. Root cause for #907 (`gwt spawn --launch` race re-classified as a
+# term_rename array-mutation bug, not a p10k init race).
+# ---------------------------------------------------------------------------
+
+@test "zsh: --persist under emulate -L sh keeps other precmd hooks" {
+    run_in_zsh '
+        # Seed a realistic multi-hook array, then mimic git_worktree_spawn:
+        # call term_rename --persist from a function with `emulate -L sh`.
+        precmd_functions=(_p9k_do_nothing _omz_async_request omz_termsupport_precmd _p9k_precmd)
+        before_count=${#precmd_functions[@]}
+        simulated_gwt() {
+            emulate -L sh
+            term_rename --persist xx >/dev/null
+        }
+        simulated_gwt
+        after_count=${#precmd_functions[@]}
+        # Original 4 hooks must survive + _term_rename_persist appended = 5.
+        print "before=${before_count}"
+        print "after=${after_count}"
+        if [[ ${precmd_functions[(I)_p9k_precmd]} -ne 0 ]]; then
+            print "p9k_precmd=present"
+        else
+            print "p9k_precmd=MISSING"
+        fi
+        if [[ ${precmd_functions[(I)_term_rename_persist]} -ne 0 ]]; then
+            print "term_hook=present"
+        else
+            print "term_hook=MISSING"
+        fi
+    '
+    assert_success
+    assert_output --partial "before=4"
+    assert_output --partial "after=5"
+    assert_output --partial "p9k_precmd=present"
+    assert_output --partial "term_hook=present"
+}
+
+@test "zsh: --clear under emulate -L sh keeps other precmd hooks" {
+    run_in_zsh '
+        precmd_functions=(_p9k_do_nothing _omz_async_request _p9k_precmd)
+        term_rename --persist yy >/dev/null   # append _term_rename_persist
+        simulated_gwt() {
+            emulate -L sh
+            term_rename --clear >/dev/null
+        }
+        simulated_gwt
+        after_count=${#precmd_functions[@]}
+        print "after=${after_count}"
+        if [[ ${precmd_functions[(I)_p9k_precmd]} -ne 0 ]]; then
+            print "p9k_precmd=present"
+        else
+            print "p9k_precmd=MISSING"
+        fi
+        if [[ ${precmd_functions[(I)_term_rename_persist]} -ne 0 ]]; then
+            print "term_hook=stuck"
+        else
+            print "term_hook=cleared"
+        fi
+    '
+    assert_success
+    assert_output --partial "after=3"
+    assert_output --partial "p9k_precmd=present"
+    assert_output --partial "term_hook=cleared"
+}
+
+@test "zsh: --persist under emulate -L sh stores name globally" {
+    # _term_rename_set_persist_name also goes through an eval under the
+    # caller's emulation; verify the assignment lands in the global scope
+    # and survives function return.
+    run_in_zsh '
+        precmd_functions=()
+        unset _TERM_RENAME_PERSIST_NAME
+        simulated_gwt() {
+            emulate -L sh
+            term_rename --persist abc >/dev/null
+        }
+        simulated_gwt
+        print "name=${_TERM_RENAME_PERSIST_NAME-MISSING}"
+    '
+    assert_success
+    assert_output --partial "name=abc"
+}


### PR DESCRIPTION
## Summary

`gwt spawn --launch` 직후 zsh prompt 가 spawn 직전 디렉터리/브랜치에
frozen 되는 회귀의 **진짜 root cause** 수정. 선행 작업
PR #696 (`INSTANT_PROMPT=off`) 와 d91e8f0 (p10k 캐시 cleaner) 는
다른 layer 만 막았고 race origin 자체는 미해결로 명시 보류돼 있었음
(d91e8f0 커밋 메시지: *"emulate -L sh subshell race 자체는 별도 작업"*).

### Root cause

`git_worktree_spawn` 이 `emulate -L sh` 로 진입한 상태에서
`term_rename --persist` 를 호출하면, term_rename 의 zsh-array 조작
`eval` 블록들이 **caller 의 sh emulation 컨텍스트로 평가**됨.

```sh
# term_rename.sh - 호출되는 시점에 caller emulation = sh
eval 'precmd_functions=("${(@)precmd_functions:#PAT}")'   # filter
eval 'precmd_functions=("${precmd_functions[@]}" "$_hook")'  # append
```

sh 규칙 하에서:
- `${(@)arr:#PATTERN}` — zsh-only `(@)` flag + `:#` filter 가 첫
  원소만 남기고 truncate
- `${arr[@]}` — 동일 truncate

→ `precmd_functions` 가 `_p9k_do_nothing _term_rename_persist` 2개로
잘려 **`_p9k_precmd` 가 소실** → p10k 가 매 prompt 마다 state 재계산을
못 해 spawn 직전 snapshot 이 영원히 표시됨.

### Fix

`term_rename.sh` 의 세 `eval` 블록 모두 본문 첫 줄에 `emulate -L zsh`
추가 → caller emulation 과 무관하게 zsh array 문법이 정상 작동.

- `_term_rename_install_hook`
- `_term_rename_remove_hook`
- `_term_rename_set_persist_name` (belt-and-braces, expansion 안전성)

## Verification

### 양방향 회귀 가드 (bats, +3 tests)

`simulated_gwt() { emulate -L sh; term_rename --persist X; }` 패턴으로
실제 race 를 통제된 환경에서 재현.

- pre-fix 실행:
  ```
  ok 14 zsh: --persist installs precmd_functions hook
  ok 15 zsh: --clear removes precmd_functions hook
  not ok 16 zsh: --persist under emulate -L sh keeps other precmd hooks   ← FAIL
  not ok 17 zsh: --clear under emulate -L sh keeps other precmd hooks     ← FAIL
  ok 18 zsh: --persist under emulate -L sh stores name globally
  ```
- post-fix 실행: **18/18 PASS** (16, 17 통과 = root cause 해소 입증)

### 수동 시나리오

`exec zsh` 만으로 복구되던 frozen prompt 가 본 fix 이후 `gwt spawn
--launch` 직후부터 정상 디렉터리/브랜치를 그려야 함.

## Test plan

- [ ] `./tests/test` 또는 `bats tests/bats/functions/term_rename.bats` PASS
- [ ] `tox -e shellcheck` / `tox -e shfmt` PASS (수정한 부분에 신규
      경고 없음 — SC3043 `local` 경고 3건은 pre-existing)
- [ ] 사내 PC / 외부 PC 양쪽에서 `gwt spawn --launch --wt-name probe-X`
      → agent 종료 후 prompt 가 `probe-X` worktree dir + 새 branch 표시
- [ ] `print -lr -- $precmd_functions` 출력에 `_p9k_precmd` 가
      포함되는지 확인 (frozen-prompt 진단 SSOT, d91e8f0 가 추가한 1줄
      진단)

## Related

- d91e8f0 `fix(zsh): #705 p10k 캐시 cleaner 확장 + frozen prompt 진단 SSOT`
  — cleaner + diagnostic SSOT (race origin 은 미해결 명시)
- e047b16 `fix(zsh): disable p10k instant prompt — frozen prompt in worktree shells` (PR #696)
  — INSTANT_PROMPT=off layer
- #709 — 별개 이슈 (VSCode tab label / OSC clobber). 본 PR 와 root cause 무관.

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 🤖 ~1 min</summary>

<!-- ai-metrics -->
📊 ~2000 tokens · 🤖 ~1 min
<!-- /ai-metrics -->

</details>
