### PR TITLE
fix(my_help): zsh 카테고리 topics 목록 word-splitting 뭉개짐 수정

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -180,7 +180,8 @@ _register_default_help_categories() {
         for category in $(_my_help_get_category_keys 2>/dev/null); do
             local members="${HELP_CATEGORY_MEMBERS[$category]}"
             # FIX: Don't declare topic separately - declare it in the for loop
-            for topic in $members; do
+            # zsh does not word-split bare $members; command substitution forces it
+            for topic in $(printf '%s' "$members"); do
                 HELP_COMMAND_TO_CATEGORY["$topic"]="$category"
             done
         done
@@ -376,7 +377,7 @@ _my_help_show_categories() {
         local total=0
 
         # FIX: Don't declare topic/label separately in zsh - causes debug output
-        for topic in $members; do
+        for topic in $(printf '%s' "$members"); do
             total=$((total + 1))
             if [ "$shown" -lt 5 ]; then
                 if [ -n "$preview" ]; then
@@ -420,17 +421,16 @@ _my_help_show_category() {
 
     # FIX: Don't declare topic separately - it causes zsh debug output
     local total=0
-    for topic in $members; do
+    for topic in $(printf '%s' "$members"); do
         total=$((total + 1))
     done
 
     ux_section "Topics (${total})"
     ux_table_header "Topic" "Description"
 
-    for topic in $members; do
-        # FIX: Combine declaration and assignment
-        local desc
-        desc=$(_my_help_topic_description "$topic")
+    for topic in $(printf '%s' "$members"); do
+        # FIX: Combine declaration and assignment - zsh echoes desc='...' otherwise
+        local desc=$(_my_help_topic_description "$topic")
         ux_table_row "$topic" "$desc"
     done
 

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -429,8 +429,9 @@ _my_help_show_category() {
     ux_table_header "Topic" "Description"
 
     for topic in $(printf '%s' "$members"); do
-        # FIX: Combine declaration and assignment - zsh echoes desc='...' otherwise
-        local desc=$(_my_help_topic_description "$topic")
+        # FIX: Suppress zsh debug output - redirect stdout during local declaration
+        { local desc; } >/dev/null 2>&1
+        desc=$(_my_help_topic_description "$topic")
         ux_table_row "$topic" "$desc"
     done
 


### PR DESCRIPTION
## Summary
- zsh에서 `my-help <category>` / `my-help --all`이 카테고리 topics를 한 줄로 뭉개서 보여주던 word-splitting 버그 수정
- 부가로 `_my_help_show_category`의 desc 변수 선언에서 zsh xtrace 잔여 echo 억제

## Changes
- `_register_default_help_categories`, `_my_help_show_categories`, `_my_help_show_category` (2곳): `for topic in $members` → `for topic in $(printf '%s' "$members")` — zsh는 따옴표 없는 단순 파라미터 확장에 단어 분리를 하지 않아 루프가 1회만 돌던 문제 수정 (bash/zsh/dash 공통 동작)
- `_my_help_show_category`의 `desc` 변수 선언에 파일 내 기존 관용구 `{ local x; } >/dev/null 2>&1`(label 변수, 396/415행) 적용 — zsh의 `desc='...'` 잔여 echo 제거

## Test plan
- [x] `DOTFILES_FORCE_INIT=1 zsh -c '... my_help_impl cli'` → `Topics (11)`, 실제 description, 잔여 echo 없음
- [x] 동일 커맨드를 bash로 실행 → 회귀 없음
- [x] `my_help_impl --all` 카테고리 요약 표에서도 정상 카운트/미리보기 확인

## Related
Closes #1225

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~6 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics:gh-pr -->

</details>
