### PR TITLE
feat(gh-pr-reply): remote 위치 인자 추가 — 동일 호스트 다중 remote repo 대상 정확화 (#1165)

### DIFF
--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -80,11 +80,12 @@ Await all three Agents, then:
 
 ## Step 5: pr-reply (per reply_mode)
 
-- `inline` (default) → run `Skill(gh:pr-reply, "<pr>")` immediately. Step 3
-  was awaited, so gemini/codex comments are already posted — reply order is
-  deterministic, no delay needed. `gh:pr-reply` takes no remote arg; it
-  targets the checked-out working tree's repo (`references/constraints.md`).
-- `defer` → `Skill(devx:schedule, "--time <reply_delay> \"/gh-pr-reply <pr>\"")`.
+- `inline` (default) → run `Skill(gh:pr-reply, "<pr> <remote>")` immediately.
+  Step 3 was awaited, so gemini/codex comments are already posted — reply
+  order is deterministic, no delay needed. The `<remote>` is threaded so
+  `gh:pr-reply` resolves the same target repo this skill did, not gh's
+  default-repo heuristic (`references/constraints.md`).
+- `defer` → `Skill(devx:schedule, "--time <reply_delay> \"/gh-pr-reply <pr> <remote>\"")`.
 - `none` → skip.
 
 ## Step 6: Report

--- a/claude/skills/devx-pr-review-all/references/constraints.md
+++ b/claude/skills/devx-pr-review-all/references/constraints.md
@@ -43,15 +43,14 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
 
 - No emojis anywhere. POSIX-compatible shell snippets (`[ ]`, `>/dev/null 2>&1`).
 
-- **`gh:pr-reply` has no remote positional at all** — its Step 1 resolves
-  `TARGET_REPO` via `gh repo view --json nameWithOwner` (no `-R`), which
-  reads the repo of whatever is checked out in the working tree, not the
-  `<remote>` arg this skill parsed. In practice this is a non-issue on the
-  supported path: Step 2 already ran `gh pr checkout <pr> -R <TARGET_REPO>`,
-  so by Step 5 the working tree *is* the PR's head branch/repo and
-  `gh repo view` resolves correctly without a flag. The residual gap is
-  local multi-remote ambiguity (e.g. both `origin` and `upstream` point at
-  GitHub) where gh's own default-repo heuristic, not this skill's `<remote>`
-  arg, decides the match. Do not invent a `--remote`/`-R` flag for
-  `gh:pr-reply` — it does not exist; fix belongs upstream in that skill if
-  ever needed.
+- **`gh:pr-reply` now takes a `[remote]` positional** (issue #1165) — Step 5
+  threads the same `<remote>` this skill parsed as `gh:pr-reply`'s second
+  positional arg (`Skill(gh:pr-reply, "<pr> <remote>")`). `gh:pr-reply` then
+  resolves `TARGET_REPO` by parsing that remote's URL (SSOT helper
+  `_gh_pr_review_resolve_target_repo`), not from `gh`'s default-repo
+  heuristic. This closes the former local multi-remote ambiguity (e.g. both
+  `origin` and `upstream` on GitHub): the reply now lands on the intended
+  repo regardless of which remote gh would have guessed. The Step 2
+  `gh pr checkout <pr> -R <TARGET_REPO>` is still load-bearing for
+  `/simplify` (working-tree diff), but no longer the only thing keeping the
+  reply pass on the right repo.

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -44,8 +44,9 @@ request-changes) — that is `gh:pr-approve`.
    Each lane is soft-fail.
 4. Commit + push any `/simplify` changes (only if the working tree changed),
    always with an explicit `-m` message.
-5. Reply — inline `gh:pr-reply` (default), or deferred via `devx:schedule`
-   (`--defer-reply M`), or skipped (`--no-reply`).
+5. Reply — inline `gh:pr-reply <pr> <remote>` (default), or deferred via
+   `devx:schedule` (`--defer-reply M`), or skipped (`--no-reply`). The
+   `<remote>` is threaded so the reply pass resolves the same target repo.
 6. Print one `[OK]`/`[SKIP]`/`[WARN]` report line.
 
 ## What the skill will NOT do

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -35,23 +35,32 @@ Positional args: `<pr-number> [remote]` (`remote` defaults to `origin`).
 number,url,headRefName,baseRefName`, stop if no PR; (3) never guess, never
 pick "the latest PR".
 
-**TARGET_REPO** — resolve from `<remote>`, not from `gh`'s default-repo
-heuristic, so a repo with two remotes on the same host (e.g. `origin` +
-`upstream`) replies to the intended one. Source the SSOT helper and parse
-the remote's URL (network-free):
+**TARGET_REPO** — resolve from the `[remote]` positional, not from `gh`'s
+default-repo heuristic, so a repo with two remotes on the same host (e.g.
+`origin` + `upstream`) replies to the intended one. Bind `remote` to the
+positional (default `origin`), source the SSOT helper, and parse the
+remote's URL (network-free):
 
 ```sh
 # DOTFILES_FORCE_INIT=1 is load-bearing: the file's interactive guard
 # otherwise returns early in a non-interactive shell and the helper is
-# never defined.
+# never defined. `remote` is the [remote] positional; ${remote:-origin}
+# keeps the block self-contained whether or not it was set.
 export DOTFILES_FORCE_INIT=1
 . "${SHELL_COMMON}/functions/gh_pr_review.sh"
-TARGET_REPO=$(_gh_pr_review_resolve_target_repo "<remote>") || {
-  echo "Cannot resolve remote '<remote>' to a repo" >&2; exit 1; }
+TARGET_REPO=$(_gh_pr_review_resolve_target_repo "${remote:-origin}") || {
+  echo "Cannot resolve remote '${remote:-origin}' to a repo" >&2; exit 1; }
 ```
 
 Pass `TARGET_REPO` (`--repo "$TARGET_REPO"` / `-R`, or as the
 `repos/$TARGET_REPO/...` path) on **every** subsequent `gh` API call.
+
+**Default-remote tradeoff** — `[remote]` defaults to `origin`. This is more
+predictable than the old `gh repo view` default-repo heuristic, but note the
+fork workflow where `origin` is your fork and `upstream` is the canonical
+repo: there, reply explicitly with `/gh:pr-reply <N> upstream`. On the
+`devx:pr-review-all` / `gh:issue-flow` path the remote is threaded through, so
+the default only applies to a bare manual `/gh:pr-reply <N>`.
 
 ## Step 2: Fetch All Review Comments
 

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gh:pr-reply
 description: >-
-  Fetch code review comments on a GitHub PR, evaluate each one, apply valid fixes, and leave an individual reply on every comment (Accepted with what changed, or Declined with reasoning). Use when the user runs /gh:pr-reply, /gh-pr-reply, or asks "PR 리뷰 코멘트 확인하고 수정", "리뷰 답변 달아", "PR 123 코멘트 처리해". Defaults to the PR for the current branch; accepts an explicit PR number as an argument. Every comment MUST get a reply — bot comments (gemini, sourcery, copilot) included. Accepts `-h`/`--help`/`help` to print usage.
+  Fetch code review comments on a GitHub PR, evaluate each one, apply valid fixes, and leave an individual reply on every comment (Accepted with what changed, or Declined with reasoning). Use when the user runs /gh:pr-reply, /gh-pr-reply, or asks "PR 리뷰 코멘트 확인하고 수정", "리뷰 답변 달아", "PR 123 코멘트 처리해". Defaults to the PR for the current branch; accepts an explicit PR number and an optional `[remote]` positional (the remote pins the target repo when several remotes share one GitHub host). Every comment MUST get a reply — bot comments (gemini, sourcery, copilot) included. Accepts `-h`/`--help`/`help` to print usage.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 metadata:
   model_recommendation:
@@ -25,14 +25,33 @@ reply to each with the outcome. **Politeness rule** — reviewers (humans and
 bots alike) must see an explicit response on every thread. Silent fixes are
 not acceptable; silent declines are worse.
 
-## Step 1: Resolve Target PR
+## Step 1: Resolve Target PR + Repo
 
 Record `START_TS=$(date +%s)` immediately (elapsed tracking in Step 7).
-Precedence: (1) **explicit arg** — `/gh:pr-reply 123` → PR #123; (2)
-**current branch** — `gh pr view --json number,url,headRefName,baseRefName`,
-stop if no PR; (3) never guess, never pick "the latest PR". Also capture
-`TARGET_REPO` via `gh repo view --json nameWithOwner -q .nameWithOwner` and
-use it in all subsequent API calls.
+Positional args: `<pr-number> [remote]` (`remote` defaults to `origin`).
+
+**PR number** precedence: (1) **explicit arg** — `/gh:pr-reply 123` → PR
+#123; (2) **current branch** — `gh pr view --json
+number,url,headRefName,baseRefName`, stop if no PR; (3) never guess, never
+pick "the latest PR".
+
+**TARGET_REPO** — resolve from `<remote>`, not from `gh`'s default-repo
+heuristic, so a repo with two remotes on the same host (e.g. `origin` +
+`upstream`) replies to the intended one. Source the SSOT helper and parse
+the remote's URL (network-free):
+
+```sh
+# DOTFILES_FORCE_INIT=1 is load-bearing: the file's interactive guard
+# otherwise returns early in a non-interactive shell and the helper is
+# never defined.
+export DOTFILES_FORCE_INIT=1
+. "${SHELL_COMMON}/functions/gh_pr_review.sh"
+TARGET_REPO=$(_gh_pr_review_resolve_target_repo "<remote>") || {
+  echo "Cannot resolve remote '<remote>' to a repo" >&2; exit 1; }
+```
+
+Pass `TARGET_REPO` (`--repo "$TARGET_REPO"` / `-R`, or as the
+`repos/$TARGET_REPO/...` path) on **every** subsequent `gh` API call.
 
 ## Step 2: Fetch All Review Comments
 

--- a/claude/skills/gh-pr-reply/references/help.md
+++ b/claude/skills/gh-pr-reply/references/help.md
@@ -5,17 +5,21 @@
 | # | Name | Default | Description |
 |---|------|---------|-------------|
 | 1 | PR number, or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `123` |
+| 2 | remote name | `origin` | Git remote used to resolve the target repo (`owner/repo`) — pins the repo when multiple remotes share one GitHub host |
 
 ## Usage
 
 - `/gh-pr-reply` — process review comments on the PR for the current branch
 - `/gh-pr-reply 123` — process review comments on PR #123 explicitly
+- `/gh-pr-reply 123 upstream` — target PR #123 on the `upstream` remote's repo
 - `/gh-pr-reply -h` / `--help` / `help` — print this help
 
 ## What the skill does
 
 1. Resolves the target PR (explicit arg first, else the current branch's
-   PR via `gh pr view --json`). Never guesses "the latest PR".
+   PR via `gh pr view --json`). Never guesses "the latest PR". Resolves
+   the target repo (`owner/repo`) by parsing the `[remote]` arg's URL
+   (default `origin`), so multi-remote repos reply to the intended host.
 2. Fetches all review comments from the three GitHub endpoints (inline
    thread, issue comment, review summary) per
    `references/comment-fetching.md`, deduped and filtered to threads you
@@ -50,6 +54,8 @@
 - **Good**: after pushing commits, `/gh-pr-reply` — processes every new
   review comment on your branch's PR.
 - **Good**: `/gh-pr-reply 99` — force target PR #99 even from a different branch.
+- **Good**: `/gh-pr-reply 99 upstream` — target PR #99 on the `upstream`
+  remote's repo when `origin` and `upstream` both point at GitHub.
 - **Bad**: running from a branch with no PR — skill stops and asks you to
   open one first.
 - **Bad**: expecting the skill to fix unrelated files — it refuses scope creep.

--- a/tests/bats/skills/gh_pr_reply_remote.bats
+++ b/tests/bats/skills/gh_pr_reply_remote.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_reply_remote.bats
+# Behavior tests for the `[remote]` positional added to the gh:pr-reply
+# skill (issue #1165). The skill's Step 1 resolves TARGET_REPO by parsing
+# the named remote's URL via the SSOT helper
+# `_gh_pr_review_resolve_target_repo` — NOT via gh's default-repo
+# heuristic. These tests prove the remote arg actually selects the repo
+# in a multi-remote repo (origin + upstream on the same GitHub host),
+# which is the edge case the issue closes.
+#
+# Reuses the arg-parse fixture (which sources
+# shell-common/functions/gh_pr_review.sh — the same file the skill sources)
+# so the production resolver is exercised, not a copy.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh"
+
+    # Fake repo with two GitHub remotes on the same host.
+    MULTI_REMOTE_REPO="$TEST_TEMP_HOME/multi-remote"
+    git init -q --initial-branch=main "$MULTI_REMOTE_REPO"
+    (
+        cd "$MULTI_REMOTE_REPO" || exit 1
+        git remote add origin "git@github.com:owner-a/repo-a.git"
+        git remote add upstream "https://github.com/owner-b/repo-b.git"
+    )
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---- the remote arg selects the target repo -------------------------------
+
+@test "remote: default (no arg) resolves origin's repo" {
+    cd "$MULTI_REMOTE_REPO" || return 1
+    run _gh_pr_review_resolve_target_repo
+    assert_success
+    [ "$output" = "owner-a/repo-a" ]
+}
+
+@test "remote: explicit 'origin' resolves owner-a/repo-a" {
+    cd "$MULTI_REMOTE_REPO" || return 1
+    run _gh_pr_review_resolve_target_repo origin
+    assert_success
+    [ "$output" = "owner-a/repo-a" ]
+}
+
+@test "remote: explicit 'upstream' resolves owner-b/repo-b (not origin)" {
+    cd "$MULTI_REMOTE_REPO" || return 1
+    run _gh_pr_review_resolve_target_repo upstream
+    assert_success
+    [ "$output" = "owner-b/repo-b" ]
+}
+
+# ---- rejection paths ------------------------------------------------------
+
+@test "remote: unknown remote fails with actionable message + remote list" {
+    cd "$MULTI_REMOTE_REPO" || return 1
+    run _gh_pr_review_resolve_target_repo does-not-exist
+    assert_failure
+    assert_output --partial "Remote 'does-not-exist' not found"
+}

--- a/tests/bats/skills/gh_pr_reply_remote.bats
+++ b/tests/bats/skills/gh_pr_reply_remote.bats
@@ -39,21 +39,21 @@ teardown() {
     cd "$MULTI_REMOTE_REPO" || return 1
     run _gh_pr_review_resolve_target_repo
     assert_success
-    [ "$output" = "owner-a/repo-a" ]
+    assert_output "owner-a/repo-a"
 }
 
 @test "remote: explicit 'origin' resolves owner-a/repo-a" {
     cd "$MULTI_REMOTE_REPO" || return 1
     run _gh_pr_review_resolve_target_repo origin
     assert_success
-    [ "$output" = "owner-a/repo-a" ]
+    assert_output "owner-a/repo-a"
 }
 
 @test "remote: explicit 'upstream' resolves owner-b/repo-b (not origin)" {
     cd "$MULTI_REMOTE_REPO" || return 1
     run _gh_pr_review_resolve_target_repo upstream
     assert_success
-    [ "$output" = "owner-b/repo-b" ]
+    assert_output "owner-b/repo-b"
 }
 
 # ---- rejection paths ------------------------------------------------------

--- a/tests/bats/skills/gh_pr_reply_remote.bats
+++ b/tests/bats/skills/gh_pr_reply_remote.bats
@@ -21,7 +21,9 @@ setup() {
 
     # Fake repo with two GitHub remotes on the same host.
     MULTI_REMOTE_REPO="$TEST_TEMP_HOME/multi-remote"
-    git init -q --initial-branch=main "$MULTI_REMOTE_REPO"
+    # No --initial-branch: these tests never reference the branch name, so
+    # omitting it keeps the setup working on Git < 2.28.
+    git init -q "$MULTI_REMOTE_REPO"
     (
         cd "$MULTI_REMOTE_REPO" || exit 1
         git remote add origin "git@github.com:owner-a/repo-a.git"


### PR DESCRIPTION
## Summary

`gh:pr-reply` 스킬에 2번째 위치 인자 `[remote]`(기본 `origin`)를 추가하여,
`TARGET_REPO` 를 `gh` 의 default-repo heuristic 이 아니라 해당 remote 의 URL
파싱으로 해석하도록 했다. `origin` + `upstream` 처럼 동일 GitHub 호스트에
remote 가 2개 이상인 repo 에서 reply 대상이 의도한 repo 로 고정된다.

## Changes

- **`gh-pr-reply/SKILL.md`** — Step 1 을 "Resolve Target PR + Repo" 로 확장.
  SSOT 헬퍼 `_gh_pr_review_resolve_target_repo`(pr-reply/pr-approve/pr-review
  공유) 재사용 — 네트워크 불필요. 파일의 interactive guard 때문에 비대화형
  셸에서는 함수가 정의되지 않으므로 `DOTFILES_FORCE_INIT=1` 로 강제 로드
  (load-bearing, 검증 완료). frontmatter description 및 `references/help.md`
  (arg 표·usage·예시) 갱신.
- **`devx-pr-review-all`** — Step 5 가 inline·defer 양쪽 reply 호출에
  `<remote>` 를 스레딩(`Skill(gh:pr-reply, "<pr> <remote>")`). `constraints.md`
  / `help.md` 에 기술돼 있던 "gh:pr-reply 는 remote 인자 없음" 한계 서술을
  해소 내용으로 갱신.
- **tests** — `tests/bats/skills/gh_pr_reply_remote.bats` 신규(4건):
  다중 remote(origin→owner-a/repo-a, upstream→owner-b/repo-b) fixture 에서
  remote 인자가 대상 repo 를 실제로 선택함을 검증 + 미존재 remote 거부.

## Acceptance criteria (#1165)

- [x] `gh:pr-reply` 가 remote 인자를 받아 모든 API 호출의 대상 repo 에 반영
- [x] `devx:pr-review-all` 이 reply 단계에 remote 전달
- [x] 파서/동작 테스트 추가

## Test

- 신규 bats 4/4 pass · 관련 focused bats 40/40 pass
- help-topics/devx-help pytest 989 pass · golden rules pass
- 기존 실패 2건(gh-pr-merge-emergency ai-metrics doc-guard, helper_fallback
  drift-guard)은 baseline 에서도 재현되는 선행 실패로 본 변경과 무관

Closes #1165

<details>
<summary>🤖 AI Metrics · 📊 ~48000 tokens · 👤 ~2 h · 🤖 ~6 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~48000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics:gh-pr -->

</details>
