### PR TITLE
fix(review): PR #765 gemini-code-assist 제안 반영 — 자매 테스트 3건 동일 패턴

### DIFF
--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -626,7 +626,11 @@ EOF
     _install_fake_ai_cli claude
     mkdir -p "$HOME/.claude"
     printf '{"access_token":"fake"}\n' >"$HOME/.claude/.credentials.json"
-    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
+    # `export PATH` (not the prefix form) — same reason as the logged-out
+    # tests above. Without it, in CI the missing system `claude` binary
+    # would short-circuit at "CLI not found" before the auth check ran,
+    # producing a false positive against `refute_output` (PR #765 review).
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; cd '$FAKE_REPO' && gh_pr_approve 42 2>&1"
     refute_output --partial "claude CLI not authenticated"
 }
 
@@ -655,7 +659,9 @@ EOF
     _install_fake_ai_cli codex
     mkdir -p "$HOME/.codex"
     printf '{"token":"fake"}\n' >"$HOME/.codex/auth.json"
-    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH cd '$FAKE_REPO' && gh_pr_approve 42 --ai codex 2>&1"
+    # See claude credentials test above for why `export PATH` is required
+    # (PR #765 review).
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; cd '$FAKE_REPO' && gh_pr_approve 42 --ai codex 2>&1"
     refute_output --partial "codex CLI not authenticated"
 }
 
@@ -672,7 +678,9 @@ EOF
     _install_fake_ai_cli gemini
     mkdir -p "$HOME/.gemini"
     printf '{"refresh_token":"fake"}\n' >"$HOME/.gemini/oauth_creds.json"
-    run_in_bash "PATH='$TEST_TEMP_HOME/bin:'\$PATH cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
+    # See claude credentials test above for why `export PATH` is required
+    # (PR #765 review).
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
     refute_output --partial "gemini CLI not authenticated"
 }
 


### PR DESCRIPTION
## Summary

PR #765 의 gemini-code-assist 리뷰 후속. 같은 PATH propagation 안티패턴이
"credentials file present → auth check passes" 자매 테스트 3건에도 남아
있어 false positive 로 통과 중이었다는 지적을 반영.

## 문제 패턴

```
PATH='$TEST_TEMP_HOME/bin:'$PATH cd '$FAKE_REPO' && gh_pr_approve ...
```

`VAR=val cmd` prefix 형태는 `cd` builtin 한 simple-command 에만 적용 →
`&&` 이후의 `gh_pr_approve` 는 부모 셸의 원본 PATH 로 돌아감. CI 환경
(시스템에 claude/gemini binary 없음) 에서는 `_have <ai>` 가 false 가
되어 "CLI not found" 로 조기 종료하고, `refute_output --partial
"<ai> CLI not authenticated"` 가 우연히 통과 — 의도한 "credentials file
이 있어서 auth 통과" 경로는 실제로 실행되지 않음.

## 수정 대상

| 라인 | 테스트 |
|------|--------|
| 629 | `auth: claude credentials file present → auth check passes` |
| 658 | `auth: codex credentials file present → auth check passes` |
| 675 | `auth: gemini credentials file present → auth check passes` |

각각 `PATH='...' cd ...` → `export PATH='...'; cd ...` 로 변경. PR #765
의 logged-out 테스트와 동일 표준 패턴.

## Test plan

- [x] CI-like minimal PATH 환경에서 7개 auth 테스트 모두 ok
- [x] 전체 80건 회귀 검증: 77 ok / 3 not ok (잔여 3건 cluster B —
      non-integer PR 검증, 본 PR 범위 밖)
- [x] shellcheck 신규 라인 0 warning

Refs PR #765 (already merged)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~0.5 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~0.5 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
