### PR TITLE
fix(git-branch): #879 gbr teardown --force 가 merge-conflict 트리에서 멈추던 버그 수정 + --discard-changes 신규

### DIFF
--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -16,7 +16,7 @@ unalias gbr 2>/dev/null || true
 _gbr_help_summary() {
     ux_info "Usage: gbr-help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "teardown: gbr teardown [--force] [--keep-branch]"
+    ux_bullet_sub "teardown: gbr teardown [--force] [--keep-branch] [--discard-changes]"
     ux_bullet_sub "details: gbr-help <section> (example: gbr-help teardown)"
 }
 
@@ -26,10 +26,10 @@ _gbr_help_list_sections() {
 }
 
 _gbr_help_rows_teardown() {
-    ux_table_row "syntax" "gbr teardown [--force] [--keep-branch]" "Cleanup merged feature branch"
+    ux_table_row "syntax" "gbr teardown [--force] [--keep-branch] [--discard-changes]" "Cleanup merged feature branch"
     ux_table_row "context" "Run from the feature branch (not main, not worktree)" "Switches to main, pulls, deletes current branch"
     ux_table_row "signal" "Detects '[gone]' upstream as PR-merged" "Blocks otherwise; use --force to override"
-    ux_table_row "flags" "--force / --keep-branch" "Skip safety checks / sync main only"
+    ux_table_row "flags" "--force / --keep-branch / --discard-changes" "Skip merge-status checks (non-destructive) / sync main only / DESTRUCTIVE overwrite of local changes"
 }
 
 _gbr_help_render_section() {
@@ -106,20 +106,22 @@ git_branch_teardown() {
         emulate -L sh
     fi
 
-    local force=false keep_branch=false
+    local force=false keep_branch=false discard_changes=false
 
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help|help)
                 ux_header "gbr teardown - feature branch cleanup after PR merge"
-                ux_info "Usage: gbr teardown [--force] [--keep-branch]"
+                ux_info "Usage: gbr teardown [--force] [--keep-branch] [--discard-changes]"
                 ux_info ""
                 ux_info "Concept: SELF-CLEANUP on the CURRENT branch."
                 ux_info "  Stand on the branch, run teardown, land on main."
                 ux_info ""
                 ux_info "Options:"
-                ux_info "  --force        delete branch even if upstream still exists or not fully merged"
-                ux_info "  --keep-branch  sync main only, keep the current branch"
+                ux_info "  --force            proceed despite upstream-still-exists / not-fully-merged / dirty tree"
+                ux_info "                     (NON-destructive: never overwrites local file contents)"
+                ux_info "  --keep-branch      sync main only, keep the current branch"
+                ux_info "  --discard-changes  DESTRUCTIVE: discard uncommitted/conflicted changes to force the switch"
                 ux_info ""
                 ux_info "Typical flow (single branch):"
                 ux_bullet "gbr teardown                           # current branch, after PR merge"
@@ -133,6 +135,7 @@ git_branch_teardown() {
                 ;;
             --force) force=true; shift ;;
             --keep-branch) keep_branch=true; shift ;;
+            --discard-changes) discard_changes=true; shift ;;
             -*)
                 ux_error "Unknown option: $1. Use --help for usage."
                 return 1
@@ -189,9 +192,39 @@ git_branch_teardown() {
         return 1
     fi
 
-    # Pre-flight: uncommitted changes
-    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-        if [ "$force" = true ]; then
+    # Detect a merge-in-progress / unmerged index up front. A plain `git checkout`
+    # later (Step "Switch to main") would refuse this with a split, opaque error —
+    # the helpful header goes to stderr ("error: you need to resolve your current
+    # index first") while only the cryptic "<file>: needs merge" reaches stdout.
+    # Surface it here with actionable guidance instead. `--force` alone must NOT
+    # bypass this: forcing the switch would silently destroy the conflicted files.
+    local has_conflict=false
+    if git rev-parse --verify --quiet MERGE_HEAD >/dev/null 2>&1 \
+        || [ -n "$(git ls-files --unmerged 2>/dev/null)" ]; then
+        has_conflict=true
+    fi
+
+    # Pre-flight: merge conflict / uncommitted changes
+    if [ "$has_conflict" = true ]; then
+        if [ "$discard_changes" = true ]; then
+            ux_warning "Merge in progress / unmerged paths present (--discard-changes will overwrite them)"
+        else
+            ux_error "Merge in progress / unmerged paths — resolve before teardown."
+            echo ""
+            ux_info "The working tree has an unmerged index; a branch switch is blocked"
+            ux_info "(git: 'you need to resolve your current index first')."
+            echo ""
+            ux_info "Pick one:"
+            ux_bullet "git merge --abort                        # discard the in-progress merge"
+            ux_bullet "resolve conflicts, then git add/commit   # keep the merge result"
+            ux_bullet "git stash --include-untracked            # shelve for later"
+            echo ""
+            ux_warning "Plain --force does NOT bypass this (it would destroy your files)."
+            ux_info "To intentionally discard local changes: gbr teardown --discard-changes"
+            return 1
+        fi
+    elif ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        if [ "$force" = true ] || [ "$discard_changes" = true ]; then
             ux_warning "Uncommitted changes present (--force)"
         else
             ux_error "Uncommitted changes. Commit, stash, or use --force."
@@ -266,10 +299,26 @@ git_branch_teardown() {
         esac
     fi
 
-    # Switch to main
-    if ! git checkout "$main_branch" 2>/dev/null; then
-        ux_error "Failed to checkout $main_branch."
-        return 1
+    # Switch to main.
+    #
+    # With --discard-changes we explicitly force-overwrite the working tree
+    # (`checkout -f`). Otherwise we use a plain checkout and SURFACE its stderr —
+    # previously swallowed by `2>/dev/null` — so the real failure reason (e.g.
+    # "you need to resolve your current index first") reaches the user instead of
+    # a bare "Failed to checkout main."
+    if [ "$discard_changes" = true ]; then
+        if ! git checkout -f "$main_branch"; then
+            ux_error "Failed to checkout $main_branch (even with --discard-changes)."
+            return 1
+        fi
+        ux_warning "Discarded local changes to switch to $main_branch (--discard-changes)."
+    else
+        local checkout_err
+        if ! checkout_err="$(git checkout "$main_branch" 2>&1 1>/dev/null)"; then
+            ux_error "Failed to checkout $main_branch."
+            [ -n "$checkout_err" ] && ux_info "git: $checkout_err"
+            return 1
+        fi
     fi
 
     # Pull main (fast-forward)

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -224,7 +224,9 @@ git_branch_teardown() {
             return 1
         fi
     elif ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-        if [ "$force" = true ] || [ "$discard_changes" = true ]; then
+        if [ "$discard_changes" = true ]; then
+            ux_warning "Uncommitted changes present (--discard-changes)"
+        elif [ "$force" = true ]; then
             ux_warning "Uncommitted changes present (--force)"
         else
             ux_error "Uncommitted changes. Commit, stash, or use --force."

--- a/tests/bats/functions/git_branch_teardown.bats
+++ b/tests/bats/functions/git_branch_teardown.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_branch_teardown.bats
+# Regression tests for `gbr teardown` against a fake origin + clone on a
+# feature branch (NOT a worktree — gbr is the in-place self-cleanup variant).
+#
+# Issue #879: `gbr teardown --force` stalled on a merge-conflict / unmerged
+# index because the actual `git checkout main` was a plain checkout (no -f),
+# which always refuses an unmerged index, and its real stderr was swallowed by
+# `2>/dev/null`. The fix:
+#   1. detect the unmerged index up front and show actionable guidance,
+#   2. keep plain --force NON-destructive (never overwrites local files),
+#   3. add an explicit destructive --discard-changes flag,
+#   4. surface git's stderr instead of swallowing it.
+
+load '../test_helper'
+
+# Create: $ORIGIN (bare) <- $CLONE (on feat/x with an unresolved merge conflict)
+_setup_conflicted_clone() {
+    ORIGIN="$TEST_TEMP_HOME/origin.git"
+    CLONE="$TEST_TEMP_HOME/clone"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init --bare --initial-branch=main "$ORIGIN" >/dev/null
+    git clone -q "$ORIGIN" "$CLONE"
+    (
+        cd "$CLONE"
+        echo base > base.txt
+        git add base.txt
+        git commit -q -m "base"
+        git push -q origin main
+
+        # main advances conflict.txt one way...
+        echo mainside > conflict.txt
+        git add conflict.txt
+        git commit -q -m "main: conflict.txt=mainside"
+
+        # ...feature branch advances it another way, from the common base.
+        git checkout -q -b feat/x HEAD~1
+        echo featureside > conflict.txt
+        git add conflict.txt
+        git commit -q -m "feat: conflict.txt=featureside"
+
+        # Merge main → produces an unmerged index (UU conflict.txt), left as-is.
+        git merge main >/dev/null 2>&1 || true
+    )
+}
+
+setup() {
+    setup_isolated_home
+    _setup_conflicted_clone
+}
+
+teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    teardown_isolated_home
+}
+
+@test "teardown: unmerged index blocks (no --force) with actionable guidance" {
+    # Sanity: we really are in a conflicted/unmerged state.
+    run git -C "$CLONE" ls-files --unmerged
+    assert_output --partial "conflict.txt"
+
+    run_in_bash "cd '$CLONE' && gbr teardown 2>&1"
+    assert_failure
+    # Failure reason is explicit (AC #1) — not a bare "Failed to checkout main".
+    assert_output --partial "unmerged"
+    assert_output --partial "resolve your current index first"
+    # Actionable next steps.
+    assert_output --partial "git merge --abort"
+    assert_output --partial "git stash"
+    assert_output --partial "gbr teardown --discard-changes"
+
+    # Non-destructive: the conflicted file content is untouched, branch intact.
+    [ "$(git -C "$CLONE" symbolic-ref --short HEAD)" = "feat/x" ]
+}
+
+@test "teardown --force does NOT bypass an unmerged index (non-destructive)" {
+    # The core #879 bug: --force changed only the warning text, then stalled at
+    # the plain checkout. Now --force is explicitly non-destructive here.
+    run_in_bash "cd '$CLONE' && gbr teardown --force 2>&1"
+    assert_failure
+    assert_output --partial "Plain --force does NOT bypass"
+    assert_output --partial "gbr teardown --discard-changes"
+
+    # Still on the feature branch; conflicted file not destroyed (AC #2).
+    [ "$(git -C "$CLONE" symbolic-ref --short HEAD)" = "feat/x" ]
+    run git -C "$CLONE" ls-files --unmerged
+    assert_output --partial "conflict.txt"
+}
+
+@test "teardown --force --discard-changes force-switches to main and deletes branch" {
+    run_in_bash "cd '$CLONE' && gbr teardown --force --discard-changes 2>&1"
+    assert_success
+    assert_output --partial "Discarded local changes"
+    assert_output --partial "Teardown complete"
+
+    # Landed on main, feature branch gone, merge state cleared.
+    [ "$(git -C "$CLONE" symbolic-ref --short HEAD)" = "main" ]
+    run git -C "$CLONE" rev-parse --verify --quiet feat/x
+    assert_failure
+    run git -C "$CLONE" ls-files --unmerged
+    assert_output ""
+}
+
+@test "teardown --help documents --discard-changes" {
+    run_in_bash "gbr teardown --help 2>&1"
+    assert_success
+    assert_output --partial "--discard-changes"
+    assert_output --partial "DESTRUCTIVE"
+    # --force is now described as non-destructive.
+    assert_output --partial "NON-destructive"
+}


### PR DESCRIPTION
## 요약

`gbr teardown --force` 가 merge-conflict(unmerged index) 트리에서 사전 경고
문구만 바꾸고, 실제 브랜치 전환(`git checkout main`) 단계에서 막혀 동일 지점에서
중단되던 버그(#879)를 수정한다.

## 근본 원인

- `--force` 가 절반만 배선됨: 사전 uncommitted 가드 하나만 우회하고, 정작
  checkout 은 `-f` 없는 평범한 `git checkout main` 이라 unmerged index 를
  무조건 거부했다.
- checkout 의 `2>/dev/null` 이 git 의 핵심 stderr 헤더
  ("you need to resolve your current index first") 를 삼켜 진단이 불투명했다.

## 변경 내용

- **사전 감지**: `MERGE_HEAD` 또는 unmerged path 를 checkout 이전에 감지해
  actionable 안내(`git merge --abort` / 충돌 해결 / `git stash`) 를 출력.
- **stderr 노출**: checkout 의 `2>/dev/null` 제거 — 실패 사유를 그대로 노출.
- **비파괴 `--force`**: 기본 `--force` 는 추적 파일 내용을 더 이상 파괴하지 않음.
- **명시적 파괴 플래그**: 진짜로 변경분을 버릴 때를 위한 `--discard-changes`
  (`git checkout -f`) 신규 추가.
- **help 일치**: 요약/테이블/상세 help 문구를 실제 동작과 일치하도록 갱신.
- **회귀 테스트**: `tests/bats/functions/git_branch_teardown.bats` 4 케이스
  (unmerged 차단 / `--force` 비파괴 / `--discard-changes` 강제전환 / help).

## Acceptance Criteria 대응

- [x] merge-conflict/dirty 트리에서 실패 사유(unmerged index)가 명확히 표시.
- [x] 기본 `--force` 는 추적 파일 uncommitted 내용을 파괴하지 않음.
- [x] destructive 옵션(`--discard-changes`)은 별도 플래그로만 동작 + help 명시.
- [x] `--force` help 문구가 실제 동작과 일치.
- [x] 회귀 테스트(bats) 로 unmerged-path teardown 커버.

자매 함수 `gwt teardown` 은 in-place checkout 이 아니라 worktree 제거 방식이라
동일 패턴에 해당하지 않음(점검 완료).

Closes #879
