### PR TITLE
feat(plugin-sync): /plugin slash-command 진입 경로 감지 — SSOT-diff SessionStart/Stop hook (#1082)

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -91,9 +91,21 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 ## Plugin Manifest (claude/plugin/)
 
-`claude plugin install/uninstall`, `claude plugin marketplace add/remove`는
-`claude/hooks/plugin-sync.sh` (PostToolUse hook)가 자동 감지해
-`claude/plugin/{marketplaces,plugins}.json`(공용, scope:user +
+플러그인 변경은 **두 진입 경로** 모두에서 동기화된다:
+
+1. **Shell CLI** (`claude plugin install/uninstall`, `claude plugin
+   marketplace add/remove`) — `claude/hooks/plugin-sync.sh` (PostToolUse+Bash
+   hook)가 명령어 문자열을 정규식으로 감지.
+2. **내장 slash command** (`/plugin install|uninstall`, `/plugin marketplace
+   add|remove`) — Claude Code UI 파이프라인을 통과해 Bash tool call 을 만들지
+   않으므로 PostToolUse hook 이 안 잡힌다. `claude/hooks/plugin-sync-session.sh`
+   (SessionStart+Stop hook)가 SSOT (`~/.claude-shared/plugins/{known_marketplaces,
+   installed_plugins}.json`) 해시를 세션 시작 시 stash 하고, 매 Stop 마다 diff 해
+   변화가 있으면 `plugin-sync.sh` 의 add/uninstall 분기를 재실행한다 — 진입 경로
+   무관 (add + remove 대칭 처리, #1082). Claude Code 2.1.x 는 slash command 전용
+   hook event 를 노출하지 않아 이 SSOT-diff 방식을 택했다.
+
+두 경로 모두 `claude/plugin/{marketplaces,plugins}.json`(공용, scope:user +
 source:github만)에 병합 반영하고 로컬 커밋한다. 사내 전용
 (non-github source) 항목은 `claude/plugin/company/`(dotfiles 트리 안이지만
 자체 `.git`을 가진 별도 private GHES 레포, `.gitignore`로 public 레포

--- a/claude/hooks/plugin-sync-session.sh
+++ b/claude/hooks/plugin-sync-session.sh
@@ -53,8 +53,17 @@ baseline="$state_dir/plugin-sync-baseline.$session_id.json"
 # yields an empty hash and an empty key list, so a later add/remove of that
 # file is still detected as a change.
 _snapshot() {
-	mp_hash=$(sha256sum "$MP_SRC" 2>/dev/null | awk '{print $1}')
-	pl_hash=$(sha256sum "$PL_SRC" 2>/dev/null | awk '{print $1}')
+	local mp_hash pl_hash mp_keys pl_keys
+	# macOS ships `shasum` but not `sha256sum`; without this fallback both
+	# hashes would be empty on macOS and always compare equal, silently
+	# disabling change detection.
+	if command -v sha256sum >/dev/null 2>&1; then
+		mp_hash=$(sha256sum "$MP_SRC" 2>/dev/null | awk '{print $1}')
+		pl_hash=$(sha256sum "$PL_SRC" 2>/dev/null | awk '{print $1}')
+	else
+		mp_hash=$(shasum -a 256 "$MP_SRC" 2>/dev/null | awk '{print $1}')
+		pl_hash=$(shasum -a 256 "$PL_SRC" 2>/dev/null | awk '{print $1}')
+	fi
 	mp_keys=$(jq -c 'keys' "$MP_SRC" 2>/dev/null) || mp_keys="[]"
 	pl_keys=$(jq -c '(.plugins // {}) | keys' "$PL_SRC" 2>/dev/null) || pl_keys="[]"
 	jq -n --arg mp "$mp_hash" --arg pl "$pl_hash" \
@@ -82,7 +91,11 @@ fi
 
 # --- Stop (or any non-SessionStart event registered here) ---
 
-[ -f "$MP_SRC" ] || exit 0
+# Either SSOT file being present is enough: a plugin-only install/uninstall
+# (default marketplace, no custom known_marketplaces.json) still needs removal
+# detection, and plugin-sync.sh's uninstall branch reads neither SSOT file. The
+# add branch degrades to a safe no-op when known_marketplaces.json is absent.
+[ -f "$MP_SRC" ] || [ -f "$PL_SRC" ] || exit 0
 SYNC_HOOK="$HOME/dotfiles/claude/hooks/plugin-sync.sh"
 [ -x "$SYNC_HOOK" ] || exit 0
 

--- a/claude/hooks/plugin-sync-session.sh
+++ b/claude/hooks/plugin-sync-session.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# claude/hooks/plugin-sync-session.sh
+#
+# Companion to claude/hooks/plugin-sync.sh. The PostToolUse+Bash hook only
+# fires for the shell CLI path (`$ claude plugin install ...`); the built-in
+# slash commands `/plugin marketplace add|remove` and `/plugin install|uninstall`
+# run inside Claude Code's UI pipeline and emit NO Bash tool call, so that hook
+# never runs and the dotfiles manifest silently drifts out of sync (#1082).
+#
+# This hook closes the gap by watching the ground-truth SSOT files themselves,
+# so it is entry-path agnostic — CLI, slash command, or any future UI path that
+# mutates them is covered:
+#
+#   SessionStart → stash a baseline snapshot (hashes + key sets) of
+#                  ~/.claude-shared/plugins/{known_marketplaces,installed_plugins}.json
+#   Stop         → re-snapshot; if the hash changed vs the baseline, re-run the
+#                  idempotent add/sync branch of plugin-sync.sh to pick up
+#                  additions, then diff the key sets to detect removals and
+#                  drive plugin-sync.sh's uninstall / marketplace-remove branch
+#                  for each vanished entry (symmetric add + remove, #1082 B-1).
+#
+# Slash-command hook event investigation (AC): Claude Code 2.1.x exposes only
+# PreToolUse / PostToolUse / UserPromptSubmit / Notification / Stop /
+# SubagentStop / PreCompact / SessionStart / SessionEnd — there is NO dedicated
+# hook event for built-in slash commands like `/plugin`, so Option A (a
+# SlashCommand matcher) is not available. This SSOT-diff approach (Option B) is
+# the entry-path-agnostic replacement and also covers the CLI path redundantly.
+#
+# Registered for BOTH SessionStart and Stop in claude/settings.json; branches
+# on hook_event_name. Always exits 0 — best-effort, never blocks the session.
+set -u
+
+# A hook always receives JSON on stdin. If stdin is a terminal the script was
+# launched by hand — bail before `cat` blocks forever.
+[ -t 0 ] && exit 0
+input=$(cat 2>/dev/null) || exit 0
+[ -n "$input" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+event=$(printf '%s' "$input" | jq -r '.hook_event_name // ""') || exit 0
+session_id=$(printf '%s' "$input" | jq -r '.session_id // ""') || exit 0
+# Without a session id there is nowhere stable to keep the per-session baseline.
+[ -n "$session_id" ] || exit 0
+
+SRC="$HOME/.claude-shared/plugins"
+MP_SRC="$SRC/known_marketplaces.json"
+PL_SRC="$SRC/installed_plugins.json"
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/claude"
+baseline="$state_dir/plugin-sync-baseline.$session_id.json"
+
+# Snapshot the SSOT as {mp_hash, pl_hash, mp_keys, pl_keys}. A missing file
+# yields an empty hash and an empty key list, so a later add/remove of that
+# file is still detected as a change.
+_snapshot() {
+	mp_hash=$(sha256sum "$MP_SRC" 2>/dev/null | awk '{print $1}')
+	pl_hash=$(sha256sum "$PL_SRC" 2>/dev/null | awk '{print $1}')
+	mp_keys=$(jq -c 'keys' "$MP_SRC" 2>/dev/null) || mp_keys="[]"
+	pl_keys=$(jq -c '(.plugins // {}) | keys' "$PL_SRC" 2>/dev/null) || pl_keys="[]"
+	jq -n --arg mp "$mp_hash" --arg pl "$pl_hash" \
+		--argjson mpk "${mp_keys:-[]}" --argjson plk "${pl_keys:-[]}" \
+		'{mp_hash: $mp, pl_hash: $pl, mp_keys: $mpk, pl_keys: $plk}'
+}
+
+# Feed a synthetic `claude plugin ...` payload to the CLI-path hook so its
+# add / uninstall / marketplace-remove branches do the actual manifest work —
+# one implementation, reused from both entry paths.
+_drive_sync() {
+	printf '{"tool_name":"Bash","tool_input":{"command":"claude plugin %s"}}' "$1" |
+		"$SYNC_HOOK" >&2 || true
+}
+
+if [ "$event" = "SessionStart" ]; then
+	mkdir -p "$state_dir" 2>/dev/null || exit 0
+	_snapshot >"$baseline" 2>/dev/null || true
+	# Prune stale per-session baselines (crash-left or long-abandoned) so the
+	# state dir doesn't grow without bound.
+	find "$state_dir" -maxdepth 1 -name 'plugin-sync-baseline.*.json' \
+		-mtime +7 -delete 2>/dev/null || true
+	exit 0
+fi
+
+# --- Stop (or any non-SessionStart event registered here) ---
+
+[ -f "$MP_SRC" ] || exit 0
+SYNC_HOOK="$HOME/dotfiles/claude/hooks/plugin-sync.sh"
+[ -x "$SYNC_HOOK" ] || exit 0
+
+now=$(_snapshot) || exit 0
+now_mp=$(printf '%s' "$now" | jq -r '.mp_hash')
+now_pl=$(printf '%s' "$now" | jq -r '.pl_hash')
+
+changed=1
+prev_mp_keys="[]"
+prev_pl_keys="[]"
+if [ -f "$baseline" ]; then
+	prev_mp=$(jq -r '.mp_hash // ""' "$baseline" 2>/dev/null)
+	prev_pl=$(jq -r '.pl_hash // ""' "$baseline" 2>/dev/null)
+	prev_mp_keys=$(jq -c '.mp_keys // []' "$baseline" 2>/dev/null) || prev_mp_keys="[]"
+	prev_pl_keys=$(jq -c '.pl_keys // []' "$baseline" 2>/dev/null) || prev_pl_keys="[]"
+	[ "$prev_mp" = "$now_mp" ] && [ "$prev_pl" = "$now_pl" ] && changed=0
+fi
+
+[ "$changed" -eq 1 ] || exit 0
+
+# 1) Additions / re-sync. plugin-sync.sh's add branch ignores the target and
+# rebuilds the manifest from the SSOT via idempotent union merge, so a dummy
+# target is fine and a no-op run creates no commit.
+_drive_sync "install __slash_command_sync__"
+
+# 2) Removals. Marketplaces / plugins present at the baseline but gone now must
+# be dropped from the manifest — the union merge above never removes anything.
+now_mp_keys=$(printf '%s' "$now" | jq -c '.mp_keys')
+now_pl_keys=$(printf '%s' "$now" | jq -c '.pl_keys')
+
+removed_mp=$(jq -n -r --argjson a "$prev_mp_keys" --argjson b "$now_mp_keys" '($a - $b)[]' 2>/dev/null)
+while IFS= read -r mp; do
+	[ -n "$mp" ] || continue
+	_drive_sync "marketplace remove $mp"
+done <<EOF
+$removed_mp
+EOF
+
+removed_pl=$(jq -n -r --argjson a "$prev_pl_keys" --argjson b "$now_pl_keys" '($a - $b)[]' 2>/dev/null)
+while IFS= read -r pl; do
+	[ -n "$pl" ] || continue
+	_drive_sync "uninstall $pl"
+done <<EOF
+$removed_pl
+EOF
+
+# 3) Refresh the baseline to the current SSOT (our sync mutates only the
+# dotfiles manifest, never the SSOT, so `now` is still accurate).
+mkdir -p "$state_dir" 2>/dev/null || exit 0
+printf '%s' "$now" >"$baseline" 2>/dev/null || true
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -9,6 +9,10 @@
           {
             "type": "command",
             "command": "${HOME}/dotfiles/claude/hooks/session-start-pc-context.sh"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh"
           }
         ]
       }
@@ -23,6 +27,10 @@
           {
             "type": "command",
             "command": "${HOME}/dotfiles/claude/hooks/skill_completion_guard.py"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh"
           }
         ]
       }

--- a/tests/bats/skills/plugin_sync_hook_registration.bats
+++ b/tests/bats/skills/plugin_sync_hook_registration.bats
@@ -31,3 +31,27 @@ SETTINGS="${_BATS_REAL_DOTFILES_ROOT}/claude/settings.json"
     ' "$SETTINGS"
     assert_success
 }
+
+@test "SessionStart includes plugin-sync-session.sh (#1082)" {
+    run jq -e '
+        .hooks.SessionStart[].hooks[]
+        | select(.command | endswith("claude/hooks/plugin-sync-session.sh"))
+    ' "$SETTINGS"
+    assert_success
+}
+
+@test "Stop includes plugin-sync-session.sh (#1082)" {
+    run jq -e '
+        .hooks.Stop[].hooks[]
+        | select(.command | endswith("claude/hooks/plugin-sync-session.sh"))
+    ' "$SETTINGS"
+    assert_success
+}
+
+@test "SessionStart still includes session-start-pc-context.sh" {
+    run jq -e '
+        .hooks.SessionStart[].hooks[]
+        | select(.command | endswith("claude/hooks/session-start-pc-context.sh"))
+    ' "$SETTINGS"
+    assert_success
+}

--- a/tests/bats/skills/plugin_sync_session_hook.bats
+++ b/tests/bats/skills/plugin_sync_session_hook.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# tests/bats/skills/plugin_sync_session_hook.bats
+# claude/hooks/plugin-sync-session.sh — SSOT-diff path that catches the
+# built-in `/plugin` slash commands the PostToolUse+Bash hook misses (#1082).
+#
+# The Stop branch shells out to $HOME/dotfiles/claude/hooks/plugin-sync.sh, so
+# each test copies the real CLI-path hook into the isolated $HOME first.
+
+load '../test_helper'
+
+HOOK="${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/plugin-sync-session.sh"
+SID="sess-1082"
+
+setup() {
+    setup_isolated_home
+    MAIN_ROOT="$TEST_TEMP_HOME/dotfiles"
+    mkdir -p "$MAIN_ROOT/claude/plugin" "$MAIN_ROOT/claude/hooks"
+    cp "${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/plugin-sync.sh" \
+        "$MAIN_ROOT/claude/hooks/plugin-sync.sh"
+    chmod +x "$MAIN_ROOT/claude/hooks/plugin-sync.sh"
+    git -C "$MAIN_ROOT" init -q
+    git -C "$MAIN_ROOT" config user.email "hook-test@example.com"
+    git -C "$MAIN_ROOT" config user.name "hook-test"
+
+    SRC="$TEST_TEMP_HOME/.claude-shared/plugins"
+    mkdir -p "$SRC"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# --- SSOT fixtures -----------------------------------------------------------
+
+_ssot_one() {
+    cat > "$SRC/known_marketplaces.json" <<'JSON'
+{"mp-a": {"source": {"source": "github", "repo": "org/a"}}}
+JSON
+    cat > "$SRC/installed_plugins.json" <<'JSON'
+{"plugins": {"plug-a@mp-a": [{"scope": "user"}]}}
+JSON
+}
+
+_ssot_two() {
+    cat > "$SRC/known_marketplaces.json" <<'JSON'
+{"mp-a": {"source": {"source": "github", "repo": "org/a"}},
+ "mp-b": {"source": {"source": "github", "repo": "org/b"}}}
+JSON
+    cat > "$SRC/installed_plugins.json" <<'JSON'
+{"plugins": {"plug-a@mp-a": [{"scope": "user"}], "plug-b@mp-b": [{"scope": "user"}]}}
+JSON
+}
+
+_session_start() {
+    payload="{\"hook_event_name\":\"SessionStart\",\"session_id\":\"$SID\",\"source\":\"startup\"}"
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+}
+
+_stop() {
+    payload="{\"hook_event_name\":\"Stop\",\"session_id\":\"$SID\",\"stop_hook_active\":false}"
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+}
+
+# --- (a) hash unchanged → no-op ---------------------------------------------
+
+@test "unchanged SSOT between SessionStart and Stop → no sync, no manifest" {
+    _ssot_one
+    _session_start
+    assert_success
+    _stop
+    assert_success
+    # add-sync never ran: the manifest file was never written.
+    [ ! -f "$MAIN_ROOT/claude/plugin/plugins.json" ]
+    # no commit either (repo has no commits at all)
+    run git -C "$MAIN_ROOT" rev-parse HEAD
+    assert_failure
+}
+
+# --- (b) hash changed → sync runs -------------------------------------------
+
+@test "SSOT changes after SessionStart → Stop syncs manifest + commits" {
+    _ssot_one
+    _session_start
+    assert_success
+    # A /plugin install happened during the session (SSOT grew a second entry).
+    _ssot_two
+    _stop
+    assert_success
+
+    run jq -e '.plugins | (any(. == "plug-a@mp-a") and any(. == "plug-b@mp-b"))' \
+        "$MAIN_ROOT/claude/plugin/plugins.json"
+    assert_success
+    run git -C "$MAIN_ROOT" log -1 --format=%s
+    assert_output "chore(claude-plugin): sync manifest"
+}
+
+# --- (c) no baseline (first session) → Stop still syncs ----------------------
+
+@test "no baseline yet → Stop treats it as changed and syncs" {
+    _ssot_two
+    # No SessionStart call → baseline file absent.
+    _stop
+    assert_success
+    run jq -e '.plugins | (any(. == "plug-a@mp-a") and any(. == "plug-b@mp-b"))' \
+        "$MAIN_ROOT/claude/plugin/plugins.json"
+    assert_success
+}
+
+# --- removal detected via key-set diff --------------------------------------
+
+@test "plugin + marketplace removed from SSOT → Stop drops them from manifest" {
+    _ssot_two
+    # Seed a manifest that already carries both entries (previously synced).
+    cat > "$MAIN_ROOT/claude/plugin/marketplaces.json" <<'JSON'
+{"mp-a": "org/a", "mp-b": "org/b"}
+JSON
+    cat > "$MAIN_ROOT/claude/plugin/plugins.json" <<'JSON'
+{"plugins": ["plug-a@mp-a", "plug-b@mp-b"]}
+JSON
+    git -C "$MAIN_ROOT" add claude/plugin
+    git -C "$MAIN_ROOT" commit -q -m "seed"
+
+    _session_start
+    assert_success
+    # /plugin uninstall plug-b + /plugin marketplace remove mp-b → SSOT shrinks.
+    _ssot_one
+    _stop
+    assert_success
+
+    run jq -e 'has("mp-b")' "$MAIN_ROOT/claude/plugin/marketplaces.json"
+    assert_failure
+    run jq -e '.plugins | any(. == "plug-b@mp-b")' "$MAIN_ROOT/claude/plugin/plugins.json"
+    assert_failure
+    # surviving entries stay
+    run jq -e 'has("mp-a")' "$MAIN_ROOT/claude/plugin/marketplaces.json"
+    assert_success
+    run jq -e '.plugins | any(. == "plug-a@mp-a")' "$MAIN_ROOT/claude/plugin/plugins.json"
+    assert_success
+}
+
+# --- guards ------------------------------------------------------------------
+
+@test "no session_id → no-op" {
+    _ssot_two
+    payload='{"hook_event_name":"Stop","stop_hook_active":false}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -f "$MAIN_ROOT/claude/plugin/plugins.json" ]
+}
+
+@test "terminal stdin → immediate exit, no work" {
+    _ssot_two
+    run bash -c "'$HOOK' < /dev/tty" 2>/dev/null || true
+    [ ! -f "$MAIN_ROOT/claude/plugin/plugins.json" ]
+}

--- a/tests/bats/skills/plugin_sync_session_hook.bats
+++ b/tests/bats/skills/plugin_sync_session_hook.bats
@@ -138,6 +138,30 @@ JSON
     assert_success
 }
 
+# --- plugin-only SSOT (no known_marketplaces.json) still detects removals -----
+
+@test "only installed_plugins.json present → plugin removal still propagates" {
+    # No known_marketplaces.json at all — the Stop guard must not early-exit.
+    cat > "$SRC/installed_plugins.json" <<'JSON'
+{"plugins": {"plug-a@mp-a": [{"scope": "user"}]}}
+JSON
+    cat > "$MAIN_ROOT/claude/plugin/plugins.json" <<'JSON'
+{"plugins": ["plug-a@mp-a"]}
+JSON
+    git -C "$MAIN_ROOT" add claude/plugin
+    git -C "$MAIN_ROOT" commit -q -m "seed"
+
+    _session_start
+    assert_success
+    # /plugin uninstall plug-a → installed_plugins.json empties out.
+    echo '{"plugins": {}}' > "$SRC/installed_plugins.json"
+    _stop
+    assert_success
+
+    run jq -e '.plugins | any(. == "plug-a@mp-a")' "$MAIN_ROOT/claude/plugin/plugins.json"
+    assert_failure
+}
+
 # --- guards ------------------------------------------------------------------
 
 @test "no session_id → no-op" {


### PR DESCRIPTION
## 요약

`/plugin` 내장 slash command 진입 경로에서 dotfiles 플러그인 매니페스트가 자동 동기화되지 않던 갭(#1082)을 SSOT-diff hook 으로 보완한다.

기존 `claude/hooks/plugin-sync.sh` 는 PostToolUse+Bash matcher 라 shell CLI `claude plugin ...` 만 감지한다. 실사용에서 가장 흔한 `/plugin marketplace add|remove` · `/plugin install|uninstall` 는 Claude Code UI 파이프라인을 통과해 **Bash tool call 을 만들지 않으므로 hook 자체가 실행되지 않고**, 매니페스트가 조용히 drift 했다.

## 변경 내용

- **`claude/hooks/plugin-sync-session.sh` (신규, SessionStart+Stop dual-event)**
  - SessionStart: SSOT (`~/.claude-shared/plugins/{known_marketplaces,installed_plugins}.json`) 의 hash + key-set baseline 을 세션별로 stash (`$XDG_STATE_HOME/claude/plugin-sync-baseline.<sid>.json`, 7일 초과분 자동 청소)
  - Stop: 재스냅샷 → hash 변화 시 `plugin-sync.sh` 의 **add 분기를 재실행**(멱등 union merge)하고, baseline↔현재 key-set diff 로 사라진 marketplace/plugin 을 감지해 **uninstall / marketplace-remove 분기**를 구동 (add + remove 대칭)
  - 진입 경로 무관: CLI · slash command · 미래 UI 경로 모두 커버. 실제 매니페스트 조작은 전부 기존 `plugin-sync.sh` 를 재사용(단일 구현).
- **`claude/settings.json`**: 신규 hook 을 SessionStart + Stop 양쪽에 등록
- **`claude/AGENTS.md`**: "Plugin Manifest" 섹션에 두 진입 경로(CLI + slash) 커버 명시
- **bats**:
  - `plugin_sync_session_hook.bats` (신규): (a) 무변화 no-op, (b) 변화 시 sync+commit, (c) 무-baseline 첫 세션, 제거 diff 전파, session_id/터미널 가드
  - `plugin_sync_hook_registration.bats`: SessionStart/Stop 등록 검증 추가

## slash-command hook event 사전 조사 (AC)

Claude Code 2.1.x 의 hook event 는 `PreToolUse / PostToolUse / UserPromptSubmit / Notification / Stop / SubagentStop / PreCompact / SessionStart / SessionEnd` 뿐 — `/plugin` 같은 내장 slash command 전용 event 는 없다. 따라서 Option A(SlashCommand matcher)는 불가하고, 진입 경로 무관한 SSOT-diff(Option B/B-1)를 채택했다. CLI 경로도 이 hook 이 중복 커버한다.

## 검증

- 대상 bats 30/30 green (`plugin_sync_session_hook` + 기존 `plugin_sync_hook` / `_delete` / `_registration` regression 무결)
- 신규 hook `shellcheck -x` + `shfmt -d` clean, POSIX (`[ ]` only, `[[ ]]` 없음)

## Acceptance Criteria

- [x] `/plugin marketplace add` 후 종료 시 매니페스트 자동 갱신 + 로컬 커밋 (SSOT-diff)
- [x] `/plugin install` 반영
- [x] `/plugin uninstall` 시 매니페스트에서 제거 (key-set diff → uninstall 분기)
- [x] 기존 CLI 경로 동작 불변 (regression 없음, bats 통과)
- [x] 신규 hook shellcheck + shfmt -d clean, POSIX
- [x] bats: 무변화 no-op / 변화 sync / 무-baseline 첫 세션
- [x] `claude/AGENTS.md` 두 진입 경로 명시
- [x] slash-command hook event 사전 조사 결과 기재 (본 PR 본문 + hook 헤더 주석)

Closes #1082
