### PR TITLE
feat(statusline): add --user account tag from CLAUDE_CONFIG_DIR

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -77,7 +77,9 @@ fi
 # Tag = uppercase first letter + trailing digits:
 #   personal → P   work → W   work1 → W1
 account_info=""
-account_dir=$(basename "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")
+account_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+account_dir="${account_dir%/}"    # tolerate a trailing slash
+account_dir="${account_dir##*/}"  # basename via param expansion (no fork)
 case "$account_dir" in
 .claude-*)
     account="${account_dir#.claude-}"

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -10,6 +10,7 @@ GREEN='\033[32m'
 RED='\033[31m'
 MAGENTA='\033[35m'
 BLUE='\033[34m'
+BOLD='\033[1m'
 RESET='\033[0m'
 
 # Read JSON input from stdin
@@ -70,6 +71,23 @@ elif [[ "$model_name" == *"Opus"* ]]; then
 else
     model_emoji="🧠" # Default - brain
 fi
+
+# Active account tag from CLAUDE_CONFIG_DIR (set by `claude-yolo --user <name>`).
+# Convention: ~/.claude-<name> → <name>; bare ~/.claude → single-account (no tag).
+# Tag = uppercase first letter + trailing digits:
+#   personal → P   work → W   work1 → W1
+account_info=""
+account_dir=$(basename "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")
+case "$account_dir" in
+.claude-*)
+    account="${account_dir#.claude-}"
+    acct_first="${account:0:1}"
+    acct_first="${acct_first^^}"      # bash uppercase
+    acct_digits="${account##*[!0-9]}" # trailing run of digits (empty if none)
+    user_tag="${acct_first}${acct_digits}"
+    account_info="${BOLD}👤 ${user_tag}${RESET}"
+    ;;
+esac
 
 # Extract last folder name from current directory
 project_name=""
@@ -242,6 +260,9 @@ fi
 # Output format with colors and emojis
 # Time: Cyan, Model: Orange, Project+Branch: Magenta, Context: Blue, Cost: varies, Git status: Red/Orange/Green
 out="${CYAN}${time_emoji} ${current_time}${RESET} | ${ORANGE}${model_emoji} ${model_name}${RESET} | ${MAGENTA}${project_branch}${RESET}"
+if [[ -n "$account_info" ]]; then
+    out="${account_info} | ${out}"
+fi
 if [[ -n "$ctx_info" ]]; then
     out="${out} | ${ctx_info}"
 fi


### PR DESCRIPTION
## 변경 사항

`claude/statusline-command.sh` 맨 앞에 현재 활성 Claude 계정을
사람 이모지 + 태그(예: `👤 W1`)로 표시합니다.

`claude-yolo --user <name>` 으로 띄운 계정은 statusline 프로세스에
`CLAUDE_CONFIG_DIR=~/.claude-<name>` 로 주입되므로, 이 환경변수에서
계정명을 파생합니다.

## 태그 규칙

`<name>` 의 **첫 글자 대문자 + 끝자리 숫자**:

| 계정 | CLAUDE_CONFIG_DIR | 태그 |
|------|-------------------|------|
| personal | `~/.claude-personal` | `👤 P` |
| work | `~/.claude-work` | `👤 W` |
| work1 | `~/.claude-work1` | `👤 W1` |

규칙 기반이라 향후 `work2` 추가 시 코드 수정 없이 `👤 W2` 로 표시됩니다.

## 단일 계정 폴백

bare `~/.claude` (단일 계정 / `CLAUDE_CONFIG_DIR` 미설정) 는 태그
세그먼트를 **생략**합니다 — `ctx`/`cost` 세그먼트와 동일한 조건부
출력 방식이라 사내 단일 계정 PC 출력은 그대로 유지됩니다.

## 출력 예시

```
👤 W1 | ☀️ 26-06-23 15:47:06 | 🎭 Opus 4.8 (1M context) | 📁 dotfiles-enhance-1(🌿 wt/enhance/1) | 📝 ✓
```

## 검증

- personal / work / work1 / bare `~/.claude` / 미설정 5가지 시나리오 직접 실행 확인
- shellcheck: clean (claude/ 는 shfmt 스코프 외 — `bash/` 만 shfmt 관리)
- pre-commit 훅 통과
