### PR TITLE
feat(skills): #786 gh:pr-resolve-outdated — PR base out-of-date 자동 해결

### DIFF
--- a/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
@@ -8,8 +8,8 @@ description: >-
   "PR CI fail 해결", "CI fail 라벨 떼줘", "PR CI 빨간 거 고쳐". Refuses on the
   default branch, refuses `--force` / `--force-with-lease`, refuses to push
   when local lint/test is red (CI infinite-loop guard). Sister skill of
-  [[gh-pr-resolve-conflict]] — different verb and risk profile, same
-  PR-lifecycle slot. Accepts `[pr-number] [remote] [--wait <seconds>]
+  [[gh-pr-resolve-conflict]] and [[gh-pr-resolve-outdated]] — same
+  PR-lifecycle slot, different verb and risk profile. Accepts `[pr-number] [remote] [--wait <seconds>]
   [--label-variant <input>]`; defaults to the PR attached to the current
   branch. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -7,9 +7,9 @@ description: >-
   /gh-pr-resolve-conflict, or asks "PR conflict 해결", "base 변경됐는데 rebase
   해줘", "리베이스로 컨플릭트 풀어". Refuses to run on the default branch,
   refuses plain `--force`, and never auto-guesses conflict content — the
-  user drives each resolution. Sister skill of [[gh-pr-resolve-ci-fail]] —
-  different verb (rebase-resolve vs read-logs-and-edit) for the same
-  PR-lifecycle slot. Accepts `[pr-number] [remote]`; defaults to the PR
+  user drives each resolution. Sister skill of [[gh-pr-resolve-ci-fail]]
+  and [[gh-pr-resolve-outdated]] — same PR-lifecycle slot, different
+  verb (rebase-resolve vs read-logs-and-edit vs clean-rebase-no-conflicts). Accepts `[pr-number] [remote]`; defaults to the PR
   attached to the current branch. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---

--- a/claude/skills/gh-pr-resolve-outdated/SKILL.md
+++ b/claude/skills/gh-pr-resolve-outdated/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: gh:pr-resolve-outdated
+description: >-
+  Resolve a GitHub PR's "This branch is out-of-date with the base branch"
+  banner (base has moved forward but there are no file conflicts) by
+  rebasing onto the latest base and pushing with `--force-with-lease`.
+  Use when the user runs /gh:pr-resolve-outdated, /gh-pr-resolve-outdated,
+  or asks "PR base out-of-date", "base 변경됐는데 그냥 sync", "rebase 후
+  force-with-lease push 해줘". Refuses the repo default branch, refuses
+  plain `--force`, and delegates to [[gh-pr-resolve-conflict]] the moment
+  rebase produces conflicts. Sister skill of [[gh-pr-resolve-conflict]]
+  and [[gh-pr-resolve-ci-fail]] — same PR-lifecycle slot, different verb
+  (clean rebase vs conflict resolution vs CI fix). Idempotent: already
+  up-to-date PR is a no-op. Accepts `[pr-number] [remote]`; defaults to
+  the PR attached to the current branch. Accepts `-h`/`--help`/`help`.
+allowed-tools: Bash, Read
+---
+
+# gh:pr-resolve-outdated — Clean Rebase for Out-of-Date PR
+
+## Help
+
+Arg #1 `-h`/`--help`/`help` → read `references/help.md` verbatim, stop.
+No API calls.
+
+## Step 1: Parse Args + Preflight
+
+Record `START_TS=$(date +%s)` immediately for Step 5.
+
+Positional: `[pr-number] [remote]`. Both optional.
+
+- `pr-number` — if omitted, auto-detect via `gh pr view --json
+  number,headRefName,baseRefName,url,mergeable,mergeStateStatus` on
+  the current branch. No PR → `[FAIL] no PR for current branch — pass
+  PR# explicitly` + exit 2.
+- `remote` — default `origin`. Resolve `TARGET_REPO` via
+  `git remote get-url <remote>`; missing → `git remote -v` + exit 2.
+- `gh` not authenticated → `[FAIL] gh CLI not authenticated — run gh
+  auth login` + exit 5.
+
+**Hard preconditions** (any fail → stop): inside a git repo · current
+branch ≠ repo default (`[FAIL] cannot run on default branch` + exit 2)
+· clean working tree (no auto-stash) · no in-progress rebase/merge/
+cherry-pick. Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it
+for `git reset --hard <sha>` recovery.
+
+## Step 2: Mergeable Triage
+
+```bash
+gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
+  --json mergeable,mergeStateStatus,baseRefName,headRefName,url
+```
+
+| `mergeable` | `mergeStateStatus` | Action |
+|---|---|---|
+| `MERGEABLE` | `CLEAN`/`UNSTABLE` | `[OK] PR은 이미 up-to-date — nothing to do.` exit 0 (NF-1) |
+| `MERGEABLE` | `BEHIND` | proceed to Step 3 (the case this skill handles) |
+| `CONFLICTING` | — | `[FAIL] PR has merge conflicts — use /gh:pr-resolve-conflict` + exit 3 |
+| `UNKNOWN` | — | GitHub still computing; print hint + exit 0 (retry later) |
+
+`BLOCKED` alone (CI/approval pending) is not an out-of-date case — not handled here.
+
+## Step 3: Fetch + Clean Rebase
+
+```bash
+git fetch "$REMOTE" "$BASE"
+git rebase "$REMOTE/$BASE"
+```
+
+Rebase exits non-zero with conflicts → `git rebase --abort` immediately,
+print `[FAIL] rebase produced conflicts — use /gh-pr-resolve-conflict
+<PR_NUMBER>` + exit 4. The skill's premise is the no-conflict case;
+the moment conflicts appear, hand off (never auto-guess — same policy
+as the sister skill).
+
+## Step 4: Push with `--force-with-lease`
+
+Only after `git rebase` exits 0 and the tree is clean:
+
+```bash
+git push --force-with-lease "$REMOTE" HEAD
+```
+
+Never plain `--force`. Rejected (remote advanced while rebasing) →
+`[FAIL] remote advanced — re-fetch and retry` + exit 6. **Never**
+silently re-fetch and re-rebase — surface divergence so the user
+decides (lost-update risk).
+
+## Step 5: Verify + Report
+
+```bash
+gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
+  --json mergeable,mergeStateStatus,url
+```
+
+`mergeStateStatus ∈ {CLEAN, UNSTABLE, BLOCKED}` → banner cleared
+(`BLOCKED` here = CI/approval pending, normal). Still `BEHIND` → push
+didn't land; print PR URL, do not loop.
+
+```
+[OK] PR #<N> out-of-date 해소됨 · <new-sha> push 됨.
+Next: /gh-pr-reply <N>  # 리뷰어 회신 또는 CI 결과 대기
+```
+
+ai-metrics footer follows the sister-skill pattern; skip when
+`GH_DISABLE_AI_METRICS=1` (#399).
+
+## Constraints
+
+- Rebase-only. Never a merge commit.
+- `--force-with-lease` only — never plain `--force`.
+- Never run on the repo's default branch.
+- Never auto-resolve conflicts — delegate to `gh:pr-resolve-conflict`
+  and exit 4 the moment rebase produces them.
+- Never retry a rejected `--force-with-lease` automatically.
+- Never auto-stash. Clean tree required.

--- a/claude/skills/gh-pr-resolve-outdated/references/help.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/help.md
@@ -1,0 +1,92 @@
+# gh:pr-resolve-outdated — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<pr-number>` or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `782` |
+| 2 | remote-name | `origin` | Git remote whose repo owns the PR |
+
+## Usage
+
+```
+/gh-pr-resolve-outdated              # PR attached to current branch, origin
+/gh-pr-resolve-outdated 782          # explicit PR, origin
+/gh-pr-resolve-outdated 782 upstream # explicit PR, upstream remote
+/gh-pr-resolve-outdated -h           # this help
+```
+
+## When to use this skill
+
+- GitHub shows **"This branch is out-of-date with the base branch"**
+  on a PR (banner / "Update branch" button), but there are **no file
+  conflicts**.
+- A colleague's PR merged first and the base (usually `main`) has
+  moved forward, but your changes don't overlap.
+- You want a 1-line slash command instead of typing
+  `git fetch && git rebase origin/main && git push --force-with-lease`
+  every time.
+
+## When NOT to use
+
+- The PR has actual file conflicts → use `/gh-pr-resolve-conflict`
+  (the sister skill that walks through each conflicting file).
+- The PR is failing CI → use `/gh-pr-resolve-ci-fail`. Out-of-date is
+  not the same problem.
+- You want a merge commit on your PR instead of a rebase. This skill
+  refuses — dotfiles policy is rebase-only.
+- You are on the repo's default branch. The skill refuses — switch to
+  the feature branch first.
+
+## What the skill does
+
+1. Parses args. Auto-detects the PR from the current branch if omitted.
+2. Prints a **backup SHA** so `git reset --hard <sha>` can undo
+   everything if the rebase goes wrong.
+3. Queries `gh pr view --json mergeable,mergeStateStatus`:
+   - `MERGEABLE` + `CLEAN`/`UNSTABLE` → already up-to-date, exit 0.
+   - `MERGEABLE` + `BEHIND` → proceed (this skill's job).
+   - `CONFLICTING` → delegate to `/gh-pr-resolve-conflict`, exit 3.
+   - `UNKNOWN` → GitHub still computing, exit 0 (retry later).
+4. `git fetch <remote> <base>`, then `git rebase <remote>/<base>`.
+5. Conflicts appear during rebase → `git rebase --abort` and exit 4
+   with a pointer to `/gh-pr-resolve-conflict <PR_NUMBER>`. Never
+   auto-guesses (same policy as the sister skill).
+6. `git push --force-with-lease` (never plain `--force`). Rejected
+   push → exit 6, no silent retry.
+7. Re-queries `gh pr view` to confirm the banner is cleared.
+
+## Safety
+
+- **Backup SHA** printed before the rebase — `git reset --hard <sha>`
+  restores the pre-rebase state; `git reflog` is always available too.
+- **Clean tree required** — no auto-stash. A dirty tree means the
+  rebase scope isn't clear; commit or stash manually first.
+- **`--force-with-lease`** — rejects the push if someone else pushed
+  while you rebased. The skill stops; it does NOT silently re-fetch
+  and re-rebase (lost-update risk).
+- **Default-branch refusal** — exit 2 if run while checked out on
+  `main` (or the repo's configured default).
+- **Worktree-safe** — only the current worktree's branch is touched.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — banner cleared, or no-op (already up-to-date / UNKNOWN) |
+| 2 | Bad arguments / default branch / no PR for current branch / remote missing |
+| 3 | PR has merge conflicts — `/gh-pr-resolve-conflict` is the right tool |
+| 4 | Rebase produced conflicts — `/gh-pr-resolve-conflict` is the right tool |
+| 5 | `gh` CLI not authenticated |
+| 6 | `--force-with-lease` rejected (remote advanced — re-fetch and retry) |
+
+## Related skills
+
+- `gh:pr-resolve-conflict` — sister skill for actual file conflicts.
+  Same rebase-and-force-with-lease structure, but walks through each
+  conflicting file with the user.
+- `gh:pr-resolve-ci-fail` — sister skill for `CI fail` label. Reads
+  failing check logs, fixes locally, pushes (no force), removes the
+  label last.
+- `gh:pr-merge` — once the banner clears, merge with rebase/squash/merge.
+- `gh:pr-reply` — reply to review comments after syncing the base.


### PR DESCRIPTION
## Summary
- GitHub PR 의 "This branch is out-of-date with the base branch" (base 가 앞서갔지만 file conflict 는 없는 상태) 케이스를 1개 슬래시 명령으로 해결하는 신규 스킬 `gh:pr-resolve-outdated` 추가.
- `gh:pr-resolve-conflict` (실제 충돌) / `gh:pr-resolve-ci-fail` (CI fail) 와 sister — 같은 PR 라이프사이클 슬롯, 다른 verb (clean-rebase vs rebase-resolve vs read-logs-and-edit).
- Idempotent (이미 up-to-date 면 no-op), worktree-safe, default branch 거부, `--force-with-lease` 강제.

## Changes
- `claude/skills/gh-pr-resolve-outdated/SKILL.md` (신규, 116 줄): 6-step 흐름 — args parse → mergeable triage → fetch+rebase → push --force-with-lease → verify → report. Error code 표: exit 0/2/3/4/5/6 분리 (rebase conflict 는 4, force-with-lease 거부는 6).
- `claude/skills/gh-pr-resolve-outdated/references/help.md` (신규): sister 스킬과 동일한 Arguments / Usage / When to use / Safety / Exit codes / Related skills 구성.
- `claude/skills/gh-pr-resolve-conflict/SKILL.md`: description 의 sister 줄에 `[[gh-pr-resolve-outdated]]` cross-link 추가.
- `claude/skills/gh-pr-resolve-ci-fail/SKILL.md`: description 의 sister 줄에 `[[gh-pr-resolve-outdated]]` cross-link 추가.

## 설계 결정 요약
- `gh:pr-resolve-conflict` 확장 대신 별도 스킬: 두 verb 의 의사결정 트리가 달라 description 이 vague 해지면 trigger 정확도 저하 — 이슈 본문 "Alternatives Considered" 표 1행과 동일 결론.
- merge commit 으로 update 거부: dotfiles 컨벤션 (linear rebase) 위반. 최근 20개 commit log 도 모두 rebase 기반.
- rebase 중 conflict 발생 시 자동 위임 (`gh:pr-resolve-conflict <N>` 안내 + exit 4) — 사용자가 의도한 케이스가 아니면 즉시 abort 해 lost-update / 잘못된 auto-resolve 위험 차단.
- `--force-with-lease` 거부 시 silent retry 금지 — lost-update 위험 (sister 스킬과 동일 정책).

## Test plan
- [ ] `mise run lint` (uv 직접 호출) — ruff check + ruff format check + mypy + shellcheck + shfmt 모두 clean ✓ 로컬 확인
- [ ] `pytest tests/integration/test_help_topics.py tests/integration/test_company_skills_safety.py tests/integration/test_gh_issue_flow_stop_guard.py` — 292 passed ✓ 로컬 확인
- [ ] CI 그린 후 `/gh-pr-resolve-outdated -h` 가 references/help.md 내용 출력하는지 수동 확인
- [ ] 다음 out-of-date PR 발생 시 `/gh-pr-resolve-outdated <N>` 으로 실제 dogfood
- [ ] `/gh-pr-resolve-outdated` (인자 없이) → 현재 branch PR 자동 해석 → rebase + force-with-lease push → banner 해소 확인

## Related
Closes #786

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
