### PR TITLE
feat(shell): grs — git restore 친절 래퍼 (Verdict + Next-action preflight)

### DIFF
--- a/shell-common/functions/git_help.sh
+++ b/shell-common/functions/git_help.sh
@@ -49,7 +49,7 @@ _git_help_rows_basic() {
     ux_table_row "gpl" "git pull" "Pull from remote"
     ux_table_row "gco" "git checkout" "Checkout branch/commit"
     ux_table_row "gd" "git diff" "Show changes"
-    ux_table_row "grs" "git restore <file>" "Discard working dir changes"
+    ux_table_row "grs" "git restore <file>" "Discard changes (친절 래퍼: untracked/오타/staged/no-op 사전 경고)"
     ux_table_row "grs --staged" "git restore --staged <file>" "Unstage file (undo git add)"
     ux_table_row "gb" "git branch" "List branches"
     ux_table_row "grmc" "git rm --cached" "Unstage, keep file"

--- a/shell-common/functions/git_restore.sh
+++ b/shell-common/functions/git_restore.sh
@@ -84,7 +84,7 @@ grs() {
         --)
             _grs_after_ddash=1
             ;;
-        --staged | -S | --worktree | -W | --source | -s | --source=* | --patch | -p)
+        --staged | -S | --worktree | -W | --source | -s | --source=* | --patch | -p | --pathspec-from-file | --pathspec-from-file=*)
             _grs_advanced=1
             ;;
         -*)
@@ -127,16 +127,17 @@ grs() {
 
         if git ls-files --error-unmatch -- "$_grs_p" >/dev/null 2>&1; then
             # Tracked path.
-            if ! git diff --quiet -- "$_grs_p" >/dev/null 2>&1; then
+            if ! git diff --no-color --no-ext-diff --quiet -- "$_grs_p" >/dev/null 2>&1; then
                 _grs_normal=$((_grs_normal + 1)) # worktree diff present
-            elif ! git diff --cached --quiet -- "$_grs_p" >/dev/null 2>&1; then
+            elif ! git diff --no-color --no-ext-diff --cached --quiet -- "$_grs_p" >/dev/null 2>&1; then
                 _grs_staged="${_grs_staged}${_grs_p}${_grs_nl}" # staged only
             else
                 _grs_noop=$((_grs_noop + 1)) # nothing to restore
             fi
         else
-            # Not tracked.
-            if [ -e "$_grs_p" ]; then
+            # Not tracked. `-L` catches broken (dangling) symlinks that `-e`
+            # reports absent — they're present-but-untracked (rm target), not typos.
+            if [ -e "$_grs_p" ] || [ -L "$_grs_p" ]; then
                 _grs_untracked="${_grs_untracked}${_grs_p}${_grs_nl}"
             else
                 _grs_missing="${_grs_missing}${_grs_p}${_grs_nl}"

--- a/shell-common/functions/git_restore.sh
+++ b/shell-common/functions/git_restore.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# shell-common/functions/git_restore.sh
+# grs — friendly `git restore` wrapper (Verdict + Next-action preflight).
+#
+# WHY this exists (issue #1146):
+# Raw `git restore` is unhelpful in the common mistake cases. It either
+# prints a bare pathspec error (untracked path) without saying *why* it
+# failed or *what to do next*, or — worse — it silently succeeds as a
+# no-op / touches only the worktree when the user meant to unstage. Both
+# hide the real problem from someone who has to re-derive `??` (untracked)
+# semantics every time.
+#
+# This file overrides the `grs` alias (Oh My Zsh git plugin + the explicit
+# `alias grs='git restore'` in shell-common/aliases/git.sh) with a shell
+# function that runs a *preflight classification* BEFORE calling git —
+# not a post-hoc error translation. Preflight is the only way to catch the
+# cases git never errors on (no-op, staged-only). When nothing is wrong the
+# function is transparent: it execs `git restore "$@"` with no extra output,
+# identical exit code, indistinguishable from raw git.
+#
+# Kept in its own file (not folded into git.sh) to isolate responsibility,
+# mirroring gh_host.sh's "explain the why" header style. Only `grs` is
+# wrapped — `grss` / `grst` (OMZ) and raw `git` are untouched, so the
+# `--staged` guidance can point at `grst` and we avoid wrapping raw git
+# (side-effect / performance risk).
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# git.sh already unaliases its own set; grs lives here, so drop it here too.
+unalias grs 2>/dev/null || true
+
+# _grs_help — usage for the friendly restore wrapper.
+_grs_help() {
+    ux_header "grs — git restore (친절 래퍼)"
+    ux_info "정상 케이스는 raw \`git restore\`와 동일하게 투명 통과합니다."
+    ux_info "흔한 실수/모호 상황에서만 판정(Verdict)과 다음 명령(Next-action)을 안내합니다."
+    ux_info ""
+    ux_info "Usage:"
+    ux_bullet "grs <path>...            워킹트리 변경 되돌리기 (preflight 검사)"
+    ux_bullet "grs --staged <path>...   스테이지 해제 (= grst, 그대로 통과)"
+    ux_bullet "grs -h | --help          이 도움말"
+    ux_info ""
+    ux_info "감지하는 상황:"
+    ux_bullet_sub "untracked 경로   → restore 대상 아님, rm / git clean 안내"
+    ux_bullet_sub "미존재 경로      → 오타 의심, git status 확인 안내"
+    ux_bullet_sub "staged 만 변경   → grs 는 unstage 안 함, grs --staged 안내"
+    ux_bullet_sub "변경 없음        → no-op 안내 (아무 것도 안 함)"
+}
+
+# grs — preflight-classify path args, then restore transparently or diagnose.
+grs() {
+    # zsh: run under POSIX word-splitting rules (git.sh convention).
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    case "${1-}" in
+    -h | --help | help)
+        _grs_help
+        return 0
+        ;;
+    esac
+
+    # Outside a git repo the plumbing below can't classify — fall back to
+    # raw git so the user sees git's own error, unchanged.
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        git restore "$@"
+        return $?
+    fi
+
+    # Pass 1 — scan args: detect advanced flags, honour `--`, count paths.
+    # Advanced flags (--staged / --source / --worktree / --patch and short
+    # forms) mean the user knows what they're doing; trust them and pass
+    # through without preflight. No path args → let git handle its usage error.
+    _grs_advanced=0
+    _grs_path_count=0
+    _grs_after_ddash=0
+    for _grs_arg in "$@"; do
+        if [ "$_grs_after_ddash" -eq 1 ]; then
+            _grs_path_count=$((_grs_path_count + 1))
+            continue
+        fi
+        case "$_grs_arg" in
+        --)
+            _grs_after_ddash=1
+            ;;
+        --staged | -S | --worktree | -W | --source | -s | --source=* | --patch | -p)
+            _grs_advanced=1
+            ;;
+        -*)
+            : # other flag (e.g. --quiet, --overlay) — not a path
+            ;;
+        *)
+            _grs_path_count=$((_grs_path_count + 1))
+            ;;
+        esac
+    done
+
+    if [ "$_grs_advanced" -eq 1 ] || [ "$_grs_path_count" -eq 0 ]; then
+        git restore "$@"
+        return $?
+    fi
+
+    # Pass 2 — classify each path arg into buckets (all git calls silent).
+    _grs_nl='
+'
+    _grs_untracked="" # [사고] untracked & exists
+    _grs_missing=""   # [사고] missing (typo?)
+    _grs_staged=""    # [주의] staged-only, grs won't unstage
+    _grs_normal=0     # has worktree diff → real restore target
+    _grs_noop=0       # tracked but no changes at all
+
+    _grs_after_ddash=0
+    for _grs_arg in "$@"; do
+        if [ "$_grs_after_ddash" -eq 0 ]; then
+            case "$_grs_arg" in
+            --)
+                _grs_after_ddash=1
+                continue
+                ;;
+            -*)
+                continue # flag, not a path
+                ;;
+            esac
+        fi
+        _grs_p="$_grs_arg"
+
+        if git ls-files --error-unmatch -- "$_grs_p" >/dev/null 2>&1; then
+            # Tracked path.
+            if ! git diff --quiet -- "$_grs_p" >/dev/null 2>&1; then
+                _grs_normal=$((_grs_normal + 1)) # worktree diff present
+            elif ! git diff --cached --quiet -- "$_grs_p" >/dev/null 2>&1; then
+                _grs_staged="${_grs_staged}${_grs_p}${_grs_nl}" # staged only
+            else
+                _grs_noop=$((_grs_noop + 1)) # nothing to restore
+            fi
+        else
+            # Not tracked.
+            if [ -e "$_grs_p" ]; then
+                _grs_untracked="${_grs_untracked}${_grs_p}${_grs_nl}"
+            else
+                _grs_missing="${_grs_missing}${_grs_p}${_grs_nl}"
+            fi
+        fi
+    done
+
+    # Gate — any accident (사고) or caution (주의) blocks the whole run so
+    # the user fixes the args and re-runs (no confusing partial restore).
+    if [ -n "$_grs_untracked" ] || [ -n "$_grs_missing" ] || [ -n "$_grs_staged" ]; then
+        if [ -n "$_grs_untracked" ]; then
+            ux_error "[사고] restore 대상이 아님 — untracked 경로 (git 이 추적하지 않음)"
+            printf '%s' "$_grs_untracked" | while IFS= read -r _grs_p; do
+                [ -n "$_grs_p" ] || continue
+                if git check-ignore -q -- "$_grs_p" >/dev/null 2>&1; then
+                    ux_bullet "삭제하려면: rm -rf -- $_grs_p  또는  git clean -fdx -- $_grs_p"
+                else
+                    ux_bullet "삭제하려면: rm -rf -- $_grs_p  또는  git clean -fd -- $_grs_p"
+                fi
+            done
+        fi
+        if [ -n "$_grs_missing" ]; then
+            ux_error "[사고] 그런 경로 없음 — 오타 의심"
+            printf '%s' "$_grs_missing" | while IFS= read -r _grs_p; do
+                [ -n "$_grs_p" ] || continue
+                ux_bullet "확인하려면: git status -- $_grs_p  (철자 점검)"
+            done
+        fi
+        if [ -n "$_grs_staged" ]; then
+            ux_warning "[주의] grs 는 unstage 하지 않음 — 스테이지된 변경만 있음"
+            printf '%s' "$_grs_staged" | while IFS= read -r _grs_p; do
+                [ -n "$_grs_p" ] || continue
+                ux_bullet "언스테이지하려면: grs --staged -- $_grs_p  (= grst)"
+            done
+        fi
+        return 1
+    fi
+
+    # No problems. All-no-op → one info line; otherwise transparent restore.
+    if [ "$_grs_normal" -eq 0 ] && [ "$_grs_noop" -gt 0 ]; then
+        ux_info "[정보] 되돌릴 변경 없음 (no-op) — 아무 것도 하지 않았습니다."
+        return 0
+    fi
+
+    git restore "$@"
+    return $?
+}

--- a/tests/bats/functions/git_restore.bats
+++ b/tests/bats/functions/git_restore.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# tests/bats/functions/git_restore.bats
+# Test the grs friendly `git restore` wrapper (issue #1146).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Emit a shell snippet that creates a fresh git repo in $tmp with one
+# committed file f.txt (content "original") and cd's into it.
+_grs_repo_setup() {
+    printf '%s' '
+        tmp=$(mktemp -d)
+        cd "$tmp"
+        git init -q -b main
+        git config user.email t@t; git config user.name t
+        printf "original\n" > f.txt
+        git add f.txt
+        git commit -q -m init
+    '
+}
+
+# --- function existence / override ---
+
+@test "bash: grs function exists" {
+    run_in_bash 'declare -f grs >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: grs resolves to a function (overrides the alias)" {
+    run_in_bash '[ "$(type -t grs)" = "function" ] && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _grs_help function exists" {
+    run_in_bash 'declare -f _grs_help >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: grs --help prints usage without touching git" {
+    run_in_bash 'grs --help'
+    assert_success
+    assert_output --partial "git restore"
+}
+
+# --- accident: untracked path ---
+
+@test "bash: grs on untracked path diagnoses and does not restore" {
+    run_in_bash "$(_grs_repo_setup)"'
+        printf "junk\n" > untracked.txt
+        grs untracked.txt; echo "RC=$?"
+        rm -rf "$tmp"
+    '
+    assert_output --partial "untracked"
+    assert_output --partial "git clean"
+    assert_output --partial "RC=1"
+}
+
+# --- accident: missing path (typo) ---
+
+@test "bash: grs on missing path diagnoses a typo" {
+    run_in_bash "$(_grs_repo_setup)"'
+        grs does-not-exist.txt; echo "RC=$?"
+        rm -rf "$tmp"
+    '
+    assert_output --partial "오타"
+    assert_output --partial "RC=1"
+}
+
+# --- caution: staged-only ---
+
+@test "bash: grs on staged-only path suggests --staged" {
+    run_in_bash "$(_grs_repo_setup)"'
+        printf "changed\n" > f.txt
+        git add f.txt
+        grs f.txt; echo "RC=$?"
+        rm -rf "$tmp"
+    '
+    assert_output --partial "unstage"
+    assert_output --partial "--staged"
+    assert_output --partial "RC=1"
+}
+
+# --- info: no-op ---
+
+@test "bash: grs on unchanged tracked path reports no-op with exit 0" {
+    run_in_bash "$(_grs_repo_setup)"'
+        grs f.txt; echo "RC=$?"
+        rm -rf "$tmp"
+    '
+    assert_output --partial "no-op"
+    assert_output --partial "RC=0"
+}
+
+# --- normal: real restore happens ---
+
+@test "bash: grs on a worktree-modified path actually restores it" {
+    run_in_bash "$(_grs_repo_setup)"'
+        printf "changed\n" > f.txt
+        grs f.txt >/dev/null 2>&1
+        printf "AFTER: "; cat f.txt
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "AFTER: original"
+}
+
+# --- passthrough: advanced flag skips preflight ---
+
+@test "bash: grs --staged unstages (advanced flag passes through)" {
+    run_in_bash "$(_grs_repo_setup)"'
+        printf "changed\n" > f.txt
+        git add f.txt
+        grs --staged f.txt
+        printf "STAGED: "; git diff --cached --name-only
+        echo "(end)"
+        rm -rf "$tmp"
+    '
+    assert_success
+    # After unstage, nothing remains staged.
+    assert_output --partial "STAGED: (end)"
+}
+
+# --- fallback: outside a git repo defers to raw git ---
+
+@test "bash: grs outside a git repo falls back to raw git" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        cd "$tmp"
+        grs some-file.txt 2>&1; echo "RC=$?"
+        rm -rf "$tmp"
+    '
+    # Raw git restore errors here (not a repo); we just must not crash our fn.
+    assert_output --partial "RC="
+    refute_output --partial "오타"
+}

--- a/tests/bats/functions/git_restore.bats
+++ b/tests/bats/functions/git_restore.bats
@@ -65,6 +65,19 @@ _grs_repo_setup() {
     assert_output --partial "RC=1"
 }
 
+# --- accident: untracked broken symlink (not a typo) ---
+
+@test "bash: grs on an untracked broken symlink diagnoses untracked, not typo" {
+    run_in_bash "$(_grs_repo_setup)"'
+        ln -s /nonexistent/target dangling.link
+        grs dangling.link; echo "RC=$?"
+        rm -rf "$tmp"
+    '
+    assert_output --partial "untracked"
+    refute_output --partial "오타"
+    assert_output --partial "RC=1"
+}
+
 # --- accident: missing path (typo) ---
 
 @test "bash: grs on missing path diagnoses a typo" {


### PR DESCRIPTION
## 요약

`grs`(Oh My Zsh git 플러그인 + `shell-common/aliases/git.sh` 의 `alias grs='git restore'`)를 자체 셸 함수로 오버라이드해, 흔한 실수/모호 상황에서 원시 git 에러 대신 **Verdict(한 줄 판정) + Next-action(추천 명령)** 을 출력한다. 정상 케이스는 추가 출력 없이 `git restore` 로 투명 통과한다(exit code 동일, raw git 과 구별 불가).

## 접근

- **실행 전 preflight 분류** — 사후 에러 번역이 아니라, git 이 에러조차 내지 않는 no-op / staged-only 케이스까지 사전 포착.
- 파일 분리(`shell-common/functions/git_restore.sh`) — `gh_host.sh` 헤더 스타일로 "왜"까지 기술. `git.sh` 의 `unalias → 함수 오버라이드 + emulate -L sh` 패턴 준수.

## 감지 케이스 (게이트 규칙)

| 상황 | 판정 | Next-action |
|------|------|-------------|
| untracked & 존재 | `[사고]` | `rm -rf` / `git clean -fd`(ignored 면 `-fdx`) |
| 미존재 (오타?) | `[사고]` | `git status` 로 확인 |
| staged diff 만 | `[주의]` | `grs --staged`(= `grst`) |
| 변경 없음 | `[정보]` | no-op, 아무 것도 안 함 |
| worktree diff | `[정상]` | 실제 restore |

- 사고·주의가 하나라도 있으면 → 진단 출력 + restore 미실행 + `return 1`.
- 문제 없으면 → 투명 통과. 전부 no-op → 정보 한 줄 + `return 0`.
- `--staged`/`-S`/`--source`/`-s`/`--worktree`/`-W`/`--patch` 등 고급 플래그·경로 인자 없음 → preflight 생략 통과. repo 밖 호출 → raw git 폴백.
- `grss`/`grst` 불변. git-help 의 grs 설명 행 갱신.

## 변경 파일

- `shell-common/functions/git_restore.sh` (신규)
- `tests/bats/functions/git_restore.bats` (신규, 11 tests)
- `shell-common/functions/git_help.sh` (grs 설명 갱신)

## 테스트

- `git_restore.bats` 11/11 통과 (함수 존재/오버라이드, untracked/미존재/staged-only/no-op/정상 restore, 고급 플래그 통과, repo 밖 폴백).
- shellcheck + shfmt(`-i 4`) clean · golden rules 통과.
- 전체 스위트의 기존 7개 실패는 이 worktree 환경(`./setup.sh` 미실행: `claude/plugin/*.json` 부재, codex budget, skill drift guard)의 사전존재 실패로, clean tree 에서 동일 재현 확인 — 본 PR 이 유발한 신규 실패 0.

Closes #1146
