### PR TITLE
fix(claude/skills): restore /code-review model-invocation

### DIFF
--- a/claude/skills/code-review/SKILL.md
+++ b/claude/skills/code-review/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: code-review
+description: Code review a pull request
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)
+context: fork
+metadata:
+  model_recommendation:
+    tier: sonnet
+    reason: "multi-agent PR review orchestration + confidence-scored comment posting; no deep implementation or conflict resolution"
+    claude: prefer
+    non_claude: advisory-only
+---
+
+Provide a code review for the given pull request.
+
+To do this, follow these steps precisely:
+
+1. Use a Haiku agent to check if the pull request (a) is closed, (b) is a draft, (c) does not need a code review (eg. because it is an automated pull request, or is very simple and obviously ok), or (d) already has a code review from you from earlier. If so, do not proceed.
+2. Use another Haiku agent to give you a list of file paths to (but not the contents of) any relevant CLAUDE.md files from the codebase: the root CLAUDE.md file (if one exists), as well as any CLAUDE.md files in the directories whose files the pull request modified
+3. Use a Haiku agent to view the pull request, and ask the agent to return a summary of the change
+4. Then, launch 5 parallel Sonnet agents to independently code review the change. The agents should do the following, then return a list of issues and the reason each issue was flagged (eg. CLAUDE.md adherence, bug, historical git context, etc.):
+   a. Agent #1: Audit the changes to make sure they compily with the CLAUDE.md. Note that CLAUDE.md is guidance for Claude as it writes code, so not all instructions will be applicable during code review.
+   b. Agent #2: Read the file changes in the pull request, then do a shallow scan for obvious bugs. Avoid reading extra context beyond the changes, focusing just on the changes themselves. Focus on large bugs, and avoid small issues and nitpicks. Ignore likely false positives.
+   c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
+   d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current pull request.
+   e. Agent #5: Read code comments in the modified files, and make sure the changes in the pull request comply with any guidance in the comments.
+5. For each issue found in #4, launch a parallel Haiku agent that takes the PR, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
+   a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
+   b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
+   c. 50: Moderately confident. The agent was able to verify this is a real issue, but it might be a nitpick or not happen very often in practice. Relative to the rest of the PR, it's not very important.
+   d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
+   e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
+6. Filter out any issues with a score less than 80. If there are no issues that meet this criteria, do not proceed.
+7. Use a Haiku agent to repeat the eligibility check from #1, to make sure that the pull request is still eligible for code review.
+8. Finally, use the gh bash command to comment back on the pull request with the result. When writing your comment, keep in mind to:
+   a. Keep your output brief
+   b. Avoid emojis
+   c. Link and cite relevant code, files, and URLs
+
+Examples of false positives, for steps 4 and 5:
+
+- Pre-existing issues
+- Something that looks like a bug but is not actually a bug
+- Pedantic nitpicks that a senior engineer wouldn't call out
+- Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
+- General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
+- Changes in functionality that are likely intentional or are directly related to the broader change
+- Real issues, but on lines that the user did not modify in their pull request
+
+Notes:
+
+- Do not check build signal or attempt to build or typecheck the app. These will run separately, and are not relevant to your code review.
+- Use `gh` to interact with Github (eg. to fetch a pull request, or to create inline comments), rather than web fetch
+- Make a todo list first
+- You must cite and link each bug (eg. if referring to a CLAUDE.md, you must link it)
+- For your final comment, follow the following format precisely (assuming for this example that you found 3 issues):
+
+---
+
+### Code review
+
+Found 3 issues:
+
+1. <brief description of bug> (CLAUDE.md says "<...>")
+
+<link to file and line with full sha1 + line range for context, note that you MUST provide the full sha and not use bash here, eg. https://github.com/anthropics/claude-code/blob/1d54823877c4de72b2316a64032a54afc404e619/README.md#L13-L17>
+
+2. <brief description of bug> (some/other/CLAUDE.md says "<...>")
+
+<link to file and line with full sha1 + line range for context>
+
+3. <brief description of bug> (bug due to <file and code snippet>)
+
+<link to file and line with full sha1 + line range for context>
+
+Generated with Claude Code (https://claude.ai/code)
+
+---
+
+- Or, if you found no issues:
+
+---
+
+### Code review
+
+No issues found. Checked for bugs and CLAUDE.md compliance.
+
+Generated with Claude Code (https://claude.ai/code)
+
+- When linking to code, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/anthropics/claude-cli-internal/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
+  - Requires full git sha
+  - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
+  - Repo name must match the repo you're code reviewing
+  - # sign after the file name
+  - Line range format is L[start]-L[end]
+  - Provide at least 1 line of context before and after, centered on the line you are commenting about (eg. if you are commenting about lines 5-6, you should link to `L4-7`)


### PR DESCRIPTION
## Summary
- Claude Code v2.1.215부터 `/code-review`, `/verify` 는 model-invocation 이 하드코딩으로 차단된 bundled skill 이 됐다(공식 문서: "Before v2.1.215, Claude could also run `/verify` and `/code-review` on its own."). `devx:pr-review-all` 의 auto-fix 체인이 이 벽에 그대로 부딪혀 `Skill(code-review, "--fix")` 호출이 매번 거부된다.
- 이 플랫폼 제약은 dotfiles 설정으로 되돌릴 수 없다 — 공식 문서에 따르면 personal/project 레벨 스킬이 동일 이름의 bundled skill 을 오버라이드한다는 점을 이용해, `disable-model-invocation` 없는 `code-review` 스킬을 dotfiles SSOT 로 배포해 model-invocation 을 복원한다.

## Changes
- `claude/skills/code-review/SKILL.md` (신규): Anthropic 이 작성한 원본 code-review 플러그인 콘텐츠(현재 `~/.claude-shared/plugins/.../code-review/`, `.orphaned_at` 로 표시된 채 남아있음 — 기능이 in-CLI bundled skill 로 이동하면서 고아가 된 캐시)를 거의 그대로 이식했다. `disable-model-invocation` 를 넣지 않아 v2.1.215 이전과 동일하게 모델이 Skill tool 로 다시 호출할 수 있다.
  - 의도적 변경 1개: PR 코멘트 템플릿의 `🤖`/`👍`/`👎` 이모지 제거 — 이 repo CLAUDE.md 의 "No emojis anywhere"(ai-metrics 블록만 예외) 정책 위반이라 삭제.
  - `metadata.model_recommendation` 추가(#809 SSOT): tier=sonnet, reason/compatibility 포함 — `skill:check` PASS.

## Test plan
- [x] `skill:check claude/skills/code-review` 실행 — 남은 FAIL/WARN 은 모두 원본 콘텐츠 충실 이식에 따른 의도된 트레이드오프(help flag 없음, references/ 미분리 등, 상세는 리뷰 코멘트 참고)로 확인.
- [x] pre-commit hook 통과.
- [ ] 머지 후 수동 확인: `~/dotfiles` (live checkout) 를 `main` 으로 갱신 + `./setup.sh` 재실행 후 새 세션에서 Claude 가 `Skill(code-review, ...)` 를 다시 호출할 수 있는지 확인 (플랫폼 제약이라 자동화된 유닛 테스트로는 검증 불가 — 실 세션 확인 필요).

## Related
없음 — 이슈 #1258 흐름과 무관한 별개 이슈.
