### PR TITLE
feat(setup): _claude_compose_skills_dir에 개별 스킬명 변경 로그 추가

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -792,11 +792,13 @@ _claude_compose_skills_dir() {
             fi
             rm -f "$_ccsd_link"
             _ccsd_refreshed=$((_ccsd_refreshed + 1))
+            ux_info "  refreshed skill: $_ccsd_name"
         elif [ -e "$_ccsd_link" ]; then
             ux_warning "  skill entry blocked by non-symlink — skipped: $_ccsd_link"
             continue
         else
             _ccsd_added=$((_ccsd_added + 1))
+            ux_info "  new skill: $_ccsd_name"
         fi
         ln -s "$_ccsd_want" "$_ccsd_link" || {
             ux_error "  symlink failed: $_ccsd_link -> $_ccsd_want"
@@ -813,7 +815,8 @@ _claude_compose_skills_dir() {
         case "$_ccsd_target_path" in
             "$_ccsd_src"/*)
                 if [ ! -d "$_ccsd_target_path" ]; then
-                    ux_info "  removing stale dotfiles skill entry: $_ccsd_existing"
+                    _ccsd_stale_name="${_ccsd_existing##*/}"
+                    ux_info "  removed stale skill: $_ccsd_stale_name"
                     rm -f "$_ccsd_existing"
                 fi
                 ;;

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -816,8 +816,7 @@ _claude_compose_skills_dir() {
             "$_ccsd_src"/*)
                 if [ ! -d "$_ccsd_target_path" ]; then
                     _ccsd_stale_name="${_ccsd_existing##*/}"
-                    ux_info "  removed stale skill: $_ccsd_stale_name"
-                    rm -f "$_ccsd_existing"
+                    rm -f "$_ccsd_existing" && ux_info "  removed stale skill: $_ccsd_stale_name"
                 fi
                 ;;
         esac


### PR DESCRIPTION
## Summary

`claude/setup.sh` 실행 시 `_claude_compose_skills_dir` 가 `added=N refreshed=N` 합산 건수만 출력하고 어떤 스킬이 바뀌었는지 표시하지 않던 문제를 해결한다. 세 이벤트에 개별 스킬명 `ux_info` 로그를 추가했다.

## Changes

- `shell-common/tools/integrations/claude.sh` — `_claude_compose_skills_dir`:
  - `added` 이벤트 → `  new skill: <name>` (합산 라인 앞에 출력)
  - `refreshed` 이벤트 → `  refreshed skill: <name>`
  - stale 제거 이벤트 → `  removed stale skill: <name>` (기존 절대경로 로그를 이름만 출력으로 개선)

## Behavior

- 변경 없는 스킬(이미 올바른 symlink)은 기존대로 출력 없이 skip → 멱등 실행 시 노이즈 없음
- 임시 src/tgt 로 함수 단위 검증 완료: new(2) → 재실행 무출력 → stale 제거 1건 정상

## Acceptance Criteria

- [x] `added`: `  new skill: <name>` 합산 라인 앞 출력
- [x] `refreshed`: `  refreshed skill: <name>` 출력
- [x] stale 제거: `  removed stale skill: <name>` (이름만)
- [x] 변경 없는 스킬 무출력 (멱등)
- [x] `mise run lint-sh` (scope `bash/`) 통과

Closes #987
