### PR TITLE
fix(gcp-scan): #961 phantom 커밋을 Analysis 단계에서 제거

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -315,13 +315,15 @@ EOF
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
         if _gcp_scan_preflight_is_noop "$sha"; then
-            noop_list="${noop_list}${sha}"$'\n'
+            noop_list="${noop_list}${sha}
+"
             noop_count=$((noop_count + 1))
         else
             if [ -z "$real_final_list" ]; then
                 real_final_list="$sha"
             else
-                real_final_list="${real_final_list}"$'\n'"${sha}"
+                real_final_list="${real_final_list}
+${sha}"
             fi
         fi
     done <<EOF
@@ -457,12 +459,14 @@ EOF
 
         # No-op check (issue #961): Stage-2 pre-flight already probed each commit
         # in the Analysis phase; reuse that result to avoid a double-probe.
-        local _in_noop=0 _noop_sha
-        while IFS= read -r _noop_sha; do
-            [ "$_noop_sha" = "$sha" ] && _in_noop=1 && break
-        done <<EOF
-$noop_list
-EOF
+        # POSIX case-pattern match avoids O(N*M) nested loop overhead.
+        local _in_noop=0
+        case "
+$noop_list" in
+            *"
+$sha
+"*) _in_noop=1 ;;
+        esac
         if [ "$_in_noop" -eq 1 ]; then
             noop_skipped=$((noop_skipped + 1))
             continue

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -16,13 +16,15 @@
 #   '+' = present in source, missing in base (will be cherry-picked)
 #   '-' = already merged in base
 #
-# Redundant-commit handling (issue #913, supersedes #903/#907/#908/#910):
-# every candidate is run through `_gcp_scan_preflight_is_noop` BEFORE any real
-# cherry-pick. The probe uses git's own merge engine (`cherry-pick -n`) so it
-# is immune to the context-drift failures (comment rewrites, refactors) that
-# broke the earlier file-compare / reverse-patch heuristics. The contiguous
-# "range cherry-pick" shortcut is gone — every commit is iterated individually
-# so the pre-flight is never bypassed.
+# Redundant-commit handling (issue #913, supersedes #903/#907/#908/#910;
+# UX improved by issue #961): each candidate is probed with
+# `_gcp_scan_preflight_is_noop` (Stage-2) during the Analysis phase, BEFORE
+# displaying the commit list. Noop commits are excluded from the display and
+# the cherry-pick count so users never see a commit that will immediately be
+# skipped. The execution loop reuses the Stage-2 result (noop_list) to avoid
+# a double-probe. The probe uses git's own merge engine (`cherry-pick -n`) so
+# it is immune to context-drift failures (comment rewrites, refactors) that
+# broke earlier file-compare / reverse-patch heuristics.
 #
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
@@ -306,6 +308,28 @@ EOF
         count=$((count - duplicate_count))
     fi
 
+    # Stage-2: no-op pre-flight in Analysis phase — filters phantom commits
+    # before display so users never see commits that will immediately be skipped
+    # (issue #961). Runs on final_selected_list (Stage-1 dups already removed).
+    local noop_list="" noop_count=0 real_final_list=""
+    while IFS= read -r sha; do
+        [ -z "$sha" ] && continue
+        if _gcp_scan_preflight_is_noop "$sha"; then
+            noop_list="${noop_list}${sha}"$'\n'
+            noop_count=$((noop_count + 1))
+        else
+            if [ -z "$real_final_list" ]; then
+                real_final_list="$sha"
+            else
+                real_final_list="${real_final_list}"$'\n'"${sha}"
+            fi
+        fi
+    done <<EOF
+$final_selected_list
+EOF
+    final_selected_list="$real_final_list"
+    count=$((count - noop_count))
+
     # Early return: all commits are duplicates (already applied)
     if [ $count -eq 0 ]; then
         if type ux_section >/dev/null 2>&1; then
@@ -313,11 +337,17 @@ EOF
             ux_bullet "Missing (all authors): $total_count"
             ux_bullet "Author filter: $author -> 0 new commit(s)"
             ux_bullet "Duplicates (already applied): $duplicate_count"
+            if [ "$noop_count" -gt 0 ]; then
+                printf "%s  ◆ Already in HEAD (no-op): %d%s\n" "${UX_MUTED-}" "$noop_count" "${UX_RESET-}"
+            fi
         else
             echo "=== Analysis Result ==="
             echo "  Missing (all authors): $total_count"
             echo "  Author filter: $author -> 0 new commit(s)"
             echo "  Duplicates (already applied): $duplicate_count"
+            if [ "$noop_count" -gt 0 ]; then
+                echo "  Already in HEAD (no-op): $noop_count"
+            fi
         fi
         if type ux_success >/dev/null 2>&1; then
             ux_success "All matching commits are already applied to '$base'. Nothing to do."
@@ -342,6 +372,9 @@ EOF
         if [ $duplicate_count -gt 0 ]; then
             ux_bullet "Duplicates (already applied): $duplicate_count"
         fi
+        if [ "$noop_count" -gt 0 ]; then
+            printf "%s  ◆ Already in HEAD (no-op): %d%s\n" "${UX_MUTED-}" "$noop_count" "${UX_RESET-}"
+        fi
         ux_bullet "Suggested Range: $range_str"
     else
         echo "=== Analysis Result ==="
@@ -349,6 +382,9 @@ EOF
         echo "  Author filter: $author -> $count commit(s)"
         if [ $duplicate_count -gt 0 ]; then
             echo "  Duplicates (already applied): $duplicate_count"
+        fi
+        if [ "$noop_count" -gt 0 ]; then
+            echo "  Already in HEAD (no-op): $noop_count"
         fi
         echo "  Suggested Range: $range_str"
     fi
@@ -419,16 +455,15 @@ EOF
             continue
         fi
 
-        # No-op pre-flight (issue #913): merge-probe the commit onto HEAD. If it
-        # adds nothing — already in HEAD, or a pure context-drift conflict that
-        # resolves to HEAD — skip it. Catches the recurring 092d0512 case the
-        # subject-based Stage-1 misses, BEFORE any real cherry-pick conflicts.
-        if _gcp_scan_preflight_is_noop "$sha"; then
-            if type ux_info >/dev/null 2>&1; then
-                ux_info "Skipping ${sha} — already in HEAD (no-op pre-flight)"
-            else
-                echo "ℹ Skipping ${sha} — already in HEAD (no-op pre-flight)"
-            fi
+        # No-op check (issue #961): Stage-2 pre-flight already probed each commit
+        # in the Analysis phase; reuse that result to avoid a double-probe.
+        local _in_noop=0 _noop_sha
+        while IFS= read -r _noop_sha; do
+            [ "$_noop_sha" = "$sha" ] && _in_noop=1 && break
+        done <<EOF
+$noop_list
+EOF
+        if [ "$_in_noop" -eq 1 ]; then
             noop_skipped=$((noop_skipped + 1))
             continue
         fi

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -615,8 +615,8 @@ FIXTURE
     assert_success
     # Subject-dup still handled by Stage-1.
     assert_output --partial "already applied as"
-    # Content-dup caught by the no-op pre-flight.
-    assert_output --partial "already in HEAD (no-op pre-flight)"
+    # Content-dup caught by Stage-2 pre-flight; shown in Analysis Result, not execution loop.
+    assert_output --partial "Already in HEAD (no-op):"
     refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
 }
@@ -739,12 +739,71 @@ FIXTURE
         printf 'y\n' | _gcp_scan main source --author=all
     "
     assert_success
-    # The context-drift commit is caught by the no-op pre-flight BEFORE any real
-    # cherry-pick, so no conflict is ever surfaced and no manual step is asked.
-    assert_output --partial "already in HEAD (no-op pre-flight)"
+    # Stage-2 pre-flight catches the context-drift commit in Analysis phase;
+    # shown as "Already in HEAD (no-op)" there, no conflict ever surfaced.
+    assert_output --partial "Already in HEAD (no-op):"
     assert_output --partial "0 conflicts"
     refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
+}
+
+@test "scan #961: noop commit absent from Commit List display (phantom removed in Analysis phase)" {
+    # Source has a real commit AND a context-drift noop (unique subject, content
+    # already in main via a different two-step path). Stage-2 pre-flight must
+    # remove the noop from the Commit List BEFORE the user sees it.
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        echo shared > b.txt && git add b.txt && git commit -qm "base: add b.txt"
+        git checkout -q -b source
+        echo real > real.txt && git add real.txt && git commit -qm "feat: real work"
+        # Unique subject; patches b.txt from shared to target in one step.
+        echo target > b.txt && git add b.txt && git commit -qm "feat: phantom noop"
+        git checkout -q main
+        # Main reaches b.txt=target via two-step path -> different patch-id,
+        # so git cherry lists the source commit as "+" even though the final
+        # state is identical. The context-drift conflict resolves to HEAD empty.
+        echo middle > b.txt && git add b.txt && git commit -qm "main: b.txt middle"
+        echo target > b.txt && git add b.txt && git commit -qm "main: b.txt target"
+        printf "n\n" | _gcp_scan main source --author=all
+    '
+    assert_success
+    # Noop commit must NOT appear in Commit List (phantom removed in Stage-2).
+    refute_output --partial "feat: phantom noop"
+    # Analysis Result must show the noop count.
+    assert_output --partial "Already in HEAD (no-op):"
+    # Real commit must still appear.
+    assert_output --partial "feat: real work"
+}
+
+@test "scan #961: all-noop scan exits cleanly without prompt (nothing to do)" {
+    # Source has only a context-drift noop; Stage-2 eliminates it so count=0
+    # triggers the early-return path with "Nothing to do" — no cherry-pick prompt.
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        echo shared > b.txt && git add b.txt && git commit -qm "base: add b.txt"
+        git checkout -q -b source
+        echo target > b.txt && git add b.txt && git commit -qm "feat: all noop"
+        git checkout -q main
+        echo middle > b.txt && git add b.txt && git commit -qm "main: b.txt middle"
+        echo target > b.txt && git add b.txt && git commit -qm "main: b.txt target"
+        _gcp_scan main source --author=all
+    '
+    assert_success
+    assert_output --partial "Already in HEAD (no-op):"
+    assert_output --partial "Nothing to do"
+    refute_output --partial "Do you want to cherry-pick"
 }
 
 @test "scan #907: partial-apply skipped while real commits still applied; HEAD drift intact" {


### PR DESCRIPTION
## Summary
- `_gcp_scan` 의 Analysis 단계에 Stage-2 no-op pre-flight 를 삽입하여, 커밋 리스트 표시 전에 phantom 커밋을 제거한다.
- Analysis Result 에 `◆ Already in HEAD (no-op): N` 줄(UX_MUTED)을 추가하여 필터링 내역을 표시한다.
- Execution loop 에서 `_gcp_scan_preflight_is_noop` 재호출을 `noop_list` SHA 매칭으로 교체하여 double-probe 를 방지한다.

## Changes
- `shell-common/functions/gcp_scan.sh`: Stage-1 완료 직후 Stage-2 프로브 블록 삽입 (~22줄); Analysis Result 에 noop_count 표시 (early-return + 정상 경로 양쪽); execution loop 에서 이중 프로브 제거
- `tests/bats/functions/gcp.bats`: `scan #913` 테스트 2개 어서션 갱신 (`already in HEAD (no-op pre-flight)` → `Already in HEAD (no-op):`); `scan #961` 신규 테스트 2개 추가 (phantom 제거 확인, all-noop early-return 확인)

## Test plan
- [x] `tests/bats/lib/bats-core/bin/bats tests/bats/functions/gcp.bats` — 51개 전부 통과
- [x] `./tests/test` — pytest 1144개 통과 (bats 2개 사전 존재 실패는 이 PR 무관)

## Related
Closes #961

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~0.5 h · 🤖 ~45 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~0.5 h · 🤖 ~45 min
<!-- /ai-metrics:gh-pr -->

</details>
