### PR TITLE
fix(file_cleanup): clean-home --cache 충돌 에러에 del-file 안내 힌트 추가

### DIFF
--- a/shell-common/functions/file_cleanup.sh
+++ b/shell-common/functions/file_cleanup.sh
@@ -311,6 +311,7 @@ del_file() {
                 new_mode="${1#--}"
                 if [ -n "$mode" ] && [ "$mode" != "$new_mode" ]; then
                     ux_error "del-file: --home and --cache are mutually exclusive"
+                    ux_bullet "clean-home is an alias for 'del-file --home' — for cache cleanup run: del-file --cache"
                     return 1
                 fi
                 mode="$new_mode"

--- a/shell-common/functions/file_cleanup.sh
+++ b/shell-common/functions/file_cleanup.sh
@@ -311,7 +311,7 @@ del_file() {
                 new_mode="${1#--}"
                 if [ -n "$mode" ] && [ "$mode" != "$new_mode" ]; then
                     ux_error "del-file: --home and --cache are mutually exclusive"
-                    ux_bullet "clean-home is an alias for 'del-file --home' — for cache cleanup run: del-file --cache"
+                    ux_info "clean-home is an alias for 'del-file --home' — for cache cleanup run: del-file --cache"
                     return 1
                 fi
                 mode="$new_mode"

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -180,7 +180,9 @@ _register_default_help_categories() {
         for category in $(_my_help_get_category_keys 2>/dev/null); do
             local members="${HELP_CATEGORY_MEMBERS[$category]}"
             # FIX: Don't declare topic separately - declare it in the for loop
-            for topic in $members; do
+            # zsh doesn't word-split a bare "$members" expansion; routing it
+            # through a command substitution forces splitting in both shells.
+            for topic in $(printf '%s' "$members"); do
                 HELP_COMMAND_TO_CATEGORY["$topic"]="$category"
             done
         done
@@ -376,7 +378,9 @@ _my_help_show_categories() {
         local total=0
 
         # FIX: Don't declare topic/label separately in zsh - causes debug output
-        for topic in $members; do
+        # zsh doesn't word-split a bare "$members" expansion; routing it
+        # through a command substitution forces splitting in both shells.
+        for topic in $(printf '%s' "$members"); do
             total=$((total + 1))
             if [ "$shown" -lt 5 ]; then
                 if [ -n "$preview" ]; then
@@ -419,18 +423,20 @@ _my_help_show_category() {
     ux_info "${HELP_CATEGORIES[$category]}"
 
     # FIX: Don't declare topic separately - it causes zsh debug output
+    # zsh doesn't word-split a bare "$members" expansion; routing it
+    # through a command substitution forces splitting in both shells.
     local total=0
-    for topic in $members; do
+    for topic in $(printf '%s' "$members"); do
         total=$((total + 1))
     done
 
     ux_section "Topics (${total})"
     ux_table_header "Topic" "Description"
 
-    for topic in $members; do
-        # FIX: Combine declaration and assignment
-        local desc
-        desc=$(_my_help_topic_description "$topic")
+    for topic in $(printf '%s' "$members"); do
+        # A separate "local desc" + "desc=$(...)" here makes zsh echo
+        # "desc='...'" once per iteration; combining onto one line avoids it.
+        local desc=$(_my_help_topic_description "$topic")
         ux_table_row "$topic" "$desc"
     done
 

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -143,6 +143,13 @@ _get_help_functions() {
 # Default Help Descriptions Registration
 # ═══════════════════════════════════════════════════════════════
 
+# zsh doesn't word-split a bare "$members" expansion; routing it through a
+# command substitution forces splitting in both shells. Used by every loop
+# that iterates a HELP_CATEGORY_MEMBERS value.
+_my_help_split_members() {
+    printf '%s' "$1"
+}
+
 _register_default_help_categories() {
     # Suppress zsh debug output - must be first command
     [ -n "$ZSH_VERSION" ] && { setopt localoptions no_xtrace 2>/dev/null || true; }
@@ -180,9 +187,7 @@ _register_default_help_categories() {
         for category in $(_my_help_get_category_keys 2>/dev/null); do
             local members="${HELP_CATEGORY_MEMBERS[$category]}"
             # FIX: Don't declare topic separately - declare it in the for loop
-            # zsh doesn't word-split a bare "$members" expansion; routing it
-            # through a command substitution forces splitting in both shells.
-            for topic in $(printf '%s' "$members"); do
+            for topic in $(_my_help_split_members "$members"); do
                 HELP_COMMAND_TO_CATEGORY["$topic"]="$category"
             done
         done
@@ -378,9 +383,7 @@ _my_help_show_categories() {
         local total=0
 
         # FIX: Don't declare topic/label separately in zsh - causes debug output
-        # zsh doesn't word-split a bare "$members" expansion; routing it
-        # through a command substitution forces splitting in both shells.
-        for topic in $(printf '%s' "$members"); do
+        for topic in $(_my_help_split_members "$members"); do
             total=$((total + 1))
             if [ "$shown" -lt 5 ]; then
                 if [ -n "$preview" ]; then
@@ -423,17 +426,15 @@ _my_help_show_category() {
     ux_info "${HELP_CATEGORIES[$category]}"
 
     # FIX: Don't declare topic separately - it causes zsh debug output
-    # zsh doesn't word-split a bare "$members" expansion; routing it
-    # through a command substitution forces splitting in both shells.
     local total=0
-    for topic in $(printf '%s' "$members"); do
+    for topic in $(_my_help_split_members "$members"); do
         total=$((total + 1))
     done
 
     ux_section "Topics (${total})"
     ux_table_header "Topic" "Description"
 
-    for topic in $(printf '%s' "$members"); do
+    for topic in $(_my_help_split_members "$members"); do
         # A separate "local desc" + "desc=$(...)" here makes zsh echo
         # "desc='...'" once per iteration; combining onto one line avoids it.
         local desc=$(_my_help_topic_description "$topic")

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -199,9 +199,7 @@ class TestHelpCategoryRendering:
         """my_help_impl cli must render all 11 topics individually, not merged."""
         result = shell_runner(shell, "my_help_impl cli")
         assert result.exit_code == 0, f"{shell}: my_help_impl cli failed"
-        assert "Topics (11)" in result.stdout, (
-            f"{shell}: expected 11 separate topics, got: {result.stdout}"
-        )
+        assert "Topics (11)" in result.stdout, f"{shell}: expected 11 separate topics, got: {result.stdout}"
         assert "No description available" not in result.stdout, (
             f"{shell}: a topic fell back to the missing-description placeholder"
         )

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -185,6 +185,31 @@ class TestHelpTopicsWithDifferentFormats:
         assert "git stash" in result.stdout.lower(), f"{shell}: stash content not shown"
 
 
+class TestHelpCategoryRendering:
+    """Regression test for the zsh word-splitting bug (#1225).
+
+    zsh doesn't word-split a bare `$members` expansion, unlike bash — a
+    category's space-separated topic list used to collapse into a single
+    loop iteration under zsh, showing one merged "topic" with a
+    "No description available" fallback instead of one row per topic.
+    """
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_category_lists_each_topic_with_its_description(self, shell_runner, shell):
+        """my_help_impl cli must render all 11 topics individually, not merged."""
+        result = shell_runner(shell, "my_help_impl cli")
+        assert result.exit_code == 0, f"{shell}: my_help_impl cli failed"
+        assert "Topics (11)" in result.stdout, (
+            f"{shell}: expected 11 separate topics, got: {result.stdout}"
+        )
+        assert "No description available" not in result.stdout, (
+            f"{shell}: a topic fell back to the missing-description placeholder"
+        )
+        assert "del_file" in result.stdout and "fzf" in result.stdout, (
+            f"{shell}: expected topic names not found individually"
+        )
+
+
 class TestHelpTopicsErrorHandling:
     """Test help system error handling."""
 


### PR DESCRIPTION
## Summary
- `clean-home --cache` was hitting "--home and --cache are mutually exclusive" with no clue that `del-file --cache` is the actual command to use.
- While testing that fix, found `my-help <category>` (e.g. `my-help cli`) silently breaks under zsh — all topics collapse into one line with "No description available".

## Changes
- `file_cleanup.sh`: add a `ux_info` hint right after the mutually-exclusive error, pointing users at `del-file --cache` and explaining that `clean-home` is just an alias for `del_file --home`. (`ux_bullet` → `ux_info` per `/simplify`, matching this file's existing "info = explain/redirect after error" convention.)
- `my_help.sh`: fix 4 `for topic in $members` loops that relied on zsh word-splitting a bare parameter expansion (zsh doesn't do this by default, unlike bash) — switched to `for topic in $(printf '%s' "$members")`. Also combined a split `local desc` + `desc=$(...)` into one line to remove a zsh debug-echo side effect.

## Test plan
- [x] `tests/bats/functions/file_cleanup.bats`, `test_clean_cache.bats`, `test_clean_home.bats` — 21/21 pass
- [x] `pytest` full suite — 1001 passed
- [x] Manual: `del_file --home --cache` prints both the error and the new hint line
- [x] Manual: `my-help cli` / `my-help --all` under both bash and zsh show full per-topic descriptions (no more collapsed single line, no `desc='...'` echo)

## Related
Closes #1223
Fixes #1225

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~25 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~25 min
<!-- /ai-metrics:gh-pr -->

</details>
