### PR TITLE
feat(skills): add devx:mise-migrate — legacy Python venv → mise + uv

### DIFF
--- a/claude/skills/devx-mise-migrate/SKILL.md
+++ b/claude/skills/devx-mise-migrate/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: devx:mise-migrate
+description: >-
+  Convert a legacy Python project (pyenv / `python -m venv` + pip,
+  setuptools, `.venv/bin/activate` workflow) into the dotfiles canonical
+  mise structure: a `mise.toml` carrying `[tools]` + `[env]` + `[tasks.*]`
+  as the command SSOT, with uv owning the venv and dependencies and
+  hatchling as the build backend. Use when the user runs
+  /devx:mise-migrate, /devx-mise-migrate, or asks "이 프로젝트 mise 구조로
+  바꿔줘", "예전 파이썬 가상환경을 mise+uv 로 마이그레이션", "venv 프로젝트를
+  mise 로 전환", "migrate this venv project to mise", "adopt mise here".
+  Default mode is `--dry-run` — prints the migration plan (the full
+  generated `mise.toml`, a `pyproject.toml` diff, and the cleanup list)
+  and mutates nothing; `--apply` writes the files, runs `uv sync`, and
+  removes the stale `.venv/` + `*.egg-info/`. Python-venv projects only —
+  refuses non-Python or already-migrated directories. Accepts
+  `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, Edit, Write, Grep
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "Config transformation + dependency/backend mapping; structured, low-ambiguity reasoning"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# devx:mise-migrate — legacy Python venv → mise + uv
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. **No detection, no file
+mutation.**
+
+## Step 1: Parse Args + Detect a Legacy Python Project
+
+Positional `[path]` defaults to `.`. Flags: `--dry-run` (default),
+`--apply`, `--backend hatchling|uv_build` (default `hatchling`),
+`--keep-venv` (skip cleanup). Full table in `references/help.md`.
+
+Detect a legacy Python project, else refuse early (exit 1):
+
+- No `pyproject.toml` / `setup.py` / `requirements*.txt` →
+  `[FAIL] devx:mise-migrate: not a Python project: <path>`.
+- A `mise.toml` already exists → `[INFO] devx:mise-migrate: already
+  migrated` (exit 0, idempotent).
+
+A pyenv `.venv/` / `pyvenv.cfg` is the signal worth migrating, but its
+absence is not fatal — a pip/requirements project still qualifies.
+
+## Step 2: Extract Migration Facts (read-only)
+
+Gather, via `Read` + `Grep`, the inputs in `references/extraction.md`:
+Python version, runtime + dev deps, `[project.scripts]` entry points,
+test runner + `testpaths`, build backend, and which linters (ruff /
+mypy) are configured — lint/fix tasks are generated only for tools
+actually present (Step 3).
+
+## Step 3: Build the Migration Plan
+
+Assemble three artifacts per `references/mise-template.md` and
+`references/pyproject-rewrite.md` (`references/example-karakeep.md` is a
+full before→after walkthrough):
+
+1. **`mise.toml`** — `[tools]` (python + uv, + ruff/mypy if detected),
+   `[env]`, `[tasks.lint|test|fix|run]` wrapping `uv run`. Mapping +
+   linter-conditional rules: `references/mise-template.md`.
+2. **`pyproject.toml` diff** — backend → `--backend`, explicit-packages
+   carried over, `optional-dependencies.dev` → `[dependency-groups].dev`.
+3. **Cleanup list** — stale `.venv/` + `*.egg-info/` (skipped by
+   `--keep-venv`).
+
+In `--dry-run` (default), **print all three and stop**:
+
+```
+Plan ready: <path> (backend=<backend>, py=<ver>, tasks=<n>)
+Run with --apply to write mise.toml, rewrite pyproject, and uv sync.
+```
+
+## Step 4: Apply (only if `--apply`)
+
+In order, stopping on first failure with `[FAIL] devx:mise-migrate
+<reason>` + exit 1 (no automatic rollback — report partial state):
+
+1. Write `mise.toml`.
+2. Rewrite `pyproject.toml` in place (backend, packages, dep-groups).
+3. Run `uv sync` to materialize the uv-managed venv + lockfile.
+4. Cleanup — remove `.venv/` + `*.egg-info/` unless `--keep-venv`;
+   never delete outside `<path>`. Guardrails: `references/constraints.md`.
+
+## Step 5: Report
+
+```
+[OK] devx:mise-migrate path=<path> backend=<backend> py=<ver> tasks=<n>
+```
+
+On `--apply` append `synced=yes cleaned=<.venv,egg-info|kept>`. On
+dry-run append `Next: review the plan, then re-run with --apply`. After
+a successful apply, hint `Next: mise run test`.

--- a/claude/skills/devx-mise-migrate/references/constraints.md
+++ b/claude/skills/devx-mise-migrate/references/constraints.md
@@ -1,0 +1,39 @@
+# Operational constraints
+
+## Safety
+
+- **Dry-run is the default.** Nothing is written, rewritten, deleted, or
+  `uv sync`-ed without an explicit `--apply`.
+- **Path-scoped.** All writes and deletes stay within the target
+  `<path>`. Never `rm` above it; never follow a `.venv` symlink outside
+  the tree.
+- **Cleanup is guarded.** `.venv/` and `*.egg-info/` are removed only on
+  `--apply` and only after `mise.toml` + `pyproject.toml` are written and
+  `uv sync` succeeds. `--keep-venv` skips this entirely. The exact paths
+  to be removed are listed in the dry-run plan first.
+- **No source edits.** Only `mise.toml` (new) and the build/dependency
+  stanzas of `pyproject.toml` change. Application code and imports are
+  never touched.
+
+## Idempotency
+
+- A target that already has a `mise.toml` is a no-op (`[INFO] already
+  migrated`). Safe to re-run.
+- Re-running dry-run on the same project yields the same plan.
+
+## Failure handling
+
+- Mid-`--apply` failure stops at the first error with `[FAIL]
+  devx:mise-migrate <reason>` + exit 1 and reports what was written so
+  far. **No automatic rollback** — the user owns cleanup. Ordering
+  (write configs → `uv sync` → delete venv last) means a failure never
+  destroys the old venv before the new one is proven.
+
+## Out of scope (refuse / skip, don't improvise)
+
+- Non-Python projects, and node/go/multi-language repos — Python-venv
+  scope only.
+- Monorepos with multiple `pyproject.toml` files — operate on the single
+  `<path>` given; do not recurse.
+- Publishing, lockfile pinning beyond what `uv sync` produces, or CI
+  config — those are follow-up work, not this skill's job.

--- a/claude/skills/devx-mise-migrate/references/example-karakeep.md
+++ b/claude/skills/devx-mise-migrate/references/example-karakeep.md
@@ -1,0 +1,85 @@
+# Worked example — karakeep/sync (before → after)
+
+A real legacy project: `~/para/project/karakeep/sync`. Has a PEP 621
+`pyproject.toml` but a pyenv-built `.venv` (pip-installed), setuptools
+backend, `*.egg-info/`, and the `.venv/bin/activate` workflow.
+
+## Extracted facts
+
+| Fact | Value | Source |
+|---|---|---|
+| Python | `3.13` | `.venv/pyvenv.cfg` → `version = 3.13.5` |
+| Runtime deps | click, httpx, pyyaml | `[project] dependencies` |
+| Dev deps | pytest, pytest-httpx | `[project.optional-dependencies] dev` |
+| Entry point | `karakeep-sync = karakeep_sync.cli:cli` | `[project.scripts]` |
+| Test runner | pytest, `testpaths = ["tests"]` | `[tool.pytest.ini_options]` |
+| Backend | `setuptools.build_meta`, `packages = ["karakeep_sync"]` | `[build-system]`, `[tool.setuptools]` |
+| Linters | none detected | no `[tool.ruff]`/`[tool.mypy]`, none in dev-deps |
+
+## Generated `mise.toml`
+
+No linter detected → **no `lint`/`fix` tasks** (logged). `test` + `run`
+emitted.
+
+```toml
+# mise.toml — Tool versions + task SSOT (migrated by devx:mise-migrate)
+#
+# Daily use:
+#   mise run test   # pytest
+#   mise run run    # karakeep-sync
+
+[tools]
+python = "3.13"
+uv     = "0.10.12"
+
+[tasks.test]
+description = "전체 테스트"
+run = "uv run pytest"
+
+[tasks.run]
+description = "Run the project entry point"
+run = "uv run karakeep-sync"
+```
+
+Plan note: `[INFO] no linter detected — lint/fix tasks omitted (add ruff
+to [dependency-groups].dev to enable)`.
+
+## `pyproject.toml` diff
+
+```diff
+ [build-system]
+-requires = ["setuptools>=68"]
+-build-backend = "setuptools.build_meta"
++requires = ["hatchling"]
++build-backend = "hatchling.build"
+
+-[tool.setuptools]
+-packages = ["karakeep_sync"]
++[tool.hatch.build.targets.wheel]
++packages = ["karakeep_sync"]
+
+-[project.optional-dependencies]
++[dependency-groups]
+ dev = [
+     "pytest>=8.0",
+     "pytest-httpx>=0.30",
+ ]
+```
+
+`[project]` metadata, runtime `dependencies`, `[project.scripts]`, and
+`[tool.pytest.ini_options]` are untouched.
+
+## Cleanup list (`--apply`, no `--keep-venv`)
+
+```
+remove: .venv/
+remove: karakeep_sync.egg-info/
+```
+
+## Verdict
+
+```
+[OK] devx:mise-migrate path=~/para/project/karakeep/sync backend=hatchling py=3.13 tasks=2
+     synced=yes cleaned=.venv,egg-info
+Next: mise run test
+```

--- a/claude/skills/devx-mise-migrate/references/extraction.md
+++ b/claude/skills/devx-mise-migrate/references/extraction.md
@@ -1,0 +1,61 @@
+# Extraction — what to read from the legacy project
+
+All read-only. Gather these facts before building the plan (Step 3).
+
+## Python version
+
+Priority order:
+
+1. `.venv/pyvenv.cfg` → `version = X.Y.Z` (the version the project was
+   actually built against — most authoritative).
+2. `pyproject.toml` → `[project] requires-python` (e.g. `>=3.11` → pin
+   the lowest satisfying stable, or echo the floor and let the user
+   bump). Prefer the concrete `pyvenv.cfg` value when both exist.
+3. `.python-version` (pyenv) if present.
+
+Emit a single concrete pin for `[tools] python` (e.g. `"3.13"`). When
+only a `>=` floor is known, pin the floor and note it in the plan.
+
+## Dependencies
+
+- **Runtime** — `pyproject.toml` `[project] dependencies`, else
+  `requirements.txt`. Carried over verbatim.
+- **Dev** — `[project.optional-dependencies] dev`, else
+  `requirements-dev.txt` / `dev-requirements.txt`. These become
+  `[dependency-groups] dev` (see `pyproject-rewrite.md`).
+
+## Entry points
+
+`[project.scripts]` — each `name = "module:fn"` line. The first entry
+becomes the `[tasks.run]` target (`uv run <name>`). If there are none,
+omit the `run` task and note it.
+
+## Test runner
+
+- `[tool.pytest.ini_options] testpaths` → pytest is the runner; the
+  `test` task becomes `uv run pytest` (append the testpath only if it is
+  non-default and not already discovered).
+- No pytest config but a `tests/` dir exists → still default to
+  `uv run pytest`.
+- No test signal → emit `test` as `uv run pytest` with a plan note that
+  no tests were detected.
+
+## Linters (conditional task generation)
+
+Detect ruff / mypy via `[tool.ruff]` / `[tool.mypy]` stanzas OR their
+presence in dev-deps. Generate `lint`/`fix` tasks **only** for tools
+found:
+
+- ruff found → `lint-py` includes `uv run ruff check .` +
+  `ruff format --check .`; `fix-py` includes `ruff check --fix .` +
+  `ruff format .`.
+- mypy found → append `uv run mypy .` to `lint-py`.
+- Neither found → omit `lint`/`fix` and log:
+  `[INFO] no linter detected — lint/fix tasks omitted (add ruff to
+  [dependency-groups].dev to enable)`.
+
+## Build backend
+
+`pyproject.toml` `[build-system] build-backend` (e.g.
+`setuptools.build_meta`) and any `[tool.setuptools] packages = [...]`.
+Both feed the rewrite in `pyproject-rewrite.md`.

--- a/claude/skills/devx-mise-migrate/references/help.md
+++ b/claude/skills/devx-mise-migrate/references/help.md
@@ -1,0 +1,83 @@
+# devx:mise-migrate — Help
+
+## Usage
+
+```
+/devx:mise-migrate [path] [flags]
+/devx-mise-migrate ~/para/project/karakeep/sync          # dry-run plan
+/devx-mise-migrate ~/para/project/karakeep/sync --apply  # write + uv sync
+/devx:mise-migrate -h        # show this help
+/devx:mise-migrate --help    # show this help
+/devx:mise-migrate help      # show this help
+```
+
+## Arguments
+
+| # | Name | Required | Description |
+|---|------|----------|-------------|
+| 1 | `[path]` | no | Target project directory. Defaults to `.` (cwd). |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | **on** | Default. Prints the migration plan; writes nothing. |
+| `--apply` | off | Writes `mise.toml`, rewrites `pyproject.toml`, runs `uv sync`, then cleans up. |
+| `--backend <name>` | `hatchling` | Build backend to modernize toward: `hatchling` or `uv_build`. |
+| `--keep-venv` | off | Skip the cleanup step — leave the old `.venv/` and `*.egg-info/` in place. |
+
+## Examples
+
+```
+# 1. Inspect the plan for the current dir (no writes):
+/devx-mise-migrate
+
+# 2. Plan a specific project:
+/devx-mise-migrate ~/para/project/karakeep/sync
+
+# 3. Apply — write mise.toml, rewrite pyproject, uv sync, clean up:
+/devx-mise-migrate ~/para/project/karakeep/sync --apply
+
+# 4. Apply but keep the old venv/egg-info, and use uv's own backend:
+/devx-mise-migrate . --apply --backend uv_build --keep-venv
+```
+
+## What the skill does
+
+1. **Detects** a legacy Python project (pyproject / setup.py /
+   requirements + a pyenv-style `.venv`) and refuses non-Python or
+   already-migrated (`mise.toml` present) directories.
+2. **Extracts** the Python version, runtime + dev deps, `[project.scripts]`
+   entry points, test runner/`testpaths`, and current build backend.
+3. **Plans** three artifacts: the generated `mise.toml`, a
+   `pyproject.toml` diff, and the cleanup list. In dry-run this is the
+   single review surface — nothing is written.
+4. **`--apply` only** — writes `mise.toml`, rewrites `pyproject.toml`
+   (backend → hatchling, `optional-dependencies.dev` →
+   `[dependency-groups].dev`), runs `uv sync`, and removes the stale
+   `.venv/` + `*.egg-info/`.
+
+## What the skill will NOT do
+
+- Touch non-Python projects, or migrate node/go/etc. — Python-venv scope
+  only by design.
+- Re-migrate a project that already has a `mise.toml` (idempotent no-op).
+- Generate lint/fix tasks for tools the project does not use — a missing
+  linter is logged, not silently added.
+- Rewrite source code or change import paths — only `mise.toml` and the
+  build/dependency stanzas of `pyproject.toml`.
+- Delete anything outside the target `<path>`, or delete the old venv
+  when `--keep-venv` is set.
+- Roll back a partial `--apply` failure — it reports partial state and
+  stops; the user owns cleanup.
+
+## Prerequisites
+
+- `uv` and `mise` available on `PATH` (the generated `[tools]` pins both,
+  but `--apply` calls `uv sync` directly).
+- Write access to `<path>` for `--apply`.
+
+## Pairs with
+
+- `mise run lint|test|fix` — the workflow this skill bootstraps. After a
+  successful apply, start with `mise run test`.

--- a/claude/skills/devx-mise-migrate/references/mise-template.md
+++ b/claude/skills/devx-mise-migrate/references/mise-template.md
@@ -32,10 +32,11 @@ depends     = ["lint-py"]
 [tasks.lint-py]
 description = "Python lint (ruff check + format check[ + mypy])"
 run = [
-    "uv run ruff check .",
-    "uv run ruff format --check .",
-    # "uv run mypy .",   # only if mypy detected
+    "uv run ruff check .",          # only if ruff detected
+    "uv run ruff format --check .", # only if ruff detected
+    # "uv run mypy .",              # only if mypy detected
 ]
+# mypy-only project (no ruff) → run = ["uv run mypy ."] and no fix-py.
 
 # ─── Test gate ───────────────────────────────────────────────────────
 [tasks.test]
@@ -47,7 +48,7 @@ run = "uv run pytest"
 description = "전체 auto-fix"
 depends     = ["fix-py"]
 
-[tasks.fix-py]
+[tasks.fix-py]   # emit only if ruff detected (mypy has no auto-fix)
 description = "Python auto-fix (ruff check --fix + format)"
 run = [
     "uv run ruff check --fix .",
@@ -69,8 +70,17 @@ run = "uv run {{ script_name }}"
   lines only when those tools are detected. They are a `uv run`
   fallback, mirroring the repo comment "fallback for environments that
   need the binary outside `uv run`".
-- **lint / fix tasks** — emit the whole `lint*`/`fix*` group only when a
-  linter is detected. Comment the `mypy` line in only when mypy is found.
+- **lint / fix tasks** — emit the `lint*`/`fix*` group only when *some*
+  linter is detected, and build each `run` array per-tool — never emit a
+  command for a tool that is absent (it would fail on `mise run`):
+  - ruff detected → include the `ruff check` / `ruff format` lines
+    (lint) and `ruff check --fix` / `ruff format` lines (fix).
+  - mypy detected → append `uv run mypy .` to `lint-py` (mypy has no
+    auto-fix, so it adds nothing to `fix-py`).
+  - **mypy only (no ruff)** → `lint-py` runs *just* `uv run mypy .`;
+    drop every ruff line and omit `fix`/`fix-py` entirely.
+  - neither → omit `lint`/`fix` (logged per `extraction.md`).
+  Adjust each `description` to match the lines actually emitted.
 - **`[tasks.run]`** — only when `[project.scripts]` has at least one
   entry; `{{ script_name }}` is the first script name.
 - **`test`** — always emitted; default `uv run pytest`.

--- a/claude/skills/devx-mise-migrate/references/mise-template.md
+++ b/claude/skills/devx-mise-migrate/references/mise-template.md
@@ -1,0 +1,78 @@
+# Generated `mise.toml` template
+
+Render this from the Step 2 facts. Modeled on the dotfiles repo's own
+`mise.toml` (the canonical target structure). Omit blocks that don't
+apply — never emit a task that wraps a tool the project lacks.
+
+## Skeleton
+
+```toml
+# mise.toml — Tool versions + task SSOT (migrated by devx:mise-migrate)
+#
+# Daily use:
+#   mise run lint   # ruff + mypy            (read-only)   [if linters detected]
+#   mise run test   # pytest                               [if tests detected]
+#   mise run fix    # ruff --fix + format    (mutating)    [if linters detected]
+#   mise run run    # <entry-point>                        [if scripts exist]
+
+[tools]
+python = "{{ py_version }}"   # from pyvenv.cfg / requires-python
+uv     = "{{ uv_pin }}"       # pin a current stable (match repo SSOT)
+# ruff / mypy lines ONLY when those tools were detected
+
+[env]
+# Project-root convenience var, mirrors the repo pattern. Drop if unused.
+# PROJECT_ROOT = "{{ config_root }}"
+
+# ─── Lint gates (read-only) — emit only if a linter was detected ─────
+[tasks.lint]
+description = "전체 lint"
+depends     = ["lint-py"]
+
+[tasks.lint-py]
+description = "Python lint (ruff check + format check[ + mypy])"
+run = [
+    "uv run ruff check .",
+    "uv run ruff format --check .",
+    # "uv run mypy .",   # only if mypy detected
+]
+
+# ─── Test gate ───────────────────────────────────────────────────────
+[tasks.test]
+description = "전체 테스트"
+run = "uv run pytest"
+
+# ─── Auto-fix (mutating) — emit only if a linter was detected ────────
+[tasks.fix]
+description = "전체 auto-fix"
+depends     = ["fix-py"]
+
+[tasks.fix-py]
+description = "Python auto-fix (ruff check --fix + format)"
+run = [
+    "uv run ruff check --fix .",
+    "uv run ruff format .",
+]
+
+# ─── App entry point — emit only if [project.scripts] exists ─────────
+[tasks.run]
+description = "Run the project entry point"
+run = "uv run {{ script_name }}"
+```
+
+## Rendering rules
+
+- **`{{ py_version }}`** — concrete pin from `extraction.md`.
+- **`{{ uv_pin }}`** — a current stable uv (e.g. the version already
+  pinned in the dotfiles repo `mise.toml`); the user can bump later.
+- **`[tools]` ruff/mypy** — add `ruff = "<ver>"` / `mypy = "<ver>"`
+  lines only when those tools are detected. They are a `uv run`
+  fallback, mirroring the repo comment "fallback for environments that
+  need the binary outside `uv run`".
+- **lint / fix tasks** — emit the whole `lint*`/`fix*` group only when a
+  linter is detected. Comment the `mypy` line in only when mypy is found.
+- **`[tasks.run]`** — only when `[project.scripts]` has at least one
+  entry; `{{ script_name }}` is the first script name.
+- **`test`** — always emitted; default `uv run pytest`.
+
+Keep the comment header honest: list only the tasks actually generated.

--- a/claude/skills/devx-mise-migrate/references/pyproject-rewrite.md
+++ b/claude/skills/devx-mise-migrate/references/pyproject-rewrite.md
@@ -1,0 +1,73 @@
+# `pyproject.toml` rewrite rules
+
+Three in-place edits. Touch only these stanzas — never reorder or
+reformat unrelated keys, and never change `dependencies` versions.
+
+## 1. Build backend → `--backend`
+
+### hatchling (default)
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+### uv_build
+
+```toml
+[build-system]
+requires = ["uv_build>=0.10"]
+build-backend = "uv_build"
+```
+
+## 2. Explicit packages mapping
+
+setuptools' explicit-packages stanza must move to the chosen backend so
+flat-layout auto-discovery doesn't pull in non-package dirs (the exact
+breakage the karakeep `[tool.setuptools]` comment guards against).
+
+| Source (setuptools) | hatchling | uv_build |
+|---|---|---|
+| `[tool.setuptools]`<br>`packages = ["pkg"]` | `[tool.hatch.build.targets.wheel]`<br>`packages = ["pkg"]` | `[tool.uv.build-backend]`<br>`module-name = "pkg"` |
+
+If the source had no explicit `packages` (auto-discovery worked), only
+emit a target-packages stanza when the project root contains non-package
+dirs that would otherwise be picked up; otherwise leave discovery to the
+backend.
+
+## 3. Dev deps → `[dependency-groups]`
+
+uv-native dependency groups (PEP 735) replace the
+`optional-dependencies.dev` extra. This matches the dotfiles repo, whose
+`mise.toml` notes ruff "is pinned in pyproject.toml's dev group".
+
+Before:
+
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-httpx>=0.30",
+]
+```
+
+After:
+
+```toml
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-httpx>=0.30",
+]
+```
+
+Remove the now-empty `[project.optional-dependencies]` table if `dev`
+was its only key. If other extras exist, keep the table and only lift
+the `dev` key out.
+
+## Left untouched
+
+`[project]` name/version/description/`requires-python`, runtime
+`dependencies`, `[project.scripts]`, `[tool.pytest.ini_options]`, and any
+tool config (`[tool.ruff]`, `[tool.mypy]`) pass through verbatim.


### PR DESCRIPTION
## Summary
- 레거시 Python 가상환경 구조(pyenv/`python -m venv` + pip, setuptools)를 이 repo 의 정본 mise 구조로 전환하는 신규 스킬 `devx:mise-migrate` 를 추가합니다.
- 여러 프로젝트에서 반복 수행하던 마이그레이션을 표준화 — `mise.toml`([tools]+[env]+[tasks.*] SSOT) 생성 + uv 로의 venv/deps 이관 + hatchling 빌드 백엔드 현대화.

## Changes
- `claude/skills/devx-mise-migrate/SKILL.md` (99줄) — detect → extract → plan → apply → report 5단계. `--dry-run` 기본(생성될 `mise.toml`·`pyproject.toml` diff·cleanup list 출력), `--apply` 로 실제 write + `uv sync` + 잔재(`.venv/`·`*.egg-info/`) 정리.
- `references/help.md` — usage/flags(`--apply`, `--backend hatchling|uv_build`, `--keep-venv`)/예제/NOT-does.
- `references/extraction.md` — Python 버전·deps·entry point·test runner·linter·build backend 추출 규칙. linter 미검출 시 lint/fix task 생략(없는 도구를 묵시 추가하지 않음).
- `references/mise-template.md` — 이 repo `mise.toml` 을 모델로 한 생성 템플릿 + 조건부 렌더링 규칙.
- `references/pyproject-rewrite.md` — setuptools→hatchling/uv_build, explicit-packages 매핑, `optional-dependencies.dev`→`[dependency-groups].dev`.
- `references/constraints.md` — dry-run 기본·path-scoped·guarded cleanup·no source edit·idempotency·실패 시 partial-state 보고.
- `references/example-karakeep.md` — `~/para/project/karakeep/sync` before→after 워크드 예제.

## Test plan
- [ ] CLI 재기동 후 스킬 로드 확인 → `/devx:mise-migrate ~/para/project/karakeep/sync` dry-run plan 출력 검증
- [ ] `--apply` 로 `mise.toml` 생성 + `uv sync` + cleanup 동작 확인 (karakeep/sync 사본에서)
- [x] `/skill:check` 12/12 PASS (EXCELLENT) — SKILL.md 99줄, references 6개 전부 wired
- [x] pre-commit 훅 통과

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
