### PR TITLE
docs(ssot): pc-environment.md 라우팅 배선 및 모드 용어 정정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 ## Standards & References
 
 - 운영 교훈 지식 베이스: `docs/guide/learnings/` (반복 실수 예방용 패턴 모음)
+- PC 환경 SSOT (5개 PC, `~/.dotfiles-setup-mode` 모드): `docs/.ssot/pc-environment.md` — 환경에 따라 동작이 달라지는 작업(계정 전환, git host, 프록시)을 다룰 때는 먼저 `cat ~/.dotfiles-setup-mode` 로 현재 모드를 확인한다.
 - Command/help interface: `docs/.ssot/command-guidelines.md`
 - GitHub Project board: `docs/.ssot/github-project-board.md`
 - GitHub Discussions 운영: `docs/.ssot/discussions-policy.md`

--- a/docs/.ssot/README.md
+++ b/docs/.ssot/README.md
@@ -22,6 +22,7 @@
 | [`discussions-policy.md`](./discussions-policy.md) | GitHub Discussions 카테고리·라우팅·변환 규약 |
 | [`commit-message-standard.md`](./commit-message-standard.md) | 브랜치 명명·커밋 메시지·work_log 자동화 |
 | [`local-test-policy.md`](./local-test-policy.md) | 테스트 실행 위치 정책 — CI = lint only, 로컬 pre-push = `mise run test` (이슈 #754) |
+| [`pc-environment.md`](./pc-environment.md) | 5개 PC 환경(internal/external/public) 인벤토리, `~/.dotfiles-setup-mode` 모드 스위치, 모드별 동기화·AI 태깅 규칙 |
 
 ## 변경 절차
 

--- a/docs/.ssot/pc-environment.md
+++ b/docs/.ssot/pc-environment.md
@@ -1,0 +1,38 @@
+# PC Environment (SSOT)
+
+내 개발 환경: **5개 PC 환경의 단일 진실 공급원(SSOT)**.
+
+> 비밀(토큰·CA·내부 호스트·회사명)은 이 문서에 적지 않는다.
+> 이 repo 가 public 이면 이 문서는 토폴로지만 담아야 한다.
+
+## 1. 공통 전제
+
+- 모든 PC: **Windows + WSL**. Windows 사용자명과 WSL 사용자명은 **PC마다 다름**
+  → 경로를 하드코딩하지 말고 런타임에 탐지한다 (부트스트랩 스크립트 참고).
+- 모드 스위치: `~/.dotfiles-setup-mode` 파일에 `internal` | `external` | `public` 중 하나 (`public` = home/개인 PC; `shell-common/setup.sh` 가 쓰는 실제 값).
+
+## 2. PC 인벤토리 (5대)
+
+| 모드 | 대수 | 사양 / LLM | 네트워크 | 비고 |
+|------|------|-----------|----------|------|
+| `internal` | 2 | 1대만 사내 local LLM 연동 가능 | 사내망 | GHES 사용 |
+| `external` | 1 | 최고 사양, **Ollama 로컬 서빙** | 회사에서 외부 접속 가능 | (이 세션 PC) |
+| `public` | 2 | 노트북, 저사양 → **local LLM 불가** | 집 | |
+
+
+## 3. 접근/동기화 규칙 (모드별)
+
+| 모드 | GitHub (common) | GHES (company) | AI 자동 태깅 |
+|------|-----------------|----------------|--------------|
+| `internal` | **pull only** (upstream, push 절대 금지) | **read/write** | local LLM 있는 1대만 |
+| `external` | read/write | 접속 불가 | Ollama 로컬 |
+| `public` | read/write | 접속 불가 | 없음 (재태깅은 다른 PC에서) |
+
+## 4. 모드가 바꾸는 것 (코드 SSOT)
+
+| 항목 | 위치 | 비고 |
+|------|------|------|
+| Claude 계정 활성화 | `shell-common/env/claude.sh` | `internal` → work 계정만; 그 외 → personal/work/work1 |
+| Git host 라우팅 | `shell-common/functions/gh_host.sh` | `internal` → GHES, 그 외 → github.com |
+| 프록시 자동 정리 | `shell-common/util/setup_mode.sh` | WSL2 프록시 상속 방지 (레거시 숫자값만 매칭 — issue 필요) |
+| Bedrock 비용 위젯 | `claude/statusline-command.sh` | `internal` 에서만 표시 |

--- a/docs/.ssot/pc-environment.md
+++ b/docs/.ssot/pc-environment.md
@@ -34,5 +34,5 @@
 |------|------|------|
 | Claude 계정 활성화 | `shell-common/env/claude.sh` | `internal` → work 계정만; 그 외 → personal/work/work1 |
 | Git host 라우팅 | `shell-common/functions/gh_host.sh` | `internal` → GHES, 그 외 → github.com |
-| 프록시 자동 정리 | `shell-common/util/setup_mode.sh` | WSL2 프록시 상속 방지 (레거시 숫자값만 매칭 — issue 필요) |
-| Bedrock 비용 위젯 | `claude/statusline-command.sh` | `internal` 에서만 표시 |
+| 프록시 자동 정리 | `shell-common/util/setup_mode.sh` | WSL2 프록시 상속 방지 (레거시 숫자값만 매칭, 문자열 값 미지원 — issue #1051) |
+| Bedrock 비용 위젯 | `claude/statusline-command.sh` | `internal` 에서만 표시 (레거시 숫자값 `2`는 미지원 — 별도 확인 필요) |


### PR DESCRIPTION
## Summary
- `docs/.ssot/pc-environment.md`가 SSOT 라우팅 체인(README 인덱스, CLAUDE.md References)에 연결되지 않아 발견되지 않는 문제를 해소한다.
- 문서의 모드 값 표기를 코드 실제값(`public`)에 맞춰 정정하고, 모드별로 달라지는 코드 동작을 표로 명시한다.

## Changes
- `docs/.ssot/README.md`: 인덱스 표에 `pc-environment.md` 행 추가.
- `CLAUDE.md`: PC 환경 SSOT 링크 + "환경 의존 작업 전 `~/.dotfiles-setup-mode` 확인" 지침 추가.
- `docs/.ssot/pc-environment.md`: `home` → `public` 용어 정정, §4 "모드가 바꾸는 것" 표 추가 (계정 전환 / git host / 프록시 정리 / 비용 위젯 각 코드 위치 명시).

## Test plan
- [ ] `docs/.ssot/README.md` 인덱스에서 pc-environment.md 링크 클릭 확인
- [ ] `CLAUDE.md` References 섹션에서 링크 및 지침 문구 확인
- [ ] `pc-environment.md` 모드 표기가 `shell-common/setup.sh`가 실제로 쓰는 값(`internal`/`external`/`public`)과 일치하는지 확인

## Related
Closes #1053

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
