### PR TITLE
feat(gcp): #811 scan dup commit 을 individual cherry-pick 모드에서도 자동 skip

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -32,8 +32,18 @@ _gcp_scan_is_empty_cherry_pick() {
 _gcp_scan_dup_base_sha() {
     # Look up the base-branch SHA that a duplicate source SHA matches.
     # $1 = candidate source SHA; $2 = duplicate map ("SRC_SHA BASE_SHA" lines).
-    # Prints the matching base SHA (or nothing) — issue #811 F-3.
-    printf '%s\n' "$2" | awk -v s="$1" '$1 == s { print $2; exit }'
+    # Prints the matching base SHA (or nothing) — issue #811 F-3. Pure shell
+    # (here-doc `while read`, no awk fork) per PR #812 review.
+    local target="$1"
+    local src_sha base_sha
+    while read -r src_sha base_sha; do
+        if [ "$src_sha" = "$target" ]; then
+            printf '%s\n' "$base_sha"
+            return 0
+        fi
+    done <<EOF
+$2
+EOF
 }
 
 _gcp_scan() {
@@ -191,23 +201,31 @@ EOF
     local duplicate_map=""
     local duplicate_count=0
 
+    # Cache the base branch's recent subjects ONCE (PR #812 review): running
+    # `git log` per source commit was an O(N) process-fork bottleneck. The
+    # per-commit lookup below is then a pure-shell here-doc `while read`
+    # (no git/awk fork, no pipe subshell).
+    local base_log tab
+    base_log=$(git log "$base" -n 200 --format='%H%x09%s' 2>/dev/null)
+    tab=$(printf '\t')
+
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
         local subject
         subject=$(git show -s --format='%s' "$sha")
 
-        # Check if base branch has a commit with same subject (search recent
-        # 200 commits). Capture the matching base SHA so the individual
-        # cherry-pick loop can report what each dup was already applied as
-        # (issue #811 F-1/F-3). Exact subject match preserved via tab split.
-        local match_base_sha
-        match_base_sha=$(git log "$base" -n 200 --format='%H%x09%s' 2>/dev/null \
-            | while IFS="$(printf '\t')" read -r _b_sha _b_subj; do
-                if [ "$_b_subj" = "$subject" ]; then
-                    printf '%s\n' "$_b_sha"
-                    break
-                fi
-            done)
+        # Find a base commit with the same subject and capture its SHA so the
+        # individual cherry-pick loop can report what each dup was already
+        # applied as (issue #811 F-1/F-3). Exact subject match via tab split.
+        local match_base_sha="" _b_sha _b_subj
+        while IFS="$tab" read -r _b_sha _b_subj; do
+            if [ "$_b_subj" = "$subject" ]; then
+                match_base_sha="$_b_sha"
+                break
+            fi
+        done <<EOF
+$base_log
+EOF
         if [ -n "$match_base_sha" ]; then
             duplicate_list="${duplicate_list}${sha}"$'\n'
             duplicate_map="${duplicate_map}${sha} ${match_base_sha}"$'\n'

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -29,6 +29,13 @@ _gcp_scan_is_empty_cherry_pick() {
     return 0
 }
 
+_gcp_scan_dup_base_sha() {
+    # Look up the base-branch SHA that a duplicate source SHA matches.
+    # $1 = candidate source SHA; $2 = duplicate map ("SRC_SHA BASE_SHA" lines).
+    # Prints the matching base SHA (or nothing) — issue #811 F-3.
+    printf '%s\n' "$2" | awk -v s="$1" '$1 == s { print $2; exit }'
+}
+
 _gcp_scan() {
     # zsh compatibility: emulate POSIX sh to ensure consistent behavior
     if [ -n "${ZSH_VERSION-}" ]; then
@@ -181,6 +188,7 @@ EOF
     # Check for duplicate commits (same subject already in base branch)
     local final_selected_list=""
     local duplicate_list=""
+    local duplicate_map=""
     local duplicate_count=0
 
     while IFS= read -r sha; do
@@ -188,9 +196,21 @@ EOF
         local subject
         subject=$(git show -s --format='%s' "$sha")
 
-        # Check if base branch has a commit with same subject (search recent 200 commits)
-        if git log "$base" -n 200 --format='%s' 2>/dev/null | grep -Fqx "$subject"; then
+        # Check if base branch has a commit with same subject (search recent
+        # 200 commits). Capture the matching base SHA so the individual
+        # cherry-pick loop can report what each dup was already applied as
+        # (issue #811 F-1/F-3). Exact subject match preserved via tab split.
+        local match_base_sha
+        match_base_sha=$(git log "$base" -n 200 --format='%H%x09%s' 2>/dev/null \
+            | while IFS="$(printf '\t')" read -r _b_sha _b_subj; do
+                if [ "$_b_subj" = "$subject" ]; then
+                    printf '%s\n' "$_b_sha"
+                    break
+                fi
+            done)
+        if [ -n "$match_base_sha" ]; then
             duplicate_list="${duplicate_list}${sha}"$'\n'
+            duplicate_map="${duplicate_map}${sha} ${match_base_sha}"$'\n'
             duplicate_count=$((duplicate_count + 1))
         else
             if [ -z "$final_selected_list" ]; then
@@ -336,14 +356,32 @@ EOF
                     return 1
                 fi
             else
-                # Non-contiguous: cherry-pick individually for better control
+                # Non-contiguous: cherry-pick individually for better control.
+                # Iterate the full author-filtered list (selected_list) — not
+                # the dup-pruned final_selected_list — so dup commits detected
+                # in Stage-1 are explicitly skipped *with a log line* instead
+                # of being silently dropped (issue #811 F-1/F-2).
                 if type ux_warning >/dev/null 2>&1; then
                     ux_warning "Non-contiguous range detected. Cherry-picking individually..."
                 fi
                 local picked=0
-                local skipped=0
+                local empty_skipped=0
+                local dup_skipped=0
                 while IFS= read -r sha; do
                     [ -z "$sha" ] && continue
+                    # F-2/F-3: a Stage-1 duplicate is skipped without a
+                    # cherry-pick attempt, naming the base SHA it matches.
+                    local dup_base_sha
+                    dup_base_sha=$(_gcp_scan_dup_base_sha "$sha" "$duplicate_map")
+                    if [ -n "$dup_base_sha" ]; then
+                        if type ux_info >/dev/null 2>&1; then
+                            ux_info "Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
+                        else
+                            echo "ℹ Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
+                        fi
+                        dup_skipped=$((dup_skipped + 1))
+                        continue
+                    fi
                     if type ux_info >/dev/null 2>&1; then
                         ux_info "Cherry-picking $sha..."
                     fi
@@ -355,7 +393,7 @@ EOF
                                 ux_warning "Empty commit at $sha; skipping..."
                             fi
                             if git cherry-pick --skip; then
-                                skipped=$((skipped + 1))
+                                empty_skipped=$((empty_skipped + 1))
                                 break
                             fi
                             break
@@ -370,10 +408,20 @@ EOF
                         return 1
                     fi
                 done <<EOF
-$final_selected_list
+$selected_list
 EOF
+                # F-4: reaching here means no unresolved conflict (a real
+                # conflict returns 1 above), so report 0 conflicts.
                 if type ux_success >/dev/null 2>&1; then
-                    ux_success "Cherry-picked $picked/$count commits successfully! (Skipped $skipped empty)"
+                    ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
+                    if [ "$empty_skipped" -gt 0 ]; then
+                        ux_info "($empty_skipped empty commit(s) also skipped)"
+                    fi
+                else
+                    echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
+                    if [ "$empty_skipped" -gt 0 ]; then
+                        echo "  ($empty_skipped empty commit(s) also skipped)"
+                    fi
                 fi
             fi
         else

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -355,6 +355,93 @@ teardown() {
     refute_output --partial "gcp: alias"
 }
 
+# ---------------------------------------------------------------------------
+# Issue #811 — individual (non-contiguous) cherry-pick auto-skips Stage-1
+# duplicates with a log line, instead of attempting them and conflicting.
+#
+# Fixture commit tree (author = all, so author filter is a no-op):
+#   main:   C0 "init"  ->  M1 "shared dup subject"
+#   source: C0 "init"  ->  S1 "feat one" -> S2 "shared dup subject" -> S3 "feat three"
+# S2 shares M1's subject (dup) but a different patch, so `git cherry` still
+# lists it as missing. final_selected_list = {S1,S3} (count 2) but the range
+# S1^..S3 spans 3 commits -> non-contiguous -> individual cherry-pick path.
+# ---------------------------------------------------------------------------
+
+_gcp811_make_repo() {
+    # Emits shell that builds the dup fixture in a fresh temp repo and cds in.
+    cat <<'FIXTURE'
+        repo="$(mktemp -d)"
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
+        echo three > f3.txt && git add f3.txt && git commit -qm "feat three"
+        git checkout -q main
+        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
+FIXTURE
+}
+
+@test "scan #811: non-contiguous dup is skipped (not cherry-picked) with base SHA logged" {
+    run_in_bash "
+        $(_gcp811_make_repo)
+        base_dup_sha=\$(git rev-parse --short main)
+        printf 'y\n' | _gcp_scan main source --author=all
+    "
+    assert_success
+    # F-3: skip log naming the matching base SHA.
+    assert_output --partial "Skipping"
+    assert_output --partial "already applied as"
+    assert_output --partial "(duplicate subject)"
+    # F-4: summary reports 1 dup skipped, 0 conflicts.
+    assert_output --partial "skipped (dup), 0 conflicts"
+    # The dup commit's own file must NOT have been applied to main.
+    refute_output --partial "CONFLICT"
+}
+
+@test "scan #811: dup commit's payload is absent, non-dup commits are applied" {
+    run_in_bash "
+        $(_gcp811_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=all >/dev/null 2>&1
+        # Non-dup commits applied:
+        git cat-file -e HEAD:f1.txt && echo HAS_F1
+        git cat-file -e HEAD:f3.txt && echo HAS_F3
+        # Dup commit (f2.txt) skipped -> absent on main:
+        git cat-file -e HEAD:f2.txt 2>/dev/null && echo HAS_F2 || echo NO_F2
+    "
+    assert_success
+    assert_output --partial "HAS_F1"
+    assert_output --partial "HAS_F3"
+    assert_output --partial "NO_F2"
+}
+
+@test "scan #811: contiguous no-dup path is unchanged (NF-1) — clean range pick" {
+    run_in_bash '
+        repo="$(mktemp -d)"
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo two > f2.txt && git add f2.txt && git commit -qm "feat two"
+        git checkout -q main
+        printf "y\n" | _gcp_scan main source --author=all
+        git cat-file -e HEAD:f1.txt && echo HAS_F1
+        git cat-file -e HEAD:f2.txt && echo HAS_F2
+    '
+    assert_success
+    assert_output --partial "Range is contiguous"
+    assert_output --partial "Cherry-pick complete"
+    assert_output --partial "HAS_F1"
+    assert_output --partial "HAS_F2"
+    refute_output --partial "skipped (dup)"
+}
+
 @test "alias-shadow: 'gcp -h' invokes dispatcher (not shadowed git cherry-pick) in zsh (#700)" {
     run zsh -f -c "
         export DOTFILES_ROOT='${DOTFILES_ROOT}'

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -370,7 +370,7 @@ teardown() {
 _gcp811_make_repo() {
     # Emits shell that builds the dup fixture in a fresh temp repo and cds in.
     cat <<'FIXTURE'
-        repo="$(mktemp -d)"
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
         cd "$repo" || exit 1
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
@@ -420,7 +420,7 @@ FIXTURE
 
 @test "scan #811: contiguous no-dup path is unchanged (NF-1) — clean range pick" {
     run_in_bash '
-        repo="$(mktemp -d)"
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
         cd "$repo" || exit 1
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"


### PR DESCRIPTION
## 요약

`gcp scan` 의 non-contiguous range 폴백(individual cherry-pick) 경로가
Stage-1 에서 감지한 duplicate commit 을 `final_selected_list` 에서 조용히
누락시키기만 하고, 사용자에게 무엇이 왜 건너뛰어졌는지 알리지 않던 문제를
정정한다. 이제 individual 루프는 author-filter 전체 목록을 순회하며 dup
commit 을 **명시적으로 skip** 하고, 매칭된 base SHA 와 함께 한 줄 로그를
출력한다. contiguous range 경로(single `cherry-pick A^..B`)는 변경 없음.

## 변경 내용 (commit: 0700b2a)

- `_gcp_scan_dup_base_sha` 헬퍼 추가 — dup source SHA → 매칭 base SHA 조회 (F-1)
- dup 감지 시 매칭된 base SHA 를 `duplicate_map` 에 기록
- individual cherry-pick 루프가 `selected_list` 전체를 순회하며 dup 을
  `git cherry-pick` 시도 없이 skip + 로그 출력 (F-2/F-3):
  `ℹ Skipping <sha> — already applied as <base-sha> (duplicate subject)`
- 루프 종료 후 F-4 요약: `✓ N applied, M skipped (dup), 0 conflicts`
- empty-commit skip 카운트를 dup-skip 과 분리

## 수용 기준 매핑

- [x] dup 이 non-contiguous 일 때 `git cherry-pick` 시도 없이 자동 skip
- [x] skip 된 SHA 마다 매칭 base SHA 를 한 줄 로그로 출력
- [x] dup 이 아닌 SHA 의 cherry-pick 동작 불변 (성공 시 commit, 실제 conflict 시 대기)
- [x] contiguous range 경로 동작/출력 불변 (NF-1)
- [x] bats 3 시나리오 추가 (dup-skip / payload-absent / contiguous-unchanged)

## 테스트

- `tests/bats/functions/gcp.bats` — 37 tests pass (신규 #811 시나리오 3건 포함)
- bash/zsh parse check 통과, pre-commit 훅 (shellcheck + naming) green

## 비고

issue 본문은 "patch-id match" 로 표현했으나 현 구현의 dup 감지는 **subject
(commit message) 매칭** 이다(Non-Goal: 감지 로직 변경 금지). 따라서 로그
문구는 실제 메커니즘에 맞춰 `(duplicate subject)` 로 표기했다.

Closes #811

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
