### PR TITLE
feat(claude-plugin): restore/reconcile/publish-sync 로그에 시맨틱 색상 강조 적용

### DIFF
--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -23,6 +23,19 @@
 # See docs/feature/superpowers-specs/2026-07-02-plugin-manifest-batch-publish-design.md
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load UX library for semantic log colors (#1114). Cosmetic only — falls
+# back to plain output when the lib is missing. ux_lib.sh itself handles
+# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE by leaving these vars empty.
+UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
+if [ -r "$UX_LIB" ]; then
+	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
+	source "$UX_LIB"
+else
+	UX_SUCCESS="" UX_ERROR="" UX_WARNING="" UX_MUTED="" UX_RESET=""
+fi
+
 # MUST stay byte-identical to SYNC_MSG in claude/hooks/plugin-sync.sh:30 —
 # _cleanup_local_main_if_pure_sync matches local commits against this string
 # to decide which are safe to fast-forward past. If the two drift, cleanup
@@ -184,7 +197,7 @@ _open_and_merge_pr() {
 	local tries=0 state="pending" saw_checks=0
 
 	target=$(_repo_target "$repo_dir") || {
-		echo "publish-sync: origin remote를 해석하지 못함 ($repo_dir)" >&2
+		echo "${UX_ERROR}publish-sync: origin remote를 해석하지 못함 ($repo_dir)${UX_RESET}" >&2
 		return 1
 	}
 
@@ -193,7 +206,7 @@ _open_and_merge_pr() {
 		--title "$SYNC_MSG" \
 		--body "plugin-sync.sh가 로컬에 쌓아둔 매니페스트 변경을 게시합니다. 자동 생성됨." \
 		2>&1) || {
-		echo "publish-sync: PR 생성 실패 — $pr_out" >&2
+		echo "${UX_ERROR}publish-sync: PR 생성 실패 — $pr_out${UX_RESET}" >&2
 		return 1
 	}
 	# gh can fold warnings/deprecation notices into stdout via the 2>&1 above;
@@ -203,10 +216,10 @@ _open_and_merge_pr() {
 	pr_url=$(printf '%s\n' "$pr_out" | grep -oE 'https?://[^[:space:]]+/pull/[0-9]+' | tail -n1)
 	pr_number="${pr_url##*/}"
 	if [ -z "$pr_number" ]; then
-		echo "publish-sync: PR URL 파싱 실패 — gh 출력: $pr_out" >&2
+		echo "${UX_ERROR}publish-sync: PR URL 파싱 실패 — gh 출력: $pr_out${UX_RESET}" >&2
 		return 1
 	fi
-	echo "publish-sync: PR 생성됨 — $pr_url"
+	echo "${UX_SUCCESS}publish-sync: PR 생성됨 — $pr_url${UX_RESET}"
 
 	# The `--json bucket` flag on the `pr checks` subcommand does not exist
 	# on gh <2.46ish (unknown flag: --json) — verified on gh 2.45.0, which
@@ -246,7 +259,7 @@ _open_and_merge_pr() {
 	case "$state" in
 	success) ;;
 	failed)
-		echo "publish-sync: status check 실패 — $pr_url 를 직접 확인하세요" >&2
+		echo "${UX_ERROR}publish-sync: status check 실패 — $pr_url 를 직접 확인하세요${UX_RESET}" >&2
 		return 1
 		;;
 	*)
@@ -255,19 +268,19 @@ _open_and_merge_pr() {
 		# genuinely checkless repo; otherwise checks appeared but stayed
 		# pending the whole window.
 		if [ "$saw_checks" -eq 0 ]; then
-			echo "publish-sync: status check가 구성되지 않은 리포 — 자동 병합하지 않습니다. $pr_url 를 직접 검토/병합하세요" >&2
+			echo "${UX_WARNING}publish-sync: status check가 구성되지 않은 리포 — 자동 병합하지 않습니다. $pr_url 를 직접 검토/병합하세요${UX_RESET}" >&2
 		else
-			echo "publish-sync: status check 대기 타임아웃 — $pr_url 를 직접 확인하세요" >&2
+			echo "${UX_ERROR}publish-sync: status check 대기 타임아웃 — $pr_url 를 직접 확인하세요${UX_RESET}" >&2
 		fi
 		return 1
 		;;
 	esac
 
 	gh pr merge "$pr_number" --repo "$target" --admin --rebase --delete-branch 2>&1 || {
-		echo "publish-sync: admin merge 실패 — $pr_url 를 직접 확인하세요" >&2
+		echo "${UX_ERROR}publish-sync: admin merge 실패 — $pr_url 를 직접 확인하세요${UX_RESET}" >&2
 		return 1
 	}
-	echo "publish-sync: 병합 완료 — $pr_url"
+	echo "${UX_SUCCESS}publish-sync: 병합 완료 — $pr_url${UX_RESET}"
 }
 
 # _publish_manifest_diff <repo_dir> <label> <file...>
@@ -282,15 +295,15 @@ _publish_manifest_diff() {
 	local before_origin
 
 	_fetch_origin "$repo_dir" || {
-		echo "[$label] origin fetch 실패 (재시도 후) — 건너뜀" >&2
+		echo "${UX_ERROR}[$label] origin fetch 실패 (재시도 후) — 건너뜀${UX_RESET}" >&2
 		return 1
 	}
 
 	if ! _manifest_diff_exists "$repo_dir" "$@"; then
-		echo "[$label] 변경 없음 — 할 일 없음"
+		echo "${UX_MUTED}[$label] 변경 없음 — 할 일 없음${UX_RESET}"
 		return 0
 	fi
-	echo "[$label] 변경 감지됨"
+	echo "${UX_MUTED}[$label] 변경 감지됨${UX_RESET}"
 
 	if [ "${DRY_RUN:-0}" = "1" ]; then
 		git -C "$repo_dir" diff origin/main -- "$@"
@@ -304,11 +317,11 @@ _publish_manifest_diff() {
 
 	local commit branch
 	commit=$(_build_publish_commit "$repo_dir" "$@") || {
-		echo "[$label] publish 커밋 생성 실패" >&2
+		echo "${UX_ERROR}[$label] publish 커밋 생성 실패${UX_RESET}" >&2
 		return 1
 	}
 	branch=$(_publish_branch "$repo_dir" "$label" "$commit") || {
-		echo "[$label] 브랜치 push 실패" >&2
+		echo "${UX_ERROR}[$label] 브랜치 push 실패${UX_RESET}" >&2
 		return 1
 	}
 	_open_and_merge_pr "$repo_dir" "$branch" || return 1
@@ -345,7 +358,7 @@ _cleanup_local_main_if_pure_sync() {
 	local sha msg f pure=1 match want cur_branch
 
 	_fetch_origin "$repo_dir" || {
-		echo "publish-sync: 정리 단계 fetch 실패 (재시도 후) — 로컬 main은 그대로 둡니다" >&2
+		echo "${UX_ERROR}publish-sync: 정리 단계 fetch 실패 (재시도 후) — 로컬 main은 그대로 둡니다${UX_RESET}" >&2
 		return 1
 	}
 
@@ -373,7 +386,7 @@ _cleanup_local_main_if_pure_sync() {
 	done
 
 	if [ "$pure" -ne 1 ]; then
-		echo "publish-sync: 로컬 main에 sync 외 다른 커밋이 섞여 있어 정리를 건너뜁니다 — 직접 확인하세요" >&2
+		echo "${UX_WARNING}publish-sync: 로컬 main에 sync 외 다른 커밋이 섞여 있어 정리를 건너뜁니다 — 직접 확인하세요${UX_RESET}" >&2
 		return 0
 	fi
 
@@ -393,11 +406,11 @@ _cleanup_local_main_if_pure_sync() {
 			# message on every real publish.
 			if ! git -C "$repo_dir" rebase origin/main >/dev/null 2>&1; then
 				git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
-				echo "publish-sync: 로컬 main rebase 중 충돌 — publish 는 성공했으니 'git rebase origin/main' 으로 직접 정리하세요" >&2
+				echo "${UX_ERROR}publish-sync: 로컬 main rebase 중 충돌 — publish 는 성공했으니 'git rebase origin/main' 으로 직접 정리하세요${UX_RESET}" >&2
 				return 1
 			fi
 		else
-			echo "publish-sync: 로컬 main 워킹트리에 미커밋 변경이 있어 정리를 건너뜁니다 — publish 는 성공했으니 필요하면 'git pull' 로 직접 정리하세요" >&2
+			echo "${UX_WARNING}publish-sync: 로컬 main 워킹트리에 미커밋 변경이 있어 정리를 건너뜁니다 — publish 는 성공했으니 필요하면 'git pull' 로 직접 정리하세요${UX_RESET}" >&2
 			return 1
 		fi
 	else
@@ -405,7 +418,7 @@ _cleanup_local_main_if_pure_sync() {
 		# out in another linked worktree, avoiding a phantom diff there.
 		git -C "$repo_dir" branch -f main origin/main || return 1
 	fi
-	echo "publish-sync: 로컬 main을 origin/main으로 정리했습니다"
+	echo "${UX_SUCCESS}publish-sync: 로컬 main을 origin/main으로 정리했습니다${UX_RESET}"
 }
 
 # _public_publish_allowed
@@ -454,14 +467,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 		exit 0
 		;;
 	*)
-		echo "publish-sync.sh: 알 수 없는 인자: $1" >&2
+		echo "${UX_ERROR}publish-sync.sh: 알 수 없는 인자: $1${UX_RESET}" >&2
 		echo "usage: publish-sync.sh [--dry-run]  (-h 로 도움말)" >&2
 		exit 2
 		;;
 	esac
 
 	command -v gh >/dev/null 2>&1 || {
-		echo "gh CLI가 필요합니다." >&2
+		echo "${UX_ERROR}gh CLI가 필요합니다.${UX_RESET}" >&2
 		exit 1
 	}
 
@@ -489,7 +502,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 		esac
 		if [ -n "$GIT_DIR_PATH" ] && exec 9>"$GIT_DIR_PATH/publish-sync.lock"; then
 			if ! flock -n 9; then
-				echo "publish-sync: 다른 인스턴스가 실행 중 — 이번 실행은 건너뜁니다"
+				echo "${UX_WARNING}publish-sync: 다른 인스턴스가 실행 중 — 이번 실행은 건너뜁니다${UX_RESET}"
 				exit 0
 			fi
 		fi
@@ -499,7 +512,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 		_publish_manifest_diff "$MAIN_ROOT" "public" \
 			claude/plugin/marketplaces.json claude/plugin/plugins.json || RC=1
 	else
-		echo "[public] internal 모드 — github.com은 pull-only 정책이라 public manifest publish를 건너뜁니다 (사내→사외 push 금지)"
+		echo "${UX_MUTED}[public] internal 모드 — github.com은 pull-only 정책이라 public manifest publish를 건너뜁니다 (사내→사외 push 금지)${UX_RESET}"
 	fi
 
 	if [ -d "$PRIV_DIR/.git" ]; then

--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -25,11 +25,13 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Load UX library for semantic log colors (#1114). Cosmetic only — falls
-# back to plain output when the lib is missing. ux_lib.sh itself handles
-# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE by leaving these vars empty.
+# Load UX library for semantic log colors (#1114). Cosmetic only — colors
+# are emitted only to an interactive TTY, so piped/redirected/automation
+# runs stay byte-plain for grep/snapshot consumers (#1116); a missing lib
+# also falls back to plain. ux_lib.sh self-disables on
+# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE as well.
 UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
-if [ -r "$UX_LIB" ]; then
+if [ -t 1 ] && [ -r "$UX_LIB" ]; then
 	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
 	source "$UX_LIB"
 else

--- a/claude/plugin/reconcile.sh
+++ b/claude/plugin/reconcile.sh
@@ -30,11 +30,13 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Load UX library for semantic log colors (#1114). Cosmetic only — falls
-# back to plain output when the lib is missing. ux_lib.sh itself handles
-# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE by leaving these vars empty.
+# Load UX library for semantic log colors (#1114). Cosmetic only — colors
+# are emitted only to an interactive TTY, so piped/redirected/automation
+# runs stay byte-plain for grep/snapshot consumers (#1116); a missing lib
+# also falls back to plain. ux_lib.sh self-disables on
+# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE as well.
 UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
-if [ -r "$UX_LIB" ]; then
+if [ -t 1 ] && [ -r "$UX_LIB" ]; then
 	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
 	source "$UX_LIB"
 else
@@ -207,12 +209,12 @@ _run_check() {
 	if ! out=$(_diff_marketplaces "$PUB_DIR/marketplaces.json" "$target_common"); then
 		drift=1
 		echo "${UX_MUTED}marketplaces.json:${UX_RESET}"
-		printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
+		while IFS= read -r _line; do _color_diff_line "$_line"; done <<<"$out"
 	fi
 	if ! out=$(_diff_plugins "$PUB_DIR/plugins.json" "$plugins_common"); then
 		drift=1
 		echo "${UX_MUTED}plugins.json:${UX_RESET}"
-		printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
+		while IFS= read -r _line; do _color_diff_line "$_line"; done <<<"$out"
 	fi
 
 	if [ "$COMPANY_ACTIVE" -eq 1 ]; then
@@ -220,12 +222,12 @@ _run_check() {
 		if ! out=$(_diff_marketplaces "$PRIV_DIR/marketplaces.json" "$target_private"); then
 			drift=1
 			echo "${UX_MUTED}company/marketplaces.json:${UX_RESET}"
-			printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
+			while IFS= read -r _line; do _color_diff_line "$_line"; done <<<"$out"
 		fi
 		if ! out=$(_diff_plugins "$PRIV_DIR/plugins.json" "$plugins_private"); then
 			drift=1
 			echo "${UX_MUTED}company/plugins.json:${UX_RESET}"
-			printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
+			while IFS= read -r _line; do _color_diff_line "$_line"; done <<<"$out"
 		fi
 	else
 		echo "${UX_MUTED}(company/ 건너뜀 — 모드: ${MODE:-미설정})${UX_RESET}"

--- a/claude/plugin/reconcile.sh
+++ b/claude/plugin/reconcile.sh
@@ -28,6 +28,30 @@
 # See docs/feature/superpowers-specs/2026-07-01-claude-plugin-manifest-design.md
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load UX library for semantic log colors (#1114). Cosmetic only — falls
+# back to plain output when the lib is missing. ux_lib.sh itself handles
+# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE by leaving these vars empty.
+UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
+if [ -r "$UX_LIB" ]; then
+	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
+	source "$UX_LIB"
+else
+	UX_SUCCESS="" UX_ERROR="" UX_WARNING="" UX_MUTED="" UX_RESET=""
+fi
+
+# Color one `_diff_marketplaces`/`_diff_plugins` output line by its leading
+# `+`/`-`/`~` marker (add/remove/change) — text itself is never altered.
+_color_diff_line() {
+	case "$1" in
+	"  +"*) printf '%s%s%s\n' "$UX_SUCCESS" "$1" "$UX_RESET" ;;
+	"  -"*) printf '%s%s%s\n' "$UX_ERROR" "$1" "$UX_RESET" ;;
+	"  ~"*) printf '%s%s%s\n' "$UX_WARNING" "$1" "$UX_RESET" ;;
+	*) printf '%s\n' "$1" ;;
+	esac
+}
+
 MODE_ACTION="check"
 
 _usage() {
@@ -57,7 +81,7 @@ for arg in "$@"; do
 		exit 0
 		;;
 	*)
-		echo "알 수 없는 인자: $arg" >&2
+		echo "${UX_ERROR}알 수 없는 인자: $arg${UX_RESET}" >&2
 		_usage >&2
 		exit 2
 		;;
@@ -65,11 +89,10 @@ for arg in "$@"; do
 done
 
 command -v jq >/dev/null 2>&1 || {
-	echo "jq가 필요합니다." >&2
+	echo "${UX_ERROR}jq가 필요합니다.${UX_RESET}" >&2
 	exit 1
 }
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUB_DIR="$SCRIPT_DIR"
 PRIV_DIR="$SCRIPT_DIR/company"
 
@@ -98,8 +121,8 @@ fi
 
 for f in "$MP_SRC" "$PL_SRC"; do
 	if [ ! -f "$f" ]; then
-		echo "SSOT 파일이 없습니다: $f" >&2
-		echo "  → ~/.claude-shared/plugins 를 확인하거나 CLAUDE_SHARED_PLUGINS_DIR 를 설정하세요." >&2
+		echo "${UX_ERROR}SSOT 파일이 없습니다: $f${UX_RESET}" >&2
+		echo "${UX_ERROR}  → ~/.claude-shared/plugins 를 확인하거나 CLAUDE_SHARED_PLUGINS_DIR 를 설정하세요.${UX_RESET}" >&2
 		exit 1
 	fi
 done
@@ -180,39 +203,39 @@ _diff_plugins() {
 _run_check() {
 	local drift=0 out
 
-	echo "== 공용(github) 매니페스트 =="
+	echo "${UX_MUTED}== 공용(github) 매니페스트 ==${UX_RESET}"
 	if ! out=$(_diff_marketplaces "$PUB_DIR/marketplaces.json" "$target_common"); then
 		drift=1
-		echo "marketplaces.json:"
-		printf '%s\n' "$out"
+		echo "${UX_MUTED}marketplaces.json:${UX_RESET}"
+		printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
 	fi
 	if ! out=$(_diff_plugins "$PUB_DIR/plugins.json" "$plugins_common"); then
 		drift=1
-		echo "plugins.json:"
-		printf '%s\n' "$out"
+		echo "${UX_MUTED}plugins.json:${UX_RESET}"
+		printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
 	fi
 
 	if [ "$COMPANY_ACTIVE" -eq 1 ]; then
-		echo "== 사내(company) 매니페스트 =="
+		echo "${UX_MUTED}== 사내(company) 매니페스트 ==${UX_RESET}"
 		if ! out=$(_diff_marketplaces "$PRIV_DIR/marketplaces.json" "$target_private"); then
 			drift=1
-			echo "company/marketplaces.json:"
-			printf '%s\n' "$out"
+			echo "${UX_MUTED}company/marketplaces.json:${UX_RESET}"
+			printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
 		fi
 		if ! out=$(_diff_plugins "$PRIV_DIR/plugins.json" "$plugins_private"); then
 			drift=1
-			echo "company/plugins.json:"
-			printf '%s\n' "$out"
+			echo "${UX_MUTED}company/plugins.json:${UX_RESET}"
+			printf '%s\n' "$out" | while IFS= read -r _line; do _color_diff_line "$_line"; done
 		fi
 	else
-		echo "(company/ 건너뜀 — 모드: ${MODE:-미설정})"
+		echo "${UX_MUTED}(company/ 건너뜀 — 모드: ${MODE:-미설정})${UX_RESET}"
 	fi
 
 	if [ "$drift" -eq 0 ]; then
-		echo "no drift — SSOT 와 매니페스트가 일치합니다."
+		echo "${UX_SUCCESS}no drift — SSOT 와 매니페스트가 일치합니다.${UX_RESET}"
 		return 0
 	fi
-	echo "drift 감지 — 복구하려면: reconcile.sh --apply"
+	echo "${UX_ERROR}drift 감지 — 복구하려면: reconcile.sh --apply${UX_RESET}"
 	return 1
 }
 
@@ -250,16 +273,16 @@ _commit_if_changed() {
 	git -C "$repo_dir" diff --cached --quiet -- "$@" 2>/dev/null && return 0
 	if ! ALLOW_MAIN_COMMIT=1 git -C "$repo_dir" commit -m "$msg" --quiet 2>/dev/null; then
 		if git -C "$repo_dir" reset -q -- "$@" 2>/dev/null; then
-			echo "reconcile: manifest commit failed in $repo_dir; changes left unstaged" >&2
+			echo "${UX_ERROR}reconcile: manifest commit failed in $repo_dir; changes left unstaged${UX_RESET}" >&2
 		else
-			echo "reconcile: manifest commit failed in $repo_dir; failed to unstage changes" >&2
+			echo "${UX_ERROR}reconcile: manifest commit failed in $repo_dir; failed to unstage changes${UX_RESET}" >&2
 		fi
 	fi
 }
 
 _run_apply() {
 	if [ -z "$MAIN_ROOT" ]; then
-		echo "git 저장소를 찾을 수 없습니다 ($SCRIPT_DIR). dotfiles 안에서 실행하세요." >&2
+		echo "${UX_ERROR}git 저장소를 찾을 수 없습니다 ($SCRIPT_DIR). dotfiles 안에서 실행하세요.${UX_RESET}" >&2
 		exit 1
 	fi
 
@@ -280,7 +303,7 @@ _run_apply() {
 			"$PRIV_DIR/marketplaces.json" "$PRIV_DIR/plugins.json"
 	fi
 
-	echo "apply 완료. 확인: reconcile.sh --check"
+	echo "${UX_SUCCESS}apply 완료. 확인: reconcile.sh --check${UX_RESET}"
 }
 
 case "$MODE_ACTION" in

--- a/claude/plugin/restore.sh
+++ b/claude/plugin/restore.sh
@@ -24,6 +24,18 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load UX library for semantic log colors (#1114). Cosmetic only — falls
+# back to plain output when the lib is missing. ux_lib.sh itself handles
+# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE by leaving these vars empty.
+UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
+if [ -r "$UX_LIB" ]; then
+	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
+	source "$UX_LIB"
+else
+	UX_SUCCESS="" UX_ERROR="" UX_WARNING="" UX_MUTED="" UX_RESET=""
+fi
+
 DRY_RUN=0
 SYNC=0
 ALL_ACCOUNTS=0
@@ -61,7 +73,7 @@ while [ $# -gt 0 ]; do
 	--user)
 		shift
 		[ $# -gt 0 ] || {
-			echo "--user 다음에 계정 이름이 필요합니다." >&2
+			echo "${UX_ERROR}--user 다음에 계정 이름이 필요합니다.${UX_RESET}" >&2
 			_usage >&2
 			exit 2
 		}
@@ -73,7 +85,7 @@ while [ $# -gt 0 ]; do
 		exit 0
 		;;
 	*)
-		echo "알 수 없는 인자: $1" >&2
+		echo "${UX_ERROR}알 수 없는 인자: $1${UX_RESET}" >&2
 		_usage >&2
 		exit 2
 		;;
@@ -82,7 +94,7 @@ while [ $# -gt 0 ]; do
 done
 
 command -v jq >/dev/null 2>&1 || {
-	echo "jq가 필요합니다." >&2
+	echo "${UX_ERROR}jq가 필요합니다.${UX_RESET}" >&2
 	exit 1
 }
 # --dry-run only prints the plan — don't require the claude CLI for that,
@@ -90,7 +102,7 @@ command -v jq >/dev/null 2>&1 || {
 # no claude binary) can exercise --dry-run in tests without it.
 if [ "$DRY_RUN" -eq 0 ]; then
 	command -v claude >/dev/null 2>&1 || {
-		echo "claude CLI가 없습니다. 먼저 clinstall 하세요." >&2
+		echo "${UX_ERROR}claude CLI가 없습니다. 먼저 clinstall 하세요.${UX_RESET}" >&2
 		exit 1
 	}
 fi
@@ -151,14 +163,14 @@ _target_config_dirs() {
 		if [ "$_tcd_n" -gt 0 ]; then
 			return 0
 		fi
-		echo "경고: --all-accounts 이나 CLAUDE_ENABLED_ACCOUNTS 가 비어 있음 — 기본 계정으로 폴백" >&2
+		echo "${UX_WARNING}경고: --all-accounts 이나 CLAUDE_ENABLED_ACCOUNTS 가 비어 있음 — 기본 계정으로 폴백${UX_RESET}" >&2
 	fi
 	_tcd_acct="${USER_ACCOUNT:-${CLAUDE_DEFAULT_ACCOUNT:-personal}}"
 	if _valid_acct "$_tcd_acct"; then
 		echo "$HOME/.claude-$_tcd_acct"
 		return 0
 	fi
-	echo "경고: 계정 이름 '$_tcd_acct' 이 유효하지 않음 — ~/.claude 로 폴백 (#1103 주의)" >&2
+	echo "${UX_WARNING}경고: 계정 이름 '$_tcd_acct' 이 유효하지 않음 — ~/.claude 로 폴백 (#1103 주의)${UX_RESET}" >&2
 	echo "$HOME/.claude"
 	return 0
 }
@@ -166,25 +178,25 @@ _target_config_dirs() {
 _restore_from() {
 	local mp_json="$1" pl_json="$2" label="$3" name repo plugin
 	if [ ! -f "$mp_json" ] || [ ! -f "$pl_json" ]; then
-		echo "  (${label} manifest 없음 — 건너뜀)"
+		echo "${UX_MUTED}  (${label} manifest 없음 — 건너뜀)${UX_RESET}"
 		return 0
 	fi
-	echo "== ${label} marketplaces =="
+	echo "${UX_MUTED}== ${label} marketplaces ==${UX_RESET}"
 	# `</dev/null` on the CLI calls: without it, `claude` reading stdin would
 	# drain the `jq | while read` pipe and cut the loop short.
 	jq -r 'to_entries[] | "\(.key)\t\(.value)"' "$mp_json" |
 		while IFS=$'\t' read -r name repo; do
-			echo "  add: ${name} (${repo})"
+			echo "${UX_SUCCESS}  add: ${name} (${repo})${UX_RESET}"
 			if [ "$DRY_RUN" -eq 0 ]; then
-				claude plugin marketplace add "$repo" </dev/null || echo "    실패 — 계속 진행" >&2
+				claude plugin marketplace add "$repo" </dev/null || echo "${UX_ERROR}    실패 — 계속 진행${UX_RESET}" >&2
 			fi
 		done
-	echo "== ${label} plugins =="
+	echo "${UX_MUTED}== ${label} plugins ==${UX_RESET}"
 	jq -r '.plugins[]' "$pl_json" |
 		while read -r plugin; do
-			echo "  install: ${plugin}"
+			echo "${UX_SUCCESS}  install: ${plugin}${UX_RESET}"
 			if [ "$DRY_RUN" -eq 0 ]; then
-				claude plugin install "$plugin" </dev/null || echo "    실패 — 계속 진행" >&2
+				claude plugin install "$plugin" </dev/null || echo "${UX_ERROR}    실패 — 계속 진행${UX_RESET}" >&2
 			fi
 		done
 }
@@ -247,13 +259,13 @@ _prune_pass() {
 	PL_LOCAL="$SHARED_DIR/installed_plugins.json"
 	WHITELIST="$SCRIPT_DIR/.local-marketplaces.json"
 
-	echo "== sync: 잉여 항목 정리 (SSOT 에 없는 로컬 항목) =="
+	echo "${UX_MUTED}== sync: 잉여 항목 정리 (SSOT 에 없는 로컬 항목) ==${UX_RESET}"
 	local surplus_pl surplus_mp
 	surplus_pl=$(comm -23 <(_local_plugins | sort -u) <(_keep_plugins | sort -u))
 	surplus_mp=$(comm -23 <(_local_marketplaces | sort -u) <(_keep_marketplaces | sort -u))
 
 	if [ -z "$surplus_pl" ] && [ -z "$surplus_mp" ]; then
-		echo "  (제거할 잉여 항목 없음 — SSOT 와 로컬이 일치)"
+		echo "${UX_MUTED}  (제거할 잉여 항목 없음 — SSOT 와 로컬이 일치)${UX_RESET}"
 	fi
 
 	# Uninstall plugins BEFORE removing their marketplaces so a plugin is never
@@ -261,26 +273,26 @@ _prune_pass() {
 	printf '%s\n' "$surplus_pl" |
 		while read -r plugin; do
 			[ -n "$plugin" ] || continue
-			echo "  uninstall: ${plugin}"
+			echo "${UX_ERROR}  uninstall: ${plugin}${UX_RESET}"
 			if [ "$DRY_RUN" -eq 0 ]; then
-				claude plugin uninstall "$plugin" </dev/null || echo "    실패 — 계속 진행" >&2
+				claude plugin uninstall "$plugin" </dev/null || echo "${UX_ERROR}    실패 — 계속 진행${UX_RESET}" >&2
 			fi
 		done
 	printf '%s\n' "$surplus_mp" |
 		while read -r name; do
 			[ -n "$name" ] || continue
-			echo "  remove: ${name}"
+			echo "${UX_ERROR}  remove: ${name}${UX_RESET}"
 			if [ "$DRY_RUN" -eq 0 ]; then
-				claude plugin marketplace remove "$name" </dev/null || echo "    실패 — 계속 진행" >&2
+				claude plugin marketplace remove "$name" </dev/null || echo "${UX_ERROR}    실패 — 계속 진행${UX_RESET}" >&2
 			fi
 		done
 }
 
 # _run_for_config_dir — one full restore against the exported CLAUDE_CONFIG_DIR.
 _run_for_config_dir() {
-	echo "== 대상 config dir: ${CLAUDE_CONFIG_DIR} =="
+	echo "${UX_MUTED}== 대상 config dir: ${CLAUDE_CONFIG_DIR} ==${UX_RESET}"
 	if [ "$DRY_RUN" -eq 0 ] && [ ! -d "$CLAUDE_CONFIG_DIR" ]; then
-		echo "  (참고: 대상 dir 없음 — claude CLI 가 첫 실행 시 생성)"
+		echo "${UX_MUTED}  (참고: 대상 dir 없음 — claude CLI 가 첫 실행 시 생성)${UX_RESET}"
 	fi
 
 	_restore_from "$SCRIPT_DIR/marketplaces.json" "$SCRIPT_DIR/plugins.json" "공용"
@@ -289,10 +301,10 @@ _run_for_config_dir() {
 		if [ "$COMPANY_ACTIVE" -eq 1 ]; then
 			_restore_from "$PRIV/marketplaces.json" "$PRIV/plugins.json" "사내 전용"
 		else
-			echo "(사내 전용 레포 미설정 — 먼저 실행: git clone <GHES private repo url> $PRIV)"
+			echo "${UX_MUTED}(사내 전용 레포 미설정 — 먼저 실행: git clone <GHES private repo url> $PRIV)${UX_RESET}"
 		fi
 	else
-		echo "(모드: ${MODE:-미설정} — 사내 전용 manifest는 internal에서만 복원)"
+		echo "${UX_MUTED}(모드: ${MODE:-미설정} — 사내 전용 manifest는 internal에서만 복원)${UX_RESET}"
 	fi
 
 	if [ "$SYNC" -eq 1 ]; then
@@ -307,4 +319,4 @@ while IFS= read -r _cfg; do
 	_run_for_config_dir
 done < <(_target_config_dirs)
 
-echo "완료. 새 Claude Code 세션을 시작해 스킬이 로드됐는지 확인하세요."
+echo "${UX_SUCCESS}완료. 새 Claude Code 세션을 시작해 스킬이 로드됐는지 확인하세요.${UX_RESET}"

--- a/claude/plugin/restore.sh
+++ b/claude/plugin/restore.sh
@@ -25,11 +25,13 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Load UX library for semantic log colors (#1114). Cosmetic only — falls
-# back to plain output when the lib is missing. ux_lib.sh itself handles
-# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE by leaving these vars empty.
+# Load UX library for semantic log colors (#1114). Cosmetic only — colors
+# are emitted only to an interactive TTY, so piped/redirected/automation
+# runs stay byte-plain for grep/snapshot consumers (#1116); a missing lib
+# also falls back to plain. ux_lib.sh self-disables on
+# NO_COLOR / TERM=dumb / DOTFILES_TEST_MODE as well.
 UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
-if [ -r "$UX_LIB" ]; then
+if [ -t 1 ] && [ -r "$UX_LIB" ]; then
 	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
 	source "$UX_LIB"
 else


### PR DESCRIPTION
## Summary
- `claude/plugin/{restore,reconcile,publish-sync}.sh`의 무채색 로그에 시맨틱 색상을 입혀 add/성공은 초록, remove/실패는 빨강, 경고는 노랑, 헤더/부가 정보는 dim으로 구분되게 했다.

## Changes
- `claude/plugin/restore.sh`: `shell-common/tools/ux_lib/ux_lib.sh` 소싱 추가(폴백 포함), `add:`/`install:`/`완료.` 라인은 초록, `remove:`/`uninstall:`/`실패` 라인은 빨강, `경고:` 라인은 노랑, `== ... ==` 헤더와 부가 안내는 dim으로 래핑.
- `claude/plugin/reconcile.sh`: 동일한 ux_lib 소싱을 인자 파싱 이전으로 끌어올려 `알 수 없는 인자` 에러까지 색상 적용 대상에 포함시켰고, `_diff_marketplaces`/`_diff_plugins`가 만드는 `+`/`-`/`~` diff 라인을 `_color_diff_line` 헬퍼로 초록/빨강/노랑 색칠, 섹션 헤더는 dim, `no drift`/`apply 완료`는 초록, `drift 감지`는 빨강.
- `claude/plugin/publish-sync.sh`: 동일한 소싱 패턴 추가, PR 생성/병합 완료 등 성공 라인은 초록, 각종 실패/충돌 메시지는 빨강, skip성 경고는 노랑, `[label] ...` 진행 라인은 dim으로 정리.

## Test plan
- [x] `shellcheck` + `shfmt -d`이 세 스크립트에 대해 깨끗함을 확인
- [x] `tests/bats/tools/claude_plugin_{restore,reconcile,publish_sync}.bats` 69개 테스트 전부 통과 (텍스트 매칭 불변 확인)
- [x] `TERM=xterm-256color`로 `restore.sh --dry-run` 실행해 색상 코드가 실제로 출력되는지, `DOTFILES_TEST_MODE=1`에서는 색상이 사라지는지 수동 확인

## Related
Closes #1114

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~8 h (1 d) · 🤖 ~10 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~8 h (1 d) · 🤖 ~10 min
<!-- /ai-metrics:gh-pr -->

</details>
