### PR TITLE
fix(claude-plugin): publish-sync.sh가 net-zero 로컬 sync 커밋을 정리하지 않음

### DIFF
--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -304,45 +304,9 @@ _publish_manifest_diff() {
 	if ! _manifest_diff_exists "$repo_dir" "$@"; then
 		echo "${UX_MUTED}[$label] 변경 없음 — 할 일 없음${UX_RESET}"
 		# No content diff vs origin/main — but local `main` can still be stuck
-		# AHEAD by un-publishable commits. The plugin-sync hook auto-commits every
-		# manifest change on `main`, and branch protection then blocks the direct
-		# push. An add-then-revert within one session (e.g. `marketplace add X`
-		# then `remove X`) leaves TWO pure-sync commits whose COMBINED diff is
-		# exactly zero: un-pushable (protection), un-PR-able (empty diff → nothing
-		# to PR), and never tidied (the post-publish _cleanup runs only on the
-		# real-publish path, never reached here). Collapse them when provably safe.
+		# ahead by un-publishable no-op commits (see _collapse_stuck_sync_commits).
 		# Skipped under --dry-run, which must stay read-only (a reset would mutate).
-		if [ "${DRY_RUN:-0}" != "1" ]; then
-			local origin_sha ahead cur_branch
-			origin_sha=$(git -C "$repo_dir" rev-parse origin/main 2>/dev/null) || return 0
-			ahead=$(git -C "$repo_dir" rev-list --count "${origin_sha}..main" 2>/dev/null || echo 0)
-			if [ "${ahead:-0}" -gt 0 ]; then
-				# The reset is provably safe ONLY when purity holds AND the tree is
-				# clean: _manifest_diff_exists already proved current content ==
-				# origin/main, and purity proves the ahead commits touch nothing but
-				# the given files — so every dropped commit's content already exists
-				# in origin/main. This is the documented exception to the
-				# "never force-reset" invariant (see _cleanup_local_main_if_pure_sync).
-				if _ahead_commits_are_pure_sync "$repo_dir" "$origin_sha" "$@" &&
-					git -C "$repo_dir" diff --quiet && git -C "$repo_dir" diff --cached --quiet; then
-					cur_branch=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
-					if [ "$cur_branch" = "main" ]; then
-						git -C "$repo_dir" reset --hard origin/main >/dev/null 2>&1 || return 0
-					else
-						# main not checked out — move the ref without a reset,
-						# mirroring _cleanup_local_main_if_pure_sync's else-branch.
-						git -C "$repo_dir" branch -f main origin/main >/dev/null 2>&1 || return 0
-					fi
-					echo "${UX_SUCCESS}[$label] origin/main과 내용이 동일한 no-op 로컬 sync 커밋 ${ahead}개를 정리했습니다 (로컬 main을 origin/main으로 리셋)${UX_RESET}"
-				else
-					# Ahead commits exist but are not provably discardable — some are
-					# not pure sync commits, or the working tree is dirty. Never reset
-					# here; these can never auto-publish (empty diff → no PR, branch
-					# protection → no push), so the user must reconcile by hand.
-					echo "${UX_WARNING}[$label] 로컬 main이 origin/main보다 ${ahead}개 앞서 있으나 자동 게시할 수 없습니다 (sync 외 커밋이 섞였거나 워킹트리가 더럽습니다) — 'git rebase origin/main' 또는 'git reset --hard origin/main' 으로 직접 정리하세요${UX_RESET}" >&2
-				fi
-			fi
-		fi
+		[ "${DRY_RUN:-0}" = "1" ] || _collapse_stuck_sync_commits "$repo_dir" "$label" "$@" || true
 		return 0
 	fi
 	echo "${UX_MUTED}[$label] 변경 감지됨${UX_RESET}"
@@ -382,6 +346,41 @@ _publish_manifest_diff() {
 	return 0
 }
 
+# _repo_is_clean <repo_dir>
+#
+# Return 0 iff the working tree and index have no uncommitted changes vs HEAD.
+# Single `git diff-index` call rather than the two-call `diff --quiet &&
+# diff --cached --quiet` idiom — same combined check, one subprocess. Like its
+# two-call predecessor, this does not detect untracked files; that's fine for
+# every caller here, since neither `reset --hard` nor `rebase` touches
+# untracked files, so their presence can't turn either operation into data loss.
+_repo_is_clean() {
+	git -C "$1" diff-index --quiet HEAD --
+}
+
+# _repo_current_branch <repo_dir>
+#
+# Print the checked-out branch name, or empty on detached HEAD / error.
+_repo_current_branch() {
+	git -C "$1" symbolic-ref --short HEAD 2>/dev/null || echo ""
+}
+
+# _move_main_ref <repo_dir> <target_sha>
+#
+# Point local `main` at <target_sha> via `branch -f` — used whenever `main` is
+# NOT the currently checked-out branch (a plain ref move is always safe there;
+# no working tree to disturb). `branch -f` refuses to move a branch checked
+# out in another linked worktree; that failure is warned to stderr rather than
+# swallowed, since a linked worktree with `main` checked out elsewhere is the
+# realistic way this fails in practice.
+_move_main_ref() {
+	local repo_dir="$1" target="$2"
+	git -C "$repo_dir" branch -f main "$target" >/dev/null 2>&1 || {
+		echo "${UX_WARNING}publish-sync: 로컬 main ref 이동 실패 (다른 worktree에서 체크아웃 중일 수 있음) — 직접 확인하세요${UX_RESET}" >&2
+		return 1
+	}
+}
+
 # _ahead_commits_are_pure_sync <repo_dir> <origin_sha> <file...>
 #
 # Return 0 iff every commit local `main` is ahead of <origin_sha> by is a pure
@@ -389,8 +388,8 @@ _publish_manifest_diff() {
 # commit with a non-sync subject or a path outside <file...>. Factored out of
 # _cleanup_local_main_if_pure_sync so the identical purity rule is shared by
 # both the post-publish tidy (that function) and the no-diff/no-op stuck-commit
-# collapse in _publish_manifest_diff — the two must never drift on what counts
-# as "safe to discard".
+# collapse in _collapse_stuck_sync_commits — the two must never drift on what
+# counts as "safe to discard".
 _ahead_commits_are_pure_sync() {
 	local repo_dir="$1" origin_sha="$2"
 	shift 2
@@ -420,6 +419,50 @@ _ahead_commits_are_pure_sync() {
 	[ "$pure" -eq 1 ]
 }
 
+# _collapse_stuck_sync_commits <repo_dir> <label> <file...>
+#
+# Called from _publish_manifest_diff's no-diff/no-op branch. The plugin-sync
+# hook auto-commits every manifest change on `main`, and branch protection
+# blocks the direct push it then attempts. An add-then-revert within one
+# session (e.g. `marketplace add X` then `remove X`) leaves TWO pure-sync
+# commits whose COMBINED diff is exactly zero: un-pushable (protection),
+# un-PR-able (empty diff vs origin/main → nothing to PR), and never tidied by
+# _cleanup_local_main_if_pure_sync (that function only runs on the real-publish
+# path, never reached here). Collapse them when provably safe: the caller
+# already proved current content == origin/main (that's WHY this is the
+# no-diff branch); if every ahead commit is also a pure sync commit touching
+# only the given files, AND the tree is clean, then every dropped commit's
+# content is already reflected in origin/main and nothing is lost.
+#
+# This is the ONE narrow, documented exception to "never force-resets" (see
+# _cleanup_local_main_if_pure_sync, which keeps that property intact for its
+# own diverged/published case).
+_collapse_stuck_sync_commits() {
+	local repo_dir="$1" label="$2"
+	shift 2
+	local ahead cur_branch
+
+	ahead=$(git -C "$repo_dir" rev-list --count "origin/main..main" 2>/dev/null) || ahead=0
+	[ "$ahead" -gt 0 ] || return 0
+
+	if ! _ahead_commits_are_pure_sync "$repo_dir" "origin/main" "$@" || ! _repo_is_clean "$repo_dir"; then
+		# Ahead commits exist but are not provably discardable — some are not
+		# pure sync commits, or the working tree is dirty. Never reset here;
+		# these can never auto-publish (empty diff → no PR, branch protection →
+		# no push), so the user must reconcile by hand.
+		echo "${UX_WARNING}[$label] 로컬 main이 origin/main보다 ${ahead}개 앞서 있으나 자동 게시할 수 없습니다 (sync 외 커밋이 섞였거나 워킹트리가 더럽습니다) — 'git rebase origin/main' 또는 'git reset --hard origin/main' 으로 직접 정리하세요${UX_RESET}" >&2
+		return 0
+	fi
+
+	cur_branch=$(_repo_current_branch "$repo_dir")
+	if [ "$cur_branch" = "main" ]; then
+		git -C "$repo_dir" reset --hard origin/main >/dev/null 2>&1 || return 0
+	else
+		_move_main_ref "$repo_dir" origin/main || return 1
+	fi
+	echo "${UX_SUCCESS}[$label] origin/main과 내용이 동일한 no-op 로컬 sync 커밋 ${ahead}개를 정리했습니다 (로컬 main을 origin/main으로 리셋)${UX_RESET}"
+}
+
 # _cleanup_local_main_if_pure_sync <repo_dir> <before_origin_sha> <file...>
 #
 # After a successful publish, advance local main to the new origin/main IF
@@ -433,16 +476,9 @@ _ahead_commits_are_pure_sync() {
 # lost. Leaves main untouched with an explanatory message when the tree is
 # dirty, the rebase conflicts, or purity fails.
 #
-# Never force-resets — with ONE narrow, documented exception that lives NOT in
-# this function but in the no-diff/no-op branch of _publish_manifest_diff: that
-# path may `git reset --hard origin/main` local main, but ONLY when (a)
-# _manifest_diff_exists has already proven zero content diff vs origin/main, (b)
-# every ahead commit is a pure sync-message commit touching only the given files
-# (the same _ahead_commits_are_pure_sync check), and (c) the working tree is
-# clean. Under all three the reset only ever discards commits whose entire
-# content is already reflected in origin/main — never real unpublished work.
-# This function itself (the diverged/published case) keeps the never-force-reset
-# property intact.
+# Never force-resets — see _collapse_stuck_sync_commits for the one narrow,
+# documented exception (a different function, called from the no-diff/no-op
+# branch of _publish_manifest_diff, never from here).
 _cleanup_local_main_if_pure_sync() {
 	local repo_dir="$1" before_origin="$2"
 	shift 2
@@ -458,11 +494,11 @@ _cleanup_local_main_if_pure_sync() {
 		return 0
 	fi
 
-	cur_branch=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+	cur_branch=$(_repo_current_branch "$repo_dir")
 	if [ "$cur_branch" = "main" ]; then
 		if git -C "$repo_dir" merge --ff-only origin/main --quiet 2>/dev/null; then
 			: # local main was a strict ancestor — a plain fast-forward sufficed
-		elif git -C "$repo_dir" diff --quiet && git -C "$repo_dir" diff --cached --quiet; then
+		elif _repo_is_clean "$repo_dir"; then
 			# Diverged, but purity is already proven (pure=1) and the working
 			# tree is clean. Rebase onto the new origin/main: git's patch-id
 			# detection drops the now-redundant published sync commit (the manual
@@ -482,9 +518,7 @@ _cleanup_local_main_if_pure_sync() {
 			return 1
 		fi
 	else
-		# `branch -f` (not `update-ref`) refuses to move main if it's checked
-		# out in another linked worktree, avoiding a phantom diff there.
-		git -C "$repo_dir" branch -f main origin/main || return 1
+		_move_main_ref "$repo_dir" origin/main || return 1
 	fi
 	echo "${UX_SUCCESS}publish-sync: 로컬 main을 origin/main으로 정리했습니다${UX_RESET}"
 }

--- a/claude/plugin/publish-sync.sh
+++ b/claude/plugin/publish-sync.sh
@@ -303,6 +303,46 @@ _publish_manifest_diff() {
 
 	if ! _manifest_diff_exists "$repo_dir" "$@"; then
 		echo "${UX_MUTED}[$label] 변경 없음 — 할 일 없음${UX_RESET}"
+		# No content diff vs origin/main — but local `main` can still be stuck
+		# AHEAD by un-publishable commits. The plugin-sync hook auto-commits every
+		# manifest change on `main`, and branch protection then blocks the direct
+		# push. An add-then-revert within one session (e.g. `marketplace add X`
+		# then `remove X`) leaves TWO pure-sync commits whose COMBINED diff is
+		# exactly zero: un-pushable (protection), un-PR-able (empty diff → nothing
+		# to PR), and never tidied (the post-publish _cleanup runs only on the
+		# real-publish path, never reached here). Collapse them when provably safe.
+		# Skipped under --dry-run, which must stay read-only (a reset would mutate).
+		if [ "${DRY_RUN:-0}" != "1" ]; then
+			local origin_sha ahead cur_branch
+			origin_sha=$(git -C "$repo_dir" rev-parse origin/main 2>/dev/null) || return 0
+			ahead=$(git -C "$repo_dir" rev-list --count "${origin_sha}..main" 2>/dev/null || echo 0)
+			if [ "${ahead:-0}" -gt 0 ]; then
+				# The reset is provably safe ONLY when purity holds AND the tree is
+				# clean: _manifest_diff_exists already proved current content ==
+				# origin/main, and purity proves the ahead commits touch nothing but
+				# the given files — so every dropped commit's content already exists
+				# in origin/main. This is the documented exception to the
+				# "never force-reset" invariant (see _cleanup_local_main_if_pure_sync).
+				if _ahead_commits_are_pure_sync "$repo_dir" "$origin_sha" "$@" &&
+					git -C "$repo_dir" diff --quiet && git -C "$repo_dir" diff --cached --quiet; then
+					cur_branch=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+					if [ "$cur_branch" = "main" ]; then
+						git -C "$repo_dir" reset --hard origin/main >/dev/null 2>&1 || return 0
+					else
+						# main not checked out — move the ref without a reset,
+						# mirroring _cleanup_local_main_if_pure_sync's else-branch.
+						git -C "$repo_dir" branch -f main origin/main >/dev/null 2>&1 || return 0
+					fi
+					echo "${UX_SUCCESS}[$label] origin/main과 내용이 동일한 no-op 로컬 sync 커밋 ${ahead}개를 정리했습니다 (로컬 main을 origin/main으로 리셋)${UX_RESET}"
+				else
+					# Ahead commits exist but are not provably discardable — some are
+					# not pure sync commits, or the working tree is dirty. Never reset
+					# here; these can never auto-publish (empty diff → no PR, branch
+					# protection → no push), so the user must reconcile by hand.
+					echo "${UX_WARNING}[$label] 로컬 main이 origin/main보다 ${ahead}개 앞서 있으나 자동 게시할 수 없습니다 (sync 외 커밋이 섞였거나 워킹트리가 더럽습니다) — 'git rebase origin/main' 또는 'git reset --hard origin/main' 으로 직접 정리하세요${UX_RESET}" >&2
+				fi
+			fi
+		fi
 		return 0
 	fi
 	echo "${UX_MUTED}[$label] 변경 감지됨${UX_RESET}"
@@ -342,38 +382,29 @@ _publish_manifest_diff() {
 	return 0
 }
 
-# _cleanup_local_main_if_pure_sync <repo_dir> <before_origin_sha> <file...>
+# _ahead_commits_are_pure_sync <repo_dir> <origin_sha> <file...>
 #
-# After a successful publish, advance local main to the new origin/main IF
-# every commit main was ahead of before_origin_sha by is a pure SYNC_MSG
-# commit touching only the given files. Fast-forwards when local main is a
-# strict ancestor; otherwise (main diverged because the PR-merged sync
-# commit landed with a different SHA than the hook's local one — the usual
-# case) rebases onto origin/main, but only when the working tree is clean —
-# git's patch-id detection drops the redundant published commit while
-# replaying any pure-sync commit whose content never landed, so nothing is
-# lost. Leaves main untouched with an explanatory message when the tree is
-# dirty, the rebase conflicts, or purity fails. Never force-resets.
-_cleanup_local_main_if_pure_sync() {
-	local repo_dir="$1" before_origin="$2"
+# Return 0 iff every commit local `main` is ahead of <origin_sha> by is a pure
+# SYNC_MSG commit that touches only the given files; return 1 on the first
+# commit with a non-sync subject or a path outside <file...>. Factored out of
+# _cleanup_local_main_if_pure_sync so the identical purity rule is shared by
+# both the post-publish tidy (that function) and the no-diff/no-op stuck-commit
+# collapse in _publish_manifest_diff — the two must never drift on what counts
+# as "safe to discard".
+_ahead_commits_are_pure_sync() {
+	local repo_dir="$1" origin_sha="$2"
 	shift 2
-	local sha msg f pure=1 match want cur_branch
-
-	_fetch_origin "$repo_dir" || {
-		echo "${UX_ERROR}publish-sync: 정리 단계 fetch 실패 (재시도 후) — 로컬 main은 그대로 둡니다${UX_RESET}" >&2
-		return 1
-	}
-
-	for sha in $(git -C "$repo_dir" rev-list "${before_origin}..main" 2>/dev/null); do
+	local sha msg f match want pure=1
+	for sha in $(git -C "$repo_dir" rev-list "${origin_sha}..main" 2>/dev/null); do
 		msg=$(git -C "$repo_dir" log -1 --format=%s "$sha")
 		if [ "$msg" != "$SYNC_MSG" ]; then
 			pure=0
 			break
 		fi
-		# `git show --name-only` is newline-delimited; read line-by-line via
-		# process substitution (keeps the loop in this shell so `break 2` still
-		# escapes the outer rev-list loop) so a path containing spaces isn't
-		# word-split into false mismatches.
+		# `git show --name-only` is newline-delimited; read line-by-line (keeps
+		# the loop in this shell so `break 2` still escapes the outer rev-list
+		# loop) so a path containing spaces isn't word-split into false
+		# mismatches.
 		while IFS= read -r f; do
 			[ -n "$f" ] || continue
 			match=0
@@ -386,8 +417,43 @@ _cleanup_local_main_if_pure_sync() {
 			}
 		done < <(git -C "$repo_dir" show --format= --name-only "$sha")
 	done
+	[ "$pure" -eq 1 ]
+}
 
-	if [ "$pure" -ne 1 ]; then
+# _cleanup_local_main_if_pure_sync <repo_dir> <before_origin_sha> <file...>
+#
+# After a successful publish, advance local main to the new origin/main IF
+# every commit main was ahead of before_origin_sha by is a pure SYNC_MSG
+# commit touching only the given files. Fast-forwards when local main is a
+# strict ancestor; otherwise (main diverged because the PR-merged sync
+# commit landed with a different SHA than the hook's local one — the usual
+# case) rebases onto origin/main, but only when the working tree is clean —
+# git's patch-id detection drops the redundant published commit while
+# replaying any pure-sync commit whose content never landed, so nothing is
+# lost. Leaves main untouched with an explanatory message when the tree is
+# dirty, the rebase conflicts, or purity fails.
+#
+# Never force-resets — with ONE narrow, documented exception that lives NOT in
+# this function but in the no-diff/no-op branch of _publish_manifest_diff: that
+# path may `git reset --hard origin/main` local main, but ONLY when (a)
+# _manifest_diff_exists has already proven zero content diff vs origin/main, (b)
+# every ahead commit is a pure sync-message commit touching only the given files
+# (the same _ahead_commits_are_pure_sync check), and (c) the working tree is
+# clean. Under all three the reset only ever discards commits whose entire
+# content is already reflected in origin/main — never real unpublished work.
+# This function itself (the diverged/published case) keeps the never-force-reset
+# property intact.
+_cleanup_local_main_if_pure_sync() {
+	local repo_dir="$1" before_origin="$2"
+	shift 2
+	local cur_branch
+
+	_fetch_origin "$repo_dir" || {
+		echo "${UX_ERROR}publish-sync: 정리 단계 fetch 실패 (재시도 후) — 로컬 main은 그대로 둡니다${UX_RESET}" >&2
+		return 1
+	}
+
+	if ! _ahead_commits_are_pure_sync "$repo_dir" "$before_origin" "$@"; then
 		echo "${UX_WARNING}publish-sync: 로컬 main에 sync 외 다른 커밋이 섞여 있어 정리를 건너뜁니다 — 직접 확인하세요${UX_RESET}" >&2
 		return 0
 	fi

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -629,6 +629,36 @@ STUB
     assert_equal "$(git -C "$REPO" rev-parse main)" "$LOCAL_HEAD"
 }
 
+@test "_publish_manifest_diff warns instead of silently no-oping when main is checked out in another worktree" {
+    # codex review (PR #1211) BLOCKER: when main isn't checked out here, the
+    # collapse falls to `git branch -f main origin/main`, which git refuses
+    # when main is checked out in ANOTHER linked worktree — that failure must
+    # be warned, not swallowed silently.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{}'
+    LOCAL_MAIN_BEFORE=$(git -C "$REPO" rev-parse main)
+
+    # Move $REPO off main first (worktree add refuses a branch already
+    # checked out in the worktree you're adding from), then check main out in
+    # a second linked worktree so `branch -f main ...` from $REPO fails.
+    git -C "$REPO" checkout -q -b other-branch
+    OTHER_WT="$TEST_TEMP_HOME/repo-other-wt"
+    git -C "$REPO" worktree add -q "$OTHER_WT" main
+
+    DRY_RUN=0
+    run _publish_manifest_diff "$REPO" "public" claude/plugin/marketplaces.json claude/plugin/plugins.json
+    assert_success
+    assert_output --partial "변경 없음"
+    assert_output --partial "다른 worktree"
+    # main ref left untouched — the failed move must not be silently accepted
+    # as success (no "정리했습니다" success message either).
+    refute_output --partial "정리했습니다"
+    assert_equal "$(git -C "$REPO" rev-parse main)" "$LOCAL_MAIN_BEFORE"
+}
+
 @test "_publish_manifest_diff --dry-run prints the diff without pushing or opening a PR" {
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"

--- a/tests/bats/tools/claude_plugin_publish_sync.bats
+++ b/tests/bats/tools/claude_plugin_publish_sync.bats
@@ -549,6 +549,86 @@ STUB
     assert_output --partial "변경 없음"
 }
 
+@test "_publish_manifest_diff collapses net-zero stuck sync commits onto origin/main" {
+    # The real-world bug: the plugin-sync hook auto-commits an `add X` then a
+    # `remove X` as TWO separate pure-sync commits on main. Their combined diff
+    # vs origin/main is exactly zero, so nothing can ever be published — but
+    # branch protection blocked the direct push, so local main sits AHEAD by 2
+    # commits forever. The no-diff branch must recognize this and collapse main
+    # back onto origin/main.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+    ORIGIN_MAIN=$(git -C "$REPO" rev-parse origin/main)
+
+    # commit 1: add an entry; commit 2: revert it back to the seed content.
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{}'
+    # two distinct local commits ahead of origin, but net-zero content diff
+    assert_equal "$(git -C "$REPO" rev-list --count "${ORIGIN_MAIN}..main")" "2"
+
+    DRY_RUN=0
+    run _publish_manifest_diff "$REPO" "public" claude/plugin/marketplaces.json claude/plugin/plugins.json
+    assert_success
+    assert_output --partial "변경 없음"
+    assert_output --partial "정리했습니다"
+    # local main collapsed onto origin/main — the two no-op commits are gone.
+    assert_equal "$(git -C "$REPO" rev-parse main)" "$(git -C "$REPO" rev-parse origin/main)"
+}
+
+@test "_publish_manifest_diff does not reset stuck commits when the working tree is dirty" {
+    # Same net-zero stuck commits, but a dirty tree — the reset is only safe on
+    # a clean tree, so main must be left ahead and a warning shown. The dirty
+    # file must be a NON-manifest tracked file: dirtying a manifest file would
+    # instead make _manifest_diff_exists true and take the publish path entirely.
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+
+    # add a tracked non-manifest file to origin so we can dirty the tree later
+    # without creating a manifest diff vs origin/main.
+    echo "readme" >"$REPO/README.md"
+    git -C "$REPO" add README.md
+    git -C "$REPO" commit -q -m "seed readme"
+    git -C "$REPO" push -q origin main
+
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{}'
+    LOCAL_MAIN_BEFORE=$(git -C "$REPO" rev-parse main)
+
+    # dirty the tree via the non-manifest file
+    echo "uncommitted work" >"$REPO/README.md"
+
+    DRY_RUN=0
+    run _publish_manifest_diff "$REPO" "public" claude/plugin/marketplaces.json claude/plugin/plugins.json
+    assert_success
+    assert_output --partial "변경 없음"
+    assert_output --partial "직접 정리하세요"
+    # main NOT reset — still at its original ahead SHA
+    assert_equal "$(git -C "$REPO" rev-parse main)" "$LOCAL_MAIN_BEFORE"
+}
+
+@test "_publish_manifest_diff does not reset stuck commits when a non-sync commit is mixed in" {
+    # Net-zero pure-sync commits, but an unrelated non-sync commit is also ahead
+    # of origin/main. Purity fails, so the reset must be skipped and a warning
+    # shown — main left untouched. (Mirrors the _cleanup skip-on-mixed test.)
+    REPO="$TEST_TEMP_HOME/repo"
+    _seed_repo_with_origin "$REPO"
+
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{"anthropic-agent-skills": "anthropics/skills"}'
+    _commit_pure_sync_change "$REPO" claude/plugin/marketplaces.json '{}'
+    echo "unrelated change" >"$REPO/README.md"
+    git -C "$REPO" add README.md
+    git -C "$REPO" commit -q -m "docs: unrelated"
+    LOCAL_HEAD=$(git -C "$REPO" rev-parse HEAD)
+
+    DRY_RUN=0
+    run _publish_manifest_diff "$REPO" "public" claude/plugin/marketplaces.json claude/plugin/plugins.json
+    assert_success
+    assert_output --partial "변경 없음"
+    assert_output --partial "직접 정리하세요"
+    # main untouched
+    assert_equal "$(git -C "$REPO" rev-parse main)" "$LOCAL_HEAD"
+}
+
 @test "_publish_manifest_diff --dry-run prints the diff without pushing or opening a PR" {
     REPO="$TEST_TEMP_HOME/repo"
     _seed_repo_with_origin "$REPO"


### PR DESCRIPTION
## Summary
- `publish-sync.sh`가 origin과 콘텐츠상 완전히 동일한(net-zero) 로컬 sync 커밋을 정리하지 않아, add 후 즉시 remove 같은 시퀀스에서 로컬 `main`이 `origin/main`보다 영구히 ahead 상태로 남던 문제를 고침.

## Changes
- `claude/plugin/publish-sync.sh`: `_publish_manifest_diff`의 "변경 없음" 분기에 정리 경로 추가 — ahead 커밋이 전부 순수 `chore(claude-plugin): sync manifest` 커밋이고(신규 헬퍼 `_ahead_commits_are_pure_sync`로 검증) 워킹트리가 clean할 때만 로컬 `main`을 `origin/main`으로 리셋(또는 `main` 미체크아웃 시 ref만 이동). `_cleanup_local_main_if_pure_sync`는 purity 체크 로직을 공용 헬퍼로 위임하도록 리팩터링(동작 동일), 문서 주석에 "Never force-resets" 원칙의 유일한 예외를 명시.
- `tests/bats/tools/claude_plugin_publish_sync.bats`: 실제 버그 시나리오(add 후 revert = net-zero) 정리 테스트, dirty-tree 시 미정리 테스트, 무관 커밋 혼입 시 미정리 테스트 3건 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/claude_plugin_publish_sync.bats` — 44/44 통과
- [x] `shellcheck -x -e SC1090,SC1091 claude/plugin/publish-sync.sh` — clean
- [x] `shfmt -d claude/plugin/publish-sync.sh` (tabs, `claude/` 기본 스타일) — clean
- [x] `bash -n claude/plugin/publish-sync.sh` — OK

## Related
Closes #1210

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~2 h · 🤖 ~50 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~2 h · 🤖 ~50 min
<!-- /ai-metrics:gh-pr -->

</details>
