### PR TITLE
fix(ci): #759 bats 단발 회귀 5건 — stale 어설션 + test_helper SSOT 정렬

### DIFF
--- a/tests/bats/functions/git_worktree_orphan.bats
+++ b/tests/bats/functions/git_worktree_orphan.bats
@@ -141,7 +141,7 @@ teardown() {
     run_in_bash "cd '$CLONE' && gwt prune --help 2>&1"
     assert_success
     assert_output --partial "gwt prune"
-    assert_output --partial "Does NOT take a path argument"
+    assert_output --partial "no path argument"
 }
 
 @test "prune: rejects unknown flag with hint to --help" {

--- a/tests/bats/functions/git_worktree_status.bats
+++ b/tests/bats/functions/git_worktree_status.bats
@@ -203,7 +203,8 @@ teardown() {
 @test "help: summary lists the new status subcommand" {
     run_in_bash 'gwt_help'
     assert_success
-    assert_output --partial "status: gwt status"
+    assert_output --partial "status"
+    assert_output --partial "gwt status"
 }
 
 @test "help: status section renders rows" {

--- a/tests/bats/skills/gh_disable_ai_metrics.bats
+++ b/tests/bats/skills/gh_disable_ai_metrics.bats
@@ -48,10 +48,12 @@ SKILLS_REQUIRING_GUARD=(
 
 @test "doc-guard: every gh:* SKILL.md that writes ai-metrics has GH_DISABLE_AI_METRICS branch" {
     for skill in "${SKILLS_REQUIRING_GUARD[@]}"; do
-        local f="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}/SKILL.md"
-        run grep -F 'GH_DISABLE_AI_METRICS:-0' "$f"
+        local dir="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}"
+        # Progressive disclosure: the guard may live inline in SKILL.md or in
+        # any references/*.md file the SKILL.md delegates to. Either is fine.
+        run grep -RF 'GH_DISABLE_AI_METRICS:-0' "$dir"
         [ "$status" -eq 0 ] || {
-            echo "missing GH_DISABLE_AI_METRICS guard in $f"
+            echo "missing GH_DISABLE_AI_METRICS guard in $dir (SKILL.md + references/)"
             return 1
         }
     done

--- a/tests/bats/skills/gh_disable_ai_metrics.bats
+++ b/tests/bats/skills/gh_disable_ai_metrics.bats
@@ -51,7 +51,8 @@ SKILLS_REQUIRING_GUARD=(
         local dir="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}"
         # Progressive disclosure: the guard may live inline in SKILL.md or in
         # any references/*.md file the SKILL.md delegates to. Either is fine.
-        run grep -RF 'GH_DISABLE_AI_METRICS:-0' "$dir"
+        # POSIX-compliant recursive grep via find -exec (no GNU/BSD grep -R).
+        run find "$dir" -type f -exec grep -F 'GH_DISABLE_AI_METRICS:-0' {} +
         [ "$status" -eq 0 ] || {
             echo "missing GH_DISABLE_AI_METRICS guard in $dir (SKILL.md + references/)"
             return 1

--- a/tests/bats/skills/gh_pr_review_remote_url.bats
+++ b/tests/bats/skills/gh_pr_review_remote_url.bats
@@ -65,7 +65,7 @@ teardown() {
 @test "remote-url: non-github host → fail with not-github message" {
     run _gh_pr_review_parse_remote_url "https://gitlab.com/owner/repo.git"
     assert_failure
-    assert_output --partial "not a github.com remote"
+    assert_output --partial "not a github remote"
 }
 
 @test "remote-url: malformed (no owner/repo path) → fail" {

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -58,8 +58,8 @@ teardown_isolated_home() {
 #     setup.sh               → cp of real (NOT symlink — setup.sh resolves
 #                              DOTFILES_ROOT via realpath of its own path,
 #                              so a symlink would escape isolation)
-#     statusline-command.sh, settings.template.json → symlinks (read-only)
-#     settings.json          → cp of template (gitignored convention)
+#     statusline-command.sh  → symlink (read-only)
+#     settings.json          → cp of real tracked SSOT (mutable copy; see #584)
 #     skills/, docs/, global-memory/ → empty dirs (satisfy setup.sh's
 #                              `[ -d ]` source-existence guards)
 #
@@ -83,12 +83,11 @@ setup_isolated_dotfiles_root() {
 
     cp "$real_root/claude/setup.sh" "$iso_root/claude/setup.sh"
     ln -s "$real_root/claude/statusline-command.sh"  "$iso_root/claude/statusline-command.sh"
-    ln -s "$real_root/claude/settings.template.json" "$iso_root/claude/settings.template.json"
 
     mkdir -p "$iso_root/claude/skills" "$iso_root/claude/docs" "$iso_root/claude/global-memory"
 
-    if [ -f "$iso_root/claude/settings.template.json" ]; then
-        cp "$iso_root/claude/settings.template.json" "$iso_root/claude/settings.json"
+    if [ -f "$real_root/claude/settings.json" ]; then
+        cp "$real_root/claude/settings.json" "$iso_root/claude/settings.json"
     else
         echo '{}' > "$iso_root/claude/settings.json"
     fi


### PR DESCRIPTION
## Summary
- run 26433105423 (main HEAD 11edbc3) 의 bats 6건 단발 회귀 중 5건을 해소. 1건(#181) 은 이미 통과 상태였으며 본 PR 범위 밖.
- 모든 회귀의 root cause 는 코드 동작 변경이 아니라 stale 어설션 또는 표준화 부수효과. 테스트 어설션 + test_helper SSOT 만 손대고 함수/스크립트는 미변경.
- umbrella #755 의 sub-issue (테마 D) — 가장 빠른 클러스터부터 닫아 main green 거리를 가시화.

## Changes
- `tests/bats/test_helper.bash` (test 28): #584 단일 settings.json SSOT 전환 후 삭제된 `settings.template.json` 을 더 이상 source 하지 않음. dangling symlink → isolated `settings.json` 이 `{}` 로 fallback 되어 Stop hook 시드가 빠지던 회귀 해소. 이제 `real_root/claude/settings.json` 을 직접 cp.
- `tests/bats/functions/git_worktree_orphan.bats` (test 496): #748 Usage 템플릿 표준화로 메시지가 "Does NOT take a path argument" → "Touches .git/worktrees/ metadata ONLY (no path argument)" 로 바뀐 것을 반영. 어설션을 "no path argument" 부분 일치로 완화.
- `tests/bats/functions/git_worktree_status.bats` (test 589): #748 표준화로 `gwt_help` summary 가 "status: gwt status" 콜론 형식 → 컬럼 정렬 ("status   gwt status [<name>]") 로 변경. 두 토큰 부분 일치로 분리.
- `tests/bats/skills/gh_disable_ai_metrics.bats` (test 903): gh-pr / gh-pr-review / gh-issue-create 는 progressive disclosure 로 `GH_DISABLE_AI_METRICS` 가드를 `references/` 하위 파일에 위임. doc-guard 를 `grep -R` 로 SKILL.md + references/ 동시 검사하도록 일반화.
- `tests/bats/skills/gh_pr_review_remote_url.bats` (test 1023): #615 호스트 추상화 (github.com + github.samsungds.net) 로 "not a github.com remote" → "not a github remote" 일반화. 어설션 동일하게 일반화.

## Test plan
- [x] 6 target test files 109/109 ok — claude_stop_hook_install + gh_flow + git_worktree_orphan + git_worktree_status + gh_disable_ai_metrics + gh_pr_review_remote_url
- [x] shellcheck/shfmt: `tests/bats/test_helper.bash` clean (SC2155 경고는 pre-existing, 본 PR 미변경 라인)
- [x] 회귀 격리 확인: 6건의 단발 어설션만 수정, 실행 코드(`shell-common/`, `git/`, `claude/`) 미변경 — 다른 sub-issue 의 영향 없음
- [ ] CI 의 mise run test 잡에서 본 5건이 모두 ok 로 전환됨을 확인

## Related
Closes #759

부수 (out-of-scope, 같은 main red 의 다른 sub-issue):
- pre-existing 실패 11건 (#727 / #739 / #740 / #777 / #784 / #785 / #792-795 / #798) 은 모두 claude_accounts 통합 테스트 (이슈 #500 / #571 / #575) 로 본 sub-issue 범위가 아님. 별도 sub-issue 에서 처리.

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
