### PR TITLE
fix(gb): gb -D remote가 origin 서버 브랜치를 실제 삭제하도록 수정

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -79,26 +79,41 @@ _gb_clean_remote() {
     # Sync tracking refs with the server so the deletion list is accurate
     git fetch --prune "$remote" >/dev/null 2>&1 || true
 
-    # Deletable branches: remote-tracking refs minus the HEAD pointer and main/master.
-    # Emit short names (no "<remote>/" prefix) — that is what `git push --delete` wants.
-    # NOTE: `grep -v -- '->'` (the `--` terminator) is required; a bare `'-> '`
-    #       pattern starts with '-' and grep parses it as an option (#bug).
-    local branches
-    branches=$(git branch -r \
-        | sed 's/^[[:space:]]*//' \
-        | grep "^$remote/" \
-        | grep -v -- '->' \
-        | grep -v "^$remote/main$" \
-        | grep -v "^$remote/master$" \
-        | sed "s#^$remote/##")
+    # Build the deletable-branch list with a pure-shell loop: no per-line
+    # subprocess forks, and `case "$ref" in "$remote"/*)` matches the remote
+    # name *literally* — a remote whose name contains a regex metachar (e.g.
+    # '.') would mis-match under `grep "^$remote/"`. Emit short names (no
+    # "<remote>/" prefix) — that is what `git push --delete` wants. Branch
+    # names carry no whitespace, so `read`'s IFS-trimming of the "  origin/foo"
+    # indentation is safe, and the HEAD pointer line is skipped via " -> ".
+    local branches="" branch_count=0 ref b
+    while read -r ref; do
+        [ -n "$ref" ] || continue
+        case "$ref" in
+            *" -> "*) continue ;;
+        esac
+        case "$ref" in
+            "$remote"/*)
+                b="${ref#"$remote"/}"
+                [ "$b" = "main" ] && continue
+                [ "$b" = "master" ] && continue
+                branch_count=$((branch_count + 1))
+                if [ -z "$branches" ]; then
+                    branches="$b"
+                else
+                    branches="${branches}
+${b}"
+                fi
+                ;;
+        esac
+    done <<EOF
+$(git branch -r)
+EOF
 
-    if [ -z "$branches" ]; then
+    if [ "$branch_count" -eq 0 ]; then
         ux_info "No branches to delete on '$remote' (keeping main/master)"
         return 0
     fi
-
-    local branch_count
-    branch_count=$(printf '%s\n' "$branches" | grep -c .)
 
     ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote':"
     while IFS= read -r branch; do

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -51,36 +51,99 @@ git_log_upstream() {
 # Usage: gb [-D local] [-D remote [<remote>]] [git-branch-flags...]
 # ============================================================================
 _gb_clean_remote() {
-    local remote="${1:-origin}"
+    # zsh compatibility: emulate POSIX sh to ensure word splitting on unquoted vars
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
 
-    # Capture branch list once, reuse for count and iteration
+    local assume_yes=0 remote=""
+
+    # Parse optional flags and an optional remote name (order-independent)
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -y | --yes) assume_yes=1 ;;
+            -h | --help) _gb_help; return 0 ;;
+            -*) ux_error "Unknown option: $1"; return 1 ;;
+            *) remote="$1" ;;
+        esac
+        shift
+    done
+    remote="${remote:-origin}"
+
+    # Fail fast if the remote is unknown
+    if ! git remote get-url "$remote" >/dev/null 2>&1; then
+        ux_error "Remote '$remote' not found"
+        return 1
+    fi
+
+    # Sync tracking refs with the server so the deletion list is accurate
+    git fetch --prune "$remote" >/dev/null 2>&1 || true
+
+    # Deletable branches: remote-tracking refs minus the HEAD pointer and main/master.
+    # Emit short names (no "<remote>/" prefix) — that is what `git push --delete` wants.
+    # NOTE: `grep -v -- '->'` (the `--` terminator) is required; a bare `'-> '`
+    #       pattern starts with '-' and grep parses it as an option (#bug).
     local branches
-    branches=$(git branch -r | grep "^[[:space:]]*$remote/" | grep -v "^[[:space:]]*$remote/main" | grep -v "^[[:space:]]*$remote/master" | grep -v "-> " | sed 's/^[[:space:]]*//')
+    branches=$(git branch -r \
+        | sed 's/^[[:space:]]*//' \
+        | grep "^$remote/" \
+        | grep -v -- '->' \
+        | grep -v "^$remote/main$" \
+        | grep -v "^$remote/master$" \
+        | sed "s#^$remote/##")
 
-    local branch_count
-    branch_count=$(printf '%s\n' "$branches" | grep -c . 2>/dev/null || echo 0)
-
-    if [ "$branch_count" -eq 0 ]; then
-        ux_info "No branches to delete (keeping $remote/main)"
+    if [ -z "$branches" ]; then
+        ux_info "No branches to delete on '$remote' (keeping main/master)"
         return 0
     fi
 
-    ux_header "Deleting $branch_count branch(es) from '$remote':"
-    printf '%s\n' "$branches" | while IFS= read -r branch; do
-        [ -n "$branch" ] || continue
-        ux_info "Deleting: $branch"
-        git branch -dr "$branch" >/dev/null 2>&1
-    done
+    local branch_count
+    branch_count=$(printf '%s\n' "$branches" | grep -c .)
 
-    ux_success "Done!"
+    ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote':"
+    while IFS= read -r branch; do
+        [ -n "$branch" ] && ux_bullet_sub "$remote/$branch"
+    done <<EOF
+$branches
+EOF
+
+    if [ "$assume_yes" -ne 1 ]; then
+        if ! ux_confirm "Permanently delete these remote branches?"; then
+            ux_info "Aborted. No branches deleted."
+            return 0
+        fi
+    fi
+
+    ux_header "Deleting $branch_count branch(es) from '$remote':"
+    local deleted=0 failed=0
+    while IFS= read -r branch; do
+        [ -n "$branch" ] || continue
+        if git push "$remote" --delete "$branch" >/dev/null 2>&1; then
+            ux_info "Deleted: $remote/$branch"
+            deleted=$((deleted + 1))
+        else
+            ux_error "Failed: $remote/$branch"
+            failed=$((failed + 1))
+        fi
+    done <<EOF
+$branches
+EOF
+
+    if [ "$failed" -gt 0 ]; then
+        ux_warning "Done with errors. Deleted $deleted, failed $failed."
+        return 1
+    fi
+    ux_success "Done! Deleted $deleted branch(es) from '$remote'."
 }
 
 _gb_help() {
-    ux_info "Usage: gb [-D local] [-D remote [<remote>]] [git-branch-flags...]"
+    ux_info "Usage: gb [-D local] [-D remote [-y] [<remote>]] [git-branch-flags...]"
     ux_bullet "sub-commands"
-    ux_bullet_sub "gb -D local               delete local branches (keeps: main + current + keywords)"
-    ux_bullet_sub "gb -D remote [<remote>]   delete remote-tracking branches (default: origin, keeps: main/master)"
-    ux_bullet_sub "gb [flags]                passthrough to git --no-pager branch"
+    ux_bullet_sub "gb -D local                  delete local branches (keeps: main + current + keywords)"
+    ux_bullet_sub "gb -D remote [-y] [<remote>] delete branches on the remote SERVER (default: origin, keeps: main/master)"
+    ux_bullet_sub "gb [flags]                   passthrough to git --no-pager branch"
+    ux_bullet "options"
+    ux_bullet_sub "-y, --yes                 skip the confirmation prompt (remote deletion is permanent)"
 }
 
 git_branch() {

--- a/tests/bats/functions/git.bats
+++ b/tests/bats/functions/git.bats
@@ -56,6 +56,47 @@ teardown() {
     assert_output --partial "git-log"
 }
 
+# --- gb -D remote behavior (server-side deletion against a local bare remote) ---
+
+@test "bash: gb -D remote deletes non-main branches on the remote server" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:docs/some-spec
+        git push -q origin HEAD:wt/issue-318/1
+        _gb_clean_remote -y origin >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "REMAINING: main"
+    refute_output --partial "docs/some-spec"
+    refute_output --partial "wt/issue-318/1"
+}
+
+@test "bash: gb -D remote keeps main and reports nothing to delete when only main exists" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        _gb_clean_remote -y origin
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "No branches to delete"
+}
+
 # --- git worktree functions ---
 
 @test "bash: gwt function exists" {


### PR DESCRIPTION
## Summary
- `gb -D remote` 가 삭제 대상을 0개로 오인하고 아무 브랜치도 지우지 못하던 문제를 수정합니다.
- 동작을 "로컬 추적 ref 삭제"에서 "origin 서버 브랜치 실제 삭제"로 변경하고, 영구 삭제에 대한 확인 게이트를 추가합니다.
- `gb -D remote` ≡ `gb -D remote origin` (remote 기본값 origin).

## Changes
- `shell-common/functions/git.sh` — `_gb_clean_remote`:
  - **버그1**: `grep -v "-> "` 의 패턴이 `-` 로 시작해 grep 이 옵션으로 해석(`invalid option -- '>'`) → grep 중단으로 목록이 빈 값. `grep -v -- '->'` 로 옵션 종료자 사용.
  - **버그2**: `grep -c` 가 0건 매치 시 `0` 출력 + 종료코드 1 → `|| echo 0` 이 또 실행되어 카운트가 `0\n0` 가 되고 `[ -eq 0 ]` 가 깨짐. 빈값 선검사 + 깔끔한 `grep -c .` 로 교체.
  - **동작**: `git branch -dr` → `git push <remote> --delete` (서버 브랜치 실제 삭제, main/master 보존).
  - **안전장치**: 삭제 전 `ux_confirm` 확인, 비대화식용 `-y`/`--yes`. `-y`/`<remote>` 순서 무관 파싱(기존엔 `-y` 를 remote 로 오인).
  - 산출 전 `git fetch --prune` 동기화, per-branch 성공/실패 집계. `_gb_help` 갱신.
- `tests/bats/functions/git.bats` — bare repo 를 remote 로 쓰는 행위 테스트 2건 추가.

## Test plan
- [x] 신규 bats 2건: 옛 코드에선 사용자 버그 그대로 실패(`grep invalid option`, `Deleting 0\n0`, 브랜치 잔존), 새 코드에선 통과
- [x] `git.bats` 전체 19건 통과
- [x] `bash -n` / `zsh -n` 구문 검사 통과
- [x] 실제 bare remote 대상 end-to-end 데모: 2개 브랜치 삭제, `main` 보존 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
