### PR TITLE
feat(structure-check): marketplace plugins[].source 정합성 검증 (M7-M9 + R6-R8)

### DIFF
--- a/claude/skills/claude-plugin-create/SKILL.md
+++ b/claude/skills/claude-plugin-create/SKILL.md
@@ -87,9 +87,9 @@ add origin git@<host>:<owner>/<plugin-name>.git`. On GHES `gh` failure, point to
 
 ## Step 9: Verify & Report
 
-Run `claude-plugin:structure-check <dest>/<plugin-name>`, confirm M1-M6 PASS,
+Run `claude-plugin:structure-check <dest>/<plugin-name>`, confirm M1-M9 PASS,
 emit the `[OK]` report per `references/help.md` → "Completion report" (repo
-URL, skills copied, M1-M6 verdict) plus the next-action hint.
+URL, skills copied, M1-M9 verdict) plus the next-action hint.
 
 ## Constraints
 

--- a/claude/skills/claude-plugin-create/SKILL.md
+++ b/claude/skills/claude-plugin-create/SKILL.md
@@ -87,9 +87,9 @@ add origin git@<host>:<owner>/<plugin-name>.git`. On GHES `gh` failure, point to
 
 ## Step 9: Verify & Report
 
-Run `claude-plugin:structure-check <dest>/<plugin-name>`, confirm M1-M9 PASS,
+Run `claude-plugin:structure-check <dest>/<plugin-name>`, confirm M1-M10 PASS,
 emit the `[OK]` report per `references/help.md` → "Completion report" (repo
-URL, skills copied, M1-M9 verdict) plus the next-action hint.
+URL, skills copied, M1-M10 verdict) plus the next-action hint.
 
 ## Constraints
 

--- a/claude/skills/claude-plugin-create/references/help.md
+++ b/claude/skills/claude-plugin-create/references/help.md
@@ -46,13 +46,13 @@ Behavior (mono golden layout):
   6. git init + checkout -b main.
   7. gh repo create (after gh auth status + user confirmation).
   8. git add + commit "feat: init <plugin-name>" + push (after confirmation).
-  9. claude-plugin:structure-check → confirm M1-M9 PASS.
+  9. claude-plugin:structure-check → confirm M1-M10 PASS.
 
 Completion report (Step 9):
   [OK] claude-plugin:create
     Repo  : https://<host>/<owner>/<plugin-name>
     Skills: N copied
-    Check : M1-M9 PASS
+    Check : M1-M10 PASS
     Next  : /claude-plugin:structure-check <dest>/<plugin-name>  (re-verify)
             docs/skill-guides/ 시각 가이드 추가 → /devx:visualize
 

--- a/claude/skills/claude-plugin-create/references/help.md
+++ b/claude/skills/claude-plugin-create/references/help.md
@@ -46,13 +46,13 @@ Behavior (mono golden layout):
   6. git init + checkout -b main.
   7. gh repo create (after gh auth status + user confirmation).
   8. git add + commit "feat: init <plugin-name>" + push (after confirmation).
-  9. claude-plugin:structure-check → confirm M1-M6 PASS.
+  9. claude-plugin:structure-check → confirm M1-M9 PASS.
 
 Completion report (Step 9):
   [OK] claude-plugin:create
     Repo  : https://<host>/<owner>/<plugin-name>
     Skills: N copied
-    Check : M1-M6 PASS
+    Check : M1-M9 PASS
     Next  : /claude-plugin:structure-check <dest>/<plugin-name>  (re-verify)
             docs/skill-guides/ 시각 가이드 추가 → /devx:visualize
 

--- a/claude/skills/claude-plugin-structure-check/SKILL.md
+++ b/claude/skills/claude-plugin-structure-check/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   Supports both `mono` (`plugins/<p>/skills/`) and `single`
   (repo-root `skills/`) layouts — auto-detected, or forced with
   `--single` / `--mono`. Read-only — never edits. Discovers plugins/skills
-  dynamically by directory scan, then evaluates mandatory items M1-M6 (FAIL)
-  and recommended items R1-R5 (WARN). Use when the user says "check my
+  dynamically by directory scan, then evaluates mandatory items M1-M9 (FAIL,
+  incl. M7-M9 marketplace `plugins[].source` install-integrity) and recommended
+  items R1-R8 (WARN). Use when the user says "check my
   claude-plugin repo structure", "is this marketplace repo standard?",
   "audit plugin layout", "/claude-plugin:structure-check". Sister skills:
   `claude-plugin:structure-refactor` (fixes what this finds),
@@ -52,7 +53,7 @@ For detailed evaluation rules and mode/type classification logic: see [reference
 Record the detected mode, plugin-root list, and skill list for the report
 header and the per-skill recommended checks (R1/R2/R5).
 
-## Step 3: Evaluate M1-M6 and R1-R5
+## Step 3: Evaluate M1-M9 and R1-R8
 
 Apply PASS/WARN/FAIL/N/A to each item per the scoring rules in
 [references/evaluation-rules.md](references/evaluation-rules.md).
@@ -61,13 +62,15 @@ Apply PASS/WARN/FAIL/N/A to each item per the scoring rules in
 
 Read `references/report-template.md` for the exact format. The report has a
 header line (path + detected mode + discovered plugins/skills), a `[필수]`
-block (M1-M6) and a `[권장]` block (R1-R5), then the summary verdict:
+block (M1-M9) and a `[권장]` block (R1-R8), then the summary verdict:
 
 - any FAIL → **FAIL**
 - no FAIL but ≥1 WARN → **WARN**
 - all PASS/N/A → **PASS**
 
-Emit the next-action hint **only when** there is ≥1 FAIL or WARN.
+Emit the next-action hint **only when** there is ≥1 FAIL or WARN. Always append
+the "structure-check PASS ≠ install/runtime 성공" disclaimer (report-template.md
+→ "Install/runtime disclaimer", #1084).
 
 ## Constraints
 

--- a/claude/skills/claude-plugin-structure-check/SKILL.md
+++ b/claude/skills/claude-plugin-structure-check/SKILL.md
@@ -6,9 +6,10 @@ description: >-
   Supports both `mono` (`plugins/<p>/skills/`) and `single`
   (repo-root `skills/`) layouts — auto-detected, or forced with
   `--single` / `--mono`. Read-only — never edits. Discovers plugins/skills
-  dynamically by directory scan, then evaluates mandatory items M1-M9 (FAIL,
-  incl. M7-M9 marketplace `plugins[].source` install-integrity) and recommended
-  items R1-R8 (WARN). Use when the user says "check my
+  dynamically by directory scan, then evaluates mandatory items M1-M10 (FAIL,
+  incl. M7-M9 marketplace `plugins[].source` install-integrity and M10
+  plugin.json known-field schema) and recommended items R1-R8 (WARN). Use when
+  the user says "check my
   claude-plugin repo structure", "is this marketplace repo standard?",
   "audit plugin layout", "/claude-plugin:structure-check". Sister skills:
   `claude-plugin:structure-refactor` (fixes what this finds),
@@ -53,7 +54,7 @@ For detailed evaluation rules and mode/type classification logic: see [reference
 Record the detected mode, plugin-root list, and skill list for the report
 header and the per-skill recommended checks (R1/R2/R5).
 
-## Step 3: Evaluate M1-M9 and R1-R8
+## Step 3: Evaluate M1-M10 and R1-R8
 
 Apply PASS/WARN/FAIL/N/A to each item per the scoring rules in
 [references/evaluation-rules.md](references/evaluation-rules.md).
@@ -62,7 +63,7 @@ Apply PASS/WARN/FAIL/N/A to each item per the scoring rules in
 
 Read `references/report-template.md` for the exact format. The report has a
 header line (path + detected mode + discovered plugins/skills), a `[필수]`
-block (M1-M9) and a `[권장]` block (R1-R8), then the summary verdict:
+block (M1-M10) and a `[권장]` block (R1-R8), then the summary verdict:
 
 - any FAIL → **FAIL**
 - no FAIL but ≥1 WARN → **WARN**

--- a/claude/skills/claude-plugin-structure-check/references/evaluation-rules.md
+++ b/claude/skills/claude-plugin-structure-check/references/evaluation-rules.md
@@ -33,14 +33,14 @@ header and the per-skill recommended checks (R1/R2/R5).
 For each item in `references/structure-spec.md`, assign exactly one of:
 
 - **PASS** — present and valid.
-- **WARN** — recommended item missing/violated (R1-R5 only).
-- **FAIL** — mandatory item missing/invalid (M1-M6 only).
+- **WARN** — recommended item missing/violated (R1-R8 only).
+- **FAIL** — mandatory item missing/invalid (M1-M9 only).
 - **N/A** — the subject does not exist (e.g. a plugin with 0 skills → its
   R1/R2 are N/A, not FAIL).
 
 ## Per-Item Evaluation Details
 
-### M1-M6 (Mandatory — FAIL if violated)
+### M1-M9 (Mandatory — FAIL if violated)
 
 M2/M3/M4 check **paths** are mode-dependent (see the spec's per-mode M-grid);
 IDs, counts, and validation logic are identical across modes. M5/M6 and
@@ -53,13 +53,41 @@ parse error is FAIL, not WARN.
 **Frontmatter validity (M4):** the SKILL.md must have both `name:` and
 `description:` keys.
 
-### R1-R5 (Recommended — WARN if violated)
+**marketplace source integrity (M7-M9):** parse `.plugins[]` with `jq`. All
+three are **N/A** when M1 fails (unreadable) or 0 plugins are listed — M1/M2
+own those FAILs.
+
+- **M7** — each element must resolve to a source: a bare string is the source;
+  an object must carry its own `source` key. Any object lacking `source` → FAIL
+  (the claude-plugin-jira#61 install-fail shape — the top-level `source` is
+  **not** inherited at install time).
+- **M8** — validate each resolved source's shape: a local path (`"."`, `"./"`,
+  `"plugins/*"`, `"./plugins/*"`) or a git-URL object
+  (`{ "source":"url", "url":"<non-empty>" }`). Any other shape → FAIL. Skip
+  elements with no resolvable source (M7 owns them) — never a double FAIL.
+- **M9** — mono only: for each `./plugins/<name>` source, `plugins/<name>/`
+  must exist on disk (declared-but-absent → FAIL). Remote url-type sources are
+  skipped; `single` mode and all-remote mono repos → N/A. This never re-flags a
+  valid remote setup (the #63 misdiagnosis guard).
+
+### R1-R8 (Recommended — WARN if violated)
 
 **R3/R4/R5** use the heuristics defined in `references/structure-spec.md`.
 
 **R5:** for each discovered skill `<s>`, grep `README.md` for both a
 `skill-guides/<s>.html` and a `skill-output/<s>-usage.{html,md}` path string
 (relative or Pages-absolute) — missing either → WARN; no skills → N/A.
+
+**R6:** `marketplace.json` has a top-level `$schema` key → else WARN; N/A when
+unreadable.
+
+**R7:** `marketplace.json` has a non-empty top-level `description` AND every
+**object** plugin carries a non-empty `homepage` → else WARN. String-form
+plugins are exempt from the homepage check; N/A when unreadable.
+
+**R8:** if `README.md` contains a `/plugin marketplace add <URL>` line, PASS
+when the URL points at the raw `marketplace.json` (or any non-`.git` URL), WARN
+when it is a `.git` clone URL. No such line, or no README → N/A.
 
 ## Summary Verdict Logic
 

--- a/claude/skills/claude-plugin-structure-check/references/evaluation-rules.md
+++ b/claude/skills/claude-plugin-structure-check/references/evaluation-rules.md
@@ -34,13 +34,13 @@ For each item in `references/structure-spec.md`, assign exactly one of:
 
 - **PASS** — present and valid.
 - **WARN** — recommended item missing/violated (R1-R8 only).
-- **FAIL** — mandatory item missing/invalid (M1-M9 only).
+- **FAIL** — mandatory item missing/invalid (M1-M10 only).
 - **N/A** — the subject does not exist (e.g. a plugin with 0 skills → its
   R1/R2 are N/A, not FAIL).
 
 ## Per-Item Evaluation Details
 
-### M1-M9 (Mandatory — FAIL if violated)
+### M1-M10 (Mandatory — FAIL if violated)
 
 M2/M3/M4 check **paths** are mode-dependent (see the spec's per-mode M-grid);
 IDs, counts, and validation logic are identical across modes. M5/M6 and
@@ -69,6 +69,15 @@ own those FAILs.
   must exist on disk (declared-but-absent → FAIL). Remote url-type sources are
   skipped; `single` mode and all-remote mono repos → N/A. This never re-flags a
   valid remote setup (the #63 misdiagnosis guard).
+
+**plugin.json known-field whitelist (M10):** for each plugin root's
+`plugin.json`, compare its top-level `keys` against the known-field set
+(`jq --argjson k '<set>' '[keys[]|select(. as $x|$k|index($x)|not)]|length'`).
+Any key outside the set → FAIL (the claude-plugin-jira#65 `skills`-array case:
+installs but the manifest fails validation at load). Known fields (2.1.x):
+`name`, `version`, `description`, `author`, `homepage`, `repository`,
+`license`, `keywords`. Missing/invalid manifest → M3 owns it (skipped); no
+valid manifest → N/A. SSOT: `_CPS_PLUGIN_JSON_KNOWN_FIELDS` in the bats fixture.
 
 ### R1-R8 (Recommended — WARN if violated)
 

--- a/claude/skills/claude-plugin-structure-check/references/help.md
+++ b/claude/skills/claude-plugin-structure-check/references/help.md
@@ -25,28 +25,38 @@ Layout modes & auto-detection:
 
 What it checks (read-only — never edits; paths shown for mono | single):
 
-  Mandatory (M1-M6 — missing → FAIL)
+  Mandatory (M1-M9 — missing → FAIL)
     M1  .claude-plugin/marketplace.json        exists + valid JSON
     M2  >=1 plugin root                         plugins/<p>/ | root plugin.json
     M3  plugin.json valid                       plugins/<p>/.claude-plugin/ | root .claude-plugin/
     M4  SKILL.md valid                          plugins/<p>/skills/<s>/ | skills/<s>/
     M5  docs/skill-guides/ + docs/skill-output/ both directories exist
     M6  README.md                              exists
+    M7  plugins[].source present                each element carries a source (#61)
+    M8  plugins[].source shape valid            local path | { source:url, url:… }
+    M9  mono plugin dirs exist                  ./plugins/<name>/ present (mono only)
 
-  Recommended (R1-R5 — missing → WARN)
+  Recommended (R1-R8 — missing → WARN)
     R1  docs/skill-guides/<skill>.html         per-skill guide
     R2  docs/skill-output/<skill>-usage.{html,md}  per-skill usage sample
     R3  README is "Simple"                     links into docs/, not too long
     R4  naming consistency                     name: colon ↔ directory hyphen
     R5  per-skill README guide+usage links     README links both for each skill
+    R6  marketplace $schema declared           top-level "$schema" for LSP/IDE
+    R7  listing metadata                       description + object plugin homepage
+    R8  README add-URL hint                    prefer raw marketplace.json over .git
 
-M5/M6 and R1-R5 are mode-independent — only the M2/M3/M4 check paths and
-skill discovery differ between modes. Each item reports PASS / WARN / FAIL /
+M5/M6, M7/M8 and R1-R8 are mode-independent — only the M2/M3/M4/M9 check paths
+and skill discovery differ between modes. Each item reports PASS / WARN / FAIL /
 N/A. N/A means the subject does not exist (e.g. a plugin with 0 skills →
-R1/R2/R5 are N/A).
+R1/R2/R5 are N/A; M9 → N/A in single mode).
 
 Verdict:
   any FAIL → FAIL ; no FAIL but >=1 WARN → WARN ; all PASS/N/A → PASS
+
+Note: this audit checks STRUCTURE only. structure-check PASS != install /
+runtime success — if /plugin install fails, inspect marketplace source (#61)
+or SKILL.md frontmatter separately.
 
 Examples:
   /claude-plugin:structure-check

--- a/claude/skills/claude-plugin-structure-check/references/help.md
+++ b/claude/skills/claude-plugin-structure-check/references/help.md
@@ -25,7 +25,7 @@ Layout modes & auto-detection:
 
 What it checks (read-only — never edits; paths shown for mono | single):
 
-  Mandatory (M1-M9 — missing → FAIL)
+  Mandatory (M1-M10 — missing → FAIL)
     M1  .claude-plugin/marketplace.json        exists + valid JSON
     M2  >=1 plugin root                         plugins/<p>/ | root plugin.json
     M3  plugin.json valid                       plugins/<p>/.claude-plugin/ | root .claude-plugin/
@@ -35,6 +35,7 @@ What it checks (read-only — never edits; paths shown for mono | single):
     M7  plugins[].source present                each element carries a source (#61)
     M8  plugins[].source shape valid            local path | { source:url, url:… }
     M9  mono plugin dirs exist                  ./plugins/<name>/ present (mono only)
+    M10 plugin.json known fields only            no unsupported key e.g. skills (#65)
 
   Recommended (R1-R8 — missing → WARN)
     R1  docs/skill-guides/<skill>.html         per-skill guide
@@ -46,10 +47,14 @@ What it checks (read-only — never edits; paths shown for mono | single):
     R7  listing metadata                       description + object plugin homepage
     R8  README add-URL hint                    prefer raw marketplace.json over .git
 
-M5/M6, M7/M8 and R1-R8 are mode-independent — only the M2/M3/M4/M9 check paths
-and skill discovery differ between modes. Each item reports PASS / WARN / FAIL /
-N/A. N/A means the subject does not exist (e.g. a plugin with 0 skills →
-R1/R2/R5 are N/A; M9 → N/A in single mode).
+M5/M6, M7/M8 and R1-R8 are mode-independent — only the M2/M3/M4/M9/M10 check
+paths and skill discovery differ between modes. Each item reports PASS / WARN /
+FAIL / N/A. N/A means the subject does not exist (e.g. a plugin with 0 skills →
+R1/R2/R5 are N/A; M9 → N/A in single mode; M10 → N/A when no valid plugin.json).
+
+Note: structure-check PASS != install/runtime success — install can still
+succeed while a schema-violating plugin.json (M10, e.g. a skills field) blocks
+the plugin from loading; a marketplace source problem (M7-M9) can block install.
 
 Verdict:
   any FAIL → FAIL ; no FAIL but >=1 WARN → WARN ; all PASS/N/A → PASS

--- a/claude/skills/claude-plugin-structure-check/references/report-template.md
+++ b/claude/skills/claude-plugin-structure-check/references/report-template.md
@@ -15,6 +15,9 @@ claude-plugin structure check — <repo-path>
  FAIL  M4 plugins/visuals/skills/visualize/SKILL.md 없음
  PASS  M5 docs/skill-guides/, docs/skill-output/
  PASS  M6 README.md
+ FAIL  M7 plugins[].source 누락 (visuals — 상위 source 상속 불가, install 실패)
+ PASS  M8 source shape 유효
+ PASS  M9 plugins/visuals/ 실재
 
 [권장]
  WARN  R1 docs/skill-guides/visualize.html 없음
@@ -22,9 +25,16 @@ claude-plugin structure check — <repo-path>
  PASS  R3 README.md 가 docs/ 로 링크 (Simple)
  PASS  R4 명명 일관성 (claude-plugin:structure-check ↔ 디렉터리)
  WARN  R5 README 에 excalidraw-diagram usage 링크 누락
+ WARN  R6 marketplace.json 에 $schema 없음
+ PASS  R7 description + plugins[].homepage
+ N/A   R8 (README 에 marketplace add 예시 없음)
 
-요약: FAIL (필수 2, 권장 2, N/A 1)
+요약: FAIL (필수 3, 권장 3, N/A 2)
 → Fix: /claude-plugin:structure-refactor <repo-path>  (먼저 dry-run, 이후 --apply)
+
+※ 이 감사는 "구조" 만 검사한다. /plugin install 이 실패하거나 세션에
+   스킬이 안 뜨는 경우, marketplace source 필드 (#61 스타일) 나 SKILL.md
+   frontmatter 를 별도 확인하라. structure-check PASS ≠ install/runtime 성공.
 ```
 
 ### Example — single (repo is one plugin)
@@ -40,6 +50,9 @@ claude-plugin structure check — <repo-path>
  PASS  M4 skills/<s>/SKILL.md (4개 모두 name/description 보유)
  PASS  M5 docs/skill-guides/, docs/skill-output/
  PASS  M6 README.md
+ PASS  M7 plugins[].source 존재 (source "./")
+ PASS  M8 source shape 유효
+ N/A   M9 (single — plugins/ 레이아웃 아님)
 
 [권장]
  PASS  R1 docs/skill-guides/<s>.html (4개 모두 존재)
@@ -47,6 +60,9 @@ claude-plugin structure check — <repo-path>
  PASS  R3 README.md 가 docs/ 로 링크 (Simple)
  PASS  R4 명명 일관성
  PASS  R5 README 가 스킬별 guide+usage 링크 보유
+ PASS  R6 $schema 선언
+ PASS  R7 description + homepage
+ N/A   R8 (README 에 marketplace add 예시 없음)
 
 요약: PASS — 표준 구조 준수
 ```
@@ -59,7 +75,7 @@ When the mode was inferred by the ambiguous fallback, append `, 추정` —
 - One line per item: `<RESULT>  <ID> <subject> <note>`.
 - `<RESULT>` is one of `PASS` / `WARN` / `FAIL` / `N/A` (uppercase),
   left-padded so the IDs align.
-- `[필수]` block lists M1-M6 in order; `[권장]` block lists R1-R5 in order.
+- `[필수]` block lists M1-M9 in order; `[권장]` block lists R1-R8 in order.
 - R5 is per-skill: when more than one skill misses a link, emit one R5 line
   naming the first offender (or summarize `<n>개 스킬`); a clean repo → PASS,
   no skills → N/A.
@@ -87,3 +103,15 @@ Emit **only** when the verdict is FAIL or WARN:
 When the verdict is PASS, end with a single line and no hint:
 
 `요약: PASS — 표준 구조 준수`
+
+## Install/runtime disclaimer (always emit, #1084)
+
+Append this note to **every** report (PASS included) — a structure audit
+cannot prove `/plugin install` or session-load success, and a prior PASS
+already misled a real diagnosis (claude-plugin-jira#63):
+
+```
+※ 이 감사는 "구조" 만 검사한다. /plugin install 이 실패하거나 세션에
+   스킬이 안 뜨는 경우, marketplace source 필드 (#61 스타일) 나 SKILL.md
+   frontmatter 를 별도 확인하라. structure-check PASS ≠ install/runtime 성공.
+```

--- a/claude/skills/claude-plugin-structure-check/references/report-template.md
+++ b/claude/skills/claude-plugin-structure-check/references/report-template.md
@@ -18,6 +18,7 @@ claude-plugin structure check — <repo-path>
  FAIL  M7 plugins[].source 누락 (visuals — 상위 source 상속 불가, install 실패)
  PASS  M8 source shape 유효
  PASS  M9 plugins/visuals/ 실재
+ N/A   M10 (plugin.json 없음 — M3 소관)
 
 [권장]
  WARN  R1 docs/skill-guides/visualize.html 없음
@@ -29,12 +30,15 @@ claude-plugin structure check — <repo-path>
  PASS  R7 description + plugins[].homepage
  N/A   R8 (README 에 marketplace add 예시 없음)
 
-요약: FAIL (필수 3, 권장 3, N/A 2)
+요약: FAIL (필수 3, 권장 3, N/A 3)
 → Fix: /claude-plugin:structure-refactor <repo-path>  (먼저 dry-run, 이후 --apply)
 
 ※ 이 감사는 "구조" 만 검사한다. /plugin install 이 실패하거나 세션에
    스킬이 안 뜨는 경우, marketplace source 필드 (#61 스타일) 나 SKILL.md
    frontmatter 를 별도 확인하라. structure-check PASS ≠ install/runtime 성공.
+※ plugin.json 은 최상위 필드도 스키마 검증 대상이다. skills 처럼 런타임이
+   자동 스캔하는 폴더명과 이름이 같은 커스텀 필드를 넣으면 validation error
+   로 플러그인 자체가 로드 실패한다 (M10 — #65 스타일).
 ```
 
 ### Example — single (repo is one plugin)
@@ -53,6 +57,7 @@ claude-plugin structure check — <repo-path>
  PASS  M7 plugins[].source 존재 (source "./")
  PASS  M8 source shape 유효
  N/A   M9 (single — plugins/ 레이아웃 아님)
+ PASS  M10 plugin.json 필드 스키마 준수 (미지원 필드 없음)
 
 [권장]
  PASS  R1 docs/skill-guides/<s>.html (4개 모두 존재)
@@ -75,7 +80,7 @@ When the mode was inferred by the ambiguous fallback, append `, 추정` —
 - One line per item: `<RESULT>  <ID> <subject> <note>`.
 - `<RESULT>` is one of `PASS` / `WARN` / `FAIL` / `N/A` (uppercase),
   left-padded so the IDs align.
-- `[필수]` block lists M1-M9 in order; `[권장]` block lists R1-R8 in order.
+- `[필수]` block lists M1-M10 in order; `[권장]` block lists R1-R8 in order.
 - R5 is per-skill: when more than one skill misses a link, emit one R5 line
   naming the first offender (or summarize `<n>개 스킬`); a clean repo → PASS,
   no skills → N/A.
@@ -114,4 +119,7 @@ already misled a real diagnosis (claude-plugin-jira#63):
 ※ 이 감사는 "구조" 만 검사한다. /plugin install 이 실패하거나 세션에
    스킬이 안 뜨는 경우, marketplace source 필드 (#61 스타일) 나 SKILL.md
    frontmatter 를 별도 확인하라. structure-check PASS ≠ install/runtime 성공.
+※ plugin.json 은 최상위 필드도 스키마 검증 대상이다. skills 처럼 런타임이
+   자동 스캔하는 폴더명과 이름이 같은 커스텀 필드를 넣으면 validation error
+   로 플러그인 자체가 로드 실패한다 (M10 — #65 스타일).
 ```

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -81,10 +81,47 @@ checked **path** changes (M5/M6 are mode-independent).
 | M4 | each SKILL.md valid | `plugins/<p>/skills/<s>/SKILL.md` | `skills/<s>/SKILL.md` |
 | M5 | docs dirs exist | `docs/skill-guides/` AND `docs/skill-output/` | **same** |
 | M6 | README.md | `README.md` | **same** |
+| M7 | each `plugins[]` element resolves to a source | `.claude-plugin/marketplace.json` | **same** |
+| M8 | each source has a valid shape | `.claude-plugin/marketplace.json` | **same** |
+| M9 | declared mono plugin dirs exist on disk | `plugins/<name>/` per source | N/A (single) |
 
 FAIL conditions: M1/M3 → missing or invalid JSON; M2 → 0 plugin roots;
 M4 → missing or frontmatter lacks `name`/`description`; M5 → either dir
-missing; M6 → missing.
+missing; M6 → missing; M7-M9 → see "marketplace source integrity" below.
+
+## marketplace `plugins[].source` integrity (M7-M9, #1084)
+
+Claude Code (observed on 2.1.198) does **not** inherit a marketplace top-level
+`source` into a plugin at install time — each `plugins[]` element must carry
+its own source, or `/plugin install` fails with *"This plugin uses a source
+type your Claude Code version does not support"* (claude-plugin-jira#61). A
+structure audit that stopped at M6 passed such a repo, which then misled the
+diagnosis (claude-plugin-jira#63). M7-M9 close that gap. They evaluate only
+when M1 passes (marketplace parses) and ≥1 plugin is listed; otherwise **N/A**
+(M1/M2 own those FAILs — never double-count).
+
+**M7 — each `plugins[]` element resolves to a source.**
+- A bare **string** element (`"./plugins/foo"`, `"./"`) **is** the source
+  (shorthand) → satisfied.
+- An **object** element MUST carry its own `source` key → missing it is the
+  #61 shape → **FAIL**.
+
+**M8 — each resolved source has a valid shape** (mono/single common). Valid:
+- local path string: `"."` / `"./"` / `"plugins/<name>"` / `"./plugins/<name>"`;
+- git-URL object: `{ "source": "url", "url": "<non-empty ….git>" }`.
+
+  Any other shape (e.g. an object whose `source` is a raw `https://…` URL with
+  no `url` field) → **FAIL**. Elements with no resolvable source are M7's
+  concern and are skipped here (never a double FAIL). The mode-shape combination
+  itself is **not** a FAIL — a mono repo may legitimately use remote URL sources
+  — so M8 never re-flags a valid remote setup (#63 misdiagnosis guard).
+
+**M9 — mono only: each declared local plugin dir exists.** For every source of
+the form `./plugins/<name>` (or `plugins/<name>`), `plugins/<name>/` must exist
+on disk. A declared-but-absent directory (typo/misconfig) → **FAIL**. Remote
+(url-type) sources have nothing local to verify and are skipped; a mono repo
+whose sources are all remote → **N/A**. In `single` mode M9 is **N/A** (no
+`plugins/` layout).
 
 ## Recommended items (WARN when missing)
 
@@ -95,6 +132,9 @@ missing; M6 → missing.
 | R3 | README is "Simple" | heuristic violated (below) |
 | R4 | naming consistency | SKILL.md `name:` colon-namespace ↔ directory hyphen mismatch |
 | R5 | per-skill README guide+usage links | README missing the guide OR the usage link for a skill |
+| R6 | marketplace `$schema` declared | `marketplace.json` lacks a top-level `$schema` |
+| R7 | listing metadata | no top-level `description`, OR an object plugin lacks `homepage` |
+| R8 | README add-URL hint | a `/plugin marketplace add` example uses a `.git` clone URL |
 
 **R3 README "Simple" heuristic** — PASS only if all hold; any miss → WARN:
 - at least one link into a `docs/` sub-document (evidence of progressive split);
@@ -119,6 +159,24 @@ README — completing the "standard" the developer relies on (see
 `claude-plugin-visuals/README.md`). Reuses the Step 2 dynamic skill list,
 so no extra scan. R3's "Simple" heuristic only requires *one* `docs/` link
 anywhere, so it cannot catch a per-skill link gap — R5 does.
+
+**R6 `$schema` rule** — `marketplace.json` should declare a top-level
+`"$schema"` (e.g. `https://anthropic.com/claude-code/marketplace.schema.json`)
+so editors/LSP can validate and autocomplete it. Missing → **WARN** only (no
+runtime impact). **N/A** when the marketplace is unreadable (M1 owns that).
+
+**R7 listing-metadata rule** — a top-level `description` and, for each
+**object** plugin, a `homepage` improve marketplace-UI listing quality.
+Missing description, or any object plugin lacking a non-empty `homepage`,
+→ **WARN**. String-form plugin elements have nowhere to carry `homepage`, so
+they are exempt. **N/A** when the marketplace is unreadable.
+
+**R8 add-URL hint** — when `README.md` contains a `/plugin marketplace add
+<URL>` example, prefer the raw `.claude-plugin/marketplace.json` URL (no local
+clone needed — the #61 success pattern) over a `.git` clone URL. A `.git`
+example → **WARN**; a raw-`marketplace.json` (or other) URL → **PASS**; no
+add example, or no README → **N/A** (both forms are valid — this is a nudge,
+not a hard rule).
 
 ## N/A rule
 

--- a/claude/skills/claude-plugin-structure-check/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-check/references/structure-spec.md
@@ -84,10 +84,12 @@ checked **path** changes (M5/M6 are mode-independent).
 | M7 | each `plugins[]` element resolves to a source | `.claude-plugin/marketplace.json` | **same** |
 | M8 | each source has a valid shape | `.claude-plugin/marketplace.json` | **same** |
 | M9 | declared mono plugin dirs exist on disk | `plugins/<name>/` per source | N/A (single) |
+| M10 | plugin.json has only known top-level fields | `plugins/<p>/.claude-plugin/plugin.json` | root `.claude-plugin/plugin.json` |
 
 FAIL conditions: M1/M3 → missing or invalid JSON; M2 → 0 plugin roots;
 M4 → missing or frontmatter lacks `name`/`description`; M5 → either dir
-missing; M6 → missing; M7-M9 → see "marketplace source integrity" below.
+missing; M6 → missing; M7-M9 → see "marketplace source integrity" below;
+M10 → see "plugin.json known fields" below.
 
 ## marketplace `plugins[].source` integrity (M7-M9, #1084)
 
@@ -122,6 +124,33 @@ on disk. A declared-but-absent directory (typo/misconfig) → **FAIL**. Remote
 (url-type) sources have nothing local to verify and are skipped; a mono repo
 whose sources are all remote → **N/A**. In `single` mode M9 is **N/A** (no
 `plugins/` layout).
+
+## plugin.json known fields (M10, #1084)
+
+M7-M9 catch marketplace-level source problems; **M10 catches the plugin.json
+level.** A third real case (claude-plugin-jira#65) installed cleanly but Claude
+Code rejected the manifest at **load** — `/plugin` Errors tab showed
+*"Plugin … has an invalid manifest … Validation errors: skills: Invalid
+input"* — so none of the plugin's skills loaded despite `enabledPlugins` being
+true. Cause: a custom `skills` array in `plugin.json`. The runtime auto-scans
+`skills/`, so the field is unnecessary **and** schema-invalid; lenient plugins
+(`aws-login`, `ds-skills`) omit it entirely.
+
+**M10 — every plugin.json top-level key is in the known-field whitelist.**
+Known fields (Claude Code manifest schema, **2.1.x**):
+
+```
+name (required), version (required), description, author,
+homepage, repository, license, keywords
+```
+
+Any key outside this set → **FAIL** (e.g. the `skills` array above). `skills`
+is the classic trap: it looks supported because it matches the auto-scanned
+folder name, so authors add it by hand. Evaluated per plugin root over the same
+root set as M3; a missing/invalid plugin.json is M3's concern (skipped here),
+and no plugin root with a valid manifest → **N/A**. The whitelist is the SSOT
+`_CPS_PLUGIN_JSON_KNOWN_FIELDS` in the bats fixture — bump it (with a version
+note) on each Claude Code manifest-schema release.
 
 ## Recommended items (WARN when missing)
 

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -7,8 +7,10 @@ description: >-
   only (create dirs, `git mv`, minimal marketplace.json/plugin.json
   skeletons, inject a missing `plugins[].source`, and strip unknown
   `plugin.json` fields with a backup — the #1084 install/load-fail fixes);
-  `--op`/`--recommended` adds recommended R1-R8 fixes (empty
-  placeholder stubs + naming correction + README link backfill). Idempotent.
+  `--op`/`--recommended` adds recommended R1-R5 fixes (empty
+  placeholder stubs + naming correction + README link backfill); R6-R8 are
+  audit-only WARNs the check surfaces but refactor does not auto-apply.
+  Idempotent.
   Supports both `mono` (`plugins/<p>/skills/`) and `single` (repo-root
   `skills/`) layouts — auto-detected, or forced with `--single` / `--mono`;
   it fixes toward the detected mode's golden layout and never converts
@@ -44,7 +46,8 @@ Positional `[repo-path]` (default = current dir). Flags:
 
 - `--apply` — execute changes. Absent → dry-run (plan only, no writes).
 - `--mandatory` / `--mp` — scope = M1-M10 only (default scope).
-- `--recommended` / `--op` — scope = M1-M10 + R1-R8.
+- `--recommended` / `--op` — scope = M1-M10 + R1-R5 fixes (R6-R8 are
+  audit-only WARNs, not auto-applied).
 - `--single` / `--mono` — force the **target** layout mode, overriding
   auto-detection (Step 2). Mutually exclusive; if both given, last wins.
   `--mp` and `--op` together → error + usage, stop.
@@ -69,8 +72,8 @@ Read `references/structure-spec.md` (embedded SSOT) for layout modes, mode detec
 ## Step 3: Build the Plan
 
 Read `references/plan-and-report-templates.md`. Produce an ordered change
-list, each tagged with its driving check ID (M1-M10, and R1-R8 only when
-scope is `--op`). **Paths are plugin-root relative** — single targets root
+list, each tagged with its driving check ID (M1-M10, and R1-R5 only when
+scope is `--op`; R6-R8 are audit-only and never produce a plan line). **Paths are plugin-root relative** — single targets root
 `./` (no `plugins/` dir ever created); mono targets `plugins/<p>/`.
 Already-correct items produce no action (idempotent). The plan header states
 the detected/forced mode; an unsupported conversion produces only the
@@ -83,7 +86,7 @@ the detected/forced mode; an unsupported conversion produces only the
   warning and stop — even under `--apply`, write nothing.
 - **`--apply`**: execute the plan in order following the **Apply rules**
   (mkdir → move → skeleton, fully listed in
-  `references/plan-and-report-templates.md`); `--op` adds R1-R8 — see
+  `references/plan-and-report-templates.md`); `--op` adds R1-R5 — see
   `references/op-rules.md`.
 
 ## Step 5: Report

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -3,10 +3,11 @@ name: claude-plugin:structure-refactor
 description: >-
   Fix a claude-plugin marketplace repo's directory structure toward the
   standard layout. Dry-run by default (plan only, no writes); `--apply`
-  performs changes. Scope `--mp`/`--mandatory` fixes mandatory items M1-M9
+  performs changes. Scope `--mp`/`--mandatory` fixes mandatory items M1-M10
   only (create dirs, `git mv`, minimal marketplace.json/plugin.json
-  skeletons, and inject a missing `plugins[].source` — the #1084 install-fail
-  fix); `--op`/`--recommended` adds recommended R1-R8 fixes (empty
+  skeletons, inject a missing `plugins[].source`, and strip unknown
+  `plugin.json` fields with a backup — the #1084 install/load-fail fixes);
+  `--op`/`--recommended` adds recommended R1-R8 fixes (empty
   placeholder stubs + naming correction + README link backfill). Idempotent.
   Supports both `mono` (`plugins/<p>/skills/`) and `single` (repo-root
   `skills/`) layouts — auto-detected, or forced with `--single` / `--mono`;
@@ -42,8 +43,8 @@ its content verbatim, then stop. No filesystem changes.
 Positional `[repo-path]` (default = current dir). Flags:
 
 - `--apply` — execute changes. Absent → dry-run (plan only, no writes).
-- `--mandatory` / `--mp` — scope = M1-M9 only (default scope).
-- `--recommended` / `--op` — scope = M1-M9 + R1-R8.
+- `--mandatory` / `--mp` — scope = M1-M10 only (default scope).
+- `--recommended` / `--op` — scope = M1-M10 + R1-R8.
 - `--single` / `--mono` — force the **target** layout mode, overriding
   auto-detection (Step 2). Mutually exclusive; if both given, last wins.
   `--mp` and `--op` together → error + usage, stop.
@@ -62,13 +63,13 @@ Read `references/structure-spec.md` (embedded SSOT) for layout modes, mode detec
    scope (rules in spec → "Mode override = layout conversion").
 3. **Compute the plugin-root set**: `mono` → each `plugins/*/`; `single` →
    repo root `./` (exactly one).
-4. **Discover skills** and run M1-M9 / R1-R8 evaluation over the roots to
+4. **Discover skills** and run M1-M10 / R1-R8 evaluation over the roots to
    compute the current → target diff.
 
 ## Step 3: Build the Plan
 
 Read `references/plan-and-report-templates.md`. Produce an ordered change
-list, each tagged with its driving check ID (M1-M9, and R1-R8 only when
+list, each tagged with its driving check ID (M1-M10, and R1-R8 only when
 scope is `--op`). **Paths are plugin-root relative** — single targets root
 `./` (no `plugins/` dir ever created); mono targets `plugins/<p>/`.
 Already-correct items produce no action (idempotent). The plan header states

--- a/claude/skills/claude-plugin-structure-refactor/SKILL.md
+++ b/claude/skills/claude-plugin-structure-refactor/SKILL.md
@@ -3,9 +3,10 @@ name: claude-plugin:structure-refactor
 description: >-
   Fix a claude-plugin marketplace repo's directory structure toward the
   standard layout. Dry-run by default (plan only, no writes); `--apply`
-  performs changes. Scope `--mp`/`--mandatory` fixes mandatory items M1-M6
+  performs changes. Scope `--mp`/`--mandatory` fixes mandatory items M1-M9
   only (create dirs, `git mv`, minimal marketplace.json/plugin.json
-  skeletons); `--op`/`--recommended` adds recommended R1-R5 fixes (empty
+  skeletons, and inject a missing `plugins[].source` — the #1084 install-fail
+  fix); `--op`/`--recommended` adds recommended R1-R8 fixes (empty
   placeholder stubs + naming correction + README link backfill). Idempotent.
   Supports both `mono` (`plugins/<p>/skills/`) and `single` (repo-root
   `skills/`) layouts — auto-detected, or forced with `--single` / `--mono`;
@@ -41,8 +42,8 @@ its content verbatim, then stop. No filesystem changes.
 Positional `[repo-path]` (default = current dir). Flags:
 
 - `--apply` — execute changes. Absent → dry-run (plan only, no writes).
-- `--mandatory` / `--mp` — scope = M1-M6 only (default scope).
-- `--recommended` / `--op` — scope = M1-M6 + R1-R5.
+- `--mandatory` / `--mp` — scope = M1-M9 only (default scope).
+- `--recommended` / `--op` — scope = M1-M9 + R1-R8.
 - `--single` / `--mono` — force the **target** layout mode, overriding
   auto-detection (Step 2). Mutually exclusive; if both given, last wins.
   `--mp` and `--op` together → error + usage, stop.
@@ -61,13 +62,13 @@ Read `references/structure-spec.md` (embedded SSOT) for layout modes, mode detec
    scope (rules in spec → "Mode override = layout conversion").
 3. **Compute the plugin-root set**: `mono` → each `plugins/*/`; `single` →
    repo root `./` (exactly one).
-4. **Discover skills** and run M1-M6 / R1-R5 evaluation over the roots to
+4. **Discover skills** and run M1-M9 / R1-R8 evaluation over the roots to
    compute the current → target diff.
 
 ## Step 3: Build the Plan
 
 Read `references/plan-and-report-templates.md`. Produce an ordered change
-list, each tagged with its driving check ID (M1-M6, and R1-R5 only when
+list, each tagged with its driving check ID (M1-M9, and R1-R8 only when
 scope is `--op`). **Paths are plugin-root relative** — single targets root
 `./` (no `plugins/` dir ever created); mono targets `plugins/<p>/`.
 Already-correct items produce no action (idempotent). The plan header states
@@ -81,7 +82,7 @@ the detected/forced mode; an unsupported conversion produces only the
   warning and stop — even under `--apply`, write nothing.
 - **`--apply`**: execute the plan in order following the **Apply rules**
   (mkdir → move → skeleton, fully listed in
-  `references/plan-and-report-templates.md`); `--op` adds R1-R5 — see
+  `references/plan-and-report-templates.md`); `--op` adds R1-R8 — see
   `references/op-rules.md`.
 
 ## Step 5: Report

--- a/claude/skills/claude-plugin-structure-refactor/references/help.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/help.md
@@ -11,8 +11,8 @@ Arguments:
 Flags:
   --apply              Execute the plan. Without it, the skill is DRY-RUN
                        (prints the plan, writes nothing).
-  --mandatory | --mp   Scope = mandatory items M1-M9 only. (default scope)
-  --recommended | --op Scope = M1-M9 + recommended R1-R8 (placeholder stubs
+  --mandatory | --mp   Scope = mandatory items M1-M10 only. (default scope)
+  --recommended | --op Scope = M1-M10 + recommended R1-R8 (placeholder stubs
                        + naming correction + README link backfill).
   --single             Force the SINGLE target layout (repo itself is one
                        plugin; marketplace source "./", skills at root
@@ -57,6 +57,9 @@ Behavior:
                          - inject a missing plugins[].source into an existing
                            marketplace (M7, #1084 install-fail fix): git URL
                            from homepage/repository, else the mode's local path
+                         - prune unknown top-level plugin.json fields (M10,
+                           #1084 load-fail fix): e.g. a schema-violating skills
+                           array; a .bak backup is kept
                          - (--op only) create empty R1/R2 placeholder stubs,
                            correct R4 naming mismatches, and backfill missing
                            R5 README guide+usage links (stub level)

--- a/claude/skills/claude-plugin-structure-refactor/references/help.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/help.md
@@ -12,8 +12,9 @@ Flags:
   --apply              Execute the plan. Without it, the skill is DRY-RUN
                        (prints the plan, writes nothing).
   --mandatory | --mp   Scope = mandatory items M1-M10 only. (default scope)
-  --recommended | --op Scope = M1-M10 + recommended R1-R8 (placeholder stubs
-                       + naming correction + README link backfill).
+  --recommended | --op Scope = M1-M10 + recommended R1-R5 fixes (placeholder stubs
+                       + naming correction + README link backfill). R6-R8 are
+                       audit-only WARNs (check surfaces them; refactor skips).
   --single             Force the SINGLE target layout (repo itself is one
                        plugin; marketplace source "./", skills at root
                        skills/<s>/ — no plugins/ directory is created).

--- a/claude/skills/claude-plugin-structure-refactor/references/help.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/help.md
@@ -11,8 +11,8 @@ Arguments:
 Flags:
   --apply              Execute the plan. Without it, the skill is DRY-RUN
                        (prints the plan, writes nothing).
-  --mandatory | --mp   Scope = mandatory items M1-M6 only. (default scope)
-  --recommended | --op Scope = M1-M6 + recommended R1-R5 (placeholder stubs
+  --mandatory | --mp   Scope = mandatory items M1-M9 only. (default scope)
+  --recommended | --op Scope = M1-M9 + recommended R1-R8 (placeholder stubs
                        + naming correction + README link backfill).
   --single             Force the SINGLE target layout (repo itself is one
                        plugin; marketplace source "./", skills at root
@@ -54,6 +54,9 @@ Behavior:
                            falls back to `mv` outside a git repo)
                          - write minimal marketplace.json / plugin.json
                            skeletons from discovered plugin/skill names
+                         - inject a missing plugins[].source into an existing
+                           marketplace (M7, #1084 install-fail fix): git URL
+                           from homepage/repository, else the mode's local path
                          - (--op only) create empty R1/R2 placeholder stubs,
                            correct R4 naming mismatches, and backfill missing
                            R5 README guide+usage links (stub level)

--- a/claude/skills/claude-plugin-structure-refactor/references/op-rules.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/op-rules.md
@@ -1,9 +1,11 @@
 # Structure Refactor: --op Flag Rules
 
-Under `--op` (`--recommended`), R1-R5 fixes are applied in addition to M1-M9
-(R6-R8 are audit-only WARN items — the refactor adds `$schema`/`description`/
-`homepage`/README-URL fixes are **not** auto-applied; a developer fills those).
-Specific behaviors when `--apply --op` is active:
+Under `--op` (`--recommended`), R1-R5 fixes are applied in addition to the
+mandatory M1-M10 (which includes the M7 source injection and M10 plugin.json
+prune — both run under `--mp` too). R6-R8 are audit-only WARN items:
+`$schema` / `description` / `homepage` / README-URL fixes are **not**
+auto-applied; a developer fills those. Specific behaviors when
+`--apply --op` is active:
 
 ## R1 — per-skill guide generation
 

--- a/claude/skills/claude-plugin-structure-refactor/references/op-rules.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/op-rules.md
@@ -1,6 +1,8 @@
 # Structure Refactor: --op Flag Rules
 
-Under `--op` (`--recommended`), R1-R5 fixes are applied in addition to M1-M6.
+Under `--op` (`--recommended`), R1-R5 fixes are applied in addition to M1-M9
+(R6-R8 are audit-only WARN items — the refactor adds `$schema`/`description`/
+`homepage`/README-URL fixes are **not** auto-applied; a developer fills those).
 Specific behaviors when `--apply --op` is active:
 
 ## R1 — per-skill guide generation

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -8,6 +8,7 @@ claude-plugin structure refactor — <repo-path>   (mode: mono|single[, 추정] 
 
 계획 (현재 → 목표):
   [M1] create  .claude-plugin/marketplace.json   (skeleton, 1 plugin)
+  [M7] source  plugins[].source 주입 (visuals ← ./plugins/visuals | git URL)
   [M3] create  plugins/visuals/.claude-plugin/plugin.json (skeleton)
   [M4] git mv  visualize/SKILL.md → plugins/visuals/skills/visualize/SKILL.md
   [M5] mkdir   docs/skill-guides/, docs/skill-output/
@@ -27,13 +28,14 @@ claude-plugin structure refactor — <repo-path>   (mode: mono|single[, 추정] 
   created**; for `mono` they are `plugins/<p>/…` as shown above.
 - One line per change: `[<ID>] <verb>  <path / detail>`.
 - Verbs: `create` (new file), `mkdir` (new dir), `git mv` / `mv` (move),
+  `source` (inject a missing `plugins[].source` into an existing marketplace — M7),
   `visualize` (generate an R1 guide by delegating to `/devx:visualize`),
   `stub` (empty placeholder), `pages` (activate GitHub Pages),
   `rename` (frontmatter/dir naming fix),
   `link` (append a per-skill Pages-URL guide link into README — R5).
 - Items already correct produce **no line** (idempotent — proof there is
   nothing to do is an empty plan + `총 0 변경`).
-- R1-R5 lines appear only when scope is `--op` / `--recommended`.
+- R1-R8 lines appear only when scope is `--op` / `--recommended`.
 
 ### Layout-conversion warning (forced mode ≠ detected mode)
 
@@ -72,6 +74,21 @@ Execute the plan in this order so later steps see earlier results:
      ```
    Fill arrays from the dynamically discovered plugin/skill names. Do not
    clobber a JSON that already parses — only create when missing.
+
+   New skeletons are written source-clean: the `marketplace.json` above uses
+   `"plugins": ["./plugins/<p>"]` (string = source shorthand) for mono and
+   `[{ "source": "./" }]` for single, so a freshly-created skeleton already
+   satisfies M7/M8.
+3b. **M7 source injection (mandatory — runs under both `--mp` and `--op`)**:
+   when a marketplace.json **already exists** and a `plugins[]` **object**
+   element lacks its own `source`, inject one (the claude-plugin-jira#61
+   install-fail shape). Derivation order per element:
+   - if the element has a `homepage`/`repository` ending in `.git` →
+     `{ "source": "url", "url": "<that>" }` (remote fetch);
+   - else the local path of the detected mode — mono `./plugins/<name>`
+     (from the element's `name`), single `"./"`.
+   Idempotent: a no-op when every element already carries a source, and never
+   touches string-form elements (they are already a source).
 4. **`--op` only — R1 guide (delegate to `/devx:visualize`)**: for each
    discovered skill `<s>`, if `docs/skill-guides/<s>.html` is **missing**,
    invoke `/devx:visualize <path-to-SKILL.md>` to generate the guide at
@@ -159,7 +176,7 @@ Planned: <n>   Applied: <n>   Skipped (already correct): <n>
 <the plan block above, with applied lines marked ✓>
 
 [OK] refactor complete   |   [FAIL] <reason>
-applied=<n> moved=<n> created=<n> visualized=<n> stubbed=<n> pages=<activated|active|skip|n/a> linked=<n> layout=<mono|single> mode=<dry-run|apply> scope=<mp|op>
+applied=<n> moved=<n> created=<n> sourced=<n> visualized=<n> stubbed=<n> pages=<activated|active|skip|n/a> linked=<n> layout=<mono|single> mode=<dry-run|apply> scope=<mp|op>
 ```
 
 For a guarded layout-conversion (forced mode ≠ detected) the report is

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -10,6 +10,7 @@ claude-plugin structure refactor — <repo-path>   (mode: mono|single[, 추정] 
   [M1] create  .claude-plugin/marketplace.json   (skeleton, 1 plugin)
   [M7] source  plugins[].source 주입 (visuals ← ./plugins/visuals | git URL)
   [M3] create  plugins/visuals/.claude-plugin/plugin.json (skeleton)
+  [M10] prune  plugins/visuals/.claude-plugin/plugin.json ← 미지원 필드(skills) 제거 (.bak 백업)
   [M4] git mv  visualize/SKILL.md → plugins/visuals/skills/visualize/SKILL.md
   [M5] mkdir   docs/skill-guides/, docs/skill-output/
   [R1] visualize docs/skill-guides/visualize.html   (→ /devx:visualize, --op only)
@@ -29,6 +30,7 @@ claude-plugin structure refactor — <repo-path>   (mode: mono|single[, 추정] 
 - One line per change: `[<ID>] <verb>  <path / detail>`.
 - Verbs: `create` (new file), `mkdir` (new dir), `git mv` / `mv` (move),
   `source` (inject a missing `plugins[].source` into an existing marketplace — M7),
+  `prune` (strip unknown top-level fields from an existing `plugin.json`, `.bak` kept — M10),
   `visualize` (generate an R1 guide by delegating to `/devx:visualize`),
   `stub` (empty placeholder), `pages` (activate GitHub Pages),
   `rename` (frontmatter/dir naming fix),
@@ -70,10 +72,13 @@ Execute the plan in this order so later steps see earlier results:
      ```
    - `plugins/<p>/.claude-plugin/plugin.json`:
      ```json
-     { "name": "<p>", "version": "0.0.0", "skills": ["./skills/<s>"] }
+     { "name": "<p>", "version": "0.0.0" }
      ```
-   Fill arrays from the dynamically discovered plugin/skill names. Do not
-   clobber a JSON that already parses — only create when missing.
+   Fill `marketplace.json`'s plugins array from the dynamically discovered
+   plugin names. Do not clobber a JSON that already parses — only create when
+   missing. **plugin.json carries no `skills` array** — the runtime auto-scans
+   `skills/`, and a `skills` field fails manifest validation (M10, #1084); the
+   skeleton stays schema-clean so it satisfies M10 on creation.
 
    New skeletons are written source-clean: the `marketplace.json` above uses
    `"plugins": ["./plugins/<p>"]` (string = source shorthand) for mono and
@@ -89,6 +94,14 @@ Execute the plan in this order so later steps see earlier results:
      (from the element's `name`), single `"./"`.
    Idempotent: a no-op when every element already carries a source, and never
    touches string-form elements (they are already a source).
+3c. **M10 unknown-field prune (mandatory — runs under both `--mp` and `--op`)**:
+   for each existing, valid `plugin.json`, drop every top-level key outside the
+   known-field whitelist (`name`, `version`, `description`, `author`,
+   `homepage`, `repository`, `license`, `keywords`) — the claude-plugin-jira#65
+   `skills`-array case that fails manifest validation at load. Copy the file to
+   `plugin.json.bak` first (recoverable removal), then rewrite with
+   `jq 'with_entries(select(.key as $x | $known | index($x)))'`. Idempotent: a
+   no-op (and no `.bak`) when the manifest already has only known fields.
 4. **`--op` only — R1 guide (delegate to `/devx:visualize`)**: for each
    discovered skill `<s>`, if `docs/skill-guides/<s>.html` is **missing**,
    invoke `/devx:visualize <path-to-SKILL.md>` to generate the guide at
@@ -176,7 +189,7 @@ Planned: <n>   Applied: <n>   Skipped (already correct): <n>
 <the plan block above, with applied lines marked ✓>
 
 [OK] refactor complete   |   [FAIL] <reason>
-applied=<n> moved=<n> created=<n> sourced=<n> visualized=<n> stubbed=<n> pages=<activated|active|skip|n/a> linked=<n> layout=<mono|single> mode=<dry-run|apply> scope=<mp|op>
+applied=<n> moved=<n> created=<n> sourced=<n> pruned=<n> visualized=<n> stubbed=<n> pages=<activated|active|skip|n/a> linked=<n> layout=<mono|single> mode=<dry-run|apply> scope=<mp|op>
 ```
 
 For a guarded layout-conversion (forced mode ≠ detected) the report is

--- a/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
@@ -37,7 +37,9 @@ claude-plugin structure refactor — <repo-path>   (mode: mono|single[, 추정] 
   `link` (append a per-skill Pages-URL guide link into README — R5).
 - Items already correct produce **no line** (idempotent — proof there is
   nothing to do is an empty plan + `총 0 변경`).
-- R1-R8 lines appear only when scope is `--op` / `--recommended`.
+- R1-R5 lines appear only when scope is `--op` / `--recommended`. R6-R8 are
+  audit-only WARNs (surfaced by structure-check) — refactor never emits a plan
+  line or applies a fix for them.
 
 ### Layout-conversion warning (forced mode ≠ detected mode)
 

--- a/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
@@ -113,10 +113,12 @@ for each item targets the same path.
 | M7 | each `plugins[]` element resolves to a source | `.claude-plugin/marketplace.json` | **same** |
 | M8 | each source has a valid shape | `.claude-plugin/marketplace.json` | **same** |
 | M9 | declared mono plugin dirs exist on disk | `plugins/<name>/` per source | N/A (single) |
+| M10 | plugin.json has only known top-level fields | `plugins/<p>/.claude-plugin/plugin.json` | root `.claude-plugin/plugin.json` |
 
 FAIL conditions: M1/M3 → missing or invalid JSON; M2 → 0 plugin roots;
 M4 → missing or frontmatter lacks `name`/`description`; M5 → either dir
-missing; M6 → missing; M7-M9 → see "marketplace source integrity" below.
+missing; M6 → missing; M7-M9 → see "marketplace source integrity" below;
+M10 → see "plugin.json known fields" below.
 
 ## marketplace `plugins[].source` integrity (M7-M9, #1084)
 
@@ -146,6 +148,23 @@ may legitimately use remote URL sources (#63 guard).
 the form `./plugins/<name>`, `plugins/<name>/` must exist. Absent → **FAIL**.
 Remote (url-type) sources are skipped; a mono repo whose sources are all remote
 → **N/A**. In `single` mode M9 is **N/A**.
+
+## plugin.json known fields (M10, #1084)
+
+A third case (claude-plugin-jira#65) installed cleanly but Claude Code rejected
+the manifest at **load** (*"Validation errors: skills: Invalid input"*), so no
+skills loaded. Cause: a custom `skills` array in `plugin.json` — the runtime
+auto-scans `skills/`, so the field is both unnecessary and schema-invalid.
+
+**M10 — every plugin.json top-level key is in the known-field whitelist.**
+Known fields (Claude Code manifest schema, **2.1.x**): `name` (required),
+`version` (required), `description`, `author`, `homepage`, `repository`,
+`license`, `keywords`. Any other key → **FAIL**. Evaluated per plugin root
+(same set as M3); missing/invalid manifest is M3's concern, no valid manifest
+→ **N/A**. Refactor's `--apply` strips the unknown fields (backup kept) — see
+`references/plan-and-report-templates.md` → "Apply rules" M10 step. The
+whitelist SSOT is `_CPS_PLUGIN_JSON_KNOWN_FIELDS` in the bats fixture; bump it
+with a version note on each Claude Code manifest-schema release.
 
 ## Recommended items (WARN when missing)
 

--- a/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
+++ b/claude/skills/claude-plugin-structure-refactor/references/structure-spec.md
@@ -110,10 +110,42 @@ for each item targets the same path.
 | M4 | each SKILL.md valid | `plugins/<p>/skills/<s>/SKILL.md` | `skills/<s>/SKILL.md` |
 | M5 | docs dirs exist | `docs/skill-guides/` AND `docs/skill-output/` | **same** |
 | M6 | README.md | `README.md` | **same** |
+| M7 | each `plugins[]` element resolves to a source | `.claude-plugin/marketplace.json` | **same** |
+| M8 | each source has a valid shape | `.claude-plugin/marketplace.json` | **same** |
+| M9 | declared mono plugin dirs exist on disk | `plugins/<name>/` per source | N/A (single) |
 
 FAIL conditions: M1/M3 → missing or invalid JSON; M2 → 0 plugin roots;
 M4 → missing or frontmatter lacks `name`/`description`; M5 → either dir
-missing; M6 → missing.
+missing; M6 → missing; M7-M9 → see "marketplace source integrity" below.
+
+## marketplace `plugins[].source` integrity (M7-M9, #1084)
+
+Claude Code (observed on 2.1.198) does **not** inherit a marketplace top-level
+`source` into a plugin at install time — each `plugins[]` element must carry
+its own source, or `/plugin install` fails with *"This plugin uses a source
+type your Claude Code version does not support"* (claude-plugin-jira#61). A
+structure audit that stopped at M6 passed such a repo, which then misled the
+diagnosis (claude-plugin-jira#63). M7-M9 close that gap. They evaluate only
+when M1 passes (marketplace parses) and ≥1 plugin is listed; otherwise **N/A**
+(M1/M2 own those FAILs — never double-count).
+
+**M7 — each `plugins[]` element resolves to a source.** A bare **string**
+element (`"./plugins/foo"`, `"./"`) **is** the source; an **object** element
+MUST carry its own `source` key (missing it is the #61 shape → **FAIL**).
+Refactor's `--apply` repairs an M7 FAIL by injecting a `source` (see
+`references/plan-and-report-templates.md` → "Apply rules" M7 step).
+
+**M8 — each resolved source has a valid shape** (mono/single common). Valid:
+local path string (`"."` / `"./"` / `"plugins/<name>"` / `"./plugins/<name>"`)
+or git-URL object (`{ "source": "url", "url": "<non-empty ….git>" }`). Any
+other shape → **FAIL**. Elements with no resolvable source are M7's concern
+(skipped here). The mode-shape combination itself is never a FAIL — a mono repo
+may legitimately use remote URL sources (#63 guard).
+
+**M9 — mono only: each declared local plugin dir exists.** For every source of
+the form `./plugins/<name>`, `plugins/<name>/` must exist. Absent → **FAIL**.
+Remote (url-type) sources are skipped; a mono repo whose sources are all remote
+→ **N/A**. In `single` mode M9 is **N/A**.
 
 ## Recommended items (WARN when missing)
 
@@ -124,6 +156,9 @@ missing; M6 → missing.
 | R3 | README is "Simple" | heuristic violated (below) |
 | R4 | naming consistency | SKILL.md `name:` colon-namespace ↔ directory hyphen mismatch |
 | R5 | per-skill README guide+usage links | README missing the guide OR the usage link for a skill |
+| R6 | marketplace `$schema` declared | `marketplace.json` lacks a top-level `$schema` |
+| R7 | listing metadata | no top-level `description`, OR an object plugin lacks `homepage` |
+| R8 | README add-URL hint | a `/plugin marketplace add` example uses a `.git` clone URL |
 
 **R3 README "Simple" heuristic** — PASS only if all hold; any miss → WARN:
 - at least one link into a `docs/` sub-document (evidence of progressive split);
@@ -148,6 +183,20 @@ README — completing the "standard" the developer relies on (see
 `claude-plugin-visuals/README.md`). Reuses the Step 2 dynamic skill list,
 so no extra scan. R3's "Simple" heuristic only requires *one* `docs/` link
 anywhere, so it cannot catch a per-skill link gap — R5 does.
+
+**R6 `$schema` rule** — `marketplace.json` should declare a top-level
+`"$schema"` so editors/LSP can validate it. Missing → **WARN** (no runtime
+impact). **N/A** when the marketplace is unreadable (M1 owns that).
+
+**R7 listing-metadata rule** — a top-level `description` plus a `homepage` on
+each **object** plugin improve marketplace-UI listing. Missing description, or
+any object plugin lacking a non-empty `homepage`, → **WARN**. String-form
+plugins are exempt (no field to carry `homepage`).
+
+**R8 add-URL hint** — when `README.md` shows a `/plugin marketplace add <URL>`
+example, prefer the raw `.claude-plugin/marketplace.json` URL over a `.git`
+clone (raw avoids a local clone — the #61 success pattern). A `.git` example
+→ **WARN**; raw/other URL → **PASS**; no example or no README → **N/A**.
 
 **Pages URL patterns** — when `structure-refactor --op` backfills R5 guide
 links it uses the GitHub Pages absolute URL, derived host-independently from

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -193,8 +193,10 @@ cps_check_M8() {
     # Shape validity of each resolvable source (mono/single common):
     #   local path : "." | "./" | "plugins/*" | "./plugins/*"
     #   git URL    : object { "source":"url", "url":"<non-empty>" }
-    # Elements with no resolvable source are M7's concern → skipped here (never
-    # double-FAIL). N/A when marketplace unreadable or 0 plugins.
+    # Only an object *missing* the source key is skipped (M7 owns that) — an
+    # explicit null source, or a null plugin element, is collected and FAILs
+    # here (a malformed source is not a free pass; PR #1085 gemini review).
+    # N/A when marketplace unreadable or 0 plugins.
     local _mf="$1/.claude-plugin/marketplace.json" _n _bad
     _cps_json_ok "$_mf" || {
         echo "N/A"
@@ -209,7 +211,7 @@ cps_check_M8() {
       [ (.plugins // [])[]
         | ( if type=="object" then . else { "source": . } end ) as $e
         | ($e.source) as $s
-        | select($s != null)
+        | select( if type=="object" then has("source") else true end )
         | select(
             ( ($s|type=="string") and
               ( $s=="." or $s=="./" or ($s|startswith("plugins/")) or ($s|startswith("./plugins/")) ) )
@@ -391,11 +393,14 @@ cps_check_R7() {
         echo "N/A"
         return
     }
-    [ "$(jq -r '(has("description") and ((.description // "")|length>0))' "$_mf" 2>/dev/null)" = "true" ] || {
+    # Guard the type before length so a non-string description/homepage (bool,
+    # number) can't crash jq and slip through the `|| echo 0` fallback as a
+    # false PASS (PR #1085 gemini review).
+    [ "$(jq -r '(has("description") and (.description|type=="string") and (.description|length>0))' "$_mf" 2>/dev/null)" = "true" ] || {
         echo WARN
         return
     }
-    _missing="$(jq '[(.plugins // [])[] | select(type=="object") | select((has("homepage")|not) or ((.homepage // "")|length==0))] | length' "$_mf" 2>/dev/null || echo 0)"
+    _missing="$(jq '[(.plugins // [])[] | select(type=="object") | select((has("homepage")|not) or (.homepage|type!="string") or (.homepage|length==0))] | length' "$_mf" 2>/dev/null || echo 0)"
     [ "${_missing:-0}" -eq 0 ] && echo PASS || echo WARN
 }
 
@@ -489,7 +494,7 @@ cps_refactor() {
 # (mono → ./plugins/<name>, single → ./). Idempotent: a no-op when every plugin
 # already carries a source, or when the marketplace is missing/invalid.
 _cps_repair_m7() {
-    local _repo="$1" _mode="$2" _mf="$1/.claude-plugin/marketplace.json" _need _tmp
+    local _repo="$1" _mode="$2" _mf="$1/.claude-plugin/marketplace.json" _need _tmp _status=0
     _cps_json_ok "$_mf" || return 0
     _need="$(jq '[(.plugins // [])[] | select(type=="object") | select(has("source")|not)] | length' "$_mf" 2>/dev/null || echo 0)"
     [ "${_need:-0}" -gt 0 ] || return 0
@@ -497,7 +502,7 @@ _cps_repair_m7() {
     if [ "$_mode" = single ]; then
         jq '.plugins |= map(if type=="object" and (has("source")|not)
               then . + {"source":"./"} else . end)' \
-            "$_mf" >"$_tmp" && mv "$_tmp" "$_mf"
+            "$_mf" >"$_tmp" && mv -f "$_tmp" "$_mf" || _status=$?
     else
         jq '.plugins |= map(if type=="object" and (has("source")|not)
               then ((.homepage // .repository // "") as $u
@@ -505,8 +510,12 @@ _cps_repair_m7() {
                       then . + {"source":"url","url":$u}
                       else . + {"source":("./plugins/" + (.name // "plugin"))} end)
               else . end)' \
-            "$_mf" >"$_tmp" && mv "$_tmp" "$_mf"
+            "$_mf" >"$_tmp" && mv -f "$_tmp" "$_mf" || _status=$?
     fi
+    # Single cleanup point: drop any orphaned temp file on failure (jq/mv),
+    # then surface the real status (PR #1085 gemini review).
+    rm -f "$_tmp"
+    return "$_status"
 }
 
 # mono apply: marketplace + per-plugin plugin.json + plugins/<p>/ stubs/links.

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -191,7 +191,9 @@ cps_check_M7() {
 
 cps_check_M8() {
     # Shape validity of each resolvable source (mono/single common):
-    #   local path : "." | "./" | "plugins/*" | "./plugins/*"
+    #   local path : "." | "./" (single) | "[./]plugins/<name>" — exactly ONE
+    #                segment after plugins/ (nested "./plugins/a/b" → FAIL, per
+    #                codex review: mono sources are plugins/<name> only)
     #   git URL    : object { "source":"url", "url":"<non-empty>" }
     # Only an object *missing* the source key is skipped (M7 owns that) — an
     # explicit null source, or a null plugin element, is collected and FAILs
@@ -214,7 +216,7 @@ cps_check_M8() {
         | select( if type=="object" then has("source") else true end )
         | select(
             ( ($s|type=="string") and
-              ( $s=="." or $s=="./" or ($s|startswith("plugins/")) or ($s|startswith("./plugins/")) ) )
+              ( $s=="." or $s=="./" or ($s|test("^(\\./)?plugins/[^/]+/?$")) ) )
             or
             ( $s=="url" and (($e.url // "")|type=="string") and (($e.url // "")|length>0) )
           | not )
@@ -238,14 +240,21 @@ cps_check_M9() {
         echo "N/A"
         return
     }
+    # Only well-formed single-segment mono paths (same shape M8 accepts); a
+    # nested/malformed path is M8's FAIL, not M9's concern. Check the EXACT
+    # declared relative path (strip a leading ./ and any trailing /), never
+    # basename — basename would probe the wrong dir for any multi-segment path
+    # (codex review).
     _paths="$(jq -r '(.plugins // [])[]
         | ( if type=="object" then .source else . end )
         | select(type=="string")
-        | select(test("^\\.?/?plugins/"))' "$_mf" 2>/dev/null)"
+        | select(test("^(\\./)?plugins/[^/]+/?$"))' "$_mf" 2>/dev/null)"
     while IFS= read -r _p; do
         [ -n "$_p" ] || continue
         _any=1
-        [ -d "$_repo/plugins/$(basename "$_p")" ] || {
+        _p="${_p#./}"
+        _p="${_p%/}"
+        [ -d "$_repo/$_p" ] || {
             echo FAIL
             return
         }

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -5,7 +5,7 @@
 #   claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
 #
 # The two skills are AI-interpreted markdown with no shell entry point;
-# these functions are the executable form of their M1-M9 / R1-R8 evaluation
+# these functions are the executable form of their M1-M10 / R1-R8 evaluation
 # and the refactor apply logic, so bats can pin the behavior against real
 # fixture repos. Keep them in sync with structure-spec.md whenever the spec
 # changes.
@@ -102,7 +102,7 @@ _cps_skills_in_root() {
     done
 }
 
-# ---- mandatory checks (M1-M9) -- echo PASS|FAIL|N/A ---------------------
+# ---- mandatory checks (M1-M10) -- echo PASS|FAIL|N/A ---------------------
 cps_check_M1() { _cps_json_ok "$1/.claude-plugin/marketplace.json" && echo PASS || echo FAIL; }
 
 cps_check_M2() {
@@ -251,6 +251,39 @@ cps_check_M9() {
         }
     done <<EOF
 $_paths
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
+}
+
+# Known top-level plugin.json fields per the Claude Code manifest schema
+# (2.1.x). SSOT mirror of structure-spec.md → "plugin.json known fields (M10)".
+# `skills` is intentionally NOT here — the runtime auto-scans skills/, and a
+# skills field makes the manifest fail validation → plugin loads not at all
+# (claude-plugin-jira#65, #1084 comment 2026-07-02). Update on CC releases.
+_CPS_PLUGIN_JSON_KNOWN_FIELDS='["name","version","description","author","homepage","repository","license","keywords"]'
+
+cps_check_M10() {
+    # Every plugin.json top-level key must be in the known-field whitelist.
+    # An unknown field (e.g. skills) → FAIL — install succeeds but Claude Code
+    # rejects the manifest at load ("Validation errors: skills: Invalid input").
+    # Evaluated per plugin root; a missing/invalid plugin.json is M3's concern
+    # (skipped here). No plugin root with a valid manifest → N/A.
+    local _mode _root _pj _unknown _any=0
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
+        _pj="$1/$_root/.claude-plugin/plugin.json"
+        _cps_json_ok "$_pj" || continue
+        _any=1
+        _unknown="$(jq --argjson k "$_CPS_PLUGIN_JSON_KNOWN_FIELDS" \
+            '[keys[] | select(. as $x | $k | index($x) | not)] | length' \
+            "$_pj" 2>/dev/null || echo 1)"
+        [ "${_unknown:-1}" -eq 0 ] || {
+            echo FAIL
+            return
+        }
+    done <<EOF
+$(_cps_plugin_roots "$1" "$_mode")
 EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
@@ -431,7 +464,7 @@ cps_verdict() {
     # echo FAIL | WARN | PASS for repo $1 ; optional $2 forces single|mono.
     # M5/M6/R3 are mode-independent so the extra arg is harmless for them.
     local _r _mode="${2:-}"
-    for _c in M1 M2 M3 M4 M5 M6 M7 M8 M9; do
+    for _c in M1 M2 M3 M4 M5 M6 M7 M8 M9 M10; do
         _r="$(cps_check_$_c "$1" "$_mode")"
         [ "$_r" = FAIL ] && {
             echo FAIL
@@ -485,7 +518,38 @@ cps_refactor() {
     # already writes source-bearing plugins, so this only rewrites a
     # pre-existing marketplace.json.
     _cps_repair_m7 "$_repo" "$_target"
+    # M10 repair (mandatory, both scopes): strip unknown fields from every
+    # plugin.json (e.g. a schema-violating skills array), keeping a .bak.
+    _cps_repair_m10 "$_repo" "$_target"
     return 0 # success (0); the conversion-guard early return above is 3
+}
+
+# M10 fix: strip any top-level plugin.json key outside the known-field
+# whitelist (the #1084 comment case: a skills array that fails manifest
+# validation). A timestamp-free `.bak` copy is left beside each rewritten
+# plugin.json so the removal is recoverable. Idempotent: a no-op when every
+# manifest is already clean, or when it is missing/invalid (M3 owns that).
+_cps_repair_m10() {
+    local _repo="$1" _mode="$2" _root _pj _unknown _tmp _status=0
+    _mode="$(_cps_detect_mode "$_repo")"
+    while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
+        _pj="$_repo/$_root/.claude-plugin/plugin.json"
+        _cps_json_ok "$_pj" || continue
+        _unknown="$(jq --argjson k "$_CPS_PLUGIN_JSON_KNOWN_FIELDS" \
+            '[keys[] | select(. as $x | $k | index($x) | not)] | length' \
+            "$_pj" 2>/dev/null || echo 0)"
+        [ "${_unknown:-0}" -gt 0 ] || continue
+        cp "$_pj" "$_pj.bak"
+        _tmp="$_pj.tmp"
+        jq --argjson k "$_CPS_PLUGIN_JSON_KNOWN_FIELDS" \
+            'with_entries(select(.key as $x | $k | index($x)))' \
+            "$_pj" >"$_tmp" && mv -f "$_tmp" "$_pj" || _status=$?
+        rm -f "$_tmp"
+    done <<EOF
+$(_cps_plugin_roots "$_repo" "$_mode")
+EOF
+    return "$_status"
 }
 
 # M7 fix: for each object plugin missing .source, inject one. Prefer a git URL
@@ -538,22 +602,16 @@ EOF
     fi
 
     # M3 per-plugin plugin.json skeleton — list ALL skills of each plugin
-    local _p _s _skills_json
+    # plugin.json carries ONLY known manifest fields — no skills array (M10,
+    # #1084): the runtime auto-scans skills/, and a skills field fails manifest
+    # validation → plugin never loads. Skills are discovered by dir scan.
+    local _p
     while IFS= read -r _p; do
         [ -n "$_p" ] || continue
         mkdir -p "$_repo/plugins/$_p/.claude-plugin"
         if ! _cps_json_ok "$_repo/plugins/$_p/.claude-plugin/plugin.json"; then
-            _skills_json=""
-            while IFS= read -r _s; do
-                [ -n "$_s" ] || continue
-                [ -n "$_skills_json" ] && _skills_json="${_skills_json}, "
-                _skills_json="${_skills_json}\"./skills/${_s}\""
-            done <<EOF
-$(_cps_skills "$_repo" "$_p")
-EOF
-            printf '{ "name": "%s", "version": "0.0.0", "skills": [%s] }\n' \
-                "$_p" "${_skills_json:-\"./skills/skill\"}" \
-                >"$_repo/plugins/$_p/.claude-plugin/plugin.json"
+            printf '{ "name": "%s", "version": "0.0.0" }\n' \
+                "$_p" >"$_repo/plugins/$_p/.claude-plugin/plugin.json"
         fi
     done <<EOF
 $(_cps_plugins "$_repo")
@@ -602,7 +660,7 @@ EOF
 # single apply: the repo root IS the one plugin root — marketplace source
 # "./", a ROOT plugin.json, root skills/<s>/. NEVER creates a plugins/ dir.
 _cps_refactor_single() {
-    local _repo="$1" _scope="$2" _s _skills_json=""
+    local _repo="$1" _scope="$2" _s
 
     # M1 marketplace.json skeleton with the single source "./".
     if ! _cps_json_ok "$_repo/.claude-plugin/marketplace.json"; then
@@ -610,18 +668,12 @@ _cps_refactor_single() {
             "$(basename "$_repo")" "$(basename "$_repo")" >"$_repo/.claude-plugin/marketplace.json"
     fi
 
-    # M3 ROOT plugin.json skeleton — list ALL root skills.
+    # M3 ROOT plugin.json skeleton — known manifest fields only, no skills
+    # array (M10, #1084): skills are auto-scanned; a skills field fails
+    # manifest validation and blocks the plugin from loading.
     if ! _cps_json_ok "$_repo/.claude-plugin/plugin.json"; then
-        while IFS= read -r _s; do
-            [ -n "$_s" ] || continue
-            [ -n "$_skills_json" ] && _skills_json="${_skills_json}, "
-            _skills_json="${_skills_json}\"./skills/${_s}\""
-        done <<EOF
-$(_cps_skills_in_root "$_repo" ".")
-EOF
-        printf '{ "name": "%s", "version": "0.0.0", "skills": [%s] }\n' \
-            "$(basename "$_repo")" "${_skills_json:-\"./skills/skill\"}" \
-            >"$_repo/.claude-plugin/plugin.json"
+        printf '{ "name": "%s", "version": "0.0.0" }\n' \
+            "$(basename "$_repo")" >"$_repo/.claude-plugin/plugin.json"
     fi
 
     # M6 README skeleton (with a docs/ link so R3 also passes).

--- a/tests/bats/skills/_fixtures/claude_plugin_structure.sh
+++ b/tests/bats/skills/_fixtures/claude_plugin_structure.sh
@@ -5,7 +5,7 @@
 #   claude/skills/claude-plugin-structure-refactor/references/plan-and-report-templates.md
 #
 # The two skills are AI-interpreted markdown with no shell entry point;
-# these functions are the executable form of their M1-M6 / R1-R5 evaluation
+# these functions are the executable form of their M1-M9 / R1-R8 evaluation
 # and the refactor apply logic, so bats can pin the behavior against real
 # fixture repos. Keep them in sync with structure-spec.md whenever the spec
 # changes.
@@ -102,7 +102,7 @@ _cps_skills_in_root() {
     done
 }
 
-# ---- mandatory checks (M1-M6) -- echo PASS|FAIL -------------------------
+# ---- mandatory checks (M1-M9) -- echo PASS|FAIL|N/A ---------------------
 cps_check_M1() { _cps_json_ok "$1/.claude-plugin/marketplace.json" && echo PASS || echo FAIL; }
 
 cps_check_M2() {
@@ -164,7 +164,97 @@ cps_check_M5() {
 
 cps_check_M6() { [ -f "$1/README.md" ] && echo PASS || echo FAIL; }
 
+# ---- M7-M9: marketplace.json plugins[].source integrity (#1084) ----------
+# Root cause (claude-plugin-jira#61): Claude Code 2.1.198 does NOT inherit a
+# marketplace top-level `source` at install time — each plugins[] element must
+# carry its own source, or /plugin install fails. structure-check PASS up to
+# M6 did not catch this, which misled diagnosis (#63). M7-M9 close that gap.
+
+cps_check_M7() {
+    # Each plugins[] element must resolve to a source. A bare STRING element IS
+    # the source (shorthand); an OBJECT element MUST have its own .source key.
+    # FAIL when any object element lacks source (the #61 shape). N/A when the
+    # marketplace is unreadable (M1 owns that) or lists 0 plugins (M2 owns it).
+    local _mf="$1/.claude-plugin/marketplace.json" _n _bad
+    _cps_json_ok "$_mf" || {
+        echo "N/A"
+        return
+    }
+    _n="$(jq '(.plugins // []) | length' "$_mf" 2>/dev/null || echo 0)"
+    [ "${_n:-0}" -ge 1 ] || {
+        echo "N/A"
+        return
+    }
+    _bad="$(jq '[(.plugins // [])[] | select(type=="object") | select(has("source")|not)] | length' "$_mf" 2>/dev/null || echo 1)"
+    [ "${_bad:-1}" -eq 0 ] && echo PASS || echo FAIL
+}
+
+cps_check_M8() {
+    # Shape validity of each resolvable source (mono/single common):
+    #   local path : "." | "./" | "plugins/*" | "./plugins/*"
+    #   git URL    : object { "source":"url", "url":"<non-empty>" }
+    # Elements with no resolvable source are M7's concern → skipped here (never
+    # double-FAIL). N/A when marketplace unreadable or 0 plugins.
+    local _mf="$1/.claude-plugin/marketplace.json" _n _bad
+    _cps_json_ok "$_mf" || {
+        echo "N/A"
+        return
+    }
+    _n="$(jq '(.plugins // []) | length' "$_mf" 2>/dev/null || echo 0)"
+    [ "${_n:-0}" -ge 1 ] || {
+        echo "N/A"
+        return
+    }
+    _bad="$(jq '
+      [ (.plugins // [])[]
+        | ( if type=="object" then . else { "source": . } end ) as $e
+        | ($e.source) as $s
+        | select($s != null)
+        | select(
+            ( ($s|type=="string") and
+              ( $s=="." or $s=="./" or ($s|startswith("plugins/")) or ($s|startswith("./plugins/")) ) )
+            or
+            ( $s=="url" and (($e.url // "")|type=="string") and (($e.url // "")|length>0) )
+          | not )
+      ] | length' "$_mf" 2>/dev/null || echo 1)"
+    [ "${_bad:-1}" -eq 0 ] && echo PASS || echo FAIL
+}
+
+cps_check_M9() {
+    # mono only: each declared LOCAL mono plugin path must exist on disk
+    #   ./plugins/<name> (or plugins/<name>) → <repo>/plugins/<name>/ present.
+    # single mode → N/A (no plugins/ layout). Remote (url-type) sources are
+    # skipped — nothing local to verify (avoids the #63-style false FAIL). N/A
+    # when the marketplace is unreadable or declares no local mono path.
+    local _repo="$1" _mode _mf="$1/.claude-plugin/marketplace.json" _paths _p _any=0
+    _mode="$(_cps_detect_mode "$1" "${2:-}")"
+    [ "$_mode" = mono ] || {
+        echo "N/A"
+        return
+    }
+    _cps_json_ok "$_mf" || {
+        echo "N/A"
+        return
+    }
+    _paths="$(jq -r '(.plugins // [])[]
+        | ( if type=="object" then .source else . end )
+        | select(type=="string")
+        | select(test("^\\.?/?plugins/"))' "$_mf" 2>/dev/null)"
+    while IFS= read -r _p; do
+        [ -n "$_p" ] || continue
+        _any=1
+        [ -d "$_repo/plugins/$(basename "$_p")" ] || {
+            echo FAIL
+            return
+        }
+    done <<EOF
+$_paths
+EOF
+    [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
+}
+
 # ---- recommended checks (R1-R5) -- echo PASS|WARN|N/A -------------------
+# (R6-R8 added below the R1-R5 block, same contract.)
 cps_check_R1() {
     # per-skill docs/skill-guides/<skill>.html ; N/A if no skills. Docs paths
     # are repo-level (mode-independent); only skill discovery is plugin-root.
@@ -280,19 +370,70 @@ EOF
     [ "$_any" -eq 1 ] && echo PASS || echo "N/A"
 }
 
+# ---- R6-R8: marketplace UI / registration quality (#1084) -- WARN|PASS|N/A
+cps_check_R6() {
+    # top-level "$schema" declaration in marketplace.json (LSP/IDE validation).
+    local _mf="$1/.claude-plugin/marketplace.json"
+    _cps_json_ok "$_mf" || {
+        echo "N/A"
+        return
+    }
+    [ "$(jq -r 'has("$schema")' "$_mf" 2>/dev/null)" = "true" ] && echo PASS || echo WARN
+}
+
+cps_check_R7() {
+    # marketplace listing quality: top-level "description" + each OBJECT
+    # plugin's "homepage". String-form plugins have nowhere for homepage → only
+    # object plugins are checked. WARN when description missing or any object
+    # plugin lacks a non-empty homepage.
+    local _mf="$1/.claude-plugin/marketplace.json" _missing
+    _cps_json_ok "$_mf" || {
+        echo "N/A"
+        return
+    }
+    [ "$(jq -r '(has("description") and ((.description // "")|length>0))' "$_mf" 2>/dev/null)" = "true" ] || {
+        echo WARN
+        return
+    }
+    _missing="$(jq '[(.plugins // [])[] | select(type=="object") | select((has("homepage")|not) or ((.homepage // "")|length==0))] | length' "$_mf" 2>/dev/null || echo 0)"
+    [ "${_missing:-0}" -eq 0 ] && echo PASS || echo WARN
+}
+
+cps_check_R8() {
+    # README /plugin marketplace add hint: prefer the raw marketplace.json URL
+    # over a .git clone (raw avoids a local clone — the #61 success pattern).
+    # Both are valid, so a .git example only WARNs. N/A when README absent or
+    # carries no marketplace-add example (no subject).
+    local _rm="$1/README.md" _line
+    [ -f "$_rm" ] || {
+        echo "N/A"
+        return
+    }
+    grep -q 'plugin marketplace add' "$_rm" || {
+        echo "N/A"
+        return
+    }
+    _line="$(grep -m1 'plugin marketplace add' "$_rm")"
+    case "$_line" in
+    *marketplace.json*) echo PASS ;;
+    *.git*) echo WARN ;;
+    *) echo PASS ;;
+    esac
+}
+
 # ---- aggregate verdict ---------------------------------------------------
 cps_verdict() {
     # echo FAIL | WARN | PASS for repo $1 ; optional $2 forces single|mono.
     # M5/M6/R3 are mode-independent so the extra arg is harmless for them.
     local _r _mode="${2:-}"
-    for _c in M1 M2 M3 M4 M5 M6; do
+    for _c in M1 M2 M3 M4 M5 M6 M7 M8 M9; do
         _r="$(cps_check_$_c "$1" "$_mode")"
         [ "$_r" = FAIL ] && {
             echo FAIL
             return
         }
     done
-    for _c in R1 R2 R3 R4 R5; do
+    for _c in R1 R2 R3 R4 R5 R6 R7 R8; do
         _r="$(cps_check_$_c "$1" "$_mode")"
         [ "$_r" = WARN ] && {
             echo WARN
@@ -334,7 +475,38 @@ cps_refactor() {
     else
         _cps_refactor_mono "$_repo" "$_scope"
     fi
+    # M7 repair (mandatory, both scopes): inject a source into any existing
+    # object plugin that lacks one (the #61 shape). The skeleton path above
+    # already writes source-bearing plugins, so this only rewrites a
+    # pre-existing marketplace.json.
+    _cps_repair_m7 "$_repo" "$_target"
     return 0 # success (0); the conversion-guard early return above is 3
+}
+
+# M7 fix: for each object plugin missing .source, inject one. Prefer a git URL
+# derived from the plugin's own homepage/repository (…​.git) → { source:"url",
+# url:<git> }; otherwise fall back to the local path of the detected mode
+# (mono → ./plugins/<name>, single → ./). Idempotent: a no-op when every plugin
+# already carries a source, or when the marketplace is missing/invalid.
+_cps_repair_m7() {
+    local _repo="$1" _mode="$2" _mf="$1/.claude-plugin/marketplace.json" _need _tmp
+    _cps_json_ok "$_mf" || return 0
+    _need="$(jq '[(.plugins // [])[] | select(type=="object") | select(has("source")|not)] | length' "$_mf" 2>/dev/null || echo 0)"
+    [ "${_need:-0}" -gt 0 ] || return 0
+    _tmp="$_mf.tmp"
+    if [ "$_mode" = single ]; then
+        jq '.plugins |= map(if type=="object" and (has("source")|not)
+              then . + {"source":"./"} else . end)' \
+            "$_mf" >"$_tmp" && mv "$_tmp" "$_mf"
+    else
+        jq '.plugins |= map(if type=="object" and (has("source")|not)
+              then ((.homepage // .repository // "") as $u
+                    | if ($u|type=="string") and ($u|endswith(".git"))
+                      then . + {"source":"url","url":$u}
+                      else . + {"source":("./plugins/" + (.name // "plugin"))} end)
+              else . end)' \
+            "$_mf" >"$_tmp" && mv "$_tmp" "$_mf"
+    fi
 }
 
 # mono apply: marketplace + per-plugin plugin.json + plugins/<p>/ stubs/links.
@@ -351,8 +523,8 @@ _cps_refactor_mono() {
         done <<EOF
 $(_cps_plugins "$_repo")
 EOF
-        printf '{ "name": "%s", "plugins": [%s] }\n' \
-            "$(basename "$_repo")" "${_plugins_json:-\"./plugins/plugin\"}" \
+        printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "%s", "description": "%s plugin marketplace", "plugins": [%s] }\n' \
+            "$(basename "$_repo")" "$(basename "$_repo")" "${_plugins_json:-\"./plugins/plugin\"}" \
             >"$_repo/.claude-plugin/marketplace.json"
     fi
 
@@ -425,8 +597,8 @@ _cps_refactor_single() {
 
     # M1 marketplace.json skeleton with the single source "./".
     if ! _cps_json_ok "$_repo/.claude-plugin/marketplace.json"; then
-        printf '{ "name": "%s", "plugins": [{ "source": "./" }] }\n' \
-            "$(basename "$_repo")" >"$_repo/.claude-plugin/marketplace.json"
+        printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "%s", "description": "%s plugin marketplace", "plugins": [{ "source": "./" }] }\n' \
+            "$(basename "$_repo")" "$(basename "$_repo")" >"$_repo/.claude-plugin/marketplace.json"
     fi
 
     # M3 ROOT plugin.json skeleton — list ALL root skills.

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # tests/bats/skills/claude_plugin_structure.bats
 # Verify the structure spec shared by
-#   claude/skills/claude-plugin-structure-check/   (M1-M6 / R1-R5 evaluation)
+#   claude/skills/claude-plugin-structure-check/   (M1-M9 / R1-R8 evaluation)
 #   claude/skills/claude-plugin-structure-refactor/ (dry-run / --apply / --op)
 # Source-of-truth fixture: _fixtures/claude_plugin_structure.sh
 #
@@ -35,8 +35,10 @@ _seed_skill() {
 }
 
 _seed_mandatory_json() {
+    # $schema + description satisfy R6/R7 (#1084); string-form plugins satisfy
+    # M7 (source shorthand) / M8 (valid mono path) / M9 (plugins/demo exists).
     mkdir -p "$1/.claude-plugin" "$1/plugins/demo/.claude-plugin"
-    printf '{ "name": "repo", "plugins": ["./plugins/demo"] }\n' \
+    printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "repo", "description": "demo marketplace", "plugins": ["./plugins/demo"] }\n' \
         > "$1/.claude-plugin/marketplace.json"
     printf '{ "name": "demo", "version": "0.0.0", "skills": ["./skills/visualize"] }\n' \
         > "$1/plugins/demo/.claude-plugin/plugin.json"
@@ -325,9 +327,11 @@ _seed_single_skill() {
 }
 
 _seed_single_mandatory_json() {
-    # marketplace source "./" (single signal) + root plugin.json manifest
+    # marketplace source "./" (single signal) + root plugin.json manifest.
+    # $schema + description + the object plugin's homepage satisfy R6/R7 (#1084)
+    # so a fully-standard single repo scores PASS.
     mkdir -p "$1/.claude-plugin"
-    printf '{ "name": "repo", "plugins": [{ "source": "./" }] }\n' \
+    printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "repo", "description": "demo marketplace", "plugins": [{ "source": "./", "homepage": "https://example.com/repo" }] }\n' \
         > "$1/.claude-plugin/marketplace.json"
     printf '{ "name": "repo", "version": "0.0.0", "skills": ["./skills/visualize"] }\n' \
         > "$1/.claude-plugin/plugin.json"
@@ -423,8 +427,9 @@ build_single_perfect() {
 
 @test "forced --single honored even when marketplace says mono" {
     build_single_perfect "$REPO"
-    # corrupt the signal: claim mono in marketplace, but force single
-    printf '{ "name": "repo", "plugins": [{ "source": "./plugins/x" }] }\n' \
+    # corrupt the signal: claim mono in marketplace, but force single ($schema/
+    # description/homepage kept so R6/R7 stay PASS — this test isolates mode).
+    printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "repo", "description": "demo", "plugins": [{ "source": "./plugins/x", "homepage": "https://example.com/x" }] }\n' \
         > "$REPO/.claude-plugin/marketplace.json"
     run _cps_detect_mode "$REPO" single; assert_output single
     run cps_verdict "$REPO" single; assert_output PASS
@@ -448,7 +453,7 @@ build_single_perfect() {
     _seed_single_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
     _seed_recommended_files "$REPO"; _seed_readme_links "$REPO" visualize
     mkdir -p "$REPO/.claude-plugin"   # single signal, root plugin.json missing
-    printf '{ "name": "repo", "plugins": [{ "source": "./" }] }\n' \
+    printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "repo", "description": "demo", "plugins": [{ "source": "./", "homepage": "https://example.com/repo" }] }\n' \
         > "$REPO/.claude-plugin/marketplace.json"
     run cps_check_M2 "$REPO"; assert_output FAIL     # 0 plugin roots yet
     run cps_verdict "$REPO"; assert_output FAIL
@@ -527,5 +532,175 @@ build_single_perfect() {
     [ "$status" -eq 0 ]
     run cps_check_M1 "$REPO"; assert_output PASS
     run cps_check_M3 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+# ---- M7 plugins[].source presence (#1084 / claude-plugin-jira#61) --------
+
+@test "M7 FAIL: plugin object lacks its own source (#61 install-fail shape)" {
+    # #61 root cause: plugins[] object relied on the inherited top-level source,
+    # which Claude Code 2.1.198 does not honor at install time.
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "source": { "source": "url", "url": "https://x/y.git" }, "plugins": [{ "name": "demo" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M7 "$REPO"; assert_output FAIL
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+@test "M7 PASS: string-form plugin element is the source (shorthand)" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_M7 "$REPO"; assert_output PASS
+}
+
+@test "M7 PASS: object plugin with its own git-URL source (#61 post-fix / #63)" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "name": "demo", "source": "url", "url": "https://x/y.git" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M7 "$REPO"; assert_output PASS
+    run cps_check_M8 "$REPO"; assert_output PASS
+}
+
+@test "M7 N/A when marketplace lists 0 plugins (M2 owns the FAIL)" {
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [] }\n' > "$REPO/.claude-plugin/marketplace.json"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_M7 "$REPO"; assert_output "N/A"
+    run cps_check_M8 "$REPO"; assert_output "N/A"
+}
+
+@test "M7 FAIL -> refactor mp apply injects source -> M7 PASS (auto-fix)" {
+    # AC: structure-refactor --apply fixes M7 FAIL by inserting a source field.
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    _seed_recommended_files "$REPO"; _seed_readme_links "$REPO" visualize
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "description": "d", "$schema": "s", "plugins": [{ "name": "demo" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M7 "$REPO"; assert_output FAIL
+    cps_refactor "$REPO" mp apply
+    run cps_check_M7 "$REPO"; assert_output PASS
+    run cps_check_M8 "$REPO"; assert_output PASS    # injected ./plugins/demo is a valid shape
+    run cps_check_M9 "$REPO"; assert_output PASS    # plugins/demo/ exists on disk
+    run jq -e '.plugins[0].source' "$REPO/.claude-plugin/marketplace.json"; assert_success
+}
+
+@test "M7 auto-fix derives git-URL source from plugin homepage (…​.git)" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "name": "demo", "homepage": "https://x/y.git" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    cps_refactor "$REPO" mp apply
+    run jq -r '.plugins[0].source' "$REPO/.claude-plugin/marketplace.json"; assert_output "url"
+    run jq -r '.plugins[0].url' "$REPO/.claude-plugin/marketplace.json"; assert_output "https://x/y.git"
+    run cps_check_M7 "$REPO"; assert_output PASS
+    run cps_check_M8 "$REPO"; assert_output PASS
+}
+
+# ---- M8 plugins[].source shape validity (#1084) --------------------------
+
+@test "M8 FAIL: object source is a raw URL without the url-type shape" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    # .source is a raw https URL string — neither a local path nor the
+    # { source:"url", url:... } shape → invalid.
+    printf '{ "name": "repo", "plugins": [{ "source": "https://x/y.git" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M7 "$REPO"; assert_output PASS     # source key present
+    run cps_check_M8 "$REPO"; assert_output FAIL     # but shape invalid
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+@test "M8 PASS: bare './' single source and bare './plugins/x' mono source" {
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": ["./plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M8 "$REPO"; assert_output PASS
+}
+
+# ---- M9 pluginRoot ↔ on-disk consistency (mono only, #1084) --------------
+
+@test "M9 FAIL: mono marketplace declares a plugin dir that is absent" {
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin" "$REPO/plugins/demo"   # 'ghost' declared, not present
+    printf '{ "name": "repo", "plugins": ["./plugins/demo", "./plugins/ghost"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M9 "$REPO"; assert_output FAIL
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+@test "M9 PASS: every declared mono plugin dir exists on disk" {
+    build_perfect "$REPO"
+    run cps_check_M9 "$REPO"; assert_output PASS
+}
+
+@test "M9 N/A in single mode (no plugins/ layout)" {
+    build_single_perfect "$REPO"
+    run cps_check_M9 "$REPO"; assert_output "N/A"
+}
+
+@test "M9 N/A for a mono repo whose sources are all remote git URLs (#63)" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "name": "demo", "source": "url", "url": "https://x/y.git" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M9 "$REPO"; assert_output "N/A"    # nothing local to verify
+}
+
+# ---- R6 $schema / R7 description+homepage / R8 add-URL hint (#1084) -------
+
+@test "R6 WARN when marketplace omits top-level \$schema" {
+    build_perfect "$REPO"                      # everything else clean
+    printf '{ "name": "repo", "description": "d", "plugins": ["./plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"   # drop $schema only
+    run cps_check_R6 "$REPO"; assert_output WARN
+    run cps_verdict "$REPO"; assert_output WARN
+}
+
+@test "R6 PASS when \$schema is declared" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R6 "$REPO"; assert_output PASS
+}
+
+@test "R7 WARN when top-level description is missing" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "$schema": "s", "name": "repo", "plugins": ["./plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_R7 "$REPO"; assert_output WARN
+}
+
+@test "R7 WARN when an object plugin lacks homepage" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "$schema": "s", "name": "repo", "description": "d", "plugins": [{ "source": "./plugins/demo" }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_R7 "$REPO"; assert_output WARN
+}
+
+@test "R7 PASS with description and (string plugins have no homepage req)" {
+    _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_R7 "$REPO"; assert_output PASS
+}
+
+@test "R8 N/A when README has no /plugin marketplace add example" {
+    build_perfect "$REPO"
+    run cps_check_R8 "$REPO"; assert_output "N/A"
+}
+
+@test "R8 WARN when the add example uses a .git clone URL" {
+    build_perfect "$REPO"
+    printf '\n`/plugin marketplace add https://github.com/o/repo.git`\n' >> "$REPO/README.md"
+    run cps_check_R8 "$REPO"; assert_output WARN
+    run cps_verdict "$REPO"; assert_output WARN
+}
+
+@test "R8 PASS when the add example uses the raw marketplace.json URL" {
+    build_perfect "$REPO"
+    printf '\n`/plugin marketplace add https://raw.githubusercontent.com/o/repo/main/.claude-plugin/marketplace.json`\n' >> "$REPO/README.md"
+    run cps_check_R8 "$REPO"; assert_output PASS
     run cps_verdict "$REPO"; assert_output PASS
 }

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -640,6 +640,22 @@ build_single_perfect() {
     run cps_check_M8 "$REPO"; assert_output FAIL
 }
 
+@test "M8 FAIL: nested mono path ./plugins/foo/bar is not a valid source (codex review)" {
+    # mono sources are plugins/<name> — exactly one segment. A nested path must
+    # not pass the prefix check.
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": ["./plugins/foo/bar"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M8 "$REPO"; assert_output FAIL
+}
+
+@test "M8 PASS: trailing-slash single-segment mono path ./plugins/demo/" {
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": ["./plugins/demo/"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M8 "$REPO"; assert_output PASS
+}
+
 # ---- M9 pluginRoot ↔ on-disk consistency (mono only, #1084) --------------
 
 @test "M9 FAIL: mono marketplace declares a plugin dir that is absent" {
@@ -653,6 +669,16 @@ build_single_perfect() {
 
 @test "M9 PASS: every declared mono plugin dir exists on disk" {
     build_perfect "$REPO"
+    run cps_check_M9 "$REPO"; assert_output PASS
+}
+
+@test "M9 checks the EXACT declared path, not basename (codex review)" {
+    # A bare 'plugins/demo' (no leading ./) must be checked at plugins/demo,
+    # not mis-derived. Present → PASS.
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin" "$REPO/plugins/demo"
+    printf '{ "name": "repo", "plugins": ["plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
     run cps_check_M9 "$REPO"; assert_output PASS
 }
 

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # tests/bats/skills/claude_plugin_structure.bats
 # Verify the structure spec shared by
-#   claude/skills/claude-plugin-structure-check/   (M1-M9 / R1-R8 evaluation)
+#   claude/skills/claude-plugin-structure-check/   (M1-M10 / R1-R8 evaluation)
 #   claude/skills/claude-plugin-structure-refactor/ (dry-run / --apply / --op)
 # Source-of-truth fixture: _fixtures/claude_plugin_structure.sh
 #
@@ -40,7 +40,7 @@ _seed_mandatory_json() {
     mkdir -p "$1/.claude-plugin" "$1/plugins/demo/.claude-plugin"
     printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "repo", "description": "demo marketplace", "plugins": ["./plugins/demo"] }\n' \
         > "$1/.claude-plugin/marketplace.json"
-    printf '{ "name": "demo", "version": "0.0.0", "skills": ["./skills/visualize"] }\n' \
+    printf '{ "name": "demo", "version": "0.0.0" }\n' \
         > "$1/plugins/demo/.claude-plugin/plugin.json"
 }
 
@@ -305,14 +305,17 @@ build_perfect() {
     assert_success
 }
 
-@test "mandatory apply lists ALL skills in plugin.json" {
+@test "mandatory apply writes a plugin.json WITHOUT a skills field (M10, #1084)" {
+    # skills are auto-scanned; a skills field fails manifest validation. The
+    # skeleton must never write one (superseding the old "lists ALL skills").
     mkdir -p "$REPO/plugins/demo/skills/s1" "$REPO/plugins/demo/skills/s2"
     printf 'name: s1\ndescription: x\n' > "$REPO/plugins/demo/skills/s1/SKILL.md"
     printf 'name: s2\ndescription: x\n' > "$REPO/plugins/demo/skills/s2/SKILL.md"
     _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
     cps_refactor "$REPO" mp apply
-    run jq -r '.skills | length' "$REPO/plugins/demo/.claude-plugin/plugin.json"
-    assert_output 2
+    run jq -e 'has("skills")' "$REPO/plugins/demo/.claude-plugin/plugin.json"
+    assert_output false
+    run cps_check_M10 "$REPO"; assert_output PASS
 }
 
 # ---- single layout mode (#914) ------------------------------------------
@@ -333,7 +336,7 @@ _seed_single_mandatory_json() {
     mkdir -p "$1/.claude-plugin"
     printf '{ "$schema": "https://anthropic.com/claude-code/marketplace.schema.json", "name": "repo", "description": "demo marketplace", "plugins": [{ "source": "./", "homepage": "https://example.com/repo" }] }\n' \
         > "$1/.claude-plugin/marketplace.json"
-    printf '{ "name": "repo", "version": "0.0.0", "skills": ["./skills/visualize"] }\n' \
+    printf '{ "name": "repo", "version": "0.0.0" }\n' \
         > "$1/.claude-plugin/plugin.json"
 }
 
@@ -472,8 +475,9 @@ build_single_perfect() {
     run jq empty "$REPO/.claude-plugin/plugin.json"; assert_success
     run jq -r '.plugins[0].source' "$REPO/.claude-plugin/marketplace.json"
     assert_output "./"
-    run jq -e '.skills | index("./skills/visualize")' "$REPO/.claude-plugin/plugin.json"
-    assert_success
+    run jq -e 'has("skills")' "$REPO/.claude-plugin/plugin.json"   # no skills field (M10)
+    assert_output false
+    run cps_check_M10 "$REPO"; assert_output PASS
     [ ! -d "$REPO/plugins" ]
 }
 
@@ -663,6 +667,73 @@ build_single_perfect() {
     printf '{ "name": "repo", "plugins": [{ "name": "demo", "source": "url", "url": "https://x/y.git" }] }\n' \
         > "$REPO/.claude-plugin/marketplace.json"
     run cps_check_M9 "$REPO"; assert_output "N/A"    # nothing local to verify
+}
+
+# ---- M10 plugin.json known-field whitelist (#1084 / claude-plugin-jira#65) --
+
+_seed_plugin_json() {
+    # $1=repo $2=raw-json : overwrite plugins/demo/.claude-plugin/plugin.json
+    mkdir -p "$1/plugins/demo/.claude-plugin"
+    printf '%s\n' "$2" > "$1/plugins/demo/.claude-plugin/plugin.json"
+}
+
+@test "M10 FAIL: plugin.json carries a schema-violating skills field (jira@0.2.0)" {
+    # claude-plugin-jira#65 repro: install succeeds but the manifest fails
+    # validation at load ("skills: Invalid input") → 0 skills load.
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": ["./plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    _seed_plugin_json "$REPO" '{ "name": "jira", "version": "0.2.0", "skills": ["skills/jira-core"] }'
+    run cps_check_M10 "$REPO"; assert_output FAIL
+    run cps_check_M3 "$REPO"; assert_output PASS      # JSON is valid — M3 doesn't catch it
+    run cps_verdict "$REPO"; assert_output FAIL
+}
+
+@test "M10 PASS: plugin.json with only known manifest fields" {
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": ["./plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    _seed_plugin_json "$REPO" '{ "name": "demo", "version": "0.2.0", "description": "d", "homepage": "https://x", "keywords": ["a"] }'
+    run cps_check_M10 "$REPO"; assert_output PASS
+}
+
+@test "M10 PASS on the perfect fixture (skeleton is schema-clean)" {
+    build_perfect "$REPO"
+    run cps_check_M10 "$REPO"; assert_output PASS
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "M10 N/A when no plugin root has a valid manifest (M3 owns it)" {
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [] }\n' > "$REPO/.claude-plugin/marketplace.json"
+    _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    run cps_check_M10 "$REPO"; assert_output "N/A"
+}
+
+@test "M10 FAIL -> refactor mp apply strips unknown field + leaves .bak -> M10 PASS" {
+    # AC: structure-refactor --apply fixes M10 (remove unknown field, keep backup).
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    _seed_recommended_files "$REPO"; _seed_readme_links "$REPO" visualize
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "$schema": "s", "name": "repo", "description": "d", "plugins": ["./plugins/demo"] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    _seed_plugin_json "$REPO" '{ "name": "demo", "version": "0.2.0", "skills": ["skills/x"] }'
+    run cps_check_M10 "$REPO"; assert_output FAIL
+    cps_refactor "$REPO" mp apply
+    run cps_check_M10 "$REPO"; assert_output PASS
+    run jq -e 'has("skills")' "$REPO/plugins/demo/.claude-plugin/plugin.json"; assert_output false
+    run jq -r '.name' "$REPO/plugins/demo/.claude-plugin/plugin.json"; assert_output demo
+    [ -f "$REPO/plugins/demo/.claude-plugin/plugin.json.bak" ]        # backup kept
+    run jq -e 'has("skills")' "$REPO/plugins/demo/.claude-plugin/plugin.json.bak"; assert_output true
+    run cps_verdict "$REPO"; assert_output PASS
+}
+
+@test "M10 refactor is a no-op on a clean manifest (no .bak spam)" {
+    build_perfect "$REPO"
+    cps_refactor "$REPO" mp apply
+    [ ! -f "$REPO/plugins/demo/.claude-plugin/plugin.json.bak" ]
 }
 
 # ---- R6 $schema / R7 description+homepage / R8 add-URL hint (#1084) -------

--- a/tests/bats/skills/claude_plugin_structure.bats
+++ b/tests/bats/skills/claude_plugin_structure.bats
@@ -619,6 +619,23 @@ build_single_perfect() {
     run cps_check_M8 "$REPO"; assert_output PASS
 }
 
+@test "M8 FAIL: explicit null source is not skipped (#1085 gemini review)" {
+    # M7 passes (the "source" key exists) but the value is null → M8 must FAIL,
+    # not silently skip it as a missing-source (M7) case.
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [{ "name": "demo", "source": null }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M7 "$REPO"; assert_output PASS
+    run cps_check_M8 "$REPO"; assert_output FAIL
+}
+
+@test "M8 FAIL: a null plugin element is collected, not skipped (#1085)" {
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "name": "repo", "plugins": [null] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_M8 "$REPO"; assert_output FAIL
+}
+
 # ---- M9 pluginRoot ↔ on-disk consistency (mono only, #1084) --------------
 
 @test "M9 FAIL: mono marketplace declares a plugin dir that is absent" {
@@ -684,6 +701,16 @@ build_single_perfect() {
     _seed_skill "$REPO"; _seed_mandatory_json "$REPO"
     _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
     run cps_check_R7 "$REPO"; assert_output PASS
+}
+
+@test "R7 WARN when metadata is a non-string type (no jq crash → false PASS) (#1085)" {
+    # boolean/number description or homepage must not crash jq and slip through
+    # the `|| echo 0` fallback as a PASS — the type guard makes them WARN.
+    _seed_skill "$REPO"; _seed_docs_dirs "$REPO"; _seed_readme "$REPO"
+    mkdir -p "$REPO/.claude-plugin"
+    printf '{ "$schema": "s", "name": "repo", "description": true, "plugins": [{ "source": "./plugins/demo", "homepage": 42 }] }\n' \
+        > "$REPO/.claude-plugin/marketplace.json"
+    run cps_check_R7 "$REPO"; assert_output WARN
 }
 
 @test "R8 N/A when README has no /plugin marketplace add example" {


### PR DESCRIPTION
## Summary
- `claude-plugin:structure-check` 에 marketplace `plugins[].source` install-integrity 검증 M7-M9 (FAIL) + 리스팅 품질 권장 R6-R8 (WARN) 추가
- `structure-check` 가 M6 까지 PASS 여도 `/plugin install` 이 실패/세션 미로딩 되던 커버리지 갭을 사전 차단 (claude-plugin-jira#61/#63 실증 기반)
- `structure-refactor --apply` 가 M7 FAIL 을 자동 수정하고, 리포트 하단에 "구조 감사 ≠ install/runtime 성공" 주석을 상시 부착

## Changes
- **M7 (FAIL)**: 각 `plugins[]` 요소가 자기 `source` 를 가짐 — object 가 `source` 누락 시 #61 install-fail shape (상위 `source` 는 CC 2.1.198 install 단계에서 상속되지 않음)
- **M8 (FAIL)**: `source` shape 유효성 — 로컬 경로 | `{ source:"url", url:… }` git-URL. mode-shape 조합 자체는 FAIL 로 잡지 않아 remote-source mono 오진(#63) 방지
- **M9 (FAIL)**: mono 모드에서 선언된 `./plugins/<name>/` 실 디렉토리 정합 (remote url source 는 skip → N/A, single 모드 N/A)
- **R6/R7/R8 (WARN)**: `$schema` 선언 / `description`+object plugin `homepage` / README `/plugin marketplace add` 는 raw marketplace.json URL 선호(.git → WARN)
- **structure-refactor**: 기존 marketplace 의 object plugin 이 `source` 누락 시 자동 주입 (homepage/repository `.git` → git-URL, 아니면 모드별 로컬 경로), mandatory 스코프
- **문서 동기화**: 양쪽 skill 의 structure-spec(2부)/evaluation-rules/report-template/help/SKILL.md + refactor plan·op-rules + sibling `claude-plugin:create` 범위 표기(M1-M6→M1-M9, R1-R5→R1-R8)
- **테스트(SSOT)**: bats fixture 에 M7-M9/R6-R8 체크·verdict·refactor 자동수정 구현 + 20개 신규 테스트 (총 67/67 PASS, #61 pre/post-fix 재현 포함)

## Test plan
- [x] `bats tests/bats/skills/claude_plugin_structure.bats` → 67/67 PASS
- [x] `shfmt -d -i 4` fixture clean · golden rules 전부 PASS · pytest 1145 PASS
- [x] #61 pre-fix(source 없음) → M7 FAIL, post-fix(source 있음) → M7 PASS 재현
- [x] `structure-refactor --apply` 가 M7 FAIL 자동 수정(source 주입) 검증

## Related
Closes #1084

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
