### PR TITLE
fix(setup): #792 OpenCode 사용자 knox-id 보존 가드

### DIFF
--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -250,6 +250,15 @@ setup_opencode_config() {
     case "$environment" in
         internal)
             mkdir -p "$(dirname "$opencode_target")"
+            # Preserve user-customised config: once `your-knox-id` has been
+            # replaced with the real Knox ID, never overwrite + never back up
+            # (issue #792). Symlinks are skipped — a leftover external-mode
+            # symlink must still be replaced by the template copy.
+            if [ ! -L "$opencode_target" ] && [ -f "$opencode_target" ] \
+                && ! grep -q 'your-knox-id' "$opencode_target"; then
+                ux_info "Preserved customised OpenCode config: $opencode_target"
+                return 0
+            fi
             _prepare_config_target "$opencode_target"
             cp "${DOTFILES_ROOT}/opencode/opencode.json.internal" "$opencode_target"
             chmod 600 "$opencode_target"
@@ -699,4 +708,10 @@ main() {
     esac
 }
 
-main "$@"
+# Direct-exec guard: only invoke main() when executed directly. When this
+# script is sourced (e.g. by bats tests), `$0` reflects the parent shell
+# instead of `setup.sh`, so the pattern below won't match and main() is
+# skipped — letting tests call individual setup_* functions in isolation.
+case "$0" in
+    *setup.sh) main "$@" ;;
+esac

--- a/shell-common/tools/custom/install_opencode.sh
+++ b/shell-common/tools/custom/install_opencode.sh
@@ -144,9 +144,18 @@ generate_internal_config() {
         return 1
     fi
 
-    # Back up an existing user-edited config (with the user's hand-edited Knox ID)
-    # before overwriting. Use mv for atomicity per repo convention.
-    if [ -f "$config_file" ]; then
+    # Preserve user-customised config: once `your-knox-id` has been replaced
+    # with the real Knox ID, never overwrite + never back up (issue #792).
+    if [ ! -L "$config_file" ] && [ -f "$config_file" ] \
+        && ! grep -q 'your-knox-id' "$config_file"; then
+        ux_info "Preserved customised OpenCode config: $config_file"
+        return 0
+    fi
+
+    # Back up an existing placeholder-state config or stray symlink before
+    # overwriting. The customised-file guard above already returned for the
+    # case we actually need to protect.
+    if [ -f "$config_file" ] || [ -L "$config_file" ]; then
         local backup="${config_file}.backup.$(date +%Y%m%d%H%M%S)"
         mv "$config_file" "$backup"
         ux_info "Backed up existing config: $backup"

--- a/tests/bats/functions/setup_opencode_config.bats
+++ b/tests/bats/functions/setup_opencode_config.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# tests/bats/functions/setup_opencode_config.bats
+# Verify setup_opencode_config preserves user-edited Knox ID across re-runs
+# (issue #792). Three scenarios mirror the issue's acceptance criteria:
+#   1. fresh install (no target)        — cp template, no backup
+#   2. re-run with placeholder unchanged — cp template again (current behavior)
+#   3. re-run with Knox ID customised   — preserve, no backup spam
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+
+    # Build a tiny dotfiles fixture so the function's cp source resolves.
+    FIXTURE_DOTFILES="$TEST_TEMP_HOME/dotfiles"
+    mkdir -p \
+        "$FIXTURE_DOTFILES/opencode" \
+        "$FIXTURE_DOTFILES/shell-common/tools/ux_lib"
+    cp "$_BATS_REAL_DOTFILES_ROOT/opencode/opencode.json.internal" \
+       "$FIXTURE_DOTFILES/opencode/opencode.json.internal"
+    cp "$_BATS_REAL_DOTFILES_ROOT/shell-common/tools/ux_lib/ux_lib.sh" \
+       "$FIXTURE_DOTFILES/shell-common/tools/ux_lib/ux_lib.sh"
+    cp "$_BATS_REAL_DOTFILES_ROOT/shell-common/setup.sh" \
+       "$FIXTURE_DOTFILES/shell-common/setup.sh"
+
+    TARGET="$HOME/.config/opencode/opencode.json"
+    mkdir -p "$(dirname "$TARGET")"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Source setup.sh in a subshell, then invoke setup_opencode_config alone.
+# The direct-exec guard in setup.sh prevents main() from prompting.
+run_setup_opencode() {
+    run bash --noprofile --norc -c "
+        set -e
+        cd '$FIXTURE_DOTFILES/shell-common'
+        . './setup.sh'
+        setup_opencode_config internal
+    "
+}
+
+count_backups() {
+    ls "${TARGET}.backup."* 2>/dev/null | wc -l
+}
+
+@test "fresh install: copies template when target does not exist" {
+    run_setup_opencode
+    assert_success
+    [ -f "$TARGET" ]
+    grep -q 'your-knox-id' "$TARGET"
+    [ "$(count_backups)" -eq 0 ]
+}
+
+@test "re-run with placeholder unchanged: re-copies template" {
+    run_setup_opencode
+    assert_success
+
+    run_setup_opencode
+    assert_success
+    [ -f "$TARGET" ]
+    grep -q 'your-knox-id' "$TARGET"
+}
+
+@test "re-run with Knox ID customised: preserves file, creates no backup" {
+    run_setup_opencode
+    assert_success
+
+    # User replaces the placeholder with a real Knox ID.
+    sed -i 's/your-knox-id/abc123knox/' "$TARGET"
+    customised_content="$(cat "$TARGET")"
+
+    run_setup_opencode
+    assert_success
+    assert_output --partial "Preserved customised OpenCode config"
+
+    # File untouched.
+    [ "$(cat "$TARGET")" = "$customised_content" ]
+    # No backup spam.
+    [ "$(count_backups)" -eq 0 ]
+}
+
+@test "stray external-mode symlink at target: overwritten with template copy" {
+    # Simulate user switching from external (symlink) to internal mode.
+    ln -s "$FIXTURE_DOTFILES/opencode/opencode.json.internal" "$TARGET"
+
+    run_setup_opencode
+    assert_success
+
+    [ -f "$TARGET" ] && [ ! -L "$TARGET" ]
+    grep -q 'your-knox-id' "$TARGET"
+}

--- a/tests/bats/functions/setup_opencode_config.bats
+++ b/tests/bats/functions/setup_opencode_config.bats
@@ -68,8 +68,11 @@ count_backups() {
     run_setup_opencode
     assert_success
 
-    # User replaces the placeholder with a real Knox ID.
-    sed -i 's/your-knox-id/abc123knox/' "$TARGET"
+    # User replaces the placeholder with a real Knox ID. Use a temp-file
+    # rewrite (not `sed -i`) — GNU sed and BSD sed disagree on the `-i`
+    # argument syntax, so the in-place form breaks on macOS dev machines.
+    sed 's/your-knox-id/abc123knox/' "$TARGET" > "${TARGET}.tmp" \
+        && mv "${TARGET}.tmp" "$TARGET"
     customised_content="$(cat "$TARGET")"
 
     run_setup_opencode
@@ -89,6 +92,7 @@ count_backups() {
     run_setup_opencode
     assert_success
 
-    [ -f "$TARGET" ] && [ ! -L "$TARGET" ]
+    [ -f "$TARGET" ]
+    [ ! -L "$TARGET" ]
     grep -q 'your-knox-id' "$TARGET"
 }


### PR DESCRIPTION
## Summary
- `setup.sh` 가 매번 `opencode/opencode.json.internal` 템플릿을 `~/.config/opencode/opencode.json` 으로 덮어쓰면서 사용자가 수동 입력한 `your-knox-id` 까지 placeholder 로 되돌리던 데이터 유실 버그 수정.
- placeholder 가 이미 치환된 상태면 덮어쓰지도 backup 도 만들지 않도록 `setup_opencode_config` + `generate_internal_config` 에 보존 가드 추가 — backup 파일 무한 누적도 함께 해결.
- 4 케이스 bats 회귀 테스트 신설 (fresh install / placeholder 재실행 / customised 보존 / external-mode symlink 잔여물).

## Changes
- `shell-common/setup.sh`: `setup_opencode_config` 의 `internal` 분기 진입부에 `[ ! -L ] && [ -f ] && ! grep -q 'your-knox-id'` 가드 추가. 매치 시 `ux_info "Preserved customised OpenCode config:"` 1줄만 남기고 `return 0`. external 모드에서 남은 잔여 symlink 는 `-L` 가드를 통과해 정상 교체.
- `shell-common/setup.sh`: 파일 끝의 `main "$@"` 를 `case "$0" in *setup.sh)` 기반 direct-exec 가드로 교체. bats 가 setup.sh 를 source 해서 개별 `setup_*` 함수를 단위 테스트할 때 main() menu prompt 가 튀지 않도록.
- `shell-common/tools/custom/install_opencode.sh`: `generate_internal_config` 에 동일 패턴의 보존 가드 추가. 기존 backup 로직은 placeholder/symlink 케이스에 한정.
- `tests/bats/functions/setup_opencode_config.bats` (신규, 4 테스트): 격리된 `$HOME` + fixture dotfiles 트리에서 issue 수용 기준 3건 + symlink 잔여 케이스 1건.

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/setup_opencode_config.bats` — 4/4 통과 확인.
- [x] `sh -n` + `bash -n` 으로 두 .sh 파일 syntax 검증.
- [x] shellcheck — 신규 라인에는 추가 경고 없음 (사전 findings 만 남음).
- [ ] 실 머신에서 internal 모드 setup.sh 재실행 → `your-knox-id` 가 치환된 상태에서 파일/백업 변경 없음 확인.

## Related
Closes #792

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~20 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~20 min
<!-- /ai-metrics:gh-pr -->

</details>
