### PR TITLE
fix(gcp-scan): cherry-pick 전 파일 의존성 사전 검사 Stage-1.5 추가

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -430,10 +430,15 @@ ${sha}"
             dep_missing_list="${dep_missing_list}${sha}
 "
             dep_missing_count=$((dep_missing_count + 1))
-            local _dep_first _dep_file _dep_sha _c_short
-            _dep_first=$(printf '%s\n' "$_dep_out" | head -n 1)
-            _dep_file=$(printf '%s\n' "$_dep_first" | cut -f1)
-            _dep_sha=$(printf '%s\n' "$_dep_first" | cut -f2)
+            local _dep_file="" _dep_sha="" _c_short
+            # Parse only the first "F<TAB>sha" line of _dep_out with a pure
+            # here-doc read (no printf/head/cut forks) — mirrors the file's
+            # established no-fork style (PR #812); gemini PR #1034 review.
+            while IFS="$tab" read -r _dep_file _dep_sha; do
+                break
+            done <<EOF
+$_dep_out
+EOF
             _c_short=$(git rev-parse --short "$sha" 2>/dev/null)
             if type ux_warning >/dev/null 2>&1; then
                 ux_warning "Skipping ${_c_short} — depends on ${_dep_sha} (creates/deletes ${_dep_file}) not yet in ${base}."

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -150,6 +150,64 @@ $2
 EOF
 }
 
+_gcp_scan_check_file_deps() {
+    # File-dependency pre-check (issue #1033). Returns 1 when cherry-picking
+    # commit $1 would hit a modify/delete conflict because a file it
+    # modifies/deletes is ABSENT from $2 (base) and the upstream commit in $3
+    # (source) that creates that file is NOT itself among the commits we are
+    # about to pick ($4, the author-filtered candidate list). Returns 0 when no
+    # such missing dependency exists.
+    #
+    # Why $4 (pick_list) is load-bearing: with --author=all the creating commit
+    # IS in the candidate list and gets cherry-picked first, so the file is no
+    # longer "missing" — checking base existence alone would false-positive
+    # there. Membership in pick_list is the guard that keeps --author=all clean.
+    #
+    # For every missing dependency it prints one "F<TAB>short_creator_sha" line
+    # to stdout so the caller can name the offending file + precedent commit.
+    local sha="$1" base="$2" source="$3" pick_list="$4"
+    local changes st f up_add rc=0 tab
+    tab=$(printf '\t')
+    # name-status of the candidate (single-parent diff -> one status letter).
+    changes=$(git diff-tree --no-commit-id -r --name-status "$sha" 2>/dev/null)
+    while IFS="$tab" read -r st f; do
+        [ -z "$st" ] && continue
+        [ -z "$f" ] && continue
+        # Only modify (M) / delete (D) require the file to pre-exist in base.
+        # Adds (A) create the file themselves; renames/copies (R/C) carry two
+        # path fields and are out of scope for this heuristic.
+        case "$st" in
+            M* | D*) ;;
+            *) continue ;;
+        esac
+        # File already present in base -> modify/delete can proceed (content
+        # conflicts, if any, are Stage-2 / real-cherry-pick territory).
+        if git cat-file -e "${base}:${f}" >/dev/null 2>&1; then
+            continue
+        fi
+        # File absent in base. Find the upstream commit that creates it.
+        up_add=$(git log "$source" --diff-filter=A --format='%H' -- "$f" 2>/dev/null | head -n 1)
+        # No known creator in source -> not a recognizable dependency; leave it
+        # for Stage-2 / the real cherry-pick rather than guess.
+        [ -z "$up_add" ] && continue
+        # Creator is among the commits we will pick first -> not missing
+        # (the --author=all path). Newline-wrapped match avoids prefix
+        # collisions, mirroring the Stage-2 noop_list membership test.
+        case "
+$pick_list
+" in
+            *"
+$up_add
+"*) continue ;;
+        esac
+        printf '%s\t%s\n' "$f" "$(git rev-parse --short "$up_add" 2>/dev/null)"
+        rc=1
+    done <<EOF
+$changes
+EOF
+    return $rc
+}
+
 _gcp_scan() {
     # zsh compatibility: emulate POSIX sh to ensure consistent behavior
     if [ -n "${ZSH_VERSION-}" ]; then
@@ -350,6 +408,49 @@ EOF
         count=$((count - duplicate_count))
     fi
 
+    # Stage-1.5: file-dependency pre-check (issue #1033). A candidate that
+    # modifies/deletes a file absent from base — because the upstream commit
+    # that creates it was filtered out (e.g. a non-author commit) and is not
+    # itself in the pick set — would hit a modify/delete conflict. Detect and
+    # skip such commits up front with a clear message. Runs on
+    # final_selected_list (Stage-1 dups already pruned), BEFORE the Stage-2
+    # noop pre-flight so we never waste a probe (or surface a conflict) on them.
+    local dep_missing_list="" dep_missing_count=0 dep_survivor_list=""
+    while IFS= read -r sha; do
+        [ -z "$sha" ] && continue
+        local _dep_out=""
+        if _dep_out=$(_gcp_scan_check_file_deps "$sha" "$base" "$source" "$selected_list"); then
+            if [ -z "$dep_survivor_list" ]; then
+                dep_survivor_list="$sha"
+            else
+                dep_survivor_list="${dep_survivor_list}
+${sha}"
+            fi
+        else
+            dep_missing_list="${dep_missing_list}${sha}
+"
+            dep_missing_count=$((dep_missing_count + 1))
+            local _dep_first _dep_file _dep_sha _c_short
+            _dep_first=$(printf '%s\n' "$_dep_out" | head -n 1)
+            _dep_file=$(printf '%s\n' "$_dep_first" | cut -f1)
+            _dep_sha=$(printf '%s\n' "$_dep_first" | cut -f2)
+            _c_short=$(git rev-parse --short "$sha" 2>/dev/null)
+            if type ux_warning >/dev/null 2>&1; then
+                ux_warning "Skipping ${_c_short} — depends on ${_dep_sha} (creates/deletes ${_dep_file}) not yet in ${base}."
+                ux_info "Cherry-pick that commit first, or re-run with --author=all to include the dependency."
+            else
+                echo "⚠ Skipping ${_c_short} — depends on ${_dep_sha} (creates/deletes ${_dep_file}) not yet in ${base}." >&2
+                echo "ℹ Cherry-pick that commit first, or re-run with --author=all to include the dependency." >&2
+            fi
+        fi
+    done <<EOF
+$final_selected_list
+EOF
+    final_selected_list="$dep_survivor_list"
+    if [ "$dep_missing_count" -gt 0 ]; then
+        count=$((count - dep_missing_count))
+    fi
+
     # Stage-2: no-op pre-flight in Analysis phase — filters phantom commits
     # before display so users never see commits that will immediately be skipped
     # (issue #961). Runs on final_selected_list (Stage-1 dups already removed).
@@ -381,6 +482,9 @@ EOF
             ux_bullet "Missing (all authors): $total_count"
             ux_bullet "Author filter: $author -> 0 new commit(s)"
             ux_bullet "Duplicates (already applied): $duplicate_count"
+            if [ "$dep_missing_count" -gt 0 ]; then
+                printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
+            fi
             if [ "$noop_count" -gt 0 ]; then
                 printf "%s  ◆ Already in HEAD (no-op): %d%s\n" "${UX_MUTED-}" "$noop_count" "${UX_RESET-}"
             fi
@@ -389,6 +493,9 @@ EOF
             echo "  Missing (all authors): $total_count"
             echo "  Author filter: $author -> 0 new commit(s)"
             echo "  Duplicates (already applied): $duplicate_count"
+            if [ "$dep_missing_count" -gt 0 ]; then
+                echo "  Dep-missing (skipped): $dep_missing_count"
+            fi
             if [ "$noop_count" -gt 0 ]; then
                 echo "  Already in HEAD (no-op): $noop_count"
             fi
@@ -416,6 +523,9 @@ EOF
         if [ $duplicate_count -gt 0 ]; then
             ux_bullet "Duplicates (already applied): $duplicate_count"
         fi
+        if [ "$dep_missing_count" -gt 0 ]; then
+            printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
+        fi
         if [ "$noop_count" -gt 0 ]; then
             printf "%s  ◆ Already in HEAD (no-op): %d%s\n" "${UX_MUTED-}" "$noop_count" "${UX_RESET-}"
         fi
@@ -426,6 +536,9 @@ EOF
         echo "  Author filter: $author -> $count commit(s)"
         if [ $duplicate_count -gt 0 ]; then
             echo "  Duplicates (already applied): $duplicate_count"
+        fi
+        if [ "$dep_missing_count" -gt 0 ]; then
+            echo "  Dep-missing (skipped): $dep_missing_count"
         fi
         if [ "$noop_count" -gt 0 ]; then
             echo "  Already in HEAD (no-op): $noop_count"
@@ -482,8 +595,25 @@ EOF
     local empty_skipped=0
     local noop_skipped=0
     local dup_skipped=0
+    local dep_skipped=0
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
+
+        # Stage-1.5 dependency-missing (issue #1033): skip with a log line so
+        # the commit is never attempted — it would conflict on a modify/delete
+        # of a file absent from base. Newline-wrapped membership match mirrors
+        # the Stage-2 noop_list test below.
+        local _in_dep=0
+        case "
+$dep_missing_list" in
+            *"
+$sha
+"*) _in_dep=1 ;;
+        esac
+        if [ "$_in_dep" -eq 1 ]; then
+            dep_skipped=$((dep_skipped + 1))
+            continue
+        fi
 
         # Stage-1 subject duplicate: skip without a cherry-pick attempt,
         # naming the base SHA it matches (issue #811 F-2/F-3).
@@ -550,6 +680,9 @@ EOF
     # above), so report 0 conflicts.
     if type ux_success >/dev/null 2>&1; then
         ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        if [ "$dep_skipped" -gt 0 ]; then
+            ux_info "($dep_skipped commit(s) skipped — file dependency missing in $base)"
+        fi
         if [ "$noop_skipped" -gt 0 ]; then
             ux_info "($noop_skipped commit(s) skipped — already in HEAD, no-op pre-flight)"
         fi
@@ -558,6 +691,9 @@ EOF
         fi
     else
         echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        if [ "$dep_skipped" -gt 0 ]; then
+            echo "  ($dep_skipped commit(s) skipped — file dependency missing in $base)"
+        fi
         if [ "$noop_skipped" -gt 0 ]; then
             echo "  ($noop_skipped commit(s) skipped — already in HEAD, no-op pre-flight)"
         fi

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -823,3 +823,114 @@ FIXTURE
     assert_output --partial "comment v2 expanded much longer"
     assert_output --partial "PICK_CLEAR"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1033 — Stage-1.5 file-dependency pre-check. When the author filter
+# drops the upstream commit that CREATES a file, a later author commit that
+# MODIFIES (or DELETES) that file would hit a modify/delete conflict because
+# the file is absent from base. Stage-1.5 detects this before any cherry-pick,
+# skips the dependent commit with a warning, and reports it as
+# "Dep-missing (skipped): N". Under --author=all the creating commit is in the
+# pick set, so the check must NOT false-positive.
+#
+# Fixture authors: a NON-author "Upstream Bot" creates dep.txt; the author
+# "Me" modifies dep.txt (the dependent candidate) and independently adds
+# other.txt (a clean, dependency-free candidate).
+# ---------------------------------------------------------------------------
+
+_gcp1033_make_repo() {
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Me" GIT_AUTHOR_EMAIL="me@me" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        # Non-author creates dep.txt (this is the commit the author filter drops).
+        echo created > dep.txt && git add dep.txt \
+            && git commit -q --author="Upstream Bot <bot@up>" -m "create dep.txt"
+        # Author modifies dep.txt -> depends on the create above.
+        echo modified > dep.txt && git add dep.txt && git commit -qm "modify dep.txt"
+        # Author adds an independent file -> no dependency.
+        echo standalone > other.txt && git add other.txt && git commit -qm "add other.txt"
+        git checkout -q main
+FIXTURE
+}
+
+@test "bash: _gcp_scan_check_file_deps private function exists" {
+    run_in_bash 'declare -f _gcp_scan_check_file_deps >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "scan #1033: create-then-modify dependency detected, dependent commit skipped (no conflict)" {
+    run_in_bash "
+        $(_gcp1033_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # Warning naming the dependent file + the absent precedent.
+    assert_output --partial "Skipping"
+    assert_output --partial "dep.txt"
+    assert_output --partial "--author=all"
+    # Analysis Result counter.
+    assert_output --partial "Dep-missing (skipped): 1"
+    # The independent commit still applied; no conflict ever surfaced.
+    assert_output --partial "0 conflicts"
+    refute_output --partial "CONFLICT"
+    refute_output --partial "Resolve and run"
+}
+
+@test "scan #1033: dependent commit's file is absent, independent commit applied" {
+    run_in_bash "
+        $(_gcp1033_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me >/dev/null 2>&1
+        git cat-file -e HEAD:other.txt && echo HAS_OTHER
+        git cat-file -e HEAD:dep.txt 2>/dev/null && echo HAS_DEP || echo NO_DEP
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    assert_output --partial "HAS_OTHER"
+    assert_output --partial "NO_DEP"
+    assert_output --partial "PICK_CLEAR"
+}
+
+@test "scan #1033: --author=all includes the creator -> no false-positive, dep applied cleanly" {
+    run_in_bash "
+        $(_gcp1033_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=all
+        git show HEAD:dep.txt 2>/dev/null
+    "
+    assert_success
+    # Creator is in the pick set, so the modify is NOT flagged as dep-missing.
+    refute_output --partial "Dep-missing (skipped)"
+    refute_output --partial "CONFLICT"
+    # dep.txt ends at the modified content (create + modify both applied).
+    assert_output --partial "modified"
+}
+
+@test "scan #1033: delete of a file whose creator was filtered out is detected" {
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp_test.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Me\" GIT_AUTHOR_EMAIL=\"me@me\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm 'init'
+        git checkout -q -b source
+        # Non-author creates del.txt; author later deletes it -> delete depends
+        # on a create absent from main.
+        echo gone > del.txt && git add del.txt \
+            && git commit -q --author='Upstream Bot <bot@up>' -m 'create del.txt'
+        git rm -q del.txt && git commit -qm 'delete del.txt'
+        git checkout -q main
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    assert_output --partial "Dep-missing (skipped): 1"
+    assert_output --partial "del.txt"
+    refute_output --partial "CONFLICT"
+}


### PR DESCRIPTION
## Summary

`gcp scan` 의 author 필터로 **skip된 upstream 커밋**이 파일을 create/delete 한 경우,
그 파일을 modify/delete 하는 **후속 author 커밋을 cherry-pick 하면 base 에 파일이 없어
modify/delete 충돌**이 발생했다 (#1033). Stage-1 subject dedup 직후·Stage-2 noop
preflight 이전에 **파일 의존성 사전 검사(Stage-1.5)**를 삽입해 충돌을 사전 차단한다.

## Changes

- **`shell-common/functions/gcp_scan.sh`**
  - 새 내부 함수 `_gcp_scan_check_file_deps <sha> <base> <source> <pick_list>`:
    후보 커밋이 modify/delete 하는 파일이 `base` 에 부재하고, 그 파일을 create 한
    upstream 커밋이 pick 목록에 없으면 의존성 누락(rc=1)으로 판정.
    `pick_list` 멤버십 검사 덕분에 `--author=all` 에서는 선행 커밋이 함께 포함되어
    **false-positive 없이** 동작.
  - Stage-1.5: 의존성 누락 커밋을 목록에서 제외 + 경고 출력(선행 SHA·파일명 안내),
    실행 루프에서도 skip 하여 cherry-pick 시도 자체를 차단.
  - Analysis Result 에 `◆ Dep-missing (skipped): N` 카운터, 최종 리포트에 dep
    skip 안내 라인 추가.
- **`tests/bats/functions/gcp.bats`**
  - `_gcp_scan_check_file_deps` 함수 존재 확인
  - create-then-modify 의존성 감지(충돌 없이 skip)
  - 의존성 누락 커밋 파일 부재 + 독립 커밋 정상 적용
  - `--author=all` 무오탐(선행 커밋 포함 → dep 정상 적용)
  - delete 의존성(생성 커밋이 필터로 제외됨) 감지

## Test

- `tests/bats/functions/gcp.bats` 56/56 통과 (신규 5건 포함, 기존 회귀 없음)

## Acceptance Criteria

- [x] `gcp scan` 실행 시 의존성 누락 커밋을 cherry-pick 전에 감지하고 경고 출력
- [x] 의존성 누락 커밋은 cherry-pick 목록에서 제외 (충돌 없음)
- [x] `◆ Dep-missing (skipped): N` 카운터가 Analysis Result 에 표시됨
- [x] `--author=all` 에서는 선행 커밋도 포함되므로 dep 검사가 false-positive 없이 동작
- [x] bats 테스트 추가 및 통과

Closes #1033

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
