### PR TITLE
feat(ports): 중앙 포트 레지스트리(PORTS.md) + decade-block 할당 규칙

### DIFF
--- a/PORTS.md
+++ b/PORTS.md
@@ -1,0 +1,78 @@
+# PORTS.md — 중앙 포트 레지스트리 (SSOT)
+
+## 목적
+
+유사 아키텍처(frontend + backend + DB)의 프로젝트를 여러 개 병행 운영할 때
+각 스택의 default 포트(Vite 5173 / uvicorn 8000 / Postgres 5432·5433)를 그대로
+쓰면 프로젝트끼리 충돌한다. 이 파일은 각 프로젝트에 **정수 index 하나만** 배정하면
+포트 3개가 공식으로 자동 결정되도록 하는 단일 진실 소스(SSOT)다. 새 프로젝트는
+"다음 빈 index"만 집으면 되고, 충돌 여부는 이 표 한 장으로 확인한다.
+
+## 할당 공식 (decade block)
+
+```
+port = 9200 + index*10 + role_offset
+
+role_offset:
+  backend  = 0
+  frontend = 1
+  db(host) = 2
+  # +3..9 는 여분 (worker / cache / metrics 등)
+```
+
+- 프로젝트당 10칸 블록을 통째로 예약 → 한 프로젝트의 포트가 다 붙어 있어 스캔·정리가 쉽다.
+- `9200`~`9299` 범위에 최대 10개 프로젝트(index 0..9)를 수용한다.
+- 주의: **9200 은 Elasticsearch/OpenSearch 기본 HTTP 포트**다. ES/OpenSearch 를
+  쓰는 프로젝트가 생기면 그때 해당 블록(index 0)만 피한다.
+
+## 레지스트리
+
+| index | project       | backend | frontend | db(host) | 비고      |
+|------:|---------------|--------:|---------:|---------:|-----------|
+| 0     | stock-steward | 9200    | 9201     | 9202     | 적용 완료 |
+| 1     | (TBD)         | 9210    | 9211     | 9212     |           |
+| 2     | (TBD)         | 9220    | 9221     | 9222     |           |
+| 3     | (TBD)         | 9230    | 9231     | 9232     |           |
+| 4     | (TBD)         | 9240    | 9241     | 9242     |           |
+| 5     | (TBD)         | 9250    | 9251     | 9252     |           |
+| 6     | (TBD)         | 9260    | 9261     | 9262     |           |
+| 7     | (TBD)         | 9270    | 9271     | 9272     |           |
+| 8     | (TBD)         | 9280    | 9281     | 9282     |           |
+| 9     | (TBD)         | 9290    | 9291     | 9292     |           |
+
+> index 는 **유일**해야 한다. 중복·공식 이탈 여부는
+> `scripts/check_port_registry.sh` 로 검증한다.
+
+## 새 프로젝트 index 배정 절차
+
+1. 위 표에서 `(TBD)` 인 가장 작은 index 를 고른다 (= "다음 빈 index").
+2. 해당 행의 `project` 를 실제 이름으로 바꾸고 `비고` 를 채운다.
+3. 공식으로 나온 3개 포트를 프로젝트 `.env.example` 에 문서화한다 (아래 스니펫).
+4. `sh scripts/check_port_registry.sh` 로 index 중복·공식 이탈이 없는지 확인한다.
+5. 이 변경을 커밋한다 — 표가 곧 예약 기록이다.
+
+index 0..9 를 모두 소진하면 `9300` 대역으로 블록을 확장하거나, 쓰지 않는
+프로젝트를 회수(recycle)한다.
+
+## 프로젝트 쪽 규약
+
+포트는 코드가 아니라 **설정**으로 다룬다. 프로젝트 config 는 env(`.env`)에서
+포트를 읽고, `.env.example` 에 블록을 문서화한다(`.env` 는 gitignore).
+
+index=1 프로젝트의 `.env.example` 예시:
+
+```dotenv
+# 중앙 포트 레지스트리(dotfiles/PORTS.md) index=1
+# port = 9200 + index*10 + role_offset
+BACKEND_PORT=9210
+FRONTEND_PORT=9211
+DB_PORT=9212
+```
+
+stock-steward(index 0)에는 이미 decade-block + env-driven 설정이 적용되어 있다.
+
+## 참고
+
+- 스캐폴딩/템플릿 자동 주입 훅(issue #1154 선택 항목 2)은 현재 dotfiles 에 공용
+  프로젝트 스캐폴더가 없어 보류한다. 스캐폴더가 생기면 그때 `.env.example` 에 위
+  블록을 주입하는 훅을 추가한다.

--- a/scripts/check_port_registry.sh
+++ b/scripts/check_port_registry.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# check_port_registry.sh — PORTS.md 포트 레지스트리 검증 (issue #1154)
+#
+# 정책:
+#   - index 컬럼은 정수이며 레지스트리 안에서 유일해야 한다 (중복 → 종료 코드 1).
+#   - 각 행의 backend/frontend/db(host) 포트는 decade-block 공식과 일치해야 한다:
+#       backend  = 9200 + index*10
+#       frontend = backend + 1
+#       db(host) = backend + 2
+#     (TBD) 행도 검증 대상 — 예약 블록이 공식에서 어긋나면 실패한다.
+#
+# 사용:
+#   sh scripts/check_port_registry.sh                   # repo root 기준 PORTS.md
+#   PORTS_FILE=path/to/PORTS.md sh scripts/check_port_registry.sh
+
+set -eu
+
+PORTS_FILE="${PORTS_FILE:-PORTS.md}"
+BASE_PORT=9200
+
+if [ ! -f "$PORTS_FILE" ]; then
+    echo "check-ports: '$PORTS_FILE' 파일을 찾을 수 없습니다." >&2
+    exit 2
+fi
+
+errors=0
+rows=0
+seen=" " # 공백 구분 index 목록 (중복 탐지용)
+
+is_int() {
+    case "$1" in
+    "" | *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+    esac
+}
+
+# 셀 앞뒤 공백 제거
+trim() {
+    _s="$1"
+    while :; do
+        case "$_s" in
+        " "*) _s="${_s# }" ;;
+        *" ") _s="${_s% }" ;;
+        *) break ;;
+        esac
+    done
+    printf '%s' "$_s"
+}
+
+while IFS= read -r line; do
+    # 표 행만 처리 ('|' 로 시작)
+    case "$line" in
+    \|*) ;;
+    *) continue ;;
+    esac
+
+    # '|' 로 필드 분해 (glob 방지 위해 noglob).
+    # 선행 '|' 때문에 $1 은 빈 필드; 데이터 컬럼은 2..6.
+    old_ifs="$IFS"
+    set -f
+    IFS='|'
+    # shellcheck disable=SC2086
+    set -- $line
+    IFS="$old_ifs"
+    set +f
+
+    idx="$(trim "${2-}")"
+    be="$(trim "${4-}")"
+    fe="$(trim "${5-}")"
+    db="$(trim "${6-}")"
+
+    # 헤더/구분선/설명 행은 index 가 정수가 아니므로 자연히 걸러진다.
+    is_int "$idx" || continue
+
+    rows=$((rows + 1))
+
+    # 중복 index 검사
+    case "$seen" in
+    *" $idx "*)
+        echo "FAIL  index=$idx 가 중복됩니다." >&2
+        errors=$((errors + 1))
+        ;;
+    *)
+        seen="$seen$idx "
+        ;;
+    esac
+
+    # decade-block 공식 일치 검사
+    exp_be=$((BASE_PORT + idx * 10))
+    exp_fe=$((exp_be + 1))
+    exp_db=$((exp_be + 2))
+
+    if is_int "$be" && [ "$be" -ne "$exp_be" ]; then
+        echo "FAIL  index=$idx backend=$be, 공식값 $exp_be 와 불일치." >&2
+        errors=$((errors + 1))
+    fi
+    if is_int "$fe" && [ "$fe" -ne "$exp_fe" ]; then
+        echo "FAIL  index=$idx frontend=$fe, 공식값 $exp_fe 와 불일치." >&2
+        errors=$((errors + 1))
+    fi
+    if is_int "$db" && [ "$db" -ne "$exp_db" ]; then
+        echo "FAIL  index=$idx db=$db, 공식값 $exp_db 와 불일치." >&2
+        errors=$((errors + 1))
+    fi
+done <"$PORTS_FILE"
+
+echo "check-ports: rows=${rows} errors=${errors} (file: ${PORTS_FILE})"
+
+[ "$errors" -eq 0 ] || exit 1

--- a/scripts/check_port_registry.sh
+++ b/scripts/check_port_registry.sh
@@ -18,6 +18,15 @@ set -eu
 PORTS_FILE="${PORTS_FILE:-PORTS.md}"
 BASE_PORT=9200
 
+# 기본값(PORTS.md)이 현재 디렉터리에 없으면 repo 루트에서 찾아 하위
+# 디렉터리 실행을 지원한다. 명시적 PORTS_FILE 은 건드리지 않는다.
+if [ "$PORTS_FILE" = "PORTS.md" ] && [ ! -f "$PORTS_FILE" ]; then
+    _repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "$_repo_root" ] && [ -f "$_repo_root/PORTS.md" ]; then
+        PORTS_FILE="$_repo_root/PORTS.md"
+    fi
+fi
+
 if [ ! -f "$PORTS_FILE" ]; then
     echo "check-ports: '$PORTS_FILE' 파일을 찾을 수 없습니다." >&2
     exit 2
@@ -34,20 +43,14 @@ is_int() {
     esac
 }
 
-# 셀 앞뒤 공백 제거
+# 셀 앞뒤 공백 제거 (POSIX 매개변수 확장 — 루프 없이 한 번에)
 trim() {
-    _s="$1"
-    while :; do
-        case "$_s" in
-        " "*) _s="${_s# }" ;;
-        *" ") _s="${_s% }" ;;
-        *) break ;;
-        esac
-    done
+    _s="${1#"${1%%[! ]*}"}"   # 선행 공백 제거
+    _s="${_s%"${_s##*[! ]}"}" # 후행 공백 제거
     printf '%s' "$_s"
 }
 
-while IFS= read -r line; do
+while IFS= read -r line || [ -n "$line" ]; do
     # 표 행만 처리 ('|' 로 시작)
     case "$line" in
     \|*) ;;
@@ -105,5 +108,11 @@ while IFS= read -r line; do
 done <"$PORTS_FILE"
 
 echo "check-ports: rows=${rows} errors=${errors} (file: ${PORTS_FILE})"
+
+# 유효 행이 하나도 없으면 표 형식이 깨졌다는 신호 — 성공 오탐 방지.
+if [ "$rows" -eq 0 ]; then
+    echo "FAIL  유효한 포트 배정 행을 찾지 못했습니다. 표 형식을 확인하세요." >&2
+    exit 1
+fi
 
 [ "$errors" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- dotfiles 레벨에 중앙 포트 레지스트리 `PORTS.md` 를 SSOT 로 도입해, 유사 아키텍처(frontend + backend + DB) 프로젝트를 여러 개 병행 운영할 때 발생하는 포트 충돌을 정수 index 하나로 해결한다.
- 프로젝트당 `port = 9200 + index*10 + role_offset` decade-block 을 통째로 예약해, 한 프로젝트의 포트가 붙어 있어 스캔·정리가 쉽다.

## Changes
- `PORTS.md` (신규): decade-block 할당 공식 + index 0..9 레지스트리 표(stock-steward = index 0) + 새 프로젝트 index 배정 절차 + `.env.example` 프로젝트 규약. 9200 = Elasticsearch 기본 포트 주의 노트 포함.
- `scripts/check_port_registry.sh` (신규, 이슈 선택 항목 3): `PORTS.md` 표를 파싱해 index 중복·공식 이탈을 검출하는 POSIX `sh` 린터. sibling `scripts/lint_docs_filenames.sh` 스타일을 따른다.
- 선택 항목 2(스캐폴딩 훅)는 공용 프로젝트 스캐폴더 부재로 보류 — `PORTS.md` 참고 절에 명시.

## Test plan
- [x] `shellcheck` + `shfmt -i 4 -d` — check_port_registry.sh 통과
- [x] `sh scripts/check_port_registry.sh` — PORTS.md 대상 `errors=0` (positive)
- [x] negative: index 중복 + 공식 이탈 fixture → 5건 검출, exit 1
- [x] `mise run lint` clean (errors=0)
- [x] `mise run test` — 1187 passed

## Related
Closes #1154

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
