### PR TITLE
chore(gitignore): ignore understand-anything diff-overlay 스크래치 파일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ claude/settings.local.json
 .understand-anything/fingerprints.json
 .understand-anything/.trash-*/
 .understand-anything/*.log
+.understand-anything/diff-overlay.json


### PR DESCRIPTION
## Summary
- `.understand-anything/diff-overlay.json`을 `.gitignore`에 추가

## Changes
- gitignore: `/understand-diff` 실행마다 재생성되는 일회성 대시보드 오버레이 파일을 무시 목록에 추가 — `knowledge-graph.json` 등 큐레이션 대상과 달리 추적 가치가 없음

## Test plan
- [x] `git status`로 `diff-overlay.json`이 더 이상 untracked로 뜨지 않음을 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~? tokens · 👤 ~? h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~? tokens · 👤 ~? h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
