### PR TITLE
docs(ssot): user-facing alias 풀어쓴 <tool>-<noun> 권장 규칙 명문화

### DIFF
--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -20,9 +20,21 @@
 |------|------|------|
 | Public 함수 (dispatcher/main) | `snake_case` | `git_branch`, `git_worktree` |
 | Private sub-function | `_<prefix>_<verb>` | `_gb_clean_local`, `_gwt_help_rows_add` |
-| Public alias (user-facing) | `dash-form` | `gb`, `gwt`, `git-clean-local` (deprecated) |
+| Public alias (user-facing) | `dash-form`, 풀어쓴 `<tool>-<noun>` 권장 (§1.1) | `agy-version`, `git-clean-local`; git 예외: `gb`, `gwt` |
 | Help 함수 (inline) | `_<prefix>_help` | `_gb_help` |
 | Help 함수 (standalone) | `<topic>_help` + alias `<topic>-help` | `gwt_help` / `gwt-help` |
+
+### 1.1 별칭 가독성 — cryptic 축약 지양
+
+- **원칙**: user-facing alias 는 의미가 드러나는 풀어쓴 `<tool>-<noun>`
+  형태를 사용한다. 축약형은 완전한 명사로 spell out 하고, 단일 문자나
+  의미를 유추할 수 없는 축약은 쓰지 않는다.
+  - Good: `agy-version`, `agy-continue`, `agy-models`, `agy-install`
+  - Avoid: `agyver`, `agyc`(= `--continue`, `c` 가 불명확), `agymodels`
+- **예외 — git 계열 고빈도 관용 축약**: `gb`(git branch),
+  `gwt`(git worktree) 등 수십 년간 관용으로 굳고 타이핑 빈도가 매우 높은
+  git 명령 축약은 그대로 유지한다. 이 예외는 **git 계열에 한정**하며,
+  신규 non-git 명령에는 적용하지 않는다.
 
 ## 2. Command 유형 결정 기준
 

--- a/docs/.ssot/command-design-pattern.md
+++ b/docs/.ssot/command-design-pattern.md
@@ -20,14 +20,14 @@
 |------|------|------|
 | Public 함수 (dispatcher/main) | `snake_case` | `git_branch`, `git_worktree` |
 | Private sub-function | `_<prefix>_<verb>` | `_gb_clean_local`, `_gwt_help_rows_add` |
-| Public alias (user-facing) | `dash-form`, 풀어쓴 `<tool>-<noun>` 권장 (§1.1) | `agy-version`, `git-clean-local`; git 예외: `gb`, `gwt` |
+| Public alias (user-facing) | `dash-form`, 풀어쓴 `<tool>-<noun/verb>` 권장 (§1.1) | `agy-version`, `git-log`; git 예외: `gb`, `gwt` |
 | Help 함수 (inline) | `_<prefix>_help` | `_gb_help` |
 | Help 함수 (standalone) | `<topic>_help` + alias `<topic>-help` | `gwt_help` / `gwt-help` |
 
 ### 1.1 별칭 가독성 — cryptic 축약 지양
 
-- **원칙**: user-facing alias 는 의미가 드러나는 풀어쓴 `<tool>-<noun>`
-  형태를 사용한다. 축약형은 완전한 명사로 spell out 하고, 단일 문자나
+- **원칙**: user-facing alias 는 의미가 드러나는 풀어쓴 `<tool>-<noun/verb>`
+  형태를 사용한다. 축약형은 완전한 단어로 spell out 하고, 단일 문자나
   의미를 유추할 수 없는 축약은 쓰지 않는다.
   - Good: `agy-version`, `agy-continue`, `agy-models`, `agy-install`
   - Avoid: `agyver`, `agyc`(= `--continue`, `c` 가 불명확), `agymodels`


### PR DESCRIPTION
## Summary
- `docs/.ssot/command-design-pattern.md` §1 명명 규칙에 user-facing alias는 cryptic 축약 대신 풀어쓴 `<tool>-<noun>` 형태를 권장하는 규칙을 명문화한다.
- git 계열 고빈도 관용 축약(`gb`, `gwt`)은 의도적 예외로 유지한다.

## Changes
- docs(ssot): §1 "Public alias" 행을 `<tool>-<noun>` 권장 + git 예외 표기로 갱신
- docs(ssot): 신규 §1.1 "별칭 가독성 — cryptic 축약 지양" 섹션 추가 (원칙 + git 예외 근거)

## Test plan
- [x] 문서 전용 변경 — 코드 테스트 대상 없음, pre-commit lint 통과 확인
- [x] `command-guidelines.md` / `command-delivery-model.md`는 변경 불필요함을 확인 (이슈에 명시)

## Related
Closes #1186

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~14 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~14 min
<!-- /ai-metrics:gh-pr -->

</details>
