### PR TITLE
fix(gh-pr-lint): lint-guard shellcheck 호출에 SC1090/SC1091 제외 추가

### DIFF
--- a/claude/skills/gh-pr/references/lint-guard.md
+++ b/claude/skills/gh-pr/references/lint-guard.md
@@ -37,7 +37,7 @@ The guard picks tools in this order, top-down:
    are actually declared.
 2. **shellcheck** — `command -v shellcheck` succeeds **and** the changed
    file set contains at least one `*.sh`. Runs
-   `shellcheck -x -S warning <changed-sh-files>`.
+   `shellcheck -x -e SC1090,SC1091 -S warning <changed-sh-files>`.
 3. **actionlint** — `command -v actionlint` succeeds **and** the change
    set contains at least one `.github/workflows/*`. Runs
    `actionlint <changed-workflow-files>`.

--- a/shell-common/functions/gh_pr_lint.sh
+++ b/shell-common/functions/gh_pr_lint.sh
@@ -149,7 +149,7 @@ _gh_pr_lint_run() {
                 done <<EOF
 $_sh_files
 EOF
-                if shellcheck -x -S warning "$@"; then
+                if shellcheck -x -e SC1090,SC1091 -S warning "$@"; then
                     _gh_pr_lint__log "shellcheck passed"
                 else
                     _gh_pr_lint__log "shellcheck FAILED"

--- a/tests/bats/functions/gh_pr_lint.bats
+++ b/tests/bats/functions/gh_pr_lint.bats
@@ -206,8 +206,9 @@ TOX
     assert_output --partial "rc=0"
     assert_output --partial "running shellcheck on 2 file(s)"
     assert_output --partial "shellcheck passed"
-    # The lint tool was invoked once with -x -S warning + both .sh files.
-    run grep -cF '[-x] [-S] [warning]' "$TOOL_LOG"
+    # The lint tool was invoked once with -x -e SC1090,SC1091 -S warning
+    # (mise.toml lint-sh SSOT parity, #1306) + both .sh files.
+    run grep -cF '[-x] [-e] [SC1090,SC1091] [-S] [warning]' "$TOOL_LOG"
     assert_output "1"
     run grep -cF '[bar.sh]' "$TOOL_LOG"
     assert_output "1"


### PR DESCRIPTION
## Summary
- `gh_pr_lint.sh`의 pre-push lint-guard가 호출하는 `shellcheck`에 `mise.toml` `lint-sh` SSOT와 동일한 `-e SC1090,SC1091` 제외 플래그를 추가해, 의도된 동적 소싱(`source "$VAR" 2>/dev/null`)을 SC1090으로 오탐 처리하던 문제를 수정

## Changes
- `shell-common/functions/gh_pr_lint.sh`: shellcheck 호출을 `-x -S warning`에서 `-x -e SC1090,SC1091 -S warning`으로 변경
- `tests/bats/functions/gh_pr_lint.bats`: 회귀 테스트가 검증하던 인자 순서 문자열(`[-x] [-S] [warning]`)을 새 플래그 순서(`[-x] [-e] [SC1090,SC1091] [-S] [warning]`)로 갱신

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_lint.bats` — 12/12 pass
- [x] `mise run lint-sh` — clean

## Related
Closes #1306

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~7 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~7 min
<!-- /ai-metrics:gh-pr -->

</details>
