### PR TITLE
fix(statusline): Bedrock cost 표시 복구 — API 스키마 + 캐시 오염 방어

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -205,14 +205,15 @@ if [ "$SETUP_MODE" = "internal" ]; then
         printf '%s\n\n' "$_now" >"$_CACHE_FILE"
         (
             _new=$(curl -sf --max-time 5 "$_API_URL" 2>/dev/null | jq -r '.latest_cost // .cost // empty' 2>/dev/null)
-            [ -n "$_new" ] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
+            [[ "$_new" =~ ^[0-9]*\.?[0-9]+$ ]] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
         ) >/dev/null 2>&1 &
     else
         _age=$((_now - _cache_ts))
         if [ "$_age" -ge "$_CACHE_TTL" ]; then
+            printf '%s\n%s\n' "$_now" "$_cost" >"$_CACHE_FILE"
             (
                 _new=$(curl -sf --max-time 5 "$_API_URL" 2>/dev/null | jq -r '.latest_cost // .cost // empty' 2>/dev/null)
-                [ -n "$_new" ] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
+                [[ "$_new" =~ ^[0-9]*\.?[0-9]+$ ]] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
             ) >/dev/null 2>&1 &
         fi
     fi

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -188,26 +188,33 @@ if [ "$SETUP_MODE" = "internal" ]; then
     _CACHE_TTL=300
     _API_URL="https://claude-usage-api-dscloud-mchat-bot-swe.svc01.stg.dss.samsungds.net/?id=${_KNOX_ID}"
     _now=$(date +%s)
+    _cache_ts=""
     _cost=""
-
     if [ -f "$_CACHE_FILE" ]; then
-        _cache_ts=$(sed -n '1p' "$_CACHE_FILE" 2>/dev/null)
-        _cost=$(sed -n '2p' "$_CACHE_FILE" 2>/dev/null)
-        if [ -n "$_cache_ts" ]; then
-            _age=$((_now - _cache_ts))
-            if [ "$_age" -ge "$_CACHE_TTL" ]; then
-                (
-                    _new=$(curl -sf --max-time 5 "$_API_URL" 2>/dev/null | jq -r '.cost // empty' 2>/dev/null)
-                    [ -n "$_new" ] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
-                ) >/dev/null 2>&1 &
-            fi
-        fi
-    else
+        _line1=$(sed -n '1p' "$_CACHE_FILE" 2>/dev/null)
+        case "$_line1" in
+        '' | *[!0-9]*) ;; # not a pure-integer timestamp → ignore corrupt cache
+        *)
+            _cache_ts="$_line1"
+            _cost=$(sed -n '2p' "$_CACHE_FILE" 2>/dev/null)
+            ;;
+        esac
+    fi
+
+    if [ -z "$_cache_ts" ]; then
         printf '%s\n\n' "$_now" >"$_CACHE_FILE"
         (
-            _new=$(curl -sf --max-time 5 "$_API_URL" 2>/dev/null | jq -r '.cost // empty' 2>/dev/null)
+            _new=$(curl -sf --max-time 5 "$_API_URL" 2>/dev/null | jq -r '.latest_cost // .cost // empty' 2>/dev/null)
             [ -n "$_new" ] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
         ) >/dev/null 2>&1 &
+    else
+        _age=$((_now - _cache_ts))
+        if [ "$_age" -ge "$_CACHE_TTL" ]; then
+            (
+                _new=$(curl -sf --max-time 5 "$_API_URL" 2>/dev/null | jq -r '.latest_cost // .cost // empty' 2>/dev/null)
+                [ -n "$_new" ] && printf '%s\n%s\n' "$(date +%s)" "$_new" >"$_CACHE_FILE"
+            ) >/dev/null 2>&1 &
+        fi
     fi
 
     if [ -n "$_cost" ]; then


### PR DESCRIPTION
## Summary
- `statusline-command.sh`의 Bedrock 비용 표시(internal 모드 전용)가 중단된 두 가지 런타임 원인을 동시 수정
- 사내 usage API 응답 스키마 변경(`.cost` 제거 → `.latest_cost`)에 대응하는 jq 경로 폴백 추가
- `/tmp` 캐시 1번째 줄에 렌더링 문자열이 기록된 경우 순수 정수 검증 실패 → 캐시 무효화 + 즉시 self-heal

## Changes
- `claude/statusline-command.sh`: jq 경로 `.cost // empty` → `.latest_cost // .cost // empty` (신규 스키마 우선, 구 스키마 호환 유지)
- `claude/statusline-command.sh`: 캐시 파일 1번째 줄 `case` 패턴으로 순수 정수 여부 검증 — 비정수(렌더링 문자열 포함) 감지 시 캐시 무효화하여 산술 크래시 방지 및 self-heal 보장

## Test plan
- [ ] shellcheck 통과 확인
- [ ] internal 모드 머신에서 `rm -f /tmp/.claude_bedrock_cost_cache` 후 statusline 재실행 → 비용 표시 정상 확인
- [ ] 오염된 캐시(렌더링 문자열 1번째 줄) 수동 생성 후 실행 → 크래시 없이 self-heal 확인
- [ ] 전체 테스트 스위트 통과 (1144 tests)

## Related
Closes #972

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1.5 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1.5 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
