### PR TITLE
fix(npm): pin npm prefix for public mode to stop auto-update permission failure

### DIFF
--- a/npm/npmrc.public
+++ b/npm/npmrc.public
@@ -1,0 +1,17 @@
+# npmrc.public
+# Public / home PC configuration (direct internet, no proxy)
+#
+# Usage:
+#   This file is symlinked to ~/.npmrc by shell-common/setup.sh
+#   Selected automatically in "public" setup mode.
+#
+# Why this exists (issue: npm auto-update permission failure):
+#   System node installs default the global prefix to /usr (root-owned),
+#   so `claude` auto-update — which writes to $prefix/lib/node_modules —
+#   fails with "no write permission to npm prefix". Pinning prefix to a
+#   user-owned dir fixes it permanently. npm expands ${HOME} in .npmrc.
+#
+# Note: public registry (registry.npmjs.org) is npm's default, so no
+#       registry/proxy/cafile lines are needed here — only the prefix.
+
+prefix=${HOME}/.npm-global

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -226,8 +226,11 @@ setup_npm_symlink() {
             ux_info "Using: Public npmjs registry (no proxy)"
             ;;
         public)
-            # Public PC: no .npmrc needed (defaults)
-            ux_info "No .npmrc needed (using npm defaults)"
+            # Public PC: pin npm prefix to a user-owned dir so `claude`
+            # auto-update does not fail against the root-owned /usr default.
+            ln -s "${DOTFILES_ROOT}/npm/npmrc.public" "$npmrc_target"
+            ux_success "Created symlink: ~/.npmrc → npm/npmrc.public"
+            ux_info "Using: Public npmjs registry (prefix pinned to ~/.npm-global)"
             ;;
     esac
 }
@@ -711,6 +714,7 @@ main() {
             echo ""
             ux_success "Setup complete for public PC (home environment)"
             ux_info "All environment-specific configuration removed"
+            ux_info "  - NPM: ~/.npmrc → npm/npmrc.public (prefix pinned to ~/.npm-global)"
             ux_info "Setup mode saved to: ~/.dotfiles-setup-mode"
             echo ""
             ;;


### PR DESCRIPTION
## Summary
- `public` 모드에서만 `~/.npmrc` 를 만들지 않아 npm global prefix 가 시스템 기본값 `/usr`(root 소유)로 떨어졌고, 이로 인해 `claude` auto-update 가 `no write permission to npm prefix` 로 실패했다.
- `external`/`internal` 과 동일하게 `public` 도 prefix 를 사용자 소유 디렉터리(`~/.npm-global`)로 고정하는 npmrc 를 심링크하도록 통일했다.
- `./setup.sh` 재실행·타 PC 에서도 재발하지 않도록 기존 `setup_npm_symlink()` 메커니즘에 편입했다.

## Changes
- `npm/npmrc.public` 신규: `prefix=${HOME}/.npm-global` 만 담음 (public 은 기본 레지스트리라 proxy/cafile 불필요)
- `shell-common/setup.sh`: `setup_npm_symlink()` 의 `public` 분기를 "no .npmrc needed" → `~/.npmrc → npm/npmrc.public` 심링크 생성으로 교체
- `shell-common/setup.sh`: public PC 셋업 완료 요약 메시지에 NPM 항목 추가

## Test plan
- [x] `~/.npmrc` → `npm/npmrc.public` 심링크 생성 후 `npm config get prefix` = `~/.npm-global` 확인
- [x] `npm root -g` = `~/.npm-global/lib/node_modules` (사용자 소유) 확인
- [x] `npm update -g @anthropic-ai/claude-code` 성공 (권한 오류 해소)
- [x] `shellcheck -x shell-common/setup.sh` — 변경 라인에 신규 지적 없음
- [ ] 다른 public PC 에서 `./setup.sh` 실행 시 심링크 자동 생성 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
