### PR TITLE
feat(claude-setup): #762 stale sudoers 자동 정리 [y/N] 프롬프트

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -428,24 +428,31 @@ _setup_gemini_skills_symlink() {
     log_dim "✓ ${HOME}/.gemini/skills SSOT 연결 완료"
 }
 
-# _print_stale_bind_mount_sudoers_hint — surface stale /etc/sudoers.d/
-# files left over from the pre-#575 bind-mount design.
+# _print_stale_bind_mount_sudoers_hint — surface (and optionally clean
+# up) stale /etc/sudoers.d/ files left over from the pre-#575 bind-mount
+# design.
 #
 # Issue #575 removed _setup_bind_mount_sudoers and the entire bind-mount
 # integration in favour of directory-level symlinks. Existing PCs may
 # still carry sudoers entries from the prior layout — they no longer
 # match anything in the setup and only widen the sudoers surface, so
-# point the user at them. Cleanup is left manual on purpose because
-# rm under /etc/sudoers.d/ needs sudo and we don't want to prompt
-# from setup.sh.
+# point the user at them.
+#
+# Issue #762: when stdin/stdout are a TTY and the caller did not opt out
+# via DOTFILES_NONINTERACTIVE=1, ask once whether to delete the files
+# via `sudo rm`. On any other condition (non-interactive run, declined
+# prompt, sudo failure) fall back to the original manual-command hint
+# so the user still has a copy-paste path.
 _print_stale_bind_mount_sudoers_hint() {
     local sudoers_glob='/etc/sudoers.d/claude-skills-mount-* /etc/sudoers.d/claude-docs-mount-*'
     local found=""
+    local count=0
     # shellcheck disable=SC2086  # glob intentionally unquoted
     for _f in $sudoers_glob; do
         [ -f "$_f" ] || continue
         found="${found}  $_f
 "
+        count=$((count + 1))
     done
 
     [ -n "$found" ] || return 0
@@ -455,11 +462,22 @@ _print_stale_bind_mount_sudoers_hint() {
     ux_info "Issue #575 retired bind-mount for Claude skills/docs in favour of"
     ux_info "a single directory symlink. The sudoers files below were created"
     ux_info "by an earlier dotfiles version and no longer have a matching"
-    ux_info "consumer — they only widen the sudoers surface. Remove them"
-    ux_info "manually when convenient (requires sudo):"
+    ux_info "consumer — they only widen the sudoers surface."
     echo ""
     printf '%s' "$found"
     echo ""
+
+    if [ -t 0 ] && [ -t 1 ] && [ "${DOTFILES_NONINTERACTIVE:-0}" != "1" ]; then
+        if ux_confirm "Stale sudoers files detected (${count}). 자동 정리하시겠습니까?" "n"; then
+            # shellcheck disable=SC2086  # glob intentionally unquoted
+            if sudo rm -f $sudoers_glob; then
+                ux_success "Stale sudoers files 정리 완료."
+                return 0
+            fi
+            ux_warning "Stale sudoers files 정리 실패 — 아래 명령을 수동으로 실행하세요:"
+        fi
+    fi
+
     ux_bullet "Quick command:"
     cat <<'EOF'
 


### PR DESCRIPTION
## Summary
- `./setup.sh` 마다 반복되던 stale bind-mount sudoers "manual cleanup" 안내에 1-keystroke 정리 경로 추가.
- TTY 환경 + `DOTFILES_NONINTERACTIVE` 미설정일 때만 `ux_confirm [y/N]` 으로 묻고, 'y' 응답 시 `sudo rm -f` 일괄 정리.
- CI / 비-TTY (`./setup.sh < /dev/null`) 호출은 기존 manual-command 안내 경로로 동일하게 떨어져 hang 위험 없음.

## Changes
- `claude/setup.sh:_print_stale_bind_mount_sudoers_hint`: stale sudoers 발견 시 인터랙티브 `sudo rm -f /etc/sudoers.d/claude-{skills,docs}-mount-*` 분기 추가. 정리 성공 시 early-return 으로 manual-command 블록 출력 생략. 정리 실패 시 경고와 함께 manual-command 블록으로 fallback.
- 함수 헤더 주석에 #762 인터랙티브 동작과 `DOTFILES_NONINTERACTIVE=1` 옵트-아웃 의도 명시.

## Test plan
- [ ] `mise run lint-sh` 통과 (shellcheck / shfmt — `bash/` 한정 scope; `claude/` 는 lint scope 밖)
- [ ] `./tests/test` — pytest 1062 PASSED 유지, 기존 golden-rule warn (`shell-common/functions/*.sh` 3 files raw echo) 외 신규 회귀 0
- [ ] 수동 검증: stale sudoers 가 실제 존재하는 사내 PC 에서 `./setup.sh` 재실행 → [y/N] 프롬프트 확인 → 'y' 응답 후 `ls /etc/sudoers.d/claude-{skills,docs}-mount-*` 가 비어있는지 검증

## Related
Closes #762

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
