### PR TITLE
fix(ci): #757 gh-pr-approve/reply — CLI presence check 순서 회귀

### DIFF
--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -977,9 +977,6 @@ gh_pr_approve() {
         ux_error "gh CLI not found"
         return 1
     fi
-    if ! _gh_pr_approve_require_ai_cli "$_ai"; then
-        return 1
-    fi
     if ! command -v gwt >/dev/null 2>&1; then
         ux_error "gwt function not loaded (source shell-common first)"
         return 1
@@ -1022,13 +1019,19 @@ gh_pr_approve() {
         return 1
     fi
 
-    # Auth pre-flight (issue #327): bail before any worktree/state I/O when
-    # the selected ai CLI is logged out, so users don't have to clean up a
-    # zombie worktree + 'failed:approving' state dir afterwards. Done here
-    # — after PR-number / main-repo validation — so obvious user errors
-    # still surface their natural message instead of an auth complaint.
+    # AI CLI presence + auth pre-flight (issue #327, #757): bail before any
+    # worktree/state I/O when the selected ai CLI is missing or logged out,
+    # so users don't have to clean up a zombie worktree + 'failed:approving'
+    # state dir afterwards. Done here — after PR-number / main-repo
+    # validation — so obvious user errors surface their natural message
+    # instead of a "claude CLI not found" / "not authenticated" complaint
+    # (issue #757: CI without claude installed was tripping the presence
+    # check before validation could run).
     # Pass --user account (or default) so multi-account profiles are
     # checked against the right .credentials.json (issue #365).
+    if ! _gh_pr_approve_require_ai_cli "$_ai"; then
+        return 1
+    fi
     if ! _gh_pr_approve_check_ai_auth "$_ai" "$_account"; then
         return 1
     fi

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -289,11 +289,21 @@ gh_pr_reply() {
         _pr_clean_args="$_pr_clean_args $_pr_clean"
     done
 
+    # Propagate per-worker spawn failures to the dispatcher exit code so
+    # missing-CLI / fork-failed runs don't print "All workers detached"
+    # and silently exit 0 (PR #773 review — gemini-code-assist). Skipped
+    # workers (state=done / failed:* / alive) return 0 and don't count.
+    local _failed=0
     ux_header "gh-pr-reply: spawning $# worker(s) (ai=$_ai${_account:+ user=$_account})"
     for _pr in $_pr_clean_args; do
-        _gh_pr_reply_spawn_worker "$_pr" "$_ai" "$_account"
+        _gh_pr_reply_spawn_worker "$_pr" "$_ai" "$_account" || _failed=$((_failed + 1))
     done
-    ux_success "All workers detached. Your shell is free. Results appear on the PR."
+    if [ "$_failed" -eq 0 ]; then
+        ux_success "All workers detached. Your shell is free. Results appear on the PR."
+        return 0
+    fi
+    ux_error "$_failed of $# worker(s) failed to spawn."
+    return 1
 }
 
 _gh_pr_reply_spawn_worker() {

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -209,6 +209,18 @@ gh_pr_reply() {
         return 1
     fi
 
+    # Validate --ai value at the parser level (issue #757). Value
+    # validation must fail-fast regardless of whether the named CLI is on
+    # PATH; CLI presence is checked later in _gh_pr_reply_spawn_worker so
+    # the failed:* short-circuit can still trip when the CLI is missing.
+    case "$_ai" in
+        claude|codex|gemini) ;;
+        *)
+            ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
+            return 1
+            ;;
+    esac
+
     # Validate --user (issue #365): only meaningful with --ai claude.
     # Mirrors gwt spawn's policy and reuses _claude_resolve_account SSOT.
     if [ -n "$_account" ]; then
@@ -236,13 +248,16 @@ gh_pr_reply() {
         ux_error "gh CLI not found"
         return 1
     fi
-    if ! _gh_pr_reply_require_ai_cli "$_ai"; then
-        return 1
-    fi
     if ! command -v gwt >/dev/null 2>&1; then
         ux_error "gwt function not loaded (source shell-common first)"
         return 1
     fi
+    # AI CLI presence check is deferred to _gh_pr_reply_spawn_worker (issue
+    # #757). Doing it here would short-circuit the failed-run guard inside
+    # spawn_worker and the dispatcher-level PR-number / main-repo
+    # validation when the CLI is missing — CI runners without claude
+    # installed were tripping the presence check first and never reached
+    # the validation / failed:* state branches the tests assert on.
 
     # Must be in main repo (not a worktree)
     local _git_dir _git_common
@@ -287,26 +302,11 @@ _gh_pr_reply_spawn_worker() {
     local _account="${3:-}"
     local _dir _log _state _pid _cfg_dir _resolve_account
     _dir=$(_gh_pr_reply_pr_dir "$_pr")
-    mkdir -p "$_dir"
-    _log="$_dir/log"
-    printf '%s\n' "$_ai" >"$_dir/ai"
-
-    # Resolve CLAUDE_CONFIG_DIR for the worker (issue #365). Without this,
-    # the bare `claude` binary inside the worker falls back to ~/.claude/
-    # which has no credentials in multi-account setups → "Not logged in".
-    # Priority: explicit --user > $CLAUDE_DEFAULT_ACCOUNT > none.
-    _cfg_dir=""
-    if [ "$_ai" = "claude" ]; then
-        _resolve_account="${_account:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
-        if [ -n "$_resolve_account" ]; then
-            if command -v _claude_resolve_account >/dev/null 2>&1; then
-                _cfg_dir="$(_claude_resolve_account "$_resolve_account" 2>/dev/null || true)"
-            fi
-            [ -z "$_cfg_dir" ] && _cfg_dir="$HOME/.claude-$_resolve_account"
-        fi
-    fi
 
     # Idempotency check — mirrors gh-pr-approve / gh-flow semantics.
+    # Done FIRST (before mkdir, AI CLI presence check, log rotation) so
+    # done / alive / failed:* short-circuits don't require the AI CLI on
+    # PATH and don't leak a state dir (issue #757 — tests 374/375).
     _state=$(_gh_pr_reply_get_state "$_pr")
     case "$_state" in
         done)
@@ -332,6 +332,31 @@ _gh_pr_reply_spawn_worker() {
             return 0
             ;;
     esac
+
+    # AI CLI presence check — deferred here from the dispatcher (issue
+    # #757) so the failed:* / done / alive branches above can short-
+    # circuit without requiring the CLI on PATH. Done before mkdir so
+    # missing-CLI runs leak no state dir.
+    _gh_pr_reply_require_ai_cli "$_ai" || return 1
+
+    mkdir -p "$_dir"
+    _log="$_dir/log"
+    printf '%s\n' "$_ai" >"$_dir/ai"
+
+    # Resolve CLAUDE_CONFIG_DIR for the worker (issue #365). Without this,
+    # the bare `claude` binary inside the worker falls back to ~/.claude/
+    # which has no credentials in multi-account setups → "Not logged in".
+    # Priority: explicit --user > $CLAUDE_DEFAULT_ACCOUNT > none.
+    _cfg_dir=""
+    if [ "$_ai" = "claude" ]; then
+        _resolve_account="${_account:-${CLAUDE_DEFAULT_ACCOUNT:-}}"
+        if [ -n "$_resolve_account" ]; then
+            if command -v _claude_resolve_account >/dev/null 2>&1; then
+                _cfg_dir="$(_claude_resolve_account "$_resolve_account" 2>/dev/null || true)"
+            fi
+            [ -z "$_cfg_dir" ] && _cfg_dir="$HOME/.claude-$_resolve_account"
+        fi
+    fi
 
     # Rotate previous log (keep one .prev for debugging)
     if [ -f "$_log" ]; then


### PR DESCRIPTION
## Summary
- `gh-pr-approve` / `gh-pr-reply` 의 AI CLI 존재 확인이 PR# / worktree 검증보다 먼저 실행되어, claude CLI 가 없는 CI runner 에서 8건 bats 가 동시 fail. #757 이 지정한 8건 모두 해소.
- 자매 호출자(gh_pr_approve.sh ↔ gh_pr_reply.sh) 의 PR# 검증 / main-repo 가드 / AI CLI presence·auth 블록은 현재 중복. 본 PR 은 검사 순서 버그만 한정 수정 — SSOT 추출은 후속 리팩터링.

## Changes
- `shell-common/functions/gh_pr_approve.sh`: `_gh_pr_approve_require_ai_cli` 호출을 precondition 블록에서 PR# / main-repo 검증 직후(auth 가드 옆) 로 이동. 검증 실패 시 'invalid PR number' / 'main repo, not a worktree' 메시지가 CLI 존재 여부와 무관하게 surface.
- `shell-common/functions/gh_pr_reply.sh`:
  - dispatcher 가 `--ai` 값 검증을 parser 단계에서 수행 (이전엔 `_gh_pr_reply_require_ai_cli` 가 동시에 처리하던 역할 분리).
  - CLI presence 체크를 `_gh_pr_reply_spawn_worker` 내부의 state inspection 직후 · mkdir 직전으로 이동. `failed:*` / `done` / `alive` short-circuit 이 CLI 없이도 정상 트립하도록 보장 (tests 374/375).

## 회귀 원인 (git blame)
- 검증/존재 체크 순서 버그는 초기 도입 시점부터 잠재:
  - `b5a98f5 feat(gh-pr-approve): add N-parallel PR approval runner` (2026-04-24)
  - `930107d feat(gh-pr-reply): add N-parallel PR review-reply runner` (2026-04-27)
- CI 환경에서 claude CLI 가 PATH 에 없는 상태로 실행되기 시작하며 표면화.

## Test plan
- [x] 8 target tests (247/248/250 + 358/359/361 + 374/375) — `PATH` 에서 claude 숨긴 CI-simulating 환경에서 모두 ok.
- [x] `tests/bats/functions/` 전체 668/668 ok.
- [x] pytest 1062/1062 passed.
- [x] shellcheck 수정 라인 0 warning.
- [ ] CI green 확인 (push 후 자동 트리거).

## Related
Closes #757

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
