### PR TITLE
fix(npm): allow-git in public npmrc for github: installs

### DIFF
--- a/npm/npmrc.public
+++ b/npm/npmrc.public
@@ -13,5 +13,12 @@
 #
 # Note: public registry (registry.npmjs.org) is npm's default, so no
 #       registry/proxy/cafile lines are needed here — only the prefix.
+#
+# Why allow-git=true:
+#   npm 12+ defaults allow-git to disabled (supply-chain hardening),
+#   blocking `npx github:owner/repo`-style installs. Some CLI installers
+#   (e.g. plugin marketplaces installed via curl|bash -> npx github:...)
+#   need it enabled.
 
 prefix=${HOME}/.npm-global
+allow-git=true


### PR DESCRIPTION
## Summary
- npm 12+ ships `allow-git=none` by default (supply-chain hardening), blocking `npx github:owner/repo` installs.
- Broke `claude /plugin marketplace add JuliusBrussee/caveman` and any curl|bash installer that shells out to `npx github:...`.
- Enable `allow-git=true` in `npm/npmrc.public` (public setup mode).

## Test plan
- [x] `git diff` reviewed — only `npm/npmrc.public` touched, header comment convention preserved (matches `npmrc.internal`/`npmrc.external`).
- [ ] Re-run `~/.npmrc` symlink refresh (`shell-common/setup.sh` or account setup) and confirm `npx -y github:JuliusBrussee/caveman` no longer errors with `EALLOWGIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)