### PR TITLE
fix(ghes-mirror): personal 계정에서 --internal 실패 시 --private 자동 선택

### DIFF
--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -74,10 +74,18 @@ ghes_mirror() {
     }
 
     # --- Step 2: Create GHES repo ---
-    ux_step 2 "Creating GHES repository (--internal)..."
-    # Use --private instead of --internal if your GHES plan does not support internal repos.
+    # --internal is only allowed on organization-owned repos (#938);
+    # personal accounts fall back to --private automatically.
+    local _account_type _visibility_flag
+    _account_type=$(gh api --hostname "${_ghes_host}" "users/${_ghes_owner}" --jq '.type' 2>/dev/null)
+    if [ "${_account_type}" = "Organization" ]; then
+        _visibility_flag="--internal"
+    else
+        _visibility_flag="--private"
+    fi
+    ux_step 2 "Creating GHES repository (${_visibility_flag})..."
     # GH_HOST env var is required; gh repo create does not support --hostname flag.
-    if ! GH_HOST="${_ghes_host}" gh repo create "${_ghes_owner}/${_repo_name}" --internal --source=.; then
+    if ! GH_HOST="${_ghes_host}" gh repo create "${_ghes_owner}/${_repo_name}" "${_visibility_flag}" --source=.; then
         ux_error "GHES repo creation failed. Check: GH_HOST=${_ghes_host} gh auth status"
         cd "${_orig_dir}" || return 1
         return 1

--- a/shell-common/functions/ghes_mirror_help.sh
+++ b/shell-common/functions/ghes_mirror_help.sh
@@ -31,8 +31,8 @@ ghes_mirror_help() {
 
     ux_section "Notes"
     ux_bullet "The wizard changes your working directory to the cloned repo."
-    ux_bullet "GHES repo visibility defaults to --internal."
-    ux_bullet "Change to --private in ghes_mirror.sh if your plan requires it."
+    ux_bullet "GHES repo visibility is auto-selected: --internal for org owners,"
+    ux_bullet "--private for personal accounts (internal is org-only)."
     echo ""
 }
 


### PR DESCRIPTION
## Summary
- `ghes_mirror` 위자드가 personal 계정 GHES 네임스페이스에서 레포 생성 시 `--internal` 고정 플래그로 인해 `Only organization-owned repositories can have internal visibility` GraphQL 에러로 실패하던 문제 수정
- 레포 생성 전 owner 계정 타입을 감지해 visibility 플래그를 자동 선택

## Changes
- `shell-common/functions/ghes_mirror.sh` Step 2: `gh api users/<owner>` 로 GHES owner 계정 타입을 조회 — `Organization` 이면 `--internal`, personal 계정이면 `--private` 자동 선택. `ux_step` 메시지도 선택된 플래그를 표시하도록 변경
- `shell-common/functions/ghes_mirror_help.sh`: Notes 섹션을 고정 `--internal` 안내에서 자동 선택 동작 설명으로 갱신

## Test plan
- [x] `./tests/test` 전체 통과 (1144 passed)
- [x] shellcheck 통과 (`shell=bash` directive 기준)
- [ ] personal 계정 GHES URL 로 `ghes-mirror` 실행 시 `--private` 로 레포 생성 확인
- [ ] org 계정 GHES URL 로 실행 시 기존 `--internal` 동작 유지 확인

## Related
Closes #938

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
