### PR TITLE
fix(proxy): recognize string setup modes in diagnostics

### DIFF
--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -3,6 +3,9 @@
 사용자 관점의 의미 있는 변경 기록. 포맷: `## YYYY-MM-DD` 헤더 아래 `- 변경: **요약**`.
 
 ## 2026-08-13
+- 변경: **`check-proxy` 와 `show-setup-mode` 가 문자열 setup mode (`public`/`internal`/`external`) 를 정상 인식하도록 수정했다. 이제 `~/.dotfiles-setup-mode` 에 `external` 이 저장된 환경에서 거짓 `Unknown setup mode` 실패가 나지 않는다.**
+
+## 2026-08-13
 - 변경: **`devx:pr-verify-live`에 스크립트 기반 컨테이너 백엔드 identity 검증(4단 fallback ladder: host PID, docker exec git, container file/route, version endpoint)을 위한 `devx_pr_verify_live_backend_identity.sh` 헬퍼 및 python helper 추가 (#1340)**
 
 ## 2026-08-12

--- a/shell-common/functions/setup_mode_help.sh
+++ b/shell-common/functions/setup_mode_help.sh
@@ -35,9 +35,9 @@ get_setup_mode_name() {
     mode=$(get_setup_mode)
 
     case "$mode" in
-        1) echo "Public PC (Home environment)" ;;
-        2) echo "Internal company PC (Direct connection)" ;;
-        3) echo "External company PC (VPN)" ;;
+        1|public) echo "Public PC (Home environment)" ;;
+        2|internal) echo "Internal company PC (Direct connection)" ;;
+        3|external) echo "External company PC (VPN)" ;;
         *) echo "Not configured" ;;
     esac
 }
@@ -61,16 +61,16 @@ show_setup_mode() {
     mode_name=$(get_setup_mode_name)
 
     case "$mode" in
-        1)
+        1|public)
             ux_success "Mode 1: $mode_name"
             ux_info "Expected: No proxy, No company configurations"
             ;;
-        2)
+        2|internal)
             ux_success "Mode 2: $mode_name"
             ux_info "Expected: Company proxy enabled (12.26.204.100:8080)"
             ux_info "Expected: All company configurations (.local.sh files) enabled"
             ;;
-        3)
+        3|external)
             ux_success "Mode 3: $mode_name"
             ux_info "Expected: No proxy, Only VPN certificate configurations"
             ;;

--- a/shell-common/tools/custom/check_proxy.sh
+++ b/shell-common/tools/custom/check_proxy.sh
@@ -56,17 +56,17 @@ check_setup_mode() {
     mode=$(cat "$setup_mode_file" 2>/dev/null)
 
     case "$mode" in
-        1)
+        1|public)
             ux_success "Setup Mode: Public PC (Home environment)"
             ux_info "Expected behavior: NO proxy variables should be set"
             record_pass
             ;;
-        2)
+        2|internal)
             ux_success "Setup Mode: Internal company PC (Direct connection)"
             ux_info "Expected behavior: Company proxy SHOULD be set (12.26.204.100:8080)"
             record_pass
             ;;
-        3)
+        3|external)
             ux_success "Setup Mode: External company PC (VPN)"
             ux_info "Expected behavior: NO proxy variables should be set"
             record_pass
@@ -104,7 +104,7 @@ check_proxy_env() {
     local mode
     mode="$(get_setup_mode)"
     case "$mode" in
-        1|3)
+        1|3|public|external)
             if [ "$has_proxy" -eq 1 ]; then
                 echo ""
                 ux_error "ISSUE DETECTED: Proxy is set but should not be (Mode $mode)"
@@ -115,10 +115,10 @@ check_proxy_env() {
                 record_pass
             fi
             ;;
-        2)
+        2|internal)
             if [ "$has_proxy" -eq 0 ]; then
                 echo ""
-                ux_warning "No proxy set but Mode 2 (Internal PC) expects proxy"
+                ux_warning "No proxy set but internal mode expects proxy"
                 ux_info "Check if proxy.local.sh exists and is properly sourced"
                 record_warn
             else
@@ -191,9 +191,9 @@ check_proxy_shell_loading() {
     local zsh_result=""
     local expected_proxy=0
 
-    if [ "$mode" = "2" ]; then
-        expected_proxy=1
-    fi
+    case "$mode" in
+        2|internal) expected_proxy=1 ;;
+    esac
 
     ux_section "Bash"
     ux_info "Testing: bash -c 'source proxy.sh && echo \$http_proxy'"
@@ -237,14 +237,17 @@ check_proxy_connectivity() {
     local mode
     mode="$(get_setup_mode)"
     if [ -z "${http_proxy:-}" ] && [ -z "${HTTP_PROXY:-}" ]; then
-        if [ "$mode" = "2" ]; then
-            ux_warning "No proxy configured but Mode 2 expects one"
+        case "$mode" in
+        2|internal)
+            ux_warning "No proxy configured but internal mode expects one"
             ux_info "Check proxy.local.sh and shell loading diagnostics"
             record_warn
-        else
+            ;;
+        *)
             ux_info "No proxy configured, skipping proxy connectivity test"
             ux_info "Run check-network quick for general internet connectivity"
-        fi
+            ;;
+        esac
         echo ""
         return 0
     fi


### PR DESCRIPTION
## Summary
- make `check-proxy` accept string setup modes (`public`/`internal`/`external`) as well as legacy numeric values
- align `show-setup-mode` with the same setup-mode parsing so help output matches runtime behavior
- record the user-visible diagnostic fix in the public changelog

## Changes
- `check-proxy`: recognize string setup modes in setup-mode validation, proxy expectation checks, and connectivity warnings so `external` no longer reports a false `Unknown setup mode` failure
- `show-setup-mode`: accept both legacy numeric and current string mode values when rendering the current environment
- `docs/public/changelog.md`: document the proxy diagnostic false-failure fix for 2026-08-13

## Test plan
- [x] `bash -n shell-common/tools/custom/check_proxy.sh && bash -n shell-common/functions/setup_mode_help.sh`
- [x] `HOME=/tmp SHELL_COMMON=/home/bwyoon/dotfiles/shell-common DOTFILES_ROOT=/home/bwyoon/dotfiles bash shell-common/tools/custom/check_proxy.sh mode`
- [x] `HOME=/tmp SHELL_COMMON=/home/bwyoon/dotfiles/shell-common DOTFILES_ROOT=/home/bwyoon/dotfiles zsh -ic 'source /home/bwyoon/dotfiles/shell-common/functions/setup_mode_help.sh; show_setup_mode'`

---
<details>
<summary>AI Metrics · ~1000 tokens · ~1 h · ~0 min</summary>

<!-- ai-metrics:gh-pr -->
~1000 tokens · ~1 h · ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
