### PR TITLE
chore(claude): settings.json autoUpdatesChannel latest 설정 추가

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -42,5 +42,6 @@
   "theme": "dark",
   "telemetry": {
     "enabled": false
-  }
+  },
+  "autoUpdatesChannel": "latest"
 }


### PR DESCRIPTION
## Summary

Claude Code 설정에 `autoUpdatesChannel: "latest"` 를 추가하여 자동 업데이트 채널을 `latest` 로 고정한다.

## Changes

- `claude/settings.json`: `autoUpdatesChannel` 키 `latest` 추가

## Test

- N/A — 단일 JSON 설정 추가 (shell/python 린트 대상 아님)
