### PR TITLE
docs(claude): devx-restart 스킬에 인증 만료(Not logged in) 트리거 명시

### DIFF
--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   /devx:restart, /devx-restart, or asks "다시 작업해",
   "이어서 해줘", "끊긴 데서 재개", "API 에러 복구",
   "15분 이상 걸려서 ESC 눌렀어", "작업이 너무 커서 중단했어",
-  "oversized turn interrupted by user ESC". Identifies the in_progress
+  "다시 로그인했어", "oversized turn interrupted by user ESC". Identifies the in_progress
   TodoList item, breaks the next step into single-tool-call chunks, and
   delegates large reads/searches to subagents (Explore / general-purpose)
   so the main context stays small. Does NOT re-invoke a process skill

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: devx:restart
 description: >-
-  API 소켓 에러, OOM, 또는 ESC 키로 현재 세션이 중단된 후 재개할 때 —
+  API 소켓 에러, OOM, 인증 만료(Not logged in), 또는 ESC 키로 현재 세션이
+  중단된 후 재개할 때 —
   [Claude Code Only] Resume the previous in-progress task after an interruption
-  — either an API error (socket disconnect, service flake, OOM, etc.) or the
-  user pressing ESC because the turn was running too long — without losing
-  context. Use when the user runs /devx:restart, /devx-restart, or asks "다시 작업해",
+  — an API error (socket disconnect, service flake, OOM, etc.), an auth
+  expiry (`Not logged in`), or the user pressing ESC because the turn was
+  running too long — without losing context. Use when the user runs
+  /devx:restart, /devx-restart, or asks "다시 작업해",
   "이어서 해줘", "끊긴 데서 재개", "API 에러 복구",
   "15분 이상 걸려서 ESC 눌렀어", "작업이 너무 커서 중단했어",
   "oversized turn interrupted by user ESC". Identifies the in_progress

--- a/claude/skills/devx-restart/references/help.md
+++ b/claude/skills/devx-restart/references/help.md
@@ -13,7 +13,8 @@
 ## What it does
 
 Recovers from an interrupted turn — usually a Claude API flake
-(`socket connection was closed unexpectedly`, gateway timeout, OOM, etc.) —
+(`socket connection was closed unexpectedly`, gateway timeout, OOM,
+`Not logged in · Please run /login`, etc.) —
 without losing context. Picks up the previous in_progress TodoList item and
 resumes it in single-tool-call chunks, with large outputs delegated to
 subagents so the next failure costs less.
@@ -24,6 +25,8 @@ subagents so the next failure costs less.
 - The model produced an `API Error` and ended the turn.
 - A long batch of edits got cut off and you don't want to re-explain it.
 - The task was too large and you interrupted it with ESC to restart in smaller chunks.
+- Your session was interrupted by an auth/login expiry
+  (`Not logged in · Please run /login`) and you already re-authenticated.
 
 Do NOT invoke for:
 


### PR DESCRIPTION
## Summary
- `devx-restart` 스킬 문서에 인증/로그인 만료(`Not logged in`)로 세션이 끊긴 뒤 재개하는 케이스를 API 소켓 에러·OOM·ESC 중단과 동급의 명시적 트리거로 추가한다.

## Changes
- docs(devx-restart): `SKILL.md` frontmatter `description`의 한글/영문 트리거 목록에 인증 만료(`Not logged in`) 케이스를 추가.
- docs(devx-restart): `references/help.md`의 `What it does` 예시 나열과 `When to invoke` 목록에 동일 트리거를 추가.
- 재개 로직(TodoList 기반 Step 1~4, chunking-rules, output-format)은 변경하지 않음 — 중단 원인과 무관하게 이미 동작함.

## Test plan
- [x] `pytest -q` 전체 스위트 재실행 — 1148 passed, 0 failed (edit 전후 baseline 동일)
- [x] `mise run lint-py` — ruff/ruff format/mypy 통과

## Related
Closes #1066

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
