### PR TITLE
fix(gwt): empty repo 에서 spawn 시 친절한 에러 + 복구 명령 안내

### DIFF
--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1643,6 +1643,18 @@ git_worktree_spawn() {
         return 1
     fi
 
+    # Repo must have at least one commit. A freshly `git init`-ed repo has an
+    # unborn HEAD, so the base ref falls back to "HEAD" (below) and
+    # `git worktree add` dies with the cryptic "fatal: invalid reference: HEAD".
+    # Surface a friendly error + copy-pasteable fix instead.
+    if ! git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+        ux_error "Cannot spawn a worktree: this repository has no commits yet."
+        ux_info "A git worktree needs at least one commit to branch from."
+        ux_info "Create an initial commit first, then re-run gwt spawn:"
+        ux_info '  git commit --allow-empty -m "chore: initial commit to allow empty repository"'
+        return 1
+    fi
+
     # Compute project, parent, next index
     local project parent next_index=1
     project="$(basename "$(git rev-parse --show-toplevel)")"

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -1643,15 +1643,34 @@ git_worktree_spawn() {
         return 1
     fi
 
-    # Repo must have at least one commit. A freshly `git init`-ed repo has an
-    # unborn HEAD, so the base ref falls back to "HEAD" (below) and
-    # `git worktree add` dies with the cryptic "fatal: invalid reference: HEAD".
-    # Surface a friendly error + copy-pasteable fix instead.
-    if ! git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
-        ux_error "Cannot spawn a worktree: this repository has no commits yet."
-        ux_info "A git worktree needs at least one commit to branch from."
-        ux_info "Create an initial commit first, then re-run gwt spawn:"
-        ux_info '  git commit --allow-empty -m "chore: initial commit to allow empty repository"'
+    # Resolve the base ref early so we can verify it before doing any work.
+    # Verifying the resolved $base (rather than HEAD directly) avoids a false
+    # positive when HEAD is unborn but a valid ref like origin/main exists
+    # (e.g. a fresh clone that fetched but never checked out), and it also
+    # catches an invalid user-supplied --base here instead of letting
+    # `git worktree add` die with a cryptic raw error later
+    # (gemini-code-assist review, PR #1020).
+    if [ -z "$base" ]; then
+        if git rev-parse --verify --quiet "origin/main" >/dev/null 2>&1; then
+            base="origin/main"
+        elif git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
+            base="main"
+        else
+            base="HEAD"
+        fi
+    fi
+
+    if ! git rev-parse --verify --quiet "$base" >/dev/null 2>&1; then
+        if [ "$base" = "HEAD" ]; then
+            # Unborn HEAD with no other base — a freshly `git init`-ed repo.
+            ux_error "Cannot spawn a worktree: this repository has no commits yet."
+            ux_info "A git worktree needs at least one commit to branch from."
+            ux_info "Create an initial commit first, then re-run gwt spawn:"
+            ux_info '  git commit --allow-empty -m "chore: initial commit to allow empty repository"'
+        else
+            ux_error "Cannot spawn a worktree: base ref '$base' is invalid."
+            ux_info "Pass an existing branch/commit via --base, or omit it to use origin/main."
+        fi
         return 1
     fi
 
@@ -1692,17 +1711,6 @@ git_worktree_spawn() {
         fi
         break
     done
-
-    # Base ref
-    if [ -z "$base" ]; then
-        if git rev-parse --verify --quiet "origin/main" >/dev/null 2>&1; then
-            base="origin/main"
-        elif git rev-parse --verify --quiet "main" >/dev/null 2>&1; then
-            base="main"
-        else
-            base="HEAD"
-        fi
-    fi
 
     # Create worktree (reuse git_worktree_add for git-crypt safety)
     git_worktree_add "$wt_path" "$branch" "$base" || return 1

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -157,6 +157,39 @@ teardown() {
     assert_output --partial "git commit --allow-empty -m"
 }
 
+@test "bash: spawn with an invalid --base fails with a friendly error (not raw git)" {
+    # gemini-code-assist review (PR #1020): an invalid user-supplied --base
+    # must be caught up front, not surface as a cryptic `git worktree add`
+    # raw error later.
+    run_in_bash "
+        cd '$FAKE_REPO' || exit 1
+        git_worktree_spawn --wt-name feat --base no-such-ref 2>&1
+    "
+    assert_failure
+    assert_output --partial "base ref 'no-such-ref' is invalid"
+    refute_output --partial "invalid reference"
+    refute_output --partial "no commits yet"
+}
+
+@test "bash: spawn succeeds with unborn HEAD when origin/main exists (no false positive)" {
+    # gemini-code-assist review (PR #1020): a repo that has fetched a remote
+    # but never checked out (unborn HEAD + valid origin/main) must still be
+    # able to spawn — the guard checks the resolved base, not HEAD directly.
+    run_in_bash "
+        UNBORN='$TEST_TEMP_HOME/unborn-with-origin'
+        git init -q --initial-branch=main \"\$UNBORN\"
+        cd \"\$UNBORN\" || exit 1
+        git remote add origin '$FAKE_REPO'
+        git fetch -q origin
+        # HEAD is still unborn here, but origin/main resolves.
+        git_worktree_spawn --wt-name feat 2>&1
+        git show-ref --verify --quiet refs/heads/wt/feat/1 && echo BRANCH_OK
+    "
+    assert_success
+    assert_output --partial "Base:   origin/main"
+    assert_output --partial "BRANCH_OK"
+}
+
 @test "bash: spawn auto-increments when branch exists without worktree" {
     run_in_bash "
         cd '$FAKE_REPO' || exit 1

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -124,6 +124,39 @@ teardown() {
     assert_output --partial "--launch"
 }
 
+# ---------------------------------------------------------------------------
+# Empty-repo guard: a freshly `git init`-ed repo has no commits, so the base
+# ref falls back to the unborn HEAD and `git worktree add` dies with the raw
+# `fatal: invalid reference: HEAD`. Surface a friendly error + copy-pasteable
+# fix instead.
+# ---------------------------------------------------------------------------
+
+@test "bash: spawn in an empty repo fails with a friendly error + fix-it command" {
+    run_in_bash "
+        EMPTY_REPO='$TEST_TEMP_HOME/empty-repo'
+        git init -q --initial-branch=main \"\$EMPTY_REPO\"
+        cd \"\$EMPTY_REPO\" || exit 1
+        git_worktree_spawn --wt-name feat 2>&1
+    "
+    assert_failure
+    assert_output --partial "no commits yet"
+    assert_output --partial "git commit --allow-empty -m"
+    # Must NOT leak the raw git error.
+    refute_output --partial "invalid reference: HEAD"
+}
+
+@test "zsh: spawn in an empty repo fails with a friendly error + fix-it command" {
+    run_in_zsh "
+        EMPTY_REPO='$TEST_TEMP_HOME/empty-repo-zsh'
+        git init -q --initial-branch=main \"\$EMPTY_REPO\"
+        cd \"\$EMPTY_REPO\" || exit 1
+        git_worktree_spawn --wt-name feat 2>&1
+    "
+    assert_failure
+    assert_output --partial "no commits yet"
+    assert_output --partial "git commit --allow-empty -m"
+}
+
 @test "bash: spawn auto-increments when branch exists without worktree" {
     run_in_bash "
         cd '$FAKE_REPO' || exit 1


### PR DESCRIPTION
## 배경

커밋이 0개인 갓 `git init` 한 저장소에서 `gwt spawn` 을 실행하면 다음과 같은
불친절한 git raw 에러로 죽었다:

```
fatal: invalid reference: HEAD
```

`git_worktree_spawn` 의 base ref 결정 로직은 `origin/main` → `main` → `HEAD`
순으로 폴백하는데, 빈 저장소에서는 unborn 브랜치라 앞의 둘이 resolvable 하지
않아 `base="HEAD"` 로 떨어진다. 이어 `git worktree add ... HEAD` 가 가리킬
커밋이 없어 실패한다. 이는 **worktree 는 분기할 base 커밋이 최소 1개 필요**
하다는 git 의 근본 제약이 불친절하게 노출된 것이다.

## 변경

- `shell-common/functions/git_worktree.sh` — worktree 가드 직후·base ref
  폴백 **이전**에 unborn HEAD(`git rev-parse --verify --quiet HEAD`)를 감지.
  복사/붙여넣기 가능한 복구 명령을 포함한 친절한 에러로 대체:

  ```
  ❌ Cannot spawn a worktree: this repository has no commits yet.
  ℹ️  A git worktree needs at least one commit to branch from.
  ℹ️  Create an initial commit first, then re-run gwt spawn:
  ℹ️    git commit --allow-empty -m "chore: initial commit to allow empty repository"
  ```

- `tests/bats/functions/git_worktree_spawn.bats` — bash/zsh 양쪽 회귀 테스트
  추가. friendly 메시지(`no commits yet`) + fix-it 명령(`git commit
  --allow-empty -m`) 포함, raw 에러 미누출(`refute_output "invalid reference"`)
  검증.

## 검증 (TDD)

- **RED**: 빈 저장소 테스트가 `fatal: invalid reference: HEAD` 로 먼저 실패함을 확인
- **GREEN**: 가드 추가 후 통과
- 전체 spawn bats 스위트 **61개 통과**, 회귀 없음
- 편집부 `shfmt -i 4` / shellcheck 클린 (파일 전반의 기존 shfmt 차이는 커밋된
  버전에 이미 존재하며 본 변경과 무관, 린트 스코프는 `bash/` 만 대상)

## Acceptance Criteria

- [x] 빈 저장소에서 `gwt spawn` 이 raw `fatal: invalid reference: HEAD` 대신 친절한 에러를 출력
- [x] 에러 메시지에 복사/붙여넣기로 해결 가능한 `git commit --allow-empty -m "..."` 명령 포함
- [x] bash/zsh 양쪽 동작 + 회귀 테스트 추가
