### PR TITLE
fix(shell-common): devx_pr_review_all_parse가 local 없이 전역 할당해 인터랙티브 셸을 오염시키는 문제 수정

### DIFF
--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -5,14 +5,20 @@
 # gh_pr_review_parse contract: one `key=value` line per resolved arg on
 # success, errors to stderr. Exit 0 ok/help, exit 2 arg error. Runtime
 # checks (PR state, gh auth, CLI presence) belong to the skill body.
+#
+# This file lives under shell-common/functions/, so it is auto-sourced into
+# the user's interactive shell. Every variable the parser assigns is `local`
+# (house style here — see gh_pr_review.sh) so a call cannot clobber the
+# user's `$pr` / `$remote`. Callers read the stdout `key=value` contract,
+# never the shell variables.
 
 devx_pr_review_all_parse() {
-    pr=""
-    remote="origin"
-    reply_mode="inline"
-    reply_delay="8"
-    _no_reply=0
-    _remote_set=0
+    local pr=""
+    local remote="origin"
+    local reply_mode="inline"
+    local reply_delay="8"
+    local _no_reply=0
+    local _remote_set=0
 
     while [ "$#" -gt 0 ]; do
         case "$1" in

--- a/tests/bats/functions/devx_pr_review_all.bats
+++ b/tests/bats/functions/devx_pr_review_all.bats
@@ -86,3 +86,19 @@ setup() {
     assert_success
     assert_output --partial "help_requested=1"
 }
+
+@test "parse does not leak pr/remote/reply_mode/reply_delay into the caller's shell" {
+    pr="SENTINEL_PR"
+    remote="SENTINEL_REMOTE"
+    reply_mode="SENTINEL_REPLY_MODE"
+    reply_delay="SENTINEL_REPLY_DELAY"
+    _no_reply="SENTINEL_NO_REPLY"
+    _remote_set="SENTINEL_REMOTE_SET"
+    devx_pr_review_all_parse 123 upstream --defer-reply 8 >/dev/null
+    [ "$pr" = "SENTINEL_PR" ]
+    [ "$remote" = "SENTINEL_REMOTE" ]
+    [ "$reply_mode" = "SENTINEL_REPLY_MODE" ]
+    [ "$reply_delay" = "SENTINEL_REPLY_DELAY" ]
+    [ "$_no_reply" = "SENTINEL_NO_REPLY" ]
+    [ "$_remote_set" = "SENTINEL_REMOTE_SET" ]
+}

--- a/tests/bats/functions/devx_pr_review_all.bats
+++ b/tests/bats/functions/devx_pr_review_all.bats
@@ -87,7 +87,7 @@ setup() {
     assert_output --partial "help_requested=1"
 }
 
-@test "parse does not leak pr/remote/reply_mode/reply_delay into the caller's shell" {
+@test "parse does not leak pr/remote/reply_mode/reply_delay/_no_reply/_remote_set into the caller's shell" {
     pr="SENTINEL_PR"
     remote="SENTINEL_REMOTE"
     reply_mode="SENTINEL_REPLY_MODE"
@@ -95,6 +95,8 @@ setup() {
     _no_reply="SENTINEL_NO_REPLY"
     _remote_set="SENTINEL_REMOTE_SET"
     devx_pr_review_all_parse 123 upstream --defer-reply 8 >/dev/null
+    _rc=$?
+    [ "$_rc" -eq 0 ]
     [ "$pr" = "SENTINEL_PR" ]
     [ "$remote" = "SENTINEL_REMOTE" ]
     [ "$reply_mode" = "SENTINEL_REPLY_MODE" ]


### PR DESCRIPTION
## Summary
- `devx_pr_review_all_parse`가 `local` 없이 전역 할당해 인터랙티브 셸을 오염시키던 결함을 수정 (PR #1273/커밋 634b2d32와 동일 패턴)

## Changes
- `shell-common/functions/devx_pr_review_all.sh`: `pr`/`remote`/`reply_mode`/`reply_delay`/`_no_reply`/`_remote_set`를 모두 `local`로 선언. stdout `key=value` 계약은 불변이라 호출자(`devx:pr-review-all` SKILL.md Step 1) 동작에 영향 없음
- `tests/bats/functions/devx_pr_review_all.bats`: 전역 오염 회귀 테스트 추가 — `devx_pr_verify_live.bats`의 "does not leak" 케이스를 본떠 직접 호출로 단언(`run`은 서브셸이라 누출을 못 잡음)

## Test plan
- [x] `tests/bats/functions/devx_pr_review_all.bats` 15/15 green (신규 케이스 포함)
- [x] `tests/bats/functions/devx_pr_verify_live.bats` 회귀 없음 (기존 57/57 green)
- [x] `shellcheck -x -e SC1090,SC1091` clean
- [x] `shfmt -d -i 4` clean

## Related
Closes #1277

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
