### PR TITLE
fix(mirror-pages-activate): #955 Pages 상태 오판 및 upstream owner 대소문자 불일치 수정

### DIFF
--- a/shell-common/tools/custom/mirror-pages-activate.sh
+++ b/shell-common/tools/custom/mirror-pages-activate.sh
@@ -95,8 +95,11 @@ main() {
 	fi
 
 	# --- Derive Pages URL components ---
-	local _upstream_pages_base _origin_pages_base _origin_pages_url
-	_upstream_pages_base="${_upstream_owner}.github.io/${_repo_name}"
+	# GitHub Pages hostnames are always lowercase, so normalize the upstream
+	# owner before building the github.io base (#955 — dEitY719 vs deity719).
+	local _upstream_pages_base _origin_pages_base _origin_pages_url _upstream_owner_lc
+	_upstream_owner_lc=$(printf '%s' "${_upstream_owner}" | tr '[:upper:]' '[:lower:]')
+	_upstream_pages_base="${_upstream_owner_lc}.github.io/${_repo_name}"
 	_origin_pages_base="${_ghe_host}/pages/${_origin_owner}/${_repo_name}"
 	_origin_pages_url="https://${_origin_pages_base}"
 
@@ -113,12 +116,15 @@ main() {
 	# --- Step 1: Activate GitHub Pages ---
 	ux_step 1 "GitHub Pages activation"
 
+	# When Pages is inactive the API returns 404 and `gh` exits non-zero, so
+	# stdout is empty. Don't substitute a sentinel — an empty string is the
+	# unambiguous "not active" signal (#955).
 	local _pages_status
 	_pages_status=$(gh api --hostname "${_ghe_host}" \
 		"repos/${_origin_owner}/${_repo_name}/pages" \
-		--jq '.status' 2>/dev/null || printf 'NOT_FOUND')
+		--jq '.status' 2>/dev/null) || _pages_status=""
 
-	if [ "${_pages_status}" != "NOT_FOUND" ] && [ -n "${_pages_status}" ]; then
+	if [ -n "${_pages_status}" ]; then
 		ux_info "Pages already active (status: ${_pages_status}) — skip"
 	else
 		if [ "${_DRY_RUN}" -eq 1 ]; then

--- a/tests/bats/tools/mirror_pages_activate.bats
+++ b/tests/bats/tools/mirror_pages_activate.bats
@@ -60,17 +60,19 @@ _setup_fake_repo() {
 }
 
 _write_mock_gh() {
-    # Writes a stub `gh` that returns NOT_FOUND for pages GET calls.
-    # Place it early in PATH so it overrides the real gh.
+    # Writes a stub `gh` that simulates an inactive Pages site: the GET
+    # returns 404 (non-zero exit, empty stdout) like the real `gh api`, and
+    # the POST succeeds. Matches the #955 logic where an empty `_pages_status`
+    # is the "not active" signal. Place it early in PATH to override real gh.
     local bin_dir="${_WORK_DIR}/bin"
     mkdir -p "${bin_dir}"
     cat >"${bin_dir}/gh" <<'EOF'
 #!/bin/bash
-# Stub: pages GET -> NOT_FOUND; pages POST -> success
+# Stub: pages GET -> 404 (inactive); pages POST -> success
 if [[ "$*" == *"/pages"* ]]; then
     case "$*" in
         *"--method POST"*) exit 0 ;;
-        *) printf 'NOT_FOUND'; exit 0 ;;
+        *) exit 1 ;;
     esac
 fi
 exit 0
@@ -241,10 +243,11 @@ EOF
     mkdir -p "${bin_dir}"
     cat >"${bin_dir}/gh" <<'EOF'
 #!/bin/bash
+# GET pages -> 404 (inactive); POST -> success (#955)
 if [[ "$*" == *"--method POST"* ]]; then
     exit 0
 fi
-printf 'NOT_FOUND'; exit 0
+exit 1
 EOF
     chmod +x "${bin_dir}/gh"
     _setup_fake_repo \


### PR DESCRIPTION
## Summary

`mirror-pages-activate.sh` 가 새 mirrored repo 에서 **처음 실행될 때** 두 가지 버그로 정상 동작하지 않던 문제를 수정합니다.

## Bug 1 — Pages 상태 판정 오류

- 기존 `--jq '.status' 2>/dev/null || printf 'NOT_FOUND'` 는 Pages 비활성(404) 상황에서도 sentinel(`NOT_FOUND`)을 채워, 후속 조건 로직이 잘못 구성되어 **활성으로 오판**하고 activation 을 건너뛰었습니다.
- `|| _pages_status=""` 로 변경해 빈 문자열을 "비활성" 신호로 사용하고, 판정을 `[ -n "${_pages_status}" ]` 로 단순화했습니다.
- `set -e` 하에서 command substitution 실패가 스크립트를 중단시키지 않도록 `||` 폴백 자체는 유지합니다.

## Bug 2 — upstream owner 대소문자 불일치

- GitHub Pages 호스트명은 항상 소문자이지만 owner(`dEitY719`)를 그대로 사용해, README 의 실제 URL(`deity719.github.io`)과 매칭되지 않아 치환이 누락됐습니다 (`--dry-run` 에서 "nothing to do").
- `tr '[:upper:]' '[:lower:]'` 로 owner 를 소문자 정규화한 뒤 `_upstream_pages_base` 를 구성합니다.

## Test plan

- [x] `shellcheck` / `shfmt -d` clean
- [x] 빈 status → activation 분기 진입 (단위 로직 검증)
- [x] `dEitY719` → `deity719.github.io/...` 정규화 검증

Closes #955
