### PR TITLE
refactor(agy): agy 명령 별칭을 agy-<명사> dash-form 으로 리네임

### DIFF
--- a/shell-common/functions/agy_help.sh
+++ b/shell-common/functions/agy_help.sh
@@ -35,7 +35,7 @@ _agy_help_rows_setup() {
 _agy_help_rows_tips() {
     ux_bullet "OAuth token stored in ~/.gemini/antigravity-cli/"
     ux_bullet "Use 'agy --help' for detailed CLI options"
-    ux_bullet "Model list changes often — use 'agy-models' instead of fixed aliases"
+    ux_bullet "Model list changes often — run 'agy models' directly rather than relying on the 'agy-models' alias"
     ux_bullet "agy install edits shell profiles; PATH SSOT is shell-common/env/path.sh"
     ux_bullet "Prefer: agy install --skip-path --skip-aliases"
 }

--- a/shell-common/functions/agy_help.sh
+++ b/shell-common/functions/agy_help.sh
@@ -7,8 +7,8 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 _agy_help_summary() {
     ux_info "Usage: agy-help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "basic: agyver | agyhelp | agyc | agyplan | agymodels"
-    ux_bullet_sub "setup: agy_install | agy_uninstall"
+    ux_bullet_sub "basic: agy-version | agy-continue | agy-plan | agy-models"
+    ux_bullet_sub "setup: agy-install | agy-uninstall"
     ux_bullet_sub "tips: OAuth token dir | agy install PATH conflict"
     ux_bullet_sub "details: agy-help <section>  (example: agy-help basic)"
 }
@@ -21,22 +21,21 @@ _agy_help_list_sections() {
 }
 
 _agy_help_rows_basic() {
-    ux_table_row "agyver" "agy --version" "Check version"
-    ux_table_row "agyhelp" "agy --help" "Show CLI help"
-    ux_table_row "agyc" "agy --continue" "Continue recent conversation"
-    ux_table_row "agyplan" "agy --mode plan" "Run in plan mode"
-    ux_table_row "agymodels" "agy models" "List available models"
+    ux_table_row "agy-version" "agy --version" "Check version"
+    ux_table_row "agy-continue" "agy --continue" "Continue recent conversation"
+    ux_table_row "agy-plan" "agy --mode plan" "Run in plan mode"
+    ux_table_row "agy-models" "agy models" "List available models"
 }
 
 _agy_help_rows_setup() {
-    ux_table_row "agy_install" "Install Script" "Install Antigravity CLI"
-    ux_table_row "agy_uninstall" "Uninstall Script" "Remove Antigravity CLI"
+    ux_table_row "agy-install" "Install Script" "Install Antigravity CLI"
+    ux_table_row "agy-uninstall" "Uninstall Script" "Remove Antigravity CLI"
 }
 
 _agy_help_rows_tips() {
     ux_bullet "OAuth token stored in ~/.gemini/antigravity-cli/"
-    ux_bullet "Use 'agyhelp' for detailed CLI options"
-    ux_bullet "Model list changes often — use 'agymodels' instead of fixed aliases"
+    ux_bullet "Use 'agy --help' for detailed CLI options"
+    ux_bullet "Model list changes often — use 'agy-models' instead of fixed aliases"
     ux_bullet "agy install edits shell profiles; PATH SSOT is shell-common/env/path.sh"
     ux_bullet "Prefer: agy install --skip-path --skip-aliases"
 }

--- a/shell-common/tools/integrations/agy.sh
+++ b/shell-common/tools/integrations/agy.sh
@@ -36,6 +36,8 @@ alias agy-continue='agy --continue'
 alias agy-plan='agy --mode plan'
 alias agy-models='agy models'
 alias agy-yolo='agy --dangerously-skip-permissions'
+alias agy-install='agy_install'
+alias agy-uninstall='agy_uninstall'
 
 # --- Functions ---
 
@@ -48,6 +50,3 @@ agy_install() {
 agy_uninstall() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/uninstall_agy.sh"
 }
-
-alias agy-install='agy_install'
-alias agy-uninstall='agy_uninstall'

--- a/shell-common/tools/integrations/agy.sh
+++ b/shell-common/tools/integrations/agy.sh
@@ -12,14 +12,14 @@ Antigravity CLI (agy) Dotfiles Helper - Getting Started
 1) 설치 (공식 스크립트)
 ------------------------
    curl -fsSL https://antigravity.google/cli/install.sh | bash
-   Use: agy_install   (runs interactive installation script)
-   Use: agy_uninstall (runs interactive uninstallation script)
+   Use: agy-install   (runs interactive installation script)
+   Use: agy-uninstall (runs interactive uninstallation script)
 
 2) 인증 / 사용
 ------------------------
    OAuth 토큰은 ~/.gemini/antigravity-cli/ 에 저장된다.
-   Use: agyhelp   (agy --help — 실제 CLI 옵션 확인)
-   Use: agymodels (agy models — 사용 가능한 모델 목록)
+   Use: agy --help (실제 CLI 옵션 확인)
+   Use: agy-models (agy models — 사용 가능한 모델 목록)
    Use: agy-yolo  (agy --dangerously-skip-permissions — codex-yolo 와 동일하게
                    승인/권한 확인을 건너뛴다. 신뢰된 로컬 작업에서만 사용할 것)
 
@@ -31,11 +31,10 @@ PATH SSOT 로 관리하므로, agy install 을 직접 쓸 때는
 AGY_DOC
 
 # --- Aliases (agy --help 로 확인된 실제 플래그 기반) ---
-alias agyver='agy --version'
-alias agyhelp='agy --help'
-alias agyc='agy --continue'
-alias agyplan='agy --mode plan'
-alias agymodels='agy models'
+alias agy-version='agy --version'
+alias agy-continue='agy --continue'
+alias agy-plan='agy --mode plan'
+alias agy-models='agy models'
 alias agy-yolo='agy --dangerously-skip-permissions'
 
 # --- Functions ---
@@ -49,3 +48,6 @@ agy_install() {
 agy_uninstall() {
     bash "${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}/tools/custom/uninstall_agy.sh"
 }
+
+alias agy-install='agy_install'
+alias agy-uninstall='agy_uninstall'


### PR DESCRIPTION
## Summary
- `agy` 명령 별칭을 축약형(`agyver`, `agyc`, `agyplan`, `agymodels`)에서 일관된 `agy-<명사>` dash-form 으로 리네임
- 함수만 있던 install/uninstall 에도 `agy-install`/`agy-uninstall` dash 별칭을 신규 노출
- 하위호환 shim 없이 구 별칭을 하드 제거 (`agyhelp` 는 `agy --help` 로 완전 대체되어 대체 별칭 없이 제거)

## Changes
- `refactor(agy)`: `shell-common/tools/integrations/agy.sh` — alias 정의부 리네임 + `AGY_DOC` 안내 주석 갱신 + `agy-install`/`agy-uninstall` 별칭 추가
- `refactor(agy)`: `shell-common/functions/agy_help.sh` — `agy-help` summary/basic/setup/tips 출력 텍스트를 신규 별칭 이름으로 교체

## Test plan
- [x] `shellcheck` — 두 수정 파일 모두 clean
- [x] 수동 소싱 검증 — `agy-version`/`agy-continue`/`agy-plan`/`agy-models`/`agy-install`/`agy-uninstall` 정상 동작, 구 별칭(`agyver`/`agyhelp`/`agyc`/`agyplan`/`agymodels`) 완전 제거 확인
- [x] `agy-help`, `agy-help basic` 출력이 신규 이름만 노출하는지 확인
- [ ] `pytest` 전체 스위트 — 샌드박스 리소스 경합으로 완주하지 못함(무관한 백그라운드 프로세스); 부분 실행분(`test_help_topics.py` 포함 ~950 케이스)에서 실패 없음. 리뷰 시 CI 결과로 최종 확인 필요

## Related
Closes #1185

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
