### PR TITLE
feat(zsh-setup): #761 setup.sh 종료 시 ~/.zshrc 백업 안내 + diff 가이드

### DIFF
--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -36,6 +36,10 @@ ZSH_DOTFILES="${DOTFILES_ROOT}/zsh"
 ZSH_ZSHRC_SOURCE="${ZSH_DOTFILES}/zshrc"
 HOME_ZSHRC="${HOME}/.zshrc"
 
+# Tracks the backup path created when ~/.zshrc was replaced from a
+# regular file to a symlink (issue #761). Empty when no backup was made.
+ZSHRC_BACKUP_NOTICE_PATH=""
+
 # Load UX library (unified library at shell-common/tools/ux_lib/)
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
 if [ -f "$UX_LIB" ]; then
@@ -82,8 +86,12 @@ create_symlink() {
         rm "$link_name" || log_error_and_exit "기존 심볼릭 링크 제거 실패: $link_name"
     elif [ -f "$link_name" ]; then
         log_warning "경고: $link_name 가 심볼릭 링크가 아닌 일반 파일입니다. 백업 후 제거합니다."
-        backup_file "$link_name" "${link_name}-$(date +%Y%m%d%H%M%S)-original"
+        local backup_path="${link_name}-$(date +%Y%m%d%H%M%S)-original"
+        backup_file "$link_name" "$backup_path"
         rm "$link_name" || log_error_and_exit "기존 파일 제거 실패: $link_name"
+        if [ "$link_name" = "$HOME_ZSHRC" ]; then
+            ZSHRC_BACKUP_NOTICE_PATH="$backup_path"
+        fi
     fi
 
     log_info "심볼릭 링크 생성: $link_name -> $target"
@@ -155,5 +163,23 @@ ux_bullet "Zsh 관리 명령어: ${UX_BOLD}zsh-help${UX_RESET}"
 ux_bullet "테마 변경: ${UX_BOLD}zsh-themes${UX_RESET}, ${UX_BOLD}zsh-theme <name>${UX_RESET}"
 ux_bullet "플러그인 확인: ${UX_BOLD}zsh-plugins${UX_RESET}"
 echo ""
+
+# Issue #761 — when ~/.zshrc was replaced from a regular file to a
+# symlink, the backup is easy for users to forget. Surface it explicitly
+# with a diff guide so external-installer lines (bun/nvm/pyenv init,
+# etc.) can be migrated into ~/.zshrc.local before the backup is lost.
+if [ -n "$ZSHRC_BACKUP_NOTICE_PATH" ]; then
+    ux_section "~/.zshrc 백업 검토 필요"
+    ux_info "설치 중 ~/.zshrc 일반 파일이 심볼릭 링크로 교체되었습니다."
+    ux_bullet "백업: ${UX_BOLD}${ZSHRC_BACKUP_NOTICE_PATH}${UX_RESET}"
+    echo ""
+    ux_info "dotfiles 외부 도구가 추가한 줄이 있는지 확인:"
+    ux_bullet "${UX_BOLD}diff ${ZSHRC_BACKUP_NOTICE_PATH} ${ZSH_ZSHRC_SOURCE}${UX_RESET}"
+    echo ""
+    ux_info "추가 설정은 다음 위치에 보관 권장:"
+    ux_bullet "${UX_BOLD}~/.zshrc.local${UX_RESET} (PC-specific overrides)"
+    ux_bullet "${UX_BOLD}shell-common/env/development.local.sh${UX_RESET}"
+    echo ""
+fi
 
 exit 0


### PR DESCRIPTION
## Summary
- `~/.zshrc` 가 일반 파일에서 심볼릭 링크로 교체되면서 생긴 백업 파일을 사용자가 잊지 않도록, `zsh/setup.sh` 종료 직전에 검토 안내와 즉시 실행 가능한 `diff` 가이드를 출력하도록 추가.

## Changes
- `zsh/setup.sh`: `ZSHRC_BACKUP_NOTICE_PATH` 추적 변수 추가 — 빈 문자열일 때만 안내 비표시.
- `zsh/setup.sh`: `create_symlink` 가 `$HOME_ZSHRC` 를 백업한 경우에만 경로 기록 (다른 심볼릭 교체 경로에는 영향 없음).
- `zsh/setup.sh`: 스크립트 끝부분에 `ux_section` 기반 검토 안내 + `diff <backup> <source>` 명령어 + 권장 이관 경로(`~/.zshrc.local`, `shell-common/env/development.local.sh`) 출력.

## Test plan
- [x] `/tmp` sandboxed `HOME` 에서 일반 파일 → 백업 + 안내 출력 확인 (스모크 통과)
- [x] 이미 symlink 인 경우 → 안내 미출력 확인 (스모크 통과)
- [ ] PR #14 머지 후 setup.sh 재실행 시나리오에서 안내가 정확한 백업 경로를 가리키는지 회귀 확인
- [x] pytest 1062건 그린 (bats 는 worktree 서브모듈 미초기화로 skip)

## Related
Closes #761

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
