### PR TITLE
fix(aliases): cd-ss 경로 갱신 + cd-at/cd-af 선언 분리

### DIFF
--- a/shell-common/aliases/directory.sh
+++ b/shell-common/aliases/directory.sh
@@ -40,10 +40,11 @@ alias cd-resource='cd ~/para/resource'
 alias cd-archive='cd ~/para/archive'
 
 # PROJECT directories
-alias cd-ss='cd ~/para/project/slea-ssem'
+alias cd-ss='cd ~/para/project/stock-steward'
 alias cd-ll='cd ~/para/project/litellm'
 alias cd-jv='cd ~/para/project/jiravis'
-alias cd-at='cd ~/para/project/agent-toolbox' cd-af='cd-at'
+alias cd-at='cd ~/para/project/agent-toolbox'
+alias cd-af='cd-at'
 alias cd-qf='cd ~/para/project/quantfolio'
 alias cd-kk='cd ~/para/project/karakeep'
 alias cd-jmcp='cd ~/para/project/jira-mcp'


### PR DESCRIPTION
## Summary
- `cd-ss` 가 리네이밍으로 사라진 경로(`slea-ssem`)를 가리켜 `cd` 가 실패하던 것을 실제 경로 `stock-steward` 로 교정
- 한 `alias` 명령에 뭉쳐 있던 `cd-at`/`cd-af` 선언을 두 줄로 분리 (가독성 향상, 동작 불변)

## Changes
- `fix(aliases)`: `cd-ss` → `~/para/project/stock-steward` 경로 교정; `cd-at`/`cd-af` 를 각각 독립된 `alias` 라인으로 분리 (`alias` 빌트인 다중 정의 → 명시적 2줄)

## Test plan
- [ ] `source shell-common/aliases/directory.sh` 후 `type cd-ss cd-at cd-af` 정의 확인
- [ ] `cd-ss` → `~/para/project/stock-steward`, `cd-af` → `cd-at` 위임 확인
- [ ] `mise run lint-sh` (shellcheck + shfmt) 통과

## Related
Fixes #1152

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
