### PR TITLE
feat(karakeep-add): --list 생략 시 classify로 폴백해 경로 제안

### DIFF
--- a/claude/skills/karakeep-add/SKILL.md
+++ b/claude/skills/karakeep-add/SKILL.md
@@ -11,8 +11,10 @@ description: >-
   verifies membership after attaching. Respects the Company confidentiality
   boundary (refuses public/personal URLs into `Company` or its children).
   Sister skill of [[karakeep:classify]] — that one suggests a List (default
-  dry-run); this one performs the write. Accepts `<url> --list <path>` and
-  `-h`/`--help`/`help` to print usage.
+  dry-run); this one performs the write. Accepts `<url> --list <path>`; if
+  `--list` is omitted it delegates to [[karakeep:classify]] for a suggested
+  path and writes nothing (propose-then-confirm). Also `-h`/`--help`/`help`
+  to print usage.
 allowed-tools: Bash, Read
 metadata:
   model_recommendation:
@@ -38,9 +40,17 @@ has no create/attach methods. Idempotent end to end.
 
 ## Step 1: Parse Args + Load Env
 
-Positional `<url>`; required flag `--list <path>` (slash-delimited nesting).
-Missing either → print the usage pointer (`Run /karakeep-add -h for usage.`)
-and stop.
+Positional `<url>`; flag `--list <path>` (slash-delimited nesting).
+
+- Missing `<url>` → print the usage pointer (`Run /karakeep-add -h for
+  usage.`) and stop.
+- `<url>` present but `--list` omitted → **do not write.** Delegate to
+  `karakeep:classify` for a suggestion and stop:
+  `Skill(karakeep:classify, "<url>")`. That runs dry-run: it proposes a
+  best-fit List path and ends with the exact `karakeep:add <url> --list
+  <path>` command for the user to confirm. This skill only writes when the
+  user re-runs with an explicit `--list` (propose-then-confirm — never
+  auto-apply the guess).
 
 Load `NEXTAUTH_URL` and `KARAKEEP_API_KEY` from the working directory's
 `.env` per `references/rest-mechanics.md` → "Env + base URL". If either is

--- a/claude/skills/karakeep-add/references/help.md
+++ b/claude/skills/karakeep-add/references/help.md
@@ -5,7 +5,7 @@
 | Token | Default | Description |
 |-------|---------|-------------|
 | `<url>` | — | The URL to bookmark (required). |
-| `--list <path>` | — | Target List, slash-nested e.g. `github/repository` (required). |
+| `--list <path>` | — | Target List, slash-nested e.g. `github/repository`. Omit to get a `karakeep:classify` suggestion (propose-then-confirm; nothing is written). |
 | `-h` / `--help` / `help` | — | Print this help and stop. |
 
 ## Usage
@@ -14,6 +14,9 @@
   — create the `github` → `repository` path if missing, bookmark the URL,
   attach it, and verify membership.
 - `/karakeep-add <url> --list reading/longform` — nested two levels deep.
+- `/karakeep-add <url>` — no `--list`: delegates to `karakeep:classify` for a
+  suggested path and stops (writes nothing). Re-run with the suggested
+  `--list` to actually add.
 - `/karakeep-add -h` — print this help.
 
 ## What the skill does


### PR DESCRIPTION
## 요약

`karakeep:add`를 `--list` 없이 실행했을 때의 동작을 **propose-then-confirm**으로 바꾼다.

- 기존: `--list`가 없으면 usage 안내만 출력하고 정지.
- 변경: `<url>`만 주어지면 `karakeep:classify`(dry-run)로 위임해 best-fit List 경로를 **제안**하고 정지. 사용자가 제안받은 `--list`로 재실행할 때만 실제 write가 일어난다.

## 왜

- 오분류를 곧장 기록하지 않도록 사용자 확인 단계를 강제 (자동 적용이 아닌 제안 방식).
- `classify=판단` / `add=쓰기`의 역할 분리를 유지 — `add`는 자체 write 로직 없이 classify에 위임만 한다.

## 변경 파일

- `claude/skills/karakeep-add/SKILL.md` — Step 1 인자 분기를 두 갈래(`<url>` 자체 누락 vs `--list`만 누락)로 분리, frontmatter description 갱신.
- `claude/skills/karakeep-add/references/help.md` — 인자 표·usage 예시를 `--list` optional 동작에 맞춰 갱신.

## 동작 흐름

```
karakeep:add <URL>                 # --list 없음 → classify 제안, write 없음
   ↓ (사용자가 제안 확인)
karakeep:add <URL> --list <path>   # 제안받은 경로로 실제 추가
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
