### PR TITLE
fix(gh-relay-merge): simplify apply-guide execution path

### DIFF
--- a/claude/skills/gh-issue-relay-flow/SKILL.md
+++ b/claude/skills/gh-issue-relay-flow/SKILL.md
@@ -74,10 +74,10 @@ target repo's standard lint/test commands, and only proceed once they pass.
 On failure, re-delegate with a sharper brief per that file's guidance.
 
 ## Step 5: Relay Delegation
+
 Record `HEAD_SHA=$(git rev-parse HEAD)`, then call `gh:relay-merge`
-verbatim — no inline patch/gist/apply-guide logic here. If Step 4 confirmed
-pre-existing unrelated failures, pass their exact file-path list verbatim in
-the delegation brief so `gh:relay-merge` can render the apply-guide's "Known unrelated pre-existing failures" section:
+verbatim — no inline patch/gist/apply-guide logic here. Pass along any
+pre-existing unrelated failure paths recorded in Step 4, as exact paths:
 
 `Skill(gh:relay-merge, "--commits <BASE_SHA>..<HEAD_SHA> --target-issue <N> --remote <remote>")`
 

--- a/claude/skills/gh-issue-relay-flow/SKILL.md
+++ b/claude/skills/gh-issue-relay-flow/SKILL.md
@@ -74,9 +74,10 @@ target repo's standard lint/test commands, and only proceed once they pass.
 On failure, re-delegate with a sharper brief per that file's guidance.
 
 ## Step 5: Relay Delegation
-
 Record `HEAD_SHA=$(git rev-parse HEAD)`, then call `gh:relay-merge`
-verbatim — no inline patch/gist/apply-guide logic here:
+verbatim — no inline patch/gist/apply-guide logic here. If Step 4 confirmed
+pre-existing unrelated failures, pass their exact file-path list verbatim in
+the delegation brief so `gh:relay-merge` can render the apply-guide's "Known unrelated pre-existing failures" section:
 
 `Skill(gh:relay-merge, "--commits <BASE_SHA>..<HEAD_SHA> --target-issue <N> --remote <remote>")`
 

--- a/claude/skills/gh-issue-relay-flow/SKILL.md
+++ b/claude/skills/gh-issue-relay-flow/SKILL.md
@@ -75,11 +75,12 @@ On failure, re-delegate with a sharper brief per that file's guidance.
 
 ## Step 5: Relay Delegation
 
-Record `HEAD_SHA=$(git rev-parse HEAD)`, then call `gh:relay-merge`
-verbatim — no inline patch/gist/apply-guide logic here. Pass along any
-pre-existing unrelated failure paths recorded in Step 4, as exact paths:
+Record `HEAD_SHA=$(git rev-parse HEAD)`, then call `gh:relay-merge` verbatim
+— no inline patch/gist/apply-guide logic here. Pass Step 4's pre-existing
+unrelated failures through `--known-failures` (comma-separated
+`<path>[::<test-or-check>]` entries); omit the flag when Step 4 found none:
 
-`Skill(gh:relay-merge, "--commits <BASE_SHA>..<HEAD_SHA> --target-issue <N> --remote <remote>")`
+`Skill(gh:relay-merge, "--commits <BASE_SHA>..<HEAD_SHA> --target-issue <N> --remote <remote> [--known-failures <entries>]")`
 
 ## Step 6: Report
 

--- a/claude/skills/gh-issue-relay-flow/references/verification.md
+++ b/claude/skills/gh-issue-relay-flow/references/verification.md
@@ -39,9 +39,13 @@ is ever run with this repo as the target, the standard commands are
 ## Run them and gate on the result
 
 - **Pass** — proceed to Step 5. If any failures here were confirmed
-  pre-existing and unrelated, record their exact file paths and carry that
-  list into the Step 5 `gh:relay-merge` brief, so the apply-guide can name
-  concrete files rather than a vague summary sentence.
+  pre-existing and unrelated, record each one as a `<path>::<test-or-check>`
+  entry and pass the comma-separated list to Step 5's `gh:relay-merge` call
+  via `--known-failures`, so the apply-guide names concrete failures rather
+  than a vague summary sentence. Use the bare `<path>` form only when every
+  current failure in that file is pre-existing — one file can hold both a
+  pre-existing failure and a new regression, and the unqualified form would
+  tell the destination-side reader to skip both.
 - **Fail** — do not proceed. Re-delegate to a fresh Worker call with a
   sharper brief: include the specific failing test output / lint errors,
   the file(s) involved, and anything the first brief's completion criteria

--- a/claude/skills/gh-issue-relay-flow/references/verification.md
+++ b/claude/skills/gh-issue-relay-flow/references/verification.md
@@ -39,6 +39,10 @@ is ever run with this repo as the target, the standard commands are
 ## Run them and gate on the result
 
 - **Pass** — proceed to Step 5.
+- If Step 4 confirmed any pre-existing unrelated failures, record the exact
+  file paths before proceeding and carry that list into the Step 5
+  `gh:relay-merge` brief verbatim so the apply-guide can say "do not
+  re-investigate" against the concrete files, not a vague summary sentence.
 - **Fail** — do not proceed. Re-delegate to a fresh Worker call with a
   sharper brief: include the specific failing test output / lint errors,
   the file(s) involved, and anything the first brief's completion criteria

--- a/claude/skills/gh-issue-relay-flow/references/verification.md
+++ b/claude/skills/gh-issue-relay-flow/references/verification.md
@@ -38,11 +38,10 @@ is ever run with this repo as the target, the standard commands are
 
 ## Run them and gate on the result
 
-- **Pass** — proceed to Step 5.
-- If Step 4 confirmed any pre-existing unrelated failures, record the exact
-  file paths before proceeding and carry that list into the Step 5
-  `gh:relay-merge` brief verbatim so the apply-guide can say "do not
-  re-investigate" against the concrete files, not a vague summary sentence.
+- **Pass** — proceed to Step 5. If any failures here were confirmed
+  pre-existing and unrelated, record their exact file paths and carry that
+  list into the Step 5 `gh:relay-merge` brief, so the apply-guide can name
+  concrete files rather than a vague summary sentence.
 - **Fail** — do not proceed. Re-delegate to a fresh Worker call with a
   sharper brief: include the specific failing test output / lint errors,
   the file(s) involved, and anything the first brief's completion criteria

--- a/claude/skills/gh-relay-merge/SKILL.md
+++ b/claude/skills/gh-relay-merge/SKILL.md
@@ -75,25 +75,26 @@ Upload each patch via single-file `gh gist create`, sequentially — never
 multi-file/parallel — per `references/gist-relay.md`. Stop on any failure.
 
 ## Step 6: Post the Apply-Guide Comment
-Build the comment from `references/apply-guide-template.md`, posting to a NEW
-destination issue (default) or `--target-issue <N>`. The top must carry a
-bold "no skill selection / no re-investigation / no separate worktree"
-directive before the 3-step command block, then the ordered gist table,
-`git am` steps, regeneration commands, and background verification notes (PR mode only).
+
+Build the comment from `references/apply-guide-template.md`, which owns its
+wording and section order. Post to a NEW destination issue (default) or
+`--target-issue <N>`; fill the pre-existing-failures section from the brief.
 
 ## Step 7: Origin-side Cleanup (optional)
+
 Only with explicit user confirmation, close a duplicate origin-side tracking
 issue with a cross-reference comment. Never auto-close.
 
 ## Step 8: Report
+
 Summarize the destination issue/comment URL, gist count, whether any patches
 were split (artifact exclusion or file-group pre-split), and — if Step 2's
 probe passed — that the simple push+PR path was used instead of relay.
 
 ## Constraints
 
-See `references/constraints.md` for the full list. Hard rules: never fall back
-to `origin` silently · never plain-`push`-then-relay (probe first) · never
-multi-file/parallel `gh gist create` · never silently truncate (only generated
-artifacts stripped; oversized commits get file-group pre-split) · never
-auto-close an origin issue.
+See `references/constraints.md` for the full list. Hard rules: never fall
+back to `origin` silently · never plain-`push`-then-relay (probe first) ·
+never multi-file/parallel `gh gist create` · never silently truncate (only
+generated artifacts stripped; oversized commits get file-group pre-split) ·
+never auto-close an origin issue.

--- a/claude/skills/gh-relay-merge/SKILL.md
+++ b/claude/skills/gh-relay-merge/SKILL.md
@@ -75,26 +75,25 @@ Upload each patch via single-file `gh gist create`, sequentially — never
 multi-file/parallel — per `references/gist-relay.md`. Stop on any failure.
 
 ## Step 6: Post the Apply-Guide Comment
-
 Build the comment from `references/apply-guide-template.md`, posting to a NEW
-destination issue (default) or `--target-issue <N>`: ordered gist table +
-`git am` steps + regeneration commands + verification basis (PR mode only).
+destination issue (default) or `--target-issue <N>`. The top must carry a
+bold "no skill selection / no re-investigation / no separate worktree"
+directive before the 3-step command block, then the ordered gist table,
+`git am` steps, regeneration commands, and background verification notes (PR mode only).
 
 ## Step 7: Origin-side Cleanup (optional)
-
-Only with explicit user confirmation, close a duplicate origin-side
-tracking issue with a cross-reference comment. Never auto-close.
+Only with explicit user confirmation, close a duplicate origin-side tracking
+issue with a cross-reference comment. Never auto-close.
 
 ## Step 8: Report
-
 Summarize the destination issue/comment URL, gist count, whether any patches
 were split (artifact exclusion or file-group pre-split), and — if Step 2's
 probe passed — that the simple push+PR path was used instead of relay.
 
 ## Constraints
 
-See `references/constraints.md` for the full list. Hard rules: never fall
-back to `origin` silently · never plain-`push`-then-relay (probe first) ·
-never multi-file/parallel `gh gist create` · never silently truncate (only
-generated artifacts stripped; oversized commits get file-group pre-split) ·
-never auto-close an origin issue.
+See `references/constraints.md` for the full list. Hard rules: never fall back
+to `origin` silently · never plain-`push`-then-relay (probe first) · never
+multi-file/parallel `gh gist create` · never silently truncate (only generated
+artifacts stripped; oversized commits get file-group pre-split) · never
+auto-close an origin issue.

--- a/claude/skills/gh-relay-merge/SKILL.md
+++ b/claude/skills/gh-relay-merge/SKILL.md
@@ -11,9 +11,9 @@ description: >-
   comment on the destination issue. Use when the user runs /gh:relay-merge,
   /gh-relay-merge, or asks "origin PR를 upstream 으로 릴레이", "push 막혀서
   patch+gist 로 넘겨줘", "relay merged PR to upstream via gist". Accepts
-  either `<origin-PR#>` or `--commits <base-sha>..<head-sha>` (mutually
-  exclusive) plus `[--remote <name-or-URL>] [--target-issue <N>]
-  [--generated-patterns <globs>]`, and `-h`/`--help`/`help`.
+  either `<origin-PR#>` or `--commits <base>..<head>` (mutually exclusive)
+  plus `[--remote <name-or-URL>] [--target-issue <N>] [--known-failures
+  <entries>] [--generated-patterns <globs>]`, and `-h`/`--help`/`help`.
 allowed-tools: Bash, Read, Write, Grep, Glob
 metadata:
   model_recommendation:
@@ -34,7 +34,7 @@ output its content verbatim, then stop. No API calls.
 
 Input is EITHER positional `<origin-PR#>` OR `--commits <base>..<head>`
 (both supplied → hard error, stop). Shared flags: `--remote`,
-`--target-issue`, `--generated-patterns`.
+`--target-issue`, `--known-failures`, `--generated-patterns`.
 - **PR mode**: `gh pr view <N> --repo <origin-repo> --json number,state,url,headRefOid,baseRefName,mergeCommit,statusCheckRollup,reviewDecision`.
   Do **not** require `merged` — use the PR's current head/base commits.
 - **`--commits` mode**: skip `gh pr view`; use the range directly. Git
@@ -78,7 +78,7 @@ multi-file/parallel — per `references/gist-relay.md`. Stop on any failure.
 
 Build the comment from `references/apply-guide-template.md`, which owns its
 wording and section order. Post to a NEW destination issue (default) or
-`--target-issue <N>`; fill the pre-existing-failures section from the brief.
+`--target-issue <N>`; render `--known-failures` into its known-failures section.
 
 ## Step 7: Origin-side Cleanup (optional)
 

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -89,10 +89,11 @@ a failure after applying, or if you need to regenerate an excluded artifact.
 These already failed on the origin side before this change. Do not
 re-investigate them; continue.
 
-- `<exact file path 1>`
-- `<exact file path 2>`
+- `<path 1>` — failing check: `<test-or-check 1>`
+- `<path 2>` — whole file (no specific check named)
 
-(Omit this section entirely if none were confirmed on the origin side.)
+Anything not listed here is in scope: a failure in a listed file under a
+*different* test/check name is NOT covered and must be investigated.
 
 ### Excluded generated artifacts
 
@@ -121,6 +122,13 @@ What was verified on the origin side (from `gh pr view` in Step 1):
   `references/gist-relay.md`, not the web URLs.
 - Keep the apply order identical to the numeric patch order from
   `git format-patch` — out-of-order application breaks `git am`.
+- **"Known unrelated pre-existing failures" is driven entirely by the
+  `--known-failures` flag** (`references/help.md` → Arguments). Render one
+  bullet per comma-separated entry, in the order given: split the entry at
+  `::` and render the qualifier after the em dash (`` `<path>` — failing
+  check: `<test-or-check>` ``); a bare `<path>` entry renders the whole-file
+  form. Omit the whole section when the flag was not supplied — never
+  invent entries, and never widen a qualified entry to the whole file.
 - The "Background" section reuses data already fetched in Step 1; do not
   make extra API calls for it.
 - **`--commits` mode** (no origin PR object exists): keep the header as-is
@@ -128,7 +136,7 @@ What was verified on the origin side (from `gh pr view` in Step 1):
   <base>..<head> on the internal remote (no origin PR).`, dropping the
   CI/Review/Origin-PR bullets — there is no `gh pr view` data to report.
   The "Known unrelated pre-existing failures" section still applies when
-  the caller supplied a list.
+  `--known-failures` was supplied.
 - **The destination-side remote name may not match this side's** — e.g.
   this side's `upstream` (github.com) may be the destination machine's
   `origin`. Steps 1 and 3 default to the literal `origin` (the

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -30,28 +30,24 @@ Fill the placeholders and write to `$tmpdir/apply-guide.md` (outer fence is
 `~~~` so the inner ```bash``` blocks nest without breaking it):
 
 ~~~markdown
-## Relay of origin PR #<N> — <PR title>
+# Instruction — execute only the 3 steps below, in order
 
-Source PR was **<merged|open>** on the internal remote. `git push` to this
-remote is proxy-blocked, so its commits are relayed as patches below.
+**Do not choose a skill. Do not re-investigate. Do not create a separate worktree.**
+This comment is a patch-relay apply-guide. Execute the three steps below as written.
 
-### Setup (destination branch)
+## 1) Create the destination branch
 
-**Note:** Commands below default to `origin` — the common case when the
-destination machine has only one remote for this repo. It may differ from
-the name used on the machine that ran this relay (e.g. this side calls it
-`upstream`; that's irrelevant on the destination side). If you already know
-the destination reader's remote is named differently, substitute it before
-posting; otherwise leave `origin` as the copy-pasteable default — the
-reader can swap it in seconds, but a `<placeholder>` blocks copy-paste
-entirely, which defeats the point of an apply-guide.
+Commands below default to `origin` — the common case when the destination
+machine has only one remote for this repo. If you already know the
+destination remote uses a different name, substitute it before posting;
+otherwise keep `origin` so the reader can copy-paste immediately.
 
 ```bash
 git fetch origin <default-branch>
 git checkout -b <new-branch-name> origin/<default-branch>
 ```
 
-### Apply order
+## 2) Apply the patches in this exact order
 
 | # | Patch (gist) | Description |
 |---|--------------|-------------|
@@ -68,7 +64,7 @@ them adjacent and in order:
 
 Omit the split rows when nothing was pre-split.
 
-Apply **in this exact order** (each patch builds on the previous):
+Apply them in this exact order (each patch builds on the previous):
 
 ```bash
 curl -sL <raw-url-0001> | git am
@@ -76,12 +72,26 @@ curl -sL <raw-url-0002> | git am
 # … one line per patch, in order
 ```
 
-### Finish (push + PR)
+## 3) Push and open the PR
 
 ```bash
 git push -u origin <new-branch-name>
 gh pr create --repo <owner/repo> --title "<title>" --body "Closes #<N>"
 ```
+
+---
+
+## Reference
+
+Check this section only if the three commands above fail or if you need to
+regenerate an intentionally excluded artifact.
+
+### Known unrelated pre-existing failures
+
+- `<exact file path 1>` — already known unrelated failure; do not re-investigate, continue.
+- `<exact file path 2>` — already known unrelated failure; do not re-investigate, continue.
+
+(Omit this section entirely if none were confirmed on the origin side.)
 
 ### Excluded generated artifacts
 
@@ -95,7 +105,7 @@ Regenerate them locally after applying:
 
 (Omit this section if nothing was excluded.)
 
-### Verification basis
+### Background
 
 What was verified on the origin side (from `gh pr view` in Step 1):
 
@@ -113,10 +123,10 @@ What was verified on the origin side (from `gh pr view` in Step 1):
 - The verification-basis section reuses data already fetched in Step 1; do
   not make extra API calls for it.
 - **`--commits` mode** (no origin PR object exists): replace the header
-  with `## Relay of commit range \`<base>..<head>\`` and the "Source PR
-  was…" line with "Source range is `<base>..<head>` on the internal remote
-  (no origin PR)."; omit the "Verification basis" section entirely — there
-  is no `gh pr view` data to report.
+  with `# Instruction — execute only the 3 steps below, in order` plus a
+  first background line stating `Source range is <base>..<head> on the
+  internal remote (no origin PR).`; omit the "Background" bullets derived
+  from `gh pr view` — there is no PR metadata to report.
 - **The destination-side remote name may not match this side's** — e.g.
   this side's `upstream` (github.com) may be the destination machine's
   `origin`. "Setup" and "Finish" default to the literal `origin` (the

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -111,6 +111,7 @@ Regenerate them locally after applying:
 
 What was verified on the origin side (from `gh pr view` in Step 1):
 
+- Source PR state: **<merged|open>** on the internal remote
 - CI: <statusCheckRollup summary — e.g. all checks green>
 - Review: <reviewDecision — e.g. APPROVED by N reviewers>
 - Origin PR: <origin PR URL>
@@ -134,7 +135,8 @@ What was verified on the origin side (from `gh pr view` in Step 1):
 - **`--commits` mode** (no origin PR object exists): keep the header as-is
   and replace the "Background" intro line with `Source range is
   <base>..<head> on the internal remote (no origin PR).`, dropping the
-  CI/Review/Origin-PR bullets — there is no `gh pr view` data to report.
+  state/CI/Review/Origin-PR bullets — there is no `gh pr view` data to
+  report, and a commit range has no merge state.
   The "Known unrelated pre-existing failures" section still applies when
   `--known-failures` was supplied.
 - **The destination-side remote name may not match this side's** — e.g.

--- a/claude/skills/gh-relay-merge/references/apply-guide-template.md
+++ b/claude/skills/gh-relay-merge/references/apply-guide-template.md
@@ -33,14 +33,12 @@ Fill the placeholders and write to `$tmpdir/apply-guide.md` (outer fence is
 # Instruction — execute only the 3 steps below, in order
 
 **Do not choose a skill. Do not re-investigate. Do not create a separate worktree.**
-This comment is a patch-relay apply-guide. Execute the three steps below as written.
+This comment is a patch-relay apply-guide.
 
 ## 1) Create the destination branch
 
-Commands below default to `origin` — the common case when the destination
-machine has only one remote for this repo. If you already know the
-destination remote uses a different name, substitute it before posting;
-otherwise keep `origin` so the reader can copy-paste immediately.
+Commands below assume the destination remote is `origin`; substitute your
+own remote name if it differs.
 
 ```bash
 git fetch origin <default-branch>
@@ -83,13 +81,16 @@ gh pr create --repo <owner/repo> --title "<title>" --body "Closes #<N>"
 
 ## Reference
 
-Check this section only if the three commands above fail or if you need to
-regenerate an intentionally excluded artifact.
+Check this section only if a command above fails, if a lint/test run reports
+a failure after applying, or if you need to regenerate an excluded artifact.
 
 ### Known unrelated pre-existing failures
 
-- `<exact file path 1>` — already known unrelated failure; do not re-investigate, continue.
-- `<exact file path 2>` — already known unrelated failure; do not re-investigate, continue.
+These already failed on the origin side before this change. Do not
+re-investigate them; continue.
+
+- `<exact file path 1>`
+- `<exact file path 2>`
 
 (Omit this section entirely if none were confirmed on the origin side.)
 
@@ -120,20 +121,21 @@ What was verified on the origin side (from `gh pr view` in Step 1):
   `references/gist-relay.md`, not the web URLs.
 - Keep the apply order identical to the numeric patch order from
   `git format-patch` — out-of-order application breaks `git am`.
-- The verification-basis section reuses data already fetched in Step 1; do
-  not make extra API calls for it.
-- **`--commits` mode** (no origin PR object exists): replace the header
-  with `# Instruction — execute only the 3 steps below, in order` plus a
-  first background line stating `Source range is <base>..<head> on the
-  internal remote (no origin PR).`; omit the "Background" bullets derived
-  from `gh pr view` — there is no PR metadata to report.
+- The "Background" section reuses data already fetched in Step 1; do not
+  make extra API calls for it.
+- **`--commits` mode** (no origin PR object exists): keep the header as-is
+  and replace the "Background" intro line with `Source range is
+  <base>..<head> on the internal remote (no origin PR).`, dropping the
+  CI/Review/Origin-PR bullets — there is no `gh pr view` data to report.
+  The "Known unrelated pre-existing failures" section still applies when
+  the caller supplied a list.
 - **The destination-side remote name may not match this side's** — e.g.
   this side's `upstream` (github.com) may be the destination machine's
-  `origin`. "Setup" and "Finish" default to the literal `origin` (the
+  `origin`. Steps 1 and 3 default to the literal `origin` (the
   overwhelmingly common case for a single-remote clone) precisely so the
   reader can copy-paste without editing anything; only override it inline
   if you already know the destination uses a different name. Never leave
-  an unresolved `<placeholder>` in these two code blocks — that forces a
+  an unresolved `<placeholder>` in those two code blocks — that forces a
   manual edit before every single command, which is the exact friction
   this template exists to remove (#1346 review: an earlier draft used
   `<remote-name>` here and the destination-side reader could not copy-paste

--- a/claude/skills/gh-relay-merge/references/help.md
+++ b/claude/skills/gh-relay-merge/references/help.md
@@ -61,7 +61,7 @@ Input is EITHER the positional `<origin-PR#>` OR `--commits <base>..<head>`
    diff still exceeds the limit stops the skill (no arbitrary truncation).
 5. Uploads each patch via single-file `gh gist create`, one call at a time.
 6. Posts an apply-guide comment (gist table + `git am` steps + regeneration
-   commands + verification basis) to a new or `--target-issue` destination.
+   commands + background notes) to a new or `--target-issue` destination.
 7. Optionally (with explicit confirmation) closes a duplicate origin issue.
 8. Reports the destination URL, gist count, and any split-patch decisions.
 

--- a/claude/skills/gh-relay-merge/references/help.md
+++ b/claude/skills/gh-relay-merge/references/help.md
@@ -11,7 +11,14 @@ Input is EITHER the positional `<origin-PR#>` OR `--commits <base>..<head>`
 | flag | `--commits <base>..<head>` | — | Alternate input mode: relay this git range directly, skipping `gh pr view`. Standard git semantics — `base` EXCLUDED, `head` INCLUDED |
 | flag | `--remote <name-or-URL>` | `upstream` | Destination remote. Name (resolved via `git remote get-url`) or raw URL |
 | flag | `--target-issue <N>` | new issue | Post the apply-guide to this existing destination issue/PR instead of creating a new one |
+| flag | `--known-failures <entries>` | none (section omitted) | Comma-separated `<path>[::<test-or-check>]` entries for lint/test failures already confirmed pre-existing and unrelated on the origin side. Rendered verbatim into the apply-guide's "Known unrelated pre-existing failures" section |
 | flag | `--generated-patterns <globs>` | built-in list | Comma-separated globs marking generated artifacts to strip from oversized patches |
+
+`--known-failures` entry format: a bare `<path>` marks the whole file's
+current failures as known; `<path>::<test-or-check>` narrows it to one named
+test/check so a file that holds both a pre-existing failure and a new
+regression does not suppress investigation of the regression. Prefer the
+qualified form whenever the runner reports a test/check name.
 
 ## Usage
 
@@ -21,6 +28,7 @@ Input is EITHER the positional `<origin-PR#>` OR `--commits <base>..<head>`
 /gh-relay-merge 168 --remote fork                # relay to remote named 'fork'
 /gh-relay-merge 168 --remote https://github.com/org/repo.git
 /gh-relay-merge 168 --target-issue 42            # post guide to existing issue #42
+/gh-relay-merge --commits abc123..def456 --known-failures 'tests/test_a.py::test_legacy,tests/flaky.bats'
 /gh-relay-merge 168 --generated-patterns '**/gen/**,*.lock'
 /gh-relay-merge -h                               # this help
 ```
@@ -61,7 +69,8 @@ Input is EITHER the positional `<origin-PR#>` OR `--commits <base>..<head>`
    diff still exceeds the limit stops the skill (no arbitrary truncation).
 5. Uploads each patch via single-file `gh gist create`, one call at a time.
 6. Posts an apply-guide comment (gist table + `git am` steps + regeneration
-   commands + background notes) to a new or `--target-issue` destination.
+   commands + any `--known-failures` entries + background notes) to a new or
+   `--target-issue` destination.
 7. Optionally (with explicit confirmation) closes a duplicate origin issue.
 8. Reports the destination URL, gist count, and any split-patch decisions.
 

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-08-17
 - 변경: **`obsidian:session-clip` 의 vault 기본 경로가 PC 모드를 인식한다 — `--vault` 도 `$OBSIDIAN_VAULT_DIR` 도 없을 때만, `~/.dotfiles-setup-mode` 가 `internal`(레거시 숫자값 `2` 포함)이면 기본 후보가 `$HOME/para/project/obsidian-para-company` 로, 그 외 값·빈 값·파일 없음이면 종전대로 `$HOME/para/project/obsidian-para` 로 해석된다. 종전에는 단일 하드코딩 기본값이라 사내 PC 에서 옵션 없이 실행하면 항상 vault-missing 으로 멈췄다. **사용자 가시 동작 변경 주의** — 사내 PC 에 두 vault 가 함께 있으면 옵션 없는 실행의 기본 저장 대상이 개인 vault 에서 사내 vault 로 바뀐다. 종전 대상을 유지하려면 `--vault $HOME/para/project/obsidian-para` 또는 `OBSIDIAN_VAULT_DIR` 로 명시한다(둘 다 모드 기본값보다 우선한다). 해석은 `lib/resolve-vault.sh` 가 SSOT 이며 경로 존재 확인은 종전대로 SKILL.md Step 1 의 몫이다 (#1351)**
+- 변경: **`gh:relay-merge` apply-guide 코멘트를 순수 3단계 명령형으로 단순화했다. 최상단에 "스킬 선택·재조사·별도 워크트리 생성 금지" 지시를 고정하고, 브랜치 생성 → 순서대로 `git am` → push/PR 생성만 먼저 보이도록 재구성했다. `gh:issue-relay-flow` 검증 단계는 origin 쪽에서 확인한 무관한 기존 실패의 정확한 파일 경로를 Step 5 relay 브리프로 넘기도록 명시해, apply-guide가 그 파일들을 "재조사하지 말고 넘어가라"는 문장과 함께 적도록 했다.**
 
 ## 2026-08-13
 - 변경: **`check-proxy` 와 `show-setup-mode` 가 문자열 setup mode (`public`/`internal`/`external`) 를 정상 인식하도록 수정했다. 이제 `~/.dotfiles-setup-mode` 에 `external` 이 저장된 환경에서 거짓 `Unknown setup mode` 실패가 나지 않는다.**

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-08-17
 - 변경: **`obsidian:session-clip` 의 vault 기본 경로가 PC 모드를 인식한다 — `--vault` 도 `$OBSIDIAN_VAULT_DIR` 도 없을 때만, `~/.dotfiles-setup-mode` 가 `internal`(레거시 숫자값 `2` 포함)이면 기본 후보가 `$HOME/para/project/obsidian-para-company` 로, 그 외 값·빈 값·파일 없음이면 종전대로 `$HOME/para/project/obsidian-para` 로 해석된다. 종전에는 단일 하드코딩 기본값이라 사내 PC 에서 옵션 없이 실행하면 항상 vault-missing 으로 멈췄다. **사용자 가시 동작 변경 주의** — 사내 PC 에 두 vault 가 함께 있으면 옵션 없는 실행의 기본 저장 대상이 개인 vault 에서 사내 vault 로 바뀐다. 종전 대상을 유지하려면 `--vault $HOME/para/project/obsidian-para` 또는 `OBSIDIAN_VAULT_DIR` 로 명시한다(둘 다 모드 기본값보다 우선한다). 해석은 `lib/resolve-vault.sh` 가 SSOT 이며 경로 존재 확인은 종전대로 SKILL.md Step 1 의 몫이다 (#1351)**
+- 변경: **`gh:relay-merge` 에 `--known-failures <entries>` 플래그 신설 — origin 쪽에서 기존·무관 실패로 확인된 항목을 쉼표 구분 `<path>[::<test-or-check>]` 로 받아 apply-guide 의 "Known unrelated pre-existing failures" 섹션으로 그대로 렌더링한다. 이전에는 이 목록을 넘길 채널이 "브리프" 라는 서술뿐이라 `Skill(gh:relay-merge, "...")` 호출로는 실제 전달이 불가능했다 (PR #1349 codex/agy 리뷰). `<path>::<test-or-check>` 한정자 덕분에 한 파일에 기존 실패와 신규 회귀가 함께 있어도 회귀 조사를 억제하지 않는다. `gh:issue-relay-flow` Step 4/5 도 이 플래그로 목록을 넘기도록 갱신.**
 - 변경: **`gh:relay-merge` apply-guide 코멘트를 순수 3단계 명령형으로 단순화했다. 최상단에 "스킬 선택·재조사·별도 워크트리 생성 금지" 지시를 고정하고, 브랜치 생성 → 순서대로 `git am` → push/PR 생성만 먼저 보이도록 재구성했다. `gh:issue-relay-flow` 검증 단계는 origin 쪽에서 확인한 무관한 기존 실패의 정확한 파일 경로를 Step 5 relay 브리프로 넘기도록 명시해, apply-guide가 그 파일들을 "재조사하지 말고 넘어가라"는 문장과 함께 적도록 했다.**
 
 ## 2026-08-13


### PR DESCRIPTION
## Summary
- rewrite the relay apply-guide into a strict 3-step imperative execution path
- move background/reference material below the execution steps and add explicit unrelated-failure file placeholders
- require `gh:issue-relay-flow` verification/relay delegation to pass exact unrelated failure paths through to `gh:relay-merge`

## Testing
- `mise run lint`
- `mise run test`

Closes #1348
