### PR TITLE
docs(claude): understand-anything 그래프 선탐색 인덱스 규칙 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,12 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 **On lint/test failure**: fix the root cause — do not use `--no-verify` or skip hooks.
 
+## Codebase Map (선탐색 인덱스)
+
+아키텍처/오리엔테이션/"X 어디 있나"/"Y가 뭘 호출하나" 류 질문은 소스 전체를 grep 하기 전에 `.understand-anything/knowledge-graph.json` 을 **먼저 grep-쿼리**한다 (노드 `summary`/`tags`/`edges` 만 슬라이스 — 파일 통독 금지, 약 1.1MB). 파일·함수 지도는 여기서 얻고, 정확한 코드 확인은 소스로 fallback 한다.
+
+**주의**: 그래프는 마지막 `/understand` 실행 시점 스냅샷 (`.understand-anything/meta.json` 의 `gitCommitHash`). 그 이후 변경된 파일은 드리프트 가능 — 소스가 최종 진실이다. 크게 어긋나면 `/understand` 재실행.
+
 ## Standards & References
 
 - 운영 교훈 지식 베이스: `docs/guide/learnings/` (반복 실수 예방용 패턴 모음)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
 ## Codebase Map (선탐색 인덱스)
 
-아키텍처/오리엔테이션/"X 어디 있나"/"Y가 뭘 호출하나" 류 질문은 소스 전체를 grep 하기 전에 `.understand-anything/knowledge-graph.json` 을 **먼저 grep-쿼리**한다 (노드 `summary`/`tags`/`edges` 만 슬라이스 — 파일 통독 금지, 약 1.1MB). 파일·함수 지도는 여기서 얻고, 정확한 코드 확인은 소스로 fallback 한다.
+아키텍처/오리엔테이션/"X 어디 있나"/"Y가 뭘 호출하나" 류 질문은 소스 전체를 grep 하기 전에 `.understand-anything/knowledge-graph.json` 을 **먼저 구조적으로 쿼리**한다 — 정밀 슬라이스는 `jq` 로 노드 `summary`/`tags`/`edges` 만 뽑고, 노드명 빠른 위치 확인은 grep 으로 (파일 통독 금지, 약 1.1MB). 파일·함수 지도는 여기서 얻고, 정확한 코드 확인은 소스로 fallback 한다.
 
 **주의**: 그래프는 마지막 `/understand` 실행 시점 스냅샷 (`.understand-anything/meta.json` 의 `gitCommitHash`). 그 이후 변경된 파일은 드리프트 가능 — 소스가 최종 진실이다. 크게 어긋나면 `/understand` 재실행.
 


### PR DESCRIPTION
## Summary
- understand-anything 지식 그래프를 코드베이스 선탐색 인덱스로 쓰는 규칙을 CLAUDE.md 에 명문화

## Changes
- docs(claude): 아키텍처/오리엔테이션/"X 어디 있나" 류 질문 시 소스 grep 전에 `.understand-anything/knowledge-graph.json` 을 먼저 grep-쿼리하도록 지시. 파일 통독 금지(약 1.1MB), 부족하면 소스로 fallback
- staleness 주의 명기: 그래프는 마지막 `/understand` 실행 스냅샷(`meta.json` 의 `gitCommitHash`) — 이후 변경 파일은 드리프트 가능, 소스가 최종 진실

## Test plan
- [x] 문서 전용 변경 — pre-commit 통과 확인
- [ ] 후속 세션에서 실제로 그래프 선탐색이 동작하는지 관찰

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
