### PR TITLE
fix(claude-plugin): plugin-sync.sh 자동 커밋을 main 에서도 성공시킴

### DIFF
--- a/claude/hooks/plugin-sync.sh
+++ b/claude/hooks/plugin-sync.sh
@@ -90,10 +90,19 @@ _commit_if_changed() {
 	[ "$#" -gt 0 ] || return 0
 	git -C "$repo_dir" add -- "$@" 2>/dev/null || return 0
 	git -C "$repo_dir" diff --cached --quiet -- "$@" 2>/dev/null && return 0
-	# Unstage on commit failure so a failed auto-commit never leaks staged
-	# changes into the user's next manual commit.
-	git -C "$repo_dir" commit -m "$msg" --quiet 2>/dev/null ||
+	# ALLOW_MAIN_COMMIT=1: an automated manifest sync is exactly the escape
+	# hatch the protected-branch guard exists for (git/hooks/checks/
+	# main_branch_guard.sh). Without it, users who stay on `main` in dotfiles
+	# get the commit silently blocked and reset — the manifest updates then
+	# pile up unstaged and never land (#1072).
+	if ! ALLOW_MAIN_COMMIT=1 git -C "$repo_dir" commit -m "$msg" --quiet 2>/dev/null; then
+		# Unstage on commit failure so a failed auto-commit never leaks staged
+		# changes into the user's next manual commit. Warn to stderr (visible
+		# in the session transcript) instead of failing fully silent.
+		printf 'plugin-sync: manifest commit failed in %s; changes left unstaged\n' \
+			"$repo_dir" >&2
 		git -C "$repo_dir" reset -q -- "$@" 2>/dev/null || true
+	fi
 }
 
 # Emit the compact JSON in file $1, or the default $2 when the file is

--- a/claude/hooks/plugin-sync.sh
+++ b/claude/hooks/plugin-sync.sh
@@ -97,11 +97,16 @@ _commit_if_changed() {
 	# pile up unstaged and never land (#1072).
 	if ! ALLOW_MAIN_COMMIT=1 git -C "$repo_dir" commit -m "$msg" --quiet 2>/dev/null; then
 		# Unstage on commit failure so a failed auto-commit never leaks staged
-		# changes into the user's next manual commit. Warn to stderr (visible
-		# in the session transcript) instead of failing fully silent.
-		printf 'plugin-sync: manifest commit failed in %s; changes left unstaged\n' \
-			"$repo_dir" >&2
-		git -C "$repo_dir" reset -q -- "$@" 2>/dev/null || true
+		# changes into the user's next manual commit. Run reset first, then warn
+		# to stderr with the *actual* outcome — a preemptive "left unstaged"
+		# message would be wrong if the reset itself failed.
+		if git -C "$repo_dir" reset -q -- "$@" 2>/dev/null; then
+			printf 'plugin-sync: manifest commit failed in %s; changes left unstaged\n' \
+				"$repo_dir" >&2
+		else
+			printf 'plugin-sync: manifest commit failed in %s; failed to unstage changes\n' \
+				"$repo_dir" >&2
+		fi
 	fi
 }
 

--- a/tests/bats/skills/plugin_sync_hook.bats
+++ b/tests/bats/skills/plugin_sync_hook.bats
@@ -33,6 +33,24 @@ _known_marketplaces() {
 JSON
 }
 
+# Simulate git/hooks/checks/main_branch_guard.sh: refuse direct commits on
+# main/master unless the ALLOW_MAIN_COMMIT=1 escape hatch is set. Lets the
+# isolated test repo reproduce the protected-branch condition (#1072) that
+# the real CI repos never hit.
+_install_protected_branch_guard() {
+    mkdir -p "$1/.git/hooks"
+    cat > "$1/.git/hooks/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+[ "${ALLOW_MAIN_COMMIT:-0}" = "1" ] && exit 0
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+case "$branch" in
+    main | master) echo "BLOCKING: direct commit on protected branch" >&2; exit 1 ;;
+esac
+exit 0
+HOOK
+    chmod +x "$1/.git/hooks/pre-commit"
+}
+
 _installed_plugins() {
     cat > "$SRC/installed_plugins.json" <<'JSON'
 {
@@ -183,6 +201,24 @@ JSON
     run jq -e '.plugins == ["ralph-loop@claude-plugins-official"]' \
         "$MAIN_ROOT/claude/plugin/plugins.json"
     assert_success
+}
+
+@test "install → commit lands even on protected 'main' branch (#1072 escape hatch)" {
+    _known_marketplaces
+    _installed_plugins
+    git -C "$MAIN_ROOT" symbolic-ref HEAD refs/heads/main
+    _install_protected_branch_guard "$MAIN_ROOT"
+
+    payload='{"tool_name":"Bash","tool_input":{"command":"claude plugin install ralph-loop@claude-plugins-official"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+
+    # The manifest is actually committed — not silently blocked and left
+    # unstaged as it was before the ALLOW_MAIN_COMMIT=1 fix.
+    run git -C "$MAIN_ROOT" log -1 --format=%s
+    assert_output "chore(claude-plugin): sync manifest"
+    run git -C "$MAIN_ROOT" status --porcelain
+    assert_output ""
 }
 
 @test "no-op re-run does not create an empty commit" {


### PR DESCRIPTION
## Summary
- `plugin-sync.sh`의 자동 매니페스트 커밋이 protected-branch(`main`)에서 항상 조용히 실패하던 버그를 수정한다 (#1072).
- dotfiles 사용자는 평소 `main`에 머무르므로, 가장 흔한 조건에서 `claude plugin install`/`marketplace add` 시 매니페스트 파일이 갱신만 되고 커밋되지 않은 채 워킹트리에 계속 쌓이던 문제를 해소한다.

## Changes
- `claude/hooks/plugin-sync.sh` (`_commit_if_changed`): 자동 sync 커밋에 `ALLOW_MAIN_COMMIT=1`을 prefix — 이 escape hatch가 존재하는 목적(자동화된 sync 커밋) 그대로 사용해 `main`에서도 커밋이 성공하도록 함. 또한 그 외 사유로 커밋이 실패할 때 완전 무음(`2>/dev/null` 후 조용히 reset) 대신 stderr에 경고 1줄을 남기고 unstage하도록 변경 — 발견 지연을 방지.
- `tests/bats/skills/plugin_sync_hook.bats`: 격리 테스트 repo에 protected-branch pre-commit 가드를 설치하는 `_install_protected_branch_guard` 헬퍼 추가 + `main`에서도 매니페스트가 실제 커밋되는지 검증하는 회귀 테스트 추가 (CI/bats는 격리 임시 repo에서 돌아 지금까지 이 조건을 재현하지 못했음).

## Test plan
- [x] `plugin_sync_hook.bats` 11/11 통과 (신규 #1072 테스트 포함)
- [x] `plugin_sync_hook_delete.bats` 6/6 통과 (공유 함수 회귀 없음)
- [x] `shellcheck` clean · `shfmt -d` clean
- [ ] 실제 `main` 브랜치에서 `claude plugin install`/`marketplace add` 발화 → 매니페스트 갱신 + 실제 커밋 생성 수동 스모크

## Related
Closes #1072

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
