### PR TITLE
refactor(devx-ai-context): #815 Check 7 stop-on-error + Check 12 model_recommendation 메타데이터

### DIFF
--- a/claude/skills/devx-ai-context/SKILL.md
+++ b/claude/skills/devx-ai-context/SKILL.md
@@ -91,7 +91,7 @@ FAIL, else `[FAIL]`. Always end with a `Next:` line per the same file.
 
 ## Constraints
 
-- If any Step 1–3 precondition fails, report it via `references/report-template.md` with Verdict=`[FAIL]` and stop — do not advance to the next step.
+- If any Step 1–3 step fails for a genuine reason (NOT a help print or a `skill:check` / `sh:check` routing stop — those are intentional early exits), report it via `references/report-template.md` with Verdict=`[FAIL]` and stop. The stop-on-error policy and `[FAIL]` report still apply to all other Step 1–3 failures.
 - `check` is audit-only — never mutate the file.
 - Always confirm before overwriting in `create` / `refactor`.
 - Auto-overwrite is never allowed when multiple context files exist.

--- a/claude/skills/devx-ai-context/SKILL.md
+++ b/claude/skills/devx-ai-context/SKILL.md
@@ -12,13 +12,17 @@ description: >-
   adapter (agents / claude / gemini). Do NOT use for SKILL.md (use skill:check)
   or for shell scripts (use sh:check).
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "dispatcher with bounded mutation (create/refactor write under confirmation); moderate analysis, not deep implementation"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:ai-context — Unified AI Context Doc Skill
 
-Replaces `agents-md:{check,create,refactor}` and `claude-md-{check,create}`.
-Legacy skills have been deleted (issue #560) — see
-`references/help.md` for the migration table.
+Replaces `agents-md:{check,create,refactor}` / `claude-md-{check,create}` (deleted in #560 — see `references/help.md` migration table).
 
 ## Help
 
@@ -82,17 +86,15 @@ extract sections and slim the root.
 
 ## Step 4: Report
 
-Use the template in `references/report-template.md` for every action.
-Verdict is `[OK]` if no FAIL, else `[FAIL]`. Always end with a `Next:`
-line per the same file.
+Use `references/report-template.md` for every action. Verdict `[OK]` if no
+FAIL, else `[FAIL]`. Always end with a `Next:` line per the same file.
 
 ## Constraints
 
+- If any Step 1–3 precondition fails, report it via `references/report-template.md` with Verdict=`[FAIL]` and stop — do not advance to the next step.
 - `check` is audit-only — never mutate the file.
 - Always confirm before overwriting in `create` / `refactor`.
 - Auto-overwrite is never allowed when multiple context files exist.
 - Honor `--file` and `--type` overrides over auto-detection.
-- Cite `references/industry-baseline.md` when stating rationale for adapter
-  checks (Codex / Claude Code / Gemini CLI official docs).
-- Do NOT run on `SKILL.md` (route to `skill:check`) or `*.sh` (route to
-  `sh:check`).
+- Cite `references/industry-baseline.md` for adapter-check rationale (Codex / Claude Code / Gemini CLI docs).
+- Do NOT run on `SKILL.md` (route to `skill:check`) or `*.sh` (route to `sh:check`).


### PR DESCRIPTION
## Summary
- `devx:ai-context` skill 의 `skill:check` 감사(10/12 PASS, 2 WARN) 에서 지적된 두 WARN 을 자체 처리한다.
- Check 7 (Step Structure) 과 Check 12 (Model Recommendation Metadata) 를 모두 해소해 12/12 PASS 를 목표로 한다.
- 동작 변경 없음 — line count 100 (≤100) 유지.

## Changes
- `refactor(devx-ai-context)`: `## Constraints` 에 단일 stop-on-error 정책 문장 추가 — Step 1–3 precondition 실패 시 `references/report-template.md` 로 `[FAIL]` 리포트 후 중단 (Check 7).
- `refactor(devx-ai-context)`: frontmatter 에 `metadata.model_recommendation` 블록 추가 (tier=sonnet, reason, claude=prefer, non_claude=advisory-only) — 분기형 dispatcher 라 read-only 룩업(haiku) 도 깊은 구현(opus) 도 아니므로 sonnet (Check 12, rubric SSOT `skill-check/references/model-recommendation.md`).
- 추가 7줄(메타데이터 6 + 제약 1)을 동작 무변경 prose 압축(intro/Step 4/Constraints)으로 상쇄해 100 라인 유지.

## Test plan
- [ ] `/skill:check claude/skills/devx-ai-context` → 12/12 PASS 확인
- [ ] SKILL.md 라인 수 ≤ 100 (현재 100)
- [ ] frontmatter YAML 파싱 유효 + `metadata.model_recommendation.tier == sonnet`
- [ ] check/create/refactor dispatch 및 `--file`/`--type` 오버라이드 동작 무변경

## Related
Closes #815

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
