### PR TITLE
refactor(claude-setup): 일회성 마이그레이션 로그를 warning→info severity 로 정정

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -289,8 +289,10 @@ _migrate_legacy_plugin_paths() {
 
         if jq --arg re "$old_regex" --arg new "$new_prefix" \
                 "$rewrite_filter" "$file" > "$tmp" && mv "$tmp" "$file"; then
-            log_warning "$(basename "$file") plugin 경로 마이그레이션: ${stale_count}건 → ${new_prefix}"
-            log_warning "  backup: $backup"
+            # Successful idempotent migration — info severity so ⚠️ stays
+            # reserved for items needing user action (issue #995).
+            log_info "$(basename "$file") plugin 경로 마이그레이션: ${stale_count}건 → ${new_prefix}"
+            log_info "  backup: $backup"
         else
             rm -f "$tmp"
             log_error "$(basename "$file") 갱신 실패 — 백업 보존: $backup"

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -657,16 +657,16 @@ _claude_ensure_settings_copy() {
     # dangling settings.local.json 정리가 model 이주보다 먼저 — 깨진 링크를
     # 통해 쓰면 소멸한 worktree 경로로 write 가 향해 실패한다 (#940).
     if [ -L "$_cesc_local" ] && [ ! -e "$_cesc_local" ]; then
-        rm -f "$_cesc_local"
         # Routine one-time cleanup, not a problem needing user action — info
         # severity keeps ⚠️ reserved for genuine warnings (issue #995).
-        ux_info "  removed dangling settings.local.json symlink: $_cesc_local"
+        rm -f "$_cesc_local" \
+            && ux_info "  removed dangling settings.local.json symlink: $_cesc_local"
     fi
 
     if [ -L "$_cesc_tgt" ]; then
-        rm "$_cesc_tgt"
         # Intended idempotent migration (#940) — info severity, not ⚠️ (#995).
-        ux_info "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
+        rm "$_cesc_tgt" \
+            && ux_info "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
     elif [ -f "$_cesc_tgt" ] && ! cmp -s "$_cesc_src" "$_cesc_tgt"; then
         # /model 이 남긴 개인 model 키 보존 — SSOT 복사로 사라지기 전에
         # settings.local.json 으로 이주. local 에 이미 model 이 있으면 그대로.

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -658,12 +658,15 @@ _claude_ensure_settings_copy() {
     # 통해 쓰면 소멸한 worktree 경로로 write 가 향해 실패한다 (#940).
     if [ -L "$_cesc_local" ] && [ ! -e "$_cesc_local" ]; then
         rm -f "$_cesc_local"
-        ux_warning "  removed dangling settings.local.json symlink: $_cesc_local"
+        # Routine one-time cleanup, not a problem needing user action — info
+        # severity keeps ⚠️ reserved for genuine warnings (issue #995).
+        ux_info "  removed dangling settings.local.json symlink: $_cesc_local"
     fi
 
     if [ -L "$_cesc_tgt" ]; then
         rm "$_cesc_tgt"
-        ux_warning "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
+        # Intended idempotent migration (#940) — info severity, not ⚠️ (#995).
+        ux_info "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
     elif [ -f "$_cesc_tgt" ] && ! cmp -s "$_cesc_src" "$_cesc_tgt"; then
         # /model 이 남긴 개인 model 키 보존 — SSOT 복사로 사라지기 전에
         # settings.local.json 으로 이주. local 에 이미 model 이 있으면 그대로.


### PR DESCRIPTION
## Summary

`claude/setup.sh` 실행 시 **성공적으로 끝난 일회성 멱등 마이그레이션**이 `⚠️`(warning) 글리프로 출력돼, 정상 동작인데도 "뭔가 잘못됐나?" 하는 착시를 줬다. 해당 로그 라인을 `ℹ️`(info) severity 로 내려 `⚠️`를 실제 사용자 조치가 필요한 항목에만 남긴다.

대상 라인 (severity 만 변경, 문구·발생 조건·횟수 불변):
- `shell-common/tools/integrations/claude.sh` — `removed dangling settings.local.json symlink`, `legacy settings.json symlink → real file (#940)`
- `claude/setup.sh` — `plugin 경로 마이그레이션: N건`, `backup:`

## 유지된 경고 (의도)

실제 조치가 필요한 항목은 `ux_warning`/`log_warning` 그대로:
- `socat 미설치`, `다른 Stop hook 이미 존재 — 자동 머지 생략`, `jq 미설치` 계열, `symlink target mismatch` / `bind-mount detected`
- 마이그레이션 **실패** 경로(`log_error`/`ux_error`)도 불변

## 검증

- 변경 라인 shellcheck/shfmt(`-i 4`) 신규 지적 없음 (기존 whole-file 스타일 diff 는 본 PR 범위 밖, `lint-sh` 는 `bash/` 만 검사).
- `tests/bats/integrations/claude_accounts.bats` 의 `_claude_ensure_settings_copy` 테스트는 동작(`assert_success`·파일 상태)만 검증하고 메시지 문자열/severity 에 의존하지 않음 → 회귀 없음.
- pre-commit hook 통과.

Closes #995

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics -->

</details>
