### PR TITLE
fix(review): PR #1313 agy+codex 리뷰 반영 후속 — main 에 미반영된 review-fix 반영

### DIFF
--- a/claude/skills/devx-pr-verify-merged/SKILL.md
+++ b/claude/skills/devx-pr-verify-merged/SKILL.md
@@ -73,10 +73,10 @@ fetch 해 Step 6 까지 재사용하고, `state != MERGED` 또는 `.mergeCommit.
 
 ## Step 6: 차등 검증 (`references/differential.md`)
 
-주장 1건마다 **PR 이전 상태**(`git show <merge>~1:<path>`, 또는 클론 안의 `<merge>~1` 워크트리)로 같은
-입력을 돌린다. 같은 `TEST_CMD` 를 공유하는 주장은 이전 상태 실행을 **1회만** 돌려 결과를 나눠 쓴다 —
-주장 개수만큼 반복 실행하지 않는다. 전·후 결과가 같으면 그 주장은 `unproven` — 전후 모두 통과하는
-검사는 아무것도 증명하지 않는다. 기본 on, `--no-diff-check` 로만 끄고 껐다는 사실을 리포트에 적는다.
+주장 1건마다 **PR 이전 상태**(머지 전략별 좌표 계산은 `differential.md` §1-1 — squash·단일커밋
+rebase 는 `~1`, 다중커밋 rebase 는 `~N`)로 같은 입력을 돌린다. 같은 `TEST_CMD` 를 공유하는 주장은 이전
+상태 실행을 **1회만** 돌려 결과를 나눠 쓴다. 전·후 결과가 같으면 `unproven` — 둘 다 통과하는 검사는
+아무것도 증명하지 않는다. 기본 on, `--no-diff-check` 로만 끄고 껐다는 사실을 리포트에 적는다.
 
 ## Step 7: 자기 반증 후 이슈화 (F-8)
 

--- a/claude/skills/devx-pr-verify-merged/references/clone-gate.md
+++ b/claude/skills/devx-pr-verify-merged/references/clone-gate.md
@@ -18,11 +18,16 @@ SKILL.md **Step 3** 을 뒷받침한다. 이 절의 두 단언은 **하드 정�
 
 ```sh
 SRC=$(git -C "$PWD" rev-parse --show-toplevel)        # 사용자 레포 (읽기 전용으로만 쓴다)
-CLONE=${clone_dir:-$(mktemp -d "${TMPDIR:-/tmp}/pr-verify-merged-${PR}-XXXXXX")}
+CLONE=${clone_dir:-$(mktemp -d "${TMPDIR:-/tmp}/pr-verify-merged-${pr}-XXXXXX")}
 git clone --no-hardlinks --no-checkout --quiet "$SRC" "$CLONE" || stop "clone failed"
 git -C "$CLONE" cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null || {
     git -C "$CLONE" remote set-url origin "$(git -C "$SRC" remote get-url "${remote:-origin}")"
-    git -C "$CLONE" fetch --quiet origin "$MERGE_SHA" || stop "merge commit not fetchable"
+    # 서버가 임의 SHA want 를 막아 두면(uploadpack.allowTipSHA1InWant=false, 흔히 자체 호스팅
+    # GHES/GitLab) 원시 SHA fetch 가 거부된다. 병합 커밋은 이미 base 브랜치 히스토리의
+    # 일부이므로, base ref 를 fetch 하면 부수적으로 함께 따라온다 — 이 경로가 항상 동작한다.
+    git -C "$CLONE" fetch --quiet origin "$MERGE_SHA" 2>/dev/null \
+        || git -C "$CLONE" fetch --quiet origin "$BASE" 2>/dev/null
+    git -C "$CLONE" cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null || stop "merge commit not fetchable"
 }
 git -C "$CLONE" checkout --quiet --detach "$MERGE_SHA" || stop "checkout failed"
 ```
@@ -68,6 +73,15 @@ HEAD_SHA=$(git -C "$CLONE" rev-parse HEAD)
 리뷰어 2명도 통과시켰다. worktree 에서 검증하는 한 영원히 안 잡힌다.
 
 그래서 이 검사는 선택이 아니다. 순서대로 한다.
+
+**의존성 설치 — 러너를 돌리기 전에 한 번.** 클론은 `git clone` 산출물이라 `node_modules` /
+`.venv` / 잠금파일 기반 설치 상태를 담지 않는다. 클론 안에서 감지된 검증 명령(F-5 사다리)을
+그대로 실행하기 전에, 프로젝트가 선언한 표준 설치 스텝을 **클론 안에서 1회** 돈다 —
+`package.json`→`npm ci`(lockfile 있으면) 아니면 `npm install`, `pyproject.toml`(uv 관리)→
+`uv sync`, `requirements.txt`→`pip install -r requirements.txt`, `Gemfile`→`bundle install`.
+AGENTS.md/README 에 명시된 설치 명령이 있으면 그쪽을 우선한다. 설치 자체가 실패하면(오프라인 ·
+사설 레지스트리 인증 없음) 정지가 아니라 `Unverified: dependency install failed (<원인>)` 로
+적고 의존성 없이도 돌아가는 검사(grep/sed 기반 lint, CLI 진입점 직접 호출)만 계속한다.
 
 **(a) 케이스 집합 비교 — 실행된 것을 센다.**
 

--- a/claude/skills/devx-pr-verify-merged/references/differential.md
+++ b/claude/skills/devx-pr-verify-merged/references/differential.md
@@ -4,25 +4,67 @@ SKILL.md **Step 6** 을 뒷받침한다. 규칙 하나로 요약된다: **전·�
 아무것도 증명하지 않는다.** 이 규칙이 없으면 "테스트가 초록이다" 가 "수정이 동작한다" 로
 잘못 승격된다.
 
-## 1. "이전" 의 정의 — `<merge>~1`
+## 1. "이전" 의 정의 — 머지 전략에 따라 다르다
 
-`<merge>~1` = 머지 커밋의 **첫 번째 부모** = 그 PR 이 올라타기 직전의 base 상태다. merge
-커밋 · squash · rebase 세 경우 모두에서 "이 머지가 착지하기 직전" 을 정확히 가리킨다.
+목표는 항상 같다: **그 PR 이 올라타기 직전의 base 상태**. 다만 그 상태를 가리키는
+좌표는 머지 전략마다 다르다 — 셋 다 `~1`이라고 뭉뚱그리면 rebase merge 에서 틀린다.
+
+| 전략 | 부모 수 | "이전" 좌표 | 이유 |
+|---|---|---|---|
+| 진짜 merge 커밋 | 2 | `<merge>~1` (첫 부모) | 첫 부모가 항상 병합 직전 base 다 |
+| squash | 1 | `<merge>~1` | 커밋 개수와 무관하게 새 커밋은 항상 정확히 1개 |
+| rebase, PR 커밋 1개 | 1 | `<merge>~1` | 재생된 커밋이 1개뿐이라 squash 와 결과가 같다 |
+| rebase, PR 커밋 N>1개 | 1 | `<merge>~N` | `~1`은 재생된 마지막 직전 커밋일 뿐 — 여전히 PR 내부다 |
+
+**`~1`을 무조건 쓰면 안 되는 이유**: rebase merge 는 PR 의 커밋을 하나씩 base 위에
+재생해 선형 히스토리를 만든다. 커밋이 N개면 `<merge>~1`은 "재생된 N번째 커밋 직전" —
+즉 PR 이 만든 (N-1)개 커밋이 여전히 포함된 상태다. 진짜 base 는 `<merge>~N`이다.
+
+### 1-1. 좌표 계산
+
+```sh
+PARENTS=$(git -C "$CLONE" cat-file -p "$MERGE_SHA" | grep -c '^parent ')
+if [ "$PARENTS" -ge 2 ]; then
+    BEFORE_REF="${MERGE_SHA}~1"                      # 진짜 merge 커밋 — 모호함 없음
+else
+    # squash 와 rebase 는 둘 다 부모가 1개라 부모 수만으로 못 가른다.
+    # PR 의 원본 커밋 개수 N 을 gh 에서 얻는다 — squash 는 N 과 무관하게 항상 ~1,
+    # rebase 는 ~N 이 정확한 base 다. 판별은 트리 비교로 한다: ~1 과 ~N 의 트리가 같으면
+    # (squash, 또는 N=1 rebase) ~1 을 쓰고, 다르면(다중 커밋 rebase) ~N 을 쓴다.
+    N=$(gh pr view "$pr" --repo "$TARGET_REPO" --json commits -q '.commits | length' 2>/dev/null)
+    if [ -z "$N" ] || [ "$N" -le 1 ]; then
+        BEFORE_REF="${MERGE_SHA}~1"
+    else
+        TREE_1=$(git -C "$CLONE" rev-parse "${MERGE_SHA}~1^{tree}" 2>/dev/null)
+        TREE_N=$(git -C "$CLONE" rev-parse "${MERGE_SHA}~${N}^{tree}" 2>/dev/null)
+        if [ -n "$TREE_N" ] && [ "$TREE_1" != "$TREE_N" ]; then
+            BEFORE_REF="${MERGE_SHA}~${N}"            # 다중 커밋 rebase merge
+        else
+            BEFORE_REF="${MERGE_SHA}~1"               # squash, 또는 N=1 rebase
+        fi
+    fi
+fi
+```
+
+`~N`까지 조상이 부족하거나(`git rev-parse` 실패) `gh pr view`가 커밋 수를 못 주면(호스트가
+GitHub 이 아니거나 PR 메타데이터 소실) 판별 자체가 불가능하다 — 그때는 **추측하지 않는다**:
+`BEFORE_REF="${MERGE_SHA}~1"` 로 진행하되, 그 사실을 리포트에 남긴다 — 아래 4절의
+`differential: n/a` 처리를 본다.
 
 - **`<merge>^2` 를 쓰지 않는다** — 진짜 merge 커밋에서만 존재하고(PR head 쪽), squash/rebase
   에는 없다.
 - **merge-base 를 쓰지 않는다** — PR 브랜치가 오래됐으면 merge-base 는 몇 주 전 상태라
   "이 머지가 무엇을 바꿨는가" 대신 "그 사이 base 가 무엇을 바꿨는가" 까지 섞인다.
-- 머지 커밋이 여러 커밋을 담아도 정의는 그대로다 — 비교 단위는 커밋이 아니라 **머지**다.
+- 이하 이 문서에서 `<merge>~1` 이라 쓴 곳은 모두 위에서 계산한 `$BEFORE_REF` 를 뜻한다.
 
 ## 2. 이전 상태를 만드는 법
 
 ```sh
 # (a) 파일 단위 — 단일 파일 검사에 충분하다
-git -C "$CLONE" show "${MERGE_SHA}~1:path/to/file" > "$BEFORE_DIR/file"
+git -C "$CLONE" show "${BEFORE_REF}:path/to/file" > "$BEFORE_DIR/file"
 
 # (b) 트리 단위 — 러너를 돌려야 하면 클론 안에 워크트리를 하나 더 만든다 (격리 유지)
-git -C "$CLONE" worktree add --detach --quiet "$CLONE/.before" "${MERGE_SHA}~1"
+git -C "$CLONE" worktree add --detach --quiet "$CLONE/.before" "$BEFORE_REF"
 ```
 
 `.before` 는 **클론 내부**에 만든다. 사용자 레포에 워크트리를 추가하지 않는다(NF-1).
@@ -46,7 +88,10 @@ pass/fail)를 모든 주장에 나눠 쓴다 — 같은 명령을 주장 개수�
 잡는다는 증거가 된다.
 
 ```sh
-git -C "$CLONE/.before" checkout "$MERGE_SHA" -- tests/            # 검사만 after 에서 가져온다
+# $NEW_TEST_PATHS 는 이 주장의 diff 에서 실제로 바뀐 테스트 파일/디렉터리 경로다
+# (프로젝트마다 tests/ · test/ · spec/ · __tests__/ 등 규약이 다르므로 고정하지 않는다) —
+# F-5 러너 탐지가 이미 그 경로를 알고 있다.
+git -C "$CLONE/.before" checkout "$MERGE_SHA" -- "$NEW_TEST_PATHS"  # 검사만 after 에서 가져온다
 ( cd "$CLONE/.before" && eval "$TEST_CMD" )                        # 옛 코드에서 돌린다 -> 실패해야 정상
 ```
 
@@ -67,7 +112,7 @@ git -C "$CLONE/.before" checkout "$MERGE_SHA" -- tests/            # 검사만 a
 |---|---|---|
 | `proven` | before ≠ after 이고 after 가 주장대로다 | `Claims:` 의 pass 로 계산 |
 | `unproven` | before == after | `Unproven:` 행에 주장과 근거 한 줄 |
-| `n/a` | 이전 상태에서 검사를 물리적으로 돌릴 수 없다 | `Unproven:` 행에 `n/a` 로 사유와 함께 |
+| `n/a` | 이전 상태에서 검사를 물리적으로 돌릴 수 없다, 또는 1-1 에서 `$BEFORE_REF` 판별이 불가해 `~1` 로 추정 실행했다 | `Unproven:` 행에 `n/a` 로 사유와 함께 |
 
 `unproven` 은 **실패가 아니다** — 검증이 그 주장을 증명하지 못했다는 사실의 기록이다. 다만
 `[OK]` 라도 `Unproven:` 이 비어 있지 않으면 리포트 첫 줄에 그 개수를 실어야 한다.


### PR DESCRIPTION
## Summary
- PR #1313(#1312, `devx:pr-verify-merged` 신설)은 review-fix 커밋(`2738613d`)이 아직 미반영인 상태에서 사람이 직접 머지했다. 그 커밋을 최신 `main` 기준 새 브랜치로 옮겨 후속 PR로 올린다.
- agy·codex 가 PR #1313에서 지적한 BLOCKER 2건씩(총 4건) + FOLLOW-UP 3건을 반영한다.

## Changes
- `differential.md`: `mergeCommit.oid~1` 을 merge/squash/rebase 세 경우 모두에 정확하다고 일반화했던 부분 제거 — 다중 커밋 rebase merge 에서는 부모 수 + 트리 비교로 `~1` vs `~N` 을 가리는 절차 추가, 판별 불가 시 `n/a`. 테스트 경로 `tests/` 하드코딩을 diff 유도 변수로 일반화 (codex BLOCKER, agy FOLLOW-UP)
- `clone-gate.md`: raw commit SHA 직접 fetch 가 서버 설정(`allowTipSHA1InWant=false`)에 막힐 수 있어 base ref fetch 폴백 추가 (codex BLOCKER). 클론 안 의존성 설치(npm/pip 등) 단계 부재로 대부분의 러너가 실패하던 문제에 표준 설치 스텝 추가, 실패 시 `Unverified` 로 강등 (agy BLOCKER). 클론 디렉터리명에 대문자 `${PR}` 참조하던 변수명 오타 수정(`${pr}`) (agy FOLLOW-UP)
- `SKILL.md`: 위 변경에 맞춘 wording 조정 (100줄 유지)

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 uv run ./tests/test` (pytest) — 1307 passed / 0 failed, 워크트리 2곳에서 각각 재확인
- [x] `${pr}` 변수 수정 및 base-ref fetch 폴백 로직 직접 확인

## Related
Follow-up to #1313 (already merged) / #1312 (already closed) — no new Closes keyword needed.
