### PR TITLE
feat(git): route github.com HTTPS auth through gh credential helper

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -3,7 +3,6 @@
 	name = dEitY719
 [credential]
 	helper = store
-	useHttpPath = true
 [core]
 	editor = code --wait
 	hooksPath = ~/.config/git/hooks
@@ -24,6 +23,8 @@
 [credential "https://github.com"]
 	helper =
 	helper = !gh auth git-credential
+	useHttpPath = true
 [credential "https://gist.github.com"]
 	helper =
 	helper = !gh auth git-credential
+	useHttpPath = true

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -3,6 +3,7 @@
 	name = dEitY719
 [credential]
 	helper = store
+	useHttpPath = true
 [core]
 	editor = code --wait
 	hooksPath = ~/.config/git/hooks
@@ -20,3 +21,9 @@
 	autoSetupRemote = true
 [fetch]
 	prune = true
+[credential "https://github.com"]
+	helper =
+	helper = !gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !gh auth git-credential


### PR DESCRIPTION
## Summary

`git/.gitconfig` 에 GitHub HTTPS 인증을 `gh` credential helper 로 라우팅하는 설정을 추가합니다 (`gh auth setup-git` 결과를 포터블하게 정리).

## Changes

- `[credential] useHttpPath = true` — 토큰을 path 단위로 스코프
- `[credential "https://github.com"]` / `[credential "https://gist.github.com"]` — 기존 helper 리셋 후 `gh auth git-credential` 로 위임
- helper 경로는 absolute `/usr/bin/gh` 대신 PATH 기반 포터블 `gh` 사용 — repo 의 no-absolute-path 컨벤션(00aa24a7)과 일치, 듀얼 PC 환경 호환

## Scope / Safety

- public GitHub(github.com / gist.github.com) 에만 적용 — GHES/사내 remote 는 영향 없음
- 기존 전역 `helper = store` 는 유지 (다른 호스트용 폴백)
