### PR TITLE
fix(zsh): #735 bun completion 하드코딩 home path → $HOME 로 portable 화

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -35,6 +35,7 @@
     "codex@openai-codex": true
   },
   "skipDangerousModePermissionPrompt": true,
+  "theme": "dark",
   "telemetry": {
     "enabled": false
   }

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -134,3 +134,10 @@ fi
 if command -v fasd &>/dev/null; then
     eval "$(fasd --init auto)"
 fi
+
+# bun completions
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"


### PR DESCRIPTION
## Summary
- bun installer 가 `zsh/zshrc` 끝에 append 한 completion 라인의 하드코딩된 `/home/deity719/.bun/_bun` 경로를 `$HOME/.bun/_bun` 으로 치환하여 multi-PC portability 복구.
- 함께 누락되어 있던 `claude/settings.json` 의 `theme: dark` SSOT drift 정리.

## Changes
- **zsh/zshrc**: bun completion 라인 `[ -s "/home/deity719/.bun/_bun" ]` → `[ -s "$HOME/.bun/_bun" ]`. `BUN_INSTALL`/`PATH` 라인은 이미 `$HOME` 기반이라 그대로 추가.
- **claude/settings.json**: `"theme": "dark"` 추가 — 모든 PC 에 일관 적용.

## Test plan
- [x] `tox -e ruff,shellcheck,shfmt` 통과 (lint guard)
- [ ] Home PC: `zsh -ic '[ -s "$HOME/.bun/_bun" ] && echo loaded'` → `loaded`
- [ ] 다른 username PC 에서 pull 후 bun completion 자동 로드 확인
- [ ] Claude Code 재기동 시 dark theme 적용 확인

## Related
Closes #735

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>

