### PR TITLE
feat(ai-cli): gemini→agy 전면 교체

### DIFF
--- a/claude/skills/ai-worktree-spawn/references/agent-detection.md
+++ b/claude/skills/ai-worktree-spawn/references/agent-detection.md
@@ -14,7 +14,7 @@ Determine `agent_name` using this order (first match wins):
 | AI Agent | Detection Method | Result Name |
 |---|---|---|
 | Claude Code | `$CLAUDECODE == 1` | `claude` |
-| Gemini CLI | `$GEMINI_CLI == 1` or process name `gemini` | `gemini` |
+| Antigravity CLI | `$AGY_CLI == 1` or process name `agy` | `agy` |
 | Codex CLI | `$CODEX_CLI == 1` or process name `codex` | `codex` |
 | OpenCode | `$OPENCODE == 1` or `~/.opencode/` exists | `opencode` |
 | Cursor | `$CURSOR == 1` or `$TERM_PROGRAM == cursor` | `cursor` |

--- a/claude/skills/ai-worktree-spawn/references/bash-commands.md
+++ b/claude/skills/ai-worktree-spawn/references/bash-commands.md
@@ -40,7 +40,7 @@ detect_ai_agent() {
 
   # Priority 3: Agent-specific env vars
   if [[ "${CLAUDECODE:-}" == "1" ]]; then echo "claude"; return; fi
-  if [[ "${GEMINI_CLI:-}" == "1" ]]; then echo "gemini"; return; fi
+  if [[ "${AGY_CLI:-}" == "1" ]]; then echo "agy"; return; fi
   if [[ "${CODEX_CLI:-}" == "1" ]]; then echo "codex"; return; fi
   if [[ "${OPENCODE:-}" == "1" ]]; then echo "opencode"; return; fi
   if [[ "${CURSOR:-}" == "1" || "${TERM_PROGRAM:-}" == "cursor" ]]; then echo "cursor"; return; fi

--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: devx:pr-review-all
 description: >-
-  Fan out every available reviewer on one PR in parallel — gemini ∥ codex
+  Fan out every available reviewer on one PR in parallel — agy ∥ codex
   second opinions ∥ a sequential /code-review --fix → /simplify auto-fix
   chain (each sub-step commits its own changes) — then run a reply pass over
   the review comments. Use for /devx:pr-review-all, /devx-pr-review-all,
-  "PR 다중 리뷰어 병렬로", "gemini codex simplify 한번에 돌려",
+  "PR 다중 리뷰어 병렬로", "agy codex simplify 한번에 돌려",
   "PR 99 전체 리뷰". A composition skill — distinct from gh:pr-review
   (single external AI, one comment). Reused by gh:issue-flow as its post-PR
   quality gate. Accepts `<PR#> [remote] [--defer-reply M] [--no-reply]`
@@ -23,7 +23,7 @@ metadata:
 
 ## Role
 
-Orchestrate a single PR through all available reviewers at once (gemini ∥
+Orchestrate a single PR through all available reviewers at once (agy ∥
 codex ∥ `/code-review --fix` → `/simplify`), commit any auto-fix changes per
 sub-step, then reply to the review comments — inline (deterministic) or
 deferred. No approve / request-changes decision (that is `gh:pr-approve`) and
@@ -61,7 +61,7 @@ print the stderr line and stop. Capture `pr`, `remote`, `reply_mode`
 
 ## Step 3: Review + auto-fix gate (dispatch all lanes in ONE turn)
 
-The three lanes dispatch together in a single turn. gemini and codex are
+The three lanes dispatch together in a single turn. agy and codex are
 comment-only (never touch the working tree), so they run fully in parallel
 with everything else. `/code-review --fix` and `/simplify` both mutate the
 PR working tree, so **within the third lane they run sequentially, each
@@ -70,8 +70,8 @@ other, or the two agents could edit the same files at once
 (`references/constraints.md`). Each lane is soft-fail — a failure marks that
 lane `[SKIP]`/`[WARN]` and the others continue.
 
-- **gemini** — if `command -v gemini`, an Agent runs
-  `Skill(gh:pr-review, "--ai gemini <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
+- **agy** — if `command -v agy`, an Agent runs
+  `Skill(gh:pr-review, "--ai agy <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
 - **codex** — if `command -v codex`, an Agent runs
   `Skill(gh:pr-review, "--ai codex <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
 - **auto-fix chain** (sequential sub-steps, both on the working-tree diff;
@@ -96,7 +96,7 @@ Await all lanes, then:
 ## Step 5: pr-reply (per reply_mode)
 
 - `inline` (default) → run `Skill(gh:pr-reply, "<pr> <remote>")` immediately.
-  Step 3 was awaited, so gemini/codex comments are already posted — reply
+  Step 3 was awaited, so agy/codex comments are already posted — reply
   order is deterministic, no delay needed. The `<remote>` is threaded so
   `gh:pr-reply` resolves the same target repo this skill did, not gh's
   default-repo heuristic (`references/constraints.md`).
@@ -106,7 +106,7 @@ Await all lanes, then:
 ## Step 6: Report
 
 Print exactly one `[OK]`/`[SKIP]`/`[WARN]` line, e.g.
-`[OK] PR #<pr> reviewed (gemini:OK codex:SKIP code-review:committed simplify:committed) — reply: inline`.
+`[OK] PR #<pr> reviewed (agy:OK codex:SKIP code-review:committed simplify:committed) — reply: inline`.
 
 ## Constraints (full rationale: `references/constraints.md`)
 

--- a/claude/skills/devx-pr-review-all/references/constraints.md
+++ b/claude/skills/devx-pr-review-all/references/constraints.md
@@ -2,10 +2,10 @@
 
 The SKILL.md body lists these as terse rules; the full rationale lives here.
 
-- **Every reviewer lane is soft-fail — never hard-fail.** A missing `gemini`
+- **Every reviewer lane is soft-fail — never hard-fail.** A missing `agy`
   or `codex` CLI (`command -v` empty), a rate-limit, or any non-zero exit from
   `gh:pr-review` marks only that lane `[SKIP]`/`[WARN]`; the other lanes and
-  the rest of the flow continue. If both gemini and codex are unavailable,
+  the rest of the flow continue. If both agy and codex are unavailable,
   `/simplify` still runs. `gh:pr-review` already does its own
   `command -v`/OPEN/draft pre-flight, so do **not** duplicate those as
   hard-fails here — always wrap the lane softly.
@@ -19,14 +19,14 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
   `git commit -am "refactor(<scope>): simplify per /simplify"`.
 
 - **`/code-review --fix` and `/simplify` both mutate the working tree — never
-  run them concurrently with each other.** gemini/codex only post PR
+  run them concurrently with each other.** agy/codex only post PR
   comments, so they're safe to fan out fully in parallel. But two agents
   editing the same files at the same time is a real correctness risk (lost
   edits, interleaved partial writes, a resulting diff that matches neither
   agent's intent). Step 3's third lane is therefore internally sequential —
   `/code-review --fix` runs to completion and commits before `/simplify`
   starts — even though the lane as a whole still dispatches in the same turn
-  as gemini/codex.
+  as agy/codex.
 
 - **Each auto-fix sub-step gets its own commit, not one combined commit.**
   `fix(<scope>): code-review --fix` and `refactor(<scope>): simplify per
@@ -36,7 +36,7 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
   versa. A single `git push` at Step 4 sends up whichever commits exist.
 
 - **Delay is not a guarantee — inline reply is the deterministic path.**
-  gemini/codex reviews are synchronous `gh:pr-review` CLI calls: they post the
+  agy/codex reviews are synchronous `gh:pr-review` CLI calls: they post the
   PR comment before returning. Because Step 3 awaits all three Agents, the
   comments exist by the time Step 5 runs, so an **inline** `gh:pr-reply` sees
   them with deterministic ordering — no fixed delay needed. `--defer-reply` is

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -1,6 +1,6 @@
 # devx:pr-review-all — Help
 
-Fan out **every available reviewer** on one PR in parallel — `gemini` ∥
+Fan out **every available reviewer** on one PR in parallel — `agy` ∥
 `codex` second opinions ∥ a sequential `/code-review --fix` → `/simplify`
 auto-fix chain (each sub-step commits its own changes) — then run a reply
 pass over the resulting review comments. A composition skill: it
@@ -39,8 +39,8 @@ request-changes) — that is `gh:pr-approve`.
 2. Pre-flight: PR must be `OPEN` and non-draft, `gh auth` must be live, and
    check out the PR head branch if not already on it (so `/code-review --fix`
    and `/simplify` act on the right tree).
-3. Review + auto-fix gate — dispatch gemini, codex, and an auto-fix chain as
-   Agent subagents **in one turn**. gemini/codex delegate to
+3. Review + auto-fix gate — dispatch agy, codex, and an auto-fix chain as
+   Agent subagents **in one turn**. agy/codex delegate to
    `gh:pr-review --ai <name>` (streams findings + posts a PR comment) and run
    fully in parallel. `/code-review --fix` and `/simplify` both mutate the
    working tree, so they run **sequentially** within their own lane, each

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -2,7 +2,7 @@
 name: gh:issue-flow
 description: >-
   Composition skill that chains gh:issue-implement → gh:commit → gh:pr →
-  devx:pr-review-all (gemini ∥ codex ∥ /code-review --fix → /simplify
+  devx:pr-review-all (agy ∥ codex ∥ /code-review --fix → /simplify
   quality gate + deferred pr-reply, 8 min) → gh:pr-resolve-conflict →
   gh:pr-resolve-outdated
   (out-of-date base sync) for a single issue number. Use when the user runs
@@ -42,7 +42,7 @@ If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
 its content verbatim, then stop. No API calls. The help output names the 6
 chained skills (gh:issue-implement, gh:commit, gh:pr, devx:pr-review-all,
 gh:pr-resolve-conflict, gh:pr-resolve-outdated); devx:pr-review-all runs the
-post-PR quality gate (gemini ∥ codex ∥ /simplify) and schedules the pr-reply.
+post-PR quality gate (agy ∥ codex ∥ /simplify) and schedules the pr-reply.
 
 ## Step 1: Parse Args
 
@@ -70,7 +70,7 @@ sequence. After each call, immediately proceed to the next.
 3. **Step 2.3 — gh:pr** (only if 2.2 succeeded) — ensures `Closes #<N>`;
    extract `<PR_NUM>` from the PR URL. `Skill(gh:pr, "<N>")`
 4. **Step 2.4 — devx:pr-review-all** (only if 2.3 succeeded; soft-fail) — one
-   delegated call runs the post-PR quality gate (gemini ∥ codex ∥ `/simplify`),
+   delegated call runs the post-PR quality gate (agy ∥ codex ∥ `/simplify`),
    commits + pushes any simplify changes synchronously, and schedules
    `/gh-pr-reply <PR_NUM>` 8 min later via `--defer-reply`. The synchronous
    simplify commit lands before the 2.5/2.5.1 rebase steps. Detail:

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -4,7 +4,7 @@
 - Never retry a failed step. Human decides retry or fix.
 - Never skip a step. All 6 or stop.
 - **Quality-gate soft-fail exception.** Step 2.4 (`devx:pr-review-all`)
-  is additive polish, not gating: gemini/codex absent → that lane skips
+  is additive polish, not gating: agy/codex absent → that lane skips
   (not a failure); `/simplify` produced no change → no commit; any error
   in review/simplify/commit → `[WARN]` and continue. The gate never stops
   the flow.

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -9,7 +9,7 @@
 
 ## Usage
 
-- `/gh-issue-flow 16` — chain: implement → commit → PR → devx:pr-review-all (gemini ∥ codex ∥ /simplify quality gate + deferred pr-reply) → resolve conflicts → resolve out-of-date, for issue #16 on `origin`.
+- `/gh-issue-flow 16` — chain: implement → commit → PR → devx:pr-review-all (agy ∥ codex ∥ /simplify quality gate + deferred pr-reply) → resolve conflicts → resolve out-of-date, for issue #16 on `origin`.
 - `/gh-issue-flow 16 upstream` — same chain on `upstream` remote.
 - `/gh-issue-flow -h` / `--help` / `help` — print this help.
 
@@ -20,7 +20,7 @@ This skill invokes **6 skills in sequence** (each step runs only if the previous
 1. **`gh:issue-implement <N> direct`** — reads the issue, edits files, runs tests. No human intervention.
 2. **`gh:commit`** — creates a commit for the changes with a message derived from the conversation (follows the repo's commit style).
 3. **`gh:pr`** — pushes the branch and opens a PR, auto-linking `Closes #<N>`.
-4. **`devx:pr-review-all` `<PR_NUM> <remote> --defer-reply 8`** — one delegated call runs the post-PR quality gate (soft-fail, parallel): gemini ∥ codex second-opinion reviews (each skipped if its CLI is absent) ∥ built-in `/simplify` on the branch diff. Any simplify changes are committed + pushed synchronously before it returns (so they land before the rebase steps), and `/gh-pr-reply <PR_NUM>` is scheduled 8 minutes later — giving CI and reviewers time to post before the reply pass runs. Failures warn and continue — they never stop the chain.
+4. **`devx:pr-review-all` `<PR_NUM> <remote> --defer-reply 8`** — one delegated call runs the post-PR quality gate (soft-fail, parallel): agy ∥ codex second-opinion reviews (each skipped if its CLI is absent) ∥ built-in `/simplify` on the branch diff. Any simplify changes are committed + pushed synchronously before it returns (so they land before the rebase steps), and `/gh-pr-reply <PR_NUM>` is scheduled 8 minutes later — giving CI and reviewers time to post before the reply pass runs. Failures warn and continue — they never stop the chain.
 5. **`gh:pr-resolve-conflict` `<PR_NUM>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
 6. **`gh:pr-resolve-outdated` `<PR_NUM>`** — clean rebase-sync when the base branch has moved forward with no conflicts. No-op if the PR is already up to date.
 

--- a/claude/skills/gh-issue-flow/references/quality-gate-step.md
+++ b/claude/skills/gh-issue-flow/references/quality-gate-step.md
@@ -16,8 +16,8 @@ Skill(devx:pr-review-all, "<PR_NUM> <remote> --defer-reply 8")
 One call replaces the former inline gate (codex ∥ /simplify + commit/push)
 AND the former `devx:schedule` pr-reply step. Inside `devx:pr-review-all`:
 
-- **gemini ∥ codex ∥ /simplify** run as parallel Agent subagents in one turn.
-  gemini review is now included (it was missing from the old inline gate).
+- **agy ∥ codex ∥ /simplify** run as parallel Agent subagents in one turn.
+  agy review is now included (it was missing from the old inline gate).
   Each lane is soft-fail: a missing CLI or transient error skips that lane and
   the others continue.
 - **simplify commit + push** happens **synchronously inside** the skill,
@@ -38,7 +38,7 @@ simplify-commit-before-rebase guarantee the old inline Step 2.3.3 provided.
 
 ## Soft-fail policy
 
-- codex/gemini absent → that lane skips (not a failure).
+- codex/agy absent → that lane skips (not a failure).
 - simplify no change → no commit (clean tree).
 - Any error in review, simplify, the simplify commit/push, or the reply
   scheduling → the delegated skill emits a `[WARN]`/`[SKIP]` line and the

--- a/claude/skills/gh-issue-flow/references/report-template.md
+++ b/claude/skills/gh-issue-flow/references/report-template.md
@@ -7,7 +7,7 @@ gh:issue-flow complete (#<N>)
   [OK] Step 1: gh:issue-implement       (<n files changed>, <n tests passed>)
   [OK] Step 2: gh:commit                (<sha> "<subject>")
   [OK] Step 3: gh:pr                    (PR #<M>)
-  [OK] Step 4: devx:pr-review-all       (gemini+codex+simplify, reply in 8 min)
+  [OK] Step 4: devx:pr-review-all       (agy+codex+simplify, reply in 8 min)
   [OK] Step 5: gh:pr-resolve-conflict   (no conflicts / resolved)
   [OK] Step 5.1: gh:pr-resolve-outdated (up to date / rebased)
   [OK] Step 6: ai-metrics               (~X tokens · ~M h · ~L min)
@@ -17,7 +17,7 @@ gh:issue-flow complete (#<N>)
 Step 4 (`devx:pr-review-all`) is soft-fail — its row uses `[SKIP]`/`[WARN]`
 for the gate's degraded cases (the delegated skill reports the per-lane
 detail):
-- `[SKIP] Step 4: devx:pr-review-all  (gemini/codex absent)` — no CLI.
+- `[SKIP] Step 4: devx:pr-review-all  (agy/codex absent)` — no CLI.
 - `[SKIP] Step 4: devx:pr-review-all  (simplify: no change)` — clean tree, no commit.
 - `[WARN] Step 4: devx:pr-review-all  (<reason>)` — review/simplify error, continued.
 

--- a/claude/skills/gh-issue-flow/references/stop-guard.md
+++ b/claude/skills/gh-issue-flow/references/stop-guard.md
@@ -5,7 +5,7 @@
 `gh:issue-flow` chains 6 sub-skills (`gh:issue-implement` → `gh:commit` →
 `gh:pr` → `devx:pr-review-all` → `gh:pr-resolve-conflict` →
 `gh:pr-resolve-outdated`) plus a final Step 3 report. The post-PR quality
-gate (gemini ∥ codex ∥ `/simplify`, with commit+push) and the deferred
+gate (agy ∥ codex ∥ `/simplify`, with commit+push) and the deferred
 `/gh-pr-reply` scheduling now live *inside* the delegated
 `devx:pr-review-all` (Step 2.4) — they are no longer dispatched inline by
 gh:issue-flow. `devx-pr-review-all` is the 4th entry of the hook's

--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: gh:pr-review
 description: >-
-  Delegate a GitHub PR's review to an external AI CLI (codex, gemini,
+  Delegate a GitHub PR's review to an external AI CLI (codex, agy,
   or claude) for a second opinion. Streams the external CLI's findings
   to stdout and posts them as a PR comment by default. Does NOT submit
   a decision (no approve / request-changes) — that is gh:pr-approve's
   job, and replying to individual review comments is gh:pr-reply's. Use
   for /gh-pr-review, /gh:pr-review, "PR 99 코덱스에 리뷰 시켜",
-  "gemini 한테 2차 의견 받아", "second-opinion review on PR 42".
-  Accepts `--ai <codex|gemini|claude>` (required), `--review <preset>`,
+  "agy 한테 2차 의견 받아", "second-opinion review on PR 42".
+  Accepts `--ai <codex|agy|claude>` (required), `--review <preset>`,
   `--user <name>` (claude only), `--no-post-comment`, and `<PR#>
   [remote]` positional args. `-h`/`--help`/`help` prints usage.
 allowed-tools: Bash, Read, Grep, Glob, Agent
@@ -25,7 +25,7 @@ metadata:
 ## Role
 
 Gather a second-opinion review on a GitHub PR from one external AI CLI
-(`codex`/`gemini`/`claude`), stream its output, and post it as a PR
+(`codex`/`agy`/`claude`), stream its output, and post it as a PR
 comment by default — then stop. No decision (approve/request-changes —
 `gh:pr-approve`'s job) and no per-comment replies (`gh:pr-reply`'s
 job). Every preset's prompt demands a critical stance

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -17,7 +17,7 @@ command -v "$AI_BIN" >/dev/null 2>&1 || {
 }
 ```
 
-`AI_BIN` is the literal command name: `codex`, `gemini`, or `claude`.
+`AI_BIN` is the literal command name: `codex`, `agy`, or `claude`.
 
 ## stdin payload shape
 
@@ -57,31 +57,20 @@ Why `codex exec` instead of `codex review --base <branch>`:
 comment renders cleanly. The CLI's exit code propagates; non-zero →
 quote the first stderr line and exit 1.
 
-## `--ai gemini`
+## `--ai agy`
 
 ```sh
-gemini -p ' ' < "$PROMPT_FILE"
+agy --print < "$PROMPT_FILE"
 ```
 
-`gemini -p` is yargs-backed and **requires a token after `-p`**. The
-original `gemini -p < "$PROMPT_FILE"` shape produced `Not enough
-arguments following: p` because yargs sees no follow-up token (issue
-#694 Bug A). However, `gemini --help` documents that the `-p` value
-is "Appended to input on stdin (if any)" — so a single-space marker
-satisfies the parser while the actual prompt still flows on stdin.
-This sidesteps the ARG_MAX / shell-quoting hazard of the earlier
-`gemini -p "$(cat "$PROMPT_FILE")"` shape (gemini-code-assist review
-on PR #695).
-
-Model selection (`-m <model>`) intentionally falls back to the user's
-environment default; add a `--gemini-model` flag in a future iteration
-only if users report drift between defaults.
+`agy --print` runs the Antigravity CLI non-interactively, reading the
+prompt (and appended diff) from stdin. Model selection intentionally
+falls back to agy's own default; no `--model` flag is passed.
 
 Stderr policy is identical to codex: non-zero exit → noise-filtered
 summary + full stderr tail + persistent stderr log on disk. The stderr
 file is created via `mktemp "/tmp/gh-pr-review-stderr.<ai>.XXXXXX"`
-to avoid the predictable-PID symlink-attack class (also raised in the
-gemini-code-assist review on PR #695).
+to avoid the predictable-PID symlink-attack class.
 
 ## `--ai claude` (no `--user`)
 
@@ -89,7 +78,7 @@ gemini-code-assist review on PR #695).
 claude -p < "$PROMPT_FILE"
 ```
 
-Same stdin pattern as the gemini invocation — `claude -p` reads from
+Same stdin pattern as the agy invocation — `claude -p` reads from
 stdin when no argv prompt is supplied. The skill inherits whatever
 `CLAUDE_CONFIG_DIR` the calling shell has set. If the user is inside
 `claude-yolo --user work`, that `work` account is preserved
@@ -125,7 +114,7 @@ CLAUDE_CONFIG_DIR="$CFG_DIR" claude -p < "$PROMPT_FILE"
 
 ```sh
 if [ -n "$USER_ACCOUNT" ] && [ "$AI" != "claude" ]; then
-    echo "--user is only valid with --ai claude (codex/gemini have no multi-account routing)" >&2
+    echo "--user is only valid with --ai claude (codex/agy have no multi-account routing)" >&2
     exit 2
 fi
 ```
@@ -149,7 +138,7 @@ omit `--user` and let the current shell's `CLAUDE_CONFIG_DIR` win.
 Step 5 of the skill delegates to `_gh_pr_review_run_ai` in
 `shell-common/functions/gh_pr_review.sh`. The function pipes
 `PROMPT_FILE` into the chosen CLI with the exact invocation shape
-documented above (`codex exec --color=never`, `gemini -p`, `claude -p`,
+documented above (`codex exec --color=never`, `agy --print`, `claude -p`,
 plus the `CLAUDE_CONFIG_DIR` injection for `--user`). Stdout streams to
 the user verbatim — no reformatting, no summarization, no truncation.
 
@@ -162,9 +151,9 @@ skips Step 6; partial output is discarded.
 
 | Condition | Exit | stderr |
 |-----------|------|--------|
-| `--ai` missing | 2 | `missing required flag: --ai <codex\|gemini\|claude>` |
-| `--ai` unknown | 2 | `Unknown --ai value: '<x>' (allowed: codex, gemini, claude)` |
-| `--user` with codex/gemini | 2 | `--user is only valid with --ai claude (codex/gemini have no multi-account routing)` |
+| `--ai` missing | 2 | `missing required flag: --ai <codex\|agy\|claude>` |
+| `--ai` unknown | 2 | `Unknown --ai value: '<x>' (allowed: codex, agy, claude)` |
+| `--user` with codex/agy | 2 | `--user is only valid with --ai claude (codex/agy have no multi-account routing)` |
 | `--user <bogus>` with claude | 1 | `Unknown claude account: '<bogus>' (allowed: ...)` |
 | AI CLI not on PATH | 1 | `Required CLI '<name>' not found in PATH` |
 | AI CLI non-zero exit | 1 | `External AI CLI '<name>' failed (exit <rc>): <noise-filtered first line>` + full tail + `/tmp/gh-pr-review-stderr.<pid>.<ai>.log` (issue #694 Bug B — no longer surfaces codex's "Reading prompt from stdin…" banner as the failure cause) |

--- a/claude/skills/gh-pr-review/references/help.md
+++ b/claude/skills/gh-pr-review/references/help.md
@@ -1,6 +1,6 @@
 # gh:pr-review — Help
 
-Delegate a GitHub PR's review to an external AI CLI (`codex`, `gemini`,
+Delegate a GitHub PR's review to an external AI CLI (`codex`, `agy`,
 or `claude`) for a **second opinion**. Output is written to stdout and
 posted as a PR comment by default. **No decision (approve /
 request-changes) is submitted** — see `gh-pr-approve` for that.
@@ -16,7 +16,7 @@ request-changes) is submitted** — see `gh-pr-approve` for that.
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--ai <codex\|gemini\|claude>` | yes | External AI CLI to delegate the review to. Single value — no CSV. |
+| `--ai <codex\|agy\|claude>` | yes | External AI CLI to delegate the review to. Single value — no CSV. |
 | `--review <preset>` | no | Review depth/lens enum. Default `default`. See below. |
 | `--user <name>` | no | `--ai claude` only. Multi-account routing via `_claude_resolve_account` (e.g. `personal`, `work`, `work1`). |
 | `--no-post-comment` | no | Skip the automatic PR comment; only print to stdout. |
@@ -51,7 +51,7 @@ claude -p ...`.
   preserved** — no forced `personal`. Calling `/gh-pr-review --ai
   claude 99` from inside a `claude-yolo --user work` shell continues to
   use the `work` account.
-- `--user` with `--ai codex` or `--ai gemini` is **rejected (exit 2)** —
+- `--user` with `--ai codex` or `--ai agy` is **rejected (exit 2)** —
   those CLIs have no multi-account routing mechanism, so silently
   ignoring would risk hiding an intent mismatch.
 - Unknown account names fall through `_claude_resolve_account` and exit
@@ -61,13 +61,13 @@ claude -p ...`.
 ## Usage
 
 - `/gh-pr-review --ai codex 99` — codex review of PR #99 (default preset)
-- `/gh-pr-review --ai gemini --review thorough 99` — gemini, thorough preset
+- `/gh-pr-review --ai agy --review thorough 99` — agy, thorough preset
 - `/gh-pr-review --ai claude --review 꼼꼼 99` — claude, KR alias → thorough
 - `/gh-pr-review --ai claude --user work 99` — claude as `work` account
 - `/gh-pr-review --ai claude --user work1 --review 보안 99` — work1 + security
 - `/gh-pr-review --ai codex --no-post-comment 99` — stdout only, no PR comment
 - `/gh-pr-review --ai codex 99 upstream` — PR #99 on `upstream`'s repo
-- `/gh-pr-review --ai gemini` — auto-detect PR from current branch
+- `/gh-pr-review --ai agy` — auto-detect PR from current branch
 - `/gh-pr-review -h` / `--help` / `help` — print this help
 
 ## What the skill does
@@ -115,8 +115,8 @@ claude -p ...`.
 ## Good vs. bad invocation
 
 - **Good**: `/gh-pr-review --ai codex 99` — gather a 2nd opinion on PR #99.
-- **Good**: `/gh-pr-review --ai gemini --review security 99` — security-focused lens.
-- **Good**: chained `/gh-pr-review --ai codex 99` then `/gh-pr-review --ai gemini 99` — three-way comparison.
+- **Good**: `/gh-pr-review --ai agy --review security 99` — security-focused lens.
+- **Good**: chained `/gh-pr-review --ai codex 99` then `/gh-pr-review --ai agy 99` — three-way comparison.
 - **Bad**: `/gh-pr-review --ai codex --user work 99` — exits 2 (`--user` is claude-only).
 - **Bad**: `/gh-pr-review --ai claude --review "꼼꼼하게 봐줘" 99` — exits 2 (free text rejected; use `꼼꼼` alias).
 - **Bad**: `/gh-pr-review --ai chatgpt 99` — exits 2 (unknown AI).

--- a/claude/skills/gh-pr-review/references/parser-contract.md
+++ b/claude/skills/gh-pr-review/references/parser-contract.md
@@ -16,7 +16,7 @@ and the production parser is caught by
 Contract this skill depends on (do not duplicate the parser here; read
 `shell-common/functions/gh_pr_review.sh` for the authoritative shape):
 
-- `--ai <codex|gemini|claude>` — required.
+- `--ai <codex|agy|claude>` — required.
 - `--review <preset>` — closed enum; KR aliases normalize before
   dispatch.
 - `--user <name>` — `--ai claude` only.
@@ -38,7 +38,7 @@ has already happened. Free-text values are rejected (see exit codes).
 |------|---------|
 | 0 | Parse succeeded. |
 | 1 | Resolution failure (e.g. unknown claude account, target/PR resolution failed). |
-| 2 | Argument-surface error (missing/unknown `--ai`, `--user` with codex/gemini, free-text `--review` typo). |
+| 2 | Argument-surface error (missing/unknown `--ai`, `--user` with codex/agy, free-text `--review` typo). |
 
 ## Post-parse setup
 

--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -32,7 +32,7 @@ Substitutions:
 
 | Token | Source |
 |-------|--------|
-| `<AI_NAME>` | The `--ai` argument value (`codex` / `gemini` / `claude`). |
+| `<AI_NAME>` | The `--ai` argument value (`codex` / `agy` / `claude`). |
 | `<PRESET>` | The normalized `--review` enum (after KR-alias mapping). |
 | `<TOKENS>` | Estimated prompt tokens, rounded to the nearest 500. Minimum 1 000. |
 | `<HUMAN_H>` | Baseline human-review hours. See "Human time baseline" below. |

--- a/claude/skills/gh-pr-review/references/review-presets.md
+++ b/claude/skills/gh-pr-review/references/review-presets.md
@@ -2,7 +2,7 @@
 
 `--review` is a **closed enum**. Free-text input is rejected; Korean
 aliases normalize to the English enum before dispatch. The same prompt
-template is fed to all three CLIs (`codex` / `gemini` / `claude`) so
+template is fed to all three CLIs (`codex` / `agy` / `claude`) so
 their outputs are comparable side-by-side.
 
 ## Enum + Korean alias table

--- a/shell-common/env/claude.sh
+++ b/shell-common/env/claude.sh
@@ -9,7 +9,7 @@
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 # AI tool for documentation generation
-# Options: claude (default), gemini, codex, or any CLI tool accepting -p/--prompt
+# Options: claude (default), agy, codex, or any CLI tool accepting -p/--prompt
 # Can be overridden per-command or per-session
 export CLAUDE_DOC_GENERATOR=claude
 

--- a/shell-common/functions/ai_setup.sh
+++ b/shell-common/functions/ai_setup.sh
@@ -27,12 +27,12 @@ ai_setup() {
                 ux_info ""
                 ux_info "Options:"
                 ux_info "  --ai <agent>   Pre-fill the 'Tmux window agents' prompt"
-                ux_info "                    default (claude, codex, gemini,"
+                ux_info "                    default (claude, codex, agy,"
                 ux_info "                    opencode, cursor, copilot)."
                 ux_info ""
                 ux_info "Steps:"
                 ux_info "  1. Enter worktree names   (free-form: issue-11 login-fix)"
-                ux_info "  2. Enter tmux windows     (AI agents: claude codex gemini)"
+                ux_info "  2. Enter tmux windows     (AI agents: claude codex agy)"
                 ux_info "  3. Worktrees + tmux sessions are created automatically"
                 ux_info ""
                 ux_info "Note: worktree names are free-form (task/issue/feature slugs)."
@@ -48,7 +48,7 @@ ai_setup() {
                 fi
                 if ! _ts_known_agent "$2"; then
                     ux_error "Unknown agent: $2"
-                    ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
+                    ux_info "Available: claude, codex, agy, opencode, cursor, copilot"
                     return 1
                 fi
                 default_agent="$2"
@@ -136,7 +136,7 @@ ai_setup() {
     for a in $win_input; do
         if ! _ts_known_agent "$a"; then
             ux_error "Unknown agent: $a"
-            ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
+            ux_info "Available: claude, codex, agy, opencode, cursor, copilot"
             return 1
         fi
         win_agents="$win_agents $a"

--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -343,6 +343,21 @@ _ai_usage_run() {
         rm -f "$_tmp"
         return 0
         ;;
+    agy)
+        # agy has no `--output-format json` equivalent (issue #1184), so we
+        # cannot parse per-call usage the way claude/codex/gemini do. Run it
+        # unchanged and record a minimal untracked entry — same
+        # graceful-degradation shape as the cli_failed records above —
+        # rather than silently reporting 0 tokens. Usage/cost tracking for
+        # agy is a follow-up issue once its output format is investigated.
+        agy --dangerously-skip-permissions --print <<<"$_prompt"
+        _ec=$?
+        printf '{"ai":"agy","ts":"%s","label":%s,"exit_code":%d,"tracking":"unsupported"}\n' \
+            "$_now" \
+            "$(printf '%s' "$_label" | jq -Rsc . 2>/dev/null || printf '"%s"' "$_label")" \
+            "$_ec" >>"$_log"
+        return $_ec
+        ;;
     *)
         printf '[ai-usage] invalid ai runner: %s\n' "$_ai" >&2
         return 2

--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -350,7 +350,7 @@ _ai_usage_run() {
         # graceful-degradation shape as the cli_failed records above —
         # rather than silently reporting 0 tokens. Usage/cost tracking for
         # agy is a follow-up issue once its output format is investigated.
-        agy --dangerously-skip-permissions --print <<<"$_prompt"
+        printf '%s\n' "$_prompt" | agy --dangerously-skip-permissions --print
         _ec=$?
         printf '{"ai":"agy","ts":"%s","label":%s,"exit_code":%d,"tracking":"unsupported"}\n' \
             "$_now" \

--- a/shell-common/functions/claude_plugins_docs_ko.sh
+++ b/shell-common/functions/claude_plugins_docs_ko.sh
@@ -7,7 +7,7 @@
 # ═══════════════════════════════════════════════════════════════
 
 # Default AI tool for documentation generation
-# Can be overridden by: CLAUDE_DOC_GENERATOR=gemini, CLAUDE_DOC_GENERATOR=codex, etc.
+# Can be overridden by: CLAUDE_DOC_GENERATOR=agy, CLAUDE_DOC_GENERATOR=codex, etc.
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
@@ -51,12 +51,12 @@ generate_plugin_doc_ko() {
         ux_header "generate-plugin-doc-ko"
         ux_usage "generate-plugin-doc-ko" "<source-file> <output-file> [ai-tool] [--force]" "Generate Korean summary from plugin file"
         ux_bullet "Example: ${UX_INFO}generate-plugin-doc-ko file.md output_KO.md${UX_RESET}"
-        ux_bullet "With specific AI: ${UX_INFO}generate-plugin-doc-ko file.md output_KO.md gemini${UX_RESET}"
+        ux_bullet "With specific AI: ${UX_INFO}generate-plugin-doc-ko file.md output_KO.md agy${UX_RESET}"
         ux_bullet "Force overwrite: ${UX_INFO}generate-plugin-doc-ko file.md output_KO.md claude --force${UX_RESET}"
 
         ux_section "Available AI Tools"
         ux_bullet "claude (default) - Anthropic Claude (uses -p flag)"
-        ux_bullet "gemini - Google Gemini (uses -p flag)"
+        ux_bullet "agy - Antigravity CLI (uses --print flag)"
         ux_bullet "codex - Codex CLI (uses 'exec' subcommand)"
         ux_bullet "Other tools - Any CLI tool that accepts -p, --prompt, exec, or positional argument"
 
@@ -64,7 +64,7 @@ generate_plugin_doc_ko() {
         ux_bullet "--force - Overwrite existing files (default: skip if exists)"
 
         ux_section "Override Default AI Tool"
-        ux_bullet "Set environment variable: ${UX_CODE}export CLAUDE_DOC_GENERATOR=gemini${UX_RESET}"
+        ux_bullet "Set environment variable: ${UX_CODE}export CLAUDE_DOC_GENERATOR=agy${UX_RESET}"
         return 1
     fi
 
@@ -128,10 +128,15 @@ generate_plugin_doc_ko() {
     local prompt_output
     local rc=0
     case "$ai_tool" in
-    claude | gemini)
+    claude)
         # These tools use -p flag
         prompt_output=$(_generate_plugin_doc_ko_prompt "$plugin_file")
         "$ai_tool" -p "$prompt_output" >"$output_file" 2>&1
+        rc=$?
+        ;;
+    agy)
+        # agy reads the prompt from stdin under --print
+        _generate_plugin_doc_ko_prompt "$plugin_file" | "$ai_tool" --print >"$output_file" 2>&1
         rc=$?
         ;;
     codex)
@@ -310,7 +315,7 @@ process_plugin_directory_ko() {
         ux_header "process-plugin-directory-ko"
         ux_usage "process-plugin-directory-ko" "<marketplace> <plugin-path/> [ai-tool] [--force]" "Recursively generate Korean docs for all files in directory"
         ux_bullet "Example: ${UX_INFO}process-plugin-directory-ko claude-code-workflows plugins/code-refactoring/${UX_RESET}"
-        ux_bullet "With Gemini: ${UX_INFO}process-plugin-directory-ko claude-code-workflows plugins/code-refactoring/ gemini${UX_RESET}"
+        ux_bullet "With agy: ${UX_INFO}process-plugin-directory-ko claude-code-workflows plugins/code-refactoring/ agy${UX_RESET}"
         ux_bullet "Force update: ${UX_INFO}process-plugin-directory-ko claude-code-workflows plugins/code-refactoring/ --force${UX_RESET}"
 
         ux_section "Options"
@@ -441,12 +446,12 @@ create_plugin_structure_ko() {
         ux_usage "create-plugin-structure-ko" "<marketplace> <plugin-path|plugin-path/> [ai-tool] [--force]" "Generate Korean docs for file or directory"
         ux_bullet "Single file: ${UX_INFO}create-plugin-structure-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md${UX_RESET}"
         ux_bullet "Full directory: ${UX_INFO}create-plugin-structure-ko claude-code-workflows plugins/code-refactoring/${UX_RESET}"
-        ux_bullet "With Gemini: ${UX_INFO}create-plugin-structure-ko claude-code-workflows plugins/code-refactoring/ gemini${UX_RESET}"
+        ux_bullet "With agy: ${UX_INFO}create-plugin-structure-ko claude-code-workflows plugins/code-refactoring/ agy${UX_RESET}"
         ux_bullet "Force overwrite: ${UX_INFO}create-plugin-structure-ko claude-code-workflows plugins/code-refactoring/ --force${UX_RESET}"
 
         ux_section "Available AI Tools"
         ux_bullet "claude (default) - Anthropic Claude (uses -p flag)"
-        ux_bullet "gemini - Google Gemini (uses -p flag)"
+        ux_bullet "agy - Antigravity CLI (uses --print flag)"
         ux_bullet "codex - Codex CLI (uses 'exec' subcommand)"
         ux_bullet "Other tools - Any CLI tool that accepts -p, --prompt, exec, or positional argument"
 

--- a/shell-common/functions/claude_plugins_help.sh
+++ b/shell-common/functions/claude_plugins_help.sh
@@ -10,7 +10,7 @@ _claude_plugins_help_summary() {
     ux_bullet_sub "commands: open_claude_plugins | list-plugins | claude-plugin-list | init-plugins-docs | sync-plugins-structure"
     ux_bullet_sub "view: view-plugin-info | generate-plugin-doc-ko | create-plugin-structure-ko"
     ux_bullet_sub "examples: quick examples for create-plugin-ko"
-    ux_bullet_sub "ai-tools: claude | gemini | codex"
+    ux_bullet_sub "ai-tools: claude | agy | codex"
     ux_bullet_sub "workflow: recommended workflow"
     ux_bullet_sub "structure: plugin and docs directory layout"
     ux_bullet_sub "git: git integration & mount details"
@@ -41,17 +41,17 @@ _claude_plugins_help_rows_view() {
     ux_bullet "  Usage: ${UX_CODE}view-plugin-info algorithmic-art${UX_RESET}"
     ux_bullet "generate-plugin-doc-ko <source-file> <output-file> [ai-tool]"
     ux_bullet "  Default Claude: ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md${UX_RESET}"
-    ux_bullet "  Gemini: ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md gemini${UX_RESET}"
+    ux_bullet "  agy: ${UX_CODE}generate-plugin-doc-ko file.md output_KO.md agy${UX_RESET}"
     ux_bullet "create-plugin-structure-ko <marketplace> <plugin-path> [ai-tool]"
     ux_bullet "  Default: ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md>${UX_RESET}"
-    ux_bullet "  Gemini: ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md> gemini${UX_RESET}"
+    ux_bullet "  agy: ${UX_CODE}create-plugin-structure-ko <marketplace> <path/to/file.md> agy${UX_RESET}"
 }
 
 _claude_plugins_help_rows_examples() {
     ux_bullet "1. Generate with default AI (Claude):"
     ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md${UX_RESET}"
-    ux_bullet "2. Generate with Gemini:"
-    ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md gemini${UX_RESET}"
+    ux_bullet "2. Generate with agy:"
+    ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md agy${UX_RESET}"
     ux_bullet "3. Change default AI tool for session:"
     ux_bullet "   ${UX_CODE}export CLAUDE_DOC_GENERATOR=codex${UX_RESET}"
     ux_bullet "   ${UX_CODE}create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md${UX_RESET}"
@@ -63,7 +63,7 @@ _claude_plugins_help_rows_examples() {
 
 _claude_plugins_help_rows_ai_tools() {
     ux_bullet "claude - Anthropic Claude (default)"
-    ux_bullet "gemini - Google Gemini"
+    ux_bullet "agy - Antigravity CLI"
     ux_bullet "codex - OpenAI Codex"
     ux_bullet "Any CLI tool accepting -p or --prompt flag"
 }

--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -69,10 +69,10 @@ _gh_flow_has_branch_commits() {
     [ "${_count:-0}" -gt 0 ]
 }
 
-# Returns 0 if the ai runner is one of: claude, codex, gemini.
+# Returns 0 if the ai runner is one of: claude, codex, agy.
 _gh_flow_known_ai() {
     case "$1" in
-    claude | codex | gemini) return 0 ;;
+    claude | codex | agy) return 0 ;;
     *) return 1 ;;
     esac
 }
@@ -92,14 +92,14 @@ _gh_flow_require_ai_cli() {
             return 1
         fi
         ;;
-    gemini)
-        if ! _have gemini; then
-            ux_error "gemini CLI not found"
+    agy)
+        if ! _have agy; then
+            ux_error "agy CLI not found"
             return 1
         fi
         ;;
     *)
-        ux_error "invalid --ai value: '$1' (allowed: claude, codex, gemini)"
+        ux_error "invalid --ai value: '$1' (allowed: claude, codex, agy)"
         return 1
         ;;
     esac
@@ -672,7 +672,7 @@ gh_flow_help() {
     ux_header "gh-flow - fire-and-forget GitHub issue → PR automation"
     ux_info "Usage:"
     ux_bullet "gh-flow <issue-number>... [--ai <agent>] [--user <account>]  spawn N parallel workers"
-    ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "agent: claude (default) | codex | agy"
     ux_bullet_sub "--user <account>: claude account (personal|work). Only with --ai claude."
     ux_bullet_sub "                  Default: \$CLAUDE_DEFAULT_ACCOUNT (multi-account env)"
     ux_bullet "gh-flow status [<N>]            full table, or per-issue diagnostic"
@@ -688,7 +688,7 @@ gh_flow_help() {
     ux_bullet "gh-flow 13                  # single issue"
     ux_bullet "gh-flow 13 42 88            # 3 issues in parallel"
     ux_bullet "gh-flow 33 --ai codex       # run workers with codex CLI"
-    ux_bullet "gh-flow --ai gemini 44      # run workers with gemini CLI"
+    ux_bullet "gh-flow --ai agy 44         # run workers with agy CLI"
     ux_bullet "gh-flow 13 --user work      # multi-account: route worker to ~/.claude-work"
     ux_bullet "gh-flow status              # full table — who's still running, who failed"
     ux_bullet "gh-flow status 153          # per-issue diagnostic (verdict + next action)"
@@ -704,7 +704,7 @@ gh_flow_help() {
     ux_bullet_sub "pr.number     - PR number"
     ux_bullet_sub "reply.done    - marker (present if reply already ran)"
     ux_bullet_sub "log           - full stdout+stderr"
-    ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + gemini)"
+    ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + agy)"
     ux_info ""
     ux_info "Failure isolation:"
     ux_bullet "One worker failure does not affect others."
@@ -747,8 +747,8 @@ gh_flow() {
     esac
 
     # Parse optional args:
-    #   --ai <claude|codex|gemini>
-    #   --ai=<claude|codex|gemini>
+    #   --ai <claude|codex|agy>
+    #   --ai=<claude|codex|agy>
     #   --user <account>          (claude multi-account, issue #365)
     #   --user=<account>
     local _ai="claude"
@@ -759,7 +759,7 @@ gh_flow() {
         --ai)
             shift
             if [ $# -eq 0 ]; then
-                ux_error "--ai requires a value (claude|codex|gemini)"
+                ux_error "--ai requires a value (claude|codex|agy)"
                 return 1
             fi
             _ai="$1"
@@ -780,7 +780,7 @@ gh_flow() {
             ;;
         -*)
             ux_error "unknown option: '$1'"
-            ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|gemini>] [--user <account>]"
+            ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|agy>] [--user <account>]"
             return 1
             ;;
         *)
@@ -795,12 +795,12 @@ gh_flow() {
     set -- $_issue_args
     if [ $# -eq 0 ]; then
         ux_error "no issue numbers provided"
-        ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|gemini>]"
+        ux_info "Usage: gh-flow <issue-number>... [--ai <claude|codex|agy>]"
         return 1
     fi
 
     if ! _gh_flow_known_ai "$_ai"; then
-        ux_error "invalid --ai value: '$_ai' (allowed: claude, codex, gemini)"
+        ux_error "invalid --ai value: '$_ai' (allowed: claude, codex, agy)"
         return 1
     fi
 

--- a/shell-common/functions/gh_pr_approve.sh
+++ b/shell-common/functions/gh_pr_approve.sh
@@ -52,10 +52,10 @@ _gh_pr_approve_get_state() {
 # AI runner helpers (mirror gh_flow.sh — keep both modules in sync)
 # ============================================================================
 
-# Returns 0 if the ai runner is one of: claude, codex, gemini.
+# Returns 0 if the ai runner is one of: claude, codex, agy.
 _gh_pr_approve_known_ai() {
     case "$1" in
-    claude | codex | gemini) return 0 ;;
+    claude | codex | agy) return 0 ;;
     *) return 1 ;;
     esac
 }
@@ -75,14 +75,14 @@ _gh_pr_approve_require_ai_cli() {
             return 1
         fi
         ;;
-    gemini)
-        if ! _have gemini; then
-            ux_error "gemini CLI not found"
+    agy)
+        if ! _have agy; then
+            ux_error "agy CLI not found"
             return 1
         fi
         ;;
     *)
-        ux_error "invalid --ai value: '$1' (allowed: claude, codex, gemini)"
+        ux_error "invalid --ai value: '$1' (allowed: claude, codex, agy)"
         return 1
         ;;
     esac
@@ -141,14 +141,11 @@ _gh_pr_approve_check_ai_auth() {
         ux_error "codex CLI not authenticated. Run 'codex login' first."
         return 1
         ;;
-    gemini)
-        if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]; then
+    agy)
+        if [ -d "$HOME/.gemini/antigravity-cli" ]; then
             return 0
         fi
-        if [ -f "$HOME/.gemini/oauth_creds.json" ]; then
-            return 0
-        fi
-        ux_error "gemini CLI not authenticated. Run 'gemini' once interactively to sign in."
+        ux_error "agy CLI not authenticated. Run 'agy' once interactively to sign in."
         return 1
         ;;
     *)
@@ -417,7 +414,7 @@ _gh_pr_approve_status_single() {
     fi
 
     # For approving failures the tail above usually only shows the Token
-    # Usage block — the actual claude/codex/gemini error message
+    # Usage block — the actual claude/codex/agy error message
     # (e.g. "Not logged in · Please run /login") gets buried earlier in
     # the log. Surface it directly from usage.jsonl so the diagnosis is
     # one glance away instead of one tail|grep away.
@@ -806,7 +803,7 @@ gh_pr_approve_help() {
     ux_header "gh-pr-approve - fire-and-forget GitHub PR approval runner"
     ux_info "Usage:"
     ux_bullet "gh-pr-approve <pr-number>... [--ai <agent>] [--user <account>] [--self-record|--admin-merge] [--squash|--rebase|--merge]"
-    ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "agent: claude (default) | codex | agy"
     ux_bullet_sub "--user <account>: claude account (personal|work). Only with --ai claude."
     ux_bullet_sub "                  Default: \$CLAUDE_DEFAULT_ACCOUNT (multi-account env)"
     ux_bullet_sub "--self-record: for self-authored PRs, leave a comment-only review record"
@@ -823,7 +820,7 @@ gh_pr_approve_help() {
     ux_bullet "gh-pr-approve 42                            # single PR (default: claude)"
     ux_bullet "gh-pr-approve 12 34 56                      # 3 PRs in parallel"
     ux_bullet "gh-pr-approve 42 --ai codex                 # run worker with codex CLI"
-    ux_bullet "gh-pr-approve --ai gemini '#56' '#78'       # gemini + #prefix"
+    ux_bullet "gh-pr-approve --ai agy '#56' '#78'          # agy + #prefix"
     ux_bullet "gh-pr-approve 42 --user work                # multi-account: route worker to ~/.claude-work"
     ux_bullet "gh-pr-approve 42 --self-record              # self-PR comment-only record"
     ux_bullet "gh-pr-approve 42 --admin-merge --squash     # self-PR admin merge"
@@ -836,13 +833,13 @@ gh_pr_approve_help() {
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-approve/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
-    ux_bullet_sub "ai            - selected ai runner (claude|codex|gemini)"
+    ux_bullet_sub "ai            - selected ai runner (claude|codex|agy)"
     ux_bullet_sub "pid           - worker process id"
     ux_bullet_sub "worktree.path - git worktree path"
     ux_bullet_sub "flags         - launch flags (--self-record, --admin-merge, etc.)"
     ux_bullet_sub "log           - full stdout+stderr"
     ux_bullet_sub "log.prev      - previous run's log (one generation)"
-    ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + gemini)"
+    ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + agy)"
     ux_info ""
     ux_info "Failure isolation:"
     ux_bullet "One worker failure does not affect others."
@@ -855,7 +852,7 @@ gh_pr_approve_help() {
     ux_bullet "Selected AI CLI authenticated (env var or local credentials file)"
     ux_bullet_sub "claude: ANTHROPIC_API_KEY or ~/.claude/.credentials.json or ~/.claude.json"
     ux_bullet_sub "codex:  OPENAI_API_KEY or ~/.codex/auth.json"
-    ux_bullet_sub "gemini: GEMINI_API_KEY / GOOGLE_API_KEY or ~/.gemini/oauth_creds.json"
+    ux_bullet_sub "agy: OAuth token in ~/.gemini/antigravity-cli/"
     ux_bullet_sub "if missing, gh-pr-approve refuses to spawn (no worktree, no state dir)"
     ux_info ""
     ux_info "Related:"
@@ -891,8 +888,8 @@ gh_pr_approve() {
     esac
 
     # Parse optional args:
-    #   --ai <claude|codex|gemini>
-    #   --ai=<claude|codex|gemini>
+    #   --ai <claude|codex|agy>
+    #   --ai=<claude|codex|agy>
     #   --user <account>          (claude multi-account, issue #365)
     #   --user=<account>
     #   --self-record             (comment-only self-PR mode in skill)
@@ -911,7 +908,7 @@ gh_pr_approve() {
         --ai)
             shift
             if [ $# -eq 0 ]; then
-                ux_error "missing value for --ai (expected: claude|codex|gemini)"
+                ux_error "missing value for --ai (expected: claude|codex|agy)"
                 return 1
             fi
             _ai="$1"
@@ -950,7 +947,7 @@ gh_pr_approve() {
             ;;
         -*)
             ux_error "unknown option: '$1'"
-            ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--user <account>] [--self-record|--admin-merge]"
+            ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|agy>] [--user <account>] [--self-record|--admin-merge]"
             return 1
             ;;
         *)
@@ -975,7 +972,7 @@ gh_pr_approve() {
     fi
 
     if ! _gh_pr_approve_known_ai "$_ai"; then
-        ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
+        ux_error "invalid --ai value: '$_ai' (expected: claude|codex|agy)"
         return 1
     fi
 
@@ -1044,7 +1041,7 @@ gh_pr_approve() {
 
     if [ "$_pr_count" -eq 0 ]; then
         ux_error "no PR numbers provided"
-        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|gemini>] [--user <account>] [--self-record|--admin-merge]"
+        ux_info "Usage: gh-pr-approve <pr-number>... [--ai <claude|codex|agy>] [--user <account>] [--self-record|--admin-merge]"
         return 1
     fi
 

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -67,11 +67,11 @@ _gh_pr_reply_get_state() {
 # Validate the requested ai runner is supported and its CLI is on PATH.
 _gh_pr_reply_require_ai_cli() {
     case "$1" in
-        claude|codex|gemini)
+        claude|codex|agy)
             ux_require "$1" || return 1
             ;;
         *)
-            ux_error "invalid --ai value: '$1' (expected: claude|codex|gemini)"
+            ux_error "invalid --ai value: '$1' (expected: claude|codex|agy)"
             return 1
             ;;
     esac
@@ -94,7 +94,7 @@ _gh_pr_reply_run_ai_prompt() {
 gh_pr_reply_help() {
     ux_header "gh-pr-reply - fire-and-forget GitHub PR review-reply runner"
     ux_info "Usage: gh-pr-reply <pr-number>... [--ai <agent>] [--user <account>] | -h|--help"
-    ux_bullet_sub "agent: claude (default) | codex | gemini"
+    ux_bullet_sub "agent: claude (default) | codex | agy"
     ux_bullet_sub "--user <account>: claude account (personal|work). Only with --ai claude."
     ux_bullet_sub "                  Default: \$CLAUDE_DEFAULT_ACCOUNT (multi-account env)"
     ux_info ""
@@ -110,17 +110,17 @@ gh_pr_reply_help() {
     ux_bullet "gh-pr-reply 12 34 56            # 3 PRs in parallel"
     ux_bullet "gh-pr-reply '#42'               # '#' prefix accepted"
     ux_bullet "gh-pr-reply 33 --ai codex       # run worker with codex CLI"
-    ux_bullet "gh-pr-reply --ai gemini 44 55   # run workers with gemini CLI"
+    ux_bullet "gh-pr-reply --ai agy 44 55      # run workers with agy CLI"
     ux_bullet "gh-pr-reply 42 --user work      # multi-account: route worker to ~/.claude-work"
     ux_info ""
     ux_info "State directory: ~/.local/state/gh-pr-reply/<repo>/<pr>/"
     ux_bullet_sub "state         - current step"
     ux_bullet_sub "pid           - worker process id"
-    ux_bullet_sub "ai            - selected ai runner (claude|codex|gemini)"
+    ux_bullet_sub "ai            - selected ai runner (claude|codex|agy)"
     ux_bullet_sub "worktree.path - git worktree path"
     ux_bullet_sub "log           - full stdout+stderr"
     ux_bullet_sub "log.prev      - previous run's log (one generation)"
-    ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + gemini)"
+    ux_bullet_sub "usage.jsonl   - per-invocation token usage (claude + codex + agy)"
     ux_info ""
     ux_info "Failure isolation:"
     ux_bullet "One worker failure does not affect others."
@@ -156,8 +156,8 @@ gh_pr_reply() {
     esac
 
     # Parse optional args (PR numbers and --ai may interleave):
-    #   --ai <claude|codex|gemini>
-    #   --ai=<claude|codex|gemini>
+    #   --ai <claude|codex|agy>
+    #   --ai=<claude|codex|agy>
     #   --user <account>          (claude multi-account, issue #365)
     #   --user=<account>
     # Last --ai/--user wins on duplicates — same policy gh-flow chose for #208.
@@ -169,7 +169,7 @@ gh_pr_reply() {
             --ai)
                 shift
                 if [ $# -eq 0 ]; then
-                    ux_error "--ai requires a value (expected: claude|codex|gemini)"
+                    ux_error "--ai requires a value (expected: claude|codex|agy)"
                     return 1
                 fi
                 _ai="$1"
@@ -190,7 +190,7 @@ gh_pr_reply() {
                 ;;
             -*)
                 ux_error "unknown option: '$1'"
-                ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>] [--user <account>]"
+                ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|agy>] [--user <account>]"
                 return 1
                 ;;
             *)
@@ -205,7 +205,7 @@ gh_pr_reply() {
     set -- $_pr_args
     if [ $# -eq 0 ]; then
         ux_error "no PR numbers provided"
-        ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|gemini>] [--user <account>]"
+        ux_info "Usage: gh-pr-reply <pr-number>... [--ai <claude|codex|agy>] [--user <account>]"
         return 1
     fi
 
@@ -214,9 +214,9 @@ gh_pr_reply() {
     # PATH; CLI presence is checked later in _gh_pr_reply_spawn_worker so
     # the failed:* short-circuit can still trip when the CLI is missing.
     case "$_ai" in
-        claude|codex|gemini) ;;
+        claude|codex|agy) ;;
         *)
-            ux_error "invalid --ai value: '$_ai' (expected: claude|codex|gemini)"
+            ux_error "invalid --ai value: '$_ai' (expected: claude|codex|agy)"
             return 1
             ;;
     esac

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -3,7 +3,7 @@
 # shell-common/functions/gh_pr_review.sh
 # gh-pr-review — synchronous PR review delegation to an external AI CLI.
 # Sibling of gh-pr-approve (gh_pr_approve.sh) and gh-pr-reply
-# (gh_pr_reply.sh). Reads the same `--ai <codex|gemini|claude>` contract
+# (gh_pr_reply.sh). Reads the same `--ai <codex|agy|claude>` contract
 # but does a single-shot opinion-collection run inline (no worktree spawn,
 # no detached worker) — the skill's only side effect is one PR comment
 # unless `--no-post-comment` is set.
@@ -103,20 +103,20 @@ gh_pr_review_parse() {
     done
 
     if [ -z "$ai" ]; then
-        echo "missing required flag: --ai <codex|gemini|claude>" >&2
+        echo "missing required flag: --ai <codex|agy|claude>" >&2
         return 2
     fi
 
     case "$ai" in
-    codex | gemini | claude) ;;
+    codex | agy | claude) ;;
     *)
-        echo "Unknown --ai value: '$ai' (allowed: codex, gemini, claude)" >&2
+        echo "Unknown --ai value: '$ai' (allowed: codex, agy, claude)" >&2
         return 2
         ;;
     esac
 
     if [ -n "$user" ] && [ "$ai" != "claude" ]; then
-        echo "--user is only valid with --ai claude (codex/gemini have no multi-account routing)" >&2
+        echo "--user is only valid with --ai claude (codex/agy have no multi-account routing)" >&2
         return 2
     fi
 
@@ -162,9 +162,9 @@ EOF
 _gh_pr_review_require_ai_cli() {
     local ai="$1"
     case "$ai" in
-    codex | gemini | claude) ;;
+    codex | agy | claude) ;;
     *)
-        echo "Unknown --ai value: '$ai' (allowed: codex, gemini, claude)" >&2
+        echo "Unknown --ai value: '$ai' (allowed: codex, agy, claude)" >&2
         return 2
         ;;
     esac
@@ -222,14 +222,12 @@ _gh_pr_review_stderr_is_noise() {
 # cleaned up automatically.
 #
 # Issue #694:
-#   - Bug A — `gemini -p` requires a string argument (yargs). Read the
-#     prompt into a variable so the CLI sees a valid positional value.
 #   - Bug B — `head -n 1` of stderr surfaced informational banners
 #     (e.g. codex's "Reading prompt from stdin...") as the failure
 #     reason. The dispatcher now skips known-noise prefixes when
 #     building the one-line summary AND emits the full stderr below it.
 #
-# Args: $1 = ai (codex|gemini|claude), $2 = PROMPT_FILE, $3 = optional
+# Args: $1 = ai (codex|agy|claude), $2 = PROMPT_FILE, $3 = optional
 # CLAUDE_CONFIG_DIR (claude --user routing). Stdout of the CLI streams to
 # the caller's stdout; stderr is captured for the failure summary.
 _gh_pr_review_run_ai() {
@@ -239,7 +237,7 @@ _gh_pr_review_run_ai() {
     # mktemp template — the `XXXXXX` suffix prevents the predictable-PID
     # symlink-attack class on shared `/tmp` filesystems (gemini-code-assist
     # review on PR #695). The `$ai` discriminator stays in the name so the
-    # user can grep for "the gemini run" vs "the codex run" when several
+    # user can grep for "the agy run" vs "the codex run" when several
     # invocations linger after failures.
     local _stderr_file
     if ! _stderr_file=$(mktemp "/tmp/gh-pr-review-stderr.$ai.XXXXXX" 2>/dev/null); then
@@ -251,19 +249,10 @@ _gh_pr_review_run_ai() {
     codex)
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
-    gemini)
-        # `gemini -p` is non-interactive headless mode and the yargs
-        # parser REQUIRES a token after `-p` — `gemini -p <file` raises
-        # "Not enough arguments following: p" (issue #694 Bug A).
-        # However, `gemini --help` says: "Run in non-interactive
-        # (headless) mode with the given prompt. Appended to input on
-        # stdin (if any)." → providing any non-empty `-p` value
-        # satisfies yargs, AND the actual prompt can still flow on
-        # stdin. That sidesteps the ARG_MAX / shell-quoting concern of
-        # `gemini -p "$(cat "$file")"` (gemini-code-assist review on
-        # PR #695). A single-space marker keeps the prompt suffix
-        # effectively empty.
-        gemini -p ' ' <"$prompt_file" 2>"$_stderr_file" || _rc=$?
+    agy)
+        # `agy --print` runs the Antigravity CLI non-interactively,
+        # reading the prompt from stdin.
+        agy --print <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     claude)
         if [ -n "$cfg_dir" ]; then
@@ -273,7 +262,7 @@ _gh_pr_review_run_ai() {
         fi
         ;;
     *)
-        echo "Unknown --ai value: '$ai' (allowed: codex, gemini, claude)" >&2
+        echo "Unknown --ai value: '$ai' (allowed: codex, agy, claude)" >&2
         rm -f "$_stderr_file"
         return 2
         ;;
@@ -703,11 +692,11 @@ for a second opinion. Streams the AI's findings to stdout and posts
 them as a PR comment by default. Does NOT submit a decision.
 
 Usage:
-  gh-pr-review --ai <codex|gemini|claude> [flags] [<pr-number>] [<remote>]
+  gh-pr-review --ai <codex|agy|claude> [flags] [<pr-number>] [<remote>]
   gh-pr-review -h | --help | help
 
 Flags:
-  --ai <codex|gemini|claude>   required; external CLI to delegate to
+  --ai <codex|agy|claude>      required; external CLI to delegate to
   --review <preset>            default 'default'; KR aliases supported
                                enum: default | quick | thorough |
                                      security | performance
@@ -724,7 +713,7 @@ Positional:
 
 Examples:
   gh-pr-review --ai codex 99
-  gh-pr-review --ai gemini --review thorough 99
+  gh-pr-review --ai agy --review thorough 99
   gh-pr-review --ai claude --review 꼼꼼 99
   gh-pr-review --ai claude --user work 99
   gh-pr-review --ai codex --no-post-comment 99

--- a/shell-common/functions/git_worktree.sh
+++ b/shell-common/functions/git_worktree.sh
@@ -72,7 +72,7 @@ _gwt_help_rows_spawn() {
     ux_table_row "syntax" "gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch [--ai <agent>]] [--user <account>]" "Create named worktree"
     ux_table_row "context" "Run from main repo only" "Fails inside a worktree"
     ux_table_row "name" "Free-form slug (required)" "e.g. issue-11, login-fix"
-    ux_table_row "--ai" "AI agent (default: claude)" "claude, codex, gemini, opencode, cursor, copilot"
+    ux_table_row "--ai" "AI agent (default: claude)" "claude, codex, agy, opencode, cursor, copilot"
     ux_table_row "--user" "Claude account for --tmux/--launch (only with --ai claude)" "personal, work — default: \$CLAUDE_DEFAULT_ACCOUNT"
     ux_table_row "--tmux" "Runs <agent>-yolo in new tmux pane" "Mutually exclusive with --launch"
     ux_table_row "--launch" "cd into worktree + run <agent>-yolo inline" "Current shell, no tmux"
@@ -1364,7 +1364,7 @@ git_worktree_add() {
 # Bypasses shell alias expansion, which is unreliable inside function
 # context — zsh in particular fails to expand `claude-yolo` from inside
 # a function body, even via `eval`. Keeping the SSOT here means the
-# alias files (claude.sh, codex.sh, gemini.sh, opencode.sh) and the
+# alias files (claude.sh, codex.sh, agy.sh, opencode.sh) and the
 # launch path stay in sync via grep, not via shell alias resolution.
 #
 # Output: command string on stdout, exit 0 on known agent.
@@ -1380,7 +1380,7 @@ _gwt_yolo_command() {
     # `claude_yolo --user <account>`; other agents ignore it because they do
     # not support multi-account.
     case "$1" in
-        --list)   echo "claude, codex, gemini, opencode" ;;
+        --list)   echo "claude, codex, agy, opencode" ;;
         claude)
             if [ -n "${2-}" ]; then
                 echo "claude_yolo --user $2"
@@ -1389,7 +1389,7 @@ _gwt_yolo_command() {
             fi
             ;;
         codex)    echo "codex --dangerously-bypass-approvals-and-sandbox" ;;
-        gemini)   echo "gemini --approval-mode=yolo --skip-trust" ;;
+        agy)      echo "agy --dangerously-skip-permissions" ;;
         opencode) echo "opencode" ;;
         *)        return 1 ;;
     esac
@@ -1418,7 +1418,7 @@ _git_worktree_spawn_show_help() {
     ux_info "  --bg             Dispatch claude in background mode (Agent View, #640)."
     ux_info "                   Requires --launch or --tmux. Only with --ai claude."
     ux_info "  --ai <agent>     AI agent (default: claude)."
-    ux_info "                   Known: claude, codex, gemini, opencode, cursor, copilot"
+    ux_info "                   Known: claude, codex, agy, opencode, cursor, copilot"
     ux_info "  --user <account> Claude account for --tmux/--launch (issue #295)."
     ux_info "                   Only valid with --ai claude."
     ux_info ""
@@ -1607,7 +1607,7 @@ git_worktree_spawn() {
     # Validate --ai: must be a known AI agent (only when tmux/launch will use it)
     if { [ "$use_tmux" = 1 ] || [ "$use_launch" = 1 ]; } && ! _ts_known_agent "$agent"; then
         ux_error "Unknown agent: $agent"
-        ux_info "Available: claude, codex, gemini, opencode, cursor, copilot"
+        ux_info "Available: claude, codex, agy, opencode, cursor, copilot"
         return 1
     fi
 

--- a/shell-common/functions/skill_loader.sh
+++ b/shell-common/functions/skill_loader.sh
@@ -40,7 +40,7 @@ skill_loader() {
         ux_bullet "Claude Code: Use ${UX_SUCCESS}/skill <name>${UX_RESET} within Claude Code"
         ux_bullet "View skill content: ${UX_SUCCESS}cat \"\$(skill-loader req-define)\"${UX_RESET}"
         ux_bullet "Codex: ${UX_SUCCESS}codex -p \"\$(cat \"\$(skill-loader cli-dev)\")\"${UX_RESET}"
-        ux_bullet "Gemini: ${UX_SUCCESS}gemini -p @\"\$(skill-loader agents-md)\"${UX_RESET}"
+        ux_bullet "Antigravity (agy): ${UX_SUCCESS}agy --print < \"\$(skill-loader agents-md)\"${UX_RESET}"
 
         ux_section "Environment"
         ux_info "Skills path: $skills_dir"
@@ -94,8 +94,8 @@ skill_loader() {
             cli_type="claude-code"
         elif [ -n "$CODEX_CLI" ] || [ -n "$CODEX_MANAGED_BY_NPM" ]; then
             cli_type="codex"
-        elif [ -n "$GEMINI_CLI" ]; then
-            cli_type="gemini"
+        elif [ -n "$AGY_CLI" ]; then
+            cli_type="agy"
         elif command -v claude >/dev/null 2>&1; then
             cli_type="claude-code"
         fi

--- a/shell-common/functions/tmux_spawn.sh
+++ b/shell-common/functions/tmux_spawn.sh
@@ -24,7 +24,7 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 _ts_known_agent() {
     case "$1" in
-        claude|codex|gemini|opencode|cursor|copilot) return 0 ;;
+        claude|codex|agy|opencode|cursor|copilot) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -110,7 +110,7 @@ tmux_spawn() {
             ux_info "  Worktree dir  session = dir name, agent auto-detected"
             ux_info "  Main repo     session = <project>-<branch>, agent = claude"
             ux_info ""
-            ux_info "Agents: claude, codex, gemini, opencode, cursor, copilot"
+            ux_info "Agents: claude, codex, agy, opencode, cursor, copilot"
             ux_info ""
             ux_info "Layout:"
             ux_info "  +----------+----------+"
@@ -161,7 +161,7 @@ tmux_spawn() {
             _ts_agent="$_ts_arg"
         else
             ux_error "Unknown agent: $_ts_arg"
-            ux_info  "Available: claude, codex, gemini, opencode, cursor, copilot"
+            ux_info  "Available: claude, codex, agy, opencode, cursor, copilot"
             unset _ts_arg _ts_dir _ts_basename _ts_agent _ts_session
             return 1
         fi

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -303,3 +303,86 @@ _usage_record_count() {
     [ "$(jq -s 'length' "$USAGE_LOG")" = "2" ]
     [ "$(jq -s '[.[] | select(.session_id != null)] | length' "$USAGE_LOG")" = "2" ]
 }
+
+# ---------------------------------------------------------------------------
+# agy dispatch (issue #1184) — gemini→agy replacement. agy has no
+# `--output-format json` equivalent, so this case only verifies the CLI is
+# actually invoked (with the right flags, prompt on stdin) and that a
+# minimal untracked record is appended — not full usage parsing.
+# ---------------------------------------------------------------------------
+
+# Stub agy — echoes its argv and copies stdin to stdout so a test can
+# assert on the exact invocation shape, then exits with $AGY_STUB_EXIT
+# (default 0).
+_setup_agy_stub() {
+    cat >"$STUB_BIN/agy" <<'STUB'
+#!/usr/bin/env bash
+printf 'agy-stub: args=%s\n' "$*"
+cat
+exit "${AGY_STUB_EXIT:-0}"
+STUB
+    chmod +x "$STUB_BIN/agy"
+}
+
+@test "agy: invoked with --dangerously-skip-permissions --print and prompt on stdin" {
+    _setup_agy_stub
+
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:/usr/bin:/bin'
+        . '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh'
+        _ai_usage_run agy '${USAGE_LOG}' 'test-label' 'hello agy'
+        echo \"rc=\$?\"
+    "
+
+    assert_output --partial "rc=0"
+    assert_output --partial "agy-stub: args=--dangerously-skip-permissions --print"
+    assert_output --partial "hello agy"
+    [ "$(jq -r '.ai' "$USAGE_LOG")" = "agy" ]
+    [ "$(jq -r '.tracking' "$USAGE_LOG")" = "unsupported" ]
+    [ "$(jq -r '.exit_code' "$USAGE_LOG")" = "0" ]
+}
+
+@test "agy: non-zero exit propagates and is recorded" {
+    _setup_agy_stub
+
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:/usr/bin:/bin'
+        export AGY_STUB_EXIT=3
+        . '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh'
+        _ai_usage_run agy '${USAGE_LOG}' 'test-label' 'hello agy'
+        echo \"rc=\$?\"
+    "
+
+    assert_output --partial "rc=3"
+    [ "$(jq -r '.exit_code' "$USAGE_LOG")" = "3" ]
+}
+
+@test "unknown ai runner is rejected" {
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='/usr/bin:/bin'
+        . '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh'
+        _ai_usage_run bogus '${USAGE_LOG}' 'test-label' 'hello'
+        echo \"rc=\$?\"
+    "
+
+    assert_output --partial "rc=2"
+    assert_output --partial "invalid ai runner: bogus"
+}

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -57,7 +57,7 @@ teardown() {
     assert_output --partial "gh-flow status"
     assert_output --partial "gh-flow prune"
     assert_output --partial "--ai"
-    assert_output --partial "claude (default) | codex | gemini"
+    assert_output --partial "claude (default) | codex | agy"
     # New distinct failure states must be documented.
     assert_output --partial "failed:committing"
     assert_output --partial "failed:opening-pr"
@@ -216,7 +216,13 @@ teardown() {
     run_in_bash "cd '$REPO_DIR' && gh_flow 13 --ai not-supported 2>&1"
     assert_failure
     assert_output --partial "invalid --ai value"
-    assert_output --partial "claude, codex, gemini"
+    assert_output --partial "claude, codex, agy"
+}
+
+@test "dispatcher: --ai gemini is now rejected (removed value)" {
+    run_in_bash "cd '$REPO_DIR' && gh_flow 13 --ai gemini 2>&1"
+    assert_failure
+    assert_output --partial "invalid --ai value"
 }
 
 @test "dispatcher: --ai without value fails with clear message" {

--- a/tests/bats/functions/gh_pr_approve.bats
+++ b/tests/bats/functions/gh_pr_approve.bats
@@ -143,7 +143,7 @@ teardown() {
     run_in_bash 'gh_pr_approve --help'
     assert_success
     assert_output --partial "--ai"
-    assert_output --partial "claude (default) | codex | gemini"
+    assert_output --partial "claude (default) | codex | agy"
 }
 
 @test "help: documents self-PR modes" {
@@ -154,7 +154,7 @@ teardown() {
 }
 
 @test "bash: '--ai codex' parses (precondition fails on missing codex CLI, not parser)" {
-    # We can't easily fake the codex/gemini CLI here, so we assert the
+    # We can't easily fake the codex/agy CLI here, so we assert the
     # parser accepted the value and produced a precondition-shaped error
     # rather than the generic 'unknown option' or 'invalid --ai value'
     # parser errors.
@@ -163,12 +163,18 @@ teardown() {
     refute_output --partial "invalid --ai value"
 }
 
-@test "bash: '--ai gemini' parses with leading position" {
+@test "bash: '--ai agy' parses with leading position" {
     # --ai may appear before PR numbers — position-agnostic.
-    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve --ai gemini 42 2>&1 || true"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve --ai agy 42 2>&1 || true"
     refute_output --partial "unknown option"
     refute_output --partial "invalid --ai value"
     refute_output --partial "invalid PR number"
+}
+
+@test "bash: '--ai gemini' is now rejected (removed value)" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_approve --ai gemini 42 2>&1"
+    assert_failure
+    assert_output --partial "invalid --ai value"
 }
 
 @test "bash: trailing '42 --ai codex' is accepted" {
@@ -182,14 +188,14 @@ teardown() {
     run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --ai 2>&1"
     assert_failure
     assert_output --partial "missing value for --ai"
-    assert_output --partial "claude|codex|gemini"
+    assert_output --partial "claude|codex|agy"
 }
 
 @test "bash: invalid --ai value is rejected" {
     run_in_bash "cd '$FAKE_REPO' && gh_pr_approve 42 --ai bogus 2>&1"
     assert_failure
     assert_output --partial "invalid --ai value"
-    assert_output --partial "claude|codex|gemini"
+    assert_output --partial "claude|codex|agy"
 }
 
 @test "bash: unknown long option is rejected" {
@@ -583,7 +589,7 @@ _seed_pr_state() {
 # ---------------------------------------------------------------------------
 # auth pre-flight (issue #327)
 # ---------------------------------------------------------------------------
-# We can't drive a real claude/codex/gemini CLI from the test sandbox, so
+# We can't drive a real claude/codex/agy CLI from the test sandbox, so
 # we install a minimal stub on PATH for each runner. The stub never gets
 # invoked — the auth check (file-existence + env var) runs *before* the
 # CLI is called. Its only job is to satisfy `_have <ai>`.
@@ -665,23 +671,23 @@ EOF
     refute_output --partial "codex CLI not authenticated"
 }
 
-@test "auth: gemini logged out — refuses spawn" {
-    _install_fake_ai_cli gemini
+@test "auth: agy logged out — refuses spawn" {
+    _install_fake_ai_cli agy
+    rm -rf "$HOME/.gemini/antigravity-cli"
     # See claude test above for why `export PATH` is required (issue #758).
-    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; unset GEMINI_API_KEY GOOGLE_API_KEY; cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; cd '$FAKE_REPO' && gh_pr_approve 42 --ai agy 2>&1"
     assert_failure
-    assert_output --partial "gemini CLI not authenticated"
+    assert_output --partial "agy CLI not authenticated"
     [ ! -d "$HOME/.local/state/gh-pr-approve/fake-main/42" ]
 }
 
-@test "auth: gemini credentials file present → auth check passes" {
-    _install_fake_ai_cli gemini
-    mkdir -p "$HOME/.gemini"
-    printf '{"refresh_token":"fake"}\n' >"$HOME/.gemini/oauth_creds.json"
+@test "auth: agy credentials dir present → auth check passes" {
+    _install_fake_ai_cli agy
+    mkdir -p "$HOME/.gemini/antigravity-cli"
     # See claude credentials test above for why `export PATH` is required
     # (PR #765 review).
-    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; cd '$FAKE_REPO' && gh_pr_approve 42 --ai gemini 2>&1"
-    refute_output --partial "gemini CLI not authenticated"
+    run_in_bash "export PATH='$TEST_TEMP_HOME/bin:'\$PATH; cd '$FAKE_REPO' && gh_pr_approve 42 --ai agy 2>&1"
+    refute_output --partial "agy CLI not authenticated"
 }
 
 @test "help: documents auth pre-flight" {
@@ -745,7 +751,7 @@ EOF
 }
 
 @test "status <N>: failed:approving — usage.jsonl .result wins over log fallback (issue #666)" {
-    # Regression guard for codex/gemini adapters that DO populate
+    # Regression guard for codex/agy adapters that DO populate
     # usage.jsonl with .result — the log fallback must not override it.
     # Pad the log so the is_error JSON dump is NOT in the last 5 lines;
     # otherwise the `tail -5 log` block in status would echo the sentinel

--- a/tests/bats/functions/gh_pr_reply.bats
+++ b/tests/bats/functions/gh_pr_reply.bats
@@ -103,11 +103,11 @@ teardown() {
 @test "bash: help documents --ai option and supported runners" {
     # Issue #215 contract: --ai must be discoverable from help, with
     # the explicit list of supported agents. If users don't see codex
-    # / gemini in help they have no way to know the option exists.
+    # / agy in help they have no way to know the option exists.
     run_in_bash 'gh_pr_reply --help 2>&1'
     assert_success
     assert_output --partial "--ai"
-    assert_output --partial "claude (default) | codex | gemini"
+    assert_output --partial "claude (default) | codex | agy"
 }
 
 # ---------------------------------------------------------------------------
@@ -166,7 +166,7 @@ teardown() {
     run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai 2>&1"
     assert_failure
     assert_output --partial "--ai requires a value"
-    assert_output --partial "claude|codex|gemini"
+    assert_output --partial "claude|codex|agy"
 }
 
 @test "bash: invalid --ai value is rejected with allowed list" {
@@ -176,7 +176,7 @@ teardown() {
     run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai not-supported 2>&1"
     assert_failure
     assert_output --partial "invalid --ai value"
-    assert_output --partial "claude|codex|gemini"
+    assert_output --partial "claude|codex|agy"
 }
 
 @test "bash: unknown long option is rejected" {
@@ -199,13 +199,19 @@ teardown() {
     refute_output --partial "unknown option"
 }
 
-@test "bash: --ai gemini with leading position is accepted" {
-    # Per issue #215 example: `gh-pr-reply --ai gemini '#56' '#78'` —
+@test "bash: --ai agy with leading position is accepted" {
+    # Per issue #215 example: `gh-pr-reply --ai agy '#56' '#78'` —
     # --ai before PR numbers must parse just as well as after them.
-    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply --ai gemini 42 2>&1 || true"
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply --ai agy 42 2>&1 || true"
     refute_output --partial "invalid --ai value"
     refute_output --partial "--ai requires a value"
     refute_output --partial "unknown option"
+}
+
+@test "bash: --ai gemini is now rejected (removed value)" {
+    run_in_bash "cd '$FAKE_REPO' && gh_pr_reply 42 --ai gemini 2>&1"
+    assert_failure
+    assert_output --partial "invalid --ai value"
 }
 
 @test "bash: --ai=value form is accepted" {
@@ -264,7 +270,7 @@ teardown() {
     # is invariant across ai runners — switching --ai must not silently
     # bypass the inspection step that protects unpushed commits.
     # Use --ai claude here so we exercise the parser path without
-    # requiring codex/gemini to be installed in the test env.
+    # requiring codex/agy to be installed in the test env.
     local _state_dir="$HOME/.local/state/gh-pr-reply/fake-main/42"
     mkdir -p "$_state_dir"
     printf 'failed:replying\n' >"$_state_dir/state"

--- a/tests/bats/functions/git_worktree_spawn.bats
+++ b/tests/bats/functions/git_worktree_spawn.bats
@@ -225,10 +225,15 @@ teardown() {
     assert_output "codex --dangerously-bypass-approvals-and-sandbox"
 }
 
-@test "bash: _gwt_yolo_command gemini returns the yolo+skip-trust command" {
-    run_in_bash '_gwt_yolo_command gemini'
+@test "bash: _gwt_yolo_command agy returns the skip-permissions command" {
+    run_in_bash '_gwt_yolo_command agy'
     assert_success
-    assert_output "gemini --approval-mode=yolo --skip-trust"
+    assert_output "agy --dangerously-skip-permissions"
+}
+
+@test "bash: _gwt_yolo_command gemini is now rejected (removed agent)" {
+    run_in_bash '_gwt_yolo_command gemini'
+    assert_failure
 }
 
 @test "bash: _gwt_yolo_command opencode returns the bare command" {
@@ -247,7 +252,7 @@ teardown() {
     # must derive from this output to prevent drift from the dispatch table.
     run_in_bash '_gwt_yolo_command --list'
     assert_success
-    assert_output "claude, codex, gemini, opencode"
+    assert_output "claude, codex, agy, opencode"
 }
 
 @test "zsh: _gwt_yolo_command claude returns the function, not the alias name" {
@@ -266,10 +271,10 @@ teardown() {
     assert_output "codex --dangerously-bypass-approvals-and-sandbox"
 }
 
-@test "zsh: _gwt_yolo_command gemini returns the yolo+skip-trust command" {
-    run_in_zsh '_gwt_yolo_command gemini'
+@test "zsh: _gwt_yolo_command agy returns the skip-permissions command" {
+    run_in_zsh '_gwt_yolo_command agy'
     assert_success
-    assert_output "gemini --approval-mode=yolo --skip-trust"
+    assert_output "agy --dangerously-skip-permissions"
 }
 
 @test "zsh: _gwt_yolo_command opencode returns the bare command" {
@@ -286,7 +291,7 @@ teardown() {
 @test "zsh: _gwt_yolo_command --list lists supported agents (SSOT)" {
     run_in_zsh '_gwt_yolo_command --list'
     assert_success
-    assert_output "claude, codex, gemini, opencode"
+    assert_output "claude, codex, agy, opencode"
 }
 
 # ---------------------------------------------------------------------------
@@ -332,7 +337,7 @@ teardown() {
 }
 
 @test "bash: _gwt_yolo_command non-claude agents ignore account" {
-    # Multi-account is claude-only — codex/gemini/opencode have no --user
+    # Multi-account is claude-only — codex/agy/opencode have no --user
     # support, so any value passed in 2nd position must be a no-op for them.
     run_in_bash '_gwt_yolo_command codex work'
     assert_success
@@ -360,7 +365,7 @@ teardown() {
 @test "bash: spawn rejects --user with non-claude agent (--tmux)" {
     run_in_bash "
         cd '${DOTFILES_ROOT}' || exit 1
-        git_worktree_spawn --wt-name issue-xyz --tmux --ai gemini --user work 2>&1
+        git_worktree_spawn --wt-name issue-xyz --tmux --ai agy --user work 2>&1
     "
     assert_failure
     assert_output --partial "--user is only supported with --ai claude"

--- a/tests/bats/skills/gh_pr_review_arg_parse.bats
+++ b/tests/bats/skills/gh_pr_review_arg_parse.bats
@@ -35,7 +35,7 @@ teardown() {
     run gh_pr_review_parse --ai chatgpt 99
     assert_failure 2
     assert_output --partial "Unknown --ai value: 'chatgpt'"
-    assert_output --partial "allowed: codex, gemini, claude"
+    assert_output --partial "allowed: codex, agy, claude"
 }
 
 @test "ai: --ai codex → ok, ai=codex" {
@@ -45,10 +45,16 @@ teardown() {
     assert_output --partial "pr=99"
 }
 
-@test "ai: --ai=gemini (= form) → ok, ai=gemini" {
-    run gh_pr_review_parse --ai=gemini 99
+@test "ai: --ai=agy (= form) → ok, ai=agy" {
+    run gh_pr_review_parse --ai=agy 99
     assert_success
-    assert_output --partial "ai=gemini"
+    assert_output --partial "ai=agy"
+}
+
+@test "ai: --ai gemini → exit 2 (removed value)" {
+    run gh_pr_review_parse --ai gemini 99
+    assert_failure 2
+    assert_output --partial "Unknown --ai value: 'gemini'"
 }
 
 @test "ai: --ai claude → ok, ai=claude" {
@@ -114,13 +120,13 @@ teardown() {
 }
 
 @test "review: KR alias 보안 → security" {
-    run gh_pr_review_parse --ai gemini --review 보안 99
+    run gh_pr_review_parse --ai agy --review 보안 99
     assert_success
     assert_output --partial "review=security"
 }
 
 @test "review: KR alias 성능 → performance" {
-    run gh_pr_review_parse --ai gemini --review 성능 99
+    run gh_pr_review_parse --ai agy --review 성능 99
     assert_success
     assert_output --partial "review=performance"
 }
@@ -149,8 +155,8 @@ teardown() {
     assert_output --partial "--user is only valid with --ai claude"
 }
 
-@test "user: --user with --ai gemini → exit 2 (cross-AI rejected)" {
-    run gh_pr_review_parse --ai gemini --user work 99
+@test "user: --user with --ai agy → exit 2 (cross-AI rejected)" {
+    run gh_pr_review_parse --ai agy --user work 99
     assert_failure 2
     assert_output --partial "--user is only valid with --ai claude"
 }

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -325,12 +325,12 @@ def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
     "sibling",
     [
         # hyphen-form siblings
-        "/gh-pr-review --ai gemini 123",
+        "/gh-pr-review --ai agy 123",
         "/gh-pr-reply 123",
         "/gh-pr-resolve-conflict 123",
         # colon-form siblings — `:` is also not a word char, so the lookahead
         # must exclude it too (PR #1169 gemini review).
-        "/gh:pr:review --ai gemini 123",
+        "/gh:pr:review --ai agy 123",
         "/gh:pr:reply 123",
         "/gh:pr:resolve-conflict 123",
     ],


### PR DESCRIPTION
## Summary
- gemini CLI가 제거되고 agy(Antigravity CLI)가 신규 설치된 뒤에도, `--ai` 계열 옵션을 제공하는 모든 명령·스킬에 `gemini` enum·호출부가 하드코딩되어 있어 선택 시 존재하지 않는 바이너리를 호출하던 문제를 해결한다.
- 전수조사한 모든 CLI-selection 지점(shell 함수 + 스킬 문서 + 테스트)에서 `gemini`를 `agy`로 완전 교체했다. 역사적 PR-리뷰 코멘트 귀속, `gemini-code-assist` 봇 언급, `GEMINI.md` 어댑터 문서 등 CLI 선택과 무관한 지점은 그대로 두었다.
- `ai_usage.sh`의 JSON 기반 비용추적 파이프라인은 Non-Goal로 별도 이슈에 분리했으나(agy는 `--output-format json` 상당 플래그가 없음), 실제 CLI 호출 자체가 끊기지 않도록 최소 untracked 기록 case는 추가했다.

## Changes
- `gwt spawn` (`git_worktree.sh`, `tmux_spawn.sh`, `ai_setup.sh`): yolo 커맨드 dispatch, agent 목록, help 텍스트를 agy로 교체.
- `gh-pr-review` (`gh_pr_review.sh`): enum 검증과 실제 호출부를 `agy --print <"$prompt_file"`로 교체.
- `gh-pr-reply` / `gh-flow` / `gh-pr-approve`: enum 검증, help 텍스트, `_have agy` 가용성 체크로 교체. `gh-pr-approve`의 인증 확인은 `~/.gemini/oauth_creds.json` 대신 `~/.gemini/antigravity-cli/` 디렉토리 존재 여부로 재작성.
- `ai_usage.sh`: 기존 `gemini)` case는 Non-Goal 범위라 그대로 두되(JSON 사용량 파싱 미대응), `agy)` case를 신규 추가해 `agy --dangerously-skip-permissions --print`로 실제 호출이 끊기지 않게 하고 `tracking:"unsupported"`로 최소 기록만 남긴다.
- `skill_loader.sh`, `claude_plugins_help.sh`, `claude_plugins_docs_ko.sh`, `shell-common/env/claude.sh`: 각자의 gemini CLI-selection 지점(문서 생성기 선택자 포함)을 agy로 교체.
- `claude/skills/{ai-worktree-spawn,gh-pr-review,gh-pr-reply,devx-pr-review-all,gh-issue-flow}/**`: "gemini ∥ codex" 병렬 설명과 `--ai gemini` 예시를 "agy ∥ codex" / `--ai agy`로 동기화.
- 관련 bats(`ai_usage`, `gh_flow`, `gh_pr_approve`, `gh_pr_reply`, `git_worktree_spawn`, `gh_pr_review_arg_parse`) + `test_skill_completion_guard.py`: `gemini` 케이스를 `agy`로 교체하고, `--ai gemini`가 이제 거부됨을 확인하는 회귀 테스트를 추가.

## Test plan
- [x] `tests/bats/functions/ai_usage.bats` — 19/19 (agy dispatch 신규 3건 포함)
- [x] `tests/bats/functions/{gh_pr_approve,gh_flow,gh_pr_reply,git_worktree_spawn,git_worktree_help,tmux_spawn,ai_setup,gh_pr_review}.bats`, `tests/bats/skills/gh_pr_review_arg_parse.bats` — 전체 통과, 회귀 없음
- [ ] `gwt spawn --ai agy`, `gh-pr-review --ai agy`, `gh-pr-reply --ai agy` 실제 실행 수동 검증 (에이전트 환경 제약으로 실제 agy 바이너리 호출은 미실행 — 머지 전 로컬 확인 권장)

## Related
Closes #1184

---
<details>
<summary>🤖 AI Metrics · 📊 ~23500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~23500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
