### PR TITLE
fix(vscode): base.json에서 Peacock 색상 키 제거 — WSL 재연결 시 색상 회귀 방지

### DIFF
--- a/.vscode/base.json
+++ b/.vscode/base.json
@@ -14,25 +14,6 @@
         "editor.defaultColorDecorators": "never"
     },
     "workbench.colorTheme": "Default Dark+",
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#fbed80",
-        "activityBar.background": "#fbed80",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#06b9a5",
-        "activityBarBadge.foreground": "#15202b",
-        "commandCenter.border": "#15202b99",
-        "sash.hoverBorder": "#fbed80",
-        "statusBar.background": "#f9e64f",
-        "statusBar.foreground": "#15202b",
-        "statusBarItem.hoverBackground": "#f7df1e",
-        "statusBarItem.remoteBackground": "#f9e64f",
-        "statusBarItem.remoteForeground": "#15202b",
-        "titleBar.activeBackground": "#f9e64f",
-        "titleBar.activeForeground": "#15202b",
-        "titleBar.inactiveBackground": "#f9e64f99",
-        "titleBar.inactiveForeground": "#15202b99"
-    },
     "editor.tabSize": 4,
     "editor.detectIndentation": false,
     "editor.formatOnSave": true,
@@ -86,7 +67,6 @@
     "remote.autoForwardPortsSource": "hybrid",
     "claudeCode.preferredLocation": "panel",
     "makefile.configureOnOpen": true,
-    "peacock.remoteColor": "#f9e64f",
     "chat.mcp.gallery.enabled": true,
     "tabnine.experimentalAutoImports": true
 }


### PR DESCRIPTION
## Summary
- `base.json`(전역 SSOT)에서 `workbench.colorCustomizations`와 `peacock.remoteColor` 제거

## Changes
- `.vscode/base.json`: Peacock 색상 키 2개 삭제 — WSL Remote 연결 시 Peacock이 User settings의 `peacock.remoteColor`를 읽어 모든 워크스페이스 색상을 덮어쓰는 root cause 제거. 색상은 워크스페이스별 관심사이므로 전역 SSOT에서 분리.

## Test plan
- [ ] VS Code 재시작 후 각 프로젝트의 Peacock 색상이 유지되는지 확인
- [ ] WSL 재연결 후 `.vscode/settings.json`의 `workbench.colorCustomizations`가 변경되지 않는지 확인
- [ ] `grep "peacock\|colorCustom" "$APPDATA/Code/User/settings.json"` → 0 matches

## Related
Fixes #976

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
