### PR TITLE
chore(aliases): cd-af 를 cd-at 참조로 통합 + cd-kk 추가

### DIFF
--- a/shell-common/aliases/directory.sh
+++ b/shell-common/aliases/directory.sh
@@ -19,13 +19,14 @@ dotfiles() {
     cd "${DOTFILES_ROOT:-$HOME/dotfiles}"
 }
 
-# Windows directory paths (WSL)
-alias cd-wdocu='cd /mnt/c/Users/bwyoon/Documents'
-alias cd-wobsidian='cd /mnt/c/Users/bwyoon/Documents/.obsidian'
-alias cd-wdown='cd /mnt/c/Users/bwyoon/Downloads'
-alias cd-wpicture='cd /mnt/c/Users/bwyoon/Pictures'
-alias cd-tilnote='cd /mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote'
-alias cd-obsidian='cd /mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote'
+# Windows directory paths (WSL) — /mnt/c/Users/... are Windows-side mounts
+# with no $HOME equivalent, so the abs-home guard is explicitly allowed here.
+alias cd-wdocu='cd /mnt/c/Users/bwyoon/Documents'                          # allow-abs-home
+alias cd-wobsidian='cd /mnt/c/Users/bwyoon/Documents/.obsidian'            # allow-abs-home
+alias cd-wdown='cd /mnt/c/Users/bwyoon/Downloads'                          # allow-abs-home
+alias cd-wpicture='cd /mnt/c/Users/bwyoon/Pictures'                        # allow-abs-home
+alias cd-tilnote='cd /mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote'  # allow-abs-home
+alias cd-obsidian='cd /mnt/c/Users/bwyoon/Documents/ObsidianVault-TilNote' # allow-abs-home
 
 # PARA structure
 alias mk-para='mkdir -p para/{archive,area,project,resource}'
@@ -42,8 +43,9 @@ alias cd-archive='cd ~/para/archive'
 alias cd-ss='cd ~/para/project/slea-ssem'
 alias cd-ll='cd ~/para/project/litellm'
 alias cd-jv='cd ~/para/project/jiravis'
-alias cd-at='cd ~/para/project/agent-toolbox'
+alias cd-at='cd ~/para/project/agent-toolbox' cd-af='cd-at'
 alias cd-qf='cd ~/para/project/quantfolio'
+alias cd-kk='cd ~/para/project/karakeep'
 alias cd-jmcp='cd ~/para/project/jira-mcp'
 alias cd-jmcp-as='cd ~/para/project/jira-mcp/mcp-atlassian'
 alias cd-jmcp-as-ds='cd ~/para/project/jira-mcp/mcp-atlassian-ds'


### PR DESCRIPTION
## Summary
- `cd-af` 와 `cd-at` 이 동일 경로(`~/para/project/agent-toolbox`)를 가리키던 중복을 alias→alias 참조로 통합(DRY)하고, `cd-kk`(karakeep) alias 를 신규 추가한다.
- abs-home 가드(#737) 도입 이후 이 파일의 첫 수정이라 표면화된 기존 WSL Windows 마운트 경로 6줄을 `# allow-abs-home` 마커로 명시 허용 처리한다(동작 변경 없음).

## Changes
- `shell-common/aliases/directory.sh`
  - `cd-af` → `cd-at` 참조로 통합 — 경로 SSOT 를 한 곳(`cd-at`)에 고정. bash/zsh 양쪽에서 재귀 확장 동작 검증 완료.
  - `cd-kk` → `~/para/project/karakeep` 신규 alias.
  - WSL `/mnt/c/Users/...` 6줄에 `# allow-abs-home` 부착 — `$HOME` 대체 불가한 의도된 경로이며, #737 pre-commit 훅을 통과시키기 위한 명시 허용.

## Test plan
- [x] bash/zsh 에서 `cd-af` → `agent-toolbox` 이동 확인
- [x] pre-commit abs-home 가드 통과 확인
- [ ] 셸 재로드 후 `cd-kk` → `karakeep` 이동 확인

## Related
Closes #1140

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
