### PR TITLE
fix(setup-company-skills): #715 SKILL.md 가드 — 메타 디렉토리 entry 생성 방지

### DIFF
--- a/scripts/setup-company-skills.sh
+++ b/scripts/setup-company-skills.sh
@@ -184,9 +184,15 @@ fi
 COMPANY_SKILLS_HOME="$(cd "$COMPANY_SKILLS_HOME" && pwd)"
 
 # Empty private repo: no entries to layer. Not an error.
+# Apply the same SKILL.md guard as _overlay_one_target so a repo that
+# only carries metadata dirs (.claude-plugin/, plugins/, tests/, …) is
+# treated as empty here too — otherwise the main loop runs to completion
+# with all-zero counters and prints a misleading "overlay applied"
+# success line. Suggested by gemini-code-assist on PR #717.
 _has_entries=0
 for _e in "$COMPANY_SKILLS_HOME"/*/; do
     [ -d "$_e" ] || continue
+    [ -f "${_e}SKILL.md" ] || continue
     _has_entries=1
     break
 done

--- a/scripts/setup-company-skills.sh
+++ b/scripts/setup-company-skills.sh
@@ -94,6 +94,15 @@ _overlay_one_target() {
                 continue
                 ;;
         esac
+
+        # Claude Code skill convention: a directory is a skill only if
+        # it contains SKILL.md. Skip metadata directories that may live
+        # alongside real skills in a marketplace-shaped overlay repo —
+        # e.g. .claude-plugin/, plugins/, tests/, docs/ (issue #715).
+        if [ ! -f "${entry}SKILL.md" ]; then
+            continue
+        fi
+
         link="${target_dir}/${name}"
         want="${COMPANY_SKILLS_HOME}/${name}"
 
@@ -142,7 +151,10 @@ _overlay_one_target() {
         target_path="$(readlink "$existing")"
         case "$target_path" in
             "${COMPANY_SKILLS_HOME}"/*)
-                if [ ! -d "$target_path" ]; then
+                # Stale if the source dir vanished OR its SKILL.md is
+                # gone — the overlay guard above no longer accepts it
+                # either way, so keep both sides consistent (#715).
+                if [ ! -d "$target_path" ] || [ ! -f "${target_path}/SKILL.md" ]; then
                     log_info "  removing stale overlay entry: $existing"
                     rm -f "$existing"
                     pruned=$((pruned + 1))

--- a/tests/bats/functions/setup_company_skills.bats
+++ b/tests/bats/functions/setup_company_skills.bats
@@ -133,6 +133,21 @@ run_overlay() {
     [ ! -e "$SKILLS_DIR/docs" ]
 }
 
+@test "meta-only repo treated as empty by _has_entries (PR #717 review)" {
+    # Consistency with the overlay loop's SKILL.md guard: if the repo
+    # carries ONLY metadata dirs, the early-exit should classify it as
+    # empty instead of falling through to the main loop and printing
+    # the "overlay applied" success line with all-zero counters.
+    mkdir -p "$SKILLS_DIR" \
+        "$HOME/company-skills/.claude-plugin" \
+        "$HOME/company-skills/plugins" \
+        "$HOME/company-skills/tests"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+    assert_output --partial "is empty"
+}
+
 @test "dual layout — only root-level skill linked, plugins/ ignored (#715)" {
     # Root-level skill alongside a plugins/<plugin>/skills/<skill>
     # nested layout. The overlay must link only the root skill; the

--- a/tests/bats/functions/setup_company_skills.bats
+++ b/tests/bats/functions/setup_company_skills.bats
@@ -109,3 +109,44 @@ run_overlay() {
     assert_success
     assert_output --partial "no ~/.claude"
 }
+
+@test "skips meta directories without SKILL.md (issue #715)" {
+    # A marketplace-shaped overlay repo carries metadata dirs alongside
+    # real skills. The SKILL.md guard must skip metadata so they do
+    # not leak into ~/.claude/skills/.
+    mkdir -p "$SKILLS_DIR" \
+        "$HOME/company-skills/real-skill" \
+        "$HOME/company-skills/.claude-plugin" \
+        "$HOME/company-skills/plugins" \
+        "$HOME/company-skills/tests" \
+        "$HOME/company-skills/docs"
+    : > "$HOME/company-skills/real-skill/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+
+    [ -L "$SKILLS_DIR/real-skill" ]
+    [ "$(readlink "$SKILLS_DIR/real-skill")" = "$HOME/company-skills/real-skill" ]
+    [ ! -e "$SKILLS_DIR/.claude-plugin" ]
+    [ ! -e "$SKILLS_DIR/plugins" ]
+    [ ! -e "$SKILLS_DIR/tests" ]
+    [ ! -e "$SKILLS_DIR/docs" ]
+}
+
+@test "dual layout — only root-level skill linked, plugins/ ignored (#715)" {
+    # Root-level skill alongside a plugins/<plugin>/skills/<skill>
+    # nested layout. The overlay must link only the root skill; the
+    # plugins/ dir has no SKILL.md and must be skipped.
+    mkdir -p "$SKILLS_DIR" \
+        "$HOME/company-skills/root-skill" \
+        "$HOME/company-skills/plugins/example-suite/skills/nested-skill"
+    : > "$HOME/company-skills/root-skill/SKILL.md"
+    : > "$HOME/company-skills/plugins/example-suite/skills/nested-skill/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+
+    [ -L "$SKILLS_DIR/root-skill" ]
+    [ "$(readlink "$SKILLS_DIR/root-skill")" = "$HOME/company-skills/root-skill" ]
+    [ ! -e "$SKILLS_DIR/plugins" ]
+}


### PR DESCRIPTION
## Summary

`scripts/setup-company-skills.sh` 의 overlay 루프가 `$COMPANY_SKILLS_HOME/*/`
glob 만 보고 모든 하위 디렉토리를 skill 후보로 잡던 문제를 막는다.
private skills repo 가 marketplace 표준 dual layout (`.claude-plugin/`,
`plugins/`, `tests/`, `docs/`) 을 운영하면 그 메타 디렉토리가
`~/.claude/skills/` 로 새어 나갔다 — Claude Code 가 `SKILL.md` 없는
디렉토리는 무시하므로 기능적 회귀는 아니지만 `~/.claude/skills/` 가
더러워지고 `claude_accounts_status` 출력이 혼란스러워졌다.

## 변경 사항

- **overlay 루프 가드** (`_overlay_one_target`) — entry 안에 `SKILL.md`
  가 있을 때만 link 후보로 처리. 메타 디렉토리는 조용히 skip.
- **stale prune 기준 동기화** — 디렉토리 존재 여부뿐 아니라 `SKILL.md`
  부재도 stale 로 인정해 overlay 가드와 일관성 유지. 기존에는 `SKILL.md`
  만 사라진 케이스가 stale 로 잡히지 않아 `pruned` 카운트가 누락됐다.
- **회귀 테스트 2건 추가** (`tests/bats/functions/setup_company_skills.bats`):
  - meta-only (4종 메타 디렉토리 + 실제 skill) → 실제 skill 만 link 되고
    메타 디렉토리는 모두 `~/.claude/skills/` 에 entry 생성 안 됨.
  - dual layout (root-level skill + `plugins/<plugin>/skills/<skill>`)
    → root-level skill 만 link, `plugins/` 는 무시.

## 영향 범위

- 정상 skill (`SKILL.md` 있음): **동작 변화 없음**.
- 메타 디렉토리 (`SKILL.md` 없음): 무시 (정상화).
- `SKILL.md` 없는 디렉토리를 일부러 entry 로 만들고 있던 사용자: Claude
  Code skill discovery 가 `SKILL.md` 를 요구하므로 그런 사용자는
  사실상 없음 — 비호환 위험 무시 가능.

## 테스트 결과

- `bats tests/bats/functions/setup_company_skills.bats` → **9/9 PASS**
  (기존 7 + 신규 2 회귀 케이스).
- `tox -e shellcheck,shfmt` → PASS.

## Test plan

- [ ] Reviewer: `~/.claude/skills/` 에 `plugins` / `.claude-plugin` 같은
      entry 가 더 이상 생기지 않는지 dual-layout overlay repo 로 확인.
- [ ] `SKILL.md` 만 빠진 디렉토리가 stale prune 로 정리되는지 확인 (선택).
- [ ] 기존 7개 bats 케이스 무회귀 재확인.

Closes #715

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
