### PR TITLE
fix(ci): #755 Golden Rule 3 위반 3건 정리 — echo→printf + ux_bullet

### DIFF
--- a/shell-common/functions/dotfiles_root.sh
+++ b/shell-common/functions/dotfiles_root.sh
@@ -41,22 +41,22 @@ _resolve_dotfiles_root_canonical() {
     _rdrc_candidate="${1:-}"
 
     if [ -z "$_rdrc_candidate" ]; then
-        echo ""
+        printf '%s\n' ""
         return 0
     fi
 
     if [ ! -d "$_rdrc_candidate" ]; then
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     fi
 
     if [ "${DOTFILES_ROOT_NO_CANONICALIZE:-0}" = "1" ]; then
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     fi
 
     if ! command -v git >/dev/null 2>&1; then
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     fi
 
@@ -69,16 +69,16 @@ _resolve_dotfiles_root_canonical() {
     # so short-circuit and return the candidate untouched. Reported by
     # gemini-code-assist on PR #593.
     _rdrc_git_dir=$(git -C "$_rdrc_candidate" rev-parse --git-dir 2>/dev/null) || {
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     }
     _rdrc_common=$(git -C "$_rdrc_candidate" rev-parse --git-common-dir 2>/dev/null) || {
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     }
 
     if [ -z "$_rdrc_common" ] || [ "$_rdrc_git_dir" = "$_rdrc_common" ]; then
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     fi
 
@@ -89,16 +89,16 @@ _resolve_dotfiles_root_canonical() {
 
     _rdrc_main=$(dirname "$_rdrc_common" 2>/dev/null)
     if [ -z "$_rdrc_main" ] || [ ! -d "$_rdrc_main" ]; then
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     fi
 
     _rdrc_main=$(cd "$_rdrc_main" 2>/dev/null && pwd) || {
-        echo "$_rdrc_candidate"
+        printf '%s\n' "$_rdrc_candidate"
         return 0
     }
 
-    echo "$_rdrc_main"
+    printf '%s\n' "$_rdrc_main"
 }
 
 # _dotfiles_root_canonicalize

--- a/shell-common/functions/gcp.sh
+++ b/shell-common/functions/gcp.sh
@@ -141,7 +141,10 @@ _gcp_author() {
     fi
 
     ux_info "Cherry-picking commits by '$author' in range $commit_range:"
-    echo "$commits"
+    # Display per-SHA via ux_bullet so the list matches the rest of the UI.
+    printf '%s\n' "$commits" | while IFS= read -r _gcp_sha; do
+        [ -n "$_gcp_sha" ] && ux_bullet "$_gcp_sha"
+    done
     echo ""
     # Word-splitting on $commits is intentional — newline-separated SHAs
     # become separate args to _gcp_pick, which then drives the per-commit

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -140,12 +140,13 @@ EOF
         ;;
     esac
 
-    echo "ai=$ai"
-    echo "review=$review"
-    echo "user=$user"
-    echo "post_comment=$post_comment"
-    echo "pr=$pr"
-    echo "remote=$remote"
+    printf '%s\n' \
+        "ai=$ai" \
+        "review=$review" \
+        "user=$user" \
+        "post_comment=$post_comment" \
+        "pr=$pr" \
+        "remote=$remote"
     return 0
 }
 
@@ -490,7 +491,7 @@ _gh_pr_review_estimate_tokens() {
     tokens=$((raw / 4))
     tokens=$(((tokens + 250) / 500 * 500))
     [ "$tokens" -lt 1000 ] && tokens=1000
-    echo "$tokens"
+    printf '%s\n' "$tokens"
 }
 
 # Builds the PR comment body to the given output file. Args: $1 = output
@@ -553,8 +554,8 @@ _gh_pr_review_post_comment() {
         printf '%s\n' "$_url"
         return 0
     fi
-    echo "[WARN] PR comment post failed — output retained on stdout" >&2
-    echo "[WARN] post failed"
+    printf '%s\n' "[WARN] PR comment post failed — output retained on stdout" >&2
+    printf '%s\n' "[WARN] post failed"
     return 0
 }
 


### PR DESCRIPTION
## Summary
- 적색 Golden Rule 3 (`No raw echo in functions/`) 위반 3개 파일을 정리한다.
- 모두 함수의 stdout 반환값 또는 parser key=value 계약 — ux_* 컬러 출력으로 바꾸면 시맨틱이 깨지므로 `echo` → `printf '%s\n'` 치환 (ux_lib 자신도 printf 사용, POSIX 권장 형태).
- 진짜 사용자 표시 한 곳 (`gcp.sh` 의 SHA 리스트) 만 `ux_bullet` 루프로 전환해 ux_info 헤더와 시각 일관성 확보.

## Changes
- `shell-common/functions/dotfiles_root.sh`: 10× `echo "$_rdrc_*"` → `printf '%s\n' ...` — `_resolve_dotfiles_root_canonical` 의 반환 경로, 모두 `$(...)` 으로 소비됨.
- `shell-common/functions/gcp.sh`: `echo "$commits"` → `printf '%s\n' "$commits" | while IFS= read -r _gcp_sha; do ux_bullet "$_gcp_sha"; done` — 사용자에게 보여주는 SHA 리스트라 ux_bullet 으로 일관성 확보.
- `shell-common/functions/gh_pr_review.sh`:
  - parser key=value contract 6 줄 → 다중 인자 `printf '%s\n'` 한 번 호출
  - `echo "$tokens"` (`_gh_pr_review_estimate_tokens` 반환값) → `printf '%s\n'`
  - `[WARN]` 2 건 (stderr 로그 + stdout 결과 문자열, 둘 다 caller 가 `$()` 로 소비) → `printf '%s\n'`

## Test plan
- [x] `bash tests/golden_rules/test_golden_rules.sh` — 5/5 PASS (Rule 3 ✓)
- [x] bats: `gh_pr_review_arg_parse.bats`, `gh_pr_review_remote_url.bats`, `gh_pr_review.bats`, `gcp.bats`, `dotfiles_root.bats` 총 104/104 PASS
- [x] parser 시맨틱 검증: `gh_pr_review_parse --ai claude --review default 999 origin` 출력이 기존 6 줄 key=value 와 동일
- [ ] CI `Test (mise)` — pre-existing red (#755 가 umbrella 로 다루는 28+1 fail) 가 PR 에 상속될 수 있으나, 본 PR 회귀는 아님

## Related
(part of #755 — umbrella 의 "Golden Rules 3 위반 파일 식별 + 별도 PR" AC 항목. 다른 AC (sub-issue 분해, CI red 정상화) 는 후속 PR.)

## 참고
- `mise.toml` 의 `lint-sh` 스코프는 `bash/` 디렉토리에 한정되어 있어 `shell-common/functions/gcp.sh` 의 pre-existing SC3043 (`local` in `#!/bin/sh` 파일) 경고는 CI 차원에서 차단되지 않음. 본 변경은 해당 경고를 도입하지 않음 (`git show main:.../gcp.sh | shellcheck` 동일 출력).


---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
