### PR TITLE
Add /code-review --fix auto-fix lane to devx:pr-review-all

### DIFF
--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -77,10 +77,10 @@ lane `[SKIP]`/`[WARN]` and the others continue.
 - **auto-fix chain** (sequential sub-steps, both on the working-tree diff;
   PR# is ignored by both — hence the Step 2 checkout):
   1. An Agent runs `/code-review --fix`. `git status --porcelain` non-empty →
-     `git commit -m "fix(<scope>): code-review --fix"`; erroring invocation →
+     `git commit -am "fix(<scope>): code-review --fix"`; erroring invocation →
      WARN, continue to sub-step 2 regardless.
   2. Only after sub-step 1's commit (or no-op), an Agent runs the built-in
-     `/simplify`. `git status --porcelain` non-empty → `git commit -m
+     `/simplify`. `git status --porcelain` non-empty → `git commit -am
      "refactor(<scope>): simplify per /simplify"`.
   **Never a bare `git commit`** in either sub-step — it hangs on the editor
   in a non-interactive shell; always pass `-m`.

--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -2,8 +2,9 @@
 name: devx:pr-review-all
 description: >-
   Fan out every available reviewer on one PR in parallel — gemini ∥ codex
-  second opinions ∥ built-in /simplify — then run a reply pass over the
-  review comments. Use for /devx:pr-review-all, /devx-pr-review-all,
+  second opinions ∥ a sequential /code-review --fix → /simplify auto-fix
+  chain (each sub-step commits its own changes) — then run a reply pass over
+  the review comments. Use for /devx:pr-review-all, /devx-pr-review-all,
   "PR 다중 리뷰어 병렬로", "gemini codex simplify 한번에 돌려",
   "PR 99 전체 리뷰". A composition skill — distinct from gh:pr-review
   (single external AI, one comment). Reused by gh:issue-flow as its post-PR
@@ -23,11 +24,12 @@ metadata:
 ## Role
 
 Orchestrate a single PR through all available reviewers at once (gemini ∥
-codex ∥ `/simplify`), commit any simplify cleanup, then reply to the review
-comments — inline (deterministic) or deferred. No approve / request-changes
-decision (that is `gh:pr-approve`) and no per-comment authoring beyond the
-delegated `gh:pr-reply`. Every reviewer is soft-fail: a missing CLI or a
-transient error skips that one lane and the rest continue.
+codex ∥ `/code-review --fix` → `/simplify`), commit any auto-fix changes per
+sub-step, then reply to the review comments — inline (deterministic) or
+deferred. No approve / request-changes decision (that is `gh:pr-approve`) and
+no per-comment authoring beyond the delegated `gh:pr-reply`. Every reviewer is
+soft-fail: a missing CLI or a transient error skips that one lane and the
+rest continue.
 
 ## Help
 
@@ -51,32 +53,45 @@ print the stderr line and stop. Capture `pr`, `remote`, `reply_mode`
 - PR state must be `OPEN` and not draft (`gh pr view <pr> -R <TARGET_REPO>`)
   → else exit 1 `PR #<pr> is <state>; aborting`.
 - `gh auth status` returns 0 → else exit 1 with the gh error line.
-- **simplify branch context**: if the current branch is not the PR head
+- **auto-fix branch context**: if the current branch is not the PR head
   branch, run `gh pr checkout <pr> -R <TARGET_REPO>`; if already on it (e.g.
-  the issue-flow worktree path), skip. `/simplify` ignores PR# and acts on
-  the working tree, so this checkout is load-bearing (`references/constraints.md`).
+  the issue-flow worktree path), skip. `/code-review --fix` and `/simplify`
+  both ignore PR# and act on the working tree, so this checkout is
+  load-bearing (`references/constraints.md`).
 
-## Step 3: Parallel review gate (dispatch all lanes in ONE turn)
+## Step 3: Review + auto-fix gate (dispatch all lanes in ONE turn)
 
-The three lanes are independent, so dispatch **all Agent subagents in a single
-turn**. Each lane is soft-fail — a failure marks that lane `[SKIP]`/`[WARN]`
-and the others continue. Detail: `references/constraints.md`.
+The three lanes dispatch together in a single turn. gemini and codex are
+comment-only (never touch the working tree), so they run fully in parallel
+with everything else. `/code-review --fix` and `/simplify` both mutate the
+PR working tree, so **within the third lane they run sequentially, each
+followed immediately by its own commit** — never concurrently with each
+other, or the two agents could edit the same files at once
+(`references/constraints.md`). Each lane is soft-fail — a failure marks that
+lane `[SKIP]`/`[WARN]` and the others continue.
 
 - **gemini** — if `command -v gemini`, an Agent runs
   `Skill(gh:pr-review, "--ai gemini <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
 - **codex** — if `command -v codex`, an Agent runs
   `Skill(gh:pr-review, "--ai codex <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
-- **/simplify** — an Agent runs the built-in `/simplify` on the working-tree
-  diff (PR# is ignored — hence the Step 2 checkout).
+- **auto-fix chain** (sequential sub-steps, both on the working-tree diff;
+  PR# is ignored by both — hence the Step 2 checkout):
+  1. An Agent runs `/code-review --fix`. `git status --porcelain` non-empty →
+     `git commit -m "fix(<scope>): code-review --fix"`; erroring invocation →
+     WARN, continue to sub-step 2 regardless.
+  2. Only after sub-step 1's commit (or no-op), an Agent runs the built-in
+     `/simplify`. `git status --porcelain` non-empty → `git commit -m
+     "refactor(<scope>): simplify per /simplify"`.
+  **Never a bare `git commit`** in either sub-step — it hangs on the editor
+  in a non-interactive shell; always pass `-m`.
 
-## Step 4: Commit + push simplify changes (only if the tree changed)
+## Step 4: Push any auto-fix commits (only if something changed)
 
-Await all three Agents, then:
+Await all lanes, then:
 
-- `git status --porcelain` non-empty → `git commit -m "refactor(<scope>):
-  simplify per /simplify"` + `git push`. **Never a bare `git commit`** — it
-  hangs on the editor in a non-interactive shell; always pass `-m`.
-- Clean tree → skip.
+- Either auto-fix sub-step committed → `git push` once (both commits go up
+  together).
+- Neither sub-step changed the tree → skip.
 
 ## Step 5: pr-reply (per reply_mode)
 
@@ -91,11 +106,13 @@ Await all three Agents, then:
 ## Step 6: Report
 
 Print exactly one `[OK]`/`[SKIP]`/`[WARN]` line, e.g.
-`[OK] PR #<pr> reviewed (gemini:OK codex:SKIP simplify:committed) — reply: inline`.
+`[OK] PR #<pr> reviewed (gemini:OK codex:SKIP code-review:committed simplify:committed) — reply: inline`.
 
 ## Constraints (full rationale: `references/constraints.md`)
 
 - Every reviewer lane is soft-fail — never hard-fail on a missing/erroring CLI.
+- `/code-review --fix` and `/simplify` both mutate the working tree — run them
+  sequentially with a commit between them, never concurrently with each other.
 - Never a bare `git commit` — always `-m` (non-interactive hang guard).
 - Inline reply is the deterministic path; `--defer-reply` is minutes-only and not a guarantee.
 - No approve / request-changes here — that is `gh:pr-approve`.

--- a/claude/skills/devx-pr-review-all/references/constraints.md
+++ b/claude/skills/devx-pr-review-all/references/constraints.md
@@ -15,6 +15,23 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
   conventional-commit message, e.g.
   `git commit -m "refactor(<scope>): simplify per /simplify"`.
 
+- **`/code-review --fix` and `/simplify` both mutate the working tree — never
+  run them concurrently with each other.** gemini/codex only post PR
+  comments, so they're safe to fan out fully in parallel. But two agents
+  editing the same files at the same time is a real correctness risk (lost
+  edits, interleaved partial writes, a resulting diff that matches neither
+  agent's intent). Step 3's third lane is therefore internally sequential —
+  `/code-review --fix` runs to completion and commits before `/simplify`
+  starts — even though the lane as a whole still dispatches in the same turn
+  as gemini/codex.
+
+- **Each auto-fix sub-step gets its own commit, not one combined commit.**
+  `fix(<scope>): code-review --fix` and `refactor(<scope>): simplify per
+  /simplify` land as two separate commits when both mutate the tree. This
+  keeps `git blame`/revert granular — a bad `/simplify` cleanup can be
+  reverted without touching a `/code-review --fix` correctness fix, and vice
+  versa. A single `git push` at Step 4 sends up whichever commits exist.
+
 - **Delay is not a guarantee — inline reply is the deterministic path.**
   gemini/codex reviews are synchronous `gh:pr-review` CLI calls: they post the
   PR comment before returning. Because Step 3 awaits all three Agents, the
@@ -31,13 +48,14 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
   and replies to comments; it never submits a `gh pr review` decision. That is
   `gh:pr-approve`'s job.
 
-- **Built-in `/simplify` ignores the PR# argument** and operates on the
-  current working tree / branch diff. This is why Step 2 checks out the PR
-  head branch first when running standalone — without it, `/simplify` would
-  edit whatever tree happens to be checked out. On the issue-flow delegation
-  path the branch is already correct, so the checkout is a no-op skip.
+- **Built-in `/simplify` and `/code-review --fix` both ignore the PR# argument**
+  and operate on the current working tree / branch diff. This is why Step 2
+  checks out the PR head branch first when running standalone — without it,
+  either command would edit whatever tree happens to be checked out. On the
+  issue-flow delegation path the branch is already correct, so the checkout
+  is a no-op skip.
 
-- **The simplify commit + push (Step 4) runs synchronously before return.**
+- **The auto-fix commits + push (Step 4) run synchronously before return.**
   On the issue-flow delegation path this guarantees no dirty tree is left for
   the later rebase steps — a dirty working tree breaks `git rebase`.
 

--- a/claude/skills/devx-pr-review-all/references/constraints.md
+++ b/claude/skills/devx-pr-review-all/references/constraints.md
@@ -12,8 +12,11 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
 
 - **Never run a bare `git commit`.** In a non-interactive AI shell a bare
   commit opens an editor for the message and hangs. Always pass `-m` with a
-  conventional-commit message, e.g.
-  `git commit -m "refactor(<scope>): simplify per /simplify"`.
+  conventional-commit message. The auto-fix agents (`/code-review --fix`,
+  `/simplify`) edit files without staging them, so a plain `-m` finds nothing
+  staged and fails with `no changes added to commit` — use `-am` so the
+  commit picks up the unstaged edits too, e.g.
+  `git commit -am "refactor(<scope>): simplify per /simplify"`.
 
 - **`/code-review --fix` and `/simplify` both mutate the working tree — never
   run them concurrently with each other.** gemini/codex only post PR

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -1,8 +1,9 @@
 # devx:pr-review-all — Help
 
 Fan out **every available reviewer** on one PR in parallel — `gemini` ∥
-`codex` second opinions ∥ the built-in `/simplify` cleanup — then run a
-reply pass over the resulting review comments. A composition skill: it
+`codex` second opinions ∥ a sequential `/code-review --fix` → `/simplify`
+auto-fix chain (each sub-step commits its own changes) — then run a reply
+pass over the resulting review comments. A composition skill: it
 orchestrates several reviewers plus a reply, unlike `gh:pr-review` (a single
 external AI, one aggregate comment). It submits **no decision** (approve /
 request-changes) — that is `gh:pr-approve`.
@@ -36,14 +37,18 @@ request-changes) — that is `gh:pr-approve`.
 
 1. Parse args via `devx_pr_review_all_parse`; record `START_TS`.
 2. Pre-flight: PR must be `OPEN` and non-draft, `gh auth` must be live, and
-   check out the PR head branch if not already on it (so `/simplify` acts on
-   the right tree).
-3. Parallel review gate — dispatch gemini, codex, and `/simplify` as Agent
-   subagents **in one turn**. gemini/codex delegate to
-   `gh:pr-review --ai <name>` (streams findings + posts a PR comment).
-   Each lane is soft-fail.
-4. Commit + push any `/simplify` changes (only if the working tree changed),
-   always with an explicit `-m` message.
+   check out the PR head branch if not already on it (so `/code-review --fix`
+   and `/simplify` act on the right tree).
+3. Review + auto-fix gate — dispatch gemini, codex, and an auto-fix chain as
+   Agent subagents **in one turn**. gemini/codex delegate to
+   `gh:pr-review --ai <name>` (streams findings + posts a PR comment) and run
+   fully in parallel. `/code-review --fix` and `/simplify` both mutate the
+   working tree, so they run **sequentially** within their own lane, each
+   committing its own changes immediately (`fix(<scope>): code-review --fix`,
+   then `refactor(<scope>): simplify per /simplify`) — never concurrently
+   with each other. Each lane is soft-fail.
+4. Push any commits from the auto-fix chain (only if the working tree
+   changed), always with an explicit `-m` message on each commit.
 5. Reply — inline `gh:pr-reply <pr> <remote>` (default), or deferred via
    `devx:schedule` (`--defer-reply M`), or skipped (`--no-reply`). The
    `<remote>` is threaded so the reply pass resolves the same target repo.

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -2,8 +2,9 @@
 name: gh:issue-flow
 description: >-
   Composition skill that chains gh:issue-implement → gh:commit → gh:pr →
-  devx:pr-review-all (gemini ∥ codex ∥ /simplify quality gate + deferred
-  pr-reply, 8 min) → gh:pr-resolve-conflict → gh:pr-resolve-outdated
+  devx:pr-review-all (gemini ∥ codex ∥ /code-review --fix → /simplify
+  quality gate + deferred pr-reply, 8 min) → gh:pr-resolve-conflict →
+  gh:pr-resolve-outdated
   (out-of-date base sync) for a single issue number. Use when the user runs
   /gh:issue-flow, /gh-issue-flow, or asks "issue #16 처음부터 PR까지 자동으로",
   "이슈 구현하고 커밋하고 PR까지 한방에", "full flow on #42". Uses direct


### PR DESCRIPTION
## Summary
- `devx:pr-review-all`의 Step 3 병렬 리뷰 게이트에 `/code-review --fix` 자동수정 레인을 추가했다.
- 워킹트리를 직접 수정하는 두 레인(`/code-review --fix`, `/simplify`)은 동시 편집 충돌을 피하려고 내부적으로 순차 실행 + 레인별 개별 커밋으로 구성했다.
- 이 스킬을 quality gate로 재사용하는 `gh:issue-flow`의 설명 문구도 새 레인 구성에 맞춰 갱신했다.

## Changes
- `devx-pr-review-all/SKILL.md`: Step 3을 "Review + auto-fix gate"로 재구성 — gemini/codex는 완전 병렬 유지, `/code-review --fix` → `/simplify` 순차 auto-fix 체인을 추가하고 각 서브스텝이 자체 커밋(`fix(<scope>): code-review --fix` / `refactor(<scope>): simplify per /simplify`)을 남기도록 함. Step 4는 "커밋된 것이 있으면 push"로 축소.
- `devx-pr-review-all/references/constraints.md`: `/code-review --fix`와 `/simplify`를 동시에 돌리면 안 되는 이유(두 에이전트가 같은 파일을 동시 편집)와 레인별 개별 커밋 정책의 rationale을 추가.
- `devx-pr-review-all/references/help.md`: 사용자 대상 흐름 설명(1~4단계)을 새 auto-fix 체인에 맞춰 갱신.
- `gh-issue-flow/SKILL.md`: `devx:pr-review-all`을 재사용하는 설명 한 줄을 새 레인 구성에 맞춰 갱신.

## Test plan
- [ ] `mise run lint` — 문서 전용 변경이라 영향 없음을 확인
- [ ] `/skill:check devx-pr-review-all`로 구조 검증
- [ ] 실제 PR에 `/devx:pr-review-all <PR#>`를 실행해 `code-review --fix → simplify` 순차 auto-fix 체인과 개별 커밋이 기대대로 동작하는지 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~8 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~8 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
