### PR TITLE
fix(git-worktree): teardown 동기화 전략 통일 + main diverge 원인 제거

### DIFF
--- a/claude/hooks/plugin-sync.sh
+++ b/claude/hooks/plugin-sync.sh
@@ -107,6 +107,32 @@ _commit_if_changed() {
 			printf 'plugin-sync: manifest commit failed in %s; failed to unstage changes\n' \
 				"$repo_dir" >&2
 		fi
+		return 0
+	fi
+	# The commit succeeded — push it if it landed on a protected branch (#1125).
+	_push_if_protected "$repo_dir"
+}
+
+# Push the just-committed branch when it is a protected branch (main/master).
+# ALLOW_MAIN_COMMIT lets the manifest commit land directly on main (#1072), but
+# an unpushed commit on main diverges the moment origin/main advances via a
+# merged PR — which then makes `gwt teardown`'s ff-only main-sync refuse (#1125).
+# Pushing right away keeps local main == origin/main so no local-only commit
+# lingers. Best-effort: no upstream / offline / branch-protection rejection just
+# leaves today's local-only commit plus a stderr hint — the hook still exits 0.
+_push_if_protected() {
+	local repo_dir="$1" branch upstream
+	branch=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null) || return 0
+	case "$branch" in
+	main | master) ;;
+	*) return 0 ;;
+	esac
+	# Never guess a remote — only push when the branch has a configured upstream.
+	upstream=$(git -C "$repo_dir" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null) || return 0
+	[ -n "$upstream" ] || return 0
+	if ! git -C "$repo_dir" push --quiet 2>/dev/null; then
+		printf 'plugin-sync: manifest committed on protected %s in %s but push to %s failed; commit is local-only (rebase/push before it diverges from origin)\n' \
+			"$branch" "$repo_dir" "$upstream" >&2
 	fi
 }
 

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -346,9 +346,23 @@ git_branch_teardown() {
         fi
     fi
 
-    # Pull main (fast-forward)
-    if ! git pull origin "$main_branch"; then
-        ux_warning "Pull failed (network?). Branch delete may misjudge merge status."
+    # Sync main to origin — fetch + `git merge --ff-only`, matching
+    # `gwt teardown` (git_worktree.sh:2308). `git pull` was wrong here: under
+    # pull.rebase=false a diverged local main would silently gain an unwanted
+    # merge commit, and under pull.rebase=true it rebases — neither is the
+    # intended "catch up only if we cleanly can". Fast-forward only; a diverged
+    # local main is reported with ahead/behind counts, never rewritten (#1125).
+    if git fetch --quiet origin "$main_branch" 2>/dev/null; then
+        if git rev-parse --verify --quiet "origin/$main_branch" >/dev/null 2>&1 \
+            && ! git merge --ff-only "origin/$main_branch" >/dev/null 2>&1; then
+            local _sync_ahead _sync_behind
+            _sync_ahead="$(git rev-list --count "origin/$main_branch..$main_branch" 2>/dev/null || printf '?')"
+            _sync_behind="$(git rev-list --count "$main_branch..origin/$main_branch" 2>/dev/null || printf '?')"
+            ux_warning "Main sync skipped — local '$main_branch' diverged from origin/$main_branch (${_sync_ahead} ahead, ${_sync_behind} behind)."
+            ux_info "  Resolve manually (rebase / reset). Branch delete may misjudge merge status."
+        fi
+    else
+        ux_warning "Fetch failed (network?). Branch delete may misjudge merge status."
     fi
 
     # Delete branch

--- a/shell-common/functions/git_branch.sh
+++ b/shell-common/functions/git_branch.sh
@@ -353,13 +353,22 @@ git_branch_teardown() {
     # intended "catch up only if we cleanly can". Fast-forward only; a diverged
     # local main is reported with ahead/behind counts, never rewritten (#1125).
     if git fetch --quiet origin "$main_branch" 2>/dev/null; then
-        if git rev-parse --verify --quiet "origin/$main_branch" >/dev/null 2>&1 \
-            && ! git merge --ff-only "origin/$main_branch" >/dev/null 2>&1; then
-            local _sync_ahead _sync_behind
-            _sync_ahead="$(git rev-list --count "origin/$main_branch..$main_branch" 2>/dev/null || printf '?')"
-            _sync_behind="$(git rev-list --count "$main_branch..origin/$main_branch" 2>/dev/null || printf '?')"
-            ux_warning "Main sync skipped — local '$main_branch' diverged from origin/$main_branch (${_sync_ahead} ahead, ${_sync_behind} behind)."
-            ux_info "  Resolve manually (rebase / reset). Branch delete may misjudge merge status."
+        if git rev-parse --verify --quiet "origin/$main_branch" >/dev/null 2>&1; then
+            # Capture ff-only stderr (same as gwt teardown, git_worktree.sh:2312)
+            # so a failure from uncommitted changes / an index lock surfaces its
+            # real cause instead of being mislabeled as pure divergence.
+            local _sync_err_file="${TMPDIR:-/tmp}/gbr-sync.$$.err"
+            if ! git merge --ff-only "origin/$main_branch" 2>"$_sync_err_file" >/dev/null; then
+                local _sync_ahead _sync_behind
+                _sync_ahead="$(git rev-list --count "origin/$main_branch..$main_branch" 2>/dev/null || printf '?')"
+                _sync_behind="$(git rev-list --count "$main_branch..origin/$main_branch" 2>/dev/null || printf '?')"
+                ux_warning "Main sync skipped — local '$main_branch' diverged from origin/$main_branch (${_sync_ahead} ahead, ${_sync_behind} behind)."
+                if [ -s "$_sync_err_file" ]; then
+                    sed 's/^/    /' "$_sync_err_file" >&2
+                fi
+                ux_info "  Resolve manually (rebase / reset). Branch delete may misjudge merge status."
+            fi
+            rm -f "$_sync_err_file"
         fi
     else
         ux_warning "Fetch failed (network?). Branch delete may misjudge merge status."

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -2318,7 +2318,12 @@ EOF
             if [ -s "$_gwt_ff_err_file" ]; then
                 sed 's/^/    /' "$_gwt_ff_err_file" >&2
             fi
-            ux_info "  Local '$main_branch' has diverged from origin/$main_branch."
+            # Reuse the status view's ahead/behind pattern (~l.986) so the
+            # message says HOW FAR local main diverged, not just that it did.
+            local _gwt_main_ahead _gwt_main_behind
+            _gwt_main_ahead="$(git rev-list --count "origin/$main_branch..$main_branch" 2>/dev/null || printf '?')"
+            _gwt_main_behind="$(git rev-list --count "$main_branch..origin/$main_branch" 2>/dev/null || printf '?')"
+            ux_info "  Local '$main_branch' has diverged from origin/$main_branch (${_gwt_main_ahead} ahead, ${_gwt_main_behind} behind)."
             ux_info "  Resolve manually (rebase / reset) before spawning new worktrees from local '$main_branch'."
         fi
     else

--- a/tests/bats/functions/git_branch_teardown.bats
+++ b/tests/bats/functions/git_branch_teardown.bats
@@ -113,6 +113,43 @@ _setup_unmerged_tracking_main() {
     )
 }
 
+# Create: $ORIGIN4 (bare) <- $CLONE4 on feat/y where LOCAL main has diverged
+# from origin/main (each side has a unique commit) — the exact shape that made
+# `git pull origin main` create a silent merge commit under pull.rebase=false
+# (#1125). pull.rebase is pinned false so the test asserts the ff-only behavior,
+# not the caller's global git config.
+_setup_diverged_main_clone() {
+    ORIGIN4="$TEST_TEMP_HOME/origin4.git"
+    CLONE4="$TEST_TEMP_HOME/clone4"
+
+    export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+           GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+    git init --bare --initial-branch=main "$ORIGIN4" >/dev/null
+    git clone -q "$ORIGIN4" "$CLONE4"
+    (
+        cd "$CLONE4"
+        git config pull.rebase false
+        echo base > base.txt && git add base.txt && git commit -q -m base
+        git push -q origin main
+
+        # Feature branch (force-deletable via --force, not merged).
+        git checkout -q -b feat/y
+        echo work > work.txt && git add work.txt && git commit -q -m "feat: work"
+
+        # origin/main advances (simulate a merged PR from elsewhere).
+        local helper="$TEST_TEMP_HOME/diverge-helper"
+        git clone -q "$ORIGIN4" "$helper"
+        ( cd "$helper" && echo adv > adv.txt && git add adv.txt && git commit -q -m advance && git push -q origin main )
+        rm -rf "$helper"
+
+        # Local main gains a local-only commit → genuine divergence.
+        git checkout -q main
+        echo localonly > localonly.txt && git add localonly.txt && git commit -q -m "local-only"
+        git checkout -q feat/y
+    )
+}
+
 setup() {
     setup_isolated_home
     _setup_conflicted_clone
@@ -190,6 +227,31 @@ teardown() {
     [ "$(git -C "$CLONE2" symbolic-ref --short HEAD)" = "feat/wip" ]
     run git -C "$CLONE2" rev-parse --verify --quiet feat/wip
     assert_success
+}
+
+@test "teardown: diverged local main is NOT silently merged — ff-only refuses (#1125)" {
+    _setup_diverged_main_clone
+    local before_main
+    before_main="$(git -C "$CLONE4" rev-parse main)"
+
+    run_in_bash "cd '$CLONE4' && gbr teardown --force 2>&1"
+    assert_success
+    assert_output --partial "Teardown complete"
+    # Divergence is reported with counts (1 local-only ahead, 1 advance behind),
+    # not collapsed into a bare "network?".
+    assert_output --partial "diverged from origin/main"
+    assert_output --partial "1 ahead, 1 behind"
+    refute_output --partial "network?"
+
+    # The crux of #1125: NO merge commit was fabricated on main under
+    # pull.rebase=false. Local main tip is unchanged and has a single parent.
+    [ "$(git -C "$CLONE4" rev-parse main)" = "$before_main" ]
+    run git -C "$CLONE4" rev-list --merges main
+    assert_output ""
+
+    # Feature branch still torn down (--force).
+    run git -C "$CLONE4" rev-parse --verify --quiet feat/y
+    assert_failure
 }
 
 @test "teardown --help documents --discard-changes" {

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -108,6 +108,18 @@ teardown() {
     refute_output --partial "network?"
 }
 
+@test "teardown: diverged local main — diagnostic shows ahead/behind counts (#1125)" {
+    # 1 local-only commit ahead, 1 origin/main commit behind → the failure
+    # message must quantify the divergence, not just say it happened.
+    _diverge_local_main
+    _advance_origin_main
+
+    run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
+    assert_failure
+    assert_output --partial "1 ahead, 1 behind"
+    assert_output --partial "diverged from origin/main"
+}
+
 @test "teardown: fetch failure surfaces real stderr (A), not 'network?'" {
     # Point origin at a non-existent path so `git fetch origin` fails at step 1.
     git -C "$CLONE" remote set-url origin "$TEST_TEMP_HOME/does-not-exist.git"

--- a/tests/bats/skills/plugin_sync_hook.bats
+++ b/tests/bats/skills/plugin_sync_hook.bats
@@ -280,18 +280,19 @@ JSON
     mkdir -p "$MAIN_ROOT/claude/plugin"
     ( cd "$MAIN_ROOT" && echo seed > seed.txt && git add seed.txt \
         && git commit -q -m seed && git push -q origin main \
-        && git checkout -q -b feat/x )
+        && git checkout -q -b feat/x && git push -q -u origin feat/x )
 
     payload='{"tool_name":"Bash","tool_input":{"command":"claude plugin install ralph-loop@claude-plugins-official"}}'
     run bash -c "printf '%s' '$payload' | '$HOOK'"
     assert_success
 
-    # Committed locally on the feature branch, but push is main/master-only, so
-    # feat/x was never pushed (no origin/feat/x ref exists).
+    # Committed locally on the feature branch. feat/x HAS an upstream, so the
+    # early @{u} return cannot mask a broken branch filter — the only reason
+    # origin/feat/x stays at seed is the main/master-only scope guard.
     run git -C "$MAIN_ROOT" log -1 --format=%s
     assert_output "chore(claude-plugin): sync manifest"
-    run git -C "$MAIN_ROOT" rev-parse --verify --quiet origin/feat/x
-    assert_failure
+    run git -C "$MAIN_ROOT" log -1 --format=%s origin/feat/x
+    assert_output "seed"
 }
 
 @test "no-op re-run does not create an empty commit" {

--- a/tests/bats/skills/plugin_sync_hook.bats
+++ b/tests/bats/skills/plugin_sync_hook.bats
@@ -237,6 +237,63 @@ JSON
     assert_output ""
 }
 
+@test "install → commit on protected 'main' with upstream is pushed, not left local-only (#1125)" {
+    _known_marketplaces
+    _installed_plugins
+
+    # Rebuild MAIN_ROOT as a clone of a bare origin so `main` tracks origin/main.
+    # A local-only manifest commit on main would diverge once origin/main moves;
+    # the hook must push it right away.
+    local origin="$TEST_TEMP_HOME/origin.git"
+    rm -rf "$MAIN_ROOT"
+    git init --bare --initial-branch=main "$origin" >/dev/null
+    git clone -q "$origin" "$MAIN_ROOT"
+    git -C "$MAIN_ROOT" config user.email "hook-test@example.com"
+    git -C "$MAIN_ROOT" config user.name "hook-test"
+    mkdir -p "$MAIN_ROOT/claude/plugin"
+    ( cd "$MAIN_ROOT" && echo seed > seed.txt && git add seed.txt \
+        && git commit -q -m seed && git push -q origin main )
+
+    payload='{"tool_name":"Bash","tool_input":{"command":"claude plugin install ralph-loop@claude-plugins-official"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+
+    # Commit landed AND was pushed: local main == origin/main, so no local-only
+    # commit lingers to later diverge.
+    run git -C "$MAIN_ROOT" log -1 --format=%s
+    assert_output "chore(claude-plugin): sync manifest"
+    [ "$(git -C "$MAIN_ROOT" rev-parse main)" = "$(git -C "$MAIN_ROOT" rev-parse origin/main)" ]
+    run git -C "$MAIN_ROOT" status --porcelain
+    assert_output ""
+}
+
+@test "install → commit on a feature branch is NOT auto-pushed (#1125 scope guard)" {
+    _known_marketplaces
+    _installed_plugins
+
+    local origin="$TEST_TEMP_HOME/origin-feat.git"
+    rm -rf "$MAIN_ROOT"
+    git init --bare --initial-branch=main "$origin" >/dev/null
+    git clone -q "$origin" "$MAIN_ROOT"
+    git -C "$MAIN_ROOT" config user.email "hook-test@example.com"
+    git -C "$MAIN_ROOT" config user.name "hook-test"
+    mkdir -p "$MAIN_ROOT/claude/plugin"
+    ( cd "$MAIN_ROOT" && echo seed > seed.txt && git add seed.txt \
+        && git commit -q -m seed && git push -q origin main \
+        && git checkout -q -b feat/x )
+
+    payload='{"tool_name":"Bash","tool_input":{"command":"claude plugin install ralph-loop@claude-plugins-official"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+
+    # Committed locally on the feature branch, but push is main/master-only, so
+    # feat/x was never pushed (no origin/feat/x ref exists).
+    run git -C "$MAIN_ROOT" log -1 --format=%s
+    assert_output "chore(claude-plugin): sync manifest"
+    run git -C "$MAIN_ROOT" rev-parse --verify --quiet origin/feat/x
+    assert_failure
+}
+
 @test "no-op re-run does not create an empty commit" {
     _known_marketplaces
     _installed_plugins


### PR DESCRIPTION
## Summary
- `main` diverge를 유발하던 근본 원인과 `gwt`/`gbr` teardown 간 main-sync 전략 불일치를 함께 정리한다.
- 로컬 전용 커밋이 protected 브랜치에 남지 않도록 하고, 동기화 실패 시 진단을 정량화한다.

## Changes
- **gbr teardown** (`git_branch.sh`): main-sync를 `git pull` → `git fetch` + `git merge --ff-only`로 통일 (`gwt teardown`과 동일 전략). `pull.rebase=false` 환경에서 diverged main에 조용히 merge commit이 생기던 위험을 제거 — fast-forward 불가 시 ahead/behind 카운트와 함께 경고만 남기고 절대 rewrite 하지 않는다.
- **gwt teardown** (`git_worktree.sh`): "Main sync failed" 진단에 ahead/behind 카운트를 추가한다 (status view의 `git rev-list --count` 패턴 재사용). `Local 'main' has diverged from origin/main (N ahead, M behind)`.
- **plugin-sync.sh**: protected 브랜치(main/master)에 매니페스트를 커밋한 뒤 upstream이 설정돼 있으면 즉시 `git push` 하여, 이후 `origin/main`이 앞서갈 때 로컬 main이 diverge 하는 근본 원인을 제거한다. #1072(main에도 커밋은 반드시 land) 회귀 없이 best-effort — push 실패 시 stderr 힌트만 남기고 `exit 0` 유지, feature 브랜치는 자동 push 대상이 아니다.
- **tests**: 회귀 테스트 4건 추가 (bats) — ff-only 거부/merge commit 미생성, ahead/behind 진단, protected-push, feature-branch scope guard.

## Test plan
- [x] `bats tests/bats/functions/git_branch_teardown.bats` (신규 diverge 테스트 포함)
- [x] `bats tests/bats/functions/git_worktree_teardown.bats` (신규 ahead/behind 테스트 포함)
- [x] `bats tests/bats/skills/plugin_sync_hook.bats` (신규 push/scope-guard 테스트 포함)
- [x] `shellcheck` 무에러 · `shfmt` 파일 컨벤션 일치 · golden rules 6/6 통과
- [ ] `main`에 unpushed commit을 인위로 만든 뒤 `gwt`/`gbr teardown` 양쪽에서 동일한 진단 메시지 확인 (실사용 검증)

## Related
Closes #1125

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
