### PR TITLE
fix(gwt-spawn): #709 term-rename 호출 가시화 + VSCode 사전 조건 안내

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1772,7 +1772,7 @@ git_worktree_spawn() {
             # only when we can detect we're running there.
             if [ "${TERM_PROGRAM-}" = "vscode" ]; then
                 ux_info "          VSCode needs settings.json: \"terminal.integrated.tabs.title\": \"\${sequence}\""
-                ux_info "          (see \`term help vscode\`)"
+                ux_info "          (see \`term-help vscode\`)"
             fi
             term_rename --persist "(${agent}) ${name}"
         fi

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1761,6 +1761,19 @@ git_worktree_spawn() {
         # review). Guarded by command -v so the spawn still works if
         # term_rename.sh somehow isn't loaded.
         if command -v term_rename >/dev/null 2>&1; then
+            # Always print the label that will be set so users have a
+            # debugging surface when the tab doesn't visibly update
+            # (#709). Silent-emit was the original reason that case
+            # turned into a "did it run?" guessing game.
+            ux_info "  label:  (${agent}) ${name}"
+            # VSCode integrated terminal needs `terminal.integrated.tabs.title`
+            # set to ${sequence} for shell-emitted OSC titles to honor
+            # (#709). The default ${process} silently discards them, so warn
+            # only when we can detect we're running there.
+            if [ "${TERM_PROGRAM-}" = "vscode" ]; then
+                ux_info "          VSCode needs settings.json: \"terminal.integrated.tabs.title\": \"\${sequence}\""
+                ux_info "          (see \`term help vscode\`)"
+            fi
             term_rename --persist "(${agent}) ${name}"
         fi
         eval "$launch_cmd"

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -789,7 +789,7 @@ teardown() {
     assert_output --partial "label:  (claude) pr-709v"
     assert_output --partial "VSCode needs settings.json"
     assert_output --partial "terminal.integrated.tabs.title"
-    assert_output --partial "term help vscode"
+    assert_output --partial "term-help vscode"
 }
 
 @test "bash: #709 spawn --launch without TERM_PROGRAM omits VSCode setting hint" {
@@ -802,7 +802,7 @@ teardown() {
     "
     assert_success
     refute_output --partial "VSCode needs settings.json"
-    refute_output --partial "term help vscode"
+    refute_output --partial "term-help vscode"
 }
 
 @test "bash: #709 spawn without --launch does NOT print 'label:' line" {
@@ -828,4 +828,5 @@ teardown() {
     assert_success
     assert_output --partial "label:  (claude) pr-709z"
     assert_output --partial "VSCode needs settings.json"
+    assert_output --partial "term-help vscode"
 }

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -758,3 +758,74 @@ teardown() {
     assert_success
     assert_output "|--persist|(claude) pr-723"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #709: --launch makes the term-rename label visible in spawn summary
+# and warns when running inside VSCode integrated terminal where the OSC
+# title is silently dropped unless the user opts into `${sequence}`.
+# ---------------------------------------------------------------------------
+
+@test "bash: #709 spawn --launch prints 'label:' line so emit is observable" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        unset TERM_PROGRAM
+        claude_yolo() { :; }
+        term_rename() { :; }
+        git_worktree_spawn --launch --ai claude --wt-name pr-709 2>/dev/null
+    "
+    assert_success
+    assert_output --partial "label:  (claude) pr-709"
+}
+
+@test "bash: #709 spawn --launch under TERM_PROGRAM=vscode prints VSCode setting hint" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        export TERM_PROGRAM=vscode
+        claude_yolo() { :; }
+        term_rename() { :; }
+        git_worktree_spawn --launch --ai claude --wt-name pr-709v 2>/dev/null
+    "
+    assert_success
+    assert_output --partial "label:  (claude) pr-709v"
+    assert_output --partial "VSCode needs settings.json"
+    assert_output --partial "terminal.integrated.tabs.title"
+    assert_output --partial "term help vscode"
+}
+
+@test "bash: #709 spawn --launch without TERM_PROGRAM omits VSCode setting hint" {
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        unset TERM_PROGRAM
+        claude_yolo() { :; }
+        term_rename() { :; }
+        git_worktree_spawn --launch --ai claude --wt-name pr-709n 2>/dev/null
+    "
+    assert_success
+    refute_output --partial "VSCode needs settings.json"
+    refute_output --partial "term help vscode"
+}
+
+@test "bash: #709 spawn without --launch does NOT print 'label:' line" {
+    # No --launch path = no agent, no label emit. Tab hint must also stay out.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        export TERM_PROGRAM=vscode
+        git_worktree_spawn --wt-name pr-709noLaunch 2>/dev/null
+    "
+    assert_success
+    refute_output --partial "label:  (claude)"
+    refute_output --partial "VSCode needs settings.json"
+}
+
+@test "zsh: #709 spawn --launch under TERM_PROGRAM=vscode prints VSCode setting hint" {
+    run_in_zsh "
+        cd '$FAKE_REPO' || exit 1
+        export TERM_PROGRAM=vscode
+        claude_yolo() { :; }
+        term_rename() { :; }
+        git_worktree_spawn --launch --ai claude --wt-name pr-709z 2>/dev/null
+    "
+    assert_success
+    assert_output --partial "label:  (claude) pr-709z"
+    assert_output --partial "VSCode needs settings.json"
+}


### PR DESCRIPTION
## Summary
- `gwt spawn --launch` 가 `term_rename --persist` 를 무성공/무경고로 emit 만 하던 문제를 spawn 측에서 한 줄 라벨 안내 + VSCode 사전 조건 힌트로 해소
- VSCode `${process}` 기본값 + agent foreground clobber 가 겹쳐 사용자는 기능이 silent no-op 처럼 느꼈음 (#709 본문 root cause 3계층 참고)
- 동작 변경 없음 — `ux_info` 추가만이라 spawn 의 제어 흐름은 무변경, 회귀 위험 최소

## Changes
- `shell-common/functions/git_worktree.sh:1763-1781` — `term_rename --persist` 호출 직전·직후에
  - `label:  (<agent>) <wt-name>` 한 줄을 모든 환경에서 출력 (emit 가시화)
  - `$TERM_PROGRAM=vscode` 일 때만 `terminal.integrated.tabs.title=${sequence}` 가 필요하다는 2 줄 힌트 (`term help vscode` 안내 포함)
- `tests/bats/functions/git_worktree_spawn.bats` — #709 신규 5 케이스
  - bash: label 한 줄이 `$TERM_PROGRAM` 무관하게 출력되는지
  - bash: `TERM_PROGRAM=vscode` 일 때 VSCode 힌트 2 줄 추가 출력
  - bash: `$TERM_PROGRAM` unset 일 때 VSCode 힌트가 안 보이는지 (refute)
  - bash: `--launch` 없으면 label 도 힌트도 출력 안 되는지 (회귀 가드)
  - zsh: VSCode 분기 미러 케이스

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/git_worktree_spawn.bats --filter '#709'` 5/5 PASS
- [x] `--filter '#675'` 5/5 PASS (기존 회귀 가드 유지)
- [x] `tox -e ruff,shellcheck,shfmt` PASS (gh-pr 의 lint guard 통과)
- [ ] 수동: VSCode integrated terminal 에서 `gwt spawn --launch --ai claude --wt-name issue-X` 실행 시 spawn summary 에 `label:  (claude) issue-X` + VSCode 힌트 2 줄이 출력되는지 육안 확인
- [ ] 수동: ssh / 일반 tmux 단독 등 `$TERM_PROGRAM` 미설정 환경에서는 VSCode 힌트가 출력되지 않는지 확인
- [ ] 수동: `gwt spawn --wt-name X` (`--launch` 없음) 시 label / 힌트 모두 미출력 확인

## Related
Closes #709
