### PR TITLE
feat(skill): devx:session-handoff — 세션 handoff 코멘트 + 재개 문장 자동화

### DIFF
--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -17,7 +17,8 @@ description: >-
   (brainstorming / TDD / debugging) that already produced output earlier
   in the conversation — it resumes from the implementation step they led
   to. Accepts `-h`/`--help`/`help` to print usage.
-  (토큰 한계 리셋 후 크론 자동 재개는 devx:resume-after-limit 사용)
+  (토큰 한계 리셋 후 크론 자동 재개는 devx:resume-after-limit 사용;
+  세션을 넘기기 전 handoff 코멘트 작성은 devx:session-handoff 사용)
 allowed-tools: Bash, Read, Edit, Write, Grep, Agent, TaskList, TaskUpdate
 metadata:
   model_recommendation:

--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -17,8 +17,7 @@ description: >-
   (brainstorming / TDD / debugging) that already produced output earlier
   in the conversation — it resumes from the implementation step they led
   to. Accepts `-h`/`--help`/`help` to print usage.
-  (토큰 한계 리셋 후 크론 자동 재개는 devx:resume-after-limit 사용;
-  세션을 넘기기 전 handoff 코멘트 작성은 devx:session-handoff 사용)
+  (재개: devx:resume-after-limit, handoff: devx:session-handoff)
 allowed-tools: Bash, Read, Edit, Write, Grep, Agent, TaskList, TaskUpdate
 metadata:
   model_recommendation:

--- a/claude/skills/devx-resume-after-limit/SKILL.md
+++ b/claude/skills/devx-resume-after-limit/SKILL.md
@@ -11,7 +11,8 @@ description: >-
   /devx:rate-limit-guard cron prompt fires. Accepts an optional <command>
   argument (cron path) or reads `.claude/.rate-limit-guard.json` (manual
   re-trigger). Accepts `-h`/`--help`/`help` to print usage.
-  (API 에러/ESC 중단 후 현재 세션 재개는 devx:restart 사용)
+  (API 에러/ESC 중단 후 현재 세션 재개는 devx:restart 사용;
+  세션을 넘기기 전 handoff 코멘트 작성은 devx:session-handoff 사용)
 allowed-tools: Bash, Read, Write, CronCreate, CronDelete
 metadata:
   model_recommendation:

--- a/claude/skills/devx-session-handoff/SKILL.md
+++ b/claude/skills/devx-session-handoff/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: devx:session-handoff
+description: >-
+  컨텍스트 임계 근접 시 세션 인수인계(handoff) 자동화 — 이번 세션의 검증된
+  완료분 / 남은 작업 / 재개 정보를 구조화해 트래킹 이슈에 코멘트로 게시하고,
+  auto-memory 를 갱신하고, 다음 세션 재개 문장 1줄을 출력한다. Use when the
+  user runs /devx:session-handoff, /devx-session-handoff, or says "핸드오프",
+  "세션 넘겨", "이어서 하게 정리해줘", "컨텍스트 다 찼어", "handoff this
+  session", "wrap up for the next session" — or when the context window nears
+  its limit mid-way through a multi-session task. 일회성 작업 완료 기록은
+  gh:issue-create / gh:discussion-create 를 쓰고, 본 스킬은 작업 진행 중
+  세션 연속성 전용. Accepts `[issue-number] [remote]`, `--memory-only`
+  (이슈 게시 생략), `--new-issue` (신규 트래킹 이슈 강제), and
+  `-h`/`--help`/`help` to print usage. (중단 후 같은 세션 재개는
+  devx:restart, 토큰 리밋 후 크론 재개는 devx:resume-after-limit — 이들은
+  재개자(resumer)이고 본 스킬은 그에 선행하는 handoff 작성자다.)
+allowed-tools: Bash, Read, Write, Grep, TaskList
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "conversation synthesis + tracking-issue resolution judgment; writes are two low-risk artifacts (issue comment, memory file)"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# devx:session-handoff — Handoff Comment + Resume Sentence
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No API calls.
+
+**Stop-on-error policy** — HARD-stop: Step 2 when no tracking issue can be
+resolved AND GitHub is unreachable without `--memory-only` (ask, don't
+guess). Soft-fail: Step 4 comment post (fall back to memory-only + warn);
+Step 5 memory write never blocks — warn and continue.
+
+## Step 1: Parse Args
+
+| Option | Description | Default |
+|---|---|---|
+| `[issue-number]` | 트래킹 이슈 번호 (양의 정수) | auto-resolve (Step 2) |
+| `[remote]` | git remote 이름 | `origin` |
+| `--memory-only` | 이슈 코멘트 생략, 메모리에만 기록 | off |
+| `--new-issue` | 기존 후보 무시, 신규 트래킹 이슈 강제 생성 | off |
+| `-h`/`--help`/`help` | usage 출력 후 정지 | — |
+
+Resolve `TARGET_REPO=<owner>/<repo>` from the remote URL (same procedure as
+gh:issue-read); unknown remote → list `git remote -v` and stop.
+
+## Step 2: Resolve the Tracking Issue
+
+Follow `references/issue-resolution.md`: explicit arg → conversation
+`#N` mentions → branch `wt/issue-N-*` → recent `gh` activity. Multiple
+candidates → pick the most-referenced or ask. No candidate → judge:
+substantive multi-session work gets a new tracking issue via
+Skill(gh:issue-create); trivial work degrades to `--memory-only`. The
+duplicate-handoff guard (prior handoff comment from this session → update
+it, don't append) also lives there.
+
+## Step 3: Compose the Handoff Artifact
+
+Build the comment body per `references/handoff-template.md`. Honesty rules
+are non-negotiable: only merged PRs and tests that ran green in this session
+go under "완료 (검증됨)"; everything else is "미검증" or "남은 작업". Pull
+remaining work from the session TodoList (TaskList) when one exists.
+
+## Step 4: Post the Comment
+
+`gh issue comment <N> --repo "$TARGET_REPO" --body-file <artifact>` — skip
+entirely when `--memory-only`. On API failure: one `[WARN]` line, continue —
+the Step 5 memory copy still preserves the handoff.
+
+## Step 5: Update Auto-memory (always)
+
+Write or update one `project`-type memory file recording issue number,
+branch, worktree, next step, and the resume sentence; refresh the memory
+index line. Format in `references/handoff-template.md` → "Memory record".
+Runs even when Step 4 posted successfully (issue = team-visible, memory =
+agent-local).
+
+## Step 6: Resume Sentence + Report
+
+Print the copy-paste resume sentence (`#<N> <next-step> 진행` — must map to
+the real tracking issue and its actual next step; never fabricate), then the
+`[OK]`/`[FAIL]` structured report per `references/report-template.md`,
+ending with the `Next:` hint.
+
+## Constraints
+
+- Writes are exactly two artifacts: one issue comment, one memory file.
+  Never commit, push, edit code, or close/relabel issues.
+- Never overstate completion — unverified work is never listed as done.
+- Never invent a resume sentence that doesn't map to the tracking issue.
+- Reuses gh:issue-create (new tracking issue) and gh:issue-read
+  (candidate validation). Sister skills devx:restart and
+  devx:resume-after-limit are the resumers this handoff feeds — the resume
+  sentence must stay parseable by the human driving them.

--- a/claude/skills/devx-session-handoff/references/handoff-template.md
+++ b/claude/skills/devx-session-handoff/references/handoff-template.md
@@ -1,0 +1,78 @@
+# devx:session-handoff — Handoff Artifact + Memory Record (Steps 3, 5)
+
+## Comment body template
+
+ALWAYS use this exact section skeleton (no emojis — CLAUDE.md repo policy):
+
+```markdown
+<!-- session-handoff -->
+## Session handoff — <YYYY-MM-DD HH:MM>
+
+### 완료 (검증됨)
+- <merged PR / green test / deployed artifact — one line each, with links>
+
+### 미검증 (작성됨, 확인 안 됨)
+- <edits made this session whose tests/review have not run — omit section if empty>
+
+### 남은 작업
+- <next track + concrete sub-items, each with file/spec pointers>
+
+### 재개 환경
+- branch: `<branch>` / worktree: `<path>`
+- test: `<command>` (기타 DSN/DB/실행법이 있으면 한 줄씩)
+
+### 설계·스펙 링크
+- <issue/PR/doc links the next session needs — omit if none>
+
+### 미결 결정·블로커
+- <open decisions or blockers — omit if none>
+
+### 재개 포인터
+`#<N> <next-step> 진행`
+```
+
+### Honesty rules (non-negotiable)
+
+- "완료 (검증됨)" holds ONLY merged PRs, tests that ran green in this
+  session, and artifacts verified end-to-end. Everything else is 미검증.
+- Never round "code written" up to "done". The next session trusts this
+  comment; an overstated handoff wastes its first hour re-verifying.
+- Remaining-work items come from the session TodoList (TaskList) when one
+  exists, plus anything discussed but not yet queued.
+
+## Resume sentence
+
+Format: `#<N> <next-step> 진행` — e.g. `#1767 P5b 진행`, `#1076 리뷰 반영
+진행`. Rules:
+
+- `<N>` is the tracking issue actually posted to (or recorded in memory).
+- `<next-step>` names the first item under "남은 작업" — a track label
+  (P5b), a phase, or a short verb phrase. It must appear in the handoff
+  body; never invent a key the issue doesn't contain.
+- One line, copy-paste ready, printed both in the comment (재개 포인터) and
+  as the skill's final output.
+
+## Memory record (Step 5)
+
+Write one `project`-type memory file (auto-memory conventions of the
+running agent; for Claude Code, the session memory directory):
+
+```markdown
+---
+name: session-handoff-issue-<N>
+description: Resume state for #<N> — <one-line next step>
+metadata:
+  type: project
+---
+
+Issue #<N> (<repo>) handoff — <YYYY-MM-DD>.
+Resume: `#<N> <next-step> 진행`
+Branch `<branch>`, worktree `<path>`.
+Done (verified): <one line>. Remaining: <one line>.
+Handoff comment: <comment URL, or "memory-only">
+```
+
+Update the existing `session-handoff-issue-<N>` file if one exists (one
+live handoff per issue), and refresh its index line in `MEMORY.md`. A
+memory-write failure is a `[WARN]`, never a stop — the issue comment
+already carries the handoff when Step 4 ran.

--- a/claude/skills/devx-session-handoff/references/help.md
+++ b/claude/skills/devx-session-handoff/references/help.md
@@ -1,0 +1,62 @@
+# devx:session-handoff — Help
+
+## Usage
+
+```
+/devx:session-handoff                    # auto-resolve tracking issue, post handoff
+/devx:session-handoff 1767               # explicit issue number
+/devx:session-handoff 1767 upstream      # explicit issue + remote
+/devx:session-handoff --memory-only      # skip the issue comment, memory only
+/devx:session-handoff --new-issue        # force a new tracking issue
+/devx:session-handoff -h                 # show this help
+/devx:session-handoff --help             # show this help
+/devx:session-handoff help               # show this help
+```
+
+## What it does
+
+When a long task is about to outlive the current session (context window
+near its limit, end of day, planned interruption), this skill writes the
+handoff so the next session can resume without re-explaining:
+
+1. Resolves the tracking issue (arg → conversation → branch → gh activity;
+   creates one via gh:issue-create when the work deserves it, or falls back
+   to memory-only when it doesn't).
+2. Composes a structured handoff comment — verified done / remaining work /
+   resume environment / open decisions — and posts it on the issue.
+3. Updates auto-memory with the same resume state (issue = team-visible,
+   memory = agent-local).
+4. Prints a one-line copy-paste resume sentence, e.g. `#1767 P5b 진행`.
+
+## When to invoke
+
+- The context window is approaching its limit mid-task.
+- You are stopping for the day but the work continues tomorrow.
+- You want the next session (or a teammate) to pick up exactly where this
+  one stopped.
+
+Do NOT invoke for:
+
+- Recording a finished one-off task — that's gh:issue-create or
+  gh:discussion-create.
+- Resuming after an API error or ESC in the SAME session — that's
+  devx:restart.
+- Auto-resuming after a token-limit reset via cron — that's
+  devx:resume-after-limit (this skill writes the handoff those resumers
+  consume).
+
+## Honesty rules
+
+- Only merged PRs and tests that ran green in this session are listed as
+  "완료 (검증됨)".
+- Unverified edits are labeled 미검증 — never rounded up to done.
+- The resume sentence must map to the real tracking issue and its actual
+  next step.
+
+## Constraints
+
+- Writes exactly two artifacts: one issue comment (skippable with
+  `--memory-only`) and one memory file. No commits, pushes, code edits, or
+  issue state changes.
+- Duplicate guard: a handoff comment already posted from this session is
+  updated in place, not appended.

--- a/claude/skills/devx-session-handoff/references/issue-resolution.md
+++ b/claude/skills/devx-session-handoff/references/issue-resolution.md
@@ -42,18 +42,20 @@ No issue found anywhere. Decide by the nature of the session's work:
 
 ## Duplicate-handoff guard
 
-Before posting, inspect the most recent comments:
+Before posting, inspect the most recent comments via REST — it returns the
+numeric comment `id` the PATCH below needs (`gh issue view --json comments`
+only exposes GraphQL node ids, which the REST endpoint rejects):
 
 ```bash
-gh issue view <N> --repo "$TARGET_REPO" --json comments \
-  -q '.comments[-3:][] | {author: .author.login, body: .body[0:120], url: .url}'
+gh api "repos/$TARGET_REPO/issues/<N>/comments" \
+  -q '.[-3:][] | {id, author: .user.login, body: .body[0:120], url: .html_url}'
 ```
 
 If a comment authored by `@me` in THIS session already carries the handoff
 marker (`<!-- session-handoff -->`, embedded by the template), update that
-comment (`gh api --method PATCH` on the comment id with the new body)
-instead of appending a second one. Two handoffs from one session force the
-next reader to diff them.
+comment (`gh api "repos/$TARGET_REPO/issues/comments/<id>" --method PATCH
+--field body=@<artifact>`) instead of appending a second one. Two handoffs
+from one session force the next reader to diff them.
 
 ## Failure modes
 

--- a/claude/skills/devx-session-handoff/references/issue-resolution.md
+++ b/claude/skills/devx-session-handoff/references/issue-resolution.md
@@ -1,0 +1,64 @@
+# devx:session-handoff — Tracking-issue Resolution (Step 2)
+
+## Priority chain
+
+Evaluate in order; the first hit wins. `--new-issue` skips straight to
+"Create a new tracking issue" below.
+
+1. **Explicit argument** — `[issue-number]` passed by the user. Validate it
+   exists and is OPEN via `gh issue view <N> --repo "$TARGET_REPO" --json
+   state,title` (the gh:issue-read fetch shape). CLOSED → warn and continue
+   down the chain (a closed issue is a finished thread, not a live handoff
+   target) unless the user insists.
+2. **Conversation mentions** — scan this session for `#N` / `Issue #N` /
+   issue URLs. Count references per issue number; the most-referenced OPEN
+   issue is the candidate.
+3. **Branch name** — `git branch --show-current` matching `wt/issue-N-*`,
+   `wt/issue-N/*`, or `issue-N` extracts `N`.
+4. **Recent gh activity** — `gh issue list --repo "$TARGET_REPO" --assignee
+   @me --state open --limit 5`; if exactly one is plausibly this session's
+   work (title matches the task), use it.
+
+## Multiple candidates
+
+When steps 2–4 surface more than one plausible issue, pick the one with the
+most conversation references. On a tie — or when none clearly matches the
+session's actual work — ask the user one short line listing the candidates
+instead of guessing. A handoff on the wrong issue misleads the next session.
+
+## No candidate — judge
+
+No issue found anywhere. Decide by the nature of the session's work:
+
+- **Substantive multi-session work** (an implementation mid-way, a design
+  with open decisions, anything the next session must continue): create a
+  new tracking issue via `Skill(gh:issue-create)` and use its number. The
+  handoff comment then becomes that issue's first status record.
+- **Trivial or nearly-done work** (small fix awaiting review, exploration
+  with no follow-up): degrade to `--memory-only` and say so in the report.
+  Creating an issue nobody will reopen is noise.
+
+`--memory-only` given explicitly always wins over issue creation.
+
+## Duplicate-handoff guard
+
+Before posting, inspect the most recent comments:
+
+```bash
+gh issue view <N> --repo "$TARGET_REPO" --json comments \
+  -q '.comments[-3:][] | {author: .author.login, body: .body[0:120], url: .url}'
+```
+
+If a comment authored by `@me` in THIS session already carries the handoff
+marker (`<!-- session-handoff -->`, embedded by the template), update that
+comment (`gh api --method PATCH` on the comment id with the new body)
+instead of appending a second one. Two handoffs from one session force the
+next reader to diff them.
+
+## Failure modes
+
+- GitHub unreachable AND no `--memory-only`: HARD-stop and ask — posting is
+  the skill's core outward action; silently degrading it hides the failure.
+- GitHub unreachable WITH `--memory-only`: proceed; nothing needed the API.
+- `gh:issue-create` sub-skill fails: warn, degrade to memory-only, report
+  `posted=none (fallback)`.

--- a/claude/skills/devx-session-handoff/references/report-template.md
+++ b/claude/skills/devx-session-handoff/references/report-template.md
@@ -1,0 +1,46 @@
+# devx:session-handoff — Final Report (Step 6)
+
+## Success
+
+```
+[OK] devx:session-handoff — #<N> handoff posted
+  issue:    <issue URL>
+  comment:  <comment URL | updated <comment URL> | memory-only>
+  memory:   session-handoff-issue-<N>.md (updated)
+  resume:   #<N> <next-step> 진행
+
+Next: 새 세션에서 재개 문장을 첫 지시로 붙여넣으세요 —
+      `#<N> <next-step> 진행`
+      (같은 세션 중단 복구는 /devx:restart, 토큰 리밋 크론 재개는
+      /devx:resume-after-limit)
+```
+
+`comment:` shows `updated <URL>` when the duplicate-handoff guard replaced
+an earlier same-session comment, and `memory-only` when `--memory-only` was
+given or the judge degraded to it.
+
+## Soft-fail (comment post failed, memory saved)
+
+```
+[WARN] devx:session-handoff — #<N> comment post failed, memory-only fallback
+  reason:   <one-line API error>
+  memory:   session-handoff-issue-<N>.md (updated)
+  resume:   #<N> <next-step> 진행
+
+Next: `gh issue comment <N> --body-file <artifact>` 를 수동 재시도하거나,
+      새 세션에서 재개 문장으로 바로 이어가세요.
+```
+
+## Failure (no target, cannot proceed)
+
+```
+[FAIL] devx:session-handoff — 트래킹 이슈를 결정할 수 없음
+  tried:    arg=<none|N>, conversation=<n candidates>, branch=<branch>, gh=<n>
+  reason:   <one line — e.g. GitHub unreachable and --memory-only not given>
+
+Next: 이슈 번호를 명시해 재실행 (`/devx:session-handoff <N>`) 하거나
+      `--memory-only` 로 메모리 기록만 남기세요.
+```
+
+Every path ends with a `Next:` hint — the whole point of a handoff is that
+the reader knows the next move without asking.


### PR DESCRIPTION
## Summary
- 컨텍스트 임계 근접 시 세션 인수인계를 자동화하는 `devx:session-handoff` 스킬 신설 (레퍼런스: AgentToolbox #1767 P5b handoff 수동 사례)
- 핵심 3동작 표준화: 트래킹 이슈에 구조화 handoff 코멘트 게시 + auto-memory 갱신 + copy-paste 가능한 재개 문장 1줄 출력
- 자매 스킬 `devx:restart` / `devx:resume-after-limit` 와 상호 링크 (이들은 resumer, 본 스킬은 선행 handoff 작성자)

## Changes
- `claude/skills/devx-session-handoff/SKILL.md` (신규, 98줄): 6단계 워크플로 — 인자 파싱 / 트래킹 이슈 해석 / handoff 아티팩트 작성 / 코멘트 게시 / 메모리 갱신 / 재개 문장 + 리포트. `--memory-only`, `--new-issue`, `-h/--help/help` 지원. stop-on-error 정책 명시 (게시 실패는 memory-only 소프트 폴백).
- `references/issue-resolution.md`: 이슈 해석 우선순위(명시 인자 → 대화 `#N` → 브랜치 `wt/issue-N-*` → 최근 gh 활동), 다중 후보 처리, 신규 이슈(gh:issue-create) / memory-only 폴백 판단 기준, 같은 세션 중복 handoff 갱신 가드.
- `references/handoff-template.md`: 코멘트 본문 템플릿 — 완료(검증됨) / 미검증 / 남은 작업 / 재개 환경 / 미결 결정·블로커 / 재개 포인터. 정직성 규칙(머지된 PR·통과 테스트만 완료 표기) + 메모리 레코드 형식.
- `references/report-template.md` / `references/help.md`: `[OK]`/`[WARN]`/`[FAIL]` 구조화 리포트 + `Next:` 힌트, usage 문서.
- `claude/skills/devx-restart/SKILL.md`, `claude/skills/devx-resume-after-limit/SKILL.md`: description 에 devx:session-handoff 상호 링크 1줄 추가.

## Test plan
- [x] `mise run test` — 1145 passed (bats + pytest + golden rules)
- [x] `skill:check` — 12/12 PASS, 0 WARN/FAIL (EXCELLENT)
- [ ] 실제 장기 세션에서 `/devx:session-handoff` 호출 — 코멘트 게시 / 메모리 갱신 / 재개 문장 확인

## Related
Closes #1076

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
