### PR TITLE
fix(claude/setup): model 이주를 setup 요약 마이그레이션 카운터에 집계 (#1101)

### DIFF
--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -494,7 +494,9 @@ ux_section "Claude Code dotfiles setup"
 # 이번 실행에서 실제로 수행된 마이그레이션 건수 누적 (#997). 완료 직전
 # _print_change_summary 가 이 값을 변경 요약 라인에 집계한다. 마이그레이션
 # 함수들(statusLine / Stop hook / plugin 경로)은 모두 본 스크립트의 최상위
-# 셸에서 호출돼 서브셸 없이 값이 전파된다.
+# 셸에서 호출돼 서브셸 없이 값이 전파된다. model 이주(#940)는 sourced
+# claude.sh 의 _claude_ensure_settings_copy 에서 수행되지만 그 함수 역시
+# 계정 루프의 최상위 셸에서 직접 호출되므로 동일하게 이 값에 집계된다 (#1101).
 SETUP_MIGRATIONS=0
 
 # _print_change_summary — 완료 메시지 직전 "이번 실행에서 바뀐 것" 한 줄

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -703,6 +703,10 @@ _claude_ensure_settings_copy() {
                     printf '{ "model": "%s" }\n' "$_cesc_model" > "$_cesc_local"
                     chmod 600 "$_cesc_local"
                     ux_info "  migrated model '$_cesc_model' → $_cesc_local"
+                    # 변경 요약 집계 (#1101). setup.sh 최상위 셸에서 sourced 되어
+                    # SETUP_MIGRATIONS 를 공유하지만, interactive 소싱 등 변수가
+                    # 미정의인 컨텍스트도 있으므로 ${VAR:-0} 로 set -u 안전 처리.
+                    SETUP_MIGRATIONS=$((${SETUP_MIGRATIONS:-0} + 1))
                 elif [ -z "$(jq -r '.model // empty' "$_cesc_local" 2>/dev/null)" ]; then
                     # mktemp: 명시 템플릿 + TMPDIR 폴백 — BSD/macOS 이식성과
                     # 공유 /tmp 의 예측 가능한 이름 회피 (PR #943 리뷰).
@@ -713,6 +717,8 @@ _claude_ensure_settings_copy() {
                     elif jq --arg m "$_cesc_model" '.model = $m' "$_cesc_local" > "$_cesc_tmp"; then
                         mv "$_cesc_tmp" "$_cesc_local"
                         ux_info "  migrated model '$_cesc_model' → $_cesc_local"
+                        # 변경 요약 집계 (#1101) — set -u 안전. 위 분기와 동일.
+                        SETUP_MIGRATIONS=$((${SETUP_MIGRATIONS:-0} + 1))
                     else
                         rm -f "$_cesc_tmp"
                         ux_warning "  model migration failed — keeping $_cesc_local as-is"


### PR DESCRIPTION
## 요약

`./claude/setup.sh` 완료 요약(`요약: 마이그레이션 N건`)이 계정 루프에서 발생하는 model 이주(`migrated model … → settings.local.json`)를 집계하지 않아, 로그에 찍힌 마이그레이션성 이벤트 수와 요약 숫자가 어긋나던 문제를 수정한다.

## 근본 원인

- 카운터 `SETUP_MIGRATIONS` 는 `claude/setup.sh` 에서 statusline / plugin 경로 / stop-hook 이주 3곳에서만 증가.
- model 이주는 sourced `shell-common/tools/integrations/claude.sh` 의 `_claude_ensure_settings_copy`(`:705`, `:717`)에서 수행되지만 카운터를 올리지 않음 → 요약에서 누락.

## 변경 내용 (이슈 권장안 A)

- **claude.sh** — model 이주 성공 두 지점에서 `SETUP_MIGRATIONS=$(( ${SETUP_MIGRATIONS:-0} + 1 ))` 증가.
  - 호출 체인 `setup.sh` → `_claude_account_setup_one` → `_claude_ensure_settings_copy` 가 서브셸 없이 직접 호출되어 최상위 셸의 변수를 공유함을 확인.
  - `${VAR:-0}` 로 interactive 소싱 등 변수 미정의 컨텍스트에서도 `set -u` 안전.
- **setup.sh** — `SETUP_MIGRATIONS` SSOT 주석에 model 이주 집계 경로를 문서화.

## 검증

- 기능 테스트 3분기 통과:
  - 신규 `settings.local.json` 생성(`:705`) → count +1
  - 기존 local 병합(`:717`) → count +1, 기존 키 보존
  - model 키 없는 실행 → count 불변(회귀 없음), `settings.local.json` 미생성
- `claude_accounts.bats`: #83/#97 실패는 사전 존재(테스트 픽스처가 `claude/workflows` 미스테이징 → precondition 가드에서 실패)로, 본 변경과 무관함을 stash 후 재현으로 확인.

Closes #1101

<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~52s</summary>

<!-- ai-metrics -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~52s
<!-- /ai-metrics -->

</details>
