### PR TITLE
fix(claude/plugin): publish-sync 게시 후 로컬 main 자동 정리 + 견고성 3건 (#1095)

### DIFF
--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -7,13 +7,18 @@
 # both repos require changes to land via PR (branch protection / GHES
 # ruleset), so a direct `git push` always fails.
 #
-# Never checks out a branch, touches the real index, or moves HEAD in the
-# target repo: the publish commit is built with plumbing commands
-# (hash-object, read-tree into a scratch index, write-tree, commit-tree)
-# against origin/main, landed as a new ref, then pushed. Local `main` is
-# only ever fast-forwarded afterward, and only when every commit it was
-# ahead by is a pure "chore(claude-plugin): sync manifest" commit (see
-# _cleanup_local_main_if_pure_sync).
+# Never checks out a branch, touches the real index, or moves HEAD to build
+# the publish commit: it is built with plumbing commands (hash-object,
+# read-tree into a scratch index, write-tree, commit-tree) against
+# origin/main, landed as a new ref, then pushed. Afterward local `main` is
+# advanced to the published origin/main — fast-forwarded when it is a strict
+# ancestor, or (the usual case, since the hook's local sync commit and the
+# PR-merged one share content but not SHA and therefore diverge) rebased onto
+# it — but ONLY when every commit main was ahead by is a pure
+# "chore(claude-plugin): sync manifest" commit AND the working tree is clean.
+# git's patch-id detection drops the now-redundant published commit while
+# replaying any pure-sync commit whose content never actually landed, so
+# nothing is lost (see _cleanup_local_main_if_pure_sync).
 #
 # See docs/feature/superpowers-specs/2026-07-02-plugin-manifest-batch-publish-design.md
 set -uo pipefail
@@ -183,14 +188,24 @@ _open_and_merge_pr() {
 		return 1
 	}
 
-	pr_url=$(gh pr create --repo "$target" --head "$branch" --base main \
+	local pr_out
+	pr_out=$(gh pr create --repo "$target" --head "$branch" --base main \
 		--title "$SYNC_MSG" \
 		--body "plugin-sync.sh가 로컬에 쌓아둔 매니페스트 변경을 게시합니다. 자동 생성됨." \
 		2>&1) || {
-		echo "publish-sync: PR 생성 실패 — $pr_url" >&2
+		echo "publish-sync: PR 생성 실패 — $pr_out" >&2
 		return 1
 	}
+	# gh can fold warnings/deprecation notices into stdout via the 2>&1 above;
+	# pull the real PR URL out by pattern rather than trusting the whole blob,
+	# so a stray line can't corrupt `${pr_url##*/}` and silently target the
+	# wrong PR (or an empty number) at merge time. Take the last match.
+	pr_url=$(printf '%s\n' "$pr_out" | grep -oE 'https?://[^[:space:]]+/pull/[0-9]+' | tail -n1)
 	pr_number="${pr_url##*/}"
+	if [ -z "$pr_number" ]; then
+		echo "publish-sync: PR URL 파싱 실패 — gh 출력: $pr_out" >&2
+		return 1
+	fi
 	echo "publish-sync: PR 생성됨 — $pr_url"
 
 	# The `--json bucket` flag on the `pr checks` subcommand does not exist
@@ -314,14 +329,20 @@ _publish_manifest_diff() {
 
 # _cleanup_local_main_if_pure_sync <repo_dir> <before_origin_sha> <file...>
 #
-# After a successful publish, fast-forward local main to the new
-# origin/main IF every commit main was ahead of before_origin_sha by is a
-# pure SYNC_MSG commit touching only the given files. Otherwise leaves
-# main untouched. Never rebases or force-resets.
+# After a successful publish, advance local main to the new origin/main IF
+# every commit main was ahead of before_origin_sha by is a pure SYNC_MSG
+# commit touching only the given files. Fast-forwards when local main is a
+# strict ancestor; otherwise (main diverged because the PR-merged sync
+# commit landed with a different SHA than the hook's local one — the usual
+# case) rebases onto origin/main, but only when the working tree is clean —
+# git's patch-id detection drops the redundant published commit while
+# replaying any pure-sync commit whose content never landed, so nothing is
+# lost. Leaves main untouched with an explanatory message when the tree is
+# dirty, the rebase conflicts, or purity fails. Never force-resets.
 _cleanup_local_main_if_pure_sync() {
 	local repo_dir="$1" before_origin="$2"
 	shift 2
-	local sha msg f changed pure=1 match want cur_branch
+	local sha msg f pure=1 match want cur_branch
 
 	_fetch_origin "$repo_dir" || {
 		echo "publish-sync: 정리 단계 fetch 실패 (재시도 후) — 로컬 main은 그대로 둡니다" >&2
@@ -334,8 +355,12 @@ _cleanup_local_main_if_pure_sync() {
 			pure=0
 			break
 		fi
-		changed=$(git -C "$repo_dir" show --format= --name-only "$sha")
-		for f in $changed; do
+		# `git show --name-only` is newline-delimited; read line-by-line via
+		# process substitution (keeps the loop in this shell so `break 2` still
+		# escapes the outer rev-list loop) so a path containing spaces isn't
+		# word-split into false mismatches.
+		while IFS= read -r f; do
+			[ -n "$f" ] || continue
 			match=0
 			for want in "$@"; do
 				[ "$f" = "$want" ] && match=1 && break
@@ -344,7 +369,7 @@ _cleanup_local_main_if_pure_sync() {
 				pure=0
 				break 2
 			}
-		done
+		done < <(git -C "$repo_dir" show --format= --name-only "$sha")
 	done
 
 	if [ "$pure" -ne 1 ]; then
@@ -354,8 +379,25 @@ _cleanup_local_main_if_pure_sync() {
 
 	cur_branch=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
 	if [ "$cur_branch" = "main" ]; then
-		if ! git -C "$repo_dir" merge --ff-only origin/main --quiet; then
-			echo "publish-sync: 로컬 main이 origin/main 과 갈라져 fast-forward 불가 — publish 는 성공했으니 필요하면 'git pull' 로 직접 정리하세요" >&2
+		if git -C "$repo_dir" merge --ff-only origin/main --quiet 2>/dev/null; then
+			: # local main was a strict ancestor — a plain fast-forward sufficed
+		elif git -C "$repo_dir" diff --quiet && git -C "$repo_dir" diff --cached --quiet; then
+			# Diverged, but purity is already proven (pure=1) and the working
+			# tree is clean. Rebase onto the new origin/main: git's patch-id
+			# detection drops the now-redundant published sync commit (the manual
+			# `git rebase origin/main` a user would otherwise run every publish),
+			# while REPLAYING any pure-sync commit whose content never actually
+			# landed — so nothing is lost. `--ff-only` can never succeed here
+			# because `gh pr merge --rebase` re-commits the snapshot under a new
+			# SHA, which is why the old code fell through to a manual-cleanup
+			# message on every real publish.
+			if ! git -C "$repo_dir" rebase origin/main >/dev/null 2>&1; then
+				git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
+				echo "publish-sync: 로컬 main rebase 중 충돌 — publish 는 성공했으니 'git rebase origin/main' 으로 직접 정리하세요" >&2
+				return 1
+			fi
+		else
+			echo "publish-sync: 로컬 main 워킹트리에 미커밋 변경이 있어 정리를 건너뜁니다 — publish 는 성공했으니 필요하면 'git pull' 로 직접 정리하세요" >&2
 			return 1
 		fi
 	else
@@ -426,6 +468,22 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	MAIN_ROOT="$HOME/dotfiles"
 	PRIV_DIR="$MAIN_ROOT/claude/plugin/company"
 	RC=0
+
+	# Serialize concurrent publishing runs — the plugin-sync hook can fire
+	# while a manual `publish-sync.sh` is mid-flight, and both would otherwise
+	# open a PR for the same manifest diff (the second lands as a no-op, but
+	# still churns a branch + PR). Per-repo, non-blocking lock kept in .git
+	# (untracked, so it never dirties the tree); a second run exits cleanly
+	# rather than piling up. Skipped for --dry-run (read-only) and when flock
+	# (util-linux) or the lock path is unavailable — then we simply proceed.
+	if [ "$DRY_RUN" = "0" ] && command -v flock >/dev/null 2>&1 &&
+		[ -d "$MAIN_ROOT/.git" ] &&
+		exec 9>"$MAIN_ROOT/.git/publish-sync.lock"; then
+		if ! flock -n 9; then
+			echo "publish-sync: 다른 인스턴스가 실행 중 — 이번 실행은 건너뜁니다"
+			exit 0
+		fi
+	fi
 
 	if _public_publish_allowed; then
 		_publish_manifest_diff "$MAIN_ROOT" "public" \

--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -472,16 +472,26 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	# Serialize concurrent publishing runs — the plugin-sync hook can fire
 	# while a manual `publish-sync.sh` is mid-flight, and both would otherwise
 	# open a PR for the same manifest diff (the second lands as a no-op, but
-	# still churns a branch + PR). Per-repo, non-blocking lock kept in .git
-	# (untracked, so it never dirties the tree); a second run exits cleanly
-	# rather than piling up. Skipped for --dry-run (read-only) and when flock
-	# (util-linux) or the lock path is unavailable — then we simply proceed.
-	if [ "$DRY_RUN" = "0" ] && command -v flock >/dev/null 2>&1 &&
-		[ -d "$MAIN_ROOT/.git" ] &&
-		exec 9>"$MAIN_ROOT/.git/publish-sync.lock"; then
-		if ! flock -n 9; then
-			echo "publish-sync: 다른 인스턴스가 실행 중 — 이번 실행은 건너뜁니다"
-			exit 0
+	# still churns a branch + PR). Per-repo, non-blocking lock kept in the git
+	# dir (untracked, so it never dirties the tree); a second run exits cleanly
+	# rather than piling up. The git dir is resolved via `git rev-parse
+	# --git-dir` rather than a bare `[ -d "$MAIN_ROOT/.git" ]`: in a worktree
+	# `.git` is a FILE ("gitdir: …"), not a directory, so the -d test would
+	# silently skip locking there (#1096 review). Skipped for --dry-run
+	# (read-only) and when flock (util-linux) or the git dir is unavailable —
+	# then we simply proceed. Top-level scope, so no `local`.
+	if [ "$DRY_RUN" = "0" ] && command -v flock >/dev/null 2>&1; then
+		GIT_DIR_PATH=$(git -C "$MAIN_ROOT" rev-parse --git-dir 2>/dev/null || echo "")
+		case "$GIT_DIR_PATH" in
+		"") ;;                                        # not a git repo — proceed unlocked
+		/*) ;;                                        # already absolute
+		*) GIT_DIR_PATH="$MAIN_ROOT/$GIT_DIR_PATH" ;; # relative → anchor to MAIN_ROOT
+		esac
+		if [ -n "$GIT_DIR_PATH" ] && exec 9>"$GIT_DIR_PATH/publish-sync.lock"; then
+			if ! flock -n 9; then
+				echo "publish-sync: 다른 인스턴스가 실행 중 — 이번 실행은 건너뜁니다"
+				exit 0
+			fi
 		fi
 	fi
 

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -78,6 +78,20 @@ _commit_pure_sync_change() {
     git -C "$repo_dir" commit -q -m "chore(claude-plugin): sync manifest"
 }
 
+_commit_pure_sync_change_dated() {
+    # Like _commit_pure_sync_change but pins author+committer dates so the
+    # commit is patch-identical to a same-content sibling yet carries a
+    # DISTINCT SHA — mirrors the real divergence (the hook's local sync commit
+    # and the gh-rebase-merged one share content but not SHA). Without this,
+    # two same-content commits made in the same wall-clock second collide to
+    # one SHA and the test never actually diverges.
+    local repo_dir="$1" rel_path="$2" content="$3" when="$4"
+    printf '%s\n' "$content" >"$repo_dir/$rel_path"
+    git -C "$repo_dir" add "$rel_path"
+    GIT_AUTHOR_DATE="$when" GIT_COMMITTER_DATE="$when" \
+        git -C "$repo_dir" commit -q -m "chore(claude-plugin): sync manifest"
+}
+
 _route_origin_offline() {
     # Point <repo_dir>'s origin at a parseable GitHub URL (so _repo_target and
     # `gh` see a real host/owner/repo) while redirecting actual git transport to
@@ -309,6 +323,12 @@ _install_gh_stub() {
 echo "\$*" >> "$GH_STUB_LOG"
 case "\$1 \$2" in
 "pr create")
+    # When pr_create_noise is set, emit a warning to stderr (which the script
+    # folds into its capture via 2>&1) to prove PR-number parsing survives
+    # non-URL noise instead of naively taking the last "/"-token of the blob.
+    if [ -f "$GH_STUB_DIR/pr_create_noise" ]; then
+        echo "Warning: 3 uncommitted changes in this repository" >&2
+    fi
     echo "https://example.com/owner/repo/pull/42"
     exit 0
     ;;
@@ -397,6 +417,24 @@ STUB
     run grep -c "^pr create" "$GH_STUB_LOG"
     assert_output "1"
     run grep -c "^pr merge.*--admin" "$GH_STUB_LOG"
+    assert_output "1"
+}
+
+@test "_open_and_merge_pr parses the PR number even when gh prints a warning to stderr" {
+    # Regression: pr_url used to be `${blob##*/}` over a stdout+stderr capture,
+    # so a stderr warning line could corrupt the PR number and misroute the
+    # merge. The URL is now extracted by pattern; the merge must target 42.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    git -C "$REPO" remote set-url origin "https://github.com/owner/repo.git"
+    _install_gh_stub
+    echo "success" >"$GH_STUB_DIR/checks_result"
+    : >"$GH_STUB_DIR/pr_create_noise"
+
+    run _open_and_merge_pr "$REPO" "chore/plugin-sync-publish-public-20260702-000000"
+    assert_success
+    # merge invoked with the correct PR number, not a warning-corrupted token
+    run grep -c "^pr merge 42 .*--admin" "$GH_STUB_LOG"
     assert_output "1"
 }
 
@@ -611,37 +649,93 @@ STUB
     assert_not_equal "$MAIN_SHA" "$LOCAL_MAIN_BEFORE"
 }
 
-@test "_cleanup_local_main_if_pure_sync leaves checked-out main untouched and fails loudly when it has diverged from origin/main" {
+@test "_cleanup_local_main_if_pure_sync rebases a diverged checked-out main onto origin/main when the published commit shares its content" {
+    # The real post-publish state: the hook's local sync commit and the
+    # PR-merged one carry IDENTICAL content but different SHAs (gh pr merge
+    # --rebase re-commits), so main diverges and `--ff-only` can never
+    # succeed. With the working tree clean and purity proven, cleanup rebases
+    # onto origin/main — git's patch-id detection drops the now-redundant
+    # local commit — landing main exactly on origin/main (issue #1095).
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"
     BEFORE_ORIGIN=$(git -C "$REPO" rev-parse origin/main)
 
-    # local main is checked out and ahead of before_origin by a pure sync
-    # commit — the real post-publish state: plugin-sync.sh's hook
-    # committed locally but could never push.
+    # local main (checked out) ahead by the hook's pure sync commit
     _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
     LOCAL_MAIN=$(git -C "$REPO" rev-parse main)
 
-    # origin/main advances to a DIFFERENT sibling commit sharing
-    # before_origin as parent — the actual publish pipeline builds this
-    # independently via plumbing (_build_publish_commit), so it is never
-    # an ancestor/descendant of local main: a real fast-forward is
-    # impossible.
+    # origin/main advances to a sibling with the SAME content but a distinct
+    # SHA (pinned date) — as _build_publish_commit + gh rebase-merge produce.
+    # A fast-forward is impossible, but the patch is identical.
+    git -C "$REPO" checkout -q "$BEFORE_ORIGIN"
+    _commit_pure_sync_change_dated "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}' "2020-01-01T00:00:00 +0000"
+    PUBLISHED=$(git -C "$REPO" rev-parse HEAD)
+    git -C "$REPO" push -q origin "${PUBLISHED}:refs/heads/main"
+    git -C "$REPO" checkout -q main
+    assert_equal "$(git -C "$REPO" rev-parse HEAD)" "$LOCAL_MAIN"
+    assert_not_equal "$LOCAL_MAIN" "$PUBLISHED"
+
+    run _cleanup_local_main_if_pure_sync "$REPO" "$BEFORE_ORIGIN" claude/plugin/marketplaces.json claude/plugin/plugins.json
+    assert_success
+    assert_output --partial "정리했습니다"
+    # main now sits exactly on the published origin/main; the redundant local
+    # commit was dropped by the rebase.
+    assert_equal "$(git -C "$REPO" rev-parse main)" "$PUBLISHED"
+}
+
+@test "_cleanup_local_main_if_pure_sync leaves a diverged checked-out main untouched when the working tree is dirty" {
+    # The rebase auto-cleanup only runs on a clean tree — a dirty working
+    # tree falls back to the safe no-op + guidance, never risking user work.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    BEFORE_ORIGIN=$(git -C "$REPO" rev-parse origin/main)
+
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    LOCAL_MAIN=$(git -C "$REPO" rev-parse main)
+
+    git -C "$REPO" checkout -q "$BEFORE_ORIGIN"
+    _commit_pure_sync_change_dated "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}' "2020-01-01T00:00:00 +0000"
+    PUBLISHED=$(git -C "$REPO" rev-parse HEAD)
+    git -C "$REPO" push -q origin "${PUBLISHED}:refs/heads/main"
+    git -C "$REPO" checkout -q main
+
+    # make the working tree dirty
+    echo "uncommitted work" >"$REPO/claude/plugin/plugins.json"
+
+    run _cleanup_local_main_if_pure_sync "$REPO" "$BEFORE_ORIGIN" claude/plugin/marketplaces.json claude/plugin/plugins.json
+    assert_failure
+    assert_output --partial "미커밋 변경"
+    # main untouched
+    assert_equal "$(git -C "$REPO" rev-parse main)" "$LOCAL_MAIN"
+}
+
+@test "_cleanup_local_main_if_pure_sync aborts the rebase and leaves main untouched when replaying the local commit conflicts" {
+    # Defensive edge: if a pure-sync local commit's content was never actually
+    # published (it differs from origin's), rebase replays it and may conflict.
+    # The cleanup must `rebase --abort` and leave main exactly where it was.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    BEFORE_ORIGIN=$(git -C "$REPO" rev-parse origin/main)
+
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    LOCAL_MAIN=$(git -C "$REPO" rev-parse main)
+
+    # origin/main advances to a DIFFERENT content on the same file — the patch
+    # won't match, so rebase replays local and conflicts.
     git -C "$REPO" checkout -q "$BEFORE_ORIGIN"
     _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills-published"}'
     PUBLISHED=$(git -C "$REPO" rev-parse HEAD)
     git -C "$REPO" push -q origin "${PUBLISHED}:refs/heads/main"
-
-    # back to main, checked out, still sitting at the pre-publish local commit
     git -C "$REPO" checkout -q main
     assert_equal "$(git -C "$REPO" rev-parse HEAD)" "$LOCAL_MAIN"
 
     run _cleanup_local_main_if_pure_sync "$REPO" "$BEFORE_ORIGIN" claude/plugin/marketplaces.json claude/plugin/plugins.json
     assert_failure
-    assert_output --partial "갈라져 fast-forward 불가"
-
-    # local main must be left completely untouched — no reset, no rebase
+    assert_output --partial "rebase 중 충돌"
+    # main untouched, and no rebase left in progress
     assert_equal "$(git -C "$REPO" rev-parse main)" "$LOCAL_MAIN"
+    run git -C "$REPO" rev-parse --verify --quiet REBASE_HEAD
+    assert_failure
 }
 
 @test "_cleanup_local_main_if_pure_sync skips when an unrelated commit is mixed in" {
@@ -719,6 +813,34 @@ STUB
     assert_success
     assert_output --partial "[public] 변경 감지됨"
     assert_output --partial "[company] 변경 감지됨"
+}
+
+@test "running the script skips cleanly when another instance holds the lock" {
+    command -v flock >/dev/null 2>&1 || skip "flock not available"
+    mkdir -p "$TEST_TEMP_HOME/dotfiles"
+    _seed_repo_with_origin "$TEST_TEMP_HOME/dotfiles"
+    BARE=$(git -C "$TEST_TEMP_HOME/dotfiles" remote get-url origin)
+    GH_STUB_BARE_REPO="$BARE"
+    export GH_STUB_BARE_REPO
+
+    _commit_pure_sync_change "$TEST_TEMP_HOME/dotfiles" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _install_gh_stub
+    _route_origin_offline "$TEST_TEMP_HOME/dotfiles" "https://github.com/dEitY719/dotfiles.git" "${BARE}"
+
+    # Hold the per-repo lock from THIS shell (inherited by the `run` child),
+    # so the script's own flock -n loses and it must skip without publishing.
+    LOCK="$TEST_TEMP_HOME/dotfiles/.git/publish-sync.lock"
+    exec 8>"$LOCK"
+    flock -n 8
+
+    run bash "$PUBLISH_SYNC"
+    assert_success
+    assert_output --partial "다른 인스턴스가 실행 중"
+    refute_output --partial "[public] 변경 감지됨"
+    run grep -c "^pr create" "$GH_STUB_LOG"
+    assert_output "0"
+
+    exec 8>&-
 }
 
 @test "running the script with -h/--help prints usage and exits 0 without requiring gh" {

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -843,6 +843,38 @@ STUB
     exec 8>&-
 }
 
+@test "running the script locks correctly when MAIN_ROOT is a git worktree (.git is a file)" {
+    # #1096 review: in a worktree `.git` is a FILE, so the old `[ -d .git ]`
+    # test silently skipped locking. The git dir is now resolved via
+    # `git rev-parse --git-dir`, so the lock must still engage here.
+    command -v flock >/dev/null 2>&1 || skip "flock not available"
+
+    # canonical clone lives elsewhere; MAIN_ROOT ($HOME/dotfiles) is a worktree
+    CANON="$TEST_TEMP_HOME/canon"
+    _seed_repo_with_origin "$CANON"
+    git -C "$CANON" worktree add -q -b wt "$TEST_TEMP_HOME/dotfiles"
+    # sanity: .git is a FILE in the worktree, not a directory
+    [ -f "$TEST_TEMP_HOME/dotfiles/.git" ]
+    [ ! -d "$TEST_TEMP_HOME/dotfiles/.git" ]
+
+    _install_gh_stub
+
+    # resolve the worktree's real git dir (as the script does) and hold the
+    # lock there, so the script's own flock -n must lose and it skips.
+    GD=$(git -C "$TEST_TEMP_HOME/dotfiles" rev-parse --git-dir)
+    case "$GD" in /*) ;; *) GD="$TEST_TEMP_HOME/dotfiles/$GD" ;; esac
+    exec 8>"$GD/publish-sync.lock"
+    flock -n 8
+
+    run bash "$PUBLISH_SYNC"
+    assert_success
+    assert_output --partial "다른 인스턴스가 실행 중"
+    run grep -c "^pr create" "$GH_STUB_LOG"
+    assert_output "0"
+
+    exec 8>&-
+}
+
 @test "running the script with -h/--help prints usage and exits 0 without requiring gh" {
     # -h/--help must work even without `gh` on PATH — arg parsing happens
     # before the `command -v gh` gate.


### PR DESCRIPTION
## 배경

`claude/plugin/publish-sync.sh` 실행 후 매번 정리 단계에서 fast-forward 실패가 발생해 사용자가 수동으로 `git rebase origin/main` 을 돌려야 했다 (#1095).

**근본 원인:** `claude/hooks/plugin-sync.sh` 가 로컬 main 에 남긴 sync 커밋(SHA `A`)과, `publish-sync.sh` 가 origin/main 위에 새로 빌드해 `gh pr merge --rebase` 로 올린 커밋(SHA `A'`)은 **내용은 같지만 SHA 가 다르다.** 따라서 로컬 main 과 origin/main 은 항상 갈라지고(diverge), `merge --ff-only` 는 매 게시마다 실패한다 — 정리 함수가 happy path 에서 사실상 죽어 있었다.

## 변경 요약 (커밋 `f52980df`)

1. **FF 정리 로직 수정 (correctness, 메인)** — 순수-sync 검증(`pure=1`) 통과 + 워킹트리 clean 이면 `merge --ff-only` 대신 `git rebase origin/main`. git 의 patch-id 감지가 이미 게시된 중복 커밋을 자동으로 드롭하고, 미게시 순수-sync 커밋은 replay 되어 **유실이 없다.** dirty 트리는 안내 메시지 후 no-op, rebase 충돌 시 `rebase --abort` 후 main 원복.
2. **`pr_url` 파싱 견고화** — `gh pr create` 의 stdout+stderr 혼합 캡처에서 PR URL 을 정규식으로 추출. stderr 경고가 PR 번호를 오염시켜 엉뚱한 PR 을 머지하는 위험 제거 + 파싱 실패 시 명시적 에러.
3. **파일명 word-splitting 하드닝** — `for f in $changed` → `while IFS= read -r f` (process substitution 로 `break 2` 유지). 공백 포함 경로 안전.
4. **동시 실행 락** — `$MAIN_ROOT/.git` 하위 per-repo `flock` non-blocking 락으로 훅 트리거 + 수동 실행 중복을 직렬화. `--dry-run` / flock 미존재 시 무락 진행.

## 테스트

- 기존 "diverged main 갈라짐 실패" 테스트를 신규 동작 3건으로 교체: rebase 성공(중복 커밋 드롭) / dirty-tree skip / 충돌 abort-원복.
- `pr_url` stderr 견고성 테스트 + flock 중복 실행 skip 테스트 추가 (SHA 충돌 회피용 dated-commit 헬퍼 포함).
- **publish-sync bats 40건 전부 통과**, `shellcheck -x` + `shfmt -d` clean.

Closes #1095

---
<details>
<summary>🤖 AI Metrics · 📊 ~13000 tokens · 👤 ~2 h · 🤖 ~8 min</summary>

<!-- ai-metrics -->
📊 ~13000 tokens · 👤 ~2 h · 🤖 ~8 min
<!-- /ai-metrics -->

</details>
