### PR TITLE
fix(ci): pin ruff==0.12.7 (dev group) — CI format 드리프트 해결

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 # --- 개발 및 테스트 환경 의존성 ---
 [dependency-groups] # 비표준으로 uv 에서는 인식, 그러나 pip 인식못함
-dev = ["ruff", "mypy", "pytest", "pytest-mock", "pytest-xdist", "pexpect"]
+dev = ["ruff==0.12.7", "mypy", "pytest", "pytest-mock", "pytest-xdist", "pexpect"]
 
 
 # --- Python 프로젝트 의존성 및 extras ---
@@ -32,7 +32,7 @@ dev = [
     "pytest-xdist>=3.0",  # For parallel test execution
     "pexpect>=4.8",  # For interactive shell testing
     # Linting and formatting
-    "ruff>=0.6.0",
+    "ruff==0.12.7",  # pinned: CI (uv sync --group dev) 가 최신 ruff 픽업 시 format 규칙 드리프트로 red (#1219 PR #1238)
     # Type checking
     "mypy>=1.10",
     "types-toml",


### PR DESCRIPTION
## 문제
`Lint (mise)` CI가 `ruff format --check .`에서 red. 원인은 PR별 코드가 아니라 **ruff 버전 드리프트**:

- CI는 `uv sync --group dev`로 설치 → `[dependency-groups] dev`의 `ruff`가 unpinned → CI가 최신 `ruff==0.16.0` 픽업.
- 0.16.0 신 포맷 규칙이 기존 `.py`(예: `tests/integration/conftest.py`의 `TemporaryDirectory(...)` 멀티라인) 재포맷 요구 → check 실패.
- 로컬/lock은 `0.12.7`이라 green. main도 지금 재실행하면 동일 red (환경 문제).

## 수정
- `[dependency-groups] dev`와 `[project.optional-dependencies] dev` 양쪽 `ruff`를 `==0.12.7`로 고정.
- `uv sync --group dev`가 결정적으로 0.12.7 설치 → CI=로컬 일치.
- `mise.toml` 주석("ruff는 pyproject dev group에 pin")의 원래 의도와 일치.

## 검증
- 강제 재설치(`uv sync --group dev --reinstall-package ruff`) → `ruff 0.12.7` (드리프트 차단 확인).
- `mise run lint-py`: ruff check / format / mypy 전부 통과.
- diff = `pyproject.toml` 2줄 (uv.lock은 이미 0.12.7이라 무변경).

Ref: #1219, #1238