### PR TITLE
fix(gbr): teardown이 base-추적 머지 브랜치를 'PR not merged'로 오탐하던 문제 수정

### DIFF
--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -256,53 +256,72 @@ git_branch_teardown() {
             || ux_warning "Fetch from '$fetch_remote' failed (offline?) — proceeding with stale refs."
     fi
 
-    # Upstream check — `[gone]` means remote branch was deleted (PR merge signal).
-    # Use `%(upstream:short)` (not `@{u}`) to detect "was ever pushed",
-    # because `@{u}` fails to resolve once the remote-tracking ref is pruned.
-    # `%(upstream:short)` also yields the actual upstream ref (e.g. origin/feature/x)
-    # even when local and remote branch names differ.
+    # Merge-safety gate — refuse to delete a branch whose work is NOT yet in
+    # main, UNLESS --force. "Merged" is confirmed by ANY of three independent
+    # signals; any one is enough:
+    #
+    #   S1  upstream is [gone]   — remote PR head was deleted (squash/rebase merge).
+    #   S2  contained in main    — the branch tip is an ancestor of origin/main
+    #                              (merge-commit or fast-forward merge). This is the
+    #                              signal that saves branches whose upstream is the
+    #                              BASE branch itself (e.g. a review/worktree branch
+    #                              created off main and pushed under a DIFFERENT
+    #                              remote name, #1108) — there [gone] can NEVER fire.
+    #   S3  gh reports MERGED    — authoritative fallback when the branch name still
+    #                              matches its own PR head ref.
+    #
+    # Use `%(upstream:short)` (not `@{u}`) to detect "was ever pushed", because
+    # `@{u}` fails to resolve once the remote-tracking ref is pruned.
+    local pr_merged=false contained=false
     if [ "$force" != true ]; then
         local upstream_ref upstream_track
         upstream_ref="$(git for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)"
         upstream_track="$(git for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null)"
 
-        if [ -z "$upstream_ref" ]; then
-            ux_error "Branch '$branch' has no upstream — never pushed?"
-            ux_info "Push and open a PR first, or use --force to delete anyway."
-            return 1
+        # S1
+        case "$upstream_track" in *gone*) upstream_gone=true ;; esac
+
+        # S2 — prefer the remote-tracking main (freshest post-merge); fall back
+        # to local main. Ancestry is reflexive, so an equal tip also counts.
+        local main_ref=""
+        if git rev-parse --verify --quiet "origin/$main_branch" >/dev/null 2>&1; then
+            main_ref="origin/$main_branch"
+        elif git rev-parse --verify --quiet "$main_branch" >/dev/null 2>&1; then
+            main_ref="$main_branch"
+        fi
+        if [ -n "$main_ref" ] \
+            && git merge-base --is-ancestor "$branch" "$main_ref" 2>/dev/null; then
+            contained=true
         fi
 
-        case "$upstream_track" in
-            *gone*)
-                upstream_gone=true
-                ;;
-            *)
-                # Best-effort PR lookup — surfaces "#151 OPEN" so the blocker is obvious
-                # at a glance. Silent on gh missing/unauthed; table row is just skipped.
-                # Use `.[]` (not `.[0]`) so an empty array yields empty output instead
-                # of stringifying null fields into "#null null  null".
-                local pr_info=""
-                if command -v gh >/dev/null 2>&1; then
-                    pr_info="$(gh pr list --head "$branch" --state all --limit 1 \
-                        --json number,state,url \
-                        --jq '.[] | "#\(.number) \(.state)  \(.url)"' 2>/dev/null)"
-                fi
+        # S3 — best-effort PR lookup; also surfaces "#151 OPEN" in the blocked
+        # message below. Silent on gh missing/unauthed. Use `.[]` (not `.[0]`) so
+        # an empty array yields empty output, not "#null null  null".
+        local pr_info=""
+        if [ "$upstream_gone" != true ] && [ "$contained" != true ] \
+            && command -v gh >/dev/null 2>&1; then
+            pr_info="$(gh pr list --head "$branch" --state all --limit 1 \
+                --json number,state,url \
+                --jq '.[] | "#\(.number) \(.state)  \(.url)"' 2>/dev/null)"
+            case "$pr_info" in *' MERGED '*) pr_merged=true ;; esac
+        fi
 
-                ux_error "Cannot tear down — PR not merged yet"
-                echo ""
-                ux_table_row "Branch" "$branch"
-                ux_table_row "Upstream" "$upstream_ref  (still on remote)"
-                ux_table_row "Track status" "${upstream_track:-up-to-date}"
-                if [ -n "$pr_info" ]; then
-                    ux_table_row "Pull request" "$pr_info"
-                fi
-                echo ""
-                ux_info "What to do next:"
-                ux_bullet "Merge the PR on GitHub, then re-run: gbr teardown"
-                ux_bullet "Or override the safety check: gbr teardown --force"
-                return 1
-                ;;
-        esac
+        if [ "$upstream_gone" != true ] && [ "$contained" != true ] \
+            && [ "$pr_merged" != true ]; then
+            ux_error "Cannot tear down — PR not merged yet"
+            echo ""
+            ux_table_row "Branch" "$branch"
+            ux_table_row "Upstream" "${upstream_ref:-<none — never pushed>}"
+            ux_table_row "Track status" "${upstream_track:-up-to-date}"
+            if [ -n "$pr_info" ]; then
+                ux_table_row "Pull request" "$pr_info"
+            fi
+            echo ""
+            ux_info "What to do next:"
+            ux_bullet "Merge the PR on GitHub, then re-run: gbr teardown"
+            ux_bullet "Or override the safety check: gbr teardown --force"
+            return 1
+        fi
     fi
 
     # Switch to main.
@@ -342,13 +361,13 @@ git_branch_teardown() {
         ux_info "Branch kept: $branch (--keep-branch)"
     elif git branch -d "$branch" 2>/dev/null; then
         : # safe-deleted (merge-commit merge)
-    elif [ "$force" = true ] || [ "$upstream_gone" = true ]; then
+    elif [ "$force" = true ] || [ "$upstream_gone" = true ] || [ "$pr_merged" = true ]; then
         git branch -D "$branch" 2>/dev/null || {
             ux_error "Failed to force-delete branch '$branch'."
             return 1
         }
-        if [ "$upstream_gone" = true ] && [ "$force" != true ]; then
-            ux_info "Force-deleted (squash/rebase merge detected via [gone] upstream)."
+        if [ "$force" != true ] && { [ "$upstream_gone" = true ] || [ "$pr_merged" = true ]; }; then
+            ux_info "Force-deleted (squash/rebase merge detected via merged PR)."
         fi
     else
         ux_warning "Branch '$branch' not fully merged into $main_branch. Use --force or --keep-branch."

--- a/tests/bats/functions/git_branch_teardown.bats
+++ b/tests/bats/functions/git_branch_teardown.bats
@@ -47,6 +47,72 @@ _setup_conflicted_clone() {
     )
 }
 
+# Create: $ORIGIN2 (bare) <- $CLONE2 with a fully-MERGED branch whose upstream is
+# the BASE branch (origin/main) rather than its own remote head. This mirrors the
+# real #1108 case: a branch created off main (worktree / review branch) whose PR
+# was pushed under a DIFFERENT remote name. Its commits already live in
+# origin/main, so it is safe to delete — but `[gone]` can NEVER fire because
+# origin/main is not gone. Old teardown wrongly reported "PR not merged yet".
+_setup_merged_tracking_main() {
+    ORIGIN2="$TEST_TEMP_HOME/origin2.git"
+    CLONE2="$TEST_TEMP_HOME/clone2"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init --bare --initial-branch=main "$ORIGIN2" >/dev/null
+    git clone -q "$ORIGIN2" "$CLONE2"
+    (
+        cd "$CLONE2"
+        echo base > base.txt
+        git add base.txt && git commit -q -m base
+        git push -q origin main
+
+        # Feature branch off main; its work then lands in main (server-side merge).
+        git checkout -q -b feat/merged
+        echo work > work.txt
+        git add work.txt && git commit -q -m "feat: work"
+        git push -q origin feat/merged:main   # simulate the PR merge landing in main
+
+        # Advance main two more commits so feat/merged is strictly behind & ff-able.
+        git checkout -q main && git pull -q origin main
+        echo m1 > m1.txt && git add m1.txt && git commit -q -m m1
+        echo m2 > m2.txt && git add m2.txt && git commit -q -m m2
+        git push -q origin main
+
+        # The crux: feat/merged tracks the BASE branch, not its own remote head.
+        git branch --set-upstream-to=origin/main feat/merged >/dev/null
+        git checkout -q feat/merged
+        git fetch -q --prune origin
+    )
+}
+
+# Same shape, but the branch has a unique commit that is NOT in origin/main.
+# Safety must be preserved: teardown stays blocked without --force.
+_setup_unmerged_tracking_main() {
+    ORIGIN2="$TEST_TEMP_HOME/origin3.git"
+    CLONE2="$TEST_TEMP_HOME/clone3"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init --bare --initial-branch=main "$ORIGIN2" >/dev/null
+    git clone -q "$ORIGIN2" "$CLONE2"
+    (
+        cd "$CLONE2"
+        echo base > base.txt
+        git add base.txt && git commit -q -m base
+        git push -q origin main
+
+        git checkout -q -b feat/wip
+        echo wip > wip.txt
+        git add wip.txt && git commit -q -m "feat: wip (unmerged)"
+
+        git branch --set-upstream-to=origin/main feat/wip >/dev/null
+        git fetch -q --prune origin
+    )
+}
+
 setup() {
     setup_isolated_home
     _setup_conflicted_clone
@@ -102,6 +168,28 @@ teardown() {
     assert_failure
     run git -C "$CLONE" ls-files --unmerged
     assert_output ""
+}
+
+@test "teardown: fully-merged branch tracking base (origin/main) tears down without --force (#1108)" {
+    _setup_merged_tracking_main
+    run_in_bash "cd '$CLONE2' && gbr teardown 2>&1"
+    assert_success
+    assert_output --partial "Teardown complete"
+    [ "$(git -C "$CLONE2" symbolic-ref --short HEAD)" = "main" ]
+    # Branch is gone.
+    run git -C "$CLONE2" rev-parse --verify --quiet feat/merged
+    assert_failure
+}
+
+@test "teardown: UNMERGED branch tracking base (origin/main) is still blocked (safety)" {
+    _setup_unmerged_tracking_main
+    run_in_bash "cd '$CLONE2' && gbr teardown 2>&1"
+    assert_failure
+    assert_output --partial "not merged yet"
+    # Branch untouched, still checked out.
+    [ "$(git -C "$CLONE2" symbolic-ref --short HEAD)" = "feat/wip" ]
+    run git -C "$CLONE2" rev-parse --verify --quiet feat/wip
+    assert_success
 }
 
 @test "teardown --help documents --discard-changes" {


### PR DESCRIPTION
## 요약
`gbr teardown` 이 **이미 머지된** 브랜치를 "PR not merged yet" 로 오탐하여 정리를 거부하던 버그를 수정한다. 브랜치의 upstream 이 자기 remote head 가 아니라 베이스 브랜치(`origin/main`)로 잡혀 있을 때 발생했다.

## 문제
- 머지 판정 게이트가 **`%(upstream:track)` 가 `[gone]` 인지** 라는 단일 신호만 사용.
- main 에서 파생한 리뷰/워크트리 브랜치는 upstream 이 `origin/main` 으로 잡히고, 실제 PR 은 다른 이름의 head 로 머지되어 `origin/<branch>` 가 애초에 없음 → `[gone]` 이 절대 발생하지 않음 → 항상 오탐 (예: PR #1108).
- 정작 브랜치 tip 은 `origin/main` 의 조상(fully merged)이라 `git branch -d` 면 그냥 삭제됐을 상태.

## 변경
머지 신호를 **3개**로 확장, 하나라도 만족하면 통과:
- **S1** `[gone]` upstream — 기존 (squash/rebase 머지)
- **S2** `git merge-base --is-ancestor <branch> origin/main` — 브랜치가 main 에 포함됨 (merge-commit / fast-forward, upstream=base 케이스 커버). remote main 우선, 없으면 로컬 main fallback
- **S3** `gh` PR 상태 `MERGED` — 이름 일치 시 authoritative fallback

- 세 신호 모두 실패할 때만 차단 → 안전성 유지
- branch-delete 조건에 `pr_merged` 추가 (gh 신호 기반 squash/rebase → `git branch -D` 승격)
- upstream 없는 케이스는 통합 게이트로 흡수 (`<none — never pushed>` 표기)

## 검증
- 회귀 테스트 2건 추가: base-추적 fully-merged → `--force` 없이 성공 / base-추적 미머지 → 여전히 차단
- 기존 4건 포함 `git_branch_teardown.bats` **6/6 통과**, shellcheck 통과
- pre-commit 훅 통과

## 관련 파일
- `shell-common/functions/git_branch.sh` (머지 게이트 + branch-delete 조건)
- `tests/bats/functions/git_branch_teardown.bats`

Fixes #1110

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~2 h · 🤖 ~25 min</summary>

<!-- ai-metrics -->
📊 ~6000 tokens · 👤 ~2 h · 🤖 ~25 min
<!-- /ai-metrics -->

</details>
