### PR TITLE
fix(windows): Compact-WSL.ps1 sparse 출력 UTF-16LE 디코딩으로 mojibake 제거

### DIFF
--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -205,12 +205,21 @@ if ($UseSparse) {
     # wsl.exe 는 UTF-16LE 로 출력하므로, 콘솔 출력 인코딩을 Unicode 로 잠시
     # 바꿔 캡처해야 한글 메시지와 E_INVALIDARG 문자열이 깨지지 않는다.
     # (안 그러면 CP949 로 오독되어 mojibake + E_INVALIDARG 매칭 실패)
-    $prevOutEnc = [Console]::OutputEncoding
+    # 단, 콘솔 핸들이 없는 비대화형 환경(CI/러너, 백그라운드, 원격 세션 등)에서는
+    # [Console]::OutputEncoding 읽기/쓰기가 IOException("handle is invalid")을
+    # 던질 수 있고 $ErrorActionPreference="Stop" 이라 전체가 중단되므로,
+    # get/set 을 각각 try/catch 로 감싸 인코딩 전환 실패 시에도 계속 진행한다.
+    $prevOutEnc = $null
     try {
+        $prevOutEnc = [Console]::OutputEncoding
         [Console]::OutputEncoding = [System.Text.Encoding]::Unicode
+    } catch {}
+    try {
         $sparseOut = (wsl @sparseArgs 2>&1 | Out-String)
     } finally {
-        [Console]::OutputEncoding = $prevOutEnc
+        if ($null -ne $prevOutEnc) {
+            try { [Console]::OutputEncoding = $prevOutEnc } catch {}
+        }
     }
     $sparseOut.TrimEnd() | Write-Host
 

--- a/windows/Compact-WSL.ps1
+++ b/windows/Compact-WSL.ps1
@@ -202,7 +202,16 @@ if ($UseSparse) {
     if ($AllowUnsafe) { $sparseArgs += '--allow-unsafe' }
 
     # 출력을 캡처해 성공/실패를 $LASTEXITCODE + 메시지로 판정한다.
-    $sparseOut = (wsl @sparseArgs 2>&1 | Out-String)
+    # wsl.exe 는 UTF-16LE 로 출력하므로, 콘솔 출력 인코딩을 Unicode 로 잠시
+    # 바꿔 캡처해야 한글 메시지와 E_INVALIDARG 문자열이 깨지지 않는다.
+    # (안 그러면 CP949 로 오독되어 mojibake + E_INVALIDARG 매칭 실패)
+    $prevOutEnc = [Console]::OutputEncoding
+    try {
+        [Console]::OutputEncoding = [System.Text.Encoding]::Unicode
+        $sparseOut = (wsl @sparseArgs 2>&1 | Out-String)
+    } finally {
+        [Console]::OutputEncoding = $prevOutEnc
+    }
     $sparseOut.TrimEnd() | Write-Host
 
     if ($LASTEXITCODE -eq 0 -and $sparseOut -notmatch 'E_INVALIDARG') {


### PR DESCRIPTION
## 요약

PR #1108 병합 후 `-UseSparse -AllowUnsafe` 재검증 로그에서 `[4/5]` sparse 전환 단계 출력이 깨져 보이던(mojibake) 문제를 수정한다.

```
[4/5] sparse 모드로 전환 중...
뫧탤D?D팟툑蘭쪘꿜?
    [OK] sparse 모드 전환 완료 ...
```

## 원인

`wsl.exe` 는 출력을 **UTF-16LE** 로 내보내는데, `[4/5]` 는 이를 콘솔 기본 인코딩(한국어 Windows=CP949)으로 캡처해 한글 성공 메시지가 깨졌다. `[3/5]` 는 이미 널 바이트 제거로 UTF-16 를 처리하지만 `[4/5]` 에는 그 처리가 빠져 있었다.

부수적으로, 같은 mojibake 때문에 `$sparseOut -notmatch 'E_INVALIDARG'` 및 실패 분기의 `-match 'E_INVALIDARG'` 가이던스 선택기가 무력화됐다. 성공/실패 판정 자체는 `$LASTEXITCODE` 로 안전했으나, 실패 시 `-AllowUnsafe` 맞춤 안내가 일반 안내로 폴백될 수 있었다.

## 변경

- sparse 출력 캡처 구간에서만 `[Console]::OutputEncoding` 을 `Unicode` 로 바꾸고 `finally` 로 원복.
- 이제 한글 메시지가 정상 표시되고, `E_INVALIDARG` 문자열 매칭도 신뢰할 수 있어 맞춤 안내가 정확히 동작한다.

## 검증

- 재검증 로그상 `-AllowUnsafe` 경로는 `$LASTEXITCODE -eq 0` 으로 실제 성공했고 `[OK]` 는 정상 — 기능 회귀 없음.
- 이 수정은 표시/문자열 매칭 정확도만 개선하며 성공/실패 판정 로직은 그대로다.
