### PR TITLE
refactor(claude/hooks): PostToolUse Bash 훅 2개를 디스패처로 통합해 per-Bash 스폰 절반 (#1144)

### DIFF
--- a/claude/hooks/post-bash-dispatch.sh
+++ b/claude/hooks/post-bash-dispatch.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# claude/hooks/post-bash-dispatch.sh
+#
+# Single front-door for PostToolUse:Bash. Claude Code spawns one process per
+# registered hook on EVERY Bash tool call, so registering the two independent
+# handlers (post-gh-pr-create.sh + plugin-sync.sh) directly meant two spawns
+# per Bash call — avg 7647ms / max 12274ms over the WSL<->Windows boundary
+# (/doctor, n=15) — for work that almost never matches. This thin dispatcher
+# reads stdin + parses the envelope ONCE, then routes to a handler only when
+# the command cheaply looks relevant. Common (non-matching) path: 2->1 spawn.
+#
+# The handlers stay STANDALONE (each still re-filters its own stdin and
+# self-exits 0 on a miss), so this dispatcher only has to reject the
+# obviously-irrelevant majority — the routing regexes are intentionally loose
+# and the handler makes the final call. Handlers are unchanged: their verified
+# edge cases (#390 #703 #804 #1072 #1125 #1080) and bats suites pass untouched.
+#
+# Contract mirrors the handlers: set -u, no-op without jq, always exit 0
+# (best-effort — a dispatch hiccup never blocks the user's flow).
+#
+# Reference: issue #1144.
+set -u
+
+# A PostToolUse hook always receives JSON on stdin. If stdin is a terminal the
+# script was launched by hand — bail before `cat` blocks forever.
+[ -t 0 ] && exit 0
+input=$(cat 2>/dev/null) || exit 0
+[ -n "$input" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+[ "$tool_name" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+
+# Handlers live beside this dispatcher. POST_BASH_DISPATCH_DIR overrides the
+# location for tests (stub handlers that record the routed stdin). The `CDPATH=`
+# prefix neutralises a user CDPATH so `cd` cannot resolve elsewhere.
+# shellcheck disable=SC1007 # intentional env-prefix: CDPATH= cd ...
+DISPATCH_DIR="${POST_BASH_DISPATCH_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)}"
+
+# Route on a cheap, deliberately-loose command match; the handler's own filter
+# makes the final call. Anchor on a word boundary so an env-var/`command`
+# prefix (`FOO=bar gh pr create`) still routes (#390). `gh pr create` and
+# `claude plugin ...` never co-occur in one command, so exclusive routing is
+# sufficient — and forwards the untouched stdin JSON the handler expects.
+if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+	printf '%s' "$input" | "$DISPATCH_DIR/post-gh-pr-create.sh"
+elif printf '%s' "$cmd" | grep -qE '(^|[[:space:]])claude[[:space:]]+plugin[[:space:]]'; then
+	printf '%s' "$input" | "$DISPATCH_DIR/plugin-sync.sh"
+fi
+
+exit 0

--- a/claude/hooks/post-bash-dispatch.sh
+++ b/claude/hooks/post-bash-dispatch.sh
@@ -41,13 +41,20 @@ DISPATCH_DIR="${POST_BASH_DISPATCH_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && 
 
 # Route on a cheap, deliberately-loose command match; the handler's own filter
 # makes the final call. Anchor on a word boundary so an env-var/`command`
-# prefix (`FOO=bar gh pr create`) still routes (#390). `gh pr create` and
+# prefix (`FOO=bar gh pr create`) still routes (#390); both regexes use the
+# same `(^|[[:space:]])…([[:space:]]|$)` shape for symmetry. `gh pr create` and
 # `claude plugin ...` never co-occur in one command, so exclusive routing is
-# sufficient — and forwards the untouched stdin JSON the handler expects.
+# sufficient — and forwards the untouched stdin JSON the handler expects. Guard
+# each handler with `-x` so a missing/non-executable script is a silent no-op
+# (best-effort contract) rather than stderr noise + a non-zero pipeline.
 if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
-	printf '%s' "$input" | "$DISPATCH_DIR/post-gh-pr-create.sh"
-elif printf '%s' "$cmd" | grep -qE '(^|[[:space:]])claude[[:space:]]+plugin[[:space:]]'; then
-	printf '%s' "$input" | "$DISPATCH_DIR/plugin-sync.sh"
+	if [ -x "$DISPATCH_DIR/post-gh-pr-create.sh" ]; then
+		printf '%s' "$input" | "$DISPATCH_DIR/post-gh-pr-create.sh"
+	fi
+elif printf '%s' "$cmd" | grep -qE '(^|[[:space:]])claude[[:space:]]+plugin([[:space:]]|$)'; then
+	if [ -x "$DISPATCH_DIR/plugin-sync.sh" ]; then
+		printf '%s' "$input" | "$DISPATCH_DIR/plugin-sync.sh"
+	fi
 fi
 
 exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -53,11 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/post-gh-pr-create.sh"
-          },
-          {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/post-bash-dispatch.sh"
           }
         ]
       }

--- a/tests/bats/skills/plugin_sync_hook_registration.bats
+++ b/tests/bats/skills/plugin_sync_hook_registration.bats
@@ -12,22 +12,26 @@ SETTINGS="${_BATS_REAL_DOTFILES_ROOT}/claude/settings.json"
     assert_success
 }
 
-@test "PostToolUse/Bash includes plugin-sync.sh" {
+@test "PostToolUse/Bash registers exactly the dispatcher (#1144)" {
+    # #1144: the two independent handlers are no longer registered directly —
+    # a single thin dispatcher fronts them, halving the common-path spawn.
     run jq -e '
-        .hooks.PostToolUse[]
-        | select(.matcher == "Bash")
-        | .hooks[]
-        | select(.command | endswith("claude/hooks/plugin-sync.sh"))
+        [.hooks.PostToolUse[] | select(.matcher == "Bash") | .hooks[]] as $h
+        | ($h | length) == 1
+          and ($h[0].command | endswith("claude/hooks/post-bash-dispatch.sh"))
     ' "$SETTINGS"
     assert_success
 }
 
-@test "PostToolUse/Bash still includes post-gh-pr-create.sh" {
+@test "PostToolUse/Bash no longer registers the handlers directly (#1144)" {
+    # The handlers stay standalone on disk but are reached via the dispatcher,
+    # not via their own PostToolUse:Bash registration.
     run jq -e '
-        .hooks.PostToolUse[]
-        | select(.matcher == "Bash")
-        | .hooks[]
-        | select(.command | endswith("claude/hooks/post-gh-pr-create.sh"))
+        [.hooks.PostToolUse[]
+            | select(.matcher == "Bash")
+            | .hooks[].command
+            | select(endswith("post-gh-pr-create.sh") or endswith("plugin-sync.sh"))]
+        | length == 0
     ' "$SETTINGS"
     assert_success
 }

--- a/tests/bats/skills/post_bash_dispatch_hook.bats
+++ b/tests/bats/skills/post_bash_dispatch_hook.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# tests/bats/skills/post_bash_dispatch_hook.bats
+# Verify the PostToolUse:Bash dispatcher documented in
+#   claude/hooks/post-bash-dispatch.sh
+# routes each event to the correct handler (or to none), forwarding the
+# untouched stdin JSON. Issue #1144.
+#
+# POST_BASH_DISPATCH_DIR points the dispatcher at stub handlers that record
+# which one was entered plus the exact stdin they received — so the real
+# board-sync / manifest-sync logic never runs and cannot mask a routing bug.
+
+load '../test_helper'
+
+HOOK="${_BATS_REAL_DOTFILES_ROOT}/claude/hooks/post-bash-dispatch.sh"
+
+setup() {
+    setup_isolated_home
+    STUB_DIR="$TEST_TEMP_HOME/hooks"
+    mkdir -p "$STUB_DIR"
+    ROUTE_LOG="$TEST_TEMP_HOME/route.log"
+    : > "$ROUTE_LOG"
+    cat > "$STUB_DIR/post-gh-pr-create.sh" <<EOF
+#!/usr/bin/env bash
+printf 'pr-create:%s\n' "\$(cat)" >> "$ROUTE_LOG"
+EOF
+    cat > "$STUB_DIR/plugin-sync.sh" <<EOF
+#!/usr/bin/env bash
+printf 'plugin-sync:%s\n' "\$(cat)" >> "$ROUTE_LOG"
+EOF
+    chmod +x "$STUB_DIR/post-gh-pr-create.sh" "$STUB_DIR/plugin-sync.sh"
+    export POST_BASH_DISPATCH_DIR="$STUB_DIR"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset POST_BASH_DISPATCH_DIR
+}
+
+@test "dispatch: non-matching Bash command → no handler spawned, exit 0" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -s "$ROUTE_LOG" ]
+}
+
+@test "dispatch: gh pr create → only post-gh-pr-create entered" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    grep -q '^pr-create:' "$ROUTE_LOG"
+    ! grep -q '^plugin-sync:' "$ROUTE_LOG"
+}
+
+@test "dispatch: env-prefixed gh pr create still routes (#390 word-boundary)" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"GH_TOKEN=x gh pr create --draft"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    grep -q '^pr-create:' "$ROUTE_LOG"
+}
+
+@test "dispatch: claude plugin install → only plugin-sync entered" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"claude plugin install foo@bar"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    grep -q '^plugin-sync:' "$ROUTE_LOG"
+    ! grep -q '^pr-create:' "$ROUTE_LOG"
+}
+
+@test "dispatch: non-Bash tool → immediate exit, no handler" {
+    payload='{"tool_name":"Read","tool_input":{"command":"gh pr create"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -s "$ROUTE_LOG" ]
+}
+
+@test "dispatch: empty stdin → exit 0, no handler" {
+    run bash -c "printf '' | '$HOOK'"
+    assert_success
+    [ ! -s "$ROUTE_LOG" ]
+}
+
+@test "dispatch: stdin forwarded verbatim to the routed handler" {
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create"},"tool_response":{"output":"https://github.com/o/r/pull/1"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    grep -qF "pr-create:$payload" "$ROUTE_LOG"
+}

--- a/tests/bats/skills/post_bash_dispatch_hook.bats
+++ b/tests/bats/skills/post_bash_dispatch_hook.bats
@@ -85,3 +85,13 @@ teardown() {
     assert_success
     grep -qF "pr-create:$payload" "$ROUTE_LOG"
 }
+
+@test "dispatch: non-executable handler → silent no-op, exit 0 (PR #1145 gemini)" {
+    # Defensive: a missing/non-executable handler must be a silent no-op, not
+    # stderr noise + a non-zero pipeline. Strip +x so the -x guard skips it.
+    chmod -x "$STUB_DIR/post-gh-pr-create.sh"
+    payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create"}}'
+    run bash -c "printf '%s' '$payload' | '$HOOK'"
+    assert_success
+    [ ! -s "$ROUTE_LOG" ]
+}


### PR DESCRIPTION
## 요약

매 `Bash` 툴 호출마다 PostToolUse 훅 2개(`post-gh-pr-create.sh`, `plugin-sync.sh`)가 각각 프로세스로 스폰돼 **avg 7647ms / max 12274ms**(`/doctor`, n=15)를 소모했다. 두 훅을 물리적으로 합치는 건 SRP 위반이라 거부하고, 대신 **얇은 디스패처 1개**를 앞단에 둬 공통(비매칭) 경로의 스폰을 **2→1** 로 줄인다.

## 변경 내용

- **신규** `claude/hooks/post-bash-dispatch.sh` — stdin 1회 읽기 → `tool_name`/`command` 1회 파싱 → 느슨한 프리픽스 매칭으로 라우팅. `gh pr create` → `post-gh-pr-create.sh`, `claude plugin …` → `plugin-sync.sh`, 그 외/비-Bash/빈 stdin → 즉시 `exit 0`. `set -u`, jq 부재 no-op, 항상 `exit 0` 계약을 핸들러와 동일하게 준수. 테스트용 `POST_BASH_DISPATCH_DIR` 오버라이드 지원.
- **변경** `claude/settings.json` — `PostToolUse`/`Bash` 두 항목을 디스패처 1개로 교체.
- **무수정** 핸들러 2개 — 독립 실행형 유지, 자체 필터로 최종 판정. 검증된 엣지케이스(#390 #703 #804 #1072 #1125 #1080)와 기존 bats 3종 무수정 통과.

## 테스트

- 신규 `tests/bats/skills/post_bash_dispatch_hook.bats` — 라우팅 7 케이스(비매칭/gh pr create/env-prefixed/claude plugin/비-Bash/빈 stdin/stdin verbatim 전달).
- `tests/bats/skills/plugin_sync_hook_registration.bats` — 디스패처 단일 등록 형태로 갱신(핸들러 직접 등록 부재 검증 추가).
- 관련 4개 bats 스위트 49/49 통과, pytest 1187/1187 통과, golden rules 통과, shellcheck/shfmt clean.

## 동작 보존

핸들러가 독립 실행형 그대로이고, 디스패처가 stdin JSON 을 `printf '%s' "$input" | handler` 로 무변형 전달하므로 핸들러가 보는 입력은 이전과 동일하다.

Closes #1144

<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~46 min</summary>

<!-- ai-metrics -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~46 min
<!-- /ai-metrics -->

</details>
