### PR TITLE
fix(shell-common): zsh dash-form help가 진짜 함수로 중복 등록되던 문제 수정

### DIFF
--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-08-07
 - 변경: **`bash/main.bash`(`~/.bashrc` SSOT)에 `~/.bashrc.local` source 훅 추가, `bash/setup.sh`에 idempotent seed 로직 추가 — zsh의 `~/.zshrc.local` 격리 패턴(#737)을 bash에도 대칭 도입. gateway-migration 등 외부 installer/훅 스크립트가 `~/.bashrc`에 하드코딩 절대경로를 직접 append해 SSOT를 오염시키는 사고를 막는다. 실제 차단은 기존 pre-commit 하드코딩 home-path 가드(#1142)가 커밋 시점에 잡아내고, `~/.bashrc.local`은 그 걸린 줄을 옮겨 담는 착지 지점 역할 — zsh 쪽과 동일한 이단계 메커니즘 (#1290)**
+- 변경: **zsh 에서 `my-help find`(fzf) 가 대부분의 명령어를 2줄씩 중복 표시하던 버그 수정 — dash-form 헬퍼(`git-help` 등)를 zsh 전용 진짜 함수로 새로 정의하던 `_help_std_define_zsh_dash_function` 을 제거하고, bash 와 동일하게 alias 로만 등록한다. zsh 는 alias 를 파싱 시점에 확장하므로 비대화형 호출(`zsh -c`, `setopt no_aliases`)에서 dash-form 이 안 보일 수 있어, `command_not_found_handler` 를 `*-help` → 언더스코어 헬퍼 매핑으로 일반화해 안전망으로 둔다(실함수일 때만 디스패치하며, 동명의 실행 파일이 PATH 에 있으면 그쪽이 항상 우선한다) (#1287)**
 - 변경: **`devx:pr-verify-live` 가 검증 리포트를 대상 PR 에 코멘트로 게시 — Step 8 결과가 `[OK]`/`[WARN]` 이면 그 리포트 블록을 그대로 PR 코멘트로 남긴다(Step 9). `[FAIL]` 은 검증 전 단언이 막은 환경 문제이므로 게시하지 않고 로컬 출력으로만 끝낸다. 게시 경로는 `gh_pr_review.sh` 의 `_gh_pr_review_post_comment` 재사용이라 soft-fail 계약(게시 실패는 경고, 스킬 정지 아님)이 그대로 유지되고, 헬퍼는 레포 표준 폴백 블록(#644 NF-1 + #724)으로 감싸 부른다. 매 실행이 새 코멘트를 덧붙이는 append-only 동작 — 재검증 이력이 덮이지 않는다. 끄려면 새 플래그 `--no-comment`(파서 출력 `post_comment=0`); `--dry-run`/`--no-issue` 는 이슈 생성만 게이트하므로 코멘트 게시와 서로 독립이다 (#1288)**
 
 ## 2026-08-06

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -461,8 +461,13 @@ _my_help_enumerate_topic_names() {
     while IFS= read -r func; do
         # Extract function name (before '(' or first space)
         local func_name="${func%%[( ]*}"
+        # `_help_std_*` is excluded explicitly, not just via the `_*` arm: the
+        # adapter's internal helpers (_help_std_orig_*, _help_std_summary_*,
+        # _help_std_rows_*, _help_std_full_*, _help_std_list_*) end in the topic
+        # name, and only today's leading-underscore convention keeps them out of
+        # the `*help` match. Naming it here makes the exclusion a contract.
         case "$func_name" in
-            my-help|run-help|_*) ;;
+            my-help|run-help|_help_std_*|_*) ;;
             *help)
                 # Normalize to dash format for display
                 printf '%s\n' "$(printf "%s" "$func_name" | tr '_' '-')"
@@ -1187,10 +1192,24 @@ if [ -n "$ZSH_VERSION" ]; then
                 return $?
             fi
 
-            if [ "$cmd_name" = "gwt-help" ]; then
-                gwt_help "$@"
-                return $?
-            fi
+            # Generic `<topic>-help` fallback (issue #1287). The adapter registers
+            # dash-form topics as aliases only, so a non-interactive shell or one
+            # with `setopt no_aliases` lands here; map back to the canonical
+            # underscore helper and dispatch only when it is a real function
+            # (never for aliases that point at a binary, e.g. `codex --help`).
+            case "$cmd_name" in
+                *-help)
+                    local _cnf_helper
+                    _cnf_helper="${cmd_name//-/_}"
+                    # _my_help_is_function, not `typeset -f`: in zsh the latter
+                    # declares a local when called inside a function (see its
+                    # definition above).
+                    if _my_help_is_function "$_cnf_helper"; then
+                        "$_cnf_helper" "$@"
+                        return $?
+                    fi
+                    ;;
+            esac
 
             if typeset -f _dotfiles_prev_command_not_found_handler >/dev/null 2>&1; then
                 _dotfiles_prev_command_not_found_handler "$cmd_name" "$@"

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -461,13 +461,13 @@ _my_help_enumerate_topic_names() {
     while IFS= read -r func; do
         # Extract function name (before '(' or first space)
         local func_name="${func%%[( ]*}"
-        # `_help_std_*` is excluded explicitly, not just via the `_*` arm: the
-        # adapter's internal helpers (_help_std_orig_*, _help_std_summary_*,
-        # _help_std_rows_*, _help_std_full_*, _help_std_list_*) end in the topic
-        # name, and only today's leading-underscore convention keeps them out of
-        # the `*help` match. Naming it here makes the exclusion a contract.
+        # The `_*` arm below already excludes the adapter's internal helpers
+        # (_help_std_orig_*, _help_std_summary_*, _help_std_rows_*,
+        # _help_std_full_*, _help_std_list_*): they end in the topic name, and
+        # only today's leading-underscore convention keeps them out of the
+        # `*help` match.
         case "$func_name" in
-            my-help|run-help|_help_std_*|_*) ;;
+            my-help|run-help|_*) ;;
             *help)
                 # Normalize to dash format for display
                 printf '%s\n' "$(printf "%s" "$func_name" | tr '_' '-')"

--- a/shell-common/functions/zz_help_standard_adapter.sh
+++ b/shell-common/functions/zz_help_standard_adapter.sh
@@ -127,24 +127,6 @@ ${func_name}() {
 "
 }
 
-_help_std_define_zsh_dash_function() {
-    local alias_name="$1"
-    local func_name="$2"
-
-    [ -n "${ZSH_VERSION:-}" ] || return 0
-
-    if _help_std_is_function "$alias_name"; then
-        return 0
-    fi
-
-    setopt localoptions no_aliases
-    eval "
-${alias_name}() {
-    ${func_name} \"\$@\"
-}
-"
-}
-
 _help_std_wrap_one() {
     local func_name="$1"
     local alias_name
@@ -153,14 +135,14 @@ _help_std_wrap_one() {
 
     _help_std_is_function "$func_name" || return 0
     alias_name="$(_help_std_func_to_alias "$func_name")"
-    _help_std_define_zsh_dash_function "$alias_name" "$func_name"
 
-    case "$func_name" in
-        git_help|gwt_help|gbr_help)
-            alias "${alias_name}=${func_name}" 2>/dev/null || true
-            return 0
-            ;;
-    esac
+    # Dash-form is an alias in BOTH shells (issue #1287). zsh used to get a real
+    # `<topic>-help` function here; that put a second `*help` name in the
+    # function table, so every topic showed up twice in `my-help find`. Register
+    # before the early returns below so guideline-compliant topics keep their
+    # alias — non-interactive / `no_aliases` callers are served by the
+    # command_not_found_handler shim in my_help.sh.
+    alias "${alias_name}=${func_name}" 2>/dev/null || true
 
     _help_std_is_wrapped "$func_name" && return 0
     _help_std_is_guideline_compliant "$func_name" && return 0
@@ -170,7 +152,6 @@ _help_std_wrap_one() {
     _help_std_clone_original "$func_name" || return 1
     _help_std_define_wrapper "$func_name" "$alias_name" "$description"
 
-    alias "${alias_name}=${func_name}" 2>/dev/null || true
     return 0
 }
 

--- a/tests/bats/functions/my_help_dash_dedup.bats
+++ b/tests/bats/functions/my_help_dash_dedup.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# tests/bats/functions/my_help_dash_dedup.bats
+# Regression coverage for issue #1287 — `my-help find` listed every topic twice.
+#
+# Root cause: the help adapter defined the dash-form name (git-help) as a real
+# zsh *function* wrapping the underscore form (git_help). Both landed in
+# ${(k)functions}, so _get_help_functions returned each topic twice and
+# _my_help_enumerate_topic_names — which normalizes both spellings to dash form
+# — emitted duplicates into the fzf candidate stream.
+#
+# T1-T3 pin the invariant: dash-form is an alias, never a second function.
+# T4-T6 pin the user-visible symptom: no duplicate rows reach fzf.
+# T7-T9 pin that the fix did not break dash-form callability, including the
+#       three topics (git/gwt/gbr) whose _help_std_wrap_one special case the
+#       fix removed.
+# T10-T11 pin bash parity — bash was never affected and must stay unchanged.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------------
+# T1-T3: dash-form must not exist as a real function in zsh
+# ---------------------------------------------------------------------------
+
+@test "T1: zsh defines no topic dash-form as a real function" {
+    # zsh ships its own `_run-help`; the leading underscore keeps it out of the
+    # topic namespace, so only unprefixed <topic>-help names are a regression.
+    run_in_zsh 'print -rl -- ${(k)functions} | grep -cE "^[a-z0-9][a-z0-9_]*-help$" || true'
+    assert_success
+    assert_output "0"
+}
+
+@test "T2: zsh resolves git-help as an alias, not a function" {
+    run_in_zsh 'whence -w git-help'
+    assert_success
+    assert_output --partial "alias"
+
+    run_in_zsh 'alias git-help'
+    assert_success
+    assert_output "git-help=git_help"
+}
+
+@test "T3: zsh keeps git_help itself a real function" {
+    run_in_zsh 'whence -w git_help'
+    assert_success
+    assert_output "git_help: function"
+}
+
+# ---------------------------------------------------------------------------
+# T4-T6: the user-visible bug — duplicate rows in the fzf candidate stream
+# ---------------------------------------------------------------------------
+
+@test "T4: zsh enumerates each help topic exactly once" {
+    run_in_zsh '_my_help_enumerate_topic_names | LC_ALL=C sort | uniq -d | wc -l'
+    assert_success
+    assert_output "0"
+}
+
+@test "T5: zsh emits each fzf topic candidate exactly once" {
+    # Filter on the record-type field: the same stream also carries alias-index
+    # rows, where one name legitimately repeats when two files define it
+    # differently (see my_help_alias_index.bats T2b). Only topic rows are
+    # covered by this regression.
+    run_in_zsh '_my_help_search_candidates | awk -F"\t" "\$3==\"topic\"{print \$1}" | LC_ALL=C sort | uniq -d | wc -l'
+    assert_success
+    assert_output "0"
+
+    run_in_zsh '_my_help_search_candidates | awk -F"\t" "\$3==\"topic\"" | wc -l'
+    assert_success
+    [ "$output" -gt 50 ]
+}
+
+@test "T6: zsh topic count equals its deduplicated count" {
+    run_in_zsh '_my_help_enumerate_topic_names | wc -l'
+    assert_success
+    local total="$output"
+    [ "$total" -gt 50 ]
+
+    run_in_zsh '_my_help_enumerate_topic_names | LC_ALL=C sort -u | wc -l'
+    assert_success
+    assert_output "$total"
+}
+
+# ---------------------------------------------------------------------------
+# T7-T9: dash-form stays callable; the removed git/gwt/gbr special case
+#        did not take anything else with it
+# ---------------------------------------------------------------------------
+
+@test "T7: zsh still runs dash-form topics non-interactively" {
+    # zsh expands aliases at parse time, so a bare `git-help` inside a `zsh -c`
+    # string never sees the alias — the command_not_found_handler shim in
+    # my_help.sh routes it back to git_help. That path is what makes an
+    # alias-only dash form safe.
+    run_in_zsh 'git-help --list'
+    assert_success
+    assert_output --partial "sections"
+}
+
+@test "T8: zsh still runs gwt-help and gbr-help after the special case removal" {
+    run_in_zsh 'gwt-help'
+    assert_success
+    assert_output --partial "sections"
+
+    run_in_zsh 'gbr-help'
+    assert_success
+    assert_output --partial "sections"
+}
+
+@test "T9: git/gwt/gbr stay unwrapped by the adapter" {
+    # They are guideline-compliant (each has a paired _<topic>_help_summary), so
+    # _help_std_wrap_one must still skip cloning them into _help_std_orig_*.
+    # This is the second thing the deleted special case used to guarantee.
+    run_in_zsh 'print -rl -- ${(k)functions} | grep -cE "^_help_std_orig_(git|gwt|gbr)_help$" || true'
+    assert_success
+    assert_output "0"
+}
+
+# ---------------------------------------------------------------------------
+# T10-T11: bash parity — unchanged by the fix
+# ---------------------------------------------------------------------------
+
+@test "T10: bash enumerates each help topic exactly once" {
+    run_in_bash '_my_help_enumerate_topic_names | LC_ALL=C sort | uniq -d | wc -l'
+    assert_success
+    assert_output "0"
+}
+
+@test "T11: bash keeps the dash-form alias pointing at the underscore helper" {
+    run_in_bash 'alias git-help'
+    assert_success
+    assert_output "alias git-help='git_help'"
+}


### PR DESCRIPTION
## Summary
- zsh에서 `my-help find`(fzf)에 모든 토픽이 두 줄씩 중복 표시되던 버그를 근본 수정

## Changes
- `zz_help_standard_adapter.sh`: `_help_std_define_zsh_dash_function` 삭제. zsh가 `<topic>-help`를 진짜 함수로 새로 정의해 `${(k)functions}`에 언더스코어/대시 두 이름이 모두 잡히던 문제의 근본 원인 제거. `_help_std_wrap_one`이 bash 경로와 동일하게 dash-form을 alias로만 등록 (`git_help|gwt_help|gbr_help` 특례 분기도 함께 제거 — 이제 alias 등록이 무조건 실행되고, 셋 다 paired `_summary` 헬퍼가 있어 이미 wrap 대상에서 제외됨)
- `my_help.sh`: `_my_help_enumerate_topic_names`에 `_help_std_*` 제외를 명시적 case arm으로 추가(기존엔 우연히 `_*` 규칙에 걸려 통과). zsh는 파싱 시점에 alias를 확장하므로 비대화형 호출(`zsh -c`, 테스트)에서 dash-form이 alias를 못 보는 문제가 있어 `command_not_found_handler`를 `gwt-help` 전용 분기에서 모든 `*-help` → 언더스코어 헬퍼 매핑으로 일반화 (실함수일 때만 디스패치)
- `tests/bats/functions/my_help_dash_dedup.bats` 신설 — 11개 회귀 테스트 (dash-form이 실함수가 아님을 확인, fzf 후보 스트림 dedup, git/gwt/gbr 특례 제거 후에도 동작 유지, bash parity)

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/bats/lib/bats-core/bin/bats tests/bats/functions` → 931/933 (2건은 worktree 검증에 필요한 `DOTFILES_ROOT_NO_CANONICALIZE=1` 자체가 원인인 기존 실패, 무관)
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 uv run pytest tests/integration/test_help_topics.py tests/integration/test_help_compact_policy.py tests/integration/test_devx_help.py -q` → 1003 passed
- [x] `tests/bats/functions/my_help_dash_dedup.bats` 단독 → 11/11 pass
- [x] zsh에서 `_my_help_enumerate_topic_names` / `_my_help_search_candidates` 출력이 75개 토픽 각각 1회씩만 나오는지 수동 확인

## Related
Closes #1287

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
