### PR TITLE
feat(herdr): setup.sh 가 플러그인까지 부트스트랩

### DIFF
--- a/docs/guide/commands/herdr.md
+++ b/docs/guide/commands/herdr.md
@@ -70,7 +70,8 @@
 
 - ./setup.sh 한 번이면 config 심링크 + 플러그인 + 외부 바이너리까지 끝 (멱등)
 - 플러그인 herdr/plugins.conf · 외부 바이너리 herdr/tools.conf (lazygit · glow · delta · bat)
-- 외부 바이너리는 gh auth login 이 끝나 있어야 한다 — 익명 GitHub API 는 IP 당 60회/시간이라 공용 사내 IP 에서 먼저 소진된다
+- 외부 바이너리는 gh 설치 + gh auth login 필요 — 익명 GitHub API 는 IP 당 60회/시간이라 공용 사내 IP 에서 먼저 소진된다
+- 외부 바이너리 릴리스 자산은 Linux x86_64 로 고정 — 다른 플랫폼은 설치 안내만 하고 건너뛴다
 - 설치 실패는 경고만 남기고 넘어간다 — 플러그인이 없으면 키바인딩이 무동작, 렌더러가 없으면 뷰어가 plain text
 - HERDR_SKIP_PLUGINS=1 / HERDR_SKIP_TOOLS=1 ./setup.sh   # 각 단계 건너뛰기
 **키바인딩**

--- a/docs/guide/commands/herdr.md
+++ b/docs/guide/commands/herdr.md
@@ -68,9 +68,11 @@
 - 현재 설치 상태는 herdr plugin list 가 SSOT — 위 표는 기본 구성
 **신규 PC 부트스트랩**
 
-- ./setup.sh 한 번이면 config 심링크 + 위 플러그인 설치까지 끝 (herdr/plugins.conf 기준, 멱등)
-- 설치는 GitHub 접근이 필요 — 사내 프록시로 막히면 경고만 남기고 넘어가며, 재시도 명령을 출력한다
-- HERDR_SKIP_PLUGINS=1 ./setup.sh                  # 플러그인 설치만 건너뛰기
+- ./setup.sh 한 번이면 config 심링크 + 플러그인 + 외부 바이너리까지 끝 (멱등)
+- 플러그인 herdr/plugins.conf · 외부 바이너리 herdr/tools.conf (lazygit · glow · delta · bat)
+- 외부 바이너리는 gh auth login 이 끝나 있어야 한다 — 익명 GitHub API 는 IP 당 60회/시간이라 공용 사내 IP 에서 먼저 소진된다
+- 설치 실패는 경고만 남기고 넘어간다 — 플러그인이 없으면 키바인딩이 무동작, 렌더러가 없으면 뷰어가 plain text
+- HERDR_SKIP_PLUGINS=1 / HERDR_SKIP_TOOLS=1 ./setup.sh   # 각 단계 건너뛰기
 **키바인딩**
 
 - 커스텀 명령은 prefix+ctrl+<letter> 로 통일 (내장 액션과 충돌 회피)
@@ -79,7 +81,7 @@
 - **prefix+ctrl+t** — 파일 뷰어 (별도 tab)
 - **prefix+ctrl+r** — reviewr 토글
 - **prefix+ctrl+p** — 플러그인 매니저 열기
-- **prefix+ctrl+g** — lazygit 팝업 (플러그인 아님, 별도 바이너리)
+- **prefix+ctrl+g** — lazygit 팝업 (플러그인 아님 — tools.conf 로 설치)
 **herdr plugin CLI**
 
 - herdr plugin install <owner>/<repo>              # 부트스트랩 실패분 수동 재시도
@@ -97,7 +99,7 @@
 - herdr config check                               # 문법 검증 (내장 액션과의 키 충돌은 검사하지 않음)
 - herdr server reload-config                       # 재시작 없이 반영
 - HERDR_CONFIG_PATH=/tmp/try.toml herdr config check  # 실제 설정을 건드리지 않고 후보 검증
-- 파일 뷰어 렌더러(선택) glow · delta · bat — PATH 에 있으면 자동 사용, 없으면 plain text
+- 파일 뷰어 렌더러 glow · delta · bat — setup.sh 가 설치, PATH 에 있으면 자동 사용
 
 ### example
 

--- a/docs/guide/commands/herdr.md
+++ b/docs/guide/commands/herdr.md
@@ -66,6 +66,11 @@
 - **persiyanov.reviewr** — persiyanov/herdr-reviewr — toggle — agent diff 코드리뷰 페인
 - **ray.plugin-manager** — speardragon/herdr-plugin-manager — open — 플러그인 매니저 팝업
 - 현재 설치 상태는 herdr plugin list 가 SSOT — 위 표는 기본 구성
+**신규 PC 부트스트랩**
+
+- ./setup.sh 한 번이면 config 심링크 + 위 플러그인 설치까지 끝 (herdr/plugins.conf 기준, 멱등)
+- 설치는 GitHub 접근이 필요 — 사내 프록시로 막히면 경고만 남기고 넘어가며, 재시도 명령을 출력한다
+- HERDR_SKIP_PLUGINS=1 ./setup.sh                  # 플러그인 설치만 건너뛰기
 **키바인딩**
 
 - 커스텀 명령은 prefix+ctrl+<letter> 로 통일 (내장 액션과 충돌 회피)
@@ -77,7 +82,7 @@
 - **prefix+ctrl+g** — lazygit 팝업 (플러그인 아님, 별도 바이너리)
 **herdr plugin CLI**
 
-- herdr plugin install <owner>/<repo>              # 설치 소스는 위 표 참조
+- herdr plugin install <owner>/<repo>              # 부트스트랩 실패분 수동 재시도
 - herdr plugin uninstall <plugin-id>               # 업데이트는 uninstall 후 재설치
 - herdr plugin list                                # 설치 목록 + plugin_id + config 경로
 - herdr plugin enable|disable <plugin-id>

--- a/herdr/plugins.conf
+++ b/herdr/plugins.conf
@@ -1,0 +1,20 @@
+# herdr Plugin Bootstrap Configuration
+# Single Source of Truth (SSOT) for the plugins herdr/setup.sh installs.
+#
+# Format: PLUGIN_ID|OWNER/REPO|DESCRIPTION
+# - PLUGIN_ID   the id herdr registers the plugin under. NOT derivable from the
+#               repo name (speardragon/herdr-plugin-manager -> ray.plugin-manager),
+#               so both are recorded. Used for the idempotency probe
+#               (`herdr plugin list --plugin <id>`).
+# - OWNER/REPO  the GitHub source passed to `herdr plugin install`.
+#
+# The installed checkouts themselves are NOT tracked in dotfiles: herdr pins
+# each one by commit SHA in ~/.config/herdr/plugins.json, which is per-machine
+# state. This file records *what* to install; herdr owns *which commit*.
+#
+# Keep in sync with the `설치된 플러그인` table in
+# shell-common/functions/herdr_help.sh (_herdr_help_rows_plugin).
+
+herdr-file-viewer|smarzban/herdr-file-viewer|git-aware file viewer (prefix+ctrl+f / prefix+ctrl+t)
+persiyanov.reviewr|persiyanov/herdr-reviewr|agent diff code-review pane (prefix+ctrl+r)
+ray.plugin-manager|speardragon/herdr-plugin-manager|plugin manager popup (prefix+ctrl+p)

--- a/herdr/setup.sh
+++ b/herdr/setup.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
-# herdr/setup.sh: herdr config activation
+# herdr/setup.sh: herdr config activation + plugin bootstrap
 #
-# PURPOSE: Symlink the tracked herdr config into ~/.config/herdr so the
-#          keybindings, theme, and plugin action bindings are identical on
-#          every machine instead of living untracked in ~/.config.
+# PURPOSE: Make a fresh machine's herdr match this repo — symlink the tracked
+#          config into ~/.config/herdr, then install the plugins whose actions
+#          that config binds keys to.
 # WHEN TO RUN: Via ./setup.sh (do NOT run manually)
 # SSOT: Symlink target declared in shell-common/config/symlinks.conf
+#       Plugin list declared in herdr/plugins.conf
 #
-# NOTE: herdr plugins themselves are NOT installed here — they are per-machine
-#       GitHub checkouts pinned by commit (see `herdr plugin list`). This script
-#       only activates the config that binds keys to their actions.
+# The two halves fail differently on purpose:
+#   - config symlink  — hard-fail (exit 1). A missing source means a dangling
+#                       link and herdr silently reverting to its defaults.
+#   - plugin install  — soft-fail. Installs reach GitHub and build from source;
+#                       on a proxied corporate network that can fail for reasons
+#                       this script cannot fix. Never abort the parent setup.sh
+#                       (which runs under `set -e`) over it — warn and move on.
+#
+# Opt out of the plugin half with HERDR_SKIP_PLUGINS=1.
 
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_ROOT="${_SCRIPT_DIR%/herdr}"
@@ -20,8 +27,13 @@ source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
 HERDR_CONFIG_SRC="${_SCRIPT_DIR}/config.toml"
 HERDR_CONFIG_DIR="${HOME}/.config/herdr"
 HERDR_CONFIG_LINK="${HERDR_CONFIG_DIR}/config.toml"
+HERDR_PLUGINS_CONF="${_SCRIPT_DIR}/plugins.conf"
 
 ux_header "herdr Config Setup"
+
+# ============================================================================
+# Part 1: config symlink (hard-fail)
+# ============================================================================
 
 # The source must exist; without it the symlink would dangle and herdr would
 # silently fall back to its built-in defaults (no custom keybindings).
@@ -36,27 +48,110 @@ if [ ! -d "${HERDR_CONFIG_DIR}" ]; then
 	ux_success "Created: ~/.config/herdr"
 fi
 
-# Handle existing symlink or file.
-if [ -L "${HERDR_CONFIG_LINK}" ]; then
-	current_target=$(readlink "${HERDR_CONFIG_LINK}")
-	if [ "${current_target}" = "${HERDR_CONFIG_SRC}" ]; then
-		ux_success "Symlink already correct: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
-		exit 0
+link_current_target=""
+[ -L "${HERDR_CONFIG_LINK}" ] && link_current_target=$(readlink "${HERDR_CONFIG_LINK}")
+
+if [ "${link_current_target}" = "${HERDR_CONFIG_SRC}" ]; then
+	ux_success "Symlink already correct: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
+else
+	if [ -L "${HERDR_CONFIG_LINK}" ]; then
+		ux_info "Updating symlink (was: ${link_current_target})"
+		rm "${HERDR_CONFIG_LINK}"
+	elif [ -e "${HERDR_CONFIG_LINK}" ]; then
+		backup="${HERDR_CONFIG_LINK}.backup"
+		rm -f "${backup}"
+		ux_info "Backing up existing file: ${backup}"
+		mv "${HERDR_CONFIG_LINK}" "${backup}"
 	fi
-	ux_info "Updating symlink (was: ${current_target})"
-	rm "${HERDR_CONFIG_LINK}"
-elif [ -e "${HERDR_CONFIG_LINK}" ]; then
-	backup="${HERDR_CONFIG_LINK}.backup"
-	rm -f "${backup}"
-	ux_info "Backing up existing file: ${backup}"
-	mv "${HERDR_CONFIG_LINK}" "${backup}"
+	ln -s "${HERDR_CONFIG_SRC}" "${HERDR_CONFIG_LINK}"
+	ux_success "Created: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
 fi
 
-ln -s "${HERDR_CONFIG_SRC}" "${HERDR_CONFIG_LINK}"
-ux_success "Created: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
+# ============================================================================
+# Part 2: plugin bootstrap (soft-fail)
+# ============================================================================
 
-# A running server keeps the old config until told otherwise. Best-effort:
-# absent binary or no running server is the normal case on a fresh machine.
+# Returns 0 when PLUGIN_ID is already installed. `--plugin` is an exact-id
+# filter (a partial id matches nothing), and it exits 0 either way, so the
+# output — not the exit status — carries the answer.
+#
+# awk compares the id field literally. grep would treat the dots in ids like
+# `persiyanov.reviewr` as any-char wildcards.
+_herdr_plugin_installed() {
+	herdr plugin list --plugin "$1" 2>/dev/null |
+		awk -v id="$1" '$1 == "-" && $2 == id { found = 1 } END { exit !found }'
+}
+
+_herdr_install_plugins() {
+	if [ "${HERDR_SKIP_PLUGINS:-0}" = "1" ]; then
+		ux_info "Plugin bootstrap skipped (HERDR_SKIP_PLUGINS=1)"
+		return 0
+	fi
+
+	if ! command -v herdr >/dev/null 2>&1; then
+		ux_info "herdr not on PATH — plugin bootstrap skipped"
+		ux_bullet "Install herdr first: herdr-help install"
+		return 0
+	fi
+
+	if [ ! -r "${HERDR_PLUGINS_CONF}" ]; then
+		ux_warning "Plugin list not readable: ${HERDR_PLUGINS_CONF} — skipping"
+		return 0
+	fi
+
+	ux_section "herdr plugins"
+
+	installed=0
+	skipped=0
+	failed=0
+	failed_repos=""
+
+	while IFS='|' read -r plugin_id repo description; do
+		case "$plugin_id" in
+			''|\#*) continue ;;
+		esac
+		[ -n "$repo" ] || continue
+
+		if _herdr_plugin_installed "$plugin_id"; then
+			ux_success "already installed: ${plugin_id}"
+			skipped=$((skipped + 1))
+			continue
+		fi
+
+		ux_info "installing ${plugin_id} from ${repo} (${description})"
+		# -y skips the interactive confirmation; setup.sh is non-interactive here.
+		if herdr plugin install "$repo" -y; then
+			installed=$((installed + 1))
+			ux_success "installed: ${plugin_id}"
+		else
+			failed=$((failed + 1))
+			failed_repos="${failed_repos} ${repo}"
+			ux_warning "failed: ${plugin_id} (${repo})"
+		fi
+	done < "${HERDR_PLUGINS_CONF}"
+
+	ux_info "plugins — installed: ${installed}, already present: ${skipped}, failed: ${failed}"
+
+	if [ "$failed" -gt 0 ]; then
+		ux_warning "Some plugins did not install. herdr still runs; the keybindings for the missing plugins will do nothing."
+		ux_bullet "Retry manually (needs GitHub reachability — behind a corporate proxy this is the usual cause):"
+		for repo in ${failed_repos}; do
+			ux_bullet_sub "herdr plugin install ${repo}"
+		done
+		ux_bullet "Verify afterwards: herdr plugin list"
+	fi
+
+	return 0
+}
+
+_herdr_install_plugins
+
+# ============================================================================
+# Part 3: apply to a running server (best-effort)
+# ============================================================================
+
+# A running server keeps the old config until told otherwise. Absent binary or
+# no running server is the normal case on a fresh machine.
 if command -v herdr >/dev/null 2>&1; then
 	if herdr server reload-config >/dev/null 2>&1; then
 		ux_success "Reloaded config in the running herdr server"
@@ -64,3 +159,6 @@ if command -v herdr >/dev/null 2>&1; then
 		ux_info "herdr server not running — config applies on next start"
 	fi
 fi
+
+# Plugin failures are reported, never fatal — see the header comment.
+exit 0

--- a/herdr/setup.sh
+++ b/herdr/setup.sh
@@ -9,16 +9,13 @@
 #       Plugin list declared in herdr/plugins.conf
 #       External tool list declared in herdr/tools.conf
 #
-# The three parts fail differently on purpose:
-#   - config symlink  — hard-fail (exit 1). A missing source means a dangling
-#                       link and herdr silently reverting to its defaults.
-#   - plugin install  — soft-fail. Installs reach GitHub and build from source;
-#   - tool install      on a proxied corporate network that can fail for reasons
-#                       this script cannot fix. Never abort the parent setup.sh
-#                       (which runs under `set -e`) over it — warn and move on.
-#                       Everything they provide degrades gracefully: a missing
-#                       plugin makes its keybinding inert, a missing renderer
-#                       drops the viewer to plain text.
+# Failure policy: Part 1 (config symlink) hard-fails — a missing source means a
+# dangling link and herdr silently reverting to its defaults. Parts 2-4 soft-fail:
+# they reach GitHub over a proxied corporate network and can fail for reasons this
+# script cannot fix, and everything they provide degrades gracefully (a missing
+# plugin makes its keybinding inert, a missing renderer drops the viewer to plain
+# text). Never abort the parent setup.sh — which runs under `set -e` — over any of
+# it: warn and move on.
 #
 # Opt out of the install halves with HERDR_SKIP_PLUGINS=1 / HERDR_SKIP_TOOLS=1.
 
@@ -53,24 +50,31 @@ if [ ! -d "${HERDR_CONFIG_DIR}" ]; then
 	ux_success "Created: ~/.config/herdr"
 fi
 
-link_current_target=""
-[ -L "${HERDR_CONFIG_LINK}" ] && link_current_target=$(readlink "${HERDR_CONFIG_LINK}")
-
-if [ "${link_current_target}" = "${HERDR_CONFIG_SRC}" ]; then
-	ux_success "Symlink already correct: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
-else
+# A function so the "already correct" case returns early instead of nesting the
+# rewrite branch. Body matches obsidian/setup.sh except `exit 0` → `return 0`:
+# Parts 2-4 must still run.
+_herdr_link_config() {
 	if [ -L "${HERDR_CONFIG_LINK}" ]; then
-		ux_info "Updating symlink (was: ${link_current_target})"
+		local current_target
+		current_target=$(readlink "${HERDR_CONFIG_LINK}")
+		if [ "${current_target}" = "${HERDR_CONFIG_SRC}" ]; then
+			ux_success "Symlink already correct: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
+			return 0
+		fi
+		ux_info "Updating symlink (was: ${current_target})"
 		rm "${HERDR_CONFIG_LINK}"
 	elif [ -e "${HERDR_CONFIG_LINK}" ]; then
-		backup="${HERDR_CONFIG_LINK}.backup"
+		local backup="${HERDR_CONFIG_LINK}.backup"
 		rm -f "${backup}"
 		ux_info "Backing up existing file: ${backup}"
 		mv "${HERDR_CONFIG_LINK}" "${backup}"
 	fi
+
 	ln -s "${HERDR_CONFIG_SRC}" "${HERDR_CONFIG_LINK}"
 	ux_success "Created: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
-fi
+}
+
+_herdr_link_config
 
 # ============================================================================
 # Part 2: plugin bootstrap (soft-fail)
@@ -106,15 +110,11 @@ _herdr_install_plugins() {
 
 	ux_section "herdr plugins"
 
-	installed=0
-	skipped=0
-	failed=0
-	failed_repos=""
+	local installed=0 skipped=0 failed=0 failed_repos=""
+	local plugin_id repo description
 
 	while IFS='|' read -r plugin_id repo description; do
-		case "$plugin_id" in
-			''|\#*) continue ;;
-		esac
+		case "$plugin_id" in ''|\#*) continue ;; esac
 		[ -n "$repo" ] || continue
 
 		if _herdr_plugin_installed "$plugin_id"; then
@@ -169,10 +169,8 @@ _herdr_bridge_batcat() {
 # ~/.local/bin (the PATH SSOT dir — shell-common/env/path.sh already exports it,
 # so nothing here touches PATH or any shell profile).
 _herdr_install_one_tool() {
-	_name="$1"
-	_repo="$2"
-	_glob="$3"
-	_bin="$4"
+	local _name="$1" _repo="$2" _glob="$3" _bin="$4"
+	local _tmp _archive _found
 
 	_tmp=$(mktemp -d) || return 1
 
@@ -182,7 +180,7 @@ _herdr_install_one_tool() {
 	fi
 
 	# One asset per glob; guard against a release that changed its naming.
-	_archive=$(find "$_tmp" -maxdepth 1 -name '*.tar.gz' | head -n 1)
+	_archive=$(find "$_tmp" -maxdepth 1 -name '*.tar.gz' -print -quit)
 	if [ -z "$_archive" ]; then
 		rm -rf "$_tmp"
 		return 1
@@ -195,7 +193,7 @@ _herdr_install_one_tool() {
 
 	# `find` rather than a fixed path: lazygit/glow put the binary at the archive
 	# root, delta/bat nest it one level down.
-	_found=$(find "$_tmp" -type f -name "$_bin" -perm -u+x | head -n 1)
+	_found=$(find "$_tmp" -type f -name "$_bin" -perm -u+x -print -quit)
 	if [ -z "$_found" ]; then
 		rm -rf "$_tmp"
 		return 1
@@ -248,44 +246,40 @@ _herdr_install_tools() {
 
 	ux_section "herdr external tools"
 
-	t_installed=0
-	t_skipped=0
-	t_failed=0
-	t_failed_names=""
+	local installed=0 skipped=0 failed=0 failed_names=""
+	local name repo glob bin description
 
 	while IFS='|' read -r name repo glob bin description; do
-		case "$name" in
-			''|\#*) continue ;;
-		esac
+		case "$name" in ''|\#*) continue ;; esac
 		[ -n "$bin" ] || continue
 
 		if command -v "$name" >/dev/null 2>&1; then
 			ux_success "already on PATH: ${name} ($(command -v "$name"))"
-			t_skipped=$((t_skipped + 1))
+			skipped=$((skipped + 1))
 			continue
 		fi
 
 		if [ "$name" = "bat" ] && _herdr_bridge_batcat; then
-			t_installed=$((t_installed + 1))
+			installed=$((installed + 1))
 			continue
 		fi
 
 		ux_info "installing ${name} from ${repo} (${description})"
 		if _herdr_install_one_tool "$name" "$repo" "$glob" "$bin"; then
-			t_installed=$((t_installed + 1))
+			installed=$((installed + 1))
 			ux_success "installed: ~/.local/bin/${name}"
 		else
-			t_failed=$((t_failed + 1))
-			t_failed_names="${t_failed_names} ${name}"
+			failed=$((failed + 1))
+			failed_names="${failed_names} ${name}"
 			ux_warning "failed: ${name} (${repo})"
 		fi
 	done < "${HERDR_TOOLS_CONF}"
 
-	ux_info "tools — installed: ${t_installed}, already present: ${t_skipped}, failed: ${t_failed}"
+	ux_info "tools — installed: ${installed}, already present: ${skipped}, failed: ${failed}"
 
-	if [ "$t_failed" -gt 0 ]; then
+	if [ "$failed" -gt 0 ]; then
 		ux_warning "Some tools did not install. herdr still runs — lazygit's keybinding does nothing, and the file viewer falls back to plain text without its renderers."
-		ux_bullet "Missing:${t_failed_names}"
+		ux_bullet "Missing:${failed_names}"
 		ux_bullet "Retry needs GitHub release reachability (corporate proxy is the usual cause)"
 	fi
 
@@ -308,5 +302,6 @@ if command -v herdr >/dev/null 2>&1; then
 	fi
 fi
 
-# Plugin failures are reported, never fatal — see the header comment.
+# Install failures are warnings, never fatal — pin the status so the parent's
+# `set -e` cannot trip over Parts 2-4. See the header comment.
 exit 0

--- a/herdr/setup.sh
+++ b/herdr/setup.sh
@@ -2,21 +2,25 @@
 # herdr/setup.sh: herdr config activation + plugin bootstrap
 #
 # PURPOSE: Make a fresh machine's herdr match this repo — symlink the tracked
-#          config into ~/.config/herdr, then install the plugins whose actions
-#          that config binds keys to.
+#          config, install the plugins whose actions that config binds keys to,
+#          and install the external binaries those bindings shell out to.
 # WHEN TO RUN: Via ./setup.sh (do NOT run manually)
 # SSOT: Symlink target declared in shell-common/config/symlinks.conf
 #       Plugin list declared in herdr/plugins.conf
+#       External tool list declared in herdr/tools.conf
 #
-# The two halves fail differently on purpose:
+# The three parts fail differently on purpose:
 #   - config symlink  — hard-fail (exit 1). A missing source means a dangling
 #                       link and herdr silently reverting to its defaults.
 #   - plugin install  — soft-fail. Installs reach GitHub and build from source;
-#                       on a proxied corporate network that can fail for reasons
+#   - tool install      on a proxied corporate network that can fail for reasons
 #                       this script cannot fix. Never abort the parent setup.sh
 #                       (which runs under `set -e`) over it — warn and move on.
+#                       Everything they provide degrades gracefully: a missing
+#                       plugin makes its keybinding inert, a missing renderer
+#                       drops the viewer to plain text.
 #
-# Opt out of the plugin half with HERDR_SKIP_PLUGINS=1.
+# Opt out of the install halves with HERDR_SKIP_PLUGINS=1 / HERDR_SKIP_TOOLS=1.
 
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_ROOT="${_SCRIPT_DIR%/herdr}"
@@ -28,6 +32,7 @@ HERDR_CONFIG_SRC="${_SCRIPT_DIR}/config.toml"
 HERDR_CONFIG_DIR="${HOME}/.config/herdr"
 HERDR_CONFIG_LINK="${HERDR_CONFIG_DIR}/config.toml"
 HERDR_PLUGINS_CONF="${_SCRIPT_DIR}/plugins.conf"
+HERDR_TOOLS_CONF="${_SCRIPT_DIR}/tools.conf"
 
 ux_header "herdr Config Setup"
 
@@ -147,7 +152,150 @@ _herdr_install_plugins() {
 _herdr_install_plugins
 
 # ============================================================================
-# Part 3: apply to a running server (best-effort)
+# Part 3: external tool bootstrap (soft-fail)
+# ============================================================================
+
+# Debian/Ubuntu ship bat's binary as `batcat`. Bridge it instead of downloading
+# a second copy — the viewer looks for `bat`.
+_herdr_bridge_batcat() {
+	command -v batcat >/dev/null 2>&1 || return 1
+	mkdir -p "${HOME}/.local/bin"
+	ln -sf "$(command -v batcat)" "${HOME}/.local/bin/bat"
+	ux_success "bridged: batcat → ~/.local/bin/bat (no download needed)"
+	return 0
+}
+
+# Downloads one GitHub release asset, extracts it, and installs the binary into
+# ~/.local/bin (the PATH SSOT dir — shell-common/env/path.sh already exports it,
+# so nothing here touches PATH or any shell profile).
+_herdr_install_one_tool() {
+	_name="$1"
+	_repo="$2"
+	_glob="$3"
+	_bin="$4"
+
+	_tmp=$(mktemp -d) || return 1
+
+	if ! gh release download --repo "$_repo" --pattern "$_glob" --dir "$_tmp" >/dev/null 2>&1; then
+		rm -rf "$_tmp"
+		return 1
+	fi
+
+	# One asset per glob; guard against a release that changed its naming.
+	_archive=$(find "$_tmp" -maxdepth 1 -name '*.tar.gz' | head -n 1)
+	if [ -z "$_archive" ]; then
+		rm -rf "$_tmp"
+		return 1
+	fi
+
+	if ! tar xzf "$_archive" -C "$_tmp" 2>/dev/null; then
+		rm -rf "$_tmp"
+		return 1
+	fi
+
+	# `find` rather than a fixed path: lazygit/glow put the binary at the archive
+	# root, delta/bat nest it one level down.
+	_found=$(find "$_tmp" -type f -name "$_bin" -perm -u+x | head -n 1)
+	if [ -z "$_found" ]; then
+		rm -rf "$_tmp"
+		return 1
+	fi
+
+	mkdir -p "${HOME}/.local/bin"
+	install -m 0755 "$_found" "${HOME}/.local/bin/${_name}"
+	rm -rf "$_tmp"
+	return 0
+}
+
+_herdr_install_tools() {
+	if [ "${HERDR_SKIP_TOOLS:-0}" = "1" ]; then
+		ux_info "External tool bootstrap skipped (HERDR_SKIP_TOOLS=1)"
+		return 0
+	fi
+
+	if [ ! -r "${HERDR_TOOLS_CONF}" ]; then
+		ux_warning "Tool list not readable: ${HERDR_TOOLS_CONF} — skipping"
+		return 0
+	fi
+
+	# The globs in tools.conf pin Linux x86_64. Rather than guess an asset name
+	# for another platform, say so and let the user install by hand.
+	if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+		ux_info "External tools skipped — release assets are pinned to Linux x86_64 (this host: $(uname -s)/$(uname -m))"
+		ux_bullet "Install by hand, or use your package manager: lazygit glow git-delta bat"
+		return 0
+	fi
+
+	# `gh release download` is the only network path here; the repo already
+	# depends on gh (gh/setup.sh) and it inherits gh's auth and proxy config.
+	if ! command -v gh >/dev/null 2>&1; then
+		ux_warning "gh not on PATH — external tool bootstrap skipped"
+		return 0
+	fi
+
+	# gh must be authenticated. Unauthenticated is not a usable fallback: the
+	# anonymous GitHub API allows 60 requests/hour *per IP*, and a shared
+	# corporate egress IP exhausts that long before you get here (measured:
+	# HTTP 403 "rate limit exceeded", X-RateLimit-Remaining: 0). Nothing in
+	# setup.sh runs `gh auth login`, so on a fresh machine this is the normal
+	# first-run state — say what to do and move on.
+	if ! gh auth status >/dev/null 2>&1; then
+		ux_warning "gh is not authenticated — external tool bootstrap skipped"
+		ux_bullet "Run: gh auth login"
+		ux_bullet "Then re-run: ./herdr/setup.sh"
+		return 0
+	fi
+
+	ux_section "herdr external tools"
+
+	t_installed=0
+	t_skipped=0
+	t_failed=0
+	t_failed_names=""
+
+	while IFS='|' read -r name repo glob bin description; do
+		case "$name" in
+			''|\#*) continue ;;
+		esac
+		[ -n "$bin" ] || continue
+
+		if command -v "$name" >/dev/null 2>&1; then
+			ux_success "already on PATH: ${name} ($(command -v "$name"))"
+			t_skipped=$((t_skipped + 1))
+			continue
+		fi
+
+		if [ "$name" = "bat" ] && _herdr_bridge_batcat; then
+			t_installed=$((t_installed + 1))
+			continue
+		fi
+
+		ux_info "installing ${name} from ${repo} (${description})"
+		if _herdr_install_one_tool "$name" "$repo" "$glob" "$bin"; then
+			t_installed=$((t_installed + 1))
+			ux_success "installed: ~/.local/bin/${name}"
+		else
+			t_failed=$((t_failed + 1))
+			t_failed_names="${t_failed_names} ${name}"
+			ux_warning "failed: ${name} (${repo})"
+		fi
+	done < "${HERDR_TOOLS_CONF}"
+
+	ux_info "tools — installed: ${t_installed}, already present: ${t_skipped}, failed: ${t_failed}"
+
+	if [ "$t_failed" -gt 0 ]; then
+		ux_warning "Some tools did not install. herdr still runs — lazygit's keybinding does nothing, and the file viewer falls back to plain text without its renderers."
+		ux_bullet "Missing:${t_failed_names}"
+		ux_bullet "Retry needs GitHub release reachability (corporate proxy is the usual cause)"
+	fi
+
+	return 0
+}
+
+_herdr_install_tools
+
+# ============================================================================
+# Part 4: apply to a running server (best-effort)
 # ============================================================================
 
 # A running server keeps the old config until told otherwise. Absent binary or

--- a/herdr/setup.sh
+++ b/herdr/setup.sh
@@ -46,7 +46,7 @@ fi
 
 # herdr creates this directory itself on first run, but setup.sh may run first.
 if [ ! -d "${HERDR_CONFIG_DIR}" ]; then
-	mkdir -p "${HERDR_CONFIG_DIR}"
+	mkdir -p "${HERDR_CONFIG_DIR}" || { ux_error "Could not create: ${HERDR_CONFIG_DIR}"; exit 1; }
 	ux_success "Created: ~/.config/herdr"
 fi
 
@@ -62,15 +62,15 @@ _herdr_link_config() {
 			return 0
 		fi
 		ux_info "Updating symlink (was: ${current_target})"
-		rm "${HERDR_CONFIG_LINK}"
+		rm "${HERDR_CONFIG_LINK}" || { ux_error "Could not remove stale symlink: ${HERDR_CONFIG_LINK}"; exit 1; }
 	elif [ -e "${HERDR_CONFIG_LINK}" ]; then
 		local backup="${HERDR_CONFIG_LINK}.backup"
 		rm -f "${backup}"
 		ux_info "Backing up existing file: ${backup}"
-		mv "${HERDR_CONFIG_LINK}" "${backup}"
+		mv "${HERDR_CONFIG_LINK}" "${backup}" || { ux_error "Could not back up: ${HERDR_CONFIG_LINK}"; exit 1; }
 	fi
 
-	ln -s "${HERDR_CONFIG_SRC}" "${HERDR_CONFIG_LINK}"
+	ln -s "${HERDR_CONFIG_SRC}" "${HERDR_CONFIG_LINK}" || { ux_error "Could not create symlink: ${HERDR_CONFIG_LINK}"; exit 1; }
 	ux_success "Created: ~/.config/herdr/config.toml → ${HERDR_CONFIG_SRC}"
 }
 
@@ -169,12 +169,15 @@ _herdr_bridge_batcat() {
 # ~/.local/bin (the PATH SSOT dir — shell-common/env/path.sh already exports it,
 # so nothing here touches PATH or any shell profile).
 _herdr_install_one_tool() {
-	local _name="$1" _repo="$2" _glob="$3" _bin="$4"
+	local _name="$1" _repo="$2" _version="$3" _glob="$4" _bin="$5"
 	local _tmp _archive _found
 
 	_tmp=$(mktemp -d) || return 1
 
-	if ! gh release download --repo "$_repo" --pattern "$_glob" --dir "$_tmp" >/dev/null 2>&1; then
+	# A positional tag pins the exact release; omitting it would fall back to
+	# latest, which breaks the "same binary on every machine" goal tools.conf
+	# documents (VERSION field).
+	if ! gh release download "$_version" --repo "$_repo" --pattern "$_glob" --dir "$_tmp" >/dev/null 2>&1; then
 		rm -rf "$_tmp"
 		return 1
 	fi
@@ -200,7 +203,10 @@ _herdr_install_one_tool() {
 	fi
 
 	mkdir -p "${HOME}/.local/bin"
-	install -m 0755 "$_found" "${HOME}/.local/bin/${_name}"
+	if ! install -m 0755 "$_found" "${HOME}/.local/bin/${_name}"; then
+		rm -rf "$_tmp"
+		return 1
+	fi
 	rm -rf "$_tmp"
 	return 0
 }
@@ -247,9 +253,9 @@ _herdr_install_tools() {
 	ux_section "herdr external tools"
 
 	local installed=0 skipped=0 failed=0 failed_names=""
-	local name repo glob bin description
+	local name repo version glob bin description
 
-	while IFS='|' read -r name repo glob bin description; do
+	while IFS='|' read -r name repo version glob bin description; do
 		case "$name" in ''|\#*) continue ;; esac
 		[ -n "$bin" ] || continue
 
@@ -264,8 +270,8 @@ _herdr_install_tools() {
 			continue
 		fi
 
-		ux_info "installing ${name} from ${repo} (${description})"
-		if _herdr_install_one_tool "$name" "$repo" "$glob" "$bin"; then
+		ux_info "installing ${name} ${version} from ${repo} (${description})"
+		if _herdr_install_one_tool "$name" "$repo" "$version" "$glob" "$bin"; then
 			installed=$((installed + 1))
 			ux_success "installed: ~/.local/bin/${name}"
 		else

--- a/herdr/tools.conf
+++ b/herdr/tools.conf
@@ -1,0 +1,32 @@
+# herdr External Tool Bootstrap Configuration
+# Single Source of Truth (SSOT) for the non-plugin binaries herdr/setup.sh installs.
+#
+# These are ordinary binaries, not herdr plugins — but every one of them exists
+# here *because* of herdr: lazygit is what prefix+ctrl+g pops up, and the three
+# renderers are what the file-viewer plugin shells out to. Without them the
+# config still loads; the keybinding just does nothing (lazygit) or the viewer
+# degrades to plain text (renderers).
+#
+# Format: NAME|OWNER/REPO|ASSET_GLOB|BIN_IN_ARCHIVE|DESCRIPTION
+# - NAME            command name probed on PATH; already present -> skipped.
+# - ASSET_GLOB      passed to `gh release download -p`. Latest release is used.
+# - BIN_IN_ARCHIVE  basename of the executable inside the extracted archive.
+#                   Located with `find`, so a nested layout needs no path here.
+#
+# Linux x86_64 only — the globs pin that arch. Other platforms are skipped with
+# a notice rather than guessed at (see _herdr_install_tools).
+#
+# The globs are case-sensitive and each project names its assets differently —
+# lazygit ships `..._linux_x86_64.tar.gz`, glow `..._Linux_x86_64.tar.gz`. Verify
+# against the real release before editing a row:
+#   gh release view -R <owner>/<repo> --json assets --jq '.assets[].name'
+#
+# Why not mise: mise.toml's [tools] is the repo's *dev toolchain* (shellcheck,
+# shfmt, uv) bootstrapped by `mise install`, which setup.sh never runs. These
+# are runtime user tools, and mise's shims are not on the PATH SSOT, so herdr's
+# popup would not resolve them.
+
+lazygit|jesseduffield/lazygit|*_linux_x86_64.tar.gz|lazygit|Git TUI — prefix+ctrl+g popup
+glow|charmbracelet/glow|*_Linux_x86_64.tar.gz|glow|markdown renderer for the file viewer
+delta|dandavison/delta|*-x86_64-unknown-linux-musl.tar.gz|delta|diff renderer for the file viewer
+bat|sharkdp/bat|*-x86_64-unknown-linux-musl.tar.gz|bat|syntax highlighter for the file viewer

--- a/herdr/tools.conf
+++ b/herdr/tools.conf
@@ -10,6 +10,7 @@
 # Format: NAME|OWNER/REPO|ASSET_GLOB|BIN_IN_ARCHIVE|DESCRIPTION
 # - NAME            command name probed on PATH; already present -> skipped.
 # - ASSET_GLOB      passed to `gh release download -p`. Latest release is used.
+#                   Must resolve to a single .tar.gz — setup.sh extracts only that.
 # - BIN_IN_ARCHIVE  basename of the executable inside the extracted archive.
 #                   Located with `find`, so a nested layout needs no path here.
 #
@@ -20,6 +21,9 @@
 # lazygit ships `..._linux_x86_64.tar.gz`, glow `..._Linux_x86_64.tar.gz`. Verify
 # against the real release before editing a row:
 #   gh release view -R <owner>/<repo> --json assets --jq '.assets[].name'
+#
+# Keep the tool names in sync with the `신규 PC 부트스트랩` bullet in
+# shell-common/functions/herdr_help.sh (_herdr_help_rows_plugin).
 #
 # Why not mise: mise.toml's [tools] is the repo's *dev toolchain* (shellcheck,
 # shfmt, uv) bootstrapped by `mise install`, which setup.sh never runs. These

--- a/herdr/tools.conf
+++ b/herdr/tools.conf
@@ -7,10 +7,16 @@
 # config still loads; the keybinding just does nothing (lazygit) or the viewer
 # degrades to plain text (renderers).
 #
-# Format: NAME|OWNER/REPO|ASSET_GLOB|BIN_IN_ARCHIVE|DESCRIPTION
+# Format: NAME|OWNER/REPO|VERSION|ASSET_GLOB|BIN_IN_ARCHIVE|DESCRIPTION
 # - NAME            command name probed on PATH; already present -> skipped.
-# - ASSET_GLOB      passed to `gh release download -p`. Latest release is used.
-#                   Must resolve to a single .tar.gz — setup.sh extracts only that.
+# - VERSION         release tag passed to `gh release download <tag>`, exactly as
+#                   GitHub names it (some projects prefix "v", some don't — copy
+#                   it from `gh release list`, never guess). Pinned, not "latest":
+#                   two machines bootstrapping a week apart must get the same
+#                   binary — same reproducibility goal as mise.toml's [tools].
+#                   Bump deliberately, in its own commit, when you want to move.
+# - ASSET_GLOB      passed to `gh release download -p`. Must resolve to a single
+#                   .tar.gz — setup.sh extracts only that.
 # - BIN_IN_ARCHIVE  basename of the executable inside the extracted archive.
 #                   Located with `find`, so a nested layout needs no path here.
 #
@@ -21,6 +27,7 @@
 # lazygit ships `..._linux_x86_64.tar.gz`, glow `..._Linux_x86_64.tar.gz`. Verify
 # against the real release before editing a row:
 #   gh release view -R <owner>/<repo> --json assets --jq '.assets[].name'
+#   gh release list -R <owner>/<repo> --limit 1 --json tagName -q '.[0].tagName'
 #
 # Keep the tool names in sync with the `신규 PC 부트스트랩` bullet in
 # shell-common/functions/herdr_help.sh (_herdr_help_rows_plugin).
@@ -30,7 +37,7 @@
 # are runtime user tools, and mise's shims are not on the PATH SSOT, so herdr's
 # popup would not resolve them.
 
-lazygit|jesseduffield/lazygit|*_linux_x86_64.tar.gz|lazygit|Git TUI — prefix+ctrl+g popup
-glow|charmbracelet/glow|*_Linux_x86_64.tar.gz|glow|markdown renderer for the file viewer
-delta|dandavison/delta|*-x86_64-unknown-linux-musl.tar.gz|delta|diff renderer for the file viewer
-bat|sharkdp/bat|*-x86_64-unknown-linux-musl.tar.gz|bat|syntax highlighter for the file viewer
+lazygit|jesseduffield/lazygit|v0.64.1|*_linux_x86_64.tar.gz|lazygit|Git TUI — prefix+ctrl+g popup
+glow|charmbracelet/glow|v3.0.0|*_Linux_x86_64.tar.gz|glow|markdown renderer for the file viewer
+delta|dandavison/delta|0.19.2|*-x86_64-unknown-linux-musl.tar.gz|delta|diff renderer for the file viewer
+bat|sharkdp/bat|v0.26.1|*-x86_64-unknown-linux-musl.tar.gz|bat|syntax highlighter for the file viewer (batcat bridge is tried first — this VERSION only applies on non-Debian hosts)

--- a/shell-common/functions/herdr_help.sh
+++ b/shell-common/functions/herdr_help.sh
@@ -74,7 +74,8 @@ _herdr_help_rows_plugin() {
     ux_section "신규 PC 부트스트랩"
     ux_bullet "${UX_BOLD}./setup.sh${UX_RESET} 한 번이면 config 심링크 + 플러그인 + 외부 바이너리까지 끝 (멱등)"
     ux_bullet "플러그인 herdr/plugins.conf · 외부 바이너리 herdr/tools.conf (lazygit · glow · delta · bat)"
-    ux_bullet "외부 바이너리는 ${UX_BOLD}gh auth login${UX_RESET} 이 끝나 있어야 한다 — 익명 GitHub API 는 IP 당 60회/시간이라 공용 사내 IP 에서 먼저 소진된다"
+    ux_bullet "외부 바이너리는 ${UX_BOLD}gh${UX_RESET} 설치 + ${UX_BOLD}gh auth login${UX_RESET} 필요 — 익명 GitHub API 는 IP 당 60회/시간이라 공용 사내 IP 에서 먼저 소진된다"
+    ux_bullet "외부 바이너리 릴리스 자산은 Linux x86_64 로 고정 — 다른 플랫폼은 설치 안내만 하고 건너뛴다"
     ux_bullet "설치 실패는 경고만 남기고 넘어간다 — 플러그인이 없으면 키바인딩이 무동작, 렌더러가 없으면 뷰어가 plain text"
     ux_bullet "HERDR_SKIP_PLUGINS=1 / HERDR_SKIP_TOOLS=1 ./setup.sh   # 각 단계 건너뛰기"
 

--- a/shell-common/functions/herdr_help.sh
+++ b/shell-common/functions/herdr_help.sh
@@ -63,6 +63,7 @@ _herdr_help_rows_control() {
 }
 
 _herdr_help_rows_plugin() {
+    # Keep this table in sync with herdr/plugins.conf (setup.sh's install SSOT).
     ux_section "설치된 플러그인"
     ux_table_header "plugin_id" "설치 소스 (owner/repo)" "액션 — 용도"
     ux_table_row "herdr-file-viewer" "smarzban/herdr-file-viewer" "open-file-viewer[-tab] — git-aware 파일 뷰어"

--- a/shell-common/functions/herdr_help.sh
+++ b/shell-common/functions/herdr_help.sh
@@ -70,6 +70,11 @@ _herdr_help_rows_plugin() {
     ux_table_row "ray.plugin-manager" "speardragon/herdr-plugin-manager" "open — 플러그인 매니저 팝업"
     ux_bullet "현재 설치 상태는 ${UX_BOLD}herdr plugin list${UX_RESET} 가 SSOT — 위 표는 기본 구성"
 
+    ux_section "신규 PC 부트스트랩"
+    ux_bullet "${UX_BOLD}./setup.sh${UX_RESET} 한 번이면 config 심링크 + 위 플러그인 설치까지 끝 (herdr/plugins.conf 기준, 멱등)"
+    ux_bullet "설치는 GitHub 접근이 필요 — 사내 프록시로 막히면 경고만 남기고 넘어가며, 재시도 명령을 출력한다"
+    ux_bullet "HERDR_SKIP_PLUGINS=1 ./setup.sh                  # 플러그인 설치만 건너뛰기"
+
     ux_section "키바인딩"
     ux_bullet "커스텀 명령은 ${UX_BOLD}prefix+ctrl+<letter>${UX_RESET} 로 통일 (내장 액션과 충돌 회피)"
     ux_table_header "Key" "Action"
@@ -80,7 +85,7 @@ _herdr_help_rows_plugin() {
     ux_table_row "prefix+ctrl+g" "lazygit 팝업 (플러그인 아님, 별도 바이너리)"
 
     ux_section "herdr plugin CLI"
-    ux_bullet "herdr plugin install <owner>/<repo>              # 설치 소스는 위 표 참조"
+    ux_bullet "herdr plugin install <owner>/<repo>              # 부트스트랩 실패분 수동 재시도"
     ux_bullet "herdr plugin uninstall <plugin-id>               # 업데이트는 uninstall 후 재설치"
     ux_bullet "herdr plugin list                                # 설치 목록 + plugin_id + config 경로"
     ux_bullet "herdr plugin enable|disable <plugin-id>"

--- a/shell-common/functions/herdr_help.sh
+++ b/shell-common/functions/herdr_help.sh
@@ -71,9 +71,11 @@ _herdr_help_rows_plugin() {
     ux_bullet "현재 설치 상태는 ${UX_BOLD}herdr plugin list${UX_RESET} 가 SSOT — 위 표는 기본 구성"
 
     ux_section "신규 PC 부트스트랩"
-    ux_bullet "${UX_BOLD}./setup.sh${UX_RESET} 한 번이면 config 심링크 + 위 플러그인 설치까지 끝 (herdr/plugins.conf 기준, 멱등)"
-    ux_bullet "설치는 GitHub 접근이 필요 — 사내 프록시로 막히면 경고만 남기고 넘어가며, 재시도 명령을 출력한다"
-    ux_bullet "HERDR_SKIP_PLUGINS=1 ./setup.sh                  # 플러그인 설치만 건너뛰기"
+    ux_bullet "${UX_BOLD}./setup.sh${UX_RESET} 한 번이면 config 심링크 + 플러그인 + 외부 바이너리까지 끝 (멱등)"
+    ux_bullet "플러그인 herdr/plugins.conf · 외부 바이너리 herdr/tools.conf (lazygit · glow · delta · bat)"
+    ux_bullet "외부 바이너리는 ${UX_BOLD}gh auth login${UX_RESET} 이 끝나 있어야 한다 — 익명 GitHub API 는 IP 당 60회/시간이라 공용 사내 IP 에서 먼저 소진된다"
+    ux_bullet "설치 실패는 경고만 남기고 넘어간다 — 플러그인이 없으면 키바인딩이 무동작, 렌더러가 없으면 뷰어가 plain text"
+    ux_bullet "HERDR_SKIP_PLUGINS=1 / HERDR_SKIP_TOOLS=1 ./setup.sh   # 각 단계 건너뛰기"
 
     ux_section "키바인딩"
     ux_bullet "커스텀 명령은 ${UX_BOLD}prefix+ctrl+<letter>${UX_RESET} 로 통일 (내장 액션과 충돌 회피)"
@@ -82,7 +84,7 @@ _herdr_help_rows_plugin() {
     ux_table_row "prefix+ctrl+t" "파일 뷰어 (별도 tab)"
     ux_table_row "prefix+ctrl+r" "reviewr 토글"
     ux_table_row "prefix+ctrl+p" "플러그인 매니저 열기"
-    ux_table_row "prefix+ctrl+g" "lazygit 팝업 (플러그인 아님, 별도 바이너리)"
+    ux_table_row "prefix+ctrl+g" "lazygit 팝업 (플러그인 아님 — tools.conf 로 설치)"
 
     ux_section "herdr plugin CLI"
     ux_bullet "herdr plugin install <owner>/<repo>              # 부트스트랩 실패분 수동 재시도"
@@ -100,7 +102,7 @@ _herdr_help_rows_plugin() {
     ux_bullet "herdr config check                               # 문법 검증 (내장 액션과의 키 충돌은 검사하지 않음)"
     ux_bullet "herdr server reload-config                       # 재시작 없이 반영"
     ux_bullet "HERDR_CONFIG_PATH=/tmp/try.toml herdr config check  # 실제 설정을 건드리지 않고 후보 검증"
-    ux_bullet "파일 뷰어 렌더러(선택) glow · delta · bat — PATH 에 있으면 자동 사용, 없으면 plain text"
+    ux_bullet "파일 뷰어 렌더러 glow · delta · bat — setup.sh 가 설치, PATH 에 있으면 자동 사용"
 }
 
 _herdr_help_rows_example() {

--- a/tests/bats/setup/herdr_setup.bats
+++ b/tests/bats/setup/herdr_setup.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# tests/bats/setup/herdr_setup.bats
+# Coverage for herdr/setup.sh — the config symlink is hard-fail, the plugin
+# and external-tool bootstraps (Parts 2-3) are soft-fail and must never abort
+# the parent `./setup.sh` (which runs under `set -e`).
+#
+# `gh` and `herdr` are stubbed on PATH so these tests never touch the
+# network. The one exception (@test "external tools: failed install is
+# reported as failed, not installed") is a direct regression guard for a
+# review finding (PR #1372): `install -m 0755`'s exit status went unchecked,
+# so a failed install was silently counted as a success.
+
+load '../test_helper'
+
+HERDR_SETUP="${_BATS_REAL_DOTFILES_ROOT}/herdr/setup.sh"
+
+setup() {
+    setup_isolated_home
+    STUB_BIN="$(mktemp -d)"
+    # A tight, real-machine-independent PATH: /usr/bin + /bin cover tar, find,
+    # install, mktemp, awk. The dev machine's own ~/.local/bin is deliberately
+    # excluded — this repo's earlier herdr work installed real herdr/lazygit/
+    # glow/delta/bat there, and an inherited PATH would let those satisfy
+    # `command -v` instead of the stubs, silently defeating every test below.
+    export PATH="${STUB_BIN}:/usr/bin:/bin"
+}
+
+teardown() {
+    teardown_isolated_home
+    rm -rf "$STUB_BIN"
+}
+
+# A `herdr` stub that reports every plugin already installed and accepts
+# `server reload-config` — exercises the "nothing to do" plugin path and the
+# Part 4 best-effort reload without a real server.
+stub_herdr_all_present() {
+    cat > "${STUB_BIN}/herdr" <<'EOF'
+#!/bin/sh
+case "$1 $2" in
+    "plugin list")
+        echo "3 plugins installed:"
+        echo "- herdr-file-viewer (herdr-file-viewer) enabled [github:x@y]"
+        echo "- persiyanov.reviewr (reviewr) enabled [github:x@y]"
+        echo "- ray.plugin-manager (Plugin Manager) enabled [github:x@y]"
+        exit 0
+        ;;
+    "server reload-config") exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/herdr"
+}
+
+@test "config symlink: missing source hard-fails with exit 1" {
+    # setup.sh resolves both its config.toml AND DOTFILES_ROOT/SHELL_COMMON
+    # relative to its own directory ($_SCRIPT_DIR, stripped of a trailing
+    # "/herdr"). Mirror that layout — herdr/setup.sh with no sibling
+    # config.toml, shell-common symlinked to the real one — so sourcing
+    # ux_lib still works and only the "missing source" branch is exercised.
+    iso="${TEST_TEMP_HOME}/herdr-src"
+    mkdir -p "$iso/herdr"
+    cp "${HERDR_SETUP}" "$iso/herdr/setup.sh"
+    ln -s "${_BATS_REAL_DOTFILES_ROOT}/shell-common" "$iso/shell-common"
+    run bash "$iso/herdr/setup.sh"
+    assert_failure
+    assert_output --partial "Source config not found"
+}
+
+@test "config symlink: fresh HOME creates the symlink to the real source" {
+    stub_herdr_all_present
+    run env HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    [ -L "${HOME}/.config/herdr/config.toml" ]
+    real_src="${_BATS_REAL_DOTFILES_ROOT}/herdr/config.toml"
+    [ "$(readlink "${HOME}/.config/herdr/config.toml")" = "$real_src" ]
+}
+
+@test "config symlink: idempotent re-run reports already correct" {
+    stub_herdr_all_present
+    run env HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    run env HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    assert_output --partial "Symlink already correct"
+}
+
+@test "config symlink: pre-existing plain file is backed up with fixed .backup suffix" {
+    stub_herdr_all_present
+    mkdir -p "${HOME}/.config/herdr"
+    printf 'old = true\n' > "${HOME}/.config/herdr/config.toml"
+    run env HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    [ -L "${HOME}/.config/herdr/config.toml" ]
+    [ -f "${HOME}/.config/herdr/config.toml.backup" ]
+    grep -q 'old = true' "${HOME}/.config/herdr/config.toml.backup"
+}
+
+@test "plugin bootstrap: HERDR_SKIP_PLUGINS=1 skips without touching herdr" {
+    # No herdr stub at all — if the skip check didn't run first, `command -v
+    # herdr` would fail, which is a different (also-skip) message. Assert the
+    # SKIP_PLUGINS-specific message to pin the actual branch taken.
+    run env HERDR_SKIP_PLUGINS=1 HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    assert_output --partial "Plugin bootstrap skipped (HERDR_SKIP_PLUGINS=1)"
+}
+
+@test "plugin bootstrap: herdr not on PATH degrades gracefully, does not abort" {
+    # Regression guard: a reviewer (agy, PR #1372) misread this branch as an
+    # abort. It must return 0 and let Part 3 still run.
+    run env HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    assert_output --partial "herdr not on PATH — plugin bootstrap skipped"
+}
+
+@test "external tools: HERDR_SKIP_TOOLS=1 skips without checking gh" {
+    stub_herdr_all_present
+    run env HERDR_SKIP_TOOLS=1 bash "${HERDR_SETUP}"
+    assert_success
+    assert_output --partial "External tool bootstrap skipped (HERDR_SKIP_TOOLS=1)"
+}
+
+@test "external tools: unauthenticated gh warns and returns cleanly (exit 0)" {
+    stub_herdr_all_present
+    cat > "${STUB_BIN}/gh" <<'EOF'
+#!/bin/sh
+[ "$1 $2" = "auth status" ] && exit 1
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/gh"
+    run bash "${HERDR_SETUP}"
+    assert_success
+    assert_output --partial "gh is not authenticated"
+    assert_output --partial "gh auth login"
+}
+
+@test "external tools: failed install is reported as failed, not installed" {
+    # Regression guard (PR #1372 agy finding): _herdr_install_one_tool used to
+    # `return 0` unconditionally after `install -m 0755`, so a failed install
+    # (permissions, disk full, ...) was silently counted as a success.
+    stub_herdr_all_present
+    cat > "${STUB_BIN}/gh" <<'EOF'
+#!/bin/sh
+if [ "$1" = "auth" ]; then exit 0; fi
+if [ "$1" = "release" ] && [ "$2" = "download" ]; then
+    # Find --dir's argument and drop a minimal real tarball there so setup.sh's
+    # tar/find steps succeed — only the final `install` step is made to fail.
+    dir=""
+    prev=""
+    for arg in "$@"; do
+        [ "$prev" = "--dir" ] && dir="$arg"
+        prev="$arg"
+    done
+    work="$(mktemp -d)"
+    printf '#!/bin/sh\necho fake\n' > "$work/lazygit"
+    chmod +x "$work/lazygit"
+    tar czf "${dir}/asset.tar.gz" -C "$work" lazygit
+    rm -rf "$work"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/gh"
+    # A read-only ~/.local/bin makes `install -m 0755` fail without touching
+    # any real system path.
+    mkdir -p "${HOME}/.local/bin"
+    chmod 555 "${HOME}/.local/bin"
+    run env HERDR_SKIP_PLUGINS=1 bash "${HERDR_SETUP}"
+    chmod 755 "${HOME}/.local/bin"
+    assert_success
+    assert_output --partial "failed: lazygit"
+    refute_output --partial "installed: ~/.local/bin/lazygit"
+}


### PR DESCRIPTION
## Summary
- #1371 로 herdr config 심링크는 `./setup.sh` 가 자동 생성하게 됐지만, 그 config 가 키를 바인딩하는 **대상인 플러그인 3종은 여전히 신규 PC 에서 손으로 설치**해야 했다. 액션이 없는 상태의 키바인딩은 눌러도 아무 일이 없으므로, 심링크만으로는 "PC 간 동일한 herdr" 가 되지 않는다.
- `herdr/setup.sh` 가 `herdr/plugins.conf` 를 읽어 플러그인까지 부트스트랩한다. 신규 PC 는 `./setup.sh` 한 번으로 끝난다.
- 사내 프록시 환경을 전제로 설계했다 — 설치 실패가 전체 setup 을 중단시키지 않는다.

## Changes
- `herdr/plugins.conf` (신규): 설치 대상 SSOT. `symlinks.conf` 와 같은 `PLUGIN_ID|OWNER/REPO|DESCRIPTION` 형식
- `herdr/setup.sh`: 심링크 뒤에 플러그인 부트스트랩 단계 추가. 기존 "이미 올바른 링크면 `exit 0`" 조기 종료가 플러그인 단계를 건너뛰게 되므로 구조 변경
- `shell-common/functions/herdr_help.sh`: `plugin` 섹션에 "신규 PC 부트스트랩" 항목 추가
- `docs/guide/commands/herdr.md`: 생성물 재생성

## 설계 근거

**두 절반의 실패 정책을 분리했다.** 심링크는 hard-fail(`exit 1`) — 소스 부재는 dangling 링크와 herdr 의 조용한 기본값 복귀를 뜻하고, 이건 즉시 드러나야 한다. 플러그인은 soft-fail — 설치가 GitHub 에 접근하고 소스 빌드까지 하므로 사내 프록시에서 막힐 수 있는데, 그 때문에 `set -e` 로 도는 루트 `setup.sh` 전체가 중단되면 안 된다. 실패는 경고 + 수동 재시도 명령으로 보고하고 `exit 0` 한다.

**plugin_id 와 owner/repo 를 둘 다 기록하는 이유**: 유도가 불가능하다 (`speardragon/herdr-plugin-manager` → `ray.plugin-manager`). id 는 멱등성 판별용, repo 는 설치용이다.

**멱등성 판별에 `herdr plugin list --plugin <id>` 를 쓴다** (정확 id 필터, 부분 일치는 매칭되지 않음). 비교는 `awk` 의 literal 비교 — `grep` 이면 `persiyanov.reviewr` 의 `.` 이 임의문자로 해석돼 오탐이 난다 (`persiyanovXreviewr` 도 매칭). 이미 설치된 경우 네트워크 접근이 전혀 발생하지 않는다.

**설치된 체크아웃 자체는 추적하지 않는다.** herdr 가 `~/.config/herdr/plugins.json` 에 커밋 SHA 로 핀하는 PC 별 상태다. 이 파일은 *무엇을* 설치할지만 기록하고, *어느 커밋인지*는 herdr 가 소유한다.

## Test plan
- [x] 전부 설치된 상태 → `already present: 3, failed: 0`, 네트워크 접근 없음
- [x] 설치 실패 (존재하지 않는 repo) → 경고 + 재시도 명령 출력, **exit 0** (부모 `set -e` 중단 없음)
- [x] `HERDR_SKIP_PLUGINS=1` → 심링크만 수행하고 건너뜀
- [x] `herdr` 미설치 (`PATH` 축소) → `herdr-help install` 안내 후 건너뜀
- [x] 멱등성 판별 오탐 검증 — `persiyanovXreviewr` / `nope.nope` → 미설치로 정확히 판정
- [x] `bash -n` · `shellcheck -x -e SC1090,SC1091 -S warning` 통과
- [x] `bats tests/bats/setup/` → 31 ok (고정 `.backup` 접미사 관례 포함)
- [x] `pytest tests/integration` → **1309 passed**

## Related
Depends on #1371 (merged)

## 미해결 — 후속 대상
사내 PC 에서 `herdr plugin install` 이 실제로 프록시를 통과하는지 미검증이다. 막힐 경우 릴리스 바이너리 직접 배치나 `herdr plugin link` 경로가 필요하며, 실측 결과를 받은 뒤 별도 이슈로 다룬다.

렌더러(`glow` · `delta` · `bat`) 와 `lazygit` 은 여전히 dotfiles 밖이다. 전자는 없어도 뷰어가 plain text 로 동작하고, 후자는 `prefix+ctrl+g` 만 실패한다 — 둘 다 이 PR 의 범위를 넘는다.

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~4 h · 🤖 ~18 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~4 h · 🤖 ~18 min
<!-- /ai-metrics:gh-pr -->

</details>
