### PR TITLE
fix(gcp-scan): preflight cherry-pick -n 충돌 마커가 ~/.gitconfig 오염시키는 버그 차단

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -68,28 +68,49 @@ _gcp_scan_preflight_is_noop() {
         fi
     fi
     # Self-protection against a config-poisoning probe (issue #1016). When the
-    # probed commit edits `git/.gitconfig` (symlinked from ~/.gitconfig) and the
-    # `cherry-pick -n` below conflicts, git writes conflict markers straight into
-    # the symlink target. From that instant EVERY subsequent git invocation —
-    # including the `git reset --hard HEAD` recovery — dies with
-    # `fatal: bad config line N`, so the markers can never be cleared. Snapshot
-    # the real config file first with a plain `cp` (no git needed) so we can
-    # restore it the moment the probe fails, before touching git again.
-    local _gcfg_real="" _gcfg_bak=""
+    # probed commit edits `git/.gitconfig` (symlinked from ~/.gitconfig), the
+    # `cherry-pick -n` below can leave the symlink target unreadable by git:
+    # a conflict writes `<<<<<<<` markers into it, and even a clean apply may
+    # stage a syntactically broken .gitconfig carried by the commit itself.
+    # From that instant EVERY subsequent git invocation — including the
+    # `git reset --hard HEAD` recovery — dies with `fatal: bad config line N`,
+    # so the breakage can never be cleared. Snapshot the real config file first
+    # with a plain `cp` (no git needed) so we can restore it before git reads it.
+    local _gcfg_real="" _gcfg_bak="" _gcp_cp_rc=0
+    # Resolve the file behind ~/.gitconfig portably: prefer GNU `readlink -f`,
+    # fall back to plain `readlink` + manual absolutisation for BSD/macOS (where
+    # `-f` is unsupported, PR #1018 review), then to the path itself when it is a
+    # regular (non-symlink) file.
     _gcfg_real=$(readlink -f "${HOME}/.gitconfig" 2>/dev/null)
-    if [ -n "$_gcfg_real" ] && [ -f "$_gcfg_real" ]; then
-        _gcfg_bak=$(mktemp 2>/dev/null) && cp "$_gcfg_real" "$_gcfg_bak" 2>/dev/null ||
-            _gcfg_bak=""
+    if [ -z "$_gcfg_real" ]; then
+        _gcfg_real=$(readlink "${HOME}/.gitconfig" 2>/dev/null)
+        if [ -n "$_gcfg_real" ]; then
+            case "$_gcfg_real" in
+                /*) ;;
+                *) _gcfg_real="${HOME}/${_gcfg_real}" ;;
+            esac
+        else
+            _gcfg_real="${HOME}/.gitconfig"
+        fi
     fi
-    if git cherry-pick -n "$sha" >/dev/null 2>&1; then
+    if [ -n "$_gcfg_real" ] && [ -f "$_gcfg_real" ]; then
+        # Explicit template + fallback dir keeps mktemp portable to BSD/macOS,
+        # where a bare `mktemp` errors out (PR #1018 review).
+        _gcfg_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null) &&
+            cp "$_gcfg_real" "$_gcfg_bak" 2>/dev/null || _gcfg_bak=""
+    fi
+    git cherry-pick -n "$sha" >/dev/null 2>&1 || _gcp_cp_rc=$?
+    # Restore the working-tree gitconfig UNCONDITIONALLY and immediately, before
+    # any further git command reads it — covers both the conflict path and the
+    # clean-apply-of-broken-config path (PR #1018 review). `cp` touches only the
+    # worktree, never the index, so the staged-diff no-op verdict below is
+    # unaffected.
+    if [ -n "$_gcfg_bak" ] && [ -f "$_gcfg_bak" ]; then
+        cp "$_gcfg_bak" "$_gcfg_real" 2>/dev/null
+    fi
+    if [ "$_gcp_cp_rc" -eq 0 ]; then
         git diff --cached --quiet && result=0
     else
-        # Restore the (possibly marker-poisoned) gitconfig with `cp` BEFORE any
-        # further git call, otherwise `git diff`/`git reset` below fail fatally
-        # and the markers leak into the live ~/.gitconfig (issue #1016).
-        if [ -n "$_gcfg_bak" ] && [ -f "$_gcfg_bak" ]; then
-            cp "$_gcfg_bak" "$_gcfg_real" 2>/dev/null
-        fi
         conflicted=$(git diff --name-only --diff-filter=U)
         # Only a real merge conflict is eligible for the context-drift no-op
         # verdict. An EMPTY list means `cherry-pick -n` failed fatally (bad

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -67,9 +67,29 @@ _gcp_scan_preflight_is_noop() {
             return 1
         fi
     fi
+    # Self-protection against a config-poisoning probe (issue #1016). When the
+    # probed commit edits `git/.gitconfig` (symlinked from ~/.gitconfig) and the
+    # `cherry-pick -n` below conflicts, git writes conflict markers straight into
+    # the symlink target. From that instant EVERY subsequent git invocation —
+    # including the `git reset --hard HEAD` recovery — dies with
+    # `fatal: bad config line N`, so the markers can never be cleared. Snapshot
+    # the real config file first with a plain `cp` (no git needed) so we can
+    # restore it the moment the probe fails, before touching git again.
+    local _gcfg_real="" _gcfg_bak=""
+    _gcfg_real=$(readlink -f "${HOME}/.gitconfig" 2>/dev/null)
+    if [ -n "$_gcfg_real" ] && [ -f "$_gcfg_real" ]; then
+        _gcfg_bak=$(mktemp 2>/dev/null) && cp "$_gcfg_real" "$_gcfg_bak" 2>/dev/null ||
+            _gcfg_bak=""
+    fi
     if git cherry-pick -n "$sha" >/dev/null 2>&1; then
         git diff --cached --quiet && result=0
     else
+        # Restore the (possibly marker-poisoned) gitconfig with `cp` BEFORE any
+        # further git call, otherwise `git diff`/`git reset` below fail fatally
+        # and the markers leak into the live ~/.gitconfig (issue #1016).
+        if [ -n "$_gcfg_bak" ] && [ -f "$_gcfg_bak" ]; then
+            cp "$_gcfg_bak" "$_gcfg_real" 2>/dev/null
+        fi
         conflicted=$(git diff --name-only --diff-filter=U)
         # Only a real merge conflict is eligible for the context-drift no-op
         # verdict. An EMPTY list means `cherry-pick -n` failed fatally (bad
@@ -86,6 +106,7 @@ _gcp_scan_preflight_is_noop() {
             git diff --cached --quiet && result=0
         fi
     fi
+    [ -n "$_gcfg_bak" ] && rm -f "$_gcfg_bak"
     git reset --hard HEAD >/dev/null 2>&1
     [ "$had_stash" -eq 1 ] && git stash pop -q >/dev/null 2>&1
     return $result


### PR DESCRIPTION
## 요약

`gcp scan` 의 preflight 프로브 `_gcp_scan_preflight_is_noop` 가
`git/.gitconfig`(=`~/.gitconfig` symlink)를 수정하는 커밋을
`git cherry-pick -n` 으로 프로브하다 충돌이 나면, git 이 충돌 마커를
symlink 타깃 파일에 직접 기록한다. 그 순간부터 복구용 `git reset --hard HEAD`
를 포함한 **모든 후속 git 명령**이 `fatal: bad config line N` 으로 죽어
마커가 영영 제거되지 않고, preflight·cherry-pick 루프가 전부 실패하면서도
`gcp scan` 이 "0 applied / 0 conflicts" 로 오보고된다.

## 변경 내용

`shell-common/functions/gcp_scan.sh` → `_gcp_scan_preflight_is_noop`:

- `cherry-pick -n` **직전** `readlink -f ~/.gitconfig` 의 실파일을
  `mktemp` + `cp` 로 스냅샷
- cherry-pick 실패 분기 진입 **즉시 — 다른 git 호출보다 먼저 —** `cp` 로
  복원하여 git 이 config 를 다시 읽을 수 있게 함 (git 을 거치지 않는 순수
  `cp` 라 config 오염 상태에서도 동작)
- 함수 종료 전 백업 파일 정리(`rm -f`)

## 검증

- 격리 git repo 에서 `~/.gitconfig` 심볼릭링크 충돌 시나리오 재현
  → 패치된 함수 실행 후: **마커 누출 없음 · git 정상 동작 · 파일 HEAD 복원 ·
  백업 정리** 모두 PASS
- shellcheck: 신규 경고 없음 (SC3043 `local` 은 파일 전반 기존 패턴)
- bats: 워크트리 submodule 미체크아웃으로 skip — 기능 검증으로 대체

## Acceptance Criteria

- [x] `git/.gitconfig` 수정 커밋이 포함된 `gcp scan` 이 충돌 없이 완료
- [x] preflight 이후 `git status` 등 정상 동작
- [x] 마커 잔존으로 인한 `fatal: bad config line` 재발 없음

Closes #1016
