### PR TITLE
feat(skill-check): 보안/정책 정렬 검사 추가 — license 선언 + capability(network) 선언 일관성

### DIFF
--- a/claude/skills/skill-check/SKILL.md
+++ b/claude/skills/skill-check/SKILL.md
@@ -3,8 +3,9 @@ name: skill:check
 description: >-
   Audit a SKILL.md for structure and UX quality — checks line count,
   progressive disclosure, frontmatter, references usage, output format,
-  help flag pattern, step structure, options docs, verdict output, and
-  next-action hints. Use when the user says "check my skill", "audit my
+  help flag pattern, step structure, options docs, verdict output,
+  next-action hints, plus security/policy alignment (license declaration
+  and network capability declaration consistency). Use when the user says "check my skill", "audit my
   skill", "does this skill follow best practices?", "/skill:check".
   Reports PASS/WARN/FAIL/N/A per criterion with concrete fixes.
   Do NOT use for AGENTS.md, CLAUDE.md, or GEMINI.md files — use devx:ai-context check instead.
@@ -23,9 +24,9 @@ If the argument is `help`, read `references/help.md` and output its content verb
 If the user specifies a path, use it. Otherwise search for SKILL.md from the
 current directory.
 
-## Step 2: Run Twelve Checks
+## Step 2: Run Fourteen Checks
 
-Read `references/checks.md` for all 12 check definitions and PASS/WARN/FAIL/N/A criteria.
+Read `references/checks.md` for all 14 check definitions and PASS/WARN/FAIL/N/A criteria.
 Assign one result per check. Audit-only — never stop on failure; report every check (`skill:check` is read-only and must produce a full report).
 
 **Checks 1–5: Structure**
@@ -44,6 +45,15 @@ from this skill's own tier; `--recursive` opts into deeper traversal.
 
 Check 11 (No Emojis) consults `references/allowed-emoji-skills.txt` —
 audited skill names that appear in that file resolve to `[N/A] allowlisted`.
+
+**Checks 13–14: Security & Policy Alignment**
+License Declaration · Capability Declaration Consistency
+
+Check 13 cross-checks frontmatter `license` against a repo-root `LICENSE`
+(pre-empts scanner `MANIFEST_MISSING_LICENSE`). Check 14 scans shipped scripts
+for network signals and compares against `compatibility.network` (pre-empts
+`TOOL_ABUSE_UNDECLARED_NETWORK`). Both are **read-only** — they flag a policy
+gap, never edit files.
 
 ## Step 3: Output the Report
 

--- a/claude/skills/skill-check/references/checks.md
+++ b/claude/skills/skill-check/references/checks.md
@@ -1,6 +1,6 @@
 # Skill Quality Checks
 
-Twelve checks, each rated PASS / WARN / FAIL / N/A.
+Fourteen checks, each rated PASS / WARN / FAIL / N/A.
 
 ---
 
@@ -125,3 +125,48 @@ the declared `tier`.
 Plan — read each sub-skill's declared `tier`, mark missing ones `unknown` (WARN),
 and report it **separately from this skill's own tier** (see report-template.md).
 Recursion is 1-depth by default; `--recursive` opts into deeper traversal.
+
+---
+
+## Security & Policy Alignment Checks (13–14)
+
+These two checks pre-empt findings that external security scanners (e.g. an
+org's AgentToolbox scanner) raise against published skills. Both are
+**read-only — they flag a policy gap, never edit files** (audit-only invariant).
+
+### Check 13: License Declaration
+Cross-check frontmatter `license` against the repo-root `LICENSE` file.
+
+| Result | Criteria |
+|---|---|
+| PASS | frontmatter declares a `license` field |
+| WARN | no `license` in frontmatter BUT a `LICENSE` file exists at the repo root → suggest "add `license: <SPDX>` to frontmatter" (pre-empts scanner `MANIFEST_MISSING_LICENSE`) |
+| N/A | repo has no `LICENSE` file (private/experimental skill — nothing to align with) |
+
+Repo root: walk up from the SKILL.md until a `LICENSE`/`LICENSE.md`/`LICENSE.txt`
+or a `.git` directory is found; the LICENSE check is relative to that root.
+On WARN, recommend a concrete SPDX identifier when the LICENSE is recognizable
+(e.g. `license: MIT`), else `license: <SPDX>`.
+
+### Check 14: Capability Declaration Consistency
+Scan the skill's executable scripts (primarily `scripts/`, plus any
+`*.sh`/`*.py` shipped beside the SKILL.md) for network-capability signals and
+compare against the `compatibility.network` declaration. 1st-scope is **network
+only** — the capability the external scanner actually flags
+(`TOOL_ABUSE_UNDECLARED_NETWORK`).
+
+Network signals: imports of `requests` / `httpx` / `urllib` / `http.client` /
+`socket` / `aiohttp`, or explicit MCP/HTTP call patterns (e.g. `curl`, `wget`,
+`fetch(`, `http(s)://` request construction).
+
+| Result | Criteria |
+|---|---|
+| PASS | no network signal found, OR network is used AND `compatibility.network` is declared |
+| WARN | network signal present BUT no `compatibility.network` declaration → suggest "scripts use the network — declare `compatibility.network: required`" |
+| N/A | skill ships no executable scripts (pure-prompt skill — nothing to scan) |
+
+Extension note: filesystem-write and subprocess capabilities follow the same
+detect-vs-declare pattern; 1st scope is intentionally network-only because that
+is what the scanner flags today. `CROSS_SKILL_SHARED_URL` (multiple skills
+sharing one external domain) is **out of scope** — it requires cross-file
+analysis, while `skill:check` audits a single SKILL.md.

--- a/claude/skills/skill-check/references/help.md
+++ b/claude/skills/skill-check/references/help.md
@@ -18,10 +18,12 @@ Examples:
   /skill:check claude/skills/gh-issue-flow/SKILL.md --recursive
   /skill:check help
 
-Checks run (12 total):
+Checks run (14 total):
   Structure (1-5):    Line Count, Progressive Disclosure, Frontmatter Validity,
                       References Directory Usage, Output Report Defined
   UX Quality (6-11):  Help Flag Pattern, Step Structure, Options Documentation,
                       Verdict Output, Next-action Hint, No Emojis
   Model (12):         Model Recommendation Metadata (read-only tier advice;
                       rubric: references/model-recommendation.md)
+  Security (13-14):   License Declaration, Capability Declaration Consistency
+                      (read-only policy alignment; pre-empts security scanners)

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -40,7 +40,7 @@ References dir: <exists / missing>
 
 Recommended tier: haiku — read-only audit, bounded output (declared: none yet)
 
-Score: 7/14 checks passed (5 warnings, 2 fails, 0 N/A)
+Score: 6/13 checks passed (5 warnings, 2 fails, 1 N/A)
 Verdict: NEEDS WORK — fix FAIL items before shipping
 
 ## Sub-skill Model Plan

--- a/claude/skills/skill-check/references/report-template.md
+++ b/claude/skills/skill-check/references/report-template.md
@@ -32,9 +32,15 @@ References dir: <exists / missing>
 |----|------------------------------|--------|---------------------------------------|
 | 12 | Model Recommendation Metadata| WARN   | metadata absent (migration period)    |
 
+### Security & Policy Alignment Checks
+| #  | Check                          | Result | Notes                                      |
+|----|--------------------------------|--------|--------------------------------------------|
+| 13 | License Declaration            | WARN   | no license; repo LICENSE exists → add MIT  |
+| 14 | Capability Declaration Consistency | WARN | scripts import requests; network undeclared |
+
 Recommended tier: haiku — read-only audit, bounded output (declared: none yet)
 
-Score: 6/11 checks passed (3 warnings, 2 fails, 1 N/A)
+Score: 7/14 checks passed (5 warnings, 2 fails, 0 N/A)
 Verdict: NEEDS WORK — fix FAIL items before shipping
 
 ## Sub-skill Model Plan
@@ -68,7 +74,7 @@ Run /skill:check again after fixes to verify.
 Rules:
 - Only include WARN and FAIL items in Issues & Improvements section
 - Quote actual lines from the file when describing problems
-- Score denominator excludes N/A checks (12 checks total, minus any N/A)
+- Score denominator excludes N/A checks (14 checks total, minus any N/A)
 - The "Model Recommendation Check" table row + "Recommended tier" line are
   always shown; the "Sub-skill Model Plan" section appears only for composite
   skills (omit it entirely for leaf skills)


### PR DESCRIPTION
## 요약

`skill:check` 에 보안/정책 정렬 검사 2종을 read-only(audit-only)로 추가한다.
사내 AgentToolbox 보안 스캐너가 `claude-plugin-jira` 스킬에 대해 보고한 9건 중,
단일 SKILL.md 감사기가 스캐너보다 먼저 잡을 수 있는 2종을 자가 점검 단계로 끌어온다.

- **Check 13 — License Declaration**: frontmatter `license` 필드 존재 여부를
  레포 루트 `LICENSE` 유무와 교차검증. license 없음 + LICENSE 존재 → WARN
  (`license: <SPDX>` 추가 권장, 스캐너 `MANIFEST_MISSING_LICENSE` 사전 차단).
  LICENSE 자체가 없으면 N/A.
- **Check 14 — Capability Declaration Consistency**: 스킬의 실행 scripts 를 스캔해
  네트워크 시그널(`requests`/`httpx`/`urllib`/`http.client`/`socket`/`aiohttp` import,
  HTTP/MCP 호출 패턴)과 `compatibility.network` 선언을 비교. 사용하는데 미선언이면
  WARN (`TOOL_ABUSE_UNDECLARED_NETWORK` 사전 차단). 실행 scripts 없으면 N/A.
  1차 범위는 network 한정(스캐너가 실제 잡는 항목).
- `CROSS_SKILL_SHARED_URL` 은 여러 SKILL.md 교차 분석이 필요해 단일 파일 감사기
  범위 밖 — 명시적 out-of-scope 로 문서화.

## 변경 파일

- `references/checks.md` — Check 13·14 정의 추가, "Twelve" → "Fourteen checks",
  새 섹션 "Security & Policy Alignment Checks (13–14)".
- `SKILL.md` — Step 2 "Run Fourteen Checks", 새 카테고리 문구, `description`
  frontmatter 에 license/capability 검사 언급 추가.
- `references/report-template.md` — "Security & Policy Alignment Checks" 표 +
  13·14 행, 점수 분모 12→14 갱신.
- `references/help.md` — "14 total" + Security(13-14) 카테고리 추가.

## 수용 기준

- [x] Check 13: license 없음 + 레포 LICENSE 있음 → WARN + 구체 수정 문구
- [x] Check 14: scripts 네트워크 import + `compatibility.network` 미선언 → WARN
- [x] 두 검사 모두 read-only (audit-only 불변식 명시)
- [x] checks.md / SKILL.md / report-template.md / help.md 체크 개수 14 일관
- [ ] jira 5스킬 회귀(license 5 + network 2) — 외부 GHE 레포라 본 PR 미실행, 설계로 커버

Closes #993
