### PR TITLE
fix(ghes-mirror): gh repo create --hostname 플래그 제거 + GHES URL 단일 입력 UX 통합

### DIFF
--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -23,21 +23,24 @@ ghes_mirror() {
     read -r _upstream
     _upstream="${_upstream:-${_default_upstream}}"
 
-    local _default_host="github.samsungds.net"
-    printf "%s2. GHES host%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_default_host}"
-    read -r _ghes_host
-    _ghes_host="${_ghes_host:-${_default_host}}"
+    # Derive GHES URL default from upstream (swap github.com with GHES host)
+    local _default_ghes_host="github.samsungds.net"
+    local _upstream_path="${_upstream#https://github.com/}"
+    local _default_ghes_url="https://${_default_ghes_host}/${_upstream_path}"
+    printf "%s2. GHES repo URL%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_default_ghes_url}"
+    read -r _ghes_full_url
+    _ghes_full_url="${_ghes_full_url:-${_default_ghes_url}}"
 
-    local _suggested_name="${_upstream##*/}"
-    _suggested_name="${_suggested_name%.git}"
-    printf "%s3. GHES repository name%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_suggested_name}"
-    read -r _repo_name
-    _repo_name="${_repo_name:-${_suggested_name}}"
+    # Parse host / owner / repo from GHES URL
+    local _ghes_url_path="${_ghes_full_url#https://}"  # host/owner/repo
+    local _ghes_host="${_ghes_url_path%%/*}"            # host
+    local _ghes_owner_repo="${_ghes_url_path#*/}"       # owner/repo
+    local _ghes_owner="${_ghes_owner_repo%%/*}"         # owner
+    local _repo_name="${_ghes_owner_repo##*/}"          # repo
 
     echo ""
     ux_info "Upstream : ${_upstream}"
-    ux_info "GHES host: ${_ghes_host}"
-    ux_info "Repo name: ${_repo_name}"
+    ux_info "GHES URL : ${_ghes_full_url}"
     echo ""
     printf "%sConfirm? [Y/n]%s " "${UX_WARNING}" "${UX_RESET}"
     read -r _confirm
@@ -65,8 +68,9 @@ ghes_mirror() {
     # --- Step 2: Create GHES repo ---
     ux_step 2 "Creating GHES repository (--internal)..."
     # Use --private instead of --internal if your GHES plan does not support internal repos.
-    if ! gh repo create "${_repo_name}" --internal --source=. --hostname="${_ghes_host}"; then
-        ux_error "GHES repo creation failed. Check: gh auth status --hostname ${_ghes_host}"
+    # GH_HOST env var is required; gh repo create does not support --hostname flag.
+    if ! GH_HOST="${_ghes_host}" gh repo create "${_ghes_owner}/${_repo_name}" --internal --source=.; then
+        ux_error "GHES repo creation failed. Check: GH_HOST=${_ghes_host} gh auth status"
         cd "${_orig_dir}" || return 1
         return 1
     fi
@@ -75,15 +79,8 @@ ghes_mirror() {
     ux_step 3 "Configuring remotes..."
     git remote rename origin upstream
 
-    local _ghes_user
-    _ghes_user=$(gh api user --hostname="${_ghes_host}" --jq '.login' 2>/dev/null)
-    while [ -z "${_ghes_user}" ]; do
-        ux_warning "Could not detect GHES username automatically."
-        printf "%sGHES username%s: " "${UX_PRIMARY}" "${UX_RESET}"
-        read -r _ghes_user
-    done
-
-    local _origin_url="https://${_ghes_host}/${_ghes_user}/${_repo_name}"
+    # Owner is parsed directly from the GHES URL — no gh api query needed.
+    local _origin_url="https://${_ghes_host}/${_ghes_owner}/${_repo_name}"
     git remote add origin "${_origin_url}"
     ux_info "upstream -> ${_upstream}"
     ux_info "origin   -> ${_origin_url}"

--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -23,20 +23,28 @@ ghes_mirror() {
     read -r _upstream
     _upstream="${_upstream:-${_default_upstream}}"
 
-    # Derive GHES URL default from upstream (swap github.com with GHES host)
+    # Derive GHES URL default — query GHES for authenticated owner namespace
     local _default_ghes_host="github.samsungds.net"
     local _upstream_path="${_upstream#https://github.com/}"
-    local _default_ghes_url="https://${_default_ghes_host}/${_upstream_path}"
+    local _upstream_owner="${_upstream_path%%/*}"
+    local _upstream_repo="${_upstream_path##*/}"
+    _upstream_repo="${_upstream_repo%.git}"
+    local _default_ghes_user
+    _default_ghes_user=$(gh api --hostname "${_default_ghes_host}" user --jq '.login' 2>/dev/null \
+        || echo "${_upstream_owner}")
+    local _default_ghes_url="https://${_default_ghes_host}/${_default_ghes_user}/${_upstream_repo}"
     printf "%s2. GHES repo URL%s [%s]: " "${UX_PRIMARY}" "${UX_RESET}" "${_default_ghes_url}"
     read -r _ghes_full_url
     _ghes_full_url="${_ghes_full_url:-${_default_ghes_url}}"
 
     # Parse host / owner / repo from GHES URL
-    local _ghes_url_path="${_ghes_full_url#https://}"  # host/owner/repo
-    local _ghes_host="${_ghes_url_path%%/*}"            # host
-    local _ghes_owner_repo="${_ghes_url_path#*/}"       # owner/repo
-    local _ghes_owner="${_ghes_owner_repo%%/*}"         # owner
-    local _repo_name="${_ghes_owner_repo##*/}"          # repo
+    local _ghes_url_path="${_ghes_full_url#*://}"       # host/owner/repo (strip any protocol)
+    local _ghes_host="${_ghes_url_path%%/*}"             # host
+    _ghes_host="${_ghes_host%%:*}"                       # strip port if present
+    local _ghes_owner_repo="${_ghes_url_path#*/}"        # owner/repo
+    local _ghes_owner="${_ghes_owner_repo%%/*}"          # owner
+    local _repo_name="${_ghes_owner_repo##*/}"           # repo
+    _repo_name="${_repo_name%.git}"                      # strip .git suffix
 
     echo ""
     ux_info "Upstream : ${_upstream}"


### PR DESCRIPTION
## Summary
- `gh repo create --hostname` 플래그 오류 수정 — `GH_HOST` 환경변수 방식으로 교체
- GHES 입력 UX 개선 — 호스트·레포명 분리 질문을 GHES repo URL 단일 입력으로 통합
- `gh api user` 중복 쿼리 제거 — owner를 URL 파싱으로 직접 추출

## Changes
- `ghes_mirror.sh`: 질문 2(GHES host) + 질문 3(repo name) → 단일 GHES repo URL 프롬프트로 통합, URL에서 `host`/`owner`/`repo` POSIX 파싱
- `ghes_mirror.sh` Step 2: `gh repo create ... --hostname=...` → `GH_HOST="${_ghes_host}" gh repo create "${_ghes_owner}/${_repo_name}" ...` (플래그 제거, 풀 경로 지정)
- `ghes_mirror.sh` Step 3: `gh api user --hostname=...` 쿼리 삭제 — `_ghes_owner` 변수를 URL 파싱 결과로 직접 사용

## Test plan
- [ ] `shellcheck` 통과 확인
- [ ] `./tests/test` 전체 테스트 1144개 통과 확인
- [ ] `ghes-mirror` 실행 시 질문이 2개(Upstream URL, GHES repo URL)로 축소되는지 확인
- [ ] GHES repo URL에 전체 URL 입력 시 host/owner/repo가 올바르게 파싱되는지 확인

## Related
Closes #936

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
