### PR TITLE
chore(claude-settings): GH_PR_REPLY_AUTO_APPROVE_REPOS allowlist에 quantfolio 추가

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles"
+    "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles,dEitY719/quantfolio"
   },
   "hooks": {
     "Stop": [


### PR DESCRIPTION
## Summary
- `claude/settings.json` 의 `GH_PR_REPLY_AUTO_APPROVE_REPOS` allowlist에 `dEitY719/quantfolio` repo 추가.
- 이 env 는 `gh:pr-reply` 스킬이 자동 승인 (no-confirm) 모드로 동작할 repo 목록을 결정.
- quantfolio repo 에서도 동일 워크플로 적용 가능하도록 확장.

## Changes
- `claude/settings.json` (env): `GH_PR_REPLY_AUTO_APPROVE_REPOS` 값을 `dEitY719/dotfiles` → `dEitY719/dotfiles,dEitY719/quantfolio` 로 변경 (쉼표 구분 리스트).

## Test plan
- [ ] `~/.claude/settings.json` 은 `claude/settings.json` 의 심볼릭 링크이므로 머지 즉시 반영 확인.
- [ ] `dEitY719/quantfolio` 에서 `/gh:pr-reply` 호출 시 `--no-confirm` 동작 확인.
- [ ] 기존 `dEitY719/dotfiles` 동작 무회귀 확인.

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~4 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~4 min
<!-- /ai-metrics:gh-pr -->

</details>
