### PR TITLE
refactor(gh-pr-review): SKILL.md 를 100줄로 압축

### DIFF
--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -24,14 +24,13 @@ metadata:
 
 ## Role
 
-Gather a second-opinion code review on a GitHub PR from one external AI
-CLI (`codex` / `gemini` / `claude`). Stream the output, post it as a PR
-comment by default, and **stop there** — no decision (approve /
-request-changes), no per-comment replies; those are `gh:pr-approve` and
-`gh:pr-reply`. Every preset's prompt always demands a critical stance —
-at least one questionable-assumption critique plus a closing verdict
-tag (`references/review-presets.md` § "Why critical review is always
-on") — with no flag to turn it off.
+Gather a second-opinion review on a GitHub PR from one external AI CLI
+(`codex`/`gemini`/`claude`), stream its output, and post it as a PR
+comment by default — then stop. No decision (approve/request-changes —
+`gh:pr-approve`'s job) and no per-comment replies (`gh:pr-reply`'s
+job). Every preset's prompt demands a critical stance
+(`references/review-presets.md` § "Why critical review is always on")
+with no flag to disable it.
 
 ## Help
 
@@ -40,10 +39,9 @@ output it verbatim, then stop. No API calls.
 
 ## Step 1: Parse Flags + Resolve Target
 
-Step 1 — Delegate to `gh_pr_review_parse`
-(`shell-common/functions/gh_pr_review.sh`). Argument shape + KR aliases
-+ exit codes: `references/parser-contract.md` (also covers `START_TS`
-and resolving `TARGET_REPO` / `PR_NUMBER`).
+Delegate to `gh_pr_review_parse` (`shell-common/functions/gh_pr_review.sh`).
+Argument shape + KR aliases + exit codes: `references/parser-contract.md`
+(also covers `START_TS` and resolving `TARGET_REPO` / `PR_NUMBER`).
 
 ## Step 2: Pre-flight
 
@@ -53,9 +51,9 @@ Run these checks in parallel before any expensive work:
 - `command -v <ai-bin>` for the chosen `--ai` → else exit 1 `Required CLI '<name>' not found in PATH`.
 - `gh auth status` returns 0 → else exit 1 with the gh error line.
 
-**CI status is intentionally NOT a gate** (a failing CI is often the
-reason a second opinion is wanted); self-authored PRs are allowed (no
-decision submitted, so the self-approve block is irrelevant).
+CI status is intentionally not a gate (a failing CI is often the reason
+a second opinion is wanted); self-authored PRs are allowed (no
+decision is submitted, so the self-approve block doesn't apply).
 
 ## Step 3: Load Review Preset
 
@@ -74,10 +72,9 @@ inline `gh pr diff`. Append the diff per `references/ai-cli-invocation.md`
 
 ## Step 5: Dispatch to External CLI
 
-Delegate to `_gh_pr_review_run_ai`
-(`shell-common/functions/gh_pr_review.sh`). Invocation shapes, stdout
-streaming, non-zero-exit handling: `references/ai-cli-invocation.md`
-§ "Step 5 dispatch procedure".
+Delegate to `_gh_pr_review_run_ai` (`shell-common/functions/gh_pr_review.sh`).
+Invocation shapes, stdout streaming, non-zero-exit handling:
+`references/ai-cli-invocation.md` § "Step 5 dispatch procedure".
 
 ## Step 6: Post PR Comment (default ON)
 


### PR DESCRIPTION
## Summary
- gh-pr-review SKILL.md 를 104줄에서 100줄로 압축 (Progressive Disclosure 구조는 그대로 유지)

## Changes
- refactor(gh-pr-review): Role / Step 1 / Step 2 / Step 5 설명 프로즈만 압축 — 이미 6개 references/ 파일로 detail 이 분리돼 있어 신규 추출 없음. 위임 대상(shell-common/functions/gh_pr_review.sh, references/*.md 경로/앵커)과 워크플로 로직은 그대로.

## Test plan
- [x] `wc -l claude/skills/gh-pr-review/SKILL.md` → 100
- [x] `mise run test` — 1148 passed, 0 pre-existing failures

## Related
Closes #1061

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
