### PR TITLE
fix(deps): skill_completion_guard 훅 런타임 PyYAML 의존성 추가 (#1035)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ description = "Opinionated Bash dotfiles for reproducible terminal environments 
 authors = [{ name = "BW-Yoon", email = "byoungwoo.yoon@samsung.com" }]
 dependencies = [
     "rich>=14.1.0",
-]  # No runtime Python dependencies needed for bash dotfiles
+    "pyyaml>=6.0",  # skill_completion_guard 훅이 런타임에 import (uv venv 에 필요, #1035)
+]
 
 
 # --- 개발 및 테스트 환경 의존성 ---


### PR DESCRIPTION
## Summary

`claude/hooks/skill_completion_guard.py` 는 런타임에 `import yaml` 하지만
`pyproject.toml` 에는 타입 스텁 `types-PyYAML` 만 선언돼 있고 런타임 패키지
`pyyaml` 자체가 누락돼 있었다. uv 가상환경(`uv run`)에는 스텁만 설치되고
`yaml` 런타임 모듈이 없어 `import yaml` 이 실패 → 훅이 fail-open 으로 빈 stdout
을 출력하며 종료 → 테스트가 `json.loads()` 단계에서 `JSONDecodeError` 로 깨졌다.

- `[project] dependencies` 에 `pyyaml>=6.0` 추가
- `uv sync` 로 lock 갱신 (`pyyaml==6.0.3`; `uv.lock` 은 gitignore 대상)

## Test

- `uv run python3 -c "import yaml"` → OK (6.0.3)
- `uv run pytest tests/integration/test_skill_completion_guard.py` → **34 passed**
  (기존 실패 11건 포함 전부 그린)

Closes #1035
