### PR TITLE
fix(gcp-scan): patch-id 로 Stage-1 중복 확정 — 동일 subject 다른 내용 커밋 유실 방지

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -626,13 +626,16 @@ EOF
             [ "$_b_subj" = "$subject" ] || continue
             # Subject collides — compute the source patch-id once (lazily, so the
             # common no-collision path forks nothing) and require content parity.
+            # `--no-color --no-ext-diff` shield the diff from user git config
+            # (color.ui=always, diff.external) that would otherwise corrupt the
+            # patch-id; stderr is silenced so a warning can't leak into the pipe.
             if [ "$_src_pid_done" -eq 0 ]; then
-                src_pid=$(git show "$sha" </dev/null | git patch-id --stable 2>/dev/null)
+                src_pid=$(git show --no-color --no-ext-diff "$sha" 2>/dev/null </dev/null | git patch-id --stable 2>/dev/null)
                 src_pid=${src_pid%% *}
                 _src_pid_done=1
             fi
             local _base_pid=""
-            _base_pid=$(git show "$_b_sha" </dev/null | git patch-id --stable 2>/dev/null)
+            _base_pid=$(git show --no-color --no-ext-diff "$_b_sha" 2>/dev/null </dev/null | git patch-id --stable 2>/dev/null)
             _base_pid=${_base_pid%% *}
             # An empty src_pid (e.g. a merge commit) never equals a non-empty
             # base patch-id, so such a commit is kept, never silently skipped.

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -608,12 +608,35 @@ EOF
         local subject
         subject=$(git show -s --format='%s' "$sha" </dev/null)
 
-        # Find a base commit with the same subject and capture its SHA so the
-        # individual cherry-pick loop can report what each dup was already
-        # applied as (issue #811 F-1/F-3). Exact subject match via tab split.
-        local match_base_sha="" _b_sha _b_subj
+        # Find a base commit that is a TRUE duplicate of this source candidate
+        # and capture its SHA so the individual cherry-pick loop can report what
+        # it was already applied as (issue #811 F-1/F-3).
+        #
+        # Subject equality is only a first-pass CANDIDATE filter — it must never
+        # confirm a skip on its own (issue #1136). Repos that reuse a subject
+        # ("chore: sync manifest", "bump", auto-generated commits) otherwise map
+        # several DISTINCT upstream commits onto one base commit and silently
+        # drop the ones carrying real, different content — a data-loss bug. So a
+        # subject match is confirmed only when the patches are actually identical
+        # by `git patch-id --stable`, the same equivalence test cherry-pick uses.
+        # This also rules out the 1:many mis-mapping: two different source
+        # commits can never share a patch-id, so at most one binds to a base SHA.
+        local match_base_sha="" _b_sha _b_subj src_pid="" _src_pid_done=0
         while IFS="$tab" read -r _b_sha _b_subj; do
-            if [ "$_b_subj" = "$subject" ]; then
+            [ "$_b_subj" = "$subject" ] || continue
+            # Subject collides — compute the source patch-id once (lazily, so the
+            # common no-collision path forks nothing) and require content parity.
+            if [ "$_src_pid_done" -eq 0 ]; then
+                src_pid=$(git show "$sha" </dev/null | git patch-id --stable 2>/dev/null)
+                src_pid=${src_pid%% *}
+                _src_pid_done=1
+            fi
+            local _base_pid=""
+            _base_pid=$(git show "$_b_sha" </dev/null | git patch-id --stable 2>/dev/null)
+            _base_pid=${_base_pid%% *}
+            # An empty src_pid (e.g. a merge commit) never equals a non-empty
+            # base patch-id, so such a commit is kept, never silently skipped.
+            if [ -n "$src_pid" ] && [ "$_base_pid" = "$src_pid" ]; then
                 match_base_sha="$_b_sha"
                 break
             fi

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -356,15 +356,17 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Issue #811 — individual (non-contiguous) cherry-pick auto-skips Stage-1
-# duplicates with a log line, instead of attempting them and conflicting.
+# Issue #811 / #1136 — Stage-1 subject matching is a CANDIDATE filter only; a
+# skip is confirmed by patch-id (content), never by subject alone.
 #
 # Fixture commit tree (author = all, so author filter is a no-op):
 #   main:   C0 "init"  ->  M1 "shared dup subject"
 #   source: C0 "init"  ->  S1 "feat one" -> S2 "shared dup subject" -> S3 "feat three"
-# S2 shares M1's subject (dup) but a different patch, so `git cherry` still
-# lists it as missing. final_selected_list = {S1,S3} (count 2) but the range
-# S1^..S3 spans 3 commits -> non-contiguous -> individual cherry-pick path.
+# S2 shares M1's subject but carries a DIFFERENT patch (dupsrc/f2.txt vs
+# dupbase/onbase.txt), so `git cherry` lists it as missing. Under #811 this was
+# wrongly skipped as a "duplicate subject"; issue #1136 proved that silently
+# dropped S2's content (data loss). With the patch-id gate S2 is a genuinely new
+# commit — final_selected_list = {S1,S2,S3} and all three are applied.
 # ---------------------------------------------------------------------------
 
 _gcp811_make_repo() {
@@ -385,37 +387,67 @@ _gcp811_make_repo() {
 FIXTURE
 }
 
-@test "scan #811: non-contiguous dup is skipped (not cherry-picked) with base SHA logged" {
+@test "scan #1136: same-subject different-content commit is NOT skipped as a dup" {
     run_in_bash "
         $(_gcp811_make_repo)
-        base_dup_sha=\$(git rev-parse --short main)
         printf 'y\n' | _gcp_scan main source --author=all
     "
     assert_success
-    # F-3: skip log naming the matching base SHA.
-    assert_output --partial "Skipping"
-    assert_output --partial "already applied as"
-    assert_output --partial "(duplicate subject)"
-    # F-4: summary reports 1 dup skipped, 0 conflicts.
-    assert_output --partial "skipped (dup), 0 conflicts"
-    # The dup commit's own file must NOT have been applied to main.
+    # #1136: subject alone must not confirm a skip — S2 carries a distinct patch
+    # so it is a real commit, never reported as a "duplicate subject".
+    refute_output --partial "(duplicate subject)"
+    # All three source commits are applied; nothing skipped as a dup.
+    assert_output --partial "3 applied, 0 skipped (dup), 0 conflicts"
     refute_output --partial "CONFLICT"
 }
 
-@test "scan #811: dup commit's payload is absent, non-dup commits are applied" {
+@test "scan #1136: same-subject different-content commit's payload IS applied" {
     run_in_bash "
         $(_gcp811_make_repo)
         printf 'y\n' | _gcp_scan main source --author=all >/dev/null 2>&1
-        # Non-dup commits applied:
         git cat-file -e HEAD:f1.txt && echo HAS_F1
         git cat-file -e HEAD:f3.txt && echo HAS_F3
-        # Dup commit (f2.txt) skipped -> absent on main:
+        # The same-subject commit (f2.txt) must NOT be dropped -> present on main.
         git cat-file -e HEAD:f2.txt 2>/dev/null && echo HAS_F2 || echo NO_F2
     "
     assert_success
     assert_output --partial "HAS_F1"
     assert_output --partial "HAS_F3"
-    assert_output --partial "NO_F2"
+    assert_output --partial "HAS_F2"
+}
+
+# ---------------------------------------------------------------------------
+# Issue #1136 — 1:many subject collision. Two DISTINCT source commits share the
+# same subject as a single base commit ("sync manifest"). The old subject-only
+# match bound both to that one base SHA and silently skipped both, dropping
+# their (different) content. With the patch-id gate neither is a dup and both
+# are applied.
+#   main:   C0 "init" -> M1 "sync manifest" (onbase.txt)
+#   source: C0 "init" -> S1 "sync manifest" (fa.txt) -> S2 "sync manifest" (fb.txt)
+# ---------------------------------------------------------------------------
+@test "scan #1136: two distinct commits sharing one base subject are both applied" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        echo init > a.txt && git add a.txt && git commit -qm "init"
+        git checkout -q -b source
+        echo a > fa.txt && git add fa.txt && git commit -qm "sync manifest"
+        echo b > fb.txt && git add fb.txt && git commit -qm "sync manifest"
+        git checkout -q main
+        echo x > onbase.txt && git add onbase.txt && git commit -qm "sync manifest"
+        printf "y\n" | _gcp_scan main source --author=all
+        git cat-file -e HEAD:fa.txt && echo HAS_FA
+        git cat-file -e HEAD:fb.txt && echo HAS_FB
+    '
+    assert_success
+    refute_output --partial "(duplicate subject)"
+    assert_output --partial "2 applied, 0 skipped (dup), 0 conflicts"
+    assert_output --partial "HAS_FA"
+    assert_output --partial "HAS_FB"
 }
 
 @test "scan #811/#913: no-dup path applies every commit (individual iteration)" {
@@ -611,10 +643,13 @@ FIXTURE
         echo MIDDLE > shared.txt && git add shared.txt && git commit -qm "wip shared"
         echo TARGET > shared.txt && git add shared.txt && git commit -qm "finalize shared"
         printf "y\n" | _gcp_scan main source --author=all
+        git cat-file -e HEAD:f2.txt 2>/dev/null && echo HAS_F2 || echo NO_F2
     '
     assert_success
-    # Subject-dup still handled by Stage-1.
-    assert_output --partial "already applied as"
+    # The same-subject/different-content commit (f2.txt) is a real commit, so it
+    # is applied — NOT skipped as a "duplicate subject" (issue #1136).
+    refute_output --partial "(duplicate subject)"
+    assert_output --partial "HAS_F2"
     # Content-dup caught by Stage-2 pre-flight; shown in Analysis Result, not execution loop.
     assert_output --partial "Already in HEAD (no-op):"
     refute_output --partial "CONFLICT"
@@ -1297,9 +1332,11 @@ FIXTURE
 # Issue #1134 — phantom commit: two independent defects.
 #
 # Bug A: the Stage-1 subject-dup cache used a fixed `git log -n 200` window, so
-#   a twin whose subject sat beyond commit 200 was never matched — its
-#   still-missing-by-patch-id counterpart flowed past Stage-1 as a phantom.
-#   The fix caches the FULL base history.
+#   a twin whose subject sat beyond commit 200 was never matched. Since issue
+#   #1136 the subject match is a candidate filter gated by patch-id, so a twin
+#   with the SAME subject but DIFFERENT content is (correctly) a real commit and
+#   is applied — never a phantom and never silently dropped, regardless of how
+#   deep its same-subject counterpart sits in base history.
 #
 # Bug B: the Analysis-phase `while read … <<EOF` loops call git-forking helpers
 #   without a `</dev/null` guard, so a helper whose git subprocess reads stdin
@@ -1308,12 +1345,12 @@ FIXTURE
 #   every in-loop subprocess from /dev/null.
 # ---------------------------------------------------------------------------
 
-@test "scan #1134 (Bug A): twin beyond the old 200-commit window is still detected as duplicate" {
-    # main history places the same-subject twin ~205 commits below HEAD (past
-    # the old -n 200 window). Its source counterpart has a DIFFERENT patch (so
-    # `git cherry` still lists it as missing) but the SAME subject, so only the
-    # full-history subject-dup scan can catch it. With the old window it slipped
-    # through as a phantom "1 commit"; with the fix it is a recognised dup.
+@test "scan #1134/#1136 (Bug A): same-subject different-content twin deep in base history is applied, not dropped" {
+    # main history places a same-subject twin ~205 commits below HEAD (past the
+    # retired -n 200 window). Its source counterpart has a DIFFERENT patch (so
+    # `git cherry` still lists it as missing) but the SAME subject. Subject alone
+    # must not confirm a skip (issue #1136), so the commit is applied as real
+    # content — no phantom, no silent data loss — no matter how deep the twin is.
     run_in_bash '
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
         trap "rm -rf $repo" EXIT
@@ -1332,11 +1369,11 @@ FIXTURE
         git cat-file -e HEAD:f2.txt 2>/dev/null && echo HAS_F2 || echo NO_F2
     '
     assert_success
-    # The twin is recognised as a duplicate — not offered as a phantom commit.
-    assert_output --partial "Duplicates (already applied): 1"
-    assert_output --partial "Nothing to do"
-    # Its payload must never reach main.
-    assert_output --partial "NO_F2"
+    # The twin carries distinct content -> applied, never skipped as a dup.
+    refute_output --partial "(duplicate subject)"
+    assert_output --partial "1 applied, 0 skipped (dup), 0 conflicts"
+    # Its payload must reach main — dropping it would be the #1136 data loss.
+    assert_output --partial "HAS_F2"
 }
 
 @test "scan #1134 (Bug B): Analysis loop survives a helper whose subprocess drains stdin" {


### PR DESCRIPTION
## Summary
- `gcp scan` 의 Stage-1 중복 탐지가 **subject 문자열만** 비교해, 재사용되는 subject(`sync manifest`, `bump` 등)를 가진 서로 다른 upstream 커밋들이 하나의 base 커밋으로 매핑돼 조용히 skip → 내용이 유실되던 데이터 손실 버그를 수정한다.
- subject 일치는 이제 1차 후보 필터로만 쓰고, `git patch-id --stable` 로 patch 내용이 실제 동일할 때만 duplicate 로 확정한다(cherry-pick 동치성과 일치).

## Changes
- `shell-common/functions/gcp_scan.sh`: Stage-1 매칭에 patch-id 게이트 추가. subject 충돌 시에만 source patch-id 를 지연 계산(무충돌 경로 fork 0)하고, base 후보와 patch-id 가 같을 때만 `match_base_sha` 를 확정. 서로 다른 두 커밋은 patch-id 가 같을 수 없어 1:다(多) 오매핑도 구조적으로 차단. 빈 patch-id(merge 커밋 등)는 절대 일치하지 않아 항상 보존.
- `tests/bats/functions/gcp.bats`: 동일 subject·상이 내용 fixture 를 skip 으로 단정하던 기존 `#811`/`#913`/`#1134 Bug A` 테스트를 "적용됨"으로 정정하고, 1:다 시나리오(서로 다른 두 커밋이 한 base subject 공유) 회귀 테스트를 신규 추가.

## Test plan
- [x] `bats tests/bats/functions/gcp.bats` — 75 ok / 1 not ok. 유일한 실패(`#913` context-drift no-op)는 clean baseline 에서도 실패하는 **기존 실패**(git 2.43.0 `merge-tree` 예측기 동작)로 본 PR 과 무관.
- [x] 신규 `#1136`/`#1134` 회귀 테스트 4건 통과 (동일 subject·상이 내용 커밋이 skip 되지 않고 payload 가 적용됨).
- [x] `tests/golden_rules/test_golden_rules.sh` 전체 통과 (Rule 5 POSIX 준수 포함).

## Related
Closes #1136

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
