### PR TITLE
feat(my-help): search 인덱스를 저장소 전체 alias로 확장

### DIFF
--- a/docs/.ssot/command-guidelines.md
+++ b/docs/.ssot/command-guidelines.md
@@ -21,7 +21,8 @@
 - 섹션 목록: `<topic>-help [--list|list]`
 - 전체 상세: `<topic>-help [--all|all]`
 - 통합 라우팅: `my-help [<topic>] [section|--list|--all]` (인자 생략 시 카테고리 목록 표시)
-- 퍼지 검색: `my-help search` (alias `find`) — fzf 기반 topic finder, fzf 미설치·비대화형이면 카테고리 목록으로 폴백
+- 퍼지 검색: `my-help search` (alias `find`) — fzf 기반 finder. 인덱스는 `*_help.sh` 토픽 + 저장소 전체 alias(`bash/`, `zsh/`, `shell-common/` 의 `*.sh`/`*.bash`/`*.zsh`) 를 함께 포함한다. 토픽을 그대로 다시 노출하는 dash-form alias(`agy-help` → `agy_help`)는 중복이므로 인덱스에서 제외한다. alias 항목을 고르면 정의·정의 위치·주석을 출력한다. fzf 미설치·비대화형이면 카테고리 목록으로 폴백
+  - alias 인덱스는 `${XDG_CACHE_HOME:-~/.cache}/dotfiles/my-help-alias-index.tsv` 에 24시간 TTL 로 캐시된다 (`MY_HELP_ALIAS_CACHE_PATH` / `MY_HELP_ALIAS_CACHE_MAX_AGE` 로 재정의 가능). 캐시가 비었거나 손상되면 자동 재생성하고, 스캔 결과가 없으면 토픽 목록만으로 폴백한다
 
 ### 2) 출력 정책
 

--- a/docs/.ssot/command-guidelines.md
+++ b/docs/.ssot/command-guidelines.md
@@ -21,7 +21,7 @@
 - 섹션 목록: `<topic>-help [--list|list]`
 - 전체 상세: `<topic>-help [--all|all]`
 - 통합 라우팅: `my-help [<topic>] [section|--list|--all]` (인자 생략 시 카테고리 목록 표시)
-- 퍼지 검색: `my-help search` (alias `find`) — fzf 기반 finder. 인덱스는 `*_help.sh` 토픽 + 저장소 전체 alias(`bash/`, `zsh/`, `shell-common/` 의 `*.sh`/`*.bash`/`*.zsh`) 를 함께 포함한다. 토픽을 그대로 다시 노출하는 dash-form alias(`agy-help` → `agy_help`)는 중복이므로 인덱스에서 제외한다. alias 항목을 고르면 정의·정의 위치·주석을 출력한다. fzf 미설치·비대화형이면 카테고리 목록으로 폴백
+- 퍼지 검색: `my-help search` (alias `find`) — fzf 기반 finder. 인덱스는 `*_help.sh` 토픽 + 저장소 전체 alias(`bash/`, `zsh/`, `shell-common/` 의 `*.sh`/`*.bash`/`*.zsh`) 를 함께 포함한다. 토픽을 그대로 다시 노출하는 dash-form alias(`agy-help` → `agy_help`)는 중복이므로 인덱스에서 제외한다. 반대로 같은 이름이 서로 다른 정의로 두 곳에 선언된 경우(`llm-help` = `litellm_help` / `ollama_help`)는 어느 쪽이 유효한지 파일 스캔만으로 알 수 없으므로 임의로 하나를 고르지 않고 양쪽 다 각자의 위치와 함께 노출한다. alias 항목을 고르면 정의·정의 위치·주석을 출력한다. fzf 미설치·비대화형이면 카테고리 목록으로 폴백
   - alias 인덱스는 `${XDG_CACHE_HOME:-~/.cache}/dotfiles/my-help-alias-index.tsv` 에 24시간 TTL 로 캐시된다 (`MY_HELP_ALIAS_CACHE_PATH` / `MY_HELP_ALIAS_CACHE_MAX_AGE` 로 재정의 가능). 캐시가 비었거나 손상되면 자동 재생성하고, 스캔 결과가 없으면 토픽 목록만으로 폴백한다
 
 ### 2) 출력 정책

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -8,6 +8,8 @@
 - 변경: **커맨드별 마크다운 레퍼런스 자동생성 — `shell-common/tools/custom/gen_command_docs.sh` 가 `_<topic>_help_rows_<section>()` row 함수를 실행해 `docs/guide/commands/<커맨드>.md` 57개를 생성. `rg "<키워드>" docs/guide/commands/` 로 커맨드 동작 전체 텍스트 검색 (#1262)**
 - 변경: **호스트 환경값(`$SSL_CERT_FILE` 등)을 출력하는 `ssl`/`crt` topic 은 문서 생성에서 제외 — 머신마다 값이 달라 재현 불가능하고 사내 인증서 경로가 공개 저장소로 새어 나간다. 해당 값은 `ssl-help`/`crt-help` 로 직접 확인 (#1262)**
 - 변경: **소스 주석에만 있던 엣지케이스를 `docs/guide/commands/.notes/<커맨드>.md` 에 수기 보강하면 재생성 시 문서에 삽입 — 첫 대상은 `csm find` 의 fzf 피커/Esc 무음 종료 동작**
+- 변경: **`my-help search`(alias `find`) 인덱스를 `*_help.sh` 토픽에서 저장소 전체 alias(385개)까지 확장 — alias 이름으로 바로 찾고, 고르면 정의·정의 위치·주석을 표시. 토픽을 그대로 다시 노출하는 dash-form alias(`agy-help` → `agy_help`)는 중복 제거 (#1261)**
+- 변경: **alias 인덱스는 `${XDG_CACHE_HOME:-~/.cache}/dotfiles/my-help-alias-index.tsv`에 24시간 TTL로 캐시 — `MY_HELP_ALIAS_CACHE_PATH` / `MY_HELP_ALIAS_CACHE_MAX_AGE`로 재정의 가능하며, 캐시가 비었거나 손상되면 자동 재생성**
 
 ## 2026-07-30
 - 변경: **statusline 시간 표시 `HH:MM:SS`로 축약 + fcitx 한글/영어 입력기 상태 표시 (#1251)**

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -8,7 +8,7 @@
 - 변경: **커맨드별 마크다운 레퍼런스 자동생성 — `shell-common/tools/custom/gen_command_docs.sh` 가 `_<topic>_help_rows_<section>()` row 함수를 실행해 `docs/guide/commands/<커맨드>.md` 57개를 생성. `rg "<키워드>" docs/guide/commands/` 로 커맨드 동작 전체 텍스트 검색 (#1262)**
 - 변경: **호스트 환경값(`$SSL_CERT_FILE` 등)을 출력하는 `ssl`/`crt` topic 은 문서 생성에서 제외 — 머신마다 값이 달라 재현 불가능하고 사내 인증서 경로가 공개 저장소로 새어 나간다. 해당 값은 `ssl-help`/`crt-help` 로 직접 확인 (#1262)**
 - 변경: **소스 주석에만 있던 엣지케이스를 `docs/guide/commands/.notes/<커맨드>.md` 에 수기 보강하면 재생성 시 문서에 삽입 — 첫 대상은 `csm find` 의 fzf 피커/Esc 무음 종료 동작**
-- 변경: **`my-help search`(alias `find`) 인덱스를 `*_help.sh` 토픽에서 저장소 전체 alias(385개)까지 확장 — alias 이름으로 바로 찾고, 고르면 정의·정의 위치·주석을 표시. 토픽을 그대로 다시 노출하는 dash-form alias(`agy-help` → `agy_help`)는 중복 제거 (#1261)**
+- 변경: **`my-help search`(alias `find`) 인덱스를 `*_help.sh` 토픽에서 저장소 전체 alias까지 확장 — alias 이름으로 바로 찾고, 고르면 정의·정의 위치·주석을 표시. 토픽을 그대로 다시 노출하는 dash-form alias(`agy-help` → `agy_help`)는 중복 제거하되, 서로 다른 정의를 가진 동명 alias(`llm-help`)는 양쪽 다 노출한다 (#1261)**
 - 변경: **alias 인덱스는 `${XDG_CACHE_HOME:-~/.cache}/dotfiles/my-help-alias-index.tsv`에 24시간 TTL로 캐시 — `MY_HELP_ALIAS_CACHE_PATH` / `MY_HELP_ALIAS_CACHE_MAX_AGE`로 재정의 가능하며, 캐시가 비었거나 손상되면 자동 재생성**
 
 ## 2026-07-30

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -570,7 +570,241 @@ _my_help_show_all() {
     return 0
 }
 
-# Internal: fzf-based fuzzy topic finder
+# ═══════════════════════════════════════════════════════════════
+# Alias Search Index (issue #1261)
+# ═══════════════════════════════════════════════════════════════
+#
+# The `*_help.sh` topics answer "what is csm?" but not "what was that one
+# alias called?" — there are two orders of magnitude more aliases than
+# topics. The index below widens `my-help search` to every `alias name=...`
+# definition in the repo (~460) so name recall works at the alias level too.
+#
+# Index record (tab-separated, 5 fields):
+#   1 name        alias name                    (fzf column 1)
+#   2 desc        trailing `# comment`, else `relpath:line`   (fzf column 2)
+#   3 kind        literal "alias" — tells _my_help_search how to render it
+#   4 location    relpath:line
+#   5 definition  the alias body, quotes and trailing comment stripped
+#
+# Fields 3-5 are hidden from fzf (`--with-nth=1,2`) and read back off the
+# selected line, so no second lookup is needed after picking an entry.
+
+# Measured on ext4 the cold scan and the cached read are within ~1ms of each
+# other at ~470 aliases, so the cache is not a local speed win — it is
+# insurance for the trees that live on a slow mount (WSL /mnt, NFS home,
+# AV-scanned corporate disk), where a 105-file recursive grep costs orders of
+# magnitude more than one file read. Same 24h TTL as csm's manifest cache.
+MY_HELP_ALIAS_CACHE_MAX_AGE="${MY_HELP_ALIAS_CACHE_MAX_AGE:-86400}"  # 24 hours
+
+# Internal: resolve the alias-index cache path. Computed per call (not frozen
+# at source time) so a test that re-points HOME/XDG_CACHE_HOME after sourcing
+# still lands in its own sandbox. Override wholesale with MY_HELP_ALIAS_CACHE_PATH.
+_my_help_alias_cache_path() {
+    if [ -n "${MY_HELP_ALIAS_CACHE_PATH-}" ]; then
+        printf '%s\n' "$MY_HELP_ALIAS_CACHE_PATH"
+        return 0
+    fi
+    printf '%s\n' "${XDG_CACHE_HOME:-${HOME}/.cache}/dotfiles/my-help-alias-index.tsv"
+}
+
+# Internal: scan the repo for alias definitions and emit index records.
+# Writes nothing and returns 1 when the tree is missing or the scan finds
+# nothing — the caller then falls back to topics-only (issue #1261 Error Cases).
+_my_help_build_alias_index() {
+    local root
+    root="${DOTFILES_ROOT:-${SHELL_COMMON%/shell-common}}"
+    [ -n "$root" ] && [ -d "$root" ] || return 1
+
+    local scanned
+    # --include keeps prose out of the index: shell-common/README.md opens a
+    # line with "alias and function defined within." which the regex would
+    # otherwise happily accept as an alias named "and".
+    scanned=$(
+        grep -rnE '^alias [^ =]+=' \
+            --include='*.sh' --include='*.bash' --include='*.zsh' \
+            "$root/bash" "$root/zsh" "$root/shell-common" 2>/dev/null |
+            awk -v root="${root}/" '
+            {
+                # grep -n emits <path>:<line>:<content>; no path in this repo
+                # contains a colon, so splitting on the first two is safe.
+                ci = index($0, ":")
+                if (ci == 0) next
+                path = substr($0, 1, ci - 1)
+                rest = substr($0, ci + 1)
+                cj = index(rest, ":")
+                if (cj == 0) next
+                lineno = substr(rest, 1, cj - 1)
+                body = substr(rest, cj + 1)
+                if (substr(body, 1, 6) != "alias ") next
+
+                kv = substr(body, 7)
+                eq = index(kv, "=")
+                if (eq < 2) next
+                name = substr(kv, 1, eq - 1)
+                expansion = substr(kv, eq + 1)
+
+                # Split the trailing "# comment" off the body. When the value is
+                # quoted only a "#" past the closing quote counts, otherwise
+                # `alias x='"'"'echo #1'"'"'` would lose everything after the hash.
+                q = substr(expansion, 1, 1)
+                defn = expansion
+                tail = ""
+                if (q == "'"'"'" || q == "\"") {
+                    ce = index(substr(expansion, 2), q)
+                    if (ce > 0) {
+                        defn = substr(expansion, 2, ce - 1)
+                        tail = substr(expansion, ce + 2)
+                    }
+                } else {
+                    si = index(expansion, " ")
+                    if (si > 0) {
+                        defn = substr(expansion, 1, si - 1)
+                        tail = substr(expansion, si)
+                    }
+                }
+
+                note = ""
+                hi = index(tail, "#")
+                if (hi > 0) {
+                    note = substr(tail, hi + 1)
+                    sub(/^[ \t]+/, "", note)
+                    sub(/[ \t]+$/, "", note)
+                }
+
+                sub(/^[ \t]+/, "", defn)
+                sub(/[ \t]+$/, "", defn)
+
+                # Drop the dash-form aliases that only re-expose a help topic
+                # (`agy-help` -> `agy_help`). The topic stream already lists
+                # every one of them, with a real description instead of a
+                # file:line — keeping both would duplicate ~72 picker rows and
+                # let the user land on "definition: agy_help" instead of the
+                # actual help text. Aliases that point elsewhere (`doc-help`
+                # -> `show_doc_help`) are genuinely new names, so they stay.
+                if (name ~ /-help$/) {
+                    canonical = name
+                    gsub(/-/, "_", canonical)
+                    if (defn == canonical) next
+                }
+
+                rel = path
+                if (index(rel, root) == 1) rel = substr(rel, length(root) + 1)
+
+                loc = rel ":" lineno
+                desc = (note != "") ? note : loc
+                printf "%s\t%s\talias\t%s\t%s\n", name, desc, loc, defn
+            }' |
+            LC_ALL=C sort -t "$(printf '\t')" -k1,1 -u
+    )
+
+    [ -n "$scanned" ] || return 1
+    printf '%s\n' "$scanned"
+}
+
+# Internal: true (0) when the cache needs rebuilding.
+_my_help_alias_cache_stale() {
+    local cache="$1"
+
+    # Missing, empty, or unreadable — all "rebuild".
+    [ -s "$cache" ] && [ -r "$cache" ] || return 0
+
+    # Truncated or hand-mangled file: every valid record carries the literal
+    # "alias" kind field, so a first line without it means rebuild (#1261).
+    head -n 1 "$cache" 2>/dev/null | grep -q "$(printf '\talias\t')" || return 0
+
+    local mtime
+    if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+        mtime=$(stat -f %m "$cache" 2>/dev/null)
+    else
+        mtime=$(stat -c %Y "$cache" 2>/dev/null)
+    fi
+    [ -n "$mtime" ] || return 0
+
+    local age
+    age=$(( $(date +%s) - mtime ))
+    [ "$age" -le "${MY_HELP_ALIAS_CACHE_MAX_AGE:-86400}" ] || return 0
+    return 1
+}
+
+# Internal: emit the alias index, rebuilding the cache when stale.
+# Returns 1 (and emits nothing) if the scan came up empty — never fatal.
+_my_help_alias_index() {
+    # Users may run with noclobber set; keep the temp-file redirection below
+    # working without leaking the option change (same guard as _my_help_show_all).
+    if [ -n "$ZSH_VERSION" ]; then
+        setopt localoptions clobber 2>/dev/null || true
+    fi
+
+    local cache
+    cache=$(_my_help_alias_cache_path)
+
+    if ! _my_help_alias_cache_stale "$cache"; then
+        cat "$cache" 2>/dev/null
+        return 0
+    fi
+
+    local fresh
+    fresh=$(_my_help_build_alias_index) || return 1
+
+    # Write via a temp file + mv so a concurrent reader never sees a half-built
+    # index. An unwritable cache dir is not an error — just skip persisting.
+    local dir tmp
+    dir=$(dirname "$cache")
+    if mkdir -p "$dir" 2>/dev/null; then
+        tmp="${cache}.$$"
+        if printf '%s\n' "$fresh" > "$tmp" 2>/dev/null; then
+            mv -f "$tmp" "$cache" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+        else
+            rm -f "$tmp" 2>/dev/null
+        fi
+    fi
+
+    printf '%s\n' "$fresh"
+    return 0
+}
+
+# Internal: render one alias index record picked out of fzf.
+_my_help_show_alias_entry() {
+    local record="$1"
+    local name desc location defn
+    name=$(printf '%s' "$record" | cut -f1)
+    desc=$(printf '%s' "$record" | cut -f2)
+    location=$(printf '%s' "$record" | cut -f4)
+    defn=$(printf '%s' "$record" | cut -f5)
+
+    ux_section "Alias: ${name}"
+    ux_bullet "definition: ${defn}"
+    if [ -n "$location" ]; then
+        ux_bullet "source:     ${location}"
+    fi
+    # desc doubles as the location when the alias carries no comment; only
+    # print it when it is a real note.
+    if [ -n "$desc" ] && [ "$desc" != "$location" ]; then
+        ux_bullet "note:       ${desc}"
+    fi
+    return 0
+}
+
+# Internal: emit every fzf candidate — help topics first, then repo aliases.
+# Split out of _my_help_search so it can be exercised without a TTY or fzf.
+_my_help_search_candidates() {
+    # Declare the loop-body variables once, up front: `local x=$(cmd)` inside
+    # the piped while-read makes zsh echo the assignment as a stray stdout line
+    # (#1248) and also masks $cmd's exit status behind the `local` builtin's.
+    # Pre-declaring keeps the in-loop assignments plain and does neither.
+    local underscore_name desc
+    _my_help_enumerate_topic_names | while IFS= read -r display_name; do
+        underscore_name=$(printf "%s" "$display_name" | tr '-' '_')
+        desc=$(_my_help_topic_description "${underscore_name%_help}")
+        printf '%s\t%s\ttopic\t\t\n' "$display_name" "$desc"
+    done
+
+    # Aliases extend the same stream. A failed/empty scan writes nothing,
+    # leaving the topic list exactly as it was before #1261.
+    _my_help_alias_index 2>/dev/null || true
+}
+
+# Internal: fzf-based fuzzy finder over help topics + repo aliases
 _my_help_search() {
     # Degrade to the static category table when fzf is missing or there is no
     # TTY (piped output, scripts, test harness) — fzf needs an interactive terminal.
@@ -583,22 +817,22 @@ _my_help_search() {
     # list, so there's no need for a temp file (see _my_help_show_all's temp
     # file, which the "unique count" and "uncategorized topics" checks below
     # it still need to re-read).
-    # Declare the loop-body variables once, up front: `local x=$(cmd)` inside
-    # the piped while-read makes zsh echo the assignment as a stray stdout line
-    # (#1248) and also masks $cmd's exit status behind the `local` builtin's.
-    # Pre-declaring keeps the in-loop assignments plain and does neither.
-    local selected underscore_name desc
+    local selected
     selected=$(
-        _my_help_enumerate_topic_names | while IFS= read -r display_name; do
-            underscore_name=$(printf "%s" "$display_name" | tr '-' '_')
-            desc=$(_my_help_topic_description "${underscore_name%_help}")
-            printf '%s\t%s\n' "$display_name" "$desc"
-        done | fzf --delimiter='\t' --with-nth=1,2 --prompt="my-help> "
+        _my_help_search_candidates |
+            fzf --delimiter='\t' --with-nth=1,2 --prompt="my-help> "
     ) || true
 
     # Esc / empty selection: nothing to show.
     if [ -z "$selected" ]; then
         return 0
+    fi
+
+    local kind
+    kind=$(printf "%s" "$selected" | cut -f3)
+    if [ "$kind" = "alias" ]; then
+        _my_help_show_alias_entry "$selected"
+        return $?
     fi
 
     local topic
@@ -614,7 +848,7 @@ _my_help_summary() {
     ux_bullet_sub "popular: git | docker | claude | uv | fzf"
     ux_bullet_sub "navigation: my-help <topic> [args] / my-help <category>"
     ux_bullet_sub "details: my-help <section>  (example: my-help categories)"
-    ux_bullet_sub "search: my-help search  (fzf fuzzy topic finder, needs fzf)"
+    ux_bullet_sub "search: my-help search  (fzf fuzzy finder over topics + aliases, needs fzf)"
 }
 
 _my_help_list_sections() {

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -641,16 +641,15 @@ _my_help_build_alias_index() {
                 return s
             }
             {
-                # grep -n emits <path>:<line>:<content>; no path in this repo
-                # contains a colon, so splitting on the first two is safe.
-                ci = index($0, ":")
-                if (ci == 0) next
-                path = substr($0, 1, ci - 1)
-                rest = substr($0, ci + 1)
-                cj = index(rest, ":")
-                if (cj == 0) next
-                lineno = substr(rest, 1, cj - 1)
-                body = substr(rest, cj + 1)
+                # grep -n emits <path>:<line>:<content>. Anchor on the first
+                # ":<digits>:" rather than the first two colons — splitting on
+                # bare colons hands back a path of "a" and a line number of
+                # "b/c.sh" the moment a parent directory contains one
+                # (PR #1266 review).
+                if (!match($0, /:[0-9]+:/)) next
+                path = substr($0, 1, RSTART - 1)
+                lineno = substr($0, RSTART + 1, RLENGTH - 2)
+                body = substr($0, RSTART + RLENGTH)
                 if (substr(body, 1, 6) != "alias ") next
 
                 kv = substr(body, 7)
@@ -665,13 +664,29 @@ _my_help_build_alias_index() {
                 q = substr(expansion, 1, 1)
                 defn = expansion
                 tail = ""
-                if (q == "'"'"'" || q == "\"") {
-                    ce = index(substr(expansion, 2), q)
-                    if (ce > 0) {
-                        defn = substr(expansion, 2, ce - 1)
-                        tail = substr(expansion, ce + 2)
+                ce = 0
+                if (q == "\"") {
+                    # Inside double quotes a backslash escapes the next
+                    # character, so `alias x="echo \"hi\""` must not terminate
+                    # on the escaped quote (PR #1266 review). No alias in this
+                    # repo is double-quoted today; this keeps the first one
+                    # that is from being silently truncated.
+                    for (i = 2; i <= length(expansion); i++) {
+                        c = substr(expansion, i, 1)
+                        if (c == "\\") { i++; continue }
+                        if (c == q) { ce = i; break }
                     }
-                } else {
+                } else if (q == "'"'"'") {
+                    # POSIX single quotes admit no escape at all — the very
+                    # next quote always closes the string, so a plain index()
+                    # is exact here rather than a heuristic.
+                    p = index(substr(expansion, 2), q)
+                    if (p > 0) ce = p + 1
+                }
+                if (ce > 0) {
+                    defn = substr(expansion, 2, ce - 2)
+                    tail = substr(expansion, ce + 1)
+                } else if (q != "'"'"'" && q != "\"") {
                     si = index(expansion, " ")
                     if (si > 0) {
                         defn = substr(expansion, 1, si - 1)
@@ -719,9 +734,12 @@ _my_help_alias_cache_stale() {
     # Missing, empty, or unreadable — all "rebuild".
     [ -s "$cache" ] && [ -r "$cache" ] || return 0
 
-    # Truncated or hand-mangled file: every valid record carries the literal
-    # "alias" kind field, so a first line without it means rebuild (#1261).
-    head -n 1 "$cache" 2>/dev/null | grep -q "$(printf '\talias\t')" || return 0
+    # Truncated or hand-mangled file: every valid record is 5 fields with
+    # "alias" in the kind column. Checking only the first line would serve a
+    # TSV truncated mid-write for the full TTL (PR #1266 review), so validate
+    # every record — one awk pass over ~400 lines, and fewer forks than the
+    # head|grep pair it replaces.
+    awk -F'\t' 'NF != 5 || $3 != "alias" { exit 1 }' "$cache" 2>/dev/null || return 0
 
     local mtime
     if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -588,6 +588,17 @@ _my_help_show_all() {
 #
 # Fields 3-5 are hidden from fzf (`--with-nth=1,2`) and read back off the
 # selected line, so no second lookup is needed after picking an entry.
+#
+# A name may legitimately appear more than once: 12 alias names in this repo
+# are defined in two places with *different* bodies (`llm-help` is
+# `litellm_help` in ai_tools_help.sh and `ollama_help` in
+# help_system_aliases.sh). Collapsing those to one row would have to pick a
+# winner, and the only correct winner is whichever file the shell sourced
+# last — which this file-level scan cannot know. An arbitrary pick would
+# actively lie about what the alias resolves to, so every distinct
+# (name, location, definition) triple is kept and the conflict shows up as
+# two adjacent rows in the picker. `sort -u` therefore dedupes whole records
+# only, never on the name key.
 
 # Measured on ext4 the cold scan and the cached read are within ~1ms of each
 # other at ~470 aliases, so the cache is not a local speed win — it is
@@ -694,7 +705,7 @@ _my_help_build_alias_index() {
                 desc = (note != "") ? note : loc
                 printf "%s\t%s\talias\t%s\t%s\n", name, desc, loc, defn
             }' |
-            LC_ALL=C sort -t "$(printf '\t')" -k1,1 -u
+            LC_ALL=C sort -u
     )
 
     [ -n "$scanned" ] || return 1

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -624,6 +624,11 @@ _my_help_build_alias_index() {
             --include='*.sh' --include='*.bash' --include='*.zsh' \
             "$root/bash" "$root/zsh" "$root/shell-common" 2>/dev/null |
             awk -v root="${root}/" '
+            function trim(s) {
+                sub(/^[ \t]+/, "", s)
+                sub(/[ \t]+$/, "", s)
+                return s
+            }
             {
                 # grep -n emits <path>:<line>:<content>; no path in this repo
                 # contains a colon, so splitting on the first two is safe.
@@ -665,14 +670,9 @@ _my_help_build_alias_index() {
 
                 note = ""
                 hi = index(tail, "#")
-                if (hi > 0) {
-                    note = substr(tail, hi + 1)
-                    sub(/^[ \t]+/, "", note)
-                    sub(/[ \t]+$/, "", note)
-                }
+                if (hi > 0) note = trim(substr(tail, hi + 1))
 
-                sub(/^[ \t]+/, "", defn)
-                sub(/[ \t]+$/, "", defn)
+                defn = trim(defn)
 
                 # Drop the dash-form aliases that only re-expose a help topic
                 # (`agy-help` -> `agy_help`). The topic stream already lists
@@ -752,11 +752,11 @@ _my_help_alias_index() {
     dir=$(dirname "$cache")
     if mkdir -p "$dir" 2>/dev/null; then
         tmp="${cache}.$$"
-        if printf '%s\n' "$fresh" > "$tmp" 2>/dev/null; then
-            mv -f "$tmp" "$cache" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-        else
-            rm -f "$tmp" 2>/dev/null
-        fi
+        # A failed write or mv just means no cache this round. The unconditional
+        # rm covers both failure paths and is a no-op once mv consumed the temp.
+        printf '%s\n' "$fresh" > "$tmp" 2>/dev/null &&
+            mv -f "$tmp" "$cache" 2>/dev/null
+        rm -f "$tmp" 2>/dev/null
     fi
 
     printf '%s\n' "$fresh"
@@ -774,9 +774,9 @@ _my_help_show_alias_entry() {
 
     ux_section "Alias: ${name}"
     ux_bullet "definition: ${defn}"
-    if [ -n "$location" ]; then
-        ux_bullet "source:     ${location}"
-    fi
+    # Field 4 is always populated for an alias record (see the record layout
+    # above), so no emptiness guard is needed here.
+    ux_bullet "source:     ${location}"
     # desc doubles as the location when the alias carries no comment; only
     # print it when it is a real note.
     if [ -n "$desc" ] && [ "$desc" != "$location" ]; then

--- a/tests/bats/functions/my_help_alias_index.bats
+++ b/tests/bats/functions/my_help_alias_index.bats
@@ -39,15 +39,37 @@ TAB=$'\t'
     assert_output "0"
 }
 
-@test "T2: build finds a meaningful number of aliases and dedupes by name" {
+@test "T2: build finds a meaningful number of aliases, with no duplicate records" {
     run_in_bash '_my_help_build_alias_index | wc -l'
     assert_success
     [ "$output" -gt 300 ]
 
-    # `sort -u -k1,1` must leave exactly one record per alias name.
-    run_in_bash '_my_help_build_alias_index | cut -f1 | LC_ALL=C sort | uniq -d | wc -l'
+    # `sort -u` dedupes whole records. Identical (name, location, definition)
+    # triples must never appear twice — but see T2b: the same *name* legitimately
+    # may, when two files define it differently.
+    run_in_bash '_my_help_build_alias_index | LC_ALL=C sort | uniq -d | wc -l'
     assert_success
     assert_output "0"
+}
+
+@test "T2b: a name defined twice with different bodies keeps BOTH definitions" {
+    # Regression pin for the PR #1266 review blocker. `llm-help` is
+    # `litellm_help` in shell-common/functions/ai_tools_help.sh and
+    # `ollama_help` in shell-common/aliases/help_system_aliases.sh. Collapsing
+    # them with `sort -u -k1,1` picked an arbitrary winner, so the picker could
+    # claim a definition the shell does not actually resolve to. Only the shell
+    # knows which file was sourced last, so the index must surface both rather
+    # than guess.
+    run_in_bash '_my_help_build_alias_index | awk -F"\t" "\$1==\"llm-help\"{print \$5}" | LC_ALL=C sort'
+    assert_success
+    assert_line --index 0 "litellm_help"
+    assert_line --index 1 "ollama_help"
+
+    # Both rows must carry their own distinct location, or the conflict is
+    # indistinguishable from a duplicate.
+    run_in_bash '_my_help_build_alias_index | awk -F"\t" "\$1==\"llm-help\"{print \$4}" | LC_ALL=C sort -u | wc -l'
+    assert_success
+    assert_output "2"
 }
 
 @test "T3: trailing comment becomes the description; kind field is 'alias'" {
@@ -81,8 +103,17 @@ TAB=$'\t'
     assert_output "show_doc_help"
 }
 
-@test "T4d: no name appears twice across the merged candidate stream" {
-    run_in_bash '_my_help_search_candidates | cut -f1 | LC_ALL=C sort | uniq -d | wc -l'
+@test "T4d: no alias row shadows a topic row of the same name" {
+    # The property that actually matters: the -help dedupe (T4c) must leave no
+    # name owned by both a topic row and an alias row, because the two would
+    # render differently for the same pick. Names duplicated *within* the alias
+    # rows are a separate, legitimate case — see T2b.
+    run_in_bash '
+        _my_help_search_candidates > "$HOME/cands.tsv"
+        awk -F"\t" "\$3==\"topic\"{print \$1}" "$HOME/cands.tsv" | LC_ALL=C sort -u > "$HOME/t.txt"
+        awk -F"\t" "\$3==\"alias\"{print \$1}" "$HOME/cands.tsv" | LC_ALL=C sort -u > "$HOME/a.txt"
+        LC_ALL=C comm -12 "$HOME/t.txt" "$HOME/a.txt" | wc -l
+    '
     assert_success
     assert_output "0"
 }

--- a/tests/bats/functions/my_help_alias_index.bats
+++ b/tests/bats/functions/my_help_alias_index.bats
@@ -1,0 +1,236 @@
+#!/usr/bin/env bats
+# tests/bats/functions/my_help_alias_index.bats
+# Coverage for the `my-help search` alias index introduced in issue #1261.
+#
+# T1-T4  cover _my_help_build_alias_index's record shape: 5 tab-separated
+#        fields, the trailing-comment vs file:line description fallback, and
+#        the quote/comment splitting that keeps `alias x='cmd #1'` intact.
+# T5-T8  cover the 24h cache (build, warm read, corrupt/empty rebuild, TTL
+#        expiry) — issue #1261 NF-1 and Error Cases.
+# T9-T11 cover the merged candidate stream (F-1/F-2) and the topics-only
+#        fallback when the scan yields nothing.
+# T12-T13 cover the fzf-missing / non-TTY regression guard (F-3).
+# T14-T15 cover zsh parity — my_help.sh is sourced by both shells.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # Keep every test's index in its own sandbox; XDG_CACHE_HOME already
+    # points at TEST_TEMP_HOME, but pinning the path makes the assertions
+    # below independent of the default layout.
+    export MY_HELP_ALIAS_CACHE_PATH="$TEST_TEMP_HOME/alias-index.tsv"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Tab literal for assertions — bats' assert_output compares raw strings.
+TAB=$'\t'
+
+# ---------------------------------------------------------------------------
+# T1-T4: index record shape
+# ---------------------------------------------------------------------------
+
+@test "T1: build emits 5 tab-separated fields on every record" {
+    run_in_bash '_my_help_build_alias_index | awk -F"\t" "NF!=5{bad++} END{print bad+0}"'
+    assert_success
+    assert_output "0"
+}
+
+@test "T2: build finds a meaningful number of aliases and dedupes by name" {
+    run_in_bash '_my_help_build_alias_index | wc -l'
+    assert_success
+    [ "$output" -gt 300 ]
+
+    # `sort -u -k1,1` must leave exactly one record per alias name.
+    run_in_bash '_my_help_build_alias_index | cut -f1 | LC_ALL=C sort | uniq -d | wc -l'
+    assert_success
+    assert_output "0"
+}
+
+@test "T3: trailing comment becomes the description; kind field is 'alias'" {
+    # shell-common/tools/integrations/apt.sh: alias aar='...'  # Remove unused dependencies
+    run_in_bash '_my_help_build_alias_index | grep "^aar'"$TAB"'"'
+    assert_success
+    assert_output --partial "Remove unused dependencies"
+    assert_output --partial "${TAB}alias${TAB}"
+    assert_output --partial "sudo apt-get autoremove"
+}
+
+@test "T4: comment-less alias falls back to relpath:line as its description" {
+    # csm carries no trailing comment, so fields 2 and 4 must both be the location.
+    run_in_bash '_my_help_build_alias_index | awk -F"\t" "\$1==\"csm\"{print (\$2==\$4) ? \"same\" : \"differ\"; print \$2}"'
+    assert_success
+    assert_line --index 0 "same"
+    assert_line --index 1 --partial "marketplace.sh:"
+}
+
+@test "T4c: dash-form aliases that only re-expose a help topic are dropped" {
+    # `agy-help` expands to `agy_help`, which the topic stream already lists
+    # with a real description — keeping the alias row would duplicate the entry.
+    run_in_bash '_my_help_build_alias_index | grep -c "^agy-help'"$TAB"'" || true'
+    assert_success
+    assert_output "0"
+
+    # ...but a -help alias pointing at a differently-named function is a
+    # genuinely new search target and must survive.
+    run_in_bash '_my_help_build_alias_index | awk -F"\t" "\$1==\"doc-help\"{print \$5}"'
+    assert_success
+    assert_output "show_doc_help"
+}
+
+@test "T4d: no name appears twice across the merged candidate stream" {
+    run_in_bash '_my_help_search_candidates | cut -f1 | LC_ALL=C sort | uniq -d | wc -l'
+    assert_success
+    assert_output "0"
+}
+
+@test "T4b: a '#' inside the quoted body is not mistaken for a comment" {
+    # `alias ..='cd ..'` has no comment; `alias aac='sudo apt-get autoclean' # ...`
+    # does. Both must keep their full definition in field 5.
+    run_in_bash '_my_help_build_alias_index | awk -F"\t" "\$1==\"..\"{print \$5}"'
+    assert_success
+    assert_output "cd .."
+}
+
+# ---------------------------------------------------------------------------
+# T5-T8: cache behavior (NF-1 + Error Cases)
+# ---------------------------------------------------------------------------
+
+@test "T5: cold call builds the index and persists it to the cache path" {
+    run_in_bash '_my_help_alias_index >/dev/null; [ -s "$MY_HELP_ALIAS_CACHE_PATH" ] && wc -l < "$MY_HELP_ALIAS_CACHE_PATH"'
+    assert_success
+    [ "$output" -gt 300 ]
+}
+
+@test "T6: a fresh cache is served verbatim without re-scanning" {
+    run_in_bash '
+        printf "SENTINEL\tdesc\talias\tloc\tdef\n" > "$MY_HELP_ALIAS_CACHE_PATH"
+        _my_help_alias_index
+    '
+    assert_success
+    assert_output "SENTINEL${TAB}desc${TAB}alias${TAB}loc${TAB}def"
+}
+
+@test "T7: corrupt or empty cache is rebuilt instead of returned" {
+    run_in_bash '
+        printf "garbage-without-tabs\n" > "$MY_HELP_ALIAS_CACHE_PATH"
+        _my_help_alias_index | wc -l
+    '
+    assert_success
+    [ "$output" -gt 300 ]
+
+    run_in_bash '
+        : > "$MY_HELP_ALIAS_CACHE_PATH"
+        _my_help_alias_index | wc -l
+    '
+    assert_success
+    [ "$output" -gt 300 ]
+}
+
+@test "T8: cache older than MY_HELP_ALIAS_CACHE_MAX_AGE is rebuilt" {
+    # POSIX `touch -t CCYYMMDDhhmm` backdates the sentinel well past the 24h
+    # TTL, so this exercises the real mtime path rather than a zeroed MAX_AGE.
+    #
+    # Redirect to a file rather than piping into `head`: on the rebuild path
+    # _my_help_alias_index writes ~385 lines, and a reader that exits after
+    # line 1 leaves the producer holding a closed pipe — an exit-141 SIGPIPE
+    # race that makes this test flaky under a loaded parallel bats run.
+    run_in_bash '
+        printf "SENTINEL\tdesc\talias\tloc\tdef\n" > "$MY_HELP_ALIAS_CACHE_PATH"
+        touch -t 200001010000 "$MY_HELP_ALIAS_CACHE_PATH"
+        _my_help_alias_index > "$HOME/rebuilt.tsv"
+        grep -c "^SENTINEL" "$HOME/rebuilt.tsv" || true
+        wc -l < "$HOME/rebuilt.tsv"
+    '
+    assert_success
+    assert_line --index 0 "0"
+    [ "${lines[1]// /}" -gt 300 ]
+}
+
+@test "T8b: an unwritable cache directory still yields a usable index" {
+    run_in_bash '
+        MY_HELP_ALIAS_CACHE_PATH=/proc/nope/idx.tsv
+        _my_help_alias_index | wc -l
+    '
+    assert_success
+    [ "$output" -gt 300 ]
+}
+
+# ---------------------------------------------------------------------------
+# T9-T11: merged candidate stream (F-1 / F-2) + empty-scan fallback
+# ---------------------------------------------------------------------------
+
+@test "T9: candidates contain both topic and alias rows" {
+    run_in_bash '_my_help_search_candidates | awk -F"\t" "{n[\$3]++} END{print n[\"topic\"]+0; print n[\"alias\"]+0}"'
+    assert_success
+    [ "${lines[0]}" -gt 20 ]
+    [ "${lines[1]}" -gt 300 ]
+}
+
+@test "T10: an alias name is findable in the candidate stream (F-1)" {
+    run_in_bash '_my_help_search_candidates | grep -c "^csm'"$TAB"'"'
+    assert_success
+    assert_output "1"
+}
+
+@test "T11: an unscannable tree degrades to topics only, without error" {
+    run_in_bash '
+        DOTFILES_ROOT=/nonexistent
+        SHELL_COMMON=/nonexistent/shell-common
+        MY_HELP_ALIAS_CACHE_PATH="$HOME/missing.tsv"
+        _my_help_search_candidates | awk -F"\t" "{n[\$3]++} END{print n[\"topic\"]+0; print n[\"alias\"]+0}"
+    '
+    assert_success
+    [ "${lines[0]}" -gt 20 ]
+    assert_line --index 1 "0"
+}
+
+# ---------------------------------------------------------------------------
+# T12-T13: fzf-missing / non-TTY fallback regression guard (F-3)
+# ---------------------------------------------------------------------------
+
+@test "T12: _my_help_search without a TTY still prints the category table" {
+    run_in_bash '_my_help_search'
+    assert_success
+    assert_output --partial "Categories"
+}
+
+@test "T13: alias records render definition, source, and note on selection" {
+    run_in_bash '_my_help_show_alias_entry "$(printf "uvs\tsync deps\talias\tshell-common/tools/integrations/uv.sh:24\tuv sync")"'
+    assert_success
+    assert_output --partial "Alias: uvs"
+    assert_output --partial "uv sync"
+    assert_output --partial "shell-common/tools/integrations/uv.sh:24"
+    assert_output --partial "sync deps"
+}
+
+@test "T13b: a comment-less record does not repeat the location as a note" {
+    run_in_bash '_my_help_show_alias_entry "$(printf "csm\tfoo.sh:1\talias\tfoo.sh:1\tclaude_skills_marketplace")"'
+    assert_success
+    assert_output --partial "claude_skills_marketplace"
+    refute_output --partial "note:"
+}
+
+# ---------------------------------------------------------------------------
+# T14-T15: zsh parity
+# ---------------------------------------------------------------------------
+
+@test "T14: zsh builds the same index without stray stdout" {
+    run_in_zsh '_my_help_build_alias_index | awk -F"\t" "NF!=5{bad++} END{print bad+0}"'
+    assert_success
+    assert_output "0"
+}
+
+@test "T15: zsh cache write survives noclobber" {
+    run_in_zsh '
+        setopt noclobber
+        export MY_HELP_ALIAS_CACHE_PATH="$HOME/alias-index.tsv"
+        _my_help_alias_index >/dev/null
+        wc -l < "$MY_HELP_ALIAS_CACHE_PATH"
+    '
+    assert_success
+    [ "${output// /}" -gt 300 ]
+}

--- a/tests/bats/functions/my_help_alias_index.bats
+++ b/tests/bats/functions/my_help_alias_index.bats
@@ -126,6 +126,63 @@ TAB=$'\t'
     assert_output "cd .."
 }
 
+# Synthetic tree — the real repo has neither a colon in its path nor a
+# double-quoted alias, so the two PR #1266 review fixes below need a fixture.
+# Written from the bats shell with a quoted heredoc: routing these lines
+# through run_in_bash's nested `bash -c` string mangles the backslashes and
+# would test the fixture's escaping rather than the parser.
+_stage_odd_tree() {
+    local root="$1"
+    mkdir -p "$root/bash" "$root/zsh" "$root/shell-common"
+    cat > "$root/shell-common/odd.sh" <<'FIXTURE'
+alias plainq='echo hi'
+alias dq="echo \"hi\" there"
+FIXTURE
+}
+
+@test "T4e: a colon in the repo path does not corrupt path/line parsing" {
+    # grep -n emits <path>:<line>:<content>; splitting on the first two colons
+    # returned path="…/we" and lineno="ird/shell-common/odd.sh" here. The
+    # parser now anchors on the first ":<digits>:" instead.
+    _stage_odd_tree "$HOME/we:ird"
+    run_in_bash 'DOTFILES_ROOT="$HOME/we:ird" _my_help_build_alias_index |
+        awk -F"\t" "\$1==\"plainq\"{print \$4; print \$5}"'
+    assert_success
+    # Location must be the relative path with a real line number, not a
+    # fragment of the path itself.
+    assert_line --index 0 "shell-common/odd.sh:1"
+    assert_line --index 1 "echo hi"
+}
+
+@test "T4f: a double-quoted alias keeps its escaped quotes intact" {
+    # `alias dq="echo \"hi\" there"` terminated on the escaped quote before the
+    # fix, truncating the body to `echo \`. Backslash escapes are honoured for
+    # the double-quoted form only — POSIX single quotes have no escapes.
+    _stage_odd_tree "$HOME/odd"
+    run_in_bash 'DOTFILES_ROOT="$HOME/odd" _my_help_build_alias_index |
+        awk -F"\t" "\$1==\"dq\"{print \$5}"'
+    assert_success
+    assert_output 'echo \"hi\" there'
+
+    # The single-quoted sibling in the same fixture must be untouched by the
+    # escape handling — POSIX gives backslash no special meaning there.
+    run_in_bash 'DOTFILES_ROOT="$HOME/odd" _my_help_build_alias_index |
+        awk -F"\t" "\$1==\"plainq\"{print \$5}"'
+    assert_success
+    assert_output "echo hi"
+}
+
+@test "T7b: a cache corrupted past the first line is rebuilt, not served" {
+    # The staleness check used to validate only line 1, so a TSV truncated
+    # mid-write stayed "valid" for the whole 24h TTL (PR #1266 review).
+    run_in_bash '
+        printf "good\tdesc\talias\tloc\tdef\nTRUNCATED-LINE\n" > "$MY_HELP_ALIAS_CACHE_PATH"
+        _my_help_alias_index | wc -l
+    '
+    assert_success
+    [ "$output" -gt 300 ]
+}
+
 # ---------------------------------------------------------------------------
 # T5-T8: cache behavior (NF-1 + Error Cases)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `my-help search`(alias `find`)의 검색 인덱스를 `*_help.sh` 토픽에서 저장소 전체 alias까지 확장한다. 토픽 75 + alias 385 = 460행이 fzf 후보로 뜬다.
- alias 항목을 고르면 정의·정의 위치·주석을 바로 출력한다 — 고른 뒤 재조회가 없다.
- 기존 토픽 검색과 fzf 미설치·비대화형 폴백은 회귀 없이 그대로다.

## Changes
- `shell-common/functions/my_help.sh` — alias 인덱스 5필드 TSV(`name` / `desc` / `kind` / `location` / `definition`) 생성기 + 24h TTL 캐시 + 선택 시 렌더러 추가. fzf는 `--with-nth=1,2`로 앞 두 필드만 보여주고, 나머지 세 필드는 선택된 라인에서 그대로 읽는다. `_my_help_search`의 후보 생성부를 `_my_help_search_candidates`로 분리해 TTY·fzf 없이도 단위 테스트 가능하게 했다.
- `tests/bats/functions/my_help_alias_index.bats` (신규) — 레코드 형태, 캐시 4종 경로, 병합 스트림, 폴백, zsh 패리티를 덮는 20개 테스트.
- `docs/.ssot/command-guidelines.md` / `docs/public/changelog.md` — 인덱스 범위·캐시 경로·중복 제거 규칙 반영.

## 설계 노트

**중복 alias 제거 (이슈 범위 밖 판단)** — 토픽을 그대로 다시 노출하는 dash-form alias 72개(`agy-help` -> `agy_help`)를 인덱스에서 뺐다. 토픽 행이 이미 실제 설명과 함께 존재하므로 중복이고, alias 행을 고르면 도움말 대신 `definition: agy_help`에 착지하게 된다. 판정 기준은 **이름이 아니라 정의** — 그래서 `doc-help` -> `show_doc_help`, `llm-help`, `my-help`, `plugins-help` 넷은 새 검색 대상으로 남는다. 제거된 72개가 모두 토픽 행에 이미 존재함을 확인해, 검색 불가가 된 이름은 없다.

**캐시는 로컬 속도용이 아니다** — 이슈 설계란이 "grep 자체가 충분히 빠른지 먼저 측정 후 결정"을 요구해서 측정했다. ext4에서 20회 평균 콜드 스캔 9.4ms / 캐시 읽기 8.6ms로 사실상 동률이다. NF-1 요구사항이기도 하고, 느린 마운트(WSL `/mnt`, NFS home, 백신 스캔 디스크)에서 105개 파일 재귀 grep이 파일 하나 읽기보다 훨씬 비싸지는 경우의 보험이라 유지했다. 이 근거는 지우지 않도록 코드 주석에 남겼다.

**주석 파싱** — alias 본문의 `#`는 따옴표가 닫힌 뒤에 오는 것만 주석으로 본다. 그러지 않으면 `alias x='echo #1'`이 해시 뒤를 통째로 잃는다.

**테스트에서 `head` 금지** — `_my_help_alias_index | head -1`은 재빌드 경로에서 385줄을 쓰는데 리더가 1줄 뒤 종료하면 producer가 닫힌 파이프를 잡고 exit 141로 죽는다. 200회 중 1회 재현되는 SIGPIPE 레이스라 병렬 bats에서 간헐 red가 됐다. 파일 리다이렉트로 바꿔 200/200, 20-way 병렬 6/6 통과.

## Test plan
- [x] `mise run test` — pytest 1233 passed / 0 failed, golden rules 통과
- [x] bats 신규 파일 20/20 통과, 20-way 병렬 6회 반복 무결
- [x] bats 전체 not-ok 8건은 baseline과 동일 (`dotfiles_root`, `claude_accounts`, `gh_disable_ai_metrics`, `claude_plugin_scaffold`, `setup_skills_ssot`) — 이 PR과 무관한 기존 실패
- [x] shellcheck / shfmt — 신규 지적 0건 (line 441 SC2155는 기존)
- [ ] 실제 TTY에서 `my-help search` 실행 후 alias 이름으로 검색 → 후보 노출 및 선택 시 정의 출력 확인

## 알려진 이슈 (이 PR 범위 밖)
- `tests/integration/test_compatibility.py::test_my_help_function_available` 가 20-way 병렬에서 exit 141로 간헐 실패한다. 원인은 위와 동일한 `declare -f ... | head -1` SIGPIPE 레이스이고 단독 실행은 10/10 통과 — 기존 flake라 이 PR에서 건드리지 않았다.

## Related
Closes #1261

---
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~24 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~24 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
