### PR TITLE
feat(hooks): #753 mechanical step-skip guard for standalone multi-step skills

### DIFF
--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Claude Code Stop hook: mechanical step-skip guard for standalone multi-step skills (issue #753).
+
+Generalizes the boundary-detection / counting logic from
+`gh_issue_flow_stop_guard.py` (#383) into a catalog-driven guard that
+backstops INNER steps of individually-invoked skills (gh:issue-implement,
+gh:pr, gh:commit, …). The motivation is identical: prompt rules in
+SKILL.md alone are insufficient — the harness must mechanically force
+the model to emit a completion marker per step before allowing turn end.
+
+Sister hook of `gh_issue_flow_stop_guard.py`:
+  - That one guards the OUTER 5-sub-skill chain of `/gh-issue-flow`.
+  - This one guards INNER required-step emit of each catalog skill.
+  - Both can coexist on the Stop hook chain — if either says block, the
+    model is re-prompted with the union of their reasons.
+
+Step ID emit contract:
+  Each protected SKILL.md emits a literal `[step:<skill>/<id>] OK` line
+  at the end of every required step (typically via `printf` in a Bash
+  block). The hook scans assistant text AND tool_result blocks for
+  these markers — tool_result is required because `printf` output from
+  a Bash tool call lands there, not in assistant text.
+
+Safety rails (each critical — never accidentally trap the user):
+  - Empty / unreadable / malformed stdin → exit 0 (allow stop).
+  - Missing or unreadable transcript_path → exit 0.
+  - `stop_hook_active == True` → exit 0 (already blocked once in this
+    chain; bowing out prevents an infinite Stop→block→Stop loop).
+  - No catalog skill boundary in the transcript → exit 0 (not our flow).
+  - Catalog file missing / unparseable YAML → exit 0 (fail-open + warn).
+  - `GH_SKILL_GUARD_BYPASS=1` → exit 0 (manual escape hatch).
+  - All required step IDs present after the most recent boundary → exit 0.
+  - Any unexpected exception → exit 0 (fail open).
+
+The hook only ever does two things: emit nothing (allow), or emit one
+JSON object `{"decision":"block","reason":"..."}` on stdout (block + nudge).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover — PyYAML is in dev deps; this is a defensive fallback
+    yaml = None  # type: ignore[assignment]
+
+# Opt-in stderr trace for debugging. Default off so production stays silent.
+_TRACE_ENABLED: bool = os.environ.get("GH_SKILL_GUARD_TRACE") == "1"
+
+# Manual escape hatch (issue #753 acceptance criteria).
+_BYPASS_ENABLED: bool = os.environ.get("GH_SKILL_GUARD_BYPASS") == "1"
+
+# Default catalog path — co-located with this hook. Override with
+# `GH_SKILL_GUARD_CATALOG=/abs/path/to/yml` (used by tests).
+_DEFAULT_CATALOG: Path = Path(__file__).resolve().parent / "skill_step_catalog.yml"
+
+# Regex that captures literal `[step:<skill>/<id>] OK` markers in transcript
+# text. `OK` is the discriminator that keeps the pattern unique enough that
+# accidental documentation reads of the catalog/hook source don't trigger
+# false positives (the catalog YAML stores the bare ids without the wrapper,
+# and the hook source uses the regex form which doesn't satisfy the literal).
+_STEP_EMIT_RE: re.Pattern[str] = re.compile(
+    r"\[step:(?P<skill>[A-Za-z0-9_:.-]+)/(?P<step>[A-Za-z0-9_.-]+)\]\s+OK\b",
+)
+
+
+def _trace(message: str, *, layer: str | None = None) -> None:
+    """Emit a `[skill-guard]` trace line on stderr when trace mode is on.
+
+    `layer` mirrors the `gh_issue_flow_stop_guard.py` taxonomy:
+      - `L1`   — boundary detection (`_find_catalog_boundaries`)
+      - `L1.5` — step-emit scan (`_scan_steps_after_boundary`)
+      - `L2`   — catalog load failure (`_load_catalog`)
+    """
+    if _TRACE_ENABLED:
+        try:
+            tag = f" layer={layer}" if layer else ""
+            print(f"[skill-guard] {message}{tag}", file=sys.stderr, flush=True)
+        except OSError:
+            pass
+
+
+def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:
+    """Allow the stop. Hook protocol: silent stdout + exit 0."""
+    if trace_reason:
+        _trace(f"allow: {trace_reason}", layer=layer)
+    return 0
+
+
+def _block(reason: str, *, layer: str | None = None) -> int:
+    """Block the stop with a directive shown to the model."""
+    json.dump({"decision": "block", "reason": reason}, sys.stdout)
+    _trace("block: catalog skill incomplete — re-prompting model", layer=layer)
+    return 0
+
+
+def _load_catalog(path: Path) -> dict[str, dict[str, Any]]:
+    """Load the YAML catalog. Returns {} on any failure (fail-open)."""
+    if yaml is None:
+        _trace("PyYAML not importable — catalog disabled", layer="L2")
+        return {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _trace(f"catalog unreadable: {exc}", layer="L2")
+        return {}
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:  # type: ignore[attr-defined]
+        _trace(f"catalog YAML invalid: {exc}", layer="L2")
+        return {}
+    if not isinstance(data, dict):
+        _trace("catalog top-level is not a mapping", layer="L2")
+        return {}
+    # Light schema normalization — only keep entries that have a `required`
+    # list. Missing `enforce` defaults to False (warn-only).
+    out: dict[str, dict[str, Any]] = {}
+    for skill, body in data.items():
+        if not isinstance(skill, str) or not isinstance(body, dict):
+            continue
+        required = body.get("required")
+        if not isinstance(required, list) or not all(isinstance(s, str) for s in required):
+            continue
+        out[skill] = {
+            "enforce": bool(body.get("enforce", False)),
+            "description": str(body.get("description", "")),
+            "required": list(required),
+        }
+    return out
+
+
+def _build_boundary_regex(catalog: dict[str, dict[str, Any]]) -> re.Pattern[str]:
+    """Build a multi-skill boundary regex from the catalog keys.
+
+    Mirrors `gh_issue_flow_stop_guard.py._USER_BOUNDARY_RE` but lifted to a
+    union over all catalog-listed skills. The four boundary surfaces from
+    issue #608 still apply per-skill:
+      (a) raw slash-command at line start
+      (b) `<command-name>/<skill></command-name>` wrapper
+      (c) `Base directory for this skill: …/<skill>` marker
+      (d) the SKILL.md H1 line `# <skill> — …`
+    """
+    if not catalog:
+        return re.compile(r"(?!x)x")  # match nothing
+    names = sorted(catalog.keys())
+    # Each name may appear in hyphen form (e.g. gh-pr) or colon namespace
+    # form (gh:pr) — accept both at match time. The hyphen→colon mapping
+    # is reversible because skill names don't contain colons in storage.
+    name_alts: list[str] = []
+    for n in names:
+        hyphenated = re.escape(n)
+        colonized = re.escape(n.replace("-", ":"))
+        if hyphenated == colonized:
+            name_alts.append(hyphenated)
+        else:
+            name_alts.append(f"(?:{hyphenated}|{colonized})")
+    union = "|".join(name_alts)
+    return re.compile(
+        rf"""
+        (?m)                                                    # multiline: ^ matches each line start
+        (?:
+            ^\s*/(?:{union})\b                                  # (a) raw slash command
+            |
+            <command-name>\s*/(?:{union})\s*</command-name>     # (b) wrapped form
+            |
+            ^Base\s+directory\s+for\s+this\s+skill:\s+.*?/(?:{union})\s*$  # (c) skill base dir
+            |
+            ^\#\s+(?:{union})\s+—\s+                            # (d) SKILL.md H1 line
+        )
+        """,
+        re.VERBOSE,
+    )
+
+
+def _iter_text_blocks(message: dict[str, Any], include_tool_results: bool = False) -> list[str]:
+    """Return all text-bearing chunks in a message's content array.
+
+    `include_tool_results=False` is the safe default for boundary
+    detection (file content mentioning a slash command must not trip the
+    flow start). For step-marker scanning, callers pass True because the
+    Bash printf output lives inside tool_result blocks.
+    """
+    parts: list[str] = []
+    content = message.get("content")
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                t = block.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+            elif btype == "tool_result" and include_tool_results:
+                rc = block.get("content")
+                if isinstance(rc, str):
+                    parts.append(rc)
+                elif isinstance(rc, list):
+                    for sub in rc:
+                        if isinstance(sub, dict) and sub.get("type") == "text":
+                            st = sub.get("text")
+                            if isinstance(st, str):
+                                parts.append(st)
+    return parts
+
+
+def _iter_skill_uses(message: dict[str, Any]) -> list[str]:
+    """Return Skill tool_use names invoked in this message."""
+    out: list[str] = []
+    content = message.get("content")
+    if not isinstance(content, list):
+        return out
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use":
+            continue
+        if block.get("name") != "Skill":
+            continue
+        tool_input = block.get("input")
+        if not isinstance(tool_input, dict):
+            continue
+        skill = tool_input.get("skill")
+        if isinstance(skill, str):
+            out.append(skill)
+    return out
+
+
+def _load_transcript(path: Path) -> list[dict[str, Any]]:
+    """Best-effort JSONL load. Skips malformed lines, never raises."""
+    out: list[dict[str, Any]] = []
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    out.append(obj)
+    except OSError:
+        return []
+    return out
+
+
+def _message_payload(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return the inner `message` dict if present, else the entry itself."""
+    inner = entry.get("message")
+    return inner if isinstance(inner, dict) else entry
+
+
+def _normalize_skill(name: str) -> str:
+    """Map colon-namespace form (gh:pr) to canonical hyphen form (gh-pr)."""
+    return name.replace(":", "-")
+
+
+def _find_latest_catalog_boundary(
+    messages: list[dict[str, Any]],
+    catalog: dict[str, dict[str, Any]],
+    boundary_re: re.Pattern[str],
+) -> tuple[int, str] | None:
+    """Return (index, skill_name) of the most recent catalog skill boundary.
+
+    Boundary signals (role-restricted to avoid false positives from
+    documentation reads landing in tool_result blocks):
+      - assistant message: Skill tool_use whose name is in the catalog
+      - user message: text content matches `boundary_re`
+
+    Returns None when no catalog skill boundary is present.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = _message_payload(messages[i])
+        role = msg.get("role")
+        if role == "assistant":
+            for skill in _iter_skill_uses(msg):
+                normalized = _normalize_skill(skill)
+                if normalized in catalog:
+                    return (i, normalized)
+        elif role == "user":
+            for text in _iter_text_blocks(msg, include_tool_results=False):
+                match = boundary_re.search(text)
+                if not match:
+                    continue
+                # Recover the skill name from the matched substring. The
+                # regex's surface variants all embed `/<skill>` (a–c) or
+                # `# <skill> ` (d). Re-scan with simpler patterns to pick
+                # which catalog key fired.
+                matched_text = match.group(0)
+                for skill_name in catalog:
+                    colon = skill_name.replace("-", ":")
+                    if (
+                        f"/{skill_name}" in matched_text
+                        or f"/{colon}" in matched_text
+                        or f"# {skill_name} " in matched_text
+                        or f"# {colon} " in matched_text
+                    ):
+                        return (i, skill_name)
+    return None
+
+
+def _next_catalog_boundary_after(
+    messages: list[dict[str, Any]],
+    start: int,
+    catalog: dict[str, dict[str, Any]],
+    boundary_re: re.Pattern[str],
+) -> int:
+    """Return the index of the next catalog skill boundary after `start`, or len(messages)."""
+    for i in range(start + 1, len(messages)):
+        msg = _message_payload(messages[i])
+        role = msg.get("role")
+        if role == "assistant":
+            for skill in _iter_skill_uses(msg):
+                if _normalize_skill(skill) in catalog:
+                    return i
+        elif role == "user":
+            for text in _iter_text_blocks(msg, include_tool_results=False):
+                if boundary_re.search(text):
+                    return i
+    return len(messages)
+
+
+def _scan_steps_in_section(
+    messages: list[dict[str, Any]],
+    start: int,
+    end: int,
+    skill: str,
+) -> set[str]:
+    """Walk messages[start+1:end] and collect emitted step IDs for `skill`.
+
+    Steps are detected by literal `[step:<skill>/<id>] OK` markers. Both
+    assistant text AND tool_result blocks contribute — the Bash printf
+    output from SKILL.md lands in tool_result.
+
+    Note: we also collect colon-form `[step:gh:issue-implement/...]` IDs
+    by normalizing the skill prefix at match time.
+    """
+    seen: set[str] = set()
+    for entry in messages[start + 1 : end]:
+        msg = _message_payload(entry)
+        for text in _iter_text_blocks(msg, include_tool_results=True):
+            for m in _STEP_EMIT_RE.finditer(text):
+                matched_skill = _normalize_skill(m.group("skill"))
+                if matched_skill != skill:
+                    continue
+                seen.add(m.group("step"))
+    return seen
+
+
+def main() -> int:
+    if _BYPASS_ENABLED:
+        return _allow("GH_SKILL_GUARD_BYPASS=1")
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return _allow("empty stdin")
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError:
+        return _allow("malformed stdin JSON")
+    if not isinstance(event, dict):
+        return _allow("event is not a JSON object")
+
+    if event.get("stop_hook_active"):
+        return _allow("stop_hook_active=True (already blocked once)")
+
+    transcript_path = event.get("transcript_path")
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return _allow("missing transcript_path")
+    p = Path(transcript_path)
+    if not p.is_file():
+        return _allow(f"transcript file not found: {transcript_path}")
+
+    catalog_path_env = os.environ.get("GH_SKILL_GUARD_CATALOG")
+    catalog_path = Path(catalog_path_env) if catalog_path_env else _DEFAULT_CATALOG
+    catalog = _load_catalog(catalog_path)
+    if not catalog:
+        return _allow(f"catalog empty / unloadable: {catalog_path}", layer="L2")
+
+    messages = _load_transcript(p)
+    if not messages:
+        return _allow("transcript empty / unreadable")
+
+    boundary_re = _build_boundary_regex(catalog)
+    boundary = _find_latest_catalog_boundary(messages, catalog, boundary_re)
+    if boundary is None:
+        return _allow("no catalog skill boundary in transcript", layer="L1")
+
+    boundary_idx, skill = boundary
+    entry = catalog[skill]
+    required: list[str] = entry["required"]
+    enforce: bool = entry["enforce"]
+
+    end_idx = _next_catalog_boundary_after(messages, boundary_idx, catalog, boundary_re)
+    seen = _scan_steps_in_section(messages, boundary_idx, end_idx, skill)
+    missing = [step for step in required if step not in seen]
+
+    if _TRACE_ENABLED:
+        _trace(
+            f"skill={skill} boundary={boundary_idx} section_end={end_idx} "
+            f"seen={sorted(seen) or 'none'} missing={missing or 'none'} enforce={enforce}",
+            layer="L1.5",
+        )
+
+    if not missing:
+        return _allow(f"{skill}: all required steps emitted", layer="L1.5")
+
+    if not enforce:
+        return _allow(f"{skill}: missing steps but enforce=false", layer="L1.5")
+
+    description = entry.get("description") or skill
+    missing_list = ", ".join(missing)
+    reason = (
+        f"{skill} ({description}) incomplete: missing required step "
+        f"emit(s) [{missing_list}]. The SKILL.md for this skill declares "
+        f"these steps must each emit a literal `[step:{skill}/<id>] OK` "
+        f"line (typically via a printf at the end of the step's Bash "
+        f"block) before turn-end. Continue the skill from where it "
+        f"stopped, emitting the missing markers. Set GH_SKILL_GUARD_BYPASS=1 "
+        f"to override for one turn. Output zero conversational text "
+        f"between the remaining steps."
+    )
+    return _block(reason, layer="L1.5")
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Final fail-open. Never accidentally trap the user inside a turn.
+        sys.exit(0)

--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -165,13 +165,13 @@ def _build_boundary_regex(catalog: dict[str, dict[str, Any]]) -> re.Pattern[str]
         rf"""
         (?m)                                                    # multiline: ^ matches each line start
         (?:
-            ^\s*/(?:{union})\b                                  # (a) raw slash command
+            ^\s*/({union})\b                                    # (a) raw slash command
             |
-            <command-name>\s*/(?:{union})\s*</command-name>     # (b) wrapped form
+            <command-name>\s*/({union})\s*</command-name>       # (b) wrapped form
             |
-            ^Base\s+directory\s+for\s+this\s+skill:\s+.*?/(?:{union})\s*$  # (c) skill base dir
+            ^Base\s+directory\s+for\s+this\s+skill:\s+.*?/({union})\s*$  # (c) skill base dir
             |
-            ^\#\s+(?:{union})\s+—\s+                            # (d) SKILL.md H1 line
+            ^\#\s+({union})\s+—\s+                              # (d) SKILL.md H1 line
         )
         """,
         re.VERBOSE,
@@ -292,20 +292,13 @@ def _find_latest_catalog_boundary(
                 match = boundary_re.search(text)
                 if not match:
                     continue
-                # Recover the skill name from the matched substring. The
-                # regex's surface variants all embed `/<skill>` (a–c) or
-                # `# <skill> ` (d). Re-scan with simpler patterns to pick
-                # which catalog key fired.
-                matched_text = match.group(0)
-                for skill_name in catalog:
-                    colon = skill_name.replace("-", ":")
-                    if (
-                        f"/{skill_name}" in matched_text
-                        or f"/{colon}" in matched_text
-                        or f"# {skill_name} " in matched_text
-                        or f"# {colon} " in matched_text
-                    ):
-                        return (i, skill_name)
+                # `_build_boundary_regex` wraps each of the 4 surfaces
+                # (a/b/c/d) in a capturing group, so exactly one of
+                # `match.groups()` is non-None and holds the matched
+                # skill name (hyphen or colon form). `_normalize_skill`
+                # collapses the form to the catalog key.
+                matched_skill = next(g for g in match.groups() if g is not None)
+                return (i, _normalize_skill(matched_skill))
     return None
 
 

--- a/claude/hooks/skill_step_catalog.yml
+++ b/claude/hooks/skill_step_catalog.yml
@@ -1,0 +1,70 @@
+# claude/hooks/skill_step_catalog.yml — SSOT for skill_completion_guard.py (issue #753).
+#
+# Lists which standalone multi-step SKILL.md files have mechanical step-skip
+# protection and what step IDs they must emit before the model is allowed to
+# end its turn. Sister catalog of the inline EXPECTED_CHAIN list in
+# gh_issue_flow_stop_guard.py — that one guards the OUTER chain of 5 sub-skills,
+# this one guards INNER steps of each individually-invoked skill.
+#
+# Schema (per skill):
+#   <skill-name>:                    # hyphen form, matches the skill base
+#                                    # directory name. Colon form is auto-
+#                                    # accepted at match time.
+#     enforce: <bool>                # default false. When false, the guard
+#                                    # only logs (trace mode) and never blocks.
+#                                    # New skills are off by default so a typo
+#                                    # in `required` never traps the user.
+#     description: <str>             # one-line human label, surfaced in the
+#                                    # block reason so the model knows what
+#                                    # skill it's failing.
+#     required: [<step-id>, ...]     # hyphen-form step IDs that MUST appear
+#                                    # in transcript content after the
+#                                    # boundary. The guard searches for the
+#                                    # literal pattern `[step:<skill>/<id>] OK`
+#                                    # in assistant text AND tool_result
+#                                    # blocks (the SKILL.md printf output
+#                                    # lands in tool_result).
+#
+# Behavior:
+#   - Required step IDs must be emitted with the exact literal:
+#       [step:<skill-name>/<step-id>] OK
+#     The hook uses a strict regex so a partial match like `[step:foo]` or
+#     `[step:foo/bar]` (missing OK) won't satisfy the requirement.
+#   - When `enforce: true` AND any required ID is missing from the section
+#     between this skill's boundary and the next catalog skill boundary
+#     (or end of transcript), the hook emits a `block` decision listing the
+#     missing IDs.
+#   - Bypass any check globally with `GH_SKILL_GUARD_BYPASS=1`.
+#   - Trace what the hook is doing with `GH_SKILL_GUARD_TRACE=1` (stderr).
+#
+# Coexistence with gh_issue_flow_stop_guard.py:
+#   Stop hooks chain in `claude/settings.json` and run independently. Both
+#   may emit a `block` — Claude Code re-prompts on either, the union of
+#   their reasons reaches the model.
+
+gh-issue-implement:
+  enforce: true
+  description: "Issue → Code implementation (no commit, no PR)"
+  required:
+    - fetch-issue
+    - self-assign
+    - board-transition
+    - implement
+    - report
+
+gh-pr:
+  enforce: true
+  description: "Create Pull Request from current branch"
+  required:
+    - push-and-create
+    - labels
+    - board-sync
+    - report
+
+gh-commit:
+  enforce: true
+  description: "Git commit with issue linking"
+  required:
+    - stage-commit
+    - metrics-board-sync
+    - report

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -9,6 +9,10 @@
           {
             "type": "command",
             "command": "${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/skill_completion_guard.py"
           }
         ]
       }

--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -81,6 +81,11 @@ their own manual edits), derive intent from the diff itself:
   fix the underlying issue, re-stage, and create a **new** commit.
 - See `references/commit-message-format.md` for the exact HEREDOC command.
 
+After `git commit` succeeds, emit the step-completion marker so the
+harness step-skip guard (`skill_completion_guard.py`, issue #753) can
+verify this step ran:
+`printf '[step:gh-commit/stage-commit] OK\n'`.
+
 ## Step 5: AI Metrics + Sync Project Board Status
 
 Before syncing the project board, record AI metrics (soft-fail — warn on
@@ -158,6 +163,12 @@ fi
 If the repo has no projectV2 board (auto-detected) the helper silently
 returns 0. Opt out with `GH_PROJECT_STATUS_SYNC=0`.
 
+Regardless of whether the metrics post happened, was skipped via
+`GH_DISABLE_AI_METRICS=1`, or the board sync ran or no-op'd, emit the
+step-completion marker so the step-skip guard recognizes Step 5 was
+visited:
+`printf '[step:gh-commit/metrics-board-sync] OK\n'`.
+
 ## Step 6: Verify
 
 After commit succeeds, run `git status` and report:
@@ -167,6 +178,10 @@ Committed <short-hash>: <subject line>
 ```
 
 If an issue was linked, mention the issue number on a second line.
+
+After printing the verify line, emit the report step-completion marker
+so the step-skip guard recognizes the skill finished:
+`printf '[step:gh-commit/report] OK\n'`.
 
 ## Constraints
 

--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -50,15 +50,23 @@ Five substeps in order. Full policy, env vars, and behavior matrix in
 `references/claim.md`.
 
 3.1 **Fetch** — `references/fetch-issue.md` (CLOSED refusal handled there).
+    After `gh issue view` succeeds, emit the step-completion marker so
+    the harness step-skip guard (`skill_completion_guard.py`, issue #753)
+    can verify this step ran:
+    `printf '[step:gh-issue-implement/fetch-issue] OK\n'`.
 3.2 **Block-label guard** — fail-closed abort (exit 2) if any label on
     the issue matches `GH_ISSUE_BLOCK_LABELS`
     (default `do-not-work,on-hold,보류,⏸️ Postpone`).
 3.3 **Self-assign** — `gh issue edit <N> --add-assignee @me` when not
     already on the assignee list; warn (no override) when held by
-    another user. Skip via `GH_ISSUE_SKIP_SELF_ASSIGN=1`.
+    another user. Skip via `GH_ISSUE_SKIP_SELF_ASSIGN=1`. After the
+    assignee edit (or the warn path) finishes, emit:
+    `printf '[step:gh-issue-implement/self-assign] OK\n'`.
 3.4 **Board Status transition** — `_gh_project_status_sync issue <N>
     "In progress" --only-from "Backlog,Ready"`. No-op on repos without
-    a board. Skip via `GH_ISSUE_SKIP_BOARD_TRANSITION=1`.
+    a board. Skip via `GH_ISSUE_SKIP_BOARD_TRANSITION=1`. After the
+    helper returns (success, no-op, or skipped via env), emit:
+    `printf '[step:gh-issue-implement/board-transition] OK\n'`.
 3.5 **Depends-on guard** — soft-warn (continue) for each `Depends on
     #M` line in the body whose `M` is still OPEN. Skip via
     `GH_ISSUE_SKIP_DEPS_CHECK=1`.
@@ -85,6 +93,12 @@ Follow the direct-mode flow in `references/implementation-flow.md` →
 run tests, on failure run the test-failure loop with max 3 iterations
 per the same file).
 
+After implementation + tests pass (or are skipped because no test
+runner was detected), emit the step-completion marker before printing
+the Step 6 report — the harness step-skip guard
+(`skill_completion_guard.py`, issue #753) requires this marker:
+`printf '[step:gh-issue-implement/implement] OK\n'`.
+
 ## Step 6: Report
 
 Print the success or failure report per
@@ -100,6 +114,10 @@ artifact exists yet at this stage):
 ```
 
 Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
+
+Finally, emit the report step-completion marker so the step-skip guard
+recognizes the skill finished:
+`printf '[step:gh-issue-implement/report] OK\n'`.
 
 ## Constraints
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -99,12 +99,21 @@ Read `references/push-and-create.md` for the upstream-state push policy and
 the `gh pr create` command (uses `mktemp` body file, `--assignee @me`,
 `--base "$BASE_BRANCH"` from Step 1a).
 
+After `gh pr create` returns the PR URL, emit the step-completion marker
+so the harness step-skip guard (`skill_completion_guard.py`, issue #753)
+can verify this step ran:
+`printf '[step:gh-pr/push-and-create] OK\n'`.
+
 ## Step 6: Apply Labels
 
 Derive labels from conventional-commit types in `git log <base>..HEAD` and
 PR scope (e.g. `skill` for `claude/skills/` changes). Apply only labels that
 exist in the repo (`gh label list`) — never create new ones. See
 `references/pr-body-template.md` for the full mapping and safe-apply loop.
+
+After the label loop returns (including the no-op case where every
+candidate label was missing from the repo), emit:
+`printf '[step:gh-pr/labels] OK\n'`.
 
 ## Step 7: Sync Project Board Status
 
@@ -174,6 +183,11 @@ Track the outcome for Step 8's report row:
 - helper ran, no projectV2 board → `[SKIP]: no projectV2`
 - helper ran with at least one card moved → `[OK]: PR card -> "In review"`
 
+Regardless of which branch ran (hook delegate, helper missing, no
+projectV2, real sync), emit the step-completion marker so the
+step-skip guard recognizes Step 7 was visited:
+`printf '[step:gh-pr/board-sync] OK\n'`.
+
 ## Step 8: Report
 
 성공 시:
@@ -187,6 +201,10 @@ Next: /gh:pr-reply (after CI green) — replies to review comments
 The `Board sync:` row is a defense-in-depth visual checklist (issue
 #747) — its absence in conversation transcripts is a regression signal
 that Step 7 was silently skipped.
+
+After printing the report block, emit the report step-completion
+marker so the step-skip guard recognizes the skill finished:
+`printf '[step:gh-pr/report] OK\n'`.
 
 Step 1b empty-range / on-base-branch stops, Step 1a `rc=2`/`rc=3`, or
 Step 4.5 lint failure:

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -1,0 +1,684 @@
+"""Tests for claude/hooks/skill_completion_guard.py (issue #753).
+
+The hook is invoked as a Claude Code Stop event handler — same protocol
+as `gh_issue_flow_stop_guard.py`. It reads a JSON event from stdin,
+parses the conversation transcript, and either:
+
+  - exits 0 with empty stdout  → allow the model to stop, OR
+  - exits 0 with `{"decision":"block","reason":"..."}` on stdout
+    → block the stop and re-prompt the model.
+
+These tests assemble synthetic transcript fixtures (one JSONL line per
+message) covering the full state space and assert the hook's stdout +
+exit code. Mirrors the fixture helpers in
+`test_gh_issue_flow_stop_guard.py` so the two hooks share the same
+shape of test infrastructure.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / "claude" / "hooks" / "skill_completion_guard.py"
+CATALOG_PATH = REPO_ROOT / "claude" / "hooks" / "skill_step_catalog.yml"
+
+
+def _run_hook(
+    stdin_payload: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    import os as _os
+
+    final_env: dict[str, str] = _os.environ.copy()
+    # Default: point the hook at the shipped catalog so the standard
+    # gh-issue-implement / gh-pr / gh-commit entries are in scope.
+    final_env.setdefault("GH_SKILL_GUARD_CATALOG", str(CATALOG_PATH))
+    if env is not None:
+        final_env.update(env)
+    return subprocess.run(
+        ["python3", str(HOOK_PATH)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=final_env,
+    )
+
+
+def _write_transcript(tmp_path: Path, messages: list[dict[str, Any]]) -> Path:
+    p = tmp_path / "transcript.jsonl"
+    with p.open("w", encoding="utf-8") as f:
+        for m in messages:
+            f.write(json.dumps(m) + "\n")
+    return p
+
+
+def _user_text(text: str) -> dict[str, Any]:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _assistant_text(text: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _user_tool_result(text: str) -> dict[str, Any]:
+    """Build a user message carrying a single tool_result block.
+
+    This is the shape Bash printf output takes in the transcript — the
+    step-emit markers will be detected from these blocks.
+    """
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_test",
+                    "content": text,
+                }
+            ],
+        },
+    }
+
+
+def _assistant_skill(skill: str, args: str = "") -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": f"toolu_{skill}",
+                    "name": "Skill",
+                    "input": {"skill": skill, "args": args},
+                }
+            ],
+        },
+    }
+
+
+def _hook_event(transcript_path: Path | None, **extras: Any) -> str:
+    payload: dict[str, Any] = {
+        "hook_event_name": "Stop",
+        "session_id": "test-session",
+        "stop_hook_active": False,
+    }
+    if transcript_path is not None:
+        payload["transcript_path"] = str(transcript_path)
+    payload.update(extras)
+    return json.dumps(payload)
+
+
+def _user_slash_command(skill_name: str, args: str) -> dict[str, Any]:
+    """Mirror the Claude Code wrapped-command transcript shape."""
+    content = (
+        f"<command-message>{skill_name}</command-message>\n"
+        f"<command-name>/{skill_name}</command-name>\n"
+        f"<command-args>{args}</command-args>\n"
+        f"Base directory for this skill: /tmp/skills/{skill_name}\n"
+        f"# {skill_name}\n"
+        f"ARGUMENTS: {args}\n"
+    )
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
+# ---------------------------------------------------------------------------
+# Safety-rail / fail-open paths
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_exists_and_is_executable() -> None:
+    assert HOOK_PATH.is_file(), f"Hook script missing: {HOOK_PATH}"
+
+
+def test_catalog_yaml_exists() -> None:
+    assert CATALOG_PATH.is_file(), f"Catalog missing: {CATALOG_PATH}"
+
+
+def test_empty_stdin_allows_stop() -> None:
+    result = _run_hook("")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_malformed_json_stdin_allows_stop() -> None:
+    result = _run_hook("this is not json {{{")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_stdin_not_a_dict_allows_stop() -> None:
+    result = _run_hook(json.dumps([1, 2, 3]))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_missing_transcript_path_allows_stop() -> None:
+    result = _run_hook(json.dumps({"hook_event_name": "Stop"}))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_unreadable_transcript_path_allows_stop(tmp_path: Path) -> None:
+    fake = tmp_path / "does-not-exist.jsonl"
+    result = _run_hook(_hook_event(fake))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_stop_hook_active_short_circuits(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            # No step markers — would normally block.
+        ],
+    )
+    payload = _hook_event(transcript, stop_hook_active=True)
+    result = _run_hook(payload)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_no_catalog_boundary_allows_stop(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("just chatting"),
+            _assistant_text("sure"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_catalog_unreadable_allows_stop(tmp_path: Path) -> None:
+    """Catalog pointed somewhere that does not exist → fail open."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+        ],
+    )
+    bogus_catalog = tmp_path / "no-such.yml"
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_SKILL_GUARD_CATALOG": str(bogus_catalog)},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_global_bypass_env_allows_stop(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            # No step markers — would normally block.
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_SKILL_GUARD_BYPASS": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Boundary detection — all 4 surfaces (raw, wrapped, base-dir, H1)
+# ---------------------------------------------------------------------------
+
+
+def test_raw_slash_command_boundary_detected(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            _assistant_text("running"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "expected block — boundary detected, no steps emitted"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-issue-implement" in decision["reason"]
+
+
+def test_wrapped_command_boundary_detected(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_slash_command("gh-pr", "42"),
+            _assistant_text("running"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-pr" in decision["reason"]
+
+
+def test_skill_tool_use_boundary_detected(tmp_path: Path) -> None:
+    """Sub-skill invocation via Skill() also counts as a boundary."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _assistant_skill("gh-commit"),
+            _assistant_text("running"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-commit" in decision["reason"]
+
+
+def test_colon_namespace_skill_tool_use_counted(tmp_path: Path) -> None:
+    """`gh:issue-implement` (colon form) maps to the catalog `gh-issue-implement` key."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _assistant_skill("gh:issue-implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-issue-implement" in decision["reason"]
+
+
+def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
+    """Mid-sentence mention of /gh-pr is not a boundary (PR #386 regression class)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("I was reading docs about /gh-pr and got confused"),
+            _assistant_text("sure"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_tool_result_command_mention_not_boundary(tmp_path: Path) -> None:
+    """A `/gh-pr` substring in a tool_result block is documentation, not a real boundary."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("read the docs"),
+            _user_tool_result("Examples: run `/gh-pr` or `/gh-commit` or `/gh-issue-implement N`"),
+            _assistant_text("ok"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Step-marker scanning — happy path + missing steps
+# ---------------------------------------------------------------------------
+
+
+def _emit_marker(skill: str, step: str) -> dict[str, Any]:
+    """Simulate a Bash printf for `[step:<skill>/<step>] OK` landing in tool_result."""
+    return _user_tool_result(f"[step:{skill}/{step}] OK\n")
+
+
+def test_all_required_steps_present_allows_stop(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            _emit_marker("gh-issue-implement", "fetch-issue"),
+            _emit_marker("gh-issue-implement", "self-assign"),
+            _emit_marker("gh-issue-implement", "board-transition"),
+            _emit_marker("gh-issue-implement", "implement"),
+            _emit_marker("gh-issue-implement", "report"),
+            _assistant_text("done"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_missing_board_transition_step_blocks(tmp_path: Path) -> None:
+    """The exact incident from issue #753: Step 3.4 board-transition skipped."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            _emit_marker("gh-issue-implement", "fetch-issue"),
+            _emit_marker("gh-issue-implement", "self-assign"),
+            # 3.4 board-transition deliberately omitted.
+            _emit_marker("gh-issue-implement", "implement"),
+            _emit_marker("gh-issue-implement", "report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "board-transition" in decision["reason"]
+    assert "gh-issue-implement" in decision["reason"]
+
+
+def test_missing_gh_pr_board_sync_step_blocks(tmp_path: Path) -> None:
+    """The other half of issue #753: gh-pr Step 7 board-sync skipped."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-pr"),
+            _emit_marker("gh-pr", "push-and-create"),
+            _emit_marker("gh-pr", "labels"),
+            # board-sync deliberately omitted.
+            _emit_marker("gh-pr", "report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "board-sync" in decision["reason"]
+    assert "gh-pr" in decision["reason"]
+
+
+def test_markers_in_assistant_text_also_count(tmp_path: Path) -> None:
+    """If the model prints the marker as assistant text (not bash), still count it."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-commit"),
+            _assistant_text("[step:gh-commit/stage-commit] OK"),
+            _assistant_text("[step:gh-commit/metrics-board-sync] OK"),
+            _assistant_text("[step:gh-commit/report] OK"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_colon_skill_markers_recognized(tmp_path: Path) -> None:
+    """Markers written as `gh:commit/<step>` (colon form) should also satisfy."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-commit"),
+            _emit_marker("gh:commit", "stage-commit"),
+            _emit_marker("gh:commit", "metrics-board-sync"),
+            _emit_marker("gh:commit", "report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_partial_marker_without_ok_does_not_satisfy(tmp_path: Path) -> None:
+    """Strings missing the trailing `OK` (the discriminator) must not count."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-commit"),
+            _user_tool_result("[step:gh-commit/stage-commit]\n"),
+            _user_tool_result("[step:gh-commit/metrics-board-sync]\n"),
+            _user_tool_result("[step:gh-commit/report]\n"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+
+
+def test_unrelated_skill_markers_do_not_satisfy(tmp_path: Path) -> None:
+    """Markers from a different catalog skill must not cross-credit."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-commit"),
+            _emit_marker("gh-pr", "push-and-create"),
+            _emit_marker("gh-pr", "labels"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-commit" in decision["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Catalog-level enforce flag
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_false_skill_does_not_block(tmp_path: Path) -> None:
+    """An entry with enforce=false logs but never blocks."""
+    custom_catalog = tmp_path / "catalog.yml"
+    custom_catalog.write_text(
+        "gh-issue-implement:\n  enforce: false\n  description: test\n  required:\n    - some-step\n",
+        encoding="utf-8",
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            # No step markers, but enforce=false → must NOT block.
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_SKILL_GUARD_CATALOG": str(custom_catalog)},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_unknown_skill_in_transcript_does_not_block(tmp_path: Path) -> None:
+    """A slash command for a skill NOT in the catalog leaves the hook silent."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/some-unrelated-skill"),
+            _assistant_text("ok"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Multi-boundary scenarios (gh-issue-flow chain compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_most_recent_boundary_governs(tmp_path: Path) -> None:
+    """When two catalog skills appear sequentially, the LATER one's requirements
+    drive the block reason. The earlier section is assumed to have moved on.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            # Step markers for gh-issue-implement — all 5 present.
+            _emit_marker("gh-issue-implement", "fetch-issue"),
+            _emit_marker("gh-issue-implement", "self-assign"),
+            _emit_marker("gh-issue-implement", "board-transition"),
+            _emit_marker("gh-issue-implement", "implement"),
+            _emit_marker("gh-issue-implement", "report"),
+            # Now the model moves on to gh-commit but skips half the steps.
+            _assistant_skill("gh-commit"),
+            _emit_marker("gh-commit", "stage-commit"),
+            # metrics-board-sync and report missing.
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-commit" in decision["reason"]
+    assert "metrics-board-sync" in decision["reason"]
+    # The previous skill's report markers must NOT bleed into gh-commit.
+    assert "fetch-issue" not in decision["reason"]
+
+
+def test_chain_of_catalog_skills_with_each_completing_allows_stop(tmp_path: Path) -> None:
+    """The gh-issue-flow happy path: each sub-skill emits all its required markers."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _emit_marker("gh-issue-implement", "fetch-issue"),
+            _emit_marker("gh-issue-implement", "self-assign"),
+            _emit_marker("gh-issue-implement", "board-transition"),
+            _emit_marker("gh-issue-implement", "implement"),
+            _emit_marker("gh-issue-implement", "report"),
+            _assistant_skill("gh-commit"),
+            _emit_marker("gh-commit", "stage-commit"),
+            _emit_marker("gh-commit", "metrics-board-sync"),
+            _emit_marker("gh-commit", "report"),
+            _assistant_skill("gh-pr"),
+            _emit_marker("gh-pr", "push-and-create"),
+            _emit_marker("gh-pr", "labels"),
+            _emit_marker("gh-pr", "board-sync"),
+            _emit_marker("gh-pr", "report"),
+            _assistant_text("gh:issue-flow complete (#42)"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Trace mode
+# ---------------------------------------------------------------------------
+
+
+def test_trace_off_by_default_no_stderr(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            _emit_marker("gh-issue-implement", "fetch-issue"),
+            _emit_marker("gh-issue-implement", "self-assign"),
+            _emit_marker("gh-issue-implement", "board-transition"),
+            _emit_marker("gh-issue-implement", "implement"),
+            _emit_marker("gh-issue-implement", "report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert result.stderr == ""
+
+
+def test_trace_on_block_emits_diagnostics(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-implement 42"),
+            # No markers — must block + emit trace.
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_SKILL_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "[skill-guard]" in result.stderr
+    assert "skill=gh-issue-implement" in result.stderr
+    assert "layer=L1.5" in result.stderr
+
+
+def test_trace_on_allow_path_no_boundary(tmp_path: Path) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [_user_text("hello")],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"GH_SKILL_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert "[skill-guard] allow:" in result.stderr
+    assert "layer=L1" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Coexistence with gh_issue_flow_stop_guard.py
+# ---------------------------------------------------------------------------
+
+
+def test_gh_issue_flow_guard_tests_unaffected_by_new_hook() -> None:
+    """The existing gh_issue_flow_stop_guard.py tests must still pass.
+
+    This is a structural sanity check — the new hook ships in the same
+    `claude/hooks/` directory and registers next to the old one in
+    settings.json. We verify the existing test module still loads its
+    hook path correctly.
+    """
+    other_hook = REPO_ROOT / "claude" / "hooks" / "gh_issue_flow_stop_guard.py"
+    assert other_hook.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Hook callable via shebang
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exec_form",
+    [
+        ["python3", str(HOOK_PATH)],
+        [str(HOOK_PATH)],
+    ],
+)
+def test_hook_callable_two_ways(tmp_path: Path, exec_form: list[str]) -> None:
+    import os as _os
+
+    transcript = _write_transcript(
+        tmp_path,
+        [_user_text("just chat")],
+    )
+    env = _os.environ.copy()
+    env["GH_SKILL_GUARD_CATALOG"] = str(CATALOG_PATH)
+    result = subprocess.run(
+        exec_form,
+        input=_hook_event(transcript),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- `gh:issue-implement` Step 3.4 (board → "In progress") 와 `gh:pr` Step 7 (board → "In review") 가 SKILL.md 단계 번호를 모델이 시각적으로 따라가지 않아 silently skip 되던 회귀를 메커니즘으로 차단. `gh-issue-flow` 가 5단계 chain 에 Stop hook 으로 backstop 을 깐 패턴(#383)을 일반화해, **단독 호출되는 다단계 SKILL.md** 도 카탈로그 기반으로 같은 보호를 받게 한다.
- 신규 hook `claude/hooks/skill_completion_guard.py` 는 카탈로그(`claude/hooks/skill_step_catalog.yml`)에 등록된 스킬마다 `[step:<skill>/<id>] OK` 마커가 transcript 에 모두 emit 됐는지 확인. 누락 시 `{"decision":"block",...}` 를 stdout 에 출력해 turn-end 차단. `gh_issue_flow_stop_guard.py` 의 sister hook — 외부 5-sub-skill chain 은 그 hook 이, 각 sub-skill 의 내부 step 은 본 hook 이 감시.
- `gh-issue-implement` / `gh-pr` / `gh-commit` SKILL.md 에 `printf '[step:...] OK\n'` 라인을 핵심 단계 끝에 삽입 (총 12개). 옵트인 — 카탈로그에 `enforce: true` 로 등록된 스킬만 차단.

## Changes
- **`claude/hooks/skill_completion_guard.py` (new, 441 lines)** — boundary detection 4 surfaces (raw slash / `<command-name>` wrapper / `Base directory for this skill:` marker / SKILL.md H1) per #608, section scan from most-recent catalog boundary to next catalog boundary, scan covers assistant text AND tool_result blocks (Bash printf 출력은 tool_result 에 lands). Safety rails: empty stdin / malformed JSON / missing transcript / `stop_hook_active=True` / catalog missing → all fail-open. `GH_SKILL_GUARD_BYPASS=1` 글로벌 escape hatch, `GH_SKILL_GUARD_TRACE=1` stderr 트레이스.
- **`claude/hooks/skill_step_catalog.yml` (new)** — opt-in SSOT. `gh-issue-implement` 5 steps, `gh-pr` 4 steps, `gh-commit` 3 steps. `enforce: false` 면 trace 로그만 남기고 차단하지 않음 (새 스킬 추가 시 false-positive 보호).
- **`claude/settings.json`** — `gh_issue_flow_stop_guard.py` 뒤에 `skill_completion_guard.py` Stop hook chain 등록. 두 hook 이 독립 실행 — 둘 중 하나라도 block 하면 모델이 재프롬프트됨.
- **`claude/skills/gh-issue-implement/SKILL.md`** — Step 3.1 (fetch-issue), 3.3 (self-assign), 3.4 (board-transition), 5 (implement), 6 (report) 각각 끝에 `printf '[step:gh-issue-implement/<id>] OK\n'` emit 추가.
- **`claude/skills/gh-pr/SKILL.md`** — Step 5 (push-and-create), 6 (labels), 7 (board-sync — hook delegate / helper missing / no projectV2 / real sync 모든 branch 포함), 8 (report) 끝에 마커 emit 추가.
- **`claude/skills/gh-commit/SKILL.md`** — Step 4 (stage-commit), 5 (metrics-board-sync), 6 (report) 끝에 마커 emit 추가.
- **`tests/integration/test_skill_completion_guard.py` (new, 34 tests)** — fail-open safety rails 8건, boundary 4 surface 검출 + colon-namespace 매핑 + tool_result mention false-positive 가드 6건, step-marker scan happy-path / missing-step / partial-without-OK / unrelated-skill-not-cross-credit 7건, catalog `enforce: false` / unknown-skill 2건, multi-boundary handoff (gh-issue-flow chain 호환성) 2건, trace mode 3건, hook 실행 방식 2건.

## Test plan
- [x] `pytest tests/integration/test_skill_completion_guard.py` — 34/34 passed (1.06s)
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py` — 40/40 passed (회귀 없음, AC: 기존 11+ 테스트 green 유지 확인)
- [x] `pytest tests/integration/` — 1096/1096 passed (9:54)
- [x] `bash tests/golden_rules/test_golden_rules.sh` — 5/5 rules passed
- [x] `ruff check` + `ruff format --check` on hook + tests — clean
- [ ] (post-merge 수동) `/gh-issue-implement N` 호출에서 Step 3.4 board-transition 의도적 누락 → hook block + 재시도 유도 동작 확인
- [ ] (post-merge 수동) `/gh-pr` 호출에서 Step 7 board-sync 의도적 누락 → hook block 동작 확인
- [ ] (post-merge 수동) `GH_SKILL_GUARD_BYPASS=1 /gh-commit` → 마커 누락해도 block 안 됨 확인

## Related
Closes #753

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~3 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~3 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
