### PR TITLE
chore(aliases): PROJECT 디렉토리 별칭 정리

### DIFF
--- a/shell-common/aliases/directory.sh
+++ b/shell-common/aliases/directory.sh
@@ -40,16 +40,15 @@ alias cd-resource='cd ~/para/resource'
 alias cd-archive='cd ~/para/archive'
 
 # PROJECT directories
-alias cd-ss='cd ~/para/project/stock-steward'
-alias cd-ll='cd ~/para/project/litellm'
-alias cd-jv='cd ~/para/project/jiravis'
-alias cd-at='cd ~/para/project/agent-toolbox'
 alias cd-af='cd-at'
-alias cd-qf='cd ~/para/project/quantfolio'
+alias cd-at='cd ~/para/project/agent-toolbox'
+alias cd-jv='cd ~/para/project/jiravis'
 alias cd-kk='cd ~/para/project/karakeep'
-alias cd-jmcp='cd ~/para/project/jira-mcp'
-alias cd-jmcp-as='cd ~/para/project/jira-mcp/mcp-atlassian'
-alias cd-jmcp-as-ds='cd ~/para/project/jira-mcp/mcp-atlassian-ds'
+alias cd-lak='cd ~/para/project/llm-agent-kit'
+alias cd-ll='cd ~/para/project/litellm'
+alias cd-op='cd ~/para/project/obsidian-para'
+alias cd-qf='cd ~/para/project/quantfolio'
+alias cd-ss='cd ~/para/project/stock-steward'
 # Note: Project-specific CLI commands are defined in project-cli-aliases.sh
 
 # AREA directories


### PR DESCRIPTION
## Summary
- PROJECT 디렉토리 이동 별칭을 알파벳순으로 재정렬하고, 더 이상 쓰지 않는 jira-mcp 관련 별칭 3개를 제거, 신규 프로젝트 별칭 2개를 추가

## Changes
- `shell-common/aliases/directory.sh`: `cd-jmcp`/`cd-jmcp-as`/`cd-jmcp-as-ds` 삭제, `cd-lak`(llm-agent-kit)/`cd-op`(obsidian-para) 추가, PROJECT 섹션 전체를 알파벳순으로 재정렬

## Test plan
- [x] `shellcheck -x shell-common/aliases/directory.sh` — clean (exit 0)
- [x] 중복 별칭명 없음, 삭제된 `cd-jmcp*` 별칭에 대한 잔여 참조 없음 (repo-wide grep)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
