### PR TITLE
feat(gh-pr-review): 비판적 검토(critical review) 기본 적용

### DIFF
--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -28,7 +28,10 @@ Gather a second-opinion code review on a GitHub PR from one external AI
 CLI (`codex` / `gemini` / `claude`). Stream the output, post it as a PR
 comment by default, and **stop there** — no decision (approve /
 request-changes), no per-comment replies; those are `gh:pr-approve` and
-`gh:pr-reply`.
+`gh:pr-reply`. Every preset's prompt always demands a critical stance —
+at least one questionable-assumption critique plus a closing verdict
+tag (`references/review-presets.md` § "Why critical review is always
+on") — with no flag to turn it off.
 
 ## Help
 

--- a/claude/skills/gh-pr-review/references/help.md
+++ b/claude/skills/gh-pr-review/references/help.md
@@ -24,7 +24,10 @@ request-changes) is submitted** — see `gh-pr-approve` for that.
 ## `--review` enum
 
 Closed enum — free-text values are rejected. Korean aliases normalize to
-the English enum before dispatch.
+the English enum before dispatch. Every preset, `quick` included,
+always adds a mandatory "at least one questionable assumption"
+critique and an overall `판정`/`Verdict: [LGTM|CONCERNS|BLOCKING]`
+line — there is no flag to turn this off.
 
 | enum | KR alias | Lens |
 |------|----------|------|
@@ -70,7 +73,8 @@ claude -p ...`.
 2. Pre-flight: refuse closed/merged/draft PRs. CI status is **not** a
    gate — opinion collection works regardless of CI.
 3. Load the `--review` preset's prompt template from
-   `references/review-presets.md`.
+   `references/review-presets.md` — the shared prefix always requires a
+   questionable-assumption critique and a closing verdict tag.
 4. Fetch `gh pr diff <N>` + PR metadata. Large diffs reuse
    `gh-pr-approve`'s subagent delegation pattern.
 5. Dispatch to the chosen external CLI per

--- a/claude/skills/gh-pr-review/references/help.md
+++ b/claude/skills/gh-pr-review/references/help.md
@@ -26,8 +26,11 @@ request-changes) is submitted** — see `gh-pr-approve` for that.
 Closed enum — free-text values are rejected. Korean aliases normalize to
 the English enum before dispatch. Every preset, `quick` included,
 always adds a mandatory "at least one questionable assumption"
-critique and an overall `판정`/`Verdict: [LGTM|CONCERNS|BLOCKING]`
-line — there is no flag to turn this off.
+critique and an overall translatable verdict line — e.g.
+`Verdict: [LGTM|CONCERNS|BLOCKING]` for an English-dominant diff, or
+`판정: [LGTM|우려있음|블로킹]` for a Korean-dominant diff — matching the
+diff's dominant language without mixing the two. There is no flag to
+turn this off.
 
 | enum | KR alias | Lens |
 |------|----------|------|

--- a/claude/skills/gh-pr-review/references/review-presets.md
+++ b/claude/skills/gh-pr-review/references/review-presets.md
@@ -44,6 +44,10 @@ You DO NOT submit a decision (no approve / request-changes) — the
 human and the primary reviewer handle that. Your job is to surface
 specific, actionable findings.
 
+Adopt a critical, skeptical stance. Do not rubber-stamp. Actively
+look for weak assumptions, missing edge cases, and alternative
+approaches the PR did not consider.
+
 Classification (use these exact labels for every finding):
   - BLOCKER   — would break or regress if merged as-is.
   - FOLLOW-UP — non-blocking quality issue worth tracking.
@@ -52,6 +56,17 @@ Classification (use these exact labels for every finding):
 Format (one line per finding):
   [BLOCKER|FOLLOW-UP|PRAISE] <path>:<line> — <one-sentence reason>
 
+Assumption check (mandatory): identify at least one assumption in the
+PR that is treated as obviously correct but is actually questionable
+(a design choice, a claim in the description, an "obviously safe"
+change). State it as one line: "Assumption: <what> — <why it's
+questionable>". If you genuinely find none after actively looking,
+say so explicitly: "Assumption: none found."
+
+Verdict (mandatory, last line): a single overall call on the PR —
+  판정: [LGTM|우려있음|블로킹]        (Korean-dominant diff)
+  Verdict: [LGTM|CONCERNS|BLOCKING]  (English-dominant diff)
+
 Reply in the dominant language of the PR diff (Korean if the diff is
 Korean-dominant, otherwise English). Be concise; no preamble; do not
 restate the diff.
@@ -59,6 +74,17 @@ restate the diff.
 
 The PR diff is appended after the prefix as raw stdin payload. The
 external CLI sees `<prefix>\n\n<preset-body>\n\n<diff>`.
+
+## Why critical review is always on
+
+The assumption check and the overall verdict tag live in the common
+prefix, not in a preset body — so every preset (`quick` included)
+carries them automatically and there is no way to accidentally leave
+them off. There is intentionally no opt-out flag: a purely-praising
+review is not a supported preset. The requirement is scoped to a
+single mandatory assumption line + one verdict line so it stays
+compatible with `quick`'s brevity budget (see the `quick` preset body
+below).
 
 ## `default` (balanced 7-dimension)
 

--- a/docs/superpowers/specs/2026-07-01-gh-pr-review-critical-review-design.md
+++ b/docs/superpowers/specs/2026-07-01-gh-pr-review-critical-review-design.md
@@ -1,0 +1,102 @@
+# gh:pr-review — Critical Review by Default (Design)
+
+Issue: [#1057](https://github.com/dEitY719/dotfiles/issues/1057)
+
+## Problem
+
+`gh:pr-review` delegates a PR review to an external AI CLI using one of
+five closed-enum presets (`default` / `quick` / `thorough` / `security`
+/ `performance`). None of them require the reviewing AI to challenge
+the PR's own assumptions — nothing stops a rubber-stamp "looks good"
+response.
+
+Three review-persona issues from a separate, unrelated repo
+(`dev-team-404/AgentToolbox#1744/#1745/#1746` — frontend/UX,
+backend/data, AI/authoring/governance lenses) were reviewed as
+reference material. All three share a structure worth adopting: a
+mandatory "point out at least one questionable assumption" clause and
+a fixed overall verdict tag (`판정: [LGTM / 우려있음 / 블로킹]`). Their
+per-domain lens and reading lists are specific to that repo and are
+*not* adopted — only the structural pattern is.
+
+## Decision
+
+Bake the pattern directly into `gh:pr-review`'s **common prompt
+prefix** (shared by all five presets) instead of adding new flags or
+new `--review` enum values:
+
+1. **Adversarial-stance directive** — explicitly instructs the
+   reviewing AI not to rubber-stamp, and to actively look for weak
+   assumptions, missing edge cases, and alternative approaches.
+2. **Mandatory assumption critique** — one line identifying a
+   questionable "obviously correct" assumption in the PR, or an
+   explicit "none found" if genuinely absent (never silently skipped).
+3. **Mandatory verdict line** — a single overall call appended after
+   the per-finding list: `판정: [LGTM|우려있음|블로킹]` for
+   Korean-dominant diffs, `Verdict: [LGTM|CONCERNS|BLOCKING]` for
+   English-dominant diffs, reusing the existing "reply in the diff's
+   dominant language" rule.
+
+This applies uniformly to all five presets, `quick` included — since
+the change lives in the shared prefix rather than any preset body,
+there is no per-preset branching and no way to accidentally omit it.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| `--role "<free text>"` flag | Free-text input widens the prompt-injection surface and conflicts with the skill's closed-enum-only design (`references/constraints.md`). |
+| New `frontend` / `backend` / `ai-governance` lens presets (mirroring the 3 reference issues) | Widens the enum surface for a benefit ("pick a lens") the user didn't ask for; the user explicitly wants critical review to be automatic, not something requiring a manual choice. |
+| `--no-critical` opt-out flag | The user explicitly chose "always on" after being shown the trade-off (no way to get a purely-praising pass) — adding an escape hatch would undercut the point of the feature. |
+
+## Architecture / components
+
+No new components. `SKILL.md` Step 3 already composes
+`<common-prompt-prefix> + <preset-body>`; only the prefix text in
+`references/review-presets.md` changes. No parser, flag, or
+`shell-common/functions/gh_pr_review.sh` changes are needed.
+
+Touched files:
+- `claude/skills/gh-pr-review/references/review-presets.md` — prefix
+  text + new "Why critical review is always on" rationale section.
+- `claude/skills/gh-pr-review/references/help.md` — two lines
+  reflecting the new default behavior for `--help` output.
+- `claude/skills/gh-pr-review/SKILL.md` — one clause in the Role
+  section pointing at the rationale.
+
+## Data flow
+
+Unchanged. `Step 3` builds `prompt = prefix + preset_body`; `Step 4`
+appends the PR diff as stdin; `Step 5` streams the external CLI's raw
+stdout; `Step 6` posts it verbatim as a PR comment. The new prefix
+content flows through the same pipe — no new data, no new state.
+
+## Error handling
+
+If the external AI CLI ignores the new instructions and omits the
+assumption line or verdict tag, `gh:pr-review` does not detect,
+retry, or reformat this — the existing "never reformat the external
+AI's stdout" constraint (`references/constraints.md`) applies
+unchanged. This is a prompt-level request, not a parsed/validated
+contract.
+
+## Testing
+
+- Existing bats coverage (`tests/bats/functions/gh_pr_review.bats`)
+  greps for fixed strings in preset bodies (e.g. `"ONLY surface
+  BLOCKER findings"`); those strings are preserved verbatim, so no
+  test changes are required.
+- No new automated test is added for prompt *content* — the repo has
+  no existing pattern for asserting on prompt text beyond the
+  substring greps already in place, and adding one would test prose
+  wording rather than behavior.
+- Manual verification: run `/gh-pr-review --ai <cli> --review quick
+  <PR#>` and confirm the streamed output contains an `Assumption:`
+  line and a closing `판정:`/`Verdict:` line.
+
+## Out of scope
+
+- No lens/role presets (frontend/backend/ai-governance).
+- No opt-out flag.
+- No changes to `gh:pr-approve` or `gh:pr-reply` (decision-making and
+  per-comment replies remain their responsibility, unchanged).

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -318,6 +318,10 @@ You DO NOT submit a decision (no approve / request-changes) — the
 human and the primary reviewer handle that. Your job is to surface
 specific, actionable findings.
 
+Adopt a critical, skeptical stance. Do not rubber-stamp. Actively
+look for weak assumptions, missing edge cases, and alternative
+approaches the PR did not consider.
+
 Classification (use these exact labels for every finding):
   - BLOCKER   — would break or regress if merged as-is.
   - FOLLOW-UP — non-blocking quality issue worth tracking.
@@ -325,6 +329,17 @@ Classification (use these exact labels for every finding):
 
 Format (one line per finding):
   [BLOCKER|FOLLOW-UP|PRAISE] <path>:<line> — <one-sentence reason>
+
+Assumption check (mandatory): identify at least one assumption in the
+PR that is treated as obviously correct but is actually questionable
+(a design choice, a claim in the description, an "obviously safe"
+change). State it as one line: "Assumption: <what> — <why it's
+questionable>". If you genuinely find none after actively looking,
+say so explicitly: "Assumption: none found."
+
+Verdict (mandatory, last line): a single overall call on the PR —
+  판정: [LGTM|우려있음|블로킹]        (Korean-dominant diff)
+  Verdict: [LGTM|CONCERNS|BLOCKING]  (English-dominant diff)
 
 Reply in the dominant language of the PR diff (Korean if the diff is
 Korean-dominant, otherwise English). Be concise; no preamble; do not


### PR DESCRIPTION
## Summary
- `gh:pr-review`의 5개 `--review` preset(`quick` 포함) 전부가 공통 prompt
  prefix 확장만으로 자동으로 "비판적 검토" 자세(가정 비판 의무 + 종합
  판정 태그)를 갖도록 한다.
- 새 플래그·새 `--review` enum 값 없음 — frontend/backend/ai-governance
  lens preset과 `--no-critical` 옵트아웃은 브레인스토밍 단계에서 범위
  밖으로 확정했다.
- 설계 문서: `docs/superpowers/specs/2026-07-01-gh-pr-review-critical-review-design.md`

## Changes
- `claude/skills/gh-pr-review/references/review-presets.md`: 공통
  prefix에 (a) 무비판적 동의 금지 지시, (b) 의심스러운 가정 최소 1개
  지적 의무 조항, (c) 종합 판정 라인(`판정`/`Verdict`) 추가 + "Why
  critical review is always on" 근거 섹션.
- `claude/skills/gh-pr-review/references/help.md`: `--help` 출력에 위
  동작 반영.
- `claude/skills/gh-pr-review/SKILL.md`: Role 섹션에 1줄 추가.
- `docs/superpowers/specs/2026-07-01-gh-pr-review-critical-review-design.md`:
  브레인스토밍 설계 문서 신규 추가.

## Test plan
- [x] `pytest` 전체 스위트(1148 tests) 통과 확인 (baseline, 이번 변경과
      무관한 파일이므로 영향 없음)
- [x] `tests/bats/functions/gh_pr_review.bats` 22개 테스트 전부 통과
      확인 (기존 grep 고정 문자열 보존 확인)
- [ ] `/gh-pr-review --ai <cli> --review quick <PR#>` 실행해 응답에
      `Assumption:` 줄과 `판정`/`Verdict:` 줄이 포함되는지 수동 확인

## Related
Closes #1057

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~4 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~4 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
