### PR TITLE
feat(skill): devx:command-rename — 명령 명명 리팩토링 이슈 생성 스킬

### DIFF
--- a/claude/skills/devx-command-rename/SKILL.md
+++ b/claude/skills/devx-command-rename/SKILL.md
@@ -38,9 +38,8 @@ its content verbatim, then stop. No API calls.
 
 ## Step 1: Parse input & resolve target family
 
-Record `START_TS=$(date +%s)`. Parse `<command-family>` (e.g. `agy`),
-`<desired-convention>` (e.g. `dash-form`), optional `[remote]` (default
-`origin`). Resolve `TARGET_REPO` per `references/repo-resolution.md`
+Parse `<command-family>` (e.g. `agy`), `<desired-convention>` (e.g.
+`dash-form`), optional `[remote]` (default `origin`). Resolve `TARGET_REPO` per `references/repo-resolution.md`
 (fail-fast on a missing remote). If the family is ambiguous or matches
 nothing, present the candidate names you found and ask — never guess.
 

--- a/claude/skills/devx-command-rename/SKILL.md
+++ b/claude/skills/devx-command-rename/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: devx:command-rename
+description: >-
+  Design a command-naming refactor and file the tracking issue(s) — never
+  touch code. Use when the user runs /devx:command-rename,
+  /devx-command-rename, or asks "이 명령 dash-form으로 리네임 이슈 만들어",
+  "agy 명령들 네이밍 통일 이슈 떠줘", "rename this command family to <convention>".
+  Takes a target command family + desired naming convention, discovers every
+  definition and reference point, compares against the 3 naming SSOT docs,
+  detects a rule gap when the requested convention isn't codified, then
+  creates a `refactor` issue (and a cross-linked `docs` issue on a gap) by
+  reusing [[gh-issue-create]]. Does NOT edit source or commit — the actual
+  rename runs later via /gh:issue-flow. Accepts
+  `<command-family> <desired-convention> [remote]` and `-h`/`--help`/`help`.
+allowed-tools: Bash, Read, Grep, Agent
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "discovery + SSOT diff + interactive mapping design; delegates issue creation"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+# devx:command-rename — Naming refactor → tracking issue(s)
+
+## Role
+
+From a target command family and a desired naming convention, design an
+old→new rename mapping, check it against the naming SSOT, flag any rule gap,
+and file the `refactor` (and gap-only `docs`) issue via [[gh-issue-create]].
+Design and file only — no code edits, no commits. The rename itself is a
+separate later `/gh:issue-flow` run.
+
+## Help
+
+If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output
+its content verbatim, then stop. No API calls.
+
+## Step 1: Parse input & resolve target family
+
+Record `START_TS=$(date +%s)`. Parse `<command-family>` (e.g. `agy`),
+`<desired-convention>` (e.g. `dash-form`), optional `[remote]` (default
+`origin`). Resolve `TARGET_REPO` per `references/repo-resolution.md`
+(fail-fast on a missing remote). If the family is ambiguous or matches
+nothing, present the candidate names you found and ask — never guess.
+
+## Step 2: Discover definitions + ALL reference points
+
+Follow `references/discovery.md` verbatim: locate alias/function definitions
+and every reference-point category (inline help/DOC blocks, `install_*.sh`,
+`my_help.sh` registration, `zz_help_standard_adapter.sh`, help tests, bats).
+Omitting a category leaves dangling references after the rename.
+
+## Step 3: Compare against SSOT + detect rule gap
+
+Follow `references/ssot-check.md`: read and cite all three docs
+(`docs/.ssot/command-design-pattern.md`, `command-guidelines.md`,
+`command-delivery-model.md`). If the requested convention is not literally
+covered by an existing SSOT section, that is a **rule gap** — record it. Do
+not invent SSOT text.
+
+## Step 4: Exclude git-family abbreviations
+
+Drop `gb`, `gwt`, and other high-frequency git abbreviations from the rename
+candidate set regardless of the requested convention
+(`references/discovery.md` → git-family exception).
+
+## Step 5: Design the mapping (interactive)
+
+Follow `references/mapping-design.md`: build the old→new table, then get the
+user's explicit decision on backward-compat (deprecated shim per
+`command-design-pattern.md` §8 vs hard removal) and on any name collisions.
+List intentionally-dropped names. Never auto-decide these — confirm first.
+
+## Step 6: Create the issue(s) via gh:issue-create
+
+Follow `references/issue-creation.md`. Create the `refactor` issue by
+`Skill(gh:issue-create, ...)` with explicit "refactor" intent so its
+classifier picks the `refactor` template. **Only if Step 3 found a rule
+gap**, also create a `docs` issue the same way, then cross-link both
+(`gh issue comment <A> --body "Related: #<B>"` each way). Never call
+`gh issue create` directly here.
+
+## Step 7: Report
+
+Format per `references/report-template.md`: created issue number(s) + URL(s),
+an `[OK]`/`[FAIL]` verdict, and a `Next:` hint pointing at
+`/gh:issue-flow <refactor-issue-number>`.
+
+## Constraints
+
+See `references/constraints.md` (no source edits/commits, never skip the
+git-family exclusion, never invent SSOT text, always confirm
+backward-compat/collision decisions, docs issue only on a real gap).

--- a/claude/skills/devx-command-rename/references/constraints.md
+++ b/claude/skills/devx-command-rename/references/constraints.md
@@ -1,0 +1,26 @@
+# devx:command-rename — Constraints
+
+- **Never edit or commit source files.** This skill designs a mapping and
+  files issues only. All searching is read-only (`grep`/`Read`). The actual
+  rename happens later via `/gh:issue-flow <refactor-issue>`.
+- **Never skip the git-family exclusion.** `gb`, `gwt`, and other
+  high-frequency git abbreviations are always dropped from rename candidates,
+  regardless of the requested convention (`references/discovery.md`).
+- **Never invent SSOT rule text.** If the requested convention isn't codified
+  in an existing SSOT section, report it as a rule gap and file a `docs`
+  issue — do not write proposed rules into the SSOT docs
+  (`references/ssot-check.md`).
+- **Always confirm backward-compat + collision decisions with the user
+  before creating issues.** Deprecated-shim vs hard-removal, and any name
+  collision, are interactive — never auto-decided (`references/mapping-design.md`).
+- **The `docs` issue is gap-only.** When there is no rule gap, create just the
+  `refactor` issue — no docs issue, no cross-link.
+- **Reuse [[gh-issue-create]] for issue creation.** Never call
+  `gh issue create` directly; let that skill own templates, labels, and
+  metrics (`references/issue-creation.md`).
+- **Do not cross the delivery-model axis.** The mapping must not move a
+  command between function and PATH-executable delivery
+  (`command-delivery-model.md`) — renames stay on the naming axis only.
+- **No delivery/behavior change.** A rename preserves behavior; the issue's
+  동작보존 section must state so, and the mapping must not alter what a command
+  does — only what it is called.

--- a/claude/skills/devx-command-rename/references/discovery.md
+++ b/claude/skills/devx-command-rename/references/discovery.md
@@ -1,0 +1,36 @@
+# devx:command-rename — Discovery checklist (F-2)
+
+Goal: find the family's **definitions** and **every reference point**, so the
+mapping designed in Step 5 has no dangling reference left after the eventual
+rename. A missed category means a broken alias, stale help text, or a failing
+test survives the refactor. Search read-only (`grep`/`Read`) — never edit.
+
+## 1. Definitions
+
+Where aliases/functions are declared:
+
+- `shell-common/tools/integrations/*.sh` — tool integration alias/function definitions.
+- `shell-common/functions/*.sh` — shared function definitions.
+
+Grep the family token across both trees (e.g. `grep -rn '\bagy\b' shell-common/tools/integrations shell-common/functions`).
+
+## 2. Reference points (all categories — check every one)
+
+- **Inline help text / comment DOC blocks** — help strings and `# DOC:`-style comment blocks that name the command.
+- **`install_*.sh` scripts** — installers referencing the alias/binary name.
+- **`my_help.sh` `HELP_DESCRIPTIONS` registration** — the help-topic registry entry.
+- **`zz_help_standard_adapter.sh`** — the standard help adapter wiring.
+- **`tests/integration/test_help_*.py`** — pytest help-topic assertions.
+- **`tests/bats/**`** — bats function/alias tests.
+
+For each category, grep the old name(s) from the Step 5 mapping and record
+every file:line hit — these become the "범위(Scope)" list in the refactor
+issue body.
+
+## 3. git-family exception (always excluded)
+
+`gb`, `gwt`, and other high-frequency git abbreviations are **always**
+excluded from rename candidates, regardless of the requested convention.
+Muscle-memory git aliases are intentionally short; renaming them breaks daily
+workflows for no naming-consistency gain. Drop them from the candidate set in
+Step 4 and note the exclusion explicitly in the issue body.

--- a/claude/skills/devx-command-rename/references/help.md
+++ b/claude/skills/devx-command-rename/references/help.md
@@ -1,0 +1,42 @@
+# devx:command-rename — Help
+
+## Synopsis
+
+`/devx-command-rename <command-family> <desired-convention> [remote]`
+
+Designs a command-naming refactor and files the tracking issue(s). It does
+NOT rename anything or commit — the actual rename runs later via
+`/gh:issue-flow <the-refactor-issue-number>`.
+
+## Arguments
+
+| # | Name | Default | Description |
+|---|------|---------|-------------|
+| 1 | `<command-family>`, or `-h`/`--help`/`help` | — | Command/alias family to rename (e.g. `agy`). Ambiguous → candidates are shown, no guess. |
+| 2 | `<desired-convention>` | — | Target naming convention (e.g. `dash-form`, `snake_case`, `<tool>-<noun>`). |
+| 3 | `[remote]` | `origin` | Git remote whose repo will own the new issue(s). Missing remote fails fast. |
+
+## Examples
+
+- `/devx-command-rename agy dash-form` — design `agy` → dash-form rename, file a `refactor` issue on `origin`.
+- `/devx-command-rename agy dash-form upstream` — same, issue on the `upstream` remote's repo.
+- `/devx-command-rename my_tool "<tool>-<noun>"` — convention not codified in SSOT → also files a cross-linked `docs` issue for the rule gap.
+- `/devx-command-rename -h` / `--help` / `help` — print this help.
+
+## What it produces
+
+- One `refactor` GitHub issue (mapping table, before/after, behavior-preservation, risk/rollback, verification).
+- Plus, only when a rule gap is detected, one `docs` GitHub issue, cross-linked with the refactor issue.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Issue(s) created; report printed with URLs. |
+| 1 | Precondition failure (not a git repo, remote not found, `gh auth` failure, or `gh:issue-create` failed). |
+| 2 | Missing/invalid required argument (`<command-family>` or `<desired-convention>`). |
+
+## Not in scope
+
+- No renaming, no source edits, no commits.
+- No delivery-model change (function vs PATH-executable) — see `references/ssot-check.md`.

--- a/claude/skills/devx-command-rename/references/issue-creation.md
+++ b/claude/skills/devx-command-rename/references/issue-creation.md
@@ -1,0 +1,48 @@
+# devx:command-rename — Issue creation (F-7 / F-8)
+
+Both issues are created by **reusing [[gh-issue-create]]** — never by calling
+`gh issue create` directly. That skill owns classification, template
+selection, auto-labels, AI-metrics, and repo resolution; this skill only
+feeds it the right context.
+
+## Refactor issue (always)
+
+Invoke `Skill(gh:issue-create, "<remote>")`, having first laid out the design
+in the conversation so gh:issue-create's classifier lands on `refactor`:
+
+- State the intent explicitly up front (the word "refactor", "동작 보존하며
+  구조 정리") so its `references/prefix-table.md` heuristic picks
+  `refactor` — matching `references/templates/refactor.md`.
+- Provide enough signal to fill the refactor skeleton:
+  **TL;DR / 동기 / 범위(Scope) / Before-After(the mapping table) /
+  동작보존(behavior-preservation) / 리스크·롤백 / 검증 / References**.
+  - 범위 = the discovery hit-list (all reference-point categories).
+  - Before-After = the Step 5 mapping table + the Removed/dropped list.
+  - 동작보존 = the backward-compat decision (shim vs hard removal) per name.
+  - 검증 = help tests + bats that must still pass.
+  - References = the three SSOT doc paths.
+
+Do **not** recreate the refactor skeleton here — it already lives at
+`claude/skills/gh-issue-create/references/templates/refactor.md`.
+
+## Docs issue (only on a rule gap)
+
+Only when `references/ssot-check.md` detected a gap, create a second issue via
+`Skill(gh:issue-create, "<remote>")` with explicit `docs` intent (문서 자체
+변경) so it selects `references/templates/docs.md`. Its content: which
+convention is missing from which SSOT doc, and that the SSOT section (e.g. a
+new `<tool>-<noun>` rule) needs to be authored. Do not propose final SSOT
+prose — the docs issue is the place that gets designed later.
+
+## Cross-linking
+
+After **both** issues exist (capture each returned number/URL), link them
+both ways:
+
+```bash
+gh issue comment <REFACTOR_N> --repo "$TARGET_REPO" --body "Related (rule gap): #<DOCS_N>"
+gh issue comment <DOCS_N>     --repo "$TARGET_REPO" --body "Related (refactor): #<REFACTOR_N>"
+```
+
+If there is no rule gap, there is no docs issue and no cross-link — skip this
+entirely.

--- a/claude/skills/devx-command-rename/references/mapping-design.md
+++ b/claude/skills/devx-command-rename/references/mapping-design.md
@@ -1,0 +1,42 @@
+# devx:command-rename — Mapping design (F-6)
+
+Build the old→new mapping from the Step 2 discovery set (minus the Step 4
+git-family exclusions), then resolve the two interactive decisions below.
+Both decisions MUST be confirmed with the user — never auto-decided.
+
+## Mapping table format
+
+| Old name | New name | Kind | Notes |
+|----------|----------|------|-------|
+| `agy` | `agent-yolo` | public alias | dash-form per §1 |
+| `_agy_run` | `_agentyolo_run` | private sub-fn | prefix follows new base |
+| … | … | … | … |
+
+Include the definition site and every reference-point hit for each row (from
+`references/discovery.md`) so the eventual implementer has the full blast
+radius.
+
+## Interactive decision 1 — backward compatibility
+
+For each renamed public alias, ask the user:
+
+- **Deprecated shim** — keep the old name as a thin alias that forwards to
+  the new one (per `command-design-pattern.md` §8), optionally emitting a
+  deprecation notice. Safer for muscle memory.
+- **Hard removal** — delete the old name outright. Cleaner, but breaks any
+  external scripts/muscle memory immediately.
+
+Record the chosen policy per name. Do not assume a default.
+
+## Interactive decision 2 — name collisions
+
+If a proposed new name already exists elsewhere (another alias, function, or
+PATH binary), surface the collision and ask how to resolve it (pick a
+different new name, or confirm the merge is intentional). Never silently
+overwrite.
+
+## Intentionally-dropped names
+
+List every name that will be **removed** (hard-removal choices, or obsolete
+names being retired) as an explicit "Removed / dropped" section — so the
+refactor issue's behavior-preservation review can account for each one.

--- a/claude/skills/devx-command-rename/references/repo-resolution.md
+++ b/claude/skills/devx-command-rename/references/repo-resolution.md
@@ -1,0 +1,40 @@
+# devx:command-rename — Repo resolution
+
+Substeps for Step 1 "resolve target family" — the remote → `owner/repo`
+resolution used before any `gh` call. Same pattern every skill in this repo
+uses; kept here so SKILL.md holds only the workflow.
+
+## Substeps
+
+1. `git rev-parse --show-toplevel` — confirm we are in a git repo.
+
+2. Determine the target remote:
+   - If the user passed a `[remote]` positional, use it.
+   - Otherwise default to `origin`.
+
+3. Validate the remote and resolve owner/repo:
+
+   ```bash
+   git remote get-url <remote-name>
+   ```
+
+   If this fails, list `git remote -v` and stop:
+
+   ```
+   Error: remote '<remote-name>' not found. Available remotes:
+   origin    https://github.com/user/repo.git (fetch)
+   upstream  https://github.com/org/repo.git (fetch)
+   ```
+
+4. Extract `owner/repo` from the URL:
+   - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
+   - `git@github.com:<owner>/<repo>.git` → `<owner>/<repo>`
+
+Store as `TARGET_REPO` and pass it through to `gh:issue-create` as the
+`[remote]` positional in Step 6.
+
+## Failure rule
+
+If the user-specified remote does not exist, fail immediately with the list
+of available remotes. **Never** silently fall back to `origin` — that masks
+typos and files the issue in the wrong repo.

--- a/claude/skills/devx-command-rename/references/repo-resolution.md
+++ b/claude/skills/devx-command-rename/references/repo-resolution.md
@@ -30,8 +30,10 @@ uses; kept here so SKILL.md holds only the workflow.
    - `https://github.com/<owner>/<repo>.git` → `<owner>/<repo>`
    - `git@github.com:<owner>/<repo>.git` → `<owner>/<repo>`
 
-Store as `TARGET_REPO` and pass it through to `gh:issue-create` as the
-`[remote]` positional in Step 6.
+Store as `TARGET_REPO` for use in this skill's own `gh` calls. `gh:issue-create`
+resolves its own repo context from a remote **name** (e.g. `origin`), not
+`owner/repo` — pass the original `[remote]` argument (not `TARGET_REPO`)
+through to it as the `[remote]` positional in Step 6.
 
 ## Failure rule
 

--- a/claude/skills/devx-command-rename/references/report-template.md
+++ b/claude/skills/devx-command-rename/references/report-template.md
@@ -1,0 +1,38 @@
+# devx:command-rename — Report (F-9)
+
+Print exactly one report block. No preamble, no design recap (that lives in
+the issue body).
+
+## Success — no rule gap
+
+```
+[OK] refactor issue #<N> created: <url>
+  family: <command-family>  ->  convention: <desired-convention>
+  renamed: <count> names   dropped: <count>   git-family excluded: gb, gwt
+Next: /gh:issue-flow <N>
+```
+
+## Success — with rule gap (docs issue + cross-link)
+
+```
+[OK] refactor issue #<N> created: <url>
+[OK] docs issue #<M> created: <url>   (rule gap: <convention> not in SSOT)
+  cross-linked: #<N> <-> #<M>
+Next: /gh:issue-flow <N>
+```
+
+## Failure
+
+```
+[FAIL] <what failed> (e.g. gh:issue-create returned non-zero / remote not found)
+<the error line>
+```
+
+## Rules
+
+- Always include every created issue's number **and** URL.
+- Always end the success path with a `Next:` hint pointing at
+  `/gh:issue-flow <refactor-issue-number>` (the refactor issue, not the docs
+  issue — the docs issue is authored separately).
+- Exactly one `[OK]`/`[FAIL]` verdict per created issue; a single `[FAIL]`
+  block on precondition failure.

--- a/claude/skills/devx-command-rename/references/ssot-check.md
+++ b/claude/skills/devx-command-rename/references/ssot-check.md
@@ -1,0 +1,37 @@
+# devx:command-rename — SSOT check & rule-gap detection (F-3 / F-4)
+
+Read all three naming SSOT docs, compare the requested convention against
+what they codify, and decide whether a **rule gap** exists. Cite each doc by
+path in the issue body. Never invent SSOT text — only report gaps.
+
+## Docs to read (cite all three by path)
+
+1. **`docs/.ssot/command-design-pattern.md`** — §1 naming table:
+   - public function → `snake_case`
+   - private sub-function → `_<prefix>_<verb>`
+   - public alias → **dash-form**
+   - help function → `_<prefix>_help` (inline) or `<topic>_help` + `<topic>-help` (standalone)
+   - §8 covers the deprecated-shim/backward-compat pattern (used in Step 5).
+
+2. **`docs/.ssot/command-guidelines.md`** — help UX: canonical `<topic>-help`
+   entry point, 15-line help budget, `ux_bullet` / `ux_bullet_sub` output.
+
+3. **`docs/.ssot/command-delivery-model.md`** — the function vs
+   PATH-executable delivery axis. **Out of scope** for a rename: the mapping
+   must not move a command across this axis. Read it only to avoid crossing
+   it by accident, then note "delivery model unchanged" in the issue.
+
+## Rule-gap detection
+
+A rule gap exists when the user's requested convention is **not literally
+covered** by an existing SSOT section.
+
+- If the request is "dash-form" for a public alias → covered by §1, **no gap**.
+- Example gap (true as of this writing): a request for an arbitrary
+  `<tool>-<noun>` naming scheme is **not** codified — there is currently **no
+  §1.1 or any section** formally defining a `<tool>-<noun>` convention beyond
+  the existing alias dash-form rule. That is a rule gap.
+
+On a gap: record it (which convention, which doc it would belong in) and
+trigger the `docs` issue in Step 6. Do **not** write proposed SSOT text into
+the SSOT — the `docs` issue is where that gets designed later.


### PR DESCRIPTION
## Summary
- 명명 리팩토링 요청을 받아 대상 탐색 → SSOT 대조 → 규칙갭 감지 → refactor(+docs) 이슈 생성까지 자동화하는 신규 스킬 `devx:command-rename` 추가

## Changes
- `claude/skills/devx-command-rename/SKILL.md`: 7단계 워크플로(입력파싱 → 탐색 → SSOT대조·갭감지 → git예외 → 매핑설계 → 이슈생성 → 리포트), `-h/--help` 지원, 94줄
- `references/discovery.md`: 정의(`shell-common/tools/integrations/*.sh`, `shell-common/functions/*.sh`) + 전 참조 지점(help/DOC 블록, `install_*.sh`, `my_help.sh`, `zz_help_standard_adapter.sh`, help 테스트, bats) 체크리스트, `gb`/`gwt` git 예외
- `references/ssot-check.md`: 명명 SSOT 3종(`command-design-pattern.md`, `command-guidelines.md`, `command-delivery-model.md`) 대조 + 규칙갭 판정 기준(현재 `<tool>-<noun>` 규칙 미명시 사례 포함)
- `references/mapping-design.md`: old→new 매핑 표 + 하위호환(deprecated shim vs 하드제거)·이름충돌 대화형 확인, 의도적 제거 목록
- `references/issue-creation.md`: `gh:issue-create` 재사용으로 refactor(+갭 시 docs) 이슈 생성 및 상호 링크
- `references/{help,repo-resolution,report-template,constraints}.md`: 사용법, remote 해석, 리포트 포맷, 제약사항

## Test plan
- [x] pre-commit 훅 통과 확인
- [x] 마크다운 전용 변경(신규 스킬 프롬프트 파일) — 기존 bash/python 로직 무변경, 셸 함수 신규 추가 없음
- [ ] `./tests/test` 전체 스위트 백그라운드 실행 중 확인 시작(부분 결과 모두 PASS, 완주 전 PR 오픈) — 완료 후 결과에 따라 후속 커밋 예정

## Related
Closes #1187

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~8 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~8 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
