### PR TITLE
fix(skills): #724 helper-fallback "sourced but function undefined" 가드 — defense-in-depth

### DIFF
--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -138,10 +138,20 @@ Skip the board sync entirely when no issue footer was written.
 
 ```bash
 # helper-fallback NF-1 (#644): silent-skip when helper missing.
+# Defense-in-depth (#724): also detect "[ -r ] passes but function never
+# defined" (interactive-guard regression, partial sourcing, future rename).
+# Without this gate `_gh_project_status_sync` would expand to nothing,
+# `command not found` (rc 127) gets absorbed by `|| true`, and the board
+# sync silently no-ops — exactly the failure surfaced in #724.
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
-    _gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog || true
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        printf '[gh-commit] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        _gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog || true
+    fi
 fi
 ```
 

--- a/claude/skills/gh-issue-implement/references/claim.md
+++ b/claude/skills/gh-issue-implement/references/claim.md
@@ -123,7 +123,18 @@ on every projectV2 it belongs to.
 if "GH_ISSUE_SKIP_BOARD_TRANSITION" set:
     return 0
 
-_gh_project_status_sync issue <N> "In progress" --only-from "Backlog,Ready"
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        # Defense-in-depth (#724): sourceable but undefined → silent no-op
+        # without this guard. One-line stderr warning, never blocks.
+        printf '[gh-issue-implement] %s sourced but _gh_project_status_sync undefined — board transition skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        _gh_project_status_sync issue <N> "In progress" --only-from "Backlog,Ready"
+    fi
+fi
 ```
 
 The helper (`shell-common/functions/gh_project_status.sh`) handles:

--- a/claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
@@ -16,10 +16,16 @@ Source the shared helper, then call it with the merged PR number:
 
 ```bash
 # helper-fallback NF-1 (#644): silent-skip when helper missing.
+# Defense-in-depth (#724): also detect "sourced but function undefined".
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
-    _gh_project_status_sync pr <PR_NUMBER> "Done" || true
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        printf '[gh-pr-merge-emergency] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        _gh_project_status_sync pr <PR_NUMBER> "Done" || true
+    fi
 fi
 ```
 

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -70,14 +70,21 @@ on the team's projectV2 board column.
 ```bash
 # Reuse the SSOT query helper — never inline a fresh GraphQL block.
 # helper-fallback NF-1 (#644): silent-skip when helper missing; never hard-fail.
+# Defense-in-depth (#724): a sourced-but-undefined function would let
+# `_gh_project_status_query_current` expand to nothing, BOARD_STATUS would
+# be empty, and the empty-status branch would silently let merges through
+# — bypassing the board approval gate. Detect that case explicitly.
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
 
+    if ! command -v _gh_project_status_query_current >/dev/null 2>&1; then
+        printf '[gh-pr-merge] %s sourced but _gh_project_status_query_current undefined — board approval gate skipped (#724).\n' \
+            "$_HELPER" >&2
     # Operator escape hatch: GH_PR_MERGE_SKIP_BOARD_CHECK=1
     # Use for in-transition repos or one-shot ops (also leaves an audit signal:
     # any reviewer can re-run gh-pr-merge without the env var to verify).
-    if [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
+    elif [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
         BOARD_STATUS=$(GH_REPO="$TARGET_REPO" \
             _gh_project_status_query_current pr "$PR_NUMBER" 2>/dev/null || true)
 
@@ -127,20 +134,26 @@ gating rationale. Two reconciliations run after a successful merge:
 
 ```bash
 # helper-fallback NF-1 (#644): silent-skip when helper missing.
+# Defense-in-depth (#724): also detect "sourced but function undefined".
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
-    GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        printf '[gh-pr-merge] %s sourced but _gh_project_status_sync undefined — Done reconciliations skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
 
-    # (b) Linked Issue cards from `closingIssuesReferences` → `Done`
-    #     (boosts the best-effort `Item closed` builtin per #250). Use the
-    #     `_gh_pr_closing_issue_numbers` helper instead of
-    #     `gh pr view --json closingIssuesReferences` — older `gh` (≤ 2.45)
-    #     rejects that field with "Unknown JSON field" (#264):
-    for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO" 2>/dev/null || true); do
-        GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
-            --only-from "Backlog,In progress,In review" || true
-    done
+        # (b) Linked Issue cards from `closingIssuesReferences` → `Done`
+        #     (boosts the best-effort `Item closed` builtin per #250). Use the
+        #     `_gh_pr_closing_issue_numbers` helper instead of
+        #     `gh pr view --json closingIssuesReferences` — older `gh` (≤ 2.45)
+        #     rejects that field with "Unknown JSON field" (#264):
+        for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO" 2>/dev/null || true); do
+            GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
+                --only-from "Backlog,In progress,In review" || true
+        done
+    fi
 fi
 # helper missing → both reconciliations silently skipped (NF-1).
 ```

--- a/claude/skills/gh-pr-merge/references/project-board-sync.md
+++ b/claude/skills/gh-pr-merge/references/project-board-sync.md
@@ -16,10 +16,16 @@ the merge report — the helper logs to stderr and returns 0.
 
 ```bash
 # helper-fallback NF-1 (#644): silent-skip when helper missing.
+# Defense-in-depth (#724): also detect "sourced but function undefined".
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
-    GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        printf '[gh-pr-merge] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
+    fi
 fi
 ```
 
@@ -54,8 +60,9 @@ query, which is supported across all `gh` versions that ship the
 
 ```bash
 # Wrap inside the same [ -r "$_HELPER" ] block from step (1) so the closing-issue
-# helper is only called after the source succeeded. With the helper missing the
-# entire reconciliation is silently skipped (NF-1).
+# helper is only called after the source succeeded. With the helper missing
+# (NF-1, #644) OR sourced-but-function-undefined (#724) the entire
+# reconciliation is silently skipped — both gates live in step (1).
 for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO" 2>/dev/null || true); do
     GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
         --only-from "Backlog,In progress,In review" || true

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -116,10 +116,14 @@ Soft-fail — warn on any error, never block the Step 7 report.
 ```bash
 if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
     # helper-fallback NF-1 (#644): silent-skip when helper missing.
+    # Defense-in-depth (#724): also detect "sourced but function undefined".
     _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
     if [ -r "$_HELPER" ]; then
         . "$_HELPER"
-        if _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+            printf '[gh-pr-reply] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+                "$_HELPER" >&2
+        elif _gh_project_status_sync pr "$PR_NUMBER" "In review" \
                 --only-from "In progress,Changes requested"; then
             echo "[OK] PR 카드 \`In review\` 로 복귀됨"
         else

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -136,11 +136,25 @@ warning (idempotent).
 
 ```bash
 if [ "$MERGEABLE" = "MERGEABLE" ]; then
-    . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh" 2>/dev/null \
-      && _gh_project_status_sync pr "$PR_NUMBER" "In review" \
-            --only-from "In progress,Changes requested" \
-      && echo "[OK] PR 카드 \`In review\` 로 복귀됨" \
-      || echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+    # Defense-in-depth (#724): the chained-`&&` form below silently no-ops
+    # when the helper sources but never defines `_gh_project_status_sync`
+    # (interactive-guard regression, partial source). Split into an
+    # explicit guard so the failure prints a stderr warning instead of
+    # collapsing into the `|| echo [WARN]` branch (which falsely suggests
+    # a board sync was attempted).
+    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        . "$_HELPER"
+        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+            printf '[gh-pr-resolve-conflict] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+                "$_HELPER" >&2
+        elif _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+                --only-from "In progress,Changes requested"; then
+            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
+        else
+            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+        fi
+    fi
 fi
 ```
 

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -62,14 +62,23 @@ Source the shared helper, then call it with the new PR number:
 
 ```bash
 # helper-fallback NF-1 (#644): silent-skip when helper missing.
+# Defense-in-depth (#724): also detect "[ -r ] passes but function never
+# defined" (interactive-guard regression, partial sourcing, future rename).
+# `|| true` would otherwise absorb `command not found` (rc 127) and the
+# entire reconciliation would silently no-op — the failure mode from #724.
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
-    _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
-    for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
-        _gh_project_status_sync issue "$_issue" "In progress" \
-            --only-from "Backlog,Ready,In review" || true
-    done
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        printf '[gh-pr] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
+        for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
+            _gh_project_status_sync issue "$_issue" "In progress" \
+                --only-from "Backlog,Ready,In review" || true
+        done
+    fi
 fi
 ```
 

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -199,3 +199,15 @@ _gh_pr_edit_safe_body() {
     rm -f "$_err"
     return 1
 }
+
+# Self-check (issue #724): catch silent breakage where this file sources
+# cleanly but its public wrappers never get defined — interactive-guard
+# regression, syntax error mid-file, future rename. Without these wrappers
+# label / body edits fall back to plain `gh pr edit`, which silently exits 1
+# on repos with classic Projects attached (the original #326 bug this helper
+# was written to absorb). rc stays 0 — best-effort contract preserved.
+if ! command -v _gh_pr_edit_safe_label >/dev/null 2>&1 \
+    || ! command -v _gh_pr_edit_safe_body >/dev/null 2>&1; then
+    printf '[gh_pr_edit_safe] BUG: _gh_pr_edit_safe_{label,body} undefined after source — PR edit safe-fallback will silently no-op. See dotfiles #724.\n' >&2
+fi
+:

--- a/shell-common/functions/gh_pr_lint.sh
+++ b/shell-common/functions/gh_pr_lint.sh
@@ -224,3 +224,14 @@ EOF
     unset _base _changed _ran_any _failed
     return 0
 }
+
+# Self-check (issue #724): catch silent breakage where this file is sourceable
+# but `_gh_pr_lint_run` never gets defined — interactive-guard regression,
+# syntax error inside a function block, future rename. Mirrors the guard in
+# gh_project_status.sh so the same "[ -r ] passes but the function vanishes"
+# failure mode does not slip through the /gh-pr pre-push lint gate. rc stays
+# 0 — the lint gate's best-effort contract is preserved.
+if ! command -v _gh_pr_lint_run >/dev/null 2>&1; then
+    printf '[gh_pr_lint] BUG: _gh_pr_lint_run undefined after source — pre-push lint will silently no-op. See dotfiles #724.\n' >&2
+fi
+:

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -429,3 +429,17 @@ _gh_project_status_in_list() {
     esac
     return 1
 }
+
+# Self-check (issue #724): catch silent breakage where this file is sourceable
+# but the canonical entry point never gets defined — interactive-guard
+# regression, syntax error inside a function block, future rename without
+# updating callers, partial sourcing in a foreign env. Callers like
+# /gh-commit and /gh-pr source the file then invoke the function with
+# `|| true`, which absorbs `command not found` (rc 127) into a silent no-op
+# and hides the breakage from the operator. Prints one stderr line; rc
+# stays 0 so the helper's best-effort contract with `|| true` callers is
+# preserved.
+if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+    printf '[gh_project_status] BUG: _gh_project_status_sync undefined after source — board sync will silently no-op. See dotfiles #724.\n' >&2
+fi
+:

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -431,7 +431,7 @@ _gh_project_status_in_list() {
 }
 
 # Self-check (issue #724): catch silent breakage where this file is sourceable
-# but the canonical entry point never gets defined — interactive-guard
+# but a canonical entry point never gets defined — interactive-guard
 # regression, syntax error inside a function block, future rename without
 # updating callers, partial sourcing in a foreign env. Callers like
 # /gh-commit and /gh-pr source the file then invoke the function with
@@ -439,7 +439,17 @@ _gh_project_status_in_list() {
 # and hides the breakage from the operator. Prints one stderr line; rc
 # stays 0 so the helper's best-effort contract with `|| true` callers is
 # preserved.
-if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-    printf '[gh_project_status] BUG: _gh_project_status_sync undefined after source — board sync will silently no-op. See dotfiles #724.\n' >&2
+#
+# Three public entry points are checked (matches the multi-function pattern
+# in gh_pr_edit_safe.sh):
+#   - _gh_project_status_sync          (write API; used by every gh-* skill)
+#   - _gh_project_status_query_current (read API; gh-pr-merge Step 2-B gate)
+#   - _gh_pr_closing_issue_numbers     (PR→issue link; gh-pr, gh-pr-merge)
+# If any one is missing the helper is broken as a whole — fail loudly.
+# Per gemini-code-assist review on PR #725.
+if ! command -v _gh_project_status_sync >/dev/null 2>&1 \
+    || ! command -v _gh_project_status_query_current >/dev/null 2>&1 \
+    || ! command -v _gh_pr_closing_issue_numbers >/dev/null 2>&1; then
+    printf '[gh_project_status] BUG: public functions undefined after source — board sync / closing-issue link will silently no-op. See dotfiles #724.\n' >&2
 fi
 :

--- a/tests/bats/functions/gh_pr_edit_safe.bats
+++ b/tests/bats/functions/gh_pr_edit_safe.bats
@@ -269,3 +269,71 @@ _run_helper() {
     assert_output --partial "rc=1"
     assert_output --partial "REST POST failed"
 }
+
+# ---------------------------------------------------------------------------
+# Self-check (#724) — "helper present but wrappers undefined" canary.
+# Codex review on PR #725 flagged the gap: gh_pr_edit_safe.sh grew a
+# multi-function self-check (verifies BOTH `_gh_pr_edit_safe_label` and
+# `_gh_pr_edit_safe_body`) but there were no Bats cases proving (a) the
+# warning stays silent on a healthy source and (b) it fires when either
+# wrapper is undefined post-source.
+# ---------------------------------------------------------------------------
+
+@test "self-check (#724): healthy gh_pr_edit_safe source emits no BUG warning" {
+    # Sanity: sourcing the real helper defines both wrappers; the tail
+    # self-check should see both `command -v` checks succeed and stay
+    # silent. Catches a future regression where the warning fires on
+    # the happy path (false positive).
+    run bash --noprofile --norc -c \
+        ". \"${SHELL_COMMON}/functions/gh_pr_edit_safe.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "BUG: _gh_pr_edit_safe_"
+}
+
+@test "self-check (#724): regressed gh_pr_edit_safe (no wrappers) prints warning" {
+    # Synthesize the failure mode #724 targets: future regression leaves
+    # the file sourceable but neither wrapper gets defined. The tail
+    # self-check MUST print a stderr warning while keeping rc 0 so
+    # caller's `||` chains stay intact.
+    cat >"$BATS_TEST_TMPDIR/regressed_edit_safe.sh" <<'STUB'
+#!/bin/sh
+# Simulate: future regression — both wrappers never get defined.
+# Trailing self-check (copied verbatim from gh_pr_edit_safe.sh tail):
+if ! command -v _gh_pr_edit_safe_label >/dev/null 2>&1 \
+    || ! command -v _gh_pr_edit_safe_body >/dev/null 2>&1; then
+    printf '[gh_pr_edit_safe] BUG: _gh_pr_edit_safe_{label,body} undefined after source — PR edit safe-fallback will silently no-op. See dotfiles #724.\n' >&2
+fi
+:
+STUB
+    run bash --noprofile --norc -c \
+        ". \"$BATS_TEST_TMPDIR/regressed_edit_safe.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial \
+        "BUG: _gh_pr_edit_safe_{label,body} undefined after source"
+}
+
+@test "self-check (#724): partial wrappers (label only) still triggers warning" {
+    # Multi-function check must catch the case where ONE wrapper is
+    # defined but the other isn't (typo / partial sourcing). Defines
+    # only `_gh_pr_edit_safe_label`; the `||` between the two
+    # `command -v` clauses MUST fire on the missing `_body`.
+    cat >"$BATS_TEST_TMPDIR/partial_edit_safe.sh" <<'STUB'
+#!/bin/sh
+# Define label wrapper only — body wrapper is missing.
+_gh_pr_edit_safe_label() { return 0; }
+# Trailing self-check (copied verbatim from gh_pr_edit_safe.sh tail):
+if ! command -v _gh_pr_edit_safe_label >/dev/null 2>&1 \
+    || ! command -v _gh_pr_edit_safe_body >/dev/null 2>&1; then
+    printf '[gh_pr_edit_safe] BUG: _gh_pr_edit_safe_{label,body} undefined after source — PR edit safe-fallback will silently no-op. See dotfiles #724.\n' >&2
+fi
+:
+STUB
+    run bash --noprofile --norc -c \
+        ". \"$BATS_TEST_TMPDIR/partial_edit_safe.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial \
+        "BUG: _gh_pr_edit_safe_{label,body} undefined after source"
+}

--- a/tests/bats/functions/gh_pr_lint.bats
+++ b/tests/bats/functions/gh_pr_lint.bats
@@ -285,3 +285,45 @@ TOX
     assert_output --partial "shellcheck FAILED"
     assert_output --partial "GH_PR_LINT_BYPASS=1"
 }
+
+# ---------------------------------------------------------------------------
+# Self-check (#724) — "helper present but function undefined" canary.
+# Codex review on PR #725 flagged the gap: gh_pr_lint.sh grew the same
+# trailing self-check as gh_project_status.sh, but there were no Bats
+# cases proving (a) the warning stays silent on a healthy source and
+# (b) it fires when `_gh_pr_lint_run` is undefined post-source.
+# ---------------------------------------------------------------------------
+
+@test "self-check (#724): healthy gh_pr_lint source emits no BUG warning" {
+    # Sanity: sourcing the real helper defines `_gh_pr_lint_run`.
+    # The tail self-check should see `command -v` succeed and stay
+    # silent — guards against a false-positive warning on the happy
+    # path.
+    run bash --noprofile --norc -c \
+        ". \"${SHELL_COMMON}/functions/gh_pr_lint.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "BUG: _gh_pr_lint_run undefined"
+}
+
+@test "self-check (#724): regressed gh_pr_lint helper triggers stderr warning" {
+    # Synthesize the failure mode #724 targets: future regression (typo,
+    # rename, interactive-guard early-return) leaves the file sourceable
+    # but `_gh_pr_lint_run` undefined. The tail self-check MUST print a
+    # stderr warning while keeping rc 0 so caller's `||` chains stay
+    # intact.
+    cat >"$BATS_TEST_TMPDIR/regressed_lint.sh" <<'STUB'
+#!/bin/sh
+# Simulate: future regression — _gh_pr_lint_run never gets defined.
+# Trailing self-check (copied verbatim from gh_pr_lint.sh tail):
+if ! command -v _gh_pr_lint_run >/dev/null 2>&1; then
+    printf '[gh_pr_lint] BUG: _gh_pr_lint_run undefined after source — pre-push lint will silently no-op. See dotfiles #724.\n' >&2
+fi
+:
+STUB
+    run bash --noprofile --norc -c \
+        ". \"$BATS_TEST_TMPDIR/regressed_lint.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "BUG: _gh_pr_lint_run undefined after source"
+}

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -694,3 +694,43 @@ _run_full_bash() {
     [ "$(grep -c '^pr-view$' "$FAKE_GH_LOG")" -eq 0 ]
     [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
 }
+
+# ---------------------------------------------------------------------------
+# Self-check (#724) — "helper present but function undefined" canary
+# ---------------------------------------------------------------------------
+
+@test "self-check (#724): healthy source emits no BUG warning to stderr" {
+    # Sanity: the real helper defines `_gh_project_status_sync`. The
+    # tail-of-file self-check should see `command -v` succeed and stay
+    # silent. Catches future regressions where the warning fires on
+    # the happy path (false positive).
+    run bash --noprofile --norc -c \
+        ". \"${SHELL_COMMON}/functions/gh_project_status.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "BUG: _gh_project_status_sync undefined"
+}
+
+@test "self-check (#724): typo'd/missing function still triggers stderr warning" {
+    # Synthesize the failure mode that #724 documents: a helper file
+    # whose top-level guards / typos / partial sourcing prevent the
+    # canonical function from ever getting defined. The self-check
+    # snippet (mirroring the trailer in gh_project_status.sh) MUST
+    # print a stderr warning and the file MUST still return rc 0 so
+    # callers' `|| true` chains stay intact.
+    cat >"$BATS_TEST_TMPDIR/regressed_helper.sh" <<'STUB'
+#!/bin/sh
+# Simulate: future regression — function definition removed/renamed.
+# Trailing self-check (copied verbatim from gh_project_status.sh tail):
+if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+    printf '[gh_project_status] BUG: _gh_project_status_sync undefined after source — board sync will silently no-op. See dotfiles #724.\n' >&2
+fi
+:
+STUB
+    run bash --noprofile --norc -c \
+        ". \"$BATS_TEST_TMPDIR/regressed_helper.sh\" 2>&1; echo \"rc=\$?\""
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial \
+        "BUG: _gh_project_status_sync undefined after source"
+}

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -700,30 +700,35 @@ _run_full_bash() {
 # ---------------------------------------------------------------------------
 
 @test "self-check (#724): healthy source emits no BUG warning to stderr" {
-    # Sanity: the real helper defines `_gh_project_status_sync`. The
-    # tail-of-file self-check should see `command -v` succeed and stay
-    # silent. Catches future regressions where the warning fires on
-    # the happy path (false positive).
+    # Sanity: the real helper defines all three public entry points.
+    # The tail-of-file self-check should see `command -v` succeed for
+    # each and stay silent. Catches future regressions where the
+    # warning fires on the happy path (false positive).
     run bash --noprofile --norc -c \
         ". \"${SHELL_COMMON}/functions/gh_project_status.sh\" 2>&1; echo \"rc=\$?\""
     assert_success
     assert_output --partial "rc=0"
-    refute_output --partial "BUG: _gh_project_status_sync undefined"
+    refute_output --partial "BUG: public functions undefined"
 }
 
 @test "self-check (#724): typo'd/missing function still triggers stderr warning" {
     # Synthesize the failure mode that #724 documents: a helper file
     # whose top-level guards / typos / partial sourcing prevent the
-    # canonical function from ever getting defined. The self-check
+    # canonical functions from ever getting defined. The self-check
     # snippet (mirroring the trailer in gh_project_status.sh) MUST
     # print a stderr warning and the file MUST still return rc 0 so
-    # callers' `|| true` chains stay intact.
+    # callers' `|| true` chains stay intact. Per gemini-code-assist
+    # review on PR #725 the canary covers three public entry points
+    # (sync / query_current / closing_issue_numbers); the bare stub
+    # below leaves all three undefined.
     cat >"$BATS_TEST_TMPDIR/regressed_helper.sh" <<'STUB'
 #!/bin/sh
-# Simulate: future regression — function definition removed/renamed.
+# Simulate: future regression — every public function removed/renamed.
 # Trailing self-check (copied verbatim from gh_project_status.sh tail):
-if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-    printf '[gh_project_status] BUG: _gh_project_status_sync undefined after source — board sync will silently no-op. See dotfiles #724.\n' >&2
+if ! command -v _gh_project_status_sync >/dev/null 2>&1 \
+    || ! command -v _gh_project_status_query_current >/dev/null 2>&1 \
+    || ! command -v _gh_pr_closing_issue_numbers >/dev/null 2>&1; then
+    printf '[gh_project_status] BUG: public functions undefined after source — board sync / closing-issue link will silently no-op. See dotfiles #724.\n' >&2
 fi
 :
 STUB
@@ -732,5 +737,5 @@ STUB
     assert_success
     assert_output --partial "rc=0"
     assert_output --partial \
-        "BUG: _gh_project_status_sync undefined after source"
+        "BUG: public functions undefined after source"
 }


### PR DESCRIPTION
## Summary

- helper-fallback NF-1 (#644) 의 `[ -r "$_HELPER" ]` 가드는 helper 파일 존재만 검사하고 *함수 등록 여부* 는 보지 않음. 함수 미정의 시 caller 의 `|| true` 가 `command not found` (rc 127) 을 흡수해 보드 sync 가 조용히 누락되는 #720 회귀의 silent 면을 닫음 (#724).
- **Defense-in-depth (Option C)** 두 레이어 동시 적용:
  - **Helper-side self-check** — `gh_project_status.sh` / `gh_pr_lint.sh` / `gh_pr_edit_safe.sh` 끝부분에 canonical 함수 정의 self-check + stderr 한 줄 경고 (rc 0 유지). 향후 typo / rename / partial sourcing 캐치.
  - **Skill-side `command -v` gate** — `gh-commit` / `gh-pr-reply` / `gh-pr-resolve-conflict` / `gh-pr-merge` / `gh-pr-merge-emergency` / `gh-pr` / `gh-issue-implement` 의 helper-fallback 블록을 `. "$_HELPER"` 직후 `command -v` 로 게이팅. 함수 미정의 시 stderr 경고 후 silent skip — 메인 플로우 차단 안 함. 인터랙티브 가드 회귀 즉시 감지.
- **bats coverage** — `gh_project_status.bats` 에 "helper present + function undefined" 케이스 2개 추가 (healthy source 무경고 / 함수 미정의 helper 경고 발화). 50/50 pass.

## Changed files (12)

`shell-common/functions/{gh_project_status,gh_pr_lint,gh_pr_edit_safe}.sh` · `claude/skills/gh-commit/SKILL.md` · `claude/skills/gh-issue-implement/references/claim.md` · `claude/skills/gh-pr-merge-emergency/references/project-board-sync.md` · `claude/skills/gh-pr-merge/SKILL.md` · `claude/skills/gh-pr-merge/references/project-board-sync.md` · `claude/skills/gh-pr-reply/SKILL.md` · `claude/skills/gh-pr-resolve-conflict/SKILL.md` · `claude/skills/gh-pr/references/project-board-sync.md` · `tests/bats/functions/gh_project_status.bats`

## Test plan

- [x] `shellcheck -x` clean on 3 modified helpers.
- [x] `tox -e shellcheck` / `tox -e shfmt-check` green.
- [x] `bats tests/bats/functions/gh_project_status.bats` — 50/50 pass (2 신규 self-check 케이스 포함).
- [x] `bats tests/bats/functions/` 전체 — 645 tests, 3 pre-existing 실패 (main 에서도 동일 실패: claude_stop_hook_install / cleanup prune help / git status help — 본 PR 과 무관).
- [x] `pytest` — 1011 pass / 20 pre-existing 실패 (`gc_help` / `gwt_help` 미구현, main 에서도 동일).
- [x] 회귀 시뮬레이션: 함수 미정의 helper 를 source 하면 `[gh_project_status] BUG: _gh_project_status_sync undefined after source` stderr + rc 0 — bats 가 검증.

Closes #724

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
