### PR TITLE
refactor(docker-help): #899 raw-command-우선 학습 표면 — raw 모드 + reverse lookup + dprune 오표기 수정

### DIFF
--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -333,15 +333,24 @@ _docker_help_is_alias() {
 # Reverse lookup: alias -> raw command. Teaches what an alias actually runs
 # so the portable command can be verified and learned (#899 F-2).
 _docker_help_reverse() {
-    local row raw desc
-    row=$(_docker_help_catalog | awk -F'|' -v a="$1" '$1 == a { print; exit }')
-    if [ -z "$row" ]; then
+    local al raw desc sec found
+    # Pure POSIX while-read over a here-doc (no awk/cut subprocesses, and no
+    # `awk -v` backslash-escape interpretation of the input) — gemini PR #901.
+    found=0
+    while IFS='|' read -r al raw desc sec; do
+        if [ "$al" = "$1" ]; then
+            found=1
+            break
+        fi
+    done <<EOF
+$(_docker_help_catalog)
+EOF
+
+    if [ "$found" -eq 0 ]; then
         ux_error "Unknown docker alias: $1"
         ux_info "Try: docker-help --list  or  docker-help raw"
         return 1
     fi
-    raw=$(printf '%s\n' "$row" | cut -d'|' -f2)
-    desc=$(printf '%s\n' "$row" | cut -d'|' -f3)
     ux_section "Alias -> raw command"
     # Bare monospace line so the raw command is copy-paste ready (no icon /
     # bullet) — same rationale as _docker_help_recommend_print (#777).
@@ -355,7 +364,7 @@ _docker_help_reverse() {
 # ready surface, alias demoted to an annotation (#899 F-1). Optional
 # section filter reuses the catalog's section tags.
 _docker_help_raw() {
-    local want_section printed
+    local want_section printed al raw desc sec
     # Split guard onto its own lines: a one-line `[ -n "..." ] && x=$(fn "$1")`
     # form flanks the private-function call with quotes, which the pre-commit
     # naming_check mis-reads as snake_case user-facing text.

--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -16,6 +16,8 @@ _docker_help_summary() {
     ux_bullet_sub "utilities: dbash | denv | dinspect_env | dstopall | drmall | dexport | dinstall | dproxy_setup"
     ux_bullet_sub "i-want: goal-based lookup  (example: docker-help i-want)"
     ux_bullet_sub "--map: intent -> alias -> raw command table"
+    ux_bullet_sub "raw: copy-paste-ready full commands  (example: docker-help raw resources)"
+    ux_bullet_sub "lookup: alias -> raw command  (example: docker-help dprune)"
     ux_bullet_sub "details: docker-help <section>  (example: docker-help compose)"
 }
 
@@ -62,8 +64,8 @@ _docker_help_rows_basics() {
 
 _docker_help_rows_resources() {
     ux_table_row "ddf" "system df" "Disk usage"
-    ux_table_row "dprune" "system prune -f" "Basic cleanup"
-    ux_table_row "dprune_full" "full prune" "Deep cleanup (interactive)"
+    ux_table_row "dprune" "system prune -f" "Basic cleanup (-f only; keeps images & volumes)"
+    ux_table_row "dprune_full" "system prune -a --volumes" "Deep cleanup (interactive; removes images+volumes)"
     ux_table_row "dvols" "volume ls -f dangling" "Dangling volumes"
     ux_table_row "dvol_rm" "volume rm" "Remove volume"
     ux_table_row "dnetwork_prune" "network prune" "Cleanup networks"
@@ -95,6 +97,7 @@ _docker_help_rows_intent() {
     ux_table_row "list all" "dpsa" "docker ps -a"
     ux_table_row "disk usage" "ddf" "docker system df"
     ux_table_row "clean dangling" "dprune" "docker system prune -f"
+    ux_table_row "reclaim everything" "dprune_full" "docker system prune -a --volumes"
     # 'docker-help here' is owned by #777 — keep the issue ref in code only,
     # not in the user-facing hint (gemini-code-assist review on PR #803).
     ux_info "Hint: 'docker-help here' inspects the current directory for compose files."
@@ -264,6 +267,131 @@ _docker_help_recommend() {
     ux_bullet "docker-help --all"
 }
 
+# --- raw-command catalog + learning surfaces (#899) ---
+#
+# SSOT for the (alias -> full raw command -> description) relationship,
+# tagged by section. The cryptic aliases (dprune etc.) live only in THIS
+# environment; this catalog is the teaching surface that surfaces the
+# portable, copy-paste-ready `docker ...` command behind each one so the
+# raw command — not the alias — is what gets learned. Both the raw-first
+# renderer and the reverse-lookup consume this single source.
+#
+# Format per line: alias|full raw command|description|section
+_docker_help_catalog() {
+    printf '%s\n' \
+        'dc|docker compose|Base command|compose' \
+        'dcu|docker compose up|Foreground start|compose' \
+        'dcud|docker compose up -d|Detached start|compose' \
+        'dcd|docker compose down|Stop & remove|compose' \
+        'dcl|docker compose logs -f <svc>|Smart logs (service/container)|compose' \
+        'dce|docker compose exec <svc> <cmd>|Execute command|compose' \
+        'dcps|docker compose ps|Status|compose-extra' \
+        'dcb|docker compose build|Build services|compose-extra' \
+        'dcr|docker compose restart <svc>|Restart services|compose-extra' \
+        'dcdv|docker compose down -v|Stop & remove volumes|compose-extra' \
+        'dcstop|docker compose stop|Stop containers|compose-extra' \
+        'dcstart|docker compose start|Start containers|compose-extra' \
+        'dps|docker ps|Running containers|basics' \
+        'dpsa|docker ps -a|All containers|basics' \
+        'di|docker images|List images|basics' \
+        'dim|docker images|List images (alias of di)|basics' \
+        'dstats|docker stats|Resource usage|basics' \
+        'dstop|docker stop <name>|Stop container|basics' \
+        'drm|docker rm <name>|Remove container|basics' \
+        'drmi|docker rmi <image>|Remove image|basics' \
+        'dlogs|docker logs -f <name>|Follow logs|basics' \
+        'dinspect|docker inspect <object>|Inspect object|basics' \
+        'ddf|docker system df|Disk usage|resources' \
+        'dprune|docker system prune -f|Basic cleanup (-f only; keeps images & volumes)|resources' \
+        'dprune_full|docker system prune -a --volumes|Deep cleanup (removes images+volumes)|resources' \
+        'dvols|docker volume ls -f dangling=true|Dangling volumes|resources' \
+        'dvol_rm|docker volume rm <name>|Remove volume|resources' \
+        'dnetwork_prune|docker network prune -f|Cleanup networks|resources' \
+        'dbuild_prune|docker builder prune -f|Cleanup build cache|resources' \
+        'dbash|docker exec -it <name> bash|Shell access (bash/sh)|utilities' \
+        'denv|docker exec <name> env|Show env vars|utilities'
+}
+
+# Normalize a user-supplied section token to a canonical catalog section.
+# Mirrors the synonym set in _docker_help_section_rows so `raw <section>`
+# accepts the same aliases (e.g. prune -> resources).
+_docker_help_normalize_section() {
+    case "$1" in
+        compose) printf 'compose\n' ;;
+        compose-extra | extra) printf 'compose-extra\n' ;;
+        basics | basic) printf 'basics\n' ;;
+        resources | resource | prune) printf 'resources\n' ;;
+        utilities | util | utils) printf 'utilities\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+_docker_help_is_alias() {
+    _docker_help_catalog | cut -d'|' -f1 | grep -qx "$1"
+}
+
+# Reverse lookup: alias -> raw command. Teaches what an alias actually runs
+# so the portable command can be verified and learned (#899 F-2).
+_docker_help_reverse() {
+    local row raw desc
+    row=$(_docker_help_catalog | awk -F'|' -v a="$1" '$1 == a { print; exit }')
+    if [ -z "$row" ]; then
+        ux_error "Unknown docker alias: $1"
+        ux_info "Try: docker-help --list  or  docker-help raw"
+        return 1
+    fi
+    raw=$(printf '%s\n' "$row" | cut -d'|' -f2)
+    desc=$(printf '%s\n' "$row" | cut -d'|' -f3)
+    ux_section "Alias -> raw command"
+    # Bare monospace line so the raw command is copy-paste ready (no icon /
+    # bullet) — same rationale as _docker_help_recommend_print (#777).
+    printf '  %s  ->  %s\n' "$1" "$raw"
+    ux_info "  $desc"
+    ux_info ""
+    ux_info "Tip: run the raw command anywhere — it works without these aliases."
+}
+
+# Raw-first rendering: full canonical commands as the primary, copy-paste
+# ready surface, alias demoted to an annotation (#899 F-1). Optional
+# section filter reuses the catalog's section tags.
+_docker_help_raw() {
+    local want_section printed
+    # Split guard onto its own lines: a one-line `[ -n "..." ] && x=$(fn "$1")`
+    # form flanks the private-function call with quotes, which the pre-commit
+    # naming_check mis-reads as snake_case user-facing text.
+    want_section=""
+    if [ -n "${1:-}" ]; then
+        want_section=$(_docker_help_normalize_section "$1")
+    fi
+
+    if [ -n "$want_section" ]; then
+        ux_section "Raw commands — $want_section (copy-paste ready)"
+    else
+        ux_section "Raw commands (copy-paste ready)"
+    fi
+
+    printed=0
+    # Read into a temp stream so the loop body can set `printed` in the
+    # current shell (a piped `while` would run in a subshell and lose it).
+    while IFS='|' read -r al raw desc sec; do
+        [ -z "$al" ] && continue
+        if [ -n "$want_section" ] && [ "$sec" != "$want_section" ]; then
+            continue
+        fi
+        printf '  %s\n' "$raw"
+        ux_info "    alias: $al   -- $desc"
+        printed=1
+    done <<EOF
+$(_docker_help_catalog)
+EOF
+
+    if [ "$printed" -eq 0 ]; then
+        ux_error "No raw commands for section: ${1:-}"
+        ux_info "Try: docker-help --list  (sections), or docker-help raw (all)"
+        return 1
+    fi
+}
+
 docker_help() {
     case "${1:-}" in
         "")
@@ -290,8 +418,19 @@ docker_help() {
         --map)
             _docker_help_rows_map
             ;;
+        raw | --raw)
+            _docker_help_raw "${2:-}"
+            ;;
         *)
-            _docker_help_section_rows "$1"
+            # A known alias (dprune, dcud, ...) -> reverse lookup to its raw
+            # command; otherwise treat the token as a section name. Section
+            # keywords and alias names do not overlap, so order is safe and
+            # the unknown-section error path is preserved (#899 F-2).
+            if _docker_help_is_alias "$1"; then
+                _docker_help_reverse "$1"
+            else
+                _docker_help_section_rows "$1"
+            fi
             ;;
     esac
 }

--- a/tests/integration/test_docker_help_raw.py
+++ b/tests/integration/test_docker_help_raw.py
@@ -1,0 +1,130 @@
+"""
+Tests for docker-help raw-command-first learning surfaces (#899).
+
+Three additive surfaces on top of the existing alias-first help:
+
+  - docker-help raw [section]   raw-first, copy-paste-ready full commands (F-1)
+  - docker-help <alias>         reverse lookup: alias -> raw command (F-2)
+  - intent map / resources      full-prune raw command surfaced + dprune
+                                scope clarified (F-3)
+  - summary mentions raw/lookup so they are discoverable (F-4)
+"""
+
+import re
+
+import pytest
+
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
+
+
+@pytest.fixture
+def shell_runner(shell_runner):
+    """Force DOTFILES_ROOT_NO_CANONICALIZE=1 so the worktree's own
+    `shell-common/functions/devops_help.sh` is sourced — not whatever the
+    main install in `~/dotfiles` happens to have (issue #589 worktree
+    canonicalization). Mirrors test_devx_help.py's `devx_runner`."""
+    base = shell_runner
+
+    def runner(shell, cmd, env_overrides=None):
+        merged = {"DOTFILES_ROOT_NO_CANONICALIZE": "1"}
+        if env_overrides:
+            merged.update(env_overrides)
+        return base(shell, cmd, env_overrides=merged)
+
+    return runner
+
+
+class TestDockerHelpRaw:
+    """`docker-help raw [section]` renders portable raw commands."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_raw_all_runs(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help raw")
+        assert result.exit_code == 0, f"{shell}: stderr={result.stderr}"
+        plain = _plain(result.stdout)
+        assert "docker compose up -d" in plain
+        assert "docker system prune -f" in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("section_arg", ["resources", "prune"])
+    def test_raw_resources_has_full_prune(self, shell_runner, shell, section_arg):
+        result = shell_runner(shell, f"docker_help raw {section_arg}")
+        assert result.exit_code == 0, f"{shell}: stderr={result.stderr}"
+        plain = _plain(result.stdout)
+        # The canonical deep-prune command the user wants to learn.
+        assert "docker system prune -a --volumes" in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_raw_flag_form(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help --raw resources")
+        assert result.exit_code == 0
+        assert "docker system prune -a --volumes" in _plain(result.stdout)
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_raw_unknown_section_fails(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help raw nope")
+        assert result.exit_code != 0, f"{shell}: unknown raw section should fail"
+
+
+class TestDockerHelpReverseLookup:
+    """`docker-help <alias>` teaches the raw command behind an alias."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_dprune_reverse(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help dprune")
+        assert result.exit_code == 0, f"{shell}: stderr={result.stderr}"
+        plain = _plain(result.stdout)
+        assert "docker system prune -f" in plain
+        assert "->" in plain
+        # dprune is the basic form — must NOT be confused with the deep one.
+        assert "-a --volumes" not in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_dprune_full_reverse(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help dprune_full")
+        assert result.exit_code == 0
+        assert "docker system prune -a --volumes" in _plain(result.stdout)
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_unknown_section_still_errors(self, shell_runner, shell):
+        # A token that is neither a section nor a known alias preserves the
+        # original unknown-section error path (regression guard).
+        result = shell_runner(shell, "docker_help totally-bogus")
+        assert result.exit_code != 0
+
+
+class TestDockerHelpDataFixes:
+    """F-3: full-prune raw command surfaced; dprune scope clarified."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_intent_map_has_full_prune(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help --map")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "reclaim everything" in plain
+        assert "docker system prune -a --volumes" in plain
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_resources_section_distinguishes_prune_scope(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help resources")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        # dprune_full now shows its real flags inline so it can't be mistaken
+        # for the lighter dprune.
+        assert "system prune -a --volumes" in plain
+
+
+class TestDockerHelpDiscoverability:
+    """F-4: summary advertises the new learning surfaces."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_summary_mentions_raw_and_lookup(self, shell_runner, shell):
+        result = shell_runner(shell, "docker_help --help")
+        assert result.exit_code == 0
+        plain = _plain(result.stdout)
+        assert "raw" in plain
+        assert "lookup" in plain


### PR DESCRIPTION
## 개요

`docker-help` 를 **alias-우선(암기형)** 에서 **raw-command-우선(학습형)** 으로 재설계한다.
`dprune` 같은 고도 축약 alias 는 이 환경에만 존재해 동료 PC·CI 에선 무용하고, 자주 쓸수록
원본 명령(`docker system prune -a --volumes`)을 떠올리는 능력이 퇴화한다. 이식 가능한 원본
docker 명령을 1차 표면으로 끌어올려 확인·복붙·암기를 돕는다.

추가 계기: `dprune` 은 실제로 `docker system prune -f`(basic) 인데 help 가 "Basic cleanup"
으로만 표기해, 사용자가 deep prune 으로 오해했다 (`dprune_full` = `-a --volumes`). alias 가
자기 범위를 속이는 문제를 데이터·표면 양쪽에서 바로잡는다.

## 변경 사항 (commit: 4b6ddd4)

- **F-1 raw 모드** — `docker-help raw [section]`: 신규 `_docker_help_catalog` SSOT 기반
  raw-first 렌더. full 명령을 복붙 가능한 monospace 로 출력(alias 는 주석으로 강등).
  `docker-help raw resources` → `docker system prune -a --volumes`.
- **F-2 reverse lookup** — `docker-help <alias>`: `dprune -> docker system prune -f`.
  section 키워드와 alias 이름이 겹치지 않으므로 `*)` 분기에서 alias 우선 판정, 미지 토큰은
  기존 unknown-section 에러 경로(`return 1`)를 그대로 보존.
- **F-3 데이터 정정** — intent 맵에 `reclaim everything -> docker system prune -a --volumes`
  추가, resources 테이블에서 `dprune`(-f only; keeps images & volumes) vs
  `dprune_full`(-a --volumes) 범위를 인라인 명시.
- **F-4 discoverability** — 요약에 `raw`/`lookup` 진입점 노출(12줄, 15줄 정책 준수).
- **NF-1 SSOT** — raw 렌더러·reverse lookup 모두 단일 `_docker_help_catalog` 소비
  (command-guidelines.md "표시와 데이터 분리").

## 설계 노트

- dispatcher 골격(positional dispatcher)은 command-design-pattern.md §4/§6 를 이미 준수 →
  **구조 재작성 없이** row 데이터 + 렌더러만 추가. alias 삭제/이름변경 없음(하위 호환).

## 테스트

- `tests/integration/test_docker_help_raw.py` 신규 **22 cases** (bash+zsh) — PASS.
- 회귀 민감 항목 수동 검증: 요약 12줄, `i-want`/`--map`/`compose`/`--all` 무회귀,
  unknown 토큰 rc=1. shellcheck/ruff/shfmt 클린.
- `#589` worktree canonicalization 회피: `test_devx_help.py` 선례대로
  `DOTFILES_ROOT_NO_CANONICALIZE=1` wrapper 를 테스트 파일 한정 적용.

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)
