### PR TITLE
feat(claude/plugin): reconcile.sh (SSOT→manifest drift 복구) + claude-plugin-list 요약 뷰

### DIFF
--- a/claude/plugin/reconcile.sh
+++ b/claude/plugin/reconcile.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# claude/plugin/reconcile.sh
+#
+# Full-recompute drift detector/repair for the dotfiles plugin manifests.
+#
+# claude/hooks/plugin-sync.sh keeps claude/plugin/{marketplaces,plugins}.json
+# (and, on internal PCs, claude/plugin/company/*) up to date INCREMENTALLY —
+# it only patches the manifest when it observes a `claude plugin ...` command.
+# Any event it misses (crash, sync from another PC, a manual edit) leaves a
+# ghost entry the hook can never remove, because there is no local event to
+# key the delete off of.
+#
+# reconcile.sh closes that gap: it treats ~/.claude-shared/plugins/
+# {known_marketplaces,installed_plugins}.json as the SSOT and rebuilds the
+# dotfiles manifest to match it EXACTLY (adds missing entries AND prunes
+# ghosts). It reuses the same jq selection rules as plugin-sync.sh so the two
+# never disagree on which marketplaces/plugins are in scope; the only
+# difference is that reconcile recomputes the whole set instead of patching
+# one entry.
+#
+#   --check (default)  print SSOT-vs-manifest diff; non-zero exit if drift
+#   --apply            rewrite the manifest to match SSOT, commit if changed
+#
+# Public (github) marketplaces route to claude/plugin/*.json; private
+# (non-github) ones to claude/plugin/company/*.json — identical to the hook.
+# company/ is processed only on an `internal` PC with the nested repo cloned.
+#
+# See docs/feature/superpowers-specs/2026-07-01-claude-plugin-manifest-design.md
+set -uo pipefail
+
+MODE_ACTION="check"
+
+_usage() {
+	cat <<'EOF'
+Usage: reconcile.sh [--check|--apply] [-h|--help]
+
+  --check   (기본) SSOT(~/.claude-shared/plugins) 와 dotfiles 매니페스트의
+            drift 를 표로 출력한다. drift 가 있으면 non-zero 로 종료한다.
+  --apply   dotfiles 매니페스트를 SSOT 기준으로 재빌드하고 (유령 엔트리 제거
+            포함), 변경이 있으면 "chore(claude-plugin): sync manifest" 커밋을
+            하나 남긴다.
+  -h, --help  이 도움말 출력 후 종료.
+
+SSOT: ~/.claude-shared/plugins/{known_marketplaces,installed_plugins}.json
+      (CLAUDE_SHARED_PLUGINS_DIR 로 재정의 가능)
+공용(github) → claude/plugin/*.json, 사내(non-github) → claude/plugin/company/*.json
+company/ 는 ~/.dotfiles-setup-mode == internal 이고 company/.git 이 있을 때만 처리.
+EOF
+}
+
+for arg in "$@"; do
+	case "$arg" in
+	--check) MODE_ACTION="check" ;;
+	--apply) MODE_ACTION="apply" ;;
+	-h | --help | help)
+		_usage
+		exit 0
+		;;
+	*)
+		echo "알 수 없는 인자: $arg" >&2
+		_usage >&2
+		exit 2
+		;;
+	esac
+done
+
+command -v jq >/dev/null 2>&1 || {
+	echo "jq가 필요합니다." >&2
+	exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUB_DIR="$SCRIPT_DIR"
+PRIV_DIR="$SCRIPT_DIR/company"
+
+# The repo that owns the public manifest — resolved from SCRIPT_DIR so this
+# works from any checkout/worktree (and from a test copy). Required for
+# --apply's commit; --check never needs it.
+MAIN_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+
+SHARED_DIR="${CLAUDE_SHARED_PLUGINS_DIR:-$HOME/.claude-shared/plugins}"
+MP_SRC="$SHARED_DIR/known_marketplaces.json"
+PL_SRC="$SHARED_DIR/installed_plugins.json"
+
+SYNC_MSG="chore(claude-plugin): sync manifest"
+
+# internal PC + cloned company/ repo → the private manifest is in scope.
+MODE=$(cat "$HOME/.dotfiles-setup-mode" 2>/dev/null || echo "")
+COMPANY_ACTIVE=0
+if [ "$MODE" = "internal" ] && [ -d "$PRIV_DIR/.git" ]; then
+	COMPANY_ACTIVE=1
+fi
+
+for f in "$MP_SRC" "$PL_SRC"; do
+	if [ ! -f "$f" ]; then
+		echo "SSOT 파일이 없습니다: $f" >&2
+		echo "  → ~/.claude-shared/plugins 를 확인하거나 CLAUDE_SHARED_PLUGINS_DIR 를 설정하세요." >&2
+		exit 1
+	fi
+done
+
+# --- SSOT → target set (jq rules mirror plugin-sync.sh) -------------------
+
+# github-sourced marketplaces → {name: repo}
+target_common=$(jq -c '
+    [to_entries[] | select(.value.source.source == "github")]
+    | map({(.key): .value.source.repo}) | add // {}
+' "$MP_SRC") || exit 1
+# everything else except source:directory (machine-local) → {name: url|repo|path}
+target_private=$(jq -c '
+    [to_entries[] | select(.value.source.source != "github" and .value.source.source != "directory")]
+    | map({(.key): (.value.source.repo // .value.source.url // .value.source.path)}) | add // {}
+' "$MP_SRC") || exit 1
+
+# scope:user plugins whose marketplace (part after `@`) is a key of $1.
+_target_plugins_for_mp() {
+	jq -c --argjson mp "$1" '
+        [(.plugins // {}) | to_entries[]
+            | select(any(.value[]?; .scope == "user"))
+            | .key
+            | select($mp[(. | split("@") | last)] != null)
+        ] | unique
+    ' "$PL_SRC"
+}
+plugins_common=$(_target_plugins_for_mp "$target_common") || exit 1
+plugins_private=$(_target_plugins_for_mp "$target_private") || exit 1
+
+# Compact JSON of file $1, or default $2 when missing/empty/invalid.
+_read_json_or() {
+	local out
+	out=$(jq -c '.' "$1" 2>/dev/null)
+	[ -n "$out" ] && printf '%s' "$out" || printf '%s' "$2"
+}
+
+# --- diff helpers ---------------------------------------------------------
+# Each prints drift lines to stdout and returns 1 when it found any.
+
+_diff_marketplaces() {
+	local current_file="$1" target="$2" current lines
+	current=$(_read_json_or "$current_file" '{}')
+	lines=$(jq -rn --argjson c "$current" --argjson t "$target" '
+        [ ($t | to_entries[] | select($c[.key] == null) | "  + \(.key) (\(.value))"),
+          ($c | to_entries[] | select($t[.key] == null) | "  - \(.key) (유령 — SSOT 에 없음)"),
+          ($t | to_entries[] | select($c[.key] != null and $c[.key] != .value)
+                             | "  ~ \(.key): \($c[.key]) -> \(.value)") ]
+        | .[]
+    ')
+	[ -z "$lines" ] && return 0
+	printf '%s\n' "$lines"
+	return 1
+}
+
+_diff_plugins() {
+	local current_file="$1" target="$2" current lines
+	current=$(_read_json_or "$current_file" '{"plugins":[]}')
+	lines=$(jq -rn --argjson c "$current" --argjson t "$target" '
+        ($c.plugins // []) as $cur |
+        [ ($t[]   | select(. as $x | ($cur | index($x)) | not) | "  + \(.)"),
+          ($cur[] | select(. as $x | ($t   | index($x)) | not) | "  - \(.) (유령 — SSOT 에 없음)") ]
+        | .[]
+    ')
+	[ -z "$lines" ] && return 0
+	printf '%s\n' "$lines"
+	return 1
+}
+
+# --- --check --------------------------------------------------------------
+
+_run_check() {
+	local drift=0 out
+
+	echo "== 공용(github) 매니페스트 =="
+	if out=$(_diff_marketplaces "$PUB_DIR/marketplaces.json" "$target_common"); then :; else
+		drift=1
+		echo "marketplaces.json:"
+		printf '%s\n' "$out"
+	fi
+	if out=$(_diff_plugins "$PUB_DIR/plugins.json" "$plugins_common"); then :; else
+		drift=1
+		echo "plugins.json:"
+		printf '%s\n' "$out"
+	fi
+
+	if [ "$COMPANY_ACTIVE" -eq 1 ]; then
+		echo "== 사내(company) 매니페스트 =="
+		if out=$(_diff_marketplaces "$PRIV_DIR/marketplaces.json" "$target_private"); then :; else
+			drift=1
+			echo "company/marketplaces.json:"
+			printf '%s\n' "$out"
+		fi
+		if out=$(_diff_plugins "$PRIV_DIR/plugins.json" "$plugins_private"); then :; else
+			drift=1
+			echo "company/plugins.json:"
+			printf '%s\n' "$out"
+		fi
+	else
+		echo "(company/ 건너뜀 — 모드: ${MODE:-미설정})"
+	fi
+
+	if [ "$drift" -eq 0 ]; then
+		echo "no drift — SSOT 와 매니페스트가 일치합니다."
+		return 0
+	fi
+	echo "drift 감지 — 복구하려면: reconcile.sh --apply"
+	return 1
+}
+
+# --- --apply --------------------------------------------------------------
+
+# Write pretty (2-space) JSON to $1 only when the content actually differs,
+# so an unchanged file keeps its mtime and never triggers a no-op commit.
+_write_if_changed() {
+	local target_file="$1" content="$2" tmp
+	tmp="$target_file.tmp"
+	printf '%s\n' "$content" >"$tmp" || return 1
+	if [ -f "$target_file" ] && cmp -s "$tmp" "$target_file"; then
+		rm -f "$tmp"
+		return 0
+	fi
+	mv "$tmp" "$target_file"
+}
+
+# Stage + commit the given absolute paths in repo $1 only if they changed.
+# Mirrors plugin-sync.sh's _commit_if_changed (ALLOW_MAIN_COMMIT escape hatch
+# included) but takes absolute paths so it is independent of nesting depth.
+_commit_if_changed() {
+	local repo_dir="$1" msg="$2" f
+	shift 2
+	for f in "$@"; do
+		[ -f "$f" ] && set -- "$@" "$f"
+		shift
+	done
+	[ "$#" -gt 0 ] || return 0
+	git -C "$repo_dir" add -- "$@" 2>/dev/null || return 0
+	git -C "$repo_dir" diff --cached --quiet -- "$@" 2>/dev/null && return 0
+	if ! ALLOW_MAIN_COMMIT=1 git -C "$repo_dir" commit -m "$msg" --quiet 2>/dev/null; then
+		if git -C "$repo_dir" reset -q -- "$@" 2>/dev/null; then
+			echo "reconcile: manifest commit failed in $repo_dir; changes left unstaged" >&2
+		else
+			echo "reconcile: manifest commit failed in $repo_dir; failed to unstage changes" >&2
+		fi
+	fi
+}
+
+_run_apply() {
+	if [ -z "$MAIN_ROOT" ]; then
+		echo "git 저장소를 찾을 수 없습니다 ($SCRIPT_DIR). dotfiles 안에서 실행하세요." >&2
+		exit 1
+	fi
+
+	local mp_pretty pl_pretty
+	mp_pretty=$(jq -n --argjson x "$target_common" '$x')
+	pl_pretty=$(jq -n --argjson p "$plugins_common" '{plugins: $p}')
+	_write_if_changed "$PUB_DIR/marketplaces.json" "$mp_pretty"
+	_write_if_changed "$PUB_DIR/plugins.json" "$pl_pretty"
+	_commit_if_changed "$MAIN_ROOT" "$SYNC_MSG" \
+		"$PUB_DIR/marketplaces.json" "$PUB_DIR/plugins.json"
+
+	if [ "$COMPANY_ACTIVE" -eq 1 ]; then
+		mp_pretty=$(jq -n --argjson x "$target_private" '$x')
+		pl_pretty=$(jq -n --argjson p "$plugins_private" '{plugins: $p}')
+		_write_if_changed "$PRIV_DIR/marketplaces.json" "$mp_pretty"
+		_write_if_changed "$PRIV_DIR/plugins.json" "$pl_pretty"
+		_commit_if_changed "$PRIV_DIR" "$SYNC_MSG" \
+			"$PRIV_DIR/marketplaces.json" "$PRIV_DIR/plugins.json"
+	fi
+
+	echo "apply 완료. 확인: reconcile.sh --check"
+}
+
+case "$MODE_ACTION" in
+check) _run_check ;;
+apply) _run_apply ;;
+esac

--- a/claude/plugin/reconcile.sh
+++ b/claude/plugin/reconcile.sh
@@ -85,9 +85,14 @@ PL_SRC="$SHARED_DIR/installed_plugins.json"
 SYNC_MSG="chore(claude-plugin): sync manifest"
 
 # internal PC + cloned company/ repo → the private manifest is in scope.
-MODE=$(cat "$HOME/.dotfiles-setup-mode" 2>/dev/null || echo "")
+# `.git` is a *file* in a worktree, so probe with `git rev-parse --git-dir`
+# rather than `[ -d .git ]` (worktree-safe, matches the repo convention).
+MODE=""
+if [ -f "$HOME/.dotfiles-setup-mode" ]; then
+	MODE=$(cat "$HOME/.dotfiles-setup-mode")
+fi
 COMPANY_ACTIVE=0
-if [ "$MODE" = "internal" ] && [ -d "$PRIV_DIR/.git" ]; then
+if [ "$MODE" = "internal" ] && git -C "$PRIV_DIR" rev-parse --git-dir >/dev/null 2>&1; then
 	COMPANY_ACTIVE=1
 fi
 
@@ -127,9 +132,15 @@ plugins_private=$(_target_plugins_for_mp "$target_private") || exit 1
 
 # Compact JSON of file $1, or default $2 when missing/empty/invalid.
 _read_json_or() {
-	local out
-	out=$(jq -c '.' "$1" 2>/dev/null)
-	[ -n "$out" ] && printf '%s' "$out" || printf '%s' "$2"
+	local out=""
+	if [ -f "$1" ]; then
+		out=$(jq -c '.' "$1" 2>/dev/null)
+	fi
+	if [ -n "$out" ]; then
+		printf '%s' "$out"
+	else
+		printf '%s' "$2"
+	fi
 }
 
 # --- diff helpers ---------------------------------------------------------
@@ -170,12 +181,12 @@ _run_check() {
 	local drift=0 out
 
 	echo "== 공용(github) 매니페스트 =="
-	if out=$(_diff_marketplaces "$PUB_DIR/marketplaces.json" "$target_common"); then :; else
+	if ! out=$(_diff_marketplaces "$PUB_DIR/marketplaces.json" "$target_common"); then
 		drift=1
 		echo "marketplaces.json:"
 		printf '%s\n' "$out"
 	fi
-	if out=$(_diff_plugins "$PUB_DIR/plugins.json" "$plugins_common"); then :; else
+	if ! out=$(_diff_plugins "$PUB_DIR/plugins.json" "$plugins_common"); then
 		drift=1
 		echo "plugins.json:"
 		printf '%s\n' "$out"
@@ -183,12 +194,12 @@ _run_check() {
 
 	if [ "$COMPANY_ACTIVE" -eq 1 ]; then
 		echo "== 사내(company) 매니페스트 =="
-		if out=$(_diff_marketplaces "$PRIV_DIR/marketplaces.json" "$target_private"); then :; else
+		if ! out=$(_diff_marketplaces "$PRIV_DIR/marketplaces.json" "$target_private"); then
 			drift=1
 			echo "company/marketplaces.json:"
 			printf '%s\n' "$out"
 		fi
-		if out=$(_diff_plugins "$PRIV_DIR/plugins.json" "$plugins_private"); then :; else
+		if ! out=$(_diff_plugins "$PRIV_DIR/plugins.json" "$plugins_private"); then
 			drift=1
 			echo "company/plugins.json:"
 			printf '%s\n' "$out"
@@ -227,10 +238,14 @@ _commit_if_changed() {
 	local repo_dir="$1" msg="$2" f
 	shift 2
 	for f in "$@"; do
-		[ -f "$f" ] && set -- "$@" "$f"
+		if [ -f "$f" ]; then
+			set -- "$@" "$f"
+		fi
 		shift
 	done
-	[ "$#" -gt 0 ] || return 0
+	if [ "$#" -eq 0 ]; then
+		return 0
+	fi
 	git -C "$repo_dir" add -- "$@" 2>/dev/null || return 0
 	git -C "$repo_dir" diff --cached --quiet -- "$@" 2>/dev/null && return 0
 	if ! ALLOW_MAIN_COMMIT=1 git -C "$repo_dir" commit -m "$msg" --quiet 2>/dev/null; then

--- a/shell-common/functions/ai_tools_help.sh
+++ b/shell-common/functions/ai_tools_help.sh
@@ -93,6 +93,9 @@ _claude_help_rows_plugin() {
     ux_table_row "./claude/plugin/restore.sh --dry-run" "실행 없이 계획만 출력 (--sync와 조합 가능)" ""
     ux_table_row "./claude/plugin/publish-sync.sh" "로컬에 쌓인 manifest sync 커밋을 PR로 origin에 게시" ""
     ux_table_row "./claude/plugin/publish-sync.sh --dry-run" "게시할 diff만 출력, 변경 없음" ""
+    ux_table_row "./claude/plugin/reconcile.sh --check" "SSOT(installed_plugins) 대비 manifest drift 감지 (유령 엔트리 포함)" ""
+    ux_table_row "./claude/plugin/reconcile.sh --apply" "manifest를 SSOT 기준으로 재빌드 + 커밋 (drift 복구)" ""
+    ux_table_row "claude-plugin-list" "설치된 플러그인을 마켓플레이스별로 요약 출력" ""
 }
 
 _claude_help_render_section() {

--- a/shell-common/functions/claude_plugin_list.sh
+++ b/shell-common/functions/claude_plugin_list.sh
@@ -15,20 +15,22 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 # Resolve the plugins state dir: explicit override → default shared dir →
 # CLAUDE_CONFIG_DIR-derived. First one that actually holds the SSOT wins.
 _claude_plugin_list_dir() {
+    local cand
     for cand in \
         "${CLAUDE_SHARED_PLUGINS_DIR:-}" \
         "$HOME/.claude-shared/plugins" \
         "${CLAUDE_CONFIG_DIR:+$CLAUDE_CONFIG_DIR/plugins}"; do
-        [ -n "$cand" ] || continue
-        [ -f "$cand/installed_plugins.json" ] && {
+        if [ -n "$cand" ] && [ -f "$cand/installed_plugins.json" ]; then
             printf '%s' "$cand"
             return 0
-        }
+        fi
     done
     return 1
 }
 
 claude_plugin_list() {
+    local shared_dir pl_src mp_src mp_json count
+
     case "${1:-}" in
     -h | --help | help)
         ux_info "Usage: claude-plugin-list"
@@ -39,25 +41,28 @@ claude_plugin_list() {
         ;;
     esac
 
-    command -v jq >/dev/null 2>&1 || {
+    if ! command -v jq >/dev/null 2>&1; then
         ux_error "jq가 필요합니다."
         return 1
-    }
+    fi
 
-    shared_dir=$(_claude_plugin_list_dir) || {
+    if ! shared_dir=$(_claude_plugin_list_dir); then
         ux_error "installed_plugins.json 을 찾을 수 없습니다."
         ux_info "확인 경로: \${CLAUDE_SHARED_PLUGINS_DIR}, ~/.claude-shared/plugins, \${CLAUDE_CONFIG_DIR}/plugins"
         return 1
-    }
+    fi
     pl_src="$shared_dir/installed_plugins.json"
     mp_src="$shared_dir/known_marketplaces.json"
 
-    # marketplace → repo|url|path map (empty object if the file is absent).
-    mp_json=$(jq -c '
-        [to_entries[] | {(.key): (.value.source.repo // .value.source.url // .value.source.path // "")}]
-        | add // {}
-    ' "$mp_src" 2>/dev/null)
-    [ -n "$mp_json" ] || mp_json='{}'
+    # marketplace → repo|url|path map (empty object when the file is absent).
+    mp_json='{}'
+    if [ -f "$mp_src" ]; then
+        mp_json=$(jq -c '
+            [to_entries[] | {(.key): (.value.source.repo // .value.source.url // .value.source.path // "")}]
+            | add // {}
+        ' "$mp_src" 2>/dev/null)
+        [ -n "$mp_json" ] || mp_json='{}'
+    fi
 
     ux_header "Installed Claude Code Plugins"
 

--- a/shell-common/functions/claude_plugin_list.sh
+++ b/shell-common/functions/claude_plugin_list.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# shell-common/functions/claude_plugin_list.sh
+#
+# claude-plugin-list — human-readable summary of installed Claude Code plugins,
+# grouped by the marketplace that provided them. Answers the question the
+# `/plugins` card UI makes tedious: "did this `superpowers` come from
+# claude-plugins-official or superpowers-dev?".
+#
+# SSOT is ~/.claude-shared/plugins/installed_plugins.json (+ known_marketplaces
+# .json for the repo/url per marketplace). Path is overridable via
+# CLAUDE_SHARED_PLUGINS_DIR, then falls back to $CLAUDE_CONFIG_DIR/plugins.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# Resolve the plugins state dir: explicit override → default shared dir →
+# CLAUDE_CONFIG_DIR-derived. First one that actually holds the SSOT wins.
+_claude_plugin_list_dir() {
+    for cand in \
+        "${CLAUDE_SHARED_PLUGINS_DIR:-}" \
+        "$HOME/.claude-shared/plugins" \
+        "${CLAUDE_CONFIG_DIR:+$CLAUDE_CONFIG_DIR/plugins}"; do
+        [ -n "$cand" ] || continue
+        [ -f "$cand/installed_plugins.json" ] && {
+            printf '%s' "$cand"
+            return 0
+        }
+    done
+    return 1
+}
+
+claude_plugin_list() {
+    case "${1:-}" in
+    -h | --help | help)
+        ux_info "Usage: claude-plugin-list"
+        ux_bullet "설치된 플러그인을 마켓플레이스별로 그룹핑해 출력"
+        ux_bullet_sub "SSOT: ~/.claude-shared/plugins/installed_plugins.json"
+        ux_bullet_sub "override: CLAUDE_SHARED_PLUGINS_DIR / CLAUDE_CONFIG_DIR"
+        return 0
+        ;;
+    esac
+
+    command -v jq >/dev/null 2>&1 || {
+        ux_error "jq가 필요합니다."
+        return 1
+    }
+
+    shared_dir=$(_claude_plugin_list_dir) || {
+        ux_error "installed_plugins.json 을 찾을 수 없습니다."
+        ux_info "확인 경로: \${CLAUDE_SHARED_PLUGINS_DIR}, ~/.claude-shared/plugins, \${CLAUDE_CONFIG_DIR}/plugins"
+        return 1
+    }
+    pl_src="$shared_dir/installed_plugins.json"
+    mp_src="$shared_dir/known_marketplaces.json"
+
+    # marketplace → repo|url|path map (empty object if the file is absent).
+    mp_json=$(jq -c '
+        [to_entries[] | {(.key): (.value.source.repo // .value.source.url // .value.source.path // "")}]
+        | add // {}
+    ' "$mp_src" 2>/dev/null)
+    [ -n "$mp_json" ] || mp_json='{}'
+
+    ux_header "Installed Claude Code Plugins"
+
+    count=$(jq -r '(.plugins // {}) | length' "$pl_src" 2>/dev/null)
+    if [ -z "$count" ] || [ "$count" = "0" ]; then
+        ux_info "설치된 플러그인이 없습니다: $pl_src"
+        return 0
+    fi
+
+    # Emit a pipe-delimited stream: one MP line per marketplace group, then a
+    # PL line per install record. `|` never appears in marketplace repos,
+    # plugin names, versions, scopes, or ISO dates, so it is a safe delimiter.
+    jq -r --argjson mp "$mp_json" '
+        (.plugins // {}) | to_entries
+        | map(. + {mp: (.key | split("@") | last), name: (.key | sub("@[^@]*$"; ""))})
+        | group_by(.mp) | .[]
+        | ("MP|" + .[0].mp + "|" + (($mp[.[0].mp]) // "unknown")),
+          (.[] | . as $e | $e.value[]
+            | "PL|" + $e.name
+              + "|" + (.version // "unknown")
+              + "|" + (.scope // "?")
+              + "|" + ((.installedAt // "")[0:10]))
+    ' "$pl_src" 2>/dev/null |
+        while IFS='|' read -r kind a b c d; do
+            case "$kind" in
+            MP) ux_section "$a  ($b)" ;;
+            PL) ux_bullet "$(printf '%-22s %-9s %-6s %s' "$a" "$b" "$c" "$d")" ;;
+            esac
+        done
+}
+
+alias claude-plugin-list='claude_plugin_list'

--- a/shell-common/functions/claude_plugin_list.sh
+++ b/shell-common/functions/claude_plugin_list.sh
@@ -12,9 +12,18 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
+# Inline help (`_<prefix>_help`) — Type 1 simple function, 0 sub-commands, so
+# help lives beside the dispatcher per command-design-pattern.md §7.
+_cpl_help() {
+    ux_info "Usage: claude-plugin-list"
+    ux_bullet "설치된 플러그인을 마켓플레이스별로 그룹핑해 출력"
+    ux_bullet_sub "SSOT: ~/.claude-shared/plugins/installed_plugins.json"
+    ux_bullet_sub "override: CLAUDE_SHARED_PLUGINS_DIR / CLAUDE_CONFIG_DIR"
+}
+
 # Resolve the plugins state dir: explicit override → default shared dir →
 # CLAUDE_CONFIG_DIR-derived. First one that actually holds the SSOT wins.
-_claude_plugin_list_dir() {
+_cpl_resolve_dir() {
     local cand
     for cand in \
         "${CLAUDE_SHARED_PLUGINS_DIR:-}" \
@@ -33,10 +42,7 @@ claude_plugin_list() {
 
     case "${1:-}" in
     -h | --help | help)
-        ux_info "Usage: claude-plugin-list"
-        ux_bullet "설치된 플러그인을 마켓플레이스별로 그룹핑해 출력"
-        ux_bullet_sub "SSOT: ~/.claude-shared/plugins/installed_plugins.json"
-        ux_bullet_sub "override: CLAUDE_SHARED_PLUGINS_DIR / CLAUDE_CONFIG_DIR"
+        _cpl_help
         return 0
         ;;
     esac
@@ -46,7 +52,7 @@ claude_plugin_list() {
         return 1
     fi
 
-    if ! shared_dir=$(_claude_plugin_list_dir); then
+    if ! shared_dir=$(_cpl_resolve_dir); then
         ux_error "installed_plugins.json 을 찾을 수 없습니다."
         ux_info "확인 경로: \${CLAUDE_SHARED_PLUGINS_DIR}, ~/.claude-shared/plugins, \${CLAUDE_CONFIG_DIR}/plugins"
         return 1

--- a/tests/bats/functions/claude_help_plugin.bats
+++ b/tests/bats/functions/claude_help_plugin.bats
@@ -41,6 +41,14 @@ _run_claude_help() {
     assert_output --partial 'claude/plugin/publish-sync.sh'
 }
 
+@test "claude-help plugin lists reconcile.sh and claude-plugin-list" {
+    run _run_claude_help plugin
+    assert_success
+    assert_output --partial 'claude/plugin/reconcile.sh --check'
+    assert_output --partial 'claude/plugin/reconcile.sh --apply'
+    assert_output --partial 'claude-plugin-list'
+}
+
 @test "claude-help --all renders the plugin section" {
     run _run_claude_help --all
     assert_success

--- a/tests/bats/functions/claude_plugin_list.bats
+++ b/tests/bats/functions/claude_plugin_list.bats
@@ -40,6 +40,34 @@ JSON
 JSON
 }
 
+# --- command-design-pattern.md §10 structural checks ------------------------
+
+_run_probe() {
+    bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh'
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/claude_plugin_list.sh'
+        $1
+    "
+}
+
+@test "claude_plugin_list: public function exists" {
+    run _run_probe 'type claude_plugin_list'
+    assert_success
+    assert_output --partial 'function'
+}
+
+@test "claude_plugin_list: private sub-functions exist (_cpl_help, _cpl_resolve_dir)" {
+    run _run_probe 'type _cpl_help && type _cpl_resolve_dir'
+    assert_success
+}
+
+@test "claude_plugin_list: alias claude-plugin-list maps to the function" {
+    run _run_probe 'alias claude-plugin-list'
+    assert_success
+    assert_output --partial 'claude_plugin_list'
+}
+
 @test "claude-plugin-list --help prints usage without needing the SSOT" {
     run _run_list --help
     assert_success

--- a/tests/bats/functions/claude_plugin_list.bats
+++ b/tests/bats/functions/claude_plugin_list.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# tests/bats/functions/claude_plugin_list.bats
+# shell-common/functions/claude_plugin_list.sh — 마켓플레이스별 그룹 요약 뷰.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    export CLAUDE_SHARED_PLUGINS_DIR="$TEST_TEMP_HOME/shared"
+    mkdir -p "$CLAUDE_SHARED_PLUGINS_DIR"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+_run_list() {
+    bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        export HOME='$TEST_TEMP_HOME'
+        export CLAUDE_SHARED_PLUGINS_DIR='$CLAUDE_SHARED_PLUGINS_DIR'
+        unset CLAUDE_CONFIG_DIR
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh'
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/claude_plugin_list.sh'
+        claude_plugin_list ${1:-}
+    "
+}
+
+_seed() {
+    cat > "$CLAUDE_SHARED_PLUGINS_DIR/known_marketplaces.json" <<'JSON'
+{
+  "official": {"source": {"source": "github", "repo": "anthropics/claude-plugins-official"}}
+}
+JSON
+    cat > "$CLAUDE_SHARED_PLUGINS_DIR/installed_plugins.json" <<'JSON'
+{"plugins": {
+  "superpowers@official":  [{"scope": "user", "version": "6.0.3", "installedAt": "2026-05-22T00:00:00Z"}],
+  "hookify@official":      [{"scope": "user", "version": "unknown", "installedAt": "2026-05-09T00:00:00Z"}]
+}}
+JSON
+}
+
+@test "claude-plugin-list --help prints usage without needing the SSOT" {
+    run _run_list --help
+    assert_success
+    assert_output --partial 'claude-plugin-list'
+}
+
+@test "claude-plugin-list groups plugins under their marketplace with the repo" {
+    _seed
+    run _run_list
+    assert_success
+    assert_output --partial 'official  (anthropics/claude-plugins-official)'
+    assert_output --partial 'superpowers'
+    assert_output --partial '6.0.3'
+    assert_output --partial 'hookify'
+}
+
+@test "claude-plugin-list shows 'unknown' versions rather than hiding them" {
+    _seed
+    run _run_list
+    assert_success
+    assert_output --partial 'unknown'
+}
+
+@test "claude-plugin-list errors clearly when the SSOT is absent" {
+    run _run_list
+    assert_failure
+    assert_output --partial 'installed_plugins.json 을 찾을 수 없습니다'
+}
+
+@test "claude-plugin-list reports an empty plugin set gracefully" {
+    echo '{}' > "$CLAUDE_SHARED_PLUGINS_DIR/known_marketplaces.json"
+    echo '{"plugins": {}}' > "$CLAUDE_SHARED_PLUGINS_DIR/installed_plugins.json"
+    run _run_list
+    assert_success
+    assert_output --partial '설치된 플러그인이 없습니다'
+}

--- a/tests/bats/tools/claude_plugin_reconcile.bats
+++ b/tests/bats/tools/claude_plugin_reconcile.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/bats/tools/claude_plugin_reconcile.bats
+# claude/plugin/reconcile.sh — SSOT → manifest full-recompute drift 감지/복구.
+# 실제 claude CLI 를 부르지 않으며, SSOT 는 CLAUDE_SHARED_PLUGINS_DIR 픽스처로 주입한다.
+
+load '../test_helper'
+
+RECONCILE="${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/reconcile.sh"
+
+setup() {
+    setup_isolated_home
+    # A throwaway git repo hosting the public manifest, so --apply can commit.
+    REPO="$TEST_TEMP_HOME/repo"
+    mkdir -p "$REPO/claude/plugin"
+    cp "$RECONCILE" "$REPO/claude/plugin/reconcile.sh"
+    chmod +x "$REPO/claude/plugin/reconcile.sh"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@example.com
+    git -C "$REPO" config user.name tester
+    SCRIPT="$REPO/claude/plugin/reconcile.sh"
+
+    export CLAUDE_SHARED_PLUGINS_DIR="$TEST_TEMP_HOME/shared"
+    mkdir -p "$CLAUDE_SHARED_PLUGINS_DIR"
+    cat > "$CLAUDE_SHARED_PLUGINS_DIR/known_marketplaces.json" <<'JSON'
+{
+  "official":   {"source": {"source": "github", "repo": "anthropics/official"}},
+  "understand": {"source": {"source": "github", "repo": "Egonex-AI/Understand"}},
+  "localdir":   {"source": {"source": "directory", "path": "/opt/x"}}
+}
+JSON
+    cat > "$CLAUDE_SHARED_PLUGINS_DIR/installed_plugins.json" <<'JSON'
+{"plugins": {
+  "superpowers@official":         [{"scope": "user"}],
+  "understand-anything@understand": [{"scope": "user"}],
+  "localthing@localdir":          [{"scope": "user"}]
+}}
+JSON
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# In-sync manifest fixture (matches the SSOT above, directory-source excluded).
+_seed_in_sync_manifest() {
+    cat > "$REPO/claude/plugin/marketplaces.json" <<'JSON'
+{
+  "official": "anthropics/official",
+  "understand": "Egonex-AI/Understand"
+}
+JSON
+    cat > "$REPO/claude/plugin/plugins.json" <<'JSON'
+{
+  "plugins": [
+    "superpowers@official",
+    "understand-anything@understand"
+  ]
+}
+JSON
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm seed
+}
+
+# Drifted manifest: a ghost marketplace + ghost plugin, and missing 'understand'.
+_seed_drifted_manifest() {
+    cat > "$REPO/claude/plugin/marketplaces.json" <<'JSON'
+{"official": "anthropics/official", "ghost-mp": "someone/ghost"}
+JSON
+    cat > "$REPO/claude/plugin/plugins.json" <<'JSON'
+{"plugins": ["superpowers@official", "ghost@ghost-mp"]}
+JSON
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm seed
+}
+
+@test "reconcile.sh --help prints usage and exits 0" {
+    run "$SCRIPT" --help
+    assert_success
+    assert_output --partial 'Usage: reconcile.sh'
+    assert_output --partial '--apply'
+}
+
+@test "reconcile.sh rejects an unknown flag" {
+    run "$SCRIPT" --bogus
+    assert_failure 2
+    assert_output --partial '알 수 없는 인자: --bogus'
+}
+
+@test "reconcile.sh --check on an in-sync manifest reports no drift, exit 0" {
+    _seed_in_sync_manifest
+    run "$SCRIPT" --check
+    assert_success
+    assert_output --partial 'no drift'
+}
+
+@test "reconcile.sh defaults to --check when no flag is given" {
+    _seed_in_sync_manifest
+    run "$SCRIPT"
+    assert_success
+    assert_output --partial 'no drift'
+}
+
+@test "reconcile.sh --check on drift prints a table and exits non-zero" {
+    _seed_drifted_manifest
+    run "$SCRIPT" --check
+    assert_failure
+    assert_output --partial '+ understand'
+    assert_output --partial '- ghost-mp'
+    assert_output --partial '+ understand-anything@understand'
+    assert_output --partial '- ghost@ghost-mp'
+}
+
+@test "reconcile.sh --apply rebuilds manifest to match SSOT (adds + prunes ghosts)" {
+    _seed_drifted_manifest
+    run "$SCRIPT" --apply
+    assert_success
+
+    # Ghost entries pruned, SSOT entries present, directory-source excluded.
+    run jq -r 'keys | join(",")' "$REPO/claude/plugin/marketplaces.json"
+    assert_output 'official,understand'
+    run jq -r '.plugins | join(",")' "$REPO/claude/plugin/plugins.json"
+    assert_output 'superpowers@official,understand-anything@understand'
+}
+
+@test "reconcile.sh --apply leaves exactly one sync commit, then --check is clean" {
+    _seed_drifted_manifest
+    before=$(git -C "$REPO" rev-list --count HEAD)
+    run "$SCRIPT" --apply
+    assert_success
+    after=$(git -C "$REPO" rev-list --count HEAD)
+    [ "$((after - before))" -eq 1 ]
+    run git -C "$REPO" log -1 --pretty=%s
+    assert_output 'chore(claude-plugin): sync manifest'
+
+    run "$SCRIPT" --check
+    assert_success
+    assert_output --partial 'no drift'
+}
+
+@test "reconcile.sh --apply makes no commit when already in sync" {
+    _seed_in_sync_manifest
+    before=$(git -C "$REPO" rev-list --count HEAD)
+    run "$SCRIPT" --apply
+    assert_success
+    after=$(git -C "$REPO" rev-list --count HEAD)
+    [ "$after" -eq "$before" ]
+}
+
+@test "reconcile.sh errors clearly when the SSOT file is missing" {
+    rm -f "$CLAUDE_SHARED_PLUGINS_DIR/installed_plugins.json"
+    run "$SCRIPT" --check
+    assert_failure 1
+    assert_output --partial 'SSOT 파일이 없습니다'
+    assert_output --partial 'installed_plugins.json'
+}
+
+@test "reconcile.sh skips company/ on a non-internal PC" {
+    echo "external" > "$TEST_TEMP_HOME/.dotfiles-setup-mode"
+    _seed_in_sync_manifest
+    run "$SCRIPT" --check
+    assert_success
+    assert_output --partial 'company/ 건너뜀'
+    refute_output --partial 'company/marketplaces.json'
+}


### PR DESCRIPTION
## 요약

`plugin-sync.sh` PostToolUse 훅은 `claude plugin ...` 이벤트를 받아 매니페스트를
**증분(delta) 갱신** 한다. 이 구조는 훅이 놓친 이벤트로 생긴 유령 엔트리를 정리할 수
없고, 어떤 마켓플레이스가 어떤 플러그인을 제공했는지 육안 확인이 어렵다. 이를 보완하는
정합성 안전망(`reconcile.sh`)과 요약 뷰(`claude-plugin-list`)를 추가한다.

이 PR 은 커밋 1개 (`f6cd4b2`) 로 F-1/F-2/F-3 을 모두 구현한다.

## 변경 내용

### F-1 — `claude/plugin/reconcile.sh` (신규)
- `installed_plugins.json` + `known_marketplaces.json` 을 SSOT 로 삼는 full-recompute.
- `--check` (기본): SSOT vs dotfiles 매니페스트 diff 를 표로 출력, drift 존재 시 non-zero exit.
- `--apply`: 매니페스트를 SSOT 기준으로 재빌드 (유령 엔트리 prune 포함) 후 변경이 있으면
  `chore(claude-plugin): sync manifest` 커밋 하나를 남긴다 (멱등 — 변경 없으면 커밋 안 함).
- github → `claude/plugin/*.json`, non-github → `claude/plugin/company/*.json` 라우팅과
  `scope:user` 필터는 `plugin-sync.sh` 의 jq 규칙을 그대로 재사용 (판정 불일치 방지).
- `~/.dotfiles-setup-mode` 가 `internal` 이 아니면 company/ 처리 건너뜀.
- SSOT 파일 부재 → 원인 경로 포함 명확한 에러 + exit 1.

### F-2 — `shell-common/functions/claude_plugin_list.sh` (신규)
- 설치된 플러그인을 마켓플레이스별로 계층 출력 (플러그인명 · 버전 · scope · installedAt).
- `unknown` 버전 등 비어있지 않은 필드도 그대로 표시. `ux_lib` 렌더링 (raw echo 금지).
- 경로 해석: `CLAUDE_SHARED_PLUGINS_DIR` → `~/.claude-shared/plugins` → `CLAUDE_CONFIG_DIR/plugins`.
- `claude-plugin-list` dash-form 별칭 제공.

### F-3 — `shell-common/functions/ai_tools_help.sh`
- `claude-help plugin` 섹션에 `reconcile.sh --check/--apply` 와 `claude-plugin-list` 라인 추가.

## 테스트
- `tests/bats/tools/claude_plugin_reconcile.bats` (10): help/unknown-flag, in-sync/drift check,
  apply prune+add, 단일 커밋·멱등, SSOT 부재 에러, non-internal company/ skip.
- `tests/bats/functions/claude_plugin_list.bats` (5): 그룹 출력, unknown 버전 표시, SSOT 부재 에러, 빈 집합.
- `tests/bats/functions/claude_help_plugin.bats`: 신규 두 커맨드 노출 회귀 케이스 추가.
- shellcheck + shfmt clean, golden rules 6/6 통과, 전체 bats 스위트 회귀 없음.

## 수용 기준
- [x] `--check` 정합 시 exit 0 + "no drift"
- [x] drift 시 표 diff + non-zero exit
- [x] `--apply` 후 `--check` → "no drift"
- [x] `--apply` 는 sync 커밋 하나만 (변경 없으면 커밋 안 함)
- [x] `claude-plugin-list` 마켓플레이스별 계층 출력 + ux_lib + unknown 필드 표시
- [x] `claude-help plugin` 에 두 커맨드 노출
- [x] non-internal PC 에서 company/ 건너뛰고 정상 종료

Closes #1097

---
<details>
<summary>🤖 AI Metrics · 📊 ~7500 tokens · 👤 ~8 (1 d) h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~7500 tokens · 👤 ~8 (1 d) h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
