### PR TITLE
fix(project-board): #813 post-gh-pr-create 훅 auto-add 레이스 흡수 — poll-until-In-review

### DIFF
--- a/claude/hooks/post-gh-pr-create.sh
+++ b/claude/hooks/post-gh-pr-create.sh
@@ -97,8 +97,58 @@ _helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_statu
 GH_REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)}"
 export GH_REPO
 
+# Absorb the projectV2 "Auto-add to project" race: when this
+# hook fires, GitHub's builtin auto-add workflow may not have placed the
+# brand-new PR on the board yet. `_gh_project_status_sync` then finds zero
+# project items and quietly no-ops (its empty-`_records` early return),
+# while GitHub auto-adds the card moments later in the default "Backlog"
+# column — leaving the PR stuck. (Issues never hit this: they are board
+# members from creation, long before any sync.) The helper's verify pair
+# only re-fights a builtin that *overwrites* our write, not one that adds
+# the item *after* we looked. So poll: re-sync until the card exists and
+# reaches "In review", bounded so boardless repos exit immediately.
+#
+# Tunables (env): POST_GH_PR_CREATE_SYNC_ATTEMPTS (default 6),
+#                 POST_GH_PR_CREATE_SYNC_SLEEP    (default 2 seconds).
+
+# True (rc 0) when GH_REPO has >=1 projectV2 board. Used once, up front, so a
+# repo with no board skips the retry budget entirely (the sync would no-op
+# forever otherwise).
+_post_gh_pr_create_repo_has_board() {
+    [ -n "$GH_REPO" ] || return 1
+    local _o="${GH_REPO%/*}" _n="${GH_REPO#*/}" _cnt
+    [ -n "$_o" ] && [ -n "$_n" ] || return 1
+    # GraphQL variables ($o, $n) are bound via the -f flags below, so the
+    # single-quoted query intentionally does not shell-expand.
+    # shellcheck disable=SC2016
+    _cnt=$(gh api graphql \
+        -f query='query($o:String!,$n:String!){repository(owner:$o,name:$n){projectsV2(first:1){totalCount}}}' \
+        -f o="$_o" -f n="$_n" --jq '.data.repository.projectsV2.totalCount' 2>/dev/null) || return 1
+    [ "${_cnt:-0}" -gt 0 ] 2>/dev/null
+}
+
 printf '[post-gh-pr-create] PR #%s → "In review"\n' "$pr_num" >&2
-_gh_project_status_sync pr "$pr_num" "In review"
+if _post_gh_pr_create_repo_has_board; then
+    _attempts="${POST_GH_PR_CREATE_SYNC_ATTEMPTS:-6}"
+    _i=1
+    while [ "$_i" -le "$_attempts" ]; do
+        _gh_project_status_sync pr "$pr_num" "In review"
+        if [ "$(_gh_project_status_query_current pr "$pr_num")" = "In review" ]; then
+            break
+        fi
+        if [ "$_i" -lt "$_attempts" ]; then
+            sleep "${POST_GH_PR_CREATE_SYNC_SLEEP:-2}"
+        fi
+        _i=$((_i + 1))
+    done
+    if [ "$_i" -gt "$_attempts" ]; then
+        printf '[post-gh-pr-create] PR #%s still not "In review" after %s attempts — GitHub auto-add may have landed late; verify the board.\n' \
+            "$pr_num" "$_attempts" >&2
+    fi
+else
+    # No board attached → single call keeps the helper's silent no-op contract.
+    _gh_project_status_sync pr "$pr_num" "In review"
+fi
 
 if [ -n "$GH_REPO" ]; then
     for _issue in $(_gh_pr_closing_issue_numbers "$pr_num" "$GH_REPO" 2>/dev/null); do

--- a/claude/hooks/post-gh-pr-create.sh
+++ b/claude/hooks/post-gh-pr-create.sh
@@ -119,7 +119,9 @@ _post_gh_pr_create_repo_has_board() {
     local _o="${GH_REPO%/*}" _n="${GH_REPO#*/}" _cnt
     [ -n "$_o" ] && [ -n "$_n" ] || return 1
     # GraphQL variables ($o, $n) are bound via the -f flags below, so the
-    # single-quoted query intentionally does not shell-expand.
+    # single-quoted query intentionally does not shell-expand. Both are
+    # String! → -f (raw string) is the correct flag, never -F (issue #395).
+    # Variables: $o String!, $n String!
     # shellcheck disable=SC2016
     _cnt=$(gh api graphql \
         -f query='query($o:String!,$n:String!){repository(owner:$o,name:$n){projectsV2(first:1){totalCount}}}' \

--- a/tests/bats/skills/post_gh_pr_create_hook.bats
+++ b/tests/bats/skills/post_gh_pr_create_hook.bats
@@ -183,3 +183,97 @@ EOF
         bash -c "printf '%s' '{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh pr create\"},\"tool_response\":{\"output\":\"https://github.example.com/owner/repo/pull/42\"}}' | '$HOOK'"
     grep -q '^sync pr 42 In review$' "$CALL_LOG"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #813 — projectV2 "Auto-add to project" race (poll-until-In-review)
+#
+# The hook now probes for a board up front (_post_gh_pr_create_repo_has_board
+# via `gh api graphql`) and, when a board exists, re-syncs in a bounded loop
+# until _gh_project_status_query_current reports "In review" — absorbing the
+# window where GitHub's builtin auto-add lands the PR card *after* our first
+# look. Boardless repos keep the single-call silent no-op contract.
+#
+# These three cases stage a fake `gh` on PATH (board count) plus a
+# query_current stub (when the card flips to "In review").
+# ---------------------------------------------------------------------------
+
+@test "T14 (#813): no projectV2 board → single sync, retry loop skipped" {
+    # has-board probe returns 0 → the hook must take the else branch: exactly
+    # one sync and zero query_current calls (the loop is never entered, so a
+    # boardless repo does not burn the retry budget spinning on a no-op).
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    cat > "$TEST_TEMP_HOME/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Fake gh: report ZERO projectV2 boards for the has-board probe.
+[ "$1 $2" = "api graphql" ] && { echo 0; exit 0; }
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/gh"
+    # query_current logs every call so its ABSENCE proves the loop was skipped.
+    cat > "$FAKE_SHELL_COMMON/functions/gh_project_status.sh" <<EOF
+_gh_project_status_sync() { printf 'sync %s\n' "\$*" >> "$CALL_LOG"; return 0; }
+_gh_project_status_query_current() { printf 'query %s\n' "\$*" >> "$CALL_LOG"; echo "Backlog"; }
+_gh_pr_closing_issue_numbers() { return 0; }
+EOF
+    export PATH="$TEST_TEMP_HOME/bin:$PATH"
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create"},"tool_response":{"output":"https://github.com/owner/repo/pull/55"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ "$(grep -c '^sync pr 55 In review$' "$CALL_LOG")" -eq 1 ]
+    ! grep -q '^query ' "$CALL_LOG"
+}
+
+@test "T15 (#813): board present, card lands late → poll until In review, no warning" {
+    # has-board probe returns 1; query_current reports Backlog on the 1st probe
+    # and In review on the 2nd — emulating auto-add landing the card between
+    # attempts. The loop must re-sync once, then break (exactly 2 sync calls)
+    # without emitting the budget-exhausted warning.
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    cat > "$TEST_TEMP_HOME/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+[ "$1 $2" = "api graphql" ] && { echo 1; exit 0; }
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/gh"
+    QC_COUNT="$TEST_TEMP_HOME/qc.count"; : > "$QC_COUNT"
+    cat > "$FAKE_SHELL_COMMON/functions/gh_project_status.sh" <<EOF
+_gh_project_status_sync() { printf 'sync %s\n' "\$*" >> "$CALL_LOG"; return 0; }
+_gh_project_status_query_current() {
+    n=\$(cat "$QC_COUNT" 2>/dev/null || echo 0); n=\$((n + 1)); echo "\$n" > "$QC_COUNT"
+    if [ "\$n" -ge 2 ]; then echo "In review"; else echo "Backlog"; fi
+}
+_gh_pr_closing_issue_numbers() { return 0; }
+EOF
+    export PATH="$TEST_TEMP_HOME/bin:$PATH"
+    export POST_GH_PR_CREATE_SYNC_SLEEP=0
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create"},"tool_response":{"output":"https://github.com/owner/repo/pull/77"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ "$(grep -c '^sync pr 77 In review$' "$CALL_LOG")" -eq 2 ]
+    ! echo "$output" | grep -q 'still not'
+}
+
+@test "T16 (#813): board present, never reaches In review → warning + exit 0" {
+    # query_current is stuck on Backlog. With attempts=2 the loop must sync
+    # twice, then warn (best-effort: still exit 0 so the user flow is never
+    # blocked).
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    cat > "$TEST_TEMP_HOME/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+[ "$1 $2" = "api graphql" ] && { echo 1; exit 0; }
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/gh"
+    cat > "$FAKE_SHELL_COMMON/functions/gh_project_status.sh" <<EOF
+_gh_project_status_sync() { printf 'sync %s\n' "\$*" >> "$CALL_LOG"; return 0; }
+_gh_project_status_query_current() { echo "Backlog"; }
+_gh_pr_closing_issue_numbers() { return 0; }
+EOF
+    export PATH="$TEST_TEMP_HOME/bin:$PATH"
+    export POST_GH_PR_CREATE_SYNC_SLEEP=0 POST_GH_PR_CREATE_SYNC_ATTEMPTS=2
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create"},"tool_response":{"output":"https://github.com/owner/repo/pull/88"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ "$(grep -c '^sync pr 88 In review$' "$CALL_LOG")" -eq 2 ]
+    assert_output --partial 'still not "In review" after 2 attempts'
+}


### PR DESCRIPTION
## 배경

`gh pr create` 직후 발화하는 PostToolUse 훅 `post-gh-pr-create.sh` 가 보드 sync 를 **1회만** 호출했다. GitHub projectV2 builtin "Auto-add to project" 워크플로가 새 PR 카드를 보드에 올리기 **전에** 훅의 sync 가 도달하면, `_gh_project_status_sync` 가 빈 project-item 레코드를 보고 조용히 no-op(empty-`_records` early-return) → PR 이 기본 "Backlog" 칼럼에 갇혔다.

이슈 카드는 같은 문제를 안 겪는다(생성 시점부터 보드 멤버). 헬퍼의 verify pair 는 "우리 쓰기를 *덮어쓰는*" builtin 만 재경쟁하고, "우리가 조회한 *뒤에* 항목을 *추가하는*" auto-add 는 막지 못하는 비대칭이 근본 원인이다.

원래 이 변경은 2026-05-29 `main` 워킹트리에 추적 이슈 없는 미커밋 잔여 WIP 로 발견되어, 이슈 #813 신설 + 격리 워크트리에서 정식화했다.

## 변경 사항 (커밋별)

- **c1879e2** `fix(project-board): post-gh-pr-create 훅 auto-add 레이스 흡수`
  - `_post_gh_pr_create_repo_has_board()` 신설 — GraphQL `projectsV2(first:1){totalCount}` 로 보드 유무 선검사. 보드 없는 repo 는 재시도 예산을 건너뛰고 단발 호출(헬퍼의 silent no-op 계약 유지).
  - 보드 있으면 `_gh_project_status_query_current` 가 `"In review"` 를 보고할 때까지 bounded poll. 예산 소진 시 stderr 경고 후 `exit 0`(board sync 는 best-effort, 사용자 흐름 비차단).
  - 튜너블: `POST_GH_PR_CREATE_SYNC_ATTEMPTS`(기본 6), `POST_GH_PR_CREATE_SYNC_SLEEP`(기본 2초).
  - 테스트 `post_gh_pr_create_hook.bats` 에 T14-T16 추가.

- **410f51c** `fix(project-board): gh api graphql 변수 타입 주석 추가`
  - has-board probe 호출부에 `# Variables: $o String!, $n String!` 주석(issue #395 컨벤션) — pre-commit `gh_api_type_check` WARN 해소. 둘 다 `String!` 이라 `-f`(raw string) 가 정답.

## 테스트

| 케이스 | 검증 |
|---|---|
| T14 | 보드 없음 → 단발 sync, 재시도 루프 skip (query_current 미호출) |
| T15 | 보드 있음 + 카드 늦게 도착 → 2번째 폴에서 "In review" → break, 경고 없음 |
| T16 | 보드 있음 + 영영 "In review" 안 됨 → 경고 출력 + exit 0 |

- `bats post_gh_pr_create_hook.bats`: **14/14 통과** (기존 11 회귀 + 신규 3)
- `shellcheck`: PASS
- `shfmt -i 4`: clean

## 영향 범위

projectV2 + auto-add 가 켜진 repo 에서 `gh pr create` 하는 모든 사용자. 비파괴적 — 보드 없는 repo 는 기존 단발 호출 경로 그대로. 항상 `exit 0`(best-effort).

Closes #813

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
