### PR TITLE
chore(skill-check): #861 MIGRATION_COMPLETE=true — Check 12 누락 WARN→FAIL

### DIFF
--- a/claude/skills/skill-check/references/model-recommendation.md
+++ b/claude/skills/skill-check/references/model-recommendation.md
@@ -51,10 +51,11 @@ metadata:
 메타데이터 누락의 결과는 **마이그레이션 단계 플래그**로 제어한다 — 43개 스킬을
 day-one red wall 로 막지 않기 위함이다 (Open Question 1 결정).
 
-- **`MIGRATION_COMPLETE = false`** (현재): 메타데이터 누락 → **WARN** +
-  아래 마이그레이션 명령 제안.
-- 전체 스킬에 메타데이터가 채워지면 이 줄을 `true` 로 바꾼다: 그 시점부터
-  누락 → **FAIL**.
+- **`MIGRATION_COMPLETE = true`** (현재): 메타데이터 누락 → **FAIL**.
+  전 스킬 `model_recommendation` 전수 마이그레이션 완료 (#815 #855 #860 #862
+  모두 close) 후 별도 PR (#861) 로 전환됨.
+- 이전 상태 `MIGRATION_COMPLETE = false`: 누락 → **WARN** + 아래 마이그레이션
+  명령 제안 (마이그레이션 유예 기간 — 종료됨).
 
 마이그레이션 명령 (제안 문구):
 `Run /skill:refactor <path> to add a metadata.model_recommendation block (rubric: references/model-recommendation.md).`


### PR DESCRIPTION
## Summary

전 스킬 model_recommendation 전수 마이그레이션 (#815 #855 #860 #862, 전부 close) 완료에 따라 migration gate 를 닫는다. 이 시점부터 누락 스킬의 metadata.model_recommendation 부재는 WARN 이 아닌 FAIL 로 보고된다.

## Changes

- model-recommendation.md Section 3: MIGRATION_COMPLETE false -> true
- absence 처리 WARN -> FAIL, 이전 false 상태는 전환 이력으로 강등

## Test plan

- [x] 전 스킬 model_recommendation 메타데이터 커버리지 확인
- [ ] 머지 후 첫 신규 스킬에서 Check 12 FAIL 동작 1회 확인 (#861 DoD)

Closes #861