### PR TITLE
fix(help): gc_help 함수 신규 — main Test (mise) 16건 해소

### DIFF
--- a/shell-common/functions/gc_help.sh
+++ b/shell-common/functions/gc_help.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# shell-common/functions/gc_help.sh
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+_gc_help_summary() {
+    ux_info "Usage: gc-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "basic: gc | gca"
+    ux_bullet_sub "options: --amend | --no-verify | --signoff"
+    ux_bullet_sub "details: gc-help <section>  (example: gc-help basic)"
+}
+
+_gc_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "basic"
+    ux_bullet_sub "options"
+}
+
+_gc_help_rows_basic() {
+    ux_table_row "gc" "git commit -m" "Commit with message"
+    ux_table_row "gca" "git commit --amend" "Amend last commit"
+}
+
+_gc_help_rows_options() {
+    ux_table_row "--amend" "git commit --amend" "Modify last commit"
+    ux_table_row "--no-verify" "git commit --no-verify" "Skip pre-commit hooks (use sparingly)"
+    ux_table_row "--signoff" "git commit -s" "Add Signed-off-by trailer"
+}
+
+_gc_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_gc_help_full() {
+    ux_header "Git Commit Quick Reference"
+    _gc_help_render_section "Basic" _gc_help_rows_basic
+    _gc_help_render_section "Options" _gc_help_rows_options
+}
+
+_gc_help_section_rows() {
+    case "$1" in
+        basic)
+            _gc_help_render_section "Basic" _gc_help_rows_basic
+            ;;
+        options)
+            _gc_help_render_section "Options" _gc_help_rows_options
+            ;;
+        *)
+            ux_error "Unknown gc-help section: $1"
+            ux_info "Try: gc-help --list"
+            return 1
+            ;;
+    esac
+}
+
+gc_help() {
+    case "${1:-}" in
+        ""|-h|--help|help)
+            _gc_help_summary
+            ;;
+        --list|list|section|sections)
+            _gc_help_list_sections
+            ;;
+        --all|all)
+            _gc_help_full
+            ;;
+        *)
+            _gc_help_section_rows "$1"
+            ;;
+    esac
+}
+
+alias gc-help='gc_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -198,6 +198,7 @@ _register_default_help_descriptions() {
     # This approach works in both bash and zsh
     HELP_DESCRIPTIONS[uv_help]="${HELP_DESCRIPTIONS[uv_help]:-[Development] UV packages and environments}"
     HELP_DESCRIPTIONS[git_help]="${HELP_DESCRIPTIONS[git_help]:-[Development] Git version control shortcuts}"
+    HELP_DESCRIPTIONS[gc_help]="${HELP_DESCRIPTIONS[gc_help]:-[CLI] Git commit shortcuts (gc, gca)}"
     HELP_DESCRIPTIONS[gwt_help]="${HELP_DESCRIPTIONS[gwt_help]:-[Development] Git worktree command guide}"
     HELP_DESCRIPTIONS[gbr_help]="${HELP_DESCRIPTIONS[gbr_help]:-[Development] Git feature-branch teardown guide}"
     HELP_DESCRIPTIONS[devx_help]="${HELP_DESCRIPTIONS[devx_help]:-[Development] Dev helper — mise wrapper + repo checks}"


### PR DESCRIPTION
## Summary
- `gc_help` 함수 누락을 보강해 main 의 `Test (mise)` 잡 16건 실패를 해소 (part of #318)
- 회귀 없음 — 929 passed. 잔여 4건은 `gwt_help` 별개 이슈로 분리 예정

## Changes
- **`shell-common/functions/gc_help.sh` 신규** — `git_help.sh` 패턴 그대로, 표준 `*-help` 인터페이스(`default` / `--list` / `--all` / `<section>`) 준수. `_gc_help_*` private helper + `gc_help()` public + `alias gc-help='gc_help'` 노출
- **`shell-common/functions/my_help.sh` +1 line** — `HELP_DESCRIPTIONS[gc_help]="[CLI] Git commit shortcuts (gc, gca)"` 등록. `HELP_CATEGORY_MEMBERS[cli]` 에는 이미 `gc` 가 멤버였음

## Context
- Root cause: PR #318 (commit `204ef08`, `feat(help): standardize help topics via adapter`) 에서 `HELP_TOPICS` 리스트에 `gc_help` 가 추가됐지만 실제 함수 구현은 같이 들어오지 않음 → pytest 가 `exit 127`(command not found) 로 16건 fail → main `Test (mise)` 빨강
- 영향: main 빨강 상태에서는 새 ruleset `main-protection` 의 required check `Test (mise)` 가 모든 PR 머지를 차단

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 pytest -k gc_help` → **16/16 PASS**
- [x] 전체 help 회귀: `pytest tests/integration/test_help_compact_policy.py tests/integration/test_help_topics.py` → 929 passed, 4 failed (gwt_help 별개)
- [x] `sh:check shell-common/functions/gc_help.sh` → Verdict: **GOOD** (7/8 PASS, 1 WARN)
- [ ] CI `Lint (mise)` / `Test (mise)` PASS 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~1 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~1 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
