### PR TITLE
feat(setup): #806 home backup 누적 방지 latest-only 정책 + clean-home 명령

### DIFF
--- a/bash/setup.sh
+++ b/bash/setup.sh
@@ -44,6 +44,15 @@ HOME_BASH_PROFILE="${HOME}/.bash_profile"
 # Load UX library (unified library at shell-common/tools/ux_lib/)
 source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
 
+# Latest-only backup policy (issue #806). SSOT for the fixed suffixes.
+# Fallback defaults guard against a missing helper so the suffix is never
+# empty (an empty suffix would overwrite the live target).
+if [ -f "${SHELL_COMMON}/functions/dotfiles_backup.sh" ]; then
+    source "${SHELL_COMMON}/functions/dotfiles_backup.sh"
+fi
+: "${DOTFILES_BACKUP_SUFFIX:=.backup}"
+: "${DOTFILES_ORIGINAL_SUFFIX:=.original}"
+
 # Define legacy mapping functions for backward compatibility
 log_info() { ux_info "$1"; }
 log_error() { ux_error "$1"; }
@@ -94,7 +103,7 @@ create_symlink() {
 
         log_warning "경고: $link_name 가 심볼릭 링크가 아닌 일반 파일입니다. 백업 후 제거합니다."
 
-        backup_file "$link_name" "${link_name}-$(date +%Y%m%d%H%M%S)-original"
+        backup_file "$link_name" "${link_name}${DOTFILES_ORIGINAL_SUFFIX}"
 
         rm "$link_name" || log_error_and_exit "기존 파일 제거 실패: $link_name"
 
@@ -159,7 +168,7 @@ if [ -f "$WORK_LOG_SRC" ]; then
         fi
     elif [ -f "$WORK_LOG_LINK" ]; then
         # Regular file exists, backup and create symlink
-        backup_file="${WORK_LOG_LINK}.backup.$(date +%s)"
+        backup_file="${WORK_LOG_LINK}${DOTFILES_BACKUP_SUFFIX}"
         log_error "경고: ~/work_log.txt가 일반 파일입니다"
         log_dim "백업: $backup_file로 이동"
         mv "$WORK_LOG_LINK" "$backup_file"
@@ -197,9 +206,10 @@ _cleanup_broken_zsh_plugins() {
         return 0
     fi
 
-    # Create backup
+    # Create backup (latest-only fixed suffix — issue #806; no timestamp so
+    # repeated runs overwrite a single backup instead of accumulating).
     local backup_file
-    backup_file="${zshrc}.backup.$(date +%s)"
+    backup_file="${zshrc}${DOTFILES_BACKUP_SUFFIX}"
     cp "$zshrc" "$backup_file" || return 1
 
     log_debug "정리: ~/.zshrc에서 설치되지 않은 플러그인 제거: $broken_plugins"
@@ -218,6 +228,8 @@ _cleanup_broken_zsh_plugins() {
     if grep -q "plugins=(" "$temp_zshrc" 2>/dev/null; then
         mv "$temp_zshrc" "$zshrc"
         rm -f "${zshrc}.bak" 2>/dev/null
+        # Cleanup succeeded — drop the safety backup so it does not linger.
+        rm -f "$backup_file" 2>/dev/null
         log_dim "✓ ~/.zshrc에서 미설치 플러그인 제거 완료"
         log_dim "  이제 zsh 시작 시 'plugin not found' 에러가 나타나지 않습니다"
     else
@@ -231,59 +243,12 @@ _cleanup_broken_zsh_plugins() {
 # Run cleanup if zshrc exists
 _cleanup_broken_zsh_plugins
 
-# Add auto-cleanup code to ~/.zshrc (if not already there)
-_add_zshrc_auto_cleanup() {
-    local zshrc="${HOME}/.zshrc"
-    local marker="# DOTFILES AUTO-CLEANUP: Remove broken plugin references"
-
-    if [ ! -f "$zshrc" ]; then
-        return 0
-    fi
-
-    # Check if auto-cleanup code is already added
-    if grep -q "$marker" "$zshrc" 2>/dev/null; then
-        return 0
-    fi
-
-    # Add auto-cleanup code at the beginning of ~/.zshrc
-    # This runs every time zsh starts to ensure no broken plugins
-    if cat >"${zshrc}.cleanup_insert" <<'CLEANUP_CODE'; then
-
-# ═══════════════════════════════════════════════════════════════
-# DOTFILES AUTO-CLEANUP: Remove broken plugin references
-# ═══════════════════════════════════════════════════════════════
-# This code runs automatically when zsh starts to ensure no
-# "plugin not found" errors occur. Plugins are only loaded if
-# they are actually installed in ~/.oh-my-zsh/custom/plugins/
-
-_dotfiles_auto_cleanup_plugins() {
-    local omz_custom="${ZSH_CUSTOM:-${HOME}/.oh-my-zsh/custom}"
-    local modified=0
-
-    # Check for broken plugin references in plugins array
-    for plugin_name in zsh-autosuggestions zsh-syntax-highlighting zsh-history-substring-search; do
-        if [[ "$plugins" == *"$plugin_name"* ]] && [ ! -d "$omz_custom/plugins/$plugin_name" ]; then
-            # Remove broken plugin reference
-            plugins=("${(@)plugins[@]//$plugin_name}")
-            modified=1
-        fi
-    done
-}
-
-_dotfiles_auto_cleanup_plugins
-unfunction _dotfiles_auto_cleanup_plugins 2>/dev/null || true
-
-CLEANUP_CODE
-        # Prepend cleanup code to zshrc
-        cat "${zshrc}.cleanup_insert" "$zshrc" >"${zshrc}.new"
-        mv "${zshrc}.new" "$zshrc"
-        rm -f "${zshrc}.cleanup_insert"
-        log_debug "✓ ~/.zshrc에 자동 정리 코드 추가됨 (매번 zsh 시작 시 자동 실행)"
-    fi
-}
-
-# Add auto-cleanup to zshrc
-_add_zshrc_auto_cleanup
+# NOTE (issue #806): the former `_add_zshrc_auto_cleanup` runtime hook was
+# removed. It prepended cleanup code via `cat ... > .new && mv .new ~/.zshrc`,
+# which converted the dotfiles-managed ~/.zshrc symlink into a regular file.
+# The next ./setup.sh run then re-backed-up and re-linked it, accumulating one
+# backup per run. The hook was redundant anyway — `_cleanup_broken_zsh_plugins`
+# above already strips missing-plugin references at build time.
 
 ux_success "dotfiles setup 완료"
 

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -581,7 +581,10 @@ _single_account_ensure_link() {
         rmdir "$tgt" 2>/dev/null || true
     elif [ -e "$tgt" ]; then
         local backup
-        backup="${tgt}.backup.$(date +%Y%m%d%H%M%S)"
+        # Latest-only fixed suffix (issue #806) — overwrite one backup instead
+        # of accumulating. SSOT: shell-common/functions/dotfiles_backup.sh
+        backup="${tgt}.backup"
+        rm -rf "$backup"
         mv "$tgt" "$backup" || {
             log_error "backup failed: $tgt → $backup"
             return 1

--- a/gh/setup.sh
+++ b/gh/setup.sh
@@ -31,8 +31,10 @@ mkdir -p "$GH_CONFIG_DIR"
 if [ -L "$GH_CONFIG_TARGET" ]; then
     rm "$GH_CONFIG_TARGET"
 elif [ -f "$GH_CONFIG_TARGET" ]; then
-    BACKUP_DATE=$(date +%Y%m%d%H%M%S)
-    BACKUP_PATH="${GH_CONFIG_TARGET}-${BACKUP_DATE}-original"
+    # Latest-only fixed suffix (issue #806) — overwrite one backup instead of
+    # accumulating. SSOT: shell-common/functions/dotfiles_backup.sh
+    BACKUP_PATH="${GH_CONFIG_TARGET}.original"
+    rm -f "$BACKUP_PATH"
     ux_warning "기존 config.yml 백업: ${BACKUP_PATH}"
     mv "$GH_CONFIG_TARGET" "$BACKUP_PATH"
 fi

--- a/git/setup.sh
+++ b/git/setup.sh
@@ -70,7 +70,9 @@ create_symlink() {
         rm "$link_name" || log_error_and_exit "기존 심볼릭 링크 제거 실패: $link_name"
     elif [ -f "$link_name" ]; then
         ux_warning "경고: $link_name 가 심볼릭 링크가 아닌 일반 파일입니다. 백업 후 제거합니다."
-        backup_file "$link_name" "${link_name}-$(date +%Y%m%d%H%M%S)-original"
+        # Latest-only fixed suffix (issue #806) — repeated runs overwrite one
+        # backup instead of accumulating. SSOT: shell-common/functions/dotfiles_backup.sh
+        backup_file "$link_name" "${link_name}.original"
         rm "$link_name" || log_error_and_exit "기존 파일 제거 실패: $link_name"
     fi
 

--- a/shell-common/functions/dotfiles_backup.sh
+++ b/shell-common/functions/dotfiles_backup.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# shell-common/functions/dotfiles_backup.sh
+# Latest-only backup policy (issue #806).
+#
+# Every ./setup.sh run used to stamp backups with a timestamp
+# (`.backup.<ts>`, `-<ts>-original`). When a dotfiles symlink got
+# converted back into a regular file, each subsequent run produced a brand
+# new backup — accumulating dozens of files in the home directory.
+#
+# These helpers use a FIXED suffix instead, so each new backup OVERWRITES
+# the previous one. At most one backup file per target survives. This is
+# the SSOT for the suffix strings and the backup primitives — setup scripts
+# source this file and reference DOTFILES_BACKUP_SUFFIX / DOTFILES_ORIGINAL_SUFFIX.
+#
+# NOTE: This file only DEFINES functions/constants and produces no output at
+# source time, so it deliberately omits the interactive guard (mirrors
+# dotfiles_root.sh, gh_host.sh, …). That lets non-interactive setup scripts
+# source it and still get the definitions, while the interactive loader can
+# auto-source it harmlessly.
+
+# Fixed suffixes (SSOT). Only set if not already defined so a caller may
+# override before sourcing.
+: "${DOTFILES_BACKUP_SUFFIX:=.backup}"
+: "${DOTFILES_ORIGINAL_SUFFIX:=.original}"
+
+# Echo the fixed backup path for a target (no side effects).
+# Usage: dotfiles_backup_path <target> [suffix]
+dotfiles_backup_path() {
+    _dbp_target="$1"
+    _dbp_suffix="${2:-$DOTFILES_BACKUP_SUFFIX}"
+    printf '%s%s\n' "$_dbp_target" "$_dbp_suffix"
+}
+
+# Copy <target> to its fixed backup path, overwriting any prior backup.
+# No-op (returns 0) when <target> does not exist.
+# Echoes the backup path on success; returns non-zero on copy failure.
+# Usage: dotfiles_backup_copy <target> [suffix]
+dotfiles_backup_copy() {
+    _dbc_target="$1"
+    _dbc_suffix="${2:-$DOTFILES_BACKUP_SUFFIX}"
+    [ -e "$_dbc_target" ] || return 0
+    # Assignment RHS does not word-split, so outer quotes are unneeded here.
+    _dbc_dest=$(dotfiles_backup_path "$_dbc_target" "$_dbc_suffix")
+    cp -f "$_dbc_target" "$_dbc_dest" || return 1
+    printf '%s\n' "$_dbc_dest"
+}
+
+# Move <target> to its fixed backup path, overwriting any prior backup.
+# No-op (returns 0) when <target> does not exist.
+# Echoes the backup path on success; returns non-zero on move failure.
+# Usage: dotfiles_backup_move <target> [suffix]
+dotfiles_backup_move() {
+    _dbm_target="$1"
+    _dbm_suffix="${2:-$DOTFILES_BACKUP_SUFFIX}"
+    [ -e "$_dbm_target" ] || return 0
+    _dbm_dest=$(dotfiles_backup_path "$_dbm_target" "$_dbm_suffix")
+    rm -rf "$_dbm_dest" 2>/dev/null || true
+    mv "$_dbm_target" "$_dbm_dest" || return 1
+    printf '%s\n' "$_dbm_dest"
+}

--- a/shell-common/functions/dotfiles_backup.sh
+++ b/shell-common/functions/dotfiles_backup.sh
@@ -41,7 +41,14 @@ dotfiles_backup_copy() {
     [ -e "$_dbc_target" ] || return 0
     # Assignment RHS does not word-split, so outer quotes are unneeded here.
     _dbc_dest=$(dotfiles_backup_path "$_dbc_target" "$_dbc_suffix")
-    cp -f "$_dbc_target" "$_dbc_dest" || return 1
+    if [ -d "$_dbc_target" ]; then
+        # Clear any prior backup first so the recursive copy does not nest
+        # the source inside an existing destination directory.
+        rm -rf "$_dbc_dest"
+        cp -Rf "$_dbc_target" "$_dbc_dest" || return 1
+    else
+        cp -f "$_dbc_target" "$_dbc_dest" || return 1
+    fi
     printf '%s\n' "$_dbc_dest"
 }
 

--- a/shell-common/functions/file_cleanup.sh
+++ b/shell-common/functions/file_cleanup.sh
@@ -19,6 +19,45 @@ _cleanup_set_default_patterns() {
     )
 }
 
+# Home-directory whitelist (issue #806). Narrower than the generic defaults
+# so `clean-home` only targets the known dotfiles backup-accumulation
+# patterns plus the post-migration fixed-suffix files.
+_cleanup_set_home_patterns() {
+    CLEANUP_HOME_PATTERNS=(
+        '.zshrc.original'
+        '.zshrc-*-original'
+        '.zshrc.backup'
+        '.zshrc.backup.*'
+        '.npmrc.backup'
+        '.npmrc.backup.*'
+        '.npmrc.bak.*'
+        '*.backup'
+        '*.backup.*'
+        '*-original'
+    )
+}
+
+# In home mode, offer to remove the legacy ~/dotfiles-backup/ directory.
+# Interactive (confirm); a decline or a missing directory is a no-op.
+_cleanup_offer_dotfiles_backup_dir() {
+    local home_dir="$1"
+    local backup_dir="${home_dir}/dotfiles-backup"
+
+    [ -d "$backup_dir" ] || return 0
+
+    ux_section "dotfiles-backup/ Directory"
+    ux_bullet "$backup_dir"
+    if ux_confirm "Remove the entire ${backup_dir} directory?" "n"; then
+        if rm -rf -- "$backup_dir"; then
+            ux_success "Removed: $backup_dir"
+        else
+            ux_error "Failed to remove: $backup_dir"
+        fi
+    else
+        ux_info "Skipped: $backup_dir"
+    fi
+}
+
 _cleanup_collect_matches() {
     local search_dir="$1"
     shift
@@ -183,22 +222,28 @@ _cleanup_select_mode() {
 
 _del_file_help() {
     ux_header "del-file"
-    ux_usage "del-file" "[pattern...]" "Interactively delete backup/original files in the current directory"
-    ux_section "Default patterns"
+    ux_usage "del-file" "[--home] [pattern...]" "Interactively delete backup/original files"
+    ux_section "Default patterns (current directory)"
     ux_bullet ".*backup*"
     ux_bullet ".*.bak*"
     ux_bullet ".*-original"
+    ux_section "--home  (alias: clean-home)"
+    ux_bullet "Targets \$HOME with a dotfiles backup whitelist (.backup / -original / .bak)"
+    ux_bullet "Also offers to remove the legacy ~/dotfiles-backup/ directory"
     ux_section "Examples"
-    ux_bullet "del-file                # use defaults"
+    ux_bullet "del-file                # current dir, use defaults"
     ux_bullet "del-file '*.tmp'        # extend with one extra pattern"
+    ux_bullet "clean-home              # clean accumulated ~/ backups (issue #806)"
     ux_info "Next: del-file (interactive — preview, then choose 1/2/0)"
 }
 
 del_file() {
     [ -n "${ZSH_VERSION:-}" ] && emulate -L sh
 
+    local home_mode=0
     case "${1:-}" in
         -h|--help|help) _del_file_help; return 0 ;;
+        --home) home_mode=1; shift ;;
     esac
 
     if [ ! -t 0 ] || [ ! -t 1 ]; then
@@ -206,24 +251,42 @@ del_file() {
         return 1
     fi
 
-    local search_dir="${PWD}"
+    local search_dir=""
     local patterns=()
     local extra_pattern=""
     local default_pattern=""
     local selection=""
 
-    _cleanup_set_default_patterns
-    for default_pattern in "${CLEANUP_DEFAULT_PATTERNS[@]}"; do
-        [ -n "$default_pattern" ] || continue
-        patterns+=("$default_pattern")
-    done
+    if [ "$home_mode" -eq 1 ]; then
+        search_dir="${HOME}"
+        _cleanup_set_home_patterns
+        for default_pattern in "${CLEANUP_HOME_PATTERNS[@]}"; do
+            [ -n "$default_pattern" ] || continue
+            patterns+=("$default_pattern")
+        done
+    else
+        search_dir="${PWD}"
+        _cleanup_set_default_patterns
+        for default_pattern in "${CLEANUP_DEFAULT_PATTERNS[@]}"; do
+            [ -n "$default_pattern" ] || continue
+            patterns+=("$default_pattern")
+        done
+    fi
 
     for extra_pattern in "$@"; do
         [ -n "$extra_pattern" ] || continue
         patterns+=("$extra_pattern")
     done
 
+    # Home mode also cleans the legacy ~/dotfiles-backup/ directory.
+    if [ "$home_mode" -eq 1 ]; then
+        _cleanup_offer_dotfiles_backup_dir "$search_dir"
+    fi
+
     if ! _cleanup_preview "$search_dir" "${patterns[@]}"; then
+        # In home mode the directory cleanup above may already have done useful
+        # work, so a "no matching files" result is not an error.
+        [ "$home_mode" -eq 1 ] && return 0
         return 1
     fi
 
@@ -250,3 +313,5 @@ del_file() {
 }
 
 alias del-file='del_file'
+# Home-directory backup cleanup (issue #806).
+alias clean-home='del_file --home'

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -20,6 +20,15 @@ else
     ux_error() { echo "✗ $1" >&2; }
 fi
 
+# Latest-only backup policy (issue #806). SSOT for the fixed suffixes;
+# fallback defaults guard against a missing helper (an empty suffix would
+# overwrite the live target).
+if [ -f "${SHELL_COMMON_DIR}/functions/dotfiles_backup.sh" ]; then
+    . "${SHELL_COMMON_DIR}/functions/dotfiles_backup.sh"
+fi
+: "${DOTFILES_BACKUP_SUFFIX:=.backup}"
+: "${DOTFILES_ORIGINAL_SUFFIX:=.original}"
+
 # ============================================================================
 # Configuration Values (SSOT - Single Source of Truth)
 # ============================================================================
@@ -51,11 +60,13 @@ _prepare_config_target() {
         rm -f "$_target"
         ux_info "Removed existing symlink: $_target"
     elif [ -d "$_target" ]; then
-        _backup="${_target}.backup.$(date +%Y%m%d%H%M%S)"
+        _backup="${_target}${DOTFILES_BACKUP_SUFFIX}"
+        rm -rf "$_backup"
         mv "$_target" "$_backup"
         ux_warning "Backed up existing directory: $_backup"
     elif [ -f "$_target" ]; then
-        _backup="${_target}.backup.$(date +%Y%m%d%H%M%S)"
+        _backup="${_target}${DOTFILES_BACKUP_SUFFIX}"
+        rm -f "$_backup"
         mv "$_target" "$_backup"
         ux_info "Backed up existing file: $_backup"
     fi
@@ -67,7 +78,13 @@ _restore_config_from_backup() {
     _target="$1"
     if [ -L "$_target" ]; then
         rm -f "$_target"
-        _latest="$(ls -t "${_target}".backup.* 2>/dev/null | head -1)"
+        # Prefer the new fixed-suffix backup (issue #806); fall back to the
+        # newest legacy timestamped backup so existing machines still migrate.
+        if [ -e "${_target}${DOTFILES_BACKUP_SUFFIX}" ]; then
+            _latest="${_target}${DOTFILES_BACKUP_SUFFIX}"
+        else
+            _latest="$(ls -t "${_target}".backup.* 2>/dev/null | head -1)"
+        fi
         if [ -n "$_latest" ]; then
             mv "$_latest" "$_target"
             ux_success "Restored: $(basename "$_latest") → $_target"
@@ -278,7 +295,11 @@ setup_opencode_config() {
                 _restore_config_from_backup "$opencode_target"
             elif [ -f "$opencode_target" ]; then
                 rm -f "$opencode_target"
-                _latest="$(ls -t "${opencode_target}.backup."* 2>/dev/null | head -1)"
+                if [ -e "${opencode_target}${DOTFILES_BACKUP_SUFFIX}" ]; then
+                    _latest="${opencode_target}${DOTFILES_BACKUP_SUFFIX}"
+                else
+                    _latest="$(ls -t "${opencode_target}.backup."* 2>/dev/null | head -1)"
+                fi
                 if [ -n "$_latest" ]; then
                     mv "$_latest" "$opencode_target"
                     ux_success "Restored: $(basename "$_latest") → $opencode_target"

--- a/ssh/setup.sh
+++ b/ssh/setup.sh
@@ -34,7 +34,10 @@ if [ -L "${SSH_CONFIG_LINK}" ]; then
     ux_info "Updating symlink (was: ${current_target})"
     rm "${SSH_CONFIG_LINK}"
 elif [ -f "${SSH_CONFIG_LINK}" ]; then
-    backup="${SSH_CONFIG_LINK}.backup.$(date +%Y%m%d%H%M%S)"
+    # Latest-only fixed suffix (issue #806) — overwrite one backup instead of
+    # accumulating. SSOT: shell-common/functions/dotfiles_backup.sh
+    backup="${SSH_CONFIG_LINK}.backup"
+    rm -f "${backup}"
     ux_info "Backing up existing file: ${backup}"
     mv "${SSH_CONFIG_LINK}" "${backup}"
 fi

--- a/tests/bats/functions/test_clean_home.bats
+++ b/tests/bats/functions/test_clean_home.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# tests/bats/functions/test_clean_home.bats
+# Tests for the `clean-home` entry point added in issue #806
+# (del_file --home + home whitelist + ~/dotfiles-backup/ offer).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "bash: clean-home alias exists" {
+    run_in_bash 'alias clean-home'
+    assert_success
+    assert_output --partial "del_file --home"
+}
+
+@test "zsh: clean-home alias exists" {
+    run_in_zsh 'alias clean-home'
+    assert_success
+    assert_output --partial "del_file --home"
+}
+
+@test "bash: _cleanup_set_home_patterns covers .backup/.original/.bak" {
+    run_in_bash '_cleanup_set_home_patterns; for p in "${CLEANUP_HOME_PATTERNS[@]}"; do echo "$p"; done'
+    assert_success
+    assert_output --partial ".backup"
+    assert_output --partial "-original"
+    assert_output --partial ".bak"
+}
+
+@test "zsh: _cleanup_set_home_patterns covers .backup/.original/.bak" {
+    run_in_zsh '_cleanup_set_home_patterns; for p in "${CLEANUP_HOME_PATTERNS[@]}"; do echo "$p"; done'
+    assert_success
+    assert_output --partial ".backup"
+    assert_output --partial "-original"
+    assert_output --partial ".bak"
+}
+
+@test "bash: dotfiles-backup dir offer is a no-op when dir is absent" {
+    run_in_bash '_cleanup_offer_dotfiles_backup_dir "$HOME"; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+}
+
+@test "bash: del_file --help documents --home / clean-home" {
+    run_in_bash 'del_file --help'
+    assert_success
+    assert_output --partial "--home"
+    assert_output --partial "clean-home"
+}
+
+@test "bash: del_file --home refuses without an interactive terminal" {
+    # The test harness pipes stdin (non-tty), so --home must bail out cleanly
+    # rather than scan/delete anything.
+    run_in_bash 'del_file --home; echo "rc=$?"'
+    assert_output --partial "requires an interactive terminal"
+    assert_output --partial "rc=1"
+}

--- a/tests/bats/setup/test_no_backup_accumulation.bats
+++ b/tests/bats/setup/test_no_backup_accumulation.bats
@@ -38,7 +38,7 @@ teardown() {
 @test "helper: backup_copy is idempotent (no accumulation)" {
     run bash -c '
         . "'"$BACKUP_HELPER"'"
-        d="$(mktemp -d)"
+        d=$(mktemp -d "${TMPDIR:-/tmp}/backup_test.XXXXXX")
         printf one > "$d/target"
         dotfiles_backup_copy "$d/target" >/dev/null
         printf two > "$d/target"
@@ -58,7 +58,7 @@ teardown() {
 @test "helper: backup_move overwrites prior backup" {
     run bash -c '
         . "'"$BACKUP_HELPER"'"
-        d="$(mktemp -d)"
+        d=$(mktemp -d "${TMPDIR:-/tmp}/backup_test.XXXXXX")
         printf first > "$d/t.backup"   # stale prior backup
         printf live  > "$d/t"
         dotfiles_backup_move "$d/t" >/dev/null

--- a/tests/bats/setup/test_no_backup_accumulation.bats
+++ b/tests/bats/setup/test_no_backup_accumulation.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# tests/bats/setup/test_no_backup_accumulation.bats
+# Regression guard for issue #806 — home-directory backup accumulation.
+#
+# Two halves:
+#   1. The dotfiles_backup.sh helper applies a FIXED suffix, so repeated
+#      backups overwrite a single file instead of accumulating.
+#   2. The setup scripts no longer stamp home-directory backups with a
+#      timestamp, and the redundant ~/.zshrc auto-cleanup hook is gone.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    BACKUP_HELPER="${DOTFILES_ROOT}/shell-common/functions/dotfiles_backup.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "helper: dotfiles_backup.sh exists" {
+    [ -f "$BACKUP_HELPER" ]
+}
+
+@test "helper: fixed suffixes default to .backup / .original" {
+    run bash -c ". '$BACKUP_HELPER'; echo \"\$DOTFILES_BACKUP_SUFFIX|\$DOTFILES_ORIGINAL_SUFFIX\""
+    assert_success
+    assert_output ".backup|.original"
+}
+
+@test "helper: backup_path appends fixed suffix" {
+    run bash -c ". '$BACKUP_HELPER'; dotfiles_backup_path /tmp/foo"
+    assert_success
+    assert_output "/tmp/foo.backup"
+}
+
+@test "helper: backup_copy is idempotent (no accumulation)" {
+    run bash -c '
+        . "'"$BACKUP_HELPER"'"
+        d="$(mktemp -d)"
+        printf one > "$d/target"
+        dotfiles_backup_copy "$d/target" >/dev/null
+        printf two > "$d/target"
+        dotfiles_backup_copy "$d/target" >/dev/null
+        # Exactly one backup file must exist.
+        count=$(find "$d" -maxdepth 1 -name "target.backup*" | wc -l | tr -d " ")
+        echo "count=$count"
+        cat "$d/target.backup"
+        rm -rf "$d"
+    '
+    assert_success
+    assert_output --partial "count=1"
+    # The single backup reflects the LATEST copy.
+    assert_output --partial "two"
+}
+
+@test "helper: backup_move overwrites prior backup" {
+    run bash -c '
+        . "'"$BACKUP_HELPER"'"
+        d="$(mktemp -d)"
+        printf first > "$d/t.backup"   # stale prior backup
+        printf live  > "$d/t"
+        dotfiles_backup_move "$d/t" >/dev/null
+        count=$(find "$d" -maxdepth 1 -name "t.backup*" | wc -l | tr -d " ")
+        echo "count=$count"
+        cat "$d/t.backup"
+        rm -rf "$d"
+    '
+    assert_success
+    assert_output --partial "count=1"
+    assert_output --partial "live"
+}
+
+@test "bash/setup.sh: redundant _add_zshrc_auto_cleanup hook removed" {
+    # The function must no longer be defined or invoked. A reference inside an
+    # explanatory comment is fine, so match only a definition/call (parens) or
+    # a bare invocation at the start of a line.
+    run grep -nE '_add_zshrc_auto_cleanup\(\)|^_add_zshrc_auto_cleanup' "${DOTFILES_ROOT}/bash/setup.sh"
+    assert_failure
+}
+
+@test "bash/setup.sh: no timestamped home backups remain" {
+    run grep -nE '(-\$\(date|\.backup\.\$\(date)' "${DOTFILES_ROOT}/bash/setup.sh"
+    assert_failure   # grep finds nothing
+}
+
+@test "zsh/setup.sh: no timestamped -original backup remains" {
+    run grep -nE '\-\$\(date' "${DOTFILES_ROOT}/zsh/setup.sh"
+    assert_failure
+}
+
+@test "git/setup.sh: fixed .original suffix" {
+    run grep -nE '\-\$\(date' "${DOTFILES_ROOT}/git/setup.sh"
+    assert_failure
+}
+
+@test "gh/setup.sh: fixed .original suffix" {
+    run grep -nE '\-\$\{BACKUP_DATE\}-original|\-\$\(date' "${DOTFILES_ROOT}/gh/setup.sh"
+    assert_failure
+}
+
+@test "ssh/setup.sh: fixed .backup suffix" {
+    run grep -nE '\.backup\.\$\(date' "${DOTFILES_ROOT}/ssh/setup.sh"
+    assert_failure
+}
+
+@test "vscode-extensions/setup.sh: fixed .original suffix" {
+    run grep -nE '\-\$\(date' "${DOTFILES_ROOT}/vscode-extensions/setup.sh"
+    assert_failure
+}

--- a/vscode-extensions/setup.sh
+++ b/vscode-extensions/setup.sh
@@ -82,7 +82,11 @@ create_symlink() {
         rm "$link_name" || log_error_and_exit "기존 심볼릭 링크 제거 실패: $link_name"
     elif [ -f "$link_name" ] || [ -d "$link_name" ]; then
         log_warning "경고: $link_name 가 심볼릭 링크가 아닙니다. 백업 후 제거합니다."
-        backup_file "$link_name" "${link_name}-$(date +%Y%m%d%H%M%S)-original"
+        # Latest-only fixed suffix (issue #806) — overwrite a single backup
+        # instead of accumulating. Clear any prior backup first so a directory
+        # backup does not nest. SSOT: shell-common/functions/dotfiles_backup.sh
+        rm -rf "${link_name}.original"
+        backup_file "$link_name" "${link_name}.original"
         rm -rf "$link_name" || log_error_and_exit "기존 파일/디렉토리 제거 실패: $link_name"
     fi
 

--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -49,6 +49,15 @@ else
     exit 1
 fi
 
+# Latest-only backup policy (issue #806). SSOT for the fixed suffixes;
+# fallback defaults guard against a missing helper (an empty suffix would
+# overwrite the live target).
+if [ -f "${DOTFILES_ROOT}/shell-common/functions/dotfiles_backup.sh" ]; then
+    source "${DOTFILES_ROOT}/shell-common/functions/dotfiles_backup.sh"
+fi
+: "${DOTFILES_BACKUP_SUFFIX:=.backup}"
+: "${DOTFILES_ORIGINAL_SUFFIX:=.original}"
+
 # --- Logging Compatibility Functions ---
 
 # Legacy logging functions for consistency with bash/setup.sh
@@ -90,7 +99,7 @@ create_symlink() {
         rm "$link_name" || log_error_and_exit "기존 심볼릭 링크 제거 실패: $link_name"
     elif [ -f "$link_name" ]; then
         log_warning "경고: $link_name 가 심볼릭 링크가 아닌 일반 파일입니다. 백업 후 제거합니다."
-        local backup_path="${link_name}-$(date +%Y%m%d%H%M%S)-original"
+        local backup_path="${link_name}${DOTFILES_ORIGINAL_SUFFIX}"
         backup_file "$link_name" "$backup_path"
         rm "$link_name" || log_error_and_exit "기존 파일 제거 실패: $link_name"
         if [ "$link_name" = "$HOME_ZSHRC" ]; then


### PR DESCRIPTION
## 배경

`./setup.sh` 반복 실행 시 홈 디렉터리에 백업 파일이 무한 누적되던 문제(#806)를 해소한다.

## 변경 내용

### 1차 원인 제거 — `bash/setup.sh` 가지치기
- `_add_zshrc_auto_cleanup()` 런타임 훅 + 호출 삭제. 이 훅이 `cat > .new && mv` 로 cleanup 코드를 prepend 하면서 dotfiles 가 만든 `~/.zshrc` **symlink 을 일반 파일로 변환** → 다음 `./setup.sh` 가 백업 + 재링크 → 매 실행 1개씩 누적시키던 근본 원인.
- 의도(미설치 plugin 정리)는 같은 파일의 `_cleanup_broken_zsh_plugins()` 가 build-time 에 이미 처리하므로 runtime 훅은 redundant.
- `_cleanup_broken_zsh_plugins()` 의 safety 백업도 timestamp → fixed `.backup` 로 전환하고 성공 시 정리.

### 2차 원인 완화 — Latest-only 백업 정책
- 8개 setup 스크립트(`shell-common`, `zsh`, `bash`, `git`, `vscode-extensions`, `claude`, `ssh`, `gh`)의 `.backup.<ts>` / `-<ts>-original` timestamp suffix 를 fixed `.backup` / `.original` 로 전환 → 재실행 시 단일 백업을 overwrite.
- SSOT 헬퍼 `shell-common/functions/dotfiles_backup.sh` 신설 — `dotfiles_backup_path/copy/move` + suffix 상수. 출력이 없는 pure-function 파일이라 인터랙티브 가드 없이 비대화형 setup 스크립트에서도 source 가능.

### 호환성
- `_restore_config_from_backup` 가 fixed `.backup` 우선, 없으면 legacy `.backup.*` glob 의 최신을 fallback → 기존 PC 가 `./setup.sh` 재실행 시 안전 마이그레이션.

### 청소 명령
- `del_file --home` + `clean-home` alias 추가. 홈 디렉터리 backup 화이트리스트 파일 + 레거시 `~/dotfiles-backup/` 디렉터리를 인터랙티브 정리.

## 테스트
- `tests/bats/setup/test_no_backup_accumulation.bats` — 헬퍼 멱등성(2회 백업 → 1개) + 8개 스크립트 timestamp 부재 회귀 가드.
- `tests/bats/functions/test_clean_home.bats` — `clean-home` alias / `--home` 파싱 / 홈 패턴 / 디렉터리 offer no-op.
- bats 전체 그린(exit 0) + `tests/integration/test_file_cleanup.py` 6 passed.

## Out of scope
- `claude/setup.sh` 의 1회성 migration backup(`pre-*-fix-*`) 정책 — 별도 이슈.
- `/etc` 시스템 repo(apt/rpm) 백업 — 홈 누적과 무관.

Closes #806

<!-- ai-metrics:gh-pr -->
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~3 h · 🤖 ~0 min</summary>

📊 ~7000 tokens · 👤 ~3 h · 🤖 ~0 min
</details>
<!-- /ai-metrics:gh-pr -->
