### PR TITLE
fix(claude/plugin): publish-sync.sh origin fetch 일시적 타임아웃 재시도 + 실제 오류 노출

### DIFF
--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -52,6 +52,33 @@ _repo_target() {
 	esac
 }
 
+# _fetch_origin <repo_dir>
+#
+# Fetch origin with a few retries. The SSH-over-443 handshake to GitHub
+# intermittently times out ("Connection timed out during banner exchange")
+# — a transient network fault that a single-shot fetch would turn into a
+# hard "publish skipped" for the whole run. Retries PUBLISH_SYNC_FETCH_TRIES
+# times (default 3) with a PUBLISH_SYNC_FETCH_DELAY-second backoff (default
+# 3); on the final failure it prints git's REAL stderr (banner-exchange
+# timeout, auth error, …) rather than the old bare "fetch 실패" that hid the
+# cause. Prints nothing on success; returns the last fetch's exit status.
+_fetch_origin() {
+	local repo_dir="$1"
+	local tries="${PUBLISH_SYNC_FETCH_TRIES:-3}"
+	local delay="${PUBLISH_SYNC_FETCH_DELAY:-3}"
+	local i=1 err rc=0
+	while :; do
+		err=$(git -C "$repo_dir" fetch origin --quiet 2>&1)
+		rc=$?
+		[ "$rc" -eq 0 ] && return 0
+		[ "$i" -ge "$tries" ] && break
+		i=$((i + 1))
+		sleep "$delay"
+	done
+	[ -n "$err" ] && printf '%s\n' "$err" >&2
+	return "$rc"
+}
+
 # _manifest_diff_exists <repo_dir> <file...>
 #
 # Assumes `origin` has already been fetched by the caller. Returns 0 if
@@ -239,8 +266,8 @@ _publish_manifest_diff() {
 	shift 2
 	local before_origin
 
-	git -C "$repo_dir" fetch origin --quiet 2>/dev/null || {
-		echo "[$label] origin fetch 실패 — 건너뜀" >&2
+	_fetch_origin "$repo_dir" || {
+		echo "[$label] origin fetch 실패 (재시도 후) — 건너뜀" >&2
 		return 1
 	}
 
@@ -296,8 +323,8 @@ _cleanup_local_main_if_pure_sync() {
 	shift 2
 	local sha msg f changed pure=1 match want cur_branch
 
-	git -C "$repo_dir" fetch origin --quiet 2>/dev/null || {
-		echo "publish-sync: 정리 단계 fetch 실패 — 로컬 main은 그대로 둡니다" >&2
+	_fetch_origin "$repo_dir" || {
+		echo "publish-sync: 정리 단계 fetch 실패 (재시도 후) — 로컬 main은 그대로 둡니다" >&2
 		return 1
 	}
 

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -91,12 +91,15 @@ _route_origin_offline() {
 
 # Installs a fake `git` at the front of PATH that intercepts ONLY the
 # `fetch` subcommand (delegating every other git invocation to the real
-# git via exec). Each fetch increments $GIT_STUB_DIR/fetch_count; a fetch
-# whose count is <= the number in $GIT_STUB_DIR/fail_until fails with a
-# realistic transient handshake error on stderr and exit 128 (the exact
-# shape the live "Connection timed out during banner exchange" flake
-# produced). Lets tests drive _fetch_origin's retry/error-surfacing paths
-# fully offline.
+# git via exec). The match is precise — `$1 == fetch`, or `git -C <path>
+# fetch` ($1 == -C, $3 == fetch), the exact form _fetch_origin uses — so a
+# stray "fetch" inside a commit message / branch name / path never gets
+# mis-intercepted (PR #1091 review). Each fetch increments
+# $GIT_STUB_DIR/fetch_count; a fetch whose count is <= the number in
+# $GIT_STUB_DIR/fail_until fails with a realistic transient handshake error
+# on stderr and exit 128 (the exact shape the live "Connection timed out
+# during banner exchange" flake produced). Lets tests drive _fetch_origin's
+# retry/error-surfacing paths fully offline.
 _install_git_fetch_stub() {
     GIT_STUB_DIR="$TEST_TEMP_HOME/git-stub"
     mkdir -p "$GIT_STUB_DIR/bin"
@@ -107,20 +110,24 @@ _install_git_fetch_stub() {
 
     cat >"$GIT_STUB_DIR/bin/git" <<STUB
 #!/usr/bin/env bash
-for a in "\$@"; do
-    if [ "\$a" = "fetch" ]; then
-        cf="$GIT_STUB_DIR/fetch_count"
-        n=\$(( \$(cat "\$cf") + 1 ))
-        echo "\$n" >"\$cf"
-        fail_until=\$(cat "$GIT_STUB_DIR/fail_until" 2>/dev/null || echo 0)
-        if [ "\$n" -le "\$fail_until" ]; then
-            echo "Connection timed out during banner exchange" >&2
-            echo "fatal: Could not read from remote repository." >&2
-            exit 128
-        fi
-        exit 0
+is_fetch=0
+if [ "\$1" = "fetch" ]; then
+    is_fetch=1
+elif [ "\$1" = "-C" ] && [ "\$3" = "fetch" ]; then
+    is_fetch=1
+fi
+if [ "\$is_fetch" -eq 1 ]; then
+    cf="$GIT_STUB_DIR/fetch_count"
+    n=\$(( \$(cat "\$cf") + 1 ))
+    echo "\$n" >"\$cf"
+    fail_until=\$(cat "$GIT_STUB_DIR/fail_until" 2>/dev/null || echo 0)
+    if [ "\$n" -le "\$fail_until" ]; then
+        echo "Connection timed out during banner exchange" >&2
+        echo "fatal: Could not read from remote repository." >&2
+        exit 128
     fi
-done
+    exit 0
+fi
 exec "$real_git" "\$@"
 STUB
     chmod +x "$GIT_STUB_DIR/bin/git"

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -89,6 +89,79 @@ _route_origin_offline() {
     git -C "$repo_dir" config "url.${bare_path}.insteadOf" "$fake_url"
 }
 
+# Installs a fake `git` at the front of PATH that intercepts ONLY the
+# `fetch` subcommand (delegating every other git invocation to the real
+# git via exec). Each fetch increments $GIT_STUB_DIR/fetch_count; a fetch
+# whose count is <= the number in $GIT_STUB_DIR/fail_until fails with a
+# realistic transient handshake error on stderr and exit 128 (the exact
+# shape the live "Connection timed out during banner exchange" flake
+# produced). Lets tests drive _fetch_origin's retry/error-surfacing paths
+# fully offline.
+_install_git_fetch_stub() {
+    GIT_STUB_DIR="$TEST_TEMP_HOME/git-stub"
+    mkdir -p "$GIT_STUB_DIR/bin"
+    echo 0 >"$GIT_STUB_DIR/fetch_count"
+    echo "${1:-0}" >"$GIT_STUB_DIR/fail_until"
+    local real_git
+    real_git=$(command -v git)
+
+    cat >"$GIT_STUB_DIR/bin/git" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+    if [ "\$a" = "fetch" ]; then
+        cf="$GIT_STUB_DIR/fetch_count"
+        n=\$(( \$(cat "\$cf") + 1 ))
+        echo "\$n" >"\$cf"
+        fail_until=\$(cat "$GIT_STUB_DIR/fail_until" 2>/dev/null || echo 0)
+        if [ "\$n" -le "\$fail_until" ]; then
+            echo "Connection timed out during banner exchange" >&2
+            echo "fatal: Could not read from remote repository." >&2
+            exit 128
+        fi
+        exit 0
+    fi
+done
+exec "$real_git" "\$@"
+STUB
+    chmod +x "$GIT_STUB_DIR/bin/git"
+    PATH="$GIT_STUB_DIR/bin:$PATH"
+    # Zero the backoff so retry tests don't actually sleep.
+    PUBLISH_SYNC_FETCH_DELAY=0
+    export PATH PUBLISH_SYNC_FETCH_DELAY
+}
+
+@test "_fetch_origin retries a transient fetch failure and then succeeds" {
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    # Fail the first two fetches, succeed on the third; allow up to 3 tries.
+    _install_git_fetch_stub 2
+    PUBLISH_SYNC_FETCH_TRIES=3
+    export PUBLISH_SYNC_FETCH_TRIES
+
+    run _fetch_origin "$REPO"
+    assert_success
+    # Proves it actually retried rather than giving up on the first failure.
+    run cat "$GIT_STUB_DIR/fetch_count"
+    assert_output "3"
+}
+
+@test "_fetch_origin surfaces the real git error after exhausting retries" {
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    # Fail every attempt.
+    _install_git_fetch_stub 99
+    PUBLISH_SYNC_FETCH_TRIES=3
+    export PUBLISH_SYNC_FETCH_TRIES
+
+    run _fetch_origin "$REPO"
+    assert_failure
+    # The real transient cause must reach stderr, not be swallowed by 2>/dev/null.
+    assert_output --partial "banner exchange"
+    # Exactly PUBLISH_SYNC_FETCH_TRIES attempts, no more.
+    run cat "$GIT_STUB_DIR/fetch_count"
+    assert_output "3"
+}
+
 @test "_manifest_diff_exists returns false when files match origin/main" {
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"


### PR DESCRIPTION
## 배경

`./claude/plugin/publish-sync.sh` 실행 시 간헐적으로 `[public] origin fetch 실패 — 건너뜀` 이 뜨며 public manifest publish 가 통째로 건너뛰어졌습니다. `2>/dev/null` 을 벗겨 확인한 실제 원인은 GitHub SSH-over-443 핸드셰이크의 일시적 타임아웃:

```
Connection timed out during banner exchange
Connection to 20.200.245.248 port 443 timed out
fatal: Could not read from remote repository.
```

스크립트 결함 2가지가 이 회복 가능한 blip 을 하드 실패로 만들었습니다: (1) 단발 fetch — 재시도 없음, (2) `2>/dev/null` 로 진짜 원인을 은폐.

## 변경 사항

- **`_fetch_origin <repo_dir>` 헬퍼 신설** — 기본 3회 재시도 + 3초 백오프. `PUBLISH_SYNC_FETCH_TRIES` / `PUBLISH_SYNC_FETCH_DELAY` 환경변수로 조정 가능.
- **실제 오류 노출** — 재시도 소진 시 git 의 실제 stderr 를 그대로 출력, 성공 시 무출력.
- **두 fetch 지점 배선** — `_publish_manifest_diff`, `_cleanup_local_main_if_pure_sync`.
- **bats 신규 테스트 2개** — git-fetch 스텁 + 재시도 성공 / 오류 노출 검증.

## 테스트

- bats 36개 전부 통과 (신규 2개 포함), 기존 무회귀.
- shellcheck + shfmt clean.
- 실제 remote 대상 8회 연속 성공 — 수정 전 ~1/5 실패가 재시도로 흡수됨.

Closes #1090

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics -->

</details>
