### PR TITLE
feat(devx-docs-bootstrap): 빈 repo에 docs 7-폴더 kind-split 스캐폴딩 스킬

### DIFF
--- a/claude/skills/devx-docs-bootstrap/SKILL.md
+++ b/claude/skills/devx-docs-bootstrap/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: devx:docs-bootstrap
+description: >-
+  Scaffold a standard kind-split docs/ tree in an empty or new repository —
+  the "folder = document kind, feature = filename" policy. Creates
+  docs/{adr,product,design,architecture/{system,features},testing,guides,public}
+  with a .gitkeep in every leaf directory (so git tracks the empty folders)
+  and a single docs/README.md describing the documentation policy + three
+  Docs-as-Code rules (status front-matter, ADR cross-linking, filename
+  linter). Use when the user runs /devx:docs-bootstrap, /devx-docs-bootstrap,
+  or asks "새 프로젝트 docs 구조 만들어줘", "빈 repo에 문서 폴더 스캐폴딩",
+  "docs 디렉토리 골격 깔아줘", "scaffold docs structure", "bootstrap docs
+  folders". Default mode is --dry-run (prints the plan, writes nothing);
+  --apply creates the tree; --check is a read-only conformance audit
+  (CI-friendly, non-zero exit on drift). Idempotent — existing files are
+  skipped. Sister skill of [[gh-kanban-bootstrap]] (board) — this one is the
+  docs-layout half of new-repo setup. Accepts -h/--help/help to print usage.
+allowed-tools: Bash, Read
+metadata:
+  model_recommendation:
+    tier: haiku
+    reason: "Deterministic scaffolder — all logic lives in lib/scaffold.sh; the skill only dispatches and reports"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# devx:docs-bootstrap — scaffold a kind-split docs/ tree
+
+All real work lives in `lib/scaffold.sh` (self-contained, copy-paste safe).
+The skill's job is to dispatch the right mode and relay the result.
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. **No filesystem access.**
+
+## Step 1: Parse Args
+
+Positional `[path]` (target repo root, default `.`). Flags: `--dry-run`
+(default), `--check`, `--apply`, `--force`. Full table in `references/help.md`.
+Mode priority: `--help` > `--check` > `--apply` > `--dry-run`.
+
+Do not re-implement the layout — `lib/scaffold.sh` is the SSOT for the
+8 leaf directories and the `docs/README.md` body
+(`references/docs-readme-template.md`).
+
+## Step 2: Run the scaffolder
+
+Invoke the script with the parsed args, from the skill's own directory so the
+relative template path resolves:
+
+```bash
+bash "$(dirname "$0")/lib/scaffold.sh" <path> [--check|--apply|--dry-run] [--force]
+```
+
+(When invoked as a skill, pass the user's args through verbatim; the script
+parses them itself.)
+
+- **`--dry-run` (default)** — prints the create/skip plan, writes nothing,
+  always exits 0.
+- **`--check`** — read-only audit; exits 0 if `docs/` already has all 8 leaf
+  dirs + `.gitkeep` + `README.md`, non-zero otherwise (use as a CI gate).
+- **`--apply`** — `mkdir -p` the tree, `touch` a `.gitkeep` per leaf, write
+  `docs/README.md` (skipped if present unless `--force`).
+
+The script is idempotent: existing paths are skipped with a `skip` line.
+
+## Step 3: Report
+
+Relay the script's `[OK]`/`[FAIL]` verdict and the create/skip plan. On
+`--apply` success, remind the user the empty folders are tracked via
+`.gitkeep` and can be deleted once real docs land. End with a `Next:` hint
+(e.g. `git add docs/ && git commit`, or `/gh-kanban-bootstrap` for the board).
+
+## Constraints
+
+- Never author document bodies beyond `docs/README.md` — folders stay empty
+  (just `.gitkeep`). Populating PRD/TRD/ADR content is out of scope.
+- Never migrate an existing populated `docs/` — this skill only scaffolds.
+- Never overwrite `docs/README.md` without `--force`.
+- Default to `--dry-run`; only write on explicit `--apply`.

--- a/claude/skills/devx-docs-bootstrap/lib/scaffold.sh
+++ b/claude/skills/devx-docs-bootstrap/lib/scaffold.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# devx:docs-bootstrap — scaffold a kind-split docs/ tree in an (empty) repo.
+#
+# Creates the 7-folder "folder = document kind, feature = filename" structure,
+# drops a .gitkeep into every leaf directory so git tracks the empty folders,
+# and writes a single docs/README.md describing the policy.
+#
+# Self-contained except for the docs/README.md body, which is read from the
+# sibling references/docs-readme-template.md (single SSOT for the policy text).
+# -----------------------------------------------------------------------------
+
+# ─── Minimal, color-aware logging (no external UX lib — copy-paste safe) ──────
+if [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ] || ! command -v tput >/dev/null 2>&1; then
+    C_RESET="" C_OK="" C_WARN="" C_ERR="" C_INFO="" C_MUTE=""
+else
+    C_RESET="$(tput sgr0 2>/dev/null || echo '')"
+    C_OK="$(tput setaf 2 2>/dev/null || echo '')"
+    C_WARN="$(tput setaf 3 2>/dev/null || echo '')"
+    C_ERR="$(tput setaf 1 2>/dev/null || echo '')"
+    C_INFO="$(tput setaf 6 2>/dev/null || echo '')"
+    C_MUTE="$(tput setaf 8 2>/dev/null || echo '')"
+fi
+
+log_ok() { printf '%s[OK]%s %s\n' "$C_OK" "$C_RESET" "$1"; }
+log_info() { printf '%s[INFO]%s %s\n' "$C_INFO" "$C_RESET" "$1"; }
+log_warn() { printf '%s[WARN]%s %s\n' "$C_WARN" "$C_RESET" "$1" >&2; }
+log_err() { printf '%s[FAIL]%s %s\n' "$C_ERR" "$C_RESET" "$1" >&2; }
+log_plan() { printf '  %s%s%s %s\n' "$C_MUTE" "$1" "$C_RESET" "$2"; }
+
+die() {
+    log_err "$1"
+    exit 1
+}
+
+# ─── Layout SSOT ──────────────────────────────────────────────────────────────
+# Leaf directories that each receive a .gitkeep. architecture/ is a parent of
+# system/ and features/, so it is intentionally absent (its leaves cover it).
+LEAF_DIRS=(
+    adr
+    product
+    design
+    architecture/system
+    architecture/features
+    testing
+    guides
+    public
+)
+
+README_NAME="README.md"
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+TARGET="."
+MODE="dry-run" # dry-run | check | apply | help
+FORCE=false
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_FILE="${SCRIPT_DIR}/../references/docs-readme-template.md"
+
+print_usage() {
+    cat <<'EOF'
+devx:docs-bootstrap — scaffold a kind-split docs/ tree.
+
+Usage:
+  bash scaffold.sh [path] [--dry-run|--check|--apply] [--force] [-h|--help]
+
+Modes (priority: --help > --check > --apply > --dry-run):
+  --dry-run   (default) Print the creation plan; write nothing.
+  --check     Read-only audit — report whether docs/ already conforms.
+              Exit 0 if complete, non-zero if anything is missing.
+  --apply     Create the directories, .gitkeep files, and docs/README.md.
+  --force     With --apply, overwrite an existing docs/README.md.
+  -h|--help   Show this help and exit.
+
+Arguments:
+  path        Target repo root (default: current directory). docs/ is
+              created under it.
+EOF
+}
+
+parse_args() {
+    local saw_help=false saw_check=false saw_apply=false
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        -h | --help | help)
+            saw_help=true
+            shift
+            ;;
+        --check)
+            saw_check=true
+            shift
+            ;;
+        --apply)
+            saw_apply=true
+            shift
+            ;;
+        --dry-run)
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        -*)
+            die "Unknown option: $1 (try --help)"
+            ;;
+        *)
+            TARGET="$1"
+            shift
+            ;;
+        esac
+    done
+
+    # Mode priority: help > check > apply > dry-run.
+    if $saw_help; then
+        MODE="help"
+    elif $saw_check; then
+        MODE="check"
+        if $saw_apply; then
+            log_warn "--check overrides --apply (read-only audit wins)"
+        fi
+    elif $saw_apply; then
+        MODE="apply"
+    else
+        MODE="dry-run"
+    fi
+}
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+docs_root() { printf '%s/docs' "${TARGET%/}"; }
+
+render_readme() {
+    [ -r "$TEMPLATE_FILE" ] || die "README template not found: $TEMPLATE_FILE"
+    cat "$TEMPLATE_FILE"
+}
+
+# ─── Modes ──────────────────────────────────────────────────────────────────-─
+do_check() {
+    local docs missing=0 d keep readme
+    docs="$(docs_root)"
+
+    log_info "Auditing ${docs}/ for the kind-split layout"
+    for d in "${LEAF_DIRS[@]}"; do
+        if [ -d "${docs}/${d}" ]; then
+            log_plan "[ok]  " "${d}/"
+        else
+            log_plan "[miss]" "${d}/  (directory absent)"
+            missing=$((missing + 1))
+        fi
+        keep="${docs}/${d}/.gitkeep"
+        if [ ! -f "$keep" ]; then
+            log_plan "[miss]" "${d}/.gitkeep"
+            missing=$((missing + 1))
+        fi
+    done
+
+    readme="${docs}/${README_NAME}"
+    if [ -f "$readme" ]; then
+        log_plan "[ok]  " "${README_NAME}"
+    else
+        log_plan "[miss]" "${README_NAME}"
+        missing=$((missing + 1))
+    fi
+
+    if [ "$missing" -eq 0 ]; then
+        log_ok "docs/ conforms to the kind-split layout (8 leaves + README)."
+        return 0
+    fi
+    log_err "docs/ is missing ${missing} item(s). Run with --apply to scaffold."
+    return 1
+}
+
+do_plan_or_apply() {
+    local docs d keep readme apply="$1"
+    docs="$(docs_root)"
+
+    if $apply; then
+        log_info "Scaffolding ${docs}/ (kind-split layout)"
+    else
+        log_info "[dry-run] Plan for ${docs}/ — nothing will be written"
+    fi
+
+    for d in "${LEAF_DIRS[@]}"; do
+        keep="${docs}/${d}/.gitkeep"
+        if [ -f "$keep" ]; then
+            log_plan "skip  " "${d}/.gitkeep (exists)"
+            continue
+        fi
+        if $apply; then
+            mkdir -p "${docs}/${d}" || die "mkdir failed: ${docs}/${d}"
+            : >"$keep" || die "write failed: $keep"
+            log_plan "create" "${d}/.gitkeep"
+        else
+            log_plan "create" "${d}/ + .gitkeep"
+        fi
+    done
+
+    readme="${docs}/${README_NAME}"
+    if [ -f "$readme" ] && ! $FORCE; then
+        log_plan "skip  " "${README_NAME} (exists — use --force to overwrite)"
+    elif $apply; then
+        mkdir -p "$docs" || die "mkdir failed: $docs"
+        render_readme >"$readme" || die "write failed: $readme"
+        log_plan "create" "${README_NAME}"
+    else
+        log_plan "create" "${README_NAME}"
+    fi
+
+    if $apply; then
+        log_ok "docs/ scaffolded. Empty folders are tracked via .gitkeep."
+    else
+        log_ok "Dry-run complete. Re-run with --apply to write."
+    fi
+}
+
+main() {
+    parse_args "$@"
+    case "$MODE" in
+    help) print_usage ;;
+    check) do_check ;;
+    apply) do_plan_or_apply true ;;
+    dry-run) do_plan_or_apply false ;;
+    esac
+}
+
+main "$@"

--- a/claude/skills/devx-docs-bootstrap/lib/scaffold.sh
+++ b/claude/skills/devx-docs-bootstrap/lib/scaffold.sh
@@ -82,7 +82,7 @@ EOF
 }
 
 parse_args() {
-    local saw_help=false saw_check=false saw_apply=false
+    local saw_help=false saw_check=false saw_apply=false saw_target=false
     while [ "$#" -gt 0 ]; do
         case "$1" in
         -h | --help | help)
@@ -108,7 +108,15 @@ parse_args() {
             die "Unknown option: $1 (try --help)"
             ;;
         *)
+            # Reject empty / duplicate target paths — an empty TARGET would
+            # resolve docs_root() to "/docs" (system root) and risk writing
+            # there (gemini PR #1030 review).
+            if $saw_target; then
+                die "Multiple target paths given: '$TARGET' and '$1' (only one allowed)"
+            fi
+            [ -n "$1" ] || die "Target path cannot be empty"
             TARGET="$1"
+            saw_target=true
             shift
             ;;
         esac

--- a/claude/skills/devx-docs-bootstrap/references/docs-readme-template.md
+++ b/claude/skills/devx-docs-bootstrap/references/docs-readme-template.md
@@ -1,0 +1,35 @@
+# 문서 관리 정책 (Documentation Policy)
+
+> **모든 문서는 "어떤 종류의 문서인가"로 분류한다. 어떤 기능을 다루는지는 파일 이름에 담는다.**
+
+폴더는 문서의 *종류(성격)* 로만 나눈다. 기능명은 파일 이름에 담는다
+(예: `architecture/features/auth-sso-integration.md`). 이렇게 하면 기능이
+늘어나도 디렉터리 복잡도가 거의 일정하게 유지된다 (SRP/SSOT).
+
+## 폴더 구조
+
+| 폴더 | 규칙 |
+|------|------|
+| `adr/` | 프로젝트 전체 아키텍처 의사결정 (불변 로그) |
+| `product/` | 제품 관리 산출물: PRD·수용기준·유즈케이스·기능 목록 |
+| `design/` | 기능 설계 스펙·UX 설계·디자인 시스템·UI 표준 |
+| `architecture/system/` | 시스템 전체 아키텍처·데이터 모델·배포 파이프라인 (현재 상태 SSOT) |
+| `architecture/features/` | 개별 기능 단위 TRD·마이그레이션 계획 (완료 시 system 으로 병합/아카이브) |
+| `testing/` | 품질 보증 산출물: 테스트 전략·E2E 시나리오·검증 기준 |
+| `guides/` | 내부 운영 방법론: 개발 프로세스·테스트 가이드·온보딩 |
+| `public/` | 외부 공개 문서 (별도 네임스페이스) |
+
+## Docs-as-Code 규칙
+
+1. **상태 메타데이터** — `product/`·`architecture/` 문서는 상단 front-matter 에
+   `status: [draft | review | approved | deprecated]` 를 명시해 어떤 문서가
+   현재 유효한 SSOT 인지 판별한다.
+2. **ADR 연동** — `architecture/features/` 에서 중대한 기술 전환이 일어나면
+   관련 `adr/` 번호를 본문에 링크한다 (예: `Ref: [ADR-0015](../../adr/0015-...)`).
+3. **파일명 린터** — 파일 이름은 `kebab-case` 로 통일하고, CI 단계에서 간단한
+   파일명 린터로 강제하는 것을 권장한다.
+
+---
+
+이 구조는 `/devx:docs-bootstrap` 로 생성되었습니다. 빈 디렉터리는 `.gitkeep`
+으로 git 에 추적됩니다 — 실제 문서를 추가하면 `.gitkeep` 은 삭제해도 됩니다.

--- a/claude/skills/devx-docs-bootstrap/references/help.md
+++ b/claude/skills/devx-docs-bootstrap/references/help.md
@@ -1,0 +1,72 @@
+# devx:docs-bootstrap — Help
+
+## Usage
+
+```
+/devx:docs-bootstrap [path] [flags]
+/devx-docs-bootstrap                 # dry-run plan for ./docs (default)
+/devx-docs-bootstrap . --apply       # scaffold ./docs
+/devx-docs-bootstrap ~/new-repo --apply
+/devx-docs-bootstrap --check         # read-only conformance audit
+/devx:docs-bootstrap -h              # show this help
+/devx:docs-bootstrap --help          # show this help
+/devx:docs-bootstrap help            # show this help
+```
+
+## Arguments
+
+| # | Name | Required | Description |
+|---|------|----------|-------------|
+| 1 | `[path]` | no | Target repo root. `docs/` is created under it. Defaults to `.` (cwd). |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | **on** | Default. Prints the creation plan; writes nothing. Always exits 0. |
+| `--check` | off | Read-only audit — reports whether `docs/` already conforms (8 leaf dirs + `.gitkeep` + `README.md`). Exits 0 if complete, non-zero if anything is missing (CI-friendly). |
+| `--apply` | off | Creates the directories, a `.gitkeep` in every leaf, and `docs/README.md`. |
+| `--force` | off | With `--apply`, overwrite an existing `docs/README.md` (otherwise skipped). |
+| `-h` / `--help` / `help` | — | Print this help and exit. No filesystem access. |
+
+**Mode priority**: `--help` > `--check` > `--apply` > `--dry-run`. If more than
+one mode flag is passed, the higher-priority one wins and a `[WARN]` is printed.
+
+## What it creates
+
+```
+docs/
+├─ adr/                     # 아키텍처 의사결정 (불변 로그)
+├─ product/                 # PRD·수용기준·유즈케이스·기능 목록
+├─ design/                  # 기능 설계 스펙·UX 설계·디자인 시스템
+├─ architecture/
+│  ├─ system/               # 시스템 전체 아키텍처 (현재 상태 SSOT)
+│  └─ features/             # 개별 기능 TRD·마이그레이션 계획
+├─ testing/                 # 테스트 전략·E2E 시나리오·품질 지표
+├─ guides/                  # 내부 운영 방법론·온보딩
+├─ public/                  # 외부 공개 문서
+└─ README.md                # 문서 관리 정책 (위 표 + Docs-as-Code 규칙 3종)
+```
+
+Each leaf directory gets a `.gitkeep` so git tracks the empty folder. The
+policy body of `README.md` is the single SSOT at
+`references/docs-readme-template.md`.
+
+## Idempotency
+
+Re-running is safe: existing directories, `.gitkeep` files, and `README.md`
+are skipped (a `skip` line is printed for each). `docs/README.md` is only
+overwritten with `--force`.
+
+## Examples
+
+```
+# 1. Preview what would be created in the current repo (no writes):
+/devx-docs-bootstrap
+
+# 2. Scaffold a brand-new repo:
+/devx-docs-bootstrap ~/code/my-new-service --apply
+
+# 3. CI gate — fail the build if docs/ drifted from the standard layout:
+/devx-docs-bootstrap --check
+```

--- a/tests/bats/skills/devx_docs_bootstrap_scaffold.bats
+++ b/tests/bats/skills/devx_docs_bootstrap_scaffold.bats
@@ -17,7 +17,11 @@ teardown() {
 }
 
 run_scaffold() {
-    run bash -c "cd '$WORK' && NO_COLOR=1 bash '$SCAFFOLD' $(printf '%q ' "$@")"
+    # Pass args as real positional parameters (not interpolated into the -c
+    # string) so a zero-arg call stays zero-arg — `printf '%q ' "$@"` would
+    # emit one empty token, making scaffold.sh target "/docs" (gemini PR
+    # #1030 review).
+    run bash -c 'cd "$1"; shift; NO_COLOR=1 bash "$@"' bash "$WORK" "$SCAFFOLD" "$@"
 }
 
 LEAVES="adr product design architecture/system architecture/features testing guides public"
@@ -40,7 +44,23 @@ LEAVES="adr product design architecture/system architecture/features testing gui
     assert_success
     assert_output --partial "[dry-run]"
     assert_output --partial "create"
+    # Zero-arg call must keep TARGET="." (→ ./docs under $WORK), NOT collapse
+    # to "" which would target the system-root /docs (gemini PR #1030 review).
+    assert_output --partial "Plan for ./docs/"
+    refute_output --partial "Plan for /docs/"
     [ ! -d "${WORK}/docs" ]
+}
+
+@test "rejects an empty target path" {
+    run bash -c 'NO_COLOR=1 bash "$1" "" --apply' bash "$SCAFFOLD"
+    assert_failure
+    assert_output --partial "Target path cannot be empty"
+}
+
+@test "rejects multiple target paths" {
+    run_scaffold "${TEST_TEMP_HOME}/a" "${TEST_TEMP_HOME}/b" --apply
+    assert_failure
+    assert_output --partial "Multiple target paths"
 }
 
 @test "--apply creates all 8 leaf dirs with .gitkeep and a README" {

--- a/tests/bats/skills/devx_docs_bootstrap_scaffold.bats
+++ b/tests/bats/skills/devx_docs_bootstrap_scaffold.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/bats/skills/devx_docs_bootstrap_scaffold.bats
+# Offline coverage for claude/skills/devx-docs-bootstrap/lib/scaffold.sh (#1028).
+
+load '../test_helper'
+
+SCAFFOLD="${DOTFILES_ROOT}/claude/skills/devx-docs-bootstrap/lib/scaffold.sh"
+
+setup() {
+    setup_isolated_home
+    WORK="${TEST_TEMP_HOME}/repo"
+    mkdir -p "$WORK"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+run_scaffold() {
+    run bash -c "cd '$WORK' && NO_COLOR=1 bash '$SCAFFOLD' $(printf '%q ' "$@")"
+}
+
+LEAVES="adr product design architecture/system architecture/features testing guides public"
+
+@test "script exists and is executable" {
+    [ -f "$SCAFFOLD" ]
+    [ -x "$SCAFFOLD" ] || head -1 "$SCAFFOLD" | grep -q '^#!'
+}
+
+@test "--help prints usage and writes nothing" {
+    run_scaffold --help
+    assert_success
+    assert_output --partial "devx:docs-bootstrap"
+    assert_output --partial "Mode"
+    [ ! -d "${WORK}/docs" ]
+}
+
+@test "dry-run (default) prints a create plan but writes nothing" {
+    run_scaffold
+    assert_success
+    assert_output --partial "[dry-run]"
+    assert_output --partial "create"
+    [ ! -d "${WORK}/docs" ]
+}
+
+@test "--apply creates all 8 leaf dirs with .gitkeep and a README" {
+    run_scaffold --apply
+    assert_success
+    assert_output --partial "[OK]"
+    for d in $LEAVES; do
+        [ -d "${WORK}/docs/${d}" ] || { echo "missing dir ${d}"; return 1; }
+        [ -f "${WORK}/docs/${d}/.gitkeep" ] || { echo "missing gitkeep ${d}"; return 1; }
+    done
+    [ -f "${WORK}/docs/README.md" ]
+    grep -q "문서 관리 정책" "${WORK}/docs/README.md"
+    # architecture/ itself is a parent, not a leaf — it has no own .gitkeep
+    [ ! -f "${WORK}/docs/architecture/.gitkeep" ]
+}
+
+@test "--check fails on an empty repo, passes after --apply" {
+    run_scaffold --check
+    assert_failure
+    assert_output --partial "missing"
+
+    run_scaffold --apply
+    assert_success
+
+    run_scaffold --check
+    assert_success
+    assert_output --partial "conforms"
+}
+
+@test "re-running --apply is idempotent (skips existing)" {
+    run_scaffold --apply
+    assert_success
+    run_scaffold --apply
+    assert_success
+    assert_output --partial "skip"
+    assert_output --partial "(exists)"
+}
+
+@test "README is not overwritten without --force, overwritten with --force" {
+    run_scaffold --apply
+    assert_success
+    printf 'CUSTOM EDIT\n' >"${WORK}/docs/README.md"
+
+    run_scaffold --apply
+    assert_success
+    grep -q "CUSTOM EDIT" "${WORK}/docs/README.md"
+
+    run_scaffold --apply --force
+    assert_success
+    ! grep -q "CUSTOM EDIT" "${WORK}/docs/README.md"
+    grep -q "문서 관리 정책" "${WORK}/docs/README.md"
+}
+
+@test "--check overrides --apply and stays read-only" {
+    run_scaffold --check --apply
+    assert_failure
+    assert_output --partial "read-only audit wins"
+    [ ! -d "${WORK}/docs" ]
+}
+
+@test "accepts an explicit target path argument" {
+    run_scaffold "${TEST_TEMP_HOME}/other" --apply
+    assert_success
+    [ -d "${TEST_TEMP_HOME}/other/docs/adr" ]
+    [ -f "${TEST_TEMP_HOME}/other/docs/README.md" ]
+}


### PR DESCRIPTION
## Summary

신규/빈 repository 에서 검증된 docs 문서 정책(kind-split)을 한 번에 깔아주는
`/devx:docs-bootstrap` 스킬을 추가합니다. #1027 이 이 dotfiles 레포용
하이브리드 6-tier 를 다룬 자매 이슈이고, 본 PR 은 빈 repo 용 정석 7-폴더
구조를 찍어내는 스킬입니다.

## Changes

- **신규 스킬 `claude/skills/devx-docs-bootstrap/`**
  - `lib/scaffold.sh` — 모든 로직의 SSOT (self-contained, copy-paste safe).
    `docs/{adr,product,design,architecture/{system,features},testing,guides,public}`
    8개 leaf 에 `.gitkeep` 생성 + `docs/README.md` 기록.
  - `SKILL.md` — 모드 디스패치 + 리포트만 담당 (haiku tier).
  - `references/help.md` — `-h/--help/help` verbatim 출력.
  - `references/docs-readme-template.md` — 생성될 `docs/README.md` 의 정책 본문 SSOT.
- **옵션**: `--dry-run`(기본) / `--check`(read-only 적합성 감사, 누락 시 비-0 종료, CI 게이트용) / `--apply` / `--force`. 모드 우선순위 `--help > --check > --apply > --dry-run`.
- **멱등성**: 기존 디렉토리·`.gitkeep`·`README.md` 는 skip; README 는 `--force` 로만 덮어씀.
- **테스트**: `tests/bats/skills/devx_docs_bootstrap_scaffold.bats` 9 케이스 (help/dry-run/apply/check/idempotent/force/explicit-path/check-overrides-apply).

## Test plan

- [x] 신규 bats 9/9 통과
- [x] `shfmt -d -i 4` + `shellcheck -x` clean
- [x] pre-commit 검증 통과

## Related

Closes #1028

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics -->

</details>
