### PR TITLE
feat(help): window-help 토픽 + fix(compact-wsl) 단일 배포판 자동 선택

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -159,7 +159,7 @@ _register_default_help_categories() {
 
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool ghes_mirror mirror_pages_activate}"
-    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check sync_to_deploy}"
+    HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check window sync_to_deploy}"
     HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc gemini codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux del_file}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip ghostty}"
@@ -221,6 +221,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[litellm_help]="${HELP_DESCRIPTIONS[litellm_help]:-[AI/LLM] LiteLLM proxy and routing}"
     HELP_DESCRIPTIONS[gpu_help]="${HELP_DESCRIPTIONS[gpu_help]:-[DevOps] GPU monitoring (WSL)}"
     HELP_DESCRIPTIONS[wsl_check_help]="${HELP_DESCRIPTIONS[wsl_check_help]:-[DevOps] WSL & Docker environment health (disk/mem/docker)}"
+    HELP_DESCRIPTIONS[window_help]="${HELP_DESCRIPTIONS[window_help]:-[DevOps] Windows host PowerShell one-liners (Compact-WSL vhdx)}"
     HELP_DESCRIPTIONS[ux_help]="${HELP_DESCRIPTIONS[ux_help]:-[Development] UX library usage}"
     HELP_DESCRIPTIONS[mytool_help]="${HELP_DESCRIPTIONS[mytool_help]:-[Development] Custom tools and scripts}"
     HELP_DESCRIPTIONS[mysql_help]="${HELP_DESCRIPTIONS[mysql_help]:-[DevOps] MySQL service management}"

--- a/shell-common/functions/window_help.sh
+++ b/shell-common/functions/window_help.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# shell-common/functions/window_help.sh
+# Help for Windows-host PowerShell one-liners (WSL vhdx compaction, etc.).
+# Registered under the `devops` category in functions/my_help.sh.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# raw URL — Compact-WSL.ps1 remote one-liner (SSOT: windows/Compact-WSL.ps1)
+WINDOW_COMPACT_WSL_URL="https://raw.githubusercontent.com/dEitY719/dotfiles/main/windows/Compact-WSL.ps1"
+
+_window_help_summary() {
+    ux_section "window — Windows host PowerShell helpers (run on Windows, not WSL)"
+    ux_bullet "Compact-WSL.ps1: shrink the WSL2 ext4.vhdx + optional Windows cleanup."
+    ux_bullet_sub "Run in PowerShell on the Windows host — NOT inside WSL"
+    ux_bullet_sub "('wsl --shutdown' terminates this very session)."
+
+    ux_section "Compact-WSL — remote one-liner (admin PowerShell)"
+    ux_bullet "iex (irm '${WINDOW_COMPACT_WSL_URL}')"
+
+    ux_section "From a non-admin shell (auto-elevates)"
+    ux_bullet "powershell -ExecutionPolicy Bypass -Command \"iex (irm '${WINDOW_COMPACT_WSL_URL}')\""
+
+    ux_section "Pass parameters (iex can't take args — use a scriptblock)"
+    ux_bullet "& ([scriptblock]::Create((irm '${WINDOW_COMPACT_WSL_URL}'))) -DistroName \"Ubuntu\""
+
+    ux_section "Notes"
+    ux_bullet "A single registered WSL2 distro is auto-selected — no -DistroName needed."
+    ux_bullet "WSL-side disk/health checks: my-help wsl_check"
+}
+
+window_help() {
+    case "${1:-}" in
+    -h | --help | help | "") _window_help_summary ;;
+    *) _window_help_summary ;;
+    esac
+}
+
+alias window-help='window_help'

--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -25,6 +25,9 @@
     # 일반 PowerShell에서 (자동 권한 상승 포함):
     powershell -ExecutionPolicy Bypass -Command "iex (irm 'https://raw.githubusercontent.com/dEitY719/dotfiles/main/windows/Compact-WSL.ps1')"
 
+    # 원격 실행 + 파라미터 전달 (iex 는 인자를 못 받으므로 scriptblock 사용):
+    & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/dEitY719/dotfiles/main/windows/Compact-WSL.ps1'))) -DistroName "Ubuntu"
+
     # 파일로 저장 후 실행:
     .\Compact-WSL.ps1
     .\Compact-WSL.ps1 -UseSparse
@@ -96,12 +99,25 @@ Write-Host "[1/5] vhdx 경로 탐색 중..." -ForegroundColor Green
 $lxssRoot = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss"
 $basePath = $null
 
+# 등록된 WSL2 배포판 전체 수집 (vhdx 기반 = Version 2 만 압축 대상)
+$distros = @()
 foreach ($key in (Get-ChildItem $lxssRoot -ErrorAction SilentlyContinue)) {
     $props = Get-ItemProperty $key.PSPath
-    if ($props.DistributionName -eq $DistroName) {
-        $basePath = $props.BasePath
-        break
-    }
+    if ($props.Version -ne 2) { continue }
+    $distros += [pscustomobject]@{ Name = $props.DistributionName; BasePath = $props.BasePath }
+}
+
+# 1) 이름 정확 일치
+$match = $distros | Where-Object { $_.Name -eq $DistroName } | Select-Object -First 1
+if ($match) {
+    $basePath = $match.BasePath
+}
+# 2) 일치 없음 + 배포판이 하나뿐이면 자동 선택 (이름 몰라도 동작)
+elseif ($distros.Count -eq 1) {
+    Write-Host "[!] '$DistroName' 을(를) 찾지 못했지만 등록된 WSL2 배포판이 하나뿐이라 자동 선택합니다." -ForegroundColor Yellow
+    $DistroName = $distros[0].Name
+    $basePath   = $distros[0].BasePath
+    Write-Host "    대상 배포판: $DistroName`n" -ForegroundColor Yellow
 }
 
 if (-not $basePath) {

--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -102,8 +102,9 @@ $basePath = $null
 # 등록된 WSL2 배포판 전체 수집 (vhdx 기반 = Version 2 만 압축 대상)
 $distros = @()
 foreach ($key in (Get-ChildItem $lxssRoot -ErrorAction SilentlyContinue)) {
-    $props = Get-ItemProperty $key.PSPath
-    if ($props.Version -ne 2) { continue }
+    $props = Get-ItemProperty $key.PSPath -ErrorAction SilentlyContinue
+    # 손상/비정상 키 방어: 조회 실패 또는 필수 속성 누락 시 건너뜀
+    if (-not $props -or $props.Version -ne 2 -or -not $props.DistributionName -or -not $props.BasePath) { continue }
     $distros += [pscustomobject]@{ Name = $props.DistributionName; BasePath = $props.BasePath }
 }
 


### PR DESCRIPTION
## Summary

Windows 호스트에서 `Compact-WSL.ps1`(WSL2 vhdx 압축)을 더 쉽게 실행할 수 있도록 두 가지를 추가/수정합니다.

1. **fix(compact-wsl)** — 배포판 이름 불일치 시 단일 WSL2 배포판 자동 선택
2. **feat(help)** — 셸에서 원격 실행 명령을 바로 조회하는 `window-help` 토픽 추가

## fix(compact-wsl): 단일 배포판 자동 선택

기본값 `-DistroName "Ubuntu-24.04"` 와 실제 배포판 이름(예: `Ubuntu`)이 다르면 레지스트리 탐색이 실패해 무조건 `throw` 되었고, 원격 one-liner(`iex (irm ...)`) 사용자는 인자 없이 실행할 수 없었습니다.

- Lxss 레지스트리에서 WSL2(Version 2) 배포판 전체 수집
- 이름 정확 일치 우선 → 없으면 등록 배포판이 하나뿐일 때 자동 선택
- 여러 개면 기존대로 목록 출력 + `throw` (명시적 선택 요구)
- 헤더에 scriptblock 기반 파라미터 전달 one-liner 예제 추가

## feat(help): window-help 토픽

`shell-common/AGENTS.md` 의 3-step 패턴 준수.

- `functions/window_help.sh` 신규: `window_help()` + `alias window-help`
  (admin / 비-admin / 파라미터 전달 one-liner 3종 + WSL 호스트 주의사항)
- `my_help.sh` devops 카테고리에 `window` 등록 + `HELP_DESCRIPTIONS` 항목

## Test

- `shellcheck -x` : `window_help.sh` 클린
- bash·zsh 양쪽에서 `window-help`, `my-help window`(라우팅), `my-help devops`(목록 노출) 검증 완료
- pre-commit 훅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
