### PR TITLE
Feat: Add sync-to-deploy shell helper

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -159,7 +159,7 @@ _register_default_help_categories() {
 
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool ghes_mirror mirror_pages_activate}"
-    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check}"
+    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check sync_to_deploy}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip ghostty}"
@@ -269,6 +269,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[gcp_help]="${HELP_DESCRIPTIONS[gcp_help]:-[DevOps] gcloud / GCP helpers}"
     HELP_DESCRIPTIONS[setup_mode_help]="${HELP_DESCRIPTIONS[setup_mode_help]:-[Meta] setup.sh mode flags}"
     HELP_DESCRIPTIONS[zsh_autosuggestions_install_help]="${HELP_DESCRIPTIONS[zsh_autosuggestions_install_help]:-[CLI] zsh-autosuggestions installer}"
+    HELP_DESCRIPTIONS[sync_to_deploy_help]="${HELP_DESCRIPTIONS[sync_to_deploy_help]:-[DevOps] Merge internal/external main branches and push a deploy branch}"
 }
 
 # ═══════════════════════════════════════════════════════════════

--- a/shell-common/functions/sync_to_deploy_help.sh
+++ b/shell-common/functions/sync_to_deploy_help.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# shell-common/functions/sync_to_deploy_help.sh
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+sync_to_deploy_help() {
+    ux_header "sync-to-deploy"
+
+    ux_section "Usage"
+    ux_bullet "sync-to-deploy <deploy-branch>"
+
+    ux_section "Examples"
+    ux_bullet "sync-to-deploy dev-server"
+    ux_bullet "sync-to-deploy prod-server"
+
+    ux_section "What it does"
+    ux_bullet "Fetches origin/main and upstream/main by default"
+    ux_bullet "Creates a temporary branch from the internal main branch"
+    ux_bullet "Merges the external main branch into that temporary branch"
+    ux_bullet "Pushes the merge result to the deploy branch with force-with-lease"
+    ux_bullet "Returns to the original branch and removes the temporary branch on success"
+
+    ux_section "Environment overrides"
+    ux_table_header "Variable" "Default" "Purpose"
+    ux_table_row "SYNC_INTERNAL_REMOTE" "origin" "Remote that receives deploy branch"
+    ux_table_row "SYNC_EXTERNAL_REMOTE" "upstream" "Remote merged into internal main"
+    ux_table_row "SYNC_BRANCH" "main" "Source branch on both remotes"
+    ux_table_row "SYNC_DEPLOY_WHITELIST" "" "Optional allowed deploy branches"
+    ux_table_row "SYNC_TMP_BRANCH" "sync-to-deploy-tmp" "Temporary merge branch"
+
+    ux_section "Safety"
+    ux_bullet "Stops when the worktree has uncommitted changes"
+    ux_bullet "Preserves the temporary branch on merge conflict"
+    ux_bullet "Uses force-with-lease instead of plain force push"
+}
+
+alias sync-to-deploy-help='sync_to_deploy_help'

--- a/shell-common/tools/integrations/sync_to_deploy.sh
+++ b/shell-common/tools/integrations/sync_to_deploy.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# shell-common/tools/integrations/sync_to_deploy.sh
+# Merge internal/external main branches and push the result to a deploy branch.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+if ! type ux_header >/dev/null 2>&1; then
+    _sync_to_deploy_dir="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"
+    . "${_sync_to_deploy_dir}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
+    unset _sync_to_deploy_dir
+fi
+
+_sync_to_deploy_usage() {
+    ux_header "sync-to-deploy"
+    ux_section "Usage"
+    ux_bullet "sync-to-deploy <deploy-branch>"
+    ux_section "Examples"
+    ux_bullet "sync-to-deploy dev-server"
+    ux_bullet "sync-to-deploy prod-server"
+    ux_section "Environment overrides"
+    ux_table_header "Variable" "Default" "Purpose"
+    ux_table_row "SYNC_INTERNAL_REMOTE" "origin" "Remote that receives deploy branch"
+    ux_table_row "SYNC_EXTERNAL_REMOTE" "upstream" "Remote merged into internal main"
+    ux_table_row "SYNC_BRANCH" "main" "Source branch on both remotes"
+    ux_table_row "SYNC_DEPLOY_WHITELIST" "" "Optional allowed deploy branches"
+    ux_table_row "SYNC_TMP_BRANCH" "sync-to-deploy-tmp" "Temporary merge branch"
+}
+
+_sync_to_deploy_in_whitelist() {
+    _sync_to_deploy_target="$1"
+    _sync_to_deploy_list="$2"
+
+    [ -n "$_sync_to_deploy_list" ] || return 0
+
+    for _sync_to_deploy_branch in $_sync_to_deploy_list; do
+        [ "$_sync_to_deploy_branch" = "$_sync_to_deploy_target" ] && return 0
+    done
+
+    return 1
+}
+
+_sync_to_deploy_ref_exists() {
+    git show-ref --verify --quiet "$1"
+}
+
+sync_to_deploy() (
+    case "${1:-}" in
+    "" | -h | --help | help)
+        [ -n "${1:-}" ] || ux_error "Deploy branch is required."
+        _sync_to_deploy_usage
+        [ -n "${1:-}" ]
+        return $?
+        ;;
+    esac
+
+    if [ $# -ne 1 ]; then
+        ux_error "Expected exactly one deploy branch."
+        _sync_to_deploy_usage
+        return 1
+    fi
+
+    _sync_to_deploy_deploy_branch="$1"
+    _sync_to_deploy_internal_remote="${SYNC_INTERNAL_REMOTE:-origin}"
+    _sync_to_deploy_external_remote="${SYNC_EXTERNAL_REMOTE:-upstream}"
+    _sync_to_deploy_branch="${SYNC_BRANCH:-main}"
+    _sync_to_deploy_whitelist="${SYNC_DEPLOY_WHITELIST:-}"
+    _sync_to_deploy_tmp_branch="${SYNC_TMP_BRANCH:-sync-to-deploy-tmp}"
+    _sync_to_deploy_conflict=0
+
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        ux_error "Run from inside a git repository."
+        return 1
+    fi
+
+    if ! _sync_to_deploy_in_whitelist "$_sync_to_deploy_deploy_branch" "$_sync_to_deploy_whitelist"; then
+        ux_error "Deploy branch is not in SYNC_DEPLOY_WHITELIST: $_sync_to_deploy_deploy_branch"
+        return 1
+    fi
+
+    if ! git diff-index --quiet HEAD --; then
+        ux_error "Uncommitted changes found. Commit or stash before running sync-to-deploy."
+        return 1
+    fi
+
+    _sync_to_deploy_original_ref="$(git symbolic-ref --short -q HEAD || git rev-parse HEAD)"
+    if [ "$_sync_to_deploy_original_ref" = "$_sync_to_deploy_tmp_branch" ]; then
+        ux_error "Already on temporary branch: $_sync_to_deploy_tmp_branch"
+        return 1
+    fi
+
+    # shellcheck disable=SC2317  # invoked by trap
+    _sync_to_deploy_cleanup() {
+        [ "$_sync_to_deploy_conflict" -eq 1 ] && return 0
+        git merge --abort >/dev/null 2>&1 || true
+        _sync_to_deploy_current_ref="$(git symbolic-ref --short -q HEAD || git rev-parse HEAD)"
+        if [ "$_sync_to_deploy_current_ref" != "$_sync_to_deploy_original_ref" ]; then
+            git checkout "$_sync_to_deploy_original_ref" >/dev/null 2>&1 || true
+        fi
+        git branch -D "$_sync_to_deploy_tmp_branch" >/dev/null 2>&1 || true
+    }
+    trap _sync_to_deploy_cleanup EXIT HUP INT TERM
+
+    ux_header "sync-to-deploy"
+    ux_info "${_sync_to_deploy_internal_remote}/${_sync_to_deploy_branch} + ${_sync_to_deploy_external_remote}/${_sync_to_deploy_branch} -> ${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch}"
+
+    ux_step 1 "Fetch internal branch"
+    if ! git fetch "$_sync_to_deploy_internal_remote" "$_sync_to_deploy_branch"; then
+        ux_error "Failed to fetch ${_sync_to_deploy_internal_remote}/${_sync_to_deploy_branch}."
+        return 1
+    fi
+
+    ux_step 2 "Fetch external branch"
+    if ! git fetch "$_sync_to_deploy_external_remote" "$_sync_to_deploy_branch"; then
+        ux_error "Failed to fetch ${_sync_to_deploy_external_remote}/${_sync_to_deploy_branch}."
+        return 1
+    fi
+
+    ux_step 3 "Create temporary branch"
+    if ! git checkout -B "$_sync_to_deploy_tmp_branch" "${_sync_to_deploy_internal_remote}/${_sync_to_deploy_branch}" >/dev/null 2>&1; then
+        ux_error "Failed to create temporary branch from ${_sync_to_deploy_internal_remote}/${_sync_to_deploy_branch}."
+        return 1
+    fi
+
+    ux_step 4 "Merge external branch"
+    if ! git merge --no-edit "${_sync_to_deploy_external_remote}/${_sync_to_deploy_branch}"; then
+        _sync_to_deploy_conflict=1
+        ux_error "Merge conflict while merging ${_sync_to_deploy_external_remote}/${_sync_to_deploy_branch}."
+        ux_warning "Temporary branch preserved: $_sync_to_deploy_tmp_branch"
+        ux_section "Manual recovery"
+        ux_bullet "Resolve conflicts, then: git add <files> && git commit"
+        ux_bullet "Push manually: git push $_sync_to_deploy_internal_remote $_sync_to_deploy_tmp_branch:$_sync_to_deploy_deploy_branch --force-with-lease=$_sync_to_deploy_deploy_branch"
+        ux_bullet "Clean up: git checkout $_sync_to_deploy_original_ref && git branch -D $_sync_to_deploy_tmp_branch"
+        ux_bullet "Cancel: git merge --abort && git checkout $_sync_to_deploy_original_ref && git branch -D $_sync_to_deploy_tmp_branch"
+        return 1
+    fi
+
+    ux_step 5 "Push deploy branch"
+    _sync_to_deploy_lease="--force-with-lease=${_sync_to_deploy_deploy_branch}"
+    if _sync_to_deploy_ref_exists "refs/remotes/${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch}"; then
+        _sync_to_deploy_lease="--force-with-lease=${_sync_to_deploy_deploy_branch}:refs/remotes/${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch}"
+    fi
+
+    if ! git push "$_sync_to_deploy_internal_remote" "${_sync_to_deploy_tmp_branch}:${_sync_to_deploy_deploy_branch}" "$_sync_to_deploy_lease"; then
+        ux_error "Push failed. ${_sync_to_deploy_deploy_branch} may have changed since fetch."
+        return 1
+    fi
+
+    ux_success "${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch} updated."
+    ux_info "Returning to $_sync_to_deploy_original_ref and removing $_sync_to_deploy_tmp_branch."
+)
+
+alias sync-to-deploy='sync_to_deploy'

--- a/shell-common/tools/integrations/sync_to_deploy.sh
+++ b/shell-common/tools/integrations/sync_to_deploy.sh
@@ -135,13 +135,16 @@ sync_to_deploy() (
     fi
 
     ux_step 5 "Push deploy branch"
-    _sync_to_deploy_lease="--force-with-lease=${_sync_to_deploy_deploy_branch}"
+    # refresh tracking ref so --force-with-lease compares against the current remote tip, not a stale one
+    git fetch "$_sync_to_deploy_internal_remote" "refs/heads/${_sync_to_deploy_deploy_branch}:refs/remotes/${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch}" >/dev/null 2>&1 || true
+
+    _sync_to_deploy_lease=""
     if _sync_to_deploy_ref_exists "refs/remotes/${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch}"; then
         _sync_to_deploy_lease="--force-with-lease=${_sync_to_deploy_deploy_branch}:refs/remotes/${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch}"
     fi
 
-    if ! git push "$_sync_to_deploy_internal_remote" "${_sync_to_deploy_tmp_branch}:${_sync_to_deploy_deploy_branch}" "$_sync_to_deploy_lease"; then
-        ux_error "Push failed. ${_sync_to_deploy_deploy_branch} may have changed since fetch."
+    if ! git push "$_sync_to_deploy_internal_remote" "${_sync_to_deploy_tmp_branch}:${_sync_to_deploy_deploy_branch}" ${_sync_to_deploy_lease:+"$_sync_to_deploy_lease"}; then
+        ux_error "Push failed. ${_sync_to_deploy_internal_remote}/${_sync_to_deploy_deploy_branch} may have changed since fetch."
         return 1
     fi
 

--- a/tests/bats/functions/sync_to_deploy.bats
+++ b/tests/bats/functions/sync_to_deploy.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# tests/bats/functions/sync_to_deploy.bats
+# Coverage for shell-common/tools/integrations/sync_to_deploy.sh.
+# shellcheck disable=SC2016
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+_sync_fixture_base() {
+    FIXTURE_DIR="$TEST_TEMP_HOME/sync-to-deploy"
+    ORIGIN_BARE="$FIXTURE_DIR/origin.git"
+    UPSTREAM_BARE="$FIXTURE_DIR/upstream.git"
+    SEED_REPO="$FIXTURE_DIR/seed"
+    WORK_REPO="$FIXTURE_DIR/work"
+
+    mkdir -p "$FIXTURE_DIR"
+    git init -q --bare --initial-branch=main "$ORIGIN_BARE"
+    git init -q --bare --initial-branch=main "$UPSTREAM_BARE"
+    git init -q --initial-branch=main "$SEED_REPO"
+
+    (
+        cd "$SEED_REPO" || exit 1
+        git config user.email "test@example.invalid"
+        git config user.name "bats"
+        git config core.hooksPath /dev/null
+        printf 'base\n' >app.txt
+        git add app.txt
+        git commit -q -m "base"
+        git remote add origin "$ORIGIN_BARE"
+        git remote add upstream "$UPSTREAM_BARE"
+        git push -q origin main
+        git push -q origin main:dev-server
+        git push -q upstream main
+    )
+}
+
+_sync_fixture_success() {
+    _sync_fixture_base
+    (
+        cd "$SEED_REPO" || exit 1
+        printf 'upstream\n' >>app.txt
+        git commit -q -am "upstream change"
+        git push -q upstream main
+    )
+    git clone -q "$ORIGIN_BARE" "$WORK_REPO"
+    (
+        cd "$WORK_REPO" || exit 1
+        git config user.email "test@example.invalid"
+        git config user.name "bats"
+        git config core.hooksPath /dev/null
+        git remote add upstream "$UPSTREAM_BARE"
+    )
+}
+
+_sync_fixture_conflict() {
+    _sync_fixture_base
+    (
+        cd "$SEED_REPO" || exit 1
+        printf 'origin change\n' >app.txt
+        git commit -q -am "origin change"
+        git push -q origin main
+        git checkout -q -B upstream-work HEAD~1
+        printf 'upstream change\n' >app.txt
+        git commit -q -am "upstream change"
+        git push -q upstream upstream-work:main
+    )
+    git clone -q "$ORIGIN_BARE" "$WORK_REPO"
+    (
+        cd "$WORK_REPO" || exit 1
+        git config user.email "test@example.invalid"
+        git config user.name "bats"
+        git config core.hooksPath /dev/null
+        git remote add upstream "$UPSTREAM_BARE"
+    )
+}
+
+_run_sync_in_bash() {
+    local snippet="$1"
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        cd '${WORK_REPO}' || exit 99
+        . '${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh'
+        . '${DOTFILES_ROOT}/shell-common/tools/integrations/sync_to_deploy.sh'
+        ${snippet}
+    "
+}
+
+@test "bash: sync_to_deploy function exists after main load" {
+    run_in_bash 'declare -f sync_to_deploy >/dev/null && alias sync-to-deploy >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: sync_to_deploy function exists after main load" {
+    run_in_zsh 'typeset -f sync_to_deploy >/dev/null && alias sync-to-deploy >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: sync_to_deploy_help is registered under devops" {
+    run_in_bash 'my_help_impl >/dev/null; echo "${HELP_CATEGORY_MEMBERS[devops]}"; echo "${HELP_DESCRIPTIONS[sync_to_deploy_help]}"'
+    assert_success
+    assert_output --partial "sync_to_deploy"
+    assert_output --partial "Merge internal/external main branches"
+}
+
+@test "success: merges upstream main and pushes deploy branch" {
+    _sync_fixture_success
+
+    _run_sync_in_bash '
+        sync_to_deploy dev-server >/tmp/sync-to-deploy-success.out 2>&1
+        sync_rc=$?
+        remote_subject=$(git --git-dir="'"$ORIGIN_BARE"'" log --format=%s -1 dev-server)
+        current_branch=$(git symbolic-ref --short HEAD)
+        tmp_exists=no
+        git show-ref --verify --quiet refs/heads/sync-to-deploy-tmp && tmp_exists=yes
+        printf "sync_rc=%s\nremote_subject=%s\ncurrent_branch=%s\ntmp_exists=%s\n" "$sync_rc" "$remote_subject" "$current_branch" "$tmp_exists"
+    '
+
+    assert_success
+    assert_output --partial "sync_rc=0"
+    assert_output --partial "remote_subject=upstream change"
+    assert_output --partial "current_branch=main"
+    assert_output --partial "tmp_exists=no"
+}
+
+@test "dirty worktree: stops before checkout" {
+    _sync_fixture_success
+    printf 'dirty\n' >>"$WORK_REPO/app.txt"
+
+    _run_sync_in_bash '
+        if sync_to_deploy dev-server >/tmp/sync-to-deploy-dirty.out 2>&1; then
+            sync_result=unexpected_success
+        else
+            sync_result=dirty_guard
+        fi
+        current_branch=$(git symbolic-ref --short HEAD)
+        remote_subject=$(git --git-dir="'"$ORIGIN_BARE"'" log --format=%s -1 dev-server)
+        printf "sync_result=%s\ncurrent_branch=%s\nremote_subject=%s\n" "$sync_result" "$current_branch" "$remote_subject"
+    '
+
+    assert_success
+    assert_output --partial "sync_result=dirty_guard"
+    assert_output --partial "current_branch=main"
+    assert_output --partial "remote_subject=base"
+}
+
+@test "conflict: preserves temporary branch and merge state without pushing" {
+    _sync_fixture_conflict
+
+    _run_sync_in_bash '
+        if sync_to_deploy dev-server >/tmp/sync-to-deploy-conflict.out 2>&1; then
+            sync_result=unexpected_success
+        else
+            sync_result=conflict_detected
+        fi
+        current_branch=$(git symbolic-ref --short HEAD)
+        tmp_exists=no
+        git show-ref --verify --quiet refs/heads/sync-to-deploy-tmp && tmp_exists=yes
+        merge_head=no
+        test -f .git/MERGE_HEAD && merge_head=yes
+        remote_subject=$(git --git-dir="'"$ORIGIN_BARE"'" log --format=%s -1 dev-server)
+        printf "sync_result=%s\ncurrent_branch=%s\ntmp_exists=%s\nmerge_head=%s\nremote_subject=%s\n" "$sync_result" "$current_branch" "$tmp_exists" "$merge_head" "$remote_subject"
+    '
+
+    assert_success
+    assert_output --partial "sync_result=conflict_detected"
+    assert_output --partial "current_branch=sync-to-deploy-tmp"
+    assert_output --partial "tmp_exists=yes"
+    assert_output --partial "merge_head=yes"
+    assert_output --partial "remote_subject=base"
+}


### PR DESCRIPTION
## Summary
- Add `sync-to-deploy <deploy-branch>` shell-common integration for origin/main + upstream/main deploy branch sync
- Add `sync-to-deploy-help` and register it in `my-help devops`
- Cover success, dirty worktree, and merge conflict behavior with Bats tests

## Verification
- `shellcheck -x -e SC1090,SC1091 shell-common/tools/integrations/sync_to_deploy.sh shell-common/functions/sync_to_deploy_help.sh tests/bats/functions/sync_to_deploy.bats`
- `shfmt -d -i 4 shell-common/tools/integrations/sync_to_deploy.sh shell-common/functions/sync_to_deploy_help.sh tests/bats/functions/sync_to_deploy.bats`
- Local git fixtures: success push, dirty guard, conflict preservation
- `python3 -m pytest tests/integration/test_help_topics.py -q` (249 passed)
- `./tests/test` (Bats skipped: bats-core missing; golden rules + pytest 1144 passed)

Closes #965