### PR TITLE
feat(claude-setup): setup.sh 로그 가독성 개선 — 백업 사유 표기 + 변경 요약 라인

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -755,7 +755,10 @@ done
 # 4 CLI 모두 entry-level 합성으로 통일했고 SSOT 는 setup-skills-ssot.sh 로 이전됨.
 
 # --- Completion Messages ---
-_print_change_summary "활성 계정 $(echo "$ENABLED_ACCOUNTS" | wc -w | tr -d ' ')개"  # 변경 요약 한 줄 (#997)
+# 활성 계정 수는 네이티브 배열로 집계 — 외부 wc/tr 포크 회피 (PR #998 리뷰).
+# shellcheck disable=SC2206  # 공백/개행 구분 목록의 의도된 word-splitting.
+_caccts=($ENABLED_ACCOUNTS)
+_print_change_summary "활성 계정 ${#_caccts[@]}개"  # 변경 요약 한 줄 (#997)
 ux_success "Claude Code dotfiles setup 완료"
 echo ""
 ux_success "Claude Code 다중 계정 설정 완료!"

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -185,6 +185,7 @@ _migrate_legacy_statusline_command() {
         log_warning "  before: $legacy_literal"
         log_warning "  after:  $new_literal"
         log_warning "  backup: $backup"
+        SETUP_MIGRATIONS=$((SETUP_MIGRATIONS + 1))  # 변경 요약 집계 (#997)
     else
         rm -f "$tmp"
         log_error "settings.json 갱신 실패 — 백업 보존: $backup"
@@ -293,6 +294,7 @@ _migrate_legacy_plugin_paths() {
             # reserved for items needing user action (issue #995).
             log_info "$(basename "$file") plugin 경로 마이그레이션: ${stale_count}건 → ${new_prefix}"
             log_info "  backup: $backup"
+            SETUP_MIGRATIONS=$((SETUP_MIGRATIONS + 1))  # 변경 요약 집계 (#997)
         else
             rm -f "$tmp"
             log_error "$(basename "$file") 갱신 실패 — 백업 보존: $backup"
@@ -400,6 +402,7 @@ _migrate_install_gh_issue_flow_stop_hook() {
         log_warning "settings.json 에 gh-issue-flow Stop hook 자동 등록 완료"
         log_warning "  hook: $hook_command"
         log_warning "  backup: $backup"
+        SETUP_MIGRATIONS=$((SETUP_MIGRATIONS + 1))  # 변경 요약 집계 (#997)
     else
         rm -f "$tmp"
         log_error "settings.json 갱신 실패 — 백업 보존: $backup"
@@ -501,6 +504,22 @@ EOF
 # --- Main Script Logic (issue #287, Phase 1: multi-account) ---
 
 ux_section "Claude Code dotfiles setup"
+
+# 이번 실행에서 실제로 수행된 마이그레이션 건수 누적 (#997). 완료 직전
+# _print_change_summary 가 이 값을 변경 요약 라인에 집계한다. 마이그레이션
+# 함수들(statusLine / Stop hook / plugin 경로)은 모두 본 스크립트의 최상위
+# 셸에서 호출돼 서브셸 없이 값이 전파된다.
+SETUP_MIGRATIONS=0
+
+# _print_change_summary — 완료 메시지 직전 "이번 실행에서 바뀐 것" 한 줄
+# 롤업 (#997). 사용자가 로그 전체를 훑지 않고도 변경 규모를 파악하게 한다.
+# 최소 집계 원칙(#997 비범위): 마이그레이션 건수 + SSOT 가 관리하는 스킬 수.
+# 인자 $1 이 있으면 뒤에 추가(예: 다중 계정 분기의 활성 계정 수).
+_print_change_summary() {
+    local skills
+    skills=$(find "$CLAUDE_SKILLS_SOURCE" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+    ux_info "요약: 마이그레이션 ${SETUP_MIGRATIONS}건 · 관리 스킬 ${skills}개${1:+ · $1}"
+}
 
 # 필수 dotfiles source 검증
 # settings.json 은 이제 tracked SSOT (#584) — 부트스트랩/템플릿 단계 불필요.
@@ -667,6 +686,7 @@ if [ "$_setup_mode" = "internal" ]; then
 
     # Gemini / OpenCode entry-level 합성은 scripts/setup-skills-ssot.sh 가 책임짐 (#791).
 
+    _print_change_summary  # 변경 요약 한 줄 (#997)
     ux_success "Claude Code dotfiles setup 완료 (internal/single-account)"
     echo ""
     ux_success "Claude Code 단일 계정 설정 완료 (internal PC mode)"
@@ -735,6 +755,7 @@ done
 # 4 CLI 모두 entry-level 합성으로 통일했고 SSOT 는 setup-skills-ssot.sh 로 이전됨.
 
 # --- Completion Messages ---
+_print_change_summary "활성 계정 $(echo "$ENABLED_ACCOUNTS" | wc -w | tr -d ' ')개"  # 변경 요약 한 줄 (#997)
 ux_success "Claude Code dotfiles setup 완료"
 echo ""
 ux_success "Claude Code 다중 계정 설정 완료!"

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -665,8 +665,13 @@ _claude_ensure_settings_copy() {
 
     if [ -L "$_cesc_tgt" ]; then
         # Intended idempotent migration (#940) — info severity, not ⚠️ (#995).
-        rm "$_cesc_tgt" \
-            && ux_info "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
+        if rm "$_cesc_tgt"; then
+            ux_info "  legacy settings.json symlink → real file (#940): $_cesc_tgt"
+            # 백업 불필요 사유를 한 줄 보강 (#997): symlink 제거이므로 잃을
+            # 데이터가 없다(실체는 dotfiles SSOT 에 보존). /model 이 남긴 개인
+            # 키는 아래 elif 실파일 분기에서 settings.local.json 으로 이주된다.
+            ux_info "    (symlink 였으므로 백업 불필요 — SSOT 보존)"
+        fi
     elif [ -f "$_cesc_tgt" ] && ! cmp -s "$_cesc_src" "$_cesc_tgt"; then
         # /model 이 남긴 개인 model 키 보존 — SSOT 복사로 사라지기 전에
         # settings.local.json 으로 이주. local 에 이미 model 이 있으면 그대로.


### PR DESCRIPTION
## Summary

`claude/setup.sh` 실행 로그의 가독성·일관성 개선 2건 (#997). 동작 변경 없이 출력 UX 만 다듬는다.

### 1. settings.json symlink→실파일 전환 시 "백업 불필요" 사유 표기
- `_claude_ensure_settings_copy` (`shell-common/tools/integrations/claude.sh`) 의 `#940` legacy symlink→실파일 전환 로그 옆에 `(symlink 였으므로 백업 불필요 — SSOT 보존)` info 한 줄을 추가.
- 로그만 보는 사용자가 "내 `/model` 설정이 백업 없이 날아간 거 아닌가?" 하고 오해하지 않게 한다. 실체는 dotfiles SSOT 에 보존되며, 개인 `model` 키는 바로 아래 실파일 분기에서 `settings.local.json` 으로 이주된다.
- `rm` 실패 시에는 사유 라인도 출력하지 않도록 `rm && ...` 를 `if rm; then ... fi` 로 정리.

### 2. 실행 종료 시 "이번 실행에서 바뀐 것" 요약 라인
- 완료 메시지 직전 변경 요약 한 줄을 출력하는 공통 헬퍼 `_print_change_summary` 추가. single-account / 다중 계정 두 분기 모두에서 호출.
- 집계 항목: 이번 실행에서 수행된 마이그레이션 건수(`SETUP_MIGRATIONS` 누적 — statusLine / Stop hook / plugin 경로 마이그레이션 성공 시 +1) + SSOT 가 관리하는 스킬 수. 다중 계정 분기는 활성 계정 수까지 덧붙인다.
- `#997` "과설계 금지 — 최소 집계" 지침에 맞춰 deep 계측 없이 top-level 셸 카운터 + 파생 카운트만 사용.

## Test
- `shellcheck` clean (`claude/setup.sh`), `bash -n` / `sh -n` 통과.
- 관련 bats 회귀 없음: `claude_accounts_repair`, `test_no_backup_accumulation`, `claude_stop_hook_install` 전부 통과.
- `claude_accounts.bats` 의 1건 실패는 pre-existing (iso 사본에 `claude/workflows` 누락 — 본 변경 stash 후 동일 재현). 미수정.

## Acceptance Criteria
- [x] #1: legacy settings.json symlink→실파일 전환 로그에 백업 불필요 사유가 info 로 1줄 출력
- [x] #2: `./claude/setup.sh` 종료 직전 변경 요약 라인 출력 (집계 항목 ≥1종)
- [x] lint / bats 회귀 없음

Closes #997

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~4 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
