### PR TITLE
fix(gh-relay-merge): 오버사이즈 patch 사전 분할 + 커밋 범위 직접 지정 모드 추가

### DIFF
--- a/claude/skills/gh-relay-merge/SKILL.md
+++ b/claude/skills/gh-relay-merge/SKILL.md
@@ -11,8 +11,9 @@ description: >-
   comment on the destination issue. Use when the user runs /gh:relay-merge,
   /gh-relay-merge, or asks "origin PR를 upstream 으로 릴레이", "push 막혀서
   patch+gist 로 넘겨줘", "relay merged PR to upstream via gist". Accepts
-  `<origin-PR#> [--remote <name-or-URL>] [--target-issue <N>]
-  [--generated-patterns <globs>]` and `-h`/`--help`/`help`.
+  either `<origin-PR#>` or `--commits <base-sha>..<head-sha>` (mutually
+  exclusive) plus `[--remote <name-or-URL>] [--target-issue <N>]
+  [--generated-patterns <globs>]`, and `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Write, Grep, Glob
 metadata:
   model_recommendation:
@@ -29,16 +30,20 @@ metadata:
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and
 output its content verbatim, then stop. No API calls.
 
-## Step 1: Preconditions
+## Step 1: Preconditions — two mutually-exclusive input modes
 
-Positional `<origin-PR#>` (required); flags `--remote`, `--target-issue`,
-`--generated-patterns`. Resolve the origin PR with
-`gh pr view <N> --repo <origin-repo> --json number,state,url,headRefOid,baseRefName,mergeCommit,statusCheckRollup,reviewDecision`.
-Do **not** require `merged` — use the PR's current head/base commits.
-Resolve `--remote` (name or raw URL) per `references/remote-resolution.md`;
-missing `upstream` with no explicit `--remote` → hard error, never fall
-back to `origin`. Confirm the destination is reachable (`git fetch` /
-`git ls-remote`) before anything else.
+Input is EITHER positional `<origin-PR#>` OR `--commits <base>..<head>`
+(both supplied → hard error, stop). Shared flags: `--remote`,
+`--target-issue`, `--generated-patterns`.
+- **PR mode**: `gh pr view <N> --repo <origin-repo> --json number,state,url,headRefOid,baseRefName,mergeCommit,statusCheckRollup,reviewDecision`.
+  Do **not** require `merged` — use the PR's current head/base commits.
+- **`--commits` mode**: skip `gh pr view`; use the range directly. Git
+  semantics — `base` EXCLUDED, `head` INCLUDED. No PR object exists, so
+  Step 3's pre-flight uses the head SHA parsed from the arg.
+
+Resolve `--remote` per `references/remote-resolution.md`; missing `upstream`
+with no explicit `--remote` → hard error, never fall back to `origin`.
+Confirm the destination is reachable (`git fetch` / `git ls-remote`) first.
 
 ## Step 2: Push-Capability Probe (branch point)
 
@@ -52,11 +57,11 @@ Run the throwaway-ref dry-run push probe in `references/push-probe.md`.
 
 ## Step 3: Determine Commit Range + Pre-flight
 
-Resolve the PR's base/head SHAs and run the destination-divergence
-sanity check in `references/patch-generation.md` → "Pre-flight". Warn the
-user up front about structurally-known conflict categories (env-specific
-config blocks, internal/external variants) instead of shipping patches
-that will fail `git am` on the far side.
+Resolve the range's base/head SHAs (from the PR, or parsed from `--commits`)
+and run the destination-divergence sanity check in
+`references/patch-generation.md` → "Pre-flight" — it runs in **both** input
+modes. Warn up front about structurally-known conflict categories instead of
+shipping patches that will fail `git am` on the far side.
 
 ## Step 4: Generate Patches
 
@@ -66,16 +71,14 @@ exclusion, and no-silent-truncation rule per `references/patch-generation.md`.
 
 ## Step 5: Upload Gists (one file per call)
 
-Upload each patch with a single-file `gh gist create <one-file>`,
-sequentially — never multi-file, never parallel — per
-`references/gist-relay.md`. Report and stop on any non-transient failure.
+Upload each patch via single-file `gh gist create`, sequentially — never
+multi-file/parallel — per `references/gist-relay.md`. Stop on any failure.
 
 ## Step 6: Post the Apply-Guide Comment
 
-Build the comment from `references/apply-guide-template.md` and post it to
-a NEW destination issue (default) or `--target-issue <N>` if supplied:
-ordered gist table + `git am` instructions + excluded-artifact regeneration
-commands + a "verification basis" section from Step 1's PR data.
+Build the comment from `references/apply-guide-template.md`, posting to a NEW
+destination issue (default) or `--target-issue <N>`: ordered gist table +
+`git am` steps + regeneration commands + verification basis (PR mode only).
 
 ## Step 7: Origin-side Cleanup (optional)
 
@@ -84,14 +87,14 @@ tracking issue with a cross-reference comment. Never auto-close.
 
 ## Step 8: Report
 
-Summarize the destination issue/comment URL, gist count, whether any
-patches were split for generated-artifact exclusion, and — if Step 2's
+Summarize the destination issue/comment URL, gist count, whether any patches
+were split (artifact exclusion or file-group pre-split), and — if Step 2's
 probe passed — that the simple push+PR path was used instead of relay.
 
 ## Constraints
 
 See `references/constraints.md` for the full list. Hard rules: never fall
 back to `origin` silently · never plain-`push`-then-relay (probe first) ·
-never multi-file/parallel `gh gist create` · never silently truncate a
-patch (only recognized generated artifacts get split) · never auto-close
-an origin issue.
+never multi-file/parallel `gh gist create` · never silently truncate (only
+generated artifacts stripped; oversized commits get file-group pre-split) ·
+never auto-close an origin issue.

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -40,7 +40,13 @@ remote is proxy-blocked, so its commits are relayed as patches below.
 | # | Patch (gist) | Description |
 |---|--------------|-------------|
 | 1 | [0001-…](https://gist.github.com/<user>/<id>) | <one-line summary> |
-| 2 | [0002-…](https://gist.github.com/<user>/<id>) | <one-line summary> |
+| 2 (commit 2의 1/2) | [0002-1-…](https://gist.github.com/<user>/<id>) | <one-line summary> — split commit, part 1/2 |
+| 2 (commit 2의 2/2) | [0002-2-…](https://gist.github.com/<user>/<id>) | <one-line summary> — split commit, part 2/2 |
+
+A commit too large for one patch is pre-split by file group (per
+`references/patch-generation.md`). Render its parts as "commit N의 1/2,
+2/2" and keep them adjacent in apply order — they reconstruct one origin
+commit. Omit the split wording when nothing was pre-split.
 
 Apply **in this exact order** (each patch builds on the previous):
 

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -31,9 +31,12 @@ Fill the placeholders and write to `$tmpdir/apply-guide.md` (outer fence is
 
 ~~~markdown
 ## Relay of origin PR #<N> — <PR title>
+<!-- --commits mode: no PR object — use "## Relay of commit range `<base>..<head>`" instead -->
 
 Source PR was **<merged|open>** on the internal remote. `git push` to this
 remote is proxy-blocked, so its commits are relayed as patches below.
+<!-- --commits mode: replace the line above with "Source range is
+`<base>..<head>` on the internal remote (no origin PR)." -->
 
 ### Apply order
 
@@ -45,8 +48,10 @@ remote is proxy-blocked, so its commits are relayed as patches below.
 
 A commit too large for one patch is pre-split by file group (per
 `references/patch-generation.md`). Render its parts as "commit N의 1/2,
-2/2" and keep them adjacent in apply order — they reconstruct one origin
-commit. Omit the split wording when nothing was pre-split.
+2/2" and keep them adjacent in apply order — applying them in order
+reproduces the origin commit's full diff as N sequential destination
+commits (not one — `git am` cannot re-merge sub-patches back into a
+single commit). Omit the split wording when nothing was pre-split.
 
 Apply **in this exact order** (each patch builds on the previous):
 
@@ -75,6 +80,9 @@ What was verified on the origin side (from `gh pr view` in Step 1):
 - CI: <statusCheckRollup summary — e.g. all checks green>
 - Review: <reviewDecision — e.g. APPROVED by N reviewers>
 - Origin PR: <origin PR URL>
+
+(PR mode only — no `gh pr view` data exists in `--commits` mode; omit this
+whole section then.)
 ~~~
 
 ## Notes

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -31,27 +31,26 @@ Fill the placeholders and write to `$tmpdir/apply-guide.md` (outer fence is
 
 ~~~markdown
 ## Relay of origin PR #<N> — <PR title>
-<!-- --commits mode: no PR object — use "## Relay of commit range `<base>..<head>`" instead -->
 
 Source PR was **<merged|open>** on the internal remote. `git push` to this
 remote is proxy-blocked, so its commits are relayed as patches below.
-<!-- --commits mode: replace the line above with "Source range is
-`<base>..<head>` on the internal remote (no origin PR)." -->
 
 ### Apply order
 
 | # | Patch (gist) | Description |
 |---|--------------|-------------|
 | 1 | [0001-…](https://gist.github.com/<user>/<id>) | <one-line summary> |
+| 2 | [0002-…](https://gist.github.com/<user>/<id>) | <one-line summary> |
+
+If a commit was pre-split by file group (`references/patch-generation.md`
+→ "File-group pre-split"), its rows look like this instead — each part
+lands as its own destination commit (not merged back into one), so keep
+them adjacent and in order:
+
 | 2 (commit 2의 1/2) | [0002-1-…](https://gist.github.com/<user>/<id>) | <one-line summary> — split commit, part 1/2 |
 | 2 (commit 2의 2/2) | [0002-2-…](https://gist.github.com/<user>/<id>) | <one-line summary> — split commit, part 2/2 |
 
-A commit too large for one patch is pre-split by file group (per
-`references/patch-generation.md`). Render its parts as "commit N의 1/2,
-2/2" and keep them adjacent in apply order — applying them in order
-reproduces the origin commit's full diff as N sequential destination
-commits (not one — `git am` cannot re-merge sub-patches back into a
-single commit). Omit the split wording when nothing was pre-split.
+Omit the split rows when nothing was pre-split.
 
 Apply **in this exact order** (each patch builds on the previous):
 
@@ -80,9 +79,6 @@ What was verified on the origin side (from `gh pr view` in Step 1):
 - CI: <statusCheckRollup summary — e.g. all checks green>
 - Review: <reviewDecision — e.g. APPROVED by N reviewers>
 - Origin PR: <origin PR URL>
-
-(PR mode only — no `gh pr view` data exists in `--commits` mode; omit this
-whole section then.)
 ~~~
 
 ## Notes
@@ -93,3 +89,8 @@ whole section then.)
   `git format-patch` — out-of-order application breaks `git am`.
 - The verification-basis section reuses data already fetched in Step 1; do
   not make extra API calls for it.
+- **`--commits` mode** (no origin PR object exists): replace the header
+  with `## Relay of commit range \`<base>..<head>\`` and the "Source PR
+  was…" line with "Source range is `<base>..<head>` on the internal remote
+  (no origin PR)."; omit the "Verification basis" section entirely — there
+  is no `gh pr view` data to report.

--- a/claude/skills/gh-relay-merge/references/constraints.md
+++ b/claude/skills/gh-relay-merge/references/constraints.md
@@ -31,10 +31,13 @@ of file count, and parallel uploads risk rate-limit / abuse triggers.
 
 A patch over `RELAY_PATCH_MAX_BYTES` (40KB) is only ever shrunk by excluding
 **recognized generated-artifact** paths (with a recorded regeneration
-command). If it is still oversized after exclusion, or its bulk is not a
-recognized generated artifact, stop and report — do not truncate or split
-arbitrary code diffs. Truncation corrupts the commit `git am` reconstructs.
-This is the repo's "no silent caps" norm.
+command), or — for an oversized non-artifact commit — pre-split by file
+group into independently `git am`-able sub-patches (see
+`references/patch-generation.md` → "File-group pre-split"). Only when a
+single **file's** own diff alone still exceeds the limit does the skill
+stop and report — do not truncate or split arbitrary code diffs at that
+point. Truncation corrupts the commit `git am` reconstructs. This is the
+repo's "no silent caps" norm.
 
 ## Never auto-close an origin-side issue
 

--- a/claude/skills/gh-relay-merge/references/help.md
+++ b/claude/skills/gh-relay-merge/references/help.md
@@ -7,8 +7,8 @@ Input is EITHER the positional `<origin-PR#>` OR `--commits <base>..<head>`
 
 | # | Name | Default | Description |
 |---|------|---------|-------------|
-| 1 | `<origin-PR#>` or `-h`/`--help`/`help` | — | PR on `origin` whose commit range is the relay payload (merged or open). Mutually exclusive with `--commits` |
-| flag | `--commits <base>..<head>` | — | Alternate input mode: relay this git range directly, skipping `gh pr view`. Standard git semantics — `base` EXCLUDED, `head` INCLUDED. Mutually exclusive with the positional `<origin-PR#>` |
+| 1 | `<origin-PR#>` or `-h`/`--help`/`help` | — | PR on `origin` whose commit range is the relay payload (merged or open) |
+| flag | `--commits <base>..<head>` | — | Alternate input mode: relay this git range directly, skipping `gh pr view`. Standard git semantics — `base` EXCLUDED, `head` INCLUDED |
 | flag | `--remote <name-or-URL>` | `upstream` | Destination remote. Name (resolved via `git remote get-url`) or raw URL |
 | flag | `--target-issue <N>` | new issue | Post the apply-guide to this existing destination issue/PR instead of creating a new one |
 | flag | `--generated-patterns <globs>` | built-in list | Comma-separated globs marking generated artifacts to strip from oversized patches |

--- a/claude/skills/gh-relay-merge/references/help.md
+++ b/claude/skills/gh-relay-merge/references/help.md
@@ -2,9 +2,13 @@
 
 ## Arguments
 
+Input is EITHER the positional `<origin-PR#>` OR `--commits <base>..<head>`
+— the two are mutually exclusive (supplying both is a hard error).
+
 | # | Name | Default | Description |
 |---|------|---------|-------------|
-| 1 | `<origin-PR#>` or `-h`/`--help`/`help` | — | PR on `origin` whose commit range is the relay payload (merged or open) |
+| 1 | `<origin-PR#>` or `-h`/`--help`/`help` | — | PR on `origin` whose commit range is the relay payload (merged or open). Mutually exclusive with `--commits` |
+| flag | `--commits <base>..<head>` | — | Alternate input mode: relay this git range directly, skipping `gh pr view`. Standard git semantics — `base` EXCLUDED, `head` INCLUDED. Mutually exclusive with the positional `<origin-PR#>` |
 | flag | `--remote <name-or-URL>` | `upstream` | Destination remote. Name (resolved via `git remote get-url`) or raw URL |
 | flag | `--target-issue <N>` | new issue | Post the apply-guide to this existing destination issue/PR instead of creating a new one |
 | flag | `--generated-patterns <globs>` | built-in list | Comma-separated globs marking generated artifacts to strip from oversized patches |
@@ -13,6 +17,7 @@
 
 ```
 /gh-relay-merge 168                              # relay origin PR #168 to upstream
+/gh-relay-merge --commits abc123..def456         # relay a raw git range (no PR lookup)
 /gh-relay-merge 168 --remote fork                # relay to remote named 'fork'
 /gh-relay-merge 168 --remote https://github.com/org/repo.git
 /gh-relay-merge 168 --target-issue 42            # post guide to existing issue #42
@@ -38,16 +43,21 @@
 
 ## What the skill does
 
-1. Resolves the origin PR and the `--remote` destination (hard error on a
-   missing remote — never silent fallback to `origin`), and confirms the
-   destination is reachable.
+1. Resolves the commit range from one of two mutually-exclusive input
+   modes — the origin PR (`<origin-PR#>`, via `gh pr view`) **or** a raw
+   `--commits <base>..<head>` range (base excluded, head included; no PR
+   lookup) — plus the `--remote` destination (hard error on a missing
+   remote — never silent fallback to `origin`), and confirms it is reachable.
 2. **Probes push capability** with a throwaway-ref `--dry-run` push. If
    push works, delegates to `gh:pr` and stops (relay is a fallback only).
-3. On confirmed block (HTTP 403 / block-page), resolves the PR's
-   base/head commit range and runs a destination-divergence pre-flight.
+3. On confirmed block (HTTP 403 / block-page), resolves the base/head SHAs
+   (from the PR or the parsed `--commits` range) and runs a
+   destination-divergence pre-flight — in both input modes.
 4. `git format-patch` per commit; oversized patches whose bulk is a
    recognized generated artifact are regenerated without that diff (with a
-   recorded regeneration command); anything else oversized stops the skill.
+   recorded regeneration command); an oversized non-artifact commit is
+   pre-split into per-file-group sub-patches; only a single file whose own
+   diff still exceeds the limit stops the skill (no arbitrary truncation).
 5. Uploads each patch via single-file `gh gist create`, one call at a time.
 6. Posts an apply-guide comment (gist table + `git am` steps + regeneration
    commands + verification basis) to a new or `--target-issue` destination.
@@ -68,8 +78,9 @@
 - Fall back to `origin` when the requested remote is missing.
 - Push normally and *then* relay — it always probes first.
 - Create a multi-file gist or run gist uploads in parallel.
-- Silently truncate a patch. Only recognized generated-artifact diffs are
-  stripped; any other oversized patch stops the skill with a report.
+- Silently truncate a patch. Recognized generated-artifact diffs are
+  stripped and oversized non-artifact commits are pre-split by file group;
+  only a single file whose own diff exceeds the limit stops the skill.
 - Auto-close an origin-side issue without explicit confirmation.
 
 ## Related skills

--- a/claude/skills/gh-relay-merge/references/patch-generation.md
+++ b/claude/skills/gh-relay-merge/references/patch-generation.md
@@ -11,7 +11,7 @@ destination's default branch (e.g. `git ls-remote --symref "$REMOTE" HEAD`)
 ```bash
 # PR mode:      reuse the headRefOid captured by Step 1's gh pr view (no re-fetch)
 # --commits mode: no PR object exists — use the head SHA parsed from <base>..<head>
-HEAD_SHA=$HEAD_REF_OID                                          # PR mode; --commits mode: HEAD_SHA=<head> from the arg
+HEAD_SHA=$HEAD_REF_OID                                          # PR mode
 BASE_SHA=$(git merge-base "$REMOTE/$DEST_DEFAULT" "$HEAD_SHA")   # or the PR's recorded base
 ```
 
@@ -129,10 +129,8 @@ limit.
    "commit N의 1/2, 2/2" (Step 6 / `references/apply-guide-template.md`) so a
    human applying in order knows they belong to one commit.
 
-Pre-split only triggers for non-artifact oversized commits; artifact
-exclusion (above) is tried first. A single **file** whose own diff alone
-exceeds the limit cannot be file-group-split — fall through to the FAIL
-below (no arbitrary truncation).
+A single **file** whose own diff alone exceeds the limit cannot be
+file-group-split — fall through to the FAIL below (no arbitrary truncation).
 
 ## No silent truncation
 

--- a/claude/skills/gh-relay-merge/references/patch-generation.md
+++ b/claude/skills/gh-relay-merge/references/patch-generation.md
@@ -101,10 +101,11 @@ limit.
    per-commit, so size per file directly):
 
    ```bash
-   for f in $(git diff --name-only "$SHA"^.."$SHA"); do
-     bytes=$(git diff "$SHA"^.."$SHA" -- "$f" | wc -c)
-     printf '%s\t%s\n' "$bytes" "$f"
-   done
+   git diff --no-color --no-ext-diff -z --name-only "$SHA"^.."$SHA" |
+     while IFS= read -r -d '' f; do
+       bytes=$(git diff --no-color --no-ext-diff "$SHA"^.."$SHA" -- "$f" | wc -c)
+       printf '%s\t%s\n' "$bytes" "$f"
+     done
    ```
 
 2. Greedily bucket files into groups so each group's cumulative patch size

--- a/claude/skills/gh-relay-merge/references/patch-generation.md
+++ b/claude/skills/gh-relay-merge/references/patch-generation.md
@@ -4,18 +4,21 @@ Steps 3-4. Runs only after Step 2 confirmed the push is blocked.
 
 ## Pre-flight (Step 3): destination divergence sanity check
 
-Resolve the PR's real commit range first. Reuse the `headRefOid` already
-captured by Step 1's `gh pr view` (no re-fetch), and resolve `$DEST_DEFAULT`
-— the destination's default branch (e.g. `git ls-remote --symref "$REMOTE"
-HEAD`) — once:
+Resolve the real commit range first, then resolve `$DEST_DEFAULT` — the
+destination's default branch (e.g. `git ls-remote --symref "$REMOTE" HEAD`)
+— once. Where `HEAD_SHA` comes from depends on Step 1's input mode:
 
 ```bash
-HEAD_SHA=$HEAD_REF_OID                                          # from Step 1; no re-fetch
+# PR mode:      reuse the headRefOid captured by Step 1's gh pr view (no re-fetch)
+# --commits mode: no PR object exists — use the head SHA parsed from <base>..<head>
+HEAD_SHA=$HEAD_REF_OID                                          # PR mode; --commits mode: HEAD_SHA=<head> from the arg
 BASE_SHA=$(git merge-base "$REMOTE/$DEST_DEFAULT" "$HEAD_SHA")   # or the PR's recorded base
 ```
 
 For a merged PR use the merge commit's parents; for an open PR use the
-current head and the PR's base. The range is `BASE..HEAD`.
+current head and the PR's base. In `--commits <base>..<head>` mode the range
+is exactly git's `<base>..<head>` (base excluded, head included) — use it
+directly, no `gh pr view`. Either way the range is `BASE..HEAD`.
 
 Before generating anything, compare the files this PR touches against the
 destination's current default branch:
@@ -84,20 +87,69 @@ Record a regeneration note for each excluded artifact so the destination
 can rebuild it — e.g. `openapi.json` → `make codegen`, a lockfile →
 `npm install`. These notes go into the apply-guide comment (Step 6).
 
+## File-group pre-split (oversized non-artifact commit)
+
+When a patch is **still** over `RELAY_PATCH_MAX_BYTES` after artifact
+exclusion **and** the excess is *not* attributable to a recognized
+generated-artifact pattern — it's just a large real code change in one
+commit — pre-split that single commit into multiple sub-patches by file
+group. This runs **before** the no-silent-truncation FAIL below; the FAIL
+now fires only when pre-split itself cannot get every sub-patch under the
+limit.
+
+1. Compute each file's diff size within the commit (`git format-patch` is
+   per-commit, so size per file directly):
+
+   ```bash
+   for f in $(git diff --name-only "$SHA"^.."$SHA"); do
+     bytes=$(git diff "$SHA"^.."$SHA" -- "$f" | wc -c)
+     printf '%s\t%s\n' "$bytes" "$f"
+   done
+   ```
+
+2. Greedily bucket files into groups so each group's cumulative patch size
+   stays under `RELAY_PATCH_MAX_BYTES` (account for ~1KB of per-patch header
+   overhead when bucketing near the limit).
+
+3. Generate one independent sub-patch per group. `git format-patch -1 <SHA>`
+   with a pathspec clones the original commit's `From`/`Subject`/date/author
+   headers onto each sub-patch (git's default for `-1` + pathspec — verified),
+   so every sub-patch stays independently `git am`-able:
+
+   ```bash
+   git format-patch -1 "$SHA" -o "$tmpdir" -- <files-in-group>   # per group
+   ```
+
+   Number the sub-patches so apply order — relative to each other and to the
+   rest of the series — is unambiguous: keep the commit's `NNNN` slot and add
+   a sub-index so they sort between it and the next commit, e.g. rename to
+   `NNNN-1-<name>.patch`, `NNNN-2-<name>.patch`. `git am` order follows the
+   order the apply-guide lists them, so the guide must render them as
+   "commit N의 1/2, 2/2" (Step 6 / `references/apply-guide-template.md`) so a
+   human applying in order knows they belong to one commit.
+
+Pre-split only triggers for non-artifact oversized commits; artifact
+exclusion (above) is tried first. A single **file** whose own diff alone
+exceeds the limit cannot be file-group-split — fall through to the FAIL
+below (no arbitrary truncation).
+
 ## No silent truncation
 
 If a patch is **still** over `RELAY_PATCH_MAX_BYTES` after excluding
-recognized generated artifacts — or is oversized and *not* attributable to
-any known generated pattern — do **not** truncate or split arbitrary code
-diffs. Stop and report:
+recognized generated artifacts **and** after the file-group pre-split above
+— i.e. a single **file's** own diff alone exceeds the limit and cannot be
+split further — do **not** truncate or split arbitrary code diffs. Stop and
+report:
 
 ```
-[FAIL] <NNNN>-<name>.patch is <size> bytes (> RELAY_PATCH_MAX_BYTES=40960)
-and its bulk is not a recognized generated artifact.
+[FAIL] <NNNN>-<name>.patch is <size> bytes (> RELAY_PATCH_MAX_BYTES=40960):
+a single file's diff exceeds the limit even after file-group pre-split, and
+its bulk is not a recognized generated artifact.
 Refusing to truncate — arbitrary truncation would corrupt the applied commit.
 Options: add its path to --generated-patterns if it IS generated, or split
 the origin commit into smaller commits and re-run.
 ```
 
 Arbitrary content truncation corrupts the commit `git am` reconstructs;
-only recognized generated-artifact diffs are ever dropped.
+only recognized generated-artifact diffs are ever dropped, and only
+whole-file groups are ever pre-split.


### PR DESCRIPTION
## Summary
- `gh:relay-merge` 실행 로그 검토(사내 GHE issue #27)에서 드러난 두 갭을 수정: 오버사이즈 patch 사전 분할 부재, PR# 전용 입력으로 인한 커밋 범위 오추정.

## Changes
- `references/patch-generation.md`: 생성물 제외 후에도 오버사이즈이고 비생성물 커밋인 경우, 파일-그룹 단위로 원본 커밋 헤더를 복제한 독립 서브패치로 사전 분할하는 단계 추가. no-silent-truncation FAIL은 단일 파일이 그 자체로 한계를 넘는 경우로 범위를 좁힘.
- `references/apply-guide-template.md`: 분할된 커밋을 "commit N의 1/2, 2/2" 형태로 렌더링하는 예시 추가.
- `SKILL.md` / `references/help.md`: `--commits <base-sha>..<head-sha>` 모드를 `<origin-PR#>` 위치 인자와 상호 배타적인 대안 입력으로 추가(`base` 제외, `head` 포함하는 표준 git range 시맨틱). `--commits` 모드에서도 Step 3의 destination-divergence pre-flight는 동일하게 수행됨을 명시.

## Test plan
- [x] `mise run lint` — errors=0 (기존 `docs/` kebab-case 경고만 존재, 변경 파일과 무관)
- [x] `wc -l SKILL.md` <= 100 (100줄)
- [x] 세 파일 재검토: SKILL.md Step 1/3/6의 참조가 patch-generation.md/help.md 실제 내용과 일치

## Related
Closes #1220

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
