### PR TITLE
feat(skills): #743 gh:kanban-bootstrap — ~/.zshrc.local auto-approve env wiring

### DIFF
--- a/claude/skills/gh-kanban-bootstrap/SKILL.md
+++ b/claude/skills/gh-kanban-bootstrap/SKILL.md
@@ -10,8 +10,9 @@ description: >-
   the former scripts/ location per issue #699). Accepts the
   same flags as the script (`--owner`, `--repo`, `--title`,
   `--auto-archive-window`, `--hide-columns`, `--dry-run`,
-  `--skip-pr-template`) plus `--no-bootstrap-labels`,
-  `--force-label-sync`, `--with-smoke-test`. Accepts `-h`/`--help`/`help`.
+  `--skip-pr-template`, `--no-auto-approve-env`) plus
+  `--no-bootstrap-labels`, `--force-label-sync`,
+  `--with-smoke-test`. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep
 ---
 
@@ -79,6 +80,13 @@ bash "${SKILL_DIR}/lib/setup.sh" <user-flags>
 Parse stdout for `Project board setup finished` (success) or
 `A project titled '<TITLE>' already exists` (idempotent re-run). Extract
 the Project URL and number.
+
+After board creation the script also performs **Step 7 (env wiring)**:
+idempotently appends `OWNER/REPO` into the
+`GH_PR_REPLY_AUTO_APPROVE_REPOS` CSV in `~/.zshrc.local` so the next
+session passes the `gh:pr-reply` Step 8 solo-repo auto-approve G1
+(repo allowlist) guard without manual edits. Suppress with
+`--no-auto-approve-env` (e.g. org/collab repos).
 
 ## Step 8: UI Checklist + Report
 

--- a/claude/skills/gh-kanban-bootstrap/lib/setup.sh
+++ b/claude/skills/gh-kanban-bootstrap/lib/setup.sh
@@ -652,12 +652,25 @@ EOF
     esac
 
     # Append repo to the existing CSV via portable awk+tmpfile (BSD/GNU sed parity).
-    tmpfile="$(mktemp)"
+    # mktemp template (PR #744 review): BSD/GNU portable + random suffix
+    # mitigates symlink/TOCTOU on shared /tmp.
+    tmpfile="$(mktemp "${TMPDIR:-/tmp}/kanban_bootstrap.XXXXXX")"
     awk -v repo="$repo_full" '
         BEGIN { done_flag = 0 }
         /^[[:space:]]*export[[:space:]]+GH_PR_REPLY_AUTO_APPROVE_REPOS=/ && done_flag == 0 {
             line = $0
             if (match(line, /"[^"]*"/)) {
+                val = substr(line, RSTART + 1, RLENGTH - 2)
+                if (val == "") {
+                    val = repo
+                } else {
+                    val = val "," repo
+                }
+                print "export GH_PR_REPLY_AUTO_APPROVE_REPOS=\"" val "\""
+                done_flag = 1
+                next
+            }
+            if (match(line, /'\''[^'\'']*'\''/)) {
                 val = substr(line, RSTART + 1, RLENGTH - 2)
                 if (val == "") {
                     val = repo

--- a/claude/skills/gh-kanban-bootstrap/lib/setup.sh
+++ b/claude/skills/gh-kanban-bootstrap/lib/setup.sh
@@ -74,6 +74,10 @@ AUTO_ARCHIVE_WINDOW="2d"
 HIDE_COLUMNS=false
 DRY_RUN=false
 SKIP_PR_TEMPLATE=false
+NO_AUTO_APPROVE_ENV=false
+
+# Override target file (test seam). Default: ${HOME}/.zshrc.local
+ZSHRC_LOCAL_PATH="${ZSHRC_LOCAL_PATH:-}"
 
 OWNER_TYPE=""
 OWNER_ID=""
@@ -113,6 +117,7 @@ print_help() {
     ux_bullet "--hide-columns               Add solo-repo hide guidance for Approved and Ready"
     ux_bullet "--dry-run                    Print the plan without mutations"
     ux_bullet "--skip-pr-template           Skip remote PR template creation/check"
+    ux_bullet "--no-auto-approve-env        Skip wiring GH_PR_REPLY_AUTO_APPROVE_REPOS into ~/.zshrc.local"
     ux_bullet "-h, --help                   Show this help"
 }
 
@@ -149,6 +154,10 @@ parse_args() {
             ;;
         --skip-pr-template)
             SKIP_PR_TEMPLATE=true
+            shift
+            ;;
+        --no-auto-approve-env)
+            NO_AUTO_APPROVE_ENV=true
             shift
             ;;
         -h | --help)
@@ -579,6 +588,105 @@ ensure_pr_template() {
     log_success "Created ${PR_TEMPLATE_PATH} on ${DEFAULT_BRANCH}"
 }
 
+wire_auto_approve_env() {
+    # Issue #743: register OWNER/REPO into the user's
+    # GH_PR_REPLY_AUTO_APPROVE_REPOS CSV (~/.zshrc.local) so the
+    # gh:pr-reply Step 8 solo-repo auto-approve guard G1 (repo
+    # allowlist) passes on the next session. Idempotent.
+    local target_file display_path repo_full existing_line existing_value tmpfile
+
+    if $NO_AUTO_APPROVE_ENV; then
+        printf '[SKIP] auto-approve env wiring (--no-auto-approve-env)\n'
+        return 0
+    fi
+
+    target_file="${ZSHRC_LOCAL_PATH:-${HOME}/.zshrc.local}"
+    repo_full="${OWNER}/${REPO}"
+
+    display_path="$target_file"
+    case "$target_file" in
+        "$HOME"/*) display_path="~${target_file#"$HOME"}" ;;
+    esac
+
+    if $DRY_RUN; then
+        printf '[dry-run] would add export GH_PR_REPLY_AUTO_APPROVE_REPOS="%s" to %s\n' \
+            "$repo_full" "$display_path"
+        return 0
+    fi
+
+    # Case 1: file does not exist — create with a header comment.
+    if [ ! -f "$target_file" ]; then
+        cat >"$target_file" <<EOF
+# ~/.zshrc.local — untracked local zsh overrides (not version-controlled).
+# Managed entries below are appended by tooling; safe to edit manually.
+export GH_PR_REPLY_AUTO_APPROVE_REPOS="${repo_full}"
+EOF
+        printf '[OK] auto-approve env updated: %s appended to %s\n' \
+            "$repo_full" "$display_path"
+        return 0
+    fi
+
+    # Case 2: file exists, variable line absent — append.
+    if ! grep -qE '^[[:space:]]*export[[:space:]]+GH_PR_REPLY_AUTO_APPROVE_REPOS=' "$target_file"; then
+        printf '\nexport GH_PR_REPLY_AUTO_APPROVE_REPOS="%s"\n' "$repo_full" >>"$target_file"
+        printf '[OK] auto-approve env updated: %s appended to %s\n' \
+            "$repo_full" "$display_path"
+        return 0
+    fi
+
+    # Case 3: variable line present — parse the CSV value.
+    existing_line="$(grep -E '^[[:space:]]*export[[:space:]]+GH_PR_REPLY_AUTO_APPROVE_REPOS=' "$target_file" | tail -n1)"
+    existing_value="${existing_line#*=}"
+    # Strip surrounding quotes (both single and double) idempotently.
+    existing_value="${existing_value#\"}"
+    existing_value="${existing_value%\"}"
+    existing_value="${existing_value#\'}"
+    existing_value="${existing_value%\'}"
+
+    # Already present in CSV → idempotent no-op.
+    case ",${existing_value}," in
+        *",${repo_full},"*)
+            printf '[OK] auto-approve env already configured for %s\n' "$repo_full"
+            return 0
+            ;;
+    esac
+
+    # Append repo to the existing CSV via portable awk+tmpfile (BSD/GNU sed parity).
+    tmpfile="$(mktemp)"
+    awk -v repo="$repo_full" '
+        BEGIN { done_flag = 0 }
+        /^[[:space:]]*export[[:space:]]+GH_PR_REPLY_AUTO_APPROVE_REPOS=/ && done_flag == 0 {
+            line = $0
+            if (match(line, /"[^"]*"/)) {
+                val = substr(line, RSTART + 1, RLENGTH - 2)
+                if (val == "") {
+                    val = repo
+                } else {
+                    val = val "," repo
+                }
+                print "export GH_PR_REPLY_AUTO_APPROVE_REPOS=\"" val "\""
+                done_flag = 1
+                next
+            }
+            if (match(line, /=[^[:space:]#]*/)) {
+                val = substr(line, RSTART + 1, RLENGTH - 1)
+                if (val == "") {
+                    val = repo
+                } else {
+                    val = val "," repo
+                }
+                print "export GH_PR_REPLY_AUTO_APPROVE_REPOS=\"" val "\""
+                done_flag = 1
+                next
+            }
+        }
+        { print }
+    ' "$target_file" >"$tmpfile" && mv "$tmpfile" "$target_file"
+
+    printf '[OK] auto-approve env updated: %s appended to %s\n' \
+        "$repo_full" "$display_path"
+}
+
 project_url_from_owner_type() {
     local prefix="users"
     if [ "$OWNER_TYPE" = "Organization" ]; then
@@ -655,6 +763,11 @@ print_final_report() {
     ux_section "Smoke Test"
     ux_bullet "gh issue create --repo ${OWNER}/${REPO} --title \"[Test] kanban smoke\" --body \"ignore\""
 
+    if ! $NO_AUTO_APPROVE_ENV; then
+        ux_section "Next Step"
+        ux_bullet "Apply the env update to your current shell: source ~/.zshrc.local"
+    fi
+
     if $DRY_RUN; then
         ux_section "Mode"
         ux_bullet "Dry-run only: no project, link, field, or file mutations were sent."
@@ -682,6 +795,9 @@ main() {
         ux_section "Existing Project"
         ux_bullet "Board: ${PROJECT_URL}"
         ux_bullet "Workflows: $(workflows_url_from_owner_type)"
+        # Idempotent env wiring even on the re-run path — solo-repo intent
+        # still holds, and the helper itself short-circuits if already set.
+        wire_auto_approve_env
         exit 0
     fi
 
@@ -704,7 +820,10 @@ main() {
     log_step 6 "Ensuring the pull request template"
     ensure_pr_template
 
-    log_step 7 "Printing the remaining UI checklist"
+    log_step 7 "Wiring auto-approve env (~/.zshrc.local)"
+    wire_auto_approve_env
+
+    log_step 8 "Printing the remaining UI checklist"
     print_final_report
 }
 

--- a/claude/skills/gh-kanban-bootstrap/references/help.md
+++ b/claude/skills/gh-kanban-bootstrap/references/help.md
@@ -33,6 +33,9 @@ label bootstrap, and host-aware UI checklist.
                                  `Approved` and `Ready`.
 - `--dry-run`                    Print the plan without mutations.
 - `--skip-pr-template`           Skip remote PR template creation/check.
+- `--no-auto-approve-env`        Skip wiring `GH_PR_REPLY_AUTO_APPROVE_REPOS`
+                                 into `~/.zshrc.local` (use for non-solo
+                                 / org / collab repos).
 
 ## Prerequisites
 
@@ -49,7 +52,11 @@ label bootstrap, and host-aware UI checklist.
    `chore`, `performance`, `build`, `skill`) — idempotent.
 4. Dry-runs `lib/setup.sh`. Aborts if dry-run fails.
 5. Real-runs `lib/setup.sh`. Captures Project URL and number.
-6. Prints the host-aware UI checklist with workflow #3 disable
+6. Idempotently wires `OWNER/REPO` into
+   `GH_PR_REPLY_AUTO_APPROVE_REPOS` (in `~/.zshrc.local`) so the
+   `gh:pr-reply` Step 8 solo-repo auto-approve G1 guard passes on
+   the next session. Disable with `--no-auto-approve-env`.
+7. Prints the host-aware UI checklist with workflow #3 disable
    guidance (per SSOT decision #289) and the smoke test commands.
 
 ## Re-run safety

--- a/tests/bats/skills/gh_kanban_bootstrap_setup.bats
+++ b/tests/bats/skills/gh_kanban_bootstrap_setup.bats
@@ -474,6 +474,24 @@ EOF
     grep -q '^export GH_PR_REPLY_AUTO_APPROVE_REPOS="other/repo,another/one,acme/widget"$' "${TEST_TEMP_HOME}/.zshrc.local"
 }
 
+@test "issue #743: PR #744 review — single-quoted CSV value is rewritten to double-quoted with repo appended" {
+    setup_basic_mocks
+    cat >"${TEST_TEMP_HOME}/.zshrc.local" <<'EOF'
+# user-managed
+export GH_PR_REPLY_AUTO_APPROVE_REPOS='other/repo'
+EOF
+    run_setup_kanban --owner acme --repo widget
+    assert_success
+    assert_output --partial "[OK] auto-approve env updated: acme/widget appended to ~/.zshrc.local"
+    # Single-quoted value must NOT corrupt the line (regression: pre-fix
+    # the unquoted fallback matched `'other/repo'` and produced
+    # `="'other/repo',acme/widget"`).
+    grep -q "^export GH_PR_REPLY_AUTO_APPROVE_REPOS=\"other/repo,acme/widget\"\$" \
+        "${TEST_TEMP_HOME}/.zshrc.local"
+    # No stray single quotes inside the rewritten value.
+    ! grep -qE "GH_PR_REPLY_AUTO_APPROVE_REPOS=.*'.*'" "${TEST_TEMP_HOME}/.zshrc.local"
+}
+
 @test "issue #743: existing-project re-run also wires env (idempotent)" {
     export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
     export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"

--- a/tests/bats/skills/gh_kanban_bootstrap_setup.bats
+++ b/tests/bats/skills/gh_kanban_bootstrap_setup.bats
@@ -396,6 +396,108 @@ EOF
     assert_output --partial "https://github.com/users/deity/projects/"
 }
 
+setup_basic_mocks() {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, project"
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_user","name":"widget","url":"https://github.com/acme/widget","owner":{"__typename":"User","login":"acme","id":"U_1"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"User","projectsV2":{"nodes":[]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" \
+        '{"data":{"createProjectV2":{"projectV2":{"id":"PVT_new","number":17,"title":"widget","url":"https://github.com/users/acme/projects/17"}}}}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" \
+        '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status"}]}}}}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" \
+        '{"data":{"repository":{"object":null}}}'
+}
+
+# ---------------------------------------------------------------------------
+# Issue #743: GH_PR_REPLY_AUTO_APPROVE_REPOS env wiring in ~/.zshrc.local
+# ---------------------------------------------------------------------------
+
+@test "issue #743: --no-auto-approve-env emits SKIP and leaves ~/.zshrc.local alone" {
+    setup_basic_mocks
+    run_setup_kanban --owner acme --repo widget --no-auto-approve-env
+    assert_success
+    assert_output --partial "[SKIP] auto-approve env wiring (--no-auto-approve-env)"
+    [ ! -e "${TEST_TEMP_HOME}/.zshrc.local" ]
+}
+
+@test "issue #743: --dry-run shows 'would add' and writes nothing" {
+    setup_basic_mocks
+    run_setup_kanban --owner acme --repo widget --dry-run
+    assert_success
+    assert_output --partial '[dry-run] would add export GH_PR_REPLY_AUTO_APPROVE_REPOS="acme/widget" to ~/.zshrc.local'
+    [ ! -e "${TEST_TEMP_HOME}/.zshrc.local" ]
+}
+
+@test "issue #743: creates ~/.zshrc.local with header + variable when file is missing" {
+    setup_basic_mocks
+    run_setup_kanban --owner acme --repo widget
+    assert_success
+    assert_output --partial "[OK] auto-approve env updated: acme/widget appended to ~/.zshrc.local"
+    [ -f "${TEST_TEMP_HOME}/.zshrc.local" ]
+    grep -q '^# ~/.zshrc.local' "${TEST_TEMP_HOME}/.zshrc.local"
+    grep -q '^export GH_PR_REPLY_AUTO_APPROVE_REPOS="acme/widget"$' "${TEST_TEMP_HOME}/.zshrc.local"
+}
+
+@test "issue #743: idempotent — same repo twice does not duplicate the CSV entry" {
+    setup_basic_mocks
+    cat >"${TEST_TEMP_HOME}/.zshrc.local" <<'EOF'
+# user-managed
+export GH_PR_REPLY_AUTO_APPROVE_REPOS="acme/widget"
+EOF
+    run_setup_kanban --owner acme --repo widget
+    assert_success
+    assert_output --partial "[OK] auto-approve env already configured for acme/widget"
+    # Variable line must still appear exactly once and unchanged
+    occurrences="$(grep -c '^export GH_PR_REPLY_AUTO_APPROVE_REPOS=' "${TEST_TEMP_HOME}/.zshrc.local")"
+    [ "$occurrences" = "1" ]
+    grep -q '^export GH_PR_REPLY_AUTO_APPROVE_REPOS="acme/widget"$' "${TEST_TEMP_HOME}/.zshrc.local"
+}
+
+@test "issue #743: appends to existing CSV when repo not present" {
+    setup_basic_mocks
+    cat >"${TEST_TEMP_HOME}/.zshrc.local" <<'EOF'
+# user-managed
+export GH_PR_REPLY_AUTO_APPROVE_REPOS="other/repo,another/one"
+EOF
+    run_setup_kanban --owner acme --repo widget
+    assert_success
+    assert_output --partial "[OK] auto-approve env updated: acme/widget appended to ~/.zshrc.local"
+    grep -q '^export GH_PR_REPLY_AUTO_APPROVE_REPOS="other/repo,another/one,acme/widget"$' "${TEST_TEMP_HOME}/.zshrc.local"
+}
+
+@test "issue #743: existing-project re-run also wires env (idempotent)" {
+    export MOCK_GH_AUTH_HEADERS="${TEST_TEMP_HOME}/auth-headers.txt"
+    export MOCK_GH_REPO_CONTEXT_JSON="${TEST_TEMP_HOME}/repo.json"
+    export MOCK_GH_EXISTING_PROJECTS_JSON="${TEST_TEMP_HOME}/projects.json"
+    export MOCK_GH_CREATE_PROJECT_JSON="${TEST_TEMP_HOME}/create.json"
+    export MOCK_GH_STATUS_FIELD_JSON="${TEST_TEMP_HOME}/status.json"
+    export MOCK_GH_TEMPLATE_JSON="${TEST_TEMP_HOME}/template.json"
+
+    write_auth_headers "$MOCK_GH_AUTH_HEADERS" "repo, project"
+    write_json_fixture "$MOCK_GH_REPO_CONTEXT_JSON" \
+        '{"data":{"repository":{"id":"R_user","name":"dotfiles","url":"https://github.com/deity/dotfiles","owner":{"__typename":"User","login":"deity","id":"U_1"},"defaultBranchRef":{"name":"main"}}}}'
+    write_json_fixture "$MOCK_GH_EXISTING_PROJECTS_JSON" \
+        '{"data":{"repositoryOwner":{"__typename":"User","projectsV2":{"nodes":[{"id":"PVT_existing","number":12,"title":"dotfiles","url":"https://github.com/users/deity/projects/12"}]}}}}'
+    write_json_fixture "$MOCK_GH_CREATE_PROJECT_JSON" '{}'
+    write_json_fixture "$MOCK_GH_STATUS_FIELD_JSON" '{}'
+    write_json_fixture "$MOCK_GH_TEMPLATE_JSON" '{}'
+
+    run_setup_kanban --owner deity --repo dotfiles
+    assert_success
+    assert_output --partial "already exists (#12)"
+    assert_output --partial "[OK] auto-approve env updated: deity/dotfiles appended to ~/.zshrc.local"
+    grep -q '^export GH_PR_REPLY_AUTO_APPROVE_REPOS="deity/dotfiles"$' "${TEST_TEMP_HOME}/.zshrc.local"
+}
+
 @test "issue #699: detect_host derives GHE host from git remote" {
     # Set up a fake git repo in TEST_TEMP_HOME with a GHE origin so
     # detect_host() picks up github.samsungds.net instead of github.com.


### PR DESCRIPTION
## Summary
- `/gh:kanban-bootstrap` 부트스트랩 직후 `OWNER/REPO` 를 `~/.zshrc.local`
  의 `GH_PR_REPLY_AUTO_APPROVE_REPOS` CSV 에 idempotent 하게 자동 등록.
- `gh:pr-reply` Step 8 솔로-레포 auto-approve G1 (repo allowlist) 가드가
  다음 세션부터 자동 통과되어, PR 카드가 `In review` 컬럼에 정지하던
  회귀 해소.
- `--no-auto-approve-env` opt-out 플래그, `--dry-run` 시 "would add"
  메시지만 출력, 6건 bats 회귀 추가.

## Changes
- `claude/skills/gh-kanban-bootstrap/lib/setup.sh` — `wire_auto_approve_env`
  헬퍼 신설 (5 케이스: skip / dry-run / 새 파일 생성 / 변수 라인 부재 /
  CSV 멤버 / CSV 비멤버 append). 새 step 7 (env wiring) → 기존 step 7
  (final report) 은 step 8 로 이동. 기존-보드 재실행 경로에서도 호출.
  최종 보고에 `source ~/.zshrc.local` 안내 추가.
- `claude/skills/gh-kanban-bootstrap/SKILL.md` — frontmatter 의 flag
  목록에 `--no-auto-approve-env` 추가, Step 7 본문에 env-wiring 동작
  설명 추가.
- `claude/skills/gh-kanban-bootstrap/references/help.md` — 옵션 표
  와 "What the skill does" 6단계에 env-wiring 항목 추가.
- `tests/bats/skills/gh_kanban_bootstrap_setup.bats` — 공통 mock
  헬퍼 `setup_basic_mocks` 추출, 이슈 #743 회귀 6건 추가
  (skip / dry-run / 새 파일 / idempotent / CSV append / 기존 보드
  재실행 경로).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_kanban_bootstrap_setup.bats` → 18/18 PASS (기존 12 + 신규 6)
- [x] `shellcheck claude/skills/gh-kanban-bootstrap/lib/setup.sh` → rc=0
- [ ] 다른 솔로-레포에서 실제 `/gh:kanban-bootstrap` 실행하여
  `~/.zshrc.local` 자동 wiring + `source ~/.zshrc.local` 안내 출력 확인
- [ ] 동일 레포에 재실행 → "already configured" 메시지로 멱등성 확인
- [ ] `--no-auto-approve-env` 플래그로 `[SKIP]` 출력 + 파일 무수정 확인

## Related
Closes #743

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
