### PR TITLE
refactor(setup): #793 섹션 헤더 ux_section 통일 + \n 리터럴 출력 제거

### DIFF
--- a/bash/setup.sh
+++ b/bash/setup.sh
@@ -52,7 +52,11 @@ log_critical() {
     exit 1
 }
 log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
-log_debug() { echo -e "${UX_MUTED}[DEBUG] $1${UX_RESET}"; }
+# [DEBUG] 접두 출력은 명시적으로 DOTFILES_DEBUG=1 일 때만 노출 (#793 F-3).
+log_debug() {
+    [ "${DOTFILES_DEBUG:-0}" = "1" ] || return 0
+    echo -e "${UX_MUTED}[DEBUG] $1${UX_RESET}"
+}
 log_warning() { ux_warning "$1"; }
 
 # --- Functions ---
@@ -104,7 +108,7 @@ create_symlink() {
 
 # --- Main Script Logic ---
 
-log_debug "\n--- dotfiles setup 시작 ---"
+ux_section "dotfiles setup"
 
 # main.bash 파일 존재 여부 확인
 
@@ -281,7 +285,7 @@ CLEANUP_CODE
 # Add auto-cleanup to zshrc
 _add_zshrc_auto_cleanup
 
-log_debug "--- dotfiles setup 완료 ---"
+ux_success "dotfiles setup 완료"
 
 log_dim "변경 사항을 적용하려면 'source ~/.bashrc' 또는 셸을 재시작하십시오."
 

--- a/bash/setup.sh
+++ b/bash/setup.sh
@@ -55,7 +55,7 @@ log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
 # [DEBUG] 접두 출력은 명시적으로 DOTFILES_DEBUG=1 일 때만 노출 (#793 F-3).
 log_debug() {
     [ "${DOTFILES_DEBUG:-0}" = "1" ] || return 0
-    echo -e "${UX_MUTED}[DEBUG] $1${UX_RESET}"
+    printf "%s[DEBUG] %s%s\n" "${UX_MUTED}" "$1" "${UX_RESET}"
 }
 log_warning() { ux_warning "$1"; }
 

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -85,7 +85,12 @@ log_critical() {
     exit 1
 }
 log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
-log_debug() { echo "${UX_MUTED}[DEBUG] $1${UX_RESET}"; }
+# [DEBUG] 접두 출력은 명시적으로 DOTFILES_DEBUG=1 일 때만 노출 (#793 F-3).
+# shellcheck disable=SC2317  # 본 파일은 호출처가 없지만 향후 디버깅 보조용으로 정의 보존
+log_debug() {
+    [ "${DOTFILES_DEBUG:-0}" = "1" ] || return 0
+    echo "${UX_MUTED}[DEBUG] $1${UX_RESET}"
+}
 log_warning() { ux_warning "$1"; }
 
 log_error_and_exit() {
@@ -502,7 +507,7 @@ EOF
 
 # --- Main Script Logic (issue #287, Phase 1: multi-account) ---
 
-log_debug "\n--- Claude Code dotfiles setup 시작 ---"
+ux_section "Claude Code dotfiles setup"
 
 # 필수 dotfiles source 검증
 # settings.json 은 이제 tracked SSOT (#584) — 부트스트랩/템플릿 단계 불필요.
@@ -648,7 +653,7 @@ if [ "$_setup_mode" = "internal" ]; then
     # absent — deprecated (#687) and never a dotfiles symlink (#584).
     # skills/ is a real directory of entry-level symlinks (#707, F-8), so
     # it is checked as `-d` (and `! -L`) rather than `-L`.
-    log_debug "\n--- 심볼릭 링크 확인 (internal/single-account) ---"
+    ux_section "심볼릭 링크 확인 (internal/single-account)"
     for link in statusline-command.sh docs plugins projects/GLOBAL/memory; do
         if [ -L "$HOME/.claude/$link" ]; then
             log_dim "✓ ~/.claude/$link 심볼릭 링크 확인됨"
@@ -664,7 +669,7 @@ if [ "$_setup_mode" = "internal" ]; then
 
     _setup_gemini_skills_symlink
 
-    log_debug "--- Claude Code dotfiles setup 완료 (internal/single-account) ---"
+    ux_success "Claude Code dotfiles setup 완료 (internal/single-account)"
     echo ""
     ux_success "Claude Code 단일 계정 설정 완료 (internal PC mode)"
     ux_info "Config dir: $HOME/.claude"
@@ -703,7 +708,7 @@ done
 # --- Verify Links (모든 활성 계정) ---
 # skills/ is a real directory of entry-level symlinks (#707, F-8), so it
 # is checked as `-d` (and `! -L`) rather than `-L`.
-log_debug "\n--- 심볼릭 링크 확인 ---"
+ux_section "심볼릭 링크 확인"
 for acct in $ENABLED_ACCOUNTS; do
     cdir=$(_claude_resolve_account "$acct")
     for link in settings.json statusline-command.sh docs plugins projects/GLOBAL/memory; do
@@ -724,7 +729,7 @@ done
 _setup_gemini_skills_symlink
 
 # --- Completion Messages ---
-log_debug "--- Claude Code dotfiles setup 완료 ---"
+ux_success "Claude Code dotfiles setup 완료"
 echo ""
 ux_success "Claude Code 다중 계정 설정 완료!"
 ux_info "활성 계정: $(echo "$ENABLED_ACCOUNTS" | tr '\n' ' ')"

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -352,7 +352,7 @@ link_skills_individual_codex() {
 
 # --- Main ---
 
-log_dim "\n--- Skills SSOT 연결 시작 ---"
+ux_section "Skills SSOT 연결"
 
 # SSOT 존재 확인
 if [ ! -d "$SKILLS_SOURCE" ]; then
@@ -414,7 +414,7 @@ fi
 
 # --- Verify ---
 
-log_dim "\n--- Skills SSOT 연결 확인 ---"
+ux_section "Skills SSOT 연결 확인"
 
 verify_link() {
     local tool="$1"
@@ -453,4 +453,4 @@ if [ -n "${CODEX_HOME_LIST:-}" ]; then
 fi
 [ -d "${HOME}/.gemini" ] && verify_link "gemini" "$GEMINI_SKILLS" "dir"
 
-log_dim "--- Skills SSOT 연결 완료 ---\n"
+ux_success "Skills SSOT 연결 완료"

--- a/vscode-extensions/setup.sh
+++ b/vscode-extensions/setup.sh
@@ -46,7 +46,12 @@ log_critical() {
     exit 1
 }
 log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
-log_debug() { echo "${UX_MUTED}[DEBUG] $1${UX_RESET}"; }
+# [DEBUG] 접두 출력은 명시적으로 DOTFILES_DEBUG=1 일 때만 노출 (#793 F-3).
+# shellcheck disable=SC2317  # 본 파일은 호출처가 없지만 향후 디버깅 보조용으로 정의 보존
+log_debug() {
+    [ "${DOTFILES_DEBUG:-0}" = "1" ] || return 0
+    echo "${UX_MUTED}[DEBUG] $1${UX_RESET}"
+}
 log_warning() { ux_warning "$1"; }
 
 log_error_and_exit() {
@@ -87,7 +92,7 @@ create_symlink() {
 
 # --- Main Script Logic ---
 
-log_debug "\n--- VS Code extensions dotfiles setup 시작 ---"
+ux_section "VS Code extensions dotfiles setup"
 
 # .prettierrc 파일 존재 여부 확인
 if [ ! -f "$PRETTIERRC_SOURCE" ]; then
@@ -99,7 +104,7 @@ create_symlink "$PRETTIERRC_SOURCE" "$HOME_PRETTIERRC"
 
 # --- Verify Links ---
 
-log_debug "\n--- 심볼릭 링크 확인 ---"
+ux_section "심볼릭 링크 확인"
 
 if [ -L "$HOME_PRETTIERRC" ]; then
     log_dim "✓ .prettierrc 심볼릭 링크 확인됨"
@@ -109,7 +114,7 @@ fi
 
 # --- Completion Messages ---
 
-log_debug "--- VS Code extensions dotfiles setup 완료 ---"
+ux_success "VS Code extensions dotfiles setup 완료"
 echo ""
 
 ux_success "VS Code extensions 설정이 완료되었습니다!"

--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -59,7 +59,11 @@ log_critical() {
     exit 1
 }
 log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
-log_debug() { echo -e "${UX_MUTED}[DEBUG] $1${UX_RESET}"; }
+# [DEBUG] 접두 출력은 명시적으로 DOTFILES_DEBUG=1 일 때만 노출 (#793 F-3).
+log_debug() {
+    [ "${DOTFILES_DEBUG:-0}" = "1" ] || return 0
+    echo -e "${UX_MUTED}[DEBUG] $1${UX_RESET}"
+}
 log_warning() { ux_warning "$1"; }
 
 # --- Functions ---
@@ -100,7 +104,7 @@ create_symlink() {
 
 # --- Main Script Logic ---
 
-log_debug "\n--- zsh dotfiles setup 시작 ---"
+ux_section "zsh dotfiles setup"
 
 # zshrc 파일 존재 여부 확인
 if [ ! -f "$ZSH_ZSHRC_SOURCE" ]; then
@@ -149,7 +153,7 @@ fi
 
 # --- Completion Messages ---
 
-log_debug "--- zsh dotfiles setup 완료 ---"
+ux_success "zsh dotfiles setup 완료"
 echo ""
 
 ux_success "Zsh 설정이 완료되었습니다!"

--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -62,7 +62,7 @@ log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
 # [DEBUG] 접두 출력은 명시적으로 DOTFILES_DEBUG=1 일 때만 노출 (#793 F-3).
 log_debug() {
     [ "${DOTFILES_DEBUG:-0}" = "1" ] || return 0
-    echo -e "${UX_MUTED}[DEBUG] $1${UX_RESET}"
+    printf "%s[DEBUG] %s%s\n" "${UX_MUTED}" "$1" "${UX_RESET}"
 }
 log_warning() { ux_warning "$1"; }
 


### PR DESCRIPTION
## Summary
- `./setup.sh` 출력에서 `[DEBUG] \n--- 제목 ---` 형태로 escape 가 미해석된 채 출력되던 UX 버그 해소.
- 5개 setup 스크립트의 섹션 헤더 15곳을 `ux_section` / `ux_success` 호출로 통일.
- `log_debug` 정의는 보존하되 출력을 `${DOTFILES_DEBUG:-0}` 가드로 감싸 `[DEBUG]` 접두를 기본 모드에서 노출하지 않음.

## Changes
- **claude/setup.sh** (5 section headers): `log_debug "\n--- ... ---"` → `ux_section "..."`, 완료 라인은 `ux_success "..."` 로 통일. `log_debug()` 정의는 보존 + `DOTFILES_DEBUG=1` 가드 추가 + `# shellcheck disable=SC2317` (호출처가 없어진 정의 보존용).
- **scripts/setup-skills-ssot.sh** (3 section headers): `log_dim "\n--- Skills SSOT ... ---"` → `ux_section "..."` + `ux_success "Skills SSOT 연결 완료"`.
- **zsh/setup.sh** (2 section headers): `log_debug "\n--- zsh dotfiles setup ... ---"` → `ux_section "..."` + `ux_success "..."`. `log_debug()` 가드 추가.
- **bash/setup.sh** (2 section headers): `log_debug "\n--- dotfiles setup ... ---"` → `ux_section "..."` + `ux_success "..."`. `log_debug()` 가드 추가.
- **vscode-extensions/setup.sh** (3 section headers): 동일 패턴 변환 + `log_debug()` 가드 추가 + `# shellcheck disable=SC2317`.

이슈에서 명시한 6 사이트 (`claude/setup.sh:487/649/709`, `scripts/setup-skills-ssot.sh:355/417/456`) 외에 `grep` sweep 으로 `zsh/setup.sh`, `bash/setup.sh`, `vscode-extensions/setup.sh` 의 동일 패턴 9곳도 함께 정리.

## Test plan
- [x] `grep -rn '\\n---' --include='*.sh' .` → setup 스크립트에서 0 hit (regex 정의용 hit 만 잔존, AC F-1).
- [x] `bash -n` syntax check 5/5 통과.
- [x] `shellcheck` — bash/setup.sh (CI scope) 깨끗. 잔존 경고 (SC1071 on zsh, SC2155, SC2088, SC2317 on pre-existing log_error) 모두 PR 이전부터 존재.
- [x] `python3 -m pytest tests/integration/` → 1100 passed.
- [x] 수동 실행 — `ux_section "Claude Code dotfiles setup"` + `ux_success "..."` 가 박스 헤더 + 체크마크로 정상 렌더 (literal `\n` 0 건).
- [x] `DOTFILES_DEBUG=1 log_debug "..."` → `[DEBUG]` 라인 정상 출력. 기본 모드 → 0 출력 (AC F-3 + 회귀 없음).

## Related
Closes #793

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
