### PR TITLE
fix(gcp-scan): Stage-1.6 context-drift 커밋을 no-op 로 위임 (#913 회귀 해소)

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -241,6 +241,57 @@ EOF
     return $rc
 }
 
+_gcp_scan_conflict_adds_new_content() {
+    # Context-drift discriminator (issue #913 regression, #1151). Returns 0
+    # (true) when cherry-picking commit $1 introduces content to file $2 that
+    # HEAD does NOT already contain — a GENUINE content conflict. Returns 1
+    # (false) when every line the commit adds (relative to its parent, the
+    # cherry-pick merge base) is already present in HEAD: the textual conflict
+    # is pure context drift (an unrelated adjacent region moved), so the commit
+    # is effectively a no-op that Stage-2's merge probe will absorb as "already
+    # in HEAD" rather than a conflict a human must resolve.
+    #
+    # Why this exists: `git merge-tree` flags BOTH a real same-line divergence
+    # (HEAD and the commit set the line to different values) AND a spurious
+    # adjacency conflict (the commit's real change already matches HEAD, but an
+    # unrelated neighbouring line drifted) as the same rc=1 conflict. Stage-2's
+    # reset-conflicted-to-HEAD probe cannot tell them apart either — it reports
+    # both as no-ops. The line-level "did theirs add anything HEAD lacks?" test
+    # below is what distinguishes the two, letting Stage-1.6 defer the drift
+    # case to Stage-2 (no-op) while still flagging the real one. Non-destructive:
+    # reads blobs only (no checkout / cherry-pick).
+    local sha="$1" f="$2" parent td
+    parent=$(git rev-parse -q --verify "${sha}^1" 2>/dev/null) || return 0
+    td=$(mktemp -d "${TMPDIR:-/tmp}/gcp_drift.XXXXXX" 2>/dev/null) || return 0
+    # base = the file in the commit's parent (the cherry-pick merge base);
+    # ours = HEAD; theirs = the commit. A missing base blob (the commit ADDS the
+    # file) leaves an empty base so every theirs line counts as added.
+    git cat-file -p "${parent}:${f}" >"${td}/base" 2>/dev/null || : >"${td}/base"
+    git cat-file -p "HEAD:${f}" >"${td}/ours" 2>/dev/null || : >"${td}/ours"
+    if ! git cat-file -p "${sha}:${f}" >"${td}/theirs" 2>/dev/null; then
+        # The commit has no such file (a delete) — it adds no content. Treat as
+        # drift (return 1); the delete, if it matters, surfaces at cherry-pick.
+        rm -rf "$td"
+        return 1
+    fi
+    # A theirs line that is absent from BOTH base (so the commit added it) AND
+    # ours (so HEAD lacks it) is genuinely new content -> real conflict (rc 0).
+    # Set membership over whole lines; no sort needed (order-independent).
+    # NOTE: a bare `exit` (not `exit 0`) is required on a hit — `exit 0` would
+    # still run END, whose `exit 1` would override it back to "drift".
+    if awk '
+        FILENAME == B { base[$0] = 1; next }
+        FILENAME == O { ours[$0] = 1; next }
+        { if (!($0 in base) && !($0 in ours)) { found = 1; exit } }
+        END { exit(found ? 0 : 1) }
+    ' B="${td}/base" O="${td}/ours" "${td}/base" "${td}/ours" "${td}/theirs"; then
+        rm -rf "$td"
+        return 0
+    fi
+    rm -rf "$td"
+    return 1
+}
+
 _gcp_scan_predict_content_conflict() {
     # Content-conflict pre-check (issue #1037, extends Stage-1.5 #1033). Returns
     # 1 when cherry-picking commit $1 onto HEAD is predicted to hit a 3-way
@@ -248,7 +299,8 @@ _gcp_scan_predict_content_conflict() {
     # that exists on both sides. This is the case Stage-1.5 does NOT cover
     # (modify/delete of a file absent from base); here both sides edited the
     # same lines. Returns 0 when the merge is predicted clean OR when the
-    # verdict is deferred (see the --author=all guard below).
+    # verdict is deferred (see the --author=all guard AND the context-drift
+    # guard below).
     #
     # Probe: `git merge-tree --write-tree --merge-base=<sha>^ HEAD <sha>`. This
     # drives git's REAL merge engine as a non-destructive dry-run (no checkout,
@@ -273,6 +325,15 @@ _gcp_scan_predict_content_conflict() {
     # Only when EVERY conflicting file is covered by a precedent is the verdict
     # deferred (return 0). Mirrors Stage-1.5's pick_list membership guard, so
     # --author=all stays false-positive-free.
+    #
+    # Context-drift guard (issue #913 regression, #1151): a conflicting file
+    # whose divergence is pure context drift — the commit's real change already
+    # matches HEAD and only an unrelated adjacent region moved — is NOT a
+    # content conflict. `_gcp_scan_conflict_adds_new_content` detects it (theirs
+    # adds no line HEAD lacks) so the commit is left for Stage-2, which absorbs
+    # it as a no-op ("already in HEAD"), instead of surfacing a phantom conflict
+    # the user is told to resolve by hand. Only a file where the commit brings
+    # content HEAD lacks flags the commit.
     #
     # Prints the first guaranteed-conflict file path to stdout when it flags.
     local sha="$1" pick_list="$2"
@@ -323,8 +384,14 @@ $other_files" in
 $f
 "*) ;;
             *)
-                printf '%s\n' "$f"
-                return 1
+                # Uncovered by any precedent — but flag ONLY if the commit
+                # brings content HEAD lacks. A pure context-drift conflict
+                # (issue #913/#1151) adds nothing new and is left for Stage-2's
+                # merge probe to absorb as a no-op, not surfaced as a conflict.
+                if _gcp_scan_conflict_adds_new_content "$sha" "$f"; then
+                    printf '%s\n' "$f"
+                    return 1
+                fi
                 ;;
         esac
     done <<EOF
@@ -790,7 +857,10 @@ EOF
     # cherry-pick merge) and skip the ones predicted to conflict, mirroring the
     # Stage-1.5 warning + counter pattern. Runs BEFORE the Stage-2 noop
     # pre-flight so we never surface a conflict on a commit that is genuinely
-    # redundant.
+    # redundant. A predicted conflict that is pure context drift (the commit's
+    # real change already matches HEAD, issue #913/#1151) is deliberately NOT
+    # flagged here — it falls through as a survivor and Stage-2 absorbs it as a
+    # no-op, so a commit already in HEAD is never mislabelled a content conflict.
     local conflict_list="" conflict_count=0 conflict_survivor_list=""
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -274,16 +274,31 @@ _gcp_scan_conflict_adds_new_content() {
         rm -rf "$td"
         return 1
     fi
-    # A theirs line that is absent from BOTH base (so the commit added it) AND
-    # ours (so HEAD lacks it) is genuinely new content -> real conflict (rc 0).
+    # The commit brings content HEAD lacks (rc 0, real) in EITHER direction:
+    #   * an ADD  — a theirs line absent from both base (the commit added it)
+    #     and ours (HEAD lacks it); or
+    #   * a DELETE — a base line absent from theirs (the commit removed it) yet
+    #     still present in ours (HEAD has not removed it).
+    # Checking adds alone would misclassify a delete-only commit as drift and
+    # let Stage-2 silently skip it — silent data loss (gemini PR #1157 review).
     # Set membership over whole lines; no sort needed (order-independent).
     # NOTE: a bare `exit` (not `exit 0`) is required on a hit — `exit 0` would
     # still run END, whose `exit 1` would override it back to "drift".
     if awk '
         FILENAME == B { base[$0] = 1; next }
         FILENAME == O { ours[$0] = 1; next }
-        { if (!($0 in base) && !($0 in ours)) { found = 1; exit } }
-        END { exit(found ? 0 : 1) }
+        {
+            theirs[$0] = 1
+            if (!($0 in base) && !($0 in ours)) { found = 1; exit }
+        }
+        END {
+            if (!found) {
+                for (l in base) {
+                    if (!(l in theirs) && (l in ours)) { found = 1; break }
+                }
+            }
+            exit(found ? 0 : 1)
+        }
     ' B="${td}/base" O="${td}/ours" "${td}/base" "${td}/ours" "${td}/theirs"; then
         rm -rf "$td"
         return 0


### PR DESCRIPTION
## Summary
- `gcp scan` 의 Stage-1.6(content-conflict, #1037) 가 Stage-2(no-op, #913) 앞에서 실행되며 **context-drift 커밋**(내용은 이미 HEAD 에 있으나 인접 영역이 밀려 3-way 로는 충돌처럼 보이는 커밋)을 "predicted content conflict" 로 오분류해 스킵하던 #913 회귀를 해소한다.
- 단순 순서 교체가 아니라 Stage-1.6 에 비파괴 line-level 판별을 추가하는 방식(이슈 옵션 2)으로, #1037 의 dry-run-first 설계 의도를 보존한다.

## Changes
- `shell-common/functions/gcp_scan.sh`:
  - `_gcp_scan_conflict_adds_new_content` 헬퍼 신설 — theirs(커밋)가 base(부모) 대비 추가한 라인 중 HEAD 에 없는 것이 하나라도 있으면 **진짜 content conflict**, 전부 이미 HEAD 에 있으면 **context-drift** 로 판정. blob 만 읽어 cherry-pick/checkout 없이 동작(비파괴).
  - `_gcp_scan_predict_content_conflict` 의 uncovered 브랜치가 위 판별이 "새 내용 있음"일 때만 flag 하도록 수정. context-drift 는 survivor 로 흘려 Stage-2 가 no-op 로 흡수.

## 근본 원인
`git merge-tree` 는 (a) 실제 같은 줄 발산과 (b) 인접 컨텍스트 드리프트를 모두 `rc=1` 충돌로 보고하고, Stage-2 의 reset-conflicted-to-HEAD 프로브도 둘 다 no-op 로 보고한다. 따라서 단순 순서 교체(옵션 1)로는 #1037 이 회귀한다. line-level "theirs 가 HEAD 에 없는 라인을 추가했는가" 판별이 두 경우를 구분하는 유일한 신호다.

## Test plan
- [x] `scan #913: context-drift commit auto-skipped by pre-flight` — "Already in HEAD (no-op)" 로 집계 (AC 1)
- [x] `#1037` content-conflict 예측 테스트들 회귀 없음 (AC 2)
- [x] 진짜 content conflict 는 계속 "predicted content conflict" 로 스킵 (AC 3)
- [x] `tests/bats/functions/gcp.bats` 78개 전부 통과

## Related
Closes #1151

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~3 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~3 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
