### PR TITLE
fix(mirror-pages-activate): #946 functions/ wrapper + alias 추가

### DIFF
--- a/shell-common/functions/mirror_pages_activate.sh
+++ b/shell-common/functions/mirror_pages_activate.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/mirror_pages_activate.sh
+# Wrapper function: delegates to tools/custom/mirror-pages-activate.sh.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+mirror_pages_activate() {
+    if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+        mirror_pages_activate_help
+        return 0
+    fi
+    "${SHELL_COMMON}/tools/custom/mirror-pages-activate.sh" "$@"
+}
+
+alias mirror-pages-activate='mirror_pages_activate'

--- a/shell-common/functions/mirror_pages_activate_help.sh
+++ b/shell-common/functions/mirror_pages_activate_help.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# shell-common/functions/mirror_pages_activate_help.sh
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+mirror_pages_activate_help() {
+    ux_header "mirror-pages-activate"
+
+    ux_section "Usage"
+    echo "  ${UX_SUCCESS}mirror-pages-activate${UX_RESET}           ${UX_MUTED}# activate Pages + replace URLs${UX_RESET}"
+    echo "  ${UX_SUCCESS}mirror-pages-activate --dry-run${UX_RESET} ${UX_MUTED}# preview without making changes${UX_RESET}"
+    echo "  ${UX_SUCCESS}mirror-pages-activate --help${UX_RESET}    ${UX_MUTED}# show this help${UX_RESET}"
+    echo ""
+
+    ux_section "What it does"
+    ux_bullet "Activates GitHub Pages on the GHE origin repo (branch=main, path=/docs)"
+    ux_bullet "Replaces upstream github.io Pages URLs in README.md with the GHE Pages URL"
+    echo ""
+
+    ux_section "Requirements"
+    ux_bullet "Run from inside a mirrored repo (set up by ghes-mirror)"
+    ux_bullet "origin   = GHE mirror  (https://<ghe-host>/owner/repo)"
+    ux_bullet "upstream = github.com source"
+    ux_bullet "gh CLI authenticated to the GHE host  (gh auth login --hostname <host>)"
+    echo ""
+
+    ux_section "See also"
+    ux_bullet "ghes-mirror — clone + mirror a public GitHub repo to GHES"
+    echo ""
+}
+
+alias mirror-pages-activate-help='mirror_pages_activate_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -158,7 +158,7 @@ _register_default_help_categories() {
     HELP_CATEGORIES[system]="${HELP_CATEGORIES[system]:-System tools (directory navigation, opencode)}"
 
     # Category membership (space-separated topic keys)
-    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool ghes_mirror}"
+    HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool ghes_mirror mirror_pages_activate}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
@@ -259,6 +259,7 @@ _register_default_help_descriptions() {
     # mirrors an existing public `<topic>_help` function in shell-common/functions/
     # that previously slipped through the registry.
     HELP_DESCRIPTIONS[ghes_mirror_help]="${HELP_DESCRIPTIONS[ghes_mirror_help]:-[Development] Mirror public GitHub repo to internal GHES instance}"
+    HELP_DESCRIPTIONS[mirror_pages_activate_help]="${HELP_DESCRIPTIONS[mirror_pages_activate_help]:-[Development] Activate GHE Pages + replace upstream URLs in README}"
     HELP_DESCRIPTIONS[gh_flow_help]="${HELP_DESCRIPTIONS[gh_flow_help]:-[Development] gh-flow issue/PR worker pipeline}"
     HELP_DESCRIPTIONS[gh_pr_review_help]="${HELP_DESCRIPTIONS[gh_pr_review_help]:-[Development] gh-pr-review external-AI review delegation}"
     HELP_DESCRIPTIONS[gh_pr_reply_help]="${HELP_DESCRIPTIONS[gh_pr_reply_help]:-[Development] gh-pr-reply review-comment handler}"


### PR DESCRIPTION
## Summary
- `shell-common/functions/` wrapper + alias 2개 추가로 `mirror-pages-activate` 명령을 인터랙티브 셸에서 직접 호출 가능하게 함
- `tools/custom/mirror-pages-activate.sh` 는 auto-source 되지 않는 경로에 위치하므로, 3-Step Pattern(wrapper + help + my_help 등록)을 적용

## Changes
- `shell-common/functions/mirror_pages_activate.sh`: wrapper 함수 + `alias mirror-pages-activate` — `tools/custom/mirror-pages-activate.sh` 로 위임
- `shell-common/functions/mirror_pages_activate_help.sh`: `mirror_pages_activate_help()` 함수 + `alias mirror-pages-activate-help`
- `shell-common/functions/my_help.sh`: `HELP_CATEGORY_MEMBERS[development]` 에 `mirror_pages_activate` 추가 + `HELP_DESCRIPTIONS[mirror_pages_activate_help]` 등록

## Test plan
- [ ] `./tests/test` 전체 통과 (bats + pytest + golden rules)
- [ ] `mirror-pages-activate --help` 가 help 텍스트 출력
- [ ] `my-help development` 목록에 `mirror_pages_activate` 항목 표시
- [ ] `mirror-pages-activate-help` 가 help 함수 실행

## Related
Closes #946

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
