### PR TITLE
feat(zsh): add obsidian-claude vault launcher

### DIFF
--- a/shell-common/aliases/obsidian_claude.sh
+++ b/shell-common/aliases/obsidian_claude.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# shell-common/aliases/obsidian_claude.sh
+# Dash-form alias for the obsidian_claude() launcher function.
+#
+# The function lives in shell-common/functions/obsidian_claude.sh; this
+# file only exposes the user-facing dash-form name (naming convention).
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+alias obsidian-claude='obsidian_claude'

--- a/shell-common/functions/obsidian_claude.sh
+++ b/shell-common/functions/obsidian_claude.sh
@@ -13,7 +13,7 @@
 # Internal function:   obsidian_claude() (snake_case)
 # ═══════════════════════════════════════════════════════════════════════════════
 #
-# Usage: obsidian-claude [yolo|work|work1] [extra claude args...]
+# Usage: obsidian-claude [personal|work|work1] [extra claude args...]
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
@@ -38,18 +38,18 @@ obsidian_claude() {
     case "$account" in
         -h|--help|help)
             ux_header "obsidian-claude - launch Claude in the Obsidian vault"
-            ux_info "Usage: obsidian-claude [yolo|work|work1] [extra claude args...]"
+            ux_info "Usage: obsidian-claude [personal|work|work1] [extra claude args...]"
             ux_info ""
             ux_info "Enters the TilNote vault, then runs claude-yolo for the"
             ux_info "chosen account (default: work)."
             ux_info ""
             ux_info "Accounts:"
-            ux_info "  yolo    personal default account (claude-yolo)"
-            ux_info "  work    work account (default)"
-            ux_info "  work1   secondary work account"
+            ux_info "  personal  personal default account (claude-yolo)"
+            ux_info "  work      work account (default)"
+            ux_info "  work1     secondary work account"
             return 0
             ;;
-        yolo)  ;;                          # personal default: no --user
+        personal)  ;;                      # personal default: no --user
         work)
             # Prepend --user work unless the caller already passed --user.
             case " $* " in
@@ -65,7 +65,7 @@ obsidian_claude() {
             ;;
         *)
             ux_error "Unknown account: $account"
-            ux_info "Available: yolo, work, work1"
+            ux_info "Available: personal, work, work1"
             return 1
             ;;
     esac

--- a/shell-common/functions/obsidian_claude.sh
+++ b/shell-common/functions/obsidian_claude.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck shell=bash
 # shell-common/functions/obsidian_claude.sh
 # Launch Claude Code inside the Obsidian vault with a chosen account.
 #
@@ -12,12 +13,14 @@
 # Internal function:   obsidian_claude() (snake_case)
 # ═══════════════════════════════════════════════════════════════════════════════
 #
-# Usage: obsidian-claude [yolo|work|work1]
+# Usage: obsidian-claude [yolo|work|work1] [extra claude args...]
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-# Windows-side Obsidian vault, mounted under WSL. Intentionally absolute.
-OBSIDIAN_VAULT_DIR="/mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote"  # allow-abs-home
+# Windows-side Obsidian vault, mounted under WSL. Absolute by design (it is a
+# Windows mount, not under the WSL $HOME); override OBSIDIAN_VAULT_DIR to use a
+# different vault.
+OBSIDIAN_VAULT_DIR="${OBSIDIAN_VAULT_DIR:-/mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote}"  # allow-abs-home
 
 obsidian_claude() {
     # zsh compatibility
@@ -25,10 +28,17 @@ obsidian_claude() {
         emulate -L sh
     fi
 
-    case "${1:-work}" in
+    local account
+
+    # Capture the account selector, keep any remaining args to pass through to
+    # claude_yolo (e.g. `obsidian-claude work --resume foo`).
+    account="${1:-work}"
+    [ $# -gt 0 ] && shift
+
+    case "$account" in
         -h|--help|help)
             ux_header "obsidian-claude - launch Claude in the Obsidian vault"
-            ux_info "Usage: obsidian-claude [yolo|work|work1]"
+            ux_info "Usage: obsidian-claude [yolo|work|work1] [extra claude args...]"
             ux_info ""
             ux_info "Enters the TilNote vault, then runs claude-yolo for the"
             ux_info "chosen account (default: work)."
@@ -39,11 +49,22 @@ obsidian_claude() {
             ux_info "  work1   secondary work account"
             return 0
             ;;
-        yolo)  set -- ;;
-        work)  set -- --user work ;;
-        work1) set -- --user work1 ;;
+        yolo)  ;;                          # personal default: no --user
+        work)
+            # Prepend --user work unless the caller already passed --user.
+            case " $* " in
+                *" --user "*) ;;
+                *) set -- --user work "$@" ;;
+            esac
+            ;;
+        work1)
+            case " $* " in
+                *" --user "*) ;;
+                *) set -- --user work1 "$@" ;;
+            esac
+            ;;
         *)
-            ux_error "Unknown account: $1"
+            ux_error "Unknown account: $account"
             ux_info "Available: yolo, work, work1"
             return 1
             ;;
@@ -51,6 +72,11 @@ obsidian_claude() {
 
     if [ ! -d "$OBSIDIAN_VAULT_DIR" ]; then
         ux_error "Vault not found: $OBSIDIAN_VAULT_DIR"
+        return 1
+    fi
+
+    if ! command -v claude_yolo >/dev/null 2>&1; then
+        ux_error "claude_yolo not found (is the dotfiles claude integration loaded?)"
         return 1
     fi
 

--- a/shell-common/functions/obsidian_claude.sh
+++ b/shell-common/functions/obsidian_claude.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# shell-common/functions/obsidian_claude.sh
+# Launch Claude Code inside the Obsidian vault with a chosen account.
+#
+# Enters the TilNote vault directory, then starts claude-yolo for the
+# selected account. Default account: work.
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEVELOPER NOTES - NAMING CONVENTION (See AGENTS.md:174-178)
+# ═══════════════════════════════════════════════════════════════════════════════
+# User-facing command: obsidian-claude (dash-form, aliased in aliases/)
+# Internal function:   obsidian_claude() (snake_case)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Usage: obsidian-claude [yolo|work|work1]
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# Windows-side Obsidian vault, mounted under WSL. Intentionally absolute.
+OBSIDIAN_VAULT_DIR="/mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote"  # allow-abs-home
+
+obsidian_claude() {
+    # zsh compatibility
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    case "${1:-work}" in
+        -h|--help|help)
+            ux_header "obsidian-claude - launch Claude in the Obsidian vault"
+            ux_info "Usage: obsidian-claude [yolo|work|work1]"
+            ux_info ""
+            ux_info "Enters the TilNote vault, then runs claude-yolo for the"
+            ux_info "chosen account (default: work)."
+            ux_info ""
+            ux_info "Accounts:"
+            ux_info "  yolo    personal default account (claude-yolo)"
+            ux_info "  work    work account (default)"
+            ux_info "  work1   secondary work account"
+            return 0
+            ;;
+        yolo)  set -- ;;
+        work)  set -- --user work ;;
+        work1) set -- --user work1 ;;
+        *)
+            ux_error "Unknown account: $1"
+            ux_info "Available: yolo, work, work1"
+            return 1
+            ;;
+    esac
+
+    if [ ! -d "$OBSIDIAN_VAULT_DIR" ]; then
+        ux_error "Vault not found: $OBSIDIAN_VAULT_DIR"
+        return 1
+    fi
+
+    cd "$OBSIDIAN_VAULT_DIR" || return 1
+    claude_yolo "$@"
+}


### PR DESCRIPTION
## Summary

WSL Claude Code를 Obsidian vault(TilNote)에서 바로 실행하는 `obsidian-claude` 런처를 추가한다. vault 디렉토리로 이동한 뒤 선택한 계정으로 `claude_yolo`를 실행한다. 기본 계정은 `work`.

- `shell-common/functions/obsidian_claude.sh`: snake_case `obsidian_claude()` 함수. 계정 인자(`yolo`/`work`/`work1`)를 `claude_yolo` 형식으로 매핑, 기본 `work`, vault 디렉토리 존재 검증, `-h|--help|help` 지원.
- `shell-common/aliases/obsidian_claude.sh`: dash-form alias `obsidian-claude`.
- NAMING_CONVENTION(함수=snake_case in `functions/`, dash alias in `aliases/`)과 ux_lib(help) 컨벤션 준수. 모든 pre-commit 게이트 통과(`--no-verify` 미사용).

## Test plan

- [x] `zsh -ic 'type obsidian-claude'` → `obsidian-claude is an alias for obsidian_claude` (함수 정의됨)
- [x] `obsidian-claude --help` → usage/Accounts 출력, claude 미실행
- [x] `obsidian-claude nope; echo rc=$?` → "Unknown account: nope" + `rc=1`
- [x] 실제 양방향 연동(Claude↔Obsidian, 횡단 grep) 수동 검증 완료

## Usage

- `obsidian-claude` → vault 진입 + `work` 계정(기본)
- `obsidian-claude work1` / `obsidian-claude yolo`

## Related

Claude Code ↔ Obsidian 직접 파일 연동 작업의 일부 (vault 측엔 CLAUDE.md + `/daily-log`·`/weekly-report` 명령 추가).

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~0.3 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~0.3 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
