### PR TITLE
feat(gcp-scan): known-resolved SHA 스킵 목록으로 상시 경고 노이즈 제거

### DIFF
--- a/git/AGENTS.md
+++ b/git/AGENTS.md
@@ -67,4 +67,5 @@ layer only — protected-branch check still runs). SSOT lives in
 - **[Hook Checks](./hooks/checks)** — Modular checks executed by the project hook
 - **[Hook Configuration](./config/hook-config.sh)** — Regex patterns, thresholds, and shared constants
 - **[Pre-push Rules](./config/pre-push-rules.sh)** — Protected branches + leak-guard SSOT
+- **[gcp-scan Skip List](./config/gcp-scan-skip.conf)** — Known-resolved SHAs `gcp scan` skips silently (issue #1039; `gcp scan --show-skip-list`, override `GCP_SCAN_SKIP_FILE`)
 - **[Git Docs](./doc/README.md)** — Hook workflow and SSH setup guides

--- a/git/config/gcp-scan-skip.conf
+++ b/git/config/gcp-scan-skip.conf
@@ -1,0 +1,25 @@
+# git/config/gcp-scan-skip.conf
+#
+# Known-resolved skip list for `gcp scan` (issue #1039).
+#
+# `gcp scan` runs several pre-checks (Stage-1.5 file-dependency, Stage-1.6
+# content-conflict, Stage-2 no-op) that correctly identify commits it cannot
+# cleanly cherry-pick. When a commit is a KNOWN, already-reconciled case —
+# manually resolved into HEAD, or permanently dependent on an upstream commit
+# that will never reach our base — re-warning about it on every scan is pure
+# UX noise. Register such commits here to skip them SILENTLY (still counted
+# under "Known-resolved (skipped)" in the summary).
+#
+# Format: one commit SHA per line; abbreviated SHAs are matched by prefix.
+# Everything after `#` on a line is a free-text reason (recommended).
+#
+#   <sha>  # why it is safe to skip
+#
+# Notes:
+#   - The list is IGNORED under `gcp scan --author=all` so full detection
+#     (the safety net) is never silenced.
+#   - View the active list with `gcp scan --show-skip-list`.
+#   - Override the file path with the GCP_SCAN_SKIP_FILE env var.
+
+092d0512  # manually resolved during #1023 cherry-pick, already in HEAD (content conflict in scripts/setup-company-skills.sh)
+00544238  # depends on 83987291 (other author, not in main) — creates/deletes scripts/setup-kanban-board.sh

--- a/shell-common/functions/gcp.sh
+++ b/shell-common/functions/gcp.sh
@@ -182,6 +182,8 @@ _gcp_help_rows_scan() {
     ux_table_row "--author=all" "show all authors" "Bypass filter"
     ux_table_row "behavior" "detects duplicates (same subject in base)" "Skips already-applied commits"
     ux_table_row "behavior" "contiguous range -> bulk cherry-pick" "Non-contiguous -> individual"
+    ux_table_row "--show-skip-list" "print known-resolved SHAs" "git/config/gcp-scan-skip.conf (issue #1039)"
+    ux_table_row "skip list" "registered SHAs skipped silently" "ignored under --author=all"
 }
 
 _gcp_help_rows_theirs() {

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -331,6 +331,18 @@ _gcp_scan_load_skip_list() {
         token=${token%"${token##*[![:space:]]}"}       # trim trailing space
         token=${token#"${token%%[![:space:]]*}"}       # trim leading space
         [ -z "$token" ] && continue
+        # Hardening (gemini PR #1040 review): the token is later used UNESCAPED
+        # as a `case` glob in _gcp_scan_in_skip_list ("$tok"*), so a stray `*`,
+        # `?`, or `[` would match every candidate SHA and silently skip ALL
+        # commits. Accept only hex (a valid abbreviated SHA) and require >=4
+        # chars so an over-short prefix can't over-match. Reject otherwise.
+        case "$token" in
+            *[!0-9a-fA-F]*) continue ;;
+        esac
+        case "$token" in
+            ????*) ;;
+            *) continue ;;
+        esac
         printf '%s\n' "$token"
     done <"$file"
 }

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -302,6 +302,94 @@ EOF
     return 0
 }
 
+_gcp_scan_skip_file() {
+    # Resolve the known-resolved skip-list file path (issue #1039). Honors the
+    # GCP_SCAN_SKIP_FILE override (absolute or cwd-relative); otherwise defaults
+    # to <repo-toplevel>/git/config/gcp-scan-skip.conf so the list is a tracked
+    # SSOT alongside the other git/config/*.conf rule files. Prints the path
+    # (it may not exist yet — callers must -f check).
+    if [ -n "${GCP_SCAN_SKIP_FILE-}" ]; then
+        printf '%s\n' "$GCP_SCAN_SKIP_FILE"
+        return 0
+    fi
+    local top
+    top=$(git rev-parse --show-toplevel 2>/dev/null) || top="."
+    printf '%s/git/config/gcp-scan-skip.conf\n' "$top"
+}
+
+_gcp_scan_load_skip_list() {
+    # Parse the known-resolved skip-list file (issue #1039) into one cleaned
+    # SHA token per line. Each line is `<sha> [# free-text reason]`; inline
+    # comments, full-comment lines, and blank lines are stripped. Pure
+    # parameter-expansion parsing (no awk/sed fork), matching this file's style.
+    local file line token
+    file=$(_gcp_scan_skip_file)
+    [ -f "$file" ] || return 0
+    # `|| [ -n "$line" ]` flushes a final newline-less line (POSIX read idiom).
+    while IFS= read -r line || [ -n "$line" ]; do
+        token=${line%%#*}                              # drop inline comment
+        token=${token%"${token##*[![:space:]]}"}       # trim trailing space
+        token=${token#"${token%%[![:space:]]*}"}       # trim leading space
+        [ -z "$token" ] && continue
+        printf '%s\n' "$token"
+    done <"$file"
+}
+
+_gcp_scan_in_skip_list() {
+    # True (0) when candidate full SHA $1 is covered by the skip tokens in $2.
+    # Tokens may be abbreviated, so a prefix match handles short SHAs while a
+    # full token still matches exactly. Mirrors the no-fork here-doc read style.
+    local cand="$1" tok
+    while IFS= read -r tok; do
+        [ -z "$tok" ] && continue
+        case "$cand" in
+            "$tok"*) return 0 ;;
+        esac
+    done <<EOF
+$2
+EOF
+    return 1
+}
+
+_gcp_scan_show_skip_list() {
+    # Render the current known-resolved skip list for `gcp scan --show-skip-list`
+    # (issue #1039): the resolved file path plus every registered SHA token.
+    local file entries
+    file=$(_gcp_scan_skip_file)
+    entries=$(_gcp_scan_load_skip_list)
+    if type ux_section >/dev/null 2>&1; then
+        ux_section "Known-resolved skip list"
+        ux_bullet "File: $file"
+    else
+        echo "=== Known-resolved skip list ==="
+        echo "  File: $file"
+    fi
+    if [ ! -f "$file" ]; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "(no skip-list file — nothing registered)"
+        else
+            echo "  (no skip-list file — nothing registered)"
+        fi
+        return 0
+    fi
+    if [ -z "$entries" ]; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "(file present but no SHAs registered)"
+        else
+            echo "  (file present but no SHAs registered)"
+        fi
+        return 0
+    fi
+    printf '%s\n' "$entries" | while IFS= read -r tok; do
+        [ -z "$tok" ] && continue
+        if type ux_bullet >/dev/null 2>&1; then
+            ux_bullet "$tok"
+        else
+            echo "  $tok"
+        fi
+    done
+}
+
 _gcp_scan() {
     # zsh compatibility: emulate POSIX sh to ensure consistent behavior
     if [ -n "${ZSH_VERSION-}" ]; then
@@ -317,6 +405,7 @@ _gcp_scan() {
     local source="upstream/main"
     local author="dEitY719"
     local arg1="" arg2=""
+    local show_skip_list=0
 
     # Check for incomplete cherry-pick
     if git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
@@ -353,6 +442,9 @@ _gcp_scan() {
                 return 1
             fi
             ;;
+        --show-skip-list)
+            show_skip_list=1
+            ;;
         *)
             # Store positional arguments without array syntax
             if [ -z "$arg1" ]; then
@@ -371,6 +463,17 @@ _gcp_scan() {
     fi
     if [ -n "$arg2" ]; then
         source="$arg2"
+    fi
+
+    # --show-skip-list (issue #1039): print the known-resolved skip list and
+    # return without scanning. Handled before the header so it stays a clean,
+    # standalone query that works outside a configured base/source.
+    if [ "$show_skip_list" -eq 1 ]; then
+        _gcp_scan_show_skip_list
+        if [ $_xtrace_set -eq 1 ]; then
+            set -x
+        fi
+        return 0
     fi
 
     # Use ux_header if available
@@ -502,6 +605,41 @@ EOF
         count=$((count - duplicate_count))
     fi
 
+    # Stage-1.4: known-resolved skip list (issue #1039). SHAs registered in
+    # git/config/gcp-scan-skip.conf (override: GCP_SCAN_SKIP_FILE) are commits a
+    # human already reconciled into HEAD (manual conflict resolution) or that
+    # depend on an unmergeable precedent — Stage-1.5/1.6 detect them correctly
+    # every run, but re-warning about an already-known skip is pure UX noise.
+    # Drop them here, BEFORE Stage-1.5/1.6, so no warning is emitted, and count
+    # them under a dedicated "Known-resolved" line. The list is IGNORED under
+    # --author=all so the full detection (safety net) is never silenced there.
+    local known_resolved_list="" known_resolved_count=0 kr_survivor_list=""
+    local skip_list=""
+    if [ "$author_lc" != "all" ]; then
+        skip_list=$(_gcp_scan_load_skip_list)
+    fi
+    if [ -n "$skip_list" ]; then
+        while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            if _gcp_scan_in_skip_list "$sha" "$skip_list"; then
+                known_resolved_list="${known_resolved_list}${sha}
+"
+                known_resolved_count=$((known_resolved_count + 1))
+            else
+                if [ -z "$kr_survivor_list" ]; then
+                    kr_survivor_list="$sha"
+                else
+                    kr_survivor_list="${kr_survivor_list}
+${sha}"
+                fi
+            fi
+        done <<EOF
+$final_selected_list
+EOF
+        final_selected_list="$kr_survivor_list"
+        count=$((count - known_resolved_count))
+    fi
+
     # Stage-1.5: file-dependency pre-check (issue #1033). A candidate that
     # modifies/deletes a file absent from base — because the upstream commit
     # that creates it was filtered out (e.g. a non-author commit) and is not
@@ -623,6 +761,9 @@ EOF
             ux_bullet "Missing (all authors): $total_count"
             ux_bullet "Author filter: $author -> 0 new commit(s)"
             ux_bullet "Duplicates (already applied): $duplicate_count"
+            if [ "$known_resolved_count" -gt 0 ]; then
+                printf "%s  ◆ Known-resolved (skipped): %d%s\n" "${UX_MUTED-}" "$known_resolved_count" "${UX_RESET-}"
+            fi
             if [ "$dep_missing_count" -gt 0 ]; then
                 printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
             fi
@@ -637,6 +778,9 @@ EOF
             echo "  Missing (all authors): $total_count"
             echo "  Author filter: $author -> 0 new commit(s)"
             echo "  Duplicates (already applied): $duplicate_count"
+            if [ "$known_resolved_count" -gt 0 ]; then
+                echo "  Known-resolved (skipped): $known_resolved_count"
+            fi
             if [ "$dep_missing_count" -gt 0 ]; then
                 echo "  Dep-missing (skipped): $dep_missing_count"
             fi
@@ -670,6 +814,9 @@ EOF
         if [ $duplicate_count -gt 0 ]; then
             ux_bullet "Duplicates (already applied): $duplicate_count"
         fi
+        if [ "$known_resolved_count" -gt 0 ]; then
+            printf "%s  ◆ Known-resolved (skipped): %d%s\n" "${UX_MUTED-}" "$known_resolved_count" "${UX_RESET-}"
+        fi
         if [ "$dep_missing_count" -gt 0 ]; then
             printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
         fi
@@ -686,6 +833,9 @@ EOF
         echo "  Author filter: $author -> $count commit(s)"
         if [ $duplicate_count -gt 0 ]; then
             echo "  Duplicates (already applied): $duplicate_count"
+        fi
+        if [ "$known_resolved_count" -gt 0 ]; then
+            echo "  Known-resolved (skipped): $known_resolved_count"
         fi
         if [ "$dep_missing_count" -gt 0 ]; then
             echo "  Dep-missing (skipped): $dep_missing_count"
@@ -750,8 +900,25 @@ EOF
     local dup_skipped=0
     local dep_skipped=0
     local conflict_skipped=0
+    local kr_skipped=0
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
+
+        # Stage-1.4 known-resolved (issue #1039): silently skip — the Analysis
+        # phase already counted it and the user registered it precisely to stop
+        # seeing a warning. No log line here (that is the whole point); the
+        # summary's "(N skipped — known-resolved)" line is the only trace.
+        local _in_kr=0
+        case "
+$known_resolved_list" in
+            *"
+$sha
+"*) _in_kr=1 ;;
+        esac
+        if [ "$_in_kr" -eq 1 ]; then
+            kr_skipped=$((kr_skipped + 1))
+            continue
+        fi
 
         # Stage-1.5 dependency-missing (issue #1033): skip with a log line so
         # the commit is never attempted — it would conflict on a modify/delete
@@ -849,6 +1016,9 @@ EOF
     # above), so report 0 conflicts.
     if type ux_success >/dev/null 2>&1; then
         ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        if [ "$kr_skipped" -gt 0 ]; then
+            ux_info "($kr_skipped commit(s) skipped — known-resolved)"
+        fi
         if [ "$dep_skipped" -gt 0 ]; then
             ux_info "($dep_skipped commit(s) skipped — file dependency missing in $base)"
         fi
@@ -863,6 +1033,9 @@ EOF
         fi
     else
         echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        if [ "$kr_skipped" -gt 0 ]; then
+            echo "  ($kr_skipped commit(s) skipped — known-resolved)"
+        fi
         if [ "$dep_skipped" -gt 0 ]; then
             echo "  ($dep_skipped commit(s) skipped — file dependency missing in $base)"
         fi

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1125,3 +1125,133 @@ FIXTURE
     assert_output --partial "foo.txt"
     refute_output --partial "rc=0"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1039 — Stage-1.4 known-resolved skip list. A commit a human has
+# already reconciled into HEAD (manual conflict resolution) or that depends on
+# an unmergeable precedent is detected correctly by Stage-1.5/1.6 every run,
+# producing repeated warning noise. Registering its SHA in the skip-list file
+# (git/config/gcp-scan-skip.conf, override GCP_SCAN_SKIP_FILE) drops it
+# SILENTLY before Stage-1.5/1.6, counted under "Known-resolved (skipped)". The
+# list is IGNORED under --author=all (full detection stays as a safety net).
+# Reuses _gcp1037_make_repo (foo.txt content-conflict fixture); the conflicting
+# "edit foo" commit is source~1.
+# ---------------------------------------------------------------------------
+
+@test "bash: _gcp_scan_load_skip_list private function exists" {
+    run_in_bash 'declare -f _gcp_scan_load_skip_list >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_scan_in_skip_list private function exists" {
+    run_in_bash 'declare -f _gcp_scan_in_skip_list >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "scan #1039: --show-skip-list prints registered SHAs, strips comments/blanks" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        skipf="$repo/skip.conf"
+        printf "deadbeef  # inline reason\n# whole-line comment\n\ncafebabe\n" > "$skipf"
+        export GCP_SCAN_SKIP_FILE="$skipf"
+        _gcp_scan main upstream/main --show-skip-list
+    '
+    assert_success
+    assert_output --partial "Known-resolved skip list"
+    assert_output --partial "deadbeef"
+    assert_output --partial "cafebabe"
+    # Reasons / full-comment lines must not be emitted as SHA tokens.
+    refute_output --partial "whole-line comment"
+    refute_output --partial "inline reason"
+}
+
+@test "scan #1039: --show-skip-list reports empty when no file registered" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        git init -q -b main
+        export GCP_SCAN_SKIP_FILE="$repo/does-not-exist.conf"
+        _gcp_scan main upstream/main --show-skip-list
+    '
+    assert_success
+    assert_output --partial "Known-resolved skip list"
+    assert_output --partial "no skip-list file"
+}
+
+@test "scan #1039: registered SHA skipped silently as known-resolved (no conflict warning)" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        conflict_sha=\$(git rev-parse source~1)
+        skipf=\"\$repo/skip.conf\"
+        printf '%s  # manually resolved, already in HEAD\n' \"\$conflict_sha\" > \"\$skipf\"
+        export GCP_SCAN_SKIP_FILE=\"\$skipf\"
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # Counted as known-resolved in the Analysis Result.
+    assert_output --partial "Known-resolved (skipped): 1"
+    # The Stage-1.6 content-conflict warning must NOT fire for the listed SHA.
+    refute_output --partial "predicted content conflict"
+    refute_output --partial "Content-conflict (skipped)"
+    # Final report carries the known-resolved skip line; no real conflict.
+    assert_output --partial "known-resolved"
+    refute_output --partial "CONFLICT"
+    refute_output --partial "Resolve and run"
+}
+
+@test "scan #1039: known-resolved commit not applied; independent commit still applied" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        conflict_sha=\$(git rev-parse source~1)
+        skipf=\"\$repo/skip.conf\"
+        printf '%s\n' \"\$conflict_sha\" > \"\$skipf\"
+        export GCP_SCAN_SKIP_FILE=\"\$skipf\"
+        printf 'y\n' | _gcp_scan main source --author=Me >/dev/null 2>&1
+        git cat-file -e HEAD:bar.txt && echo HAS_BAR
+        git show HEAD:foo.txt
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    assert_output --partial "HAS_BAR"
+    # foo.txt keeps main's content — the known-resolved edit was never applied.
+    assert_output --partial "mainline"
+    refute_output --partial "upstream"
+    assert_output --partial "PICK_CLEAR"
+}
+
+@test "scan #1039: --author=all ignores the skip list (safety net)" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        conflict_sha=\$(git rev-parse source~1)
+        skipf=\"\$repo/skip.conf\"
+        printf '%s\n' \"\$conflict_sha\" > \"\$skipf\"
+        export GCP_SCAN_SKIP_FILE=\"\$skipf\"
+        printf 'y\n' | _gcp_scan main source --author=all
+    "
+    assert_success
+    # Under --author=all the list is bypassed -> Stage-1.6 still detects it.
+    assert_output --partial "Content-conflict (skipped): 1"
+    refute_output --partial "Known-resolved (skipped)"
+}
+
+@test "scan #1039: abbreviated SHA token matches by prefix" {
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        conflict_short=\$(git rev-parse --short=8 source~1)
+        skipf=\"\$repo/skip.conf\"
+        printf '%s  # short form\n' \"\$conflict_short\" > \"\$skipf\"
+        export GCP_SCAN_SKIP_FILE=\"\$skipf\"
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    assert_output --partial "Known-resolved (skipped): 1"
+    refute_output --partial "Content-conflict (skipped)"
+}

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1255,3 +1255,40 @@ FIXTURE
     assert_output --partial "Known-resolved (skipped): 1"
     refute_output --partial "Content-conflict (skipped)"
 }
+
+@test "scan #1040: glob/short tokens rejected at load (no all-commit silent skip)" {
+    # gemini PR #1040 review: tokens are used unescaped as a `case` glob, so a
+    # stray `*`/`?` or an over-short prefix must be rejected at load time — else
+    # every commit would be silently skipped. The conflicting commit must still
+    # be detected by Stage-1.6 (i.e. the wildcard did NOT silence it).
+    run_in_bash "
+        $(_gcp1037_make_repo)
+        skipf=\"\$repo/skip.conf\"
+        printf '%s\n' '*' '?' '0' 'zz12' '012' > \"\$skipf\"
+        export GCP_SCAN_SKIP_FILE=\"\$skipf\"
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # No token survived validation -> nothing skipped as known-resolved.
+    refute_output --partial "Known-resolved (skipped)"
+    # The real content conflict is still detected (wildcard did not silence it).
+    assert_output --partial "Content-conflict (skipped): 1"
+}
+
+@test "scan #1040: --show-skip-list omits invalid tokens, keeps valid hex SHAs" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        git init -q -b main
+        skipf="$repo/skip.conf"
+        printf "%s\n" "*" "0" "deadbeef" "ab12  # ok" > "$skipf"
+        export GCP_SCAN_SKIP_FILE="$skipf"
+        _gcp_scan main upstream/main --show-skip-list
+    '
+    assert_success
+    assert_output --partial "deadbeef"
+    assert_output --partial "ab12"
+    # Wildcard and too-short token must not appear as registered SHAs.
+    refute_output --partial " *"
+}


### PR DESCRIPTION
## Summary
- `gcp scan`이 매 실행마다 Stage-1.5/1.6에서 이미 알고 있는 skip 사유를 경고로 반복 출력하던 UX 노이즈를 제거한다.
- 탐지 로직은 정확하므로 손대지 않고, UX 레이어에 known-resolved 스킵 목록을 추가하는 방식이다.

## Changes
- `shell-common/functions/gcp_scan.sh`: **Stage-1.4** 사전 분리 추가 — `git/config/gcp-scan-skip.conf`(override env `GCP_SCAN_SKIP_FILE`)에 등록된 SHA를 Stage-1.5/1.6 *이전*에 경고 없이 조용히 drop. `--show-skip-list` 플래그, 헬퍼 4종(`_gcp_scan_skip_file`/`_load_skip_list`/`_in_skip_list`/`_show_skip_list`), Analysis/실행루프/최종 summary 카운터 추가. no-fork 파라미터 확장 파싱 + prefix 매칭(단축 SHA 지원).
- `git/config/gcp-scan-skip.conf`: 신규 SSOT. 이슈의 상시 경고 두 SHA(`092d0512`, `00544238`)를 사유 주석과 함께 등록.
- `shell-common/functions/gcp.sh`: `gcp help scan` 행에 `--show-skip-list` / skip-list 안내 추가.
- `git/AGENTS.md`: 새 config 파일 참조 추가.
- `tests/bats/functions/gcp.bats`: bats 6건 추가(헬퍼 존재, `--show-skip-list`, 조용한 skip, payload 미적용, `--author=all` 무시, 단축 SHA prefix).

## Behavior
- `--author=all` 모드에서는 skip 목록을 무시 → 전체 탐지(안전망) 유지.
- 등록 SHA는 Analysis `Known-resolved (skipped): N` + 최종 `(N skipped — known-resolved)`로 집계.

## Test plan
- [x] `tests/bats/functions/gcp.bats` 신규 6건 통과
- [x] golden rules 6/6 통과 (POSIX·ux·emoji 포함), `mise run lint-sh` 통과
- [ ] 실제 repo에서 `gcp scan --show-skip-list`로 등록 SHA 확인

> 참고: 사전 존재 실패 1건(`scan #913: context-drift commit auto-skipped`)은 clean HEAD에서도 실패하는 #1037 Stage-1.6 ↔ #913 테스트 기대값 stale 이슈로 본 PR 범위 밖.

## Related
Closes #1039

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
