### PR TITLE
fix(ghes-mirror): --source=. origin remote 충돌 버그 수정

### DIFF
--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -85,7 +85,8 @@ ghes_mirror() {
     fi
     ux_step 2 "Creating GHES repository (${_visibility_flag})..."
     # GH_HOST env var is required; gh repo create does not support --hostname flag.
-    if ! GH_HOST="${_ghes_host}" gh repo create "${_ghes_owner}/${_repo_name}" "${_visibility_flag}" --source=.; then
+    # --remote=_ghes_tmp avoids collision with clone's existing "origin" remote (#941).
+    if ! GH_HOST="${_ghes_host}" gh repo create "${_ghes_owner}/${_repo_name}" "${_visibility_flag}" --source=. --remote=_ghes_tmp; then
         ux_error "GHES repo creation failed. Check: GH_HOST=${_ghes_host} gh auth status"
         cd "${_orig_dir}" || return 1
         return 1
@@ -94,10 +95,10 @@ ghes_mirror() {
     # --- Step 3: Configure remotes ---
     ux_step 3 "Configuring remotes..."
     git remote rename origin upstream
+    git remote rename _ghes_tmp origin
 
     # Owner is parsed directly from the GHES URL — no gh api query needed.
     local _origin_url="https://${_ghes_host}/${_ghes_owner}/${_repo_name}"
-    git remote add origin "${_origin_url}"
     ux_info "upstream -> ${_upstream}"
     ux_info "origin   -> ${_origin_url}"
 

--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -94,8 +94,16 @@ ghes_mirror() {
 
     # --- Step 3: Configure remotes ---
     ux_step 3 "Configuring remotes..."
-    git remote rename origin upstream
-    git remote rename _ghes_tmp origin
+    if ! git remote rename origin upstream; then
+        ux_error "Failed to rename origin to upstream."
+        cd "${_orig_dir}" || return 1
+        return 1
+    fi
+    if ! git remote rename _ghes_tmp origin; then
+        ux_error "Failed to rename _ghes_tmp to origin."
+        cd "${_orig_dir}" || return 1
+        return 1
+    fi
 
     # Owner is parsed directly from the GHES URL — no gh api query needed.
     local _origin_url="https://${_ghes_host}/${_ghes_owner}/${_repo_name}"


### PR DESCRIPTION
## Summary
- `gh repo create --source=.`에 `--remote=_ghes_tmp` 추가로 clone의 기존 `origin` remote 충돌 방지
- Step 3에서 `git remote rename _ghes_tmp origin` 으로 최종 remote 구조 완성

## Changes
- `shell-common/functions/ghes_mirror.sh` Step 2: `--source=.` 에 `--remote=_ghes_tmp` 플래그 추가
- `shell-common/functions/ghes_mirror.sh` Step 3: `git remote add origin` 대신 `git remote rename _ghes_tmp origin` 으로 대체

## Test plan
- [ ] `ghes-mirror` 실행 후 Step 2에서 "Unable to add remote origin" 에러가 사라지는지 확인
- [ ] Step 3 완료 후 `git remote -v` 에서 `upstream`(공개 GitHub) + `origin`(GHES) 구조 확인

## Related
Closes #941

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
