### PR TITLE
fix(claude): tui:fullscreen SSOT 누락으로 work1/personal 계정 statusLine 미표시 (#1021)

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -38,6 +38,7 @@
     "ralph-loop@claude-plugins-official": true,
     "codex@openai-codex": true
   },
+  "tui": "fullscreen",
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark",


### PR DESCRIPTION
## Summary

- `"tui": "fullscreen"` 설정이 `claude/settings.json` SSOT에 누락돼 work1/personal 계정에서 custom statusLine이 표시되지 않았음
- SSOT에 설정 추가 후 `claude/setup.sh` 재실행으로 3개 계정 전파 완료

Closes #1021

## Test plan

- [ ] `grep "tui" ~/.claude-personal/settings.json ~/.claude-work/settings.json ~/.claude-work1/settings.json` — 3개 모두 `"tui": "fullscreen"` 확인
- [ ] `claude-yolo-work1` 또는 `claude-yolo --user personal`로 새 세션 시작 시 custom statusline 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)