### PR TITLE
fix(git): ~/.gitconfig include 모델로 gh의 SSOT 오염 근본 차단 + gh SSH 전환

### DIFF
--- a/gh/config.yml
+++ b/gh/config.yml
@@ -1,7 +1,7 @@
 # The current version of the config schema
 version: 1
 # What protocol to use when performing git operations. Supported values: ssh, https
-git_protocol: https
+git_protocol: ssh
 # What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
 editor:
 # When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled

--- a/git/AGENTS.md
+++ b/git/AGENTS.md
@@ -16,6 +16,7 @@
 - **SSOT Config**: Treat `git/config/hook-config.sh` as the single source of truth for patterns and thresholds.
 - **No Surprises**: Hook changes must be fast, deterministic, and explain failures clearly.
 - **Test First**: Add a failing case to `git/tests/test_hooks.sh` before tightening checks.
+- **~/.gitconfig include model (NOT a symlink)**: `git/setup.sh` creates `~/.gitconfig` as a **real machine-local file** whose first section is `[include] path = <repo>/git/.gitconfig`. Never symlink `~/.gitconfig` to the tracked SSOT. Reason: tools that run `git config --global` — chiefly `gh auth setup-git` (triggered by `gh auth login`/`refresh`) — write **through** a symlink and rewrite the SSOT's portable credential-helper line (`git/scripts/gh-credential-helper.sh`, which probes multiple `gh` install paths across PCs) into a machine-specific absolute path, breaking portability. With the include model those writes land in the local file and the SSOT stays clean. Same principle as CLAUDE.md's settings.json "real file, not symlink" rule. Defense in depth: `gh/config.yml` sets `git_protocol: ssh` so `gh` stops managing HTTPS credential helpers at all.
 
 # Testing Strategy
 

--- a/git/setup.sh
+++ b/git/setup.sh
@@ -6,7 +6,13 @@
 # WHEN TO RUN: Via ./setup.sh (do NOT run manually)
 #
 # SPECIAL FEATURES (why this file is REQUIRED):
-#   1. Creates ~/.gitconfig symlink to git/.gitconfig
+#   1. Creates ~/.gitconfig as a REAL machine-local file that [include]s the
+#      tracked SSOT (git/.gitconfig) — NOT a symlink. This mirrors the
+#      settings.json "real file, not symlink" rule in CLAUDE.md: tools that
+#      run `git config --global` (e.g. `gh auth setup-git`) write THROUGH a
+#      symlink and dirty the tracked SSOT with machine-specific absolute
+#      paths. With the include model those writes land in the local file and
+#      the SSOT stays clean. See git/AGENTS.md → "~/.gitconfig include model".
 #   2. Provides user feedback using UX library
 #   3. Ensures proper git configuration initialization
 #
@@ -78,6 +84,51 @@ create_symlink() {
 
     echo "${UX_MUTED}심볼릭 링크 생성: $link_name -> $target${UX_RESET}"
     ln -s "$target" "$link_name" || log_error_and_exit "심볼릭 링크 생성 실패: $link_name -> $target"
+}
+
+
+# ~/.gitconfig 를 "실파일 + [include] SSOT" 모델로 보장합니다 (symlink 금지).
+#
+# WHY: ~/.gitconfig 를 추적 SSOT 로 symlink 하면 `git config --global` 을 쓰는
+# 도구(대표적으로 `gh auth setup-git`)가 symlink 를 관통해 SSOT 를 머신별
+# 절대경로로 덮어써 이식성이 깨진다. include 모델에서는 그런 쓰기가 로컬
+# 실파일에만 쌓이고 SSOT 는 항상 clean 하게 유지된다. (CLAUDE.md 의
+# settings.json "실파일, symlink 아님" 규칙과 동일 원리)
+#
+# 멱등: 이미 include 가 있는 실파일이면 로컬 커스터마이즈를 보존하고 아무것도
+# 하지 않는다. 레거시 symlink 이면 제거 후 실파일로 전환한다.
+ensure_gitconfig_include() {
+    local ssot="$1"
+    local target="$2"
+
+    # 레거시 symlink 제거 (SSOT 는 repo 에 안전하게 있으므로 백업 불필요)
+    if [ -L "$target" ]; then
+        echo "${UX_MUTED}레거시 symlink 제거 (include 모델로 전환): $target${UX_RESET}"
+        rm "$target" || log_error_and_exit "기존 symlink 제거 실패: $target"
+    fi
+
+    if [ -f "$target" ]; then
+        # 이미 SSOT include 가 있으면 멱등 종료 (로컬 설정 보존)
+        if git config --file "$target" --get-all include.path 2>/dev/null | grep -qxF "$ssot"; then
+            ux_info ".gitconfig include 이미 설정됨 — 로컬 커스터마이즈 보존"
+            return 0
+        fi
+        # 실파일은 있는데 include 만 없음 → include 추가 (기존 내용 보존)
+        ux_info ".gitconfig 실파일에 SSOT include 추가"
+        git config --file "$target" --add include.path "$ssot" ||
+            log_error_and_exit "include.path 추가 실패: $target"
+        return 0
+    fi
+
+    # 신규 생성: include 를 최상단에 두어 이후 도구 쓰기가 로컬에 쌓이게 한다
+    ux_info ".gitconfig 실파일 생성 (SSOT include 모델)"
+    {
+        printf '# ~/.gitconfig — machine-local, NOT tracked.\n'
+        printf '# Tool writes (gh, git config --global) land HERE, never the tracked SSOT.\n'
+        printf '# Portable tracked config is included below. See git/AGENTS.md.\n'
+        printf '[include]\n'
+        printf '\tpath = %s\n' "$ssot"
+    } >"$target" || log_error_and_exit ".gitconfig 실파일 생성 실패: $target"
 }
 
 
@@ -215,11 +266,11 @@ setup_ssh_auto || ux_warning "SSH 설정 중 일부 작업이 실패했습니다
 echo ""
 
 
-# .gitconfig 심볼릭 링크 생성
+# .gitconfig: 실파일 + [include] SSOT 모델 (symlink 아님 — 함수 주석 참고)
 if [ -f "$GIT_CONFIG_SOURCE" ]; then
-    create_symlink "$GIT_CONFIG_SOURCE" "$HOME_GITCONFIG"
+    ensure_gitconfig_include "$GIT_CONFIG_SOURCE" "$HOME_GITCONFIG"
 else
-    ux_warning "경고: .gitconfig 파일이 '${GIT_CONFIG_SOURCE}' 경로에 없습니다. 심볼릭 링크를 생성하지 않습니다."
+    ux_warning "경고: .gitconfig SSOT 가 '${GIT_CONFIG_SOURCE}' 경로에 없습니다. include 설정을 건너뜁니다."
 fi
 
 

--- a/git/setup.sh
+++ b/git/setup.sh
@@ -113,11 +113,22 @@ ensure_gitconfig_include() {
             ux_info ".gitconfig include 이미 설정됨 — 로컬 커스터마이즈 보존"
             return 0
         fi
-        # 실파일은 있는데 include 만 없음 → include 추가 (기존 내용 보존)
-        ux_info ".gitconfig 실파일에 SSOT include 추가"
-        git config --file "$target" --add include.path "$ssot" ||
-            log_error_and_exit "include.path 추가 실패: $target"
-        return 0
+        # 실파일은 있는데 include 만 없음 → include 를 "최상단"에 추가.
+        # 맨 아래에 추가하면 SSOT 설정이 기존 로컬 설정을 덮어써 우선순위가
+        # 역전됨 (git 은 위→아래 순차 평가, 뒤 값이 이김). PR #1105 gemini 리뷰.
+        ux_info ".gitconfig 실파일 최상단에 SSOT include 추가 (기존 로컬 설정 보존)"
+        local temp_file
+        temp_file=$(mktemp "${TMPDIR:-/tmp}/gitconfig_XXXXXX") ||
+            log_error_and_exit "임시 파일 생성 실패"
+        if {
+            printf '[include]\n\tpath = %s\n' "$ssot"
+            cat "$target"
+        } >"$temp_file" && mv "$temp_file" "$target"; then
+            return 0
+        else
+            rm -f "$temp_file"
+            log_error_and_exit "include.path 최상단 추가 실패: $target"
+        fi
     fi
 
     # 신규 생성: include 를 최상단에 두어 이후 도구 쓰기가 로컬에 쌓이게 한다


### PR DESCRIPTION
## 배경 / 문제

`gh auth refresh`(또는 `gh auth login`) 실행 후 `git/.gitconfig`가 아래처럼 오염됨:

```diff
-	helper = !${DOTFILES_ROOT:-$HOME/dotfiles}/git/scripts/gh-credential-helper.sh
+	helper = !/home/deity719/.local/bin/gh auth git-credential
```

**근본 원인:** `~/.gitconfig`가 추적 SSOT(`git/.gitconfig`)로 **symlink**되어 있어, `gh auth setup-git`(gh auth login/refresh가 트리거) 등 `git config --global`을 쓰는 도구가 symlink를 관통해 SSOT를 **머신별 절대경로**로 덮어씀. 이식성 wrapper(`git/scripts/gh-credential-helper.sh` — PC별 gh 설치 경로를 탐색)가 특정 PC 경로로 치환되어 5-PC 이식성이 깨짐.

## 해법 (이중 방어)

| # | 변경 | 효과 |
|---|------|------|
| 1 | `git/setup.sh` — `~/.gitconfig`를 symlink 대신 **실파일 + `[include] path=SSOT`** 로 생성 (멱등 마이그레이션) | 도구의 `git config --global` 쓰기가 로컬 실파일에만 쌓이고 **SSOT는 항상 clean** |
| 2 | `gh/config.yml` — `git_protocol: https → ssh` | gh가 HTTPS credential helper를 **아예 관리하지 않음** (추가 방어) |
| 3 | `git/AGENTS.md` — include 모델 golden rule 문서화 | 재발 방지 근거 |

`settings.json`을 "실파일(symlink 아님)"로 두어 `/model` 쓰기가 SSOT를 더럽히지 않게 한 CLAUDE.md 선례와 **동일 원리**입니다. SSOT `git/.gitconfig` 내용 자체는 변경하지 않았습니다.

## 검증 (로컬)

- `~/.gitconfig` = 실파일 / SSOT 설정 `[include]`로 정상 해석 (`user.name`, credential helper 등)
- **오염 재발 시뮬레이션**: `gh`와 동일한 `git config --global credential."https://github.com".helper "..."` 쓰기 → **SSOT 변경 0**, 로컬 파일로만 반영
- `gh config get git_protocol` = `ssh` / `git ls-remote origin` (SSH) OK
- `git push`(이 PR) SSH로 정상 동작
- 추가 코드 shellcheck/shfmt(`-i 4`) clean

---

## 5개 PC 반영 가이드

> 각 PC에서 아래를 순서대로 1회씩 실행하세요. 모두 **멱등**이라 여러 번 실행해도 안전합니다.

### 0) 최신 반영

```bash
cd ~/dotfiles        # (PC마다 경로 다를 수 있음)
git switch main
git pull
```

### 1) `~/.gitconfig`를 include 모델로 전환 (핵심)

```bash
bash git/setup.sh
```

- 기존 `~/.gitconfig` symlink를 제거하고 **실파일 + `[include]`** 로 전환합니다.
- 이미 전환된 PC면 "include 이미 설정됨"으로 skip합니다 (로컬 설정 보존).

확인:

```bash
ls -la ~/.gitconfig            # symlink 아닌 '-rw-...' 실파일이어야 함
git config --show-origin --get credential."https://github.com".helper
# → file:.../git/.gitconfig  (SSOT wrapper) 로 나오면 정상
```

> `git/setup.sh`는 SSH 키/에이전트 설정과 hook symlink도 함께 처리합니다. 부작용 없이 멱등합니다. 전체 셋업을 원하면 `./setup.sh`를 써도 됩니다.

### 2) gh를 SSH 프로토콜로 (로컬 hosts.yml override)

`gh/config.yml`(SSOT)은 이 PR로 `ssh`가 되지만, gh는 **로컬 `~/.config/gh/hosts.yml`의 per-host 값을 우선**합니다. 각 PC에서 1회:

```bash
# public / external PC (github.com)
gh config set git_protocol ssh --host github.com

# internal PC (GHE)
gh config set git_protocol ssh --host github.samsungds.net
```

확인:

```bash
gh config get git_protocol      # → ssh
```

> 현재 PC 모드는 `cat ~/.dotfiles-setup-mode` 로 확인 (public/external → github.com, internal → github.samsungds.net).

### 3) (권장) origin 원격을 SSH로

HTTPS로 clone된 PC라면:

```bash
# github.com
git remote set-url origin git@github.com:dEitY719/dotfiles.git
# GHE
# git remote set-url origin git@github.samsungds.net:<org>/dotfiles.git

ssh -T git@github.com          # "Hi dEitY719! ..." 나오면 정상
```

> SSH 키가 그 PC의 GitHub 계정에 등록돼 있어야 합니다. 미등록 시:
> `gh auth refresh -h <host> -s admin:public_key && gh ssh-key add ~/.ssh/id_ed25519.pub --title "$(hostname)"`

### 반영 체크리스트 (PC별)

- [x] msi-laptop (public)
- [ ] PC 2
- [ ] PC 3
- [ ] PC 4
- [ ] PC 5

각 PC에서 1)~3) 완료 후, 다음 `gh auth refresh`를 실행해도 `git/.gitconfig`(SSOT)가 더 이상 오염되지 않는지 `git -C ~/dotfiles status`로 최종 확인하세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
