### PR TITLE
feat(gitconfig): github.samsungds.net credential helper 항목 추가

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -28,3 +28,7 @@
 	helper =
 	useHttpPath = true
 	helper = !${DOTFILES_ROOT:-$HOME/dotfiles}/git/scripts/gh-credential-helper.sh
+[credential "https://github.samsungds.net"]
+	helper =
+	useHttpPath = true
+	helper = !${DOTFILES_ROOT:-$HOME/dotfiles}/git/scripts/gh-credential-helper.sh


### PR DESCRIPTION
## Summary
- `git/.gitconfig`에 `github.samsungds.net` GHE 호스트에 대한 credential helper 항목 추가
- HTTPS push 시 인증 실패 문제(`fatal: Authentication failed`) 해결

## Changes
- gitconfig: `[credential "https://github.samsungds.net"]` 블록 추가 — `github.com` / `gist.github.com` 과 동일하게 `gh-credential-helper.sh` 경유하도록 설정

## Test plan
- [ ] `github.samsungds.net` 레포에 HTTPS URL로 `git push` 성공 확인
- [ ] `github.com` push가 기존과 동일하게 동작하는지 확인

## Related
Closes #1049

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
