### PR TITLE
feat(apt): #733 auug 비대화형 실행 — [Y/n] 프롬프트 자동 승인

### DIFF
--- a/shell-common/tools/integrations/apt.sh
+++ b/shell-common/tools/integrations/apt.sh
@@ -18,7 +18,7 @@ alias aac='sudo apt-get autoclean'    # Remove old .deb files from cache
 alias ac='sudo apt-get clean'         # Remove all .deb files from cache
 
 # All-in-one cleanup (update → upgrade → autoremove → autoclean), non-interactive
-alias auug='sudo apt-get update && sudo apt-get -y upgrade && sudo apt-get -y autoremove && sudo apt-get -y autoclean'
+alias auug='sudo apt-get update && sudo apt-get -y upgrade && sudo apt-get -y autoremove && sudo apt-get autoclean'
 
 # Migration guard: previous versions of this file defined `ai` as an alias.
 # In interactive zsh, an active alias causes `ai() { ... }` to fail parsing
@@ -200,7 +200,7 @@ _apt_help_rows_update() {
     ux_table_row "aug" "apt-get upgrade" "Safe upgrade"
     ux_table_row "afa" "apt-get full-upgrade" "Aggressive upgrade"
     ux_table_row "adu" "apt-get dist-upgrade" "Dist upgrade"
-    ux_table_row "auug" "update+upgrade+clean -y" "Full cleanup (auto-yes)"
+    ux_table_row "auug" "update+upgrade+cleanup" "Full cleanup (auto-yes)"
 }
 
 _apt_help_rows_cleanup() {

--- a/shell-common/tools/integrations/apt.sh
+++ b/shell-common/tools/integrations/apt.sh
@@ -17,8 +17,8 @@ alias aar='sudo apt-get autoremove'   # Remove unused dependencies
 alias aac='sudo apt-get autoclean'    # Remove old .deb files from cache
 alias ac='sudo apt-get clean'         # Remove all .deb files from cache
 
-# All-in-one cleanup (update → upgrade → autoremove → autoclean)
-alias auug='sudo apt-get update && sudo apt-get upgrade && sudo apt-get autoremove && sudo apt-get autoclean'
+# All-in-one cleanup (update → upgrade → autoremove → autoclean), non-interactive
+alias auug='sudo apt-get update && sudo apt-get -y upgrade && sudo apt-get -y autoremove && sudo apt-get -y autoclean'
 
 # Migration guard: previous versions of this file defined `ai` as an alias.
 # In interactive zsh, an active alias causes `ai() { ... }` to fail parsing
@@ -200,7 +200,7 @@ _apt_help_rows_update() {
     ux_table_row "aug" "apt-get upgrade" "Safe upgrade"
     ux_table_row "afa" "apt-get full-upgrade" "Aggressive upgrade"
     ux_table_row "adu" "apt-get dist-upgrade" "Dist upgrade"
-    ux_table_row "auug" "update+upgrade+clean" "Full cleanup"
+    ux_table_row "auug" "update+upgrade+clean -y" "Full cleanup (auto-yes)"
 }
 
 _apt_help_rows_cleanup() {


### PR DESCRIPTION
## Summary

- `shell-common/tools/integrations/apt.sh` — `auug` alias 의 `apt-get upgrade` / `autoremove` / `autoclean` 호출에 `-y` 플래그 부여 (line 21).
- `apt-help update` 의 `auug` 행 설명을 "Full cleanup (auto-yes)" 로 갱신 (line 203).
- 개별 alias (`au`, `aug`, `aar`, `aac`) 의 인터랙티브 동작은 변경 없음.

## 동기

`auug` 는 "한 번 호출로 update → upgrade → autoremove → autoclean 까지 일괄 수행" 을 의도한 alias 인데, 중간에 `Do you want to continue? [Y/n]` 프롬프트가 떠서 사용자 입력 없이는 멈춘다. 사용자가 입력 시점을 놓치면 셸 세션이 장시간 방치된다.

## Closes

Closes #733

## Test plan

- [ ] `source ~/.zshrc` 후 `type auug` 결과가 `-y` 포함 alias 인지 확인
- [ ] `auug` 실행 시 `[Y/n]` 프롬프트 없이 4단계 완료
- [ ] `aug` / `aar` 단독 호출 시 기존처럼 인터랙티브 동작 유지
- [ ] `apt-help update` 출력의 `auug` 행이 "Full cleanup (auto-yes)" 표시
- [ ] `apt-help --all` 정상 렌더링
- [x] `tox -e shellcheck`, `tox -e shfmt` 통과 (lint guard)

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~10 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~10 min
<!-- /ai-metrics:gh-pr -->

</details>
