### PR TITLE
fix(gh-pr-review): lane-discriminate PROMPT_FILE to stop parallel-review collisions

### DIFF
--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -78,7 +78,10 @@ tool call. The Bash tool starts a fresh subprocess per call, so
 `$PROMPT_FILE` does not survive into the next one; splitting the two steps
 forces re-typing a fixed path, and parallel `devx:pr-review-all` lanes then
 overwrite each other's prompt — agy and codex review identical bytes and
-the run false-passes (#1276).
+the run false-passes (#1276). After Step 5's dispatch completes, `rm -f
+"$PROMPT_FILE"` — the file is created fresh per invocation and nothing
+else reads it afterward, so leaving it behind just accumulates /tmp
+clutter across repeated reviews.
 
 ## Step 5: Dispatch to External CLI
 

--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -70,6 +70,16 @@ Decide path by diff size (`gh pr view ... --json additions,deletions`):
 inline `gh pr diff`. Append the diff per `references/ai-cli-invocation.md`
 § "stdin payload shape"; write `(prompt + diff)` to `PROMPT_FILE` (stdin).
 
+Never hardcode or reuse a `PROMPT_FILE` name. Derive it from
+`_gh_pr_review_mktemp_prompt "$ai" "$PR_NUMBER"`
+(`shell-common/functions/gh_pr_review.sh` — source it first if this turn
+has not), and do the write **and** the Step 5 dispatch in the *same* Bash
+tool call. The Bash tool starts a fresh subprocess per call, so
+`$PROMPT_FILE` does not survive into the next one; splitting the two steps
+forces re-typing a fixed path, and parallel `devx:pr-review-all` lanes then
+overwrite each other's prompt — agy and codex review identical bytes and
+the run false-passes (#1276).
+
 ## Step 5: Dispatch to External CLI
 
 Delegate to `_gh_pr_review_run_ai` (`shell-common/functions/gh_pr_review.sh`).

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -2,9 +2,11 @@
 
 Maps the three supported `--ai` values to concrete CLI commands. The
 prompt (built from `references/review-presets.md`) is passed via
-**stdin**; the PR diff is appended to that same stdin payload. None of
-the three CLIs receive the prompt as a single argv string — argv has
-length limits and quoting hazards, stdin doesn't.
+**stdin** by default; the PR diff is appended to that same stdin
+payload. Exception: `agy --print` takes the prompt as an argv string
+(see `--ai agy` below) — everything else (`PROMPT_FILE`'s own creation,
+codex, claude) stays stdin-based, since argv has length limits and
+quoting hazards that stdin avoids.
 
 ## PATH pre-flight
 

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -33,6 +33,15 @@ All three CLIs receive the same byte stream on stdin:
 --- END PR DIFF ---
 ```
 
+`PROMPT_FILE` is created via
+`_gh_pr_review_mktemp_prompt <ai> <PR#>` (SSOT in
+`shell-common/functions/gh_pr_review.sh`), which expands to
+`mktemp "/tmp/gh-pr-review-prompt.<ai>.<PR#>.XXXXXX"` — the same
+`<ai>`-discriminated template the stderr file uses. The `<ai>` + PR
+discriminators are mandatory, not cosmetic: `devx:pr-review-all` runs the
+agy and codex lanes concurrently, and a shared path lets one lane clobber
+the other's prompt so both CLIs review identical bytes (#1276).
+
 Large diffs follow the same delegation pattern as
 `gh-pr-approve/references/large-diff-delegation.md`. When `additions +
 deletions ≥ 800`, dispatch an Explore subagent to pre-classify

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -3,6 +3,7 @@
 사용자 관점의 의미 있는 변경 기록. 포맷: `## YYYY-MM-DD` 헤더 아래 `- 변경: **요약**`.
 
 ## 2026-08-06
+- 변경: **`gh:pr-review` 의 `PROMPT_FILE` 경로를 레인별로 분리 — `_gh_pr_review_mktemp_prompt <ai> <PR#>`(`mktemp "/tmp/gh-pr-review-prompt.<ai>.<PR#>.XXXXXX"`) 가 SSOT. `devx:pr-review-all` 이 agy·codex 레인을 같은 턴에 병렬로 띄울 때 두 레인이 고정된 프롬프트 파일 이름을 공유해 서로 덮어쓰면 두 CLI 가 동일한 바이트를 리뷰하고도 `agy:OK codex:OK` 로 조용히 통과하던 위양성을 차단한다. SKILL.md Step 4 는 프롬프트 작성과 Step 5 디스패치를 같은 Bash 호출 안에서 수행하도록 명시(Bash 툴은 호출마다 새 서브프로세스라 `$PROMPT_FILE` 이 다음 호출로 이어지지 않는다) (#1276)**
 - 변경: **`PostToolUse:Bash` 훅 지연 제거 — `gh pr create` 후 project board retry-poll(최대 6회 x 2s sleep + GraphQL 왕복)과 연결 이슈 동기화를 백그라운드로 분리. foreground 는 sync 1회만 수행하므로 훅이 재시도 예산을 기다리지 않고 반환한다 (median 7.8s / max 48.7s → sync 1회 왕복) (#1258)**
 - 변경: **훅 구간별 타이밍 계측 추가 — 라우팅된 호출만 `~/.local/state/claude/post-bash-dispatch-timing.log` 에 기록하고, `claude/tools/hook-perf-report.sh` 로 median/p90/p99/max 와 목표치(median < 2000ms · p99 < 5000ms) PASS/FAIL 을 집계한다 (#1258)**
 - 변경: **커맨드별 마크다운 레퍼런스 자동생성 — `shell-common/tools/custom/gen_command_docs.sh` 가 `_<topic>_help_rows_<section>()` row 함수를 실행해 `docs/guide/commands/<커맨드>.md` 57개를 생성. `rg "<키워드>" docs/guide/commands/` 로 커맨드 동작 전체 텍스트 검색 (#1262)**

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -11,7 +11,7 @@
 # SSOT: this file owns the Step 1 arg-parse logic, the AI CLI dispatch,
 # the prompt builder, and the PR comment body builder. The matching
 # claude/skills/gh-pr-review/SKILL.md delegates to gh_pr_review on
-# Steps 1, 5, and 6. The bats fixture
+# Steps 1, 4 (PROMPT_FILE path allocation only), 5, and 6. The bats fixture
 # tests/bats/skills/_fixtures/gh_pr_review_arg_parse.sh sources this
 # file so the arg-parse contract has exactly one definition.
 
@@ -212,6 +212,22 @@ _gh_pr_review_stderr_is_noise() {
     "") return 0 ;;                           # blank line
     esac
     return 1
+}
+
+# _gh_pr_review_mktemp_prompt — lane-discriminated unique prompt-file path.
+# SSOT for PROMPT_FILE naming (issue #1276). Mirrors the `$ai`-discriminated
+# mktemp template used for the stderr file in _gh_pr_review_run_ai: the
+# `XXXXXX` suffix avoids the predictable-PID symlink-attack class, and the
+# `$ai` + PR discriminators keep parallel lanes apart. devx:pr-review-all
+# dispatches agy and codex as separate subagents in the same turn — a shared
+# or hardcoded prompt path lets one lane clobber the other's prompt, so both
+# CLIs review byte-identical input and the run silently false-passes.
+# Args: $1 = ai (codex|agy|claude), $2 = PR number (for debuggability).
+# Prints the created path on stdout; non-zero when /tmp is unwritable.
+_gh_pr_review_mktemp_prompt() {
+    local ai="$1"
+    local pr="${2:-0}"
+    mktemp "/tmp/gh-pr-review-prompt.$ai.$pr.XXXXXX" 2>/dev/null
 }
 
 # _gh_pr_review_run_ai — pipes PROMPT_FILE into the chosen AI CLI per
@@ -854,7 +870,8 @@ EOF
 
     # ---- Step 3 + 4: build prompt + diff into a temp file ----
     local PROMPT_FILE BODY_FILE AI_OUT
-    PROMPT_FILE=$(mktemp 2>/dev/null) || PROMPT_FILE="/tmp/gh-pr-review-prompt.$$"
+    PROMPT_FILE=$(_gh_pr_review_mktemp_prompt "$ai" "$PR_NUMBER") ||
+        PROMPT_FILE="/tmp/gh-pr-review-prompt.$ai.$PR_NUMBER.$$"
     AI_OUT=$(mktemp 2>/dev/null) || AI_OUT="/tmp/gh-pr-review-out.$$"
     BODY_FILE=$(mktemp 2>/dev/null) || BODY_FILE="/tmp/gh-pr-review-body.$$"
 

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -226,9 +226,15 @@ _gh_pr_review_stderr_is_noise() {
 # Prints a path on stdout. Falls back to a $$-suffixed path (still
 # lane-discriminated) when mktemp itself is unavailable, so this stays
 # the single place that knows the PROMPT_FILE naming template.
+# Both args are sanitized to `[A-Za-z0-9_-]` before touching the path —
+# an unvalidated PR token (e.g. containing `/`) could otherwise steer
+# the mktemp template outside /tmp (codex review, PR #1282 / issue #1276).
 _gh_pr_review_mktemp_prompt() {
-    local ai="$1"
-    local pr="${2:-0}"
+    local ai pr
+    ai=$(printf '%s' "${1:-unknown}" | tr -cd 'A-Za-z0-9_-')
+    pr=$(printf '%s' "${2:-0}" | tr -cd 'A-Za-z0-9_-')
+    [ -n "$ai" ] || ai="unknown"
+    [ -n "$pr" ] || pr="0"
     mktemp "/tmp/gh-pr-review-prompt.$ai.$pr.XXXXXX" 2>/dev/null ||
         echo "/tmp/gh-pr-review-prompt.$ai.$pr.$$"
 }

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -223,11 +223,14 @@ _gh_pr_review_stderr_is_noise() {
 # or hardcoded prompt path lets one lane clobber the other's prompt, so both
 # CLIs review byte-identical input and the run silently false-passes.
 # Args: $1 = ai (codex|agy|claude), $2 = PR number (for debuggability).
-# Prints the created path on stdout; non-zero when /tmp is unwritable.
+# Prints a path on stdout. Falls back to a $$-suffixed path (still
+# lane-discriminated) when mktemp itself is unavailable, so this stays
+# the single place that knows the PROMPT_FILE naming template.
 _gh_pr_review_mktemp_prompt() {
     local ai="$1"
     local pr="${2:-0}"
-    mktemp "/tmp/gh-pr-review-prompt.$ai.$pr.XXXXXX" 2>/dev/null
+    mktemp "/tmp/gh-pr-review-prompt.$ai.$pr.XXXXXX" 2>/dev/null ||
+        echo "/tmp/gh-pr-review-prompt.$ai.$pr.$$"
 }
 
 # _gh_pr_review_run_ai — pipes PROMPT_FILE into the chosen AI CLI per
@@ -870,8 +873,7 @@ EOF
 
     # ---- Step 3 + 4: build prompt + diff into a temp file ----
     local PROMPT_FILE BODY_FILE AI_OUT
-    PROMPT_FILE=$(_gh_pr_review_mktemp_prompt "$ai" "$PR_NUMBER") ||
-        PROMPT_FILE="/tmp/gh-pr-review-prompt.$ai.$PR_NUMBER.$$"
+    PROMPT_FILE=$(_gh_pr_review_mktemp_prompt "$ai" "$PR_NUMBER")
     AI_OUT=$(mktemp 2>/dev/null) || AI_OUT="/tmp/gh-pr-review-out.$$"
     BODY_FILE=$(mktemp 2>/dev/null) || BODY_FILE="/tmp/gh-pr-review-body.$$"
 

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -186,6 +186,41 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Prompt-file path allocator — parallel-lane collision guard (issue #1276)
+# ---------------------------------------------------------------------------
+
+@test "mktemp_prompt: different ai, same PR → two distinct lane-tagged paths" {
+    _source_module
+    local agy_path codex_path
+    agy_path=$(_gh_pr_review_mktemp_prompt agy 99)
+    codex_path=$(_gh_pr_review_mktemp_prompt codex 99)
+    [ -n "$agy_path" ]
+    [ -n "$codex_path" ]
+    [ "$agy_path" != "$codex_path" ]
+    case "$agy_path" in *agy*) ;; *) false ;; esac
+    case "$codex_path" in *codex*) ;; *) false ;; esac
+    rm -f "$agy_path" "$codex_path"
+}
+
+@test "mktemp_prompt: same ai + PR twice → still distinct (retries never collide)" {
+    _source_module
+    local first second
+    first=$(_gh_pr_review_mktemp_prompt codex 99)
+    second=$(_gh_pr_review_mktemp_prompt codex 99)
+    [ "$first" != "$second" ]
+    rm -f "$first" "$second"
+}
+
+@test "mktemp_prompt: returned path exists as a file" {
+    _source_module
+    local p
+    p=$(_gh_pr_review_mktemp_prompt claude 1276)
+    [ -f "$p" ]
+    case "$p" in /tmp/gh-pr-review-prompt.claude.1276.*) ;; *) false ;; esac
+    rm -f "$p"
+}
+
+# ---------------------------------------------------------------------------
 # Token estimator
 # ---------------------------------------------------------------------------
 

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -17,6 +17,11 @@ setup() {
 }
 
 teardown() {
+    # Sweep this file's own /tmp naming convention even when a test's
+    # assertions abort mid-body before its own `rm -f` runs (agy review,
+    # PR #1282 / issue #1276) — teardown_isolated_home only cleans
+    # $TEST_TEMP_HOME, not real /tmp.
+    rm -f /tmp/gh-pr-review-prompt.*
     teardown_isolated_home
 }
 
@@ -200,6 +205,16 @@ EOF
     case "$agy_path" in *agy*) ;; *) false ;; esac
     case "$codex_path" in *codex*) ;; *) false ;; esac
     rm -f "$agy_path" "$codex_path"
+}
+
+@test "mktemp_prompt: PR token with path-traversal chars is sanitized, never escapes /tmp" {
+    _source_module
+    local p
+    p=$(_gh_pr_review_mktemp_prompt codex "../../etc/passwd")
+    [ -n "$p" ]
+    case "$p" in /tmp/gh-pr-review-prompt.codex.*) ;; *) false ;; esac
+    case "$p" in *..* | */etc/*) false ;; esac
+    rm -f "$p"
 }
 
 @test "mktemp_prompt: same ai + PR twice → still distinct (retries never collide)" {


### PR DESCRIPTION
## Summary
- Parallel `agy`/`codex` review lanes in `devx:pr-review-all` could clobber each other's prompt file, causing byte-identical "second opinions" that silently false-pass as independent reviews.
- Fixes `gh:pr-review`'s `PROMPT_FILE` allocation to be lane-discriminated and adds a regression test + docs to prevent recurrence.

## Changes
- `shell-common/functions/gh_pr_review.sh`: new `_gh_pr_review_mktemp_prompt(ai, pr)` SSOT helper (`mktemp "/tmp/gh-pr-review-prompt.<ai>.<pr>.XXXXXX"`), mirroring the existing `$ai`-discriminated stderr-file pattern in `_gh_pr_review_run_ai`. Wired into `gh_pr_review()`'s `PROMPT_FILE` allocation.
- `claude/skills/gh-pr-review/SKILL.md`: Step 4 now mandates deriving `PROMPT_FILE` through the helper and doing the write + Step 5 dispatch within the same Bash tool call (the Bash tool forks a fresh subprocess per call, so a locally-scoped `$PROMPT_FILE` cannot survive a split across calls).
- `claude/skills/gh-pr-review/references/ai-cli-invocation.md`: documents the helper as the SSOT for `PROMPT_FILE` naming.
- `tests/bats/functions/gh_pr_review.bats`: 3 regression tests — different-ai-same-PR paths never collide, repeated same-ai-same-PR calls never collide, and the returned path exists as a file.
- `docs/public/changelog.md`: entry under 2026-08-06.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_review.bats` — 28/28 pass (25 existing + 3 new).
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_review_arg_parse.bats tests/bats/skills/gh_pr_review_remote_url.bats` — 39/39 pass, unaffected.
- [x] `shellcheck -x -e SC1090,SC1091` + `shfmt -d -i 4` on the modified `.sh` file — clean.

## Related
Closes #1276

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~1.5 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~1.5 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
