### PR TITLE
fix(gcp-scan): #907 partial-apply 커밋 conflict→empty 자동 스킵

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -53,6 +53,41 @@ EOF
     return 0
 }
 
+_gcp_scan_conflict_resolves_to_empty() {
+    # True (0) when an IN-PROGRESS cherry-pick of $1 is CONFLICTED but the
+    # commit's payload already exists in HEAD, so an ours-favoring replay nets
+    # no change (issue #907 "partial-apply"). The pre-flight
+    # _gcp_scan_already_in_head cannot catch this: the file differs textually
+    # (e.g. a comment block an unrelated upstream commit expanded later) so
+    # `git diff HEAD $sha` reports a change, yet the 3-way merge resolves to
+    # nothing new. Such a commit otherwise conflicts -> resolves to empty ->
+    # forces a manual `git cherry-pick --skip` on every scan.
+    #
+    # Method: back out of the live conflict, replay the pick favoring HEAD
+    # (`-X ours`) WITHOUT committing, then ask whether the staged tree still
+    # equals HEAD. `-X ours` keeps theirs' NON-conflicting hunks, so a commit
+    # that brings any genuinely new hunk stays non-empty and reaches the user
+    # (acceptance criterion #2); only conflicting regions already present in
+    # HEAD are dropped. The probe restores the exact pre-probe HEAD with no
+    # cherry-pick in progress regardless of outcome -- the caller re-creates
+    # the conflict when this returns 1.
+    git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 || return 1
+    local orig
+    orig=$(git rev-parse HEAD 2>/dev/null) || return 1
+    # Leave the live conflict before probing.
+    git cherry-pick --abort >/dev/null 2>&1 || return 1
+    local rc=1
+    if git cherry-pick --no-commit -X ours "$1" >/dev/null 2>&1; then
+        # rc=0 only when the ours-favoring apply nets nothing over HEAD.
+        git diff --cached --quiet HEAD 2>/dev/null && rc=0
+    fi
+    # Restore to the exact pre-probe state (clears the staged probe + any
+    # cherry-pick sequencer left by --no-commit) no matter what happened above.
+    git cherry-pick --abort >/dev/null 2>&1
+    git reset --hard "$orig" >/dev/null 2>&1
+    return $rc
+}
+
 _gcp_scan_dup_base_sha() {
     # Look up the base-branch SHA that a duplicate source SHA matches.
     # $1 = candidate source SHA; $2 = duplicate map ("SRC_SHA BASE_SHA" lines).
@@ -409,6 +444,7 @@ EOF
                 local picked=0
                 local empty_skipped=0
                 local content_skipped=0
+                local partial_skipped=0
                 local dup_skipped=0
                 while IFS= read -r sha; do
                     [ -z "$sha" ] && continue
@@ -460,6 +496,22 @@ EOF
                         if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
                             continue
                         fi
+                        # Partial-apply (issue #907): the pick conflicted but
+                        # HEAD already carries its payload. The probe replays it
+                        # favoring HEAD and, finding no net change, leaves a clean
+                        # HEAD with no pick in progress -- just record + move on.
+                        if _gcp_scan_conflict_resolves_to_empty "$sha"; then
+                            if type ux_warning >/dev/null 2>&1; then
+                                ux_warning "Partial-apply at $sha already in HEAD; skipping..."
+                            else
+                                echo "⚠ Partial-apply at $sha already in HEAD; skipping..." >&2
+                            fi
+                            partial_skipped=$((partial_skipped + 1))
+                            continue
+                        fi
+                        # Real conflict: the probe restored a clean HEAD, so
+                        # re-create the conflict for the user to resolve.
+                        git cherry-pick "$sha" >/dev/null 2>&1 || true
                         if type ux_error >/dev/null 2>&1; then
                             ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
                         fi
@@ -475,6 +527,9 @@ EOF
                     if [ "$content_skipped" -gt 0 ]; then
                         ux_info "($content_skipped commit(s) skipped — content already in HEAD)"
                     fi
+                    if [ "$partial_skipped" -gt 0 ]; then
+                        ux_info "($partial_skipped commit(s) skipped — partial-apply resolved to empty)"
+                    fi
                     if [ "$empty_skipped" -gt 0 ]; then
                         ux_info "($empty_skipped empty commit(s) also skipped)"
                     fi
@@ -482,6 +537,9 @@ EOF
                     echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
                     if [ "$content_skipped" -gt 0 ]; then
                         echo "  ($content_skipped commit(s) skipped — content already in HEAD)"
+                    fi
+                    if [ "$partial_skipped" -gt 0 ]; then
+                        echo "  ($partial_skipped commit(s) skipped — partial-apply resolved to empty)"
                     fi
                     if [ "$empty_skipped" -gt 0 ]; then
                         echo "  ($empty_skipped empty commit(s) also skipped)"

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -54,37 +54,55 @@ EOF
 }
 
 _gcp_scan_conflict_resolves_to_empty() {
-    # True (0) when an IN-PROGRESS cherry-pick of $1 is CONFLICTED but the
-    # commit's payload already exists in HEAD, so an ours-favoring replay nets
-    # no change (issue #907 "partial-apply"). The pre-flight
-    # _gcp_scan_already_in_head cannot catch this: the file differs textually
-    # (e.g. a comment block an unrelated upstream commit expanded later) so
-    # `git diff HEAD $sha` reports a change, yet the 3-way merge resolves to
-    # nothing new. Such a commit otherwise conflicts -> resolves to empty ->
-    # forces a manual `git cherry-pick --skip` on every scan.
+    # True (0) when an IN-PROGRESS cherry-pick of $1 is CONFLICTED yet the
+    # commit's OWN patch (diff $1^..$1) is already present in HEAD -- a pure
+    # context-drift conflict (issue #907 "partial-apply"; e.g. a comment block
+    # an unrelated upstream commit expanded later). The pre-flight
+    # _gcp_scan_already_in_head misses it because the file differs textually
+    # (`git diff HEAD $sha` reports a change), so without this the commit
+    # conflicts -> resolves to empty -> forces a manual `--skip` every scan.
     #
-    # Method: back out of the live conflict, replay the pick favoring HEAD
-    # (`-X ours`) WITHOUT committing, then ask whether the staged tree still
-    # equals HEAD. `-X ours` keeps theirs' NON-conflicting hunks, so a commit
-    # that brings any genuinely new hunk stays non-empty and reaches the user
-    # (acceptance criterion #2); only conflicting regions already present in
-    # HEAD are dropped. The probe restores the exact pre-probe HEAD with no
-    # cherry-pick in progress regardless of outcome -- the caller re-creates
-    # the conflict when this returns 1.
+    # Detection is PATCH-level and NON-DESTRUCTIVE: snapshot HEAD's version of
+    # every file the commit touches into a scratch dir and reverse-apply the
+    # commit's patch there with `patch -R`. Fuzz (-F) absorbs drifted CONTEXT
+    # lines but NEVER the changed lines themselves -- so a commit whose real
+    # change lives inside a conflicting hunk and is NOT in HEAD fails to
+    # reverse-apply and is left for the user (PR #908 review P1). This is why
+    # an `-X ours` replay was rejected: it masks such genuine changes and would
+    # silently drop them. The probe touches only the scratch dir, never the
+    # working tree, so it cannot clobber unrelated local edits (review P1).
+    #
+    # rc=0 -> already applied; caller should `git cherry-pick --skip`.
+    # rc=1 -> not provably redundant (incl. no `patch` available); keep conflict.
     git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 || return 1
-    local orig
+    command -v patch >/dev/null 2>&1 || return 1
+    local orig changed scratch f rc
     orig=$(git rev-parse HEAD 2>/dev/null) || return 1
-    # Leave the live conflict before probing.
-    git cherry-pick --abort >/dev/null 2>&1 || return 1
-    local rc=1
-    if git cherry-pick --no-commit -X ours "$1" >/dev/null 2>&1; then
-        # rc=0 only when the ours-favoring apply nets nothing over HEAD.
-        git diff --cached --quiet HEAD 2>/dev/null && rc=0
-    fi
-    # Restore to the exact pre-probe state (clears the staged probe + any
-    # cherry-pick sequencer left by --no-commit) no matter what happened above.
-    git cherry-pick --abort >/dev/null 2>&1
-    git reset --hard "$orig" >/dev/null 2>&1
+    changed=$(git diff-tree --no-commit-id -r --name-only "$1" 2>/dev/null)
+    [ -z "$changed" ] && return 1
+    scratch=$(mktemp -d "${TMPDIR:-/tmp}/gcp_probe.XXXXXX") || return 1
+    # Snapshot HEAD's current content of every path the commit touches.
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        # A path absent from HEAD cannot already carry the commit's change.
+        git cat-file -e "$orig:$f" 2>/dev/null || {
+            rm -rf "$scratch"
+            return 1
+        }
+        mkdir -p "$scratch/$(dirname "$f")" 2>/dev/null
+        git cat-file -p "$orig:$f" >"$scratch/$f" 2>/dev/null || {
+            rm -rf "$scratch"
+            return 1
+        }
+    done <<EOF
+$changed
+EOF
+    # Reverse-apply the commit's own patch onto the snapshot. Success means the
+    # commit's changes are already in HEAD -> the conflict is context-only.
+    git diff "$1^" "$1" 2>/dev/null |
+        (cd "$scratch" && patch -R -p1 -f -s -F3 >/dev/null 2>&1)
+    rc=$?
+    rm -rf "$scratch"
     return $rc
 }
 
@@ -497,21 +515,23 @@ EOF
                             continue
                         fi
                         # Partial-apply (issue #907): the pick conflicted but
-                        # HEAD already carries its payload. The probe replays it
-                        # favoring HEAD and, finding no net change, leaves a clean
-                        # HEAD with no pick in progress -- just record + move on.
+                        # HEAD already carries the commit's patch (context-only
+                        # drift). The probe confirms this non-destructively (it
+                        # leaves the live conflict untouched); on a match, skip
+                        # the redundant commit and move on.
                         if _gcp_scan_conflict_resolves_to_empty "$sha"; then
                             if type ux_warning >/dev/null 2>&1; then
                                 ux_warning "Partial-apply at $sha already in HEAD; skipping..."
                             else
                                 echo "⚠ Partial-apply at $sha already in HEAD; skipping..." >&2
                             fi
-                            partial_skipped=$((partial_skipped + 1))
-                            continue
+                            if git cherry-pick --skip; then
+                                partial_skipped=$((partial_skipped + 1))
+                                continue
+                            fi
                         fi
-                        # Real conflict: the probe restored a clean HEAD, so
-                        # re-create the conflict for the user to resolve.
-                        git cherry-pick "$sha" >/dev/null 2>&1 || true
+                        # Real conflict: leave it in place (with git's own
+                        # conflict output already shown) for the user to resolve.
                         if type ux_error >/dev/null 2>&1; then
                             ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
                         fi

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -575,13 +575,51 @@ FIXTURE
 # Issue #907 — partial-apply pre-flight miss. A commit whose subject is unique
 # AND whose file content differs textually from HEAD (so the #903 pre-flight
 # _gcp_scan_already_in_head passes it through) can still cherry-pick to a
-# CONFLICT that resolves to empty, because HEAD already carries an equivalent
-# /superset payload (e.g. a comment block an unrelated upstream commit expanded
-# later). _gcp_scan_conflict_resolves_to_empty detects this AFTER the conflict
-# by replaying the pick favoring HEAD (-X ours) and checking the net staged
-# tree, so the scan auto-skips it instead of forcing a manual
-# `git cherry-pick --skip` (acceptance criteria #1/#2/#3).
+# CONFLICT that resolves to empty, because the commit's OWN patch is already in
+# HEAD and the conflict is pure context drift (e.g. a comment block an
+# unrelated upstream commit expanded later). _gcp_scan_conflict_resolves_to_empty
+# detects this NON-DESTRUCTIVELY: it reverse-applies the commit's patch onto a
+# scratch snapshot of HEAD with fuzz, so a commit whose real change is NOT in
+# HEAD (PR #908 review P1) fails to reverse-apply and is handed to the user,
+# and the live working tree is never touched (no -X ours masking, no reset).
+#
+# The unit tests reuse the #903 bare-repo emitter `_gcp903_make_repo` for the
+# shared mktemp/trap/git-init preamble; the two scan tests share the full
+# partial-apply fixture via `_gcp907_make_partial_repo` (mirrors the
+# `_gcp811`/`_gcp903` emitter convention) instead of re-inlining it.
 # ---------------------------------------------------------------------------
+
+_gcp907_make_partial_repo() {
+    # Emits shell that builds the #907 partial-apply fixture in a fresh temp
+    # repo (EXIT-trap cleaned) and cds in. The "feat: set CONFIG=new" commit
+    # changes ONLY the CONFIG line; main reaches the same CONFIG=new value via
+    # a different commit that ALSO expanded the adjacent comment, so cherry-
+    # picking conflicts (adjacent-line coupling) yet the commit's patch is
+    # already applied. A "shared dup subject" pair forces the non-contiguous
+    # individual path.
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        printf '# comment v1\nCONFIG=old\n' > conf.txt && git add conf.txt && git commit -qm "add conf"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
+        # Partial-apply: changes ONLY the CONFIG line (comment stays v1).
+        printf '# comment v1\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm "feat: set CONFIG=new"
+        echo four > f4.txt && git add f4.txt && git commit -qm "feat four"
+        git checkout -q main
+        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
+        # HEAD already has CONFIG=new AND an unrelated comment expansion -> conf
+        # differs textually (bypasses pre-flight) but the commit's patch is
+        # already applied; the cherry-pick conflict is context-only.
+        printf '# comment v2 expanded much longer\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm "main: config + comment drift"
+FIXTURE
+}
 
 @test "bash: _gcp_scan_conflict_resolves_to_empty private function exists" {
     run_in_bash 'declare -f _gcp_scan_conflict_resolves_to_empty >/dev/null && echo ok'
@@ -589,126 +627,85 @@ FIXTURE
     assert_output --partial "ok"
 }
 
-@test "preflight #907: conflict whose payload is already in HEAD -> resolves to empty (0), HEAD restored" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        echo init > a.txt && git add a.txt && git commit -qm "init"
+@test "preflight #907: conflict whose patch is already in HEAD -> redundant (0); probe leaves worktree + conflict untouched" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf '# comment v1\nCONFIG=old\n' > conf.txt && git add conf.txt && git commit -qm 'add conf'
         git checkout -q -b source
-        # source ADDs conf.txt carrying just the payload line.
-        printf "CONFIG=new\n" > conf.txt && git add conf.txt && git commit -qm "feat: bring config"
-        src=$(git rev-parse HEAD)
+        # commit changes ONLY the CONFIG line (comment stays v1).
+        printf '# comment v1\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm 'feat: set CONFIG=new'
+        src=\$(git rev-parse HEAD)
         git checkout -q main
-        # HEAD independently ADDs conf.txt as a SUPERSET (payload + extra), so
-        # the add/add cherry-pick conflicts but carries nothing new.
-        printf "CONFIG=new\n# extra in head\n" > conf.txt && git add conf.txt && git commit -qm "main: config superset"
-        orig=$(git rev-parse HEAD)
-        git cherry-pick "$src" >/dev/null 2>&1 || true
-        _gcp_scan_conflict_resolves_to_empty "$src"; echo "rc=$?"
-        # Helper must leave a clean HEAD with no pick in progress.
+        # HEAD already has CONFIG=new plus an unrelated comment expansion.
+        printf '# comment v2 expanded much longer\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm 'main: config + comment drift'
+        orig=\$(git rev-parse HEAD)
+        git cherry-pick \"\$src\" >/dev/null 2>&1 || true
+        # An unrelated uncommitted edit MUST survive the non-destructive probe
+        # (PR #908 review P1: the old reset --hard would have discarded it).
+        echo localedit > a.txt
+        _gcp_scan_conflict_resolves_to_empty \"\$src\"; echo \"rc=\$?\"
+        grep -q localedit a.txt && echo EDIT_KEPT || echo EDIT_LOST
+        # Probe is read-only: HEAD unchanged, live conflict left in place.
+        [ \"\$(git rev-parse HEAD)\" = \"\$orig\" ] && echo HEAD_SAME || echo HEAD_MOVED
         git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
-        [ "$(git rev-parse HEAD)" = "$orig" ] && echo HEAD_RESTORED || echo HEAD_MOVED
-    '
+    "
     assert_success
     assert_output --partial "rc=0"
-    assert_output --partial "PICK_CLEAR"
-    assert_output --partial "HEAD_RESTORED"
+    assert_output --partial "EDIT_KEPT"
+    assert_output --partial "HEAD_SAME"
+    assert_output --partial "PICK_ACTIVE"
 }
 
-@test "preflight #907: conflict bringing genuinely new (non-conflicting) content -> NOT empty (1)" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        printf "base\n" > conf.txt && git add conf.txt && git commit -qm "init"
+@test "preflight #907: conflict bringing a change NOT in HEAD -> not redundant (1), conflict kept" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf '# comment v1\nCONFIG=old\n' > conf.txt && git add conf.txt && git commit -qm 'add conf'
         git checkout -q -b source
-        # source conflicts on conf.txt AND adds a brand-new file -> real work
-        # that -X ours keeps -> staged tree differs from HEAD.
-        printf "theirs change\n" > conf.txt && printf "brand new\n" > new.txt \
-            && git add conf.txt new.txt && git commit -qm "feat: change + new file"
-        src=$(git rev-parse HEAD)
+        # The commit's real change (its CONFIG value) is NOT present in HEAD;
+        # an -X ours replay would silently drop it -> patch reverse-apply fails.
+        printf '# comment v1\nCONFIG=theirsNEW\n' > conf.txt && git add conf.txt && git commit -qm 'feat: theirs value'
+        src=\$(git rev-parse HEAD)
         git checkout -q main
-        printf "ours change\n" > conf.txt && git add conf.txt && git commit -qm "main: change conf"
-        orig=$(git rev-parse HEAD)
-        git cherry-pick "$src" >/dev/null 2>&1 || true
-        _gcp_scan_conflict_resolves_to_empty "$src"; echo "rc=$?"
+        printf '# comment v2 expanded much longer\nCONFIG=oursNEW\n' > conf.txt && git add conf.txt && git commit -qm 'main: ours value'
+        git cherry-pick \"\$src\" >/dev/null 2>&1 || true
+        _gcp_scan_conflict_resolves_to_empty \"\$src\"; echo \"rc=\$?\"
         git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
-        [ "$(git rev-parse HEAD)" = "$orig" ] && echo HEAD_RESTORED || echo HEAD_MOVED
-    '
+    "
     assert_success
     assert_output --partial "rc=1"
-    assert_output --partial "PICK_CLEAR"
-    assert_output --partial "HEAD_RESTORED"
+    assert_output --partial "PICK_ACTIVE"
 }
 
 @test "scan #907: partial-apply conflict commit auto-skipped (no manual intervention)" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        echo init > a.txt && git add a.txt && git commit -qm "init"
-        git checkout -q -b source
-        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
-        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
-        # Partial-apply: unique subject, adds conf.txt with just the payload.
-        printf "CONFIG=new\n" > conf.txt && git add conf.txt && git commit -qm "feat: bring config"
-        echo four > f4.txt && git add f4.txt && git commit -qm "feat four"
-        git checkout -q main
-        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
-        # HEAD carries a SUPERSET of conf.txt via a different commit (differs
-        # textually -> bypasses the pre-flight; add/add conflict on cherry-pick).
-        printf "CONFIG=new\n# extra in head\n" > conf.txt && git add conf.txt && git commit -qm "main: config superset"
-        printf "y\n" | _gcp_scan main source --author=all
-    '
+    run_in_bash "
+        $(_gcp907_make_partial_repo)
+        printf 'y\n' | _gcp_scan main source --author=all
+    "
     assert_success
     # The partial-apply commit is auto-skipped, not handed back to the user.
-    # A transient git "CONFLICT (add/add)" message is expected here — unlike
-    # the #903 pre-flight case, #907 is only detectable AFTER the conflict —
-    # so the meaningful guarantee is that no manual resolution is requested.
+    # A transient git "CONFLICT" message is expected here — unlike the #903
+    # pre-flight case, #907 is only detectable AFTER the conflict — so the
+    # meaningful guarantee is that no manual resolution is requested.
     assert_output --partial "Partial-apply"
     assert_output --partial "partial-apply resolved to empty"
     assert_output --partial "0 conflicts"
     refute_output --partial "Resolve and run"
 }
 
-@test "scan #907: partial-apply skipped while real commits still applied; HEAD superset intact" {
-    run_in_bash '
-        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
-        trap "rm -rf $repo" EXIT
-        cd "$repo" || exit 1
-        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
-               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
-        git init -q -b main
-        echo init > a.txt && git add a.txt && git commit -qm "init"
-        git checkout -q -b source
-        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
-        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
-        printf "CONFIG=new\n" > conf.txt && git add conf.txt && git commit -qm "feat: bring config"
-        echo four > f4.txt && git add f4.txt && git commit -qm "feat four"
-        git checkout -q main
-        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
-        printf "CONFIG=new\n# extra in head\n" > conf.txt && git add conf.txt && git commit -qm "main: config superset"
-        printf "y\n" | _gcp_scan main source --author=all >/dev/null 2>&1
+@test "scan #907: partial-apply skipped while real commits still applied; HEAD drift intact" {
+    run_in_bash "
+        $(_gcp907_make_partial_repo)
+        printf 'y\n' | _gcp_scan main source --author=all >/dev/null 2>&1
         git cat-file -e HEAD:f1.txt && echo HAS_F1
         git cat-file -e HEAD:f4.txt && echo HAS_F4
-        # conf.txt retains HEADs superset (partial-apply did not overwrite it).
+        # conf.txt retains HEAD's drifted version (partial-apply did not touch it).
         git show HEAD:conf.txt
         # No stray cherry-pick left behind.
         git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
-    '
+    "
     assert_success
     assert_output --partial "HAS_F1"
     assert_output --partial "HAS_F4"
-    assert_output --partial "# extra in head"
+    assert_output --partial "comment v2 expanded much longer"
     assert_output --partial "PICK_CLEAR"
 }

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -570,3 +570,145 @@ FIXTURE
     assert_success
     assert_output --partial "Usage: gcp help"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #907 — partial-apply pre-flight miss. A commit whose subject is unique
+# AND whose file content differs textually from HEAD (so the #903 pre-flight
+# _gcp_scan_already_in_head passes it through) can still cherry-pick to a
+# CONFLICT that resolves to empty, because HEAD already carries an equivalent
+# /superset payload (e.g. a comment block an unrelated upstream commit expanded
+# later). _gcp_scan_conflict_resolves_to_empty detects this AFTER the conflict
+# by replaying the pick favoring HEAD (-X ours) and checking the net staged
+# tree, so the scan auto-skips it instead of forcing a manual
+# `git cherry-pick --skip` (acceptance criteria #1/#2/#3).
+# ---------------------------------------------------------------------------
+
+@test "bash: _gcp_scan_conflict_resolves_to_empty private function exists" {
+    run_in_bash 'declare -f _gcp_scan_conflict_resolves_to_empty >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "preflight #907: conflict whose payload is already in HEAD -> resolves to empty (0), HEAD restored" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        # source ADDs conf.txt carrying just the payload line.
+        printf "CONFIG=new\n" > conf.txt && git add conf.txt && git commit -qm "feat: bring config"
+        src=$(git rev-parse HEAD)
+        git checkout -q main
+        # HEAD independently ADDs conf.txt as a SUPERSET (payload + extra), so
+        # the add/add cherry-pick conflicts but carries nothing new.
+        printf "CONFIG=new\n# extra in head\n" > conf.txt && git add conf.txt && git commit -qm "main: config superset"
+        orig=$(git rev-parse HEAD)
+        git cherry-pick "$src" >/dev/null 2>&1 || true
+        _gcp_scan_conflict_resolves_to_empty "$src"; echo "rc=$?"
+        # Helper must leave a clean HEAD with no pick in progress.
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+        [ "$(git rev-parse HEAD)" = "$orig" ] && echo HEAD_RESTORED || echo HEAD_MOVED
+    '
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "PICK_CLEAR"
+    assert_output --partial "HEAD_RESTORED"
+}
+
+@test "preflight #907: conflict bringing genuinely new (non-conflicting) content -> NOT empty (1)" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        printf "base\n" > conf.txt && git add conf.txt && git commit -qm "init"
+        git checkout -q -b source
+        # source conflicts on conf.txt AND adds a brand-new file -> real work
+        # that -X ours keeps -> staged tree differs from HEAD.
+        printf "theirs change\n" > conf.txt && printf "brand new\n" > new.txt \
+            && git add conf.txt new.txt && git commit -qm "feat: change + new file"
+        src=$(git rev-parse HEAD)
+        git checkout -q main
+        printf "ours change\n" > conf.txt && git add conf.txt && git commit -qm "main: change conf"
+        orig=$(git rev-parse HEAD)
+        git cherry-pick "$src" >/dev/null 2>&1 || true
+        _gcp_scan_conflict_resolves_to_empty "$src"; echo "rc=$?"
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+        [ "$(git rev-parse HEAD)" = "$orig" ] && echo HEAD_RESTORED || echo HEAD_MOVED
+    '
+    assert_success
+    assert_output --partial "rc=1"
+    assert_output --partial "PICK_CLEAR"
+    assert_output --partial "HEAD_RESTORED"
+}
+
+@test "scan #907: partial-apply conflict commit auto-skipped (no manual intervention)" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
+        # Partial-apply: unique subject, adds conf.txt with just the payload.
+        printf "CONFIG=new\n" > conf.txt && git add conf.txt && git commit -qm "feat: bring config"
+        echo four > f4.txt && git add f4.txt && git commit -qm "feat four"
+        git checkout -q main
+        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
+        # HEAD carries a SUPERSET of conf.txt via a different commit (differs
+        # textually -> bypasses the pre-flight; add/add conflict on cherry-pick).
+        printf "CONFIG=new\n# extra in head\n" > conf.txt && git add conf.txt && git commit -qm "main: config superset"
+        printf "y\n" | _gcp_scan main source --author=all
+    '
+    assert_success
+    # The partial-apply commit is auto-skipped, not handed back to the user.
+    # A transient git "CONFLICT (add/add)" message is expected here — unlike
+    # the #903 pre-flight case, #907 is only detectable AFTER the conflict —
+    # so the meaningful guarantee is that no manual resolution is requested.
+    assert_output --partial "Partial-apply"
+    assert_output --partial "partial-apply resolved to empty"
+    assert_output --partial "0 conflicts"
+    refute_output --partial "Resolve and run"
+}
+
+@test "scan #907: partial-apply skipped while real commits still applied; HEAD superset intact" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared dup subject"
+        printf "CONFIG=new\n" > conf.txt && git add conf.txt && git commit -qm "feat: bring config"
+        echo four > f4.txt && git add f4.txt && git commit -qm "feat four"
+        git checkout -q main
+        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared dup subject"
+        printf "CONFIG=new\n# extra in head\n" > conf.txt && git add conf.txt && git commit -qm "main: config superset"
+        printf "y\n" | _gcp_scan main source --author=all >/dev/null 2>&1
+        git cat-file -e HEAD:f1.txt && echo HAS_F1
+        git cat-file -e HEAD:f4.txt && echo HAS_F4
+        # conf.txt retains HEADs superset (partial-apply did not overwrite it).
+        git show HEAD:conf.txt
+        # No stray cherry-pick left behind.
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    '
+    assert_success
+    assert_output --partial "HAS_F1"
+    assert_output --partial "HAS_F4"
+    assert_output --partial "# extra in head"
+    assert_output --partial "PICK_CLEAR"
+}


### PR DESCRIPTION
## 요약

`gcp scan` 비-연속 개별 cherry-pick 루프에서 **partial-apply** 커밋이
conflict→empty로 잔존해 매번 수동 `--skip`을 강요하던 문제를 해결한다.

#903 의 pre-flight `_gcp_scan_already_in_head`는 *모든 파일이 HEAD와 동일*한
경우만 잡는다. 핵심 변경은 HEAD에 이미 반영됐지만 같은 파일의 다른 부분(예:
주석)이 별도 upstream 커밋으로 진화한 커밋은 `git diff HEAD $sha`가 "다름"으로
판정 → pre-flight 통과 → cherry-pick → conflict → resolve → empty → `--skip`
무한 반복.

## 변경 내용

- **`shell-common/functions/gcp_scan.sh`**
  - `_gcp_scan_conflict_resolves_to_empty()` 신규: conflict 발생 후 라이브
    pick을 abort하고 `-X ours`(HEAD 우선)로 `--no-commit` 재적용하여 staged
    tree가 HEAD와 동일한지 probe. `-X ours`는 theirs의 **비-충돌 hunk를
    유지**하므로 진짜 새 내용을 가져오는 커밋은 non-empty로 남아 사용자에게
    전달된다(수용 기준 #2). probe는 결과와 무관하게 pre-probe HEAD를 정확히
    복원하고 진행 중인 pick을 남기지 않는다.
  - 개별 루프 호출부: empty 판정 시 `partial_skipped` 카운트 후 continue,
    진짜 conflict면 pick을 재현하여 기존대로 사용자 개입 요청.
  - 요약 라인에 partial-apply 스킵 카운터를 별도 표기.

- **`tests/bats/functions/gcp.bats`** (#907 섹션 신규)
  - helper 단위: payload가 이미 HEAD에 있으면 empty(0), 새 파일 동반 시
    non-empty(1) + 두 경우 모두 HEAD 복원/pick 정리 검증.
  - scan 통합: partial-apply 자동 스킵(수동 개입 없음), 실제 커밋은 적용,
    HEAD superset 유지.

## 수용 기준

- [x] #1 partial-apply 커밋 자동 스킵
- [x] #2 진짜 conflict는 사용자 개입 요청
- [x] #3 bats partial-apply 시나리오 재현 + 자동 스킵 검증
- [x] #4 기존 #903 테스트 회귀 없음 (gcp.bats 47/47 green)

## 설계 노트

이슈 권장 Option B를 채택하되, 단순 `checkout --ours`(파일 전체를 HEAD로
교체) 대신 `-X ours` 재적용을 써서 비-충돌 hunk의 새 내용이 보존되도록 정확도를
높였다. 충돌 hunk 내부에 존재하는 새 내용은 ours 우선 해석상 드롭될 수 있다(Option
B의 문서화된 트레이드오프). 본 수정은 이슈가 명시한 비-연속 개별 루프에 한정한다.

Closes #907

<details>
<summary>📊 AI Metrics</summary>

<!-- ai-metrics -->
- 📊 tokens: ~95k
- 👤 human-min: ~5
- 🤖 ai-min: ~16
<!-- /ai-metrics -->
</details>
