### PR TITLE
feat(agy): agy-yolo alias 추가 (--dangerously-skip-permissions)

### DIFF
--- a/shell-common/tools/integrations/agy.sh
+++ b/shell-common/tools/integrations/agy.sh
@@ -34,6 +34,7 @@ alias agyhelp='agy --help'
 alias agyc='agy --continue'
 alias agyplan='agy --mode plan'
 alias agymodels='agy models'
+alias agy-yolo='agy --dangerously-skip-permissions'
 
 # --- Functions ---
 

--- a/shell-common/tools/integrations/agy.sh
+++ b/shell-common/tools/integrations/agy.sh
@@ -20,6 +20,8 @@ Antigravity CLI (agy) Dotfiles Helper - Getting Started
    OAuth 토큰은 ~/.gemini/antigravity-cli/ 에 저장된다.
    Use: agyhelp   (agy --help — 실제 CLI 옵션 확인)
    Use: agymodels (agy models — 사용 가능한 모델 목록)
+   Use: agy-yolo  (agy --dangerously-skip-permissions — codex-yolo 와 동일하게
+                   승인/권한 확인을 건너뛴다. 신뢰된 로컬 작업에서만 사용할 것)
 
 주의: agy 자체 인스톨러(agy install)는 셸 프로파일의 PATH/alias 를
 수정한다. dotfiles 는 shell-common/env/path.sh 가 ~/.local/bin 을


### PR DESCRIPTION
## Summary
- `agy.sh`에 `codex-yolo`와 대칭되는 `agy-yolo` alias 추가

## Changes
- `agy.sh`: `alias agy-yolo='agy --dangerously-skip-permissions'` 추가 — 기존 `codex.sh`의 `codex-yolo` 패턴을 따름

## Test plan
- [x] `shellcheck` 통과 (신규 라인 기준)
- [x] `pytest` 전체 스위트 통과 (1199 passed)

## Related
Closes #1182

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
