### PR TITLE
fix(gcp-scan): Stage-2 no-op preflight가 real single-file conflict를 드롭하지 않도록 수정

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -57,7 +57,7 @@ _gcp_scan_preflight_is_noop() {
         echo "Error: Not in a git repository" >&2
         return 1
     fi
-    local sha="$1" result=1 had_stash=0 conflicted f
+    local sha="$1" result=1 had_stash=0 conflicted f real_content_conflict=0
     if ! git diff --quiet || ! git diff --cached --quiet; then
         git stash push -q --include-untracked -m "gcp_preflight_probe" && had_stash=1
         # Data-loss guard (PR #916 review): a failed stash leaves the tree
@@ -152,11 +152,22 @@ _gcp_scan_preflight_is_noop() {
         # `git add` is needed (and `git add -A` would wrongly stage untracked
         # files, breaking the empty-diff check).
         if [ -n "$conflicted" ]; then
-            echo "$conflicted" | while IFS= read -r f; do
+            while IFS= read -r f; do
                 [ -z "$f" ] && continue
+                # Keep genuine content conflicts intact: resetting those files
+                # to HEAD would erase the commit's only real work and
+                # misclassify the probe as "already in HEAD" (#1177).
+                if _gcp_scan_conflict_adds_new_content "$sha" "$f"; then
+                    real_content_conflict=1
+                    continue
+                fi
                 git checkout HEAD -- "$f"
-            done
-            git diff --cached --quiet && result=0
+            done <<EOF
+$conflicted
+EOF
+            if [ "$real_content_conflict" -eq 0 ]; then
+                git diff --cached --quiet && result=0
+            fi
         fi
     fi
     [ -n "$_gcfg1_bak" ] && rm -f "$_gcfg1_bak"

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -159,7 +159,7 @@ _gcp_scan_preflight_is_noop() {
                 # misclassify the probe as "already in HEAD" (#1177).
                 if _gcp_scan_conflict_adds_new_content "$sha" "$f"; then
                     real_content_conflict=1
-                    continue
+                    break
                 fi
                 git checkout HEAD -- "$f"
             done <<EOF

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -842,6 +842,32 @@ FIXTURE
     assert_output --partial "PICK_CLEAR"
 }
 
+@test "preflight #1177: single conflicted file with real new content is NOT dropped as no-op" {
+    # Regression: a child commit touching the same lone file as its parent can
+    # be deferred by Stage-1.6 when the parent is also in the pick list, but
+    # Stage-2 must still keep it once the file carries genuine new content.
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp1177.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Test\" GIT_AUTHOR_EMAIL=\"t@t\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        printf 'line 1\nbase\n' > setup.sh && git add setup.sh && git commit -qm 'init'
+        git checkout -q -b source
+        printf 'line 1\nparent\n' > setup.sh && git add setup.sh && git commit -qm 'parent change'
+        printf 'line 1\nchild\n' > setup.sh && git add setup.sh && git commit -qm 'child change'
+        child_sha=\$(git rev-parse HEAD)
+        git checkout -q main
+        printf 'line 1\nmain\n' > setup.sh && git add setup.sh && git commit -qm 'main diverges'
+        _gcp_scan_preflight_is_noop \"\$child_sha\"; echo \"rc=\$?\"
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    assert_output --partial "rc=1"
+    assert_output --partial "PICK_CLEAR"
+}
+
 @test "scan #913: context-drift commit auto-skipped by pre-flight (no conflict surfaced)" {
     run_in_bash "
         $(_gcp907_make_partial_repo)


### PR DESCRIPTION
## Summary
- keep `_gcp_scan_preflight_is_noop` from resetting conflicted files that still add content missing from `HEAD`
- preserve the existing context-drift no-op path while preventing Stage-2 from misclassifying real single-file conflicts as absorbed
- add a `gcp.bats` regression for the deferred-parent/real-child conflict shape from #1177

## Testing
- `bash -n shell-common/functions/gcp_scan.sh`
- `zsh -n shell-common/functions/gcp_scan.sh`
- `tests/bats/lib/bats-core/bin/bats -f 'preflight #1177: single conflicted file with real new content is NOT dropped as no-op' tests/bats/functions/gcp.bats`
- `tests/bats/lib/bats-core/bin/bats -f 'preflight #913: context-drift conflict that resolves to HEAD -> no-op \(0\), non-destructive' tests/bats/functions/gcp.bats`

Closes #1177
