### PR TITLE
feat(claude): SessionStart hook으로 PC 환경(setup-mode) 자동 컨텍스트 주입

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -86,6 +86,8 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 `~/.dotfiles-setup-mode` 가 `internal` 이면 `claude_yolo` 가 멀티-계정 해석을 우회하고 `~/.claude/` 를 강제 사용 (F-2). 잘못 migrate된 사내 PC 복구: `claude-accounts rollback` (F-3). 자세한 내용은 `docs/guide/internal-pc.md`.
 
+`claude/hooks/session-start-pc-context.sh` — `SessionStart` hook, `settings.json`에 등록됨. `~/.dotfiles-setup-mode` + hostname을 매 세션 시작마다 `additionalContext`로 주입해 5대 PC 혼동을 방지한다(#1052). 모드 파일이 없으면 조용히 빈 컨텍스트를 반환하고 세션 시작을 막지 않는다.
+
 ---
 
 ## Skill 작성 규칙

--- a/claude/hooks/session-start-pc-context.sh
+++ b/claude/hooks/session-start-pc-context.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# claude/hooks/session-start-pc-context.sh
+# Claude Code SessionStart hook: injects the current PC's setup-mode
+# (~/.dotfiles-setup-mode) + hostname into the session as additionalContext.
+#
+# Why: `~/.dotfiles-setup-mode` differs per machine (public/internal/external)
+# but nothing told a fresh session which mode the current PC is in —
+# CLAUDE.md is shared across all 5 PCs and can't hold a per-machine fact,
+# and relying on Claude Code memory to "remember to check" is fragile
+# (breaks silently the moment a session skips the check). This hook makes
+# the mode injection unconditional and mechanical instead.
+#
+# Mode file missing (fresh install, setup.sh not run yet) or unrecognized
+# → silently emit no context. Never blocks session start.
+#
+# Always exits 0 — best-effort context injection, never blocks the session.
+#
+# Reference: issue #1052.
+
+set -u
+
+# Canonicalize the same way `_dotfiles_setup_mode()` does
+# (shell-common/tools/integrations/claude.sh) — legacy numeric values 1/2/3
+# from pre-#571 setup.sh map to public/internal/external. Duplicated inline
+# rather than sourced: shell-common files carry the interactive guard
+# (`case $- in *i*) ;; *) return 0 ;; esac`) that would make sourcing them
+# here a no-op, since this hook always runs non-interactively.
+_mode_file="$HOME/.dotfiles-setup-mode"
+[ -f "$_mode_file" ] || exit 0
+
+_raw=$(tr -d ' \t\n\r' <"$_mode_file" 2>/dev/null)
+case "$_raw" in
+1 | public) _mode="public" ;;
+2 | internal) _mode="internal" ;;
+3 | external) _mode="external" ;;
+*) exit 0 ;;
+esac
+
+_hostname=$(hostname 2>/dev/null || echo "")
+
+_context="Dotfiles PC setup-mode: ${_mode}"
+[ -n "$_hostname" ] && _context="${_context} (host: ${_hostname})"
+_context="${_context}. Mode drives account routing (claude/AGENTS.md) and git host resolution (shell-common/functions/gh_host.sh)."
+
+if command -v jq >/dev/null 2>&1; then
+	jq -n --arg ctx "$_context" \
+		'{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$ctx}}'
+else
+	printf '%s\n' "$_context"
+fi
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,6 +3,16 @@
     "GH_PR_REPLY_AUTO_APPROVE_REPOS": "dEitY719/dotfiles,dEitY719/quantfolio"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-pc-context.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/tests/bats/skills/session_start_pc_context_hook.bats
+++ b/tests/bats/skills/session_start_pc_context_hook.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# tests/bats/skills/session_start_pc_context_hook.bats
+# Verify the SessionStart hook documented in
+#   claude/hooks/session-start-pc-context.sh (issue #1052)
+#
+# Cases:
+#   1. mode file missing              → exit 0, no output (never blocks session)
+#   2. unrecognized mode value        → exit 0, no output
+#   3. internal (text)                → JSON additionalContext with host
+#   4. legacy numeric "3" (external)  → canonicalized to "external"
+#   5. jq unavailable                 → plain-text fallback on stdout
+
+load '../test_helper'
+
+HOOK="${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/session-start-pc-context.sh"
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "session-start-pc-context: mode file missing → silent, exit 0" {
+    run "$HOOK"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "session-start-pc-context: unrecognized mode value → silent, exit 0" {
+    printf 'bogus' >"$HOME/.dotfiles-setup-mode"
+    run "$HOOK"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "session-start-pc-context: internal mode → JSON additionalContext" {
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not available"
+    fi
+    printf 'internal' >"$HOME/.dotfiles-setup-mode"
+    run "$HOOK"
+    assert_success
+    assert_output --partial '"hookEventName": "SessionStart"'
+    assert_output --partial 'Dotfiles PC setup-mode: internal'
+
+    ctx=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    [[ "$ctx" == *"host: "* ]]
+}
+
+@test "session-start-pc-context: legacy numeric 3 canonicalizes to external" {
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not available"
+    fi
+    printf '3' >"$HOME/.dotfiles-setup-mode"
+    run "$HOOK"
+    assert_success
+    ctx=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    [[ "$ctx" == "Dotfiles PC setup-mode: external"* ]]
+}
+
+@test "session-start-pc-context: no jq → plain-text fallback" {
+    printf 'public' >"$HOME/.dotfiles-setup-mode"
+    fake_bin="$TEST_TEMP_HOME/fakebin"
+    mkdir -p "$fake_bin"
+    for c in bash hostname tr cat printf; do
+        real="$(command -v "$c")"
+        [ -n "$real" ] && ln -sf "$real" "$fake_bin/$c"
+    done
+    run env -i HOME="$HOME" PATH="$fake_bin" "$HOOK"
+    assert_success
+    assert_output --partial "Dotfiles PC setup-mode: public"
+    [[ "$output" != *"hookSpecificOutput"* ]]
+}


### PR DESCRIPTION
## Summary
- Claude Code SessionStart hook을 신설해 `~/.dotfiles-setup-mode`(+hostname)를 매 세션 시작마다 컨텍스트로 자동 주입 — 5대 PC 환경 혼동 문제의 근본 원인(수동 확인 강제 불가)을 해소

## Changes
- `claude/hooks/session-start-pc-context.sh`: `SessionStart` hook 스크립트 — 모드 파일 없음/미인식 값은 조용히 빈 컨텍스트 반환(세션 시작 절대 방해 안 함), 존재 시 `jq`로 `additionalContext` JSON 생성(no-jq 환경은 plain text fallback)
- `claude/settings.json`: `hooks.SessionStart`에 위 스크립트 등록
- `claude/AGENTS.md`: 해당 hook의 동작을 기존 `~/.dotfiles-setup-mode` 설명 옆에 2줄 문서화
- `tests/bats/skills/session_start_pc_context_hook.bats`: 모드 파일 없음/미인식값/internal/legacy numeric(3→external)/no-jq fallback 5개 케이스 커버

## Test plan
- [x] `shellcheck` / `shfmt -d` — 신규 hook 스크립트 클린
- [x] `bash tests/golden_rules/test_golden_rules.sh` — 전체 통과
- [x] `tests/bats/skills/session_start_pc_context_hook.bats` — 5/5 통과
- [x] 관련 회귀 스위트(`claude_stop_hook_install.bats`, `post_gh_pr_create_hook.bats`) — 24/24 통과 (no regression)
- [ ] 실제 5대 PC 중 최소 2개 모드(internal/external)에서 세션 시작 시 컨텍스트 주입 수동 확인 (AC 항목 5, 실기기 필요 — 이 세션에서는 `HOME` override로 시뮬레이션만 수행)

## Related
Closes #1052

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
