### PR TITLE
chore(aliases): add cd-opc shortcut for obsidian-para-company

### DIFF
--- a/shell-common/aliases/directory.sh
+++ b/shell-common/aliases/directory.sh
@@ -47,6 +47,7 @@ alias cd-kk='cd ~/para/project/karakeep'
 alias cd-lak='cd ~/para/project/llm-agent-kit'
 alias cd-ll='cd ~/para/project/litellm'
 alias cd-op='cd ~/para/project/obsidian-para'
+alias cd-opc='cd ~/para/project/obsidian-para-company'
 alias cd-qf='cd ~/para/project/quantfolio'
 alias cd-ss='cd ~/para/project/stock-steward'
 # Note: Project-specific CLI commands are defined in project-cli-aliases.sh


### PR DESCRIPTION
## Summary
- PARA project alias 목록에 obsidian-para-company용 `cd-opc` 단축 명령 1줄 추가

## Changes
- aliases: `directory.sh` 의 PARA project alias 블록에 `cd-opc='cd ~/para/project/obsidian-para-company'` 추가 (기존 정렬 순서 유지)

## Test plan
- [ ] `source shell-common/aliases/directory.sh` 후 `cd-opc` 실행해 디렉토리 이동 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~10 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~0.5 h · 🤖 ~10 min
<!-- /ai-metrics:gh-pr -->

</details>
