### PR TITLE
feat(skills): devx:mise-migrate stale 참조 스캔 + PEP 735 회귀 경고

### DIFF
--- a/claude/skills/devx-mise-migrate/SKILL.md
+++ b/claude/skills/devx-mise-migrate/SKILL.md
@@ -48,9 +48,9 @@ Detect a legacy Python project, else refuse early (exit 1):
 - No `pyproject.toml` / `setup.py` / `requirements*.txt` at `<path>` →
   **nested fallback**: if `<path>` has none but exactly one direct child
   dir (depth 1) does, retarget to it and note
-  `[INFO] retargeting to nested project: <child>` (≥2 candidates →
-  list them and stop). Still none → `[FAIL] devx:mise-migrate: not a
-  Python project: <path>`.
+  `[INFO] retargeting to nested project: <child>` (≥2 candidates → list
+  them and fail with exit 1). Still none → `[FAIL] devx:mise-migrate: not
+  a Python project: <path>` (exit 1).
 - A `mise.toml` already exists → `[INFO] devx:mise-migrate: already
   migrated` (exit 0, idempotent).
 

--- a/claude/skills/devx-mise-migrate/SKILL.md
+++ b/claude/skills/devx-mise-migrate/SKILL.md
@@ -10,11 +10,15 @@ description: >-
   바꿔줘", "예전 파이썬 가상환경을 mise+uv 로 마이그레이션", "venv 프로젝트를
   mise 로 전환", "migrate this venv project to mise", "adopt mise here".
   Default mode is `--dry-run` — prints the migration plan (the full
-  generated `mise.toml`, a `pyproject.toml` diff, and the cleanup list)
+  generated `mise.toml`, a `pyproject.toml` diff, the cleanup list, and a
+  read-only scan for stale `venv`/`pip` references left in docs/scripts)
   and mutates nothing; `--apply` writes the files, runs `uv sync`, and
-  removes the stale `.venv/` + `*.egg-info/`. Python-venv projects only —
-  refuses non-Python or already-migrated directories. Accepts
-  `-h`/`--help`/`help` to print usage.
+  removes the stale `.venv/` + `*.egg-info/` (add `--update-docs` to also
+  rewrite the stale doc references). Warns when lifting dev deps to PEP
+  735 `[dependency-groups]` silently breaks `pip install -e ".[dev]"`,
+  and auto-retargets to a single nested project when the path has none.
+  Python-venv projects only — refuses non-Python or already-migrated
+  directories. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep
 metadata:
   model_recommendation:
@@ -36,12 +40,17 @@ mutation.**
 
 Positional `[path]` defaults to `.`. Flags: `--dry-run` (default),
 `--apply`, `--backend hatchling|uv_build` (default `hatchling`),
-`--keep-venv` (skip cleanup). Full table in `references/help.md`.
+`--keep-venv` (skip cleanup), `--update-docs` (opt-in stale-doc rewrite,
+`references/stale-scan.md`). Full table in `references/help.md`.
 
 Detect a legacy Python project, else refuse early (exit 1):
 
-- No `pyproject.toml` / `setup.py` / `requirements*.txt` →
-  `[FAIL] devx:mise-migrate: not a Python project: <path>`.
+- No `pyproject.toml` / `setup.py` / `requirements*.txt` at `<path>` →
+  **nested fallback**: if `<path>` has none but exactly one direct child
+  dir (depth 1) does, retarget to it and note
+  `[INFO] retargeting to nested project: <child>` (≥2 candidates →
+  list them and stop). Still none → `[FAIL] devx:mise-migrate: not a
+  Python project: <path>`.
 - A `mise.toml` already exists → `[INFO] devx:mise-migrate: already
   migrated` (exit 0, idempotent).
 
@@ -58,7 +67,7 @@ actually present (Step 3).
 
 ## Step 3: Build the Migration Plan
 
-Assemble three artifacts per `references/mise-template.md` and
+Assemble four artifacts per `references/mise-template.md` and
 `references/pyproject-rewrite.md` (`references/example-karakeep.md` is a
 full before→after walkthrough):
 
@@ -69,11 +78,20 @@ full before→after walkthrough):
    carried over, `optional-dependencies.dev` → `[dependency-groups].dev`.
 3. **Cleanup list** — stale `.venv/` + `*.egg-info/` (skipped by
    `--keep-venv`).
+4. **Stale references** — read-only grep of `<path>` for the legacy
+   `venv`/`pip`/`.[dev]` workflow, reported as `file:line` with
+   history/archive paths excluded. Full ERE, exclusions, and the opt-in
+   `--update-docs` rewrite: `references/stale-scan.md`.
 
-In `--dry-run` (default), **print all three and stop**:
+When a `dev` extra is lifted to `[dependency-groups]`, also surface the
+PEP 735 silent-regression `[WARN]` (`references/pyproject-rewrite.md`),
+and when the Python pin came from a `requires-python` floor (no
+`pyvenv.cfg`), the floor-vs-resolved `[INFO]` (`references/extraction.md`).
+
+In `--dry-run` (default), **print all four and stop**:
 
 ```
-Plan ready: <path> (backend=<backend>, py=<ver>, tasks=<n>)
+Plan ready: <path> (backend=<backend>, py=<ver>, tasks=<n>, stale=<s>)
 Run with --apply to write mise.toml, rewrite pyproject, and uv sync.
 ```
 
@@ -87,6 +105,9 @@ In order, stopping on first failure with `[FAIL] devx:mise-migrate
 3. Run `uv sync` to materialize the uv-managed venv + lockfile.
 4. Cleanup — remove `.venv/` + `*.egg-info/` unless `--keep-venv`;
    never delete outside `<path>`. Guardrails: `references/constraints.md`.
+5. Stale docs — **only if `--update-docs`**, rewrite the non-excluded
+   stale hits and re-print touched files (`references/stale-scan.md`).
+   The PEP 735 `[WARN]` still fires (external CI is out of reach).
 
 ## Step 5: Report
 
@@ -94,6 +115,9 @@ In order, stopping on first failure with `[FAIL] devx:mise-migrate
 [OK] devx:mise-migrate path=<path> backend=<backend> py=<ver> tasks=<n>
 ```
 
-On `--apply` append `synced=yes cleaned=<.venv,egg-info|kept>`. On
-dry-run append `Next: review the plan, then re-run with --apply`. After
-a successful apply, hint `Next: mise run test`.
+On `--apply` append `synced=yes cleaned=<.venv,egg-info|kept>
+docs=<rewrote-N|scan-only>`. Always re-print any `[WARN]`/`[INFO]`
+notes (PEP 735 regression, stale references, pin-is-floor) so they
+survive into the final surface. On dry-run append `Next: review the
+plan, then re-run with --apply`. After a successful apply, hint
+`Next: mise run test`.

--- a/claude/skills/devx-mise-migrate/references/example-karakeep.md
+++ b/claude/skills/devx-mise-migrate/references/example-karakeep.md
@@ -76,10 +76,31 @@ remove: .venv/
 remove: karakeep_sync.egg-info/
 ```
 
+## Stale references (read-only scan)
+
+The migration is correct, but the repo still documents the old flow:
+
+```
+[WARN] scripts/bootstrap.sh:12   pip install -e ".[dev]"   (silent regression — now skips dev deps)
+[WARN] README.md:40              source .venv/bin/activate
+       README.md:38              python -m venv .venv
+       docs/todo.md:21           pip install -e ".[dev]"
+       docs/pc-environment.md:9  python -m venv .venv
+[INFO] 2 stale-reference hits in docs/archive/ (history — not shown)
+```
+
+`--update-docs` would rewrite the five live hits to `uv sync` / `uv run`
+and leave the archived ones alone. `scripts/bootstrap.sh` is the real
+victim of the PEP 735 move — without the rewrite it keeps exiting 0 while
+pytest never installs.
+
 ## Verdict
 
 ```
+[WARN] dev deps moved to PEP 735 [dependency-groups] — any
+       `pip install -e ".[dev]"` in scripts/CI will now silently skip
+       dev deps. Use `uv sync` instead.
 [OK] devx:mise-migrate path=~/para/project/karakeep/sync backend=hatchling py=3.13 tasks=2
-     synced=yes cleaned=.venv,egg-info
+     synced=yes cleaned=.venv,egg-info docs=rewrote-5
 Next: mise run test
 ```

--- a/claude/skills/devx-mise-migrate/references/extraction.md
+++ b/claude/skills/devx-mise-migrate/references/extraction.md
@@ -14,7 +14,16 @@ Priority order:
 3. `.python-version` (pyenv) if present.
 
 Emit a single concrete pin for `[tools] python` (e.g. `"3.13"`). When
-only a `>=` floor is known, pin the floor and note it in the plan.
+only a `>=` floor is known (no `pyvenv.cfg`), pin the floor and note in
+the plan that the pin is the **floor**, not what `uv` will actually
+resolve — `uv sync` picks the newest interpreter on the box that
+satisfies it (e.g. floor `3.11` but uv grabs the system `3.13.5`):
+
+```
+[INFO] python pin = requires-python floor (3.11); no pyvenv.cfg found.
+       `uv sync` may resolve a newer interpreter (e.g. 3.13). Pin
+       [tools] python to an exact version if you need it reproducible.
+```
 
 ## Dependencies
 

--- a/claude/skills/devx-mise-migrate/references/help.md
+++ b/claude/skills/devx-mise-migrate/references/help.md
@@ -25,6 +25,7 @@
 | `--apply` | off | Writes `mise.toml`, rewrites `pyproject.toml`, runs `uv sync`, then cleans up. |
 | `--backend <name>` | `hatchling` | Build backend to modernize toward: `hatchling` or `uv_build`. |
 | `--keep-venv` | off | Skip the cleanup step — leave the old `.venv/` and `*.egg-info/` in place. |
+| `--update-docs` | off | With `--apply`, rewrite in-repo stale `venv`/`pip` references (README, docs, bootstrap scripts) to the `uv` workflow. Off → the scan is report-only. |
 
 ## Examples
 
@@ -46,22 +47,34 @@
 
 1. **Detects** a legacy Python project (pyproject / setup.py /
    requirements + a pyenv-style `.venv`) and refuses non-Python or
-   already-migrated (`mise.toml` present) directories.
+   already-migrated (`mise.toml` present) directories. If the given path
+   has no project file but exactly one direct subdir does, it retargets
+   to that nested project.
 2. **Extracts** the Python version, runtime + dev deps, `[project.scripts]`
    entry points, test runner/`testpaths`, and current build backend.
-3. **Plans** three artifacts: the generated `mise.toml`, a
-   `pyproject.toml` diff, and the cleanup list. In dry-run this is the
-   single review surface — nothing is written.
+3. **Plans** four artifacts: the generated `mise.toml`, a
+   `pyproject.toml` diff, the cleanup list, and a read-only **stale
+   reference** scan (in-repo docs/scripts still describing the old
+   `venv`/`pip` flow). In dry-run this is the single review surface —
+   nothing is written.
 4. **`--apply` only** — writes `mise.toml`, rewrites `pyproject.toml`
    (backend → hatchling, `optional-dependencies.dev` →
    `[dependency-groups].dev`), runs `uv sync`, and removes the stale
-   `.venv/` + `*.egg-info/`.
+   `.venv/` + `*.egg-info/`. With `--update-docs`, also rewrites the
+   stale in-repo references found in step 3.
+
+> **PEP 735 silent regression** — lifting `dev` out of
+> `optional-dependencies` means `pip install -e ".[dev]"` silently stops
+> installing dev deps (exit 0, no error). The skill warns whenever this
+> happens; switch such callers to `uv sync`.
 
 ## What the skill will NOT do
 
 - Touch non-Python projects, or migrate node/go/etc. — Python-venv scope
   only by design.
 - Re-migrate a project that already has a `mise.toml` (idempotent no-op).
+- Rewrite stale doc/script references unless `--update-docs` is set, and
+  never touch history/archive/design-spec paths even then.
 - Generate lint/fix tasks for tools the project does not use — a missing
   linter is logged, not silently added.
 - Rewrite source code or change import paths — only `mise.toml` and the

--- a/claude/skills/devx-mise-migrate/references/pyproject-rewrite.md
+++ b/claude/skills/devx-mise-migrate/references/pyproject-rewrite.md
@@ -66,6 +66,27 @@ Remove the now-empty `[project.optional-dependencies]` table if `dev`
 was its only key. If other extras exist, keep the table and only lift
 the `dev` key out.
 
+### Silent regression — warn loudly
+
+Moving `dev` out of `optional-dependencies` is a **breaking change for
+any pip-based install path**. `pip install -e ".[dev]"` no longer finds a
+`dev` extra and *skips the dev deps with exit 0* — no error. Bootstrap /
+CI scripts that called it keep passing while pytest, ruff, etc. are never
+installed.
+
+So whenever a `dev` extra is lifted, the plan **and** the `--apply`
+report must carry this warning verbatim:
+
+```
+[WARN] dev deps moved to PEP 735 [dependency-groups] — any
+       `pip install -e ".[dev]"` in scripts/CI will now silently skip
+       dev deps. Use `uv sync` instead.
+```
+
+The `--update-docs` flag (see `stale-scan.md`) rewrites the in-repo
+callers; external CI still needs a manual look, so the warning fires even
+when `--update-docs` is set.
+
 ## Left untouched
 
 `[project]` name/version/description/`requires-python`, runtime

--- a/claude/skills/devx-mise-migrate/references/stale-scan.md
+++ b/claude/skills/devx-mise-migrate/references/stale-scan.md
@@ -5,8 +5,8 @@ bootstrap scripts still describe the **old** `venv + pip` workflow.
 Worst case is a *silent regression*: a script that calls
 `pip install -e ".[dev]"` keeps running with **exit 0** but now skips the
 dev deps, because the `dev` extra was lifted to PEP 735
-`[dependency-groups]` (see `pyproject-rewrite.md` §3). CI passes with
-pytest never installed.
+`[dependency-groups]` (see `references/pyproject-rewrite.md` "3. Dev deps
+→ `[dependency-groups]`"). CI passes with pytest never installed.
 
 This scan surfaces those references. It is **always read-only** in the
 plan; rewriting them is opt-in via `--update-docs`.
@@ -16,8 +16,12 @@ plan; rewriting them is opt-in via `--update-docs`.
 `Grep` the target `<path>` (recursively) for the legacy-workflow ERE:
 
 ```
-python -m venv|python3 -m venv|pip install|\.venv/bin/activate|\.\[dev\]|setuptools
+python -m venv|python3 -m venv|pip install|\.venv/bin/activate|\.\[dev\]|setuptools|requirements\.txt
 ```
+
+The `requirements\.txt` alternative catches bare doc references (e.g.
+"see `requirements.txt`") that `pip install` alone would miss — uv folds
+those deps into `pyproject.toml`, so the file reference is also stale.
 
 Report each hit as `file:line` under a **Stale references** heading in
 the plan. The `pip install -e ".[dev]"` and `.[dev]` hits are the
@@ -47,6 +51,7 @@ then re-print the touched files. Never edit excluded/history paths.
 | `python -m venv .venv` / `python3 -m venv .venv` | `uv sync` (creates the venv) |
 | `source .venv/bin/activate` | (drop; prefix commands with `uv run`) |
 | `pip install -e ".[dev]"` / `pip install -e .` | `uv sync` |
+| `pip install -r requirements.txt` / `pip install -r requirements-dev.txt` | `uv sync` (deps now in `pyproject.toml`) |
 | `pip install <pkg>` | `uv add <pkg>` |
 
 Code blocks that show a *full* sequence (`venv` → `activate` →

--- a/claude/skills/devx-mise-migrate/references/stale-scan.md
+++ b/claude/skills/devx-mise-migrate/references/stale-scan.md
@@ -55,9 +55,13 @@ then re-print the touched files. Never edit excluded/history paths.
 | `pip install <pkg>` | `uv add <pkg>` |
 
 Code blocks that show a *full* sequence (`venv` → `activate` →
-`pip install`) collapse to a single `uv sync`. When a line's intent is
-ambiguous, leave it and report it as a manual-review hit rather than
-guess — this skill never improvises source/doc edits (`constraints.md`).
+`pip install`) collapse to a single `uv sync`. The remaining ERE
+alternatives have **no mechanical rewrite** — a bare `setuptools` mention
+or a prose `requirements.txt` reference depends on surrounding context
+(build-backend prose, a stale install doc, a historical note). Report
+these as manual-review hits and leave them untouched. When any line's
+intent is ambiguous, do the same rather than guess — this skill never
+improvises source/doc edits (`constraints.md`).
 
 `--update-docs` without `--apply` is a no-op with a note:
 `[INFO] --update-docs requires --apply; scan is read-only in dry-run`.

--- a/claude/skills/devx-mise-migrate/references/stale-scan.md
+++ b/claude/skills/devx-mise-migrate/references/stale-scan.md
@@ -1,0 +1,58 @@
+# Stale legacy-reference scan (read-only) + `--update-docs`
+
+After a migration the config files are correct, but README / docs /
+bootstrap scripts still describe the **old** `venv + pip` workflow.
+Worst case is a *silent regression*: a script that calls
+`pip install -e ".[dev]"` keeps running with **exit 0** but now skips the
+dev deps, because the `dev` extra was lifted to PEP 735
+`[dependency-groups]` (see `pyproject-rewrite.md` §3). CI passes with
+pytest never installed.
+
+This scan surfaces those references. It is **always read-only** in the
+plan; rewriting them is opt-in via `--update-docs`.
+
+## Scan (always, both dry-run and `--apply`)
+
+`Grep` the target `<path>` (recursively) for the legacy-workflow ERE:
+
+```
+python -m venv|python3 -m venv|pip install|\.venv/bin/activate|\.\[dev\]|setuptools
+```
+
+Report each hit as `file:line` under a **Stale references** heading in
+the plan. The `pip install -e ".[dev]"` and `.[dev]` hits are the
+high-severity ones (silent regression) — flag them with `[WARN]`.
+
+### Exclusions (history, not live instructions)
+
+Skip paths that document the *past* rather than instruct the *present* —
+they are expected to mention the old flow:
+
+- `**/archive/**`, `**/_archive/**`
+- design/spec/plan docs: `**/*plan*.md`, `**/*spec*.md`, `**/*design*.md`,
+  `CHANGELOG*`, `docs/**/decisions/**`
+- the generated `mise.toml` / `uv.lock` / `.venv/**` themselves
+
+List how many hits were excluded so the suppression is never silent:
+`[INFO] N stale-reference hits in history/archive paths (not shown)`.
+
+## `--update-docs` (opt-in, only with `--apply`)
+
+Off by default. When set, after the config rewrite + `uv sync` succeed,
+rewrite the **non-excluded** hits with the canonical replacements below,
+then re-print the touched files. Never edit excluded/history paths.
+
+| Legacy | Replacement |
+|---|---|
+| `python -m venv .venv` / `python3 -m venv .venv` | `uv sync` (creates the venv) |
+| `source .venv/bin/activate` | (drop; prefix commands with `uv run`) |
+| `pip install -e ".[dev]"` / `pip install -e .` | `uv sync` |
+| `pip install <pkg>` | `uv add <pkg>` |
+
+Code blocks that show a *full* sequence (`venv` → `activate` →
+`pip install`) collapse to a single `uv sync`. When a line's intent is
+ambiguous, leave it and report it as a manual-review hit rather than
+guess — this skill never improvises source/doc edits (`constraints.md`).
+
+`--update-docs` without `--apply` is a no-op with a note:
+`[INFO] --update-docs requires --apply; scan is read-only in dry-run`.


### PR DESCRIPTION
## Summary
- `devx:mise-migrate` 스킬에 이슈 #1005 의 4개 개선 제안을 모두 반영. karakeep/sync 실전 `--apply` 에서 드러난 silent regression 과 스코프 밖 후속 정리 마찰을 줄인다.
- 마이그레이션 동작 자체는 변경 없음 — 경고/스캔/안내를 더해 사용자가 후속 수작업을 놓치지 않게 하는 가드성 보강.

## Changes
- **(高) PEP 735 회귀 경고** — `optional-dependencies.dev` → `[dependency-groups]` 전환이 `pip install -e ".[dev]"` 를 에러 없이(exit 0) dev 의존성 누락으로 망가뜨린다. dry-run plan + `--apply` 리포트에 `[WARN]` verbatim 출력. `references/pyproject-rewrite.md` §3 에 silent-regression 섹션 추가.
- **(高) 레거시 참조 read-only 스캔** — 신규 `references/stale-scan.md` (ERE 패턴 + history/archive 제외 규칙 + opt-in `--update-docs` 재작성 매핑). Step 3 의 4번째 플랜 아티팩트로 추가, Step 4 에 `--update-docs` 적용 단계 추가.
- **(中) 중첩 `pyproject.toml` 자동 탐지** — Step 1 detect 에 nested fallback (depth-1 단일 후보 retarget, ≥2 면 나열 후 중단).
- **(低) Python 핀 소스 불일치 안내** — `references/extraction.md` 에 floor-vs-resolved `[INFO]` 강화 (`uv sync` 가 더 최신 인터프리터를 잡을 수 있음).
- frontmatter description / `references/help.md` / `references/example-karakeep.md` (karakeep bootstrap.sh 회귀 사례 포함) 일관 갱신.

## Test plan
- [ ] `/devx:mise-migrate <legacy-project>` dry-run 에 stale 참조 목록 + (해당 시) PEP 735 `[WARN]` + 핀 `[INFO]` 가 출력되는지
- [ ] 루트에 `pyproject.toml` 없고 하위 1뎁스에 하나만 있을 때 nested retarget 동작
- [ ] `--apply --update-docs` 가 live 참조만 재작성하고 archive/spec 경로는 건드리지 않는지
- [ ] SKILL.md body < 100줄, 참조 링크 무결성, 이모지 없음 (수동 확인 완료)

## Related
Closes #1005

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
