### PR TITLE
fix(claude-setup): claude-accounts status skills/workflows 진단 오탐 + plugin 경로 마이그레이션 churn 수정

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -193,34 +193,6 @@ _migrate_legacy_statusline_command() {
     fi
 }
 
-# Resolve the currently active Claude Code config directory used as the
-# canonical prefix for plugin state migration.
-#
-# Detection order (issue: multi-account installLocation prefix mismatch):
-#   1. $CLAUDE_CONFIG_DIR if set (Claude Code's own override)
-#   2. $HOME/.claude — only when _dotfiles_setup_mode says we are in
-#      `internal` (single-account) mode. In multi-account mode the
-#      script later (~L578) creates ~/.claude as an empty guard dir, so
-#      a bare `[ -d ~/.claude ]` filesystem test would falsely succeed
-#      and the migration would normalize prefixes to the guard path.
-#      Gate by the SSOT mode helper instead.
-#   3. $HOME/.claude-personal (multi-account default — backward compat
-#      with the original #340 migration target)
-#
-# Prints the absolute dir on stdout (no trailing slash). Never fails.
-_current_claude_config_dir() {
-    if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
-        printf '%s' "${CLAUDE_CONFIG_DIR%/}"
-        return 0
-    fi
-    if command -v _dotfiles_setup_mode >/dev/null 2>&1 \
-       && [ "$(_dotfiles_setup_mode)" = "internal" ]; then
-        printf '%s' "${HOME}/.claude"
-        return 0
-    fi
-    printf '%s' "${HOME}/.claude-personal"
-}
-
 # Auto-migrate stale Claude Code plugin paths (issue #340 + multi-account
 # follow-up).
 #
@@ -245,12 +217,26 @@ _current_claude_config_dir() {
 #     (.plugins[<key>][<idx>].installPath)
 _migrate_legacy_plugin_paths() {
     local plugins_root="${HOME}/.claude-shared/plugins"
-    local new_prefix
-    new_prefix="$(_current_claude_config_dir)/plugins/"
+    # Normalize to the *shared* physical plugin dir, NOT the active account's
+    # dir. Every per-account ~/.claude-<acct>/plugins is a symlink INTO
+    # ~/.claude-shared/plugins (wired by _claude_ensure_symlink in
+    # _claude_account_setup_one), and installed_plugins.json itself lives in
+    # the shared dir and is read by *all* accounts. The previous code aimed
+    # at the active account's dir (~/.claude-<active>/plugins/), which made
+    # the recorded prefix volatile: switching the active account and re-running
+    # setup
+    # rewrote every path to the new account (2건씩 재마이그레이션 + backup
+    # 덮어쓰기) even though nothing physically moved — all prefixes resolve
+    # through the symlink to the same shared files anyway. The shared dir is
+    # a stable fixed point, so the migration converges and later runs are
+    # 0건 regardless of which account is active when setup runs.
+    local new_prefix="${plugins_root}/"
     # Match any ${HOME}/.claude(-suffix)?/plugins/ — the legacy ${HOME}/.claude/
-    # form from #340 plus every per-account variant. $HOME is interpolated
-    # literally (not as a regex), so an unusual $HOME containing regex
-    # meta-chars would over-match; acceptable for our environment.
+    # form from #340 plus every per-account variant (.claude-shared itself
+    # matches too, so already-normalized entries skip via the startswith($new)
+    # guard in the jq filters). $HOME is interpolated literally (not as a
+    # regex), so an unusual $HOME containing regex meta-chars would
+    # over-match; acceptable for our environment.
     local old_regex="^${HOME}/\\.claude(-[A-Za-z0-9_]+)?/plugins/"
 
     [ -d "$plugins_root" ] || return 0

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -973,7 +973,7 @@ claude_accounts_status() {
             echo "                → Run: claude-yolo --user $_cas_acct"
         fi
 
-        for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory skills docs; do
+        for _cas_link in settings.json settings.local.json statusline-command.sh plugins projects/GLOBAL/memory skills docs workflows; do
             if [ "$_cas_link" = "settings.json" ]; then
                 # settings.json is a real-file copy since #940 (was a
                 # symlink) — a symlink here is the legacy write-through
@@ -997,6 +997,15 @@ claude_accounts_status() {
                 # file (#584), never a symlink — report it as present
                 # rather than missing (gemini review on PR #590).
                 echo "  $_cas_link: regular file ✓"
+            elif [ "$_cas_link" = "skills" ] && [ -d "$_cas_cdir/$_cas_link" ]; then
+                # skills/ is an entry-level *composed directory* since #707
+                # (F-8), not a symlink — _claude_compose_skills_dir fills it
+                # with per-skill links so a private company-skills overlay
+                # can layer in. Without this branch the diagnostic fell to
+                # the else arm and wrongly reported "✗ missing" even though
+                # setup.sh's own verify confirmed the dir (this loop never
+                # learned the #707 layout change).
+                echo "  $_cas_link: composed dir ✓"
             else
                 echo "  $_cas_link: ✗ missing"
             fi

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -1434,6 +1434,7 @@ settings.json|${_car_claude_src}/settings.json
 statusline-command.sh|${_car_claude_src}/statusline-command.sh
 skills|${_car_claude_src}/skills
 docs|${_car_claude_src}/docs
+workflows|${_car_claude_src}/workflows
 projects/GLOBAL/memory|${_car_claude_src}/global-memory
 EOF
     done

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -395,6 +395,28 @@ SH
     assert_output --partial "Account: work"
 }
 
+@test "bash: claude_accounts_status reports skills as composed dir, not missing (#707 regression)" {
+    # skills/ became a real composed directory in #707 (F-8). The status
+    # loop only knew symlink / real-file shapes, so the real dir fell to
+    # the else arm and printed "skills: ✗ missing" even though setup.sh's
+    # own verify confirmed the dir — a false negative the diagnostic showed.
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs" "${DOTFILES_ROOT}/claude/workflows"
+    run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init && CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
+    assert_success
+    assert_output --partial "skills: composed dir ✓"
+    refute_output --partial "skills: ✗ missing"
+}
+
+@test "bash: claude_accounts_status reports workflows symlink (#707 regression)" {
+    # The status loop omitted workflows entirely, so a broken workflows
+    # link would never surface at diagnosis time even though setup.sh
+    # creates and verifies it.
+    mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs" "${DOTFILES_ROOT}/claude/workflows"
+    run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_init && CLAUDE_ENABLED_ACCOUNTS=personal claude_accounts_status'
+    assert_success
+    assert_output --partial "workflows: symlink ✓"
+}
+
 @test "bash: claude_accounts_status reports NOT logged in when no .credentials.json" {
     mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
     run_in_bash 'CLAUDE_SKIP_BIND_MOUNT=1 claude_accounts_init && claude_accounts_status'


### PR DESCRIPTION
## 요약

`claude-accounts status` 진단 출력의 오탐 2건과 plugin 경로 마이그레이션의 churn 1건을 수정한다. setup.sh 의 자체 verify 는 정상이라고 보고하는데 `claude-accounts status` 만 모순된 결과를 내던 stale 진단 코드가 근본 원인이다.

## 배경 (재현)

```
$ ./claude/setup.sh
✓ work1/skills entry-level 합성 디렉토리 확인됨      # setup 은 정상
$ claude-accounts status
  skills: ✗ missing                                  # 진단은 missing (모순)
```

## 변경 내용

- **skills 오탐 수정** — skills 는 #707(F-8) 이후 symlink 가 아니라 entry-level 합성 *실디렉토리* 인데, `claude_accounts_status` 루프에 실디렉토리 분기가 없어 `else → "✗ missing"` 으로 떨어졌다. 합성 실디렉토리 분기를 추가해 `composed dir ✓` 로 보고.
- **workflows 진단 누락 수정** — status 루프 목록에 `workflows` 가 빠져 있어, setup 이 만들고 verify 까지 하는 workflows symlink 가 진단에서 침묵 누락됐다. 루프에 추가해 `symlink ✓` 노출.
- **plugin 경로 마이그레이션 churn 수정** — 세 계정의 `plugins` 가 모두 `~/.claude-shared/plugins` 로 가는 symlink 라 경로의 계정 접두사는 무의미한데, 마이그레이션 대상 prefix 가 "현재 active 계정" 기준이었다. 그래서 계정을 바꿔가며 setup 을 돌리면 같은 경로를 매번 재마이그레이션(+backup 덮어쓰기)하는 churn 이 발생했다 (실제 파일도 personal 8 / work1 2 로 섞여 있었음). 고정점인 `~/.claude-shared/plugins/` 로 변경해 1회 정규화 후 영구 0건 수렴.
- 위 변경으로 미사용이 된 `_current_claude_config_dir` 헬퍼 + doc 주석 제거.

## 테스트

- `claude_accounts_status` 진단 회귀 테스트 2건 추가 (skills `composed dir ✓` / workflows `symlink ✓`) — 둘 다 통과.
- `claude_accounts.bats` 기존 실패 11건은 변경 전후 동일 (setup.sh 전체실행 테스트가 격리 dotfiles 에 `claude/workflows` 를 안 만들어 발생하는 워크트리 baseline 이슈, 본 변경과 무관). 신규 실패 0.
- `sh -n` / `bash -n` 구문 검증, shellcheck (기존 SC3043 외 신규 경고 없음), shfmt 변경 라인 무차이 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
