### PR TITLE
fix(gcp-scan): #903 내용 동일 커밋 pre-flight 스킵 — subject 우회 conflict→empty 무한루프 차단

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -408,6 +408,7 @@ EOF
                 fi
                 local picked=0
                 local empty_skipped=0
+                local content_skipped=0
                 local dup_skipped=0
                 while IFS= read -r sha; do
                     [ -z "$sha" ] && continue
@@ -434,7 +435,9 @@ EOF
                         else
                             echo "ℹ Skipping ${sha} — changes already in HEAD (pre-flight)"
                         fi
-                        empty_skipped=$((empty_skipped + 1))
+                        # A content-dup is "already applied via another path", not
+                        # a git-empty commit — keep the counts distinct (issue #903).
+                        content_skipped=$((content_skipped + 1))
                         continue
                     fi
                     if type ux_info >/dev/null 2>&1; then
@@ -469,11 +472,17 @@ EOF
                 # conflict returns 1 above), so report 0 conflicts.
                 if type ux_success >/dev/null 2>&1; then
                     ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
+                    if [ "$content_skipped" -gt 0 ]; then
+                        ux_info "($content_skipped commit(s) skipped — content already in HEAD)"
+                    fi
                     if [ "$empty_skipped" -gt 0 ]; then
                         ux_info "($empty_skipped empty commit(s) also skipped)"
                     fi
                 else
                     echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
+                    if [ "$content_skipped" -gt 0 ]; then
+                        echo "  ($content_skipped commit(s) skipped — content already in HEAD)"
+                    fi
                     if [ "$empty_skipped" -gt 0 ]; then
                         echo "  ($empty_skipped empty commit(s) also skipped)"
                     fi

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -29,6 +29,30 @@ _gcp_scan_is_empty_cherry_pick() {
     return 0
 }
 
+_gcp_scan_already_in_head() {
+    # True (0) when every file that commit $1 touches already has identical
+    # content in HEAD — i.e. cherry-picking it would produce no net change.
+    # Catches the "same content, different path" case that Stage-1's
+    # subject-based dup detection misses (issue #903): a commit whose subject
+    # is unique but whose payload arrived in HEAD via merge/squash/edit. Such
+    # a commit otherwise conflicts, resolves to empty, and forces --skip.
+    local sha="$1"
+    local changed_files
+    changed_files=$(git diff-tree --no-commit-id -r --name-only "$sha" 2>/dev/null)
+    # No file changes (e.g. an already-empty commit) -> nothing to apply.
+    [ -z "$changed_files" ] && return 0
+    local f
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        # Any file whose HEAD content differs from $sha's means real work
+        # remains -> not already in HEAD.
+        git diff --quiet HEAD "$sha" -- "$f" 2>/dev/null || return 1
+    done <<EOF
+$changed_files
+EOF
+    return 0
+}
+
 _gcp_scan_dup_base_sha() {
     # Look up the base-branch SHA that a duplicate source SHA matches.
     # $1 = candidate source SHA; $2 = duplicate map ("SRC_SHA BASE_SHA" lines).
@@ -398,6 +422,19 @@ EOF
                             echo "ℹ Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
                         fi
                         dup_skipped=$((dup_skipped + 1))
+                        continue
+                    fi
+                    # Pre-flight (issue #903): subject is unique but the payload
+                    # may already be in HEAD via a different path. Cherry-picking
+                    # it would conflict then resolve to empty, forcing an endless
+                    # conflict -> --skip loop. Detect content-equality up front.
+                    if _gcp_scan_already_in_head "$sha"; then
+                        if type ux_info >/dev/null 2>&1; then
+                            ux_info "Skipping ${sha} — changes already in HEAD (pre-flight)"
+                        else
+                            echo "ℹ Skipping ${sha} — changes already in HEAD (pre-flight)"
+                        fi
+                        empty_skipped=$((empty_skipped + 1))
                         continue
                     fi
                     if type ux_info >/dev/null 2>&1; then

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -442,6 +442,117 @@ FIXTURE
     refute_output --partial "skipped (dup)"
 }
 
+# ---------------------------------------------------------------------------
+# Issue #903 — content-based pre-flight skip. Stage-1 (subject-based) dup
+# detection misses a commit whose subject is unique but whose payload already
+# landed in HEAD via a different path (merge / squash / edit). Cherry-picking
+# it conflicts, resolves to empty, and forces an endless conflict -> --skip
+# loop. `_gcp_scan_already_in_head` catches it before the cherry-pick attempt.
+# ---------------------------------------------------------------------------
+
+@test "bash: _gcp_scan_already_in_head private function exists" {
+    run_in_bash 'declare -f _gcp_scan_already_in_head >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "preflight #903: empty commit (no file changes) -> already in HEAD (0)" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo v1 > a.txt && git add a.txt && git commit -qm "init"
+        git commit -q --allow-empty -m "empty"
+        empty_sha=$(git rev-parse HEAD)
+        _gcp_scan_already_in_head "$empty_sha"
+        echo "rc=$?"
+    '
+    assert_success
+    assert_output --partial "rc=0"
+}
+
+@test "preflight #903: all touched files identical to HEAD -> already in HEAD (0)" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo v1 > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b side
+        echo v2 > a.txt && git add a.txt && git commit -qm "side: bump to v2"
+        side_sha=$(git rev-parse HEAD)
+        git checkout -q main
+        # HEAD reaches the SAME content for a.txt via a different commit.
+        echo v2 > a.txt && git add a.txt && git commit -qm "main: bump to v2 (other path)"
+        _gcp_scan_already_in_head "$side_sha"
+        echo "rc=$?"
+    '
+    assert_success
+    assert_output --partial "rc=0"
+}
+
+@test "preflight #903: some touched files differ from HEAD -> NOT in HEAD (1)" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo v1 > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b side
+        echo only-on-side > b.txt && echo shared > c.txt && git add b.txt c.txt \
+            && git commit -qm "side: add b and c"
+        side_sha=$(git rev-parse HEAD)
+        git checkout -q main
+        # HEAD matches c.txt but never gets b.txt -> real work remains.
+        echo shared > c.txt && git add c.txt && git commit -qm "main: add c only"
+        _gcp_scan_already_in_head "$side_sha"
+        echo "rc=$?"
+    '
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "scan #903: content-dup commit (unique subject, different patch-id) skipped via pre-flight, no conflict" {
+    # The content-dup commit must reach the individual loop, so its patch-id
+    # has to DIFFER from how HEAD acquired the same final content (else
+    # `git cherry` filters it out up front). HEAD reaches shared.txt=TARGET via
+    # MIDDLE (two-step), source reaches it in one step from a different parent
+    # -> distinct patch-ids, unique subject. A separate subject-dup commit
+    # creates the gap that forces the non-contiguous (individual) path.
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
+        # Unique subject; creates shared.txt=TARGET in one step.
+        echo TARGET > shared.txt && git add shared.txt && git commit -qm "feat: bring shared payload"
+        echo four > f4.txt && git add f4.txt && git commit -qm "feat four"
+        git checkout -q main
+        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
+        # HEAD reaches shared.txt=TARGET via a DIFFERENT path (MIDDLE -> TARGET)
+        # so the patch-id differs from source -> git cherry still lists it.
+        echo MIDDLE > shared.txt && git add shared.txt && git commit -qm "wip shared"
+        echo TARGET > shared.txt && git add shared.txt && git commit -qm "finalize shared"
+        printf "y\n" | _gcp_scan main source --author=all
+    '
+    assert_success
+    # Subject-dup still handled by Stage-1.
+    assert_output --partial "already applied as"
+    # Content-dup caught by the new pre-flight.
+    assert_output --partial "changes already in HEAD (pre-flight)"
+    refute_output --partial "CONFLICT"
+    refute_output --partial "Resolve and run"
+}
+
 @test "alias-shadow: 'gcp -h' invokes dispatcher (not shadowed git cherry-pick) in zsh (#700)" {
     run zsh -f -c "
         export DOTFILES_ROOT='${DOTFILES_ROOT}'

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -459,6 +459,7 @@ FIXTURE
 @test "preflight #903: empty commit (no file changes) -> already in HEAD (0)" {
     run_in_bash '
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
         cd "$repo" || exit 1
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
@@ -476,6 +477,7 @@ FIXTURE
 @test "preflight #903: all touched files identical to HEAD -> already in HEAD (0)" {
     run_in_bash '
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
         cd "$repo" || exit 1
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
@@ -497,6 +499,7 @@ FIXTURE
 @test "preflight #903: some touched files differ from HEAD -> NOT in HEAD (1)" {
     run_in_bash '
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
         cd "$repo" || exit 1
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
@@ -525,6 +528,7 @@ FIXTURE
     # creates the gap that forces the non-contiguous (individual) path.
     run_in_bash '
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
         cd "$repo" || exit 1
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -450,6 +450,21 @@ FIXTURE
 # loop. `_gcp_scan_already_in_head` catches it before the cherry-pick attempt.
 # ---------------------------------------------------------------------------
 
+_gcp903_make_repo() {
+    # Emits shell that builds a fresh temp repo (main @ a.txt=v1) and cds in,
+    # with EXIT cleanup. Mirrors _gcp811_make_repo; shared by the #903 unit
+    # tests below so the mktemp/trap/git-init boilerplate lives in one place.
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo v1 > a.txt && git add a.txt && git commit -qm "init"
+FIXTURE
+}
+
 @test "bash: _gcp_scan_already_in_head private function exists" {
     run_in_bash 'declare -f _gcp_scan_already_in_head >/dev/null && echo ok'
     assert_success
@@ -457,64 +472,45 @@ FIXTURE
 }
 
 @test "preflight #903: empty commit (no file changes) -> already in HEAD (0)" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        echo v1 > a.txt && git add a.txt && git commit -qm "init"
-        git commit -q --allow-empty -m "empty"
-        empty_sha=$(git rev-parse HEAD)
-        _gcp_scan_already_in_head "$empty_sha"
-        echo "rc=$?"
-    '
+    run_in_bash "
+        $(_gcp903_make_repo)
+        git commit -q --allow-empty -m empty
+        empty_sha=\$(git rev-parse HEAD)
+        _gcp_scan_already_in_head \"\$empty_sha\"
+        echo \"rc=\$?\"
+    "
     assert_success
     assert_output --partial "rc=0"
 }
 
 @test "preflight #903: all touched files identical to HEAD -> already in HEAD (0)" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        echo v1 > a.txt && git add a.txt && git commit -qm "init"
+    run_in_bash "
+        $(_gcp903_make_repo)
         git checkout -q -b side
-        echo v2 > a.txt && git add a.txt && git commit -qm "side: bump to v2"
-        side_sha=$(git rev-parse HEAD)
+        echo v2 > a.txt && git add a.txt && git commit -qm 'side: bump to v2'
+        side_sha=\$(git rev-parse HEAD)
         git checkout -q main
         # HEAD reaches the SAME content for a.txt via a different commit.
-        echo v2 > a.txt && git add a.txt && git commit -qm "main: bump to v2 (other path)"
-        _gcp_scan_already_in_head "$side_sha"
-        echo "rc=$?"
-    '
+        echo v2 > a.txt && git add a.txt && git commit -qm 'main: bump to v2 (other path)'
+        _gcp_scan_already_in_head \"\$side_sha\"
+        echo \"rc=\$?\"
+    "
     assert_success
     assert_output --partial "rc=0"
 }
 
 @test "preflight #903: some touched files differ from HEAD -> NOT in HEAD (1)" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        echo v1 > a.txt && git add a.txt && git commit -qm "init"
+    run_in_bash "
+        $(_gcp903_make_repo)
         git checkout -q -b side
-        echo only-on-side > b.txt && echo shared > c.txt && git add b.txt c.txt \
-            && git commit -qm "side: add b and c"
-        side_sha=$(git rev-parse HEAD)
+        echo only-on-side > b.txt && echo shared > c.txt && git add b.txt c.txt && git commit -qm 'side: add b and c'
+        side_sha=\$(git rev-parse HEAD)
         git checkout -q main
         # HEAD matches c.txt but never gets b.txt -> real work remains.
-        echo shared > c.txt && git add c.txt && git commit -qm "main: add c only"
-        _gcp_scan_already_in_head "$side_sha"
-        echo "rc=$?"
-    '
+        echo shared > c.txt && git add c.txt && git commit -qm 'main: add c only'
+        _gcp_scan_already_in_head \"\$side_sha\"
+        echo \"rc=\$?\"
+    "
     assert_success
     assert_output --partial "rc=1"
 }


### PR DESCRIPTION
## Summary

`gcp scan` 의 비-연속(non-contiguous) 개별 cherry-pick 루프에서, subject 는
고유하지만 payload 가 이미 다른 경로(merge/squash/직접 편집)로 HEAD 에 들어온
커밋이 Stage-1 subject 기반 dup 감지를 우회해 `cherry-pick → conflict →
empty → --skip` 무한 반복을 유발하던 버그를 수정한다 (#903).

## Changes

- **`shell-common/functions/gcp_scan.sh`**
  - `_gcp_scan_already_in_head()` 신규 — 커밋이 건드리는 모든 파일이 이미
    HEAD 와 내용 동일하면 `0` 반환 (변경 없는 빈 커밋도 `0`). 기존
    `_gcp_scan_dup_base_sha()` 바로 앞에 배치.
  - 개별 cherry-pick 루프에서 Stage-1 subject-dup 스킵 직후 pre-flight 호출
    추가 — content-dup 은 `Skipping <sha> — changes already in HEAD
    (pre-flight)` 로그를 남기고 `continue`, cherry-pick 자체를 시도하지 않음.
- **`tests/bats/functions/gcp.bats`**
  - `_gcp_scan_already_in_head` 함수 존재 확인
  - 단위 3케이스: empty 커밋 → 0, 모든 파일 동일 → 0, 일부 파일 상이 → 1
  - 통합 1케이스: 고유 subject·상이 patch-id 의 content-dup 이 conflict 없이
    pre-flight 로 스킵되는지 검증

## Test

- `bats tests/bats/functions/gcp.bats` → 42/42 OK (신규 5케이스 포함)
- `shellcheck` / `shfmt -i 4` → 변경 코드 무진단 (기존 파일 전반의
  SC3003/SC3043 경고는 사전 존재)

## Note

통합 픽스처는 `git cherry` 가 동일 patch-id 를 사전 필터링하기 때문에,
실제 #903 조건인 *상이 patch-id·동일 최종 내용* (base 는 MIDDLE→TARGET 2단계,
source 는 1단계)을 재현하도록 구성했다.

Closes #903
