### PR TITLE
feat(wsl-check): #897 WSL/Docker 환경 헬스체크 명령어 신규 — 1줄/--all/prune/src 훅

### DIFF
--- a/shell-common/aliases/core.sh
+++ b/shell-common/aliases/core.sh
@@ -44,6 +44,14 @@ src() {
     else
         echo "src: reloaded from $_canon"
     fi
+
+    # One-line health hint (issue #897). This only fires on a manual `src`:
+    # a new terminal sources the rc files directly and never calls src(), so
+    # the hint stays out of shell startup. Non-fatal — a failing health probe
+    # must never break the reload.
+    if command -v _wsl_check_oneline >/dev/null 2>&1; then
+        _wsl_check_oneline 2>/dev/null || true
+    fi
 }
 
 # 파일 시스템 탐색

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -159,7 +159,7 @@ _register_default_help_categories() {
 
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool}"
-    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network}"
+    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip ghostty}"
@@ -220,6 +220,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[nvm_help]="${HELP_DESCRIPTIONS[nvm_help]:-[Development] nvm node versions}"
     HELP_DESCRIPTIONS[litellm_help]="${HELP_DESCRIPTIONS[litellm_help]:-[AI/LLM] LiteLLM proxy and routing}"
     HELP_DESCRIPTIONS[gpu_help]="${HELP_DESCRIPTIONS[gpu_help]:-[DevOps] GPU monitoring (WSL)}"
+    HELP_DESCRIPTIONS[wsl_check_help]="${HELP_DESCRIPTIONS[wsl_check_help]:-[DevOps] WSL & Docker environment health (disk/mem/docker)}"
     HELP_DESCRIPTIONS[ux_help]="${HELP_DESCRIPTIONS[ux_help]:-[Development] UX library usage}"
     HELP_DESCRIPTIONS[mytool_help]="${HELP_DESCRIPTIONS[mytool_help]:-[Development] Custom tools and scripts}"
     HELP_DESCRIPTIONS[mysql_help]="${HELP_DESCRIPTIONS[mysql_help]:-[DevOps] MySQL service management}"

--- a/shell-common/functions/wsl_check.sh
+++ b/shell-common/functions/wsl_check.sh
@@ -28,17 +28,28 @@ _wsl_check_timeout() {
     fi
 }
 
+# True only when $1 is a real mountpoint. `/mnt/c` can exist as a bare
+# directory without being mounted (automount off, or a non-WSL host), in
+# which case `df /mnt/c` silently reports the root fs — the trailing-space
+# match avoids substring false positives (e.g. /mnt/cd).
+_wsl_check_is_mounted() { # $1 = mountpoint
+    mount 2>/dev/null | grep -q " on $1 "
+}
+
 # --- metric gatherers (each prints digits-only, or empty on failure) ---------
 # `command df/free` bypasses the `df -h` / `free -h` aliases defined in
-# aliases/core.sh, so -P/-BG output stays machine-parseable.
+# aliases/core.sh, so -P output stays machine-parseable.
 _wsl_check_cdrive_pct() {
-    [ -d /mnt/c ] || return 0
+    _wsl_check_is_mounted /mnt/c || return 0
     command df -P /mnt/c 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }'
 }
 
 _wsl_check_cdrive_avail_gb() {
-    [ -d /mnt/c ] || return 0
-    command df -P -BG /mnt/c 2>/dev/null | awk 'NR==2 { gsub(/G/, "", $4); print $4 }'
+    _wsl_check_is_mounted /mnt/c || return 0
+    # -P -k = POSIX-portable 1024-byte blocks (avoids the GNU-only -BG); the
+    # explicit -k removes the 512-vs-1024 block ambiguity of bare -P, so the
+    # /1048576 (1024^2) byte->GB conversion is correct everywhere.
+    command df -P -k /mnt/c 2>/dev/null | awk 'NR==2 { printf "%d", $4 / 1048576 }'
 }
 
 _wsl_check_disk_pct() {
@@ -59,7 +70,7 @@ _wsl_check_cpu_pct() {
 _wsl_check_docker_img_pct() {
     command -v docker >/dev/null 2>&1 || return 0
     _wsl_check_timeout 1 docker system df 2>/dev/null |
-        awk '/^Images/ { v=$NF; gsub(/[()%]/, "", v); if (v ~ /^[0-9]+$/) print v }'
+        awk '/^Images/ { v=$NF; gsub(/[^0-9]/, "", v); if (v ~ /^[0-9]+$/) print v }'
 }
 
 # Total docker reclaimable space in whole GB (best-effort sum across types).
@@ -141,6 +152,14 @@ _wsl_check_df_section() { # $1=title $2=mountpoint
     if [ ! -d "$2" ]; then
         ux_warning "$2 not mounted (non-WSL host?)"
         return 0
+    fi
+    # `/` is always a mountpoint; any other target must be really mounted,
+    # else df silently reports the root fs and C: mirrors the WSL disk.
+    if [ "$2" != "/" ]; then
+        _wsl_check_is_mounted "$2" || {
+            ux_warning "$2 not mounted (non-WSL host?)"
+            return 0
+        }
     fi
     # shellcheck disable=SC2046  # intentional word-split of the df row
     set -- $(command df -h -P "$2" 2>/dev/null | awk 'NR==2 { print $2, $3, $4, $5 }')

--- a/shell-common/functions/wsl_check.sh
+++ b/shell-common/functions/wsl_check.sh
@@ -1,0 +1,250 @@
+#!/bin/sh
+# shell-common/functions/wsl_check.sh
+# WSL & Docker environment health check — a single source of truth for the
+# Windows host C: drive / WSL disk / memory / CPU / Docker reclaimable space.
+#
+# Motivation (issue #897): a full WSL crash (SIGBUS / E_UNEXPECTED) during a
+# Docker build was caused by the *Windows host C: drive* — not the WSL disk —
+# running out of space (the vhdx could not grow). So the host C: drive is the
+# primary risk indicator and is always shown first.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# --- thresholds (SSOT: function-internal defaults, env-overridable) ----------
+_wsl_check_thresholds() {
+    : "${WSL_CHECK_DISK_WARN:=90}"        # disk / mem / cpu warn %
+    : "${WSL_CHECK_CDRIVE_MIN_GB:=10}"    # host C: avail floor (GB) — #897 cause
+    : "${WSL_CHECK_DOCKER_RECLAIM_GB:=5}" # docker reclaimable auto-prune trigger
+    : "${WSL_CHECK_AUTO_PRUNE:=0}"        # 1 = auto-prune on --all over threshold
+}
+
+# timeout wrapper — degrades gracefully where coreutils `timeout` is absent.
+_wsl_check_timeout() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$@"
+    else
+        shift
+        "$@"
+    fi
+}
+
+# --- metric gatherers (each prints digits-only, or empty on failure) ---------
+# `command df/free` bypasses the `df -h` / `free -h` aliases defined in
+# aliases/core.sh, so -P/-BG output stays machine-parseable.
+_wsl_check_cdrive_pct() {
+    [ -d /mnt/c ] || return 0
+    command df -P /mnt/c 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }'
+}
+
+_wsl_check_cdrive_avail_gb() {
+    [ -d /mnt/c ] || return 0
+    command df -P -BG /mnt/c 2>/dev/null | awk 'NR==2 { gsub(/G/, "", $4); print $4 }'
+}
+
+_wsl_check_disk_pct() {
+    command df -P / 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }'
+}
+
+_wsl_check_mem_pct() {
+    awk '/^MemTotal:/ { t=$2 } /^MemAvailable:/ { a=$2 } \
+         END { if (t > 0) printf "%d", (t - a) * 100 / t }' /proc/meminfo 2>/dev/null
+}
+
+_wsl_check_cpu_pct() {
+    ncpu=$(nproc 2>/dev/null || echo 1)
+    awk -v n="$ncpu" '{ p = $1 / n * 100; if (p > 100) p = 100; printf "%d", p }' \
+        /proc/loadavg 2>/dev/null
+}
+
+_wsl_check_docker_img_pct() {
+    command -v docker >/dev/null 2>&1 || return 0
+    _wsl_check_timeout 1 docker system df 2>/dev/null |
+        awk '/^Images/ { v=$NF; gsub(/[()%]/, "", v); if (v ~ /^[0-9]+$/) print v }'
+}
+
+# Total docker reclaimable space in whole GB (best-effort sum across types).
+_wsl_check_docker_reclaim_gb() {
+    command -v docker >/dev/null 2>&1 || return 0
+    _wsl_check_timeout 2 docker system df --format '{{.Reclaimable}}' 2>/dev/null |
+        awk '{ x=$1;
+                 if (x ~ /GB/)      { sub(/GB/, "", x); s += x }
+                 else if (x ~ /MB/) { sub(/MB/, "", x); s += x / 1024 } }
+               END { printf "%d", s }'
+}
+
+# --- one-line summary (manual printf: a single line with per-field coloring
+#     is not expressible via ux_bullet/ux_table_*; same sanctioned exception
+#     gpu_status.sh uses for its custom layout) ----------------------------
+_wsl_check_seg() { # $1=label $2=value $3=severity(ok|warn|crit)
+    color="$UX_MUTED"
+    case "$3" in
+    warn) color="$UX_WARNING" ;;
+    crit) color="$UX_ERROR" ;;
+    esac
+    printf '%s%s:%s%s' "$color" "$1" "$2" "$UX_RESET"
+}
+
+_wsl_check_oneline() {
+    _wsl_check_thresholds
+
+    # Each segment is built into its own variable so the _wsl_check_seg call
+    # is never preceded by a quote on the line — the pre-commit naming check
+    # greedily flags "<snake_func>" patterns, and a leading `line="` quote
+    # would trip it (the call args are themselves quoted).
+
+    # c-drive (Windows host) — primary risk indicator, shown first (#897)
+    cd_pct=$(_wsl_check_cdrive_pct)
+    if [ -z "$cd_pct" ]; then
+        seg_cd=$(_wsl_check_seg c-drive "n/a" ok)
+    else
+        cd_av=$(_wsl_check_cdrive_avail_gb)
+        sev=ok
+        [ "$cd_pct" -ge "$WSL_CHECK_DISK_WARN" ] && sev=crit
+        [ -n "$cd_av" ] && [ "$cd_av" -lt "$WSL_CHECK_CDRIVE_MIN_GB" ] && sev=crit
+        seg_cd=$(_wsl_check_seg c-drive "${cd_pct}%" "$sev")
+    fi
+
+    # WSL root disk
+    d_pct=$(_wsl_check_disk_pct)
+    sev=ok
+    [ -n "$d_pct" ] && [ "$d_pct" -ge "$WSL_CHECK_DISK_WARN" ] && sev=crit
+    seg_disk=$(_wsl_check_seg disk "${d_pct:-?}%" "$sev")
+
+    # CPU (1-min loadavg vs cores — instant, non-blocking)
+    c_pct=$(_wsl_check_cpu_pct)
+    sev=ok
+    [ -n "$c_pct" ] && [ "$c_pct" -ge "$WSL_CHECK_DISK_WARN" ] && sev=warn
+    seg_cpu=$(_wsl_check_seg cpu "${c_pct:-?}%" "$sev")
+
+    # Memory
+    m_pct=$(_wsl_check_mem_pct)
+    sev=ok
+    [ -n "$m_pct" ] && [ "$m_pct" -ge "$WSL_CHECK_DISK_WARN" ] && sev=warn
+    seg_mem=$(_wsl_check_seg mem "${m_pct:-?}%" "$sev")
+
+    # Docker images reclaimable %
+    dk=$(_wsl_check_docker_img_pct)
+    if [ -z "$dk" ]; then
+        seg_docker=$(_wsl_check_seg docker "?" ok)
+    else
+        sev=ok
+        [ "$dk" -ge 50 ] && sev=warn
+        seg_docker=$(_wsl_check_seg docker "${dk}%" "$sev")
+    fi
+
+    printf '%s %s %s %s %s\n' "$seg_cd" "$seg_disk" "$seg_cpu" "$seg_mem" "$seg_docker"
+}
+
+# --- detailed report ---------------------------------------------------------
+_wsl_check_df_section() { # $1=title $2=mountpoint
+    ux_section "$1"
+    if [ ! -d "$2" ]; then
+        ux_warning "$2 not mounted (non-WSL host?)"
+        return 0
+    fi
+    # shellcheck disable=SC2046  # intentional word-split of the df row
+    set -- $(command df -h -P "$2" 2>/dev/null | awk 'NR==2 { print $2, $3, $4, $5 }')
+    ux_table_row "Size" "${1:-?}"
+    ux_table_row "Used" "${2:-?}"
+    ux_table_row "Avail" "${3:-?}"
+    ux_table_row "Use%" "${4:-?}"
+}
+
+_wsl_check_full() {
+    _wsl_check_thresholds
+    ux_header "WSL & Docker Environment Health"
+
+    _wsl_check_df_section "[1] Windows C: Drive (host)" /mnt/c
+    _wsl_check_df_section "[2] WSL Virtual Disk (/)" /
+
+    ux_section "[3] Memory & Swap"
+    # shellcheck disable=SC2046
+    set -- $(command free -h 2>/dev/null | awk 'NR==2 { print $2, $3, $7 }')
+    ux_table_row "Total" "${1:-?}"
+    ux_table_row "Used" "${2:-?}"
+    ux_table_row "Available" "${3:-?}"
+
+    ux_section "[4] Docker Reclaimable"
+    if ! command -v docker >/dev/null 2>&1; then
+        ux_warning "docker not installed"
+    elif ! _wsl_check_timeout 2 docker info >/dev/null 2>&1; then
+        ux_warning "docker daemon not running"
+    else
+        _wsl_check_timeout 3 docker system df \
+            --format '{{.Type}}|{{.Size}}|{{.Reclaimable}}' 2>/dev/null |
+            while IFS='|' read -r dtype dsize drec; do
+                ux_table_row "$dtype" "$dsize  (reclaimable $drec)"
+            done
+    fi
+
+    # auto-prune guard (opt-in, build-cache + dangling only, never destructive
+    # beyond that; the interactive guard lives in _wsl_check_prune)
+    if [ "$WSL_CHECK_AUTO_PRUNE" = "1" ]; then
+        rec=$(_wsl_check_docker_reclaim_gb)
+        if [ -n "$rec" ] && [ "$rec" -ge "$WSL_CHECK_DOCKER_RECLAIM_GB" ]; then
+            ux_info ""
+            ux_warning "Docker reclaimable ${rec}GB >= ${WSL_CHECK_DOCKER_RECLAIM_GB}GB — auto-pruning"
+            _wsl_check_prune builder
+        fi
+    fi
+}
+
+# --- prune (destructive — single chokepoint with the interactive guard) ------
+_wsl_check_prune() { # $1 = builder | system
+    case $- in *i*) ;; *)
+        ux_warning "non-interactive shell — refusing destructive prune"
+        return 0
+        ;;
+    esac
+    if ! command -v docker >/dev/null 2>&1; then
+        ux_warning "docker not installed — nothing to prune"
+        return 0
+    fi
+    if ! _wsl_check_timeout 2 docker info >/dev/null 2>&1; then
+        ux_warning "docker daemon not running — skip prune"
+        return 0
+    fi
+    case "$1" in
+    system)
+        ux_warning "FULL prune: stopped containers + unused networks + dangling images + build cache"
+        docker system prune -f
+        ;;
+    *)
+        ux_info "Pruning build cache + dangling images (safe set)"
+        docker builder prune -f
+        docker image prune -f
+        ;;
+    esac
+    ux_success "Prune complete"
+}
+
+# --- dispatcher --------------------------------------------------------------
+wsl_check() {
+    _wsl_check_thresholds
+    case "${1:-}" in
+    "") _wsl_check_oneline ;;
+    --all | all) _wsl_check_full ;;
+    --prune)
+        _wsl_check_full
+        _wsl_check_prune builder
+        ;;
+    --prune-all)
+        _wsl_check_full
+        _wsl_check_prune system
+        ;;
+    -h | --help | help)
+        if command -v wsl_check_help >/dev/null 2>&1; then
+            wsl_check_help
+        else
+            ux_info "wsl-check [--all|--prune|--prune-all|-h]"
+        fi
+        ;;
+    *)
+        ux_error "wsl-check: unknown option '$1'"
+        ux_info "Try: wsl-check -h"
+        return 1
+        ;;
+    esac
+}
+
+alias wsl-check='wsl_check'

--- a/shell-common/functions/wsl_check_help.sh
+++ b/shell-common/functions/wsl_check_help.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# shell-common/functions/wsl_check_help.sh
+# Help for wsl-check (see wsl_check.sh). Registered under the `devops`
+# category in functions/my_help.sh.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+_wsl_check_help_summary() {
+    ux_section "wsl-check — WSL & Docker environment health"
+    ux_table_header "Command" "Description"
+    ux_table_row "wsl-check" "One-line summary (c-drive / disk / cpu / mem / docker)"
+    ux_table_row "wsl-check --all" "Detailed sectioned report"
+    ux_table_row "wsl-check --prune" "Report + prune build cache & dangling images"
+    ux_table_row "wsl-check --prune-all" "Report + full docker system prune"
+    ux_table_row "wsl-check -h" "This help"
+
+    ux_section "Thresholds (env overrides)"
+    ux_table_row "WSL_CHECK_DISK_WARN" "disk / mem / cpu warn % (default 90)"
+    ux_table_row "WSL_CHECK_CDRIVE_MIN_GB" "host C: avail floor GB (default 10)"
+    ux_table_row "WSL_CHECK_DOCKER_RECLAIM_GB" "auto-prune trigger GB (default 5)"
+    ux_table_row "WSL_CHECK_AUTO_PRUNE" "1 = auto-prune on --all when over threshold"
+
+    ux_section "Notes"
+    ux_bullet "C: drive is shown first: a full WSL crash (SIGBUS) was caused by"
+    ux_bullet_sub "the Windows host C: drive filling up, not the WSL disk (#897)."
+    ux_bullet "The one-line summary also prints after a manual 'src' reload."
+    ux_bullet "Prune is destructive and never runs in a non-interactive shell."
+}
+
+wsl_check_help() {
+    case "${1:-}" in
+    -h | --help | help | "") _wsl_check_help_summary ;;
+    *) _wsl_check_help_summary ;;
+    esac
+}
+
+alias wsl-check-help='wsl_check_help'


### PR DESCRIPTION
## 개요

WSL 개발 환경(특히 Docker 빌드)에서 **Windows 호스트 C: 드라이브 고갈**로 인한
`SIGBUS` / `E_UNEXPECTED` 크래시를 사전 감지하는 단일 헬스체크 명령어
`wsl-check` 를 신설합니다. WSL 내부 디스크가 아니라 `/mnt/c`(호스트) 용량이
1차 위험 지표라는 점을 반영해, 1줄 요약에서 **C: 드라이브를 맨 앞**에 둡니다.

Closes #897

## 변경 사항 (commit 48c939e)

- **`functions/wsl_check.sh`** (신규) — 디스패처 + 1줄 요약(`_wsl_check_oneline`)
  + `--all` 상세 리포트(`_wsl_check_full`) + prune 가드(`_wsl_check_prune`).
  - `command df`/`command free` 로 `df -h`/`free -h` alias 우회 → 파싱 안정화.
  - `timeout` 래퍼로 docker 데몬 다운 시 hang 방지(없으면 graceful degrade).
- **`functions/wsl_check_help.sh`** (신규) — `wsl-check-help` + devops 등록.
- **`aliases/core.sh`** — `src()` 끝에 1줄 헬스 힌트. **수동 `src` 호출에서만**
  동작(신규 터미널은 rc 직접 source 라 `src()` 미경유). non-fatal 가드.
- **`functions/my_help.sh`** — devops 멤버 + `HELP_DESCRIPTIONS` 등록.

## 결정 사항

| ID | 결정 |
|----|------|
| D-1 | 1줄 포맷 `c-drive:90% disk:50% cpu:34% mem:42% docker:83%` (풀네임, C드라이브 우선) |
| D-2 | `--prune` 기본 = 빌드 캐시 + dangling 이미지 / `--prune-all` = 전체 system prune |
| D-3 | 임계값은 함수 내 기본값(`WSL_CHECK_*`), env override 가능 |
| D-4 | `src` 훅 기본 ON (신규 터미널 미경유라 안전) |

## 사용법

```text
wsl-check                # 1줄 요약 (src 직후에도 자동 출력)
wsl-check --all          # 섹션별 상세 리포트
wsl-check --prune        # 빌드 캐시 + dangling 이미지 정리
wsl-check --prune-all    # docker system prune
wsl-check -h             # 도움말
```

## 검증

- shfmt / shellcheck clean, golden rules 5/5 PASS, bats `functions/` 전체 PASS.
- bash·zsh 양쪽 기능 확인: 1줄·`--all` 렌더, 비대화형 prune 거부, unknown opt `rc=1`.
- 실측 출력(이 머신, C: 91%): `c-drive:91% disk:5% cpu:7% mem:24% docker:0%`.

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics -->
📊 ~6000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics -->

</details>
