### PR TITLE
fix(gcp-scan): content-conflict 사전 탐지 (Stage-1.6)

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -232,14 +232,18 @@ _gcp_scan_predict_content_conflict() {
     # --author=all guard ($2 = pick_list): a predicted conflict is a FALSE
     # positive when an earlier, not-yet-applied pick_list commit also touches
     # the conflicting file — the execution loop applies that precedent first,
-    # after which the merge is clean. When any conflicting file is modified by
-    # ANOTHER commit in the pick set, defer (return 0) and let the real
-    # cherry-pick decide. Mirrors Stage-1.5's pick_list membership guard, so
+    # after which the merge is clean. The verdict is evaluated PER conflicting
+    # file: a file ALSO modified by another pick commit may be a precedent
+    # artifact (skip it), but a conflicting file touched by NO other pick
+    # commit is guaranteed to still conflict (no precedent changes HEAD's
+    # copy) — so the commit is flagged as soon as one such file is found.
+    # Only when EVERY conflicting file is covered by a precedent is the verdict
+    # deferred (return 0). Mirrors Stage-1.5's pick_list membership guard, so
     # --author=all stays false-positive-free.
     #
-    # Prints the first conflicting file path to stdout on the conflict path.
+    # Prints the first guaranteed-conflict file path to stdout when it flags.
     local sha="$1" pick_list="$2"
-    local parent merge_out conflicted f other_files p rc first
+    local parent merge_out conflicted f other_files p rc
     # Root commit (no parent) or merge commit (2+ parents): the cherry-pick
     # merge base is undefined/ambiguous -> out of scope, defer to the real
     # cherry-pick rather than probe with the wrong base.
@@ -248,12 +252,17 @@ _gcp_scan_predict_content_conflict() {
         return 0
     fi
     # Single invocation with --name-only: rc carries the conflict verdict, and
-    # stdout is the merged tree OID on line 1 followed by one conflicted path
-    # per line. On older git the unknown flags exit > 1 and we bail to "clean".
+    # stdout is the merged tree OID on line 1, then the conflicted paths (one
+    # per line), then a blank line and an "Informational messages" block
+    # (Auto-merging / CONFLICT lines). On older git the unknown flags exit > 1
+    # and we bail to "clean".
     merge_out=$(git merge-tree --write-tree --name-only --merge-base="$parent" HEAD "$sha" 2>/dev/null)
     rc=$?
     [ "$rc" -eq 1 ] || return 0
-    conflicted=$(printf '%s\n' "$merge_out" | tail -n +2)
+    # Keep ONLY the path list: drop the OID (line 1) and stop at the blank line
+    # before the informational block — otherwise "Auto-merging <f>" / "CONFLICT"
+    # lines would be misread as conflicting file paths.
+    conflicted=$(printf '%s\n' "$merge_out" | awk 'NR>1 { if ($0=="") exit; print }')
     [ -z "$conflicted" ] && return 0
     # Build the set of paths touched by every OTHER pick_list commit, for the
     # --author=all false-positive guard.
@@ -266,25 +275,31 @@ _gcp_scan_predict_content_conflict() {
     done <<EOF
 $pick_list
 EOF
-    first=""
     while IFS= read -r f; do
         [ -z "$f" ] && continue
-        # Deferral guard: the conflicting file is also touched by another pick
-        # commit -> the conflict is an artifact of an unapplied precedent.
+        # Deferral guard, per-file: a conflicting file ALSO touched by another
+        # pick commit may be an artifact of an unapplied precedent -> skip it.
+        # But a conflicting file touched by NO other pick commit is guaranteed
+        # to still conflict at the real cherry-pick (no precedent can change
+        # HEAD's copy), so flag the commit immediately on the first such file
+        # rather than deferring the whole commit (gemini PR #1038 review).
         # Newline-wrapped match avoids prefix collisions (Stage-1.5 pattern).
         case "
 $other_files" in
             *"
 $f
-"*) return 0 ;;
+"*) ;;
+            *)
+                printf '%s\n' "$f"
+                return 1
+                ;;
         esac
-        [ -z "$first" ] && first="$f"
     done <<EOF
 $conflicted
 EOF
-    [ -z "$first" ] && return 0
-    printf '%s\n' "$first"
-    return 1
+    # Every conflicting file is covered by an earlier pick_list commit -> defer
+    # the whole verdict to the real cherry-pick (it applies precedents first).
+    return 0
 }
 
 _gcp_scan() {

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -208,6 +208,85 @@ EOF
     return $rc
 }
 
+_gcp_scan_predict_content_conflict() {
+    # Content-conflict pre-check (issue #1037, extends Stage-1.5 #1033). Returns
+    # 1 when cherry-picking commit $1 onto HEAD is predicted to hit a 3-way
+    # *content* conflict — HEAD and the commit change the same region of a file
+    # that exists on both sides. This is the case Stage-1.5 does NOT cover
+    # (modify/delete of a file absent from base); here both sides edited the
+    # same lines. Returns 0 when the merge is predicted clean OR when the
+    # verdict is deferred (see the --author=all guard below).
+    #
+    # Probe: `git merge-tree --write-tree --merge-base=<sha>^ HEAD <sha>`. This
+    # drives git's REAL merge engine as a non-destructive dry-run (no checkout,
+    # no index/worktree mutation) using the cherry-pick's own merge base — the
+    # candidate's parent — so the exit status mirrors exactly what
+    # `git cherry-pick <sha>` would hit. rc 0 = clean, rc 1 = conflict; rc > 1 =
+    # usage/unsupported (git < 2.38 lacks --write-tree, < 2.40 lacks
+    # --merge-base) -> treated as "clean" so pre-#1037 behavior is preserved on
+    # older git. The legacy `git merge-tree <base> <a> <b>` form is deliberately
+    # NOT used: it is a trivial merge that prints conflict markers for
+    # adjacent-but-cleanly-mergeable hunks, producing false positives (#1037
+    # investigation).
+    #
+    # --author=all guard ($2 = pick_list): a predicted conflict is a FALSE
+    # positive when an earlier, not-yet-applied pick_list commit also touches
+    # the conflicting file — the execution loop applies that precedent first,
+    # after which the merge is clean. When any conflicting file is modified by
+    # ANOTHER commit in the pick set, defer (return 0) and let the real
+    # cherry-pick decide. Mirrors Stage-1.5's pick_list membership guard, so
+    # --author=all stays false-positive-free.
+    #
+    # Prints the first conflicting file path to stdout on the conflict path.
+    local sha="$1" pick_list="$2"
+    local parent merge_out conflicted f other_files p rc first
+    # Root commit (no parent) or merge commit (2+ parents): the cherry-pick
+    # merge base is undefined/ambiguous -> out of scope, defer to the real
+    # cherry-pick rather than probe with the wrong base.
+    parent=$(git rev-parse -q --verify "${sha}^1" 2>/dev/null) || return 0
+    if git rev-parse -q --verify "${sha}^2" >/dev/null 2>&1; then
+        return 0
+    fi
+    # Single invocation with --name-only: rc carries the conflict verdict, and
+    # stdout is the merged tree OID on line 1 followed by one conflicted path
+    # per line. On older git the unknown flags exit > 1 and we bail to "clean".
+    merge_out=$(git merge-tree --write-tree --name-only --merge-base="$parent" HEAD "$sha" 2>/dev/null)
+    rc=$?
+    [ "$rc" -eq 1 ] || return 0
+    conflicted=$(printf '%s\n' "$merge_out" | tail -n +2)
+    [ -z "$conflicted" ] && return 0
+    # Build the set of paths touched by every OTHER pick_list commit, for the
+    # --author=all false-positive guard.
+    other_files=""
+    while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        [ "$p" = "$sha" ] && continue
+        other_files="${other_files}$(git diff-tree --no-commit-id -r --name-only "$p" 2>/dev/null)
+"
+    done <<EOF
+$pick_list
+EOF
+    first=""
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        # Deferral guard: the conflicting file is also touched by another pick
+        # commit -> the conflict is an artifact of an unapplied precedent.
+        # Newline-wrapped match avoids prefix collisions (Stage-1.5 pattern).
+        case "
+$other_files" in
+            *"
+$f
+"*) return 0 ;;
+        esac
+        [ -z "$first" ] && first="$f"
+    done <<EOF
+$conflicted
+EOF
+    [ -z "$first" ] && return 0
+    printf '%s\n' "$first"
+    return 1
+}
+
 _gcp_scan() {
     # zsh compatibility: emulate POSIX sh to ensure consistent behavior
     if [ -n "${ZSH_VERSION-}" ]; then
@@ -456,6 +535,48 @@ EOF
         count=$((count - dep_missing_count))
     fi
 
+    # Stage-1.6: content-conflict pre-check (issue #1037, extends Stage-1.5). A
+    # candidate whose change overlaps the same region HEAD already changed in a
+    # file present on both sides would hit a 3-way *content* conflict — the case
+    # Stage-1.5 (modify/delete of an absent file) does not cover. Probe each
+    # Stage-1.5 survivor with `git merge-tree` (a non-destructive dry-run of the
+    # cherry-pick merge) and skip the ones predicted to conflict, mirroring the
+    # Stage-1.5 warning + counter pattern. Runs BEFORE the Stage-2 noop
+    # pre-flight so we never surface a conflict on a commit that is genuinely
+    # redundant.
+    local conflict_list="" conflict_count=0 conflict_survivor_list=""
+    while IFS= read -r sha; do
+        [ -z "$sha" ] && continue
+        local _cf_out=""
+        if _cf_out=$(_gcp_scan_predict_content_conflict "$sha" "$selected_list"); then
+            if [ -z "$conflict_survivor_list" ]; then
+                conflict_survivor_list="$sha"
+            else
+                conflict_survivor_list="${conflict_survivor_list}
+${sha}"
+            fi
+        else
+            conflict_list="${conflict_list}${sha}
+"
+            conflict_count=$((conflict_count + 1))
+            local _cf_short
+            _cf_short=$(git rev-parse --short "$sha" 2>/dev/null)
+            if type ux_warning >/dev/null 2>&1; then
+                ux_warning "Skipping ${_cf_short} — predicted content conflict in ${_cf_out} (same region changed in ${base})."
+                ux_info "Cherry-pick it manually and resolve, or rebase the change onto the latest ${base}."
+            else
+                echo "⚠ Skipping ${_cf_short} — predicted content conflict in ${_cf_out} (same region changed in ${base})." >&2
+                echo "ℹ Cherry-pick it manually and resolve, or rebase the change onto the latest ${base}." >&2
+            fi
+        fi
+    done <<EOF
+$final_selected_list
+EOF
+    final_selected_list="$conflict_survivor_list"
+    if [ "$conflict_count" -gt 0 ]; then
+        count=$((count - conflict_count))
+    fi
+
     # Stage-2: no-op pre-flight in Analysis phase — filters phantom commits
     # before display so users never see commits that will immediately be skipped
     # (issue #961). Runs on final_selected_list (Stage-1 dups already removed).
@@ -490,6 +611,9 @@ EOF
             if [ "$dep_missing_count" -gt 0 ]; then
                 printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
             fi
+            if [ "$conflict_count" -gt 0 ]; then
+                printf "%s  ◆ Content-conflict (skipped): %d%s\n" "${UX_MUTED-}" "$conflict_count" "${UX_RESET-}"
+            fi
             if [ "$noop_count" -gt 0 ]; then
                 printf "%s  ◆ Already in HEAD (no-op): %d%s\n" "${UX_MUTED-}" "$noop_count" "${UX_RESET-}"
             fi
@@ -500,6 +624,9 @@ EOF
             echo "  Duplicates (already applied): $duplicate_count"
             if [ "$dep_missing_count" -gt 0 ]; then
                 echo "  Dep-missing (skipped): $dep_missing_count"
+            fi
+            if [ "$conflict_count" -gt 0 ]; then
+                echo "  Content-conflict (skipped): $conflict_count"
             fi
             if [ "$noop_count" -gt 0 ]; then
                 echo "  Already in HEAD (no-op): $noop_count"
@@ -531,6 +658,9 @@ EOF
         if [ "$dep_missing_count" -gt 0 ]; then
             printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
         fi
+        if [ "$conflict_count" -gt 0 ]; then
+            printf "%s  ◆ Content-conflict (skipped): %d%s\n" "${UX_MUTED-}" "$conflict_count" "${UX_RESET-}"
+        fi
         if [ "$noop_count" -gt 0 ]; then
             printf "%s  ◆ Already in HEAD (no-op): %d%s\n" "${UX_MUTED-}" "$noop_count" "${UX_RESET-}"
         fi
@@ -544,6 +674,9 @@ EOF
         fi
         if [ "$dep_missing_count" -gt 0 ]; then
             echo "  Dep-missing (skipped): $dep_missing_count"
+        fi
+        if [ "$conflict_count" -gt 0 ]; then
+            echo "  Content-conflict (skipped): $conflict_count"
         fi
         if [ "$noop_count" -gt 0 ]; then
             echo "  Already in HEAD (no-op): $noop_count"
@@ -601,6 +734,7 @@ EOF
     local noop_skipped=0
     local dup_skipped=0
     local dep_skipped=0
+    local conflict_skipped=0
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
 
@@ -617,6 +751,21 @@ $sha
         esac
         if [ "$_in_dep" -eq 1 ]; then
             dep_skipped=$((dep_skipped + 1))
+            continue
+        fi
+
+        # Stage-1.6 content-conflict (issue #1037): skip with a log line so the
+        # commit is never attempted — it would hit a 3-way content conflict on a
+        # file both sides changed. Membership match mirrors the dep_missing test.
+        local _in_conflict=0
+        case "
+$conflict_list" in
+            *"
+$sha
+"*) _in_conflict=1 ;;
+        esac
+        if [ "$_in_conflict" -eq 1 ]; then
+            conflict_skipped=$((conflict_skipped + 1))
             continue
         fi
 
@@ -688,6 +837,9 @@ EOF
         if [ "$dep_skipped" -gt 0 ]; then
             ux_info "($dep_skipped commit(s) skipped — file dependency missing in $base)"
         fi
+        if [ "$conflict_skipped" -gt 0 ]; then
+            ux_info "($conflict_skipped commit(s) skipped — predicted content conflict with $base)"
+        fi
         if [ "$noop_skipped" -gt 0 ]; then
             ux_info "($noop_skipped commit(s) skipped — already in HEAD, no-op pre-flight)"
         fi
@@ -698,6 +850,9 @@ EOF
         echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
         if [ "$dep_skipped" -gt 0 ]; then
             echo "  ($dep_skipped commit(s) skipped — file dependency missing in $base)"
+        fi
+        if [ "$conflict_skipped" -gt 0 ]; then
+            echo "  ($conflict_skipped commit(s) skipped — predicted content conflict with $base)"
         fi
         if [ "$noop_skipped" -gt 0 ]; then
             echo "  ($noop_skipped commit(s) skipped — already in HEAD, no-op pre-flight)"

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1086,3 +1086,42 @@ FIXTURE
     assert_output --partial "DEFERRED"
     refute_output --partial "STILL_FLAGGED"
 }
+
+@test "scan #1037: one uncovered conflicting file flags the commit despite a covered one (unit)" {
+    # gemini PR #1038 review: the guard is per-file. A commit that conflicts in
+    # TWO files — one also touched by a precedent (covered), one touched by no
+    # other pick commit (uncovered) — is still GUARANTEED to conflict on the
+    # uncovered file, so it must be FLAGGED (return 1) naming that file, NOT
+    # deferred just because the other file is covered.
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp_test.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Me\" GIT_AUTHOR_EMAIL=\"me@me\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        printf 'Foo0\n' > foo.txt && printf 'Bar0\n' > bar.txt \
+            && git add foo.txt bar.txt && git commit -qm 'init'
+        git checkout -q -b source
+        # Precedent touches bar.txt only.
+        printf 'Bar1\n' > bar.txt && git add bar.txt \
+            && git commit -q --author='Upstream Bot <bot@up>' -m 'bar->Bar1'
+        c1=\$(git rev-parse HEAD)
+        # Candidate touches BOTH foo.txt (uncovered) and bar.txt (covered by c1).
+        printf 'Foo2\n' > foo.txt && printf 'Bar2\n' > bar.txt \
+            && git add foo.txt bar.txt && git commit -qm 'foo+bar'
+        c2=\$(git rev-parse HEAD)
+        git checkout -q main
+        # main diverges on BOTH files so each conflicts in the 3-way merge.
+        printf 'FooMain\n' > foo.txt && printf 'BarMain\n' > bar.txt \
+            && git add foo.txt bar.txt && git commit -qm 'main diverges'
+        out=\$(_gcp_scan_predict_content_conflict \"\$c2\" \"\$c1
+\$c2\"); rc=\$?
+        echo \"rc=\$rc out=\$out\"
+    "
+    assert_success
+    # Flagged (rc=1) despite bar.txt being covered, naming the uncovered foo.txt.
+    assert_output --partial "rc=1"
+    assert_output --partial "foo.txt"
+    refute_output --partial "rc=0"
+}

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -934,3 +934,155 @@ FIXTURE
     assert_output --partial "del.txt"
     refute_output --partial "CONFLICT"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1037 — Stage-1.6 content-conflict pre-check. Extends Stage-1.5: when a
+# candidate and HEAD both change the same region of a file present on BOTH
+# sides, a real cherry-pick hits a 3-way *content* conflict (Stage-1.5 only
+# covers modify/delete of a file absent from base). Stage-1.6 probes each
+# survivor with `git merge-tree` (non-destructive dry-run, cherry-pick merge
+# base = candidate's parent), skips the ones predicted to conflict, and reports
+# "Content-conflict (skipped): N". Under --author=all an earlier pick_list
+# commit touching the same file means the conflict is an unapplied-precedent
+# artifact, so the check must NOT false-positive.
+#
+# Fixture: author "Me" edits foo.txt (same line main later edits -> conflict)
+# and independently adds bar.txt (clean, different file). main diverges on the
+# same foo.txt line.
+# ---------------------------------------------------------------------------
+
+_gcp1037_make_repo() {
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Me" GIT_AUTHOR_EMAIL="me@me" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        printf 'orig\n' > foo.txt && echo init > a.txt \
+            && git add foo.txt a.txt && git commit -qm "init"
+        git checkout -q -b source
+        # Author edits foo.txt -> will collide with main's edit to the same line.
+        printf 'upstream\n' > foo.txt && git add foo.txt && git commit -qm "edit foo"
+        # Author adds an independent file -> clean, conflict-free candidate.
+        echo standalone > bar.txt && git add bar.txt && git commit -qm "add bar.txt"
+        git checkout -q main
+        # main diverges on the SAME line of foo.txt.
+        printf 'mainline\n' > foo.txt && git add foo.txt && git commit -qm "main edits foo"
+FIXTURE
+}
+
+@test "bash: _gcp_scan_predict_content_conflict private function exists" {
+    run_in_bash 'declare -f _gcp_scan_predict_content_conflict >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "scan #1037: same-line edit on both sides predicted, candidate skipped (no conflict surfaced)" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # Warning naming the conflicting file.
+    assert_output --partial "Skipping"
+    assert_output --partial "foo.txt"
+    assert_output --partial "content conflict"
+    # Analysis Result counter.
+    assert_output --partial "Content-conflict (skipped): 1"
+    # The independent commit still applied; no real conflict ever surfaced.
+    assert_output --partial "0 conflicts"
+    refute_output --partial "CONFLICT"
+    refute_output --partial "Resolve and run"
+}
+
+@test "scan #1037: conflicting commit skipped, independent commit applied, foo untouched" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me >/dev/null 2>&1
+        git cat-file -e HEAD:bar.txt && echo HAS_BAR
+        git show HEAD:foo.txt
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    assert_output --partial "HAS_BAR"
+    # foo.txt keeps main's content — the conflicting edit was never applied.
+    assert_output --partial "mainline"
+    refute_output --partial "upstream"
+    assert_output --partial "PICK_CLEAR"
+}
+
+@test "scan #1037: non-conflicting candidate (different file) is NOT flagged" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # Only foo.txt's edit conflicts; bar.txt is applied, never counted.
+    assert_output --partial "Content-conflict (skipped): 1"
+    refute_output --partial "Content-conflict (skipped): 2"
+}
+
+@test "scan #1037: --author=all defers to precedent, no false-positive" {
+    # When the precedent that the dependent edit builds on is itself in the pick
+    # set (--author=all), Stage-1.6 must NOT flag the dependent as a content
+    # conflict — the real loop applies the precedent first. (The dependent is
+    # then absorbed by the pre-existing Stage-2 no-op pre-flight, which probes
+    # against bare main; that is out of Stage-1.6's scope. The point under test
+    # is solely the absence of a false content-conflict skip / surfaced conflict.)
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp_test.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Me\" GIT_AUTHOR_EMAIL=\"me@me\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        printf 'orig\n' > foo.txt && git add foo.txt && git commit -qm 'init'
+        git checkout -q -b source
+        # Non-author appends a line; author then modifies that same appended line
+        # -> a static probe of the author commit alone (vs main, which lacks the
+        # appended line) predicts a conflict, but the precedent is in the pick set.
+        printf 'orig\nlineC1\n' > foo.txt && git add foo.txt \
+            && git commit -q --author='Upstream Bot <bot@up>' -m 'append lineC1'
+        printf 'orig\nlineC1-modified\n' > foo.txt && git add foo.txt \
+            && git commit -qm 'modify lineC1'
+        git checkout -q main
+        printf 'y\n' | _gcp_scan main source --author=all
+    "
+    assert_success
+    # Precedent is in the pick set -> conflict prediction deferred, not skipped.
+    refute_output --partial "Content-conflict (skipped)"
+    refute_output --partial "CONFLICT"
+    refute_output --partial "Resolve and run"
+}
+
+@test "scan #1037: guard flips verdict on pick_list membership (unit)" {
+    # Directly exercise _gcp_scan_predict_content_conflict: the SAME commit that
+    # is flagged a conflict with an empty pick_list must be DEFERRED once a
+    # precedent touching the conflicting file is present in the pick_list.
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp_test.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Me\" GIT_AUTHOR_EMAIL=\"me@me\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        printf 'A\nB\nC\n' > foo.txt && git add foo.txt && git commit -qm 'init'
+        git checkout -q -b source
+        printf 'A\nB1\nC\n' > foo.txt && git add foo.txt \
+            && git commit -q --author='Upstream Bot <bot@up>' -m 'B->B1'
+        c1=\$(git rev-parse HEAD)
+        printf 'A\nB2\nC\n' > foo.txt && git add foo.txt && git commit -qm 'B1->B2'
+        c2=\$(git rev-parse HEAD)
+        git checkout -q main
+        # No precedent in pick_list -> conflict predicted (return 1, prints file).
+        if _gcp_scan_predict_content_conflict \"\$c2\" \"\$c2\"; then echo NO_FLAG; else echo FLAGGED; fi
+        # Precedent c1 present in pick_list -> deferred (return 0, prints nothing).
+        if _gcp_scan_predict_content_conflict \"\$c2\" \"\$c1
+\$c2\"; then echo DEFERRED; else echo STILL_FLAGGED; fi
+    "
+    assert_success
+    assert_output --partial "FLAGGED"
+    assert_output --partial "DEFERRED"
+    refute_output --partial "STILL_FLAGGED"
+}


### PR DESCRIPTION
## Summary
- `gcp scan` 의 cherry-pick 충돌을 한 단계 더 사전 차단한다. Stage-1.5(#1033)는
  파일이 base에 없는 modify/delete 충돌만 막았고, 양쪽이 같은 줄을 다르게
  수정하는 3-way content conflict 는 매번 수동 해결로 남아 있었다.
- Stage-1.6 을 추가해 `git merge-tree` dry-run 으로 content conflict 를 예측,
  해당 커밋을 Analysis 단계에서 skip 하고 카운터로 표시한다 (충돌 0건 목표).

## Changes
- `shell-common/functions/gcp_scan.sh`
  - `_gcp_scan_predict_content_conflict <sha> <pick_list>` 신설:
    `git merge-tree --write-tree --merge-base=<sha>^ HEAD <sha>` 로 cherry-pick
    3-way merge 를 비파괴 dry-run(체크아웃·인덱스 변경 없음) 하고 exit code
    (1=충돌)로 판정. 레거시 `git merge-tree <base> <a> <b>` 형식은 인접하지만
    깨끗하게 병합되는 hunk 에도 충돌 마커를 찍어 false-positive 가 발생하므로
    의도적으로 사용하지 않음.
  - `--author=all` 무오탐 가드: 충돌 파일을 pick_list 의 선행 커밋도 수정하면
    그 선행 적용으로 해소될 가짜 충돌이므로 defer. Stage-1.5 의 pick_list
    멤버십 가드와 동일 패턴.
  - Stage-1.6 블록을 Stage-1.5 와 Stage-2(noop) 사이에 삽입, Analysis Result 에
    `Content-conflict (skipped): N` 카운터, 실행 루프 skip, 최종 리포트 안내 추가.
  - root/merge 커밋과 git < 2.38(`--write-tree` 미지원)은 defer 하여 기존 동작 보존.
- `tests/bats/functions/gcp.bats`
  - 동일 줄 충돌 탐지·독립 커밋 적용·다른 파일 무오탐·`--author=all` defer·
    pick_list 멤버십 verdict flip(unit) 케이스 추가.

## Test plan
- [x] `bats tests/bats/functions/gcp.bats` — 62 passed (신규 6 케이스 포함)
- [x] `bats tests/bats/lint/` — 12 passed
- [x] `bash tests/golden_rules/test_golden_rules.sh` — all rules pass (emoji/POSIX 포함)
- [x] `git merge-tree` 동작 검증: 레거시 형식 false-positive 재현 → modern
      `--write-tree --merge-base` 형식이 인접 hunk 를 정확히 clean(rc=0)/충돌(rc=1) 구분

## Related
Closes #1037

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
