### PR TITLE
feat(gcp-scan): 경로 기반 skip 메커니즘으로 sync manifest whack-a-mole 해소

### DIFF
--- a/git/config/gcp-scan-skip-paths.conf
+++ b/git/config/gcp-scan-skip-paths.conf
@@ -1,0 +1,38 @@
+# git/config/gcp-scan-skip-paths.conf
+#
+# Path-based skip list for `gcp scan` (path-excluded bucket).
+#
+# Companion to the SHA-based gcp-scan-skip.conf, solving a DIFFERENT problem.
+# The SHA list silences ONE specific commit; a path never changes, so this
+# list silences a whole CLASS of commits by their changed-file-set — no matter
+# how many new SHAs the class spawns.
+#
+# Motivating case: `claude/hooks/plugin-sync.sh` auto-commits
+# `chore(claude-plugin): sync manifest` every time a Claude plugin is
+# installed/removed. It touches ONLY the manifest files below, which record
+# which plugins are installed on THIS machine (SSOT is the machine-local,
+# non-git-tracked ~/.claude-shared/plugins/ — see claude/plugin/reconcile.sh).
+# Upstream's machine and this one have divergent plugin sets by design and were
+# never meant to converge, so every install produces a NEW commit with a NEW
+# SHA and this exact subject. Registering each SHA in gcp-scan-skip.conf is a
+# whack-a-mole; a PATH allowlist stops it at the root.
+#
+# Matching rule: a commit is skipped as "path-excluded" when its changed-file
+# set is NON-EMPTY and EVERY changed path exactly matches one entry below. A
+# commit that also touches any other file still surfaces (it carries real,
+# unrelated content).
+#
+# Format: one LITERAL path per line; everything after `#` is a free-text
+# reason. Entries are compared by string EQUALITY — glob metacharacters
+# (`*`, `?`, `[`) are NOT interpreted, so a stray `*` cannot match every file.
+#
+# Notes:
+#   - The list is IGNORED under `gcp scan --author=all` so full detection
+#     (the safety net) is never silenced.
+#   - View the active list with `gcp scan --show-skip-paths`.
+#   - Override the file path with the GCP_SCAN_SKIP_PATHS_FILE env var.
+
+claude/plugin/marketplaces.json          # claude-plugin-sync manifest (machine-local plugin set)
+claude/plugin/plugins.json               # claude-plugin-sync manifest (machine-local plugin set)
+claude/plugin/company/marketplaces.json  # claude-plugin-sync manifest (company scope; may not exist)
+claude/plugin/company/plugins.json       # claude-plugin-sync manifest (company scope; may not exist)

--- a/git/config/gcp-scan-skip-paths.conf
+++ b/git/config/gcp-scan-skip-paths.conf
@@ -25,6 +25,9 @@
 # Format: one LITERAL path per line; everything after `#` is a free-text
 # reason. Entries are compared by string EQUALITY — glob metacharacters
 # (`*`, `?`, `[`) are NOT interpreted, so a stray `*` cannot match every file.
+# Limitation: a tracked path containing a literal `#` cannot be registered
+# here (the `#` and everything after it is always parsed as the comment) —
+# same constraint as the sibling gcp-scan-skip.conf's SHA format.
 #
 # Notes:
 #   - The list is IGNORED under `gcp scan --author=all` so full detection

--- a/shell-common/functions/gcp.sh
+++ b/shell-common/functions/gcp.sh
@@ -184,6 +184,8 @@ _gcp_help_rows_scan() {
     ux_table_row "behavior" "contiguous range -> bulk cherry-pick" "Non-contiguous -> individual"
     ux_table_row "--show-skip-list" "print known-resolved SHAs" "git/config/gcp-scan-skip.conf (issue #1039)"
     ux_table_row "skip list" "registered SHAs skipped silently" "ignored under --author=all"
+    ux_table_row "--show-skip-paths" "print path-excluded paths" "git/config/gcp-scan-skip-paths.conf"
+    ux_table_row "skip paths" "commits touching only listed paths skipped" "ignored under --author=all"
 }
 
 _gcp_help_rows_theirs() {

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -443,19 +443,26 @@ _gcp_scan_skip_file() {
     printf '%s/git/config/gcp-scan-skip.conf\n' "$top"
 }
 
+_gcp_scan_clean_token() {
+    # Shared line-cleaning for the skip-list parsers below: drop an inline
+    # `#` comment, then trim leading/trailing whitespace. Pure
+    # parameter-expansion (no awk/sed fork), matching this file's style.
+    local token="${1%%#*}"                         # drop inline comment
+    token=${token%"${token##*[![:space:]]}"}       # trim trailing space
+    token=${token#"${token%%[![:space:]]*}"}       # trim leading space
+    printf '%s\n' "$token"
+}
+
 _gcp_scan_load_skip_list() {
     # Parse the known-resolved skip-list file (issue #1039) into one cleaned
     # SHA token per line. Each line is `<sha> [# free-text reason]`; inline
-    # comments, full-comment lines, and blank lines are stripped. Pure
-    # parameter-expansion parsing (no awk/sed fork), matching this file's style.
+    # comments, full-comment lines, and blank lines are stripped.
     local file line token
     file=$(_gcp_scan_skip_file)
     [ -f "$file" ] || return 0
     # `|| [ -n "$line" ]` flushes a final newline-less line (POSIX read idiom).
     while IFS= read -r line || [ -n "$line" ]; do
-        token=${line%%#*}                              # drop inline comment
-        token=${token%"${token##*[![:space:]]}"}       # trim trailing space
-        token=${token#"${token%%[![:space:]]*}"}       # trim leading space
+        token=$(_gcp_scan_clean_token "$line")
         [ -z "$token" ] && continue
         # Hardening (gemini PR #1040 review): the token is later used UNESCAPED
         # as a `case` glob in _gcp_scan_in_skip_list ("$tok"*), so a stray `*`,
@@ -489,43 +496,54 @@ EOF
     return 1
 }
 
+_gcp_scan_show_skip_generic() {
+    # Shared renderer behind --show-skip-list (issue #1039) and
+    # --show-skip-paths (issue #1215): section title, resolved file path, and
+    # every registered entry. $1=title $2=file $3=entries $4=no-file-message
+    # $5=no-entries-message.
+    local title="$1" file="$2" entries="$3" no_file_msg="$4" no_entries_msg="$5"
+    if type ux_section >/dev/null 2>&1; then
+        ux_section "$title"
+        ux_bullet "File: $file"
+    else
+        echo "=== $title ==="
+        echo "  File: $file"
+    fi
+    if [ ! -f "$file" ]; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "$no_file_msg"
+        else
+            echo "  $no_file_msg"
+        fi
+        return 0
+    fi
+    if [ -z "$entries" ]; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "$no_entries_msg"
+        else
+            echo "  $no_entries_msg"
+        fi
+        return 0
+    fi
+    printf '%s\n' "$entries" | while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        if type ux_bullet >/dev/null 2>&1; then
+            ux_bullet "$entry"
+        else
+            echo "  $entry"
+        fi
+    done
+}
+
 _gcp_scan_show_skip_list() {
     # Render the current known-resolved skip list for `gcp scan --show-skip-list`
     # (issue #1039): the resolved file path plus every registered SHA token.
     local file entries
     file=$(_gcp_scan_skip_file)
     entries=$(_gcp_scan_load_skip_list)
-    if type ux_section >/dev/null 2>&1; then
-        ux_section "Known-resolved skip list"
-        ux_bullet "File: $file"
-    else
-        echo "=== Known-resolved skip list ==="
-        echo "  File: $file"
-    fi
-    if [ ! -f "$file" ]; then
-        if type ux_info >/dev/null 2>&1; then
-            ux_info "(no skip-list file — nothing registered)"
-        else
-            echo "  (no skip-list file — nothing registered)"
-        fi
-        return 0
-    fi
-    if [ -z "$entries" ]; then
-        if type ux_info >/dev/null 2>&1; then
-            ux_info "(file present but no SHAs registered)"
-        else
-            echo "  (file present but no SHAs registered)"
-        fi
-        return 0
-    fi
-    printf '%s\n' "$entries" | while IFS= read -r tok; do
-        [ -z "$tok" ] && continue
-        if type ux_bullet >/dev/null 2>&1; then
-            ux_bullet "$tok"
-        else
-            echo "  $tok"
-        fi
-    done
+    _gcp_scan_show_skip_generic "Known-resolved skip list" "$file" "$entries" \
+        "(no skip-list file — nothing registered)" \
+        "(file present but no SHAs registered)"
 }
 
 _gcp_scan_skip_paths_file() {
@@ -547,19 +565,17 @@ _gcp_scan_skip_paths_file() {
 _gcp_scan_load_skip_paths() {
     # Parse the path-excluded skip-list file (issue #1215) into one cleaned
     # LITERAL path per line. Each line is `<path> [# free-text reason]`; inline
-    # comments, full-comment lines, and blank lines are stripped. Pure
-    # parameter-expansion parsing (no awk/sed fork). Mirrors
-    # _gcp_scan_load_skip_list() but does NOT validate/reject glob characters:
-    # the path matcher is string-EQUALITY (not a `case` glob), so a stray `*`
-    # is harmless — it simply matches nothing.
+    # comments, full-comment lines, and blank lines are stripped. Shares
+    # _gcp_scan_clean_token() with _gcp_scan_load_skip_list() but does NOT
+    # validate/reject glob characters: the path matcher is string-EQUALITY
+    # (not a `case` glob), so a stray `*` is harmless — it simply matches
+    # nothing.
     local file line token
     file=$(_gcp_scan_skip_paths_file)
     [ -f "$file" ] || return 0
     # `|| [ -n "$line" ]` flushes a final newline-less line (POSIX read idiom).
     while IFS= read -r line || [ -n "$line" ]; do
-        token=${line%%#*}                              # drop inline comment
-        token=${token%"${token##*[![:space:]]}"}       # trim trailing space
-        token=${token#"${token%%[![:space:]]*}"}       # trim leading space
+        token=$(_gcp_scan_clean_token "$line")
         [ -z "$token" ] && continue
         printf '%s\n' "$token"
     done <"$file"
@@ -607,41 +623,12 @@ EOF
 _gcp_scan_show_skip_paths() {
     # Render the current path-excluded skip list for `gcp scan --show-skip-paths`
     # (issue #1215): the resolved file path plus every registered literal path.
-    # Mirrors _gcp_scan_show_skip_list().
     local file entries
     file=$(_gcp_scan_skip_paths_file)
     entries=$(_gcp_scan_load_skip_paths)
-    if type ux_section >/dev/null 2>&1; then
-        ux_section "Path-excluded skip list"
-        ux_bullet "File: $file"
-    else
-        echo "=== Path-excluded skip list ==="
-        echo "  File: $file"
-    fi
-    if [ ! -f "$file" ]; then
-        if type ux_info >/dev/null 2>&1; then
-            ux_info "(no skip-paths file — nothing registered)"
-        else
-            echo "  (no skip-paths file — nothing registered)"
-        fi
-        return 0
-    fi
-    if [ -z "$entries" ]; then
-        if type ux_info >/dev/null 2>&1; then
-            ux_info "(file present but no paths registered)"
-        else
-            echo "  (file present but no paths registered)"
-        fi
-        return 0
-    fi
-    printf '%s\n' "$entries" | while IFS= read -r entry; do
-        [ -z "$entry" ] && continue
-        if type ux_bullet >/dev/null 2>&1; then
-            ux_bullet "$entry"
-        else
-            echo "  $entry"
-        fi
-    done
+    _gcp_scan_show_skip_generic "Path-excluded skip list" "$file" "$entries" \
+        "(no skip-paths file — nothing registered)" \
+        "(file present but no paths registered)"
 }
 
 _gcp_scan() {

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -528,6 +528,122 @@ _gcp_scan_show_skip_list() {
     done
 }
 
+_gcp_scan_skip_paths_file() {
+    # Resolve the path-excluded skip-list file path (issue #1215). Honors the
+    # GCP_SCAN_SKIP_PATHS_FILE override (absolute or cwd-relative); otherwise
+    # defaults to <repo-toplevel>/git/config/gcp-scan-skip-paths.conf so the
+    # list is a tracked SSOT alongside the SHA-based gcp-scan-skip.conf. Prints
+    # the path (it may not exist yet — callers must -f check). Mirrors
+    # _gcp_scan_skip_file().
+    if [ -n "${GCP_SCAN_SKIP_PATHS_FILE-}" ]; then
+        printf '%s\n' "$GCP_SCAN_SKIP_PATHS_FILE"
+        return 0
+    fi
+    local top
+    top=$(git rev-parse --show-toplevel 2>/dev/null) || top="."
+    printf '%s/git/config/gcp-scan-skip-paths.conf\n' "$top"
+}
+
+_gcp_scan_load_skip_paths() {
+    # Parse the path-excluded skip-list file (issue #1215) into one cleaned
+    # LITERAL path per line. Each line is `<path> [# free-text reason]`; inline
+    # comments, full-comment lines, and blank lines are stripped. Pure
+    # parameter-expansion parsing (no awk/sed fork). Mirrors
+    # _gcp_scan_load_skip_list() but does NOT validate/reject glob characters:
+    # the path matcher is string-EQUALITY (not a `case` glob), so a stray `*`
+    # is harmless — it simply matches nothing.
+    local file line token
+    file=$(_gcp_scan_skip_paths_file)
+    [ -f "$file" ] || return 0
+    # `|| [ -n "$line" ]` flushes a final newline-less line (POSIX read idiom).
+    while IFS= read -r line || [ -n "$line" ]; do
+        token=${line%%#*}                              # drop inline comment
+        token=${token%"${token##*[![:space:]]}"}       # trim trailing space
+        token=${token#"${token%%[![:space:]]*}"}       # trim leading space
+        [ -z "$token" ] && continue
+        printf '%s\n' "$token"
+    done <"$file"
+}
+
+_gcp_scan_path_in_list() {
+    # True (0) when candidate path $1 EXACTLY equals one of the allowlist paths
+    # in $2 (newline-separated). Deliberately a string-equality test
+    # ([ "$cand" = "$entry" ]), NEVER a `case` glob like the SHA matcher's
+    # intentional prefix-glob: a path allowlist must match literally so a stray
+    # `*`/`?`/`[` in the config cannot over-match every file (the glob-over-match
+    # bug class gemini PR #1040 flagged for the SHA matcher). Mirrors the no-fork
+    # here-doc read style.
+    local cand="$1" entry
+    while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        if [ "$cand" = "$entry" ]; then
+            return 0
+        fi
+    done <<EOF
+$2
+EOF
+    return 1
+}
+
+_gcp_scan_is_path_excluded() {
+    # True (0) when commit $1's full changed-file set is NON-EMPTY and EVERY
+    # changed path is in the allowlist $2 (issue #1215). A single miss (a file
+    # not in the allowlist) disqualifies the whole commit, so a commit carrying
+    # any real, unrelated content still surfaces. Uses `git diff-tree` for the
+    # complete changed-file set of the commit.
+    local sha="$1" paths="$2" file seen=0
+    while IFS= read -r file; do
+        [ -z "$file" ] && continue
+        seen=1
+        if ! _gcp_scan_path_in_list "$file" "$paths"; then
+            return 1
+        fi
+    done <<EOF
+$(git diff-tree --no-commit-id --name-only -r "$sha" 2>/dev/null)
+EOF
+    [ "$seen" -eq 1 ]
+}
+
+_gcp_scan_show_skip_paths() {
+    # Render the current path-excluded skip list for `gcp scan --show-skip-paths`
+    # (issue #1215): the resolved file path plus every registered literal path.
+    # Mirrors _gcp_scan_show_skip_list().
+    local file entries
+    file=$(_gcp_scan_skip_paths_file)
+    entries=$(_gcp_scan_load_skip_paths)
+    if type ux_section >/dev/null 2>&1; then
+        ux_section "Path-excluded skip list"
+        ux_bullet "File: $file"
+    else
+        echo "=== Path-excluded skip list ==="
+        echo "  File: $file"
+    fi
+    if [ ! -f "$file" ]; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "(no skip-paths file — nothing registered)"
+        else
+            echo "  (no skip-paths file — nothing registered)"
+        fi
+        return 0
+    fi
+    if [ -z "$entries" ]; then
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "(file present but no paths registered)"
+        else
+            echo "  (file present but no paths registered)"
+        fi
+        return 0
+    fi
+    printf '%s\n' "$entries" | while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        if type ux_bullet >/dev/null 2>&1; then
+            ux_bullet "$entry"
+        else
+            echo "  $entry"
+        fi
+    done
+}
+
 _gcp_scan() {
     # zsh compatibility: emulate POSIX sh to ensure consistent behavior
     if [ -n "${ZSH_VERSION-}" ]; then
@@ -544,6 +660,7 @@ _gcp_scan() {
     local author="dEitY719"
     local arg1="" arg2=""
     local show_skip_list=0
+    local show_skip_paths=0
 
     # Check for incomplete cherry-pick
     if git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
@@ -583,6 +700,9 @@ _gcp_scan() {
         --show-skip-list)
             show_skip_list=1
             ;;
+        --show-skip-paths)
+            show_skip_paths=1
+            ;;
         *)
             # Store positional arguments without array syntax
             if [ -z "$arg1" ]; then
@@ -608,6 +728,16 @@ _gcp_scan() {
     # standalone query that works outside a configured base/source.
     if [ "$show_skip_list" -eq 1 ]; then
         _gcp_scan_show_skip_list
+        if [ $_xtrace_set -eq 1 ]; then
+            set -x
+        fi
+        return 0
+    fi
+
+    # --show-skip-paths (issue #1215): print the path-excluded skip list and
+    # return without scanning. Mirrors --show-skip-list above.
+    if [ "$show_skip_paths" -eq 1 ]; then
+        _gcp_scan_show_skip_paths
         if [ $_xtrace_set -eq 1 ]; then
             set -x
         fi
@@ -827,6 +957,44 @@ EOF
         count=$((count - known_resolved_count))
     fi
 
+    # Stage-1.4b: path-excluded skip list. Independent of and parallel to the
+    # SHA-based Stage-1.4 above: instead of matching a specific SHA, it matches
+    # a commit's whole changed-file SET against a path allowlist
+    # (git/config/gcp-scan-skip-paths.conf, override GCP_SCAN_SKIP_PATHS_FILE).
+    # A commit whose every changed file is in the allowlist (e.g. an
+    # auto-generated `chore(claude-plugin): sync manifest` touching only the
+    # machine-local plugin manifests) is silently dropped here — no per-SHA
+    # registration, so a class of ever-new SHAs stops being whack-a-mole. A
+    # commit that also touches any other file is left to surface (it carries
+    # real content). Like Stage-1.4 this is IGNORED under --author=all so the
+    # full detection safety net is never silenced.
+    local path_excluded_list="" path_excluded_count=0 pe_survivor_list=""
+    local skip_paths=""
+    if [ "$author_lc" != "all" ]; then
+        skip_paths=$(_gcp_scan_load_skip_paths)
+    fi
+    if [ -n "$skip_paths" ]; then
+        while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            if _gcp_scan_is_path_excluded "$sha" "$skip_paths" </dev/null; then
+                path_excluded_list="${path_excluded_list}${sha}
+"
+                path_excluded_count=$((path_excluded_count + 1))
+            else
+                if [ -z "$pe_survivor_list" ]; then
+                    pe_survivor_list="$sha"
+                else
+                    pe_survivor_list="${pe_survivor_list}
+${sha}"
+                fi
+            fi
+        done <<EOF
+$final_selected_list
+EOF
+        final_selected_list="$pe_survivor_list"
+        count=$((count - path_excluded_count))
+    fi
+
     # Stage-1.5: file-dependency pre-check (issue #1033). A candidate that
     # modifies/deletes a file absent from base — because the upstream commit
     # that creates it was filtered out (e.g. a non-author commit) and is not
@@ -954,6 +1122,9 @@ EOF
             if [ "$known_resolved_count" -gt 0 ]; then
                 printf "%s  ◆ Known-resolved (skipped): %d%s\n" "${UX_MUTED-}" "$known_resolved_count" "${UX_RESET-}"
             fi
+            if [ "$path_excluded_count" -gt 0 ]; then
+                printf "%s  ◆ Path-excluded (skipped): %d%s\n" "${UX_MUTED-}" "$path_excluded_count" "${UX_RESET-}"
+            fi
             if [ "$dep_missing_count" -gt 0 ]; then
                 printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
             fi
@@ -970,6 +1141,9 @@ EOF
             echo "  Duplicates (already applied): $duplicate_count"
             if [ "$known_resolved_count" -gt 0 ]; then
                 echo "  Known-resolved (skipped): $known_resolved_count"
+            fi
+            if [ "$path_excluded_count" -gt 0 ]; then
+                echo "  Path-excluded (skipped): $path_excluded_count"
             fi
             if [ "$dep_missing_count" -gt 0 ]; then
                 echo "  Dep-missing (skipped): $dep_missing_count"
@@ -1007,6 +1181,9 @@ EOF
         if [ "$known_resolved_count" -gt 0 ]; then
             printf "%s  ◆ Known-resolved (skipped): %d%s\n" "${UX_MUTED-}" "$known_resolved_count" "${UX_RESET-}"
         fi
+        if [ "$path_excluded_count" -gt 0 ]; then
+            printf "%s  ◆ Path-excluded (skipped): %d%s\n" "${UX_MUTED-}" "$path_excluded_count" "${UX_RESET-}"
+        fi
         if [ "$dep_missing_count" -gt 0 ]; then
             printf "%s  ◆ Dep-missing (skipped): %d%s\n" "${UX_MUTED-}" "$dep_missing_count" "${UX_RESET-}"
         fi
@@ -1026,6 +1203,9 @@ EOF
         fi
         if [ "$known_resolved_count" -gt 0 ]; then
             echo "  Known-resolved (skipped): $known_resolved_count"
+        fi
+        if [ "$path_excluded_count" -gt 0 ]; then
+            echo "  Path-excluded (skipped): $path_excluded_count"
         fi
         if [ "$dep_missing_count" -gt 0 ]; then
             echo "  Dep-missing (skipped): $dep_missing_count"
@@ -1091,8 +1271,27 @@ EOF
     local dep_skipped=0
     local conflict_skipped=0
     local kr_skipped=0
+    local pe_skipped=0
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
+
+        # Stage-1.4b path-excluded (issue #1215): silently skip — the Analysis
+        # phase already counted it; the user configured a path allowlist
+        # precisely to stop seeing this class of auto-generated commit. No log
+        # line here (that is the point); the summary's "(N skipped —
+        # path-excluded)" line is the only trace. Mirrors the known-resolved
+        # skip below.
+        local _in_pe=0
+        case "
+$path_excluded_list" in
+            *"
+$sha
+"*) _in_pe=1 ;;
+        esac
+        if [ "$_in_pe" -eq 1 ]; then
+            pe_skipped=$((pe_skipped + 1))
+            continue
+        fi
 
         # Stage-1.4 known-resolved (issue #1039): silently skip — the Analysis
         # phase already counted it and the user registered it precisely to stop
@@ -1209,6 +1408,9 @@ EOF
         if [ "$kr_skipped" -gt 0 ]; then
             ux_info "($kr_skipped commit(s) skipped — known-resolved)"
         fi
+        if [ "$pe_skipped" -gt 0 ]; then
+            ux_info "($pe_skipped commit(s) skipped — path-excluded)"
+        fi
         if [ "$dep_skipped" -gt 0 ]; then
             ux_info "($dep_skipped commit(s) skipped — file dependency missing in $base)"
         fi
@@ -1225,6 +1427,9 @@ EOF
         echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
         if [ "$kr_skipped" -gt 0 ]; then
             echo "  ($kr_skipped commit(s) skipped — known-resolved)"
+        fi
+        if [ "$pe_skipped" -gt 0 ]; then
+            echo "  ($pe_skipped commit(s) skipped — path-excluded)"
         fi
         if [ "$dep_skipped" -gt 0 ]; then
             echo "  ($dep_skipped commit(s) skipped — file dependency missing in $base)"

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1429,6 +1429,153 @@ FIXTURE
 }
 
 # ---------------------------------------------------------------------------
+# Issue #1215 — Stage-1.4b path-excluded skip list. A class of auto-generated
+# commits (e.g. `chore(claude-plugin): sync manifest`) touches ONLY the
+# machine-local plugin manifests, spawning an endless stream of new SHAs.
+# Rather than registering each SHA (whack-a-mole), a PATH allowlist
+# (git/config/gcp-scan-skip-paths.conf, override GCP_SCAN_SKIP_PATHS_FILE)
+# silently drops any commit whose whole changed-file SET is a subset of the
+# allowlist, counted under "Path-excluded (skipped)". A commit that also
+# touches any other file still surfaces. The list is IGNORED under
+# --author=all (full detection stays as a safety net). Independent of and
+# parallel to the SHA-based Stage-1.4.
+#
+# Fixture: main seeds both manifest files; source commit A modifies ONLY
+# claude/plugin/plugins.json (pure manifest sync — the path-excluded case);
+# source commit B adds an unrelated file AND modifies marketplaces.json (mixed
+# — must surface and apply cleanly onto main).
+# ---------------------------------------------------------------------------
+
+_gcp_pathskip_make_repo() {
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Me" GIT_AUTHOR_EMAIL="me@me" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        mkdir -p claude/plugin
+        printf 'v0\n' > claude/plugin/plugins.json
+        printf 'v0\n' > claude/plugin/marketplaces.json
+        git add claude/plugin/plugins.json claude/plugin/marketplaces.json \
+            && git commit -qm "init"
+        git checkout -q -b source
+        # Commit A: pure manifest sync — touches ONLY plugins.json.
+        printf 'v1\n' > claude/plugin/plugins.json \
+            && git add claude/plugin/plugins.json \
+            && git commit -qm "chore(claude-plugin): sync manifest"
+        # Commit B: mixed — an unrelated file plus a manifest edit.
+        echo real > unrelated.txt
+        printf 'v1\n' > claude/plugin/marketplaces.json
+        git add unrelated.txt claude/plugin/marketplaces.json \
+            && git commit -qm "feat: real change"
+        git checkout -q main
+        skipf="$repo/skip-paths.conf"
+        printf 'claude/plugin/plugins.json\nclaude/plugin/marketplaces.json\n' > "$skipf"
+        export GCP_SCAN_SKIP_PATHS_FILE="$skipf"
+FIXTURE
+}
+
+@test "bash: _gcp_scan_load_skip_paths private function exists" {
+    run_in_bash 'declare -f _gcp_scan_load_skip_paths >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "bash: _gcp_scan_is_path_excluded private function exists" {
+    run_in_bash 'declare -f _gcp_scan_is_path_excluded >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "scan path-skip: pure manifest-sync commit skipped silently as path-excluded" {
+    run_in_bash "
+        $(_gcp_pathskip_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # Counted as path-excluded in the Analysis Result.
+    assert_output --partial "Path-excluded (skipped): 1"
+    # The pure-manifest commit never surfaces — no subject, no conflict warning.
+    refute_output --partial "sync manifest"
+    refute_output --partial "CONFLICT"
+    refute_output --partial "Resolve and run"
+}
+
+@test "scan path-skip: manifest+unrelated commit is NOT skipped (surfaces and applies)" {
+    run_in_bash "
+        $(_gcp_pathskip_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=Me >/dev/null 2>&1
+        git cat-file -e HEAD:unrelated.txt && echo HAS_UNRELATED
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    # The mixed commit was applied — its unrelated file is now in HEAD.
+    assert_output --partial "HAS_UNRELATED"
+    # Only the pure-manifest commit was path-excluded, not the mixed one.
+    assert_output --partial "PICK_CLEAR"
+}
+
+@test "scan path-skip: --author=all ignores the path list (safety net)" {
+    run_in_bash "
+        $(_gcp_pathskip_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=all
+    "
+    assert_success
+    # Under --author=all the allowlist is bypassed -> nothing path-excluded and
+    # the pure-manifest commit surfaces in the commit list (full detection).
+    refute_output --partial "Path-excluded (skipped)"
+    assert_output --partial "sync manifest"
+}
+
+@test "scan path-skip: --show-skip-paths prints entries, strips comments/blanks" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        git init -q -b main
+        skipf="$repo/skip-paths.conf"
+        printf "claude/plugin/plugins.json  # inline reason\n# whole-line comment\n\nclaude/plugin/marketplaces.json\n" > "$skipf"
+        export GCP_SCAN_SKIP_PATHS_FILE="$skipf"
+        _gcp_scan main upstream/main --show-skip-paths
+    '
+    assert_success
+    assert_output --partial "Path-excluded skip list"
+    assert_output --partial "claude/plugin/plugins.json"
+    assert_output --partial "claude/plugin/marketplaces.json"
+    # Reasons / full-comment lines must not be emitted as path entries.
+    refute_output --partial "whole-line comment"
+    refute_output --partial "inline reason"
+}
+
+@test "scan path-skip: --show-skip-paths reports empty when no file registered" {
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp_test.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        git init -q -b main
+        export GCP_SCAN_SKIP_PATHS_FILE="$repo/does-not-exist.conf"
+        _gcp_scan main upstream/main --show-skip-paths
+    '
+    assert_success
+    assert_output --partial "Path-excluded skip list"
+    assert_output --partial "no skip-paths file"
+}
+
+@test "scan path-skip: comments and blank lines in the paths config are tolerated" {
+    run_in_bash "
+        $(_gcp_pathskip_make_repo)
+        # Rewrite the config with comments and blanks interleaved.
+        printf '# header comment\n\nclaude/plugin/plugins.json  # reason\n\n# trailing\nclaude/plugin/marketplaces.json\n' > \"\$skipf\"
+        printf 'y\n' | _gcp_scan main source --author=Me
+    "
+    assert_success
+    # Parsing tolerates the noise -> the pure-manifest commit is still excluded.
+    assert_output --partial "Path-excluded (skipped): 1"
+    refute_output --partial "sync manifest"
+}
+
+# ---------------------------------------------------------------------------
 # Issue #1134 — phantom commit: two independent defects.
 #
 # Bug A: the Stage-1 subject-dup cache used a fixed `git log -n 200` window, so


### PR DESCRIPTION
## Summary
- `gcp scan`에 SHA 기반 known-resolved skip-list와 병렬로 동작하는 **경로 기반** skip 메커니즘을 추가한다.
- `claude/hooks/plugin-sync.sh`가 플러그인 설치/제거마다 새 SHA로 재생성하는 `chore(claude-plugin): sync manifest` 커밋류를 경로만으로 영구히 걸러낸다.

## Changes
- `git/config/gcp-scan-skip-paths.conf` (신규): 리터럴 경로 allowlist, `GCP_SCAN_SKIP_PATHS_FILE`로 오버라이드 가능.
- `shell-common/functions/gcp_scan.sh`: `_gcp_scan_skip_paths_file`/`_gcp_scan_load_skip_paths`/`_gcp_scan_path_in_list`/`_gcp_scan_is_path_excluded`/`_gcp_scan_show_skip_paths` 5개 헬퍼, Stage-1.4b(경로 배제 단계), 요약 4곳의 "Path-excluded (skipped): N" 라인, cherry-pick 루프 내 조용한 스킵, `--show-skip-paths` 플래그.
- `shell-common/functions/gcp.sh`: `--show-skip-paths` 도움말 테이블 행 2개.
- `tests/bats/functions/gcp.bats`: 신규 8개 테스트(총 87개, 회귀 0건).
- 매처는 `case` glob이 아닌 문자열 등가 비교(`[ "$cand" = "$entry" ]`)를 사용해 PR #1040에서 지적된 SHA 매처의 과매칭 버그 클래스를 구조적으로 배제.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gcp.bats` → 87/87 pass (기존 79 + 신규 8, 회귀 0)
- [x] `shellcheck` — 신규 경고 클래스 없음(기존 SC3003/SC3043 패턴만)
- [x] `shfmt -d` — 신규 diff는 인접 형제 함수와 동일한 스타일
- [x] 새로 생성된, 등록된 적 없는 SHA가 allowlist 경로만 건드릴 때 수동 등록 없이 조용히 스킵됨을 격리 fixture로 확인

## Related
Closes #1215

---
<details>
<summary>🤖 AI Metrics · 📊 ~9000 tokens · 👤 ~8 h · 🤖 ~14 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~8 h · 🤖 ~14 min
<!-- /ai-metrics:gh-pr -->

</details>
