### PR TITLE
refactor(ai-worktree-teardown): #832 skill:check FAIL/WARN 해소 — Help 플래그 + model_recommendation

### DIFF
--- a/claude/skills/ai-worktree-teardown/SKILL.md
+++ b/claude/skills/ai-worktree-teardown/SKILL.md
@@ -7,15 +7,23 @@ description: >-
   "워크트리 정리", "teardown", "cleanup worktree", "작업 완료", "워크트리 제거",
   or any request to clean up after finishing work in a worktree.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "structured CLI wrapper — git worktree cleanup; low reasoning"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # AI Worktree Teardown
 
-Remove an AI worktree and sync main after work is complete.
-This is the reverse of `ai-worktree:spawn`.
+## Help
 
-**Must run from the main repo**, not from inside the worktree.
-The worktree path is passed as an argument (e.g., `/ai-worktree:teardown ~/dotfiles-claude-2`).
+If arg #1 is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
+
+Remove an AI worktree and sync main after work is complete — the reverse of
+`ai-worktree:spawn`. **Must run from the main repo**, not inside the worktree.
+The worktree path is an argument (e.g., `/ai-worktree:teardown ~/dotfiles-claude-2`).
 
 Read `references/options-and-errors.md` for CLI options and error handling.
 
@@ -31,25 +39,21 @@ actions) and stop. No destructive action.
 
 ### Step 1: Validate — Must Be in Main Repo, NOT a Worktree
 
-Check `git-dir == git-common-dir`. If INSIDE a worktree, print error and stop.
-This is the same check as spawn — both run from the main repo.
+Check `git-dir == git-common-dir`. If INSIDE a worktree, print error and stop
+(same check as spawn — both run from the main repo).
 
 Require a `<worktree-path>` argument. If missing, list existing worktrees and stop.
 
 ### Step 2: Resolve Worktree Info
 
-From the given `<worktree-path>`, extract:
-- `WORKTREE_PATH` — resolved absolute path
-- `BRANCH` — branch checked out in that worktree (via `git worktree list`)
-- `WORKTREE_NAME` — basename of worktree path
-
-Verify the path is a known worktree. If not, print error and stop.
+From `<worktree-path>`, resolve `WORKTREE_PATH` (absolute), `BRANCH` (checked
+out there, via `git worktree list`), and `WORKTREE_NAME` (basename). Verify it
+is a known worktree; if not, print error and stop.
 
 ### Step 3: Pre-flight Checks
 
-Use `git -C <worktree-path>` to check for uncommitted changes or unpushed commits.
-Block on issues to prevent work loss.
-Skip these checks if `--force` is given.
+Use `git -C <worktree-path>` to check for uncommitted changes or unpushed
+commits. Block to prevent work loss. Skip these checks if `--force` is given.
 
 ### Step 4: Remove Worktree
 
@@ -78,9 +82,8 @@ Append `TEARDOWN` entry to `ai-worktree-spawn.log` (same file as spawn).
   Branch:   wt/gemini/1 (deleted)
   Now on:   main (up to date with origin/main)
 
-  Note: if your outer shell (the one that launched claude) was cd'd
-  inside the removed worktree, run `cd <main-repo>` there now —
-  otherwise its next prompt will spew `getcwd: cannot access parent
+  Note: if your outer shell was cd'd inside the removed worktree, run
+  `cd <main-repo>` there now to avoid `getcwd: cannot access parent
   directories` errors from zsh/pyenv/p10k.
 ```
 
@@ -92,7 +95,6 @@ On failure, emit a structured failure verdict instead:
   Detail:  <error message or exit code>
 ```
 
-Always include the `Note:` block on the `[OK]` path — the skill cannot
-detect the outer shell's cwd, so the hint is unconditional. Substitute
-`<main-repo>` with the absolute path of the main repo this skill is
-running from (`git rev-parse --show-toplevel`).
+Always include the `Note:` block on `[OK]` — the outer shell's cwd is
+undetectable, so the hint is unconditional. Substitute `<main-repo>` with
+`git rev-parse --show-toplevel`.

--- a/claude/skills/ai-worktree-teardown/references/help.md
+++ b/claude/skills/ai-worktree-teardown/references/help.md
@@ -4,6 +4,7 @@
 
 ```
 /ai-worktree:teardown <worktree-path> [--force] [--keep-branch] [--dry-run]
+/ai-worktree:teardown [-h | --help | help]
 ```
 
 Run from the **main repo** (not from inside a worktree).

--- a/claude/skills/ai-worktree-teardown/references/help.md
+++ b/claude/skills/ai-worktree-teardown/references/help.md
@@ -1,0 +1,41 @@
+# skill:ai-worktree-teardown — Help
+
+## Synopsis
+
+```
+/ai-worktree:teardown <worktree-path> [--force] [--keep-branch] [--dry-run]
+```
+
+Run from the **main repo** (not from inside a worktree).
+
+## Description
+
+Clean up an AI worktree after work is done — remove the worktree, sync main,
+and delete the branch. The reverse of `ai-worktree:spawn`. The worktree path
+is passed as an argument (e.g., `/ai-worktree:teardown ~/dotfiles-claude-2`).
+
+## Arguments
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<worktree-path>` | Path to the worktree to remove (required). | — |
+| `--force` | Skip pre-flight checks, force-remove a dirty worktree, force-delete an unmerged branch. | `false` |
+| `--keep-branch` | Don't delete the branch after removing the worktree. | `false` |
+| `--dry-run` | Print the plan (worktree path, branch, intended actions) without executing anything. | `false` |
+| `-h` / `--help` / `help` | Print this help and stop. | — |
+
+## Examples
+
+```
+/ai-worktree:teardown ~/dotfiles-claude-2
+/ai-worktree:teardown ~/dotfiles-claude-2 --dry-run
+/ai-worktree:teardown ~/dotfiles-claude-2 --force --keep-branch
+/ai-worktree:teardown -h
+```
+
+## Stop conditions
+
+- Inside a worktree (not the main repo) → print error with a `cd` hint, stop.
+- Missing `<worktree-path>` argument → list active worktrees, stop.
+- Path is not a known worktree → print error, list active worktrees, stop.
+- Uncommitted changes or unpushed commits in the worktree → warn, stop (unless `--force`).


### PR DESCRIPTION
## Summary

`ai-worktree-teardown` 스킬의 `/skill:check` 감사 결과(9/12 PASS, 2 WARN, 1 FAIL)를 해소한다.

- **Check 6 (Help Flag) FAIL → PASS**: `SKILL.md` 에 `## Help` 섹션 추가(verbatim read+stop 패턴), `references/help.md` 신규 작성. 자매 스킬 `ai-worktree-spawn` 의 help.md 골격(Synopsis/Description/Arguments/Examples/Stop conditions)을 따른다.
- **Check 12 (Model Recommendation) WARN → PASS**: frontmatter 에 `metadata.model_recommendation` 블록 추가 (tier=haiku, claude=prefer, non_claude=advisory-only).
- **100줄 한도 유지**: Help 섹션 + metadata 로 +12줄 발생분을 본문 prose 압축으로 상쇄 — 최종 100줄(≤100). 기존 teardown 동작(`--force`/`--keep-branch`/`--dry-run`) 무변경.

## Changes

- `claude/skills/ai-worktree-teardown/SKILL.md` — frontmatter metadata + `## Help` 섹션 추가, 본문 압축
- `claude/skills/ai-worktree-teardown/references/help.md` — 신규 (Usage/Arguments/Examples/Stop conditions)

## Test

문서 전용 스킬 변경 — 코드 테스트 러너 무관. 검증: 라인 수 100(≤100), 이모지 없음, FAIL/WARN 3개 항목 해소.

Closes #832

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
