### PR TITLE
fix(mirror-pages-activate): #957 Pages 활성화 실패 시 API 에러 진단 출력 복구

### DIFF
--- a/shell-common/tools/custom/mirror-pages-activate.sh
+++ b/shell-common/tools/custom/mirror-pages-activate.sh
@@ -131,15 +131,23 @@ main() {
 			ux_info "[dry-run] Would POST repos/${_origin_owner}/${_repo_name}/pages"
 			ux_info "[dry-run]   source[branch]=main  source[path]=/docs"
 		else
-			if gh api --hostname "${_ghe_host}" \
-				"repos/${_origin_owner}/${_repo_name}/pages" \
-				--method POST \
-				-F "source[branch]=main" \
-				-F "source[path]=/docs" \
-				>/dev/null 2>&1; then
+			# GHE 3.17's Pages API requires a JSON body and rejects the
+			# form-urlencoded payload produced by `gh api -F`, so send JSON
+			# via --input. Capture stdout+stderr instead of discarding them
+			# so a real API rejection is surfaced rather than swallowed (#957).
+			local _pages_err _pages_rc
+			_pages_err=$(printf '{"source":{"branch":"main","path":"/docs"}}' |
+				gh api --hostname "${_ghe_host}" \
+					"repos/${_origin_owner}/${_repo_name}/pages" \
+					--method POST \
+					--input - 2>&1) && _pages_rc=0 || _pages_rc=$?
+
+			if [ "${_pages_rc}" -eq 0 ]; then
 				ux_success "Pages activated (branch=main, path=/docs)"
 			else
-				ux_error "Pages activation failed. Verify: gh auth status --hostname ${_ghe_host}"
+				ux_error "Pages activation failed (exit ${_pages_rc})."
+				[ -n "${_pages_err}" ] && ux_info "API response: ${_pages_err}"
+				ux_info "Verify: gh auth status --hostname ${_ghe_host}"
 				exit 1
 			fi
 		fi

--- a/shell-common/tools/custom/mirror-pages-activate.sh
+++ b/shell-common/tools/custom/mirror-pages-activate.sh
@@ -135,12 +135,12 @@ main() {
 			# form-urlencoded payload produced by `gh api -F`, so send JSON
 			# via --input. Capture stdout+stderr instead of discarding them
 			# so a real API rejection is surfaced rather than swallowed (#957).
-			local _pages_err _pages_rc
+			local _pages_err _pages_rc=0
 			_pages_err=$(printf '{"source":{"branch":"main","path":"/docs"}}' |
 				gh api --hostname "${_ghe_host}" \
 					"repos/${_origin_owner}/${_repo_name}/pages" \
 					--method POST \
-					--input - 2>&1) && _pages_rc=0 || _pages_rc=$?
+					--input - 2>&1) || _pages_rc=$?
 
 			if [ "${_pages_rc}" -eq 0 ]; then
 				ux_success "Pages activated (branch=main, path=/docs)"

--- a/tests/bats/tools/mirror_pages_activate.bats
+++ b/tests/bats/tools/mirror_pages_activate.bats
@@ -258,3 +258,26 @@ EOF
     assert_output --partial "main"
     assert_output --partial "/docs"
 }
+
+@test "mirror-pages-activate: surfaces API response when POST fails (#957)" {
+    local bin_dir="${_WORK_DIR}/bin"
+    mkdir -p "${bin_dir}"
+    cat >"${bin_dir}/gh" <<'EOF'
+#!/bin/bash
+# GET pages -> 404 (inactive); POST -> failure with an API error message on
+# stderr, mirroring a real GHE rejection (#957).
+if [[ "$*" == *"--method POST"* ]]; then
+    printf 'HTTP 422: Unprocessable Entity\n' >&2
+    exit 1
+fi
+exit 1
+EOF
+    chmod +x "${bin_dir}/gh"
+    _setup_fake_repo \
+        "https://ghe.example.com/user/repo" \
+        "https://github.com/owner/repo"
+    run bash -c "cd '${_WORK_DIR}' && PATH='${bin_dir}:${PATH}' bash '${SCRIPT}'"
+    assert_failure
+    assert_output --partial "Pages activation failed"
+    assert_output --partial "API response: HTTP 422: Unprocessable Entity"
+}


### PR DESCRIPTION
## Summary

`mirror-pages-activate` 의 GitHub Pages 활성화 POST 호출이 실패할 때 모든 진단 정보를 삼켜버려, GHE 3.17 의 JSON-only Pages API 거부를 "gh auth status 확인" 이라는 막다른 에러로 둔갑시키던 문제를 수정한다.

## Changes

- **fix** `shell-common/tools/custom/mirror-pages-activate.sh`
  - Pages 활성화 POST 를 `gh api -F` (form-urlencoded) → JSON body via `--input -` 로 교체. GHE 3.17 의 Pages API 는 JSON body 만 받고 form-urlencoded 를 거부하므로 이것이 실제 root cause.
  - `>/dev/null 2>&1` 로 stdout/stderr 를 버리던 것을 `2>&1` 캡처로 변경. 실패 시 `ux_info "API response: ..."` 로 실제 API 응답(예: `HTTP 422: Unprocessable Entity`)을 노출.
- **test** `tests/bats/tools/mirror_pages_activate.bats`
  - POST 실패 시 API 응답을 surface 하는지 검증하는 #957 케이스 추가.

## Verification

- shellcheck OK · shfmt OK
- bats 16/16 PASS (신규 #957 케이스 포함)

Closes #957
