### PR TITLE
chore(skills): #860 카테고리 B — devx-* GOOD 8개 model_recommendation 메타데이터 추가

### DIFF
--- a/claude/skills/devx-exception-merge-checklist/SKILL.md
+++ b/claude/skills/devx-exception-merge-checklist/SKILL.md
@@ -14,6 +14,12 @@ description: >-
   `[<PR#>] [--skip-bisect] [--auto-fix] [--build-cmd <cmd>]` and
   `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep, Glob, Edit
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "checklist generation with low reasoning; 10 read-only checks aggregated"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:exception-merge-checklist — Pre-merge 10-point sanity check
@@ -85,16 +91,8 @@ by other skills. `GH_DISABLE_AI_METRICS=1` skips this step entirely
 
 ## Constraints
 
-- **Read-only default.** Never merge, approve, push, or edit PR
-  body / labels. Only `--auto-fix` mutates, and only as far as
-  `git add`.
-- **No fail-fast.** All 10 checks run. Aggregating in one pass is
-  the whole point of the skill.
-- **C6 opt-out via `--skip-bisect` only.** C7–C10 are not
-  opt-outable — that would re-open the regression gap.
-- **Exit codes**: `0` (all PASS or only WARN) / `1` (≥ 1 FAIL) /
-  `2` (bad args, missing remote) / `3` (no PR detected).
-- **Never silently switch the build command.** If `--build-cmd` is
-  not given and `bun run build` does not exist in the repo, mark
-  C6 `N/A` with the reason — do NOT guess `npm test`.
-- **Never auto-commit.** `--auto-fix` stages only.
+- **Read-only default.** Never merge, approve, push, or edit PR body/labels. Only `--auto-fix` mutates, and only as far as `git add` (never `git commit`).
+- **No fail-fast.** All 10 checks run — aggregating in one pass is the whole point.
+- **C6 opt-out via `--skip-bisect` only.** C7–C10 are not opt-outable — that would re-open the regression gap.
+- **Exit codes**: `0` (all PASS or only WARN) / `1` (≥ 1 FAIL) / `2` (bad args, missing remote) / `3` (no PR detected).
+- **Never silently switch the build command.** If `--build-cmd` is absent and `bun run build` does not exist, mark C6 `N/A` with the reason — do NOT guess `npm test`.

--- a/claude/skills/devx-prd-to-trd/SKILL.md
+++ b/claude/skills/devx-prd-to-trd/SKILL.md
@@ -13,6 +13,12 @@ description: >-
   upstream slot in the PRD → TRD → Milestones+Issues pipeline. Accepts
   `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "PRD → multi-TRD decomposition; 8-section standard mapping; structured reasoning"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:prd-to-trd — PRD → per-component TRD scaffolds
@@ -89,7 +95,6 @@ Print the verdict:
 [OK] devx:prd-to-trd plan=<path> components=<n> [scaffolds=<n> skipped=<n>]
 ```
 
-`scaffolds=` and `skipped=` appear only on `--apply`. For dry-run,
-append `Next: review <plan-out>, then re-run with --apply`.
-
-Operational constraints: see `references/constraints.md`.
+`scaffolds=` and `skipped=` appear only on `--apply`. For dry-run, append
+`Next: review <plan-out>, then re-run with --apply`. Operational
+constraints: see `references/constraints.md`.

--- a/claude/skills/devx-rate-limit-guard/SKILL.md
+++ b/claude/skills/devx-rate-limit-guard/SKILL.md
@@ -11,6 +11,12 @@ description: >-
   user to know their reset time (run /usage first). Accepts `-h`/`--help`/`help`
   to print usage.
 allowed-tools: Bash, Read, Write, CronCreate, CronDelete
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "scheduling wrapper (CronCreate); low reasoning; deterministic cron spec generation"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:rate-limit-guard — Rate-Limit Resume Safety Net

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -15,6 +15,12 @@ description: >-
   in the conversation — it resumes from the implementation step they led
   to. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep, Agent, TaskList, TaskUpdate
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "interrupt recovery orchestration; TodoList interpretation + 1-tool-call chunking + subagent delegation"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:restart — Resume After API Error
@@ -87,13 +93,8 @@ and for the per-step / `Next:` line rules. Both Step 2 (announce) and Step 4
 
 ## Constraints
 
-- Never re-run a process skill that already produced output earlier in the
-  conversation — read its result from context instead.
-- Never batch tool calls "to be efficient" inside this skill; the whole
-  premise is that the previous batch died mid-way.
-- Never modify TodoList task subjects — only status. The user wrote the
-  subjects; rewriting them loses intent.
-- Never silently skip the announce line in Step 2 — the user needs to see
-  what you picked up so they can correct it cheaply if it's wrong.
-- Never invoke this skill from inside another skill. It is user-triggered
-  recovery, not a programmable building block.
+- Never re-run a process skill that already produced output earlier — read its result from context.
+- Never batch tool calls "to be efficient"; the premise is that the previous batch died mid-way.
+- Never modify TodoList task subjects — only status (rewriting them loses the user's intent).
+- Never silently skip the Step 2 announce line — the user must see what you picked up to correct it cheaply.
+- Never invoke this skill from inside another skill — it is user-triggered recovery, not a building block.

--- a/claude/skills/devx-resume-after-limit/SKILL.md
+++ b/claude/skills/devx-resume-after-limit/SKILL.md
@@ -11,6 +11,12 @@ description: >-
   argument (cron path) or reads `.claude/.rate-limit-guard.json` (manual
   re-trigger). Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Write, CronCreate, CronDelete
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "cron-driven re-run wrapper, low reasoning"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:resume-after-limit — Resume After Rate-Limit Reset
@@ -36,8 +42,7 @@ test -f .claude/.rate-limit-guard.json && cat .claude/.rate-limit-guard.json
 ```
 
 Parse `command`, `worktree`, `branch`, `max_cycles`, `cycles_remaining`,
-`cycle_window_min` (jq or Python). Missing multi-cycle fields default to
-`max_cycles=1`, `cycles_remaining=1`, `cycle_window_min=305` (PR #369 compat).
+`cycle_window_min` (jq/Python). Missing multi-cycle fields default to `max_cycles=1`, `cycles_remaining=1`, `cycle_window_min=305` (PR #369 compat).
 
 ### 2. Resolve the Command
 
@@ -57,9 +62,8 @@ PWD_NOW=$(pwd); BRANCH=$(git branch --show-current 2>/dev/null || echo unknown)
 ### 4. Pre-emptive Re-arm
 
 If `cycles_remaining > 1`, register the next cycle's cron **before** running
-the wrapped command per `references/preemptive-rearm.md` (fire-time
-arithmetic, `CronCreate` args, state-file rewrite). Save `<NEXT_ID>` for
-Step 7. Otherwise skip.
+the wrapped command per `references/preemptive-rearm.md` (fire-time arithmetic,
+`CronCreate` args, state-file rewrite). Save `<NEXT_ID>` for Step 7. Else skip.
 
 ### 5. Announce
 
@@ -72,8 +76,7 @@ Step 7. Otherwise skip.
 
 ### 6. Execute the Command
 
-Hand off to the wrapped command. The wrapped workflow's own idempotency
-handles already-done sub-steps.
+Hand off to the wrapped command. The wrapped workflow's own idempotency handles already-done sub-steps.
 
 ### 7. Cleanup on Success
 
@@ -85,12 +88,10 @@ rm -f .claude/.rate-limit-guard.json
 ```
 
 Print `[OK] 재개 완료 — 안전망 상태 파일 정리됨`.
-
-The just-fired cron auto-deleted (`recurring: false`); the next-cycle cron
-from Step 4 must be explicitly cancelled.
-
-On failure (transient or otherwise), **leave state + next cron** in place —
-the next fire re-triggers this skill, or the user re-invokes manually.
+The just-fired cron auto-deleted (`recurring: false`); the Step 4 next-cycle
+cron must be explicitly cancelled. On failure (transient or otherwise), **leave
+state + next cron** in place — the next fire re-triggers this skill, or the user
+re-invokes manually.
 
 ## Constraints
 

--- a/claude/skills/devx-reverse-engineering-analysis/SKILL.md
+++ b/claude/skills/devx-reverse-engineering-analysis/SKILL.md
@@ -10,6 +10,12 @@ description: >-
   and reproduce a codebase feature elsewhere. Always produces a markdown document
   in the specified output directory.
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
+metadata:
+  model_recommendation:
+    tier: opus
+    reason: "deep code analysis, large reasoning surface"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # DevX: Reverse Engineering Analysis
@@ -88,15 +94,7 @@ Required sections:
 - **File Map** — source files with roles
 - **AI Implementation Prompt** — copy-pasteable, no project-specific paths
 
-End with `[OK] analysis written: <path>` or `[FAIL] <reason>`.
+End with `[OK] analysis written: <path>` or `[FAIL] <reason>`. A pre-write
+quality checklist is in `references/output-template.md`.
 
 `Next: read <output_dir>/analysis.md and paste the AI Implementation Prompt section into the target project's AI assistant.`
-
----
-
-## Quality Checklist
-
-Before writing the output file:
-- [ ] No internal file paths leaked into the AI prompt
-- [ ] Library install commands correct for the ecosystem
-- [ ] Output written to `<output_dir>/analysis.md`

--- a/claude/skills/devx-reverse-engineering-analysis/references/output-template.md
+++ b/claude/skills/devx-reverse-engineering-analysis/references/output-template.md
@@ -62,3 +62,9 @@ Please implement this step by step, starting with [entry point].
 ## Notes
 [Any caveats, version-specific behaviors, or gotchas discovered during analysis]
 ```
+
+## Quality Checklist (verify before writing the output file)
+
+- [ ] No internal file paths leaked into the AI prompt
+- [ ] Library install commands correct for the ecosystem
+- [ ] Output written to `<output_dir>/analysis.md`

--- a/claude/skills/devx-schedule/SKILL.md
+++ b/claude/skills/devx-schedule/SKILL.md
@@ -8,6 +8,12 @@ description: >-
   "schedule /skill in N minutes", or "[command] N분 후에 해줘". Always invoke
   this skill whenever the user wants to defer any slash-command or task to
   run after a time delay.
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "simple cron registration"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # devx:schedule — Deferred Skill Executor

--- a/claude/skills/devx-ux-guidelines/SKILL.md
+++ b/claude/skills/devx-ux-guidelines/SKILL.md
@@ -6,6 +6,12 @@ description: >-
   commands, or ensuring consistent formatting with semantic UX functions
   (ux_header, ux_section, ux_bullet, etc).
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "convention-driven refactoring"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # UX Guidelines Skill


### PR DESCRIPTION
## 배경

umbrella #860 카테고리 B (권장 PR 분할 표의 **PR 2**). GOOD 판정 devx-* 8개 스킬에 `metadata.model_recommendation` 블록을 일괄 추가한다. rubric SSOT: `claude/skills/skill-check/references/model-recommendation.md`. 각 블록 값은 해당 sub-task 이슈의 audit 제안값을 그대로 사용.

## 변경 내용

### 메타데이터 추가 (tier별)

| Tier | 스킬 | sub-task |
|---|---|---|
| haiku | devx-exception-merge-checklist | #838 |
| haiku | devx-rate-limit-guard | #845 |
| haiku | devx-resume-after-limit | #817 |
| haiku | devx-schedule | #821 |
| sonnet | devx-prd-to-trd | #839 |
| sonnet | devx-restart | #849 |
| sonnet | devx-ux-guidelines | #831 |
| opus | devx-reverse-engineering-analysis | #819 |

모두 `claude: prefer` + `non_claude: advisory-only` (기존 ai-worktree-spawn / devx-ai-context 컨벤션과 동일).

### 본문 축소 (Check 1 ≤100줄 PASS 유지)

메타데이터(+6L) 추가로 100줄을 넘긴 5개를 축소 — #828 과 동일 패턴:

| 스킬 | 전 | 후 | 방법 |
|---|---|---|---|
| exception-merge-checklist | 106 | 98 | Constraints 불릿 1줄화 |
| resume-after-limit | 105 | 100 | 산문 압축 |
| restart | 105 | 100 | Constraints 불릿 1줄화 |
| prd-to-trd | 101 | 100 | Step 5 말미 병합 |
| reverse-engineering-analysis | 108 | 100 | #819 권고대로 Quality Checklist → references/output-template.md 추출 |

> reverse-engineering-analysis 는 audit 시점(#819)에 이미 102L Check 1 WARN 이었음 — 추출로 함께 해소.

## 검증

- 8개 전부 frontmatter YAML 파싱 유효 + `tier`/`reason`/`claude`/`non_claude` 필드 확인
- 8개 전부 SKILL.md ≤ 100L
- 변경 파일 이모지 0
- 대표 스킬(reverse-engineering-analysis) `/skill:check` **12/12 PASS**
- pre-commit hook 통과

## 완료 기준

- [x] 8개 sub-task 메타데이터 추가 (#838 #845 #817 #821 #839 #849 #831 #819)
- [x] 각 스킬 Check 1 + Check 12 PASS

Closes #838, #845, #817, #821, #839, #849, #831, #819
Refs #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)