### PR TITLE
feat(zsh): zsh-git-fix — gitstatusd 레포 복구 + teardown 자동 복원

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -2269,7 +2269,9 @@ EOF
     if [ "${_gwt_remaining:-2}" -le 1 ] \
        && [ "$(git config core.repositoryformatversion 2>/dev/null)" = "1" ]; then
         git config --unset extensions.worktreeConfig 2>/dev/null || true
-        git config core.repositoryformatversion 0
+        if ! git config --name-only --get-regexp '^extensions\.' >/dev/null 2>&1; then
+            git config core.repositoryformatversion 0
+        fi
     fi
 
     # Sync main BEFORE branch delete.

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -2259,6 +2259,19 @@ EOF
     rm -f "$_gwt_rm_err_file"
     git worktree prune
 
+    # Restore repo format when this was the last linked worktree.
+    # git worktree add writes repositoryformatversion=1 + extensions.worktreeConfig
+    # into .git/config. When all worktrees are gone these linger and cause
+    # gitstatusd v1.5.4 to treat the repo as "not a git repo" (result=0),
+    # breaking p10k's branch display (issue #968).
+    local _gwt_remaining
+    _gwt_remaining="$(git worktree list --porcelain | grep -c "^worktree ")"
+    if [ "${_gwt_remaining:-2}" -le 1 ] \
+       && [ "$(git config core.repositoryformatversion 2>/dev/null)" = "1" ]; then
+        git config --unset extensions.worktreeConfig 2>/dev/null || true
+        git config core.repositoryformatversion 0
+    fi
+
     # Sync main BEFORE branch delete.
     local main_branch="main"
     if ! git rev-parse --verify --quiet "main" >/dev/null 2>&1; then

--- a/shell-common/functions/zsh.sh
+++ b/shell-common/functions/zsh.sh
@@ -341,6 +341,35 @@ zsh_fix_vscode() {
     fi
 }
 
+# Restore .git/config after all worktrees removed (issue #968).
+# gitstatusd v1.5.4 treats repositoryformatversion=1 as "not a git repo",
+# breaking p10k's branch display. Run after `gwt teardown --all`.
+zsh_git_fix() {
+    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        ux_error "Not a git repository."
+        return 1
+    fi
+
+    local rfv
+    rfv="$(git config core.repositoryformatversion 2>/dev/null)"
+    if [ "${rfv:-0}" = "0" ]; then
+        ux_info "Already OK: repositoryformatversion=0"
+        return 0
+    fi
+
+    local wt_count
+    wt_count="$(git worktree list --porcelain | grep -c "^worktree ")"
+    if [ "${wt_count:-1}" -gt 1 ]; then
+        ux_warning "Active worktrees present (${wt_count}). Run ${UX_BOLD}gwt teardown --all${UX_RESET} first."
+        return 1
+    fi
+
+    git config --unset extensions.worktreeConfig 2>/dev/null || true
+    git config core.repositoryformatversion 0
+    ux_success "Fixed: repositoryformatversion=0, worktreeConfig removed."
+    ux_info "Verify: ${UX_BOLD}exec zsh${UX_RESET}"
+}
+
 # ═══════════════════════════════════════════════════════════════
 # Naming Convention: Function uses underscore, alias provides dash format
 # ═══════════════════════════════════════════════════════════════
@@ -359,3 +388,4 @@ alias zsh-snippet='zsh_snippet'
 alias zsh-snippets='zsh_snippets'
 alias zsh-fix-vscode='zsh_fix_vscode'
 alias zsh-clear-p10k-caches='zsh_clear_p10k_caches'
+alias zsh-git-fix='zsh_git_fix'

--- a/shell-common/functions/zsh.sh
+++ b/shell-common/functions/zsh.sh
@@ -365,8 +365,12 @@ zsh_git_fix() {
     fi
 
     git config --unset extensions.worktreeConfig 2>/dev/null || true
-    git config core.repositoryformatversion 0
-    ux_success "Fixed: repositoryformatversion=0, worktreeConfig removed."
+    if ! git config --name-only --get-regexp '^extensions\.' >/dev/null 2>&1; then
+        git config core.repositoryformatversion 0
+        ux_success "Fixed: repositoryformatversion=0, worktreeConfig removed."
+    else
+        ux_success "Fixed: worktreeConfig removed (kept repositoryformatversion=1 due to other active extensions)."
+    fi
     ux_info "Verify: ${UX_BOLD}exec zsh${UX_RESET}"
 }
 

--- a/shell-common/functions/zsh_help.sh
+++ b/shell-common/functions/zsh_help.sh
@@ -15,7 +15,7 @@ _zsh_help_summary() {
     ux_bullet_sub "plugins-list: git | autosuggestions | syntax-highlighting"
     ux_bullet_sub "coexist: bash & zsh coexistence tips"
     ux_bullet_sub "tips: configuration & snippet tips"
-    ux_bullet_sub "troubleshoot: zsh-fix-vscode | zsh-clear-p10k-caches | p10k issues"
+    ux_bullet_sub "troubleshoot: zsh-fix-vscode | zsh-clear-p10k-caches | zsh-git-fix | p10k issues"
     ux_bullet_sub "status: zsh-version | zsh-info"
     ux_bullet_sub "details: zsh-help <section>  (example: zsh-help theme)"
 }
@@ -109,6 +109,9 @@ _zsh_help_rows_troubleshoot() {
     ux_bullet "${UX_BOLD}gwt spawn 직후 prompt 가 이전 디렉터리/브랜치에 frozen 일 때:${UX_RESET}"
     ux_bullet "  진단: ${UX_BOLD}print -lr -- \$precmd_functions${UX_RESET} 에 ${UX_BOLD}_p9k_precmd${UX_RESET} 가 있는지 확인"
     ux_bullet "  해결: ${UX_BOLD}zsh-clear-p10k-caches${UX_RESET} 후 ${UX_BOLD}exec zsh${UX_RESET}"
+    ux_bullet "${UX_BOLD}gwt teardown 후 p10k 가 branch 이름을 표시하지 않을 때:${UX_RESET}"
+    ux_bullet "  원인: .git/config 에 repositoryformatversion=1 잔존 (gitstatusd 오인식)"
+    ux_bullet "  해결: ${UX_BOLD}zsh-git-fix${UX_RESET} (worktree 없는 상태에서 실행)"
     ux_bullet "${UX_BOLD}p10k 프롬프트가 깨지거나 느릴 때:${UX_RESET}"
     ux_bullet "  해결: ${UX_BOLD}p10k configure${UX_RESET} 로 재설정"
 }

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -784,3 +784,23 @@ GH_EOF
     git -C "$CLONE" worktree remove --force "$extra" 2>/dev/null || true
     git -C "$CLONE" branch -D wt/extra/968 2>/dev/null || true
 }
+
+@test "teardown: other active extensions — keeps repositoryformatversion=1 after last worktree" {
+    # If the repo uses another extension (e.g. objectFormat=sha256),
+    # version must stay at 1 even after the last linked worktree is gone.
+    git -C "$CLONE" config core.repositoryformatversion 1
+    git -C "$CLONE" config extensions.worktreeConfig true
+    git -C "$CLONE" config extensions.objectFormat sha256
+
+    _advance_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+
+    # worktreeConfig removed, but version stays 1 due to objectFormat.
+    run git -C "$CLONE" config extensions.worktreeConfig
+    assert_failure
+    [ "$(git -C "$CLONE" config core.repositoryformatversion)" = "1" ]
+
+    git -C "$CLONE" config --unset extensions.objectFormat 2>/dev/null || true
+}

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -743,3 +743,44 @@ GH_EOF
     assert_output --partial "upstream: (none)"
     refute_output --partial "upstream: @{u}"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #968: auto-restore repositoryformatversion after last worktree gone
+# ---------------------------------------------------------------------------
+
+@test "teardown: last worktree removal restores repositoryformatversion to 0" {
+    # Simulate the broken state: git worktree add writes version=1 +
+    # extensions.worktreeConfig. After teardown of the only linked worktree
+    # these must be restored so gitstatusd v1.5.4 re-recognises the repo.
+    git -C "$CLONE" config core.repositoryformatversion 1
+    git -C "$CLONE" config extensions.worktreeConfig true
+
+    _advance_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+
+    [ "$(git -C "$CLONE" config core.repositoryformatversion)" = "0" ]
+    run git -C "$CLONE" config extensions.worktreeConfig
+    assert_failure
+}
+
+@test "teardown: non-last worktree removal leaves repositoryformatversion=1" {
+    # If another linked worktree still exists after this teardown, the
+    # format must stay at 1 (the remaining worktree still needs it).
+    git -C "$CLONE" config core.repositoryformatversion 1
+    git -C "$CLONE" config extensions.worktreeConfig true
+
+    local extra="$TEST_TEMP_HOME/clone-extra-968"
+    git -C "$CLONE" worktree add -q -b wt/extra/968 "$extra" origin/main
+
+    _advance_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_success
+
+    [ "$(git -C "$CLONE" config core.repositoryformatversion)" = "1" ]
+
+    git -C "$CLONE" worktree remove --force "$extra" 2>/dev/null || true
+    git -C "$CLONE" branch -D wt/extra/968 2>/dev/null || true
+}

--- a/tests/bats/functions/zsh_git_fix.bats
+++ b/tests/bats/functions/zsh_git_fix.bats
@@ -154,3 +154,21 @@ teardown() {
     assert_success
     [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "0" ]
 }
+
+# ---------------------------------------------------------------------------
+# Other-active-extensions guard (issue #969 review — gemini-code-assist)
+# ---------------------------------------------------------------------------
+
+@test "bash: zsh-git-fix keeps repositoryformatversion=1 when other extensions remain" {
+    _set_worktree_format
+    # Add another extension to simulate SHA256 or reftable usage.
+    git -C "$TESTREPO" config extensions.objectFormat sha256
+
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    # worktreeConfig removed but version must stay at 1 (other extension present).
+    run git -C "$TESTREPO" config extensions.worktreeConfig
+    assert_failure
+    [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "1" ]
+    assert_output --partial "kept repositoryformatversion=1"
+}

--- a/tests/bats/functions/zsh_git_fix.bats
+++ b/tests/bats/functions/zsh_git_fix.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# tests/bats/functions/zsh_git_fix.bats
+# Unit tests for zsh_git_fix() — gitstatusd repo-detection recovery (issue #968).
+# Tests cover all acceptance criteria: alias existence, non-repo guard,
+# already-OK early exit, active-worktree abort, and the happy-path fix.
+
+load '../test_helper'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Create a minimal git repo in TEST_TEMP_HOME/testrepo.
+_setup_git_repo() {
+    TESTREPO="$TEST_TEMP_HOME/testrepo"
+    mkdir -p "$TESTREPO"
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+    git -C "$TESTREPO" init -q --initial-branch=main
+    echo base > "$TESTREPO/base.txt"
+    git -C "$TESTREPO" add base.txt
+    git -C "$TESTREPO" commit -q -m "base"
+}
+
+# Simulate the state left by `git worktree add` (the broken state).
+_set_worktree_format() {
+    git -C "$TESTREPO" config core.repositoryformatversion 1
+    git -C "$TESTREPO" config extensions.worktreeConfig true
+}
+
+setup() {
+    setup_isolated_home
+    _setup_git_repo
+}
+
+teardown() {
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# Alias + function existence
+# ---------------------------------------------------------------------------
+
+@test "bash: zsh-git-fix alias exists" {
+    run_in_bash 'alias zsh-git-fix'
+    assert_success
+}
+
+@test "zsh: zsh-git-fix alias exists" {
+    run_in_zsh 'alias zsh-git-fix'
+    assert_success
+}
+
+@test "bash: zsh_git_fix function exists" {
+    run_in_bash 'declare -f zsh_git_fix >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "zsh: zsh_git_fix function exists" {
+    run_in_zsh 'functions[zsh_git_fix] >/dev/null 2>&1 || declare -f zsh_git_fix >/dev/null; echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+# ---------------------------------------------------------------------------
+# Not-a-git-repo guard
+# ---------------------------------------------------------------------------
+
+@test "bash: zsh-git-fix returns 1 outside a git repo" {
+    run_in_bash "cd '$TEST_TEMP_HOME' && zsh_git_fix 2>&1"
+    assert_failure
+    assert_output --partial "Not a git repository"
+}
+
+@test "zsh: zsh-git-fix returns 1 outside a git repo" {
+    run_in_zsh "cd '$TEST_TEMP_HOME' && zsh_git_fix 2>&1"
+    assert_failure
+    assert_output --partial "Not a git repository"
+}
+
+# ---------------------------------------------------------------------------
+# Already-OK early exit (repositoryformatversion=0)
+# ---------------------------------------------------------------------------
+
+@test "bash: zsh-git-fix prints 'Already OK' when version is already 0" {
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    assert_output --partial "Already OK"
+}
+
+@test "bash: zsh-git-fix does not modify config when already version 0" {
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    # Config must still be 0 after the call.
+    [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Active-worktree abort
+# ---------------------------------------------------------------------------
+
+@test "bash: zsh-git-fix aborts when active worktrees are present" {
+    _set_worktree_format
+    local wt="$TEST_TEMP_HOME/linked-wt"
+    git -C "$TESTREPO" worktree add -q -b wt/test "$wt" HEAD
+
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_failure
+    assert_output --partial "Active worktrees present"
+
+    # .git/config must be unchanged (still version=1).
+    [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "1" ]
+
+    git -C "$TESTREPO" worktree remove --force "$wt" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Happy-path fix: version=1, no linked worktrees → restore version=0
+# ---------------------------------------------------------------------------
+
+@test "bash: zsh-git-fix restores repositoryformatversion to 0" {
+    _set_worktree_format
+
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "0" ]
+}
+
+@test "bash: zsh-git-fix removes extensions.worktreeConfig" {
+    _set_worktree_format
+
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    # extensions.worktreeConfig must be gone (exit non-zero means key absent).
+    run git -C "$TESTREPO" config extensions.worktreeConfig
+    assert_failure
+}
+
+@test "bash: zsh-git-fix prints success and exec-zsh hint" {
+    _set_worktree_format
+
+    run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    assert_output --partial "Fixed"
+    assert_output --partial "exec zsh"
+}
+
+@test "zsh: zsh-git-fix restores repositoryformatversion to 0" {
+    _set_worktree_format
+
+    run_in_zsh "cd '$TESTREPO' && zsh_git_fix 2>&1"
+    assert_success
+    [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "0" ]
+}


### PR DESCRIPTION
## Summary
- `zsh-git-fix` 신규 함수/alias: `gwt teardown` 후 `.git/config`에 잔존하는 `repositoryformatversion=1`을 복원하여 gitstatusd가 레포를 인식 못하는 문제 해결
- `gwt teardown` 자동 복원: 마지막 linked worktree 제거 후 `_gwt_teardown_one_inplace()`가 repo format을 자동으로 복원
- `zsh-help troubleshoot` 섹션에 `zsh-git-fix` 항목 추가 + 단위/회귀 테스트

## Changes
- `shell-common/functions/zsh.sh`: `zsh_git_fix()` 추가 — non-repo 가드, already-OK early exit, 활성 worktree abort, version=0 복원
- `shell-common/functions/git_worktree.sh`: `_gwt_teardown_one_inplace()`에 마지막 worktree 제거 후 자동 복원 블록 추가
- `shell-common/functions/zsh_help.sh`: troubleshoot 섹션에 `zsh-git-fix` 항목 3줄 추가
- `tests/bats/functions/zsh_git_fix.bats`: 12개 단위 테스트 신규 생성
- `tests/bats/functions/git_worktree_teardown.bats`: #968 회귀 테스트 2개 추가

## Test plan
- [ ] `zsh-git-fix` — git repo 아닌 경로에서 실행 시 error + return 1
- [ ] `zsh-git-fix` — `repositoryformatversion=0` 레포에서 "Already OK" + return 0 (변경 없음)
- [ ] `zsh-git-fix` — 활성 worktree 있을 때 abort + return 1, `.git/config` 변경 없음
- [ ] `zsh-git-fix` — `repositoryformatversion=1` + worktree 없음 → version=0 복원, `worktreeConfig` 제거
- [ ] `gwt teardown` — 마지막 worktree 제거 후 `repositoryformatversion=0` 자동 복원 확인
- [ ] `gwt teardown` — 다른 worktree 존재 시 `repositoryformatversion=1` 유지 확인
- [ ] `mise run test` 전체 통과

## Related
Closes #968

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~0.3 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~0.3 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
