### PR TITLE
perf(test): bats 파일 단위 병렬화로 mise run test ~3배 단축

### DIFF
--- a/tests/test
+++ b/tests/test
@@ -181,9 +181,20 @@ run_bats() {
     fi
 
     # Parallel: one bats process per file, bounded by CPU count.
-    local jobs="${BATS_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+    # CPU count: nproc (Linux) → getconf (macOS/BSD) → 4. BATS_JOBS overrides.
+    local jobs="${BATS_JOBS:-$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+    # Guard a non-positive-integer BATS_JOBS override (gemini review).
+    case "$jobs" in
+        '' | *[!0-9]*) jobs=4 ;;
+    esac
+    [ "$jobs" -lt 1 ] && jobs=1
     local outdir
     outdir="$(mktemp -d)"
+    # Clean the temp dir on normal exit and on interrupt so an aborted run
+    # never leaks it; the signal handler also exits so Ctrl+C stops the
+    # runner instead of continuing on a deleted outdir (gemini review).
+    trap 'rm -rf "$outdir"' EXIT
+    trap 'rm -rf "$outdir"; trap - EXIT; exit 130' INT TERM HUP
     print_info "Parallel: ${#bats_files[@]} files across ${jobs} jobs (override with BATS_JOBS=N, or -s for serial)"
 
     # Emit "index\npath" pairs; -n 2 hands each (idx, path) to one worker.
@@ -227,6 +238,7 @@ run_bats() {
     done
 
     rm -rf "$outdir"
+    trap - EXIT INT TERM HUP
 
     if [ "$rc" -eq 0 ]; then
         print_success "bats: ${total_tests} tests in ${#bats_files[@]} files passed"

--- a/tests/test
+++ b/tests/test
@@ -81,8 +81,9 @@ EXAMPLES:
     ./tests/test --verbose --serial # Verbose + sequential
 
 PERFORMANCE:
-    Default: Parallel execution using all CPU cores (~60-80s)
-    Serial:  Sequential execution (~250s)
+    Default: bats + pytest both run parallel across all CPU cores (~4-5 min)
+    Serial:  Sequential execution, single bats process (~15+ min)
+    Tune:    BATS_JOBS=N overrides bats job count (default: nproc)
 
 REQUIREMENTS:
     - Python 3.10+
@@ -139,6 +140,14 @@ check_requirements() {
 
 
 # Run bats tests
+#
+# bats-core's own `--jobs` needs GNU parallel (or shenwei356/rush), which we
+# do not want as a hard test dependency. Instead we run one bats process per
+# .bats file bounded by CPU count via `xargs -P` — dependency-free and
+# portable to bash 3.2 (macOS) + Linux. This is safe because every bats test
+# isolates its own $HOME via mktemp (see tests/bats/test_helper.bash
+# setup_isolated_home), so file-level parallelism has no shared mutable state.
+# Serial mode (-s) keeps the single-process path for deterministic output.
 run_bats() {
     local bats_bin="${SCRIPT_DIR}/bats/lib/bats-core/bin/bats"
     if [ ! -x "$bats_bin" ]; then
@@ -148,17 +157,76 @@ run_bats() {
     fi
 
     print_header "Running Bats Shell Unit Tests"
-    # Auto-discover bats test directories, excluding lib/ (submodules)
-    local bats_dirs=()
-    while IFS= read -r d; do
-        bats_dirs+=("$d")
-    done < <(find "${SCRIPT_DIR}/bats" -type f -name '*.bats' -not -path '*/lib/*' -exec dirname {} \; | sort -u)
-    if [ ${#bats_dirs[@]} -eq 0 ]; then
-        print_warning "No bats test directories found"
+
+    # Discover .bats files (exclude lib/ submodules), ordered by @test count
+    # descending (Longest-Processing-Time scheduling) so the long-pole file
+    # starts first and the parallel makespan approaches its floor.
+    local bats_files=()
+    while IFS= read -r f; do
+        bats_files+=("$f")
+    done < <(
+        find "${SCRIPT_DIR}/bats" -type f -name '*.bats' -not -path '*/lib/*' \
+            -exec sh -c 'printf "%s\t%s\n" "$(grep -c "^@test" "$1")" "$1"' _ {} \; \
+            | sort -rn | cut -f2-
+    )
+    if [ ${#bats_files[@]} -eq 0 ]; then
+        print_warning "No bats test files found"
         return 0
     fi
-    "$bats_bin" "${bats_dirs[@]}"
-    return $?
+
+    # Serial: single bats invocation over all files (deterministic order).
+    if [ "$SERIAL" = "1" ]; then
+        "$bats_bin" "${bats_files[@]}"
+        return $?
+    fi
+
+    # Parallel: one bats process per file, bounded by CPU count.
+    local jobs="${BATS_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+    local outdir
+    outdir="$(mktemp -d)"
+    print_info "Parallel: ${#bats_files[@]} files across ${jobs} jobs (override with BATS_JOBS=N, or -s for serial)"
+
+    printf '%s\n' "${bats_files[@]}" \
+        | xargs -P "$jobs" -I {} bash -c '
+            f="$1"; bats="$2"; out="$3"
+            base=$(printf "%s" "$f" | tr "/" "_")
+            if "$bats" "$f" >"$out/$base.log" 2>&1; then
+                printf "0" >"$out/$base.status"
+            else
+                printf "1" >"$out/$base.status"
+            fi
+          ' _ {} "$bats_bin" "$outdir"
+
+    # Aggregate: count tests, print per-file failures with their full log.
+    local rc=0 total_tests=0 failed_files=0
+    local f base status_val log_file
+    for f in "${bats_files[@]}"; do
+        base=$(printf "%s" "$f" | tr '/' '_')
+        log_file="$outdir/$base.log"
+        status_val=$(cat "$outdir/$base.status" 2>/dev/null || echo 1)
+        if [ -f "$log_file" ]; then
+            local n
+            n=$(grep -cE '^(ok|not ok)' "$log_file" 2>/dev/null || echo 0)
+            total_tests=$((total_tests + n))
+        fi
+        if [ "$status_val" != "0" ]; then
+            failed_files=$((failed_files + 1))
+            rc=1
+            print_error "FAILED: ${f#"${SCRIPT_DIR}/"}"
+            [ -f "$log_file" ] && cat "$log_file"
+        elif [ "$VERBOSE" = "1" ] && [ -f "$log_file" ]; then
+            cat "$log_file"
+        fi
+    done
+
+    rm -rf "$outdir"
+
+    if [ "$rc" -eq 0 ]; then
+        print_success "bats: ${total_tests} tests in ${#bats_files[@]} files passed"
+    else
+        print_error "bats: ${failed_files} of ${#bats_files[@]} files failed (${total_tests} tests total)"
+    fi
+    return $rc
 }
 
 # Run golden rules

--- a/tests/test
+++ b/tests/test
@@ -186,27 +186,34 @@ run_bats() {
     outdir="$(mktemp -d)"
     print_info "Parallel: ${#bats_files[@]} files across ${jobs} jobs (override with BATS_JOBS=N, or -s for serial)"
 
-    printf '%s\n' "${bats_files[@]}" \
-        | xargs -P "$jobs" -I {} bash -c '
-            f="$1"; bats="$2"; out="$3"
-            base=$(printf "%s" "$f" | tr "/" "_")
-            if "$bats" "$f" >"$out/$base.log" 2>&1; then
-                printf "0" >"$out/$base.status"
+    # Emit "index\npath" pairs; -n 2 hands each (idx, path) to one worker.
+    # Keying outputs by array index (not a path-derived name) gives the
+    # producer and the aggregation loop below one shared, collision-free map.
+    local i=0 f
+    for f in "${bats_files[@]}"; do
+        printf '%s\n%s\n' "$i" "$f"
+        i=$((i + 1))
+    done \
+        | xargs -P "$jobs" -n 2 bash -c '
+            bats="$1"; out="$2"; idx="$3"; f="$4"
+            if "$bats" "$f" >"$out/$idx.log" 2>&1; then
+                printf "0" >"$out/$idx.status"
             else
-                printf "1" >"$out/$base.status"
+                printf "1" >"$out/$idx.status"
             fi
-          ' _ {} "$bats_bin" "$outdir"
+          ' _ "$bats_bin" "$outdir"
 
     # Aggregate: count tests, print per-file failures with their full log.
+    # Iterate the same indices the producer used, so outputs line up exactly.
     local rc=0 total_tests=0 failed_files=0
-    local f base status_val log_file
-    for f in "${bats_files[@]}"; do
-        base=$(printf "%s" "$f" | tr '/' '_')
-        log_file="$outdir/$base.log"
-        status_val=$(cat "$outdir/$base.status" 2>/dev/null || echo 1)
+    local status_val log_file n
+    for i in "${!bats_files[@]}"; do
+        f="${bats_files[$i]}"
+        log_file="$outdir/$i.log"
+        status_val=$(cat "$outdir/$i.status" 2>/dev/null || echo 1)
         if [ -f "$log_file" ]; then
-            local n
-            n=$(grep -cE '^(ok|not ok)' "$log_file" 2>/dev/null || echo 0)
+            # grep -c always prints a count (0 on no match), so no fallback needed.
+            n=$(grep -cE '^(ok|not ok)' "$log_file" 2>/dev/null)
             total_tests=$((total_tests + n))
         fi
         if [ "$status_val" != "0" ]; then


### PR DESCRIPTION
## Summary
- `mise run test`(로컬 pre-push 게이트, #754)의 지배적 병목이던 **bats 직렬 실행**을 파일 단위 병렬로 전환.
- 20코어 기준 bats `~600–828s → ~103s`, 전체 `./tests/test` `~800–1000s → 299s`(~3배 단축).
- 새 하드 의존성(GNU parallel) 없이 구현하고, 병렬/직렬 결과가 완전히 동일함을 검증.

## Changes
- `perf(test)`: `tests/test` 의 `run_bats()` 를 `xargs -P nproc` 파일 단위 병렬 러너로 교체.
  - **LPT 스케줄링** — `@test` 개수 내림차순 투입으로 long-pole 파일(`claude_accounts.bats`, 84s)을 먼저 시작해 makespan 을 하한에 근접.
  - **병렬 안전** — 각 테스트가 `setup_isolated_home` 에서 `mktemp` 로 `$HOME` 격리, repo 트리는 read-only → 파일 간 공유 가변상태 없음.
  - **호환성** — bats-core `--jobs`(GNU parallel 의존) 대신 `xargs -P` 사용, bash 3.2/macOS 이식.
  - `-s/--serial` 은 기존 단일 프로세스 경로 유지, `BATS_JOBS=N` 로 잡 수 조절, 실패 파일은 전체 로그 덤프.
  - help/PERFORMANCE 문구를 실측값으로 갱신.

## Test plan
- [x] `./tests/test` 전체 실행: bats 1566 + pytest 1189, 299s 완료.
- [x] 병렬 vs 직렬 **실패 테스트 집합 `diff` 완전 일치**(1566 테스트, 6 실패) — 동작 보존 입증.
- [x] `bash -n tests/test` 구문 통과, `tests/test` 는 lint 게이트(`bash/` 스캔) 대상 아님.
- [ ] 리뷰어: `-s` 직렬 경로 및 `BATS_JOBS=1` 회귀 확인(선택).

## Notes
- 하한 103s 는 `claude_accounts.bats`(84s) 한 파일이 결정 — 분할 시 추가 단축 가능(별도 이슈 권장).
- 기존 bats 실패 6건은 이 환경 관련 사안으로 본 PR 과 무관.

## Related
Closes #1163

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~3 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~3 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
