### PR TITLE
feat(setup): opencode knox-id 를 SSOT 에서 자동 치환해 placeholder warning 제거

### DIFF
--- a/shell-common/env/development.local.example
+++ b/shell-common/env/development.local.example
@@ -12,3 +12,8 @@
 
 # 예: 회사PC — 전체 코어 사용 (기본값과 동일하므로 설정 불필요)
 # export PYTEST_ADDOPTS="-n auto"
+
+# 예: OpenCode internal 모드 — Samsung Knox ID SSOT (issue #1121)
+# 여기서 export 하면 setup.sh 가 opencode.json 의 your-knox-id 를 자동 치환한다.
+# 설정하지 않으면 ~/.dotfiles-knox-id 파일 또는 setup 중 1회 프롬프트로 대체된다.
+# export DOTFILES_KNOX_ID="your-knox-id"

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -333,9 +333,14 @@ setup_opencode_config() {
             _knox_id="$(_resolve_knox_id)" || _knox_id=""
             if [ -n "$_knox_id" ]; then
                 # Escape sed replacement metacharacters (\ / &) so unusual IDs
-                # cannot corrupt the substitution.
-                _knox_esc="$(printf '%s' "$_knox_id" | sed -e 's/[\/&]/\\&/g')"
-                sed -i "s/your-knox-id/${_knox_esc}/g" "$opencode_target"
+                # cannot corrupt the substitution. Use the portable temp-file
+                # rewrite instead of `sed -i` — GNU and BSD (macOS) disagree on
+                # the -i argument syntax (PR #1123 review). `mv` drops the 600
+                # perms, so re-apply chmod afterwards.
+                _knox_esc="$(printf '%s' "$_knox_id" | sed -e 's/[\\/&]/\\&/g')"
+                sed "s/your-knox-id/${_knox_esc}/g" "$opencode_target" >"${opencode_target}.tmp"
+                mv "${opencode_target}.tmp" "$opencode_target"
+                chmod 600 "$opencode_target"
                 ux_success "Applied Knox ID to OpenCode config (SSOT: \$DOTFILES_KNOX_ID or ~/.dotfiles-knox-id)"
             else
                 ux_warning "Edit $opencode_target and replace 'your-knox-id' with your Samsung Knox ID"

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -258,6 +258,51 @@ setup_bun_config() {
     esac
 }
 
+# Resolve the Samsung Knox ID for OpenCode's internal-mode config (issue #1121).
+# Lookup order (first non-empty wins):
+#   1. $DOTFILES_KNOX_ID env var  — reuse the shell-sourced SSOT
+#      (see shell-common/env/development.local.example).
+#   2. ~/.dotfiles-knox-id file   — persistent file SSOT, mirrors the
+#      ~/.dotfiles-setup-mode convention.
+#   3. one-time interactive prompt (tty only) — the entered value is saved to
+#      ~/.dotfiles-knox-id so later runs are non-interactive and idempotent.
+# Prints the resolved Knox ID on stdout; returns 1 (no output) when nothing is
+# available and stdin is not a tty — keeping non-interactive setup / CI safe.
+_resolve_knox_id() {
+    _knox_file="$HOME/.dotfiles-knox-id"
+
+    # 1. Environment variable SSOT.
+    if [ -n "${DOTFILES_KNOX_ID:-}" ]; then
+        printf '%s\n' "$DOTFILES_KNOX_ID"
+        return 0
+    fi
+
+    # 2. File SSOT.
+    if [ -f "$_knox_file" ]; then
+        _knox_val="$(head -n 1 "$_knox_file" | tr -d '[:space:]')"
+        if [ -n "$_knox_val" ]; then
+            printf '%s\n' "$_knox_val"
+            return 0
+        fi
+    fi
+
+    # 3. One-time prompt (interactive shells only). Persist to the file SSOT so
+    #    subsequent runs resolve via step 2 without prompting again.
+    if [ -t 0 ]; then
+        printf 'Enter your Samsung Knox ID (saved to %s): ' "$_knox_file" >&2
+        read -r _knox_val || _knox_val=""
+        _knox_val="$(printf '%s' "$_knox_val" | tr -d '[:space:]')"
+        if [ -n "$_knox_val" ]; then
+            printf '%s\n' "$_knox_val" >"$_knox_file"
+            chmod 600 "$_knox_file" 2>/dev/null || true
+            printf '%s\n' "$_knox_val"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 setup_opencode_config() {
     environment="$1"
     opencode_target="$HOME/.config/opencode/opencode.json"
@@ -281,7 +326,21 @@ setup_opencode_config() {
             chmod 600 "$opencode_target"
             ux_success "Copied template: opencode/opencode.json.internal → ~/.config/opencode/opencode.json"
             ux_info "Using: Samsung internal gateway (a2g.samsungds.net)"
-            ux_warning "Edit $opencode_target and replace 'your-knox-id' with your Samsung Knox ID"
+            # Fill in the Knox ID from the SSOT (env → ~/.dotfiles-knox-id →
+            # one-time prompt) so the placeholder warning no longer recurs on
+            # every setup (issue #1121). Falls back to the manual-edit warning
+            # only when nothing is available and setup is non-interactive.
+            _knox_id="$(_resolve_knox_id)" || _knox_id=""
+            if [ -n "$_knox_id" ]; then
+                # Escape sed replacement metacharacters (\ / &) so unusual IDs
+                # cannot corrupt the substitution.
+                _knox_esc="$(printf '%s' "$_knox_id" | sed -e 's/[\/&]/\\&/g')"
+                sed -i "s/your-knox-id/${_knox_esc}/g" "$opencode_target"
+                ux_success "Applied Knox ID to OpenCode config (SSOT: \$DOTFILES_KNOX_ID or ~/.dotfiles-knox-id)"
+            else
+                ux_warning "Edit $opencode_target and replace 'your-knox-id' with your Samsung Knox ID"
+                ux_info "Tip: save it once to ~/.dotfiles-knox-id (or export DOTFILES_KNOX_ID) to auto-fill next time"
+            fi
             ;;
         external)
             mkdir -p "$(dirname "$opencode_target")"
@@ -673,7 +732,7 @@ main() {
             ux_info "  - Proxy: Company proxy (12.26.204.100:8080) configured"
             ux_info "  - NPM: ~/.npmrc → npm/npmrc.internal (Nexus + proxy)"
             ux_info "  - Bun: ~/.bunfig.toml → bun/bunfig.toml.internal (Nexus registry)"
-            ux_info "  - OpenCode: copied from opencode/opencode.json.internal (edit your-knox-id manually)"
+            ux_info "  - OpenCode: opencode/opencode.json.internal with Knox ID from SSOT (\$DOTFILES_KNOX_ID / ~/.dotfiles-knox-id, else 1-time prompt)"
             ux_info "  - Pip: Samsung internal repository configured"
             ux_info "  - uv: Samsung internal repository + proxy configured"
             ux_info "  - Cargo: ~/.cargo/config.toml (Nexus proxy for crates.io)"

--- a/tests/bats/functions/setup_opencode_config.bats
+++ b/tests/bats/functions/setup_opencode_config.bats
@@ -96,3 +96,69 @@ count_backups() {
     [ ! -L "$TARGET" ]
     grep -q 'your-knox-id' "$TARGET"
 }
+
+# --- Knox ID SSOT auto-fill (issue #1121) -----------------------------------
+# The four scenarios below mirror the issue's acceptance criteria: fill from
+# each SSOT, suppress the warning, and stay idempotent across re-runs.
+
+# Same as run_setup_opencode but with DOTFILES_KNOX_ID exported into the child.
+run_setup_opencode_env() {
+    run bash --noprofile --norc -c "
+        set -e
+        export DOTFILES_KNOX_ID='$1'
+        cd '$FIXTURE_DOTFILES/shell-common'
+        . './setup.sh'
+        setup_opencode_config internal
+    "
+}
+
+@test "env SSOT: DOTFILES_KNOX_ID substitutes placeholder, no warning" {
+    run_setup_opencode_env "envknox42"
+    assert_success
+    [ -f "$TARGET" ]
+    grep -q 'envknox42' "$TARGET"
+    ! grep -q 'your-knox-id' "$TARGET"
+    refute_output --partial "replace 'your-knox-id'"
+}
+
+@test "file SSOT: ~/.dotfiles-knox-id substitutes placeholder, no warning" {
+    printf 'fileknox99\n' >"$HOME/.dotfiles-knox-id"
+
+    run_setup_opencode
+    assert_success
+    grep -q 'fileknox99' "$TARGET"
+    ! grep -q 'your-knox-id' "$TARGET"
+    refute_output --partial "replace 'your-knox-id'"
+}
+
+@test "env SSOT takes precedence over file SSOT" {
+    printf 'fileknox99\n' >"$HOME/.dotfiles-knox-id"
+
+    run_setup_opencode_env "envknox42"
+    assert_success
+    grep -q 'envknox42' "$TARGET"
+    ! grep -q 'fileknox99' "$TARGET"
+}
+
+@test "file SSOT: re-run is idempotent (preserve, no warning, no backup)" {
+    printf 'fileknox99\n' >"$HOME/.dotfiles-knox-id"
+
+    run_setup_opencode
+    assert_success
+    filled_content="$(cat "$TARGET")"
+
+    # Second run: placeholder is gone, so the #792 preserve guard fires.
+    run_setup_opencode
+    assert_success
+    assert_output --partial "Preserved customised OpenCode config"
+    [ "$(cat "$TARGET")" = "$filled_content" ]
+    [ "$(count_backups)" -eq 0 ]
+}
+
+@test "no SSOT + non-interactive: keeps placeholder and warns (fallback)" {
+    # No env var, no file, no tty (bash -c) — must degrade gracefully.
+    run_setup_opencode
+    assert_success
+    grep -q 'your-knox-id' "$TARGET"
+    assert_output --partial "replace 'your-knox-id'"
+}


### PR DESCRIPTION
## Summary
- internal 모드 `setup.sh` 실행마다 `opencode.json` 이 `your-knox-id` placeholder 로 복사되어 매번 수동 편집 warning 이 반복되던 문제를 해결한다.
- Knox ID 를 재사용 가능한 SSOT(환경변수 / 파일)에서 읽어 setup 시점에 자동 치환하고, 없으면 tty 1회 프롬프트로 획득해 저장한다.
- #792 preserve 가드와 결합해 재실행 idempotent 를 유지한다.

## Changes
- `shell-common/setup.sh`: `_resolve_knox_id` 헬퍼 신설 — `$DOTFILES_KNOX_ID` → `~/.dotfiles-knox-id` 파일 → tty 1회 프롬프트(입력값을 파일 SSOT 에 저장) 순으로 Knox ID 해석. `setup_opencode_config internal` 이 template 복사 후 `sed` 로 placeholder 를 치환하고, 실패(비인터랙티브 + SSOT 없음) 시에만 기존 manual-edit warning 으로 안전 강등. sed 치환 메타문자(`\ / &`) 이스케이프로 방어. internal 요약 로그 문구 갱신.
- `shell-common/env/development.local.example`: `DOTFILES_KNOX_ID` 환경변수 SSOT 사용 예시를 주석으로 문서화.
- `tests/bats/functions/setup_opencode_config.bats`: 수용 기준 4항을 커버하는 bats 5종 추가 — env SSOT 치환/무경고, 파일 SSOT 치환/무경고, env > 파일 우선순위, 재실행 idempotent(preserve, 백업 없음), SSOT 부재 + 비인터랙티브 fallback.

## Test plan
- [x] `bats tests/bats/functions/setup_opencode_config.bats` — 9/9 통과 (기존 4 + 신규 5)
- [x] `shellcheck -s sh` / `shfmt -d -i 4` — 변경 영역 clean
- [ ] internal PC 에서 `rm -f ~/.config/opencode/opencode.json && ./setup.sh` (2) → `grep '"x-user-id"'` 결과가 실제 Knox ID 로 치환됐는지, warning 이 사라졌는지 확인

## Related
Closes #1121

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
