### PR TITLE
fix(gwt-spawn): #781 VSCode AI-agent detect 회피 — claude tab title sticky 화

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1780,6 +1780,17 @@ git_worktree_spawn() {
                 ux_info "          (see \`term-help vscode\`)"
             fi
             term_rename --persist "(${agent}) ${name}"
+            # VSCode 의 AI-agent foreground detect (ptyHostMain.js 의
+            # claude-code/codex/copilot/gemini-cli regex) 가 agent 기동
+            # 직후 ${sequence} 를 자체 title 로 일시 override 한다. 그
+            # detect 가 settle 된 뒤에 OSC 0 을 한 번 더 발사하면 이후엔
+            # sticky 하게 우리 라벨이 유지됨 — 경험적으로 #781 에서 확인.
+            # alt-screen TUI 는 OSC bytes 를 무시하므로 claude 렌더링과
+            # 충돌하지 않는다. 3s 는 claude 기동 + detect settle 의
+            # 헤드룸; 느린 머신이면 키워야 할 수 있음.
+            if [ "${TERM_PROGRAM-}" = "vscode" ]; then
+                (sleep 3; printf '\033]0;(%s) %s\007' "$agent" "$name") &
+            fi
         fi
         eval "$launch_cmd"
     else


### PR DESCRIPTION
## Summary
- `gwt spawn --launch --ai claude` 실행 시 의도한 탭 라벨 `(claude) <wt-name>` 이 claude TUI 가 떠 있는 동안 표시되지 않고 VSCode 가 process name (`zsh`/`node`/`claude`) 으로 그려버리던 회귀 해결.
- Root cause: `~/.vscode-server/.../ptyHostMain.js` 의 `claude-code/codex/copilot/gemini-cli` regex 가 foreground process 를 detect 해서 `${sequence}` 를 자체 title 로 일시 override. 우리 `term_rename --persist` 가 그 detect *전에* OSC 0 을 발사해 silent override 됨.
- Fix: `gwt_spawn` 의 `term_rename --persist` 직후, `TERM_PROGRAM=vscode` 일 때만 backgrounded sleep 3s + OSC 0 재발사. detect 가 settle 된 뒤 발사하므로 sticky 하게 우리 라벨 유지.

## Changes
- `shell-common/functions/git_worktree.sh:1778-1789` — `git_worktree_spawn()` 안 `term_rename --persist` 호출 직후 11 줄 추가. `TERM_PROGRAM=vscode` 가드로 다른 emulator (iTerm / Windows Terminal / kitty 등) 에서는 race 발사하지 않음 (불필요).

## Test plan
- [ ] 새 zsh 세션에서 `source shell-common/functions/git_worktree.sh` 후 `gwt spawn --launch --ai claude --user personal --wt-name verify` 실행 → claude TUI 기동 ~3 초 후 탭이 `(claude) verify` 로 갱신되고 유지되는지 확인.
- [ ] `/exit` 후 셸 프롬프트 복귀 시점에도 precmd hook 이 같은 라벨 유지하는지 확인 (기존 동작 회귀 없음).
- [ ] `--bg` 모드 (`gwt spawn --launch --bg ...`) 에서도 무해함 확인 — 사용자는 셸 프롬프트에 있고 precmd hook 이 같은 라벨 재발사하므로 BG OSC 가 중복돼도 결과 동일.
- [ ] non-VSCode 환경 (예: WSL 의 Windows Terminal) 에서 race 가 발사되지 않음 — 가드 `TERM_PROGRAM=vscode` 동작 확인.
- [ ] 다중 worktree 병렬 spawn 시 (`gwt spawn ... --wt-name a` → 다른 터미널에서 `gwt spawn ... --wt-name b`) 각 탭이 자기 라벨로 분리되는지 확인.

## Related
Fixes #781

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
