### PR TITLE
feat(claude/skills): gh-relay-merge — origin→upstream 역merge push 차단 우회 스킬

### DIFF
--- a/claude/skills/gh-relay-merge/SKILL.md
+++ b/claude/skills/gh-relay-merge/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gh:relay-merge
+description: >-
+  Relay a merged (or open) PR's commits from an isolated `origin` (internal
+  GHE) to a separate `upstream` (github.com) when `git push upstream` is
+  blocked by a corporate proxy but `gh api` / single-file `gh gist create`
+  still work. Probes push capability first — if a normal push succeeds it
+  delegates to [[gh-pr]] and stops; only when push is confirmed blocked
+  (HTTP 403 / block-page) does it fall back to relay mode: `git format-patch`
+  per commit, one-file-per-call gist upload, then a `git am` apply-guide
+  comment on the destination issue. Use when the user runs /gh:relay-merge,
+  /gh-relay-merge, or asks "origin PR를 upstream 으로 릴레이", "push 막혀서
+  patch+gist 로 넘겨줘", "relay merged PR to upstream via gist". Accepts
+  `<origin-PR#> [--remote <name-or-URL>] [--target-issue <N>]
+  [--generated-patterns <globs>]` and `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Write, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: opus
+    reason: "asymmetric-network branch logic + per-patch size/artifact reasoning + no-silent-truncation judgement; multi-step relay with irreversible gist/comment side effects"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# gh:relay-merge — Patch+Gist Relay for Push-Blocked Upstream
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
+output its content verbatim, then stop. No API calls.
+
+## Step 1: Preconditions
+
+Positional `<origin-PR#>` (required); flags `--remote`, `--target-issue`,
+`--generated-patterns`. Resolve the origin PR with
+`gh pr view <N> --repo <origin-repo> --json number,state,url,headRefOid,baseRefName,mergeCommit,statusCheckRollup,reviewDecision`.
+Do **not** require `merged` — use the PR's current head/base commits.
+Resolve `--remote` (name or raw URL) per `references/remote-resolution.md`;
+missing `upstream` with no explicit `--remote` → hard error, never fall
+back to `origin`. Confirm the destination is reachable (`git fetch` /
+`git ls-remote`) before anything else.
+
+## Step 2: Push-Capability Probe (branch point)
+
+Run the throwaway-ref dry-run push probe in `references/push-probe.md`.
+- Probe says push works → **SIMPLE PATH**: delegate to [[gh-pr]] (or an
+  equivalent normal branch push + PR) and stop. Relay mode is a fallback,
+  not the default.
+- Confirmed blocked (HTTP 403 / block-page marker) → continue to Step 3.
+- Transient/inconclusive → retry once with short backoff; still
+  inconclusive → treat as not-blocked and take the SIMPLE PATH.
+
+## Step 3: Determine Commit Range + Pre-flight
+
+Resolve the PR's base/head SHAs and run the destination-divergence
+sanity check in `references/patch-generation.md` → "Pre-flight". Warn the
+user up front about structurally-known conflict categories (env-specific
+config blocks, internal/external variants) instead of shipping patches
+that will fail `git am` on the far side.
+
+## Step 4: Generate Patches
+
+`git format-patch <base>..<head> -o <tmpdir>` (one `git am`-able file per
+commit). Enforce the `RELAY_PATCH_MAX_BYTES` size cutoff, generated-artifact
+exclusion, and no-silent-truncation rule per `references/patch-generation.md`.
+
+## Step 5: Upload Gists (one file per call)
+
+Upload each patch with a single-file `gh gist create <one-file>`,
+sequentially — never multi-file, never parallel — per
+`references/gist-relay.md`. Report and stop on any non-transient failure.
+
+## Step 6: Post the Apply-Guide Comment
+
+Build the comment from `references/apply-guide-template.md` and post it to
+a NEW destination issue (default) or `--target-issue <N>` if supplied:
+ordered gist table + `git am` instructions + excluded-artifact regeneration
+commands + a "verification basis" section from Step 1's PR data.
+
+## Step 7: Origin-side Cleanup (optional)
+
+Only with explicit user confirmation, close a duplicate origin-side
+tracking issue with a cross-reference comment. Never auto-close.
+
+## Step 8: Report
+
+Summarize the destination issue/comment URL, gist count, whether any
+patches were split for generated-artifact exclusion, and — if Step 2's
+probe passed — that the simple push+PR path was used instead of relay.
+
+## Constraints
+
+See `references/constraints.md` for the full list. Hard rules: never fall
+back to `origin` silently · never plain-`push`-then-relay (probe first) ·
+never multi-file/parallel `gh gist create` · never silently truncate a
+patch (only recognized generated artifacts get split) · never auto-close
+an origin issue.

--- a/claude/skills/gh-relay-merge/SKILL.md
+++ b/claude/skills/gh-relay-merge/SKILL.md
@@ -60,8 +60,8 @@ that will fail `git am` on the far side.
 
 ## Step 4: Generate Patches
 
-`git format-patch <base>..<head> -o <tmpdir>` (one `git am`-able file per
-commit). Enforce the `RELAY_PATCH_MAX_BYTES` size cutoff, generated-artifact
+Run `git format-patch` over the commit range (one `git am`-able file per
+commit) and enforce the `RELAY_PATCH_MAX_BYTES` size cutoff, generated-artifact
 exclusion, and no-silent-truncation rule per `references/patch-generation.md`.
 
 ## Step 5: Upload Gists (one file per call)

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -1,0 +1,81 @@
+# gh:relay-merge — Apply-Guide Comment Template
+
+Step 6. Post this to the destination: a NEW issue (default) or the
+`--target-issue <N>` issue/PR if supplied.
+
+## Where to post
+
+- **New issue (default):**
+
+  ```bash
+  gh issue create --repo "$DEST_REPO" \
+    --title "Relay: origin PR #<N> — <PR title>" \
+    --body-file "$tmpdir/apply-guide.md"
+  ```
+
+- **Existing target:**
+
+  ```bash
+  gh issue comment "$TARGET_ISSUE" --repo "$DEST_REPO" \
+    --body-file "$tmpdir/apply-guide.md"
+  ```
+
+`--repo "$DEST_REPO"` uses the `owner/repo` resolved in
+`references/remote-resolution.md`; `gh` parses both `owner/repo` and URL
+forms safely.
+
+## Body template
+
+Fill the placeholders and write to `$tmpdir/apply-guide.md` (outer fence is
+`~~~` so the inner ```bash``` blocks nest without breaking it):
+
+~~~markdown
+## Relay of origin PR #<N> — <PR title>
+
+Source PR was **<merged|open>** on the internal remote. `git push` to this
+remote is proxy-blocked, so its commits are relayed as patches below.
+
+### Apply order
+
+| # | Patch (gist) | Description |
+|---|--------------|-------------|
+| 1 | [0001-…](https://gist.github.com/<user>/<id>) | <one-line summary> |
+| 2 | [0002-…](https://gist.github.com/<user>/<id>) | <one-line summary> |
+
+Apply **in this exact order** (each patch builds on the previous):
+
+```bash
+curl -sL <raw-url-0001> | git am
+curl -sL <raw-url-0002> | git am
+# … one line per patch, in order
+```
+
+### Excluded generated artifacts
+
+The following files were stripped from their patches (too large / generated).
+Regenerate them locally after applying:
+
+| Artifact | Regenerate with |
+|----------|-----------------|
+| openapi.json | `make codegen` |
+| package-lock.json | `npm install` |
+
+(Omit this section if nothing was excluded.)
+
+### Verification basis
+
+What was verified on the origin side (from `gh pr view` in Step 1):
+
+- CI: <statusCheckRollup summary — e.g. all checks green>
+- Review: <reviewDecision — e.g. APPROVED by N reviewers>
+- Origin PR: <origin PR URL>
+~~~
+
+## Notes
+
+- The `git am` block uses the **raw** gist URLs captured in
+  `references/gist-relay.md`, not the web URLs.
+- Keep the apply order identical to the numeric patch order from
+  `git format-patch` — out-of-order application breaks `git am`.
+- The verification-basis section reuses data already fetched in Step 1; do
+  not make extra API calls for it.

--- a/claude/skills/gh-relay-merge/references/constraints.md
+++ b/claude/skills/gh-relay-merge/references/constraints.md
@@ -1,0 +1,55 @@
+# gh:relay-merge — Hard Constraints
+
+Deliberate boundaries. Do not violate them even when the user asks "just
+this once" — the safer alternative is usually `gh:pr` (normal push) once
+the network allows it.
+
+## Never fall back to `origin` silently
+
+If the requested `--remote` (or the default `upstream`) does not exist,
+hard-error with the list of available remotes and stop. `origin` is the
+*source* of the relay payload, never a destination. Silent fallback masks
+typos and would relay commits into the wrong (internal) repo. Same rule as
+`gh:issue-implement`'s repo resolution.
+
+## Never push-then-relay — probe first
+
+Relay mode (public gists + a destination issue comment) has irreversible
+side effects. Always run the Step 2 push-capability probe first. If push
+works, take the SIMPLE PATH (`gh:pr`) and stop. Only a *confirmed* block
+(HTTP 403 / block-page marker) triggers relay. Transient/inconclusive
+errors get one backoff retry, then default to not-blocked — never treat a
+flaky network as a confirmed block.
+
+## Never multi-file or parallel `gh gist create`
+
+Upload exactly one patch file per `gh gist create` invocation, sequentially.
+Multi-file gist creation always fails under this network policy regardless
+of file count, and parallel uploads risk rate-limit / abuse triggers.
+
+## Never silently truncate a patch
+
+A patch over `RELAY_PATCH_MAX_BYTES` (40KB) is only ever shrunk by excluding
+**recognized generated-artifact** paths (with a recorded regeneration
+command). If it is still oversized after exclusion, or its bulk is not a
+recognized generated artifact, stop and report — do not truncate or split
+arbitrary code diffs. Truncation corrupts the commit `git am` reconstructs.
+This is the repo's "no silent caps" norm.
+
+## Never auto-close an origin-side issue
+
+Step 7 cleanup (closing a duplicate origin tracking issue with a
+cross-reference) runs **only** with the user's explicit confirmation. No
+auto-close, ever.
+
+## Never post a partial apply-guide
+
+If gist upload stops midway, list the gists already created and stop before
+Step 6. A partial apply-guide (missing patches, wrong order) is worse than
+none — the destination reader would build a broken commit series.
+
+## Size cutoff is a fixed named constant
+
+`RELAY_PATCH_MAX_BYTES = 40960`. Do not implement binary-search
+auto-detection of the real gist limit. The value is named and greppable so
+it can be tuned from future empirical evidence in one place.

--- a/claude/skills/gh-relay-merge/references/gist-relay.md
+++ b/claude/skills/gh-relay-merge/references/gist-relay.md
@@ -1,0 +1,56 @@
+# gh:relay-merge — Gist Upload (one file per call)
+
+Step 5. Uploads each patch file from Step 4 as its own gist.
+
+## The hard rule: one file, one call, sequential
+
+```bash
+for patch in "$tmpdir"/*.patch; do
+    gh gist create "$patch" --desc "relay: $(basename "$patch")"
+    # capture the returned gist URL for the apply-guide table
+done
+```
+
+- **Exactly one file per `gh gist create` invocation.** Multi-file gist
+  creation (`gh gist create a.patch b.patch ...`) is reported to **always**
+  fail under this network policy, regardless of file count — so never batch.
+- **Sequential, never parallel.** Parallel uploads risk rate-limit / abuse
+  triggers on the same policy. Run one at a time.
+
+## Capturing the raw URL
+
+`gh gist create` prints the gist's web URL. The apply-guide needs the
+**raw** URL for `curl … | git am`. Derive it after creation:
+
+```bash
+GIST_URL=$(gh gist create "$patch" --desc "...")      # https://gist.github.com/<user>/<id>
+GIST_ID=${GIST_URL##*/}
+RAW_URL=$(gh gist view "$GIST_ID" --files -q '...' ) # or construct the /raw/ URL
+```
+
+Prefer resolving the raw URL via `gh gist view` so it points at the exact
+file, rather than hand-constructing it. Record `(order, description,
+web URL, raw URL)` per patch for the Step 6 table.
+
+## Failure handling
+
+- **Size-related failure on an individual file** — this means Step 4's
+  exclusion did not bring the file under the cutoff, or a non-artifact file
+  is itself oversized. Report which file and stop. Do **not** split
+  arbitrary code diffs to force it through; only recognized generated
+  artifacts get split (see `references/patch-generation.md`).
+- **Transient/network failure** — retry that single upload once after a
+  short backoff (same policy as the push probe). Still failing → stop.
+- **Any other failure** — report and stop. No automatic retries beyond the
+  one transient-error backoff.
+
+On stop, list the gists already created (so the user knows what exists) and
+do not proceed to Step 6 with a partial set — a partial apply-guide would
+be misleading.
+
+## One-line description per patch
+
+While uploading, keep a human-readable one-line summary for each patch
+(from the commit subject) — it becomes the description column in the
+apply-guide table so the destination reader knows what each patch does
+without opening it.

--- a/claude/skills/gh-relay-merge/references/gist-relay.md
+++ b/claude/skills/gh-relay-merge/references/gist-relay.md
@@ -23,22 +23,21 @@ done
 **raw** URL for `curl … | git am`. Derive it after creation:
 
 ```bash
-GIST_URL=$(gh gist create "$patch" --desc "...")      # https://gist.github.com/<user>/<id>
+GIST_URL=$(gh gist create "$patch" --desc "...")            # https://gist.github.com/<user>/<id>
 GIST_ID=${GIST_URL##*/}
-RAW_URL=$(gh gist view "$GIST_ID" --files -q '...' ) # or construct the /raw/ URL
+RAW_URL=$(gh api "gists/$GIST_ID" --jq '.files[].raw_url')  # exact file's raw URL
 ```
 
-Prefer resolving the raw URL via `gh gist view` so it points at the exact
-file, rather than hand-constructing it. Record `(order, description,
-web URL, raw URL)` per patch for the Step 6 table.
+Resolve the raw URL from the gist API (`.files[].raw_url`) so it points at
+the exact file, rather than hand-constructing it. Record `(order,
+description, web URL, raw URL)` per patch for the Step 6 table.
 
 ## Failure handling
 
-- **Size-related failure on an individual file** — this means Step 4's
-  exclusion did not bring the file under the cutoff, or a non-artifact file
-  is itself oversized. Report which file and stop. Do **not** split
-  arbitrary code diffs to force it through; only recognized generated
-  artifacts get split (see `references/patch-generation.md`).
+- **Size-related failure on an individual file** — Step 4's exclusion did
+  not clear the cutoff, or a non-artifact file is itself oversized. Report
+  which file and stop; do not force it through (no-silent-truncation rule,
+  see `references/patch-generation.md`).
 - **Transient/network failure** — retry that single upload once after a
   short backoff (same policy as the push probe). Still failing → stop.
 - **Any other failure** — report and stop. No automatic retries beyond the

--- a/claude/skills/gh-relay-merge/references/help.md
+++ b/claude/skills/gh-relay-merge/references/help.md
@@ -1,0 +1,80 @@
+# gh:relay-merge — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<origin-PR#>` or `-h`/`--help`/`help` | — | PR on `origin` whose commit range is the relay payload (merged or open) |
+| flag | `--remote <name-or-URL>` | `upstream` | Destination remote. Name (resolved via `git remote get-url`) or raw URL |
+| flag | `--target-issue <N>` | new issue | Post the apply-guide to this existing destination issue/PR instead of creating a new one |
+| flag | `--generated-patterns <globs>` | built-in list | Comma-separated globs marking generated artifacts to strip from oversized patches |
+
+## Usage
+
+```
+/gh-relay-merge 168                              # relay origin PR #168 to upstream
+/gh-relay-merge 168 --remote fork                # relay to remote named 'fork'
+/gh-relay-merge 168 --remote https://github.com/org/repo.git
+/gh-relay-merge 168 --target-issue 42            # post guide to existing issue #42
+/gh-relay-merge 168 --generated-patterns '**/gen/**,*.lock'
+/gh-relay-merge -h                               # this help
+```
+
+## When to use this skill
+
+- You work in `origin` (an isolated internal network, e.g. corporate GHE)
+  and need a merged/open PR's commits to reach a separate `upstream`
+  (e.g. github.com).
+- The network path is **asymmetric**: `git fetch upstream` works, but
+  `git push upstream <branch>` is blocked by a corporate proxy (HTTP 403
+  block page). `gh api` single REST calls work; single-file
+  `gh gist create` works.
+
+## When NOT to use
+
+- `git push upstream` actually works. Use `/gh-pr` directly — this skill's
+  Step 2 probe will detect that and delegate to it anyway.
+- Both remotes are the same host / no asymmetric block exists.
+
+## What the skill does
+
+1. Resolves the origin PR and the `--remote` destination (hard error on a
+   missing remote — never silent fallback to `origin`), and confirms the
+   destination is reachable.
+2. **Probes push capability** with a throwaway-ref `--dry-run` push. If
+   push works, delegates to `gh:pr` and stops (relay is a fallback only).
+3. On confirmed block (HTTP 403 / block-page), resolves the PR's
+   base/head commit range and runs a destination-divergence pre-flight.
+4. `git format-patch` per commit; oversized patches whose bulk is a
+   recognized generated artifact are regenerated without that diff (with a
+   recorded regeneration command); anything else oversized stops the skill.
+5. Uploads each patch via single-file `gh gist create`, one call at a time.
+6. Posts an apply-guide comment (gist table + `git am` steps + regeneration
+   commands + verification basis) to a new or `--target-issue` destination.
+7. Optionally (with explicit confirmation) closes a duplicate origin issue.
+8. Reports the destination URL, gist count, and any split-patch decisions.
+
+## Constants (tunable)
+
+- `RELAY_PATCH_MAX_BYTES` = **40960** (40KB) — fixed safe per-file gist
+  size cutoff. Empirically ~35KB is known-good and ~62KB known-bad; there
+  is no confirmed safe threshold between them, so 40KB is the conservative
+  named constant. Not auto-detected — tune here if real limits change.
+- Default `--generated-patterns`: `**/generated/**`, `**/*.generated.*`,
+  `openapi.json`, `package-lock.json`, `*.lock`, `**/dist/**`, `**/build/**`.
+
+## What this skill will NOT do
+
+- Fall back to `origin` when the requested remote is missing.
+- Push normally and *then* relay — it always probes first.
+- Create a multi-file gist or run gist uploads in parallel.
+- Silently truncate a patch. Only recognized generated-artifact diffs are
+  stripped; any other oversized patch stops the skill with a report.
+- Auto-close an origin-side issue without explicit confirmation.
+
+## Related skills
+
+- `gh:pr` — the SIMPLE PATH delegate when push actually works.
+- `gh:issue-flow` — conventions for posting issue comments / metrics.
+- `gh:issue-implement` — source of the "resolve remote, never silent
+  fallback" pattern reused in `references/remote-resolution.md`.

--- a/claude/skills/gh-relay-merge/references/patch-generation.md
+++ b/claude/skills/gh-relay-merge/references/patch-generation.md
@@ -1,0 +1,100 @@
+# gh:relay-merge — Patch Generation, Size Cutoff, Artifact Exclusion
+
+Steps 3-4. Runs only after Step 2 confirmed the push is blocked.
+
+## Pre-flight (Step 3): destination divergence sanity check
+
+Resolve the PR's real commit range first:
+
+```bash
+HEAD_SHA=$(gh pr view "$N" --repo "$ORIGIN_REPO" --json headRefOid -q .headRefOid)
+BASE_SHA=$(git merge-base "$REMOTE/$DEST_DEFAULT" "$HEAD_SHA")   # or the PR's recorded base
+```
+
+For a merged PR use the merge commit's parents; for an open PR use the
+current head and the PR's base. The range is `BASE..HEAD`.
+
+Before generating anything, compare the files this PR touches against the
+destination's current default branch:
+
+```bash
+git fetch "$REMOTE"
+git diff --name-only "$BASE_SHA" "$HEAD_SHA"        # files the PR changes
+# for each, check it exists / is compatible on $REMOTE/$DEST_DEFAULT
+```
+
+If a touched file falls into a **structurally-known divergence category** —
+env-specific config blocks, files that deliberately differ between the
+internal and external variants — warn the user up front:
+
+```
+[WARN] <path> is known to diverge between internal/external variants.
+Its patch will likely fail `git am` on the destination.
+```
+
+Surface these before uploading, so the user can decide, rather than
+silently shipping patches that fail on the far side.
+
+## Generate patches (Step 4)
+
+```bash
+tmpdir=$(mktemp -d)
+git format-patch "$BASE_SHA".."$HEAD_SHA" -o "$tmpdir"
+```
+
+One `.patch` file per commit, each independently `git am`-able, numbered so
+apply order is unambiguous (`0001-*.patch`, `0002-*.patch`, ...).
+
+## Size cutoff
+
+Named, greppable constant — tune here if empirical limits change:
+
+```bash
+RELAY_PATCH_MAX_BYTES=40960   # 40KB. ~35KB known-good, ~62KB known-bad on
+                              # the observed gist policy; no confirmed safe
+                              # value between them, so 40KB is conservative.
+```
+
+For each patch, `wc -c`. Under the cutoff → ship as-is. Over → artifact
+exclusion below.
+
+## Generated-artifact exclusion
+
+`--generated-patterns` (comma-separated globs) overrides the built-in
+default list:
+
+```
+**/generated/**  **/*.generated.*  openapi.json  package-lock.json  *.lock  **/dist/**  **/build/**
+```
+
+For an oversized patch, check whether the bulk of its diff is under a
+matching path (`git format-patch` reports per-file; or inspect the patch's
+`diff --git` headers). If so, regenerate that one commit's patch with those
+paths excluded via pathspec:
+
+```bash
+git format-patch -1 "$SHA" -o "$tmpdir" -- . \
+  ':(exclude)**/generated/**' ':(exclude)*.lock'   # etc., per matched globs
+```
+
+Record a regeneration note for each excluded artifact so the destination
+can rebuild it — e.g. `openapi.json` → `make codegen`, a lockfile →
+`npm install`. These notes go into the apply-guide comment (Step 6).
+
+## No silent truncation
+
+If a patch is **still** over `RELAY_PATCH_MAX_BYTES` after excluding
+recognized generated artifacts — or is oversized and *not* attributable to
+any known generated pattern — do **not** truncate or split arbitrary code
+diffs. Stop and report:
+
+```
+[FAIL] <NNNN>-<name>.patch is <size> bytes (> RELAY_PATCH_MAX_BYTES=40960)
+and its bulk is not a recognized generated artifact.
+Refusing to truncate — arbitrary truncation would corrupt the applied commit.
+Options: add its path to --generated-patterns if it IS generated, or split
+the origin commit into smaller commits and re-run.
+```
+
+Arbitrary content truncation corrupts the commit `git am` reconstructs;
+only recognized generated-artifact diffs are ever dropped.

--- a/claude/skills/gh-relay-merge/references/patch-generation.md
+++ b/claude/skills/gh-relay-merge/references/patch-generation.md
@@ -4,10 +4,13 @@ Steps 3-4. Runs only after Step 2 confirmed the push is blocked.
 
 ## Pre-flight (Step 3): destination divergence sanity check
 
-Resolve the PR's real commit range first:
+Resolve the PR's real commit range first. Reuse the `headRefOid` already
+captured by Step 1's `gh pr view` (no re-fetch), and resolve `$DEST_DEFAULT`
+— the destination's default branch (e.g. `git ls-remote --symref "$REMOTE"
+HEAD`) — once:
 
 ```bash
-HEAD_SHA=$(gh pr view "$N" --repo "$ORIGIN_REPO" --json headRefOid -q .headRefOid)
+HEAD_SHA=$HEAD_REF_OID                                          # from Step 1; no re-fetch
 BASE_SHA=$(git merge-base "$REMOTE/$DEST_DEFAULT" "$HEAD_SHA")   # or the PR's recorded base
 ```
 
@@ -18,7 +21,7 @@ Before generating anything, compare the files this PR touches against the
 destination's current default branch:
 
 ```bash
-git fetch "$REMOTE"
+# Step 1 already fetched "$REMOTE"; re-fetch only if the branch may have moved.
 git diff --name-only "$BASE_SHA" "$HEAD_SHA"        # files the PR changes
 # for each, check it exists / is compatible on $REMOTE/$DEST_DEFAULT
 ```

--- a/claude/skills/gh-relay-merge/references/patch-generation.md
+++ b/claude/skills/gh-relay-merge/references/patch-generation.md
@@ -41,7 +41,7 @@ silently shipping patches that fail on the far side.
 ## Generate patches (Step 4)
 
 ```bash
-tmpdir=$(mktemp -d)
+# Reuse the $tmpdir initialized in Step 2's push-probe — do not re-create it.
 git format-patch "$BASE_SHA".."$HEAD_SHA" -o "$tmpdir"
 ```
 

--- a/claude/skills/gh-relay-merge/references/push-probe.md
+++ b/claude/skills/gh-relay-merge/references/push-probe.md
@@ -14,11 +14,16 @@ never a protected/default branch name — and `--dry-run` so nothing is
 actually written:
 
 ```bash
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
 LOCAL=<PR head SHA or local branch>
 PROBE_REF="refs/heads/relay-probe-$(date -u +%s)"
 git push --dry-run "$REMOTE" "$LOCAL:$PROBE_REF" 2>&1 | tee "$tmpdir/probe.out"
 PROBE_RC=${PIPESTATUS[0]}
 ```
+
+`$tmpdir` is created here — the earliest point it's needed — and reused
+by every later step (patch generation, gist upload); no step re-creates it.
 
 `--dry-run` still performs the network negotiation with the remote, so a
 proxy block page surfaces here exactly as it would on a real push, without

--- a/claude/skills/gh-relay-merge/references/push-probe.md
+++ b/claude/skills/gh-relay-merge/references/push-probe.md
@@ -1,0 +1,71 @@
+# gh:relay-merge — Push-Capability Probe
+
+Step 2's branch point. The whole skill exists because the network path to
+`upstream` is **asymmetric**: fetch works, push is proxy-blocked. But that
+block is environment-specific and may not apply, so the skill must never
+assume it — it probes first and only falls into relay mode on a *confirmed*
+block. If push actually works, the correct answer is the SIMPLE PATH
+(delegate to `gh:pr`), not relay.
+
+## The probe
+
+Use a **throwaway ref name** on the remote — never a real branch, and
+never a protected/default branch name — and `--dry-run` so nothing is
+actually written:
+
+```bash
+LOCAL=<PR head SHA or local branch>
+PROBE_REF="refs/heads/relay-probe-$(date -u +%s)"
+git push --dry-run "$REMOTE" "$LOCAL:$PROBE_REF" 2>&1 | tee "$tmpdir/probe.out"
+PROBE_RC=${PIPESTATUS[0]}
+```
+
+`--dry-run` still performs the network negotiation with the remote, so a
+proxy block page surfaces here exactly as it would on a real push, without
+creating the ref.
+
+## Classifying the result
+
+| Signal | Meaning | Action |
+|---|---|---|
+| `PROBE_RC == 0` | push would succeed | **SIMPLE PATH** — delegate to `gh:pr`, stop |
+| Output matches a block signal (below) | confirmed blocked | continue to Step 3 (relay) |
+| Any other non-zero (transient/network) | inconclusive | retry once (below) |
+
+### Block signals (confirmed blocked)
+
+Treat only these as a definite block — match against the git/curl error
+text captured in `probe.out`:
+
+- `HTTP 403` / `403 Forbidden`
+- an HTML block-page marker (a configurable regex, default e.g.
+  `block(ed)?|proxy|forbidden|corporate policy|access denied`)
+
+Anything else — connection reset, timeout, DNS hiccup, `Could not resolve
+host`, TLS errors — is **inconclusive**, not a confirmed block. Flaky
+networks must not produce a false "blocked" positive that pushes the user
+into the heavier relay flow unnecessarily.
+
+## One retry with backoff
+
+On an inconclusive result, wait a short backoff and re-probe exactly once:
+
+```bash
+sleep 3
+git push --dry-run "$REMOTE" "$LOCAL:$PROBE_REF" 2>&1 | tee "$tmpdir/probe2.out"
+```
+
+- Second probe `rc == 0` → SIMPLE PATH.
+- Second probe shows a block signal → relay mode.
+- Second probe still inconclusive → **treat as not-blocked** and take the
+  SIMPLE PATH. Rationale: relay mode has irreversible side effects (public
+  gists, a destination issue comment); do not trigger it on ambiguous
+  evidence. If the subsequent `gh:pr` push then genuinely fails, the user
+  can re-run this skill, and the now-consistent block will be confirmed.
+
+## SIMPLE PATH delegation
+
+When push works, hand off to `gh:pr` (or an equivalent normal branch push
++ PR creation) for the destination remote and stop. Note in the Step 8
+report that the simple path was used and relay mode was skipped. Do not
+generate patches or create any gist.

--- a/claude/skills/gh-relay-merge/references/remote-resolution.md
+++ b/claude/skills/gh-relay-merge/references/remote-resolution.md
@@ -1,0 +1,77 @@
+# gh:relay-merge — Destination Remote Resolution
+
+Detailed procedure for Step 1's `--remote` resolution. Mirrors
+`gh-issue-implement`'s repo-resolution rule: **resolve, hard-error on a
+missing remote, never silently fall back.** The convention in this repo's
+asymmetric-network setup is `origin` = internal (isolated GHE),
+`upstream` = external (github.com).
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we're in a git repo.
+
+2. Determine the destination:
+   - If `--remote <value>` was passed, use `<value>`.
+   - Otherwise default to the remote literally named `upstream`.
+
+3. Decide whether `<value>` is a **name** or a **raw URL**:
+   - Contains `://` or matches `git@host:owner/repo` → treat as a raw URL.
+   - Otherwise treat as a remote name.
+
+4. **Name path** — validate and resolve the URL:
+
+   ```bash
+   git remote get-url "$REMOTE_NAME"
+   ```
+
+   If this fails, list available remotes (`git remote -v`) and stop:
+
+   ```
+   Error: remote '<name>' not found. Available remotes:
+   origin    https://ghe.corp.example/team/repo.git (fetch)
+   upstream  https://github.com/org/repo.git (fetch)
+   ```
+
+5. **Raw-URL path** — do not require a configured remote. Use the URL
+   directly with `git ls-remote <url>` / `git push <url> ...`, or add a
+   throwaway remote for the run:
+
+   ```bash
+   git remote add relay-tmp "$REMOTE_URL"   # remove in cleanup
+   ```
+
+6. Extract `owner/repo` from the resolved URL for `gh` calls that need
+   `--repo` (the destination issue/comment in Step 6):
+
+   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git` → `<owner>/<repo>`
+
+   Store as `DEST_REPO`.
+
+## The default-`upstream` hard-error rule
+
+If `--remote` was **omitted** and no remote named `upstream` exists, stop
+immediately:
+
+```
+Error: no 'upstream' remote and no --remote given.
+origin is the internal remote and is never a relay destination.
+Pass --remote <name-or-URL> explicitly.
+```
+
+Do **not** fall back to `origin`. `origin` is the *source* of the relay
+payload; relaying to it is always wrong, and a silent fallback would mask
+a typo in the remote name.
+
+## Reachability check
+
+Before any patch work, confirm the destination actually answers:
+
+```bash
+git fetch "$REMOTE_NAME"          # name path
+git ls-remote "$REMOTE_URL" >/dev/null   # raw-URL path
+```
+
+Reachability failing here is distinct from a *push* block — fetch is
+expected to work even when push is proxy-blocked. If fetch itself fails,
+stop and report (the destination is simply unreachable, not push-blocked).

--- a/claude/skills/gh-relay-merge/references/remote-resolution.md
+++ b/claude/skills/gh-relay-merge/references/remote-resolution.md
@@ -48,6 +48,10 @@ asymmetric-network setup is `origin` = internal (isolated GHE),
 
    Store as `DEST_REPO`.
 
+Downstream steps (2-6) refer to the resolved destination as `$REMOTE` — the
+remote name on the name path, or the `relay-tmp` name added on the raw-URL
+path.
+
 ## The default-`upstream` hard-error rule
 
 If `--remote` was **omitted** and no remote named `upstream` exists, stop


### PR DESCRIPTION
## Summary
- 사내 GHE(origin)→github.com(upstream) 역병합 시 push 만 비대칭 차단되는 상황을 위한 신규 스킬 `gh:relay-merge` 를 설계·작성했다(이슈 #1162 실측 사례 기반).

## Changes
- `claude/skills/gh-relay-merge/SKILL.md`: 8-step 워크플로우(preconditions → push-probe 분기 → commit-range/pre-flight → format-patch → 개별 gist 업로드 → apply-guide 코멘트 → 선택적 origin cleanup → report). 100줄 이내(97줄).
- `references/push-probe.md`: 핵심 분기점 — `git push --dry-run` 프로브로 실제 차단 여부를 확인하고, 정상 push 가능하면 즉시 `gh:pr` 로 위임·종료. 오탐 방지를 위해 1회 backoff 재시도, 여전히 불확실하면 SIMPLE PATH.
- `references/remote-resolution.md`: `--remote` 이름/URL 모두 허용, `upstream` remote 없고 `--remote` 미지정 시 하드 에러(gh-issue-implement 의 "silent fallback 금지" 패턴 재사용).
- `references/patch-generation.md`: `RELAY_PATCH_MAX_BYTES=40960`(고정 상수, 실측 35KB 성공/62KB 실패 사이 보수값) 초과 시 생성물(`--generated-patterns` 글롭) 제외 재생성, 그래도 초과하면 무음 truncation 대신 정지·보고.
- `references/gist-relay.md`: 파일당 1회 `gh gist create`, 순차 실행(멀티파일 업로드는 정책상 항상 실패하므로).
- `references/apply-guide-template.md`: 목적지 이슈/PR 코멘트 템플릿(gist 순서 표 + `git am` 안내 + 재생성 커맨드 + 검증 근거).
- `references/help.md`, `references/constraints.md`: usage/when-(not)-to-use, 8개 하드 룰(silent fallback 금지 · probe-first · multi-file gist 금지 · silent truncation 금지 · auto-close 금지 등).

## Test plan
- [x] `bash tests/golden_rules/test_golden_rules.sh` — 전체 통과(이모지 없음 포함).
- [x] `./tests/test` — 1189 passed, 0 failed (전체 bats + pytest + golden rules; 신규 파일은 markdown-only 라 기존 스킬 테스트에 영향 없음 확인).
- [ ] 실제 push-차단 네트워크에서 end-to-end 수동 검증(사내망 필요, 이 PR 범위 밖).

## Related
Closes #1162

---
<details>
<summary>🤖 AI Metrics · 📊 ~8000 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~8000 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
