### PR TITLE
fix(gcp-scan): phantom 커밋 제거 — full-history dup + Analysis 루프 stdin 가드 (#1134)

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -572,18 +572,31 @@ EOF
     local duplicate_map=""
     local duplicate_count=0
 
-    # Cache the base branch's recent subjects ONCE (PR #812 review): running
+    # Cache the base branch's subjects ONCE (PR #812 review): running
     # `git log` per source commit was an O(N) process-fork bottleneck. The
     # per-commit lookup below is then a pure-shell here-doc `while read`
     # (no git/awk fork, no pipe subshell).
+    #
+    # Cache the FULL base history, not a fixed `-n 200` window (issue #1134). A
+    # twin whose subject sat beyond commit 200 (e.g. main's 218th commit) was
+    # never matched, so its counterpart — still "missing" by patch-id — slipped
+    # past Stage-1 as a phantom commit that showed up as "1 commit" yet had an
+    # empty range/list and immediately became an empty cherry-pick. Full history
+    # is one `git log` (~0.02s on this repo), so it closes the window entirely.
     local base_log tab
-    base_log=$(git log "$base" -n 200 --format='%H%x09%s' 2>/dev/null)
+    base_log=$(git log "$base" --format='%H%x09%s' 2>/dev/null)
     tab=$(printf '\t')
 
+    # stdin guard (issue #1134): every git/helper call inside these analysis
+    # `while read … <<EOF` loops redirects `</dev/null`. Without it a git
+    # subprocess that reads stdin (TTY/environment-dependent) would swallow the
+    # loop's remaining here-doc input and terminate the loop after one
+    # iteration — silently dropping later commits from the analysis and
+    # producing the count-vs-list mismatch users saw as a phantom commit.
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
         local subject
-        subject=$(git show -s --format='%s' "$sha")
+        subject=$(git show -s --format='%s' "$sha" </dev/null)
 
         # Find a base commit with the same subject and capture its SHA so the
         # individual cherry-pick loop can report what each dup was already
@@ -663,7 +676,7 @@ EOF
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
         local _dep_out=""
-        if _dep_out=$(_gcp_scan_check_file_deps "$sha" "$base" "$source" "$selected_list"); then
+        if _dep_out=$(_gcp_scan_check_file_deps "$sha" "$base" "$source" "$selected_list" </dev/null); then
             if [ -z "$dep_survivor_list" ]; then
                 dep_survivor_list="$sha"
             else
@@ -713,7 +726,7 @@ EOF
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
         local _cf_out=""
-        if _cf_out=$(_gcp_scan_predict_content_conflict "$sha" "$selected_list"); then
+        if _cf_out=$(_gcp_scan_predict_content_conflict "$sha" "$selected_list" </dev/null); then
             if [ -z "$conflict_survivor_list" ]; then
                 conflict_survivor_list="$sha"
             else
@@ -748,7 +761,7 @@ EOF
     local noop_list="" noop_count=0 real_final_list=""
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
-        if _gcp_scan_preflight_is_noop "$sha"; then
+        if _gcp_scan_preflight_is_noop "$sha" </dev/null; then
             noop_list="${noop_list}${sha}
 "
             noop_count=$((noop_count + 1))

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -577,14 +577,24 @@ EOF
     # per-commit lookup below is then a pure-shell here-doc `while read`
     # (no git/awk fork, no pipe subshell).
     #
-    # Cache the FULL base history, not a fixed `-n 200` window (issue #1134). A
-    # twin whose subject sat beyond commit 200 (e.g. main's 218th commit) was
-    # never matched, so its counterpart — still "missing" by patch-id — slipped
-    # past Stage-1 as a phantom commit that showed up as "1 commit" yet had an
-    # empty range/list and immediately became an empty cherry-pick. Full history
-    # is one `git log` (~0.02s on this repo), so it closes the window entirely.
+    # Cache base subjects over the DIVERGED range `$source..$base`, not a fixed
+    # `-n 200` window (issue #1134). A twin whose subject sat beyond commit 200
+    # (e.g. main's 218th commit) was never matched, so its counterpart — still
+    # "missing" by patch-id — slipped past Stage-1 as a phantom commit that
+    # showed up as "1 commit" yet had an empty range/list and immediately became
+    # an empty cherry-pick.
+    #
+    # `$source..$base` (not the full base history — PR #1135 gemini review) is
+    # both the complete AND the minimal set to match against: a source candidate
+    # can only be a "already applied under a different SHA" dup of a base commit
+    # that diverged after the merge-base; base commits before the merge-base are
+    # in source's own history too, so matching them would wrongly flag a
+    # genuinely new source commit that merely reuses an old subject. On this
+    # scan (`main <- upstream/main`) the reported twin is a base-local
+    # cherry-pick absent from upstream, so it stays inside the range and is
+    # still caught — while large-repo performance/memory stays bounded.
     local base_log tab
-    base_log=$(git log "$base" --format='%H%x09%s' 2>/dev/null)
+    base_log=$(git log "$source..$base" --format='%H%x09%s' 2>/dev/null)
     tab=$(printf '\t')
 
     # stdin guard (issue #1134): every git/helper call inside these analysis

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1292,3 +1292,77 @@ FIXTURE
     # Wildcard and too-short token must not appear as registered SHAs.
     refute_output --partial " *"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1134 — phantom commit: two independent defects.
+#
+# Bug A: the Stage-1 subject-dup cache used a fixed `git log -n 200` window, so
+#   a twin whose subject sat beyond commit 200 was never matched — its
+#   still-missing-by-patch-id counterpart flowed past Stage-1 as a phantom.
+#   The fix caches the FULL base history.
+#
+# Bug B: the Analysis-phase `while read … <<EOF` loops call git-forking helpers
+#   without a `</dev/null` guard, so a helper whose git subprocess reads stdin
+#   swallows the loop's remaining here-doc input and terminates the loop after
+#   one iteration — dropping later commits from the analysis. The fix redirects
+#   every in-loop subprocess from /dev/null.
+# ---------------------------------------------------------------------------
+
+@test "scan #1134 (Bug A): twin beyond the old 200-commit window is still detected as duplicate" {
+    # main history places the same-subject twin ~205 commits below HEAD (past
+    # the old -n 200 window). Its source counterpart has a DIFFERENT patch (so
+    # `git cherry` still lists it as missing) but the SAME subject, so only the
+    # full-history subject-dup scan can catch it. With the old window it slipped
+    # through as a phantom "1 commit"; with the fix it is a recognised dup.
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo dupsrc > f2.txt && git add f2.txt && git commit -qm "shared old subject"
+        git checkout -q main
+        echo dupbase > onbase.txt && git add onbase.txt && git commit -qm "shared old subject"
+        # Push the twin beyond the retired 200-commit window.
+        i=0; while [ $i -lt 205 ]; do git commit -q --allow-empty -m "pad $i"; i=$((i + 1)); done
+        printf "y\n" | _gcp_scan main source --author=all
+        git cat-file -e HEAD:f2.txt 2>/dev/null && echo HAS_F2 || echo NO_F2
+    '
+    assert_success
+    # The twin is recognised as a duplicate — not offered as a phantom commit.
+    assert_output --partial "Duplicates (already applied): 1"
+    assert_output --partial "Nothing to do"
+    # Its payload must never reach main.
+    assert_output --partial "NO_F2"
+}
+
+@test "scan #1134 (Bug B): Analysis loop survives a helper whose subprocess drains stdin" {
+    # Simulate the TTY/environment-dependent failure: the Stage-2 helper reads
+    # its stdin (as a git plumbing call can). Without the `</dev/null` guard the
+    # first call swallows the loop's here-doc and the loop exits after one
+    # iteration, so only 1 of 2 survivors is counted. With the guard both are
+    # processed -> both no-op -> count 0 -> "Nothing to do".
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo one > f1.txt && git add f1.txt && git commit -qm "feat one"
+        echo two > f2.txt && git add f2.txt && git commit -qm "feat two"
+        git checkout -q main
+        # Override the Stage-2 helper: drain stdin like a stdin-reading git
+        # subprocess, then report no-op so BOTH survivors must be counted.
+        _gcp_scan_preflight_is_noop() { cat >/dev/null 2>&1; return 0; }
+        _gcp_scan main source --author=all
+    '
+    assert_success
+    assert_output --partial "Already in HEAD (no-op): 2"
+    assert_output --partial "Nothing to do"
+}


### PR DESCRIPTION
## 요약

`gcp scan` 이 실제 적용할 커밋이 하나도 없는데도 "cherry-pick 1개" 로 표시하고, 확인(`y`) 시 곧바로 빈 커밋이 되어 skip 되는 **phantom 커밋** 문제(#1134)를 수정한다. 두 개의 독립 결함이 겹쳐 발생했다.

## 근본 원인 및 수정

### Bug A — Stage-1 subject-dup 캐시가 `git log -n 200` 고정 window
subject 쌍둥이가 base 히스토리 200번째 이후(예: `main` 의 218번째)에 있으면 매칭되지 못했다. `git cherry` 는 patch-id 로 판정하므로 이 짝은 여전히 missing(`+`) 으로 떠서 Stage-1 을 통과, phantom 으로 남았다.

→ base **전체 히스토리**를 캐시하도록 수정 (`git log "$base" --format=...`, `-n 200` 제거). 리포 규모상 단일 `git log` (~0.02s) 로 저렴하며 window 를 완전히 제거한다.

### Bug B — Analysis 루프가 stdin 미보호로 조기 종료
Stage-1 / 1.5 / 1.6 / 2 의 `while read … <<EOF` 루프가 git 서브프로세스를 포크하는 헬퍼를 `</dev/null` 가드 없이 호출했다. TTY/환경 의존적으로 git plumbing 이 stdin 을 읽으면 루프의 남은 here-doc 입력을 삼켜 **첫 iteration 후 조기 종료** → 뒤 커밋이 분석에서 누락되고 `count` 와 `final_selected_list` 가 어긋난다(사용자가 본 `count=1` + 빈 목록 + `Suggested Range: ^..` 증상).

→ 루프 내부의 모든 git/헬퍼 호출에 `</dev/null` 추가: Stage-1 `git show`, Stage-1.5 `_gcp_scan_check_file_deps`, Stage-1.6 `_gcp_scan_predict_content_conflict`, Stage-2 `_gcp_scan_preflight_is_noop`.

## 테스트

`tests/bats/functions/gcp.bats` 에 회귀 테스트 2건 추가 — **둘 다 수정 전 코드에서 실패함을 확인**:

- **Bug A**: 쌍둥이를 200 window 밖(~205 커밋 아래)에 배치 → dup 로 인식되어 phantom 으로 제시되지 않는지 검증.
- **Bug B**: Stage-2 헬퍼가 stdin 을 소비하도록 오버라이드 → 두 생존자 모두 처리되어 count 0(“Nothing to do”)이 되는지 검증. 수정 전엔 `Already in HEAD (no-op): 1` + `Suggested Range: ^..` phantom 증상을 그대로 재현.

검증 결과: `gcp.bats` **75/75 통과**, `mise run lint-sh` clean.

## 변경 파일
- `shell-common/functions/gcp_scan.sh` — Bug A + Bug B 수정
- `tests/bats/functions/gcp.bats` — 회귀 테스트 2건

Closes #1134
