### PR TITLE
fix(gh_project_status): #804 GH_HOST 미설정 시 _gh_resolve_host SSOT 로 자동 라우팅 — GHE 보드 sync 누락 해소

### DIFF
--- a/claude/hooks/post-gh-pr-create.sh
+++ b/claude/hooks/post-gh-pr-create.sh
@@ -60,7 +60,15 @@ output=$(printf '%s' "$input" |
 # shellcheck disable=SC1091
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_host.sh" 2>/dev/null
 if command -v _gh_resolve_host >/dev/null 2>&1; then
-    _gh_host_regex=$(_gh_resolve_host | sed 's#\.#\\.#g')
+    _gh_host=$(_gh_resolve_host)
+    _gh_host_regex=$(printf '%s' "$_gh_host" | sed 's#\.#\\.#g')
+    # Export GH_HOST so the later `gh repo view` and `_gh_project_status_sync`
+    # calls route to the same host (issue #804). The helper now self-heals
+    # too, but exporting here keeps the hook correct on a stale install and
+    # is defense-in-depth. Skip when already set (explicit caller override).
+    : "${GH_HOST:=$_gh_host}"
+    export GH_HOST
+    unset _gh_host
 else
     _gh_host_regex='(github\.com|github\.samsungds\.net)'
 fi

--- a/claude/hooks/post-gh-pr-create.sh
+++ b/claude/hooks/post-gh-pr-create.sh
@@ -60,15 +60,21 @@ output=$(printf '%s' "$input" |
 # shellcheck disable=SC1091
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_host.sh" 2>/dev/null
 if command -v _gh_resolve_host >/dev/null 2>&1; then
-    _gh_host=$(_gh_resolve_host)
-    _gh_host_regex=$(printf '%s' "$_gh_host" | sed 's#\.#\\.#g')
+    _gh_resolved=$(_gh_resolve_host)
+    # Build the URL-match regex from the host `gh` will actually use: when
+    # the caller exported GH_HOST, `gh pr create` emits a URL on that host,
+    # so the regex must honor the override. Matching the resolved default
+    # instead would miss the URL and silently drop the sync. Native bash
+    # parameter expansion escapes the dots (no printf|sed subshell).
+    _gh_host="${GH_HOST:-$_gh_resolved}"
+    _gh_host_regex="${_gh_host//./\\.}"
     # Export GH_HOST so the later `gh repo view` and `_gh_project_status_sync`
     # calls route to the same host (issue #804). The helper now self-heals
     # too, but exporting here keeps the hook correct on a stale install and
-    # is defense-in-depth. Skip when already set (explicit caller override).
-    : "${GH_HOST:=$_gh_host}"
+    # is defense-in-depth. Default to the resolved host only when unset.
+    : "${GH_HOST:=$_gh_resolved}"
     export GH_HOST
-    unset _gh_host
+    unset _gh_resolved _gh_host
 else
     _gh_host_regex='(github\.com|github\.samsungds\.net)'
 fi

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -58,6 +58,24 @@
 # before defining `_gh_project_status_sync`, breaking the workflow with
 # `command not found` (exit 127). See PR #497 / CI run 25601743398.
 
+# Ensure GH_HOST is set before any `gh` call so requests route to the
+# correct host. On the internal PC (GHE = github.samsungds.net) a caller
+# that does not export GH_HOST would otherwise let `gh` default to
+# github.com, silently failing every ProjectV2 lookup and skipping the
+# board sync (issue #804). We source the gh_host.sh SSOT and resolve the
+# host via `_gh_resolve_host`, which maps `_dotfiles_setup_mode` to the
+# right domain. A caller that already exported GH_HOST (an explicit host
+# override) is left untouched -> regression-zero for github.com users.
+_gh_project_status_ensure_host() {
+    [ -n "${GH_HOST-}" ] && return 0
+    # shellcheck disable=SC1091
+    . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_host.sh" 2>/dev/null || return 0
+    if command -v _gh_resolve_host >/dev/null 2>&1; then
+        GH_HOST=$(_gh_resolve_host)
+        export GH_HOST
+    fi
+}
+
 _gh_project_status_sync() {
     local _kind="$1" _num="$2" _target="$3"
     [ "$#" -ge 3 ] && shift 3
@@ -88,6 +106,10 @@ _gh_project_status_sync() {
     if [ -z "$_kind" ] || [ -z "$_num" ] || [ -z "$_target" ]; then
         return 0
     fi
+
+    # Route every downstream `gh` call (repo view, pr view, graphql) to the
+    # correct host before the first one fires (issue #804).
+    _gh_project_status_ensure_host
 
     local _q_field
     case "$_kind" in
@@ -292,6 +314,10 @@ _gh_project_status_query_current() {
     local _kind="$1" _num="$2"
     [ -z "$_kind" ] && return 0
     [ -z "$_num" ] && return 0
+
+    # Public entry point (gh-pr-merge Step 2-B gate) — also route to the
+    # correct host when invoked directly without GH_HOST (issue #804).
+    _gh_project_status_ensure_host
 
     local _q_field
     case "$_kind" in

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -67,7 +67,13 @@
 # right domain. A caller that already exported GH_HOST (an explicit host
 # override) is left untouched -> regression-zero for github.com users.
 _gh_project_status_ensure_host() {
-    [ -n "${GH_HOST-}" ] && return 0
+    # Already set: still export it. A caller may have assigned GH_HOST as a
+    # plain (non-exported) shell variable, in which case downstream `gh`
+    # subprocesses would not inherit it without this export.
+    if [ -n "${GH_HOST-}" ]; then
+        export GH_HOST
+        return 0
+    fi
     # shellcheck disable=SC1091
     . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_host.sh" 2>/dev/null || return 0
     if command -v _gh_resolve_host >/dev/null 2>&1; then

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -108,6 +108,48 @@ _run_closing_issues_bash() {
 }
 
 # ---------------------------------------------------------------------------
+# Host routing (issue #804): _gh_project_status_ensure_host
+#
+# Callers that don't export GH_HOST must still reach the right host. On the
+# internal PC (GHE) the helper resolves GH_HOST via _gh_resolve_host so the
+# ProjectV2 graphql calls don't silent-fall-back to github.com. An explicit
+# GH_HOST from the caller must never be overwritten (regression-zero).
+# ---------------------------------------------------------------------------
+
+@test "bash: _gh_project_status_ensure_host helper exists" {
+    run_in_bash 'declare -f _gh_project_status_ensure_host >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: _gh_project_status_ensure_host helper exists" {
+    run_in_zsh 'typeset -f _gh_project_status_ensure_host >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "host: GH_HOST unset + internal mode -> resolves to GHE host" {
+    echo "internal" > "$HOME/.dotfiles-setup-mode"
+    run_in_bash 'unset GH_HOST; _gh_project_status_ensure_host; echo "GH_HOST=$GH_HOST"'
+    assert_success
+    assert_output --partial "GH_HOST=github.samsungds.net"
+}
+
+@test "host: GH_HOST unset + external mode -> resolves to github.com" {
+    echo "external" > "$HOME/.dotfiles-setup-mode"
+    run_in_bash 'unset GH_HOST; _gh_project_status_ensure_host; echo "GH_HOST=$GH_HOST"'
+    assert_success
+    assert_output --partial "GH_HOST=github.com"
+}
+
+@test "host: explicit GH_HOST is preserved (no overwrite)" {
+    echo "internal" > "$HOME/.dotfiles-setup-mode"
+    run_in_bash 'GH_HOST=github.example.com; _gh_project_status_ensure_host; echo "GH_HOST=$GH_HOST"'
+    assert_success
+    assert_output --partial "GH_HOST=github.example.com"
+}
+
+# ---------------------------------------------------------------------------
 # Opt-out guards
 # ---------------------------------------------------------------------------
 

--- a/tests/bats/skills/post_gh_pr_create_hook.bats
+++ b/tests/bats/skills/post_gh_pr_create_hook.bats
@@ -157,3 +157,29 @@ EOF
         bash -c "printf '%s' '{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh pr create\"},\"tool_response\":{\"output\":\"https://github.samsungds.net/byoungwoo-yoon/dotfiles/pull/8\"}}' | '$HOOK'"
     grep -q '^sync pr 8 In review$' "$CALL_LOG"
 }
+
+@test "T13 (#804): explicit GH_HOST override → regex honors it, PR URL still matched" {
+    # PR #805 gemini-code-assist (HIGH): when the caller exports GH_HOST,
+    # `gh pr create` emits a URL on THAT host. The regex must be built from
+    # the override, not the resolved default — otherwise pr_num is empty and
+    # the hook silently exits. We point _dotfiles_setup_mode at `external`
+    # (resolves to github.com) but export GH_HOST=github.example.com and feed
+    # a URL on github.example.com; the sync must still fire.
+    HYBRID_SHELL_COMMON="$TEST_TEMP_HOME/hybrid-override"
+    mkdir -p "$HYBRID_SHELL_COMMON/functions"
+    cp "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh" \
+        "$HYBRID_SHELL_COMMON/functions/gh_host.sh"
+    cat > "$HYBRID_SHELL_COMMON/functions/_setup_mode_stub.sh" <<'EOF'
+_dotfiles_setup_mode() { echo "external"; }
+EOF
+    cat > "$HYBRID_SHELL_COMMON/functions/gh_project_status.sh" <<EOF
+_gh_project_status_sync() { printf 'sync %s\n' "\$*" >> "$CALL_LOG"; return 0; }
+_gh_pr_closing_issue_numbers() { return 0; }
+EOF
+    BASH_ENV="$HYBRID_SHELL_COMMON/functions/_setup_mode_stub.sh" \
+    DOTFILES_FORCE_INIT=1 \
+    GH_HOST="github.example.com" \
+    SHELL_COMMON="$HYBRID_SHELL_COMMON" \
+        bash -c "printf '%s' '{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh pr create\"},\"tool_response\":{\"output\":\"https://github.example.com/owner/repo/pull/42\"}}' | '$HOOK'"
+    grep -q '^sync pr 42 In review$' "$CALL_LOG"
+}


### PR DESCRIPTION
## 요약

내부 PC(GHE = `github.samsungds.net`)에서 호출자가 `GH_HOST` 를 export 하지 않으면 `_gh_project_status_sync` 의 `gh api graphql` 호출이 default host(`github.com`)로 나가 ProjectV2 카드를 찾지 못하고 silent-fail → 보드 sync 가 누락되는 문제를 해소한다. (#804)

## 변경 사항

- **`shell-common/functions/gh_project_status.sh`**
  - `_gh_project_status_ensure_host` 헬퍼 신규. `GH_HOST` 미설정 시 `gh_host.sh` 를 source 해 `_gh_resolve_host` (`_dotfiles_setup_mode` SSOT) 로 host 를 해석/export.
  - 명시적으로 `GH_HOST` 를 export 한 호출자는 건드리지 않음 → github.com 사용자 **회귀 zero**.
  - 두 public 진입점 `_gh_project_status_sync`, `_gh_project_status_query_current` 에 모두 연결 (write/read path 모두 커버).
- **`claude/hooks/post-gh-pr-create.sh`**
  - 이미 `_gh_resolve_host` 로 host regex 를 만들던 지점에서 `GH_HOST` 도 export. helper 패치가 자동 처리하지만 stale install 대비 defense-in-depth.
- **`tests/bats/functions/gh_project_status.bats`**
  - 회귀 테스트 5건: helper 존재(bash/zsh), `internal`→GHE, `external`→github.com, 명시 `GH_HOST` 보존.

## 검증

- 신규 bats 5건 통과.
- `tests/bats/functions` + `tests/bats/skills` 전체 914건 통과 (exit 0).
- 변경 shell 파일 shellcheck clean.

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~1 h · 🤖 ~21 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~1 h · 🤖 ~21 min
<!-- /ai-metrics:gh-pr -->

</details>

Closes #804
