### PR TITLE
fix(claude-setup): settings.json SSOT model 키 누출 자가치유 + 가드

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -723,19 +723,21 @@ _claude_ensure_settings_copy() {
         fi
     fi
 
+    # 단일 cleanup/return — sanitize 임시파일 정리를 세 경로에 중복하지 않고
+    # 함수 말미에서 한 번만 수행 (PR #1000 gemini-code-assist 제안).
+    _cesc_ret=0
     if [ -f "$_cesc_tgt" ] && cmp -s "$_cesc_src" "$_cesc_tgt"; then
         ux_info "  ✓ settings.json up to date (real file): $_cesc_tgt"
-        [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
-        return 0
-    fi
-    if ! cp "$_cesc_src" "$_cesc_tgt"; then
+    elif ! cp "$_cesc_src" "$_cesc_tgt"; then
         ux_error "  settings.json copy failed: $_cesc_src → $_cesc_tgt"
-        [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
-        return 1
+        _cesc_ret=1
+    else
+        chmod 600 "$_cesc_tgt"
+        ux_success "  installed settings.json (real file): $_cesc_tgt"
     fi
-    chmod 600 "$_cesc_tgt"
+
     [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
-    ux_success "  installed settings.json (real file): $_cesc_tgt"
+    return $_cesc_ret
 }
 
 # _claude_dir_sync_one / _claude_count_dir_sync / claude_skills_sync —

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -653,6 +653,26 @@ _claude_ensure_settings_copy() {
     _cesc_src="$1"
     _cesc_tgt="$2"
     _cesc_local="$(dirname "$_cesc_tgt")/settings.local.json"
+    _cesc_srctmp=
+
+    # 방어: SSOT (claude/settings.json) 에 model 키가 새어들면 — 배포 지연 틈에
+    # 남은 pre-#940 write-through symlink 로 /model 이 추적 파일을 오염시킨
+    # 경우 — 모든 계정 복사본이 그 키를 물려받고, live 복사본이 SSOT 와 바이트
+    # 동일해져 아래 cmp 게이트의 model 이주가 영구 skip 된다(자가치유 불능).
+    # 복사 source 를 sanitize 해 오염 전파를 끊고 추적 파일 청소를 안내한다.
+    # 추적 SSOT 자체는 건드리지 않는다 — setup 이 tracked 파일에 쓰는 것이 바로
+    # #924 안티패턴. 영구 커밋 가드는 golden rule 6 이 담당.
+    if command -v jq >/dev/null 2>&1 \
+        && [ -n "$(jq -r '.model // empty' "$_cesc_src" 2>/dev/null)" ]; then
+        ux_warning "  SSOT 에 model 키 오염: $_cesc_src — 복구: git checkout claude/settings.json"
+        _cesc_srctmp=$(mktemp "${TMPDIR:-/tmp}/claude_ssot.XXXXXX" 2>/dev/null) || _cesc_srctmp=
+        if [ -n "$_cesc_srctmp" ] && jq 'del(.model)' "$_cesc_src" > "$_cesc_srctmp" 2>/dev/null; then
+            _cesc_src="$_cesc_srctmp"
+        else
+            [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
+            _cesc_srctmp=
+        fi
+    fi
 
     # dangling settings.local.json 정리가 model 이주보다 먼저 — 깨진 링크를
     # 통해 쓰면 소멸한 worktree 경로로 write 가 향해 실패한다 (#940).
@@ -705,13 +725,16 @@ _claude_ensure_settings_copy() {
 
     if [ -f "$_cesc_tgt" ] && cmp -s "$_cesc_src" "$_cesc_tgt"; then
         ux_info "  ✓ settings.json up to date (real file): $_cesc_tgt"
+        [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
         return 0
     fi
     if ! cp "$_cesc_src" "$_cesc_tgt"; then
         ux_error "  settings.json copy failed: $_cesc_src → $_cesc_tgt"
+        [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
         return 1
     fi
     chmod 600 "$_cesc_tgt"
+    [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
     ux_success "  installed settings.json (real file): $_cesc_tgt"
 }
 

--- a/tests/golden_rules/test_golden_rules.sh
+++ b/tests/golden_rules/test_golden_rules.sh
@@ -140,6 +140,22 @@ else
 fi
 echo ""
 
+# Rule 6: tracked claude/settings.json (SSOT) must not carry a `model` key.
+# Claude Code's /model persists into the active config dir's settings.json.
+# If that file is ever a write-through symlink to this SSOT (e.g. a stale
+# pre-#940 link surviving a deploy-lag window), the personal model choice
+# leaks into the tracked file (#924). #598 removed model from the SSOT;
+# this rule keeps it out so a leak can never be committed.
+# Recovery: git checkout claude/settings.json
+echo "Rule 6: No model key in tracked claude/settings.json SSOT (#924)"
+if [ -f claude/settings.json ] \
+    && grep -qE '^[[:space:]]*"model"[[:space:]]*:' claude/settings.json; then
+    test_case "claude/settings.json has no model key" 1
+else
+    test_case "claude/settings.json has no model key" 0
+fi
+echo ""
+
 echo "════════════════════════════════════════════════════════════"
 if [ "$failed" -eq 0 ]; then
     echo -e "${GREEN}All golden rules validated ✓${NC}"


### PR DESCRIPTION
## Summary
- `claude/settings.json`(추적 SSOT)가 `/model` 의 `"model"` 키로 다시 오염되는 재발을 차단한다. #924 후속 (#940 보강).
- 원인은 두 겹: (1) #940 배포 지연 틈에 살아있던 옛 write-through symlink, (2) cmp-게이트 model 이주가 동일 값 오염을 자가치유하지 못함.

## Changes
- **`_claude_ensure_settings_copy`** (`shell-common/tools/integrations/claude.sh`): 복사 source(SSOT)에 `model` 키가 있으면 `jq 'del(.model)'` 로 sanitize + 경고 → 계정 복사본으로의 오염 전파를 끊고, `! cmp -s SSOT copy` 게이트의 model 이주를 재작동시켜 자가치유를 회복. 추적 SSOT 파일 자체는 건드리지 않음(setup 의 tracked write 가 #924 안티패턴).
- **golden rule 6** (`tests/golden_rules/test_golden_rules.sh`): `claude/settings.json` 에 top-level `model` 키가 있으면 `mise run test` FAIL → 누출이 커밋되는 것 자체를 차단 (#598 이 SSOT 에서 제거한 불변식을 강제).

## Test plan
- [x] golden rules 전체 통과 (Rule 6 포함) — `bash tests/golden_rules/test_golden_rules.sh`
- [x] Rule 6 negative test — 오염된 settings.json 에서 grep 이 model 키를 검출
- [x] `claude/setup.sh` 재실행 — 3개 계정의 잔존 model 키가 각 `settings.local.json` 으로 정상 이주
- [x] shellcheck — 신규 finding 없음 (기존 SC3043 경고만)
- [ ] CI: `claude_accounts.bats #92` 는 본 변경 이전부터 실패하던 fixture 갭(iso 에 `claude/workflows` 부재) — 무관

## Related
Follow-up to #924 (#940 보강) — 추적 SSOT 오염 재발 방지. #924 의 원래 스코프(local override 패턴)는 이미 종료되어 auto-close 하지 않는다.

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
