### PR TITLE
refactor(skills): #862 PR-NW-5 — line-count 추출 4 스킬 (≤100L + Check 12)

### DIFF
--- a/claude/skills/gh-add-ai-metrics/SKILL.md
+++ b/claude/skills/gh-add-ai-metrics/SKILL.md
@@ -16,6 +16,12 @@ description: >-
   (recompute, not blind overwrite). Never modifies issue/PR body content
   other than the footer. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "metadata backfill via gh CLI"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:add-ai-metrics — Retrofit ai-metrics footer onto past Issues/PRs
@@ -33,22 +39,11 @@ Parse args per the table in `references/help.md` — positional `issue#N` /
 `pr#M` (case-insensitive), flags `--type`, `--date`, `--force`, `--remote`,
 plus the pacing flags `--pace`, `--limit`, `--budget`, `--dry-run`.
 
-`--date` accepts four shapes — single day, whole month, or half-open range —
-parsed by `parse_date_arg` in `references/date-parsing.md`:
-
-| Length / shape          | Form                | Meaning                          |
-|-------------------------|---------------------|----------------------------------|
-| 5 chars `YY-MM`         | month               | whole month, 1st through last day |
-| 7 chars `YYYY-MM`       | month               | same                             |
-| 8 chars `YY-MM-DD`      | single              | one day (existing)               |
-| 10 chars `YYYY-MM-DD`   | single              | one day (existing)               |
-| contains `..` or `~`    | range `[start, end)` | end-day excluded; `~` normalized to `..` |
-
-Other inputs → format error and stop.
-
-`--pace`, `--budget` accept duration strings (`30s` / `5m` / `1h` / `1h30m`)
-parsed by `parse_duration` in `references/pace-control.md`. `--limit` takes
-a positive integer. `--dry-run` is a boolean flag.
+`--date` accepts single day / whole month / half-open range (`..` / `~`)
+per `parse_date_arg` in `references/date-parsing.md` (SSOT).
+`--pace`/`--budget` accept durations (`30s`/`5m`/`1h30m`) via
+`parse_duration` in `references/pace-control.md`; `--limit` a positive
+integer; `--dry-run` a boolean.
 
 Resolve `TARGET_REPO` via the shared flow in
 `gh-issue-create/references/repo-resolution.md`. Missing remote → list
@@ -60,100 +55,46 @@ cards is a hard error: print
 
 First match wins:
 
-1. `--date` present → **date-filter mode**.
-   Feed the value through `parse_date_arg` → three-token output
-   (`single|month|range <a> [<b>]`) → `build_search_clause` → the
-   `created:...` fragment for the GitHub query. Then run `gh issue list`
-   and/or `gh pr list` (filtered by `--type` if given) with
-   `--search "<clause>" --state all --limit 200 --json number,title`.
-   The `--limit 200` cap stays — for month/range queries that would exceed
-   it the user must narrow the date or split into sub-ranges.
-2. Positional cards present → **explicit-list mode**. Parse, validate
-   each `N` as a positive integer, dedupe, preserve order.
-3. Otherwise → **conversation-infer mode**. Scan recent chat turns for
-   `#NNN` mentions paired with `issue` / `PR` / `pr` cues — bare numbers
-   without `#` are ignored to avoid false positives. No candidates →
-   print `Error: no issue/PR references in conversation; pass them explicitly.`
-   and stop.
+1. `--date` → **date-filter mode**: `parse_date_arg` →
+   `build_search_clause` → `created:...` fragment, then `gh issue/pr list`
+   (filtered by `--type`) `--search "<clause>" --state all --limit 200
+   --json number,title`. The 200 cap stays — wider ranges split by user.
+2. Positional cards → **explicit-list mode**: validate each `N` positive,
+   dedupe, preserve order.
+3. Otherwise → **conversation-infer mode**: scan recent turns for `#NNN`
+   paired with `issue`/`PR`/`pr` cues (bare numbers ignored); none →
+   `Error: no issue/PR references in conversation; pass them explicitly.`
 
-If `|targets| > 100`, print the count and prompt
-`Continue with N cards? [y/N]:`. Default no → stop. `--limit <N>` does
-**not** suppress this prompt — the prompt protects against accidentally
-huge target lists (e.g. a typo'd month range), independent of how many
-the loop will actually modify.
+If `|targets| > 100`, prompt `Continue with N cards? [y/N]:` (default no).
+`--limit` does not suppress it — it guards against huge target lists.
 
 ## Step 3: Per-Card Loop
 
-If `--dry-run` was passed, take the dry-run branch in
-`references/pace-control.md` → "`--dry-run` branch" — same per-card view
-fetch, but emits `· will-write` / `· will-skip` / `· will-force-replace`
-classification rows and the dry-run summary line, **never calling
-`gh edit`**. Then stop.
+`--dry-run` → take the dry-run branch in `references/pace-control.md`
+(per-card view fetch, `· will-write`/`· will-skip`/`· will-force-replace`
+rows, dry-run summary, **never `gh edit`**), then stop.
 
-Otherwise, for each `(type, N)` follow `references/footer-detection.md`:
-
-1. **Stop check (top of iteration)** — before fetching this card.
-   Compute `elapsed_secs=$(( $(date +%s) - START_TS ))` here (seconds,
-   matching `check_budget`'s contract — Step 4's `ELAPSED` is a separate
-   minutes-rounded display value, do not reuse it):
-   - `check_budget "$elapsed_secs" "$BUDGET_SECS"` true → break with
-     `stop_reason="--budget"`. (Skipped when `--budget` not set.)
-   - `--limit` set and `modified_count >= LIMIT` → break with
-     `stop_reason="--limit"`.
-   See `references/pace-control.md` → "Stop-reason composition".
-2. `gh {issue,pr} view N --repo "$TARGET_REPO" --json title,body` → fetch.
-3. Detect `<!-- ai-metrics -->` (also matches `<!-- ai-metrics:<skill> -->`).
-4. Branch:
-   - **No footer** → compute metrics → append (after a `---` separator).
-   - **Footer + no `--force`** → print `→ skipped #N <title>` and continue
-     **without sleeping**. Do NOT call `gh edit` (saves API quota).
-   - **Footer + `--force`** → recompute fresh metrics → in-place replace
-     (single regex pass, no append).
-5. On modification only: write the new body to `mktemp`, call
-   `gh {issue,pr} edit N --repo "$TARGET_REPO" --body-file <tmp>`,
-   increment `modified_count`, then `sleep_pace "$PACE_SECS"` (no-op when
-   `--pace` not set, skipped on the last card so no trailing wait).
-6. Print the one-line status string per the "Per-card status output
-   format" section in `references/footer-detection.md`. Continue on
-   failure — never abort the loop.
-
-Metric values follow `references/post-hoc-metrics.md` (TOKENS / HUMAN_H /
-ELAPSED formulas, SSOT lookup table, post-hoc estimation rules).
+Otherwise iterate per `references/footer-detection.md` (SSOT — not
+restated here): top-of-iteration stop check (`--budget`/`--limit` via
+`check_budget`, see `references/pace-control.md` → "Stop-reason
+composition"), fetch, detect `<!-- ai-metrics -->`, branch
+no-footer→append / footer→skip / footer+`--force`→in-place replace,
+`gh edit` + `sleep_pace` on modify only, one-line status, continue on
+failure. Metric values follow `references/post-hoc-metrics.md`.
 
 ## Step 4: Final Report
 
-After the loop, print the summary line + context-only ai-metrics line per
-the "Final report output format" section in `references/footer-detection.md`.
-Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
-
-When the loop exited early via `--limit` or `--budget`, append a third line
-naming the trigger and the count remaining in the original target list:
-
-```
-Stopped early: <stop_reason>; <X> cards remaining. Re-run the same command to resume (skip-existing makes this idempotent).
-```
-
-For `--dry-run`, the final report is the dry-run summary block from
-`references/pace-control.md` instead — no per-card metrics line, no
-edit-counters.
+Print the summary line + context-only ai-metrics line per the "Final
+report output format" section in `references/footer-detection.md`, after
+computing `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`. On early exit
+via `--limit`/`--budget`, append a `Stopped early: <stop_reason>; <X>
+cards remaining. Re-run to resume (idempotent).` line. For `--dry-run`,
+the report is the dry-run summary block from `references/pace-control.md`
+instead — no per-card metrics, no counters.
 
 ## Constraints
 
-- Always pass `--repo "$TARGET_REPO"` — no implicit repo detection.
-- Body byte-identical outside the footer: stripping the new footer must
-  yield the original body verbatim. No rewrap, no language change.
-- `--force` is **recompute → replace**, never blind overwrite or
-  duplicate-append. If no footer exists, `--force` degrades to plain append.
-- Continue-on-error: a single card failure never stops the loop.
-- Skip path is API-silent — no `gh edit` call, no body diff, **no sleep**.
-- Conversation-infer mode rejects bare numbers (`123` without `#`).
-- > 100 hits require explicit `y` confirmation; no `--yes` flag.
-- `--pace` sleeps **after** each successful modify, **never before**, and
-  **never after the last card** — no trailing wait.
-- `--dry-run` makes zero `gh edit` calls. `gh view` is still allowed
-  (needed to classify will-write vs will-skip vs will-force-replace).
-- `--limit` counts only cards that took the modify path (skipped cards
-  do not advance the counter — this makes "process N new backfills"
-  deterministic across re-runs).
-- `--limit` and `--budget` compose with **OR semantics** — whichever
-  fires first stops the loop. Stop reason is reported in the summary.
+Operating invariants (always `--repo`, body byte-identical outside the
+footer, `--force` recompute-not-overwrite, continue-on-error, pacing,
+`--limit`/`--budget` OR-semantics) live in
+[`references/constraints.md`](references/constraints.md).

--- a/claude/skills/gh-add-ai-metrics/references/constraints.md
+++ b/claude/skills/gh-add-ai-metrics/references/constraints.md
@@ -1,0 +1,23 @@
+# Constraints — gh:add-ai-metrics operating rules
+
+Operational invariants for the backfill loop. The SKILL.md body points
+here instead of restating them inline.
+
+- Always pass `--repo "$TARGET_REPO"` — no implicit repo detection.
+- Body byte-identical outside the footer: stripping the new footer must
+  yield the original body verbatim. No rewrap, no language change.
+- `--force` is **recompute → replace**, never blind overwrite or
+  duplicate-append. If no footer exists, `--force` degrades to plain append.
+- Continue-on-error: a single card failure never stops the loop.
+- Skip path is API-silent — no `gh edit` call, no body diff, **no sleep**.
+- Conversation-infer mode rejects bare numbers (`123` without `#`).
+- > 100 hits require explicit `y` confirmation; no `--yes` flag.
+- `--pace` sleeps **after** each successful modify, **never before**, and
+  **never after the last card** — no trailing wait.
+- `--dry-run` makes zero `gh edit` calls. `gh view` is still allowed
+  (needed to classify will-write vs will-skip vs will-force-replace).
+- `--limit` counts only cards that took the modify path (skipped cards
+  do not advance the counter — this makes "process N new backfills"
+  deterministic across re-runs).
+- `--limit` and `--budget` compose with **OR semantics** — whichever
+  fires first stops the loop. Stop reason is reported in the summary.

--- a/claude/skills/gh-commit/SKILL.md
+++ b/claude/skills/gh-commit/SKILL.md
@@ -12,6 +12,12 @@ description: >-
   Creates a new commit — never amends. Never skips hooks. Accepts
   `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "git commit wrapping, structured"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:commit — Git Commit with Issue Linking
@@ -23,163 +29,66 @@ output its content verbatim, then stop. No API calls.
 
 ## Role
 
-Stage the relevant changes and create a new git commit that follows the
-repository's existing commit style, with `Closes #N` / `Fixes #N` footer
-when a GitHub issue is known. `Refs` / `Resolves` / `See` / `References`
-keywords are forbidden — they break GitHub auto-close and project-board
-automation (see issue #392).
+Stage the relevant changes and create a new git commit in the repo's commit
+style, with a `Closes #N` / `Fixes #N` footer when a GitHub issue is known.
+`Refs` / `Resolves` / `See` / `References` keywords are forbidden — they break
+GitHub auto-close and project-board automation (see issue #392).
 
 ## Step 1: Inspect State (parallel) — ALWAYS FIRST
 
 Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
 
-This step runs **unconditionally** on every invocation, even bare `/gh-commit`
-with no prior conversation context. The working-tree state observed here is
-the source of truth — do NOT ask the user "what did you change?" before
-running these.
-
-Run these in a single message:
-- `git status` (never `-uall`)
-- `git diff` (staged + unstaged)
-- `git diff --staged` if anything is already staged
-- `git log --oneline -20` — mimic the repo's commit message style
+Runs **unconditionally** on every invocation, even bare `/gh-commit` with no
+conversation context — the working-tree state is the source of truth, so do
+NOT ask "what did you change?". In a single message run: `git status` (never
+`-uall`), `git diff` (staged + unstaged), `git diff --staged` if anything is
+staged, and `git log --oneline -20` (to mimic the repo's commit style).
 
 ## Step 2: Resolve the Issue Number
 
-Check in this order and use the first hit:
-
-1. **Explicit argument** — if the user said `/gh:commit 123` or mentioned
-   "이슈 123번 연결" in their latest message.
-2. **Recent conversation** — scan the last ~10 messages for `#N` or
-   "Issue #N created" (gh:issue-create's output format). If found, use it.
-3. **None** — skip the footer. Do NOT invent an issue number.
+First hit wins: (1) explicit argument (`/gh:commit 123` or "이슈 123번 연결"
+in the latest message); (2) recent conversation — scan the last ~10 messages
+for `#N` or "Issue #N created" (gh:issue-create's output); (3) none → skip
+the footer, do NOT invent an issue number.
 
 ## Step 3: Draft the Commit Message
 
 Read `references/commit-message-format.md` for the message template, HEREDOC
-pattern, and `Closes` / `Fixes` rules (`Refs` / `Resolves` forbidden). Match the repo's commit style
-derived from `git log`.
-
-**When there is no prior conversation context** (user ran `/gh-commit` on
-their own manual edits), derive intent from the diff itself:
-- File paths and function/alias names tell you *what* area changed.
-- Small additions (one new alias, one new config line) get a short subject
-  like `chore(aliases): add <name> shortcut` — explanation body can be omitted
-  (but mandatory footers like `Co-Authored-By` still apply per
-  `references/commit-message-format.md`).
-- Do NOT ask the user "what was the intent?" for obviously self-describing
-  changes. Only ask if the diff is ambiguous or spans unrelated areas.
+pattern, and `Closes`/`Fixes` rules (`Refs`/`Resolves` forbidden); match the
+`git log` style. With no conversation context (manual edits), derive intent
+from the diff — paths and names tell you *what* changed; small additions get
+a short subject like `chore(aliases): add <name> shortcut` (body optional,
+mandatory footers still apply). Only ask the user when the diff is ambiguous
+or spans unrelated areas.
 
 ## Step 4: Stage and Commit
 
-- Stage only files relevant to this commit. Prefer listing files by name over
-  `git add -A` / `git add .` to avoid sweeping in secrets or unrelated changes.
-- **Never stage files that look like secrets** (`.env`, `credentials.json`,
-  keys). If the diff touches such files, stop and warn the user.
-- **NEVER** use `--amend` unless the user explicitly asked.
-- **NEVER** use `--no-verify` / `--no-gpg-sign`. If a pre-commit hook fails,
-  fix the underlying issue, re-stage, and create a **new** commit.
+- Stage only relevant files by name — avoid `git add -A`/`.` to keep secrets
+  and unrelated changes out. **Never stage secret-looking files** (`.env`,
+  `credentials.json`, keys); if the diff touches such files, stop and warn.
+- **NEVER** `--amend` unless explicitly asked. **NEVER** `--no-verify` /
+  `--no-gpg-sign`: if a hook fails, fix the cause, re-stage, new commit.
 - See `references/commit-message-format.md` for the exact HEREDOC command.
 
-After `git commit` succeeds, emit the step-completion marker so the
-harness step-skip guard (`skill_completion_guard.py`, issue #753) can
-verify this step ran:
+After `git commit` succeeds, emit the step-completion marker so the step-skip
+guard (`skill_completion_guard.py`, issue #753) can verify this step ran:
 `printf '[step:gh-commit/stage-commit] OK\n'`.
 
 ## Step 5: AI Metrics + Sync Project Board Status
 
-Before syncing the project board, record AI metrics (soft-fail — warn on
-error, never block). Compute elapsed time and post a comment on the linked
-issue (only when an issue number was resolved in Step 2). When
-`GH_DISABLE_AI_METRICS=1`, skip the comment entirely — board sync below
-still runs (issue #399):
-
-```bash
-ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-# Token estimate: (char count of commit diff + message) / 4, rounded to nearest 500, min 1000
-# See gh-issue-create/references/metrics-helper.md "Token Estimation" for the formula
-TOKENS=$(( ( ($(git diff HEAD~1 | wc -c) / 4 / 500) + 1 ) * 500 ))
-[ "$TOKENS" -lt 1000 ] && TOKENS=1000
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
-else
-    gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
-      -X POST \
-      -f body="### AI Metrics — gh-commit
-
-| 항목 | 값 |
-|------|-----|
-| 커밋 | $COMMIT_SHA |
-| 구현 시간 (gh-issue-implement) | ~${IMPL_MIN:-?} min |
-| 커밋 시간 (gh-commit) | ~$ELAPSED min |
-| 토큰 | ~$TOKENS |
-
----
-<details>
-<summary>🤖 AI Metrics · 📊 ~$TOKENS tokens · 🤖 ~$ELAPSED min</summary>
-
-<!-- ai-metrics:gh-commit -->
-📊 ~$TOKENS tokens · 🤖 ~$ELAPSED min
-<!-- /ai-metrics:gh-commit -->
-
-</details>"
-fi
-```
-
-If no issue number exists, print the metrics to stdout only and skip the
-comment. On any API failure, print `[WARN] ai-metrics comment failed — continuing.`
-and proceed.
-
-Then sync the project board: if the commit message contains
-`Closes|Fixes #N` (i.e. the issue number resolved in Step 2 was
-actually written into the footer), push the linked Issue's project-board
-card to `In progress` — but only when its current Status is `Backlog`.
-The `--only-from Backlog` guard is mandatory: `/gh-commit` is invoked
-many times per branch (initial commit + follow-up fix commits), and after
-a PR opens the issue moves to `In review`; without the guard a follow-up
-fix commit would bounce it back to `In progress`.
-
-Skip the board sync entirely when no issue footer was written.
-
-```bash
-# helper-fallback NF-1 (#644): silent-skip when helper missing.
-# Defense-in-depth (#724): also detect "[ -r ] passes but function never
-# defined" (interactive-guard regression, partial sourcing, future rename).
-# Without this gate `_gh_project_status_sync` would expand to nothing,
-# `command not found` (rc 127) gets absorbed by `|| true`, and the board
-# sync silently no-ops — exactly the failure surfaced in #724.
-_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
-if [ -r "$_HELPER" ]; then
-    . "$_HELPER"
-    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
-        printf '[gh-commit] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
-            "$_HELPER" >&2
-    else
-        _gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog || true
-    fi
-fi
-```
-
-If the repo has no projectV2 board (auto-detected) the helper silently
-returns 0. Opt out with `GH_PROJECT_STATUS_SYNC=0`.
-
-Regardless of whether the metrics post happened, was skipped via
-`GH_DISABLE_AI_METRICS=1`, or the board sync ran or no-op'd, emit the
-step-completion marker so the step-skip guard recognizes Step 5 was
-visited:
+The ai-metrics comment POST (`GH_DISABLE_AI_METRICS` branch, token formula,
+soft-fail) follows
+[`references/ai-metrics-comment.md`](references/ai-metrics-comment.md). The
+project-board sync (`--only-from Backlog` guard, helper-fallback NF-1/#724
+defense) follows [`references/board-sync.md`](references/board-sync.md) —
+skip it entirely when no issue footer was written. After both blocks, emit
 `printf '[step:gh-commit/metrics-board-sync] OK\n'`.
 
 ## Step 6: Verify
 
-After commit succeeds, run `git status` and report:
-
-```
-Committed <short-hash>: <subject line>
-```
-
-If an issue was linked, mention the issue number on a second line.
-
-After printing the verify line, emit the report step-completion marker
+After commit succeeds, run `git status` and report
+`Committed <short-hash>: <subject line>` (mention the issue number on a
+second line if one was linked). Then emit the report step-completion marker
 so the step-skip guard recognizes the skill finished:
 `printf '[step:gh-commit/report] OK\n'`.
 
@@ -187,6 +96,4 @@ so the step-skip guard recognizes the skill finished:
 
 - One commit per invocation by default. If the diff is clearly two unrelated
   changes, ask the user whether to split before staging.
-- Never push. `/gh:pr` handles pushing.
-- Never create empty commits.
-- Never edit git config.
+- Never push (`/gh:pr` handles pushing), create empty commits, or edit git config.

--- a/claude/skills/gh-commit/references/ai-metrics-comment.md
+++ b/claude/skills/gh-commit/references/ai-metrics-comment.md
@@ -1,0 +1,48 @@
+# AI Metrics Comment — gh:commit Step 5 (first half)
+
+Record AI metrics as a soft-fail step: warn on error, never block the
+commit. Compute elapsed time and post a comment on the linked issue
+**only** when an issue number was resolved in Step 2. When
+`GH_DISABLE_AI_METRICS=1`, skip the comment entirely (board sync still
+runs — issue #399).
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+# Token estimate: (char count of commit diff + message) / 4, rounded to nearest 500, min 1000
+# See gh-issue-create/references/metrics-helper.md "Token Estimation" for the formula
+TOKENS=$(( ( ($(git diff HEAD~1 | wc -c) / 4 / 500) + 1 ) * 500 ))
+[ "$TOKENS" -lt 1000 ] && TOKENS=1000
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
+      -X POST \
+      -f body="### AI Metrics — gh-commit
+
+| 항목 | 값 |
+|------|-----|
+| 커밋 | $COMMIT_SHA |
+| 구현 시간 (gh-issue-implement) | ~${IMPL_MIN:-?} min |
+| 커밋 시간 (gh-commit) | ~$ELAPSED min |
+| 토큰 | ~$TOKENS |
+
+---
+<details>
+<summary>🤖 AI Metrics · 📊 ~$TOKENS tokens · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-commit -->
+📊 ~$TOKENS tokens · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-commit -->
+
+</details>"
+fi
+```
+
+If no issue number exists, print the metrics to stdout only and skip the
+comment. On any API failure, print
+`[WARN] ai-metrics comment failed — continuing.` and proceed.
+
+> The four emoji glyphs above (`🤖 📊 👤`) are the intended ai-metrics
+> footer visual design — CLAUDE.md SSOT exception (#317 F-2, PR #320,
+> #367). `gh-commit` is registered in
+> `skill-check/references/allowed-emoji-skills.txt` (#837).

--- a/claude/skills/gh-commit/references/board-sync.md
+++ b/claude/skills/gh-commit/references/board-sync.md
@@ -1,0 +1,41 @@
+# Board Sync — gh:commit Step 5 (second half)
+
+Sync the project board **only** when the commit message contains
+`Closes|Fixes #N` (i.e. the issue number resolved in Step 2 was actually
+written into the footer). Push the linked Issue's card to `In progress`,
+but only when its current Status is `Backlog`.
+
+The `--only-from Backlog` guard is mandatory: `/gh-commit` is invoked
+many times per branch (initial commit + follow-up fix commits), and after
+a PR opens the issue moves to `In review`; without the guard a follow-up
+fix commit would bounce it back to `In progress`.
+
+Skip the board sync entirely when no issue footer was written.
+
+```bash
+# helper-fallback NF-1 (#644): silent-skip when helper missing.
+# Defense-in-depth (#724): also detect "[ -r ] passes but function never
+# defined" (interactive-guard regression, partial sourcing, future rename).
+# Without this gate `_gh_project_status_sync` would expand to nothing,
+# `command not found` (rc 127) gets absorbed by `|| true`, and the board
+# sync silently no-ops — exactly the failure surfaced in #724.
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_project_status.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    if ! command -v _gh_project_status_sync >/dev/null 2>&1; then
+        printf '[gh-commit] %s sourced but _gh_project_status_sync undefined — board sync skipped (#724).\n' \
+            "$_HELPER" >&2
+    else
+        _gh_project_status_sync issue <ISSUE_NUMBER> "In progress" --only-from Backlog || true
+    fi
+fi
+```
+
+If the repo has no projectV2 board (auto-detected) the helper silently
+returns 0. Opt out with `GH_PROJECT_STATUS_SYNC=0`.
+
+After both blocks (metrics post + board sync), regardless of whether the
+post happened, was skipped via `GH_DISABLE_AI_METRICS=1`, or the board
+sync ran or no-op'd, emit the step-completion marker so the step-skip
+guard recognizes Step 5 was visited:
+`printf '[step:gh-commit/metrics-board-sync] OK\n'`.

--- a/claude/skills/gh-discussion-convert/SKILL.md
+++ b/claude/skills/gh-discussion-convert/SKILL.md
@@ -3,21 +3,24 @@ name: gh:discussion-convert
 description: >-
   Promote a decided `Ideas` Discussion into a tracked Issue by emulating
   GitHub's UI `Convert to issue` flow — creates the Issue with an
-  `Originated from discussion #<N>` backlink, posts a `Linked to issue
-  #<M>` comment back on the Discussion, locks the Discussion (reason
-  Resolved), closes it, and moves the new Issue card to `In progress`
-  on the project board. Use when the user runs /gh:discussion-convert,
-  /gh-discussion-convert, asks "Discussion #N 결정났으니 issue 로
-  승격", "RFC 결정 — convert 해줘", or wants the 4-step variant from
-  `discussions-policy.md` (#612) automated end-to-end. Sister skill of
-  [[gh-discussion-create]]; reuses the same `gh_discussion.sh` helpers.
-  Idempotent — re-running on a Discussion that was already converted
-  prints the existing issue URL and exits 0. Refuses non-`Ideas`
-  categories unless `--force-category` is set. Accepts `<N>` plus
-  optional `[remote]`, and `--no-comment` / `--no-lock` /
-  `--no-board-sync` / `--no-close` to skip the optional steps.
-  `-h`/`--help`/`help` prints usage.
+  `Originated from discussion #<N>` backlink, posts a `Linked to issue #<M>`
+  comment back on the Discussion, locks + closes it (reason Resolved), and
+  moves the new Issue card to `In progress`. Use when the user runs
+  /gh:discussion-convert, /gh-discussion-convert, asks "Discussion #N
+  결정났으니 issue 로 승격", "RFC 결정 — convert 해줘", or wants the 4-step
+  variant from `discussions-policy.md` (#612) automated end-to-end. Sister
+  skill of [[gh-discussion-create]]; reuses the same `gh_discussion.sh`
+  helpers. Idempotent — a re-run prints the existing issue URL and exits 0.
+  Refuses non-`Ideas` categories unless `--force-category` is set. Accepts
+  `<N>` plus optional `[remote]` and `--no-comment`/`--no-lock`/
+  `--no-board-sync`/`--no-close`; `-h`/`--help`/`help` prints usage.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "type conversion CLI wrap; 4-step UI emulation, bounded mutations"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:discussion-convert — Decided Ideas Discussion -> Issue
@@ -30,181 +33,68 @@ output its content verbatim, then stop. No API calls.
 ## Role
 
 Automate the 4-step `Discussion -> Issue` 변환 규약 from
-`docs/.ssot/discussions-policy.md` (#612). The native UI button is the
-only first-party path GitHub exposes — there is no public REST or
-GraphQL `convertDiscussion` mutation as of 2026-05. This skill emulates
-the UI path via four primitive mutations (`createIssue` +
-`addDiscussionComment` + `closeDiscussion` + `lockLockable`) plus a
-board-status sync, all wired together so the policy's bidirectional
-backlink invariant (operating principle #4) never gets dropped.
-
-Print the new Issue URL at the end. Idempotent — see Step 4.
+`docs/.ssot/discussions-policy.md` (#612). GitHub exposes no public
+`convertDiscussion` mutation, so this skill emulates the UI path via four
+primitive mutations (createIssue + comment + close + lock) plus a board
+sync, keeping the bidirectional-backlink invariant (principle #4). Print
+the new Issue URL; idempotent (Step 4).
 
 ## Options
 
-| Argument | Description | Default |
-|----------|-------------|---------|
-| `<discussion-number>` (positional, required) | Positive integer. | — |
-| `[remote]` (positional) | Git remote whose repo owns the Discussion + new Issue. | `origin` |
-| `--no-comment` | Skip the `Linked to issue #<M>` backlink comment on the Discussion. | off |
-| `--no-lock` | Skip the `Lock conversation` step. | off |
-| `--no-close` | Skip the close step (Discussion stays open). | off |
-| `--no-board-sync` | Skip the `In progress` Status transition on the project board. | off |
-| `--force-category` | Bypass the Step 3 `Ideas`-only guard. | off |
-| `GH_DISABLE_AI_METRICS=1` (env) | Suppress ai-metrics handling (parity with [[gh-discussion-create]]). | off |
-| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+Arguments (`<discussion-number>`, `[remote]`, the four `--no-*` skip flags,
+`--force-category`, `-h`/`--help`/`help`) →
+[`references/options.md`](references/options.md).
 
 ## Step 1: Detect Repo Context
 
-Record `START_TS=$(date +%s)` for elapsed-time reporting. Parse the
-positional args and flags above. Confirm we are in a git repo
-(`git rev-parse --show-toplevel`) and resolve
-`TARGET_REPO=<owner>/<repo>` via the chosen remote — substeps in
-[`references/repo-resolution.md`](references/repo-resolution.md).
-Never silently fall back to `origin` when the user-supplied remote
-is missing.
+Record `START_TS=$(date +%s)` for elapsed-time reporting. Parse args, confirm
+a git repo, and resolve `TARGET_REPO` via the chosen remote — substeps in
+[`references/repo-resolution.md`](references/repo-resolution.md). No silent
+`origin` fallback on a missing remote.
 
 ## Step 2: Fetch the Discussion
 
 Source `shell-common/functions/gh_discussion.sh` and call
-`_gh_discussion_fetch "$_owner" "$_repo" "$N"`. Capture the JSON to
-a temp file and read these fields with `jq`:
-
-- `.id` (node ID — needed for comment / close / lock mutations)
-- `.number`, `.title`, `.body`, `.url`
-- `.category`, `.closed`, `.locked`
-
-Fetch failure -> abort with the helper's stderr trace.
+`_gh_discussion_fetch "$_owner" "$_repo" "$N"`. Read with `jq`: `.id` (node
+ID for comment/close/lock), `.number`, `.title`, `.body`, `.url`,
+`.category`, `.closed`, `.locked`. Fetch failure -> abort with stderr.
 
 ## Step 3: Category Guard
 
-If `.category != "Ideas"` and `--force-category` is not set, refuse:
+If `.category != "Ideas"` and `--force-category` is not set, refuse with
+the message in [`references/error-cases.md`](references/error-cases.md),
+exit 1, and skip Steps 4-9. Principle #2 ("결정되면 즉시 convert") targets
+only the Ideas bucket; other categories have different lifecycles and must
+not be silently coerced into the tracker.
 
-```
-Discussion #<N> 카테고리가 '<X>' 입니다 — 정책상 Ideas 만 변환합니다.
-근거: docs/.ssot/discussions-policy.md -> "운영 원칙 4 개조" #2.
-강제 변환하려면: /gh-discussion-convert <N> --force-category
-```
+## Step 4: Idempotency Check (BEFORE any mutation)
 
-Exit 1. Skip Steps 4-8 entirely. Operating principle #2 ("결정되면
-즉시 Issue convert") refers specifically to the Ideas bucket; other
-categories have different lifecycles (Announcements = transient,
-Lessons = Discussion-first, Q&A = answered-not-converted) and must
-not be silently coerced into the Issue tracker.
-
-## Step 4: Idempotency Check
-
-Search for an Issue whose body already contains the backlink marker:
-
-```bash
-EXISTING=$(gh issue list --repo "$TARGET_REPO" --state all --search \
-    "in:body \"Originated from discussion #${N}\"" \
-    --json number,url --limit 1 --jq '.[0].url // empty')
-```
-
-`// empty` is load-bearing: without it, `jq '.[0].url'` on an empty
-result array prints the literal string `null`, which `[ -n "$EXISTING" ]`
-treats as non-empty — the skill would then claim "already converted"
-on every first invocation. With `// empty`, `$EXISTING` is the empty
-string when no match exists, so the standard `[ -n ... ]` test in
-`convert-cmd.md` Step 4 works correctly.
-
-If `$EXISTING` is non-empty, print the existing issue URL and exit 0
-with `[OK] Discussion #<N> already converted to <issue-url>`. This
-preserves NF-1 (idempotency) even when the previous run posted a
-comment / locked / closed and the user re-invokes the skill.
-
-Step 4 happens BEFORE any mutation; a re-run never creates a second
-issue.
+Search for an Issue whose body already contains the backlink marker
+`Originated from discussion #${N}`. The full `gh issue list` command and the
+load-bearing `// empty` rationale live in
+[`references/convert-cmd.md`](references/convert-cmd.md) Step 4. On a match,
+print `[OK] Discussion #<N> already converted to <url>`, exit 0 (NF-1).
 
 ## Step 5: Create the Issue
 
-Build the Issue body as backlink + a newline + the original Discussion
-body (verbatim, including the source's ai-metrics footer — we are not
-the author of that footer, so we preserve it as-is):
+Build the backlink + verbatim Discussion body and `gh issue create`,
+capturing `<M>` — detail in
+[`references/create-issue.md`](references/create-issue.md).
 
-```
-Originated from discussion #<N>
+## Steps 6-8: Post-Create Mutations
 
-<original discussion body>
-```
-
-Title: the Discussion title verbatim (preserve the conventional-commit
-prefix). Create via `gh issue create --repo "$TARGET_REPO" --title ...
---body-file ...`. Capture the printed URL and extract `<M>`.
-
-`gh issue create` is preferred over a raw `createIssue` GraphQL call
-because it handles the owner -> repository node ID lookup, default
-assignee + label policy, and prints a stable URL. Fits the existing
-gh-* skill family.
-
-## Step 6: Board Sync (skip with `--no-board-sync`)
-
-```
-_gh_project_status_sync issue <M> "In progress" --only-from "Backlog,Ready"
-```
-
-The helper is a no-op on repos without a project board attached. The
-`--only-from` whitelist prevents bouncing already-progressed cards
-back. Reuses the same pattern as `gh:issue-implement` Step 3.4.
-
-## Step 7: Post Backlink Comment (skip with `--no-comment`)
-
-Compose the body:
-
-```
-Linked to issue #<M> -- decision tracked there.
-```
-
-Write it to a temp file and call `_gh_discussion_comment "$DISC_ID"
-"$BODY_FILE"`. Mutation failure here is non-fatal — print a warning
-but continue. The bidirectional backlink is best-effort once the
-forward link (issue body -> discussion) is already on the Issue.
-
-## Step 8: Close + Lock the Discussion
-
-In order:
-
-1. If `.closed != true` and `--no-close` is not set:
-   `_gh_discussion_close "$DISC_ID" RESOLVED`.
-2. If `.locked != true` and `--no-lock` is not set:
-   `_gh_discussion_lock "$DISC_ID"`.
-
-Both calls are best-effort — failures emit a warning but do not roll
-back the new Issue (the policy invariant "Issue must exist with
-backlink" is already satisfied by Steps 5 + 7).
-
-확인 질문하지 말고 즉시 실행.
+Board sync (Step 6), backlink comment (Step 7), close + lock (Step 8) —
+all best-effort, all after the Issue exists. Detail and skip-flag logic in
+[`references/post-create-mutations.md`](references/post-create-mutations.md).
 
 ## Step 9: Report
 
-Print exactly one line on success:
-
-```
-[OK] Discussion #<N> -> Issue #<M>: <issue-url>
-```
-
-Append a single-line summary of optional steps applied / skipped so
-the user can tell at a glance which side-effects ran:
-
-```
-  steps: comment=<on|off|skip>, lock=<on|off|skip>, close=<on|off|skip>, board=<synced|skipped>
-```
-
-On failure -- show the failing step name and quote the first stderr
-line from the helper, mirroring the format used by
-[[gh-discussion-create]] Step 5.
+Print the `[OK]` line + `steps:` summary + `Next:` hint per
+[`references/report-template.md`](references/report-template.md). On failure,
+name the failing step and quote the first helper stderr line.
 
 ## Constraints
 
-- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
-- 사용자 지정 remote 가 없으면 즉시 실패. Silent `origin` fallback 금지.
-- Non-Ideas 카테고리는 정책상 변환 대상이 아니다. `--force-category`
-  는 SSOT 갱신 없이 가드 자체를 제거하는 것이 아니라 1 회용 우회 전용.
-- Steps 5 (createIssue) 이후 mutation 들 (6/7/8) 은 best-effort.
-  하나 실패해도 새 Issue 는 이미 backlink 를 가진 채 존재하므로
-  롤백 시도 금지 — 사람이 보강하도록 경고만 출력한다.
-- 두 번 호출해도 새 Issue 가 두 개 생기지 않는다 (Step 4 idempotency
-  check). 단, Discussion 본문이 backlink 마커 인덱싱 전에 호출되면
-  중복이 가능 — 그래도 인간 검토가 마지막 방어선.
-- "should I convert?" 같은 확인 질문 금지. Skill 실행이 컨펌이다.
+Operating invariants (always `--repo`, fail on missing remote, Ideas-only
+guard, best-effort post-create mutations, idempotency) →
+[`references/constraints.md`](references/constraints.md).

--- a/claude/skills/gh-discussion-convert/references/constraints.md
+++ b/claude/skills/gh-discussion-convert/references/constraints.md
@@ -1,0 +1,13 @@
+# Constraints — gh:discussion-convert operating rules
+
+- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
+- 사용자 지정 remote 가 없으면 즉시 실패. Silent `origin` fallback 금지.
+- Non-Ideas 카테고리는 정책상 변환 대상이 아니다. `--force-category`
+  는 SSOT 갱신 없이 가드 자체를 제거하는 것이 아니라 1 회용 우회 전용.
+- Steps 5 (createIssue) 이후 mutation 들 (6/7/8) 은 best-effort.
+  하나 실패해도 새 Issue 는 이미 backlink 를 가진 채 존재하므로
+  롤백 시도 금지 — 사람이 보강하도록 경고만 출력한다.
+- 두 번 호출해도 새 Issue 가 두 개 생기지 않는다 (Step 4 idempotency
+  check). 단, Discussion 본문이 backlink 마커 인덱싱 전에 호출되면
+  중복이 가능 — 그래도 인간 검토가 마지막 방어선.
+- "should I convert?" 같은 확인 질문 금지. Skill 실행이 컨펌이다.

--- a/claude/skills/gh-discussion-convert/references/create-issue.md
+++ b/claude/skills/gh-discussion-convert/references/create-issue.md
@@ -1,0 +1,20 @@
+# Create the Issue — gh:discussion-convert Step 5
+
+Build the Issue body as backlink + a newline + the original Discussion
+body (verbatim, including the source's ai-metrics footer — we are not
+the author of that footer, so we preserve it as-is):
+
+```
+Originated from discussion #<N>
+
+<original discussion body>
+```
+
+Title: the Discussion title verbatim (preserve the conventional-commit
+prefix). Create via `gh issue create --repo "$TARGET_REPO" --title ...
+--body-file ...`. Capture the printed URL and extract `<M>`.
+
+`gh issue create` is preferred over a raw `createIssue` GraphQL call
+because it handles the owner -> repository node ID lookup, default
+assignee + label policy, and prints a stable URL. Fits the existing
+gh-* skill family.

--- a/claude/skills/gh-discussion-convert/references/error-cases.md
+++ b/claude/skills/gh-discussion-convert/references/error-cases.md
@@ -24,14 +24,22 @@ into the wrong repo (mirrors `gh-discussion-create` failure rule).
 
 ## Step 3 — Category guard
 
-| Trigger | Output | Exit |
-|---------|--------|------|
-| Discussion category is not `Ideas` and `--force-category` not set | `Discussion #N 카테고리가 '<X>' 입니다 — 정책상 Ideas 만 변환합니다. ...` (multiline refusal per SKILL.md Step 3) | 1 |
+When `.category != "Ideas"` and `--force-category` is not set, print this
+multiline refusal verbatim and exit 1 (skip Steps 4-9):
+
+```
+Discussion #<N> 카테고리가 '<X>' 입니다 — 정책상 Ideas 만 변환합니다.
+근거: docs/.ssot/discussions-policy.md -> "운영 원칙 4 개조" #2.
+강제 변환하려면: /gh-discussion-convert <N> --force-category
+```
 
 The refusal text intentionally cites
 `docs/.ssot/discussions-policy.md` operating principle #2 so the
 audit trail explains the policy decision, not just the mechanical
-rejection.
+rejection. Operating principle #2 ("결정되면 즉시 Issue convert") refers
+specifically to the Ideas bucket; other categories have different
+lifecycles (Announcements = transient, Lessons = Discussion-first, Q&A =
+answered-not-converted) and must not be silently coerced into the tracker.
 
 ## Step 4 — Idempotency
 

--- a/claude/skills/gh-discussion-convert/references/options.md
+++ b/claude/skills/gh-discussion-convert/references/options.md
@@ -1,0 +1,13 @@
+# Options — gh:discussion-convert arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `<discussion-number>` (positional, required) | Positive integer. | — |
+| `[remote]` (positional) | Git remote whose repo owns the Discussion + new Issue. | `origin` |
+| `--no-comment` | Skip the `Linked to issue #<M>` backlink comment on the Discussion. | off |
+| `--no-lock` | Skip the `Lock conversation` step. | off |
+| `--no-close` | Skip the close step (Discussion stays open). | off |
+| `--no-board-sync` | Skip the `In progress` Status transition on the project board. | off |
+| `--force-category` | Bypass the Step 3 `Ideas`-only guard. | off |
+| `GH_DISABLE_AI_METRICS=1` (env) | Suppress ai-metrics handling (parity with [[gh-discussion-create]]). | off |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |

--- a/claude/skills/gh-discussion-convert/references/post-create-mutations.md
+++ b/claude/skills/gh-discussion-convert/references/post-create-mutations.md
@@ -1,0 +1,40 @@
+# Post-Create Mutations — gh:discussion-convert Steps 6-8
+
+All three run **after** the Issue exists (Step 5). Each is best-effort:
+a failure emits a warning but never rolls back the new Issue — the policy
+invariant "Issue must exist with backlink" is already satisfied.
+
+## Step 6: Board Sync (skip with `--no-board-sync`)
+
+```
+_gh_project_status_sync issue <M> "In progress" --only-from "Backlog,Ready"
+```
+
+The helper is a no-op on repos without a project board attached. The
+`--only-from` whitelist prevents bouncing already-progressed cards back.
+Reuses the same pattern as `gh:issue-implement` Step 3.4.
+
+## Step 7: Post Backlink Comment (skip with `--no-comment`)
+
+Compose the body:
+
+```
+Linked to issue #<M> -- decision tracked there.
+```
+
+Write it to a temp file and call `_gh_discussion_comment "$DISC_ID"
+"$BODY_FILE"`. Mutation failure here is non-fatal — print a warning but
+continue. The bidirectional backlink is best-effort once the forward link
+(issue body -> discussion) is already on the Issue.
+
+## Step 8: Close + Lock the Discussion
+
+In order:
+
+1. If `.closed != true` and `--no-close` is not set:
+   `_gh_discussion_close "$DISC_ID" RESOLVED`.
+2. If `.locked != true` and `--no-lock` is not set:
+   `_gh_discussion_lock "$DISC_ID"`.
+
+Both calls are best-effort — failures emit a warning but do not roll
+back the new Issue. 확인 질문하지 말고 즉시 실행.

--- a/claude/skills/gh-discussion-convert/references/report-template.md
+++ b/claude/skills/gh-discussion-convert/references/report-template.md
@@ -1,0 +1,15 @@
+# Report Template — gh:discussion-convert Step 9
+
+Print exactly one line on success, then the steps summary and the
+follow-up hint:
+
+```
+[OK] Discussion #<N> -> Issue #<M>: <issue-url>
+  steps: comment=<on|off|skip>, lock=<on|off|skip>, close=<on|off|skip>, board=<synced|skipped>
+Next: /gh-issue-implement <M>
+```
+
+The `steps:` line lets the user tell at a glance which optional
+side-effects ran. On failure — show the failing step name and quote the
+first stderr line from the helper, mirroring the format used by
+[[gh-discussion-create]] Step 5.

--- a/claude/skills/gh-discussion-create/SKILL.md
+++ b/claude/skills/gh-discussion-create/SKILL.md
@@ -5,18 +5,20 @@ description: >-
   `Ideas`, RFC-shaped body). Use when the user runs /gh:discussion-create,
   /gh-discussion-create, asks "이 대화 RFC 로 등록", "Ideas Discussion 으로
   남겨", "이 토론 깃허브 디스커션으로", or wants the chat preserved as a
-  pre-decision RFC instead of a to-do issue. Drafts an Open-Questions-
-  forward body (TL;DR + Why + Options + Alternatives + Open Questions),
-  posts it via the `createDiscussion` GraphQL mutation, and prints the
-  Discussion URL. Sister skill of [[gh-issue-create]] — same conversation
-  capture quality, different lifecycle target. Refuses when the
-  conversation already represents a decided to-do unless
-  `--force-discussion` is set; suggests `/gh-issue-create` instead.
-  Accepts an optional remote name (e.g. `/gh-discussion-create upstream`)
-  to target a different remote's repo, an optional `[category]` flag to
-  pick `Ideas` (default) / `Q&A` / `Announcements` / `Lessons`, and
-  `-h`/`--help`/`help` to print usage.
+  pre-decision RFC instead of a to-do issue. Drafts an Open-Questions-forward
+  body and posts it via the `createDiscussion` GraphQL mutation. Sister skill
+  of [[gh-issue-create]] — same conversation capture, different lifecycle.
+  Refuses when the conversation is already a decided to-do unless
+  `--force-discussion` is set; suggests `/gh-issue-create` instead. Accepts an
+  optional remote name and a `[category]` (`Ideas` / `Q&A` / `Announcements` /
+  `Lessons`); `-h`/`--help`/`help` prints usage.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "discussion creation wrap; bounded GraphQL mutation with RFC body skeleton"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:discussion-create — Conversation -> Ideas Discussion
@@ -28,134 +30,71 @@ output its content verbatim, then stop. No API calls.
 
 ## Role
 
-Convert the current chat into a well-structured GitHub Discussion on the
-target repo, defaulting to the `Ideas` (RFC) category. Execute
-immediately without confirmation once the routing guard passes. Print
-only the Discussion URL at the end.
-
-This is the sister skill of `gh:issue-create`: same "preserve detail,
-do not over-compress" contract, but the body emphasises **Open
-Questions** instead of Acceptance Criteria, and the lifecycle target is
-the Discussions forum — not the Issues to-do tracker.
+Convert the chat into a GitHub Discussion (default `Ideas`/RFC), executing
+once the routing guard passes and printing only the URL. Sister of
+`gh:issue-create` (same "preserve detail" contract), emphasising **Open Questions** over AC.
 
 ## Options
 
-| Argument | Description | Default |
-|----------|-------------|---------|
-| `[remote]` (positional) | Git remote whose repo will own the Discussion. | `origin` |
-| `[category]` (positional) | Discussion category. Case-insensitive match against the repo's category list. Allowed: `Ideas`, `Q&A`, `Announcements`, `Lessons`. | `Ideas` |
-| `--force-discussion` | Bypass the routing guard (Step 2.1) when you know the chat is RFC-shaped despite a decided tone. | off |
-| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
-| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
-
-The two positional args are order-insensitive when one is clearly a
-category (e.g. `Q&A`, `Ideas`); otherwise the first non-flag positional
-is treated as the remote.
+Arguments (positional `[remote]`/`[category]`, `--force-discussion`,
+`GH_DISABLE_AI_METRICS`, `-h`/`--help`/`help`) →
+[`references/options.md`](references/options.md).
 
 ## Step 1: Detect Repo Context
 
-Record `START_TS=$(date +%s)` for the ai-metrics footer in Step 4.
-Parse the positional args and flags above. Confirm we are in a git repo
-(`git rev-parse --show-toplevel`) and resolve `TARGET_REPO=<owner>/<repo>`
-via the chosen remote — substeps in
-[`references/repo-resolution.md`](references/repo-resolution.md).
-Never silently fall back to `origin` when the user-supplied remote is
-missing.
+Record `START_TS=$(date +%s)` for Step 4. Parse args, confirm a git repo,
+resolve `TARGET_REPO=<owner>/<repo>` via the remote — substeps in
+[`references/repo-resolution.md`](references/repo-resolution.md). No silent `origin` fallback on a missing remote.
 
 ## Step 2: Classify the Conversation
 
-Pick exactly one category. Default to `Ideas`. The four categories and
-when to pick each are listed in
-[`references/category-table.md`](references/category-table.md), which
-mirrors the SSOT in `docs/.ssot/discussions-policy.md`.
-
-If the user passed `[category]` explicitly, honour it — but still run
-the routing guard in Step 2.1; user intent does not bypass the
-"decided to-do" warning, only the body shape changes.
+Pick exactly one category (default `Ideas`) per
+[`references/category-table.md`](references/category-table.md) (mirrors the
+discussions-policy SSOT). An explicit `[category]` still runs the Step 2.1
+guard — body shape changes, not the check.
 
 ## Step 2.1: Routing Guard (Issue-vs-Discussion)
 
-Per the SSOT routing decision tree (operating principle #1: "Issue is
-default"), reject the chat when it represents a **decided to-do** —
-the right destination is `/gh-issue-create`, not a Discussion. Apply
-the trigger signals in
-[`references/scope-guard.md`](references/scope-guard.md):
-
-- "decided to-do" signals matched -> stop with the suggestion in
-  `scope-guard.md` -> "Refusal format". The user can re-run with
-  `--force-discussion` to override.
-- ambiguous-noun-list / ≥3-component-mix signals matched -> emit the
-  same 1~2 line clarification as `gh:issue-create`'s clarification
-  guide; do not call the mutation until the user answers.
-- Otherwise -> no-op, continue to Step 3.
-
-This is the load-bearing requirement F-3 + F-4 from issue #617 — never
-disable it without a SSOT update.
+Per the SSOT routing tree (principle #1 "Issue is default"), apply the
+trigger signals in [`references/scope-guard.md`](references/scope-guard.md):
+a **decided to-do** -> stop with that file's "Refusal format" (destination
+`/gh-issue-create`; override with `--force-discussion`); ambiguous-noun-list
+/ ≥3-component-mix -> emit the same 1~2 line clarification as
+`gh:issue-create` and wait. Load-bearing requirement F-3 + F-4 (issue #617)
+— never disable without a SSOT update.
 
 ## Step 3: Draft the Discussion Body
 
 Use the body skeleton in
-[`references/rfc-template.md`](references/rfc-template.md). Write in
-the conversation language (Korean chat -> Korean body). **Do NOT
-over-compress** — preserve file paths, command outputs, decisions,
-trade-offs, and the discussion log. A 200-line RFC is fine, just like
-a 200-line `feat` issue is fine.
-
-For non-`Ideas` categories, swap the template per
-`references/rfc-template.md` -> "Category variants".
+[`references/rfc-template.md`](references/rfc-template.md), in the
+conversation language. **Do NOT over-compress** — preserve file paths,
+outputs, decisions, trade-offs, and the discussion log (a 200-line RFC is
+fine). For non-`Ideas` categories, swap per that file's "Category variants".
 
 ## Step 3.5: Compute AI Metrics
 
 Read `gh-issue-create`'s
 [`references/metrics-baseline.md`](../gh-issue-create/references/metrics-baseline.md)
-and bind `TOKENS`, `HUMAN_H`, `ELAPSED` for Step 4. Inputs: `START_TS`
-from Step 1, the chosen category, the drafted title + body. For
-`Ideas` (RFC), treat the size heuristic the same way as `feat` —
-small / medium / large by component count and architectural footprint.
+and bind `TOKENS`, `HUMAN_H`, `ELAPSED` for Step 4 (inputs: `START_TS`,
+category, title + body; for `Ideas`, size like `feat`).
 
 ## Step 4: Create the Discussion
 
-Source the helper and call the three lookups + mutation in order. The
-helper file lives at
-`shell-common/functions/gh_discussion.sh`.
-Full bash block in
-[`references/create-cmd.md`](references/create-cmd.md) — paste it
-verbatim. It handles the `mktemp` body file, the
-`GH_DISABLE_AI_METRICS=1` short-circuit (issue #399 parity), the
-ai-metrics footer printf, and the three GraphQL calls
-(`_gh_discussion_repo_id`, `_gh_discussion_category_id`,
-`_gh_discussion_create`).
-
+Source `shell-common/functions/gh_discussion.sh` and paste the full bash
+block in [`references/create-cmd.md`](references/create-cmd.md) verbatim — it
+handles the `mktemp` body file, the `GH_DISABLE_AI_METRICS=1` short-circuit
+(#399 parity), the ai-metrics footer printf, and the three GraphQL calls.
 확인 질문하지 말고 즉시 실행.
 
 ## Step 5: Report
 
-성공 시:
-
-```
-[OK] Discussion (<category>): <url>
-Next: /gh-discussion-convert <discussion-number>   # when decision lands
-```
-
-실패 시 — 첫 stderr 줄을 그대로 인용:
-
-```
-[FAIL] <gh stderr first line>
-Next: <recovery — e.g. enable Discussions in repo settings, gh auth refresh>
-```
-
-Routing-guard refusal (Step 2.1) prints its own message from
-`references/scope-guard.md` and skips Steps 3-5.
+Print the `[OK]` / `[FAIL]` block + `Next:` hint per
+[`references/report-template.md`](references/report-template.md). A
+routing-guard refusal (Step 2.1) prints its own message and skips Steps 3-5.
 
 ## Constraints
 
-- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
-- 사용자 지정 remote 가 없으면 즉시 실패 (gh:issue-create 와 동일).
-- `Ideas` 외 카테고리에서도 routing guard 는 동일하게 작동. 본문 골격만
-  교체된다.
-- discussion log 를 2~3 줄로 압축 금지 — Discussion 은 future-self 검색의
-  1 차 SSOT 다.
-- `--force-discussion` 은 가드 우회 전용. SSOT 업데이트 없이 가드 자체를
-  제거하지 말 것.
-- "should I create it?" 같은 확인 질문 금지.
-- 카테고리 ID 캐시 도입 금지 — `references/cache-decision.md` 참고.
+Operating invariants (always `--repo`, fail on missing remote, guard active
+for all categories, no log over-compression, `--force-discussion`
+bypass-only, no confirmation prompt, no category-ID cache) live in
+[`references/constraints.md`](references/constraints.md).

--- a/claude/skills/gh-discussion-create/references/constraints.md
+++ b/claude/skills/gh-discussion-create/references/constraints.md
@@ -1,0 +1,12 @@
+# Constraints — gh:discussion-create operating rules
+
+- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
+- 사용자 지정 remote 가 없으면 즉시 실패 (gh:issue-create 와 동일).
+- `Ideas` 외 카테고리에서도 routing guard 는 동일하게 작동. 본문 골격만
+  교체된다.
+- discussion log 를 2~3 줄로 압축 금지 — Discussion 은 future-self 검색의
+  1 차 SSOT 다.
+- `--force-discussion` 은 가드 우회 전용. SSOT 업데이트 없이 가드 자체를
+  제거하지 말 것.
+- "should I create it?" 같은 확인 질문 금지.
+- 카테고리 ID 캐시 도입 금지 — `references/cache-decision.md` 참고.

--- a/claude/skills/gh-discussion-create/references/options.md
+++ b/claude/skills/gh-discussion-create/references/options.md
@@ -1,0 +1,13 @@
+# Options — gh:discussion-create arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `[remote]` (positional) | Git remote whose repo will own the Discussion. | `origin` |
+| `[category]` (positional) | Discussion category. Case-insensitive match against the repo's category list. Allowed: `Ideas`, `Q&A`, `Announcements`, `Lessons`. | `Ideas` |
+| `--force-discussion` | Bypass the routing guard (Step 2.1) when you know the chat is RFC-shaped despite a decided tone. | off |
+| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+
+The two positional args are order-insensitive when one is clearly a
+category (e.g. `Q&A`, `Ideas`); otherwise the first non-flag positional
+is treated as the remote.

--- a/claude/skills/gh-discussion-create/references/report-template.md
+++ b/claude/skills/gh-discussion-create/references/report-template.md
@@ -1,0 +1,18 @@
+# Report Template — gh:discussion-create Step 5
+
+On success:
+
+```
+[OK] Discussion (<category>): <url>
+Next: /gh-discussion-convert <discussion-number>   # when decision lands
+```
+
+On failure — quote the first stderr line verbatim:
+
+```
+[FAIL] <gh stderr first line>
+Next: <recovery — e.g. enable Discussions in repo settings, gh auth refresh>
+```
+
+Routing-guard refusal (Step 2.1) prints its own message from
+`references/scope-guard.md` and skips Steps 3-5.


### PR DESCRIPTION
## 배경

NEEDS WORK 25개 일괄 처리 (#862) 의 **PR-NW-5** 묶음 — Line-count 추출 대상
4 스킬을 `references/` 분리로 SKILL.md ≤100 라인으로 줄이고, Check 12
`metadata.model_recommendation` (tier=haiku) 블록을 추가한다.

## 변경 스킬

| 스킬 | 이슈 | Before | After | 처리 |
|------|------|--------|-------|------|
| gh-add-ai-metrics | #835 | 159L | 100L | Constraints → `references/constraints.md`, Step 3/4 ref 포인터 축약 |
| gh-commit | #837 | 192L | 99L | Step 5 → `references/ai-metrics-comment.md` + `references/board-sync.md` |
| gh-discussion-create | #844 | 161L | 100L | Options/Report/Constraints → `references/` |
| gh-discussion-convert | #843 | 210L | 100L | Step 5/6-8/9/Options/Constraints → `references/`, Step 9 `Next:` 힌트 추가 |

## 검증

- 4 스킬 모두 SKILL.md **≤100 라인** (Check 1 PASS).
- 모든 `references/` 링크 resolve (cross-skill 포함).
- `metadata.model_recommendation` schema 유효 — `tier`/`reason`/`claude`/`non_claude` (Check 12 PASS, tier=haiku).
- SKILL.md 본문 emoji 없음 (Check 11). gh-commit·gh-discussion-create 의 ai-metrics 글리프는 PR-NW-1 에서 allowlist 등재 완료 → N/A.
- gh-discussion-convert Step 9 에 `Next: /gh-issue-implement <M>` 후속 힌트 추가 (#843 Check 10 WARN 해소).
- 정보 무손실: category-guard refusal 전문은 `error-cases.md` 로, idempotency `// empty` 근거는 `convert-cmd.md` 로 보존.
- `gh_disable_ai_metrics.bats` doc-guard 통과 — gh-commit 가드 literal 은 `references/ai-metrics-comment.md` 에 존재, gh-add-ai-metrics 는 `GH_DISABLE_AI_METRICS` 미포함(backfill exempt) 유지.

기존 동작 무변경 — 본문 축약 + 추출만이며 functional change 아님.

Closes #835
Closes #837
Closes #843
Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)