### PR TITLE
fix(ghes-mirror): origin remote SSH → HTTPS 강제 설정

### DIFF
--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -107,6 +107,9 @@ ghes_mirror() {
 
     # Owner is parsed directly from the GHES URL — no gh api query needed.
     local _origin_url="https://${_ghes_host}/${_ghes_owner}/${_repo_name}"
+    # gh repo create may have registered an SSH URL (following gh's git_protocol
+    # setting); force HTTPS so origin is always protocol-agnostic.
+    git remote set-url origin "${_origin_url}"
     ux_info "upstream -> ${_upstream}"
     ux_info "origin   -> ${_origin_url}"
 

--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -109,7 +109,11 @@ ghes_mirror() {
     local _origin_url="https://${_ghes_host}/${_ghes_owner}/${_repo_name}"
     # gh repo create may have registered an SSH URL (following gh's git_protocol
     # setting); force HTTPS so origin is always protocol-agnostic.
-    git remote set-url origin "${_origin_url}"
+    if ! git remote set-url origin "${_origin_url}"; then
+        ux_error "Failed to set origin URL to ${_origin_url}."
+        cd "${_orig_dir}" || return 1
+        return 1
+    fi
     ux_info "upstream -> ${_upstream}"
     ux_info "origin   -> ${_origin_url}"
 


### PR DESCRIPTION
## Summary
- `ghes_mirror` Step 3의 remote 이름 변경 후 origin URL이 SSH 형태로 남는 버그 수정
- `git remote set-url`로 HTTPS URL을 명시적으로 강제 설정

## Changes
- `shell-common/functions/ghes_mirror.sh`: `git remote rename _ghes_tmp origin` 직후 `git remote set-url origin "${_origin_url}"` 추가 — `gh`의 `git_protocol` 설정(SSH)과 무관하게 origin이 항상 HTTPS URL을 갖도록 보장

## Test plan
- [ ] shellcheck 통과 확인 (no output)
- [ ] 1144개 기존 테스트 전체 통과

## Related
Closes #951

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
