### PR TITLE
fix(settings-json): herdr-agent-state.sh SessionStart 훅 SSOT 반영

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,80 +1,90 @@
 {
+  "autoUpdatesChannel": "latest",
+  "enabledPlugins": {
+    "codex@openai-codex": true,
+    "ralph-loop@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "understand-anything@understand-anything": true
+  },
   "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "${HOME}/dotfiles/claude/hooks/post-bash-dispatch.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/session-start-plugin-path-normalize.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-plugin-path-normalize.sh",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/session-start-pc-context.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-pc-context.sh",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/session-start-settings-drift.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-settings-drift.sh",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/session-start-statusline-project-override.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/session-start-statusline-project-override.sh",
+            "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "bash '/home/bwyoon/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
       }
     ],
     "Stop": [
       {
         "hooks": [
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py"
+            "command": "${HOME}/dotfiles/claude/hooks/gh_issue_flow_stop_guard.py",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/devx_autopilot_stop_guard.py"
+            "command": "${HOME}/dotfiles/claude/hooks/devx_autopilot_stop_guard.py",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/skill_completion_guard.py"
+            "command": "${HOME}/dotfiles/claude/hooks/skill_completion_guard.py",
+            "type": "command"
           },
           {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${HOME}/dotfiles/claude/hooks/post-bash-dispatch.sh"
+            "command": "${HOME}/dotfiles/claude/hooks/plugin-sync-session.sh",
+            "type": "command"
           }
         ]
       }
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "${HOME}/dotfiles/claude/statusline-command.sh"
-  },
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": true,
-    "codex@openai-codex": true,
-    "understand-anything@understand-anything": true
-  },
-  "tui": "fullscreen",
-  "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
-  "theme": "dark",
+  "statusLine": {
+    "command": "${HOME}/dotfiles/claude/statusline-command.sh",
+    "type": "command"
+  },
   "telemetry": {
     "enabled": false
-  }
+  },
+  "theme": "dark",
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Summary
- `claude/settings.json`(SSOT)에 반영되지 않고 있던 `herdr-agent-state.sh` SessionStart 훅 drift를 커밋한다.

## Changes
- settings-json: live 설정(herdr 플러그인이 등록)에는 있고 SSOT에는 없던 `SessionStart` 훅(`herdr-agent-state.sh session`, matcher `*`, timeout 10) 추가. 나머지 diff는 `session-start-settings-drift.sh`가 jq로 재직렬화하며 생긴 key 정렬 변경뿐 — 의미 변경은 이 1건.

## Test plan
- [x] `jq empty claude/settings.json` — JSON 문법 검증
- [x] `diff <(git show HEAD~1:claude/settings.json | jq -S .) <(jq -S . claude/settings.json)` — key 정렬을 제외한 실제 의미 변경이 herdr 훅 추가뿐임을 확인
- [x] pre-commit 훅 통과
