### PR TITLE
fix(gh-discussion): -f "body=@file" → -F 로 @file 확장 (#1043)

### DIFF
--- a/shell-common/functions/gh_discussion.sh
+++ b/shell-common/functions/gh_discussion.sh
@@ -202,7 +202,7 @@ _gh_discussion_create() {
         -f repoId="$_repo_id" \
         -f categoryId="$_category_id" \
         -f title="$_title" \
-        -f "body=@$_body_file" \
+        -F "body=@$_body_file" \
         --jq '.data.createDiscussion.discussion.url' 2>"$_err")
     local _rc=$?
 
@@ -301,7 +301,7 @@ _gh_discussion_comment() {
             }
           }' \
         -f discId="$_disc_id" \
-        -f "body=@$_body_file" \
+        -F "body=@$_body_file" \
         --jq '.data.addDiscussionComment.comment.url' 2>"$_err")
     local _rc=$?
 


### PR DESCRIPTION
## Summary
- `gh_discussion.sh` 의 discussion/comment 생성 헬퍼가 본문을 `gh api -f "body=@file"` 로 넘겨, `-f`(`--raw-field`)의 리터럴 처리 때문에 `@file` 확장이 일어나지 않고 `@/tmp/...` 경로 문자열이 그대로 저장되던 버그를 수정한다.

## Changes
- `shell-common/functions/gh_discussion.sh`: `_gh_discussion_create`(L205) / `_gh_discussion_comment`(L304) 의 `body` 필드를 `-f` → `-F`(`--field`) 로 변경 — `-F` 는 `@file` 을 파일 내용으로 확장한다. `@` 접두사가 있어 타입 추론 부작용 없음. `repoId`/`categoryId`/`title`/`discId` 등 리터럴 필드는 `-f` 유지.

## Test plan
- [ ] `_gh_discussion_create` 로 생성한 Discussion 본문에 마크다운(표/코드블록)이 그대로 렌더링됨
- [ ] `_gh_discussion_comment` 댓글 본문도 정상
- [ ] `tests/bats/functions/gh_discussion.bats` 통과
- [ ] shellcheck / shfmt 통과

## Related
Closes #1043

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
