### PR TITLE
feat(skill): claude-plugin:create — 신규 플러그인 레포 생성 컴포지션 스킬

### DIFF
--- a/claude/skills/claude-plugin-create/SKILL.md
+++ b/claude/skills/claude-plugin-create/SKILL.md
@@ -72,9 +72,11 @@ empty `plugins/<plugin>/skills/`, `docs/skill-guides/`, `docs/skill-output/`,
 
 ## Step 4: Copy Skills (source is read-only)
 
-`cp -r <src>/<skill> <dest>/<plugin-name>/plugins/<plugin>/skills/<skill>` per
-skill; re-confirm every source dir is still present and unchanged afterward.
-**Never edit, move, delete, or symlink the source.**
+`cp -r <src>/<skill> <dest>/<plugin-name>/plugins/<plugin>/skills/` per skill
+(copy **into** the existing parent `skills/` dir — never name the target
+`skills/<skill>`, which nests to `skills/<skill>/<skill>/` if it already
+exists); re-confirm every source dir is still present and unchanged
+afterward. **Never edit, move, delete, or symlink the source.**
 
 ## Step 5: Write Manifests, README, LICENSE, .gitignore
 
@@ -84,7 +86,9 @@ discovered plugin/skill names.
 
 ## Step 6: git init & Branch
 
-`git init <dest>/<plugin-name>`, then `git -C <dest>/<plugin-name> checkout -b main`.
+`git init <dest>/<plugin-name>`, then `git -C <dest>/<plugin-name> checkout -B main`
+(`-B`, not `-b` — modern Git may already default the branch to `main`, and
+`-b` would fail with "branch named 'main' already exists").
 
 ## Step 7: Create the Remote Repo (outward-facing — confirm first)
 

--- a/claude/skills/claude-plugin-create/SKILL.md
+++ b/claude/skills/claude-plugin-create/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: claude-plugin:create
+description: >-
+  Create a new claude-plugin marketplace repo from scratch — build the
+  directory structure, copy skills in, write the manifests, git init,
+  create the GHES/GitHub repo, and push the initial commit, all in one
+  pass. NEVER modifies the source tree (dotfiles etc.) — copy-only. Use
+  when the user says "새 플러그인 만들어", "스킬 묶어서 플러그인으로",
+  "claude-plugin 신규 생성", "/claude-plugin:create <name>", or any request
+  to bundle skills into a new plugin repo. Sister skills:
+  `claude-plugin:structure-check` (verify after create),
+  `claude-plugin:structure-refactor` (fix structure),
+  `claude-plugin:rename-repo` (rename to the team convention).
+compatibility:
+  tools: Read, Write, Edit, Bash, Glob
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "multi-step composition: file writes + git/gh CLI orchestration; moderate complexity, no deep reasoning"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# claude-plugin Repo Creator
+
+Compose a fresh `claude-plugin-<domain>` marketplace repo end-to-end:
+generate the `mono`-layout golden structure, copy skills **without mutating
+the source**, write manifests/README, then `git init` → repo create → push.
+The "new repo" entry point the three sister skills do not cover.
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No filesystem or network calls.
+
+**Stop-on-error policy** — HARD-abort on: Step 1 validation (prefix/naming,
+missing `--src`, existing dest), Step 7 `gh auth status` failure, and any
+push rejection. Everything else fails loudly without partial cleanup.
+
+## Step 1: Parse & Validate
+
+Positional `<plugin-name>` (required) + optional `[skill ...]` list, plus:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--src <path>` | skill source directory | `~/dotfiles/claude/skills/` |
+| `--dest <path>` | repo creation location | `~/para/project/` |
+| `--host <host>` | GitHub host | `github.samsungds.net` |
+| `--owner <owner>` | GitHub owner | `byoungwoo-yoon` |
+| `--plugin <name>` | plugin key (inner name) | domain part of name |
+| `--dry-run` | plan only — no writes/repo/commit | off |
+| `-h`/`--help` | print help, stop | — |
+
+Validate: prepend `claude-plugin-` if missing (tell the user) + enforce
+lowercase-hyphen naming; abort if `--src` missing or `<dest>/<plugin-name>`
+exists (no overwrite — NOT idempotent); infer `[skill ...]` from the
+conversation when omitted, else ask (never guess).
+
+## Step 2: Plan (always)
+
+Print the `[PLAN]` block per `references/help.md` → "Plan output" (plugin
+name/key, destination, the resolved skill→dest copy map, GH repo, dry-run
+flag). If `--dry-run`, stop here — write nothing, create no repo.
+
+## Step 3: Build the Directory Structure
+
+Create the `mono` golden layout under `<dest>/<plugin-name>/`:
+`.claude-plugin/marketplace.json`, `plugins/<plugin>/.claude-plugin/plugin.json`,
+empty `plugins/<plugin>/skills/`, `docs/skill-guides/`, `docs/skill-output/`,
+`README.md`, `LICENSE`, `.gitignore`. May delegate the skeleton dirs to
+`claude-plugin:structure-refactor --apply --mandatory`.
+
+## Step 4: Copy Skills (source is read-only)
+
+`cp -r <src>/<skill> <dest>/<plugin-name>/plugins/<plugin>/skills/<skill>` per
+skill; re-confirm every source dir is still present and unchanged afterward.
+**Never edit, move, delete, or symlink the source.**
+
+## Step 5: Write Manifests, README, LICENSE, .gitignore
+
+Fill the files from `references/manifest-templates.md` and
+`references/readme-template.md` (MIT LICENSE, current year), using the
+discovered plugin/skill names.
+
+## Step 6: git init & Branch
+
+`git init <dest>/<plugin-name>`, then `git -C <dest>/<plugin-name> checkout -b main`.
+
+## Step 7: Create the Remote Repo (outward-facing — confirm first)
+
+After `GH_HOST=<host> gh auth status` and explicit user confirmation:
+`gh repo create <owner>/<plugin-name> --public --description "<desc>"`, then
+`git remote add origin git@<host>:<owner>/<plugin-name>.git`. On GHES `gh`
+failure, point the user to the web UI.
+
+## Step 8: Initial Commit & Push (confirm first)
+
+`git add .` → `git commit -m "feat: init <plugin-name>"` → after
+confirmation, `git push -u origin main`. **Never `git push --force`.**
+
+## Step 9: Verify & Report
+
+Run `claude-plugin:structure-check <dest>/<plugin-name>`, confirm M1-M6 PASS,
+and emit the `[OK]` report per `references/help.md` → "Completion report"
+(repo URL, skills copied, M1-M6 verdict) plus the next-action hint.
+
+## Constraints
+
+- **Source is copy-only** — never modify/delete/symlink the `--src` tree.
+- Abort if `<dest>/<plugin-name>` exists (no overwrite; not idempotent).
+- `--dry-run` writes nothing, creates no repo or commit.
+- `gh auth status` before any `gh` call; confirm before repo-create + push;
+  never `git push --force`.
+- Sister skills: `claude-plugin:structure-check` (verify),
+  `claude-plugin:structure-refactor` (fix), `claude-plugin:rename-repo`
+  (rename). This skill creates.

--- a/claude/skills/claude-plugin-create/references/help.md
+++ b/claude/skills/claude-plugin-create/references/help.md
@@ -1,0 +1,74 @@
+/claude-plugin:create — Create a new claude-plugin marketplace repo from scratch
+
+Usage:
+  /claude-plugin:create <plugin-name> [skill ...] [--src <path>] [--dest <path>]
+                        [--host <ghes-host>] [--owner <owner>] [--plugin <name>] [--dry-run]
+  /claude-plugin:create help
+
+Arguments:
+  <plugin-name>   Repo name in `claude-plugin-<domain>` form (required).
+                  Missing prefix is auto-prepended (you are told). Lowercase
+                  + hyphens only — GitHub repo naming rules.
+  [skill ...]     Skill directory names to copy (space-separated). Omitted →
+                  inferred from the conversation; if not inferable, you are
+                  asked for the list (never guessed).
+
+Flags:
+  --src <path>    Skill source directory.   default ~/dotfiles/claude/skills/
+  --dest <path>   Where the repo is created. default ~/para/project/
+  --host <host>   GitHub host.               default github.samsungds.net
+  --owner <owner> GitHub owner.              default byoungwoo-yoon
+  --plugin <name> Plugin key (inner name).   default = domain part of
+                  <plugin-name>  (claude-plugin-harness → harness)
+  --dry-run       Print the plan only — no files, no repo, no commit.
+  -h | --help     Print this help and stop. No filesystem or network calls.
+
+Plan output (Step 2, always printed):
+  [PLAN] claude-plugin:create
+    Plugin name : claude-plugin-harness
+    Plugin key  : harness
+    Destination : ~/para/project/claude-plugin-harness/
+    Skills to copy (N):
+      ~/dotfiles/claude/skills/<skill>  → plugins/harness/skills/<skill>
+      ...
+    GH repo     : github.samsungds.net/byoungwoo-yoon/claude-plugin-harness
+    Dry-run     : off
+  (--dry-run stops here.)
+
+Behavior (mono golden layout):
+  1. Parse & validate (prefix, --src exists, dest not present, skill list).
+  2. Print the plan (stop if --dry-run).
+  3. Build the structure: .claude-plugin/marketplace.json,
+     plugins/<plugin>/.claude-plugin/plugin.json, plugins/<plugin>/skills/,
+     docs/skill-guides/, docs/skill-output/, README.md, LICENSE, .gitignore.
+  4. Copy each skill (cp -r). Source is RE-VERIFIED unchanged afterward.
+  5. Write manifests + README + LICENSE + .gitignore from templates.
+  6. git init + checkout -b main.
+  7. gh repo create (after gh auth status + user confirmation).
+  8. git add + commit "feat: init <plugin-name>" + push (after confirmation).
+  9. claude-plugin:structure-check → confirm M1-M6 PASS.
+
+Completion report (Step 9):
+  [OK] claude-plugin:create
+    Repo  : https://<host>/<owner>/<plugin-name>
+    Skills: N copied
+    Check : M1-M6 PASS
+    Next  : /claude-plugin:structure-check <dest>/<plugin-name>  (re-verify)
+            docs/skill-guides/ 시각 가이드 추가 → /devx:visualize
+
+Safety:
+  - Source (--src) is COPY-ONLY — never modified, moved, deleted, symlinked.
+  - <dest>/<plugin-name> already exists → ABORT (no overwrite; not idempotent).
+  - Remote repo creation and push are outward-facing — confirmed before each.
+  - gh auth status is checked before any gh call; never git push --force.
+
+Examples:
+  /claude-plugin:create claude-plugin-harness skill-check skill-create
+  /claude-plugin:create harness skill-check --dry-run
+  /claude-plugin:create claude-plugin-visuals devx-visualize --owner acme --host github.com
+  /claude-plugin:create help
+
+Sister skills:
+  /claude-plugin:structure-check     — read-only audit (run after create)
+  /claude-plugin:structure-refactor  — fix an existing repo's structure
+  /claude-plugin:rename-repo         — rename a repo to the team convention

--- a/claude/skills/claude-plugin-create/references/manifest-templates.md
+++ b/claude/skills/claude-plugin-create/references/manifest-templates.md
@@ -1,0 +1,92 @@
+# claude-plugin:create — Manifest, LICENSE & .gitignore Templates
+
+These are written in Step 5 (`mono` golden layout). `<plugin-name>` is the
+repo name (`claude-plugin-harness`); `<plugin>` is the plugin key
+(`harness`); `<owner>`/`<host>` come from the flags; `<skill>` entries come
+from the dynamically discovered skill list. Keep `marketplace.json`
+`name` equal to the repo name 1:1 (same rule as `claude-plugin:rename-repo`).
+
+## `.claude-plugin/marketplace.json`
+
+```json
+{
+  "name": "<plugin-name>",
+  "owner": "<owner>",
+  "description": "<one-line marketplace description>",
+  "plugins": [
+    {
+      "name": "<plugin>",
+      "source": "./plugins/<plugin>",
+      "description": "<plugin description>"
+    }
+  ]
+}
+```
+
+The `source` is a **relative** path (`./plugins/<plugin>`) — repo-name
+independent, so a later `rename-repo` never has to touch it.
+
+## `plugins/<plugin>/.claude-plugin/plugin.json`
+
+```json
+{
+  "name": "<plugin>",
+  "version": "0.1.0",
+  "description": "<plugin description>",
+  "maintainer": "<owner>",
+  "keywords": ["claude-plugin", "<domain>"],
+  "category": "skills",
+  "skills": ["./skills/<skill>"]
+}
+```
+
+Fill `skills[]` from the copied skill list (one `./skills/<skill>` per
+skill). Start at `version: "0.1.0"`.
+
+## `LICENSE` (MIT, current year)
+
+Derive the year at runtime (`date +%Y`) — do not hardcode it.
+
+```
+MIT License
+
+Copyright (c) <year> <owner>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## `.gitignore`
+
+```gitignore
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.swp
+
+# Node
+node_modules/
+
+# Local
+*.local
+.env
+```

--- a/claude/skills/claude-plugin-create/references/readme-template.md
+++ b/claude/skills/claude-plugin-create/references/readme-template.md
@@ -1,0 +1,64 @@
+# claude-plugin:create — README Template
+
+Written in Step 5 at `<dest>/<plugin-name>/README.md`. Placeholders:
+`<plugin-name>` = repo name, `<plugin>` = plugin key, `<owner>`/`<host>`
+from the flags, `<skill>` rows from the discovered skill list.
+
+This template is designed to satisfy `claude-plugin:structure-check`'s
+recommended checks out of the box: R3 ("Simple" — at least one `docs/` link,
+a skill section), and R5 (per-skill guide **and** usage links). The
+`docs/skill-guides/<skill>.html` and `docs/skill-output/<skill>-usage.md`
+files are placeholder stubs at create time — fill them later with
+`/devx:visualize` (that satisfies R1/R2).
+
+## Template
+
+````markdown
+# <plugin-name>
+
+> Claude Code 스킬 마켓플레이스 플러그인. `<plugin>` 플러그인이 아래 스킬들을 번들합니다.
+
+## 설치
+
+```
+/plugin marketplace add <owner>/<plugin-name>
+/plugin install <plugin>@<plugin-name>
+```
+
+GHES(`<host>`)에서는 호스트 인증 후 동일하게 추가합니다.
+
+## 스킬 목록
+
+| 스킬 | 설명 | 가이드 / 사용 예시 |
+|------|------|--------------------|
+| `<skill>` | <SKILL.md description 첫 문장> | [guide](docs/skill-guides/<skill>.html) · [usage](docs/skill-output/<skill>-usage.md) |
+
+> 표의 각 행은 스킬 1개에 대응합니다. 가이드/사용 예시 링크는
+> `docs/skill-guides/`, `docs/skill-output/` 의 문서를 가리킵니다
+> (생성 시 placeholder, 이후 `/devx:visualize` 로 채움).
+
+## 구조
+
+```
+.
+├── .claude-plugin/marketplace.json
+├── plugins/<plugin>/
+│   ├── .claude-plugin/plugin.json
+│   └── skills/<skill>/SKILL.md
+├── docs/skill-guides/
+├── docs/skill-output/
+└── README.md
+```
+
+## License
+
+MIT © <year> <owner>
+````
+
+## Notes
+
+- One table row per discovered skill — both the `skill-guides/<skill>.html`
+  guide link and the `skill-output/<skill>-usage.md` usage link must be
+  present (R5).
+- Keep the body "Simple" (R3): it links into `docs/`, names the
+  `plugins`/`skills`, and stays short.


### PR DESCRIPTION
## Summary

기존 `claude-plugin` sister 스킬 3종(`structure-check` / `structure-refactor` / `rename-repo`)은 모두 **이미 존재하는 레포**를 대상으로 한다. 신규 플러그인 레포를 처음부터 만드는 **자연어 진입점**이 없어 매번 수동(~40분)으로 반복하던 흐름을, 한 번에 처리하는 컴포지션 스킬 `claude-plugin:create` 로 추가한다.

## Changes

- `claude/skills/claude-plugin-create/SKILL.md` — Step 1-9 흐름 (parse/validate → plan → 구조 생성 → 스킬 복사 → 매니페스트/README 작성 → git init → repo create → commit/push → 검증). mono 골든 레이아웃 기준, `--dry-run` 은 plan만 출력 후 중단. 옵션 테이블 + stop-on-error 정책 포함.
- `references/help.md` — args/flags 전체 문서 + plan/completion 리포트 포맷
- `references/manifest-templates.md` — `marketplace.json` / `plugin.json` / `LICENSE` / `.gitignore` 템플릿
- `references/readme-template.md` — `structure-check` R3/R5 통과형 README 템플릿

## Safety constraints

- 원본(`--src`) **copy-only** — 수정/삭제/symlink 절대 금지, 복사 후 무결성 재확인
- 기존 `<dest>/<plugin-name>` 존재 시 **abort** (no-overwrite, not idempotent)
- 원격 repo 생성·push 는 outward-facing → 각각 **확인 후 실행**, `gh auth status` 선행
- `git push --force` 금지

## Verification

- `skill:check`: **11 PASS / 1 WARN / 0 FAIL** — 유일한 WARN 은 line count(9-step 구성상 116줄; sister `structure-refactor` 도 111줄로 동급)
- golden rules: **All passed** (변경은 markdown/docs 한정, shell 코드 무영향)
- Acceptance Criteria #991 전 항목 충족

Closes #991
