### PR TITLE
fix(vscode): #976 base.json 색상 키 제거 — WSL 재연결 시 워크스페이스 색상 회귀 해결

### DIFF
--- a/.vscode/base.json
+++ b/.vscode/base.json
@@ -14,25 +14,6 @@
         "editor.defaultColorDecorators": "never"
     },
     "workbench.colorTheme": "Default Dark+",
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#fbed80",
-        "activityBar.background": "#fbed80",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#06b9a5",
-        "activityBarBadge.foreground": "#15202b",
-        "commandCenter.border": "#15202b99",
-        "sash.hoverBorder": "#fbed80",
-        "statusBar.background": "#f9e64f",
-        "statusBar.foreground": "#15202b",
-        "statusBarItem.hoverBackground": "#f7df1e",
-        "statusBarItem.remoteBackground": "#f9e64f",
-        "statusBarItem.remoteForeground": "#15202b",
-        "titleBar.activeBackground": "#f9e64f",
-        "titleBar.activeForeground": "#15202b",
-        "titleBar.inactiveBackground": "#f9e64f99",
-        "titleBar.inactiveForeground": "#15202b99"
-    },
     "editor.tabSize": 4,
     "editor.detectIndentation": false,
     "editor.formatOnSave": true,
@@ -86,7 +67,6 @@
     "remote.autoForwardPortsSource": "hybrid",
     "claudeCode.preferredLocation": "panel",
     "makefile.configureOnOpen": true,
-    "peacock.remoteColor": "#f9e64f",
     "chat.mcp.gallery.enabled": true,
     "tabnine.experimentalAutoImports": true
 }


### PR DESCRIPTION
## Summary

WSL Remote 환경에서 VS Code 재시작/재연결 시 Peacock 워크스페이스 색상이 노란색으로
회귀하던 버그를 해결한다. `.vscode/base.json`(전역 SSOT)에서 색상 관련 키 2개를 제거.

- `workbench.colorCustomizations` 블록 제거 (노란색 계열 하드코딩)
- `peacock.remoteColor` 제거 (`#f9e64f`)

## 근본 원인

`base.json` → `sync-push.sh` → Windows User settings 로 색상 키가 주입되면, WSL
Remote 재연결 시마다 Peacock 이 User settings 의 `peacock.remoteColor` 를 읽어
워크스페이스의 `workbench.colorCustomizations` 를 강제로 덮어썼다. 10개 이상 프로젝트가
각각 다른 색을 쓰는데 매 재연결마다 노란색으로 초기화됐다.

## 해결

색상은 워크스페이스별 관심사이므로 전역 SSOT 에서 제외한다. User settings 에
`peacock.remoteColor` 가 사라지면 Peacock 의 remote auto-apply 트리거가 없어지고,
각 프로젝트의 `.vscode/settings.json` 이 독립적으로 색상을 유지한다.

## 검증

- [x] `.vscode/base.json` JSON 유효성 확인 (`python3 -m json.tool`)
- [x] `grep "peacock\|colorCustom" base.json` → 0 matches
- [ ] (런타임) `sync-push.sh` 실행 후 Windows User settings 에서 두 키 부재 확인
- [ ] (런타임) VS Code 재시작 후 워크스페이스 색상 유지 확인

Closes #976
