### PR TITLE
refactor(gh-issue-flow): #875 Step 4 pr-reply 예약 지연 10분 → 5분 단축

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -2,7 +2,7 @@
 name: gh:issue-flow
 description: >-
   Composition skill that chains gh:issue-implement → gh:commit → gh:pr
-  → devx:schedule (pr-reply, 10 min) → gh:pr-resolve-conflict for a
+  → devx:schedule (pr-reply, 5 min) → gh:pr-resolve-conflict for a
   single issue number. Use when the user runs /gh:issue-flow,
   /gh-issue-flow, or asks "issue #16 처음부터 PR까지 자동으로",
   "이슈 구현하고 커밋하고 PR까지 한방에", "full flow on #42". Uses
@@ -102,9 +102,9 @@ if the previous completed successfully.
 
 4. **Step 2.4 — devx:schedule** (only if 2.3 succeeded)
    ```
-   Skill(devx:schedule, "--time 10 \"/gh-pr-reply <PR_NUM>\"")
+   Skill(devx:schedule, "--time 5 \"/gh-pr-reply <PR_NUM>\"")
    ```
-   Schedules `/gh-pr-reply <PR_NUM>` to run 10 minutes after PR creation,
+   Schedules `/gh-pr-reply <PR_NUM>` to run 5 minutes after PR creation,
    giving CI checks and reviewers time to post before the bot replies.
    **Now invoke Step 2.5 — no recap, no summary, no header.**
 
@@ -187,7 +187,7 @@ gh:issue-flow complete (#<N>)
   [OK] Step 1: gh:issue-implement       (<n files changed>, <n tests passed>)
   [OK] Step 2: gh:commit                (<sha> "<subject>")
   [OK] Step 3: gh:pr                    (PR #<M>)
-  [OK] Step 4: devx:schedule            (pr-reply in 10 min, job: <id>)
+  [OK] Step 4: devx:schedule            (pr-reply in 5 min, job: <id>)
   [OK] Step 5: gh:pr-resolve-conflict   (no conflicts / resolved)
   [OK] Step 6: ai-metrics               (~X tokens · ~M h · ~L min)
   PR URL: <pr-url>
@@ -210,7 +210,7 @@ Resume hint logic:
 - Failed at step 1 → `/gh-issue-implement <N>` (user decides retry).
 - Failed at step 2 → `/gh-commit && /gh-pr <N>`.
 - Failed at step 3 → `/gh-pr <N>`.
-- Failed at step 4 → `/devx:schedule --time 10 "/gh-pr-reply <PR_NUM>"`.
+- Failed at step 4 → `/devx:schedule --time 5 "/gh-pr-reply <PR_NUM>"`.
 - Failed at step 5 → `/gh-pr-resolve-conflict <PR_NUM>`.
 
 ## Constraints

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -20,7 +20,7 @@ This skill invokes **5 skills in sequence** (each step runs only if the previous
 1. **`gh:issue-implement <N> direct`** — reads the issue, edits files, runs tests. No human intervention.
 2. **`gh:commit`** — creates a commit for the changes with a message derived from the conversation (follows the repo's commit style).
 3. **`gh:pr`** — pushes the branch and opens a PR, auto-linking `Closes #<N>`.
-4. **`devx:schedule` `--time 10 "/gh-pr-reply <PR_NUM>"`** — schedules a pr-reply run 10 minutes after PR creation, giving CI and reviewers time to post before the bot replies.
+4. **`devx:schedule` `--time 5 "/gh-pr-reply <PR_NUM>"`** — schedules a pr-reply run 5 minutes after PR creation, giving CI and reviewers time to post before the bot replies.
 5. **`gh:pr-resolve-conflict` `<PR_NUM>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
 
 If any step fails, the chain stops immediately. No automatic retry.


### PR DESCRIPTION
## Summary

`gh:issue-flow` 의 Step 4 (`devx:schedule` → `/gh-pr-reply` 예약) 지연을
**10분 → 5분**으로 단축한다. 문구가 흩어져 있던 6곳을 일괄 치환해 drift 없이
일치시켰다.

## Changes

- `SKILL.md` (5곳)
  - frontmatter `description` — `(pr-reply, 10 min)` → `(pr-reply, 5 min)`
  - Step 2.4 호출 — `--time 10` → `--time 5`
  - Step 2.4 본문 설명 — `10 minutes` → `5 minutes`
  - Step 3 리포트 템플릿 — `pr-reply in 10 min` → `5 min`
  - resume 힌트 (step 4 실패) — `--time 10` → `--time 5`
- `references/help.md` (1곳) — chained-skill 목록의 `--time 10` / `10 minutes` → 5분

## Rationale

CI/리뷰어가 코멘트를 남길 여유는 5분이면 충분하며, 첫 PR 직후 gemini/sourcery
등 봇 리뷰는 보통 2~3분 내 도착해 10분 대기는 과도했다. `devx:schedule` 자체
기본값(5분)은 건드리지 않고, `gh:issue-flow` 가 명시적으로 넘기던 `--time`
인자만 5로 맞춰 기본값과 동일선상으로 정리했다.

## Test

문서 전용 변경 (런타임 코드 없음). `grep` 으로 잔여 10분 참조 0건, 신규 5분 참조 6건 확인.

Closes #875
