### PR TITLE
feat(gh-issue-proceed): #874 directive 이슈 실행 스킬 — 8-section 스키마 + 4-layer safety

### DIFF
--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -9,7 +9,9 @@ description: >-
   modes invoke the matching superpowers skills when the plugin is
   installed (falls back to direct with a warning if not). Precondition:
   user is already inside a dedicated git worktree on a feature branch.
-  Accepts `<issue-number> [direct|plan|brainstorming] [remote]`,
+  Sibling of [[gh:issue-proceed]] — this skill edits files to satisfy a
+  code-change issue; that one executes the protocol a directive issue
+  embeds. Accepts `<issue-number> [direct|plan|brainstorming] [remote]`,
   optional `--no-next-hint` (suppress final `Next:` hint), and
   `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/claude/skills/gh-issue-proceed/SKILL.md
+++ b/claude/skills/gh-issue-proceed/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: gh:issue-proceed
+description: >-
+  Read a GitHub directive issue (a work-order issue whose body embeds an
+  executable 8-section protocol) and proceed end-to-end WITHOUT human
+  intervention — strictly validating the schema, executing each step per
+  the body's decision rules, and applying authorized write actions
+  (commit / PR / comment / close / file follow-up). Use when the user runs
+  /gh:issue-proceed, /gh-issue-proceed, or asks "이 지시 이슈 끝까지 수행해",
+  "directive 이슈 실행해", "proceed #81". Sibling of [[gh:issue-implement]]
+  (which edits files to satisfy a code-change issue) — this skill instead
+  EXECUTES the protocol the issue carries. Strict schema: refuses any issue
+  missing one of the 8 required sections. Always direct mode — the directive
+  is the plan; no plan/brainstorming dispatch. Safety gates (absolute
+  prohibitions + token-gated conditional permissions + pre-flight + runtime
+  monitors) bound every write. Accepts `<issue-number> [remote]` and
+  `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write, Skill, TaskCreate, TaskUpdate, TaskList
+metadata:
+  model_recommendation:
+    tier: opus
+    reason: "full write authority + per-step safety classification + protocol reasoning; high blast radius"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# gh:issue-proceed — Directive Issue → Execution
+
+Sibling of `/gh:issue-implement`: same shell, but Step 2 (superpowers
+detection) and Step 4 (mode dispatch) are dropped — directive issues are
+already designed, so execution is always direct. Full design SSOT:
+`docs/feature/gh-issue-proceed-skill/design.md`.
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Parse Args + Resolve Repo
+
+Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
+
+Positional args: `<issue-number> [remote]`.
+
+- `issue-number` — required, positive integer.
+- `remote` — default `origin`. Resolve `TARGET_REPO=<owner>/<repo>` per
+  `references/repo-resolution.md`. Missing remote → list `git remote -v`
+  and stop (no silent fallback).
+
+This skill takes no `mode` arg; execution is always `direct`.
+
+## Step 2: Fetch + Claim + Schema Validation
+
+2.1 **Fetch + Claim** — run the five claim substeps in
+`references/claim.md` (fetch → block-label guard → self-assign → board
+transition → depends-on). CLOSED-issue refusal precedes schema check
+(`references/fetch-issue.md`). After fetch succeeds, emit:
+`printf '[step:gh-issue-proceed/fetch-issue] OK\n'`.
+
+2.2 **Schema validation** — validate the body against the strict
+8-section schema in `references/protocol-schema.md` (goal, preconditions,
+execution_protocol, decision_rules, deliverables, done_criteria,
+out_of_scope, safety). Any missing / empty / unparseable required section
+→ print the §3.4 failure block and STOP (no comment on the issue; schema
+failure is a caller-side problem). On pass emit:
+`printf '[step:gh-issue-proceed/schema-valid] OK\n'`.
+
+2.3 **Precondition class** — classify mutation requirement per
+`references/preconditions.md` (read-only / mutation-required / mixed /
+verify-only). Log the class to stdout. A `mutation-required` class while
+on the default branch or with a dirty tree → STOP with the remediation
+hint from that file.
+
+## Step 3: Execute Protocol
+
+Follow `references/execution-flow.md` and `references/safety-gates.md`:
+
+1. **Pre-flight** (safety Layer 3): branch / secret-shaped files /
+   `gh auth status` / dry-run §preconditions. Any failure → STOP.
+2. **Parse steps** from `execution_protocol` (matrix or numbered mode,
+   `references/protocol-schema.md` §3.3). Unknown action verb in
+   `decision_rules` → fail-closed at parse time.
+3. **Step loop** — for each parsed step: `TaskCreate` → execute under
+   Layer-1 absolute-prohibition + Layer-4 runtime monitors (per-step /
+   global timeout, output secret scanner, write-action quota) → classify
+   the result against `decision_rules` (fail-closed on an unknown class)
+   → apply the mapped action verb (`references/execution-flow.md` §5.3) →
+   `TaskUpdate` with result + classification.
+4. **Done-criteria reconciliation** — match every `- [ ]` item in
+   `done_criteria` to an executed write action / classification. All
+   matched and no abort → `close_issue: <self>` + final comment; else
+   keep the issue open with an `N/M criteria met` comment.
+
+Conditional permissions (bulk ops, force-with-lease, cross-repo, outbound
+net) are default-deny — allowed only when the body's §safety carries the
+matching `allow:` token (`references/safety-gates.md` §4.2). After the loop
+completes (or aborts) emit:
+`printf '[step:gh-issue-proceed/execute] OK\n'`.
+
+## Step 4: Report
+
+Print the audit report per `references/report-format.md` (per-step table,
+write-action audit, done-criteria reconciliation, outcome). Then append:
+
+```
+[ai-metrics:gh-issue-proceed] ~{ELAPSED} min — write actions: {N}, blocked: {M}
+```
+
+Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
+Honor `GH_DISABLE_AI_METRICS=1` (omit the metrics line). Finally emit:
+`printf '[step:gh-issue-proceed/report] OK\n'`.
+
+## Constraints
+
+Read `references/safety-gates.md` before relaxing any of these:
+
+- **Never** force-push to the default branch, leak a secret to any GitHub
+  output, mutate another worktree, or run `gh pr merge` — these are Layer-1
+  absolute prohibitions, ignored even if the issue body authorizes them.
+- **Never** invent a result classification or an action verb — both are
+  fail-closed against the body's `decision_rules` and the fixed verb
+  registry.
+- **Never** apply a conditional permission (bulk / force-with-lease /
+  cross-repo / net) without its explicit §safety `allow:` token.
+- **Never** run a `mutation-required` directive on the default branch or
+  with a dirty tree.
+- **Never** post a comment on schema-validation failure — that is a
+  caller-side problem.
+- Mode is always `direct`; there is no plan / brainstorming dispatch.

--- a/claude/skills/gh-issue-proceed/references/claim.md
+++ b/claude/skills/gh-issue-proceed/references/claim.md
@@ -1,0 +1,107 @@
+# gh:issue-proceed — Step 2.1 Fetch + Claim
+
+Five substeps in order. This mirrors `/gh:issue-implement`'s claim policy
+(kept as a self-contained copy per the dotfiles per-skill references
+convention). Worktree creation stays the user's job; everything else
+lands here.
+
+## Substep order
+
+```
+2.1.1 Fetch issue              (gates everything; CLOSED refusal here)
+2.1.2 Block-label guard        (HARD abort exit 2; cheapest "no")
+2.1.3 Self-assign              (broadcast claim ASAP)
+2.1.4 Board Status transition  (idempotent; verify-pair absorbs race)
+2.1.5 Depends-on guard         (slowest; soft-warn, do last)
+```
+
+The HARD aborts (2.1.1, 2.1.2) come before any mutation (2.1.3, 2.1.4) so
+an abort never leaves a stale claim or board state.
+
+## 2.1.1 Fetch issue
+
+See `references/fetch-issue.md`. The `gh issue view` JSON it returns is
+reused by 2.1.2 (`labels`), 2.1.3 (`assignees`), 2.1.5 (`body`), and Step
+2.2 schema validation (`body`) — call once, parse multiple times.
+
+## 2.1.2 Block-label guard (fail-closed)
+
+Refuse to proceed on an issue tagged `do-not-work`, `on-hold`, `보류`,
+`⏸️ Postpone`, or whatever `GH_ISSUE_BLOCK_LABELS` lists. No escape hatch —
+label removal is the only release.
+
+```
+labels = json.labels[].name
+block  = split(GH_ISSUE_BLOCK_LABELS, ",")   # default above
+for L in labels:
+    if L in block:
+        print "Refusing to start #<N> — blocked by label '<L>'."
+        exit 2
+```
+
+`exit 2` is reserved suite-wide for "policy refusal" (distinct from `1`,
+the implicit shell-error code).
+
+## 2.1.3 Self-assign
+
+```
+me        = gh api user -q .login
+assignees = json.assignees[].login
+if GH_ISSUE_SKIP_SELF_ASSIGN set: return 0
+if me in assignees:               return 0   # idempotent
+if assignees == []:
+    gh issue edit <N> --repo <repo> --add-assignee @me   # soft-fail on API error
+    return 0
+print "[WARN] Issue #<N> is assigned to <other>; not overriding."
+return 0
+```
+
+`--add-assignee` appends (never `--assignee`, which replaces). Forking a
+teammate's claim is worse than a duplicated attempt — warn, don't override.
+
+## 2.1.4 Board Status transition
+
+```
+if GH_ISSUE_SKIP_BOARD_TRANSITION set: return 0
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+[ -r "$_HELPER" ] && . "$_HELPER"
+command -v _gh_project_status_sync >/dev/null 2>&1 \
+  && _gh_project_status_sync issue <N> "In progress" --only-from "Backlog,Ready"
+```
+
+No-board repos → silent rc 0. `--only-from Backlog,Ready` never bounces an
+`In review` / `Done` card backwards. Soft-fail: any non-policy error → rc 0.
+
+## 2.1.5 Depends-on guard (soft)
+
+```
+if GH_ISSUE_SKIP_DEPS_CHECK set: return 0
+deps = grep -oEi 'Depends on #[0-9]+' <body> | sed 's/.*#//'
+for M in deps:
+    state = gh issue view <M> --repo <repo> --json state -q .state
+    [ "$state" != CLOSED ] && print "[WARN] #<N> depends on #<M> (still <state>)."
+```
+
+Soft (warn + continue): the reference may be stale, or the user may be
+scaffolding on an in-flight dependency. A `gh issue view <M>` error itself
+→ one warn line + continue.
+
+## Environment variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `GH_ISSUE_BLOCK_LABELS` | `do-not-work,on-hold,보류,⏸️ Postpone` | Block-label list for 2.1.2. |
+| `GH_ISSUE_SKIP_SELF_ASSIGN` | unset | When `1`, skip 2.1.3. |
+| `GH_ISSUE_SKIP_BOARD_TRANSITION` | unset | When `1`, skip 2.1.4. |
+| `GH_ISSUE_SKIP_DEPS_CHECK` | unset | When `1`, skip 2.1.5. |
+
+There is **no** env var to bypass 2.1.2 (block-label guard) — intentional.
+
+## What this does NOT do
+
+- **Does not create a worktree** — the precondition class (mutation-required)
+  still requires the user to be on a feature branch in a worktree
+  (`references/preconditions.md`).
+- **Does not auto-unassign on later abort.** If Step 3 aborts, the assignee
+  + board state stay set. Manual cleanup: `gh issue edit <N>
+  --remove-assignee @me` and move the card back on the board.

--- a/claude/skills/gh-issue-proceed/references/execution-flow.md
+++ b/claude/skills/gh-issue-proceed/references/execution-flow.md
@@ -1,0 +1,96 @@
+# gh:issue-proceed — Execution semantics (Step 3)
+
+## Step loop (pseudocode)
+
+```
+parsed_steps = parse(execution_protocol)          # matrix or numbered (schema §3)
+
+for step in parsed_steps:
+    TaskCreate(subject="Step <n>: <description>",
+               activeForm="Executing step <n>")
+    start = now()
+
+    result = execute(step,
+                     out_of_scope=section["out_of_scope"],
+                     safety_layer1=ABSOLUTE_BLOCK_PATTERNS)
+
+    classification = classify(result,
+                              allowed=decision_rules.keys,
+                              fail_closed_on_unknown=True)   # never invent a class
+
+    apply(decision_rules[classification])                    # §verb registry below
+
+    TaskUpdate(taskId=step.id, status=completed,
+               metadata={"result": ..., "classification": ...})
+
+    if now() - start > per_step_timeout:
+        apply(decision_rules["TIMEOUT"])                     # retroactive
+
+if all_done_criteria_met and no_abort:
+    close_proceed_issue()                                    # self-close (no quota cost)
+else:
+    keep_open + final_comment
+```
+
+## Done-criteria semantics
+
+- Parse all `- [ ]` / `- [x]` items from `done_criteria`.
+- `- [x]` items are assumed pre-satisfied (authoring-time).
+- Each `- [ ]` item is matched against executed write actions + step
+  classifications. Every `- [ ]` item with a matching audit entry →
+  `done_criteria_met = True`.
+- Ambiguous matching (item text doesn't clearly map to any verb) →
+  `done_criteria_met = False`; the skill keeps the issue open.
+
+## Action verb registry
+
+Fixed allowlist. An unknown verb in a decision rule → **fail-closed at
+parse time** (before any step runs).
+
+| Verb | Implementation |
+|---|---|
+| `continue` | proceed to next step |
+| `file_issue: <template-key>` | `Skill(gh:issue-create, …)`. Template source: §decision_rules may define named inline templates; `<template-key>` references one by name. No match → minimal default `{title:"<auto>", body:"Filed by /gh:issue-proceed from #<N> step <s>", labels:[]}` |
+| `queue_doc_patch: <file>` | accumulate; flushed as a single commit + PR at end of loop |
+| `comment_on_self: <body>` | `gh issue comment <PROCEED_N>` |
+| `comment_on_other: <N> <body>` | `gh issue comment <N>` |
+| `commit_changes` | `Skill(gh:commit)` |
+| `open_pr` | `Skill(gh:pr)` |
+| `close_issue: <N>` | `gh issue close <N>` |
+| `abort_all` | break + final report; proceed issue stays open |
+| `skip` | record result only; next step |
+
+## Composition payload protocol
+
+When the skill calls another skill, the payload is **always structured**
+(no free-form prompt):
+
+```
+Skill(gh:issue-create, prompt=<<STRUCTURED
+TITLE: <...>
+BODY: <markdown>
+LABELS: <comma-list>
+NO_INTERACTIVE: true
+STRUCTURED)
+```
+
+Callees that see `NO_INTERACTIVE: true` skip confirmation prompts.
+
+> **Follow-up (design Open-Q3, non-blocking for this skill):** `/gh:commit`,
+> `/gh:pr`, `/gh:issue-create` do not yet formally honor the `STRUCTURED` /
+> `NO_INTERACTIVE` contract. Until they do, this skill passes the structured
+> block as the prompt and relies on each callee's existing
+> no-confirmation-by-design behavior (all three already create their
+> artifact without an interactive prompt). Tracked as a separate issue;
+> it does not block `/gh:issue-proceed` shipping.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Issue already CLOSED | Step 2.1 refusal (`already closed`); precedes schema check |
+| Hierarchical protocol (H4+ sub-protocols) | only the canonical `execution_protocol` section is parsed for steps; H4 content is context only |
+| Re-running a partially-done issue | TaskList consulted; resume at first non-completed step **iff** the body declares `Re-runnable: true`; else abort `[manual-review] non-idempotent rerun` |
+| Network failure mid-step | retry once; second failure → BLOCKED via decision rules |
+| Directive references a nonexistent file/command | classify FAIL; comment `[doc-bug] protocol references nonexistent <X>`; abort |
+| Decision rules don't cover an actual result class | first unhandled → BLOCKED; counts as a dynamic schema violation |

--- a/claude/skills/gh-issue-proceed/references/fetch-issue.md
+++ b/claude/skills/gh-issue-proceed/references/fetch-issue.md
@@ -1,0 +1,37 @@
+# gh:issue-proceed — Fetch Issue
+
+## Command
+
+```bash
+gh issue view <N> --repo "$TARGET_REPO" --json \
+  number,title,body,state,labels,assignees,comments,url
+```
+
+## Error handling
+
+- On non-zero exit (issue not found, auth failure, network) → print the
+  captured stderr verbatim and stop. Do not retry, do not fall back to a
+  different repo.
+
+## Closed-issue refusal (precedes schema check)
+
+If the parsed `state` is `CLOSED`, stop with this exact message:
+
+```
+Issue #<N> is CLOSED. Refuse to proceed on a closed directive — reopen it
+or pass a different number.
+```
+
+Rationale: a closed directive has either been executed or retired.
+Re-executing it silently risks duplicating side-effects (re-filing issues,
+re-opening PRs) or reviving a deliberately retired protocol. Forcing the
+human to reopen makes intent explicit and creates an audit trail. This
+refusal runs **before** schema validation — there is no point validating a
+protocol we will not execute.
+
+## After successful fetch
+
+Continue to the claim substeps (`references/claim.md`). The fetched JSON
+(`body`, `labels`, `assignees`, `comments`) is reused by claim (labels /
+assignees), schema validation (body), and the execution loop (body).
+Call `gh issue view` once, parse the JSON multiple times.

--- a/claude/skills/gh-issue-proceed/references/help.md
+++ b/claude/skills/gh-issue-proceed/references/help.md
@@ -1,0 +1,81 @@
+# gh:issue-proceed — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<issue-number>` or `-h`/`--help`/`help` | — | GitHub directive issue number |
+| 2 | remote-name | `origin` | Git remote whose repo owns the issue |
+
+## Usage
+
+- `/gh-issue-proceed 81` — read directive issue #81, validate the embedded
+  protocol, execute it end-to-end, apply authorized write actions.
+- `/gh-issue-proceed 81 upstream` — same, against `upstream` remote's repo.
+- `/gh-issue-proceed -h` / `--help` / `help` — print this help.
+
+There is no `mode` argument: a directive issue is already designed, so
+execution is always direct. For code-change issues ("edit files to satisfy
+the issue") use the sibling `/gh-issue-implement`.
+
+## What a directive issue is
+
+A work-order issue whose body embeds an **execution protocol** — numbered
+steps or a workflow matrix, plus decision rules, deliverables, and done
+criteria. Verify / triage / analysis / docs-ship tasks are typical. The
+skill executes the protocol; it does not author or edit it.
+
+## The 8 required sections (strict schema)
+
+`goal`, `preconditions`, `execution_protocol`, `decision_rules`,
+`deliverables`, `done_criteria`, `out_of_scope`, `safety`. Each is matched
+by H2/H3 heading with case-insensitive KO/EN aliases. Any missing, empty,
+or unparseable required section → schema-validation refusal (no work
+done, no comment posted). Full schema: `references/protocol-schema.md`.
+
+## What the skill does
+
+1. Resolves the repo, fetches the issue, claims it (assign + board move).
+2. Validates the body against the strict 8-section schema.
+3. Classifies the precondition (read-only / mutation-required / mixed /
+   verify-only) and enforces branch + clean-tree accordingly.
+4. Runs pre-flight safety checks, parses the protocol into steps.
+5. Executes each step under safety gates, classifies the result against
+   the body's decision rules, and applies the mapped action verb
+   (commit / PR / comment / close / file follow-up).
+6. Reconciles the done-criteria checklist, closes the issue when fully
+   met, and prints a structured audit report.
+
+## Safety posture
+
+Four layers (`references/safety-gates.md`):
+
+1. **Absolute prohibitions** — force-push to default, secret leakage,
+   cross-worktree mutation, `gh pr merge`, etc. Abort regardless of the
+   issue body.
+2. **Conditional permissions** — bulk ops, force-with-lease, cross-repo,
+   outbound net. Default-deny; allowed only with the matching §safety
+   `allow:` token.
+3. **Pre-flight** — branch / secret-shaped files / `gh auth status` /
+   §preconditions dry-run.
+4. **Runtime monitors** — per-step + global timeout, output secret
+   scanner, write-action quota (per-type 5, total 20).
+
+## What the skill will NOT do
+
+- Merge a PR. That belongs to `/gh-pr-merge` / `/gh-pr-merge-emergency`.
+- Author or edit the directive itself — humans (or `/devx:trd-to-issues`)
+  do that.
+- Run a `mutation-required` directive on the default branch or with a
+  dirty tree.
+- Post a comment when schema validation fails (caller-side problem).
+
+## Environment variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `GH_ISSUE_BLOCK_LABELS` | `do-not-work,on-hold,보류,⏸️ Postpone` | Block-label list (claim guard). |
+| `GH_ISSUE_SKIP_SELF_ASSIGN` | unset | When `1`, skip self-assign. |
+| `GH_ISSUE_SKIP_BOARD_TRANSITION` | unset | When `1`, skip board transition. |
+| `GH_ISSUE_SKIP_DEPS_CHECK` | unset | When `1`, skip depends-on guard. |
+| `GH_DISABLE_AI_METRICS` | unset | When `1`, omit the ai-metrics line. |

--- a/claude/skills/gh-issue-proceed/references/preconditions.md
+++ b/claude/skills/gh-issue-proceed/references/preconditions.md
@@ -1,0 +1,50 @@
+# gh:issue-proceed — Precondition classes (Step 2.3)
+
+The skill auto-detects whether the directive requires mutation, then
+enforces branch + clean-tree accordingly. The class is logged to stdout on
+Step 2.3 entry.
+
+## Mutation-required keyword scan
+
+Scan `§deliverables ∪ §execution_protocol ∪ §decision_rules` for any of:
+
+- `commit_changes`, `Skill(gh:commit)`, `git commit`
+- `open_pr`, `Skill(gh:pr)`, `gh pr create`
+- `queue_doc_patch`
+- `신규 파일` / `new file` (in deliverables)
+
+## Classes
+
+| Class | Trigger | Requirements |
+|---|---|---|
+| `read-only` | no mutation keyword | git repo only; any branch OK |
+| `mutation-required` | ≥1 mutation keyword | worktree + non-default branch + clean tree |
+| `mixed` | mutation + `allow: cross-repo` token in §safety | mutation-required + cross-repo permission check |
+| `verify-only` (override) | §track = `verify-only` | force read-only regardless of keywords |
+
+## Enforcement
+
+- `read-only` / `verify-only` → confirm we are inside a git repo; proceed.
+- `mutation-required` / `mixed`:
+  - current branch ≠ default (`main`/`master`) — else STOP.
+  - working tree clean (`git status --porcelain` empty) — else STOP.
+  - inside a dedicated worktree by convention (the skill does **not**
+    create one).
+
+Mismatch → STOP with a remediation hint, e.g.:
+
+```
+gh:issue-proceed #<N> precondition mismatch
+  Class: mutation-required (keyword '<kw>' found in <section>)
+  But: currently on default branch 'main'.
+  Create a feature branch in a worktree (e.g. `gwt`) and re-run, or
+  add `Track: verify-only` to the issue body if no mutation is intended.
+```
+
+## Why classify before executing
+
+A directive that only verifies (runs a CLI, reads output, files a report)
+must not be blocked by a clean-tree requirement; one that commits must
+never run on `main`. Auto-detection keeps read-only directives friction-
+free while fencing mutating ones — the `verify-only` override exists for
+the ambiguous case where keywords appear only in quoted/example context.

--- a/claude/skills/gh-issue-proceed/references/protocol-schema.md
+++ b/claude/skills/gh-issue-proceed/references/protocol-schema.md
@@ -1,0 +1,61 @@
+# gh:issue-proceed — Protocol schema (Step 2.2)
+
+The issue body must contain **8 required sections**, each identified by an
+H2 or H3 heading whose normalized text matches one of the listed aliases
+(case-insensitive substring; alias list per row is OR). SSOT for the
+schema validator; the bats fixture
+`tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh` mirrors this and
+the suite `gh_issue_proceed_schema.bats` exercises five variants.
+
+## 1. Required sections
+
+**"Empty" definition** (used uniformly): section content under 50 chars
+after stripping leading/trailing whitespace, markdown list markers
+(`-`, `*`, `1.`), and code-fence delimiters.
+
+| # | Key | Aliases | Failure rule |
+|---|---|---|---|
+| 1 | `goal` | `Goal`, `목표` | fail if empty |
+| 2 | `preconditions` | `Preconditions`, `사전 조건`, `Prerequisites` | fail if empty |
+| 3 | `execution_protocol` | `Execution Protocol`, `Execution Matrix`, `실행 절차`, `Steps` | fail if empty **or** no parseable steps (§3) |
+| 4 | `decision_rules` | `Decision Rules`, `결정 규칙`, `Branching`, `Decision matrix` | fail if empty |
+| 5 | `deliverables` | `Deliverables`, `산출물`, `Output`, `Outputs` | fail if empty |
+| 6 | `done_criteria` | `Done Criteria`, `종료 조건`, `Acceptance`, `Acceptance Criteria` | fail if no `- [ ]` / `- [x]` checklist item |
+| 7 | `out_of_scope` | `Out of Scope`, `Out-of-scope`, `범위 밖` | fail if empty |
+| 8 | `safety` | `Safety`, `Safety / Abort`, `Abort`, `안전 규칙`, `Safety Rules` | fail if empty |
+
+## 2. Recommended (optional, parsed if present)
+
+- `background` — context.
+- `references` — external links.
+- `track` — explicit `verify-only` declaration that overrides mutation
+  auto-detection (`references/preconditions.md`).
+
+## 3. Step parsing in `execution_protocol`
+
+Two formats, auto-detected:
+
+| Format | Trigger | Result |
+|---|---|---|
+| **Matrix mode** | a markdown table whose header row contains `#`, `Workflow`/`Step`, and `Command`/`명령` | one parsed step per data row |
+| **Numbered mode** | `^### \d+\.` or `^\d+\.` lines | one parsed step per numbered block until the next sibling heading |
+
+Both normalize into the same record:
+`{index, description, command_block_or_text, expected_outcome}`.
+
+## 4. Validation failure output
+
+```
+gh:issue-proceed #<N> schema validation failed
+  Missing required sections:
+    - <key>  (aliases tried: ...)
+  Empty required sections:
+    - <key>  (heading present, content < 50 chars)
+  Unparseable sections:
+    - execution_protocol  (no matrix table and no numbered steps found)
+  Fix the issue body to satisfy the directive schema, then retry.
+  Reference: <repo>/docs/feature/gh-issue-proceed-skill/design.md §3
+```
+
+No comment is posted on the issue itself — schema failure is a caller-side
+problem, and writing to a malformed directive risks acting on garbage.

--- a/claude/skills/gh-issue-proceed/references/repo-resolution.md
+++ b/claude/skills/gh-issue-proceed/references/repo-resolution.md
@@ -1,0 +1,43 @@
+# gh:issue-proceed — Repo resolution
+
+Detailed procedure for Step 1 remote validation and owner/repo extraction.
+SKILL.md keeps only the workflow; this file holds the substeps and
+error-message shape. (Same procedure as `/gh:issue-implement` — kept as a
+self-contained copy per the dotfiles per-skill references convention.)
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we're in a git repo.
+
+2. Determine the target remote:
+   - If the user passed an argument, use it as remote name.
+   - Otherwise default to `origin`.
+
+3. Validate the remote and resolve owner/repo:
+
+   ```bash
+   git remote get-url <remote-name>
+   ```
+
+   If this fails, list available remotes (`git remote -v`) and stop with
+   an error like:
+
+   ```
+   Error: remote '<remote-name>' not found. Available remotes:
+   origin  https://github.com/user/repo.git (fetch)
+   upstream  https://github.com/org/repo.git (fetch)
+   ```
+
+4. Extract `owner/repo` from the remote URL returned in step 3:
+
+   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git` → `<owner>/<repo>`
+
+Store the resolved `owner/repo` as `TARGET_REPO` for use in Step 2 of the
+main workflow.
+
+## Failure rule
+
+If the user-specified remote does not exist, fail immediately with the
+list of available remotes. **Do not** fall back to `origin` silently —
+that masks typos and proceeds against the wrong repo.

--- a/claude/skills/gh-issue-proceed/references/report-format.md
+++ b/claude/skills/gh-issue-proceed/references/report-format.md
@@ -1,0 +1,47 @@
+# gh:issue-proceed — Reporting (Step 4)
+
+## Per-step audit (always)
+
+| # | Step | Result | Classification | Verb applied | Duration |
+|---|---|---|---|---|---|
+| 1 | help | PASS | PASS | continue | 4s |
+| 2 | stock list 1 10 | FAIL-CLI | FAIL-CLI | file_issue: #NN | 12s |
+| ... | | | | | |
+
+## Write-action audit
+
+```markdown
+### Write actions executed
+| # | Action | Target | Triggered by step | Triggered by rule |
+|---|---|---|---|---|
+
+### Blocked attempts
+(none) | <list>
+
+### Aborts
+(none) | reason: <layer-N pattern>
+```
+
+## Done-criteria reconciliation
+
+Compare the §done_criteria checklist to actual step outcomes. Any unchecked
+item lists the reason (`step skipped: SKIP-NET`, `ambiguous match`, etc.).
+
+## Outcome
+
+| All done + no abort | Partial | Abort |
+|---|---|---|
+| `close_issue: <self>` + final comment | keep-open + final comment `N/M criteria met` | keep-open + final comment `[aborted] <layer> <pattern>` |
+
+## ai-metrics
+
+Appended after the report (omit entirely when `GH_DISABLE_AI_METRICS=1`):
+
+```
+[ai-metrics:gh-issue-proceed] ~{ELAPSED} min — write actions: {N}, blocked: {M}
+```
+
+The proceed issue thread is the single audit surface: the per-step table,
+the write-action audit, and the done-criteria reconciliation together let a
+human reconstruct exactly what the skill did and why, without re-reading
+the transcript.

--- a/claude/skills/gh-issue-proceed/references/safety-gates.md
+++ b/claude/skills/gh-issue-proceed/references/safety-gates.md
@@ -1,0 +1,70 @@
+# gh:issue-proceed — Safety gates
+
+Four layers, strictest to weakest. Each can independently trigger abort.
+This file is the SSOT for `ABSOLUTE_BLOCK_PATTERNS` (Layer 1); the bats
+fixture `tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh` mirrors
+the patterns and the suite `gh_issue_proceed_safety.bats` covers one
+positive + one negative per pattern.
+
+## Layer 1 — Absolute prohibitions
+
+Ignored **even if the issue body authorizes them**. A match aborts the
+flow, comments `[blocked] absolute prohibition triggered: <pattern>` on
+the proceed issue, and leaves the issue open for manual review.
+
+| Key | Detection | Behavior |
+|---|---|---|
+| `force_push_default` | `git push --force`/`-f` targeting the default branch | abort |
+| `force_push_general` | `git push --force`/`-f` (any branch) | abort — only `--force-with-lease` is allowed, and only when §safety authorizes |
+| `rm_rf_outside_pwd` | `rm -rf` with a path resolving outside `$PWD` | abort |
+| `destructive_db` | `DROP`, `TRUNCATE`, `admin reset`, mass `DELETE` | abort |
+| `secret_in_output` | `*_KEY` / `*_TOKEN` / `*_SECRET` / `password=` / `Bearer ` / JWT shape in stdout/stderr | abort + output never posted to GitHub |
+| `cross_worktree_mutation` | write path resolves outside the active worktree (`git worktree list`) | abort |
+| `gh_pr_merge` | `gh pr merge` | abort — sibling skills own merges |
+| `branch_deletion` | `git branch -D`, `gh api -X DELETE` against a branch ref | abort |
+| `reopen_foreign_closed` | reopen of an issue closed by someone else | abort |
+
+The secret scanner (`secret_in_output`) is the one monitor that is **never
+overrideable** — a leaked credential cannot be un-leaked once posted.
+
+## Layer 2 — Conditional permissions
+
+Allowed **only** when §safety carries the matching `allow:` token (exact
+substring). Default-deny: a missing token promotes the action to a Layer-1
+abort.
+
+| Action | Required §safety token |
+|---|---|
+| Bulk-close (≥5 issues) | `allow: bulk-close` |
+| Bulk-create (≥5 new issues) | `allow: bulk-create-issue` |
+| Force-with-lease push | `allow: force-with-lease` |
+| Non-allowlisted outbound network | `allow: net: <host glob>` |
+| Cross-repo mutation | `allow: cross-repo: <owner/repo>` |
+
+## Layer 3 — Pre-flight (Step 3 entry, run in parallel)
+
+All must pass or the skill stops with a hint:
+
+- Current branch ≠ default — enforced only for the mutation class
+  (`references/preconditions.md`).
+- No untracked secret-shaped files (`.env`, `*.pem`, `*.key`) in the tree.
+- `gh auth status` succeeds.
+- §preconditions block dry-runs successfully (any embedded check commands).
+
+## Layer 4 — Runtime monitors
+
+| Monitor | Default | Override |
+|---|---|---|
+| Per-step timeout | 5 min | §preconditions may state `per-step timeout: <N>m` |
+| Global timeout | 60 min | §preconditions may state `global timeout: <N>m` |
+| Output secret scanner | always on | none — never overrideable |
+| Write-action quota | per-type ceiling **5** (close / create / commit / pr / comment counted separately, excluding self-comment / self-close) **and** total ceiling **20** | §safety `allow: bulk-close` / `bulk-create-issue` raises the matching per-type ceiling to 50; total stays 20 unless §safety also declares `allow: total-quota: <N>` |
+| Edit-path memory | always on | none — needed for the §6 audit |
+
+## Quota counting rules
+
+- Self-comment on the proceed issue and self-close of the proceed issue do
+  **not** count against any quota (they are bookkeeping, not side-effects).
+- The total ceiling (20) is checked across all types combined; reaching it
+  aborts the loop with `[blocked] write-action total quota exceeded`, even
+  if no per-type ceiling was hit.

--- a/claude/skills/gh-issue-proceed/references/safety-gates.md
+++ b/claude/skills/gh-issue-proceed/references/safety-gates.md
@@ -27,6 +27,11 @@ the proceed issue, and leaves the issue open for manual review.
 The secret scanner (`secret_in_output`) is the one monitor that is **never
 overrideable** — a leaked credential cannot be un-leaked once posted.
 
+Pattern matching is **case-insensitive and quote-tolerant**: trivial
+obfuscation must not bypass a gate. `git push "-f"`, lowercase `drop table`,
+mixed-case `PASSWORD=`, and a quoted `rm -rf "/etc"` all still trigger their
+respective patterns.
+
 ## Layer 2 — Conditional permissions
 
 Allowed **only** when §safety carries the matching `allow:` token (exact

--- a/claude/skills/gh-issue-read/SKILL.md
+++ b/claude/skills/gh-issue-read/SKILL.md
@@ -5,7 +5,9 @@ description: >-
   summary without modifying it. Use when the user runs /gh:issue-read,
   /gh-issue-read, or asks "이슈 #N 읽고 정리해줘", "issue 42 뭐하는 거야",
   "#16 요약", "이 이슈 내용 파악". Preserves body and comments verbatim
-  so the output can be reused as context for implementation work. Accepts
+  so the output can be reused as context for implementation work — by
+  [[gh:issue-implement]] (code-change issues) or [[gh:issue-proceed]]
+  (directive issues that embed an executable protocol). Accepts
   `<issue-number> [remote]`; defaults remote to `origin`. Accepts
   `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep

--- a/docs/feature/gh-issue-proceed-skill/design.md
+++ b/docs/feature/gh-issue-proceed-skill/design.md
@@ -1,0 +1,367 @@
+# Design: `/gh:issue-proceed` Skill
+
+**Created**: 2026-05-30
+**Status**: Design (awaiting user review → writing-plans → implementation)
+**Owner**: panicdna@gmail.com
+**Source**: brainstorming session in quantfolio worktree `wt/issue-47/1` (spawning context: closure of umbrella #47 series)
+**Approach**: A — Slim wrapper mirroring `/gh:issue-implement` 6-step shell
+
+---
+
+## 1. Intent & positioning
+
+### 1.1 Problem
+
+GitHub issues come in two distinct shapes:
+
+- **Code-change requests** — "implement feature X", "fix bug Y". Existing skill: `/gh:issue-implement`.
+- **Work-order / directive issues** — verify/triage/analysis/audit tasks whose body contains an embedded **execution protocol** (numbered steps + decision rules + deliverables + done criteria). Examples authored in this conversation: quantfolio #78 (CLI manual end-to-end verify), #79 (docs PR ship), #80 (backlog triage), #81 (strategy inventory analysis).
+
+`/gh:issue-implement` assumes "edit files to satisfy the issue". Directive issues need a different verb: "execute the protocol embedded in the issue body". Today there is no skill for that — the user has to drive each step manually or rely on the LLM's ad-hoc reading of the issue.
+
+### 1.2 What `/gh:issue-proceed` does
+
+Reads a GitHub directive issue, validates the embedded protocol against a strict 8-section schema, executes the protocol end-to-end **without human intervention**, applies write actions (commit / PR / comment / close / file follow-up issue) where the protocol authorizes them, and produces a structured audit report.
+
+### 1.3 Explicit non-goals
+
+- **Not a replacement** for `/gh:issue-implement`. Directive issues are a sibling class, not a superset.
+- **Not a PR-merge skill** — that responsibility belongs to `/gh:pr-merge` / `/gh:pr-merge-emergency`.
+- **Not a brainstorming skill** — directive issues are already designed; this skill executes them.
+- **Not a code generator** for the directive itself — humans (or `/devx:trd-to-issues`-style helpers) author the directive.
+
+---
+
+## 2. Architectural decisions (settled in brainstorming)
+
+| # | Decision | Value |
+|---|---|---|
+| D-1 | Write authority | **Full directive authority** — skill may commit, push, comment, close, file issues, open PRs when the protocol so dictates. Safety gates (§4) provide the floor. |
+| D-2 | Schema strictness | **Strict** — refuse with a structured error any issue lacking the 8 required sections (§3). |
+| D-3 | Worktree precondition | **Conditional** — auto-detect from issue body whether mutation is required, then enforce branch + clean tree accordingly (§5.1). |
+| D-4 | Mode dispatch | **None** — always direct execution. No `plan`/`brainstorming` modes. The directive *is* the plan. |
+| D-5 | Composition | **Yes, via `Skill()`** — call `/gh:commit`, `/gh:pr`, `/gh:issue-create`, `/gh:issue-read` for matching action verbs (§3.6). Inline `gh` CLI only for single-shot ops (comment / close / label). |
+| D-6 | Progress tracking | **TaskCreate per parsed step** — real-time visible progress; metadata stores per-step result + classification (§3.5). |
+| D-7 | Skill family | **Sibling of `/gh:issue-implement`** — same 6-step shell, but Step 2 (superpowers detection) and Step 4 (mode dispatch) are dropped; Step 5 swaps "implement+test" for "execute protocol". |
+
+---
+
+## 3. Protocol schema (`references/protocol-schema.md`)
+
+Issue body must contain **8 required sections**, each identified by an H2 or H3 heading whose normalized text matches one of the listed aliases (case-insensitive substring; alias list per row is OR).
+
+### 3.1 Required sections
+
+**"Empty" definition** (used uniformly below): section content under 50 chars after stripping leading/trailing whitespace, markdown list markers (`-`, `*`, `1.`), and code-fence delimiters.
+
+| # | Key | Aliases | Failure rule |
+|---|---|---|---|
+| 1 | `goal` | `Goal`, `목표` | fail if empty |
+| 2 | `preconditions` | `Preconditions`, `사전 조건`, `Prerequisites` | fail if empty |
+| 3 | `execution_protocol` | `Execution Protocol`, `Execution Matrix`, `실행 절차`, `Steps` | fail if empty **or** if no parseable steps (§3.3) |
+| 4 | `decision_rules` | `Decision Rules`, `결정 규칙`, `Branching`, `Decision matrix` | fail if empty |
+| 5 | `deliverables` | `Deliverables`, `산출물`, `Output`, `Outputs` | fail if empty |
+| 6 | `done_criteria` | `Done Criteria`, `종료 조건`, `Acceptance`, `Acceptance Criteria` | fail if no `- [ ]` or `- [x]` checklist item found |
+| 7 | `out_of_scope` | `Out of Scope`, `Out-of-scope`, `범위 밖` | fail if empty |
+| 8 | `safety` | `Safety`, `Safety / Abort`, `Abort`, `안전 규칙`, `Safety Rules` | fail if empty |
+
+### 3.2 Recommended (optional, parsed if present)
+
+- `background` — context
+- `references` — external links
+- `track` — explicit `verify-only` declaration that overrides mutation auto-detection (§5.1)
+
+### 3.3 Step parsing in `execution_protocol`
+
+Two formats auto-detected:
+
+| Format | Trigger | Result |
+|---|---|---|
+| **Matrix mode** | A markdown table with header row containing `#`, `Workflow`/`Step`, `Command`/`명령` | one parsed step per data row |
+| **Numbered mode** | `^### \d+\.` or `^\d+\.` lines | one parsed step per numbered block until the next sibling heading |
+
+Both formats normalize into the same step record: `{index, description, command_block_or_text, expected_outcome}`.
+
+### 3.4 Validation failure output
+
+```
+gh:issue-proceed #<N> schema validation failed
+  Missing required sections:
+    - <key>  (aliases tried: ...)
+  Empty required sections:
+    - <key>  (heading present, content < 50 chars)
+  Unparseable sections:
+    - execution_protocol  (no matrix table and no numbered steps found)
+  Fix the issue body to satisfy the directive schema, then retry.
+  Reference: <repo>/docs/feature/gh-issue-proceed-skill/design.md §3
+```
+
+No comment is posted on the validated issue itself — schema failure is a caller-side problem.
+
+---
+
+## 4. Safety gates (`references/safety-gates.md`)
+
+Four layers, listed from strictest to weakest. Each layer can independently trigger abort.
+
+### 4.1 Layer 1 — Absolute prohibitions (ignored even if the issue body says so)
+
+| Pattern | Detection | Behavior |
+|---|---|---|
+| `git push --force` to default branch | pre-execute pattern match | abort |
+| `git push --force` (general) | pre-execute | abort — only `--force-with-lease` allowed, and only when §safety authorizes |
+| `rm -rf` outside `$PWD` | pre-execute path resolution | abort |
+| Destructive DB ops (`admin reset`, `DROP`, `TRUNCATE`, mass DELETE) | command keyword match | abort |
+| Secret in any output (`*_KEY`, `*_TOKEN`, `*_SECRET`, `password=`, `Bearer `, JWT shape) | stdout/stderr regex stream scan | abort + output never posted to GitHub |
+| Cross-worktree mutation | pre-execute path check against `git worktree list` | abort |
+| `gh pr merge` | command match | abort — sibling skills handle this |
+| Branch deletion (`git branch -D`, `gh api -X DELETE` against branches) | command match | abort |
+| Reopen of a non-self closed issue | command match | abort |
+
+The list lives in `references/safety-gates.md` as the SSOT `ABSOLUTE_BLOCK_PATTERNS`. Triggering it: skill aborts, comments on the proceed issue with `[blocked] absolute prohibition triggered: <pattern>`, leaves the proceed issue open for manual review.
+
+### 4.2 Layer 2 — Conditional permissions (allowed only when §safety explicitly opts in)
+
+| Action | Required §safety token (exact substring) |
+|---|---|
+| Bulk-close (≥5 issues) | `allow: bulk-close` |
+| Bulk-create (≥5 new issues) | `allow: bulk-create-issue` |
+| Force-with-lease push | `allow: force-with-lease` |
+| Non-allowlisted outbound network | `allow: net: <host glob>` |
+| Cross-repo mutation | `allow: cross-repo: <owner/repo>` |
+
+Default-deny. Missing token → action treated as Layer-1 abort.
+
+### 4.3 Layer 3 — Pre-flight (Step 5 entry, parallel)
+
+All must pass or skill stops with hint:
+
+- Current branch ≠ default (only enforced when mutation class — §5.1).
+- No untracked secret-shaped files (`.env`, `*.pem`, `*.key`) in working tree.
+- `gh auth status` succeeds.
+- §preconditions block executes successfully (dry-run any embedded check commands).
+
+### 4.4 Layer 4 — Runtime monitors
+
+| Monitor | Default | Override |
+|---|---|---|
+| Per-step timeout | 5 min | §preconditions may state `per-step timeout: <N>m` |
+| Global timeout | 60 min | §preconditions may state `global timeout: <N>m` |
+| Output secret scanner | always on | none — never overrideable |
+| Write-action quota | per-type ceiling 5 (close / create / commit / pr / comment counted separately, excluding self-comment / self-close) **and** total ceiling 20 across all types | §safety `allow: bulk-close`/`bulk-create-issue` raises the matching per-type ceiling to 50; total ceiling stays 20 unless §safety also declares `allow: total-quota: <N>` |
+| Edit-path memory | always on | none — needed for §6 audit |
+
+---
+
+## 5. Execution semantics (`references/execution-flow.md`)
+
+### 5.1 Conditional worktree precondition
+
+Mutation-required keywords scanned in §deliverables ∪ §execution_protocol ∪ §decision_rules:
+
+- `commit_changes`, `Skill(gh:commit)`, `git commit`
+- `open_pr`, `Skill(gh:pr)`, `gh pr create`
+- `queue_doc_patch`
+- "신규 파일" / "new file" in deliverables
+
+Precondition classes:
+
+| Class | Trigger | Requirements |
+|---|---|---|
+| `read-only` | no mutation keyword | git repo only; any branch OK |
+| `mutation-required` | ≥1 mutation keyword | worktree + non-default branch + clean tree |
+| `mixed` | mutation + `allow: cross-repo` | mutation-required + cross-repo permission check |
+| `verify-only` (override) | §track = `verify-only` | force read-only regardless of keywords |
+
+Class is logged to stdout on Step 1 entry. Mismatch (e.g., `mutation-required` while on `main`) → fail with remediation hint.
+
+### 5.2 Step loop (pseudocode)
+
+```
+parsed_steps = parse(execution_protocol)              # matrix or numbered
+
+for step in parsed_steps:
+    TaskCreate(subject="Step <n>: <description>",
+               activeForm="Executing step <n>")
+    start = now()
+
+    result = LLM.execute(
+        step,
+        out_of_scope=section_content["out_of_scope"],
+        safety_layer1=ABSOLUTE_BLOCK_PATTERNS,
+    )
+
+    classification = LLM.classify(
+        result,
+        allowed=decision_rules.keywords,
+        fail_closed_on_unknown=True,                  # never invent a class
+    )
+
+    action_verb = decision_rules[classification]
+    apply(action_verb)                                # §5.3
+
+    TaskUpdate(taskId=step.id, status=completed,
+               metadata={"result": ..., "classification": ...})
+
+    if now() - start > per_step_timeout:
+        # retroactive TIMEOUT
+        apply(decision_rules["TIMEOUT"])
+
+if all_done_criteria_met and no_abort:
+    close_proceed_issue()
+else:
+    keep_open + final_comment
+
+# done_criteria_met semantics:
+#   - Parse all `- [ ]` and `- [x]` items from section_content["done_criteria"].
+#   - Items already `- [x]` in the body are assumed pre-satisfied (authoring-time).
+#   - For each `- [ ]` item, the skill matches it against executed write actions
+#     and step classifications. If every `- [ ]` item has a matching audit entry,
+#     done_criteria_met = True.
+#   - If matching is ambiguous (item text doesn't clearly map to any verb),
+#     done_criteria_met = False — skill keeps the issue open.
+```
+
+### 5.3 Action verb registry (`references/execution-flow.md`)
+
+Fixed allowlist. Unknown verb in decision rule → fail-closed at parse time.
+
+| Verb | Implementation |
+|---|---|
+| `continue` | proceed to next step |
+| `file_issue: <template-key>` | `Skill(gh:issue-create, payload=...)`. **Template source**: the issue body's §decision_rules section defines named templates inline (e.g., a markdown sub-block under the rule row) — the `<template-key>` references that block by name. If no template is found, the skill substitutes a minimal default `{title: "<auto>", body: "Filed by /gh:issue-proceed from #<N> step <s>", labels: []}`. |
+| `queue_doc_patch: <file>` | accumulate; flushed as single commit + PR in Step 6 |
+| `comment_on_self: <body>` | `gh issue comment <PROCEED_N>` |
+| `comment_on_other: <N> <body>` | `gh issue comment <N>` |
+| `commit_changes` | `Skill(gh:commit)` |
+| `open_pr` | `Skill(gh:pr)` |
+| `close_issue: <N>` | `gh issue close <N>` |
+| `abort_all` | break + final report; proceed issue stays open |
+| `skip` | record result only; next step |
+
+### 5.4 Composition payload protocol
+
+When the skill calls another skill, payload is **always structured** (no free-form prompt):
+
+```
+Skill(gh:issue-create, prompt=<<STRUCTURED
+TITLE: <...>
+BODY: <markdown>
+LABELS: <comma-list>
+NO_INTERACTIVE: true
+STRUCTURED)
+```
+
+Callees that see `NO_INTERACTIVE: true` skip confirmation prompts. This contract must be added to each composed skill in a follow-up. (Tracked as part of implementation; not blocking the proceed skill itself.)
+
+---
+
+## 6. Reporting (`references/report-format.md`)
+
+### 6.1 Per-step audit (always)
+
+| # | Step | Result | Classification | Verb applied | Duration |
+|---|---|---|---|---|---|
+| 1 | help | PASS | PASS | continue | 4s |
+| 2 | stock list 1 10 | FAIL-CLI | FAIL-CLI | file_issue: #NN | 12s |
+| ... | | | | | |
+
+### 6.2 Write-action audit
+
+```markdown
+### Write actions executed
+| # | Action | Target | Triggered by step | Triggered by rule |
+|---|---|---|---|---|
+
+### Blocked attempts
+(none) | <list>
+
+### Aborts
+(none) | reason: <layer-N pattern>
+```
+
+### 6.3 Done-criteria reconciliation
+
+Compare §done_criteria checklist to actual matrix outcomes. Any unchecked item lists the reason ("step skipped: SKIP-NET", etc.).
+
+### 6.4 Outcome
+
+| All done + no abort | partial | abort |
+|---|---|---|
+| `close_issue: <self>` + final comment | keep-open + final comment with `N/M criteria met` | keep-open + final comment with `[aborted] <layer> <pattern>` |
+
+### 6.5 `ai-metrics`
+
+```
+[ai-metrics:gh-issue-proceed] ~{ELAPSED} min — write actions: {N}, blocked: {M}
+```
+
+---
+
+## 7. File layout
+
+```
+~/dotfiles/claude/skills/gh-issue-proceed/
+├── SKILL.md                          (~120 lines: 4-step shell + Constraints)
+└── references/
+    ├── help.md                       (full --help)
+    ├── repo-resolution.md            (reuse strategy decided in impl)
+    ├── fetch-issue.md                (reuse strategy decided in impl)
+    ├── claim.md                      (reuse strategy decided in impl)
+    ├── protocol-schema.md            (§3 — 8 sections, aliases, parser)
+    ├── preconditions.md              (§5.1 — 4-class detection)
+    ├── execution-flow.md             (§5.2-5.4 — step loop, verb registry, payload)
+    ├── safety-gates.md               (§4 — 4 layers, ABSOLUTE_BLOCK_PATTERNS SSOT)
+    └── report-format.md              (§6 — audit templates)
+```
+
+> The three "reuse" files (`repo-resolution`, `fetch-issue`, `claim`) currently exist in `/gh:issue-implement` and `/gh:issue-read`. Reuse strategy (symlink vs copy vs new module) is left to the implementation plan — both options are valid; preference depends on dotfiles conventions to be confirmed during writing-plans.
+
+---
+
+## 8. Testing
+
+| Layer | Approach |
+|---|---|
+| Schema validator | unit test (bats or shell). Fixtures: all-OK, 1-missing, empty-section, H3-nested, KO-aliases |
+| Step parser | unit test. Fixtures: matrix-only, numbered-only, mixed-malformed |
+| Safety Layer 1 patterns | regex unit tests per pattern |
+| End-to-end smoke | run the skill on its own tracking issue (the one created in step §10) in a sandboxed scratch issue context |
+| Composition payload | mock Skill() calls; assert STRUCTURED payload shape |
+
+Test home: `~/dotfiles/claude/skills/gh-issue-proceed/tests/` (introduces test-dir convention if absent; confirm during writing-plans).
+
+---
+
+## 9. Edge cases
+
+| Case | Behavior |
+|---|---|
+| Issue closed already | Step 3 refusal (`already closed`); precedes schema check |
+| Hierarchical execution_protocol (sub-protocols at H4+) | Only the canonical execution_protocol section is parsed for steps; H4 content is context only |
+| Re-running a partially-done issue | TaskList consulted; resume at first non-completed step IF the issue body declares `Re-runnable: true`; else abort with `[manual-review] non-idempotent rerun` |
+| Network failure mid-step | retry once; second failure → BLOCKED via decision rules |
+| Directive itself is broken (references nonexistent file/command) | classify as FAIL; comment `[doc-bug] protocol references nonexistent <X>`; abort |
+| Decision rules don't cover an actual result class | first unhandled → BLOCKED; counts as dynamic schema violation |
+
+---
+
+## 10. Acceptance criteria (for the implementation issue)
+
+- [ ] `SKILL.md` at `~/dotfiles/claude/skills/gh-issue-proceed/` ≤ 150 lines, 4-step shell + Constraints
+- [ ] All 8 `references/*.md` files present and SSOT-consistent with this design
+- [ ] Schema validator passes 5 fixture variants (all-OK, missing, empty, H3, KO)
+- [ ] Safety Layer 1 patterns covered by unit tests (one positive + one negative per pattern)
+- [ ] End-to-end smoke test against a scratch directive issue passes
+- [ ] Sibling skill descriptions (`gh-issue-implement`, `gh-issue-read`) updated to cross-link `[[gh:issue-proceed]]`
+- [ ] PR opened against `~/dotfiles` `main`; CI green
+- [ ] Tracking issue (filed alongside this design) closed automatically via PR's `Closes #<N>`
+
+---
+
+## 11. Open questions (resolved during writing-plans)
+
+1. Reuse strategy for `repo-resolution.md` / `fetch-issue.md` / `claim.md` — symlink, copy, or extract to shared `claude/skills/_lib/`?
+2. Test convention — does dotfiles already have a per-skill test pattern, or does this skill introduce one?
+3. `STRUCTURED` payload contract on composed skills — needs follow-up edits to `/gh:commit`, `/gh:pr`, `/gh:issue-create`; sequence vs. parallel with this skill's PR.
+4. Should the skill emit step-completion markers (`[step:gh-issue-proceed/<name>] OK`) for harness step-skip guard, mirroring `/gh:issue-implement` (issue #753 pattern in dotfiles)?

--- a/docs/feature/gh-issue-proceed-skill/plan.md
+++ b/docs/feature/gh-issue-proceed-skill/plan.md
@@ -1,0 +1,1466 @@
+# /gh:issue-proceed Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `/gh:issue-proceed` skill at `~/dotfiles/claude/skills/gh-issue-proceed/` per the design at `docs/feature/gh-issue-proceed-skill/design.md`, with full bats test coverage and cross-linked sibling skills.
+
+**Architecture:** Approach A — slim wrapper mirroring `/gh:issue-implement` 6-step shell. Markdown SSOTs at `references/*.md`; executable mirrors at `tests/bats/skills/_fixtures/gh_issue_proceed_*.sh`; bats tests at `tests/bats/skills/gh_issue_proceed_*.bats`.
+
+**Tech Stack:** Bash 5+, Bats (already installed at `~/dotfiles/tests/bats/lib/bats-core/`), `gh` CLI, `jq`, markdown.
+
+---
+
+## Open Question Resolutions (settled)
+
+| Q | Resolution |
+|---|---|
+| Q1 — Reuse strategy | **COPY** each shared reference (`repo-resolution.md`, `fetch-issue.md`, `claim.md`) from sibling skills. Matches dotfiles convention (see existing `gh-issue-implement/` vs `gh-issue-read/` — they have copies, not symlinks). |
+| Q2 — Test convention | `tests/bats/skills/gh_issue_proceed_*.bats` + `tests/bats/skills/_fixtures/gh_issue_proceed_*.sh`. Source-of-truth = markdown; fixtures kept in sync per dotfiles `claim.md` ↔ `claim.sh` precedent. |
+| Q3 — STRUCTURED payload | v1 = plain `Skill(gh:commit)` / `Skill(gh:pr)` / `Skill(gh:issue-create)` invocations (composed skills' current contracts). STRUCTURED payload contract deferred to a follow-up issue filed at PR time. |
+| Q4 — Step-completion markers | YES — mirror `/gh:issue-implement` pattern. Emit at: `fetch-issue`, `schema-validate`, `execute`, `report`. |
+
+---
+
+## File Structure
+
+### New files (created by this plan)
+
+| Path | Responsibility |
+|---|---|
+| `claude/skills/gh-issue-proceed/SKILL.md` | 4-step shell + frontmatter + Constraints. ≤ 150 lines. |
+| `claude/skills/gh-issue-proceed/references/help.md` | Full `--help` output (verbatim). |
+| `claude/skills/gh-issue-proceed/references/repo-resolution.md` | Copy from gh-issue-implement, rename skill ref. |
+| `claude/skills/gh-issue-proceed/references/fetch-issue.md` | Copy from gh-issue-implement, rename skill ref. |
+| `claude/skills/gh-issue-proceed/references/claim.md` | Copy from gh-issue-implement, rename skill ref. |
+| `claude/skills/gh-issue-proceed/references/protocol-schema.md` | 8-section schema + aliases + parser algorithm (SSOT). |
+| `claude/skills/gh-issue-proceed/references/preconditions.md` | 4-class detector algorithm + mutation keyword list (SSOT). |
+| `claude/skills/gh-issue-proceed/references/execution-flow.md` | Step parser + verb registry + step loop pseudocode (SSOT). |
+| `claude/skills/gh-issue-proceed/references/safety-gates.md` | 4-layer gates + `ABSOLUTE_BLOCK_PATTERNS` list (SSOT). |
+| `claude/skills/gh-issue-proceed/references/report-format.md` | §6 audit templates. |
+| `tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh` | Executable mirror of schema parser. |
+| `tests/bats/skills/_fixtures/gh_issue_proceed_preconditions.sh` | Executable mirror of class detector. |
+| `tests/bats/skills/_fixtures/gh_issue_proceed_steps.sh` | Executable mirror of step parser. |
+| `tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh` | Executable mirror of safety pattern matcher. |
+| `tests/bats/skills/gh_issue_proceed_schema.bats` | 5 fixture variants: all-OK / 1-missing / empty / H3-nested / KO-aliases. |
+| `tests/bats/skills/gh_issue_proceed_preconditions.bats` | 4 class detection cases. |
+| `tests/bats/skills/gh_issue_proceed_steps.bats` | Matrix mode + numbered mode + malformed cases. |
+| `tests/bats/skills/gh_issue_proceed_safety.bats` | Positive + negative for each `ABSOLUTE_BLOCK_PATTERNS` entry. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `claude/skills/gh-issue-implement/SKILL.md` (frontmatter `description`) | Add `Sister skill of [[gh:issue-proceed]] for directive issues.` |
+| `claude/skills/gh-issue-read/SKILL.md` (frontmatter `description`) | Add `Output feeds [[gh:issue-implement]] for code-change issues, [[gh:issue-proceed]] for directive issues.` |
+
+---
+
+## Task 1: Scaffold skill directory + SKILL.md skeleton
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md`
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/` (empty dir)
+
+- [ ] **Step 1.1: Create directory structure**
+
+```bash
+mkdir -p ~/dotfiles/claude/skills/gh-issue-proceed/references
+ls ~/dotfiles/claude/skills/gh-issue-proceed/
+```
+Expected: `references` listed; no other files.
+
+- [ ] **Step 1.2: Write SKILL.md skeleton**
+
+Create `~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md`:
+
+````markdown
+---
+name: gh:issue-proceed
+description: >-
+  Read a GitHub directive issue (containing an embedded 8-section
+  execution protocol) and proceed end-to-end without human
+  intervention — validating the protocol schema, executing the steps
+  per-rule, and (when the protocol authorizes) committing, opening
+  PRs, filing follow-ups, commenting on or closing the issue. Use
+  when the user runs /gh:issue-proceed, /gh-issue-proceed, or asks
+  "이 작업지시서대로 진행해", "issue #N 끝까지 자동으로", "#78 진행해".
+  Sister of /gh:issue-implement — distinct intent: this skill handles
+  verify/triage/analysis/audit "work order" issues, not code-change
+  requests. Refuses any issue lacking the 8 required sections (Goal,
+  Preconditions, Execution Protocol, Decision Rules, Deliverables,
+  Done Criteria, Out of Scope, Safety / Abort). Auto-detects
+  read-only vs mutation-required precondition class from issue body.
+  Composes with /gh:commit, /gh:pr, /gh:issue-create for write
+  actions. Hard-blocks PR merge, force-push, secret leakage, and
+  cross-worktree mutation regardless of issue content. Accepts
+  `<issue-number> [remote]` and `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write, Skill
+---
+
+# gh:issue-proceed — Directive Issue → End-to-End Execution
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Parse Args + Repo + Preconditions
+
+(stub — wired in Task 11)
+
+## Step 3: Fetch + Claim + Schema-Validate
+
+(stub — wired in Task 12)
+
+## Step 5: Execute Protocol
+
+(stub — wired in Task 13)
+
+## Step 6: Report + Close
+
+(stub — wired in Task 14)
+
+## Constraints
+
+Read `references/safety-gates.md` Layer 1 before relaxing any of these:
+never `gh pr merge`, never force-push, never leak secrets, never
+mutate cross-worktree paths, never reopen non-self closed issues.
+````
+
+- [ ] **Step 1.3: Verify file**
+
+```bash
+wc -l ~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md
+```
+Expected: 30-50 lines.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/SKILL.md
+git -C ~/dotfiles commit -m "feat(skill): Scaffold /gh:issue-proceed skill directory
+
+T1 of #874 — SKILL.md skeleton with frontmatter + step stubs.
+Implementation tasks 2-15 follow."
+```
+
+---
+
+## Task 2: Copy shared references from gh-issue-implement
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/repo-resolution.md`
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/fetch-issue.md`
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/claim.md`
+
+- [ ] **Step 2.1: Copy three reference files**
+
+```bash
+cp ~/dotfiles/claude/skills/gh-issue-implement/references/repo-resolution.md \
+   ~/dotfiles/claude/skills/gh-issue-proceed/references/repo-resolution.md
+cp ~/dotfiles/claude/skills/gh-issue-implement/references/fetch-issue.md \
+   ~/dotfiles/claude/skills/gh-issue-proceed/references/fetch-issue.md
+cp ~/dotfiles/claude/skills/gh-issue-implement/references/claim.md \
+   ~/dotfiles/claude/skills/gh-issue-proceed/references/claim.md
+```
+
+- [ ] **Step 2.2: Rewrite skill name + step references**
+
+Use `Edit` on each of the 3 files:
+
+In `repo-resolution.md`:
+- Replace `gh:issue-implement` → `gh:issue-proceed`
+- Replace `Step 3 of the` → `Step 3 of the` (no change — same step number)
+
+In `fetch-issue.md`:
+- Replace `gh:issue-implement` → `gh:issue-proceed`
+
+In `claim.md`:
+- Replace `gh:issue-implement` → `gh:issue-proceed`
+
+Use `grep -n "gh:issue-implement" claim.md repo-resolution.md fetch-issue.md` to verify zero matches after.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/
+git -C ~/dotfiles commit -m "feat(skill): Copy shared references for /gh:issue-proceed
+
+T2 of #874 — repo-resolution / fetch-issue / claim copied from
+gh-issue-implement and renamed. COPY strategy per design Q1
+(matches existing dotfiles convention)."
+```
+
+---
+
+## Task 3: Write `references/help.md`
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/help.md`
+
+- [ ] **Step 3.1: Author help content**
+
+````markdown
+# gh:issue-proceed — Help
+
+## Usage
+
+```
+/gh:issue-proceed <issue-number> [remote]
+/gh-issue-proceed <issue-number> [remote]
+```
+
+## Arguments
+
+| Arg | Description | Default |
+|---|---|---|
+| `<issue-number>` | GitHub issue number containing a directive protocol | — |
+| `[remote]` | Git remote whose repo owns the issue | `origin` |
+
+## What it does
+
+Reads the issue, validates that the body contains the 8-section
+directive schema, executes the embedded protocol end-to-end, and
+applies write actions (commit / PR / comment / close / file
+follow-up) per the protocol's `Decision Rules`. Refuses if the
+schema is incomplete.
+
+## Required issue body sections
+
+`Goal`, `Preconditions`, `Execution Protocol`, `Decision Rules`,
+`Deliverables`, `Done Criteria`, `Out of Scope`, `Safety / Abort`.
+Aliases listed in `references/protocol-schema.md`.
+
+## Sibling skills
+
+- `/gh:issue-implement` — for code-change issues (not directives).
+- `/gh:issue-read` — to inspect an issue before deciding which skill
+  to use.
+
+## Hard-blocked actions (regardless of issue body)
+
+- `gh pr merge` (use `/gh:pr-merge`)
+- `git push --force` (only `--force-with-lease` with explicit
+  `allow: force-with-lease` in §Safety)
+- Secret leakage to GitHub
+- Cross-worktree mutation
+- Reopening a non-self closed issue
+
+## Exit codes
+
+- `0` — success, issue closed
+- `1` — schema validation failed; nothing posted to GitHub
+- `2` — safety gate triggered; issue kept open with audit comment
+- `3` — done criteria not met after protocol exhausted; issue kept open
+
+See `docs/feature/gh-issue-proceed-skill/design.md` for full
+behavior spec.
+````
+
+- [ ] **Step 3.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/help.md
+git -C ~/dotfiles commit -m "feat(skill): Add help.md for /gh:issue-proceed
+
+T3 of #874."
+```
+
+---
+
+## Task 4: Write `references/protocol-schema.md` SSOT
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/protocol-schema.md`
+
+- [ ] **Step 4.1: Author schema content (~100 lines)**
+
+Translate design §3 verbatim into the SSOT. Include:
+
+1. The 8-section table with aliases (copy from design.md §3.1).
+2. The "Empty" definition (50 chars after stripping).
+3. The H2/H3 parsing rule.
+4. The `## Validator algorithm` section with pseudocode:
+
+````markdown
+## Validator algorithm
+
+```
+1. body = issue_body_markdown
+2. headings = extract_headings(body, levels=[2, 3])
+3. for each heading h:
+       normalized = lower(strip_numeric_prefix(strip_punctuation(h.text)))
+       captures[normalized] = content_until_next_heading(h, body)
+4. for each required_section in [goal, preconditions, ..., safety]:
+       match = find_first_alias_match(required_section.aliases, captures)
+       if no match: missing += [required_section.key]
+       else if empty(captures[match]): empty += [required_section.key]
+       else if special_rule(required_section) fails: invalid += [required_section.key]
+5. if any of missing/empty/invalid: emit error report (design §3.4), exit 1
+6. return SectionContent map
+```
+````
+
+5. Add `## Section content access keys` (so downstream files have a stable contract):
+
+```
+goal | preconditions | execution_protocol | decision_rules | deliverables | done_criteria | out_of_scope | safety | background? | references? | track?
+```
+
+- [ ] **Step 4.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/protocol-schema.md
+git -C ~/dotfiles commit -m "feat(skill): Add protocol-schema.md SSOT
+
+T4 of #874 — 8-section schema with aliases, empty-content rules,
+validator algorithm, and stable section content keys."
+```
+
+---
+
+## Task 5: Write schema parser fixture (TDD red)
+
+**Files:**
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh`
+
+- [ ] **Step 5.1: Write the executable mirror**
+
+````bash
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh
+# Source-of-truth mirror for the validator in
+#   claude/skills/gh-issue-proceed/references/protocol-schema.md
+# Keep in sync whenever schema rules change.
+
+set -u
+
+# Required section keys + alias regex (case-insensitive, ALT in OR).
+gh_issue_proceed_required_sections() {
+    cat <<'EOF'
+goal|goal|목표
+preconditions|preconditions|사전 조건|prerequisites
+execution_protocol|execution protocol|execution matrix|실행 절차|steps
+decision_rules|decision rules|결정 규칙|branching|decision matrix
+deliverables|deliverables|산출물|output|outputs
+done_criteria|done criteria|종료 조건|acceptance|acceptance criteria
+out_of_scope|out of scope|out-of-scope|범위 밖
+safety|safety|safety / abort|abort|안전 규칙|safety rules
+EOF
+}
+
+# Lowercase + strip numeric prefix (e.g. "5. Deliverables" → "deliverables").
+gh_issue_proceed_normalize_heading() {
+    local s="$1"
+    s="$(printf '%s' "$s" | sed -E 's/^[#[:space:]]+//; s/^[0-9]+\.[[:space:]]*//')"
+    printf '%s' "$s" | tr '[:upper:]' '[:lower:]' | sed -E 's/[[:space:]]+$//'
+}
+
+# Strip whitespace, list markers, code fences for "empty" check.
+gh_issue_proceed_content_size() {
+    printf '%s' "$1" \
+        | sed -E 's/```//g; s/^[-*][[:space:]]+//; s/^[0-9]+\.[[:space:]]+//' \
+        | tr -d '[:space:]' \
+        | wc -c \
+        | tr -d '[:space:]'
+}
+
+# Validate a body file. Output: zero lines on OK; one line per error otherwise.
+# Exit code: 0 OK, 1 schema-invalid.
+gh_issue_proceed_validate_body() {
+    local body_file="$1"
+    local err_count=0
+
+    while IFS='|' read -r key aliases; do
+        # Find heading line containing one of the aliases.
+        local found_heading=""
+        while IFS= read -r heading_line; do
+            local normalized
+            normalized="$(gh_issue_proceed_normalize_heading "$heading_line")"
+            local IFS_old="$IFS"; IFS='|'
+            for alias in $aliases; do
+                if [ -n "$alias" ] && printf '%s' "$normalized" | grep -qF "$alias"; then
+                    found_heading="$heading_line"
+                    break
+                fi
+            done
+            IFS="$IFS_old"
+            [ -n "$found_heading" ] && break
+        done < <(grep -E '^(##|###) ' "$body_file")
+
+        if [ -z "$found_heading" ]; then
+            echo "missing: $key"
+            err_count=$((err_count + 1))
+            continue
+        fi
+
+        # Extract content between this heading and the next H2/H3.
+        local content
+        content="$(awk -v h="$found_heading" '
+            $0 == h {capture=1; next}
+            capture && /^(##|###) / {exit}
+            capture
+        ' "$body_file")"
+
+        if [ "$(gh_issue_proceed_content_size "$content")" -lt 50 ]; then
+            # Special-case execution_protocol + done_criteria handled later
+            echo "empty: $key"
+            err_count=$((err_count + 1))
+        fi
+    done < <(gh_issue_proceed_required_sections)
+
+    [ "$err_count" -eq 0 ]
+}
+````
+
+- [ ] **Step 5.2: Verify shellcheck clean**
+
+```bash
+shellcheck ~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git -C ~/dotfiles add tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh
+git -C ~/dotfiles commit -m "test(skill): Add executable mirror for /gh:issue-proceed schema validator
+
+T5 of #874 — bash fixture mirroring protocol-schema.md. Bats suite
+in T6 will exercise this fixture."
+```
+
+---
+
+## Task 6: Write bats tests for schema validator (TDD green)
+
+**Files:**
+- Create: `~/dotfiles/tests/bats/skills/gh_issue_proceed_schema.bats`
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_bodies/all_ok.md`
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_bodies/missing_safety.md`
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_bodies/empty_decision_rules.md`
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_bodies/h3_nested.md`
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_bodies/ko_aliases.md`
+
+- [ ] **Step 6.1: Create fixture issue bodies**
+
+Each fixture is a minimal valid (or intentionally invalid) directive issue body.
+
+`all_ok.md`:
+````markdown
+## Goal
+Build and verify thing X end-to-end within 60 minutes.
+## Preconditions
+- Backend running on port 8000
+- gh CLI authenticated
+## Execution Protocol
+| # | Step | Command | Expected |
+|---|---|---|---|
+| 1 | warmup | echo hi | hi |
+## Decision Rules
+| PASS | continue |
+| FAIL | abort_all |
+## Deliverables
+Final report comment on this issue.
+## Done Criteria
+- [ ] step 1 PASS
+- [ ] final comment posted
+## Out of Scope
+- DB mutations
+- PR merge
+## Safety / Abort
+- Hard block on secret leakage
+- Hard block on force push
+````
+
+`missing_safety.md`: identical to `all_ok.md` but with the `## Safety / Abort` section removed entirely.
+
+`empty_decision_rules.md`: identical to `all_ok.md` but `## Decision Rules` heading is followed by no content (next heading immediately).
+
+`h3_nested.md`: like `all_ok.md` but all sections are H3 instead of H2 (e.g. `### Goal`).
+
+`ko_aliases.md`: identical structure but Korean headings (`## 목표`, `## 사전 조건`, `## 실행 절차`, `## 결정 규칙`, `## 산출물`, `## 종료 조건`, `## 범위 밖`, `## 안전 규칙`).
+
+- [ ] **Step 6.2: Write bats suite**
+
+````bash
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_proceed_schema.bats
+# Validates the source-of-truth mirror of
+#   claude/skills/gh-issue-proceed/references/protocol-schema.md
+# Five fixtures exercise: all-OK, missing section, empty section,
+# H3-nested, KO aliases.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh"
+    FIXTURE_DIR="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_bodies"
+}
+
+teardown() { teardown_isolated_home; }
+
+@test "schema: all 8 sections present and well-formed → OK" {
+    run gh_issue_proceed_validate_body "$FIXTURE_DIR/all_ok.md"
+    assert_success
+}
+
+@test "schema: missing 'Safety / Abort' section → fail" {
+    run gh_issue_proceed_validate_body "$FIXTURE_DIR/missing_safety.md"
+    assert_failure
+    assert_output --partial "missing: safety"
+}
+
+@test "schema: empty 'Decision Rules' content → fail" {
+    run gh_issue_proceed_validate_body "$FIXTURE_DIR/empty_decision_rules.md"
+    assert_failure
+    assert_output --partial "empty: decision_rules"
+}
+
+@test "schema: H3 headings instead of H2 → OK" {
+    run gh_issue_proceed_validate_body "$FIXTURE_DIR/h3_nested.md"
+    assert_success
+}
+
+@test "schema: Korean aliases (목표 / 사전 조건 / ...) → OK" {
+    run gh_issue_proceed_validate_body "$FIXTURE_DIR/ko_aliases.md"
+    assert_success
+}
+````
+
+- [ ] **Step 6.3: Run tests, expect green**
+
+```bash
+~/dotfiles/tests/bats/lib/bats-core/bin/bats ~/dotfiles/tests/bats/skills/gh_issue_proceed_schema.bats
+```
+Expected: 5 tests pass. If any fail, edit the fixture (`gh_issue_proceed_schema.sh`) and re-run — do not loosen the test cases.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git -C ~/dotfiles add tests/bats/skills/gh_issue_proceed_schema.bats \
+    tests/bats/skills/_fixtures/gh_issue_proceed_bodies/
+git -C ~/dotfiles commit -m "test(skill): Cover /gh:issue-proceed schema validator (5 fixtures)
+
+T6 of #874 — all-OK, missing, empty, H3-nested, KO-aliases."
+```
+
+---
+
+## Task 7: Write `references/preconditions.md` SSOT
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/preconditions.md`
+
+- [ ] **Step 7.1: Author content (~60 lines)**
+
+Translate design §5.1 verbatim. Include:
+
+- 4-class table (read-only / mutation-required / mixed / verify-only)
+- Mutation keyword list (verbatim from design)
+- Detection pseudocode:
+
+````markdown
+## Class detection algorithm
+
+```
+1. If section_content.track == "verify-only": class = verify-only; return.
+2. haystack = concat(execution_protocol, decision_rules, deliverables)
+3. for kw in MUTATION_KEYWORDS:
+       if kw in haystack: mutation = True; break
+4. If mutation:
+       if "allow: cross-repo:" in section_content.safety: class = mixed
+       else: class = mutation-required
+   else:
+       class = read-only
+5. return class
+```
+```
+
+MUTATION_KEYWORDS = [
+    "commit_changes",
+    "Skill(gh:commit)",
+    "git commit",
+    "open_pr",
+    "Skill(gh:pr)",
+    "gh pr create",
+    "queue_doc_patch",
+    "신규 파일",
+    "new file",
+]
+````
+
+- [ ] **Step 7.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/preconditions.md
+git -C ~/dotfiles commit -m "feat(skill): Add preconditions.md SSOT (4-class detector)
+
+T7 of #874 — verify-only / read-only / mutation-required / mixed
+class detection algorithm + MUTATION_KEYWORDS list."
+```
+
+---
+
+## Task 8: Write preconditions fixture + bats (TDD)
+
+**Files:**
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_preconditions.sh`
+- Create: `~/dotfiles/tests/bats/skills/gh_issue_proceed_preconditions.bats`
+
+- [ ] **Step 8.1: Write fixture shell**
+
+````bash
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_proceed_preconditions.sh
+# Mirror of claude/skills/gh-issue-proceed/references/preconditions.md
+
+set -u
+
+GH_ISSUE_PROCEED_MUTATION_KEYWORDS=(
+    "commit_changes"
+    "Skill(gh:commit)"
+    "git commit"
+    "open_pr"
+    "Skill(gh:pr)"
+    "gh pr create"
+    "queue_doc_patch"
+    "신규 파일"
+    "new file"
+)
+
+# Inputs (env):
+#   FAKE_TRACK            — "verify-only" or ""
+#   FAKE_BODY             — concat of execution_protocol + decision_rules + deliverables
+#   FAKE_SAFETY           — safety section content
+#
+# Output: class name on stdout. Exit 0.
+gh_issue_proceed_classify() {
+    if [ "${FAKE_TRACK:-}" = "verify-only" ]; then
+        echo "verify-only"; return 0
+    fi
+    local mutation=0
+    for kw in "${GH_ISSUE_PROCEED_MUTATION_KEYWORDS[@]}"; do
+        if printf '%s' "${FAKE_BODY:-}" | grep -qF "$kw"; then
+            mutation=1
+            break
+        fi
+    done
+    if [ "$mutation" -eq 1 ]; then
+        if printf '%s' "${FAKE_SAFETY:-}" | grep -qF "allow: cross-repo:"; then
+            echo "mixed"
+        else
+            echo "mutation-required"
+        fi
+    else
+        echo "read-only"
+    fi
+}
+````
+
+- [ ] **Step 8.2: Write bats suite**
+
+````bash
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_proceed_preconditions.bats
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_preconditions.sh"
+}
+teardown() { teardown_isolated_home; unset FAKE_TRACK FAKE_BODY FAKE_SAFETY; }
+
+@test "preconditions: verify-only track → verify-only" {
+    FAKE_TRACK="verify-only"
+    FAKE_BODY="git commit -m foo"   # would otherwise trigger mutation
+    run gh_issue_proceed_classify
+    assert_output "verify-only"
+}
+
+@test "preconditions: no mutation keyword → read-only" {
+    FAKE_BODY="gh issue comment 78"
+    run gh_issue_proceed_classify
+    assert_output "read-only"
+}
+
+@test "preconditions: 'git commit' present → mutation-required" {
+    FAKE_BODY="step 3: git commit -m 'docs'"
+    run gh_issue_proceed_classify
+    assert_output "mutation-required"
+}
+
+@test "preconditions: mutation + cross-repo allow → mixed" {
+    FAKE_BODY="Skill(gh:commit)"
+    FAKE_SAFETY="allow: cross-repo: dEitY719/other"
+    run gh_issue_proceed_classify
+    assert_output "mixed"
+}
+````
+
+- [ ] **Step 8.3: Run + commit**
+
+```bash
+~/dotfiles/tests/bats/lib/bats-core/bin/bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_preconditions.bats
+```
+Expected: 4 pass.
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/preconditions.md \
+    tests/bats/skills/_fixtures/gh_issue_proceed_preconditions.sh \
+    tests/bats/skills/gh_issue_proceed_preconditions.bats
+git -C ~/dotfiles commit -m "test(skill): Cover /gh:issue-proceed precondition class detector
+
+T8 of #874 — 4 cases (verify-only / read-only / mutation-required / mixed)."
+```
+
+---
+
+## Task 9: Write `references/execution-flow.md` SSOT
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/execution-flow.md`
+
+- [ ] **Step 9.1: Author content (~120 lines)**
+
+Translate design §5.2-5.4. Sections:
+
+1. **Step parsing** — matrix detection (markdown table with header `| # | ... |`), numbered detection (`^### \d+\.` or `^\d+\.`).
+2. **Step loop pseudocode** — exact code from design.md §5.2.
+3. **Action verb registry** — table from design §5.3 (with file_issue template clarification).
+4. **Composition payload** — design §5.4 (note that v1 uses plain Skill() invocation; STRUCTURED is v2 follow-up).
+5. **`done_criteria_met` semantics** — exact paragraph from design.
+
+- [ ] **Step 9.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/execution-flow.md
+git -C ~/dotfiles commit -m "feat(skill): Add execution-flow.md SSOT
+
+T9 of #874 — step parsing (matrix + numbered), step loop pseudocode,
+verb registry, composition payload notes, done-criteria semantics."
+```
+
+---
+
+## Task 10: Write step parser fixture + bats (TDD)
+
+**Files:**
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_steps.sh`
+- Create: `~/dotfiles/tests/bats/skills/gh_issue_proceed_steps.bats`
+
+- [ ] **Step 10.1: Fixture**
+
+````bash
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_proceed_steps.sh
+# Mirror step parser from execution-flow.md.
+
+set -u
+
+# Detect mode of execution_protocol section content.
+# stdin = section content. stdout = "matrix" | "numbered" | "none".
+gh_issue_proceed_step_mode() {
+    local content
+    content="$(cat)"
+    if printf '%s' "$content" | grep -qE '^\|.*#.*\|'; then
+        echo "matrix"; return
+    fi
+    if printf '%s' "$content" | grep -qE '^(### |^)[0-9]+\.[[:space:]]'; then
+        echo "numbered"; return
+    fi
+    echo "none"
+}
+
+# Count parsed steps. stdin = section content. stdout = integer.
+gh_issue_proceed_step_count() {
+    local content mode
+    content="$(cat)"
+    mode="$(printf '%s' "$content" | gh_issue_proceed_step_mode)"
+    case "$mode" in
+        matrix)
+            # Count data rows (table rows excluding header + separator).
+            printf '%s' "$content" \
+                | grep -cE '^\|' \
+                | awk '{print $1 - 2}'   # subtract header + separator
+            ;;
+        numbered)
+            printf '%s' "$content" \
+                | grep -cE '^(### |^)[0-9]+\.[[:space:]]'
+            ;;
+        none)
+            echo 0
+            ;;
+    esac
+}
+````
+
+- [ ] **Step 10.2: Bats**
+
+````bash
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_proceed_steps.bats
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_steps.sh"
+}
+teardown() { teardown_isolated_home; }
+
+@test "step parser: matrix mode detected from table header" {
+    run bash -c 'printf "| # | Step | Cmd |\n|---|---|---|\n| 1 | a | b |\n" | gh_issue_proceed_step_mode'
+    assert_output "matrix"
+}
+
+@test "step parser: numbered H3 mode detected" {
+    run bash -c 'printf "### 1. setup\nfoo\n### 2. run\nbar\n" | gh_issue_proceed_step_mode'
+    assert_output "numbered"
+}
+
+@test "step parser: plain numbered list mode detected" {
+    run bash -c 'printf "1. first\n2. second\n3. third\n" | gh_issue_proceed_step_mode'
+    assert_output "numbered"
+}
+
+@test "step parser: count matches matrix data rows" {
+    run bash -c 'printf "| # | A |\n|---|---|\n| 1 | x |\n| 2 | y |\n| 3 | z |\n" | gh_issue_proceed_step_count'
+    assert_output "3"
+}
+
+@test "step parser: count matches numbered items" {
+    run bash -c 'printf "### 1. a\n### 2. b\n### 3. c\n### 4. d\n" | gh_issue_proceed_step_count'
+    assert_output "4"
+}
+````
+
+- [ ] **Step 10.3: Run + commit**
+
+```bash
+~/dotfiles/tests/bats/lib/bats-core/bin/bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_steps.bats
+```
+Expected: 5 pass.
+
+```bash
+git -C ~/dotfiles add tests/bats/skills/_fixtures/gh_issue_proceed_steps.sh \
+    tests/bats/skills/gh_issue_proceed_steps.bats
+git -C ~/dotfiles commit -m "test(skill): Cover /gh:issue-proceed step parser
+
+T10 of #874 — matrix vs numbered detection + step count."
+```
+
+---
+
+## Task 11: Write `references/safety-gates.md` SSOT
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/safety-gates.md`
+
+- [ ] **Step 11.1: Author content (~80 lines)**
+
+Translate design §4 verbatim. Critical: define `ABSOLUTE_BLOCK_PATTERNS` as a stable bash array (so the fixture in T12 mirrors exact entries).
+
+````markdown
+## Layer 1 — ABSOLUTE_BLOCK_PATTERNS (SSOT)
+
+Each entry is a `pattern_name : regex` pair. The skill scans every
+intended command string before execution; first match → abort.
+
+```
+ABSOLUTE_BLOCK_PATTERNS=(
+    "force_push_default:git push.*--force.*(main|master)"
+    "force_push_any:git push.*--force([^-]|$)"
+    "rm_rf_outside_pwd:rm[[:space:]]+-rf?[[:space:]]+/"
+    "destructive_db:(admin[[:space:]]+reset|DROP[[:space:]]+TABLE|TRUNCATE|DELETE FROM [^W])"
+    "pr_merge:gh[[:space:]]+pr[[:space:]]+merge"
+    "branch_delete:git[[:space:]]+branch[[:space:]]+-D"
+    "reopen_external:gh[[:space:]]+issue[[:space:]]+reopen"
+)
+```
+
+Secret output scanner (post-execute regex on stdout/stderr):
+
+```
+SECRET_OUTPUT_PATTERNS=(
+    "secret_env_keyword:(API|AUTH|ACCESS|SECRET|TOKEN|PASSWORD)[_-]?(KEY|TOKEN|SECRET|PASS)?[[:space:]]*=[[:space:]]*[^[:space:]]{8,}"
+    "bearer_token:Bearer[[:space:]]+[A-Za-z0-9._-]{20,}"
+    "jwt:eyJ[A-Za-z0-9_=-]+\\.eyJ[A-Za-z0-9_=-]+\\.[A-Za-z0-9_.+/=-]+"
+)
+```
+````
+
+Plus paragraphs for Layers 2, 3, 4 from design §4.2-4.4.
+
+- [ ] **Step 11.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/safety-gates.md
+git -C ~/dotfiles commit -m "feat(skill): Add safety-gates.md SSOT (4 layers + ABSOLUTE_BLOCK_PATTERNS)
+
+T11 of #874."
+```
+
+---
+
+## Task 12: Write safety fixture + bats (TDD)
+
+**Files:**
+- Create: `~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh`
+- Create: `~/dotfiles/tests/bats/skills/gh_issue_proceed_safety.bats`
+
+- [ ] **Step 12.1: Fixture**
+
+````bash
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh
+# Mirror of safety-gates.md Layer 1 + output secret scanner.
+
+set -u
+
+ABSOLUTE_BLOCK_PATTERNS=(
+    "force_push_default:git push.*--force.*(main|master)"
+    "force_push_any:git push.*--force([^-]|$)"
+    "rm_rf_outside_pwd:rm[[:space:]]+-rf?[[:space:]]+/"
+    "destructive_db:(admin[[:space:]]+reset|DROP[[:space:]]+TABLE|TRUNCATE|DELETE FROM [^W])"
+    "pr_merge:gh[[:space:]]+pr[[:space:]]+merge"
+    "branch_delete:git[[:space:]]+branch[[:space:]]+-D"
+    "reopen_external:gh[[:space:]]+issue[[:space:]]+reopen"
+)
+
+SECRET_OUTPUT_PATTERNS=(
+    "secret_env_keyword:(API|AUTH|ACCESS|SECRET|TOKEN|PASSWORD)[_-]?(KEY|TOKEN|SECRET|PASS)?[[:space:]]*=[[:space:]]*[^[:space:]]{8,}"
+    "bearer_token:Bearer[[:space:]]+[A-Za-z0-9._-]{20,}"
+    "jwt:eyJ[A-Za-z0-9_=-]+\\.eyJ[A-Za-z0-9_=-]+\\.[A-Za-z0-9_.+/=-]+"
+)
+
+# stdin = command string. stdout = matching pattern_name or "OK".
+gh_issue_proceed_check_command() {
+    local cmd
+    cmd="$(cat)"
+    for entry in "${ABSOLUTE_BLOCK_PATTERNS[@]}"; do
+        local name="${entry%%:*}"
+        local rx="${entry#*:}"
+        if printf '%s' "$cmd" | grep -qE "$rx"; then
+            echo "$name"; return 1
+        fi
+    done
+    echo "OK"
+}
+
+# stdin = output text. stdout = matching pattern_name or "OK".
+gh_issue_proceed_scan_output() {
+    local out
+    out="$(cat)"
+    for entry in "${SECRET_OUTPUT_PATTERNS[@]}"; do
+        local name="${entry%%:*}"
+        local rx="${entry#*:}"
+        if printf '%s' "$out" | grep -qE "$rx"; then
+            echo "$name"; return 1
+        fi
+    done
+    echo "OK"
+}
+````
+
+- [ ] **Step 12.2: Bats — positive + negative per pattern**
+
+````bash
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_proceed_safety.bats
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh"
+}
+teardown() { teardown_isolated_home; }
+
+# --- ABSOLUTE_BLOCK_PATTERNS ---
+
+@test "safety: 'git push --force main' → force_push_default" {
+    run bash -c 'echo "git push --force origin main" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "force_push_default"
+}
+
+@test "safety: 'git push --force feat/x' → force_push_any" {
+    run bash -c 'echo "git push --force origin feat/x" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "force_push_any"
+}
+
+@test "safety: 'git push --force-with-lease' → OK" {
+    run bash -c 'echo "git push --force-with-lease origin feat/x" | gh_issue_proceed_check_command'
+    assert_success
+    assert_output "OK"
+}
+
+@test "safety: 'rm -rf /tmp/foo' → rm_rf_outside_pwd" {
+    run bash -c 'echo "rm -rf /tmp/foo" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "rm_rf_outside_pwd"
+}
+
+@test "safety: 'rm -rf ./build' → OK" {
+    run bash -c 'echo "rm -rf ./build" | gh_issue_proceed_check_command'
+    assert_success
+}
+
+@test "safety: 'gh pr merge 123' → pr_merge" {
+    run bash -c 'echo "gh pr merge 123" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "pr_merge"
+}
+
+@test "safety: 'gh pr view 123' → OK" {
+    run bash -c 'echo "gh pr view 123" | gh_issue_proceed_check_command'
+    assert_success
+}
+
+@test "safety: 'git branch -D old' → branch_delete" {
+    run bash -c 'echo "git branch -D old" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "branch_delete"
+}
+
+@test "safety: 'admin reset' → destructive_db" {
+    run bash -c 'echo "uv run python -m src.backend.cli.admin admin reset" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "destructive_db"
+}
+
+@test "safety: 'gh issue reopen 99' → reopen_external" {
+    run bash -c 'echo "gh issue reopen 99" | gh_issue_proceed_check_command'
+    assert_failure
+    assert_output "reopen_external"
+}
+
+# --- SECRET_OUTPUT_PATTERNS ---
+
+@test "safety: output with 'API_KEY=abcd1234...' → secret_env_keyword" {
+    run bash -c 'echo "config: API_KEY=abcd1234efgh5678" | gh_issue_proceed_scan_output'
+    assert_failure
+    assert_output "secret_env_keyword"
+}
+
+@test "safety: output with 'Authorization: Bearer <jwt>' → bearer_token" {
+    run bash -c 'echo "Authorization: Bearer abc123def456ghi789jkl" | gh_issue_proceed_scan_output'
+    assert_failure
+    assert_output "bearer_token"
+}
+
+@test "safety: clean output → OK" {
+    run bash -c 'echo "All tests pass." | gh_issue_proceed_scan_output'
+    assert_success
+}
+````
+
+- [ ] **Step 12.3: Run + commit**
+
+```bash
+~/dotfiles/tests/bats/lib/bats-core/bin/bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_safety.bats
+```
+Expected: 13 pass.
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/safety-gates.md \
+    tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh \
+    tests/bats/skills/gh_issue_proceed_safety.bats
+git -C ~/dotfiles commit -m "test(skill): Cover /gh:issue-proceed safety gates (Layer 1)
+
+T12 of #874 — positive + negative case for each ABSOLUTE_BLOCK_PATTERN
+and SECRET_OUTPUT_PATTERN."
+```
+
+---
+
+## Task 13: Write `references/report-format.md`
+
+**Files:**
+- Create: `~/dotfiles/claude/skills/gh-issue-proceed/references/report-format.md`
+
+- [ ] **Step 13.1: Author content (~80 lines)**
+
+Translate design §6 verbatim. Sections: per-step audit table template, write-action audit template, done-criteria reconciliation rules, outcome table (close vs keep-open vs abort), ai-metrics line.
+
+- [ ] **Step 13.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/references/report-format.md
+git -C ~/dotfiles commit -m "feat(skill): Add report-format.md SSOT
+
+T13 of #874 — per-step audit, write-action audit, done-criteria
+reconciliation, outcome table."
+```
+
+---
+
+## Task 14: Wire SKILL.md Step 1 — Parse args + Preconditions
+
+**Files:**
+- Modify: `~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md`
+
+- [ ] **Step 14.1: Replace Step 1 stub with full content**
+
+````markdown
+## Step 1: Parse Args + Repo + Preconditions
+
+Record `START_TS=$(date +%s)` immediately.
+
+Positional args: `<issue-number> [remote]`.
+
+| Arg | Description | Default | Required |
+|---|---|---|---|
+| `<issue-number>` | GitHub issue number (positive integer) | — | Yes |
+| `[remote]` | Git remote whose repo owns the issue | `origin` | No |
+
+Substeps:
+
+1. **Parse + validate args** — missing/invalid → print `Run /gh-issue-proceed -h for usage.` and stop.
+2. **Resolve `TARGET_REPO`** per `references/repo-resolution.md`. Missing remote → list `git remote -v` and stop.
+3. **Detect precondition class** per `references/preconditions.md` — done after Step 3 fetch since class depends on body content.
+
+The class-conditional checks (worktree, branch ≠ default, clean tree) fire in Step 3 immediately after schema validation succeeds.
+
+Emit `printf '[step:gh-issue-proceed/parse-args] OK\n'`.
+````
+
+- [ ] **Step 14.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/SKILL.md
+git -C ~/dotfiles commit -m "feat(skill): Wire /gh:issue-proceed SKILL.md Step 1
+
+T14 of #874."
+```
+
+---
+
+## Task 15: Wire SKILL.md Step 3 — Fetch + Claim + Schema-Validate
+
+**Files:**
+- Modify: `~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md`
+
+- [ ] **Step 15.1: Replace Step 3 stub**
+
+````markdown
+## Step 3: Fetch + Claim + Schema-Validate
+
+1. **Fetch** per `references/fetch-issue.md`. Closed issue → refusal stop.
+   Emit `printf '[step:gh-issue-proceed/fetch-issue] OK\n'`.
+2. **Block-label guard** per `references/claim.md` 3.2.
+3. **Self-assign + Board transition + Depends-on guard** per `references/claim.md` 3.3-3.5 (soft-fail).
+4. **Schema-validate** per `references/protocol-schema.md`. Missing/empty section → emit error report (design §3.4 format), exit 1. **No comment posted on the issue.**
+   Emit `printf '[step:gh-issue-proceed/schema-validate] OK\n'`.
+5. **Precondition class enforcement** — apply per-class rules from `references/preconditions.md`:
+   - `read-only` → no further check.
+   - `mutation-required` → branch ≠ default, clean tree, in worktree.
+   - `mixed` → mutation-required + verify `allow: cross-repo: <owner/repo>` matches target.
+   - `verify-only` → force read-only behavior even if mutation keywords found.
+
+   On class/state mismatch: print remediation hint per design §5.1 and stop.
+````
+
+- [ ] **Step 15.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/SKILL.md
+git -C ~/dotfiles commit -m "feat(skill): Wire /gh:issue-proceed SKILL.md Step 3
+
+T15 of #874 — fetch + claim + schema-validate + class enforcement."
+```
+
+---
+
+## Task 16: Wire SKILL.md Step 5 — Execute Protocol
+
+**Files:**
+- Modify: `~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md`
+
+- [ ] **Step 16.1: Replace Step 5 stub**
+
+````markdown
+## Step 5: Execute Protocol
+
+Follow the loop in `references/execution-flow.md`:
+
+1. Parse `section_content[execution_protocol]` into ordered steps (matrix or numbered mode).
+2. For each step:
+   a. `TaskCreate` with `subject="Step <n>: <description>"`.
+   b. Pre-execute scan against `references/safety-gates.md` Layer 1. Match → abort all (per §Safety).
+   c. Execute the step's commands. Capture stdout + stderr.
+   d. Post-execute scan output against `SECRET_OUTPUT_PATTERNS`. Match → abort, do NOT post output anywhere.
+   e. Classify result against the issue's `decision_rules`. Unknown class → fail-closed (treat as BLOCKED).
+   f. Apply action verb (registry in `execution-flow.md` §Verb registry). Composition calls go through `Skill(gh:commit)` / `Skill(gh:pr)` / `Skill(gh:issue-create)`. Inline `gh` CLI for comment / close / label.
+   g. `TaskUpdate` → completed with `metadata={result, classification, action}`.
+3. Enforce Layer 4 runtime monitors: per-step timeout (5 min default), global timeout (60 min default), write-action quota (per-type 5 / total 20 unless §Safety raises).
+
+Emit `printf '[step:gh-issue-proceed/execute] OK\n'`.
+````
+
+- [ ] **Step 16.2: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/SKILL.md
+git -C ~/dotfiles commit -m "feat(skill): Wire /gh:issue-proceed SKILL.md Step 5
+
+T16 of #874 — execute loop with safety pre/post scans + composition."
+```
+
+---
+
+## Task 17: Wire SKILL.md Step 6 — Report + Close
+
+**Files:**
+- Modify: `~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md`
+
+- [ ] **Step 17.1: Replace Step 6 stub**
+
+````markdown
+## Step 6: Report + Close
+
+Assemble report per `references/report-format.md`. Sections: per-step audit, write-action audit, done-criteria reconciliation, ai-metrics.
+
+Outcome decision (per design §6.4):
+
+| Condition | Action |
+|---|---|
+| All `done_criteria` `- [ ]` items matched AND no abort | `gh issue close <PROCEED_N>` + final comment with audit |
+| Partial — some criteria unmet | Keep open + final comment with `N/M criteria met` |
+| Abort triggered (Layer 1-4) | Keep open + final comment with `[aborted] <layer> <pattern>` |
+
+Append ai-metrics line:
+
+```
+[ai-metrics:gh-issue-proceed] ~{ELAPSED} min — write actions: {N}, blocked: {M}
+```
+
+Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`.
+
+Emit `printf '[step:gh-issue-proceed/report] OK\n'`.
+````
+
+- [ ] **Step 17.2: Verify SKILL.md is ≤ 150 lines**
+
+```bash
+wc -l ~/dotfiles/claude/skills/gh-issue-proceed/SKILL.md
+```
+Expected: ≤ 150. If over, move detail to references/.
+
+- [ ] **Step 17.3: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-proceed/SKILL.md
+git -C ~/dotfiles commit -m "feat(skill): Wire /gh:issue-proceed SKILL.md Step 6
+
+T17 of #874 — report + close decision + ai-metrics + step marker."
+```
+
+---
+
+## Task 18: Cross-link sibling skills
+
+**Files:**
+- Modify: `~/dotfiles/claude/skills/gh-issue-implement/SKILL.md` (frontmatter description)
+- Modify: `~/dotfiles/claude/skills/gh-issue-read/SKILL.md` (frontmatter description)
+
+- [ ] **Step 18.1: Edit gh-issue-implement description**
+
+Use `Edit` to append after `... Accepts ... \`-h\`/\`--help\`/\`help\`.`:
+
+```
+Sister skill of [[gh:issue-proceed]] for directive (work-order) issues with an embedded execution protocol.
+```
+
+- [ ] **Step 18.2: Edit gh-issue-read description**
+
+Use `Edit` to append after `... \`-h\`/\`--help\`/\`help\` to print usage.`:
+
+```
+Output feeds [[gh:issue-implement]] for code-change issues or [[gh:issue-proceed]] for directive issues.
+```
+
+- [ ] **Step 18.3: Commit**
+
+```bash
+git -C ~/dotfiles add claude/skills/gh-issue-implement/SKILL.md \
+                    claude/skills/gh-issue-read/SKILL.md
+git -C ~/dotfiles commit -m "docs(skill): Cross-link sibling skills with /gh:issue-proceed
+
+T18 of #874."
+```
+
+---
+
+## Task 19: Run full test suite + lint
+
+**Files:** none modified.
+
+- [ ] **Step 19.1: Run all new bats tests**
+
+```bash
+~/dotfiles/tests/bats/lib/bats-core/bin/bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_schema.bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_preconditions.bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_steps.bats \
+    ~/dotfiles/tests/bats/skills/gh_issue_proceed_safety.bats
+```
+Expected: 27 tests pass (5 + 4 + 5 + 13).
+
+- [ ] **Step 19.2: Run shellcheck on all new fixtures**
+
+```bash
+shellcheck ~/dotfiles/tests/bats/skills/_fixtures/gh_issue_proceed_*.sh
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 19.3: Run repo lint gate**
+
+```bash
+mise run lint -C ~/dotfiles 2>&1 | tail -20
+```
+Expected: green or only pre-existing warnings (not introduced by this PR).
+
+- [ ] **Step 19.4: Existing test suite still green**
+
+```bash
+~/dotfiles/tests/test 2>&1 | tail -30
+```
+Expected: full suite passes. If pre-existing failures, document them in the PR body as not-introduced-by-this-PR.
+
+---
+
+## Task 20: Open PR
+
+**Files:** none.
+
+- [ ] **Step 20.1: Verify branch state**
+
+```bash
+git -C ~/dotfiles status
+git -C ~/dotfiles log --oneline origin/main..HEAD | head -25
+```
+Expected: clean tree, ~20 commits ahead of `origin/main`.
+
+- [ ] **Step 20.2: Push latest commits**
+
+```bash
+git -C ~/dotfiles push
+```
+Expected: fast-forward push, no force.
+
+- [ ] **Step 20.3: Open PR**
+
+```bash
+gh pr create --repo dEitY719/dotfiles \
+  --title "feat(skill): Add /gh:issue-proceed — directive issue executor" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Adds the `/gh:issue-proceed` skill — a sibling of `/gh:issue-implement` for **directive issues** (work-order issues whose body embeds an 8-section execution protocol). Closes #874.
+
+## What it does
+
+Reads a GitHub directive issue, validates the body against a strict 8-section schema, executes the embedded protocol end-to-end without human intervention, and applies write actions (commit / PR / comment / close / file follow-up) per the protocol's `Decision Rules`.
+
+## Sections enforced
+
+`Goal`, `Preconditions`, `Execution Protocol`, `Decision Rules`, `Deliverables`, `Done Criteria`, `Out of Scope`, `Safety / Abort`. Bilingual aliases (KO/EN) supported.
+
+## Safety
+
+Four-layer gates: absolute prohibitions (force-push, `gh pr merge`, secret leakage, cross-worktree mutation) override any issue body. Layer 2 conditional permissions, Layer 3 pre-flight, Layer 4 runtime monitors (per-step + global timeout, write-action quota).
+
+## Test plan
+
+- 27 new bats tests (`tests/bats/skills/gh_issue_proceed_*.bats`)
+  - schema validator (5 fixtures: all-OK, missing, empty, H3-nested, KO-aliases)
+  - precondition class detector (4 cases)
+  - step parser (5 cases)
+  - safety gates (13 cases — positive + negative per pattern)
+- shellcheck clean on all new `_fixtures/*.sh`
+- Existing test suite still green
+
+## Files
+
+- New: `claude/skills/gh-issue-proceed/SKILL.md` + 9 `references/*.md`
+- New: `tests/bats/skills/gh_issue_proceed_*.bats` (4 files) + `_fixtures/*.sh` (4 files) + `_fixtures/gh_issue_proceed_bodies/*.md` (5 fixtures)
+- Modified: sibling skill descriptions (`gh-issue-implement`, `gh-issue-read`) cross-link `[[gh:issue-proceed]]`
+
+## Follow-up (not in this PR)
+
+- STRUCTURED payload contract for composed skills (`/gh:commit`, `/gh:pr`, `/gh:issue-create`) — design §5.4, marked as v2 in plan. Will file as a separate issue on merge.
+
+## Design references
+
+- Spec: `docs/feature/gh-issue-proceed-skill/design.md`
+- Plan: `docs/feature/gh-issue-proceed-skill/plan.md`
+- Tracking issue: #874
+EOF
+)"
+```
+Expected: PR URL printed.
+
+- [ ] **Step 20.4: File STRUCTURED-payload v2 follow-up issue**
+
+```bash
+gh issue create --repo dEitY719/dotfiles \
+  --label "skill,feat,enhancement" \
+  --title "[skill] STRUCTURED payload contract for composed skills (v2 follow-up of #874)" \
+  --body "$(cat <<'EOF'
+## TL;DR
+
+Add an opt-in `STRUCTURED:` / `NO_INTERACTIVE: true` payload contract to `/gh:commit`, `/gh:pr`, `/gh:issue-create`. Marked as design §5.4 v2 follow-up of the `/gh:issue-proceed` skill (#874).
+
+## Why
+
+`/gh:issue-proceed` composes with these three skills. Today it can call them with free-form prompts, but that mixes conversation history with structured action payloads. A formal `STRUCTURED` envelope lets the caller specify exact title/body/labels/etc. without ambiguity, and `NO_INTERACTIVE: true` skips any confirmation prompts so end-to-end execution doesn't stall.
+
+## Acceptance
+
+- [ ] `/gh:commit` accepts `STRUCTURED:` envelope (type, scope, body, files) and respects `NO_INTERACTIVE: true`
+- [ ] `/gh:pr` accepts `STRUCTURED:` envelope (title, body, base, draft, NO_INTERACTIVE)
+- [ ] `/gh:issue-create` accepts `STRUCTURED:` envelope (title, body, labels, NO_INTERACTIVE)
+- [ ] `/gh:issue-proceed` switches its composition calls to use STRUCTURED
+- [ ] Bats coverage on each skill's STRUCTURED parsing
+
+## References
+
+- Source: #874 PR (this skill)
+- Design: `docs/feature/gh-issue-proceed-skill/design.md` §5.4
+EOF
+)"
+```
+Expected: issue URL printed.
+
+- [ ] **Step 20.5: Final report**
+
+Print:
+
+```
+[OK] /gh:issue-proceed plan executed end-to-end.
+  PR: <url>
+  Closes: #874
+  Follow-up filed: <url for STRUCTURED v2>
+  Tests: 27 bats green, shellcheck clean, repo lint green
+```
+
+---
+
+## Self-Review Checklist (mental note for the implementer)
+
+After all tasks complete, verify:
+
+- [ ] Every design §3-6 requirement maps to a Task above (spec coverage).
+- [ ] No "TBD" / "TODO" left in any committed file.
+- [ ] Function names consistent (`gh_issue_proceed_validate_body`, `gh_issue_proceed_classify`, `gh_issue_proceed_step_mode`, `gh_issue_proceed_step_count`, `gh_issue_proceed_check_command`, `gh_issue_proceed_scan_output`) — no drift between fixtures and bats.
+- [ ] All commits link `#874` in the commit message (`T<N> of #874`).
+- [ ] PR body references the tracking issue with `Closes #874`.

--- a/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh
+# Source-of-truth mirror for the Layer-1 ABSOLUTE_BLOCK_PATTERNS
+# documented in
+#   claude/skills/gh-issue-proceed/references/safety-gates.md §4.1
+#
+# gh_proceed_check_absolute_block <command-string> returns 2 and prints
+# "blocked: <key>" when the command matches a Layer-1 absolute
+# prohibition; otherwise prints "ok" and returns 0. The bats suite
+# exercises one positive + one negative per pattern.
+#
+# Context inputs (optional):
+#   FAKE_DEFAULT_BRANCH   — default branch name (default: main)
+#   FAKE_ME               — current user login (default: me)
+#   FAKE_ISSUE_CLOSED_BY  — who closed the issue being reopened
+#                           (default: $FAKE_ME → self → allowed)
+
+_gp_block() { printf 'blocked: %s\n' "$1"; }
+
+gh_proceed_check_absolute_block() {
+    local _cmd="${1-}"
+    local _default="${FAKE_DEFAULT_BRANCH:-main}"
+
+    # gh pr merge — sibling skills own merges.
+    if printf '%s' "$_cmd" | grep -iqE 'gh +pr +merge'; then
+        _gp_block gh_pr_merge
+        return 2
+    fi
+
+    # Branch deletion: local -D/-d, REST DELETE on a branch/ref, or a
+    # remote delete push ("git push <remote> :branch").
+    if printf '%s' "$_cmd" | grep -iqE 'git +branch +-D\b|git +branch +-d\b' ||
+        printf '%s' "$_cmd" | grep -iqE 'gh +api +-X +DELETE.*/(branches|git/refs)/' ||
+        printf '%s' "$_cmd" | grep -iqE 'git +push +[^ ]+ +:'; then
+        _gp_block branch_deletion
+        return 2
+    fi
+
+    # Force push. --force-with-lease is exempt here (Layer 2 token-gates it).
+    if printf '%s' "$_cmd" | grep -iqE 'git +push'; then
+        if printf '%s' "$_cmd" | grep -iqE -- '--force-with-lease'; then
+            : # allowed at Layer 1
+        elif printf '%s' "$_cmd" | grep -iqE -- '(--force|[[:space:]]-f([[:space:]]|$))'; then
+            if printf '%s' "$_cmd" | grep -iqE -- "(\\b${_default}\\b|\\bmain\\b|\\bmaster\\b)"; then
+                _gp_block force_push_default
+                return 2
+            fi
+            _gp_block force_push_general
+            return 2
+        fi
+    fi
+
+    # rm -rf with a path outside $PWD (absolute, home, or parent-relative).
+    if printf '%s' "$_cmd" | grep -iqE 'rm +-[a-z]*r[a-z]*f|rm +-[a-z]*f[a-z]*r'; then
+        if printf '%s' "$_cmd" | grep -qE 'rm +-[A-Za-z]+ +(/|~|[^ ]*\.\.)'; then
+            _gp_block rm_rf_outside_pwd
+            return 2
+        fi
+    fi
+
+    # Destructive DB ops.
+    if printf '%s' "$_cmd" | grep -qE '\b(DROP|TRUNCATE)\b|admin +reset|DELETE +FROM'; then
+        _gp_block destructive_db
+        return 2
+    fi
+
+    # Secret-shaped token in the command/output.
+    if printf '%s' "$_cmd" | grep -qE '[A-Za-z0-9_]*(_KEY|_TOKEN|_SECRET)[A-Za-z0-9_]*=|password=|Bearer +|eyJ[A-Za-z0-9_-]+\.'; then
+        _gp_block secret_in_output
+        return 2
+    fi
+
+    # Cross-worktree mutation (heuristic: explicit alternate git dir / -C).
+    if printf '%s' "$_cmd" | grep -iqE 'git +-C +|--git-dir=|--work-tree='; then
+        _gp_block cross_worktree_mutation
+        return 2
+    fi
+
+    # Reopen of an issue closed by someone else.
+    if printf '%s' "$_cmd" | grep -iqE 'gh +issue +reopen'; then
+        local _me="${FAKE_ME:-me}"
+        local _by="${FAKE_ISSUE_CLOSED_BY:-$_me}"
+        if [ "$_by" != "$_me" ]; then
+            _gp_block reopen_foreign_closed
+            return 2
+        fi
+    fi
+
+    printf 'ok\n'
+    return 0
+}

--- a/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh
@@ -40,7 +40,7 @@ gh_proceed_check_absolute_block() {
     if printf '%s' "$_cmd" | grep -iqE 'git +push'; then
         if printf '%s' "$_cmd" | grep -iqE -- '--force-with-lease'; then
             : # allowed at Layer 1
-        elif printf '%s' "$_cmd" | grep -iqE -- '(--force|[[:space:]]-f([[:space:]]|$))'; then
+        elif printf '%s' "$_cmd" | grep -iqE -- '(--force|[[:space:]"'\'']-f([[:space:]"'\'']|$))'; then
             if printf '%s' "$_cmd" | grep -iqE -- "(\\b${_default}\\b|\\bmain\\b|\\bmaster\\b)"; then
                 _gp_block force_push_default
                 return 2
@@ -52,20 +52,21 @@ gh_proceed_check_absolute_block() {
 
     # rm -rf with a path outside $PWD (absolute, home, or parent-relative).
     if printf '%s' "$_cmd" | grep -iqE 'rm +-[a-z]*r[a-z]*f|rm +-[a-z]*f[a-z]*r'; then
-        if printf '%s' "$_cmd" | grep -qE 'rm +-[A-Za-z]+ +(/|~|[^ ]*\.\.)'; then
+        if printf '%s' "$_cmd" | grep -qE 'rm +-[A-Za-z]+ +["'\'']?(/|~|[^ ]*\.\.)'; then
             _gp_block rm_rf_outside_pwd
             return 2
         fi
     fi
 
-    # Destructive DB ops.
-    if printf '%s' "$_cmd" | grep -qE '\b(DROP|TRUNCATE)\b|admin +reset|DELETE +FROM'; then
+    # Destructive DB ops. Case-insensitive: lowercase `drop table` must not bypass.
+    if printf '%s' "$_cmd" | grep -iqE '\b(DROP|TRUNCATE)\b|admin +reset|DELETE +FROM'; then
         _gp_block destructive_db
         return 2
     fi
 
-    # Secret-shaped token in the command/output.
-    if printf '%s' "$_cmd" | grep -qE '[A-Za-z0-9_]*(_KEY|_TOKEN|_SECRET)[A-Za-z0-9_]*=|password=|Bearer +|eyJ[A-Za-z0-9_-]+\.'; then
+    # Secret-shaped token in the command/output. Case-insensitive: lowercase
+    # `api_key=` / mixed-case `PASSWORD=` must not bypass the scanner.
+    if printf '%s' "$_cmd" | grep -iqE '[A-Za-z0-9_]*(_KEY|_TOKEN|_SECRET)[A-Za-z0-9_]*=|password=|Bearer +|eyJ[A-Za-z0-9_-]+\.'; then
         _gp_block secret_in_output
         return 2
     fi

--- a/tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh
+# Source-of-truth mirror for the strict 8-section schema validator
+# documented in
+#   claude/skills/gh-issue-proceed/references/protocol-schema.md
+#
+# The bats suite injects an issue body via FAKE_BODY and asserts the
+# validator's pass/fail verdict + categorized output. Keep this in sync
+# with protocol-schema.md whenever the schema changes.
+#
+# Inputs:
+#   FAKE_BODY — the GitHub directive issue body (markdown)
+
+# Comma-separated, lowercased alias list for one required section key.
+_gp_aliases() {
+    case "$1" in
+    goal) printf 'goal,목표' ;;
+    preconditions) printf 'preconditions,사전 조건,prerequisites' ;;
+    execution_protocol) printf 'execution protocol,execution matrix,실행 절차,steps' ;;
+    decision_rules) printf 'decision rules,결정 규칙,branching,decision matrix' ;;
+    deliverables) printf 'deliverables,산출물,output,outputs' ;;
+    done_criteria) printf 'done criteria,종료 조건,acceptance,acceptance criteria' ;;
+    out_of_scope) printf 'out of scope,out-of-scope,범위 밖' ;;
+    safety) printf 'safety,abort,안전 규칙,safety rules' ;;
+    esac
+}
+
+# Returns 0 if a heading (H2-H6) matching any alias for KEY exists in
+# FAKE_BODY, 1 otherwise.
+_gp_has_section() {
+    local _aliases
+    _aliases=$(_gp_aliases "$1")
+    printf '%s\n' "${FAKE_BODY-}" | awk -v al="$_aliases" '
+        BEGIN { n = split(al, A, ","); rc = 1 }
+        /^##+[[:blank:]]+/ {
+            h = tolower($0); sub(/^##+[[:blank:]]+/, "", h)
+            for (i = 1; i <= n; i++)
+                if (A[i] != "" && index(h, A[i]) > 0) { rc = 0; exit }
+        }
+        END { exit rc }
+    '
+}
+
+# Echoes the content lines under the first heading matching KEY (heading
+# excluded), stopping at the next heading.
+_gp_get_content() {
+    local _aliases
+    _aliases=$(_gp_aliases "$1")
+    printf '%s\n' "${FAKE_BODY-}" | awk -v al="$_aliases" '
+        BEGIN { n = split(al, A, ","); cap = 0 }
+        /^##+[[:blank:]]+/ {
+            if (cap == 1) { exit }
+            h = tolower($0); sub(/^##+[[:blank:]]+/, "", h)
+            for (i = 1; i <= n; i++)
+                if (A[i] != "" && index(h, A[i]) > 0) { cap = 1; next }
+            next
+        }
+        { if (cap == 1) print }
+    '
+}
+
+# Returns 0 (true) when CONTENT is "empty" per the schema definition:
+# under 50 chars after stripping fences, list markers, and outer
+# whitespace.
+_gp_is_empty() {
+    local _c
+    _c=$(printf '%s\n' "$1" |
+        sed -E 's/`{3,}//g' |
+        sed -E 's/^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+//' |
+        tr -s '[:space:]' ' ' |
+        sed -E 's/^ //; s/ $//')
+    [ "${#_c}" -lt 50 ]
+}
+
+# Returns 0 when CONTENT has parseable steps: a numbered block
+# (^N. or ^### N.) OR a workflow/step+command matrix table.
+_gp_protocol_parseable() {
+    local _c="$1"
+    if printf '%s\n' "$_c" | grep -qE '^[[:space:]]*(#{3,6}[[:space:]]*)?[0-9]+\.'; then
+        return 0
+    fi
+    if printf '%s\n' "$_c" | grep -E '^\|' | grep -iqE '(workflow|step)' &&
+        printf '%s\n' "$_c" | grep -E '^\|' | grep -iqE '(command|명령)'; then
+        return 0
+    fi
+    return 1
+}
+
+# Main validator. Prints a verdict line and (on failure) categorized
+# section lists. Returns 0 when the body satisfies the 8-section schema,
+# 1 otherwise.
+gh_proceed_validate_schema() {
+    local _n="${1:-?}"
+    local _missing="" _empty="" _unparseable=""
+    local _keys="goal preconditions execution_protocol decision_rules deliverables done_criteria out_of_scope safety"
+    local _k _content
+
+    for _k in $_keys; do
+        if ! _gp_has_section "$_k"; then
+            _missing="$_missing $_k"
+            continue
+        fi
+        _content=$(_gp_get_content "$_k")
+        case "$_k" in
+        done_criteria)
+            if ! printf '%s\n' "$_content" | grep -qE '^[[:space:]]*- \[[ xX]\]'; then
+                _empty="$_empty $_k"
+            fi
+            ;;
+        execution_protocol)
+            if _gp_is_empty "$_content"; then
+                _empty="$_empty $_k"
+            elif ! _gp_protocol_parseable "$_content"; then
+                _unparseable="$_unparseable execution_protocol"
+            fi
+            ;;
+        *)
+            if _gp_is_empty "$_content"; then
+                _empty="$_empty $_k"
+            fi
+            ;;
+        esac
+    done
+
+    if [ -n "$_missing$_empty$_unparseable" ]; then
+        printf 'gh:issue-proceed #%s schema validation failed\n' "$_n"
+        [ -n "$_missing" ] && printf '  Missing required sections:%s\n' "$_missing"
+        [ -n "$_empty" ] && printf '  Empty required sections:%s\n' "$_empty"
+        [ -n "$_unparseable" ] && printf '  Unparseable sections:%s\n' "$_unparseable"
+        return 1
+    fi
+
+    printf 'gh:issue-proceed #%s schema OK\n' "$_n"
+    return 0
+}

--- a/tests/bats/skills/gh_issue_proceed_safety.bats
+++ b/tests/bats/skills/gh_issue_proceed_safety.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_proceed_safety.bats
+# Verify the Layer-1 ABSOLUTE_BLOCK_PATTERNS documented in
+#   claude/skills/gh-issue-proceed/references/safety-gates.md §4.1
+# Source-of-truth fixture: _fixtures/gh_issue_proceed_safety.sh
+#
+# One positive (blocked, rc=2) + one negative (ok, rc=0) per pattern.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_safety.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset FAKE_DEFAULT_BRANCH FAKE_ME FAKE_ISSUE_CLOSED_BY
+}
+
+# ---------- gh pr merge ----------
+
+@test "safety: 'gh pr merge' → blocked gh_pr_merge" {
+    run gh_proceed_check_absolute_block "gh pr merge 5 --squash"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: gh_pr_merge'
+}
+
+@test "safety: 'gh pr view' → ok" {
+    run gh_proceed_check_absolute_block "gh pr view 5"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- branch deletion ----------
+
+@test "safety: 'git branch -D feature' → blocked branch_deletion" {
+    run gh_proceed_check_absolute_block "git branch -D feature"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: branch_deletion'
+}
+
+@test "safety: remote delete push 'git push origin :feature' → blocked branch_deletion" {
+    run gh_proceed_check_absolute_block "git push origin :feature"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: branch_deletion'
+}
+
+@test "safety: 'git branch feature' (create) → ok" {
+    run gh_proceed_check_absolute_block "git branch feature"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- force push to default ----------
+
+@test "safety: 'git push --force origin main' → blocked force_push_default" {
+    run gh_proceed_check_absolute_block "git push --force origin main"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: force_push_default'
+}
+
+@test "safety: 'git push origin main' (no force) → ok" {
+    run gh_proceed_check_absolute_block "git push origin main"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- force push general ----------
+
+@test "safety: 'git push -f origin feature' → blocked force_push_general" {
+    run gh_proceed_check_absolute_block "git push -f origin feature"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: force_push_general'
+}
+
+@test "safety: 'git push --force-with-lease origin feature' → ok (Layer 2 gate)" {
+    run gh_proceed_check_absolute_block "git push --force-with-lease origin feature"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- rm -rf outside pwd ----------
+
+@test "safety: 'rm -rf /etc/app' → blocked rm_rf_outside_pwd" {
+    run gh_proceed_check_absolute_block "rm -rf /etc/app"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: rm_rf_outside_pwd'
+}
+
+@test "safety: 'rm -rf ./build' (inside pwd) → ok" {
+    run gh_proceed_check_absolute_block "rm -rf ./build"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- destructive db ----------
+
+@test "safety: 'DROP TABLE users' → blocked destructive_db" {
+    run gh_proceed_check_absolute_block 'psql -c "DROP TABLE users"'
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: destructive_db'
+}
+
+@test "safety: 'SELECT * FROM users' → ok" {
+    run gh_proceed_check_absolute_block 'psql -c "SELECT * FROM users"'
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- secret in output ----------
+
+@test "safety: 'AWS_SECRET=abc123' → blocked secret_in_output" {
+    run gh_proceed_check_absolute_block "echo AWS_SECRET=abc123"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: secret_in_output'
+}
+
+@test "safety: 'echo hello world' → ok" {
+    run gh_proceed_check_absolute_block "echo hello world"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- cross-worktree mutation ----------
+
+@test "safety: 'git -C /other/wt commit' → blocked cross_worktree_mutation" {
+    run gh_proceed_check_absolute_block "git -C /other/wt commit -m x"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: cross_worktree_mutation'
+}
+
+@test "safety: 'git commit -m x' (current tree) → ok" {
+    run gh_proceed_check_absolute_block "git commit -m x"
+    assert_success
+    assert_output 'ok'
+}
+
+# ---------- reopen foreign-closed issue ----------
+
+@test "safety: reopen issue closed by another user → blocked reopen_foreign_closed" {
+    FAKE_ME="alice"
+    FAKE_ISSUE_CLOSED_BY="bob"
+    run gh_proceed_check_absolute_block "gh issue reopen 5"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: reopen_foreign_closed'
+}
+
+@test "safety: reopen issue closed by self → ok" {
+    FAKE_ME="alice"
+    FAKE_ISSUE_CLOSED_BY="alice"
+    run gh_proceed_check_absolute_block "gh issue reopen 5"
+    assert_success
+    assert_output 'ok'
+}

--- a/tests/bats/skills/gh_issue_proceed_safety.bats
+++ b/tests/bats/skills/gh_issue_proceed_safety.bats
@@ -81,6 +81,12 @@ teardown() {
     assert_output 'ok'
 }
 
+@test "safety: quoted-flag bypass 'git push \"-f\" origin main' → blocked force_push_default (PR #876)" {
+    run gh_proceed_check_absolute_block 'git push "-f" origin main'
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: force_push_default'
+}
+
 # ---------- rm -rf outside pwd ----------
 
 @test "safety: 'rm -rf /etc/app' → blocked rm_rf_outside_pwd" {
@@ -93,6 +99,12 @@ teardown() {
     run gh_proceed_check_absolute_block "rm -rf ./build"
     assert_success
     assert_output 'ok'
+}
+
+@test "safety: quoted-path bypass 'rm -rf \"/etc/app\"' → blocked rm_rf_outside_pwd (PR #876)" {
+    run gh_proceed_check_absolute_block 'rm -rf "/etc/app"'
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: rm_rf_outside_pwd'
 }
 
 # ---------- destructive db ----------
@@ -109,6 +121,12 @@ teardown() {
     assert_output 'ok'
 }
 
+@test "safety: lowercase bypass 'drop table users' → blocked destructive_db (PR #876)" {
+    run gh_proceed_check_absolute_block 'psql -c "drop table users"'
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: destructive_db'
+}
+
 # ---------- secret in output ----------
 
 @test "safety: 'AWS_SECRET=abc123' → blocked secret_in_output" {
@@ -121,6 +139,12 @@ teardown() {
     run gh_proceed_check_absolute_block "echo hello world"
     assert_success
     assert_output 'ok'
+}
+
+@test "safety: lowercase bypass 'api_key=secret' → blocked secret_in_output (PR #876)" {
+    run gh_proceed_check_absolute_block "echo api_key=secret"
+    [ "$status" -eq 2 ]
+    assert_output --partial 'blocked: secret_in_output'
 }
 
 # ---------- cross-worktree mutation ----------

--- a/tests/bats/skills/gh_issue_proceed_schema.bats
+++ b/tests/bats/skills/gh_issue_proceed_schema.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_issue_proceed_schema.bats
+# Verify the strict 8-section schema validator documented in
+#   claude/skills/gh-issue-proceed/references/protocol-schema.md
+# Source-of-truth fixture: _fixtures/gh_issue_proceed_schema.sh
+#
+# Five variants from design §8 / acceptance criteria:
+#   1. all-OK     → PASS
+#   2. missing    → FAIL (Missing required sections)
+#   3. empty      → FAIL (Empty required sections)
+#   4. H3-nested  → PASS (validator matches H2-H6)
+#   5. KO-aliases → PASS (Korean heading aliases)
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_issue_proceed_schema.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset FAKE_BODY
+}
+
+# ---------- Variant 1: all-OK ----------
+
+@test "schema: complete 8-section body (H2, EN) → PASS" {
+    FAKE_BODY=$(cat <<'EOF'
+## Goal
+Verify the CLI end-to-end so that every documented command returns success.
+
+## Preconditions
+The repo is cloned and the binary is built; network access to the API is available.
+
+## Execution Protocol
+1. Run `app --help` and confirm a usage block prints without any error here.
+2. Run `app list 1 10` and confirm ten rows of output appear correctly here.
+
+## Decision Rules
+- PASS: continue to the next step in the protocol as normal without action.
+- FAIL-CLI: file_issue: cli-bug and then continue with the remaining steps.
+
+## Deliverables
+A short verification report plus one filed follow-up issue per failing command.
+
+## Done Criteria
+- [ ] every documented command was executed at least once during the run
+- [ ] a report comment summarizing pass and fail counts was posted
+
+## Out of Scope
+Performance benchmarking and load testing are explicitly not part of this task.
+
+## Safety
+Read-only verification only. Abort on any destructive command encountered here.
+EOF
+)
+    run gh_proceed_validate_schema 81
+    assert_success
+    assert_output --partial 'schema OK'
+}
+
+# ---------- Variant 2: missing section ----------
+
+@test "schema: body missing the Safety section → FAIL (missing)" {
+    FAKE_BODY=$(cat <<'EOF'
+## Goal
+Verify the CLI end-to-end so that every documented command returns success.
+
+## Preconditions
+The repo is cloned and the binary is built; network access to the API is available.
+
+## Execution Protocol
+1. Run `app --help` and confirm a usage block prints without any error here.
+
+## Decision Rules
+- PASS: continue to the next step in the protocol as normal without action.
+
+## Deliverables
+A short verification report plus one filed follow-up issue per failing command.
+
+## Done Criteria
+- [ ] every documented command was executed at least once during the run
+
+## Out of Scope
+Performance benchmarking and load testing are explicitly not part of this task.
+EOF
+)
+    run gh_proceed_validate_schema 81
+    assert_failure
+    assert_output --partial 'Missing required sections'
+    assert_output --partial 'safety'
+}
+
+# ---------- Variant 3: empty section ----------
+
+@test "schema: Goal heading present but content < 50 chars → FAIL (empty)" {
+    FAKE_BODY=$(cat <<'EOF'
+## Goal
+- ok
+
+## Preconditions
+The repo is cloned and the binary is built; network access to the API is available.
+
+## Execution Protocol
+1. Run `app --help` and confirm a usage block prints without any error here.
+
+## Decision Rules
+- PASS: continue to the next step in the protocol as normal without action.
+
+## Deliverables
+A short verification report plus one filed follow-up issue per failing command.
+
+## Done Criteria
+- [ ] every documented command was executed at least once during the run
+
+## Out of Scope
+Performance benchmarking and load testing are explicitly not part of this task.
+
+## Safety
+Read-only verification only. Abort on any destructive command encountered here.
+EOF
+)
+    run gh_proceed_validate_schema 81
+    assert_failure
+    assert_output --partial 'Empty required sections'
+    assert_output --partial 'goal'
+}
+
+# ---------- Variant 4: H3-nested headings ----------
+
+@test "schema: same body with H3 (###) headings → PASS" {
+    FAKE_BODY=$(cat <<'EOF'
+### Goal
+Verify the CLI end-to-end so that every documented command returns success.
+
+### Preconditions
+The repo is cloned and the binary is built; network access to the API is available.
+
+### Execution Protocol
+1. Run `app --help` and confirm a usage block prints without any error here.
+2. Run `app list 1 10` and confirm ten rows of output appear correctly here.
+
+### Decision Rules
+- PASS: continue to the next step in the protocol as normal without action.
+
+### Deliverables
+A short verification report plus one filed follow-up issue per failing command.
+
+### Done Criteria
+- [ ] every documented command was executed at least once during the run
+
+### Out of Scope
+Performance benchmarking and load testing are explicitly not part of this task.
+
+### Safety
+Read-only verification only. Abort on any destructive command encountered here.
+EOF
+)
+    run gh_proceed_validate_schema 81
+    assert_success
+    assert_output --partial 'schema OK'
+}
+
+# ---------- Variant 5: Korean aliases ----------
+
+@test "schema: Korean heading aliases → PASS" {
+    FAKE_BODY=$(cat <<'EOF'
+## 목표
+모든 문서화된 명령을 직접 실행하여 정상적으로 종료되는지 처음부터 끝까지 빠짐없이 검증한다 end to end verification.
+
+## 사전 조건
+저장소가 클론되어 있고 바이너리가 빌드되어 있으며 API 네트워크 접근이 가능하다 here.
+
+## 실행 절차
+1. `app --help` 를 실행하여 사용법 블록이 오류 없이 출력되는지 확인한다 step one.
+2. `app list 1 10` 를 실행하여 열 개의 행이 정상 출력되는지 확인한다 step two.
+
+## 결정 규칙
+- PASS: 다음 단계로 계속 진행한다 continue without any extra action taken here.
+
+## 산출물
+짧은 검증 리포트와 실패한 명령마다 하나씩 등록한 후속 이슈를 제출한다 deliverable.
+
+## 종료 조건
+- [ ] 모든 문서화된 명령이 최소 한 번 이상 실행되었다 executed at least once
+
+## 범위 밖
+성능 벤치마크와 부하 테스트 그리고 보안 감사는 이 작업의 범위에 전혀 포함되지 않는다 strictly out of scope here.
+
+## 안전 규칙
+읽기 전용 검증만 수행한다. 파괴적 명령을 만나면 즉시 중단한다 abort on danger.
+EOF
+)
+    run gh_proceed_validate_schema 81
+    assert_success
+    assert_output --partial 'schema OK'
+}


### PR DESCRIPTION
## Summary

Implements issue #874 — a new sibling skill `/gh:issue-proceed` that reads a
GitHub **directive issue** (work-order whose body embeds an executable
8-section protocol) and proceeds end-to-end without human intervention:
strict schema validation → per-step execution under safety gates → authorized
write actions → audit report.

This PR bundles 3 commits:

1. `f37e4da` docs — design spec (`design.md`, 367 lines, SSOT, issue #874 output)
2. `2bf49c0` docs — implementation plan (`plan.md`)
3. `1114faa` feat — the actual skill + tests + sibling cross-links

The design + plan docs are preserved intact (per #874 they are the SSOT output).

## What's implemented

- **`claude/skills/gh-issue-proceed/SKILL.md`** (129 lines, ≤150) — 4-step
  shell: parse → fetch+claim+schema → execute → report. Step 2 (superpowers)
  and Step 4 (mode dispatch) dropped vs `/gh:issue-implement`; always direct.
  `metadata.model_recommendation: opus` (full write authority + safety
  classification ⇒ opus tier per #809/#860 rubric).
- **9 reference files**: `help`, `repo-resolution` / `fetch-issue` / `claim`
  (self-contained copies, per the per-skill convention), `protocol-schema`
  (8 required sections, KO/EN aliases, matrix+numbered parser),
  `preconditions` (read-only / mutation-required / mixed / verify-only),
  `execution-flow` (step loop + verb registry + STRUCTURED payload),
  `safety-gates` (`ABSOLUTE_BLOCK_PATTERNS` SSOT + 4 layers), `report-format`.
- **Sibling cross-links**: `gh-issue-implement` and `gh-issue-read`
  descriptions now reference `[[gh:issue-proceed]]`.

## Tests (24 new bats, all green)

- `gh_issue_proceed_schema.bats` — 5 schema variants: all-OK, missing,
  empty, H3-nested, KO-aliases.
- `gh_issue_proceed_safety.bats` — Layer-1 `ABSOLUTE_BLOCK_PATTERNS`, one
  positive + one negative per pattern (9 patterns).
- Pure-shell fixtures mirror the SSOT reference files (repo convention).
- Full `./tests/test` suite: **exit 0**. shellcheck + `shfmt -i 4` clean.

## Open-question resolutions (from design §11)

| Q | Decision |
|---|---|
| Reuse strategy | **copy** (matches existing self-contained `references/` convention) |
| Test convention | **bats `_fixtures/*.sh` mirror** at `tests/bats/skills/` |
| STRUCTURED payload contract on composed skills | **follow-up issue** (non-blocking; callees already create artifacts without prompts) |
| Step-completion markers | **yes** (mirrors #753 pattern) |

## Acceptance criteria (#874)

- [x] `SKILL.md` ≤ 150 lines, 4-step shell + Constraints
- [x] All 9 `references/*.md` present, SSOT-consistent with the design
- [x] Schema validator passes 5 fixture variants
- [x] Safety Layer-1 patterns covered (positive + negative per pattern)
- [x] Sibling descriptions cross-link `[[gh:issue-proceed]]`
- [x] CI green (full suite exit 0)
- [x] Closes the issue via footer

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
