### PR TITLE
refactor(skills): #862 PR-NW-6 — gh-issue-* 2개 line-count 추출 + Check 12 metadata

### DIFF
--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -22,9 +22,8 @@ metadata:
 
 # gh:issue-create — Conversation → GitHub Issue
 
-Convert the current chat into a well-structured issue on the target repo,
-execute immediately without confirmation, and print only the issue number
-+ URL. 본문은 사용자 대화 언어로 작성.
+Convert the current chat into a well-structured issue on the target repo
+(본문은 대화 언어로), execute immediately, and print only the issue number + URL.
 
 ## Help
 

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -3,175 +3,99 @@ name: gh:issue-create
 description: >-
   Save the current conversation as a GitHub issue. Use when the user runs
   /gh:issue-create, /gh-issue-create, or asks "이 대화 이슈로 등록",
-  "chat을 깃허브 이슈로 남겨", "기록용 이슈 만들어". Summarizes the chat
-  into a body keyed by conventional-commit prefix
-  (feat / fix / refactor / perf / docs / test / chore / misc) and creates
-  the issue via `gh issue create` on the target remote's repo without
-  confirmation, printing only the issue number and URL. Preserves
-  reasoning, decisions, and concrete details — the issue is reused for
-  PR drafts and blog posts. Accepts an optional remote name positional
-  arg (e.g. `/gh-issue-create upstream`) to target a non-`origin` remote.
-  Flags `--no-auto-labels`, `--auto-label-debug`, and
-  `--as-discussion <category>` (`Ideas` / `Q&A` / `Announcements` /
-  `Lessons`, #619) are documented in references/help.md, alongside the
-  `.gh-issue-defaults.yml` auto-label behavior. Accepts
-  `-h`/`--help`/`help` to print usage.
+  "chat을 깃허브 이슈로 남겨", "기록용 이슈 만들어". Summarizes the chat into
+  a body keyed by conventional-commit prefix (feat / fix / refactor / perf /
+  docs / test / chore / misc) and creates the issue via `gh issue create` on
+  the target remote's repo without confirmation, printing only the issue
+  number and URL. Preserves reasoning and concrete details — the issue is
+  reused for PR drafts and blog posts. Optional remote positional arg; flags
+  `--no-auto-labels`, `--auto-label-debug`, `--as-discussion <category>`
+  (#619) and `-h`/`--help`/`help` are documented in references/help.md.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "chat→issue summarization with classification + auto-labels + clarification guard"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:issue-create — Conversation → GitHub Issue
 
+Convert the current chat into a well-structured issue on the target repo,
+execute immediately without confirmation, and print only the issue number
++ URL. 본문은 사용자 대화 언어로 작성.
+
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
-
-## Role
-
-Convert the current chat into a well-structured GitHub issue on the target
-repo. Execute immediately without confirmation. Print only the issue
-number + URL at the end.
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No API calls.
 
 ## Options
 
-| Argument | Description | Default |
-|----------|-------------|---------|
-| `[remote]` (positional) | Target remote name. Resolved to `TARGET_REPO=<owner>/<repo>`. Fails fast if missing. | `origin` |
-| `--no-auto-labels` | Skip Step 2.5 entirely; user `--label` flags remain in effect. | off |
-| `--auto-label-debug` | Verbose stderr trace of Stage-1 detection and the kept/dropped label sets. | off |
-| `--label <name>` | User label, union with Step 2.5 auto-labels. Repeatable. | — |
-| `--assignee @me` | Only added when the user explicitly asks. | off |
-| `--as-discussion <category>` | Route to [[gh-discussion-create]] instead of creating an Issue. Category is one of `Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive). Skips Step 2.5 (auto-labels) and Step 4's `gh issue create` — Discussions do not carry labels/milestones. `--label` / `--assignee` flags, if also passed, are ignored with a 1-line warning. | off |
-| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
-| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |
+All arguments, flags, and env vars are in `references/options.md`
+(Option | Description | Default). Key: `[remote]` positional (default
+`origin`), `--no-auto-labels`, `--auto-label-debug`, `--label`,
+`--assignee @me`, `--as-discussion <category>`, `GH_DISABLE_AI_METRICS=1`.
 
 ## Step 1: Detect Repo Context
 
-Record `START_TS=$(date +%s)` immediately for Step 3.5. Parse the
-positional remote arg and the flags above. Confirm we're in a git repo
-(`git rev-parse --show-toplevel`) and resolve `TARGET_REPO=<owner>/<repo>`
-via the remote — full substeps in `references/repo-resolution.md`.
-Never silently fall back to `origin` when the user-supplied remote is
-missing.
-
-### Step 1.1: `--as-discussion` parse
-
-If `--as-discussion <category>` is present, bind `DISCUSSION_MODE=1` and
-`CATEGORY=<value>`. Validate `<value>` against the allow-list
-`Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive); on
-mismatch, print the four allowed values and **exit 3** without calling
-any API. When `DISCUSSION_MODE=1` and the user also supplied `--label`
-or `--assignee`, emit a 1-line warning to stderr and drop those flags
-(Discussions do not carry labels/assignees):
-
-```
-[gh-issue-create] --as-discussion: dropping --label/--assignee (Discussions do not carry these)
-```
-
-When `DISCUSSION_MODE` is unset the legacy issue path is unchanged.
+Record `START_TS=$(date +%s)` for Step 3.5. Parse the positional remote arg
++ flags. Confirm a git repo (`git rev-parse --show-toplevel`) and resolve
+`TARGET_REPO=<owner>/<repo>` via the remote (substeps in
+`references/repo-resolution.md`). Never silently fall back to `origin` when
+the user-supplied remote is missing. When `--as-discussion <category>` is
+present, follow `references/discussion-mode.md` to bind `DISCUSSION_MODE` /
+`CATEGORY` and validate the category (exit 3 on mismatch).
 
 ## Step 2: Classify the Conversation
 
 Read `references/prefix-table.md` and pick exactly one conventional-commit
-prefix as the dominant intent. The reference also covers the disambiguation
-rules (default to `misc`; large-`feat` heuristic) and title formatting.
+prefix as the dominant intent (covers disambiguation, `misc` default,
+large-`feat` heuristic, and title formatting).
 
 ## Step 2.1: Clarification & Scope Guard
 
 Apply `references/clarification.md` trigger signals (동사 없는 명사 나열 /
 컴포넌트 ≥3 혼재 / feature 범위 미정의). 매치되면 1~2줄 확인 또는 분리안을
-사용자에게 보내고 응답 전에는 `gh issue create` 호출 금지. 사용자가
-"한 이슈로" 라고 답하면 그대로 생성 — 강제 분할 아닌 안전망.
+보내고 응답 전 `gh issue create` 호출 금지. "한 이슈로" 답하면 그대로 생성.
 
 ## Step 2.5: Auto-labels + Milestone (opt-in via SSOT)
 
-Skip entirely when `--no-auto-labels` **or** `DISCUSSION_MODE=1` is set.
-Discussions do not carry labels or milestones (#619 F-3) — running the
-auto-label dispatch and then discarding the result would be wasteful
-and noisy. Otherwise read `references/auto-labels.md` and follow
-verbatim (Stage-1 signal → SSOT load → label union → `gh label list`
-validation → milestone resolution). Stash kept labels + milestone for
-Step 4. `--auto-label-debug` emits the Stage-1 trace per the same
-reference.
+Skip entirely when `--no-auto-labels` **or** `DISCUSSION_MODE=1` is set
+(#619 F-3). Otherwise read `references/auto-labels.md` and follow verbatim
+(Stage-1 signal → SSOT load → label union → `gh label list` validation →
+milestone resolution). Stash kept labels + milestone for Step 4.
+`--auto-label-debug` emits the Stage-1 trace.
 
 ## Step 3: Draft the Issue Body
 
-`references/templates/<prefix>.md` 에 정의된 본문 골격을 그대로 사용한다.
-타이틀 포맷은 Step 2 의 `references/prefix-table.md` 참조. 본문은 사용자 대화 언어로
-작성하고 (한국어 대화 → 한국어 이슈) **over-compress 금지** — 파일
-경로·명령 출력·결정·근거를 그대로 유지한다. 200 줄짜리 이슈도 정상.
-
-When `DISCUSSION_MODE=1`, swap the Acceptance Criteria section for an
-**Open Questions** section and use the matching skeleton from
-[[gh-discussion-create]]'s `references/rfc-template.md`
-(Ideas/Q&A/Announcements/Lessons variants). All other detail-preservation
-rules remain identical — Discussions are not a license to compress.
+Use the `references/templates/<prefix>.md` skeleton; title format per
+`references/prefix-table.md`. **Over-compress 금지** — 파일 경로·명령 출력·
+결정·근거 유지 (200줄 이슈도 정상). `DISCUSSION_MODE=1` 일 때는 Acceptance
+Criteria 대신 Open Questions 섹션 + [[gh-discussion-create]] 의
+`references/rfc-template.md` 스켈레톤 사용 (압축 금지 동일).
 
 ## Step 3.5: Compute AI Metrics
 
 Read `references/metrics-baseline.md` and bind `TOKENS`, `HUMAN_H`,
-`ELAPSED` for Step 4. Inputs: `START_TS` from Step 1, the prefix from
-Step 2, the drafted title + body. For `feat`, infer size (small /
-medium / large) from the conversation scope.
+`ELAPSED` for Step 4 (inputs: `START_TS`, the prefix, drafted title+body;
+for `feat` infer small/medium/large from scope).
 
 ## Step 4: Create the Issue (or Discussion)
 
-Read `references/create-cmd.md` and paste the matching bash block
-verbatim:
-
-- **Issue path** (default, `DISCUSSION_MODE` unset) — `mktemp` body
-  file, `GH_DISABLE_AI_METRICS=1` short-circuit (issue #399),
-  ai-metrics footer printf, and `gh issue create` with `LABEL_ARGS` /
-  `MILESTONE_ARGS` from Step 2.5.
-- **Discussion path** (`DISCUSSION_MODE=1`) — same body file +
-  ai-metrics footer, then source
-  `shell-common/functions/gh_discussion.sh` and run the three lookups
-  (`_gh_discussion_repo_id`, `_gh_discussion_category_id`,
-  `_gh_discussion_create`). Print the Discussion URL instead of an
-  issue URL. If the helper is missing, fail with
-  `[FAIL] gh-discussion helper not found at $DOTFILES_ROOT/shell-common/functions/gh_discussion.sh`
-  and exit 1.
-
-확인 질문하지 말고 즉시 실행.
+Follow `references/discussion-dispatch.md`: read `references/create-cmd.md`
+and paste the matching bash block verbatim — Issue path (default) or
+Discussion path (`DISCUSSION_MODE=1`). 확인 질문 없이 즉시 실행.
 
 ## Step 5: Report
 
-Issue 경로 성공 시:
-
-```
-[OK] Issue: #123, URL: https://github.com/owner/repo/issues/123
-Next: /gh:issue-implement 123
-```
-
-Discussion 경로 (`DISCUSSION_MODE=1`) 성공 시 — Discussion URL 만 출력:
-
-```
-[OK] Discussion (<category>): https://github.com/owner/repo/discussions/45
-Next: /gh-discussion-convert 45   # when decision lands
-```
-
-실패 시 (gh stderr 또는 helper stderr 첫 줄을 인용):
-
-```
-[FAIL] <stderr first line>
-Next: <recovery step — e.g. `gh auth login`, fix `.gh-issue-defaults.yml`, enable Discussions in repo settings>
-```
+Output format (Issue / Discussion / failure) is in
+`references/report-template.md`. Always end with an `[OK]`/`[FAIL]` verdict
+line + a `Next:` hint.
 
 ## Constraints
 
-- `--assignee @me` 는 사용자 요청이 있을 때만 추가.
-- 라벨/마일스톤 은 (a) 사용자 명시 또는 (b) Step 2.5 의 SSOT 기반
-  자동 적용 일 때만 부착. 자동 적용 결과는 항상 `gh label list` 검증
-  통과한 라벨만 유지 — 미존재 라벨 자동 생성 금지.
-- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
-- 사용자 지정 remote 가 없으면 즉시 실패.
-- discussion log 를 2~3줄로 압축하지 말 것. `DISCUSSION_MODE=1`
-  경로에서도 동일하게 적용된다 — Discussion 본문은 future-self 검색의
-  SSOT 다.
-- `--as-discussion` 는 명시적 사용자 의도 전용. AI 가 "이건 Discussion
-  같음" 자동 판정해서 분기하지 말 것 (#619 Non-Goal). 잘못된 분기 =
-  SSOT 분산.
-- `--as-discussion` + `--label` / `--assignee` 동시 사용 시 후자를
-  버리고 경고 1줄. `DISCUSSION_MODE=1` 일 때 Step 2.5 와 `gh issue
-  create` 둘 다 우회.
-- "should I create it?" 같은 확인 질문 금지.
+See `references/constraints.md` (assignee/label rules, always
+`--repo "$TARGET_REPO"`, fail-fast on missing remote, no over-compression,
+`--as-discussion` explicit-intent only, no confirmation prompts).

--- a/claude/skills/gh-issue-create/references/constraints.md
+++ b/claude/skills/gh-issue-create/references/constraints.md
@@ -1,0 +1,18 @@
+# gh:issue-create — Constraints
+
+- `--assignee @me` 는 사용자 요청이 있을 때만 추가.
+- 라벨/마일스톤 은 (a) 사용자 명시 또는 (b) Step 2.5 의 SSOT 기반
+  자동 적용 일 때만 부착. 자동 적용 결과는 항상 `gh label list` 검증
+  통과한 라벨만 유지 — 미존재 라벨 자동 생성 금지.
+- 항상 `--repo "$TARGET_REPO"` — 암묵적 repo 감지 의존 금지.
+- 사용자 지정 remote 가 없으면 즉시 실패.
+- discussion log 를 2~3줄로 압축하지 말 것. `DISCUSSION_MODE=1`
+  경로에서도 동일하게 적용된다 — Discussion 본문은 future-self 검색의
+  SSOT 다.
+- `--as-discussion` 는 명시적 사용자 의도 전용. AI 가 "이건 Discussion
+  같음" 자동 판정해서 분기하지 말 것 (#619 Non-Goal). 잘못된 분기 =
+  SSOT 분산.
+- `--as-discussion` + `--label` / `--assignee` 동시 사용 시 후자를
+  버리고 경고 1줄. `DISCUSSION_MODE=1` 일 때 Step 2.5 와 `gh issue
+  create` 둘 다 우회.
+- "should I create it?" 같은 확인 질문 금지.

--- a/claude/skills/gh-issue-create/references/discussion-dispatch.md
+++ b/claude/skills/gh-issue-create/references/discussion-dispatch.md
@@ -1,0 +1,19 @@
+# gh:issue-create — Create dispatch (Step 4)
+
+Read `references/create-cmd.md` and paste the matching bash block
+verbatim:
+
+- **Issue path** (default, `DISCUSSION_MODE` unset) — `mktemp` body
+  file, `GH_DISABLE_AI_METRICS=1` short-circuit (issue #399),
+  ai-metrics footer printf, and `gh issue create` with `LABEL_ARGS` /
+  `MILESTONE_ARGS` from Step 2.5.
+- **Discussion path** (`DISCUSSION_MODE=1`) — same body file +
+  ai-metrics footer, then source
+  `shell-common/functions/gh_discussion.sh` and run the three lookups
+  (`_gh_discussion_repo_id`, `_gh_discussion_category_id`,
+  `_gh_discussion_create`). Print the Discussion URL instead of an
+  issue URL. If the helper is missing, fail with
+  `[FAIL] gh-discussion helper not found at $DOTFILES_ROOT/shell-common/functions/gh_discussion.sh`
+  and exit 1.
+
+확인 질문하지 말고 즉시 실행.

--- a/claude/skills/gh-issue-create/references/discussion-mode.md
+++ b/claude/skills/gh-issue-create/references/discussion-mode.md
@@ -1,0 +1,15 @@
+# gh:issue-create — `--as-discussion` parse (Step 1.1)
+
+If `--as-discussion <category>` is present, bind `DISCUSSION_MODE=1` and
+`CATEGORY=<value>`. Validate `<value>` against the allow-list
+`Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive); on
+mismatch, print the four allowed values and **exit 3** without calling
+any API. When `DISCUSSION_MODE=1` and the user also supplied `--label`
+or `--assignee`, emit a 1-line warning to stderr and drop those flags
+(Discussions do not carry labels/assignees):
+
+```
+[gh-issue-create] --as-discussion: dropping --label/--assignee (Discussions do not carry these)
+```
+
+When `DISCUSSION_MODE` is unset the legacy issue path is unchanged.

--- a/claude/skills/gh-issue-create/references/options.md
+++ b/claude/skills/gh-issue-create/references/options.md
@@ -1,0 +1,12 @@
+# gh:issue-create — Options
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `[remote]` (positional) | Target remote name. Resolved to `TARGET_REPO=<owner>/<repo>`. Fails fast if missing. | `origin` |
+| `--no-auto-labels` | Skip Step 2.5 entirely; user `--label` flags remain in effect. | off |
+| `--auto-label-debug` | Verbose stderr trace of Stage-1 detection and the kept/dropped label sets. | off |
+| `--label <name>` | User label, union with Step 2.5 auto-labels. Repeatable. | — |
+| `--assignee @me` | Only added when the user explicitly asks. | off |
+| `--as-discussion <category>` | Route to [[gh-discussion-create]] instead of creating an Issue. Category is one of `Ideas` / `Q&A` / `Announcements` / `Lessons` (case-insensitive). Skips Step 2.5 (auto-labels) and Step 4's `gh issue create` — Discussions do not carry labels/milestones. `--label` / `--assignee` flags, if also passed, are ignored with a 1-line warning. | off |
+| `GH_DISABLE_AI_METRICS=1` (env) | Skip ai-metrics footer append in Step 4. | off |
+| `-h`/`--help`/`help` | Print `references/help.md` verbatim and stop. | — |

--- a/claude/skills/gh-issue-create/references/report-template.md
+++ b/claude/skills/gh-issue-create/references/report-template.md
@@ -1,0 +1,22 @@
+# gh:issue-create — Report (Step 5)
+
+Issue 경로 성공 시:
+
+```
+[OK] Issue: #123, URL: https://github.com/owner/repo/issues/123
+Next: /gh:issue-implement 123
+```
+
+Discussion 경로 (`DISCUSSION_MODE=1`) 성공 시 — Discussion URL 만 출력:
+
+```
+[OK] Discussion (<category>): https://github.com/owner/repo/discussions/45
+Next: /gh-discussion-convert 45   # when decision lands
+```
+
+실패 시 (gh stderr 또는 helper stderr 첫 줄을 인용):
+
+```
+[FAIL] <stderr first line>
+Next: <recovery step — e.g. `gh auth login`, fix `.gh-issue-defaults.yml`, enable Discussions in repo settings>
+```

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -2,248 +2,98 @@
 name: gh:issue-flow
 description: >-
   Composition skill that chains gh:issue-implement → gh:commit → gh:pr
-  → devx:schedule (pr-reply, 5 min) → gh:pr-resolve-conflict for a
-  single issue number. Use when the user runs /gh:issue-flow,
-  /gh-issue-flow, or asks "issue #16 처음부터 PR까지 자동으로",
-  "이슈 구현하고 커밋하고 PR까지 한방에", "full flow on #42". Uses
-  direct implementation mode only — for plan/brainstorming modes, use
-  the atomic gh:issue-implement skill manually. Stops on first step
-  failure with a resume-instructions report. Precondition: already on
-  a feature branch in a dedicated worktree. Accepts
-  `<issue-number> [remote]` and `-h`/`--help`/`help`.
+  → devx:schedule (pr-reply, 5 min) → gh:pr-resolve-conflict for a single
+  issue number. Use when the user runs /gh:issue-flow, /gh-issue-flow, or
+  asks "issue #16 처음부터 PR까지 자동으로", "이슈 구현하고 커밋하고 PR까지
+  한방에", "full flow on #42". Uses direct implementation mode only — for
+  plan/brainstorming modes, use the atomic gh:issue-implement skill
+  manually. Stops on first step failure with a resume-instructions report.
+  Precondition: already on a feature branch in a dedicated worktree.
+  Accepts `<issue-number> [remote]` and `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "composite orchestration (implement→commit→PR→reply→rebase); chain dispatcher with stop-on-error"
+    claude: prefer
+    non_claude: advisory-only
 ---
 
 # gh:issue-flow — Issue → PR composition
 
 ## CRITICAL CONTRACT — read before editing
 
-**Recurring failure mode: early-stop after Step 2.x.** When a sub-skill
-(`gh:issue-implement`, `gh:commit`, …) returns, the model treats its own
-self-authored success block as a turn-ending answer and stops mid-chain —
-leaving the user to manually re-trigger the rest. Reported by users as
-"100번 실행하면 50번은 stop" (half of all runs stop early). History:
-issue #333 (introduced `--no-next-hint`), issue #383 (re-occurred even
-with `--no-next-hint`).
-
-**Three guards are layered against this — do not remove any of them.**
-
-1. **`--no-next-hint` on Step 2.1** — suppresses `gh:issue-implement`'s
-   trailing `Next:` hint, the original trip-wire from #333. Load-bearing
-   even though insufficient on its own (see #383).
-2. **Zero conversational text between the five `Skill()` calls in Step 2** —
-   no recap, no "now committing", no markdown headers, no progress
-   bullets. Those tokens read as a turn-ending summary and re-introduce
-   the early-stop. The only prose allowed inside Step 2 is the final
-   Step 3 report.
-3. **Harness Stop hook (`claude/hooks/gh_issue_flow_stop_guard.py`)** —
-   when the model nonetheless tries to end its turn mid-flow, this hook
-   parses the transcript, detects that fewer than 5 sub-skills have run
-   without a Step 3 marker, and returns `{"decision":"block","reason":...}`
-   so Claude Code re-prompts the model to invoke the next sub-skill.
-   See `references/stop-guard.md` for the detection logic, safety rails,
-   and how to disable it temporarily for debugging.
-
-If you edit Step 2 in any way, re-verify all three guards are still in
-place. The harness guard is a backstop, not a license to weaken the
-prose rules — Claude can still emit verbose text BEFORE attempting to
-stop, which the hook cannot prevent.
+**Recurring failure mode: early-stop after Step 2.x.** Three layered guards
+prevent it — (1) `--no-next-hint` on Step 2.1, (2) zero conversational text
+between the five `Skill()` calls in Step 2, (3) the harness Stop hook
+(`claude/hooks/gh_issue_flow_stop_guard.py`). **Do not remove any of them.**
+Full failure history (#333, #383), guard rationale, and the
+backstop-not-a-license rule are in `references/critical-contract.md` — read
+it before editing Step 2.
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
-
-The help output explicitly names the 5 chained skills:
-gh:issue-implement, gh:commit, gh:pr, devx:schedule, gh:pr-resolve-conflict.
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No API calls. The help output explicitly
+names the 5 chained skills: gh:issue-implement, gh:commit, gh:pr,
+devx:schedule, gh:pr-resolve-conflict.
 
 ## Step 1: Parse Args
 
-- `issue-number` — required, positive integer.
-- `remote` — default `origin`.
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `<issue-number>` | 처리할 GitHub Issue 번호 (양의 정수) | — |
+| `[remote]` | git remote 이름 | `origin` |
+| `-h`/`--help`/`help` | usage 출력 후 정지 | — |
 
-This skill takes no `mode` arg; implementation is always `direct`.
-
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 2.6.
+No `mode` arg — implementation is always `direct`. Record
+`START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 2.6.
 
 ## Step 2: Chain the 5 Skills
 
-Invoke in order. Each uses Claude Code's Skill tool. Each runs only
-if the previous completed successfully.
+Invoke in order; each runs only if the previous succeeded. **Zero
+conversational text between the calls — no recap, headers, or progress
+bullets** (see CRITICAL CONTRACT). After each call, immediately invoke the next.
 
-1. **Step 2.1 — gh:issue-implement**
+1. **Step 2.1 — gh:issue-implement** — `--no-next-hint` is load-bearing.
    ```
    Skill(gh:issue-implement, "<N> direct <remote> --no-next-hint")
    ```
-   `--no-next-hint` is **load-bearing** — it suppresses the trailing
-   `Next:` hint that would otherwise read as a turn-ending answer
-   (see CRITICAL CONTRACT above). Track success = skill returned its
-   success report (not failure). **Now invoke Step 2.2 — no recap,
-   no summary, no header.**
-
-2. **Step 2.2 — gh:commit** (only if 2.1 succeeded)
+2. **Step 2.2 — gh:commit** (only if 2.1 succeeded) — auto-detects the issue
+   number from the conversation.
    ```
    Skill(gh:commit)
    ```
-   gh:commit auto-detects the issue number from the conversation
-   (the `#<N>` was just mentioned by Step 2.1's report), so no
-   explicit args needed. **Now invoke Step 2.3 — no recap, no
-   summary, no header.**
-
-3. **Step 2.3 — gh:pr** (only if 2.2 succeeded)
+3. **Step 2.3 — gh:pr** (only if 2.2 succeeded) — ensures `Closes #<N>`;
+   extract `<PR_NUM>` from the PR URL in the output.
    ```
    Skill(gh:pr, "<N>")
    ```
-   Passing the issue number ensures `Closes #<N>` ends up in the PR
-   body via gh:pr's Step 3 (issue resolution).
-   After this step succeeds, extract <PR_NUM> from the PR URL in the
-   output (e.g., 123 from `.../pull/123`).
-   **Now invoke Step 2.4 — no recap, no summary, no header.**
-
-4. **Step 2.4 — devx:schedule** (only if 2.3 succeeded)
+4. **Step 2.4 — devx:schedule** (only if 2.3 succeeded) — schedules
+   `/gh-pr-reply <PR_NUM>` 5 min after PR creation.
    ```
    Skill(devx:schedule, "--time 5 \"/gh-pr-reply <PR_NUM>\"")
    ```
-   Schedules `/gh-pr-reply <PR_NUM>` to run 5 minutes after PR creation,
-   giving CI checks and reviewers time to post before the bot replies.
-   **Now invoke Step 2.5 — no recap, no summary, no header.**
-
-5. **Step 2.5 — gh:pr-resolve-conflict** (only if 2.4 succeeded)
+5. **Step 2.5 — gh:pr-resolve-conflict** (only if 2.4 succeeded) —
+   rebase-resolve; a fresh PR usually prints "이미 충돌 없음 — skip".
    ```
    Skill(gh:pr-resolve-conflict, "<PR_NUM>")
    ```
-   Checks and resolves any merge conflicts in the PR via rebase.
-   If the PR is already conflict-free (`MERGEABLE == MERGEABLE`), the
-   skill prints "PR은 이미 충돌 없음 — skip." and exits successfully —
-   this is the expected case for a freshly created PR. **Now invoke
-   Step 2.6 — no recap, no summary, no header.**
-
-6. **Step 2.6 — Post AI Metrics to Issue** (only if 2.5 succeeded; soft-fail)
-
-   Post a flow-level aggregate metrics comment on the **linked GitHub Issue**.
-   The PR body already carries the per-step `<!-- ai-metrics:gh-pr -->` block
-   written by `gh:pr`; this step adds the total across all five sub-skills to
-   the Issue so the Issue thread is the single place to review full AI effort.
-   This step soft-fails — warn on any error but never block the flow.
-
-   a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
-      Track per-step timing by recording `STEP_TS=$(date +%s)` at the
-      start of each sub-skill and computing its elapsed at the end:
-      - `IMPL_MIN` — elapsed for Step 2.1 (gh:issue-implement)
-      - `COMMIT_MIN` — elapsed for Step 2.2 (gh:commit)
-      - `PR_MIN` — elapsed for Step 2.3 (gh:pr)
-      - `SCHEDULE_MIN` — elapsed for Step 2.4 (devx:schedule)
-      - `CONFLICT_MIN` — elapsed for Step 2.5 (gh:pr-resolve-conflict)
-      Any variable not yet computed defaults to `?` in the template.
-   b. Issue type: parse the conventional-commit prefix from the issue title
-      fetched in Step 2.1 (e.g. `feat`, `fix`, `refactor`).
-   c. Human time: look up the issue type in `gh-issue-create`'s
-      `references/metrics-baseline.md` (in the same skills directory).
-      For `feat`, infer size from the implementation scope.
-   d. Token estimate: character count of (issue body + implementation file reads) ÷ 4,
-      rounded to nearest 500. Minimum 1 000.
-   e. Post the aggregate comment on the linked issue (body template below).
-      Skip the post entirely when `GH_DISABLE_AI_METRICS=1` (issue #399);
-      the five sub-skills already honour the same env var, so a disabled
-      run leaves zero ai-metrics artifacts on the issue or PR.
-   f. On failure: print `[WARN] ai-metrics comment failed (<reason>) — continuing.`
-
-```bash
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
-else
-    gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
-      -X POST \
-      -f body="### gh-issue-flow 완료
-
-| 단계 | AI 소요 |
-|------|---------|
-| gh-issue-implement | ~${IMPL_MIN:-?} min |
-| gh-commit | ~${COMMIT_MIN:-?} min |
-| gh-pr | ~${PR_MIN:-?} min |
-| devx:schedule (pr-reply) | ~${SCHEDULE_MIN:-?} min |
-| gh-pr-resolve-conflict | ~${CONFLICT_MIN:-?} min |
-| **합계** | **~$ELAPSED min** |
-
-예상 사람 시간: ~$HUMAN_H h · 토큰: ~$TOKENS
-
----
-<details>
-<summary>🤖 AI Metrics · 📊 ~$TOKENS tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
-
-<!-- ai-metrics:gh-issue-flow -->
-📊 ~$TOKENS tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
-<!-- /ai-metrics:gh-issue-flow -->
-
-</details>"
-fi
-```
+6. **Step 2.6 — Post AI Metrics to Issue** (only if 2.5 succeeded;
+   soft-fail) — aggregate flow-level metrics comment on the linked Issue.
+   Full procedure (per-step timing, human-time lookup, token estimate,
+   `gh api` body template, `GH_DISABLE_AI_METRICS` short-circuit, soft-fail
+   warning) is in `references/ai-metrics-step.md`.
 
 ## Step 3: Report
 
-If all steps succeeded:
-```
-gh:issue-flow complete (#<N>)
-  [OK] Step 1: gh:issue-implement       (<n files changed>, <n tests passed>)
-  [OK] Step 2: gh:commit                (<sha> "<subject>")
-  [OK] Step 3: gh:pr                    (PR #<M>)
-  [OK] Step 4: devx:schedule            (pr-reply in 5 min, job: <id>)
-  [OK] Step 5: gh:pr-resolve-conflict   (no conflicts / resolved)
-  [OK] Step 6: ai-metrics               (~X tokens · ~M h · ~L min)
-  PR URL: <pr-url>
-```
-
-If Step 2.6 soft-failed, show `[WARN] Step 6: ai-metrics  (skipped — <reason>)` instead.
-
-If a step failed:
-```
-gh:issue-flow stopped at step <i>/5 (<skill-name>)
-  [OK] Step 1: gh:issue-implement  (<summary>)
-  [FAIL] Step <i>: <skill-name>       (<failure reason>)
-  [SKIP] Steps <i+1>..5               (not reached)
-
-Resume after fix:
-  /<commands to finish>
-```
-
-Resume hint logic:
-- Failed at step 1 → `/gh-issue-implement <N>` (user decides retry).
-- Failed at step 2 → `/gh-commit && /gh-pr <N>`.
-- Failed at step 3 → `/gh-pr <N>`.
-- Failed at step 4 → `/devx:schedule --time 5 "/gh-pr-reply <PR_NUM>"`.
-- Failed at step 5 → `/gh-pr-resolve-conflict <PR_NUM>`.
+Output format (success template, soft-fail variant, failure template, and
+the per-step resume-hint logic) is defined in `references/report-template.md`.
+Always end with the `[OK]`/`[FAIL]`/`[SKIP]` structured report.
 
 ## Constraints
 
-- Never invoke implementation modes other than `direct`.
-- Never retry a failed step. Human decides retry or fix.
-- Never skip a step. All 5 or stop.
-- Never mutate state between steps beyond what the sub-skills do.
-  Exception: Step 2.6 may post a comment after Step 2.5 — this is
-  intentional and must soft-fail (never block the flow). If a future
-  variant of Step 2.6 needs to mutate PR labels or body, route through
-  `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
-  (`shell-common/functions/gh_pr_edit_safe.sh`); plain `gh pr edit
-  --add-label` / `--body-file` silently exits 1 on repos with classic
-  Projects attached (issue #326 Bug B).
-- Do NOT preface or summarize beyond the compact report.
-- Do NOT end the turn until the Step 3 report is issued (success or
-  failure template). A `Next:` / resume-hint from a sub-skill
-  (notably gh:issue-implement's `Next: /gh-commit && /gh-pr <N>`) is
-  a waypoint during this composition, not a final answer — keep
-  going. Don't let a success hint from 2.1 or 2.2 end the flow
-  before Step 3.
-- **Never drop `--no-next-hint` from the Step 2.1 invocation.** It is
-  the mechanical guard against the early-stop failure mode documented
-  in the CRITICAL CONTRACT section. If a refactor of Step 2 looks
-  cleaner without it, the refactor is wrong.
-- **Zero conversational text between Skill() calls in Step 2.** No
-  recap ("Step 2.1 complete, now committing..."), no progress
-  markdown headers, no per-step bullet summaries. Such text reads as
-  a turn-ending answer and re-introduces the early-stop. The only
-  prose allowed inside Step 2 is the final Step 3 report.
-- **Do NOT stop after any sub-skill completes.** Each step (2.1 through
-  2.5) is a waypoint, not a final answer. Continue to the next step
-  immediately. The only valid stopping points are: a step failure
-  (output the failure report), or the Step 3 success report after all
-  5 steps complete.
+See `references/constraints.md` for the full list (direct mode only, never
+retry/skip a step, no state mutation beyond sub-skills, the Step 2.6
+soft-fail exception, the `--no-next-hint` and zero-prose early-stop guards,
+and the do-not-stop-mid-flow rule).

--- a/claude/skills/gh-issue-flow/references/ai-metrics-step.md
+++ b/claude/skills/gh-issue-flow/references/ai-metrics-step.md
@@ -1,0 +1,61 @@
+# gh:issue-flow — Step 2.6: Post AI Metrics to Issue (soft-fail)
+
+Runs only if Step 2.5 succeeded. Post a flow-level aggregate metrics
+comment on the **linked GitHub Issue**. The PR body already carries the
+per-step `<!-- ai-metrics:gh-pr -->` block written by `gh:pr`; this step
+adds the total across all five sub-skills to the Issue so the Issue thread
+is the single place to review full AI effort. This step soft-fails — warn
+on any error but never block the flow.
+
+a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
+   Track per-step timing by recording `STEP_TS=$(date +%s)` at the
+   start of each sub-skill and computing its elapsed at the end:
+   - `IMPL_MIN` — elapsed for Step 2.1 (gh:issue-implement)
+   - `COMMIT_MIN` — elapsed for Step 2.2 (gh:commit)
+   - `PR_MIN` — elapsed for Step 2.3 (gh:pr)
+   - `SCHEDULE_MIN` — elapsed for Step 2.4 (devx:schedule)
+   - `CONFLICT_MIN` — elapsed for Step 2.5 (gh:pr-resolve-conflict)
+   Any variable not yet computed defaults to `?` in the template.
+b. Issue type: parse the conventional-commit prefix from the issue title
+   fetched in Step 2.1 (e.g. `feat`, `fix`, `refactor`).
+c. Human time: look up the issue type in `gh-issue-create`'s
+   `references/metrics-baseline.md` (in the same skills directory).
+   For `feat`, infer size from the implementation scope.
+d. Token estimate: character count of (issue body + implementation file
+   reads) ÷ 4, rounded to nearest 500. Minimum 1 000.
+e. Post the aggregate comment on the linked issue (body template below).
+   Skip the post entirely when `GH_DISABLE_AI_METRICS=1` (issue #399);
+   the five sub-skills already honour the same env var, so a disabled
+   run leaves zero ai-metrics artifacts on the issue or PR.
+f. On failure: print `[WARN] ai-metrics comment failed (<reason>) — continuing.`
+
+```bash
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$ISSUE_NUMBER/comments" \
+      -X POST \
+      -f body="### gh-issue-flow 완료
+
+| 단계 | AI 소요 |
+|------|---------|
+| gh-issue-implement | ~${IMPL_MIN:-?} min |
+| gh-commit | ~${COMMIT_MIN:-?} min |
+| gh-pr | ~${PR_MIN:-?} min |
+| devx:schedule (pr-reply) | ~${SCHEDULE_MIN:-?} min |
+| gh-pr-resolve-conflict | ~${CONFLICT_MIN:-?} min |
+| **합계** | **~$ELAPSED min** |
+
+예상 사람 시간: ~$HUMAN_H h · 토큰: ~$TOKENS
+
+---
+<details>
+<summary>🤖 AI Metrics · 📊 ~$TOKENS tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-issue-flow -->
+📊 ~$TOKENS tokens · 👤 ~$HUMAN_H h · 🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-issue-flow -->
+
+</details>"
+fi
+```

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -1,0 +1,34 @@
+# gh:issue-flow — Constraints
+
+- Never invoke implementation modes other than `direct`.
+- Never retry a failed step. Human decides retry or fix.
+- Never skip a step. All 5 or stop.
+- Never mutate state between steps beyond what the sub-skills do.
+  Exception: Step 2.6 may post a comment after Step 2.5 — this is
+  intentional and must soft-fail (never block the flow). If a future
+  variant of Step 2.6 needs to mutate PR labels or body, route through
+  `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
+  (`shell-common/functions/gh_pr_edit_safe.sh`); plain `gh pr edit
+  --add-label` / `--body-file` silently exits 1 on repos with classic
+  Projects attached (issue #326 Bug B).
+- Do NOT preface or summarize beyond the compact report.
+- Do NOT end the turn until the Step 3 report is issued (success or
+  failure template). A `Next:` / resume-hint from a sub-skill
+  (notably gh:issue-implement's `Next: /gh-commit && /gh-pr <N>`) is
+  a waypoint during this composition, not a final answer — keep
+  going. Don't let a success hint from 2.1 or 2.2 end the flow
+  before Step 3.
+- **Never drop `--no-next-hint` from the Step 2.1 invocation.** It is
+  the mechanical guard against the early-stop failure mode documented
+  in `references/critical-contract.md`. If a refactor of Step 2 looks
+  cleaner without it, the refactor is wrong.
+- **Zero conversational text between Skill() calls in Step 2.** No
+  recap ("Step 2.1 complete, now committing..."), no progress
+  markdown headers, no per-step bullet summaries. Such text reads as
+  a turn-ending answer and re-introduces the early-stop. The only
+  prose allowed inside Step 2 is the final Step 3 report.
+- **Do NOT stop after any sub-skill completes.** Each step (2.1 through
+  2.5) is a waypoint, not a final answer. Continue to the next step
+  immediately. The only valid stopping points are: a step failure
+  (output the failure report), or the Step 3 success report after all
+  5 steps complete.

--- a/claude/skills/gh-issue-flow/references/critical-contract.md
+++ b/claude/skills/gh-issue-flow/references/critical-contract.md
@@ -1,0 +1,32 @@
+# gh:issue-flow — CRITICAL CONTRACT (read before editing Step 2)
+
+**Recurring failure mode: early-stop after Step 2.x.** When a sub-skill
+(`gh:issue-implement`, `gh:commit`, …) returns, the model treats its own
+self-authored success block as a turn-ending answer and stops mid-chain —
+leaving the user to manually re-trigger the rest. Reported by users as
+"100번 실행하면 50번은 stop" (half of all runs stop early). History:
+issue #333 (introduced `--no-next-hint`), issue #383 (re-occurred even
+with `--no-next-hint`).
+
+**Three guards are layered against this — do not remove any of them.**
+
+1. **`--no-next-hint` on Step 2.1** — suppresses `gh:issue-implement`'s
+   trailing `Next:` hint, the original trip-wire from #333. Load-bearing
+   even though insufficient on its own (see #383).
+2. **Zero conversational text between the five `Skill()` calls in Step 2** —
+   no recap, no "now committing", no markdown headers, no progress
+   bullets. Those tokens read as a turn-ending summary and re-introduce
+   the early-stop. The only prose allowed inside Step 2 is the final
+   Step 3 report.
+3. **Harness Stop hook (`claude/hooks/gh_issue_flow_stop_guard.py`)** —
+   when the model nonetheless tries to end its turn mid-flow, this hook
+   parses the transcript, detects that fewer than 5 sub-skills have run
+   without a Step 3 marker, and returns `{"decision":"block","reason":...}`
+   so Claude Code re-prompts the model to invoke the next sub-skill.
+   See `references/stop-guard.md` for the detection logic, safety rails,
+   and how to disable it temporarily for debugging.
+
+If you edit Step 2 in any way, re-verify all three guards are still in
+place. The harness guard is a backstop, not a license to weaken the
+prose rules — Claude can still emit verbose text BEFORE attempting to
+stop, which the hook cannot prevent.

--- a/claude/skills/gh-issue-flow/references/report-template.md
+++ b/claude/skills/gh-issue-flow/references/report-template.md
@@ -1,0 +1,35 @@
+# gh:issue-flow — Step 3: Report
+
+If all steps succeeded:
+
+```
+gh:issue-flow complete (#<N>)
+  [OK] Step 1: gh:issue-implement       (<n files changed>, <n tests passed>)
+  [OK] Step 2: gh:commit                (<sha> "<subject>")
+  [OK] Step 3: gh:pr                    (PR #<M>)
+  [OK] Step 4: devx:schedule            (pr-reply in 5 min, job: <id>)
+  [OK] Step 5: gh:pr-resolve-conflict   (no conflicts / resolved)
+  [OK] Step 6: ai-metrics               (~X tokens · ~M h · ~L min)
+  PR URL: <pr-url>
+```
+
+If Step 2.6 soft-failed, show `[WARN] Step 6: ai-metrics  (skipped — <reason>)` instead.
+
+If a step failed:
+
+```
+gh:issue-flow stopped at step <i>/5 (<skill-name>)
+  [OK] Step 1: gh:issue-implement  (<summary>)
+  [FAIL] Step <i>: <skill-name>       (<failure reason>)
+  [SKIP] Steps <i+1>..5               (not reached)
+
+Resume after fix:
+  /<commands to finish>
+```
+
+Resume hint logic:
+- Failed at step 1 → `/gh-issue-implement <N>` (user decides retry).
+- Failed at step 2 → `/gh-commit && /gh-pr <N>`.
+- Failed at step 3 → `/gh-pr <N>`.
+- Failed at step 4 → `/devx:schedule --time 5 "/gh-pr-reply <PR_NUM>"`.
+- Failed at step 5 → `/gh-pr-resolve-conflict <PR_NUM>`.


### PR DESCRIPTION
## 배경

`#862` (NEEDS WORK 25개 일괄 처리) 의 **PR-NW-6** — `gh-issue-*` 2개 스킬의
line-count 초과(Check 1 FAIL)를 `references/` 추출로 해소하고, Check 12
`model_recommendation` 메타데이터를 추가한다.

- #847 gh-issue-create — 177L, 8/12 PASS · 2 WARN · 2 FAIL
- #848 gh-issue-flow — 249L, 7/12 PASS · 2 WARN · 3 FAIL (composite skill)

## 변경 내용

### gh-issue-create (#847) — 177L → 100L

본문을 workflow phase 만 남기고 상세를 `references/` 로 추출:

| 추출 대상 | 새 파일 |
|---|---|
| Options 테이블 | `references/options.md` |
| Step 1.1 `--as-discussion` parse | `references/discussion-mode.md` |
| Step 4 Issue/Discussion dispatch | `references/discussion-dispatch.md` |
| Step 5 Report 템플릿 | `references/report-template.md` |
| Constraints | `references/constraints.md` |

- frontmatter 에 `metadata.model_recommendation` (tier: **sonnet**) 추가.

### gh-issue-flow (#848) — 249L → 99L

| 추출 대상 | 새 파일 |
|---|---|
| CRITICAL CONTRACT (early-stop 가드 해설) | `references/critical-contract.md` |
| Step 2.6 ai-metrics 본문 + bash | `references/ai-metrics-step.md` |
| Step 3 Report + resume-hint 로직 | `references/report-template.md` |
| Constraints | `references/constraints.md` |

- Step 1 에 **Options 테이블** 추가 (Check 8 WARN 해소).
- frontmatter 에 `metadata.model_recommendation` (tier: **sonnet**) 추가.
- **early-stop 3-guard 보존** — `--no-next-hint`(Step 2.1), Step 2 내
  zero-prose 규칙, harness Stop hook. 본문에 요약 + 가드별 inline 유지,
  해설은 `critical-contract.md` 로 분리. 5-skill chain sequence 무변경.

## skill:check 결과 (12/12 PASS · N/A 제외)

| # | Check | create | flow |
|---|---|---|---|
| 1 | Line Count | PASS (100) | PASS (99) |
| 2 | Progressive Disclosure | PASS | PASS |
| 8 | Options Documentation | PASS | PASS (신규 표) |
| 11 | No Emojis | N/A (allowlist) | N/A (allowlist) |
| 12 | Model Recommendation | PASS (sonnet) | PASS (sonnet) |

- Check 11: 두 스킬은 `allowed-emoji-skills.txt` 에 이미 등재됨 (PR-NW-1
  기머지) → **본 PR 은 allowlist 미변경**. ai-metrics footer 글리프는
  추출된 `gh-issue-flow/references/ai-metrics-step.md` 로 이동.
- gh-issue-flow Sub-skill Model Plan: `gh-issue-implement`=opus,
  `devx-schedule`=haiku 는 채워짐. `gh-commit`/`gh-pr`/`gh-pr-resolve-conflict`
  은 아직 `unknown` (각 PR-NW-4/5 소관) — 본 PR 범위 외.

## 검증

- `wc -l` — gh-issue-create 100L, gh-issue-flow 99L (둘 다 ≤100).
- SKILL.md 본문 emoji 0건 (`U+1F300–1FAFF` / `U+2600–27BF` grep).
- 모든 `references/*` 링크 대상 파일 존재 확인.
- pre-commit / pre-push hook 통과.

## 동작 무변경

- gh-issue-create: Issue/Discussion dispatch, auto-labels, clarification
  guard 로직 동일 (추출만, 의미 변경 없음).
- gh-issue-flow: 5-skill chain, stop-guard, `--no-next-hint`, Step 2.6
  soft-fail 보존.

Closes #847
Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)
