### PR TITLE
feat(skills): #791 codex/opencode/gemini entry-level 합성 + company-skills overlay 4 CLI 확장

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -11,45 +11,46 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 **`dotfiles/claude/skills/`** 가 Claude Code·Gemini·Codex 3개 도구 모두의 단일 SSOT다.
 
-### 도구별 연결 방식
+### 도구별 연결 방식 (issue #791 — 4 CLI 모두 entry-level 합성으로 통일)
 
 | 도구 | 경로 | 연결 방식 | 신규 스킬 자동 반영 |
 |------|------|-----------|---------------------|
 | **Claude Code** (모든 모드) | `~/.claude*/skills/<name>` → `dotfiles/claude/skills/<name>` | entry-level symlink (#707, F-8) | ❌ setup 재실행 필요 |
-| **Gemini CLI** | `~/.gemini/skills` → `dotfiles/claude/skills` | 디렉토리 symlink | ✅ 즉시 |
-| **Codex** | `~/.codex/skills/<name>` → `dotfiles/claude/skills/<name>/` | 개별 skill symlink | ❌ setup 재실행 필요 |
+| **Codex** | `~/.codex/skills/<name>` → `dotfiles/claude/skills/<name>` | entry-level symlink (#707 → #791) + `.system` 로컬 보존 | ❌ setup 재실행 필요 |
+| **OpenCode** | `~/.config/opencode/skills/<name>` → `dotfiles/claude/skills/<name>` | entry-level symlink (#791) | ❌ setup 재실행 필요 |
+| **Gemini CLI** | `~/.gemini/skills/<name>` → `dotfiles/claude/skills/<name>` | entry-level symlink (#791) | ❌ setup 재실행 필요 |
 
-`~/.claude*/skills/` 는 #575 의 디렉토리-단위 symlink 가 아니라 **실제 디렉토리** 다. 각 child entry 만 `dotfiles/claude/skills/<name>` 로 가는 symlink. 이 형태가 private overlay (`scripts/setup-company-skills.sh`, #707) 를 같은 디렉토리에 추가 entry 로 layer 할 여지를 만든다. SSOT 위치 자체는 변하지 않음.
+`~/.claude*/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/` 는 모두 **실제 디렉토리** 이며 child entry 만 `dotfiles/claude/skills/<name>` 로 가는 symlink. 이 4-way 일관성이 private overlay (`scripts/setup-company-skills.sh`, #707 / #791) 를 모든 CLI 의 같은 디렉토리에 추가 entry 로 layer 할 여지를 만든다. SSOT 위치 자체는 변하지 않음.
 
 ### 관리 스크립트
 
 | 도구 | 담당 스크립트 / 함수 | 트리거 |
 |------|----------------------|--------|
 | Claude Code (각 계정) | `shell-common/tools/integrations/claude.sh` → `_claude_account_setup_one()` + `_claude_compose_skills_dir()` (#707, F-8) | `./claude/setup.sh` |
-| Gemini CLI | `claude/setup.sh` → `_setup_gemini_skills_symlink()` | `./claude/setup.sh` |
+| OpenCode / Gemini | `scripts/setup-skills-ssot.sh` → `link_skills_compose()` (#791) | `./setup.sh` 또는 `./scripts/setup-skills-ssot.sh` |
 | Codex | `scripts/setup-skills-ssot.sh` → `link_skills_individual_codex()` | `./setup.sh` 또는 `./scripts/setup-skills-ssot.sh` |
-| Private overlay (#707) | `scripts/setup-company-skills.sh` | `./setup.sh` (no-op when `$COMPANY_SKILLS_HOME` missing) |
+| Private overlay (#707 / #791) | `scripts/setup-company-skills.sh` — 4 CLI 모두 적용 | `./setup.sh` (no-op when `$COMPANY_SKILLS_HOME` missing) |
 
 ### 신규 스킬 추가 후 동기화
 
 ```bash
-./claude/setup.sh          # Claude Code 계정 + Gemini 동기화
-./scripts/setup-skills-ssot.sh  # Codex 동기화
+./claude/setup.sh                   # Claude Code 계정
+./scripts/setup-skills-ssot.sh      # Codex / OpenCode / Gemini
 # 또는 한번에:
 ./setup.sh
 ```
 
-Claude Code 의 skills/ 는 entry-level symlink 합성으로 (#707, F-8) 새 스킬 디렉토리를 추가했을 때 `./claude/setup.sh` 재실행이 필요하다. 빠진 entry 만 추가하므로 idempotent.
+4 CLI 모두 entry-level symlink 합성이라 (#707, F-8 + #791) 새 스킬 디렉토리를 추가했을 때 위 명령으로 빠진 entry 만 추가된다. Idempotent.
 
-### 연결 방식이 다른 이유
+### 연결 방식이 통일된 이유 (issue #791)
 
-- **Gemini**: 커스텀 전용 디렉토리 → 디렉토리 symlink가 가장 단순
-- **Codex**: `.system/`(내장 5개) 보존 필요 → 개별 symlink로 내장/커스텀 분리
-- **Claude Code**: 옵션 1·2·3 모두 entry-level symlink 합성 (#707, F-8). `_claude_account_setup_one` 이 `_claude_compose_skills_dir` 로 위임해 처리. 이전의 bind-mount (#287) → 디렉토리-단위 symlink (#575) → entry-level 합성 (#707) 의 점진 전환이다. F-8 의 목적은 private overlay 가 같은 디렉토리에 추가 entry 로 들어갈 수 있도록 합성 layer 를 만드는 것.
+- **이전**: Claude/Codex 는 entry-level 합성, OpenCode/Gemini 는 디렉토리-단위 symlink. private overlay 가 Claude/Codex 에만 노출되고 OpenCode/Gemini 에서는 보이지 않는 비대칭.
+- **현재**: 4 CLI 모두 entry-level 합성. private overlay 가 4 곳 전부에 동일하게 layer 됨.
+- **Codex 특수**: `.system/` (내장 skill) 디렉토리는 로컬 보존하므로 `link_skills_individual_codex` 가 따로 존재. OpenCode/Gemini 는 내장 디렉토리가 없으므로 단순한 `link_skills_compose` 로 충분.
 
 ### 절대 하지 말 것
 
-- `~/.claude*/skills/`, `~/.gemini/skills/`, `~/.codex/skills/` 직접 편집 금지
+- `~/.claude*/skills/`, `~/.gemini/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/` 직접 편집 금지
 - 스킬은 반드시 SSOT인 `dotfiles/claude/skills/`에만 생성/수정
 - Codex `.system/` 디렉토리 삭제 금지 (Codex 내장 스킬)
 
@@ -74,9 +75,10 @@ Claude Code 의 skills/ 는 entry-level symlink 합성으로 (#707, F-8) 새 스
 ~/.claude/plugins                        -> ~/.claude-shared/plugins
 ~/.claude/projects/GLOBAL/memory         -> dotfiles/claude/global-memory
 
-# 모든 환경 공통
-~/.gemini/skills                         -> dotfiles/claude/skills          (dir symlink)
-~/.codex/skills/<name>                   -> dotfiles/claude/skills/<name>/  (per-skill)
+# 모든 환경 공통 (issue #791 — 4 CLI 모두 entry-level 합성)
+~/.codex/skills/<name>                   -> dotfiles/claude/skills/<name>   (entry symlink, #707 → #791)
+~/.config/opencode/skills/<name>         -> dotfiles/claude/skills/<name>   (entry symlink, #791)
+~/.gemini/skills/<name>                  -> dotfiles/claude/skills/<name>   (entry symlink, #791)
 ```
 
 기존 PC 에 남아 있는 `/etc/sudoers.d/claude-{skills,docs}-mount-*` 파일은 #575 이후로 사용처가 없다. `claude/setup.sh` 실행 시 잔존 파일이 감지되면 수동 삭제 명령을 안내한다.

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -399,39 +399,16 @@ _check_socat_for_sandbox() {
     fi
 }
 
-# Auto-link ~/.gemini/skills → claude/skills SSOT when Gemini CLI is installed
-# (issue #562). Idempotent — correct symlink → no-op; real directory →
-# timestamped backup + symlink; wrong-target symlink → replace.
-_setup_gemini_skills_symlink() {
-    local gemini_home="${HOME}/.gemini"
-    local target="${gemini_home}/skills"
-
-    [ -d "$gemini_home" ] || return 0
-
-    if [ -L "$target" ]; then
-        local current
-        current="$(readlink -f "$target" 2>/dev/null)"
-        if [ "$current" = "$(readlink -f "$CLAUDE_SKILLS_SOURCE")" ]; then
-            log_dim "✓ ${HOME}/.gemini/skills SSOT symlink 이미 연결됨"
-            return 0
-        fi
-        log_warning "${HOME}/.gemini/skills symlink 대상이 다름 — 교체"
-        rm -f "$target"
-    elif [ -e "$target" ] || [ -L "$target" ]; then
-        local backup
-        backup="${target}-$(date +%Y%m%d%H%M%S)-backup"
-        log_warning "${HOME}/.gemini/skills 기존 항목 백업: $backup"
-        mv "$target" "$backup" || {
-            log_error "${HOME}/.gemini/skills 백업 실패 — skip"
-            return 1
-        }
-    fi
-
-    log_info "${HOME}/.gemini/skills → $CLAUDE_SKILLS_SOURCE symlink 생성"
-    ln -s "$CLAUDE_SKILLS_SOURCE" "$target" \
-        || { log_error "${HOME}/.gemini/skills symlink 생성 실패"; return 1; }
-    log_dim "✓ ${HOME}/.gemini/skills SSOT 연결 완료"
-}
+# NOTE (issue #791): the previous `_setup_gemini_skills_symlink` helper
+# was retired. It created ~/.gemini/skills as a directory symlink to the
+# SSOT — but #791 converged Gemini / OpenCode / Codex onto the same
+# entry-level synthesis layout Claude Code uses (#707, F-8), so
+# `scripts/setup-skills-ssot.sh` (which runs after claude/setup.sh in
+# ./setup.sh) is now the single owner of ~/.gemini/skills and performs
+# both the migration (legacy dir-symlink → real dir) and the entry-level
+# synthesis. Leaving the old helper in place would re-create the legacy
+# dir-symlink one step before setup-skills-ssot.sh tears it back down —
+# correct in the end but noisy and confusing.
 
 # _print_stale_bind_mount_sudoers_hint — surface (and optionally clean
 # up) stale /etc/sudoers.d/ files left over from the pre-#575 bind-mount
@@ -667,7 +644,7 @@ if [ "$_setup_mode" = "internal" ]; then
         log_error_and_exit "$HOME/.claude/skills entry-level 합성 실패 (디렉토리 아님)"
     fi
 
-    _setup_gemini_skills_symlink
+    # Gemini / OpenCode entry-level 합성은 scripts/setup-skills-ssot.sh 가 책임짐 (#791).
 
     ux_success "Claude Code dotfiles setup 완료 (internal/single-account)"
     echo ""
@@ -725,8 +702,9 @@ for acct in $ENABLED_ACCOUNTS; do
     fi
 done
 
-# Gemini CLI 설치 시 ~/.gemini/skills → claude/skills SSOT symlink 설정 (issue #562).
-_setup_gemini_skills_symlink
+# Gemini / OpenCode entry-level 합성은 scripts/setup-skills-ssot.sh 가 책임짐 (#791).
+# 이전엔 본 분기에서 _setup_gemini_skills_symlink 를 호출했지만, #791 에서
+# 4 CLI 모두 entry-level 합성으로 통일했고 SSOT 는 setup-skills-ssot.sh 로 이전됨.
 
 # --- Completion Messages ---
 ux_success "Claude Code dotfiles setup 완료"

--- a/scripts/setup-company-skills.sh
+++ b/scripts/setup-company-skills.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
 # scripts/setup-company-skills.sh: layer a private skills overlay into
-# every active Claude Code config dir.
+# every entry-level skills directory the dotfiles tree manages.
 #
 # PURPOSE: take entries from a user-supplied private skills repo
 #   ($COMPANY_SKILLS_HOME, default /home/bwyoon/para/project/company-skills)
-#   and add them as entry-level symlinks inside ~/.claude*/skills/, which
-#   claude/setup.sh has just materialised as real directories of
-#   entry-level symlinks (issue #707, F-8).
+#   and add them as entry-level symlinks inside every entry-level skills
+#   directory dotfiles owns. After issue #791 this is all four CLI homes:
+#     - ~/.claude*/skills/       (Claude Code, #707, F-8)
+#     - ~/.codex/skills/         (Codex, #707)
+#     - ~/.config/opencode/skills/ (OpenCode, #791)
+#     - ~/.gemini/skills/        (Gemini, #791)
+#   claude/setup.sh + scripts/setup-skills-ssot.sh have just materialised
+#   these targets as real directories of entry-level symlinks.
 #
-# WHEN TO RUN: via ./setup.sh, after claude/setup.sh. Safe to run on
-#   hosts that do not have a private skills repo — when the source
-#   directory is missing the script prints one info line and exits 0.
+# WHEN TO RUN: via ./setup.sh, after claude/setup.sh and
+#   scripts/setup-skills-ssot.sh. Safe to run on hosts that do not have a
+#   private skills repo — when the source directory is missing the script
+#   prints one info line and exits 0.
 #
 # DESIGN NOTES (issue #707):
 #   - The dotfiles tree must never carry private skill content. The
@@ -50,12 +56,20 @@ log_dim() { echo "${UX_DIM}$1${UX_RESET}"; }
 
 # --- Functions ---
 
-# Emit one absolute path per ~/.claude*/skills/ directory that already
-# exists as a real (non-symlink) directory. claude/setup.sh has just
-# converted these from the legacy directory-symlink layout (#575) to the
-# entry-composition layout (#707, F-8). If we can't find any real-dir
-# targets, this is either a fresh install where setup.sh has not run
-# yet or a host where the user opted out — either way, no-op.
+# Emit one absolute path per entry-level skills directory the dotfiles
+# tree owns AND that already exists as a real (non-symlink) directory.
+# claude/setup.sh + scripts/setup-skills-ssot.sh have just materialised
+# these from the legacy directory-symlink layout (#575) to the
+# entry-composition layout (Claude Code: #707, F-8 — Codex / OpenCode /
+# Gemini: #791). If we can't find any real-dir targets, this is either a
+# fresh install where setup.sh has not run yet or a host where the user
+# opted out — either way, no-op.
+#
+# The `! -L` guard is also the safety net that keeps the overlay from
+# being applied to a target whose migration to entry-composition has not
+# happened yet (e.g. an older Gemini/OpenCode layout still on the
+# directory-symlink form). The overlay simply skips those targets until
+# the migration runs.
 _enumerate_target_skills_dirs() {
     # Single-account internal-PC layout.
     if [ -d "${HOME}/.claude/skills" ] && [ ! -L "${HOME}/.claude/skills" ]; then
@@ -63,6 +77,17 @@ _enumerate_target_skills_dirs() {
     fi
     # Multi-account layouts (#287 / #571). Globs may not match — guard.
     for _esd in "${HOME}/.claude-"*/skills; do
+        [ -d "$_esd" ] || continue
+        [ -L "$_esd" ] && continue
+        printf '%s\n' "$_esd"
+    done
+    # Codex / OpenCode / Gemini — entry-level 합성 (#791). 각각 별도
+    # CLI 가 설치돼 있을 때만 dotfiles 가 그 skills 디렉토리를 합성으로
+    # 만든다. dir-symlink (마이그레이션 전) 는 `-L` 가드로 건너뛴다.
+    for _esd in \
+        "${HOME}/.codex/skills" \
+        "${HOME}/.config/opencode/skills" \
+        "${HOME}/.gemini/skills"; do
         [ -d "$_esd" ] || continue
         [ -L "$_esd" ] && continue
         printf '%s\n' "$_esd"

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -5,12 +5,11 @@
 # PURPOSE: claude/skills/를 SSOT로 삼아 OpenCode·Codex·Gemini에 연결
 # WHEN TO RUN: Via ./setup.sh (do NOT run manually)
 #
-# 연결 전략:
-#   - 전체 디렉토리 symlink: tools skills dir가 없거나 빈 경우
-#     ~/.config/opencode/skills/ → ~/dotfiles/claude/skills/
-#     ~/.gemini/skills/          → ~/dotfiles/claude/skills/
-#   - Codex 전용 개별 연결: skill 디렉토리는 실제 폴더로 만들고
-#     .system 디렉토리는 로컬 보존, 나머지 custom skill 디렉토리는 symlink
+# 연결 전략 (issue #791 — 4 CLI 모두 entry-level 합성):
+#   - entry-level 합성 디렉토리 (4 CLI 공통, #707 / #791):
+#     ~/.config/opencode/skills/<skill>     → ~/dotfiles/claude/skills/<skill>
+#     ~/.gemini/skills/<skill>              → ~/dotfiles/claude/skills/<skill>
+#   - Codex 전용 합성: .system 디렉토리는 로컬 보존
 #     ~/.codex/skills/.system                          ← local (codex managed)
 #     ~/.codex/skills/<custom-skill>                   → ~/dotfiles/claude/skills/<custom-skill>
 #
@@ -20,7 +19,13 @@
 #     발생하는 것을 막는 용도. 한 줄에 하나의 skill 디렉토리 이름, '#' 으로 시작하는
 #     주석과 빈 줄은 무시됨. 파일이 없거나 모두 비어 있으면 종전대로 전체 연결.
 #
-# ~/.claude*/skills 는 claude/setup.sh 가 디렉토리 symlink 로 관리 (#575)
+#   - 마이그레이션 (#791): 기존 opencode/gemini 의 디렉토리-단위 symlink 는
+#     entry-level 합성으로 변환된다. 사용자가 직접 만든 symlink (target 이
+#     SSOT 가 아닌 경우) 는 보존 + warn.
+#
+# ~/.claude*/skills 는 claude/setup.sh 가 entry-level 합성 디렉토리로 관리 (#707, F-8).
+# 4 CLI 모두 동일 layout 이므로 setup-company-skills.sh 의 private overlay 도
+# 4 곳 전부에 적용된다.
 
 # --- Constants ---
 
@@ -116,31 +121,100 @@ collect_codex_homes() {
     done
 }
 
-# 전체 디렉토리를 SSOT로 symlink
-# Usage: link_skills_dir <tool_name> <target_path>
-link_skills_dir() {
+# Entry-level 합성 + 레거시 dir-symlink 마이그레이션 (issue #791).
+# OpenCode / Gemini 가 #707 의 Claude Code entry-composition layout 과
+# 동일하게 동작하도록 한다. 호출 후 <target_dir> 은 실제 디렉토리이며 그
+# child entry 들이 SSOT 의 각 skill 으로 가는 symlink. private overlay
+# (setup-company-skills.sh) 가 이후 같은 디렉토리에 추가 entry 를 layer.
+#
+# 마이그레이션 정책:
+#   - target 이 SSOT 로 향하는 dir-symlink → 해제 후 합성으로 전환.
+#   - target 이 사용자 symlink (다른 위치) → 보존 + warn (skip, 무손실).
+#   - target 이 일반 파일 → 보존 + warn (사용자 데이터 가능성, skip).
+#   - target 이 일반 디렉토리 → 합성 시도 (기존 entry 보존).
+# Usage: link_skills_compose <tool_name> <target_dir>
+link_skills_compose() {
     local tool="$1"
     local target="$2"
+    local source_root
+    source_root="$(readlink -f "$SKILLS_SOURCE")"
 
-    # 이미 SSOT를 가리키는 symlink면 skip
+    # 1. Migrate legacy directory-symlink → real directory.
     if [ -L "$target" ]; then
         local current_target
         current_target="$(readlink -f "$target" 2>/dev/null)"
-        if [ "$current_target" = "$(readlink -f "$SKILLS_SOURCE")" ]; then
-            log_dim "✓ [$tool] skills symlink 이미 연결됨: $target"
+        if [ "$current_target" = "$source_root" ]; then
+            log_info "[$tool] legacy dir-symlink 감지 — entry-level 합성으로 마이그레이션"
+            rm -f "$target"
+        else
+            log_warning "[$tool] 사용자 symlink 감지 — 합성 마이그레이션 건너뜀: $target"
             return 0
         fi
-        log_dim "[$tool] 기존 symlink 교체: $target"
-        rm "$target"
-    elif [ -d "$target" ]; then
-        # 디렉토리가 존재하면 백업 후 제거
-        local backup="${target}-$(date +%Y%m%d%H%M%S)-backup"
-        log_warning "[$tool] 기존 디렉토리 백업: $target -> $backup"
-        mv "$target" "$backup"
+    elif [ -e "$target" ] && [ ! -d "$target" ]; then
+        log_warning "[$tool] 비-디렉토리 항목 감지 — 합성 마이그레이션 건너뜀: $target"
+        return 0
     fi
 
-    log_info "[$tool] skills symlink 생성: $target -> $SKILLS_SOURCE"
-    ln -s "$SKILLS_SOURCE" "$target" || log_critical "[$tool] symlink 생성 실패: $target"
+    mkdir -p "$target" || log_critical "[$tool] target 디렉토리 생성 실패: $target"
+
+    local linked=0 refreshed=0 skipped=0 pruned=0
+    local skill_path skill_name link_target source_realpath current_link existing_target_path
+
+    for skill_path in "$SKILLS_SOURCE"/*/; do
+        [ -d "$skill_path" ] || continue
+        skill_name="$(basename "$skill_path")"
+        link_target="${target}/${skill_name}"
+        source_realpath="$(readlink -f "$skill_path")"
+
+        if [ -L "$link_target" ]; then
+            current_link="$(readlink "$link_target")"
+            if [ "$current_link" = "$skill_path" ] \
+                || [ "$(readlink -f "$link_target" 2>/dev/null)" = "$source_realpath" ]; then
+                continue
+            fi
+            case "$current_link" in
+                "$SKILLS_SOURCE"/*)
+                    rm -f "$link_target"
+                    refreshed=$((refreshed + 1))
+                    ;;
+                *)
+                    log_dim "[$tool] 사용자 symlink 보존: $link_target"
+                    skipped=$((skipped + 1))
+                    continue
+                    ;;
+            esac
+        elif [ -e "$link_target" ]; then
+            log_dim "[$tool] 비-symlink 엔트리 보존: $link_target"
+            skipped=$((skipped + 1))
+            continue
+        else
+            linked=$((linked + 1))
+        fi
+
+        ln -s "$skill_path" "$link_target" || {
+            log_error "[$tool] skill symlink 생성 실패: $link_target"
+            continue
+        }
+    done
+
+    # Stale cleanup: SSOT 로 향하던 symlink 의 원본이 사라진 경우만 정리.
+    # SSOT 밖을 가리키는 entry (private overlay 등) 는 보존.
+    local existing
+    for existing in "$target"/*; do
+        [ -L "$existing" ] || continue
+        existing_target_path="$(readlink "$existing")"
+        case "$existing_target_path" in
+            "$SKILLS_SOURCE"/*)
+                if [ ! -d "$existing_target_path" ]; then
+                    log_info "[$tool] stale entry 정리: $existing"
+                    rm -f "$existing"
+                    pruned=$((pruned + 1))
+                fi
+                ;;
+        esac
+    done
+
+    log_info "[$tool] skill 합성 완료: ${linked}개 신규, ${refreshed}개 갱신, ${skipped}개 보존, ${pruned}개 정리"
 }
 
 # 개별 skill을 SSOT에서 symlink (기존 디렉토리 보존)
@@ -359,12 +433,12 @@ if [ ! -d "$SKILLS_SOURCE" ]; then
     log_critical "SSOT 디렉토리가 없습니다: $SKILLS_SOURCE"
 fi
 
-# 1. OpenCode: 전체 디렉토리 symlink
+# 1. OpenCode: entry-level 합성 (issue #791 — 4 CLI 공통 layout)
 OPENCODE_SKILLS="${HOME}/.config/opencode/skills"
 if [ ! -d "${HOME}/.config/opencode" ]; then
     log_warning "OpenCode 설정 디렉토리가 없습니다. 건너뜁니다: ${HOME}/.config/opencode"
 else
-    link_skills_dir "opencode" "$OPENCODE_SKILLS"
+    link_skills_compose "opencode" "$OPENCODE_SKILLS"
 fi
 
 # 2. Codex: .system 보존 + custom skill 디렉토리 symlink (선택적 allowlist 적용)
@@ -404,12 +478,12 @@ else
     done <<< "$CODEX_HOME_LIST"
 fi
 
-# 3. Gemini: 전체 디렉토리 symlink
+# 3. Gemini: entry-level 합성 (issue #791 — 4 CLI 공통 layout)
 GEMINI_SKILLS="${HOME}/.gemini/skills"
 if [ ! -d "${HOME}/.gemini" ]; then
     log_warning "Gemini 설정 디렉토리가 없습니다. 건너뜁니다: ${HOME}/.gemini"
 else
-    link_skills_dir "gemini" "$GEMINI_SKILLS"
+    link_skills_compose "gemini" "$GEMINI_SKILLS"
 fi
 
 # --- Verify ---
@@ -419,18 +493,17 @@ ux_section "Skills SSOT 연결 확인"
 verify_link() {
     local tool="$1"
     local path="$2"
-    local mode="$3"   # "dir" or "individual" or "codex"
+    local mode="$3"   # "compose" or "codex"
 
-    if [ "$mode" = "dir" ]; then
-        if [ -L "$path" ]; then
-            log_dim "✓ [$tool] $path -> $(readlink "$path")"
-        else
-            log_warning "[$tool] symlink 확인 실패: $path"
-        fi
-    elif [ "$mode" = "individual" ]; then
+    if [ "$mode" = "compose" ]; then
+        # Entry-level 합성: 실제 디렉토리 + child symlink 카운트.
         local count
-        count=$(find "$path" -maxdepth 1 -type l 2>/dev/null | wc -l)
-        log_dim "✓ [$tool] $path (개별 symlink: ${count}개)"
+        if [ -d "$path" ] && [ ! -L "$path" ]; then
+            count=$(find "$path" -mindepth 1 -maxdepth 1 -type l 2>/dev/null | wc -l)
+            log_dim "✓ [$tool] $path (entry symlink: ${count}개)"
+        else
+            log_warning "[$tool] entry-level 합성 디렉토리 확인 실패: $path"
+        fi
     else
         local link_count
         local system_state
@@ -444,13 +517,13 @@ verify_link() {
     fi
 }
 
-[ -d "${HOME}/.config/opencode" ] && verify_link "opencode" "$OPENCODE_SKILLS" "dir"
+[ -d "${HOME}/.config/opencode" ] && verify_link "opencode" "$OPENCODE_SKILLS" "compose"
 if [ -n "${CODEX_HOME_LIST:-}" ]; then
     while IFS= read -r codex_home; do
         [ -n "$codex_home" ] || continue
         verify_link "codex" "${codex_home}/skills" "codex"
     done <<< "$CODEX_HOME_LIST"
 fi
-[ -d "${HOME}/.gemini" ] && verify_link "gemini" "$GEMINI_SKILLS" "dir"
+[ -d "${HOME}/.gemini" ] && verify_link "gemini" "$GEMINI_SKILLS" "compose"
 
 ux_success "Skills SSOT 연결 완료"

--- a/tests/bats/functions/setup_company_skills.bats
+++ b/tests/bats/functions/setup_company_skills.bats
@@ -165,3 +165,98 @@ run_overlay() {
     [ "$(readlink "$SKILLS_DIR/root-skill")" = "$HOME/company-skills/root-skill" ]
     [ ! -e "$SKILLS_DIR/plugins" ]
 }
+
+# ---------------------------------------------------------------------
+# issue #791 — 4 CLI 합성 디렉토리 매트릭스
+# Claude / Codex / OpenCode / Gemini 모두 entry-level 합성 디렉토리이면
+# private overlay 가 4 곳 전부에 동일하게 적용돼야 한다.
+# ---------------------------------------------------------------------
+
+@test "links overlay into ~/.codex/skills when present (#791)" {
+    CODEX_DIR="$HOME/.codex/skills"
+    mkdir -p "$CODEX_DIR" "$HOME/company-skills/foo"
+    : > "$HOME/company-skills/foo/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+
+    [ -L "$CODEX_DIR/foo" ]
+    [ "$(readlink "$CODEX_DIR/foo")" = "$HOME/company-skills/foo" ]
+}
+
+@test "links overlay into ~/.config/opencode/skills when present (#791)" {
+    OC_DIR="$HOME/.config/opencode/skills"
+    mkdir -p "$OC_DIR" "$HOME/company-skills/bar"
+    : > "$HOME/company-skills/bar/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+
+    [ -L "$OC_DIR/bar" ]
+    [ "$(readlink "$OC_DIR/bar")" = "$HOME/company-skills/bar" ]
+}
+
+@test "links overlay into ~/.gemini/skills when present (#791)" {
+    G_DIR="$HOME/.gemini/skills"
+    mkdir -p "$G_DIR" "$HOME/company-skills/baz"
+    : > "$HOME/company-skills/baz/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+
+    [ -L "$G_DIR/baz" ]
+    [ "$(readlink "$G_DIR/baz")" = "$HOME/company-skills/baz" ]
+}
+
+@test "skips ~/.gemini/skills when it is still a legacy directory-symlink (#791)" {
+    # Pre-migration layout: ~/.gemini/skills is a dir-symlink. The
+    # overlay must skip it (-L guard) so setup-skills-ssot.sh has a
+    # chance to migrate first. After migration the next overlay run
+    # will pick it up — verified separately by the entry-level test.
+    mkdir -p "$HOME/.gemini" "$HOME/some-dotfiles-tree/claude/skills"
+    ln -s "$HOME/some-dotfiles-tree/claude/skills" "$HOME/.gemini/skills"
+    # Sanity: the link must really exist before the run.
+    [ -L "$HOME/.gemini/skills" ]
+
+    # No claude target either, so the script should exit informing the
+    # user that no target was found.
+    mkdir -p "$HOME/company-skills/foo"
+    : > "$HOME/company-skills/foo/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+    # The dir-symlink itself must NOT be touched.
+    [ -L "$HOME/.gemini/skills" ]
+    # No entry symlink under it (since the script skipped it). The
+    # dir-symlink would happily resolve `foo` against the target dir,
+    # so check the entry via the symlink path NOT through it.
+    [ ! -L "$HOME/.gemini/skills/foo" ]
+}
+
+@test "applies overlay to all 4 CLI targets simultaneously (#791)" {
+    mkdir -p \
+        "$SKILLS_DIR" \
+        "$HOME/.codex/skills" \
+        "$HOME/.config/opencode/skills" \
+        "$HOME/.gemini/skills" \
+        "$HOME/company-skills/quad"
+    : > "$HOME/company-skills/quad/SKILL.md"
+
+    run_overlay "$HOME/company-skills"
+    assert_success
+
+    for tgt in \
+        "$SKILLS_DIR/quad" \
+        "$HOME/.codex/skills/quad" \
+        "$HOME/.config/opencode/skills/quad" \
+        "$HOME/.gemini/skills/quad"; do
+        [ -L "$tgt" ] || {
+            echo "missing overlay entry: $tgt" >&2
+            false
+        }
+        [ "$(readlink "$tgt")" = "$HOME/company-skills/quad" ] || {
+            echo "wrong readlink: $tgt -> $(readlink "$tgt")" >&2
+            false
+        }
+    done
+}

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -39,6 +39,17 @@ EOF
     export FIXTURE_DOTFILES FIXTURE_HOME
 }
 
+# Provision the opencode + gemini config dirs so the script's CLI-presence
+# guards (`[ -d ~/.config/opencode ]` / `[ -d ~/.gemini ]`) light up. Each
+# test that exercises the entry-level synthesis calls this helper to set
+# the initial layout (real-dir, dir-symlink, or absent skills/ subdir).
+seed_opencode_home() {
+    mkdir -p "${FIXTURE_HOME}/.config/opencode"
+}
+seed_gemini_home() {
+    mkdir -p "${FIXTURE_HOME}/.gemini"
+}
+
 teardown() {
     teardown_isolated_home
 }
@@ -128,4 +139,145 @@ EOF
     [ "$status" -eq 1 ]
     assert_output --partial "exceed budget"
     assert_output --partial ".codex-allowlist"
+}
+
+# ---------------------------------------------------------------------
+# issue #791 — OpenCode / Gemini entry-level 합성
+# 이전 디렉토리-단위 symlink 를 entry-level 합성 디렉토리로 변환.
+# ---------------------------------------------------------------------
+
+@test "opencode: fresh install creates entry-level synthesis directory (#791)" {
+    seed_opencode_home
+
+    run_setup
+    assert_success
+
+    local oc_dir="${FIXTURE_HOME}/.config/opencode/skills"
+    [ -d "$oc_dir" ] && [ ! -L "$oc_dir" ]
+    for s in alpha beta gamma; do
+        [ -L "${oc_dir}/${s}" ]
+        [ "$(readlink -f "${oc_dir}/${s}")" = "$(readlink -f "${FIXTURE_DOTFILES}/claude/skills/${s}")" ]
+    done
+}
+
+@test "gemini: fresh install creates entry-level synthesis directory (#791)" {
+    seed_gemini_home
+
+    run_setup
+    assert_success
+
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    [ -d "$g_dir" ] && [ ! -L "$g_dir" ]
+    for s in alpha beta gamma; do
+        [ -L "${g_dir}/${s}" ]
+        [ "$(readlink -f "${g_dir}/${s}")" = "$(readlink -f "${FIXTURE_DOTFILES}/claude/skills/${s}")" ]
+    done
+}
+
+@test "opencode: legacy dir-symlink migrates to entry-level synthesis (#791)" {
+    seed_opencode_home
+    # Pre-state: legacy directory symlink → SSOT.
+    ln -s "${FIXTURE_DOTFILES}/claude/skills" \
+        "${FIXTURE_HOME}/.config/opencode/skills"
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills" ]
+
+    run_setup
+    assert_success
+    assert_output --partial "[opencode] legacy dir-symlink"
+
+    local oc_dir="${FIXTURE_HOME}/.config/opencode/skills"
+    [ ! -L "$oc_dir" ]
+    [ -d "$oc_dir" ]
+    for s in alpha beta gamma; do
+        [ -L "${oc_dir}/${s}" ]
+    done
+}
+
+@test "gemini: legacy dir-symlink migrates to entry-level synthesis (#791)" {
+    seed_gemini_home
+    ln -s "${FIXTURE_DOTFILES}/claude/skills" "${FIXTURE_HOME}/.gemini/skills"
+    [ -L "${FIXTURE_HOME}/.gemini/skills" ]
+
+    run_setup
+    assert_success
+    assert_output --partial "[gemini] legacy dir-symlink"
+
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    [ ! -L "$g_dir" ]
+    [ -d "$g_dir" ]
+    for s in alpha beta gamma; do
+        [ -L "${g_dir}/${s}" ]
+    done
+}
+
+@test "opencode: synthesis is idempotent on re-run (#791)" {
+    seed_opencode_home
+
+    run_setup
+    assert_success
+    local before
+    before="$(ls -la "${FIXTURE_HOME}/.config/opencode/skills")"
+
+    run_setup
+    assert_success
+    local after
+    after="$(ls -la "${FIXTURE_HOME}/.config/opencode/skills")"
+
+    [ "$before" = "$after" ]
+}
+
+@test "gemini: user symlink to non-SSOT location is preserved + warned (#791)" {
+    seed_gemini_home
+    # User-managed symlink pointing somewhere other than the SSOT.
+    mkdir -p "${TEST_TEMP_HOME}/elsewhere/skills"
+    ln -s "${TEST_TEMP_HOME}/elsewhere/skills" "${FIXTURE_HOME}/.gemini/skills"
+
+    run_setup
+    assert_success
+    assert_output --partial "[gemini] 사용자 symlink"
+
+    # The user's symlink must NOT have been clobbered.
+    [ -L "${FIXTURE_HOME}/.gemini/skills" ]
+    [ "$(readlink "${FIXTURE_HOME}/.gemini/skills")" = "${TEST_TEMP_HOME}/elsewhere/skills" ]
+}
+
+@test "opencode: stale entry whose source vanished gets pruned (#791)" {
+    seed_opencode_home
+
+    run_setup
+    assert_success
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/beta" ]
+
+    # Remove `beta` from the SSOT, then re-run. The stale entry under
+    # opencode must be cleaned up.
+    rm -rf "${FIXTURE_DOTFILES}/claude/skills/beta"
+
+    run_setup
+    assert_success
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/beta" ]
+    # Other skills still present.
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/alpha" ]
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/gamma" ]
+}
+
+@test "opencode: private overlay entry (outside SSOT) survives pruning (#791)" {
+    seed_opencode_home
+
+    run_setup
+    assert_success
+
+    # Simulate a private overlay entry that lives outside the SSOT.
+    mkdir -p "${TEST_TEMP_HOME}/company-skills/private-one"
+    : > "${TEST_TEMP_HOME}/company-skills/private-one/SKILL.md"
+    ln -s "${TEST_TEMP_HOME}/company-skills/private-one" \
+        "${FIXTURE_HOME}/.config/opencode/skills/private-one"
+
+    run_setup
+    assert_success
+
+    # The overlay link survives — pruning only touches SSOT-pointing
+    # symlinks whose source vanished.
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/private-one" ]
+    [ "$(readlink "${FIXTURE_HOME}/.config/opencode/skills/private-one")" \
+        = "${TEST_TEMP_HOME}/company-skills/private-one" ]
 }


### PR DESCRIPTION
## Summary
- `#707` 의 entry-level 합성 (Claude Code 전용) 을 codex / opencode / gemini 까지 확장해 4 CLI 모두에서 동일한 skills layout 을 제공한다.
- `scripts/setup-company-skills.sh` 의 private overlay 가 이전엔 Claude Code 에만 노출되던 비대칭을 해소 — 이제 4 CLI 모두에 동일하게 layer 된다.
- 마이그레이션은 idempotent: 기존 디렉토리-단위 symlink → entry-level 합성 디렉토리 변환 + stale cleanup + 사용자 직접 symlink 보존.

## Changes
- `scripts/setup-skills-ssot.sh`
  - 새 헬퍼 `link_skills_compose()` 추가 — legacy dir-symlink 감지 → 합성으로 마이그레이션 + 매 skill entry symlink 생성 + SSOT 로 향하던 stale link 정리.
  - opencode / gemini 가 `link_skills_dir`(전체 디렉토리 symlink) 대신 새 헬퍼로 합성된다.
  - 사용자 symlink (target 이 SSOT 가 아닌 경우) 는 보존 + warn — 무손실 마이그레이션.
  - `verify_link` 의 `dir` 모드를 `compose` 모드로 교체 (entry symlink 개수 표시).
- `scripts/setup-company-skills.sh`
  - `_enumerate_target_skills_dirs()` 가 `~/.codex/skills`, `~/.config/opencode/skills`, `~/.gemini/skills` 도 emit (실제 디렉토리일 때만).
  - 마이그레이션 전 (dir-symlink) 상태는 `-L` 가드로 안전 skip — setup-skills-ssot.sh 가 먼저 합성으로 변환된 후 다음 overlay 실행에서 자동 포함된다.
- `claude/setup.sh`
  - `_setup_gemini_skills_symlink()` 함수 + 두 호출 사이트 제거. setup-skills-ssot.sh 가 4 CLI 모두의 SSOT 가 됐으므로 본 분기의 dir-symlink 생성은 churn (생성 → 곧바로 마이그레이션 → entry-level 합성).
- `claude/AGENTS.md`
  - "도구별 연결 방식" 테이블을 4 CLI entry-level 매트릭스로 업데이트.
  - "관리 스크립트" 테이블 갱신 — opencode/gemini 는 setup-skills-ssot.sh → `link_skills_compose()`, codex 는 기존대로 `link_skills_individual_codex()`.
  - "Configuration Files" 섹션 4 CLI 모두 `(entry symlink)` 표기.

## Test plan
- [x] `setup_skills_ssot.bats` — opencode/gemini fresh install / legacy dir-symlink migration / idempotent / 사용자 symlink 보존 / stale prune / private overlay 보존 (+8 tests)
- [x] `setup_company_skills.bats` — codex / opencode / gemini 단일 타겟 overlay + legacy dir-symlink skip + 4 CLI 동시 적용 매트릭스 (+5 tests)
- [x] 전체 bats 1121/1122 통과 (1 fail = 기존 `check_codex_skills_budget` whitespace, main 에도 동일하게 빨강)
- [x] 전체 pytest 1077/1079 통과 (2 fail = 기존 `test_skill_completion_guard.py`, main 에도 동일)
- [x] 신규 추가 14/14 통과
- [x] `mise run lint` 통과 (ruff / mypy / shellcheck / shfmt all clean)
- [ ] (수동) 한 PC 에서 `./setup.sh` 실행 후 4 CLI 모두 `~/.<cli>/skills` 가 entry-level 합성 디렉토리인지 확인
- [ ] (수동) private overlay 설치된 PC 에서 4 CLI 모두에 overlay entry 노출 확인

## Related
Closes #791

---
<details>
<summary>🤖 AI Metrics · 📊 ~9000 tokens · 👤 ~8 h · 🤖 ~29 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~8 h · 🤖 ~29 min
<!-- /ai-metrics:gh-pr -->

</details>
