### PR TITLE
fix(skill-guard): boundary 정규식 하이픈 형제 스킬 오탐 제거

### DIFF
--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -165,7 +165,7 @@ def _build_boundary_regex(catalog: dict[str, dict[str, Any]]) -> re.Pattern[str]
         rf"""
         (?m)                                                    # multiline: ^ matches each line start
         (?:
-            ^\s*/({union})\b                                    # (a) raw slash command
+            ^\s*/({union})(?![\w-])                             # (a) raw slash command (hyphenated siblings excluded)
             |
             <command-name>\s*/({union})\s*</command-name>       # (b) wrapped form
             |

--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -165,7 +165,7 @@ def _build_boundary_regex(catalog: dict[str, dict[str, Any]]) -> re.Pattern[str]
         rf"""
         (?m)                                                    # multiline: ^ matches each line start
         (?:
-            ^\s*/({union})(?![\w-])                             # (a) raw slash command (hyphenated siblings excluded)
+            ^\s*/({union})(?![\w:-])                            # (a) raw slash command (hyphen/colon siblings excluded)
             |
             <command-name>\s*/({union})\s*</command-name>       # (b) wrapped form
             |

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -344,21 +344,21 @@ def test_hyphenated_sibling_command_not_matched_as_gh_pr(tmp_path: Path, sibling
     assert result.stdout.strip() == "", f"{sibling} should not be a gh-pr boundary"
 
 
-def test_bare_gh_pr_command_still_matched(tmp_path: Path) -> None:
+@pytest.mark.parametrize("cmd", ["/gh-pr", "/gh-pr 123"])
+def test_bare_gh_pr_command_still_matched(tmp_path: Path, cmd: str) -> None:
     """The real `/gh-pr` (bare, or with args) must still be detected (issue #1164)."""
-    for cmd in ("/gh-pr", "/gh-pr 123"):
-        transcript = _write_transcript(
-            tmp_path,
-            [
-                _user_text(cmd),
-                _assistant_text("running"),
-            ],
-        )
-        result = _run_hook(_hook_event(transcript))
-        assert result.returncode == 0
-        decision = json.loads(result.stdout)
-        assert decision["decision"] == "block", f"{cmd!r} should be a gh-pr boundary"
-        assert "gh-pr" in decision["reason"]
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text(cmd),
+            _assistant_text("running"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block", f"{cmd!r} should be a gh-pr boundary"
+    assert "gh-pr" in decision["reason"]
 
 
 def test_tool_result_command_mention_not_boundary(tmp_path: Path) -> None:

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -323,14 +323,25 @@ def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "sibling",
-    ["/gh-pr-review --ai gemini 123", "/gh-pr-reply 123", "/gh-pr-resolve-conflict 123"],
+    [
+        # hyphen-form siblings
+        "/gh-pr-review --ai gemini 123",
+        "/gh-pr-reply 123",
+        "/gh-pr-resolve-conflict 123",
+        # colon-form siblings — `:` is also not a word char, so the lookahead
+        # must exclude it too (PR #1169 gemini review).
+        "/gh:pr:review --ai gemini 123",
+        "/gh:pr:reply 123",
+        "/gh:pr:resolve-conflict 123",
+    ],
 )
 def test_hyphenated_sibling_command_not_matched_as_gh_pr(tmp_path: Path, sibling: str) -> None:
     """Line-start `/gh-pr-review` etc. must NOT be read as a `gh-pr` boundary (issue #1164).
 
-    `-` is a non-word char, so the old `\\b` after `gh-pr` in surface (a)
-    let `/gh-pr-review` false-match the `gh-pr` catalog entry, wedging the
-    Stop hook into a permanent block. Surface (a) now uses `(?![\\w-])`.
+    Both `-` and `:` are non-word chars, so the old `\\b` after `gh-pr` in
+    surface (a) let `/gh-pr-review` (and, after the first fix, the colon
+    form `/gh:pr:review`) false-match the `gh-pr` catalog entry, wedging the
+    Stop hook into a permanent block. Surface (a) now uses `(?![\\w:-])`.
     """
     transcript = _write_transcript(
         tmp_path,
@@ -344,9 +355,11 @@ def test_hyphenated_sibling_command_not_matched_as_gh_pr(tmp_path: Path, sibling
     assert result.stdout.strip() == "", f"{sibling} should not be a gh-pr boundary"
 
 
-@pytest.mark.parametrize("cmd", ["/gh-pr", "/gh-pr 123"])
+@pytest.mark.parametrize("cmd", ["/gh-pr", "/gh-pr 123", "/gh:pr", "/gh:pr 123"])
 def test_bare_gh_pr_command_still_matched(tmp_path: Path, cmd: str) -> None:
-    """The real `/gh-pr` (bare, or with args) must still be detected (issue #1164)."""
+    """The real `/gh-pr` (hyphen or colon form, bare or with args) must still
+    be detected (issue #1164 / PR #1169). Whitespace or EOL after the name
+    passes the `(?![\\w:-])` lookahead."""
     transcript = _write_transcript(
         tmp_path,
         [

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -321,6 +321,46 @@ def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
     assert result.stdout.strip() == ""
 
 
+@pytest.mark.parametrize(
+    "sibling",
+    ["/gh-pr-review --ai gemini 123", "/gh-pr-reply 123", "/gh-pr-resolve-conflict 123"],
+)
+def test_hyphenated_sibling_command_not_matched_as_gh_pr(tmp_path: Path, sibling: str) -> None:
+    """Line-start `/gh-pr-review` etc. must NOT be read as a `gh-pr` boundary (issue #1164).
+
+    `-` is a non-word char, so the old `\\b` after `gh-pr` in surface (a)
+    let `/gh-pr-review` false-match the `gh-pr` catalog entry, wedging the
+    Stop hook into a permanent block. Surface (a) now uses `(?![\\w-])`.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text(sibling),
+            _assistant_text("running"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"{sibling} should not be a gh-pr boundary"
+
+
+def test_bare_gh_pr_command_still_matched(tmp_path: Path) -> None:
+    """The real `/gh-pr` (bare, or with args) must still be detected (issue #1164)."""
+    for cmd in ("/gh-pr", "/gh-pr 123"):
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_text(cmd),
+                _assistant_text("running"),
+            ],
+        )
+        result = _run_hook(_hook_event(transcript))
+        assert result.returncode == 0
+        decision = json.loads(result.stdout)
+        assert decision["decision"] == "block", f"{cmd!r} should be a gh-pr boundary"
+        assert "gh-pr" in decision["reason"]
+
+
 def test_tool_result_command_mention_not_boundary(tmp_path: Path) -> None:
     """A `/gh-pr` substring in a tool_result block is documentation, not a real boundary."""
     transcript = _write_transcript(


### PR DESCRIPTION
## Summary
- `skill_completion_guard.py` 의 boundary 정규식 surface (a) 가 하이픈으로 이어지는 형제 스킬(`/gh-pr-review`, `/gh-pr-reply`, `/gh-pr-resolve-*`)을 `gh-pr` 실행으로 오탐하던 문제를 수정한다.
- 오탐 시 이후 모든 turn-end 에서 `gh-pr incomplete` 로 Stop hook 이 세션을 영구 block 하던 회귀를 해소한다.

## Changes
- `claude/hooks/skill_completion_guard.py` (`_build_boundary_regex`): surface (a) 의 `^\s*/({union})\b` → `^\s*/({union})(?![\w-])`. `-` 는 non-word 문자라 `\b` 가 `gh-pr` 뒤에서 경계를 만들어 하이픈 연장 형제를 매칭했음. `(?![\w-])` 는 뒤에 word 문자나 하이픈이 오면 매칭을 거부해 진짜 `/gh-pr`(bare/args)만 남긴다. surfaces (b)/(c)/(d) 는 접미사 토큰으로 막혀 오탐 없음 — (a)만 수정.
- `tests/integration/test_skill_completion_guard.py`: 하이픈 형제 3종(`/gh-pr-review`·`/gh-pr-reply`·`/gh-pr-resolve-conflict`)이 boundary 미매칭임을 검증하는 parametrized 테스트 + `/gh-pr`·`/gh-pr 123` 은 여전히 매칭되는 회귀 테스트 추가.

## Test plan
- [x] `pytest tests/integration/test_skill_completion_guard.py` — 38 passed
- [x] `ruff check` — clean
- [x] 하이픈 형제 라인이 더 이상 `gh-pr` boundary 로 잡히지 않음(신규 테스트로 확인)

## Related
Closes #1164

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
