### PR TITLE
fix(my-help): search 결과에 zsh debug-echo 노이즈 라인 섞이는 문제 수정

### DIFF
--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -583,15 +583,15 @@ _my_help_search() {
     # list, so there's no need for a temp file (see _my_help_show_all's temp
     # file, which the "unique count" and "uncategorized topics" checks below
     # it still need to re-read).
-    local selected
+    # Declare the loop-body variables once, up front: `local x=$(cmd)` inside
+    # the piped while-read makes zsh echo the assignment as a stray stdout line
+    # (#1248) and also masks $cmd's exit status behind the `local` builtin's.
+    # Pre-declaring keeps the in-loop assignments plain and does neither.
+    local selected underscore_name desc
     selected=$(
         _my_help_enumerate_topic_names | while IFS= read -r display_name; do
-            # Combine "local x" + "x=$(...)" onto one line — zsh echoes the
-            # assignment as a stray stdout line otherwise when split across
-            # two statements inside a piped while-read (same fix already
-            # applied to _my_help_show_category's "local desc=$(...)" line).
-            local underscore_name=$(printf "%s" "$display_name" | tr '-' '_')
-            local desc=$(_my_help_topic_description "${underscore_name%_help}")
+            underscore_name=$(printf "%s" "$display_name" | tr '-' '_')
+            desc=$(_my_help_topic_description "${underscore_name%_help}")
             printf '%s\t%s\n' "$display_name" "$desc"
         done | fzf --delimiter='\t' --with-nth=1,2 --prompt="my-help> "
     ) || true

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -586,10 +586,12 @@ _my_help_search() {
     local selected
     selected=$(
         _my_help_enumerate_topic_names | while IFS= read -r display_name; do
-            local underscore_name
-            underscore_name=$(printf "%s" "$display_name" | tr '-' '_')
-            local desc
-            desc=$(_my_help_topic_description "${underscore_name%_help}")
+            # Combine "local x" + "x=$(...)" onto one line — zsh echoes the
+            # assignment as a stray stdout line otherwise when split across
+            # two statements inside a piped while-read (same fix already
+            # applied to _my_help_show_category's "local desc=$(...)" line).
+            local underscore_name=$(printf "%s" "$display_name" | tr '-' '_')
+            local desc=$(_my_help_topic_description "${underscore_name%_help}")
             printf '%s\t%s\n' "$display_name" "$desc"
         done | fzf --delimiter='\t' --with-nth=1,2 --prompt="my-help> "
     ) || true

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -5,7 +5,14 @@ Tests that all registered my-help topics are callable
 without errors in both bash and zsh environments.
 """
 
+import os
+import re
+import stat
+from pathlib import Path
+
 import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
 
 HELP_TOPICS = [
     "agy_help",
@@ -225,6 +232,90 @@ class TestHelpSearchFallback:
         assert "Categories" in result.stdout, f"{shell}: my_help_impl {arg} did not render the category table"
         assert "CLI Utilities" in result.stdout, f"{shell}: my_help_impl {arg} category rows missing"
         assert "not found" not in result.stdout, f"{shell}: '{arg}' fell through to topic resolution"
+
+
+class TestHelpSearchInteractive:
+    """`my-help search` on the real fzf path, driven through a pty (#1248).
+
+    TestHelpSearchFallback above can only reach the no-TTY fallback, so the
+    interactive branch — the one where the zsh stray-`desc=` line bug lived —
+    went untested. pexpect gives us a pty so `[ -t 0 ] && [ -t 1 ]` holds, and
+    a stub `fzf` on PATH captures the candidate stream and picks a topic.
+    """
+
+    @staticmethod
+    def _spawn(shell, tmp_path, stub_body, prelude=""):
+        """Run `my_help_impl search` under a pty with a stubbed fzf.
+
+        Returns (exit_code, output, captured_candidates_or_None).
+        """
+        pexpect = pytest.importorskip("pexpect")
+
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        capture = tmp_path / "candidates.txt"
+        stub = bindir / "fzf"
+        stub.write_text('#!/bin/sh\ncat > "$FZF_STUB_CAPTURE"\n' + stub_body)
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        home = tmp_path / "home"
+        home.mkdir()
+        env = {
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "FZF_STUB_CAPTURE": str(capture),
+            "DOTFILES_FORCE_INIT": "1",
+            "DOTFILES_TEST_MODE": "1",
+            "DOTFILES_ROOT": str(REPO_ROOT),
+            "SHELL_COMMON": str(REPO_ROOT / "shell-common"),
+            "DOTFILES_ROOT_NO_CANONICALIZE": "1",
+            "HOME": str(home),
+            "ZDOTDIR": str(home),
+            "XDG_CONFIG_HOME": str(home),
+            "XDG_CACHE_HOME": str(home),
+            "XDG_DATA_HOME": str(home),
+            "TERM": "dumb",
+        }
+        if shell == "zsh":
+            entry, args = REPO_ROOT / "zsh/main.zsh", ["-f", "-lc"]
+        else:
+            entry, args = REPO_ROOT / "bash/main.bash", ["--noprofile", "--norc", "-lc"]
+        args.append(f"source {entry}; {prelude}my_help_impl search")
+
+        child = pexpect.spawn(shell, args, env=env, encoding="utf-8", timeout=60, dimensions=(40, 200))
+        child.expect(pexpect.EOF)
+        output = child.before
+        child.close()
+        captured = capture.read_text() if capture.exists() else None
+        return child.exitstatus, output, captured
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_selecting_a_candidate_dispatches_to_that_topic(self, shell, tmp_path):
+        """The fzf candidate stream carries only `topic<TAB>desc` lines, and the
+        selected line dispatches to that topic's help output."""
+        exit_code, output, captured = self._spawn(
+            shell, tmp_path, stub_body='grep -m1 "^git-help\t" "$FZF_STUB_CAPTURE"\n'
+        )
+        assert exit_code == 0, f"{shell}: my_help_impl search failed\n{output}"
+        assert captured, f"{shell}: fzf stub received no candidates"
+
+        # #1248: zsh echoed `local x=$(...)` assignments as stray stdout lines,
+        # polluting the list the user picks from.
+        noise = [ln for ln in captured.splitlines() if re.match(r"^(desc|underscore_name)=", ln)]
+        assert not noise, f"{shell}: {len(noise)} debug-echo noise lines in candidate list, e.g. {noise[:3]}"
+        assert all("\t" in ln for ln in captured.splitlines()), f"{shell}: malformed candidate line in {captured!r}"
+        assert "git-help\t" in captured, f"{shell}: git-help candidate missing"
+
+        # Same assertion style as TestHelpTopicsWithDifferentFormats: the topic ran.
+        assert "Usage: git-help" in output, f"{shell}: selection did not dispatch to git-help\n{output}"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_cancelling_fzf_exits_cleanly(self, shell, tmp_path):
+        """Esc (fzf exits 130 with no selection) must return 0 silently instead
+        of aborting the shell under err_exit / pipefail (PR #1247)."""
+        prelude = "setopt err_exit pipe_fail; " if shell == "zsh" else "set -e -o pipefail; "
+        exit_code, output, _ = self._spawn(shell, tmp_path, stub_body="exit 130\n", prelude=prelude)
+        assert exit_code == 0, f"{shell}: cancelled search returned {exit_code}\n{output}"
+        assert not output.strip(), f"{shell}: cancelled search printed output: {output!r}"
 
 
 class TestHelpTopicsErrorHandling:


### PR DESCRIPTION
## Summary
- `my-help search`(#1247)에서 fzf 후보 목록에 `desc='...'`/`underscore_name=...` 같은 zsh 디버그 echo 라인이 실제 topic과 섞여 나와, 그 라인을 선택해도 아무 곳으로도 이동하지 않던 버그 수정

## Changes
- `shell-common/functions/my_help.sh`: `_my_help_search()` 내부 `local x; x=$(...)` 분리 패턴을 `local x=$(...)` 한 줄로 합침 — 이 파일에 이미 여러 번 문서화된 zsh 안티패턴(파이프 안 while-read 루프에서 local 선언과 대입이 분리되면 대입 결과가 stdout으로 echo됨)이 `/simplify` 리팩터(PR #1247, 9250cf5f)에서 재도입된 것

## Test plan
- [x] 재현 스크립트로 수정 전/후 비교 — 수정 후 `desc=`/`underscore_name=` 노이즈 라인 0건
- [x] fzf stub + pty(`script -qec`)로 실제 `_my_help_search` 파이프 입력 캡처 — 노이즈 없이 51개 topic 라인만 확인
- [x] `pytest tests/integration/test_help_topics.py` — 275 passed
- [x] `./tests/test` (bats + pytest + golden rules) — 1209 passed

## Related
Closes #1248

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
