### PR TITLE
feat(gh-issue-flow): PR 직후 품질 게이트(codex∥simplify) + out-of-date 동기화 스텝

### DIFF
--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -3,7 +3,7 @@
 
 Reads a Stop event JSON from stdin, parses the conversation transcript, and
 emits a `block` decision when the model tries to end its turn while a
-gh-issue-flow chain is still in progress (5 sub-skills + Step 3 report).
+gh-issue-flow chain is still in progress (6 sub-skills + Step 3 report).
 
 Failure mode being mitigated: the model self-authors a markdown success
 report between Skill() calls in Step 2 of gh-issue-flow and treats that
@@ -60,15 +60,29 @@ def _trace(message: str, *, layer: str | None = None) -> None:
 
 
 # Sub-skill names accepted in either hyphen or colon namespace form.
-# Order matters — it's the canonical 5-step gh-issue-flow chain.
+# Order matters — it's the canonical 6-step gh-issue-flow chain.
 EXPECTED_CHAIN: list[tuple[str, str]] = [
     ("gh-issue-implement", "gh:issue-implement"),
     ("gh-commit", "gh:commit"),
     ("gh-pr", "gh:pr"),
     ("devx-schedule", "devx:schedule"),
     ("gh-pr-resolve-conflict", "gh:pr-resolve-conflict"),
+    ("gh-pr-resolve-outdated", "gh:pr-resolve-outdated"),
 ]
 SUB_SKILL_NAMES: set[str] = {n for pair in EXPECTED_CHAIN for n in pair}
+
+# Human-facing SKILL.md step labels, parallel to EXPECTED_CHAIN. These are
+# NOT derived arithmetically because gh-pr-resolve-outdated is labeled
+# "Step 2.5.1" in SKILL.md (it runs after the "Step 2.5" resolve-conflict
+# step), not "Step 2.6". Keep this list in lockstep with EXPECTED_CHAIN.
+STEP_LABELS: list[str] = [
+    "Step 2.1",
+    "Step 2.2",
+    "Step 2.3",
+    "Step 2.4",
+    "Step 2.5",
+    "Step 2.5.1",
+]
 
 # Terminal Step 3 markers — presence in any assistant text after the
 # gh-issue-flow boundary means the flow has finished and the model may stop.
@@ -302,8 +316,19 @@ def _next_step_label(seen: list[str]) -> str:
             next_idx = i + 1
     if next_idx >= len(canonical):
         return "Step 3 — emit the final 'gh:issue-flow complete (#N)' report"
-    step_num = next_idx + 1  # 1-based for human display
-    return f"Step 2.{step_num} — Skill({canonical[next_idx]})"
+    if canonical[next_idx] == "devx-schedule":
+        # gh-pr just completed. Before the rebase steps the model must run
+        # the parallel Agent-based quality gate (2.3.1 gh:pr-review --ai codex
+        # ∥ 2.3.2 /simplify), then commit+push any simplify changes. That gate
+        # is dispatched via Agent/git tools, not Skill() calls, so it is not
+        # tracked in EXPECTED_CHAIN — remind the model here.
+        return (
+            "the quality gate first if not already done (2.3.1 gh:pr-review "
+            "--ai codex ∥ 2.3.2 /simplify via 2 parallel Agent subagents, "
+            "then 2.3.3 commit+push any simplify changes BEFORE the rebase "
+            f"steps), then {STEP_LABELS[next_idx]} — Skill({canonical[next_idx]})"
+        )
+    return f"{STEP_LABELS[next_idx]} — Skill({canonical[next_idx]})"
 
 
 def main() -> int:
@@ -347,14 +372,14 @@ def main() -> int:
 
     next_label = _next_step_label(seen)
     reason = (
-        f"gh-issue-flow incomplete: {len(seen)}/5 sub-skills invoked since the "
+        f"gh-issue-flow incomplete: {len(seen)}/{len(EXPECTED_CHAIN)} sub-skills invoked since the "
         f"flow started, and no terminal Step 3 report ('gh:issue-flow complete' "
         f"or 'gh:issue-flow stopped at step') has been emitted yet. Per the "
         f"CRITICAL CONTRACT in claude/skills/gh-issue-flow/SKILL.md, you MUST "
         f"continue immediately. Next action: {next_label}. Output ZERO "
         f"conversational text — no recap, no markdown summary, no per-step "
         f"bullets, no progress headers — just the next Skill() call (or, if all "
-        f"5 sub-skills are already done, the Step 3 success/failure report "
+        f"{len(EXPECTED_CHAIN)} sub-skills are already done, the Step 3 success/failure report "
         f"verbatim per the SKILL.md template)."
     )
     return _block(reason, layer="L1.5")

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: gh:issue-flow
 description: >-
-  Composition skill that chains gh:issue-implement → gh:commit → gh:pr
-  → devx:schedule (pr-reply, 5 min) → gh:pr-resolve-conflict for a single
-  issue number. Use when the user runs /gh:issue-flow, /gh-issue-flow, or
-  asks "issue #16 처음부터 PR까지 자동으로", "이슈 구현하고 커밋하고 PR까지
-  한방에", "full flow on #42". Uses direct implementation mode only — for
-  plan/brainstorming modes, use the atomic gh:issue-implement skill
-  manually. Stops on first step failure with a resume-instructions report.
-  Precondition: already on a feature branch in a dedicated worktree.
-  Accepts `<issue-number> [remote]` and `-h`/`--help`/`help`.
-allowed-tools: Bash, Read, Grep
+  Composition skill that chains gh:issue-implement → gh:commit → gh:pr →
+  a parallel post-PR quality gate (codex review ∥ /simplify) → devx:schedule
+  (pr-reply, 5 min) → gh:pr-resolve-conflict → gh:pr-resolve-outdated
+  (out-of-date base sync) for a single issue number. Use when the user runs
+  /gh:issue-flow, /gh-issue-flow, or asks "issue #16 처음부터 PR까지 자동으로",
+  "이슈 구현하고 커밋하고 PR까지 한방에", "full flow on #42". Uses direct
+  implementation mode only — for plan/brainstorming modes, use the atomic
+  gh:issue-implement skill manually. Stops on first step failure with a
+  resume-instructions report. Precondition: already on a feature branch in a
+  dedicated worktree. Accepts `<issue-number> [remote]` and `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Grep, Agent
 metadata:
   model_recommendation:
     tier: sonnet
-    reason: "composite orchestration (implement→commit→PR→reply→rebase); chain dispatcher with stop-on-error"
+    reason: "composite orchestration (implement→commit→PR→gate→reply→rebase); chain dispatcher with stop-on-error"
     claude: prefer
     non_claude: advisory-only
 ---
@@ -25,18 +26,21 @@ metadata:
 
 **Recurring failure mode: early-stop after Step 2.x.** Three layered guards
 prevent it — (1) `--no-next-hint` on Step 2.1, (2) zero conversational text
-between the five `Skill()` calls in Step 2, (3) the harness Stop hook
+between the six `Skill()` calls in Step 2, (3) the harness Stop hook
 (`claude/hooks/gh_issue_flow_stop_guard.py`). **Do not remove any of them.**
-Full failure history (#333, #383), guard rationale, and the
-backstop-not-a-license rule are in `references/critical-contract.md` — read
-it before editing Step 2.
+Tool calls between Skill() calls are permitted — the Agent dispatch for the
+2.3.1/2.3.2 quality gate and the Bash commit+push of 2.3.3 are fine; only
+conversational prose (recaps, headers, bullets) is forbidden. Terminal-marker
+gating in the hook covers those tool steps automatically. Full failure history
+(#333, #383) and guard rationale: `references/critical-contract.md`.
 
 ## Help
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
-its content verbatim, then stop. No API calls. The help output explicitly
-names the 5 chained skills: gh:issue-implement, gh:commit, gh:pr,
-devx:schedule, gh:pr-resolve-conflict.
+its content verbatim, then stop. No API calls. The help output names the 6
+chained skills (gh:issue-implement, gh:commit, gh:pr, devx:schedule,
+gh:pr-resolve-conflict, gh:pr-resolve-outdated) and the parallel post-PR
+quality gate (codex review ∥ /simplify).
 
 ## Step 1: Parse Args
 
@@ -49,41 +53,36 @@ devx:schedule, gh:pr-resolve-conflict.
 No `mode` arg — implementation is always `direct`. Record
 `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 2.6.
 
-## Step 2: Chain the 5 Skills
+## Step 2: Chain the Skills
 
 Invoke in order; each runs only if the previous succeeded. **Zero
 conversational text between the calls — no recap, headers, or progress
-bullets** (see CRITICAL CONTRACT). After each call, immediately invoke the next.
+bullets** (see CRITICAL CONTRACT). Tool calls for the quality gate are allowed;
+prose is not. After each call, immediately proceed to the next.
 
 1. **Step 2.1 — gh:issue-implement** — `--no-next-hint` is load-bearing.
-   ```
-   Skill(gh:issue-implement, "<N> direct <remote> --no-next-hint")
-   ```
+   `Skill(gh:issue-implement, "<N> direct <remote> --no-next-hint")`
 2. **Step 2.2 — gh:commit** (only if 2.1 succeeded) — auto-detects the issue
-   number from the conversation.
-   ```
-   Skill(gh:commit)
-   ```
+   number from the conversation. `Skill(gh:commit)`
 3. **Step 2.3 — gh:pr** (only if 2.2 succeeded) — ensures `Closes #<N>`;
-   extract `<PR_NUM>` from the PR URL in the output.
-   ```
-   Skill(gh:pr, "<N>")
-   ```
-4. **Step 2.4 — devx:schedule** (only if 2.3 succeeded) — schedules
+   extract `<PR_NUM>` from the PR URL. `Skill(gh:pr, "<N>")`
+4. **Steps 2.3.1 ∥ 2.3.2 ∥ 2.3.3 — quality gate** (only if 2.3 succeeded;
+   soft-fail). Dispatch 2.3.1 (codex review, if `command -v codex`) and 2.3.2
+   (`/simplify`) as **two parallel Agent subagents in one turn**, then 2.3.3
+   commits + pushes any simplify changes — this **must run before 2.5/2.5.1**
+   (dirty tree breaks rebase). Detail: `references/quality-gate-step.md`.
+5. **Step 2.4 — devx:schedule** (only if the gate finished) — schedules
    `/gh-pr-reply <PR_NUM>` 5 min after PR creation.
-   ```
-   Skill(devx:schedule, "--time 5 \"/gh-pr-reply <PR_NUM>\"")
-   ```
-5. **Step 2.5 — gh:pr-resolve-conflict** (only if 2.4 succeeded) —
+   `Skill(devx:schedule, "--time 5 \"/gh-pr-reply <PR_NUM>\"")`
+6. **Step 2.5 — gh:pr-resolve-conflict** (only if 2.4 succeeded) —
    rebase-resolve; a fresh PR usually prints "이미 충돌 없음 — skip".
-   ```
-   Skill(gh:pr-resolve-conflict, "<PR_NUM>")
-   ```
-6. **Step 2.6 — Post AI Metrics to Issue** (only if 2.5 succeeded;
+   `Skill(gh:pr-resolve-conflict, "<PR_NUM>")`
+7. **Step 2.5.1 — gh:pr-resolve-outdated** (only if 2.5 succeeded) — clean
+   rebase-sync when the base moved forward with no conflicts; no-op if already
+   up to date. `Skill(gh:pr-resolve-outdated, "<PR_NUM>")`
+8. **Step 2.6 — Post AI Metrics to Issue** (only if 2.5.1 succeeded;
    soft-fail) — aggregate flow-level metrics comment on the linked Issue.
-   Full procedure (per-step timing, human-time lookup, token estimate,
-   `gh api` body template, `GH_DISABLE_AI_METRICS` short-circuit, soft-fail
-   warning) is in `references/ai-metrics-step.md`.
+   Full procedure: `references/ai-metrics-step.md`.
 
 ## Step 3: Report
 
@@ -94,6 +93,6 @@ Always end with the `[OK]`/`[FAIL]`/`[SKIP]` structured report.
 ## Constraints
 
 See `references/constraints.md` for the full list (direct mode only, never
-retry/skip a step, no state mutation beyond sub-skills, the Step 2.6
-soft-fail exception, the `--no-next-hint` and zero-prose early-stop guards,
-and the do-not-stop-mid-flow rule).
+retry/skip a step, quality-gate + Step 2.6 soft-fail exceptions, the
+simplify-commit-before-rebase rule, the `--no-next-hint` and zero-prose
+early-stop guards, and the do-not-stop-mid-flow rule).

--- a/claude/skills/gh-issue-flow/references/ai-metrics-step.md
+++ b/claude/skills/gh-issue-flow/references/ai-metrics-step.md
@@ -1,11 +1,11 @@
 # gh:issue-flow — Step 2.6: Post AI Metrics to Issue (soft-fail)
 
-Runs only if Step 2.5 succeeded. Post a flow-level aggregate metrics
+Runs only if Step 2.5.1 succeeded. Post a flow-level aggregate metrics
 comment on the **linked GitHub Issue**. The PR body already carries the
 per-step `<!-- ai-metrics:gh-pr -->` block written by `gh:pr`; this step
-adds the total across all five sub-skills to the Issue so the Issue thread
-is the single place to review full AI effort. This step soft-fails — warn
-on any error but never block the flow.
+adds the total across all six sub-skills (plus the quality gate) to the
+Issue so the Issue thread is the single place to review full AI effort.
+This step soft-fails — warn on any error but never block the flow.
 
 a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
    Track per-step timing by recording `STEP_TS=$(date +%s)` at the
@@ -13,8 +13,10 @@ a. Compute: `ELAPSED=$(( ($(date +%s) - START_TS) / 60 ))`
    - `IMPL_MIN` — elapsed for Step 2.1 (gh:issue-implement)
    - `COMMIT_MIN` — elapsed for Step 2.2 (gh:commit)
    - `PR_MIN` — elapsed for Step 2.3 (gh:pr)
+   - `GATE_MIN` — elapsed for Steps 2.3.1–2.3.3 (quality gate)
    - `SCHEDULE_MIN` — elapsed for Step 2.4 (devx:schedule)
    - `CONFLICT_MIN` — elapsed for Step 2.5 (gh:pr-resolve-conflict)
+   - `OUTDATED_MIN` — elapsed for Step 2.5.1 (gh:pr-resolve-outdated)
    Any variable not yet computed defaults to `?` in the template.
 b. Issue type: parse the conventional-commit prefix from the issue title
    fetched in Step 2.1 (e.g. `feat`, `fix`, `refactor`).
@@ -42,8 +44,10 @@ else
 | gh-issue-implement | ~${IMPL_MIN:-?} min |
 | gh-commit | ~${COMMIT_MIN:-?} min |
 | gh-pr | ~${PR_MIN:-?} min |
+| quality gate (review + simplify) | ~${GATE_MIN:-?} min |
 | devx:schedule (pr-reply) | ~${SCHEDULE_MIN:-?} min |
 | gh-pr-resolve-conflict | ~${CONFLICT_MIN:-?} min |
+| gh-pr-resolve-outdated | ~${OUTDATED_MIN:-?} min |
 | **합계** | **~$ELAPSED min** |
 
 예상 사람 시간: ~$HUMAN_H h · 토큰: ~$TOKENS

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -2,9 +2,20 @@
 
 - Never invoke implementation modes other than `direct`.
 - Never retry a failed step. Human decides retry or fix.
-- Never skip a step. All 5 or stop.
+- Never skip a step. All 6 or stop.
+- **Quality-gate soft-fail exception.** Steps 2.3.1/2.3.2/2.3.3 are
+  additive polish, not gating: codex absent → 2.3.1 skip (not a
+  failure); `/simplify` produced no change → 2.3.3 skip; any error in
+  review/simplify/commit → `[WARN]` and continue. The gate never stops
+  the flow.
+- **Simplify commit before rebase.** Step 2.3.3 (commit + push simplify
+  changes) MUST run before the rebase steps 2.5 / 2.5.1 — a dirty
+  working tree breaks `git rebase`.
+- Step 2.5.1 (gh:pr-resolve-outdated) does a clean rebase-sync when the
+  base moved forward with no conflicts; it is a no-op when the PR is
+  already up to date.
 - Never mutate state between steps beyond what the sub-skills do.
-  Exception: Step 2.6 may post a comment after Step 2.5 — this is
+  Exception: Step 2.6 may post a comment after Step 2.5.1 — this is
   intentional and must soft-fail (never block the flow). If a future
   variant of Step 2.6 needs to mutate PR labels or body, route through
   `_gh_pr_edit_safe_label` / `_gh_pr_edit_safe_body`
@@ -26,9 +37,11 @@
   recap ("Step 2.1 complete, now committing..."), no progress
   markdown headers, no per-step bullet summaries. Such text reads as
   a turn-ending answer and re-introduces the early-stop. The only
-  prose allowed inside Step 2 is the final Step 3 report.
+  prose allowed inside Step 2 is the final Step 3 report. Tool calls
+  are not prose — the quality-gate Agent dispatch (2.3.1/2.3.2) and the
+  Bash commit+push (2.3.3) between Skill() calls are permitted.
 - **Do NOT stop after any sub-skill completes.** Each step (2.1 through
-  2.5) is a waypoint, not a final answer. Continue to the next step
-  immediately. The only valid stopping points are: a step failure
-  (output the failure report), or the Step 3 success report after all
-  5 steps complete.
+  2.5.1, including the 2.3.x quality gate) is a waypoint, not a final
+  answer. Continue to the next step immediately. The only valid stopping
+  points are: a step failure (output the failure report), or the Step 3
+  success report after all 6 steps complete.

--- a/claude/skills/gh-issue-flow/references/critical-contract.md
+++ b/claude/skills/gh-issue-flow/references/critical-contract.md
@@ -13,14 +13,18 @@ with `--no-next-hint`).
 1. **`--no-next-hint` on Step 2.1** — suppresses `gh:issue-implement`'s
    trailing `Next:` hint, the original trip-wire from #333. Load-bearing
    even though insufficient on its own (see #383).
-2. **Zero conversational text between the five `Skill()` calls in Step 2** —
+2. **Zero conversational text between the six `Skill()` calls in Step 2** —
    no recap, no "now committing", no markdown headers, no progress
    bullets. Those tokens read as a turn-ending summary and re-introduce
    the early-stop. The only prose allowed inside Step 2 is the final
-   Step 3 report.
+   Step 3 report. **Tool calls are not prose and are permitted** — the
+   Agent dispatch for the 2.3.1/2.3.2 quality gate and the Bash
+   commit+push of 2.3.3 may run between Skill() calls. Only conversational
+   prose is forbidden; the terminal-marker gating (see guard 3) covers
+   those tool steps automatically, so no Agent-detection logic is needed.
 3. **Harness Stop hook (`claude/hooks/gh_issue_flow_stop_guard.py`)** —
    when the model nonetheless tries to end its turn mid-flow, this hook
-   parses the transcript, detects that fewer than 5 sub-skills have run
+   parses the transcript, detects that fewer than 6 sub-skills have run
    without a Step 3 marker, and returns `{"decision":"block","reason":...}`
    so Claude Code re-prompts the model to invoke the next sub-skill.
    See `references/stop-guard.md` for the detection logic, safety rails,

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -9,19 +9,21 @@
 
 ## Usage
 
-- `/gh-issue-flow 16` — chain: implement → commit → PR → schedule pr-reply → resolve conflicts, for issue #16 on `origin`.
+- `/gh-issue-flow 16` — chain: implement → commit → PR → quality gate (codex review ∥ /simplify) → schedule pr-reply → resolve conflicts → resolve out-of-date, for issue #16 on `origin`.
 - `/gh-issue-flow 16 upstream` — same chain on `upstream` remote.
 - `/gh-issue-flow -h` / `--help` / `help` — print this help.
 
 ## What this skill chains
 
-This skill invokes **5 skills in sequence** (each step runs only if the previous succeeded):
+This skill invokes **6 skills in sequence** (each step runs only if the previous succeeded), plus a parallel post-PR quality gate:
 
 1. **`gh:issue-implement <N> direct`** — reads the issue, edits files, runs tests. No human intervention.
 2. **`gh:commit`** — creates a commit for the changes with a message derived from the conversation (follows the repo's commit style).
 3. **`gh:pr`** — pushes the branch and opens a PR, auto-linking `Closes #<N>`.
+   - **Post-PR quality gate (soft-fail, parallel).** Two Agent subagents run in one turn: codex second-opinion review (`gh:pr-review --ai codex`, skipped if `codex` is not installed) ∥ built-in `/simplify` on the branch diff. Any resulting simplify changes are committed + pushed before the rebase steps. Failures warn and continue — they never stop the chain.
 4. **`devx:schedule` `--time 5 "/gh-pr-reply <PR_NUM>"`** — schedules a pr-reply run 5 minutes after PR creation, giving CI and reviewers time to post before the bot replies.
 5. **`gh:pr-resolve-conflict` `<PR_NUM>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
+6. **`gh:pr-resolve-outdated` `<PR_NUM>`** — clean rebase-sync when the base branch has moved forward with no conflicts. No-op if the PR is already up to date.
 
 If any step fails, the chain stops immediately. No automatic retry.
 The final report shows which steps ran, which failed, and how to

--- a/claude/skills/gh-issue-flow/references/quality-gate-step.md
+++ b/claude/skills/gh-issue-flow/references/quality-gate-step.md
@@ -1,0 +1,49 @@
+# gh:issue-flow — Post-PR Quality Gate (Steps 2.3.1 / 2.3.2 / 2.3.3)
+
+Runs after Step 2.3 (`gh:pr`) has produced `<PR_NUM>`, before the rebase
+steps 2.5 / 2.5.1. The whole gate is **soft-fail**: review and simplify are
+additive polish, so any failure warns and the chain continues — never block.
+
+## F-3 — dispatch 2.3.1 ∥ 2.3.2 as two parallel Agent subagents in one turn
+
+Steps 2.3.1 and 2.3.2 are independent (pr-review reads the remote PR diff;
+simplify edits the local working tree), so dispatch **both Agent subagents
+in a single turn** for parallel execution. Do not serialize them. No
+conversational prose between the dispatches (see `references/critical-contract.md`);
+the Agent/Bash tool calls of this gate are themselves permitted between the
+Skill() calls — only prose is forbidden.
+
+### Step 2.3.1 — codex second-opinion review
+
+- Check availability first: `command -v codex`.
+- **Present** → dispatch an Agent that runs
+  `Skill(gh:pr-review, "--ai codex <PR_NUM>")`. It streams codex findings and
+  posts them as a PR comment (no approve / request-changes — that is not this
+  gate's job).
+- **Absent** → skip. A missing `codex` CLI is a normal skip, not a failure.
+
+### Step 2.3.2 — /simplify on the branch diff
+
+- Dispatch an Agent that runs the built-in `/simplify`.
+- `simplify` operates on the **working-tree / branch diff**, so a PR-number
+  argument may be ignored — do not rely on passing `<PR_NUM>` to it. It edits
+  local files to reduce duplication / complexity without changing behaviour.
+
+## Step 2.3.3 — commit + push simplify changes (only if the tree changed)
+
+After both subagents return:
+
+- If `/simplify` produced working-tree changes (`git status --porcelain`
+  non-empty) → `git commit` the changes and `git push`.
+- If the tree is clean → skip (simplify found nothing to change).
+
+**Ordering is load-bearing: 2.3.3 MUST run before the rebase steps 2.5 /
+2.5.1.** A dirty working tree breaks `git rebase`, so the simplify commit has
+to land (or be confirmed absent) before any rebase-sync runs.
+
+## Soft-fail policy
+
+- codex absent → 2.3.1 skip (not a failure).
+- simplify no change → 2.3.3 skip.
+- Any error in review, simplify, or the simplify commit/push → emit a
+  `[WARN] …` line and continue to Step 2.4. The gate never stops the flow.

--- a/claude/skills/gh-issue-flow/references/quality-gate-step.md
+++ b/claude/skills/gh-issue-flow/references/quality-gate-step.md
@@ -34,7 +34,11 @@ Skill() calls — only prose is forbidden.
 After both subagents return:
 
 - If `/simplify` produced working-tree changes (`git status --porcelain`
-  non-empty) → `git commit` the changes and `git push`.
+  non-empty) → commit with an explicit `-m` message in the repo's
+  conventional-commit style (e.g.
+  `git commit -m "refactor(<scope>): simplify per /simplify"`) and
+  `git push`. Never run a bare `git commit` — in a non-interactive AI
+  environment it opens an editor and hangs; always pass `-m`.
 - If the tree is clean → skip (simplify found nothing to change).
 
 **Ordering is load-bearing: 2.3.3 MUST run before the rebase steps 2.5 /

--- a/claude/skills/gh-issue-flow/references/report-template.md
+++ b/claude/skills/gh-issue-flow/references/report-template.md
@@ -7,21 +7,28 @@ gh:issue-flow complete (#<N>)
   [OK] Step 1: gh:issue-implement       (<n files changed>, <n tests passed>)
   [OK] Step 2: gh:commit                (<sha> "<subject>")
   [OK] Step 3: gh:pr                    (PR #<M>)
+  [OK] Step 3.x: quality gate           (codex review + simplify)
   [OK] Step 4: devx:schedule            (pr-reply in 5 min, job: <id>)
   [OK] Step 5: gh:pr-resolve-conflict   (no conflicts / resolved)
+  [OK] Step 5.1: gh:pr-resolve-outdated (up to date / rebased)
   [OK] Step 6: ai-metrics               (~X tokens · ~M h · ~L min)
   PR URL: <pr-url>
 ```
+
+Quality-gate rows use `[SKIP]` for their soft-fail cases:
+- `[SKIP] Step 3.x: quality gate  (codex absent)` — no `codex` CLI.
+- `[SKIP] Step 3.x: quality gate  (simplify: no change)` — clean tree, no commit.
+- `[WARN] Step 3.x: quality gate  (<reason>)` — review/simplify error, continued.
 
 If Step 2.6 soft-failed, show `[WARN] Step 6: ai-metrics  (skipped — <reason>)` instead.
 
 If a step failed:
 
 ```
-gh:issue-flow stopped at step <i>/5 (<skill-name>)
+gh:issue-flow stopped at step <i>/6 (<skill-name>)
   [OK] Step 1: gh:issue-implement  (<summary>)
   [FAIL] Step <i>: <skill-name>       (<failure reason>)
-  [SKIP] Steps <i+1>..5               (not reached)
+  [SKIP] Steps <i+1>..6               (not reached)
 
 Resume after fix:
   /<commands to finish>
@@ -33,3 +40,8 @@ Resume hint logic:
 - Failed at step 3 → `/gh-pr <N>`.
 - Failed at step 4 → `/devx:schedule --time 5 "/gh-pr-reply <PR_NUM>"`.
 - Failed at step 5 → `/gh-pr-resolve-conflict <PR_NUM>`.
+- Failed at step 5.1 → `/gh-pr-resolve-outdated <PR_NUM>`.
+
+The quality gate (Step 3.x) is soft-fail and never produces a `stopped at`
+report — it only contributes `[OK]`/`[SKIP]`/`[WARN]` rows to the success
+template above.

--- a/claude/skills/gh-issue-flow/references/stop-guard.md
+++ b/claude/skills/gh-issue-flow/references/stop-guard.md
@@ -2,12 +2,21 @@
 
 ## Why this exists
 
-`gh:issue-flow` chains 5 sub-skills (`gh:issue-implement` → `gh:commit` →
-`gh:pr` → `devx:schedule` → `gh:pr-resolve-conflict`) plus a final Step 3
-report. Across multiple revisions of this skill (issue #333, issue #383)
-the model has repeatedly invented a "I'm done now" markdown block between
-Skill() calls and ended its turn early — leaving the user to manually
-finish the chain.
+`gh:issue-flow` chains 6 sub-skills (`gh:issue-implement` → `gh:commit` →
+`gh:pr` → `devx:schedule` → `gh:pr-resolve-conflict` →
+`gh:pr-resolve-outdated`) plus a parallel post-PR quality gate (2.3.1
+codex review ∥ 2.3.2 `/simplify` → 2.3.3 commit+push) and a final Step 3
+report. `gh-pr-resolve-outdated` is now the 6th entry of the hook's
+`EXPECTED_CHAIN`. Across multiple revisions of this skill (issue #333,
+issue #383) the model has repeatedly invented a "I'm done now" markdown
+block between Skill() calls and ended its turn early — leaving the user to
+manually finish the chain.
+
+The quality gate's Agent dispatch (2.3.1/2.3.2) and the Bash commit+push
+(2.3.3) are tool calls, not `Skill()` calls, and are permitted between the
+chain skills. They need no Agent-detection logic in the hook: the
+terminal-marker gating (L1.5 below) blocks turn-end until a Step 3 marker
+appears, which transitively covers these tool steps too.
 
 Two earlier mitigations help but are not sufficient:
 

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -194,7 +194,7 @@ def test_stop_hook_active_short_circuits(tmp_path: Path) -> None:
 
 
 def test_completed_flow_allows_stop(tmp_path: Path) -> None:
-    """All 5 sub-skills + Step 3 marker present → allow stop."""
+    """All 6 sub-skills + Step 3 marker present → allow stop."""
     transcript = _write_transcript(
         tmp_path,
         [
@@ -204,6 +204,7 @@ def test_completed_flow_allows_stop(tmp_path: Path) -> None:
             _assistant_skill("gh-pr"),
             _assistant_skill("devx-schedule"),
             _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_skill("gh-pr-resolve-outdated"),
             _assistant_text("gh:issue-flow complete (#42)\n  PR URL: https://github.com/example/repo/pull/99"),
         ],
     )
@@ -246,7 +247,7 @@ def test_mid_flow_after_step_2_1_blocks_with_next_hint(tmp_path: Path) -> None:
     reason = decision.get("reason", "")
     assert "gh-commit" in reason
     assert "Step 2.2" in reason
-    assert "1/5" in reason
+    assert "1/6" in reason
 
 
 def test_mid_flow_skill_call_with_colon_namespace_counted(tmp_path: Path) -> None:
@@ -265,11 +266,11 @@ def test_mid_flow_skill_call_with_colon_namespace_counted(tmp_path: Path) -> Non
     assert decision["decision"] == "block"
     assert "gh-pr" in decision["reason"]
     assert "Step 2.3" in decision["reason"]
-    assert "2/5" in decision["reason"]
+    assert "2/6" in decision["reason"]
 
 
-def test_mid_flow_after_all_5_blocks_for_step_3_report(tmp_path: Path) -> None:
-    """All 5 sub-skills run but no terminal marker → block, ask for Step 3."""
+def test_mid_flow_after_all_6_blocks_for_step_3_report(tmp_path: Path) -> None:
+    """All 6 sub-skills run but no terminal marker → block, ask for Step 3."""
     transcript = _write_transcript(
         tmp_path,
         [
@@ -279,6 +280,7 @@ def test_mid_flow_after_all_5_blocks_for_step_3_report(tmp_path: Path) -> None:
             _assistant_skill("gh-pr"),
             _assistant_skill("devx-schedule"),
             _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_skill("gh-pr-resolve-outdated"),
             # No Step 3 report yet.
         ],
     )
@@ -287,7 +289,58 @@ def test_mid_flow_after_all_5_blocks_for_step_3_report(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     assert "Step 3" in decision["reason"]
-    assert "5/5" in decision["reason"]
+    assert "6/6" in decision["reason"]
+
+
+def test_mid_flow_after_resolve_conflict_blocks_for_resolve_outdated(tmp_path: Path) -> None:
+    """5 sub-skills through gh-pr-resolve-conflict, no terminal → block,
+    naming gh-pr-resolve-outdated (Step 2.5.1) as the next step."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr"),
+            _assistant_skill("devx-schedule"),
+            _assistant_skill("gh-pr-resolve-conflict"),
+            # No Step 3 report yet — resolve-outdated still pending.
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    reason = decision["reason"]
+    assert "gh-pr-resolve-outdated" in reason
+    assert "Step 2.5.1" in reason
+    assert "5/6" in reason
+
+
+def test_quality_gate_reminder_after_gh_pr(tmp_path: Path) -> None:
+    """After gh-pr (3 seen), the next-step hint routes to Step 2.4 but must
+    also remind the model to run the parallel quality gate first."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 42"),
+            _assistant_skill("gh-issue-implement"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr"),
+            # No Step 3 report yet.
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    reason = decision["reason"]
+    assert "Step 2.4" in reason
+    assert "devx-schedule" in reason
+    assert "3/6" in reason
+    # Quality-gate reminder substrings.
+    assert "simplify" in reason
+    assert "pr-review" in reason
 
 
 def test_skill_invocation_via_assistant_works_as_boundary(tmp_path: Path) -> None:
@@ -321,7 +374,7 @@ def test_unrelated_skill_after_boundary_not_counted(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     # Still only 1/5 — the unrelated skills must not bump the counter.
-    assert "1/5" in decision["reason"]
+    assert "1/6" in decision["reason"]
 
 
 def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
@@ -474,7 +527,7 @@ def test_trace_on_emits_block_diagnostics(tmp_path: Path) -> None:
     # Trace lines all share the [stop-guard] prefix.
     assert "[stop-guard]" in result.stderr
     # The boundary scan summary should report 1/5 sub-skills seen.
-    assert "sub_skills_seen=1/5" in result.stderr
+    assert "sub_skills_seen=1/6" in result.stderr
     assert "block:" in result.stderr
 
 
@@ -505,6 +558,7 @@ def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None
             _assistant_skill("gh-pr"),
             _assistant_skill("devx-schedule"),
             _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_skill("gh-pr-resolve-outdated"),
             _assistant_text("gh:issue-flow complete (#42)"),
         ],
     )
@@ -515,7 +569,7 @@ def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None
     assert result.returncode == 0
     assert result.stdout.strip() == ""
     assert "Step 3 terminal marker" in result.stderr
-    assert "sub_skills_seen=5/5" in result.stderr
+    assert "sub_skills_seen=6/6" in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -669,7 +723,7 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
     reason = decision["reason"]
     assert "Step 2.2" in reason
     assert "gh-commit" in reason
-    assert "1/5" in reason
+    assert "1/6" in reason
 
 
 # ---------------------------------------------------------------------------
@@ -912,7 +966,7 @@ def test_skill_template_text_in_user_message_does_not_false_terminate(
     assert decision["decision"] == "block"
     assert "Step 2.2" in decision["reason"]
     assert "gh-commit" in decision["reason"]
-    assert "1/5" in decision["reason"]
+    assert "1/6" in decision["reason"]
 
 
 def test_skill_template_text_in_tool_result_does_not_false_terminate(
@@ -952,7 +1006,7 @@ def test_skill_template_text_in_tool_result_does_not_false_terminate(
     )
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "1/5" in decision["reason"]
+    assert "1/6" in decision["reason"]
 
 
 def test_real_terminal_marker_in_assistant_text_still_allows_stop(
@@ -980,6 +1034,7 @@ def test_real_terminal_marker_in_assistant_text_still_allows_stop(
             _assistant_skill("gh-pr"),
             _assistant_skill("devx-schedule"),
             _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_skill("gh-pr-resolve-outdated"),
             # Real Step 3 success report — assistant role, real terminal marker.
             _assistant_text("gh:issue-flow complete (#608)\n  PR URL: https://x/pull/9"),
         ],


### PR DESCRIPTION
## Summary
- `gh:issue-flow` 체인에 PR 생성 직후 **품질 게이트**(2.3.1 codex 리뷰 ∥ 2.3.2 `/simplify` 를 Agent 서브에이전트 2개로 병렬 dispatch, 2.3.3 simplify 변경 commit+push)를 추가한다.
- 2.5(resolve-conflict) 뒤에 **base out-of-date 동기화**(2.5.1 `gh:pr-resolve-outdated`)를 추가한다.
- 새 스텝이 조기종료 가드 hook의 보호를 받도록 `gh_issue_flow_stop_guard.py` 의 canonical chain(EXPECTED_CHAIN)을 6-스텝으로 확장한다.

## Changes
- **SKILL.md**: Step 2 재작성(2.3.1/2.3.2/2.3.3 게이트, 2.5.1 resolve-outdated), `allowed-tools` 에 `Agent` 추가, frontmatter description 갱신. 98줄 유지(≤100, progressive disclosure).
- **references/quality-gate-step.md** (신설): 게이트 상세 — codex 미설치 skip, `/simplify` 브랜치 diff 동작, F-3 병렬 Agent dispatch, 2.3.3 commit-before-rebase 규칙, whole-gate soft-fail.
- **hook `gh_issue_flow_stop_guard.py`**: `EXPECTED_CHAIN` 에 `gh-pr-resolve-outdated` 추가(6-스텝), 하드코딩 `/5` → `/{len(EXPECTED_CHAIN)}`, `STEP_LABELS`(2.5.1 라벨) 도입, gh-pr 직후 nudge 에 품질 게이트 리마인더 추가. fail-open 세이프레일·assistant-only terminal-scan 스코프 보존.
- **references** critical-contract / constraints / report-template / help / ai-metrics-step / stop-guard: 6-스텝 + 게이트로 정합화(툴콜 허용·prose 금지 명시, soft-fail·commit-before-rebase 규칙, resume-hint, 6번째 EXPECTED_CHAIN 반영).
- **tests**: 6-스텝 케이스 갱신(`X/5`→`X/6`, 6번째 skill), `resolve-outdated`(Step 2.5.1) 및 품질 게이트 nudge 신규 테스트.

## Test plan
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py -v` → 42 passed
- [x] `mise run test` → 1189 passed
- [x] `mise run lint` → errors=0 (legacy warn-only만)
- [x] `/skill:check gh-issue-flow` → EXCELLENT (11/11 applicable PASS), SKILL.md 98줄
- [x] codex 미설치 환경에서 2.3.1 skip / simplify 무변경 시 2.3.3 skip 은 게이트 문서·hook 리마인더로 반영

## Related
Closes #1158

---
<details>
<summary>🤖 AI Metrics · 📊 ~10500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~10500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
