### PR TITLE
chore(claude-setup): #924 settings.local.json 로컬 오버라이드 패턴 도입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,10 @@ All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `
 
 `claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` and `claude/docs/` directories are also symlinked (directory-level) into each account's `~/.claude*/skills` and `~/.claude*/docs` — the same scheme in every setup mode (#575).
 
-**Personal overrides (model, env vars)** — `claude/settings.local.json` is gitignored (#924). Create `~/.claude/settings.local.json` directly for machine-specific settings:
+**Personal overrides (model, env vars)** — `claude/settings.local.json` is gitignored (#924). Create `settings.local.json` in your active Claude config directory for machine-specific settings:
+
+- Single-account: `~/.claude/settings.local.json`
+- Multi-account: `~/.claude-personal/settings.local.json` (or whichever `$CLAUDE_CONFIG_DIR` is active)
 
 ```json
 { "model": "sonnet" }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,14 @@ All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `
 
 `claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` and `claude/docs/` directories are also symlinked (directory-level) into each account's `~/.claude*/skills` and `~/.claude*/docs` — the same scheme in every setup mode (#575).
 
+**Personal overrides (model, env vars)** — `claude/settings.local.json` is gitignored (#924). Create `~/.claude/settings.local.json` directly for machine-specific settings:
+
+```json
+{ "model": "sonnet" }
+```
+
+Claude Code merges this with `settings.json` natively (local wins). Running `/model` writes back to the symlinked `settings.json` — run `git restore claude/settings.json` to discard and keep the model in `settings.local.json` instead.
+
 ## Critical Rules
 
 **POSIX compatibility in shell-common/**

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -38,10 +38,10 @@
     "ralph-loop@claude-plugins-official": true,
     "codex@openai-codex": true
   },
+  "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark",
   "telemetry": {
     "enabled": false
-  },
-  "autoUpdatesChannel": "latest"
+  }
 }


### PR DESCRIPTION
## Summary

- `claude/settings.json`에서 `"model"` 키 제거 — 개인 선호 설정은 공유 기본값에 포함하지 않음
- `CLAUDE.md`에 `~/.claude/settings.local.json` 로컬 오버라이드 패턴 문서화

## Background

`claude/settings.json`은 `~/.claude/settings.json`으로 심볼릭 링크되어 있어, `/model` 커맨드 실행 시 `"model"` 키가 dotfiles 파일에 직접 기록된다. 이로 인해 모델 변경 때마다 `git status`에 noise가 발생하는 문제가 있었다.

Claude Code는 `settings.json`과 `settings.local.json`을 네이티브로 머지하므로, 개인 설정은 `settings.local.json`에 분리하는 것이 올바른 패턴이다. `claude/settings.local.json`은 이미 `.gitignore`에 등록되어 있다.

## Changes

| File | Change |
|---|---|
| `claude/settings.json` | `"model"` 키 제거 + `autoUpdatesChannel` 위치 정규화 |
| `CLAUDE.md` | `settings.local.json` 패턴 사용법 문서 추가 |

## Test plan

- [ ] `jq . claude/settings.json` — valid JSON 확인
- [ ] `~/dotfiles/setup.sh` 실행 후 `~/.claude/settings.json` symlink 동작 확인
- [ ] `~/.claude/settings.local.json`에 `{"model": "sonnet"}` 추가 후 Claude Code 모델 반영 확인

Closes #924

<!-- ai-metrics -->
<details><summary>AI Metrics</summary>

📊 Tokens ~2 000 | 👤 Human ~0.1 h | 🤖 Elapsed ~5 min

</details>
