### PR TITLE
feat(skills): #887 claude-plugin:structure-check / structure-refactor 자매 스킬 신규

### DIFF
--- a/claude/skills/claude-plugin-structure-check/SKILL.md
+++ b/claude/skills/claude-plugin-structure-check/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: claude-plugin:structure-check
+description: >-
+  Audit a claude-plugin marketplace repo (e.g. `claude-plugin-visuals`)
+  against the standard directory layout and report PASS/WARN/FAIL/N/A.
+  Read-only — never edits. Discovers plugins/skills dynamically by directory
+  scan, then evaluates mandatory items M1-M6 (FAIL) and recommended items
+  R1-R4 (WARN). Use when the user says "check my claude-plugin repo
+  structure", "is this marketplace repo standard?", "audit plugin layout",
+  "/claude-plugin:structure-check". Sister skill of
+  `claude-plugin:structure-refactor` (which fixes what this finds). Do NOT
+  use for SKILL.md content quality (use `skill:check`) or shell scripts
+  (use `sh:check`).
+compatibility:
+  tools: Read, Glob, Grep, Bash
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "read-only directory-structure audit; dynamic scan + JSON/frontmatter validation; bounded PASS/WARN/FAIL report"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# claude-plugin Structure Auditor
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No filesystem scan.
+
+## Step 1: Resolve Repo Path
+
+- Argument given → audit that path. No argument → audit the current
+  directory.
+- Confirm the path exists; if not, stop with a one-line error pointing to
+  `/claude-plugin:structure-check path/to/repo`.
+- Check `test -d <path>/.git`; not a git repo → continue, but note it
+  (one warning line — the audit still runs).
+
+## Step 2: Discover Plugins + Skills
+
+Read `references/structure-spec.md` for the full standard (it is the
+embedded SSOT). Discover dynamically — never hard-code names:
+
+1. `plugins/*/` → each directory is a plugin.
+2. `plugins/<p>/skills/*/` → each directory is a skill of that plugin.
+
+Record the plugin and skill lists for the report header and for the
+per-skill recommended checks (R1/R2).
+
+## Step 3: Evaluate M1-M6 and R1-R4
+
+For each item in `references/structure-spec.md`, assign exactly one of:
+
+- **PASS** — present and valid.
+- **WARN** — recommended item missing/violated (R1-R4 only).
+- **FAIL** — mandatory item missing/invalid (M1-M6 only).
+- **N/A** — the subject does not exist (e.g. a plugin with 0 skills → its
+  R1/R2 are N/A, not FAIL).
+
+JSON validity (M1, M3): parse with `python3 -m json.tool` (or `jq`); a
+parse error is FAIL, not WARN. Frontmatter validity (M4): the SKILL.md must
+have both `name:` and `description:` keys. R3/R4 use the heuristics defined
+in the spec.
+
+## Step 4: Output the Report
+
+Read `references/report-template.md` for the exact format. The report has a
+header line (path + discovered plugins/skills), a `[필수]` block (M1-M6) and
+a `[권장]` block (R1-R4), then the summary verdict:
+
+- any FAIL → **FAIL**
+- no FAIL but ≥1 WARN → **WARN**
+- all PASS/N/A → **PASS**
+
+Emit the next-action hint **only when** there is ≥1 FAIL or WARN.
+
+## Constraints
+
+- Read-only — never create, move, or edit any file. Fixing is
+  `claude-plugin:structure-refactor`'s job.
+- N/A is not FAIL — a missing *subject* (no skills, no plugins beyond M2)
+  yields N/A for dependent checks.
+- Do not audit SKILL.md *content* (that is `skill:check`) or shell script
+  quality (that is `sh:check`) — only the directory structure.
+- Repo-agnostic: discover plugins/skills by scan; the spec is embedded, not
+  read from the target repo.

--- a/claude/skills/claude-plugin-structure-check/references/help.md
+++ b/claude/skills/claude-plugin-structure-check/references/help.md
@@ -1,0 +1,44 @@
+/claude-plugin:structure-check — Audit a claude-plugin marketplace repo's structure
+
+Usage:
+  /claude-plugin:structure-check [repo-path]
+  /claude-plugin:structure-check help
+
+Arguments:
+  [repo-path]   Path to the claude-plugin repo to audit (optional).
+                Defaults to the current directory.
+
+What it checks (read-only — never edits):
+
+  Mandatory (M1-M6 — missing → FAIL)
+    M1  .claude-plugin/marketplace.json        exists + valid JSON
+    M2  plugins/ with >=1 plugin               at least one plugin
+    M3  plugins/<p>/.claude-plugin/plugin.json exists + valid JSON
+    M4  plugins/<p>/skills/<s>/SKILL.md        exists + name/description
+    M5  docs/skill-guides/ + docs/skill-output/ both directories exist
+    M6  README.md                              exists
+
+  Recommended (R1-R4 — missing → WARN)
+    R1  docs/skill-guides/<skill>.html         per-skill guide
+    R2  docs/skill-output/<skill>-usage.{html,md}  per-skill usage sample
+    R3  README is "Simple"                     links into docs/, not too long
+    R4  naming consistency                     name: colon ↔ directory hyphen
+
+Each item reports PASS / WARN / FAIL / N/A. N/A means the subject does not
+exist (e.g. a plugin with 0 skills → R1/R2 are N/A).
+
+Verdict:
+  any FAIL → FAIL ; no FAIL but >=1 WARN → WARN ; all PASS/N/A → PASS
+
+Examples:
+  /claude-plugin:structure-check
+  /claude-plugin:structure-check ../claude-plugin-visuals
+  /claude-plugin:structure-check help
+
+Sister skill:
+  /claude-plugin:structure-refactor   — fix the structure this audit reports
+                                         (dry-run by default, --apply to write)
+
+Not this skill:
+  /skill:check   — audit a SKILL.md's content quality (Progressive Disclosure)
+  /sh:check      — audit a shell script's quality

--- a/claude/skills/claude-plugin-structure-check/references/report-template.md
+++ b/claude/skills/claude-plugin-structure-check/references/report-template.md
@@ -1,0 +1,54 @@
+# claude-plugin:structure-check — Report Template
+
+Use this exact format when outputting the audit report.
+
+```
+claude-plugin structure check — <repo-path>
+  plugins: <p1> / <p2>   skills: <count>   (git: yes|no)
+
+[필수]
+ PASS  M1 .claude-plugin/marketplace.json (유효)
+ PASS  M2 plugins/ — 1 plugin (visuals)
+ FAIL  M3 plugins/visuals/.claude-plugin/plugin.json 없음
+ FAIL  M4 plugins/visuals/skills/visualize/SKILL.md 없음
+ PASS  M5 docs/skill-guides/, docs/skill-output/
+ PASS  M6 README.md
+
+[권장]
+ WARN  R1 docs/skill-guides/visualize.html 없음
+ N/A   R2 (스킬 없음 — 평가 대상 없음)
+ PASS  R3 README.md 가 docs/ 로 링크 (Simple)
+ PASS  R4 명명 일관성 (claude-plugin:structure-check ↔ 디렉터리)
+
+요약: FAIL (필수 2, 권장 1, N/A 1)
+→ Fix: /claude-plugin:structure-refactor <repo-path>  (먼저 dry-run, 이후 --apply)
+```
+
+## Layout rules
+
+- One line per item: `<RESULT>  <ID> <subject> <note>`.
+- `<RESULT>` is one of `PASS` / `WARN` / `FAIL` / `N/A` (uppercase),
+  left-padded so the IDs align.
+- `[필수]` block lists M1-M6 in order; `[권장]` block lists R1-R4 in order.
+- Header line names the discovered plugins and total skill count — proof
+  the scan was dynamic, not hard-coded.
+
+## Summary line
+
+`요약: <VERDICT> (필수 <fail#>, 권장 <warn#>, N/A <na#>)`
+
+- `<VERDICT>`: `FAIL` if any M failed; else `WARN` if any R warned; else
+  `PASS`.
+- Counts: `필수` = number of FAILs, `권장` = number of WARNs, `N/A` =
+  number of N/A rows. Omit a count that is zero except keep `필수`/`권장`
+  for readability.
+
+## Next-action hint
+
+Emit **only** when the verdict is FAIL or WARN:
+
+`→ Fix: /claude-plugin:structure-refactor <repo-path>  (먼저 dry-run, 이후 --apply)`
+
+When the verdict is PASS, end with a single line and no hint:
+
+`요약: PASS — 표준 구조 준수`

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -61,7 +61,10 @@ hyphen directory form. Mismatch → WARN (same rule as `devx:ai-context`
 ## N/A rule
 
 When the subject of a check does not exist, the check is **N/A**, not FAIL.
-Example: a plugin with 0 skills → R1/R2 are N/A for that plugin.
+Examples: a plugin with 0 skills → R1/R2 are N/A for that plugin; with no
+plugins at all M3 is N/A and with no skills anywhere M4 is N/A — M2 still
+carries the single "no plugins" FAIL, so the absent subject is never
+double-counted as a second FAIL.
 
 ## Summary verdict
 

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -1,0 +1,70 @@
+# claude-plugin Standard Structure — spec SSOT (embedded copy)
+
+Standard directory layout for a **claude-plugin marketplace repo** (e.g.
+`claude-plugin-visuals`). This file is an intentional copy of the design
+SSOT (`docs/feature/superpowers-specs/2026-05-30-claude-plugin-structure-skills-design.md`)
+so each skill installs independently. Keep both copies in sync when the
+spec changes.
+
+`structure-check` evaluates against it (read-only). `structure-refactor`
+edits a repo toward it (dry-run / `--apply`). Plugins and skills are
+discovered **dynamically** by directory scan — the spec is abstract, never
+repo-specific.
+
+## Golden layout
+
+```
+.
+├── .claude-plugin/marketplace.json      # exists + valid JSON       (M1)
+├── plugins/<plugin>/
+│   ├── .claude-plugin/plugin.json       # exists + valid JSON       (M3)
+│   └── skills/<skill>/SKILL.md          # exists + name/description (M4)
+├── docs/skill-guides/                   # directory exists          (M5)
+├── docs/skill-output/                   # directory exists          (M5)
+└── README.md                            # exists                    (M6)
+```
+
+Dynamic discovery order:
+1. `plugins/*/` → each is a plugin.
+2. `plugins/*/skills/*/` → each is a skill of that plugin.
+
+## Mandatory items (FAIL when missing)
+
+| ID | Item | FAIL condition |
+|----|------|----------------|
+| M1 | `.claude-plugin/marketplace.json` | missing or invalid JSON |
+| M2 | `plugins/` dir with ≥1 plugin | missing or 0 plugins |
+| M3 | each `plugins/<p>/.claude-plugin/plugin.json` | missing or invalid JSON |
+| M4 | each `plugins/<p>/skills/<s>/SKILL.md` | missing or frontmatter lacks `name`/`description` |
+| M5 | `docs/skill-guides/` AND `docs/skill-output/` | either directory missing |
+| M6 | `README.md` | missing |
+
+## Recommended items (WARN when missing)
+
+| ID | Item | WARN condition |
+|----|------|----------------|
+| R1 | per-skill `docs/skill-guides/<skill>.html` | that file missing |
+| R2 | per-skill `docs/skill-output/<skill>-usage.{html,md}` | both missing |
+| R3 | README is "Simple" | heuristic violated (below) |
+| R4 | naming consistency | SKILL.md `name:` colon-namespace ↔ directory hyphen mismatch |
+
+**R3 README "Simple" heuristic** — PASS only if all hold; any miss → WARN:
+- at least one link into a `docs/` sub-document (evidence of progressive split);
+- body not excessively long (guide: ≤ ~200 lines excluding code blocks);
+- a skill-description section exists (mentions `plugins`/`skills`).
+
+**R4 naming rule** — directory `claude-plugin-structure-check` ↔ frontmatter
+`name: claude-plugin:structure-check`: the colon-namespace form maps to the
+hyphen directory form. Mismatch → WARN (same rule as `devx:ai-context`
+→ `devx-ai-context`).
+
+## N/A rule
+
+When the subject of a check does not exist, the check is **N/A**, not FAIL.
+Example: a plugin with 0 skills → R1/R2 are N/A for that plugin.
+
+## Summary verdict
+
+- any FAIL → **FAIL**
+- no FAIL, any WARN → **WARN**
+- all PASS/N/A → **PASS**

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: claude-plugin:structure-refactor
+description: >-
+  Fix a claude-plugin marketplace repo's directory structure toward the
+  standard layout. Dry-run by default (plan only, no writes); `--apply`
+  performs changes. Scope `--mp`/`--mandatory` fixes mandatory items M1-M6
+  only (create dirs, `git mv`, minimal marketplace.json/plugin.json
+  skeletons); `--op`/`--recommended` adds recommended R1-R4 fixes (empty
+  placeholder stubs + naming correction). Idempotent. Use when the user
+  says "fix my claude-plugin repo structure", "make this marketplace repo
+  standard", "/claude-plugin:structure-refactor". Sister skill of
+  `claude-plugin:structure-check` (which finds what this fixes). Does NOT
+  generate real guide/usage content — stubs only.
+compatibility:
+  tools: Read, Glob, Grep, Write, Edit, Bash
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "structure correction: dir creation + git mv history-preserving moves + JSON skeletons + placeholder stubs; bounded multi-file write, no deep reasoning"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# claude-plugin Structure Refactorer
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No filesystem changes.
+
+## Step 1: Parse Args + Resolve Path
+
+Positional `[repo-path]` (default = current dir). Flags:
+
+- `--apply` — execute changes. Absent → dry-run (plan only, no writes).
+- `--mandatory` / `--mp` — scope = M1-M6 only (default scope).
+- `--recommended` / `--op` — scope = M1-M6 + R1-R4.
+- `--mp` and `--op` together → error + usage, stop.
+
+Confirm the path exists. `test -d <path>/.git`: not a git repo → warn (moves
+fall back to `mv`). Dirty tree → show the dry-run plan and require an
+explicit `--apply` before writing (never auto-apply on a dirty tree).
+
+## Step 2: Evaluate Current ↔ Target
+
+Read `references/structure-spec.md` (embedded SSOT — identical copy to
+structure-check's). Run the same M1-M6 / R1-R4 evaluation as
+`claude-plugin:structure-check` to compute the current → target diff.
+Discover plugins/skills dynamically (`plugins/*/`, `plugins/*/skills/*/`).
+
+## Step 3: Build the Plan
+
+Read `references/plan-and-report-templates.md`. Produce an ordered change
+list, each tagged with its driving check ID (M1-M6, and R1-R4 only when
+scope is `--op`). Already-correct items produce no action (idempotent).
+
+## Step 4: Dry-run or Apply
+
+- **Dry-run (default)**: print the plan only. Touch nothing.
+- **`--apply`**: execute the plan in order, per
+  `references/plan-and-report-templates.md` → "Apply rules":
+  - create missing dirs: `.claude-plugin/`, `docs/skill-guides/`,
+    `docs/skill-output/`, `plugins/<p>/skills/`;
+  - move misplaced files with `git mv` when possible (else `mv`);
+  - write minimal skeletons for a missing `marketplace.json` / `plugin.json`
+    (filled with discovered plugin/skill names);
+  - **`--op` only**: create empty R1/R2 placeholder stubs (TODO header +
+    "fill with /devx:visualize" comment) and correct R4 naming mismatches.
+
+## Step 5: Report
+
+Use the completion report template in
+`references/plan-and-report-templates.md`. End with `[OK]` or `[FAIL]` plus
+a key=value summary, then the next-action hint:
+
+- after a dry-run: `Next: /claude-plugin:structure-refactor <path> --apply [--op]`
+- after `--apply`: `Next: /claude-plugin:structure-check <path>` (re-verify)
+
+## Constraints
+
+- Dry-run is the default — only `--apply` writes. Never auto-apply on a
+  dirty tree.
+- Idempotent: an already-standard repo (within scope) is a no-op.
+- Placeholder stubs only — never call `/devx:visualize` or
+  `/devx:excalidraw-diagram` to generate real content (that is out of
+  scope; the stub carries a TODO pointing there).
+- Prefer `git mv` to preserve history; fall back to `mv` outside a git repo.
+- Repo-agnostic: discover plugins/skills by scan; the spec is embedded.

--- a/claude/skills/claude-plugin-structure-refactor/references/help.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/help.md
@@ -1,0 +1,54 @@
+/claude-plugin:structure-refactor — Fix a claude-plugin marketplace repo's structure
+
+Usage:
+  /claude-plugin:structure-refactor [repo-path] [--apply] [--mp|--op]
+  /claude-plugin:structure-refactor help
+
+Arguments:
+  [repo-path]   Path to the claude-plugin repo to fix (optional).
+                Defaults to the current directory.
+
+Flags:
+  --apply              Execute the plan. Without it, the skill is DRY-RUN
+                       (prints the plan, writes nothing).
+  --mandatory | --mp   Scope = mandatory items M1-M6 only. (default scope)
+  --recommended | --op Scope = M1-M6 + recommended R1-R4 (placeholder stubs
+                       + naming correction).
+  --mp and --op together → error.
+
+Behavior:
+
+  DRY-RUN (default)    Compute current → target diff and print the ordered
+                       plan. No file is created, moved, or edited.
+  --apply              Run the plan:
+                         - create missing dirs (.claude-plugin/,
+                           docs/skill-guides/, docs/skill-output/,
+                           plugins/<p>/skills/)
+                         - move misplaced files with `git mv` (history-safe;
+                           falls back to `mv` outside a git repo)
+                         - write minimal marketplace.json / plugin.json
+                           skeletons from discovered plugin/skill names
+                         - (--op only) create empty R1/R2 placeholder stubs
+                           and correct R4 naming mismatches
+
+Placeholder stub boundary (--op):
+  Stubs are empty files with a TODO header only. This skill never calls
+  /devx:visualize or /devx:excalidraw-diagram to generate real guide/usage
+  content — the stub carries a comment pointing there for a later pass.
+
+Safety:
+  - Not a git repo → warning (moves use plain `mv`).
+  - Dirty tree → shows dry-run plan; requires explicit --apply to write.
+  - Idempotent: an already-standard repo (within scope) is a no-op.
+
+Examples:
+  /claude-plugin:structure-refactor                  # dry-run, mandatory scope
+  /claude-plugin:structure-refactor --apply          # apply mandatory (= --mp)
+  /claude-plugin:structure-refactor --apply --op     # apply mandatory + recommended
+  /claude-plugin:structure-refactor --op             # dry-run, recommended scope
+  /claude-plugin:structure-refactor ../repo --apply
+  /claude-plugin:structure-refactor help
+
+Sister skill:
+  /claude-plugin:structure-check   — read-only audit (run first, and again
+                                      after --apply to verify)

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -1,0 +1,86 @@
+# claude-plugin:structure-refactor — Plan & Report Templates
+
+## Plan template (dry-run AND the pre-amble of --apply)
+
+```
+claude-plugin structure refactor — <repo-path>   (scope: mandatory|recommended)
+  plugins: <p1> / <p2>   skills: <count>   (git: yes|no, tree: clean|dirty)
+
+계획 (현재 → 목표):
+  [M1] create  .claude-plugin/marketplace.json   (skeleton, 1 plugin)
+  [M3] create  plugins/visuals/.claude-plugin/plugin.json (skeleton)
+  [M4] git mv  visualize/SKILL.md → plugins/visuals/skills/visualize/SKILL.md
+  [M5] mkdir   docs/skill-guides/, docs/skill-output/
+  [R1] stub    docs/skill-guides/visualize.html        (--op only)
+  [R4] rename  name: 교정 → claude-plugin:visualize     (--op only)
+
+총 <n> 변경  (필수 <m>, 권장 <r>)
+```
+
+- One line per change: `[<ID>] <verb>  <path / detail>`.
+- Verbs: `create` (new file), `mkdir` (new dir), `git mv` / `mv` (move),
+  `stub` (empty placeholder), `rename` (frontmatter/dir naming fix).
+- Items already correct produce **no line** (idempotent — proof there is
+  nothing to do is an empty plan + `총 0 변경`).
+- R1-R4 lines appear only when scope is `--op` / `--recommended`.
+
+## Apply rules
+
+Execute the plan in this order so later steps see earlier results:
+
+1. **mkdir** missing dirs: `.claude-plugin/`, `docs/skill-guides/`,
+   `docs/skill-output/`, `plugins/<p>/skills/`.
+2. **move** misplaced files: `git mv <src> <dst>` inside a git repo;
+   `mv <src> <dst>` otherwise. Never overwrite an existing destination.
+3. **skeleton** for a missing JSON:
+   - `marketplace.json`:
+     ```json
+     { "name": "<repo-basename>", "plugins": ["./plugins/<p>"] }
+     ```
+   - `plugins/<p>/.claude-plugin/plugin.json`:
+     ```json
+     { "name": "<p>", "version": "0.0.0", "skills": ["./skills/<s>"] }
+     ```
+   Fill arrays from the dynamically discovered plugin/skill names. Do not
+   clobber a JSON that already parses — only create when missing.
+4. **`--op` only — R1/R2 stubs**: empty placeholder files with a TODO
+   header. Example `docs/skill-guides/<skill>.html`:
+   ```html
+   <!-- TODO: claude-plugin guide for <skill> -->
+   <!-- 이 가이드는 /devx:visualize 로 채우세요 (placeholder stub). -->
+   ```
+   `docs/skill-output/<skill>-usage.md`:
+   ```markdown
+   <!-- TODO: <skill> usage sample — fill with /devx:visualize -->
+   ```
+5. **`--op` only — R4 naming**: when a SKILL.md `name:` colon-namespace ↔
+   directory hyphen form disagree, correct the directory name (prefer
+   `git mv`) so it matches the `name:`; never silently rewrite a correct
+   `name:`.
+
+Skeleton/stub writes never touch a file that already exists — the skill is
+idempotent.
+
+## Completion report template
+
+```
+## claude-plugin:structure-refactor Report
+Repo: <repo-path>
+Mode: dry-run | apply
+Scope: mandatory | recommended
+
+Planned: <n>   Applied: <n>   Skipped (already correct): <n>
+
+<the plan block above, with applied lines marked ✓>
+
+[OK] refactor complete   |   [FAIL] <reason>
+applied=<n> moved=<n> created=<n> stubbed=<n> mode=<dry-run|apply> scope=<mp|op>
+```
+
+End with the next-action hint:
+
+- after a dry-run: `Next: /claude-plugin:structure-refactor <path> --apply [--op]`
+- after `--apply`: `Next: /claude-plugin:structure-check <path>`
+
+A no-op run (nothing to change) still reports `[OK] refactor complete` with
+`applied=0` and the verify hint.

--- a/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
@@ -61,7 +61,10 @@ hyphen directory form. Mismatch → WARN (same rule as `devx:ai-context`
 ## N/A rule
 
 When the subject of a check does not exist, the check is **N/A**, not FAIL.
-Example: a plugin with 0 skills → R1/R2 are N/A for that plugin.
+Examples: a plugin with 0 skills → R1/R2 are N/A for that plugin; with no
+plugins at all M3 is N/A and with no skills anywhere M4 is N/A — M2 still
+carries the single "no plugins" FAIL, so the absent subject is never
+double-counted as a second FAIL.
 
 ## Summary verdict
 

--- a/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
@@ -1,0 +1,70 @@
+# claude-plugin Standard Structure — spec SSOT (embedded copy)
+
+Standard directory layout for a **claude-plugin marketplace repo** (e.g.
+`claude-plugin-visuals`). This file is an intentional copy of the design
+SSOT (`docs/feature/superpowers-specs/2026-05-30-claude-plugin-structure-skills-design.md`)
+so each skill installs independently. Keep both copies in sync when the
+spec changes.
+
+`structure-check` evaluates against it (read-only). `structure-refactor`
+edits a repo toward it (dry-run / `--apply`). Plugins and skills are
+discovered **dynamically** by directory scan — the spec is abstract, never
+repo-specific.
+
+## Golden layout
+
+```
+.
+├── .claude-plugin/marketplace.json      # exists + valid JSON       (M1)
+├── plugins/<plugin>/
+│   ├── .claude-plugin/plugin.json       # exists + valid JSON       (M3)
+│   └── skills/<skill>/SKILL.md          # exists + name/description (M4)
+├── docs/skill-guides/                   # directory exists          (M5)
+├── docs/skill-output/                   # directory exists          (M5)
+└── README.md                            # exists                    (M6)
+```
+
+Dynamic discovery order:
+1. `plugins/*/` → each is a plugin.
+2. `plugins/*/skills/*/` → each is a skill of that plugin.
+
+## Mandatory items (FAIL when missing)
+
+| ID | Item | FAIL condition |
+|----|------|----------------|
+| M1 | `.claude-plugin/marketplace.json` | missing or invalid JSON |
+| M2 | `plugins/` dir with ≥1 plugin | missing or 0 plugins |
+| M3 | each `plugins/<p>/.claude-plugin/plugin.json` | missing or invalid JSON |
+| M4 | each `plugins/<p>/skills/<s>/SKILL.md` | missing or frontmatter lacks `name`/`description` |
+| M5 | `docs/skill-guides/` AND `docs/skill-output/` | either directory missing |
+| M6 | `README.md` | missing |
+
+## Recommended items (WARN when missing)
+
+| ID | Item | WARN condition |
+|----|------|----------------|
+| R1 | per-skill `docs/skill-guides/<skill>.html` | that file missing |
+| R2 | per-skill `docs/skill-output/<skill>-usage.{html,md}` | both missing |
+| R3 | README is "Simple" | heuristic violated (below) |
+| R4 | naming consistency | SKILL.md `name:` colon-namespace ↔ directory hyphen mismatch |
+
+**R3 README "Simple" heuristic** — PASS only if all hold; any miss → WARN:
+- at least one link into a `docs/` sub-document (evidence of progressive split);
+- body not excessively long (guide: ≤ ~200 lines excluding code blocks);
+- a skill-description section exists (mentions `plugins`/`skills`).
+
+**R4 naming rule** — directory `claude-plugin-structure-check` ↔ frontmatter
+`name: claude-plugin:structure-check`: the colon-namespace form maps to the
+hyphen directory form. Mismatch → WARN (same rule as `devx:ai-context`
+→ `devx-ai-context`).
+
+## N/A rule
+
+When the subject of a check does not exist, the check is **N/A**, not FAIL.
+Example: a plugin with 0 skills → R1/R2 are N/A for that plugin.
+
+## Summary verdict
+
+- any FAIL → **FAIL**
+- no FAIL, any WARN → **WARN**
+- all PASS/N/A → **PASS**

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -59,7 +59,8 @@ cps_check_M3() {
     done <<EOF
 $(_cps_plugins "$1")
 EOF
-    [ "$_any" -eq 1 ] && echo PASS || echo FAIL
+    # No plugins → subject absent → N/A (M2 already owns the "0 plugins" FAIL).
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
 cps_check_M4() {
@@ -85,7 +86,8 @@ EOF
     done <<EOF
 $(_cps_plugins "$1")
 EOF
-    [ "$_any" -eq 1 ] && echo PASS || echo FAIL
+    # No skills anywhere → subject absent → N/A, not FAIL (N/A rule).
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
 cps_check_M5() {
@@ -156,7 +158,8 @@ cps_check_R4() {
             _sm="$1/plugins/$_p/skills/$_s/SKILL.md"
             [ -f "$_sm" ] || continue
             _any=1
-            _name="$(grep -m1 '^name:' "$_sm" | sed 's/^name:[[:space:]]*//')"
+            # strip leading `name:` + surrounding spaces/quotes (single & double)
+            _name="$(grep -m1 '^name:' "$_sm" | sed 's/^name:[[:space:]'\''" ]*//;s/[[:space:]'\''" ]*$//')"
             _expect="$(printf '%s' "$_name" | tr ':' '-')"
             [ "$_expect" = "$_s" ] || {
                 echo WARN
@@ -204,24 +207,37 @@ cps_refactor() {
     mkdir -p "$_repo/docs/skill-guides" "$_repo/docs/skill-output"
     mkdir -p "$_repo/.claude-plugin"
 
-    # M1 marketplace.json skeleton (only if missing/invalid)
+    # M1 marketplace.json skeleton (only if missing/invalid) — list ALL plugins
     if ! _cps_json_ok "$_repo/.claude-plugin/marketplace.json"; then
-        local _first_p
-        _first_p="$(_cps_plugins "$_repo" | head -n1)"
-        printf '{ "name": "%s", "plugins": ["./plugins/%s"] }\n' \
-            "$(basename "$_repo")" "${_first_p:-plugin}" \
+        local _p _plugins_json=""
+        while IFS= read -r _p; do
+            [ -n "$_p" ] || continue
+            [ -n "$_plugins_json" ] && _plugins_json="${_plugins_json}, "
+            _plugins_json="${_plugins_json}\"./plugins/${_p}\""
+        done <<EOF
+$(_cps_plugins "$_repo")
+EOF
+        printf '{ "name": "%s", "plugins": [%s] }\n' \
+            "$(basename "$_repo")" "${_plugins_json:-\"./plugins/plugin\"}" \
             >"$_repo/.claude-plugin/marketplace.json"
     fi
 
-    # M3 per-plugin plugin.json skeleton
-    local _p _s
+    # M3 per-plugin plugin.json skeleton — list ALL skills of each plugin
+    local _p _s _skills_json
     while IFS= read -r _p; do
         [ -n "$_p" ] || continue
         mkdir -p "$_repo/plugins/$_p/.claude-plugin"
         if ! _cps_json_ok "$_repo/plugins/$_p/.claude-plugin/plugin.json"; then
-            _s="$(_cps_skills "$_repo" "$_p" | head -n1)"
-            printf '{ "name": "%s", "version": "0.0.0", "skills": ["./skills/%s"] }\n' \
-                "$_p" "${_s:-skill}" \
+            _skills_json=""
+            while IFS= read -r _s; do
+                [ -n "$_s" ] || continue
+                [ -n "$_skills_json" ] && _skills_json="${_skills_json}, "
+                _skills_json="${_skills_json}\"./skills/${_s}\""
+            done <<EOF
+$(_cps_skills "$_repo" "$_p")
+EOF
+            printf '{ "name": "%s", "version": "0.0.0", "skills": [%s] }\n' \
+                "$_p" "${_skills_json:-\"./skills/skill\"}" \
                 >"$_repo/plugins/$_p/.claude-plugin/plugin.json"
         fi
     done <<EOF

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/claude_plugin_structure.sh
+# Source-of-truth mirror for the structure spec documented in
+#   claude/skills/claude-plugin-structure-check/references/structure-spec.md
+#   claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+#
+# The two skills are AI-interpreted markdown with no shell entry point;
+# these functions are the executable form of their M1-M6 / R1-R4 evaluation
+# and the refactor apply logic, so bats can pin the behavior against real
+# fixture repos. Keep them in sync with structure-spec.md whenever the spec
+# changes.
+#
+# All functions take an explicit <repo> path — no globals, no network.
+
+# ---- JSON validity helper ------------------------------------------------
+_cps_json_ok() {
+    # $1 = path to a JSON file. 0 if it exists and parses, 1 otherwise.
+    [ -f "$1" ] || return 1
+    jq empty "$1" >/dev/null 2>&1
+}
+
+# ---- dynamic discovery ---------------------------------------------------
+_cps_plugins() {
+    # echo plugin basenames, one per line (dirs under plugins/).
+    [ -d "$1/plugins" ] || return 0
+    for _p in "$1"/plugins/*/; do
+        [ -d "$_p" ] || continue
+        basename "$_p"
+    done
+}
+
+_cps_skills() {
+    # $1=repo $2=plugin -> skill basenames under plugins/<p>/skills/.
+    local _sd="$1/plugins/$2/skills"
+    [ -d "$_sd" ] || return 0
+    for _s in "$_sd"/*/; do
+        [ -d "$_s" ] || continue
+        basename "$_s"
+    done
+}
+
+# ---- mandatory checks (M1-M6) -- echo PASS|FAIL -------------------------
+cps_check_M1() { _cps_json_ok "$1/.claude-plugin/marketplace.json" && echo PASS || echo FAIL; }
+
+cps_check_M2() {
+    [ "$(_cps_plugins "$1" | grep -c .)" -ge 1 ] && echo PASS || echo FAIL
+}
+
+cps_check_M3() {
+    # every plugin must carry a valid plugin.json
+    local _p _any=0
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        _any=1
+        _cps_json_ok "$1/plugins/$_p/.claude-plugin/plugin.json" || {
+            echo FAIL
+            return
+        }
+    done <<EOF
+$(_cps_plugins "$1")
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo FAIL
+}
+
+cps_check_M4() {
+    # every skill must have a SKILL.md with name: and description:
+    local _p _s _any=0 _sm
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            _any=1
+            _sm="$1/plugins/$_p/skills/$_s/SKILL.md"
+            [ -f "$_sm" ] || {
+                echo FAIL
+                return
+            }
+            if ! grep -q '^name:' "$_sm" || ! grep -q '^description:' "$_sm"; then
+                echo FAIL
+                return
+            fi
+        done <<EOF
+$(_cps_skills "$1" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$1")
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo FAIL
+}
+
+cps_check_M5() {
+    [ -d "$1/docs/skill-guides" ] && [ -d "$1/docs/skill-output" ] && echo PASS || echo FAIL
+}
+
+cps_check_M6() { [ -f "$1/README.md" ] && echo PASS || echo FAIL; }
+
+# ---- recommended checks (R1-R4) -- echo PASS|WARN|N/A -------------------
+cps_check_R1() {
+    # per-skill docs/skill-guides/<skill>.html ; N/A if no skills
+    local _p _s _any=0
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            _any=1
+            [ -f "$1/docs/skill-guides/$_s.html" ] || {
+                echo WARN
+                return
+            }
+        done <<EOF
+$(_cps_skills "$1" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$1")
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
+}
+
+cps_check_R2() {
+    local _p _s _any=0
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            _any=1
+            { [ -f "$1/docs/skill-output/$_s-usage.html" ] ||
+                [ -f "$1/docs/skill-output/$_s-usage.md" ]; } || {
+                echo WARN
+                return
+            }
+        done <<EOF
+$(_cps_skills "$1" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$1")
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
+}
+
+cps_check_R3() {
+    # README "Simple": links into docs/. N/A when README absent (M6 owns that).
+    [ -f "$1/README.md" ] || {
+        echo "N/A"
+        return
+    }
+    grep -Eq '\]\(\.?/?docs/' "$1/README.md" && echo PASS || echo WARN
+}
+
+cps_check_R4() {
+    # naming: SKILL.md name: colon-namespace ↔ skill directory hyphen form.
+    local _p _s _any=0 _sm _name _expect
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            _sm="$1/plugins/$_p/skills/$_s/SKILL.md"
+            [ -f "$_sm" ] || continue
+            _any=1
+            _name="$(grep -m1 '^name:' "$_sm" | sed 's/^name:[[:space:]]*//')"
+            _expect="$(printf '%s' "$_name" | tr ':' '-')"
+            [ "$_expect" = "$_s" ] || {
+                echo WARN
+                return
+            }
+        done <<EOF
+$(_cps_skills "$1" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$1")
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
+}
+
+# ---- aggregate verdict ---------------------------------------------------
+cps_verdict() {
+    # echo FAIL | WARN | PASS for repo $1
+    local _r
+    for _c in M1 M2 M3 M4 M5 M6; do
+        _r="$(cps_check_$_c "$1")"
+        [ "$_r" = FAIL ] && {
+            echo FAIL
+            return
+        }
+    done
+    for _c in R1 R2 R3 R4; do
+        _r="$(cps_check_$_c "$1")"
+        [ "$_r" = WARN ] && {
+            echo WARN
+            return
+        }
+    done
+    echo PASS
+}
+
+# ---- refactor apply ------------------------------------------------------
+# cps_refactor <repo> <scope:mp|op> <mode:dry-run|apply>
+# Dry-run is a no-op on disk. Apply creates missing mandatory items, and
+# (op scope) recommended placeholder stubs. Idempotent.
+cps_refactor() {
+    local _repo="$1" _scope="${2:-mp}" _mode="${3:-dry-run}"
+    [ "$_mode" = "apply" ] || return 0 # dry-run: touch nothing
+
+    # M5 dirs
+    mkdir -p "$_repo/docs/skill-guides" "$_repo/docs/skill-output"
+    mkdir -p "$_repo/.claude-plugin"
+
+    # M1 marketplace.json skeleton (only if missing/invalid)
+    if ! _cps_json_ok "$_repo/.claude-plugin/marketplace.json"; then
+        local _first_p
+        _first_p="$(_cps_plugins "$_repo" | head -n1)"
+        printf '{ "name": "%s", "plugins": ["./plugins/%s"] }\n' \
+            "$(basename "$_repo")" "${_first_p:-plugin}" \
+            >"$_repo/.claude-plugin/marketplace.json"
+    fi
+
+    # M3 per-plugin plugin.json skeleton
+    local _p _s
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        mkdir -p "$_repo/plugins/$_p/.claude-plugin"
+        if ! _cps_json_ok "$_repo/plugins/$_p/.claude-plugin/plugin.json"; then
+            _s="$(_cps_skills "$_repo" "$_p" | head -n1)"
+            printf '{ "name": "%s", "version": "0.0.0", "skills": ["./skills/%s"] }\n' \
+                "$_p" "${_s:-skill}" \
+                >"$_repo/plugins/$_p/.claude-plugin/plugin.json"
+        fi
+    done <<EOF
+$(_cps_plugins "$_repo")
+EOF
+
+    # M6 README skeleton (with a docs/ link so R3 also passes)
+    [ -f "$_repo/README.md" ] || printf '# %s\n\nSee [docs/](./docs/).\n' \
+        "$(basename "$_repo")" >"$_repo/README.md"
+
+    [ "$_scope" = "op" ] || return 0
+
+    # --op: R1/R2 placeholder stubs per skill
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            [ -f "$_repo/docs/skill-guides/$_s.html" ] || printf \
+                '<!-- TODO: claude-plugin guide for %s — fill with /devx:visualize -->\n' \
+                "$_s" >"$_repo/docs/skill-guides/$_s.html"
+            { [ -f "$_repo/docs/skill-output/$_s-usage.html" ] ||
+                [ -f "$_repo/docs/skill-output/$_s-usage.md" ]; } || printf \
+                '<!-- TODO: %s usage sample — fill with /devx:visualize -->\n' \
+                "$_s" >"$_repo/docs/skill-output/$_s-usage.md"
+        done <<EOF
+$(_cps_skills "$_repo" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$_repo")
+EOF
+}

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -167,3 +167,53 @@ build_perfect() {
     _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
     run cps_check_R4 "$REPO"; assert_output PASS
 }
+
+@test "R4 tolerates a quoted name: value (PR #894 gemini review)" {
+    mkdir -p "$REPO/plugins/demo/skills/structure-check"
+    printf 'name: "structure:check"\ndescription: x\n' \
+        > "$REPO/plugins/demo/skills/structure-check/SKILL.md"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R4 "$REPO"; assert_output PASS
+}
+
+# ---- N/A for absent subject on mandatory checks (PR #894 gemini review) --
+
+@test "no plugins -> M3 is N/A (M2 owns the FAIL), verdict still FAIL" {
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [] }\n' > "$REPO/.claude-plugin/marketplace.json"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_M2 "$REPO"; assert_output FAIL
+    run cps_check_M3 "$REPO"; assert_output "N/A"
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+@test "plugin with 0 skills -> M4 is N/A, not FAIL" {
+    mkdir -p "$REPO/plugins/demo/skills"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_M4 "$REPO"; assert_output "N/A"
+}
+
+# ---- multi-plugin / multi-skill JSON skeletons (PR #894 gemini review) --
+
+@test "mandatory apply lists ALL plugins in marketplace.json" {
+    mkdir -p "$REPO/plugins/alpha/skills/s1" "$REPO/plugins/beta/skills/s2"
+    printf 'name: s1\ndescription: x\n' > "$REPO/plugins/alpha/skills/s1/SKILL.md"
+    printf 'name: s2\ndescription: x\n' > "$REPO/plugins/beta/skills/s2/SKILL.md"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    cps_refactor "$REPO" mp apply
+    run jq -r '.plugins | length' "$REPO/.claude-plugin/marketplace.json"
+    assert_output 2
+    run jq -e '.plugins | index("./plugins/alpha") and index("./plugins/beta")' \
+        "$REPO/.claude-plugin/marketplace.json"
+    assert_success
+}
+
+@test "mandatory apply lists ALL skills in plugin.json" {
+    mkdir -p "$REPO/plugins/demo/skills/s1" "$REPO/plugins/demo/skills/s2"
+    printf 'name: s1\ndescription: x\n' > "$REPO/plugins/demo/skills/s1/SKILL.md"
+    printf 'name: s2\ndescription: x\n' > "$REPO/plugins/demo/skills/s2/SKILL.md"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    cps_refactor "$REPO" mp apply
+    run jq -r '.skills | length' "$REPO/plugins/demo/.claude-plugin/plugin.json"
+    assert_output 2
+}

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+# tests/bats/skills/claude_plugin_structure.bats
+# Verify the structure spec shared by
+#   claude/skills/claude-plugin-structure-check/   (M1-M6 / R1-R4 evaluation)
+#   claude/skills/claude-plugin-structure-refactor/ (dry-run / --apply / --op)
+# Source-of-truth fixture: _fixtures/claude_plugin_structure.sh
+#
+# Four scenarios from the design test strategy:
+#   1. Perfect structure        -> check PASS / refactor no-op
+#   2. Mandatory missing        -> check FAIL / refactor --apply -> recheck PASS
+#   3. Recommended missing       -> check WARN / refactor --op    -> recheck PASS
+#   4. Dry-run idempotency       -> dry-run touches nothing, verdict unchanged
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/claude_plugin_structure.sh"
+    REPO="${TEST_TEMP_HOME}/repo"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset REPO
+}
+
+# ---- fixture builders ----------------------------------------------------
+
+_seed_skill() {
+    # $1=repo  builds plugins/demo/skills/visualize/SKILL.md (name matches dir)
+    mkdir -p "$1/plugins/demo/skills/visualize"
+    printf 'name: visualize\ndescription: demo skill\n' \
+        > "$1/plugins/demo/skills/visualize/SKILL.md"
+}
+
+_seed_mandatory_json() {
+    mkdir -p "$1/.claude-plugin" "$1/plugins/demo/.claude-plugin"
+    printf '{ "name": "repo", "plugins": ["./plugins/demo"] }\n' \
+        > "$1/.claude-plugin/marketplace.json"
+    printf '{ "name": "demo", "version": "0.0.0", "skills": ["./skills/visualize"] }\n' \
+        > "$1/plugins/demo/.claude-plugin/plugin.json"
+}
+
+_seed_docs_dirs() { mkdir -p "$1/docs/skill-guides" "$1/docs/skill-output"; }
+
+_seed_readme() { printf '# repo\n\nSee [docs/](./docs/).\n' > "$1/README.md"; }
+
+_seed_recommended_files() {
+    printf '<!-- guide -->\n' > "$1/docs/skill-guides/visualize.html"
+    printf '<!-- usage -->\n' > "$1/docs/skill-output/visualize-usage.md"
+}
+
+build_perfect() {
+    _seed_skill "$1"; _seed_mandatory_json "$1"; _seed_docs_dirs "$1"
+    _seed_readme "$1"; _seed_recommended_files "$1"
+}
+
+# ---- Scenario 1: perfect -------------------------------------------------
+
+@test "perfect repo -> verdict PASS" {
+    build_perfect "$REPO"
+    run cps_verdict "$REPO"
+    assert_success
+    assert_output PASS
+}
+
+@test "perfect repo -> refactor --apply is a no-op (verdict still PASS)" {
+    build_perfect "$REPO"
+    before="$(find "$REPO" -type f | sort)"
+    cps_refactor "$REPO" op apply
+    after="$(find "$REPO" -type f | sort)"
+    [ "$before" = "$after" ]
+    run cps_verdict "$REPO"
+    assert_output PASS
+}
+
+# ---- Scenario 2: mandatory missing --------------------------------------
+
+@test "mandatory missing (no marketplace/plugin json) -> verdict FAIL" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"
+    _seed_readme "$REPO"; _seed_recommended_files "$REPO"
+    run cps_check_M1 "$REPO"; assert_output FAIL
+    run cps_check_M3 "$REPO"; assert_output FAIL
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+@test "mandatory missing -> refactor --apply (mp) -> recheck PASS" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"
+    _seed_readme "$REPO"; _seed_recommended_files "$REPO"
+    cps_refactor "$REPO" mp apply
+    run cps_check_M1 "$REPO"; assert_output PASS
+    run cps_check_M3 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "mandatory apply writes VALID json skeletons" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    _seed_recommended_files "$REPO"
+    cps_refactor "$REPO" mp apply
+    run jq empty "$REPO/.claude-plugin/marketplace.json"; assert_success
+    run jq empty "$REPO/plugins/demo/.claude-plugin/plugin.json"; assert_success
+}
+
+# ---- Scenario 3: recommended missing ------------------------------------
+
+@test "recommended missing (no guide/usage) -> verdict WARN" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R1 "$REPO"; assert_output WARN
+    run cps_check_R2 "$REPO"; assert_output WARN
+    run cps_verdict "$REPO"; assert_output WARN
+}
+
+@test "recommended missing -> refactor --apply --op -> recheck PASS" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    cps_refactor "$REPO" op apply
+    run cps_check_R1 "$REPO"; assert_output PASS
+    run cps_check_R2 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "mandatory scope (mp) does NOT create recommended stubs" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    cps_refactor "$REPO" mp apply
+    run cps_check_R1 "$REPO"; assert_output WARN
+}
+
+# ---- Scenario 4: dry-run idempotency ------------------------------------
+
+@test "dry-run touches nothing and leaves verdict FAIL" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"
+    _seed_readme "$REPO"; _seed_recommended_files "$REPO"
+    before="$(find "$REPO" -type f | sort)"
+    cps_refactor "$REPO" op dry-run
+    after="$(find "$REPO" -type f | sort)"
+    [ "$before" = "$after" ]
+    [ ! -f "$REPO/.claude-plugin/marketplace.json" ]
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+# ---- N/A rule ------------------------------------------------------------
+
+@test "plugin with 0 skills -> R1/R2 are N/A, not FAIL" {
+    mkdir -p "$REPO/plugins/demo/skills"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R1 "$REPO"; assert_output "N/A"
+    run cps_check_R2 "$REPO"; assert_output "N/A"
+}
+
+# ---- R4 naming -----------------------------------------------------------
+
+@test "R4 naming mismatch (name colon != dir hyphen) -> WARN" {
+    mkdir -p "$REPO/plugins/demo/skills/structure-check"
+    printf 'name: structure:wrong\ndescription: x\n' \
+        > "$REPO/plugins/demo/skills/structure-check/SKILL.md"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R4 "$REPO"; assert_output WARN
+}
+
+@test "R4 naming match (structure:check <-> structure-check) -> PASS" {
+    mkdir -p "$REPO/plugins/demo/skills/structure-check"
+    printf 'name: structure:check\ndescription: x\n' \
+        > "$REPO/plugins/demo/skills/structure-check/SKILL.md"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R4 "$REPO"; assert_output PASS
+}


### PR DESCRIPTION
## Summary

issue #887 — claude-plugin 마켓플레이스 repo 의 표준 디렉터리 구조를 검사/교정하는
자매 스킬 한 쌍을 신규 구현. 기존 `sh:check` ↔ `skill:refactor` 패턴을 따른다.
설계 SSOT: `docs/feature/superpowers-specs/2026-05-30-claude-plugin-structure-skills-design.md`.

## 변경 내용

**`claude-plugin:structure-check`** (read-only 감사)
- 표준 구조 대비 `PASS/WARN/FAIL/N/A` 리포트.
- 필수 M1-M6 (누락 → FAIL) / 권장 R1-R4 (누락 → WARN) / 대상 부재 → N/A.
- plugin·skill 디렉터리 동적 발견 (특정 repo 비종속).
- SKILL.md 87L + `references/{help,structure-spec,report-template}.md`.
- `metadata.model_recommendation: haiku`.

**`claude-plugin:structure-refactor`** (구조 교정)
- dry-run 기본 + `--apply` 로만 변경. scope `--mp`(필수) / `--op`(필수+권장).
- 누락 디렉터리 생성, `git mv` 히스토리 보존, JSON 최소 스켈레톤, 멱등.
- `--op` placeholder 스텁은 TODO 헤더까지만 — visualize/excalidraw 실제
  콘텐츠 생성은 비목표.
- SKILL.md 88L + `references/{help,structure-spec,plan-and-report-templates}.md`.
- `metadata.model_recommendation: sonnet`.

**공유 SSOT**
- `references/structure-spec.md` 를 양 스킬에 의도적 중복 사본으로 내장
  (스킬 독립 설치 가능성 보장).

**테스트**
- `tests/bats/skills/claude_plugin_structure.{sh,bats}` — M/R 평가 + refactor
  로직의 실행형 미러 픽스처 + 12 테스트: 완벽→PASS / 필수누락→FAIL→apply→PASS /
  권장누락→WARN→`--op`→PASS / dry-run 멱등 / N/A 규칙 / R4 명명.

## 검증

- bats: 12/12 PASS
- golden rules: 5/5 PASS (no-emoji 포함)
- shellcheck + `shfmt -i 4`: 픽스처 clean
- 두 SKILL.md ≤ 100L, frontmatter name/description, help-flag 패턴,
  Check 12 `model_recommendation` 메타데이터 포함
- pytest 통합 테스트는 이 환경에 `pytest` 미설치로 skip (사전 환경 한계, 본 변경 무관)

Closes #887
