### PR TITLE
docs(internal-pc): 사내 PC gateway-cli 의존성을 PC-환경 SSOT 에 문서화

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -71,6 +71,8 @@ gateway-cli setup && gateway-cli verify
 
 `~/.claude/settings.json` 에 `apiKeyHelper` / `awsCredentialExport` / `awsAuthRefresh` / `cleanupPeriodDays` / `env.*` 를 씁니다. dotfiles 는 이 키들을 쓰지 않으므로 모델 목록이 비거나 인증이 깨지면 먼저 이 두 명령을 의심하세요. `setup` 은 `.statusLine.command` 도 덮어쓰지만 조치는 불필요 — 다음 세션 시작 시 drift 훅이 dotfiles statusline 으로 되돌리고 "auto-corrected" 로 알립니다.
 
+설치 아티팩트 위치와 `gateway-cli env --persist` 의 tracked `zsh/zshrc` 오염 주의사항은 `docs/guide/internal-pc.md` → "Claude Code 인증 (gateway-cli)" 참고.
+
 ## Step 4 — OTel 텔레메트리 설치
 
 ```sh

--- a/docs/.ssot/pc-environment.md
+++ b/docs/.ssot/pc-environment.md
@@ -32,6 +32,7 @@
 
 | 항목 | 위치 | 비고 |
 |------|------|------|
+| Claude Code 인증 | `gateway-cli setup` (조직 LLM Gateway) | `internal` → 2026-08-18부터 `gateway-cli` 소유; 상세: `claude/AGENTS.md` / `aws/AGENTS.md` |
 | Claude 계정 활성화 | `shell-common/env/claude.sh` | `internal` → work 계정만; 그 외 → personal/work/work1 |
 | Git host 라우팅 | `shell-common/functions/gh_host.sh` | `internal` → GHES, 그 외 → github.com |
 | 프록시 자동 정리 | `shell-common/util/setup_mode.sh` | WSL2 프록시 상속 방지 (레거시 숫자값만 매칭, 문자열 값 미지원 — issue #1051) |

--- a/docs/.ssot/pc-environment.md
+++ b/docs/.ssot/pc-environment.md
@@ -32,7 +32,7 @@
 
 | 항목 | 위치 | 비고 |
 |------|------|------|
-| Claude Code 인증 | `gateway-cli setup` (조직 LLM Gateway) | `internal` → 2026-08-18부터 `gateway-cli` 소유; 상세: `claude/AGENTS.md` / `aws/AGENTS.md` |
+| Claude Code 인증 | `gateway-cli setup` (조직 LLM Gateway) | `internal` → 2026-08-18~ `gateway-cli` 소유; 상세: `docs/guide/internal-pc.md` |
 | Claude 계정 활성화 | `shell-common/env/claude.sh` | `internal` → work 계정만; 그 외 → personal/work/work1 |
 | Git host 라우팅 | `shell-common/functions/gh_host.sh` | `internal` → GHES, 그 외 → github.com |
 | 프록시 자동 정리 | `shell-common/util/setup_mode.sh` | WSL2 프록시 상속 방지 (레거시 숫자값만 매칭, 문자열 값 미지원 — issue #1051) |

--- a/docs/guide/internal-pc.md
+++ b/docs/guide/internal-pc.md
@@ -15,6 +15,36 @@
 | `claude-yolo` 동작 | `~/.dotfiles-setup-mode == internal` 감지 시 `~/.claude/` 강제 | `_claude_resolve_account` 로 분기 |
 | `settings.local.json` 위치 | `claude/settings.local.json` (gitignored) | 동일, 두 계정이 SSOT 공유 |
 
+## Claude Code 인증 (gateway-cli)
+
+`internal` 모드 PC 의 Claude Code 인증은 2026-08-18부터 조직 LLM Gateway 전환 도구
+`gateway-cli` 가 담당한다. `~/.claude/settings.json` 의 auth/env/model 키 소유권 상세는
+`claude/AGENTS.md` "Configuration Files" 섹션과 `aws/AGENTS.md` 참고 (중복 서술 생략).
+
+### 설치
+
+- 설치 아티팩트 `gateway-cli-setup.run` (~50MB 바이너리) 은 git 에 커밋하지 않는다 —
+  사내 전용 배포물이므로 `~/download/` 에 수동 다운로드해 실행한다.
+- 설치 결과 레이아웃:
+  - 실체: `~/.local/share/gateway-cli-suite/gateway-cli`
+  - symlink: `~/.local/bin/gateway-cli`
+
+### `gateway-cli env --persist` 주의사항 — tracked 파일 오염
+
+`gateway-cli env --persist` 는 `ADMIN_API_URL` / `ANTHROPIC_BASE_URL` 등을 셸 rc 파일에
+쓴다. 이 값은 tracked `zsh/zshrc` 가 아니라 `~/.zshrc.local` (gitignored 개인 슬롯) 에
+떨어져야 한다.
+
+실제로 2026-08-18 에 tracked 파일에 먼저 쓰였다가 수동으로 옮긴 전례가 있다
+(`~/.zshrc.local:11` 주석: "moved from tracked zshrc, 2026-08-18"). 재설치하거나 두 번째
+사내 PC 를 셋업할 때는 `git -C ~/dotfiles status` 로 tracked `zsh/zshrc` 오염 여부를
+먼저 확인한다.
+
+### 설치 확인 체크리스트
+
+- [ ] `gateway-cli verify` 통과
+- [ ] `git -C ~/dotfiles status` 로 tracked 파일(특히 `zsh/zshrc`) 오염 없음 확인
+
 ## 사내 게이트웨이 env 블록 추가
 
 `./setup.sh` 실행 후 다음 파일을 편집한다 (gitignored, 푸시되지 않음):

--- a/docs/guide/internal-pc.md
+++ b/docs/guide/internal-pc.md
@@ -18,32 +18,23 @@
 ## Claude Code 인증 (gateway-cli)
 
 `internal` 모드 PC 의 Claude Code 인증은 2026-08-18부터 조직 LLM Gateway 전환 도구
-`gateway-cli` 가 담당한다. `~/.claude/settings.json` 의 auth/env/model 키 소유권 상세는
-`claude/AGENTS.md` "Configuration Files" 섹션과 `aws/AGENTS.md` 참고 (중복 서술 생략).
+`gateway-cli` 가 담당한다. 전체 부트스트랩 순서는 `aws/README.md` Step 3.5,
+`~/.claude/settings.json` 의 auth/env/model 키 소유권 상세는 `claude/AGENTS.md`
+"Configuration Files" 섹션과 `aws/AGENTS.md` 참고 (중복 서술 생략).
 
-### 설치
+1. **설치** — 아티팩트 `gateway-cli-setup.run` (~50MB 바이너리) 은 사내 전용 배포물이라
+   git 에 커밋하지 않는다. `~/download/` 에 수동 다운로드해 실행하면 실체
+   `~/.local/share/gateway-cli-suite/gateway-cli` + symlink `~/.local/bin/gateway-cli` 가 생긴다.
+2. **`gateway-cli env --persist` 는 tracked 파일을 오염시킬 수 있다** — 이 명령이 쓰는
+   `ADMIN_API_URL` / `ANTHROPIC_BASE_URL` 등은 tracked `zsh/zshrc` 가 아니라
+   `~/.zshrc.local` (gitignored 개인 슬롯, #737) 에 떨어져야 한다. 실제로 tracked 쪽에
+   먼저 쓰였다가 수동으로 옮긴 전례가 있다.
+3. **설치 확인** — `gateway-cli verify` 통과, 그리고 `git -C ~/dotfiles status` 로
+   `zsh/zshrc` 오염 없음. 재설치하거나 두 번째 사내 PC 를 셋업할 때도 같다.
 
-- 설치 아티팩트 `gateway-cli-setup.run` (~50MB 바이너리) 은 git 에 커밋하지 않는다 —
-  사내 전용 배포물이므로 `~/download/` 에 수동 다운로드해 실행한다.
-- 설치 결과 레이아웃:
-  - 실체: `~/.local/share/gateway-cli-suite/gateway-cli`
-  - symlink: `~/.local/bin/gateway-cli`
-
-### `gateway-cli env --persist` 주의사항 — tracked 파일 오염
-
-`gateway-cli env --persist` 는 `ADMIN_API_URL` / `ANTHROPIC_BASE_URL` 등을 셸 rc 파일에
-쓴다. 이 값은 tracked `zsh/zshrc` 가 아니라 `~/.zshrc.local` (gitignored 개인 슬롯) 에
-떨어져야 한다.
-
-실제로 2026-08-18 에 tracked 파일에 먼저 쓰였다가 수동으로 옮긴 전례가 있다
-(`~/.zshrc.local:11` 주석: "moved from tracked zshrc, 2026-08-18"). 재설치하거나 두 번째
-사내 PC 를 셋업할 때는 `git -C ~/dotfiles status` 로 tracked `zsh/zshrc` 오염 여부를
-먼저 확인한다.
-
-### 설치 확인 체크리스트
-
-- [ ] `gateway-cli verify` 통과
-- [ ] `git -C ~/dotfiles status` 로 tracked 파일(특히 `zsh/zshrc`) 오염 없음 확인
+아래 "사내 게이트웨이 env 블록 추가" 는 별개 파일(`settings.local.json`) 경로다 —
+gateway-cli 가 쓴 `settings.json` 값을 개인적으로 덮을 때 쓰며 native merge 에서 local 이
+이긴다 (`claude/AGENTS.md`). gateway-cli 를 대체하는 절차가 아니다.
 
 ## 사내 게이트웨이 env 블록 추가
 

--- a/docs/guide/internal-pc.md
+++ b/docs/guide/internal-pc.md
@@ -23,14 +23,18 @@
 "Configuration Files" 섹션과 `aws/AGENTS.md` 참고 (중복 서술 생략).
 
 1. **설치** — 아티팩트 `gateway-cli-setup.run` (~50MB 바이너리) 은 사내 전용 배포물이라
-   git 에 커밋하지 않는다. `~/download/` 에 수동 다운로드해 실행하면 실체
+   git 에 커밋하지 않는다. 정확한 배포 URL은 사내 전용이라 이 문서(`pc-environment.md`
+   의 "비밀은 적지 않는다" 원칙 적용)에는 적지 않는다 — 사내 IT 소프트웨어 배포 포털에서
+   `gateway-cli` 로 검색해 받는다. `~/download/` 에 수동 다운로드해 실행하면 실체
    `~/.local/share/gateway-cli-suite/gateway-cli` + symlink `~/.local/bin/gateway-cli` 가 생긴다.
 2. **`gateway-cli env --persist` 는 tracked 파일을 오염시킬 수 있다** — 이 명령이 쓰는
    `ADMIN_API_URL` / `ANTHROPIC_BASE_URL` 등은 tracked `zsh/zshrc` 가 아니라
-   `~/.zshrc.local` (gitignored 개인 슬롯, #737) 에 떨어져야 한다. 실제로 tracked 쪽에
-   먼저 쓰였다가 수동으로 옮긴 전례가 있다.
-3. **설치 확인** — `gateway-cli verify` 통과, 그리고 `git -C ~/dotfiles status` 로
-   `zsh/zshrc` 오염 없음. 재설치하거나 두 번째 사내 PC 를 셋업할 때도 같다.
+   `~/.zshrc.local` (gitignored 개인 슬롯, #737) 에 떨어져야 한다. bash 사용자도 마찬가지
+   위험이 있다 — `~/.bashrc` 는 tracked `bash/main.bash` 에 심링크되어 있다. 실제로
+   tracked 쪽에 먼저 쓰였다가 수동으로 옮긴 전례가 있다.
+3. **설치 확인** — `gateway-cli verify` 통과, 그리고
+   `git -C "${DOTFILES_ROOT:-$HOME/dotfiles}" status` 로 `zsh/zshrc` / `bash/main.bash`
+   오염 없음. 재설치하거나 두 번째 사내 PC 를 셋업할 때도 같다.
 
 아래 "사내 게이트웨이 env 블록 추가" 는 별개 파일(`settings.local.json`) 경로다 —
 gateway-cli 가 쓴 `settings.json` 값을 개인적으로 덮을 때 쓰며 native merge 에서 local 이


### PR DESCRIPTION
## Summary
- 사내 PC (`internal` 모드) 의 Claude Code 인증이 gateway-cli 로 전환됐음에도 그 설치/재현 절차가 PC-환경 SSOT 문서에 반영되지 않은 공백을 메운다.
- `pc-environment.md` §4 표와 `internal-pc.md` 에 gateway-cli 설치 경로/레이아웃/재현 주의사항을 추가한다. 코드 변경 없음 — 문서만.

## Changes
- `docs/.ssot/pc-environment.md`: §4 "모드가 바꾸는 것" 표에 "Claude Code 인증" 행 추가, 상세는 `claude/AGENTS.md` / `aws/AGENTS.md` 로 위임.
- `docs/guide/internal-pc.md`: "Claude Code 인증 (gateway-cli)" 섹션 신설 — 설치 아티팩트(`gateway-cli-setup.run`) 배포 경로, 설치 결과 레이아웃(`~/.local/share/gateway-cli-suite/gateway-cli` 실체 + `~/.local/bin/gateway-cli` symlink), `gateway-cli env --persist` 가 tracked `zsh/zshrc` 대신 `~/.zshrc.local` 에 떨어져야 한다는 주의사항, 설치 확인 체크리스트를 추가.

## Test plan
- [x] 문서만 변경 — 코드 테스트 대상 없음.
- [x] `mise run lint-docs` (파일명 kebab-case) 대상 파일명 변경 없음 — 영향 없음.

## Related
Closes #1367

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~1 h · 🤖 ~8 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~1 h · 🤖 ~8 min
<!-- /ai-metrics:gh-pr -->

</details>
