### PR TITLE
fix(claude-plugin): understand-anything 활성화 + claude-plugin-list 노출

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -66,7 +66,8 @@
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
-    "codex@openai-codex": true
+    "codex@openai-codex": true,
+    "understand-anything@understand-anything": true
   },
   "tui": "fullscreen",
   "autoUpdatesChannel": "latest",

--- a/shell-common/functions/claude_plugins_help.sh
+++ b/shell-common/functions/claude_plugins_help.sh
@@ -7,7 +7,7 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 _claude_plugins_help_summary() {
     ux_info "Usage: claude-plugins-help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "commands: open_claude_plugins | list-plugins | init-plugins-docs | sync-plugins-structure"
+    ux_bullet_sub "commands: open_claude_plugins | list-plugins | claude-plugin-list | init-plugins-docs | sync-plugins-structure"
     ux_bullet_sub "view: view-plugin-info | generate-plugin-doc-ko | create-plugin-structure-ko"
     ux_bullet_sub "examples: quick examples for create-plugin-ko"
     ux_bullet_sub "ai-tools: claude | gemini | codex"
@@ -31,6 +31,7 @@ _claude_plugins_help_list_sections() {
 _claude_plugins_help_rows_commands() {
     ux_bullet "open_claude_plugins  - Open marketplace plugins directory in VSCode"
     ux_bullet "list-plugins         - List all available marketplaces and their skills"
+    ux_bullet "claude-plugin-list   - List installed plugins grouped by marketplace (SSOT: installed_plugins.json)"
     ux_bullet "init-plugins-docs    - Initialize Korean documentation directory structure"
     ux_bullet "sync-plugins-structure - Create directory structure mirroring plugins organization"
 }


### PR DESCRIPTION
## Summary
- `claude plugin install`은 캐싱만 하고 세션 로드에는 별도 `enable`이 필요하다는 걸 발견 — `understand-anything`이 설치는 됐지만 활성화되지 않아 스킬이 로드되지 않던 문제를 수정
- `claude-plugin-list` 명령어를 `claude-plugins-help`에도 노출해 발견성 개선

## Changes
- `fix(claude/plugin)`: `claude/settings.json`의 `enabledPlugins`에 `understand-anything@understand-anything` 추가. `restore.sh`는 marketplace add + install까지만 수행하고 enable은 하지 않아, SSOT에 없는 플러그인은 설치돼도 비활성 상태로 남는다. 3개 계정(personal/work/work1) 모두 `claude plugin enable`로 즉시 활성화 반영, personal은 이미 별도로 활성화돼 있었음을 확인.
- `chore(claude-plugins-help)`: 기존에 있던 `claude-plugin-list` 명령어가 `claude-help plugin`에서만 노출되고 `claude-plugins-help`의 summary/commands 섹션에는 등록돼 있지 않아 발견이 어려웠음 — 두 곳 모두에 추가.

## Test plan
- [x] `claude plugin enable understand-anything`(work/work1) 성공, personal은 already-enabled 확인
- [x] 재접속한 새 세션에서 `understand-anything:*` 스킬/에이전트 로드 확인
- [x] `claude-plugins-help` / `claude-plugins-help commands` 출력에 `claude-plugin-list` 노출 확인 (source 테스트)
- [x] `shellcheck` 통과, pre-commit hook 통과 (커밋 시 확인됨)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
