### PR TITLE
fix(devx:ssh-delegate): add 명령 3개 결함 수정 (#1132)

### DIFF
--- a/claude/skills/devx-ssh-delegate/SKILL.md
+++ b/claude/skills/devx-ssh-delegate/SKILL.md
@@ -41,7 +41,7 @@ First positional arg selects the action:
 | Sub-command | Args | Effect |
 |---|---|---|
 | `sync` | — | Reconcile manifest ↔ reality (regen config, pin/verify). |
-| `add` | `<user>@<host> [alias] [--dry-run]` | Add + install + verify one entry. |
+| `add` | `<user>@<host> [alias] [--dry-run] [--key-only]` | Add + install + verify one entry. |
 | `list` | `[--json]` | Print the delegation table / JSON. |
 | `test` | `[<alias>\|--all]` | BatchMode reachability check. |
 | `revoke` | `<alias>` | Remove remote key + mark `revoked: true`. |
@@ -59,10 +59,17 @@ skill's directory):
 ```
 
 - `add` runs `ssh-copy-id` interactively — the user enters the remote password
-  **once**. Tell them to expect that single prompt; do not try to supply it.
+  **once**. Tell them to expect that single prompt; do not try to supply it. In
+  a non-interactive shell (a Claude `!` session) `add` fails fast with the exact
+  command to run in a real terminal — relay it verbatim (issue #1132).
+- If the alias already has a hand-written `Host` block with a different
+  `IdentityFile`, `add` adopts that key (via `ssh -G`) so the installed key is
+  the one ssh actually offers — surface the adoption warning it prints.
 - `add --dry-run` prints the planned actions (manifest upsert, `ssh-copy-id`
   command, config regen, verify) without touching the remote — use it first
   when the user is unsure.
+- `add --key-only` installs the key without regenerating the ssh config drop-in
+  — for a host that already has a working hand-written alias (issue #1132).
 - Never bypass a fingerprint MISMATCH from `sync`. Surface the ALERT and stop;
   re-trust is a human decision (see `references/safety-model.md`).
 

--- a/claude/skills/devx-ssh-delegate/lib/install.sh
+++ b/claude/skills/devx-ssh-delegate/lib/install.sh
@@ -28,6 +28,27 @@ ssh_install_capture_fingerprint() {
         awk '/SHA256:/ {for(i=1;i<=NF;i++) if($i ~ /^SHA256:/){print $i; exit}}'
 }
 
+# Can ssh-copy-id obtain the remote password in this environment? (issue #1132
+# defect C.) `ssh-copy-id` needs a TTY for its single password prompt; a
+# non-interactive shell (a Claude `!` session, CI) without a usable SSH_ASKPASS
+# makes it die as `ssh_askpass: No such file or directory` -> `Permission
+# denied`, which reads as a wrong password. Returns 0 when a prompt is possible.
+# The TTY check is overridable via $DEVX_SSH_ASSUME_TTY (1=yes, 0=no) so tests
+# can exercise both branches deterministically.
+ssh_install_can_prompt() {
+    case "${DEVX_SSH_ASSUME_TTY:-}" in
+    1) return 0 ;;
+    0) : ;; # forced non-interactive — still allow a force-enabled askpass below
+    *) [ -t 0 ] && return 0 ;;
+    esac
+    # No TTY: OpenSSH only consults SSH_ASKPASS without a TTY when REQUIRE=force.
+    if [ -n "${SSH_ASKPASS:-}" ] && [ -x "${SSH_ASKPASS}" ] &&
+        [ "${SSH_ASKPASS_REQUIRE:-}" = "force" ]; then
+        return 0
+    fi
+    return 1
+}
+
 # ssh_install_copy_id <alias> [--dry-run]
 # Resolves the entry, copies the identity's .pub to the remote (one password
 # prompt), then pins installed_at + fingerprint. Returns the command line on

--- a/claude/skills/devx-ssh-delegate/lib/ssh_config.sh
+++ b/claude/skills/devx-ssh-delegate/lib/ssh_config.sh
@@ -71,14 +71,22 @@ ssh_config_conflicting_identity() {
     _cci_want="$2"
     _cci_ssh="${DEVX_SSH_BIN:-ssh}"
     command -v "$_cci_ssh" >/dev/null 2>&1 || return 1
-    _cci_ids="$("$_cci_ssh" -G "$_cci_al" 2>/dev/null | awk 'tolower($1)=="identityfile"{print $2}')"
-    [ -n "$_cci_ids" ] || return 1
     _cci_first=""
-    for _cci_id in $_cci_ids; do
+    # `ssh -G` prints one `identityfile <path>` per line. awk strips only the
+    # first field + its trailing whitespace, keeping the rest of the line
+    # verbatim, and `read` (with a nulled IFS) preserves internal spaces — so a
+    # path like macOS `/Users/John Doe/.ssh/id_rsa` survives intact. The loop
+    # runs in the current shell (here-doc, not a pipe) so `_cci_first` and the
+    # early `return` below take effect.
+    while IFS= read -r _cci_id; do
+        [ -n "$_cci_id" ] || continue
         [ -n "$_cci_first" ] || _cci_first="$_cci_id"
         # Our intended key is offered → ssh will try it → no shadowing.
         [ "$(ssh_config_expand_tilde "$_cci_id")" = "$_cci_want" ] && return 1
-    done
+    done <<EOF
+$("$_cci_ssh" -G "$_cci_al" 2>/dev/null | awk 'tolower($1)=="identityfile"{sub(/^[^ \t]+[ \t]+/, ""); print}')
+EOF
+    [ -n "$_cci_first" ] || return 1
     printf '%s\n' "$_cci_first"
     return 0
 }

--- a/claude/skills/devx-ssh-delegate/lib/ssh_config.sh
+++ b/claude/skills/devx-ssh-delegate/lib/ssh_config.sh
@@ -59,6 +59,30 @@ ssh_config_regen() {
     mv "$tmp" "$dropin"
 }
 
+# Detect a pre-existing IdentityFile that would shadow the key `add` intends to
+# install for <alias> (issue #1132 defect A). `ssh -G <alias>` prints every
+# identity ssh would actually try; an explicit `Host` block suppresses the
+# built-in defaults, so if our intended key ($2, tilde-expanded absolute) is
+# NOT among them a hand-written block is winning. In that case echo the identity
+# ssh WOULD use (its first `identityfile`, in the original ~-form) and return 0.
+# Return 1 silently when there is no conflict, no output, or ssh is unavailable.
+ssh_config_conflicting_identity() {
+    _cci_al="$1"
+    _cci_want="$2"
+    _cci_ssh="${DEVX_SSH_BIN:-ssh}"
+    command -v "$_cci_ssh" >/dev/null 2>&1 || return 1
+    _cci_ids="$("$_cci_ssh" -G "$_cci_al" 2>/dev/null | awk 'tolower($1)=="identityfile"{print $2}')"
+    [ -n "$_cci_ids" ] || return 1
+    _cci_first=""
+    for _cci_id in $_cci_ids; do
+        [ -n "$_cci_first" ] || _cci_first="$_cci_id"
+        # Our intended key is offered → ssh will try it → no shadowing.
+        [ "$(ssh_config_expand_tilde "$_cci_id")" = "$_cci_want" ] && return 1
+    done
+    printf '%s\n' "$_cci_first"
+    return 0
+}
+
 # Ensure ~/.ssh/config includes the drop-in exactly once.
 ssh_config_ensure_include() {
     main="$(ssh_config_main_path)"

--- a/claude/skills/devx-ssh-delegate/lib/ssh_delegate.sh
+++ b/claude/skills/devx-ssh-delegate/lib/ssh_delegate.sh
@@ -36,7 +36,8 @@ devx:ssh-delegate — manifest-based SSH key delegation + audit log
 
 Usage:
   ssh_delegate.sh sync                       Reconcile manifest with reality
-  ssh_delegate.sh add <user>@<host> [alias]  Add + install + verify one entry
+  ssh_delegate.sh add <user>@<host> [alias] [--key-only]
+                                             Add + install + verify one entry
   ssh_delegate.sh list [--json]              Show entries + last-verified table
   ssh_delegate.sh test [<alias>|--all]       BatchMode reachability check
   ssh_delegate.sh revoke <alias>             Remove remote key + mark revoked
@@ -46,6 +47,8 @@ Usage:
 Manifest: ${DEVX_SSH_MANIFEST:-~/.ssh/delegations.yml}  (mode 0600)
 Audit log: ${DEVX_SSH_AUDIT_LOG:-~/.local/state/devx/ssh-delegations.log}
 Add --dry-run to `add` to print actions without touching the remote.
+Add --key-only to `add` to install the key without regenerating ssh config
+(for hosts that already have a working hand-written alias).
 EOF
 }
 
@@ -55,9 +58,11 @@ cmd_add() {
     target=""
     alias_=""
     dry=""
+    key_only=""
     for a in "$@"; do
         case "$a" in
         --dry-run) dry="--dry-run" ;;
+        --key-only) key_only="--key-only" ;;
         *@*) target="$a" ;;
         *) [ -z "$alias_" ] && alias_="$a" ;;
         esac
@@ -78,17 +83,57 @@ cmd_add() {
         alias_="${user}-$(printf '%s' "$host" | tr '.:' '--')"
     fi
 
+    # Identity `add` would install absent any override (manifest default).
+    default_idf="$(manifest_default identity_file 2>/dev/null)"
+    # shellcheck disable=SC2088  # literal ~; expanded by ssh_config_expand_tilde
+    [ -n "$default_idf" ] || default_idf='~/.ssh/id_ed25519'
+    want_idf="$(ssh_config_expand_tilde "$default_idf")"
+
+    # Defect A (#1132): a hand-written `Host` block may pin a different
+    # IdentityFile that shadows our drop-in, so the key we install is never the
+    # key ssh offers — a silent mismatch. Detect it via `ssh -G` and adopt the
+    # resolved key so install target == connect key. `detected` stays in ~-form.
+    detected="$(ssh_config_conflicting_identity "$alias_" "$want_idf" 2>/dev/null || true)"
+    eff_idf="$want_idf"
+    [ -n "$detected" ] && eff_idf="$(ssh_config_expand_tilde "$detected")"
+
+    port="$(manifest_eff "$alias_" port port)"
+    [ -n "$port" ] || port=22
+    copyid="${DEVX_SSH_COPY_ID_BIN:-ssh-copy-id}"
+
     if [ "$dry" = "--dry-run" ]; then
         # Dry-run mutates nothing — no manifest, no remote, no config.
         ux_header "add (dry-run): $alias_ -> ${user}@${host}"
-        ux_info "manifest upsert: alias=$alias_ user=$user host=$host"
-        ux_info "would run: $(ssh_install_copy_id_dry "$alias_" "$user" "$host")"
-        ux_info "would regenerate $(ssh_config_dropin_path) and verify '$alias_'"
+        [ -n "$detected" ] &&
+            ux_warning "existing ssh config resolves IdentityFile '$detected' for '$alias_' — add would adopt it (drop-in default '$default_idf' would be shadowed)"
+        ux_info "manifest upsert: alias=$alias_ user=$user host=$host identity_file=$eff_idf"
+        ux_info "would run: $copyid -i ${eff_idf}.pub -p $port ${user}@${host}"
+        if [ -n "$key_only" ]; then
+            ux_info "--key-only: would NOT regenerate $(ssh_config_dropin_path)"
+        else
+            ux_info "would regenerate $(ssh_config_dropin_path) and verify '$alias_'"
+        fi
         return 0
+    fi
+
+    # Defect C (#1132): fail fast — before mutating anything — when ssh-copy-id
+    # has no way to read the remote password here. A misleading `Permission
+    # denied` in a non-interactive shell is worse than a clear up-front error.
+    if ! ssh_install_can_prompt; then
+        ux_error "add needs an interactive terminal for the ssh-copy-id password prompt"
+        ux_info "no TTY detected (Claude '!' / CI session). Run this in a normal terminal:"
+        ux_info "  $copyid -i ${eff_idf}.pub -p $port ${user}@${host}"
+        ux_info "then re-run 'add' to record it — or set SSH_ASKPASS + SSH_ASKPASS_REQUIRE=force to supply the password non-interactively."
+        return 3
     fi
 
     manifest_ensure
     manifest_upsert "$alias_" "$user" "$host" "" ""
+    if [ -n "$detected" ]; then
+        manifest_set_field "$alias_" identity_file "$detected"
+        audit_log_event identity-adopt "$alias_" "$detected"
+        ux_warning "adopted existing IdentityFile '$detected' for '$alias_' (manifest default '$default_idf' would have been shadowed)"
+    fi
     audit_log_event add "$alias_" "${user}@${host}"
     ux_header "add: $alias_ -> ${user}@${host}"
     if ! ssh_install_copy_id "$alias_"; then
@@ -96,8 +141,14 @@ cmd_add() {
         return 1
     fi
     audit_log_event install-ok "$alias_" ""
-    ssh_config_regen
-    ssh_config_ensure_include
+    if [ -n "$key_only" ]; then
+        # Defect B (#1132): the host already has a working hand-written alias —
+        # install the key but leave the user's ssh config untouched (no regen).
+        ux_info "--key-only: leaving ssh config untouched (no drop-in regen)"
+    else
+        ssh_config_regen
+        ssh_config_ensure_include
+    fi
     if ssh_verify_alias "$alias_"; then
         audit_log_event verify-ok "$alias_" ""
         ux_success "ssh $alias_ now works passwordless"
@@ -105,20 +156,6 @@ cmd_add() {
         audit_log_event verify-fail "$alias_" ""
         ux_warning "key installed but BatchMode verify failed for '$alias_'"
     fi
-}
-
-# Helper so dry-run can show the command without an installed pubkey check.
-ssh_install_copy_id_dry() {
-    al="$1"
-    user="$2"
-    host="$3"
-    port="$(manifest_eff "$al" port port)"
-    [ -n "$port" ] || port=22
-    idf="$(manifest_eff "$al" identity_file identity_file)"
-    # shellcheck disable=SC2088  # literal ~; expanded by ssh_config_expand_tilde
-    [ -n "$idf" ] || idf='~/.ssh/id_ed25519'
-    printf '%s -i %s.pub -p %s %s@%s\n' "${DEVX_SSH_COPY_ID_BIN:-ssh-copy-id}" \
-        "$(ssh_config_expand_tilde "$idf")" "$port" "$user" "$host"
 }
 
 cmd_list() {

--- a/claude/skills/devx-ssh-delegate/lib/ssh_delegate.sh
+++ b/claude/skills/devx-ssh-delegate/lib/ssh_delegate.sh
@@ -107,7 +107,7 @@ cmd_add() {
         [ -n "$detected" ] &&
             ux_warning "existing ssh config resolves IdentityFile '$detected' for '$alias_' — add would adopt it (drop-in default '$default_idf' would be shadowed)"
         ux_info "manifest upsert: alias=$alias_ user=$user host=$host identity_file=$eff_idf"
-        ux_info "would run: $copyid -i ${eff_idf}.pub -p $port ${user}@${host}"
+        ux_info "would run: $copyid -i \"${eff_idf}.pub\" -p $port ${user}@${host}"
         if [ -n "$key_only" ]; then
             ux_info "--key-only: would NOT regenerate $(ssh_config_dropin_path)"
         else
@@ -122,7 +122,7 @@ cmd_add() {
     if ! ssh_install_can_prompt; then
         ux_error "add needs an interactive terminal for the ssh-copy-id password prompt"
         ux_info "no TTY detected (Claude '!' / CI session). Run this in a normal terminal:"
-        ux_info "  $copyid -i ${eff_idf}.pub -p $port ${user}@${host}"
+        ux_info "  $copyid -i \"${eff_idf}.pub\" -p $port ${user}@${host}"
         ux_info "then re-run 'add' to record it — or set SSH_ASKPASS + SSH_ASKPASS_REQUIRE=force to supply the password non-interactively."
         return 3
     fi

--- a/claude/skills/devx-ssh-delegate/references/help.md
+++ b/claude/skills/devx-ssh-delegate/references/help.md
@@ -25,12 +25,25 @@ lib/ssh_delegate.sh add bwyoon@12.81.221.129 gpu1-bwyoon
 ssh gpu1-bwyoon            # passwordless after one password prompt
 ```
 
+`add` notes:
+
+- **Interactive only.** `ssh-copy-id` prompts for the remote password once, so
+  `add` needs a real TTY. In a non-interactive shell (a Claude `!` session, CI)
+  it fails fast with the exact command to run in a terminal instead of dying as
+  a misleading `Permission denied`. To supply the password without a TTY, set
+  `SSH_ASKPASS` + `SSH_ASKPASS_REQUIRE=force`.
+- **Adopts an existing IdentityFile.** If a hand-written `Host <alias>` block
+  already pins a different key, `add` detects it via `ssh -G` and installs
+  *that* key (with a warning) so the installed key matches the one ssh offers.
+- **`--key-only`** installs the key but skips ssh-config regeneration — use it
+  when the host already has a working hand-written alias you don't want rewritten.
+
 ## Sub-commands
 
 | Command | What it does |
 |---|---|
 | `sync` | Regenerates the ssh config drop-in, pins first-seen fingerprints, verifies every active alias. Aborts on a fingerprint MISMATCH. |
-| `add <user>@<host> [alias]` | Upserts a manifest entry, runs `ssh-copy-id`, pins the fingerprint, regenerates config, verifies. `--dry-run` prints actions only. |
+| `add <user>@<host> [alias]` | Upserts a manifest entry, runs `ssh-copy-id`, pins the fingerprint, regenerates config, verifies. `--dry-run` prints actions only; `--key-only` installs the key but leaves ssh config untouched (host already has a working hand-written alias). |
 | `list [--json]` | Prints the entry table (alias / user / host / last-verified / state) or JSON. |
 | `test [<alias>\|--all]` | `ssh -o BatchMode=yes <alias> true` — no password fallback. |
 | `revoke <alias>` | Removes the key line from the remote `authorized_keys`, sets `revoked: true`, regenerates config. |

--- a/tests/bats/skills/ssh_delegate/test_add_defects_1132.bats
+++ b/tests/bats/skills/ssh_delegate/test_add_defects_1132.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# tests/bats/skills/ssh_delegate/test_add_defects_1132.bats
+# Issue #1132 — three `add` defects:
+#   A (P0) a hand-written `Host` block's IdentityFile silently shadows the key
+#          `add` installs; `add` must detect it via `ssh -G` and adopt it.
+#   C (P1) `ssh-copy-id` in a non-interactive shell dies as a misleading
+#          Permission denied; `add` must fail fast with guidance instead.
+#   B (P2) `--key-only` installs the key without regenerating ssh config, for a
+#          host that already has a working hand-written alias.
+
+load '../../test_helper'
+
+SKILL_DIR="${DOTFILES_ROOT}/claude/skills/devx-ssh-delegate"
+SKILL_LIB="${SKILL_DIR}/lib"
+DELEGATE="${SKILL_LIB}/ssh_delegate.sh"
+
+setup() {
+    setup_isolated_home
+    export TEST_TEMP_HOME
+    # shellcheck source=/dev/null
+    . "${SKILL_LIB}/ux.sh"
+    # shellcheck source=/dev/null
+    . "${SKILL_LIB}/manifest.sh"
+    # shellcheck source=/dev/null
+    . "${SKILL_LIB}/ssh_config.sh"
+    # shellcheck source=/dev/null
+    . "${SKILL_LIB}/install.sh"
+
+    export DEVX_SSH_MANIFEST="${TEST_TEMP_HOME}/delegations.yml"
+    export DEVX_SSH_CONFIG="${TEST_TEMP_HOME}/ssh_config"
+    export DEVX_SSH_CONFIG_DROPIN="${TEST_TEMP_HOME}/ssh_config.d/devx-delegations"
+    export DEVX_SSH_AUDIT_LOG="${TEST_TEMP_HOME}/audit.log"
+    # Fingerprint capture must never hit the network in tests.
+    export DEVX_SSH_KEYSCAN_BIN=true
+
+    STUB_BIN="${TEST_TEMP_HOME}/bin"
+    mkdir -p "$STUB_BIN" "${TEST_TEMP_HOME}/.ssh"
+
+    # Mock ssh: `-G` prints identityfile lines from $FAKE_SSH_G (space-separated
+    # ~-paths); any other call (a BatchMode verify) exits $FAKE_SSH_RC.
+    cat >"${STUB_BIN}/ssh" <<'SSH'
+#!/usr/bin/env bash
+for a in "$@"; do
+    if [ "$a" = "-G" ]; then
+        for id in $FAKE_SSH_G; do printf 'identityfile %s\n' "$id"; done
+        exit 0
+    fi
+done
+exit "${FAKE_SSH_RC:-0}"
+SSH
+    chmod +x "${STUB_BIN}/ssh"
+    export DEVX_SSH_BIN="${STUB_BIN}/ssh"
+
+    # Mock ssh-copy-id: succeed without touching a remote.
+    cat >"${STUB_BIN}/ssh-copy-id" <<'COPY'
+#!/usr/bin/env bash
+exit 0
+COPY
+    chmod +x "${STUB_BIN}/ssh-copy-id"
+    export DEVX_SSH_COPY_ID_BIN="${STUB_BIN}/ssh-copy-id"
+}
+
+teardown() { teardown_isolated_home; }
+
+# --- Defect A: ssh_config_conflicting_identity ------------------------------
+
+@test "A: no conflict when our intended key is among the resolved identities" {
+    export FAKE_SSH_G='~/.ssh/id_rsa ~/.ssh/id_ed25519 ~/.ssh/id_ecdsa'
+    run ssh_config_conflicting_identity somealias "${TEST_TEMP_HOME}/.ssh/id_ed25519"
+    assert_failure # return 1 => no conflict
+    assert_output ''
+}
+
+@test "A: conflict echoes the shadowing identity when ours is absent" {
+    export FAKE_SSH_G='~/.ssh/id_rsa_ssai_bwyoon'
+    run ssh_config_conflicting_identity ssai-dev "${TEST_TEMP_HOME}/.ssh/id_ed25519"
+    assert_success # return 0 => conflict
+    assert_output '~/.ssh/id_rsa_ssai_bwyoon'
+}
+
+@test "A: add adopts a pre-existing IdentityFile (installed key == connect key)" {
+    export DEVX_SSH_ASSUME_TTY=1
+    export FAKE_SSH_G='~/.ssh/id_rsa_ssai_bwyoon'
+    : >"${TEST_TEMP_HOME}/.ssh/id_rsa_ssai_bwyoon.pub"
+    run "$DELEGATE" add bwyoon@ssai-dev ssai-dev
+    assert_success
+    assert_output --partial 'adopted existing IdentityFile'
+    run manifest_get ssai-dev identity_file
+    assert_output '~/.ssh/id_rsa_ssai_bwyoon'
+}
+
+@test "A: fresh alias keeps the manifest default (no adoption)" {
+    export DEVX_SSH_ASSUME_TTY=1
+    export FAKE_SSH_G='~/.ssh/id_rsa ~/.ssh/id_ed25519 ~/.ssh/id_ecdsa'
+    : >"${TEST_TEMP_HOME}/.ssh/id_ed25519.pub"
+    run "$DELEGATE" add deity@10.0.0.9 box
+    assert_success
+    refute_output --partial 'adopted existing IdentityFile'
+    run manifest_get box identity_file
+    assert_output '' # empty => falls back to the default id_ed25519
+}
+
+@test "A: dry-run surfaces the adoption warning + adopted key, mutates nothing" {
+    export FAKE_SSH_G='~/.ssh/id_rsa_ssai_bwyoon'
+    run "$DELEGATE" add bwyoon@ssai-dev ssai-dev --dry-run
+    assert_success
+    assert_output --partial 'would adopt it'
+    assert_output --partial 'id_rsa_ssai_bwyoon.pub'
+    assert [ ! -f "$DEVX_SSH_MANIFEST" ]
+}
+
+# --- Defect C: ssh_install_can_prompt + add fail-fast -----------------------
+
+@test "C: can_prompt is true when DEVX_SSH_ASSUME_TTY=1" {
+    export DEVX_SSH_ASSUME_TTY=1
+    run ssh_install_can_prompt
+    assert_success
+}
+
+@test "C: can_prompt is false when non-interactive with no askpass" {
+    export DEVX_SSH_ASSUME_TTY=0
+    unset SSH_ASKPASS SSH_ASKPASS_REQUIRE
+    run ssh_install_can_prompt
+    assert_failure
+}
+
+@test "C: can_prompt is true when a forced SSH_ASKPASS is configured" {
+    export DEVX_SSH_ASSUME_TTY=0
+    askpass="${TEST_TEMP_HOME}/askpass"
+    printf '#!/bin/sh\necho pw\n' >"$askpass"
+    chmod +x "$askpass"
+    export SSH_ASKPASS="$askpass"
+    export SSH_ASKPASS_REQUIRE=force
+    run ssh_install_can_prompt
+    assert_success
+}
+
+@test "C: add fails fast (exit 3) and mutates nothing without a TTY" {
+    export DEVX_SSH_ASSUME_TTY=0
+    unset SSH_ASKPASS SSH_ASKPASS_REQUIRE
+    export FAKE_SSH_G='~/.ssh/id_ed25519'
+    : >"${TEST_TEMP_HOME}/.ssh/id_ed25519.pub"
+    run "$DELEGATE" add bwyoon@12.81.221.129 gpu1
+    assert_failure 3
+    assert_output --partial 'interactive terminal'
+    assert [ ! -f "$DEVX_SSH_MANIFEST" ]
+    assert [ ! -f "$DEVX_SSH_CONFIG_DROPIN" ]
+}
+
+# --- Defect B: --key-only ---------------------------------------------------
+
+@test "B: --key-only installs the key but writes no ssh config drop-in" {
+    export DEVX_SSH_ASSUME_TTY=1
+    export FAKE_SSH_G='~/.ssh/id_ed25519'
+    : >"${TEST_TEMP_HOME}/.ssh/id_ed25519.pub"
+    run "$DELEGATE" add bwyoon@ssai-dev ssai-dev --key-only
+    assert_success
+    assert_output --partial '--key-only'
+    assert [ ! -f "$DEVX_SSH_CONFIG_DROPIN" ]
+    run manifest_has ssai-dev
+    assert_success
+}
+
+@test "B: plain add (no --key-only) does regenerate the drop-in" {
+    export DEVX_SSH_ASSUME_TTY=1
+    export FAKE_SSH_G='~/.ssh/id_ed25519'
+    : >"${TEST_TEMP_HOME}/.ssh/id_ed25519.pub"
+    run "$DELEGATE" add bwyoon@ssai-dev ssai-dev
+    assert_success
+    assert [ -f "$DEVX_SSH_CONFIG_DROPIN" ]
+}

--- a/tests/bats/skills/ssh_delegate/test_add_defects_1132.bats
+++ b/tests/bats/skills/ssh_delegate/test_add_defects_1132.bats
@@ -78,6 +78,22 @@ teardown() { teardown_isolated_home; }
     assert_output '~/.ssh/id_rsa_ssai_bwyoon'
 }
 
+@test "A: an IdentityFile path with spaces is preserved (PR #1133 review)" {
+    # Bespoke ssh mock: `-G` prints a single identityfile whose path has a
+    # space — FAKE_SSH_G word-splits, so this test uses its own stub.
+    cat >"${STUB_BIN}/ssh" <<'SSH'
+#!/usr/bin/env bash
+for a in "$@"; do
+    [ "$a" = "-G" ] && { printf 'identityfile /Users/John Doe/.ssh/id_rsa\n'; exit 0; }
+done
+exit 0
+SSH
+    chmod +x "${STUB_BIN}/ssh"
+    run ssh_config_conflicting_identity somealias "${TEST_TEMP_HOME}/.ssh/id_ed25519"
+    assert_success
+    assert_output '/Users/John Doe/.ssh/id_rsa'
+}
+
 @test "A: add adopts a pre-existing IdentityFile (installed key == connect key)" {
     export DEVX_SSH_ASSUME_TTY=1
     export FAKE_SSH_G='~/.ssh/id_rsa_ssai_bwyoon'


### PR DESCRIPTION
## Summary
- `devx:ssh-delegate add` 의 세 결함(P0/P1/P2)을 수정한다: 수기 `Host` 블록 IdentityFile 충돌로 인한 조용한 오작동, 비대화형 셸에서의 오해 유발 실패, 목표(원격 등록)-수단(alias 생성) 결합.

## Changes
- **A (P0)** `ssh_config_conflicting_identity` (ssh_config.sh): `ssh -G <alias>` 로 기존 IdentityFile 을 감지 — 우리 기본 키가 offered 목록에 없으면(explicit block 이 defaults 를 suppress) shadow 로 판정하고 해당 키를 **자동 채택 + 명시적 경고**. 설치 키와 실제 접속 키 불일치를 제거.
- **C (P1)** `ssh_install_can_prompt` (install.sh): TTY 없는 셸(Claude `!` / CI)에서 `ssh-copy-id` 가 `ssh_askpass: No such file` → `Permission denied` 로 오해되던 문제. manifest 변경 **전** fail-fast(exit 3) + 일반 터미널 실행 명령 안내. `SSH_ASKPASS`+`SSH_ASKPASS_REQUIRE=force` 설정 시 통과.
- **B (P2)** `add --key-only` (ssh_delegate.sh): 이미 수기 alias 가 있는 호스트용 경량 경로 — 키만 설치하고 ssh config drop-in 재생성을 건너뜀.
- 문서: `SKILL.md` / `references/help.md` / `usage()` 갱신.

## Test plan
- [x] bats 11건 추가 (`test_add_defects_1132.bats`); ssh_delegate 스위트 총 37건 통과
- [x] `shellcheck -s sh` + `shfmt -d -i 4` 클린
- [x] golden rules 통과

## Related
Closes #1132

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
