### PR TITLE
fix(skill): #747 gh-pr Step 7 board-sync — inline snippet to prevent silent skip

### DIFF
--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -108,10 +108,61 @@ exist in the repo (`gh label list`) — never create new ones. See
 
 ## Step 7: Sync Project Board Status
 
-Read `references/project-board-sync.md` for the helper-source snippet
-that pushes the new PR's project-board card to `In review`. The
-reference also documents the PostToolUse hook auto-skip (issue #390)
-and the no-projectV2 fallback.
+Push the new PR card to `In review` and correct any linked Issue cards
+the GitHub builtin mis-moved to `In review` (Issues belong in
+`In progress` — see `references/project-board-sync.md` for the
+rationale, hook auto-skip narrative, and `GH_REPO` requirement).
+
+First, detect a PostToolUse hook that already handles this sync — when
+present, skip the inline call to avoid triple-syncing (issue #390):
+
+```bash
+hook_skip=0
+for hook_path in \
+    "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/post-pr-create-status.sh" \
+    "$HOME/.claude/hooks/post-gh-pr-create.sh" \
+    "$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh"
+do
+    if [ -x "$hook_path" ]; then
+        hook_skip=1
+        printf '[gh-pr] board sync delegated to PostToolUse hook (%s) — skipping inline.\n' "$hook_path" >&2
+        break
+    fi
+done
+
+if [ "$hook_skip" -eq 0 ]; then
+    # helper-fallback NF-1 (#644): silent-skip when helper missing.
+    # Defense-in-depth (#724): also detect "[ -r ] passes but function never
+    # defined" (interactive-guard regression, partial sourcing, future rename).
+    # `|| true` would otherwise absorb `command not found` (rc 127) and the
+    # entire reconciliation would silently no-op — the failure mode from #724.
+    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        . "$_HELPER"
+        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+            printf '[gh-pr] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+                "$_HELPER" >&2
+        else
+            _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
+            for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
+                _gh_project_status_sync issue "$_issue" "In progress" \
+                    --only-from "Backlog,Ready,In review" || true
+            done
+        fi
+    fi
+fi
+```
+
+`GH_REPO` must be `owner/repo` (e.g. `dEitY719/dotfiles`). If unavailable,
+resolve it via `gh repo view --json nameWithOwner --jq .nameWithOwner`.
+Opt-out per invocation: `GH_PROJECT_STATUS_SYNC=0`. Repos without a
+projectV2 board auto-skip silently (helper returns 0).
+
+Track the outcome for Step 8's report row:
+- `hook_skip=1` → `[SKIP]: hook auto-skip`
+- helper missing or function undefined → `[SKIP]: helper unavailable`
+- helper ran, no projectV2 board → `[SKIP]: no projectV2`
+- helper ran with at least one card moved → `[OK]: PR card -> "In review"`
 
 ## Step 8: Report
 
@@ -119,8 +170,13 @@ and the no-projectV2 fallback.
 
 ```
 [OK] PR: https://github.com/owner/repo/pull/<N>
+[OK] Board sync: PR card -> "In review" (or [SKIP]: hook auto-skip / no projectV2 / helper unavailable)
 Next: /gh:pr-reply (after CI green) — replies to review comments
 ```
+
+The `Board sync:` row is a defense-in-depth visual checklist (issue
+#747) — its absence in conversation transcripts is a regression signal
+that Step 7 was silently skipped.
 
 Step 1b empty-range / on-base-branch stops, Step 1a `rc=2`/`rc=3`, or
 Step 4.5 lint failure:

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -144,6 +144,14 @@ if [ "$hook_skip" -eq 0 ]; then
                 "$_HELPER" >&2
         else
             _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
+            # Auto-resolve GH_REPO when unset/empty so the linked-issues
+            # sync isn't silently no-op'd by an empty repo arg (PR #780
+            # review). Matches the existing convention in
+            # shell-common/functions/gh_pr_edit_safe.sh and
+            # gh_audit_builtin_workflows.sh.
+            if [ -z "${GH_REPO:-}" ]; then
+                GH_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+            fi
             for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
                 _gh_project_status_sync issue "$_issue" "In progress" \
                     --only-from "Backlog,Ready,In review" || true
@@ -153,10 +161,12 @@ if [ "$hook_skip" -eq 0 ]; then
 fi
 ```
 
-`GH_REPO` must be `owner/repo` (e.g. `dEitY719/dotfiles`). If unavailable,
-resolve it via `gh repo view --json nameWithOwner --jq .nameWithOwner`.
-Opt-out per invocation: `GH_PROJECT_STATUS_SYNC=0`. Repos without a
-projectV2 board auto-skip silently (helper returns 0).
+`GH_REPO` should be `owner/repo` (e.g. `dEitY719/dotfiles`). The block
+auto-resolves it via `gh repo view --json nameWithOwner --jq
+.nameWithOwner` when unset/empty so the linked-issues loop never
+silently no-ops on a missing env var. Opt-out per invocation:
+`GH_PROJECT_STATUS_SYNC=0`. Repos without a projectV2 board auto-skip
+silently (helper returns 0).
 
 Track the outcome for Step 8's report row:
 - `hook_skip=1` → `[SKIP]: hook auto-skip`

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -54,10 +54,16 @@ still refusing to drag `Done` Issues backwards if a closed PR is re-opened (#309
 ## `GH_REPO` requirement
 
 The closing-issues helper (`_gh_pr_closing_issue_numbers`) needs the repo
-slug as `owner/repo` (e.g. `dEitY719/dotfiles`). If `GH_REPO` is unset at
-the point Step 7 runs, resolve it via
-`gh repo view --json nameWithOwner --jq .nameWithOwner`. This is a thin
-wrapper — no auth state changes, no API mutation.
+slug as `owner/repo` (e.g. `dEitY719/dotfiles`). The Step 7 snippet
+auto-resolves `GH_REPO` inline when it is unset/empty via
+`gh repo view --json nameWithOwner --jq .nameWithOwner` — added in
+response to the PR #780 review: an unset `GH_REPO` would otherwise pass
+an empty string to `_gh_pr_closing_issue_numbers`, the helper would
+return immediately, and the linked-issues sync loop would silently
+no-op. The fallback is a thin wrapper — no auth state changes, no API
+mutation — and matches the existing convention in
+`shell-common/functions/gh_pr_edit_safe.sh` /
+`gh_audit_builtin_workflows.sh`.
 
 ## Behavior summary
 

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -1,41 +1,36 @@
-# Project Board Sync — push the new PR's card to "In review" + linked Issues to "In progress"
+# Project Board Sync — narrative + rationale
+
+> **Canonical executable snippet lives in `SKILL.md` Step 7.** This file is
+> the narrative companion — rationale, edge cases, and pointers — not a
+> source of code. If you find yourself copying bash out of here into the
+> skill, you've found a regression of issue #747.
 
 After the PR is created, sync cards on the kanban so reviewers see the PR and
-the linked Issues are at the right column without a manual drag.
+the linked Issues are at the right column without a manual drag. Two cards
+need to move:
+
+- The new **PR card** → `In review`.
+- Each linked **Issue card** (anything matched by `Closes #N` in the PR
+  body) → `In progress`, correcting the GitHub builtin's mis-move to
+  `In review`.
 
 ## Hook auto-skip (issue #390)
 
 If a PostToolUse hook is going to do this work, the skill must NOT run the
 inline sync — triple-syncing (skill + hook + GitHub builtin) wastes tokens
-and widens the race window. Detect the hook by file presence and skip:
+and widens the race window. The skill detects the hook by file presence
+across three paths:
 
-```bash
-hook_skip=0
-for hook_path in \
-    "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/post-pr-create-status.sh" \
-    "$HOME/.claude/hooks/post-gh-pr-create.sh" \
-    "$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh"
-do
-    if [ -x "$hook_path" ]; then
-        hook_skip=1
-        printf '[gh-pr] board sync delegated to PostToolUse hook (%s) — skipping inline.\n' "$hook_path" >&2
-        break
-    fi
-done
+1. `${REPO_ROOT}/.claude/hooks/post-pr-create-status.sh` —
+   AgentToolbox-style in-repo hook.
+2. `$HOME/.claude/hooks/post-gh-pr-create.sh` — runtime copy.
+3. `$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh` — dotfiles SSOT.
 
-if [ "$hook_skip" -eq 0 ]; then
-    # Run the snippet below.
-    :
-fi
-```
-
-The three paths cover (a) AgentToolbox-style in-repo hook, (b) a runtime
-copy at `~/.claude/hooks/`, and (c) the dotfiles SSOT location. When **any**
-exists, the inline snippet is skipped — the hook (or the AgentToolbox hook)
-will handle it. When none exist, the inline snippet runs as a fallback,
-preserving behavior for environments without hook support. Idempotence of
-`_gh_project_status_sync` (verify pair, issue #393) absorbs the case where
-both a dotfiles hook and an AgentToolbox hook fire.
+When **any** path exists, the inline snippet is skipped and the hook (or
+AgentToolbox hook) handles it. When none exist, the inline snippet runs
+as a fallback, preserving behavior for environments without hook support.
+Idempotence of `_gh_project_status_sync` (verify pair, issue #393) absorbs
+the case where both a dotfiles hook and an AgentToolbox hook fire.
 
 ## Why "In review" with no guard (PR card)
 
@@ -56,36 +51,15 @@ PR is created corrects the builtin's transition. The
 so we can undo the builtin's mis-move even when it fires before our sync, while
 still refusing to drag `Done` Issues backwards if a closed PR is re-opened (#309).
 
-## Snippet
+## `GH_REPO` requirement
 
-Source the shared helper, then call it with the new PR number:
+The closing-issues helper (`_gh_pr_closing_issue_numbers`) needs the repo
+slug as `owner/repo` (e.g. `dEitY719/dotfiles`). If `GH_REPO` is unset at
+the point Step 7 runs, resolve it via
+`gh repo view --json nameWithOwner --jq .nameWithOwner`. This is a thin
+wrapper — no auth state changes, no API mutation.
 
-```bash
-# helper-fallback NF-1 (#644): silent-skip when helper missing.
-# Defense-in-depth (#724): also detect "[ -r ] passes but function never
-# defined" (interactive-guard regression, partial sourcing, future rename).
-# `|| true` would otherwise absorb `command not found` (rc 127) and the
-# entire reconciliation would silently no-op — the failure mode from #724.
-_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-if [ -r "$_HELPER" ]; then
-    . "$_HELPER"
-    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-        printf '[gh-pr] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
-            "$_HELPER" >&2
-    else
-        _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
-        for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
-            _gh_project_status_sync issue "$_issue" "In progress" \
-                --only-from "Backlog,Ready,In review" || true
-        done
-    fi
-fi
-```
-
-`GH_REPO` must be `owner/repo` (e.g. `dEitY719/dotfiles`). If unavailable,
-resolve it via `gh repo view --json nameWithOwner --jq .nameWithOwner`.
-
-## Behavior
+## Behavior summary
 
 - **No projectV2 board attached** — the helper auto-detects zero project items
   and silently returns 0. Nothing happens, no error.
@@ -93,9 +67,17 @@ resolve it via `gh repo view --json nameWithOwner --jq .nameWithOwner`.
   nothing; the for-loop body never runs. PR sync still proceeds.
 - **Opt-out per invocation** — set `GH_PROJECT_STATUS_SYNC=0` in the
   environment to skip both syncs entirely.
+- **Helper unavailable** — when `_HELPER` is unreadable, the inline block
+  silently skips (NF-1 fallback, #644). When the file sources but the
+  function is undefined (interactive-guard regression, partial sourcing,
+  future rename), an explicit `#724` warning is printed and the sync is
+  skipped — preventing the silent `rc 127` swallow.
 
 ## Where the helper lives
 
 `shell-common/functions/gh_project_status.sh` — shared between `gh:pr`,
-`gh:pr-reply`, and other PR/issue lifecycle skills. Do not inline-copy the
-snippet; always source the file so a single fix propagates everywhere.
+`gh:pr-reply`, and other PR/issue lifecycle skills. The skill **sources**
+this file; do not duplicate the helper's implementation. The bash that
+*calls* the helper, however, is intentionally inlined in `SKILL.md`
+Step 7 (issue #747) so the model reads it linearly during execution
+without a reference-load indirection.

--- a/tests/bats/skills/_fixtures/helper_fallback_nf1.sh
+++ b/tests/bats/skills/_fixtures/helper_fallback_nf1.sh
@@ -5,7 +5,7 @@
 #   claude/skills/gh-pr-merge/SKILL.md           (Step 2-B, Step 4)
 #   claude/skills/gh-commit/SKILL.md             (Step 5)
 #   claude/skills/gh-pr-reply/SKILL.md           (Step 6.5)
-#   claude/skills/gh-pr/references/project-board-sync.md
+#   claude/skills/gh-pr/SKILL.md                 (Step 7 — inlined in #747)
 #   claude/skills/gh-pr-merge/references/project-board-sync.md
 #   claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
 #

--- a/tests/bats/skills/helper_fallback_nf1.bats
+++ b/tests/bats/skills/helper_fallback_nf1.bats
@@ -76,13 +76,15 @@ teardown() {
     assert_success
 
     # Spot-check that each updated SKILL.md/reference also carries the guard.
+    # NOTE: gh-pr's canonical executable snippet moved from
+    # references/project-board-sync.md → SKILL.md Step 7 in issue #747.
     local f
     for f in \
         "claude/skills/gh-pr-merge/SKILL.md" \
         "claude/skills/gh-pr-merge/references/project-board-sync.md" \
         "claude/skills/gh-commit/SKILL.md" \
         "claude/skills/gh-pr-reply/SKILL.md" \
-        "claude/skills/gh-pr/references/project-board-sync.md" \
+        "claude/skills/gh-pr/SKILL.md" \
         "claude/skills/gh-pr-merge-emergency/references/project-board-sync.md"; do
         run grep -F 'if [ -r "$_HELPER" ]; then' "${_BATS_REAL_DOTFILES_ROOT}/$f"
         assert_success


### PR DESCRIPTION
## Summary
- `gh-pr` SKILL.md Step 7 previously delegated board-sync execution to `references/project-board-sync.md`. The reference-load step was silently skipped in observed runs (quantfolio PR #35 stayed at `Backlog`), bypassing the inline snippet entirely.
- Lift the `_HELPER` source + `_gh_project_status_sync` block into `SKILL.md` Step 7 verbatim, mirroring `gh-commit` Step 5's inline pattern. The reference file is trimmed to narrative-only.
- Step 8 success template gains a `Board sync:` checklist row so a silent skip is visible in transcripts.

## Changes
- `claude/skills/gh-pr/SKILL.md` Step 7 — inlined hook auto-skip loop + helper source-and-call block (including #724 defense-in-depth guard). Step 8 success template adds a `Board sync:` row.
- `claude/skills/gh-pr/references/project-board-sync.md` — rewritten as a narrative companion: hook auto-skip rationale, "Why In review" / "Why In progress for linked Issues", `GH_REPO` requirement, behavior summary. The Snippet section is removed; the file now opens with a pointer back to SKILL.md as the canonical executable copy.
- `tests/bats/skills/helper_fallback_nf1.bats` — drift-guard list updated: the gh-pr canonical pattern moved from `references/project-board-sync.md` → `SKILL.md`. Added an in-test comment naming issue #747.
- `tests/bats/skills/_fixtures/helper_fallback_nf1.sh` — header comment list updated to match the same move.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/helper_fallback_nf1.bats` — 4/4 pass.
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/skills/` — 247/247 pass with 0 failures.
- [ ] CI green on the full mise lint + test matrix.
- [ ] Sanity-check on the next real `/gh-pr` invocation that the Step 8 report includes the new `Board sync:` row.

## Related
Closes #747

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
