### PR TITLE
feat(claude-skill): karakeep:add / karakeep:classify 북마크 추가·분류-제안 스킬 신설

### DIFF
--- a/claude/skills/karakeep-add/SKILL.md
+++ b/claude/skills/karakeep-add/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: karakeep:add
+description: >-
+  Add a URL to a Karakeep List via REST, creating the List (and any nested
+  parent path) on demand. Use when the user runs /karakeep:add,
+  /karakeep-add, or asks "이 URL Karakeep <list>에 넣어줘", "북마크를
+  github/repository 에 추가", "add <url> to list <path>". Idempotent —
+  reuses an existing bookmark for the same URL and an existing List for the
+  same name/parent, so re-runs never duplicate. Writes directly to the live
+  Karakeep instance (base URL = `.env` `NEXTAUTH_URL`, not localhost) and
+  verifies membership after attaching. Respects the Company confidentiality
+  boundary (refuses public/personal URLs into `Company` or its children).
+  Sister skill of [[karakeep:classify]] — that one suggests a List (default
+  dry-run); this one performs the write. Accepts `<url> --list <path>` and
+  `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "deterministic REST writes, but needs judgment for the Company guardrail and nested-path creation"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# karakeep:add — URL → List (write path via REST)
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Role
+
+Add `<url>` to the Karakeep List at `<path>`, creating the List (and every
+missing parent in a nested `부모/자식` path) first. The write path is pure
+REST — `KarakeepClient` in the karakeep-sync project is read/sync only and
+has no create/attach methods. Idempotent end to end.
+
+## Step 1: Parse Args + Load Env
+
+Positional `<url>`; required flag `--list <path>` (slash-delimited nesting).
+Missing either → print the usage pointer (`Run /karakeep-add -h for usage.`)
+and stop.
+
+Load `NEXTAUTH_URL` and `KARAKEEP_API_KEY` from the working directory's
+`.env` per `references/rest-mechanics.md` → "Env + base URL". If either is
+unset, **fail clearly** — never guess a base URL or hardcode `localhost`.
+
+## Step 2: Company Guardrail
+
+If `<path>` is `Company` or starts with `Company/`, refuse unless the URL is
+explicitly company-internal and the user confirmed. Public/personal URLs
+into the Company subtree are blocked — see `references/rest-mechanics.md`
+→ "Company boundary". This is acceptance-criterion-critical, not advisory.
+
+## Step 3: Resolve / Create the List Path
+
+Walk `<path>` segment by segment from the root, per
+`references/rest-mechanics.md` → "Resolve or create a List". For each
+segment: look it up under the current parent; reuse its id if present,
+else `POST /api/v1/lists` with an emoji `icon` and the running `parentId`.
+List membership is preserved by full path, so create parents first.
+
+## Step 4: Resolve / Create the Bookmark
+
+Dedup by `url.rstrip("/")` per `references/rest-mechanics.md` → "Resolve or
+create a bookmark". Found → reuse its id. Not found → `POST
+/api/v1/bookmarks` `{type:"link", url, title}`.
+
+## Step 5: Attach + Verify
+
+`PUT /api/v1/lists/<list_id>/bookmarks/<bookmark_id>` (idempotent, empty
+body on success), then `GET /api/v1/lists/<list_id>/bookmarks` and confirm
+the bookmark id is present. Report the final List path, list id, bookmark
+id, and a verified/not-verified verdict.
+
+## Step 6: Report
+
+Print a `[OK]` / `[FAIL]` line with the List path, ids, and whether each
+List/bookmark was created or reused (proves idempotency). End with the
+`Next:` hint: `karakeep:classify <url>` for the suggest flow, or re-run to
+confirm the no-op. Error templates: `references/rest-mechanics.md`
+→ "Error cases".
+
+## Constraints
+
+- Base URL is always `NEXTAUTH_URL` — never `localhost:3001` (that is the
+  `config.yaml` internal value, wrong for live writes).
+- Idempotent: never create a duplicate List (same name+parent) or bookmark
+  (same `url.rstrip("/")`).
+- Never write a public/personal URL into the `Company` subtree.
+- This skill only touches the live Karakeep instance — it does not edit the
+  karakeep-sync repo or run `karakeep-sync push` (next push materializes).

--- a/claude/skills/karakeep-add/references/help.md
+++ b/claude/skills/karakeep-add/references/help.md
@@ -1,0 +1,44 @@
+# karakeep:add — Help
+
+## Arguments
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `<url>` | — | The URL to bookmark (required). |
+| `--list <path>` | — | Target List, slash-nested e.g. `github/repository` (required). |
+| `-h` / `--help` / `help` | — | Print this help and stop. |
+
+## Usage
+
+- `/karakeep-add https://github.com/dEitY719/dotfiles --list github/repository`
+  — create the `github` → `repository` path if missing, bookmark the URL,
+  attach it, and verify membership.
+- `/karakeep-add <url> --list reading/longform` — nested two levels deep.
+- `/karakeep-add -h` — print this help.
+
+## What the skill does
+
+1. Loads `NEXTAUTH_URL` + `KARAKEEP_API_KEY` from `./.env` (no localhost
+   fallback, no guessing).
+2. Enforces the Company confidentiality boundary before any write.
+3. Walks the `--list` path, reusing or creating each segment (emoji icon
+   required by the API), parents first.
+4. Dedups the bookmark by `url.rstrip("/")` — reuses an existing bookmark or
+   creates a new one.
+5. Attaches the bookmark to the List (`PUT`, idempotent) and verifies via
+   `GET /api/v1/lists/<id>/bookmarks`.
+6. Reports the path, ids, created-vs-reused for each, and a verified verdict.
+
+## What the skill will NOT do
+
+- Use `localhost:3001` — the live base URL is always `NEXTAUTH_URL`.
+- Create a duplicate List or bookmark on re-run (idempotent).
+- Put a public/personal URL into `Company` or its children.
+- Run `karakeep-sync push` or edit the karakeep-sync repo (next push
+  materializes the change to Obsidian on its own).
+- Bulk-import — that is `import-chrome`'s job.
+
+## Related
+
+- `karakeep:classify <url>` — analyze a URL and suggest the best List
+  (default dry-run); `--apply` delegates to this skill.

--- a/claude/skills/karakeep-add/references/rest-mechanics.md
+++ b/claude/skills/karakeep-add/references/rest-mechanics.md
@@ -1,0 +1,114 @@
+# karakeep:add — REST mechanics
+
+All calls are plain `curl` against the **live** Karakeep instance. The
+karakeep-sync project's `KarakeepClient` is read/sync only — it has no
+List-create or attach method, so REST is the correct (and verified) path.
+
+## Env + base URL
+
+Load from the working directory's `.env` (do not hardcode):
+
+```bash
+set -a; . ./.env 2>/dev/null; set +a
+: "${NEXTAUTH_URL:?NEXTAUTH_URL not set — refusing to guess base URL}"
+: "${KARAKEEP_API_KEY:?KARAKEEP_API_KEY not set — cannot authenticate}"
+BASE="${NEXTAUTH_URL%/}"
+AUTH="Authorization: Bearer ${KARAKEEP_API_KEY}"
+```
+
+- **Base URL is `NEXTAUTH_URL`** (e.g. `https://karakeep.tail7f8427.ts.net`),
+  reachable from home/internal over tailscale. It is **not** the
+  `config.yaml` `localhost:3001` value.
+- If either var is unset, fail with the message above — never invent a URL.
+
+## Resolve or create a List
+
+Lists nest via `parentId`. To resolve a slash path like `github/repository`,
+start at the root and walk one segment at a time, carrying `parentId`.
+
+```bash
+# List all lists once, then match by name + parentId locally.
+curl -fsS -H "$AUTH" "$BASE/api/v1/lists" | jq -c '.lists[]'
+```
+
+For each segment:
+- Match an existing list where `name == <segment>` and `parentId` equals the
+  running parent (`null` at the root). Found → reuse `.id`.
+- Not found → create it:
+
+```bash
+curl -fsS -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  "$BASE/api/v1/lists" \
+  -d '{"name":"<segment>","icon":"<emoji>","parentId":<parentId-or-omit>}' | jq -r '.id'
+```
+
+`icon` is **required** by the API and must be a single emoji — substitute a
+sensible one for `<emoji>` (a folder glyph as default, or a topic-fitting
+one). Omit `parentId` (or send `null`) for a root list.
+Creating parents first preserves full-path membership. Idempotent: a second
+run finds every segment and creates nothing.
+
+## Resolve or create a bookmark
+
+Dedup on the trailing-slash-stripped URL:
+
+```bash
+KEY="$(printf '%s' "$URL" | sed 's:/*$::')"   # url.rstrip("/")
+```
+
+Search existing bookmarks for one whose URL (also stripped) equals `KEY`;
+reuse its id. None → create:
+
+```bash
+curl -fsS -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  "$BASE/api/v1/bookmarks" \
+  -d '{"type":"link","url":"<url>","title":"<title>"}' | jq -r '.id'
+```
+
+`title` may be the URL itself when no better title is known; Karakeep
+backfills metadata asynchronously.
+
+## Attach + verify
+
+```bash
+# Idempotent; success returns an empty body / 2xx.
+curl -fsS -X PUT -H "$AUTH" \
+  "$BASE/api/v1/lists/<list_id>/bookmarks/<bookmark_id>"
+
+# Verify membership.
+curl -fsS -H "$AUTH" "$BASE/api/v1/lists/<list_id>/bookmarks" \
+  | jq -e --arg id "<bookmark_id>" '.bookmarks[] | select(.id==$id)' >/dev/null \
+  && echo verified || echo NOT-verified
+```
+
+## Reading the live tree on an external host
+
+When REST is awkward or the host is external, read the SQLite DB directly —
+the `sqlite3` CLI is not installed, so use Python stdlib:
+
+```bash
+python3 - <<'PY'
+import sqlite3
+db = sqlite3.connect("data/db.db")
+for row in db.execute("SELECT id, name, parentId FROM bookmarkLists"):
+    print(row)
+PY
+```
+
+## Company boundary
+
+`Company` and every descendant list form a confidentiality boundary
+(CLAUDE.md §4.3). Refuse to attach a public or personal URL anywhere under
+`Company/`. Only proceed if the URL is genuinely company-internal **and** the
+user confirmed the target. When refusing, name the rule and suggest a
+non-Company list instead.
+
+## Error cases
+
+| Situation | Behavior |
+|---|---|
+| List name already exists under parent | Skip create, reuse existing id (idempotent). |
+| URL already bookmarked | Skip create, attach existing bookmark id only. |
+| `NEXTAUTH_URL` / `KARAKEEP_API_KEY` unset | Fail clearly, no fallback guess. |
+| Public URL → `Company` subtree | Block with a warning; do not write. |
+| `curl` non-2xx | Print status + response body, stop; do not retry blindly. |

--- a/claude/skills/karakeep-add/references/rest-mechanics.md
+++ b/claude/skills/karakeep-add/references/rest-mechanics.md
@@ -9,7 +9,7 @@ List-create or attach method, so REST is the correct (and verified) path.
 Load from the working directory's `.env` (do not hardcode):
 
 ```bash
-set -a; . ./.env 2>/dev/null; set +a
+set -a; [ -f ./.env ] && . ./.env; set +a   # guard: sourcing a missing file aborts a POSIX shell
 : "${NEXTAUTH_URL:?NEXTAUTH_URL not set — refusing to guess base URL}"
 : "${KARAKEEP_API_KEY:?KARAKEEP_API_KEY not set — cannot authenticate}"
 BASE="${NEXTAUTH_URL%/}"
@@ -28,23 +28,28 @@ start at the root and walk one segment at a time, carrying `parentId`.
 
 ```bash
 # List all lists once, then match by name + parentId locally.
-curl -fsS -H "$AUTH" "$BASE/api/v1/lists" | jq -c '.lists[]'
+# `.lists[]?` (not `.lists[]`) — null-safe if the field is missing/null.
+curl -fsS -H "$AUTH" "$BASE/api/v1/lists" | jq -c '.lists[]?'
 ```
 
-For each segment:
-- Match an existing list where `name == <segment>` and `parentId` equals the
+For each segment (bound to shell vars `SEGMENT`, `EMOJI`, `PARENT_ID` — not
+`<...>` placeholders, which a shell would read as redirection):
+- Match an existing list where `name == $SEGMENT` and `parentId` equals the
   running parent (`null` at the root). Found → reuse `.id`.
-- Not found → create it:
+- Not found → create it. Build the JSON with `jq -n` so values are always
+  escaped (a raw `-d '{"name":"'"$SEGMENT"'"...}'` breaks or injects when a
+  value contains `"` or `\`):
 
 ```bash
+payload=$(jq -n --arg name "$SEGMENT" --arg icon "$EMOJI" --arg parentId "$PARENT_ID" \
+  '{name: $name, icon: $icon, parentId: (if $parentId == "" then null else $parentId end)}')
 curl -fsS -X POST -H "$AUTH" -H 'Content-Type: application/json' \
-  "$BASE/api/v1/lists" \
-  -d '{"name":"<segment>","icon":"<emoji>","parentId":<parentId-or-omit>}' | jq -r '.id'
+  "$BASE/api/v1/lists" -d "$payload" | jq -r '.id'
 ```
 
-`icon` is **required** by the API and must be a single emoji — substitute a
-sensible one for `<emoji>` (a folder glyph as default, or a topic-fitting
-one). Omit `parentId` (or send `null`) for a root list.
+`icon` is **required** by the API and must be a single emoji — set `EMOJI` to
+a sensible one (a folder glyph as default, or a topic-fitting one). Leave
+`PARENT_ID` empty for a root list (the `jq` expression emits `null`).
 Creating parents first preserves full-path membership. Idempotent: a second
 run finds every segment and creates nothing.
 
@@ -60,24 +65,27 @@ Search existing bookmarks for one whose URL (also stripped) equals `KEY`;
 reuse its id. None → create:
 
 ```bash
+payload=$(jq -n --arg url "$URL" --arg title "$TITLE" \
+  '{type:"link", url:$url, title:$title}')
 curl -fsS -X POST -H "$AUTH" -H 'Content-Type: application/json' \
-  "$BASE/api/v1/bookmarks" \
-  -d '{"type":"link","url":"<url>","title":"<title>"}' | jq -r '.id'
+  "$BASE/api/v1/bookmarks" -d "$payload" | jq -r '.id'
 ```
 
-`title` may be the URL itself when no better title is known; Karakeep
-backfills metadata asynchronously.
+`TITLE` may be the URL itself when no better title is known; Karakeep
+backfills metadata asynchronously. As above, `jq -n` keeps the payload valid
+even when the URL or title contains quotes or backslashes.
 
 ## Attach + verify
 
 ```bash
-# Idempotent; success returns an empty body / 2xx.
+# Idempotent; success returns an empty body / 2xx. (LIST_ID / BOOKMARK_ID are
+# shell vars, not `<...>` placeholders.)
 curl -fsS -X PUT -H "$AUTH" \
-  "$BASE/api/v1/lists/<list_id>/bookmarks/<bookmark_id>"
+  "$BASE/api/v1/lists/$LIST_ID/bookmarks/$BOOKMARK_ID"
 
-# Verify membership.
-curl -fsS -H "$AUTH" "$BASE/api/v1/lists/<list_id>/bookmarks" \
-  | jq -e --arg id "<bookmark_id>" '.bookmarks[] | select(.id==$id)' >/dev/null \
+# Verify membership. `.bookmarks[]?` is null-safe.
+curl -fsS -H "$AUTH" "$BASE/api/v1/lists/$LIST_ID/bookmarks" \
+  | jq -e --arg id "$BOOKMARK_ID" '.bookmarks[]? | select(.id==$id)' >/dev/null \
   && echo verified || echo NOT-verified
 ```
 

--- a/claude/skills/karakeep-classify/SKILL.md
+++ b/claude/skills/karakeep-classify/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: karakeep:classify
+description: >-
+  Analyze a URL and suggest the best-fit Karakeep List, comparing it against
+  the live List tree — default dry-run (prints the proposal, writes nothing).
+  Use when the user runs /karakeep:classify, /karakeep-classify, or asks
+  "이 URL 어느 list 가 좋을지", "분류 제안해줘", "where should this bookmark
+  go", "triage <url>". When no existing List fits, proposes a new (possibly
+  nested) List structure. `--apply` executes the proposal by delegating to
+  [[karakeep:add]]; otherwise the user confirms with `karakeep:add <url>
+  --list <path>`. Honors the Company confidentiality boundary — never
+  suggests a public/personal URL into `Company` or its children. Reads the
+  live tree via REST (base URL = `.env` `NEXTAUTH_URL`). Sister skill of
+  [[karakeep:add]] — that one writes; this one decides. Accepts `<url>`,
+  `--apply`, and `-h`/`--help`/`help` to print usage.
+allowed-tools: Bash, Read, WebFetch
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "judgment task — fits URL content against a live taxonomy and reasons about the Company boundary"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# karakeep:classify — Suggest a List for a URL (default dry-run)
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Role
+
+Decide where `<url>` belongs in Karakeep. Compare the URL's topic against
+the live List tree and recommend the best-fit existing List, or — when
+nothing fits — propose a new (possibly nested) List path. **Default is
+dry-run**: print the proposal and write nothing. This skill is the "judge";
+the "write" is `karakeep:add`.
+
+## Step 1: Parse Args + Load Env
+
+Positional `<url>` (required → else usage pointer `Run /karakeep-classify -h
+for usage.`). Flag `--apply` switches from dry-run to execution.
+
+Load `NEXTAUTH_URL` + `KARAKEEP_API_KEY` from `./.env` per
+`references/classify-mechanics.md` → "Env + read the tree". Unset → fail
+clearly, no localhost fallback.
+
+## Step 2: Read the Live List Tree
+
+Fetch the current List tree via REST (`GET /api/v1/lists`), reconstructing
+full nested paths from `parentId`. See `references/classify-mechanics.md`
+→ "Env + read the tree".
+
+## Step 3: Analyze the URL
+
+Determine the URL's topic from its host/path and, when useful, a WebFetch of
+the page title + meta description (do not deep-fetch bodies by default). Keep
+it lightweight — title/host/path usually suffice.
+
+## Step 4: Match or Propose
+
+Pick the best-fit existing List path. If none is a good fit, propose a new
+(possibly nested) path with a one-line rationale. Apply the Company
+guardrail at proposal time: never suggest a public/personal URL into
+`Company/*` — see `references/classify-mechanics.md` → "Company boundary".
+
+## Step 5: Output (dry-run) or Apply
+
+- **dry-run (default)** — print: the analyzed topic, the recommended path,
+  whether it exists or would be created, a confidence note, and the exact
+  follow-up command `karakeep:add <url> --list <path>`. Write nothing.
+- **`--apply`** — hand the chosen `<url>` + `<path>` to `karakeep:add`
+  (Skill(karakeep:add, "<url> --list <path>")); it owns creation, dedup,
+  attach, and verification.
+
+## Step 6: Report
+
+End with a `[DRY-RUN]` or `[APPLIED]` verdict line and the `Next:` hint —
+dry-run → the `karakeep:add` command to confirm; applied → re-run classify
+to confirm the no-op.
+
+## Constraints
+
+- Default writes nothing — only `--apply` mutates, and only via
+  `karakeep:add` (no duplicate REST write logic here).
+- Base URL is always `NEXTAUTH_URL`, never `localhost:3001`.
+- Never propose or apply a public/personal URL under the `Company` subtree.
+- Lightweight analysis — title/meta over full-body fetch unless the user
+  asks for deeper inspection.

--- a/claude/skills/karakeep-classify/references/classify-mechanics.md
+++ b/claude/skills/karakeep-classify/references/classify-mechanics.md
@@ -8,7 +8,7 @@ This skill is read + judge only. The single write path lives in
 Load from the working directory's `.env` (no hardcoded base URL):
 
 ```bash
-set -a; . ./.env 2>/dev/null; set +a
+set -a; [ -f ./.env ] && . ./.env; set +a   # guard: sourcing a missing file aborts a POSIX shell
 : "${NEXTAUTH_URL:?NEXTAUTH_URL not set — refusing to guess base URL}"
 : "${KARAKEEP_API_KEY:?KARAKEEP_API_KEY not set — cannot authenticate}"
 BASE="${NEXTAUTH_URL%/}"
@@ -20,7 +20,7 @@ Base URL is `NEXTAUTH_URL` (tailscale-reachable), **not** the `config.yaml`
 
 ```bash
 curl -fsS -H "$AUTH" "$BASE/api/v1/lists" \
-  | jq -r '.lists[] | "\(.id)\t\(.parentId // "")\t\(.name)"'
+  | jq -r '.lists[]? | "\(.id)\t\(.parentId // "")\t\(.name)"'
 # Then join child -> parent on id to print full "부모/자식" paths.
 ```
 
@@ -34,8 +34,11 @@ db = sqlite3.connect("data/db.db")
 rows = {r[0]: (r[1], r[2]) for r in
         db.execute("SELECT id, parentId, name FROM bookmarkLists")}
 def path(i):
-    name, parent = rows[i][1], rows[i][0]
-    return (path(parent) + "/" if parent else "") + name
+    if i not in rows:          # dangling parentId → stop, don't KeyError
+        return ""
+    parent, name = rows[i]     # row is (parentId, name)
+    p = path(parent) if parent else ""
+    return f"{p}/{name}" if p else name
 for i in rows:
     print(path(i))
 PY

--- a/claude/skills/karakeep-classify/references/classify-mechanics.md
+++ b/claude/skills/karakeep-classify/references/classify-mechanics.md
@@ -1,0 +1,68 @@
+# karakeep:classify — mechanics
+
+This skill is read + judge only. The single write path lives in
+`karakeep:add`; `--apply` delegates there rather than duplicating REST logic.
+
+## Env + read the tree
+
+Load from the working directory's `.env` (no hardcoded base URL):
+
+```bash
+set -a; . ./.env 2>/dev/null; set +a
+: "${NEXTAUTH_URL:?NEXTAUTH_URL not set — refusing to guess base URL}"
+: "${KARAKEEP_API_KEY:?KARAKEEP_API_KEY not set — cannot authenticate}"
+BASE="${NEXTAUTH_URL%/}"
+AUTH="Authorization: Bearer ${KARAKEEP_API_KEY}"
+```
+
+Base URL is `NEXTAUTH_URL` (tailscale-reachable), **not** the `config.yaml`
+`localhost:3001` value. Read the List tree and rebuild nested paths:
+
+```bash
+curl -fsS -H "$AUTH" "$BASE/api/v1/lists" \
+  | jq -r '.lists[] | "\(.id)\t\(.parentId // "")\t\(.name)"'
+# Then join child -> parent on id to print full "부모/자식" paths.
+```
+
+On an external host where REST is awkward, read SQLite directly (the
+`sqlite3` CLI is absent — use Python stdlib):
+
+```bash
+python3 - <<'PY'
+import sqlite3
+db = sqlite3.connect("data/db.db")
+rows = {r[0]: (r[1], r[2]) for r in
+        db.execute("SELECT id, parentId, name FROM bookmarkLists")}
+def path(i):
+    name, parent = rows[i][1], rows[i][0]
+    return (path(parent) + "/" if parent else "") + name
+for i in rows:
+    print(path(i))
+PY
+```
+
+## Analyzing the URL
+
+Cheapest signal first: host + path segments. When ambiguous, WebFetch the
+page for its `<title>` and `meta description` only — do not fetch full
+article bodies by default. Map the topic to the closest existing path; if
+the gap is large, propose a new path (prefer extending an existing parent
+over a brand-new root).
+
+## Company boundary
+
+`Company` and its descendants are a confidentiality boundary (CLAUDE.md
+§4.3). Never recommend a public or personal URL into `Company/*`, even when
+the topic seems to match — the boundary is about provenance, not topic.
+State the rule if the user pushes a public URL toward Company, and offer a
+non-Company alternative.
+
+## Delegating on --apply
+
+```
+Skill(karakeep:add, "<url> --list <chosen-path>")
+```
+
+`karakeep:add` owns List/parent creation, `url.rstrip("/")` dedup, the
+idempotent attach, and post-attach verification. This skill never issues a
+write `curl` itself.

--- a/claude/skills/karakeep-classify/references/help.md
+++ b/claude/skills/karakeep-classify/references/help.md
@@ -1,0 +1,43 @@
+# karakeep:classify — Help
+
+## Arguments
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `<url>` | — | The URL to classify (required). |
+| `--apply` | off (dry-run) | Execute the proposal by delegating to `karakeep:add`. |
+| `-h` / `--help` / `help` | — | Print this help and stop. |
+
+## Usage
+
+- `/karakeep-classify https://github.com/dEitY719/dotfiles` — analyze and
+  print the suggested List path; write nothing (dry-run).
+- `/karakeep-classify <url> --apply` — analyze, then immediately add the URL
+  to the chosen List via `karakeep:add`.
+- `/karakeep-classify -h` — print this help.
+
+## What the skill does
+
+1. Loads `NEXTAUTH_URL` + `KARAKEEP_API_KEY` from `./.env` (no localhost
+   fallback).
+2. Reads the live List tree (REST `GET /api/v1/lists`, or SQLite on an
+   external host) and rebuilds nested paths.
+3. Analyzes the URL — host/path first, lightweight WebFetch of title/meta
+   only when ambiguous.
+4. Recommends the best-fit existing List, or proposes a new (possibly
+   nested) path when nothing fits, with a short rationale and confidence.
+5. **Dry-run by default**: prints the proposal + the exact `karakeep:add`
+   follow-up command. With `--apply`, delegates to `karakeep:add` to write.
+
+## What the skill will NOT do
+
+- Write anything in the default dry-run mode.
+- Duplicate `karakeep:add`'s write logic — `--apply` always delegates.
+- Use `localhost:3001` — base URL is always `NEXTAUTH_URL`.
+- Suggest or apply a public/personal URL into `Company` or its children.
+- Deep-fetch full page bodies unless explicitly asked.
+
+## Related
+
+- `karakeep:add <url> --list <path>` — the write path this skill delegates
+  to under `--apply`, and the command printed for manual confirmation.


### PR DESCRIPTION
## 요약

Karakeep 북마크 운영 중 **신규 List 생성·분류 고민** 상황만 Claude 에게 위임하기 위한 `karakeep:` 네임스페이스 2-skill 신설. 이슈 #1047 권장안 그대로 write(add) vs judge(classify) 관심사 분리.

## 변경 내용

- **`karakeep:add <url> --list <path>`** (`claude/skills/karakeep-add/`)
  - nested List 경로를 부모부터 멱등 생성, `url.rstrip("/")` 기준 북마크 dedup, `PUT` 편입 후 `GET .../bookmarks` 로 검증.
  - write 경로는 `KarakeepClient`(read/sync 전용) 대신 REST 직접 호출.
- **`karakeep:classify <url>`** (`claude/skills/karakeep-classify/`)
  - live List 트리 대조 후 best-fit 제안. **기본 dry-run** (아무것도 안 씀), `--apply` 시 `karakeep:add` 로 위임해 write 로직 단일화.
  - host/path 우선 분석, 모호할 때만 title/meta WebFetch.
- **공통 규칙**
  - base URL = `.env` `NEXTAUTH_URL` (localhost:3001 하드코딩 금지).
  - Company(및 children) List 기밀 경계 — 공개/개인 URL 제안·편입 차단.
  - API 필수 emoji icon 은 no-emoji 규칙 준수 위해 글리프 대신 `<emoji>` 텍스트로 표기.

## 수용 기준

- [x] add: nested List 생성 + 편입 + 검증 출력
- [x] 동일 URL/List 재실행 시 중복 생성 없음 (멱등)
- [x] classify 기본 dry-run, 아무것도 안 씀
- [x] `--apply` / 후속 add 로 제안 반영
- [x] Company 경계 — 공개/개인 URL 차단
- [x] base URL = `NEXTAUTH_URL`

## Open Questions 결정 (issue 권장 채택)

- 1 vs 2 스킬 → 2개 분리 (write vs judge)
- 분석 깊이 → host/path 우선, 모호 시 title/meta (본문 deep-fetch 안 함)
- REST vs KarakeepClient → 단기 검증 경로인 REST 직접 호출

## 검증

- golden rules 전체 통과 (Rule 4 이모지 규칙 포함)
- 두 SKILL.md frontmatter YAML 유효, 각 <100 lines, references 분리(progressive disclosure)
- entry-level symlink 자동 발견 — 레지스트리/AGENTS.md 갱신 불필요

Closes #1047

<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics -->
📊 ~6000 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics -->

</details>
