### PR TITLE
Refactor my-help commands to satisfy command-design-pattern.md

### DIFF
--- a/shell-common/aliases/claude_plugins.sh
+++ b/shell-common/aliases/claude_plugins.sh
@@ -17,10 +17,16 @@ alias init-plugins-docs='init_plugins_docs'
 
 # Sync plugins structure to documentation directory
 alias sync-plugins='sync_plugins_structure'
+alias sync-plugins-structure='sync_plugins_structure'
+
+# Inspect a single plugin
+alias view-plugin-info='view_plugin_info'
 
 # Generate Korean documentation for plugins (both files and directories)
 alias gen-plugin-ko='generate_plugin_doc_ko'
+alias generate-plugin-doc-ko='generate_plugin_doc_ko'
 alias create-plugin-ko='create_plugin_structure_ko'
+alias create-plugin-structure-ko='create_plugin_structure_ko'
 
 # Process plugin directory recursively
 alias process-plugin-ko='process_plugin_directory_ko'

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -79,10 +79,14 @@ gbr_help() {
 gbr() {
     case "${1:-}" in
         teardown) shift; git_branch_teardown "$@" ;;
-        -h|--help|help|"")
-            ux_error "Usage: gbr <command> [args...]"
-            ux_info "Run: gbr-help"
+        help)
+            ux_error "Use canonical entrypoint: gbr-help (not 'gbr help')"
+            ux_info "Try: gbr-help"
             return 1
+            ;;
+        -h|--help|"")
+            [ $# -gt 0 ] && shift
+            gbr_help "$@"
             ;;
         *)
             ux_error "Unknown command: $1"

--- a/shell-common/functions/git_ssh_check.sh
+++ b/shell-common/functions/git_ssh_check.sh
@@ -15,9 +15,9 @@ git_ssh_check() {
 
     # 1. Check SSH key
     if [ -f "${HOME}/.ssh/id_ed25519" ]; then
-        ux_success "✓ SSH Key found: ${HOME}/.ssh/id_ed25519"
+        ux_success "SSH Key found: ${HOME}/.ssh/id_ed25519"
     else
-        ux_error "✗ SSH Key not found: ${HOME}/.ssh/id_ed25519"
+        ux_error "SSH Key not found: ${HOME}/.ssh/id_ed25519"
         ux_info "Generate SSH key: ssh-keygen -t ed25519 -C '$(hostname)'"
         return 1
     fi
@@ -25,9 +25,9 @@ git_ssh_check() {
 
     # 2. Check SSH agent
     if [ -n "$SSH_AUTH_SOCK" ]; then
-        ux_success "✓ SSH Agent running (PID: ${SSH_AGENT_PID:-unknown})"
+        ux_success "SSH Agent running (PID: ${SSH_AGENT_PID:-unknown})"
     else
-        ux_warning "⚠ SSH Agent not running"
+        ux_warning "SSH Agent not running"
         ux_info "Start SSH Agent: eval \"\$(ssh-agent -s)\""
         return 1
     fi
@@ -35,9 +35,9 @@ git_ssh_check() {
 
     # 3. Check key in agent
     if ssh-add -l 2>/dev/null | grep -q "id_ed25519"; then
-        ux_success "✓ SSH Key registered in agent"
+        ux_success "SSH Key registered in agent"
     else
-        ux_warning "⚠ SSH Key not registered in agent"
+        ux_warning "SSH Key not registered in agent"
         ux_info "Register key: ssh-add ${HOME}/.ssh/id_ed25519"
         return 1
     fi
@@ -46,19 +46,19 @@ git_ssh_check() {
     # 4. Test GitHub SSH connection
     ux_info "Testing GitHub SSH connection..."
     if ssh -T git@github.samsungds.net >/dev/null 2>&1; then
-        ux_success "✓ GitHub SSH connection successful"
+        ux_success "GitHub SSH connection successful"
         echo ""
     else
-        ux_error "✗ GitHub SSH connection failed"
+        ux_error "GitHub SSH connection failed"
         ux_info ""
         ux_info "Troubleshooting steps:"
         ux_bullet "1. Verify public key is registered in GitHub:"
-        ux_bullet "   - Go to: https://github.samsungds.net/settings/keys"
-        ux_bullet "   - Your public key: $(cat ${HOME}/.ssh/id_ed25519.pub)"
+        ux_bullet_sub "Go to: https://github.samsungds.net/settings/keys"
+        ux_bullet_sub "Your public key: $(cat "${HOME}/.ssh/id_ed25519.pub")"
         ux_bullet "2. Check SSH config:"
-        ux_bullet "   - cat ~/.ssh/config"
+        ux_bullet_sub "cat ~/.ssh/config"
         ux_bullet "3. Test SSH manually:"
-        ux_bullet "   - ssh -vvv git@github.samsungds.net"
+        ux_bullet_sub "ssh -vvv git@github.samsungds.net"
         ux_bullet "4. SSH Setup Guide: git/doc/SSH_SETUP_GUIDE.md"
         echo ""
         return 1

--- a/shell-common/functions/marketplace.sh
+++ b/shell-common/functions/marketplace.sh
@@ -183,11 +183,12 @@ _ensure_manifest_fresh() {
 }
 
 # =============================================================================
-# User-Facing Functions (snake_case, suffixed with _marketplace)
+# Private sub-commands (reached via the `claude_skills_marketplace` dispatcher /
+# `csm <verb>`; not user-facing entry points — see command-design-pattern.md R1)
 # =============================================================================
 
 # List all marketplace skills grouped by plugin (default) or all skills by marketplace (--all)
-claude_skills_marketplace_list() {
+_claude_skills_marketplace_list() {
     local show_all=false
     local marketplace_filter=""
 
@@ -268,12 +269,12 @@ claude_skills_marketplace_list() {
         fi
     else
         # Default: show plugin groups (headers only)
-        claude_skills_marketplace_group
+        _claude_skills_marketplace_group
     fi
 }
 
 # Group skills by category/plugin (show headers only, or detailed list if filter provided)
-claude_skills_marketplace_group() {
+_claude_skills_marketplace_group() {
     local category_filter="${1:-}"
 
     _ensure_manifest_fresh || {
@@ -372,7 +373,7 @@ claude_skills_marketplace_group() {
 }
 
 # Show marketplace statistics
-claude_skills_marketplace_stats() {
+_claude_skills_marketplace_stats() {
     _ensure_manifest_fresh || {
         ux_error "Failed to generate marketplace manifest"
         return 1
@@ -405,7 +406,7 @@ claude_skills_marketplace_stats() {
 }
 
 # Search marketplace skills
-claude_skills_marketplace_search() {
+_claude_skills_marketplace_search() {
     local query="$1"
 
     [ -z "$query" ] && {
@@ -453,7 +454,7 @@ claude_skills_marketplace_search() {
 }
 
 # Display detailed skill information
-claude_skills_marketplace_info() {
+_claude_skills_marketplace_info() {
     local skill_name="$1"
 
     [ -z "$skill_name" ] && {
@@ -497,7 +498,7 @@ claude_skills_marketplace_info() {
 }
 
 # Force rebuild of manifest cache
-claude_skills_marketplace_refresh() {
+_claude_skills_marketplace_refresh() {
     ux_section "Rebuilding Skill Manifest"
 
     rm -f "$MANIFEST_CACHE_PATH"
@@ -633,29 +634,29 @@ claude_skills_marketplace() {
 
     case "$command" in
         list)
-            claude_skills_marketplace_list "$@"
+            _claude_skills_marketplace_list "$@"
             ;;
         group)
-            claude_skills_marketplace_group "$@"
+            _claude_skills_marketplace_group "$@"
             ;;
         stats)
-            claude_skills_marketplace_stats "$@"
+            _claude_skills_marketplace_stats "$@"
             ;;
         search)
-            claude_skills_marketplace_search "$@"
+            _claude_skills_marketplace_search "$@"
             ;;
         info)
-            claude_skills_marketplace_info "$@"
+            _claude_skills_marketplace_info "$@"
             ;;
         refresh)
-            claude_skills_marketplace_refresh "$@"
+            _claude_skills_marketplace_refresh "$@"
             ;;
         help)
             claude_skills_marketplace_help "$@"
             ;;
         *)
             ux_error "Unknown command: $command"
-            ux_info "Try: claude-skills-marketplace help"
+            ux_info "Run: claude-skills-marketplace help"
             return 1
             ;;
     esac
@@ -665,3 +666,5 @@ claude_skills_marketplace() {
 # This is safe as a function alias (no naming conflicts with my_help.sh pattern)
 alias claude-skills-marketplace='claude_skills_marketplace'
 alias claude-skills-marketplace-help='claude_skills_marketplace_help'
+# Short alias documented throughout the help/output (csm list, csm search, ...)
+alias csm='claude_skills_marketplace'

--- a/shell-common/functions/mount.sh
+++ b/shell-common/functions/mount.sh
@@ -340,8 +340,8 @@ HELP
 mount_show() {
     local mount_path="${1}"
 
-    # Show help if requested with -h or --help
-    if [ "$mount_path" = "-h" ] || [ "$mount_path" = "--help" ]; then
+    # Show help if requested with -h, --help, or help
+    if [ "$mount_path" = "-h" ] || [ "$mount_path" = "--help" ] || [ "$mount_path" = "help" ]; then
         _mount_show_help
         return 0
     fi

--- a/shell-common/functions/my_man.sh
+++ b/shell-common/functions/my_man.sh
@@ -34,14 +34,17 @@ myman() {
 
     local type_to_show="${1:-}"
 
+    # R3: reject unknown verbs up-front, before any side effect (mktemp).
     case "$type_to_show" in
         -h|--help|help) _myman_help; return 0 ;;
+        "") _myman_help; return 1 ;;
+        alias|function) ;;
+        *)
+            ux_error "Unknown command: $type_to_show"
+            ux_info "Run: my-man help"
+            return 1
+            ;;
     esac
-
-    if [[ -z "$type_to_show" ]]; then
-        _myman_help
-        return 1
-    fi
 
     local analyzer_script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/analyze_bash_scripts.sh"
     local sh_config_dir="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"

--- a/shell-common/functions/mytool.sh
+++ b/shell-common/functions/mytool.sh
@@ -10,7 +10,7 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 get_hw_info() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/get_hw_info.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: Hardware info script not found: $script" >&2
+        ux_error "Hardware info script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -20,7 +20,7 @@ get_hw_info() {
 srcpack() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/srcpack.py"
     if [ ! -f "$script" ]; then
-        echo "not found: $script" >&2
+        ux_error "srcpack script not found: $script"
         return 2
     fi
     python "$script" "$@"
@@ -30,7 +30,7 @@ srcpack() {
 agents_init() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/run_agents_md_master_prompt.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: AGENTS.md generation script not found: $script" >&2
+        ux_error "AGENTS.md generation script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -40,7 +40,7 @@ agents_init() {
 install_p10k() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_p10k.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-p10k script not found: $script" >&2
+        ux_error "install-p10k script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -50,7 +50,7 @@ install_p10k() {
 install_fzf() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_fzf.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-fzf script not found: $script" >&2
+        ux_error "install-fzf script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -60,7 +60,7 @@ install_fzf() {
 install_fasd() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_fasd.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-fasd script not found: $script" >&2
+        ux_error "install-fasd script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -70,7 +70,7 @@ install_fasd() {
 install_ripgrep() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_ripgrep.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-ripgrep script not found: $script" >&2
+        ux_error "install-ripgrep script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -80,7 +80,7 @@ install_ripgrep() {
 install_fd() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_fd.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-fd script not found: $script" >&2
+        ux_error "install-fd script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -90,7 +90,7 @@ install_fd() {
 install_bat() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_bat.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-bat script not found: $script" >&2
+        ux_error "install-bat script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -100,7 +100,7 @@ install_bat() {
 install_pet() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_pet.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-pet script not found: $script" >&2
+        ux_error "install-pet script not found: $script"
         return 2
     fi
     bash "$script" "$@"
@@ -110,10 +110,21 @@ install_pet() {
 install_zsh_autosuggestions() {
     local script="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/install_zsh_autosuggestions.sh"
     if [ ! -f "$script" ]; then
-        echo "Error: install-zsh-autosuggestions script not found: $script" >&2
+        ux_error "install-zsh-autosuggestions script not found: $script"
         return 2
     fi
     bash "$script" "$@"
 }
 
+# Dash-form aliases (command-design-pattern.md R1: user-facing = dash-form).
+# `srcpack` has no underscore, so it is already the dash-form entry point.
+alias get-hw-info='get_hw_info'
+alias agents-init='agents_init'
+alias install-p10k='install_p10k'
+alias install-fzf='install_fzf'
+alias install-fasd='install_fasd'
+alias install-ripgrep='install_ripgrep'
+alias install-fd='install_fd'
+alias install-bat='install_bat'
+alias install-pet='install_pet'
 alias install-zsh-autosuggestions='install_zsh_autosuggestions'

--- a/shell-common/functions/ollama_launcher.sh
+++ b/shell-common/functions/ollama_launcher.sh
@@ -7,9 +7,17 @@
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 ollama_serve() {
-    local backend=$(ollama_backend_detect 2>/dev/null || echo "")
-    
-    if [[ -z "$backend" ]] || [[ "$backend" == "unavailable" ]]; then
+    case "${1:-}" in
+        -h|--help|help)
+            ux_usage "ollama-serve" "" "Start the WSL Ollama API server (127.0.0.1:11434)"
+            return 0
+            ;;
+    esac
+
+    local backend
+    backend=$(ollama_backend_detect 2>/dev/null || echo "")
+
+    if [ -z "$backend" ] || [ "$backend" = "unavailable" ]; then
         ux_error "No Ollama backend available"
         ux_info "Install WSL Ollama: install-ollama"
         ux_info "Or ensure Docker Ollama is running"
@@ -35,10 +43,18 @@ ollama_serve() {
 
 # Launch Claude Code or other tools with Ollama
 ollama_launch() {
+    case "${1:-}" in
+        -h|--help|help)
+            ux_usage "ollama-launch" "[tool]" "Launch a tool (default: claude) wired to Ollama"
+            return 0
+            ;;
+    esac
+
     local tool="${1:-claude}"
-    
-    local backend=$(ollama_backend_detect 2>/dev/null || echo "")
-    if [[ -z "$backend" ]] || [[ "$backend" == "unavailable" ]]; then
+
+    local backend
+    backend=$(ollama_backend_detect 2>/dev/null || echo "")
+    if [ -z "$backend" ] || [ "$backend" = "unavailable" ]; then
         ux_error "Ollama is not available"
         ux_info "Make sure Ollama server is running first:"
         ux_info "  ollama-serve &"

--- a/shell-common/functions/skill_loader.sh
+++ b/shell-common/functions/skill_loader.sh
@@ -5,9 +5,12 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-_skill_loader() {
-    # Load UX library (unified library at shell-common/tools/ux_lib/)
-    source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+skill_loader() {
+    # Load UX library (unified library at shell-common/tools/ux_lib/) only if
+    # it is not already available — avoid re-sourcing on every invocation.
+    if ! type ux_header >/dev/null 2>&1; then
+        source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+    fi
 
     # Get skills directory
     local skills_dir="${CLAUDE_SKILLS_PATH:-${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills}"
@@ -51,9 +54,9 @@ _skill_loader() {
         return 0
     fi
 
-    # Handle --help flag
-    if [ "$1" = "--help" ]; then
-        _skill_loader  # Call with no args to show help
+    # Handle help flags
+    if [ "$1" = "--help" ] || [ "$1" = "-h" ] || [ "$1" = "help" ]; then
+        skill_loader  # Call with no args to show help
         return 0
     fi
 
@@ -109,4 +112,4 @@ _skill_loader() {
 }
 
 # Alias for skill-loader format (using dash instead of underscore)
-alias skill-loader='_skill_loader'
+alias skill-loader='skill_loader'

--- a/shell-common/functions/ta.sh
+++ b/shell-common/functions/ta.sh
@@ -11,6 +11,13 @@
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 ta() {
+    case "${1:-}" in
+        -h|--help|help)
+            ux_usage "ta" "" "Attach (or switch) to the first tmux session"
+            return 0
+            ;;
+    esac
+
     ux_require "tmux" || return 1
 
     local _ta_session

--- a/shell-common/functions/zsh_autosuggestions.sh
+++ b/shell-common/functions/zsh_autosuggestions.sh
@@ -10,7 +10,7 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-if ! type ux_header &>/dev/null 2>&1; then
+if ! type ux_header >/dev/null 2>&1; then
     SHELL_COMMON="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"
     # shellcheck source=/dev/null
     source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Audit every `my-help` command function against `docs/.ssot/command-design-pattern.md` and fix only the genuine deviations (R1 naming, R3 dispatcher help-entry / unknown-verb guard, R7 DIP+POSIX), leaving already-compliant code untouched per the doc's OCP rule.
- Fixes two real user-facing bugs along the way: dash-form commands that the help text advertised but were never actually defined (`csm`, `view-plugin-info`, `sync-plugins-structure`, `generate-plugin-doc-ko`, `create-plugin-structure-ko`).

## Changes
- **gbr / my-man / ta / git-ssh-check**: `gbr`'s canonical `-h`/`""` now routes to `gbr_help` instead of hard-erroring (mirrors the `gwt` Type 2A gold standard, R3); `my-man` rejects unknown verbs up-front before the `mktemp` side effect (R3); `ta` gains a `-h|--help|help` entry; `git-ssh-check` drops the duplicate ✓/✗/⚠ glyphs (the `ux_*` helpers already render the icon) and uses `ux_bullet_sub` (R7).
- **marketplace**: privatize the 6 dispatcher sub-commands (`list`/`group`/`stats`/`search`/`info`/`refresh`) so only the dispatcher is user-facing (R1); add the missing `csm` alias referenced ~10× in the help/output; `Try:` → `Run:`.
- **mytool**: add 9 dash-form aliases the file's own `install-zsh-autosuggestions` already established the pattern for (R1); guard `echo "Error" >&2` → `ux_error` (R7).
- **ollama_launcher / skill_loader / mount / zsh_autosuggestions**: replace bash-only `[[ ]]` with POSIX `[ ]` + add `-h` guards; rename private `_skill_loader` → public `skill_loader` so the `skill-loader` alias targets a public function (R1); `mount_show` honors the bare `help` keyword; fix a malformed `&>/dev/null 2>&1` redirect.
- **claude-plugins**: add the 4 canonical dash aliases the `claude_plugins_help` advertised but the aliases file never defined; keep the 4 functions as independent Type 1 commands (section-2 decision tree, like the `zsh_*` family) rather than forcing a dispatcher.

## Test plan
- [x] pytest: **11 failed / 1137 passed** — identical to the pre-existing baseline (all 11 in `test_skill_completion_guard.py`, the unrelated #608 cluster); zero new failures.
- [x] bats: **15 not-ok / 1280 ok** — proven **byte-for-byte identical at the base commit** under the same command (env-only `claude/setup.sh` / worktree-teardown / codex-budget failures in subsystems this PR never touches); zero regressions.
- [x] golden rules green after every batch; shellcheck clean (only pre-existing POSIX-dialect noise in untouched code).
- [x] every changed function exercised in both bash and zsh (help paths, alias resolution, dispatcher routing).

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
