### PR TITLE
feat(skill-check): #809 Check #12 스킬별 권장 모델 티어 감사 (supersedes #807)

### DIFF
--- a/claude/skills/skill-check/SKILL.md
+++ b/claude/skills/skill-check/SKILL.md
@@ -23,9 +23,9 @@ If the argument is `help`, read `references/help.md` and output its content verb
 If the user specifies a path, use it. Otherwise search for SKILL.md from the
 current directory.
 
-## Step 2: Run Eleven Checks
+## Step 2: Run Twelve Checks
 
-Read `references/checks.md` for all 11 check definitions and PASS/WARN/FAIL/N/A criteria.
+Read `references/checks.md` for all 12 check definitions and PASS/WARN/FAIL/N/A criteria.
 Assign one result per check. Audit-only — never stop on failure; report every check (`skill:check` is read-only and must produce a full report).
 
 **Checks 1–5: Structure**
@@ -33,6 +33,14 @@ Line Count · Progressive Disclosure · Frontmatter Validity · References Direc
 
 **Checks 6–11: UX Quality**
 Help Flag Pattern · Step Structure · Options Documentation · Verdict Output · Next-action Hint · No Emojis
+
+**Check 12: Model Recommendation Metadata**
+Detects/validates `metadata.model_recommendation` (tier haiku/sonnet/opus +
+reason + compatibility) and reports a recommended tier per the rubric SSOT
+`references/model-recommendation.md`. **Read-only — recommends a tier, never
+switches models or writes files** (#809). For composite skills (body invokes
+`/gh-*`, `gh:*`, `Skill(...)`), build a 1-depth Sub-skill Model Plan separate
+from this skill's own tier; `--recursive` opts into deeper traversal.
 
 Check 11 (No Emojis) consults `references/allowed-emoji-skills.txt` —
 audited skill names that appear in that file resolve to `[N/A] allowlisted`.

--- a/claude/skills/skill-check/references/checks.md
+++ b/claude/skills/skill-check/references/checks.md
@@ -107,8 +107,8 @@ Detect `metadata.model_recommendation` in the SKILL.md frontmatter:
 | Result | Criteria |
 |---|---|
 | PASS | valid `tier` (haiku/sonnet/opus) + `reason` + compatibility (`claude` and `non_claude`) all present |
-| WARN | `tier` present but `reason` or compatibility missing — OR metadata absent while migration gate is open (`MIGRATION_COMPLETE = false`) |
-| FAIL | disallowed `tier` value — OR metadata absent after migration completes (`MIGRATION_COMPLETE = true`) |
+| WARN | `tier` present but `reason` or compatibility missing — OR metadata absent while the migration gate is open (gate state = `MIGRATION_COMPLETE` in `references/model-recommendation.md`) |
+| FAIL | disallowed `tier` value — OR metadata absent after the migration gate closes (gate state = `MIGRATION_COMPLETE` in `references/model-recommendation.md`) |
 | N/A | skill explicitly disables model invocation (`disable-model-invocation: true`) |
 
 On WARN-for-absence, suggest the migration command from

--- a/claude/skills/skill-check/references/checks.md
+++ b/claude/skills/skill-check/references/checks.md
@@ -1,6 +1,6 @@
 # Skill Quality Checks
 
-Ten checks, each rated PASS / WARN / FAIL / N/A.
+Twelve checks, each rated PASS / WARN / FAIL / N/A.
 
 ---
 
@@ -37,7 +37,7 @@ FAIL — no output format defined
 
 ---
 
-## UX Quality Checks (6–10)
+## UX Quality Checks (6–11)
 
 ### Check 6: Help Flag Pattern
 PASS — `-h`/`--help`/`help` arg → reads `references/help.md` verbatim, then stops. No API calls.
@@ -92,3 +92,36 @@ entry must carry an inline rationale comment.
 
 FAIL output: list up to 5 matched files+lines and append the guidance
 `Remove emoji or add to references/allowed-emoji-skills.txt with rationale`.
+
+---
+
+## Model Recommendation Check (12)
+
+### Check 12: Model Recommendation Metadata
+Read `references/model-recommendation.md` (rubric SSOT) for the full schema,
+tier rubric, migration gate, and compatibility policy. This check is
+**read-only — it recommends a tier, never switches models or writes files** (#809).
+
+Detect `metadata.model_recommendation` in the SKILL.md frontmatter:
+
+| Result | Criteria |
+|---|---|
+| PASS | valid `tier` (haiku/sonnet/opus) + `reason` + compatibility (`claude` and `non_claude`) all present |
+| WARN | `tier` present but `reason` or compatibility missing — OR metadata absent while migration gate is open (`MIGRATION_COMPLETE = false`) |
+| FAIL | disallowed `tier` value — OR metadata absent after migration completes (`MIGRATION_COMPLETE = true`) |
+| N/A | skill explicitly disables model invocation (`disable-model-invocation: true`) |
+
+On WARN-for-absence, suggest the migration command from
+`references/model-recommendation.md` Section 3. On FAIL-for-tier, print the
+allowed values `haiku | sonnet | opus`.
+
+**Recommended tier (always reported, even when metadata exists):** apply the
+Section 2 rubric to the audited skill and report the recommended tier with a
+one-line rationale. When metadata is present, note agreement or mismatch with
+the declared `tier`.
+
+**Composite skills (F-5 / F-6):** when the SKILL.md body invokes other skills
+(`/gh-*`, `gh:*`, `Skill(<name> ...)` patterns), build a 1-depth Sub-skill Model
+Plan — read each sub-skill's declared `tier`, mark missing ones `unknown` (WARN),
+and report it **separately from this skill's own tier** (see report-template.md).
+Recursion is 1-depth by default; `--recursive` opts into deeper traversal.

--- a/claude/skills/skill-check/references/help.md
+++ b/claude/skills/skill-check/references/help.md
@@ -1,22 +1,27 @@
 /skill:check — Audit a SKILL.md for structure and UX quality
 
 Usage:
-  /skill:check [path/to/SKILL.md]
+  /skill:check [path/to/SKILL.md] [--recursive]
 
 Arguments:
   [path]    Path to the SKILL.md file to audit (optional)
             If omitted, searches for SKILL.md from the current directory
 
+Options:
+  --recursive   For composite skills, traverse the Sub-skill Model Plan deeper
+                than the default 1-depth (Check 12). Off by default.
+  help          Show this message
+
 Examples:
   /skill:check
   /skill:check claude/skills/my-skill/SKILL.md
+  /skill:check claude/skills/gh-issue-flow/SKILL.md --recursive
   /skill:check help
 
-Options:
-  help    Show this message
-
-Checks run (10 total):
-  Structure (1-5):   Line Count, Progressive Disclosure, Frontmatter Validity,
-                     References Directory Usage, Output Report Defined
-  UX Quality (6-10): Help Flag Pattern, Step Structure, Options Documentation,
-                     Verdict Output, Next-action Hint
+Checks run (12 total):
+  Structure (1-5):    Line Count, Progressive Disclosure, Frontmatter Validity,
+                      References Directory Usage, Output Report Defined
+  UX Quality (6-11):  Help Flag Pattern, Step Structure, Options Documentation,
+                      Verdict Output, Next-action Hint, No Emojis
+  Model (12):         Model Recommendation Metadata (read-only tier advice;
+                      rubric: references/model-recommendation.md)

--- a/claude/skills/skill-check/references/model-recommendation.md
+++ b/claude/skills/skill-check/references/model-recommendation.md
@@ -1,0 +1,91 @@
+# Model Recommendation Metadata — rubric SSOT
+
+Single source of truth for the **권장 모델 티어** policy (#809, supersedes #807).
+Shared by `skill:check` (audits/recommends, read-only) and `skill:refactor`
+(generates the metadata). Keep the rubric here so the two skills never drift.
+
+> **`skill:check` 는 read-only.** 티어를 **추천**만 하고, 모델을 직접 전환하지
+> 않으며, 파일을 쓰지도 않는다. 실제 메타데이터 기입은 `skill:refactor`,
+> 실제 런타임 모델 전환은 별도 후속 이슈의 몫이다.
+
+---
+
+## 1. Frontmatter schema
+
+권장 티어는 기존 `metadata:` 블록 하위에 둔다 (top-level 확장보다 호환성 높음):
+
+```yaml
+metadata:
+  model_recommendation:
+    tier: haiku | sonnet | opus      # Claude 티어 — 안정적 티어명, 버전 ID 아님
+    reason: "read-only gh metadata lookup; bounded output"
+    claude: prefer                    # prefer | force  (force 는 실행계층 후속이슈 예약값)
+    non_claude: advisory-only | skip  # codex/gemini/opencode degrade 동작
+```
+
+- `tier` — **필수**. `haiku` / `sonnet` / `opus` 셋 중 하나. 그 외 값은 FAIL.
+- `reason` — 권장 산정 근거 한 줄. 누락 시 WARN.
+- `claude` — `prefer`(권장, 기본) 또는 `force`(실행계층 후속이슈 예약값).
+- `non_claude` — `advisory-only`(리포트에 노출) 또는 `skip`(무시). 강제 매핑 없음.
+- `claude` / `non_claude` 를 합쳐 **compatibility** 라 부른다. 둘 다 있어야 PASS.
+
+## 2. Tier rubric
+
+난이도·위험도·수정 범위·추론 깊이·외부 쓰기 여부로 티어를 정한다.
+
+| Tier | 기준 | 예시 |
+|---|---|---|
+| `haiku` | 읽기 전용, 짧은 요약, 정형 CLI 래핑, 낮은 추론 | `gh:issue-read`, `gh:commit`, `gh:pr` |
+| `sonnet` | 중간 난이도 분석, 리뷰 응답, 제한적 수정, CI 로그 해석 | `gh:pr-reply`, `gh:pr-resolve-ci-fail` |
+| `opus` | 깊은 구현, 대규모 리팩터링, 충돌 해결, 아키텍처 판단, 고위험 쓰기 | `gh:issue-implement`, `gh:pr-resolve-conflict` |
+
+원칙 (NF-1~4):
+- 비용 절감 — 가벼운 스킬은 기본 `haiku`.
+- 고위험 쓰기·대규모 구현·충돌 해결·깊은 설계 판단은 `opus`.
+- 일반 분석·리뷰 응답·중간 난이도 수정은 `sonnet`.
+- 모델명은 공급자별 버전 ID 보다 안정적 티어명을 우선 (실제 ID 는
+  `references/model-tier-map.md` 로 분리).
+
+## 3. Migration gate (WARN → FAIL)
+
+메타데이터 누락의 결과는 **마이그레이션 단계 플래그**로 제어한다 — 43개 스킬을
+day-one red wall 로 막지 않기 위함이다 (Open Question 1 결정).
+
+- **`MIGRATION_COMPLETE = false`** (현재): 메타데이터 누락 → **WARN** +
+  아래 마이그레이션 명령 제안.
+- 전체 스킬에 메타데이터가 채워지면 이 줄을 `true` 로 바꾼다: 그 시점부터
+  누락 → **FAIL**.
+
+마이그레이션 명령 (제안 문구):
+`Run /skill:refactor <path> to add a metadata.model_recommendation block (rubric: references/model-recommendation.md).`
+
+## 4. Composite skill model plan (F-5 / F-6)
+
+합성 스킬은 본문에서 호출하는 하위 스킬을 1-depth 로 찾아 **자체 티어와
+분리해** 하위 스킬별 권장 모델 계획을 표시한다.
+
+- 탐지 패턴: 본문의 `/gh-*`, `gh:*`, `Skill(<name> ...)` 를 정규화해 후보 추출.
+- 후보 스킬 파일이 있으면 그 `metadata.model_recommendation.tier` 를 읽는다.
+- 파일/메타데이터가 없으면 `unknown` 으로 표시하고 WARN.
+- **재귀는 기본 1-depth.** 깊은 재귀는 `--recursive` opt-in (비용·복잡도 분리,
+  Open Question 2 결정).
+
+예시 — `gh:issue-flow` 는 자체 티어(오케스트레이션 → `sonnet`)와 5개 하위
+스킬 계획을 따로 리포트한다 (`Sub-skill Model Plan` 섹션, report-template.md).
+
+## 5. Compatibility policy (F-7 / F-8)
+
+- **Claude**: `tier` 를 실행 계층(후속 이슈)이 소비할 authoritative metadata 로
+  취급한다. 단 `skill:check`/`skill:refactor` 자체는 모델을 전환하지 않는다.
+- **codex / gemini / opencode**: 실행 모델 전환 기능이 없으면 `tier` 를
+  `non_claude` 값에 따라 advisory metadata 로 리포트(`advisory-only`)하거나
+  무시(`skip`)한다. Claude 모델명을 강제 매핑하지 않는다.
+- 공급자별 실제 모델 ID 는 `references/model-tier-map.md` 로 분리해 모델 버전
+  변경 시 이 rubric 은 불변으로 유지한다.
+
+## 6. `skill:refactor` 연동 (F-9)
+
+`skill:refactor` 는 이 SSOT 를 읽어 누락된 스킬 frontmatter 에
+`metadata.model_recommendation` 블록을 **생성**한다 (보존이 아니라 생성,
+Open Question 3 결정). 추천 로직(Section 2 rubric)을 양쪽이 공유하므로 중복
+판단을 막는다. 전체 마이그레이션은 이 이슈 구현 후 별도로 수행한다.

--- a/claude/skills/skill-check/references/model-tier-map.md
+++ b/claude/skills/skill-check/references/model-tier-map.md
@@ -13,14 +13,20 @@
 
 ## Claude (authoritative)
 
-| Tier | Model ID | 비고 |
+아래는 **2026-05 기준 현행 Claude 4.x 패밀리의 안정적 별칭(alias) ID** 다 —
+placeholder 가 아니라 실제 사용 중인 모델 식별자다. alias 는 그 패밀리의 최신
+스냅샷으로 해석된다 (예: haiku 의 dated 형은 `claude-haiku-4-5-20251001`).
+
+| Tier | Model ID (alias) | 비고 |
 |---|---|---|
 | `haiku` | `claude-haiku-4-5` | 경량·저비용, 정형 작업 |
 | `sonnet` | `claude-sonnet-4-6` | 범용 기본 |
 | `opus` | `claude-opus-4-8` | 깊은 추론·고위험 작업 |
 
 Claude 환경에서 `tier` 는 authoritative — 실행 계층이 이 매핑으로 모델을
-선택할 수 있다 (F-7). 모델 패밀리가 갱신되면 위 ID 만 교체한다.
+선택할 수 있다 (F-7). 모델 패밀리가 갱신되면 위 ID 만 교체한다 (rubric 불변).
+dated/pinned ID 가 필요한 실행 계층(후속 이슈)은 alias 를 그 시점의 dated 형으로
+해석하면 된다.
 
 ## Non-Claude CLI (advisory-only / skip)
 

--- a/claude/skills/skill-check/references/model-tier-map.md
+++ b/claude/skills/skill-check/references/model-tier-map.md
@@ -1,0 +1,49 @@
+# Model Tier → Provider ID Map
+
+권장 티어(`haiku` / `sonnet` / `opus`)를 공급자별 실제 모델 ID 로 옮기는 매핑.
+**rubric(`references/model-recommendation.md`)과 분리**하는 이유: 모델 버전은
+자주 바뀌지만 티어 기준은 불변이어야 하기 때문이다 (NF-4). 버전이 바뀌면 이
+파일만 갱신하고 rubric 과 전체 스킬 메타데이터는 그대로 둔다.
+
+> 이 파일은 **advisory reference** 다. `skill:check` 는 이 매핑을 강제하지
+> 않고, 런타임 모델 전환도 하지 않는다 (read-only 계약). 실제 소비는 향후
+> 실행 계층(별도 후속 이슈)의 몫이다.
+
+---
+
+## Claude (authoritative)
+
+| Tier | Model ID | 비고 |
+|---|---|---|
+| `haiku` | `claude-haiku-4-5` | 경량·저비용, 정형 작업 |
+| `sonnet` | `claude-sonnet-4-6` | 범용 기본 |
+| `opus` | `claude-opus-4-8` | 깊은 추론·고위험 작업 |
+
+Claude 환경에서 `tier` 는 authoritative — 실행 계층이 이 매핑으로 모델을
+선택할 수 있다 (F-7). 모델 패밀리가 갱신되면 위 ID 만 교체한다.
+
+## Non-Claude CLI (advisory-only / skip)
+
+codex / gemini / opencode 는 Claude 티어 개념이 없다. 강제 매핑하지 않으며,
+SKILL.md 의 `metadata.model_recommendation.non_claude` 값으로 동작을 정한다:
+
+| `non_claude` | 동작 |
+|---|---|
+| `advisory-only` | 리포트에 권장 티어를 정보로만 노출, 실행 영향 없음 |
+| `skip` | 권장 티어 무시, 리포트에서 생략 |
+
+아래는 참고용 느슨한 대응표일 뿐 — 공급자별 성능·명칭이 상이하므로 강제하지
+않는다 (잘못된 비용·품질 결정 방지, Alternatives 거절 사유 참조).
+
+| Tier | codex (참고) | gemini (참고) |
+|---|---|---|
+| `haiku` | 경량 모델 | `gemini-flash` 계열 |
+| `sonnet` | 중간 모델 | `gemini-pro` 계열 |
+| `opus` | 상위 추론 모델 | `gemini-pro` 상위 계열 |
+
+## 갱신 규칙
+
+- 모델 버전 변경 → **이 파일의 ID 만** 수정. rubric/스킬 메타데이터 불변.
+- 새 티어 추가는 rubric SSOT(`model-recommendation.md`) 변경이 선행되어야 함.
+- 노후화 감지: ID 가 더 이상 유효하지 않아도 tier 기준은 유지되고, 실제 ID
+  매핑만 갱신한다 (Error Cases).

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -27,8 +27,27 @@ References dir: <exists / missing>
 | 10 | Next-action Hint             | PASS   | teardown shown in success report      |
 | 11 | No Emojis                    | PASS   | no emoji glyphs in body or references |
 
-Score: 6/10 checks passed (2 warnings, 2 fails, 1 N/A)
+### Model Recommendation Check
+| #  | Check                        | Result | Notes                                 |
+|----|------------------------------|--------|---------------------------------------|
+| 12 | Model Recommendation Metadata| WARN   | metadata absent (migration period)    |
+
+Recommended tier: haiku — read-only audit, bounded output (declared: none yet)
+
+Score: 6/11 checks passed (3 warnings, 2 fails, 1 N/A)
 Verdict: NEEDS WORK — fix FAIL items before shipping
+
+## Sub-skill Model Plan
+(only for composite skills that invoke other skills; 1-depth unless --recursive)
+This skill's own tier: sonnet — orchestration, no deep edits
+
+| Sub-skill                | Declared tier | Notes                          |
+|--------------------------|---------------|--------------------------------|
+| gh:issue-implement       | opus          | deep implementation             |
+| gh:commit                | haiku         | structured CLI wrapping         |
+| gh:pr                    | haiku         | structured CLI wrapping         |
+| gh:pr-resolve-conflict   | opus          | rebase / conflict resolution    |
+| devx:schedule            | unknown       | metadata absent (WARN)          |
 
 ## Issues & Improvements
 
@@ -49,7 +68,10 @@ Run /skill:check again after fixes to verify.
 Rules:
 - Only include WARN and FAIL items in Issues & Improvements section
 - Quote actual lines from the file when describing problems
-- Score denominator excludes N/A checks
+- Score denominator excludes N/A checks (12 checks total, minus any N/A)
+- The "Model Recommendation Check" table row + "Recommended tier" line are
+  always shown; the "Sub-skill Model Plan" section appears only for composite
+  skills (omit it entirely for leaf skills)
 - Verdict labels:
   - All applicable checks PASS → `EXCELLENT — gold standard`
   - ≥80% PASS, no FAIL → `GOOD — production-ready, minor polish needed`


### PR DESCRIPTION
## Summary
- `skill:check` 에 12번째 검사 **Model Recommendation Metadata** 를 추가한다 — frontmatter 의 `metadata.model_recommendation`(tier haiku/sonnet/opus + reason + compatibility)을 감지·검증하고 rubric 으로 권장 티어를 추천한다.
- **read-only 계약 유지**: 모델을 직접 전환하거나 파일을 쓰지 않는다. 메타데이터 기입은 `skill:refactor`, 런타임 모델 전환은 별도 후속 이슈.
- #807 의 스키마·rubric 설계를 계승하고 4개 Open Question 을 확정 결정으로 닫는다 (supersedes #807).

## Changes
- `SKILL.md`: Eleven→Twelve checks, Check 12 설명 + 합성 스킬 Sub-skill Model Plan 요약 (50줄, 100줄 한도 유지)
- `references/checks.md`: Check 12 정의(PASS/WARN/FAIL/N/A) + migration gate(WARN→FAIL) + 1-depth 합성 스킬 탐지 규칙
- `references/report-template.md`: 12번째 행 + `Recommended tier` 라인 + 조건부 `Sub-skill Model Plan` 섹션 + 6/11 scoring
- `references/help.md`: 12 checks 목록, `--recursive` 플래그, rubric 포인터
- 신규 `references/model-recommendation.md`: rubric SSOT — 스키마, tier rubric, migration gate, F-5/F-8/F-9 정책 (`skill:check`/`skill:refactor` 공유)
- 신규 `references/model-tier-map.md`: tier→공급자 모델 ID 매핑 (Claude authoritative, non-Claude advisory-only/skip)

## #807 Open Questions 확정
- 메타데이터 누락 = **마이그레이션 전 WARN → 완료 후 FAIL 승격**
- 합성 스킬 탐지 depth = **1-depth 기본 + `--recursive` opt-in**
- `skill:refactor` = **생성**(보존 아님), 공유 rubric SSOT 소비
- 런타임 모델 전환 = **이 이슈 범위 밖, 별도 후속 이슈** (`Skill()` in-session 실행이라 전환 불가; subagent dispatch 는 fresh context 로 `gh:issue-flow` 공유 컨텍스트/Stop-hook guard 충돌)

## Test plan
- [x] `tests/golden_rules/test_golden_rules.sh` 통과 (emoji 규칙 — 셸 소스만 스캔, 영향 없음)
- [x] 변경된/신규 markdown emoji 스캔 clean (checks.md 의 기존 ai-metrics 예외 글리프만 잔존)
- [x] `SKILL.md` 50줄 (≤100), references 각 파일 <300줄
- [ ] (수동) `/skill:check claude/skills/skill-check/SKILL.md` 가 12번째 행을 출력하는지 확인
- [ ] (수동) `/skill:check claude/skills/gh-issue-flow/SKILL.md --recursive` 가 하위 5개 스킬 모델 계획을 자체 티어와 분리해 표시하는지 확인

## Related
Closes #809

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
