### PR TITLE
fix(claude): setup.sh 재실행 시 로컬 전용 enabledPlugins 보존

### DIFF
--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -654,6 +654,7 @@ _claude_ensure_settings_copy() {
     _cesc_tgt="$2"
     _cesc_local="$(dirname "$_cesc_tgt")/settings.local.json"
     _cesc_srctmp=
+    _cesc_merged=
 
     # 방어: SSOT (claude/settings.json) 에 model 키가 새어들면 — 배포 지연 틈에
     # 남은 pre-#940 write-through symlink 로 /model 이 추적 파일을 오염시킨
@@ -723,6 +724,34 @@ _claude_ensure_settings_copy() {
         fi
     fi
 
+    # 로컬 전용 enabledPlugins 보존 (#1070) — `claude plugin install/enable`
+    # 은 활성 계정 실파일의 enabledPlugins 에 직접 기록한다. SSOT 를 그대로
+    # 복사하면 SSOT 에 커밋되지 않은 로컬 전용 항목이 매 setup 재실행마다
+    # 조용히 disabled 로 리셋된다. 병합으로 해결: SSOT 값이 충돌 키에서 우선
+    # 하되(오른쪽 우선인 jq `+`), 로컬 전용 키는 보존한다. jq 없거나 로컬 전용
+    # 항목이 없으면 무동작 — 흔한 경우의 완전 멱등성(아래 cmp 게이트)을 유지.
+    if command -v jq >/dev/null 2>&1 && [ -f "$_cesc_tgt" ]; then
+        _cesc_extra=$(jq -n \
+            --slurpfile ssot "$_cesc_src" \
+            --slurpfile cur "$_cesc_tgt" \
+            '(($cur[0].enabledPlugins // {}) | keys) - (($ssot[0].enabledPlugins // {}) | keys) | length' \
+            2>/dev/null)
+        if [ -n "$_cesc_extra" ] && [ "$_cesc_extra" -gt 0 ] 2>/dev/null; then
+            _cesc_merged=$(mktemp "${TMPDIR:-/tmp}/claude_ep_merge.XXXXXX" 2>/dev/null) || _cesc_merged=
+            if [ -n "$_cesc_merged" ] && jq -n \
+                --slurpfile ssot "$_cesc_src" \
+                --slurpfile cur "$_cesc_tgt" \
+                '$ssot[0] | .enabledPlugins = (($cur[0].enabledPlugins // {}) + ($ssot[0].enabledPlugins // {}))' \
+                > "$_cesc_merged" 2>/dev/null; then
+                _cesc_src="$_cesc_merged"
+                ux_info "  preserved $_cesc_extra local-only enabledPlugins entry/entries (#1070)"
+            else
+                [ -n "$_cesc_merged" ] && rm -f "$_cesc_merged"
+                _cesc_merged=
+            fi
+        fi
+    fi
+
     # 단일 cleanup/return — sanitize 임시파일 정리를 세 경로에 중복하지 않고
     # 함수 말미에서 한 번만 수행 (PR #1000 gemini-code-assist 제안).
     _cesc_ret=0
@@ -737,6 +766,7 @@ _claude_ensure_settings_copy() {
     fi
 
     [ -n "$_cesc_srctmp" ] && rm -f "$_cesc_srctmp"
+    [ -n "$_cesc_merged" ] && rm -f "$_cesc_merged"
     return $_cesc_ret
 }
 

--- a/tests/bats/integrations/claude_accounts.bats
+++ b/tests/bats/integrations/claude_accounts.bats
@@ -291,6 +291,51 @@ LOCAL
     assert_output --partial "up to date"
 }
 
+@test "bash: _claude_ensure_settings_copy preserves local-only enabledPlugins across a re-copy (#1070)" {
+    mkdir -p "$HOME/.claude-personal"
+    # Simulate the CLI having written a local-only plugin enable into the
+    # account real file: SSOT's 3 entries + one extra not committed to SSOT.
+    jq '.enabledPlugins["understand-anything@understand-anything"] = true' \
+        "${DOTFILES_ROOT}/claude/settings.json" \
+        > "$HOME/.claude-personal/settings.json"
+
+    run_in_bash "_claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'"
+    assert_success
+
+    # The local-only entry survives the SSOT re-copy...
+    [ "$(jq -r '.enabledPlugins["understand-anything@understand-anything"]' \
+        "$HOME/.claude-personal/settings.json")" = "true" ]
+    # ...and the SSOT-committed entries are still present (no regression).
+    [ "$(jq -r '.enabledPlugins["superpowers@claude-plugins-official"]' \
+        "$HOME/.claude-personal/settings.json")" = "true" ]
+}
+
+@test "bash: _claude_ensure_settings_copy lets SSOT win on conflicting enabledPlugins keys (#1070)" {
+    mkdir -p "$HOME/.claude-personal"
+    # Local file disables a plugin that the SSOT enables → SSOT must win.
+    jq '.enabledPlugins["superpowers@claude-plugins-official"] = false' \
+        "${DOTFILES_ROOT}/claude/settings.json" \
+        > "$HOME/.claude-personal/settings.json"
+
+    run_in_bash "_claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'"
+    assert_success
+
+    [ "$(jq -r '.enabledPlugins["superpowers@claude-plugins-official"]' \
+        "$HOME/.claude-personal/settings.json")" = "true" ]
+}
+
+@test "bash: _claude_ensure_settings_copy stays byte-identical to SSOT when no local-only plugins (#1070)" {
+    mkdir -p "$HOME/.claude-personal"
+    # No extra entries → the merge is a no-op and the copy is exact (keeps
+    # the cmp idempotency gate working for the common case).
+    cp "${DOTFILES_ROOT}/claude/settings.json" "$HOME/.claude-personal/settings.json"
+
+    run_in_bash "_claude_ensure_settings_copy '${DOTFILES_ROOT}/claude/settings.json' '$HOME/.claude-personal/settings.json'"
+    assert_success
+
+    cmp -s "${DOTFILES_ROOT}/claude/settings.json" "$HOME/.claude-personal/settings.json"
+}
+
 @test "bash: _claude_account_setup_one unmounts a legacy bind mount on skills (issue #575 migration)" {
     mkdir -p "${DOTFILES_ROOT}/claude/skills" "${DOTFILES_ROOT}/claude/docs"
     mkdir -p "$HOME/.claude-shared/plugins"


### PR DESCRIPTION
## Summary
- `setup.sh` 재실행 시 계정 실파일 `settings.json` 을 SSOT 로 덮어쓰면서, `claude plugin install/enable` 이 기록한 로컬 전용 `enabledPlugins` 항목이 조용히 disabled 로 리셋되던 문제(#1070)를 수정한다.
- SSOT 복사 직전 `enabledPlugins` 를 병합해 로컬 전용 항목을 보존하되, 충돌 키는 SSOT 가 우선한다.

## Changes
- `shell-common/tools/integrations/claude.sh` — `_claude_ensure_settings_copy` 에 enabledPlugins 병합 블록 추가. jq 로 `(local.enabledPlugins) + (ssot.enabledPlugins)` 를 계산(오른쪽 우선 → SSOT 승)해 로컬 전용 키만 보존한다. 로컬 전용 항목이 없거나 jq 미설치면 무동작이라 흔한 경우의 byte-identical 복사(cmp 멱등 게이트)와 완전 호환. 임시파일 정리 1줄 추가.
- `tests/bats/integrations/claude_accounts.bats` — 회귀 3건 추가: (1) 로컬 전용 항목이 재복사 후에도 유지, (2) SSOT 와 충돌하는 키는 SSOT 우선, (3) 로컬 전용 항목이 없으면 SSOT 와 byte-identical.

## Test plan
- [x] `bats tests/bats/integrations/claude_accounts.bats` — 신규 3건 PASS
- [x] `shellcheck -x` clean (기존 SC3043 `local` 경고만, 사전 존재)
- [x] `shfmt -i 4` — 추가 블록 diff 없음
- [ ] 실환경: SSOT 미등재 플러그인 설치+enable → `setup.sh` 재실행 → enabled 유지 확인

## Related
Closes #1070

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
