### PR TITLE
fix(help): #746 gwt_help 표준 인터페이스 — gwt help reject + Usage 템플릿

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -13,7 +13,7 @@ unalias gwt 2>/dev/null || true
 # Usage: gwt-help [section]
 # ============================================================================
 _gwt_help_summary() {
-    ux_info "Usage: gwt help [section|--list|--all]"
+    ux_info "Usage: gwt-help [section|--list|--all]"
     ux_bullet "sections"
     ux_bullet_sub "add      gwt add <path> [branch] [start]              create worktree"
     ux_bullet_sub "list     gwt list|ls [--quick|--remote]               list worktrees"
@@ -22,7 +22,7 @@ _gwt_help_summary() {
     ux_bullet_sub "spawn    gwt spawn <name> [--task|--base|--tmux|...]  create named worktree (AI workflow)"
     ux_bullet_sub "status   gwt status [<name>]                          per-worktree diagnostic"
     ux_bullet_sub "teardown gwt teardown [--force] [--keep-branch]       cleanup current/all worktree(s)"
-    ux_bullet_sub "details  gwt help <section> (example: gwt help spawn)"
+    ux_bullet_sub "details: gwt-help <section>  (example: gwt-help spawn)"
 }
 
 _gwt_help_list_sections() {
@@ -46,7 +46,7 @@ _gwt_help_rows_list() {
     ux_table_row "default" "PATH/BRANCH/STATE/AGE/NEXT columns" "Local signals (no network)"
     ux_table_row "--quick" "path/commit/branch only" "Legacy output"
     ux_table_row "--remote" "Adds PR state via batched gh CLI call" "One network call regardless of N"
-    ux_table_row "states" "dirty/ahead/pr-open/pr-merged/merged/..." "See 'gwt help status' for full list"
+    ux_table_row "states" "dirty/ahead/pr-open/pr-merged/merged/..." "See 'gwt-help status' for full list"
 }
 
 _gwt_help_rows_status() {
@@ -117,8 +117,8 @@ _gwt_help_section_rows() {
             _gwt_help_rows_teardown
             ;;
         *)
-            ux_error "Unknown gwt help section: $1"
-            ux_info "Try: gwt help --list"
+            ux_error "Unknown gwt-help section: $1"
+            ux_info "Try: gwt-help --list"
             return 1
             ;;
     esac
@@ -166,13 +166,18 @@ gwt() {
         spawn)     shift; git_worktree_spawn "$@" ;;
         status)    shift; git_worktree_status "$@" ;;
         teardown)  shift; git_worktree_teardown "$@" ;;
-        -h|--help|help|"")
+        help)
+            ux_error "Use canonical entrypoint: gwt-help (not 'gwt help')"
+            ux_info "Try: gwt-help"
+            return 1
+            ;;
+        -h|--help|"")
             [ $# -gt 0 ] && shift
             gwt_help "$@"
             ;;
         *)
             ux_error "Unknown command: $1"
-            ux_info "Run: gwt help"
+            ux_info "Run: gwt-help"
             return 1
             ;;
     esac

--- a/tests/bats/functions/git_worktree_alias_shadow.bats
+++ b/tests/bats/functions/git_worktree_alias_shadow.bats
@@ -18,6 +18,12 @@
 # even with a broken unalias guard (false positive, PR #693 review). `eval`
 # forces a runtime re-parse at the point where the alias *is* registered, so
 # only a working guard prevents the alias from expanding to `git worktree`.
+#
+# Post-#746: `gwt help` (legacy 공백 형식) 은 dotfiles 함수가 명시적으로
+# 거부 (`exit 1` + canonical-entrypoint 안내). 함수 호출이 실제로 일어났는지
+# (alias shadow 가 무효화됐는지) 검증할 때, 거부 메시지 그 자체가 dotfiles
+# 함수만이 생성하는 고유 시그니처이므로 git native (`git worktree help` →
+# git 자체 도움말) 와 명확히 구분된다.
 
 load '../test_helper'
 
@@ -79,10 +85,13 @@ teardown() {
         shopt -s expand_aliases
         alias gwt='git worktree'
         source '${DOTFILES_ROOT}/bash/main.bash'
-        eval 'gwt help'
+        eval 'gwt help' 2>&1
     "
-    assert_success
-    assert_output --partial "Usage: gwt help"
+    # Post-#746: dotfiles 함수는 'gwt help' 를 거부 (exit 1) + canonical
+    # entrypoint 안내. git native ('git worktree help') 가 호출됐다면
+    # 이 시그니처가 절대 나오지 않으므로 alias-shadow 가 무효화됐음을 증명.
+    assert_failure
+    assert_output --partial "canonical entrypoint: gwt-help"
 }
 
 @test "alias-shadow: 'gwt help' invokes dotfiles function (not the shadowed git native) in zsh" {
@@ -97,8 +106,8 @@ teardown() {
         export TERM=dumb
         alias gwt='git worktree'
         source '${DOTFILES_ROOT}/zsh/main.zsh'
-        eval 'gwt help'
+        eval 'gwt help' 2>&1
     "
-    assert_success
-    assert_output --partial "Usage: gwt help"
+    assert_failure
+    assert_output --partial "canonical entrypoint: gwt-help"
 }

--- a/tests/bats/functions/git_worktree_help.bats
+++ b/tests/bats/functions/git_worktree_help.bats
@@ -1,21 +1,22 @@
 #!/usr/bin/env bats
 # tests/bats/functions/git_worktree_help.bats
-# Tests for issue #605 — gwt help entry-point activation + remove/prune
-# disambiguation.
+# Tests for issue #605 (gwt help entry-point activation + remove/prune
+# disambiguation) and issue #746 (canonical `gwt-help` enforcement —
+# `gwt help` 공백 형식은 거부, dash 형식만 허용).
 #
 # Behavior under test:
-#   - `gwt`, `gwt -h`, `gwt --help`, `gwt help` all show the standalone help
-#     instead of an error + hint (previous behavior returned 1).
-#   - `gwt help <section>` forwards to `gwt_help <section>` and shows the
-#     section detail (equivalent to `gwt-help <section>`).
+#   - `gwt`, `gwt -h`, `gwt --help` show the standalone help summary
+#     (canonical `Usage: gwt-help [section|--list|--all]` 템플릿).
+#   - `gwt help` (legacy 공백 형식) 은 exit 1 + canonical entrypoint
+#     안내 (#746) — `test_help_compact_policy.py` 의 SSOT 와 일치.
+#   - `gwt_help <section>` (함수 직접 호출) 와 `gwt-help` alias 는 그대로 작동.
 #   - The summary distinguishes `remove` (deletes worktree dir + branch)
 #     from `prune` (cleans stale .git/worktrees/ entries only).
 #   - `gwt remove -h` and `gwt prune -h` cross-reference each other.
 #   - `gwt remove --force` (path/name omitted) shows a clear
 #     "Missing <path|name|all>" error instead of misinterpreting `--force`
 #     as a worktree name.
-#   - `gwt-help` alias still works (backward compat).
-#   - Unknown command hint points to `gwt help` (not legacy `gwt-help`).
+#   - Unknown command hint points to `gwt-help` (#746 canonical entrypoint).
 
 load '../test_helper'
 
@@ -28,59 +29,64 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Help entry points: gwt / gwt -h / gwt --help / gwt help
+# Help entry points: gwt / gwt -h / gwt --help show summary (canonical form)
 # ---------------------------------------------------------------------------
 
 @test "help: bare 'gwt' invocation shows help (no error)" {
     run_in_bash "gwt"
     assert_success
-    assert_output --partial "Usage: gwt help"
+    assert_output --partial "Usage: gwt-help"
 }
 
 @test "help: 'gwt -h' shows help" {
     run_in_bash "gwt -h"
     assert_success
-    assert_output --partial "Usage: gwt help"
+    assert_output --partial "Usage: gwt-help"
 }
 
 @test "help: 'gwt --help' shows help" {
     run_in_bash "gwt --help"
     assert_success
-    assert_output --partial "Usage: gwt help"
+    assert_output --partial "Usage: gwt-help"
 }
 
-@test "help: 'gwt help' shows help" {
-    run_in_bash "gwt help"
-    assert_success
-    assert_output --partial "Usage: gwt help"
+# ---------------------------------------------------------------------------
+# Legacy 'gwt help' (공백 형식) — rejected per #746 SSOT
+# Section detail / --list 은 canonical `gwt_help` 함수로 검증
+# ---------------------------------------------------------------------------
+
+@test "help: 'gwt help' is rejected with canonical-entrypoint guidance (#746)" {
+    run_in_bash "gwt help 2>&1"
+    assert_failure
+    assert_output --partial "canonical entrypoint: gwt-help"
 }
 
-@test "help: 'gwt help <section>' shows section detail" {
-    run_in_bash "gwt help spawn"
+@test "help: 'gwt_help <section>' (canonical) shows section detail" {
+    run_in_bash "gwt_help spawn"
     assert_success
     assert_output --partial "spawn"
 }
 
-@test "help: 'gwt help --list' lists sections" {
-    run_in_bash "gwt help --list"
+@test "help: 'gwt_help --list' (canonical) lists sections" {
+    run_in_bash "gwt_help --list"
     assert_success
     assert_output --partial "spawn"
     assert_output --partial "teardown"
 }
 
 # ---------------------------------------------------------------------------
-# Summary disambiguates remove vs prune
+# Summary disambiguates remove vs prune (via canonical entry point)
 # ---------------------------------------------------------------------------
 
 @test "help: summary says remove deletes worktree dir + branch" {
-    run_in_bash "gwt help"
+    run_in_bash "gwt"
     assert_success
     assert_output --partial "remove"
     assert_output --partial "delete worktree dir + branch"
 }
 
 @test "help: summary says prune cleans stale .git/worktrees/ refs" {
-    run_in_bash "gwt help"
+    run_in_bash "gwt"
     assert_success
     assert_output --partial "prune"
     assert_output --partial "stale .git/worktrees/ refs"
@@ -168,11 +174,11 @@ teardown() {
 # Unknown command hint
 # ---------------------------------------------------------------------------
 
-@test "dispatch: unknown command hint points to 'gwt help'" {
+@test "dispatch: unknown command hint points to 'gwt-help' (#746)" {
     run_in_bash "gwt bogus 2>&1"
     assert_failure
     assert_output --partial "Unknown command: bogus"
-    assert_output --partial "Run: gwt help"
+    assert_output --partial "Run: gwt-help"
 }
 
 # ---------------------------------------------------------------------------
@@ -182,13 +188,19 @@ teardown() {
 @test "zsh: bare 'gwt' shows help" {
     run_in_zsh "gwt"
     assert_success
-    assert_output --partial "Usage: gwt help"
+    assert_output --partial "Usage: gwt-help"
 }
 
-@test "zsh: 'gwt help spawn' shows section detail" {
-    run_in_zsh "gwt help spawn"
+@test "zsh: 'gwt_help spawn' (canonical) shows section detail" {
+    run_in_zsh "gwt_help spawn"
     assert_success
     assert_output --partial "spawn"
+}
+
+@test "zsh: 'gwt help' (legacy) is rejected (#746)" {
+    run_in_zsh "gwt help 2>&1"
+    assert_failure
+    assert_output --partial "canonical entrypoint: gwt-help"
 }
 
 @test "zsh: 'gwt remove --force' shows missing-path error" {


### PR DESCRIPTION
## Summary
- `gwt_help` 가 표준 *-help 인터페이스 (`Usage: gwt-help [section|--list|--all]`) 를 준수하도록 교정 → main `Test (mise)` 잡 잔여 4건 fail 해소.
- legacy `gwt help` 공백 형식을 명시적으로 거부하고 canonical `gwt-help` 로 안내. `-h|--help|""` 는 기존대로 summary 출력을 유지하여 사용자 습관을 깨지 않음.

## Changes
- `_gwt_help_summary` Usage 라인을 표준 템플릿으로 교정 (`gwt help` → `gwt-help`). PR #318 (`feat(help): standardize help topics via adapter`, `204ef08`) 에서 도입된 표준의 누락 마이그레이션.
- details bullet 도 `details: gwt-help <section>` 형식으로 표준화하여 `test_gwt_help_summary_uses_standard_template` 의 colon-prefix assertion 만족.
- `gwt()` 디스패처에 `help)` 거부 arm 추가 — `ux_error "Use canonical entrypoint: gwt-help (not 'gwt help')"` + `return 1`. `gwt spawn help` / `gwt teardown help` 는 각 sub-command 의 `*)` 분기가 이미 거부 (no-op).
- 잔여 `gwt help` 문자열 (state 안내 / 에러 hint) 도 일괄 `gwt-help` 로 치환 — 거부될 명령을 사용자에게 안내하지 않도록.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 pytest tests/integration/test_help_compact_policy.py -k gwt -v` → **60 passed** (이전 fail 4건 모두 통과).
- [x] `shellcheck` / `shfmt -d` exit 0 — 수정 영역에 신규 경고 없음 (기존 SC3043 pre-existing).
- [ ] CI `Test (mise)` 잡 green 확인.

## Related
Closes #746

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
