### PR TITLE
feat(zsh): #978 obsidian-clone — WSL에서 Windows 경로로 vault 부트스트랩 clone

### DIFF
--- a/shell-common/aliases/obsidian_claude.sh
+++ b/shell-common/aliases/obsidian_claude.sh
@@ -8,3 +8,4 @@
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 alias obsidian-claude='obsidian_claude'
+alias obsidian-clone='obsidian_clone'

--- a/shell-common/functions/obsidian_claude.sh
+++ b/shell-common/functions/obsidian_claude.sh
@@ -117,6 +117,11 @@ obsidian_claude() {
 #   url  vault git remote (default: GitHub til-note.git; pass a GHES URL
 #        on an internal PC to override).
 obsidian_clone() {
+	# zsh compatibility
+	if [ -n "${ZSH_VERSION-}" ]; then
+		emulate -L sh
+	fi
+
 	local url target
 
 	case "${1-}" in

--- a/shell-common/functions/obsidian_claude.sh
+++ b/shell-common/functions/obsidian_claude.sh
@@ -108,3 +108,47 @@ obsidian_claude() {
 	cd "$vault" || return 1
 	claude_yolo "$@"
 }
+
+# Bootstrap-clone the TilNote vault into its Windows path from inside WSL.
+# Reuses _obsidian_vault_dir() (#975) so the target path is derived per-PC
+# without hardcoding the Windows username.
+#
+# Usage: obsidian-clone [url]
+#   url  vault git remote (default: GitHub til-note.git; pass a GHES URL
+#        on an internal PC to override).
+obsidian_clone() {
+	local url target
+
+	case "${1-}" in
+	-h | --help | help)
+		ux_header "obsidian-clone - bootstrap-clone the TilNote vault"
+		ux_info "Usage: obsidian-clone [url]"
+		ux_info ""
+		ux_info "Clones the vault into the per-PC Windows path derived by"
+		ux_info "_obsidian_vault_dir (e.g. /mnt/c/Users/<user>/Documents/"
+		ux_info "ObsidianVault-TilNote), then sets core.fileMode false to"
+		ux_info "avoid /mnt/c permission churn."
+		ux_info ""
+		ux_info "  url  vault git remote (default: GitHub til-note.git)"
+		ux_info "       pass a GHES URL to override on an internal PC."
+		return 0
+		;;
+	esac
+
+	url="${1:-https://github.com/dEitY719/til-note.git}"
+	target=$(_obsidian_vault_dir) || {
+		ux_error "vault 경로 결정 실패 (OBSIDIAN_VAULT_DIR 설정 또는 cmd.exe/wslpath 확인)"
+		return 1
+	}
+
+	# Clobber guard: refuse when target exists and is non-empty.
+	if [ -e "$target" ] && [ -n "$(ls -A "$target" 2>/dev/null)" ]; then
+		ux_error "이미 존재하고 비어있지 않음: $target"
+		return 1
+	fi
+
+	mkdir -p "$(dirname "$target")" || return 1
+	git clone "$url" "$target" || return 1
+	git -C "$target" config core.fileMode false # /mnt/c 모드 churn 방지
+	ux_info "Cloned → $target"
+}


### PR DESCRIPTION
## Summary

신규 PC에서 Obsidian TilNote vault 를 WSL 내부에서 Windows 경로로 손쉽게
부트스트랩 clone 하는 헬퍼 `obsidian_clone()` 를 추가한다. PowerShell 없이
WSL 의 `/mnt/c` 직접 쓰기를 활용하되, PC별 경로 자동 도출과 `/mnt/c` git
함정 처리를 헬퍼로 감싸 "쉽게" 만든다.

## Changes

- `shell-common/functions/obsidian_claude.sh` — `obsidian_clone()` 추가
  - #975 의 `_obsidian_vault_dir` 재사용 → PC별 경로 자동 도출 (Windows
    사용자명 하드코딩 없음)
  - 기본 URL `til-note.git`, 인자로 GHES URL override (Internal PC 대응)
  - clobber 가드: target 이 존재하고 비어있지 않으면 거부
  - clone 직후 `core.fileMode false` 로 `/mnt/c` DrvFs 권한 churn 방지
  - `-h/--help` UX 제공
- `shell-common/aliases/obsidian_claude.sh` — dash-form alias `obsidian-clone`

## Acceptance Criteria

- [x] PC별 경로 자동 도출 후 `/mnt/c/Users/<user>/Documents/ObsidianVault-TilNote` clone
- [x] 인자로 URL override 가능 (GHES 대응)
- [x] target 비어있지 않으면 clobber 없이 거부
- [x] clone 직후 `core.fileMode false` 설정
- [x] `shellcheck -S info -x` 0 위반, pre-commit 게이트 통과
- [x] 3개 PC(External/Internal/Home) 동일 절차 부트스트랩 가능 (경로 범용 도출)

## Test

- `shellcheck -S info -x` + `shfmt -d`: 0 violations
- `./tests/test`: 1144 passed
- 함수/alias 로딩 + `--help` 경로 경험적 검증 완료

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
