### PR TITLE
fix(setup-company-skills): #763 default COMPANY_SKILLS_HOME PARA 경로로 정정

### DIFF
--- a/scripts/setup-company-skills.sh
+++ b/scripts/setup-company-skills.sh
@@ -4,8 +4,8 @@
 # every active Claude Code config dir.
 #
 # PURPOSE: take entries from a user-supplied private skills repo
-#   ($COMPANY_SKILLS_HOME, default ${HOME}/company-skills) and add them
-#   as entry-level symlinks inside ~/.claude*/skills/, which
+#   ($COMPANY_SKILLS_HOME, default /home/bwyoon/para/project/company-skills)
+#   and add them as entry-level symlinks inside ~/.claude*/skills/, which
 #   claude/setup.sh has just materialised as real directories of
 #   entry-level symlinks (issue #707, F-8).
 #
@@ -31,7 +31,7 @@
 _SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
 
-COMPANY_SKILLS_HOME="${COMPANY_SKILLS_HOME:-${HOME}/company-skills}"
+COMPANY_SKILLS_HOME="${COMPANY_SKILLS_HOME:-/home/bwyoon/para/project/company-skills}"
 
 # Load UX library
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"


### PR DESCRIPTION
## Summary

- PR #14 가 default 를 `${HOME}/company-skills` 로 잡았으나 실제 작업 환경의 private skills repo 위치는 `/home/bwyoon/para/project/company-skills` (PARA 디렉토리 구조).
- default 가 어긋나 setup.sh 마지막 단계에서 private overlay 가 실재함에도 항상 skip.
- PR #14 와 동일한 hardcode 패턴으로 default 만 정정. 헤더 주석도 함께 갱신.

Closes #763. Follow-up to #13/PR #14.

## Diff

```diff
-#   ($COMPANY_SKILLS_HOME, default ${HOME}/company-skills) and add them
-#   as entry-level symlinks inside ~/.claude*/skills/, which
+#   ($COMPANY_SKILLS_HOME, default /home/bwyoon/para/project/company-skills)
+#   and add them as entry-level symlinks inside ~/.claude*/skills/, which
...
-COMPANY_SKILLS_HOME="${COMPANY_SKILLS_HOME:-${HOME}/company-skills}"
+COMPANY_SKILLS_HOME="${COMPANY_SKILLS_HOME:-/home/bwyoon/para/project/company-skills}"
```

## Test Plan

- [x] `shellcheck scripts/setup-company-skills.sh` — pass
- [x] `bash -n scripts/setup-company-skills.sh` — pass
- [x] Pre-commit hook (global + project) — pass
- [x] Smoke test: `bash scripts/setup-company-skills.sh` 실행 결과
  ```
  COMPANY_SKILLS_HOME=/home/bwyoon/para/project/company-skills
    /home/bwyoon/.claude/skills (added=4 refreshed=1 skipped=0 pruned=0)
  ✅ company-skills overlay applied
  ```
- [x] `~/.claude/skills/` 에 jira-agile/check/read/swsupport-mchat/write 5개 entry 생성 확인
- [x] 충돌한 jira-create 는 dotfiles 측 유지 (F-4 collision policy 정상 동작)
- [ ] CI tox 통과 확인