### PR TITLE
fix(ux_lib): ux_header 박스 테두리가 wide character 텍스트에서 어긋나는 문제 수정

### DIFF
--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -132,8 +132,20 @@ fi
 ux_header() {
     local text="$1"
     local width=60
-    if [ ${#text} -gt "$width" ]; then
-        width=${#text}
+
+    # ${#text} counts characters, not terminal columns — CJK/한글처럼
+    # 2칸을 차지하는 wide character가 섞이면 border/padding이 어긋난다.
+    # `wc -L`은 locale-aware하게 실제 표시 폭을 반환한다.
+    local text_width
+    text_width=$(printf '%s' "$text" | wc -L)
+    if [ "$text_width" -gt "$width" ]; then
+        width=$text_width
+    fi
+
+    local pad=$((width - text_width))
+    local padding=""
+    if [ "$pad" -gt 0 ]; then
+        padding=$(printf '%*s' "$pad" '')
     fi
 
     local border
@@ -149,7 +161,7 @@ ux_header() {
 
     echo ""
     printf "%s%s╔%s╗%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$border" "${UX_RESET}"
-    printf "%s%s║%s %-${width}s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
+    printf "%s%s║%s %s%s %s%s║%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}" "$text" "$padding" "${UX_BOLD}" "${UX_PRIMARY}" "${UX_RESET}"
     printf "%s%s╚%s╝%s\n" "${UX_BOLD}" "${UX_PRIMARY}" "$border" "${UX_RESET}"
     echo ""
 }

--- a/tests/bats/tools/ux_lib_header.bats
+++ b/tests/bats/tools/ux_lib_header.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# tests/bats/tools/ux_lib_header.bats
+# ux_header 박스 테두리가 표시 폭(display width) 기준으로 정렬되는지 검증.
+# d5a52cf0(문자 수 기준 width 계산)은 CJK/한글처럼 터미널에서 2칸을 차지하는
+# 문자를 만나면 border/본문 padding이 다시 어긋난다 — 회귀 케이스.
+
+load '../test_helper'
+
+_run_ux_header() {
+    bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh'
+        ux_header \"\$1\"
+    " _ "$1"
+}
+
+_assert_box_aligned() {
+    local -a lines=()
+    while IFS= read -r line; do
+        [ -n "$line" ] && lines+=("$line")
+    done <<<"$output"
+
+    [ "${#lines[@]}" -eq 3 ]
+
+    local top_width mid_width bottom_width
+    top_width=$(printf '%s' "${lines[0]}" | wc -L)
+    mid_width=$(printf '%s' "${lines[1]}" | wc -L)
+    bottom_width=$(printf '%s' "${lines[2]}" | wc -L)
+
+    [ "$top_width" -eq "$mid_width" ]
+    [ "$top_width" -eq "$bottom_width" ]
+}
+
+@test "ux_header aligns border for plain ASCII text under 60 chars" {
+    run _run_ux_header "Short header"
+    assert_success
+    _assert_box_aligned
+}
+
+@test "ux_header aligns border for ASCII text over 60 chars (#d5a52cf0 original case)" {
+    run _run_ux_header "Scanning for missing commits from 'upstream/main' in 'main'..."
+    assert_success
+    _assert_box_aligned
+}
+
+@test "ux_header aligns border for Korean text under 60 chars (wide-char regression)" {
+    run _run_ux_header "문장을 Box 테두리로 감싸는 것"
+    assert_success
+    _assert_box_aligned
+}
+
+@test "ux_header aligns border for Korean text over 60 chars (wide-char regression)" {
+    run _run_ux_header "문장을 Box 테두리로 감싸는 것인데 지금은 더 엉뚱하게 망가진 상태이니 다시 정확히 고쳐야 한다는 요청 사항"
+    assert_success
+    _assert_box_aligned
+}


### PR DESCRIPTION
## Summary
- `ux_header`가 wide character(한글/CJK)를 만나면 박스 테두리가 어긋나던 문제를 근본 수정
- 재발 방지용 bats 테스트(`ux_lib_header.bats`) 신규 추가

## Changes
- `shell-common/tools/ux_lib/ux_lib.sh`: width/padding 계산을 `${#text}`(문자 수) 대신 `printf '%s' "$text" | wc -L`(터미널 표시 폭)로 교체. printf `%-${width}s` 필드 폭도 문자 수 기준이라 부정확해, pad 값을 직접 계산해 공백을 붙이는 방식으로 바꿈.
- `tests/bats/tools/ux_lib_header.bats`: ASCII 60자 이하/초과, 한글 60자 이하/초과 4케이스에서 상/중/하단 라인의 표시 폭이 모두 일치하는지 검증(회귀 잠금).

## Test plan
- [x] 신규 bats 4케이스 통과 (`./tests/bats/lib/bats-core/bin/bats tests/bats/tools/ux_lib_header.bats`)
- [x] 전체 pytest 스위트 1307 passed
- [x] 전체 bats 스위트 회귀 없음 확인
- [x] bash/zsh 양쪽에서 한글 텍스트 `ux_header` 육안 확인 — 박스 정상 종결

## Related
Closes #1316

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~31 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~31 min
<!-- /ai-metrics:gh-pr -->

</details>
