### PR TITLE
refactor(skills): #862 PR-NW-8 잔여 2 스킬 NEEDS WORK 해소 (emoji FAIL + Check 12)

### DIFF
--- a/claude/skills/gh-pr-merge-emergency/SKILL.md
+++ b/claude/skills/gh-pr-merge-emergency/SKILL.md
@@ -63,10 +63,10 @@ Never auto-proceed.
 
 Order matters — comment first so the audit survives branch deletion. (1) Post
 the "PR audit comment" from `references/audit-templates.md`, capturing its URL
-for Step 7. (2) `gh pr merge <N> --admin --squash --delete-branch` (flag
-rationale in the same file); "Must have admin rights" → **stop**, never fall
-back to `--merge`/`--rebase`. (3) Capture the merge SHA via
-`gh pr view <N> --json mergeCommit -q .mergeCommit.oid`.
+for Step 7. (2) `gh pr merge <N> --repo "$TARGET_REPO" --admin --squash
+--delete-branch`; "Must have admin rights" → **stop**, never fall back to
+`--merge`/`--rebase`. (3) `gh pr view <N> --repo "$TARGET_REPO" --json
+mergeCommit -q .mergeCommit.oid` for the merge SHA (flag rationale: same file).
 
 ## Step 5: Create Post-Merge Incident Issue
 

--- a/claude/skills/gh-pr-merge-emergency/SKILL.md
+++ b/claude/skills/gh-pr-merge-emergency/SKILL.md
@@ -12,6 +12,12 @@ description: >-
   `-h`/`--help`/`help` to print usage. Project-agnostic; works in any repo
   where the caller has admin/merge permission.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "admin bypass + audit trail (PR comment + incident issue); requires user confirmation & substantive reason validation"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-merge-emergency — Admin-Bypass Merge with Audit Trail
@@ -27,75 +33,56 @@ Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
 
 Positional args: `<PR> <reason> [remote]`.
 
-- `PR` — number (required). If omitted, try `gh pr view --json number` on
-  current branch; else stop with a usage pointer.
-- `reason` — **required**, ≥10 chars, must reference an incident/ticket
-  ID or concrete user impact. Vague reasons (`"urgent"`, `"fix"`) → refuse.
-  Examples in `references/help.md`.
-- `remote` — default `origin`. Resolve `TARGET_REPO` via
-  `git remote get-url`; missing → `git remote -v` and stop.
+- `PR` — number (required). Omitted → `gh pr view --json number` on current
+  branch; else stop with a usage pointer.
+- `reason` — **required**, ≥10 chars, referencing an incident/ticket ID or
+  concrete user impact. Vague reasons (`"urgent"`, `"fix"`) → refuse. Examples
+  in `references/help.md`.
+- `remote` — default `origin`. Resolve `TARGET_REPO` via `git remote get-url`;
+  missing → `git remote -v` and stop.
 
 Capture `ME=$(gh api user -q .login)`, `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)`.
 
 ## Step 2: Pre-flight Safety Gate (parallel)
 
-Fetch in parallel; evaluate stops **before** touching merge:
-
-- PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,baseRefName,headRefName`
-- `gh pr checks <N> --repo $TARGET_REPO --required`
+Fetch in parallel, evaluate stops **before** touching merge: PR JSON
+(`number,title,author,state,isDraft,mergeable,mergeStateStatus,baseRefName,headRefName`)
+and `gh pr checks <N> --repo $TARGET_REPO --required`.
 
 **Hard stops**: `state != OPEN`, draft, conflicts, or failing/pending required
-checks. Emergency bypasses **approval**, not **CI**.
-
-**Soft warnings**: base `BEHIND`; no approving review.
+checks — emergency bypasses **approval**, not **CI**. **Soft warnings**: base
+`BEHIND`; no approving review.
 
 ## Step 3: Confirm with the User
 
-Print the planned action (repo, PR, author, base/head, CI summary, reason)
-followed by `Proceed? (yes/ok/진행/머지)`. Exact prompt template:
-`references/audit-templates.md`. Never auto-proceed.
+Print the planned action (repo, PR, author, base/head, CI summary, reason) then
+`Proceed? (yes/ok/진행/머지)`. Exact prompt: `references/audit-templates.md`.
+Never auto-proceed.
 
 ## Step 4: Audit Comment + Admin Merge
 
-Order matters — comment first so the audit survives branch deletion.
-
-1. `gh pr comment <N> --repo "$TARGET_REPO"` with the "PR audit comment"
-   body from `references/audit-templates.md`; capture the comment URL for
-   Step 7.
-2. `gh pr merge <N> --repo "$TARGET_REPO" --admin --squash --delete-branch`
-   (flag rationale in the same reference file). If it fails with "Must
-   have admin rights", **stop** and report — do NOT fall back to
-   `--merge`/`--rebase`.
-3. Capture the merge SHA:
-   `gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -q .mergeCommit.oid`.
+Order matters — comment first so the audit survives branch deletion. (1) Post
+the "PR audit comment" from `references/audit-templates.md`, capturing its URL
+for Step 7. (2) `gh pr merge <N> --admin --squash --delete-branch` (flag
+rationale in the same file); "Must have admin rights" → **stop**, never fall
+back to `--merge`/`--rebase`. (3) Capture the merge SHA via
+`gh pr view <N> --json mergeCommit -q .mergeCommit.oid`.
 
 ## Step 5: Create Post-Merge Incident Issue
 
-Non-negotiable audit tail. File `incident: emergency merge of PR #<N> —
-<reason first line>` with the body + retro checklist from
-`references/audit-templates.md`. Attach an `incident` label **only if**
-`gh label list --repo "$TARGET_REPO"` confirms it exists.
+Non-negotiable audit tail. File `incident: emergency merge of PR #<N> — <reason
+first line>` with the body + retro checklist from `references/audit-templates.md`.
+Attach an `incident` label **only if** `gh label list --repo "$TARGET_REPO"`
+confirms it exists.
 
-Include the ai-metrics block in the incident issue body (append before
-creating — no soft-fail here since the incident issue is a required
-artifact). When `GH_DISABLE_AI_METRICS=1`, skip the footer; the
-incident issue itself is still created (issue #399):
-
-```bash
-ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-# Append to the issue body temp file before gh issue create:
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics footer skipped via GH_DISABLE_AI_METRICS
-else
-    printf '\n---\n<!-- ai-metrics:gh-pr-merge-emergency -->\n📊 ~%s tokens · 👤 ~%s h · 🤖 ~%s min\n<!-- /ai-metrics:gh-pr-merge-emergency -->\n' \
-      "${TOKENS:-3000}" "${HUMAN_H:-1}" "$ELAPSED" >> "$INCIDENT_BODY"
-fi
-```
+Append the ai-metrics footer to the incident issue body before creating it
+(required artifact — no soft-fail; honors `GH_DISABLE_AI_METRICS=1` per issue
+#399). Exact block: `references/audit-templates.md` -> "ai-metrics footer".
 
 ## Step 6: Sync Project Board Status
 
-Read `references/project-board-sync.md` and push the merged PR card to
-`Done`. Sync failure never blocks the audit report.
+Read `references/project-board-sync.md` and push the merged PR card to `Done`.
+Sync failure never blocks the audit report.
 
 ## Step 7: Report
 
@@ -110,8 +97,7 @@ Emergency-merged PR #<N>
 
 ## Constraints
 
-- Never bypass CI. Approval bypass only.
-- Never skip the incident issue — the audit tail is the whole point.
-- Never run without an affirmative user confirmation.
-- Never use `--merge`/`--rebase` to dodge a failing admin merge.
-- Reason must be substantive; refuse `"urgent"`/`"fix"`/`"merge now"`.
+Never: bypass CI (approval bypass only); skip the incident issue (the audit tail
+is the whole point); run without affirmative confirmation; use `--merge`/`--rebase`
+to dodge a failing admin merge. Reason must be substantive — refuse
+`"urgent"`/`"fix"`/`"merge now"`.

--- a/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
@@ -13,6 +13,12 @@ description: >-
   [--label-variant <input>]`; defaults to the PR attached to the current
   branch. Accepts `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "CI log analysis + root-cause identification + targeted fix; pattern-matching reasoning, no deep architectural decisions"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:pr-resolve-ci-fail — CI Failure Resolution
@@ -25,100 +31,73 @@ Arg #1 `-h`/`--help`/`help` → read `references/help.md` verbatim, stop. No API
 
 Record `START_TS=$(date +%s)` immediately for Step 7.
 
-Positional: `[pr-number] [remote]`. Flags: `--wait <seconds>` (opt-in,
-default off), `--label-variant <input>` (override canonical label).
+Positional: `[pr-number] [remote]`. Flags: `--wait <seconds>` (opt-in, default
+off), `--label-variant <input>` (override canonical label).
 
 - `pr-number` omitted → auto-detect via `gh pr view --json
   number,state,headRefName` on current branch. No PR → stop.
-- `remote` default `origin`. Missing → `git remote -v` and stop.
-- `--label-variant` normalized via `references/label-normalization.md`; unknown → fail-fast.
+- `remote` default `origin`. Missing → `git remote -v` and stop. `--label-variant`
+  normalized via `references/label-normalization.md`; unknown → fail-fast.
 
 State `OPEN` required. Hard preconditions in `references/safety.md` →
 "Preconditions". Capture `BACKUP_SHA=$(git rev-parse HEAD)` for recovery.
 
 ## Step 2: Fetch Failing Checks
 
-### Pre-check — is `main` itself red?
-
-본격 분석 전에 main 의 동일 workflow 가 inherited red 인지 1초 확인:
-
-```bash
-gh run list --repo "$TARGET_REPO" --branch main --workflow "$WORKFLOW_NAME" --limit 3
-```
-
-세 run 중 2개 이상 failure 이고 PR run 과 동일 step 에서 fail 한다면
-PR 회귀가 아닐 가능성이 높다 (#755 의 28건 bats fail 이 그 사례).
-다음과 같이 stop — 라벨은 건드리지 않고 그대로 종료:
-
-```
-[STOP] main 자체가 적색입니다 (latest 3 runs: failure / failure / success).
-       PR 회귀가 아니라 inherited red — main 먼저 회복하세요.
-       Next: /gh-issue-create  # umbrella 또는 sub-issue 등록
-```
-
-False-positive: main 의 transient red (1회 fail, 직후 green) 은 무시하고
-통상 절차 진행. 판정 기준·예시·예외 케이스 전체는
-`references/ci-log-analysis.md` → "Step 2 — pre-check (is main red?)".
+Pre-check — main 의 동일 workflow 가 inherited red 인지 먼저 확인한다. 최신 3 run
+중 2개 이상이 PR 과 동일 step 에서 fail 하면 inherited red — 라벨을 건드리지 않고
+`[STOP]` 종료 (#755 사례). transient red(1회 fail 후 green)은 무시하고 진행.
+명령·예제·판정 기준·예외: `references/ci-log-analysis.md` → "Step 2 — pre-check".
 
 ### Failing-check fetch
 
-`gh pr checks <N> --required --json name,state,workflow,link`, filter
-`state == FAILURE`. All green → `[OK] no failing checks — nothing to
-resolve.` and stop. Filter rubric + in-progress carveout in
-`references/ci-log-analysis.md` → "Step 2".
+`gh pr checks <N> --required --json name,state,workflow,link`, filter `state ==
+FAILURE`. All green → `[OK] no failing checks — nothing to resolve.` and stop.
+Filter rubric + in-progress carveout: `references/ci-log-analysis.md` → "Step 2".
 
 ## Step 3: Fetch + Analyze Logs
 
-Resolve each failing workflow's latest `RUN_ID`, dump `gh run view
-<id> --log-failed`, identify the root cause. Parsing rubric +
-common patterns (lint / type / test / build) in
-`references/ci-log-analysis.md` → "Step 3 — Log triage". No
-identifiable fix → surface log and stop. **Never** blind-retry.
+Resolve each failing workflow's latest `RUN_ID`, dump `gh run view <id>
+--log-failed`, identify the root cause. Parsing rubric + common patterns (lint /
+type / test / build): `references/ci-log-analysis.md` → "Step 3 — Log triage".
+No identifiable fix → surface log and stop. **Never** blind-retry.
 
 ## Step 4: Fix Locally + Validate
 
-Edit failing files per Step 3, then run the same lint/test command CI
-ran (NF-3 — CI infinite-loop guard; detection heuristic in
-`references/safety.md` → "Local validation gate"). Still red → stop with
-`[FAIL] local checks failed — fix before push`. **Do not push.**
+Edit failing files per Step 3, then run the same lint/test command CI ran (NF-3
+— CI infinite-loop guard; detection heuristic in `references/safety.md` → "Local
+validation gate"). Still red → stop with `[FAIL] local checks failed — fix
+before push`. **Do not push.**
 
 ## Step 5: Commit + Push (no force)
 
-Inline commit (do NOT delegate to `gh:commit` — composition re-prompt).
-Title `fix(ci): <summary> (#<PR_NUMBER>)`. Fast-forward push only —
-**no `--force`, no `--force-with-lease`**. Rejected → surface
-divergence and stop; **label is NOT yet removed**. Exact commands +
-divergence message in `references/safety.md` → "Step 5 push".
+Inline commit (do NOT delegate to `gh:commit` — composition re-prompt). Title
+`fix(ci): <summary> (#<PR_NUMBER>)`. Fast-forward push only — **no `--force`, no
+`--force-with-lease`**. Rejected → surface divergence and stop; **label is NOT
+yet removed**. Exact commands + divergence message: `references/safety.md` →
+"Step 5 push".
 
 ## Step 6: Optional CI Green Wait (`--wait`)
 
-`--wait <seconds>` passed → poll `gh pr checks --required` every 30 s
-until green or timeout. Timeout → `[WARN] CI still pending after
-<N>s — proceeding to label removal.` Without flag, skip. Polling loop
-in `references/ci-log-analysis.md` → "Step 6 wait".
+`--wait <seconds>` passed → poll `gh pr checks --required` every 30 s until green
+or timeout. Timeout → `[WARN] CI still pending after <N>s — proceeding to label
+removal.` Without flag, skip. Polling loop: `references/ci-log-analysis.md` →
+"Step 6 wait".
 
 ## Step 7: Remove `CI fail` Label + Report
 
-**Invariant** — last mutation. Step 5 push failed → this step does NOT
-run (label stays so reviewers know CI is still red). Canonical label
-name from `references/label-normalization.md`.
+**Invariant** — last mutation. Step 5 push failed → this step does NOT run
+(label stays so reviewers know CI is still red). Canonical label name from
+`references/label-normalization.md`. Remove via REST DELETE (not `gh pr edit
+--remove-label` — classic-Projects silent-fail, #326 Bug B); 404 = absent →
+soft-fail. Full block + ai-metrics comment: `references/safety.md` → "Step 7".
 
-REST DELETE: `gh api -X DELETE
-"repos/{owner}/{repo}/issues/<N>/labels/CI%20fail"` (URL-encode space;
-404 = absent → soft-fail). **Do not** use `gh pr edit --remove-label` —
-classic-Projects silent-fail issue same as `gh:pr-resolve-conflict` Step
-5 (#326 Bug B). Full block + ai-metrics comment in
-`references/safety.md` → "Step 7".
-
-Report: `[OK] PR #<N> CI 복구 완료 · 라벨 제거됨 · <sha> push 됨.`
-followed by `Next: /gh-pr-reply <N>  # CI 그린 확인 후 리뷰어 회신`.
+Report: `[OK] PR #<N> CI 복구 완료 · 라벨 제거됨 · <sha> push 됨.` followed by
+`Next: /gh-pr-reply <N>  # CI 그린 확인 후 리뷰어 회신`.
 
 ## Constraints
 
-- Never `--force` / `--force-with-lease`. Fast-forward only.
-- Never run on the default branch.
-- Never push when local lint/test is red.
-- Never remove the label before push succeeds.
-- Never auto-create labels (missing label → soft-fail).
-- Never auto-stash. Clean tree required.
-- Never delegate to `gh:commit` (re-prompt inside composition).
+Never: `--force`/`--force-with-lease` (fast-forward only); run on the default
+branch; push when local lint/test is red; remove the label before push
+succeeds; auto-create labels (missing → soft-fail); auto-stash (clean tree
+required); delegate to `gh:commit` (re-prompt inside composition).

--- a/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/SKILL.md
@@ -47,13 +47,13 @@ State `OPEN` required. Hard preconditions in `references/safety.md` →
 Pre-check — main 의 동일 workflow 가 inherited red 인지 먼저 확인한다. 최신 3 run
 중 2개 이상이 PR 과 동일 step 에서 fail 하면 inherited red — 라벨을 건드리지 않고
 `[STOP]` 종료 (#755 사례). transient red(1회 fail 후 green)은 무시하고 진행.
-명령·예제·판정 기준·예외: `references/ci-log-analysis.md` → "Step 2 — pre-check".
+명령·예제·판정 기준·예외: `references/ci-log-analysis.md` → "Pre-check (is main red?)".
 
 ### Failing-check fetch
 
 `gh pr checks <N> --required --json name,state,workflow,link`, filter `state ==
 FAILURE`. All green → `[OK] no failing checks — nothing to resolve.` and stop.
-Filter rubric + in-progress carveout: `references/ci-log-analysis.md` → "Step 2".
+Filter rubric + in-progress carveout: `references/ci-log-analysis.md` → "Step 2 — Fetch failing checks".
 
 ## Step 3: Fetch + Analyze Logs
 
@@ -82,7 +82,7 @@ yet removed**. Exact commands + divergence message: `references/safety.md` →
 `--wait <seconds>` passed → poll `gh pr checks --required` every 30 s until green
 or timeout. Timeout → `[WARN] CI still pending after <N>s — proceeding to label
 removal.` Without flag, skip. Polling loop: `references/ci-log-analysis.md` →
-"Step 6 wait".
+"Step 6 — --wait polling loop".
 
 ## Step 7: Remove `CI fail` Label + Report
 

--- a/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
@@ -137,9 +137,10 @@ fi
 - `${TOKENS:-3000}` — caller may pre-export an estimate; default 3000.
 - `~2 h` — `fix` lookup from `gh-issue-create/references/metrics-baseline.md`.
 - soft-fail: comment failure does NOT block the success report.
-- Glyph note: the rendered footer on GitHub uses the `📊 👤 🤖` glyphs
-  (the #317 F-2 exception). They are omitted here to keep references/
-  emoji-free; substitute them at render time to match the standard card.
+- Glyph note: the rendered footer on GitHub uses the standard ai-metrics
+  glyphs (the #317 F-2 exception — see `gh-add-ai-metrics`, the footer SSOT).
+  They are omitted here to keep references/ emoji-free; substitute them at
+  render time to match the standard card.
 
 ## Recovery cheat-sheet (final report appendix)
 

--- a/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
+++ b/claude/skills/gh-pr-resolve-ci-fail/references/safety.md
@@ -121,10 +121,10 @@ else
     gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/comments" -X POST \
       -f body="---
 <details>
-<summary>🤖 AI Metrics · 📊 ~${TOKENS:-3000} tokens · 👤 ~2 h · 🤖 ~$ELAPSED min</summary>
+<summary>AI Metrics · tokens=~${TOKENS:-3000} · human_h=~2 · ai_min=~$ELAPSED</summary>
 
 <!-- ai-metrics:gh-pr-resolve-ci-fail -->
-📊 ~${TOKENS:-3000} tokens · 👤 ~2 h · 🤖 ~$ELAPSED min
+AI Metrics tokens=~${TOKENS:-3000} human_h=~2 ai_min=~$ELAPSED
 <!-- /ai-metrics:gh-pr-resolve-ci-fail -->
 
 </details>
@@ -137,6 +137,9 @@ fi
 - `${TOKENS:-3000}` — caller may pre-export an estimate; default 3000.
 - `~2 h` — `fix` lookup from `gh-issue-create/references/metrics-baseline.md`.
 - soft-fail: comment failure does NOT block the success report.
+- Glyph note: the rendered footer on GitHub uses the `📊 👤 🤖` glyphs
+  (the #317 F-2 exception). They are omitted here to keep references/
+  emoji-free; substitute them at render time to match the standard card.
 
 ## Recovery cheat-sheet (final report appendix)
 


### PR DESCRIPTION
## 개요

`skill:check` NEEDS WORK 25개 일괄 처리(#862)의 **PR-NW-8 (잔여 mop-up)** 그룹.
isolated 2 스킬 — `gh-pr-merge-emergency` (#820), `gh-pr-resolve-ci-fail` (#823) —
의 동일 FAIL 패턴을 한 번에 해소한다.

두 스킬 모두 audit 결과 동일: **Check 11(No Emojis) FAIL + Check 1(Line Count) WARN
+ Check 12(Model Recommendation Metadata) WARN** — Verdict `NEEDS WORK`.

## 변경 내용

### gh-pr-merge-emergency (Closes #820)
- **Check 11/1** — Step 5 의 ai-metrics `printf` 이모지 블록을
  `references/audit-templates.md` 의 "ai-metrics footer" 섹션으로 추출하고
  본문은 1줄 포인터로 대체. references/ 는 emoji-free 로 유지.
- **Check 12** — frontmatter 에 `metadata.model_recommendation` (tier: sonnet) 추가.
- SKILL.md **117 -> 103 라인** (Check 1 PASS, <=150; 100 라인 목표에는 3 라인 초과 — WARN 구간 아님, 본문 phase only 유지).

### gh-pr-resolve-ci-fail (Closes #823)
- **Check 11** — `references/safety.md` 의 ai-metrics 글리프를 emoji-free
  placeholder 로 치환. (후속 커밋에서 glyph note 설명문에 잔존하던 이모지도 제거 —
  전수 스캔 emoji 0 확인.)
- **Check 1** — Step 2 pre-check 인라인 bash/`[STOP]` 블록을 `references/ci-log-analysis.md`
  포인터로 축약.
- **Check 12** — frontmatter 에 `metadata.model_recommendation` (tier: sonnet) 추가.
- SKILL.md **124 -> 103 라인** (Check 1 PASS).

## 불변 사항 (기존 동작 무변경)
- merge-emergency: admin 머지 정책, incident issue 생성, audit 댓글 순서.
- resolve-ci-fail: inherited-red pre-check, `--force` 거부, label removal invariant.
- 두 스킬 모든 references 파일 본문 인용 유지 (Check 4 PASS).

## 검증
- 두 스킬 트리(SKILL.md + `references/*.md`) 전수 codepoint 스캔: **emoji 잔존 0** (Check 11 PASS).
- 두 SKILL.md 모두 `metadata.model_recommendation` 존재 (Check 12 PASS).
- 커밋 pre-commit 훅: "All checks passed" (2 커밋 모두).
- 주의: 이 작업 환경에는 `mise`/`shellcheck`/`shfmt` 미설치 — `mise run lint`/`test`
  를 직접 실행하지 못했다. 변경 파일은 전부 `.md` 라 shellcheck/shfmt 대상 아님.
  CI 에서 full lint/test 가 한 번 더 게이트한다.

Closes #820
Closes #823
Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
