### PR TITLE
refactor(git-hooks): abs-home 가드를 파일 전체 스캔 → diff 추가 라인 검사로 전환

### DIFF
--- a/git/hooks/checks/hardcoded_home_path_check.sh
+++ b/git/hooks/checks/hardcoded_home_path_check.sh
@@ -17,10 +17,16 @@
 #   docs/      (same)
 #   lines that start with `#` (comments / heredoc markers)
 #   lines with the `# allow-abs-home` escape marker on the same line
+#
+# Scan input (issue #1142): only the **added lines** of the staged diff
+# (`git diff --cached -U0`), not the whole file. Pre-existing absolute
+# paths that predate this guard no longer surface when an unrelated line
+# of an old file is first touched. The #737 defense contract is preserved
+# because an installer re-appending `/home/...` shows up as an added line.
 
 check_hardcoded_home_path() {
     local repo_root="$1"
-    local tmpdir="$2"
+    # $2 (tmpdir) is unused now — the diff scan streams git output directly.
     local repo_rel_path="$3"
     local output_file="$4"
 
@@ -36,36 +42,38 @@ check_hardcoded_home_path() {
         docs/* | */docs/*) return 0 ;;
     esac
 
-    local tmp_file
-    tmp_file=$(mktemp "$tmpdir/abs_home_stage_XXXXXX.txt")
-    write_staged_or_worktree_to_tmp "$repo_root" "$repo_rel_path" "$tmp_file" 2>/dev/null || {
-        rm -f "$tmp_file"
-        return 0
-    }
-
+    # Scan only the added (`+`) lines of the staged diff. Hunk headers
+    # (`@@ -a,b +c,d @@`) seed the new-file line number so reported line
+    # numbers still point at the real location in the committed file.
+    #
     # Pattern: `/home/<segment>` or `/Users/<segment>`. <segment> is one or
     # more name chars; the trailing `/` is intentionally NOT required so
     # `export MY_HOME=/home/user` (no slash, no following path) is also
     # caught (gemini-code-assist review on PR #738). `awk -v pfx=...`
     # embeds the file name directly into the printf so a downstream sed
-    # rewrite is unnecessary and whitespace in $0 stays safe.
+    # rewrite is unnecessary and whitespace in the line stays safe.
     local hits
-    hits=$(awk -v pfx="$repo_rel_path" '
-        {
-            line = $0
-            # Skip pure comment lines (first non-blank char is #)
-            if (line ~ /^[[:space:]]*#/) next
-            # Skip explicit allowlist
-            if (line ~ /# allow-abs-home/) next
-            # Match resolved home paths
-            if (line ~ /\/home\/[A-Za-z0-9._-]+/ ||
-                line ~ /\/Users\/[A-Za-z0-9._-]+/) {
-                printf "    %s:%d:%s\n", pfx, NR, line
+    hits=$(git -C "$repo_root" diff --cached -U0 -- "$repo_rel_path" 2>/dev/null |
+        awk -v pfx="$repo_rel_path" '
+            # Hunk header: capture the new-file start line (the `+c` field).
+            /^@@/ {
+                match($0, /\+[0-9]+/)
+                newline = substr($0, RSTART + 1, RLENGTH - 1) + 0
+                next
             }
-        }
-    ' "$tmp_file" 2>/dev/null || true)
-
-    rm -f "$tmp_file"
+            # Added content lines only (skip the `+++ b/file` file header).
+            /^\+/ {
+                if ($0 ~ /^\+\+\+/) next
+                line = substr($0, 2)
+                if (line !~ /^[[:space:]]*#/ && line !~ /# allow-abs-home/ &&
+                    (line ~ /\/home\/[A-Za-z0-9._-]+/ ||
+                     line ~ /\/Users\/[A-Za-z0-9._-]+/)) {
+                    printf "    %s:%d:%s\n", pfx, newline, line
+                }
+                newline++
+                next
+            }
+        ' 2>/dev/null || true)
 
     if [ -z "$hits" ]; then
         return 0

--- a/git/hooks/checks/hardcoded_home_path_check.sh
+++ b/git/hooks/checks/hardcoded_home_path_check.sh
@@ -53,7 +53,7 @@ check_hardcoded_home_path() {
     # embeds the file name directly into the printf so a downstream sed
     # rewrite is unnecessary and whitespace in the line stays safe.
     local hits
-    hits=$(git -C "$repo_root" diff --cached -U0 -- "$repo_rel_path" 2>/dev/null |
+    hits=$(git -C "$repo_root" diff --cached --no-color --no-ext-diff -U0 -- "$repo_rel_path" 2>/dev/null |
         awk -v pfx="$repo_rel_path" '
             # Hunk header: capture the new-file start line (the `+c` field).
             /^@@/ {

--- a/git/tests/test_hooks.sh
+++ b/git/tests/test_hooks.sh
@@ -261,6 +261,33 @@ EOF
   rm -rf "$repo_dir"
 }
 
+# Issue #1142: a file that already carries a pre-existing absolute home path
+# (debt predating the #737 guard) must NOT block an unrelated one-line edit —
+# only added diff lines are scanned, so the untouched legacy line is ignored.
+test_allows_preexisting_abs_home_on_unrelated_edit() {
+  local repo_dir
+  repo_dir="$(mktemp -d /tmp/dotfiles-hook-test.XXXXXX)"
+  make_repo "$repo_dir"
+
+  # Seed legacy debt: commit an abs-home line while bypassing the guard,
+  # simulating a path that landed before the guard existed.
+  cat >"$repo_dir/zsh/legacy.zsh" <<'EOF'
+#!/bin/zsh
+[ -s "/home/deity719/.bun/_bun" ] && source "/home/deity719/.bun/_bun"
+EOF
+  git -C "$repo_dir" add zsh/legacy.zsh
+  git -C "$repo_dir" commit -q --no-verify -m "legacy debt (pre-guard)"
+
+  # Unrelated edit that does NOT touch the legacy line — must pass.
+  cat >>"$repo_dir/zsh/legacy.zsh" <<'EOF'
+export EDITOR=vim
+EOF
+  git -C "$repo_dir" add zsh/legacy.zsh
+  assert_success "git -C \"$repo_dir\" commit -m \"unrelated edit of legacy file\""
+
+  rm -rf "$repo_dir"
+}
+
 main() {
   ux_header "Hook integration tests"
   test_allows_spaces_in_filename
@@ -274,6 +301,7 @@ main() {
   test_blocks_hardcoded_home_path_in_zshrc
   test_allows_hardcoded_home_path_with_marker
   test_allows_home_var_reference
+  test_allows_preexisting_abs_home_on_unrelated_edit
   ux_success "All hook tests passed"
 }
 


### PR DESCRIPTION
## 요약
`hardcoded_home_path_check.sh` 의 스캔 입력을 **스테이징 파일 전체** → **`git diff --cached -U0` 의 추가(`+`) 라인**으로 좁혀, abs-home 가드(#737) 도입 이전부터 존재하던 절대경로가 "그 파일을 처음 수정하는 순간" 무관하게 표면화돼 커밋을 막던 마찰을 근본 제거한다.

## 배경
PR #1141(cd-af/cd-kk alias) 작업 중, alias 파일이 #737 훅 도입 이후 첫 수정이었는데 내가 건드리지 않은 기존 WSL 경로 6줄이 전량 표면화돼 커밋이 차단됐다. "파일 전체 스캔" 구조가 남아 있는 한 오래된 파일을 처음 손댈 때마다 재발한다.

## 변경 내용
- **`git/hooks/checks/hardcoded_home_path_check.sh`**
  - tmp 덤프 + 전 라인 awk → `git diff --cached -U0` 의 추가 라인만 검사.
  - 헌크 헤더(`@@ -a,b +c,d @@`)의 `+c` 로 신규 파일 라인번호를 시드 → 리포트 라인번호 정확도 유지.
  - 매치 패턴(`/home/`·`/Users/`), `# allow-abs-home` 마커, 파일 스코프, 제외규칙 모두 **불변**.
  - 미사용이 된 `tmpdir` 인자는 주석 처리(SC2034 회피).
- **`git/tests/test_hooks.sh`**
  - 회귀 케이스 `test_allows_preexisting_abs_home_on_unrelated_edit` 추가: 기존 abs-home 라인이 있는 파일의 무관 한 줄 수정은 통과함을 검증.

## 동작 보존 (Behavior Preservation)
- #737 시나리오(installer 가 경로를 append) = **추가 라인** → 여전히 차단 (핵심 방어 계약 유지).
- 기존 abs-home 라인 **자체를 수정**하면 diff 추가 라인으로 잡혀 여전히 차단.

## 검증
로컬에서 feature 브랜치 임시 repo로 실제 커밋을 돌려 4종 시나리오 확인 (모두 PASS):
1. 새 abs-home append → 차단
2. `# allow-abs-home` 마커 → 통과
3. 기존(pre-guard) abs-home + 무관 한 줄 수정 → **통과** (이번 수정의 핵심)
4. 기존 abs-home 라인 자체 수정 → 차단

`shellcheck -x` clean. `mise run lint-sh` 는 `bash/` 만 대상이라 `git/` 변경은 shfmt 게이트 밖 — 추가 코드는 각 파일의 실제 컨벤션에 맞춤.

> 참고: `git/tests/test_hooks.sh` 전체 스위트는 이 로컬 머신의 git 기본 브랜치가 `master`(보호 브랜치 가드 차단) + 선행 `library_purity` 실패로 중단됨 — **둘 다 이번 변경과 무관**(원본에서 동일 재현). CI(기본 브랜치 정상)에서는 정상 실행 예상.

Closes #1142
