### PR TITLE
refactor(skill/gh-kanban-bootstrap): SKILL.md Progressive Disclosure (111→99 lines)

### DIFF
--- a/claude/skills/gh-kanban-bootstrap/SKILL.md
+++ b/claude/skills/gh-kanban-bootstrap/SKILL.md
@@ -32,14 +32,10 @@ Locate `SKILL_DIR` (this file's directory). The script lives at
 
 ## Step 2: Prereq Check
 
-Follow `references/prereq.md`:
-- `command -v gh && command -v jq` — abort with install hint on miss.
-- Detect host from `git remote get-url origin`.
-- `gh api --hostname <host> -i user` → check `X-Oauth-Scopes` header
-  includes `project`. On miss: print `gh auth refresh -h <host> -s project`
-  and abort (rc=1). NOTE: `gh api` uses `--hostname` (not `-h`, which is
-  the help flag) — `gh auth refresh` keeps `-h` as its hostname short
-  flag. The two CLIs are inconsistent; both correct as written.
+Follow `references/prereq.md` for tool / host / token-scope checks
+(including the `gh api --hostname` vs `gh auth refresh -h` flag-naming
+inconsistency). On any miss the helper prints the install or
+`gh auth refresh -h <host> -s project` hint and aborts (rc=1).
 
 ## Step 3: Target Repo
 
@@ -58,18 +54,12 @@ Parse `--no-bootstrap-labels` (skip Step 5 entirely) and
 
 ## Step 5: Label Bootstrap
 
-Per `references/labels.md` (the SSOT table). For each label:
-- Already exists + `--force-label-sync` unset → print
-  `label '<x>' already exists — skip`, no API call.
-- Already exists + `--force-label-sync` set → `PATCH
-  /repos/$REPO/labels/$NAME` with SSOT color/description.
-- Missing → `POST /repos/$REPO/labels`.
-
-If `--no-bootstrap-labels`: print one line
-`label bootstrap skipped (--no-bootstrap-labels)` and skip the step.
-
-Permission errors on a single label → stderr 1-line warn, continue.
-Label absence does not block board setup.
+Apply the 8 SSOT labels per `references/labels.md` — the "Apply
+decision matrix" section there resolves skip / PATCH (on
+`--force-label-sync`) / POST per label. `--no-bootstrap-labels` skips
+the whole step with a one-line notice. Per-label permission errors
+warn on stderr and continue — label absence does not block board
+setup.
 
 ## Step 6: Dry-run Dispatch
 
@@ -106,6 +96,4 @@ output. Append:
 - Never auto-execute smoke test without explicit `--with-smoke-test`.
 - Never echo token / collaborator / project ID to stdout (NF-3).
 - Never silently fall back to a different remote — `origin` only.
-- The script `lib/setup.sh` is the SOLE entry point for kanban setup in
-  this repo. Do not reintroduce the old scripts/ location — that path
-  was removed in issue #699.
+- `lib/setup.sh` is the sole entry point — do not reintroduce the old `scripts/` location (removed in #699).

--- a/claude/skills/gh-kanban-bootstrap/references/labels.md
+++ b/claude/skills/gh-kanban-bootstrap/references/labels.md
@@ -35,6 +35,25 @@ build|0e8a16|빌드 시스템
 skill|5319e7|claude/skills/** 변경
 ```
 
+## Apply decision matrix
+
+For each label in the SSOT feed below, the skill resolves one of three
+actions based on the existing label set and the `--force-label-sync`
+flag:
+
+| existing | `--force-label-sync` | action | notes |
+|----------|----------------------|--------|-------|
+| yes | unset | **skip** | print `label '<x>' already exists — skip`, no API call |
+| yes | set | **PATCH** | `PATCH /repos/$REPO/labels/$NAME` with SSOT color + description |
+| no | (either) | **POST** | `POST /repos/$REPO/labels` with SSOT color + description |
+
+When `--no-bootstrap-labels` is passed the skill skips this step
+entirely and prints `label bootstrap skipped (--no-bootstrap-labels)`.
+
+Per-label permission errors (e.g. fork without `repo:write`) print a
+one-line warning on stderr and continue — label absence does not block
+the board setup that follows in Step 6/7.
+
 ## Idempotent apply helper
 
 ```sh

--- a/claude/skills/gh-kanban-bootstrap/references/prereq.md
+++ b/claude/skills/gh-kanban-bootstrap/references/prereq.md
@@ -51,6 +51,13 @@ case ",${scopes// /}," in
 esac
 ```
 
+## Flag naming inconsistency (`gh api` vs `gh auth refresh`)
+
+`gh api` uses `--hostname` for the target host — `-h` is reserved as
+its help flag. `gh auth refresh`, however, keeps `-h` as its hostname
+short flag. The two CLIs are intentionally inconsistent; both forms
+above are correct as written. Do not "fix" one to match the other.
+
 ## rc matrix
 
 | condition | rc | message |


### PR DESCRIPTION
## Summary
- `claude/skills/gh-kanban-bootstrap/SKILL.md` 가 111 줄로 100 줄 제한을
  초과했던 문제를 동작 보존 압축으로 해소 (`wc -l` 99).
- 새 references/ 파일은 추가하지 않고, 기존 `prereq.md` / `labels.md`
  에 absorb 섹션을 신설해 정보 손실 0.

## Changes
- `SKILL.md`: Step 2 (Prereq) 10→4 lines, Step 5 (Label Bootstrap)
  14→6 lines, Constraints 마지막 bullet 3→1 line. 8 단계 워크플로
  순서·이름·트리거 조건 동일.
- `references/prereq.md`: `Flag naming inconsistency (gh api vs gh
  auth refresh)` 섹션 추가 — `--hostname` vs `-h` 비대칭 설명을
  control-tower 에서 reference 로 이관.
- `references/labels.md`: `Apply decision matrix` 표 섹션 추가 —
  skip / PATCH / POST + `--no-bootstrap-labels` + per-label permission
  warn 정책을 SSOT 한 자리에 모음.

## Test plan
- [x] `wc -l claude/skills/gh-kanban-bootstrap/SKILL.md` → 99 (≤100)
- [x] `bash claude/skills/gh-kanban-bootstrap/lib/setup.sh --dry-run`
      여전히 정상 (스크립트 본체 미터치 확인)
- [x] `tox -e ruff,shellcheck,shfmt` 통과 (gh:pr Step 4.5 lint guard)
- [ ] (리뷰어) references/ 신규 섹션이 SKILL.md pointer 와 1:1 매칭
      되는지 spot-check

## Related
Closes #714

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
