### PR TITLE
fix(gcp-scan): 실행 루프 CHERRY_PICK_HEAD 판별을 파일 테스트로 교체

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -1259,6 +1259,12 @@ EOF
     local conflict_skipped=0
     local kr_skipped=0
     local pe_skipped=0
+    # Cache the .git dir BEFORE any cherry-pick runs, while config is still
+    # readable (issue #1213). A real conflict in a tracked-and-[include]-d
+    # git/.gitconfig poisons config, so the later CHERRY_PICK_HEAD check must
+    # be a plain file test — `git rev-parse` itself would die on the poison.
+    local _gcp_git_dir
+    _gcp_git_dir=$(git rev-parse --git-dir 2>/dev/null) || _gcp_git_dir=".git"
     while IFS= read -r sha; do
         [ -z "$sha" ] && continue
 
@@ -1374,7 +1380,10 @@ $sha
                 fi
                 break
             done
-            if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
+            # Plain file test, not `git rev-parse` (issue #1213): a poisoned
+            # config makes any git call fail, which the old code misread as
+            # "no conflict → skip", silently dropping the real conflict.
+            if [ ! -f "${_gcp_git_dir}/CHERRY_PICK_HEAD" ]; then
                 continue
             fi
             # Genuine conflict (the pre-flight already excluded redundant ones):

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -689,6 +689,51 @@ FIXTURE
     assert_output --partial "NAME_OK"
 }
 
+@test "scan #1213: real conflict in [include]-d git/.gitconfig reaches execution loop — surfaced, not silently skipped" {
+    # The config-poisoning class (#1016/#1149) only defended the non-destructive
+    # preflight probe. Here a REAL cherry-pick conflict lands in the tracked
+    # git/.gitconfig that ~/.gitconfig [include]s, poisoning config so every
+    # later git call dies with "bad config line". The old
+    # `git rev-parse --verify CHERRY_PICK_HEAD` check misread that death as
+    # "no conflict" and `continue`d, silently skipping it and reporting
+    # "0 conflicts". Two source commits both touch git/.gitconfig so Stage-1.6's
+    # precedent guard defers the conflict to the execution loop (where the fix
+    # lives) instead of pre-flagging it into conflict_list.
+    run_in_bash '
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp1213.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        mkdir -p git
+        printf "[user]\n\tname = base\n" > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "init: tracked gitconfig"
+        git checkout -q -b source
+        # A — precedent: also touches git/.gitconfig (adds a section, keeps name)
+        # so Stage-1.6 defers B rather than pre-flagging the conflict.
+        printf "[user]\n\tname = base\n[core]\n\teditor = vim\n" > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "source: add core section"
+        # B — changes name; conflicts against mainvalue at the real cherry-pick.
+        printf "[user]\n\tname = sidevalue\n[core]\n\teditor = vim\n" > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "source: gitconfig name=sidevalue"
+        git checkout -q main
+        printf "[user]\n\tname = mainvalue\n" > git/.gitconfig
+        git add git/.gitconfig && git commit -qm "main: gitconfig name=mainvalue"
+        # [include] topology: ~/.gitconfig pulls in the tracked file the conflict
+        # will corrupt.
+        rm -f "$HOME/.gitconfig"
+        printf "[include]\n\tpath = %s/git/.gitconfig\n" "$repo" > "$HOME/.gitconfig"
+        printf "y\n" | _gcp_scan main source --author=all
+        echo "scan_rc=$?"
+    '
+    # New code: the real conflict is surfaced and the scan stops with rc=1.
+    assert_output --partial "Resolve and run"
+    assert_output --partial "scan_rc=1"
+    # Old code silently skipped it and lied "0 conflicts" — regression guard.
+    refute_output --partial "0 conflicts"
+}
+
 @test "scan #913: content-dup commit (unique subject, different patch-id) skipped via no-op pre-flight, no conflict" {
     # The content-dup commit must reach the individual loop, so its patch-id
     # has to DIFFER from how HEAD acquired the same final content (else

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -726,10 +726,16 @@ FIXTURE
         printf "[include]\n\tpath = %s/git/.gitconfig\n" "$repo" > "$HOME/.gitconfig"
         printf "y\n" | _gcp_scan main source --author=all
         echo "scan_rc=$?"
+        # PR #1228 review (codex): assert the sequencer state itself, not just
+        # the message text — guards against a future regression that clears
+        # CHERRY_PICK_HEAD (e.g. an accidental --skip/--abort) while still
+        # coincidentally printing "Resolve and run".
+        [ -f "$repo/.git/CHERRY_PICK_HEAD" ] && echo "CPH_PRESENT" || echo "CPH_MISSING"
     '
     # New code: the real conflict is surfaced and the scan stops with rc=1.
     assert_output --partial "Resolve and run"
     assert_output --partial "scan_rc=1"
+    assert_output --partial "CPH_PRESENT"
     # Old code silently skipped it and lied "0 conflicts" — regression guard.
     refute_output --partial "0 conflicts"
 }


### PR DESCRIPTION
## Summary
- `git/.gitconfig`가 `[include]`로 활성 global config에 편입된 토폴로지에서, 실행 루프가 진짜 conflict를 낼 때 config가 오염돼 이후 모든 `git` 호출이 죽는 문제를 수정
- 오염된 config 하에서 `git rev-parse -q --verify CHERRY_PICK_HEAD`가 `rc!=0`을 "conflict 없음"으로 오독해 실제 conflict를 조용히 skip하고 이후 모든 후보까지 연쇄 스킵하던 오탐을 제거
- 회귀 방지 bats 테스트 1건 추가 (구 코드에서 fail, 신 코드에서 pass 확인 완료)

## Changes
- `gcp-scan`: 실행 루프 시작 시점(config 정상 상태)에 `git rev-parse --git-dir` 결과를 캐시해 두고, `CHERRY_PICK_HEAD` 존재 판별을 `git rev-parse` 대신 순수 파일 테스트(`[ -f "$_gcp_git_dir/CHERRY_PICK_HEAD" ]`)로 교체 — config 오염과 무관하게 정확히 판별
- `tests`: `[include]` 토폴로지에서 두 커밋이 `git/.gitconfig`를 함께 건드려 실행 루프까지 conflict가 전달되는 시나리오를 재현하는 bats 테스트 추가, `_gcp_scan`이 conflict를 은폐하지 않고 "Resolve and run" 메시지와 함께 `return 1`하는지 검증

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gcp.bats` — 88 passed, 0 failed (87 기존 + 1 신규)
- [x] 신규 테스트가 fix 이전 코드에서는 실패함을 확인 (진짜 회귀 가드)

## Related
Fixes #1213

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
