### PR TITLE
test(shell-common): PR #1307 회귀 3건 잠금 — tools/custom 인터랙티브 스크립트

### DIFF
--- a/shell-common/tools/custom/docker_configure_proxy.sh
+++ b/shell-common/tools/custom/docker_configure_proxy.sh
@@ -10,6 +10,27 @@ set -e
 source "$(dirname "$0")/init.sh" || exit 1
 
 
+# Create the systemd drop-in directory that holds http-proxy.conf.
+# Usage: docker_proxy_create_dropin_dir /etc/systemd/system/docker.service.d
+#
+# Extracted out of main() so the failure path is directly testable with a
+# mocked `sudo` (issue #1308). Success is decided by `sudo mkdir -p` itself:
+# the previous `sudo mkdir -p ...` followed by a separate `if [ $? -ne 0 ]`
+# inspected the status one statement too late, and under this script's `set -e`
+# the bare mkdir aborted the whole run first — the error handler was dead code
+# (issue #1305 / PR #1307). The explicit `return 0` keeps the ux_success side
+# effect out of the function's exit status.
+docker_proxy_create_dropin_dir() {
+    local dir="$1"
+
+    if ! sudo mkdir -p "$dir"; then
+        ux_error "Failed to create directory: $dir"
+        return 1
+    fi
+    ux_success "Directory created: $dir"
+    return 0
+}
+
 # Main script
 main() {
     clear
@@ -65,11 +86,9 @@ main() {
 
     local drop_in_dir="/etc/systemd/system/docker.service.d"
 
-    if ! sudo mkdir -p "$drop_in_dir"; then
-        ux_error "Failed to create directory: $drop_in_dir"
+    if ! docker_proxy_create_dropin_dir "$drop_in_dir"; then
         return 1
     fi
-    ux_success "Directory created: $drop_in_dir"
 
     # ========================================
     # Step 4: Create http-proxy.conf file

--- a/shell-common/tools/custom/docker_configure_proxy.sh
+++ b/shell-common/tools/custom/docker_configure_proxy.sh
@@ -13,13 +13,10 @@ source "$(dirname "$0")/init.sh" || exit 1
 # Create the systemd drop-in directory that holds http-proxy.conf.
 # Usage: docker_proxy_create_dropin_dir /etc/systemd/system/docker.service.d
 #
-# Extracted out of main() so the failure path is directly testable with a
-# mocked `sudo` (issue #1308). Success is decided by `sudo mkdir -p` itself:
-# the previous `sudo mkdir -p ...` followed by a separate `if [ $? -ne 0 ]`
-# inspected the status one statement too late, and under this script's `set -e`
-# the bare mkdir aborted the whole run first — the error handler was dead code
-# (issue #1305 / PR #1307). The explicit `return 0` keeps the ux_success side
-# effect out of the function's exit status.
+# Branches on `sudo mkdir -p` directly, not a separately-inspected `$?` —
+# under this script's `set -e`, a failing bare `mkdir -p` would abort the
+# run before any later `$?` check ran. The explicit `return 0` keeps the
+# ux_success side effect out of the function's exit status.
 docker_proxy_create_dropin_dir() {
     local dir="$1"
 

--- a/shell-common/tools/custom/install_claude.sh
+++ b/shell-common/tools/custom/install_claude.sh
@@ -9,6 +9,27 @@ set -e
 # Initialize common tools environment
 source "$(dirname "$0")/init.sh" || exit 1
 
+# Classify an OSTYPE string into the installer branch it selects.
+# Usage: install_claude_platform_branch "$OSTYPE"  ->  unix | windows | unsupported
+#
+# Pure routing helper: no side effects, and the token it writes to stdout is a
+# return value, not user-facing output. Extracted from main() so the OSTYPE
+# variants stay verifiable after the case-pattern cleanup in PR #1307
+# (issue #1308).
+install_claude_platform_branch() {
+    case "$1" in
+        darwin* | linux* | freebsd*)
+            printf '%s\n' "unix"
+            ;;
+        msys | msys* | win32 | cygwin)
+            printf '%s\n' "windows"
+            ;;
+        *)
+            printf '%s\n' "unsupported"
+            ;;
+    esac
+}
+
 main() {
     clear
     ux_header "Claude Code CLI Installer"
@@ -39,8 +60,8 @@ main() {
     # ========================================
     ux_step "2/2" "Installing Claude Code..."
 
-    case "$OSTYPE" in
-        darwin* | linux* | freebsd*)
+    case "$(install_claude_platform_branch "$OSTYPE")" in
+        unix)
             # macOS, Linux, WSL - use bash installer
             ux_info "Platform: ${OSTYPE} (using bash installer)"
             if ! ux_with_spinner "Installing Claude Code" \
@@ -50,7 +71,7 @@ main() {
                 exit 1
             fi
             ;;
-        msys | msys* | win32 | cygwin)
+        windows)
             # Windows (Git Bash, Cygwin)
             ux_error "Windows detected in Git Bash/Cygwin environment"
             echo ""

--- a/shell-common/tools/custom/install_claude.sh
+++ b/shell-common/tools/custom/install_claude.sh
@@ -21,7 +21,7 @@ install_claude_platform_branch() {
         darwin* | linux* | freebsd*)
             printf '%s\n' "unix"
             ;;
-        msys | msys* | win32 | cygwin)
+        msys* | win32 | cygwin)
             printf '%s\n' "windows"
             ;;
         *)

--- a/shell-common/tools/custom/work_log.sh
+++ b/shell-common/tools/custom/work_log.sh
@@ -115,6 +115,54 @@ validate_category() {
 # Core Functions
 # =============================================================================
 
+# Validate one interactive field and report the outcome.
+#
+# Usage:
+#   work_log_prompt_validate OUT_VAR VALIDATOR INPUT OK_PREFIX ERR_MSG [OK_SUFFIX]
+#
+#   OUT_VAR    name of the caller's variable that receives the normalized value
+#   VALIDATOR  name of a validate_* function (prints the normalized value)
+#   INPUT      raw user input to validate
+#   OK_PREFIX  success message prefix, e.g. "Jira key: "
+#   ERR_MSG    message passed to ux_error when validation fails
+#   OK_SUFFIX  optional success message suffix, e.g. "h" for time values
+#
+# On success  : OUT_VAR is set to the normalized value, ux_success reports it,
+#               and the function returns 0.
+# On failure  : OUT_VAR is reset to the empty string, ux_error reports ERR_MSG,
+#               and the function returns 1.
+#
+# The value is handed back through OUT_VAR (not stdout) so that the ux_success
+# side effect can never influence what the caller receives. Deciding success
+# strictly on the VALIDATOR's exit status — and returning 0 explicitly after
+# ux_success — is the point of this helper: the previous
+# `value=$(validate ...) && { ux_success ...; } || { value=""; }` form wiped a
+# validly-parsed value whenever the success branch itself returned non-zero
+# (issue #1305 / PR #1307, regression-locked by issue #1308).
+#
+# Call sites append `|| continue`. The loop would repeat regardless, but the
+# trailing list is what keeps a legitimate validation failure from tripping the
+# script-level `set -eE`.
+work_log_prompt_validate() {
+    local _wlpv_out="$1"
+    local _wlpv_validator="$2"
+    local _wlpv_input="$3"
+    local _wlpv_ok_prefix="$4"
+    local _wlpv_err_msg="$5"
+    local _wlpv_ok_suffix="${6:-}"
+    local _wlpv_value
+
+    if ! _wlpv_value=$("$_wlpv_validator" "$_wlpv_input"); then
+        printf -v "$_wlpv_out" '%s' ""
+        ux_error "$_wlpv_err_msg"
+        return 1
+    fi
+
+    printf -v "$_wlpv_out" '%s' "$_wlpv_value"
+    ux_success "${_wlpv_ok_prefix}${_wlpv_value}${_wlpv_ok_suffix}"
+    return 0
+}
+
 # Record a work log entry
 work_log_record() {
     local jira_key="$1"
@@ -154,48 +202,32 @@ work_log_add_interactive() {
             ux_error "Jira key cannot be empty"
             continue
         fi
-        if jira_key=$(validate_jira_key "$jira_input"); then
-            ux_success "Jira key: $jira_key"
-        else
-            ux_error "Invalid Jira key format. Expected: [A-Z][A-Z0-9]*-[0-9]+"
-            jira_key=""
-        fi
+        work_log_prompt_validate jira_key validate_jira_key "$jira_input" \
+            "Jira key: " "Invalid Jira key format. Expected: [A-Z][A-Z0-9]*-[0-9]+" || continue
     done
 
     # Prompt for type
     while [ -z "$type" ]; do
         printf "%s❓%s Type (coordination/assessment/approval/meeting): " "${UX_WARNING}" "${UX_RESET}"
         read -r type_input
-        if type=$(validate_type "$type_input"); then
-            ux_success "Type: $type"
-        else
-            ux_error "Invalid type. Choose: coordination, assessment, approval, or meeting"
-            type=""
-        fi
+        work_log_prompt_validate type validate_type "$type_input" \
+            "Type: " "Invalid type. Choose: coordination, assessment, approval, or meeting" || continue
     done
 
     # Prompt for category
     while [ -z "$category" ]; do
         printf "%s❓%s Category (Testing/Infrastructure/Documentation/Communication/Training/Other): " "${UX_WARNING}" "${UX_RESET}"
         read -r cat_input
-        if category=$(validate_category "$cat_input"); then
-            ux_success "Category: $category"
-        else
-            ux_error "Invalid category"
-            category=""
-        fi
+        work_log_prompt_validate category validate_category "$cat_input" \
+            "Category: " "Invalid category" || continue
     done
 
     # Prompt for time
     while [ -z "$time_spent" ]; do
         printf "%s❓%s Time spent (e.g., 2.5h or 2.5): " "${UX_WARNING}" "${UX_RESET}"
         read -r time_input
-        if time_spent=$(validate_time "$time_input"); then
-            ux_success "Time: ${time_spent}h"
-        else
-            ux_error "Invalid time format. Use numeric format: 2.5, 2.5h, or 4h"
-            time_spent=""
-        fi
+        work_log_prompt_validate time_spent validate_time "$time_input" \
+            "Time: " "Invalid time format. Use numeric format: 2.5, 2.5h, or 4h" "h" || continue
     done
 
     # Record the entry

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -119,6 +119,42 @@ run_in_bash() {
     "
 }
 
+# Quote each argument with printf %q and print them space-joined, for
+# interpolation into a `bash -c "..."` command string (e.g. a `for x in ...`
+# list built from bats args). Assign the result with `args_q="$(quote_args ...)"`.
+quote_args() {
+    local q="" arg
+    for arg in "$@"; do
+        q+=" $(printf '%q' "$arg")"
+    done
+    printf '%s' "$q"
+}
+
+# Run BODY in a bash subprocess after sourcing a tools/custom/*.sh script that
+# resolves its own dependencies via `source "$(dirname "$0")/init.sh"`.
+#
+# Sourcing under `bash -c` makes $0 == "bash", so `dirname "$0"` would resolve
+# relative to the caller's cwd instead of the script's — hence the leading
+# `cd` into TOOLS_DIR before sourcing. DOTFILES_TEST_MODE=1 makes init.sh
+# return before defining ux_*, so any doubles installed in BODY are the only
+# implementations in play. The script's own main() stays dormant: its
+# direct-exec guard compares BASH_SOURCE[0] against $0, which never matches
+# while sourced.
+#
+# Usage: run_sourced_tool_script TOOLS_DIR SCRIPT BODY
+run_sourced_tool_script() {
+    local tools_dir="$1" script="$2" body="$3"
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        cd '${tools_dir}' || exit 1
+        source '${script}'
+        ${body}
+    "
+}
+
 # Run a command in zsh subprocess with dotfiles loaded
 run_in_zsh() {
     run zsh -f -c "

--- a/tests/bats/tools/docker_configure_proxy_mkdir.bats
+++ b/tests/bats/tools/docker_configure_proxy_mkdir.bats
@@ -47,26 +47,14 @@ teardown() {
     teardown_isolated_home
 }
 
-# Source docker_configure_proxy.sh and call the extracted step.
-#
-# The script resolves its own dependency with `source "$(dirname "$0")/init.sh"`,
-# so the subshell cds into the tools dir first: under `bash -c` $0 is "bash",
-# dirname yields "." and the real init.sh is found. init.sh returns early under
-# DOTFILES_TEST_MODE=1 without defining ux_*, so the doubles below are the only
-# implementations in play. main() stays dormant because the script's direct-exec
-# guard compares BASH_SOURCE[0] against $0.
+# Source docker_configure_proxy.sh and call the extracted step, via the
+# shared run_sourced_tool_script helper (tests/bats/test_helper.bash).
 #
 # $1 = extra statement appended to the ux_success double (e.g. "return 1")
 run_create_dropin_dir() {
     local ux_success_tail="${1:-return 0}"
 
-    run bash -c "
-        export DOTFILES_ROOT='${DOTFILES_ROOT}'
-        export DOTFILES_TEST_MODE=1
-        export HOME='${HOME}'
-        export TERM=dumb
-        cd '${TOOLS_DIR}' || exit 1
-        source '${DOCKER_PROXY_SCRIPT}'
+    run_sourced_tool_script "$TOOLS_DIR" "$DOCKER_PROXY_SCRIPT" "
         ux_success() { printf 'OK: %s\n' \"\$1\"; ${ux_success_tail}; }
         ux_error() { printf 'ERR: %s\n' \"\$1\" >&2; }
         if docker_proxy_create_dropin_dir '${TARGET_DIR}'; then

--- a/tests/bats/tools/docker_configure_proxy_mkdir.bats
+++ b/tests/bats/tools/docker_configure_proxy_mkdir.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# tests/bats/tools/docker_configure_proxy_mkdir.bats
+# Regression coverage for issue #1308 — locks the PR #1307 fix of issue #1305.
+#
+# main() used to create the systemd drop-in directory like this:
+#     sudo mkdir -p "$drop_in_dir"
+#     if [ $? -ne 0 ]; then ...            # $? already clobbered by `local`
+# so a failing mkdir was never detected. The step now lives in
+# docker_proxy_create_dropin_dir(), which branches on `sudo mkdir -p` directly.
+#
+# `sudo` is a PATH-injected mock binary (same pattern as
+# tests/bats/skills/gh_label_bootstrap.bats) — no privileged call is ever made.
+
+load '../test_helper'
+
+TOOLS_DIR="${DOTFILES_ROOT}/shell-common/tools/custom"
+DOCKER_PROXY_SCRIPT="${TOOLS_DIR}/docker_configure_proxy.sh"
+
+setup() {
+    setup_isolated_home
+
+    MOCK_BIN="${TEST_TEMP_HOME}/mock-bin"
+    MOCK_LOG="${TEST_TEMP_HOME}/mock-sudo.log"
+    TARGET_DIR="${TEST_TEMP_HOME}/systemd/docker.service.d"
+    mkdir -p "$MOCK_BIN"
+    : >"$MOCK_LOG"
+
+    cat >"${MOCK_BIN}/sudo" <<'EOF'
+#!/usr/bin/env bash
+# Mock sudo: log the delegated command, then either fail or run it unprivileged.
+printf '%s\n' "$*" >>"${MOCK_SUDO_LOG}"
+
+if [ "${MOCK_SUDO_FAIL:-0}" = "1" ]; then
+    exit 1
+fi
+
+exec "$@"
+EOF
+    chmod +x "${MOCK_BIN}/sudo"
+
+    export MOCK_SUDO_LOG="$MOCK_LOG"
+    export MOCK_SUDO_FAIL=0
+    export PATH="${MOCK_BIN}:${PATH}"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Source docker_configure_proxy.sh and call the extracted step.
+#
+# The script resolves its own dependency with `source "$(dirname "$0")/init.sh"`,
+# so the subshell cds into the tools dir first: under `bash -c` $0 is "bash",
+# dirname yields "." and the real init.sh is found. init.sh returns early under
+# DOTFILES_TEST_MODE=1 without defining ux_*, so the doubles below are the only
+# implementations in play. main() stays dormant because the script's direct-exec
+# guard compares BASH_SOURCE[0] against $0.
+#
+# $1 = extra statement appended to the ux_success double (e.g. "return 1")
+run_create_dropin_dir() {
+    local ux_success_tail="${1:-return 0}"
+
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        cd '${TOOLS_DIR}' || exit 1
+        source '${DOCKER_PROXY_SCRIPT}'
+        ux_success() { printf 'OK: %s\n' \"\$1\"; ${ux_success_tail}; }
+        ux_error() { printf 'ERR: %s\n' \"\$1\" >&2; }
+        if docker_proxy_create_dropin_dir '${TARGET_DIR}'; then
+            printf 'rc=0\n'
+        else
+            printf 'rc=1\n'
+        fi
+    "
+}
+
+# --- the actual PR #1307 regression -----------------------------------------
+
+@test "docker_proxy_create_dropin_dir: failing sudo mkdir is reported and returns 1" {
+    MOCK_SUDO_FAIL=1 run_create_dropin_dir
+    assert_success # the driver itself completes; the function's rc is printed
+    assert_output --partial "ERR: Failed to create directory: ${TARGET_DIR}"
+    assert_output --partial "rc=1"
+    refute_output --partial "OK:"
+    [ ! -d "$TARGET_DIR" ]
+}
+
+@test "docker_proxy_create_dropin_dir: delegates exactly 'mkdir -p <dir>' to sudo" {
+    MOCK_SUDO_FAIL=1 run_create_dropin_dir
+    run grep -Fx "mkdir -p ${TARGET_DIR}" "$MOCK_LOG"
+    assert_success
+}
+
+# --- success path ------------------------------------------------------------
+
+@test "docker_proxy_create_dropin_dir: successful sudo mkdir creates the dir and returns 0" {
+    run_create_dropin_dir
+    assert_output --partial "OK: Directory created: ${TARGET_DIR}"
+    assert_output --partial "rc=0"
+    refute_output --partial "ERR:"
+    [ -d "$TARGET_DIR" ]
+}
+
+@test "docker_proxy_create_dropin_dir: failing ux_success does not turn success into failure" {
+    # Same class of bug as the work_log fix: the reporting side effect must not
+    # decide the step's exit status (hence the explicit `return 0`).
+    run_create_dropin_dir "return 1"
+    assert_output --partial "rc=0"
+    [ -d "$TARGET_DIR" ]
+}
+
+# --- structural guard --------------------------------------------------------
+
+@test "docker_configure_proxy.sh no longer inspects \$? after the mkdir step" {
+    if grep -nE '^[[:space:]]*if \[ \$\? -ne 0 \]' "$DOCKER_PROXY_SCRIPT"; then
+        echo "docker_configure_proxy.sh reintroduced the late '\$?' check"
+        return 1
+    fi
+}

--- a/tests/bats/tools/install_claude_platform.bats
+++ b/tests/bats/tools/install_claude_platform.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# tests/bats/tools/install_claude_platform.bats
+# Static routing check for issue #1308 (PR #1307 / issue #1305).
+#
+# PR #1307 dropped the unreachable `linux-gnu*` arm from the OSTYPE case in
+# install_claude.sh — `linux*` already matched it, so it was dead code, not a
+# behaviour change. The dispatch now lives in install_claude_platform_branch(),
+# a pure classifier, so the equivalence is verifiable without running the
+# installer: `linux-gnu` must route exactly like `linux`.
+
+load '../test_helper'
+
+TOOLS_DIR="${DOTFILES_ROOT}/shell-common/tools/custom"
+INSTALL_CLAUDE_SCRIPT="${TOOLS_DIR}/install_claude.sh"
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Source install_claude.sh and classify each argument, one token per line.
+#
+# The script resolves its dependency with `source "$(dirname "$0")/init.sh"`,
+# so the subshell cds into the tools dir first: under `bash -c` $0 is "bash",
+# dirname yields "." and the real init.sh is found (it returns early under
+# DOTFILES_TEST_MODE=1). main() stays dormant — its direct-exec guard requires
+# BASH_SOURCE[0] = $0 or a $0 basename of install_claude.sh, neither of which
+# holds here.
+classify() {
+    local args_q="" arg
+    for arg in "$@"; do
+        args_q+=" $(printf '%q' "$arg")"
+    done
+
+    run bash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        cd '${TOOLS_DIR}' || exit 1
+        source '${INSTALL_CLAUDE_SCRIPT}'
+        for ostype in${args_q}; do
+            install_claude_platform_branch \"\$ostype\"
+        done
+    "
+}
+
+# --- the equivalence PR #1307 relied on -------------------------------------
+
+@test "install_claude_platform_branch: linux-gnu routes identically to linux" {
+    classify linux-gnu
+    assert_success
+    local linux_gnu_branch="$output"
+
+    classify linux
+    assert_success
+    assert_output "$linux_gnu_branch"
+    assert_output "unix"
+}
+
+# --- full classification table ----------------------------------------------
+
+@test "install_claude_platform_branch: unix-family OSTYPE values all route to unix" {
+    classify darwin23 darwin linux linux-gnu linux-musl freebsd14
+    assert_success
+    assert_output "unix
+unix
+unix
+unix
+unix
+unix"
+}
+
+@test "install_claude_platform_branch: windows shells route to windows" {
+    classify msys msys2 win32 cygwin
+    assert_success
+    assert_output "windows
+windows
+windows
+windows"
+}
+
+@test "install_claude_platform_branch: unknown OSTYPE routes to unsupported" {
+    classify solaris2.11 "" aix
+    assert_success
+    assert_output "unsupported
+unsupported
+unsupported"
+}
+
+# --- structural guard: main() consumes the classifier -----------------------
+
+@test "install_claude.sh main() dispatches on install_claude_platform_branch" {
+    run grep -Fq 'case "$(install_claude_platform_branch "$OSTYPE")" in' "$INSTALL_CLAUDE_SCRIPT"
+    assert_success
+}

--- a/tests/bats/tools/install_claude_platform.bats
+++ b/tests/bats/tools/install_claude_platform.bats
@@ -21,27 +21,13 @@ teardown() {
     teardown_isolated_home
 }
 
-# Source install_claude.sh and classify each argument, one token per line.
-#
-# The script resolves its dependency with `source "$(dirname "$0")/init.sh"`,
-# so the subshell cds into the tools dir first: under `bash -c` $0 is "bash",
-# dirname yields "." and the real init.sh is found (it returns early under
-# DOTFILES_TEST_MODE=1). main() stays dormant — its direct-exec guard requires
-# BASH_SOURCE[0] = $0 or a $0 basename of install_claude.sh, neither of which
-# holds here.
+# Source install_claude.sh and classify each argument, one token per line, via
+# the shared run_sourced_tool_script / quote_args helpers (test_helper.bash).
 classify() {
-    local args_q="" arg
-    for arg in "$@"; do
-        args_q+=" $(printf '%q' "$arg")"
-    done
+    local args_q
+    args_q="$(quote_args "$@")"
 
-    run bash -c "
-        export DOTFILES_ROOT='${DOTFILES_ROOT}'
-        export DOTFILES_TEST_MODE=1
-        export HOME='${HOME}'
-        export TERM=dumb
-        cd '${TOOLS_DIR}' || exit 1
-        source '${INSTALL_CLAUDE_SCRIPT}'
+    run_sourced_tool_script "$TOOLS_DIR" "$INSTALL_CLAUDE_SCRIPT" "
         for ostype in${args_q}; do
             install_claude_platform_branch \"\$ostype\"
         done

--- a/tests/bats/tools/install_claude_platform.bats
+++ b/tests/bats/tools/install_claude_platform.bats
@@ -83,3 +83,18 @@ unsupported"
     run grep -Fq 'case "$(install_claude_platform_branch "$OSTYPE")" in' "$INSTALL_CLAUDE_SCRIPT"
     assert_success
 }
+
+# A text match on the dispatch line alone would not catch a label mismatch
+# (e.g. main() spelling an arm "Unix)" while the classifier still returns
+# "unix") — this pins main()'s case arms to the classifier's exact output
+# vocabulary, so the two can't drift apart silently.
+@test "install_claude.sh main() case arms match the classifier's output vocabulary exactly" {
+    run bash -c "
+        sed -n '/case \"\\\$(install_claude_platform_branch \"\\\$OSTYPE\")\" in/,/esac/p' '$INSTALL_CLAUDE_SCRIPT' |
+            grep -oE '^[[:space:]]+[a-z*]+\)' | sed 's/^[[:space:]]*//; s/)\$//' | sort
+    "
+    assert_success
+    assert_output "*
+unix
+windows"
+}

--- a/tests/bats/tools/work_log_field_validation.bats
+++ b/tests/bats/tools/work_log_field_validation.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# tests/bats/tools/work_log_field_validation.bats
+# Regression coverage for issue #1308 — locks the PR #1307 fix of issue #1305.
+#
+# work_log_add_interactive() used to validate each of its four fields with
+#   value=$(validate_x "$input") && { ux_success ...; } || { value=""; }
+# With that form, a non-zero exit from the SUCCESS branch itself (ux_success)
+# made bash fall through to the || branch and wipe an already-validated value.
+# The shared logic now lives in work_log_prompt_validate(), which decides
+# purely on the validator's exit status. These tests pin that behaviour down:
+# the ux_success side effect must never influence the produced value or the rc.
+
+load '../test_helper'
+
+TOOLS_DIR="${DOTFILES_ROOT}/shell-common/tools/custom"
+WORK_LOG_SCRIPT="${TOOLS_DIR}/work_log.sh"
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Source work_log.sh (never auto-sourced, so it is loaded by path), install
+# ux_* doubles, call work_log_prompt_validate and print the resulting rc plus
+# the out-var value.
+#
+# Usage: run_prompt_validate <ux_success_tail> <preset_value> <validate args...>
+#   ux_success_tail  extra statement appended to the ux_success double
+#                    (e.g. "return 1" to simulate a failing success side effect)
+#   preset_value     value the out var holds before the call
+#   validate args    everything after the out var name (validator, input, ...)
+#
+# The out var is always named `field`. ux_success/ux_error are overridden AFTER
+# sourcing so they replace the real ux_lib implementations.
+run_prompt_validate() {
+    local ux_success_tail="$1"
+    shift
+    local preset_q
+    preset_q="$(printf '%q' "$1")"
+    shift
+
+    local args_q="" arg
+    for arg in "$@"; do
+        args_q+=" $(printf '%q' "$arg")"
+    done
+
+    run bash -c "
+        export HOME='${HOME}'
+        export TERM=dumb
+        source '${WORK_LOG_SCRIPT}'
+        ux_success() { printf 'OK: %s\n' \"\$1\"; ${ux_success_tail}; }
+        ux_error() { printf 'ERR: %s\n' \"\$1\" >&2; }
+        field=${preset_q}
+        if work_log_prompt_validate field${args_q}; then
+            printf 'rc=0 value=[%s]\n' \"\$field\"
+        else
+            printf 'rc=1 value=[%s]\n' \"\$field\"
+        fi
+    "
+}
+
+# --- the actual PR #1307 regression -----------------------------------------
+
+@test "work_log_prompt_validate: failing ux_success does not discard a valid value" {
+    # ux_success returns 1 unconditionally. The old '&& { } || { }' form would
+    # have run the failure branch and reset the value to "".
+    run_prompt_validate "return 1" "" \
+        validate_jira_key "swinnoteam-903" "Jira key: " "Invalid Jira key format"
+    assert_success
+    assert_output --partial "rc=0 value=[SWINNOTEAM-903]"
+    refute_output --partial "ERR:"
+}
+
+@test "work_log_prompt_validate: failing ux_success does not overwrite an earlier valid value" {
+    # Same hazard seen from the loop's angle: a previously accepted value must
+    # survive a failing success side effect instead of being reset to "".
+    run_prompt_validate "return 1" "STALE-1" \
+        validate_type "meeting" "Type: " "Invalid type"
+    assert_success
+    assert_output --partial "rc=0 value=[meeting]"
+}
+
+# --- happy path (ux_success healthy) ----------------------------------------
+
+@test "work_log_prompt_validate: valid input yields the normalized value and reports it" {
+    run_prompt_validate "return 0" "" \
+        validate_jira_key "[proj-245]" "Jira key: " "Invalid Jira key format"
+    assert_success
+    assert_output --partial "OK: Jira key: PROJ-245"
+    assert_output --partial "rc=0 value=[PROJ-245]"
+}
+
+@test "work_log_prompt_validate: optional suffix is appended to the success label only" {
+    # Time: the label reads "2.5h" while the stored value stays "2.5".
+    run_prompt_validate "return 0" "" \
+        validate_time "2.5h" "Time: " "Invalid time format" "h"
+    assert_success
+    assert_output --partial "OK: Time: 2.5h"
+    assert_output --partial "rc=0 value=[2.5]"
+}
+
+# --- failure path: value is reset, error reported ---------------------------
+
+@test "work_log_prompt_validate: invalid input reports the error and produces no value" {
+    run_prompt_validate "return 0" "" \
+        validate_category "NotACategory" "Category: " "Invalid category"
+    assert_success
+    assert_output --partial "ERR: Invalid category"
+    assert_output --partial "rc=1 value=[]"
+    refute_output --partial "OK:"
+}
+
+@test "work_log_prompt_validate: invalid input resets a previously held value" {
+    # "이전 값이 리셋되는지" — the while-loops depend on the out var going back
+    # to "" so the prompt repeats instead of accepting stale input.
+    run_prompt_validate "return 0" "SWINNOTEAM-903" \
+        validate_jira_key "not a key" "Jira key: " "Invalid Jira key format"
+    assert_success
+    assert_output --partial "ERR: Invalid Jira key format"
+    assert_output --partial "rc=1 value=[]"
+}
+
+# --- structural guards against reintroducing the anti-pattern ---------------
+
+@test "work_log_add_interactive routes all four fields through the shared helper" {
+    run grep -c 'work_log_prompt_validate [a-z_]* validate_' "$WORK_LOG_SCRIPT"
+    assert_success
+    assert_output "4"
+}
+
+@test "work_log.sh has no executable '&& { ... }' success-branch anti-pattern" {
+    if grep -nE '^[[:space:]]*[^#[:space:]].*\) && \{' "$WORK_LOG_SCRIPT"; then
+        echo "work_log.sh reintroduced the 'cmd && { ... } || { ... }' pattern"
+        return 1
+    fi
+}

--- a/tests/bats/tools/work_log_field_validation.bats
+++ b/tests/bats/tools/work_log_field_validation.bats
@@ -42,10 +42,8 @@ run_prompt_validate() {
     preset_q="$(printf '%q' "$1")"
     shift
 
-    local args_q="" arg
-    for arg in "$@"; do
-        args_q+=" $(printf '%q' "$arg")"
-    done
+    local args_q
+    args_q="$(quote_args "$@")"
 
     run bash -c "
         export HOME='${HOME}'


### PR DESCRIPTION
## Summary
- PR #1307이 고친 실버그 3건(work_log.sh 값-소멸, docker_configure_proxy.sh 늦은 `$?` 체크, install_claude.sh 죽은 case 분기)을 회귀 테스트로 잠근다.
- 세 스크립트 모두 인터랙티브 `main()` 안에 로직이 뒤섞여 mock이 불가능했던 구조 문제를 최소 범위 함수 추출로 해소했다.
- 레포 bats 스위트에 `sudo` PATH-injection mock 선례를 처음 도입했다.

## Changes
- `work_log.sh`: 4개 필드 while-loop가 반복하던 `value=$(validate) && { ux_success; } || { value=""; }` 패턴을 `work_log_prompt_validate()`로 통합. 값은 stdout이 아닌 OUT_VAR(`printf -v`)로 반환해 `ux_success` 실패가 값에 영향을 줄 수 없는 구조로 고정.
- `docker_configure_proxy.sh`: `sudo mkdir -p` 단계를 `docker_proxy_create_dropin_dir()`로 추출, mock `sudo`로 실패 경로(`Failed to create directory` + rc 1) 검증.
- `install_claude.sh`: `OSTYPE` case 분기를 순수 함수 `install_claude_platform_branch()`로 추출, `linux-gnu*`가 `linux*`와 동일하게 라우팅됨을 정적으로 고정.
- 신규 bats 테스트 3개 파일 18건 추가 (`tests/bats/tools/work_log_field_validation.bats`, `docker_configure_proxy_mkdir.bats`, `install_claude_platform.bats`).

## Test plan
- [x] `bash -n` on all 3 modified scripts
- [x] `shellcheck -x -e SC1090,SC1091` on all 3 modified scripts (clean, no new warnings)
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/` — 144 tests, only 3 pre-existing unrelated failures (verified identical on clean `main`)
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/` — 948/948 pass
- [x] Real interactive-flow diff (old vs new `work_log.sh`) confirmed byte-identical stdout/stderr/output-file

## Related
Closes #1308

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
