### PR TITLE
feat(plugin-sync): 사외↔사내 격리 corner case 두 방향 보완 (external 힌트 + internal publish 가드)

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -100,12 +100,17 @@ source:github만)에 병합 반영하고 로컬 커밋한다. 사내 전용
 추적 제외)로 간다 — internal PC에서 최초 1회 `git clone <url>
 claude/plugin/company` 필요.
 
+external/public PC에서 사내 GHES 마켓플레이스가 우연히 감지되면(company/
+레포 미clone) hook은 격리 정책상 저장하지 않고 stderr 힌트만 남긴다 — 조용한
+skip이 아니다 (#1080).
+
 신규 PC: `./claude/plugin/restore.sh` (mode-aware, `--dry-run` 지원).
 
 두 레포 모두 "PR을 통해서만 변경 가능" 규칙이 걸려 있어 hook의 로컬 커밋이
 origin에 직접 push되지 않는다 — `./claude/plugin/publish-sync.sh`
 (`--dry-run` 지원)를 수동 실행하면 쌓인 변경분을 브랜치+PR+admin-merge로
-게시한다. 자세한 설계: `docs/feature/superpowers-specs/2026-07-01-claude-plugin-manifest-design.md`,
+게시한다. internal PC는 github.com이 pull-only라 public 단계를 자동으로
+건너뛴다 (company/ GHES 단계만 게시, #1080). 자세한 설계: `docs/feature/superpowers-specs/2026-07-01-claude-plugin-manifest-design.md`,
 `docs/feature/superpowers-specs/2026-07-02-plugin-manifest-batch-publish-design.md`.
 
 ---

--- a/claude/hooks/plugin-sync.sh
+++ b/claude/hooks/plugin-sync.sh
@@ -172,6 +172,16 @@ if [ "$action" = "add" ]; then
 			mv "$PRIV_DIR/plugins.json.tmp" "$PRIV_DIR/plugins.json"
 		_commit_if_changed "$PRIV_DIR" "$SYNC_MSG" \
 			marketplaces.json plugins.json
+	elif [ "$mp_internal" != "{}" ] && [ ! -d "$PRIV_DIR/.git" ]; then
+		# 사내(non-github) 마켓플레이스가 감지됐지만 이 PC 에는 company/ 레포가
+		# clone 돼 있지 않다 — external/public PC 에서 사내 GHES 마켓플레이스가
+		# 우연히 설치된 경우다. 저장하지 않는 건 사내→사외 격리 정책이자 의도된
+		# 동작이지만, 예전엔 조용히 skip 해 사용자가 "왜 매니페스트에 아무 것도
+		# 안 남지?" 라고 헷갈렸다 (#1080). 저장은 여전히 하지 않고, 다음 액션을
+		# 알 수 있도록 stderr 힌트만 남긴다 (exit 0 원칙은 그대로).
+		printf 'plugin-sync: 사내 GHES 마켓플레이스 감지 — 이 PC 에는 company/ 레포가 없습니다 (external/public PC 로 판단)\n' >&2
+		printf 'plugin-sync:   → 격리 정책상 %s 에 저장하지 않습니다 (사내 URL 이 공개 레포로 유출되지 않도록)\n' "$PRIV_DIR" >&2
+		printf 'plugin-sync:   → internal PC 에서 관리하세요. 이 PC 에서도 관리하려면 먼저: git clone <GHES private repo url> "%s"\n' "$PRIV_DIR" >&2
 	fi
 fi
 

--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -271,6 +271,12 @@ _publish_manifest_diff() {
 	}
 	_open_and_merge_pr "$repo_dir" "$branch" || return 1
 
+	# Publish landed. `gh pr merge --delete-branch` removed the REMOTE branch,
+	# but the local ref we created in $repo_dir via update-ref survives — drop
+	# it so successful runs don't accumulate orphaned chore/plugin-sync-publish-*
+	# refs (mirrors the push-failure cleanup in _publish_branch).
+	git -C "$repo_dir" update-ref -d "refs/heads/$branch" 2>/dev/null || true
+
 	# Local-main cleanup is best-effort AFTER the irreversible publish — its
 	# own stderr already explains any skip/failure; never let it flip the
 	# orchestrator's result, or Task 8's loop would misread a successful
@@ -349,8 +355,15 @@ _cleanup_local_main_if_pure_sync() {
 # mode falls through to "allowed" (github.com), matching gh_host.sh's
 # regression-zero fail-safe.
 _public_publish_allowed() {
-	local mode
-	mode=$(tr -d ' \t\n\r' <"$HOME/.dotfiles-setup-mode" 2>/dev/null || echo "")
+	local mode=""
+	# Guard the read with `[ -f ]` (like gh_host.sh): a bare `<missing-file`
+	# redirection leaks "bash: …: No such file or directory" to the real
+	# stderr even with `2>/dev/null` on the command, since the redirection
+	# failure is reported by the shell, not `tr`. A missing file means "no
+	# mode set" → github.com default (allowed).
+	if [ -f "$HOME/.dotfiles-setup-mode" ]; then
+		mode=$(tr -d ' \t\n\r' <"$HOME/.dotfiles-setup-mode" 2>/dev/null || echo "")
+	fi
 	case "$mode" in
 	1) mode="public" ;;
 	2) mode="internal" ;;

--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -126,8 +126,14 @@ _publish_branch() {
 	local repo_dir="$1" label="$2" commit="$3" branch
 	branch="chore/plugin-sync-publish-${label}-$(date +%Y%m%d-%H%M%S)-$$"
 	git -C "$repo_dir" update-ref "refs/heads/$branch" "$commit" || return 1
-	git -C "$repo_dir" push --quiet origin \
-		"refs/heads/$branch:refs/heads/$branch" || return 1
+	if ! git -C "$repo_dir" push --quiet origin \
+		"refs/heads/$branch:refs/heads/$branch"; then
+		# Push failed (network/auth/policy) — drop the local ref we just
+		# created so repeated failed runs don't litter the repo with orphaned
+		# chore/plugin-sync-publish-* branches.
+		git -C "$repo_dir" update-ref -d "refs/heads/$branch" 2>/dev/null || true
+		return 1
+	fi
 	printf '%s\n' "$branch"
 }
 
@@ -327,6 +333,32 @@ _cleanup_local_main_if_pure_sync() {
 	echo "publish-sync: 로컬 main을 origin/main으로 정리했습니다"
 }
 
+# _public_publish_allowed
+#
+# Return 0 if the public (github.com) dotfiles repo may be published from
+# this PC, 1 if it must not. `internal` PCs are github.com **pull-only**
+# (docs/.ssot/pc-environment.md §3) — pushing there is a policy violation,
+# so publish-sync must not even attempt the branch/PR/merge on the public
+# repo from an internal PC (#1080). The company/ GHES repo is unaffected
+# (its own `[ -d "$PRIV_DIR/.git" ]` gate already scopes it to internal).
+#
+# Reads ~/.dotfiles-setup-mode directly (like restore.sh — this is a
+# stand-alone script, not sourced with the shell-common integration layer),
+# canonicalizing the legacy numeric values 1/2/3 exactly as
+# shell-common/functions/gh_host.sh does so the two agree. A missing/unknown
+# mode falls through to "allowed" (github.com), matching gh_host.sh's
+# regression-zero fail-safe.
+_public_publish_allowed() {
+	local mode
+	mode=$(tr -d ' \t\n\r' <"$HOME/.dotfiles-setup-mode" 2>/dev/null || echo "")
+	case "$mode" in
+	1) mode="public" ;;
+	2) mode="internal" ;;
+	3) mode="external" ;;
+	esac
+	[ "$mode" != "internal" ]
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	DRY_RUN=0
 	case "${1:-}" in
@@ -355,8 +387,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	PRIV_DIR="$MAIN_ROOT/claude/plugin/company"
 	RC=0
 
-	_publish_manifest_diff "$MAIN_ROOT" "public" \
-		claude/plugin/marketplaces.json claude/plugin/plugins.json || RC=1
+	if _public_publish_allowed; then
+		_publish_manifest_diff "$MAIN_ROOT" "public" \
+			claude/plugin/marketplaces.json claude/plugin/plugins.json || RC=1
+	else
+		echo "[public] internal 모드 — github.com은 pull-only 정책이라 public manifest publish를 건너뜁니다 (사내→사외 push 금지)"
+	fi
 
 	if [ -d "$PRIV_DIR/.git" ]; then
 		_publish_manifest_diff "$PRIV_DIR" "company" \

--- a/tests/bats/skills/plugin_sync_hook.bats
+++ b/tests/bats/skills/plugin_sync_hook.bats
@@ -173,6 +173,22 @@ JSON
     [ ! -d "$MAIN_ROOT/claude/plugin/company" ]
 }
 
+@test "install → GHES marketplace on a PC without company/ prints a stderr hint (not a silent skip, #1080)" {
+    _known_marketplaces
+    _installed_plugins
+    # No company/.git → simulates an external/public PC. The internal entry
+    # must NOT be stored (isolation), but the user gets a stderr hint instead
+    # of the old silent skip.
+    payload='{"tool_name":"Bash","tool_input":{"command":"claude plugin install secret@internal-tools"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    assert_output --partial "사내 GHES 마켓플레이스 감지"
+    # Still no company/ manifest written, and no leak into the public manifest.
+    [ ! -d "$MAIN_ROOT/claude/plugin/company" ]
+    run jq -e 'has("internal-tools")' "$MAIN_ROOT/claude/plugin/marketplaces.json"
+    assert_failure
+}
+
 @test "marketplace add → treated the same as install (re-sync)" {
     _known_marketplaces
     _installed_plugins

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -726,3 +726,33 @@ STUB
     run grep -c "^pr create" "$GH_STUB_LOG"
     assert_output "0"
 }
+
+# --- #1081 review (gemini-code-assist) follow-ups ---
+
+@test "_public_publish_allowed emits nothing on stderr when the mode file is missing" {
+    rm -f "$HOME/.dotfiles-setup-mode"
+    stderr_file="$TEST_TEMP_HOME/ppa_stderr"
+    _public_publish_allowed 2>"$stderr_file" || true
+    run cat "$stderr_file"
+    assert_output ""
+}
+
+@test "a successful publish leaves no orphaned local chore/plugin-sync-publish-* ref" {
+    mkdir -p "$TEST_TEMP_HOME/dotfiles"
+    _seed_repo_with_origin "$TEST_TEMP_HOME/dotfiles"
+    BARE=$(git -C "$TEST_TEMP_HOME/dotfiles" remote get-url origin)
+    GH_STUB_BARE_REPO="$BARE"
+    export GH_STUB_BARE_REPO
+
+    _commit_pure_sync_change "$TEST_TEMP_HOME/dotfiles" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _install_gh_stub
+    _route_origin_offline "$TEST_TEMP_HOME/dotfiles" "https://github.com/dEitY719/dotfiles.git" "${BARE}"
+
+    run bash "$PUBLISH_SYNC"
+    assert_success
+    assert_output --partial "[public] 변경 감지됨"
+    # The local publish branch ref must be gone after a successful merge
+    # (gh --delete-branch only removes the remote branch).
+    run git -C "$TEST_TEMP_HOME/dotfiles" for-each-ref --format='%(refname)' 'refs/heads/chore/plugin-sync-publish-*'
+    assert_output ""
+}

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -670,3 +670,59 @@ STUB
     run grep -c "^pr create" "$GH_STUB_LOG"
     assert_output "0"
 }
+
+# --- #1080: internal PC must never publish the public (github.com) repo ---
+
+@test "_public_publish_allowed forbids publish in internal mode" {
+    printf 'internal\n' >"$HOME/.dotfiles-setup-mode"
+    run _public_publish_allowed
+    assert_failure
+}
+
+@test "_public_publish_allowed allows publish in external mode" {
+    printf 'external\n' >"$HOME/.dotfiles-setup-mode"
+    run _public_publish_allowed
+    assert_success
+}
+
+@test "_public_publish_allowed allows publish in public mode" {
+    printf 'public\n' >"$HOME/.dotfiles-setup-mode"
+    run _public_publish_allowed
+    assert_success
+}
+
+@test "_public_publish_allowed allows publish when the mode file is missing (github.com fail-safe)" {
+    rm -f "$HOME/.dotfiles-setup-mode"
+    run _public_publish_allowed
+    assert_success
+}
+
+@test "_public_publish_allowed normalizes the legacy numeric '2' to internal" {
+    printf '2\n' >"$HOME/.dotfiles-setup-mode"
+    run _public_publish_allowed
+    assert_failure
+}
+
+@test "running the script in internal mode skips the public step without pushing or opening a PR (#1080)" {
+    mkdir -p "$TEST_TEMP_HOME/dotfiles"
+    _seed_repo_with_origin "$TEST_TEMP_HOME/dotfiles"
+    BARE=$(git -C "$TEST_TEMP_HOME/dotfiles" remote get-url origin)
+    GH_STUB_BARE_REPO="$BARE"
+    export GH_STUB_BARE_REPO
+
+    # A pending public-manifest diff that WOULD be published on external/public.
+    _commit_pure_sync_change "$TEST_TEMP_HOME/dotfiles" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _install_gh_stub
+    _route_origin_offline "$TEST_TEMP_HOME/dotfiles" "https://github.com/dEitY719/dotfiles.git" "${BARE}"
+
+    # internal PC: github.com is pull-only.
+    printf 'internal\n' >"$HOME/.dotfiles-setup-mode"
+
+    run bash "$PUBLISH_SYNC"
+    assert_success
+    assert_output --partial "internal 모드"
+    refute_output --partial "[public] 변경 감지됨"
+    # No PR ever created against the public github.com repo.
+    run grep -c "^pr create" "$GH_STUB_LOG"
+    assert_output "0"
+}


### PR DESCRIPTION
## 요약

PR #1075(publish-sync 신설) 검증 중 드러난 **사외↔사내 격리 corner case 두 방향**을 한 PR로 보완한다. 정상 워크플로우(공용은 external, GHES는 internal에서만 설치)에는 영향이 없고, 규율이 어긋난 우발 상황에서의 UX/정책 안전만 메운다.

### 1. `claude/hooks/plugin-sync.sh` — external/public PC에서 사내 GHES 마켓 감지 시 silent skip → stderr 힌트

- external/public PC(`company/.git` 미clone)에서 사내 GHES 마켓플레이스가 우연히 설치되면, 훅이 `mp_internal`로 분류하지만 저장할 레포가 없어 **아무 로그 없이 조용히 skip**했다 → "왜 매니페스트에 아무것도 안 남지?" 혼란.
- 저장은 여전히 하지 않되(사내→사외 격리 정책 유지, 데이터 유출 0), 다음 액션을 알려주는 **stderr 힌트 3줄**을 남긴다. `exit 0` 원칙 유지.
- clone 안내는 사내 host를 공개 레포에 박지 않도록 `restore.sh`와 동일한 `<GHES private repo url>` 플레이스홀더를 쓴다 (이슈 제안의 하드코딩 URL에서 의도적으로 변경).

### 2. `claude/plugin/publish-sync.sh` — internal PC의 github.com publish 시도 차단 (내 리뷰 제안)

- internal PC는 github.com이 **pull-only**(pc-environment SSOT §3)인데, 기존 코드는 setup-mode를 읽지 않아 public manifest diff가 쌓여 있으면 github.com으로 branch+PR+admin-merge를 **시도**했다 → 사내→사외 push 금지 정책 위반.
- `_public_publish_allowed()` 추가: `internal` 모드면 public 단계를 **시도조차 하지 않고** 스킵(company/ GHES 단계는 기존 `.git` 가드 그대로). legacy 숫자값 `2` 정규화를 `gh_host.sh` 매핑과 일치시킴.
- 부수: `_publish_branch`가 push 실패 시 방금 만든 로컬 브랜치 ref를 정리 → 고아 `chore/plugin-sync-publish-*` 누적 방지.

### 3. 문서 · 테스트

- `claude/AGENTS.md` Plugin Manifest 섹션에 두 동작 명시.
- 신규 bats: hook 1건(stderr 힌트 + 무유출 assert) + publish-sync 6건(`_public_publish_allowed` 5개 모드 + internal e2e no-PR). 관련 스위트 53건 전부 통과, `shellcheck`/`shfmt -d` clean.

## 테스트

```
bats plugin_sync_hook.bats + claude_plugin_publish_sync.bats → 44 ok
bats plugin_sync_hook_delete.bats + _registration.bats       →  9 ok
shellcheck + shfmt -d (변경 스크립트)                          → clean
```

Closes #1080
