### PR TITLE
fix(review): agy --print stdin 대신 인자로 프롬프트 전달

### DIFF
--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -246,6 +246,7 @@ _gh_pr_review_run_ai() {
     fi
     local _rc=0
     local _prompt_size
+    local _prompt_content
     case "$ai" in
     codex)
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
@@ -261,8 +262,10 @@ _gh_pr_review_run_ai() {
             printf 'agy --print: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
                 "$_prompt_size" 131072 >"$_stderr_file"
             _rc=1
+        elif ! _prompt_content=$(cat "$prompt_file" 2>"$_stderr_file"); then
+            _rc=1
         else
-            agy --print "$(cat "$prompt_file")" 2>"$_stderr_file" || _rc=$?
+            agy --print "$_prompt_content" 2>>"$_stderr_file" || _rc=$?
         fi
         ;;
     claude)

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -245,14 +245,25 @@ _gh_pr_review_run_ai() {
         return 1
     fi
     local _rc=0
+    local _prompt_size
     case "$ai" in
     codex)
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     agy)
-        # `agy --print` runs the Antigravity CLI non-interactively,
-        # reading the prompt from the prompt file content.
-        agy --print "$(cat "$prompt_file")" 2>"$_stderr_file" || _rc=$?
+        # `agy --print` runs the Antigravity CLI non-interactively but
+        # takes the prompt as a value argument, not stdin. The kernel caps
+        # a single argv string at MAX_ARG_STRLEN (32 pages = 131072 bytes
+        # on Linux) — a large PR diff would blow past that as a bare
+        # "Argument list too long" exec failure, so guard it explicitly.
+        _prompt_size=$(wc -c <"$prompt_file")
+        if [ "$_prompt_size" -ge 131072 ]; then
+            printf 'agy --print: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
+                "$_prompt_size" 131072 >"$_stderr_file"
+            _rc=1
+        else
+            agy --print "$(cat "$prompt_file")" 2>"$_stderr_file" || _rc=$?
+        fi
         ;;
     claude)
         if [ -n "$cfg_dir" ]; then

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -251,8 +251,8 @@ _gh_pr_review_run_ai() {
         ;;
     agy)
         # `agy --print` runs the Antigravity CLI non-interactively,
-        # reading the prompt from stdin.
-        agy --print <"$prompt_file" 2>"$_stderr_file" || _rc=$?
+        # reading the prompt from the prompt file content.
+        agy --print "$(cat "$prompt_file")" 2>"$_stderr_file" || _rc=$?
         ;;
     claude)
         if [ -n "$cfg_dir" ]; then

--- a/shell-common/functions/skill_loader.sh
+++ b/shell-common/functions/skill_loader.sh
@@ -40,7 +40,7 @@ skill_loader() {
         ux_bullet "Claude Code: Use ${UX_SUCCESS}/skill <name>${UX_RESET} within Claude Code"
         ux_bullet "View skill content: ${UX_SUCCESS}cat \"\$(skill-loader req-define)\"${UX_RESET}"
         ux_bullet "Codex: ${UX_SUCCESS}codex -p \"\$(cat \"\$(skill-loader cli-dev)\")\"${UX_RESET}"
-        ux_bullet "Antigravity (agy): ${UX_SUCCESS}agy --print < \"\$(skill-loader agents-md)\"${UX_RESET}"
+        ux_bullet "Antigravity (agy): ${UX_SUCCESS}agy --print \"\$(cat \"\$(skill-loader agents-md)\")\"${UX_RESET}"
 
         ux_section "Environment"
         ux_info "Skills path: $skills_dir"

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -296,3 +296,57 @@ EOF
     assert_success
     assert_output --partial "issuecomment-1"
 }
+
+# ---------------------------------------------------------------------------
+# _gh_pr_review_run_ai — agy transport (issue #1244 / PR #1245 review)
+# ---------------------------------------------------------------------------
+
+# Stub `agy` so the run_ai dispatcher can exercise the --print value-argument
+# path without invoking the real Antigravity CLI. Echoes its own argv back
+# so tests can assert on exactly what the function passed as $1.
+_stub_agy_echo() {
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/agy" <<'EOF'
+#!/bin/sh
+# $1 is --print; $2 is the prompt value this test asserts on.
+echo "agy called with: $2"
+exit 0
+EOF
+    chmod +x "$stub_dir/agy"
+    export PATH="$stub_dir:$PATH"
+}
+
+@test "run_ai agy: small prompt → passed as value argument, not stdin" {
+    _source_module
+    _stub_agy_echo
+    local f="$TEST_TEMP_HOME/prompt.txt"
+    printf 'review this diff' >"$f"
+    run _gh_pr_review_run_ai agy "$f"
+    assert_success
+    assert_output --partial "agy called with: review this diff"
+}
+
+@test "run_ai agy: prompt at/over MAX_ARG_STRLEN (131072 bytes) → fails with clear message, agy never invoked" {
+    _source_module
+    _stub_agy_echo
+    local f="$TEST_TEMP_HOME/big.txt"
+    # 131072 bytes exactly — the guard's `-ge` boundary.
+    head -c 131072 /dev/zero | tr '\0' 'x' >"$f"
+    run _gh_pr_review_run_ai agy "$f"
+    assert_failure
+    assert_output --partial "over the 131072-byte argv limit"
+    refute_output --partial "agy called with"
+}
+
+@test "run_ai agy: unreadable prompt file → fails, does not silently swallow the read error" {
+    _source_module
+    _stub_agy_echo
+    local f="$TEST_TEMP_HOME/unreadable.txt"
+    printf 'x' >"$f"
+    chmod 000 "$f"
+    run _gh_pr_review_run_ai agy "$f"
+    assert_failure
+    refute_output --partial "agy called with"
+    chmod 644 "$f" # restore so bats can clean up TEST_TEMP_HOME
+}


### PR DESCRIPTION
## Summary
- `agy --print`가 stdin이 아닌 값 인자를 요구해 `gh-pr-review --ai agy` 호출이 항상 실패하던 문제를 수정.

## Changes
- `shell-common/functions/gh_pr_review.sh`: agy 분기를 `agy --print <"$prompt_file"` (stdin, 실패) 에서 `agy --print "$(cat "$prompt_file")"` (값 인자, 성공)으로 변경. gemini bug A(issue #694)와 동일 패턴 재발이었음을 실측으로 확인.

## Test plan
- [x] `agy --print </tmp/p.txt` → `flag needs an argument: -print` (수정 전 실패 재현)
- [x] `agy --print "$(cat /tmp/p.txt)"` → 정상 응답 (수정 후 확인)
- [x] `shellcheck` / `shfmt -d` clean
- [x] `tests/bats/functions/gh_pr_review.bats` + `tests/bats/skills/gh_pr_review_*.bats` 61/61 pass

## Related
Closes #1244

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
