### PR TITLE
fix(claude): statusline fcitx 체크에 PC별 opt-out 추가

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -3,6 +3,10 @@
 # Status line command for Claude Code
 # Format: [한글|영어] HH:MM:SS | model | project(branch) | git-status
 # ([한글|영어]는 fcitx-remote가 설치된 환경에서만 나타나는 optional 필드)
+# CLAUDE_STATUSLINE_SKIP_FCITX=1 이면 fcitx-remote 호출 자체를 생략한다.
+# Windows Terminal / VS Code Remote-WSL 콘솔은 X11 클라이언트가 아니라 fcitx
+# XIM 경로에 아예 안 걸려 상태가 항상 비어있다 — 매 프롬프트마다 의미 없는
+# timeout 0.3s 대기만 생기므로, 이런 PC는 ~/.zshrc.local 에 export 로 꺼둔다.
 
 # ANSI color codes
 CYAN='\033[36m'
@@ -46,7 +50,7 @@ current_hour="${current_time%%:*}"
 # `timeout 0.3` bounds a hung/no-DBus fcitx-remote so it can't stall the
 # whole statusline render.
 ime_label=""
-if command -v fcitx-remote >/dev/null 2>&1; then
+if [ "${CLAUDE_STATUSLINE_SKIP_FCITX:-0}" != "1" ] && command -v fcitx-remote >/dev/null 2>&1; then
     case "$(timeout 0.3 fcitx-remote 2>/dev/null)" in
     2) ime_label="한글" ;;
     1) ime_label="영어" ;;

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-07-30
 - 변경: **statusline 시간 표시 `HH:MM:SS`로 축약 + fcitx 한글/영어 입력기 상태 표시 (#1251)**
+- 변경: **`CLAUDE_STATUSLINE_SKIP_FCITX=1` 환경변수 추가 — Windows Terminal/VS Code Remote-WSL처럼 X11 클라이언트가 아닌 콘솔에서는 fcitx 상태를 원천적으로 못 읽으므로 매 프롬프트 fcitx-remote 호출을 건너뜀 (개인 PC는 `~/.zshrc.local`에서 설정)**
 - 변경: **`claude-skills-marketplace search`(alias `find`)에 fzf 퍼지 피커 추가 — fzf 미설치·비대화형이면 기존 jq substring 검색으로 폴백**
 
 ## 2026-07-29


### PR DESCRIPTION
## Summary
- Windows Terminal/VS Code Remote-WSL 콘솔에서 statusline 한글/영어 필드가 항상 비어있는 근본 원인(fcitx가 X11 클라이언트 아닌 콘솔엔 원천적으로 안 닿음)을 규명하고, 무의미한 매 프롬프트 `fcitx-remote` 호출을 PC별로 끌 수 있는 opt-out을 추가했다.

## Changes
- `claude/statusline-command.sh`: `CLAUDE_STATUSLINE_SKIP_FCITX=1`이면 fcitx-remote 호출(및 timeout 0.3s 대기)을 생략하는 가드 추가. 옵트아웃이므로 미설정 시 기존 동작(7fd57796) 그대로 유지.
- `docs/public/changelog.md`: 변경 기록 추가.

## Test plan
- [x] `bash -n claude/statusline-command.sh` 문법 통과
- [x] `shellcheck claude/statusline-command.sh` 클린
- [x] `CLAUDE_STATUSLINE_SKIP_FCITX=1` 설정/미설정 양쪽 실행 비교 — 이 PC에서는 라벨 없음 동일(성능만 차이), 옵트아웃 미설정 PC는 기존 로직 그대로

## Related
Closes #1254

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~8 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~8 min
<!-- /ai-metrics:gh-pr -->

</details>