### PR TITLE
feat(ghes-mirror): #930 공개 GitHub 레포를 사내 GHES 인스턴스로 미러링하는 인터랙티브 위자드 명령어 추가

### DIFF
--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/ghes_mirror.sh
+# Interactive wizard: clone a public GitHub repo and mirror it to an internal GHES instance.
+# Sets up upstream (public) + origin (GHES) remotes and pushes all content.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+ghes_mirror() {
+    if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+        ghes_mirror_help
+        return 0
+    fi
+
+    ux_header "GHES Mirror Wizard"
+    ux_info "Mirrors a public GitHub repo into your internal GHES instance."
+    ux_info "Press Enter to accept [ default ] values."
+    echo ""
+
+    # --- Collect inputs ---
+    local _default_upstream="https://github.com/dEitY719/claude-plugin-visuals"
+    printf "%s1. Upstream URL%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_default_upstream}"
+    read -r _upstream
+    _upstream="${_upstream:-${_default_upstream}}"
+
+    local _default_host="github.samsungds.net"
+    printf "%s2. GHES host%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_default_host}"
+    read -r _ghes_host
+    _ghes_host="${_ghes_host:-${_default_host}}"
+
+    local _suggested_name="${_upstream##*/}"
+    _suggested_name="${_suggested_name%.git}"
+    printf "%s3. GHES repository name%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_suggested_name}"
+    read -r _repo_name
+    _repo_name="${_repo_name:-${_suggested_name}}"
+
+    echo ""
+    ux_info "Upstream : ${_upstream}"
+    ux_info "GHES host: ${_ghes_host}"
+    ux_info "Repo name: ${_repo_name}"
+    echo ""
+    printf "%sConfirm? [Y/n]%s " "${UX_WARNING}" "${UX_RESET}"
+    read -r _confirm
+    case "${_confirm:-Y}" in
+    [Nn]*)
+        ux_info "Aborted."
+        return 0
+        ;;
+    esac
+    echo ""
+
+    # --- Step 1: Clone ---
+    ux_step 1 "Cloning upstream..."
+    if ! git clone "${_upstream}" "${_repo_name}"; then
+        ux_error "Clone failed. Check upstream URL and network access."
+        return 1
+    fi
+    cd "${_repo_name}" || {
+        ux_error "Cannot enter directory: ${_repo_name}"
+        return 1
+    }
+
+    # --- Step 2: Create GHES repo ---
+    ux_step 2 "Creating GHES repository (--internal)..."
+    # Use --private instead of --internal if your GHES plan does not support internal repos.
+    if ! gh repo create "${_repo_name}" --internal --source=. --hostname="${_ghes_host}"; then
+        ux_error "GHES repo creation failed. Check: gh auth status --hostname ${_ghes_host}"
+        return 1
+    fi
+
+    # --- Step 3: Configure remotes ---
+    ux_step 3 "Configuring remotes..."
+    git remote rename origin upstream
+
+    local _ghes_user
+    _ghes_user=$(gh api user --hostname="${_ghes_host}" --jq '.login' 2>/dev/null)
+    if [ -z "${_ghes_user}" ]; then
+        ux_warning "Could not detect GHES username automatically."
+        printf "%sGHES username%s: " "${UX_PRIMARY}" "${UX_RESET}"
+        read -r _ghes_user
+    fi
+
+    local _origin_url="https://${_ghes_host}/${_ghes_user}/${_repo_name}"
+    git remote add origin "${_origin_url}"
+    ux_info "upstream -> ${_upstream}"
+    ux_info "origin   -> ${_origin_url}"
+
+    # --- Step 4: Push ---
+    ux_step 4 "Pushing to GHES..."
+    local _branch
+    _branch=$(git branch --show-current)
+    if ! git push -u origin "${_branch}"; then
+        ux_error "Push failed. Verify GHES authentication and repo permissions."
+        return 1
+    fi
+
+    echo ""
+    ux_success "Mirror complete."
+    ux_info "Working directory is now: $(pwd)"
+    echo ""
+    git remote -v
+}
+
+alias ghes-mirror='ghes_mirror'

--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -55,6 +55,8 @@ ghes_mirror() {
         ux_error "Clone failed. Check upstream URL and network access."
         return 1
     fi
+    local _orig_dir
+    _orig_dir=$(pwd)
     cd "${_repo_name}" || {
         ux_error "Cannot enter directory: ${_repo_name}"
         return 1
@@ -65,6 +67,7 @@ ghes_mirror() {
     # Use --private instead of --internal if your GHES plan does not support internal repos.
     if ! gh repo create "${_repo_name}" --internal --source=. --hostname="${_ghes_host}"; then
         ux_error "GHES repo creation failed. Check: gh auth status --hostname ${_ghes_host}"
+        cd "${_orig_dir}" || return 1
         return 1
     fi
 
@@ -74,11 +77,11 @@ ghes_mirror() {
 
     local _ghes_user
     _ghes_user=$(gh api user --hostname="${_ghes_host}" --jq '.login' 2>/dev/null)
-    if [ -z "${_ghes_user}" ]; then
+    while [ -z "${_ghes_user}" ]; do
         ux_warning "Could not detect GHES username automatically."
         printf "%sGHES username%s: " "${UX_PRIMARY}" "${UX_RESET}"
         read -r _ghes_user
-    fi
+    done
 
     local _origin_url="https://${_ghes_host}/${_ghes_user}/${_repo_name}"
     git remote add origin "${_origin_url}"
@@ -89,8 +92,14 @@ ghes_mirror() {
     ux_step 4 "Pushing to GHES..."
     local _branch
     _branch=$(git branch --show-current)
+    if [ -z "${_branch}" ]; then
+        ux_error "Could not detect current branch name (detached HEAD?)."
+        cd "${_orig_dir}" || return 1
+        return 1
+    fi
     if ! git push -u origin "${_branch}"; then
         ux_error "Push failed. Verify GHES authentication and repo permissions."
+        cd "${_orig_dir}" || return 1
         return 1
     fi
 

--- a/shell-common/functions/ghes_mirror_help.sh
+++ b/shell-common/functions/ghes_mirror_help.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# shell-common/functions/ghes_mirror_help.sh
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+ghes_mirror_help() {
+    ux_header "ghes-mirror"
+
+    ux_section "Usage"
+    echo "  ${UX_SUCCESS}ghes-mirror${UX_RESET}         ${UX_MUTED}# launch interactive wizard${UX_RESET}"
+    echo "  ${UX_SUCCESS}ghes-mirror --help${UX_RESET}  ${UX_MUTED}# show this help${UX_RESET}"
+    echo ""
+
+    ux_section "What it does"
+    ux_bullet "Clones a public GitHub repo (becomes upstream)"
+    ux_bullet "Creates a mirror repo in your internal GHES instance"
+    ux_bullet "Renames origin -> upstream, adds GHES as origin"
+    ux_bullet "Pushes the default branch to GHES origin"
+    echo ""
+
+    ux_section "Resulting remotes"
+    echo "  ${UX_INFO}origin    https://<ghes-host>/<user>/<repo>${UX_RESET}"
+    echo "  ${UX_INFO}upstream  https://github.com/<owner>/<repo>${UX_RESET}"
+    echo ""
+
+    ux_section "Requirements"
+    ux_bullet "git"
+    ux_bullet "gh CLI authenticated to github.com  (gh auth login)"
+    ux_bullet "gh CLI authenticated to GHES host   (gh auth login --hostname <host>)"
+    echo ""
+
+    ux_section "Notes"
+    ux_bullet "The wizard changes your working directory to the cloned repo."
+    ux_bullet "GHES repo visibility defaults to --internal."
+    ux_bullet "Change to --private in ghes_mirror.sh if your plan requires it."
+    echo ""
+}
+
+alias ghes-mirror-help='ghes_mirror_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -158,7 +158,7 @@ _register_default_help_categories() {
     HELP_CATEGORIES[system]="${HELP_CATEGORIES[system]:-System tools (directory navigation, opencode)}"
 
     # Category membership (space-separated topic keys)
-    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool}"
+    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool ghes_mirror}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
@@ -258,6 +258,7 @@ _register_default_help_descriptions() {
     # Registrations to keep `devx lint-helpfunc` clean (#726 AC). Each entry
     # mirrors an existing public `<topic>_help` function in shell-common/functions/
     # that previously slipped through the registry.
+    HELP_DESCRIPTIONS[ghes_mirror_help]="${HELP_DESCRIPTIONS[ghes_mirror_help]:-[Development] Mirror public GitHub repo to internal GHES instance}"
     HELP_DESCRIPTIONS[gh_flow_help]="${HELP_DESCRIPTIONS[gh_flow_help]:-[Development] gh-flow issue/PR worker pipeline}"
     HELP_DESCRIPTIONS[gh_pr_review_help]="${HELP_DESCRIPTIONS[gh_pr_review_help]:-[Development] gh-pr-review external-AI review delegation}"
     HELP_DESCRIPTIONS[gh_pr_reply_help]="${HELP_DESCRIPTIONS[gh_pr_reply_help]:-[Development] gh-pr-reply review-comment handler}"


### PR DESCRIPTION
## Summary

- `ghes_mirror()` 함수 + `alias ghes-mirror` 신규 추가 — 공개 GitHub 레포를 사내 GHES 인스턴스로 미러링하는 인터랙티브 4단계 위자드
- `ghes_mirror_help()` + `alias ghes-mirror-help` 신규 추가 — Usage/Requirements/Notes 포함 help 화면
- `my_help.sh`: `development` 카테고리 멤버 + `HELP_DESCRIPTIONS` 에 `ghes_mirror_help` 등록

## Motivation

사내 GHES 미러링 시 매번 clone → gh repo create → remote rename → push 4단계를
수동 입력해야 했던 반복 작업을 단일 명령어로 자동화. upstream(공개) + origin(GHES) 2-remote 구성 표준화.

## Changes

### `shell-common/functions/ghes_mirror.sh` (new, +104)

- 인터랙티브 위자드: upstream URL → GHES 호스트 → 레포 이름 → Y/n 확인
- 엔터 입력 시 기본값 자동 적용
- `gh api user --jq '.login'` 으로 GHES 계정명 자동 감지, 실패 시 수동 입력 폴백
- 각 단계 실패(clone / gh repo create / push) 시 `ux_error` + `return 1` 조기 종료
- `--help / -h` 플래그로 `ghes_mirror_help` 라우팅
- `# shellcheck shell=bash` pragma + `shfmt -i 4` 포맷 통과

### `shell-common/functions/ghes_mirror_help.sh` (new, +39)

- Usage, What it does, Resulting remotes, Requirements, Notes 5개 섹션
- `alias ghes-mirror-help='ghes_mirror_help'`

### `shell-common/functions/my_help.sh` (modified, +2/-1)

- `HELP_CATEGORY_MEMBERS[development]` 에 `ghes_mirror` 추가
- `HELP_DESCRIPTIONS[ghes_mirror_help]` 등록

## Test Plan

- [ ] `ghes-mirror` 실행 → 인터랙티브 4단계 진행 확인
- [ ] 엔터 입력 시 기본값 적용 확인
- [ ] `ghes-mirror --help` / `ghes-mirror-help` 동작 확인
- [ ] `my-help development` 목록에 `ghes_mirror` 항목 출력 확인
- [ ] shellcheck + shfmt lint 통과

## Closes

Closes #930

<!-- ai-metrics -->
<details><summary>📊 AI Metrics</summary>

| Metric | Value |
|--------|-------|
| 👤 Human turns | 2 |
| 🤖 Tokens (est.) | ~5,500 |
| ⏱ Elapsed | ~2 min |

</details>
<!-- /ai-metrics -->
