### PR TITLE
feat(docs): 커맨드별 마크다운 레퍼런스 자동생성 + ripgrep 전체 텍스트 검색

### DIFF
--- a/docs/.ssot/command-guidelines.md
+++ b/docs/.ssot/command-guidelines.md
@@ -55,6 +55,19 @@
 - row 데이터 정의와 화면 조립 로직을 분리한다.
 - 섹션 추가 시 row 함수만 추가하고 renderer에 조립한다.
 
+### 3) 문서 자동생성 (issue #1262)
+
+row 함수는 화면 출력뿐 아니라 **커맨드 레퍼런스 문서의 데이터 소스** 이기도 하다.
+`shell-common/tools/custom/gen_command_docs.sh` 가 `shell-common/functions/*.sh` 전체에서
+`_<topic>_help_rows_<section>()` 를 찾아 실행하고, 결과를
+`docs/guide/commands/<커맨드>.md` 로 렌더링한다 (`rg` 전체 텍스트 검색 대상).
+
+- row 함수 네이밍(`_<topic>_help_rows_<section>`)을 벗어나면 그 커맨드는 문서 생성에서 **조용히 누락된다**.
+- 생성 문서는 직접 편집하지 않는다. 내용을 바꾸려면 row 함수를 고치고 재생성한다.
+- 소스 주석에만 있는 엣지케이스(예: fzf 피커가 Esc 에 조용히 exit 0)는 자동 추출 대상이 아니다.
+  `docs/guide/commands/.notes/<커맨드>.md` 에 수기로 적으면 재생성 시 문서에 삽입된다.
+- 재생성: `./shell-common/tools/custom/gen_command_docs.sh --force` (내용이 바뀐 파일만 갱신).
+
 ## 네이밍 규칙 (help 함수)
 
 - 함수명: snake_case (`git_help`, `gwt_help`)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,7 +19,7 @@
 - **DO**: 일관된 용어 사용
 - **DO**: 구체적 예시(코드 스니펫·명령어) 포함
 - **DO**: 피처별 문서는 `feature/<feature-name>/` 로 묶기
-- **DO**: 사람-팀원 가이드는 `guide/` 하위에 두기 (`guide/learnings/`, `guide/playbooks/`, `guide/technic/`, `guide/superpowers-ko/`)
+- **DO**: 사람-팀원 가이드는 `guide/` 하위에 두기 (`guide/learnings/`, `guide/playbooks/`, `guide/technic/`, `guide/superpowers-ko/`). 단 `guide/commands/` 는 자동 생성물 — 직접 편집 금지
 - **DON'T**: TODO 마커를 추적 없이 남기기 (`archive/todo-<topic>.md` 처럼 별도 파일로 분리)
 - **DON'T**: 이유 없이 archive 하지 않기 (이동 사유를 `archive/README.md` 또는 커밋 메시지에 남길 것)
 - **DON'T**: `docs/` 루트에 산문 파일 새로 만들지 않기 — 항상 6 개 디렉토리 중 하나로 분류 (AGENTS.md 제외)
@@ -33,7 +33,7 @@
 | **`.ssot/`** | 프로젝트 정책 SSOT — 명령 UX, env vars, 보드 운영, 커밋/discussion 규칙 | [`.ssot/README.md`](./.ssot/README.md) |
 | **`requirement/`** | 제품 요구사항 entry SSOT — D (확정 결정) / F (기능) / NF (비기능) / O (미해소) 4-섹션. D-섹션 = **경량 inline 결정** | [`requirement/product-requirements.md`](./requirement/product-requirements.md) |
 | **`adr/`** | 아키텍처 결정 로그 (#1027) — 프로젝트 전체에 파급되는 **굵직한 결정**의 불변 기록. `NNNN-<kebab>.md` | [`adr/README.md`](./adr/README.md) |
-| **`guide/`** | 사람-팀원 가이드 — setup, team-git, learnings, playbooks, technic, superpowers-ko 한글 가이드 | [`guide/README.md`](./guide/README.md) |
+| **`guide/`** | 사람-팀원 가이드 — setup, team-git, learnings, playbooks, technic, superpowers-ko 한글 가이드. `commands/` 는 row 함수에서 자동 생성 (#1262) | [`guide/README.md`](./guide/README.md) |
 | **`feature/`** | 피처별 설계·분석 번들 — 한 디렉토리 = 한 피처. superpowers-plans/specs 포함 | (디렉토리 직접 탐색) |
 | **`archive/`** | 보관소 — 사후 분석, 평가 자료(company), 다이어그램, 도래일 지난 todo. 외부 노출 차단 영역 포함 | [`archive/README.md`](./archive/README.md) |
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -16,6 +16,7 @@
 - [technic/](./technic/) — 검증된 스택 중심 기술 문서 (수백 줄). 전체 셋업 + tradeoff
 - [superpowers-ko/](./superpowers-ko/) — superpowers 플러그인 14 개 스킬의 한글 가이드 (`SKILL_ko.md` + 동료 공유용 `README.md`)
 - [plugins/](./plugins/) — 체리픽 플러그인별 설치 방법 · 스킬 설명 · 사용법 (1 플러그인 = 1 파일)
+- [commands/](./commands/) — `*_help.sh` row 함수에서 자동 생성한 커맨드별 레퍼런스 (1 커맨드 = 1 파일). "동작을 까먹었을 때" `rg <키워드> docs/guide/commands/` 로 검색
 
 ## 디렉토리 분담 (vs 다른 docs 영역)
 

--- a/docs/guide/commands/.notes/csm.md
+++ b/docs/guide/commands/.notes/csm.md
@@ -1,0 +1,21 @@
+`csm` (`claude_skills_marketplace`) 의 소스 주석에만 있던 동작들. 출처는
+`shell-common/functions/marketplace.sh` 의 `_claude_skills_marketplace_search()`.
+
+- `csm find` 는 `csm search` 의 별칭이고, 둘 다 **fzf 피커** 로 동작한다.
+  단 `fzf` 가 설치돼 있고 stdin/stdout 이 **모두 TTY** 일 때만 피커가 뜬다.
+- 피커에서 **Esc 를 누르면 아무것도 선택하지 않은 것으로 보고 조용히 종료한다**
+  (exit 0 — 에러가 아니다). 화면에 아무것도 안 남아서 실패처럼 보이지만 의도된
+  동작이다. 매칭 결과가 없거나 fzf 가 다른 이유로 끝날 때도 같다.
+- 피커 모드에서 넘긴 `<keyword>` 는 결과를 걸러내는 필터가 아니라 fzf 의
+  **초기 query 프리필** 이다 — 입력을 지우면 전체 스킬 목록이 다시 보인다.
+- 비대화형(파이프 · 스크립트 · 테스트 하네스)이거나 `fzf` 가 없으면 jq substring
+  검색으로 폴백한다. 이 경로에서는 `<keyword>` 가 **필수** — 없으면
+  `Query required` 에러와 함께 exit 1.
+- 매니페스트 파싱 실패는 "사용자가 취소함" 으로 삼키지 않고
+  `Failed to parse marketplace manifest` 에러로 드러난다. `jq` 실패와 `fzf` 취소를
+  일부러 분리해 둔 것이다.
+- 인자 없이 `csm` 만 치면 **help 가 출력된다** (라우터 기본값이 `help`).
+  `csm help` 의 quickstart 절은 "Group by plugin (default): csm" 이라고 안내하지만,
+  실제 플러그인 목록은 `csm list` 로 봐야 한다.
+- 매니페스트 캐시는 24 시간 TTL. 만료되거나 파일이 없으면 자동 재생성되고,
+  강제 재생성은 `csm refresh`.

--- a/docs/guide/commands/README.md
+++ b/docs/guide/commands/README.md
@@ -1,0 +1,84 @@
+# 커맨드 레퍼런스 인덱스
+
+`shell-common/functions/` 의 `_<topic>_help_rows_<section>()` 정의에서
+자동 생성한 커맨드별 상세 문서 모음입니다 (issue #1262).
+
+## 사용법
+
+```bash
+# 동작을 까먹었을 때 — 전체 텍스트 검색
+rg "fzf 피커" docs/guide/commands/
+
+# 전체 재생성 (내용이 바뀐 파일만 갱신)
+./shell-common/tools/custom/gen_command_docs.sh --force
+```
+
+이름 자체가 기억나지 않을 때는 `my-help search` (fzf topic finder) 를 쓰세요.
+
+## 문서 목록
+
+- [agy](./agy.md)
+- [bat](./bat.md)
+- [bun](./bun.md)
+- [category](./category.md)
+- [cc](./cc.md)
+- [claude](./claude.md)
+- [claude-plugins](./claude-plugins.md)
+- [cli](./cli.md)
+- [codex](./codex.md)
+- [crt](./crt.md)
+- [csm](./csm.md)
+- [devx](./devx.md)
+- [dir](./dir.md)
+- [docker](./docker.md)
+- [dot](./dot.md)
+- [dproxy](./dproxy.md)
+- [du](./du.md)
+- [fasd](./fasd.md)
+- [fd](./fd.md)
+- [fzf](./fzf.md)
+- [gbr](./gbr.md)
+- [gc](./gc.md)
+- [gcp](./gcp.md)
+- [ghostty](./ghostty.md)
+- [git](./git.md)
+- [gpu](./gpu.md)
+- [gwt](./gwt.md)
+- [herdr](./herdr.md)
+- [hook](./hook.md)
+- [litellm](./litellm.md)
+- [mount](./mount.md)
+- [mysql](./mysql.md)
+- [mytool](./mytool.md)
+- [network](./network.md)
+- [npm](./npm.md)
+- [nvm](./nvm.md)
+- [p10k](./p10k.md)
+- [pet](./pet.md)
+- [pip](./pip.md)
+- [pp](./pp.md)
+- [proxy](./proxy.md)
+- [psql](./psql.md)
+- [py](./py.md)
+- [redis](./redis.md)
+- [register](./register.md)
+- [ripgrep](./ripgrep.md)
+- [setup-mode](./setup-mode.md)
+- [show-doc](./show-doc.md)
+- [ssh](./ssh.md)
+- [ssl](./ssl.md)
+- [superpowers](./superpowers.md)
+- [sys](./sys.md)
+- [tmux](./tmux.md)
+- [uv](./uv.md)
+- [ux](./ux.md)
+- [work](./work.md)
+- [work-log](./work-log.md)
+- [zsh](./zsh.md)
+- [zsh-autosuggestions](./zsh-autosuggestions.md)
+
+## 수기 보강 노트
+
+소스 주석에만 있는 엣지케이스는 자동 추출 대상이 아닙니다.
+`.notes/<커맨드>.md` 에 작성하면 재생성 시 각 문서의
+"엣지케이스 / 의도된 동작" 절에 그대로 삽입됩니다.

--- a/docs/guide/commands/agy.md
+++ b/docs/guide/commands/agy.md
@@ -1,0 +1,51 @@
+# agy
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/agy_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic agy --force`
+
+## 호출
+
+- Help 진입점: `agy-help [section|--list|--all]`
+- 통합 라우팅: `my-help agy [section]`
+- Alias: `agy-help`
+
+## 요약 (agy-help)
+
+- Usage: agy-help [section|--list|--all]
+- sections
+    - basic: agy-version | agy-continue | agy-plan | agy-models
+    - setup: agy-install | agy-uninstall
+    - tips: OAuth token dir | agy install PATH conflict
+    - details: agy-help <section>  (example: agy-help basic)
+
+## 섹션
+
+### basic
+
+- **agy-version** — agy --version — Check version
+- **agy-continue** — agy --continue — Continue recent conversation
+- **agy-plan** — agy --mode plan — Run in plan mode
+- **agy-models** — agy models — List available models
+
+### setup
+
+- **agy-install** — Install Script — Install Antigravity CLI
+- **agy-uninstall** — Uninstall Script — Remove Antigravity CLI
+
+### tips
+
+- OAuth token stored in ~/.gemini/antigravity-cli/
+- Use 'agy --help' for detailed CLI options
+- Model list changes often — run 'agy models' directly rather than relying on the 'agy-models' alias
+- agy install edits shell profiles; PATH SSOT is shell-common/env/path.sh
+- Prefer: agy install --skip-path --skip-aliases
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/agy.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/agy_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/bat.md
+++ b/docs/guide/commands/bat.md
@@ -1,0 +1,97 @@
+# bat
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/bat_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic bat --force`
+
+## 호출
+
+- Help 진입점: `bat-help [section|--list|--all]`
+- 통합 라우팅: `my-help bat [section]`
+- Alias: `bat-help`
+
+## 요약 (bat-help)
+
+- Usage: bat-help [section|--list|--all]
+- sections
+    - concept: cat replacement | syntax highlighting | git integration
+    - basic: bat file | piped | multiple
+    - lines: -n | -r 5:10 | -r 5: | -r :10
+    - language: -l | --list-languages | --theme | --list-themes
+    - display: --plain | --color | --style
+    - git: shows changes (green/red)
+    - advanced: -A | -t | --tabs | -H
+    - config: ~/.config/bat/config defaults
+    - related: install-bat | ripgrep-help | fd-help | fzf-help
+    - details: bat-help <section>  (example: bat-help basic)
+
+## 섹션
+
+### concept
+
+- Cat replacement with syntax highlighting
+- Supports 200+ languages and file formats
+- Git integration - shows file changes in color
+- Automatic language detection from filename
+
+### basic
+
+- **bat file.txt** — View file with syntax highlighting
+- **cat file.txt | bat** — View piped content
+- **bat file.txt file2.txt** — View multiple files
+
+### lines
+
+- **bat -n file.txt** — Show line numbers
+- **bat -r 5:10 file.txt** — Show lines 5-10
+- **bat -r 5: file.txt** — Show from line 5 to end
+- **bat -r :10 file.txt** — Show first 10 lines
+
+### language
+
+- **bat -l python file.py** — Specify language explicitly
+- **bat --list-languages** — Show all supported languages
+- **bat --theme Monokai file.txt** — Use different color theme
+- **bat --list-themes** — Show all available themes
+
+### display
+
+- **bat --plain file.txt** — Plain output (no decorations)
+- **bat --color=never file.txt** — Disable colors
+- **bat --color=always file.txt** — Force colors
+- **bat --style=numbers file.txt** — Show only line numbers
+
+### git
+
+- **bat file.txt** — Shows git changes (green/red lines)
+
+### advanced
+
+- **bat -A file.txt** — Show invisible characters
+- **bat -t file.txt** — Show tabs as visual indicators
+- **bat --tabs 4 file.txt** — Set tab width to 4 spaces
+- **bat -H file.txt** — Highlight specific lines
+
+### config
+
+- Create ~/.config/bat/config for default options:
+- --theme=Monokai Extended - Set default theme
+- --style=numbers - Always show line numbers
+- --tabs=4 - Set tab width
+- --paging=auto - Auto pagination
+
+### related
+
+- Install bat: install-bat
+- Text search: ripgrep-help
+- File finder: fd-help
+- Fuzzy finder: fzf-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/bat.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/bat_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/bun.md
+++ b/docs/guide/commands/bun.md
@@ -1,0 +1,71 @@
+# bun
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/package_managers_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic bun --force`
+
+## 호출
+
+- Help 진입점: `bun-help [section|--list|--all]`
+- 통합 라우팅: `my-help bun [section]`
+- Alias: `bun-help`
+
+## 요약 (bun-help)
+
+- Usage: bun-help [section|--list|--all]
+- sections
+    - install: install-bun | uninstall-bun | bun-v
+    - packages: bun-i | bun-id | bun-ig | bun-un | bun-update | bun-outdated
+    - run: bun-run | bunx
+    - examples: bunx oh-my-opencode | bunx create-next-app
+    - config: ~/.bunfig.toml | internal vs external
+    - troubleshoot: not found | registry | SSL
+    - details: bun-help <section>  (example: bun-help packages)
+
+## 섹션
+
+### install
+
+- **install-bun** — curl .../bun.sh/install — Install Bun
+- **uninstall-bun** — Remove ~/.bun — Uninstall Bun
+- **bun-v** — bun --version — Check version
+
+### packages
+
+- **bun-i** — bun install — Install deps
+- **bun-id** — install --dev — Dev dependency
+- **bun-ig** — install --global — Global install
+- **bun-un** — bun remove — Remove package
+- **bun-update** — bun update — Update deps
+- **bun-outdated** — bun outdated — Check outdated
+
+### run
+
+- **bun-run** — bun run <script> — Run package.json script
+- **bunx** — bun x <pkg> — Run package without install
+
+### examples
+
+- bunx oh-my-opencode install  : OMO 설치
+- bunx create-next-app         : Next.js 프로젝트 생성
+
+### config
+
+- Config file  : ~/.bunfig.toml (dotfiles symlink)
+- Environments : internal (Samsung registry), external (default)
+
+### troubleshoot
+
+- bun not found?   : Run install-bun
+- Registry error?  : Check ~/.bunfig.toml registry setting
+- SSL error?       : Verify cafile path in bunfig.toml
+- Binary path: ~/.bun/bin
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/bun.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/package_managers_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/category.md
+++ b/docs/guide/commands/category.md
@@ -1,0 +1,50 @@
+# category
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/category_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic category --force`
+
+## 호출
+
+- Help 진입점: `category-help [section|--list|--all]`
+- 통합 라우팅: `my-help category [section]`
+- Alias: `category-help`
+
+## 요약 (category-help)
+
+- Usage: category-help [section|--list|--all]
+- sections
+    - categories: list all help categories
+    - topics: route to my-help <topic>
+    - details: category-help <section>  (example: category-help categories)
+
+## 섹션
+
+### categories
+
+**Categories**
+
+- **Category** — Topics
+- **AI/LLM (9)** — claude, cc, agy, codex, litellm, +4 more
+- **CLI Utilities (12)** — fzf, fd, fasd, ripgrep, pet, +7 more
+- **Configuration (5)** — p10k, crt, apt, pip, ghostty
+- **Development (17)** — git, gwt, gbr, devx, uv, +12 more
+- **DevOps/Infra (13)** — docker, dproxy, sys, proxy, ssl, +8 more
+- **Documentation (5)** — dot, show_doc, notion, work_log, work
+- **Meta/Help (2)** — category, register
+- **System/Tools (2)** — dir, opencode
+- Use: my-help <category> (example: my-help ai)
+- Use: my-help <topic> (example: my-help git)
+
+### topics
+
+- (렌더 실패)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/category.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/category_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/cc.md
+++ b/docs/guide/commands/cc.md
@@ -1,0 +1,40 @@
+# cc
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/cc_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic cc --force`
+
+## 호출
+
+- Help 진입점: `cc-help [section|--list|--all]`
+- 통합 라우팅: `my-help cc [section]`
+- Alias: `cc-help`
+
+## 요약 (cc-help)
+
+- Usage: cc-help [section|--list|--all]
+- sections
+    - install: npm install -g ccusage
+    - commands: ccd | ccs | ccb
+    - details: cc-help <section>  (example: cc-help commands)
+
+## 섹션
+
+### install
+
+- Global prefix: npm install -g ccusage --prefix=$HOME/.npm-global
+
+### commands
+
+- **ccd** — ccusage daily --breakdown — Token usage by model
+- **ccs** — ccusage session --sort tokens — Session analysis
+- **ccb** — ccusage blocks --live — Cache hit ratio (live)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/cc.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/cc_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/claude-plugins.md
+++ b/docs/guide/commands/claude-plugins.md
@@ -1,0 +1,100 @@
+# claude-plugins
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/claude_plugins_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic claude_plugins --force`
+
+## 호출
+
+- Help 진입점: `claude-plugins-help [section|--list|--all]`
+- 통합 라우팅: `my-help claude_plugins [section]`
+- Alias: `claude-plugins-help`
+
+## 요약 (claude-plugins-help)
+
+- Usage: claude-plugins-help [section|--list|--all]
+- sections
+    - commands: open_claude_plugins | list-plugins | claude-plugin-list | init-plugins-docs | sync-plugins-structure
+    - view: view-plugin-info | generate-plugin-doc-ko | create-plugin-structure-ko
+    - examples: quick examples for create-plugin-ko
+    - ai-tools: claude | agy | codex
+    - workflow: recommended workflow
+    - structure: plugin and docs directory layout
+    - git: git integration & mount details
+    - details: claude-plugins-help <section>
+
+## 섹션
+
+### commands
+
+- open_claude_plugins  - Open marketplace plugins directory in VSCode
+- list-plugins         - List all available marketplaces and their skills
+- claude-plugin-list   - List installed plugins grouped by marketplace (SSOT: installed_plugins.json)
+- init-plugins-docs    - Initialize Korean documentation directory structure
+- sync-plugins-structure - Create directory structure mirroring plugins organization
+
+### view
+
+- view-plugin-info <plugin-name>
+-   Usage: view-plugin-info algorithmic-art
+- generate-plugin-doc-ko <source-file> <output-file> [ai-tool]
+-   Default Claude: generate-plugin-doc-ko file.md output_KO.md
+-   agy: generate-plugin-doc-ko file.md output_KO.md agy
+- create-plugin-structure-ko <marketplace> <plugin-path> [ai-tool]
+-   Default: create-plugin-structure-ko <marketplace> <path/to/file.md>
+-   agy: create-plugin-structure-ko <marketplace> <path/to/file.md> agy
+
+### examples
+
+- 1. Generate with default AI (Claude):
+-    create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md
+- 2. Generate with agy:
+-    create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md agy
+- 3. Change default AI tool for session:
+-    export CLAUDE_DOC_GENERATOR=codex
+-    create-plugin-ko claude-code-workflows plugins/code-refactoring/agents/code-reviewer.md
+- 4. Review the generated file:
+-    code ~/.claude/docs/marketplaces/claude-code-workflows/plugins/code-refactoring/agents/code-reviewer_KO.md
+- 5. Commit to git:
+-    cd ~/dotfiles && git add claude/docs/ && git commit -m 'docs: Add Korean summary'
+
+### ai_tools
+
+- claude - Anthropic Claude (default)
+- agy - Antigravity CLI
+- codex - OpenAI Codex
+- Any CLI tool accepting -p or --prompt flag
+
+### workflow
+
+- 1. init-plugins-docs - Initialize docs directory (first time only)
+- 2. open_claude_plugins - Review plugin files in VSCode
+- 3. create-plugin-ko <marketplace> <path> - Generate Korean summary
+- 4. Edit & customize generated *_KO.md file
+- 5. Add personal notes to README.md
+- 6. git add && git commit - Save to dotfiles repository
+
+### structure
+
+- Plugins (read-only marketplace):
+- $HOME/.claude/plugins/marketplaces/[marketplace]/plugins/[plugin-name]/agents/[agent].md
+- Documentation (git-tracked, mounted):
+- $HOME/.claude/docs/marketplaces/[marketplace]/plugins/[plugin-name]/agents/
+-   ├── [agent]_KO.md    (Korean summary, auto-generated)
+-   └── README.md         (Learning notes, manual)
+
+### git
+
+- All documentation is symlinked to the SSOT and automatically git-tracked:
+- User location: ~/.claude/docs (directory symlink, #575)
+- Git source: ~/dotfiles/claude/docs
+- Changes are version-controlled and shareable across machines
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/claude-plugins.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/claude_plugins_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/claude.md
+++ b/docs/guide/commands/claude.md
@@ -1,0 +1,97 @@
+# claude
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/ai_tools_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic claude --force`
+
+## 호출
+
+- Help 진입점: `claude-help [section|--list|--all]`
+- 통합 라우팅: `my-help claude [section]`
+- Alias: `claude-help`
+
+## 요약 (claude-help)
+
+- Usage: claude-help [section|--list|--all]
+- sections
+    - mcp: list | get | add | remove
+    - recommended: Playwright MCP | Sequential Thinking MCP
+    - setup: clinstall | ensure_jq | claude_init | claude_edit_settings
+    - sandbox: /sandbox | Auto-allow | pytest, git, npm
+    - config: settings.json | autoAllow | block paths | block cmds
+    - statusline: time | model | project | context | cost
+    - skills: claude-skills
+    - plugin: claude plugin sync + restore.sh
+    - details: claude-help <section>  (example: claude-help mcp)
+
+## 섹션
+
+### mcp
+
+- **claude mcp list** — List installed MCP servers
+- **claude mcp get <name>** — Show MCP server details
+- **claude mcp add <name> ...** — Add MCP server
+- **claude mcp remove <name>** — Remove MCP server
+
+### recommended
+
+- Playwright MCP: Web browser automation
+- Install: claude mcp add playwright --transport stdio -- npx -y @playwright/mcp@latest
+- Sequential Thinking MCP: Logical analysis
+- Install: claude mcp add sequential-thinking --transport stdio -- npx -y @modelcontextprotocol/server-sequential-thinking
+
+### setup
+
+- **clinstall** — Install Claude Code CLI
+- **ensure_jq** — Install jq (required for statusline)
+- **claude_init** — Initialize config & skills
+- **claude_edit_settings** — Edit settings.json
+
+### sandbox
+
+- Use in Claude conversation: /sandbox
+- Select Auto-allow mode
+- pytest, git, npm auto-approved
+
+### config
+
+- Settings file: ~/dotfiles/claude/settings.json
+- Sandbox: autoAllowBashIfSandboxed
+- Auto-allow: pytest, ruff, mypy, tox
+- Block: .env, ~/.aws, ~/.ssh
+- Block commands: rm -rf, sudo rm
+
+### statusline
+
+- Real-time session information in Claude Code status bar
+- 🕐 Time (morning/afternoon/night emoji + YY-MM-DD HH:MM:SS)
+- 🤖 Model (emoji + display name: 🐰 Haiku, 🎼 Sonnet, 🎭 Opus)
+- 📁 Project (folder name + git branch with emoji)
+- 📊 Context usage percentage + weekly percentage
+- 💰 Session cost (Green <$5, Orange $5-20, Red >$20)
+
+### skills
+
+- **claude-skills** — List available Claude Code skills
+- Skills location: ~/dotfiles/claude/skills/
+
+### plugin
+
+- **claude plugin marketplace add/remove, install/uninstall** — 자동으로 claude/plugin/*.json에 동기화됨 (hook)
+- **./claude/plugin/restore.sh** — 신규 PC에서 manifest 기반 일괄 재설치 (add-only)
+- **./claude/plugin/restore.sh --sync** — 양방향 sync — SSOT에 없는 잉여 로컬 항목까지 제거
+- **./claude/plugin/restore.sh --dry-run** — 실행 없이 계획만 출력 (--sync와 조합 가능)
+- **./claude/plugin/publish-sync.sh** — 로컬에 쌓인 manifest sync 커밋을 PR로 origin에 게시
+- **./claude/plugin/publish-sync.sh --dry-run** — 게시할 diff만 출력, 변경 없음
+- **./claude/plugin/reconcile.sh --check** — SSOT(installed_plugins) 대비 manifest drift 감지 (유령 엔트리 포함)
+- **./claude/plugin/reconcile.sh --apply** — manifest를 SSOT 기준으로 재빌드 + 커밋 (drift 복구)
+- **claude-plugin-list** — 설치된 플러그인을 마켓플레이스별로 요약 출력
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/claude.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/ai_tools_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/cli.md
+++ b/docs/guide/commands/cli.md
@@ -1,0 +1,70 @@
+# cli
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/cli_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic cli --force`
+
+## 호출
+
+- Help 진입점: `cli-help [section|--list|--all]`
+- 통합 라우팅: `my-help cli [section]`
+- Alias: `cli-help`
+
+## 요약 (cli-help)
+
+- Usage: cli-help [section|--list|--all]
+- sections
+    - repos: dotfiles | FinRx | dmc-playground
+    - urls: DEV | TEST | PROD
+    - finrx: run_fr_cli
+    - dmc: run_bes | run_tbes | run_pbes | run_api_cli | run_db_cli
+    - smt: run_smt | run_tsmt | run_psmt
+    - tips: project root | uv venv | no --reload in prod
+    - details: cli-help <section>  (example: cli-help repos)
+
+## 섹션
+
+### repos
+
+- **dotfiles** — ✨
+- **FinRx** — 💰
+- **dmc-playground** — 📚
+
+### urls
+
+- **DEV** —  (port ) — smithery-playground
+- **TEST** —  (port ) — smithery-playground
+- **PROD** —  (port ) — smithery-playground
+
+### finrx
+
+- **run_fr_cli** — python ./src/ticker_library/cli/cli.py — Run CLI
+
+### dmc
+
+- **run_bes** — Backend dev server (reload) — DEV: 
+- **run_tbes** — Backend test server (reload) — TEST: 
+- **run_pbes** — Backend prod server (no reload) — PROD: 
+- **run_api_cli [URL]** — API CLI (default: DEV) — Query/test API
+- **run_db_cli [URL]** — DB CLI (default: DEV) — Query/test database
+
+### smt
+
+- **run_smt** — Dev server (reload) — URL: 
+- **run_tsmt** — Test server (reload) — URL: 
+- **run_psmt** — Prod server (no reload) — URL: 
+
+### tips
+
+- Run from project root (current: )
+- Recommend uv/pyproject-based venv (uvs/uvd)
+- Never use --reload in production
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/cli.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/cli_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/codex.md
+++ b/docs/guide/commands/codex.md
@@ -1,0 +1,62 @@
+# codex
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/ai_tools_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic codex --force`
+
+## 호출
+
+- Help 진입점: `codex-help [section|--list|--all]`
+- 통합 라우팅: `my-help codex [section]`
+- Alias: `codex-help`
+
+## 요약 (codex-help)
+
+- Usage: codex-help [section|--list|--all]
+- sections
+    - basic: codex | codex-help | official help | codex-version | codex-yolo
+    - setup: codex-install | codex-uninstall | codex-status | codex-skills-sync | auto sync
+    - interactive: codex | codex prompt
+    - tips: config dir | auth | auto sync env vars
+    - details: codex-help <section>  (example: codex-help setup)
+
+## 섹션
+
+### basic
+
+- **codex** — codex — Base command
+- **codex-help** — codex-help — Show dotfiles codex commands
+- **Official help** — codex help | --help | -h — Show CLI help
+- **codex-version** — codex --version — Check version
+- **codex-yolo** — codex --dangerously-bypass-approvals-and-sandbox — Bypass guardrails
+
+### setup
+
+- **codex-install** — Install Script — Install Codex CLI
+- **codex-uninstall** — Uninstall Script — Remove Codex CLI
+- **codex-status** — Status Check — Show installation status
+- **codex-skills-sync** — Skills Sync — Sync skills symlinks
+- **Auto skill sync** — Enabled by default — Before codex command
+
+### interactive
+
+- **codex** — codex — Start interactive
+- **codex prompt** — codex prompt — Run with prompt
+
+### tips
+
+- Config: ~/.codex/ or ~/.config/codex/
+- Auth: Use 'codex' to authenticate
+- Auto sync: before codex command + prompt cycle
+- Disable auto sync: export CODEX_SKILLS_AUTO_SYNC=0
+- Verbose auto sync: export CODEX_SKILLS_AUTO_SYNC_VERBOSE=1
+- Auto sync interval(sec): export CODEX_SKILLS_AUTO_SYNC_INTERVAL=5
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/codex.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/ai_tools_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/crt.md
+++ b/docs/guide/commands/crt.md
@@ -1,0 +1,68 @@
+# crt
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/security_ssh_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic crt --force`
+
+## 호출
+
+- Help 진입점: `crt-help [section|--list|--all]`
+- 통합 라우팅: `my-help crt [section]`
+- Alias: `crt-help`
+
+## 요약 (crt-help)
+
+- Usage: crt-help [section|--list|--all]
+- sections
+    - overview: npm/Node/Python CA | custom & system | security.local.sh
+    - options: External (custom crt) | Internal (system CA)
+    - setup: crtsetup
+    - env: NODE_EXTRA_CA_CERTS | REQUESTS_CA_BUNDLE
+    - config: shell-common/env/security.local.sh
+    - related: npm-help | security.sh | setup.sh
+    - details: crt-help <section>  (example: crt-help options)
+
+## 섹션
+
+### overview
+
+- Manages CA certificates for npm, Node.js, and Python
+- Supports custom certificates (company proxy) and system CA bundles
+- Configuration stored in: shell-common/env/security.local.sh
+
+### options
+
+- Option 1: Custom Certificate (External Company PC - VPN)
+-  • Certificate path: /usr/local/share/ca-certificates/samsungsemi-prx.com.crt
+-  • Install with: crtsetup
+- Option 2: System CA Bundle (Internal Company PC)
+-  • Certificate path: /etc/ssl/certs/ca-certificates.crt
+-  • Already system default, no setup needed
+
+### setup
+
+- **crtsetup** — Interactive CA certificate setup script
+
+### env
+
+- **NODE_EXTRA_CA_CERTS** — Used by Node.js/npm for certificate validation
+- **REQUESTS_CA_BUNDLE** — Used by Python for certificate validation
+
+### config
+
+- Location: shell-common/env/security.local.sh
+
+### related
+
+- **npm-help** — NPM package manager commands and setup
+- **security.sh** — Security environment variable configuration
+- **setup.sh** — Initial environment-specific setup
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/crt.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/security_ssh_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/csm.md
+++ b/docs/guide/commands/csm.md
@@ -1,0 +1,92 @@
+# csm (claude-skills-marketplace)
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/marketplace.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic claude_skills_marketplace --force`
+
+## 호출
+
+- Help 진입점: `claude-skills-marketplace-help [section|--list|--all]`
+- 통합 라우팅: `my-help claude_skills_marketplace [section]`
+- Alias: `claude-skills-marketplace`, `claude-skills-marketplace-help`, `csm`
+
+## 요약 (claude-skills-marketplace-help)
+
+- Usage: claude-skills-marketplace-help [section|--list|--all]
+- sections
+    - quickstart: csm | csm list --all | csm search | csm info
+    - commands: list | group | stats | search (find) | info | refresh | help
+    - aliases: claude_skills_marketplace | csm
+    - examples: common usage examples
+    - caching: manifest cache details
+    - details: claude-skills-marketplace-help <section>
+
+## 섹션
+
+### quickstart
+
+- Group by plugin (default): csm
+- All skills by marketplace: csm list --all
+- Search skills: csm search python
+- Get details: csm info api-design-principles
+
+### commands
+
+1. list [--all|-A]         - Group by plugin (default), or --all for marketplace view
+2. group [plugin]          - Group skills by plugin (optionally filter)
+3. stats                   - Show marketplace statistics
+4. search|find [keyword]   - fzf fuzzy picker (needs fzf+TTY), else keyword search
+5. info <skill-name>       - Show detailed skill information
+6. refresh                 - Force rebuild skill manifest
+7. help                    - Show this help message
+
+### aliases
+
+- Long form: claude_skills_marketplace
+- Short form: csm
+- Subcommand: csm find = csm search
+
+### examples
+
+- Show plugins: csm (shows plugin headers)
+- Same as above: csm list
+- Show marketplaces: csm list --all
+- Explore plugin: csm search backend (or filter: csm group backend)
+- Search skills: csm search python
+- Fuzzy pick: csm find (fzf picker over all skills)
+- Skill details: csm info api-design-principles
+- Statistics: csm stats
+
+### caching
+
+- Manifest cache: ~/.claude/plugins/marketplaces/.skills-manifest.json
+- Cache TTL: 24 hours
+- Auto-refresh: When cache expires or manifest missing
+
+## 엣지케이스 / 의도된 동작
+
+`csm` (`claude_skills_marketplace`) 의 소스 주석에만 있던 동작들. 출처는
+`shell-common/functions/marketplace.sh` 의 `_claude_skills_marketplace_search()`.
+
+- `csm find` 는 `csm search` 의 별칭이고, 둘 다 **fzf 피커** 로 동작한다.
+  단 `fzf` 가 설치돼 있고 stdin/stdout 이 **모두 TTY** 일 때만 피커가 뜬다.
+- 피커에서 **Esc 를 누르면 아무것도 선택하지 않은 것으로 보고 조용히 종료한다**
+  (exit 0 — 에러가 아니다). 화면에 아무것도 안 남아서 실패처럼 보이지만 의도된
+  동작이다. 매칭 결과가 없거나 fzf 가 다른 이유로 끝날 때도 같다.
+- 피커 모드에서 넘긴 `<keyword>` 는 결과를 걸러내는 필터가 아니라 fzf 의
+  **초기 query 프리필** 이다 — 입력을 지우면 전체 스킬 목록이 다시 보인다.
+- 비대화형(파이프 · 스크립트 · 테스트 하네스)이거나 `fzf` 가 없으면 jq substring
+  검색으로 폴백한다. 이 경로에서는 `<keyword>` 가 **필수** — 없으면
+  `Query required` 에러와 함께 exit 1.
+- 매니페스트 파싱 실패는 "사용자가 취소함" 으로 삼키지 않고
+  `Failed to parse marketplace manifest` 에러로 드러난다. `jq` 실패와 `fzf` 취소를
+  일부러 분리해 둔 것이다.
+- 인자 없이 `csm` 만 치면 **help 가 출력된다** (라우터 기본값이 `help`).
+  `csm help` 의 quickstart 절은 "Group by plugin (default): csm" 이라고 안내하지만,
+  실제 플러그인 목록은 `csm list` 로 봐야 한다.
+- 매니페스트 캐시는 24 시간 TTL. 만료되거나 파일이 없으면 자동 재생성되고,
+  강제 재생성은 `csm refresh`.
+
+## 소스
+
+- `shell-common/functions/marketplace.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/devx.md
+++ b/docs/guide/commands/devx.md
@@ -1,0 +1,61 @@
+# devx
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/devx_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic devx --force`
+
+## 호출
+
+- Help 진입점: `devx-help [section|--list|--all]`
+- 통합 라우팅: `my-help devx [section]`
+
+## 요약 (devx-help)
+
+- Usage: devx help [section|--list|--all]
+- sections
+    - lint           devx lint                  mise run lint (read-only)
+    - fix            devx fix                   mise run fix  (mutating)
+    - lint-helpfunc  devx lint-helpfunc         help-function registration check
+    - lint-deadcode  devx lint-deadcode         unused _internal function check
+    - stat           devx stat                  repo statistics (repo_stats.sh)
+    - details        devx help <section> (example: devx help fix)
+
+## 섹션
+
+### lint
+
+- **syntax** — devx lint — Run mise run lint (read-only)
+- **scope** — ruff check + ruff format --check + mypy + shellcheck + shfmt -d — All language gates
+- **behavior** — No file mutations — Safe for CI / pre-commit
+
+### fix
+
+- **syntax** — devx fix — Run mise run fix (mutating)
+- **scope** — ruff check --fix + ruff format + shfmt -w — Python + Shell auto-fix
+- **deprecated** — devx fmt / devx format — Routed to fix with a one-time warning
+
+### lint_helpfunc
+
+- **syntax** — devx lint-helpfunc — Audit help-function registration
+- **checks** — Every public *_help in shell-common/functions/ — Must appear in HELP_DESCRIPTIONS
+- **exit** — 0 = all registered, 1 = unregistered helpers found — Pre-commit gate candidate
+
+### lint_deadcode
+
+- **syntax** — devx lint-deadcode — Find unused _internal functions
+- **checks** — ^_<name>() definitions in shell-common/functions/ — 1 ref = likely dead code
+- **exit** — 0 = all in use, 1 = unused detected — Cleanup hint, not a hard gate
+
+### stat
+
+- **syntax** — devx stat [args] — Run shell-common/tools/custom/repo_stats.sh
+- **behavior** — Args passed through to repo_stats.sh — See repo_stats.sh -h for details
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/devx.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/devx_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/dir.md
+++ b/docs/guide/commands/dir.md
@@ -1,0 +1,65 @@
+# dir
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/system_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic dir --force`
+
+## 호출
+
+- Help 진입점: `dir-help [section|--list|--all]`
+- 통합 라우팅: `my-help dir [section]`
+- Alias: `dir-help`
+
+## 요약 (dir-help)
+
+- Usage: dir-help [section|--list|--all]
+- sections
+    - core: cd-dot | cd-down | cd-work
+    - windows: cd-wdocu | cd-wobsidian | cd-wdown | cd-wpicture | cd-tilnote | cd-obsidian
+    - para: mkpara | cd-para | cd-project | cd-area | cd-vault | cd-resource | cd-archive
+    - copy: cp_wdown
+    - details: dir-help <section>  (example: dir-help para)
+
+## 섹션
+
+### core
+
+- **Command** — Destination — Purpose
+- **cd-dot** — $DOTFILES_ROOT — Dotfiles repository root
+- **cd-down** — $HOME/downloads — Downloads folder
+- **cd-work** — $HOME/workspace — Workspace root
+
+### windows
+
+- **Command** — Destination — Purpose
+- **cd-wdocu** — Windows Documents — Access Windows documents
+- **cd-wobsidian** — Windows Obsidian — Obsidian vault location
+- **cd-wdown** — Windows Downloads — Quick access to downloads
+- **cd-wpicture** — Windows Pictures — Photo library
+- **cd-tilnote** — Obsidian TilNote — TilNote vault
+- **cd-obsidian** — Obsidian vault — Default vault in WSL
+
+### para
+
+- **Command** — Destination — Purpose
+- **mkpara** — para/{archive,area,project,resource} — Create PARA directories
+- **cd-para** — $HOME/para — PARA root
+- **cd-project** — $HOME/para/project — Projects workspace
+- **cd-area** — $HOME/para/area — Areas of responsibility
+- **cd-vault** — $HOME/para/area/vault — Vault under Areas
+- **cd-resource** — $HOME/para/resource — Reference materials
+- **cd-archive** — $HOME/para/archive — Archived items
+
+### copy
+
+- **Command** — Usage — Purpose
+- **cp_wdown** — cp_wdown [options] <file...> — Copy from Windows Downloads into WSL (run -h for details)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/dir.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/system_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/docker.md
+++ b/docs/guide/commands/docker.md
@@ -1,0 +1,129 @@
+# docker
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/devops_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic docker --force`
+
+## 호출
+
+- Help 진입점: `docker-help [section|--list|--all]`
+- 통합 라우팅: `my-help docker [section]`
+- Alias: `docker-help`
+
+## 요약 (docker-help)
+
+- Usage: docker-help [section|--list|--all]
+- sections
+    - compose: dc | dcu | dcud | dcd | dcl | dce
+    - compose-extra: dcps | dcb | dcr | dcdv | dcdo | dcstop | dcstart
+    - basics: dps | dpsa | di | dstats | dstop | drm | drmi | dlogs | dinspect
+    - resources: ddf | dprune | dprune_full | dvols | dvol_rm | dnetwork_prune | dbuild_prune
+    - utilities: dbash | denv | dinspect_env | dstopall | drmall | dexport | dinstall | dproxy_setup
+    - i-want: goal-based lookup  (example: docker-help i-want)
+    - --map: intent -> alias -> raw command table
+    - raw: copy-paste-ready full commands  (example: docker-help raw resources)
+    - lookup: alias -> raw command  (example: docker-help dprune)
+    - details: docker-help <section>  (example: docker-help compose)
+
+## 섹션
+
+### compose
+
+- **dc** — docker compose — Base command
+- **dcu** — docker compose up — Foreground start
+- **dcud** — docker compose up -d — Detached start
+- **dcd** — docker compose down — Stop & remove
+- **dcl** — logs <svc> — Smart logs (service/container)
+- **dce** — exec <svc> <cmd> — Execute command
+
+### compose_extra
+
+- **dcps** — docker compose ps — Status
+- **dcb** — docker compose build — Build services
+- **dcr** — docker compose restart — Restart services
+- **dcdv** — down -v — Stop & remove volumes
+- **dcdo** — down --remove-orphans — Stop & remove orphan containers (fixes net 'still in use')
+- **dcstop** — stop — Stop containers
+- **dcstart** — start — Start containers
+
+### basics
+
+- **dps** — docker ps — Running containers
+- **dpsa** — docker ps -a — All containers
+- **di/dim** — docker images — List images
+- **dstats** — docker stats — Resource usage
+- **dstop** — docker stop — Stop container
+- **drm** — docker rm — Remove container
+- **drmi** — docker rmi — Remove image
+- **dlogs** — docker logs -f — Follow logs
+- **dinspect** — docker inspect — Inspect object
+
+### resources
+
+- **ddf** — system df — Disk usage
+- **dprune** — system prune -f — Basic cleanup (-f only; keeps images & volumes)
+- **dprune_full** — system prune -a --volumes — Deep cleanup (interactive; removes images+volumes)
+- **dvols** — volume ls -f dangling — Dangling volumes
+- **dvol_rm** — volume rm — Remove volume
+- **dnetwork_prune** — network prune — Cleanup networks
+- **dbuild_prune** — builder prune — Cleanup build cache
+
+### utilities
+
+- **dbash** — dbash <name> — Shell access (bash/sh)
+- **denv** — denv <name> — Show env vars
+- **dinspect_env** — inspect env — Inspect env section
+- **dstopall** — Stop all — Stop all running
+- **drmall** — Remove all — Remove all containers
+- **dexport** — Export all — Backup to tar files
+- **dinstall** — Install script — Install Docker on WSL
+- **dproxy_setup** — Proxy setup — Corporate proxy config
+- Note: 'docker compose' (V2) is used by default.
+
+### intent
+
+- **start a stack** — dcud — docker compose up -d
+- **start with overlay** — (raw) — docker compose -f a.yml -f b.yml up -d --build
+- **stop a stack** — dcd — docker compose down
+- **wipe data too** — dcdv — docker compose down -v
+- **stop + clear orphans** — dcdo — docker compose down --remove-orphans
+- **rebuild a service** — dcb <svc> — docker compose build <svc>
+- **reset stack with volumes + rebuild** — (raw) — docker compose down -v && docker compose up -d --build
+- **restart a service** — dcr <svc> — docker compose restart <svc>
+- **follow logs** — dcl <svc> — docker compose logs -f <svc>
+- **shell into container** — dbash <name> — docker exec -it <name> bash
+- **list running** — dps — docker ps
+- **list all** — dpsa — docker ps -a
+- **disk usage** — ddf — docker system df
+- **clean dangling** — dprune — docker system prune -f
+- **reclaim everything** — dprune_full — docker system prune -a --volumes
+- Hint: 'docker-help here' inspects the current directory for compose files.
+
+### map
+
+- **Intent** — Alias — Raw command
+- **start a stack** — dcud — docker compose up -d
+- **start with overlay** — (raw) — docker compose -f a.yml -f b.yml up -d --build
+- **stop a stack** — dcd — docker compose down
+- **wipe data too** — dcdv — docker compose down -v
+- **stop + clear orphans** — dcdo — docker compose down --remove-orphans
+- **rebuild a service** — dcb <svc> — docker compose build <svc>
+- **reset stack with volumes + rebuild** — (raw) — docker compose down -v && docker compose up -d --build
+- **restart a service** — dcr <svc> — docker compose restart <svc>
+- **follow logs** — dcl <svc> — docker compose logs -f <svc>
+- **shell into container** — dbash <name> — docker exec -it <name> bash
+- **list running** — dps — docker ps
+- **list all** — dpsa — docker ps -a
+- **disk usage** — ddf — docker system df
+- **clean dangling** — dprune — docker system prune -f
+- **reclaim everything** — dprune_full — docker system prune -a --volumes
+- Hint: 'docker-help here' inspects the current directory for compose files.
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/docker.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/devops_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/dot.md
+++ b/docs/guide/commands/dot.md
@@ -1,0 +1,72 @@
+# dot
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/dot_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic dot --force`
+
+## 호출
+
+- Help 진입점: `dot-help [section|--list|--all]`
+- 통합 라우팅: `my-help dot [section]`
+- Alias: `dot-help`
+
+## 요약 (dot-help)
+
+- Usage: dot-help [section|--list|--all]
+- sections
+    - overview: project pillars (SOLID, cross-platform, skills SSOT)
+    - setup: setup.sh | maintenance | diagnostics
+    - features: shell separation | UX | help | git | skills
+    - commands: my-help | src | dot | ux-help
+    - docs: SETUP_GUIDE | AGENTS | UX_GUIDELINES
+    - details: dot-help <section>  (example: dot-help setup)
+
+## 섹션
+
+### overview
+
+- SOLID-based shell configuration separation (bash/zsh)
+- Cross-platform support (Windows WSL, macOS, Linux)
+- Environment-aware setup (Internal/External PC)
+- Claude Code skills SSOT via directory symlink (no sudo, #575)
+
+### setup
+
+- Initial setup: ./setup.sh
+- Maintenance: scripts/maintenance/fix_crlf_issue.sh
+- Diagnostic: shell-common/tools/custom/check_ux_consistency.sh
+
+### mounts
+
+- Claude environment directories automatically configured
+- (렌더 실패)
+
+### features
+
+1. Shell separation: bash/ and zsh/ directories
+2. UX guidelines: Consistent color and formatting
+3. Help system: Type help or [function]-help for info
+4. Git attributes: Automatic CRLF/LF line ending management
+5. Skills integration: SSOT exposed as directory symlinks (#575)
+
+### commands
+
+- **my-help** — List all available help topics
+- **src** — Reload shell configuration
+- **dot** — Navigate to dotfiles directory
+- **ux-help** — View UX guidelines and semantic colors
+
+### docs
+
+- Complete setup guide: ./SETUP_GUIDE.md
+- Project structure: ./AGENTS.md
+- UX standards: ./shell-common/tools/ux_lib/UX_GUIDELINES.md
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/dot.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/dot_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/dproxy.md
+++ b/docs/guide/commands/dproxy.md
@@ -1,0 +1,48 @@
+# dproxy
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/devops_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic dproxy --force`
+
+## 호출
+
+- Help 진입점: `dproxy-help [section|--list|--all]`
+- 통합 라우팅: `my-help dproxy [section]`
+- Alias: `dproxy-help`
+
+## 요약 (dproxy-help)
+
+- Usage: dproxy-help [section|--list|--all]
+- sections
+    - commands: dproxy_setup | dproxy_show | dproxy-help
+    - config: /etc/systemd/system/docker.service.d/http-proxy.conf
+    - reference: systemctl show | nano edit | daemon-reload | docker pull test
+    - details: dproxy-help <section>  (example: dproxy-help reference)
+
+## 섹션
+
+### commands
+
+- **dproxy_setup** — Interactive setup script — Configure Docker proxy
+- **dproxy_show** — Show current proxy config — Display active settings
+- **dproxy-help** — Show this help
+
+### config
+
+- /etc/systemd/system/docker.service.d/http-proxy.conf
+
+### reference
+
+- Check config: systemctl show --property=Environment docker
+- Edit config: sudo nano /etc/systemd/system/docker.service.d/http-proxy.conf
+- Apply changes: sudo systemctl daemon-reload && sudo systemctl restart docker
+- Test connection: docker pull alpine:latest
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/dproxy.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/devops_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/du.md
+++ b/docs/guide/commands/du.md
@@ -1,0 +1,41 @@
+# du
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/system_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic du --force`
+
+## 호출
+
+- Help 진입점: `du-help [section|--list|--all]`
+- 통합 라우팅: `my-help du [section]`
+- Alias: `du-help`
+
+## 요약 (du-help)
+
+- Usage: du-help [section|--list|--all]
+- sections
+    - commands: dus | dud | dsql | dubig
+    - tips: -h means human-readable (K, M, G)
+    - details: du-help <section>  (example: du-help commands)
+
+## 섹션
+
+### commands
+
+- **dus** — du -sh . — Current dir summary
+- **dud** — du -sh * — Subdir summary (sorted)
+- **dsql** — du .sql — SQL dump sizes
+- **dubig** — du top 10 — Top 10 largest items
+
+### tips
+
+- Tip: -h option means 'human-readable' (K, M, G)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/du.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/system_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/fasd.md
+++ b/docs/guide/commands/fasd.md
@@ -1,0 +1,117 @@
+# fasd
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/fasd.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic fasd --force`
+
+## 호출
+
+- Help 진입점: `fasd-help [section|--list|--all]`
+- 통합 라우팅: `my-help fasd [section]`
+- Alias: `fasd-help`
+
+## 요약 (fasd-help)
+
+- Usage: fasd-help [section|--list|--all]
+- sections
+    - core: z | zz | f | ff
+    - ranking: frequency | recency | combined
+    - patterns: z pro | z my pro | z /tmp | z -l
+    - advanced: -r | -t | -e | -d
+    - usecases: jump dirs | file ops | dir ops
+    - tips: partial match | multiple terms | -l | -d
+    - compare: cd vs z
+    - integration: fzf | vim | grep | git
+    - trouble: -l verify | reset history
+    - related: install-fasd | fzf-help
+    - details: fasd-help <section>  (example: fasd-help core)
+
+## 섹션
+
+### core
+
+- **z <dir>** — Jump to recently used directory
+- **zz <dir>** — Thorough search, jump to directory
+- **f <file>** — Open/edit recently used file
+- **ff <file>** — Thorough search, open file
+
+### ranking
+
+- Frequency - How often you visit (w weight)
+- Recency - How recently you visited (time decay)
+- Combined score determines ranking
+- Most relevant items appear first
+
+### patterns
+
+- **z pro** — Match 'project' (partial)
+- **z my pro** — Match 'my_project' (multiple terms)
+- **z /tmp** — Match full path
+- **z -l** — List directory frecency data
+
+### advanced
+
+- **z -r <dir>** — Interactive ranking (by recency)
+- **z -t <dir>** — Interactive ranking (by frequency)
+- **z -e <dir>** — Echo directory path without jumping
+- **z -d <dir>** — Delete frecency data for directory
+
+### usecases
+
+- Quick directory jumping:
+- z docs - Jump to most recent 'docs' directory
+- z project - Navigate to project directory
+- z dev src - Jump to 'dev/src' or 'src/dev'
+- File operations:
+- vim $(f project) - Edit file from project directory
+- cat $(f config) - View config file
+- ls $(zz search) - List files in search directory
+- Directory operations:
+- cd $(z downloads) && ls - Navigate and list files
+- z -e config > path.txt - Save directory path to file
+- cp file.txt $(z backup)/ - Copy to backup directory
+
+### tips
+
+- No exact match needed: 'z pj' may match 'project'
+- Multiple patterns: 'z my config' for more specificity
+- View all matches: 'z -l' to see frecency database
+- Clean history: 'z -d /old/path' to remove from database
+- Combine with pipes: 'z config | xargs grep pattern'
+
+### compare
+
+- cd - Requires full/exact path
+- z - Requires only partial, fuzzy matching
+- fasd learns from usage patterns over time
+- No need to remember exact directory structure
+
+### integration
+
+- Works well with:
+- fzf - Combine for interactive selection: z -i
+- vim/neovim - Quick file access: :e $(f pattern)
+- grep - Search in recent directories: grep -r pattern $(z proj)
+- git - Navigate git repos: z my_repo && git status
+
+### trouble
+
+- Not jumping? 'z -l' to verify directory is recorded
+- Wrong directory? Use more specific patterns
+- Reset history: Remove ~/.local/share/fasd/data
+- Verify installation: 'fasd --version'
+
+### related
+
+- Install fasd: install-fasd
+- Fuzzy finder: fzf-help
+- File manager: z -i (interactive mode)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/fasd.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/fasd.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/fd.md
+++ b/docs/guide/commands/fd.md
@@ -1,0 +1,138 @@
+# fd
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/fd.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic fd --force`
+
+## 호출
+
+- Help 진입점: `fd-help [section|--list|--all]`
+- 통합 라우팅: `my-help fd [section]`
+- Alias: `fd-help`
+
+## 요약 (fd-help)
+
+- Usage: fd-help [section|--list|--all]
+- sections
+    - concept: fast | gitignore | smart-case | colored
+    - basic: pattern | path | regex
+    - type: -t f | -t d | -t l | -t x
+    - case: smart | -s | -i
+    - extension: -e | -x
+    - depth: -d 1 | -d 2 | -d 3
+    - scope: -u | -H | --exclude
+    - exec: -0 | -x
+    - examples | compare | fzf | ripgrep | trouble | related
+    - details: fd-help <section>  (example: fd-help basic)
+
+## 섹션
+
+### concept
+
+- Rust-based find replacement - much faster than find
+- Respects .gitignore automatically - avoids unwanted files
+- Smart case sensitivity - case-insensitive unless pattern has uppercase
+- Intuitive syntax - simpler than find command
+- Colored output for better readability
+
+### basic
+
+- **fd 'pattern'** — Find files/directories matching pattern
+- **fd 'pattern' /path** — Search in specific directory
+- **fd '^file$'** — Regex pattern search
+
+### type
+
+- **fd -t f 'pattern'** — Find files only
+- **fd -t d 'pattern'** — Find directories only
+- **fd -t l 'pattern'** — Find symlinks only
+- **fd -t x 'pattern'** — Find executable files only
+
+### case
+
+- **fd 'pattern'** — Smart case (case-insensitive by default)
+- **fd -s 'pattern'** — Case-sensitive search
+- **fd -i 'pattern'** — Case-insensitive (explicit)
+
+### extension
+
+- **fd -e .txt** — Find all .txt files
+- **fd -e .py 'test'** — Find .py files matching pattern
+- **fd -x 'name'** — Find executable files
+
+### depth
+
+- **fd -d 1 'pattern'** — Search only in current directory
+- **fd -d 2 'pattern'** — Search up to 2 levels deep
+- **fd -d 3 'pattern'** — Search up to 3 levels deep
+
+### scope
+
+- **fd 'pattern'** — Respects .gitignore (default)
+- **fd -u 'pattern'** — Skip .gitignore (search ignored files)
+- **fd -H 'pattern'** — Show hidden files/directories
+- **fd --exclude 'dir' 'pattern'** — Exclude specific directory
+
+### exec
+
+- **fd -0 'pattern'** — NUL character separator (for xargs)
+- **fd -x CMD 'pattern'** — Execute command for each result
+- **fd -x echo '{}' 'pattern'** — Display full path of matches
+
+### examples
+
+- Finding specific file types:
+- fd -e .py - Find all Python files
+- fd -t f 'test' - Find all test files
+- fd -t d 'node_modules' - Find all node_modules directories
+- Finding without .gitignore:
+- fd -u '.git' - Find all .git directories (including hidden)
+- fd -H -t f '.env' - Find .env files (hidden)
+- Integration with other tools:
+- fd -e .rs | xargs wc -l - Count lines in all Rust files
+- fd -x file {} - Determine file type of all results
+- fd -x grep 'TODO' {} - Search for TODO in matched files
+- Finding within depth limits:
+- fd -d 1 '.*' - Find all files/dirs in current directory only
+- fd -d 2 'src' - Find src directories up to 2 levels deep
+
+### compare
+
+- find: Standard but slow, complex syntax
+- fd: Much faster (10-100x), simpler syntax, auto .gitignore support
+- find: Full control, can be used in scripts
+- fd: Better defaults, more intuitive
+
+### fzf
+
+- fd | fzf - Interactive file selection
+- vim $(fd -e .txt | fzf) - Open selected file in vim
+- fd --type f | fzf --preview 'cat {}' - Preview files
+
+### ripgrep
+
+- fd -e .py | xargs rg 'pattern' - Search pattern in Python files
+- fd -t f | xargs grep -l 'TODO' - Find files with TODO comments
+
+### trouble
+
+- Case sensitivity issues? Use smart case or -s/-i flags
+- Hidden files not showing? Use -H flag
+- Gitignore being respected? Use -u to override
+- Command too slow? Try limiting depth with -d flag
+
+### related
+
+- Install fd: install-fd
+- Text search: ripgrep-help
+- Fuzzy finder: fzf-help
+- Directory access: fasd-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/fd.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/fd.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/fzf.md
+++ b/docs/guide/commands/fzf.md
@@ -1,0 +1,112 @@
+# fzf
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/fzf.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic fzf --force`
+
+## 호출
+
+- Help 진입점: `fzf-help [section|--list|--all]`
+- 통합 라우팅: `my-help fzf [section]`
+- Alias: `fzf-help`
+
+## 요약 (fzf-help)
+
+- Usage: fzf-help [section|--list|--all]
+- sections
+    - core: Ctrl+T | Ctrl+R | Alt+C
+    - nav: Tab | Shift+Tab | Ctrl+K | Ctrl+J | PgUp | PgDn
+    - edit: Ctrl+W | Ctrl+U | Ctrl+A | Ctrl+E | Backspace
+    - select: Ctrl+A | Ctrl+D | Ctrl+X
+    - actions: Enter | Esc | Ctrl+V | Ctrl+L
+    - preview: ? | > | <
+    - examples: file | history | process | git
+    - tips: type | ^ | ! | ' | Tab
+    - config: FZF_DEFAULT_OPTS | FZF_DEFAULT_COMMAND
+    - details: fzf-help <section>  (example: fzf-help core)
+
+## 섹션
+
+### core
+
+- **Ctrl+T** — Insert selected file(s) into command line
+- **Ctrl+R** — Search and insert command from history
+- **Alt+C** — Change to selected directory
+
+### nav
+
+- **Tab** — Toggle selection (multi-select mode)
+- **Shift+Tab** — Toggle selection (reverse)
+- **Ctrl+K** — Move cursor up
+- **Ctrl+J** — Move cursor down
+- **Page Up** — Scroll up
+- **Page Down** — Scroll down
+
+### edit
+
+- **Ctrl+W** — Delete word backward
+- **Ctrl+U** — Clear line
+- **Ctrl+A** — Move to beginning of line
+- **Ctrl+E** — Move to end of line
+- **Backspace** — Delete character
+
+### select
+
+- **Ctrl+A** — Select all items
+- **Ctrl+D** — Deselect all items
+- **Ctrl+X** — Toggle all selections
+
+### actions
+
+- **Enter** — Confirm selection(s)
+- **Esc/Ctrl+C** — Abort (no selection)
+- **Ctrl+V** — Toggle preview window
+- **Ctrl+L** — Toggle layout
+
+### preview
+
+- **?** — Show/hide help
+- **>** — Toggle info on the right
+- **<** — Toggle info on the left
+
+### examples
+
+- File selection:
+- vim $(fzf) - Open file in vim
+- cat $(fzf) - Display file contents
+- cd $(dirname $(fzf)) - Navigate to file's directory
+- Command history:
+- Press Ctrl+R to search command history interactively
+- Process selection:
+- kill -9 $(pgrep -f process | fzf)
+- Git integration:
+- git checkout $(git branch | fzf)
+- git log --oneline | fzf
+
+### tips
+
+- Type to filter: Just start typing to narrow down results
+- Regex matching: Use ^pattern to match from start
+- Inverse match: Use !pattern to exclude matches
+- Exact match: Use 'pattern for exact string match
+- Multi-select: Use Tab to select multiple items
+
+### config
+
+- Customize fzf with environment variables:
+- FZF_DEFAULT_OPTS - Default options
+- FZF_DEFAULT_COMMAND - Default command
+- FZF_CTRL_T_COMMAND - Ctrl+T command
+- FZF_CTRL_R_OPTS - Ctrl+R options
+- FZF_ALT_C_COMMAND - Alt+C command
+- Example: Add to ~/.bashrc or ~/.zshrc
+- export FZF_DEFAULT_OPTS='--multi --preview "head -20 {}"'
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/fzf.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/fzf.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/gbr.md
+++ b/docs/guide/commands/gbr.md
@@ -1,0 +1,36 @@
+# gbr
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/git_branch.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic gbr --force`
+
+## 호출
+
+- Help 진입점: `gbr-help [section|--list|--all]`
+- 통합 라우팅: `my-help gbr [section]`
+- Alias: `gbr-help`
+
+## 요약 (gbr-help)
+
+- Usage: gbr-help [section|--list|--all]
+- sections
+    - teardown: gbr teardown [--force] [--keep-branch] [--discard-changes]
+    - details: gbr-help <section> (example: gbr-help teardown)
+
+## 섹션
+
+### teardown
+
+- **syntax** — gbr teardown [--force] [--keep-branch] [--discard-changes] — Cleanup merged feature branch
+- **context** — Run from the feature branch (not main, not worktree) — Switches to main, pulls, deletes current branch
+- **signal** — Detects '[gone]' upstream as PR-merged — Blocks otherwise; use --force to override
+- **flags** — --force / --keep-branch / --discard-changes — Skip merge-status checks (non-destructive) / sync main only / DESTRUCTIVE overwrite of local changes
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/gbr.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/git_branch.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/gc.md
+++ b/docs/guide/commands/gc.md
@@ -1,0 +1,41 @@
+# gc
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/gc_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic gc --force`
+
+## 호출
+
+- Help 진입점: `gc-help [section|--list|--all]`
+- 통합 라우팅: `my-help gc [section]`
+- Alias: `gc-help`
+
+## 요약 (gc-help)
+
+- Usage: gc-help [section|--list|--all]
+- sections
+    - basic: gc | gca
+    - options: --amend | --no-verify | --signoff
+    - details: gc-help <section>  (example: gc-help basic)
+
+## 섹션
+
+### basic
+
+- **gc** — git commit -m — Commit with message
+- **gca** — git commit --amend — Amend last commit
+
+### options
+
+- **--amend** — git commit --amend — Modify last commit
+- **--no-verify** — git commit --no-verify — Skip pre-commit hooks (use sparingly)
+- **--signoff** — git commit -s — Add Signed-off-by trailer
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/gc.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/gc_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/gcp.md
+++ b/docs/guide/commands/gcp.md
@@ -1,0 +1,66 @@
+# gcp
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/gcp.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic gcp --force`
+
+## 호출
+
+- Help 진입점: `gcp-help [section|--list|--all]`
+- 통합 라우팅: `my-help gcp [section]`
+- Alias: `gcp-help`
+
+## 요약 (gcp-help)
+
+- Usage: gcp help [section|--list|--all]
+- sections
+    - scan    gcp scan [base] [src] [--author=<name|all>]   compare & cherry-pick missing commits
+    - theirs  gcp theirs <commit>...                         cherry-pick with -X theirs (incoming wins)
+    - ours    gcp ours <commit>...                           cherry-pick with -X ours (current wins)
+    - author  gcp author <range> [author]                    cherry-pick commits by author
+    - pick    gcp pick <commit>...                           bare cherry-pick (one or more)
+    - details gcp help <section>  (example: gcp help scan)
+
+## 섹션
+
+### scan
+
+- **syntax** — gcp scan [base] [src] [--author=<name|all>] — Compare & pick missing commits
+- **default** — main <- upstream/main, author=dEitY719 — Filter by author by default
+- **--author=all** — show all authors — Bypass filter
+- **behavior** — detects duplicates (same subject in base) — Skips already-applied commits
+- **behavior** — contiguous range -> bulk cherry-pick — Non-contiguous -> individual
+- **--show-skip-list** — print known-resolved SHAs — git/config/gcp-scan-skip.conf (issue #1039)
+- **skip list** — registered SHAs skipped silently — ignored under --author=all
+- **--show-skip-paths** — print path-excluded paths — git/config/gcp-scan-skip-paths.conf
+- **skip paths** — commits touching only listed paths skipped — ignored under --author=all
+
+### theirs
+
+- **syntax** — gcp theirs <commit>... — Cherry-pick with -X theirs
+- **conflict** — incoming (cherry-picked) changes win
+
+### ours
+
+- **syntax** — gcp ours <commit>... — Cherry-pick with -X ours
+- **conflict** — current branch changes win
+
+### author
+
+- **syntax** — gcp author <range> [author] — Cherry-pick commits by author
+- **default author** — dEitY719
+- **range format** — <start>..<end> or <start>^..<end>
+
+### pick
+
+- **syntax** — gcp pick <commit>... — Bare cherry-pick (one or more)
+- **note** — replaces deprecated bare 'gcp <commit>' — bare form bridges with deprecation warning
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/gcp.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/gcp.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/ghostty.md
+++ b/docs/guide/commands/ghostty.md
@@ -1,0 +1,68 @@
+# ghostty
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/ghostty_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic ghostty --force`
+
+## 호출
+
+- Help 진입점: `ghostty-help [section|--list|--all]`
+- 통합 라우팅: `my-help ghostty [section]`
+- Alias: `ghostty-help`
+
+## 요약 (ghostty-help)
+
+- Usage: ghostty-help [section|--list|--all]
+- sections
+    - concept: GPU-accelerated | AppKit/GTK4 | Catppuccin
+    - config: ghostty_init | ghostty_edit_config
+    - symlink: ~/dotfiles/ghostty/config -> ~/.config/ghostty/config
+    - settings: theme | font-family | background-opacity | quick-terminal
+    - commands: +list-themes | +list-fonts | +show-config
+    - related: tmux-help | zsh-help
+    - details: ghostty-help <section>  (example: ghostty-help config)
+
+## 섹션
+
+### concept
+
+- GPU-accelerated terminal emulator (Zig + libghostty)
+- Platform-native UI on macOS (AppKit) and Linux (GTK4)
+- Catppuccin Mocha/Latte theme with Hack Nerd Font Mono
+
+### config
+
+- **ghostty_init** — 설정 파일 symbolic link 초기화
+- **ghostty_edit_config** — config 파일 편집 (symlinked)
+
+### symlink
+
+- Source: ~/dotfiles/ghostty/config
+- Target: ~/.config/ghostty/config
+
+### settings
+
+- **theme** — dark:catppuccin-mocha, light:catppuccin-latte
+- **font-family** — Hack Nerd Font Mono (size 14)
+- **background-opacity** — 0.8 with blur radius 10
+- **quick-terminal** — Cmd+` toggle, bottom position
+
+### commands
+
+- **ghostty +list-themes** — List all available themes
+- **ghostty +list-fonts** — List available fonts
+- **ghostty +show-config** — Show current configuration
+
+### related
+
+- Terminal multiplexer: tmux-help
+- Zsh shell: zsh-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/ghostty.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/ghostty_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/git.md
+++ b/docs/guide/commands/git.md
@@ -1,0 +1,233 @@
+# git
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/git_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic git --force`
+
+## 호출
+
+- Help 진입점: `git-help [section|--list|--all]`
+- 통합 라우팅: `my-help git [section]`
+- Alias: `git-help`
+
+## 요약 (git-help)
+
+- Usage: git-help [section|--list|--all]
+- sections
+    - basic: gs | ga | gc | gca | gp | gpl | gco | gd | grs | gb | grmc
+    - sync: gf | gfu | gfa | gsw | gr
+    - logs: gl | gl1 | gl2 | glref
+    - upstream: gupa | gupdel | glum | glub
+    - branch: gset-main | gset-dev | gset | gb -D local | gb -D remote
+    - stash: git stash list | show -p | pop | apply | drop
+    - pick: gcp scan | gcp theirs | gcp ours | gcp author | gcp pick
+    - special: gpf_dev_server | gpfu
+    - lfs: git_lfs_install | glfs
+    - ssh: git_ssh_check | git_ssh_setup
+    - deploy: deploy | release | release-artifacts | rollback | pitfalls | principles
+    - details: git-help <section>  (example: git-help stash)
+
+## 섹션
+
+### basic
+
+- **gs** — git status -sb — Short status
+- **ga** — git add . — Stage all changes
+- **gc** — git commit -m — Commit with message
+- **gca** — git commit --amend — Amend last commit
+- **gp** — git push — Push to remote
+- **gpl** — git pull — Pull from remote
+- **gco** — git checkout — Checkout branch/commit
+- **gd** — git diff — Show changes
+- **grs** — git restore <file> — Discard changes (친절 래퍼: untracked/오타/staged/no-op 사전 경고)
+- **grs --staged** — git restore --staged <file> — Unstage file (undo git add)
+- **gb** — git branch — List branches
+- **grmc** — git rm --cached — Unstage, keep file
+
+### sync
+
+- **gf [remote]** — gf / gf u / gf <name> — Fetch & prune (default: origin, u=upstream)
+- **gfu** — git fetch upstream — Fetch upstream
+- **gfa** — git fetch --all — Fetch all & prune
+- **gsw** — git switch -c — Switch to remote branch
+- **gr** — git remote -v — List remotes
+
+### logs
+
+- **gl** — git-log — Graph log (default 11)
+- **gl1** — log --oneline — One-line graph log
+- **gl2** — git-log2 — Alternative log format
+- **glref** — log ref/main — Ref log for main
+
+### upstream
+
+- **gupa** — remote add upstream — Add upstream remote
+- **gupdel** — gupdel <remote> — Remove remote
+- **glum** — git-log-upstream — Upstream main log
+- **glub** — glub [branch] — Upstream branch log
+
+### branch
+
+- **gset-main** — set-upstream main — Track origin/main
+- **gset-dev** — set-upstream dev — Track origin/dev
+- **gset** — gset [branch] — Track origin/[branch]
+- **gb -D local** — git_branch -D local — Delete local branches (keeps: main/master + current + keywords)
+- **gb -D remote [<remote>]** — git_branch -D remote — Delete remote-tracking branches (default: origin, e.g. origin, upstream, keeps: main/master)
+- **gb -h** — git_branch --help — Show gb sub-command help
+
+### stash
+
+- **git stash list** — git stash list — List saved stashes
+- **git stash show -p** — git stash show -p [stash] — Show stashed patch (default: latest)
+- **git stash pop** — git stash pop [stash] — Apply stash and remove it
+- **git stash apply** — git stash apply [stash] — Apply stash and keep it
+- **git stash drop** — git stash drop [stash] — Delete a stash entry
+
+### pick
+
+- **gcp pick** — gcp pick <commit>... — Cherry-pick commits
+- **gcp theirs** — gcp theirs <commit>... — Cherry-pick with -X theirs (incoming)
+- **gcp ours** — gcp ours <commit>... — Cherry-pick with -X ours (current)
+- **gcp author** — gcp author <range> [author] — Cherry-pick by author
+- **gcp scan** — gcp scan [base] [src] [--author=<name|all>] — Compare & pick missing (default: main <- upstream/main, author=dEitY719)
+- **gcp -h** — gcp help [section] — Show gcp sub-command help
+
+### special
+
+- **gpf_dev_server** — push force dev — Force push dev-server
+- **gpfu** — push --force-with-lease — Force push main
+
+### lfs
+
+- **git_lfs_install** — Install LFS — Ubuntu setup
+- **glfs** — track <pattern> — Track files with LFS
+
+### ssh
+
+- **git_ssh_check** — Test GitHub SSH — Verify GitHub SSH connection
+- **git_ssh_setup** — Setup SSH — Manual SSH configuration guide
+
+### deploy
+
+**치환값 (placeholder)**
+
+- **<DEV_WORKFLOW>** — 예: dev-deploy.yml — dev 배포 workflow 파일
+- **<REPO_COORD>** — 예: github.example.net/org/repo — gh --repo 좌표 <GHE_HOST>/<ORG>/<REPO>
+**[Phase 0] Refresh origin/main**
+
+- fork repo (사내 fork <-> 공개 upstream):
+  git checkout main
+  git fetch --all --prune
+  git merge upstream/main   # 충돌/ruff drift -> git-help pitfalls
+  git push origin main
+- plain repo (upstream 없음):
+  git checkout main
+  git pull --ff-only
+**[Phase 1] Trigger dev deploy**
+
+  gh workflow run <DEV_WORKFLOW> --repo <REPO_COORD> -f ref=main
+- optional: -f no_cache=true  (Docker 강제 재빌드)
+- optional: -f reset_db=true  (DB 볼륨 초기화 — 데이터 삭제 주의)
+**[Phase 2] Check status**
+
+  gh run list --workflow=<DEV_WORKFLOW> --repo <REPO_COORD> --limit 3
+- 근거·상세: docs/guide/deploy-workflow.md
+
+### release
+
+**치환값 (placeholder)**
+
+- **<PROD_WORKFLOW>** — 예: prod-deploy.yml — prod 배포 workflow 파일
+- **<REPO_COORD>** — 예: github.example.net/org/repo — gh --repo 좌표
+- **<TAG>** — 예: v2.1.0 — 릴리스 태그
+- **<DEPLOY_STRATEGY>** — rolling | recreate — prod 배포 전략
+- **<TEST_CMD>** — 예: uv run pytest -q — 릴리스 게이트 테스트
+- **<RELEASE_FILES>** — version bump + notes — 릴리스 커밋에 스테이징할 파일
+- **<PROD_SSH_ALIAS>** — 예: devops-prod — prod 로그/psql 접근 (~/.ssh/config 별칭)
+- **<PROD_API_CONTAINER>** — 예: prod-api — prod api 컨테이너 이름
+**[Phase A] Refresh origin/main**
+
+- git-help deploy 의 Phase 0 과 동일 (fork=merge / plain=pull)
+**[Phase B] Update release artifacts**
+
+- 프로젝트별 산출물 -> git-help release-artifacts
+**[Phase C] Gate -> commit -> tag -> push -> deploy -> verify**
+
+- C-1. test gate (프록시 env 오염 시 -> git-help pitfalls)
+  <TEST_CMD>
+- C-2. stage release artifacts only (다른 변경 넣지 말 것)
+  git add <RELEASE_FILES>
+- C-3. commit + annotated tag
+  git commit -m "release(<TAG>): ..."
+  git tag -a <TAG> -m "<TAG>"
+- C-4. push tag first, then main
+  git push origin <TAG>
+  git push origin main
+- C-5. prod deploy (태그 직접 지정)
+  gh workflow run <PROD_WORKFLOW> --repo <REPO_COORD> -f ref=<TAG> -f deploy_strategy=<DEPLOY_STRATEGY>
+- rolling: 무중단 / recreate: down->up (파괴적 migration)
+- C-6. watch
+  gh run list --workflow=<PROD_WORKFLOW> --repo <REPO_COORD> --limit 3
+  gh run watch <run-id> --repo <REPO_COORD>
+- C-7. 사후검증: 푸터 <TAG> 표시 / prod 로그 무이상
+  ssh <PROD_SSH_ALIAS> "docker logs <PROD_API_CONTAINER> --since 10m --tail 50"
+- 공지 등 후처리: git-help release-artifacts / 근거: docs/guide/deploy-workflow.md
+
+### release_artifacts
+
+**Release artifacts (프로젝트별 — 예시)**
+
+- version bump (버전 표기 단일 소스)  예: apps/web/vite.config.ts 의 APP_VERSION
+- release notes 신설  예: docs/public/release-notes/<TAG>.md
+- release notes 목록 최상단 링크 추가  예: docs/public/release-notes/README.md
+- 인앱 공지 본문 작성 (리포 밖)  예: /tmp/announcement.json
+- (배포 성공 후) 공지 등록 — psql 접근  예: PROD_SSH=<PROD_SSH_ALIAS> <release-script>
+- 도메인 variable(APP_BASE_URL 등) 최신인지 확인 — 옛 도메인이면 로그인 nonce_missing
+- 근거·상세: docs/guide/deploy-workflow.md
+
+### rollback
+
+**치환값 (placeholder)**
+
+- **<PROD_WORKFLOW>** — 예: prod-deploy.yml — prod 배포 workflow 파일
+- **<REPO_COORD>** — 예: github.example.net/org/repo — gh --repo 좌표
+- **<PREV_TAG>** — 예: v2.0.3 — 롤백 대상 이전 태그
+**[Step 1] 이전 태그 확인**
+
+  git tag --sort=-v:refname | head
+  gh release list --repo <REPO_COORD>
+**[Step 2] 이전 태그로 prod 재배포**
+
+  gh workflow run <PROD_WORKFLOW> --repo <REPO_COORD> -f ref=<PREV_TAG> -f deploy_strategy=rolling
+**[Step 3] watch + 사후검증**
+
+  gh run watch <run-id> --repo <REPO_COORD>
+- 파괴적 DB migration 이 있었으면 코드 롤백만으로 복구 안 됨 -> recreate + DB 복구 별도
+- 근거·상세: docs/guide/deploy-workflow.md
+
+### pitfalls
+
+- **함정** — 대응
+- **upstream merge ruff drift** — uv run --project <PKG> ruff format <파일> 재커밋
+- **pytest 프록시 env 오염** — env -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy -u NO_PROXY -u no_proxy
+- **prod SSH 인증 실패** — PROD_SSH=<PROD_SSH_ALIAS> (~/.ssh/config 별칭) 사용
+- **dev-deploy rolling 없음** — dev 는 no_cache/reset_db 만 유효
+- **배포 커밋-태그 불일치** — prod 는 -f ref=<TAG> 로 태그 직접 지정
+- **릴리스 후 nonce_missing** — APP_BASE_URL variable 이 신 도메인인지 확인 후 재배포
+- 전체 함정·맥락: docs/guide/deploy-workflow.md
+
+### principles
+
+- 1) Fork sync = merge (rebase 금지) — origin/main 공용, force-push/SHA/stale tag 회피
+- 2) 배포 = gh workflow run (branch push 아님) — 폐기된 dev-server/prod-server 무시
+- 3) prod=태그(-f ref=<TAG>), dev=main — 태그는 롤백·release·감사 좌표
+- 근거 상세: docs/guide/deploy-workflow.md
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/git.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/git_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/gpu.md
+++ b/docs/guide/commands/gpu.md
@@ -1,0 +1,86 @@
+# gpu
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/system_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic gpu --force`
+
+## 호출
+
+- Help 진입점: `gpu-help [section|--list|--all]`
+- 통합 라우팅: `my-help gpu [section]`
+- Alias: `gpu-help`
+
+## 요약 (gpu-help)
+
+- Usage: gpu-help [section|--list|--all]
+- sections
+    - diagnostics: gpustatus | gpuinfo
+    - docker: gpu-offload | gpu-mem
+    - fixes: docker compose restart ollama | docker restart ollama | dcr ollama
+    - wsl: gpu-info-basic | gpu-memory | gpu-watch
+    - test: tinyllama | llama3:instruct
+    - troubleshoot: OLLAMA_NUM_GPU | OLLAMA_FLASH_ATTENTION
+    - examples: good vs bad layer offload
+    - tips: gpustatus | gpuinfo | gpu-offload | gpu-memory | gpu-watch
+    - details: gpu-help <section>  (example: gpu-help diagnostics)
+
+## 섹션
+
+### diagnostics
+
+- **gpustatus** — bash gpu_status.sh — 5-part detailed GPU diagnostic
+- **gpuinfo** — Compact GPU summary — Brief GPU hardware + layer offload
+
+### docker
+
+- **gpu-offload** — docker logs ollama | grep offloaded — Layer offload status (25/25 = good)
+- **gpu-mem** — docker logs ollama | grep gpu memory — GPU memory recognition check
+
+### fixes
+
+- **docker compose restart ollama** — Restart Ollama — Forces GPU layer re-init
+- **docker restart ollama** — Restart container — Direct restart without compose
+- **dcr ollama** — Auto-detect restart — Compose-aware restart
+
+### wsl
+
+- **gpu-info-basic** — nvidia-smi — GPU hardware info, workload, temp
+- **gpu-memory** — nvidia-smi memory (CSV) — Detailed memory info
+- **gpu-watch** — Real-time GPU monitor — Live monitoring (Ctrl+C to exit)
+
+### test
+
+- Fast test (1-2s): docker exec ollama ollama run tinyllama "hi"
+- Full test (10s+): docker exec ollama ollama run llama3:instruct "hi"
+
+### troubleshoot
+
+- Add to docker-compose.yml (Ollama service):
+  environment:
+    OLLAMA_NUM_GPU: '25'           # or your GPU's layer count
+    OLLAMA_FLASH_ATTENTION: '1'    # enables flash attention
+- Then restart: docker compose up -d ollama
+
+### examples
+
+- ✅ Good GPU layer offload:
+  offloaded 25/25 layers to GPU
+
+- ❌ Bad GPU layer offload:
+  offloaded 0/25 layers to GPU
+
+### tips
+
+- Full diagnosis: gpustatus
+- Quick overview: gpuinfo
+- Monitor layers: gpu-offload
+- Check memory: gpu-memory or gpu-watch
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/gpu.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/system_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/gwt.md
+++ b/docs/guide/commands/gwt.md
@@ -1,0 +1,87 @@
+# gwt
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/git_worktree.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic gwt --force`
+
+## 호출
+
+- Help 진입점: `gwt-help [section|--list|--all]`
+- 통합 라우팅: `my-help gwt [section]`
+- Alias: `gwt-help`
+
+## 요약 (gwt-help)
+
+- Usage: gwt-help [section|--list|--all]
+- sections
+    - add      gwt add <path> [branch] [start]              create worktree
+    - list     gwt list|ls [--quick|--remote]               list worktrees
+    - remove   gwt remove <path|name|all> [--force]         delete worktree dir + branch
+    - prune    gwt prune                                    clean stale .git/worktrees/ refs (no path)
+    - spawn    gwt spawn <name> [--task|--base|--tmux|...]  create named worktree (AI workflow)
+    - status   gwt status [<name>]                          per-worktree diagnostic
+    - teardown gwt teardown [--force] [--keep-branch]       cleanup current/all worktree(s)
+    - details: gwt-help <section>  (example: gwt-help spawn)
+
+## 섹션
+
+### add
+
+- **syntax** — gwt add <path> [<new-branch> [<start-point>]] — Create git-crypt-safe worktree
+- **behavior** — Sparse checkout excludes encrypted paths — Keeps encrypted layout safe
+
+### list
+
+- **syntax** — gwt list | gwt ls [--quick|-q] [--remote|-r] — List linked worktrees
+- **default** — PATH/BRANCH/STATE/AGE/NEXT columns — Local signals (no network)
+- **--quick** — path/commit/branch only — Legacy output
+- **--remote** — Adds PR state via batched gh CLI call — One network call regardless of N
+- **states** — dirty/ahead/pr-open/pr-merged/merged/... — See 'gwt-help status' for full list
+
+### status
+
+- **syntax** — gwt status [<name>] — Per-worktree diagnostic
+- **no arg** — status for the worktree containing $PWD — Single-worktree mode
+- **<name>** — Matches *-<name>-* like 'gwt remove' — Fails if multiple match
+- **rows** — Path/Branch/HEAD/Upstream/Uncommitted/PR/Lock/Ahead-Behind — Mirrors gh-flow status
+- **verdict** — dirty/ahead/pr-open/pr-merged/pr-closed/merged/stale/locked/prunable/clean — + Next action hint
+
+### remove
+
+- **syntax** — gwt remove <path|name|all> [--force] — Remove worktree + branch
+- **name mode** — <name> matches *-<name>-* — Batch remove by worktree name
+- **all mode** — all removes non-main worktrees — Batch cleanup
+- **force** — --force — Force remove and branch delete
+
+### prune
+
+- **syntax** — gwt prune — Run: git worktree prune
+
+### spawn
+
+- **syntax** — gwt spawn <name> [--task <slug>] [--base <ref>] [--tmux|--launch [--ai <agent>]] [--user <account>] — Create named worktree
+- **context** — Run from main repo only — Fails inside a worktree
+- **name** — Free-form slug (required) — e.g. issue-11, login-fix
+- **--ai** — AI agent (default: claude) — claude, codex, agy, opencode, cursor, copilot
+- **--user** — Claude account for --tmux/--launch (only with --ai claude) — personal, work — default: $CLAUDE_DEFAULT_ACCOUNT
+- **--tmux** — Runs <agent>-yolo in new tmux pane — Mutually exclusive with --launch
+- **--launch** — cd into worktree + run <agent>-yolo inline — Current shell, no tmux
+- **example** — gwt spawn issue-11 --tmux --ai codex — Free-form name + codex agent
+- **example** — gwt spawn feat --launch — spawn -> cd -> claude-yolo (one shot)
+- **example** — gwt spawn feat --launch --user work — spawn -> cd -> claude-yolo --user work
+
+### teardown
+
+- **syntax** — gwt teardown [--all|-a|all] [--force] [--keep-branch] — Cleanup AI worktree(s)
+- **context** — Single mode: run inside a worktree — Syncs main repo after cleanup
+- **all mode** — Run from main repo or any worktree — Tears down every non-main worktree
+- **flags** — --force / --keep-branch — Discard changes / keep branch
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/gwt.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/git_worktree.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/herdr.md
+++ b/docs/guide/commands/herdr.md
@@ -1,0 +1,90 @@
+# herdr
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/herdr_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic herdr --force`
+
+## 호출
+
+- Help 진입점: `herdr-help [section|--list|--all]`
+- 통합 라우팅: `my-help herdr [section]`
+- Alias: `herdr-help`
+
+## 요약 (herdr-help)
+
+- Usage: herdr-help [section|--list|--all]
+- sections
+    - concept: agent multiplexer | 세션 유지 | prefix Ctrl+b
+    - pane: split right/down | hjkl 이동 | zoom | rename | close
+    - tab: new | next/prev
+    - workspace: navigation | new
+    - control: detach
+    - example | related
+    - install: 사외 curl|sh · 사내 GitHub 릴리스 바이너리
+    - details: herdr-help <section>  (example: herdr-help pane)
+
+## 섹션
+
+### concept
+
+- 여러 코딩 agent를 한 터미널에서 실행하는 multiplexer
+- 서버에 세션 유지 — 터미널/SSH 끊겨도 agent 계속 동작
+- 모든 단축키: prefix (기본 Ctrl+b) 누른 뒤 해당 키
+
+### pane
+
+- **prefix+v** — split right (좌우 분할)
+- **prefix+minus** — split down (상하 분할, horizontal)
+- **prefix+h** — 왼쪽 pane으로 이동
+- **prefix+j** — 아래 pane으로 이동
+- **prefix+k** — 위 pane으로 이동
+- **prefix+l** — 오른쪽 pane으로 이동
+- **prefix+z** — 현재 pane 풀스크린 토글 (zoom)
+- **prefix+shift+p** — 현재 pane 이름 변경
+- **prefix+x** — 현재 pane 닫기
+
+### tab
+
+- **prefix+c** — 새 탭 생성
+- **prefix+n / prefix+p** — 다음 / 이전 탭
+
+### workspace
+
+- **prefix+w** — workspace 간 이동
+- **prefix+shift+n** — 새 workspace 생성
+
+### control
+
+- **prefix+q** — 세션에서 빠져나오기 (detach client) — agent는 계속 실행
+
+### example
+
+- herdr                    # 세션 시작/재접속
+- claude                   # pane 안에서 agent 실행
+- prefix+v                 # 오른쪽 split
+- prefix+minus             # 아래 split (오른쪽 pane 안에서)
+- prefix+j / prefix+l 등   # pane 간 이동
+- prefix+q                 # detach
+- herdr                    # 나중에 다시 접속, agent 그대로
+
+### related
+
+- Docs: https://herdr.dev/docs/
+- tmux 사용자라면: tmux-help
+
+### install
+
+- 사외(표준, 전 OS): curl -fsSL https://herdr.dev/install.sh | sh  (또는 brew install herdr / mise use -g herdr)
+- 사내(프록시 차단 우회, Linux x86_64 전용): curl -fsSL -o ~/.local/bin/herdr https://github.com/ogulcancelik/herdr/releases/latest/download/herdr-linux-x86_64 && chmod +x ~/.local/bin/herdr
+- macOS/Apple Silicon 사내망: 위 바이너리는 Linux 전용 — 사외(표준) brew/mise 경로 사용 또는 releases 페이지에서 darwin 자산명 확인
+- 사내(버전 고정): 위 URL의 latest/download 대신 download/v0.7.5 로 태그 지정
+- 근본 해결: 프록시 예외 신청 — GSAMS https://gsams.samsungds.net
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/herdr.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/herdr_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/hook.md
+++ b/docs/guide/commands/hook.md
@@ -1,0 +1,77 @@
+# hook
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/hook_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic hook --force`
+
+## 호출
+
+- Help 진입점: `hook-help [section|--list|--all]`
+- 통합 라우팅: `my-help hook [section]`
+- Alias: `hook-help`
+
+## 요약 (hook-help)
+
+- Usage: hook-help [section|--list|--all]
+- sections
+    - overview: 2-tier (user + project) | 자동 진단 | HOOK_WORKFLOW.md
+    - commands: hook-check | hook-check --help
+    - results: ✓ 정상 | ✗ 오류 | ⚠ 경고
+    - trouble: hook 안 됨 | hooksPath | 권한 | 재실행
+    - types: User-level | Project-level
+    - more: HOOK_WORKFLOW.md | global-hooks | hook-config | setup.sh
+    - tips: 주기적 점검 | 새 PC 셋업 | GIT_HOOKS_DEBUG
+    - details: hook-help <section>  (example: hook-help commands)
+
+## 섹션
+
+### overview
+
+- 2-tier Hook 아키텍처: User-level (전역) + Project-level (로컬)
+- 자동 진단 도구로 설정 문제를 쉽게 해결
+- 상세 가이드: git/doc/HOOK_WORKFLOW.md
+
+### commands
+
+- **hook-check** — Hook 설정 진단 ⭐ — 6가지 자동 체크 + 자동 수정 옵션
+- **hook-check --help** — 도움말 보기 — 이 페이지 표시
+
+### results
+
+- ✓ = 설정 정상
+- ✗ = 설정 오류 (수정 필요)
+- ⚠ = 경고 (선택적)
+
+### trouble
+
+- **Hook이 실행 안 됨** — hook-check 실행 — 자동 진단 및 수정
+- **core.hooksPath 오류** — git config 명령 직접 실행
+- **권한 오류** — chmod +x 명령 실행 — Hook 파일을 실행 가능하게
+- **설정 전부 다시** — setup.sh 재실행 — cd ~/dotfiles && ./git/setup.sh
+
+### types
+
+- **User-level** — ~/.config/git/hooks/pre-commit — 모든 git 프로젝트에 적용 (전역)
+- **Project-level** — dotfiles/.git/hooks/pre-commit — 이 dotfiles 프로젝트에만 적용
+
+### more
+
+- 자세한 가이드: git/doc/HOOK_WORKFLOW.md
+- Hook 구현: git/global-hooks/pre-commit
+- Hook 설정값: git/config/hook-config.sh
+- Setup 스크립트: git/setup.sh
+
+### tips
+
+- hook-check를 주기적으로 실행해서 설정 상태 확인
+- 새 PC에서는 반드시 ./git/setup.sh 실행
+- Hook 문제 발생 시 GIT_HOOKS_DEBUG=1 환경변수로 디버그 출력
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/hook.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/hook_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/litellm.md
+++ b/docs/guide/commands/litellm.md
@@ -1,0 +1,45 @@
+# litellm
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/ai_tools_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic litellm --force`
+
+## 호출
+
+- Help 진입점: `litellm-help [section|--list|--all]`
+- 통합 라우팅: `my-help litellm [section]`
+- Alias: `litellm-help`, `llm-help`
+
+## 요약 (litellm-help)
+
+- Usage: litellm-help [section|--list|--all]
+- sections
+    - basic: llm-start | llm-stop | llm-restart | llm-status | llm-models | llm-test
+    - info: Path | URL | Key
+    - details: litellm-help <section>  (example: litellm-help basic)
+
+## 섹션
+
+### basic
+
+- **llm-start** — Start Stack — docker compose up
+- **llm-stop** — Stop Stack — docker compose down
+- **llm-restart** — Restart — Stop & Start
+- **llm-status** — Status — Check health & models
+- **llm-models** — List Models — Show loaded models
+- **llm-test** — Test Model — Run basic prompt
+
+### info
+
+- **Path** — 
+- **URL** — 
+- **Key** — 
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/litellm.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/ai_tools_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/mount.md
+++ b/docs/guide/commands/mount.md
@@ -1,0 +1,51 @@
+# mount
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/mount.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic mount --force`
+
+## 호출
+
+- Help 진입점: `mount-help [section|--list|--all]`
+- 통합 라우팅: `my-help mount [section]`
+- Alias: `mount-help`
+
+## 요약 (mount-help)
+
+- Usage: mount-help [section|--list|--all]
+- sections
+    - description: generic bind mount helpers
+    - commands: addmnt | show-mnt
+    - info: per-command --help references
+    - notes: sudo & sudoers configuration
+    - details: mount-help <section>  (example: mount-help commands)
+
+## 섹션
+
+### description
+
+- Generic bind mount helpers (Claude skills/docs now use directory symlinks, #575)
+
+### commands
+
+- addmnt <source> <target>    Create bind mount
+- show-mnt [path]             Display mount status
+
+### info
+
+- addmnt --help       Usage for addmnt command
+- show-mnt --help     Usage for show-mnt command
+
+### notes
+
+- Requires sudo for mount operations
+- Configure sudoers for passwordless mounting in /etc/sudoers.d/
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/mount.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/mount.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/mysql.md
+++ b/docs/guide/commands/mysql.md
@@ -1,0 +1,37 @@
+# mysql
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/database_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic mysql --force`
+
+## 호출
+
+- Help 진입점: `mysql-help [section|--list|--all]`
+- 통합 라우팅: `my-help mysql [section]`
+- Alias: `mysql-help`
+
+## 요약 (mysql-help)
+
+- Usage: mysql-help [section|--list|--all]
+- sections
+    - service: mysql_list | mysql_dmc_dev | mysql_dmc_test | mysql_cmd | mysql_server
+    - details: mysql-help <section>  (example: mysql-help service)
+
+## 섹션
+
+### service
+
+- **mysql_list** — List configured services — Show all database connections
+- **mysql_dmc_dev** — Connect to dev database — Use .my.cnf config
+- **mysql_dmc_test** — Connect to test database — Use .my.cnf config
+- **mysql_cmd <svc> <cmd>** — Execute SQL command — databases, tables, version, describe, status, etc.
+- **mysql_server <action>** — Manage service — start, stop, restart, status, reload
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/mysql.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/database_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/mytool.md
+++ b/docs/guide/commands/mytool.md
@@ -1,0 +1,105 @@
+# mytool
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/mytool_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic mytool --force`
+
+## 호출
+
+- Help 진입점: `mytool-help [section|--list|--all]`
+- 통합 라우팅: `my-help mytool [section]`
+- Alias: `mytool-help`
+
+## 요약 (mytool-help)
+
+- Usage: mytool-help [section|--list|--all]
+- sections
+    - tools: list all .sh files in shell-common/tools/custom/
+    - usage: how to run custom tools
+    - details: mytool-help <section>  (example: mytool-help tools)
+
+## 섹션
+
+### tools
+
+- Executable utility scripts in ~/dotfiles/shell-common/tools/custom
+- **Tool** — Description
+- **analyze_bash_scripts** — Scan a directory of bash files and emit a Markdown summar...
+- **check_apt** — Comprehensive APT sources configuration diagnostic script
+- **check_cargo** — Comprehensive Cargo configuration diagnostic script
+- **check_network** — Comprehensive internet connectivity diagnostic script
+- **check_npm** — Comprehensive npm configuration diagnostic script
+- **check_nuget** — Comprehensive NuGet configuration diagnostic script
+- **check_pip** — Comprehensive pip configuration diagnostic script
+- **check_proxy** — Comprehensive proxy diagnostic script
+- **check_rpm** — Comprehensive RPM/YUM repository configuration diagnostic...
+- **check_ssh** — SSH key setup and diagnostics for SSAI project (WSL envir...
+- **check_uv** — Comprehensive uv configuration diagnostic script
+- **check_ux_consistency** — Check UX consistency across all bash files
+- **cp_wdown** — Copy files from Windows "Downloads" to WSL ~/downloads wi...
+- **delete_claude** — Claude Code CLI Uninstall Script
+- **demo_ux** — Interactive demo of UX library features
+- **devx** — This script exists so `devx` can be run as a standalone c...
+- **docker_configure_proxy** — Docker Proxy 설정 스크립트 (대화형)
+- **enable_docker** — Docker 서비스 자동 시작 설정 (systemd) - 대화형
+- **ensure_jq** — Ensure jq is installed (dependency checker)
+- **ensure-ollama-deps** — Ollama Dependency Installer
+- **gen_command_docs** — Generate one markdown reference doc per user-facing comma...
+- **get_hw_info** — Display comprehensive hardware information
+- **gpu_status** — 목적: WSL2 특성상 컨테이너 내 nvidia-smi 사용 불가를 해결하고
+- **hook_check** — Git Hook Configuration Diagnostic Tool
+- **init** — Centralized initialization for all custom tools scripts.
+- **install_agy** — Antigravity CLI (agy) 설치 스크립트 (대화형)
+- **install_bat** — Install and configure bat (cat replacement with syntax hi...
+- **install_claude** — Claude Code CLI Install Script
+- **install_codex** — Codex CLI 설치 스크립트 (대화형)
+- **install_docker** — WSL Docker 설치 스크립트 (대화형)
+- **install_fasd** — Install and configure fasd (fast access to directories an...
+- **install_fd** — Install and configure fd (fast file search tool)
+- **install_fzf** — Install and configure fzf (fuzzy finder) for bash and zsh
+- **install_git_lfs** — Install and initialize Git LFS (Ubuntu/Debian)
+- **install_notion_mcp** — Install and configure Notion MCP (Model Context Protocol)...
+- **install_npm** — Node.js & npm 설치 스크립트 (대화형)
+- **install_nvm** — NVM (Node Version Manager) Install Script
+- **install-ollama** — WSL Environment: Ollama Binary Installation Script
+- **install_opencode** — OpenCode CLI Installation Script (Interactive)
+- **install_p10k** — Install and configure powerlevel10k theme for zsh
+- **install_pet** — Install and configure pet (command snippet manager)
+- **install_postgresql** — PostgreSQL 서버 설치 스크립트 (대화형)
+- **install_python** — Pyenv & Python Install Script
+- **install_redis** — Redis server installer for WSL/Ubuntu (interactive)
+- **install_ripgrep** — Install and configure ripgrep (fast text search tool)
+- **install_uv** — UV Install Script
+- **install_zsh_autosuggestions** — Install and configure zsh-autosuggestions
+- **install_zsh** — Zsh Install Script
+- **make_confluence** — Transform a technical markdown document into a Confluence...
+- **make_jira** — Simple version handling both:
+- **mirror-pages-activate** — Activates GitHub Pages on the GHE origin repo and replace...
+- **repo_stats** — Initialize common tools environment
+- **run_agents_md_master_prompt** — Claude Code에게 AGENTS.md 생성 요청 (비대화형)
+- **set_locale** — This script sets up the en_US.UTF-8 locale to resolve "ma...
+- **setup_crt** — CA Certificate Setup Script
+- **setup_gpg_cache** — GPG agent 캐싱 설정 스크립트 (편의성 향상)
+- **skill_loader** — Standalone skill loader utility for programmatic access
+- **symlink-manager** — Symbolic Link Manager for Dotfiles
+- **uninstall_agy** — Antigravity CLI (agy) 제거 스크립트 (대화형)
+- **uninstall_codex** — Codex CLI 제거 스크립트 (대화형)
+- **uninstall_docker** — WSL Docker 제거 스크립트 (대화형)
+- **uninstall_npm** — Node.js & npm 제거 스크립트 (대화형)
+- **work_log** — Companion to post-commit hook for tracking non-developmen...
+- Total: 63 custom tools available
+- Location: ~/dotfiles/shell-common/tools/custom
+
+### usage
+
+- Run a tool directly: ${SHELL_COMMON}/tools/custom/tool-name.sh
+- Or add to PATH for direct execution: tool-name.sh
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/mytool.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/mytool_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/network.md
+++ b/docs/guide/commands/network.md
@@ -1,0 +1,63 @@
+# network
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/system_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic network --force`
+
+## 호출
+
+- Help 진입점: `network-help [section|--list|--all]`
+- 통합 라우팅: `my-help network [section]`
+- Alias: `network-help`
+
+## 요약 (network-help)
+
+- Usage: network-help [section|--list|--all]
+- sections
+    - diagnostics: check-network | quick | dns | ping | https | git | apt | pip | curl
+    - typical: check-network | check-network quick | check-proxy
+    - checks: DNS | ICMP | HTTPS | git | apt | pip
+    - notes: ICMP fallback | APT auto-skip | check-proxy
+    - details: network-help <section>  (example: network-help diagnostics)
+
+## 섹션
+
+### diagnostics
+
+- check-network         Run full network diagnostic
+- check-network quick   DNS + HTTPS + git quick check
+- check-network dns     DNS resolution test
+- check-network ping    ICMP ping test
+- check-network https   HTTPS HEAD request test
+- check-network git     Git remote access test
+- check-network apt     APT repository reachability
+- check-network pip     pip repository reachability
+- check-network curl    curl GET request test
+
+### typical
+
+- check-network         Verify internet access end-to-end
+- check-network quick   Fast sanity check after shell startup
+- check-proxy           Diagnose proxy-specific configuration
+
+### checks
+
+- DNS lookup to confirm name resolution
+- ICMP ping to detect low-level reachability
+- HTTPS and curl requests to validate outbound web access
+- git, apt, and pip endpoints for real tool-level access
+
+### notes
+
+- ICMP ping may fail even when normal web traffic works
+- APT check is skipped automatically on non-APT systems
+- Use check-proxy for proxy variables and proxy.local.sh issues
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/network.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/system_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/npm.md
+++ b/docs/guide/commands/npm.md
@@ -1,0 +1,84 @@
+# npm
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/package_managers_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic npm --force`
+
+## 호출
+
+- Help 진입점: `npm-help [section|--list|--all]`
+- 통합 라우팅: `my-help npm [section]`
+- Alias: `npm-help`
+
+## 요약 (npm-help)
+
+- Usage: npm-help [section|--list|--all]
+- sections
+    - info: npm-v | npm-list | npm-info | npm-search | npm-outdated
+    - install: npm-i | npm-is | npm-isd | npm-ig
+    - uninstall: npm-un | npm-ung
+    - maintenance: npm-update | npm-cache-clean
+    - config: npm-config
+    - setup: npminstall | npmuninstall
+    - cert: crt-help | crtsetup
+    - troubleshoot: EACCES | nvm conflict | certificate | config mismatch
+    - details: npm-help <section>  (example: npm-help install)
+
+## 섹션
+
+### info
+
+- **npm-v** — npm --version — Check version
+- **npm-list** — list -g --depth=0 — Global packages
+- **npm-info** — info <pkg> — Package details
+- **npm-search** — search <keyword> — Search packages
+- **npm-outdated** — outdated -g — Check updates
+
+### install
+
+- **npm-i** — npm install — Install deps
+- **npm-is** — install --save — Save prod dep
+- **npm-isd** — install --save-dev — Save dev dep
+- **npm-ig** — install -g — Global install
+
+### uninstall
+
+- **npm-un** — npm uninstall — Remove dep
+- **npm-ung** — uninstall -g — Remove global
+
+### maintenance
+
+- **npm-update** — update -g — Update global
+- **npm-cache-clean** — cache clean --force — Clear cache
+
+### config
+
+- **npm-config** — Show current config — Registry, CA, SSL
+
+### setup
+
+- **npminstall** — Install Script — Install Node/NPM
+- **npmuninstall** — Uninstall Script — Remove Node/NPM
+
+### cert
+
+- For CA certificate setup (company proxy/internal network):
+- Run: crt-help for detailed guide
+- Setup: crtsetup to install certificate
+
+### troubleshoot
+
+- EACCES permission error (npm WARN): npm config set prefix ~/.npm-global
+- nvm과 npm prefix 충돌: .npmrc 파일의 prefix 라인 제거
+- Certificate error: Run crt-help for CA setup guide
+- Config mismatch: Run ./shell-common/setup.sh to reconfigure symlink
+- Global Path: ~/.npm-global
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/npm.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/package_managers_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/nvm.md
+++ b/docs/guide/commands/nvm.md
@@ -1,0 +1,40 @@
+# nvm
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/nvm_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic nvm --force`
+
+## 호출
+
+- Help 진입점: `nvm-help [section|--list|--all]`
+- 통합 라우팅: `my-help nvm [section]`
+- Alias: `nvm-help`
+
+## 요약 (nvm-help)
+
+- Usage: nvm-help [section|--list|--all]
+- sections
+    - commands: nvm-install
+    - usage: nvm install --lts | nvm use --lts | nvm ls
+    - details: nvm-help <section>  (example: nvm-help usage)
+
+## 섹션
+
+### commands
+
+- **nvm-install** — Install Script — Install NVM & Node LTS
+
+### usage
+
+- nvm install --lts  : Install latest LTS Node
+- nvm use --lts      : Use latest LTS Node
+- nvm ls             : List installed versions
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/nvm.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/nvm_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/p10k.md
+++ b/docs/guide/commands/p10k.md
@@ -1,0 +1,71 @@
+# p10k
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/p10k.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic p10k --force`
+
+## 호출
+
+- Help 진입점: `p10k-help [section|--list|--all]`
+- 통합 라우팅: `my-help p10k [section]`
+- Alias: `p10k-help`
+
+## 요약 (p10k-help)
+
+- Usage: p10k-help [section|--list|--all]
+- sections
+    - vscode: Ctrl+Shift+P → Open User Settings (JSON)
+    - settings: editor.fontFamily | terminal.integrated.fontFamily
+    - install: install-p10k | p10k configure | font setup
+    - trouble: missing MesloLGS NF | nerdfonts.com | brew cask
+    - fonts: FiraCode | JetBrains Mono | Hack Nerd Font
+    - verify: p10k configure | zsh-theme-current
+    - details: p10k-help <section>  (example: p10k-help install)
+
+## 섹션
+
+### vscode
+
+- Open settings with: Ctrl+Shift+P → Preference: Open User Settings (JSON)
+
+### settings
+
+  "editor.fontFamily": "D2Coding, Consolas, 'Courier New', monospace, 'MesloLGS NF'",
+  "editor.fontSize": 14,
+  "terminal.integrated.fontFamily": "MesloLGS NF",
+  "terminal.integrated.fontSize": 14,
+
+### install
+
+- 1. Install powerlevel10k: install-p10k
+- 2. Configure p10k: p10k configure
+- 3. Select font preference in configuration wizard
+- 4. Add settings above to VSCode settings.json
+- 5. Restart VSCode terminal
+
+### trouble
+
+- Font not showing? MesloLGS NF font may not be installed
+- Install MesloLGS NF: Visit https://www.nerdfonts.com/font-downloads
+- Or use: brew install --cask font-meslo-lg-nerd-font (macOS)
+- After installation, restart VSCode completely
+
+### fonts
+
+- FiraCode Nerd Font
+- JetBrains Mono Nerd Font
+- Hack Nerd Font
+
+### verify
+
+- Run: p10k configure to test font rendering
+- Or check theme: zsh-theme-current
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/p10k.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/p10k.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/pet.md
+++ b/docs/guide/commands/pet.md
@@ -1,0 +1,154 @@
+# pet
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/pet.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic pet --force`
+
+## 호출
+
+- Help 진입점: `pet-help [section|--list|--all]`
+- 통합 라우팅: `my-help pet [section]`
+- Alias: `pet-help`
+
+## 요약 (pet-help)
+
+- Usage: pet-help [section|--list|--all]
+- sections
+    - concept: snippet manager | search/exec | TOML
+    - core: pet new | search | list | edit | version
+    - structure: description | command | tags
+    - create: pet new (interactive)
+    - search: pet search | grep
+    - examples: file | git | docker | system
+    - fzf | config | storage | workflow | tips | compare | advantages
+    - related: install-pet | fzf-help | ripgrep-help | zsh-help
+    - details: pet-help <section>  (example: pet-help core)
+
+## 섹션
+
+### concept
+
+- Store and recall frequently used commands
+- Interactive search and execution
+- Snippets stored as TOML configuration
+- Built-in editor support for managing snippets
+- Integrates with shell for easy access
+
+### core
+
+- **pet new** — Create a new snippet interactively
+- **pet search** — Search and execute snippet
+- **pet list** — List all stored snippets
+- **pet edit** — Edit snippets in text editor
+- **pet version** — Show pet version
+
+### structure
+
+- Each snippet contains:
+- description - What the snippet does
+- command - The actual command to execute
+- tags - Keywords for searching (optional)
+
+### create
+
+- Interactive creation:
+- pet new - Opens editor to create snippet
+- Prompts for: description, command, tags
+- Example: 'Find large files' -> 'find . -size +100M'
+
+### search
+
+- **pet search** — Interactive search (fzf integration)
+- **pet search 'find'** — Search by description/command
+- **pet list | grep 'find'** — Grep search results
+
+### examples
+
+- File Operations:
+- find large files: find . -size +100M
+- recursive search: grep -r 'pattern' .
+- count lines: find . -name '*.rs' | xargs wc -l
+- Git Operations:
+- undo last commit: git reset --soft HEAD~1
+- delete local branch: git branch -d branch_name
+- prune remote branches: git remote prune origin
+- Docker Operations:
+- remove dangling images: docker rmi $(docker images -f dangling=true -q)
+- clean all: docker system prune -a
+- view logs: docker logs --follow container_name
+- System Commands:
+- disk usage: du -sh * | sort -h
+- find and delete: find . -name '.DS_Store' -delete
+- monitor processes: watch -n 1 'ps aux | grep pattern'
+
+### fzf
+
+- pet integrates with fzf for interactive search
+- Fuzzy match snippets by description or command
+- Preview snippet before execution
+- Execute directly from search results
+
+### config
+
+- Location: ~/.config/pet/config.toml
+- Editor integration:
+- editor = 'vim' - Set preferred editor
+- selector = 'fzf' - Use fzf for selection
+- pager = 'less' - Set pager for output
+
+### storage
+
+- Location: ~/.config/pet/snippets.toml
+- Text format (TOML) - easy to edit manually
+- Portable - copy between systems
+- Versionable - track with git
+
+### workflow
+
+- Regular workflow:
+- Execute a command frequently: pet new
+- Need to use it later: pet search
+- Found a better version: pet edit
+- Integration with other tools:
+- Copy snippet command: pet search | xargs echo
+- Share snippets: Upload ~/.config/pet/snippets.toml
+- Backup snippets: cp ~/.config/pet/snippets.toml backup/
+
+### tips
+
+- Create aliases for frequently used snippets: alias myfunc='pet search'
+- Document complex commands as snippets instead of comments
+- Use tags to organize snippets by category
+- Combine with fzf for fuzzy search experience
+- Backup snippets regularly - they're valuable
+
+### compare
+
+- bash history: Unorganized, easy to lose
+- pet: Organized, searchable, persistent
+- Man pages: Complex to read
+- pet: Simple description + example
+
+### advantages
+
+- Simpler than writing scripts for one-off commands
+- Better than trying to remember complex commands
+- Easier than searching through bash history
+- Portable configuration files
+- Built-in editor for easy management
+
+### related
+
+- Install pet: install-pet
+- Interactive search: fzf-help
+- Text search: ripgrep-help
+- Zsh shell: zsh-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/pet.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/pet.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/pip.md
+++ b/docs/guide/commands/pip.md
@@ -1,0 +1,67 @@
+# pip
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/package_managers_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic pip --force`
+
+## 호출
+
+- Help 진입점: `pip-help [section|--list|--all]`
+- 통합 라우팅: `my-help pip [section]`
+- Alias: `pip-help`
+
+## 요약 (pip-help)
+
+- Usage: pip-help [section|--list|--all]
+- sections
+    - diagnostics: check-pip | config | file | repo | env
+    - commands: pip config list | --verbose | view conf | --version
+    - setup: ./setup.sh (Public | Internal | External)
+    - repos: Proxy | Internal Repo | DataService Repo
+    - notes: CA cert | setup.sh managed | symlink
+    - details: pip-help <section>  (example: pip-help repos)
+
+## 섹션
+
+### diagnostics
+
+- check-pip            Run full pip diagnostic
+- check-pip config     Show pip configuration
+- check-pip file       pip.conf file check
+- check-pip repo       Repository connectivity test
+- check-pip env        Environment variables
+
+### commands
+
+- pip config list                 Show all pip settings
+- pip config list --verbose       Show pip config files loading
+- cat $HOME/.config/pip/pip.conf  View user pip config
+- pip --version                   Check pip version
+
+### setup
+
+- ./setup.sh                      Run setup (choose environment)
+-                1) Public PC
+-                2) Internal company PC (proxy + internal repo)
+-                3) External company PC (VPN)
+
+### repos
+
+- Proxy:            http://12.26.204.100:8080
+- Internal Repo:    http://repository.samsungds.net/repository/proxy-pypi-files.pythonhosted.org/simple
+- DataService Repo: http://nexus.adpaas.cloud.samsungds.net/repository/dataservice-pypi/simple
+
+### notes
+
+- CA certificate: Configured via security.local.sh (REQUESTS_CA_BUNDLE)
+- Config files are managed by setup.sh - do not edit manually
+- Symlink: ~/.config/pip/pip.conf -> pip/pip.conf.{environment}
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/pip.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/package_managers_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/pp.md
+++ b/docs/guide/commands/pp.md
@@ -1,0 +1,57 @@
+# pp
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/pp_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic pp --force`
+
+## 호출
+
+- Help 진입점: `pp-help [section|--list|--all]`
+- 통합 라우팅: `my-help pp [section]`
+- Alias: `pp-help`
+
+## 요약 (pp-help)
+
+- Usage: pp-help [section|--list|--all]
+- sections
+    - package: pp_install | pp_install_up | pp_reqs | pp_uninstall | pp_freeze | pp_list | pp_check
+    - quality: code_check | code_fix | code_type
+    - test: test_pytest | test_unittest
+    - docs: docs_gen
+    - details: pp-help <section>  (example: pp-help quality)
+
+## 섹션
+
+### package
+
+- **pp_install** — pip install — Install package
+- **pp_install_up** — upgrade pip & install — Update pip first
+- **pp_reqs** — pip install -r reqs — Install from file
+- **pp_uninstall** — pip uninstall -y — Remove package
+- **pp_freeze** — Freeze to reqs.txt — Exclude project name
+- **pp_list** — pip list --outdated — Check updates
+- **pp_check** — pip check — Verify deps
+
+### quality
+
+- **code_check** — ruff format & check — CI mode (check only)
+- **code_fix** — ruff format & fix — Auto-fix issues
+- **code_type** — mypy . — Type checking
+
+### test
+
+- **test_pytest** — pytest -q — Run pytest (fast)
+- **test_unittest** — unittest discover — Run unittest
+
+### docs
+
+- **docs_gen** — sphinx build — Generate HTML docs
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/pp.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/pp_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/proxy.md
+++ b/docs/guide/commands/proxy.md
@@ -1,0 +1,79 @@
+# proxy
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/devops_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic proxy --force`
+
+## 호출
+
+- Help 진입점: `proxy-help [section|--list|--all]`
+- 통합 라우팅: `my-help proxy [section]`
+- Alias: `proxy-help`
+
+## 요약 (proxy-help)
+
+- Usage: proxy-help [section|--list|--all]
+- sections
+    - diagnostics: check-proxy | env | file | shell | conn | git
+    - commands: $http_proxy | $https_proxy | $no_proxy | env | grep proxy
+    - set: export http_proxy | https_proxy | no_proxy
+    - unset: unset HTTP_PROXY HTTPS_PROXY NO_PROXY
+    - git: connectTimeout | lowSpeedLimit | lowSpeedTime | view config
+    - related: check-network quick | check-network
+    - notes: NO_PROXY commas | uppercase env | proxy-only check
+    - details: proxy-help <section>  (example: proxy-help set)
+
+## 섹션
+
+### diagnostics
+
+- check-proxy          Run full diagnostic
+- check-proxy env      Environment variables only
+- check-proxy file     proxy.local.sh file check
+- check-proxy shell    Shell loading test
+- check-proxy conn     Configured proxy connectivity test
+- check-proxy git      Git configuration
+
+### commands
+
+- echo $http_proxy          Current proxy setting
+- echo $https_proxy         Current HTTPS proxy
+- echo $no_proxy            NO_PROXY exceptions
+- env | grep -i proxy        Show all proxy vars
+
+### set
+
+- export http_proxy="http://proxy.example.com:8080/"
+- export https_proxy="http://proxy.example.com:8080/"
+- export no_proxy="localhost,127.0.0.1,.internal.domain.com"
+
+### unset
+
+- unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY
+
+### git
+
+- git config --global http.connectTimeout 60    Increase timeout
+- git config --global http.lowSpeedLimit 0      Disable low speed limit
+- git config --global http.lowSpeedTime 999999   Disable low speed time
+- git config --global -l | grep proxy           View git proxy config
+
+### related
+
+- check-network quick       General internet access check
+- check-network             DNS, HTTPS, git, apt, pip, curl checks
+
+### notes
+
+- NO_PROXY with spaces is not recognized - use commas only
+- Some tools only recognize uppercase (HTTP_PROXY, HTTPS_PROXY)
+- check-proxy focuses on proxy configuration only
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/proxy.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/devops_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/psql.md
+++ b/docs/guide/commands/psql.md
@@ -1,0 +1,43 @@
+# psql
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/database_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic psql --force`
+
+## 호출
+
+- Help 진입점: `psql-help [section|--list|--all]`
+- 통합 라우팅: `my-help psql [section]`
+- Alias: `psql-help`
+
+## 요약 (psql-help)
+
+- Usage: psql-help [section|--list|--all]
+- sections
+    - primary: psql_list | psql_bootstrap | psql_sync | psql_add | psql_del
+    - lowlevel: psql_db | psql_user
+    - details: psql-help <section>  (example: psql-help primary)
+
+## 섹션
+
+### primary
+
+- **psql_list** — List Services — Show all configured connections
+- **psql_bootstrap** — Create New — Full Setup: Create DB, User, Grant & Save
+- **psql_sync** — Sync DBs — Scan server and add existing DBs to config
+- **psql_add** — Add Link — Manually add a shortcut for existing DB
+- **psql_del** — Remove — Remove service (and optionally drop DB)
+
+### lowlevel
+
+- **psql_db** — DB Ops — list, create, delete, grant
+- **psql_user** — User Ops — list, create, attr, passwd, delete
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/psql.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/database_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/py.md
+++ b/docs/guide/commands/py.md
@@ -1,0 +1,43 @@
+# py
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/py_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic py --force`
+
+## 호출
+
+- Help 진입점: `py-help [section|--list|--all]`
+- 통합 라우팅: `my-help py [section]`
+- Alias: `py-help`
+
+## 요약 (py-help)
+
+- Usage: py-help [section|--list|--all]
+- sections
+    - commands: cv | av | ev | rv | dv
+    - setup: install-py | uninstall-py
+    - details: py-help <section>  (example: py-help commands)
+
+## 섹션
+
+### commands
+
+- **create-venv (cv)** — python -m venv .venv — Create venv
+- **act-venv (av)** — . .venv/bin/activate — Activate
+- **echo-venv (ev)** — echo $VIRTUAL_ENV — Show path
+- **rm-venv (rv)** — rm -rf .venv — Delete venv
+- **deact-venv (dv)** — . deactivate — Deactivate
+
+### setup
+
+- **install-py [version...]** — Install Script — Install default or specific Python versions
+- **uninstall-py <version>** — pyenv uninstall — Remove a specific Python version
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/py.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/py_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/redis.md
+++ b/docs/guide/commands/redis.md
@@ -1,0 +1,51 @@
+# redis
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/database_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic redis --force`
+
+## 호출
+
+- Help 진입점: `redis-help [section|--list|--all]`
+- 통합 라우팅: `my-help redis [section]`
+- Alias: `redis-help`
+
+## 요약 (redis-help)
+
+- Usage: redis-help [section|--list|--all]
+- sections
+    - commands: server-ctl | ping | info | monitor | dbsize | keys | flush | config-get | slowlog | clients | memory | install-redis
+    - env: REDISCLI_AUTH | REDIS_DEFAULT_HOST | REDIS_DEFAULT_PORT
+    - details: redis-help <section>  (example: redis-help commands)
+
+## 섹션
+
+### commands
+
+- **redis-server-ctl <action>** — Manage service — start, stop, restart, status
+- **redis-ping** — Health check — PING/PONG test
+- **redis-info [section]** — Server info — server, memory, clients, etc.
+- **redis-monitor** — Live monitor — Real-time command stream
+- **redis-dbsize** — Key count — Current DB key count
+- **redis-keys [pattern] [limit]** — Scan keys — SCAN with glob pattern (default: 20)
+- **redis-flush <db|all>** — Flush data — Clear current DB or all DBs
+- **redis-config-get <param>** — Config value — Get runtime config
+- **redis-slowlog [count]** — Slow queries — Recent slow log entries
+- **redis-clients** — Client list — Connected clients info
+- **redis-memory** — Memory stats — Memory usage details
+- **install-redis** — Install Redis — Interactive installer for WSL
+
+### env
+
+- **REDISCLI_AUTH** — Password — Auto-auth for all commands
+- **REDIS_DEFAULT_HOST** — Server host — Default: 127.0.0.1
+- **REDIS_DEFAULT_PORT** — Server port — Default: 6379
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/redis.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/database_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/register.md
+++ b/docs/guide/commands/register.md
@@ -1,0 +1,45 @@
+# register
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/register_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic register --force`
+
+## 호출
+
+- Help 진입점: `register-help [section|--list|--all]`
+- 통합 라우팅: `my-help register [section]`
+- Alias: `register-help`
+
+## 요약 (register-help)
+
+- Usage: register-help [section|--list|--all]
+- sections
+    - topic: function ending with _help
+    - description: HELP_DESCRIPTIONS[<name>_help]
+    - category: HELP_CATEGORY_MEMBERS[<category>]
+    - details: register-help <section>  (example: register-help topic)
+
+## 섹션
+
+### topic
+
+- Create a function ending with: _help
+- Example: mytool_help() { ... }
+
+### description
+
+- Set: HELP_DESCRIPTIONS[mytool_help]="[Development] ..."
+
+### category
+
+- Edit: HELP_CATEGORY_MEMBERS[development]="... mytool"
+- Then reload your shell (source ~/.bashrc or ~/.zshrc)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/register.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/register_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/ripgrep.md
+++ b/docs/guide/commands/ripgrep.md
@@ -1,0 +1,138 @@
+# ripgrep
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/ripgrep.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic ripgrep --force`
+
+## 호출
+
+- Help 진입점: `ripgrep-help [section|--list|--all]`
+- 통합 라우팅: `my-help ripgrep [section]`
+- Alias: `ripgrep-help`
+
+## 요약 (ripgrep-help)
+
+- Usage: ripgrep-help [section|--list|--all]
+- sections
+    - concept: fast | gitignore | parallel | binary-safe
+    - basic: pattern | path | file
+    - case: smart | -i | -S
+    - pattern: regex | -F | -w | -x
+    - output: -n | -c | -l | -o
+    - filter: -t | -T | --type-list | -g
+    - scope: -u | -uu | -j 1
+    - context: -B | -A | -C
+    - examples | compare | fzf | config | trouble | related
+    - details: ripgrep-help <section>  (example: ripgrep-help basic)
+
+## 섹션
+
+### concept
+
+- Rust-based grep replacement - much faster than grep
+- Respects .gitignore automatically - avoids unwanted files
+- Automatic parallelization - uses all available CPU cores
+- Handles binary files gracefully
+
+### basic
+
+- **rg 'pattern'** — Search for pattern in current directory
+- **rg 'pattern' /path** — Search in specific directory
+- **rg 'pattern' file.txt** — Search in specific file
+
+### case
+
+- **rg 'pattern'** — Smart case (sensitive if pattern has uppercase)
+- **rg -i 'pattern'** — Case-insensitive search
+- **rg -S 'pattern'** — Case-sensitive (always)
+
+### pattern
+
+- **rg 'regex'** — Regular expression search (default)
+- **rg -F 'literal'** — Literal string search (no regex)
+- **rg -w 'word'** — Match whole words only
+- **rg -x 'line'** — Match entire lines only
+
+### output
+
+- **rg -n 'pattern'** — Show line numbers (default)
+- **rg -c 'pattern'** — Count matches per file
+- **rg -l 'pattern'** — List filenames only
+- **rg -o 'pattern'** — Show only matches, not whole lines
+
+### filter
+
+- **rg 'pattern' -t py** — Search in Python files only
+- **rg 'pattern' -T py** — Exclude Python files
+- **rg 'pattern' --type-list** — Show all available file types
+- **rg 'pattern' -g '*.py'** — Glob pattern filtering
+
+### scope
+
+- **rg 'pattern'** — Search respecting .gitignore (default)
+- **rg -u 'pattern'** — Skip .gitignore (search hidden/ignored)
+- **rg -uu 'pattern'** — Skip .gitignore and .ignore files
+- **rg -j 1 'pattern'** — Single-threaded search
+
+### context
+
+- **rg -B 3 'pattern'** — Show 3 lines before match
+- **rg -A 3 'pattern'** — Show 3 lines after match
+- **rg -C 3 'pattern'** — Show 3 lines before and after
+
+### examples
+
+- Search in specific file type:
+- rg 'TODO' -t py - Find TODO comments in Python files
+- rg 'import' -t js src/ - Find imports in JavaScript source
+- Search with context:
+- rg -C 2 'function' - See function definitions with context
+- rg -B 5 'error' - Show error messages with preceding context
+- Counting and statistics:
+- rg -c 'pattern' | sort -t: -k2 -rn - Count occurrences by file
+- rg 'pattern' -c --sort=count - Show most frequent matches
+- Replace with sed integration:
+- rg 'old' -l | xargs sed -i 's/old/new/g' - Replace in all matched files
+- rg 'pattern' --files-with-matches | xargs -I {} sh -c 'echo {}; rg pattern {}'
+
+### compare
+
+- grep: Standard but slow, easy regex syntax
+- rg: Much faster (50-100x), auto .gitignore support
+- rg: Better output formatting, sensible defaults
+- rg: No need for -r flag for recursion
+
+### fzf
+
+- rg 'pattern' | fzf - Interactive result selection
+- vim $(rg -l 'pattern' | fzf) - Open matched file in vim
+- rg --files | fzf - Find file then search in it
+
+### config
+
+- Create ~/.ripgreprc for default options:
+- --color=auto - Always colorize output
+- --max-columns=200 - Truncate long lines
+- --smart-case - Smart case sensitivity
+
+### trouble
+
+- Not finding files? Use -u to skip .gitignore
+- Slow search? Use -j 1 to disable parallelization
+- Too much output? Use -l to list files only, or -c to count
+
+### related
+
+- Install ripgrep: install-ripgrep
+- Fuzzy finder: fzf-help
+- Fast find: fd-help
+- File viewer: bat-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/ripgrep.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/ripgrep.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/setup-mode.md
+++ b/docs/guide/commands/setup-mode.md
@@ -1,0 +1,50 @@
+# setup-mode
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/setup_mode_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic setup_mode --force`
+
+## 호출
+
+- Help 진입점: `setup-mode-help [section|--list|--all]`
+- 통합 라우팅: `my-help setup_mode [section]`
+- Alias: `setup-mode-help`
+
+## 요약 (setup-mode-help)
+
+- Usage: setup-mode-help [section|--list|--all]
+- sections
+    - overview: tracks PC environment, auto-applies settings
+    - modes: 1=Public | 2=Internal | 3=External(VPN)
+    - usage: show-setup-mode | setup-mode-help | setup.sh
+    - details: setup-mode-help <section>  (example: setup-mode-help modes)
+
+## 섹션
+
+### overview
+
+- Tracks which environment your PC is configured for
+- Automatically applies environment-specific settings
+- Stored in: ~/.dotfiles-setup-mode
+
+### modes
+
+- **Mode 1** — Public PC (Home environment) — No proxy, no company configs
+- **Mode 2** — Internal company PC (Direct) — Company proxy, internal repos, CA certs
+- **Mode 3** — External company PC (VPN) — No proxy, VPN certificate
+
+### usage
+
+- **show-setup-mode** — Show current mode
+- **setup-mode-help** — View this help
+- Reconfigure: cd ~/dotfiles && ./setup.sh
+- Check proxy: check-proxy
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/setup-mode.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/setup_mode_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/show-doc.md
+++ b/docs/guide/commands/show-doc.md
@@ -1,0 +1,66 @@
+# show-doc
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/manage_doc.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic show_doc --force`
+
+## 호출
+
+- Help 진입점: `show-doc-help [section|--list|--all]`
+- 통합 라우팅: `my-help show_doc [section]`
+- Alias: `doc-help`, `show-doc-help`
+
+## 요약 (show-doc-help)
+
+- Usage: show-doc-help [section|--list|--all]
+- sections
+    - clear: clear-doc <file|pattern> usage and examples
+    - delete: del-doc <file|pattern> usage and examples
+    - description: behavior and safety notes
+    - patterns: glob pattern reference
+    - details: show-doc-help <section>  (example: show-doc-help clear)
+
+## 섹션
+
+### clear
+
+- Clear content of documentation files
+- Usage: clear-doc <file|pattern>
+- Examples:
+- clear-doc docs/archive/review-2026/abc-review-G.md       // Clear single file
+- clear-doc docs/archive/review-2026/abc-review*           // Unquoted glob (both work!)
+- clear-doc 'docs/archive/review-2026/abc-review*'         // Quoted pattern
+- clear-doc docs/file1.md docs/file2.md       // Multiple files
+- clear-doc 'docs/*.md' notes.txt             // Mixed patterns + files
+
+### delete
+
+- Permanently delete documentation files
+- Usage: del-doc <file|pattern>
+- Examples:
+- del-doc docs/archive/review-2026/abc-review-G.md         // Delete single file
+- del-doc docs/archive/review-2026/abc-plan*               // Unquoted glob
+- del-doc 'docs/archive/review-2026/abc-review*2.md'       // Quoted pattern (deletes *2.md files)
+- del-doc docs/file1.md docs/file2.md         // Multiple files
+- del-doc 'docs/abc-*' notes.txt              // Mixed patterns + files
+
+### description
+
+- Safely clears the content of documentation files (clear-doc)
+- Permanently deletes documentation files (del-doc)
+- Both operations require user confirmation (destructive)
+- Support both individual files and glob patterns
+
+### patterns
+
+- * matches any characters
+- ? matches single character
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/show-doc.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/manage_doc.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/ssh.md
+++ b/docs/guide/commands/ssh.md
@@ -1,0 +1,61 @@
+# ssh
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/security_ssh_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic ssh --force`
+
+## 호출
+
+- Help 진입점: `ssh-help [section|--list|--all]`
+- 통합 라우팅: `my-help ssh [section]`
+- Alias: `ssh-help`
+
+## 요약 (ssh-help)
+
+- Usage: ssh-help [section|--list|--all]
+- sections
+    - ssh: ssh <host> | ssh <host> <cmd>
+    - scp: pull | push
+    - hosts: registered hosts in ~/.ssh/config
+    - config: ~/.ssh/config -> dotfiles/ssh/config
+    - details: ssh-help <section>  (example: ssh-help hosts)
+
+## 섹션
+
+### ssh
+
+- **ssh <host>** — ssh ssai-dev — Connect to server
+- **ssh <host> <cmd>** — ssh ssai-dev 'ls /home' — Run remote command
+
+### scp
+
+- **pull** — scp <host>:<src> <dst> — Download from server
+- **push** — scp <src> <host>:<dst> — Upload to server
+
+### hosts
+
+- github.samsungds.net
+- Replica-Gerrit
+- github.com
+- ssai-*
+- server-ssai-*
+- ssai-dev
+- ssai-ops
+- server-ssai-ops-*
+- ssai-ops
+- server-ssai-ops-devops
+- server-ssai-ops-jiravis
+- server-ssai-ops-bwyoon
+
+### config
+
+- **config file** — ~/.ssh/config → dotfiles/ssh/config — Managed by dotfiles
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/ssh.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/security_ssh_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/ssl.md
+++ b/docs/guide/commands/ssl.md
@@ -1,0 +1,72 @@
+# ssl
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/security_ssh_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic ssl --force`
+
+## 호출
+
+- Help 진입점: `ssl-help [section|--list|--all]`
+- 통합 라우팅: `my-help ssl [section]`
+- Alias: `ssl-help`
+
+## 요약 (ssl-help)
+
+- Usage: ssl-help [section|--list|--all]
+- sections
+    - status: SSL_CERT_FILE | REQUESTS_CA_BUNDLE | NODE_EXTRA_CA_CERTS
+    - commands: echo $SSL_CERT_FILE | env grep cert
+    - files: security.local.sh status
+    - paths: Internal | External | System CA
+    - tools: curl | wget | git | python | npm
+    - notes: SSL_CERT_FILE | REQUESTS_CA_BUNDLE | NODE_EXTRA_CA_CERTS
+    - details: ssl-help <section>  (example: ssl-help status)
+
+## 섹션
+
+### status
+
+- SSL_CERT_FILE: /usr/local/share/ca-certificates/samsungsemi-prx.com.crt
+-   ✓ File exists and is readable
+- REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/samsungsemi-prx.com.crt (Python requests)
+- NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/samsungsemi-prx.com.crt (Node.js)
+
+### commands
+
+- echo $SSL_CERT_FILE                  Show SSL certificate file
+- echo $REQUESTS_CA_BUNDLE             Show Python requests CA bundle
+- env | grep -i cert                   Show all certificate vars
+
+### files
+
+- security.local.sh: not configured (public environment)
+
+### paths
+
+- Internal PC:  /usr/share/ca-certificates/extra/McAfee_Certificate.crt
+- External PC:  /usr/local/share/ca-certificates/samsungsemi-prx.com.crt
+- System CA:    /etc/ssl/certs/ca-certificates.crt
+
+### tools
+
+- curl                 - Web requests and downloads
+- wget                 - File downloads
+- git                  - Git operations (HTTPS)
+- python (requests)    - HTTP library
+- npm                  - Node.js package manager
+
+### notes
+
+- Different variables for different tools:
+-   - SSL_CERT_FILE:        curl, wget, git
+-   - REQUESTS_CA_BUNDLE:   Python requests
+-   - NODE_EXTRA_CA_CERTS:  Node.js
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/ssl.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/security_ssh_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/superpowers.md
+++ b/docs/guide/commands/superpowers.md
@@ -1,0 +1,91 @@
+# superpowers
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/superpowers_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic superpowers --force`
+
+## 호출
+
+- Help 진입점: `superpowers-help [section|--list|--all]`
+- 통합 라우팅: `my-help superpowers [section]`
+- Alias: `superpowers-help`
+
+## 요약 (superpowers-help)
+
+- Usage: superpowers-help [section|--list|--all]
+- sections
+    - process: brainstorming | plans | TDD | debugging | verify
+    - execution: parallel agents | subagents | worktrees
+    - review: request | receive | finishing branch
+    - meta: using-superpowers | writing-skills
+    - flow: feature & bug-fix lifecycles
+    - location: skill files path
+    - usage: invocation tips
+    - details: superpowers-help <section>
+
+## 섹션
+
+### process
+
+- **brainstorming** — Creative work, feature design, requirements exploration before implementation
+- **writing-plans** — Multi-step task planning from spec/requirements, before touching code
+- **executing-plans** — Execute written implementation plans in separate sessions with review checkpoints
+- **systematic-debugging** — Bug/test failure diagnosis - root cause analysis before proposing fixes
+- **test-driven-development** — Red-green-refactor: write tests before implementation code
+- **verification-before-completion** — Run verification commands and confirm output before claiming done
+
+### execution
+
+- **dispatching-parallel-agents** — Run 2+ independent tasks concurrently without shared state
+- **subagent-driven-development** — Execute implementation plans with independent sub-agents
+- **using-git-worktrees** — Isolated feature work via git worktrees with safety checks
+
+### review
+
+- **requesting-code-review** — Request review after feature completion or before merge
+- **receiving-code-review** — Handle review feedback with technical rigor, not blind agreement
+- **finishing-a-development-branch** — Branch integration: merge, PR, or cleanup options
+
+### meta
+
+- **using-superpowers** — Skill discovery and invocation at conversation start
+- **writing-skills** — Create, edit, or verify skills before deployment
+
+### flow
+
+- Feature Development (full lifecycle):
+1. brainstorming          - explore requirements, design spec
+2. writing-plans          - break spec into bite-sized tasks
+3. executing-plans        - execute tasks (TDD per step)
+4.   or subagent-driven-development (parallel, same session)
+5. requesting-code-review - dispatch reviewer subagent
+6. receiving-code-review  - evaluate & apply feedback
+7. finishing-a-dev-branch - merge, PR, or cleanup
+- verification-before-completion runs at every completion claim.
+- test-driven-development runs inside each execution step.
+- Bug Fix (shorter cycle):
+1. systematic-debugging   - root cause analysis first
+2. test-driven-development - write failing test for the bug
+3. verification-before-completion
+4. finishing-a-dev-branch - merge the fix
+- Parallel tasks: use dispatching-parallel-agents or using-git-worktrees
+
+### location
+
+- Superpowers plugin not found. Install via Claude Code marketplace.
+- Expected: ~/.claude/plugins/cache/superpowers-dev/superpowers/<version>/skills/
+
+### usage
+
+- Invoke in Claude Code: /brainstorm, /write-plan, /execute-plan
+- Read a skill: cat <skills_path>/<skill-name>/SKILL.md
+- Priority: Process skills first, then implementation skills
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/superpowers.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/superpowers_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/sys.md
+++ b/docs/guide/commands/sys.md
@@ -1,0 +1,69 @@
+# sys
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/system_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic sys --force`
+
+## 호출
+
+- Help 진입점: `sys-help [section|--list|--all]`
+- 통합 라우팅: `my-help sys [section]`
+- Alias: `sys-help`
+
+## 요약 (sys-help)
+
+- Usage: sys-help [section|--list|--all]
+- sections
+    - process: psgrep | psg | kill9 | psa
+    - network: ports | myip | localip | ping | check-network | ssh-help
+    - monitoring: top | meminfo | cpuinfo | diskusage
+    - apt: update | upgrade | remove | auto-remove
+    - logs: logs | error | auth
+    - details: sys-help <section>  (example: sys-help network)
+
+## 섹션
+
+### process
+
+- **psgrep** — ps aux | grep <pattern> — Find process by pattern
+- **psg** — ps aux | grep — Find process
+- **kill9** — kill -9 — Force kill
+- **psa** — ps aux — List all processes
+
+### network
+
+- **ports** — ss -tulanp — Show open ports
+- **myip** — curl ipecho.net — Public IP
+- **localip** — hostname -I — Local IP
+- **ping** — ping -c 5 — Ping (5 times)
+- **check-network** — check-network — Internet connectivity diagnostics
+- **ssh-help** — ssh-help — SSH hosts and examples
+
+### monitoring
+
+- **top** — htop — Process monitor
+- **meminfo** — free -m — Memory usage
+- **cpuinfo** — lscpu — CPU info
+- **diskusage** — df -h — Disk usage
+
+### apt
+
+- **update** — apt update — Update lists
+- **upgrade** — apt upgrade — Upgrade packages
+- **remove** — apt remove — Remove package
+- **auto-remove** — apt autoremove — Remove unused
+
+### logs
+
+- **logs** — syslog — System logs
+- **error** — error.log — Error logs
+- **auth** — auth.log — Auth logs
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/sys.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/system_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/tmux.md
+++ b/docs/guide/commands/tmux.md
@@ -1,0 +1,105 @@
+# tmux
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/tmux_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic tmux --force`
+
+## 호출
+
+- Help 진입점: `tmux-help [section|--list|--all]`
+- 통합 라우팅: `my-help tmux [section]`
+- Alias: `tmux-help`
+
+## 요약 (tmux-help)
+
+- Usage: tmux-help [section|--list|--all]
+- sections
+    - concept: 세션 유지 | 화면 분할 | prefix Ctrl+b
+    - session: tmux new | attach | ls | kill-session
+    - pane: % | " | arrow | z | x | Alt+arrow
+    - control: d | s | $
+    - window: c | n/p | 0-9 | ,
+    - copy: [ | Space | Enter | q | ]
+    - example | companion | custom | related
+    - details: tmux-help <section>  (example: tmux-help session)
+
+## 섹션
+
+### concept
+
+- SSH/터미널 종료 후에도 세션 유지
+- 화면 분할로 여러 작업 동시 수행
+- 모든 단축키: Ctrl+b (prefix) 누른 뒤 해당 키
+
+### session
+
+- **tmux new -s <name>** — 새 세션 생성
+- **tmux attach -t <name>** — 세션 다시 연결
+- **tmux ls** — 세션 목록 확인
+- **tmux kill-session -t <name>** — 세션 삭제
+
+### pane
+
+- **%** — 좌우 분할
+- **"** — 상하 분할
+- **arrow keys** — 패인 이동
+- **z** — 현재 패인 전체화면 토글
+- **x** — 현재 패인 닫기
+- **Alt+arrow (no prefix)** — 패인 크기 조절
+
+### control
+
+- **d** — 세션에서 빠져나오기 (detach)
+- **s** — 세션 목록 선택 이동
+- **$** — 현재 세션 이름 변경
+
+### window
+
+- **c** — 새 윈도우 생성
+- **n / p** — 다음 / 이전 윈도우
+- **0-9** — 해당 번호 윈도우로 이동
+- **,** — 현재 윈도우 이름 변경
+
+### copy
+
+- **[** — 카피 모드 (스크롤 가능)
+- **Space** — 선택 시작 (카피 모드 내)
+- **Enter** — 선택 영역 복사 (카피 모드 내)
+- **q** — 카피 모드 종료
+- **]** — buffer_0 붙여넣기
+
+### example
+
+- tmux new -s dev        # 세션 시작
+- Ctrl+b %               # 좌우 분할
+- 오른쪽에서 claude 실행
+- Ctrl+b z               # 전체화면 토글
+- Ctrl+b d               # detach
+- tmux attach -t dev     # 나중에 다시 연결
+
+### companion
+
+- **marmonitor** — tmux 상태바 모니터링 플러그인
+- Install: npm install -g marmonitor
+- Setup:   marmonitor setup tmux
+- tmux 안에서 prefix+I 로 플러그인 활성화
+
+### custom
+
+- **tmux-spawn [agent]** — 3-pane AI 세션 생성
+- **tmux-teardown [name|all]** — 세션 정리 (기본: all)
+
+### related
+
+- Cheat sheet: https://tmuxcheatsheet.com/
+- Terminal: ghostty-help
+- Zsh shell: zsh-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/tmux.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/tmux_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/uv.md
+++ b/docs/guide/commands/uv.md
@@ -1,0 +1,56 @@
+# uv
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/package_managers_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic uv --force`
+
+## 호출
+
+- Help 진입점: `uv-help [section|--list|--all]`
+- 통합 라우팅: `my-help uv [section]`
+- Alias: `uv-help`
+
+## 요약 (uv-help)
+
+- Usage: uv-help [section|--list|--all]
+- sections
+    - sync: uvs | uvu | uvd | uv-install
+    - lock: uvk | uvl | uvc | uvr
+    - maintenance: uvcheck
+    - recipes: --all-extras | backend dev | frontend dev
+    - details: uv-help <section>  (example: uv-help recipes)
+
+## 섹션
+
+### sync
+
+- **uvs** — uv sync — Sync env & prune (Prod)
+- **uvu** — uv sync --upgrade — Upgrade deps
+- **uvd** — uv sync --dev — Dev install
+- **uv-install** — install script — Install UV tool
+
+### lock
+
+- **uvk** — uv lock — Refresh lockfile
+- **uvl** — uv pip list — List packages
+- **uvc** — uv pip compile — Export requirements
+- **uvr** — uv pip sync — Sync from reqs
+
+### maintenance
+
+- **uvcheck** — uv pip check — Verify env
+
+### recipes
+
+- Install all extras: uv pip sync --all-extras
+- Backend dev:      uv pip sync --extra backend --extra dev
+- Frontend dev:     uv pip sync --extra frontend --extra dev
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/uv.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/package_managers_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/ux.md
+++ b/docs/guide/commands/ux.md
@@ -1,0 +1,137 @@
+# ux
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/ux_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic ux --force`
+
+## 호출
+
+- Help 진입점: `ux-help [section|--list|--all]`
+- 통합 라우팅: `my-help ux [section]`
+- Alias: `ux-help`
+
+## 요약 (ux-help)
+
+- Usage: ux-help [section|--list|--all]
+- sections
+    - colors: semantic color variables
+    - output: ux_header | ux_section | ux_success | ux_error
+    - progress: ux_spinner | ux_with_spinner
+    - interactive: ux_confirm | ux_input
+    - tables: ux_table_header | ux_table_row | ux_bullet
+    - utilities: ux_divider | ux_usage | ux_require
+    - example: usage example template
+    - quickstart: load library and use
+    - demo: ux-demo
+    - docs: library and demo locations
+    - details: ux-help <section>  (example: ux-help colors)
+
+## 섹션
+
+### colors
+
+- **Variable** — Purpose — Color
+- **UX_PRIMARY** — Headers, titles, commands — Blue
+- **UX_SUCCESS** — Success states, valid input — Green
+- **UX_WARNING** — Warnings, confirmations — Yellow
+- **UX_ERROR** — Errors, failed operations — Red
+- **UX_INFO** — Info messages, tips — Cyan
+- **UX_MUTED** — Secondary info, hints — Gray
+
+### output
+
+- **Function** — Purpose
+- **ux_header** — Display prominent header with box
+- **ux_section** — Display section title with underline
+- **ux_success** — Success message with check
+- **ux_error** — Error message (to stderr)
+- **ux_warning** — Warning message
+- **ux_info** — Info message
+- **ux_step** — Step indicator with number
+
+### progress
+
+- **Function** — Usage
+- **ux_spinner** — ux_spinner <pid> "message"
+- **ux_with_spinner** — ux_with_spinner "msg" command args
+
+### interactive
+
+- **Function** — Usage
+- **ux_confirm** — if ux_confirm "prompt" "y"; then ...
+- **ux_input** — result=$(ux_input "prompt" "pattern")
+
+### tables
+
+- **Function** — Usage
+- **ux_table_header** — ux_table_header "Col1" "Col2" ["Col3"]
+- **ux_table_row** — ux_table_row "val1" "val2" ["val3"]
+- **ux_bullet** — ux_bullet "Item description"
+- **ux_numbered** — ux_numbered 1 "First item"
+
+### utilities
+
+- **Function** — Purpose
+- **ux_divider** — Print horizontal line (60 chars)
+- **ux_usage** — Display usage help template
+- **ux_require** — Check if command exists
+
+### example
+
+  #!/bin/bash
+
+  my_function() {
+      # Load UX library (unified library at shell-common/tools/ux_lib/)
+      source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+
+      # Show help if no arguments
+      if [ -z "$1" ]; then
+          ux_header "My Function"
+          ux_usage "my-function" "<arg>" "Description"
+          return 0
+      fi
+
+      # Check requirements
+      if ! ux_require "docker"; then
+          return 1
+      fi
+
+      # Show progress
+      ux_info "Processing $1..."
+      ux_with_spinner "Running task" some_command "$1"
+
+      # Show result
+      if [ $? -eq 0 ]; then
+          ux_success "Task completed"
+      else
+          ux_error "Task failed"
+          return 1
+      fi
+  }
+
+### quickstart
+
+1. Load library: source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+2. Use semantic colors: ${UX_PRIMARY}, ${UX_SUCCESS}, etc.
+3. Use helper functions: ux_header, ux_success, etc.
+4. Always end with ${UX_RESET} to reset colors
+
+### demo
+
+- Run the interactive demo to see all features in action:
+- ux-demo  or  bash ${SHELL_COMMON}/tools/custom/demo_ux.sh
+
+### docs
+
+- Library file: shell-common/tools/ux_lib/ux_lib.sh
+- Demo script: shell-common/tools/custom/demo_ux.sh
+- Example migrations: my_help(), dcl(), dbash()
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/ux.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/ux_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/work-log.md
+++ b/docs/guide/commands/work-log.md
@@ -1,0 +1,94 @@
+# work-log
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/work_log_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic work_log --force`
+
+## 호출
+
+- Help 진입점: `work-log-help [section|--list|--all]`
+- 통합 라우팅: `my-help work_log [section]`
+- Alias: `work-log-help`
+
+## 요약 (work-log-help)
+
+- Usage: work-log-help [section|--list|--all]
+- sections
+    - overview: manual work log for non-dev work
+    - usage: work-log add | list | help
+    - add: interactive & argument modes
+    - list: list options & filters
+    - format: output entry format
+    - types: coordination | assessment | approval | meeting
+    - categories: Testing | Infrastructure | Documentation | ...
+    - tasks: common task templates
+    - details: work-log-help <section>
+
+## 섹션
+
+### overview
+
+- Manual work log recording tool for non-development work
+- Companion to post-commit hook for development work
+- All entries are appended to ~/work_log.txt
+
+### usage
+
+- work-log add [JIRA-KEY] [OPTIONS]  - Add a work log entry
+- work-log list [OPTIONS]            - List recent entries
+- work-log help                      - Show this help
+
+### add
+
+- Interactive Mode:
+1. work-log add
+- System will prompt for Jira key, type, category, and time
+- Argument Mode:
+1. work-log add JIRA-KEY --type TYPE --category CATEGORY --time TIME
+- Short options:
+- -t, --type TYPE          (coordination|assessment|approval|meeting)
+- -c, --category CATEGORY  (Testing|Infrastructure|Documentation|Communication|Training|Other)
+- -T, --time TIME          (numeric: 2.5 or 2.5h)
+- Example Coordination meeting on testing strategy
+  work-log add SWINNOTEAM-903 -t coordination -c Communication -T 2.5h
+
+### list
+
+1. work-log list              - Show last 10 entries
+2. work-log list --count 20  - Show last 20 entries
+3. work-log list --today     - Show today's entries
+
+### format
+
+- [YYYY-MM-DD HH:MM:SS] [JIRA-KEY] | type | category | time | manual
+- └─ Category: CategoryName
+
+### types
+
+- coordination  - Team coordination, meetings, planning
+- assessment    - Code/design reviews, evaluations
+- approval      - Approval requests, sign-offs
+- meeting       - Official meetings, presentations
+
+### categories
+
+- Testing, Infrastructure, Documentation, Performance, Security
+- Communication, Coordination, Training, Other
+
+### tasks
+
+- Daily standup:  work-log add [PROJ-XXX] -t meeting -c Communication -T 0.5h
+- Code review:    work-log add [PROJ-XXX] -t assessment -c Communication -T 1.5h
+- Team planning:  work-log add [ADMIN-001] -t coordination -c Coordination -T 2h
+- All entries stored in: ~/work_log.txt (symlink → dotfiles)
+- Git tracking: Automatically versioned in dotfiles/shell-common/data/
+- Use these entries for weekly reports and time tracking
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/work-log.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/work_log_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/work.md
+++ b/docs/guide/commands/work.md
@@ -1,0 +1,108 @@
+# work
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/work.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic work --force`
+
+## 호출
+
+- Help 진입점: `work-help [section|--list|--all]`
+- 통합 라우팅: `my-help work [section]`
+- Alias: `work-help`
+
+## 요약 (work-help)
+
+- Usage: work-help [section|--list|--all]
+- sections
+    - overview: integrated tracking & docs workflow
+    - commands: work-log | make-jira | make-confluence
+    - workflow: daily & weekly cycles
+    - dataflow: input -> processing -> output
+    - files: locations of logs, reports, tools
+    - integration: git tracking & multi-PC sync
+    - more: per-command help references
+    - details: work-help <section>  (example: work-help commands)
+
+## 섹션
+
+### overview
+
+- Integrated workflow for work tracking and documentation
+- Combines: work-log (manual tracking) + make-jira (reports) + make-confluence (guides)
+- All data git-tracked in dotfiles and playbook
+
+### commands
+
+- 1. Record Work (Manual Log Entry) work-log
+- Add non-development work to weekly log
+  work-log add SWINNOTEAM-903 -t coordination -c Communication -T 2.5h
+  work-log list --today
+- 2. Generate Weekly Report make-jira
+- Create Jira-formatted weekly report from work_log.txt
+  make-jira                    # Current week
+  make-jira --week 2026-W05    # Specific week
+  make-jira SWINNOTEAM-906     # Filter by key
+- Output: playbook/docs/jira-records/YYYY-W##-report.md
+- 3. Transform Docs to Confluence Guides make-confluence
+- Convert markdown technical docs to Confluence format
+  make-confluence docs/guide/technic/file.md                        # Auto-detect category
+  make-confluence docs/analysis/file.md --category testing  # Explicit category
+- Output: playbook/docs/confluence-guides/{category}/YYYY-MM-DD-{title}.md
+
+### workflow
+
+Daily Workflow:
+  1. Work happens → git commits (auto-tracked)
+  2. Manual non-dev work → work-log add
+  3. Friday: make-jira → Weekly Jira report
+  4. As needed: make-confluence → Technical guides
+Weekly Cycle:
+  Mon-Fri: Regular work + work-log entries
+  Friday:  make-jira 2026-W05 → Jira report
+  Anytime: make-confluence → Knowledge base
+
+### dataflow
+
+Work Input
+  ├─ Git commits (post-commit hook → work_log.txt)
+  ├─ work-log add (manual → work_log.txt)
+  └─ Technical markdown (docs/guide/technic/, playbook/docs/analysis/)
+
+Processing
+  ├─ make-jira: work_log.txt → Jira reports
+  └─ make-confluence: markdown → Confluence guides
+
+Output
+  ├─ playbook/docs/jira-records/ (weekly reports)
+  ├─ playbook/docs/confluence-guides/ (technical guides)
+  └─ All git-tracked in dotfiles (multi-PC sync via symlink)
+
+### files
+
+- work_log.txt: ~/work_log.txt (symlink → ~/para/archive/playbook/logs/work_log.txt)
+- Jira reports: ~/para/archive/playbook/docs/jira-records/
+- Confluence guides: ~/para/archive/playbook/docs/confluence-guides/
+- CLI tools: ~/dotfiles/shell-common/tools/custom/make_{jira,confluence}.sh
+
+### integration
+
+- All commands are git-tracked:
+  dotfiles:                CLI tools + alias definitions
+  playbook:           Reports and guides
+  Multi-PC sync:           Symlink abstraction (automatic)
+
+### more
+
+- For detailed help on individual commands:
+  work-log help              # work-log manual
+  make-jira --help           # make-jira manual (if implemented)
+  make-confluence --help     # make-confluence manual (if implemented)
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/work.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/work.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/zsh-autosuggestions.md
+++ b/docs/guide/commands/zsh-autosuggestions.md
@@ -1,0 +1,92 @@
+# zsh-autosuggestions
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/zsh_autosuggestions.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic zsh_autosuggestions --force`
+
+## 호출
+
+- Help 진입점: `zsh-autosuggestions-help [section|--list|--all]`
+- 통합 라우팅: `my-help zsh_autosuggestions [section]`
+- Alias: `zsh-autosuggestions-help`
+
+## 요약 (zsh-autosuggestions-help)
+
+- Usage: zsh-autosuggestions-help [section|--list|--all]
+- sections
+    - about: what is zsh-autosuggestions
+    - keys: Tab | Ctrl+Right | Ctrl+F | Ctrl+A
+    - how: how the suggestions work
+    - example: example usage
+    - env: ZSH_AUTOSUGGEST_* variables
+    - strategies: history | completion | match_prev_cmd
+    - customize: ~/.zshrc snippets
+    - status: installation status
+    - details: zsh-autosuggestions-help <section>
+
+## 섹션
+
+### about
+
+- Auto-suggests commands as you type, based on your history.
+- Press Tab or Ctrl+Right to accept the suggestion.
+
+### keys
+
+- **Key** — Action
+- **Tab / Ctrl+Right** — Accept suggestion
+- **Ctrl+F** — Accept next word of suggestion
+- **Ctrl+A** — Accept entire suggestion
+- **Up/Down Arrow** — Navigate history (overrides suggestions)
+
+### how
+
+- As you type, suggestions appear in gray text
+- Suggestions are based on command history
+- Press Tab (or configured key) to accept
+- Press Esc or start typing to dismiss
+
+### example
+
+- Type 'work' and zsh will suggest:
+- work-log list help
+- work-log add SWINNOTEAM-906 -t coordination...
+- work-help
+- Press Tab to accept any suggestion
+
+### env
+
+- **Variable** — Description — Default
+- **ZSH_AUTOSUGGEST_STRATEGY** — Suggestion matching strategy — history
+- **ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE** — Max command length to suggest — unbounded
+- **ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE** — Suggestion text color — fg=8
+
+### strategies
+
+- history - Suggest from command history
+- completion - Suggest from completion
+- match_prev_cmd - Suggest matching previous command
+
+### customize
+
+- Add to ~/.zshrc (before sourcing zsh-autosuggestions):
+  # Accept suggestion with Tab key
+  bindkey '\t' autosuggest-accept
+  # Change suggestion highlight color
+  export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=10'
+  # Use history strategy only
+  export ZSH_AUTOSUGGEST_STRATEGY=(history)
+
+### status
+
+- zsh-autosuggestions is not installed
+  Run: install-zsh-autosuggestions
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/zsh-autosuggestions.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/zsh_autosuggestions.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/guide/commands/zsh.md
+++ b/docs/guide/commands/zsh.md
@@ -1,0 +1,125 @@
+# zsh
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/zsh_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic zsh --force`
+
+## 호출
+
+- Help 진입점: `zsh-help [section|--list|--all]`
+- 통합 라우팅: `my-help zsh [section]`
+- Alias: `zsh-help`
+
+## 요약 (zsh-help)
+
+- Usage: zsh-help [section|--list|--all]
+- sections
+    - switch: zsh-switch | bash-switch | install-zsh
+    - config: zsh-edit | zsh-reload | zsh-snippet
+    - theme: zsh-themes | zsh-theme-current | zsh-theme
+    - plugins: zsh-plugins | zsh-update
+    - packages: install-p10k | install-fzf | install-fasd
+    - themes-list: robbyrussell | powerlevel10k | agnoster
+    - plugins-list: git | autosuggestions | syntax-highlighting
+    - coexist: bash & zsh coexistence tips
+    - tips: configuration & snippet tips
+    - troubleshoot: zsh-fix-vscode | zsh-clear-p10k-caches | zsh-git-fix | p10k issues
+    - status: zsh-version | zsh-info
+    - details: zsh-help <section>  (example: zsh-help theme)
+
+## 섹션
+
+### switch
+
+- **zsh-switch** — Switch to zsh
+- **bash-switch** — Switch back to bash
+- **install-zsh** — Install zsh (if not installed)
+
+### config
+
+- **zsh-edit** — Edit $HOME/.zshrc
+- **zsh-reload** — Reload zsh config
+- **zsh-snippet <name>** — Create config snippet
+- **zsh-snippets** — List all snippets
+- **zsh-config** — View current zsh config
+- **zsh-edit-quick** — Quick edit with nano
+
+### theme
+
+- **zsh-themes** — List all available themes
+- **zsh-theme-current** — Show current theme
+- **zsh-theme <name>** — Change zsh theme
+
+### plugins
+
+- **zsh-plugins** — List installed plugins
+- **zsh-update** — Update oh-my-zsh framework
+
+### packages
+
+- **install-p10k** — Install powerlevel10k theme
+- **p10k-help** — VSCode terminal font setup guide
+- **p10k configure** — Configure powerlevel10k
+- **install-zsh-autosuggestions** — Install zsh-autosuggestions
+- **install-fzf** — Install fzf (fuzzy finder)
+- **install-fasd** — Install fasd (fast directory access)
+- **install-ripgrep** — Install ripgrep (fast text search)
+- **install-fd** — Install fd (fast file finder)
+- **install-bat** — Install bat (cat with highlighting)
+- **install-pet** — Install pet (command snippet manager)
+
+### themes_list
+
+- robbyrussell - Default clean theme
+- powerlevel10k - Modern powerline theme (requires Nerd Font)
+- agnoster - Git-aware theme
+- minimal - Minimal and fast
+- afowler - Syntax highlighting focused
+
+### plugins_list
+
+- git - Git aliases and functions
+- zsh-autosuggestions - Command suggestions (type then use arrow)
+- zsh-syntax-highlighting - Syntax highlighting as you type
+- extract - Smart archive extraction (extract file.tar.gz)
+- web-search - Quick web search (google 'query')
+
+### coexist
+
+- Both shells can coexist without conflicts
+- Switch shells anytime: zsh-switch or bash-switch
+- Set default: chsh -s $(which zsh) (then login again)
+
+### tips
+
+- Shared config: Add to shell-common/ for portable settings
+- Shell-specific: Use shell-specific files for unique functions
+- Use snippets: Organize $HOME/.zshrc.d/ for better management
+
+### troubleshoot
+
+- VS Code 터미널에서 기본 프롬프트(HOSTNAME%)만 표시될 때:
+-   원인: VS Code 업데이트 후 셸 통합 캐시 불일치
+-   해결: zsh-fix-vscode
+- gwt spawn 직후 prompt 가 이전 디렉터리/브랜치에 frozen 일 때:
+-   진단: print -lr -- $precmd_functions 에 _p9k_precmd 가 있는지 확인
+-   해결: zsh-clear-p10k-caches 후 exec zsh
+- gwt teardown 후 p10k 가 branch 이름을 표시하지 않을 때:
+-   원인: .git/config 에 repositoryformatversion=1 잔존 (gitstatusd 오인식)
+-   해결: zsh-git-fix (worktree 없는 상태에서 실행)
+- p10k 프롬프트가 깨지거나 느릴 때:
+-   해결: p10k configure 로 재설정
+
+### status
+
+- **zsh-version** — Show zsh version
+- **zsh-info** — System info
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/zsh.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/zsh_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -5,6 +5,8 @@
 ## 2026-08-06
 - 변경: **`PostToolUse:Bash` 훅 지연 제거 — `gh pr create` 후 project board retry-poll(최대 6회 x 2s sleep + GraphQL 왕복)과 연결 이슈 동기화를 백그라운드로 분리. foreground 는 sync 1회만 수행하므로 훅이 즉시 반환한다 (median 7.8s / max 48.7s → 즉시) (#1258)**
 - 변경: **훅 구간별 타이밍 계측 추가 — 라우팅된 호출만 `~/.local/state/claude/post-bash-dispatch-timing.log` 에 기록하고, `claude/tools/hook-perf-report.sh` 로 median/p90/p99/max 와 목표치(median < 2000ms · p99 < 5000ms) PASS/FAIL 을 집계한다 (#1258)**
+- 변경: **커맨드별 마크다운 레퍼런스 자동생성 — `shell-common/tools/custom/gen_command_docs.sh` 가 `_<topic>_help_rows_<section>()` row 함수를 실행해 `docs/guide/commands/<커맨드>.md` 59개를 생성. `rg "<키워드>" docs/guide/commands/` 로 커맨드 동작 전체 텍스트 검색 (#1262)**
+- 변경: **소스 주석에만 있던 엣지케이스를 `docs/guide/commands/.notes/<커맨드>.md` 에 수기 보강하면 재생성 시 문서에 삽입 — 첫 대상은 `csm find` 의 fzf 피커/Esc 무음 종료 동작**
 
 ## 2026-07-30
 - 변경: **statusline 시간 표시 `HH:MM:SS`로 축약 + fcitx 한글/영어 입력기 상태 표시 (#1251)**

--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -56,7 +56,7 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
 |------|----------|---|---------|
 | Alias | `aliases/*.sh` | yes | `gs='git status'` |
 | Environment | `env/*.sh` | yes | `export PATH=...` |
-| Help function | `functions/*_help.sh` | yes | `apt_help()` |
+| Help function | `functions/*_help.sh` | yes | `apt_help()` — row 함수는 `docs/guide/commands/` 자동생성 소스 (#1262) |
 | Utility function | `functions/*.sh` | yes | `devx()`, `gitlog()` |
 | 3rd-party wrapper | `tools/integrations/*.sh` | yes | `npm.sh`, `docker.sh` |
 | Executable script | `tools/custom/*.sh` | **no** | `install_npm.sh`, `setup.sh` |

--- a/shell-common/tools/custom/gen_command_docs.sh
+++ b/shell-common/tools/custom/gen_command_docs.sh
@@ -1,0 +1,471 @@
+#!/bin/bash
+# shell-common/tools/custom/gen_command_docs.sh
+#
+# Generate one markdown reference doc per user-facing command from the
+# `_<topic>_help_rows_<section>()` row functions that
+# docs/.ssot/command-guidelines.md defines as the help SSOT (issue #1262).
+#
+# Why execute the row functions instead of parsing rendered help output:
+# the row functions ARE the data layer. Overriding the ux_lib renderers with
+# markdown-emitting stubs intercepts that data before it is styled for a
+# terminal, so the docs never drift from what `<topic>-help <section>` prints.
+#
+# Hand-written edge cases (the "Esc quietly exits" kind that only lives in
+# source comments) are NOT auto-extractable. They live in
+# docs/guide/commands/.notes/<name>.md and are spliced into the generated
+# doc verbatim. The notes dir is dot-prefixed so `rg` (which skips hidden
+# paths by default) returns exactly one hit per command, not two.
+#
+# Usage:
+#   shell-common/tools/custom/gen_command_docs.sh                # generate missing docs
+#   shell-common/tools/custom/gen_command_docs.sh --force        # regenerate all
+#   shell-common/tools/custom/gen_command_docs.sh --topic cc     # single topic
+#   shell-common/tools/custom/gen_command_docs.sh --list         # discovery only
+#   shell-common/tools/custom/gen_command_docs.sh --out-dir DIR  # write elsewhere
+#
+# Search the result with ripgrep:
+#   rg "fzf 피커" docs/guide/commands/
+
+# The markdown templates below are full of single-quoted backticks (inline code
+# spans), which shellcheck reads as command substitution it cannot expand.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+_SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+_SCRIPT_DIR="$(dirname "$_SCRIPT_PATH")"
+SHELL_COMMON="${_SCRIPT_DIR%/tools/custom}"
+export SHELL_COMMON
+DOTFILES_ROOT="${SHELL_COMMON%/shell-common}"
+export DOTFILES_ROOT
+
+# shellcheck source=/dev/null
+source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+
+FUNCTIONS_DIR="${SHELL_COMMON}/functions"
+DEFAULT_OUT_DIR="${DOTFILES_ROOT}/docs/guide/commands"
+NOTES_DIRNAME=".notes"
+
+OPT_FORCE=0
+OPT_LIST=0
+OPT_TOPIC=""
+OPT_OUT_DIR=""
+
+_STUB_FILE=""
+
+_cleanup() {
+    [ -n "$_STUB_FILE" ] && [ -f "$_STUB_FILE" ] && rm -f "$_STUB_FILE"
+    return 0
+}
+trap _cleanup EXIT
+
+usage() {
+    ux_info "Usage: gen_command_docs.sh [--force] [--topic <name>] [--out-dir <dir>] [--list]"
+    ux_bullet "options"
+    ux_bullet_sub "--force: 기존 문서도 다시 렌더링 (내용이 같으면 파일은 그대로 둔다)"
+    ux_bullet_sub "--topic <name>: 특정 topic 만 생성 (예: cc, claude_skills_marketplace)"
+    ux_bullet_sub "--out-dir <dir>: 출력 디렉토리 (기본 docs/guide/commands)"
+    ux_bullet_sub "--list: 탐지된 topic 목록만 출력하고 종료"
+}
+
+# ---------------------------------------------------------------------------
+# ux_lib -> markdown stubs
+#
+# Written to a temp file once and sourced by every render subshell. Sourced
+# BEFORE the target file (so a file that self-loads ux_lib behind a
+# `type ux_header` check keeps our stubs) and AGAIN after (so a file that
+# loads ux_lib unconditionally cannot win).
+# ---------------------------------------------------------------------------
+make_stub_file() {
+    _STUB_FILE="$(mktemp "${TMPDIR:-/tmp}/gen_command_docs_stubs.XXXXXX")"
+    cat >"$_STUB_FILE" <<'STUBS'
+UX_BOLD=""
+UX_DIM=""
+UX_RESET=""
+UX_PRIMARY=""
+UX_MUTED=""
+UX_SUCCESS=""
+UX_ERROR=""
+UX_WARNING=""
+UX_INFO=""
+export UX_BOLD UX_DIM UX_RESET UX_PRIMARY UX_MUTED UX_SUCCESS UX_ERROR UX_WARNING UX_INFO
+
+ux_header() { printf '**%s**\n\n' "$1"; }
+ux_section() { printf '**%s**\n\n' "$1"; }
+ux_bullet() { printf -- '- %s\n' "$1"; }
+ux_bullet_sub() { printf -- '    - %s\n' "$1"; }
+ux_numbered() { printf -- '%s. %s\n' "$1" "$2"; }
+ux_info() { printf -- '- %s\n' "$*"; }
+ux_success() { printf -- '- %s\n' "$*"; }
+ux_warning() { printf -- '- %s\n' "$*"; }
+ux_error() { printf -- '- %s\n' "$*"; }
+ux_step() { printf -- '- %s\n' "$*"; }
+ux_divider() { :; }
+ux_divider_thick() { :; }
+ux_spinner() { :; }
+
+_gcd_row() {
+    if [ -n "${3:-}" ]; then
+        printf -- '- **%s** — %s — %s\n' "$1" "$2" "$3"
+    else
+        printf -- '- **%s** — %s\n' "$1" "${2:-}"
+    fi
+}
+ux_table_row() { _gcd_row "$@"; }
+ux_table_header() { _gcd_row "$@"; }
+STUBS
+}
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+# List every row function defined in a file, in definition order.
+row_functions_in() {
+    grep -oE '^_[a-z0-9_]+_help_rows_[a-z0-9_]+\(\)' "$1" 2>/dev/null | sed 's/()$//' || true
+}
+
+# "<topic>\t<file>" for every topic that owns at least one row function.
+# A topic seen in more than one file keeps its first definition.
+discover_topics() {
+    local file fn topic seen=" "
+    for file in "$FUNCTIONS_DIR"/*.sh; do
+        [ -f "$file" ] || continue
+        while IFS= read -r fn; do
+            [ -n "$fn" ] || continue
+            topic="${fn#_}"
+            topic="${topic%%_help_rows_*}"
+            case "$seen" in *" $topic "*) continue ;; esac
+            seen="${seen}${topic} "
+            printf '%s\t%s\n' "$topic" "$file"
+        done <<<"$(row_functions_in "$file")"
+    done
+}
+
+# Section names for a topic, in definition order.
+topic_sections() {
+    local file="$1" topic="$2" fn
+    while IFS= read -r fn; do
+        case "$fn" in
+        "_${topic}_help_rows_"*) printf '%s\n' "${fn#_"${topic}"_help_rows_}" ;;
+        esac
+    done <<<"$(row_functions_in "$file")"
+}
+
+# Warn about `*_help.sh` files that predate the row-function SSOT pattern.
+# They are invisible to discovery (which keys off `_help_rows_`), so without
+# this they would drop out of the docs silently. Warning only — one legacy
+# file must never fail the whole run. Sets N_LEGACY.
+N_LEGACY=0
+warn_legacy_help_files() {
+    local file
+    N_LEGACY=0
+    for file in "$FUNCTIONS_DIR"/*_help.sh; do
+        [ -f "$file" ] || continue
+        # my_help.sh is the topic router itself, not a documentable topic.
+        [ "$(basename "$file")" = "my_help.sh" ] && continue
+        [ -n "$(row_functions_in "$file")" ] && continue
+        ux_warning "$(basename "$file"): row 함수 없음 (레거시 포맷) — 문서 생성 제외"
+        N_LEGACY=$((N_LEGACY + 1))
+    done
+}
+
+# Aliases defined in a file, as "<alias> <target>" pairs.
+aliases_in() {
+    sed -n "s/^alias \([A-Za-z0-9_.-]\{1,\}\)=['\"]\{0,1\}\([A-Za-z0-9_]\{1,\}\)['\"]\{0,1\}[[:space:]]*$/\1 \2/p" "$1" 2>/dev/null || true
+}
+
+# Doc filename stem. Defaults to the dash-form topic, but prefers the
+# shortest alias that points at the topic's router function — that is the
+# name users actually type (`csm` for `claude_skills_marketplace`).
+topic_doc_basename() {
+    local file="$1" topic="$2"
+    local best="${topic//_/-}"
+    local name target
+    while read -r name target; do
+        [ -n "${name:-}" ] || continue
+        [ "$target" = "$topic" ] || continue
+        if [ "${#name}" -lt "${#best}" ]; then
+            best="$name"
+        fi
+    done <<<"$(aliases_in "$file")"
+    printf '%s\n' "$best"
+}
+
+# Alias list for the doc header: aliases pointing at the topic router or its
+# help entry point.
+topic_alias_list() {
+    local file="$1" topic="$2"
+    local name target out=""
+    while read -r name target; do
+        [ -n "${name:-}" ] || continue
+        case "$target" in
+        "$topic" | "${topic}_help") out="${out}${out:+, }\`${name}\`" ;;
+        esac
+    done <<<"$(aliases_in "$file")"
+    printf '%s\n' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+# Render a topic's summary + every section in ONE bash subshell.
+# One process per topic keeps a full 40+ topic regeneration well under a
+# second (NF-1); a process per section would not.
+#
+# The output is post-processed so the committed docs stay machine-independent:
+# ANSI escapes stripped, and absolute paths folded back to `~/dotfiles` / `~`
+# (some rows interpolate $DOTFILES_ROOT, which differs per worktree — without
+# this every clone would regenerate a diff).
+render_topic_body() {
+    local file="$1" topic="$2"
+    shift 2
+
+    DOTFILES_FORCE_INIT=1 NO_COLOR=1 TERM=dumb DOTFILES_TEST_MODE=1 \
+        SHELL_COMMON="$SHELL_COMMON" DOTFILES_ROOT="$DOTFILES_ROOT" \
+        bash --noprofile --norc -c '
+            set +u
+            stubs="$1"; target="$2"; topic="$3"; shift 3
+            . "$stubs" || exit 3
+            . "$target" >/dev/null 2>&1 || exit 4
+            . "$stubs" || exit 3
+
+            if declare -F "_${topic}_help_summary" >/dev/null 2>&1; then
+                printf "## 요약 (%s-help)\n\n" "${topic//_/-}"
+                "_${topic}_help_summary"
+                printf "\n"
+            fi
+
+            printf "## 섹션\n\n"
+            for section in "$@"; do
+                printf "### %s\n\n" "$section"
+                "_${topic}_help_rows_${section}" || printf -- "- (렌더 실패)\n"
+                printf "\n"
+            done
+        ' _ "$_STUB_FILE" "$file" "$topic" "$@" 2>/dev/null |
+        LC_ALL=C sed \
+            -e 's/\x1b\[[0-9;]*[A-Za-z]//g' \
+            -e "s|${DOTFILES_ROOT}|~/dotfiles|g" \
+            -e "s|${HOME}|~|g"
+}
+
+# Full markdown document for one topic.
+render_topic_doc() {
+    local file="$1" topic="$2" basename_stem="$3" notes_file="$4"
+    shift 4
+
+    local rel_source="${file#"${DOTFILES_ROOT}"/}"
+    local topic_dash="${topic//_/-}"
+    local aliases
+    aliases="$(topic_alias_list "$file" "$topic")"
+
+    if [ "$basename_stem" = "$topic_dash" ]; then
+        printf '# %s\n\n' "$topic_dash"
+    else
+        printf '# %s (%s)\n\n' "$basename_stem" "$topic_dash"
+    fi
+    printf '> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `%s` 의 row 함수가 SSOT 입니다.\n' "$rel_source"
+    printf '> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic %s --force`\n\n' "$topic"
+
+    printf '## 호출\n\n'
+    printf -- '- Help 진입점: `%s-help [section|--list|--all]`\n' "$topic_dash"
+    printf -- '- 통합 라우팅: `my-help %s [section]`\n' "$topic"
+    if [ -n "$aliases" ]; then
+        printf -- '- Alias: %s\n' "$aliases"
+    fi
+    printf '\n'
+
+    render_topic_body "$file" "$topic" "$@"
+
+    printf '## 엣지케이스 / 의도된 동작\n\n'
+    if [ -f "$notes_file" ]; then
+        cat "$notes_file"
+        printf '\n'
+    else
+        printf '아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면\n'
+        printf '`docs/guide/commands/%s/%s.md` 에 추가한 뒤 이 문서를 재생성하세요.\n\n' \
+            "$NOTES_DIRNAME" "$basename_stem"
+    fi
+
+    printf '## 소스\n\n'
+    printf -- '- `%s`\n' "$rel_source"
+    printf -- '- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`\n'
+}
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+# Write only when the rendered content differs, so a no-op regeneration
+# leaves the file (and its mtime) untouched. Echoes the verdict.
+write_if_changed() {
+    local target="$1" content="$2"
+    if [ -f "$target" ] && [ "$content" = "$(cat "$target")" ]; then
+        printf 'unchanged\n'
+        return 0
+    fi
+    printf '%s\n' "$content" >"$target"
+    printf 'written\n'
+}
+
+write_index() {
+    local out_dir="$1"
+    shift
+    local content entry
+    content="$(
+        printf '# 커맨드 레퍼런스 인덱스\n\n'
+        printf '`shell-common/functions/` 의 `_<topic>_help_rows_<section>()` 정의에서\n'
+        printf '자동 생성한 커맨드별 상세 문서 모음입니다 (issue #1262).\n\n'
+        printf '## 사용법\n\n'
+        printf '```bash\n'
+        printf '# 동작을 까먹었을 때 — 전체 텍스트 검색\n'
+        printf 'rg "fzf 피커" docs/guide/commands/\n\n'
+        printf '# 전체 재생성 (내용이 바뀐 파일만 갱신)\n'
+        printf './shell-common/tools/custom/gen_command_docs.sh --force\n'
+        printf '```\n\n'
+        printf '이름 자체가 기억나지 않을 때는 `my-help search` (fzf topic finder) 를 쓰세요.\n\n'
+        printf '## 문서 목록\n\n'
+        for entry in "$@"; do
+            printf -- '- [%s](./%s.md)\n' "$entry" "$entry"
+        done
+        printf '\n## 수기 보강 노트\n\n'
+        printf '소스 주석에만 있는 엣지케이스는 자동 추출 대상이 아닙니다.\n'
+        printf '`%s/<커맨드>.md` 에 작성하면 재생성 시 각 문서의\n' "$NOTES_DIRNAME"
+        printf '"엣지케이스 / 의도된 동작" 절에 그대로 삽입됩니다.\n'
+    )"
+    write_if_changed "${out_dir}/README.md" "$content"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -h | --help | help)
+            usage
+            return 0
+            ;;
+        --force)
+            OPT_FORCE=1
+            shift
+            ;;
+        --list)
+            OPT_LIST=1
+            shift
+            ;;
+        --topic)
+            OPT_TOPIC="${2:-}"
+            [ -n "$OPT_TOPIC" ] || {
+                ux_error "--topic requires a value"
+                return 1
+            }
+            shift 2
+            ;;
+        --out-dir)
+            OPT_OUT_DIR="${2:-}"
+            [ -n "$OPT_OUT_DIR" ] || {
+                ux_error "--out-dir requires a value"
+                return 1
+            }
+            shift 2
+            ;;
+        *)
+            ux_error "Unknown option: $1"
+            usage
+            return 1
+            ;;
+        esac
+    done
+
+    local out_dir="${OPT_OUT_DIR:-$DEFAULT_OUT_DIR}"
+    local notes_dir="${out_dir}/${NOTES_DIRNAME}"
+
+    if [ "$OPT_LIST" -eq 1 ]; then
+        ux_header "Command doc topics"
+        local topic file
+        while IFS=$'\t' read -r topic file; do
+            [ -n "$topic" ] || continue
+            ux_table_row "$topic" "${file#"${DOTFILES_ROOT}"/}"
+        done <<<"$(discover_topics)"
+        return 0
+    fi
+
+    make_stub_file
+    mkdir -p "$out_dir" "$notes_dir"
+
+    ux_header "Command Docs Generator"
+
+    local topic file stem doc content verdict
+    local -a sections=()
+    local -a stems=()
+    local -a taken=()
+    local n_written=0 n_unchanged=0 n_skipped=0 n_failed=0
+
+    while IFS=$'\t' read -r topic file; do
+        [ -n "$topic" ] || continue
+        if [ -n "$OPT_TOPIC" ] && [ "$topic" != "$OPT_TOPIC" ]; then
+            continue
+        fi
+
+        mapfile -t sections < <(topic_sections "$file" "$topic")
+        if [ "${#sections[@]}" -eq 0 ]; then
+            ux_warning "${topic}: row 함수 없음 — skip"
+            n_failed=$((n_failed + 1))
+            continue
+        fi
+
+        stem="$(topic_doc_basename "$file" "$topic")"
+        # Two topics claiming one filename: the later one falls back to its
+        # own topic name rather than silently overwriting the earlier doc.
+        if [[ " ${taken[*]-} " == *" $stem "* ]]; then
+            ux_warning "${topic}: 문서명 '${stem}' 충돌 — '${topic//_/-}' 로 대체"
+            stem="${topic//_/-}"
+        fi
+        taken+=("$stem")
+        stems+=("$stem")
+
+        doc="${out_dir}/${stem}.md"
+        if [ -f "$doc" ] && [ "$OPT_FORCE" -eq 0 ]; then
+            n_skipped=$((n_skipped + 1))
+            continue
+        fi
+
+        content="$(render_topic_doc "$file" "$topic" "$stem" "${notes_dir}/${stem}.md" "${sections[@]}")"
+        if [ -z "$content" ]; then
+            ux_warning "${topic}: 렌더 실패 — skip"
+            n_failed=$((n_failed + 1))
+            continue
+        fi
+
+        verdict="$(write_if_changed "$doc" "$content")"
+        case "$verdict" in
+        written) n_written=$((n_written + 1)) ;;
+        *) n_unchanged=$((n_unchanged + 1)) ;;
+        esac
+    done <<<"$(discover_topics)"
+
+    if [ -z "$OPT_TOPIC" ]; then
+        warn_legacy_help_files
+    fi
+
+    if [ -z "$OPT_TOPIC" ] && [ "${#stems[@]}" -gt 0 ]; then
+        local -a sorted_stems=()
+        mapfile -t sorted_stems < <(printf '%s\n' "${stems[@]}" | LC_ALL=C sort)
+        write_index "$out_dir" "${sorted_stems[@]}" >/dev/null
+    fi
+
+    ux_table_row "written" "$n_written"
+    ux_table_row "unchanged" "$n_unchanged"
+    ux_table_row "skipped (문서 존재, --force 없음)" "$n_skipped"
+    ux_table_row "legacy (row 함수 없는 *_help.sh)" "$N_LEGACY"
+    ux_table_row "failed" "$n_failed"
+    ux_success "Docs: ${out_dir#"${DOTFILES_ROOT}"/}"
+    ux_info "Search: rg \"<keyword>\" ${out_dir#"${DOTFILES_ROOT}"/}"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi

--- a/tests/integration/test_command_docs.py
+++ b/tests/integration/test_command_docs.py
@@ -1,0 +1,158 @@
+"""Tests for the command reference doc generator (issue #1262).
+
+`shell-common/tools/custom/gen_command_docs.sh` renders one markdown file per
+user-facing command by executing the `_<topic>_help_rows_<section>()` row
+functions with markdown-emitting ux_lib stubs.
+
+The generated tree is what makes command behaviour greppable:
+    rg "fzf 피커" docs/guide/commands/
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+GENERATOR = REPO_ROOT / "shell-common" / "tools" / "custom" / "gen_command_docs.sh"
+DOCS_DIR = REPO_ROOT / "docs" / "guide" / "commands"
+NOTES_DIRNAME = ".notes"
+
+# csm's help lives inside marketplace.sh, not a dedicated *_help.sh — it is the
+# regression anchor for "discovery must scan every functions/*.sh file".
+CSM_TOPIC = "claude_skills_marketplace"
+CSM_DOC = "csm.md"
+
+
+def run_generator(*args: str) -> subprocess.CompletedProcess:
+    """Invoke the generator with ANSI colouring disabled."""
+    return subprocess.run(
+        [str(GENERATOR), *args],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(Path.home()), "NO_COLOR": "1", "TERM": "dumb"},
+    )
+
+
+@pytest.fixture
+def out_dir(tmp_path: Path) -> Path:
+    """A scratch output dir seeded with the repo's hand-written notes."""
+    target = tmp_path / "commands"
+    target.mkdir()
+    src_notes = DOCS_DIR / NOTES_DIRNAME
+    if src_notes.is_dir():
+        shutil.copytree(src_notes, target / NOTES_DIRNAME)
+    return target
+
+
+class TestGeneratorScript:
+    """The generator itself."""
+
+    def test_generator_is_executable(self):
+        assert GENERATOR.is_file(), f"{GENERATOR} missing"
+        assert GENERATOR.stat().st_mode & 0o111, f"{GENERATOR} is not executable"
+
+    def test_help_flag_exits_clean(self):
+        result = run_generator("--help")
+        assert result.returncode == 0, result.stderr
+        assert "gen_command_docs.sh" in result.stdout
+
+    def test_list_discovers_topics_outside_help_files(self):
+        """csm's row functions live in marketplace.sh — discovery must find them."""
+        result = run_generator("--list")
+        assert result.returncode == 0, result.stderr
+        assert CSM_TOPIC in result.stdout
+        assert "marketplace.sh" in result.stdout
+
+    def test_legacy_help_files_warn_but_do_not_fail(self, out_dir: Path):
+        """A *_help.sh without row functions is invisible to discovery — say so."""
+        result = run_generator("--out-dir", str(out_dir), "--force")
+        assert result.returncode == 0, result.stderr
+        assert "레거시 포맷" in result.stdout, "legacy *_help.sh files should be reported"
+        # the run still produces the full doc set
+        assert len(list(out_dir.glob("*.md"))) > 10
+
+    def test_unknown_topic_writes_nothing(self, out_dir: Path):
+        result = run_generator("--topic", "definitely_not_a_topic", "--out-dir", str(out_dir))
+        assert result.returncode == 0, result.stderr
+        assert list(out_dir.glob("*.md")) == []
+
+
+class TestGeneratedDoc:
+    """Rendering a topic into a scratch dir."""
+
+    def test_csm_doc_is_generated(self, out_dir: Path):
+        result = run_generator("--topic", CSM_TOPIC, "--out-dir", str(out_dir))
+        assert result.returncode == 0, result.stderr
+
+        doc = out_dir / CSM_DOC
+        assert doc.is_file(), f"{CSM_DOC} not generated: {sorted(p.name for p in out_dir.iterdir())}"
+
+        text = doc.read_text(encoding="utf-8")
+        # (1) command list / entry point, (2) per-subcommand one-liners
+        assert "claude-skills-marketplace-help" in text
+        assert "info <skill-name>" in text
+        assert "refresh" in text
+        # source pointer back to the SSOT
+        assert "shell-common/functions/marketplace.sh" in text
+
+    def test_hand_written_edge_cases_are_spliced_in(self, out_dir: Path):
+        """Source-comment-only behaviour reaches the doc via .notes/<name>.md."""
+        run_generator("--topic", CSM_TOPIC, "--out-dir", str(out_dir))
+        text = (out_dir / CSM_DOC).read_text(encoding="utf-8")
+        assert "fzf 피커" in text
+        assert "Esc" in text
+
+    def test_home_path_is_normalised(self, out_dir: Path):
+        """Absolute $HOME paths would make every machine produce a different doc."""
+        run_generator("--topic", CSM_TOPIC, "--out-dir", str(out_dir))
+        text = (out_dir / CSM_DOC).read_text(encoding="utf-8")
+        assert str(Path.home()) not in text
+        assert "~/.claude/plugins" in text
+
+    def test_existing_doc_is_skipped_without_force(self, out_dir: Path):
+        doc = out_dir / CSM_DOC
+        doc.write_text("sentinel\n", encoding="utf-8")
+
+        result = run_generator("--topic", CSM_TOPIC, "--out-dir", str(out_dir))
+        assert result.returncode == 0, result.stderr
+        assert doc.read_text(encoding="utf-8") == "sentinel\n"
+
+    def test_force_regeneration_is_idempotent(self, out_dir: Path):
+        """A second --force run must not rewrite an unchanged file."""
+        run_generator("--topic", CSM_TOPIC, "--out-dir", str(out_dir))
+        doc = out_dir / CSM_DOC
+        first = doc.read_text(encoding="utf-8")
+        mtime = doc.stat().st_mtime_ns
+
+        result = run_generator("--topic", CSM_TOPIC, "--out-dir", str(out_dir), "--force")
+        assert result.returncode == 0, result.stderr
+        assert doc.read_text(encoding="utf-8") == first
+        assert doc.stat().st_mtime_ns == mtime, "unchanged content must not be rewritten"
+
+
+class TestCommittedDocs:
+    """The docs checked into the repo — what `rg` actually searches."""
+
+    def test_commands_dir_is_populated(self):
+        docs = sorted(DOCS_DIR.glob("*.md"))
+        assert len(docs) > 10, f"only {len(docs)} command docs found"
+        assert (DOCS_DIR / "README.md").is_file()
+
+    def test_csm_doc_is_committed_with_its_edge_cases(self):
+        text = (DOCS_DIR / CSM_DOC).read_text(encoding="utf-8")
+        assert "fzf 피커" in text
+        assert "Esc" in text
+
+    def test_edge_case_is_full_text_searchable(self):
+        """rg-equivalent: the keyword must be findable across docs/guide/commands/."""
+        hits = [p.name for p in DOCS_DIR.glob("*.md") if "fzf 피커" in p.read_text(encoding="utf-8")]
+        assert CSM_DOC in hits, f"'fzf 피커' not found in command docs (hits: {hits})"
+
+    def test_index_links_every_doc(self):
+        index = (DOCS_DIR / "README.md").read_text(encoding="utf-8")
+        for doc in DOCS_DIR.glob("*.md"):
+            if doc.name == "README.md":
+                continue
+            assert f"](./{doc.name})" in index, f"{doc.name} missing from README index"


### PR DESCRIPTION
## Summary
- `*_help.sh` 의 row 함수를 **실행**해 커맨드별 마크다운 레퍼런스 59개를 자동 생성하고, `rg` 로 전체 텍스트 검색 가능하게 만든다.
- 소스 주석에만 있던 엣지케이스(`csm find` 는 fzf 피커, Esc 시 조용히 exit 0)를 `.notes/` 수기 파일로 보강해 생성 문서에 삽입한다.
- `*-help` 출력은 15줄 요약 포맷이라 이런 설명을 담을 수 없고(`command-guidelines.md` "출력 정책"), 지식그래프는 아키텍처 질의용이라 사용자 매뉴얼 질문에 맞지 않는다 — 그 빈틈을 메우는 문서 자산.

## Changes
- `shell-common/tools/custom/gen_command_docs.sh` (신규 471줄) — ux_lib 를 마크다운 stub 으로 덮어쓰고 `_<topic>_help_rows_<section>()` 를 직접 실행해 렌더링. 터미널 출력 파싱이 아니라 데이터 계층을 가로채므로 help 출력과 구조적으로 드리프트할 수 없다.
- 탐색 범위는 `functions/*_help.sh` 가 아니라 **`_help_rows_` 를 정의한 모든 파일** — `csm` 의 help 는 `marketplace.sh` 안에 있어 전자로는 누락된다 (44 파일 / 59 topic).
- 문서명은 router 함수를 가리키는 **최단 alias** 우선 — `claude-skills-marketplace.md` 가 아니라 사용자가 실제로 치는 `csm.md`.
- 커밋되는 산출물이 머신 독립적이도록 `$DOTFILES_ROOT` → `~/dotfiles`, `$HOME` → `~` 정규화. 정규화 전에는 워크트리 경로(`~/dotfiles-issue-1262-1/...`)가 `mytool.md` 에 그대로 박혔다.
- **idempotent 2단**: `--force` 없으면 기존 파일 skip, `--force` 여도 내용이 같으면 쓰지 않는다(mtime 보존). 전체 재생성 1.8초 (NF-1).
- `.notes/` 는 dot-dir — `rg` 가 기본적으로 hidden 을 건너뛰므로 검색 결과에 커맨드당 **1건만** 잡힌다 (생성 문서에서만).
- row 함수 없는 레거시 `*_help.sh` 5개는 경고만 하고 전체 실행을 막지 않는다 (issue Error Cases).
- `tests/integration/test_command_docs.py` (신규 14 테스트) — 생성/스킵/`--force` 미기록/HOME 정규화/레거시 경고/커밋된 문서의 검색 가능성/인덱스 링크 정합성.
- SSOT·인덱스 갱신: `command-guidelines.md` 에 문서 자동생성 규칙 추가, `docs/guide/README.md` + `docs/AGENTS.md` + `shell-common/AGENTS.md` + changelog.

## Test plan
- [x] `mise run test` — 1246 passed, 0 failed
- [x] `mise run lint` — errors=0 (ruff + mypy + shellcheck + shfmt)
- [x] `shellcheck -x` / `shfmt -d` on the new generator — clean
- [x] `rg "fzf 피커" docs/guide/commands/` → `csm.md` 히트
- [x] 재실행 idempotent — 2회차 `--force` 에서 written=0 / unchanged=59
- [x] 전체 재생성 1.8s (warm)

## Note
문서를 쓰다 발견한 불일치 하나: 인자 없는 `csm` 은 실제로 `help` 를 띄우는데(`local command="${1:-help}"`), `csm help` 의 quickstart 는 "Group by plugin (default): csm" 이라고 안내한다. 이번 PR 범위 밖이라 코드는 건드리지 않고 `.notes/csm.md` 에 실제 동작으로 기록만 했다.

## Related
Closes #1262

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~24 h · 🤖 ~22 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~24 h · 🤖 ~22 min
<!-- /ai-metrics:gh-pr -->

</details>
