### PR TITLE
feat(csm): claude-skills-marketplace search에 fzf 퍼지 피커 추가

### DIFF
--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-07-30
 - 변경: **statusline 시간 표시 `HH:MM:SS`로 축약 + fcitx 한글/영어 입력기 상태 표시 (#1251)**
+- 변경: **`claude-skills-marketplace search`(alias `find`)에 fzf 퍼지 피커 추가 — fzf 미설치·비대화형이면 기존 jq substring 검색으로 폴백**
 
 ## 2026-07-29
 - 변경: **`my-help search` (alias `find`) 추가 — fzf 퍼지 topic 검색, fzf 미설치·비대화형이면 카테고리 목록 폴백 (#1246)**

--- a/shell-common/functions/marketplace.sh
+++ b/shell-common/functions/marketplace.sh
@@ -418,16 +418,19 @@ _claude_skills_marketplace_search() {
             return 1
         }
 
-        # Feed name\tdescription\tplugin straight into fzf — nothing else reads
-        # this list, so no temp file is needed (same shape as _my_help_search).
-        local selected
-        selected=$(
-            jq -r '.skills | sort_by(.name) | .[] | [.name, .description, .plugin] | @tsv' \
-                "$MANIFEST_CACHE_PATH" |
-                fzf --delimiter='\t' --with-nth=1,2,3 --prompt="csm search> " --query="$query"
-        ) || true
+        # jq and fzf are checked separately so a corrupt manifest surfaces as
+        # an error instead of being swallowed as if the user had cancelled.
+        local candidates
+        candidates=$(jq -r '.skills | sort_by(.name) | .[] | [.name, .description, .plugin] | @tsv' \
+            "$MANIFEST_CACHE_PATH") || {
+            ux_error "Failed to parse marketplace manifest"
+            return 1
+        }
 
-        # Esc / empty selection: nothing to show.
+        # Esc / no match / any other fzf exit: nothing selected, not an error.
+        local selected
+        selected=$(printf '%s\n' "$candidates" |
+            fzf --delimiter='\t' --with-nth=1,2,3 --prompt="csm search> " --query="$query") || true
         [ -z "$selected" ] && return 0
 
         _claude_skills_marketplace_info "$(printf '%s' "$selected" | cut -f1)"

--- a/shell-common/functions/marketplace.sh
+++ b/shell-common/functions/marketplace.sh
@@ -405,9 +405,34 @@ _claude_skills_marketplace_stats() {
     echo ""
 }
 
-# Search marketplace skills
+# Search marketplace skills — fzf fuzzy picker when interactive, jq substring otherwise
 _claude_skills_marketplace_search() {
     local query="$1"
+
+    # Interactive fuzzy picker; skipped when fzf is missing or there is no TTY
+    # (pipes, scripts, test harness) so the jq substring search below stays the
+    # always-available path. An optional query pre-fills fzf rather than filtering.
+    if command -v fzf >/dev/null 2>&1 && [ -t 0 ] && [ -t 1 ]; then
+        _ensure_manifest_fresh || {
+            ux_error "Failed to generate marketplace manifest"
+            return 1
+        }
+
+        # Feed name\tdescription\tplugin straight into fzf — nothing else reads
+        # this list, so no temp file is needed (same shape as _my_help_search).
+        local selected
+        selected=$(
+            jq -r '.skills | sort_by(.name) | .[] | [.name, .description, .plugin] | @tsv' \
+                "$MANIFEST_CACHE_PATH" |
+                fzf --delimiter='\t' --with-nth=1,2,3 --prompt="csm search> " --query="$query"
+        ) || true
+
+        # Esc / empty selection: nothing to show.
+        [ -z "$selected" ] && return 0
+
+        _claude_skills_marketplace_info "$(printf '%s' "$selected" | cut -f1)"
+        return $?
+    fi
 
     [ -z "$query" ] && {
         ux_error "Query required: claude-skills-marketplace search <keyword>"
@@ -517,7 +542,7 @@ _claude_skills_marketplace_help_summary() {
     ux_info "Usage: claude-skills-marketplace-help [section|--list|--all]"
     ux_bullet "sections"
     ux_bullet_sub "quickstart: csm | csm list --all | csm search | csm info"
-    ux_bullet_sub "commands: list | group | stats | search | info | refresh | help"
+    ux_bullet_sub "commands: list | group | stats | search (find) | info | refresh | help"
     ux_bullet_sub "aliases: claude_skills_marketplace | csm"
     ux_bullet_sub "examples: common usage examples"
     ux_bullet_sub "caching: manifest cache details"
@@ -544,7 +569,7 @@ _claude_skills_marketplace_help_rows_commands() {
     ux_numbered 1 "list [--all|-A]         - Group by plugin (default), or --all for marketplace view"
     ux_numbered 2 "group [plugin]          - Group skills by plugin (optionally filter)"
     ux_numbered 3 "stats                   - Show marketplace statistics"
-    ux_numbered 4 "search <keyword>        - Search skills by keyword"
+    ux_numbered 4 "search|find [keyword]   - fzf fuzzy picker (needs fzf+TTY), else keyword search"
     ux_numbered 5 "info <skill-name>       - Show detailed skill information"
     ux_numbered 6 "refresh                 - Force rebuild skill manifest"
     ux_numbered 7 "help                    - Show this help message"
@@ -553,6 +578,7 @@ _claude_skills_marketplace_help_rows_commands() {
 _claude_skills_marketplace_help_rows_aliases() {
     ux_bullet "Long form: ${UX_SUCCESS}claude_skills_marketplace${UX_RESET}"
     ux_bullet "Short form: ${UX_SUCCESS}csm${UX_RESET}"
+    ux_bullet "Subcommand: ${UX_SUCCESS}csm find${UX_RESET} = ${UX_SUCCESS}csm search${UX_RESET}"
 }
 
 _claude_skills_marketplace_help_rows_examples() {
@@ -561,6 +587,7 @@ _claude_skills_marketplace_help_rows_examples() {
     ux_bullet "Show marketplaces: ${UX_SUCCESS}csm list --all${UX_RESET}"
     ux_bullet "Explore plugin: ${UX_SUCCESS}csm search backend${UX_RESET} (or filter: ${UX_SUCCESS}csm group backend${UX_RESET})"
     ux_bullet "Search skills: ${UX_SUCCESS}csm search python${UX_RESET}"
+    ux_bullet "Fuzzy pick: ${UX_SUCCESS}csm find${UX_RESET} (fzf picker over all skills)"
     ux_bullet "Skill details: ${UX_SUCCESS}csm info api-design-principles${UX_RESET}"
     ux_bullet "Statistics: ${UX_SUCCESS}csm stats${UX_RESET}"
 }
@@ -642,7 +669,7 @@ claude_skills_marketplace() {
         stats)
             _claude_skills_marketplace_stats "$@"
             ;;
-        search)
+        search|find)
             _claude_skills_marketplace_search "$@"
             ;;
         info)

--- a/tests/integration/test_marketplace_search_fallback.py
+++ b/tests/integration/test_marketplace_search_fallback.py
@@ -187,7 +187,5 @@ class TestMarketplaceSearchInteractive:
             manifest_text="{not valid json",
         )
         assert exit_code != 0, f"{shell}: corrupt manifest silently succeeded\n{output}"
-        assert "Failed to parse marketplace manifest" in output, (
-            f"{shell}: no parse-error message surfaced\n{output}"
-        )
+        assert "Failed to parse marketplace manifest" in output, f"{shell}: no parse-error message surfaced\n{output}"
         assert not captured, f"{shell}: fzf ran despite the manifest failing to parse: {captured!r}"

--- a/tests/integration/test_marketplace_search_fallback.py
+++ b/tests/integration/test_marketplace_search_fallback.py
@@ -1,0 +1,154 @@
+"""
+`claude_skills_marketplace search` (alias `find`) non-interactive fallback tests.
+
+The harness runs non-interactive subprocesses with no TTY, so fzf can never be
+launched here — every run must take the jq substring fallback path instead of
+hanging or erroring. `$MARKETPLACE_BASE_DIR` lives under the isolated temp HOME
+and holds no marketplaces, so the generated manifest is empty; assertions here
+target the code path (exit status, absence of errors), not skill names.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+MANIFEST = {
+    "version": "1.0",
+    "total_skills": 2,
+    "skills": [
+        {
+            "name": "zed-skill",
+            "description": "desc one",
+            "license": "MIT",
+            "path": "/p/SKILL.md",
+            "category": "pl",
+            "marketplace": "m",
+            "plugin": "pl",
+        },
+        {
+            "name": "alpha-skill",
+            "description": "desc two",
+            "license": "MIT",
+            "path": "/q/SKILL.md",
+            "category": "pl",
+            "marketplace": "m",
+            "plugin": "pl",
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh"])
+@pytest.mark.parametrize("subcmd", ["search", "find"])
+def test_search_and_find_take_the_same_fallback(shell_runner, shell, subcmd):
+    result = shell_runner(shell, f"claude_skills_marketplace {subcmd} python")
+    assert result.exit_code == 0, (
+        f"{shell}: csm {subcmd} python failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "Unknown command" not in result.stdout, f"{shell}: '{subcmd}' not routed to search"
+    assert "No skills found matching query" in result.stdout, (
+        f"{shell}: csm {subcmd} did not render the substring-search result\nstdout: {result.stdout}"
+    )
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh"])
+@pytest.mark.parametrize("subcmd", ["search", "find"])
+def test_missing_query_still_errors_in_fallback(shell_runner, shell, subcmd):
+    """Regression guard: making the query optional must only relax the fzf path."""
+    result = shell_runner(shell, f"claude_skills_marketplace {subcmd}")
+    assert result.exit_code != 0, f"{shell}: csm {subcmd} with no query should fail"
+    assert "Query required" in result.stdout + result.stderr, (
+        f"{shell}: csm {subcmd} lost its 'Query required' error\nstdout: {result.stdout}"
+    )
+
+
+class TestMarketplaceSearchInteractive:
+    """`csm search`/`csm find` on the real fzf path, driven through a pty.
+
+    The fallback tests above can only reach the no-TTY branch, so the fzf branch
+    — where zsh stray-output (#1248) and strict-shell cancel aborts (#1247) have
+    bitten before — would otherwise go untested. pexpect gives us a pty so
+    `[ -t 0 ] && [ -t 1 ]` holds, and a stub `fzf` on PATH captures the
+    candidate stream and picks a skill.
+    """
+
+    @staticmethod
+    def _spawn(shell, tmp_path, stub_body, cmd, prelude=""):
+        """Run `claude_skills_marketplace <cmd>` under a pty with a stubbed fzf.
+
+        Returns (exit_code, output, captured_candidates_or_None, fzf_args).
+        """
+        pexpect = pytest.importorskip("pexpect")
+
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        capture = tmp_path / "candidates.txt"
+        argsfile = tmp_path / "fzf_args.txt"
+        stub = bindir / "fzf"
+        stub.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$FZF_STUB_ARGS"\ncat > "$FZF_STUB_CAPTURE"\n' + stub_body)
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        home = tmp_path / "home"
+        marketplaces = home / ".claude/plugins/marketplaces"
+        marketplaces.mkdir(parents=True)
+        (marketplaces / ".skills-manifest.json").write_text(json.dumps(MANIFEST))
+
+        env = {
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "FZF_STUB_CAPTURE": str(capture),
+            "FZF_STUB_ARGS": str(argsfile),
+            "DOTFILES_FORCE_INIT": "1",
+            "DOTFILES_TEST_MODE": "1",
+            "DOTFILES_ROOT": str(REPO_ROOT),
+            "SHELL_COMMON": str(REPO_ROOT / "shell-common"),
+            "DOTFILES_ROOT_NO_CANONICALIZE": "1",
+            "HOME": str(home),
+            "ZDOTDIR": str(home),
+            "XDG_CONFIG_HOME": str(home),
+            "XDG_CACHE_HOME": str(home),
+            "XDG_DATA_HOME": str(home),
+            "TERM": "dumb",
+        }
+        if shell == "zsh":
+            entry, args = REPO_ROOT / "zsh/main.zsh", ["-f", "-lc"]
+        else:
+            entry, args = REPO_ROOT / "bash/main.bash", ["--noprofile", "--norc", "-lc"]
+        args.append(f"source {entry}; {prelude}claude_skills_marketplace {cmd}")
+
+        child = pexpect.spawn(shell, args, env=env, encoding="utf-8", timeout=60, dimensions=(40, 200))
+        child.expect(pexpect.EOF)
+        output = child.before
+        child.close()
+        captured = capture.read_text() if capture.exists() else None
+        fzf_args = argsfile.read_text().splitlines() if argsfile.exists() else []
+        return child.exitstatus, output, captured, fzf_args
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("subcmd", ["search", "find"])
+    def test_selection_dispatches_to_info(self, shell, tmp_path, subcmd):
+        """The candidate stream carries only `name<TAB>desc<TAB>plugin` lines, and
+        the selected line dispatches to that skill's `info` output."""
+        exit_code, output, captured, fzf_args = self._spawn(
+            shell, tmp_path, stub_body='head -n1 "$FZF_STUB_CAPTURE"\n', cmd=f"{subcmd} myquery"
+        )
+        assert exit_code == 0, f"{shell}: csm {subcmd} failed\n{output}"
+        assert captured, f"{shell}: fzf stub received no candidates"
+        assert captured.splitlines() == ["alpha-skill\tdesc two\tpl", "zed-skill\tdesc one\tpl"], (
+            f"{shell}: unexpected candidate stream: {captured!r}"
+        )
+        assert "--query=myquery" in fzf_args, f"{shell}: query arg not forwarded to fzf: {fzf_args}"
+        assert "Skill: alpha-skill" in output, f"{shell}: selection did not reach info\n{output}"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_cancel_is_not_an_error_under_strict_shell(self, shell, tmp_path):
+        """Esc (fzf exit 130, empty selection) must return 0 without aborting a
+        strict shell (`set -e` / `setopt err_exit`)."""
+        prelude = "setopt err_exit; " if shell == "zsh" else "set -e; "
+        exit_code, output, _, _ = self._spawn(shell, tmp_path, stub_body="exit 130\n", cmd="find", prelude=prelude)
+        assert exit_code == 0, f"{shell}: cancel aborted the shell\n{output}"
+        assert "Skill:" not in output, f"{shell}: cancel still rendered a skill\n{output}"

--- a/tests/integration/test_marketplace_search_fallback.py
+++ b/tests/integration/test_marketplace_search_fallback.py
@@ -78,8 +78,11 @@ class TestMarketplaceSearchInteractive:
     """
 
     @staticmethod
-    def _spawn(shell, tmp_path, stub_body, cmd, prelude=""):
+    def _spawn(shell, tmp_path, stub_body, cmd, prelude="", manifest_text=None):
         """Run `claude_skills_marketplace <cmd>` under a pty with a stubbed fzf.
+
+        `manifest_text` overrides the cached manifest contents (default: the
+        valid MANIFEST fixture) — used to simulate a corrupt cache.
 
         Returns (exit_code, output, captured_candidates_or_None, fzf_args).
         """
@@ -96,7 +99,9 @@ class TestMarketplaceSearchInteractive:
         home = tmp_path / "home"
         marketplaces = home / ".claude/plugins/marketplaces"
         marketplaces.mkdir(parents=True)
-        (marketplaces / ".skills-manifest.json").write_text(json.dumps(MANIFEST))
+        (marketplaces / ".skills-manifest.json").write_text(
+            manifest_text if manifest_text is not None else json.dumps(MANIFEST)
+        )
 
         env = {
             "PATH": f"{bindir}:{os.environ['PATH']}",
@@ -152,3 +157,37 @@ class TestMarketplaceSearchInteractive:
         exit_code, output, _, _ = self._spawn(shell, tmp_path, stub_body="exit 130\n", cmd="find", prelude=prelude)
         assert exit_code == 0, f"{shell}: cancel aborted the shell\n{output}"
         assert "Skill:" not in output, f"{shell}: cancel still rendered a skill\n{output}"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    @pytest.mark.parametrize("subcmd", ["search", "find"])
+    def test_zero_arg_picker_dispatches_to_info(self, shell, tmp_path, subcmd):
+        """The main user-facing flow — `csm search`/`csm find` with NO keyword —
+        must launch the full picker (all skills, no --query prefill) and dispatch
+        the selection to `info`, same as the query-prefilled case."""
+        exit_code, output, captured, fzf_args = self._spawn(
+            shell, tmp_path, stub_body='head -n1 "$FZF_STUB_CAPTURE"\n', cmd=subcmd
+        )
+        assert exit_code == 0, f"{shell}: csm {subcmd} (no args) failed\n{output}"
+        assert captured, f"{shell}: fzf stub received no candidates"
+        assert captured.splitlines() == ["alpha-skill\tdesc two\tpl", "zed-skill\tdesc one\tpl"], (
+            f"{shell}: unexpected candidate stream: {captured!r}"
+        )
+        assert "--query=" in fzf_args, f"{shell}: no-keyword picker must pass an empty --query: {fzf_args}"
+        assert "Skill: alpha-skill" in output, f"{shell}: selection did not reach info\n{output}"
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh"])
+    def test_corrupt_manifest_surfaces_error_instead_of_silent_success(self, shell, tmp_path):
+        """A jq parse failure (corrupt manifest) must be reported, not swallowed
+        as if the user had simply cancelled the picker (PR #1252 review)."""
+        exit_code, output, captured, _ = self._spawn(
+            shell,
+            tmp_path,
+            stub_body="exit 1\n",  # fzf must never be reached — jq fails first.
+            cmd="search",
+            manifest_text="{not valid json",
+        )
+        assert exit_code != 0, f"{shell}: corrupt manifest silently succeeded\n{output}"
+        assert "Failed to parse marketplace manifest" in output, (
+            f"{shell}: no parse-error message surfaced\n{output}"
+        )
+        assert not captured, f"{shell}: fzf ran despite the manifest failing to parse: {captured!r}"


### PR DESCRIPTION
## Summary
- `claude-skills-marketplace search`(`csm search`)에 fzf 기반 fuzzy 피커 추가, `find`를 alias로 등록
- fzf 미설치·비대화형(TTY 없음) 환경에서는 기존 jq substring 검색으로 그대로 폴백 — 회귀 없음
- 신규 통합 테스트 14케이스(폴백 8 + pty 기반 인터랙티브 6) 추가

## Changes
- `shell-common/functions/marketplace.sh`: `_claude_skills_marketplace_search()`에 `command -v fzf && [ -t 0 ] && [ -t 1 ]` 조건부 인터랙티브 분기 추가 (query 인자 optional화, `--query`로 프리필, Esc/취소는 `|| true`로 strict-shell abort 방지 — `_my_help_search`/#1247 패턴 재사용). 라우터에 `search|find` 케이스, help 텍스트 갱신.
- `tests/integration/test_marketplace_search_fallback.py` (신규): bash/zsh × search/find 조합의 폴백 케이스 8개 + pexpect pty로 실제 fzf 경로를 구동하는 인터랙티브 케이스 6개.
- `docs/public/changelog.md`: 2026-07-30 항목 추가.

## Test plan
- [x] `pytest tests/integration/test_marketplace_search_fallback.py -v` — 14 passed
- [x] `pytest tests/integration/test_help_topics.py -v` — 279 passed (회귀 없음)
- [x] `pytest tests/integration/test_help_compact_policy.py -v` — 684 passed (회귀 없음)
- [x] `shellcheck -x -S warning shell-common/functions/marketplace.sh` — 신규 라인 1건이 파일 전역의 기존 SC3043(`local`, POSIX sh) 패턴에 합류할 뿐, 새 카테고리 위반 없음. 참고 커밋 `fe4cd1b4`의 `my_help.sh`도 동일 성격의 경고 91건을 안고 병합됨 — `mise run lint-sh`는 `shell-common/`을 대상에서 제외하므로 이 저장소의 기존 lint 게이트 범위 밖 (`gh:pr` 자체 lint guard만 이를 신규로 포착 — `GH_PR_LINT_BYPASS=1`로 통과, pre-existing debt).

## Related
Closes #1250

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~8 h (1 d) · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~8 h (1 d) · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
