### PR TITLE
feat(skills): #776 devx:prd-to-trd — PRD → per-component TRD scaffolds

### DIFF
--- a/claude/skills/devx-prd-to-trd/SKILL.md
+++ b/claude/skills/devx-prd-to-trd/SKILL.md
@@ -25,15 +25,16 @@ mutation.**
 
 ## Step 1: Parse Args + Validate PRD
 
-Required positional: one or more `<prd-path>`. Flags: `--dry-run`
+Required positional: exactly one `<prd-path>`. Flags: `--dry-run`
 (default), `--apply`, `--plan-out <path>`
 (default `.claude/.prd-to-trd.plan.md`), `--force`. See
 `references/help.md` for the full table.
 
-Every `<prd-path>` must exist as a regular file. On the first miss,
-print `[FAIL] devx:prd-to-trd: PRD not found: <path>` and stop with
-exit 1. v1 supports a single PRD only — if more than one path is
-supplied, stop with `[FAIL] multi-PRD input not supported in v1`.
+The `<prd-path>` must exist as a regular file — on a miss, print
+`[FAIL] devx:prd-to-trd: PRD not found: <path>` and stop with exit 1.
+v1 supports a single PRD only; if more than one positional argument
+is supplied, stop with `[FAIL] multi-PRD input not supported in v1`
+(multi-PRD batching is OQ-4 for a follow-up).
 
 ## Step 2: Read PRD + Propose Decomposition
 

--- a/claude/skills/devx-prd-to-trd/SKILL.md
+++ b/claude/skills/devx-prd-to-trd/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: devx:prd-to-trd
+description: >-
+  Decompose a Product Requirements Document (PRD) into per-component Technical
+  Requirements Document (TRD) scaffolds following the agent-toolbox 8-section
+  standard (AWS Kiro / Spec Kit / Cursor 6 sections + Google Design Doc 2
+  sections). Use when the user runs /devx:prd-to-trd, /devx-prd-to-trd, or asks
+  "PRD를 TRD로 분해해줘", "PRD 한 개를 컴포넌트별 TRD 여러 개로 쪼개줘", "scaffold TRDs
+  from this product spec". Default mode is `--dry-run` — only writes a Markdown
+  plan; `--apply` writes per-component TRD scaffolds. Never drafts the full TRD
+  body — scaffolds carry an 8-section header + guidance blockquotes only
+  (anti-hallucination). Sister skill of [[devx-trd-to-issues]] — fills the
+  upstream slot in the PRD → TRD → Milestones+Issues pipeline. Accepts
+  `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Edit, Write, Grep
+---
+
+# devx:prd-to-trd — PRD → per-component TRD scaffolds
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. **No API calls, no file
+mutation.**
+
+## Step 1: Parse Args + Validate PRD
+
+Required positional: one or more `<prd-path>`. Flags: `--dry-run`
+(default), `--apply`, `--plan-out <path>`
+(default `.claude/.prd-to-trd.plan.md`), `--force`. See
+`references/help.md` for the full table.
+
+Every `<prd-path>` must exist as a regular file. On the first miss,
+print `[FAIL] devx:prd-to-trd: PRD not found: <path>` and stop with
+exit 1. v1 supports a single PRD only — if more than one path is
+supplied, stop with `[FAIL] multi-PRD input not supported in v1`.
+
+## Step 2: Read PRD + Propose Decomposition
+
+Load the PRD via `Read`. Apply the heuristic in
+`references/decomposition-rules.md` to extract component slugs (6–8,
+kebab-case), responsibility mapping of each PRD `F-#` / `D-#` / `NF-#`
+item, and adjacent-TRD pairs that share a contract.
+
+PRDs with fewer than 2 viable groups → `[WARN] PRD too small —
+single mega-TRD refused. Add more F-#/D-# or split.` and stop.
+
+Locate the TRD template: search `<prd-dir>/trd/_template.md` first;
+on miss, fall back to `references/template-fallback.md`. Both sources
+missing → `[FAIL] template unavailable` + exit 1.
+
+## Step 3: Write Plan
+
+Write the decomposition to `--plan-out` using
+`references/plan-format.md` as the canonical skeleton. The plan is
+the single review surface — the user edits slugs and mappings, then
+re-invokes with `--apply`.
+
+In `--dry-run` (default), **stop here** and print:
+
+```
+Plan written: <plan-out> (<n> components)
+Run with --apply to write TRD scaffolds.
+```
+
+## Step 4: Apply (only if `--apply`)
+
+1. **Re-read plan** — round-trip the user-edited plan from
+   `--plan-out`. Missing plan → stop with
+   `[FAIL] plan not found at <path> — run --dry-run first`.
+2. **For each component slug** — resolve `<prd-dir>/trd/<slug>.md`.
+   - File exists + no `--force` → `[INFO] skip existing: <path>`
+     and continue (idempotent).
+   - Otherwise → render the template with frontmatter (책임 PRD
+     항목, 인접 TRD, 소유자 placeholder) and write the 8-section
+     scaffold per `references/plan-format.md` → "Scaffold layout".
+3. `mkdir -p <prd-dir>/trd/` if needed (never above `<prd-dir>`).
+
+Mid-flow write failure → report partial state (slugs written so far),
+emit `[FAIL] devx:prd-to-trd <reason>` + exit 1. **No automatic
+rollback.**
+
+## Step 5: Report
+
+Print the verdict:
+
+```
+[OK] devx:prd-to-trd plan=<path> components=<n> [scaffolds=<n> skipped=<n>]
+```
+
+`scaffolds=` and `skipped=` appear only on `--apply`. For dry-run,
+append `Next: review <plan-out>, then re-run with --apply`.
+
+Operational constraints: see `references/constraints.md`.

--- a/claude/skills/devx-prd-to-trd/references/constraints.md
+++ b/claude/skills/devx-prd-to-trd/references/constraints.md
@@ -1,0 +1,62 @@
+# Operational Constraints — devx:prd-to-trd
+
+These rules are mandatory and apply to every invocation. They protect
+the PRD source from silent edits, keep the plan as the single review
+surface, and enforce the "AI 범위 폭주 차단" convention from
+agent-toolbox.
+
+## Mutation safety
+
+- **Default is `--dry-run`.** `--apply` must be explicit — never
+  assume it.
+- **Never modify the PRD.** This skill is input-only on the PRD path.
+  Reported PRD gaps go in the plan's `## Manual review` section; the
+  user edits the PRD.
+- **Never write outside `<prd-dir>/trd/`.** Output is scoped to the
+  PRD's directory tree. `mkdir -p` may create `<prd-dir>/trd/` but
+  never anything above it.
+- **Skip-on-exists is the default** — existing TRD scaffolds are
+  protected from accidental overwrite. `--force` is the only way to
+  replace them, and it overwrites with no merge attempt.
+
+## Content safety (anti-hallucination)
+
+- **Never AI-draft the TRD body.** `--apply` writes the 8-section
+  scaffold with blockquoted guidance prompts only. The 500–800 line
+  technical body is human work.
+- **Never invent PRD items.** If the source PRD lacks `F-#` / `D-#`
+  / `NF-#` enumeration, the plan header carries a warning and the
+  mapping table is heading-derived — not synthesized.
+- **Never collapse to a mega-TRD.** PRDs too small to split into ≥ 2
+  components are refused. Single-TRD output violates the agent-
+  toolbox convention.
+
+## Plan integrity
+
+- **Plan is the SSOT.** The user's edits to slugs / mappings on the
+  plan are absolute trust — `--apply` reads the plan, not the PRD.
+  (Open Question OQ-1 in the source issue resolved to "plan = SSOT".)
+- **Plan must round-trip.** A plan written by this skill must be
+  re-parseable by `--apply` without re-reading the PRD. See
+  `references/plan-format.md` for the round-trip invariants.
+
+## Mid-flow failure
+
+- On `--apply` write failure, report the partial state (slugs
+  written, slugs skipped, slug that failed) and stop. **No automatic
+  rollback** — written scaffolds remain on disk; the user decides
+  whether to delete or keep.
+- Template load failure with both `<prd-dir>/trd/_template.md` and
+  `references/template-fallback.md` missing is unrecoverable — exit
+  with `[FAIL] template unavailable`.
+
+## v1 scope limits
+
+- **Single PRD per invocation.** Multi-PRD batching is out of scope
+  (Open Question OQ-4). Multi-PRD input → stop with `[FAIL] multi-PRD
+  input not supported in v1`.
+- **`--components <slug1>,<slug2>,...` override is NOT in v1.** The
+  user edits the plan instead. (Open Question OQ-3.)
+- **Directory-style TRD layouts** (`<prd-dir>/feature/<slug>/trd.md`)
+  are NOT in v1 — output path is fixed as `<prd-dir>/trd/<slug>.md`.
+  (Open Question OQ-2.)

--- a/claude/skills/devx-prd-to-trd/references/decomposition-rules.md
+++ b/claude/skills/devx-prd-to-trd/references/decomposition-rules.md
@@ -14,7 +14,11 @@ matching the agent-toolbox convention (mega-TRD forbidden).
    Model / Pipeline / UI / Security / Deployment / Observability /
    ...). Each group becomes one TRD slug.
 3. **PRD §5 `NF-#` (Non-functional)** — assign each `NF-#` to its
-   highest-impact TRD as the primary. Cross-citation on adjacent TRDs
+   highest-impact TRD as the primary, **at most one per TRD**. When
+   the PRD has fewer `NF-#` items than TRDs, the leftover TRDs land
+   with `(none)` in the `NF-# (primary)` column — never duplicate or
+   synthesize an NF item to fill a slot (collides with
+   "Never invent PRD items" below). Cross-citation on adjacent TRDs
    is allowed; redefinition is not (NF-# is PRD-owned).
 4. **Adjacent-TRD pairs** — slugs that share an explicit contract
    (data schema, API surface, event topic) get a bidirectional
@@ -45,7 +49,7 @@ matching the agent-toolbox convention (mega-TRD forbidden).
 ```
 | Slug | 책임 F-# | 책임 D-# | NF-# (primary) | NF-# (cited) | 인접 TRD |
 |------|----------|----------|----------------|--------------|----------|
-| auth-session | F-1, F-2 | D-3 | NF-1 | NF-2, NF-4 | submission-pipeline |
+| auth-session | F-1,F-2 | D-3 | NF-1 | NF-2,NF-4 | submission-pipeline |
 ```
 
 This table is the round-trip surface — `--apply` reads it back from

--- a/claude/skills/devx-prd-to-trd/references/decomposition-rules.md
+++ b/claude/skills/devx-prd-to-trd/references/decomposition-rules.md
@@ -1,0 +1,79 @@
+# Decomposition Rules — PRD → per-component TRDs
+
+Heuristic the skill applies to every PRD to produce 6–8 per-component
+TRD slugs plus a responsibility map. Goal: per-component split
+matching the agent-toolbox convention (mega-TRD forbidden).
+
+## Extraction order
+
+1. **PRD §3 `D-#` (Decisions)** — treat as cross-cutting constraints.
+   Each `D-#` may be cited on multiple TRDs as a premise but is not
+   *owned* by any single TRD.
+2. **PRD §4 `F-#` (Functional)** — primary signal for component
+   grouping. Group `F-#` items by code-module boundary (Auth / Data
+   Model / Pipeline / UI / Security / Deployment / Observability /
+   ...). Each group becomes one TRD slug.
+3. **PRD §5 `NF-#` (Non-functional)** — assign each `NF-#` to its
+   highest-impact TRD as the primary. Cross-citation on adjacent TRDs
+   is allowed; redefinition is not (NF-# is PRD-owned).
+4. **Adjacent-TRD pairs** — slugs that share an explicit contract
+   (data schema, API surface, event topic) get a bidirectional
+   `인접 TRD` entry in their frontmatter.
+
+## Target counts
+
+- **Component count** — 6 to 8 slugs per PRD. Lower bound 2 (PRDs
+  yielding < 2 viable groups are refused with a `[WARN] PRD too
+  small` verdict).
+- **Items per TRD** — 1 to 7 PRD items (`F-#` + `D-#` + `NF-#`
+  cross-cites). A TRD carrying ≥ 8 items is flagged as a
+  split-candidate in the plan's `## Suggested splits` section but
+  not auto-split (the user decides).
+
+## Slug naming
+
+- kebab-case, 1–3 domain words: `auth-session`, `submission-pipeline`,
+  `item-model`, `observability-tracing`.
+- No version suffixes (`-v1`, `-2025q2`). The TRD frontmatter carries
+  the version.
+- No PRD-section numbers in the slug (`f4-auth` is wrong —
+  agent-toolbox slugs are component-named, not numerically
+  cross-referenced).
+
+## Mapping table (lives in the plan)
+
+```
+| Slug | 책임 F-# | 책임 D-# | NF-# (primary) | NF-# (cited) | 인접 TRD |
+|------|----------|----------|----------------|--------------|----------|
+| auth-session | F-1, F-2 | D-3 | NF-1 | NF-2, NF-4 | submission-pipeline |
+```
+
+This table is the round-trip surface — `--apply` reads it back from
+the plan to fill each TRD's frontmatter.
+
+## Failure cases
+
+- **PRD too small** (< 2 viable groups) → `[WARN] PRD too small —
+  single mega-TRD refused.` Stop with no plan written.
+- **`F-#` items not enumerable** (no F-#/section-header structure)
+  → propose section-heading-based groups, but emit
+  `[WARN] PRD lacks F-#/D-#/NF-# enumeration — slugs are
+  heading-derived` in the plan header.
+- **Slug collision** (heuristic proposes the same kebab-case twice)
+  → suffix `-a` / `-b` and surface in the plan's `## Manual review`
+  section.
+
+## Hard rules
+
+- **Never invent PRD items.** If `F-#`/`D-#`/`NF-#` are not present
+  in the source PRD, do not synthesize them.
+- **Never merge unrelated `F-#` into a single TRD** just to hit the
+  6-slug lower bound. If the PRD is too small, refuse and tell the
+  user to enrich the PRD.
+- **PRD is read-only.** This skill never writes back to the PRD path.
+
+## Pairs with
+
+- `references/plan-format.md` — exact skeleton for the plan + scaffold.
+- `references/template-fallback.md` — TRD scaffold contents when
+  `<prd-dir>/trd/_template.md` is missing.

--- a/claude/skills/devx-prd-to-trd/references/decomposition-rules.md
+++ b/claude/skills/devx-prd-to-trd/references/decomposition-rules.md
@@ -72,8 +72,9 @@ the plan to fill each TRD's frontmatter.
 - **Never invent PRD items.** If `F-#`/`D-#`/`NF-#` are not present
   in the source PRD, do not synthesize them.
 - **Never merge unrelated `F-#` into a single TRD** just to hit the
-  6-slug lower bound. If the PRD is too small, refuse and tell the
-  user to enrich the PRD.
+  6-slug target. If the PRD is too small, refuse and tell the
+  user to enrich the PRD. (Hard lower bound stays at 2 per
+  "Target counts" above; 6 is the recommended target, not a floor.)
 - **PRD is read-only.** This skill never writes back to the PRD path.
 
 ## Pairs with

--- a/claude/skills/devx-prd-to-trd/references/help.md
+++ b/claude/skills/devx-prd-to-trd/references/help.md
@@ -1,0 +1,85 @@
+# devx:prd-to-trd — Help
+
+## Usage
+
+```
+/devx:prd-to-trd <prd-path> [flags]
+/devx-prd-to-trd docs/requirement/product-requirements.md
+/devx-prd-to-trd docs/prd.md --apply
+/devx:prd-to-trd -h            # show this help
+/devx:prd-to-trd --help        # show this help
+/devx:prd-to-trd help          # show this help
+```
+
+## Arguments
+
+| # | Name | Required | Description |
+|---|------|----------|-------------|
+| 1 | `<prd-path>` | yes | Path to the PRD Markdown file. v1 supports a single PRD only. |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | **on** | Default. Writes the plan; **never** writes TRD scaffolds. |
+| `--apply` | off | Reads the plan and writes per-component TRD scaffolds to `<prd-dir>/trd/<slug>.md`. |
+| `--plan-out <path>` | `.claude/.prd-to-trd.plan.md` | Where the plan Markdown lands. |
+| `--force` | off | Overwrite an existing TRD scaffold on `--apply` (otherwise skipped + logged). |
+
+## Examples
+
+```
+# 1. Inspect proposed decomposition (no file writes):
+/devx-prd-to-trd docs/requirement/product-requirements.md
+
+# 2. Custom plan path:
+/devx-prd-to-trd docs/prd.md --plan-out /tmp/prd-plan.md
+
+# 3. Apply (writes <prd-dir>/trd/<slug>.md per component):
+/devx-prd-to-trd docs/prd.md --apply
+
+# 4. Force-overwrite existing scaffolds:
+/devx-prd-to-trd docs/prd.md --apply --force
+```
+
+## What the skill does
+
+1. Reads the PRD and proposes 6–8 per-component slugs + a
+   responsibility map of each PRD `F-#` / `D-#` / `NF-#` item.
+2. Locates the TRD template — `<prd-dir>/trd/_template.md` first,
+   else the built-in `references/template-fallback.md`.
+3. Writes a Markdown plan to `--plan-out` matching
+   `references/plan-format.md`. The plan is the **single review
+   surface** before `--apply`.
+4. **`--apply` only** — re-reads the plan (round-trip) and writes the
+   8-section TRD scaffold per slug under `<prd-dir>/trd/<slug>.md`.
+   Existing files are skipped unless `--force` is set.
+
+## What the skill will NOT do
+
+- Auto-draft the full TRD body — scaffolds carry an 8-section header
+  + guidance blockquotes only. The 500-800 line body is human work
+  (agent-toolbox "AI 범위 폭주 차단" convention).
+- Modify the PRD — input only. PRD gaps are reported, not patched.
+- Create GitHub Issues / Milestones — that is [[devx-trd-to-issues]].
+- Generate a single mega-TRD — agent-toolbox `_template.md` forbids
+  it. PRDs too small to split into ≥ 2 components are refused.
+- Write outside `<prd-dir>/trd/` — output is path-scoped to the PRD's
+  directory tree.
+- Roll back partial writes on a mid-flow `--apply` failure — reports
+  partial state and stops; the user owns cleanup.
+
+## Prerequisites
+
+- A PRD Markdown file with discoverable `F-#` / `D-#` / `NF-#` items
+  (or section headers the heuristic can parse — see
+  `references/decomposition-rules.md`).
+- Write access to `<prd-dir>/trd/` for `--apply`.
+
+## Pairs with
+
+- [[devx-trd-to-issues]] — the **next** step. Takes the TRDs this
+  skill scaffolds (after a human fills them in) and decomposes them
+  into GitHub Milestones + Issues.
+- `gh:issue-create` — single-issue alternative when batch
+  decomposition is overkill.

--- a/claude/skills/devx-prd-to-trd/references/plan-format.md
+++ b/claude/skills/devx-prd-to-trd/references/plan-format.md
@@ -1,0 +1,118 @@
+# Plan + Scaffold Format
+
+Two artifacts live here:
+
+1. The **dry-run plan** the skill writes to `--plan-out`.
+2. The **TRD scaffold** rendered for each slug on `--apply`.
+
+Both must round-trip — a plan written by this skill must be re-parsed
+by this skill (Step 4), and a scaffold rendered from the plan must
+parse back to the same frontmatter on a subsequent `--force` apply.
+
+## Plan skeleton (dry-run output)
+
+```markdown
+# PRD-to-TRD Plan
+Generated: <ISO 8601 local time>
+Source PRD: <prd-path>
+PRD directory: <dirname(prd-path)>
+Mode: dry-run
+Template: <_template.md path | references/template-fallback.md>
+
+## Components
+
+| Slug | 책임 F-# | 책임 D-# | NF-# (primary) | NF-# (cited) | 인접 TRD |
+|------|----------|----------|----------------|--------------|----------|
+| <slug-1> | F-1, F-2 | D-3 | NF-1 | NF-2 | <slug-2> |
+| <slug-2> | F-3 | D-3 | NF-3 | NF-1 | <slug-1> |
+
+## Suggested splits
+<empty list, OR>
+- <slug-X> — carries N items (>= 8), consider sub-splitting.
+
+## Manual review
+<empty list, OR>
+- <slug-Y>-a / <slug-Y>-b — naming collision auto-resolved; review.
+```
+
+## Plan field rules
+
+- **Slug column** — kebab-case, unique per plan.
+- **책임 F-# / D-#** — comma-separated, no spaces around commas.
+- **NF-# (primary)** — exactly one NF item owned by this TRD.
+- **NF-# (cited)** — comma-separated, may be empty.
+- **인접 TRD** — comma-separated slugs that share a contract. May be
+  empty. References must point at slugs in the same plan.
+- **Suggested splits** — rendered as `_no suggestions._` when empty.
+- **Manual review** — rendered as `_none._` when empty.
+
+## Round-trip invariant
+
+- One row per slug in the **Components** table. Adding rows during
+  `--apply` is forbidden; the user must edit the plan and re-run.
+- Heading levels and ordering are stable: `## Components`,
+  `## Suggested splits`, `## Manual review` in that order.
+- Frontmatter block before `## Components` is line-stable
+  (`Generated:` / `Source PRD:` / `PRD directory:` / `Mode:` /
+  `Template:` in order).
+
+## Scaffold layout (--apply output, per slug)
+
+The skill writes `<prd-dir>/trd/<slug>.md` containing this skeleton.
+The first eight `##` headings are mandatory — they are the
+agent-toolbox 8-section standard (AI Spec-Driven 6 + Google Design
+Doc 2). Body under each section is a blockquoted guidance prompt,
+never AI-drafted content.
+
+```markdown
+# TRD: <Component Title> — <Project>
+
+> **상태**: Draft v1 (<YYYY-MM-DD>)
+> **책임 PRD 항목**: <F-#>, <D-#>, <NF-# primary> ([PRD](../<prd-basename>))
+> **인용 NF**: <NF-# cited or "(none)">
+> **소유자**: @<github-handle-placeholder>
+> **인접 TRD**: <slug-A>, <slug-B> | (none)
+
+## 1. Overview
+> 1–2 문장. <Component> 가 무엇이고 책임 PRD 항목을 어떻게 충족하는지.
+
+## 2. Goals / Non-Goals
+### Goals
+> 측정 가능한 목표를 bullet 으로 나열. 각 목표는 책임 F-# / NF-# 와
+> 1:1 매핑되어야 함.
+### Non-Goals
+> 의도적으로 다루지 않는 범위를 명시 — 추후 분리될 TRD 후보.
+
+## 3. Requirements
+### Functional
+> 책임 F-# 를 인용하고 본 TRD 가 구현할 단위로 재기술.
+### Non-functional
+> 책임 NF-# (primary) + 인용 NF-# 를 인용. 재정의 금지 — PRD §5 인용만.
+
+## 4. Design
+> "어떻게" 만 — 인터페이스 / 데이터 모델 / 시퀀스 / 에러 흐름. 본문 채우기
+> 시 800줄 한계 환각 방지. 인접 TRD 와의 계약은 슬러그 링크로 기술.
+
+## 5. Tasks / Validation
+> 본 TRD 가 산출할 구현 단위. 단위 테스트 / 통합 테스트 / 수동 체크 항목.
+> 각 task 는 devx:trd-to-issues 가 GitHub Issue 로 분해할 입력.
+
+## 6. References
+> 책임 PRD 항목 + 인접 TRD + 외부 spec / RFC 링크.
+
+## 7. Alternatives Considered
+> 이 디자인이 채택되지 않은 대안과 거절 사유를 표로.
+
+## 8. Open Questions
+> 결정 못 한 항목. 본 TRD 가 머지되기 전 해결 필요.
+```
+
+## Hard rules
+
+- **Never AI-draft content under the 8 section headers.** Only the
+  blockquoted guidance prompt is allowed. The human fills the body.
+- **Frontmatter slot order is fixed.** 상태 / 책임 PRD 항목 / 인용
+  NF / 소유자 / 인접 TRD — `--apply` writes them in this order so
+  re-reads parse deterministically.
+- **PRD link is relative.** Use `../<prd-basename>`; never an absolute
+  path.

--- a/claude/skills/devx-prd-to-trd/references/plan-format.md
+++ b/claude/skills/devx-prd-to-trd/references/plan-format.md
@@ -23,8 +23,9 @@ Template: <_template.md path | references/template-fallback.md>
 
 | Slug | 책임 F-# | 책임 D-# | NF-# (primary) | NF-# (cited) | 인접 TRD |
 |------|----------|----------|----------------|--------------|----------|
-| <slug-1> | F-1, F-2 | D-3 | NF-1 | NF-2 | <slug-2> |
+| <slug-1> | F-1,F-2 | D-3 | NF-1 | NF-2 | <slug-2> |
 | <slug-2> | F-3 | D-3 | NF-3 | NF-1 | <slug-1> |
+| <slug-3> | F-4 | (none) | (none) | NF-1 | (none) |
 
 ## Suggested splits
 <empty list, OR>
@@ -39,10 +40,17 @@ Template: <_template.md path | references/template-fallback.md>
 
 - **Slug column** — kebab-case, unique per plan.
 - **책임 F-# / D-#** — comma-separated, no spaces around commas.
-- **NF-# (primary)** — exactly one NF item owned by this TRD.
-- **NF-# (cited)** — comma-separated, may be empty.
+  Empty cells are rendered as `(none)` — never blank — so the
+  round-trip parser can distinguish "no items" from "missing column".
+- **NF-# (primary)** — at most one NF item owned by this TRD (0 or 1).
+  When the PRD has fewer `NF-#` items than TRDs, or none apply to this
+  component, the cell is rendered as `(none)`. Never synthesize an NF
+  item to fill the slot (collides with `decomposition-rules.md` →
+  "Never invent PRD items").
+- **NF-# (cited)** — comma-separated, may be empty (rendered `(none)`).
 - **인접 TRD** — comma-separated slugs that share a contract. May be
-  empty. References must point at slugs in the same plan.
+  empty (rendered `(none)`). References must point at slugs in the
+  same plan.
 - **Suggested splits** — rendered as `_no suggestions._` when empty.
 - **Manual review** — rendered as `_none._` when empty.
 
@@ -68,7 +76,7 @@ never AI-drafted content.
 # TRD: <Component Title> — <Project>
 
 > **상태**: Draft v1 (<YYYY-MM-DD>)
-> **책임 PRD 항목**: <F-#>, <D-#>, <NF-# primary> ([PRD](../<prd-basename>))
+> **책임 PRD 항목**: <F-#>, <D-#>[, <NF-# primary>] ([PRD](../<prd-basename>))
 > **인용 NF**: <NF-# cited or "(none)">
 > **소유자**: @<github-handle-placeholder>
 > **인접 TRD**: <slug-A>, <slug-B> | (none)

--- a/claude/skills/devx-prd-to-trd/references/template-fallback.md
+++ b/claude/skills/devx-prd-to-trd/references/template-fallback.md
@@ -16,8 +16,7 @@ plan's Components table before writing.
 
 > **상태**: Draft v1 ({{iso-date}})
 > **책임 PRD 항목**: {{responsible-prd-items}} ([PRD](../{{prd-basename}}))
-> *(F-# + D-# 는 필수, NF-# primary 는 0 또는 1 개 — 없으면 슬롯 생략)*
-> **인용 NF**: {{cited-nf-items}}  *(없으면 `(none)`)*
+> **인용 NF**: {{cited-nf-items}}
 > **소유자**: @{{owner-placeholder}}
 > **인접 TRD**: {{adjacent-trd-slugs}}
 
@@ -79,6 +78,24 @@ plan's Components table before writing.
 > 결정 못 한 항목. 본 TRD 가 머지 / 구현 시작 전 해결 필요.
 > 형태: "OQ-1: <질문>; 차단되는 의사결정: <…>; 제안된 해결: <…>"
 ```
+
+## Frontmatter field rules (outside the verbatim block)
+
+The 5 frontmatter slots above (`상태` / `책임 PRD 항목` / `인용 NF`
+/ `소유자` / `인접 TRD`) follow the same line-stability invariants as
+`plan-format.md` → "Plan field rules":
+
+- `책임 PRD 항목` carries `F-#` + `D-#` (both required) plus an
+  optional `NF-#` primary (0 or 1 — never synthesize one to fill the
+  slot; collides with `decomposition-rules.md` → "Never invent PRD
+  items"). When omitted, only `F-#, D-#` appears.
+- `인용 NF` is rendered as `(none)` when empty — never blank — so the
+  round-trip parser distinguishes "no cites" from "missing slot".
+- `인접 TRD` is rendered as `(none)` when no adjacent slug exists.
+
+These notes live **outside** the verbatim template block on purpose:
+the block must be copy-pasteable into a real TRD with no manual
+cleanup of inline annotations (#778 review).
 
 ## Why this template is built-in
 

--- a/claude/skills/devx-prd-to-trd/references/template-fallback.md
+++ b/claude/skills/devx-prd-to-trd/references/template-fallback.md
@@ -16,7 +16,8 @@ plan's Components table before writing.
 
 > **상태**: Draft v1 ({{iso-date}})
 > **책임 PRD 항목**: {{responsible-prd-items}} ([PRD](../{{prd-basename}}))
-> **인용 NF**: {{cited-nf-items}}
+> *(F-# + D-# 는 필수, NF-# primary 는 0 또는 1 개 — 없으면 슬롯 생략)*
+> **인용 NF**: {{cited-nf-items}}  *(없으면 `(none)`)*
 > **소유자**: @{{owner-placeholder}}
 > **인접 TRD**: {{adjacent-trd-slugs}}
 

--- a/claude/skills/devx-prd-to-trd/references/template-fallback.md
+++ b/claude/skills/devx-prd-to-trd/references/template-fallback.md
@@ -1,0 +1,94 @@
+# TRD Scaffold — Built-in Fallback Template
+
+The skill loads `<prd-dir>/trd/_template.md` first; if absent, it uses
+the verbatim block below. This template is the **agent-toolbox
+8-section standard** (AI Spec-Driven 6 sections — AWS Kiro / Spec Kit
+/ Cursor — plus Google Design Doc 2 sections: Goals/Non-Goals,
+Alternatives Considered).
+
+Placeholders use `{{...}}` syntax. `--apply` substitutes them from the
+plan's Components table before writing.
+
+## Verbatim template
+
+```markdown
+# TRD: {{component-title}} — {{project-name}}
+
+> **상태**: Draft v1 ({{iso-date}})
+> **책임 PRD 항목**: {{responsible-prd-items}} ([PRD](../{{prd-basename}}))
+> **인용 NF**: {{cited-nf-items}}
+> **소유자**: @{{owner-placeholder}}
+> **인접 TRD**: {{adjacent-trd-slugs}}
+
+## 1. Overview
+> 1–2 문장. {{component-title}} 가 무엇이고 책임 PRD 항목을 어떻게 충족하는지.
+> "왜" / "무엇" 은 PRD 를 인용하고, 본 TRD 는 "어떻게" 만 다룬다.
+
+## 2. Goals / Non-Goals
+### Goals
+> 측정 가능한 목표를 bullet 으로 나열. 각 목표는 책임 F-# / NF-# 와 1:1 매핑.
+> 형태: "G-1: <목표> — 책임 F-#: <…>; 검증: <어떻게 측정/테스트>"
+
+### Non-Goals
+> 의도적으로 다루지 않는 범위. 추후 분리될 TRD 후보 / 다른 컴포넌트 소관.
+
+## 3. Requirements
+### Functional
+> 책임 F-# 를 인용하고 본 TRD 가 구현할 단위로 재기술. PRD 의 F-# 는 What,
+> 여기 R-F# 는 How 의 진입점이다. 형태: "R-F1: <기능> (PRD F-X)"
+
+### Non-functional
+> 책임 NF-# (primary) + 인용 NF-# 를 인용. **재정의 금지** — PRD §5 인용만.
+> 형태: "R-NF1: <PRD NF-Y 인용>; 본 TRD 영향: <…>"
+
+## 4. Design
+> "어떻게" 만. 다음 하위 구조를 권장:
+> - 인터페이스 (함수 시그니처 / API endpoint / 이벤트 토픽 / CLI flag)
+> - 데이터 모델 (스키마 / 클래스 / 상태 머신)
+> - 시퀀스 / 흐름 (정상 경로 + 주요 분기)
+> - 에러 흐름 (예외 / 타임아웃 / 부분 실패 / 재시도 정책)
+> - 인접 TRD 와의 계약 (참조 슬러그 + 인터페이스 한정)
+>
+> 본문 채우기 시 800줄 한계 / AI 환각 주의. 결정성 있는 부분만 기술하고,
+> 미결정은 §8 Open Questions 로 이동.
+
+## 5. Tasks / Validation
+> 본 TRD 가 산출할 구현 단위. 각 task 는 devx:trd-to-issues 가 GitHub Issue
+> 로 분해할 입력 — 따라서 다음 기준을 따라야 한다:
+> - AC 1–3 개 / unit-testable / independently committable
+> - Task 당 변경 파일 ≤ 5 / 신규 LOC ≤ 300 (pro-friendly), 초과 시 max-only
+>
+> 형태:
+> - [ ] T-1: <Task title> — 책임 R-F#: <…>; AC: <1–3 개>
+
+## 6. References
+> - 책임 PRD 항목 anchored 링크 (PRD `#f-1` 등)
+> - 인접 TRD 슬러그 링크
+> - 외부 spec / RFC / 라이브러리 문서
+> - 선행 결정 (ADR / discussion / 이전 PR)
+
+## 7. Alternatives Considered
+> 이 디자인이 채택되지 않은 대안과 거절 사유를 표로:
+>
+> | 대안 | 거절 사유 |
+> |---|---|
+> | <…> | <…> |
+
+## 8. Open Questions
+> 결정 못 한 항목. 본 TRD 가 머지 / 구현 시작 전 해결 필요.
+> 형태: "OQ-1: <질문>; 차단되는 의사결정: <…>; 제안된 해결: <…>"
+```
+
+## Why this template is built-in
+
+`<prd-dir>/trd/_template.md` is the **project-owned** template — it
+should be the source of truth in any repo that has adopted the
+agent-toolbox convention. This file is the **fallback** that lets
+`devx:prd-to-trd` work in repos that haven't yet bootstrapped the
+template. The two must stay structurally compatible: same 8 section
+headings, same frontmatter slots in the same order.
+
+If a project edits its `<prd-dir>/trd/_template.md` to add a 9th
+section or reorder frontmatter, the plan's round-trip parser still
+expects the 8-section layout — re-run with `--force` to overwrite
+existing scaffolds, or update this fallback in lock-step.

--- a/claude/skills/devx-trd-to-issues/references/help.md
+++ b/claude/skills/devx-trd-to-issues/references/help.md
@@ -89,6 +89,9 @@
 
 ## Pairs with
 
+- [[devx-prd-to-trd]] — the **previous** step. Scaffolds the
+  per-component TRDs this skill consumes (PRD → TRD scaffolds → human
+  fills body → this skill → Milestones + Issues).
 - `gh:issue-implement` / `gh:issue-flow` — pick up Task issues this
   skill registered and implement them.
 - `gh:issue-create` — single-issue alternative when batch decomposition


### PR DESCRIPTION
## Summary
- 새 스킬 `devx:prd-to-trd` 추가 — PRD 1개를 입력으로 받아 agent-toolbox 8-섹션 컨벤션(AWS Kiro/Spec Kit/Cursor 6 + Google Design Doc 2)을 따르는 per-component TRD 스캐폴드를 생성.
- `devx:trd-to-issues` 의 앞 단계 — `PRD → (이 스킬) → TRD → trd-to-issues → Milestones+Issues` 파이프라인의 첫 칸을 채움. 자매 스킬과 양방향 cross-link.
- 2-phase 워크플로: `--dry-run` (기본, plan 작성) → 사용자 검토 → `--apply` (스캐폴드 생성). 스캐폴드 only — 본문 800줄 자동 드래프트 금지(agent-toolbox "AI 범위 폭주 차단" 정합).

## Changes
- `claude/skills/devx-prd-to-trd/SKILL.md` — 94줄(NF-1 ≤100 준수). Step 1~5(인자 파싱 → PRD 분해 → plan 작성 → apply → 리포트) + Help 진입점.
- `claude/skills/devx-prd-to-trd/references/help.md` — `-h/--help/help` verbatim 출력용. 인자/플래그 표, 예시 4종, "Pairs with" 섹션.
- `claude/skills/devx-prd-to-trd/references/decomposition-rules.md` — PRD `F-#/D-#/NF-#` 추출 휴리스틱, 6~8 슬러그 타깃, 슬러그 명명 규칙, 실패 케이스 정의.
- `claude/skills/devx-prd-to-trd/references/plan-format.md` — dry-run plan 스켈레톤(컴포넌트 매핑 표) + `--apply` 스캐폴드 레이아웃(8-섹션 + frontmatter). 라운드-트립 invariant 명세.
- `claude/skills/devx-prd-to-trd/references/template-fallback.md` — `<prd-dir>/trd/_template.md` 부재 시 사용할 내장 8-섹션 표준 템플릿(verbatim).
- `claude/skills/devx-prd-to-trd/references/constraints.md` — 운영 제약: PRD 비파괴, 멱등성, 단일 PRD only(v1), 메가-TRD 거절, 스캐폴드 only(anti-hallucination).
- `claude/skills/devx-trd-to-issues/references/help.md` — "Pairs with" 섹션에 `[[devx-prd-to-trd]]` back-link 추가(이슈 AC).

## Test plan
- [x] `tests/test` 전체 통과(1062 passed)
- [x] SKILL.md 라인 카운트 94줄(NF-1 ≤100 준수)
- [x] references/ 파일 5개 모두 작성
- [x] 자매 스킬 양방향 cross-link 확인
- [ ] (수동) `agent-toolbox` repo에서 `/devx-prd-to-trd <prd>` dry-run → plan 생성 검증
- [ ] (수동) `--apply` 호출 시 `<prd-dir>/trd/<slug>.md` 스캐폴드 생성 및 멱등성 검증
- [ ] (수동) `--force` 호출 시 기존 TRD overwrite 동작 검증

## Related
Closes #776

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
