### PR TITLE
docs(windows): Compact-WSL.ps1 에 -UseSparse 원격 실행 예시 추가

### DIFF
--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -28,6 +28,9 @@
     # 원격 실행 + 파라미터 전달 (iex 는 인자를 못 받으므로 scriptblock 사용):
     & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/dEitY719/dotfiles/main/windows/Compact-WSL.ps1'))) -DistroName "Ubuntu"
 
+    # 원격 실행 + sparse 모드 전환 (이후 자동 축소; iex 대신 scriptblock 필수):
+    & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/dEitY719/dotfiles/main/windows/Compact-WSL.ps1'))) -UseSparse
+
     # 파일로 저장 후 실행:
     .\Compact-WSL.ps1
     .\Compact-WSL.ps1 -UseSparse


### PR DESCRIPTION
## Summary

`windows/Compact-WSL.ps1` 의 `.EXAMPLE` 주석에 `-UseSparse` **원격 실행 예시**를 추가했다.

`iex (irm '...')` 는 다운로드한 스크립트에 파라미터를 전달하지 못하므로, sparse 모드 전환 같은 인자 전달은 `scriptblock` 형태로만 가능하다. 기존 `-DistroName` scriptblock 예시 바로 옆에 `-UseSparse` 예시를 나란히 배치해 원격 실행 시 바로 참고할 수 있게 했다.

## Changes

- `windows/Compact-WSL.ps1`: `.EXAMPLE` 에 `-UseSparse` scriptblock 원격 실행 예시 주석 3줄 추가

## Motivation

기본 compact 후 sparse 모드로 전환하는 2단계 워크플로우를 파일 저장 없이 원격으로 수행할 때, `iex` 로는 `-UseSparse` 를 넘길 수 없다는 점이 문서에 예시로 드러나 있지 않아 혼동될 수 있었다.

## Test

문서(주석) 변경으로 런타임 영향 없음. pre-commit 검증 통과.
