### PR TITLE
feat(claude/skills): add claude-to-codex skill (phase docs → Codex)

### DIFF
--- a/claude/skills/devx-claude-to-codex/SKILL.md
+++ b/claude/skills/devx-claude-to-codex/SKILL.md
@@ -36,9 +36,10 @@ content verbatim, then stop. No API calls, no file mutation.
 
 ## Step 1: Read Inputs
 
-Read every reference document the user listed, then the target phase
-document. Scan repo structure (`AGENTS.md`, `CLAUDE.md`) for context the
-transformed document should preserve.
+Read every reference document the user listed plus the target phase
+document in one batch (they are independent reads). Scan repo structure
+(`AGENTS.md`, `CLAUDE.md`) for context the transformed document should
+preserve.
 
 ## Step 2: Decide Single vs Split
 
@@ -46,9 +47,8 @@ Evaluate whether the phase document is already narrow and deterministic
 enough for one Codex pass. Default to a single output document — do not
 split by default. Split into multiple numbered documents only when a
 trigger condition in `references/output-and-split.md` is met; follow that
-file's split-axis guidance (backend/frontend/shared,
-transport/state/UI, infrastructure/integration/UX, deterministic-first/
-uncertain-later) and prefer the minimum number of documents needed.
+file's split-axis guidance and prefer the minimum number of documents
+needed.
 
 ## Step 3: Write the Output File(s)
 
@@ -56,11 +56,8 @@ Naming and path rules (zero-padded `-codex-NN` suffix, base filename
 preservation, `docs/ai/phases/codex/` target dir): see
 `references/output-and-split.md`. Rewrite descriptive prose into imperative
 instructions and strip vague/deferred wording per
-`references/rewrite-rules.md`. Structure each generated document — Title,
-Goal, Inputs/References, Scope, Out of scope, Files to create or modify,
-Implementation instructions, Constraints, Assumptions/Notes, Completion
-checklist, and the closing Codex prompt block (plus the multi-slice notice
-when splitting) — exactly per `references/document-template.md`.
+`references/rewrite-rules.md`. Structure each generated document exactly
+per `references/document-template.md`.
 
 ## Step 4: Sync AGENTS.md
 

--- a/claude/skills/devx-claude-to-codex/SKILL.md
+++ b/claude/skills/devx-claude-to-codex/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: devx:claude-to-codex
+description: >-
+  Transform detailed phase implementation documents authored with Claude
+  Opus into Codex-optimized implementation documents. Use when the user
+  provides one or more reference documents plus a phase document and asks
+  to convert, split, rewrite, or optimize that phase document for Codex
+  execution inside a real project — e.g. "docs/ai/architecture.md,
+  docs/ai/backend.md, docs/ai/phases/phase-02-x.md를 참조해서
+  phase-02-x 문서를 codex에서 작업하기 최적화된 설계문서로 변경해줘",
+  "phase-03 문서를 codex용으로 재구성해줘", "이 phase 문서를 codex-friendly
+  task 문서로 필요하면 분할해서 만들어줘". Also use when the user wants
+  codex-ready task documents, imperative implementation specs, or derived
+  Codex documents under docs/ai/phases/codex/.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "phase-doc → imperative Codex-doc rewrite; split-boundary judgment; structured reasoning, no direct code execution"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# Purpose
+
+Convert Claude-authored phase implementation documents into Codex-friendly,
+imperative implementation documents. Preserve the original phase document —
+never edit it. Generate derived documents under `docs/ai/phases/codex/`.
+Treat `CLAUDE.md` as the source of truth and `AGENTS.md` as a thin bridge
+for Codex. Never rewrite `CLAUDE.md` itself unless the user explicitly asks.
+
+## Help
+
+If the user asks for help/usage, read `references/help.md` and output its
+content verbatim, then stop. No API calls, no file mutation.
+
+## Step 1: Read Inputs
+
+Read every reference document the user listed, then the target phase
+document. Scan repo structure (`AGENTS.md`, `CLAUDE.md`) for context the
+transformed document should preserve.
+
+## Step 2: Decide Single vs Split
+
+Evaluate whether the phase document is already narrow and deterministic
+enough for one Codex pass. Default to a single output document — do not
+split by default. Split into multiple numbered documents only when a
+trigger condition in `references/output-and-split.md` is met; follow that
+file's split-axis guidance (backend/frontend/shared,
+transport/state/UI, infrastructure/integration/UX, deterministic-first/
+uncertain-later) and prefer the minimum number of documents needed.
+
+## Step 3: Write the Output File(s)
+
+Naming and path rules (zero-padded `-codex-NN` suffix, base filename
+preservation, `docs/ai/phases/codex/` target dir): see
+`references/output-and-split.md`. Rewrite descriptive prose into imperative
+instructions and strip vague/deferred wording per
+`references/rewrite-rules.md`. Structure each generated document — Title,
+Goal, Inputs/References, Scope, Out of scope, Files to create or modify,
+Implementation instructions, Constraints, Assumptions/Notes, Completion
+checklist, and the closing Codex prompt block (plus the multi-slice notice
+when splitting) — exactly per `references/document-template.md`.
+
+## Step 4: Sync AGENTS.md
+
+Apply the three-way branch (missing / has `@CLAUDE.md` / missing
+`@CLAUDE.md`) in `references/agents-md-handling.md`. Do not add extra
+Codex policy text to `AGENTS.md` unless the user explicitly requests it.
+
+## Quality bar
+
+- Codex can execute from the generated document alone, without the
+  original long phase spec open at all times.
+- Implementation scope and the file list are unambiguous; mixed
+  responsibilities are separated only when it genuinely helps reliability.
+- Output stays faithful to the original Claude-authored intent — these are
+  practical implementation documents, not summaries.
+
+## Step 5: Report
+
+Print a concise verdict, then keep any remaining chat response short:
+
+```
+[OK] devx:claude-to-codex — <n> Codex document(s) written
+  docs/ai/phases/codex/<base>-codex-01.md (single|slice 1/<n>)
+  ...
+  AGENTS.md: created | updated (@CLAUDE.md added) | unchanged
+```
+
+Next: hand the printed Codex prompt block(s) to Codex.

--- a/claude/skills/devx-claude-to-codex/references/agents-md-handling.md
+++ b/claude/skills/devx-claude-to-codex/references/agents-md-handling.md
@@ -1,0 +1,23 @@
+# devx:claude-to-codex — AGENTS.md handling
+
+Repository root means the nearest project root containing the main
+project files (of the target project being worked on — not this dotfiles
+repo).
+
+When invoked:
+
+- If root `AGENTS.md` does not exist, create it with exactly:
+
+  ```md
+  @CLAUDE.md
+  ```
+
+- If root `AGENTS.md` exists and already contains `@CLAUDE.md`, leave it
+  unchanged.
+- If root `AGENTS.md` exists and does not contain `@CLAUDE.md`, add
+  `@CLAUDE.md` at the top unless doing so would obviously break an
+  existing structured file. In that case, add it in the least disruptive
+  location and preserve existing content.
+
+Do not add extra Codex policy text to `AGENTS.md` unless the user
+explicitly requests it.

--- a/claude/skills/devx-claude-to-codex/references/document-template.md
+++ b/claude/skills/devx-claude-to-codex/references/document-template.md
@@ -1,0 +1,72 @@
+# devx:claude-to-codex — Generated document structure
+
+Use this structure unless the user explicitly requests a different
+layout.
+
+## Title
+Use the source phase title and add a Codex suffix.
+Example:
+`# Phase 03 — Session + Chat UI + SSE Streaming (Codex 01)`
+
+## Goal
+State the concrete implementation goal for this Codex document only.
+
+## Inputs / References
+List the documents that were used to derive this file. Include absolute
+or repo-relative paths exactly as referenced by the user.
+
+## Scope
+List only the work included in this Codex document.
+
+## Out of scope
+List related work intentionally excluded from this Codex document.
+
+## Files to create or modify
+Use a flat bullet list of exact file paths. Mark each as `NEW` or
+`MODIFY`.
+
+## Implementation instructions
+Provide an ordered list of imperative steps. Each step should be
+actionable and implementation-oriented.
+
+## Constraints
+Include hard requirements and "do not do" rules. Examples:
+- Do not refactor unrelated files.
+- Do not implement speculative UX refinements.
+- Do not invent missing API schema fields beyond safe placeholders.
+- Stop after the listed files are updated.
+
+## Assumptions / Notes
+List uncertainties, especially around APIs, protocols, schemas, or
+runtime behavior.
+
+## Completion checklist
+Use checkboxes and keep them specific to this Codex document.
+
+## Codex prompt
+At the very bottom, include a fenced text block containing a Codex-ready
+execution prompt.
+
+## Codex prompt block rules
+
+Each generated document must end with:
+
+```text
+Implement this Codex task exactly as specified in this document.
+Before making changes:
+- Read AGENTS.md
+- Read CLAUDE.md
+- Read the referenced input documents listed above
+Execution rules:
+- Only modify the files listed in "Files to create or modify"
+- Follow the implementation instructions in order
+- Do not expand scope
+- If an interface is uncertain, implement the safest minimal version and leave a clear note
+- When finished, summarize changed files, key decisions, and unresolved risks
+```
+
+If the generated document is one slice of several, add:
+
+```text
+This is only one slice of the original phase. Do not implement work assigned to other codex documents.
+```

--- a/claude/skills/devx-claude-to-codex/references/help.md
+++ b/claude/skills/devx-claude-to-codex/references/help.md
@@ -1,0 +1,33 @@
+# devx:claude-to-codex — Help
+
+## Usage
+
+This skill has no CLI flags — it triggers on natural-language requests
+that name reference document(s) plus a target phase document, e.g.:
+
+```
+docs/ai/architecture.md, docs/ai/backend.md, docs/ai/phases/phase-02-x.md를
+참조해서 phase-02-x 문서를 codex에서 작업하기 최적화된 설계문서로 변경해줘
+
+phase-03 문서를 codex용으로 재구성해줘
+
+이 phase 문서를 codex-friendly task 문서로 필요하면 분할해서 만들어줘
+```
+
+## What it does
+
+1. Reads the named reference document(s), then the target phase document.
+2. Decides single vs. multi-document Codex output — see
+   `references/output-and-split.md`.
+3. Writes `docs/ai/phases/codex/<base>-codex-NN.md` (zero-padded,
+   numbered only when split).
+4. Rewrites prose into imperative Codex instructions — see
+   `references/rewrite-rules.md` and `references/document-template.md`.
+5. Creates or updates `AGENTS.md` with `@CLAUDE.md` per
+   `references/agents-md-handling.md`. Never rewrites `CLAUDE.md` itself.
+
+## Output
+
+Reports the created Codex document path(s), whether the phase stayed
+single or was split, and whether `AGENTS.md` was created / updated /
+left unchanged.

--- a/claude/skills/devx-claude-to-codex/references/help.md
+++ b/claude/skills/devx-claude-to-codex/references/help.md
@@ -19,8 +19,8 @@ phase-03 문서를 codex용으로 재구성해줘
 1. Reads the named reference document(s), then the target phase document.
 2. Decides single vs. multi-document Codex output — see
    `references/output-and-split.md`.
-3. Writes `docs/ai/phases/codex/<base>-codex-NN.md` (zero-padded,
-   numbered only when split).
+3. Writes `docs/ai/phases/codex/<base>-codex-NN.md` (zero-padded from
+   `01`; additional `-codex-02`, `-codex-03`, ... only appear when split).
 4. Rewrites prose into imperative Codex instructions — see
    `references/rewrite-rules.md` and `references/document-template.md`.
 5. Creates or updates `AGENTS.md` with `@CLAUDE.md` per

--- a/claude/skills/devx-claude-to-codex/references/output-and-split.md
+++ b/claude/skills/devx-claude-to-codex/references/output-and-split.md
@@ -29,17 +29,11 @@ implementation pass.
 Split into multiple Codex documents only when one or more of the
 following are true:
 
-- The phase mixes main-process, backend, frontend, renderer, IPC, and UI
-  responsibilities in one document.
-- The phase includes both infrastructure wiring and detailed UX work in
-  the same implementation scope.
+- The scope spans multiple distinct responsibility domains (e.g.
+  backend/frontend/shared, infra/UX, staged implementation slices) or
+  would require Codex to touch many unrelated files or too many distinct
+  concerns in one reliable pass.
 - The phase depends on uncertain or unverified external interfaces.
-- The completion criteria cover too many distinct concerns for one
-  reliable Codex pass.
-- The implementation would likely require Codex to modify many unrelated
-  files at once.
-- The document contains meaningful internal subgroups such as backend,
-  frontend, shared, integration, or staged implementation slices.
 
 When splitting, prefer coherent implementation boundaries over mechanical
 equal sizing. Good split axes include:

--- a/claude/skills/devx-claude-to-codex/references/output-and-split.md
+++ b/claude/skills/devx-claude-to-codex/references/output-and-split.md
@@ -1,0 +1,53 @@
+# devx:claude-to-codex — Output location, naming, and split policy
+
+## Output location and naming
+
+Write generated files under:
+`docs/ai/phases/codex/`
+
+For an input phase file like:
+`docs/ai/phases/phase-01-scaffold.md`
+
+Generate:
+- `docs/ai/phases/codex/phase-01-scaffold-codex-01.md`
+
+If splitting is needed, continue numbering:
+- `docs/ai/phases/codex/phase-01-scaffold-codex-02.md`
+- `docs/ai/phases/codex/phase-01-scaffold-codex-03.md`
+
+Always preserve the original base filename and append `-codex-XX`.
+Use zero-padded numbering starting from `01`.
+
+## Split policy
+
+Do not split by default.
+
+Generate only one Codex document when the source phase document is
+already narrow, deterministic, and suitable for a single Codex
+implementation pass.
+
+Split into multiple Codex documents only when one or more of the
+following are true:
+
+- The phase mixes main-process, backend, frontend, renderer, IPC, and UI
+  responsibilities in one document.
+- The phase includes both infrastructure wiring and detailed UX work in
+  the same implementation scope.
+- The phase depends on uncertain or unverified external interfaces.
+- The completion criteria cover too many distinct concerns for one
+  reliable Codex pass.
+- The implementation would likely require Codex to modify many unrelated
+  files at once.
+- The document contains meaningful internal subgroups such as backend,
+  frontend, shared, integration, or staged implementation slices.
+
+When splitting, prefer coherent implementation boundaries over mechanical
+equal sizing. Good split axes include:
+
+- backend / frontend / shared
+- transport / state / UI
+- infrastructure / integration / UX refinement
+- deterministic implementation first, uncertain integration later
+
+Avoid unnecessary fragmentation. Prefer the minimum number of Codex
+documents needed for reliable execution.

--- a/claude/skills/devx-claude-to-codex/references/rewrite-rules.md
+++ b/claude/skills/devx-claude-to-codex/references/rewrite-rules.md
@@ -1,0 +1,50 @@
+# devx:claude-to-codex — Codex optimization and transformation rules
+
+## Codex optimization rules
+
+Rewrite the target phase document for Codex using imperative instructions.
+Prefer explicit, operational wording over descriptive wording. The
+generated Codex documents must reduce ambiguity and avoid high-level
+narrative.
+
+For each generated Codex document:
+- clearly state the goal
+- define exact files to create or modify
+- specify the implementation scope
+- exclude unrelated work
+- provide ordered implementation steps
+- identify assumptions and risks
+- provide a concrete completion checklist
+- include a Codex execution prompt block at the bottom
+
+Prefer wording like:
+- "Create ..."
+- "Modify ..."
+- "Register ..."
+- "Do not ..."
+- "Stop after ..."
+- "Return a short summary of changed files and unresolved risks."
+
+Do not preserve vague wording such as:
+- "could support"
+- "might later be used"
+- "optionally add" unless the option is intentionally deferred
+- narrative architecture commentary that does not help immediate
+  implementation
+
+## Document transformation rules
+
+When transforming a Claude-authored phase document into a Codex document:
+
+1. Preserve the original intent.
+2. Preserve important dependencies and preconditions.
+3. Preserve file paths and architecture references.
+4. Convert explanatory design prose into implementation instructions.
+5. Pull hidden assumptions into an explicit "Assumptions / Notes" section.
+6. Convert broad checklists into scoped completion criteria for the
+   specific Codex slice.
+7. Remove or defer work that is out of scope for the current generated
+   Codex document.
+8. If the source includes uncertain protocol details or unverified
+   schemas, mark them clearly and instruct Codex to implement
+   conservatively.

--- a/claude/skills/devx-claude-to-codex/references/rewrite-rules.md
+++ b/claude/skills/devx-claude-to-codex/references/rewrite-rules.md
@@ -1,19 +1,26 @@
-# devx:claude-to-codex — Codex optimization and transformation rules
-
-## Codex optimization rules
+# devx:claude-to-codex — Rewrite rules
 
 Rewrite the target phase document for Codex using imperative instructions.
 Prefer explicit, operational wording over descriptive wording. The
 generated Codex documents must reduce ambiguity and avoid high-level
 narrative.
 
+Preserve, unchanged, from the source phase document:
+1. The original intent.
+2. Important dependencies and preconditions.
+3. File paths and architecture references.
+
 For each generated Codex document:
 - clearly state the goal
 - define exact files to create or modify
-- specify the implementation scope
+- specify the implementation scope, scoped to the current Codex slice
+  (not the full source checklist)
 - exclude unrelated work
 - provide ordered implementation steps
-- identify assumptions and risks
+- pull hidden assumptions into an explicit "Assumptions / Notes" section
+- if the source includes uncertain protocol details or unverified
+  schemas, mark them clearly and instruct Codex to implement
+  conservatively
 - provide a concrete completion checklist
 - include a Codex execution prompt block at the bottom
 
@@ -31,20 +38,3 @@ Do not preserve vague wording such as:
 - "optionally add" unless the option is intentionally deferred
 - narrative architecture commentary that does not help immediate
   implementation
-
-## Document transformation rules
-
-When transforming a Claude-authored phase document into a Codex document:
-
-1. Preserve the original intent.
-2. Preserve important dependencies and preconditions.
-3. Preserve file paths and architecture references.
-4. Convert explanatory design prose into implementation instructions.
-5. Pull hidden assumptions into an explicit "Assumptions / Notes" section.
-6. Convert broad checklists into scoped completion criteria for the
-   specific Codex slice.
-7. Remove or defer work that is out of scope for the current generated
-   Codex document.
-8. If the source includes uncertain protocol details or unverified
-   schemas, mark them clearly and instruct Codex to implement
-   conservatively.


### PR DESCRIPTION
## Summary
- Add a new `devx:claude-to-codex` skill under `claude/skills/` that turns a Claude-authored phase implementation document into Codex-ready, imperative task documents.

## Changes
- `claude/skills/devx-claude-to-codex/SKILL.md`: workflow entry point (read inputs → decide split → write output → sync `AGENTS.md` → report), plus required `allowed-tools` / `metadata.model_recommendation` frontmatter and a `## Help` pointer.
- `references/output-and-split.md`: output path/naming (`docs/ai/phases/codex/<base>-codex-NN.md`) and the split-trigger policy.
- `references/rewrite-rules.md`: imperative-rewrite and vague-wording-removal rules.
- `references/document-template.md`: the fixed per-document structure and the Codex prompt block text.
- `references/agents-md-handling.md`: the three-way `AGENTS.md` branch (missing / has `@CLAUDE.md` / needs it added).
- `references/help.md`: usage examples backing the `-h`/`help` pattern.

## Test plan
- [x] `uv run pytest -q` — 1199 passed, 0 failed
- [x] `/skill:check` criteria walked manually — line count (91 ≤ 100), progressive disclosure via `references/`, frontmatter (`allowed-tools`, `metadata.model_recommendation: sonnet`), no emojis, no LICENSE/network capability applicable (pure-prompt skill, no shipped scripts)

## Related
Closes #1174

---
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
