### PR TITLE
fix(zsh-git-fix): zsh_git_fix.bats 테스트 2건 버그 수정

### DIFF
--- a/tests/bats/functions/zsh_git_fix.bats
+++ b/tests/bats/functions/zsh_git_fix.bats
@@ -59,7 +59,7 @@ teardown() {
 }
 
 @test "zsh: zsh_git_fix function exists" {
-    run_in_zsh 'functions[zsh_git_fix] >/dev/null 2>&1 || declare -f zsh_git_fix >/dev/null; echo ok'
+    run_in_zsh '(( ${+functions[zsh_git_fix]} )) && echo ok'
     assert_success
     assert_output --partial "ok"
 }
@@ -166,9 +166,9 @@ teardown() {
 
     run_in_bash "cd '$TESTREPO' && zsh_git_fix 2>&1"
     assert_success
-    # worktreeConfig removed but version must stay at 1 (other extension present).
+    assert_output --partial "kept repositoryformatversion=1"
+
     run git -C "$TESTREPO" config extensions.worktreeConfig
     assert_failure
     [ "$(git -C "$TESTREPO" config core.repositoryformatversion)" = "1" ]
-    assert_output --partial "kept repositoryformatversion=1"
 }


### PR DESCRIPTION
## Summary

- `zsh_git_fix.bats` 테스트 2개 버그 수정 (기능 자체는 정상, 테스트 코드 결함)
- Test #4: zsh에서 `functions[...]`를 명령어 위치에 쓰면 glob 패턴으로 해석 → 수정
- Test #14: 중간 `run git config` 호출이 `$output`을 덮어쓰는 버그 → `assert_output` 순서 조정

## Changes

- `tests/bats/functions/zsh_git_fix.bats`: Test #4 — `functions[zsh_git_fix]` glob 오용을 `(( ${+functions[zsh_git_fix]} ))` zsh 파라미터 확장으로 교체
- `tests/bats/functions/zsh_git_fix.bats`: Test #14 — `assert_output --partial "kept repositoryformatversion=1"`을 `run_in_bash` 직후로 이동하여 두 번째 `run git config` 호출로 `$output`이 덮어쓰이기 전에 검사

## Test plan

- [x] `bats tests/bats/functions/zsh_git_fix.bats` 14/14 통과 확인
- [x] 다른 `*.bats` 파일에서 동일한 `run` → 중간 `run` → `assert_output` 안티패턴 없음 확인

## Related
Fixes #970

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~0.2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~0.2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
