### PR TITLE
feat(devx-pr-verify-live): PR에 검증 리포트를 코멘트로 게시

### DIFF
--- a/claude/skills/devx-pr-verify-live/SKILL.md
+++ b/claude/skills/devx-pr-verify-live/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   PR branch too. Read-only on source code — fixes go out as new issues via
   gh:issue-create. Accepts `[pr-number] [remote] [--url <base-url>] [--api-url
   <origin>] [--start <cmd>] [--matrix auto|full] [--viewports <csv>] [--locales
-  <csv>] [--dry-run] [--no-issue] [--allow-remote-host]` and `-h`/`--help`/`help`.
+  <csv>] [--dry-run] [--no-issue] [--no-comment] [--allow-remote-host]` and
+  `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Grep, Glob, Write, AskUserQuestion, Agent
 metadata:
   model_recommendation:
@@ -40,7 +41,8 @@ verbatim, then stop. No API calls, no browser.
 `source "${SHELL_COMMON}/functions/devx_pr_verify_live.sh"` then
 `devx_pr_verify_live_parse "$@"`. On `help_requested=1` follow Help; on exit 2 print
 the stderr line and stop. Capture `pr` `remote` `url` `api_url` `start_cmd` `matrix`
-`viewports` `locales` `issue_mode` `allow_remote_host`. Record `START_TS=$(date +%s)`.
+`viewports` `locales` `issue_mode` `allow_remote_host` `post_comment`. Record
+`START_TS=$(date +%s)`.
 
 ## Step 2: Resolve target + discover the environment (`references/discovery.md`)
 
@@ -90,6 +92,13 @@ merge 로 재작성되므로 쓰지 않는다(미머지 PR 일 때만 폴백). �
 ## Step 8: Report (`references/report-template.md`)
 
 그 양식으로 한 블록을 출력한다. `Checks:` 만 적지 않는다 — `Matrix:` `Unverified:` `Synthetic:` `Rejected:` `Created:` 가 빠지면 실제보다 강해 보인다.
+
+## Step 9: 리포트를 PR 코멘트로 게시 (`references/pr-comment.md`)
+
+Step 8 이 `[OK]` 또는 `[WARN]` 이고 `post_comment=1` 일 때만, 그 리포트 블록을 **그대로**
+대상 PR 에 코멘트로 남긴다 — `gh_pr_review.sh` 의 `_gh_pr_review_post_comment` 를 폴백
+블록으로 감싸 재사용하고, 게시 실패는 경고일 뿐 정지가 아니다. `[FAIL]` 은 게시하지 않으며
+(`--no-comment` 여부와 무관), `--dry-run`·`--no-issue` 는 이 단계를 게이트하지 않는다.
 
 ## Constraints (전체 목록과 근거: `references/constraints.md`)
 

--- a/claude/skills/devx-pr-verify-live/references/help.md
+++ b/claude/skills/devx-pr-verify-live/references/help.md
@@ -31,10 +31,12 @@ remote 만 지정**하는 호출이 가능하다. 반대로 `12a` 는 숫자로 
 | `--locales <csv>` | 유도 | 명시하면 그 로케일만 |
 | `--dry-run` | off | 이슈 본문을 **작성해서 출력**하되 등록하지 않는다 |
 | `--no-issue` | off | 초안조차 쓰지 않고 리포트 행으로만 보고한다 |
+| `--no-comment` | off | 리포트를 PR 코멘트로 **게시하지 않는다**. 기본은 게시 — `[OK]`/`[WARN]` 이면 리포트 블록이 대상 PR 에 코멘트로 남는다(`[FAIL]` 은 원래 게시하지 않는다) |
 | `--allow-remote-host` | off | 로컬이 아닌 호스트 대상 허용. 이 스킬은 앱 데이터에 쓰기를 한다. 로컬 판정: `localhost` · `127.0.0.0/8` · `::1` · `[::1]` · `0.0.0.0` · `[::]` |
 | `-h` / `--help` / `help` | — | 이 도움말을 출력하고 정지 |
 
 `--dry-run` 과 `--no-issue` 를 같이 주면 `--no-issue` 가 이긴다(초안조차 쓰지 않음).
+`--no-comment` 는 그 둘과 **독립**이다 — 이슈 생성과 코멘트 게시는 서로를 게이트하지 않는다.
 플래그는 모두 `--url X` 와 `--url=X` 두 형태를 받는다.
 
 ## Usage
@@ -46,6 +48,7 @@ remote 만 지정**하는 호출이 가능하다. 반대로 `12a` 는 숫자로 
 - `/devx-pr-verify-live 2483 --locales ko,en --viewports 1440` — 축을 직접 고정
 - `/devx-pr-verify-live 2483 --dry-run` — 이슈 본문만 출력하고 등록하지 않는다
 - `/devx-pr-verify-live 2483 --no-issue` — 리포트만
+- `/devx-pr-verify-live 2483 --no-comment` — 검증은 그대로 하되 PR 에 리포트 코멘트를 남기지 않는다
 - `/devx-pr-verify-live -h` / `--help` / `help` — 이 도움말
 
 ## What the skill does
@@ -64,6 +67,8 @@ remote 만 지정**하는 호출이 가능하다. 반대로 `12a` 는 숫자로 
 7. 후보 발견마다 **자기 반증 3가설**을 세워 반증하고, 게이트를 통과한 것만 발견 1건 =
    이슈 1건으로 `gh:issue-create` 에 넘긴다.
 8. 돈 셀 · 미검증 · 합성 · 기각 · 생성 레코드를 모두 담은 리포트를 출력한다.
+9. 결과가 `[OK]` 또는 `[WARN]` 이면 그 리포트를 대상 PR 에 코멘트로 게시한다 —
+   매번 새 코멘트로 덧붙이며, `--no-comment` 로 끌 수 있다. `[FAIL]` 은 게시하지 않는다.
 
 ## What the skill will NOT do
 

--- a/claude/skills/devx-pr-verify-live/references/pr-comment.md
+++ b/claude/skills/devx-pr-verify-live/references/pr-comment.md
@@ -46,6 +46,9 @@ PR 에 남는 것이 **한 글자도 다르면 안 된다.**
 `command not found` 로 스킬이 통째로 죽는다.
 
 ```bash
+REPORT_BODY_FILE=$(mktemp) && trap 'rm -f "$REPORT_BODY_FILE"' EXIT
+# ... Step 8 이 stdout 에 출력한 리포트 블록을 한 글자도 바꾸지 않고 "$REPORT_BODY_FILE" 에 그대로 옮겨 쓴다 ...
+
 _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_review.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
@@ -53,10 +56,15 @@ if [ -r "$_HELPER" ]; then
         printf '[pr-verify-live] %s sourced but _gh_pr_review_post_comment undefined (#724).\n' \
             "$_HELPER" >&2
     else
-        _gh_pr_review_post_comment "$PR_NUMBER" "$TARGET_REPO" "$REPORT_BODY_FILE" 1 || true
+        _gh_pr_review_post_comment "$PR" "$TARGET_REPO" "$REPORT_BODY_FILE" "$post_comment" || true
     fi
 fi
 ```
+
+`$PR` 는 Step 2 (`discovery.md`) 가 해소한 그 변수다 — 이 스킬 안에 `PR_NUMBER` 라는 변수는
+없다. 4 번째 인자는 `1` 을 하드코딩하지 않고 Step 1 이 캡처한 `$post_comment` 를 그대로
+넘긴다 — 트리거 조건(§1)이 프로즈에만 있고 실행 코드에는 없으면, 이 블록만 따로 복사해
+쓰는 자리에서 `--no-comment` 가 조용히 무시된다.
 
 `export DOTFILES_FORCE_INIT=1` 이 여기서도 load-bearing 이다 — Step 2 가 이미
 `discovery.md` §3 에서 export 했다면 그대로 유효하다. 없으면 인터랙티브 가드에 막혀

--- a/claude/skills/devx-pr-verify-live/references/pr-comment.md
+++ b/claude/skills/devx-pr-verify-live/references/pr-comment.md
@@ -50,10 +50,10 @@ _HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_review.sh"
 if [ -r "$_HELPER" ]; then
     . "$_HELPER"
     if ! command -v _gh_pr_review_post_comment >/dev/null 2>&1; then
-        printf '[pr-verify-live] %s sourced but _gh_pr_review_post_comment undefined.\n' \
+        printf '[pr-verify-live] %s sourced but _gh_pr_review_post_comment undefined (#724).\n' \
             "$_HELPER" >&2
     else
-        _gh_pr_review_post_comment "$PR_NUMBER" "$TARGET_REPO" "$REPORT_BODY_FILE" 1
+        _gh_pr_review_post_comment "$PR_NUMBER" "$TARGET_REPO" "$REPORT_BODY_FILE" 1 || true
     fi
 fi
 ```

--- a/claude/skills/devx-pr-verify-live/references/pr-comment.md
+++ b/claude/skills/devx-pr-verify-live/references/pr-comment.md
@@ -1,0 +1,83 @@
+# 리포트 → PR 코멘트 (pr-comment)
+
+SKILL.md **Step 9** 를 뒷받침한다 — Step 8 이 만든 리포트 블록을 대상 PR 에 코멘트로 남긴다.
+목적은 하나다: **검증 결과가 실행한 터미널에서만 사라지지 않게 하는 것.** 리포트가 stdout 에만
+남으면 며칠 뒤 "이 PR 을 라이브로 확인했나" 를 PR 화면에서 되짚을 방법이 없다.
+
+## 1. 트리거 조건
+
+| 조건 | 게시 |
+|---|---|
+| Step 8 결과가 `[OK]` 이고 `post_comment=1` | **한다** |
+| Step 8 결과가 `[WARN]` 이고 `post_comment=1` | **한다** — 축소된 커버리지도 기록 가치가 있다 |
+| Step 8 결과가 `[FAIL]` | **하지 않는다** (플래그와 무관) |
+| `post_comment=0` (`--no-comment`) | **하지 않는다** |
+
+`[FAIL]` 은 검증 전 단언(Step 3 · Step 5)이 막아 **측정을 시작조차 못 한** 상태다. 그건 대상
+PR 의 결함이 아니라 **이쪽 환경의 문제**(잘못된 체크아웃 · 전환 no-op · 대상 가림)라, PR 에
+남기면 리뷰어에게 PR 이 깨진 것처럼 읽힌다. 로컬 출력으로만 끝낸다.
+
+## 2. `--dry-run` · `--no-issue` 와 독립이다
+
+`issue_mode`(`--dry-run` / `--no-issue`)는 **Step 7 의 이슈 생성만** 게이트한다. 이 단계에는
+영향이 없다 — `--no-issue` 로 돌려도 `post_comment=1` 이면 리포트 코멘트는 게시된다.
+반대로 `--no-comment` 는 Step 7 을 건드리지 않는다: 이슈는 그대로 생성된다.
+
+두 축을 섞지 않는 이유는 뜻이 다르기 때문이다 — `--no-issue` 는 "대상 레포에 이슈를 만들지
+마라", `--no-comment` 는 "PR 타임라인을 어지럽히지 마라" 다. 하나로 묶으면 "이슈는 싫지만
+결과 기록은 남기고 싶다" 를 표현할 수 없다.
+
+## 3. append-only — 이전 코멘트를 갱신하지 않는다
+
+**중복 제거도, 기존 코멘트 수정도 하지 않는다.** 조건을 만족한 실행은 매번 **새 코멘트**를
+남긴다. 같은 PR 을 여러 번 검증하면 코멘트가 여러 개 쌓이고, 그게 의도다 — 실행 시점마다
+서빙 체크아웃 · 드라이버 · 매트릭스가 달랐으므로 **각각이 독립된 관측 기록**이다. 마지막
+것으로 덮어쓰면 "처음엔 3/7 이었다가 재검증에서 7/7 이 됐다" 는 이력이 사라진다.
+
+## 4. 게시 블록
+
+본문은 **Step 8 이 만든 리포트 문자열을 그대로 body-file 로 옮겨 쓴다** — Step 8 은 리포트를
+stdout 에 출력할 뿐 파일로 만들지 않으므로, 여기서 같은 문자열을 `$REPORT_BODY_FILE` 에
+인라인으로 기록한다. 리포트를 여기서 다시 요약하거나 편집하지 않는다: stdout 에 보인 것과
+PR 에 남는 것이 **한 글자도 다르면 안 된다.**
+
+게시는 `gh_pr_review.sh` 의 `_gh_pr_review_post_comment` 를 **재사용**한다. 레포 표준
+폴백 블록(#644 NF-1 + #724)으로 감싸 부른다 — 맨 호출로 쓰면 헬퍼가 없는 환경에서
+`command not found` 로 스킬이 통째로 죽는다.
+
+```bash
+_HELPER="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_review.sh"
+if [ -r "$_HELPER" ]; then
+    . "$_HELPER"
+    if ! command -v _gh_pr_review_post_comment >/dev/null 2>&1; then
+        printf '[pr-verify-live] %s sourced but _gh_pr_review_post_comment undefined.\n' \
+            "$_HELPER" >&2
+    else
+        _gh_pr_review_post_comment "$PR_NUMBER" "$TARGET_REPO" "$REPORT_BODY_FILE" 1
+    fi
+fi
+```
+
+`export DOTFILES_FORCE_INIT=1` 이 여기서도 load-bearing 이다 — Step 2 가 이미
+`discovery.md` §3 에서 export 했다면 그대로 유효하다. 없으면 인터랙티브 가드에 막혀
+`gh_pr_review.sh` 가 조기 return 하고, 위 `command -v` 분기가 경고를 찍는다.
+
+`$TARGET_REPO` 는 Step 2 에서 확정된 값을 쓴다 — 여기서 다시 해소하지 않는다. 헬퍼가
+`--repo "$TARGET_REPO"` 로 넘기므로, dotfiles 가 아니라 **대상 프로젝트 레포의 PR** 에
+코멘트가 붙는다.
+
+## 5. 실패는 치명적이지 않다
+
+`_gh_pr_review_post_comment` 는 **soft-fail 계약**이다 — `gh pr comment` 가 실패하면
+`[WARN] PR comment post failed — output retained on stdout` 을 stderr 로 찍고 **0 을
+반환**한다. 게시 실패로 스킬 전체를 실패 처리하지 않는다: 리포트는 이미 stdout 에 있고,
+검증 자체는 끝났다. 종료 코드는 Step 8 의 판정(`[OK]`/`[WARN]` → 0)을 그대로 따른다.
+
+## 6. 금지
+
+- **`gh_pr_review.sh` 를 수정하지 않는다.** 헬퍼는 `gh:pr-review` 의 SSOT 다.
+- **`gh pr comment` 를 직접 부르는 코드를 어디에도 새로 쓰지 않는다.** 게시 경로는
+  `_gh_pr_review_post_comment` 하나뿐이다 — 두 개가 되면 soft-fail 계약과 skip 경로
+  (`GH_DISABLE_AI_METRICS=1`)가 한쪽에서만 지켜진다.
+- 자격증명 · `storage_state` 경로를 코멘트 본문에 넣지 않는다 (`report-template.md` 와
+  같은 규칙 — 코멘트는 리포트보다 오래, 더 넓게 남는다).

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -2,6 +2,9 @@
 
 사용자 관점의 의미 있는 변경 기록. 포맷: `## YYYY-MM-DD` 헤더 아래 `- 변경: **요약**`.
 
+## 2026-08-07
+- 변경: **`devx:pr-verify-live` 가 검증 리포트를 대상 PR 에 코멘트로 게시 — Step 8 결과가 `[OK]`/`[WARN]` 이면 그 리포트 블록을 그대로 PR 코멘트로 남긴다(Step 9). `[FAIL]` 은 검증 전 단언이 막은 환경 문제이므로 게시하지 않고 로컬 출력으로만 끝낸다. 게시 경로는 `gh_pr_review.sh` 의 `_gh_pr_review_post_comment` 재사용이라 soft-fail 계약(게시 실패는 경고, 스킬 정지 아님)이 그대로 유지되고, 헬퍼는 레포 표준 폴백 블록(#644 NF-1 + #724)으로 감싸 부른다. 매 실행이 새 코멘트를 덧붙이는 append-only 동작 — 재검증 이력이 덮이지 않는다. 끄려면 새 플래그 `--no-comment`(파서 출력 `post_comment=0`); `--dry-run`/`--no-issue` 는 이슈 생성만 게이트하므로 코멘트 게시와 서로 독립이다 (#1288)**
+
 ## 2026-08-06
 - 변경: **Stop 가드 두 개(`gh_issue_flow_stop_guard.py` / `devx_autopilot_stop_guard.py`)의 harness 마커 판정을 부분 문자열에서 줄머리 고정(`(?m)^`) 으로 교체 — 사람이 `"Stop hook feedback:"` 이나 `<task-notification>` 을 문장 안에 인용하기만 해도 그 턴 전체가 fresh user prompt 집계에서 빠져 stale boundary 가 만료되지 않던 문제 수정. 마커 문자열 SSOT 인 `_SKILL_EXPANSION_MARKERS` / `_HARNESS_INJECTION_MARKERS` 튜플에서 `re.escape` 로 정규식을 파생하며, 두 훅에 동일한 구조로 적용해 #1275 식 구조 드리프트를 막는다. 단 `is already loaded above` 는 예외 — 실제 주입문이 `Skill <name> is already loaded above; instructions unchanged. Arguments: …` 형태라 리터럴이 줄머리에 오지 않으므로, `_SKILL_EXPANSION_SHAPES` 의 `^Skill\s+\S+\s+is already loaded above` 정규식 조각으로 실제 문장 구조를 매칭한다(그대로 리터럴로 두면 이 한 마커에 대해 #1270 의 over-count 가 되살아난다) (#1281)**
 - 변경: **`gh:pr-review` 의 임시파일 3종(`PROMPT_FILE`/`AI_OUT`/`BODY_FILE`) 할당을 `_gh_pr_review_mktemp_safe <template>` 하나로 통일 — `mktemp` 실패 시 쓰던 예측 가능한 `$$` 폴백 경로를 `set -C`(noclobber, O_CREAT\|O_EXCL) 서브셸로 배타 생성하고, 그 자리에 파일이나 심볼릭 링크가 이미 있으면 링크를 따라 덮어쓰지 않고 즉시 실패한다. 세 호출 지점 모두 실패를 검사해 `gh_pr_review` 를 중단하므로(빈 경로로 진행하지 않음), `/tmp` 가 쓰기 불가·쿼터 초과일 때 로컬 공격자가 PID 를 예측해 심링크를 심어 임의 파일을 덮어쓰던 경로가 닫힌다 (#1283)**

--- a/shell-common/functions/devx_pr_verify_live.sh
+++ b/shell-common/functions/devx_pr_verify_live.sh
@@ -31,6 +31,7 @@ devx_pr_verify_live_parse() {
     local locales=""
     local issue_mode="create"
     local allow_remote_host=0
+    local post_comment=1
     local _remote_set=0
     local _pos_seen=0
     local _url_set=0
@@ -119,6 +120,10 @@ devx_pr_verify_live_parse() {
             ;;
         --no-issue)
             _no_issue=1
+            shift
+            ;;
+        --no-comment)
+            post_comment=0
             shift
             ;;
         --allow-remote-host)
@@ -266,5 +271,6 @@ devx_pr_verify_live_parse() {
     printf '%s\n' "locales=$locales"
     printf '%s\n' "issue_mode=$issue_mode"
     printf '%s\n' "allow_remote_host=$allow_remote_host"
+    printf '%s\n' "post_comment=$post_comment"
     return 0
 }

--- a/tests/bats/functions/devx_pr_verify_live.bats
+++ b/tests/bats/functions/devx_pr_verify_live.bats
@@ -21,6 +21,7 @@ setup() {
     assert_line "locales="
     assert_line "issue_mode=create"
     assert_line "allow_remote_host=0"
+    assert_line "post_comment=1"
 }
 
 @test "pr only -> remote origin" {
@@ -255,6 +256,13 @@ setup() {
     assert_line "issue_mode=none"
 }
 
+@test "--no-comment -> post_comment=0" {
+    run devx_pr_verify_live_parse --no-comment
+    assert_success
+    assert_line "post_comment=0"
+    assert_line "issue_mode=create"
+}
+
 @test "--allow-remote-host -> 1" {
     run devx_pr_verify_live_parse --allow-remote-host
     assert_success
@@ -338,7 +346,8 @@ setup() {
 @test "combined flags resolve together" {
     run devx_pr_verify_live_parse 99 upstream --url http://127.0.0.1:3000 \
         --api-url=http://127.0.0.1:8080 --start "npm run dev" \
-        --matrix full --viewports 1440,768,390 --locales ko,en --allow-remote-host
+        --matrix full --viewports 1440,768,390 --locales ko,en --allow-remote-host \
+        --no-comment
     assert_success
     assert_line "pr=99"
     assert_line "remote=upstream"
@@ -350,6 +359,7 @@ setup() {
     assert_line "locales=ko,en"
     assert_line "issue_mode=create"
     assert_line "allow_remote_host=1"
+    assert_line "post_comment=0"
 }
 
 # The parser lives in shell-common/functions/, which zsh/main.zsh auto-sources
@@ -379,19 +389,21 @@ setup() {
     [ "$matrix" = "SENTINEL_MATRIX" ]
 }
 
-@test "parse does not leak viewports/locales/issue_mode/allow_remote_host/_item" {
+@test "parse does not leak viewports/locales/issue_mode/allow_remote_host/post_comment/_item" {
     viewports="SENTINEL_VIEWPORTS"
     locales="SENTINEL_LOCALES"
     issue_mode="SENTINEL_ISSUE_MODE"
     allow_remote_host="SENTINEL_ALLOW"
+    post_comment="SENTINEL_POST_COMMENT"
     _rest="SENTINEL_REST"
     _item="SENTINEL_ITEM"
     devx_pr_verify_live_parse --viewports 1440,390 --locales ko,en \
-        --dry-run --allow-remote-host >/dev/null
+        --dry-run --allow-remote-host --no-comment >/dev/null
     [ "$viewports" = "SENTINEL_VIEWPORTS" ]
     [ "$locales" = "SENTINEL_LOCALES" ]
     [ "$issue_mode" = "SENTINEL_ISSUE_MODE" ]
     [ "$allow_remote_host" = "SENTINEL_ALLOW" ]
+    [ "$post_comment" = "SENTINEL_POST_COMMENT" ]
     [ "$_rest" = "SENTINEL_REST" ]
     [ "$_item" = "SENTINEL_ITEM" ]
 }


### PR DESCRIPTION
## Summary
- `devx:pr-verify-live` 가 Step 8 리포트를 `[OK]`/`[WARN]` 결과에 한해 대상 PR 코멘트로 게시하는 Step 9 를 추가한다.

## Changes
- `shell-common/functions/devx_pr_verify_live.sh`: `--no-comment` 플래그 추가, 파서 출력에 `post_comment`(기본 1) 라인 추가
- `tests/bats/functions/devx_pr_verify_live.bats`: 신규/확장 4개 테스트로 `post_comment` 계약 고정(leak guard 포함)
- `claude/skills/devx-pr-verify-live/references/pr-comment.md`: 신규 — Step 9 트리거 조건 · `--dry-run`/`--no-issue` 와의 독립성 · append-only 근거 · `_gh_pr_review_post_comment` 재사용 가드 블록 문서화
- `claude/skills/devx-pr-verify-live/SKILL.md`: frontmatter 인자 목록 갱신, Step 1 capture 목록에 `post_comment` 추가, Step 9 신설
- `claude/skills/devx-pr-verify-live/references/help.md`: `--no-comment` Flags 행 · Usage 예시 · "What the skill does" 9번 항목 추가
- `docs/public/changelog.md`: 2026-08-07 항목 추가

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_verify_live.bats` — 58/58 green
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/devx_pr_verify_live.sh` — clean
- [x] `shfmt -d -i 4 shell-common/functions/devx_pr_verify_live.sh` — no diff
- [ ] 실제 PR 에서 `/devx-pr-verify-live` 를 `[OK]`/`[WARN]` 결과로 실행해 코멘트가 실제 게시되는지 라이브 확인 (후속)

## Related
Closes #1288

---
<details>
<summary>🤖 AI Metrics · 📊 ~4500 tokens · 👤 ~8 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4500 tokens · 👤 ~8 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
