### PR TITLE
fix(aws/setup): SSOT hooks 가 재실행 시 ~/.claude/settings.json 에 반영되도록 수정 (#1088)

### DIFF
--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -177,6 +177,14 @@ _merge_claude_settings_json() {
     # Deep merge: base * overlay * (existing - legacy gateway keys).
     # 사용자 편집이 가장 우선 — 사내 PC 에서 ~/.claude/settings.json 을 직접
     # 손대지 않는 게 정상이지만, 손댄 경우 보존된다. _comment 는 머지에서 항상 제거.
+    #
+    # SSOT-우선 필드 (#1088): jq 의 `*` 는 오브젝트만 재귀 병합하고 배열은 RHS
+    # 로 대체한다. hooks.SessionStart 등은 배열이므로 existing (구값) 이 base
+    # (신값) 를 영구히 덮어써 SSOT 갱신이 절대 반영되지 않았다. hooks /
+    # statusLine (base 소유) 와 availableModels / modelOverrides (overlay 소유)
+    # 는 "SSOT 가 진실" 인 필드이므로 existing 에서 제거한 뒤 base/overlay 값이
+    # 그대로 살아나게 한다. model 등 사용자가 /model 로 바꾸는 필드는 화이트
+    # 리스트에 없으므로 그대로 existing 이 보존된다.
     _tmp_merged=$(mktemp)
     if jq -s '
         def _strip_gateway:
@@ -193,7 +201,8 @@ _merge_claude_settings_json() {
         (.[0])                          as $base
         | (.[1] | del(._comment?))      as $overlay
         | (.[2] | _strip_gateway)       as $existing
-        | $base * $overlay * $existing
+        | $base * $overlay
+            * ($existing | del(.hooks, .statusLine, .availableModels, .modelOverrides))
     ' "$_base" "$_overlay" "$_tgt" > "$_tmp_merged"; then
         if cmp -s "$_tgt" "$_tmp_merged"; then
             rm -f "$_tmp_merged"

--- a/tests/bats/setup/aws_merge_claude_settings.bats
+++ b/tests/bats/setup/aws_merge_claude_settings.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/bats/setup/aws_merge_claude_settings.bats
+# Regression guard for aws/setup.sh → _merge_claude_settings_json() (issue #1088).
+#
+# Bug (#1088): the deep-merge `base * overlay * existing` let the live real file
+# (existing) win on EVERY field. jq's `*` recurses objects but REPLACES arrays
+# with the RHS, so a stale `existing.hooks.SessionStart` array permanently
+# clobbered the SSOT `base.hooks.SessionStart` — new hooks added to the SSOT
+# never propagated to already-set-up PCs.
+#
+# Fix: SSOT-owned fields (hooks / statusLine from base, availableModels /
+# modelOverrides from overlay) are del'd from `existing` before the merge so the
+# SSOT values survive. User-owned fields (model, custom keys) stay preserved.
+#
+# The real function is extracted from aws/setup.sh at test time (the script has
+# no source guard and `exit 0`s for non-internal mode, so it can't be sourced
+# wholesale) and run against isolated fixtures with ux_* stubbed to no-ops.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    command -v jq >/dev/null 2>&1 || skip "jq not available"
+
+    # Extract just _merge_claude_settings_json() from the real script, source
+    # it, and stub the ux_* helpers it calls. This tests the SHIPPED jq program,
+    # not a copy — any drift in the merge logic breaks this test.
+    local fn_file="$TEST_TEMP_HOME/merge_fn.sh"
+    awk '/^_merge_claude_settings_json\(\) \{/{grab=1} grab{print} /^}/{if(grab)exit}' \
+        "${_BATS_REAL_DOTFILES_ROOT}/aws/setup.sh" >"$fn_file"
+    # shellcheck disable=SC1090
+    ux_success() { :; }
+    ux_error() { echo "ux_error: $*" >&2; }
+    ux_warning() { :; }
+    ux_bullet() { :; }
+    . "$fn_file"
+
+    BASE="$TEST_TEMP_HOME/base.json"
+    OVERLAY="$TEST_TEMP_HOME/overlay.json"
+    TGT="$TEST_TEMP_HOME/settings.json"
+
+    # SSOT base: 3-hook SessionStart block + statusLine.
+    cat >"$BASE" <<'JSON'
+{
+  "hooks": { "SessionStart": [ { "hooks": [
+    { "type": "command", "command": "a.sh" },
+    { "type": "command", "command": "b.sh" },
+    { "type": "command", "command": "c.sh" }
+  ] } ] },
+  "statusLine": { "type": "command", "command": "new-statusline.sh" },
+  "theme": "dark"
+}
+JSON
+
+    # Bedrock overlay: SSOT-owned availableModels / modelOverrides.
+    cat >"$OVERLAY" <<'JSON'
+{
+  "_comment": "overlay",
+  "availableModels": ["sonnet", "haiku"],
+  "modelOverrides": { "opus": "global.anthropic.opus" },
+  "model": "global.anthropic.opus"
+}
+JSON
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "merge #1088: stale existing.hooks is replaced by SSOT base.hooks" {
+    # existing real file: only 1 stale hook, plus a user-edited field.
+    cat >"$TGT" <<'JSON'
+{
+  "hooks": { "SessionStart": [ { "hooks": [
+    { "type": "command", "command": "a.sh" }
+  ] } ] },
+  "model": "user-picked-model",
+  "myCustomKey": "keep-me"
+}
+JSON
+
+    run _merge_claude_settings_json "$BASE" "$OVERLAY" "$TGT"
+    [ "$status" -eq 0 ]
+
+    # SSOT hooks win: all 3 commands present.
+    run jq -r '.hooks.SessionStart[0].hooks | length' "$TGT"
+    [ "$output" -eq 3 ]
+    run jq -r '[.hooks.SessionStart[0].hooks[].command] | join(",")' "$TGT"
+    [ "$output" = "a.sh,b.sh,c.sh" ]
+}
+
+@test "merge #1088: SSOT statusLine / availableModels / modelOverrides win over stale existing" {
+    cat >"$TGT" <<'JSON'
+{
+  "statusLine": { "type": "command", "command": "OLD-statusline.sh" },
+  "availableModels": ["stale-model"],
+  "modelOverrides": { "opus": "stale-map" },
+  "model": "user-picked-model"
+}
+JSON
+
+    run _merge_claude_settings_json "$BASE" "$OVERLAY" "$TGT"
+    [ "$status" -eq 0 ]
+
+    run jq -r '.statusLine.command' "$TGT"
+    [ "$output" = "new-statusline.sh" ]
+    run jq -r '.availableModels | join(",")' "$TGT"
+    [ "$output" = "sonnet,haiku" ]
+    run jq -r '.modelOverrides.opus' "$TGT"
+    [ "$output" = "global.anthropic.opus" ]
+}
+
+@test "merge #1088: user-owned fields (model, custom keys) are still preserved" {
+    cat >"$TGT" <<'JSON'
+{
+  "hooks": { "SessionStart": [ { "hooks": [
+    { "type": "command", "command": "a.sh" }
+  ] } ] },
+  "model": "user-picked-model",
+  "theme": "light",
+  "myCustomKey": "keep-me"
+}
+JSON
+
+    run _merge_claude_settings_json "$BASE" "$OVERLAY" "$TGT"
+    [ "$status" -eq 0 ]
+
+    # model is NOT in the SSOT whitelist → existing (user /model choice) wins.
+    run jq -r '.model' "$TGT"
+    [ "$output" = "user-picked-model" ]
+    # arbitrary user key survives.
+    run jq -r '.myCustomKey' "$TGT"
+    [ "$output" = "keep-me" ]
+    # existing overrides base for non-whitelisted scalar (theme).
+    run jq -r '.theme' "$TGT"
+    [ "$output" = "light" ]
+}

--- a/tests/bats/setup/aws_merge_claude_settings.bats
+++ b/tests/bats/setup/aws_merge_claude_settings.bats
@@ -26,7 +26,9 @@ setup() {
     # it, and stub the ux_* helpers it calls. This tests the SHIPPED jq program,
     # not a copy — any drift in the merge logic breaks this test.
     local fn_file="$TEST_TEMP_HOME/merge_fn.sh"
-    awk '/^_merge_claude_settings_json\(\) \{/{grab=1} grab{print} /^}/{if(grab)exit}' \
+    # Spacing-tolerant so a shfmt reformat of the `func() {` line can't
+    # silently break extraction (PR #1089 review — gemini).
+    awk '/^_merge_claude_settings_json[[:space:]]*\([[:space:]]*\)[[:space:]]*\{/{grab=1} grab{print} /^}/{if(grab)exit}' \
         "${_BATS_REAL_DOTFILES_ROOT}/aws/setup.sh" >"$fn_file"
     # shellcheck disable=SC1090
     ux_success() { :; }


### PR DESCRIPTION
## Summary
- `aws/setup.sh` 의 `_merge_claude_settings_json()` 에서 SSOT 신규 hook 이 이미 셋업된 PC 에 절대 반영되지 않던 버그를 수정한다.
- deep-merge 우선순위(`base * overlay * existing`)에서 jq `*` 가 배열을 RHS 로 대체하는 특성 때문에, 구값 `existing.hooks.SessionStart` 배열이 신값 SSOT 를 영구히 덮어썼다.
- SSOT-우선 필드 화이트리스트(이슈 권장 옵션 A)를 도입하고, 실제 함수를 검증하는 bats 회귀 테스트를 추가한다.

## Changes
- `fix(aws/setup)`: 머지 직전 `existing` 에서 SSOT-소유 필드(`hooks`, `statusLine` = base / `availableModels`, `modelOverrides` = overlay)를 `del` 하여 base/overlay 값이 그대로 살아나게 함. `model` 등 사용자 `/model` 편집 필드는 화이트리스트에 없어 기존처럼 보존.
- `test`: `tests/bats/setup/aws_merge_claude_settings.bats` 추가 — `aws/setup.sh` 에서 실제 함수를 추출(복사본 아님)해 (1) stale hooks 가 SSOT 로 교체, (2) statusLine/availableModels/modelOverrides 가 SSOT 우선, (3) model/커스텀키 보존을 검증.

## Test plan
- [x] 신규 bats 3종 통과 (`bats tests/bats/setup/aws_merge_claude_settings.bats`)
- [x] `shellcheck aws/setup.sh` 클린, 수정 라인 `shfmt -i 4` 클린
- [x] 재현 시나리오 직접 확인: stale 1-hook existing → 머지 후 SSOT 3-hook(`plugin-sync-session.sh` 포함) 반영, `availableModels` overlay 값으로 갱신, `model`/`theme`/커스텀키 보존
- [x] 전체 스위트: 신규 3종 pass, 기존 2건 실패는 무관(git worktree teardown 환경 이슈, 변경 전에도 동일 실패)

## Related
Closes #1088

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
