### PR TITLE
fix(claude-setup): SSOT↔live settings.json .hooks drift 를 SessionStart hook 으로 경고 (#1086)

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -87,6 +87,8 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 `claude/hooks/session-start-pc-context.sh` — `SessionStart` hook, `settings.json`에 등록됨. `~/.dotfiles-setup-mode` + hostname을 매 세션 시작마다 `additionalContext`로 주입해 5대 PC 혼동을 방지한다(#1052). 모드 파일이 없으면 조용히 빈 컨텍스트를 반환하고 세션 시작을 막지 않는다.
 
+`claude/hooks/session-start-settings-drift.sh` — `SessionStart` hook, `settings.json`에 등록됨. 모든 모드에서 live `settings.json`은 SSOT의 **실파일**이라 SSOT에 훅을 추가/변경한 커밋 이후 `./setup.sh`(internal: `./aws/setup.sh`) 재실행 전까지 새 훅이 발화하지 않는다(#1086). 이 훅은 SSOT(`claude/settings.json`, 스크립트 경로 기준 상대 해석)와 live(`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`)의 `.hooks` 필드만 jq로 비교해 drift 감지 시 stderr + `additionalContext`로 재시드를 안내한다. Bedrock 오버레이는 `.hooks`를 건드리지 않아 오탐이 없다. 자기 자신의 최초 미설치는 감지 못하지만(체크인 후 1회 재시드 필요) 이후 추가되는 모든 훅은 커버한다. best-effort, 항상 exit 0.
+
 ---
 
 ## Plugin Manifest (claude/plugin/)

--- a/claude/hooks/session-start-settings-drift.sh
+++ b/claude/hooks/session-start-settings-drift.sh
@@ -36,7 +36,7 @@ input=$(cat 2>/dev/null) || exit 0
 [ -n "$input" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-event=$(printf '%s' "$input" | jq -r '.hook_event_name // ""') || exit 0
+event=$(printf '%s' "$input" | jq -r '.hook_event_name // ""' 2>/dev/null) || exit 0
 [ "$event" = "SessionStart" ] || exit 0
 
 # SSOT resolves relative to this script (…/claude/hooks/x.sh → …/claude), so a

--- a/claude/hooks/session-start-settings-drift.sh
+++ b/claude/hooks/session-start-settings-drift.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# claude/hooks/session-start-settings-drift.sh
+#
+# Claude Code SessionStart hook: warn when the live ~/.claude*/settings.json
+# `.hooks` block has drifted from the dotfiles SSOT (claude/settings.json).
+#
+# Why (#1086): in every mode the live settings.json is a REAL FILE, not a
+# symlink — multi-account copies the SSOT (#940), internal deep-merges
+# SSOT + Bedrock overlay (#687). So a commit that adds or changes a hook in
+# the SSOT does NOT reach the live file until `./setup.sh` (internal:
+# `./aws/setup.sh`) is re-run. A user who only `git pull`s + restarts Claude
+# Code starts sessions with the OLD hook set, so new hooks silently never
+# fire — the concrete failure mode that hid plugin-sync-session.sh for ~1h.
+# This hook makes that drift loud instead of silent.
+#
+# Compares ONLY the `.hooks` field: the Bedrock overlay touches
+# env / model / availableModels but never `.hooks`, so after a re-seed the
+# two `.hooks` blocks are byte-identical — any difference means the live file
+# is stale (or hand-edited, which also warrants a heads-up).
+#
+# Inherent limit: this detector can only fire once it is itself present in the
+# live file, so it cannot warn about its own first install — but every hook
+# added AFTER it is covered, which is the recurring pattern (#1086).
+#
+# Best-effort: always exits 0, never blocks the session. jq missing, either
+# file absent, or malformed JSON → silent no-op.
+#
+# Reference: issue #1086. Sibling SessionStart hooks:
+# session-start-pc-context.sh (#1052), plugin-sync-session.sh (#1082).
+set -u
+
+# A hook always receives JSON on stdin; a terminal means it was launched by
+# hand — bail before `cat` blocks forever.
+[ -t 0 ] && exit 0
+input=$(cat 2>/dev/null) || exit 0
+[ -n "$input" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+event=$(printf '%s' "$input" | jq -r '.hook_event_name // ""') || exit 0
+[ "$event" = "SessionStart" ] || exit 0
+
+# SSOT resolves relative to this script (…/claude/hooks/x.sh → …/claude), so a
+# non-standard dotfiles checkout path still works. $0 is absolute (the hook is
+# registered with an absolute command path), so the literal `..` in the path
+# resolves fine for `[ -f ]`/jq without needing cd+pwd. LIVE follows the same
+# ${CLAUDE_CONFIG_DIR:-$HOME/.claude} convention as statusline-command.sh.
+_hook_dir=$(dirname -- "$0")
+SSOT="$_hook_dir/../settings.json"
+LIVE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+
+[ -f "$SSOT" ] || exit 0
+[ -f "$LIVE" ] || exit 0
+
+ssot_hooks=$(jq -S -c '.hooks // {}' "$SSOT" 2>/dev/null) || exit 0
+live_hooks=$(jq -S -c '.hooks // {}' "$LIVE" 2>/dev/null) || exit 0
+
+[ "$ssot_hooks" = "$live_hooks" ] && exit 0
+
+# --- Drift detected ---
+# Point the user at the right re-seed entry point for their mode (internal PC
+# seeds via aws/setup.sh's Bedrock merge; everyone else via ./setup.sh).
+_reseed="./setup.sh"
+if [ -f "$HOME/.dotfiles-setup-mode" ]; then
+	_raw=$(tr -d ' \t\n\r' <"$HOME/.dotfiles-setup-mode" 2>/dev/null)
+	case "$_raw" in
+	2 | internal) _reseed="./aws/setup.sh" ;;
+	esac
+fi
+
+_msg="[dotfiles #1086] Claude settings.json hook drift: the live config (${LIVE}) .hooks block differs from the dotfiles SSOT (claude/settings.json). New or changed hooks will NOT fire until you re-seed the live file — run ${_reseed} in your dotfiles checkout, then restart Claude Code."
+
+printf '%s\n' "$_msg" >&2
+jq -n --arg ctx "$_msg" \
+	'{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$ctx}}'
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -13,6 +13,10 @@
           {
             "type": "command",
             "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-settings-drift.sh"
           }
         ]
       }

--- a/tests/bats/skills/session_start_settings_drift_hook.bats
+++ b/tests/bats/skills/session_start_settings_drift_hook.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# tests/bats/skills/session_start_settings_drift_hook.bats
+# Verify the SessionStart hook documented in
+#   claude/hooks/session-start-settings-drift.sh (issue #1086)
+#
+# The hook compares the `.hooks` block of the dotfiles SSOT
+# (claude/settings.json, resolved relative to the hook's own dir) against the
+# live ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json and warns on drift.
+#
+# Cases:
+#   1. non-SessionStart event   → exit 0, silent
+#   2. empty stdin              → exit 0, silent
+#   3. .hooks identical         → exit 0, silent (no drift)
+#   4. live missing a hook      → exit 0, drift warning (stderr + additionalContext)
+#   5. live file absent         → exit 0, silent
+#   6. internal mode            → drift message points at ./aws/setup.sh
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    command -v jq >/dev/null 2>&1 || skip "jq not available"
+
+    # Isolated dotfiles/claude tree so SSOT (…/claude/settings.json, resolved
+    # relative to the hook) is fully under test control.
+    ISO_CLAUDE="$TEST_TEMP_HOME/iso/claude"
+    mkdir -p "$ISO_CLAUDE/hooks"
+    cp "${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/session-start-settings-drift.sh" \
+        "$ISO_CLAUDE/hooks/session-start-settings-drift.sh"
+    HOOK="$ISO_CLAUDE/hooks/session-start-settings-drift.sh"
+
+    # SSOT with a two-hook SessionStart block.
+    SSOT="$ISO_CLAUDE/settings.json"
+    cat >"$SSOT" <<'JSON'
+{ "hooks": { "SessionStart": [ { "hooks": [
+  { "type": "command", "command": "a.sh" },
+  { "type": "command", "command": "b.sh" }
+] } ] } }
+JSON
+
+    # Live config dir (CLAUDE_CONFIG_DIR override).
+    LIVE_DIR="$TEST_TEMP_HOME/live"
+    mkdir -p "$LIVE_DIR"
+    export CLAUDE_CONFIG_DIR="$LIVE_DIR"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Feed a SessionStart payload (or the given event) to the hook on stdin.
+# stderr is redirected to a file so $output holds only the stdout JSON
+# (bats otherwise merges the two, corrupting the JSON parse).
+_run_hook() {
+    local event="${1:-SessionStart}"
+    run bash -c "printf '{\"hook_event_name\":\"%s\"}' '$event' | '$HOOK' 2>'$TEST_TEMP_HOME/stderr'"
+    STDERR_CONTENT=$(cat "$TEST_TEMP_HOME/stderr" 2>/dev/null)
+}
+
+@test "settings-drift: non-SessionStart event → silent, exit 0" {
+    cp "$SSOT" "$LIVE_DIR/settings.json"
+    _run_hook "Stop"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "settings-drift: empty stdin → silent, exit 0" {
+    cp "$SSOT" "$LIVE_DIR/settings.json"
+    run bash -c "printf '' | '$HOOK'"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "settings-drift: identical .hooks → no drift, silent exit 0" {
+    cp "$SSOT" "$LIVE_DIR/settings.json"
+    _run_hook
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "settings-drift: live missing a hook → drift warning" {
+    cat >"$LIVE_DIR/settings.json" <<'JSON'
+{ "hooks": { "SessionStart": [ { "hooks": [
+  { "type": "command", "command": "a.sh" }
+] } ] } }
+JSON
+    _run_hook
+    assert_success
+    assert_output --partial '"hookEventName": "SessionStart"'
+    assert_output --partial 'hook drift'
+    [[ "$STDERR_CONTENT" == *"hook drift"* ]]
+
+    ctx=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    [[ "$ctx" == *"./setup.sh"* ]]
+}
+
+@test "settings-drift: overlay-style extra top-level key is ignored (only .hooks compared)" {
+    # Live has identical .hooks but an extra Bedrock-overlay-style key —
+    # must NOT be flagged as drift.
+    cat >"$LIVE_DIR/settings.json" <<'JSON'
+{ "model": "global.anthropic.claude-opus-4-7",
+  "hooks": { "SessionStart": [ { "hooks": [
+  { "type": "command", "command": "a.sh" },
+  { "type": "command", "command": "b.sh" }
+] } ] } }
+JSON
+    _run_hook
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "settings-drift: live settings.json absent → silent, exit 0" {
+    _run_hook
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "settings-drift: internal mode → message points at ./aws/setup.sh" {
+    printf 'internal' >"$HOME/.dotfiles-setup-mode"
+    cat >"$LIVE_DIR/settings.json" <<'JSON'
+{ "hooks": { "SessionStart": [ { "hooks": [
+  { "type": "command", "command": "a.sh" }
+] } ] } }
+JSON
+    _run_hook
+    assert_success
+    ctx=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    [[ "$ctx" == *"./aws/setup.sh"* ]]
+}


### PR DESCRIPTION
## 배경

모든 setup 모드에서 live `~/.claude*/settings.json` 은 dotfiles SSOT
(`claude/settings.json`) 의 **실파일**이다 — 멀티계정은 복사 (#940),
internal 은 SSOT + Bedrock overlay 를 jq deep-merge (#687). symlink 가 아니다.

그래서 SSOT 에 훅을 추가/변경한 커밋을 머지해도, `./setup.sh` (internal:
`./aws/setup.sh`) 를 재실행하기 전까지 새 훅이 live 파일에 반영되지 않는다.
사용자가 `git pull` + Claude Code 재시작만 하면 **새 훅이 조용히 미발화**한다.
`plugin-sync-session.sh` 가 ~1시간 숨어 있던 근본 원인 (#1086 본문의 15:46~16:50
케이스).

## 변경

이슈 제안 **(b)** 채택 — 저자 판단대로 "알림만으로 충분":

- **신규** `claude/hooks/session-start-settings-drift.sh` (SessionStart hook)
  - SSOT (스크립트 경로 기준 상대 해석) 와 live
    (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`) 의 `.hooks` 필드만
    `jq -S` 로 비교
  - drift 감지 시 stderr + `additionalContext` 로 재시드 안내 (mode-file 로
    internal 은 `./aws/setup.sh`, 그 외 `./setup.sh`)
  - `.hooks` 만 비교 → Bedrock overlay (env/model/availableModels) 는
    `.hooks` 를 건드리지 않으므로 **오탐 없음**
  - best-effort: jq 부재 / 파일 부재 / malformed JSON → 조용히 no-op, 항상 exit 0
- `claude/settings.json` — SessionStart 배열에 등록 (기존 pc-context /
  plugin-sync-session 다음)
- `claude/AGENTS.md` — Configuration Files 섹션에 훅 문서화
- `tests/bats/skills/session_start_settings_drift_hook.bats` — 7 케이스

## 알려진 한계 (의도적)

이 감지기는 **자기 자신이 live 에 등록된 후에만** 발화하므로, 자신의 최초
미설치는 감지 못한다 (체크인 후 1회 재시드 필요). 그러나 그 이후 추가되는
**모든** 훅은 커버한다 — 반복되는 실패 패턴이 바로 그것이므로 실용적으로 충분.

대안 (a) live 를 symlink 화 / (c) post-merge git hook 은 각각 Bedrock overlay
실파일 요구 / clone 마다 설치 필요 (chicken-egg) 때문에 이번 스코프에서 제외.

## 검증

- 신규 bats 7/7 green (non-SessionStart / 빈 stdin / 동일 .hooks / live 누락
  drift / overlay 스타일 top-level key 무시 / live 부재 / internal 모드 메시지)
- 신규 hook `shellcheck` + `shfmt -d` clean, POSIX (`[ ]` only)
- 실 SSOT 대상 end-to-end 수동 확인: drift → 경고(exit 0), no-drift → silent(exit 0)

## Acceptance Criteria

- [x] SessionStart 시 SSOT↔live `.hooks` drift 감지
- [x] drift 시 재시드 안내 (mode-aware: `./setup.sh` / `./aws/setup.sh`)
- [x] Bedrock overlay 로 인한 오탐 없음 (`.hooks` 만 비교)
- [x] best-effort — 세션 시작을 절대 막지 않음 (항상 exit 0)
- [x] `claude/settings.json` 등록 + `claude/AGENTS.md` 문서화
- [x] bats 커버리지 + shellcheck/shfmt clean

Closes #1086
