### PR TITLE
fix(shell-common): #720 비-interactive 가드 제거 — pure-function 헬퍼 3종

### DIFF
--- a/shell-common/functions/gh_discussion.sh
+++ b/shell-common/functions/gh_discussion.sh
@@ -56,8 +56,15 @@
 # line to stderr and returns a non-zero exit code so the caller can
 # present the user with an actionable message. Helpers never call
 # `exit` — they `return` so a sourced caller stays in the same shell.
-
-case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+#
+# NOTE: This file intentionally has NO interactive guard. It is a pure
+# function-defining library (no top-level side effects) consumed by the
+# `gh:discussion-create`, `gh:discussion-convert`, and `gh:issue-create`
+# skills in non-interactive bash (Claude Code's Bash tool runs
+# `bash --noprofile --norc`). An interactive guard would `return 0`
+# before defining the helpers, breaking the skills with
+# `command not found`. Mirrors the same NOTE in gh_project_status.sh
+# (PR #497). See issue #720.
 
 _gh_discussion_repo_id() {
     local _owner="${1:-}" _repo="${2:-}"

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -35,8 +35,14 @@
 #   hitting the REST endpoint. Without this guard, POST /labels would
 #   auto-create a missing label silently — see project memory
 #   `feedback_gh_label_no_autocreate.md`.
-
-case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+#
+# NOTE: This file intentionally has NO interactive guard. It is a pure
+# function-defining library (no top-level side effects) consumed by the
+# `gh:pr` skill in non-interactive bash (Claude Code's Bash tool runs
+# `bash --noprofile --norc`). An interactive guard would `return 0`
+# before defining `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`,
+# breaking PR body / label edits with `command not found`. Mirrors the
+# same NOTE in gh_project_status.sh (PR #497). See issue #720.
 
 _gh_pr_edit_safe__deprecation_marker='Projects (classic) is being deprecated'
 

--- a/shell-common/functions/gh_pr_lint.sh
+++ b/shell-common/functions/gh_pr_lint.sh
@@ -21,8 +21,14 @@
 #   0 — all detected tools passed, or skipped (no tools / bypass / no changes)
 #   1 — at least one tool failed; caller should block the push
 #   2 — usage error (missing base-branch argument)
-
-case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+#
+# NOTE: This file intentionally has NO interactive guard. It is a pure
+# function-defining library (no top-level side effects) consumed by the
+# `gh:pr` skill in non-interactive bash (Claude Code's Bash tool runs
+# `bash --noprofile --norc`). An interactive guard would `return 0`
+# before defining `_gh_pr_lint_run`, breaking the skill's Step 4.5 lint
+# guard with `command not found`. Mirrors the same NOTE in
+# gh_project_status.sh (PR #497). See issue #720.
 
 _gh_pr_lint__log() {
     printf '[lint guard] %s\n' "$*"


### PR DESCRIPTION
## Summary
- 비-interactive `bash --noprofile --norc` 환경 (Claude Code Bash 도구) 에서 `gh:pr` Step 4.5 lint guard, `gh:discussion-*`, `gh:issue-create` 의 헬퍼 함수가 `command not found` 으로 silent skip 되던 회귀를 차단.
- `gh_project_status.sh` 가 PR #497 (commit `13f3152`) 에서 동일 사유로 가드를 제거한 패턴을 그대로 적용 — 헬퍼 SSOT precedent 유지.
- 3 개 파일은 모두 top-level side effect 없는 pure function 라이브러리이므로 `case $- in *i*) ;; *) ... return 0` 가드가 불필요. NOTE 블록을 추가해 의도를 명시하고 sh:check 회귀 시 가이드.

## Changes
- `shell-common/functions/gh_pr_lint.sh` — interactive 가드 제거 + NOTE 추가. `gh:pr` Step 4.5 lint guard 가 Claude Code 서브셸에서 실제로 동작.
- `shell-common/functions/gh_discussion.sh` — interactive 가드 제거 + NOTE 추가. `gh:discussion-create`, `gh:discussion-convert`, `gh:issue-create` 가 `_gh_discussion_*` 헬퍼를 정상 사용.
- `shell-common/functions/gh_pr_edit_safe.sh` — interactive 가드 제거 + NOTE 추가. `gh:pr` PR body / label edit 의 classic-project deprecation fallback (`_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`) 가 Claude Code 경로에서 동작.

## Test plan
- [x] `bash -c '. <file>; type <func>'` 각각 함수 정의 확인 (3 helper, 4 funcs)
- [x] `DOTFILES_FORCE_INIT=1 zsh -c '. <file>; type <func>'` interactive lazy-init 경로 회귀 없음
- [x] `tests/bats/functions/{gh_pr_lint,gh_discussion,gh_pr_edit_safe}.bats` — 65/65 PASS
- [x] `tests/bats/functions/` 전체 sweep — 643 / 643 PASS
- [x] `tox` (ruff / mypy / shellcheck / shfmt) all green
- [ ] 머지 후 `/gh-issue-flow` 를 사내 GHE 환경에서 1회 돌려 board sync silent skip 부재 확인 (verify section)

## Implementation note
이슈 본문은 `gh_project_status.sh:1` 에 동일 가드가 있다고 기술했으나 실측 결과 해당 가드는 PR #497 (commit `13f3152`) 에서 이미 제거된 상태였다. 같은 증상을 보이는 나머지 3 개 헬퍼를 동일 precedent 로 처리. (Option A: 헬퍼 가드 완화 — 이슈에서 권장한 Option B 가 아니지만 `gh_project_status.sh` 의 기존 fix 와 일관됨.)

## Related
Closes #720

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
