### PR TITLE
feat(structure-check): #914 single|mono 모드 지원 — plugin-root 추상화로 자동 감지

### DIFF
--- a/claude/skills/claude-plugin-structure-check/SKILL.md
+++ b/claude/skills/claude-plugin-structure-check/SKILL.md
@@ -3,11 +3,13 @@ name: claude-plugin:structure-check
 description: >-
   Audit a claude-plugin marketplace repo (e.g. `claude-plugin-visuals`)
   against the standard directory layout and report PASS/WARN/FAIL/N/A.
-  Read-only — never edits. Discovers plugins/skills dynamically by directory
-  scan, then evaluates mandatory items M1-M6 (FAIL) and recommended items
-  R1-R5 (WARN). Use when the user says "check my claude-plugin repo
-  structure", "is this marketplace repo standard?", "audit plugin layout",
-  "/claude-plugin:structure-check". Sister skills:
+  Supports both `mono` (`plugins/<p>/skills/`) and `single`
+  (repo-root `skills/`) layouts — auto-detected, or forced with
+  `--single` / `--mono`. Read-only — never edits. Discovers plugins/skills
+  dynamically by directory scan, then evaluates mandatory items M1-M6 (FAIL)
+  and recommended items R1-R5 (WARN). Use when the user says "check my
+  claude-plugin repo structure", "is this marketplace repo standard?",
+  "audit plugin layout", "/claude-plugin:structure-check". Sister skills:
   `claude-plugin:structure-refactor` (fixes what this finds),
   `claude-plugin:rename-repo` (renames the repo to the team convention).
   Do NOT use for SKILL.md content quality (use `skill:check`) or shell
@@ -29,25 +31,35 @@ metadata:
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
 its content verbatim, then stop. No filesystem scan.
 
-## Step 1: Resolve Repo Path
+## Step 1: Parse Args + Resolve Repo Path
 
-- Argument given → audit that path. No argument → audit the current
+- Positional `[repo-path]` → audit that path. None → audit the current
   directory.
+- Flags `--single` / `--mono` → force the layout mode, overriding
+  auto-detection (Step 2). Mutually exclusive; if both given, last wins.
 - Confirm the path exists; if not, stop with a one-line error pointing to
   `/claude-plugin:structure-check path/to/repo`.
 - Check `test -d <path>/.git`; not a git repo → continue, but note it
   (one warning line — the audit still runs).
 
-## Step 2: Discover Plugins + Skills
+## Step 2: Detect Mode + Discover Plugin Roots + Skills
 
-Read `references/structure-spec.md` for the full standard (it is the
-embedded SSOT). Discover dynamically — never hard-code names:
+Read `references/structure-spec.md` for the full standard (embedded SSOT) —
+see "Layout modes", "Mode detection", and "Mandatory items by mode". A
+**plugin root** is the directory holding `.claude-plugin/plugin.json` and
+`skills/`.
 
-1. `plugins/*/` → each directory is a plugin.
-2. `plugins/<p>/skills/*/` → each directory is a skill of that plugin.
+1. **Detect mode** by the spec's priority order: `--single`/`--mono` flag →
+   `marketplace.json` `plugins[].source` (`"./"`⇒single, `"./plugins/.."`⇒
+   mono) → filesystem fallback → ambiguous defaults to `mono` (header
+   notes `(추정)`).
+2. **Plugin roots**: `mono` → each `plugins/*/`; `single` → repo root `./`
+   (exactly one).
+3. **Skills** (both modes, dynamic — never hard-code names): `<root>/skills/*/`
+   → each directory is a skill of that plugin root.
 
-Record the plugin and skill lists for the report header and for the
-per-skill recommended checks (R1/R2/R5).
+Record the detected mode, plugin-root list, and skill list for the report
+header and the per-skill recommended checks (R1/R2/R5).
 
 ## Step 3: Evaluate M1-M6 and R1-R5
 
@@ -58,6 +70,11 @@ For each item in `references/structure-spec.md`, assign exactly one of:
 - **FAIL** — mandatory item missing/invalid (M1-M6 only).
 - **N/A** — the subject does not exist (e.g. a plugin with 0 skills → its
   R1/R2 are N/A, not FAIL).
+
+M2/M3/M4 check **paths** are mode-dependent (see the spec's per-mode
+M-grid); IDs, counts, and validation logic are identical across modes.
+M5/M6 and R1/R2/R5 are mode-independent — only the skill-discovery path is
+plugin-root relative.
 
 JSON validity (M1, M3): parse with `python3 -m json.tool` (or `jq`); a
 parse error is FAIL, not WARN. Frontmatter validity (M4): the SKILL.md must
@@ -70,8 +87,8 @@ path string (relative or Pages-absolute) — missing either → WARN; no skills
 ## Step 4: Output the Report
 
 Read `references/report-template.md` for the exact format. The report has a
-header line (path + discovered plugins/skills), a `[필수]` block (M1-M6) and
-a `[권장]` block (R1-R5), then the summary verdict:
+header line (path + detected mode + discovered plugins/skills), a `[필수]`
+block (M1-M6) and a `[권장]` block (R1-R5), then the summary verdict:
 
 - any FAIL → **FAIL**
 - no FAIL but ≥1 WARN → **WARN**
@@ -87,5 +104,7 @@ Emit the next-action hint **only when** there is ≥1 FAIL or WARN.
   yields N/A for dependent checks.
 - Do not audit SKILL.md *content* (that is `skill:check`) or shell script
   quality (that is `sh:check`) — only the directory structure.
-- Repo-agnostic: discover plugins/skills by scan; the spec is embedded, not
-  read from the target repo.
+- Repo-agnostic: detect mode + discover plugin roots/skills by scan; the
+  spec is embedded, not read from the target repo. A `--single`/`--mono`
+  override means "score by *that* mode" — a wrong override surfaces as a
+  normal M2 FAIL, never a silent skip.

--- a/claude/skills/claude-plugin-structure-check/references/help.md
+++ b/claude/skills/claude-plugin-structure-check/references/help.md
@@ -1,20 +1,35 @@
 /claude-plugin:structure-check — Audit a claude-plugin marketplace repo's structure
 
 Usage:
-  /claude-plugin:structure-check [repo-path]
+  /claude-plugin:structure-check [repo-path] [--single | --mono]
   /claude-plugin:structure-check help
 
 Arguments:
   [repo-path]   Path to the claude-plugin repo to audit (optional).
                 Defaults to the current directory.
 
-What it checks (read-only — never edits):
+Options:
+  --single      Force the single layout (repo itself is one plugin;
+                marketplace source "./", skills at root skills/<s>/).
+  --mono        Force the mono layout (repo bundles many plugins;
+                source "./plugins/<name>", skills at plugins/<p>/skills/<s>/).
+                --single / --mono override auto-detection (last one wins).
+
+Layout modes & auto-detection:
+  Without a flag the mode is detected in priority order:
+    1. --single / --mono flag (if given)
+    2. marketplace.json plugins[].source  ("./" => single, "./plugins/.." => mono)
+    3. filesystem fallback  (plugins/*/ => mono ; root plugin.json => single)
+    4. still ambiguous => defaults to mono, header marks "(추정)"
+  The detected mode is printed in the report header.
+
+What it checks (read-only — never edits; paths shown for mono | single):
 
   Mandatory (M1-M6 — missing → FAIL)
     M1  .claude-plugin/marketplace.json        exists + valid JSON
-    M2  plugins/ with >=1 plugin               at least one plugin
-    M3  plugins/<p>/.claude-plugin/plugin.json exists + valid JSON
-    M4  plugins/<p>/skills/<s>/SKILL.md        exists + name/description
+    M2  >=1 plugin root                         plugins/<p>/ | root plugin.json
+    M3  plugin.json valid                       plugins/<p>/.claude-plugin/ | root .claude-plugin/
+    M4  SKILL.md valid                          plugins/<p>/skills/<s>/ | skills/<s>/
     M5  docs/skill-guides/ + docs/skill-output/ both directories exist
     M6  README.md                              exists
 
@@ -25,8 +40,10 @@ What it checks (read-only — never edits):
     R4  naming consistency                     name: colon ↔ directory hyphen
     R5  per-skill README guide+usage links     README links both for each skill
 
-Each item reports PASS / WARN / FAIL / N/A. N/A means the subject does not
-exist (e.g. a plugin with 0 skills → R1/R2/R5 are N/A).
+M5/M6 and R1-R5 are mode-independent — only the M2/M3/M4 check paths and
+skill discovery differ between modes. Each item reports PASS / WARN / FAIL /
+N/A. N/A means the subject does not exist (e.g. a plugin with 0 skills →
+R1/R2/R5 are N/A).
 
 Verdict:
   any FAIL → FAIL ; no FAIL but >=1 WARN → WARN ; all PASS/N/A → PASS
@@ -34,6 +51,8 @@ Verdict:
 Examples:
   /claude-plugin:structure-check
   /claude-plugin:structure-check ../claude-plugin-visuals
+  /claude-plugin:structure-check ../superpowers --single
+  /claude-plugin:structure-check . --mono
   /claude-plugin:structure-check help
 
 Sister skill:

--- a/claude/skills/claude-plugin-structure-check/references/report-template.md
+++ b/claude/skills/claude-plugin-structure-check/references/report-template.md
@@ -2,9 +2,11 @@
 
 Use this exact format when outputting the audit report.
 
+### Example — mono (multi-plugin bundle)
+
 ```
 claude-plugin structure check — <repo-path>
-  plugins: <p1> / <p2>   skills: <count>   (git: yes|no)
+  mode: mono (source "./plugins/..")   plugins: <p1> / <p2>   skills: <count>   (git: yes|no)
 
 [필수]
  PASS  M1 .claude-plugin/marketplace.json (유효)
@@ -25,6 +27,33 @@ claude-plugin structure check — <repo-path>
 → Fix: /claude-plugin:structure-refactor <repo-path>  (먼저 dry-run, 이후 --apply)
 ```
 
+### Example — single (repo is one plugin)
+
+```
+claude-plugin structure check — <repo-path>
+  mode: single (source "./")   plugins: . (root)   skills: 4   (git: yes)
+
+[필수]
+ PASS  M1 .claude-plugin/marketplace.json (유효, source "./")
+ PASS  M2 root .claude-plugin/plugin.json (plugin root 1개)
+ PASS  M3 .claude-plugin/plugin.json (유효)
+ PASS  M4 skills/<s>/SKILL.md (4개 모두 name/description 보유)
+ PASS  M5 docs/skill-guides/, docs/skill-output/
+ PASS  M6 README.md
+
+[권장]
+ PASS  R1 docs/skill-guides/<s>.html (4개 모두 존재)
+ PASS  R2 docs/skill-output/<s>-usage.{html,md}
+ PASS  R3 README.md 가 docs/ 로 링크 (Simple)
+ PASS  R4 명명 일관성
+ PASS  R5 README 가 스킬별 guide+usage 링크 보유
+
+요약: PASS — 표준 구조 준수
+```
+
+When the mode was inferred by the ambiguous fallback, append `, 추정` —
+`mode: mono (추정)`.
+
 ## Layout rules
 
 - One line per item: `<RESULT>  <ID> <subject> <note>`.
@@ -34,8 +63,10 @@ claude-plugin structure check — <repo-path>
 - R5 is per-skill: when more than one skill misses a link, emit one R5 line
   naming the first offender (or summarize `<n>개 스킬`); a clean repo → PASS,
   no skills → N/A.
-- Header line names the discovered plugins and total skill count — proof
-  the scan was dynamic, not hard-coded.
+- Header line names the **detected mode** (with the deciding signal:
+  `source "./"`, `source "./plugins/.."`, or `추정`), the discovered
+  plugins, and total skill count — proof the scan + mode detection were
+  dynamic, not hard-coded. In `single` mode the plugins field is `. (root)`.
 
 ## Summary line
 

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -11,12 +11,29 @@ edits a repo toward it (dry-run / `--apply`). Plugins and skills are
 discovered **dynamically** by directory scan — the spec is abstract, never
 repo-specific.
 
-## Golden layout
+## Layout modes
+
+The official plugin spec allows two valid layouts. **`single` is the more
+common one** in the wild (Superpowers, most OSS/personal plugins); `mono` is
+the team standard (`anthropics/claude-code` bundles 13 plugins this way).
+
+| | `mono` | `single` |
+|---|---|---|
+| marketplace `source` | `"./plugins/<name>"` | `"./"` |
+| plugin roots | each `plugins/<p>/` | repo root `./` (exactly 1) |
+| skill path | `plugins/<p>/skills/<s>/` | `skills/<s>/` |
+
+A **plugin root** is the directory holding the plugin manifest
+(`.claude-plugin/plugin.json`) and `skills/`. Defining M3/M4/R1/R2/R4/R5
+over the *plugin-root set* makes them mode-agnostic — only "how the
+plugin-root set is computed" differs between modes (Approach C, #914).
+
+### Golden layout — mono
 
 ```
 .
 ├── .claude-plugin/marketplace.json      # exists + valid JSON       (M1)
-├── plugins/<plugin>/
+├── plugins/<plugin>/                     # plugin root
 │   ├── .claude-plugin/plugin.json       # exists + valid JSON       (M3)
 │   └── skills/<skill>/SKILL.md          # exists + name/description (M4)
 ├── docs/skill-guides/                   # directory exists          (M5)
@@ -24,20 +41,49 @@ repo-specific.
 └── README.md                            # exists                    (M6)
 ```
 
-Dynamic discovery order:
-1. `plugins/*/` → each is a plugin.
-2. `plugins/*/skills/*/` → each is a skill of that plugin.
+### Golden layout — single
 
-## Mandatory items (FAIL when missing)
+```
+.                                         # repo root IS the plugin root
+├── .claude-plugin/
+│   ├── marketplace.json                 # exists + valid JSON, source "./" (M1)
+│   └── plugin.json                      # exists + valid JSON       (M3)
+├── skills/<skill>/SKILL.md              # exists + name/description (M4)
+├── docs/skill-guides/                   # directory exists          (M5)
+├── docs/skill-output/                   # directory exists          (M5)
+└── README.md                            # exists                    (M6)
+```
 
-| ID | Item | FAIL condition |
-|----|------|----------------|
-| M1 | `.claude-plugin/marketplace.json` | missing or invalid JSON |
-| M2 | `plugins/` dir with ≥1 plugin | missing or 0 plugins |
-| M3 | each `plugins/<p>/.claude-plugin/plugin.json` | missing or invalid JSON |
-| M4 | each `plugins/<p>/skills/<s>/SKILL.md` | missing or frontmatter lacks `name`/`description` |
-| M5 | `docs/skill-guides/` AND `docs/skill-output/` | either directory missing |
-| M6 | `README.md` | missing |
+## Mode detection (priority order — first match wins)
+
+1. **`--single` / `--mono` flag** → forced override (highest authority).
+2. **`marketplace.json` `plugins[].source`** → `"./"` ⇒ single,
+   `"./plugins/.."` ⇒ mono (most authoritative *signal* when unflagged).
+3. **Filesystem fallback** → `plugins/*/` exists ⇒ mono; root
+   `.claude-plugin/plugin.json` exists ⇒ single.
+4. **Still ambiguous** → default `mono`, header notes `(mode: mono, 추정)`.
+
+A forced override is honored even when wrong — it means "score *as* this
+mode". An invalid combo (e.g. `--mono` with no `plugins/`) then yields a
+normal M2 FAIL, never a silent skip.
+
+## Mandatory items by mode (FAIL when missing)
+
+IDs, counts, and validation logic are identical across modes — only the
+checked **path** changes (M5/M6 are mode-independent).
+
+| ID | Item | mono path | single path |
+|----|------|-----------|-------------|
+| M1 | marketplace.json valid | `.claude-plugin/marketplace.json` | **same** |
+| M2 | ≥1 plugin root | `plugins/` has ≥1 plugin | root `.claude-plugin/plugin.json` exists (=1 root) |
+| M3 | each plugin.json valid | `plugins/<p>/.claude-plugin/plugin.json` | root `.claude-plugin/plugin.json` |
+| M4 | each SKILL.md valid | `plugins/<p>/skills/<s>/SKILL.md` | `skills/<s>/SKILL.md` |
+| M5 | docs dirs exist | `docs/skill-guides/` AND `docs/skill-output/` | **same** |
+| M6 | README.md | `README.md` | **same** |
+
+FAIL conditions: M1/M3 → missing or invalid JSON; M2 → 0 plugin roots;
+M4 → missing or frontmatter lacks `name`/`description`; M5 → either dir
+missing; M6 → missing.
 
 ## Recommended items (WARN when missing)
 
@@ -77,10 +123,13 @@ anywhere, so it cannot catch a per-skill link gap — R5 does.
 
 When the subject of a check does not exist, the check is **N/A**, not FAIL.
 Examples: a plugin with 0 skills → R1/R2/R5 are N/A for that plugin; with no
-plugins at all M3 is N/A and with no skills anywhere M4 **and R5** are N/A —
-M2 still carries the single "no plugins" FAIL, so the absent subject is never
-double-counted as a second FAIL. R5 is per-skill: with no skills there is no
-link to require, so it is N/A (never FAIL).
+**plugin roots** M3 is N/A and with no skills anywhere M4 **and R5** are N/A —
+M2 still carries the single "no plugin root" FAIL, so the absent subject is
+never double-counted as a second FAIL. This holds per mode: in `single` a
+missing root `.claude-plugin/plugin.json` means 0 plugin roots, so M2 FAILs
+and M3/M4 are N/A — exactly mirroring mono's "0 plugins" case. R5 is
+per-skill: with no skills there is no link to require, so it is N/A (never
+FAIL).
 
 ## Summary verdict
 

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -57,8 +57,9 @@ plugin-root set is computed" differs between modes (Approach C, #914).
 ## Mode detection (priority order — first match wins)
 
 1. **`--single` / `--mono` flag** → forced override (highest authority).
-2. **`marketplace.json` `plugins[].source`** → `"./"` ⇒ single,
-   `"./plugins/.."` ⇒ mono (most authoritative *signal* when unflagged).
+2. **`marketplace.json` `plugins[].source`** → `"./"` (or `"."`) ⇒ single,
+   `"./plugins/.."` (or bare `"plugins/.."`) ⇒ mono — the leading `./` is
+   optional, matched leniently (most authoritative *signal* when unflagged).
 3. **Filesystem fallback** → `plugins/*/` exists ⇒ mono; root
    `.claude-plugin/plugin.json` exists ⇒ single.
 4. **Still ambiguous** → default `mono`, header notes `(mode: mono, 추정)`.

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -60,7 +60,7 @@ _cps_detect_mode() {
         _src="$(jq -r '.plugins[]? | if type=="object" then .source else . end' "$_mf" 2>/dev/null | head -n1)"
         case "$_src" in
         ./ | .) echo single && return ;;
-        ./plugins/*) echo mono && return ;;
+        plugins/* | ./plugins/*) echo mono && return ;;
         esac
     fi
     # filesystem fallback.

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -39,39 +39,107 @@ _cps_skills() {
     done
 }
 
+# ---- mode detection + plugin-root abstraction (#914) ---------------------
+# A "plugin root" is the dir holding .claude-plugin/plugin.json and skills/.
+#   mono   -> each plugins/<p>/   single -> the repo root "." (exactly one).
+# Defining M3/M4/R1/R2/R4/R5 over the plugin-root set makes them mode-agnostic
+# (Approach C in structure-spec.md): only HOW the root set is computed differs.
+
+_cps_detect_mode() {
+    # $1=repo [$2=forced: single|mono] -> echo single|mono (priority order).
+    local _repo="$1" _forced="${2:-}" _mf _src
+    case "$_forced" in
+    single | mono)
+        echo "$_forced"
+        return
+        ;;
+    esac
+    # marketplace.json plugins[].source — most authoritative unflagged signal.
+    _mf="$_repo/.claude-plugin/marketplace.json"
+    if _cps_json_ok "$_mf"; then
+        _src="$(jq -r '.plugins[]? | if type=="object" then .source else . end' "$_mf" 2>/dev/null | head -n1)"
+        case "$_src" in
+        ./ | .) echo single && return ;;
+        ./plugins/*) echo mono && return ;;
+        esac
+    fi
+    # filesystem fallback.
+    if [ -d "$_repo/plugins" ] && [ -n "$(_cps_plugins "$_repo")" ]; then
+        echo mono
+        return
+    fi
+    [ -f "$_repo/.claude-plugin/plugin.json" ] && {
+        echo single
+        return
+    }
+    echo mono # still ambiguous -> default (header marks "추정")
+}
+
+_cps_plugin_roots() {
+    # $1=repo $2=mode -> plugin-root paths RELATIVE to repo, one per line.
+    #   single: "." iff the root manifest exists (so a missing manifest yields
+    #           0 roots -> M3/M4 N/A, with M2 owning the single FAIL, mirroring
+    #           the mono "0 plugins" rule). mono: plugins/<p> per dir.
+    local _repo="$1" _mode="$2" _p
+    if [ "$_mode" = single ]; then
+        [ -f "$_repo/.claude-plugin/plugin.json" ] && echo "."
+        return
+    fi
+    [ -d "$_repo/plugins" ] || return 0
+    for _p in "$_repo"/plugins/*/; do
+        [ -d "$_p" ] || continue
+        echo "plugins/$(basename "$_p")"
+    done
+}
+
+_cps_skills_in_root() {
+    # $1=repo $2=root(relative) -> skill basenames under <root>/skills/.
+    local _sd="$1/$2/skills"
+    [ -d "$_sd" ] || return 0
+    for _s in "$_sd"/*/; do
+        [ -d "$_s" ] || continue
+        basename "$_s"
+    done
+}
+
 # ---- mandatory checks (M1-M6) -- echo PASS|FAIL -------------------------
 cps_check_M1() { _cps_json_ok "$1/.claude-plugin/marketplace.json" && echo PASS || echo FAIL; }
 
 cps_check_M2() {
-    [ "$(_cps_plugins "$1" | grep -c .)" -ge 1 ] && echo PASS || echo FAIL
+    # ≥1 plugin root. mono: plugins/<p>/ dirs; single: root manifest exists.
+    local _mode
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    [ "$(_cps_plugin_roots "$1" "$_mode" | grep -c .)" -ge 1 ] && echo PASS || echo FAIL
 }
 
 cps_check_M3() {
-    # every plugin must carry a valid plugin.json
-    local _p _any=0
-    while IFS= read -r _p; do
-        [ -n "$_p" ] || continue
+    # every plugin root must carry a valid plugin.json
+    local _mode _root _any=0
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
         _any=1
-        _cps_json_ok "$1/plugins/$_p/.claude-plugin/plugin.json" || {
+        _cps_json_ok "$1/$_root/.claude-plugin/plugin.json" || {
             echo FAIL
             return
         }
     done <<EOF
-$(_cps_plugins "$1")
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
-    # No plugins → subject absent → N/A (M2 already owns the "0 plugins" FAIL).
+    # No plugin roots → subject absent → N/A (M2 already owns the FAIL).
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
 cps_check_M4() {
     # every skill must have a SKILL.md with name: and description:
-    local _p _s _any=0 _sm
-    while IFS= read -r _p; do
-        [ -n "$_p" ] || continue
+    local _mode _root _s _any=0 _sm
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
             _any=1
-            _sm="$1/plugins/$_p/skills/$_s/SKILL.md"
+            _sm="$1/$_root/skills/$_s/SKILL.md"
             [ -f "$_sm" ] || {
                 echo FAIL
                 return
@@ -81,10 +149,10 @@ cps_check_M4() {
                 return
             fi
         done <<EOF
-$(_cps_skills "$1" "$_p")
+$(_cps_skills_in_root "$1" "$_root")
 EOF
     done <<EOF
-$(_cps_plugins "$1")
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
     # No skills anywhere → subject absent → N/A, not FAIL (N/A rule).
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
@@ -98,10 +166,12 @@ cps_check_M6() { [ -f "$1/README.md" ] && echo PASS || echo FAIL; }
 
 # ---- recommended checks (R1-R5) -- echo PASS|WARN|N/A -------------------
 cps_check_R1() {
-    # per-skill docs/skill-guides/<skill>.html ; N/A if no skills
-    local _p _s _any=0
-    while IFS= read -r _p; do
-        [ -n "$_p" ] || continue
+    # per-skill docs/skill-guides/<skill>.html ; N/A if no skills. Docs paths
+    # are repo-level (mode-independent); only skill discovery is plugin-root.
+    local _mode _root _s _any=0
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
             _any=1
@@ -110,18 +180,19 @@ cps_check_R1() {
                 return
             }
         done <<EOF
-$(_cps_skills "$1" "$_p")
+$(_cps_skills_in_root "$1" "$_root")
 EOF
     done <<EOF
-$(_cps_plugins "$1")
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
 cps_check_R2() {
-    local _p _s _any=0
-    while IFS= read -r _p; do
-        [ -n "$_p" ] || continue
+    local _mode _root _s _any=0
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
             _any=1
@@ -131,10 +202,10 @@ cps_check_R2() {
                 return
             }
         done <<EOF
-$(_cps_skills "$1" "$_p")
+$(_cps_skills_in_root "$1" "$_root")
 EOF
     done <<EOF
-$(_cps_plugins "$1")
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
@@ -150,12 +221,13 @@ cps_check_R3() {
 
 cps_check_R4() {
     # naming: SKILL.md name: colon-namespace ↔ skill directory hyphen form.
-    local _p _s _any=0 _sm _name _expect
-    while IFS= read -r _p; do
-        [ -n "$_p" ] || continue
+    local _mode _root _s _any=0 _sm _name _expect
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
-            _sm="$1/plugins/$_p/skills/$_s/SKILL.md"
+            _sm="$1/$_root/skills/$_s/SKILL.md"
             [ -f "$_sm" ] || continue
             _any=1
             # strip leading `name:` + surrounding spaces/quotes (single & double)
@@ -166,10 +238,10 @@ cps_check_R4() {
                 return
             }
         done <<EOF
-$(_cps_skills "$1" "$_p")
+$(_cps_skills_in_root "$1" "$_root")
 EOF
     done <<EOF
-$(_cps_plugins "$1")
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
@@ -183,9 +255,10 @@ cps_check_R5() {
         echo "N/A"
         return
     }
-    local _p _s _any=0
-    while IFS= read -r _p; do
-        [ -n "$_p" ] || continue
+    local _mode _root _s _any=0
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
             _any=1
@@ -199,27 +272,28 @@ cps_check_R5() {
                 return
             }
         done <<EOF
-$(_cps_skills "$1" "$_p")
+$(_cps_skills_in_root "$1" "$_root")
 EOF
     done <<EOF
-$(_cps_plugins "$1")
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
 # ---- aggregate verdict ---------------------------------------------------
 cps_verdict() {
-    # echo FAIL | WARN | PASS for repo $1
-    local _r
+    # echo FAIL | WARN | PASS for repo $1 ; optional $2 forces single|mono.
+    # M5/M6/R3 are mode-independent so the extra arg is harmless for them.
+    local _r _mode="${2:-}"
     for _c in M1 M2 M3 M4 M5 M6; do
-        _r="$(cps_check_$_c "$1")"
+        _r="$(cps_check_$_c "$1" "$_mode")"
         [ "$_r" = FAIL ] && {
             echo FAIL
             return
         }
     done
     for _c in R1 R2 R3 R4 R5; do
-        _r="$(cps_check_$_c "$1")"
+        _r="$(cps_check_$_c "$1" "$_mode")"
         [ "$_r" = WARN ] && {
             echo WARN
             return

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -312,3 +312,111 @@ build_perfect() {
     run jq -r '.skills | length' "$REPO/plugins/demo/.claude-plugin/plugin.json"
     assert_output 2
 }
+
+# ---- single layout mode (#914) ------------------------------------------
+# single = the repo itself is one plugin: marketplace source "./", plugin
+# manifest at the repo root, skills at root skills/<s>/ (no plugins/ dir).
+
+_seed_single_skill() {
+    # $1=repo  builds root-level skills/visualize/SKILL.md (name matches dir)
+    mkdir -p "$1/skills/visualize"
+    printf 'name: visualize\ndescription: demo skill\n' \
+        > "$1/skills/visualize/SKILL.md"
+}
+
+_seed_single_mandatory_json() {
+    # marketplace source "./" (single signal) + root plugin.json manifest
+    mkdir -p "$1/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "source": "./" }] }\n' \
+        > "$1/.claude-plugin/marketplace.json"
+    printf '{ "name": "repo", "version": "0.0.0", "skills": ["./skills/visualize"] }\n' \
+        > "$1/.claude-plugin/plugin.json"
+}
+
+build_single_perfect() {
+    _seed_single_skill "$1"; _seed_single_mandatory_json "$1"; _seed_docs_dirs "$1"
+    _seed_readme "$1"; _seed_recommended_files "$1"; _seed_readme_links "$1" visualize
+}
+
+@test "mode auto-detects single from marketplace source \"./\"" {
+    build_single_perfect "$REPO"
+    run _cps_detect_mode "$REPO"
+    assert_output single
+}
+
+@test "mode auto-detects mono from a plugins/ layout" {
+    build_perfect "$REPO"
+    run _cps_detect_mode "$REPO"
+    assert_output mono
+}
+
+@test "mode auto-detects single from root plugin.json (no marketplace source)" {
+    # filesystem fallback: no plugins/, root manifest present
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "version": "0.0.0" }\n' > "$REPO/.claude-plugin/plugin.json"
+    run _cps_detect_mode "$REPO"
+    assert_output single
+}
+
+@test "mode defaults to mono when ambiguous (no signals)" {
+    mkdir -p "$REPO"; _seed_readme "$REPO"
+    run _cps_detect_mode "$REPO"
+    assert_output mono
+}
+
+@test "single perfect repo -> verdict PASS (no false M2/M3/M4 FAIL)" {
+    build_single_perfect "$REPO"
+    run cps_verdict "$REPO"
+    assert_success
+    assert_output PASS
+}
+
+@test "single repo scores M2/M3/M4 at the ROOT (#914 false-FAIL fix)" {
+    # The core regression: before mode support, a single repo (no plugins/)
+    # falsely FAILed M2/M3/M4. With auto-detect they pass at the root.
+    build_single_perfect "$REPO"
+    run cps_check_M2 "$REPO"; assert_output PASS
+    run cps_check_M3 "$REPO"; assert_output PASS
+    run cps_check_M4 "$REPO"; assert_output PASS
+}
+
+@test "single repo: M5/R1/R2/R5 apply mode-independently" {
+    build_single_perfect "$REPO"
+    run cps_check_M5 "$REPO"; assert_output PASS
+    run cps_check_R1 "$REPO"; assert_output PASS
+    run cps_check_R2 "$REPO"; assert_output PASS
+    run cps_check_R5 "$REPO"; assert_output PASS
+}
+
+@test "single repo missing root manifest -> M2 FAIL, M3 N/A (not double FAIL)" {
+    _seed_single_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "source": "./" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"   # marketplace only, no plugin.json
+    run cps_check_M2 "$REPO"; assert_output FAIL
+    run cps_check_M3 "$REPO"; assert_output "N/A"
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+# ---- forced override (--single / --mono) --------------------------------
+
+@test "forced --mono on a single repo -> M2 FAIL (override scores as mono)" {
+    # override means 'score by THIS mode' — a wrong override surfaces as a
+    # normal M2 FAIL (no plugins/ dir), never a silent skip.
+    build_single_perfect "$REPO"
+    run cps_check_M2 "$REPO" mono; assert_output FAIL
+}
+
+@test "forced --single on a mono repo -> M2 FAIL (no root manifest)" {
+    build_perfect "$REPO"   # mono: manifest under plugins/demo, not root
+    run cps_check_M2 "$REPO" single; assert_output FAIL
+}
+
+@test "forced --single honored even when marketplace says mono" {
+    build_single_perfect "$REPO"
+    # corrupt the signal: claim mono in marketplace, but force single
+    printf '{ "name": "repo", "plugins": [{ "source": "./plugins/x" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run _cps_detect_mode "$REPO" single; assert_output single
+    run cps_verdict "$REPO" single; assert_output PASS
+}

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -350,6 +350,15 @@ build_single_perfect() {
     assert_output mono
 }
 
+@test "mode auto-detects mono from a bare 'plugins/..' source (no leading ./)" {
+    # gemini #917 review: hand-written marketplace may omit the leading ./
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "source": "plugins/demo" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run _cps_detect_mode "$REPO"
+    assert_output mono
+}
+
 @test "mode auto-detects single from root plugin.json (no marketplace source)" {
     # filesystem fallback: no plugins/, root manifest present
     mkdir -p "$REPO/.claude-plugin"


### PR DESCRIPTION
## 요약

`claude-plugin:structure-check` 를 **mono 단일 기준**에서 **mono + single 양쪽**을 감사하도록 확장한다. 그동안 single 레포(루트 `skills/`, 예: Superpowers)를 감사하면 M2/M3/M4 가 오탐 FAIL 났는데, 이는 레포가 망가진 게 아니라 모드 불일치였다.

브레인스토밍 합의된 **Approach C (plugin-root 추상화)** 채택 — 평가 로직·리포트 템플릿을 거의 손대지 않고 모드 차이를 한 곳으로 격리.

## 변경 내용 (커밋 `3edc8a21`)

- **모드 자동 감지** (우선순위): `--single`/`--mono` 플래그 → `marketplace.json` `plugins[].source` (`"./"`⇒single, `"./plugins/.."`⇒mono) → 파일시스템 폴백 → 모호 시 `mono`(추정)
- **plugin-root 추상화**: M3/M4/R1/R2/R4/R5 를 "plugin root 집합" 위에서 한 번만 정의 — 모드 차이는 "root 집합을 어떻게 구하나" 한 곳으로 격리
- **모드별 M2/M3/M4 검사 경로만 변경**, ID·개수·검증 로직 및 M5/M6/R* 의미는 불변 (docs 컨벤션은 모드 무관 동일 적용)
- **리포트 헤더**에 감지/지정 모드 표기 + single 예시 추가
- single 루트 manifest 부재 시 **M2 FAIL + M3/M4 N/A** (mono "0 plugins" 규칙 미러 — 이중 카운트 방지)

### 문서 (SSOT)
- `SKILL.md` — Step 1 플래그 파싱, Step 2 "모드 감지 → plugin-root 산출 → root별 스킬 탐색" 재작성
- `references/structure-spec.md` — Layout modes / 모드 감지 / 모드별 M-grid / mono·single golden layout 2개
- `references/report-template.md` — `mode:` 헤더 필드 + single 리포트 예시
- `references/help.md` — `--single`/`--mono` + 자동감지 우선순위 문서화

### 테스트
- bats fixture(`_fixtures/claude_plugin_structure.sh`)를 plugin-root 기반으로 재작성 — **mono 회귀 0**
- single 모드 / 모드 자동감지 / forced override 검증 **11개 신규** → structure-check **38/38 PASS**

## 검증
- structure-check bats 38/38 PASS, shfmt `-i 4` clean, shellcheck 신규 findings 0 (기존 SC2016 info 3개 동일)
- 전체 suite: 내 변경으로 인한 **신규 실패 0** — 변경 stash 후 baseline 재실행으로 동일한 기존 실패(worktree canonicalize, codex budget 포맷, gh:pr helper drift, ai-metrics doc-guard)만 확인. 모두 #914 범위 밖.

## 하위호환
플래그 없고 mono 레포면 동작 100% 동일. 기존 mono 사용자 영향 없음.

## 범위 밖 (후속 이슈 검토)
자매 스킬 `claude-plugin:structure-refactor` 의 동일 모드 인식 — 본 이슈 범위 밖.

Closes #914

<!-- ai-metrics -->
<details>
<summary>📊 AI Metrics</summary>

- 📊 tokens: ~85k
- 👤 human-time: ~6m
- 🤖 ai-time: ~44m

</details>
