### PR TITLE
fix(claude/plugin): 계정별 CLAUDE_CONFIG_DIR 표기로 플러그인 경로 정규화 SessionStart hook 추가 (#1098)

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -89,6 +89,8 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 `claude/hooks/session-start-settings-drift.sh` — `SessionStart` hook, `settings.json`에 등록됨. 모든 모드에서 live `settings.json`은 SSOT의 **실파일**이라 SSOT에 훅을 추가/변경한 커밋 이후 `./setup.sh`(internal: `./aws/setup.sh`) 재실행 전까지 새 훅이 발화하지 않는다(#1086). 이 훅은 SSOT(`claude/settings.json`, 스크립트 경로 기준 상대 해석)와 live(`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`)의 `.hooks` 필드만 jq로 비교해 drift 감지 시 stderr + `additionalContext`로 재시드를 안내한다. Bedrock 오버레이는 `.hooks`를 건드리지 않아 오탐이 없다. 자기 자신의 최초 미설치는 감지 못하지만(체크인 후 1회 재시드 필요) 이후 추가되는 모든 훅은 커버한다. best-effort, 항상 exit 0.
 
+`claude/hooks/session-start-plugin-path-normalize.sh` — `SessionStart` hook, `plugin-sync-session.sh`보다 **먼저** 등록됨(#1098). 모든 계정 `plugins` 디렉터리가 `~/.claude-shared/plugins` 한 곳으로 symlink되어 SSOT를 공유하는데, Claude Code 2.1.199+는 marketplace `installLocation`을 `$CLAUDE_CONFIG_DIR/plugins/marketplaces` 기준 **문자열 prefix로만**(symlink 미해석) 검증한다. 공유 파일에 담긴 단일 표기는 다른 계정에서 "corrupted installLocation"으로 거부되므로, 이 훅이 시작 중인 계정의 `$CLAUDE_CONFIG_DIR` 표기로 `known_marketplaces.json`의 `installLocation`과 `installed_plugins.json`의 `installPath`(예방 차원)를 재작성한다(`~/.claude*/plugins/` prefix만 대상, 그 외 경로는 불변). 경로 **값**만 바꾸고 marketplace/plugin **키셋**은 건드리지 않아 `plugin-sync.sh`의 union-merge/삭제 감지에 영향을 주지 않는다. 의미 변화가 있을 때만 1회 백업 후 재작성하는 멱등 동작이라 매 세션 mtime이 안정적이다. best-effort, 항상 exit 0.
+
 ---
 
 ## Plugin Manifest (claude/plugin/)

--- a/claude/hooks/session-start-plugin-path-normalize.sh
+++ b/claude/hooks/session-start-plugin-path-normalize.sh
@@ -52,45 +52,59 @@ CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 PLUGINS_DIR="$CONFIG_DIR/plugins"
 [ -d "$PLUGINS_DIR" ] || exit 0
 
-# Regex-escape $HOME so its dots/metachars are literal, then match any
-# ~/.claude<suffix>/plugins/ prefix and re-point it at the active config dir.
-# shellcheck disable=SC2016 # single quotes intentional — $ and & are sed syntax
-HOME_RE=$(printf '%s' "$HOME" | sed 's/[.[\*^$(){}+?|/]/\\&/g')
-PATTERN="^${HOME_RE}/\\.claude[^/]*/plugins/"
+# The active config dir's plugins/ — the spelling every path is re-pointed to.
 REPL="$PLUGINS_DIR/"
 
+# renorm(): the jq path-rewrite, shared by both files below. $HOME is passed as
+# a plain string and matched with startswith (no regex escaping — this is why we
+# no longer build a regex from $HOME via sed, which mishandled ] / - and differed
+# across sed implementations). Only the portion AFTER $HOME is regex-matched, and
+# that regex is a CONSTANT (^/.claude<suffix>/plugins/), so it needs no escaping.
+# A value not under ~/.claude*/plugins/ is returned unchanged.
+# shellcheck disable=SC2016 # single quotes intentional — $home/$repl are jq vars
+JQ_RENORM='
+def renorm($home; $repl):
+	if type == "string" and startswith($home) then
+		(.[($home | length):]) as $tail
+		| ($tail | sub("^/\\.claude[^/]*/plugins/"; "")) as $rest
+		| if $rest == $tail then . else $repl + $rest end
+	else . end;
+'
+
 # Rewrite one JSON file in place with the given jq program, touching it (with a
-# single timestamped backup) ONLY when the normalization changes semantic
+# single overwrite-in-place backup) ONLY when the normalization changes semantic
 # content. Change detection compares the normalized output against the ORIGINAL
 # reserialized through jq too, so jq's own reformatting is neutralized on both
 # sides — an already-correct file (whatever its byte formatting) is left as-is.
 # That idempotence keeps mtimes stable and avoids churning plugin-sync-session's
-# baseline hash on every startup.
+# baseline hash on every startup. The backup is a single fixed .backup file (repo
+# SSOT DOTFILES_BACKUP_SUFFIX, not a timestamped .bak) so frequent account
+# switching cannot accumulate backups without bound.
 _normalize_file() {
 	file="$1"
 	prog="$2"
 	[ -f "$file" ] || return 0
 	base=$(jq '.' "$file" 2>/dev/null) || return 0
 	[ -n "$base" ] || return 0
-	new=$(jq --arg pat "$PATTERN" --arg repl "$REPL" "$prog" "$file" 2>/dev/null) || return 0
+	new=$(jq --arg home "$HOME" --arg repl "$REPL" "$JQ_RENORM$prog" "$file" 2>/dev/null) || return 0
 	[ -n "$new" ] || return 0
 	[ "$new" = "$base" ] && return 0
-	cp "$file" "$file.bak.$(date +%Y%m%d-%H%M%S)" 2>/dev/null || return 0
+	cp "$file" "$file.backup" 2>/dev/null || return 0
 	tmp="$file.tmp.$$"
 	printf '%s\n' "$new" >"$tmp" 2>/dev/null || return 0
 	mv "$tmp" "$file" 2>/dev/null || rm -f "$tmp"
 }
 
-# shellcheck disable=SC2016 # single quotes intentional — $pat/$repl are jq vars
+# shellcheck disable=SC2016 # single quotes intentional — $home/$repl are jq vars
 _normalize_file "$PLUGINS_DIR/known_marketplaces.json" '
 	with_entries(
 		if (.value.installLocation | type) == "string"
-		then .value.installLocation |= sub($pat; $repl)
+		then .value.installLocation |= renorm($home; $repl)
 		else . end
 	)
 '
 
-# shellcheck disable=SC2016 # single quotes intentional — $pat/$repl are jq vars
+# shellcheck disable=SC2016 # single quotes intentional — $home/$repl are jq vars
 _normalize_file "$PLUGINS_DIR/installed_plugins.json" '
 	if (.plugins | type) == "object" then
 		.plugins |= with_entries(
@@ -98,7 +112,7 @@ _normalize_file "$PLUGINS_DIR/installed_plugins.json" '
 				if type == "array" then
 					map(
 						if (.installPath | type) == "string"
-						then .installPath |= sub($pat; $repl)
+						then .installPath |= renorm($home; $repl)
 						else . end
 					)
 				else . end

--- a/claude/hooks/session-start-plugin-path-normalize.sh
+++ b/claude/hooks/session-start-plugin-path-normalize.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# claude/hooks/session-start-plugin-path-normalize.sh
+#
+# Claude Code SessionStart hook: rewrite the plugin path fields in the shared
+# plugin SSOT to the ACTIVE $CLAUDE_CONFIG_DIR spelling (#1098).
+#
+# Why: the multi-account layout symlinks every account's plugins dir at one
+# physical store —
+#     ~/.claude/plugins, ~/.claude-work/plugins, ~/.claude-personal/plugins
+#         → ~/.claude-shared/plugins
+# so a single known_marketplaces.json / installed_plugins.json is shared across
+# accounts. Claude Code 2.1.199+ validates each marketplace `installLocation`
+# by a LITERAL string-prefix check against $CLAUDE_CONFIG_DIR/plugins/marketplaces
+# (no symlink resolution). Whatever single spelling the shared file records, it
+# is wrong for every OTHER account, so marketplace refresh fails there with
+# "corrupted installLocation". This hook re-stamps the paths to the account
+# that is starting up, making them physically identical but textually valid.
+#
+# Scope: only prefixes under ~/.claude*/plugins/ are rewritten (any sibling
+# account spelling or the .claude-shared realpath). Custom/out-of-tree install
+# paths are left untouched. Also normalizes installed_plugins.json installPath
+# preventively — today `claude plugin list` does not validate it, but the
+# install/update flows may adopt the same check.
+#
+# Ordering: registered BEFORE plugin-sync-session.sh in the SessionStart array
+# so that hook's baseline snapshot captures the already-normalized bytes. Even
+# out of order it is harmless: this hook only rewrites path VALUES, never the
+# marketplace/plugin KEY SETS that plugin-sync.sh's union-merge and removal
+# detection operate on, so it can never fabricate or drop a manifest entry.
+#
+# Best-effort: always exits 0, never blocks the session. jq missing, files
+# absent, malformed JSON, or an unwritable store → silent no-op. Idempotent:
+# a file is rewritten (and backed up once) ONLY when its content changes, so a
+# steady state leaves mtimes untouched and produces no backup churn.
+#
+# Reference: issue #1098. Sibling SessionStart hooks:
+# session-start-pc-context.sh (#1052), plugin-sync-session.sh (#1082),
+# session-start-settings-drift.sh (#1086).
+set -u
+
+# A hook always receives JSON on stdin; a terminal means it was launched by
+# hand — bail before `cat` blocks forever.
+[ -t 0 ] && exit 0
+input=$(cat 2>/dev/null) || exit 0
+[ -n "$input" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+event=$(printf '%s' "$input" | jq -r '.hook_event_name // ""' 2>/dev/null) || exit 0
+[ "$event" = "SessionStart" ] || exit 0
+
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+PLUGINS_DIR="$CONFIG_DIR/plugins"
+[ -d "$PLUGINS_DIR" ] || exit 0
+
+# Regex-escape $HOME so its dots/metachars are literal, then match any
+# ~/.claude<suffix>/plugins/ prefix and re-point it at the active config dir.
+# shellcheck disable=SC2016 # single quotes intentional — $ and & are sed syntax
+HOME_RE=$(printf '%s' "$HOME" | sed 's/[.[\*^$(){}+?|/]/\\&/g')
+PATTERN="^${HOME_RE}/\\.claude[^/]*/plugins/"
+REPL="$PLUGINS_DIR/"
+
+# Rewrite one JSON file in place with the given jq program, touching it (with a
+# single timestamped backup) ONLY when the normalization changes semantic
+# content. Change detection compares the normalized output against the ORIGINAL
+# reserialized through jq too, so jq's own reformatting is neutralized on both
+# sides — an already-correct file (whatever its byte formatting) is left as-is.
+# That idempotence keeps mtimes stable and avoids churning plugin-sync-session's
+# baseline hash on every startup.
+_normalize_file() {
+	file="$1"
+	prog="$2"
+	[ -f "$file" ] || return 0
+	base=$(jq '.' "$file" 2>/dev/null) || return 0
+	[ -n "$base" ] || return 0
+	new=$(jq --arg pat "$PATTERN" --arg repl "$REPL" "$prog" "$file" 2>/dev/null) || return 0
+	[ -n "$new" ] || return 0
+	[ "$new" = "$base" ] && return 0
+	cp "$file" "$file.bak.$(date +%Y%m%d-%H%M%S)" 2>/dev/null || return 0
+	tmp="$file.tmp.$$"
+	printf '%s\n' "$new" >"$tmp" 2>/dev/null || return 0
+	mv "$tmp" "$file" 2>/dev/null || rm -f "$tmp"
+}
+
+# shellcheck disable=SC2016 # single quotes intentional — $pat/$repl are jq vars
+_normalize_file "$PLUGINS_DIR/known_marketplaces.json" '
+	with_entries(
+		if (.value.installLocation | type) == "string"
+		then .value.installLocation |= sub($pat; $repl)
+		else . end
+	)
+'
+
+# shellcheck disable=SC2016 # single quotes intentional — $pat/$repl are jq vars
+_normalize_file "$PLUGINS_DIR/installed_plugins.json" '
+	if (.plugins | type) == "object" then
+		.plugins |= with_entries(
+			.value |= (
+				if type == "array" then
+					map(
+						if (.installPath | type) == "string"
+						then .installPath |= sub($pat; $repl)
+						else . end
+					)
+				else . end
+			)
+		)
+	else . end
+'
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -8,6 +8,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-plugin-path-normalize.sh"
+          },
+          {
+            "type": "command",
             "command": "${HOME}/dotfiles/claude/hooks/session-start-pc-context.sh"
           },
           {

--- a/tests/bats/skills/plugin_path_normalize_hook.bats
+++ b/tests/bats/skills/plugin_path_normalize_hook.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/bats/skills/plugin_path_normalize_hook.bats
+# claude/hooks/session-start-plugin-path-normalize.sh — rewrites plugin path
+# fields in the shared SSOT to the ACTIVE $CLAUDE_CONFIG_DIR spelling so that
+# Claude Code 2.1.199+'s literal-prefix installLocation check passes in every
+# account, despite all account dirs symlinking to one ~/.claude-shared (#1098).
+
+load '../test_helper'
+
+HOOK="${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/session-start-plugin-path-normalize.sh"
+
+setup() {
+    setup_isolated_home
+    # Shared physical dir + the active-account symlink into it (the #1098 layout).
+    SHARED="$TEST_TEMP_HOME/.claude-shared/plugins"
+    mkdir -p "$SHARED"
+    export CLAUDE_CONFIG_DIR="$TEST_TEMP_HOME/.claude-work"
+    mkdir -p "$TEST_TEMP_HOME/.claude-work"
+    ln -s "$SHARED" "$TEST_TEMP_HOME/.claude-work/plugins"
+    MP="$TEST_TEMP_HOME/.claude-work/plugins/known_marketplaces.json"
+    PL="$TEST_TEMP_HOME/.claude-work/plugins/installed_plugins.json"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+_session_start() {
+    payload='{"hook_event_name":"SessionStart","session_id":"s1","source":"startup"}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+}
+
+# Seed a marketplace file whose installLocation uses the .claude-shared realpath
+# spelling — the corrupted-by-validation state after a raw Claude Code write.
+_seed_shared_spelling() {
+    cat > "$MP" <<JSON
+{"mp-a": {"source": {"source": "github", "repo": "org/a"},
+          "installLocation": "$TEST_TEMP_HOME/.claude-shared/plugins/marketplaces/mp-a"}}
+JSON
+}
+
+@test "installLocation rewritten from .claude-shared to active CLAUDE_CONFIG_DIR spelling" {
+    _seed_shared_spelling
+    _session_start
+    assert_success
+    run jq -r '.["mp-a"].installLocation' "$MP"
+    assert_output "$TEST_TEMP_HOME/.claude-work/plugins/marketplaces/mp-a"
+}
+
+@test "installPath in installed_plugins.json normalized too (#1098 preventive)" {
+    cat > "$PL" <<JSON
+{"plugins": {"plug-a@mp-a": [{"scope": "user",
+        "installPath": "$TEST_TEMP_HOME/.claude-shared/plugins/cache/mp-a/plug-a/1.0.0"}]}}
+JSON
+    _session_start
+    assert_success
+    run jq -r '.plugins["plug-a@mp-a"][0].installPath' "$PL"
+    assert_output "$TEST_TEMP_HOME/.claude-work/plugins/cache/mp-a/plug-a/1.0.0"
+}
+
+@test "idempotent: already-normalized file is left byte-identical (mtime unchanged)" {
+    cat > "$MP" <<JSON
+{"mp-a": {"source": {"source": "github", "repo": "org/a"},
+          "installLocation": "$TEST_TEMP_HOME/.claude-work/plugins/marketplaces/mp-a"}}
+JSON
+    before=$(stat -c %Y "$MP" 2>/dev/null || stat -f %m "$MP")
+    sleep 1
+    _session_start
+    assert_success
+    after=$(stat -c %Y "$MP" 2>/dev/null || stat -f %m "$MP")
+    [ "$before" = "$after" ]
+}
+
+@test "a single backup is written only when a change is made" {
+    _seed_shared_spelling
+    _session_start
+    assert_success
+    run bash -c "ls '$TEST_TEMP_HOME/.claude-shared/plugins/'known_marketplaces.json.bak.* 2>/dev/null | wc -l"
+    assert_output "1"
+}
+
+@test "non-SessionStart event is a no-op" {
+    _seed_shared_spelling
+    payload='{"hook_event_name":"Stop","session_id":"s1"}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    run jq -r '.["mp-a"].installLocation' "$MP"
+    assert_output "$TEST_TEMP_HOME/.claude-shared/plugins/marketplaces/mp-a"
+}
+
+@test "missing SSOT files → clean no-op" {
+    # No MP/PL files created at all.
+    _session_start
+    assert_success
+}
+
+@test "terminal stdin → immediate exit" {
+    _seed_shared_spelling
+    run bash -c "'$HOOK' < /dev/tty" 2>/dev/null || true
+    # File untouched (hook bailed before reading).
+    run jq -r '.["mp-a"].installLocation' "$MP"
+    assert_output "$TEST_TEMP_HOME/.claude-shared/plugins/marketplaces/mp-a"
+}
+
+@test "unrelated (non-.claude) install paths are left untouched" {
+    cat > "$MP" <<JSON
+{"mp-x": {"source": {"source": "github", "repo": "org/x"},
+          "installLocation": "/opt/custom/plugins/marketplaces/mp-x"}}
+JSON
+    _session_start
+    assert_success
+    run jq -r '.["mp-x"].installLocation' "$MP"
+    assert_output "/opt/custom/plugins/marketplaces/mp-x"
+}

--- a/tests/bats/skills/plugin_path_normalize_hook.bats
+++ b/tests/bats/skills/plugin_path_normalize_hook.bats
@@ -71,11 +71,29 @@ JSON
     [ "$before" = "$after" ]
 }
 
-@test "a single backup is written only when a change is made" {
+@test "a single fixed .backup is written when a change is made (repo SSOT suffix)" {
     _seed_shared_spelling
     _session_start
     assert_success
+    # Repo convention is a single .backup file (DOTFILES_BACKUP_SUFFIX), never a
+    # timestamped .bak.* — so repeated account switches cannot accumulate backups.
+    [ -f "$TEST_TEMP_HOME/.claude-shared/plugins/known_marketplaces.json.backup" ]
     run bash -c "ls '$TEST_TEMP_HOME/.claude-shared/plugins/'known_marketplaces.json.bak.* 2>/dev/null | wc -l"
+    assert_output "0"
+}
+
+@test "backups stay bounded: a second change overwrites the single .backup" {
+    _seed_shared_spelling
+    _session_start
+    assert_success
+    # Simulate switching back to the shared spelling, then re-normalizing again.
+    cat > "$MP" <<JSON
+{"mp-a": {"source": {"source": "github", "repo": "org/a"},
+          "installLocation": "$TEST_TEMP_HOME/.claude-shared/plugins/marketplaces/mp-a"}}
+JSON
+    _session_start
+    assert_success
+    run bash -c "ls '$TEST_TEMP_HOME/.claude-shared/plugins/'known_marketplaces.json.backup* 2>/dev/null | wc -l"
     assert_output "1"
 }
 

--- a/tests/bats/skills/plugin_sync_hook_registration.bats
+++ b/tests/bats/skills/plugin_sync_hook_registration.bats
@@ -55,3 +55,22 @@ SETTINGS="${_BATS_REAL_DOTFILES_ROOT}/claude/settings.json"
     ' "$SETTINGS"
     assert_success
 }
+
+@test "SessionStart includes session-start-plugin-path-normalize.sh (#1098)" {
+    run jq -e '
+        .hooks.SessionStart[].hooks[]
+        | select(.command | endswith("claude/hooks/session-start-plugin-path-normalize.sh"))
+    ' "$SETTINGS"
+    assert_success
+}
+
+@test "path-normalize runs BEFORE plugin-sync-session in SessionStart (#1098)" {
+    # The normalizer must re-stamp installLocation before plugin-sync-session
+    # snapshots its baseline, else the baseline captures stale spellings.
+    run jq -e '
+        .hooks.SessionStart[].hooks
+        | (map(.command | endswith("session-start-plugin-path-normalize.sh")) | index(true))
+          < (map(.command | endswith("plugin-sync-session.sh")) | index(true))
+    ' "$SETTINGS"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Claude Code 2.1.199+ 가 marketplace `installLocation` 을 `$CLAUDE_CONFIG_DIR/plugins/marketplaces` 기준 **문자열 prefix 로만**(symlink 미해석) 검증하면서, 멀티 계정 공유 설계(`~/.claude`/`.claude-work`/`.claude-personal` 의 `plugins` 가 모두 `~/.claude-shared/plugins` 로 symlink)와 충돌해 다른 계정에서 "corrupted installLocation" 으로 marketplace refresh 가 실패하던 문제(#1098)를 해결한다.

새 SessionStart hook `claude/hooks/session-start-plugin-path-normalize.sh` 가 세션 시작 중인 계정의 `$CLAUDE_CONFIG_DIR` 표기로 공유 SSOT 의 경로 필드를 재작성한다.

## Changes

- **`claude/hooks/session-start-plugin-path-normalize.sh`** (신규) — `known_marketplaces.json` 의 `installLocation` 과 `installed_plugins.json` 의 `installPath`(예방)를 활성 config dir 표기로 정규화.
  - `~/.claude*/plugins/` prefix 만 대상 — 그 외(예: `/opt/...`) 경로는 불변.
  - 경로 **값**만 변경하고 marketplace/plugin **키셋**은 보존 → `plugin-sync.sh` 의 union-merge/삭제 감지에 영향 없음(오생성 커밋 방지).
  - 의미 변화가 있을 때만 1회 백업 후 재작성하는 **멱등** 동작 — steady state 에서 mtime 불변.
  - best-effort, 항상 exit 0.
- **`claude/settings.json`** — 위 hook 을 SessionStart 에 등록하되 `plugin-sync-session.sh` **보다 먼저** 배치해 baseline 스냅샷이 정규화본을 캡처하도록 함.
- **`claude/AGENTS.md`** — hook 문서 1문단 추가.
- **`tests/bats/skills/plugin_path_normalize_hook.bats`** (신규, 8건) — 정규화 / 예방 필드 / 멱등성 / 백업 / 이벤트 가드 / 터미널 stdin / 무관 경로 보존.
- **`tests/bats/skills/plugin_sync_hook_registration.bats`** (+2건) — SessionStart 등록 + `plugin-sync-session.sh` 대비 순서 검증.

## Verification

- `plugin_path_normalize_hook.bats` 8/8 통과, red-green 확인(hook 제거 시 7건 실패 → 복원 시 8건 통과).
- 관련 hook/plugin bats 전체 53건 통과(회귀 없음).
- 실환경 스모크: `.claude-shared` 표기 픽스처 → 활성 `.claude-work` 표기로 교정, `/opt/...` 경로 불변, 변경 파일당 백업 1개, 2회차 실행 시 백업 미증가(멱등).
- `shellcheck` + `shfmt` clean, `settings.json` 유효 JSON.

Closes #1098

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~11 min</summary>

<!-- ai-metrics -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~11 min
<!-- /ai-metrics -->

</details>
