### PR TITLE
refactor(skills): #862 PR-NW-7 write-* 라인 초과 추출 — write-blog-dev-learnings + write-task-history

### DIFF
--- a/claude/skills/write-blog-dev-learnings/SKILL.md
+++ b/claude/skills/write-blog-dev-learnings/SKILL.md
@@ -12,6 +12,12 @@ description: >-
   debugging story and wants to preserve it. Do NOT trigger for formal RCA
   documents (use write:rca), API documentation, README files, or
   non-narrative technical docs.
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "narrative blog generation: title brainstorm, 7-section war story structure, Korean tone, emoji styling"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # Developer Blog Writer — "삽질 블로그"
@@ -20,165 +26,53 @@ description: >-
 
 If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
 
-You are a developer blog ghostwriter who turns painful debugging stories into entertaining, educational posts that teammates actually want to read. Your posts live in `~/para/archive/playbook/docs/dev-learnings/`.
+You are a developer blog ghostwriter who turns painful debugging stories into
+entertaining, educational posts that teammates actually want to read. Posts live
+in `~/para/archive/playbook/docs/dev-learnings/`.
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<topic-hint>` | Free-text hint (e.g. "오늘 redis 삽질") — conversation summary, specific incident, or vague pointer. | none — mine the current conversation |
+| `-h` / `--help` / `help` | Print `references/help.md` verbatim and stop. | — |
 
 ## Why This Matters
 
-Developers learn best from war stories, not documentation. A well-written "I suffered so you don't have to" blog post prevents the same mistake from happening to 10 other people on the team. The key is making it fun enough that people actually read it — nobody reads boring postmortems voluntarily.
+Developers learn best from war stories, not documentation. A well-written "I
+suffered so you don't have to" post prevents the same mistake from happening to 10
+other people. The key is making it fun enough that people actually read it — nobody
+reads boring postmortems voluntarily.
 
-## The Single Most Important Thing: The Title
+## Step 1: Pick the Title
 
-The title decides whether anyone clicks. It must:
+The title decides whether anyone clicks. Read `references/title-guide.md` for the
+title formula, great examples, and anti-patterns. Propose 3 candidates and let the
+user choose (or pick the best if the user says "알아서 해").
 
-1. **Provoke curiosity or disbelief** — make the reader think "wait, WHAT?"
-2. **Hint at the pain** — the reader should feel "oh no, that could be me"
-3. **Be in Korean** (the team's primary language) with occasional English tech terms
-4. **Use conversational/dramatic tone**, not corporate-speak
+## Step 2: Write the Post
 
-### Title Formula
+Follow the narrative arc 고통 → 삽질 → 깨달음 → 해결. Read
+`references/blog-structure.md` for the exact 7-section template, and
+`references/style-rules.md` for tone, emoji, voice, length, and file-naming rules.
 
-```
-# {자극적인 메인 제목} {이모지}
-## (feat. {기술적 핵심 키워드 나열})
-```
+## Step 3: Save and Confirm
 
-### Great Title Examples (from real posts)
+Read `references/process.md` for the two invocation paths (conversation-context vs
+interview), the absolute save path, the stop-on-error policy, and the final verdict
+block.
 
-- `# 돈 없는 사람은 Claude 병렬작업 하지마!! 🚀`
-- `# 테스트 다 통과했는데 버그가 4번 살아남은 이유 🧟`
-- `# SSO 배포하자마자 즉사했습니다 — .env 믿다가 당한 Docker의 배신 🔥`
-- `# Mock IDP에서는 멀쩡했는데, 사내 SSO는 왜 배포하자마자 3번 터졌을까`
+Steps are sequential — on the first error (no conversation context to mine and no
+topic given, or an unwriteable target directory), stop and report rather than
+fabricating content.
 
-### Title Anti-Patterns (AVOID)
-
-- [BAD] "Docker Compose 환경변수 사용법" (교과서 느낌, 클릭 욕구 제로)
-- [BAD] "SSO 구현 가이드" (건조하고 재미없음)
-- [BAD] "테스트 모킹 시 주의사항" (누가 읽겠는가)
-
-## Blog Structure
-
-Every post follows this exact structure. The narrative arc is: **고통 → 삽질 → 깨달음 → 해결**.
-
-### 1. Title + Subtitle
-```markdown
-# {자극적 제목} {이모지}
-## (feat. {기술 키워드 3개 이내})
-```
-
-### 2. TL;DR (3줄 이내)
-```markdown
----
-
-## TL;DR
-
-**{한 문장으로 핵심 교훈}**
-{보충 설명 1줄}
-
----
-```
-
-The TL;DR is the "trailer" — it should make the reader want to know HOW you got there.
-
-### 3. Problem Situation — "나의 고생"
-
-This is the hook. Write in first person. Include:
-- **감정**: 당시 심정 (자신감 → 절망 → 혼란)
-- **실제 에러 로그**: 코드블록으로 리얼하게
-- **시간/상황 묘사**: "아침 8시 15분, 커피를 마시며..." 같은 디테일
-- **반복적 실패**: "고쳤습니다. 다시 실행했습니다. 에러가 났습니다." 패턴
-- **표 요약**: 증상 vs 진짜 원인을 한눈에 보여주는 테이블
-
-```markdown
-## 문제 상황: {고통을 한 줄로 요약}
-
-### 🔥 나의 현상: "{당시 나의 외침}"
-
-{1인칭 서사. 자신감에 찬 시작 → 현실의 벽}
-
-**결과?**
-
-\`\`\`
-{실제 에러 로그 또는 재현한 에러}
-\`\`\`
-```
-
-### 4. Root Cause — "진짜 원인"
-
-반전 포인트. "알고 보니 이게 문제였다"를 드라마틱하게 전달.
-
-- 코드 비교 (before/after 또는 예상 vs 실제)
-- 도표나 다이어그램으로 시각화
-- 라이브러리/프레임워크의 반직관적 동작 설명
-
-### 5. Solution — "해결 방법"
-
-Step-by-step으로 구체적으로. 코드블록 필수.
-
-### 6. Lessons Learned — "교훈"
-
-번호 매긴 리스트로 핵심 교훈 3-5개.
-
-### 7. Closing — "결론"
-
-- 감성적 마무리 또는 유머
-- P.S. (선택사항, 가벼운 유머)
-
-## Writing Style Rules
-
-1. **한국어 기본**, 기술 용어는 영어 유지 (`mock`, `docker compose`, `env-file` 등)
-2. **1인칭 서사**: "나는", "했습니다", "겪었습니다" — 경험담이므로
-3. **이모지 적극 사용**: 섹션 헤딩에 🔥 ⚠️ ✅ 📊 💣 🧟 등
-4. **에러 로그는 코드블록**: 실제 로그처럼 생생하게
-5. **비유와 은유**: "친절한 금자씨 같은 라이브러리의 배신", "파이프라인의 다음 관문" 등
-6. **독자에게 말 걸기**: "당신도 이런 경험 있지 않나요?", "이거 읽고 있는 Free 이용자 여러분..."
-7. **분량**: 150~300줄 (너무 짧으면 깊이 없고, 너무 길면 안 읽음)
-
-## File Naming and Location
-
-- **Path**: `~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`
-- **Naming**: kebab-case, `-blog` suffix, no date prefix
-- **Examples**: `redis-password-sed-injection-blog.md`, `wsl-systemd-false-positive-blog.md`
-
-## How This Skill Is Invoked
-
-The user runs this skill from **any project directory** via Claude Code TUI:
+## Final Output
 
 ```
-/write:blog-dev-learnings "지금까지 너와 작업한 내용"
-/write:blog-dev-learnings "오늘 redis sed injection 삽질"
-/write:blog-dev-learnings "WSL systemd 감지 문제"
+[OK] write:blog-dev-learnings — <slug>-blog.md
+  path: ~/para/archive/playbook/docs/dev-learnings/<slug>-blog.md
+  lines: <n>
+  title: "<chosen title>"
+
+Next: open file and review; commit when satisfied
 ```
-
-The quoted text is the **topic hint**. It can be:
-- A summary of the current conversation ("지금까지 작업한 내용")
-- A specific incident ("docker env-file 대체 문제")
-- A vague pointer ("오늘 삽질한 거")
-
-## Process
-
-### When the user provides conversation context ("지금까지 작업한 내용")
-
-The current conversation already contains the war story. Extract from it:
-
-1. **Mine the conversation** for: symptoms, failed attempts, root cause, solution, and lessons learned
-2. **Read 1-2 existing posts** from `~/para/archive/playbook/docs/dev-learnings/` to calibrate voice and style
-3. **Propose 3 title candidates** — let the user pick (or pick the best one if the user says "알아서 해")
-4. **Write the full post** following the structure above
-5. **Save** to `~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`
-
-### When the user provides a specific topic without context
-
-If the conversation doesn't contain enough detail about the incident:
-
-1. **Interview** — ask the user:
-   - What happened? (symptoms)
-   - What did you try? (failed attempts)
-   - What was the real cause? (root cause)
-   - How did you fix it? (solution)
-2. **Read 1-2 existing posts** to calibrate voice
-3. **Propose 3 title candidates**
-4. **Write and save**
-
-### Important: Always write to the absolute path
-
-The output path is always `~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`, regardless of the current working directory. This skill writes across project boundaries.

--- a/claude/skills/write-blog-dev-learnings/references/blog-structure.md
+++ b/claude/skills/write-blog-dev-learnings/references/blog-structure.md
@@ -1,0 +1,67 @@
+# Blog Structure — the 7-section template
+
+Every post follows this exact structure. The narrative arc is: **고통 → 삽질 → 깨달음 → 해결**.
+
+## 1. Title + Subtitle
+```markdown
+# {자극적 제목} {이모지}
+## (feat. {기술 키워드 3개 이내})
+```
+
+## 2. TL;DR (3줄 이내)
+```markdown
+---
+
+## TL;DR
+
+**{한 문장으로 핵심 교훈}**
+{보충 설명 1줄}
+
+---
+```
+
+The TL;DR is the "trailer" — it should make the reader want to know HOW you got there.
+
+## 3. Problem Situation — "나의 고생"
+
+This is the hook. Write in first person. Include:
+- **감정**: 당시 심정 (자신감 → 절망 → 혼란)
+- **실제 에러 로그**: 코드블록으로 리얼하게
+- **시간/상황 묘사**: "아침 8시 15분, 커피를 마시며..." 같은 디테일
+- **반복적 실패**: "고쳤습니다. 다시 실행했습니다. 에러가 났습니다." 패턴
+- **표 요약**: 증상 vs 진짜 원인을 한눈에 보여주는 테이블
+
+```markdown
+## 문제 상황: {고통을 한 줄로 요약}
+
+### 🔥 나의 현상: "{당시 나의 외침}"
+
+{1인칭 서사. 자신감에 찬 시작 → 현실의 벽}
+
+**결과?**
+
+\`\`\`
+{실제 에러 로그 또는 재현한 에러}
+\`\`\`
+```
+
+## 4. Root Cause — "진짜 원인"
+
+반전 포인트. "알고 보니 이게 문제였다"를 드라마틱하게 전달.
+
+- 코드 비교 (before/after 또는 예상 vs 실제)
+- 도표나 다이어그램으로 시각화
+- 라이브러리/프레임워크의 반직관적 동작 설명
+
+## 5. Solution — "해결 방법"
+
+Step-by-step으로 구체적으로. 코드블록 필수.
+
+## 6. Lessons Learned — "교훈"
+
+번호 매긴 리스트로 핵심 교훈 3-5개.
+
+## 7. Closing — "결론"
+
+- 감성적 마무리 또는 유머
+- P.S. (선택사항, 가벼운 유머)

--- a/claude/skills/write-blog-dev-learnings/references/process.md
+++ b/claude/skills/write-blog-dev-learnings/references/process.md
@@ -1,0 +1,61 @@
+# Process — how the skill is invoked and runs
+
+Steps are sequential — on the first error (e.g., target directory unwriteable, no
+conversation context to mine and no topic provided), stop and report rather than
+fabricating content.
+
+## How This Skill Is Invoked
+
+The user runs this skill from **any project directory** via Claude Code TUI:
+
+```
+/write:blog-dev-learnings "지금까지 너와 작업한 내용"
+/write:blog-dev-learnings "오늘 redis sed injection 삽질"
+/write:blog-dev-learnings "WSL systemd 감지 문제"
+```
+
+The quoted text is the **topic hint**. It can be:
+- A summary of the current conversation ("지금까지 작업한 내용")
+- A specific incident ("docker env-file 대체 문제")
+- A vague pointer ("오늘 삽질한 거")
+
+## When the user provides conversation context ("지금까지 작업한 내용")
+
+The current conversation already contains the war story. Extract from it:
+
+1. **Mine the conversation** for: symptoms, failed attempts, root cause, solution, and lessons learned
+2. **Read 1-2 existing posts** from `~/para/archive/playbook/docs/dev-learnings/` to calibrate voice and style
+3. **Propose 3 title candidates** — let the user pick (or pick the best one if the user says "알아서 해")
+4. **Write the full post** following the structure above
+5. **Save** to `~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`
+
+## When the user provides a specific topic without context
+
+If the conversation doesn't contain enough detail about the incident:
+
+1. **Interview** — ask the user:
+   - What happened? (symptoms)
+   - What did you try? (failed attempts)
+   - What was the real cause? (root cause)
+   - How did you fix it? (solution)
+2. **Read 1-2 existing posts** to calibrate voice
+3. **Propose 3 title candidates**
+4. **Write and save**
+
+## Important: Always write to the absolute path
+
+The output path is always `~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`,
+regardless of the current working directory. This skill writes across project boundaries.
+
+## Final Output (verdict)
+
+After saving, report:
+
+```
+[OK] write:blog-dev-learnings — <slug>-blog.md
+  path: ~/para/archive/playbook/docs/dev-learnings/<slug>-blog.md
+  lines: <n>
+  title: "<chosen title>"
+
+Next: open file and review; commit when satisfied
+```

--- a/claude/skills/write-blog-dev-learnings/references/style-rules.md
+++ b/claude/skills/write-blog-dev-learnings/references/style-rules.md
@@ -1,0 +1,15 @@
+# Writing Style Rules
+
+1. **한국어 기본**, 기술 용어는 영어 유지 (`mock`, `docker compose`, `env-file` 등)
+2. **1인칭 서사**: "나는", "했습니다", "겪었습니다" — 경험담이므로
+3. **이모지 적극 사용**: 섹션 헤딩에 🔥 ⚠️ ✅ 📊 💣 🧟 등
+4. **에러 로그는 코드블록**: 실제 로그처럼 생생하게
+5. **비유와 은유**: "친절한 금자씨 같은 라이브러리의 배신", "파이프라인의 다음 관문" 등
+6. **독자에게 말 걸기**: "당신도 이런 경험 있지 않나요?", "이거 읽고 있는 Free 이용자 여러분..."
+7. **분량**: 150~300줄 (너무 짧으면 깊이 없고, 너무 길면 안 읽음)
+
+## File Naming and Location
+
+- **Path**: `~/para/archive/playbook/docs/dev-learnings/{topic}-blog.md`
+- **Naming**: kebab-case, `-blog` suffix, no date prefix
+- **Examples**: `redis-password-sed-injection-blog.md`, `wsl-systemd-false-positive-blog.md`

--- a/claude/skills/write-blog-dev-learnings/references/title-guide.md
+++ b/claude/skills/write-blog-dev-learnings/references/title-guide.md
@@ -1,0 +1,28 @@
+# Title Guide — the single most important part of the post
+
+The title decides whether anyone clicks. It must:
+
+1. **Provoke curiosity or disbelief** — make the reader think "wait, WHAT?"
+2. **Hint at the pain** — the reader should feel "oh no, that could be me"
+3. **Be in Korean** (the team's primary language) with occasional English tech terms
+4. **Use conversational/dramatic tone**, not corporate-speak
+
+## Title Formula
+
+```
+# {자극적인 메인 제목} {이모지}
+## (feat. {기술적 핵심 키워드 나열})
+```
+
+## Great Title Examples (from real posts)
+
+- `# 돈 없는 사람은 Claude 병렬작업 하지마!! 🚀`
+- `# 테스트 다 통과했는데 버그가 4번 살아남은 이유 🧟`
+- `# SSO 배포하자마자 즉사했습니다 — .env 믿다가 당한 Docker의 배신 🔥`
+- `# Mock IDP에서는 멀쩡했는데, 사내 SSO는 왜 배포하자마자 3번 터졌을까`
+
+## Title Anti-Patterns (AVOID)
+
+- [BAD] "Docker Compose 환경변수 사용법" (교과서 느낌, 클릭 욕구 제로)
+- [BAD] "SSO 구현 가이드" (건조하고 재미없음)
+- [BAD] "테스트 모킹 시 주의사항" (누가 읽겠는가)

--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -9,6 +9,12 @@ description: >-
   ticket drafting from conversation context, or preparing PR descriptions based
   on what was just done. Works across any project.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "simple session summary: conversation mining -> JIRA + PR templates -> append file + auto-commit; bounded structured output"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # write-task-history
@@ -18,15 +24,21 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 If args is `-h`/`--help`/`help`, read `references/help.md` verbatim and stop.
 
 Document completed work from the current conversation into a daily task history file,
-producing JIRA ticket and git PR formats that can be directly copy-pasted.
+producing copy-pasteable JIRA ticket and git PR formats.
 
-## When to use
+## Options
 
-- User says "/write-task-history" with optional description
-- User asks to record, log, or summarize today's work
-- User wants a JIRA ticket or PR description based on work just completed
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<description>` | Free-text extra context | none — mine the conversation |
+| `-h` / `--help` / `help` | Print `references/help.md` verbatim and stop. | — |
+
+Env: `TASK_HISTORY_DIR` (default `~/para/archive/playbook/docs/task-history/`)
 
 ## Step-by-step workflow
+
+Steps 1–8 are sequential — if Step 1 cannot resolve a writable directory, or Step 7
+commit fails, stop and report rather than producing a partial entry.
 
 ### Step 1: Determine output file path
 
@@ -41,214 +53,48 @@ Run `mkdir -p` on the directory if it does not exist.
 
 ### Step 2: Analyze the current conversation
 
-Review the full conversation to extract:
-
-- **What was done**: list of concrete actions and changes
-- **Why it was done**: background, motivation, or triggering event
-- **What resulted**: outcomes, files created, PRs merged, issues resolved
-
-If the user provided a description argument, use it as additional context but still
-analyze the conversation for completeness.
+Extract **what was done** (concrete actions/changes), **why** (background, trigger),
+and **what resulted** (outcomes, files, PRs, issues). Use any description argument as
+extra context, but still analyze the conversation for completeness.
 
 ### Step 3: Gather git information (if in a git repo)
 
-Run these commands to collect context:
-
-```bash
-# Project name from remote
-basename "$(git remote get-url origin 2>/dev/null)" .git 2>/dev/null
-
-# Commits made during this conversation (look for hashes mentioned in conversation)
-git log --oneline -10
-
-# Current branch and diff scope (if not on main)
-git branch --show-current
-git diff main...HEAD --stat 2>/dev/null
-```
-
-Use the conversation context to identify which commits were made during this session,
-not just today's commits. This avoids false positives from unrelated commits.
+Collect project name (`basename "$(git remote get-url origin)" .git`), recent commits
+(`git log --oneline -10`), current branch, and diff scope (`git diff main...HEAD
+--stat`). Use the conversation to identify this session's commits, not just today's.
 
 ### Step 4: Generate JIRA ticket format
 
-Write inside a `text` code block. Use `>` for section headers and `-` for items.
-Do not use markdown formatting, emoji, or special characters beyond `>` and `-`.
-The content should be directly pasteable into a JIRA Description field.
+Read `references/jira-template.md` for the JIRA Description-pasteable text block.
 
-**Template:**
+### Step 5: Generate PR format (conditional)
 
-```text
-[Title]
-[project-name] Concise summary of work
-
-[Description]
-> Background
-- Why this work was needed
-- Context or triggering event
-
-> Work performed
-- Specific action 1
-- Specific action 2
-- Specific action 3
-
-> Results
-- Outcome 1
-- Outcome 2
-
-> Notes
-- Additional context if relevant
-```
-
-Omit the "Notes" section if there is nothing noteworthy.
-
-### Step 5: Generate PR format (only if commits exist)
-
-Only produce this section if the conversation included git commits, branch creation,
-or PR activity. If no commits were made, skip entirely — do not write an empty section
-or a placeholder.
-
-Write inside a `markdown` code block. Use plain section headers without emoji.
-
-**Template:**
-
-```markdown
-## Title
-Short PR title (under 70 characters)
-
-## Summary
-- Change description 1
-- Change description 2
-
-## Changes
-- `file-or-path`: what changed
-- `file-or-path`: what changed
-
-## Test plan
-- [ ] Verification step 1
-- [ ] Verification step 2
-```
+Read `references/pr-template.md` for the markdown PR template. Skip entirely if no
+commits exist in the conversation.
 
 ### Step 6: Write to file
 
-Check if the target file already exists:
+Read `references/file-entry-structure.md` for the append/create + separator policy
+and per-entry structure.
 
-- **File does not exist**: Create it with a level-1 heading, then the entry.
-- **File exists**: Append a `---` separator followed by the new entry.
+### Step 7–8: Auto-commit + confirm
 
-Each entry uses this structure:
+Read `references/commit-confirm.md` for the commit pattern and final verdict block.
 
-```markdown
-## HH:MM | project-name | Short task title
+## Rules and Example
 
-### JIRA Ticket
+Read `references/rules.md` for output conventions (emoji-free, append-only, language).
+Read `references/example.md` for a full worked entry.
 
-\`\`\`text
-(JIRA content here)
-\`\`\`
-
-### PR
-
-\`\`\`markdown
-(PR content here — or omit this entire section if no commits)
-\`\`\`
-```
-
-The timestamp is the current time when the skill runs (24-hour format).
-
-### Step 7: Auto-commit to the task-history repository
-
-After writing the file, automatically commit it in the repository where the file lives.
-The task-history file may be in a different repository than the current working directory.
-
-Commit format (fixed pattern):
+## Final Output
 
 ```
-chore(task-history): YYYY-MM-DD short task summary
-```
+[OK] write:task-history — entry appended
+  path: <task-history-file>
+  time: HH:MM
+  project: <project-name>
+  pr_section: included | skipped
+  commit: <hash> chore(task-history): YYYY-MM-DD <summary>
 
-Example:
-
-```
-chore(task-history): 2026-03-20 write-task-history skill design
-```
-
-Steps:
-
-```bash
-cd <directory-containing-the-task-history-file>
-git add <task-history-file>
-git commit -m "chore(task-history): YYYY-MM-DD short task summary"
-```
-
-This commit is low-importance and does not require review, so commit directly
-without asking the user for confirmation.
-
-### Step 8: Confirm to user
-
-After writing and committing, tell the user:
-- The file path that was written to
-- The commit hash and message
-- Whether a PR section was included or skipped
-
-## Important rules
-
-- Never use emoji in any output (repo convention)
-- JIRA format uses only `>` and `-` symbols for structure, no markdown
-- PR section is conditional: only when commits exist in conversation context
-- Always append, never overwrite existing file content
-- The `text` and `markdown` code blocks are essential for copy-paste workflow
-- Determine project name from `git remote`, falling back to directory name, then "N/A"
-- Write content in the same language the user used during the conversation
-
-## Example
-
-Given a conversation where the user fixed a bug and committed:
-
-File: `~/para/archive/playbook/docs/task-history/2026-03-20-task-list.md`
-
-```markdown
-# Task History: 2026-03-20
-
----
-
-## 14:30 | dotfiles | Fix symlink creation for pip config
-
-### JIRA Ticket
-
-\`\`\`text
-[Title]
-[dotfiles] pip config symlink 생성 오류 수정
-
-[Description]
-> 배경
-- setup.sh 실행 시 ~/.config/pip/pip.conf symlink가 생성되지 않는 문제 발견
-- 디렉터리 미존재가 원인
-
-> 수행 내용
-- shell-common/setup.sh에서 mkdir -p 호출 추가
-- pip config symlink 생성 로직 수정
-- 테스트 후 PR 생성
-
-> 결과
-- setup.sh 실행 시 pip config 정상 생성 확인
-- PR #33 생성 및 머지 완료
-\`\`\`
-
-### PR
-
-\`\`\`markdown
-## Title
-fix: add mkdir for pip config directory before symlink creation
-
-## Summary
-- Add `mkdir -p ~/.config/pip` before creating pip.conf symlink
-- Fixes setup.sh failure on fresh installations where ~/.config/pip does not exist
-
-## Changes
-- `shell-common/setup.sh`: Added directory creation before symlink
-
-## Test plan
-- [ ] Run setup.sh on clean home directory
-- [ ] Verify ~/.config/pip/pip.conf symlink exists after setup
-\`\`\`
+Next: paste JIRA block into ticket / open PR with the markdown block
 ```

--- a/claude/skills/write-task-history/references/commit-confirm.md
+++ b/claude/skills/write-task-history/references/commit-confirm.md
@@ -1,0 +1,45 @@
+# Auto-commit and Confirm — Steps 7-8
+
+## Step 7: Auto-commit to the task-history repository
+
+After writing the file, automatically commit it in the repository where the file
+lives. The task-history file may be in a different repository than the current
+working directory.
+
+Commit format (fixed pattern):
+
+```
+chore(task-history): YYYY-MM-DD short task summary
+```
+
+Example:
+
+```
+chore(task-history): 2026-03-20 write-task-history skill design
+```
+
+Steps:
+
+```bash
+cd <directory-containing-the-task-history-file>
+git add <task-history-file>
+git commit -m "chore(task-history): YYYY-MM-DD short task summary"
+```
+
+This commit is low-importance and does not require review, so commit directly
+without asking the user for confirmation.
+
+## Step 8: Confirm to user
+
+After writing and committing, report the verdict:
+
+```
+[OK] write:task-history — entry appended
+  path: <task-history-file>
+  time: HH:MM
+  project: <project-name>
+  pr_section: included | skipped
+  commit: <hash> chore(task-history): YYYY-MM-DD <summary>
+
+Next: paste JIRA block into ticket / open PR with the markdown block
+```

--- a/claude/skills/write-task-history/references/example.md
+++ b/claude/skills/write-task-history/references/example.md
@@ -1,0 +1,52 @@
+# Worked Example
+
+Given a conversation where the user fixed a bug and committed:
+
+File: `~/para/archive/playbook/docs/task-history/2026-03-20-task-list.md`
+
+```markdown
+# Task History: 2026-03-20
+
+---
+
+## 14:30 | dotfiles | Fix symlink creation for pip config
+
+### JIRA Ticket
+
+\`\`\`text
+[Title]
+[dotfiles] pip config symlink 생성 오류 수정
+
+[Description]
+> 배경
+- setup.sh 실행 시 ~/.config/pip/pip.conf symlink가 생성되지 않는 문제 발견
+- 디렉터리 미존재가 원인
+
+> 수행 내용
+- shell-common/setup.sh에서 mkdir -p 호출 추가
+- pip config symlink 생성 로직 수정
+- 테스트 후 PR 생성
+
+> 결과
+- setup.sh 실행 시 pip config 정상 생성 확인
+- PR #33 생성 및 머지 완료
+\`\`\`
+
+### PR
+
+\`\`\`markdown
+## Title
+fix: add mkdir for pip config directory before symlink creation
+
+## Summary
+- Add `mkdir -p ~/.config/pip` before creating pip.conf symlink
+- Fixes setup.sh failure on fresh installations where ~/.config/pip does not exist
+
+## Changes
+- `shell-common/setup.sh`: Added directory creation before symlink
+
+## Test plan
+- [ ] Run setup.sh on clean home directory
+- [ ] Verify ~/.config/pip/pip.conf symlink exists after setup
+\`\`\`
+```

--- a/claude/skills/write-task-history/references/file-entry-structure.md
+++ b/claude/skills/write-task-history/references/file-entry-structure.md
@@ -1,0 +1,26 @@
+# File Entry Structure — Step 6
+
+Check if the target file already exists:
+
+- **File does not exist**: Create it with a level-1 heading, then the entry.
+- **File exists**: Append a `---` separator followed by the new entry.
+
+Each entry uses this structure:
+
+```markdown
+## HH:MM | project-name | Short task title
+
+### JIRA Ticket
+
+\`\`\`text
+(JIRA content here)
+\`\`\`
+
+### PR
+
+\`\`\`markdown
+(PR content here — or omit this entire section if no commits)
+\`\`\`
+```
+
+The timestamp is the current time when the skill runs (24-hour format).

--- a/claude/skills/write-task-history/references/jira-template.md
+++ b/claude/skills/write-task-history/references/jira-template.md
@@ -1,0 +1,31 @@
+# JIRA Ticket Format — Step 4
+
+Write inside a `text` code block. Use `>` for section headers and `-` for items.
+Do not use markdown formatting, emoji, or special characters beyond `>` and `-`.
+The content should be directly pasteable into a JIRA Description field.
+
+## Template
+
+```text
+[Title]
+[project-name] Concise summary of work
+
+[Description]
+> Background
+- Why this work was needed
+- Context or triggering event
+
+> Work performed
+- Specific action 1
+- Specific action 2
+- Specific action 3
+
+> Results
+- Outcome 1
+- Outcome 2
+
+> Notes
+- Additional context if relevant
+```
+
+Omit the "Notes" section if there is nothing noteworthy.

--- a/claude/skills/write-task-history/references/pr-template.md
+++ b/claude/skills/write-task-history/references/pr-template.md
@@ -1,0 +1,26 @@
+# PR Format — Step 5 (conditional)
+
+Only produce this section if the conversation included git commits, branch creation,
+or PR activity. If no commits were made, skip entirely — do not write an empty section
+or a placeholder.
+
+Write inside a `markdown` code block. Use plain section headers without emoji.
+
+## Template
+
+```markdown
+## Title
+Short PR title (under 70 characters)
+
+## Summary
+- Change description 1
+- Change description 2
+
+## Changes
+- `file-or-path`: what changed
+- `file-or-path`: what changed
+
+## Test plan
+- [ ] Verification step 1
+- [ ] Verification step 2
+```

--- a/claude/skills/write-task-history/references/rules.md
+++ b/claude/skills/write-task-history/references/rules.md
@@ -1,0 +1,9 @@
+# Important Rules
+
+- Never use emoji in any output (repo convention)
+- JIRA format uses only `>` and `-` symbols for structure, no markdown
+- PR section is conditional: only when commits exist in conversation context
+- Always append, never overwrite existing file content
+- The `text` and `markdown` code blocks are essential for copy-paste workflow
+- Determine project name from `git remote`, falling back to directory name, then "N/A"
+- Write content in the same language the user used during the conversation


### PR DESCRIPTION
## 개요

트래킹 이슈 #862 의 **PR-NW-7 — Line count 추출: `write-*` (2 스킬)** 을 단일 PR 로 처리한다. `/skill:check` audit 에서 NEEDS WORK 판정된 두 `write-*` 스킬의 FAIL 패턴(라인 초과, `references/` 미사용)과 동반 WARN(verdict / options / metadata 누락)을 해소한다.

## 변경 스킬

### write-blog-dev-learnings (#850) — 184L → 78L
- `references/` 4개 추출: `title-guide.md`, `blog-structure.md`, `style-rules.md`, `process.md`
- SKILL.md 본문은 Step 1–3 포인터 + 옵션 테이블 + verdict 블록만 유지
- emoji 글리프(블로그 핵심 스타일)는 PR-NW-1 에서 `allowed-emoji-skills.txt` 등재 완료 → Check 11 = N/A
- `metadata.model_recommendation` 추가 (tier=**sonnet** — 서사형 블로그 생성)

### write-task-history (#859) — 254L → 100L
- `references/` 6개 추출: `jira-template.md`, `pr-template.md`, `file-entry-structure.md`, `commit-confirm.md`, `rules.md`, `example.md`
- SKILL.md 본문은 Step 1–8 포인터 + 옵션 테이블(+ `TASK_HISTORY_DIR` env) + verdict 블록만 유지
- `metadata.model_recommendation` 추가 (tier=**haiku** — 정형 세션 요약)

## 공통 처리

- 옵션 테이블 (Option | Description | Default) 추가
- `[OK]` verdict 블록 + key=value + `Next:` 라인 추가
- stop-on-error 정책 1문장 명시
- 콜론 SSOT 네이밍(`write:blog-dev-learnings`, `write:task-history`) byte-for-byte 보존

## 검증

| 스킬 | 라인 | `/skill:check` |
|---|---|---|
| write-blog-dev-learnings | 78 (≤100) | 11/11 PASS (Check 11 N/A) — EXCELLENT |
| write-task-history | 100 (≤100) | 12/12 PASS — EXCELLENT |

- pre-commit hook PASS (markdown-only 변경 — shell/python lint 비해당)
- 기존 동작 무변경: 추출은 내용 이동만, 워크플로 의미 보존

## 관련

- 트래킹: #862 (PR-NW-7) — 본 PR 머지 후에도 잔여 PR(NW-8) 완료 시 close
- 선행: PR-NW-1 (allowlist 등재, 머지 완료)

Closes #850
Closes #859
