### PR TITLE
fix(claude-plugin): publish-sync check-polling을 gh pr view statusCheckRollup 로 전환 (gh 2.45 호환)

### DIFF
--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -143,7 +143,7 @@ _open_and_merge_pr() {
 	local repo_dir="$1" branch="$2" target pr_url pr_number
 	local interval="${PUBLISH_SYNC_CHECK_INTERVAL:-15}"
 	local max_tries="${PUBLISH_SYNC_CHECK_MAX_TRIES:-20}"
-	local tries=0 state="pending" tmp_err
+	local tries=0 state="pending" saw_checks=0
 
 	target=$(_repo_target "$repo_dir") || {
 		echo "publish-sync: origin remote를 해석하지 못함 ($repo_dir)" >&2
@@ -160,9 +160,6 @@ _open_and_merge_pr() {
 	pr_number="${pr_url##*/}"
 	echo "publish-sync: PR 생성됨 — $pr_url"
 
-	# Explicit template (not bare `mktemp`): BSD/macOS mktemp requires one.
-	tmp_err=$(mktemp "${TMPDIR:-/tmp}/publish-sync-checks.XXXXXX") || return 1
-
 	# The `--json bucket` flag on the `pr checks` subcommand does not exist
 	# on gh <2.46ish (unknown flag: --json) — verified on gh 2.45.0, which
 	# every poll would error on, always falling to "pending" and eventually
@@ -170,44 +167,33 @@ _open_and_merge_pr() {
 	# statusCheckRollup` works on 2.45.0 and returns each check as either a
 	# CheckRun (`status` + `conclusion`) or a StatusContext (`state`, no
 	# `conclusion`); the jq below normalizes both shapes to one aggregate
-	# word, fail-closed on any unrecognized shape.
+	# word, fail-closed on any unrecognized shape. Unlike the old `gh pr
+	# checks` subcommand, `gh pr view --json statusCheckRollup` has no "no
+	# checks reported" signal — a genuinely checkless repo just exits 0
+	# with an empty `statusCheckRollup: []`, indistinguishable from checks
+	# that simply haven't registered yet. So an empty rollup polls as
+	# "pending" for the FULL window below (never a premature give-up);
+	# "checkless" is only declared at timeout if checks were never once
+	# observed (see saw_checks below).
 	while [ "$tries" -lt "$max_tries" ]; do
 		# shellcheck disable=SC2016 # `$v` below is jq's `as $v` binding, not a shell variable — single-quoted on purpose.
 		state=$(gh pr view "$pr_number" --repo "$target" \
 			--json statusCheckRollup \
-			--jq '[ .statusCheckRollup[]? | if (.conclusion != null) then (if (.conclusion|IN("FAILURE","CANCELLED","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE")) then "fail" elif (.conclusion|IN("SUCCESS","NEUTRAL","SKIPPED")) then "pass" else "pending" end) elif (.status != null and .status != "COMPLETED") then "pending" elif (.state != null) then (if (.state|IN("FAILURE","ERROR")) then "fail" elif (.state=="SUCCESS") then "pass" else "pending" end) else "pending" end ] as $v | if ($v|length)==0 then "empty" elif ($v|any(.=="fail")) then "failed" elif ($v|any(.=="pending")) then "pending" else "success" end' \
-			2>"$tmp_err") || {
-			# gh exits non-zero on auth/network errors (and possibly a "no
-			# checks reported"-style message on some versions). Treat that as
-			# a terminal "no checks" state only after a couple of retries (so
-			# a transient not-yet-registered window on a repo that DOES
-			# require checks isn't mistaken for checkless); any other gh
-			# failure stays "pending" and retries.
-			if grep -q "no checks reported" "$tmp_err" && [ "$tries" -ge 2 ]; then
-				state="nochecks"
-			else
-				state="pending"
-			fi
+			--jq '[ .statusCheckRollup[]? | if (.conclusion != null) then (if (.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT" or .conclusion == "ACTION_REQUIRED" or .conclusion == "STARTUP_FAILURE") then "fail" elif (.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED") then "pass" else "pending" end) elif (.status != null and .status != "COMPLETED") then "pending" elif (.state != null) then (if (.state == "FAILURE" or .state == "ERROR") then "fail" elif (.state == "SUCCESS") then "pass" else "pending" end) else "pending" end ] as $v | if ($v|length)==0 then "empty" elif ($v|any(.=="fail")) then "failed" elif ($v|any(.=="pending")) then "pending" else "success" end' \
+			2>/dev/null) || {
+			# gh exits non-zero on auth/network errors — stay "pending" and
+			# retry; a transient error message must not abort the poll loop.
+			state="pending"
 		}
-		if [ "$state" = "empty" ]; then
-			# Zero checks reported. Right after PR creation this is normal
-			# (checks not yet registered) — keep polling as "pending". Only
-			# after a couple of retries do we treat it as a genuinely
-			# checkless repo and stop, same terminal "nochecks" semantics as
-			# the gh-failure path above.
-			if [ "$tries" -ge 2 ]; then
-				state="nochecks"
-			else
-				state="pending"
-			fi
-		fi
+		# Record whether we've ever seen a non-empty rollup BEFORE folding
+		# "empty" into "pending" for the loop's own break/continue logic.
+		[ "$state" != "empty" ] && saw_checks=1
+		[ "$state" = "empty" ] && state="pending"
 		[ "$state" = "success" ] && break
 		[ "$state" = "failed" ] && break
-		[ "$state" = "nochecks" ] && break
 		tries=$((tries + 1))
 		sleep "$interval"
 	done
-	rm -f "$tmp_err"
 
 	case "$state" in
 	success) ;;
@@ -215,12 +201,16 @@ _open_and_merge_pr() {
 		echo "publish-sync: status check 실패 — $pr_url 를 직접 확인하세요" >&2
 		return 1
 		;;
-	nochecks)
-		echo "publish-sync: status check가 구성되지 않은 리포 — 자동 병합하지 않습니다. $pr_url 를 직접 검토/병합하세요" >&2
-		return 1
-		;;
 	*)
-		echo "publish-sync: status check 대기 타임아웃 — $pr_url 를 직접 확인하세요" >&2
+		# Loop exhausted without success/failed. If checks were NEVER
+		# observed (rollup was empty on every single poll), treat this as a
+		# genuinely checkless repo; otherwise checks appeared but stayed
+		# pending the whole window.
+		if [ "$saw_checks" -eq 0 ]; then
+			echo "publish-sync: status check가 구성되지 않은 리포 — 자동 병합하지 않습니다. $pr_url 를 직접 검토/병합하세요" >&2
+		else
+			echo "publish-sync: status check 대기 타임아웃 — $pr_url 를 직접 확인하세요" >&2
+		fi
 		return 1
 		;;
 	esac

--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -163,22 +163,44 @@ _open_and_merge_pr() {
 	# Explicit template (not bare `mktemp`): BSD/macOS mktemp requires one.
 	tmp_err=$(mktemp "${TMPDIR:-/tmp}/publish-sync-checks.XXXXXX") || return 1
 
+	# The `--json bucket` flag on the `pr checks` subcommand does not exist
+	# on gh <2.46ish (unknown flag: --json) — verified on gh 2.45.0, which
+	# every poll would error on, always falling to "pending" and eventually
+	# timing out even when checks are green. `gh pr view --json
+	# statusCheckRollup` works on 2.45.0 and returns each check as either a
+	# CheckRun (`status` + `conclusion`) or a StatusContext (`state`, no
+	# `conclusion`); the jq below normalizes both shapes to one aggregate
+	# word, fail-closed on any unrecognized shape.
 	while [ "$tries" -lt "$max_tries" ]; do
-		state=$(gh pr checks "$pr_number" --repo "$target" \
-			--json bucket \
-			--jq '[.[].bucket] | if length == 0 then "pending" elif any(.=="fail" or .=="cancel") then "failed" elif any(.=="pending") then "pending" else "success" end' \
+		# shellcheck disable=SC2016 # `$v` below is jq's `as $v` binding, not a shell variable — single-quoted on purpose.
+		state=$(gh pr view "$pr_number" --repo "$target" \
+			--json statusCheckRollup \
+			--jq '[ .statusCheckRollup[]? | if (.conclusion != null) then (if (.conclusion|IN("FAILURE","CANCELLED","TIMED_OUT","ACTION_REQUIRED","STARTUP_FAILURE")) then "fail" elif (.conclusion|IN("SUCCESS","NEUTRAL","SKIPPED")) then "pass" else "pending" end) elif (.status != null and .status != "COMPLETED") then "pending" elif (.state != null) then (if (.state|IN("FAILURE","ERROR")) then "fail" elif (.state=="SUCCESS") then "pass" else "pending" end) else "pending" end ] as $v | if ($v|length)==0 then "empty" elif ($v|any(.=="fail")) then "failed" elif ($v|any(.=="pending")) then "pending" else "success" end' \
 			2>"$tmp_err") || {
-			# gh exits non-zero when a PR has no checks at all. Treat that as a
-			# terminal "no checks" state only after a couple of retries (so a
-			# transient not-yet-registered window on a repo that DOES require
-			# checks isn't mistaken for checkless); any other gh failure
-			# (auth/network) stays "pending" and retries.
+			# gh exits non-zero on auth/network errors (and possibly a "no
+			# checks reported"-style message on some versions). Treat that as
+			# a terminal "no checks" state only after a couple of retries (so
+			# a transient not-yet-registered window on a repo that DOES
+			# require checks isn't mistaken for checkless); any other gh
+			# failure stays "pending" and retries.
 			if grep -q "no checks reported" "$tmp_err" && [ "$tries" -ge 2 ]; then
 				state="nochecks"
 			else
 				state="pending"
 			fi
 		}
+		if [ "$state" = "empty" ]; then
+			# Zero checks reported. Right after PR creation this is normal
+			# (checks not yet registered) — keep polling as "pending". Only
+			# after a couple of retries do we treat it as a genuinely
+			# checkless repo and stop, same terminal "nochecks" semantics as
+			# the gh-failure path above.
+			if [ "$tries" -ge 2 ]; then
+				state="nochecks"
+			else
+				state="pending"
+			fi
+		fi
 		[ "$state" = "success" ] && break
 		[ "$state" = "failed" ] && break
 		[ "$state" = "nochecks" ] && break

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -189,19 +189,26 @@ _route_origin_offline() {
 # to $GH_STUB_LOG as one line (argv joined by spaces). Behavior is
 # controlled by files under $GH_STUB_DIR:
 #   checks_result   - "success" | "failed" | "pending" | "empty" | "nochecks"
-#                     (default: success)
+#                     | "state-success" | "state-failed" (default: success)
 #   merge_result    - "success" | "failed" (default: success)
 #
-# For the legacy literal words (success/failed/pending), the stub emits
-# REAL `bucket` JSON so the script's actual `--jq` expression runs and is
-# exercised (rather than a pre-aggregated string), while still driving the
-# loop to the same state the test names imply:
-#   success -> [{"bucket":"pass"}]      failed  -> [{"bucket":"fail"}]
-#   pending -> [{"bucket":"pending"}]
-# Two new sentinels exercise the fail-closed edges FIX 1 addresses:
-#   empty    -> [] (checks not yet registered — must stay "pending", never
-#               premature-"success")
-#   nochecks -> exit 1 with "no checks reported" on stderr (checkless repo)
+# The script polls via `gh pr view --json statusCheckRollup --jq ...`
+# (real gh 2.45.0 has no `--json` on `gh pr checks` at all — verified
+# live, see publish-sync.sh comment). The stub's `pr view` branch emits
+# REAL `statusCheckRollup`-shaped JSON so the script's actual `--jq`
+# aggregation expression runs and is exercised end-to-end (rather than a
+# pre-aggregated string):
+#   success -> CheckRun conclusion=SUCCESS   failed -> conclusion=FAILURE
+#   pending -> CheckRun status=IN_PROGRESS, conclusion=null
+#   state-success / state-failed -> StatusContext shape (state=SUCCESS /
+#               state=FAILURE, no conclusion) to exercise that jq branch
+# Two more sentinels exercise the fail-closed edges FIX 1 addresses:
+#   empty    -> {"statusCheckRollup":[]} (checks not yet registered — must
+#               stay "pending" until tries>=2, never premature-"success")
+#   nochecks -> {"statusCheckRollup":[]} too — relies on the same
+#               empty-after-retries -> "nochecks" path as "empty" (a
+#               genuinely checkless repo looks identical to a not-yet-
+#               registered one from `gh pr view`'s point of view)
 _install_gh_stub() {
     GH_STUB_DIR="$TEST_TEMP_HOME/gh-stub"
     mkdir -p "$GH_STUB_DIR/bin"
@@ -219,21 +226,21 @@ case "\$1 \$2" in
     echo "https://example.com/owner/repo/pull/42"
     exit 0
     ;;
-"pr checks")
+"pr view")
     RESULT=\$(cat "$GH_STUB_DIR/checks_result")
-    if [ "\$RESULT" = "nochecks" ]; then
-        printf 'no checks reported\n' >&2
-        exit 1
-    fi
     case "\$RESULT" in
-    success) BUCKETS='[{"bucket":"pass"}]' ;;
-    failed) BUCKETS='[{"bucket":"fail"}]' ;;
-    pending) BUCKETS='[{"bucket":"pending"}]' ;;
-    empty) BUCKETS='[]' ;;
-    *) BUCKETS="\$RESULT" ;;
+    success) ROLLUP='[{"name":"CI","status":"COMPLETED","conclusion":"SUCCESS","state":null}]' ;;
+    failed) ROLLUP='[{"name":"CI","status":"COMPLETED","conclusion":"FAILURE","state":null}]' ;;
+    pending) ROLLUP='[{"name":"CI","status":"IN_PROGRESS","conclusion":null,"state":null}]' ;;
+    state-success) ROLLUP='[{"name":"ci/legacy","conclusion":null,"state":"SUCCESS"}]' ;;
+    state-failed) ROLLUP='[{"name":"ci/legacy","conclusion":null,"state":"FAILURE"}]' ;;
+    empty) ROLLUP='[]' ;;
+    nochecks) ROLLUP='[]' ;;
+    *) ROLLUP="\$RESULT" ;;
     esac
+    JSON="{\\"statusCheckRollup\\":\$ROLLUP}"
     # Pull out the --jq filter the caller passed and run it for real via
-    # the system jq, so the script's actual bucket-mapping expression is
+    # the system jq, so the script's actual aggregation expression is
     # exercised end-to-end instead of re-implemented here.
     JQ_FILTER=""
     PREV=""
@@ -245,9 +252,9 @@ case "\$1 \$2" in
         PREV="\$ARG"
     done
     if [ -n "\$JQ_FILTER" ]; then
-        echo "\$BUCKETS" | jq -r "\$JQ_FILTER"
+        echo "\$JSON" | jq -r "\$JQ_FILTER"
     else
-        echo "\$BUCKETS"
+        echo "\$JSON"
     fi
     exit 0
     ;;
@@ -296,6 +303,35 @@ STUB
     assert_output "1"
 }
 
+@test "_open_and_merge_pr admin-merges when checks report a StatusContext state=SUCCESS (no conclusion field)" {
+    # Exercises the jq's StatusContext branch (`.state`, no `.conclusion`) —
+    # e.g. legacy commit statuses, distinct from the CheckRun
+    # status/conclusion branch covered by the "success" sentinel above.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    git -C "$REPO" remote set-url origin "https://github.com/owner/repo.git"
+    _install_gh_stub
+    echo "state-success" >"$GH_STUB_DIR/checks_result"
+
+    run _open_and_merge_pr "$REPO" "chore/plugin-sync-publish-public-20260702-000000"
+    assert_success
+    run grep -c "^pr merge.*--admin" "$GH_STUB_LOG"
+    assert_output "1"
+}
+
+@test "_open_and_merge_pr does not merge when a StatusContext reports state=FAILURE" {
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    git -C "$REPO" remote set-url origin "https://github.com/owner/repo.git"
+    _install_gh_stub
+    echo "state-failed" >"$GH_STUB_DIR/checks_result"
+
+    run _open_and_merge_pr "$REPO" "chore/plugin-sync-publish-public-20260702-000000"
+    assert_failure
+    run grep -c "^pr merge" "$GH_STUB_LOG"
+    assert_output "0"
+}
+
 @test "_open_and_merge_pr does not merge when checks fail" {
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"
@@ -324,10 +360,15 @@ STUB
     assert_output "0"
 }
 
-@test "_open_and_merge_pr never premature-merges when checks report an empty bucket array" {
-    # FIX 1 (blocker): an empty `[]` bucket array (checks not yet registered
-    # right after PR creation) must map to "pending", NOT fall through the
-    # jq's `else "success"` branch into a premature --admin merge.
+@test "_open_and_merge_pr never premature-merges when checks report an empty rollup array" {
+    # FIX 1 (blocker): an empty `statusCheckRollup: []` (checks not yet
+    # registered right after PR creation) must map to "pending" on the
+    # first couple of polls, NOT fall through the jq's `else "success"`
+    # branch into a premature --admin merge. With PUBLISH_SYNC_CHECK_MAX_TRIES=3
+    # the empty result keeps polling as "pending" until tries>=2, at which
+    # point it becomes the same terminal "nochecks" state a genuinely
+    # checkless repo would hit (indistinguishable from `gh pr view`'s point
+    # of view) — never a premature merge either way.
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"
     git -C "$REPO" remote set-url origin "https://github.com/owner/repo.git"
@@ -336,7 +377,7 @@ STUB
 
     run _open_and_merge_pr "$REPO" "chore/plugin-sync-publish-public-20260702-000000"
     assert_failure
-    assert_output --partial "대기 타임아웃"
+    assert_output --partial "status check가 구성되지 않은 리포"
     run grep -c "^pr merge" "$GH_STUB_LOG"
     assert_output "0"
 }

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -188,8 +188,9 @@ _route_origin_offline() {
 # Installs a fake `gh` at the front of PATH. Every invocation is appended
 # to $GH_STUB_LOG as one line (argv joined by spaces). Behavior is
 # controlled by files under $GH_STUB_DIR:
-#   checks_result   - "success" | "failed" | "pending" | "empty" | "nochecks"
-#                     | "state-success" | "state-failed" (default: success)
+#   checks_result   - "success" | "failed" | "pending" | "empty"
+#                     | "empty-then-success" | "state-success" | "state-failed"
+#                     (default: success)
 #   merge_result    - "success" | "failed" (default: success)
 #
 # The script polls via `gh pr view --json statusCheckRollup --jq ...`
@@ -202,13 +203,18 @@ _route_origin_offline() {
 #   pending -> CheckRun status=IN_PROGRESS, conclusion=null
 #   state-success / state-failed -> StatusContext shape (state=SUCCESS /
 #               state=FAILURE, no conclusion) to exercise that jq branch
-# Two more sentinels exercise the fail-closed edges FIX 1 addresses:
-#   empty    -> {"statusCheckRollup":[]} (checks not yet registered — must
-#               stay "pending" until tries>=2, never premature-"success")
-#   nochecks -> {"statusCheckRollup":[]} too — relies on the same
-#               empty-after-retries -> "nochecks" path as "empty" (a
-#               genuinely checkless repo looks identical to a not-yet-
-#               registered one from `gh pr view`'s point of view)
+# Two more sentinels exercise the fail-closed edges FIX 1/2 address:
+#   empty              -> {"statusCheckRollup":[]} on every poll (a
+#                          genuinely checkless repo — the script has no "no
+#                          checks reported" signal to short-circuit on, so
+#                          this must poll the FULL window before declaring
+#                          the repo checkless)
+#   empty-then-success -> empty on the first 2 polls (checks not yet
+#                          registered), then a real SUCCESS CheckRun from
+#                          the 3rd poll onward — proves the script does NOT
+#                          give up early on an empty rollup and still
+#                          merges once checks appear. Poll count is tracked
+#                          via $GH_STUB_DIR/pr_view_count.
 _install_gh_stub() {
     GH_STUB_DIR="$TEST_TEMP_HOME/gh-stub"
     mkdir -p "$GH_STUB_DIR/bin"
@@ -228,6 +234,11 @@ case "\$1 \$2" in
     ;;
 "pr view")
     RESULT=\$(cat "$GH_STUB_DIR/checks_result")
+    # Poll counter, used only by empty-then-success to flip its answer
+    # partway through the window.
+    COUNT_FILE="$GH_STUB_DIR/pr_view_count"
+    COUNT=\$(( \$(cat "\$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+    echo "\$COUNT" >"\$COUNT_FILE"
     case "\$RESULT" in
     success) ROLLUP='[{"name":"CI","status":"COMPLETED","conclusion":"SUCCESS","state":null}]' ;;
     failed) ROLLUP='[{"name":"CI","status":"COMPLETED","conclusion":"FAILURE","state":null}]' ;;
@@ -235,7 +246,13 @@ case "\$1 \$2" in
     state-success) ROLLUP='[{"name":"ci/legacy","conclusion":null,"state":"SUCCESS"}]' ;;
     state-failed) ROLLUP='[{"name":"ci/legacy","conclusion":null,"state":"FAILURE"}]' ;;
     empty) ROLLUP='[]' ;;
-    nochecks) ROLLUP='[]' ;;
+    empty-then-success)
+        if [ "\$COUNT" -le 2 ]; then
+            ROLLUP='[]'
+        else
+            ROLLUP='[{"name":"CI","status":"COMPLETED","conclusion":"SUCCESS","state":null}]'
+        fi
+        ;;
     *) ROLLUP="\$RESULT" ;;
     esac
     JSON="{\\"statusCheckRollup\\":\$ROLLUP}"
@@ -360,45 +377,48 @@ STUB
     assert_output "0"
 }
 
-@test "_open_and_merge_pr never premature-merges when checks report an empty rollup array" {
-    # FIX 1 (blocker): an empty `statusCheckRollup: []` (checks not yet
-    # registered right after PR creation) must map to "pending" on the
-    # first couple of polls, NOT fall through the jq's `else "success"`
-    # branch into a premature --admin merge. With PUBLISH_SYNC_CHECK_MAX_TRIES=3
-    # the empty result keeps polling as "pending" until tries>=2, at which
-    # point it becomes the same terminal "nochecks" state a genuinely
-    # checkless repo would hit (indistinguishable from `gh pr view`'s point
-    # of view) — never a premature merge either way.
+@test "_open_and_merge_pr hits the terminal checkless state and does not merge when the rollup stays empty for the full window" {
+    # FIX 2 (codex BLOCKER): `gh pr view --json statusCheckRollup` has no
+    # "no checks reported" signal to short-circuit on — a genuinely
+    # checkless repo just returns an empty rollup on every single poll.
+    # The script must poll the FULL max_tries window (never give up early
+    # on an empty rollup) and only THEN, having never observed a real
+    # check, report the repo as checkless. Never a merge either way.
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"
     git -C "$REPO" remote set-url origin "https://github.com/owner/repo.git"
     _install_gh_stub
     echo "empty" >"$GH_STUB_DIR/checks_result"
+    PUBLISH_SYNC_CHECK_INTERVAL=0
+    PUBLISH_SYNC_CHECK_MAX_TRIES=3
+    export PUBLISH_SYNC_CHECK_INTERVAL PUBLISH_SYNC_CHECK_MAX_TRIES
 
     run _open_and_merge_pr "$REPO" "chore/plugin-sync-publish-public-20260702-000000"
     assert_failure
     assert_output --partial "status check가 구성되지 않은 리포"
+    run grep -c "^pr view" "$GH_STUB_LOG"
+    assert_output "3"
     run grep -c "^pr merge" "$GH_STUB_LOG"
     assert_output "0"
 }
 
-@test "_open_and_merge_pr hits the terminal no-checks state and does not merge on a checkless repo" {
-    # FIX 1 (blocker): `gh pr checks` exiting non-zero with "no checks
-    # reported" on every poll (a repo with no status checks configured at
-    # all) must become a terminal "nochecks" state after a couple of
-    # retries, not loop silently to the generic 5-minute timeout, and must
-    # never merge.
+@test "_open_and_merge_pr does not give up early on an empty rollup and merges once checks appear" {
+    # FIX 2 (codex BLOCKER) proof: the rollup is empty on the first two
+    # polls (checks not yet registered) and only becomes a real SUCCESS
+    # CheckRun from the third poll onward. The old logic declared
+    # "nochecks" as soon as tries>=2 and would have given up here without
+    # ever seeing the SUCCESS — this asserts the script instead keeps
+    # polling through the empty window and merges once checks land.
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"
     git -C "$REPO" remote set-url origin "https://github.com/owner/repo.git"
     _install_gh_stub
-    echo "nochecks" >"$GH_STUB_DIR/checks_result"
+    echo "empty-then-success" >"$GH_STUB_DIR/checks_result"
 
     run _open_and_merge_pr "$REPO" "chore/plugin-sync-publish-public-20260702-000000"
-    assert_failure
-    assert_output --partial "status check가 구성되지 않은 리포"
-    run grep -c "^pr merge" "$GH_STUB_LOG"
-    assert_output "0"
+    assert_success
+    run grep -c "^pr merge.*--admin" "$GH_STUB_LOG"
+    assert_output "1"
 }
 
 @test "_publish_manifest_diff no-ops when there is nothing to publish" {


### PR DESCRIPTION
## Summary

`claude/plugin/publish-sync.sh`의 check-polling(`_open_and_merge_pr`)이 `gh pr checks <n> --json bucket` 에 의존했는데, **설치 환경 gh 2.45.0 의 `gh pr checks` 에는 `--json` 플래그가 없어**(`unknown flag: --json`) 매 폴링이 exit≠0 → `pending` 흡수 → 20회 재시도 타임아웃 → **auto-merge 가 실제 환경에서 절대 성공하지 못했다.** PR #1069/#1075 라이브 스모크(플랜 Task 9)에서 실측 발견한 BLOCKER.

Closes #1078.

## Changes

- **`_open_and_merge_pr`**: 폴링을 모든 최근 gh 에서 동작하는 `gh pr view <n> --json statusCheckRollup` 으로 교체. 신규 jq 가 두 엔트리 shape 을 fail-closed 로 정규화:
  - CheckRun(`status`/`conclusion`): `FAILURE/CANCELLED/TIMED_OUT/ACTION_REQUIRED/STARTUP_FAILURE`→fail, `SUCCESS/NEUTRAL/SKIPPED`→pass, 그 외/미완료→pending.
  - StatusContext(`state`): `FAILURE/ERROR`→fail, `SUCCESS`→pass, 그 외→pending.
  - 집계: 하나라도 fail→failed, 하나라도 pending→pending, 전부 pass→success, 빈 배열→empty.
  - 빈 배열은 pending 으로 대기(premature merge 차단), `tries>=2` 지속 시 `nochecks` terminal(자동 병합 안 함 + 수동 안내). #1075 의 fail-closed 규칙 유지.
- **bats**: fake `gh` 스텁의 `pr checks` 분기를 실제 `statusCheckRollup` JSON 을 뱉는 `pr view` 분기로 교체 — 스크립트의 실제 `--jq` 를 system `jq` 로 통과시켜 검증한다(스텁이 현실과 일치 → 이번 갭의 근본 원인 해소). StatusContext `state` 경로 케이스 2건 추가.

## Test plan

- [x] `tests/bats/tools/claude_plugin_publish_sync.bats` 26 + `claude_help_plugin.bats` 4 = **30/30 통과**.
- [x] `shellcheck` + `shfmt -d` (publish-sync.sh) clean.
- [x] `grep "gh pr checks" claude/plugin/publish-sync.sh` → 0건(완전 제거).
- [x] 스크립트의 실제 statusCheckRollup 집계 jq 가 스텁 경로에서 system jq 로 실제 실행됨(jq 오타 시 테스트 실패로 검증) — StatusContext 테스트 통과로 확인.
- [ ] 라이브: 실제 대기 중 sync 커밋으로 end-to-end publish→check-wait→admin-merge 1회 성공 확인(gh 2.45.0 실환경).

## 대안 (검토·비채택)

`gh pr checks --watch --fail-fast --interval` + `timeout` — 단순하나 (a) `timeout` 이식성 의존(macOS 기본 미탑재), (b) `--watch` 블로킹이라 결정적 유닛테스트 곤란. statusCheckRollup 방식이 테스트 용이성 + 무의존성 우위.

## References
- Closes #1078. 발견 경위: #1069/#1075 라이브 스모크. 배경 #1063.
- 관련 파일: `claude/plugin/publish-sync.sh`(`_open_and_merge_pr`), `tests/bats/tools/claude_plugin_publish_sync.bats`
- 환경: `gh version 2.45.0`

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~14 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~14 min
<!-- /ai-metrics:gh-pr -->

</details>
