### PR TITLE
refactor(docs): 하이브리드 docs 정책 — adr/ 신설 + status 메타 + 파일명 린터

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,7 +1,7 @@
 # Module Context
 
 - **Purpose**: Project documentation, AI agent prompts, learnings, playbooks, archived analyses
-- **5-디렉토리 구조 (#660)**: `.ssot/` (정책) · `requirement/` (제품 요구사항) · `guide/` (사람 가이드) · `feature/` (피처별 설계) · `archive/` (보관소)
+- **6-디렉토리 구조 (#660 5-tier + #1027 `adr/` 하이브리드)**: `.ssot/` (정책) · `requirement/` (제품 요구사항) · `adr/` (아키텍처 결정 로그) · `guide/` (사람 가이드) · `feature/` (피처별 설계) · `archive/` (보관소)
 - **AGENTS.md 라우터 정책**: 정책 본문은 `.ssot/*.md` 에 두고 AGENTS.md 는 요약 + 링크만 유지
 
 # Operational Commands
@@ -9,6 +9,7 @@
 - **Review**: open in markdown viewer (VS Code, grip)
 - **Line count**: `wc -l docs/**/*.md`
 - **Markdown lint**: 비활성화 — 자동 실행 금지
+- **파일명 린트**: `mise run lint-docs` — docs 파일명 kebab-case 검사 (`adr/`·`requirement/` 강제, 나머지 warn-only, #1027)
 
 # Golden Rules
 
@@ -21,21 +22,37 @@
 - **DO**: 사람-팀원 가이드는 `guide/` 하위에 두기 (`guide/learnings/`, `guide/playbooks/`, `guide/technic/`, `guide/superpowers-ko/`)
 - **DON'T**: TODO 마커를 추적 없이 남기기 (`archive/todo-<topic>.md` 처럼 별도 파일로 분리)
 - **DON'T**: 이유 없이 archive 하지 않기 (이동 사유를 `archive/README.md` 또는 커밋 메시지에 남길 것)
-- **DON'T**: `docs/` 루트에 산문 파일 새로 만들지 않기 — 항상 5 개 디렉토리 중 하나로 분류 (AGENTS.md 제외)
+- **DON'T**: `docs/` 루트에 산문 파일 새로 만들지 않기 — 항상 6 개 디렉토리 중 하나로 분류 (AGENTS.md 제외)
+- **DO**: 굵직한 아키텍처 결정은 `adr/NNNN-<kebab>.md` 로 일원화 (제품 요구사항 내 경량 결정은 `requirement/` D-섹션)
+- **DO**: `requirement/`·`feature/`·`adr/` 문서는 front-matter `status:` 메타데이터 포함
 
-## 디렉토리 역할 분담 (5-tier, #660)
+## 디렉토리 역할 분담 (6-tier, #660 + #1027)
 
 | 디렉토리 | 역할 | 인덱스 |
 |---------|------|--------|
 | **`.ssot/`** | 프로젝트 정책 SSOT — 명령 UX, env vars, 보드 운영, 커밋/discussion 규칙 | [`.ssot/README.md`](./.ssot/README.md) |
-| **`requirement/`** | 제품 요구사항 entry SSOT — D (확정 결정) / F (기능) / NF (비기능) / O (미해소) 4-섹션 | [`requirement/product-requirements.md`](./requirement/product-requirements.md) |
+| **`requirement/`** | 제품 요구사항 entry SSOT — D (확정 결정) / F (기능) / NF (비기능) / O (미해소) 4-섹션. D-섹션 = **경량 inline 결정** | [`requirement/product-requirements.md`](./requirement/product-requirements.md) |
+| **`adr/`** | 아키텍처 결정 로그 (#1027) — 프로젝트 전체에 파급되는 **굵직한 결정**의 불변 기록. `NNNN-<kebab>.md` | [`adr/README.md`](./adr/README.md) |
 | **`guide/`** | 사람-팀원 가이드 — setup, team-git, learnings, playbooks, technic, superpowers-ko 한글 가이드 | [`guide/README.md`](./guide/README.md) |
 | **`feature/`** | 피처별 설계·분석 번들 — 한 디렉토리 = 한 피처. superpowers-plans/specs 포함 | (디렉토리 직접 탐색) |
 | **`archive/`** | 보관소 — 사후 분석, 평가 자료(company), 다이어그램, 도래일 지난 todo. 외부 노출 차단 영역 포함 | [`archive/README.md`](./archive/README.md) |
 
+**`adr/` vs `requirement/` D-섹션 경계**: 여러 모듈에 파급되는 굵직한 결정은 `adr/`,
+제품 요구사항 맥락의 경량 결정은 `requirement/` D-섹션 (상세: [`adr/README.md`](./adr/README.md)).
+
 추가 컨텍스트:
 
 - **`memory/` (Claude 비공개)**: 세션 간 컨텍스트. `guide/learnings/` 로 포인터를 두고 본문 중복 금지.
+
+## 문서 메타데이터·파일명 규칙 (#1027)
+
+- **front-matter `status:`** — `requirement/`·`feature/`·`adr/` 문서는 YAML front-matter
+  `status: draft | review | approved | deprecated` 로 현재 유효 SSOT 여부를 표시한다.
+- **파일명 kebab-case** — docs 파일명은 kebab-case (`README.md`/`AGENTS.md` 면제).
+  `mise run lint-docs` (SSOT: `scripts/lint_docs_filenames.sh`)가 검사 — 현재 **강제(FAIL)**
+  범위는 `adr/`·`requirement/`, 나머지는 warn-only (레거시 정리는 별도 이슈).
+- **ADR 상호링크** — `feature/` 문서에서 중대한 기술 전환이 일어나면 본문에 관련
+  ADR 번호를 링크한다: `Ref: [ADR-0001](../../adr/0001-hybrid-docs-policy.md)`.
 
 ## Language Policy
 
@@ -70,14 +87,14 @@
 2. 피처별이면 `feature/<feature-name>/` 하위
 3. 정책이라면 `.ssot/`, 실행 절차라면 `guide/playbooks/`, 학습 자료라면 `guide/learnings/` 또는 `guide/technic/`
 4. 사후 분석·평가 자료라면 `archive/` 하위 (격리 필요 시 `archive/company/`)
-
-## 문서 archive 절차
+5. 굵직한 아키텍처 결정이라면 `adr/NNNN-<kebab>.md` (front-matter `status:` 포함, 인덱스 표 갱신)
 
 # Context Map
 
 - **[Parent Context](../AGENTS.md)** — 프로젝트 root + 표준 링크
 - **[`.ssot/`](./.ssot/README.md)** — 정책 SSOT 인덱스
 - **[`requirement/`](./requirement/product-requirements.md)** — 제품 요구사항 entry SSOT
+- **[`adr/`](./adr/README.md)** — 아키텍처 결정 로그 (#1027)
 - **[`guide/`](./guide/README.md)** — 사람-팀원 가이드 통합 인덱스
 - **[`archive/`](./archive/README.md)** — 보관소 (이동 로그 포함)
 - **[Shell Common](../shell-common/AGENTS.md)** — POSIX 공유 유틸리티

--- a/docs/adr/0001-hybrid-docs-policy.md
+++ b/docs/adr/0001-hybrid-docs-policy.md
@@ -1,0 +1,56 @@
+---
+status: approved
+---
+
+# ADR-0001: docs 문서 정책 하이브리드 확정
+
+- **일자**: 2026-06-26
+- **관련 이슈/PR**: #1027 (기반 결정: #660 5-tier 구조)
+
+## 맥락 (Context)
+
+다른 제품 프로젝트(avatar-system 을 가진 앱)가 채택한 "폴더=문서 종류,
+파일명=기능" 의 7-폴더 kind-split 구조(`adr/`·`product/`·`design/`·
+`architecture/{system,features}`·`testing/`·`guides/`·`public/`)를
+이 dotfiles 레포에 도입할지 검토했다.
+
+정통 방법론(IEEE 830, ISO/IEC/IEEE 12207)과 Docs-as-Code 트렌드를 반영해
+docs 정책을 한층 견고히 하려는 요구가 배경이다.
+
+## 결정 (Decision)
+
+**전면 이주가 아니라, 기존 #660 5-tier 구조를 유지하면서 고가치·저위험
+아이디어만 선별 채택하는 하이브리드 방식**을 채택한다. 도입 항목:
+
+1. `adr/` 신설 — 굵직한 아키텍처 결정의 불변 로그.
+2. front-matter `status:` 메타데이터 규칙 (`draft`/`review`/`approved`/`deprecated`).
+   적용 대상: `requirement/`, `feature/`, `adr/`.
+3. 파일명 kebab-case 린터 — `mise run lint` 에 docs 파일명 규칙 검사 추가, CI 게이트 포함.
+4. ADR 상호링크 규칙 — `feature/` 문서에서 중대한 기술 전환 시 관련 ADR 번호 링크.
+5. `docs/AGENTS.md` 정책을 5-tier → 6-tier (`adr/` 포함)로 갱신.
+
+## 고려한 대안 (Alternatives)
+
+**참조 구조 전면 이주** — 채택하지 않았다. 세 축에서 충돌한다:
+
+1. **철학 충돌 (가장 중요)** — 이 레포는 #660 에서 `feature/<name>/` =
+   "한 디렉토리 = 한 피처" 번들 철학을 확정했다. 참조 구조는 정반대로 한
+   피처의 문서를 종류별로 흩뿌리고 파일명으로 묶는다. 채택 시 13개 feature
+   번들을 전부 해체해야 하고 "관련 문서가 한곳에" 라는 장점을 잃는다.
+2. **기존 자산이 갈 곳이 없음** — `.ssot/` 는 스킬·CLAUDE.md·AGENTS.md
+   36개 파일에서 참조된다. 참조 구조엔 `.ssot/`·`requirement/`·`archive/`
+   자리가 없어 대규모 링크 깨짐 + 마이그레이션 비용이 발생한다.
+3. **도메인 불일치** — 셸 도구 dotfiles 레포다. 참조의 `product/`·`design/`·
+   `testing/` 이 전제하는 산출물이 거의 없어 의례적 빈 폴더가 될 위험이 크다.
+
+## 결과 (Consequences)
+
+- **긍정**: 결정 이력이 `adr/` 한곳으로 일원화. `status:` 로 유효 SSOT 판별
+  가능. 파일명 일관성을 CI 가 강제. 기존 5-tier 의 모든 장점·경로 보존.
+- **경로 불변**: `.ssot/`·`requirement/`·`guide/`·`feature/`·`archive/` 그대로 —
+  기존 36개 `docs/.ssot` 참조 무손상. `adr/` 는 순수 신설이라 깨질 링크 없음.
+- **부정/후속**: 기존 docs 파일명에 다수의 kebab-case 위반이 존재한다. 린터는
+  신설 tier(`adr/`·`requirement/`)만 강제하고 나머지는 warn-only 로 시작하며,
+  레거시 일괄 정리는 별도 이슈로 분리한다.
+- **롤백**: 각 항목이 독립적이라 항목 단위 revert 가능. 린터는 mise 태스크 +
+  CI 단계 제거로 즉시 비활성화.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,84 @@
+---
+status: approved
+---
+
+# `adr/` — Architecture Decision Records
+
+프로젝트 전체에 걸친 **굵직한 아키텍처 의사결정의 불변 로그**다.
+한 번 작성된 ADR 은 사실상 수정하지 않는다 — 결정을 뒤집을 때는
+새 ADR 을 작성하고 기존 ADR 의 `status:` 를 `deprecated` 로 바꾼 뒤
+"Superseded by ADR-NNNN" 한 줄을 덧붙인다 (#1027).
+
+## `adr/` vs `requirement/` D-섹션 경계 규칙
+
+| 위치 | 담는 내용 |
+|------|-----------|
+| **`adr/NNNN-<kebab>.md`** | 프로젝트 전체 구조에 영향을 주는 굵직한 아키텍처 결정. 맥락·대안·근거·결과를 갖춘 불변 로그. |
+| **`requirement/product-requirements.md` D-섹션** | 제품 요구사항 맥락 안의 **경량 inline 결정** (한 줄 표 항목). |
+
+판단 기준: "이 결정이 여러 모듈/디렉토리 구조에 파급되는가?" → 그렇다면 ADR.
+"제품 요구사항을 서술하다가 자연스럽게 따라오는 결정인가?" → D-섹션.
+
+## 번호 규칙
+
+- 파일명: `NNNN-<kebab-case-title>.md` (4자리 zero-pad, 예: `0001-hybrid-docs-policy.md`).
+- 번호는 단조 증가하며 재사용하지 않는다. 결정이 폐기돼도 번호는 비워 두지 않는다.
+- 파일명은 kebab-case 린터(`mise run lint-docs`)의 강제 검사 대상이다.
+
+## front-matter `status:` 규칙
+
+모든 ADR 은 YAML front-matter 로 시작한다:
+
+```yaml
+---
+status: approved   # draft | review | approved | deprecated
+---
+```
+
+- `draft` — 작성 중, 아직 합의 전.
+- `review` — 리뷰/논의 진행 중.
+- `approved` — 확정. 현재 유효한 SSOT.
+- `deprecated` — 폐기됨. 본문 첫 줄에 "Superseded by ADR-NNNN" 명시.
+
+## ADR 상호링크 규칙
+
+`feature/` 문서에서 중대한 기술 전환이 일어나면 본문에 관련 ADR 번호를 링크한다:
+
+```markdown
+Ref: [ADR-0001](../../adr/0001-hybrid-docs-policy.md)
+```
+
+## 템플릿
+
+```markdown
+---
+status: draft
+---
+
+# ADR-NNNN: <결정 제목>
+
+- **일자**: YYYY-MM-DD
+- **관련 이슈/PR**: #NNNN
+
+## 맥락 (Context)
+
+무엇이 이 결정을 필요하게 만들었는가.
+
+## 결정 (Decision)
+
+무엇을 하기로 했는가.
+
+## 고려한 대안 (Alternatives)
+
+채택하지 않은 선택지와 그 이유.
+
+## 결과 (Consequences)
+
+이 결정으로 생기는 긍정·부정 영향, 후속 작업.
+```
+
+## 인덱스
+
+| ADR | 제목 | status |
+|-----|------|--------|
+| [0001](./0001-hybrid-docs-policy.md) | docs 문서 정책 하이브리드 확정 | approved |

--- a/docs/requirement/product-requirements.md
+++ b/docs/requirement/product-requirements.md
@@ -1,3 +1,7 @@
+---
+status: approved
+---
+
 # dotfiles 제품 요구사항 (Entry SSOT)
 
 > **버전**: v1 (2026-05-16) — Initial draft, issue #660 docs/ 재정렬과 함께 entry 파일 신설

--- a/mise.toml
+++ b/mise.toml
@@ -29,8 +29,8 @@ DOTFILES_ROOT = "{{ config_root }}"
 
 # ─── Lint gates (read-only) ──────────────────────────────────────────
 [tasks.lint]
-description = "전체 lint (Python + Shell)"
-depends     = ["lint-py", "lint-sh"]
+description = "전체 lint (Python + Shell + Docs)"
+depends     = ["lint-py", "lint-sh", "lint-docs"]
 
 [tasks.lint-py]
 description = "Python lint (ruff check + format check + mypy)"
@@ -46,6 +46,12 @@ run = [
     'find bash -type f \( -name "*.sh" -o -name "*.bash" \) -exec shellcheck -x -e SC1090,SC1091 {} +',
     "shfmt -d -i 4 bash/",
 ]
+
+[tasks.lint-docs]
+description = "Docs 파일명 kebab-case 린터 (issue #1027)"
+# adr/ + requirement/ 는 강제(FAIL), 나머지 docs/ 는 warn-only.
+# 레거시 위반 일괄 정리는 별도 이슈로 분리한다.
+run = "sh scripts/lint_docs_filenames.sh"
 
 # ─── Test gate ───────────────────────────────────────────────────────
 [tasks.test]

--- a/scripts/lint_docs_filenames.sh
+++ b/scripts/lint_docs_filenames.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# lint_docs_filenames.sh — docs/ 파일명 kebab-case 규칙 검사 (issue #1027)
+#
+# 정책:
+#   - 파일명은 kebab-case (^[a-z0-9]+(-[a-z0-9]+)*\.md$) 를 따른다.
+#   - 관례적 대문자 파일(README/AGENTS/GEMINI/CLAUDE)은 면제한다.
+#   - 강제(ENFORCED) 범위: 새 정책으로 신설/정비된 tier (docs/adr, docs/requirement).
+#     이 범위의 위반은 종료 코드 1 로 CI 를 막는다.
+#   - 그 외 docs/ 하위는 warn-only — 레거시 위반은 별도 정리 이슈로 분리한다 (#1027 리스크 1).
+#
+# 사용:
+#   sh scripts/lint_docs_filenames.sh           # repo root 기준
+#   DOCS_ROOT=path/to/docs sh scripts/lint_docs_filenames.sh
+
+set -eu
+
+DOCS_ROOT="${DOCS_ROOT:-docs}"
+
+# 강제 검사 범위 (공백 구분 prefix 목록)
+ENFORCED_DIRS="${DOCS_ROOT}/adr ${DOCS_ROOT}/requirement"
+
+if [ ! -d "$DOCS_ROOT" ]; then
+    echo "lint-docs: '$DOCS_ROOT' 디렉토리를 찾을 수 없습니다." >&2
+    exit 2
+fi
+
+errors=0
+warnings=0
+
+is_exempt() {
+    # 관례적 대문자 인덱스/컨텍스트 파일은 면제
+    case "$1" in
+    README.md | AGENTS.md | GEMINI.md | CLAUDE.md) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+is_enforced() {
+    # $1 == 파일 경로. ENFORCED_DIRS 중 하나로 시작하면 강제 범위.
+    _path="$1"
+    for _dir in $ENFORCED_DIRS; do
+        case "$_path" in
+        "$_dir"/*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# kebab-case 검사: 소문자/숫자 + 단일 하이픈 구분
+is_kebab() {
+    printf '%s' "$1" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'
+}
+
+while IFS= read -r file; do
+    base="$(basename "$file")"
+    is_exempt "$base" && continue
+
+    stem="${base%.md}"
+    is_kebab "$stem" && continue
+
+    if is_enforced "$file"; then
+        echo "FAIL  $file — 파일명이 kebab-case 가 아닙니다 (강제 범위)." >&2
+        errors=$((errors + 1))
+    else
+        echo "warn  $file — 파일명이 kebab-case 가 아닙니다 (legacy, warn-only)."
+        warnings=$((warnings + 1))
+    fi
+done <<EOF
+$(find "$DOCS_ROOT" -type f -name '*.md' | sort)
+EOF
+
+echo "lint-docs: errors=${errors} warnings=${warnings} (enforced: ${ENFORCED_DIRS})"
+
+[ "$errors" -eq 0 ] || exit 1

--- a/scripts/lint_docs_filenames.sh
+++ b/scripts/lint_docs_filenames.sh
@@ -46,9 +46,15 @@ is_enforced() {
     return 1
 }
 
-# kebab-case 검사: 소문자/숫자 + 단일 하이픈 구분
+# kebab-case 검사: 소문자/숫자 + 단일 하이픈 구분.
+# grep 포크를 피해 POSIX case 내장 패턴으로 검사 (PR #1029 리뷰 반영).
 is_kebab() {
-    printf '%s' "$1" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'
+    case "$1" in
+    "" | -* | *-) return 1 ;; # 빈 문자열 / 선행·후행 하이픈
+    *--*) return 1 ;;         # 연속 하이픈
+    *[!a-z0-9-]*) return 1 ;; # 허용 문자 외
+    *) return 0 ;;
+    esac
 }
 
 while IFS= read -r file; do


### PR DESCRIPTION
## Summary
- #660 5-tier docs 구조를 유지하면서 참조 프로젝트의 고가치·저위험 아이디어만 선별 채택 (전면 이주 미채택).
- `adr/` 신설 + front-matter `status:` 규칙 + 파일명 kebab-case 린터(CI) + ADR 상호링크 규칙 도입.
- 기존 `.ssot/`·`requirement/`·`guide/`·`feature/`·`archive/` 경로 불변 — 36개 `docs/.ssot` 참조 무손상.

## Changes
- `docs/adr/` 신설: `README.md`(번호·`status:`·`adr/` vs D-섹션 경계·템플릿·인덱스) + 샘플 `0001-hybrid-docs-policy.md`(본 하이브리드 결정).
- front-matter `status:` 규칙(`draft|review|approved|deprecated`)을 AGENTS.md에 명문화하고 `requirement/product-requirements.md`에 `status: approved` 적용.
- 파일명 kebab-case 린터: `scripts/lint_docs_filenames.sh`(POSIX sh, shellcheck/shfmt clean) + `mise.toml`에 `[tasks.lint-docs]` 추가, `lint`가 의존 → CI 게이트 자동 포함. `adr/`·`requirement/`는 강제(FAIL), 나머지 docs/는 warn-only(레거시 36건 — 별도 정리 이슈로 분리, 리스크 1 완화).
- ADR 상호링크 규칙(`Ref: [ADR-NNNN](...)`) 명문화.
- `docs/AGENTS.md` 5-tier → 6-tier 갱신(역할표·DO/DON'T·Maintenance·Context Map), 100줄 유지.

## Test plan
- [x] `mise run lint` 전체 통과 (ruff + mypy + shellcheck + shfmt + lint-docs).
- [x] `mise run lint-docs` 통과 (errors=0, warnings=36).
- [x] `mise run test`: 1137 passed. 11 failed는 `test_skill_completion_guard.py`의 pre-existing 실패(clean HEAD에서도 동일 재현) — 본 PR 변경과 무관.
- [x] 기존 36개 `docs/.ssot` 참조 경로 불변 확인.

## Related
Closes #1027

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
