### PR TITLE
fix(gcp-scan): preflight cherry-pick -n 이 [include] 토폴로지 git/.gitconfig 오염 방지 (#1149)

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -115,14 +115,18 @@ _gcp_scan_preflight_is_noop() {
         _gcfg2=""
     fi
     # Explicit template + fallback dir keeps mktemp portable to BSD/macOS, where
-    # a bare `mktemp` errors out (PR #1018 review).
+    # a bare `mktemp` errors out (PR #1018 review). On a `cp` failure after a
+    # successful mktemp, remove the now-orphan temp before clearing the var so a
+    # failed snapshot leaks no file (gemini PR #1150 review).
     if [ -n "$_gcfg1" ] && [ -f "$_gcfg1" ]; then
-        _gcfg1_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null) &&
-            cp "$_gcfg1" "$_gcfg1_bak" 2>/dev/null || _gcfg1_bak=""
+        if _gcfg1_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null); then
+            cp "$_gcfg1" "$_gcfg1_bak" 2>/dev/null || { rm -f "$_gcfg1_bak"; _gcfg1_bak=""; }
+        fi
     fi
     if [ -n "$_gcfg2" ] && [ -f "$_gcfg2" ]; then
-        _gcfg2_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null) &&
-            cp "$_gcfg2" "$_gcfg2_bak" 2>/dev/null || _gcfg2_bak=""
+        if _gcfg2_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null); then
+            cp "$_gcfg2" "$_gcfg2_bak" 2>/dev/null || { rm -f "$_gcfg2_bak"; _gcfg2_bak=""; }
+        fi
     fi
     git cherry-pick -n "$sha" >/dev/null 2>&1 || _gcp_cp_rc=$?
     # Restore BOTH snapshots UNCONDITIONALLY and immediately, before any further

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -67,46 +67,74 @@ _gcp_scan_preflight_is_noop() {
             return 1
         fi
     fi
-    # Self-protection against a config-poisoning probe (issue #1016). When the
-    # probed commit edits `git/.gitconfig` (symlinked from ~/.gitconfig), the
-    # `cherry-pick -n` below can leave the symlink target unreadable by git:
-    # a conflict writes `<<<<<<<` markers into it, and even a clean apply may
-    # stage a syntactically broken .gitconfig carried by the commit itself.
-    # From that instant EVERY subsequent git invocation — including the
-    # `git reset --hard HEAD` recovery — dies with `fatal: bad config line N`,
-    # so the breakage can never be cleared. Snapshot the real config file first
-    # with a plain `cp` (no git needed) so we can restore it before git reads it.
-    local _gcfg_real="" _gcfg_bak="" _gcp_cp_rc=0
-    # Resolve the file behind ~/.gitconfig portably: prefer GNU `readlink -f`,
-    # fall back to plain `readlink` + manual absolutisation for BSD/macOS (where
-    # `-f` is unsupported, PR #1018 review), then to the path itself when it is a
-    # regular (non-symlink) file.
-    _gcfg_real=$(readlink -f "${HOME}/.gitconfig" 2>/dev/null)
-    if [ -z "$_gcfg_real" ]; then
-        _gcfg_real=$(readlink "${HOME}/.gitconfig" 2>/dev/null)
-        if [ -n "$_gcfg_real" ]; then
-            case "$_gcfg_real" in
+    # Self-protection against a config-poisoning probe (issues #1016, #1149).
+    # When the probed commit edits `git/.gitconfig`, the `cherry-pick -n` below
+    # can leave the active git config unreadable: a conflict writes `<<<<<<<`
+    # markers into the worktree file, and even a clean apply may stage a
+    # syntactically broken .gitconfig carried by the commit itself. From that
+    # instant EVERY subsequent git invocation — including the `git reset --hard
+    # HEAD` recovery — dies with `fatal: bad config line N`, so the breakage can
+    # never be cleared. Snapshot the file(s) first with a plain `cp` (no git
+    # needed) so we can restore them before git reads config again.
+    #
+    # Two topologies poison DIFFERENT files, so snapshot BOTH candidate targets
+    # (#1016/#1018 covered only the symlink case, hence the #1149 regression):
+    #   * symlink:  ~/.gitconfig -> git/.gitconfig. `readlink -f` resolves to the
+    #     tracked file, which is both the active global config AND the cherry-pick
+    #     target — one file, caught by slot 1.
+    #   * [include]: ~/.gitconfig is a REGULAR file whose `[include] path =` pulls
+    #     in the tracked git/.gitconfig (documented setup-mode `internal`, see
+    #     git/AGENTS.md). `readlink -f` returns ~/.gitconfig itself — the wrong
+    #     file — so slot 1 misses the real target. Slot 2 snapshots the tracked
+    #     git/.gitconfig in the worktree, which is what the cherry-pick corrupts
+    #     regardless of topology.
+    local _gcfg1="" _gcfg1_bak="" _gcfg2="" _gcfg2_bak="" _gcp_cp_rc=0 _top=""
+    # Slot 1 — the file behind ~/.gitconfig. Prefer GNU `readlink -f`, fall back
+    # to plain `readlink` + manual absolutisation for BSD/macOS (where `-f` is
+    # unsupported, PR #1018 review), then to the path itself when it is a regular
+    # (non-symlink) file.
+    _gcfg1=$(readlink -f "${HOME}/.gitconfig" 2>/dev/null)
+    if [ -z "$_gcfg1" ]; then
+        _gcfg1=$(readlink "${HOME}/.gitconfig" 2>/dev/null)
+        if [ -n "$_gcfg1" ]; then
+            case "$_gcfg1" in
                 /*) ;;
-                *) _gcfg_real="${HOME}/${_gcfg_real}" ;;
+                *) _gcfg1="${HOME}/${_gcfg1}" ;;
             esac
         else
-            _gcfg_real="${HOME}/.gitconfig"
+            _gcfg1="${HOME}/.gitconfig"
         fi
     fi
-    if [ -n "$_gcfg_real" ] && [ -f "$_gcfg_real" ]; then
-        # Explicit template + fallback dir keeps mktemp portable to BSD/macOS,
-        # where a bare `mktemp` errors out (PR #1018 review).
-        _gcfg_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null) &&
-            cp "$_gcfg_real" "$_gcfg_bak" 2>/dev/null || _gcfg_bak=""
+    # Slot 2 — the tracked git/.gitconfig in this worktree (the real [include]
+    # target). Resolve the toplevel NOW, before `cherry-pick -n` corrupts config:
+    # `git rev-parse` reads config, so once the file carries markers this lookup
+    # would itself die with `fatal: bad config line`. Deduped against slot 1 so
+    # the symlink topology snapshots the shared file only once.
+    _top=$(git rev-parse --show-toplevel 2>/dev/null) && _gcfg2="${_top}/git/.gitconfig"
+    if [ -n "$_gcfg2" ] && [ "$_gcfg2" = "$_gcfg1" ]; then
+        _gcfg2=""
+    fi
+    # Explicit template + fallback dir keeps mktemp portable to BSD/macOS, where
+    # a bare `mktemp` errors out (PR #1018 review).
+    if [ -n "$_gcfg1" ] && [ -f "$_gcfg1" ]; then
+        _gcfg1_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null) &&
+            cp "$_gcfg1" "$_gcfg1_bak" 2>/dev/null || _gcfg1_bak=""
+    fi
+    if [ -n "$_gcfg2" ] && [ -f "$_gcfg2" ]; then
+        _gcfg2_bak=$(mktemp "${TMPDIR:-/tmp}/gcfg_bak.XXXXXX" 2>/dev/null) &&
+            cp "$_gcfg2" "$_gcfg2_bak" 2>/dev/null || _gcfg2_bak=""
     fi
     git cherry-pick -n "$sha" >/dev/null 2>&1 || _gcp_cp_rc=$?
-    # Restore the working-tree gitconfig UNCONDITIONALLY and immediately, before
-    # any further git command reads it — covers both the conflict path and the
+    # Restore BOTH snapshots UNCONDITIONALLY and immediately, before any further
+    # git command reads config — covers both the conflict path and the
     # clean-apply-of-broken-config path (PR #1018 review). `cp` touches only the
     # worktree, never the index, so the staged-diff no-op verdict below is
     # unaffected.
-    if [ -n "$_gcfg_bak" ] && [ -f "$_gcfg_bak" ]; then
-        cp "$_gcfg_bak" "$_gcfg_real" 2>/dev/null
+    if [ -n "$_gcfg1_bak" ] && [ -f "$_gcfg1_bak" ]; then
+        cp "$_gcfg1_bak" "$_gcfg1" 2>/dev/null
+    fi
+    if [ -n "$_gcfg2_bak" ] && [ -f "$_gcfg2_bak" ]; then
+        cp "$_gcfg2_bak" "$_gcfg2" 2>/dev/null
     fi
     if [ "$_gcp_cp_rc" -eq 0 ]; then
         git diff --cached --quiet && result=0
@@ -127,7 +155,8 @@ _gcp_scan_preflight_is_noop() {
             git diff --cached --quiet && result=0
         fi
     fi
-    [ -n "$_gcfg_bak" ] && rm -f "$_gcfg_bak"
+    [ -n "$_gcfg1_bak" ] && rm -f "$_gcfg1_bak"
+    [ -n "$_gcfg2_bak" ] && rm -f "$_gcfg2_bak"
     git reset --hard HEAD >/dev/null 2>&1
     [ "$had_stash" -eq 1 ] && git stash pop -q >/dev/null 2>&1
     return $result

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -615,6 +615,80 @@ FIXTURE
     assert_output --partial "UNTRACKED_KEPT"
 }
 
+# ---------------------------------------------------------------------------
+# Config-poisoning self-protection (issues #1016 / #1018 / #1149)
+#
+# A probed commit that edits the tracked `git/.gitconfig` makes `cherry-pick -n`
+# write `<<<<<<<` markers into the active git config, after which EVERY
+# subsequent git command — including the probe's own `git reset --hard HEAD`
+# recovery — dies with `fatal: bad config line N`, leaving the markers stuck.
+# #1016/#1018 defended the SYMLINK topology (~/.gitconfig -> git/.gitconfig);
+# #1149 is the [include] topology (~/.gitconfig is a regular file that pulls in
+# git/.gitconfig) where the old fix backed up the wrong file. Both must survive
+# the probe with config intact.
+# ---------------------------------------------------------------------------
+
+_gcp1149_make_repo() {
+    # Emits shell building a repo whose tracked git/.gitconfig conflicts between
+    # main and a side branch, so `cherry-pick -n side` writes conflict markers
+    # into git/.gitconfig. Leaves $repo + $side_sha set, cd'd into the repo on
+    # main. Identity comes from GIT_* env so the (deliberately mutated) config
+    # user.name never blocks commits.
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp1149.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        mkdir -p git
+        printf '[user]\n\tname = base\n' > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "init: tracked gitconfig"
+        git checkout -q -b side
+        printf '[user]\n\tname = sidevalue\n' > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "side: gitconfig name=sidevalue"
+        side_sha=$(git rev-parse HEAD)
+        git checkout -q main
+        printf '[user]\n\tname = mainvalue\n' > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "main: gitconfig name=mainvalue"
+FIXTURE
+}
+
+@test "preflight #1149: symlink topology — probe leaves ~/.gitconfig -> git/.gitconfig uncorrupted (#1016/#1018 regression guard)" {
+    run_in_bash "
+        $(_gcp1149_make_repo)
+        rm -f \"\$HOME/.gitconfig\"
+        ln -s \"\$repo/git/.gitconfig\" \"\$HOME/.gitconfig\"
+        _gcp_scan_preflight_is_noop \"\$side_sha\"; echo \"rc=\$?\"
+        git rev-parse HEAD >/dev/null 2>&1 && echo GIT_OK || echo GIT_BROKEN
+        grep -q '<<<<<<<' git/.gitconfig && echo MARKERS || echo NO_MARKERS
+        [ \"\$(git config --get user.name)\" = mainvalue ] && echo NAME_OK || echo NAME_BAD
+    "
+    assert_success
+    assert_output --partial "GIT_OK"
+    assert_output --partial "NO_MARKERS"
+    assert_output --partial "NAME_OK"
+}
+
+@test "preflight #1149: [include] topology — probe leaves the tracked git/.gitconfig uncorrupted" {
+    run_in_bash "
+        $(_gcp1149_make_repo)
+        rm -f \"\$HOME/.gitconfig\"
+        printf '[include]\n\tpath = %s/git/.gitconfig\n' \"\$repo\" > \"\$HOME/.gitconfig\"
+        # Sanity: the [include] is live before the probe.
+        [ \"\$(git config --get user.name)\" = mainvalue ] && echo PRE_OK || echo PRE_BAD
+        _gcp_scan_preflight_is_noop \"\$side_sha\"; echo \"rc=\$?\"
+        git rev-parse HEAD >/dev/null 2>&1 && echo GIT_OK || echo GIT_BROKEN
+        grep -q '<<<<<<<' git/.gitconfig && echo MARKERS || echo NO_MARKERS
+        [ \"\$(git config --get user.name)\" = mainvalue ] && echo NAME_OK || echo NAME_BAD
+    "
+    assert_success
+    assert_output --partial "PRE_OK"
+    assert_output --partial "GIT_OK"
+    assert_output --partial "NO_MARKERS"
+    assert_output --partial "NAME_OK"
+}
+
 @test "scan #913: content-dup commit (unique subject, different patch-id) skipped via no-op pre-flight, no conflict" {
     # The content-dup commit must reach the individual loop, so its patch-id
     # has to DIFFER from how HEAD acquired the same final content (else


### PR DESCRIPTION
## 요약

`gcp scan` 의 preflight 무해성 probe(`_gcp_scan_preflight_is_noop`)가 `[include]`
토폴로지에서 `git/.gitconfig` 를 오염시켜 git 전체가 불통되던 버그(#1016/#1018
재발)를 수정한다.

## 배경 / 근본 원인

`_gcp_scan_preflight_is_noop` 는 `cherry-pick -n` probe 직전 활성 git config 를
백업했다 복원하지만, 대상 파일을 `readlink -f ~/.gitconfig` **한 곳**으로만
해석했다.

- **symlink 토폴로지**(#1016/#1018 상정): `~/.gitconfig` → `git/.gitconfig`,
  `readlink -f` 가 실제 오염 대상으로 해석 → 정상 동작.
- **`[include]` 토폴로지**(setup-mode `internal`, `git/AGENTS.md` 지원 구성):
  `~/.gitconfig` 는 일반 파일이고 `[include] path = .../git/.gitconfig` 로 tracked
  config 를 포함한다. `readlink -f` 는 자기 자신을 반환 → **엉뚱한 파일**을
  백업하고, 실제 오염 대상 worktree `git/.gitconfig` 는 복원되지 않는다.
  `cherry-pick -n` 이 남긴 충돌 마커가 `[include]` 로 활성 config 에 로드되어
  이후 모든 git 명령(복구용 `git reset --hard HEAD` 포함)이 `fatal: bad config
  line N` 로 죽고, 마커는 영구 잔존한다.

## 변경 내용

- **`shell-common/functions/gcp_scan.sh`** — config 백업/복원을 2개 슬롯으로 확장:
  - slot 1 = `readlink -f ~/.gitconfig` (symlink 토폴로지, 기존 방어 유지)
  - slot 2 = `git rev-parse --show-toplevel`/`git/.gitconfig` — probe 가 config 를
    오염시키기 **전에** 미리 해석한 실제 tracked config 경로(`[include]` 대상)
  - 두 슬롯을 plain `cp` 로 스냅샷(동일 경로면 dedup)하고, 이후 어떤 git 명령이
    config 를 읽기 전에 즉시 무조건 복원.
- **`tests/bats/functions/gcp.bats`** — 회귀 테스트 2건: symlink · `[include]`
  토폴로지 각각에서 probe 이후 무오염(마커 없음 · git 명령 정상 · `user.name`
  보존) 검증. `[include]` 테스트는 수정 전 코드에서 `fatal: bad config line` 으로
  실제 재현됨을 확인.

## 검증

- `gcp.bats` 77 passed / 1 pre-existing failure(#51 `context-drift auto-skipped`,
  본 변경과 무관 — 미수정 원본에서도 동일 실패).
- 새 `#1149` 테스트 2건 통과, 수정 전 원본에서는 `[include]` 테스트가 재현 실패함을
  확인.

## Acceptance Criteria

- [x] `[include]` 토폴로지에서 `git/.gitconfig` 수정 커밋 섞인 scan 이 오염 없이 완료
- [x] symlink 토폴로지(#1018) 회귀 없음
- [x] preflight 이후 `git status` 등 모든 git 명령 정상, `fatal: bad config line` 미재발
- [x] 두 토폴로지 커버 bats 회귀 테스트 추가

Closes #1149
