### PR TITLE
fix(claude/hooks): devx-autopilot stop guard에 boundary 만료 밸브 이식

### DIFF
--- a/claude/hooks/devx_autopilot_stop_guard.py
+++ b/claude/hooks/devx_autopilot_stop_guard.py
@@ -32,6 +32,7 @@ Safety rails (each is critical — never accidentally trap the user):
     chain; bowing out prevents an infinite Stop→block→Stop loop).
   - No devx-autopilot boundary in the transcript → exit 0 (not our flow).
   - Terminal report marker present in assistant text → exit 0 (chain done).
+  - Boundary went stale (N fresh user prompts since it) → exit 0 (#1275).
   - Any unexpected exception → exit 0 (fail open).
 
 The hook only ever does two things: emit nothing (allow), or emit one JSON
@@ -52,6 +53,16 @@ from typing import Any
 # `DEVX_AUTOPILOT_STOP_GUARD_TRACE=1`.
 _TRACE_ENABLED: bool = os.environ.get("DEVX_AUTOPILOT_STOP_GUARD_TRACE") == "1"
 
+# Issue #1275 (ported from #1270 / PR #1272) — how many *fresh* user prompts
+# may accumulate after a devx-autopilot boundary before the hook declares that
+# boundary stale and fails open. Without this valve a boundary lives forever:
+# `stop_hook_active` only prevents an infinite Stop→block→Stop loop *within*
+# one turn, and it resets the moment the user sends a new message, so an
+# abandoned Stage-B run that never emitted a terminal report would keep
+# blocking every unrelated turn for the rest of the session (cross-turn
+# session hijacking).
+_DEFAULT_MAX_STALE_USER_TURNS: int = 3
+
 
 def _trace(message: str, *, layer: str | None = None) -> None:
     """Emit an `[autopilot-stop-guard]` trace line on stderr when trace mode is on.
@@ -59,6 +70,9 @@ def _trace(message: str, *, layer: str | None = None) -> None:
     `layer` is the protection layer the trace belongs to:
       - `L1`   — boundary detection (`_find_flow_boundary`)
       - `L1.5` — step-marker / terminal scan (`_scan_after_boundary`)
+    Boundary *expiry* (#1275) is scored `L1.5` even though it invalidates an
+    `L1` boundary: it is decided purely from the post-boundary window that
+    `L1.5` owns, so it belongs with the scan it runs alongside.
     The tag is appended (not prepended) so substring-based test assertions
     like `[autopilot-stop-guard] allow:` keep matching.
     """
@@ -103,6 +117,55 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
     "[step:devx-autopilot/report] OK",
     "[OK] devx:autopilot",
     "[FAIL] devx:autopilot",
+)
+
+# Issue #1275 — spans Claude Code injects into user-role messages that are
+# NOT user prose. `<system-reminder>…</system-reminder>` blocks are harness
+# chatter appended to otherwise-empty turns, so they must not make a message
+# look like a fresh user prompt.
+_SYSTEM_REMINDER_RE: re.Pattern[str] = re.compile(
+    r"<system-reminder>.*?</system-reminder>",
+    re.DOTALL,
+)
+
+# Issue #1275 — markers proving a `role=user` message is a skill expansion
+# (Claude Code injects an invoked skill's SKILL.md body as a user-role
+# message) rather than something the human typed. Any of these present ⇒
+# flow machinery, not a fresh user turn.
+_SKILL_EXPANSION_MARKERS: tuple[str, ...] = (
+    "Base directory for this skill:",
+    "<command-name>",
+    "<command-message>",
+    "<local-command-stdout>",
+    "is already loaded above",
+)
+
+# Issue #1275 — markers proving a `role=user` message is a *harness
+# injection*, i.e. text Claude Code itself wrote into the user channel, not a
+# human turn. A different category from `_SKILL_EXPANSION_MARKERS` above
+# (which identifies an expanded SKILL.md body), so it lives in its own tuple;
+# both are consulted.
+#
+# WHY this exists (measured on gh-issue-flow's twin guard in PR #1272): a
+# naive `role=user` count reported 102 "fresh prompts" on a real transcript of
+# which only 4 were human — the rest were Stop-hook feedback blocks (Claude
+# Code re-injects THIS hook's own `reason` string as a `role=user` text
+# message) and `<task-notification>` background-subagent completions. The
+# default limit of 3 would therefore be reached mid-flow with zero human
+# involvement, disabling the guard exactly when it is needed. Stage-B runs
+# `simplify` and `pr-reply`, which fan out background agents, so the
+# `<task-notification>` case is the norm here too.
+#
+# `isMeta` on the outer transcript entry is the primary defense; this tuple is
+# defense-in-depth for transcripts that lack the flag. `devx-autopilot
+# incomplete:` is this hook's own block-reason prefix — exactly the string
+# that gets re-injected — so it is the strongest single signal available.
+_HARNESS_INJECTION_MARKERS: tuple[str, ...] = (
+    "Stop hook feedback:",
+    "devx-autopilot incomplete:",
+    "<task-notification>",
+    "[SYSTEM NOTIFICATION - NOT USER INPUT]",
+    "<local-command-caveat>",
 )
 
 # Regex that marks the *start* of a devx-autopilot chain in a user message.
@@ -286,6 +349,74 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     return terminal, steps
 
 
+def _max_stale_user_turns() -> int:
+    """Read the boundary-expiry threshold from the environment (#1275).
+
+    Env var: `DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS`.
+      - a valid non-negative int  → use it,
+      - `0`                       → expiry disabled (never fail open on
+                                    staleness alone),
+      - unset / unparseable / negative → `_DEFAULT_MAX_STALE_USER_TURNS`
+        (unset reaches the `ValueError` arm via the `""` default).
+    Never raises — a bad value silently degrades to the default.
+    """
+    try:
+        value = int(os.environ.get("DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS", ""))
+    except ValueError:
+        return _DEFAULT_MAX_STALE_USER_TURNS
+    return value if value >= 0 else _DEFAULT_MAX_STALE_USER_TURNS
+
+
+def _count_fresh_user_prompts(messages: list[dict[str, Any]], start: int) -> int:
+    """Count genuinely NEW user prompts after the boundary (#1275).
+
+    A `role=user` transcript entry counts only when ALL of these hold:
+      - the OUTER transcript entry is not flagged `isMeta` — Claude Code
+        stamps that flag on Stop-hook feedback injections and skill
+        expansions but never on a genuine human prompt. The flag lives on the
+        entry, NOT on the inner `message` dict, which is why this loop
+        inspects `entry` and `_message_payload(entry)` separately;
+      - after collecting text (`include_tool_results=False`), joining, and
+        deleting every `<system-reminder>…</system-reminder>` span, the
+        remainder is non-empty. This is also what makes a tool-output-only
+        message free: `tool_result` blocks contribute no text under
+        `include_tool_results=False`, so such a message yields "" and is
+        dropped here — which matters especially in this guard, whose step
+        markers ride in Bash `tool_result` payloads. There is deliberately NO
+        wholesale "has a tool_result block ⇒ skip" rule: a real human prompt
+        bundled in the same turn as tool output must still count, otherwise a
+        stale boundary can never expire;
+      - the remainder contains none of `_SKILL_EXPANSION_MARKERS` (an invoked
+        sub-skill's body injected as a user message — Stage-B expands several)
+        nor any of `_HARNESS_INJECTION_MARKERS` (Stop-hook feedback,
+        background-task notifications) — both are machinery generated by the
+        flow itself.
+
+    Drives boundary expiry — see `_DEFAULT_MAX_STALE_USER_TURNS` for why that
+    valve has to exist at all.
+
+    Never raises: `entry` is treated as "not meta" whenever it is not a dict
+    or carries no flag, and every other access is already isinstance-guarded.
+    """
+    count = 0
+    for entry in messages[start + 1 :]:
+        if isinstance(entry, dict) and entry.get("isMeta"):
+            continue
+        msg = _message_payload(entry)
+        if msg.get("role") != "user":
+            continue
+        joined = "\n".join(_iter_text_blocks(msg, include_tool_results=False))
+        remainder = _SYSTEM_REMINDER_RE.sub("", joined).strip()
+        if not remainder:
+            continue
+        if any(marker in remainder for marker in _SKILL_EXPANSION_MARKERS):
+            continue
+        if any(marker in remainder for marker in _HARNESS_INJECTION_MARKERS):
+            continue
+        count += 1
+    return count
+
+
 def _first_missing_step(steps: set[str]) -> str | None:
     """Return the first REQUIRED_STEPS id not yet emitted, or None if all done."""
     for sid in REQUIRED_STEPS:
@@ -324,14 +455,33 @@ def main() -> int:
         return _allow("no devx-autopilot boundary in transcript", layer="L1")
 
     terminal, steps = _scan_after_boundary(messages, boundary)
+    # Issue #1275 — the fresh-prompt count feeds nothing but the expiry valve
+    # below, and counting is a second full pass over the transcript on the
+    # turn-end hot path. Skip it whenever the result provably cannot be used
+    # (flow already terminal, or expiry disabled); trace mode still forces it
+    # so the L1.5 diagnostic line stays complete.
+    limit = _max_stale_user_turns()
+    fresh_prompts = (
+        _count_fresh_user_prompts(messages, boundary) if _TRACE_ENABLED or (not terminal and limit > 0) else 0
+    )
     if _TRACE_ENABLED:
         emitted = ",".join(s for s in REQUIRED_STEPS if s in steps) or "none"
         _trace(
-            f"boundary={boundary} steps_seen={len(steps)}/{len(REQUIRED_STEPS)} ({emitted}) terminal={terminal}",
+            f"boundary={boundary} steps_seen={len(steps)}/{len(REQUIRED_STEPS)} ({emitted}) "
+            f"terminal={terminal} fresh_user_prompts={fresh_prompts}",
             layer="L1.5",
         )
     if terminal:
         return _allow("terminal report marker present — flow finished", layer="L1.5")
+
+    # Issue #1275 — stale-boundary expiry valve. Why `stop_hook_active` is not
+    # enough on its own: see `_DEFAULT_MAX_STALE_USER_TURNS`.
+    if limit > 0 and fresh_prompts >= limit:
+        return _allow(
+            f"stale boundary expiry — {fresh_prompts} fresh user prompt(s) since the "
+            f"devx-autopilot boundary (limit {limit}); flow abandoned, failing open",
+            layer="L1.5",
+        )
 
     missing = _first_missing_step(steps)
     if missing is None:

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -18,6 +18,7 @@
 - 변경: **`/devx:pr-verify-live` 스킬 신설 — 머지 직후(또는 PR 브랜치에서) 이미 떠 있는 dev 앱에 붙어 PR 이 실제로 동작하는지 확인하고 발견을 대상 프로젝트 레포 이슈로 등록한다. base URL·API origin 을 하드코딩 없이 발견하고, 서빙 중인 체크아웃이 대상 커밋(`mergeCommit.oid`)을 포함하는지 확인한 뒤에만 측정한다 (#1271)**
 - 변경: **`devx:pr-verify-live` 의 검증 전 단언 3종 — 서빙 체크아웃 · 로케일/뷰포트 전환 적용 · 대상 요소 비가림. 하나라도 실패하면 측정하지 않고 정지한다. "화면은 멀쩡히 뜨는데 검증이 무효" 인 실패를 여섯 번의 실행에서 반복 관측한 결과 (#1271)**
 - 변경: **`devx:pr-verify-live` 는 이슈 등록 전에 자기 반증 3가설(하네스 오류 · 데이터 상태 · 의도된 동작)을 세워 위양성을 걷어낸다. 근거 게이트는 "수치" 가 아니라 "기계 판독 가능한 단언" 이라 i18n·상태·어포던스 결함도 등록 가능하다. 이슈 본문·라벨·메트릭은 `gh:issue-create` 가 SSOT (#1271)**
+- 변경: **devx-autopilot Stop 훅에도 오래된 boundary 자동 만료 이식 — 종료 리포트 없이 중단된 Stage-B 실행의 boundary 가 세션 내내 남아 무관한 턴까지 계속 차단하던 문제 수정(gh-issue-flow 는 #1270 에서 이미 해결). boundary 이후 진짜 사용자 프롬프트가 3회 쌓이면 fail-open 하며 `DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS` 로 조정하고 `0` 이면 만료 비활성화. 엔트리의 `isMeta` 플래그, 훅 자신의 `devx-autopilot incomplete:` 재주입, `<task-notification>` 등 harness 주입, skill 확장, `<system-reminder>` 전용·tool_result 전용 메시지는 사용자 프롬프트로 세지 않는다 (#1275)**
 - 변경: **macOS/BSD 이식성 수정 — 타이밍 테스트가 GNU 전용 `date +%s%N` 대신 bash 내장 `SECONDS` 를 쓰도록 바꿔 BSD `date` 에서 테스트가 중단되지 않는다. ms 변환 헬퍼는 `claude/hooks/lib/pbd_ms.sh`(디스패처와 같은 디렉터리에 함께 배포되어야 하는 신규 파일) 로 분리해 BSD `date` fallback 경로에 테스트 커버리지를 붙였다 (#1258 리뷰 후속)**
 
 ## 2026-07-30

--- a/tests/integration/test_devx_autopilot_stop_guard.py
+++ b/tests/integration/test_devx_autopilot_stop_guard.py
@@ -870,60 +870,35 @@ def test_ismeta_user_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
     assert json.loads(result.stdout)["decision"] == "block"
 
 
-def test_stop_hook_feedback_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
-    """The hook's own `reason`, re-injected as user text, must not count.
-
-    This is the self-defeat loop: every block the guard emits comes back as a
-    "fresh user prompt", and three of them would expire the guard's own
-    boundary.
-    """
-    feedback = (
-        "Stop hook feedback: devx-autopilot incomplete: 1/7 Stage-B step markers "
-        "emitted since the flow started, and no terminal report "
-        "('[OK] devx:autopilot' / '[FAIL] devx:autopilot') has been emitted yet. "
-        "Per the CRITICAL CONTRACT in claude/skills/devx-autopilot/SKILL.md, you "
-        "MUST continue immediately. Next action: Step 0b — Skill(gh:issue-create)."
-    )
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/devx-autopilot"),
-            _step_markers_result("plan"),
-            _user_text(feedback),
-            _user_text(feedback),
-            _user_text(feedback),
-            _user_text(feedback),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip(), f"Stop-hook feedback was miscounted as fresh user prompts. stdout={result.stdout!r}"
-    assert json.loads(result.stdout)["decision"] == "block"
-
-
-def test_task_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
-    """Background-subagent completion notices are harness, not human."""
-    notice = "<task-notification>Agent 'codex-review' (id: agent_1) has completed.</task-notification>"
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/devx-autopilot"),
-            _step_markers_result("plan"),
-            _user_text(notice),
-            _user_text(notice),
-            _user_text(notice),
-            _user_text(notice),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip(), f"<task-notification> was miscounted as fresh user prompts. stdout={result.stdout!r}"
-    assert json.loads(result.stdout)["decision"] == "block"
-
-
-def test_system_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
-    """`[SYSTEM NOTIFICATION - NOT USER INPUT]` says so on the tin."""
-    notice = "[SYSTEM NOTIFICATION - NOT USER INPUT] Background command exited with code 0."
+@pytest.mark.parametrize(
+    ("label", "notice"),
+    [
+        (
+            "stop-hook-feedback",
+            # The hook's own `reason`, re-injected as user text, must not count —
+            # this is the self-defeat loop: every block the guard emits comes back
+            # as a "fresh user prompt", and three of them would expire the guard's
+            # own boundary.
+            "Stop hook feedback: devx-autopilot incomplete: 1/7 Stage-B step markers "
+            "emitted since the flow started, and no terminal report "
+            "('[OK] devx:autopilot' / '[FAIL] devx:autopilot') has been emitted yet. "
+            "Per the CRITICAL CONTRACT in claude/skills/devx-autopilot/SKILL.md, you "
+            "MUST continue immediately. Next action: Step 0b — Skill(gh:issue-create).",
+        ),
+        (
+            "task-notification",
+            # Background-subagent completion notices are harness, not human.
+            "<task-notification>Agent 'codex-review' (id: agent_1) has completed.</task-notification>",
+        ),
+        (
+            "system-notification",
+            # `[SYSTEM NOTIFICATION - NOT USER INPUT]` says so on the tin.
+            "[SYSTEM NOTIFICATION - NOT USER INPUT] Background command exited with code 0.",
+        ),
+    ],
+)
+def test_harness_injection_markers_are_not_fresh_prompts(tmp_path: Path, label: str, notice: str) -> None:
+    """Each `_HARNESS_INJECTION_MARKERS` entry must not count as a fresh user prompt."""
     transcript = _write_transcript(
         tmp_path,
         [
@@ -937,9 +912,7 @@ def test_system_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> N
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
-    assert result.stdout.strip(), (
-        f"[SYSTEM NOTIFICATION] was miscounted as fresh user prompts. stdout={result.stdout!r}"
-    )
+    assert result.stdout.strip(), f"{label} was miscounted as fresh user prompts. stdout={result.stdout!r}"
     assert json.loads(result.stdout)["decision"] == "block"
 
 

--- a/tests/integration/test_devx_autopilot_stop_guard.py
+++ b/tests/integration/test_devx_autopilot_stop_guard.py
@@ -100,6 +100,40 @@ def _user_tool_result(text: str) -> dict[str, Any]:
     }
 
 
+def _user_meta_text(text: str) -> dict[str, Any]:
+    """Build a user-role entry flagged `isMeta` on the OUTER entry (#1275).
+
+    Claude Code stamps `isMeta: true` on the text it injects into the user
+    channel itself (Stop-hook feedback, skill expansions) and never on a
+    human prompt. The flag deliberately sits outside `message`, which is
+    exactly what a naive `role=user` counter fails to look at.
+    """
+    return {"type": "user", "isMeta": True, "message": {"role": "user", "content": text}}
+
+
+def _user_text_with_tool_result(text: str) -> dict[str, Any]:
+    """Build a user message carrying BOTH human text and tool output (#1275).
+
+    Real transcripts bundle these in one turn. Skipping any message that
+    contains a tool_result wholesale would mean the human half never counts,
+    so a genuinely abandoned flow could never expire its boundary.
+    """
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_test_mixed",
+                    "content": "tests: 42 passed",
+                },
+                {"type": "text", "text": text},
+            ],
+        },
+    }
+
+
 def _assistant_skill(skill: str, args: str = "") -> dict[str, Any]:
     """Build an assistant tool_use message invoking Skill(<skill>)."""
     return {
@@ -599,6 +633,360 @@ def test_trace_on_emits_allow_reason_for_no_boundary(tmp_path: Path) -> None:
     assert result.stdout.strip() == ""
     assert "[autopilot-stop-guard] allow:" in result.stderr
     assert "no devx-autopilot boundary" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Issue #1275 — stale boundary expiry (ported from #1270 / PR #1272). After N
+# fresh user prompts (default 3, `DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS`,
+# `0` = disabled) the boundary is abandoned and the hook fails open. Without
+# it, a Stage-B run the user walks away from keeps blocking every unrelated
+# turn for the rest of the session.
+# ---------------------------------------------------------------------------
+
+
+def test_three_fresh_user_prompts_expire_the_boundary(tmp_path: Path) -> None:
+    """3 unrelated user prompts after an unfinished flow → allow."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text("actually, forget that — what does mise tasks list?"),
+            _assistant_text("It lists the repo's lint/test tasks."),
+            _user_text("thanks. now show me the zsh env file"),
+            _assistant_text("Here it is."),
+            _user_text("what is the p10k prompt config path?"),
+            _assistant_text("~/.p10k.zsh"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"Stale devx-autopilot boundary kept blocking unrelated turns. stdout={result.stdout!r}"
+    )
+
+
+def test_boundary_expiry_reported_in_trace(tmp_path: Path) -> None:
+    """The expiry allow-path names itself under trace mode."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text("unrelated question one"),
+            _user_text("unrelated question two"),
+            _user_text("unrelated question three"),
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"DEVX_AUTOPILOT_STOP_GUARD_TRACE": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert "stale boundary expiry" in result.stderr, f"stderr={result.stderr!r}"
+    assert "fresh_user_prompts=3" in result.stderr, f"stderr={result.stderr!r}"
+    assert "layer=L1.5" in result.stderr
+
+
+def test_two_fresh_user_prompts_still_block(tmp_path: Path) -> None:
+    """Boundary condition: below the limit the guard keeps blocking."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _user_text("wait, is the PR going to close the issue?"),
+            _assistant_text("Yes, via Closes #1275."),
+            _user_text("ok continue"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"Expected a block below the expiry limit. stdout={result.stdout!r}"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "0/7 Stage-B step markers emitted" in decision["reason"]
+
+
+def test_skill_expansion_user_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
+    """Claude Code injects an invoked sub-skill's body as a user-role message.
+    Stage-B expands several of those; they must not expire the boundary."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _user_text("Base directory for this skill: /home/user/.claude/skills/gh-issue-create\n"),
+            _assistant_skill("gh-issue-create"),
+            _user_text("<command-message>gh-pr</command-message>\n<command-args></command-args>\n"),
+            _user_text("<command-name>/gh-pr</command-name>\n<command-args></command-args>\n"),
+            _user_text("<local-command-stdout>ok</local-command-stdout>"),
+            _user_text("The gh-pr skill is already loaded above."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        "Skill-expansion user messages were miscounted as fresh user prompts "
+        f"and expired the boundary. stdout={result.stdout!r}"
+    )
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_tool_result_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
+    """Tool output rides in `role=user` messages but is not a prompt.
+
+    Load-bearing for this guard specifically: its own step markers arrive as
+    Bash tool_result payloads, so every real flow generates such messages.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_tool_result("tests: 42 passed"),
+            _user_tool_result("commit abc123 created"),
+            _user_tool_result("PR https://x/pull/9 opened"),
+            _user_tool_result("review posted"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        f"tool_result messages were miscounted as fresh user prompts. stdout={result.stdout!r}"
+    )
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_system_reminder_only_user_message_is_not_a_fresh_prompt(
+    tmp_path: Path,
+) -> None:
+    """A user message consisting solely of a `<system-reminder>` span is
+    harness chatter, not a human turn."""
+    reminder = "<system-reminder>\nThis is a reminder about file state.\nIt spans lines.\n</system-reminder>"
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text(reminder),
+            _user_text(reminder),
+            _user_text(reminder),
+            _user_text(reminder),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        f"A <system-reminder>-only message was counted as a fresh prompt. stdout={result.stdout!r}"
+    )
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_expiry_disabled_by_env_zero(tmp_path: Path) -> None:
+    """`DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS=0` never expires."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            *[_user_text(f"unrelated prompt {i}") for i in range(5)],
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS": "0"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"Expiry ran even though it was disabled with =0. stdout={result.stdout!r}"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_expiry_limit_configurable_via_env(tmp_path: Path) -> None:
+    """A custom non-zero limit is honoured (1 prompt is enough here)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text("never mind, different topic now"),
+        ],
+    )
+    result = _run_hook(
+        _hook_event(transcript),
+        env={"DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS": "1"},
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"stdout={result.stdout!r}"
+
+
+def test_invalid_expiry_env_falls_back_to_default(tmp_path: Path) -> None:
+    """An unparseable / negative value degrades to the default of 3."""
+    two_prompts = [
+        _user_text("/devx-autopilot"),
+        _step_markers_result("plan"),
+        _user_text("question one"),
+        _user_text("question two"),
+    ]
+    transcript = _write_transcript(tmp_path, two_prompts)
+    for bad in ("not-a-number", "-1", ""):
+        result = _run_hook(
+            _hook_event(transcript),
+            env={"DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS": bad},
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip(), f"value {bad!r} did not fall back to the default limit"
+        assert json.loads(result.stdout)["decision"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1275 — fresh-prompt counter over/under-counting.
+#
+# Measured on gh-issue-flow's twin guard (PR #1272): a naive `role=user` count
+# saw 102 "fresh prompts" on a real transcript of which only 4 were human —
+# the rest were Stop-hook feedback re-injections and `<task-notification>`
+# background-subagent completions, so the limit of 3 was hit mid-flow and the
+# guard disabled itself. Two independent fixes are pinned below: `isMeta` on
+# the OUTER entry plus harness-injection markers (over-count), and counting a
+# mixed text + tool_result turn (under-count).
+# ---------------------------------------------------------------------------
+
+
+def test_ismeta_user_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
+    """`isMeta: true` on the outer entry means harness text, never a human."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_meta_text("please continue with the next step"),
+            _user_meta_text("keep going, do not stop"),
+            _user_meta_text("resume the chain now"),
+            _user_meta_text("another injected line"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"isMeta entries were miscounted as fresh user prompts. stdout={result.stdout!r}"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_stop_hook_feedback_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
+    """The hook's own `reason`, re-injected as user text, must not count.
+
+    This is the self-defeat loop: every block the guard emits comes back as a
+    "fresh user prompt", and three of them would expire the guard's own
+    boundary.
+    """
+    feedback = (
+        "Stop hook feedback: devx-autopilot incomplete: 1/7 Stage-B step markers "
+        "emitted since the flow started, and no terminal report "
+        "('[OK] devx:autopilot' / '[FAIL] devx:autopilot') has been emitted yet. "
+        "Per the CRITICAL CONTRACT in claude/skills/devx-autopilot/SKILL.md, you "
+        "MUST continue immediately. Next action: Step 0b — Skill(gh:issue-create)."
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text(feedback),
+            _user_text(feedback),
+            _user_text(feedback),
+            _user_text(feedback),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"Stop-hook feedback was miscounted as fresh user prompts. stdout={result.stdout!r}"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_task_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
+    """Background-subagent completion notices are harness, not human."""
+    notice = "<task-notification>Agent 'codex-review' (id: agent_1) has completed.</task-notification>"
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text(notice),
+            _user_text(notice),
+            _user_text(notice),
+            _user_text(notice),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"<task-notification> was miscounted as fresh user prompts. stdout={result.stdout!r}"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_system_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
+    """`[SYSTEM NOTIFICATION - NOT USER INPUT]` says so on the tin."""
+    notice = "[SYSTEM NOTIFICATION - NOT USER INPUT] Background command exited with code 0."
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text(notice),
+            _user_text(notice),
+            _user_text(notice),
+            _user_text(notice),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        f"[SYSTEM NOTIFICATION] was miscounted as fresh user prompts. stdout={result.stdout!r}"
+    )
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_mixed_text_and_tool_result_message_counts_as_fresh_prompt(
+    tmp_path: Path,
+) -> None:
+    """A human prompt bundled with tool output still counts.
+
+    Skipping such messages wholesale would mean a genuinely abandoned flow
+    keeps blocking forever whenever the user types while a tool is in flight.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _user_text_with_tool_result("stop that — what does mise tasks list?"),
+            _user_text_with_tool_result("and where is the zsh env file?"),
+            _user_text_with_tool_result("last one: the p10k config path?"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        "Human text bundled alongside a tool_result was not counted, so the "
+        f"stale boundary kept blocking. stdout={result.stdout!r}"
+    )
+
+
+def test_tool_result_only_message_still_not_a_fresh_prompt(tmp_path: Path) -> None:
+    """Regression guard: having no wholesale tool_result skip must not let
+    bare tool output start counting — `include_tool_results=False` yields
+    empty text, and the emptiness check drops it."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _user_tool_result("tests: 42 passed"),
+            _user_tool_result("commit abc123 created"),
+            _user_tool_result("PR https://x/pull/9 opened"),
+            _user_tool_result("review posted"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"tool_result-only messages were counted as fresh prompts. stdout={result.stdout!r}"
+    assert json.loads(result.stdout)["decision"] == "block"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `/devx-autopilot` Stop 훅에 `#1270`/PR #1272에서 gh-issue-flow 가드에 도입한 boundary 만료 밸브를 이식했다. 종료 리포트 없이 Stage-B 실행이 중단되면 boundary가 세션 끝까지 살아남아 무관한 턴을 계속 block하던 문제(#1270과 동일한 결함)를 해결한다.

## Changes
- `claude/hooks/devx_autopilot_stop_guard.py`: `_max_stale_user_turns` / `_count_fresh_user_prompts` 이식, `isMeta` 플래그·harness 주입 마커(`Stop hook feedback:`, `devx-autopilot incomplete:`, `<task-notification>` 등)를 신선한 사용자 프롬프트에서 제외, `DEVX_AUTOPILOT_STOP_GUARD_MAX_USER_TURNS` env var 로 임계값(기본 3) 조정
- `tests/integration/test_devx_autopilot_stop_guard.py`: gh-issue-flow 가드의 boundary-expiry 회귀 테스트 15건을 이 가드의 어휘(스텝 마커, env var 이름)에 맞춰 이식
- `docs/public/changelog.md`: 변경 기록 추가

이슈에서 제안한 P-2(Bash 채널 쌍 매칭 이식 여부 판단)와 P-3(공용 라이브러리 추출)는 동작 수정과 구조 리팩터를 한 PR에 섞지 않기 위해 범위에서 제외했다.

## Test plan
- [x] `pytest tests/integration/test_devx_autopilot_stop_guard.py tests/integration/test_gh_issue_flow_stop_guard.py` — 114 passed
- [x] `ruff check` — clean on changed files

## Related
Closes #1275

---
<details>
<summary>🤖 AI Metrics · 📊 ~8500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~8500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
