### PR TITLE
docs(skills): #775 gh-pr-resolve-ci-fail — Step 2 "main green?" pre-check

### DIFF
--- a/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
@@ -43,7 +43,7 @@ State `OPEN` required. Hard preconditions in `references/safety.md` →
 본격 분석 전에 main 의 동일 workflow 가 inherited red 인지 1초 확인:
 
 ```bash
-gh run list --repo "$TARGET_REPO" --branch main --workflow <workflow> --limit 3
+gh run list --repo "$TARGET_REPO" --branch main --workflow "$WORKFLOW_NAME" --limit 3
 ```
 
 세 run 중 2개 이상 failure 이고 PR run 과 동일 step 에서 fail 한다면

--- a/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
@@ -38,6 +38,30 @@ State `OPEN` required. Hard preconditions in `references/safety.md` →
 
 ## Step 2: Fetch Failing Checks
 
+### Pre-check — is `main` itself red?
+
+본격 분석 전에 main 의 동일 workflow 가 inherited red 인지 1초 확인:
+
+```bash
+gh run list --repo "$TARGET_REPO" --branch main --workflow <workflow> --limit 3
+```
+
+세 run 중 2개 이상 failure 이고 PR run 과 동일 step 에서 fail 한다면
+PR 회귀가 아닐 가능성이 높다 (#755 의 28건 bats fail 이 그 사례).
+다음과 같이 stop — 라벨은 건드리지 않고 그대로 종료:
+
+```
+[STOP] main 자체가 적색입니다 (latest 3 runs: failure / failure / success).
+       PR 회귀가 아니라 inherited red — main 먼저 회복하세요.
+       Next: /gh-issue-create  # umbrella 또는 sub-issue 등록
+```
+
+False-positive: main 의 transient red (1회 fail, 직후 green) 은 무시하고
+통상 절차 진행. 판정 기준·예시·예외 케이스 전체는
+`references/ci-log-analysis.md` → "Step 2 — pre-check (is main red?)".
+
+### Failing-check fetch
+
 `gh pr checks <N> --required --json name,state,workflow,link`, filter
 `state == FAILURE`. All green → `[OK] no failing checks — nothing to
 resolve.` and stop. Filter rubric + in-progress carveout in

--- a/claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md
@@ -4,6 +4,55 @@ Detail companion for SKILL.md Steps 2, 3, and 6.
 
 ## Step 2 — Fetch failing checks
 
+### Pre-check (is `main` red?)
+
+PR 회귀 fix 에 들어가기 전에 main 자체가 적색인지 먼저 확인한다.
+#755 의 28건 bats fail 처럼 PR 입장에선 inherited red — PR 차원의
+fix 가 원천적으로 불가능한 케이스를 30분 분석 후에야 깨닫는 회귀를 막는다.
+
+#### 1초 점검 명령
+
+```bash
+# 같은 워크플로의 main 최신 3 runs
+gh run list --repo "$TARGET_REPO" \
+    --branch main \
+    --workflow "$WORKFLOW_NAME" \
+    --limit 3 \
+    --json databaseId,conclusion,headSha,updatedAt
+```
+
+#### 판정 기준 — "same step as main"
+
+같은 step 에서 fail 했다고 보려면 두 조건을 모두 만족해야 한다:
+
+1. main 최신 3 runs 중 **2 개 이상** `conclusion == "failure"` (또는
+   `"timed_out"`).
+2. main 의 실패 run 과 PR run 이 **동일 job + 동일 step name** 에서
+   터진다 — `gh run view <main-run-id> --log-failed` 와
+   `gh run view <pr-run-id> --log-failed` 의 첫 `##[error]` /
+   `Error:` 라인 (또는 첫 non-zero exit 의 step header) 이 일치하는지
+   2초 비교.
+
+두 조건 모두 참 → inherited red. SKILL.md Step 2 의 `[STOP]` 메시지로
+종료. 라벨은 떼지 않는다 (CI 가 실제로 PR 회귀 없음을 증명하지 못한 상태).
+
+#### False-positive — main 의 transient red
+
+다음 케이스는 inherited red 가 **아니므로** pre-check 통과로 처리하고
+통상 절차 진행:
+
+- main 최신 3 runs 가 `failure / success / success` 처럼 1회만 fail
+  이고 직후 run 이 다시 green — flaky / transient. 회복됨.
+- main 의 실패 run 과 PR run 의 fail step name 이 다름 — 같은 적색이
+  아니라 PR 만의 새 회귀.
+- main 의 fail 이 24h 이상 지난 단발 — 최신 2 run 이 green 이면 무시.
+
+#### Skip 조건
+
+`GH_PR_RESOLVE_CI_SKIP_MAIN_CHECK=1` 가 set 이면 pre-check 를 건너뛴다 —
+사용자가 의도적으로 main red 상태에서 PR fix 를 강제 진행하려는 경우
+(e.g., main 회복 PR 자체의 CI 디버깅).
+
 ```bash
 gh pr checks "$PR_NUMBER" --repo "$TARGET_REPO" --required \
     --json name,state,workflow,link \


### PR DESCRIPTION
## Summary
- `gh:pr-resolve-ci-fail` Step 2 의 결정 트리에 **"main 의 동일 workflow 가 적색인지 먼저 확인"** pre-check 를 문서화.
- inherited red (PR 회귀가 아니라 main 자체 red 가 PR run 까지 전염된 상태) 를 30분 분석 후에야 깨닫는 회귀를 방지 — #755 의 28건 bats fail 이 motivating 사례.
- heuristic + sample stop 메시지만 추가, 자동 stop 로직은 v2 로 분리.

## Changes
- `claude/skills/gh-pr-resolve-ci-fail/SKILL.md` — Step 2 본문 앞에 `### Pre-check — is main itself red?` 단락 추가. 1초 점검 명령 (`gh run list --branch main`), `[STOP]` 메시지 샘플, false-positive 1줄, 상세 문서 포인터 — 약 22줄.
- `claude/skills/gh-pr-resolve-ci-fail/references/ci-log-analysis.md` — 같은 "Step 2" 절 상단에 `### Pre-check (is main red?)` 풀어쓴 판정 기준 추가. "same step as main" 2 조건, false-positive 3종 (transient red / 다른 step / 단발 fail), `GH_PR_RESOLVE_CI_SKIP_MAIN_CHECK=1` opt-out — 약 49줄.

## Test plan
- [ ] SKILL.md 의 Step 2 가 여전히 Markdown 으로 잘 렌더링 (heading hierarchy: `## Step 2 → ### Pre-check / ### Failing-check fetch`).
- [ ] references 파일 line count 가 reference 권장 한도 (~200) 이내 — 현재 172.
- [ ] 이모지 회귀 grep: `grep -P '[\x{2600}-\x{27BF}\x{1F300}-\x{1FAFF}]'` 두 파일에서 0 매치.
- [ ] CLAUDE.md `no emojis anywhere (token efficiency)` 룰 준수 — `[STOP]` / `[OK]` / `[FAIL]` 같은 bracket-prefix 만 사용.
- [ ] AC 5건 (SKILL.md 단락 / references 풀이 / false-positive / stop 메시지 형식 / 선택: bats) 중 4건 충족, bats 는 의도적 skip (doc-only 변경).

## Related
Closes #775

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~1 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~1 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
