### PR TITLE
feat(docker-help): #779 intent-based 발견성 — i-want / --map 신규 진입점

### DIFF
--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -95,7 +95,9 @@ _docker_help_rows_intent() {
     ux_table_row "list all" "dpsa" "docker ps -a"
     ux_table_row "disk usage" "ddf" "docker system df"
     ux_table_row "clean dangling" "dprune" "docker system prune -f"
-    ux_info "Hint: 'docker-help here' inspects the current directory for compose files (#777)."
+    # 'docker-help here' is owned by #777 — keep the issue ref in code only,
+    # not in the user-facing hint (gemini-code-assist review on PR #803).
+    ux_info "Hint: 'docker-help here' inspects the current directory for compose files."
 }
 
 _docker_help_rows_map() {

--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -14,6 +14,8 @@ _docker_help_summary() {
     ux_bullet_sub "basics: dps | dpsa | di | dstats | dstop | drm | drmi | dlogs | dinspect"
     ux_bullet_sub "resources: ddf | dprune | dprune_full | dvols | dvol_rm | dnetwork_prune | dbuild_prune"
     ux_bullet_sub "utilities: dbash | denv | dinspect_env | dstopall | drmall | dexport | dinstall | dproxy_setup"
+    ux_bullet_sub "i-want: goal-based lookup  (example: docker-help i-want)"
+    ux_bullet_sub "--map: intent -> alias -> raw command table"
     ux_bullet_sub "details: docker-help <section>  (example: docker-help compose)"
 }
 
@@ -24,6 +26,8 @@ _docker_help_list_sections() {
     ux_bullet_sub "basics"
     ux_bullet_sub "resources"
     ux_bullet_sub "utilities"
+    ux_bullet_sub "i-want"
+    ux_bullet_sub "map"
 }
 
 _docker_help_rows_compose() {
@@ -78,6 +82,27 @@ _docker_help_rows_utilities() {
     ux_info "Note: 'docker compose' (V2) is used by default."
 }
 
+_docker_help_rows_intent() {
+    ux_table_row "start a stack" "dcud" "docker compose up -d"
+    ux_table_row "start with overlay" "(raw)" "docker compose -f a.yml -f b.yml up -d --build"
+    ux_table_row "stop a stack" "dcd" "docker compose down"
+    ux_table_row "wipe data too" "dcdv" "docker compose down -v"
+    ux_table_row "rebuild a service" "dcb <svc>" "docker compose build <svc>"
+    ux_table_row "restart a service" "dcr <svc>" "docker compose restart <svc>"
+    ux_table_row "follow logs" "dcl <svc>" "docker compose logs -f <svc>"
+    ux_table_row "shell into container" "dbash <name>" "docker exec -it <name> bash"
+    ux_table_row "list running" "dps" "docker ps"
+    ux_table_row "list all" "dpsa" "docker ps -a"
+    ux_table_row "disk usage" "ddf" "docker system df"
+    ux_table_row "clean dangling" "dprune" "docker system prune -f"
+    ux_info "Hint: 'docker-help here' inspects the current directory for compose files (#777)."
+}
+
+_docker_help_rows_map() {
+    ux_table_header "Intent" "Alias" "Raw command"
+    _docker_help_rows_intent
+}
+
 _docker_help_render_section() {
     ux_section "$1"
     "$2"
@@ -100,6 +125,12 @@ _docker_help_section_rows() {
         utilities|util|utils)
             _docker_help_rows_utilities
             ;;
+        i-want|iwant|intent|want|goals|goal)
+            _docker_help_rows_intent
+            ;;
+        map)
+            _docker_help_rows_map
+            ;;
         *)
             ux_error "Unknown docker-help section: $1"
             ux_info "Try: docker-help --list"
@@ -116,6 +147,7 @@ _docker_help_full() {
     _docker_help_render_section "Docker Basics" _docker_help_rows_basics
     _docker_help_render_section "Resource Management" _docker_help_rows_resources
     _docker_help_render_section "Utilities" _docker_help_rows_utilities
+    _docker_help_render_section "Intent -> Alias -> Raw" _docker_help_rows_map
 }
 
 # --- docker_help recommend (#777) ---
@@ -252,6 +284,9 @@ docker_help() {
             ;;
         --all|all)
             _docker_help_full
+            ;;
+        --map)
+            _docker_help_rows_map
             ;;
         *)
             _docker_help_section_rows "$1"

--- a/tests/integration/test_docker_help_intent.py
+++ b/tests/integration/test_docker_help_intent.py
@@ -44,9 +44,7 @@ class TestDockerHelpIntent:
         result = shell_runner(shell, "docker_help i-want")
         assert result.exit_code == 0
         plain = _plain(result.stdout)
-        assert "-f" in plain and "overlay" in plain.lower(), (
-            f"{shell}: overlay guidance missing from i-want output"
-        )
+        assert "-f" in plain and "overlay" in plain.lower(), f"{shell}: overlay guidance missing from i-want output"
 
 
 class TestDockerHelpMap:

--- a/tests/integration/test_docker_help_intent.py
+++ b/tests/integration/test_docker_help_intent.py
@@ -1,0 +1,94 @@
+"""
+Tests for docker-help intent-based extensions (#779).
+
+Two additive entry points on top of #777's PWD-aware `here` recommender
+(which is separately covered by tests/bats/functions/docker_help_recommend.bats):
+
+  - docker-help i-want   goal-based lookup (intent -> alias -> raw)
+  - docker-help --map    intent -> alias -> raw command table
+"""
+
+import re
+
+import pytest
+
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
+
+
+class TestDockerHelpIntent:
+    """`docker-help i-want` exposes intent -> alias -> raw command rows."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("alias_arg", ["i-want", "iwant", "intent", "want"])
+    def test_intent_aliases_exit_clean(self, shell_runner, shell, alias_arg):
+        result = shell_runner(shell, f"docker_help {alias_arg}")
+        assert result.exit_code == 0, f"{shell}: 'docker_help {alias_arg}' failed: {result.stderr}"
+        assert result.stdout.strip(), f"{shell}: 'docker_help {alias_arg}' empty output"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_intent_contains_alias_and_raw_command(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help i-want")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "dcud" in plain
+        assert "docker compose up -d" in plain
+        assert "dcd" in plain
+        assert "docker compose down" in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_intent_includes_overlay_pattern(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help i-want")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "-f" in plain and "overlay" in plain.lower(), (
+            f"{shell}: overlay guidance missing from i-want output"
+        )
+
+
+class TestDockerHelpMap:
+    """`docker-help --map` is the explicit three-column header view."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_map_flag_runs(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help --map")
+        assert result.exit_code == 0, f"{shell}: stderr={result.stderr}"
+        plain = _plain(result.stdout)
+        assert "Intent" in plain
+        assert "Alias" in plain
+        assert "Raw command" in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_map_section_keyword_runs(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help map")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "dcud" in plain
+        assert "docker compose up -d" in plain
+
+
+class TestDockerHelpSummaryDiscoverability:
+    """Default summary must mention the new entry points so they are findable.
+
+    `--help` is used as the discriminator instead of bare `docker_help`,
+    because #777 made bare `docker_help` switch to PWD-aware recommendation
+    when a compose file is present in CWD. `--help` always renders the
+    canonical summary.
+    """
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_summary_mentions_i_want(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help --help")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "i-want" in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_summary_mentions_map(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help --help")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "--map" in plain


### PR DESCRIPTION
## Summary
- `docker-help` 가 카테고리 나열만 노출하던 발견성 문제(#779)에 대응해, 이미 #777 로 머지된 PWD 컨텍스트 인지형 `here` 위에 추가 진입점 2 개를 얹어 사용자가 **명령어 이름을 모르는 상태에서도** 의도 → 명령 으로 도달할 수 있게 한다.
- 기본 summary (≤ 15 라인 cap) 와 `[section|--list|--all]` 표준 템플릿을 그대로 보존해 기존 compact-policy 테스트가 변경 없이 통과한다.
- `here` 디스패치는 #777 소유 영역으로 두고, 신규 `i-want` hint 줄에서 `docker-help here (#777)` 를 명시적으로 안내해 두 기능을 연결한다.

## Changes
- `shell-common/functions/devops_help.sh`
  - `_docker_help_summary` / `_docker_help_list_sections` 에 `i-want`, `--map` 두 항목 추가 (Usage 라인은 표준 템플릿 유지).
  - `_docker_help_rows_intent` 신설 — 12 행 `intent → alias → raw command` 매핑 (start / start-with-overlay / stop / wipe-data / rebuild / restart / follow-logs / exec / ps / df / prune).
  - `_docker_help_rows_map` 신설 — `Intent / Alias / Raw command` 3 컬럼 헤더 + intent 행 재사용.
  - `_docker_help_section_rows` 에 `i-want | iwant | intent | want | goals | goal`, `map` 케이스 추가.
  - `_docker_help_full` 에 `Intent -> Alias -> Raw` 섹션 1 줄 추가.
  - `docker_help` 디스패처에 `--map` 분기 추가 (`here` 분기는 #777 코드 그대로 보존).
- `tests/integration/test_docker_help_intent.py` 신설 (bash + zsh, 20 케이스)
  - `i-want` 4 alias 클린 종료 + 컨텐츠 어설션 (`dcud` / `docker compose up -d` / `dcd` / `docker compose down`) + overlay 가이드.
  - `--map` / `map` 키워드 + 헤더 검증.
  - 요약 발견성 — `docker_help --help` 출력이 `i-want`, `--map` 를 언급하는지.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 python -m pytest tests/integration/test_docker_help_intent.py` → 20 passed
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 python -m pytest tests/integration/test_help_topics.py tests/integration/test_help_compact_policy.py -k docker_help` → 16 passed (기존 회귀 0)
- [x] 인터랙티브 스모크: bash + zsh 양쪽에서 `docker-help i-want`, `docker-help --map`, `docker-help map`, `docker-help --help`, `docker-help --all` 출력 확인.
- [ ] CI: `mise run lint` + `mise run test` 전체 통과 확인.
- [ ] `#777` 의 `docker-help here` 동작 유지 — 같은 worktree 에서 compose 파일 0/1/N 개 케이스 출력이 main 동작과 동일한지 직접 확인.

## Related
Closes #779

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~145 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~145 min
<!-- /ai-metrics:gh-pr -->

</details>
