### PR TITLE
feat(setup): claude.local.sh 생성 시점에 계정별 이메일 대화형 주입

### DIFF
--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -117,6 +117,15 @@ copy_local_files() {
 
     ux_header "Copying template files for: $environment"
 
+    # Capture whether the script's stdin is a real terminal *before* entering
+    # the `find | while` pipe below. Inside that pipe fd 0 is rebound to find's
+    # output, so `[ -t 0 ]` there is always false — the interactive email
+    # prompt (issue #1173) reads this saved flag instead, and reads answers
+    # from /dev/tty so the pipe's stdin is never consumed. Non-interactive runs
+    # (CI / test harness / `bash -c`) leave stdin non-tty → prompt is skipped.
+    _stdin_is_tty=0
+    [ -t 0 ] && _stdin_is_tty=1
+
     # Copy .local.example files to .local.sh (sh-compatible approach)
     find "$SHELL_COMMON_DIR" -name "*.local.example" -type f | while IFS= read -r example_file; do
         dir="$(dirname "$example_file")"
@@ -147,12 +156,49 @@ copy_local_files() {
 
                     # External-specific: Auto-enable work1 for multi-account setup
                     if [ "$basename_file" = "claude.local.example" ]; then
-                        cat >> "$local_file" <<'EOF'
+                        # SSOT for the external-PC account list — reused by both
+                        # the heredoc below and the email-prompt loop (F-2), so
+                        # the "personal work work1" literal lives in one place.
+                        _ext_accounts="personal work work1"
+                        cat >> "$local_file" <<EOF
 
 # ─── External PC: Multi-account setup ────────────────────────────────────
-export CLAUDE_ENABLED_ACCOUNTS="personal work work1"
+export CLAUDE_ENABLED_ACCOUNTS="$_ext_accounts"
 EOF
                         ux_info "  + Configured: work1 account for multi-account setup"
+
+                        # Interactive per-account email prompt (issue #1173).
+                        # Populates CLAUDE_ACCOUNT_EMAIL_<name> so the account/
+                        # email mismatch guard in tools/integrations/claude.sh
+                        # works without hand-editing the file on every new PC.
+                        # Mirrors _resolve_knox_id's tty pattern: prompt to
+                        # stderr, and skip silently when stdin is not a tty (CI /
+                        # test harness / `bash -c`) so non-interactive setup
+                        # falls back to the current behavior (F-4). Reads from
+                        # /dev/tty (not fd 0) because this runs inside the
+                        # `find | while` pipe above — see _stdin_is_tty note.
+                        if [ "$_stdin_is_tty" = 1 ] && [ -e /dev/tty ]; then
+                            for _acct in $_ext_accounts; do
+                                # Backticks are literal prompt text, so the
+                                # format string stays single-quoted (SC2016).
+                                # shellcheck disable=SC2016
+                                printf '`%s` 계정 이메일 (Enter로 건너뛰기): ' "$_acct" >&2
+                                read -r _acct_email </dev/tty || _acct_email=""
+                                if [ -n "$_acct_email" ]; then
+                                    # Escape backslash/quote/backtick/dollar before
+                                    # embedding in a double-quoted export — this
+                                    # file gets `.`-sourced on every shell startup
+                                    # (shell-common/env/claude.sh), so an
+                                    # unescaped `"`, `` ` ``, or `$(...)` in the
+                                    # typed value would execute as shell syntax.
+                                    _acct_email_esc="$(printf '%s' "$_acct_email" \
+                                        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+                                              -e 's/`/\\`/g' -e 's/\$/\\$/g')"
+                                    printf 'export CLAUDE_ACCOUNT_EMAIL_%s="%s"\n' \
+                                        "$_acct" "$_acct_email_esc" >> "$local_file"
+                                fi
+                            done
+                        fi
                     fi
                 fi
                 ;;

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -117,14 +117,15 @@ copy_local_files() {
 
     ux_header "Copying template files for: $environment"
 
-    # Capture whether the script's stdin is a real terminal *before* entering
-    # the `find | while` pipe below. Inside that pipe fd 0 is rebound to find's
-    # output, so `[ -t 0 ]` there is always false — the interactive email
-    # prompt (issue #1173) reads this saved flag instead, and reads answers
-    # from /dev/tty so the pipe's stdin is never consumed. Non-interactive runs
-    # (CI / test harness / `bash -c`) leave stdin non-tty → prompt is skipped.
-    _stdin_is_tty=0
-    [ -t 0 ] && _stdin_is_tty=1
+    # External-PC account list. SSOT is shell-common/env/claude.sh's
+    # external-mode default (CLAUDE_ENABLED_ACCOUNTS="personal work work1");
+    # kept as a literal here (not sourced from claude.sh) because that file
+    # has an interactive guard and sources claude.local.sh itself — the very
+    # file this function is generating. Update both places if the list
+    # changes. Assigned once here, before the `find | while` pipe below,
+    # so it survives into the post-pipe block further down (that pipe forks
+    # a subshell — anything assigned inside it is lost once `done` returns).
+    _ext_accounts="personal work work1"
 
     # Copy .local.example files to .local.sh (sh-compatible approach)
     find "$SHELL_COMMON_DIR" -name "*.local.example" -type f | while IFS= read -r example_file; do
@@ -154,55 +155,63 @@ copy_local_files() {
                     cp "$example_file" "$local_file"
                     ux_success "Created: ${local_file#"$SHELL_COMMON_DIR"/}"
 
-                    # External-specific: Auto-enable work1 for multi-account setup
+                    # External-specific: Auto-enable work1 for multi-account setup.
                     if [ "$basename_file" = "claude.local.example" ]; then
-                        # SSOT for the external-PC account list — reused by both
-                        # the heredoc below and the email-prompt loop (F-2), so
-                        # the "personal work work1" literal lives in one place.
-                        _ext_accounts="personal work work1"
                         cat >> "$local_file" <<EOF
 
 # ─── External PC: Multi-account setup ────────────────────────────────────
 export CLAUDE_ENABLED_ACCOUNTS="$_ext_accounts"
 EOF
                         ux_info "  + Configured: work1 account for multi-account setup"
-
-                        # Interactive per-account email prompt (issue #1173).
-                        # Populates CLAUDE_ACCOUNT_EMAIL_<name> so the account/
-                        # email mismatch guard in tools/integrations/claude.sh
-                        # works without hand-editing the file on every new PC.
-                        # Mirrors _resolve_knox_id's tty pattern: prompt to
-                        # stderr, and skip silently when stdin is not a tty (CI /
-                        # test harness / `bash -c`) so non-interactive setup
-                        # falls back to the current behavior (F-4). Reads from
-                        # /dev/tty (not fd 0) because this runs inside the
-                        # `find | while` pipe above — see _stdin_is_tty note.
-                        if [ "$_stdin_is_tty" = 1 ] && [ -e /dev/tty ]; then
-                            for _acct in $_ext_accounts; do
-                                # Backticks are literal prompt text, so the
-                                # format string stays single-quoted (SC2016).
-                                # shellcheck disable=SC2016
-                                printf '`%s` 계정 이메일 (Enter로 건너뛰기): ' "$_acct" >&2
-                                read -r _acct_email </dev/tty || _acct_email=""
-                                if [ -n "$_acct_email" ]; then
-                                    # Escape backslash/quote/backtick/dollar before
-                                    # embedding in a double-quoted export — this
-                                    # file gets `.`-sourced on every shell startup
-                                    # (shell-common/env/claude.sh), so an
-                                    # unescaped `"`, `` ` ``, or `$(...)` in the
-                                    # typed value would execute as shell syntax.
-                                    _acct_email_esc="$(printf '%s' "$_acct_email" \
-                                        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
-                                              -e 's/`/\\`/g' -e 's/\$/\\$/g')"
-                                    printf 'export CLAUDE_ACCOUNT_EMAIL_%s="%s"\n' \
-                                        "$_acct" "$_acct_email_esc" >> "$local_file"
-                                fi
-                            done
-                        fi
                     fi
                 fi
                 ;;
         esac
+    done
+
+    # External-specific: interactive per-account email prompt (issue #1173),
+    # run *after* the find|while pipe above (not inside it) so the prompt's
+    # own `[ -t 0 ]` check sees the real terminal — inside the pipe, fd 0 is
+    # rebound to find's output and would always read as non-tty. Populates
+    # CLAUDE_ACCOUNT_EMAIL_<name> so the account/email mismatch guard in
+    # tools/integrations/claude.sh works without hand-editing the file on
+    # every new PC. Guarded on the file actually having been created above
+    # (skipped e.g. if claude.local.example is ever removed from the repo).
+    if [ "$environment" = "external" ]; then
+        _claude_local_file="${SHELL_COMMON_DIR}/env/claude.local.sh"
+        [ -f "$_claude_local_file" ] && _prompt_claude_account_emails "$_ext_accounts" "$_claude_local_file"
+    fi
+}
+
+# Interactively populate CLAUDE_ACCOUNT_EMAIL_<account> for each account in
+# $1 (space-separated), appending export lines to file $2 (issue #1173).
+# Mirrors _resolve_knox_id's tty-guard pattern: skip silently when stdin is
+# not a tty (CI / test harness / `bash -c`) so non-interactive setup falls
+# back to the current behavior (F-4). Caller must invoke this outside any
+# pipe (see copy_local_files) so `[ -t 0 ]` reflects the real terminal.
+_prompt_claude_account_emails() {
+    _pcae_accounts="$1"
+    _pcae_file="$2"
+
+    [ -t 0 ] || return 0
+
+    for _pcae_acct in $_pcae_accounts; do
+        # Backticks are literal prompt text, so the format string stays
+        # single-quoted (SC2016).
+        # shellcheck disable=SC2016
+        printf '`%s` 계정 이메일 (Enter로 건너뛰기): ' "$_pcae_acct" >&2
+        read -r _pcae_email || _pcae_email=""
+        [ -n "$_pcae_email" ] || continue
+
+        # Escape backslash/quote/backtick/dollar before embedding in a
+        # double-quoted export — this file gets `.`-sourced on every shell
+        # startup (shell-common/env/claude.sh), so an unescaped `"`, `` ` ``,
+        # or `$(...)` in the typed value would execute as shell syntax.
+        _pcae_email_esc="$(printf '%s' "$_pcae_email" \
+            | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+                  -e 's/`/\\`/g' -e 's/\$/\\$/g')"
+        printf 'export CLAUDE_ACCOUNT_EMAIL_%s="%s"\n' \
+            "$_pcae_acct" "$_pcae_email_esc" >> "$_pcae_file"
     done
 }
 

--- a/shell-common/setup.sh
+++ b/shell-common/setup.sh
@@ -183,6 +183,30 @@ EOF
     fi
 }
 
+# Escape + append one CLAUDE_ACCOUNT_EMAIL_<acct> export line to file $3
+# (issue #1173 review, PR #1176). Pure — no prompt, no tty check — so it is
+# directly unit-testable without a pty harness, unlike the interactive loop
+# below. Empty $2 is a silent no-op (mirrors the caller's skip-on-Enter rule).
+_pcae_write_email_export() {
+    _pcae_acct="$1"
+    _pcae_email="$2"
+    _pcae_file="$3"
+
+    [ -n "$_pcae_email" ] || return 0
+
+    # Escape backslash/quote/backtick/dollar before embedding in a
+    # double-quoted export — this file gets `.`-sourced on every shell
+    # startup (shell-common/env/claude.sh), so an unescaped `"`, `` ` ``,
+    # or `$(...)` in the typed value would execute as shell syntax. `[$]`
+    # (not `\$`) matches a literal dollar portably across sed
+    # implementations (gemini-code-assist review on PR #1176).
+    _pcae_email_esc="$(printf '%s' "$_pcae_email" \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+              -e 's/`/\\`/g' -e 's/[$]/\\$/g')"
+    printf 'export CLAUDE_ACCOUNT_EMAIL_%s="%s"\n' \
+        "$_pcae_acct" "$_pcae_email_esc" >> "$_pcae_file"
+}
+
 # Interactively populate CLAUDE_ACCOUNT_EMAIL_<account> for each account in
 # $1 (space-separated), appending export lines to file $2 (issue #1173).
 # Mirrors _resolve_knox_id's tty-guard pattern: skip silently when stdin is
@@ -201,17 +225,7 @@ _prompt_claude_account_emails() {
         # shellcheck disable=SC2016
         printf '`%s` 계정 이메일 (Enter로 건너뛰기): ' "$_pcae_acct" >&2
         read -r _pcae_email || _pcae_email=""
-        [ -n "$_pcae_email" ] || continue
-
-        # Escape backslash/quote/backtick/dollar before embedding in a
-        # double-quoted export — this file gets `.`-sourced on every shell
-        # startup (shell-common/env/claude.sh), so an unescaped `"`, `` ` ``,
-        # or `$(...)` in the typed value would execute as shell syntax.
-        _pcae_email_esc="$(printf '%s' "$_pcae_email" \
-            | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
-                  -e 's/`/\\`/g' -e 's/\$/\\$/g')"
-        printf 'export CLAUDE_ACCOUNT_EMAIL_%s="%s"\n' \
-            "$_pcae_acct" "$_pcae_email_esc" >> "$_pcae_file"
+        _pcae_write_email_export "$_pcae_acct" "$_pcae_email" "$_pcae_file"
     done
 }
 

--- a/tests/bats/functions/claude_local_email_prompt.bats
+++ b/tests/bats/functions/claude_local_email_prompt.bats
@@ -4,12 +4,18 @@
 # mappings interactively (issue #1173) while staying safe non-interactively.
 #
 # Scope note: like tests/bats/functions/setup_opencode_config.bats (the
-# _resolve_knox_id precedent), only the non-interactive path is automated —
-# the test suite has no pty/expect harness, so the interactive prompt-success
-# path (a typed email producing an `export CLAUDE_ACCOUNT_EMAIL_<name>` line)
-# is manually verified only. What is covered here:
+# _resolve_knox_id precedent), the interactive *prompt loop* itself (tty
+# read via `_prompt_claude_account_emails`) has no pty/expect harness in this
+# suite, so it stays manually verified only. But the escaping/export-writing
+# logic it calls — `_pcae_write_email_export` — was deliberately extracted
+# into a pure function (no prompt, no tty check) precisely so it CAN be
+# unit-tested directly (PR #1176 review feedback: codex flagged the escaping
+# safety contract as untested). What is covered here:
 #   1. non-interactive run → CLAUDE_ENABLED_ACCOUNTS written, NO email lines (F-4)
 #   2. git-tracked claude.local.example stays byte-identical (NF-1)
+#   3. _pcae_write_email_export: shell-metacharacter input is escaped so the
+#      resulting export line is inert when the generated file is sourced
+#   4. _pcae_write_email_export: empty input writes no line
 
 load '../test_helper'
 
@@ -72,4 +78,58 @@ run_copy_local_files() {
     # The generated .local.sh is where writes land; the tracked .example
     # template must remain byte-identical to the pristine repo source.
     cmp "$EXAMPLE" "$_BATS_REAL_DOTFILES_ROOT/shell-common/env/claude.local.example"
+}
+
+# --- _pcae_write_email_export: escaping safety (PR #1176 review) -----------
+# claude.local.sh is `.`-sourced on every shell startup (shell-common/env/
+# claude.sh), so an unescaped `"`, backtick, or `$(...)` typed at the prompt
+# would execute as shell syntax the next time a shell starts. These tests
+# call the pure write function directly (no read, no tty) so the escaping
+# contract is verified without needing a pty/expect harness.
+
+run_write_email_export() {
+    run bash --noprofile --norc -c "
+        set -e
+        cd '$FIXTURE_DOTFILES/shell-common'
+        . './setup.sh'
+        _pcae_write_email_export \"\$1\" \"\$2\" \"\$3\"
+    " _ "$1" "$2" "$3"
+}
+
+@test "_pcae_write_email_export: shell metacharacters are escaped inert" {
+    OUT="$TEST_TEMP_HOME/out.sh"
+    : >"$OUT"
+    run_write_email_export personal 'a"; touch INJECTED; echo "' "$OUT"
+    assert_success
+
+    grep -q '^export CLAUDE_ACCOUNT_EMAIL_personal=' "$OUT"
+
+    # Sourcing the generated line must not execute the embedded command and
+    # must preserve the literal value.
+    run bash --noprofile --norc -c ". '$OUT'; printf '%s' \"\$CLAUDE_ACCOUNT_EMAIL_personal\""
+    assert_success
+    [ "$output" = 'a"; touch INJECTED; echo "' ]
+    [ ! -e "$TEST_TEMP_HOME/INJECTED" ]
+    [ ! -e "./INJECTED" ]
+}
+
+@test "_pcae_write_email_export: dollar and backtick are escaped inert" {
+    OUT="$TEST_TEMP_HOME/out.sh"
+    : >"$OUT"
+    run_write_email_export work 'a$(touch INJECTED2)`touch INJECTED3`b' "$OUT"
+    assert_success
+
+    run bash --noprofile --norc -c ". '$OUT'; printf '%s' \"\$CLAUDE_ACCOUNT_EMAIL_work\""
+    assert_success
+    [ "$output" = 'a$(touch INJECTED2)`touch INJECTED3`b' ]
+    [ ! -e "$TEST_TEMP_HOME/INJECTED2" ]
+    [ ! -e "$TEST_TEMP_HOME/INJECTED3" ]
+}
+
+@test "_pcae_write_email_export: empty input writes no line" {
+    OUT="$TEST_TEMP_HOME/out.sh"
+    : >"$OUT"
+    run_write_email_export work1 "" "$OUT"
+    assert_success
+    [ ! -s "$OUT" ]
 }

--- a/tests/bats/functions/claude_local_email_prompt.bats
+++ b/tests/bats/functions/claude_local_email_prompt.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# tests/bats/functions/claude_local_email_prompt.bats
+# Verify copy_local_files' external branch auto-populates per-account email
+# mappings interactively (issue #1173) while staying safe non-interactively.
+#
+# Scope note: like tests/bats/functions/setup_opencode_config.bats (the
+# _resolve_knox_id precedent), only the non-interactive path is automated —
+# the test suite has no pty/expect harness, so the interactive prompt-success
+# path (a typed email producing an `export CLAUDE_ACCOUNT_EMAIL_<name>` line)
+# is manually verified only. What is covered here:
+#   1. non-interactive run → CLAUDE_ENABLED_ACCOUNTS written, NO email lines (F-4)
+#   2. git-tracked claude.local.example stays byte-identical (NF-1)
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+
+    # Minimal dotfiles fixture: copy_local_files() finds *.local.example under
+    # $SHELL_COMMON_DIR, so we stage only claude.local.example plus the two
+    # optional sources setup.sh sources at load time (both `[ -f ]`-guarded).
+    FIXTURE_DOTFILES="$TEST_TEMP_HOME/dotfiles"
+    mkdir -p \
+        "$FIXTURE_DOTFILES/shell-common/env" \
+        "$FIXTURE_DOTFILES/shell-common/tools/ux_lib"
+    cp "$_BATS_REAL_DOTFILES_ROOT/shell-common/setup.sh" \
+       "$FIXTURE_DOTFILES/shell-common/setup.sh"
+    cp "$_BATS_REAL_DOTFILES_ROOT/shell-common/tools/ux_lib/ux_lib.sh" \
+       "$FIXTURE_DOTFILES/shell-common/tools/ux_lib/ux_lib.sh"
+    cp "$_BATS_REAL_DOTFILES_ROOT/shell-common/env/claude.local.example" \
+       "$FIXTURE_DOTFILES/shell-common/env/claude.local.example"
+
+    EXAMPLE="$FIXTURE_DOTFILES/shell-common/env/claude.local.example"
+    LOCAL="$FIXTURE_DOTFILES/shell-common/env/claude.local.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Source setup.sh in a subshell, then invoke copy_local_files alone. The
+# direct-exec guard in setup.sh keeps main() from running on source. stdin is
+# redirected from /dev/null so `[ -t 0 ]` is deterministically false — this
+# exercises the non-interactive path and cannot hang on `read` even if bats
+# is launched from an interactive terminal.
+run_copy_local_files() {
+    run bash --noprofile --norc -c "
+        set -e
+        cd '$FIXTURE_DOTFILES/shell-common'
+        . './setup.sh'
+        copy_local_files external
+    " </dev/null
+}
+
+@test "non-interactive external: enables accounts but writes no email lines (F-4)" {
+    run_copy_local_files
+    assert_success
+
+    [ -f "$LOCAL" ]
+    # Anchor to `^export`: the copied template also carries *commented*
+    # `# export CLAUDE_ENABLED_ACCOUNTS=...` / `# export CLAUDE_ACCOUNT_EMAIL_*`
+    # example lines, so only the active (uncommented) exports are meaningful.
+    grep -q '^export CLAUDE_ENABLED_ACCOUNTS="personal work work1"' "$LOCAL"
+    # No tty → the prompt loop is skipped entirely, so no active email exports.
+    ! grep -q '^export CLAUDE_ACCOUNT_EMAIL_' "$LOCAL"
+}
+
+@test "git-tracked claude.local.example is never modified (NF-1)" {
+    run_copy_local_files
+    assert_success
+
+    # The generated .local.sh is where writes land; the tracked .example
+    # template must remain byte-identical to the pristine repo source.
+    cmp "$EXAMPLE" "$_BATS_REAL_DOTFILES_ROOT/shell-common/env/claude.local.example"
+}


### PR DESCRIPTION
## Summary
- External PC 설정 시 `claude.local.sh` 생성 직후 계정별 이메일을 대화형으로 물어 `CLAUDE_ACCOUNT_EMAIL_<name>` 매핑을 즉시 주입한다.
- 비대화형 실행(CI/테스트 하네스)에서는 프롬프트를 건너뛰어 기존 동작을 그대로 유지한다.

## Changes
- `feat(setup)`: `copy_local_files()`의 external 분기에서 `CLAUDE_ENABLED_ACCOUNTS`(`personal work work1`)를 순회하며 계정별 이메일을 프롬프트하고, 입력값이 있으면 `export CLAUDE_ACCOUNT_EMAIL_<name>="<value>"`를 생성된 `claude.local.sh`에 append한다. `find | while` 파이프 내부에서 `[ -t 0 ]`이 항상 거짓이 되는 문제를 파이프 진입 전 tty 스냅샷 + `/dev/tty` 직접 읽기로 우회했다. 입력값은 이 파일이 매 쉘 시작마다 source되므로 셸 특수문자(`"`, `` ` ``, `$`, `\`)를 이스케이프한 뒤 기록한다.
- `test`: `tests/bats/functions/claude_local_email_prompt.bats` 신규 — 비대화형 실행 시 이메일 라인이 기록되지 않는지(F-4), `claude.local.example`이 변경되지 않는지(NF-1) 검증.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/claude_local_email_prompt.bats` — 2/2 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/setup_opencode_config.bats tests/bats/integrations/claude_accounts.bats tests/bats/integrations/claude_accounts_repair.bats` — 126/126 통과 (회귀 없음)
- [x] `mise run test` (전체) — pytest 1199 통과, bats 1581/1586 통과(나머지 5건은 이 변경과 무관한 기존 실패, `git stash` 베이스라인으로 확인)

## Related
Closes #1173

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~8 h (1 d) h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~8 h (1 d) h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
