### PR TITLE
fix(ghes-mirror): GHES 레포 visibility --public 고정

### DIFF
--- a/shell-common/functions/ghes_mirror.sh
+++ b/shell-common/functions/ghes_mirror.sh
@@ -74,15 +74,9 @@ ghes_mirror() {
     }
 
     # --- Step 2: Create GHES repo ---
-    # --internal is only allowed on organization-owned repos (#938);
-    # personal accounts fall back to --private automatically.
-    local _account_type _visibility_flag
-    _account_type=$(gh api --hostname "${_ghes_host}" "users/${_ghes_owner}" --jq '.type' 2>/dev/null)
-    if [ "${_account_type}" = "Organization" ]; then
-        _visibility_flag="--internal"
-    else
-        _visibility_flag="--private"
-    fi
+    # upstream is always a public repo, so mirror as --public.
+    # --internal is GHEC-only (not supported on GHES); account-type detection is unnecessary.
+    local _visibility_flag="--public"
     ux_step 2 "Creating GHES repository (${_visibility_flag})..."
     # GH_HOST env var is required; gh repo create does not support --hostname flag.
     # --remote=_ghes_tmp avoids collision with clone's existing "origin" remote (#941).

--- a/shell-common/functions/ghes_mirror_help.sh
+++ b/shell-common/functions/ghes_mirror_help.sh
@@ -31,8 +31,7 @@ ghes_mirror_help() {
 
     ux_section "Notes"
     ux_bullet "The wizard changes your working directory to the cloned repo."
-    ux_bullet "GHES repo visibility is auto-selected: --internal for org owners,"
-    ux_bullet "--private for personal accounts (internal is org-only)."
+    ux_bullet "GHES repo visibility: --public (upstream is public; --internal is GHEC-only)."
     echo ""
 }
 


### PR DESCRIPTION
## Summary
- `ghes_mirror` Step 2의 GHES 레포 생성 시 visibility를 `--public`으로 고정
- GHEC 전용인 `--internal` 플래그와 불필요한 계정 타입 감지 로직(`gh api users/<owner>`) 제거

## Changes
- `shell-common/functions/ghes_mirror.sh`: 계정 타입 분기 블록(5줄) → `local _visibility_flag="--public"` 단일 라인 대체

## Test plan
- [ ] `shellcheck shell-common/functions/ghes_mirror.sh` 통과 확인
- [ ] `ghes_mirror` 호출 시 Step 2가 `--public` 플래그로 GHES 레포를 생성하는지 확인

## Related
Fixes #953

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
