### PR TITLE
feat(docker-help): #777 PWD 컨텍스트 인지형 추천 명령어

### DIFF
--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -118,9 +118,133 @@ _docker_help_full() {
     _docker_help_render_section "Utilities" _docker_help_rows_utilities
 }
 
+# --- docker_help recommend (#777) ---
+#
+# PWD-aware Docker Compose project recommendation. Scans the current
+# directory (NOT parent directories — by design, to avoid catching an
+# unintended compose file) and prints a single ready-to-copy command.
+
+_docker_help_compose_bases_in_pwd() {
+    for f in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+        [ -f "$f" ] && printf '%s\n' "$f"
+    done
+}
+
+# Use `find -maxdepth 1` instead of POSIX shell globs because zsh
+# defaults to `nomatch` errors on unmatched globs (zsh-side regression
+# during early dev: `for f in compose.*.yml` aborted the function).
+# `find` is shell-agnostic and ignores empty matches naturally.
+_docker_help_compose_variants_in_pwd() {
+    find . -maxdepth 1 -type f \( \
+        -name 'docker-compose.*.yml' -o \
+        -name 'docker-compose.*.yaml' -o \
+        -name 'compose.*.yml' -o \
+        -name 'compose.*.yaml' \
+        \) 2>/dev/null | sed 's|^\./||' | sort
+}
+
+_docker_help_has_compose_in_pwd() {
+    # Assign-without-outer-quotes form so the pre-commit naming check
+    # (`git/hooks/checks/naming_check.sh`) does not mis-flag these as
+    # snake_case user-facing text inside quoted strings.
+    local _bases _variants
+    _bases=$(_docker_help_compose_bases_in_pwd)
+    [ -n "$_bases" ] && return 0
+    _variants=$(_docker_help_compose_variants_in_pwd)
+    [ -n "$_variants" ] && return 0
+    return 1
+}
+
+_docker_help_recommend_print() {
+    # $1 = command, $2 = base, $3 = variant (may be empty), $4 = mode
+    ux_section "Recommended command"
+    # Bare monospace line for copy-paste (no icon / bullet). ux_lib has
+    # no plain-text helper for code lines and the AC requires the user
+    # to be able to paste this verbatim — see #777 Step 3.
+    printf '  %s\n' "$1"
+    ux_info ""
+    ux_section "Why"
+    [ -n "$2" ] && ux_bullet "base:    $2"
+    [ -n "$3" ] && ux_bullet "variant: $3"
+    [ -n "$4" ] && ux_bullet "mode:    $4"
+}
+
+_docker_help_recommend() {
+    local bases variants base variant fake_variant variant_count
+
+    bases=$(_docker_help_compose_bases_in_pwd)
+    variants=$(_docker_help_compose_variants_in_pwd)
+
+    if [ -z "$bases" ] && [ -z "$variants" ]; then
+        ux_info "No Docker Compose files in current directory."
+        ux_info "Run \`docker-help --all\` for the full alias catalog."
+        return 1
+    fi
+
+    ux_info "Detected Docker Compose project."
+
+    base="$(printf '%s\n' "$bases" | head -n1)"
+    if [ -n "$variants" ]; then
+        variant_count="$(printf '%s\n' "$variants" | grep -c .)"
+    else
+        variant_count=0
+    fi
+    fake_variant="$(printf '%s\n' "$variants" | grep -E '\.fake\.(yml|yaml)$' | head -n1)"
+
+    if [ -n "$base" ] && [ -n "$fake_variant" ]; then
+        _docker_help_recommend_print \
+            "docker compose -f $base -f $fake_variant up -d --build" \
+            "$base" "$fake_variant" "detached + rebuild"
+    elif [ -n "$base" ] && [ "$variant_count" -eq 1 ]; then
+        variant="$(printf '%s\n' "$variants" | head -n1)"
+        _docker_help_recommend_print \
+            "docker compose -f $base -f $variant up -d --build" \
+            "$base" "$variant" "detached + rebuild"
+    elif [ -n "$base" ] && [ "$variant_count" -ge 2 ]; then
+        ux_info "Multiple compose variants detected — no single recommendation."
+        ux_section "Candidate compose files"
+        ux_bullet "$base (base)"
+        printf '%s\n' "$variants" | while IFS= read -r f; do
+            [ -n "$f" ] && ux_bullet "$f (variant)"
+        done
+        ux_info ""
+        ux_info "Hint: check the project's helper scripts first — e.g.,"
+        ux_info "  bun run 2>&1 | grep docker"
+        ux_info "  jq -r '.scripts | keys[]' package.json 2>/dev/null | grep docker"
+        ux_info "  grep -E '^[a-z_-]+:' Makefile 2>/dev/null"
+    elif [ -n "$base" ]; then
+        _docker_help_recommend_print \
+            "docker compose up -d --build" \
+            "$base" "" "detached + rebuild"
+    else
+        ux_info "Compose variant(s) found but no base file — no recommendation."
+        ux_section "Candidate compose files"
+        printf '%s\n' "$variants" | while IFS= read -r f; do
+            [ -n "$f" ] && ux_bullet "$f (variant)"
+        done
+    fi
+
+    ux_info ""
+    ux_section "More"
+    ux_bullet "docker-help compose"
+    ux_bullet "docker-help --all"
+}
+
 docker_help() {
     case "${1:-}" in
-        ""|-h|--help|help)
+        "")
+            # PWD compose project → recommend; otherwise fall back to
+            # the canonical summary so non-compose dirs see no regression.
+            if _docker_help_has_compose_in_pwd; then
+                _docker_help_recommend
+            else
+                _docker_help_summary
+            fi
+            ;;
+        here)
+            _docker_help_recommend
+            ;;
+        -h|--help|help)
             _docker_help_summary
             ;;
         --list|list|section|sections)

--- a/tests/bats/functions/docker_help_recommend.bats
+++ b/tests/bats/functions/docker_help_recommend.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/bats/functions/docker_help_recommend.bats
+# Regression test for issue #777 — docker-help PWD-aware compose recommendation.
+# Covers AC cases A-E plus `here` subcommand and non-compose regressions.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    TEST_PWD="$(mktemp -d)"
+}
+
+teardown() {
+    if [ -n "$TEST_PWD" ] && [ -d "$TEST_PWD" ]; then
+        rm -rf "$TEST_PWD"
+    fi
+    teardown_isolated_home
+}
+
+@test "bash: case A — base + fake variant → fake overlay command" {
+    : >"$TEST_PWD/docker-compose.yml"
+    : >"$TEST_PWD/docker-compose.fake.yml"
+    run_in_bash "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "docker compose -f docker-compose.yml -f docker-compose.fake.yml up -d --build"
+}
+
+@test "bash: case B — base only → simple up command" {
+    : >"$TEST_PWD/docker-compose.yml"
+    run_in_bash "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "docker compose up -d --build"
+    refute_output --partial "-f docker-compose.yml -f"
+}
+
+@test "bash: case C — base + 2 variants without fake → no single recommendation + helper hint" {
+    : >"$TEST_PWD/docker-compose.yml"
+    : >"$TEST_PWD/docker-compose.dev.yml"
+    : >"$TEST_PWD/docker-compose.prod.yml"
+    run_in_bash "cd '$TEST_PWD' && docker_help"
+    assert_success
+    refute_output --partial "Recommended command"
+    assert_output --partial "Candidate compose files"
+    assert_output --partial "docker-compose.dev.yml"
+    assert_output --partial "docker-compose.prod.yml"
+    assert_output --partial "helper scripts"
+}
+
+@test "bash: case D — no compose file → existing summary (regression)" {
+    run_in_bash "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "Usage: docker-help [section|--list|--all]"
+    refute_output --partial "Recommended command"
+    refute_output --partial "Detected Docker Compose"
+}
+
+@test "bash: case E — compose.yml (new-style) only → simple up command" {
+    : >"$TEST_PWD/compose.yml"
+    run_in_bash "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "docker compose up -d --build"
+    assert_output --partial "base:    compose.yml"
+}
+
+@test "bash: case A via 'docker-help here' explicit invocation" {
+    : >"$TEST_PWD/docker-compose.yml"
+    : >"$TEST_PWD/docker-compose.fake.yml"
+    run_in_bash "cd '$TEST_PWD' && docker_help here"
+    assert_success
+    assert_output --partial "docker compose -f docker-compose.yml -f docker-compose.fake.yml up -d --build"
+}
+
+@test "bash: 'docker-help here' in empty dir reports no compose files" {
+    run_in_bash "cd '$TEST_PWD' && docker_help here"
+    assert_failure
+    assert_output --partial "No Docker Compose files"
+}
+
+@test "bash: regression — docker-help compose unchanged" {
+    run_in_bash "cd '$TEST_PWD' && docker_help compose"
+    assert_success
+    assert_output --partial "dcud"
+}
+
+@test "bash: regression — docker-help --all unchanged" {
+    run_in_bash "cd '$TEST_PWD' && docker_help --all"
+    assert_success
+    assert_output --partial "Docker Compose Basics"
+}
+
+@test "bash: regression — docker-help --help unchanged" {
+    run_in_bash "cd '$TEST_PWD' && docker_help --help"
+    assert_success
+    assert_output --partial "Usage: docker-help [section|--list|--all]"
+}
+
+@test "zsh: case A — base + fake variant → fake overlay command" {
+    : >"$TEST_PWD/docker-compose.yml"
+    : >"$TEST_PWD/docker-compose.fake.yml"
+    run_in_zsh "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "docker compose -f docker-compose.yml -f docker-compose.fake.yml up -d --build"
+}
+
+@test "zsh: case D — no compose file → existing summary (regression)" {
+    run_in_zsh "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "Usage: docker-help [section|--list|--all]"
+    refute_output --partial "Recommended command"
+}
+
+@test "zsh: case E — compose.yml (new-style) only → simple up command" {
+    : >"$TEST_PWD/compose.yml"
+    run_in_zsh "cd '$TEST_PWD' && docker_help"
+    assert_success
+    assert_output --partial "docker compose up -d --build"
+}

--- a/tests/bats/functions/docker_help_recommend.bats
+++ b/tests/bats/functions/docker_help_recommend.bats
@@ -7,7 +7,7 @@ load '../test_helper'
 
 setup() {
     setup_isolated_home
-    TEST_PWD="$(mktemp -d)"
+    TEST_PWD="$(mktemp -d "${TMPDIR:-/tmp}/docker_help_test.XXXXXX")"
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

- `docker-help` 를 PWD 컨텍스트 인지형으로 진화: compose 프로젝트 디렉터리에서는 alias 카탈로그보다 먼저 **추천 명령어 + Why 블록** 을 출력. 비-compose 디렉터리는 기존 summary 그대로 (회귀 없음).
- 추천 알고리즘 5-case 우선순위 — base+fake / base+1variant / base+≥2variants / base only / variants only — 모두 PWD 내에서만 탐색 (부모 디렉터리 traversal 금지).
- `docker-help here` 명시적 호출 지원 — 문서/README 에서 안정적 지시 가능.
- variant 탐색은 `find -maxdepth 1` 사용 — zsh 의 `nomatch` 글로브 회피 (POSIX shell 글로브로 시작했다가 zsh 회귀 발견 후 변경).

## Changes

- `shell-common/functions/devops_help.sh` — `_docker_help_recommend` / `_docker_help_compose_*_in_pwd` / `_docker_help_has_compose_in_pwd` 헬퍼 추가. `docker_help()` no-arg 분기는 PWD 감지 → recommend, 아니면 summary. `here` 서브커맨드 신규.
- `tests/bats/functions/docker_help_recommend.bats` — 회귀 13 케이스: AC 의 A/B/C/D/E + `here` (compose 있음/없음) + 기존 `compose` / `--all` / `--help` 출력 보존 + zsh A/D/E 듀얼-셸 확인.

## Test plan

- [x] bats: `tests/bats/functions/docker_help_recommend.bats` 13/13 pass (bash + zsh)
- [x] pytest: `tests/integration/test_help_compact_policy.py -k docker_help` 12/12 pass — `docker_help` no-arg 가 여전히 [section|--list|--all] 템플릿 + 15-line 한도 만족
- [x] pytest: `tests/integration/test_help_topics.py` 249/249 pass
- [x] 수동 smoke: case A/B/C/D/E in bash + zsh 모두 기대 출력
- [ ] CI: pre-push hook 통과 후 GitHub Actions green 확인

Closes #777

<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~0.2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~0.2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
