### PR TITLE
feat(skill): #909 claude-plugin:rename-repo 스킬 신규

### DIFF
--- a/claude/skills/claude-plugin-rename-repo/SKILL.md
+++ b/claude/skills/claude-plugin-rename-repo/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: claude-plugin:rename-repo
+description: >-
+  Rename a claude-plugin marketplace repo to the team naming convention
+  (claude-plugin-<domain>). Walks through: env check → name proposal →
+  gh repo rename → remote URL update → hardcoded reference scan & fix →
+  commit. Destructive steps (rename, push) require user confirmation.
+  Use when the user says "rename this plugin repo", "이 레포 이름 바꿔",
+  "/claude-plugin:rename-repo <name>".
+  Sister skills: `claude-plugin:structure-check`, `claude-plugin:structure-refactor`.
+compatibility:
+  tools: Read, Bash, Edit, Write, Grep
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "multi-step repo rename: git/gh CLI, regex scan, multi-file edit; needs tool orchestration but not deep reasoning"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# claude-plugin Repo Renamer
+
+Rename an existing `claude-plugin-*` marketplace repo to the team naming
+convention `claude-plugin-<domain>`, then fix every hardcoded reference.
+The full procedure (the embedded SSOT) lives in `references/playbook.md` —
+read it before executing.
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No git/gh calls.
+
+## Step 0: Environment + Host Check
+
+- Confirm the current directory is a clone of the target repo: `git remote -v`.
+- Identify whether the remote host is `github.com` or an internal GHES
+  host (e.g. `github.our-company.com`) from the remote URL.
+- Confirm `gh` is authenticated for that host: `gh auth status`. If the
+  target host is missing, tell the user to run `gh auth login --hostname
+  <host>` themselves — interactive login cannot be done on their behalf.
+- Refuse to work on the default branch; require a feature branch.
+
+## Step 1: Decide the New Name
+
+- If `<new-name>` was passed as an argument, use it verbatim. It must
+  include the `claude-plugin-` prefix.
+- If no argument, inspect the plugin composition
+  (`.claude-plugin/marketplace.json` `plugins[]` + `plugins/` dirs) and
+  propose 1-2 `claude-plugin-<domain>` names. The user picks the final
+  name. Do NOT rename before their choice.
+
+## Step 2: Rename the Repo (DESTRUCTIVE — confirm first)
+
+After the user confirms the name:
+`gh repo rename <new-name> --repo <org>/<OLD_REPO> --yes` (add
+`--hostname <host>` on GHES). If `gh` fails on GHES, guide the user to the
+web UI (Settings → Repository name).
+
+## Step 3: Update the Local Remote URL
+
+- `git remote set-url origin <new repo URL>`.
+- Verify: `git remote get-url origin` and
+  `git ls-remote --heads origin >/dev/null && echo REMOTE_OK`.
+
+## Step 4: Scan + Fix Hardcoded Old Names
+
+- `git grep -n "<OLD_REPO>"` across tracked files.
+- Replace in: `marketplace.json` `name` (1:1 with the new repo name),
+  `plugins/<p>/.claude-plugin/plugin.json` `homepage`/`repository`,
+  `README.md` title + `/plugin marketplace add <org>/<OLD_REPO>` install
+  command, and each skill README's marketplace link/install command.
+- Do NOT touch fields whose `source` is a relative path (`./plugins/...`)
+  — those are repo-name-independent.
+- Confirm `git grep -n "<OLD_REPO>"` returns 0 hits afterward.
+
+## Step 5: Commit (push is separate — confirm first)
+
+- Match the repo's existing git-log style (Conventional Commits). Title
+  e.g. `chore: rename repo to <new-name> and update references`; body
+  records the why (convention) and the changed-file list.
+- Push only after explicit user confirmation.
+
+## Constraints
+
+- Destructive actions (repo rename, push) require user confirmation first.
+- Works on both github.com and GHES — identify the host from the remote URL.
+- Never edit fields whose value is a relative `source` path.
+- Never work directly on the default branch.
+- `marketplace.json` `name` must equal the new repo name 1:1.
+- Sister skills: `claude-plugin:structure-check` (audit layout),
+  `claude-plugin:structure-refactor` (fix layout). This skill renames.

--- a/claude/skills/claude-plugin-rename-repo/SKILL.md
+++ b/claude/skills/claude-plugin-rename-repo/SKILL.md
@@ -33,6 +33,10 @@ its content verbatim, then stop. No git/gh calls.
 ## Step 0: Environment + Host Check
 
 - Confirm the current directory is a clone of the target repo: `git remote -v`.
+- Resolve `owner/repo` by parsing `git remote get-url <remote>` with a
+  host-agnostic pattern (`<protocol>://<host>/<owner>/<repo>.git`) rather
+  than depending on `gh` — never hardcode `github.com`, so GHES/self-hosted
+  remotes work too.
 - Identify whether the remote host is `github.com` or an internal GHES
   host (e.g. `github.our-company.com`) from the remote URL.
 - Confirm `gh` is authenticated for that host: `gh auth status`. If the
@@ -43,7 +47,9 @@ its content verbatim, then stop. No git/gh calls.
 ## Step 1: Decide the New Name
 
 - If `<new-name>` was passed as an argument, use it verbatim. It must
-  include the `claude-plugin-` prefix.
+  include the `claude-plugin-` prefix and follow GitHub repo naming rules
+  (lowercase + hyphens only, e.g. `claude-plugin-visuals`) — uppercase or
+  underscores can break `gh repo rename` or violate the convention.
 - If no argument, inspect the plugin composition
   (`.claude-plugin/marketplace.json` `plugins[]` + `plugins/` dirs) and
   propose 1-2 `claude-plugin-<domain>` names. The user picks the final

--- a/claude/skills/claude-plugin-rename-repo/references/help.md
+++ b/claude/skills/claude-plugin-rename-repo/references/help.md
@@ -1,0 +1,41 @@
+/claude-plugin:rename-repo — Rename a claude-plugin repo to the team convention
+
+Usage:
+  /claude-plugin:rename-repo <new-name>   Rename to an explicit name
+  /claude-plugin:rename-repo              Auto-propose a name, you choose
+  /claude-plugin:rename-repo help         Print this usage
+
+Arguments:
+  <new-name>   Full new repo name, including the claude-plugin- prefix
+               (e.g. claude-plugin-visuals). Optional — when omitted, the
+               skill inspects the plugin composition and proposes 1-2 names.
+
+Behavior (per-step):
+  0  Env/host check     git remote -v + gh auth status; identify github.com
+                        vs GHES; refuse the default branch
+  1  Name decision      use the arg, or propose claude-plugin-<domain> names
+  2  gh repo rename     DESTRUCTIVE — confirm first (GHES: --hostname / web UI)
+  3  Remote URL update  git remote set-url origin + ls-remote verification
+  4  Reference scan/fix  git grep "<OLD>" → fix marketplace.json name,
+                        plugin.json homepage/repository, README install cmds;
+                        skip relative ./plugins/... source paths; verify 0 hits
+  5  Commit             Conventional Commits style; push only after confirm
+
+Safety:
+  - Destructive steps (repo rename, push) require explicit user confirmation.
+  - Never works on the default branch — needs a feature branch.
+  - Interactive gh login (gh auth login) must be run by the user, not the skill.
+  - Relative `source` paths are repo-name-independent — left untouched.
+
+Examples:
+  /claude-plugin:rename-repo claude-plugin-visuals
+  /claude-plugin:rename-repo
+  /claude-plugin:rename-repo help
+
+Sister skills:
+  /claude-plugin:structure-check     — audit a claude-plugin repo's layout
+  /claude-plugin:structure-refactor  — fix that layout toward the standard
+
+Not this skill:
+  /skill:check   — audit a SKILL.md's content quality
+  /sh:check      — audit a shell script's quality

--- a/claude/skills/claude-plugin-rename-repo/references/help.md
+++ b/claude/skills/claude-plugin-rename-repo/references/help.md
@@ -6,9 +6,10 @@ Usage:
   /claude-plugin:rename-repo help         Print this usage
 
 Arguments:
-  <new-name>   Full new repo name, including the claude-plugin- prefix
-               (e.g. claude-plugin-visuals). Optional — when omitted, the
-               skill inspects the plugin composition and proposes 1-2 names.
+  <new-name>   Full new repo name in lowercase with hyphens, including the
+               claude-plugin- prefix (e.g. claude-plugin-visuals). Optional —
+               when omitted, the skill inspects the plugin composition and
+               proposes 1-2 names.
 
 Behavior (per-step):
   0  Env/host check     git remote -v + gh auth status; identify github.com

--- a/claude/skills/claude-plugin-rename-repo/references/playbook.md
+++ b/claude/skills/claude-plugin-rename-repo/references/playbook.md
@@ -8,7 +8,8 @@ github.com / 사내 GHES 양쪽 모두 동작한다.
 ## 합의된 네이밍 컨벤션
 
 - 새 레포 이름 형식: `claude-plugin-<domain>` (예: `xxx-yyy-zzz` →
-  `claude-plugin-visuals`).
+  `claude-plugin-visuals`). `<domain>` 은 GitHub 레포 네이밍 규칙에 따라
+  반드시 소문자와 하이픈(-)만 사용 (대문자/언더스코어 금지).
 - 이유:
   - `plugin-` 이 `skills-` 보다 상위/범용 개념 — plugin 은 skills·commands·
     agents·hooks 를 모두 번들하며 `.claude-plugin/` 디렉터리 구조와 일치한다.
@@ -25,6 +26,9 @@ github.com / 사내 GHES 양쪽 모두 동작한다.
 ### 0단계 — 환경/호스트 확인
 
 - 지금 디렉터리가 대상 레포의 클론인지 확인: `git remote -v`.
+- `owner/repo` 는 `gh` 대신 `git remote get-url <remote>` 출력을 호스트
+  독립적 패턴(`<protocol>://<host>/<owner>/<repo>.git`)으로 파싱해서 얻는다
+  — github.com 하드코딩 금지(GHES/self-hosted 지원).
 - remote 호스트가 github.com 인지 사내 GHES(예: github.our-company.com)인지 식별.
 - gh CLI 가 그 호스트로 인증돼 있는지 확인: `gh auth status`.
   - 대상 호스트가 안 보이면 `gh auth login --hostname <호스트>` 를 사용자가

--- a/claude/skills/claude-plugin-rename-repo/references/playbook.md
+++ b/claude/skills/claude-plugin-rename-repo/references/playbook.md
@@ -1,0 +1,88 @@
+# rename-repo 플레이북 (embedded SSOT)
+
+출처: [dotfiles discussions #886](https://github.com/dEitY719/dotfiles/discussions/886)
+— `xxx-yyy-zzz` 형태의 기존 레포 이름을 팀 컨벤션 `claude-plugin-<domain>`
+으로 rename 하는 범용 작업 지시서. SKILL.md 의 각 Step 은 이 절차를 실행한다.
+github.com / 사내 GHES 양쪽 모두 동작한다.
+
+## 합의된 네이밍 컨벤션
+
+- 새 레포 이름 형식: `claude-plugin-<domain>` (예: `xxx-yyy-zzz` →
+  `claude-plugin-visuals`).
+- 이유:
+  - `plugin-` 이 `skills-` 보다 상위/범용 개념 — plugin 은 skills·commands·
+    agents·hooks 를 모두 번들하며 `.claude-plugin/` 디렉터리 구조와 일치한다.
+  - `claude-` prefix 로 프로필/조직에서 "무엇의 플러그인인지" 식별성을 확보한다.
+- marketplace `name` 1:1 일치: `.claude-plugin/marketplace.json` 의 `name` 을
+  새 레포 이름과 동일하게 맞춘다.
+
+## 작업 절차
+
+각 단계는 실행 전에 사용자가 확인할 수 있게 명령을 먼저 보여주고,
+파괴적이거나 외부에 영향을 주는 작업(레포 rename, push) 전에는 반드시 한 번
+사용자 확인을 받는다.
+
+### 0단계 — 환경/호스트 확인
+
+- 지금 디렉터리가 대상 레포의 클론인지 확인: `git remote -v`.
+- remote 호스트가 github.com 인지 사내 GHES(예: github.our-company.com)인지 식별.
+- gh CLI 가 그 호스트로 인증돼 있는지 확인: `gh auth status`.
+  - 대상 호스트가 안 보이면 `gh auth login --hostname <호스트>` 를 사용자가
+    직접 실행하도록 안내 (대화형 로그인은 대신 못 함).
+- 기본 브랜치에서 직접 작업하지 말고, 필요하면 작업 브랜치를 딴다.
+
+### 1단계 — 새 이름 결정
+
+- 레포 안의 plugin 구성을 살핀다 (`.claude-plugin/marketplace.json` 의
+  `plugins[]` 와 `plugins/` 디렉터리 구조).
+- 그걸 근거로 `claude-plugin-<domain>` 형식의 새 이름을 1~2개 제안한다.
+  - plugin 이 하나의 도메인이면: `claude-plugin-<그도메인>`.
+  - 여러 도메인을 담은 marketplace 면: `claude-plugin-<팀/제품명>` 처럼 묶는 이름.
+- 최종 이름은 사용자가 고른다. 선택을 받기 전에는 rename 하지 않는다.
+
+### 2단계 — 레포 rename (파괴적 — 확인 필수)
+
+- 사용자가 이름을 확정하면:
+  `gh repo rename <새이름> --repo <org>/<OLD_REPO> --yes`.
+  - GHES 라면 gh 가 사내 호스트로 인증돼 있어야 동작. 안 되면 웹 UI 의
+    Settings → Repository name 에서 rename 하도록 안내한다.
+
+### 3단계 — 로컬 remote URL 갱신
+
+- gh 가 로컬 remote 를 자동 갱신 못 할 수 있으니 직접:
+  `git remote set-url origin <새 레포 URL>`.
+- 검증: `git remote get-url origin` /
+  `git ls-remote --heads origin >/dev/null && echo REMOTE_OK`.
+
+### 4단계 — 하드코딩된 옛 이름/URL 전부 스캔 & 수정
+
+- 추적 파일 전체에서 옛 이름 잔재 검색: `git grep -n "<OLD_REPO>"`.
+- 아래 위치를 빠짐없이 점검하고 새 이름으로 교체:
+  - `.claude-plugin/marketplace.json` 의 `name` → 새 레포 이름과 1:1 일치.
+  - `plugins/<plugin>/.claude-plugin/plugin.json` 의 `homepage` / `repository`.
+  - `README.md` 의 제목과 `/plugin marketplace add <org>/<OLD_REPO>` 설치 명령.
+  - 각 skill 의 README 안의 marketplace 링크 / 설치 명령.
+- 단, `source` 가 `./plugins/...` 같은 상대경로면 레포명과 무관하니 건드리지 않는다.
+- 수정 후 `git grep -n "<OLD_REPO>"` 가 0건인지 확인.
+
+### 5단계 — 커밋
+
+- Conventional Commits 스타일로 커밋 (이 레포의 git log 스타일을 먼저 확인하고
+  맞춘다): 제목 예) `chore: rename repo to <새이름> and update references`.
+  본문에는 "왜"(컨벤션 채택 이유)와 바꾼 파일 목록을 적는다.
+- push 는 사용자 확인을 받고 별도로.
+
+## 주의
+
+- GHES redirect 동작은 github.com 과 다를 수 있으니, 옛 설치 명령
+  (`/plugin marketplace add ...`) 은 반드시 새 이름으로 갱신한다.
+- 호스트가 GHES 면 URL 이 github.com 이 아니라
+  `https://<GHES호스트>/<org>/<repo>` 형태인 점에 유의.
+
+## 참고: 실제 적용 사례
+
+- github.com: `dEitY719/claude-skills` → `dEitY719/claude-plugin-visuals`
+  (marketplace.json `name`, plugin.json `homepage`/`repository`, README 제목+
+  설치 명령, skill README 링크 — 4개 파일 수정 후 0건 확인 → 커밋).
+- GHES: `byoungwoo-yoon/company-skills` → `byoungwoo-yoon/claude-plugin-jira`
+  (동일 패턴, gh 사내 호스트 인증 + GHES URL 형태 유의).

--- a/claude/skills/claude-plugin-structure-check/SKILL.md
+++ b/claude/skills/claude-plugin-structure-check/SKILL.md
@@ -7,10 +7,11 @@ description: >-
   scan, then evaluates mandatory items M1-M6 (FAIL) and recommended items
   R1-R5 (WARN). Use when the user says "check my claude-plugin repo
   structure", "is this marketplace repo standard?", "audit plugin layout",
-  "/claude-plugin:structure-check". Sister skill of
-  `claude-plugin:structure-refactor` (which fixes what this finds). Do NOT
-  use for SKILL.md content quality (use `skill:check`) or shell scripts
-  (use `sh:check`).
+  "/claude-plugin:structure-check". Sister skills:
+  `claude-plugin:structure-refactor` (fixes what this finds),
+  `claude-plugin:rename-repo` (renames the repo to the team convention).
+  Do NOT use for SKILL.md content quality (use `skill:check`) or shell
+  scripts (use `sh:check`).
 compatibility:
   tools: Read, Glob, Grep, Bash
 metadata:

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -9,9 +9,10 @@ description: >-
   placeholder stubs + naming correction + README link backfill). Idempotent.
   Use when the user
   says "fix my claude-plugin repo structure", "make this marketplace repo
-  standard", "/claude-plugin:structure-refactor". Sister skill of
-  `claude-plugin:structure-check` (which finds what this fixes). Does NOT
-  generate real guide/usage content — stubs only.
+  standard", "/claude-plugin:structure-refactor". Sister skills:
+  `claude-plugin:structure-check` (finds what this fixes),
+  `claude-plugin:rename-repo` (renames the repo to the team convention).
+  Does NOT generate real guide/usage content — stubs only.
 compatibility:
   tools: Read, Glob, Grep, Write, Edit, Bash
 metadata:


### PR DESCRIPTION
## Summary

discussion #886 의 범용 "레포를 `claude-plugin-<domain>` 컨벤션으로 rename" 플레이북을
형제 스킬과 동일 레이아웃의 스킬로 승격한다.

## Changes

- **신규 `claude-plugin:rename-repo` 스킬** (`claude/skills/claude-plugin-rename-repo/`)
  - `SKILL.md` — 6 step 흐름: 환경/호스트 확인 → 새 이름 결정 → `gh repo rename`
    → remote URL 갱신 → 하드코딩 잔재 스캔/수정 → 커밋. 파괴적 작업(rename/push)
    전 사용자 확인. frontmatter `tier: sonnet`, github.com/GHES 양쪽 동작.
  - `references/help.md` — 형제 스킬 포맷 (Usage/Arguments/Behavior/Safety/Examples/
    Sister skills/Not this skill).
  - `references/playbook.md` — discussion #886 의 컨벤션 + 0~5단계 + 주의 embedded SSOT
    (no-emoji 규칙 준수해 이모지 제거).
- **형제 스킬 상호 참조** — `structure-check` / `structure-refactor` 의 description 에
  `claude-plugin:rename-repo` 를 sister skill 로 추가.

## Verification

- golden rules 5종 통과 (no-emoji / POSIX / ux_lib / direct-exec guard / no hardcoded path).
- 문서 전용(.md) 변경 — 셸/파이썬 코드 없음. bats 서브모듈 미체크아웃(worktree)으로 bats 미실행.
- 체크리스트의 `claude-plugin-jira` dry-run 검증은 별도 GHES 레포 대상 수동 작업 — 후속.

Closes #909

<!-- ai-metrics -->
<details>
<summary>📊 AI Metrics</summary>

- 📊 tokens: ~16k
- 👤 human-time: ~5m
- 🤖 ai-time: 4m 20s

</details>
