### PR TITLE
fix(ux_lib): ux_header 박스 테두리 정렬 버그 수정

### DIFF
--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -131,11 +131,24 @@ fi
 ux_header() {
     local text="$1"
     local width=60
+    if [ ${#text} -gt "$width" ]; then
+        width=${#text}
+    fi
+
+    local border
+    if $_UX_IS_BASH; then
+        border=$(printf '═%.0s' $(seq 1 $((width + 2))))
+    elif $_UX_IS_ZSH; then
+        border=$(printf '═%.0s' {1..$((width + 2))})
+    else
+        # POSIX fallback
+        border=$(printf '═%.0s' $(seq 1 $((width + 2))))
+    fi
 
     echo ""
-    printf "%s%s╔══════════════════════════════════════════════════════════════╗%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
-    printf "%s%s║%s %-60s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
-    printf "%s%s╚══════════════════════════════════════════════════════════════╝%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    printf "%s%s╔%s╗%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$border" "${UX_RESET}"
+    printf "%s%s║%s %-${width}s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    printf "%s%s╚%s╝%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$border" "${UX_RESET}"
     echo ""
 }
 


### PR DESCRIPTION
## Summary
- `ux_header`가 렌더링하는 박스 테두리(╔═…═╗)가 60자를 넘는 헤더 텍스트에서 오른쪽 `║`가 밀려 나오는 정렬 버그 수정

## Changes
- `ux_lib`: `ux_header`의 상하단 `═` 테두리 폭을 텍스트 길이에 맞춰 동적으로 계산하도록 변경(최소 60자 유지). 기존에는 상하단 테두리가 62자로 고정된 반면 본문 `%-60s` 필드는 60자를 넘는 텍스트를 자르지 않고 그대로 초과 출력해, `gcp scan` 헤더처럼 62자짜리 텍스트가 들어오면 오른쪽 `║`가 2칸 밀려 렌더링됐다.

## Test plan
- [x] bash/zsh 각각에서 60자 이하(`Short`) / 60자 초과(gcp scan 헤더, 62자) 텍스트로 `ux_header` 렌더링 후 3줄(상단/본문/하단) 폭 일치 확인 — 64/64/64, 66/66/66
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/test` — 1307 passed (워크트리 canonicalize로 메인 체크아웃을 잘못 검증하는 것을 방지)
- [x] `shellcheck`/`shfmt`를 `shell-common/tools/ux_lib/ux_lib.sh`에 직접 실행 — 수정 전 대비 신규 경고 카테고리 없음(기존 POSIX-vs-bash/zsh 스타일 경고 2건 추가, 전부 파일에 이미 존재하던 패턴과 동일 계열)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
