### PR TITLE
feat(devx-plugin-guide): 체리픽 플러그인 설치+문서화 자동화 스킬 신설

### DIFF
--- a/claude/skills/devx-plugin-guide/SKILL.md
+++ b/claude/skills/devx-plugin-guide/SKILL.md
@@ -41,13 +41,12 @@ Set repo root `ROOT` = this dotfiles repo, `CFG=${CLAUDE_CONFIG_DIR:-$HOME/.clau
 
 ## Step 2: Verify Installed (F-2)
 
-Grep `claude/plugin/plugins.json` for an entry matching `PLUGIN@`. If found and
-`MARKETPLACE` was omitted, take `MARKETPLACE` from the matched entry.
-
-Not found → this is the **not-installed error case**. Print the install
-instructions block from `references/help.md` ("설치 안내") filled in with this
-plugin + its `marketplaces.json` `owner/repo`, then **stop** — never run
-`/plugin install` yourself. The user installs, then re-runs the skill.
+Resolve `MARKETPLACE` by exact-matching `PLUGIN@` against
+`claude/plugin/plugins.json`'s `plugins` array — **never** substring `grep`
+(a plugin named `skills` would falsely match `example-skills@...`). Zero, one,
+or 2+ matches (e.g. `superpowers` is installed under two marketplaces today)
+are each handled per `references/marketplace-resolution.md`, which also
+covers the not-installed case when `MARKETPLACE` itself is unknown.
 
 ## Step 3: Locate Cache + Enumerate Skills (F-3)
 
@@ -75,13 +74,14 @@ sections. `--force` overwrites the file wholesale.
 ## Step 5: Write the Doc (F-4, F-6)
 
 Write `docs/guide/plugins/<PLUGIN>.md` in **Korean**, following the exact
-3-section skeleton in `references/doc-template.md`
-(설치 방법 → 스킬 설명 → 사용법 예제). SKILL.md sources are English; summarize
-them in Korean — do not copy English prose.
+3-section skeleton in `references/doc-template.md` (설치 방법 → 스킬 설명 →
+사용법 예제). SKILL.md sources are English — summarize, don't copy prose.
 
 ## Step 6: Update Index (F-5)
 
-Append one line under `## Index` in `docs/guide/plugins/README.md`:
+Insert one line inside the `## Index` list in `docs/guide/plugins/README.md`
+— after the last existing `- [...]` item and **before** the next `## ` header
+(e.g. `## 문서 구성`); never blindly append to end-of-file:
 `- [<PLUGIN>](./<PLUGIN>.md) — <one-line Korean summary>`. **Idempotent**: if a
 line already links `./<PLUGIN>.md`, skip. `docs/guide/README.md` already has a
 `plugins/` link — leave it untouched (add only if genuinely absent).

--- a/claude/skills/devx-plugin-guide/SKILL.md
+++ b/claude/skills/devx-plugin-guide/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: devx:plugin-guide
+description: >-
+  Generate a Korean, human-facing guide doc for an already-installed Claude
+  Code plugin by reading its cached SKILL.md files, then update the plugins
+  index. Use when the user runs /devx:plugin-guide <plugin-name>, or asks
+  "이 플러그인 가이드 만들어줘", "플러그인 문서화해줘", "새 플러그인 스킬
+  정리해줘". Produces docs/guide/plugins/<plugin>.md with 3 fixed sections
+  (설치 방법 / 스킬 설명 / 사용법). Does NOT install plugins and does NOT
+  commit. Accepts `<plugin-name> [--force]` and `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Grep, Write, Edit
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "parses N SKILL.md frontmatters + builds a structured Korean doc; low-risk doc writes, no code changes"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# devx:plugin-guide — Plugin Guide Generator
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No file reads/writes.
+
+## Step 1: Parse Args
+
+Positional: `<plugin-name> [--force]`.
+
+| Arg | Description | Default | Required |
+|-----|-------------|---------|----------|
+| `<plugin-name>` | `<plugin>@<marketplace>` or `<plugin>` alone | — | Yes |
+| `--force` | Regenerate even if the target doc already exists | off | No |
+
+Split `<plugin-name>` on `@` into `PLUGIN` and (optional) `MARKETPLACE`.
+The output filename is always `PLUGIN.md`. Missing arg → print
+`Run /devx-plugin-guide -h for usage.` and stop.
+
+Set repo root `ROOT` = this dotfiles repo, `CFG=${CLAUDE_CONFIG_DIR:-$HOME/.claude}`.
+
+## Step 2: Verify Installed (F-2)
+
+Grep `claude/plugin/plugins.json` for an entry matching `PLUGIN@`. If found and
+`MARKETPLACE` was omitted, take `MARKETPLACE` from the matched entry.
+
+Not found → this is the **not-installed error case**. Print the install
+instructions block from `references/help.md` ("설치 안내") filled in with this
+plugin + its `marketplaces.json` `owner/repo`, then **stop** — never run
+`/plugin install` yourself. The user installs, then re-runs the skill.
+
+## Step 3: Locate Cache + Enumerate Skills (F-3)
+
+```bash
+find "$CFG/plugins/cache/<MARKETPLACE>/<PLUGIN>" -maxdepth 4 -iname SKILL.md
+```
+
+If multiple version dirs exist, keep only the highest (`sort -V` on the
+version path component). Zero `SKILL.md` found → this is the **no-skills error
+case**: report `스킬 없음, 문서화 대상 아님` and stop.
+
+If skill count > 10, print ONE warning line
+(`스킬 N개 (>10) — YAGNI: 단일 파일로 생성`) and continue with a single file.
+Do NOT build subdirectory-splitting logic.
+
+For each `SKILL.md`, read frontmatter `name`/`description` and skim the body for
+its one core rule → a 1-2 line "하는 일" summary (see `references/doc-template.md`).
+
+## Step 4: Idempotent Skip (Acceptance: safe re-run)
+
+If `docs/guide/plugins/<PLUGIN>.md` already exists and `--force` was NOT passed:
+print `이미 문서화됨 — 재생성하려면 --force` and stop. Do NOT diff or merge
+sections. `--force` overwrites the file wholesale.
+
+## Step 5: Write the Doc (F-4, F-6)
+
+Write `docs/guide/plugins/<PLUGIN>.md` in **Korean**, following the exact
+3-section skeleton in `references/doc-template.md`
+(설치 방법 → 스킬 설명 → 사용법 예제). SKILL.md sources are English; summarize
+them in Korean — do not copy English prose.
+
+## Step 6: Update Index (F-5)
+
+Append one line under `## Index` in `docs/guide/plugins/README.md`:
+`- [<PLUGIN>](./<PLUGIN>.md) — <one-line Korean summary>`. **Idempotent**: if a
+line already links `./<PLUGIN>.md`, skip. `docs/guide/README.md` already has a
+`plugins/` link — leave it untouched (add only if genuinely absent).
+
+## Step 7: Report
+
+Print the report per `references/help.md` "출력 형식": `[OK]` verdict, files
+written/skipped, skill count, and the next step (review the doc, then commit
+manually — this skill never commits).
+
+## Constraints
+
+- Never install plugins / run `/plugin install` (F-2 stops for the user), never
+  commit or open a PR (Non-Goal), never smoke-test skills (out of scope).
+- Generated docs are Korean (docs/AGENTS.md Language Policy); the SKILL.md
+  sources stay English — do not confuse the two. No emojis anywhere.

--- a/claude/skills/devx-plugin-guide/references/doc-template.md
+++ b/claude/skills/devx-plugin-guide/references/doc-template.md
@@ -1,0 +1,76 @@
+# Generated Doc Template
+
+The output `docs/guide/plugins/<plugin>.md` is Korean and has exactly 3 fixed
+sections. Model it on `docs/guide/plugins/ponytail.md` (the canonical example).
+Fill the placeholders `<...>` from the plugin's `plugins.json` /
+`marketplaces.json` entries and its cached `SKILL.md` files.
+
+## Skeleton
+
+```markdown
+# <plugin> 플러그인 가이드
+
+<1-2줄 한국어 개요 — 이 플러그인이 무엇을 하는지. 각 SKILL.md description 을
+종합해 한국어로 요약. 영어 원문 복붙 금지.>
+
+- Marketplace: [`<owner/repo>`](https://github.com/<owner/repo>)
+- 이 dotfiles 저장소 SSOT: `claude/plugin/plugins.json` (`<plugin>@<marketplace>`), `claude/plugin/marketplaces.json`
+
+## 1. 설치 방법
+
+​```
+/plugin marketplace add <owner/repo>
+/plugin install <plugin>@<marketplace>
+/reload-plugins
+​```
+
+`claude/plugin/plugins.json`·`marketplaces.json`은 `plugin-sync.sh` / `plugin-sync-session.sh` hook이
+세션 종료 시 자동으로 동기화한다 (`claude/AGENTS.md` → "Plugin Manifest" 참조) — 수동으로 SSOT 파일을
+편집할 필요 없음. 신규 PC에는 `./claude/plugin/restore.sh`로 일괄 복원된다.
+
+## 2. 스킬 설명
+
+| 스킬 | 성격 | 하는 일 |
+|------|------|---------|
+| `<skill-name>` | <일회성/지속 모드 등 한 단어 성격> | <SKILL.md description + 핵심 규칙 1줄 한국어 요약> |
+| ... | ... | ... |
+
+<스킬이 여러 개면 공통 규칙/해제 방법 등을 한 줄로 덧붙일 수 있음 (선택).>
+
+## 3. 사용법 예제
+
+**<대표 사용 시나리오 1>**
+​```
+/<skill-name>
+"<사용자 요청 예시>"
+→ <기대 출력 스케치>
+​```
+
+<스킬 수만큼 반복하되, 스킬이 많으면 대표 2-4개만. 각 예제는 실제 호출 형태 +
+기대 출력 한 줄.>
+```
+
+## Building the 스킬 설명 table (Step 3 extraction)
+
+For each `SKILL.md`:
+- **스킬** = frontmatter `name` (colon form as-is, e.g. `ponytail-review`).
+- **성격** = one Korean word/phrase inferred from the body: is it a persistent
+  mode, a one-shot report, a read-only audit, a file-writing action? Keep it to
+  a few words.
+- **하는 일** = 1 line. Compress the `description` + the single most important
+  body rule into Korean. Do not translate the whole SKILL.md — one line.
+
+Single-skill plugins (e.g. `andrej-karpathy-skills`) still get the full 3
+sections; the table just has one row and 사용법 has one example.
+
+## Optional closing section
+
+If the plugin has misc config/notes worth surfacing (env vars, config file
+location, related commands), add a `## 참고` section like ponytail.md's. Skip it
+if there is nothing natural to say — do not pad.
+
+## Note on the code fences above
+
+The `​` before the triple-backtick fences in the skeleton is a zero-width space
+so this template renders inside a markdown code block. Strip it when you write
+the real doc — the generated file uses plain ` ``` ` fences.

--- a/claude/skills/devx-plugin-guide/references/help.md
+++ b/claude/skills/devx-plugin-guide/references/help.md
@@ -1,0 +1,60 @@
+# devx:plugin-guide — Help
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<plugin-name>` or `-h`/`--help`/`help` | — | `<plugin>@<marketplace>` or `<plugin>` alone (required unless help) |
+| 2 | `--force` | off | Regenerate the doc even if it already exists |
+
+## Usage
+
+- `/devx-plugin-guide ponytail@ponytail` — generate `docs/guide/plugins/ponytail.md`
+- `/devx-plugin-guide andrej-karpathy-skills` — marketplace inferred from `plugins.json`
+- `/devx-plugin-guide ponytail --force` — overwrite an existing doc
+- `/devx-plugin-guide -h` / `--help` / `help` — print this help
+
+## What the skill does
+
+1. Confirms the plugin is in `claude/plugin/plugins.json` (SSOT). If not
+   installed, prints the 설치 안내 below and stops — never installs for you.
+2. Finds every `skills/*/SKILL.md` under the plugin's cache dir
+   (`$CLAUDE_CONFIG_DIR/plugins/cache/<marketplace>/<plugin>/<version>/`),
+   picking the highest version. Zero skills → reports "스킬 없음" and stops.
+3. Extracts each skill's `name` / `description` + one core rule.
+4. Writes `docs/guide/plugins/<plugin>.md` in Korean with 3 fixed sections:
+   설치 방법 / 스킬 설명 / 사용법 예제.
+5. Adds an idempotent index line to `docs/guide/plugins/README.md`.
+6. Existing doc + no `--force` → skips (safe re-run). `--force` overwrites.
+
+## What the skill will NOT do
+
+- Install plugins, run `/plugin install`, or add marketplaces (Non-Goal).
+- Commit or open a PR — it stops after writing the doc.
+- Smoke-test the skills — out of scope.
+- Merge/diff sections into an existing doc — it either skips or overwrites.
+
+## 설치 안내 (not-installed error case, filled per plugin)
+
+```
+플러그인 <plugin>@<marketplace> 이 plugins.json 에 없습니다. 설치 후 재실행하세요:
+
+/plugin marketplace add <owner/repo>
+/plugin install <plugin>@<marketplace>
+/reload-plugins
+```
+
+`<owner/repo>` comes from `claude/plugin/marketplaces.json[<marketplace>]`.
+
+## 출력 형식 (final report)
+
+```
+[OK] docs/guide/plugins/<plugin>.md 생성 (스킬 N개)
+- docs/guide/plugins/README.md 인덱스 갱신
+Next: 문서 검토 후 /gh-commit 으로 커밋 (이 스킬은 커밋하지 않음)
+```
+
+Skip case:
+```
+[SKIP] docs/guide/plugins/<plugin>.md 이미 존재 — 재생성하려면 --force
+```

--- a/claude/skills/devx-plugin-guide/references/marketplace-resolution.md
+++ b/claude/skills/devx-plugin-guide/references/marketplace-resolution.md
@@ -1,0 +1,57 @@
+# Marketplace Resolution — Step 2 detail
+
+Exact-match lookup for `PLUGIN` (and optional `MARKETPLACE`) against
+`claude/plugin/plugins.json`'s `plugins` array of `"<plugin>@<marketplace>"`
+strings. Never `grep "PLUGIN@"` — a plain substring/suffix grep for `skills`
+would also match `example-skills@anthropic-agent-skills`. Use `jq` so only
+the plugin-name segment before `@` is compared:
+
+```bash
+MATCHES=$(jq -r --arg p "$PLUGIN" \
+  '.plugins[] | select(split("@")[0] == $p)' \
+  claude/plugin/plugins.json)
+```
+
+## Case A — `MARKETPLACE` given explicitly (`<plugin>@<marketplace>`)
+
+Check that the exact string `"$PLUGIN@$MARKETPLACE"` is one of `$MATCHES`.
+
+- Present → installed, proceed to Step 3.
+- Absent → not-installed error case (below), with `MARKETPLACE` known.
+
+## Case B — `MARKETPLACE` omitted (bare `<plugin>`)
+
+Count the lines in `$MATCHES`:
+
+- **Zero** → not-installed error case (below), with `MARKETPLACE` unknown.
+- **One** → take `MARKETPLACE` from that entry's suffix after `@`. Proceed
+  to Step 3.
+- **Two or more** — the same plugin name is installed under multiple
+  marketplaces (e.g. today's `plugins.json` has both
+  `superpowers@claude-plugins-official` and `superpowers@superpowers-dev`).
+  **Stop.** Never guess which one the user meant. Print the candidate list
+  and ask the user to re-run with an explicit `<plugin>@<marketplace>`:
+
+  ```
+  플러그인 <plugin> 이 여러 marketplace에 설치되어 있습니다:
+    - <plugin>@<marketplace-1>
+    - <plugin>@<marketplace-2>
+  재실행: /devx-plugin-guide <plugin>@<marketplace-N>
+  ```
+
+## Not-installed error case
+
+- **`MARKETPLACE` known** (Case A, or Case B narrowed by the user's own
+  `@marketplace` suffix): look up `claude/plugin/marketplaces.json[MARKETPLACE]`
+  for `owner/repo` and print the install instructions block from
+  `references/help.md` ("설치 안내") filled in with `<plugin>@<marketplace>` +
+  `<owner/repo>`, then **stop** — never run `/plugin install` yourself.
+- **`MARKETPLACE` unknown** (Case B, zero matches): there is no `owner/repo`
+  to look up — printing a fabricated install command would be a guess. Stop
+  with:
+
+  ```
+  플러그인 <plugin> 이 claude/plugin/plugins.json 에 없고 marketplace 정보도
+  없습니다. 정확한 marketplace를 알고 있다면 <plugin>@<marketplace> 형태로
+  재실행하세요.
+  ```

--- a/docs/guide/plugins/README.md
+++ b/docs/guide/plugins/README.md
@@ -7,6 +7,7 @@
 ## Index
 
 - [ponytail](./ponytail.md) — 과잉설계 방지 (YAGNI/stdlib/native 우선 강제)
+- [andrej-karpathy-skills](./andrej-karpathy-skills.md) — LLM 코딩 실수 방지 행동 지침 (가정 명시/단순성/외과적 수정)
 
 ## 문서 구성
 

--- a/docs/guide/plugins/andrej-karpathy-skills.md
+++ b/docs/guide/plugins/andrej-karpathy-skills.md
@@ -1,0 +1,53 @@
+# andrej-karpathy-skills 플러그인 가이드
+
+LLM 코딩에서 반복되는 실수(과잉구현·불필요한 리팩터·숨긴 가정·모호한 성공 기준)를
+줄이기 위한 행동 지침 플러그인. Andrej Karpathy가 정리한 LLM 코딩 함정 관찰에서 파생됐다.
+
+- Marketplace: [`forrestchang/andrej-karpathy-skills`](https://github.com/forrestchang/andrej-karpathy-skills)
+- 이 dotfiles 저장소 SSOT: `claude/plugin/plugins.json` (`andrej-karpathy-skills@karpathy-skills`), `claude/plugin/marketplaces.json`
+
+## 1. 설치 방법
+
+```
+/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin install andrej-karpathy-skills@karpathy-skills
+/reload-plugins
+```
+
+`claude/plugin/plugins.json`·`marketplaces.json`은 `plugin-sync.sh` / `plugin-sync-session.sh` hook이
+세션 종료 시 자동으로 동기화한다 (`claude/AGENTS.md` → "Plugin Manifest" 참조) — 수동으로 SSOT 파일을
+편집할 필요 없음. 신규 PC에는 `./claude/plugin/restore.sh`로 일괄 복원된다.
+
+## 2. 스킬 설명
+
+| 스킬 | 성격 | 하는 일 |
+|------|------|---------|
+| `karpathy-guidelines` | 지속 지침 (코드 작성/리뷰/리팩터 시) | 코딩 전 가정·트레이드오프를 명시(assume 금지), 요청된 최소 코드만(단순성 우선), 요청과 무관한 부분은 건드리지 않는 외과적 수정, 검증 가능한 성공 기준을 세워 통과까지 반복 — 네 가지 행동 규칙을 강제 |
+
+이 플러그인은 스킬 1개로 구성된다. `karpathy-guidelines`는 파일을 직접 수정하지 않는
+행동 지침(behavioral guideline)으로, 다른 코딩 작업의 품질 가드레일로 함께 적용한다.
+사소한 작업에는 판단에 따라 생략 가능(속도보다 신중함으로 편향된 지침이라는 점을 명시).
+
+## 3. 사용법 예제
+
+**기능 구현 전 가정·단순성 점검**
+```
+/karpathy-guidelines
+"이 모듈에 검증 로직 추가해줘"
+→ 가정을 먼저 명시하고 모호하면 질문, 요청 범위 밖 추상화/설정은 배제,
+  "잘못된 입력에 대한 테스트 작성 → 통과" 형태의 검증 가능한 목표로 변환
+```
+
+**기존 코드 편집 시 외과적 수정 강제**
+```
+/karpathy-guidelines
+"버그 수정하면서 근처 코드도 정리해줘"
+→ 인접 코드/포맷은 손대지 않음, 내 변경이 만든 orphan(미사용 import 등)만 정리,
+  기존 dead code는 삭제 대신 언급만 — 변경된 모든 줄이 요청에 직접 대응하는지 검증
+```
+
+## 참고
+
+- 트레이드오프: 이 지침은 속도보다 신중함(caution)으로 편향된다. 정말 사소한 작업이면
+  판단에 따라 완화한다.
+- 정확성 버그·보안·성능 리뷰는 이 지침의 범위 밖 — `/code-review`로 별도 확인.


### PR DESCRIPTION
## Summary
- 새 Claude Code 스킬 `devx:plugin-guide` 를 추가해, 체리픽 플러그인 설치 후 가이드 문서 작성을 자동화한다.
- ponytail 플러그인(PR #1193)에서 수동으로 했던 절차(스킬 SKILL.md 읽기 → 3섹션 문서 작성 → 인덱스 갱신)를 재사용 가능하게 만들었다.

## Changes
- feat(devx-plugin-guide): `claude/skills/devx-plugin-guide/SKILL.md` 신설 — plugins.json 설치 확인 → 플러그인 캐시의 `skills/*/SKILL.md` 파싱 → `docs/guide/plugins/<plugin>.md` 생성 → README 인덱스 갱신, 7단계 direct 플로우
- feat(devx-plugin-guide): `references/help.md`, `references/doc-template.md` 추가 — help 출력과 3섹션(설치 방법/스킬 설명/사용법) 문서 템플릿
- docs(guide): `andrej-karpathy-skills` 플러그인으로 실제 실행해 `docs/guide/plugins/andrej-karpathy-skills.md` 생성 및 `docs/guide/plugins/README.md` 인덱스 갱신 (스킬 동작 검증 겸용)

## Test plan
- [x] `skill:check` 감사 결과 12 PASS / 2 N/A(License, Capability) / 0 WARN / 0 FAIL
- [x] `andrej-karpathy-skills` 플러그인 대상 실제 실행 — 3섹션 문서 생성 + 인덱스 갱신 확인
- [x] 이미 문서가 있는 `ponytail` 대상 재실행 시 idempotent skip 로직 확인 (덮어쓰기 없음)

## Related
Closes #1195

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
