### PR TITLE
fix(zsh): #737 bun installer 재오염 차단 — pre-commit guard + ~/.zshrc.local 분리

### DIFF
--- a/git/hooks/checks/hardcoded_home_path_check.sh
+++ b/git/hooks/checks/hardcoded_home_path_check.sh
@@ -43,11 +43,14 @@ check_hardcoded_home_path() {
         return 0
     }
 
-    # Pattern: `/home/<segment>/` or `/Users/<segment>/`. <segment> excludes
-    # `$` (placeholder) and `{` (already-quoted ${HOME}) so we never flag a
-    # template, only resolved values.
+    # Pattern: `/home/<segment>` or `/Users/<segment>`. <segment> is one or
+    # more name chars; the trailing `/` is intentionally NOT required so
+    # `export MY_HOME=/home/user` (no slash, no following path) is also
+    # caught (gemini-code-assist review on PR #738). `awk -v pfx=...`
+    # embeds the file name directly into the printf so a downstream sed
+    # rewrite is unnecessary and whitespace in $0 stays safe.
     local hits
-    hits=$(awk '
+    hits=$(awk -v pfx="$repo_rel_path" '
         {
             line = $0
             # Skip pure comment lines (first non-blank char is #)
@@ -55,9 +58,9 @@ check_hardcoded_home_path() {
             # Skip explicit allowlist
             if (line ~ /# allow-abs-home/) next
             # Match resolved home paths
-            if (line ~ /\/home\/[A-Za-z0-9._-]+\// ||
-                line ~ /\/Users\/[A-Za-z0-9._-]+\//) {
-                printf "%d:%s\n", NR, line
+            if (line ~ /\/home\/[A-Za-z0-9._-]+/ ||
+                line ~ /\/Users\/[A-Za-z0-9._-]+/) {
+                printf "    %s:%d:%s\n", pfx, NR, line
             }
         }
     ' "$tmp_file" 2>/dev/null || true)
@@ -73,7 +76,7 @@ check_hardcoded_home_path() {
         echo "  Use \$HOME or ~ instead. If the path is intentional, add"
         echo "  '# allow-abs-home' on the same line."
         echo "  Matches:"
-        echo "$hits" | sed "s|^|    $repo_rel_path:|"
+        echo "$hits"
         echo ""
     } >>"$output_file"
 

--- a/git/hooks/checks/hardcoded_home_path_check.sh
+++ b/git/hooks/checks/hardcoded_home_path_check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# git/hooks/checks/hardcoded_home_path_check.sh
+#
+# Blocks staged shell config files that contain a hardcoded absolute home
+# path like `/home/<user>/...` or `/Users/<user>/...`. Triggered by issue
+# #737 — bun installer re-appends `/home/deity719/.bun/_bun` to `zsh/zshrc`
+# on every run, silently breaking multi-PC portability after PR #736's
+# one-shot normalization.
+#
+# Scope (staged files only):
+#   bash/        zsh/        shell-common/
+#   plus top-level dotfiles: zshrc, bashrc, profile (if ever tracked)
+#
+# Exclusions:
+#   *.md       (docs may quote example paths)
+#   tests/     (fixtures often hardcode tmpdir-shaped paths)
+#   docs/      (same)
+#   lines that start with `#` (comments / heredoc markers)
+#   lines with the `# allow-abs-home` escape marker on the same line
+
+check_hardcoded_home_path() {
+    local repo_root="$1"
+    local tmpdir="$2"
+    local repo_rel_path="$3"
+    local output_file="$4"
+
+    case "$repo_rel_path" in
+        bash/* | zsh/* | shell-common/*) ;;
+        zshrc | bashrc | profile) ;;
+        *) return 0 ;;
+    esac
+
+    case "$repo_rel_path" in
+        *.md) return 0 ;;
+        tests/* | */tests/*) return 0 ;;
+        docs/* | */docs/*) return 0 ;;
+    esac
+
+    local tmp_file
+    tmp_file=$(mktemp "$tmpdir/abs_home_stage_XXXXXX.txt")
+    write_staged_or_worktree_to_tmp "$repo_root" "$repo_rel_path" "$tmp_file" 2>/dev/null || {
+        rm -f "$tmp_file"
+        return 0
+    }
+
+    # Pattern: `/home/<segment>/` or `/Users/<segment>/`. <segment> excludes
+    # `$` (placeholder) and `{` (already-quoted ${HOME}) so we never flag a
+    # template, only resolved values.
+    local hits
+    hits=$(awk '
+        {
+            line = $0
+            # Skip pure comment lines (first non-blank char is #)
+            if (line ~ /^[[:space:]]*#/) next
+            # Skip explicit allowlist
+            if (line ~ /# allow-abs-home/) next
+            # Match resolved home paths
+            if (line ~ /\/home\/[A-Za-z0-9._-]+\// ||
+                line ~ /\/Users\/[A-Za-z0-9._-]+\//) {
+                printf "%d:%s\n", NR, line
+            }
+        }
+    ' "$tmp_file" 2>/dev/null || true)
+
+    rm -f "$tmp_file"
+
+    if [ -z "$hits" ]; then
+        return 0
+    fi
+
+    {
+        echo "$repo_rel_path: [BLOCKING] Hardcoded absolute home path"
+        echo "  Use \$HOME or ~ instead. If the path is intentional, add"
+        echo "  '# allow-abs-home' on the same line."
+        echo "  Matches:"
+        echo "$hits" | sed "s|^|    $repo_rel_path:|"
+        echo ""
+    } >>"$output_file"
+
+    return 1
+}

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -61,8 +61,9 @@ HELP_INTEGRITY_VIOLATIONS_FILE=$(mktemp "$TMPDIR/help_integrity_violations_XXXXX
 DIRECT_EXEC_GUARD_FILE=$(mktemp "$TMPDIR/direct_exec_guard_XXXXXX.txt")
 SHELLCHECK_VIOLATIONS_FILE=$(mktemp "$TMPDIR/shellcheck_violations_XXXXXX.txt")
 GH_API_TYPE_FILE=$(mktemp "$TMPDIR/gh_api_type_XXXXXX.txt")
+ABS_HOME_VIOLATIONS_FILE=$(mktemp "$TMPDIR/abs_home_XXXXXX.txt")
 
-trap 'rm -f "$VIOLATIONS_FILE" "$FUNC_VIOLATIONS_FILE" "$SHEBANG_VIOLATIONS_FILE" "$SUBSHELL_VIOLATIONS_FILE" "$PIPE_LOOP_VIOLATIONS_FILE" "$ZSH_EMULATION_FILE" "$ALIAS_CONFLICT_FILE" "$ALIAS_LOCATION_FILE" "$WRAPPER_VIOLATIONS_FILE" "$CUSTOM_TOOLS_SOURCING_FILE" "$AUTO_EXEC_CUSTOM_FILE" "$AUTO_EXEC_SOURCED_FILE" "$PURITY_VIOLATIONS_FILE" "$BACKUP_FILES_FILE" "$HELP_INTEGRITY_VIOLATIONS_FILE" "$DIRECT_EXEC_GUARD_FILE" "$SHELLCHECK_VIOLATIONS_FILE" "$GH_API_TYPE_FILE"' EXIT
+trap 'rm -f "$VIOLATIONS_FILE" "$FUNC_VIOLATIONS_FILE" "$SHEBANG_VIOLATIONS_FILE" "$SUBSHELL_VIOLATIONS_FILE" "$PIPE_LOOP_VIOLATIONS_FILE" "$ZSH_EMULATION_FILE" "$ALIAS_CONFLICT_FILE" "$ALIAS_LOCATION_FILE" "$WRAPPER_VIOLATIONS_FILE" "$CUSTOM_TOOLS_SOURCING_FILE" "$AUTO_EXEC_CUSTOM_FILE" "$AUTO_EXEC_SOURCED_FILE" "$PURITY_VIOLATIONS_FILE" "$BACKUP_FILES_FILE" "$HELP_INTEGRITY_VIOLATIONS_FILE" "$DIRECT_EXEC_GUARD_FILE" "$SHELLCHECK_VIOLATIONS_FILE" "$GH_API_TYPE_FILE" "$ABS_HOME_VIOLATIONS_FILE"' EXIT
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Load check modules
@@ -96,6 +97,7 @@ source_check_or_exit "${CHECKS_DIR}/auto_execution_check.sh"
 source_check_or_exit "${CHECKS_DIR}/direct_exec_guard_check.sh"
 source_check_or_exit "${CHECKS_DIR}/shellcheck_check.sh"
 source_check_or_exit "${CHECKS_DIR}/gh_api_type_check.sh"
+source_check_or_exit "${CHECKS_DIR}/hardcoded_home_path_check.sh"
 source_check_or_exit "${CHECKS_DIR}/main_branch_guard.sh"
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -147,6 +149,7 @@ help_integrity_violations=0
 direct_exec_guard_violations=0
 shellcheck_violations=0
 gh_api_type_violations=0
+abs_home_violations=0
 
 # 1) Shebang consistency for staged .sh files under shell-common/bash/zsh
 while IFS= read -r file; do
@@ -272,6 +275,13 @@ while IFS= read -r file; do
     fi
 done <<<"$STAGED_FILES"
 
+# 9) Hardcoded absolute home path guard (issue #737)
+while IFS= read -r file; do
+    if ! check_hardcoded_home_path "$REPO_ROOT" "$TMPDIR" "$file" "$ABS_HOME_VIOLATIONS_FILE" 2>/dev/null; then
+        ((abs_home_violations++))
+    fi
+done <<<"$STAGED_FILES"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Reporting and exit logic
 # ═══════════════════════════════════════════════════════════════════════════
@@ -280,7 +290,7 @@ echo ""
 echo -e "${BLUE}Pre-commit validation (staged files only)${NC}"
 echo ""
 
-blocking_violations=$((shebang_violations + naming_violations + function_naming_violations + alias_conflict_violations + alias_location_violations + custom_tools_sourcing_violations + auto_exec_custom_violations + auto_exec_sourced_violations + library_purity_violations + help_integrity_violations + direct_exec_guard_violations + pipe_loop_violations + shellcheck_violations))
+blocking_violations=$((shebang_violations + naming_violations + function_naming_violations + alias_conflict_violations + alias_location_violations + custom_tools_sourcing_violations + auto_exec_custom_violations + auto_exec_sourced_violations + library_purity_violations + help_integrity_violations + direct_exec_guard_violations + pipe_loop_violations + shellcheck_violations + abs_home_violations))
 warning_count=$((subshell_violations + wrapper_violations + ux_violations + backup_files_found + gh_api_type_violations))
 
 if [ $blocking_violations -eq 0 ]; then
@@ -428,6 +438,13 @@ if [ $pipe_loop_violations -gt 0 ] && [ -s "$PIPE_LOOP_VIOLATIONS_FILE" ]; then
     echo -e "${RED}[BLOCKING] Pipe-based loop anti-pattern ($pipe_loop_violations):${NC}"
     head -n 5 "$PIPE_LOOP_VIOLATIONS_FILE" | sed 's/^/  /'
     [ $(wc -l <"$PIPE_LOOP_VIOLATIONS_FILE") -gt 5 ] && echo "  ... and more"
+    echo ""
+fi
+
+if [ $abs_home_violations -gt 0 ] && [ -s "$ABS_HOME_VIOLATIONS_FILE" ]; then
+    echo -e "${RED}[BLOCKING] Hardcoded absolute home path ($abs_home_violations file(s)):${NC}"
+    head -n 10 "$ABS_HOME_VIOLATIONS_FILE" | sed 's/^/  /'
+    [ $(wc -l <"$ABS_HOME_VIOLATIONS_FILE") -gt 10 ] && echo "  ... and more"
     echo ""
 fi
 

--- a/git/tests/test_hooks.sh
+++ b/git/tests/test_hooks.sh
@@ -217,6 +217,50 @@ EOF
   rm -rf "$repo_dir"
 }
 
+test_blocks_hardcoded_home_path_in_zshrc() {
+  local repo_dir
+  repo_dir="$(mktemp -d /tmp/dotfiles-hook-test.XXXXXX)"
+  make_repo "$repo_dir"
+
+  # Simulate the bun installer re-appending a resolved /home/<user> path.
+  cat >>"$repo_dir/zsh/main.zsh" <<'EOF'
+[ -s "/home/deity719/.bun/_bun" ] && source "/home/deity719/.bun/_bun"
+EOF
+  git -C "$repo_dir" add zsh/main.zsh
+  assert_failure "git -C \"$repo_dir\" commit -m \"hardcoded bun path\""
+
+  rm -rf "$repo_dir"
+}
+
+test_allows_hardcoded_home_path_with_marker() {
+  local repo_dir
+  repo_dir="$(mktemp -d /tmp/dotfiles-hook-test.XXXXXX)"
+  make_repo "$repo_dir"
+
+  cat >>"$repo_dir/zsh/main.zsh" <<'EOF'
+# allow-abs-home — example only, this PC's owner asked for a fixed path
+[ -s "/home/deity719/.bun/_bun" ] && source "/home/deity719/.bun/_bun" # allow-abs-home
+EOF
+  git -C "$repo_dir" add zsh/main.zsh
+  assert_success "git -C \"$repo_dir\" commit -m \"allow-listed path\""
+
+  rm -rf "$repo_dir"
+}
+
+test_allows_home_var_reference() {
+  local repo_dir
+  repo_dir="$(mktemp -d /tmp/dotfiles-hook-test.XXXXXX)"
+  make_repo "$repo_dir"
+
+  cat >>"$repo_dir/zsh/main.zsh" <<'EOF'
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+EOF
+  git -C "$repo_dir" add zsh/main.zsh
+  assert_success "git -C \"$repo_dir\" commit -m \"portable path\""
+
+  rm -rf "$repo_dir"
+}
+
 main() {
   ux_header "Hook integration tests"
   test_allows_spaces_in_filename
@@ -227,6 +271,9 @@ main() {
   test_blocks_library_purity_top_level_read
   test_blocks_library_purity_top_level_install
   test_allows_library_purity_commented_install
+  test_blocks_hardcoded_home_path_in_zshrc
+  test_allows_hardcoded_home_path_with_marker
+  test_allows_home_var_reference
   ux_success "All hook tests passed"
 }
 

--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -102,6 +102,31 @@ fi
 # ~/.zshrc 를 심볼릭 링크로 생성
 create_symlink "$ZSH_ZSHRC_SOURCE" "$HOME_ZSHRC"
 
+# Seed ~/.zshrc.local (untracked, PC-specific overrides). Issue #737 —
+# installer side-effects (bun, nvm, …) must NOT land in the tracked
+# dotfile. We create the file once if it does not exist, and migrate
+# any known bun init block if the host already runs bun (idempotent).
+HOME_ZSHRC_LOCAL="${HOME}/.zshrc.local"
+if [ ! -f "$HOME_ZSHRC_LOCAL" ]; then
+    log_info "~/.zshrc.local 생성 (PC-specific overrides 용)"
+    cat >"$HOME_ZSHRC_LOCAL" <<'EOF'
+# ~/.zshrc.local — PC-specific overrides, NOT tracked in dotfiles.
+# Installer-mutable lines (bun, nvm, pyenv, …) belong here so the
+# tracked zsh/zshrc stays portable across machines. See issue #737.
+EOF
+fi
+
+if [ -d "$HOME/.bun" ] && ! grep -q 'BUN_INSTALL' "$HOME_ZSHRC_LOCAL" 2>/dev/null; then
+    log_info "기존 bun 설치 감지 — ~/.zshrc.local 에 bun init 블록 이관"
+    cat >>"$HOME_ZSHRC_LOCAL" <<'EOF'
+
+# bun (migrated from zsh/zshrc per issue #737)
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+EOF
+fi
+
 # --- Setup Powerlevel10k Configuration ---
 
 # Powerlevel10k 설정 파일 symlink 생성

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -135,9 +135,9 @@ if command -v fasd &>/dev/null; then
     eval "$(fasd --init auto)"
 fi
 
-# bun completions
-[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
-# bun
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
+# Local PC-specific overrides — installer-mutable lines (bun, nvm, pyenv, …)
+# live here so the tracked dotfile stays clean. Issue #737 / PR #736 — the
+# bun installer keeps re-appending a resolved /home/<user>/.bun/_bun path
+# to ~/.zshrc; routing those through ~/.zshrc.local (untracked) plus the
+# pre-commit hardcoded-home-path guard prevents the drift from landing here.
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"


### PR DESCRIPTION
## Summary
- PR #736 의 follow-up. PR #736 은 `zsh/zshrc` 의 *기존* 하드코딩 라인을 1회 정리한 증상 fix 였고, **bun installer 가 재실행되면 동일한 `/home/<user>/.bun/_bun` 라인이 다시 append** 되는 root cause 는 그대로였다. 본 PR 은 두 layer 로 재발을 차단.
- **Layer 1 (root cause 회피)** — `zsh/zshrc` 의 bun init 블록을 제거하고, untracked `~/.zshrc.local` 만 source 하도록 변경. installer-mutable 코드의 단일 진입점을 dotfile 바깥으로 옮긴다.
- **Layer 2 (defensive guard)** — pre-commit 에 `hardcoded_home_path_check.sh` 신설. staged shell 파일 (`bash/`, `zsh/`, `shell-common/`) 에서 `/home/<user>/` · `/Users/<user>/` 패턴이 나타나면 BLOCKING. 의도된 하드코딩은 `# allow-abs-home` marker 로 escape.

## Changes
- **zsh/zshrc** (-6 / +6) — bun 5줄 제거 + `[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"` 한 줄 추가. 회귀 방지 의도 주석 포함.
- **zsh/setup.sh** (+25) — `~/.zshrc.local` 자동 생성 + 기존 PC 에 `~/.bun` 가 있으면 bun init 블록을 onetime migration (`BUN_INSTALL` 미존재 시에만 추가하여 idempotent).
- **git/hooks/checks/hardcoded_home_path_check.sh** (신규, +84) — `/home/<seg>/` · `/Users/<seg>/` 매칭. scope 외 (`*.md`, `tests/`, `docs/`) 자동 skip. 순수 comment 라인 (`^[[:space:]]*#`) 과 same-line `# allow-abs-home` marker 통과.
- **git/hooks/pre-commit** (+11 / -2) — 신규 check 모듈 등록 (mktemp · trap · source · counter · BLOCKING 리포트 섹션). 기존 dispatcher 패턴 그대로 따름.
- **git/tests/test_hooks.sh** (+47) — 3 케이스: block 하드코딩 / allow `# allow-abs-home` marker / allow `$HOME` portable path.

## Test plan
- [x] 신규 check unit 검증: 6/6 fixture 통과 — bad path / good `$HOME` / allow-marker / pure comment / docs 스코프 제외 / macOS `/Users` 패턴.
- [x] `tox -e ruff,shellcheck,shfmt` 통과.
- [x] real pre-commit 통과 (본 PR 의 commit 자체가 새 guard 를 통과한 첫 사례).
- [ ] Home PC 에서 `curl -fsSL https://bun.sh/install | bash` 재실행 → `git diff zsh/zshrc` 비어야 함 (bun 라인은 `~/.zshrc` = `zsh/zshrc` 에 다시 append 되지만, pre-commit 이 commit 시 차단).
- [ ] `~/.zshrc.local` 생성 후 `zsh -ic '[ -s "$HOME/.bun/_bun" ] && echo loaded'` → `loaded`.
- [ ] 다른 username 환경 (`HOME=/tmp/fake zsh -ic ...`) 에서 bun completion 정상 동작.

## Notes
- bun installer 가 `~/.zshrc` 를 직접 append 하는 행위 자체는 막을 수 없다. Layer 2 (pre-commit guard) 가 "commit 시점 차단" 으로 다음 단계를 방어한다. 사용자는 bun installer 실행 후 `git checkout zsh/zshrc` 로 dotfile 을 되돌리고, 필요한 환경변수는 `~/.zshrc.local` 에 손으로 기록한다 (이미 setup.sh 가 한 번 자동 migration 함).
- Option B (자동 normalize) 는 의도된 하드코딩까지 치환할 위험이 있어 채택하지 않음. Option D (zsh startup warn-only) 는 drift 자체를 못 막아 채택 안 함.

## Related
- Closes #737
- Follows up PR #736 (merged), Issue #735 (closed)

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~10 min · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~10 min · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
