### PR TITLE
fix(compact-wsl): diskpart 로그 한글 깨짐 수정 (OEM 코드페이지 디코딩)

### DIFF
--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -187,11 +187,19 @@ exit
 
     # diskpart 는 콘솔 OEM 코드페이지(한국어 Windows=CP949)로 로그를 쓴다.
     # StreamReader 기본값(UTF-8)으로 읽으면 한글이 깨지므로 OEM 인코딩으로 디코딩한다.
-    $oemEncoding = [System.Text.Encoding]::GetEncoding(
-        [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.OEMCodePage)
+    # GetEncoding 은 비정상 코드페이지에서 ArgumentException 을 던질 수 있고
+    # $ErrorActionPreference="Stop" 이라 전체 중단될 수 있으므로 콘솔 출력
+    # 인코딩으로 폴백한다.
+    $oemEncoding = try {
+        [System.Text.Encoding]::GetEncoding(
+            [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.OEMCodePage)
+    } catch {
+        [System.Console]::OutputEncoding
+    }
 
     # diskpart 가 로그를 쓰는 중에도 읽을 수 있도록 공유 모드로 연다
-    function Get-SharedText([string]$path, [System.Text.Encoding]$encoding) {
+    function Get-SharedText([string]$path, [System.Text.Encoding]$encoding = [System.Text.Encoding]::UTF8) {
+        if ($null -eq $encoding) { $encoding = [System.Text.Encoding]::UTF8 }
         $fs = $null
         $sr = $null
         try {

--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -185,13 +185,18 @@ exit
     $proc = Start-Process diskpart.exe -ArgumentList "/s `"$tmp`"" `
         -PassThru -NoNewWindow -RedirectStandardOutput $logOut
 
+    # diskpart 는 콘솔 OEM 코드페이지(한국어 Windows=CP949)로 로그를 쓴다.
+    # StreamReader 기본값(UTF-8)으로 읽으면 한글이 깨지므로 OEM 인코딩으로 디코딩한다.
+    $oemEncoding = [System.Text.Encoding]::GetEncoding(
+        [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.OEMCodePage)
+
     # diskpart 가 로그를 쓰는 중에도 읽을 수 있도록 공유 모드로 연다
-    function Get-SharedText([string]$path) {
+    function Get-SharedText([string]$path, [System.Text.Encoding]$encoding) {
         $fs = $null
         $sr = $null
         try {
             $fs = [System.IO.File]::Open($path, 'Open', 'Read', 'ReadWrite')
-            $sr = New-Object System.IO.StreamReader($fs)
+            $sr = New-Object System.IO.StreamReader($fs, $encoding)
             return $sr.ReadToEnd()
         } catch {
             return ''
@@ -215,7 +220,7 @@ exit
     Write-Host ""   # 진행 바를 그릴 빈 줄 확보
 
     while (-not $proc.HasExited) {
-        $raw = Get-SharedText $logOut
+        $raw = Get-SharedText $logOut $oemEncoding
         $m   = $pctRe.Matches($raw)
         $pct = if ($m.Count) { [int]$m[$m.Count - 1].Groups[1].Value } else { -1 }
 
@@ -236,7 +241,7 @@ exit
 
     if ($proc.ExitCode -ne 0) {
         Write-Host "  [!] diskpart 종료 코드 $($proc.ExitCode) — 로그 확인:" -ForegroundColor Yellow
-        Get-SharedText $logOut | Write-Host
+        Get-SharedText $logOut $oemEncoding | Write-Host
     }
     Remove-Item $tmp, $logOut -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## 요약

`windows/Compact-WSL.ps1` 의 diskpart 로그 출력이 PowerShell 콘솔에서 한글이 깨지는(mojibake) 문제를 수정한다.

원격 실행 시 diskpart 종료 코드가 0 이 아닐 때 로그를 그대로 보여주는데, 다음과 같이 한글이 전부 깨져 나왔다:

```
Microsoft DiskPart ???? 10.0.26100.1150
...
DiskPart?? ?? ??? ?????.
```

## 원인

`diskpart.exe` 는 리다이렉트된 표준출력 로그를 **콘솔 OEM 코드페이지**(한국어 Windows = CP949)로 기록한다. `Get-SharedText` 가 인코딩 지정 없이 `StreamReader` 를 생성하면서 .NET 기본값인 UTF-8 로 디코딩 → CP949 바이트가 깨진 문자로 출력됐다.

## 변경

- `Get-SharedText` 에 `[System.Text.Encoding]$encoding` 파라미터 추가
- `CurrentCulture.TextInfo.OEMCodePage` 로 만든 `Encoding` 을 `StreamReader` 에 전달
- 진행률 폴링 루프와 종료 코드 로그 출력 두 호출부에서 OEM 인코딩 전달

로케일별 OEM 코드페이지가 자동 선택되므로 한국어 외 환경에서도 올바르게 디코딩된다. 진행률 정규식의 `퍼센트` 한글 매칭도 함께 정상 동작하게 된다.

## 검증

- Linux 환경이라 `pwsh` 미설치 → 실행 검증 불가. PowerShell/.NET API(`System.Text.Encoding.GetEncoding`, `StreamReader(stream, encoding)`) 정합성으로 검증.
- 변경 범위는 인코딩 디코딩 한정, 압축 로직 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
