### PR TITLE
refactor(skills): 100줄 초과 SKILL.md 12개를 progressive disclosure 로 정리

### DIFF
--- a/claude/skills/claude-plugin-create/SKILL.md
+++ b/claude/skills/claude-plugin-create/SKILL.md
@@ -23,98 +23,78 @@ metadata:
 
 # claude-plugin Repo Creator
 
-Compose a fresh `claude-plugin-<domain>` marketplace repo end-to-end:
-generate the `mono`-layout golden structure, copy skills **without mutating
-the source**, write manifests/README, then `git init` → repo create → push.
-The "new repo" entry point the three sister skills do not cover.
+Compose a fresh `claude-plugin-<domain>` marketplace repo end-to-end: generate
+the `mono`-layout golden structure, copy skills **without mutating the
+source**, write manifests/README, then `git init` → repo create → push — the
+"new repo" entry point the three sister skills do not cover.
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
-its content verbatim, then stop. No filesystem or network calls.
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output it
+verbatim, then stop. No filesystem or network calls.
 
-**Stop-on-error policy** — HARD-abort on: Step 1 validation (prefix/naming,
-missing `--src`, existing dest), Step 7 `gh auth status` failure, and any
-push rejection. Everything else fails loudly without partial cleanup.
+**Stop-on-error** — HARD-abort on: Step 1 validation (prefix/naming, missing
+`--src`, existing dest), Step 7 `gh auth status` failure, and any push rejection. Everything else fails loudly without partial cleanup.
 
 ## Step 1: Parse & Validate
 
-Positional `<plugin-name>` (required) + optional `[skill ...]` list, plus:
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--src <path>` | skill source directory | `~/dotfiles/claude/skills/` |
-| `--dest <path>` | repo creation location | `~/para/project/` |
-| `--host <host>` | GitHub host | `github.samsungds.net` |
-| `--owner <owner>` | GitHub owner | `byoungwoo-yoon` |
-| `--plugin <name>` | plugin key (inner name) | domain part of name |
-| `--dry-run` | plan only — no writes/repo/commit | off |
-| `-h`/`--help` | print help, stop | — |
-
-Validate: prepend `claude-plugin-` if missing (tell the user) + enforce
-lowercase-hyphen naming; abort if `--src` missing or `<dest>/<plugin-name>`
-exists (no overwrite — NOT idempotent); infer `[skill ...]` from the
-conversation when omitted, else ask (never guess).
+Read `references/options.md` for the full flag/argument table and validation
+rules. In short: `<plugin-name>` (required) + optional `[skill ...]`, flags
+`--src/--dest/--host/--owner/--plugin/--dry-run/-h`. Prepend `claude-plugin-` if
+missing, enforce lowercase-hyphen naming, abort if `--src` missing or dest
+exists (NOT idempotent), infer skills from chat else ask.
 
 ## Step 2: Plan (always)
 
 Print the `[PLAN]` block per `references/help.md` → "Plan output" (plugin
-name/key, destination, the resolved skill→dest copy map, GH repo, dry-run
-flag). If `--dry-run`, stop here — write nothing, create no repo.
+name/key, destination, skill→dest copy map, GH repo, dry-run flag). If
+`--dry-run`, stop here — write nothing, create no repo.
 
 ## Step 3: Build the Directory Structure
 
-Create the `mono` golden layout under `<dest>/<plugin-name>/`:
-`.claude-plugin/marketplace.json`, `plugins/<plugin>/.claude-plugin/plugin.json`,
-empty `plugins/<plugin>/skills/`, `docs/skill-guides/`, `docs/skill-output/`,
-`README.md`, `LICENSE`, `.gitignore`. May delegate the skeleton dirs to
-`claude-plugin:structure-refactor --apply --mandatory`.
+Create the `mono` golden layout under `<dest>/<plugin-name>/` — see
+`references/options.md` → "Golden `mono` layout" for the full tree. May
+delegate the skeleton dirs to `claude-plugin:structure-refactor --apply
+--mandatory`.
 
 ## Step 4: Copy Skills (source is read-only)
 
-`cp -r <src>/<skill> <dest>/<plugin-name>/plugins/<plugin>/skills/` per skill
-(copy **into** the existing parent `skills/` dir — never name the target
-`skills/<skill>`, which nests to `skills/<skill>/<skill>/` if it already
-exists); re-confirm every source dir is still present and unchanged
-afterward. **Never edit, move, delete, or symlink the source.**
+`cp -r <src>/<skill> <dest>/<plugin-name>/plugins/<plugin>/skills/` per skill —
+copy **into** the parent `skills/` dir, never target `skills/<skill>` (nests to
+`skills/<skill>/<skill>/`). Re-confirm each source dir unchanged afterward.
+**Never edit, move, delete, or symlink the source.**
 
 ## Step 5: Write Manifests, README, LICENSE, .gitignore
 
-Fill the files from `references/manifest-templates.md` and
+Fill from `references/manifest-templates.md` and
 `references/readme-template.md` (MIT LICENSE, current year), using the
 discovered plugin/skill names.
 
 ## Step 6: git init & Branch
 
-`git init <dest>/<plugin-name>`, then `git -C <dest>/<plugin-name> checkout -B main`
-(`-B`, not `-b` — modern Git may already default the branch to `main`, and
-`-b` would fail with "branch named 'main' already exists").
+`git init <dest>/<plugin-name>`, then `git -C <dest>/<plugin-name> checkout -B main` (`-B` not `-b` — Git may already default to `main`, where `-b` fails).
 
 ## Step 7: Create the Remote Repo (outward-facing — confirm first)
 
-After `GH_HOST=<host> gh auth status` and explicit user confirmation:
-`gh repo create <owner>/<plugin-name> --public --description "<desc>"`, then
-`git remote add origin git@<host>:<owner>/<plugin-name>.git`. On GHES `gh`
-failure, point the user to the web UI.
+After `GH_HOST=<host> gh auth status` and explicit confirmation: `gh repo
+create <owner>/<plugin-name> --public --description "<desc>"`, then `git remote
+add origin git@<host>:<owner>/<plugin-name>.git`. On GHES `gh` failure, point to the web UI.
 
 ## Step 8: Initial Commit & Push (confirm first)
 
-`git add .` → `git commit -m "feat: init <plugin-name>"` → after
-confirmation, `git push -u origin main`. **Never `git push --force`.**
+`git add .` → `git commit -m "feat: init <plugin-name>"` → after confirmation,
+`git push -u origin main`. **Never `git push --force`.**
 
 ## Step 9: Verify & Report
 
 Run `claude-plugin:structure-check <dest>/<plugin-name>`, confirm M1-M6 PASS,
-and emit the `[OK]` report per `references/help.md` → "Completion report"
-(repo URL, skills copied, M1-M6 verdict) plus the next-action hint.
+emit the `[OK]` report per `references/help.md` → "Completion report" (repo
+URL, skills copied, M1-M6 verdict) plus the next-action hint.
 
 ## Constraints
 
-- **Source is copy-only** — never modify/delete/symlink the `--src` tree.
-- Abort if `<dest>/<plugin-name>` exists (no overwrite; not idempotent).
-- `--dry-run` writes nothing, creates no repo or commit.
-- `gh auth status` before any `gh` call; confirm before repo-create + push;
-  never `git push --force`.
-- Sister skills: `claude-plugin:structure-check` (verify),
-  `claude-plugin:structure-refactor` (fix), `claude-plugin:rename-repo`
-  (rename). This skill creates.
+- **Source is copy-only** — never modify/delete/symlink `--src`. Abort if dest
+  exists (not idempotent); `--dry-run` writes nothing. `gh auth status` before
+  any `gh` call; confirm repo-create + push; never force-push.
+- Sisters: `structure-check` (verify) · `structure-refactor` (fix) ·
+  `rename-repo` (rename). This skill creates.

--- a/claude/skills/claude-plugin-create/references/options.md
+++ b/claude/skills/claude-plugin-create/references/options.md
@@ -1,0 +1,42 @@
+# Options — full flag/argument reference for claude-plugin:create
+
+Positional `<plugin-name>` (required) + optional `[skill ...]` list, plus the
+flags below. (The same surface, with examples, is in `help.md`.)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<plugin-name>` | repo name in `claude-plugin-<domain>` form (required) | — |
+| `[skill ...]` | skill directory names to copy (space-separated) | inferred from chat, else ask |
+| `--src <path>` | skill source directory | `~/dotfiles/claude/skills/` |
+| `--dest <path>` | repo creation location | `~/para/project/` |
+| `--host <host>` | GitHub host | `github.samsungds.net` |
+| `--owner <owner>` | GitHub owner | `byoungwoo-yoon` |
+| `--plugin <name>` | plugin key (inner name) | domain part of name |
+| `--dry-run` | plan only — no writes/repo/commit | off |
+| `-h`/`--help` | print help, stop | — |
+
+## Validation rules (Step 1)
+
+- Prepend `claude-plugin-` if the prefix is missing (tell the user).
+- Enforce lowercase-hyphen naming (GitHub repo naming rules).
+- Abort if `--src` is missing.
+- Abort if `<dest>/<plugin-name>` already exists — no overwrite, NOT idempotent.
+- `[skill ...]`: infer from the conversation when omitted; if not inferable,
+  ask the user (never guess).
+
+## Golden `mono` layout built in Step 3
+
+```
+<dest>/<plugin-name>/
+  .claude-plugin/marketplace.json
+  plugins/<plugin>/.claude-plugin/plugin.json
+  plugins/<plugin>/skills/          # empty — skills copied in at Step 4
+  docs/skill-guides/
+  docs/skill-output/
+  README.md
+  LICENSE
+  .gitignore
+```
+
+May delegate the skeleton dirs to
+`claude-plugin:structure-refactor --apply --mandatory`.

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -45,61 +45,50 @@ Positional `[repo-path]` (default = current dir). Flags:
 - `--recommended` / `--op` — scope = M1-M6 + R1-R5.
 - `--single` / `--mono` — force the **target** layout mode, overriding
   auto-detection (Step 2). Mutually exclusive; if both given, last wins.
-- `--mp` and `--op` together → error + usage, stop.
+  `--mp` and `--op` together → error + usage, stop.
 
 Confirm the path exists. `test -d <path>/.git`: not a git repo → warn (moves
-fall back to `mv`). Dirty tree → show the dry-run plan and require an
-explicit `--apply` before writing (never auto-apply on a dirty tree).
+fall back to `mv`). Dirty tree → show the dry-run plan and require an explicit
+`--apply` before writing (never auto-apply on a dirty tree).
 
 ## Step 2: Detect Mode + Compute Plugin Roots + Evaluate Current ↔ Target
 
-Read `references/structure-spec.md` (embedded SSOT — identical copy to
-structure-check's) — see "Layout modes", "Mode detection", "Mode override =
-layout conversion", and "Mandatory items by mode".
+Read `references/structure-spec.md` (embedded SSOT) for layout modes, mode detection/override, and mandatory items by mode.
 
-1. **Detect the current mode** from signals (priority order: flag → manifest
-   `plugins[].source` → filesystem → default `mono`).
+1. **Detect the current mode** (priority: flag → manifest `plugins[].source`
+   → filesystem → default `mono`).
 2. **Conversion guard** — forced mode ≠ detected current layout → out of
-   scope. Detailed rules: see [references/structure-spec.md](references/structure-spec.md)
-   → "Mode override = layout conversion".
+   scope (rules in spec → "Mode override = layout conversion").
 3. **Compute the plugin-root set**: `mono` → each `plugins/*/`; `single` →
    repo root `./` (exactly one).
-4. **Discover skills** and run M1-M6 / R1-R5 evaluation over the plugin-root
-   set to compute the current → target diff.
+4. **Discover skills** and run M1-M6 / R1-R5 evaluation over the roots to
+   compute the current → target diff.
 
 ## Step 3: Build the Plan
 
 Read `references/plan-and-report-templates.md`. Produce an ordered change
 list, each tagged with its driving check ID (M1-M6, and R1-R5 only when
-scope is `--op`). Action **paths are plugin-root relative** — single targets
-root `./` (no `plugins/` dir is ever created); mono targets `plugins/<p>/`.
+scope is `--op`). **Paths are plugin-root relative** — single targets root
+`./` (no `plugins/` dir ever created); mono targets `plugins/<p>/`.
 Already-correct items produce no action (idempotent). The plan header states
-the detected/forced mode; a needed-but-unsupported conversion produces only
-the `[convert]` warning line.
+the detected/forced mode; an unsupported conversion produces only the
+`[convert]` warning line.
 
 ## Step 4: Dry-run or Apply
 
 - **Dry-run (default)**: print the plan only. Touch nothing.
 - **Conversion required (forced mode ≠ detected)**: print the `[convert]`
   warning and stop — even under `--apply`, write nothing.
-- **`--apply`**: execute the plan in order, per
-  `references/plan-and-report-templates.md` → "Apply rules":
-  - create missing dirs: `.claude-plugin/`, `docs/skill-guides/`,
-    `docs/skill-output/`, and the per-plugin-root `skills/` — for `mono`
-    that is `plugins/<p>/skills/`, for `single` it is root `skills/` (no
-    `plugins/` directory is created);
-  - move misplaced files with `git mv` when possible (else `mv`);
-  - write minimal skeletons for a missing `marketplace.json` / `plugin.json`
-    (filled with discovered plugin/skill names);
-  - **`--op` only**: apply R1-R5 fixes (guide generation, usage stubs,
-    Pages activation, naming correction, README link backfill). Detailed
-    rules: see [references/op-rules.md](references/op-rules.md).
+- **`--apply`**: execute the plan in order per the "Apply rules" in
+  `references/plan-and-report-templates.md` (mkdir dirs incl. per-plugin-root
+  `skills/`, `git mv`/`mv` moves, minimal `marketplace.json`/`plugin.json`
+  skeletons). `--op` adds R1-R5 — see [references/op-rules.md](references/op-rules.md).
 
 ## Step 5: Report
 
 Use the completion report template in
-`references/plan-and-report-templates.md`. End with `[OK]` or `[FAIL]` plus
-a key=value summary, then the next-action hint:
+`references/plan-and-report-templates.md` — end with `[OK]`/`[FAIL]` + a
+key=value summary, then the next-action hint:
 
 - after a dry-run: `Next: /claude-plugin:structure-refactor <path> --apply [--op]`
 - after `--apply`: `Next: /claude-plugin:structure-check <path>` (re-verify)

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -79,10 +79,10 @@ the detected/forced mode; an unsupported conversion produces only the
 - **Dry-run (default)**: print the plan only. Touch nothing.
 - **Conversion required (forced mode ≠ detected)**: print the `[convert]`
   warning and stop — even under `--apply`, write nothing.
-- **`--apply`**: execute the plan in order per the "Apply rules" in
-  `references/plan-and-report-templates.md` (mkdir dirs incl. per-plugin-root
-  `skills/`, `git mv`/`mv` moves, minimal `marketplace.json`/`plugin.json`
-  skeletons). `--op` adds R1-R5 — see [references/op-rules.md](references/op-rules.md).
+- **`--apply`**: execute the plan in order following the **Apply rules**
+  (mkdir → move → skeleton, fully listed in
+  `references/plan-and-report-templates.md`); `--op` adds R1-R5 — see
+  `references/op-rules.md`.
 
 ## Step 5: Report
 

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -70,16 +70,15 @@ Mark the task `in_progress` with `TaskUpdate` if it isn't already.
 
 ## Step 3: Delegate Large Outputs
 
-Per the thresholds in `references/chunking-rules.md`, large outputs
-(broad search, full-repo `find`, multi-file conformance checks) MUST go
-through a subagent. Brief it with the resume target and cap the response
-at ~200 words so the main context stays lean.
+Per the thresholds in `references/chunking-rules.md`, large outputs (broad search, full-repo `find`, multi-file conformance checks) MUST go through a subagent.
+Brief it with the resume target and cap the response at ~200 words so the main context stays lean.
 
 ## Step 4: Execute, Then Hand Back
 
-Run the chunked steps. After each: (1) update the TodoList (`TaskUpdate` →
-`completed` or new `in_progress`); (2) emit one short user-facing line about
-what just landed (format in `references/output-format.md`).
+Run the chunked steps. After each step:
+
+1. Update the TodoList (`TaskUpdate` → `completed` or new `in_progress`).
+2. Emit one short user-facing line about what just landed (format in `references/output-format.md`).
 
 When the originally-interrupted task is done, hand control back to the user's
 prior flow. Always end with an explicit `Next:` line naming the next concrete

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -77,15 +77,13 @@ at ~200 words so the main context stays lean.
 
 ## Step 4: Execute, Then Hand Back
 
-Run the chunked steps. After each step:
+Run the chunked steps. After each: (1) update the TodoList (`TaskUpdate` →
+`completed` or new `in_progress`); (2) emit one short user-facing line about
+what just landed (format in `references/output-format.md`).
 
-1. Update the TodoList (`TaskUpdate` → `completed` or new `in_progress`).
-2. Emit one short user-facing line about what just landed (format in
-   `references/output-format.md`).
-
-When the originally-interrupted task is done, hand control back to whatever
-flow the user was in. Always end with an explicit `Next:` line naming the
-next concrete command — never silently return to idle.
+When the originally-interrupted task is done, hand control back to the user's
+prior flow. Always end with an explicit `Next:` line naming the next concrete
+command — never silently return to idle.
 
 ## Output
 

--- a/claude/skills/devx-resume-after-limit/SKILL.md
+++ b/claude/skills/devx-resume-after-limit/SKILL.md
@@ -43,8 +43,7 @@ If arg #1 is `-h`/`--help`/`help`, print `references/help.md` verbatim and stop.
 test -f .claude/.rate-limit-guard.json && cat .claude/.rate-limit-guard.json
 ```
 
-Parse `command`, `worktree`, `branch`, `max_cycles`, `cycles_remaining`,
-`cycle_window_min` (jq/Python). Missing multi-cycle fields default to `max_cycles=1`, `cycles_remaining=1`, `cycle_window_min=305` (PR #369 compat).
+Parse `command`, `worktree`, `branch`, `max_cycles`, `cycles_remaining`, `cycle_window_min` (jq/Python). Missing multi-cycle fields default to `max_cycles=1`, `cycles_remaining=1`, `cycle_window_min=305` (PR #369 compat).
 
 ### 2. Resolve the Command
 
@@ -89,11 +88,10 @@ In the same turn after success:
 rm -f .claude/.rate-limit-guard.json
 ```
 
-Print `[OK] 재개 완료 — 안전망 상태 파일 정리됨`.
-The just-fired cron auto-deleted (`recurring: false`); the Step 4 next-cycle
-cron must be explicitly cancelled. On failure (transient or otherwise), **leave
-state + next cron** in place — the next fire re-triggers this skill, or the user
-re-invokes manually.
+Print `[OK] 재개 완료 — 안전망 상태 파일 정리됨`. The just-fired cron auto-deleted
+(`recurring: false`); the Step 4 next-cycle cron must be explicitly cancelled.
+On failure (transient or otherwise), **leave state + next cron** in place — the
+next fire re-triggers this skill, or the user re-invokes manually.
 
 ## Constraints
 

--- a/claude/skills/gh-issue-create/SKILL.md
+++ b/claude/skills/gh-issue-create/SKILL.md
@@ -23,8 +23,7 @@ metadata:
 
 # gh:issue-create — Conversation → GitHub Issue
 
-Convert the current chat into a well-structured issue on the target repo
-(본문은 대화 언어로), execute immediately, and print only the issue number + URL.
+Convert the current chat into a well-structured issue on the target repo (본문은 대화 언어로), execute immediately, and print only the issue number + URL.
 
 ## Help
 
@@ -50,11 +49,7 @@ present, follow `references/discussion-mode.md` to bind `DISCUSSION_MODE` /
 
 ## Step 2: Classify the Conversation
 
-Read `references/prefix-table.md` and pick exactly one conventional-commit
-prefix as the dominant intent (covers disambiguation, `misc` default,
-large-`feat` heuristic, and title formatting). `verify` 는 코드 변경이
-아닌 라이브 검증 추적용 — 산출물이 issue + 코멘트 누적이면 `verify`,
-테스트 코드 파일이면 `test` (`references/templates/verify.md`).
+Read `references/prefix-table.md` and pick exactly one conventional-commit prefix as dominant intent (covers disambiguation, `misc` default, large-`feat` heuristic, title formatting). `verify` = 라이브 검증 추적용 (산출물 issue+코멘트 누적); 테스트 코드 파일이면 `test` (`references/templates/verify.md`).
 
 ## Step 2.1: Clarification & Scope Guard
 
@@ -64,11 +59,7 @@ Apply `references/clarification.md` trigger signals (동사 없는 명사 나열
 
 ## Step 2.5: Auto-labels + Milestone (opt-in via SSOT)
 
-Skip entirely when `--no-auto-labels` **or** `DISCUSSION_MODE=1` is set
-(#619 F-3). Otherwise read `references/auto-labels.md` and follow verbatim
-(Stage-1 signal → SSOT load → label union → `gh label list` validation →
-milestone resolution). Stash kept labels + milestone for Step 4.
-`--auto-label-debug` emits the Stage-1 trace.
+Skip entirely when `--no-auto-labels` **or** `DISCUSSION_MODE=1` is set (#619 F-3). Otherwise read `references/auto-labels.md` and follow verbatim (Stage-1 signal → SSOT load → label union → `gh label list` validation → milestone resolution). Stash kept labels + milestone for Step 4. `--auto-label-debug` emits the Stage-1 trace.
 
 ## Step 3: Draft the Issue Body
 

--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -56,19 +56,14 @@ Per `references/superpowers-detection.md`: plugin missing → force mode
 ## Step 3: Fetch + Claim Issue
 
 Five substeps in order — full policy, env vars, and behavior matrix in
-`references/claim.md`. Emit each step-completion marker so the harness
-step-skip guard (`skill_completion_guard.py`, #753) can verify the run.
+`references/claim.md`. After 3.1/3.3/3.4 emit `printf '[step:gh-issue-implement/<marker>] OK\n'`
+(markers `fetch-issue`, `self-assign`, `board-transition`) so the harness step-skip
+guard (`skill_completion_guard.py`, #753) can verify the run.
 
-3.1 **Fetch** — `references/fetch-issue.md` (CLOSED refusal there). On
-    success: `printf '[step:gh-issue-implement/fetch-issue] OK\n'`.
-3.2 **Block-label guard** — fail-closed abort (exit 2) if any label
-    matches `GH_ISSUE_BLOCK_LABELS`.
-3.3 **Self-assign** — `--add-assignee @me` unless already assigned (warn,
-    no override, if held by another). After it (or the warn path):
-    `printf '[step:gh-issue-implement/self-assign] OK\n'`.
-3.4 **Board transition** — `_gh_project_status_sync issue <N> "In
-    progress" --only-from "Backlog,Ready"`; no-op without a board. After
-    it: `printf '[step:gh-issue-implement/board-transition] OK\n'`.
+3.1 **Fetch** — `references/fetch-issue.md` (CLOSED refusal there).
+3.2 **Block-label guard** — fail-closed abort (exit 2) if any label matches `GH_ISSUE_BLOCK_LABELS`.
+3.3 **Self-assign** — `--add-assignee @me` unless already assigned (warn, no override, if held by another).
+3.4 **Board transition** — `_gh_project_status_sync issue <N> "In progress" --only-from "Backlog,Ready"`; no-op without a board.
 3.5 **Depends-on guard** — soft-warn per OPEN `Depends on #M` line.
 
 Skip 3.3 / 3.4 / 3.5 via their `GH_ISSUE_SKIP_*` env vars.

--- a/claude/skills/gh-issue-proceed/SKILL.md
+++ b/claude/skills/gh-issue-proceed/SKILL.md
@@ -26,104 +26,75 @@ metadata:
 
 # gh:issue-proceed — Directive Issue → Execution
 
-Sibling of `/gh:issue-implement`: same shell, but Step 2 (superpowers
-detection) and Step 4 (mode dispatch) are dropped — directive issues are
-already designed, so execution is always direct. Full design SSOT:
-`docs/feature/gh-issue-proceed-skill/design.md`.
+Sibling of `/gh:issue-implement`: same shell, minus superpowers detection
+and mode dispatch — directive issues are pre-designed, so execution is always
+direct. SSOT: `docs/feature/gh-issue-proceed-skill/design.md`. On each step's
+success emit its marker `printf '[step:gh-issue-proceed/<id>] OK\n'` (`<id>`
+= `fetch-issue`, `schema-valid`, `execute`, `report`).
 
 ## Help
 
-If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. No API calls.
+If arg #1 is `-h`, `--help`, or `help`, output `references/help.md`
+verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Repo
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
-
-Positional args: `<issue-number> [remote]`.
+Record `START_TS=$(date +%s)` immediately (elapsed-time for Step 4).
+Positional args: `<issue-number> [remote]` — no `mode` arg; always `direct`.
 
 - `issue-number` — required, positive integer.
 - `remote` — default `origin`. Resolve `TARGET_REPO=<owner>/<repo>` per
-  `references/repo-resolution.md`. Missing remote → list `git remote -v`
-  and stop (no silent fallback).
-
-This skill takes no `mode` arg; execution is always `direct`.
+  `references/repo-resolution.md`. Missing remote → `git remote -v` + stop
+  (no silent fallback).
 
 ## Step 2: Fetch + Claim + Schema Validation
 
-2.1 **Fetch + Claim** — run the five claim substeps in
-`references/claim.md` (fetch → block-label guard → self-assign → board
-transition → depends-on). CLOSED-issue refusal precedes schema check
-(`references/fetch-issue.md`). After fetch succeeds, emit:
-`printf '[step:gh-issue-proceed/fetch-issue] OK\n'`.
+2.1 **Fetch + Claim** (`fetch-issue` marker) — run the five claim substeps
+in `references/claim.md` (fetch → block-label guard → self-assign → board
+transition → depends-on). CLOSED-issue refusal precedes schema
+(`references/fetch-issue.md`).
 
-2.2 **Schema validation** — validate the body against the strict
-8-section schema in `references/protocol-schema.md` (goal, preconditions,
-execution_protocol, decision_rules, deliverables, done_criteria,
-out_of_scope, safety). Any missing / empty / unparseable required section
-→ print the §3.4 failure block and STOP (no comment on the issue; schema
-failure is a caller-side problem). On pass emit:
-`printf '[step:gh-issue-proceed/schema-valid] OK\n'`.
+2.2 **Schema validation** (`schema-valid` marker) — validate the body
+against the strict 8-section schema in `references/protocol-schema.md`. Any
+missing / empty / unparseable required section → print the §3.4 failure
+block and STOP — **no comment on the issue** (schema failure is caller-side).
 
-2.3 **Precondition class** — classify mutation requirement per
-`references/preconditions.md` (read-only / mutation-required / mixed /
-verify-only). Log the class to stdout. A `mutation-required` class while
-on the default branch or with a dirty tree → STOP with the remediation
-hint from that file.
+2.3 **Precondition class** — classify per `references/preconditions.md`
+(read-only / mutation-required / mixed / verify-only); log it.
+`mutation-required` on the default branch or a dirty tree → STOP (hint there).
 
 ## Step 3: Execute Protocol
 
-Follow `references/execution-flow.md` and `references/safety-gates.md`:
+Full sequence in `references/step3-sequence.md` (with
+`references/execution-flow.md` + `references/safety-gates.md`). Four stages;
+every STOP / fail-closed / default-deny trigger below is binding:
 
-1. **Pre-flight** (safety Layer 3): branch / secret-shaped files /
-   `gh auth status` / dry-run §preconditions. Any failure → STOP.
-2. **Parse steps** from `execution_protocol` (matrix or numbered mode,
-   `references/protocol-schema.md` §3.3). Unknown action verb in
-   `decision_rules` → fail-closed at parse time.
-3. **Step loop** — for each parsed step: `TaskCreate` → execute under
-   Layer-1 absolute-prohibition + Layer-4 runtime monitors (per-step /
-   global timeout, output secret scanner, write-action quota) → classify
-   the result against `decision_rules` (fail-closed on an unknown class)
-   → apply the mapped action verb (`references/execution-flow.md` §5.3) →
-   `TaskUpdate` with result + classification.
-4. **Done-criteria reconciliation** — match every `- [ ]` item in
-   `done_criteria` to an executed write action / classification. All
-   matched and no abort → `close_issue: <self>` + final comment; else
-   keep the issue open with an `N/M criteria met` comment.
-
-Conditional permissions (bulk ops, force-with-lease, cross-repo, outbound
-net) are default-deny — allowed only when the body's §safety carries the
-matching `allow:` token (`references/safety-gates.md` §4.2). After the loop
-completes (or aborts) emit:
-`printf '[step:gh-issue-proceed/execute] OK\n'`.
+1. **Pre-flight** (Layer 3): branch / secret-shaped files / `gh auth status`
+   / dry-run §preconditions. Any failure → STOP.
+2. **Parse** `execution_protocol`. Unknown verb in `decision_rules` →
+   fail-closed at parse time.
+3. **Step loop** — `TaskCreate` → execute under Layer-1 prohibitions +
+   Layer-4 monitors → classify vs `decision_rules` (fail-closed on unknown
+   class) → apply mapped verb → `TaskUpdate`. Conditional permissions (bulk
+   / force-with-lease / cross-repo / net) **default-deny** — only with the
+   matching §safety `allow:` token.
+4. **Reconcile** `done_criteria`: all matched + no abort → `close_issue:
+   <self>` + comment; else keep open `N/M criteria met`. Then emit `execute`.
 
 ## Step 4: Report
 
 Print the audit report per `references/report-format.md` (per-step table,
-write-action audit, done-criteria reconciliation, outcome). Then append:
-
-```
-[ai-metrics:gh-issue-proceed] ~{ELAPSED} min — write actions: {N}, blocked: {M}
-```
-
-Compute `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))` just before printing.
-Honor `GH_DISABLE_AI_METRICS=1` (omit the metrics line). Finally emit:
-`printf '[step:gh-issue-proceed/report] OK\n'`.
+write-action audit, done-criteria reconciliation, outcome), then append the
+ai-metrics line defined there. Compute `ELAPSED=$(( ($(date +%s) - START_TS)
+/ 60 ))` before printing; honor `GH_DISABLE_AI_METRICS=1`. Then emit `report`.
 
 ## Constraints
 
-Read `references/safety-gates.md` before relaxing any of these:
+Gate rules are absolute; see `references/safety-gates.md` for full layers:
 
-- **Never** force-push to the default branch, leak a secret to any GitHub
-  output, mutate another worktree, or run `gh pr merge` — these are Layer-1
-  absolute prohibitions, ignored even if the issue body authorizes them.
-- **Never** invent a result classification or an action verb — both are
-  fail-closed against the body's `decision_rules` and the fixed verb
-  registry.
-- **Never** apply a conditional permission (bulk / force-with-lease /
-  cross-repo / net) without its explicit §safety `allow:` token.
-- **Never** run a `mutation-required` directive on the default branch or
-  with a dirty tree.
-- **Never** post a comment on schema-validation failure — that is a
-  caller-side problem.
-- Mode is always `direct`; there is no plan / brainstorming dispatch.
+- **Never** force-push the default branch, leak a secret to GitHub output, mutate another worktree, or `gh pr merge` — Layer-1, body cannot override.
+- **Never** invent a result class or action verb — fail-closed vs `decision_rules` and the fixed verb registry.
+- **Never** apply a conditional permission (bulk / force-with-lease / cross-repo / net) without its §safety `allow:` token.
+- **Never** run `mutation-required` on the default branch or a dirty tree.
+- **Never** comment on schema-validation failure (caller-side).
+- Mode is always `direct`; no plan / brainstorming dispatch.

--- a/claude/skills/gh-issue-proceed/references/step3-sequence.md
+++ b/claude/skills/gh-issue-proceed/references/step3-sequence.md
@@ -1,0 +1,55 @@
+# Step 3 execution sequence — the four stages of protocol execution
+
+Companion to `execution-flow.md` (verb registry, §5.3 verb→action map) and
+`safety-gates.md` (the four layers). This file is the expanded form of the
+Step 3 stage list summarized in `SKILL.md`. All STOP / fail-closed /
+default-deny triggers below are decision logic — never relax them without
+re-reading `safety-gates.md`.
+
+## 1. Pre-flight (safety Layer 3)
+
+Run these checks in parallel; **any** failure → STOP before the loop:
+
+- Current branch ≠ default branch (enforced only for the `mutation`
+  precondition class — see `preconditions.md`).
+- No untracked secret-shaped files (`.env`, `*.pem`, `*.key`) in the tree.
+- `gh auth status` succeeds.
+- §preconditions block dry-runs successfully (any embedded check commands).
+
+## 2. Parse steps
+
+Parse the `execution_protocol` section into ordered steps — **matrix** or
+**numbered** mode per `protocol-schema.md` §3.3. An unknown action verb
+referenced in `decision_rules` → **fail-closed at parse time** (do not
+enter the loop).
+
+## 3. Step loop
+
+For each parsed step, in order:
+
+1. `TaskCreate` for the step.
+2. Execute under Layer-1 absolute prohibitions + Layer-4 runtime monitors
+   (per-step timeout, global timeout, output secret scanner, write-action
+   quota). A monitor trip aborts the loop.
+3. Classify the result against the body's `decision_rules`. An unknown
+   result class → **fail-closed** (abort; never invent a class).
+4. Apply the mapped action verb per `execution-flow.md` §5.3. The verb must
+   exist in the fixed verb registry — never invent one.
+5. `TaskUpdate` with the result + classification.
+
+**Conditional permissions** (bulk ops, force-with-lease, cross-repo,
+outbound net) are **default-deny**: allowed only when the body's §safety
+carries the matching `allow:` token (`safety-gates.md` §4.2). A missing
+token promotes the action to a Layer-1 abort.
+
+## 4. Done-criteria reconciliation
+
+Match every `- [ ]` item in `done_criteria` to an executed write action /
+classification.
+
+- All matched and no abort occurred → `close_issue: <self>` + final
+  summary comment.
+- Otherwise → keep the issue open with an `N/M criteria met` comment.
+
+After the loop completes (or aborts) emit
+`printf '[step:gh-issue-proceed/execute] OK\n'`.

--- a/claude/skills/gh-pr-approve/SKILL.md
+++ b/claude/skills/gh-pr-approve/SKILL.md
@@ -27,40 +27,13 @@ output it verbatim, then stop. Help is detected only at arg #1, so
 
 Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 
-Parse args first. Positional: `<pr-number>` and `<remote>` (default
-`origin`). Flags may appear anywhere:
-
-- `--self-record` - self-authored PR only; submit a comment-only record.
-- `--admin-merge` - self-authored PR only; after a blocker-free review,
-  run `gh pr merge --admin`.
-- `--squash`, `--rebase`, `--merge` - optional strategy for
-  `--admin-merge`; reject if used without it.
-
-Reject unknown flags, `--self-record` with `--admin-merge`, and legacy
-`--self-ok` with:
-`--self-ok is not supported; GitHub blocks self-approval server-side.`
-
-Fetch in parallel before reading the diff:
-
-- `TARGET_REPO` from `git remote get-url <remote>`. Missing remote:
-  list `git remote -v` and stop.
-- PR number: explicit arg or `gh pr view --json number` on current
-  branch; if neither exists, stop and ask.
-- `ME=$(gh api user -q .login)`.
-- PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,files`
-- `REBASEABLE=$(gh api repos/$OWNER/$REPO/pulls/<N> --jq .rebaseable)` —
-  the `rebaseable` field is REST-only; `gh pr view --json rebaseable`
-  fails with `Unknown JSON field` because GraphQL has no such field.
-- Prior reviews/comments on this PR by `ME`.
-- `gh pr checks <N> --repo $TARGET_REPO`.
-
-Stop on `state != OPEN`, draft, or required-check failure. Warn (but
-do not stop) on `mergeable: CONFLICTING` or `rebaseable: false` —
-prepend a visible conflict warning block to the review body and include
-it in the Step 5 report.
-If `author.login == ME`, follow `references/self-pr-handling.md`.
-If prior `ME` comments/reviews exist, use re-review mode: every prior
-concern must be verified as fixed, tracked, or acceptably declined.
+Parse args first, then fetch PR metadata in parallel before reading the
+diff. Read `references/arg-parsing.md` for the full flag table,
+rejection rules, the parallel fetch list (incl. the REST-only
+`rebaseable` field), and gate decisions (stop vs. warn). Self-PR
+(`author.login == ME`) follows `references/self-pr-handling.md`; prior
+`ME` comments trigger re-review mode (verify every prior concern fixed,
+tracked, or acceptably declined).
 
 ## Step 2: Fetch Review Material
 
@@ -99,35 +72,8 @@ Match the PR's dominant language.
   `--admin-merge` exactly as specified in `references/self-pr-handling.md`.
 
 After submitting the review (any path), post a separate PR comment with
-ai-metrics (soft-fail — warn on error, never block). When
-`GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399):
-
-```bash
-ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
-if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
-    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
-else
-    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
-      -X POST \
-      -f body="---
-<details>
-<summary>🤖 AI Metrics · 🤖 ~$ELAPSED min</summary>
-
-<!-- ai-metrics:gh-pr-approve -->
-🤖 ~$ELAPSED min
-<!-- /ai-metrics:gh-pr-approve -->
-
-</details>
-PR 리뷰: ~$ELAPSED min"
-fi
-```
-
-The `tokens` and `human_h` fields are intentionally omitted: this skill
-has no real measurement source for either, and the prior `${TOKENS:-5000}`
-/ `human_h=1` placeholders would silently inject the same false numbers
-into every aggregator (issue #403). Only `ai_min` is reported.
-
-On failure: `[WARN] ai-metrics comment failed — continuing.`
+ai-metrics. Read `references/ai-metrics.md` for the exact command,
+footer template, and the `GH_DISABLE_AI_METRICS=1` skip path (#399/#403).
 
 ## Step 5: Verify and Report
 

--- a/claude/skills/gh-pr-approve/references/ai-metrics.md
+++ b/claude/skills/gh-pr-approve/references/ai-metrics.md
@@ -1,0 +1,32 @@
+# ai-metrics footer — post-review metric comment
+
+After submitting the review (any path), post a separate PR comment with
+ai-metrics. Soft-fail: warn on error, never block. When
+`GH_DISABLE_AI_METRICS=1`, skip the comment entirely (issue #399).
+
+```bash
+ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))
+if [ "${GH_DISABLE_AI_METRICS:-0}" = "1" ]; then
+    : # ai-metrics comment skipped via GH_DISABLE_AI_METRICS
+else
+    gh api "repos/$TARGET_REPO/issues/$PR_NUMBER/comments" \
+      -X POST \
+      -f body="---
+<details>
+<summary>🤖 AI Metrics · 🤖 ~$ELAPSED min</summary>
+
+<!-- ai-metrics:gh-pr-approve -->
+🤖 ~$ELAPSED min
+<!-- /ai-metrics:gh-pr-approve -->
+
+</details>
+PR 리뷰: ~$ELAPSED min"
+fi
+```
+
+The `tokens` and `human_h` fields are intentionally omitted: this skill
+has no real measurement source for either, and the prior `${TOKENS:-5000}`
+/ `human_h=1` placeholders would silently inject the same false numbers
+into every aggregator (issue #403). Only `ai_min` is reported.
+
+On failure: `[WARN] ai-metrics comment failed — continuing.`

--- a/claude/skills/gh-pr-approve/references/arg-parsing.md
+++ b/claude/skills/gh-pr-approve/references/arg-parsing.md
@@ -1,0 +1,42 @@
+# Argument parsing — flags, rejections, fetch list
+
+## Positional + flags
+
+Positional: `<pr-number>` and `<remote>` (default `origin`). Flags may
+appear anywhere:
+
+- `--self-record` - self-authored PR only; submit a comment-only record.
+- `--admin-merge` - self-authored PR only; after a blocker-free review,
+  run `gh pr merge --admin`.
+- `--squash`, `--rebase`, `--merge` - optional strategy for
+  `--admin-merge`; reject if used without it.
+
+## Rejections
+
+Reject unknown flags, `--self-record` with `--admin-merge`, and legacy
+`--self-ok` with:
+`--self-ok is not supported; GitHub blocks self-approval server-side.`
+
+## Parallel fetch (before reading the diff)
+
+- `TARGET_REPO` from `git remote get-url <remote>`. Missing remote:
+  list `git remote -v` and stop.
+- PR number: explicit arg or `gh pr view --json number` on current
+  branch; if neither exists, stop and ask.
+- `ME=$(gh api user -q .login)`.
+- PR JSON: `number,title,author,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,files`
+- `REBASEABLE=$(gh api repos/$OWNER/$REPO/pulls/<N> --jq .rebaseable)` —
+  the `rebaseable` field is REST-only; `gh pr view --json rebaseable`
+  fails with `Unknown JSON field` because GraphQL has no such field.
+- Prior reviews/comments on this PR by `ME`.
+- `gh pr checks <N> --repo $TARGET_REPO`.
+
+## Gate decisions
+
+Stop on `state != OPEN`, draft, or required-check failure. Warn (but
+do not stop) on `mergeable: CONFLICTING` or `rebaseable: false` —
+prepend a visible conflict warning block to the review body and include
+it in the Step 5 report.
+If `author.login == ME`, follow `references/self-pr-handling.md`.
+If prior `ME` comments/reviews exist, use re-review mode: every prior
+concern must be verified as fixed, tracked, or acceptably declined.

--- a/claude/skills/gh-pr-merge-emergency/SKILL.md
+++ b/claude/skills/gh-pr-merge-emergency/SKILL.md
@@ -29,17 +29,11 @@ output it verbatim, then stop. No API calls.
 
 ## Step 1: Parse Args + Resolve Target
 
-Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
+Record `START_TS=$(date +%s)` for Step 5 elapsed time. Positional: `<PR> <reason> [remote]`.
 
-Positional args: `<PR> <reason> [remote]`.
-
-- `PR` — number (required). Omitted → `gh pr view --json number` on current
-  branch; else stop with a usage pointer.
-- `reason` — **required**, ≥10 chars, referencing an incident/ticket ID or
-  concrete user impact. Vague reasons (`"urgent"`, `"fix"`) → refuse. Examples
-  in `references/help.md`.
-- `remote` — default `origin`. Resolve `TARGET_REPO` via `git remote get-url`;
-  missing → `git remote -v` and stop.
+- `PR` — required; omitted → `gh pr view --json number` on current branch, else stop with usage pointer.
+- `reason` — **required**, ≥10 chars, citing an incident/ticket ID or concrete user impact; vague (`"urgent"`, `"fix"`) → refuse. Examples: `references/help.md`.
+- `remote` — default `origin`; resolve `TARGET_REPO` via `git remote get-url`, missing → `git remote -v` and stop.
 
 Capture `ME=$(gh api user -q .login)`, `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)`.
 

--- a/claude/skills/write-insight/SKILL.md
+++ b/claude/skills/write-insight/SKILL.md
@@ -41,8 +41,7 @@ Capture one reusable insight from the current chat as a short Korean note in
 ## Step 1: Resolve repo + read the rulebook
 
 In parallel: `git rev-parse --show-toplevel`, read `<repo-root>/docs/guide/learnings/README.md`,
-list existing notes. If `docs/guide/learnings/` is missing, stop — this skill is repo-specific.
-The README is SSOT for template/length/language; re-read it every run.
+list existing notes. Missing `docs/guide/learnings/` → stop (repo-specific). README is SSOT for template/length/language; re-read every run.
 
 ## Step 2: Identify the candidate
 
@@ -61,10 +60,9 @@ when accessible: learnings holds the body, memory keeps a one-line pointer.
 
 ## Step 4: Mine the conversation for sources
 
-Extract from chat: PR numbers, commit SHAs, issue numbers, review URLs
-(`discussion_r...`), file paths with line ranges. A learning without provenance
-is forgettable trivia — if extraction yields nothing, the Context section must
-state the concrete situation ("발견 상황: …"), not vague claims.
+Extract from chat: PR numbers, commit SHAs, issue numbers, review URLs (`discussion_r...`),
+file paths with line ranges. Provenance-less learning is forgettable trivia — if extraction
+yields nothing, the Context section must state the concrete situation ("발견 상황: …"), not vague claims.
 
 ## Step 5: Draft the note
 
@@ -81,8 +79,7 @@ section: append a numbered entry matching the existing 3-line format (heading li
 
 ## Step 7: Suggest a memory pointer (don't auto-create)
 
-If the insight is cross-session reusable, ask: `memory/reference_learnings_<slug>.md`
-포인터 추가할까요? (한 줄짜리, 본문은 learnings, memory 는 경로만). Wait for yes — `MEMORY.md` is loaded into every session, churn there is expensive.
+If cross-session reusable, ask: `memory/reference_learnings_<slug>.md` 포인터 추가할까요? (한 줄짜리, 본문은 learnings, memory 는 경로만). Wait for yes — `MEMORY.md` loads every session; churn is expensive.
 
 ## Step 8: Report
 

--- a/claude/skills/write-rca/SKILL.md
+++ b/claude/skills/write-rca/SKILL.md
@@ -92,9 +92,7 @@ Failure:
 
 ## SSOT — repository path
 
-`$RCA_REPO_PATH` (default: `~/para/archive/rca-knowledge`) is the single
-source of truth for every output path in this skill. Set it once in your
-shell profile to override; every reference here resolves through it.
+`$RCA_REPO_PATH` (default: `~/para/archive/rca-knowledge`) is the SSOT for every output path; set it once in your shell profile to override.
 
 ## References
 

--- a/claude/skills/write-task-history/SKILL.md
+++ b/claude/skills/write-task-history/SKILL.md
@@ -39,8 +39,7 @@ Env: `TASK_HISTORY_DIR` (default `~/para/archive/playbook/docs/task-history/`)
 
 ## Step-by-step workflow
 
-Steps 1–8 are sequential — if Step 1 cannot resolve a writable directory, or Step 7
-commit fails, stop and report rather than producing a partial entry.
+Steps 1–8 are sequential — if Step 1 cannot resolve a writable directory or Step 7 commit fails, stop and report rather than producing a partial entry.
 
 ### Step 1: Determine output file path
 
@@ -55,9 +54,7 @@ Run `mkdir -p` on the directory if it does not exist.
 
 ### Step 2: Analyze the current conversation
 
-Extract **what was done** (concrete actions/changes), **why** (background, trigger),
-and **what resulted** (outcomes, files, PRs, issues). Use any description argument as
-extra context, but still analyze the conversation for completeness.
+Extract **what was done** (concrete actions/changes), **why** (background, trigger), and **what resulted** (outcomes, files, PRs, issues). Use any description argument as extra context, but still analyze the conversation for completeness.
 
 ### Step 3: Gather git information (if in a git repo)
 


### PR DESCRIPTION
## 배경

`/skill-refactor` 전수 검사: `claude/skills/` 하위 **52개 스킬** 중 SKILL.md 가 100줄 한도를 넘긴 **12개**를 일괄 정리. 나머지 40개는 이미 `≤ 100줄 + references/` 구조라 변경 없음.

## 기준 (skill-refactor)

- SKILL.md = control tower (phase·step·decision·pointer 만), `references/` = knowledge base (템플릿·표·상세)
- 콘텐츠 삭제 금지 → references/ 이관 또는 무손실 압축(soft-wrap 제거 포함)
- frontmatter(콜론형 `name:` 포함)·동작·help·출력 포맷 바이트 단위 보존
- 이모지 금지(ai-metrics footer 예외만 유지)

## 변경 (before → after)

| 스킬 | before | after | 방식 |
|------|-------:|------:|------|
| gh-pr-approve | 148 | 94 | `ai-metrics.md`, `arg-parsing.md` 추출 |
| gh-issue-proceed | 129 | 100 | `step3-sequence.md` 추출 + Constraints 압축 |
| claude-plugin-create | 120 | 100 | `options.md` 추출 |
| claude-plugin-structure-refactor | 111 | 100 | prose 압축 |
| gh-pr-merge-emergency | 103 | 97 | prose 압축 |
| gh-issue-create | 103 | 94 | prose 압축 |
| write-task-history | 102 | 99 | prose 압축 |
| write-rca | 102 | 100 | prose 압축 |
| write-insight | 102 | 99 | prose 압축 |
| gh-issue-implement | 102 | 97 | prose 압축 |
| devx-resume-after-limit | 102 | 100 | prose 압축 |
| devx-restart | 102 | 100 | prose 압축 |

신규 references: `gh-pr-approve/{ai-metrics,arg-parsing}.md`, `gh-issue-proceed/step3-sequence.md`, `claude-plugin-create/options.md` — 모두 SKILL.md 에서 pointer 로 연결됨.

## 검증

- 12개 전부 `wc -l ≤ 100` 확인
- 신규 references 4개 비어있지 않고 `# Topic — purpose` 헤더 + SKILL.md pointer 연결 확인
- 콜론형 frontmatter name 12개 모두 보존, 이모지 누출 없음
- pre-commit 훅 통과

## 후속

`/skill:check <path>` 로 각 스킬 품질 재검증 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)