### PR TITLE
chore(claude-plugin): superpowers-dev 중복 마켓플레이스 제거

### DIFF
--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -1,6 +1,5 @@
 {
   "anthropic-agent-skills": "anthropics/skills",
-  "superpowers-dev": "obra/superpowers",
   "openai-codex": "openai/codex-plugin-cc",
   "claude-plugins-official": "anthropics/claude-plugins-official",
   "obsidian-skills": "kepano/obsidian-skills",

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -5,6 +5,7 @@
     "document-skills@anthropic-agent-skills",
     "example-skills@anthropic-agent-skills",
     "hookify@claude-plugins-official",
+    "playwright@claude-plugins-official",
     "ralph-loop@claude-plugins-official",
     "session-report@claude-plugins-official",
     "superpowers@claude-plugins-official",

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -9,7 +9,6 @@
     "ralph-loop@claude-plugins-official",
     "session-report@claude-plugins-official",
     "superpowers@claude-plugins-official",
-    "superpowers@superpowers-dev",
     "understand-anything@understand-anything"
   ]
 }


### PR DESCRIPTION
## 배경

`superpowers` 플러그인은 `claude-plugins-official` 마켓플레이스를 통해 설치·유지되고 있는데, dotfiles SSOT 매니페스트에는 `obra/superpowers`(`superpowers-dev`) 중복 항목이 stale 상태로 남아 있었다.

라이브 설정(`~/.claude-shared/plugins/known_marketplaces.json`)에는 이미 `superpowers-dev`가 없었으나(과거 `/plugin` TUI 로 제거 → PostToolUse 훅 미발동), dotfiles 매니페스트만 동기화되지 않아 잔재가 남아 있던 상황.

## 변경

`claude plugin marketplace remove superpowers-dev` 실행 → `claude/hooks/plugin-sync.sh` 훅이 발동하여 SSOT 를 정리:

- `claude/plugin/marketplaces.json` — `superpowers-dev` 키 삭제
- `claude/plugin/plugins.json` — 스테일 `superpowers@superpowers-dev` 삭제 (정식 `superpowers@claude-plugins-official` 유지)

이제 dotfiles 매니페스트가 라이브 설정과 일치한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)