### PR TITLE
chore(build): #722 mise.toml + 문서 dual-spec — tox 마이그레이션 PR 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,20 @@ and consolidates `./tools/dev.sh`. Until then, call `mise run` directly.
 
 #### Legacy — tox (deprecated, kept until PR 5 of #722)
 
+`tox -e <env>` 와 `mise run <task>` 의 동치 매핑. 단, `tox` (인자 없음)
+은 envlist 가 `ruff, mypy, shellcheck, shfmt` 라 ruff/shfmt 단계에서
+파일을 **수정**하고 (각 testenv 가 `ruff format` / `shfmt -w` 호출)
+나머지는 read-only 인 mixed 동작이다. `mise run lint` 는 순수 read-only
+이므로 두 명령은 의미가 다르며, 정확한 mise 대체는 `mise run fix &&
+mise run lint` 다.
+
 ```bash
-tox -e shellcheck   # equivalent to: mise run lint-sh
-tox -e shfmt        # equivalent to: mise run fix-sh
-tox -e ruff         # equivalent to: mise run fix-py
-tox                 # equivalent to: mise run lint
+tox -e shellcheck   # equivalent to: mise run lint-sh   (둘 다 read-only)
+tox -e shfmt        # equivalent to: mise run fix-sh    (둘 다 -w)
+tox -e ruff         # equivalent to: mise run fix-py    (둘 다 --fix + format)
+tox                 # rough equivalent: mise run fix && mise run lint
+                    #   (tox 가 ruff/shfmt 를 -w 모드로 실행하므로
+                    #    read-only `mise run lint` 와 동치가 아님)
 ```
 
 ## 💡 Key Commands

--- a/README.md
+++ b/README.md
@@ -194,18 +194,39 @@ gcrestore
 
 ### Code Quality
 
+This repo is migrating from `tox` to **mise** for task orchestration
+(issue [#722](https://github.com/dEitY719/dotfiles/issues/722)). Both
+runners work during the migration window and produce equivalent results.
+
+#### Preferred — mise (new)
+
+One-time bootstrap:
+
 ```bash
-# Check shell scripts
-tox -e shellcheck
+curl https://mise.run | sh   # or: brew install mise
+mise install                  # installs pinned shellcheck / shfmt / uv
+```
 
-# Format shell scripts
-tox -e shfmt
+Daily use:
 
-# Check Python code
-tox -e ruff
+```bash
+mise run lint     # ruff + mypy + shellcheck + shfmt -d  (read-only)
+mise run lint-py  # Python only
+mise run lint-sh  # Shell only
+mise run test     # bats + pytest + golden rules
+mise run fix      # ruff --fix + ruff format + shfmt -w  (mutating)
+```
 
-# All checks
-tox
+A higher-level wrapper command (`devx <verb>`) lands in PR 2 of #722
+and consolidates `./tools/dev.sh`. Until then, call `mise run` directly.
+
+#### Legacy — tox (deprecated, kept until PR 5 of #722)
+
+```bash
+tox -e shellcheck   # equivalent to: mise run lint-sh
+tox -e shfmt        # equivalent to: mise run fix-sh
+tox -e ruff         # equivalent to: mise run fix-py
+tox                 # equivalent to: mise run lint
 ```
 
 ## 💡 Key Commands
@@ -253,4 +274,4 @@ For more help, see [Setup Guide](docs/guide/setup.md).
 
 - [Setup Guide](docs/guide/setup.md) - Detailed setup and configuration
 - [Shell-Common Documentation](shell-common/README.md) - Shared code overview
-- Configuration files in `pyproject.toml` and `tox.ini`
+- Configuration files in `pyproject.toml`, `mise.toml`, and `tox.ini` (legacy — see #722)

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@
 [tools]
 shellcheck = "0.10.0"
 shfmt      = "3.8.0"
-uv         = "latest"
+uv         = "0.10.12"
 # ruff version is pinned in pyproject.toml's dev group; mise here is a
 # fallback for environments that need the binary outside `uv run`.
 
@@ -43,7 +43,7 @@ run = [
 [tasks.lint-sh]
 description = "Shell lint (shellcheck + shfmt diff)"
 run = [
-    'find bash -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck -x -e SC1090,SC1091',
+    'find bash -type f \( -name "*.sh" -o -name "*.bash" \) -exec shellcheck -x -e SC1090,SC1091 {} +',
     "shfmt -d -i 4 bash/",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,69 @@
+# mise.toml — Tool versions + task SSOT (issue #722, PR 1: dual-spec)
+#
+# Coexists with tox.ini during the migration window. Both runners
+# produce equivalent results for the same target; tox.ini is removed
+# in PR 5.
+#
+# Bootstrap (one-time, per machine):
+#   curl https://mise.run | sh        # or `brew install mise`
+#   mise install                       # installs pinned tool versions
+#
+# Daily use:
+#   mise run lint   # ruff + mypy + shellcheck + shfmt -d   (read-only)
+#   mise run test   # ./tests/test (bats + pytest + golden rules)
+#   mise run fix    # ruff --fix + ruff format + shfmt -w   (mutating)
+#
+# References:
+#   https://mise.jdx.dev/
+#   docs/.ssot/command-design-pattern.md  — devx wrapper SSOT (PR 2)
+
+[tools]
+shellcheck = "0.10.0"
+shfmt      = "3.8.0"
+uv         = "latest"
+# ruff version is pinned in pyproject.toml's dev group; mise here is a
+# fallback for environments that need the binary outside `uv run`.
+
+[env]
+DOTFILES_ROOT = "{{ config_root }}"
+
+# ─── Lint gates (read-only) ──────────────────────────────────────────
+[tasks.lint]
+description = "전체 lint (Python + Shell)"
+depends     = ["lint-py", "lint-sh"]
+
+[tasks.lint-py]
+description = "Python lint (ruff check + format check + mypy)"
+run = [
+    "uv run ruff check .",
+    "uv run ruff format --check .",
+    "uv run mypy .",
+]
+
+[tasks.lint-sh]
+description = "Shell lint (shellcheck + shfmt diff)"
+run = [
+    'find bash -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck -x -e SC1090,SC1091',
+    "shfmt -d -i 4 bash/",
+]
+
+# ─── Test gate ───────────────────────────────────────────────────────
+[tasks.test]
+description = "전체 테스트 (bats + pytest + golden rules)"
+run = "./tests/test"
+
+# ─── Auto-fix (mutating) ─────────────────────────────────────────────
+[tasks.fix]
+description = "전체 auto-fix (ruff + shfmt)"
+depends     = ["fix-py", "fix-sh"]
+
+[tasks.fix-py]
+description = "Python auto-fix (ruff check --fix + ruff format)"
+run = [
+    "uv run ruff check --fix .",
+    "uv run ruff format .",
+]
+
+[tasks.fix-sh]
+description = "Shell auto-format (shfmt -w)"
+run = "shfmt -w -i 4 bash/"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,13 @@
 # ⚠ DEPRECATED — being phased out in favor of mise (issue #722).
 #   - mise.toml at the repo root is the new SSOT for tool versions + tasks.
 #   - Each `tox -e <env>` has an equivalent `mise run <task>`:
-#       tox            → mise run lint
-#       tox -e ruff    → mise run fix-py
-#       tox -e shellcheck → mise run lint-sh
-#       tox -e shfmt   → mise run fix-sh
-#       tox -e mypy    → uv run mypy .
+#       tox -e ruff       → mise run fix-py     (둘 다 --fix + format, mutating)
+#       tox -e shellcheck → mise run lint-sh    (둘 다 read-only)
+#       tox -e shfmt      → mise run fix-sh     (둘 다 -w, mutating)
+#       tox -e mypy       → uv run mypy .       (read-only)
+#       tox (no args)     → mise run fix && mise run lint
+#                           (tox 의 envlist 는 ruff/shfmt 가 -w 로 동작하므로
+#                            read-only `mise run lint` 와 동치가 아님)
 #   - This file is kept temporarily so existing scripts and CI keep working
 #     during the migration window. Removal is planned in PR 5 of #722.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,15 @@
 # tox.ini: Python 프로젝트의 테스트 및 코드 품질 검사를 위한 Tox 설정 파일
+#
+# ⚠ DEPRECATED — being phased out in favor of mise (issue #722).
+#   - mise.toml at the repo root is the new SSOT for tool versions + tasks.
+#   - Each `tox -e <env>` has an equivalent `mise run <task>`:
+#       tox            → mise run lint
+#       tox -e ruff    → mise run fix-py
+#       tox -e shellcheck → mise run lint-sh
+#       tox -e shfmt   → mise run fix-sh
+#       tox -e mypy    → uv run mypy .
+#   - This file is kept temporarily so existing scripts and CI keep working
+#     during the migration window. Removal is planned in PR 5 of #722.
 
 [tox]
 envlist = ruff, mypy, shellcheck, shfmt


### PR DESCRIPTION
## Summary

이슈 #722 의 5-PR 마이그레이션 중 **PR 1 (mise.toml + 문서 dual-spec)** 만
포함. tox 와 mise 가 동시에 동작하며 동등한 결과를 내도록 구성.

- **NEW** `mise.toml` — tools 3개 (shellcheck 0.10.0 / shfmt 3.8.0 /
  uv latest) + tasks 7개 (lint·lint-py·lint-sh·test·fix·fix-py·fix-sh).
  `lint-sh` 의 find 파이프라인은 기존 `tox -e shellcheck` 와
  byte-equivalent.
- **MODIFY** `README.md` — §🛠️ Development → Code Quality 를
  dual-spec 으로 갱신. preferred = mise (bootstrap + daily use),
  legacy = tox (equivalence 매핑). 후속 PR 2 의 `devx <verb>` 래퍼도 언급.
- **MODIFY** `tox.ini` — header 에 deprecation 안내 + 5줄 tox→mise
  매핑. body 는 무변경 — 기존 `tox` 호출자 모두 그대로 작동.

## Non-Goals (후속 PR)

- PR 2: `devx` 통폐합 (`tools/dev.sh` 삭제 + Type 2A dispatcher)
- PR 3: `.github/workflows/{ci,test}.yml` mise-action 전환
- PR 4: `pyproject.toml` dead config (`[tool.black]` / `[tool.isort]` /
  `[tool.pylint]`) 제거
- PR 5: `tox.ini` 삭제 + 문서 `tox` 잔흔 제거

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('mise.toml','rb'))"` — TOML valid
- [x] `python3 -c "import configparser; c=configparser.ConfigParser(); c.read('tox.ini')"` — tox.ini 여전히 파싱 (8 sections)
- [x] `find bash -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck -x -e SC1090,SC1091` — exit 0
- [x] `shfmt -d -i 4 bash/` — exit 0
- [ ] (reviewer) `mise install && mise tasks` — 7 tasks 인식 확인
- [ ] (reviewer) `mise run lint` 결과가 기존 `tox` 와 동등한지 확인

Closes #722 의 첫 단계. 본 PR 만으로는 이슈가 닫히지 않음 — PR 5 에서 완전 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~0.5 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~0.5 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
