### PR TITLE
feat(settings-json): enable 1-hour prompt cache TTL

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -6,6 +6,9 @@
     "superpowers@claude-plugins-official": true,
     "understand-anything@understand-anything": true
   },
+  "env": {
+    "ENABLE_PROMPT_CACHING_1H": "1"
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary
- `claude/settings.json`(dotfiles SSOT) 의 `env`에 `ENABLE_PROMPT_CACHING_1H: "1"`을 추가해 모든 계정/PC에 동일하게 1시간 prompt-cache TTL을 적용한다.

## Changes
- settings-json: `env.ENABLE_PROMPT_CACHING_1H=1` 추가 — 세션 간 prompt cache 유지 시간을 기본 5분에서 1시간으로 늘려 반복 호출 캐시 히트율을 높인다.

## Test plan
- [x] `jq empty claude/settings.json` — JSON 문법 검증
- [x] `claude/setup.sh` 실행 후 personal/work/work1 세 계정 모두 `~/.claude-*/settings.json`의 `env.ENABLE_PROMPT_CACHING_1H`가 `"1"`로 반영됨을 `jq`로 확인
- [ ] 다른 PC에서 `main` pull 후 `setup.sh` 재실행으로 동일 반영 확인 (머지 후)

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~4 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~4 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
