### PR TITLE
fix(compact-wsl): exit → return — iex 실행 시 PS 창 종료 버그 수정

### DIFF
--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -108,7 +108,7 @@ if (-not $basePath) {
     Write-Host "[X] '$DistroName' 배포판을 찾지 못했습니다." -ForegroundColor Red
     Write-Host "    아래 목록에서 정확한 이름을 확인하고 -DistroName 으로 다시 실행하세요:" -ForegroundColor Red
     wsl -l -v
-    return
+    throw "배포판을 찾지 못했습니다."
 }
 
 # BasePath 의 \\?\ 접두사 제거
@@ -123,7 +123,7 @@ if (-not (Test-Path $vhdxPath)) {
     } else {
         Write-Host "[X] vhdx 파일을 찾지 못했습니다." -ForegroundColor Red
         Write-Host "    BasePath (레지스트리 원본): $basePath" -ForegroundColor Red
-        return
+        throw "vhdx 파일을 찾지 못했습니다."
     }
 }
 

--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -71,7 +71,7 @@ if (-not $isAdmin) {
             "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", $cmd
         ) -Verb RunAs
     }
-    exit
+    return
 }
 
 function Get-VhdxSizeGB {
@@ -108,7 +108,7 @@ if (-not $basePath) {
     Write-Host "[X] '$DistroName' 배포판을 찾지 못했습니다." -ForegroundColor Red
     Write-Host "    아래 목록에서 정확한 이름을 확인하고 -DistroName 으로 다시 실행하세요:" -ForegroundColor Red
     wsl -l -v
-    exit 1
+    return
 }
 
 # BasePath 의 \\?\ 접두사 제거
@@ -123,7 +123,7 @@ if (-not (Test-Path $vhdxPath)) {
     } else {
         Write-Host "[X] vhdx 파일을 찾지 못했습니다." -ForegroundColor Red
         Write-Host "    BasePath (레지스트리 원본): $basePath" -ForegroundColor Red
-        exit 1
+        return
     }
 }
 


### PR DESCRIPTION
## Summary
- `iex (irm ...)` 실행 시 PowerShell 창이 사라지는 버그 수정
- 비관리자 감지 후 `exit` 호출이 스크립트 종료가 아닌 PS 프로세스 종료로 해석되는 문제
- 3곳의 `exit` / `exit 1` 을 모두 `return` 으로 교체

## Changes
- `windows/Compact-WSL.ps1`: `exit` → `return` (권한 상승 분기, distro 미발견, vhdx 미발견 3곳)

## Test plan
- [ ] 비관리자 PowerShell 에서 `iex (irm ...)` 실행 → UAC 프롬프트 뜬 후 기존 창이 살아있는지 확인
- [ ] 관리자 PowerShell 에서 직접 실행 → 정상 동작 확인
- [ ] 존재하지 않는 DistroName 으로 실행 → 오류 메시지 출력 후 창 유지 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
