### PR TITLE
fix(ci): #755 Golden Rule 3 fail 시 위반 파일 출력 — Rule 2 패턴 미러링

### DIFF
--- a/tests/golden_rules/test_golden_rules.sh
+++ b/tests/golden_rules/test_golden_rules.sh
@@ -78,6 +78,7 @@ echo ""
 #   - lines already using UX_* variables (ux_lib colors)
 echo "Rule 3: Use ux_lib for output (no raw echo)"
 raw_echo_files=0
+raw_echo_list=""
 for file in shell-common/functions/*.sh; do
     [ -f "$file" ] || continue
     # Skip help content files — they display structured text by design
@@ -88,6 +89,7 @@ for file in shell-common/functions/*.sh; do
         | grep -v 'UX_' \
         | grep -vq 'echo "  '; then
         raw_echo_files=$((raw_echo_files + 1))
+        raw_echo_list="${raw_echo_list}  $file\n"
     fi
 done
 
@@ -95,6 +97,9 @@ if [ "$raw_echo_files" -eq 0 ]; then
     test_case "No raw echo in functions/" 0
 else
     test_case "No raw echo in functions/ ($raw_echo_files files)" 1
+    printf "%b" "$raw_echo_list" | head -5
+    remaining=$((raw_echo_files - 5))
+    [ "$remaining" -gt 0 ] && echo "  ... and $remaining more"
 fi
 echo ""
 

--- a/tests/golden_rules/test_golden_rules.sh
+++ b/tests/golden_rules/test_golden_rules.sh
@@ -77,8 +77,7 @@ echo ""
 #   - file writes / pipes: echo ... > file, echo ... | cmd
 #   - lines already using UX_* variables (ux_lib colors)
 echo "Rule 3: Use ux_lib for output (no raw echo)"
-raw_echo_files=0
-raw_echo_list=""
+raw_echo_files=()
 for file in shell-common/functions/*.sh; do
     [ -f "$file" ] || continue
     # Skip help content files — they display structured text by design
@@ -88,17 +87,18 @@ for file in shell-common/functions/*.sh; do
         | grep -v -e '> *\$' -e '> *"' -e '| ' \
         | grep -v 'UX_' \
         | grep -vq 'echo "  '; then
-        raw_echo_files=$((raw_echo_files + 1))
-        raw_echo_list="${raw_echo_list}  $file\n"
+        raw_echo_files+=("$file")
     fi
 done
 
-if [ "$raw_echo_files" -eq 0 ]; then
+if [ "${#raw_echo_files[@]}" -eq 0 ]; then
     test_case "No raw echo in functions/" 0
 else
-    test_case "No raw echo in functions/ ($raw_echo_files files)" 1
-    printf "%b" "$raw_echo_list" | head -5
-    remaining=$((raw_echo_files - 5))
+    test_case "No raw echo in functions/ (${#raw_echo_files[@]} files)" 1
+    for file in "${raw_echo_files[@]:0:5}"; do
+        echo "  $file"
+    done
+    remaining=$((${#raw_echo_files[@]} - 5))
     [ "$remaining" -gt 0 ] && echo "  ... and $remaining more"
 fi
 echo ""


### PR DESCRIPTION
## Summary
- `tests/golden_rules/test_golden_rules.sh` 의 Rule 3 (raw echo 검사) 가 실패할 때 위반 파일 경로를 출력하도록 보강
- main 적색 디버깅 시 매번 grep 으로 다시 찾는 비용 제거
- 검사 로직은 그대로 (count 3 → 3 동일), 출력 메시지만 보강

## Changes
- `tests/golden_rules/test_golden_rules.sh`:
  - Rule 3 루프에서 위반 파일 경로를 `raw_echo_list` 변수에 누적
  - 실패 케이스 출력 블록에서 Rule 2 와 동일한 패턴 (`printf "%b" | head -5` + "and N more") 으로 표시

## Test plan
- [x] `bash tests/golden_rules/test_golden_rules.sh` 실행 → Rule 3 fail 메시지에 3개 파일 경로 표시
- [x] `shellcheck tests/golden_rules/test_golden_rules.sh` clean
- [x] count 3 → 3 동일 (검사 로직 회귀 없음)

## Related

본 PR 은 umbrella issue #755 의 AC 항목 "Rule 3 출력 보강 PR" 한 건만
다룬다. 나머지 AC (3건 위반 파일 정리, main green 복구,
`gh:pr-resolve-ci-fail` 결정 트리 문서화) 는 별도 PR/이슈로 분리되어
있으므로 `Closes #755` footer 는 의도적으로 생략.

부수 산출물 — 출력 보강으로 식별된 현재 위반 3건:
- `shell-common/functions/dotfiles_root.sh`
- `shell-common/functions/gcp.sh`
- `shell-common/functions/gh_pr_review.sh`

(part of #755)

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
