### PR TITLE
fix(vscode): #794 sync-push/pull diff 기반 가드 — 동일하면 backup/copy skip

### DIFF
--- a/.vscode/sync-pull.sh
+++ b/.vscode/sync-pull.sh
@@ -112,7 +112,7 @@ cat "$BASE_FILE" | python3 -m json.tool --indent 2 2>/dev/null || cat "$BASE_FIL
 # keybindings.json 복사 (존재하는 경우)
 if [[ -f "$VSCODE_KEYBINDINGS_PATH" ]]; then
     # VS Code의 JSON 주석을 제거하고 정렬된 형식으로 임시 파일에 작성
-    KEYBINDINGS_TMP=$(mktemp)
+    KEYBINDINGS_TMP=$(mktemp "${TMPDIR:-/tmp}/keybindings.XXXXXX")
     trap 'rm -f "$KEYBINDINGS_TMP"' EXIT
 
     if ! python3 - "$VSCODE_KEYBINDINGS_PATH" "$KEYBINDINGS_TMP" <<'EOF'; then

--- a/.vscode/sync-pull.sh
+++ b/.vscode/sync-pull.sh
@@ -30,6 +30,30 @@ log_warning() {
     echo -e "${YELLOW}⚠${NC}  $1"
 }
 
+# 동일하면 skip, 다르면 backup→copy. target 없으면 backup 없이 copy.
+copy_if_changed() {
+    local src="$1" dst="$2" name
+    name=$(basename "$dst")
+
+    if [[ ! -f "$dst" ]]; then
+        cp "$src" "$dst"
+        log_success "${name} 복사 완료 (신규)"
+        return 0
+    fi
+
+    if cmp -s "$src" "$dst" 2>/dev/null || diff -q "$src" "$dst" >/dev/null 2>&1; then
+        log_info "${name} 변경 없음 — skip"
+        return 0
+    fi
+
+    local backup
+    backup="${dst}.backup.$(date +%Y%m%d_%H%M%S)"
+    cp "$dst" "$backup"
+    log_info "기존 ${name} 백업: $backup"
+    cp "$src" "$dst"
+    log_success "${name} 복사 완료"
+}
+
 # WSL 환경 감지 함수
 is_wsl() {
     if [[ -f /proc/version ]] && grep -qi "microsoft\|wsl" /proc/version 2>/dev/null; then
@@ -78,16 +102,8 @@ fi
 # VS Code 설정 파일들의 경로 결정
 VSCODE_KEYBINDINGS_PATH="${VSCODE_SETTINGS_PATH%/*}/keybindings.json"
 
-# base.json 백업 생성
-BACKUP_FILE="${BASE_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
-if [[ -f "$BASE_FILE" ]]; then
-    cp "$BASE_FILE" "$BACKUP_FILE"
-    log_info "기존 base.json 백업: $BACKUP_FILE"
-fi
-
-# VS Code 설정을 base.json에 복사
-cp "$VSCODE_SETTINGS_PATH" "$BASE_FILE"
-log_success "settings.json 복사 완료"
+# settings.json: diff 가드 후 backup → copy
+copy_if_changed "$VSCODE_SETTINGS_PATH" "$BASE_FILE"
 
 echo ""
 log_info "Settings 파일:"
@@ -95,31 +111,25 @@ cat "$BASE_FILE" | python3 -m json.tool --indent 2 2>/dev/null || cat "$BASE_FIL
 
 # keybindings.json 복사 (존재하는 경우)
 if [[ -f "$VSCODE_KEYBINDINGS_PATH" ]]; then
-    KEYBINDINGS_BACKUP_FILE="${KEYBINDINGS_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
-    if [[ -f "$KEYBINDINGS_FILE" ]]; then
-        cp "$KEYBINDINGS_FILE" "$KEYBINDINGS_BACKUP_FILE"
-        log_info "기존 keybindings.json 백업: $KEYBINDINGS_BACKUP_FILE"
-    fi
+    # VS Code의 JSON 주석을 제거하고 정렬된 형식으로 임시 파일에 작성
+    KEYBINDINGS_TMP=$(mktemp)
+    trap 'rm -f "$KEYBINDINGS_TMP"' EXIT
 
-    # VS Code의 JSON 주석을 제거하고 정렬된 형식으로 저장
-    python3 << EOF
+    if ! python3 - "$VSCODE_KEYBINDINGS_PATH" "$KEYBINDINGS_TMP" <<'EOF'; then
 import json
 import re
+import sys
 
-vscode_file = "$VSCODE_KEYBINDINGS_PATH"
-target_file = "$KEYBINDINGS_FILE"
+vscode_file = sys.argv[1]
+target_file = sys.argv[2]
 
 try:
     with open(vscode_file, 'r', encoding='utf-8') as f:
         content = f.read()
 
-    # JSON 주석 제거 (// 로 시작하는 라인)
     content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
-
-    # JSON 파싱
     data = json.loads(content)
 
-    # 정렬된 JSON으로 저장
     with open(target_file, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
         f.write('\n')
@@ -127,19 +137,18 @@ try:
     print("OK")
 except Exception as e:
     print(f"ERROR: {e}")
-    exit(1)
+    sys.exit(1)
 EOF
-
-    if [[ $? -eq 0 ]]; then
-        log_success "keybindings.json 복사 완료"
-
-        echo ""
-        log_info "Keybindings 파일:"
-        cat "$KEYBINDINGS_FILE" | python3 -m json.tool --indent 2 2>/dev/null || cat "$KEYBINDINGS_FILE"
-    else
         log_error "keybindings.json 처리 중 오류가 발생했습니다"
         exit 1
     fi
+
+    # 정규화된 임시 파일과 현재 KEYBINDINGS_FILE 을 비교 후 backup → copy
+    copy_if_changed "$KEYBINDINGS_TMP" "$KEYBINDINGS_FILE"
+
+    echo ""
+    log_info "Keybindings 파일:"
+    python3 -m json.tool --indent 2 "$KEYBINDINGS_FILE" 2>/dev/null || cat "$KEYBINDINGS_FILE"
 else
     log_warning "keybindings.json 파일을 찾을 수 없습니다: $VSCODE_KEYBINDINGS_PATH"
 fi

--- a/.vscode/sync-push.sh
+++ b/.vscode/sync-push.sh
@@ -26,6 +26,30 @@ log_error() {
     echo -e "${RED}✗${NC}  $1" >&2
 }
 
+# 동일하면 skip, 다르면 backup→copy. target 없으면 backup 없이 copy.
+copy_if_changed() {
+    local src="$1" dst="$2" name
+    name=$(basename "$dst")
+
+    if [[ ! -f "$dst" ]]; then
+        cp "$src" "$dst"
+        log_success "${name} 복사 완료 (신규)"
+        return 0
+    fi
+
+    if cmp -s "$src" "$dst" 2>/dev/null || diff -q "$src" "$dst" >/dev/null 2>&1; then
+        log_info "${name} 변경 없음 — skip"
+        return 0
+    fi
+
+    local backup
+    backup="${dst}.backup.$(date +%Y%m%d_%H%M%S)"
+    cp "$dst" "$backup"
+    log_info "기존 ${name} 백업: $backup"
+    cp "$src" "$dst"
+    log_success "${name} 복사 완료"
+}
+
 # base.json 파일 확인
 if [[ ! -f "$BASE_FILE" ]]; then
     log_error "base.json 파일을 찾을 수 없습니다: $BASE_FILE"
@@ -86,27 +110,11 @@ fi
 # VS Code 설정 파일들의 경로 결정
 VSCODE_KEYBINDINGS_PATH="${VSCODE_SETTINGS_PATH%/*}/keybindings.json"
 
-# settings.json 백업 생성
-BACKUP_FILE="${VSCODE_SETTINGS_PATH}.backup.$(date +%Y%m%d_%H%M%S)"
-if [[ -f "$VSCODE_SETTINGS_PATH" ]]; then
-    cp "$VSCODE_SETTINGS_PATH" "$BACKUP_FILE"
-    log_info "기존 settings.json 백업: $BACKUP_FILE"
-fi
+# settings.json: diff 가드 후 backup → copy
+copy_if_changed "$BASE_FILE" "$VSCODE_SETTINGS_PATH"
 
-# base.json을 VS Code settings.json에 복사
-cp "$BASE_FILE" "$VSCODE_SETTINGS_PATH"
-log_success "settings.json 복사 완료"
-
-# keybindings.json 백업 생성
-KEYBINDINGS_BACKUP_FILE="${VSCODE_KEYBINDINGS_PATH}.backup.$(date +%Y%m%d_%H%M%S)"
-if [[ -f "$VSCODE_KEYBINDINGS_PATH" ]]; then
-    cp "$VSCODE_KEYBINDINGS_PATH" "$KEYBINDINGS_BACKUP_FILE"
-    log_info "기존 keybindings.json 백업: $KEYBINDINGS_BACKUP_FILE"
-fi
-
-# keybindings.json을 VS Code에 복사
-cp "$KEYBINDINGS_FILE" "$VSCODE_KEYBINDINGS_PATH"
-log_success "keybindings.json 복사 완료"
+# keybindings.json: diff 가드 후 backup → copy
+copy_if_changed "$KEYBINDINGS_FILE" "$VSCODE_KEYBINDINGS_PATH"
 
 echo ""
 log_info "VS Code를 재시작하여 변경 사항을 적용하세요"


### PR DESCRIPTION
## Summary
- `./setup.sh` 마다 `.vscode/sync-push.sh` 가 Windows VS Code 설정 파일들을 무조건 backup → 덮어쓰기 하던 동작에 diff 기반 가드를 추가. byte-identical 일 때 backup/copy 모두 skip, 다를 때만 기존 동작 유지.
- 같은 정책을 `.vscode/sync-pull.sh` 의 base.json / keybindings.json 두 사이트에도 적용. keybindings.json 은 Python 으로 주석 제거 + 재포맷한 결과를 임시 파일에 먼저 쓰고 그 결과와 기존 파일을 비교하여 정규화 후 동일한 경우에도 backup 생성을 회피.
- `copy_if_changed(src, dst)` 헬퍼로 통합: target 없음 → 신규 copy, 동일 → "변경 없음 — skip", 다름 → backup + copy. `cmp -s` 우선 + `diff -q` fallback 으로 busybox 환경도 안전.

## 변경 파일
- `.vscode/sync-push.sh` — `copy_if_changed` 추가 + settings.json / keybindings.json 2 사이트 교체
- `.vscode/sync-pull.sh` — `copy_if_changed` 추가 + base.json / keybindings.json 2 사이트 교체 (keybindings.json 은 temp-file 경유 비교)

## Test plan
- [x] `shellcheck -x` / `shfmt -d -i 4` 통과 (사전 존재 SC2002 1건은 별도 — `.vscode/` 는 `mise run lint-sh` 매트릭스 밖)
- [x] `bash -n` syntax OK
- [x] `copy_if_changed` 4 케이스 골든 path 수동 검증:
  - 신규 (target 없음) → copy, no backup
  - 동일 (byte-identical) → skip, 파일 카운트 불변
  - 다름 → backup 1개 + copy, dst == src
  - 재실행 → backup 카운트 불변
- [ ] (수동) 실제 WSL 환경에서 `./setup.sh` 재실행 시 backup 파일 미생성 확인

Closes #794

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
