### PR TITLE
fix(skill): #785 gh-issue-create description 1024자 로더 한계 초과 회피

### DIFF
--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -1,24 +1,21 @@
 ---
 name: gh:issue-create
 description: >-
-  Save the current conversation as a GitHub issue in the current repository.
-  Use when the user runs /gh:issue-create, /gh-issue-create, or asks to "이 대화 이슈로 등록",
-  "chat을 깃허브 이슈로 남겨", "기록용 이슈 만들어". Summarizes the conversation so
-  far into a structured issue body keyed by conventional-commit prefix
-  (feat / fix / refactor / perf / docs / test / chore / misc),
-  creates it via `gh issue create` on the target remote's repo without asking
-  for confirmation, and prints only the issue number and URL. Do NOT over-
-  compress — the issue is reused for PR drafts and blog posts, so preserve
-  reasoning, decisions, and concrete details.
-  Accepts an optional remote name argument (e.g., `/gh-issue-create upstream`) to
-  target a different remote's repository instead of origin. When the
-  target repo ships a `.gh-issue-defaults.yml`, default labels and a
-  milestone are auto-applied per that file (Step 2.5); pass
-  `--no-auto-labels` to opt out or `--auto-label-debug` for the dispatch
-  trace. Pass `--as-discussion <category>` (`Ideas` / `Q&A` /
-  `Announcements` / `Lessons`) to route the same conversation to
-  [[gh-discussion-create]] without re-running a different skill (#619).
-  Accepts `-h`/`--help`/`help` to print usage.
+  Save the current conversation as a GitHub issue. Use when the user runs
+  /gh:issue-create, /gh-issue-create, or asks "이 대화 이슈로 등록",
+  "chat을 깃허브 이슈로 남겨", "기록용 이슈 만들어". Summarizes the chat
+  into a body keyed by conventional-commit prefix
+  (feat / fix / refactor / perf / docs / test / chore / misc) and creates
+  the issue via `gh issue create` on the target remote's repo without
+  confirmation, printing only the issue number and URL. Preserves
+  reasoning, decisions, and concrete details — the issue is reused for
+  PR drafts and blog posts. Accepts an optional remote name positional
+  arg (e.g. `/gh-issue-create upstream`) to target a non-`origin` remote.
+  Flags `--no-auto-labels`, `--auto-label-debug`, and
+  `--as-discussion <category>` (`Ideas` / `Q&A` / `Announcements` /
+  `Lessons`, #619) are documented in references/help.md, alongside the
+  `.gh-issue-defaults.yml` auto-label behavior. Accepts
+  `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
 ---
 

--- a/scripts/maintenance/README.md
+++ b/scripts/maintenance/README.md
@@ -29,13 +29,14 @@ Dotfiles 유지보수를 위한 1회성/주기적 도구 모음
   - 더 읽기 쉬운 출력 형식
 
 ### check_codex_skills_budget.py
-- **목적**: Codex skill description 컨텍스트 예산 (~5440자) 초과 감지 (issue #216)
-- **사용**: `python3 check_codex_skills_budget.py [--budget N] [--top N] [--all] [--quiet]`
+- **목적**: Codex skill description 컨텍스트 예산 (~5440자) 초과 감지 (issue #216) + 개별 skill description 의 로더 하드 리밋 (1024자) 초과 감지 (issue #785)
+- **사용**: `python3 check_codex_skills_budget.py [--budget N] [--top N] [--all] [--quiet] [--per-skill-max N]`
 - **요구사항**: Python stdlib 만 (외부 의존성 없음)
 - **기능**:
   - `claude/skills/*/SKILL.md` frontmatter 의 `description` 길이 합산
   - 가장 긴 설명 Top N 노출 (기본 10개)
-  - 예산 초과 시 종료 코드 1, 트리밍 또는 `.codex-allowlist` 사용 안내
+  - 개별 skill 이 `--per-skill-max` (기본 1024자) 초과 시 종료 코드 1 — 로더가 해당 skill 을 silently drop 하기 전에 사전 차단
+  - 총합 예산 초과 시 종료 코드 1, 트리밍 또는 `.codex-allowlist` 사용 안내
 
 ## 💡 사용 시나리오
 

--- a/scripts/maintenance/check_codex_skills_budget.py
+++ b/scripts/maintenance/check_codex_skills_budget.py
@@ -10,10 +10,14 @@ trigger accuracy. Run this to detect when the SSOT is approaching that limit.
 Usage:
     python3 check_codex_skills_budget.py [--budget N] [--top N] [--all]
                                           [--quiet] [--skills-dir PATH]
+                                          [--per-skill-max N]
 
 Exit codes:
-    0  total description length is within budget
-    1  total description length exceeds budget
+    0  total description length is within budget AND every individual
+       description is within the per-skill hard limit
+    1  total description length exceeds budget, OR at least one
+       description exceeds the per-skill hard limit (default 1024 — the
+       skill loader will silently refuse to load skills above this cap)
     2  error (skills directory missing, parse failure)
 """
 
@@ -35,6 +39,7 @@ class Colors:
 
 
 DEFAULT_BUDGET_CHARS = 5440  # observed Codex skill metadata budget
+DEFAULT_PER_SKILL_HARD_LIMIT = 1024  # loader hard limit per single description
 DEFAULT_TOP_N = 10
 LONG_WARN = 400  # per-skill chars that strongly suggest trimming
 LONG_HINT = 250  # per-skill chars that hint at being on the long side
@@ -155,6 +160,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="skills directory (default: <dotfiles>/claude/skills)",
     )
+    parser.add_argument(
+        "--per-skill-max",
+        type=int,
+        default=DEFAULT_PER_SKILL_HARD_LIMIT,
+        help=(
+            "hard per-skill description ceiling in chars "
+            f"(default: {DEFAULT_PER_SKILL_HARD_LIMIT}). "
+            "Any skill above this fails the check even if the total is under budget."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -179,13 +194,15 @@ def main(argv: list[str] | None = None) -> int:
     skill_count = len(rows)
     avg = total_chars / skill_count if skill_count else 0
     over_budget = total_chars > args.budget
+    over_limit = [(name, length, path) for name, length, path in rows if length > args.per_skill_max]
 
     if not args.quiet:
         print(f"{Colors.BLUE}=== Codex Skill Description Budget ==={Colors.RESET}")
-        print(f"  Source dir: {skills_dir}")
-        print(f"  Skills:     {skill_count}")
-        print(f"  Total:      {total_chars} chars  (avg {avg:.0f}/skill)")
-        print(f"  Budget:     {args.budget} chars")
+        print(f"  Source dir:     {skills_dir}")
+        print(f"  Skills:         {skill_count}")
+        print(f"  Total:          {total_chars} chars  (avg {avg:.0f}/skill)")
+        print(f"  Budget:         {args.budget} chars")
+        print(f"  Per-skill cap:  {args.per_skill_max} chars (loader hard limit)")
         print()
 
         rows_sorted = sorted(rows, key=lambda r: -r[1])
@@ -195,6 +212,19 @@ def main(argv: list[str] | None = None) -> int:
         for name, length, _path in view:
             print(f"  {length:5d}  {name}{format_marker(length)}")
 
+    if over_limit:
+        print()
+        print(
+            f"{Colors.RED}! {len(over_limit)} skill(s) exceed the "
+            f"per-skill description hard limit ({args.per_skill_max} chars).{Colors.RESET}"
+        )
+        for name, length, path in over_limit:
+            print(f"{Colors.RED}    {length:5d}  {name}  ({path}/SKILL.md){Colors.RESET}")
+        print(
+            f"{Colors.YELLOW}  The skill loader will refuse to load these skills. "
+            f"Trim each description and move detail into references/help.md.{Colors.RESET}"
+        )
+
     if over_budget:
         print()
         print(f"{Colors.RED}! Total description chars ({total_chars}) exceed budget ({args.budget}).{Colors.RESET}")
@@ -203,6 +233,8 @@ def main(argv: list[str] | None = None) -> int:
             f"150-250 chars, or pin Codex to a subset via "
             f"claude/skills/.codex-allowlist.{Colors.RESET}"
         )
+
+    if over_limit or over_budget:
         return 1
 
     if not args.quiet:

--- a/scripts/maintenance/check_codex_skills_budget.py
+++ b/scripts/maintenance/check_codex_skills_budget.py
@@ -219,7 +219,7 @@ def main(argv: list[str] | None = None) -> int:
             f"per-skill description hard limit ({args.per_skill_max} chars).{Colors.RESET}"
         )
         for name, length, path in over_limit:
-            print(f"{Colors.RED}    {length:5d}  {name}  ({path}/SKILL.md){Colors.RESET}")
+            print(f"{Colors.RED}    {length:5d}  {name}  ({path / 'SKILL.md'}){Colors.RESET}")
         print(
             f"{Colors.YELLOW}  The skill loader will refuse to load these skills. "
             f"Trim each description and move detail into references/help.md.{Colors.RESET}"

--- a/tests/integration/test_codex_skills_budget.py
+++ b/tests/integration/test_codex_skills_budget.py
@@ -1,0 +1,72 @@
+"""Tests for scripts/maintenance/check_codex_skills_budget.py.
+
+Covers the per-skill hard limit added in issue #785: any single skill
+description exceeding 1024 characters must fail the check so the loader
+never silently drops a skill again.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "maintenance" / "check_codex_skills_budget.py"
+
+
+def _make_skill(skills_dir: Path, name: str, description: str) -> None:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n# {name}\nbody\n",
+        encoding="utf-8",
+    )
+
+
+def _run(skills_dir: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--skills-dir", str(skills_dir), "--quiet", *extra],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path) -> Path:
+    root = tmp_path / "skills"
+    root.mkdir()
+    return root
+
+
+def test_under_per_skill_limit_passes(skills_root: Path) -> None:
+    _make_skill(skills_root, "ok", "a" * 500)
+    result = _run(skills_root)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_per_skill_limit_failure_exits_1(skills_root: Path) -> None:
+    _make_skill(skills_root, "tiny", "ok")
+    _make_skill(skills_root, "bloated", "x" * 1100)
+    result = _run(skills_root)
+    assert result.returncode == 1
+    assert "bloated" in result.stdout
+    assert "per-skill description hard limit" in result.stdout
+
+
+def test_per_skill_limit_flag_respected(skills_root: Path) -> None:
+    _make_skill(skills_root, "modest", "x" * 600)
+    result = _run(skills_root, "--per-skill-max", "500")
+    assert result.returncode == 1
+    assert "modest" in result.stdout
+
+
+def test_total_budget_still_enforced(skills_root: Path) -> None:
+    for i in range(5):
+        _make_skill(skills_root, f"s{i}", "y" * 500)
+    result = _run(skills_root, "--budget", "100")
+    assert result.returncode == 1
+    assert "exceed budget" in result.stdout


### PR DESCRIPTION
## Summary
- `gh:issue-create` SKILL.md frontmatter `description` 가 로더 하드 리밋 1024자를 초과(1201자)해 codex 가 silently drop 하던 회귀를 해결.
- 같은 사고가 재발하지 않도록 `check_codex_skills_budget.py` 에 per-skill hard cap 검사를 추가.
- README + 회귀 테스트(pytest) 동반 갱신.

## Changes
- `claude/skills/gh-issue-create/SKILL.md`: description 1201 → 924 chars. 핵심 트리거(슬래시 커맨드, 한국어 트리거구, `feat/fix/...` 분류, `--no-auto-labels` / `--auto-label-debug` / `--as-discussion`)는 한 줄 포인터로 유지하고, 옵션 세부 동작·예시는 이미 `references/help.md` 에 있던 표를 사용.
- `scripts/maintenance/check_codex_skills_budget.py`: `--per-skill-max N` 옵션 추가 (기본 `DEFAULT_PER_SKILL_HARD_LIMIT = 1024`). 임계치를 넘는 skill 이 1개라도 있으면 총합 budget 통과 여부와 무관하게 exit 1, 빨간색으로 어떤 skill 이 어떤 경로에서 넘었는지 출력. 헤더에 `Per-skill cap` 줄을 추가해 운영자가 SSOT 를 한눈에 확인 가능.
- `scripts/maintenance/README.md`: 새 플래그 + 이슈 #785 링크 반영, 기능 설명에 per-skill cap 항목 추가.
- `tests/integration/test_codex_skills_budget.py` (신규): pass 케이스, per-skill cap 위반 → exit 1, `--per-skill-max` 플래그 동작, total budget 검사가 여전히 동작하는지 4개 케이스로 고정.

## Verification
- `python3 scripts/maintenance/check_codex_skills_budget.py --top 3` 결과 `gh:issue-create` 가 924 chars 로 떨어졌고, 그 어떤 skill 도 1024 한계를 넘지 않음(가장 긴 `gh:discussion-convert` = 1011 chars, 후속 작업 대상).
- `uv run pytest tests/integration/test_codex_skills_budget.py -v` → 4 passed.
- `uv run pytest tests/integration/` → 1066 passed (회귀 없음).
- `uv run ruff check . && uv run ruff format --check . && uv run mypy .` → 모두 통과.

## Test plan
- [ ] CI 가 `Skipped loading 1 skill(s) due to invalid SKILL.md files` 경고를 더 이상 출력하지 않는지 확인.
- [ ] `python3 scripts/maintenance/check_codex_skills_budget.py` 가 현재 상태에서 per-skill 한계 위반은 없음을 보고하는지 확인.
- [ ] 신규 pytest 4건이 main 머지 후에도 통과하는지 확인.
- [ ] `gh:issue-create --help` (또는 `references/help.md` 직접 읽기) 가 `--no-auto-labels` / `--auto-label-debug` / `--as-discussion` 동작을 여전히 설명하는지 확인.

## Related
Closes #785

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
