### PR TITLE
fix(ci): #758 auth-guard bats 2건 — fake-shim PATH propagation

### DIFF
--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -607,7 +607,12 @@ EOF
     # message and NOT create a state dir under
     # ~/.local/state/gh-pr-approve/<repo>/<pr>/.
     _install_fake_ai_cli claude
-    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH unset ANTHROPIC_API_KEY 2>/dev/null; cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
+    # PATH must be exported, not prefix-set on `unset` — the prefix form
+    # only applies to that single command, so PATH would revert after the
+    # `;` and `_have claude` would then fall through to the system PATH.
+    # In CI the system has no `claude` binary → "claude CLI not found"
+    # would fire before the auth check (issue #758).
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; unset ANTHROPIC_API_KEY; cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
     assert_failure
     assert_output --partial "claude CLI not authenticated"
     assert_output --partial "claude /login"
@@ -636,7 +641,11 @@ EOF
 
 @test "auth: codex logged out — refuses spawn" {
     _install_fake_ai_cli codex
-    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH unset OPENAI_API_KEY 2>/dev/null; cd '$FAKE_REPO' && gh_pr_approve 42 --ai codex 2>&1"
+    # See claude test above for why `export PATH` is required (issue #758).
+    # codex would pass either way (`codex()` is a function defined in
+    # shell-common/tools/integrations/codex.sh, so `_have codex` returns
+    # true even without the stub), but keep the pattern consistent.
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; unset OPENAI_API_KEY; cd '$FAKE_REPO' && gh_pr_approve 42 --ai codex 2>&1"
     assert_failure
     assert_output --partial "codex CLI not authenticated"
     [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/42" ]
@@ -652,7 +661,8 @@ EOF
 
 @test "auth: gemini logged out — refuses spawn" {
     _install_fake_ai_cli gemini
-    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH unset GEMINI_API_KEY GOOGLE_API_KEY 2>/dev/null; cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
+    # See claude test above for why `export PATH` is required (issue #758).
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; unset GEMINI_API_KEY GOOGLE_API_KEY; cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
     assert_failure
     assert_output --partial "gemini CLI not authenticated"
     [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/42" ]


### PR DESCRIPTION
## Summary

Issue #758 (umbrella #755 의 sub-issue, theme C) — CI 의 `Test (mise)`
sub-suite 에서 적색이던 auth-guard bats 2건을 결정론적으로 fix.

  not ok 299 auth: claude logged out — refuses spawn before worktree creation
  not ok 304 auth: gemini logged out — refuses spawn

## Root cause

`tests/bats/functions/gh_pr_approve.bats` 의 fake-shim 설치 패턴이
PATH 를 잘못 전달:

```
PATH='$TEST_TEMP_HOME/bin:'$PATH unset ANTHROPIC_API_KEY 2>/dev/null; \
    cd '$FAKE_REPO' && gh_pr_approve 42 2>&1
```

bash 의 `VAR=val cmd` prefix 형태는 `cmd` 한 simple-command 에만 적용 →
`unset` 만 새 PATH 를 보고, `;` 이후 `cd`/`gh_pr_approve` 는 부모 셸의
원본 PATH 로 돌아감.

CI 러너에는 시스템 `claude`/`gemini` binary 가 없으므로 `_have <ai>` 가
false → `shell-common/functions/gh_pr_approve.sh:64-89` 의
`_gh_pr_approve_require_ai_cli` 가 먼저 "CLI not found" 출력 후 종료 →
auth 체크 (line 98-158) 까지 도달하지 못해 어설션 fail.

### Why codex (test 302) passed

`shell-common/tools/integrations/codex.sh:343` 에 `codex()` 함수 wrapper
가 정의되어 있어 main.bash sourcing 시점에 `command -v codex` 가 true
반환 → `_have codex` 가 false 인 fake-shim 미적용 상태에서도 통과.
claude/gemini 는 동일한 wrapper 가 없으므로 fake-shim PATH 가 실제로
작동해야만 함.

## Fix

기존 패턴을 같은 파일 line 624 (credentials-file) / 633 (env-var)
테스트가 이미 사용 중인 표준 패턴과 정렬:

```
export PATH='$TEST_TEMP_HOME/bin:'$PATH; unset ANTHROPIC_API_KEY; \
    cd '$FAKE_REPO' && gh_pr_approve 42 2>&1
```

일관성을 위해 codex 케이스도 동일 패턴으로 교체. 현 codex 통과는 우연
의존이므로 future-proof 차원에서 정렬 (claude.sh / gemini.sh 에 향후
wrapper 가 추가되어도 영향 없음).

## Test plan

- [x] 로컬 reproduction: 기존 코드 + CI-like minimal PATH
      (`PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`)
      에서 `output: ❌ claude CLI not found` 로 CI 실패 메시지 완전 일치
- [x] Fix 후 동일 환경: 3개 auth 테스트 모두 ok (claude/codex/gemini)
- [x] `gh_pr_approve.bats` 전체 80건: 77 ok / 3 not ok — 잔여 3건은
      cluster B (non-integer PR 검증) 로 별도 sub-issue, 본 PR 범위 밖
- [x] shellcheck: 신규 라인 0 warning. SC2164 2건 (line 20/797) 은
      pre-existing
- [x] CI 에서 `not ok 299` / `not ok 304` 가 ok 로 전환되는지 확인
- [x] auth-guard 호출이 실제 코드 경로에 존재 (보안 회귀 없음) —
      `gh_pr_approve.sh:64-158` 의 require_ai_cli + check_ai_auth 체인 확인

Closes #758

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
