### PR TITLE
feat(structure-refactor): #915 mono/single 모드 인식 + 레이아웃 변환 안전 가드

### DIFF
--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -7,6 +7,10 @@ description: >-
   only (create dirs, `git mv`, minimal marketplace.json/plugin.json
   skeletons); `--op`/`--recommended` adds recommended R1-R5 fixes (empty
   placeholder stubs + naming correction + README link backfill). Idempotent.
+  Supports both `mono` (`plugins/<p>/skills/`) and `single` (repo-root
+  `skills/`) layouts — auto-detected, or forced with `--single` / `--mono`;
+  it fixes toward the detected mode's golden layout and never converts
+  single↔mono (that is an out-of-scope, guarded no-op).
   Use when the user
   says "fix my claude-plugin repo structure", "make this marketplace repo
   standard", "/claude-plugin:structure-refactor". Sister skills:
@@ -39,32 +43,61 @@ Positional `[repo-path]` (default = current dir). Flags:
 - `--apply` — execute changes. Absent → dry-run (plan only, no writes).
 - `--mandatory` / `--mp` — scope = M1-M6 only (default scope).
 - `--recommended` / `--op` — scope = M1-M6 + R1-R5.
+- `--single` / `--mono` — force the **target** layout mode, overriding
+  auto-detection (Step 2). Mutually exclusive; if both given, last wins.
 - `--mp` and `--op` together → error + usage, stop.
 
 Confirm the path exists. `test -d <path>/.git`: not a git repo → warn (moves
 fall back to `mv`). Dirty tree → show the dry-run plan and require an
 explicit `--apply` before writing (never auto-apply on a dirty tree).
 
-## Step 2: Evaluate Current ↔ Target
+## Step 2: Detect Mode + Compute Plugin Roots + Evaluate Current ↔ Target
 
 Read `references/structure-spec.md` (embedded SSOT — identical copy to
-structure-check's). Run the same M1-M6 / R1-R5 evaluation as
-`claude-plugin:structure-check` to compute the current → target diff.
-Discover plugins/skills dynamically (`plugins/*/`, `plugins/*/skills/*/`).
+structure-check's) — see "Layout modes", "Mode detection", "Mode override =
+layout conversion", and "Mandatory items by mode".
+
+1. **Detect the current mode** from the *signals* only (independent of any
+   flag): `marketplace.json` `plugins[].source` (`"./"`⇒single,
+   `"./plugins/.."`⇒mono) → filesystem fallback → ambiguous defaults to
+   `mono` (header notes `(추정)`). A `--single`/`--mono` flag sets the
+   **target** mode (priority 1 in the spec) but does not change what the
+   current layout *is*.
+2. **Conversion guard** — if a forced `--single`/`--mono` names a mode that
+   **differs from the detected current layout**, that is a single↔mono
+   *conversion* (relocate the whole plugin + rewrite the manifest), which is
+   **out of scope**. Emit the `[convert]` warning line in the plan and, under
+   `--apply`, **stop without writing** (fail-safe). Do not proceed to a
+   partial move. See the spec's "Mode override = layout conversion".
+3. **Compute the plugin-root set** for the chosen mode: `mono` → each
+   `plugins/*/`; `single` → repo root `./` (exactly one).
+4. **Discover skills** (both modes, dynamic — never hard-code names):
+   `<root>/skills/*/`. Run the same M1-M6 / R1-R5 evaluation as
+   `claude-plugin:structure-check` over the plugin-root set to compute the
+   current → target diff. Record the detected/forced mode for the plan and
+   report header.
 
 ## Step 3: Build the Plan
 
 Read `references/plan-and-report-templates.md`. Produce an ordered change
 list, each tagged with its driving check ID (M1-M6, and R1-R5 only when
-scope is `--op`). Already-correct items produce no action (idempotent).
+scope is `--op`). Action **paths are plugin-root relative** — single targets
+root `./` (no `plugins/` dir is ever created); mono targets `plugins/<p>/`.
+Already-correct items produce no action (idempotent). The plan header states
+the detected/forced mode; a needed-but-unsupported conversion produces only
+the `[convert]` warning line.
 
 ## Step 4: Dry-run or Apply
 
 - **Dry-run (default)**: print the plan only. Touch nothing.
+- **Conversion required (forced mode ≠ detected)**: print the `[convert]`
+  warning and stop — even under `--apply`, write nothing.
 - **`--apply`**: execute the plan in order, per
   `references/plan-and-report-templates.md` → "Apply rules":
   - create missing dirs: `.claude-plugin/`, `docs/skill-guides/`,
-    `docs/skill-output/`, `plugins/<p>/skills/`;
+    `docs/skill-output/`, and the per-plugin-root `skills/` — for `mono`
+    that is `plugins/<p>/skills/`, for `single` it is root `skills/` (no
+    `plugins/` directory is created);
   - move misplaced files with `git mv` when possible (else `mv`);
   - write minimal skeletons for a missing `marketplace.json` / `plugin.json`
     (filled with discovered plugin/skill names);
@@ -98,4 +131,9 @@ a key=value summary, then the next-action hint:
   token scope or an unreachable host warns and continues — it never aborts
   the run.
 - Prefer `git mv` to preserve history; fall back to `mv` outside a git repo.
+- Mode-aware: fix toward the **detected** layout's golden form — `single`
+  never creates a `plugins/` directory; `mono` keeps the `plugins/<p>/…`
+  paths. A `--single`/`--mono` that differs from the detected current layout
+  is a single↔mono conversion: **out of scope** — warn and write nothing
+  (never a partial move), even under `--apply`.
 - Repo-agnostic: discover plugins/skills by scan; the spec is embedded.

--- a/claude/skills/claude-plugin-structure-refactor/references/help.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/help.md
@@ -1,7 +1,7 @@
 /claude-plugin:structure-refactor — Fix a claude-plugin marketplace repo's structure
 
 Usage:
-  /claude-plugin:structure-refactor [repo-path] [--apply] [--mp|--op]
+  /claude-plugin:structure-refactor [repo-path] [--apply] [--mp|--op] [--single|--mono]
   /claude-plugin:structure-refactor help
 
 Arguments:
@@ -14,7 +14,33 @@ Flags:
   --mandatory | --mp   Scope = mandatory items M1-M6 only. (default scope)
   --recommended | --op Scope = M1-M6 + recommended R1-R5 (placeholder stubs
                        + naming correction + README link backfill).
+  --single             Force the SINGLE target layout (repo itself is one
+                       plugin; marketplace source "./", skills at root
+                       skills/<s>/ — no plugins/ directory is created).
+  --mono               Force the MONO target layout (repo bundles many
+                       plugins; source "./plugins/<name>", skills at
+                       plugins/<p>/skills/<s>/). --single / --mono override
+                       auto-detection (last one wins).
   --mp and --op together → error.
+
+Layout modes & auto-detection:
+  Without a flag the CURRENT layout is detected (same priority as
+  /claude-plugin:structure-check):
+    1. --single / --mono flag (forces the TARGET mode)
+    2. marketplace.json plugins[].source  ("./" => single, "./plugins/.." => mono)
+    3. filesystem fallback  (plugins/*/ => mono ; root plugin.json => single)
+    4. still ambiguous => defaults to mono, header marks "(추정)"
+  Refactor fixes toward the detected mode's golden layout and prints the
+  mode in the plan/report header.
+
+Layout conversion is NOT supported (safety guard):
+  When --single/--mono names a TARGET mode different from the detected
+  CURRENT layout, that is a single<->mono conversion (relocate the whole
+  plugin + rewrite the manifest). Refactor does NOT perform it — the plan
+  shows a "[convert] ... 현재 미지원" line and --apply stops without writing.
+  Conversion is deferred to a follow-up (structure-convert). This guard
+  stops refactor from force-restructuring a valid single repo (e.g.
+  Superpowers) into mono and breaking upstream compatibility.
 
 Behavior:
 
@@ -47,6 +73,8 @@ Examples:
   /claude-plugin:structure-refactor --apply          # apply mandatory (= --mp)
   /claude-plugin:structure-refactor --apply --op     # apply mandatory + recommended
   /claude-plugin:structure-refactor --op             # dry-run, recommended scope
+  /claude-plugin:structure-refactor ../superpowers --single  # fix toward single layout
+  /claude-plugin:structure-refactor . --mono --apply # fix toward mono layout
   /claude-plugin:structure-refactor ../repo --apply
   /claude-plugin:structure-refactor help
 

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -3,8 +3,8 @@
 ## Plan template (dry-run AND the pre-amble of --apply)
 
 ```
-claude-plugin structure refactor — <repo-path>   (scope: mandatory|recommended)
-  plugins: <p1> / <p2>   skills: <count>   (git: yes|no, tree: clean|dirty)
+claude-plugin structure refactor — <repo-path>   (mode: mono|single[, 추정]  scope: mandatory|recommended)
+  plugin roots: <p1> / <p2>   skills: <count>   (git: yes|no, tree: clean|dirty)
 
 계획 (현재 → 목표):
   [M1] create  .claude-plugin/marketplace.json   (skeleton, 1 plugin)
@@ -20,6 +20,11 @@ claude-plugin structure refactor — <repo-path>   (scope: mandatory|recommended
 총 <n> 변경  (필수 <m>, 권장 <r>)
 ```
 
+- The header `mode:` is the detected (or forced) layout — `mono` /
+  `single`, with `, 추정` appended when detection was ambiguous (spec
+  priority 4). For `single` the action paths are root-relative (`skills/<s>/`,
+  root `.claude-plugin/plugin.json`) and **no `plugins/` directory is
+  created**; for `mono` they are `plugins/<p>/…` as shown above.
 - One line per change: `[<ID>] <verb>  <path / detail>`.
 - Verbs: `create` (new file), `mkdir` (new dir), `git mv` / `mv` (move),
   `visualize` (generate an R1 guide by delegating to `/devx:visualize`),
@@ -29,6 +34,24 @@ claude-plugin structure refactor — <repo-path>   (scope: mandatory|recommended
 - Items already correct produce **no line** (idempotent — proof there is
   nothing to do is an empty plan + `총 0 변경`).
 - R1-R5 lines appear only when scope is `--op` / `--recommended`.
+
+### Layout-conversion warning (forced mode ≠ detected mode)
+
+When `--single`/`--mono` forces a **target** mode that differs from the
+detected **current** layout, refactor does **not** convert (single↔mono is a
+whole-plugin relocation + manifest rewrite — out of scope). The plan shows a
+single warning line **in place of** any fix lines, and `--apply` stops
+without writing:
+
+```
+claude-plugin structure refactor — <repo-path>   (mode: single→mono  scope: mandatory)
+  plugin roots: . (single)   skills: <count>   (git: yes, tree: clean)
+
+  [convert] 레이아웃 변환 필요 (single → mono) — 현재 미지원, 변경 없음.
+            single↔mono 변환은 후속 작업(structure-convert)으로 분리됨.
+
+총 0 변경  (변환 미수행)
+```
 
 ## Apply rules
 
@@ -127,6 +150,7 @@ The full R5 guide URL is therefore
 ```
 ## claude-plugin:structure-refactor Report
 Repo: <repo-path>
+Layout: mono | single  (detected | forced[, 추정])
 Mode: dry-run | apply
 Scope: mandatory | recommended
 
@@ -135,8 +159,13 @@ Planned: <n>   Applied: <n>   Skipped (already correct): <n>
 <the plan block above, with applied lines marked ✓>
 
 [OK] refactor complete   |   [FAIL] <reason>
-applied=<n> moved=<n> created=<n> visualized=<n> stubbed=<n> pages=<activated|active|skip|n/a> linked=<n> mode=<dry-run|apply> scope=<mp|op>
+applied=<n> moved=<n> created=<n> visualized=<n> stubbed=<n> pages=<activated|active|skip|n/a> linked=<n> layout=<mono|single> mode=<dry-run|apply> scope=<mp|op>
 ```
+
+For a guarded layout-conversion (forced mode ≠ detected) the report is
+`[OK] no conversion (out of scope)` with `applied=0 layout=<from>→<to>` and
+the verify hint — never `[FAIL]` (refusing an out-of-scope move is a
+safe no-op, not an error).
 
 End with the next-action hint:
 

--- a/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
@@ -11,12 +11,34 @@ edits a repo toward it (dry-run / `--apply`). Plugins and skills are
 discovered **dynamically** by directory scan — the spec is abstract, never
 repo-specific.
 
-## Golden layout
+## Layout modes
+
+The official plugin spec allows two valid layouts. **`single` is the more
+common one** in the wild (Superpowers, most OSS/personal plugins); `mono` is
+the team standard (`anthropics/claude-code` bundles 13 plugins this way).
+
+| | `mono` | `single` |
+|---|---|---|
+| marketplace `source` | `"./plugins/<name>"` | `"./"` |
+| plugin roots | each `plugins/<p>/` | repo root `./` (exactly 1) |
+| skill path | `plugins/<p>/skills/<s>/` | `skills/<s>/` |
+
+A **plugin root** is the directory holding the plugin manifest
+(`.claude-plugin/plugin.json`) and `skills/`. Defining M3/M4/R1/R2/R4/R5
+over the *plugin-root set* makes them mode-agnostic — only "how the
+plugin-root set is computed" differs between modes (Approach C, #914).
+`structure-refactor` generates its create/`git mv`/skeleton/stub actions
+over the *same plugin-root set*, so a single repo is fixed toward the
+**root** golden layout and a mono repo toward the **plugins/** layout — the
+mode is chosen once, never converted mid-refactor (see "Mode override =
+layout conversion" below).
+
+### Golden layout — mono
 
 ```
 .
 ├── .claude-plugin/marketplace.json      # exists + valid JSON       (M1)
-├── plugins/<plugin>/
+├── plugins/<plugin>/                     # plugin root
 │   ├── .claude-plugin/plugin.json       # exists + valid JSON       (M3)
 │   └── skills/<skill>/SKILL.md          # exists + name/description (M4)
 ├── docs/skill-guides/                   # directory exists          (M5)
@@ -24,20 +46,74 @@ repo-specific.
 └── README.md                            # exists                    (M6)
 ```
 
-Dynamic discovery order:
-1. `plugins/*/` → each is a plugin.
-2. `plugins/*/skills/*/` → each is a skill of that plugin.
+### Golden layout — single
 
-## Mandatory items (FAIL when missing)
+```
+.                                         # repo root IS the plugin root
+├── .claude-plugin/
+│   ├── marketplace.json                 # exists + valid JSON, source "./" (M1)
+│   └── plugin.json                      # exists + valid JSON       (M3)
+├── skills/<skill>/SKILL.md              # exists + name/description (M4)
+├── docs/skill-guides/                   # directory exists          (M5)
+├── docs/skill-output/                   # directory exists          (M5)
+└── README.md                            # exists                    (M6)
+```
 
-| ID | Item | FAIL condition |
-|----|------|----------------|
-| M1 | `.claude-plugin/marketplace.json` | missing or invalid JSON |
-| M2 | `plugins/` dir with ≥1 plugin | missing or 0 plugins |
-| M3 | each `plugins/<p>/.claude-plugin/plugin.json` | missing or invalid JSON |
-| M4 | each `plugins/<p>/skills/<s>/SKILL.md` | missing or frontmatter lacks `name`/`description` |
-| M5 | `docs/skill-guides/` AND `docs/skill-output/` | either directory missing |
-| M6 | `README.md` | missing |
+## Mode detection (priority order — first match wins)
+
+1. **`--single` / `--mono` flag** → forced override (highest authority).
+2. **`marketplace.json` `plugins[].source`** → `"./"` (or `"."`) ⇒ single,
+   `"./plugins/.."` (or bare `"plugins/.."`) ⇒ mono — the leading `./` is
+   optional, matched leniently (most authoritative *signal* when unflagged).
+3. **Filesystem fallback** → `plugins/*/` exists ⇒ mono; root
+   `.claude-plugin/plugin.json` exists ⇒ single.
+4. **Still ambiguous** → default `mono`, header notes `(mode: mono, 추정)`.
+
+A forced override is honored even when wrong — it means "refactor *toward*
+this mode's golden layout". When the override names a mode **different from
+the detected current layout** that is a single↔mono *conversion*, which is
+out of scope — see "Mode override = layout conversion".
+
+## Mode override = layout conversion (out of scope — safety guard)
+
+`structure-refactor` fixes a repo toward the golden layout **of its current
+detected mode**. It never silently converts single↔mono:
+
+- When the forced `--single`/`--mono` equals the detected current mode (or
+  no flag is given), refactor proceeds normally over that mode's plugin-root
+  set.
+- When the forced mode **differs** from the detected current layout, fixing
+  toward it would require relocating the whole plugin (single→mono: `git mv`
+  the root plugin into `plugins/<name>/`, move `skills/`, rewrite
+  `marketplace.json` source; mono→single: the inverse). This is a large,
+  high-risk move + manifest rewrite and is **not performed**:
+  - the dry-run plan prints a `[convert]` warning line ("레이아웃 변환 필요
+    — 현재 미지원"), and
+  - `--apply` **stops without writing** (fail-safe — never a partial move).
+
+Conversion support is deferred to a follow-up (`structure-convert` or a
+refactor `--convert` flag). This guard exists precisely so refactor never
+force-restructures a valid `single` repo (e.g. Superpowers) into `mono` and
+breaks upstream compatibility.
+
+## Mandatory items by mode (FAIL when missing)
+
+IDs, counts, and validation logic are identical across modes — only the
+checked **path** changes (M5/M6 are mode-independent). Refactor's fix action
+for each item targets the same path.
+
+| ID | Item | mono path | single path |
+|----|------|-----------|-------------|
+| M1 | marketplace.json valid | `.claude-plugin/marketplace.json` | **same** |
+| M2 | ≥1 plugin root | `plugins/` has ≥1 plugin | root `.claude-plugin/plugin.json` exists (=1 root) |
+| M3 | each plugin.json valid | `plugins/<p>/.claude-plugin/plugin.json` | root `.claude-plugin/plugin.json` |
+| M4 | each SKILL.md valid | `plugins/<p>/skills/<s>/SKILL.md` | `skills/<s>/SKILL.md` |
+| M5 | docs dirs exist | `docs/skill-guides/` AND `docs/skill-output/` | **same** |
+| M6 | README.md | `README.md` | **same** |
+
+FAIL conditions: M1/M3 → missing or invalid JSON; M2 → 0 plugin roots;
+M4 → missing or frontmatter lacks `name`/`description`; M5 → either dir
+missing; M6 → missing.
 
 ## Recommended items (WARN when missing)
 
@@ -92,10 +168,13 @@ rules" + "Pages host & URL derivation (`--op`)".
 
 When the subject of a check does not exist, the check is **N/A**, not FAIL.
 Examples: a plugin with 0 skills → R1/R2/R5 are N/A for that plugin; with no
-plugins at all M3 is N/A and with no skills anywhere M4 **and R5** are N/A —
-M2 still carries the single "no plugins" FAIL, so the absent subject is never
-double-counted as a second FAIL. R5 is per-skill: with no skills there is no
-link to require, so it is N/A (never FAIL).
+**plugin roots** M3 is N/A and with no skills anywhere M4 **and R5** are N/A —
+M2 still carries the single "no plugin root" FAIL, so the absent subject is
+never double-counted as a second FAIL. This holds per mode: in `single` a
+missing root `.claude-plugin/plugin.json` means 0 plugin roots, so M2 FAILs
+and M3/M4 are N/A — exactly mirroring mono's "0 plugins" case. R5 is
+per-skill: with no skills there is no link to require, so it is N/A (never
+FAIL).
 
 ## Summary verdict
 

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -303,16 +303,43 @@ cps_verdict() {
 }
 
 # ---- refactor apply ------------------------------------------------------
-# cps_refactor <repo> <scope:mp|op> <mode:dry-run|apply>
-# Dry-run is a no-op on disk. Apply creates missing mandatory items, and
-# (op scope) recommended placeholder stubs. Idempotent.
+# cps_refactor <repo> <scope:mp|op> <run:dry-run|apply> [forced:single|mono]
+# Dry-run is a no-op on disk. Apply fixes the repo toward the golden layout
+# of its DETECTED mode (or the forced target when it equals the detected
+# layout); single targets the repo root (no plugins/ dir), mono targets
+# plugins/<p>/. Idempotent.
+#
+# Conversion guard (#915): when the forced target mode differs from the
+# detected current layout, that is a single<->mono CONVERSION (relocate the
+# whole plugin + rewrite the manifest) — OUT OF SCOPE. The function writes
+# NOTHING and returns 3 (a safe no-op, never a partial move).
 cps_refactor() {
-    local _repo="$1" _scope="${2:-mp}" _mode="${3:-dry-run}"
-    [ "$_mode" = "apply" ] || return 0 # dry-run: touch nothing
+    local _repo="$1" _scope="${2:-mp}" _run="${3:-dry-run}" _forced="${4:-}"
+    [ "$_run" = "apply" ] || return 0 # dry-run: touch nothing
 
-    # M5 dirs
-    mkdir -p "$_repo/docs/skill-guides" "$_repo/docs/skill-output"
-    mkdir -p "$_repo/.claude-plugin"
+    # Conversion guard — forced target ≠ detected current layout → refuse.
+    local _current _target
+    _current="$(_cps_detect_mode "$_repo")" # signal-based current layout
+    if [ -n "$_forced" ] && [ "$_forced" != "$_current" ]; then
+        return 3 # layout conversion required — not performed (safe no-op)
+    fi
+    _target="${_forced:-$_current}"
+
+    # M5 docs dirs + .claude-plugin (mode-independent).
+    mkdir -p "$_repo/docs/skill-guides" "$_repo/docs/skill-output" \
+        "$_repo/.claude-plugin"
+
+    if [ "$_target" = single ]; then
+        _cps_refactor_single "$_repo" "$_scope"
+    else
+        _cps_refactor_mono "$_repo" "$_scope"
+    fi
+    return 0 # success (0); the conversion-guard early return above is 3
+}
+
+# mono apply: marketplace + per-plugin plugin.json + plugins/<p>/ stubs/links.
+_cps_refactor_mono() {
+    local _repo="$1" _scope="$2"
 
     # M1 marketplace.json skeleton (only if missing/invalid) — list ALL plugins
     if ! _cps_json_ok "$_repo/.claude-plugin/marketplace.json"; then
@@ -362,13 +389,7 @@ EOF
         [ -n "$_p" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
-            [ -f "$_repo/docs/skill-guides/$_s.html" ] || printf \
-                '<!-- TODO: claude-plugin guide for %s — fill with /devx:visualize -->\n' \
-                "$_s" >"$_repo/docs/skill-guides/$_s.html"
-            { [ -f "$_repo/docs/skill-output/$_s-usage.html" ] ||
-                [ -f "$_repo/docs/skill-output/$_s-usage.md" ]; } || printf \
-                '<!-- TODO: %s usage sample — fill with /devx:visualize -->\n' \
-                "$_s" >"$_repo/docs/skill-output/$_s-usage.md"
+            _cps_stub_recommended "$_repo" "$_s"
         done <<EOF
 $(_cps_skills "$_repo" "$_p")
 EOF
@@ -384,25 +405,83 @@ EOF
     # → "Pages host & URL derivation"). This hermetic fixture has no remote, so
     # it writes the relative fallback form — both satisfy cps_check_R5, which
     # matches by the `skill-guides/<s>.html` substring common to both forms.
-    local _has_guide _has_usage
     while IFS= read -r _p; do
         [ -n "$_p" ] || continue
         while IFS= read -r _s; do
             [ -n "$_s" ] || continue
-            _has_guide=0
-            _has_usage=0
-            grep -qF "skill-guides/$_s.html" "$_repo/README.md" && _has_guide=1
-            { grep -qF "skill-output/$_s-usage.html" "$_repo/README.md" ||
-                grep -qF "skill-output/$_s-usage.md" "$_repo/README.md"; } && _has_usage=1
-            [ "$_has_guide" -eq 1 ] && [ "$_has_usage" -eq 1 ] && continue
-            [ "$_has_guide" -eq 0 ] && printf -- '- `%s` ([visual guide ↗](docs/skill-guides/%s.html))\n' \
-                "$_s" "$_s" >>"$_repo/README.md"
-            [ "$_has_usage" -eq 0 ] && printf -- '- `%s` usage: [usage](docs/skill-output/%s-usage.md)\n' \
-                "$_s" "$_s" >>"$_repo/README.md"
+            _cps_backfill_links "$_repo" "$_s"
         done <<EOF
 $(_cps_skills "$_repo" "$_p")
 EOF
     done <<EOF
 $(_cps_plugins "$_repo")
 EOF
+}
+
+# single apply: the repo root IS the one plugin root — marketplace source
+# "./", a ROOT plugin.json, root skills/<s>/. NEVER creates a plugins/ dir.
+_cps_refactor_single() {
+    local _repo="$1" _scope="$2" _s _skills_json=""
+
+    # M1 marketplace.json skeleton with the single source "./".
+    if ! _cps_json_ok "$_repo/.claude-plugin/marketplace.json"; then
+        printf '{ "name": "%s", "plugins": [{ "source": "./" }] }\n' \
+            "$(basename "$_repo")" >"$_repo/.claude-plugin/marketplace.json"
+    fi
+
+    # M3 ROOT plugin.json skeleton — list ALL root skills.
+    if ! _cps_json_ok "$_repo/.claude-plugin/plugin.json"; then
+        while IFS= read -r _s; do
+            [ -n "$_s" ] || continue
+            [ -n "$_skills_json" ] && _skills_json="${_skills_json}, "
+            _skills_json="${_skills_json}\"./skills/${_s}\""
+        done <<EOF
+$(_cps_skills_in_root "$_repo" ".")
+EOF
+        printf '{ "name": "%s", "version": "0.0.0", "skills": [%s] }\n' \
+            "$(basename "$_repo")" "${_skills_json:-\"./skills/skill\"}" \
+            >"$_repo/.claude-plugin/plugin.json"
+    fi
+
+    # M6 README skeleton (with a docs/ link so R3 also passes).
+    [ -f "$_repo/README.md" ] || printf '# %s\n\nSee [docs/](./docs/).\n' \
+        "$(basename "$_repo")" >"$_repo/README.md"
+
+    [ "$_scope" = "op" ] || return 0
+
+    # --op: R1/R2 stubs + R5 link backfill over ROOT skills (paths identical
+    # to mono — only the skill-discovery root differs).
+    while IFS= read -r _s; do
+        [ -n "$_s" ] || continue
+        _cps_stub_recommended "$_repo" "$_s"
+        _cps_backfill_links "$_repo" "$_s"
+    done <<EOF
+$(_cps_skills_in_root "$_repo" ".")
+EOF
+}
+
+# ---- shared --op write helpers (mode-independent — docs paths are repo-level)
+_cps_stub_recommended() {
+    # $1=repo $2=skill : create R1 guide + R2 usage placeholder stubs if absent.
+    local _repo="$1" _s="$2"
+    [ -f "$_repo/docs/skill-guides/$_s.html" ] || printf \
+        '<!-- TODO: claude-plugin guide for %s — fill with /devx:visualize -->\n' \
+        "$_s" >"$_repo/docs/skill-guides/$_s.html"
+    { [ -f "$_repo/docs/skill-output/$_s-usage.html" ] ||
+        [ -f "$_repo/docs/skill-output/$_s-usage.md" ]; } || printf \
+        '<!-- TODO: %s usage sample — fill with /devx:visualize -->\n' \
+        "$_s" >"$_repo/docs/skill-output/$_s-usage.md"
+}
+
+_cps_backfill_links() {
+    # $1=repo $2=skill : append ONLY the missing README link(s) (idempotent).
+    local _repo="$1" _s="$2" _has_guide=0 _has_usage=0
+    grep -qF "skill-guides/$_s.html" "$_repo/README.md" && _has_guide=1
+    { grep -qF "skill-output/$_s-usage.html" "$_repo/README.md" ||
+        grep -qF "skill-output/$_s-usage.md" "$_repo/README.md"; } && _has_usage=1
+    [ "$_has_guide" -eq 1 ] && [ "$_has_usage" -eq 1 ] && return 0
+    [ "$_has_guide" -eq 0 ] && printf -- '- `%s` ([visual guide ↗](docs/skill-guides/%s.html))\n' \
+        "$_s" "$_s" >>"$_repo/README.md"
+    [ "$_has_usage" -eq 0 ] && printf -- '- `%s` usage: [usage](docs/skill-output/%s-usage.md)\n' \
+        "$_s" "$_s" >>"$_repo/README.md"
 }

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -429,3 +429,103 @@ build_single_perfect() {
     run _cps_detect_mode "$REPO" single; assert_output single
     run cps_verdict "$REPO" single; assert_output PASS
 }
+
+# ---- single layout REFACTOR (#915) --------------------------------------
+# refactor fixes a single repo toward the ROOT golden layout and NEVER
+# creates a plugins/ directory (the core danger #915 guards against).
+
+@test "single perfect repo -> refactor op apply is a no-op (no plugins/ dir)" {
+    build_single_perfect "$REPO"
+    before="$(find "$REPO" -type f | sort)"
+    cps_refactor "$REPO" op apply
+    after="$(find "$REPO" -type f | sort)"
+    [ "$before" = "$after" ]
+    [ ! -d "$REPO/plugins" ]
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "single repo missing root plugin.json -> refactor mp -> PASS, no plugins/ dir" {
+    _seed_single_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    _seed_recommended_files "$REPO"; _seed_readme_links "$REPO" visualize
+    mkdir -p "$REPO/.claude-plugin"   # single signal, root plugin.json missing
+    printf '{ "name": "repo", "plugins": [{ "source": "./" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M2 "$REPO"; assert_output FAIL     # 0 plugin roots yet
+    run cps_verdict "$REPO"; assert_output FAIL
+    cps_refactor "$REPO" mp apply
+    [ ! -d "$REPO/plugins" ]                          # single fix never makes plugins/
+    run cps_check_M3 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "single mandatory apply writes VALID root JSON with source ./" {
+    _seed_single_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "source": "./" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    cps_refactor "$REPO" mp apply
+    run jq empty "$REPO/.claude-plugin/plugin.json"; assert_success
+    run jq -r '.plugins[0].source' "$REPO/.claude-plugin/marketplace.json"
+    assert_output "./"
+    run jq -e '.skills | index("./skills/visualize")' "$REPO/.claude-plugin/plugin.json"
+    assert_success
+    [ ! -d "$REPO/plugins" ]
+}
+
+@test "single missing recommended -> refactor op -> recheck PASS (root stubs+links)" {
+    _seed_single_skill "$REPO"; _seed_single_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R1 "$REPO"; assert_output WARN
+    cps_refactor "$REPO" op apply
+    [ ! -d "$REPO/plugins" ]
+    run cps_check_R1 "$REPO"; assert_output PASS
+    run cps_check_R2 "$REPO"; assert_output PASS
+    run cps_check_R5 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+# ---- layout-conversion guard (#915) -------------------------------------
+# A forced TARGET mode that differs from the detected CURRENT layout is a
+# single<->mono conversion — OUT OF SCOPE: write nothing, return 3.
+
+@test "forced --mono on a detected-single repo -> conversion guard no-op (rc=3)" {
+    build_single_perfect "$REPO"
+    rm -f "$REPO/docs/skill-guides/visualize.html"   # a same-mode op WOULD rewrite this
+    before="$(find "$REPO" -type f | sort)"
+    run cps_refactor "$REPO" op apply mono
+    [ "$status" -eq 3 ]
+    after="$(find "$REPO" -type f | sort)"
+    [ "$before" = "$after" ]
+    [ ! -d "$REPO/plugins" ]
+}
+
+@test "forced --single on a detected-mono repo -> conversion guard no-op (rc=3)" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"  # mono, mandatory missing
+    before="$(find "$REPO" -type f | sort)"
+    run cps_refactor "$REPO" mp apply single
+    [ "$status" -eq 3 ]
+    after="$(find "$REPO" -type f | sort)"
+    [ "$before" = "$after" ]
+    [ ! -f "$REPO/.claude-plugin/marketplace.json" ]   # nothing written
+}
+
+@test "forced --single on a detected-single repo proceeds (target == current)" {
+    _seed_single_skill "$REPO"; _seed_single_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_refactor "$REPO" op apply single
+    [ "$status" -eq 0 ]
+    run cps_check_R5 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "forced --mono on a detected-mono repo proceeds (mono regression intact)" {
+    # mirrors test "mandatory missing -> refactor --apply (mp)" but with an
+    # explicit --mono target == the detected layout: identical mono behavior.
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    _seed_recommended_files "$REPO"; _seed_readme_links "$REPO" visualize
+    run cps_refactor "$REPO" mp apply mono
+    [ "$status" -eq 0 ]
+    run cps_check_M1 "$REPO"; assert_output PASS
+    run cps_check_M3 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}


### PR DESCRIPTION
## 요약

`claude-plugin:structure-refactor` 에 #914 와 동일한 mono/single 모드 인식을
추가하고, 감지된(또는 지정된) 모드의 golden layout 으로만 수정하도록 한다.
single 레포(예: Superpowers)를 강제로 mono 구조로 재배치하는 오탐 "수정" 을
원천 차단한다.

## 변경 내용

- **structure-spec.md (SSOT 동기화)** — #914 가 추가한 *Layout modes* /
  *Mode detection* / *Mandatory items by mode* / per-mode *N/A rule* 섹션을
  refactor 쪽 복사본에 **byte-identical 동기화** (공유 SSOT). refactor 전용
  *"Mode override = layout conversion"* 안전 가드 섹션과 기존 Pages URL 블록
  은 유지.
- **SKILL.md** — Step 1 에 `--single`/`--mono` 파싱; Step 2 를 "모드 감지 →
  plugin-root 산출 → 평가" 로; Step 3/4 액션을 plugin-root 상대 경로로
  (single → 루트 기준, `plugins/` 미생성 / mono → 기존 동작); 변환 필요 시
  경고 후 미수행 가드.
- **plan-and-report-templates.md** — 플랜/리포트 헤더에 layout 모드 표기 +
  `[convert]` 경고 라인 + `layout=` 요약 키.
- **help.md** — `--single`/`--mono` 옵션 + 자동감지 우선순위 + 변환 미지원 명시.
- **테스트** — fixture `cps_refactor` 를 모드 인식형으로 재설계
  (mono/single 분기 + 변환 가드 `rc=3`, 공유 `--op` 헬퍼 추출로 mono 회귀 없음);
  bats 에 single refactor 4종 + 변환 가드 4종 추가 → **47 tests green**.

## 범위 분리

single↔mono **레이아웃 변환**(전체 플러그인 이동 + manifest 재작성)은 위험도가
높아 1차 범위에서 제외. 오버라이드 모드 ≠ 감지 모드일 때는 경고 후 미수행
(안전 가드). 변환 지원은 후속 이슈(`structure-convert`)로 분리.

## 검증

- `bats tests/bats/skills/claude_plugin_structure.bats` → 47/47 PASS
- `shfmt -d -i 4` / `shellcheck -x` (fixture) → clean
- 두 spec 의 공유 섹션 byte-identical 확인

## 의존성

- 선행 #914 (structure-check 모드 인식) 머지 완료 후 spec 복사본 동기화부터 진행.

Closes #915
