### PR TITLE
feat(structure-check): #905 README 스킬별 문서 링크 검증(R5) 추가

### DIFF
--- a/claude/skills/claude-plugin-structure-check/SKILL.md
+++ b/claude/skills/claude-plugin-structure-check/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   against the standard directory layout and report PASS/WARN/FAIL/N/A.
   Read-only — never edits. Discovers plugins/skills dynamically by directory
   scan, then evaluates mandatory items M1-M6 (FAIL) and recommended items
-  R1-R4 (WARN). Use when the user says "check my claude-plugin repo
+  R1-R5 (WARN). Use when the user says "check my claude-plugin repo
   structure", "is this marketplace repo standard?", "audit plugin layout",
   "/claude-plugin:structure-check". Sister skill of
   `claude-plugin:structure-refactor` (which fixes what this finds). Do NOT
@@ -46,28 +46,31 @@ embedded SSOT). Discover dynamically — never hard-code names:
 2. `plugins/<p>/skills/*/` → each directory is a skill of that plugin.
 
 Record the plugin and skill lists for the report header and for the
-per-skill recommended checks (R1/R2).
+per-skill recommended checks (R1/R2/R5).
 
-## Step 3: Evaluate M1-M6 and R1-R4
+## Step 3: Evaluate M1-M6 and R1-R5
 
 For each item in `references/structure-spec.md`, assign exactly one of:
 
 - **PASS** — present and valid.
-- **WARN** — recommended item missing/violated (R1-R4 only).
+- **WARN** — recommended item missing/violated (R1-R5 only).
 - **FAIL** — mandatory item missing/invalid (M1-M6 only).
 - **N/A** — the subject does not exist (e.g. a plugin with 0 skills → its
   R1/R2 are N/A, not FAIL).
 
 JSON validity (M1, M3): parse with `python3 -m json.tool` (or `jq`); a
 parse error is FAIL, not WARN. Frontmatter validity (M4): the SKILL.md must
-have both `name:` and `description:` keys. R3/R4 use the heuristics defined
-in the spec.
+have both `name:` and `description:` keys. R3/R4/R5 use the heuristics
+defined in the spec. R5: for each discovered skill `<s>`, grep `README.md`
+for both a `skill-guides/<s>.html` and a `skill-output/<s>-usage.{html,md}`
+path string (relative or Pages-absolute) — missing either → WARN; no skills
+→ N/A.
 
 ## Step 4: Output the Report
 
 Read `references/report-template.md` for the exact format. The report has a
 header line (path + discovered plugins/skills), a `[필수]` block (M1-M6) and
-a `[권장]` block (R1-R4), then the summary verdict:
+a `[권장]` block (R1-R5), then the summary verdict:
 
 - any FAIL → **FAIL**
 - no FAIL but ≥1 WARN → **WARN**

--- a/claude/skills/claude-plugin-structure-check/references/help.md
+++ b/claude/skills/claude-plugin-structure-check/references/help.md
@@ -18,14 +18,15 @@ What it checks (read-only — never edits):
     M5  docs/skill-guides/ + docs/skill-output/ both directories exist
     M6  README.md                              exists
 
-  Recommended (R1-R4 — missing → WARN)
+  Recommended (R1-R5 — missing → WARN)
     R1  docs/skill-guides/<skill>.html         per-skill guide
     R2  docs/skill-output/<skill>-usage.{html,md}  per-skill usage sample
     R3  README is "Simple"                     links into docs/, not too long
     R4  naming consistency                     name: colon ↔ directory hyphen
+    R5  per-skill README guide+usage links     README links both for each skill
 
 Each item reports PASS / WARN / FAIL / N/A. N/A means the subject does not
-exist (e.g. a plugin with 0 skills → R1/R2 are N/A).
+exist (e.g. a plugin with 0 skills → R1/R2/R5 are N/A).
 
 Verdict:
   any FAIL → FAIL ; no FAIL but >=1 WARN → WARN ; all PASS/N/A → PASS

--- a/claude/skills/claude-plugin-structure-check/references/report-template.md
+++ b/claude/skills/claude-plugin-structure-check/references/report-template.md
@@ -19,8 +19,9 @@ claude-plugin structure check — <repo-path>
  N/A   R2 (스킬 없음 — 평가 대상 없음)
  PASS  R3 README.md 가 docs/ 로 링크 (Simple)
  PASS  R4 명명 일관성 (claude-plugin:structure-check ↔ 디렉터리)
+ WARN  R5 README 에 excalidraw-diagram usage 링크 누락
 
-요약: FAIL (필수 2, 권장 1, N/A 1)
+요약: FAIL (필수 2, 권장 2, N/A 1)
 → Fix: /claude-plugin:structure-refactor <repo-path>  (먼저 dry-run, 이후 --apply)
 ```
 
@@ -29,7 +30,10 @@ claude-plugin structure check — <repo-path>
 - One line per item: `<RESULT>  <ID> <subject> <note>`.
 - `<RESULT>` is one of `PASS` / `WARN` / `FAIL` / `N/A` (uppercase),
   left-padded so the IDs align.
-- `[필수]` block lists M1-M6 in order; `[권장]` block lists R1-R4 in order.
+- `[필수]` block lists M1-M6 in order; `[권장]` block lists R1-R5 in order.
+- R5 is per-skill: when more than one skill misses a link, emit one R5 line
+  naming the first offender (or summarize `<n>개 스킬`); a clean repo → PASS,
+  no skills → N/A.
 - Header line names the discovered plugins and total skill count — proof
   the scan was dynamic, not hard-coded.
 

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -47,6 +47,7 @@ Dynamic discovery order:
 | R2 | per-skill `docs/skill-output/<skill>-usage.{html,md}` | both missing |
 | R3 | README is "Simple" | heuristic violated (below) |
 | R4 | naming consistency | SKILL.md `name:` colon-namespace ↔ directory hyphen mismatch |
+| R5 | per-skill README guide+usage links | README missing the guide OR the usage link for a skill |
 
 **R3 README "Simple" heuristic** — PASS only if all hold; any miss → WARN:
 - at least one link into a `docs/` sub-document (evidence of progressive split);
@@ -58,13 +59,28 @@ Dynamic discovery order:
 hyphen directory form. Mismatch → WARN (same rule as `devx:ai-context`
 → `devx-ai-context`).
 
+**R5 per-skill README link rule** — for each discovered skill `<s>`,
+`README.md` must contain **both**:
+- a link to `skill-guides/<s>.html`, **and**
+- a link to `skill-output/<s>-usage.{html,md}`.
+
+Matching is by path-string presence in the README body — relative
+(`skill-guides/<s>.html`) or Pages absolute URL both count. Any skill
+missing either link → **WARN**. This pairs with R1/R2 (which check that
+the files *exist*) to assert the files are *also actually surfaced* in the
+README — completing the "standard" the developer relies on (see
+`claude-plugin-visuals/README.md`). Reuses the Step 2 dynamic skill list,
+so no extra scan. R3's "Simple" heuristic only requires *one* `docs/` link
+anywhere, so it cannot catch a per-skill link gap — R5 does.
+
 ## N/A rule
 
 When the subject of a check does not exist, the check is **N/A**, not FAIL.
-Examples: a plugin with 0 skills → R1/R2 are N/A for that plugin; with no
-plugins at all M3 is N/A and with no skills anywhere M4 is N/A — M2 still
-carries the single "no plugins" FAIL, so the absent subject is never
-double-counted as a second FAIL.
+Examples: a plugin with 0 skills → R1/R2/R5 are N/A for that plugin; with no
+plugins at all M3 is N/A and with no skills anywhere M4 **and R5** are N/A —
+M2 still carries the single "no plugins" FAIL, so the absent subject is never
+double-counted as a second FAIL. R5 is per-skill: with no skills there is no
+link to require, so it is N/A (never FAIL).
 
 ## Summary verdict
 

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -5,8 +5,9 @@ description: >-
   standard layout. Dry-run by default (plan only, no writes); `--apply`
   performs changes. Scope `--mp`/`--mandatory` fixes mandatory items M1-M6
   only (create dirs, `git mv`, minimal marketplace.json/plugin.json
-  skeletons); `--op`/`--recommended` adds recommended R1-R4 fixes (empty
-  placeholder stubs + naming correction). Idempotent. Use when the user
+  skeletons); `--op`/`--recommended` adds recommended R1-R5 fixes (empty
+  placeholder stubs + naming correction + README link backfill). Idempotent.
+  Use when the user
   says "fix my claude-plugin repo structure", "make this marketplace repo
   standard", "/claude-plugin:structure-refactor". Sister skill of
   `claude-plugin:structure-check` (which finds what this fixes). Does NOT
@@ -34,7 +35,7 @@ Positional `[repo-path]` (default = current dir). Flags:
 
 - `--apply` — execute changes. Absent → dry-run (plan only, no writes).
 - `--mandatory` / `--mp` — scope = M1-M6 only (default scope).
-- `--recommended` / `--op` — scope = M1-M6 + R1-R4.
+- `--recommended` / `--op` — scope = M1-M6 + R1-R5.
 - `--mp` and `--op` together → error + usage, stop.
 
 Confirm the path exists. `test -d <path>/.git`: not a git repo → warn (moves
@@ -44,14 +45,14 @@ explicit `--apply` before writing (never auto-apply on a dirty tree).
 ## Step 2: Evaluate Current ↔ Target
 
 Read `references/structure-spec.md` (embedded SSOT — identical copy to
-structure-check's). Run the same M1-M6 / R1-R4 evaluation as
+structure-check's). Run the same M1-M6 / R1-R5 evaluation as
 `claude-plugin:structure-check` to compute the current → target diff.
 Discover plugins/skills dynamically (`plugins/*/`, `plugins/*/skills/*/`).
 
 ## Step 3: Build the Plan
 
 Read `references/plan-and-report-templates.md`. Produce an ordered change
-list, each tagged with its driving check ID (M1-M6, and R1-R4 only when
+list, each tagged with its driving check ID (M1-M6, and R1-R5 only when
 scope is `--op`). Already-correct items produce no action (idempotent).
 
 ## Step 4: Dry-run or Apply
@@ -65,7 +66,9 @@ scope is `--op`). Already-correct items produce no action (idempotent).
   - write minimal skeletons for a missing `marketplace.json` / `plugin.json`
     (filled with discovered plugin/skill names);
   - **`--op` only**: create empty R1/R2 placeholder stubs (TODO header +
-    "fill with /devx:visualize" comment) and correct R4 naming mismatches.
+    "fill with /devx:visualize" comment), correct R4 naming mismatches, and
+    backfill missing R5 README links (append a per-skill `Docs:` line with
+    the guide+usage links under the skill's README section — stub level).
 
 ## Step 5: Report
 

--- a/claude/skills/claude-plugin-structure-refactor/references/help.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/help.md
@@ -12,8 +12,8 @@ Flags:
   --apply              Execute the plan. Without it, the skill is DRY-RUN
                        (prints the plan, writes nothing).
   --mandatory | --mp   Scope = mandatory items M1-M6 only. (default scope)
-  --recommended | --op Scope = M1-M6 + recommended R1-R4 (placeholder stubs
-                       + naming correction).
+  --recommended | --op Scope = M1-M6 + recommended R1-R5 (placeholder stubs
+                       + naming correction + README link backfill).
   --mp and --op together → error.
 
 Behavior:
@@ -28,8 +28,9 @@ Behavior:
                            falls back to `mv` outside a git repo)
                          - write minimal marketplace.json / plugin.json
                            skeletons from discovered plugin/skill names
-                         - (--op only) create empty R1/R2 placeholder stubs
-                           and correct R4 naming mismatches
+                         - (--op only) create empty R1/R2 placeholder stubs,
+                           correct R4 naming mismatches, and backfill missing
+                           R5 README guide+usage links (stub level)
 
 Placeholder stub boundary (--op):
   Stubs are empty files with a TODO header only. This skill never calls

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -60,15 +60,17 @@ Execute the plan in this order so later steps see earlier results:
    `git mv`) so it matches the `name:`; never silently rewrite a correct
    `name:`.
 6. **`--op` only — R5 README links**: for each skill `<s>` whose README is
-   missing the guide or usage link, append a stub-level `Docs:` line into
-   the README naming both relative paths:
+   missing the guide or usage link, append a stub-level line into the README
+   for **each missing link only** (check guide and usage independently):
    ```markdown
-   - `<s>`: [guide](docs/skill-guides/<s>.html) · [usage](docs/skill-output/<s>-usage.md)
+   - `<s>` guide: [guide](docs/skill-guides/<s>.html)
+   - `<s>` usage: [usage](docs/skill-output/<s>-usage.md)
    ```
-   Append only the link(s) actually missing; never rewrite or reorder
-   existing README content, and never duplicate a link already present
-   (idempotent). Stub level — does not author guide/usage *content* (R1/R2
-   own the file stubs).
+   Append only the link(s) actually missing — if the guide is already linked
+   and only the usage is absent, append the usage line alone. Never rewrite
+   or reorder existing README content, and never duplicate a link already
+   present (idempotent). Stub level — does not author guide/usage *content*
+   (R1/R2 own the file stubs).
 
 Skeleton/stub writes never touch a file that already exists, and link
 backfill never duplicates an existing link — the skill is idempotent.

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -13,16 +13,18 @@ claude-plugin structure refactor — <repo-path>   (scope: mandatory|recommended
   [M5] mkdir   docs/skill-guides/, docs/skill-output/
   [R1] stub    docs/skill-guides/visualize.html        (--op only)
   [R4] rename  name: 교정 → claude-plugin:visualize     (--op only)
+  [R5] link    README.md ← excalidraw-diagram guide+usage 링크 추가 (--op only)
 
 총 <n> 변경  (필수 <m>, 권장 <r>)
 ```
 
 - One line per change: `[<ID>] <verb>  <path / detail>`.
 - Verbs: `create` (new file), `mkdir` (new dir), `git mv` / `mv` (move),
-  `stub` (empty placeholder), `rename` (frontmatter/dir naming fix).
+  `stub` (empty placeholder), `rename` (frontmatter/dir naming fix),
+  `link` (append a per-skill guide+usage link into README — R5).
 - Items already correct produce **no line** (idempotent — proof there is
   nothing to do is an empty plan + `총 0 변경`).
-- R1-R4 lines appear only when scope is `--op` / `--recommended`.
+- R1-R5 lines appear only when scope is `--op` / `--recommended`.
 
 ## Apply rules
 
@@ -57,9 +59,19 @@ Execute the plan in this order so later steps see earlier results:
    directory hyphen form disagree, correct the directory name (prefer
    `git mv`) so it matches the `name:`; never silently rewrite a correct
    `name:`.
+6. **`--op` only — R5 README links**: for each skill `<s>` whose README is
+   missing the guide or usage link, append a stub-level `Docs:` line into
+   the README naming both relative paths:
+   ```markdown
+   - `<s>`: [guide](docs/skill-guides/<s>.html) · [usage](docs/skill-output/<s>-usage.md)
+   ```
+   Append only the link(s) actually missing; never rewrite or reorder
+   existing README content, and never duplicate a link already present
+   (idempotent). Stub level — does not author guide/usage *content* (R1/R2
+   own the file stubs).
 
-Skeleton/stub writes never touch a file that already exists — the skill is
-idempotent.
+Skeleton/stub writes never touch a file that already exists, and link
+backfill never duplicates an existing link — the skill is idempotent.
 
 ## Completion report template
 
@@ -74,7 +86,7 @@ Planned: <n>   Applied: <n>   Skipped (already correct): <n>
 <the plan block above, with applied lines marked ✓>
 
 [OK] refactor complete   |   [FAIL] <reason>
-applied=<n> moved=<n> created=<n> stubbed=<n> mode=<dry-run|apply> scope=<mp|op>
+applied=<n> moved=<n> created=<n> stubbed=<n> linked=<n> mode=<dry-run|apply> scope=<mp|op>
 ```
 
 End with the next-action hint:

--- a/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
@@ -47,6 +47,7 @@ Dynamic discovery order:
 | R2 | per-skill `docs/skill-output/<skill>-usage.{html,md}` | both missing |
 | R3 | README is "Simple" | heuristic violated (below) |
 | R4 | naming consistency | SKILL.md `name:` colon-namespace ↔ directory hyphen mismatch |
+| R5 | per-skill README guide+usage links | README missing the guide OR the usage link for a skill |
 
 **R3 README "Simple" heuristic** — PASS only if all hold; any miss → WARN:
 - at least one link into a `docs/` sub-document (evidence of progressive split);
@@ -58,13 +59,28 @@ Dynamic discovery order:
 hyphen directory form. Mismatch → WARN (same rule as `devx:ai-context`
 → `devx-ai-context`).
 
+**R5 per-skill README link rule** — for each discovered skill `<s>`,
+`README.md` must contain **both**:
+- a link to `skill-guides/<s>.html`, **and**
+- a link to `skill-output/<s>-usage.{html,md}`.
+
+Matching is by path-string presence in the README body — relative
+(`skill-guides/<s>.html`) or Pages absolute URL both count. Any skill
+missing either link → **WARN**. This pairs with R1/R2 (which check that
+the files *exist*) to assert the files are *also actually surfaced* in the
+README — completing the "standard" the developer relies on (see
+`claude-plugin-visuals/README.md`). Reuses the Step 2 dynamic skill list,
+so no extra scan. R3's "Simple" heuristic only requires *one* `docs/` link
+anywhere, so it cannot catch a per-skill link gap — R5 does.
+
 ## N/A rule
 
 When the subject of a check does not exist, the check is **N/A**, not FAIL.
-Examples: a plugin with 0 skills → R1/R2 are N/A for that plugin; with no
-plugins at all M3 is N/A and with no skills anywhere M4 is N/A — M2 still
-carries the single "no plugins" FAIL, so the absent subject is never
-double-counted as a second FAIL.
+Examples: a plugin with 0 skills → R1/R2/R5 are N/A for that plugin; with no
+plugins at all M3 is N/A and with no skills anywhere M4 **and R5** are N/A —
+M2 still carries the single "no plugins" FAIL, so the absent subject is never
+double-counted as a second FAIL. R5 is per-skill: with no skills there is no
+link to require, so it is N/A (never FAIL).
 
 ## Summary verdict
 

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -302,19 +302,23 @@ EOF
 $(_cps_plugins "$_repo")
 EOF
 
-    # --op: R5 README link backfill — append a per-skill guide+usage link line
-    # for any skill missing either link. Idempotent: skip when both present.
+    # --op: R5 README link backfill — append ONLY the missing link(s) per skill
+    # so an already-present link is never duplicated (idempotent, per spec).
+    local _has_guide _has_usage
     while IFS= read -r _p; do
         [ -n "$_p" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
-            if grep -qF "skill-guides/$_s.html" "$_repo/README.md" &&
-                { grep -qF "skill-output/$_s-usage.html" "$_repo/README.md" ||
-                    grep -qF "skill-output/$_s-usage.md" "$_repo/README.md"; }; then
-                continue
-            fi
-            printf -- '- `%s`: [guide](docs/skill-guides/%s.html) · [usage](docs/skill-output/%s-usage.md)\n' \
-                "$_s" "$_s" "$_s" >>"$_repo/README.md"
+            _has_guide=0
+            _has_usage=0
+            grep -qF "skill-guides/$_s.html" "$_repo/README.md" && _has_guide=1
+            { grep -qF "skill-output/$_s-usage.html" "$_repo/README.md" ||
+                grep -qF "skill-output/$_s-usage.md" "$_repo/README.md"; } && _has_usage=1
+            [ "$_has_guide" -eq 1 ] && [ "$_has_usage" -eq 1 ] && continue
+            [ "$_has_guide" -eq 0 ] && printf -- '- `%s` guide: [guide](docs/skill-guides/%s.html)\n' \
+                "$_s" "$_s" >>"$_repo/README.md"
+            [ "$_has_usage" -eq 0 ] && printf -- '- `%s` usage: [usage](docs/skill-output/%s-usage.md)\n' \
+                "$_s" "$_s" >>"$_repo/README.md"
         done <<EOF
 $(_cps_skills "$_repo" "$_p")
 EOF

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -5,7 +5,7 @@
 #   claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
 #
 # The two skills are AI-interpreted markdown with no shell entry point;
-# these functions are the executable form of their M1-M6 / R1-R4 evaluation
+# these functions are the executable form of their M1-M6 / R1-R5 evaluation
 # and the refactor apply logic, so bats can pin the behavior against real
 # fixture repos. Keep them in sync with structure-spec.md whenever the spec
 # changes.
@@ -96,7 +96,7 @@ cps_check_M5() {
 
 cps_check_M6() { [ -f "$1/README.md" ] && echo PASS || echo FAIL; }
 
-# ---- recommended checks (R1-R4) -- echo PASS|WARN|N/A -------------------
+# ---- recommended checks (R1-R5) -- echo PASS|WARN|N/A -------------------
 cps_check_R1() {
     # per-skill docs/skill-guides/<skill>.html ; N/A if no skills
     local _p _s _any=0
@@ -174,6 +174,39 @@ EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
+cps_check_R5() {
+    # per-skill README links: README must reference BOTH skill-guides/<s>.html
+    # AND skill-output/<s>-usage.{html,md} for every skill. Matching is by
+    # path-string presence (relative or Pages-absolute both count). N/A when
+    # README absent (M6 owns that) or no skills exist.
+    [ -f "$1/README.md" ] || {
+        echo "N/A"
+        return
+    }
+    local _p _s _any=0
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            _any=1
+            grep -qF "skill-guides/$_s.html" "$1/README.md" || {
+                echo WARN
+                return
+            }
+            { grep -qF "skill-output/$_s-usage.html" "$1/README.md" ||
+                grep -qF "skill-output/$_s-usage.md" "$1/README.md"; } || {
+                echo WARN
+                return
+            }
+        done <<EOF
+$(_cps_skills "$1" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$1")
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
+}
+
 # ---- aggregate verdict ---------------------------------------------------
 cps_verdict() {
     # echo FAIL | WARN | PASS for repo $1
@@ -185,7 +218,7 @@ cps_verdict() {
             return
         }
     done
-    for _c in R1 R2 R3 R4; do
+    for _c in R1 R2 R3 R4 R5; do
         _r="$(cps_check_$_c "$1")"
         [ "$_r" = WARN ] && {
             echo WARN
@@ -262,6 +295,26 @@ EOF
                 [ -f "$_repo/docs/skill-output/$_s-usage.md" ]; } || printf \
                 '<!-- TODO: %s usage sample — fill with /devx:visualize -->\n' \
                 "$_s" >"$_repo/docs/skill-output/$_s-usage.md"
+        done <<EOF
+$(_cps_skills "$_repo" "$_p")
+EOF
+    done <<EOF
+$(_cps_plugins "$_repo")
+EOF
+
+    # --op: R5 README link backfill — append a per-skill guide+usage link line
+    # for any skill missing either link. Idempotent: skip when both present.
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            if grep -qF "skill-guides/$_s.html" "$_repo/README.md" &&
+                { grep -qF "skill-output/$_s-usage.html" "$_repo/README.md" ||
+                    grep -qF "skill-output/$_s-usage.md" "$_repo/README.md"; }; then
+                continue
+            fi
+            printf -- '- `%s`: [guide](docs/skill-guides/%s.html) · [usage](docs/skill-output/%s-usage.md)\n' \
+                "$_s" "$_s" "$_s" >>"$_repo/README.md"
         done <<EOF
 $(_cps_skills "$_repo" "$_p")
 EOF

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -240,6 +240,19 @@ build_perfect() {
     [ "$first" = "$second" ]
 }
 
+@test "R5 backfill appends ONLY the missing link (no duplicate of present one)" {
+    # gemini #906 review: guide already linked, only usage missing.
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    printf -- '- [guide](docs/skill-guides/visualize.html)\n' >> "$REPO/README.md"
+    run cps_check_R5 "$REPO"; assert_output WARN          # usage missing
+    cps_refactor "$REPO" op apply
+    # guide link still appears exactly once (not re-appended), usage now present
+    [ "$(grep -c 'skill-guides/visualize.html' "$REPO/README.md")" = "1" ]
+    [ "$(grep -c 'skill-output/visualize-usage.md' "$REPO/README.md")" = "1" ]
+    run cps_check_R5 "$REPO"; assert_output PASS
+}
+
 # ---- N/A for absent subject on mandatory checks (PR #894 gemini review) --
 
 @test "no plugins -> M3 is N/A (M2 owns the FAIL), verdict still FAIL" {

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # tests/bats/skills/claude_plugin_structure.bats
 # Verify the structure spec shared by
-#   claude/skills/claude-plugin-structure-check/   (M1-M6 / R1-R4 evaluation)
+#   claude/skills/claude-plugin-structure-check/   (M1-M6 / R1-R5 evaluation)
 #   claude/skills/claude-plugin-structure-refactor/ (dry-run / --apply / --op)
 # Source-of-truth fixture: _fixtures/claude_plugin_structure.sh
 #
@@ -51,9 +51,16 @@ _seed_recommended_files() {
     printf '<!-- usage -->\n' > "$1/docs/skill-output/visualize-usage.md"
 }
 
+_seed_readme_links() {
+    # $1=repo $2=skill : append a per-skill guide+usage link line (R5)
+    printf -- '- `%s`: [guide](docs/skill-guides/%s.html) [usage](docs/skill-output/%s-usage.md)\n' \
+        "$2" "$2" "$2" >> "$1/README.md"
+}
+
 build_perfect() {
     _seed_skill "$1"; _seed_mandatory_json "$1"; _seed_docs_dirs "$1"
     _seed_readme "$1"; _seed_recommended_files "$1"
+    _seed_readme_links "$1" visualize
 }
 
 # ---- Scenario 1: perfect -------------------------------------------------
@@ -88,6 +95,7 @@ build_perfect() {
 @test "mandatory missing -> refactor --apply (mp) -> recheck PASS" {
     _seed_skill "$REPO"; _seed_docs_dirs "$REPO"
     _seed_readme "$REPO"; _seed_recommended_files "$REPO"
+    _seed_readme_links "$REPO" visualize    # recommended satisfied; only mandatory missing
     cps_refactor "$REPO" mp apply
     run cps_check_M1 "$REPO"; assert_output PASS
     run cps_check_M3 "$REPO"; assert_output PASS
@@ -174,6 +182,62 @@ build_perfect() {
         > "$REPO/plugins/demo/skills/structure-check/SKILL.md"
     _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
     run cps_check_R4 "$REPO"; assert_output PASS
+}
+
+# ---- R5 per-skill README links (#905) -----------------------------------
+
+@test "R5 PASS when README links both guide and usage for each skill" {
+    build_perfect "$REPO"
+    run cps_check_R5 "$REPO"; assert_output PASS
+}
+
+@test "R5 WARN when README links the guide but not the usage" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"; _seed_recommended_files "$REPO"
+    printf -- '- [guide](docs/skill-guides/visualize.html)\n' >> "$REPO/README.md"
+    run cps_check_R5 "$REPO"; assert_output WARN
+    run cps_verdict "$REPO"; assert_output WARN
+}
+
+@test "R5 WARN when README has a docs/ link but no per-skill links (R3 PASS gap)" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"; _seed_recommended_files "$REPO"
+    run cps_check_R3 "$REPO"; assert_output PASS
+    run cps_check_R5 "$REPO"; assert_output WARN
+}
+
+@test "R5 WARN when one of two skills is missing its links" {
+    mkdir -p "$REPO/plugins/demo/skills/visualize" "$REPO/plugins/demo/skills/excalidraw"
+    printf 'name: visualize\ndescription: x\n' > "$REPO/plugins/demo/skills/visualize/SKILL.md"
+    printf 'name: excalidraw\ndescription: x\n' > "$REPO/plugins/demo/skills/excalidraw/SKILL.md"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    _seed_readme_links "$REPO" visualize    # excalidraw links intentionally absent
+    run cps_check_R5 "$REPO"; assert_output WARN
+}
+
+@test "R5 is N/A when the plugin has 0 skills" {
+    mkdir -p "$REPO/plugins/demo/skills"
+    _seed_mandatory_json "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R5 "$REPO"; assert_output "N/A"
+}
+
+@test "R5 missing -> refactor --apply --op backfills links -> recheck PASS" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R5 "$REPO"; assert_output WARN
+    cps_refactor "$REPO" op apply
+    run cps_check_R5 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "R5 backfill is idempotent (no duplicate link lines on second apply)" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    cps_refactor "$REPO" op apply
+    first="$(grep -c 'skill-guides/visualize.html' "$REPO/README.md")"
+    cps_refactor "$REPO" op apply
+    second="$(grep -c 'skill-guides/visualize.html' "$REPO/README.md")"
+    [ "$first" = "$second" ]
 }
 
 # ---- N/A for absent subject on mandatory checks (PR #894 gemini review) --


### PR DESCRIPTION
## 요약

`claude-plugin:structure-check` 에 권장 항목 **R5** 를 신설한다. 발견된 각 스킬 `<s>` 마다 `README.md` 가 `skill-guides/<s>.html` 과 `skill-output/<s>-usage.{html,md}` 링크를 **모두** 포함하는지 검사하고, 하나라도 누락 시 **WARN** 을 낸다(스킬 0개 → N/A). 기존 R3 "Simple" 휴리스틱은 `docs/` 링크가 어딘가 1개만 있으면 PASS 라 스킬별 링크 갭을 감지하지 못하던 사각지대를 R5 가 보완한다.

## 변경 내용

- **structure-spec.md** (check/refactor 양쪽 동기화) — Recommended 표에 R5 행 + N/A 규칙(스킬 0개 → N/A) 명시
- **report-template.md** — `[권장]` 블록 예시에 R5 행 추가 + 카운트/레이아웃 규칙 갱신
- **check SKILL.md / help.md** — `R1-R4` → `R1-R5`, R5 판정 휴리스틱(경로 문자열 grep, 상대/Pages 절대 URL 모두 허용) 기술
- **refactor SKILL.md / help.md / plan-and-report-templates.md** — `--op` 스코프에 R5 README 링크 백필(스텁 수준, 멱등) + `link` verb + `linked=<n>` 리포트 키
- **bats 픽스처** (`_fixtures/claude_plugin_structure.sh`) — `cps_check_R5` 신규 + `cps_verdict` 루프에 R5 추가 + `--op` 백필 구현
- **bats 테스트** — R5 7종 추가(PASS / guide만-있고-usage없음 WARN / R3-PASS-갭 WARN / 2개중1개누락 WARN / 0스킬 N/A / 백필→PASS / 멱등). 기존 `mp-apply→PASS` 테스트에 R5 시드 보강

## 검증

- `tests/bats/skills/claude_plugin_structure.bats` 24/24 PASS
- `shfmt -i 4 -d` (repo 플래그) 픽스처 클린, 변경 파일은 `bash/` 외부라 lint-sh 스코프 밖
- 이모지 없음, 픽스처의 `✓` 는 기존 컨텍스트(미변경)

## Acceptance Criteria

- [x] `structure-spec.md` Recommended 표에 R5 행 + N/A 규칙 명시
- [x] `report-template.md` `[권장]` 블록 예시에 R5 행 추가
- [x] 스킬별 README guide·usage 링크 검사 + 누락 시 WARN
- [x] 표준 레포(링크 완비)에서 R5 PASS
- [x] 스킬 0개 플러그인에서 R5 N/A(FAIL 아님)
- [x] `structure-refactor` 에 R5 대응(최소 스텁 백필) 반영

Closes #905
