### PR TITLE
chore(skills): #860 category C — gh-* GOOD 5개 model_recommendation 메타데이터 (PR 3)

### DIFF
--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -13,6 +13,12 @@ description: >-
   optional `--no-next-hint` (suppress final `Next:` hint), and
   `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+metadata:
+  model_recommendation:
+    tier: opus
+    reason: "deep implementation — repo-context reasoning, multi-file edits, test-failure loop, high-risk writes"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:issue-implement — Issue → Code
@@ -22,22 +28,23 @@ allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
 output its content verbatim, then stop. No API calls.
 
+**Stop-on-error policy** — HARD-abort: Step 1 preconditions, 3.1 fetch,
+3.2 block-label guard. Everything else (3.3–3.5 claim writes, Step 5 test
+loop) soft-fails or bounded-retries — a transient blip never blocks.
+
 ## Step 1: Parse Args + Resolve Repo + Preconditions
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 6.
-
-Positional args: `<issue-number> [mode] [remote]`. Optional flag: `--no-next-hint`.
+Record `START_TS=$(date +%s)` immediately for Step 6 elapsed tracking.
+Positional args: `<issue-number> [mode] [remote]`; flag `--no-next-hint`.
 
 - `issue-number` — required, positive integer.
-- `mode` — default `direct`. Must be `direct`, `plan`, or `brainstorming`.
+- `mode` — default `direct`; one of `direct` / `plan` / `brainstorming`.
 - `remote` — default `origin`. Resolve `TARGET_REPO=<owner>/<repo>` per
-  `references/repo-resolution.md`. Missing remote → list `git remote -v`
-  and stop (no silent fallback).
-- `--no-next-hint` — when present, omit the final `Next:` line in Step 6.
+  `references/repo-resolution.md`; missing → `git remote -v` + stop.
+- `--no-next-hint` — omit the final `Next:` line in Step 6.
 
 Check preconditions in parallel per `references/implementation-flow.md`
-→ "Preconditions" (in a `git` repo, not on default branch, clean tree).
-Fail-fast with the reasons from that file.
+→ "Preconditions" (git repo, not default branch, clean tree); fail-fast.
 
 ## Step 2: superpowers Plugin Detection
 
@@ -46,82 +53,48 @@ Per `references/superpowers-detection.md`: plugin missing → force mode
 
 ## Step 3: Fetch + Claim Issue
 
-Five substeps in order. Full policy, env vars, and behavior matrix in
-`references/claim.md`.
+Five substeps in order — full policy, env vars, and behavior matrix in
+`references/claim.md`. Emit each step-completion marker so the harness
+step-skip guard (`skill_completion_guard.py`, #753) can verify the run.
 
-3.1 **Fetch** — `references/fetch-issue.md` (CLOSED refusal handled there).
-    After `gh issue view` succeeds, emit the step-completion marker so
-    the harness step-skip guard (`skill_completion_guard.py`, issue #753)
-    can verify this step ran:
-    `printf '[step:gh-issue-implement/fetch-issue] OK\n'`.
-3.2 **Block-label guard** — fail-closed abort (exit 2) if any label on
-    the issue matches `GH_ISSUE_BLOCK_LABELS`
-    (default `do-not-work,on-hold,보류,⏸️ Postpone`).
-3.3 **Self-assign** — `gh issue edit <N> --add-assignee @me` when not
-    already on the assignee list; warn (no override) when held by
-    another user. Skip via `GH_ISSUE_SKIP_SELF_ASSIGN=1`. After the
-    assignee edit (or the warn path) finishes, emit:
+3.1 **Fetch** — `references/fetch-issue.md` (CLOSED refusal there). On
+    success: `printf '[step:gh-issue-implement/fetch-issue] OK\n'`.
+3.2 **Block-label guard** — fail-closed abort (exit 2) if any label
+    matches `GH_ISSUE_BLOCK_LABELS`.
+3.3 **Self-assign** — `--add-assignee @me` unless already assigned (warn,
+    no override, if held by another). After it (or the warn path):
     `printf '[step:gh-issue-implement/self-assign] OK\n'`.
-3.4 **Board Status transition** — `_gh_project_status_sync issue <N>
-    "In progress" --only-from "Backlog,Ready"`. No-op on repos without
-    a board. Skip via `GH_ISSUE_SKIP_BOARD_TRANSITION=1`. After the
-    helper returns (success, no-op, or skipped via env), emit:
-    `printf '[step:gh-issue-implement/board-transition] OK\n'`.
-3.5 **Depends-on guard** — soft-warn (continue) for each `Depends on
-    #M` line in the body whose `M` is still OPEN. Skip via
-    `GH_ISSUE_SKIP_DEPS_CHECK=1`.
+3.4 **Board transition** — `_gh_project_status_sync issue <N> "In
+    progress" --only-from "Backlog,Ready"`; no-op without a board. After
+    it: `printf '[step:gh-issue-implement/board-transition] OK\n'`.
+3.5 **Depends-on guard** — soft-warn per OPEN `Depends on #M` line.
 
-Only 3.1 fetch failures and 3.2 block-label hits abort the flow.
-3.3–3.5 are soft-fail (warn + continue) so a transient API blip never
-blocks the implement step.
+Skip 3.3 / 3.4 / 3.5 via their `GH_ISSUE_SKIP_*` env vars.
 
 ## Step 4: Mode Dispatch
 
-- **`direct`** → go to Step 5.
-- **`plan`** → check ambiguity signals in
-  `references/superpowers-detection.md`. If any → switch to
-  `brainstorming`. Else invoke `Skill(superpowers:writing-plans)`.
-  After plan is approved, proceed to Step 5 guided by the plan.
-- **`brainstorming`** → invoke `Skill(superpowers:brainstorming)`.
-  Its terminal state invokes `writing-plans`. After plan is approved,
-  proceed to Step 5 guided by the plan.
+- **`direct`** → Step 5.
+- **`plan`** → if ambiguity signals (`references/superpowers-detection.md`)
+  appear, switch to `brainstorming`; else `Skill(superpowers:writing-plans)`.
+- **`brainstorming`** → `Skill(superpowers:brainstorming)` (terminal state
+  invokes `writing-plans`). After plan approval, proceed to Step 5.
 
 ## Step 5: Implement + Test
 
 Follow the direct-mode flow in `references/implementation-flow.md` →
-"Direct-mode flow" (detect `$TEST_CMD`, scan repo context, edit files,
-run tests, on failure run the test-failure loop with max 3 iterations
-per the same file).
-
-After implementation + tests pass (or are skipped because no test
-runner was detected), emit the step-completion marker before printing
-the Step 6 report — the harness step-skip guard
-(`skill_completion_guard.py`, issue #753) requires this marker:
+"Direct-mode flow" (detect `$TEST_CMD`, scan, edit, run tests, failure
+loop max 3×). After tests pass (or skip — no runner), emit before Step 6:
 `printf '[step:gh-issue-implement/implement] OK\n'`.
 
 ## Step 6: Report
 
-Print the success or failure report per
-`references/implementation-flow.md` → "Final report format". Always
-include the `Next:` hint pointing to `gh:commit` / `gh:pr` /
-`gh:issue-flow`, unless `--no-next-hint` is set.
-
-After the report, append the ai-metrics line (context only — no GitHub
-artifact exists yet at this stage):
-
-```
-[ai-metrics:gh-issue-implement] ~{ELAPSED} min — will be included in gh-commit metrics
-```
-
-Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
-
-Finally, emit the report step-completion marker so the step-skip guard
-recognizes the skill finished:
-`printf '[step:gh-issue-implement/report] OK\n'`.
+Print the success/failure report per `references/implementation-flow.md`
+→ "Final report format" + its "ai-metrics line" (ELAPSED). Include the
+`Next:` hint (`gh:commit` / `gh:pr` / `gh:issue-flow`) unless
+`--no-next-hint`; then `printf '[step:gh-issue-implement/report] OK\n'`.
 
 ## Constraints
 
-Read `references/constraints.md` before relaxing any of these: never
-commit/PR, never create a worktree, never run on the default branch,
-never fix pre-existing test failures, never retry the test loop more
-than 3 times, never hard-require superpowers.
+Read `references/constraints.md` first: never commit/PR, create a
+worktree, run on the default branch, fix pre-existing test failures,
+exceed 3 test-loop retries, or hard-require superpowers.

--- a/claude/skills/gh-issue-implement/references/help.md
+++ b/claude/skills/gh-issue-implement/references/help.md
@@ -7,6 +7,7 @@
 | 1 | `<issue-number>` or `-h`/`--help`/`help` | — | GitHub issue number |
 | 2 | mode | `direct` | One of `direct`, `plan`, `brainstorming` |
 | 3 | remote-name | `origin` | Git remote whose repo owns the issue |
+| flag | `--no-next-hint` | off | Suppress the final `Next:` hint in the Step 6 report |
 
 ## Usage
 

--- a/claude/skills/gh-issue-implement/references/implementation-flow.md
+++ b/claude/skills/gh-issue-implement/references/implementation-flow.md
@@ -107,3 +107,14 @@ gh:issue-implement #<N> stopped after 3 test-fix attempts
     <file:line>
   Resolution: review the edits above, fix manually, re-run tests.
 ```
+
+## ai-metrics line
+
+After the report, append the ai-metrics line (context only — no GitHub
+artifact exists yet at this stage):
+
+```
+[ai-metrics:gh-issue-implement] ~{ELAPSED} min — will be included in gh-commit metrics
+```
+
+Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.

--- a/claude/skills/gh-issue-read/SKILL.md
+++ b/claude/skills/gh-issue-read/SKILL.md
@@ -9,6 +9,12 @@ description: >-
   `<issue-number> [remote]`; defaults remote to `origin`. Accepts
   `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "read-only issue summary; verbatim body/comments preservation, no mutation"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:issue-read — Issue Summary

--- a/claude/skills/gh-kanban-bootstrap/SKILL.md
+++ b/claude/skills/gh-kanban-bootstrap/SKILL.md
@@ -14,6 +14,12 @@ description: >-
   `--no-bootstrap-labels`, `--force-label-sync`,
   `--with-smoke-test`. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "structured Projects v2 board bootstrap; wraps deterministic lib/setup.sh, bounded report output, low reasoning"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:kanban-bootstrap — Kanban Board Setup
@@ -25,11 +31,9 @@ output its content verbatim, then stop. No API calls.
 
 ## Step 1: Resolve Skill Dir
 
-Record `START_TS=$(date +%s)` immediately.
-
-Locate `SKILL_DIR` (this file's directory). The script lives at
-`${SKILL_DIR}/lib/setup.sh`; label SSOT at
-`${SKILL_DIR}/references/labels.md`.
+Record `START_TS=$(date +%s)` immediately. Locate `SKILL_DIR` (this
+file's directory): the script lives at `${SKILL_DIR}/lib/setup.sh`, the
+label SSOT at `${SKILL_DIR}/references/labels.md`.
 
 ## Step 2: Prereq Check
 
@@ -47,20 +51,17 @@ this repo). Detect `OWNER/REPO` via `gh repo view`. If user passed
 ## Step 4: Options
 
 If `--hide-columns` was not passed and this looks like a personal repo,
-ask the user once (1-line question) — do not auto-infer from
-collaborator count (NF-3 / privacy).
-
-Parse `--no-bootstrap-labels` (skip Step 5 entirely) and
+ask the user once (1-line question) — never auto-infer from collaborator
+count (NF-3 / privacy). Parse `--no-bootstrap-labels` (skip Step 5) and
 `--force-label-sync` (Step 5 sync mode).
 
 ## Step 5: Label Bootstrap
 
-Apply the 8 SSOT labels per `references/labels.md` — the "Apply
-decision matrix" section there resolves skip / PATCH (on
-`--force-label-sync`) / POST per label. `--no-bootstrap-labels` skips
-the whole step with a one-line notice. Per-label permission errors
-warn on stderr and continue — label absence does not block board
-setup.
+Apply the 8 SSOT labels per `references/labels.md` — its "Apply decision
+matrix" resolves skip / PATCH (on `--force-label-sync`) / POST per label.
+`--no-bootstrap-labels` skips the step with a one-line notice. Per-label
+permission errors warn on stderr and continue (label absence never blocks
+board setup).
 
 ## Step 6: Dry-run Dispatch
 
@@ -79,24 +80,16 @@ bash "${SKILL_DIR}/lib/setup.sh" <user-flags>
 
 Parse stdout for `Project board setup finished` (success) or
 `A project titled '<TITLE>' already exists` (idempotent re-run). Extract
-the Project URL and number.
-
-After board creation the script also performs **Step 7 (env wiring)**:
-idempotently appends `OWNER/REPO` into the
-`GH_PR_REPLY_AUTO_APPROVE_REPOS` CSV in `~/.zshrc.local` so the next
-session passes the `gh:pr-reply` Step 8 solo-repo auto-approve G1
-(repo allowlist) guard without manual edits. Suppress with
-`--no-auto-approve-env` (e.g. org/collab repos).
+the Project URL and number. The script then idempotently wires the
+`gh:pr-reply` auto-approve env per `references/env-wiring.md` (suppress
+with `--no-auto-approve-env`).
 
 ## Step 8: UI Checklist + Report
 
 The script's `print_final_report` already emits host-aware URLs (post-
-#699 fix) and the workflow #3 `DISABLE` instruction. Pass-through its
-output. Append:
-- Smoke test command block (host-corrected; do not execute unless
-  `--with-smoke-test`).
-- Compact closing report: project URL, project number, label bootstrap
-  summary (`<n> created, <m> skipped, <k> synced`), elapsed time.
+#699 fix) and the workflow #3 `DISABLE` instruction — pass it through,
+then append the smoke-test block and compact closing report per
+`references/report-template.md`.
 
 ## Constraints
 

--- a/claude/skills/gh-kanban-bootstrap/references/env-wiring.md
+++ b/claude/skills/gh-kanban-bootstrap/references/env-wiring.md
@@ -1,0 +1,8 @@
+# Step 7 — gh:pr-reply auto-approve env wiring
+
+After board creation `lib/setup.sh` idempotently appends `OWNER/REPO`
+into the `GH_PR_REPLY_AUTO_APPROVE_REPOS` CSV in `~/.zshrc.local`, so the
+next session passes the `gh:pr-reply` Step 8 solo-repo auto-approve G1
+(repo allowlist) guard without manual edits.
+
+Suppress with `--no-auto-approve-env` (e.g. org / collab repos).

--- a/claude/skills/gh-kanban-bootstrap/references/help.md
+++ b/claude/skills/gh-kanban-bootstrap/references/help.md
@@ -12,30 +12,24 @@ label bootstrap, and host-aware UI checklist.
 
 ## Options (skill-layer)
 
-- `--no-bootstrap-labels`  Skip the label registration step (use when
-                           the target repo follows a different label
-                           policy).
-- `--force-label-sync`     PATCH existing labels whose color/description
-                           differ from the SSOT (`references/labels.md`).
-                           Default is preserve — colors are not changed
-                           unless this flag is set.
-- `--with-smoke-test`      Execute the smoke test commands instead of
-                           only printing them. Default: print-only.
+| Option | Description | Default |
+|---|---|---|
+| `--no-bootstrap-labels` | Skip the label registration step (target repo follows a different label policy) | labels bootstrapped |
+| `--force-label-sync` | PATCH existing labels whose color/description differ from the SSOT (`references/labels.md`) | preserve (no color change) |
+| `--with-smoke-test` | Execute the smoke test commands instead of only printing them | print-only |
 
 ## Options (passed through to `lib/setup.sh`)
 
-- `--owner <login>`              GitHub user or org (default: auto from
-                                 `gh repo view`).
-- `--repo <name>`                Repository name (default: auto).
-- `--title <board-title>`        Project title (default: repo name).
-- `--auto-archive-window <dur>`  Done auto-archive filter (default: `2d`).
-- `--hide-columns`               Add solo-repo hide guidance for
-                                 `Approved` and `Ready`.
-- `--dry-run`                    Print the plan without mutations.
-- `--skip-pr-template`           Skip remote PR template creation/check.
-- `--no-auto-approve-env`        Skip wiring `GH_PR_REPLY_AUTO_APPROVE_REPOS`
-                                 into `~/.zshrc.local` (use for non-solo
-                                 / org / collab repos).
+| Option | Description | Default |
+|---|---|---|
+| `--owner <login>` | GitHub user or org | auto from `gh repo view` |
+| `--repo <name>` | Repository name | auto |
+| `--title <board-title>` | Project title | repo name |
+| `--auto-archive-window <dur>` | Done auto-archive filter | `2d` |
+| `--hide-columns` | Add solo-repo hide guidance for `Approved` and `Ready` | off |
+| `--dry-run` | Print the plan without mutations | off |
+| `--skip-pr-template` | Skip remote PR template creation/check | off |
+| `--no-auto-approve-env` | Skip wiring `GH_PR_REPLY_AUTO_APPROVE_REPOS` into `~/.zshrc.local` (non-solo / org / collab repos) | env wired |
 
 ## Prerequisites
 

--- a/claude/skills/gh-kanban-bootstrap/references/report-template.md
+++ b/claude/skills/gh-kanban-bootstrap/references/report-template.md
@@ -1,0 +1,9 @@
+# Step 8 — appended output
+
+Pass through the script's `print_final_report` (host-aware URLs + the
+workflow #3 `DISABLE` instruction), then append:
+
+- **Smoke test command block** — host-corrected; do not execute unless
+  `--with-smoke-test`.
+- **Compact closing report** — project URL, project number, label
+  bootstrap summary (`<n> created, <m> skipped, <k> synced`), elapsed time.

--- a/claude/skills/gh-pr-resolve-outdated/SKILL.md
+++ b/claude/skills/gh-pr-resolve-outdated/SKILL.md
@@ -14,6 +14,12 @@ description: >-
   up-to-date PR is a no-op. Accepts `[pr-number] [remote]`; defaults to
   the PR attached to the current branch. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "clean rebase + --force-with-lease push with rejected-push and conflict handoff; not pure read-only, but no deep reasoning"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-resolve-outdated — Clean Rebase for Out-of-Date PR
@@ -27,22 +33,15 @@ No API calls.
 
 Record `START_TS=$(date +%s)` immediately for Step 5.
 
-Positional: `[pr-number] [remote]`. Both optional.
+| Arg | Description | Default |
+|---|---|---|
+| `[pr-number]` | PR to resolve; auto-detect from branch if omitted | branch PR |
+| `[remote]` | Remote owning the PR's repo | `origin` |
 
-- `pr-number` — if omitted, auto-detect via `gh pr view --json
-  number,headRefName,baseRefName,url,mergeable,mergeStateStatus` on
-  the current branch. No PR → `[FAIL] no PR for current branch — pass
-  PR# explicitly` + exit 2.
-- `remote` — default `origin`. Resolve `TARGET_REPO` via
-  `git remote get-url <remote>`; missing → `git remote -v` + exit 2.
-- `gh` not authenticated → `[FAIL] gh CLI not authenticated — run gh
-  auth login` + exit 5.
-
-**Hard preconditions** (any fail → stop): inside a git repo · current
-branch ≠ repo default (`[FAIL] cannot run on default branch` + exit 2)
-· clean working tree (no auto-stash) · no in-progress rebase/merge/
-cherry-pick. Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it
-for `git reset --hard <sha>` recovery.
+Resolve `TARGET_REPO`, check `gh` auth, and enforce the hard
+preconditions (git repo · not default branch · clean tree · no
+in-progress rebase) per `references/preflight.md` — full exit codes and
+error templates there. Capture `BACKUP_SHA=$(git rev-parse HEAD)`.
 
 ## Step 2: Mergeable Triage
 
@@ -51,14 +50,10 @@ gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
   --json mergeable,mergeStateStatus,baseRefName,headRefName,url
 ```
 
-| `mergeable` | `mergeStateStatus` | Action |
-|---|---|---|
-| `MERGEABLE` | `CLEAN`/`UNSTABLE` | `[OK] PR은 이미 up-to-date — nothing to do.` exit 0 (NF-1) |
-| `MERGEABLE` | `BEHIND` | proceed to Step 3 (the case this skill handles) |
-| `CONFLICTING` | — | `[FAIL] PR has merge conflicts — use /gh:pr-resolve-conflict` + exit 3 |
-| `UNKNOWN` | — | GitHub still computing; print hint + exit 0 (retry later) |
-
-`BLOCKED` alone (CI/approval pending) is not an out-of-date case — not handled here.
+Resolve the result via the action matrix in
+`references/mergeable-triage.md` — only `MERGEABLE`/`BEHIND` proceeds to
+Step 3; `CONFLICTING` delegates to `gh:pr-resolve-conflict` (exit 3),
+already-clean is a no-op (exit 0).
 
 ## Step 3: Fetch + Clean Rebase
 
@@ -69,9 +64,7 @@ git rebase "$REMOTE/$BASE"
 
 Rebase exits non-zero with conflicts → `git rebase --abort` immediately,
 print `[FAIL] rebase produced conflicts — use /gh-pr-resolve-conflict
-<PR_NUMBER>` + exit 4. The skill's premise is the no-conflict case;
-the moment conflicts appear, hand off (never auto-guess — same policy
-as the sister skill).
+<PR_NUMBER>` + exit 4. Never auto-guess — hand off to the sister skill.
 
 ## Step 4: Push with `--force-with-lease`
 
@@ -82,20 +75,13 @@ git push --force-with-lease "$REMOTE" HEAD
 ```
 
 Never plain `--force`. Rejected (remote advanced while rebasing) →
-`[FAIL] remote advanced — re-fetch and retry` + exit 6. **Never**
-silently re-fetch and re-rebase — surface divergence so the user
-decides (lost-update risk).
+`[FAIL] remote advanced — re-fetch and retry` + exit 6. Never silently
+re-fetch — surface divergence so the user decides (lost-update risk).
 
 ## Step 5: Verify + Report
 
-```bash
-gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
-  --json mergeable,mergeStateStatus,url
-```
-
-`mergeStateStatus ∈ {CLEAN, UNSTABLE, BLOCKED}` → banner cleared
-(`BLOCKED` here = CI/approval pending, normal). Still `BEHIND` → push
-didn't land; print PR URL, do not loop.
+Re-read `--json mergeable,mergeStateStatus,url` and interpret per
+`references/mergeable-triage.md` → "Step 5 verification".
 
 ```
 [OK] PR #<N> out-of-date 해소됨 · <new-sha> push 됨.
@@ -110,7 +96,5 @@ ai-metrics footer follows the sister-skill pattern; skip when
 - Rebase-only. Never a merge commit.
 - `--force-with-lease` only — never plain `--force`.
 - Never run on the repo's default branch.
-- Never auto-resolve conflicts — delegate to `gh:pr-resolve-conflict`
-  and exit 4 the moment rebase produces them.
-- Never retry a rejected `--force-with-lease` automatically.
-- Never auto-stash. Clean tree required.
+- Never auto-resolve conflicts — delegate to `gh:pr-resolve-conflict` (exit 4).
+- Never retry a rejected `--force-with-lease`; never auto-stash (clean tree required).

--- a/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
@@ -1,0 +1,20 @@
+# Mergeable triage matrix
+
+Step 2 maps `gh pr view --json mergeable,mergeStateStatus` to an action:
+
+| `mergeable` | `mergeStateStatus` | Action |
+|---|---|---|
+| `MERGEABLE` | `CLEAN`/`UNSTABLE` | `[OK] PR은 이미 up-to-date — nothing to do.` exit 0 (NF-1) |
+| `MERGEABLE` | `BEHIND` | proceed to Step 3 (the case this skill handles) |
+| `CONFLICTING` | — | `[FAIL] PR has merge conflicts — use /gh:pr-resolve-conflict` + exit 3 |
+| `UNKNOWN` | — | GitHub still computing; print hint + exit 0 (retry later) |
+
+`BLOCKED` alone (CI/approval pending) is not an out-of-date case — not handled here.
+
+## Step 5 verification
+
+After the push, re-read `--json mergeable,mergeStateStatus,url`:
+
+- `mergeStateStatus ∈ {CLEAN, UNSTABLE, BLOCKED}` → banner cleared
+  (`BLOCKED` here = CI/approval pending, normal).
+- Still `BEHIND` → push didn't land; print PR URL, do not loop.

--- a/claude/skills/gh-pr-resolve-outdated/references/preflight.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/preflight.md
@@ -1,0 +1,22 @@
+# Step 1 — args, repo resolution, and hard preconditions
+
+Positional args: `[pr-number] [remote]`, both optional.
+
+- `pr-number` — if omitted, auto-detect via `gh pr view --json
+  number,headRefName,baseRefName,url,mergeable,mergeStateStatus` on the
+  current branch. No PR → `[FAIL] no PR for current branch — pass PR#
+  explicitly` + exit 2.
+- `remote` — default `origin`. Resolve `TARGET_REPO` via `git remote
+  get-url <remote>`; missing → `git remote -v` + exit 2.
+- `gh` not authenticated → `[FAIL] gh CLI not authenticated — run gh
+  auth login` + exit 5.
+
+**Hard preconditions** (any fail → stop):
+
+- inside a git repo
+- current branch ≠ repo default (`[FAIL] cannot run on default branch` + exit 2)
+- clean working tree (no auto-stash)
+- no in-progress rebase / merge / cherry-pick
+
+Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it for
+`git reset --hard <sha>` recovery.

--- a/claude/skills/sh-check/SKILL.md
+++ b/claude/skills/sh-check/SKILL.md
@@ -12,6 +12,12 @@ description: >-
   (use `agents-md:check`).
 compatibility:
   tools: Read, Glob, Grep, Bash
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "audit-only shell script linter; read-only pattern matching against git_worktree.sh canonical reference; bounded output"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # Shell Script Quality Auditor


### PR DESCRIPTION
## 개요

#860 (GOOD 19개 일괄 model_recommendation 메타데이터 추가) **카테고리 C — PR 3**.
`gh-* GOOD` 4개 + `sh-check` 총 5개 스킬에 `metadata.model_recommendation` 블록을
추가하고, Check 1 line-count WARN 동반 스킬은 references/ 추출로 ≤100L PASS 전환.

rubric SSOT: `claude/skills/skill-check/references/model-recommendation.md`

## 변경 스킬 (5)

| 스킬 | tier | 변경 | 라인 |
|---|---|---|---|
| `gh-issue-read` | haiku | 메타데이터만 | 96 PASS |
| `sh-check` | haiku | `compatibility` 아래 `metadata` 추가 | 98 PASS |
| `gh-kanban-bootstrap` | haiku | 메타데이터 + Step 7/8 references 추출 + help.md 옵션 테이블 | 107→100 PASS |
| `gh-pr-resolve-outdated` | sonnet | 메타데이터 + preflight/triage references 추출 + 옵션 테이블 유지 | 116→100 PASS |
| `gh-issue-implement` | opus | 메타데이터 + Step 3/5/6 압축 + Check 7 stop-on-error 정책 + help.md `--no-next-hint` 행 | 127→100 PASS |

## 추출된 references (신규)

- `gh-kanban-bootstrap/references/env-wiring.md`, `report-template.md`
- `gh-pr-resolve-outdated/references/preflight.md`, `mergeable-triage.md`
- `gh-issue-implement/references/implementation-flow.md` 에 ai-metrics 형식 이관

## 검증

- 5개 SKILL.md 모두 **≤100 라인** (Check 1 PASS)
- 모든 신규/기존 references 본문에서 인용 (Check 4 PASS)
- `metadata.model_recommendation` (tier/reason/claude/non_claude) 전부 유효 (Check 12 PASS)
- `gh-issue-implement` step-completion 마커 5개 (#753) 전부 보존
- `tests/golden_rules` 전체 통과 (이모지 없음 포함)

## Closes

Closes #852 · Closes #854 · Closes #830 · Closes #826 · Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)