### PR TITLE
fix(ssh): SSAI IdentityFile 경로를 ~ 기반으로 변경

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -32,7 +32,7 @@ Host github.com
 # ==========================================
 # SSAI 프로젝트 공통 설정 (IdentityFile 통합 관리)
 Host ssai-* server-ssai-*
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
+    IdentityFile ~/.ssh/id_rsa_ssai_bwyoon
     IdentitiesOnly yes
 
 # SSAI 개발 서버


### PR DESCRIPTION
## 요약

`ssh/config`의 SSAI 프로젝트 공통 설정(`Host ssai-* server-ssai-*`)에서 `IdentityFile` 값이 Windows 절대경로로 하드코딩되어 비-Windows 환경에서 SSAI 서버 SSH 인증이 실패하던 문제를 해결한다.

```diff
-    IdentityFile C:/Users/byoungwoo.yoon/.ssh/id_rsa_ssai_bwyoon
+    IdentityFile ~/.ssh/id_rsa_ssai_bwyoon
```

`~` 기반 경로로 변경하면 각 환경의 홈 디렉터리 기준으로 해석되어, OpenSSH가 WSL/Linux/macOS/Windows 어디서든 동일하게 키 파일을 찾는다.

## 배경

사내 PC에서 검증한 결과, Windows 절대경로(`C:/Users/...`)가 다른 환경에서 키 파일을 찾지 못하는 직접 원인으로 확인되었다. 1줄 수정으로 해결.

## 검증

- [x] 사내 PC 검증에서 원인 확인 및 수정 동작 확인
- [ ] `ssh/config`에 `C:/Users/...` 형태 하드코딩 경로 부재
- [ ] 사내 PC `git pull` 후 SSAI 서버 SSH 접속 정상 동작

Closes #1044
