### PR TITLE
refactor(skills): devx:mise-migrate SKILL.md progressive disclosure (123→99줄)

### DIFF
--- a/claude/skills/devx-mise-migrate/SKILL.md
+++ b/claude/skills/devx-mise-migrate/SKILL.md
@@ -33,29 +33,17 @@ metadata:
 ## Help
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
-output its content verbatim, then stop. **No detection, no file
-mutation.**
+output its content verbatim, then stop. **No detection, no file mutation.**
 
 ## Step 1: Parse Args + Detect a Legacy Python Project
 
 Positional `[path]` defaults to `.`. Flags: `--dry-run` (default),
 `--apply`, `--backend hatchling|uv_build` (default `hatchling`),
-`--keep-venv` (skip cleanup), `--update-docs` (opt-in stale-doc rewrite,
-`references/stale-scan.md`). Full table in `references/help.md`.
+`--keep-venv`, `--update-docs`. Full table in `references/help.md`.
 
-Detect a legacy Python project, else refuse early (exit 1):
-
-- No `pyproject.toml` / `setup.py` / `requirements*.txt` at `<path>` →
-  **nested fallback**: if `<path>` has none but exactly one direct child
-  dir (depth 1) does, retarget to it and note
-  `[INFO] retargeting to nested project: <child>` (≥2 candidates → list
-  them and fail with exit 1). Still none → `[FAIL] devx:mise-migrate: not
-  a Python project: <path>` (exit 1).
-- A `mise.toml` already exists → `[INFO] devx:mise-migrate: already
-  migrated` (exit 0, idempotent).
-
-A pyenv `.venv/` / `pyvenv.cfg` is the signal worth migrating, but its
-absence is not fatal — a pip/requirements project still qualifies.
+Detect a legacy Python project (pyproject / setup.py / `requirements*.txt`),
+applying the nested-fallback retarget, the already-migrated short-circuit,
+and the refusal exit codes in `references/detection.md`.
 
 ## Step 2: Extract Migration Facts (read-only)
 
@@ -79,21 +67,16 @@ full before→after walkthrough):
 3. **Cleanup list** — stale `.venv/` + `*.egg-info/` (skipped by
    `--keep-venv`).
 4. **Stale references** — read-only grep of `<path>` for the legacy
-   `venv`/`pip`/`.[dev]` workflow, reported as `file:line` with
-   history/archive paths excluded. Full ERE, exclusions, and the opt-in
-   `--update-docs` rewrite: `references/stale-scan.md`.
+   `venv`/`pip`/`.[dev]` workflow, reported as `file:line` (history /
+   archive excluded). Full ERE + opt-in `--update-docs` rewrite:
+   `references/stale-scan.md`.
 
-When a `dev` extra is lifted to `[dependency-groups]`, also surface the
-PEP 735 silent-regression `[WARN]` (`references/pyproject-rewrite.md`),
-and when the Python pin came from a `requires-python` floor (no
-`pyvenv.cfg`), the floor-vs-resolved `[INFO]` (`references/extraction.md`).
+Surface the PEP 735 silent-regression `[WARN]` when a `dev` extra is
+lifted (`references/pyproject-rewrite.md`), and the floor-vs-resolved
+`[INFO]` when the pin came from `requires-python` (`references/extraction.md`).
 
-In `--dry-run` (default), **print all four and stop**:
-
-```
-Plan ready: <path> (backend=<backend>, py=<ver>, tasks=<n>, stale=<s>)
-Run with --apply to write mise.toml, rewrite pyproject, and uv sync.
-```
+In `--dry-run` (default), print all four and stop using the plan block in
+`references/output-format.md`.
 
 ## Step 4: Apply (only if `--apply`)
 
@@ -111,13 +94,6 @@ In order, stopping on first failure with `[FAIL] devx:mise-migrate
 
 ## Step 5: Report
 
-```
-[OK] devx:mise-migrate path=<path> backend=<backend> py=<ver> tasks=<n>
-```
-
-On `--apply` append `synced=yes cleaned=<.venv,egg-info|kept>
-docs=<rewrote-N|scan-only>`. Always re-print any `[WARN]`/`[INFO]`
-notes (PEP 735 regression, stale references, pin-is-floor) so they
-survive into the final surface. On dry-run append `Next: review the
-plan, then re-run with --apply`. After a successful apply, hint
-`Next: mise run test`.
+Emit the success line, the `--apply` append fields, the dry-run `Next:`
+hint, and the carried-over `[WARN]`/`[INFO]` notes per
+`references/output-format.md`.

--- a/claude/skills/devx-mise-migrate/references/detection.md
+++ b/claude/skills/devx-mise-migrate/references/detection.md
@@ -1,0 +1,41 @@
+# Detection — is this a legacy Python project? (Step 1)
+
+Run after parsing args. Decide whether `<path>` is a migratable legacy
+Python project, retarget if needed, or refuse early. All read-only.
+
+## Signals
+
+A pyenv `.venv/` / `pyvenv.cfg` is the signal worth migrating, but its
+absence is **not** fatal — a pip/`requirements*.txt` project still
+qualifies. The project markers are `pyproject.toml`, `setup.py`, or
+`requirements*.txt` at `<path>`.
+
+## Decision rules (in order)
+
+1. **No marker at `<path>` → nested fallback.** If `<path>` itself has no
+   marker but exactly **one** direct child dir (depth 1) does, retarget to
+   it and note:
+
+   ```
+   [INFO] retargeting to nested project: <child>
+   ```
+
+   - **≥2 candidate child dirs** → list them and fail (exit 1).
+   - **Still none** anywhere →
+
+     ```
+     [FAIL] devx:mise-migrate: not a Python project: <path>
+     ```
+
+     (exit 1).
+
+2. **Already migrated.** A `mise.toml` already exists at the (possibly
+   retargeted) path → idempotent no-op:
+
+   ```
+   [INFO] devx:mise-migrate: already migrated
+   ```
+
+   (exit 0).
+
+3. Otherwise proceed to Step 2 (Extract Migration Facts).

--- a/claude/skills/devx-mise-migrate/references/output-format.md
+++ b/claude/skills/devx-mise-migrate/references/output-format.md
@@ -15,29 +15,26 @@ Run with --apply to write mise.toml, rewrite pyproject, and uv sync.
 
 ## Final report (Step 5)
 
-Always emit the success line:
+Emit a **single** structured success line. The `--apply` fields append to
+that same line (one key=value verdict line — never a second line); the
+`Next:` hint then prints on its own separate line.
+
+Base success line (always):
 
 ```
 [OK] devx:mise-migrate path=<path> backend=<backend> py=<ver> tasks=<n>
 ```
 
-### On `--apply`, append the apply fields
+On `--apply`, append the apply fields to that **same** line:
 
 ```
-synced=yes cleaned=<.venv,egg-info|kept> docs=<rewrote-N|scan-only>
+[OK] devx:mise-migrate path=<path> backend=<backend> py=<ver> tasks=<n> synced=yes cleaned=<.venv,egg-info|kept> docs=<rewrote-N|scan-only>
 ```
 
-After a successful apply, hint:
+Then print the next-step hint on its **own** line:
 
-```
-Next: mise run test
-```
-
-### On `--dry-run`, append the next-step hint
-
-```
-Next: review the plan, then re-run with --apply
-```
+- `--dry-run` → `Next: review the plan, then re-run with --apply`
+- successful `--apply` → `Next: mise run test`
 
 ## Carried-over notes (both modes)
 

--- a/claude/skills/devx-mise-migrate/references/output-format.md
+++ b/claude/skills/devx-mise-migrate/references/output-format.md
@@ -1,0 +1,51 @@
+# Output & report formats — dry-run plan + final report
+
+Used by Step 3 (dry-run plan) and Step 5 (final report). Print these
+verbatim, substituting the `<...>` fields.
+
+## Dry-run plan block (Step 3, `--dry-run` default)
+
+After printing all four artifacts, end with this block and stop — mutate
+nothing:
+
+```
+Plan ready: <path> (backend=<backend>, py=<ver>, tasks=<n>, stale=<s>)
+Run with --apply to write mise.toml, rewrite pyproject, and uv sync.
+```
+
+## Final report (Step 5)
+
+Always emit the success line:
+
+```
+[OK] devx:mise-migrate path=<path> backend=<backend> py=<ver> tasks=<n>
+```
+
+### On `--apply`, append the apply fields
+
+```
+synced=yes cleaned=<.venv,egg-info|kept> docs=<rewrote-N|scan-only>
+```
+
+After a successful apply, hint:
+
+```
+Next: mise run test
+```
+
+### On `--dry-run`, append the next-step hint
+
+```
+Next: review the plan, then re-run with --apply
+```
+
+## Carried-over notes (both modes)
+
+Always re-print any `[WARN]` / `[INFO]` notes so they survive into the
+final surface:
+
+- PEP 735 silent-regression `[WARN]` (dev extra lifted to
+  `[dependency-groups]`) — `references/pyproject-rewrite.md`.
+- Stale legacy references found by the scan — `references/stale-scan.md`.
+- Pin-is-floor `[INFO]` (Python pin came from `requires-python`, no
+  `pyvenv.cfg`) — `references/extraction.md`.


### PR DESCRIPTION
## 요약

`devx:mise-migrate` SKILL.md 를 Progressive Disclosure 원칙으로 리팩터해 100줄 제한 아래로 축소 (123 → 99줄, ↓20%).

오버플로는 두 곳에 몰려 있었음: Step 1 의 탐지 결정 규칙과 Step 3/5 의 인라인 출력·리포트 템플릿. 둘 다 references/ 로 추출하고 SKILL.md 본문은 컨트롤 타워(phase + 포인터)만 남김.

## 변경 사항

- **references/detection.md** (신규) — Step 1 legacy-Python 탐지 결정 트리: nested-fallback retarget, already-migrated short-circuit, refusal 메시지 + exit code, `.venv` 부재가 fatal 이 아니라는 신호 노트.
- **references/output-format.md** (신규) — dry-run `Plan ready:` 블록, `[OK]` 성공 라인, `--apply` append 필드, dry-run/apply `Next:` 힌트, 캐리오버 `[WARN]`/`[INFO]` 노트 규칙.
- **SKILL.md** — 추출 블록을 포인터 라인으로 대체, 단계 설명 압축. **frontmatter 는 바이트 단위 보존** (긴 description = 트리거 정확도, `name: devx:mise-migrate` 콜론 SSOT 유지).

## 검증

- `skill:check`: **12/12 PASS** (License·Capability 2건 N/A) → EXCELLENT — gold standard
- 9개 reference 파일 전부 SKILL.md 에서 도달 가능, orphan 없음
- 이모지 0, pre-commit 훅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
