### PR TITLE
test(git-worktree): teardown 테스트의 objectFormat=sha256 를 preciousObjects 로 교체 (#1166)

### DIFF
--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -822,6 +822,10 @@ GH_EOF
     run git -C "$CLONE" config extensions.worktreeConfig
     assert_failure
     [ "$(git -C "$CLONE" config core.repositoryformatversion)" = "1" ]
+    # Pin the *cause*, not just the effect: the other extension must survive
+    # teardown — otherwise a bug that drops preciousObjects while leaving
+    # version=1 would slip through (codex review, PR #1172).
+    [ "$(git -C "$CLONE" config extensions.preciousObjects)" = "true" ]
 
     git -C "$CLONE" config --unset extensions.preciousObjects 2>/dev/null || true
 }

--- a/tests/bats/functions/git_worktree_teardown.bats
+++ b/tests/bats/functions/git_worktree_teardown.bats
@@ -798,21 +798,30 @@ GH_EOF
 }
 
 @test "teardown: other active extensions — keeps repositoryformatversion=1 after last worktree" {
-    # If the repo uses another extension (e.g. objectFormat=sha256),
+    # If the repo uses another extension (e.g. preciousObjects), the format
     # version must stay at 1 even after the last linked worktree is gone.
+    #
+    # NB: use preciousObjects, NOT objectFormat=sha256. The clone's objects
+    # are SHA-1, so declaring extensions.objectFormat=sha256 makes git read
+    # the SHA-1 index as SHA-256 and abort with
+    #   fatal: unknown index entry format 0x45450000
+    # on the very next git operation (issue #1166). preciousObjects is a
+    # storage-agnostic extension that satisfies the same code path
+    # (git_worktree.sh keeps version=1 while any extensions.* key remains)
+    # without corrupting the repo.
     git -C "$CLONE" config core.repositoryformatversion 1
     git -C "$CLONE" config extensions.worktreeConfig true
-    git -C "$CLONE" config extensions.objectFormat sha256
+    git -C "$CLONE" config extensions.preciousObjects true
 
     _advance_origin_main
 
     run_in_bash "cd '$WORKTREE' && gwt teardown --force 2>&1"
     assert_success
 
-    # worktreeConfig removed, but version stays 1 due to objectFormat.
+    # worktreeConfig removed, but version stays 1 due to preciousObjects.
     run git -C "$CLONE" config extensions.worktreeConfig
     assert_failure
     [ "$(git -C "$CLONE" config core.repositoryformatversion)" = "1" ]
 
-    git -C "$CLONE" config --unset extensions.objectFormat 2>/dev/null || true
+    git -C "$CLONE" config --unset extensions.preciousObjects 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary
- `git_worktree_teardown.bats` 의 "other active extensions" 케이스가 이 환경에서 결정적으로 실패하던 원인을 테스트 가정 결함으로 규명하고 수정했다.
- 실패 원인: SHA-1 저장소(clone)에 `extensions.objectFormat=sha256` 를 선언 → 다음 git 연산이 SHA-1 index 를 SHA-256 으로 오독 → `fatal: unknown index entry format 0x45450000` (status 128).

## Changes
- `tests/bats/functions/git_worktree_teardown.bats`: "other active extensions" 케이스의 보조 확장을 `extensions.objectFormat=sha256` → `extensions.preciousObjects=true` 로 교체. production 코드(`git_worktree.sh`)는 `extensions.*` 키의 **종류가 아니라 존재 여부**만 확인하므로 저장소 포맷과 무관한 확장으로 동일 코드 경로(worktreeConfig 제거 후에도 `repositoryformatversion=1` 유지)를 손상 없이 검증한다.
- 회귀 방지를 위해 objectFormat 을 쓰면 안 되는 이유를 테스트 주석으로 명시.

## Test plan
- [x] `bats tests/bats/functions/git_worktree_teardown.bats` → 35/35 green (이전: 케이스 35 status 128 실패)
- [x] 원인 재현 확인: `extensions.objectFormat sha256` 은 fetch 를 status 128 로 실패, `extensions.preciousObjects true` 는 정상
- [x] pytest 전체 green (1189 passed)

> 주: `mise run test` 실행 시 본 PR 과 무관한 기존 실패 5건(SKILL.md doc-guard, plugin scaffold json, codex budget)이 `main`(38a7e14b)에서도 동일하게 관측됨 — 본 이슈 범위 밖.

## Related
Closes #1166

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
