### PR TITLE
docs(claude): CLAUDE.md Commands 섹션을 mise tasks 참조로 축소

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,19 +9,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./setup.sh          # Symlinks + environment config
 ./install.sh        # Full install
 
-# Lint (all)
-mise run lint       # ruff + mypy + shellcheck + shfmt -d (read-only)
-mise run fix        # ruff --fix + ruff format + shfmt -w (mutating)
+# Lint / test tasks
+mise tasks          # SSOT for lint / fix / test / lint-docs — read mise.toml, not this file
 
-# Lint (targeted)
-mise run lint-sh    # Shell lint (shellcheck + shfmt diff)
-mise run fix-sh     # Shell format (shfmt -w bash/)
-mise run lint-py    # Python lint (ruff + mypy, read-only)
-mise run fix-py     # Python format + fix (ruff, mutating)
-
-# Tests
-mise run test       # All tests (bats + pytest + golden rules)
-./tests/test        # Same runner invoked directly
+# Tests (non-obvious invocations only)
+./tests/test        # Runner invoked directly (mise run test wraps it in `uv run`)
 ./tests/test -v     # Verbose
 pytest tests/integration/test_help_topics.py -v  # Single pytest file
 ./tests/bats/lib/bats-core/bin/bats tests/bats/functions  # Bats only


### PR DESCRIPTION
## Summary
- `CLAUDE.md`의 Commands 섹션에 하드코딩돼 있던 `mise run lint/fix/test` 목록을 `mise tasks` 참조로 축소해, `mise.toml` 태스크가 늘어날 때(`lint-docs` 등)마다 문서가 stale해지는 걸 방지한다.

## Changes
- `docs(claude)`: `mise run lint`/`fix`/`lint-sh`/`fix-sh`/`lint-py`/`fix-py`/`test` 라인을 나열하던 부분을 `mise tasks` 한 줄로 대체하고, `mise.toml`만으론 알기 어려운 비자명한 실행법(`./tests/test`가 `mise run test`의 `uv run` 래핑이라는 점, 단일 pytest 파일 실행, bats 단독 실행)만 남김.

## Test plan
- [x] `mise tasks` 출력이 CLAUDE.md 새 설명(`lint/fix/test/lint-docs`)과 일치하는지 확인 (`fix, fix-py, fix-sh, lint, lint-docs, lint-py, lint-sh, test` 8개 태스크 확인됨)
- [ ] `mise run lint` (문서 변경만 있어 스코프 밖이지만, pre-commit hook이 커밋 시점에 이미 통과함)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
