### PR TITLE
fix(aws/setup): settings.json 머지 idempotency — 순서 무관 semantic 비교

### DIFF
--- a/aws/setup.sh
+++ b/aws/setup.sh
@@ -204,7 +204,12 @@ _merge_claude_settings_json() {
         | $base * $overlay
             * ($existing | del(.hooks, .statusLine, .availableModels, .modelOverrides))
     ' "$_base" "$_overlay" "$_tgt" > "$_tmp_merged"; then
-        if cmp -s "$_tgt" "$_tmp_merged"; then
+        # 순서 무관(semantic) 비교 (#1130): jq `*` 는 overlay/기타 키를 좌변 뒤로
+        # 이어 붙여 값이 동일해도 키 순서가 매 실행 달라진다. byte 비교(cmp -s)는
+        # 이 순서 churn 을 "변경" 으로 오판해 매번 백업+재작성했다. 양변을 canonical
+        # key order(jq -S)로 정규화해 비교하면 값 드리프트 0 일 때 아래 Preserved
+        # 분기로 정확히 떨어진다. 디스크 표현(파일 순서)은 건드리지 않는다.
+        if jq -S . "$_tgt" 2>/dev/null | cmp -s - <(jq -S . "$_tmp_merged" 2>/dev/null); then
             rm -f "$_tmp_merged"
             ux_success "Preserved (already up to date): $_tgt"
         else

--- a/tests/bats/setup/aws_merge_claude_settings.bats
+++ b/tests/bats/setup/aws_merge_claude_settings.bats
@@ -137,3 +137,55 @@ JSON
     run jq -r '.theme' "$TGT"
     [ "$output" = "light" ]
 }
+
+@test "merge #1130: values equal but key order differs → Preserved, no backup churn" {
+    # Seed TGT via one real merge so it becomes the merge fixed point.
+    cat >"$TGT" <<'JSON'
+{
+  "model": "user-picked-model",
+  "theme": "light",
+  "myCustomKey": "keep-me"
+}
+JSON
+    run _merge_claude_settings_json "$BASE" "$OVERLAY" "$TGT"
+    [ "$status" -eq 0 ]
+
+    # Rewrite TGT with IDENTICAL values but a different (sorted) key order —
+    # this is the real-world churn trigger. jq `*` re-orders keys, so a byte
+    # comparison (cmp -s) always saw a "change" and re-wrote + backed up on
+    # every re-run even though nothing drifted (issue #1130).
+    jq -S . "$TGT" >"$TGT.sorted"
+    mv "$TGT.sorted" "$TGT"
+    # Drop the backup produced by the seeding merge above — we only want to
+    # observe whether the SECOND (idempotent) run creates one.
+    rm -f "$TEST_TEMP_HOME"/settings.json.bedrock-merge-backup.*
+
+    # Capture which branch the idempotent re-run takes.
+    ux_success() { echo "SUCCESS: $*"; }
+    run _merge_claude_settings_json "$BASE" "$OVERLAY" "$TGT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Preserved (already up to date)"* ]]
+    [[ "$output" != *"Merged Bedrock keys into"* ]]
+
+    # No new backup file created on the idempotent run.
+    run bash -c 'ls "$1"/settings.json.bedrock-merge-backup.* 2>/dev/null | wc -l' _ "$TEST_TEMP_HOME"
+    [ "$output" -eq 0 ]
+}
+
+@test "merge #1130: real value drift still Merges + creates one backup" {
+    # existing lacks the SSOT-owned fields → a genuine merge is required.
+    cat >"$TGT" <<'JSON'
+{
+  "model": "user-picked-model",
+  "theme": "light"
+}
+JSON
+    ux_success() { echo "SUCCESS: $*"; }
+    run _merge_claude_settings_json "$BASE" "$OVERLAY" "$TGT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Merged Bedrock keys into"* ]]
+    [[ "$output" != *"Preserved (already up to date)"* ]]
+
+    run bash -c 'ls "$1"/settings.json.bedrock-merge-backup.* 2>/dev/null | wc -l' _ "$TEST_TEMP_HOME"
+    [ "$output" -eq 1 ]
+}

--- a/tests/bats/setup/aws_merge_claude_settings.bats
+++ b/tests/bats/setup/aws_merge_claude_settings.bats
@@ -156,6 +156,9 @@ JSON
     # every re-run even though nothing drifted (issue #1130).
     jq -S . "$TGT" >"$TGT.sorted"
     mv "$TGT.sorted" "$TGT"
+    # umask can reset perms on a temp-file rewrite; restore 0600 to mirror the
+    # real ~/.claude/settings.json (matches the chmod-after-mv idiom in setup.sh).
+    chmod 0600 "$TGT"
     # Drop the backup produced by the seeding merge above — we only want to
     # observe whether the SECOND (idempotent) run creates one.
     rm -f "$TEST_TEMP_HOME"/settings.json.bedrock-merge-backup.*


### PR DESCRIPTION
## Summary
- `aws/setup.sh` 의 `_merge_claude_settings_json` idempotency 버그 수정: 값 드리프트가 0 인데도 `./aws/setup.sh` 재실행마다 "Merged Bedrock keys into..." 오보 + 백업 파일 churn 이 발생하던 문제를 해결한다.
- 근본 원인은 병합 결과 동일성을 byte 단위(`cmp -s`)로 판정한 것. jq `*` 가 overlay/기타 키를 좌변 뒤로 이어 붙여 값이 SSOT 와 완전히 동일해도 키 순서가 매 실행 달라진다.

## Changes
- `aws/setup.sh`: 비교 직전 양변을 canonical key order(`jq -S`)로 정규화해 순서 무관(semantic)하게 판정 (이슈 #1130 권장 방안 A). 디스크 표현(파일 키 순서)은 건드리지 않아 사용자가 손으로 정렬해 둔 순서를 보존한다. 값이 실제로 바뀔 때는 기존대로 백업+재작성 경로를 탄다.
- `tests/bats/setup/aws_merge_claude_settings.bats`: 회귀 테스트 2건 추가 — (1) 값 동일·키 순서만 상이 → `Preserved` (백업 미생성), (2) 실제 값 드리프트 → `Merged` + 백업 1개.

## Test plan
- [x] `bats tests/bats/setup/aws_merge_claude_settings.bats` — 5/5 green (신규 2건 포함)
- [x] old `cmp -s` 로직이 동일 시나리오에서 churn(Merged+backup) 함을, 신 `jq -S` 로직이 `Preserved` 함을 격리 재현으로 확인
- [x] `shellcheck -x aws/setup.sh` clean
- [x] 전체 스위트: pytest 1157 passed · golden rules 6/6 · bats green (무관 pre-existing `gcp.bats #913` 1건 제외)

## Related
Closes #1130

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
