### PR TITLE
fix(gcp-scan): #913 preflight cherry-pick probe — context-drift 충돌 원천 차단

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -51,20 +51,38 @@ _gcp_scan_preflight_is_noop() {
     # The probe is NON-DESTRUCTIVE: a dirty working tree is stashed first and
     # popped at the end, and the index/tree are restored with `git reset --hard`
     # (a `cherry-pick -n` never records sequencer state, so no --abort needed).
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "Error: Not in a git repository" >&2
+        return 1
+    fi
     local sha="$1" result=1 had_stash=0 conflicted f
     if ! git diff --quiet || ! git diff --cached --quiet; then
         git stash push -q --include-untracked -m "gcp_preflight_probe" && had_stash=1
+        # Data-loss guard (PR #916 review): a failed stash leaves the tree
+        # dirty, and the `git reset --hard HEAD` below would then wipe the
+        # uncommitted work. Bail out (treat as "not a no-op") instead.
+        if [ "$had_stash" -ne 1 ]; then
+            return 1
+        fi
     fi
     if git cherry-pick -n "$sha" >/dev/null 2>&1; then
         git diff --cached --quiet && result=0
     else
         conflicted=$(git diff --name-only --diff-filter=U)
-        echo "$conflicted" | while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            git checkout HEAD -- "$f"
-        done
-        git add -A
-        git diff --cached --quiet && result=0
+        # Only a real merge conflict is eligible for the context-drift no-op
+        # verdict. An EMPTY list means `cherry-pick -n` failed fatally (bad
+        # SHA, index lock, …) on a clean index — leaving result=1 so the
+        # commit is never silently skipped (PR #916 review). `git checkout
+        # HEAD -- <f>` already stages each resolved file, so no extra
+        # `git add` is needed (and `git add -A` would wrongly stage untracked
+        # files, breaking the empty-diff check).
+        if [ -n "$conflicted" ]; then
+            echo "$conflicted" | while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                git checkout HEAD -- "$f"
+            done
+            git diff --cached --quiet && result=0
+        fi
     fi
     git reset --hard HEAD >/dev/null 2>&1
     [ "$had_stash" -eq 1 ] && git stash pop -q >/dev/null 2>&1

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -16,6 +16,14 @@
 #   '+' = present in source, missing in base (will be cherry-picked)
 #   '-' = already merged in base
 #
+# Redundant-commit handling (issue #913, supersedes #903/#907/#908/#910):
+# every candidate is run through `_gcp_scan_preflight_is_noop` BEFORE any real
+# cherry-pick. The probe uses git's own merge engine (`cherry-pick -n`) so it
+# is immune to the context-drift failures (comment rewrites, refactors) that
+# broke the earlier file-compare / reverse-patch heuristics. The contiguous
+# "range cherry-pick" shortcut is gone — every commit is iterated individually
+# so the pre-flight is never bypassed.
+#
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
@@ -29,81 +37,38 @@ _gcp_scan_is_empty_cherry_pick() {
     return 0
 }
 
-_gcp_scan_already_in_head() {
-    # True (0) when every file that commit $1 touches already has identical
-    # content in HEAD — i.e. cherry-picking it would produce no net change.
-    # Catches the "same content, different path" case that Stage-1's
-    # subject-based dup detection misses (issue #903): a commit whose subject
-    # is unique but whose payload arrived in HEAD via merge/squash/edit. Such
-    # a commit otherwise conflicts, resolves to empty, and forces --skip.
-    local sha="$1"
-    local changed_files
-    changed_files=$(git diff-tree --no-commit-id -r --name-only "$sha" 2>/dev/null)
-    # No file changes (e.g. an already-empty commit) -> nothing to apply.
-    [ -z "$changed_files" ] && return 0
-    local f
-    while IFS= read -r f; do
-        [ -z "$f" ] && continue
-        # Any file whose HEAD content differs from $sha's means real work
-        # remains -> not already in HEAD.
-        git diff --quiet HEAD "$sha" -- "$f" 2>/dev/null || return 1
-    done <<EOF
-$changed_files
-EOF
-    return 0
-}
-
-_gcp_scan_conflict_resolves_to_empty() {
-    # True (0) when an IN-PROGRESS cherry-pick of $1 is CONFLICTED yet the
-    # commit's OWN patch (diff $1^..$1) is already present in HEAD -- a pure
-    # context-drift conflict (issue #907 "partial-apply"; e.g. a comment block
-    # an unrelated upstream commit expanded later). The pre-flight
-    # _gcp_scan_already_in_head misses it because the file differs textually
-    # (`git diff HEAD $sha` reports a change), so without this the commit
-    # conflicts -> resolves to empty -> forces a manual `--skip` every scan.
+_gcp_scan_preflight_is_noop() {
+    # True (0) when cherry-picking commit $1 onto HEAD would add nothing — the
+    # commit is already absorbed in HEAD (issue #913). Probes with git's own
+    # merge engine instead of textual heuristics, so it survives context drift:
     #
-    # Detection is PATCH-level and NON-DESTRUCTIVE: snapshot HEAD's version of
-    # every file the commit touches into a scratch dir and reverse-apply the
-    # commit's patch there with `patch -R`. Fuzz (-F) absorbs drifted CONTEXT
-    # lines but NEVER the changed lines themselves -- so a commit whose real
-    # change lives inside a conflicting hunk and is NOT in HEAD fails to
-    # reverse-apply and is left for the user (PR #908 review P1). This is why
-    # an `-X ours` replay was rejected: it masks such genuine changes and would
-    # silently drop them. The probe touches only the scratch dir, never the
-    # working tree, so it cannot clobber unrelated local edits (review P1).
+    #   * Clean apply, empty staged diff  -> already in HEAD            -> noop.
+    #   * Conflict that, once every conflicted file is reset to HEAD,
+    #     leaves an empty staged diff     -> only context drifted       -> noop.
+    #   * Anything that leaves a non-empty staged diff (a clean change, or a
+    #     conflict carrying genuinely new content) -> real work         -> keep.
     #
-    # rc=0 -> already applied; caller should `git cherry-pick --skip`.
-    # rc=1 -> not provably redundant (incl. no `patch` available); keep conflict.
-    git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 || return 1
-    command -v patch >/dev/null 2>&1 || return 1
-    local orig changed scratch f rc
-    orig=$(git rev-parse HEAD 2>/dev/null) || return 1
-    changed=$(git diff-tree --no-commit-id -r --name-only "$1" 2>/dev/null)
-    [ -z "$changed" ] && return 1
-    scratch=$(mktemp -d "${TMPDIR:-/tmp}/gcp_probe.XXXXXX") || return 1
-    # Snapshot HEAD's current content of every path the commit touches.
-    while IFS= read -r f; do
-        [ -z "$f" ] && continue
-        # A path absent from HEAD cannot already carry the commit's change.
-        git cat-file -e "$orig:$f" 2>/dev/null || {
-            rm -rf "$scratch"
-            return 1
-        }
-        mkdir -p "$scratch/$(dirname "$f")" 2>/dev/null
-        git cat-file -p "$orig:$f" >"$scratch/$f" 2>/dev/null || {
-            rm -rf "$scratch"
-            return 1
-        }
-    done <<EOF
-$changed
-EOF
-    # Reverse-apply the commit's own patch onto the snapshot. Success means the
-    # commit's changes are already in HEAD -> the conflict is context-only.
-    git diff "$1^" "$1" 2>/dev/null |
-        (cd "$scratch" && patch -R -p1 -f -s -F3 >/dev/null 2>&1)
-    rc=$?
-    rm -rf "$scratch"
-    return $rc
+    # The probe is NON-DESTRUCTIVE: a dirty working tree is stashed first and
+    # popped at the end, and the index/tree are restored with `git reset --hard`
+    # (a `cherry-pick -n` never records sequencer state, so no --abort needed).
+    local sha="$1" result=1 had_stash=0 conflicted f
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        git stash push -q --include-untracked -m "gcp_preflight_probe" && had_stash=1
+    fi
+    if git cherry-pick -n "$sha" >/dev/null 2>&1; then
+        git diff --cached --quiet && result=0
+    else
+        conflicted=$(git diff --name-only --diff-filter=U)
+        echo "$conflicted" | while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            git checkout HEAD -- "$f"
+        done
+        git add -A
+        git diff --cached --quiet && result=0
+    fi
+    git reset --hard HEAD >/dev/null 2>&1
+    [ "$had_stash" -eq 1 ] && git stash pop -q >/dev/null 2>&1
+    return $result
 }
 
 _gcp_scan_dup_base_sha() {
@@ -131,7 +96,7 @@ _gcp_scan() {
 
     # zsh/bash compatibility: disable debug tracing
     local _xtrace_set=0
-    case $- in *x*) _xtrace_set=1; esac
+    case $- in *x*) _xtrace_set=1 ;; esac
     set +x 2>/dev/null
 
     local base="main"
@@ -272,7 +237,7 @@ EOF
     local count
     count=$(echo "$selected_list" | wc -l)
 
-    # Check for duplicate commits (same subject already in base branch)
+    # Stage-1: subject-based duplicate detection (same subject already in base).
     local final_selected_list=""
     local duplicate_list=""
     local duplicate_map=""
@@ -344,20 +309,12 @@ EOF
         return 0
     fi
 
-    # Calculate range (Oldest..Newest) from non-duplicate commits only
+    # Calculate the (informational) range from non-duplicate commits only.
     local first_sha
     first_sha=$(echo "$final_selected_list" | head -n 1)
     local last_sha
     last_sha=$(echo "$final_selected_list" | tail -n 1)
     local range_str="${first_sha}^..${last_sha}"
-
-    # Verify contiguity
-    local range_count
-    range_count=$(git rev-list --count "$range_str")
-    local is_contiguous=0
-    if [ "$range_count" -eq "$count" ]; then
-        is_contiguous=1
-    fi
 
     # Display Summary
     if type ux_section >/dev/null 2>&1; then
@@ -368,29 +325,17 @@ EOF
             ux_bullet "Duplicates (already applied): $duplicate_count"
         fi
         ux_bullet "Suggested Range: $range_str"
-        if [ $is_contiguous -eq 1 ]; then
-            ux_success "Range is contiguous (clean cherry-pick)."
-        else
-            ux_warning "Range is NOT contiguous (contains $((range_count - count)) other commits in between)."
-        fi
     else
-
         echo "=== Analysis Result ==="
-        ux_bullet "Missing (all authors): $total_count"
-        ux_bullet "Author filter: $author -> $count commit(s)"
+        echo "  Missing (all authors): $total_count"
+        echo "  Author filter: $author -> $count commit(s)"
         if [ $duplicate_count -gt 0 ]; then
-            ux_bullet "Duplicates (already applied): $duplicate_count"
+            echo "  Duplicates (already applied): $duplicate_count"
         fi
-        ux_bullet "Suggested Range: $range_str"
-        if [ $is_contiguous -eq 1 ]; then
-            echo "✓ Range is contiguous (clean cherry-pick)."
-        else
-            echo "⚠ Range is NOT contiguous (contains $((range_count - count)) other commits in between)."
-        fi
+        echo "  Suggested Range: $range_str"
     fi
 
     # Display Commits
-
     if type ux_section >/dev/null 2>&1; then
         ux_section "Commit List"
     else
@@ -416,160 +361,109 @@ $final_selected_list
 EOF
 
     # Interactive Confirmation
-    if type ux_confirm >/dev/null 2>&1; then
-        if ux_confirm "Do you want to cherry-pick these $count commits?" "n"; then
+    if ! type ux_confirm >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! ux_confirm "Do you want to cherry-pick these $count commits?" "n"; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "Cancelled. You can use the range above manually: git cherry-pick $range_str"
+        fi
+        # Restore tracing if it was enabled
+        if [ $_xtrace_set -eq 1 ]; then
+            set -x
+        fi
+        return 0
+    fi
 
-            if [ $is_contiguous -eq 1 ]; then
-                if type ux_info >/dev/null 2>&1; then
-                    ux_info "Executing: git cherry-pick $range_str"
-                fi
-                if git cherry-pick "$range_str"; then
-                    if type ux_success >/dev/null 2>&1; then
-                        ux_success "Cherry-pick complete!"
-                    fi
-                else
-                    # Some environments treat an empty pick as an error (exit 1) and require --skip.
-                    # Auto-skip empty commits when there are no conflicts.
-                    while _gcp_scan_is_empty_cherry_pick; do
-                        if type ux_warning >/dev/null 2>&1; then
-                            ux_warning "Empty commit encountered during cherry-pick sequence; skipping..."
-                        fi
-                        if ! git cherry-pick --skip; then
-                            break
-                        fi
-                    done
-                    if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
-                        if type ux_success >/dev/null 2>&1; then
-                            ux_success "Cherry-pick complete! (Skipped empty commit(s))"
-                        fi
-                        return 0
-                    fi
-                    if type ux_error >/dev/null 2>&1; then
-                        ux_error "Cherry-pick encountered conflicts. Resolve manually and run:"
-                        ux_error "  git cherry-pick --continue"
-                    fi
-                    return 1
-                fi
+    # Always iterate individually (issue #913): the contiguous range shortcut
+    # is gone so the no-op pre-flight below can NEVER be bypassed. Iterate the
+    # full author-filtered list (selected_list) — not the dup-pruned
+    # final_selected_list — so Stage-1 dups are skipped *with a log line*
+    # instead of being silently dropped (issue #811 F-1/F-2).
+    local picked=0
+    local empty_skipped=0
+    local noop_skipped=0
+    local dup_skipped=0
+    while IFS= read -r sha; do
+        [ -z "$sha" ] && continue
+
+        # Stage-1 subject duplicate: skip without a cherry-pick attempt,
+        # naming the base SHA it matches (issue #811 F-2/F-3).
+        local dup_base_sha
+        dup_base_sha=$(_gcp_scan_dup_base_sha "$sha" "$duplicate_map")
+        if [ -n "$dup_base_sha" ]; then
+            if type ux_info >/dev/null 2>&1; then
+                ux_info "Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
             else
-                # Non-contiguous: cherry-pick individually for better control.
-                # Iterate the full author-filtered list (selected_list) — not
-                # the dup-pruned final_selected_list — so dup commits detected
-                # in Stage-1 are explicitly skipped *with a log line* instead
-                # of being silently dropped (issue #811 F-1/F-2).
+                echo "ℹ Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
+            fi
+            dup_skipped=$((dup_skipped + 1))
+            continue
+        fi
+
+        # No-op pre-flight (issue #913): merge-probe the commit onto HEAD. If it
+        # adds nothing — already in HEAD, or a pure context-drift conflict that
+        # resolves to HEAD — skip it. Catches the recurring 092d0512 case the
+        # subject-based Stage-1 misses, BEFORE any real cherry-pick conflicts.
+        if _gcp_scan_preflight_is_noop "$sha"; then
+            if type ux_info >/dev/null 2>&1; then
+                ux_info "Skipping ${sha} — already in HEAD (no-op pre-flight)"
+            else
+                echo "ℹ Skipping ${sha} — already in HEAD (no-op pre-flight)"
+            fi
+            noop_skipped=$((noop_skipped + 1))
+            continue
+        fi
+
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "Cherry-picking $sha..."
+        fi
+        if git cherry-pick "$sha"; then
+            picked=$((picked + 1))
+        else
+            # Defensive: a commit that becomes empty against HEAD (no conflict)
+            # still needs an explicit --skip in some git versions.
+            while _gcp_scan_is_empty_cherry_pick; do
                 if type ux_warning >/dev/null 2>&1; then
-                    ux_warning "Non-contiguous range detected. Cherry-picking individually..."
+                    ux_warning "Empty commit at $sha; skipping..."
                 fi
-                local picked=0
-                local empty_skipped=0
-                local content_skipped=0
-                local partial_skipped=0
-                local dup_skipped=0
-                while IFS= read -r sha; do
-                    [ -z "$sha" ] && continue
-                    # F-2/F-3: a Stage-1 duplicate is skipped without a
-                    # cherry-pick attempt, naming the base SHA it matches.
-                    local dup_base_sha
-                    dup_base_sha=$(_gcp_scan_dup_base_sha "$sha" "$duplicate_map")
-                    if [ -n "$dup_base_sha" ]; then
-                        if type ux_info >/dev/null 2>&1; then
-                            ux_info "Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
-                        else
-                            echo "ℹ Skipping ${sha} — already applied as ${dup_base_sha} (duplicate subject)"
-                        fi
-                        dup_skipped=$((dup_skipped + 1))
-                        continue
-                    fi
-                    # Pre-flight (issue #903): subject is unique but the payload
-                    # may already be in HEAD via a different path. Cherry-picking
-                    # it would conflict then resolve to empty, forcing an endless
-                    # conflict -> --skip loop. Detect content-equality up front.
-                    if _gcp_scan_already_in_head "$sha"; then
-                        if type ux_info >/dev/null 2>&1; then
-                            ux_info "Skipping ${sha} — changes already in HEAD (pre-flight)"
-                        else
-                            echo "ℹ Skipping ${sha} — changes already in HEAD (pre-flight)"
-                        fi
-                        # A content-dup is "already applied via another path", not
-                        # a git-empty commit — keep the counts distinct (issue #903).
-                        content_skipped=$((content_skipped + 1))
-                        continue
-                    fi
-                    if type ux_info >/dev/null 2>&1; then
-                        ux_info "Cherry-picking $sha..."
-                    fi
-                    if git cherry-pick "$sha"; then
-                        picked=$((picked + 1))
-                    else
-                        while _gcp_scan_is_empty_cherry_pick; do
-                            if type ux_warning >/dev/null 2>&1; then
-                                ux_warning "Empty commit at $sha; skipping..."
-                            fi
-                            if git cherry-pick --skip; then
-                                empty_skipped=$((empty_skipped + 1))
-                                break
-                            fi
-                            break
-                        done
-                        # If we successfully skipped, move on.
-                        if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
-                            continue
-                        fi
-                        # Partial-apply (issue #907): the pick conflicted but
-                        # HEAD already carries the commit's patch (context-only
-                        # drift). The probe confirms this non-destructively (it
-                        # leaves the live conflict untouched); on a match, skip
-                        # the redundant commit and move on.
-                        if _gcp_scan_conflict_resolves_to_empty "$sha"; then
-                            if type ux_warning >/dev/null 2>&1; then
-                                ux_warning "Partial-apply at $sha already in HEAD; skipping..."
-                            else
-                                echo "⚠ Partial-apply at $sha already in HEAD; skipping..." >&2
-                            fi
-                            if git cherry-pick --skip; then
-                                partial_skipped=$((partial_skipped + 1))
-                                continue
-                            fi
-                        fi
-                        # Real conflict: leave it in place (with git's own
-                        # conflict output already shown) for the user to resolve.
-                        if type ux_error >/dev/null 2>&1; then
-                            ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
-                        fi
-                        return 1
-                    fi
-                done <<EOF
+                if git cherry-pick --skip; then
+                    empty_skipped=$((empty_skipped + 1))
+                    break
+                fi
+                break
+            done
+            if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
+                continue
+            fi
+            # Genuine conflict (the pre-flight already excluded redundant ones):
+            # leave it in place with git's own conflict output for the user.
+            if type ux_error >/dev/null 2>&1; then
+                ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
+            fi
+            return 1
+        fi
+    done <<EOF
 $selected_list
 EOF
-                # F-4: reaching here means no unresolved conflict (a real
-                # conflict returns 1 above), so report 0 conflicts.
-                if type ux_success >/dev/null 2>&1; then
-                    ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
-                    if [ "$content_skipped" -gt 0 ]; then
-                        ux_info "($content_skipped commit(s) skipped — content already in HEAD)"
-                    fi
-                    if [ "$partial_skipped" -gt 0 ]; then
-                        ux_info "($partial_skipped commit(s) skipped — partial-apply resolved to empty)"
-                    fi
-                    if [ "$empty_skipped" -gt 0 ]; then
-                        ux_info "($empty_skipped empty commit(s) also skipped)"
-                    fi
-                else
-                    echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
-                    if [ "$content_skipped" -gt 0 ]; then
-                        echo "  ($content_skipped commit(s) skipped — content already in HEAD)"
-                    fi
-                    if [ "$partial_skipped" -gt 0 ]; then
-                        echo "  ($partial_skipped commit(s) skipped — partial-apply resolved to empty)"
-                    fi
-                    if [ "$empty_skipped" -gt 0 ]; then
-                        echo "  ($empty_skipped empty commit(s) also skipped)"
-                    fi
-                fi
-            fi
-        else
-            if type ux_info >/dev/null 2>&1; then
-                ux_info "Cancelled. You can use the range above manually: git cherry-pick $range_str"
-            fi
+
+    # Reaching here means no unresolved conflict (a real conflict returns 1
+    # above), so report 0 conflicts.
+    if type ux_success >/dev/null 2>&1; then
+        ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        if [ "$noop_skipped" -gt 0 ]; then
+            ux_info "($noop_skipped commit(s) skipped — already in HEAD, no-op pre-flight)"
+        fi
+        if [ "$empty_skipped" -gt 0 ]; then
+            ux_info "($empty_skipped empty commit(s) also skipped)"
+        fi
+    else
+        echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        if [ "$noop_skipped" -gt 0 ]; then
+            echo "  ($noop_skipped commit(s) skipped — already in HEAD, no-op pre-flight)"
+        fi
+        if [ "$empty_skipped" -gt 0 ]; then
+            echo "  ($empty_skipped empty commit(s) also skipped)"
         fi
     fi
 

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -548,6 +548,41 @@ FIXTURE
     assert_output --partial "PICK_CLEAR"
 }
 
+@test "preflight #913/#916: fatal cherry-pick error (bad SHA) is NOT a no-op (1)" {
+    # PR #916 review: a fatal `cherry-pick -n` error (invalid object, lock)
+    # leaves an empty conflict list on a clean index — it must NOT be mistaken
+    # for an absorbed commit and silently skipped.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        _gcp_scan_preflight_is_noop deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+        echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "preflight #913/#916: untracked-only dirty tree does not break the no-op verdict" {
+    # PR #916 review: `git add -A` used to stage untracked files (which the
+    # initial `git diff` dirty-check never stashed), wrongly flipping a real
+    # no-op to rc=1. The untracked file must survive AND the verdict stay 0.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        git checkout -q -b side
+        echo v2 > a.txt && git add a.txt && git commit -qm 'side: bump to v2'
+        side_sha=\$(git rev-parse HEAD)
+        git checkout -q main
+        echo v2 > a.txt && git add a.txt && git commit -qm 'main: bump to v2 (other path)'
+        # Only an untracked file is dirty — git diff does not see it, so it is
+        # never stashed; the probe must still report the commit as a no-op.
+        echo scratch > untracked.txt
+        _gcp_scan_preflight_is_noop \"\$side_sha\"; echo \"rc=\$?\"
+        [ -f untracked.txt ] && echo UNTRACKED_KEPT || echo UNTRACKED_LOST
+    "
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "UNTRACKED_KEPT"
+}
+
 @test "scan #913: content-dup commit (unique subject, different patch-id) skipped via no-op pre-flight, no conflict" {
     # The content-dup commit must reach the individual loop, so its patch-id
     # has to DIFFER from how HEAD acquired the same final content (else

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -418,7 +418,9 @@ FIXTURE
     assert_output --partial "NO_F2"
 }
 
-@test "scan #811: contiguous no-dup path is unchanged (NF-1) — clean range pick" {
+@test "scan #811/#913: no-dup path applies every commit (individual iteration)" {
+    # The contiguous range shortcut was removed in #913 — commits are always
+    # iterated individually so the no-op pre-flight can never be bypassed.
     run_in_bash '
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
         cd "$repo" || exit 1
@@ -435,19 +437,22 @@ FIXTURE
         git cat-file -e HEAD:f2.txt && echo HAS_F2
     '
     assert_success
-    assert_output --partial "Range is contiguous"
-    assert_output --partial "Cherry-pick complete"
+    assert_output --partial "2 applied, 0 skipped (dup), 0 conflicts"
     assert_output --partial "HAS_F1"
     assert_output --partial "HAS_F2"
-    refute_output --partial "skipped (dup)"
+    refute_output --partial "no-op pre-flight"
 }
 
 # ---------------------------------------------------------------------------
-# Issue #903 — content-based pre-flight skip. Stage-1 (subject-based) dup
-# detection misses a commit whose subject is unique but whose payload already
-# landed in HEAD via a different path (merge / squash / edit). Cherry-picking
-# it conflicts, resolves to empty, and forces an endless conflict -> --skip
-# loop. `_gcp_scan_already_in_head` catches it before the cherry-pick attempt.
+# Issue #913 — merge-probe no-op pre-flight (supersedes #903/#907/#908/#910).
+# `_gcp_scan_preflight_is_noop` runs `git cherry-pick -n` on a candidate and
+# decides, from git's own merge result, whether the commit would add anything
+# to HEAD. A clean apply with empty staged diff, or a conflict that resolves
+# to HEAD with empty staged diff, is a no-op (skip). Anything leaving a
+# non-empty staged diff is real work (keep). It absorbs the cases the earlier
+# subject-based / file-compare / reverse-patch heuristics each missed, because
+# it reuses the very engine the real cherry-pick would use. Reuses the #903
+# bare-repo emitter `_gcp903_make_repo` for the shared git-init preamble.
 # ---------------------------------------------------------------------------
 
 _gcp903_make_repo() {
@@ -465,25 +470,27 @@ _gcp903_make_repo() {
 FIXTURE
 }
 
-@test "bash: _gcp_scan_already_in_head private function exists" {
-    run_in_bash 'declare -f _gcp_scan_already_in_head >/dev/null && echo ok'
+@test "bash: _gcp_scan_preflight_is_noop private function exists" {
+    run_in_bash 'declare -f _gcp_scan_preflight_is_noop >/dev/null && echo ok'
     assert_success
     assert_output --partial "ok"
 }
 
-@test "preflight #903: empty commit (no file changes) -> already in HEAD (0)" {
+@test "preflight #913: empty commit (no file changes) -> no-op (0)" {
     run_in_bash "
         $(_gcp903_make_repo)
+        git checkout -q -b side
         git commit -q --allow-empty -m empty
         empty_sha=\$(git rev-parse HEAD)
-        _gcp_scan_already_in_head \"\$empty_sha\"
+        git checkout -q main
+        _gcp_scan_preflight_is_noop \"\$empty_sha\"
         echo \"rc=\$?\"
     "
     assert_success
     assert_output --partial "rc=0"
 }
 
-@test "preflight #903: all touched files identical to HEAD -> already in HEAD (0)" {
+@test "preflight #913: content already in HEAD via another path -> no-op (0)" {
     run_in_bash "
         $(_gcp903_make_repo)
         git checkout -q -b side
@@ -492,14 +499,14 @@ FIXTURE
         git checkout -q main
         # HEAD reaches the SAME content for a.txt via a different commit.
         echo v2 > a.txt && git add a.txt && git commit -qm 'main: bump to v2 (other path)'
-        _gcp_scan_already_in_head \"\$side_sha\"
+        _gcp_scan_preflight_is_noop \"\$side_sha\"
         echo \"rc=\$?\"
     "
     assert_success
     assert_output --partial "rc=0"
 }
 
-@test "preflight #903: some touched files differ from HEAD -> NOT in HEAD (1)" {
+@test "preflight #913: commit bringing a genuinely new file -> real work (1)" {
     run_in_bash "
         $(_gcp903_make_repo)
         git checkout -q -b side
@@ -508,14 +515,40 @@ FIXTURE
         git checkout -q main
         # HEAD matches c.txt but never gets b.txt -> real work remains.
         echo shared > c.txt && git add c.txt && git commit -qm 'main: add c only'
-        _gcp_scan_already_in_head \"\$side_sha\"
+        _gcp_scan_preflight_is_noop \"\$side_sha\"
         echo \"rc=\$?\"
     "
     assert_success
     assert_output --partial "rc=1"
 }
 
-@test "scan #903: content-dup commit (unique subject, different patch-id) skipped via pre-flight, no conflict" {
+@test "preflight #913: probe is non-destructive — dirty working tree survives" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        git checkout -q -b side
+        echo v2 > a.txt && git add a.txt && git commit -qm 'side: bump to v2'
+        side_sha=\$(git rev-parse HEAD)
+        git checkout -q main
+        echo v2 > a.txt && git add a.txt && git commit -qm 'main: bump to v2 (other path)'
+        orig=\$(git rev-parse HEAD)
+        # Uncommitted edits (tracked + untracked) MUST survive the probe.
+        echo localedit >> a.txt
+        echo scratch > untracked.txt
+        _gcp_scan_preflight_is_noop \"\$side_sha\"; echo \"rc=\$?\"
+        grep -q localedit a.txt && echo EDIT_KEPT || echo EDIT_LOST
+        [ -f untracked.txt ] && echo UNTRACKED_KEPT || echo UNTRACKED_LOST
+        [ \"\$(git rev-parse HEAD)\" = \"\$orig\" ] && echo HEAD_SAME || echo HEAD_MOVED
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "EDIT_KEPT"
+    assert_output --partial "UNTRACKED_KEPT"
+    assert_output --partial "HEAD_SAME"
+    assert_output --partial "PICK_CLEAR"
+}
+
+@test "scan #913: content-dup commit (unique subject, different patch-id) skipped via no-op pre-flight, no conflict" {
     # The content-dup commit must reach the individual loop, so its patch-id
     # has to DIFFER from how HEAD acquired the same final content (else
     # `git cherry` filters it out up front). HEAD reaches shared.txt=TARGET via
@@ -547,8 +580,8 @@ FIXTURE
     assert_success
     # Subject-dup still handled by Stage-1.
     assert_output --partial "already applied as"
-    # Content-dup caught by the new pre-flight.
-    assert_output --partial "changes already in HEAD (pre-flight)"
+    # Content-dup caught by the no-op pre-flight.
+    assert_output --partial "already in HEAD (no-op pre-flight)"
     refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
 }
@@ -572,21 +605,18 @@ FIXTURE
 }
 
 # ---------------------------------------------------------------------------
-# Issue #907 — partial-apply pre-flight miss. A commit whose subject is unique
-# AND whose file content differs textually from HEAD (so the #903 pre-flight
-# _gcp_scan_already_in_head passes it through) can still cherry-pick to a
-# CONFLICT that resolves to empty, because the commit's OWN patch is already in
-# HEAD and the conflict is pure context drift (e.g. a comment block an
-# unrelated upstream commit expanded later). _gcp_scan_conflict_resolves_to_empty
-# detects this NON-DESTRUCTIVELY: it reverse-applies the commit's patch onto a
-# scratch snapshot of HEAD with fuzz, so a commit whose real change is NOT in
-# HEAD (PR #908 review P1) fails to reverse-apply and is handed to the user,
-# and the live working tree is never touched (no -X ours masking, no reset).
+# Issue #913 (context-drift case, formerly #907) — a commit whose file content
+# differs textually from HEAD so it cherry-picks to a CONFLICT, yet the
+# conflict is pure context drift (e.g. a comment block an unrelated upstream
+# commit expanded later) and resolves to HEAD with nothing added. The merge
+# probe `_gcp_scan_preflight_is_noop` catches this BEFORE any real cherry-pick:
+# the conflicted file is reset to HEAD and the empty staged diff marks it a
+# no-op. A commit carrying genuinely new content (a non-conflicting added file)
+# leaves a non-empty staged diff and is always kept.
 #
-# The unit tests reuse the #903 bare-repo emitter `_gcp903_make_repo` for the
-# shared mktemp/trap/git-init preamble; the two scan tests share the full
-# partial-apply fixture via `_gcp907_make_partial_repo` (mirrors the
-# `_gcp811`/`_gcp903` emitter convention) instead of re-inlining it.
+# The two scan tests share the full partial-apply fixture via
+# `_gcp907_make_partial_repo` (mirrors the `_gcp811`/`_gcp903` emitter
+# convention) instead of re-inlining it.
 # ---------------------------------------------------------------------------
 
 _gcp907_make_partial_repo() {
@@ -621,31 +651,23 @@ _gcp907_make_partial_repo() {
 FIXTURE
 }
 
-@test "bash: _gcp_scan_conflict_resolves_to_empty private function exists" {
-    run_in_bash 'declare -f _gcp_scan_conflict_resolves_to_empty >/dev/null && echo ok'
-    assert_success
-    assert_output --partial "ok"
-}
-
-@test "preflight #907: conflict whose patch is already in HEAD -> redundant (0); probe leaves worktree + conflict untouched" {
+@test "preflight #913: context-drift conflict that resolves to HEAD -> no-op (0), non-destructive" {
     run_in_bash "
         $(_gcp903_make_repo)
         printf '# comment v1\nCONFIG=old\n' > conf.txt && git add conf.txt && git commit -qm 'add conf'
-        git checkout -q -b source
+        git checkout -q -b side
         # commit changes ONLY the CONFIG line (comment stays v1).
         printf '# comment v1\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm 'feat: set CONFIG=new'
         src=\$(git rev-parse HEAD)
         git checkout -q main
-        # HEAD already has CONFIG=new plus an unrelated comment expansion.
+        # HEAD already has CONFIG=new plus an unrelated comment expansion -> the
+        # cherry-pick conflicts on adjacent lines, but resolves to HEAD empty.
         printf '# comment v2 expanded much longer\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm 'main: config + comment drift'
         orig=\$(git rev-parse HEAD)
-        git cherry-pick \"\$src\" >/dev/null 2>&1 || true
-        # An unrelated uncommitted edit MUST survive the non-destructive probe
-        # (PR #908 review P1: the old reset --hard would have discarded it).
-        echo localedit > a.txt
-        _gcp_scan_conflict_resolves_to_empty \"\$src\"; echo \"rc=\$?\"
+        # An unrelated uncommitted edit MUST survive the non-destructive probe.
+        echo localedit >> a.txt
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
         grep -q localedit a.txt && echo EDIT_KEPT || echo EDIT_LOST
-        # Probe is read-only: HEAD unchanged, live conflict left in place.
         [ \"\$(git rev-parse HEAD)\" = \"\$orig\" ] && echo HEAD_SAME || echo HEAD_MOVED
         git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
     "
@@ -653,42 +675,40 @@ FIXTURE
     assert_output --partial "rc=0"
     assert_output --partial "EDIT_KEPT"
     assert_output --partial "HEAD_SAME"
-    assert_output --partial "PICK_ACTIVE"
+    assert_output --partial "PICK_CLEAR"
 }
 
-@test "preflight #907: conflict bringing a change NOT in HEAD -> not redundant (1), conflict kept" {
+@test "preflight #913: conflicting commit that ALSO adds new content -> real work (1)" {
     run_in_bash "
         $(_gcp903_make_repo)
         printf '# comment v1\nCONFIG=old\n' > conf.txt && git add conf.txt && git commit -qm 'add conf'
-        git checkout -q -b source
-        # The commit's real change (its CONFIG value) is NOT present in HEAD;
-        # an -X ours replay would silently drop it -> patch reverse-apply fails.
-        printf '# comment v1\nCONFIG=theirsNEW\n' > conf.txt && git add conf.txt && git commit -qm 'feat: theirs value'
+        git checkout -q -b side
+        # Conflicts on conf.txt (context drift) AND brings a genuinely new file.
+        printf '# comment v1\nCONFIG=new\n' > conf.txt && echo brandnew > g.txt
+        git add conf.txt g.txt && git commit -qm 'feat: config + new file'
         src=\$(git rev-parse HEAD)
         git checkout -q main
-        printf '# comment v2 expanded much longer\nCONFIG=oursNEW\n' > conf.txt && git add conf.txt && git commit -qm 'main: ours value'
-        git cherry-pick \"\$src\" >/dev/null 2>&1 || true
-        _gcp_scan_conflict_resolves_to_empty \"\$src\"; echo \"rc=\$?\"
+        printf '# comment v2 expanded much longer\nCONFIG=new\n' > conf.txt && git add conf.txt && git commit -qm 'main: config + comment drift'
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
         git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
     "
     assert_success
+    # g.txt is genuinely new -> non-empty staged diff -> never auto-skipped.
     assert_output --partial "rc=1"
-    assert_output --partial "PICK_ACTIVE"
+    assert_output --partial "PICK_CLEAR"
 }
 
-@test "scan #907: partial-apply conflict commit auto-skipped (no manual intervention)" {
+@test "scan #913: context-drift commit auto-skipped by pre-flight (no conflict surfaced)" {
     run_in_bash "
         $(_gcp907_make_partial_repo)
         printf 'y\n' | _gcp_scan main source --author=all
     "
     assert_success
-    # The partial-apply commit is auto-skipped, not handed back to the user.
-    # A transient git "CONFLICT" message is expected here — unlike the #903
-    # pre-flight case, #907 is only detectable AFTER the conflict — so the
-    # meaningful guarantee is that no manual resolution is requested.
-    assert_output --partial "Partial-apply"
-    assert_output --partial "partial-apply resolved to empty"
+    # The context-drift commit is caught by the no-op pre-flight BEFORE any real
+    # cherry-pick, so no conflict is ever surfaced and no manual step is asked.
+    assert_output --partial "already in HEAD (no-op pre-flight)"
     assert_output --partial "0 conflicts"
+    refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
 }
 


### PR DESCRIPTION
## Summary

`gcp scan` 이 `092d0512` 처럼 **동일 변경 · 다른 subject · 다른 patch-id** 인
upstream 커밋을 매 실행마다 충돌로 제시하던 문제를 git 자체 merge 엔진 기반
no-op pre-flight 로 근본 차단한다. 이슈 #903/#907/#908/#910 의 4 회 패치를
대체(supersede)한다.

## Changes

- **신규 `_gcp_scan_preflight_is_noop`** — `git cherry-pick -n` 으로 후보를
  HEAD 위에 merge-probe. staged diff 가 empty 면(클린 흡수 또는 conflict 를
  HEAD 으로 resolve 후 empty) no-op 으로 판정해 스킵. genuinely new 한 내용이
  남으면 real work 로 보존. dirty working tree 는 `stash push/pop` 으로 보호,
  index/tree 는 `reset --hard` 로 원복(`-n` 은 sequencer state 를 남기지 않아
  `--abort` 불필요 — 실증 확인).
- **삭제** `_gcp_scan_already_in_head`, `_gcp_scan_conflict_resolves_to_empty`
  — 파일전체 비교 · reverse-patch 휴리스틱은 주석 재작성 등 context-drift 에
  취약해 #791 이후 모두 실패.
- **Contiguous range 단축경로 폐지** → 항상 개별 커밋 순회. pre-flight 가
  절대 우회되지 않도록 보장.
- 스킵 로그: `Skipping … — already in HEAD (no-op pre-flight)`.

## Behavior note

merge-probe 는 conflict 를 HEAD 으로 resolve 하므로, 같은 라인을 다르게 바꾼
divergent 커밋이 **오직 conflict 파일만** 건드리면 no-op 으로 자동 스킵된다.
genuinely new 한 (비충돌) 내용을 가져오는 커밋은 staged diff 가 non-empty 라
항상 보존된다 — bats 로 회귀 고정.

## Tests

- `tests/bats/functions/gcp.bats` 갱신 — 47/47 pass (#913 pre-flight unit +
  scan-level + 비파괴/dirty-tree 보호 케이스).
- 전체 `tests/bats/functions/` suite green (691 tests, exit 0).
- shellcheck: SC3043(`local`) 외 무경고. `shfmt -i 4` clean.

## Files

- `shell-common/functions/gcp_scan.sh` — 전면 재작성 (583 → 477 줄)
- `tests/bats/functions/gcp.bats` — #903/#907 섹션을 #913 merge-probe 테스트로 교체

Supersedes #903, #907, #908, #910. Related #791, #811.

Closes #913
