### PR TITLE
docs(claude): tool-call 파라미터 non-ASCII 리터럴 UTF-8 작성 규칙 추가

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,5 +1,7 @@
 # Global Instructions
 
+**Always write Korean (and other non-ASCII) strings in tool-call parameters as literal UTF-8; never as \uXXXX unicode escapes.**
+
 ## 모델 역할 분담: Advisor / Worker
 
 메인 세션(Advisor)은 판단에 집중하고, 열린 구현 작업(open-ended implementation)은


### PR DESCRIPTION
## Summary
- `claude/CLAUDE.md`(전역 지침) 최상단에 tool-call 파라미터 non-ASCII 리터럴 UTF-8 작성 규칙 1줄 추가

## Changes
- docs(claude): `# Global Instructions` 헤더 바로 아래에 "Claude Code 툴콜 파라미터 내 한글 등 non-ASCII 문자열은 항상 리터럴 UTF-8로 쓰고 `\uXXXX` 유니코드 이스케이프를 쓰지 않는다"는 규칙을 추가 — 툴콜 파라미터의 한글이 유니코드 이스케이프로 깨지던 반복 현상을 방지

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/test` — pytest 1307 passed (bats는 이 워크트리에 bats-core 서브모듈이 체크아웃되지 않아 기존과 동일하게 skip, 이번 변경과 무관)

## Related
Closes #1299

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
