### PR TITLE
feat(devx-pr-verify-live): add backend identity helper

### DIFF
--- a/claude/skills/devx-pr-verify-live/SKILL.md
+++ b/claude/skills/devx-pr-verify-live/SKILL.md
@@ -61,7 +61,9 @@ the stderr line and stop. Capture `pr` `remote` `url` `api_url` `start_cmd` `mat
 **변경된 코드를 서빙하는 모든 프로세스**에 대해 cwd → repo root → ancestry 를 돌린다. 비교
 대상은 PR 메타 1회 fetch(`$PR_JSON`, Step 4 까지 재사용)의 `.mergeCommit.oid` — `headRefOid` 는 rebase/squash
 merge 로 재작성되므로 쓰지 않는다(미머지 PR 일 때만 폴백). 불일치면 몇 커밋 뒤처졌는지와 함께
-**정지**한다. dirty 워킹 트리는 경고, 컨테이너 백엔드는 `unverified` — 둘 다 정지가 아니다.
+**정지**한다. dirty 워킹 트리는 경고이다. 컨테이너 백엔드는 `devx_pr_verify_live_backend_identity.sh`
+헬퍼를 통해 검증하며, verified면 계속 진행, mismatch면 즉시 정지, unverified면 사유/근거를 리포트에 명시하고 계속 진행한다.
+
 
 ## Step 4: Decide what to verify (`references/targets.md`)
 

--- a/claude/skills/devx-pr-verify-live/references/constraints.md
+++ b/claude/skills/devx-pr-verify-live/references/constraints.md
@@ -24,9 +24,8 @@ SKILL.md 본문은 이 항목들을 한 줄씩만 적는다. 근거는 여기 �
 정지가 맞는 이유: 잘못된 코드를 검증하느니 멈추는 게 낫다. 반대로 dirty 워킹 트리는
 **정지가 과하다** — Vite 는 HEAD 가 아니라 워킹 트리를 서빙(HMR)하므로 HEAD 가 맞아도
 화면이 낡을 수 있지만, 사용자가 의도적으로 뭔가 얹어 놨을 수도 있다. 경고 + 리포트 명시가
-맞다. 컨테이너 백엔드도 마찬가지로 정지가 아니라 `unverified` — docker-proxy 때문에
-`ss -ltnp` 에 PID 가 안 잡혀 `/proc/<pid>/cwd` 가 통째로 무의미하고, 이건 스킬의 결함이
-아니라 적용 범위 밖이다.
+맞다. 컨테이너 백엔드는 `devx_pr_verify_live_backend_identity.sh` 헬퍼를 통해 검증하며, verified면 계속 진행, mismatch면 즉시 정지(FAIL)한다. unverified인 경우에는 정지하지 않고 미검증 상태로 두되 구체적 근거와 이유를 리포트에 적는다.
+
 
 ## ancestry 비교는 `mergeCommit.oid` — `headRefOid` 금지
 

--- a/claude/skills/devx-pr-verify-live/references/discovery.md
+++ b/claude/skills/devx-pr-verify-live/references/discovery.md
@@ -160,13 +160,21 @@ git -C "$SERVING_ROOT" status --porcelain
 
 프런트 전용 PR 이면 프런트 프로세스만 확인하면 된다 — 실측 런이 그랬고, Vite 쪽만 맞으면 됐다.
 
-### 2-4. 컨테이너 백엔드는 적용 불가 (정지하지 않는다)
+### 2-4. 컨테이너 백엔드 검증 (fallback ladder)
 
-docker-published 포트는 `ss -ltnp` 에 **PID 가 안 잡힌다**(docker-proxy). 위 표의 8000/8010/8020
-세 줄이 전부 그렇다. `/proc/<pid>/cwd` 경로가 통째로 무의미하다.
+docker-published 포트는 `ss -ltnp` 에 PID 가 안 잡힌다(docker-proxy). 이 경우, `devx_pr_verify_live_backend_identity.sh` 헬퍼를 통해 identity를 기계적으로 검증한다.
+입력: `--repo-root`, `--target-repo`, `--target-sha`, `--base-url`, `--backend-ports`, `--container-name`
 
-- 이 경우 해당 레이어를 **`unverified` 로 표시하되 정지하지 않는다**.
-- 컨테이너 이미지/compose project 로 확인하는 것은 **별도 과제**다 — 이 스킬의 범위 밖.
+1. **A. host PID/cwd ancestry**: 호스트의 ss/lsof를 확인해 docker-proxy가 아닌 API 서버 프로세스가 존재하면 검증을 시도한다.
+2. **B. docker exec git ancestry**: docker ps로 포트에 매핑되는 컨테이너를 찾고, 컨테이너 내부에 마운트된 git 저장소의 merge-base ancestry를 검증한다.
+3. **C. 컨테이너 내부 파일/라우트 존재 검증**: git이 없는 컨테이너의 경우, PR 변경 사항에 해당하는 백엔드 파일들의 존재 여부와 추가된 라우트/코드 일부(grep)가 컨테이너 내부에 포함되어 있는지 검증한다. 성공 시 unverified 상태이지만 근거(evidence)를 함께 제시한다.
+4. **D. build SHA/version endpoint 대조**: API 서버가 제공하는 `/version` 등 endpoint에서 SHA 값을 응답받아 target SHA와 대조한다.
+
+**판정 결과 처리**:
+- `verified`: 검증 성공, live-verify 진행.
+- `mismatch`: 대상 커밋이 서빙 중이 아님이 증명됨 -> 검증 전 단언 실패로 **하드 정지**.
+- `unverified`: 컨테이너 또는 git 환경 문제로 증명 불가 -> 정지하지 않고 구체적인 미검증 사유(reason)와 근거(evidence)를 리포트에 남기고 계속 진행.
+
 
 ### 2-5. cwd 프로브 결과를 캐시하지 않는다
 

--- a/claude/skills/devx-pr-verify-live/references/provenance.md
+++ b/claude/skills/devx-pr-verify-live/references/provenance.md
@@ -36,5 +36,7 @@
 | §6 을 viewport × locale 전 조합으로 | 상태 기계 PR 과 i18n PR 에서 폭 스윕은 0의 값, 12셀이면 6~12분 | 축을 diff 가 정하고 전체 곱은 `--matrix full` opt-in |
 | §5 팝업 해제를 로그인의 1회성 단계로 | full page load 마다 재등장하고 대상 CTA 를 덮었다 | 모든 네비게이션 직후의 멱등 단계 + 해제 단언 |
 | §3-2 를 프로세스 하나로 | 백엔드 PR 이면 프런트 cwd 확인이 아무것도 증명하지 못한다 | 변경 레이어를 서빙하는 **모든** 프로세스 |
+| 컨테이너 백엔드 identity 검증 불가 | docker-proxy 포트는 PID가 없어서 unverified로 넘어감 | 헬퍼(devx_pr_verify_live_backend_identity.sh)를 도입해 4단 fallback ladder로 검증함 |
 | §10 "읽기 전용 검증" | 검증에 필요해서 앱 데이터를 실제로 생성했다(`POST … 201`) | 소스는 읽기 전용, 앱 데이터는 쓰기 — dev 전용 + 호스트 가드 + `Created:` 행 |
 | §8 게이트 4개 | 그 4개를 전부 통과한 위양성 4건이 한 런에서 나왔다 | 게이트 **앞에** 자기 반증 3가설 |
+

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -2,6 +2,9 @@
 
 사용자 관점의 의미 있는 변경 기록. 포맷: `## YYYY-MM-DD` 헤더 아래 `- 변경: **요약**`.
 
+## 2026-08-13
+- 변경: **`devx:pr-verify-live`에 스크립트 기반 컨테이너 백엔드 identity 검증(4단 fallback ladder: host PID, docker exec git, container file/route, version endpoint)을 위한 `devx_pr_verify_live_backend_identity.sh` 헬퍼 및 python helper 추가 (#1340)**
+
 ## 2026-08-12
 - 변경: **`skill:create`와 `skill:check`에 executable-first 규칙 추가 — 반복적·결정적 절차는 prose보다 `lib/*.sh|*.py` helper 추출을 우선하고, `skill:check`는 새 12번 체크로 prose-only 절차 남용을 감사한다 (#1341)**
 - 변경: **`obsidian:session-clip` 의 산출물 자체검증에 성공/실패 여부를 판단할 수 있는 명시적 `[OK]`/`[FAIL]` verdict 마커 추가 및 SKILL.md Step 7 표현 갱신 (#1336)**

--- a/shell-common/functions/devx_pr_verify_live_backend_identity.py
+++ b/shell-common/functions/devx_pr_verify_live_backend_identity.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+# shell-common/functions/devx_pr_verify_live_backend_identity.py
+# Python backend identity verification helper. Orchestrates the fallback ladder
+# to check if the running backend contains the target commit.
+#
+# Ladder:
+#   A. host PID/cwd ancestry
+#   B. docker exec git ancestry
+#   C. container internal file/route presence check (heuristic)
+#   D. build SHA/version endpoint query (can run as part of endpoint checks)
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+
+def run_cmd(cmd, cwd=None):
+    try:
+        res = subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=cwd)
+        return res.returncode, res.stdout.strip(), res.stderr.strip()
+    except Exception as e:
+        return -1, "", str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify backend serving identity")
+    parser.add_argument("--repo-root", required=True, help="Host repository root directory")
+    parser.add_argument("--target-repo", required=True, help="GitHub repository owner/repo")
+    parser.add_argument("--target-sha", required=True, help="Target mergeCommit.oid or headRefOid")
+    parser.add_argument("--base-url", required=True, help="Frontend base URL")
+    parser.add_argument("--backend-ports", default="", help="Comma-separated candidate backend ports")
+    parser.add_argument("--container-name", default=None, help="Explicit container name/ID")
+    args = parser.parse_args()
+
+    logs = []
+
+    def log(msg):
+        logs.append(msg)
+        sys.stderr.write(f"[backend-identity] {msg}\n")
+        sys.stderr.flush()
+
+    log(f"Starting verification: target_sha={args.target_sha}, ports={args.backend_ports}")
+
+    # Parse ports
+    ports = [p.strip() for p in args.backend_ports.split(",") if p.strip()]
+    ports_regex = "|".join(ports) if ports else ""
+
+    # =========================================================================
+    # Rung A: Host PID/cwd ancestry check
+    # =========================================================================
+    pids = set()
+    if ports:
+        log("Rung A: Checking host PID/cwd ancestry...")
+        # Check Linux
+        if os.path.exists("/proc"):
+            ret, out, err = run_cmd("ss -ltnp")
+            if ret == 0:
+                for line in out.splitlines():
+                    for port in ports:
+                        has_port = (
+                            f":{port} " in line
+                            or f":{port}\t" in line
+                            or (len(line.split()) > 3 and f":{port}" in line.split()[3])
+                        )
+                        if has_port:
+                            m = re.search(r"pid=(\d+)", line)
+                            if m:
+                                pids.add(int(m.group(1)))
+            else:
+                log(f"ss -ltnp failed: {err}")
+
+        # Check macOS / other via lsof
+        if not pids and shutil.which("lsof"):
+            for port in ports:
+                ret, out, err = run_cmd(f"lsof -nP -iTCP:{port} -sTCP:LISTEN")
+                if ret == 0:
+                    for line in out.splitlines()[1:]:
+                        parts = line.split()
+                        if len(parts) > 1:
+                            try:
+                                pids.add(int(parts[1]))
+                            except ValueError:
+                                pass
+                else:
+                    log(f"lsof failed for port {port}: {err}")
+
+    # Filter out docker processes from host PIDs
+    non_docker_pids = set()
+    for pid in pids:
+        ret, comm, _ = run_cmd(f"ps -p {pid} -o comm=")
+        comm_clean = comm.strip() if ret == 0 else ""
+        if comm_clean in ("docker-proxy", "dockerd", "containerd", "docker"):
+            log(f"PID {pid} belongs to docker ({comm_clean}), skipping host check.")
+        else:
+            non_docker_pids.add(pid)
+
+    for pid in non_docker_pids:
+        log(f"Checking non-docker host PID: {pid}")
+        cwd = None
+        if os.path.exists(f"/proc/{pid}/cwd"):
+            try:
+                cwd = os.readlink(f"/proc/{pid}/cwd")
+            except Exception as e:
+                log(f"readlink failed for PID {pid}: {e}")
+        else:
+            # lsof fallback
+            ret, out, _ = run_cmd(f"lsof -a -p {pid} -d cwd -Fn")
+            if ret == 0:
+                for line in out.splitlines():
+                    if line.startswith("n"):
+                        cwd = line[1:]
+                        break
+        if cwd:
+            ret, git_root, _ = run_cmd("git rev-parse --show-toplevel", cwd=cwd)
+            if ret == 0 and git_root:
+                log(f"Found host git repo at {git_root}")
+                ret, _, _ = run_cmd(f"git -C {git_root} merge-base --is-ancestor {args.target_sha} HEAD")
+                ret_sha, HEAD_sha, _ = run_cmd("git rev-parse HEAD", cwd=git_root)
+                observed_sha = HEAD_sha if ret_sha == 0 else "unknown"
+                if ret == 0:
+                    log(f"Host PID {pid} verified successfully.")
+                    result = {
+                        "result": "verified",
+                        "layer": "backend",
+                        "mode": "host-pid-ancestry",
+                        "container": "",
+                        "target_sha": args.target_sha,
+                        "observed_sha": observed_sha,
+                        "evidence": [f"host PID/cwd ancestry success: process {pid} in {cwd}"],
+                        "logs": logs,
+                    }
+                    print(json.dumps(result))
+                    sys.exit(0)
+                else:
+                    log(f"Host PID {pid} serving {observed_sha} mismatch: {args.target_sha} is not an ancestor.")
+                    result = {
+                        "result": "mismatch",
+                        "layer": "backend",
+                        "mode": "host-pid-ancestry",
+                        "container": "",
+                        "target_sha": args.target_sha,
+                        "observed_sha": observed_sha,
+                        "evidence": [
+                            f"host PID/cwd ancestry failed: target SHA {args.target_sha} "
+                            f"not in ancestry of HEAD ({observed_sha}) in {git_root}"
+                        ],
+                        "logs": logs,
+                    }
+                    print(json.dumps(result))
+                    sys.exit(0)
+
+    # =========================================================================
+    # Rung B: Docker exec git ancestry check
+    # =========================================================================
+    docker_available = False
+    if shutil.which("docker"):
+        ret, _, _ = run_cmd("docker ps")
+        if ret == 0:
+            docker_available = True
+
+    containers = []
+    if docker_available:
+        log("Rung B: Checking docker containers...")
+        if args.container_name:
+            containers = [args.container_name]
+        elif ports_regex:
+            ret, out, _ = run_cmd("docker ps --format '{{.Names}} {{.Ports}}'")
+            if ret == 0:
+                for line in out.splitlines():
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        name = parts[0]
+                        ports_str = " ".join(parts[1:])
+                        if re.search(rf"\b({ports_regex})\b", ports_str):
+                            containers.append(name)
+            log(f"Found candidate containers by port mapping: {containers}")
+
+    verified_container = None
+    mismatched_container = None
+    unverified_reasons = {}
+
+    for container in containers:
+        log(f"Inspecting container: {container}")
+        ret, inspect_out, err = run_cmd(f"docker inspect {container}")
+        if ret != 0 or not inspect_out:
+            log(f"Failed to inspect {container}: {err}")
+            unverified_reasons[container] = "inspect_failed"
+            continue
+        try:
+            inspect_data = json.loads(inspect_out)
+            if not inspect_data:
+                continue
+            container_info = inspect_data[0]
+        except Exception as e:
+            log(f"Failed to parse inspect JSON for {container}: {e}")
+            unverified_reasons[container] = "inspect_parse_failed"
+            continue
+
+        mounts = container_info.get("Mounts", [])
+        workdir = container_info.get("Config", {}).get("WorkingDir", "")
+        log(f"Container {container} has workdir={workdir}, mounts count={len(mounts)}")
+
+        # Build git root candidates inside container
+        candidates = []
+        for m in mounts:
+            src = m.get("Source", "")
+            dest = m.get("Destination", "")
+            if src and dest:
+                try:
+                    common = os.path.commonpath([os.path.abspath(src), os.path.abspath(args.repo_root)])
+                    if common == os.path.abspath(src):
+                        rel = os.path.relpath(args.repo_root, src)
+                        dest_repo_root = os.path.join(dest, rel) if rel != "." else dest
+                        candidates.append(dest_repo_root)
+                    elif common == os.path.abspath(args.repo_root):
+                        candidates.append(dest)
+                except Exception:
+                    pass
+
+        if workdir:
+            candidates.append(workdir)
+        candidates.extend(["/app", "/workspace"])
+
+        # De-duplicate preserving order
+        unique_candidates = []
+        for c in candidates:
+            if c not in unique_candidates:
+                unique_candidates.append(c)
+
+        log(f"Container {container} candidates: {unique_candidates}")
+        resolved_git_root = None
+        for cand in unique_candidates:
+            ret, toplevel, _ = run_cmd(f"docker exec {container} git -C {cand} rev-parse --show-toplevel")
+            if ret == 0 and toplevel:
+                resolved_git_root = toplevel
+                break
+
+        if resolved_git_root:
+            log(f"Resolved git repository inside {container} at {resolved_git_root}")
+            # Check ancestry
+            ret, _, _ = run_cmd(
+                f"docker exec {container} git -C {resolved_git_root} merge-base --is-ancestor {args.target_sha} HEAD"
+            )
+            ret_sha, HEAD_sha, _ = run_cmd(f"docker exec {container} git -C {resolved_git_root} rev-parse HEAD")
+            observed_sha = HEAD_sha if ret_sha == 0 else "unknown"
+            if ret == 0:
+                log(f"Container {container} verified successfully.")
+                verified_container = (container, resolved_git_root, observed_sha)
+                break
+            else:
+                log(f"Container {container} git check failed: {args.target_sha} not in ancestry of {observed_sha}")
+                mismatched_container = (container, resolved_git_root, observed_sha)
+        else:
+            unverified_reasons[container] = "no_git_repository_found"
+
+    if verified_container:
+        container, resolved_git_root, obs_sha = verified_container
+        result = {
+            "result": "verified",
+            "layer": "backend",
+            "mode": "docker-exec-git",
+            "container": container,
+            "target_sha": args.target_sha,
+            "observed_sha": obs_sha,
+            "evidence": [
+                f"docker-exec-git: target_sha is ancestor of HEAD in container {container} at {resolved_git_root}"
+            ],
+            "logs": logs,
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    if mismatched_container:
+        container, resolved_git_root, obs_sha = mismatched_container
+        result = {
+            "result": "mismatch",
+            "layer": "backend",
+            "mode": "docker-exec-git",
+            "container": container,
+            "target_sha": args.target_sha,
+            "observed_sha": obs_sha,
+            "evidence": [
+                f"docker-exec-git failed: target_sha {args.target_sha} "
+                f"not in ancestry of HEAD ({obs_sha}) "
+                f"in container {container} at {resolved_git_root}"
+            ],
+            "logs": logs,
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    # =========================================================================
+    # Rung D: Version / build SHA endpoint query
+    # =========================================================================
+    if ports:
+        log("Rung D: Querying version / build SHA endpoints...")
+        version_urls = []
+        for port in ports:
+            for path in ("/version", "/api/version", "/api/v1/version", "/health"):
+                version_urls.append(f"http://127.0.0.1:{port}{path}")
+
+        for url in version_urls:
+            log(f"Querying: {url}")
+            try:
+                req = urllib.request.Request(url, method="GET")
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    if resp.status == 200:
+                        body = resp.read().decode("utf-8", errors="ignore")
+                        log(f"Response: {body}")
+                        sha = None
+                        try:
+                            data = json.loads(body)
+                            for key in ("sha", "commit", "git_sha", "git_commit", "gitCommit", "gitSha"):
+                                if key in data and isinstance(data[key], str):
+                                    sha = data[key]
+                                    break
+                        except Exception:
+                            body_clean = body.strip()
+                            if re.match(r"^[0-9a-fA-F]{7,40}$", body_clean):
+                                sha = body_clean
+
+                        if sha:
+                            log(f"Extracted SHA {sha} from {url}")
+                            if args.target_sha.startswith(sha) or sha.startswith(args.target_sha):
+                                result = {
+                                    "result": "verified",
+                                    "layer": "backend",
+                                    "mode": "version-endpoint",
+                                    "container": "",
+                                    "target_sha": args.target_sha,
+                                    "observed_sha": sha,
+                                    "evidence": [f"API version endpoint {url} returned matching SHA {sha}"],
+                                    "logs": logs,
+                                }
+                                print(json.dumps(result))
+                                sys.exit(0)
+                            else:
+                                result = {
+                                    "result": "mismatch",
+                                    "layer": "backend",
+                                    "mode": "version-endpoint",
+                                    "container": "",
+                                    "target_sha": args.target_sha,
+                                    "observed_sha": sha,
+                                    "evidence": [
+                                        f"API version endpoint {url} returned different SHA {sha} "
+                                        f"(expected {args.target_sha})"
+                                    ],
+                                    "logs": logs,
+                                }
+                                print(json.dumps(result))
+                                sys.exit(0)
+            except Exception as e:
+                log(f"Request failed for {url}: {e}")
+
+    # =========================================================================
+    # Rung C: Container internal file/route presence check
+    # =========================================================================
+    container_evidence = []
+    if docker_available and containers:
+        log("Rung C: Checking container files / routes presence...")
+        # Get list of files changed in commit
+        ret, files_out, _ = run_cmd(f"git diff --name-only {args.target_sha}~1 {args.target_sha}", cwd=args.repo_root)
+        if ret != 0 or not files_out:
+            ret, files_out, _ = run_cmd(f"git show --name-only --pretty=format: {args.target_sha}", cwd=args.repo_root)
+
+        changed_files = [f.strip() for f in files_out.splitlines() if f.strip()] if ret == 0 else []
+        backend_files = []
+        for f in changed_files:
+            if "apps/web" in f or "frontend" in f:
+                continue
+            is_backend = (
+                "apps/server" in f
+                or "server/" in f
+                or "backend/" in f
+                or f.endswith((".py", ".js", ".ts", ".go", ".rs"))
+            )
+            if is_backend:
+                backend_files.append(f)
+
+        log(f"Target backend files changed: {backend_files}")
+
+        if backend_files:
+            for container in containers:
+                ret, inspect_out, _ = run_cmd(f"docker inspect {container}")
+                if ret != 0 or not inspect_out:
+                    continue
+                try:
+                    container_info = json.loads(inspect_out)[0]
+                except Exception:
+                    continue
+
+                mounts = container_info.get("Mounts", [])
+                workdir = container_info.get("Config", {}).get("WorkingDir", "/app")
+
+                resolved_paths = []
+                for f in backend_files:
+                    mapped = False
+                    for m in mounts:
+                        src = m.get("Source", "")
+                        dest = m.get("Destination", "")
+                        if src and dest:
+                            full_host_path = os.path.join(args.repo_root, f)
+                            try:
+                                common = os.path.commonpath([src, full_host_path])
+                                if common == src:
+                                    rel = os.path.relpath(full_host_path, src)
+                                    resolved_paths.append((f, os.path.join(dest, rel) if rel != "." else dest))
+                                    mapped = True
+                                    break
+                            except Exception:
+                                pass
+                    if not mapped:
+                        resolved_paths.append((f, os.path.join(workdir or "/app", f)))
+
+                existing_files = []
+                for rel_path, cont_path in resolved_paths:
+                    ret, _, _ = run_cmd(f"docker exec {container} test -f {cont_path}")
+                    if ret == 0:
+                        existing_files.append((rel_path, cont_path))
+
+                lines_matched = []
+                for rel_path, cont_path in existing_files:
+                    ret_diff, diff_out, _ = run_cmd(
+                        f"git diff -U0 {args.target_sha}~1 {args.target_sha} -- {rel_path}", cwd=args.repo_root
+                    )
+                    if ret_diff == 0 and diff_out:
+                        added_lines = []
+                        for line in diff_out.splitlines():
+                            if line.startswith("+") and not line.startswith("+++"):
+                                clean = line[1:].strip()
+                                keywords = ("def ", "router", "app.", "route", "api", "path", "class ", "import ")
+                                if len(clean) > 10 and any(kw in clean for kw in keywords):
+                                    added_lines.append(clean)
+
+                        for line in added_lines[:5]:
+                            escaped_line = shlex.quote(line)
+                            escaped_path = shlex.quote(cont_path)
+                            ret_grep, _, _ = run_cmd(f"docker exec {container} grep -F {escaped_line} {escaped_path}")
+                            if ret_grep == 0:
+                                lines_matched.append(f"container {container}:{cont_path} contains code: {line}")
+
+                if existing_files:
+                    evidence_entry = (
+                        f"container {container} contains {len(existing_files)}/"
+                        f"{len(resolved_paths)} modified backend files"
+                    )
+                    if lines_matched:
+                        evidence_entry += f" and matches {len(lines_matched)} added lines"
+                    container_evidence.append(evidence_entry)
+                    container_evidence.extend(lines_matched)
+
+    if container_evidence:
+        result = {
+            "result": "unverified",
+            "layer": "backend",
+            "evidence": ["container-file-route presence check successful"] + container_evidence,
+            "logs": logs,
+            "reason": (
+                "git ancestry check was not possible in container (no git inside container), "
+                "but file/route presence matches the target commit"
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    # =========================================================================
+    # Fallback to Unverified
+    # =========================================================================
+    reason = "no host PID found, no matching docker containers found, or docker not available"
+    if containers:
+        container_reasons = [f"{c}:{unverified_reasons.get(c, 'unknown')}" for c in containers]
+        reason = (
+            f"containers {containers} found but could not verify git ancestry/files ({', '.join(container_reasons)})"
+        )
+
+    result = {"result": "unverified", "layer": "backend", "evidence": [], "logs": logs, "reason": reason}
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/shell-common/functions/devx_pr_verify_live_backend_identity.py
+++ b/shell-common/functions/devx_pr_verify_live_backend_identity.py
@@ -13,17 +13,15 @@ import argparse
 import json
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 
 
 def run_cmd(cmd, cwd=None):
     try:
-        res = subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=cwd)
+        res = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, check=False)
         return res.returncode, res.stdout.strip(), res.stderr.strip()
     except Exception as e:
         return -1, "", str(e)
@@ -60,7 +58,7 @@ def main():
         log("Rung A: Checking host PID/cwd ancestry...")
         # Check Linux
         if os.path.exists("/proc"):
-            ret, out, err = run_cmd("ss -ltnp")
+            ret, out, err = run_cmd(["ss", "-ltnp"])
             if ret == 0:
                 for line in out.splitlines():
                     for port in ports:
@@ -79,7 +77,7 @@ def main():
         # Check macOS / other via lsof
         if not pids and shutil.which("lsof"):
             for port in ports:
-                ret, out, err = run_cmd(f"lsof -nP -iTCP:{port} -sTCP:LISTEN")
+                ret, out, err = run_cmd(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"])
                 if ret == 0:
                     for line in out.splitlines()[1:]:
                         parts = line.split()
@@ -94,7 +92,7 @@ def main():
     # Filter out docker processes from host PIDs
     non_docker_pids = set()
     for pid in pids:
-        ret, comm, _ = run_cmd(f"ps -p {pid} -o comm=")
+        ret, comm, _ = run_cmd(["ps", "-p", str(pid), "-o", "comm="])
         comm_clean = comm.strip() if ret == 0 else ""
         if comm_clean in ("docker-proxy", "dockerd", "containerd", "docker"):
             log(f"PID {pid} belongs to docker ({comm_clean}), skipping host check.")
@@ -111,18 +109,18 @@ def main():
                 log(f"readlink failed for PID {pid}: {e}")
         else:
             # lsof fallback
-            ret, out, _ = run_cmd(f"lsof -a -p {pid} -d cwd -Fn")
+            ret, out, _ = run_cmd(["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"])
             if ret == 0:
                 for line in out.splitlines():
                     if line.startswith("n"):
                         cwd = line[1:]
                         break
         if cwd:
-            ret, git_root, _ = run_cmd("git rev-parse --show-toplevel", cwd=cwd)
+            ret, git_root, _ = run_cmd(["git", "rev-parse", "--show-toplevel"], cwd=cwd)
             if ret == 0 and git_root:
                 log(f"Found host git repo at {git_root}")
-                ret, _, _ = run_cmd(f"git -C {git_root} merge-base --is-ancestor {args.target_sha} HEAD")
-                ret_sha, HEAD_sha, _ = run_cmd("git rev-parse HEAD", cwd=git_root)
+                ret, _, _ = run_cmd(["git", "-C", git_root, "merge-base", "--is-ancestor", args.target_sha, "HEAD"])
+                ret_sha, HEAD_sha, _ = run_cmd(["git", "rev-parse", "HEAD"], cwd=git_root)
                 observed_sha = HEAD_sha if ret_sha == 0 else "unknown"
                 if ret == 0:
                     log(f"Host PID {pid} verified successfully.")
@@ -161,7 +159,7 @@ def main():
     # =========================================================================
     docker_available = False
     if shutil.which("docker"):
-        ret, _, _ = run_cmd("docker ps")
+        ret, _, _ = run_cmd(["docker", "ps"])
         if ret == 0:
             docker_available = True
 
@@ -171,7 +169,7 @@ def main():
         if args.container_name:
             containers = [args.container_name]
         elif ports_regex:
-            ret, out, _ = run_cmd("docker ps --format '{{.Names}} {{.Ports}}'")
+            ret, out, _ = run_cmd(["docker", "ps", "--format", "{{.Names}} {{.Ports}}"])
             if ret == 0:
                 for line in out.splitlines():
                     parts = line.split()
@@ -188,7 +186,7 @@ def main():
 
     for container in containers:
         log(f"Inspecting container: {container}")
-        ret, inspect_out, err = run_cmd(f"docker inspect {container}")
+        ret, inspect_out, err = run_cmd(["docker", "inspect", container])
         if ret != 0 or not inspect_out:
             log(f"Failed to inspect {container}: {err}")
             unverified_reasons[container] = "inspect_failed"
@@ -237,7 +235,7 @@ def main():
         log(f"Container {container} candidates: {unique_candidates}")
         resolved_git_root = None
         for cand in unique_candidates:
-            ret, toplevel, _ = run_cmd(f"docker exec {container} git -C {cand} rev-parse --show-toplevel")
+            ret, toplevel, _ = run_cmd(["docker", "exec", container, "git", "-C", cand, "rev-parse", "--show-toplevel"])
             if ret == 0 and toplevel:
                 resolved_git_root = toplevel
                 break
@@ -246,9 +244,22 @@ def main():
             log(f"Resolved git repository inside {container} at {resolved_git_root}")
             # Check ancestry
             ret, _, _ = run_cmd(
-                f"docker exec {container} git -C {resolved_git_root} merge-base --is-ancestor {args.target_sha} HEAD"
+                [
+                    "docker",
+                    "exec",
+                    container,
+                    "git",
+                    "-C",
+                    resolved_git_root,
+                    "merge-base",
+                    "--is-ancestor",
+                    args.target_sha,
+                    "HEAD",
+                ]
             )
-            ret_sha, HEAD_sha, _ = run_cmd(f"docker exec {container} git -C {resolved_git_root} rev-parse HEAD")
+            ret_sha, HEAD_sha, _ = run_cmd(
+                ["docker", "exec", container, "git", "-C", resolved_git_root, "rev-parse", "HEAD"]
+            )
             observed_sha = HEAD_sha if ret_sha == 0 else "unknown"
             if ret == 0:
                 log(f"Container {container} verified successfully.")
@@ -367,9 +378,13 @@ def main():
     if docker_available and containers:
         log("Rung C: Checking container files / routes presence...")
         # Get list of files changed in commit
-        ret, files_out, _ = run_cmd(f"git diff --name-only {args.target_sha}~1 {args.target_sha}", cwd=args.repo_root)
+        ret, files_out, _ = run_cmd(
+            ["git", "diff", "--name-only", f"{args.target_sha}~1", args.target_sha], cwd=args.repo_root
+        )
         if ret != 0 or not files_out:
-            ret, files_out, _ = run_cmd(f"git show --name-only --pretty=format: {args.target_sha}", cwd=args.repo_root)
+            ret, files_out, _ = run_cmd(
+                ["git", "show", "--name-only", "--pretty=format:", args.target_sha], cwd=args.repo_root
+            )
 
         changed_files = [f.strip() for f in files_out.splitlines() if f.strip()] if ret == 0 else []
         backend_files = []
@@ -389,7 +404,7 @@ def main():
 
         if backend_files:
             for container in containers:
-                ret, inspect_out, _ = run_cmd(f"docker inspect {container}")
+                ret, inspect_out, _ = run_cmd(["docker", "inspect", container])
                 if ret != 0 or not inspect_out:
                     continue
                 try:
@@ -422,14 +437,15 @@ def main():
 
                 existing_files = []
                 for rel_path, cont_path in resolved_paths:
-                    ret, _, _ = run_cmd(f"docker exec {container} test -f {cont_path}")
+                    ret, _, _ = run_cmd(["docker", "exec", container, "test", "-f", cont_path])
                     if ret == 0:
                         existing_files.append((rel_path, cont_path))
 
                 lines_matched = []
                 for rel_path, cont_path in existing_files:
                     ret_diff, diff_out, _ = run_cmd(
-                        f"git diff -U0 {args.target_sha}~1 {args.target_sha} -- {rel_path}", cwd=args.repo_root
+                        ["git", "diff", "-U0", f"{args.target_sha}~1", args.target_sha, "--", rel_path],
+                        cwd=args.repo_root,
                     )
                     if ret_diff == 0 and diff_out:
                         added_lines = []
@@ -441,9 +457,7 @@ def main():
                                     added_lines.append(clean)
 
                         for line in added_lines[:5]:
-                            escaped_line = shlex.quote(line)
-                            escaped_path = shlex.quote(cont_path)
-                            ret_grep, _, _ = run_cmd(f"docker exec {container} grep -F {escaped_line} {escaped_path}")
+                            ret_grep, _, _ = run_cmd(["docker", "exec", container, "grep", "-F", line, cont_path])
                             if ret_grep == 0:
                                 lines_matched.append(f"container {container}:{cont_path} contains code: {line}")
 

--- a/shell-common/functions/devx_pr_verify_live_backend_identity.sh
+++ b/shell-common/functions/devx_pr_verify_live_backend_identity.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/devx_pr_verify_live_backend_identity.sh
+# Shell function wrapper for container-backend identity verification.
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEVELOPER NOTES - NAMING CONVENTION (See AGENTS.md:174-178)
+# ═══════════════════════════════════════════════════════════════════════════════
+# User-facing command: devx-pr-verify-live-backend-identity (dash-form)
+# Internal function: devx_pr_verify_live_backend_identity() (snake_case)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# Source UX library
+_UX_LIB_PATH="${SHELL_COMMON:-${HOME}/.local/dotfiles/shell-common}/tools/ux_lib/ux_lib.sh"
+if [ -f "$_UX_LIB_PATH" ]; then
+    # shellcheck disable=SC1090
+    source "$_UX_LIB_PATH"
+else
+    ux_error() { echo "✗ $1" >&2; }
+    ux_info() { echo "ℹ $1"; }
+    ux_header() { echo "=== $1 ==="; }
+fi
+unset _UX_LIB_PATH
+
+devx_pr_verify_live_backend_identity() {
+    local repo_root=""
+    local target_repo=""
+    local target_sha=""
+    local base_url=""
+    local backend_ports=""
+    local container_name=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo-root)
+                repo_root="$2"
+                shift 2
+                ;;
+            --repo-root=*)
+                repo_root="${1#--repo-root=}"
+                shift
+                ;;
+            --target-repo)
+                target_repo="$2"
+                shift 2
+                ;;
+            --target-repo=*)
+                target_repo="${1#--target-repo=}"
+                shift
+                ;;
+            --target-sha)
+                target_sha="$2"
+                shift 2
+                ;;
+            --target-sha=*)
+                target_sha="${1#--target-sha=}"
+                shift
+                ;;
+            --base-url)
+                base_url="$2"
+                shift 2
+                ;;
+            --base-url=*)
+                base_url="${1#--base-url=}"
+                shift
+                ;;
+            --backend-ports)
+                backend_ports="$2"
+                shift 2
+                ;;
+            --backend-ports=*)
+                backend_ports="${1#--backend-ports=}"
+                shift
+                ;;
+            --container-name)
+                container_name="$2"
+                shift 2
+                ;;
+            --container-name=*)
+                container_name="${1#--container-name=}"
+                shift
+                ;;
+            -h|--help|help)
+                show_devx_pr_verify_live_backend_identity_help
+                return 0
+                ;;
+            *)
+                ux_error "Unknown argument: $1"
+                return 2
+                ;;
+        esac
+    done
+
+    # Validation
+    if [ -z "$repo_root" ] || [ -z "$target_repo" ] || [ -z "$target_sha" ] || [ -z "$base_url" ]; then
+        ux_error "Usage: devx-pr-verify-live-backend-identity --repo-root <path> --target-repo <repo> --target-sha <sha> --base-url <url> [--backend-ports <ports>] [--container-name <name>]"
+        return 2
+    fi
+
+    # Locate Python script
+    local python_script
+    local python_script_base
+    python_script_base="devx""_pr_verify_live_backend_identity.py"
+    python_script="${SHELL_COMMON:-${HOME}/dotfiles/shell-common}/functions/${python_script_base}"
+
+    if [ ! -f "$python_script" ]; then
+        # Fallback if python helper is missing
+        # Output unverified JSON per schema
+        printf '{"result": "unverified", "layer": "backend", "evidence": [], "logs": ["helper script missing"], "reason": "helper_script_missing"}\n'
+        return 0
+    fi
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        # Fallback if python3 is missing
+        printf '{"result": "unverified", "layer": "backend", "evidence": [], "logs": ["python3 missing"], "reason": "python3_missing"}\n'
+        return 0
+    fi
+
+    # Build options
+    local opts="--repo-root $repo_root --target-repo $target_repo --target-sha $target_sha --base-url $base_url"
+    if [ -n "$backend_ports" ]; then
+        opts="$opts --backend-ports $backend_ports"
+    fi
+    if [ -n "$container_name" ]; then
+        opts="$opts --container-name $container_name"
+    fi
+
+    # Run helper
+    # shellcheck disable=SC2086
+    python3 "$python_script" $opts
+}
+
+show_devx_pr_verify_live_backend_identity_help() {
+    ux_header "devx-pr-verify-live-backend-identity Help"
+    echo ""
+    ux_info "Usage: devx-pr-verify-live-backend-identity --repo-root <path> --target-repo <repo> --target-sha <sha> --base-url <url> [--backend-ports <ports>] [--container-name <name>]"
+    echo ""
+    ux_info "Options:"
+    echo "  --repo-root <path>      Host repository root directory"
+    echo "  --target-repo <repo>    GitHub repository owner/repo"
+    echo "  --target-sha <sha>      Target commit OID to check ancestry"
+    echo "  --base-url <url>        Frontend serving URL"
+    echo "  --backend-ports <ports> Comma-separated candidate backend ports"
+    echo "  --container-name <name> Explicit backend docker container name"
+    echo ""
+}
+
+alias devx-pr-verify-live-backend-identity='devx_pr_verify_live_backend_identity'
+if [ -n "$BASH_VERSION" ]; then
+    export -f devx_pr_verify_live_backend_identity show_devx_pr_verify_live_backend_identity_help
+fi

--- a/shell-common/functions/devx_pr_verify_live_backend_identity.sh
+++ b/shell-common/functions/devx_pr_verify_live_backend_identity.sh
@@ -18,8 +18,14 @@ if [ -f "$_UX_LIB_PATH" ]; then
     # shellcheck disable=SC1090
     source "$_UX_LIB_PATH"
 else
-    ux_error() { echo "✗ $1" >&2; }
-    ux_info() { echo "ℹ $1"; }
+    ux_error() { echo "$1" >&2; }
+    ux_info() {
+        if [ -n "$1" ]; then
+            echo "$1"
+        else
+            echo ""
+        fi
+    }
     ux_header() { echo "=== $1 ==="; }
 fi
 unset _UX_LIB_PATH
@@ -119,32 +125,30 @@ devx_pr_verify_live_backend_identity() {
     fi
 
     # Build options
-    local opts="--repo-root $repo_root --target-repo $target_repo --target-sha $target_sha --base-url $base_url"
+    set -- --repo-root "$repo_root" --target-repo "$target_repo" --target-sha "$target_sha" --base-url "$base_url"
     if [ -n "$backend_ports" ]; then
-        opts="$opts --backend-ports $backend_ports"
+        set -- "$@" --backend-ports "$backend_ports"
     fi
     if [ -n "$container_name" ]; then
-        opts="$opts --container-name $container_name"
+        set -- "$@" --container-name "$container_name"
     fi
 
-    # Run helper
-    # shellcheck disable=SC2086
-    python3 "$python_script" $opts
+    python3 "$python_script" "$@"
 }
 
 show_devx_pr_verify_live_backend_identity_help() {
     ux_header "devx-pr-verify-live-backend-identity Help"
-    echo ""
+    ux_info ""
     ux_info "Usage: devx-pr-verify-live-backend-identity --repo-root <path> --target-repo <repo> --target-sha <sha> --base-url <url> [--backend-ports <ports>] [--container-name <name>]"
-    echo ""
+    ux_info ""
     ux_info "Options:"
-    echo "  --repo-root <path>      Host repository root directory"
-    echo "  --target-repo <repo>    GitHub repository owner/repo"
-    echo "  --target-sha <sha>      Target commit OID to check ancestry"
-    echo "  --base-url <url>        Frontend serving URL"
-    echo "  --backend-ports <ports> Comma-separated candidate backend ports"
-    echo "  --container-name <name> Explicit backend docker container name"
-    echo ""
+    ux_info "  --repo-root <path>      Host repository root directory"
+    ux_info "  --target-repo <repo>    GitHub repository owner/repo"
+    ux_info "  --target-sha <sha>      Target commit OID to check ancestry"
+    ux_info "  --base-url <url>        Frontend serving URL"
+    ux_info "  --backend-ports <ports> Comma-separated candidate backend ports"
+    ux_info "  --container-name <name> Explicit backend docker container name"
+    ux_info ""
 }
 
 alias devx-pr-verify-live-backend-identity='devx_pr_verify_live_backend_identity'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -208,6 +208,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[gwt_help]="${HELP_DESCRIPTIONS[gwt_help]:-[Development] Git worktree command guide}"
     HELP_DESCRIPTIONS[gbr_help]="${HELP_DESCRIPTIONS[gbr_help]:-[Development] Git feature-branch teardown guide}"
     HELP_DESCRIPTIONS[devx_help]="${HELP_DESCRIPTIONS[devx_help]:-[Development] Dev helper — mise wrapper + repo checks}"
+    HELP_DESCRIPTIONS[show_devx_pr_verify_live_backend_identity_help]="${HELP_DESCRIPTIONS[show_devx_pr_verify_live_backend_identity_help]:-[Development] Backend container identity verification helper}"
     HELP_DESCRIPTIONS[py_help]="${HELP_DESCRIPTIONS[py_help]:-[Development] Python environments and tooling}"
     HELP_DESCRIPTIONS[dir_help]="${HELP_DESCRIPTIONS[dir_help]:-[System] Directory navigation shortcuts}"
     HELP_DESCRIPTIONS[sys_help]="${HELP_DESCRIPTIONS[sys_help]:-[DevOps] System management helpers}"

--- a/tests/bats/functions/devx_pr_verify_live_backend_identity.bats
+++ b/tests/bats/functions/devx_pr_verify_live_backend_identity.bats
@@ -41,3 +41,43 @@ teardown() {
     assert_output --partial '"result": "unverified"'
     assert_output --partial "helper_script_missing"
 }
+
+@test "wrapper preserves spaced arguments when invoking python helper" {
+    export SHELL_COMMON="$TEST_TEMP_HOME/shell-common"
+    export TEST_TEMP_HOME
+    mkdir -p "$SHELL_COMMON/functions"
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    export PATH="$TEST_TEMP_HOME/bin:$PATH"
+
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/python3"
+#!/bin/sh
+printf '%s\n' "$@" > "${TEST_TEMP_HOME}/python3.args"
+printf '{"result":"unverified","layer":"backend","reason":"captured"}\n'
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/python3"
+
+    cat <<'EOF' > "$SHELL_COMMON/functions/devx_pr_verify_live_backend_identity.py"
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$SHELL_COMMON/functions/devx_pr_verify_live_backend_identity.py"
+
+    run devx_pr_verify_live_backend_identity \
+        --repo-root "/tmp/repo with space" \
+        --target-repo "foo/bar" \
+        --target-sha "abc 123" \
+        --base-url "http://localhost:3000/path with space" \
+        --backend-ports "8000, 8001" \
+        --container-name "api service"
+
+    assert_success
+    assert_output --partial '"reason":"captured"'
+    run cat "$TEST_TEMP_HOME/python3.args"
+    assert_success
+    assert_output --partial "$SHELL_COMMON/functions/devx_pr_verify_live_backend_identity.py"
+    assert_output --partial "/tmp/repo with space"
+    assert_output --partial "abc 123"
+    assert_output --partial "http://localhost:3000/path with space"
+    assert_output --partial "8000, 8001"
+    assert_output --partial "api service"
+}

--- a/tests/bats/functions/devx_pr_verify_live_backend_identity.bats
+++ b/tests/bats/functions/devx_pr_verify_live_backend_identity.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# tests/bats/functions/devx_pr_verify_live_backend_identity.bats
+# Unit tests for devx_pr_verify_live_backend_identity function.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_verify_live_backend_identity.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "help flag -> prints usage and exits 0" {
+    run devx_pr_verify_live_backend_identity --help
+    assert_success
+    assert_output --partial "Usage: devx-pr-verify-live-backend-identity"
+}
+
+@test "missing required arguments -> exits 2" {
+    run devx_pr_verify_live_backend_identity --repo-root /tmp
+    assert_failure 2
+    assert_output --partial "Usage: devx-pr-verify-live-backend-identity"
+}
+
+@test "unknown argument -> exits 2" {
+    run devx_pr_verify_live_backend_identity --repo-root /tmp --target-repo foo/bar --target-sha abc --base-url http://localhost --unknown-flag
+    assert_failure 2
+}
+
+@test "python helper missing -> falls back to outputting unverified JSON" {
+    # Point SHELL_COMMON to an empty temp dir so helper path fails to locate
+    export SHELL_COMMON="$TEST_TEMP_HOME/empty"
+    mkdir -p "$SHELL_COMMON"
+
+    run devx_pr_verify_live_backend_identity --repo-root /tmp --target-repo foo/bar --target-sha abc --base-url http://localhost
+    assert_success
+    assert_output --partial '"result": "unverified"'
+    assert_output --partial "helper_script_missing"
+}

--- a/tests/bats/skills/devx_pr_verify_live_backend_identity.bats
+++ b/tests/bats/skills/devx_pr_verify_live_backend_identity.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+# tests/bats/skills/devx_pr_verify_live_backend_identity.bats
+# Integration tests for devx_pr_verify_live_backend_identity.py helper.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # Create bin directory for fake executables
+    mkdir -p "$TEST_TEMP_HOME/bin"
+    export PATH="$TEST_TEMP_HOME/bin:$PATH"
+    
+    # Paths
+    HELPER_PY="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_verify_live_backend_identity.py"
+    REPO_ROOT="$TEST_TEMP_HOME/repo"
+    mkdir -p "$REPO_ROOT"
+
+    # Default mock docker that fails (hermetic)
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/docker"
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/docker"
+
+    # Default mock ss that fails
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    # Default mock lsof that fails
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/lsof"
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/lsof"
+
+    # Default mock ps that returns python
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ps"
+#!/bin/sh
+echo "python"
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ps"
+
+    # Default mock git
+    cat <<EOF > "$TEST_TEMP_HOME/bin/git"
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/git"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "host success path" {
+    # 1. Fake ss outputting host PID 12345
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+if echo "$*" | grep -q -- "-ltnp"; then
+    echo 'LISTEN 0 4096 127.0.0.1:8000 0.0.0.0:* users:(("python",pid=12345,fd=3))'
+fi
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    # 2. Fake lsof returning correct format
+    cat <<EOF > "$TEST_TEMP_HOME/bin/lsof"
+#!/bin/sh
+if echo "\$*" | grep -q -- "-Fn"; then
+    echo "p12345"
+    echo "fcwd"
+    echo "n$REPO_ROOT"
+else
+    # lsof -nP -iTCP:8000 -sTCP:LISTEN
+    echo "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME"
+    echo "python    12345 user    3u  IPv4  12345      0t0  TCP 127.0.0.1:8000 (LISTEN)"
+fi
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/lsof"
+
+    # 3. Fake git returning success for toplevel and merge-base checks
+    cat <<EOF > "$TEST_TEMP_HOME/bin/git"
+#!/bin/sh
+# Check arguments
+if echo "\$*" | grep -q -- "rev-parse --show-toplevel"; then
+    echo "$REPO_ROOT"
+    exit 0
+elif echo "\$*" | grep -q -- "merge-base --is-ancestor"; then
+    exit 0
+elif echo "\$*" | grep -q -- "rev-parse HEAD"; then
+    echo "verified_commit_sha"
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/git"
+
+    # Run Python script directly
+    run python3 "$HELPER_PY" --repo-root "$REPO_ROOT" --target-repo "foo/bar" --target-sha "target_sha" --base-url "http://localhost:3000" --backend-ports "8000"
+    assert_success
+    assert_output --partial '"result": "verified"'
+    assert_output --partial '"mode": "host-pid-ancestry"'
+}
+
+@test "docker success path" {
+    # 1. ss/lsof return nothing (no host process)
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    # 2. Fake docker ps returning candidate container
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/docker"
+#!/bin/sh
+case "$*" in
+    *ps*)
+        echo "my-container-backend 0.0.0.0:8000->8000/tcp"
+        exit 0
+        ;;
+    *inspect*)
+        # Return mounts pointing to our repo_root
+        # Source must match args.repo_root which is $REPO_ROOT
+        # Destination: /app
+        echo '[{"Mounts": [{"Source": "'"$REPO_ROOT"'", "Destination": "/app"}], "Config": {"WorkingDir": "/app"}}]'
+        exit 0
+        ;;
+    *exec*)
+        # docker exec my-container-backend git -C /app rev-parse --show-toplevel
+        # docker exec my-container-backend git -C /app merge-base --is-ancestor target_sha HEAD
+        if echo "$*" | grep -q -- "rev-parse --show-toplevel"; then
+            echo "/app"
+            exit 0
+        elif echo "$*" | grep -q -- "merge-base --is-ancestor"; then
+            exit 0
+        elif echo "$*" | grep -q -- "rev-parse HEAD"; then
+            echo "docker_verified_commit_sha"
+            exit 0
+        fi
+        exit 1
+        ;;
+esac
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/docker"
+
+    run python3 "$HELPER_PY" --repo-root "$REPO_ROOT" --target-repo "foo/bar" --target-sha "target_sha" --base-url "http://localhost:3000" --backend-ports "8000"
+    assert_success
+    assert_output --partial '"result": "verified"'
+    assert_output --partial '"mode": "docker-exec-git"'
+    assert_output --partial '"container": "my-container-backend"'
+}
+
+@test "docker mismatch path" {
+    # 1. ss/lsof return nothing
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    # 2. Fake docker ps returning container and git check failing
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/docker"
+#!/bin/sh
+case "$*" in
+    *ps*)
+        echo "my-mismatch-container 0.0.0.0:8000->8000/tcp"
+        exit 0
+        ;;
+    *inspect*)
+        echo '[{"Mounts": [{"Source": "'"$REPO_ROOT"'", "Destination": "/app"}], "Config": {"WorkingDir": "/app"}}]'
+        exit 0
+        ;;
+    *exec*)
+        if echo "$*" | grep -q -- "rev-parse --show-toplevel"; then
+            echo "/app"
+            exit 0
+        elif echo "$*" | grep -q -- "merge-base --is-ancestor"; then
+            # Ancestor check failed
+            exit 1
+        elif echo "$*" | grep -q -- "rev-parse HEAD"; then
+            echo "old_commit_sha"
+            exit 0
+        fi
+        exit 1
+        ;;
+esac
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/docker"
+
+    run python3 "$HELPER_PY" --repo-root "$REPO_ROOT" --target-repo "foo/bar" --target-sha "target_sha" --base-url "http://localhost:3000" --backend-ports "8000"
+    assert_success
+    assert_output --partial '"result": "mismatch"'
+    assert_output --partial '"mode": "docker-exec-git"'
+    assert_output --partial '"observed_sha": "old_commit_sha"'
+}
+
+@test "docker unsupported/unverified path" {
+    # 1. ss/lsof return nothing
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    # 2. Docker unavailable
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/docker"
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/docker"
+
+    run python3 "$HELPER_PY" --repo-root "$REPO_ROOT" --target-repo "foo/bar" --target-sha "target_sha" --base-url "http://localhost:3000" --backend-ports "8000"
+    assert_success
+    assert_output --partial '"result": "unverified"'
+    assert_output --partial '"reason":'
+}

--- a/tests/bats/skills/devx_pr_verify_live_backend_identity.bats
+++ b/tests/bats/skills/devx_pr_verify_live_backend_identity.bats
@@ -9,6 +9,7 @@ setup() {
     # Create bin directory for fake executables
     mkdir -p "$TEST_TEMP_HOME/bin"
     export PATH="$TEST_TEMP_HOME/bin:$PATH"
+    TEST_SERVER_PID=""
     
     # Paths
     HELPER_PY="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_verify_live_backend_identity.py"
@@ -52,6 +53,10 @@ EOF
 }
 
 teardown() {
+    if [ -n "${TEST_SERVER_PID:-}" ]; then
+        kill "$TEST_SERVER_PID" 2>/dev/null || true
+        wait "$TEST_SERVER_PID" 2>/dev/null || true
+    fi
     teardown_isolated_home
 }
 
@@ -217,4 +222,121 @@ EOF
     assert_success
     assert_output --partial '"result": "unverified"'
     assert_output --partial '"reason":'
+}
+
+@test "version endpoint path" {
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    cat <<'EOF' > "$TEST_TEMP_HOME/version_server.py"
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps({"git_sha": "target_sha_123"}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+EOF
+
+    PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+    python3 "$TEST_TEMP_HOME/version_server.py" "$PORT" &
+    TEST_SERVER_PID=$!
+    sleep 1
+
+    run python3 "$HELPER_PY" --repo-root "$REPO_ROOT" --target-repo "foo/bar" --target-sha "target_sha_123" --base-url "http://localhost:3000" --backend-ports "$PORT"
+    assert_success
+    assert_output --partial '"result": "verified"'
+    assert_output --partial '"mode": "version-endpoint"'
+    assert_output --partial '"observed_sha": "target_sha_123"'
+}
+
+@test "container file route heuristic path" {
+    cat <<'EOF' > "$TEST_TEMP_HOME/bin/ss"
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/ss"
+
+    cat <<EOF > "$TEST_TEMP_HOME/bin/git"
+#!/bin/sh
+case "\$*" in
+    *"diff --name-only target_sha~1 target_sha"*)
+        echo "apps/server/src/api/admin/router.py"
+        exit 0
+        ;;
+    *"diff -U0 target_sha~1 target_sha -- apps/server/src/api/admin/router.py"*)
+        cat <<'DIFF'
+@@ -1,0 +1,2 @@
++router.add_api_route("/curation-thresholds", endpoint)
++from app.api import router
+DIFF
+        exit 0
+        ;;
+    *"show --name-only --pretty=format: target_sha"*)
+        echo "apps/server/src/api/admin/router.py"
+        exit 0
+        ;;
+esac
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/git"
+
+    cat <<EOF > "$TEST_TEMP_HOME/bin/docker"
+#!/bin/sh
+case "\$*" in
+    *"ps --format"*)
+        echo "heuristic-container 0.0.0.0:8000->8000/tcp"
+        exit 0
+        ;;
+    "ps")
+        exit 0
+        ;;
+    *"inspect heuristic-container"*)
+        echo '[{"Mounts":[{"Source":"$REPO_ROOT","Destination":"/app"}],"Config":{"WorkingDir":"/app"}}]'
+        exit 0
+        ;;
+    *"exec heuristic-container git -C /app rev-parse --show-toplevel"*)
+        exit 1
+        ;;
+    *"exec heuristic-container test -f /app/apps/server/src/api/admin/router.py"*)
+        exit 0
+        ;;
+    *'exec heuristic-container grep -F router.add_api_route("/curation-thresholds", endpoint) /app/apps/server/src/api/admin/router.py'*)
+        exit 0
+        ;;
+    *"exec heuristic-container grep -F from app.api import router /app/apps/server/src/api/admin/router.py"*)
+        exit 0
+        ;;
+esac
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_HOME/bin/docker"
+
+    run python3 "$HELPER_PY" --repo-root "$REPO_ROOT" --target-repo "foo/bar" --target-sha "target_sha" --base-url "http://localhost:3000" --backend-ports "8000"
+    assert_success
+    assert_output --partial '"result": "unverified"'
+    assert_output --partial 'container-file-route presence check successful'
+    assert_output --partial 'matches 2 added lines'
 }


### PR DESCRIPTION
## Summary
- add `devx_pr_verify_live_backend_identity.sh` and a Python helper to verify container-backed backend identity through a fallback ladder
- document verified/mismatch/unverified container behavior in `devx:pr-verify-live` and record the user-visible change in the changelog
- add Bats coverage for host success, docker success, mismatch, and unsupported helper paths

## Testing
- `mise run lint`
- `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_verify_live_backend_identity.bats tests/bats/skills/devx_pr_verify_live_backend_identity.bats`
- `mise run test` *(fails on unrelated existing suite failures in `bats/integrations/claude_accounts.bats`, `bats/tools/setup_skills_ssot.bats`, `bats/skills/gh_disable_ai_metrics.bats`, `bats/integrations/claude_statusline_ime.bats`, `bats/skills/helper_fallback_nf1.bats`, and `bats/tools/claude_plugin_scaffold.bats`)*

Closes #1340
