### PR TITLE
feat(docker): docker compose down --remove-orphans 를 dcdo alias + docker-help 에 추가

### DIFF
--- a/shell-common/functions/devops_help.sh
+++ b/shell-common/functions/devops_help.sh
@@ -10,7 +10,7 @@ _docker_help_summary() {
     ux_info "Usage: docker-help [section|--list|--all]"
     ux_bullet "sections"
     ux_bullet_sub "compose: dc | dcu | dcud | dcd | dcl | dce"
-    ux_bullet_sub "compose-extra: dcps | dcb | dcr | dcdv | dcstop | dcstart"
+    ux_bullet_sub "compose-extra: dcps | dcb | dcr | dcdv | dcdo | dcstop | dcstart"
     ux_bullet_sub "basics: dps | dpsa | di | dstats | dstop | drm | drmi | dlogs | dinspect"
     ux_bullet_sub "resources: ddf | dprune | dprune_full | dvols | dvol_rm | dnetwork_prune | dbuild_prune"
     ux_bullet_sub "utilities: dbash | denv | dinspect_env | dstopall | drmall | dexport | dinstall | dproxy_setup"
@@ -46,6 +46,7 @@ _docker_help_rows_compose_extra() {
     ux_table_row "dcb" "docker compose build" "Build services"
     ux_table_row "dcr" "docker compose restart" "Restart services"
     ux_table_row "dcdv" "down -v" "Stop & remove volumes"
+    ux_table_row "dcdo" "down --remove-orphans" "Stop & remove orphan containers (fixes net 'still in use')"
     ux_table_row "dcstop" "stop" "Stop containers"
     ux_table_row "dcstart" "start" "Start containers"
 }
@@ -89,6 +90,7 @@ _docker_help_rows_intent() {
     ux_table_row "start with overlay" "(raw)" "docker compose -f a.yml -f b.yml up -d --build"
     ux_table_row "stop a stack" "dcd" "docker compose down"
     ux_table_row "wipe data too" "dcdv" "docker compose down -v"
+    ux_table_row "stop + clear orphans" "dcdo" "docker compose down --remove-orphans"
     ux_table_row "rebuild a service" "dcb <svc>" "docker compose build <svc>"
     ux_table_row "reset stack with volumes + rebuild" "(raw)" "docker compose down -v && docker compose up -d --build"
     ux_table_row "restart a service" "dcr <svc>" "docker compose restart <svc>"
@@ -290,6 +292,7 @@ _docker_help_catalog() {
         'dcb|docker compose build|Build services|compose-extra' \
         'dcr|docker compose restart <svc>|Restart services|compose-extra' \
         'dcdv|docker compose down -v|Stop & remove volumes|compose-extra' \
+        'dcdo|docker compose down --remove-orphans|Stop & remove orphan containers (fixes net "still in use")|compose-extra' \
         'dcstop|docker compose stop|Stop containers|compose-extra' \
         'dcstart|docker compose start|Start containers|compose-extra' \
         'dps|docker ps|Running containers|basics' \

--- a/shell-common/tools/integrations/docker.sh
+++ b/shell-common/tools/integrations/docker.sh
@@ -24,6 +24,7 @@ alias dce='docker compose exec' # 서비스 내 명령 실행 (dce app bash 등)
 alias dcps='docker compose ps'       # compose 서비스 상태
 alias dcb='docker compose build'     # 서비스 이미지 빌드
 alias dcdv='docker compose down -v'  # 볼륨까지 삭제 (데이터 초기화)
+alias dcdo='docker compose down --remove-orphans' # compose 밖 orphan 컨테이너까지 정리 (네트워크 "still in use" 해결)
 alias dcstop='docker compose stop'   # 컨테이너만 정지
 alias dcstart='docker compose start' # 정지된 컨테이너 시작
 


### PR DESCRIPTION
## Summary
- `docker compose down` 후 나타나는 `Network ... Resource is still in use` 경고의 해결책인 `docker compose down --remove-orphans` 를 `dcdo` alias 로 추가.
- 같은 명령을 `docker-help` 의 SSOT 표면 전체에 일관되게 노출해, alias·raw·intent 어느 경로로 찾아도 발견되도록 함.

## Changes
- `shell-common/tools/integrations/docker.sh`: `alias dcdo='docker compose down --remove-orphans'` 추가.
- `shell-common/functions/devops_help.sh`: 4개 표면에 항목 반영 — compose-extra 표, raw·reverse 카탈로그, i-want(intent) 맵("stop + clear orphans"), summary 목록 한 줄.

## Why
compose 밖에서 같은 네트워크에 join 한 orphan 컨테이너가 남으면 `down` 이 네트워크를 못 지운다. `--remove-orphans` 가 정석 해결책인데 `docker-help` 에 없어 사용자가 `--force` 같은 존재하지 않는 옵션을 찾게 됨. 이를 학습 가능한 alias + help 항목으로 등록.

## Test plan
- [x] `docker-help --all` 에 dcdo 표 + intent 두 줄 노출 확인
- [x] `docker-help dcdo` reverse lookup → raw 명령 출력 확인
- [x] `docker-help raw compose-extra` 에 노출 확인
- [x] docker-help pytest 44 passed, help-integrity 훅 통과

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
