### PR TITLE
refactor(skills): #862 PR-NW-4 — gh-pr-* 5개 line-count 추출 + Check 12 metadata

### DIFF
--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -9,14 +9,19 @@ description: >-
   draft PRs, or PRs with conflicts. Accepts
   `<pr-number> [rebase|squash|merge] [remote]`. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "gh pr merge wrap with policy/preflight gate; bounded mutation, no deep reasoning"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-merge — Merge Approved PR (3 strategies)
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
+If arg #1 is `-h`/`--help`/`help`, output `references/help.md` verbatim and stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Repo
 
@@ -24,93 +29,38 @@ Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 
 Positional args: `<pr-number> [strategy] [remote]`.
 
-- `pr-number` — required, positive integer. Missing/invalid → print
-  usage pointer and stop.
-- `strategy` — default `rebase`. Must be `rebase`, `squash`, or `merge`.
-  Any other value → print allowed values and stop.
-- `remote` — default `origin`. Resolve `TARGET_REPO=<owner>/<repo>`
-  via `git remote get-url <remote>` (parse `https://github.com/<o>/<r>.git`
-  or `git@github.com:<o>/<r>.git`). Missing remote → list `git remote -v`
-  and stop (no silent fallback).
+- `pr-number` — required, positive integer. Missing/invalid → usage pointer, stop.
+- `strategy` — default `rebase`; one of `rebase`/`squash`/`merge`. Other → print allowed values, stop.
+- `remote` — default `origin`. Resolve `TARGET_REPO=<owner>/<repo>` from
+  `git remote get-url <remote>` (parse `https://github.com/<o>/<r>.git` or
+  `git@github.com:<o>/<r>.git`). Missing remote → list `git remote -v`, stop (no silent fallback).
 
 ## Step 2: Pre-flight (parallel)
 
-Run in one message:
-- `gh pr view <N> --repo $TARGET_REPO --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,url`
-- `gh pr checks <N> --repo $TARGET_REPO --required`
+Run in one message: `gh pr view <N> --repo $TARGET_REPO --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,url`
+and `gh pr checks <N> --repo $TARGET_REPO --required`.
 
-Then detect whether the base branch has protection rules (uses
-`baseRefName` from the previous call):
+Then detect base-branch protection via
+`gh api "repos/$TARGET_REPO/branches/<baseRefName>/protection"`
+(exit 0 → present; 403/404 → absent). The exact protection-vs-
+`reviewDecision` behavior table is in `references/strategy-selection.md`
+→ "Branch protection detection".
 
-- `gh api "repos/$TARGET_REPO/branches/<baseRefName>/protection"`
-  - HTTP 200 → protection **present**; strict rules apply.
-  - HTTP 403 (Free plan locks the feature) or 404 (not configured)
-    → protection **absent**; empty `reviewDecision` is accepted
-    (solo / personal repos where no one can approve your own PR).
-
-**Hard stops** (see `references/strategy-selection.md` for exact table):
-- `state != OPEN`
-- `isDraft == true`
-- `mergeable == CONFLICTING`
-- `reviewDecision != APPROVED` → suggest `/gh-pr-merge-emergency` for admin bypass
-  - Exception: protection **absent** (403/404) **AND** `reviewDecision == ""`
-    → accept and print an informational line:
-    `INFO: No branch protection on <baseRefName> — accepting empty reviewDecision.`
-    A non-empty non-APPROVED value (`REVIEW_REQUIRED`,
-    `CHANGES_REQUESTED`) still stops regardless of protection.
-- `mergeStateStatus ∈ {BEHIND, BLOCKED, DIRTY}`
-- Any required check FAILURE or pending
+**Hard stops** (full table in `references/strategy-selection.md` →
+"Hard-stop decisions"): `state != OPEN`; `isDraft`; `mergeable ==
+CONFLICTING`; `mergeStateStatus ∈ {BEHIND, BLOCKED, DIRTY}`; any required
+check FAILURE/pending; `reviewDecision != APPROVED` → suggest
+`/gh-pr-merge-emergency`. Conditional exception: protection **absent**
+**AND** `reviewDecision == ""` → accept and print
+`INFO: No branch protection on <baseRefName> — accepting empty reviewDecision.`
+(a non-empty non-APPROVED value still stops).
 
 ## Step 2-B: Project Board Approval Gate (fail-closed)
 
-Read `references/board-policy.md` for the rule set and the cross-link
-to `gh-pr-approve`. This step runs **before** Step 3 and gates merges
-on the team's projectV2 board column.
-
-```bash
-# Reuse the SSOT query helper — never inline a fresh GraphQL block.
-# helper-fallback NF-1 (#644): silent-skip when helper missing; never hard-fail.
-# Defense-in-depth (#724): a sourced-but-undefined function would let
-# `_gh_project_status_query_current` expand to nothing, BOARD_STATUS would
-# be empty, and the empty-status branch would silently let merges through
-# — bypassing the board approval gate. Detect that case explicitly.
-_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-if [ -r "$_HELPER" ]; then
-    . "$_HELPER"
-
-    if ! command -v _gh_project_status_query_current >/dev/null 2>&1; then
-        printf '[gh-pr-merge] %s sourced but _gh_project_status_query_current undefined — board approval gate skipped (#724).\n' \
-            "$_HELPER" >&2
-    # Operator escape hatch: GH_PR_MERGE_SKIP_BOARD_CHECK=1
-    # Use for in-transition repos or one-shot ops (also leaves an audit signal:
-    # any reviewer can re-run gh-pr-merge without the env var to verify).
-    elif [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
-        BOARD_STATUS=$(GH_REPO="$TARGET_REPO" \
-            _gh_project_status_query_current pr "$PR_NUMBER" 2>/dev/null || true)
-
-        # Empty result = no projectV2 attached OR no read access.
-        # Auto-skip in both cases — the merge gate is opt-in by board attachment.
-        if [ -n "$BOARD_STATUS" ] && [ "$BOARD_STATUS" != "Approved" ]; then
-            echo "Refusing to merge PR #$PR_NUMBER — board Status is \"$BOARD_STATUS\", required \"Approved\"."
-            echo "  Have a teammate move the card to Approved, or use /gh-pr-merge-emergency for admin bypass."
-            echo "  One-shot escape: GH_PR_MERGE_SKIP_BOARD_CHECK=1 /gh-pr-merge $PR_NUMBER"
-            exit 2
-        fi
-    fi
-fi
-# helper missing → board approval gate is silently skipped (NF-1).
-```
-
-Failure modes:
-
-- Board Status `!= Approved` (and non-empty) → exit 2, redirect to
-  `/gh-pr-merge-emergency`.
-- Empty Status (no projectV2 attached, or query failed) → silently
-  continue. Repos without a board run on the legacy `reviewDecision`
-  gate from Step 2 alone.
-- `GH_PR_MERGE_SKIP_BOARD_CHECK=1` → skip Step 2-B entirely. Document
-  the reason in the operator's commit message or Slack channel; this
-  flag is for repos in transition, not a quiet-the-warning button.
+Rule set + `gh-pr-approve` cross-link in `references/board-policy.md`.
+Run the board approval gate per `references/board-approval-gate.sh.md`
+(fail-closed; helper-missing → silent-skip; `GH_PR_MERGE_SKIP_BOARD_CHECK=1`
+to bypass). Runs **before** Step 3; gates on the projectV2 board column.
 
 ## Step 3: Merge (no confirmation)
 
@@ -118,74 +68,22 @@ Failure modes:
 gh pr merge <N> --repo "$TARGET_REPO" --<strategy> --delete-branch
 ```
 
-Flag mapping in `references/strategy-selection.md`.
-
-If `gh` returns "merge method is not allowed", print the repo-settings
-guidance from `references/strategy-selection.md` and stop. **Never**
-silently switch strategies.
+Flag mapping in `references/strategy-selection.md`. If `gh` returns
+"merge method is not allowed", print the repo-settings guidance from
+`references/strategy-selection.md` and stop. **Never** silently switch
+strategies.
 
 ## Step 4: Sync Project Board Status
 
-Read `references/project-board-sync.md` for the failure modes and
-gating rationale. Two reconciliations run after a successful merge:
+Run the two post-merge board reconciliations (PR card → Done; linked
+Issue cards → Done) per `references/project-board-sync.md` — paste the
+snippets verbatim (that file also holds the failure modes and gating
+rationale). Both helpers auto-detect repos without a projectV2
+attachment and silently return; failures hit stderr, never block the report.
 
-(a) PR card → `Done` (closes the gap from #248 where the merged PR
-    card stayed at `Approved`):
-
-```bash
-# helper-fallback NF-1 (#644): silent-skip when helper missing.
-# Defense-in-depth (#724): also detect "sourced but function undefined".
-_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-if [ -r "$_HELPER" ]; then
-    . "$_HELPER"
-    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-        printf '[gh-pr-merge] %s sourced but _gh_project_status_sync undefined — Done reconciliations skipped (#724).\n' \
-            "$_HELPER" >&2
-    else
-        GH_REPO="$TARGET_REPO" _gh_project_status_sync pr "$PR_NUMBER" "Done" || true
-
-        # (b) Linked Issue cards from `closingIssuesReferences` → `Done`
-        #     (boosts the best-effort `Item closed` builtin per #250). Use the
-        #     `_gh_pr_closing_issue_numbers` helper instead of
-        #     `gh pr view --json closingIssuesReferences` — older `gh` (≤ 2.45)
-        #     rejects that field with "Unknown JSON field" (#264):
-        for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$TARGET_REPO" 2>/dev/null || true); do
-            GH_REPO="$TARGET_REPO" _gh_project_status_sync issue "$_issue" "Done" \
-                --only-from "Backlog,In progress,In review" || true
-        done
-    fi
-fi
-# helper missing → both reconciliations silently skipped (NF-1).
-```
-
-Both helpers auto-detect repos without a projectV2 attachment and
-silently return. This step never blocks the report — failures are
-logged to stderr and ignored.
-
-After the board sync completes, post an ai-metrics PR comment (soft-fail).
-When `GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399):
-
-```bash
-ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
-else
-    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-      -X POST \
-      -f body="---
-<details>
-<summary>🤖 AI Metrics · 📊 ~${TOKENS:-2000} tokens · 👤 ~0.25 h · 🤖 ~$ELAPSED min</summary>
-
-<!-- ai-metrics:gh-pr-merge -->
-📊 ~${TOKENS:-2000} tokens · 👤 ~0.25 h · 🤖 ~$ELAPSED min
-<!-- /ai-metrics:gh-pr-merge -->
-
-</details>
-PR merge: ~$ELAPSED min"
-fi
-```
-
-On failure: `[WARN] ai-metrics comment failed — continuing.`
+After the board sync completes, post the ai-metrics PR comment per
+`references/ai-metrics-comment.sh.md` (soft-fail; skip entirely when
+`GH_DISABLE_AI_METRICS=1`).
 
 ## Step 5: Fetch Merge SHA + Report
 
@@ -193,13 +91,10 @@ On failure: `[WARN] ai-metrics comment failed — continuing.`
 gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -q .mergeCommit.oid
 ```
 
-Print **only** the compact report (format in
-`references/strategy-selection.md` → "Final report format").
+Print **only** the compact report (format in `references/strategy-selection.md` → "Final report format").
 
 ## Constraints
 
 - Never ask for confirmation — running the skill is the confirmation.
-- Never merge an un-approved PR. Redirect to `gh:pr-merge-emergency`.
-- Never swap to a different strategy if the chosen one fails.
-- Always `--delete-branch` — head branches accumulate fast.
-- Never bypass CI. Required checks must pass.
+- Never merge an un-approved PR; redirect to `gh:pr-merge-emergency`. Never bypass CI.
+- Never swap strategy if the chosen one fails. Always `--delete-branch`.

--- a/claude/skills/gh-pr-merge/references/ai-metrics-comment.sh.md
+++ b/claude/skills/gh-pr-merge/references/ai-metrics-comment.sh.md
@@ -1,0 +1,28 @@
+# ai-metrics Comment — post-merge PR footer (soft-fail)
+
+Posted after the board sync (Step 4) completes. Soft-fail: on error,
+print `[WARN] ai-metrics comment failed — continuing.` and proceed.
+When `GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399).
+
+The footer glyphs (🤖 📊 👤) are intentional — `gh-pr-merge` is on the
+emoji allowlist (CLAUDE.md #317/#320/#367). Keep them as-is.
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-2000} tokens · 👤 ~0.25 h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-merge -->
+📊 ~${TOKENS:-2000} tokens · 👤 ~0.25 h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-merge -->
+
+</details>
+PR merge: ~$ELAPSED min"
+fi
+```

--- a/claude/skills/gh-pr-merge/references/board-approval-gate.sh.md
+++ b/claude/skills/gh-pr-merge/references/board-approval-gate.sh.md
@@ -1,0 +1,50 @@
+# Board Approval Gate — fail-closed pre-merge check
+
+Step 2-B runs **before** Step 3 and gates the merge on the team's
+projectV2 board column. See `board-policy.md` for the rule set and the
+cross-link to `gh-pr-approve`.
+
+```bash
+# Reuse the SSOT query helper — never inline a fresh GraphQL block.
+# helper-fallback NF-1 (#644): silent-skip when helper missing; never hard-fail.
+# Defense-in-depth (#724): a sourced-but-undefined function would let
+# `_gh_project_status_query_current` expand to nothing, BOARD_STATUS would
+# be empty, and the empty-status branch would silently let merges through
+# — bypassing the board approval gate. Detect that case explicitly.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+
+    if ! command -v _gh_project_status_query_current >/dev/null 2>&1; then
+        printf '[gh-pr-merge] %s sourced but _gh_project_status_query_current undefined — board approval gate skipped (#724).\n' \
+            "$_HELPER" >&2
+    # Operator escape hatch: GH_PR_MERGE_SKIP_BOARD_CHECK=1
+    # Use for in-transition repos or one-shot ops (also leaves an audit signal:
+    # any reviewer can re-run gh-pr-merge without the env var to verify).
+    elif [ "${GH_PR_MERGE_SKIP_BOARD_CHECK:-0}" != "1" ]; then
+        BOARD_STATUS=$(GH_REPO="$TARGET_REPO" \
+            _gh_project_status_query_current pr "$PR_NUMBER" 2>/dev/null || true)
+
+        # Empty result = no projectV2 attached OR no read access.
+        # Auto-skip in both cases — the merge gate is opt-in by board attachment.
+        if [ -n "$BOARD_STATUS" ] && [ "$BOARD_STATUS" != "Approved" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER — board Status is \"$BOARD_STATUS\", required \"Approved\"."
+            echo "  Have a teammate move the card to Approved, or use /gh-pr-merge-emergency for admin bypass."
+            echo "  One-shot escape: GH_PR_MERGE_SKIP_BOARD_CHECK=1 /gh-pr-merge $PR_NUMBER"
+            exit 2
+        fi
+    fi
+fi
+# helper missing → board approval gate is silently skipped (NF-1).
+```
+
+## Failure modes
+
+- Board Status `!= Approved` (and non-empty) → exit 2, redirect to
+  `/gh-pr-merge-emergency`.
+- Empty Status (no projectV2 attached, or query failed) → silently
+  continue. Repos without a board run on the legacy `reviewDecision`
+  gate from Step 2 alone.
+- `GH_PR_MERGE_SKIP_BOARD_CHECK=1` → skip Step 2-B entirely. Document
+  the reason in the operator's commit message or Slack channel; this
+  flag is for repos in transition, not a quiet-the-warning button.

--- a/claude/skills/gh-pr-merge/references/strategy-selection.md
+++ b/claude/skills/gh-pr-merge/references/strategy-selection.md
@@ -102,9 +102,16 @@ report and include the PR URL so the user can resolve manually.
 
 ## Final report format
 
+Lead with an explicit verdict line, then the structured key-values:
+
 ```
-PR #<N> merged (<strategy>)
+[OK] PR #<N> merged (<strategy>)
   Merge SHA:  <sha>
   Branch:     <headRefName> → <baseRefName> (deleted)
   URL:        <pr-url>
 ```
+
+A hard stop before the merge (un-approved, conflicting, failing checks,
+board gate) instead prints a `[FAIL] PR #<N> not merged — <reason>` line
+and the redirect (e.g. `/gh-pr-merge-emergency`). The Merge SHA renders as
+`(pending)` when GitHub has not yet computed `mergeCommit.oid`.

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -1,227 +1,100 @@
 ---
 name: gh:pr-reply
 description: >-
-  Fetch code review comments on a GitHub PR, evaluate each one, apply valid
-  fixes, and leave an individual reply on every comment (Accepted with what
-  changed, or Declined with reasoning). Use when the user runs /gh:pr-reply,
-  /gh-pr-reply, or asks "PR 리뷰 코멘트 확인하고 수정", "리뷰 답변 달아", "PR 123
-  코멘트 처리해". Defaults to the PR for the current branch; accepts an explicit
-  PR number as an argument. Every comment MUST get a reply — bot comments
-  (gemini, sourcery, copilot) included. Accepts `-h`/`--help`/`help` to
-  print usage.
+  Fetch code review comments on a GitHub PR, evaluate each one, apply valid fixes, and leave an individual reply on every comment (Accepted with what changed, or Declined with reasoning). Use when the user runs /gh:pr-reply, /gh-pr-reply, or asks "PR 리뷰 코멘트 확인하고 수정", "리뷰 답변 달아", "PR 123 코멘트 처리해". Defaults to the PR for the current branch; accepts an explicit PR number as an argument. Every comment MUST get a reply — bot comments (gemini, sourcery, copilot) included. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "review comment evaluation + classification + targeted edits + per-comment reply; moderate analysis, not deep implementation"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-reply — Address PR Review Comments
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md`, output it
+verbatim, then stop. No API calls.
 
 ## Role
 
-Systematically process every code-review comment on a PR: judge validity,
-fix valid ones, and reply to each comment with the outcome. **Politeness
-rule** — reviewers (humans and bots alike) must see an explicit response on
-every thread. Silent fixes are not acceptable; silent declines are worse.
+Process every code-review comment on a PR: judge validity, fix valid ones,
+reply to each with the outcome. **Politeness rule** — reviewers (humans and
+bots alike) must see an explicit response on every thread. Silent fixes are
+not acceptable; silent declines are worse.
 
 ## Step 1: Resolve Target PR
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 7.
-
-Precedence:
-1. **Explicit argument** — `/gh:pr-reply 123` → PR #123.
-2. **Current branch auto-detect** — `gh pr view --json number,url,headRefName,baseRefName`; if no PR exists, stop and tell the user.
-3. Never guess. Never pick "the latest PR in the repo".
-
-Also capture `TARGET_REPO` via `gh repo view --json nameWithOwner -q .nameWithOwner`
-(e.g. `owner/repo`). Use `$TARGET_REPO` consistently in all subsequent API calls.
+Record `START_TS=$(date +%s)` immediately (elapsed tracking in Step 7).
+Precedence: (1) **explicit arg** — `/gh:pr-reply 123` → PR #123; (2)
+**current branch** — `gh pr view --json number,url,headRefName,baseRefName`,
+stop if no PR; (3) never guess, never pick "the latest PR". Also capture
+`TARGET_REPO` via `gh repo view --json nameWithOwner -q .nameWithOwner` and
+use it in all subsequent API calls.
 
 ## Step 2: Fetch All Review Comments
 
 Read `references/comment-fetching.md` for the three API endpoints, field
 extraction, and dedup rule. Fetch all three; filter out already-replied
-threads. Bot service notices (quota / rate-limit / outage) — whether
-posted as review summaries OR as conversation comments — follow the
-"Bot service notices" section in the same reference: classify as
-service-notice, single-line ack in Step 5, count separately in Step 7.
+threads. Bot service notices (quota / rate-limit / outage) follow that
+reference's "Bot service notices" section (service-notice classification,
+single-line ack in Step 5, counted separately in Step 7).
 
-## Step 2.5: Early Exit — No Unaddressed Comments
-
-If Step 2 yields **zero unaddressed threads** after deduplication:
-
-1. Print exactly one line:
-   ```
-   No unaddressed review comments — nothing to do.
-   ```
-2. **Stop immediately.** Do not run Steps 3–7. Do not post an ai-metrics
-   comment. Do not push anything.
+**Step 2.5 early exit:** if this yields **zero unaddressed threads** after
+dedup, print exactly `No unaddressed review comments — nothing to do.` and
+**stop** — do not run Steps 3–7, do not post ai-metrics, do not push.
 
 ## Step 3: Evaluate Each Comment
 
 For each unaddressed comment, read the referenced file (`path` at `line`)
 and classify as **ACCEPT** / **ACCEPT-PARTIAL** / **DECLINE** / **QUESTION**.
 Bot comments (gemini-code-assist, sourcery-ai, copilot) follow the same
-rules. See `references/reply-templates.md` for the full rubric.
+rules; see `references/reply-templates.md` for the full rubric.
 
 ## Step 4: Apply Fixes (ACCEPT / ACCEPT-PARTIAL only)
 
 Keep each fix minimal and scoped — no drive-by refactors. Group related
-fixes into themed commits (one per theme, not one per comment) with messages
-like `fix(review): address X as suggested in PR #123 review`. Never
-`--amend` or `--no-verify`.
+fixes into themed commits (one per theme, not per comment), e.g.
+`fix(review): address X …`. Never `--amend` or `--no-verify`.
 
 ## Step 5: Reply to Every Comment
 
-**Non-negotiable. Every comment identified in Step 2 must receive a reply,
-including declined ones and bot comments.**
+**Non-negotiable. Every comment from Step 2 must receive a reply, including
+declined ones and bot comments.** Read `references/reply-templates.md` for
+POST command shapes, the four body templates, the long-body fallback, and
+the consolidated table reply. Reply in the reviewer's language.
 
-Read `references/reply-templates.md` for POST command shapes (inline thread
-vs top-level), the four body templates (Accepted / Accepted-with-modification
-/ Declined / Question), the "Long-body fallback" pattern (review body
-> 500 chars → cite by review id instead of verbatim blockquote), and the
-"Consolidated table reply" template (single review body with N ≥ 3
-independent items → one table reply, not N separate ones). Reply in the
-reviewer's language.
-
-## Step 6: Push the Fix Commits
+## Step 6: Push the Fix Commits + Sync Board
 
 If any fixes were committed: `git push` (never force-push unless the user
-asked) and report new commit SHAs alongside the reply summary.
-
-Track the push outcome in `PUSHED_FIXES` (count of new commit SHAs that
-landed on the remote branch in this step). Step 6.5 reads this variable
-to decide whether to move the PR card. When no fixes were committed
-(all comments were DECLINE / QUESTION) or `git push` is skipped, set
-`PUSHED_FIXES=0` so Step 6.5 becomes a no-op.
-
-## Step 6.5: Sync Project Board (`In review` 복귀)
-
-If Step 6 actually pushed at least one fix commit (i.e. `PUSHED_FIXES > 0`,
-new SHAs created on the remote branch), push the PR card back to
-`In review` so reviewers see it in their queue. Mirrors the
-`/gh-pr-resolve-conflict` Step 5 pattern (issue #591) so both flows
-share one board-recovery surface.
-
-Skips when `PUSHED_FIXES == 0` (all comments DECLINE / QUESTION — no
-push happened, so the card lifecycle has not changed and there is
-nothing to recover). The `--only-from "In progress,Changes requested"`
-guard makes the call a no-op for cards already at `In review` /
-`Approved` / `Done`, so re-running on an already-recovered card never
-demotes status.
-
-Soft-fail — warn on any error, never block the Step 7 report.
-
-```bash
-if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
-    # helper-fallback NF-1 (#644): silent-skip when helper missing.
-    # Defense-in-depth (#724): also detect "sourced but function undefined".
-    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-    if [ -r "$_HELPER" ]; then
-        . "$_HELPER"
-        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-            printf '[gh-pr-reply] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
-                "$_HELPER" >&2
-        elif _gh_project_status_sync pr "$PR_NUMBER" "In review" \
-                --only-from "In progress,Changes requested"; then
-            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
-        else
-            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
-        fi
-    fi
-    # helper missing → board sync silently skipped (NF-1).
-fi
-```
-
-`GH_PROJECT_STATUS_SYNC=0` opt-out is absorbed by the helper itself.
-projectV2 보드가 없는 레포는 helper 가 silent 0 반환. `--only-from`
-의 missing column 은 helper 가 silently skip 하므로 `Changes requested`
-컬럼 없는 보드와도 호환된다.
+asked) and report new commit SHAs alongside the reply summary. Set
+`PUSHED_FIXES` to the count of new SHAs on the remote branch; no fixes /
+skipped push → `PUSHED_FIXES=0`. If `PUSHED_FIXES > 0`, push the PR card
+back to `In review` per `references/board-sync-in-review.sh.md` (soft-fail;
+no-op when `PUSHED_FIXES == 0`).
 
 ## Step 7: Report
 
-Print the summary table per `references/final-summary.md` showing
-Accepted / Declined / Answered counts, commit SHAs, any skipped
-already-replied comments, **and the Step 8 outcome row** (always one
-of `[OK] Step 8: …`, `[SKIP] Step 8: …`, or `[WARN] Step 8: …` — see
-`references/final-summary.md` for the full row template). The Step 8
-row consumes the `STEP8_OUTCOME` variable bound by the auto-approve
-gate; if `STEP8_OUTCOME` is empty the gate never ran and the report
-is **incomplete** (a regression signal — see issue #662). After the
-table, run the "Lingering `CHANGES_REQUESTED` nudge" check from the
-same reference: re-query `gh pr view --json reviewDecision`, and if
-still `CHANGES_REQUESTED`, emit the one-line nudge so the user knows
-replies + fixes alone do not clear the review block — the reviewer
-must re-review.
-
-After printing the report, post a PR comment with ai-metrics (soft-fail —
-warn on error, never block). `COMMENT_COUNT` is the number of comments
-addressed in Step 5 (including declined and bot comments). When
-`GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399):
-
-```bash
-ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-HUMAN_H=$(echo "scale=2; $COMMENT_COUNT * 0.25" | bc)
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
-else
-    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-      -X POST \
-      -f body="---
-<details>
-<summary>🤖 AI Metrics · 📊 ~${TOKENS:-5000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
-
-<!-- ai-metrics:gh-pr-reply -->
-📊 ~${TOKENS:-5000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
-<!-- /ai-metrics:gh-pr-reply -->
-
-</details>
-리뷰 답변: ~$ELAPSED min · 사람: ~$HUMAN_H h ($COMMENT_COUNT comments × 0.25 h)"
-fi
-```
-
-On failure: `[WARN] ai-metrics comment failed — continuing.`
+Print the summary table per `references/final-summary.md` (Accepted /
+Declined / Answered counts, commit SHAs, skipped comments, the
+`STEP8_OUTCOME`-driven Step 8 row, and the lingering `CHANGES_REQUESTED`
+nudge — all rendering rules in that reference; an empty `STEP8_OUTCOME` is an
+**incomplete** report, issue #662). Then post the ai-metrics PR comment per
+`references/ai-metrics-comment.sh.md` (soft-fail; skip when `GH_DISABLE_AI_METRICS=1`).
 
 ## Step 8: Solo-Repo Auto-Approve (opt-in, soft-fail)
 
 After Step 7, optionally move the PR card from `In review` to `Approved`.
-**Always evaluate the 4 guards (skip is itself a logged outcome)** —
-the move fires only when all four guards pass, but the gate runs on
-every invocation so the outcome (fire / skip / warn) is bound to
-`STEP8_OUTCOME` and surfaced as a row in the Step 7 report. Never
-short-circuit the evaluation based on a prior assumption about env
-configuration; the four-guard algorithm is the single source of
-truth (issue #662). Guards:
-
-| Guard | Pass condition |
-|---|---|
-| G1 | `GH_PR_REPLY_AUTO_APPROVE_REPOS` (`owner/repo` CSV) contains `$TARGET_REPO` (case-exact) |
-| G2 | Step 2.5 did NOT early-exit (`COMMENT_COUNT >= 1`) |
-| G3 | PR `state == OPEN` AND `isDraft == false` |
-| G4 | PR `reviewDecision` is empty/`null` or `APPROVED` (never `REVIEW_REQUIRED` / `CHANGES_REQUESTED`) |
-
-On all-pass: emit the audit-trace line and call
-`_gh_project_status_sync pr "$PR_NUMBER" "Approved" --only-from "In review"`
-with `_GH_PROJECT_STATUS_GUARD_APPROVED_BYPASS=1` scoped to that single
-call (prefix form, never `env` — it is a shell function). Helper rc
-0/2 is soft-fail and never blocks the report. Bind `STEP8_OUTCOME`
-on every branch (`OK:fired` / `SKIP:<reason>` / `WARN:rc=<N>`) so the
-Step 7 report row reflects the actual evaluation result — full
-outcome matrix and rendering rules: `references/auto-approve.md`
-and `references/final-summary.md`. Full SSOT (4-guard algorithm,
-audit format, defense-in-depth, ties to #275/#231/#393/#397):
-`references/auto-approve.md`.
+Run the 4-guard gate per `references/auto-approve.md`.
 
 ## Constraints
 
-- **Never skip a reply** — even "Declined: out of scope" counts. Bot comments included. This is the core contract of the skill.
-- Never close or resolve threads programmatically — leave that to the user.
-- Never dismiss bot comments as "just a bot".
+- **Never skip a reply** — even "Declined: out of scope" counts, bot comments included; core contract. Never dismiss a bot comment as "just a bot".
+- Never close/resolve threads programmatically — leave that to the user.
 - Never fix files outside the PR's diff without flagging scope creep first.
 - Never `--force-push`. If history rewrite is needed, stop and ask.
-- If a future fix flow needs to mutate PR labels or body, route through
-  `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
-  (`shell-common/functions/gh_pr_edit_safe.sh`). Bare `gh pr edit
-  --add-label` / `--body-file` silently exits 1 on repos with classic
-  Projects attached (issue #326 Bug B).
+- To mutate PR labels or body, route through `_gh_pr_edit_safe_label` /
+  `_gh_pr_edit_safe_body` (`shell-common/functions/gh_pr_edit_safe.sh`) — bare
+  `gh pr edit --add-label` / `--body-file` silently exits 1 on classic-Projects repos (issue #326 Bug B).

--- a/claude/skills/gh-pr-reply/references/ai-metrics-comment.sh.md
+++ b/claude/skills/gh-pr-reply/references/ai-metrics-comment.sh.md
@@ -8,7 +8,7 @@ comment entirely (issue #399).
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-HUMAN_H=$(echo "scale=2; $COMMENT_COUNT * 0.25" | bc)
+HUMAN_H=$(awk -v cc="$COMMENT_COUNT" 'BEGIN { printf "%.2f", cc * 0.25 }')
 if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
     : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
 else

--- a/claude/skills/gh-pr-reply/references/ai-metrics-comment.sh.md
+++ b/claude/skills/gh-pr-reply/references/ai-metrics-comment.sh.md
@@ -1,0 +1,30 @@
+# gh:pr-reply Step 7 — ai-metrics PR comment
+
+Called from `SKILL.md` Step 7, after printing the final report. Post a
+PR comment with ai-metrics (soft-fail — warn on error, never block).
+`COMMENT_COUNT` is the number of comments addressed in Step 5 (including
+declined and bot comments). When `GH_DISABLE_AI_METRICS=1`, skip the
+comment entirely (issue #399).
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+HUMAN_H=$(echo "scale=2; $COMMENT_COUNT * 0.25" | bc)
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-5000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-reply -->
+📊 ~${TOKENS:-5000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-reply -->
+
+</details>
+리뷰 답변: ~$ELAPSED min · 사람: ~$HUMAN_H h ($COMMENT_COUNT comments × 0.25 h)"
+fi
+```
+
+On failure: `[WARN] ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr-reply/references/board-sync-in-review.sh.md
+++ b/claude/skills/gh-pr-reply/references/board-sync-in-review.sh.md
@@ -1,0 +1,42 @@
+# gh:pr-reply Step 6.5 — Sync Project Board (`In review` 복귀)
+
+Called from `SKILL.md` Step 6.5. If Step 6 actually pushed at least one
+fix commit (i.e. `PUSHED_FIXES > 0`, new SHAs created on the remote
+branch), push the PR card back to `In review` so reviewers see it in
+their queue. Mirrors the `/gh-pr-resolve-conflict` Step 5 pattern
+(issue #591) so both flows share one board-recovery surface.
+
+Skips when `PUSHED_FIXES == 0` (all comments DECLINE / QUESTION — no
+push happened, so the card lifecycle has not changed and there is
+nothing to recover). The `--only-from "In progress,Changes requested"`
+guard makes the call a no-op for cards already at `In review` /
+`Approved` / `Done`, so re-running on an already-recovered card never
+demotes status.
+
+Soft-fail — warn on any error, never block the Step 7 report.
+
+```bash
+if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
+    # helper-fallback NF-1 (#644): silent-skip when helper missing.
+    # Defense-in-depth (#724): also detect "sourced but function undefined".
+    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        . "$_HELPER"
+        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+            printf '[gh-pr-reply] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+                "$_HELPER" >&2
+        elif _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+                --only-from "In progress,Changes requested"; then
+            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
+        else
+            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+        fi
+    fi
+    # helper missing → board sync silently skipped (NF-1).
+fi
+```
+
+`GH_PROJECT_STATUS_SYNC=0` opt-out is absorbed by the helper itself.
+projectV2 보드가 없는 레포는 helper 가 silent 0 반환. `--only-from`
+의 missing column 은 helper 가 silently skip 하므로 `Changes requested`
+컬럼 없는 보드와도 호환된다.

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -12,6 +12,12 @@ description: >-
   verb (rebase-resolve vs read-logs-and-edit vs clean-rebase-no-conflicts). Accepts `[pr-number] [remote]`; defaults to the PR
   attached to the current branch. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: opus
+    reason: "rebase + conflict resolution with user-intent reasoning; high-risk --force-with-lease push, deep context tracking required"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-resolve-conflict — Rebase-based PR Conflict Resolution
@@ -33,16 +39,9 @@ Positional args: `[pr-number] [remote]`. Both optional.
 - `remote` — default `origin`. Resolve `TARGET_REPO` via
   `git remote get-url <remote>`; missing → `git remote -v` and stop.
 
-**Mergeable preflight** — immediately after resolving `PR_NUMBER`:
-
-```bash
-MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
-  --json mergeable --jq '.mergeable')
-```
-
-- `MERGEABLE == MERGEABLE` → print `[OK] PR은 이미 충돌 없음 — skip.` and stop (success).
-- `MERGEABLE == UNKNOWN` → GitHub is still computing; continue the flow normally (do not skip).
-- Any other value (`CONFLICTING` etc.) → continue.
+**Mergeable preflight** — immediately after resolving `PR_NUMBER`, run the
+`gh pr view --json mergeable` short-circuit per `references/rebase-flow.md`
+→ "Mergeable preflight" (`MERGEABLE` → already-clean skip; `UNKNOWN`/other → continue).
 
 **Hard preconditions** (parallel batch; any fail → stop):
 - inside a git repo
@@ -56,36 +55,23 @@ Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it so the user can
 
 ## Step 2: Fetch + Rebase
 
-```bash
-git fetch "$REMOTE" "$BASE"
-git rebase "$REMOTE/$BASE"
-```
-
-Full rebase mechanics, stash handling, and abort instructions live in
+Run `git fetch "$REMOTE" "$BASE"` then `git rebase "$REMOTE/$BASE"`. Full
+rebase mechanics, stash handling, and abort instructions live in
 `references/rebase-flow.md`.
 
 ## Step 3: Conflict Resolution Loop
 
-If `git rebase` exits non-zero with conflicts:
-
-1. `git status --short` to list `UU` / `AA` / `DU` paths.
-2. Print the rebase context — `git log --oneline "$REMOTE/$BASE"..HEAD`
-   plus the applying commit (`git log -1 --format='%h %s' REBASE_HEAD`).
-3. Open each file, resolve with the user's intent. **Never auto-guess**
-   when the commit message doesn't make the choice obvious — ask.
-4. `git add <file>` once the user confirms each resolution.
-5. `git rebase --continue`. If more commits conflict, loop to step 1.
-
-Full rubric (abort guidance, squash suggestions for repeated conflicts)
-in `references/conflict-handling.md`.
+If `git rebase` exits non-zero with conflicts, run the per-commit loop in
+`references/conflict-handling.md`: list `UU`/`AA`/`DU` paths, print the rebase
+context, resolve each file with the user's intent (**never auto-guess** an
+ambiguous conflict — ask), `git add`, then `git rebase --continue` and repeat.
+That file also carries the abort guidance and squash suggestions for repeated
+conflicts.
 
 ## Step 4: Push with `--force-with-lease`
 
-Only after `git rebase` exits 0 and the working tree is clean:
-
-```bash
-git push --force-with-lease "$REMOTE" HEAD
-```
+Only after `git rebase` exits 0 and the working tree is clean, run
+`git push --force-with-lease "$REMOTE" HEAD`.
 
 Never plain `--force`. If `--force-with-lease` is rejected (someone
 pushed while you rebased), stop and surface the upstream per
@@ -93,103 +79,16 @@ pushed while you rebased), stop and surface the upstream per
 
 ## Step 5: Verify Mergeable + Report
 
-```bash
-gh pr view <N> --repo "$TARGET_REPO" --json mergeable,mergeStateStatus,url,labels
-```
-
+Run `gh pr view <N> --repo "$TARGET_REPO" --json mergeable,mergeStateStatus,url,labels`.
 If `mergeable == MERGEABLE` and `mergeStateStatus ∈ {CLEAN, UNSTABLE}`,
 the warning is cleared. Print the final report from
 `references/rebase-flow.md` → "Final report format". Still `CONFLICTING`
 / `BEHIND` → print the PR URL, name which side diverged, do not loop.
 
-**conflict 라벨 제거** (soft-fail — `mergeable == MERGEABLE` 인 경우에만):
-
-Check if `labels[].name` contains `"conflict"`. If so, remove via REST DELETE
-(not `gh pr edit --remove-label`) — the latter can silent-fail on repos with
-classic Projects attached due to GraphQL deprecation (#326 Bug B, same pattern
-as `_gh_pr_edit_safe_label` fallback). 404 = label already absent → the
-`||` branch surfaces a soft-fail warning, idempotent for the caller.
-
-```bash
-gh api -X DELETE "repos/{owner}/{repo}/issues/$PR_NUMBER/labels/conflict" \
-    --repo "$TARGET_REPO" \
-    >/dev/null 2>&1 \
-  && echo "[OK] \`conflict\` 라벨 제거됨" \
-  || echo "[WARN] \`conflict\` 라벨 제거 실패 — GitHub Actions 가 cover."
-```
-
-`{owner}/{repo}` placeholder + `--repo "$TARGET_REPO"` 조합을 쓰는 이유:
-Step 1 의 `TARGET_REPO` 는 `git remote get-url` 결과(URL 형태)일 수
-있어 `repos/$TARGET_REPO/...` 직접 보간 시 경로가 깨질 수 있다. `gh api`
-의 `--repo` 플래그는 URL 과 `owner/repo` 양쪽 입력을 모두 안전하게
-파싱한다.
-
-If the label is absent, the `||` branch absorbs the 404 as a soft-fail
-warning (idempotent).
-
-**보드 status `In review` 복귀** (soft-fail — `mergeable == MERGEABLE` 인 경우에만):
-
-`changes-requested` → fix push → 카드가 `In progress` 또는 `Changes requested` 에
-머무는 흐름을 자동으로 끊어 리뷰어 큐 (`In review`) 로 되돌린다. 신규 PR
-단계의 conflict (카드가 이미 `In review` / `Approved` / `Done`) 는
-`--only-from` 가드가 막아 후퇴시키지 않는다. 자세한 lifecycle 근거는 issue #591.
-
-```bash
-if [ "$MERGEABLE" = "MERGEABLE" ]; then
-    # Defense-in-depth (#724): the chained-`&&` form below silently no-ops
-    # when the helper sources but never defines `_gh_project_status_sync`
-    # (interactive-guard regression, partial source). Split into an
-    # explicit guard so the failure prints a stderr warning instead of
-    # collapsing into the `|| echo [WARN]` branch (which falsely suggests
-    # a board sync was attempted).
-    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-    if [ -r "$_HELPER" ]; then
-        . "$_HELPER"
-        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-            printf '[gh-pr-resolve-conflict] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
-                "$_HELPER" >&2
-        elif _gh_project_status_sync pr "$PR_NUMBER" "In review" \
-                --only-from "In progress,Changes requested"; then
-            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
-        else
-            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
-        fi
-    fi
-fi
-```
-
-`GH_PROJECT_STATUS_SYNC=0` opt-out 은 helper 자체가 흡수한다. projectV2
-보드가 없는 레포는 helper 가 silent 0 반환. `--only-from` 의 missing column
-은 helper 가 silently skip 하므로 `Changes requested` 컬럼 없는 보드와도
-호환된다.
-
-After the report, post a PR comment with ai-metrics (soft-fail — warn on
-error, never block). `CONFLICT_FILES` is the count of files that had
-`UU`/`AA`/`DU` conflicts in Step 3. When `GH_DISABLE_AI_METRICS=1`,
-skip the comment entirely (issue #399):
-
-```bash
-ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-HUMAN_H=$(echo "scale=2; $CONFLICT_FILES * 0.5" | bc)
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
-else
-    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-      -X POST \
-      -f body="---
-<details>
-<summary>🤖 AI Metrics · 📊 ~${TOKENS:-3000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
-
-<!-- ai-metrics:gh-pr-resolve-conflict -->
-📊 ~${TOKENS:-3000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
-<!-- /ai-metrics:gh-pr-resolve-conflict -->
-
-</details>
-컨플릭트 해결: ~$ELAPSED min · 사람: ~$HUMAN_H h ($CONFLICT_FILES files × 0.5 h)"
-fi
-```
-
-On failure: `[WARN] ai-metrics comment failed — continuing.`
+Helper policy (each soft-fail, applies only when `mergeable == MERGEABLE`):
+- Remove the `conflict` label per `references/label-removal.sh.md`.
+- Return the board status to `In review` per `references/board-sync-in-review.sh.md`.
+- Post the ai-metrics PR comment per `references/ai-metrics-comment.sh.md` (soft-fail; skip when `GH_DISABLE_AI_METRICS=1`).
 
 ## Constraints
 
@@ -197,6 +96,5 @@ On failure: `[WARN] ai-metrics comment failed — continuing.`
 - Never use plain `git push --force`. `--force-with-lease` or stop.
 - Never rebase onto the default branch from the default branch.
 - Never auto-resolve ambiguous conflicts. Ask the user.
-- Never retry a rejected `--force-with-lease` by fetching and
-  re-rebasing on the user's behalf. Surface divergence and stop.
+- Never retry a rejected `--force-with-lease` by fetching and re-rebasing on the user's behalf. Surface divergence and stop.
 - Never skip Step 5. The whole point is clearing the PR warning.

--- a/claude/skills/gh-pr-resolve-conflict/references/ai-metrics-comment.sh.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/ai-metrics-comment.sh.md
@@ -1,0 +1,29 @@
+# Step 5 — ai-metrics PR comment (soft-fail)
+
+After the report, post a PR comment with ai-metrics (soft-fail — warn on
+error, never block). `CONFLICT_FILES` is the count of files that had
+`UU`/`AA`/`DU` conflicts in Step 3. When `GH_DISABLE_AI_METRICS=1`,
+skip the comment entirely (issue #399):
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+HUMAN_H=$(echo "scale=2; $CONFLICT_FILES * 0.5" | bc)
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 📊 ~${TOKENS:-3000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-resolve-conflict -->
+📊 ~${TOKENS:-3000} tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-resolve-conflict -->
+
+</details>
+컨플릭트 해결: ~$ELAPSED min · 사람: ~$HUMAN_H h ($CONFLICT_FILES files × 0.5 h)"
+fi
+```
+
+On failure: `[WARN] ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr-resolve-conflict/references/ai-metrics-comment.sh.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/ai-metrics-comment.sh.md
@@ -7,7 +7,7 @@ skip the comment entirely (issue #399):
 
 ```bash
 ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-HUMAN_H=$(echo "scale=2; $CONFLICT_FILES * 0.5" | bc)
+HUMAN_H=$(awk -v cf="$CONFLICT_FILES" 'BEGIN { printf "%.2f", cf * 0.5 }')
 if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
     : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
 else

--- a/claude/skills/gh-pr-resolve-conflict/references/board-sync-in-review.sh.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/board-sync-in-review.sh.md
@@ -1,0 +1,37 @@
+# Step 5 — 보드 status `In review` 복귀 (soft-fail)
+
+Applies **only when `mergeable == MERGEABLE`**.
+
+`changes-requested` → fix push → 카드가 `In progress` 또는 `Changes requested` 에
+머무는 흐름을 자동으로 끊어 리뷰어 큐 (`In review`) 로 되돌린다. 신규 PR
+단계의 conflict (카드가 이미 `In review` / `Approved` / `Done`) 는
+`--only-from` 가드가 막아 후퇴시키지 않는다. 자세한 lifecycle 근거는 issue #591.
+
+```bash
+if [ "$MERGEABLE" = "MERGEABLE" ]; then
+    # Defense-in-depth (#724): the chained-`&&` form below silently no-ops
+    # when the helper sources but never defines `_gh_project_status_sync`
+    # (interactive-guard regression, partial source). Split into an
+    # explicit guard so the failure prints a stderr warning instead of
+    # collapsing into the `|| echo [WARN]` branch (which falsely suggests
+    # a board sync was attempted).
+    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        . "$_HELPER"
+        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+            printf '[gh-pr-resolve-conflict] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+                "$_HELPER" >&2
+        elif _gh_project_status_sync pr "$PR_NUMBER" "In review" \
+                --only-from "In progress,Changes requested"; then
+            echo "[OK] PR 카드 \`In review\` 로 복귀됨"
+        else
+            echo "[WARN] 보드 sync 실패 — 카드 수동 이동 필요할 수 있음"
+        fi
+    fi
+fi
+```
+
+`GH_PROJECT_STATUS_SYNC=0` opt-out 은 helper 자체가 흡수한다. projectV2
+보드가 없는 레포는 helper 가 silent 0 반환. `--only-from` 의 missing column
+은 helper 가 silently skip 하므로 `Changes requested` 컬럼 없는 보드와도
+호환된다.

--- a/claude/skills/gh-pr-resolve-conflict/references/label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/label-removal.sh.md
@@ -1,0 +1,26 @@
+# Step 5 — `conflict` 라벨 제거 (soft-fail)
+
+Applies **only when `mergeable == MERGEABLE`**.
+
+Check if `labels[].name` contains `"conflict"`. If so, remove via REST DELETE
+(not `gh pr edit --remove-label`) — the latter can silent-fail on repos with
+classic Projects attached due to GraphQL deprecation (#326 Bug B, same pattern
+as `_gh_pr_edit_safe_label` fallback). 404 = label already absent → the
+`||` branch surfaces a soft-fail warning, idempotent for the caller.
+
+```bash
+gh api -X DELETE "repos/{owner}/{repo}/issues/$PR_NUMBER/labels/conflict" \
+    --repo "$TARGET_REPO" \
+    >/dev/null 2>&1 \
+  && echo "[OK] \`conflict\` 라벨 제거됨" \
+  || echo "[WARN] \`conflict\` 라벨 제거 실패 — GitHub Actions 가 cover."
+```
+
+`{owner}/{repo}` placeholder + `--repo "$TARGET_REPO"` 조합을 쓰는 이유:
+Step 1 의 `TARGET_REPO` 는 `git remote get-url` 결과(URL 형태)일 수
+있어 `repos/$TARGET_REPO/...` 직접 보간 시 경로가 깨질 수 있다. `gh api`
+의 `--repo` 플래그는 URL 과 `owner/repo` 양쪽 입력을 모두 안전하게
+파싱한다.
+
+If the label is absent, the `||` branch absorbs the 404 as a soft-fail
+warning (idempotent).

--- a/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
@@ -114,3 +114,17 @@ gh:pr-resolve-conflict stopped at <step>
   Backup SHA:   <sha>
   Resume:       <command the user should run>
 ```
+
+## Mergeable preflight (Step 1)
+
+Immediately after resolving `PR_NUMBER`, short-circuit when there is
+nothing to resolve:
+
+```bash
+MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" \
+  --json mergeable --jq '.mergeable')
+```
+
+- `MERGEABLE == MERGEABLE` → print `[OK] PR은 이미 충돌 없음 — skip.` and stop (success).
+- `MERGEABLE == UNKNOWN` → GitHub is still computing; continue the flow normally (do not skip).
+- Any other value (`CONFLICTING` etc.) → continue.

--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -12,184 +12,89 @@ description: >-
   `--user <name>` (claude only), `--no-post-comment`, and `<PR#>
   [remote]` positional args. `-h`/`--help`/`help` prints usage.
 allowed-tools: Bash, Read, Grep, Glob, Agent
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "dispatches to external AI CLI; prompt assembly + diff routing + comment posting; moderate orchestration, code judgment delegated"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-review — Delegate PR Review to an External AI CLI
 
 ## Role
 
-Gather a second-opinion code review on a GitHub PR from one of three
-external AI CLIs (`codex` / `gemini` / `claude`). Stream the output to
-the user, post it as a PR comment by default, and **stop there** — no
-decision (approve / request-changes) and no per-comment replies. Those
-belong to the sister skills `gh:pr-approve` and `gh:pr-reply`.
+Gather a second-opinion code review on a GitHub PR from one external AI
+CLI (`codex` / `gemini` / `claude`). Stream the output, post it as a PR
+comment by default, and **stop there** — no decision (approve /
+request-changes), no per-comment replies; those are `gh:pr-approve` and
+`gh:pr-reply`.
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
+If arg #1 is `-h` / `--help` / `help`, read `references/help.md` and
+output it verbatim, then stop. No API calls.
 
 ## Step 1: Parse Flags + Resolve Target
 
-Delegates to `gh_pr_review_parse` in
-`shell-common/functions/gh_pr_review.sh` (issue #664). That function is
-the **single source of truth** for the argument surface — the flat
-state machine, the closed `--review` enum, the KR-alias normalization,
-the `--user` cross-AI rejection, and the exit-code mapping (0 / 1 / 2)
-all live there. The bats fixture
-`tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh` is now a thin
-wrapper around the same function, so any drift between this section
-and the production parser is caught by
-`tests/bats/skills/gh_pr_review_arg_parse.bats`.
-
-Contract this skill depends on (do not duplicate the parser here; read
-`shell-common/functions/gh_pr_review.sh` for the authoritative shape):
-
-- `--ai <codex|gemini|claude>` — required.
-- `--review <preset>` — closed enum; KR aliases normalize before
-  dispatch.
-- `--user <name>` — `--ai claude` only.
-- `--no-post-comment` — skips Step 6.
-- Positional `<pr-number>` (optional; auto-detect from current branch)
-  and `<remote>` (default `origin`).
-
-Record `START_TS=$(date +%s)` immediately so Step 6 can compute
-`ELAPSED`.
-
-Resolve `TARGET_REPO` via
-`gh repo view --json nameWithOwner -q .nameWithOwner` and `PR_NUMBER`
-via the explicit arg or `gh pr view --json number -q .number`. Failing
-either → exit 1.
+Step 1 — Delegate to `gh_pr_review_parse`
+(`shell-common/functions/gh_pr_review.sh`). Argument shape + KR aliases
++ exit codes: `references/parser-contract.md` (also covers `START_TS`
+and resolving `TARGET_REPO` / `PR_NUMBER`).
 
 ## Step 2: Pre-flight
 
-Run these checks in parallel before doing any expensive work:
+Run these checks in parallel before any expensive work:
 
-- PR state must be `OPEN` AND not draft. Closed / merged / draft →
-  exit 1 with `PR #<N> is <state>; aborting`.
-- `command -v <ai-bin>` for the chosen `--ai` value. Missing →
-  exit 1 with `Required CLI '<name>' not found in PATH`.
-- `gh auth status` returns 0. Failing → exit 1 with the gh error line.
+- PR state must be `OPEN` AND not draft → else exit 1 `PR #<N> is <state>; aborting`.
+- `command -v <ai-bin>` for the chosen `--ai` → else exit 1 `Required CLI '<name>' not found in PATH`.
+- `gh auth status` returns 0 → else exit 1 with the gh error line.
 
-**CI status is intentionally NOT a gate.** Opinion collection works
-regardless of failing CI — sometimes that is the reason the user
-wants a second opinion in the first place.
-
-Self-authored PRs are also allowed: no decision is submitted, so the
-GitHub server-side self-approve block is irrelevant.
+**CI status is intentionally NOT a gate** (a failing CI is often the
+reason a second opinion is wanted); self-authored PRs are allowed (no
+decision submitted, so the self-approve block is irrelevant).
 
 ## Step 3: Load Review Preset
 
-Read `references/review-presets.md`. Build the prompt as:
-
-```text
-<common-prompt-prefix>
-
-<preset-body for the resolved enum>
-```
-
-The normalized enum is one of `default`, `quick`, `thorough`,
-`security`, `performance`. If a KR alias was passed, the normalization
-has already happened in Step 1.
+Read `references/review-presets.md`. Build the prompt as
+`<common-prompt-prefix>` + `<preset-body for the resolved enum>`.
+Normalized enum: `default` / `quick` / `thorough` / `security` /
+`performance` (KR-alias normalized in Step 1).
 
 ## Step 4: Fetch Review Material
 
-Decide path by diff size:
-
-```sh
-gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json additions,deletions
-```
-
-When `additions + deletions ≥ 800`, follow the subagent delegation
-pattern documented in
-`claude/skills/gh-pr-approve/references/large-diff-delegation.md`.
-Inline path otherwise:
-
-```sh
-gh pr diff "$PR_NUMBER" --repo "$TARGET_REPO"
-```
-
-Append the diff to the prompt under a clearly delimited section per
-`references/ai-cli-invocation.md` § "stdin payload shape". Write the
-combined `(prompt + diff)` to a temp file `PROMPT_FILE` — the external
-CLI receives it on stdin so argv length and quoting are not concerns.
+Decide path by diff size (`gh pr view ... --json additions,deletions`):
+`≥ 800` lines → follow
+`claude/skills/gh-pr-approve/references/large-diff-delegation.md`; else
+inline `gh pr diff`. Append the diff per `references/ai-cli-invocation.md`
+§ "stdin payload shape"; write `(prompt + diff)` to `PROMPT_FILE` (stdin).
 
 ## Step 5: Dispatch to External CLI
 
-Delegates to `_gh_pr_review_run_ai` in
-`shell-common/functions/gh_pr_review.sh`. The function pipes
-`PROMPT_FILE` into the chosen CLI with the exact invocation shape
-documented in `references/ai-cli-invocation.md` (`codex exec
---color=never`, `gemini -p`, `claude -p`, plus the `CLAUDE_CONFIG_DIR`
-injection for `--user`). Stdout streams to the user verbatim — no
-reformatting, no summarization, no truncation.
-
-On non-zero exit from the external CLI the helper writes
-`External AI CLI '<name>' failed: <first stderr line>` to stderr and
-returns the CLI's exit code. The skill propagates that as exit 1 and
-skips Step 6; partial output is discarded.
+Delegate to `_gh_pr_review_run_ai`
+(`shell-common/functions/gh_pr_review.sh`). Invocation shapes, stdout
+streaming, non-zero-exit handling: `references/ai-cli-invocation.md`
+§ "Step 5 dispatch procedure".
 
 ## Step 6: Post PR Comment (default ON)
 
-Delegates body construction and posting to two helpers in
-`shell-common/functions/gh_pr_review.sh`:
-
-- `_gh_pr_review_build_comment_body` — emits the SSOT body per
-  `references/post-comment.md` (collapsed `<details>` AI-review block
-  + `<!-- ai-review:<ai> -->` markers + ai-metrics footer with
-  `<!-- ai-metrics:gh-pr-review -->` markers).
-- `_gh_pr_review_post_comment` — wraps `gh pr comment --body-file`
-  and enforces three behaviors with a single decision tree:
-  1. `--no-post-comment` → print `skipped (--no-post-comment)` and
-     return 0.
-  2. `GH_DISABLE_AI_METRICS=1` → print
-     `skipped (GH_DISABLE_AI_METRICS=1)` and return 0. The opt-out
-     skips the **entire** PR comment (not just the metrics footer),
-     because the AI-review body and the metrics footer ship together
-     (issue #399).
-  3. `gh pr comment` non-zero exit → print `[WARN] PR comment post
-     failed — output retained on stdout` to stderr, emit
-     `[WARN] post failed` to stdout, and still return 0 — the user
-     already has the AI output on their terminal.
-
-Token, human-h, and elapsed-minute inputs are computed by
-`_gh_pr_review_estimate_tokens` and `_gh_pr_review_human_h`
-(per-preset baseline from `references/post-comment.md`). The skill
-does not duplicate those formulas — read the shell function for the
-authoritative arithmetic.
+Delegate to `_gh_pr_review_build_comment_body` +
+`_gh_pr_review_post_comment` (`shell-common/functions/gh_pr_review.sh`).
+SSOT body template, 3-branch decision tree (`--no-post-comment` /
+`GH_DISABLE_AI_METRICS=1` / soft-fail), and token/human-h arithmetic:
+`references/post-comment.md` § "Step 6 delegation + 3-branch decision tree".
 
 ## Step 7: Report
 
 Print exactly one line on success:
+`[OK] PR #<N> reviewed by <ai> (--review=<preset>) — comment: <URL or skipped>`,
+where `<URL or skipped>` is the comment URL, else
+`skipped (--no-post-comment)` / `skipped (GH_DISABLE_AI_METRICS=1)` / `[WARN] post failed`.
 
-```text
-[OK] PR #<N> reviewed by <ai> (--review=<preset>) — comment: <URL or skipped>
-```
+## Constraints (full rationale: `references/constraints.md`)
 
-`<URL or skipped>` is the comment URL on success, `skipped (--no-post-comment)`
-when the flag was set, `skipped (GH_DISABLE_AI_METRICS=1)` when the env
-var was set, or `[WARN] post failed` when the soft-fail branch ran.
-
-## Constraints
-
-- **Never submit a decision.** `gh pr review --approve` and
-  `--request-changes` are out of scope. This skill collects opinions
-  only; the human (or `gh:pr-approve`) decides.
-- **Never reply to individual review comments.** That is `gh:pr-reply`'s
-  job. This skill writes one aggregate comment per invocation.
-- **Never run multiple AI CLIs in one invocation.** Single `--ai`
-  value; rerun the command N times for an N-way comparison.
-- **Never accept free-text `--review`.** Closed enum + KR aliases only.
-  Typos exit 2 cleanly.
-- **Never reformat the external AI's stdout.** The user wants raw
-  output to judge for themselves.
-- **Never block self-authored PRs.** No decision is submitted; the
-  self-approve restriction does not apply.
-- **Never edit the PR body.** Use `gh pr comment` (append) — `gh pr
-  edit --body` silently exits 1 on repos with classic Projects
-  attached (issue #326 Bug B). If a future iteration needs body
-  mutation, route through `_gh_pr_edit_safe_body` per CLAUDE.md.
-- **Never log the external CLI's stderr to a PR comment.** Stderr is
-  only used to derive the error-message first line on non-zero exit.
-- Honor `GH_DISABLE_AI_METRICS=1` consistently with sister skills:
-  skip the entire PR comment (not just the footer).
+- Never submit a decision (`gh:pr-approve`'s job) or reply to individual comments (`gh:pr-reply`'s job) — write one aggregate comment.
+- Never run multiple AI CLIs per invocation (single `--ai`; rerun N times) or accept free-text `--review` (closed enum + KR aliases; typos exit 2).
+- Never reformat the external AI's stdout (raw only) or block self-authored PRs (no decision submitted).
+- Never edit the PR body — `gh pr comment` (append); `gh pr edit --body` fails on classic-Projects repos (#326 Bug B). Never log the CLI's stderr to a PR comment.
+- Honor `GH_DISABLE_AI_METRICS=1` like sister skills: skip the entire PR comment, not just the footer.

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -144,6 +144,20 @@ branch — internal PCs typically have an empty
 rejects any `--user <name>`. The cleanest user experience there is to
 omit `--user` and let the current shell's `CLAUDE_CONFIG_DIR` win.
 
+## Step 5 dispatch procedure (`_gh_pr_review_run_ai`)
+
+Step 5 of the skill delegates to `_gh_pr_review_run_ai` in
+`shell-common/functions/gh_pr_review.sh`. The function pipes
+`PROMPT_FILE` into the chosen CLI with the exact invocation shape
+documented above (`codex exec --color=never`, `gemini -p`, `claude -p`,
+plus the `CLAUDE_CONFIG_DIR` injection for `--user`). Stdout streams to
+the user verbatim — no reformatting, no summarization, no truncation.
+
+On non-zero exit from the external CLI the helper writes
+`External AI CLI '<name>' failed: <first stderr line>` to stderr and
+returns the CLI's exit code. The skill propagates that as exit 1 and
+skips Step 6; partial output is discarded.
+
 ## Common error mapping
 
 | Condition | Exit | stderr |

--- a/claude/skills/gh-pr-review/references/constraints.md
+++ b/claude/skills/gh-pr-review/references/constraints.md
@@ -1,0 +1,26 @@
+# Constraints (rationale) — for gh:pr-review
+
+The SKILL.md body lists these as terse "Never" rules; the full
+rationale lives here.
+
+- **Never submit a decision.** `gh pr review --approve` and
+  `--request-changes` are out of scope. This skill collects opinions
+  only; the human (or `gh:pr-approve`) decides.
+- **Never reply to individual review comments.** That is `gh:pr-reply`'s
+  job. This skill writes one aggregate comment per invocation.
+- **Never run multiple AI CLIs in one invocation.** Single `--ai`
+  value; rerun the command N times for an N-way comparison.
+- **Never accept free-text `--review`.** Closed enum + KR aliases only.
+  Typos exit 2 cleanly.
+- **Never reformat the external AI's stdout.** The user wants raw
+  output to judge for themselves.
+- **Never block self-authored PRs.** No decision is submitted; the
+  self-approve restriction does not apply.
+- **Never edit the PR body.** Use `gh pr comment` (append) — `gh pr
+  edit --body` silently exits 1 on repos with classic Projects
+  attached (issue #326 Bug B). If a future iteration needs body
+  mutation, route through `_gh_pr_edit_safe_body` per CLAUDE.md.
+- **Never log the external CLI's stderr to a PR comment.** Stderr is
+  only used to derive the error-message first line on non-zero exit.
+- Honor `GH_DISABLE_AI_METRICS=1` consistently with sister skills:
+  skip the entire PR comment (not just the footer).

--- a/claude/skills/gh-pr-review/references/parser-contract.md
+++ b/claude/skills/gh-pr-review/references/parser-contract.md
@@ -1,0 +1,50 @@
+# Parser Contract — for gh:pr-review
+
+Step 1 delegates to `gh_pr_review_parse` in
+`shell-common/functions/gh_pr_review.sh` (issue #664). That function is
+the **single source of truth** for the argument surface — the flat
+state machine, the closed `--review` enum, the KR-alias normalization,
+the `--user` cross-AI rejection, and the exit-code mapping (0 / 1 / 2)
+all live there. The bats fixture
+`tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh` is now a thin
+wrapper around the same function, so any drift between this contract
+and the production parser is caught by
+`tests/bats/skills/gh_pr_review_arg_parse.bats`.
+
+## Argument shape
+
+Contract this skill depends on (do not duplicate the parser here; read
+`shell-common/functions/gh_pr_review.sh` for the authoritative shape):
+
+- `--ai <codex|gemini|claude>` — required.
+- `--review <preset>` — closed enum; KR aliases normalize before
+  dispatch.
+- `--user <name>` — `--ai claude` only.
+- `--no-post-comment` — skips Step 6.
+- Positional `<pr-number>` (optional; auto-detect from current branch)
+  and `<remote>` (default `origin`).
+
+## KR aliases
+
+The `--review` value is a closed enum normalized to one of `default`,
+`quick`, `thorough`, `security`, `performance`. Korean aliases are
+mapped to those canonical enum values inside `gh_pr_review_parse`
+before dispatch — by the time Step 3 reads the preset, normalization
+has already happened. Free-text values are rejected (see exit codes).
+
+## Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| 0 | Parse succeeded. |
+| 1 | Resolution failure (e.g. unknown claude account, target/PR resolution failed). |
+| 2 | Argument-surface error (missing/unknown `--ai`, `--user` with codex/gemini, free-text `--review` typo). |
+
+## Post-parse setup
+
+- Record `START_TS=$(date +%s)` immediately so Step 6 can compute
+  `ELAPSED`.
+- Resolve `TARGET_REPO` via
+  `gh repo view --json nameWithOwner -q .nameWithOwner` and `PR_NUMBER`
+  via the explicit arg or `gh pr view --json number -q .number`.
+  Failing either → exit 1.

--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -45,12 +45,40 @@ introduces a sibling marker `<!-- ai-review:<ai> -->` that mirrors the
 same `<details>` + glyph pattern. Treat the new marker as a **scoped
 extension** of the existing exception:
 
-- 🤖 in `<summary>` line — allowed (same role as the existing
-  ai-metrics summary glyph).
+- 🤖 in `<summary>` line — allowed per `claude/skills/skill-check/references/allowed-emoji-skills.txt` (gh-pr-review registered; ai-metrics/AI-review footer SSOT, CLAUDE.md #317 F-2).
 - All other emoji — still forbidden everywhere.
 
 If the CLAUDE.md SSOT needs updating, do it in the same PR that lands
 this skill so the rule and the artifact ship together.
+
+## Step 6 delegation + 3-branch decision tree
+
+Step 6 of the skill delegates body construction and posting to two
+helpers in `shell-common/functions/gh_pr_review.sh`:
+
+- `_gh_pr_review_build_comment_body` — emits the SSOT body per this
+  file's "Body template" (collapsed `<details>` AI-review block +
+  `<!-- ai-review:<ai> -->` markers + ai-metrics footer with
+  `<!-- ai-metrics:gh-pr-review -->` markers).
+- `_gh_pr_review_post_comment` — wraps `gh pr comment --body-file`
+  and enforces three behaviors with a single decision tree:
+  1. `--no-post-comment` → print `skipped (--no-post-comment)` and
+     return 0.
+  2. `GH_DISABLE_AI_METRICS=1` → print
+     `skipped (GH_DISABLE_AI_METRICS=1)` and return 0. The opt-out
+     skips the **entire** PR comment (not just the metrics footer),
+     because the AI-review body and the metrics footer ship together
+     (issue #399).
+  3. `gh pr comment` non-zero exit → print `[WARN] PR comment post
+     failed — output retained on stdout` to stderr, emit
+     `[WARN] post failed` to stdout, and still return 0 — the user
+     already has the AI output on their terminal.
+
+Token, human-h, and elapsed-minute inputs are computed by
+`_gh_pr_review_estimate_tokens` and `_gh_pr_review_human_h` (per-preset
+baseline from "Human time baseline" / "Token estimation" below). The
+skill does not duplicate those formulas — read the shell function for
+the authoritative arithmetic.
 
 ## Posting via `gh pr comment`
 

--- a/claude/skills/gh-pr/SKILL.md
+++ b/claude/skills/gh-pr/SKILL.md
@@ -8,216 +8,93 @@ description: >-
   the range (not just HEAD), auto-links a related issue when known, and
   returns only the PR URL. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "gh pr create wrap with body draft; structured commit-range bundling + bounded lint/board mutations"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr — Create Pull Request
 
-## Help
+## Help & Role
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
-its content verbatim, then stop. No API calls.
-
-## Role
-
-Bundle the current branch's commits into a GitHub PR with a well-structured
-body. Push the branch if needed. Return the PR URL.
-
-## Options
-
-| Argument | Description | Default |
-|----------|-------------|---------|
-| `[N]` (positional) | Legacy `/gh:pr 123` form — overrides issue auto-detection. | — |
-| `--no-stack` | Force a non-stacked PR even when stacked-PR signals fire. | off |
-| `--base <branch>` | Explicit base branch; bypasses stacked-PR detection. | repo default |
-| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
-| `GH_PR_LINT_BYPASS=1` (env) | Skip Step 4.5 lint guard. | off |
-| `DOTFILES_ROOT` (env) | Root used to source `gh_pr_lint.sh`. | `$HOME/dotfiles` |
-| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
-
-`--no-stack` and `--base` are mutually exclusive — see Step 1a exit codes.
-Auto-detected parent PR must be `OPEN` — refuses (rc=5) otherwise.
+If arg #1 is `-h`/`--help`/`help`, read `references/help.md`, output it
+verbatim, then stop (no API calls). Otherwise: bundle the current branch's
+commits into a GitHub PR with a well-structured body, push if needed, and
+return the PR URL. Accepted options: `references/options.md`.
 
 ## Step 1: Parse Args, Resolve Base Branch, Gather State
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
+Record `START_TS=$(date +%s)` immediately for Step 4 elapsed-time tracking.
+**1a — base via stacked-PR detection:** read `references/stacked-pr.md` and
+paste its SSOT functions + dispatch block ("How Step 1 of SKILL.md ties it
+together") verbatim. They bind `BASE_BRANCH`, `PARENT_PR`, `ISSUE_NUMBER` and
+exit on bad input (`rc=2` mutually-exclusive flags, `rc=3` bad `--base`,
+`rc=5` parent PR not `OPEN`). Abort without pushing on any of them.
 
-### Step 1a: Parse args + resolve base via stacked-PR detection
+**1b — gather range + push state (one message):** using `$BASE_BRANCH`, run
+`git rev-parse --abbrev-ref HEAD`, `git status`, `git fetch origin`, `git log
+--oneline "$BASE_BRANCH"..HEAD`, `git diff "$BASE_BRANCH"...HEAD`, `git
+rev-parse --symbolic-full-name @{u} 2>/dev/null`. Stop conditions: current
+branch equals `BASE_BRANCH` → ask for a feature branch; empty range → nothing to PR.
 
-Read `references/stacked-pr.md` and paste the SSOT functions
-(`parse_stacked_args`, `is_stacked_pr_repo`, `find_parent_pr_candidates`,
-`assert_parent_pr_open`) and the dispatch block ("How Step 1 of
-SKILL.md ties it together") verbatim. They bind `BASE_BRANCH`,
-`PARENT_PR`, and `ISSUE_NUMBER`, and they exit on bad input — `rc=2`
-for mutually-exclusive flags, `rc=3` for a bad `--base` value, `rc=5`
-when the auto-detected parent PR is no longer `OPEN` (stacking refuses
-on closed/merged parents — recovery hint: reopen the parent or rerun
-with `--no-stack`). Abort without pushing on any of them.
+## Steps 2-3: Analyze ALL Commits + Resolve Issue
 
-### Step 1b: Gather range + push state (parallel)
+The PR body must reflect **every commit** in the range, not just the latest:
+read `git log <base>..HEAD` and group changes by theme (a 5-commit PR mentions
+all 5 concerns). Resolve the issue number with the same precedence as
+`gh:commit`: (1) explicit `/gh:pr <N>` arg, (2) recent conversation `#N` /
+`Issue #N created`, (3) range commit messages (`Refs/Closes/Fixes #N`), (4)
+none → omit the link.
 
-Run in a single message, using `$BASE_BRANCH` from Step 1a:
-`git rev-parse --abbrev-ref HEAD`, `git status`, `git fetch origin`,
-`git log --oneline "$BASE_BRANCH"..HEAD`, `git diff "$BASE_BRANCH"...HEAD`,
-and `git rev-parse --symbolic-full-name @{u} 2>/dev/null`.
+## Step 4 + 4.5: Draft Body, then Lint Guard (pre-push)
 
-Stop conditions: current branch equals `BASE_BRANCH` → ask for a
-feature branch; `git log "$BASE_BRANCH"..HEAD` empty → nothing to PR.
-
-## Step 2: Analyze ALL Commits in the Range
-
-The PR body must reflect **every commit** in the range, not just the latest.
-Read `git log <base>..HEAD` output and group changes by theme. A 5-commit PR
-mentions all 5 concerns.
-
-## Step 3: Resolve the Issue Number
-
-Same precedence as `gh:commit`: (1) explicit `/gh:pr <N>` arg, (2)
-recent conversation `#N` / `Issue #N created`, (3) commit messages in
-the range (`Refs/Closes/Fixes #N`), (4) none → omit the link.
-
-## Step 4: Draft Title and Body
-
-Read `references/pr-body-template.md` for title rules, body structure,
-and the body markdown. Match the language of existing commits (Korean
-if commits are Korean).
-
-Then read `references/ai-metrics-footer.md` and follow it verbatim to
-compute `TOKENS`, `HUMAN_H`, `ELAPSED` and append the footer to `$BODY`
-(soft-fail — warn on error, never block). Honours
-`GH_DISABLE_AI_METRICS=1` (issue #399).
-
-## Step 4.5: Lint Guard (pre-push)
-
-Read `references/lint-guard.md` and paste its "Helper" source-and-run
-snippet verbatim. Runs against `$BASE_BRANCH` **before** the push in
-Step 5. Hard-fails on lint errors; auto-skips when no tools are
-detected, when the change set is empty, or when `GH_PR_LINT_BYPASS=1`.
+Read `references/pr-body-template.md` for title rules and body markdown; match
+the language of existing commits. Then read `references/ai-metrics-footer.md`
+and follow it verbatim to compute `TOKENS`/`HUMAN_H`/`ELAPSED` and append the
+footer to `$BODY` (soft-fail, never block; honours `GH_DISABLE_AI_METRICS=1`,
+issue #399). Next (Step 4.5) read `references/lint-guard.md` and paste its
+"Helper" snippet verbatim — runs against `$BASE_BRANCH` **before** the Step 5
+push; hard-fails on lint errors; auto-skips when no tools detected, change set
+empty, or `GH_PR_LINT_BYPASS=1`.
 
 ## Step 5: Push and Create
 
 Read `references/push-and-create.md` for the upstream-state push policy and
-the `gh pr create` command (uses `mktemp` body file, `--assignee @me`,
-`--base "$BASE_BRANCH"` from Step 1a).
-
-After `gh pr create` returns the PR URL, emit the step-completion marker
-so the harness step-skip guard (`skill_completion_guard.py`, issue #753)
-can verify this step ran:
-`printf '[step:gh-pr/push-and-create] OK\n'`.
+the `gh pr create` command (`mktemp` body file, `--assignee @me`, `--base
+"$BASE_BRANCH"`). After the URL returns, emit
+`printf '[step:gh-pr/push-and-create] OK\n'` for the step-skip guard
+(`skill_completion_guard.py`, issue #753).
 
 ## Step 6: Apply Labels
 
-Derive labels from conventional-commit types in `git log <base>..HEAD` and
-PR scope (e.g. `skill` for `claude/skills/` changes). Apply only labels that
+Derive labels from conventional-commit types in `git log <base>..HEAD` and PR
+scope (e.g. `skill` for `claude/skills/` changes). Apply only labels that
 exist in the repo (`gh label list`) — never create new ones. See
 `references/pr-body-template.md` for the full mapping and safe-apply loop.
-
-After the label loop returns (including the no-op case where every
-candidate label was missing from the repo), emit:
+After the loop (including the all-missing no-op case), emit
 `printf '[step:gh-pr/labels] OK\n'`.
 
 ## Step 7: Sync Project Board Status
 
-Push the new PR card to `In review` and correct any linked Issue cards
-the GitHub builtin mis-moved to `In review` (Issues belong in
-`In progress` — see `references/project-board-sync.md` for the
-rationale, hook auto-skip narrative, and `GH_REPO` requirement).
-
-First, detect a PostToolUse hook that already handles this sync — when
-present, skip the inline call to avoid triple-syncing (issue #390):
-
-```bash
-hook_skip=0
-for hook_path in \
-    "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/post-pr-create-status.sh" \
-    "$HOME/.claude/hooks/post-gh-pr-create.sh" \
-    "$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh"
-do
-    if [ -x "$hook_path" ]; then
-        hook_skip=1
-        printf '[gh-pr] board sync delegated to PostToolUse hook (%s) — skipping inline.\n' "$hook_path" >&2
-        break
-    fi
-done
-
-if [ "$hook_skip" -eq 0 ]; then
-    # helper-fallback NF-1 (#644): silent-skip when helper missing.
-    # Defense-in-depth (#724): also detect "[ -r ] passes but function never
-    # defined" (interactive-guard regression, partial sourcing, future rename).
-    # `|| true` would otherwise absorb `command not found` (rc 127) and the
-    # entire reconciliation would silently no-op — the failure mode from #724.
-    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-    if [ -r "$_HELPER" ]; then
-        . "$_HELPER"
-        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-            printf '[gh-pr] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
-                "$_HELPER" >&2
-        else
-            _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
-            # Auto-resolve GH_REPO when unset/empty so the linked-issues
-            # sync isn't silently no-op'd by an empty repo arg (PR #780
-            # review). Matches the existing convention in
-            # shell-common/functions/gh_pr_edit_safe.sh and
-            # gh_audit_builtin_workflows.sh.
-            if [ -z "${GH_REPO:-}" ]; then
-                GH_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
-            fi
-            for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
-                _gh_project_status_sync issue "$_issue" "In progress" \
-                    --only-from "Backlog,Ready,In review" || true
-            done
-        fi
-    fi
-fi
-```
-
-`GH_REPO` should be `owner/repo` (e.g. `dEitY719/dotfiles`). The block
-auto-resolves it via `gh repo view --json nameWithOwner --jq
-.nameWithOwner` when unset/empty so the linked-issues loop never
-silently no-ops on a missing env var. Opt-out per invocation:
-`GH_PROJECT_STATUS_SYNC=0`. Repos without a projectV2 board auto-skip
-silently (helper returns 0).
-
-Track the outcome for Step 8's report row:
-- `hook_skip=1` → `[SKIP]: hook auto-skip`
-- helper missing or function undefined → `[SKIP]: helper unavailable`
-- helper ran, no projectV2 board → `[SKIP]: no projectV2`
-- helper ran with at least one card moved → `[OK]: PR card -> "In review"`
-
-Regardless of which branch ran (hook delegate, helper missing, no
-projectV2, real sync), emit the step-completion marker so the
-step-skip guard recognizes Step 7 was visited:
-`printf '[step:gh-pr/board-sync] OK\n'`.
+Push the new PR card to `In review` and correct any linked Issue cards the
+GitHub builtin mis-moved there (Issues belong in `In progress`). Run the
+post-create board sync per `references/project-board-sync.md` — paste the
+snippet verbatim. That file also carries the hook auto-skip narrative,
+`GH_REPO` requirement, Step 8 report-row mapping, and the
+`[step:gh-pr/board-sync] OK` marker.
 
 ## Step 8: Report
 
-성공 시:
-
-```
-[OK] PR: https://github.com/owner/repo/pull/<N>
-[OK] Board sync: PR card -> "In review" (or [SKIP]: hook auto-skip / no projectV2 / helper unavailable)
-Next: /gh:pr-reply (after CI green) — replies to review comments
-```
-
-The `Board sync:` row is a defense-in-depth visual checklist (issue
-#747) — its absence in conversation transcripts is a regression signal
-that Step 7 was silently skipped.
-
-After printing the report block, emit the report step-completion
-marker so the step-skip guard recognizes the skill finished:
-`printf '[step:gh-pr/report] OK\n'`.
-
-Step 1b empty-range / on-base-branch stops, Step 1a `rc=2`/`rc=3`, or
-Step 4.5 lint failure:
-
-```
-[FAIL] <one-line reason>
-Next: <recovery — e.g. switch branch, fix lint, drop conflicting flag>
-```
-
-No additional summary — the user opens GitHub directly from the URL.
+Read `references/report-template.md` for the success/failure report blocks
+(including the defense-in-depth `Board sync:` row, issue #747) and the closing
+`[step:gh-pr/report] OK` marker. No extra summary — the user opens GitHub from
+the URL.
 
 ## Constraints
 
-Read `references/constraints.md` for hard rules: no force-push without
-approval, default base only, no AI footer unless the repo already uses one,
-never skip commits in the Summary.
+Read `references/constraints.md` for hard rules: no force-push without approval,
+default base only, no AI footer unless the repo already uses one, never skip
+commits in the Summary.

--- a/claude/skills/gh-pr/references/options.md
+++ b/claude/skills/gh-pr/references/options.md
@@ -1,0 +1,14 @@
+# gh:pr — Accepted Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `[N]` (positional) | Legacy `/gh:pr 123` form — overrides issue auto-detection. | — |
+| `--no-stack` | Force a non-stacked PR even when stacked-PR signals fire. | off |
+| `--base <branch>` | Explicit base branch; bypasses stacked-PR detection. | repo default |
+| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
+| `GH_PR_LINT_BYPASS=1` (env) | Skip Step 4.5 lint guard. | off |
+| `DOTFILES_ROOT` (env) | Root used to source `gh_pr_lint.sh`. | `$HOME/dotfiles` |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+
+`--no-stack` and `--base` are mutually exclusive — see Step 1a exit codes.
+Auto-detected parent PR must be `OPEN` — refuses (rc=5) otherwise.

--- a/claude/skills/gh-pr/references/project-board-sync.md
+++ b/claude/skills/gh-pr/references/project-board-sync.md
@@ -1,9 +1,79 @@
-# Project Board Sync — narrative + rationale
+# Project Board Sync — snippet + narrative
 
-> **Canonical executable snippet lives in `SKILL.md` Step 7.** This file is
-> the narrative companion — rationale, edge cases, and pointers — not a
-> source of code. If you find yourself copying bash out of here into the
-> skill, you've found a regression of issue #747.
+> **Canonical executable snippet lives in this file** (below). `SKILL.md`
+> Step 7 points here and the model pastes the snippet verbatim. This file
+> is both the source of the bash and its narrative companion — rationale,
+> edge cases, and pointers. (Relocated from inline Step 7 for progressive
+> disclosure; the issue #747 visual-checklist guarantees are preserved by
+> the Step 8 report row, not by inlining the bash.)
+
+## Executable snippet (paste verbatim into Step 7)
+
+First, detect a PostToolUse hook that already handles this sync — when
+present, skip the inline call to avoid triple-syncing (issue #390):
+
+```bash
+hook_skip=0
+for hook_path in \
+    "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}/.claude/hooks/post-pr-create-status.sh" \
+    "$HOME/.claude/hooks/post-gh-pr-create.sh" \
+    "$HOME/dotfiles/claude/hooks/post-gh-pr-create.sh"
+do
+    if [ -x "$hook_path" ]; then
+        hook_skip=1
+        printf '[gh-pr] board sync delegated to PostToolUse hook (%s) — skipping inline.\n' "$hook_path" >&2
+        break
+    fi
+done
+
+if [ "$hook_skip" -eq 0 ]; then
+    # helper-fallback NF-1 (#644): silent-skip when helper missing.
+    # Defense-in-depth (#724): also detect "[ -r ] passes but function never
+    # defined" (interactive-guard regression, partial sourcing, future rename).
+    # `|| true` would otherwise absorb `command not found` (rc 127) and the
+    # entire reconciliation would silently no-op — the failure mode from #724.
+    _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+    if [ -r "$_HELPER" ]; then
+        . "$_HELPER"
+        if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+            printf '[gh-pr] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+                "$_HELPER" >&2
+        else
+            _gh_project_status_sync pr "$PR_NUMBER" "In review" || true
+            # Auto-resolve GH_REPO when unset/empty so the linked-issues
+            # sync isn't silently no-op'd by an empty repo arg (PR #780
+            # review). Matches the existing convention in
+            # shell-common/functions/gh_pr_edit_safe.sh and
+            # gh_audit_builtin_workflows.sh.
+            if [ -z "${GH_REPO:-}" ]; then
+                GH_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+            fi
+            for _issue in $(_gh_pr_closing_issue_numbers "$PR_NUMBER" "$GH_REPO" 2>/dev/null || true); do
+                _gh_project_status_sync issue "$_issue" "In progress" \
+                    --only-from "Backlog,Ready,In review" || true
+            done
+        fi
+    fi
+fi
+```
+
+`GH_REPO` should be `owner/repo` (e.g. `dEitY719/dotfiles`). The block
+auto-resolves it via `gh repo view --json nameWithOwner --jq
+.nameWithOwner` when unset/empty so the linked-issues loop never
+silently no-ops on a missing env var. Opt-out per invocation:
+`GH_PROJECT_STATUS_SYNC=0`. Repos without a projectV2 board auto-skip
+silently (helper returns 0).
+
+Track the outcome for Step 8's report row:
+- `hook_skip=1` → `[SKIP]: hook auto-skip`
+- helper missing or function undefined → `[SKIP]: helper unavailable`
+- helper ran, no projectV2 board → `[SKIP]: no projectV2`
+- helper ran with at least one card moved → `[OK]: PR card -> "In review"`
+
+Regardless of which branch ran (hook delegate, helper missing, no
+projectV2, real sync), emit the step-completion marker so the
+step-skip guard recognizes Step 7 was visited:
+`printf '[step:gh-pr/board-sync] OK\n'`.
 
 After the PR is created, sync cards on the kanban so reviewers see the PR and
 the linked Issues are at the right column without a manual drag. Two cards
@@ -84,6 +154,5 @@ mutation — and matches the existing convention in
 `shell-common/functions/gh_project_status.sh` — shared between `gh:pr`,
 `gh:pr-reply`, and other PR/issue lifecycle skills. The skill **sources**
 this file; do not duplicate the helper's implementation. The bash that
-*calls* the helper, however, is intentionally inlined in `SKILL.md`
-Step 7 (issue #747) so the model reads it linearly during execution
-without a reference-load indirection.
+*calls* the helper lives in the "Executable snippet" section above; Step 7
+of `SKILL.md` points here and the model pastes it verbatim.

--- a/claude/skills/gh-pr/references/report-template.md
+++ b/claude/skills/gh-pr/references/report-template.md
@@ -1,0 +1,27 @@
+# gh:pr — Step 8 Report Format
+
+성공 시:
+
+```
+[OK] PR: https://github.com/owner/repo/pull/<N>
+[OK] Board sync: PR card -> "In review" (or [SKIP]: hook auto-skip / no projectV2 / helper unavailable)
+Next: /gh:pr-reply (after CI green) — replies to review comments
+```
+
+The `Board sync:` row is a defense-in-depth visual checklist (issue
+#747) — its absence in conversation transcripts is a regression signal
+that Step 7 was silently skipped.
+
+After printing the report block, emit the report step-completion
+marker so the step-skip guard recognizes the skill finished:
+`printf '[step:gh-pr/report] OK\n'`.
+
+Step 1b empty-range / on-base-branch stops, Step 1a `rc=2`/`rc=3`, or
+Step 4.5 lint failure:
+
+```
+[FAIL] <one-line reason>
+Next: <recovery — e.g. switch branch, fix lint, drop conflicting flag>
+```
+
+No additional summary — the user opens GitHub directly from the URL.

--- a/claude/skills/skill-check/references/allowed-emoji-skills.txt
+++ b/claude/skills/skill-check/references/allowed-emoji-skills.txt
@@ -15,6 +15,11 @@ gh-pr                                # ai-metrics footer (#856)
 gh-pr-approve                        # ai-metrics footer (#857)
 gh-pr-merge                          # ai-metrics footer (#818)
 devx-pr-to-ssot-issue                # ai-metrics footer in references/metrics-footer.md SSOT 참조 (#841)
+
+# --- #862 PR-NW-4: PR-NW-1 누락분 — gh-pr-* ai-metrics footer 보강 (Check 11) ---
+gh-pr-reply                          # ai-metrics footer (#822)
+gh-pr-resolve-conflict               # ai-metrics footer (#825)
+gh-pr-review                         # ai-metrics footer + AI review summary in references/post-comment.md (#829)
 # 문서적/데모용 글리프 — 정책 설명·스타일·UI 아이콘 용도
 skill-check                          # references/checks.md 의 정책 설명용 데모 글리프 (📊 👤 🤖 ✓ ✗) (#840)
 write-blog-dev-learnings             # 의도적 블로그 스타일 글리프 (#850)

--- a/tests/bats/skills/_fixtures/helper_fallback_nf1.sh
+++ b/tests/bats/skills/_fixtures/helper_fallback_nf1.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # tests/bats/skills/_fixtures/helper_fallback_nf1.sh
 # Source-of-truth mirror for the canonical F-2 helper-fallback pattern
-# documented in issue #644 and applied across:
-#   claude/skills/gh-pr-merge/SKILL.md           (Step 2-B, Step 4)
-#   claude/skills/gh-commit/SKILL.md             (Step 5)
-#   claude/skills/gh-pr-reply/SKILL.md           (Step 6.5)
-#   claude/skills/gh-pr/SKILL.md                 (Step 7 — inlined in #747)
-#   claude/skills/gh-pr-merge/references/project-board-sync.md
+# documented in issue #644 and applied across (canonical pattern relocated
+# from SKILL.md bodies into references/ by #862 PR-NW-4 for progressive
+# disclosure; the owning SKILL.md Step points at the reference verbatim):
+#   claude/skills/gh-pr-merge/references/board-approval-gate.sh.md  (Step 2-B)
+#   claude/skills/gh-pr-merge/references/project-board-sync.md      (Step 4)
+#   claude/skills/gh-commit/SKILL.md                                (Step 5)
+#   claude/skills/gh-pr-reply/references/board-sync-in-review.sh.md (Step 6.5)
+#   claude/skills/gh-pr/references/project-board-sync.md            (Step 7)
 #   claude/skills/gh-pr-merge-emergency/references/project-board-sync.md
 #
 # Tests inject SHELL_COMMON pointing at a real fixture dir (helper present)

--- a/tests/bats/skills/helper_fallback_nf1.bats
+++ b/tests/bats/skills/helper_fallback_nf1.bats
@@ -75,16 +75,20 @@ teardown() {
     run grep -F 'if [ -r "$_HELPER" ]; then' "$fixture"
     assert_success
 
-    # Spot-check that each updated SKILL.md/reference also carries the guard.
-    # NOTE: gh-pr's canonical executable snippet moved from
-    # references/project-board-sync.md → SKILL.md Step 7 in issue #747.
+    # Spot-check that each skill's canonical helper-fallback guard carries
+    # through. NOTE: #862 PR-NW-4 relocated these bash blocks out of the
+    # SKILL.md bodies into references/ for progressive disclosure (Check 1
+    # line-count ≤100). Each owning SKILL.md Step now points at the reference
+    # and the model pastes it verbatim, so the guard still executes — the
+    # drift check just follows it to its new home. (This reverses the #747
+    # inlining for gh-pr.)
     local f
     for f in \
-        "claude/skills/gh-pr-merge/SKILL.md" \
+        "claude/skills/gh-pr-merge/references/board-approval-gate.sh.md" \
         "claude/skills/gh-pr-merge/references/project-board-sync.md" \
         "claude/skills/gh-commit/SKILL.md" \
-        "claude/skills/gh-pr-reply/SKILL.md" \
-        "claude/skills/gh-pr/SKILL.md" \
+        "claude/skills/gh-pr-reply/references/board-sync-in-review.sh.md" \
+        "claude/skills/gh-pr/references/project-board-sync.md" \
         "claude/skills/gh-pr-merge-emergency/references/project-board-sync.md"; do
         run grep -F 'if [ -r "$_HELPER" ]; then' "${_BATS_REAL_DOTFILES_ROOT}/$f"
         assert_success


### PR DESCRIPTION
## 개요

Umbrella #862 의 **PR-NW-4** — `gh-pr-*` 5개 스킬을 `/skill:check` **12/12 PASS** (N/A 제외) 로 정리. 각 `SKILL.md` 를 **≤100L** 로 축소.

| Issue | Skill | tier | 전 → 후 (SKILL.md) |
|---|---|---|---|
| #818 | gh-pr-merge | haiku | 205 → 100 |
| #822 | gh-pr-reply | sonnet | 227 → 100 |
| #825 | gh-pr-resolve-conflict | opus | 202 → 100 |
| #829 | gh-pr-review | sonnet | 195 → 100 |
| #856 | gh-pr | haiku | 223 → 100 |

## 처방 (FAIL 패턴별)

- **Check 1/2 (line count · progressive disclosure)** — 인라인 bash/표/템플릿을 `references/` 로 추출: board approval gate, board sync, ai-metrics POST, label removal, parser contract, options 표, report 템플릿 등. 본문은 1줄 포인터로 위임.
- **Check 11 (no emojis)** — 표준 ai-metrics footer(📊 👤 🤖)는 CLAUDE.md 예외. PR-NW-1 누락분인 `gh-pr-reply` / `gh-pr-resolve-conflict` / `gh-pr-review` 를 `allowed-emoji-skills.txt` 에 등재 → 셋 다 N/A. (`gh-pr`, `gh-pr-merge` 는 PR-NW-1 에서 이미 등재)
- **Check 12 (model recommendation)** — 각 frontmatter 에 `metadata.model_recommendation` 블록 추가 (rubric SSOT 의 tier/reason 사용).
- **Check 9 (verdict)** — `gh-pr-merge` final report 에 `[OK]`/`[FAIL]` verdict 라인 추가 (4개 자매 스킬과 일관성).

## 행위 비변경 (추출만)

모든 bash/env/helper/명령 토큰을 references/ 로 **이동**(삭제 아님). `GH_DISABLE_AI_METRICS:-0` 가드, `_gh_project_status_*` 호출, `if [ -r "$_HELPER" ]` NF-1 가드 등 전수 보존 확인.

helper-fallback **NF-1 drift-guard** 테스트(`helper_fallback_nf1.bats` + fixture)를 추출된 `references/` 경로로 갱신 — `gh-pr` 의 #747 inline 보장은 progressive disclosure 로 대체(주석에 명시).

## 검증

- skills bats **279/279** · functions/init/lint bats **732/732** · help-policy pytest **684/684** 전부 green
- 5개 스킬 전부 SKILL.md = 100L, frontmatter YAML 유효, references 인용 전부 resolve

Closes #818, #822, #825, #829, #856
Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)