### PR TITLE
fix(claude-setup): settings.json symlink → 실파일 복사로 /model 오염 차단

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `
 
 ### Claude Code Integration
 
-`claude/settings.json` and `claude/statusline-command.sh` are symlinked into `~/.claude/`. The `claude/skills/` and `claude/docs/` directories are also symlinked (directory-level) into each account's `~/.claude*/skills` and `~/.claude*/docs` — the same scheme in every setup mode (#575).
+`claude/statusline-command.sh` is symlinked into `~/.claude/`. The `claude/skills/` and `claude/docs/` directories are also symlinked (directory-level) into each account's `~/.claude*/skills` and `~/.claude*/docs` — the same scheme in every setup mode (#575). `claude/settings.json` is **copied as a real file** (not symlinked) into each config dir (#940 multi-account, #687 internal) — Claude Code's `/model` persists into that file, and a symlink would write through into the tracked SSOT (#924).
 
 **Personal overrides (model, env vars)** — `claude/settings.local.json` is gitignored (#924). Create `settings.local.json` in your active Claude config directory for machine-specific settings:
 
@@ -71,7 +71,7 @@ All output must use `ux_lib` functions (`ux_header`, `ux_success`, `ux_error`, `
 { "model": "sonnet" }
 ```
 
-Claude Code merges this with `settings.json` natively (local wins). Running `/model` writes back to the symlinked `settings.json` — run `git restore claude/settings.json` to discard and keep the model in `settings.local.json` instead.
+Claude Code merges this with `settings.json` natively (local wins). Running `/model` writes into the per-account **real-file** `settings.json` copy — since #940 this no longer dirties the repo. Re-running `claude/setup.sh` refreshes the copy from the SSOT and auto-migrates any `/model`-written `model` key into `settings.local.json`.
 
 ## Critical Rules
 

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -60,7 +60,7 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 ```bash
 # 외부 PC (옵션 1, 3) — 멀티-계정
-~/.claude-personal/settings.json         -> dotfiles/claude/settings.json
+~/.claude-personal/settings.json         = dotfiles/claude/settings.json 의 실파일 복사 (#940, symlink 아님)
 ~/.claude-personal/statusline-command.sh -> dotfiles/claude/statusline-command.sh
 ~/.claude-personal/skills/<name>         -> dotfiles/claude/skills/<name>   (entry symlink, #707)
 ~/.claude-personal/docs                  -> dotfiles/claude/docs            (dir symlink, #575)
@@ -68,7 +68,7 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 ~/.claude-personal/projects/GLOBAL/memory -> dotfiles/claude/global-memory
 
 # 사내 PC (옵션 2) — 단일 계정 (issue #571)
-~/.claude/settings.json                  -> dotfiles/claude/settings.json
+~/.claude/settings.json                  = aws/setup.sh 가 SSOT + Bedrock 오버레이를 merge 한 실파일 (#687)
 ~/.claude/statusline-command.sh          -> dotfiles/claude/statusline-command.sh
 ~/.claude/skills/<name>                  -> dotfiles/claude/skills/<name>   (entry symlink, #707)
 ~/.claude/docs                           -> dotfiles/claude/docs            (dir symlink)
@@ -83,7 +83,7 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 기존 PC 에 남아 있는 `/etc/sudoers.d/claude-{skills,docs}-mount-*` 파일은 #575 이후로 사용처가 없다. `claude/setup.sh` 실행 시 잔존 파일이 감지되면 수동 삭제 명령을 안내한다.
 
-`settings.json` — **tracked SSOT** (#584). 동일한 파일이 Home/External/Internal 모두에서 `~/.claude/settings.json` 으로 심볼릭링크됨.
+`settings.json` — **tracked SSOT** (#584). 모든 모드에서 config dir 의 `settings.json` 은 SSOT 의 **실파일 복사**다 — 멀티 계정은 `_claude_ensure_settings_copy` (#940), Internal 은 `aws/setup.sh` merge (#687). symlink 였던 구 레이아웃은 Claude Code `/model` 이 tracked SSOT 를 write-through 로 오염시켰음 (#924 → #940). 기존 실파일의 개인 `model` 키는 setup 재실행 시 `settings.local.json` 으로 자동 이주.
 `~/.claude/settings.local.json` — out-of-repo, gitignored, Internal PC 1회 손수 작성. 사번 헤더 / 사내 `ANTHROPIC_*` 가 들어가며 Claude Code 가 settings.json 과 native merge. `claude/setup.sh` 가 Internal 모드 종료 직전 copy-paste heredoc 안내 출력 (#584).
 
 `~/.dotfiles-setup-mode` 가 `internal` 이면 `claude_yolo` 가 멀티-계정 해석을 우회하고 `~/.claude/` 를 강제 사용 (F-2). 잘못 migrate된 사내 PC 복구: `claude-accounts rollback` (F-3). 자세한 내용은 `docs/guide/internal-pc.md`.

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -700,10 +700,17 @@ done
 # --- Verify Links (모든 활성 계정) ---
 # skills/ is a real directory of entry-level symlinks (#707, F-8), so it
 # is checked as `-d` (and `! -L`) rather than `-L`.
+# settings.json is a real-file copy since #940 (not a symlink) — the
+# write-through symlink let /model pollute the tracked SSOT (#924).
 ux_section "심볼릭 링크 확인"
 for acct in $ENABLED_ACCOUNTS; do
     cdir=$(_claude_resolve_account "$acct")
-    for link in settings.json statusline-command.sh docs plugins projects/GLOBAL/memory; do
+    if [ -f "${cdir}/settings.json" ] && [ ! -L "${cdir}/settings.json" ]; then
+        log_dim "✓ ${acct}/settings.json 실파일 확인됨"
+    else
+        log_error_and_exit "${acct}/settings.json 실파일 생성 실패"
+    fi
+    for link in statusline-command.sh docs plugins projects/GLOBAL/memory; do
         if [ -L "${cdir}/${link}" ]; then
             log_dim "✓ ${acct}/${link} 심볼릭 링크 확인됨"
         else

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -639,6 +639,69 @@ _claude_ensure_symlink() {
     ux_success "  created symlink: $_ces_tgt → $_ces_src"
 }
 
+# _claude_ensure_settings_copy — settings.json 멱등 실파일 설치 (#940).
+#
+# Claude Code 의 /model 은 active config dir 의 settings.json 에 직접
+# persist 한다. 이 파일이 dotfiles SSOT 로의 symlink 면 write-through 로
+# tracked 파일이 오염된다 (#924 의 재발 경로). internal 모드가 #687 에서
+# 실파일로 전환한 것과 같은 원리를 다중 계정 모드에도 적용:
+#   - 기존 symlink (canonical / worktree-tainted 불문) 는 제거 후 SSOT 복사
+#   - 기존 실파일의 개인 `model` 키는 settings.local.json 으로 1회 이주
+#     (jq 없으면 경고 후 SSOT 가 덮어씀)
+#   - dangling settings.local.json symlink (teardown 된 worktree 잔재) 제거
+_claude_ensure_settings_copy() {
+    _cesc_src="$1"
+    _cesc_tgt="$2"
+    _cesc_local="$(dirname "$_cesc_tgt")/settings.local.json"
+
+    # dangling settings.local.json 정리가 model 이주보다 먼저 — 깨진 링크를
+    # 통해 쓰면 소멸한 worktree 경로로 write 가 향해 실패한다 (#940).
+    if [ -L "$_cesc_local" ] && [ ! -e "$_cesc_local" ]; then
+        rm -f "$_cesc_local"
+        ux_warning "  removed dangling settings.local.json symlink: $_cesc_local"
+    fi
+
+    if [ -L "$_cesc_tgt" ]; then
+        rm "$_cesc_tgt"
+        ux_warning "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
+    elif [ -f "$_cesc_tgt" ] && ! cmp -s "$_cesc_src" "$_cesc_tgt"; then
+        # /model 이 남긴 개인 model 키 보존 — SSOT 복사로 사라지기 전에
+        # settings.local.json 으로 이주. local 에 이미 model 이 있으면 그대로.
+        if command -v jq >/dev/null 2>&1; then
+            _cesc_model=$(jq -r '.model // empty' "$_cesc_tgt" 2>/dev/null)
+            if [ -n "$_cesc_model" ]; then
+                if [ ! -f "$_cesc_local" ]; then
+                    printf '{ "model": "%s" }\n' "$_cesc_model" > "$_cesc_local"
+                    chmod 600 "$_cesc_local"
+                    ux_info "  migrated model '$_cesc_model' → $_cesc_local"
+                elif [ -z "$(jq -r '.model // empty' "$_cesc_local" 2>/dev/null)" ]; then
+                    _cesc_tmp=$(mktemp)
+                    if jq --arg m "$_cesc_model" '.model = $m' "$_cesc_local" > "$_cesc_tmp"; then
+                        mv "$_cesc_tmp" "$_cesc_local"
+                        ux_info "  migrated model '$_cesc_model' → $_cesc_local"
+                    else
+                        rm -f "$_cesc_tmp"
+                        ux_warning "  model migration failed — keeping $_cesc_local as-is"
+                    fi
+                fi
+            fi
+        else
+            ux_warning "  jq 없음 — $_cesc_tgt 의 로컬 변경(model 등)은 SSOT 로 덮어씀"
+        fi
+    fi
+
+    if [ -f "$_cesc_tgt" ] && cmp -s "$_cesc_src" "$_cesc_tgt"; then
+        ux_info "  ✓ settings.json up to date (real file): $_cesc_tgt"
+        return 0
+    fi
+    if ! cp "$_cesc_src" "$_cesc_tgt"; then
+        ux_error "  settings.json copy failed: $_cesc_src → $_cesc_tgt"
+        return 1
+    fi
+    chmod 600 "$_cesc_tgt"
+    ux_success "  installed settings.json (real file): $_cesc_tgt"
+}
+
 # _claude_dir_sync_one / _claude_count_dir_sync / claude_skills_sync —
 # REMOVED (issue #575).
 #
@@ -770,7 +833,10 @@ _claude_account_setup_one() {
     mkdir -p "$_caso_cdir"
     mkdir -p "$_caso_cdir/projects/GLOBAL"
 
-    _claude_ensure_symlink "${DOTFILES_ROOT}/claude/settings.json"          "$_caso_cdir/settings.json"
+    # settings.json is a real-file copy, NOT a symlink (#940) — Claude Code's
+    # /model persists into this file, and a symlink would write through into
+    # the tracked dotfiles SSOT (the #924 recurrence path).
+    _claude_ensure_settings_copy "${DOTFILES_ROOT}/claude/settings.json"    "$_caso_cdir/settings.json"
     # settings.local.json is intentionally NOT symlinked from dotfiles (#584) —
     # it is a per-PC regular file the user hand-creates only when local env
     # overrides are needed. Claude Code merges it with settings.json natively.
@@ -867,7 +933,23 @@ claude_accounts_status() {
         fi
 
         for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory skills docs; do
-            if [ -L "$_cas_cdir/$_cas_link" ]; then
+            if [ "$_cas_link" = "settings.json" ]; then
+                # settings.json is a real-file copy since #940 (was a
+                # symlink) — a symlink here is the legacy write-through
+                # layout that lets /model pollute the tracked SSOT (#924).
+                if [ -L "$_cas_cdir/$_cas_link" ]; then
+                    echo "  $_cas_link: symlink ✗ legacy layout (#940) — run: claude-accounts repair"
+                elif [ -f "$_cas_cdir/$_cas_link" ]; then
+                    echo "  $_cas_link: regular file ✓"
+                else
+                    echo "  $_cas_link: ✗ missing"
+                fi
+            elif [ -L "$_cas_cdir/$_cas_link" ] && [ ! -e "$_cas_cdir/$_cas_link" ]; then
+                # Dangling symlink — e.g. settings.local.json left pointing
+                # into a torn-down worktree (#940). Reporting it as
+                # "symlink ✓" hid the breakage at diagnosis time.
+                echo "  $_cas_link: broken symlink ✗ — target missing"
+            elif [ -L "$_cas_cdir/$_cas_link" ]; then
                 echo "  $_cas_link: symlink ✓"
             elif [ "$_cas_link" = "settings.local.json" ] && [ -f "$_cas_cdir/$_cas_link" ]; then
                 # settings.local.json is a per-PC hand-created regular
@@ -1238,6 +1320,28 @@ claude_accounts_repair() {
             [ -L "$_car_link" ] || continue
 
             _car_target=$(readlink "$_car_link" 2>/dev/null || true)
+
+            # settings.json must be a real-file copy since #940 — ANY
+            # symlink here (canonical or tainted) is the legacy
+            # write-through layout that lets /model pollute the tracked
+            # SSOT (#924). Convert instead of rebinding.
+            if [ "$_car_rel" = "settings.json" ]; then
+                ux_warning "  convert to real file (#940): $_car_link"
+                ux_info    "    from symlink: $_car_target"
+                ux_info    "    copy of:      $_car_canon"
+                if [ "$_car_dry" = "0" ]; then
+                    if rm -f "$_car_link" && cp "$_car_canon" "$_car_link"; then
+                        chmod 600 "$_car_link"
+                        _car_repaired=$((_car_repaired + 1))
+                    else
+                        ux_error "    convert failed — manual recovery needed"
+                    fi
+                else
+                    _car_repaired=$((_car_repaired + 1))
+                fi
+                continue
+            fi
+
             _car_needs_fix=0
 
             # Case 1: dangling — readlink target does not resolve.

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -675,8 +675,13 @@ _claude_ensure_settings_copy() {
                     chmod 600 "$_cesc_local"
                     ux_info "  migrated model '$_cesc_model' → $_cesc_local"
                 elif [ -z "$(jq -r '.model // empty' "$_cesc_local" 2>/dev/null)" ]; then
-                    _cesc_tmp=$(mktemp)
-                    if jq --arg m "$_cesc_model" '.model = $m' "$_cesc_local" > "$_cesc_tmp"; then
+                    # mktemp: 명시 템플릿 + TMPDIR 폴백 — BSD/macOS 이식성과
+                    # 공유 /tmp 의 예측 가능한 이름 회피 (PR #943 리뷰).
+                    # 실패 시 soft-fail — sourced 함수이므로 exit 금지.
+                    _cesc_tmp=$(mktemp "${TMPDIR:-/tmp}/claude_settings.XXXXXX") || _cesc_tmp=
+                    if [ -z "$_cesc_tmp" ]; then
+                        ux_warning "  mktemp failed — model migration skipped, keeping $_cesc_local as-is"
+                    elif jq --arg m "$_cesc_model" '.model = $m' "$_cesc_local" > "$_cesc_tmp"; then
                         mv "$_cesc_tmp" "$_cesc_local"
                         ux_info "  migrated model '$_cesc_model' → $_cesc_local"
                     else

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -222,7 +222,11 @@ LOCAL
     run_in_bash "_claude_account_setup_one personal '$HOME/.claude-personal'"
     assert_success
 
-    [ -L "$HOME/.claude-personal/settings.json" ]
+    # settings.json is a real-file copy of the SSOT since #940 — a symlink
+    # would let /model write through into the tracked dotfiles file (#924).
+    [ -f "$HOME/.claude-personal/settings.json" ]
+    [ ! -L "$HOME/.claude-personal/settings.json" ]
+    cmp -s "${DOTFILES_ROOT}/claude/settings.json" "$HOME/.claude-personal/settings.json"
     [ -L "$HOME/.claude-personal/statusline-command.sh" ]
     [ -L "$HOME/.claude-personal/plugins" ]
     [ -L "$HOME/.claude-personal/projects/GLOBAL/memory" ]
@@ -236,6 +240,55 @@ LOCAL
     # settings.local.json is intentionally a per-PC hand-created regular
     # file (#584) — never a dotfiles symlink.
     [ ! -L "$HOME/.claude-personal/settings.local.json" ]
+}
+
+@test "bash: _claude_ensure_settings_copy converts a legacy settings.json symlink to a real file (#940)" {
+    mkdir -p "$HOME/.claude-personal"
+    ln -s "${DOTFILES_ROOT}/claude/settings.json" "$HOME/.claude-personal/settings.json"
+
+    run_in_bash "_claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'"
+    assert_success
+
+    [ -f "$HOME/.claude-personal/settings.json" ]
+    [ ! -L "$HOME/.claude-personal/settings.json" ]
+    cmp -s "${DOTFILES_ROOT}/claude/settings.json" "$HOME/.claude-personal/settings.json"
+}
+
+@test "bash: _claude_ensure_settings_copy migrates a /model-written model key into settings.local.json (#940)" {
+    mkdir -p "$HOME/.claude-personal"
+    # Simulate the post-/model state: real file = SSOT + personal model key.
+    jq '.model = "opus"' "${DOTFILES_ROOT}/claude/settings.json" \
+        > "$HOME/.claude-personal/settings.json"
+
+    run_in_bash "_claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'"
+    assert_success
+
+    # SSOT wins in settings.json; the model preference survives in local.
+    cmp -s "${DOTFILES_ROOT}/claude/settings.json" "$HOME/.claude-personal/settings.json"
+    [ "$(jq -r '.model' "$HOME/.claude-personal/settings.local.json")" = "opus" ]
+}
+
+@test "bash: _claude_ensure_settings_copy removes a dangling settings.local.json symlink (#940)" {
+    mkdir -p "$HOME/.claude-personal"
+    ln -s "/tmp/torn-down-worktree-DOES-NOT-EXIST/claude/settings.local.json" \
+        "$HOME/.claude-personal/settings.local.json"
+
+    run_in_bash "_claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'"
+    assert_success
+
+    [ ! -L "$HOME/.claude-personal/settings.local.json" ]
+    [ ! -e "$HOME/.claude-personal/settings.local.json" ]
+}
+
+@test "bash: _claude_ensure_settings_copy is idempotent (second run reports up to date)" {
+    mkdir -p "$HOME/.claude-personal"
+
+    run_in_bash "
+        _claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json' >/dev/null 2>&1
+        _claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'
+    "
+    assert_success
+    assert_output --partial "up to date"
 }
 
 @test "bash: _claude_account_setup_one unmounts a legacy bind mount on skills (issue #575 migration)" {
@@ -678,7 +731,9 @@ _setup_sh_prereqs() {
     run_in_bash "CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_SKIP_SUDOERS=1 bash '${DOTFILES_ROOT}/claude/setup.sh'"
     assert_success
 
-    [ -L "$HOME/.claude-personal/settings.json" ]
+    # settings.json is a real-file copy since #940 — not a symlink.
+    [ -f "$HOME/.claude-personal/settings.json" ]
+    [ ! -L "$HOME/.claude-personal/settings.json" ]
     [ -L "$HOME/.claude-personal/projects/GLOBAL/memory" ]
 }
 

--- a/tests/bats/integrations/claude_accounts_repair.bats
+++ b/tests/bats/integrations/claude_accounts_repair.bats
@@ -42,10 +42,14 @@ teardown() {
 # repair (apply) — dangling symlinks rebound to canonical DOTFILES_ROOT
 # ---------------------------------------------------------------------------
 
-@test "claude_accounts_repair: rebinds dangling settings.json to canonical root" {
-    run_in_bash 'claude_accounts_repair >/dev/null 2>&1; readlink "$HOME/.claude-personal/settings.json"'
+@test "claude_accounts_repair: converts dangling settings.json symlink to a real-file copy (#940)" {
+    run_in_bash 'claude_accounts_repair >/dev/null 2>&1'
     assert_success
-    assert_output "$DOTFILES_ROOT/claude/settings.json"
+    # settings.json must be a real file since #940 — a symlink (even a
+    # canonical one) lets /model write through into the tracked SSOT (#924).
+    [ -f "$HOME/.claude-personal/settings.json" ]
+    [ ! -L "$HOME/.claude-personal/settings.json" ]
+    cmp -s "$DOTFILES_ROOT/claude/settings.json" "$HOME/.claude-personal/settings.json"
 }
 
 @test "claude_accounts_repair: rebinds dangling skills (directory symlink) too" {
@@ -60,13 +64,20 @@ teardown() {
     assert_output "$DOTFILES_ROOT/claude/global-memory"
 }
 
-@test "claude_accounts_repair: leaves an already-canonical symlink alone" {
-    run_in_bash 'claude_accounts_repair >/dev/null 2>&1; readlink "$HOME/.claude-work/settings.json"'
+@test "claude_accounts_repair: converts even a canonical settings.json symlink (#940 legacy layout)" {
+    # Pre-#940 the canonical symlink was left alone; it is now the legacy
+    # write-through layout and must become a real-file copy.
+    run_in_bash 'claude_accounts_repair >/dev/null 2>&1'
     assert_success
-    assert_output "$DOTFILES_ROOT/claude/settings.json"
+    [ -f "$HOME/.claude-work/settings.json" ]
+    [ ! -L "$HOME/.claude-work/settings.json" ]
+    cmp -s "$DOTFILES_ROOT/claude/settings.json" "$HOME/.claude-work/settings.json"
 }
 
 @test "claude_accounts_repair: reports skipped count for canonical entries" {
+    # Stage a canonical non-settings symlink so the skip path is exercised
+    # (settings.json no longer counts as canonical-skippable since #940).
+    ln -s "$DOTFILES_ROOT/claude/docs" "$HOME/.claude-work/docs"
     run_in_bash 'claude_accounts_repair 2>&1'
     assert_success
     assert_output --partial "already canonical"


### PR DESCRIPTION
## Summary
- 다중 계정 모드의 `~/.claude-*/settings.json` 을 SSOT symlink 에서 **실파일 복사**로 전환 — Claude Code `/model` 의 write-through 로 tracked `claude/settings.json` 이 재오염되던 구조적 갭 차단 (#924 재발 경로)
- dangling `settings.local.json` symlink (teardown 된 worktree 잔재) 자동 정리 + 진단 가시화
- internal 모드가 #687 에서 채택한 실파일 원리를 멀티 계정 모드로 확장

## Changes
- `shell-common/tools/integrations/claude.sh`
  - `_claude_ensure_settings_copy` 신설: SSOT 실파일 복사 (멱등, cmp 비교), 기존 symlink (canonical/tainted 불문) 제거, 기존 실파일의 개인 `model` 키를 `settings.local.json` 으로 1회 이주 (jq 가드), dangling `settings.local.json` symlink 정리
  - `_claude_account_setup_one`: settings.json 을 symlink 대신 실파일 복사로 설치
  - `claude_accounts_repair`: settings.json symlink 발견 시 rebind 대신 실파일 전환 (canonical symlink 도 legacy 로 간주)
  - `claude_accounts_status`: settings.json 실파일 보고 + dangling symlink 를 `broken symlink ✗` 로 보고 (기존엔 `symlink ✓` 오보고)
- `claude/setup.sh`: 멀티 계정 verify 루프에서 settings.json 을 실파일 검증으로 분리
- `tests/bats/integrations/claude_accounts.bats`: #940 신규 4 케이스 (symlink→실파일 전환 / model 키 이주 / dangling 정리 / 멱등성) + 기존 케이스 실파일 기대로 갱신
- `tests/bats/integrations/claude_accounts_repair.bats`: settings.json 전환 기대로 갱신 (canonical symlink 도 전환됨을 고정)
- `CLAUDE.md` / `claude/AGENTS.md`: 레이아웃 서술 갱신 (#940 실파일 정책)

## Test plan
- [x] bats: `claude_accounts.bats` 100 케이스 중 99 통과 (실패 1건은 main 에서도 동일 실패하는 pre-existing #300-A)
- [x] bats: `claude_accounts_repair.bats` 8/8 통과
- [x] bats 전체 1153 중 1150 통과 — 실패 3건 모두 main 에서 동일 실패 (pre-existing)
- [x] pytest 1144 통과
- [x] shellcheck: main 대비 신규 경고 0 (diff 비교)
- [ ] 실환경: `claude/setup.sh` 재실행 후 `/model` 변경 → `~/dotfiles` `git status` clean 유지

## Related
Fixes #940

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
