### PR TITLE
fix(claude/skills): devx:pr-review-all 의 죽은 /code-review 레인 제거

### DIFF
--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -2,9 +2,9 @@
 name: devx:pr-review-all
 description: >-
   Fan out every available reviewer on one PR in parallel — agy ∥ codex
-  second opinions ∥ a sequential /code-review --fix → /simplify auto-fix
-  chain (each sub-step commits its own changes) — then run a reply pass over
-  the review comments. Use for /devx:pr-review-all, /devx-pr-review-all,
+  second opinions ∥ a /simplify auto-fix pass (which commits its own
+  changes) — then run a reply pass over the review comments.
+  Use for /devx:pr-review-all, /devx-pr-review-all,
   "PR 다중 리뷰어 병렬로", "agy codex simplify 한번에 돌려",
   "PR 99 전체 리뷰". A composition skill — distinct from gh:pr-review
   (single external AI, one comment). Reused by gh:issue-flow as its post-PR
@@ -24,8 +24,8 @@ metadata:
 ## Role
 
 Orchestrate a single PR through all available reviewers at once (agy ∥
-codex ∥ `/code-review --fix` → `/simplify`), commit any auto-fix changes per
-sub-step, then reply to the review comments — inline (deterministic) or
+codex ∥ `/simplify`), commit any auto-fix changes, then reply to the review
+comments — inline (deterministic) or
 deferred. No approve / request-changes decision (that is `gh:pr-approve`) and
 no per-comment authoring beyond the delegated `gh:pr-reply`. Every reviewer is
 soft-fail: a missing CLI or a transient error skips that one lane and the
@@ -55,43 +55,38 @@ print the stderr line and stop. Capture `pr`, `remote`, `reply_mode`
 - `gh auth status` returns 0 → else exit 1 with the gh error line.
 - **auto-fix branch context**: if the current branch is not the PR head
   branch, run `gh pr checkout <pr> -R <TARGET_REPO>`; if already on it (e.g.
-  the issue-flow worktree path), skip. `/code-review --fix` and `/simplify`
-  both ignore PR# and act on the working tree, so this checkout is
-  load-bearing (`references/constraints.md`).
+  the issue-flow worktree path), skip. `/simplify` ignores PR# and acts on
+  the working tree, so this checkout is load-bearing
+  (`references/constraints.md`).
 
 ## Step 3: Review + auto-fix gate (dispatch all lanes in ONE turn)
 
 The three lanes dispatch together in a single turn. agy and codex are
 comment-only (never touch the working tree), so they run fully in parallel
-with everything else. `/code-review --fix` and `/simplify` both mutate the
-PR working tree, so **within the third lane they run sequentially, each
-followed immediately by its own commit** — never concurrently with each
-other, or the two agents could edit the same files at once
-(`references/constraints.md`). Each lane is soft-fail — a failure marks that
-lane `[SKIP]`/`[WARN]` and the others continue.
+with everything else. `/simplify` mutates the PR working tree and commits its
+own changes. Each lane is soft-fail — a failure marks that lane
+`[SKIP]`/`[WARN]` and the others continue.
 
 - **agy** — if `command -v agy`, an Agent runs
   `Skill(gh:pr-review, "--ai agy <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
 - **codex** — if `command -v codex`, an Agent runs
   `Skill(gh:pr-review, "--ai codex <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
-- **auto-fix chain** (sequential sub-steps, both on the working-tree diff;
-  PR# is ignored by both — hence the Step 2 checkout):
-  1. An Agent runs `/code-review --fix`. `git status --porcelain` non-empty →
-     `git commit -am "fix(<scope>): code-review --fix"`; erroring invocation →
-     WARN, continue to sub-step 2 regardless.
-  2. Only after sub-step 1's commit (or no-op), an Agent runs the built-in
-     `/simplify`. `git status --porcelain` non-empty → `git commit -am
-     "refactor(<scope>): simplify per /simplify"`.
-  **Never a bare `git commit`** in either sub-step — it hangs on the editor
-  in a non-interactive shell; always pass `-m`.
+- **auto-fix** — an Agent runs the built-in `/simplify` (working-tree diff;
+  PR# is ignored — hence the Step 2 checkout). `git status --porcelain`
+  non-empty → `git commit -am "refactor(<scope>): simplify per /simplify"`.
+  **Never a bare `git commit`** — it hangs on the editor in a non-interactive
+  shell; always pass `-m`.
 
-## Step 4: Push any auto-fix commits (only if something changed)
+`/code-review --fix` is deliberately NOT part of this lane — it is
+user-invocation-only since Claude Code v2.1.215 and cannot be called from a
+skill (`references/constraints.md`).
+
+## Step 4: Push the auto-fix commit (only if something changed)
 
 Await all lanes, then:
 
-- Either auto-fix sub-step committed → `git push` once (both commits go up
-  together).
-- Neither sub-step changed the tree → skip.
+- `/simplify` committed → `git push`.
+- The tree was unchanged → skip.
 
 ## Step 5: pr-reply (per reply_mode)
 
@@ -106,13 +101,14 @@ Await all lanes, then:
 ## Step 6: Report
 
 Print exactly one `[OK]`/`[SKIP]`/`[WARN]` line, e.g.
-`[OK] PR #<pr> reviewed (agy:OK codex:SKIP code-review:committed simplify:committed) — reply: inline`.
+`[OK] PR #<pr> reviewed (agy:OK codex:SKIP simplify:committed) — reply: inline`.
 
 ## Constraints (full rationale: `references/constraints.md`)
 
 - Every reviewer lane is soft-fail — never hard-fail on a missing/erroring CLI.
-- `/code-review --fix` and `/simplify` both mutate the working tree — run them
-  sequentially with a commit between them, never concurrently with each other.
+- `/simplify` mutates the working tree — it commits its own changes before Step 4 pushes.
+- Never add a `/code-review` lane back — it is user-invocation-only since
+  Claude Code v2.1.215 and a skill cannot invoke it.
 - Never a bare `git commit` — always `-m` (non-interactive hang guard).
 - Inline reply is the deterministic path; `--defer-reply` is minutes-only and not a guarantee.
 - No approve / request-changes here — that is `gh:pr-approve`.

--- a/claude/skills/devx-pr-review-all/references/constraints.md
+++ b/claude/skills/devx-pr-review-all/references/constraints.md
@@ -12,28 +12,40 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
 
 - **Never run a bare `git commit`.** In a non-interactive AI shell a bare
   commit opens an editor for the message and hangs. Always pass `-m` with a
-  conventional-commit message. The auto-fix agents (`/code-review --fix`,
-  `/simplify`) edit files without staging them, so a plain `-m` finds nothing
-  staged and fails with `no changes added to commit` — use `-am` so the
-  commit picks up the unstaged edits too, e.g.
+  conventional-commit message. `/simplify` edits files without staging them,
+  so a plain `-m` finds nothing staged and fails with `no changes added to
+  commit` — use `-am` so the commit picks up the unstaged edits too, e.g.
   `git commit -am "refactor(<scope>): simplify per /simplify"`.
 
-- **`/code-review --fix` and `/simplify` both mutate the working tree — never
-  run them concurrently with each other.** agy/codex only post PR
-  comments, so they're safe to fan out fully in parallel. But two agents
-  editing the same files at the same time is a real correctness risk (lost
-  edits, interleaved partial writes, a resulting diff that matches neither
-  agent's intent). Step 3's third lane is therefore internally sequential —
-  `/code-review --fix` runs to completion and commits before `/simplify`
-  starts — even though the lane as a whole still dispatches in the same turn
-  as agy/codex.
+- **`/code-review --fix` is NOT a lane here, and must not be re-added.**
+  Claude Code v2.1.215 made `/code-review` (and `/verify`) user-invocation-only:
+  the docs mark it `disable-model-invocation`, so a skill calling
+  `Skill(code-review, ...)` is rejected outright. Two reasons Anthropic gives,
+  both sound: the review fans out a fleet of agents (the managed cloud variant
+  bills $15-25 per run), and `--fix` writes to the working tree from a
+  background subagent **outside the session's checkpoints** — `/rewind` cannot
+  undo those edits, only git can. A model firing that autonomously is exactly
+  the failure mode the restriction prevents.
 
-- **Each auto-fix sub-step gets its own commit, not one combined commit.**
-  `fix(<scope>): code-review --fix` and `refactor(<scope>): simplify per
-  /simplify` land as two separate commits when both mutate the tree. This
-  keeps `git blame`/revert granular — a bad `/simplify` cleanup can be
-  reverted without touching a `/code-review --fix` correctness fix, and vice
-  versa. A single `git push` at Step 4 sends up whichever commits exist.
+  Before this was understood, the lane sat here silently soft-failing on every
+  single run. Two workarounds were considered and rejected: shadowing the
+  bundled skill with a same-named override (it would mask a maintained,
+  more capable tool — working-diff scoping, `--fix`, `--comment`, `ultra`,
+  effort tuning — with a frozen fork), and prompting the user mid-flow (breaks
+  the unattended issue-flow contract). Removal is the honest fix.
+
+  **Nothing meaningful is lost.** Bug-hunting is covered by the agy and codex
+  lanes, which post real PR comments; cleanup is covered by `/simplify`; and
+  the apply-fixes-and-commit behaviour still happens at the end of the flow,
+  where `gh:pr-reply` evaluates each review comment and commits the valid
+  fixes. Users who want the bundled reviewer can type `/code-review --fix`
+  themselves at any point — it runs in the background and does not block.
+
+- **The auto-fix commit is its own commit.** `refactor(<scope>): simplify per
+  /simplify` lands separately from any fix commits `gh:pr-reply` makes later,
+  keeping `git blame`/revert granular — a bad cleanup can be reverted without
+  touching a review-driven correctness fix. A single `git push` at Step 4
+  sends up whatever exists.
 
 - **Delay is not a guarantee — inline reply is the deterministic path.**
   agy/codex reviews are synchronous `gh:pr-review` CLI calls: they post the
@@ -51,14 +63,13 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
   and replies to comments; it never submits a `gh pr review` decision. That is
   `gh:pr-approve`'s job.
 
-- **Built-in `/simplify` and `/code-review --fix` both ignore the PR# argument**
-  and operate on the current working tree / branch diff. This is why Step 2
-  checks out the PR head branch first when running standalone — without it,
-  either command would edit whatever tree happens to be checked out. On the
-  issue-flow delegation path the branch is already correct, so the checkout
-  is a no-op skip.
+- **Built-in `/simplify` ignores the PR# argument** and operates on the
+  current working tree / branch diff. This is why Step 2 checks out the PR
+  head branch first when running standalone — without it, `/simplify` would
+  edit whatever tree happens to be checked out. On the issue-flow delegation
+  path the branch is already correct, so the checkout is a no-op skip.
 
-- **The auto-fix commits + push (Step 4) run synchronously before return.**
+- **The auto-fix commit + push (Step 4) run synchronously before return.**
   On the issue-flow delegation path this guarantees no dirty tree is left for
   the later rebase steps — a dirty working tree breaks `git rebase`.
 

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -1,9 +1,9 @@
 # devx:pr-review-all — Help
 
 Fan out **every available reviewer** on one PR in parallel — `agy` ∥
-`codex` second opinions ∥ a sequential `/code-review --fix` → `/simplify`
-auto-fix chain (each sub-step commits its own changes) — then run a reply
-pass over the resulting review comments. A composition skill: it
+`codex` second opinions ∥ a `/simplify` auto-fix pass (which commits its own
+changes) — then run a reply pass over the resulting review comments. A
+composition skill: it
 orchestrates several reviewers plus a reply, unlike `gh:pr-review` (a single
 external AI, one aggregate comment). It submits **no decision** (approve /
 request-changes) — that is `gh:pr-approve`.
@@ -37,18 +37,16 @@ request-changes) — that is `gh:pr-approve`.
 
 1. Parse args via `devx_pr_review_all_parse`; record `START_TS`.
 2. Pre-flight: PR must be `OPEN` and non-draft, `gh auth` must be live, and
-   check out the PR head branch if not already on it (so `/code-review --fix`
-   and `/simplify` act on the right tree).
-3. Review + auto-fix gate — dispatch agy, codex, and an auto-fix chain as
+   check out the PR head branch if not already on it (so `/simplify` acts on
+   the right tree).
+3. Review + auto-fix gate — dispatch agy, codex, and the auto-fix pass as
    Agent subagents **in one turn**. agy/codex delegate to
    `gh:pr-review --ai <name>` (streams findings + posts a PR comment) and run
-   fully in parallel. `/code-review --fix` and `/simplify` both mutate the
-   working tree, so they run **sequentially** within their own lane, each
-   committing its own changes immediately (`fix(<scope>): code-review --fix`,
-   then `refactor(<scope>): simplify per /simplify`) — never concurrently
-   with each other. Each lane is soft-fail.
-4. Push any commits from the auto-fix chain (only if the working tree
-   changed), always with an explicit `-m` message on each commit.
+   fully in parallel. `/simplify` mutates the working tree and commits its own
+   changes (`refactor(<scope>): simplify per /simplify`). Each lane is
+   soft-fail.
+4. Push the auto-fix commit (only if the working tree changed), always with
+   an explicit `-m` message.
 5. Reply — inline `gh:pr-reply <pr> <remote>` (default), or deferred via
    `devx:schedule` (`--defer-reply M`), or skipped (`--no-reply`). The
    `<remote>` is threaded so the reply pass resolves the same target repo.
@@ -57,6 +55,9 @@ request-changes) — that is `gh:pr-approve`.
 ## What the skill will NOT do
 
 - Submit `gh pr review --approve` / `--request-changes` — that is `gh:pr-approve`.
+- Run `/code-review --fix` — it is user-invocation-only since Claude Code
+  v2.1.215, so no skill can invoke it. Run it yourself when you want it; agy,
+  codex, and the closing `gh:pr-reply` pass cover the same ground here.
 - Hard-fail because a reviewer CLI is missing or errors — each lane is soft-fail.
 - Run a bare `git commit` — an editor prompt would hang the non-interactive shell.
 - Schedule sub-minute delays — `devx:schedule` is minutes-only; for tight

--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -2,8 +2,8 @@
 name: gh:issue-flow
 description: >-
   Composition skill that chains gh:issue-implement → gh:commit → gh:pr →
-  devx:pr-review-all (agy ∥ codex ∥ /code-review --fix → /simplify
-  quality gate + deferred pr-reply, 8 min) → gh:pr-resolve-conflict →
+  devx:pr-review-all (agy ∥ codex ∥ /simplify quality gate + deferred
+  pr-reply, 8 min) → gh:pr-resolve-conflict →
   gh:pr-resolve-outdated
   (out-of-date base sync) for a single issue number. Use when the user runs
   /gh:issue-flow, /gh-issue-flow, or asks "issue #16 처음부터 PR까지 자동으로",


### PR DESCRIPTION
## Summary
- Claude Code v2.1.215 부터 `/code-review` (와 `/verify`) 는 **user-invocation-only** 가 됐다 — 공식 문서에 `disable-model-invocation` 로 명시돼 있어, `devx:pr-review-all` 의 `Skill(code-review, "--fix")` 호출은 그 이후 **매 실행마다 거부**되고 있었다.
- soft-fail 설계 덕에 흐름 자체는 계속 돌아서 죽은 레인이 눈에 띄지 않았다. 이번에 PR #1260 흐름에서 실제로 드러나 제거한다.
- 대안(동명 오버라이드 / 흐름 중단 후 사용자 대기) 2가지를 검토했으나 모두 기각 — 아래 참고.

## Changes
- `claude/skills/devx-pr-review-all/SKILL.md` — Role · Step 2 · Step 3 · Step 4 · Step 6 리포트 포맷 · Constraints 에서 `/code-review --fix` 제거. auto-fix 레인은 `/simplify` 단독이 되어 "순차 실행 + 사이에 커밋" 제약이 불필요해졌다(동시 편집 위험이 사라짐). 119 → 114 줄.
- `claude/skills/devx-pr-review-all/references/constraints.md` — 제거 근거 전문 + **"must not be re-added"** 명시(재도입 방지). bare `git commit` 제약과 PR# 무시 제약은 `/simplify` 기준으로 정리.
- `claude/skills/devx-pr-review-all/references/help.md` — 동작 설명 및 "What the skill will NOT do" 에 `/code-review` 항목 추가(사용자가 직접 실행하면 된다는 안내 포함).
- `claude/skills/gh-issue-flow/SKILL.md` — frontmatter description 의 체인 표기 갱신.

## 왜 우회하지 않았나

Anthropic 의 차단 사유가 타당하다고 판단했다:
1. **비용** — 리뷰가 에이전트 fleet 을 병렬로 띄운다(managed 클라우드 변형은 회당 $15-25 과금).
2. **되돌릴 수 없는 쓰기** — `--fix` 는 background subagent 가 세션 checkpoint **바깥에서** working tree 를 수정한다. `/rewind` 로 취소 불가, git 으로만 되돌릴 수 있다. 모델이 자율적으로 이걸 실행하는 것이 정확히 이 제약이 막으려는 시나리오다.

기각한 우회 2가지:
- **동명 스킬 오버라이드** (초안 PR #1267, closed): 개인 레벨 스킬이 번들 스킬을 shadow 하는 건 사실이나, 유지보수되는 더 강력한 도구(working-diff 스코핑 · `--fix` · `--comment` · `ultra` · effort 조절)를 **동결된 fork 로 가려버린다**. 게다가 `~/.claude-shared/plugins` 에 캐시된 orphaned `code-review` 플러그인은 현재 번들과 **다른(구버전 PR-코멘팅) 도구**라 `--fix` 를 아예 받지도 않는다.
- **흐름 중단 후 사용자 대기**: `gh:issue-flow` 의 무인 실행 계약을 깬다.

## 무엇을 잃는가 — 실질적으로 없음
- **버그 탐지** → `agy` + `codex` 레인이 실제 PR 코멘트로 커버 (이번 #1260 에서 codex 가 유효 BLOCKER 2건 검출).
- **정리/품질** → `/simplify` 가 계속 자동 실행.
- **수정 후 커밋** → 흐름 마지막 `gh:pr-reply` 가 리뷰 코멘트를 평가해 유효한 것만 고쳐서 커밋.
- 번들 리뷰어가 필요하면 사용자가 `/code-review --fix` 를 직접 치면 된다 — background 로 돌아 대화를 막지 않는다.

## Test plan
- [x] pre-commit hook 통과 (4개 파일 staged).
- [x] 잔여 `/code-review` 언급이 모두 의도된 "재도입 금지" 문서인지 grep 확인.
- [x] 이모지 정책(CLAUDE.md) 위반 없음 확인.
- [x] SKILL.md 줄 수 감소 확인 (119 → 114).

## Related
없음 — 독립 정리 작업. 초안이었던 #1267 은 접근이 잘못돼 closed.
