### PR TITLE
chore(bash): #1290 주석에 남은 사내 gateway-migration 스킬명 일반화

### DIFF
--- a/bash/main.bash
+++ b/bash/main.bash
@@ -234,8 +234,8 @@ _apply_setup_mode_config
 
 # Local PC-specific overrides — installer-mutable lines (bun, nvm, pyenv, …)
 # live here so the tracked dotfile stays clean. Issue #1290 mirrors the zsh
-# pattern from issue #737 / PR #736 — installer and hook scripts (e.g. the
-# internal gateway-migration plugin) keep appending resolved absolute
+# pattern from issue #737 / PR #736 — installer and hook scripts (e.g.
+# internal plugin hooks) keep appending resolved absolute
 # /home/<user>/... paths to ~/.bashrc; routing those through ~/.bashrc.local
 # (untracked) plus the pre-commit hardcoded-home-path guard prevents the
 # drift from landing in this tracked SSOT.

--- a/bash/setup.sh
+++ b/bash/setup.sh
@@ -133,7 +133,7 @@ create_symlink "$MAIN_BASH_SOURCE" "$HOME_BASHRC"
 
 # Seed ~/.bashrc.local (untracked, PC-specific overrides). Issue #1290 —
 # mirrors the zsh pattern from issue #737. Installer/hook side-effects
-# (gateway-migration, bun, nvm, …) must NOT land in the tracked dotfile.
+# (bun, nvm, …) must NOT land in the tracked dotfile.
 # We create the file once if it does not exist; existing content is never
 # touched (idempotent).
 


### PR DESCRIPTION
## Summary
- #1290 fix(커밋 57c42d01)의 주석에 남아있던 사내 전용 Claude Code 플러그인 스킬명 `gateway-migration`을 범용 표현으로 일반화한다. 이 저장소는 public이라 사내 고유명사가 남으면 안 된다.

## Changes
- `bash/main.bash:238`: "internal gateway-migration plugin" → "internal plugin hooks"로 일반화.
- `bash/setup.sh:136`: 예시 나열에서 `gateway-migration` 제거, 기존 `bun, nvm, …` 범용 예시만 유지 — zsh 쪽(zsh/zshrc, zsh/setup.sh)이 이미 쓰던 스타일과 통일.

## Test plan
- [x] `grep -rn "gateway-migration" bash/ zsh/ tests/` → 0건
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/setup/test_bashrc_local_seed.bats` — 4/4 pass

## Related
Closes #1296

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
