### PR TITLE
fix(gh-host): #718 _dotfiles_setup_mode 함수 부재 시 디스크 폴백

### DIFF
--- a/shell-common/functions/gh_host.sh
+++ b/shell-common/functions/gh_host.sh
@@ -34,11 +34,32 @@
 #
 # Reads `_dotfiles_setup_mode` (defined in
 # shell-common/tools/integrations/claude.sh). When that function isn't
-# in scope (sourcing order glitch or a non-interactive caller that
-# hasn't loaded the integrations layer), fall back to `github.com` —
-# external/public PCs stay on the public cloud regardless.
+# in scope, fall back to reading `~/.dotfiles-setup-mode` directly so
+# non-interactive callers (hooks, one-shot scripts) that source
+# gh_host.sh without the integrations layer still resolve `internal`
+# correctly. Before issue #718 this branch unconditionally returned
+# `github.com`, which silently broke `claude/hooks/post-gh-pr-create.sh`
+# on internal PCs (host regex never matched the GHE PR URL → board
+# sync skipped). The disk fallback mirrors the same canonicalisation
+# that `_dotfiles_setup_mode` performs (legacy numeric values 1/2/3
+# from pre-#571 setup.sh) so the two code paths agree.
 _gh_resolve_host() {
-    _grh_mode=$(_dotfiles_setup_mode 2>/dev/null || echo "")
+    if command -v _dotfiles_setup_mode >/dev/null 2>&1; then
+        _grh_mode=$(_dotfiles_setup_mode 2>/dev/null || echo "")
+    else
+        _grh_file="$HOME/.dotfiles-setup-mode"
+        if [ -f "$_grh_file" ]; then
+            _grh_mode=$(tr -d ' \t\n\r' < "$_grh_file" 2>/dev/null)
+            case "$_grh_mode" in
+                1) _grh_mode="public" ;;
+                2) _grh_mode="internal" ;;
+                3) _grh_mode="external" ;;
+            esac
+        else
+            _grh_mode=""
+        fi
+        unset _grh_file
+    fi
     case "$_grh_mode" in
         internal)           echo "github.samsungds.net" ;;
         external|public|"") echo "github.com" ;;

--- a/tests/bats/functions/gh_host.bats
+++ b/tests/bats/functions/gh_host.bats
@@ -152,3 +152,52 @@ teardown() {
     assert_output --partial "resolve_ok"
     assert_output --partial "parse_ok"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #718 — disk fallback when `_dotfiles_setup_mode` function is absent.
+#
+# Reproduces the hook context: `claude/hooks/post-gh-pr-create.sh` sources
+# only `gh_host.sh` (NOT the integrations layer that defines
+# `_dotfiles_setup_mode`). Before #718 this path always returned
+# `github.com`, masking `internal` PCs' GHE host and breaking the post-PR
+# board-sync regex. The fix adds a `~/.dotfiles-setup-mode` file fallback,
+# tested here with a clean `env -i` bash so neither the function nor any
+# parent-shell env can leak in.
+# ---------------------------------------------------------------------------
+
+@test "#718: function present -> function result wins over disk (no regression)" {
+    echo "external" > "$HOME/.dotfiles-setup-mode"
+    # When _dotfiles_setup_mode is in scope and returns 'internal', the
+    # function MUST win — even if the disk file disagrees. This pins
+    # the "function-first" precedence.
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        _dotfiles_setup_mode() { echo internal; }
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh'
+        _gh_resolve_host
+    "
+    assert_success
+    assert_output "github.samsungds.net"
+}
+
+@test "#718: function absent + setup-mode=internal on disk -> GHE (hook context)" {
+    echo "internal" > "$HOME/.dotfiles-setup-mode"
+    # env -i strips the parent shell so _dotfiles_setup_mode cannot leak in.
+    # PATH must be preserved or `bash`/`tr` won't resolve.
+    run env -i "HOME=$HOME" "PATH=$PATH" bash --noprofile --norc -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh'
+        _gh_resolve_host
+    "
+    assert_success
+    assert_output "github.samsungds.net"
+}
+
+@test "#718: function absent + setup-mode file absent -> github.com" {
+    rm -f "$HOME/.dotfiles-setup-mode"
+    run env -i "HOME=$HOME" "PATH=$PATH" bash --noprofile --norc -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh'
+        _gh_resolve_host
+    "
+    assert_success
+    assert_output "github.com"
+}


### PR DESCRIPTION
## Summary
- `_gh_resolve_host` 가 `_dotfiles_setup_mode` 함수에만 의존해, hook 등 비대화형 컨텍스트에서 항상 `github.com` 으로 fallback 되던 회귀 수정.
- 함수 부재 시 `~/.dotfiles-setup-mode` 를 직접 읽는 디스크 fallback 추가. 함수가 있으면 함수 결과 우선 — 무회귀.
- bats 회귀 케이스 3개 추가 (함수 우선 / 파일 fallback / 둘 다 부재).

## Changes
- **shell-common/functions/gh_host.sh**: `_gh_resolve_host` 에 `command -v _dotfiles_setup_mode` 분기 추가. 함수가 scope 에 없을 때 `tr -d ' \t\n\r' < ~/.dotfiles-setup-mode` 로 모드를 읽고, 레거시 숫자값 (`1|2|3`) 까지 `_dotfiles_setup_mode` 와 동일하게 canonicalise. 두 코드 경로의 출력이 일치한다.
- **tests/bats/functions/gh_host.bats**: 이슈 #718 회귀 케이스 3개 추가.
  - 함수 우선 — 함수가 internal 을 돌려주면 디스크의 external 무시.
  - 함수 부재 + 디스크 internal — `env -i` clean bash 에서 GHE 호스트 복구.
  - 함수 부재 + 파일 부재 — `github.com` fallback (regression-zero).

## Test plan
- [x] `bats tests/bats/functions/gh_host.bats` — 19/19 PASS (기존 16개 + 신규 3개 무회귀).
- [x] `shellcheck shell-common/functions/gh_host.sh` — clean.
- [x] `tox -e ruff,shellcheck,shfmt` (pre-push lint guard) — all green.
- [ ] 사내 internal PC 에서 `gh pr create` 후 `claude/hooks/post-gh-pr-create.sh` 가 GHE PR URL 을 정상 매칭해 board sync 가 In review 로 이동하는지 실측 (이슈 본문 시나리오).

## Related
Closes #718

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
