### PR TITLE
fix(ci): concurrency cancel-in-progress 를 false 로 변경 (#1007)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,12 @@ on:
       - develop
   workflow_dispatch:
 
-# Cancel superseded runs on the same ref to save runner minutes.
+# Do not cancel in-progress runs: GitHub marks pre-start cancelled jobs as
+# "failure" (not "cancelled") in the API, which pollutes check history.
+# Lint takes ~1-2 min on the runner — the extra runner minutes are acceptable.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Do not cancel in-progress runs: GitHub marks pre-start cancelled jobs as
+# "failure" (not "cancelled") in the API, which pollutes check history.
+# Lint takes ~1-2 min on the runner — the extra runner minutes are acceptable.
 concurrency:
   group: test-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   lint:


### PR DESCRIPTION
## 요약

GitHub Actions 의 `concurrency.cancel-in-progress: true` 가 일으키는 check
history 오염을 막기 위해 `ci.yml` / `test.yml` 두 워크플로의 설정을 `false`
로 변경합니다.

## 배경 / 근본 원인

`cancel-in-progress: true` 상태에서 새 push 로 이전 run 이 취소될 때, 아직
runner 를 할당받지 못한 job 은 GitHub API 에서 `cancelled` 가 아닌
**`failure`** 로 conclusion 을 받습니다 (`"Job is completed before starting."`).

이로 인해:
- check history 가 `failure` 로 오염됨
- branch protection 규칙이 있는 경우 merge 차단 요인이 됨

## 변경 내용

- `.github/workflows/ci.yml` — `cancel-in-progress: true → false`
- `.github/workflows/test.yml` — `cancel-in-progress: true → false`
- 두 파일 모두 변경 사유를 주석으로 명시

lint job 은 runner 에서 1~2분이면 끝나므로, 취소로 절약되는 runner 분보다
깔끔한 check history 가 더 중요합니다.

## 검증

- YAML 문법 검증 통과
- 로컬 pre-commit 훅 (ruff / mypy / shellcheck / shfmt) 통과

Closes #1007
