### PR TITLE
feat(hermes): Hermes Agent 설치 자동화 모듈 추가 (커스텀 LLM 엔드포인트 지원)

### DIFF
--- a/docs/guide/commands/README.md
+++ b/docs/guide/commands/README.md
@@ -44,6 +44,7 @@ rg "fzf 피커" docs/guide/commands/
 - [gpu](./gpu.md)
 - [gwt](./gwt.md)
 - [herdr](./herdr.md)
+- [hermes](./hermes.md)
 - [hook](./hook.md)
 - [litellm](./litellm.md)
 - [mount](./mount.md)

--- a/docs/guide/commands/category.md
+++ b/docs/guide/commands/category.md
@@ -24,7 +24,7 @@
 **Categories**
 
 - **Category** — Topics
-- **AI/LLM (9)** — claude, cc, agy, codex, litellm, +4 more
+- **AI/LLM (10)** — claude, cc, agy, codex, hermes, +5 more
 - **CLI Utilities (12)** — fzf, fd, fasd, ripgrep, pet, +7 more
 - **Configuration (5)** — p10k, crt, apt, pip, ghostty
 - **Development (17)** — git, gwt, gbr, devx, uv, +12 more

--- a/docs/guide/commands/hermes.md
+++ b/docs/guide/commands/hermes.md
@@ -71,10 +71,10 @@
 - hermes config set model.base_url <url>    # OpenAI-compatible 엔드포인트 (/v1 포함)
 - hermes config set model.api_key <key>     # .env 아님 — 함정 1 참조
 - hermes doctor                             # 키/엔드포인트 인식 여부 확인
-**주의: config.yaml 은 이 저장소 심링크**
+**config.yaml 은 이 저장소 심링크 — 시크릿 주입 전 자동 detach**
 
-- 런타임 config ($HOME/.hermes/config.yaml) 은 hermes/config.yaml 심링크라 hermes config set 결과가 repo 작업트리에 나타난다
-- 커밋 전 git diff hermes/config.yaml 로 api_key 가 스테이징되지 않는지 확인할 것
+- 런타임 config ($HOME/.hermes/config.yaml) 은 기본적으로 hermes/config.yaml 심링크
+- setup.sh 는 hermes config set 직전 그 심링크를 로컬 실파일로 바꿔치기한다 — api_key 는 저장소에 절대 안 들어감
 
 ### pitfalls
 

--- a/docs/guide/commands/hermes.md
+++ b/docs/guide/commands/hermes.md
@@ -1,0 +1,137 @@
+# hermes
+
+> 자동 생성 문서입니다. 직접 편집하지 마세요 — 내용은 `shell-common/functions/hermes_help.sh` 의 row 함수가 SSOT 입니다.
+> 재생성: `shell-common/tools/custom/gen_command_docs.sh --topic hermes --force`
+
+## 호출
+
+- Help 진입점: `hermes-help [section|--list|--all]`
+- 통합 라우팅: `my-help hermes [section]`
+- Alias: `hermes-help`
+
+## 요약 (hermes-help)
+
+- Usage: hermes-help [section|--list|--all]
+- sections
+    - concept: 코딩 에이전트 | 커스텀 OpenAI-compatible 엔드포인트
+    - install: 공식 install.sh | ./hermes/setup.sh 가 하는 5단계
+    - config: llm_endpoint.local.sh | hermes config set | 심링크 SSOT
+    - pitfalls: api_key 위치 | agent-browser workspace | TLS 인터셉션 CA
+    - browser: agent-browser 설치 옵션
+    - example | related
+    - details: hermes-help <section>  (example: hermes-help pitfalls)
+
+## 섹션
+
+### concept
+
+- Hermes Agent (NousResearch) — 터미널에서 도는 코딩 에이전트
+- OpenAI-compatible 엔드포인트면 무엇이든 붙는다 — 자체 호스팅 모델, 사내 LLM 게이트웨이, Gemini 호환 엔드포인트
+- 이 저장소는 설치와 설정의 재현만 관리 — 에이전트 기능 자체는 upstream 소관
+- config SSOT: hermes/config.yaml → ~/.hermes/config.yaml 심링크
+
+### install
+
+- 공식 설치: curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh
+- dotfiles 경유(권장): ./setup.sh 또는 ./hermes/setup.sh — 멱등, 이미 설치돼 있으면 스킵
+- 확인: hermes --version · hermes doctor (alias hermes-doctor)
+**./hermes/setup.sh 가 하는 일 (5단계)**
+
+- **Part** — 동작 — 실패 정책
+- **1** — hermes/config.yaml → ~/.hermes/config.yaml 심링크 — hard-fail
+- **2** — 공식 install.sh 실행 (설치돼 있으면 스킵) — soft-fail
+- **3** — llm_endpoint.local.sh 읽어 base_url/api_key 주입 — soft-fail, 옵션
+- **4** — agent-browser npm 의존성 설치 — soft-fail, 옵션
+- **5** — root CA 를 Chromium NSS 저장소에 임포트 — soft-fail, 옵션
+- Part 2-5 는 실패해도 경고만 — 부모 ./setup.sh 의 set -e 를 죽이지 않는다
+**환경변수 (전부 선택)**
+
+- **Variable** — 효과
+- **HERMES_SKIP_INSTALL=1** — Part 2 (CLI 설치) 건너뛰기
+- **HERMES_SKIP_BROWSER=1** — Part 4 (agent-browser) 건너뛰기
+- **HERMES_AGENT_BROWSER_DIR** — agent-browser 의 package.json 이 있는 디렉터리 직접 지정
+- **HERMES_BROWSER_FULL_INSTALL=1** — 데스크톱(Electron) workspace 까지 전체 설치
+- **HERMES_CORP_CA_CERT** — NSS 저장소에 임포트할 root CA 인증서 경로
+
+### config
+
+- 커스텀 엔드포인트 값은 git 추적 파일에 절대 넣지 않는다 — 로컬 파일 경유
+- cp hermes/llm_endpoint.local.example hermes/llm_endpoint.local.sh
+- HERMES_LLM_BASE_URL / HERMES_LLM_API_KEY 두 값을 채운 뒤 ./hermes/setup.sh 재실행
+- llm_endpoint.local.sh 는 .gitignore 의 *.local.sh 글롭이 커버 — 셸이 자동 source 하지 않고 setup.sh 만 읽는다
+**시크릿 흐름**
+
+- hermes/llm_endpoint.local.example  (추적, 값 없음)
+    - cp ↓
+- hermes/llm_endpoint.local.sh      (gitignored, 실제 base_url/api_key)
+    - setup.sh Part 3 가 source ↓
+- hermes config set model.api_key <value>   → ~/.hermes/config.yaml
+**수동 설정**
+
+- hermes config set model.base_url <url>    # OpenAI-compatible 엔드포인트 (/v1 포함)
+- hermes config set model.api_key <key>     # .env 아님 — 함정 1 참조
+- hermes doctor                             # 키/엔드포인트 인식 여부 확인
+**주의: config.yaml 은 이 저장소 심링크**
+
+- 런타임 config ($HOME/.hermes/config.yaml) 은 hermes/config.yaml 심링크라 hermes config set 결과가 repo 작업트리에 나타난다
+- 커밋 전 git diff hermes/config.yaml 로 api_key 가 스테이징되지 않는지 확인할 것
+
+### pitfalls
+
+**1. 커스텀 provider 의 api_key 는 .env 가 아니라 config**
+
+- 증상: model.provider 를 custom 으로 두고 ~/.hermes/.env 에 OPENAI_API_KEY 를 넣었는데 401
+- 원인: hermes 가 자격증명 유출 방지로 OPENAI_API_KEY 를 openai.com / openai.azure.com 호스트에만 전달 (host-gate)
+- 해결: hermes config set model.api_key "<key>" 로 config 에 직접 주입
+**2. agent-browser 는 workspace 전체를 설치할 필요가 없다**
+
+- 증상: agent-browser 설치가 불필요하게 무겁고, 제한된 네트워크에서 잘 깨짐
+- 원인: 데스크톱 앱(Electron)이 같은 npm workspace 트리에 있어 같이 끌려온다
+- 해결: npm install --workspaces=false — agent-browser 는 루트 package.json 의존성이라 정상 동작
+- 이 저장소 기본값이 이 경량 설치 — 데스크톱이 필요하면 HERMES_BROWSER_FULL_INSTALL=1
+**3. TLS 인터셉션 프록시 뒤에서 브라우저만 SSL 실패**
+
+- 증상: curl / pip / uv 는 되는데 agent-browser 탐색만 전부 SSL 오류
+- 원인: Chromium 은 시스템 CA 번들이 아니라 자체 NSS 저장소를 본다 — ~/.pki/nssdb
+- snap Chromium 이면 경로가 다르다: ~/snap/chromium/<rev>/.pki/nssdb
+- 해결: certutil (libnss3-tools) 로 회사 root CA 를 해당 NSS DB 에 임포트
+- certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n corp-root-ca -i <cert.crt>
+- setup.sh Part 5 가 대신 해준다 — HERMES_CORP_CA_CERT 지정 시 (미지정이면 sudo 프롬프트 없이 완전 스킵)
+- HERMES_CORP_CA_CERT 미지정이면 shell-common/env/security.local.sh 의 $CA_CERT 를 폴백으로 쓴다
+
+### browser
+
+- agent-browser = hermes 의 브라우저 자동화 툴 (Chromium 구동)
+- **설치 방식** — 명령 — 언제
+- **루트 전용 (기본)** — npm install --workspaces=false — CLI 만 쓰는 대다수
+- **전체** — npm install — Electron 데스크톱 앱도 필요할 때
+- setup.sh 는 package.json 위치를 ~/.hermes, ~/.local/share/hermes 순으로 탐색
+- 못 찾으면 건너뛰고 안내만 — HERMES_AGENT_BROWSER_DIR=<dir> 로 직접 지정
+- TLS 인터셉션 환경이면 hermes-help pitfalls 3번 (NSS CA) 먼저 처리
+
+### example
+
+- ./hermes/setup.sh                                  # 설치 + 심링크 (멱등)
+- cp hermes/llm_endpoint.local.example hermes/llm_endpoint.local.sh
+- $EDITOR hermes/llm_endpoint.local.sh               # base_url + api_key 채우기
+- ./hermes/setup.sh                                  # 재실행 — 엔드포인트 주입
+- hermes doctor                                      # 설정 인식 확인
+- HERMES_BROWSER_FULL_INSTALL=1 ./hermes/setup.sh    # 데스크톱 포함 설치
+- HERMES_CORP_CA_CERT=/path/to/root-ca.crt ./hermes/setup.sh   # NSS CA 임포트
+
+### related
+
+- Upstream: https://github.com/NousResearch/hermes-agent
+- 모듈 문서: hermes/AGENTS.md
+- CA 인증서 일반: crt-help · 프록시: proxy-help
+- 다른 코딩 에이전트: claude-help · codex-help · opencode-help
+
+## 엣지케이스 / 의도된 동작
+
+아직 정리된 항목이 없습니다. 소스 주석에만 있는 동작을 발견하면
+`docs/guide/commands/.notes/hermes.md` 에 추가한 뒤 이 문서를 재생성하세요.
+
+## 소스
+
+- `shell-common/functions/hermes_help.sh`
+- 인터페이스 규칙: `docs/.ssot/command-guidelines.md`

--- a/hermes/AGENTS.md
+++ b/hermes/AGENTS.md
@@ -1,0 +1,80 @@
+# Module Context
+
+- **Purpose**: [Hermes Agent](https://github.com/NousResearch/hermes-agent) 설치·설정을 이 저장소로 재현
+- **Scope**: 설치 + config SSOT + 커스텀 OpenAI-compatible 엔드포인트 연동. 에이전트 기능 자체는 upstream 소관
+- **Structure**: `setup.sh` · `config.yaml` (SSOT) · `llm_endpoint.local.example` (템플릿)
+- **Dependencies**: `shell-common/tools/ux_lib` · (옵션) `npm`, `certutil`(libnss3-tools)
+- **대칭 모듈**: `herdr/` — 동일한 hard-fail/soft-fail 구조
+
+# Operational Commands
+
+- **Setup**: `./hermes/setup.sh` (루트 `./setup.sh` 가 호출, 멱등)
+- **Help**: `hermes-help` / `hermes-help pitfalls` / `hermes-help --all`
+- **Verify**: `hermes --version` · `hermes doctor` (alias `hermes-doctor`)
+- **Syntax**: `bash -n hermes/setup.sh`
+
+# setup.sh 5단계
+
+| Part | 동작 | 실패 정책 |
+|---|---|---|
+| 1 | `hermes/config.yaml` → `~/.hermes/config.yaml` 심링크 | **hard-fail** (dangling link = 조용한 기본값 복귀) |
+| 2 | 공식 `install.sh` 실행 (`command -v hermes` 로 스킵) | soft-fail |
+| 3 | `llm_endpoint.local.sh` 읽어 `model.base_url`/`model.api_key` 주입 | soft-fail, 옵션 |
+| 4 | `agent-browser` npm 의존성 설치 | soft-fail, 옵션 |
+| 5 | root CA 를 Chromium NSS 저장소에 임포트 | soft-fail, 옵션 |
+
+Part 2-5 는 네트워크/호스트 상태에 의존하므로 실패해도 경고만 남기고 계속한다 —
+부모 `./setup.sh` 는 `set -e` 로 돌기 때문에 이 스크립트는 항상 `exit 0` 으로 끝난다.
+
+**환경변수 (전부 선택)**: `HERMES_SKIP_INSTALL` · `HERMES_SKIP_BROWSER` ·
+`HERMES_AGENT_BROWSER_DIR` · `HERMES_BROWSER_FULL_INSTALL` · `HERMES_CORP_CA_CERT`
+
+# 시크릿 흐름
+
+```
+hermes/llm_endpoint.local.example   (git 추적, 값 없음, 안내 주석만)
+        │  cp
+        ▼
+hermes/llm_endpoint.local.sh        (.gitignore 의 *.local.sh 글롭이 커버)
+        │  setup.sh Part 3 이 실행 시점에 한 번 source
+        ▼
+hermes config set model.api_key "<value>"   → ~/.hermes/config.yaml
+```
+
+`llm_endpoint.local.sh` 는 셸이 자동 source 하지 않는다 (`shell-common/env/*.local.sh`
+와 다른 점) — API 키가 매 셸 환경변수로 떠 있지 않게 하기 위함이다.
+
+Part 1 은 `~/.hermes/config.yaml` 을 이 저장소로 심링크하지만, Part 3 는 `hermes
+config set` 을 실행하기 직전 그 심링크를 로컬 실파일로 교체한다
+(`_hermes_materialize_config`) — 시크릿은 로컬 사본에만 쓰이고 이 저장소의
+`hermes/config.yaml` 에는 도달하지 않는다. 다음 실행의 Part 1 이 그 사본을
+백업하고 저장소 기본값으로 다시 심링크한다.
+
+# 3가지 함정 (`hermes-help pitfalls` 가 SSOT)
+
+1. **`model.provider: custom` 의 API 키는 `.env` 가 아니라 config** — hermes 는
+   `OPENAI_API_KEY` 를 `openai.com` / `openai.azure.com` 호스트로만 전달하는
+   host-gate 를 걸어둔다. 커스텀 `base_url` 이면 키가 조용히 누락되어 401 이 난다.
+   해결: `hermes config set model.api_key "<key>"`.
+2. **`agent-browser` 는 workspace 전체를 설치할 필요가 없다** — 데스크톱 앱(Electron)이
+   같은 npm workspace 트리에 있어 같이 끌려온다. `agent-browser` 는 루트
+   `package.json` 의존성이라 `npm install --workspaces=false` 로 충분하다 (기본값).
+3. **TLS 인터셉션 프록시 뒤에서는 브라우저만 SSL 실패** — Chromium 은 시스템 CA
+   번들이 아니라 자체 NSS 저장소(`~/.pki/nssdb`, snap 이면
+   `~/snap/chromium/<rev>/.pki/nssdb`)를 본다. `certutil` 로 root CA 를 명시적으로
+   임포트해야 한다.
+
+# 검증되지 않은 부분
+
+- **Part 4 의 경로 탐색**: `agent-browser` 의 `package.json` 위치는 upstream 설치
+  레이아웃에 달렸다. `~/.hermes` → `~/.local/share/hermes` 순으로만 탐색하고,
+  못 찾으면 스킵 + 안내한다. 실제 위치는 설치 후 확인해 `HERMES_AGENT_BROWSER_DIR`
+  로 지정하거나 이 탐색 목록을 갱신할 것.
+- **`config.yaml` 스키마**: 검증되지 않은 키를 지어내지 않기 위해 주석만 두었다.
+  설정을 추가할 때는 설치된 버전의 `hermes config` 로 키를 먼저 확인할 것.
+
+# References
+
+- **[Root](../AGENTS.md)** · **[shell-common](../shell-common/AGENTS.md)** · **[herdr](../herdr/)**
+- **Upstream**: https://github.com/NousResearch/hermes-agent
+- **Symlink SSOT**: `shell-common/config/symlinks.conf`

--- a/hermes/AGENTS.md
+++ b/hermes/AGENTS.md
@@ -72,6 +72,11 @@ config set` 을 실행하기 직전 그 심링크를 로컬 실파일로 교체�
   로 지정하거나 이 탐색 목록을 갱신할 것.
 - **`config.yaml` 스키마**: 검증되지 않은 키를 지어내지 않기 위해 주석만 두었다.
   설정을 추가할 때는 설치된 버전의 `hermes config` 로 키를 먼저 확인할 것.
+- **api_key 가 커맨드라인 인자로 전달됨**: `hermes config set model.api_key
+  "<key>"` 는 `hermes` CLI 자체의 인터페이스라 이 저장소에서 바꿀 수 없다.
+  실행 짧은 구간 동안 같은 머신의 다른 사용자가 `ps`/`/proc/<pid>/cmdline`
+  으로 값을 볼 수 있는 알려진 한계 — stdin 기반 입력을 지원하는 hermes CLI
+  버전이 나오면 그쪽으로 전환할 것.
 
 # References
 

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -1,0 +1,20 @@
+# Hermes Agent configuration
+# Managed via dotfiles symlink:
+#   ~/.hermes/config.yaml -> ~/dotfiles/hermes/config.yaml
+#
+# Secrets are deliberately NOT here. This file is git-tracked, so anything you
+# add lands in the repo. `model.api_key` in particular must be injected
+# separately — hermes/setup.sh reads hermes/llm_endpoint.local.sh (gitignored)
+# and applies it with:
+#   hermes config set model.api_key "<key>"
+# which writes into this same ~/.hermes/config.yaml at runtime.
+#
+# Note: ~/.hermes/config.yaml starts as a symlink into this repo, but
+# hermes/setup.sh detaches it into a real local copy before any `hermes
+# config set` write (see _hermes_materialize_config) — the secret lands only
+# in the local copy, never in this tracked file.
+#
+# Keys are intentionally left to hermes' own defaults; add only settings you
+# have verified against `hermes config` on your version.
+#
+# See: hermes-help config

--- a/hermes/llm_endpoint.local.example
+++ b/hermes/llm_endpoint.local.example
@@ -1,0 +1,44 @@
+#!/bin/sh
+# llm_endpoint.local.sh (template)
+# Hermes Agent 커스텀 LLM 엔드포인트 설정 예제
+#
+# 사용 방법:
+#   1. 이 파일을 llm_endpoint.local.sh로 복사
+#      cp hermes/llm_endpoint.local.example hermes/llm_endpoint.local.sh
+#   2. 아래 두 값을 실제 엔드포인트/키로 교체
+#   3. ./hermes/setup.sh 재실행 — Part 3 이 값을 읽어
+#      `hermes config set model.base_url` / `model.api_key` 로 주입한다
+#   4. llm_endpoint.local.sh 는 .gitignore 의 `*.local.sh` 글롭으로 제외됨
+#      (이 .example 파일만 추적된다 — 여기에 실제 값을 쓰지 말 것)
+#
+# 이 파일은 셸이 자동으로 source 하지 않는다. hermes/setup.sh 가 실행 시점에
+# 한 번 읽을 뿐이라 매 셸마다 API 키가 환경변수로 떠 있지 않다.
+#
+# WHY 이 경로인가 (함정 1):
+#   `model.provider: custom` 일 때 ~/.hermes/.env 의 OPENAI_API_KEY 는
+#   적용되지 않는다. hermes 가 자격증명 유출 방지를 위해 그 키를
+#   openai.com / openai.azure.com 호스트로만 전달하도록 host-gate 를
+#   걸어두기 때문이다. 커스텀 base_url 을 쓰면 키가 조용히 누락되어 401 이
+#   난다. 그래서 키는 반드시 config 의 model.api_key 로 넣어야 한다.
+
+# OpenAI-compatible 엔드포인트의 base URL (경로에 /v1 까지 포함)
+export HERMES_LLM_BASE_URL="https://your-llm-endpoint.example.com/v1"
+
+# 위 엔드포인트용 API 키
+export HERMES_LLM_API_KEY="<your-api-key>"
+
+# ============================================================
+# 참고: Gemini 를 쓰는 경우
+# ============================================================
+# Google 은 OpenAI-compatible 엔드포인트를 공개 제공한다:
+#   export HERMES_LLM_BASE_URL="https://generativelanguage.googleapis.com/v1beta/openai/"
+#   export HERMES_LLM_API_KEY="<Google AI Studio 에서 발급받은 Gemini API 키>"
+#
+# ============================================================
+# 참고: 자체 호스팅 / 사내 LLM 게이트웨이
+# ============================================================
+# 엔드포인트 URL 과 키는 환경마다 다르므로 이 저장소에는 어떤 실제 값도
+# 넣지 않는다 (NF-1). 사내 게이트웨이 주소는 사내 문서에서 확인할 것.
+#
+# TLS 인터셉션 프록시 뒤라면 `hermes-help pitfalls` 의 3번 항목
+# (Chromium NSS 인증서 저장소) 도 같이 확인.

--- a/hermes/setup.sh
+++ b/hermes/setup.sh
@@ -253,26 +253,22 @@ _hermes_install_browser() {
 
 	ux_section "agent-browser"
 
-	local mode
+	local npm_flag="--workspaces=false"
+	local mode="root only (--workspaces=false)"
 	if [ "${HERMES_BROWSER_FULL_INSTALL:-0}" = "1" ]; then
+		npm_flag=""
 		mode="full (desktop workspace included)"
-		ux_info "installing in ${browser_dir} — ${mode}"
-		if (cd "${browser_dir}" && npm install); then
-			ux_success "agent-browser dependencies installed (${mode})"
-		else
-			ux_warning "npm install failed in ${browser_dir}"
-			ux_bullet "Retry: cd ${browser_dir} && npm install"
+	fi
+
+	ux_info "installing in ${browser_dir} — ${mode}"
+	if (cd "${browser_dir}" && npm install ${npm_flag}); then
+		ux_success "agent-browser dependencies installed (${mode})"
+		if [ -n "${npm_flag}" ]; then
+			ux_bullet "Need the Electron desktop app too? HERMES_BROWSER_FULL_INSTALL=1 ./hermes/setup.sh"
 		fi
 	else
-		mode="root only (--workspaces=false)"
-		ux_info "installing in ${browser_dir} — ${mode}"
-		if (cd "${browser_dir}" && npm install --workspaces=false); then
-			ux_success "agent-browser dependencies installed (${mode})"
-			ux_bullet "Need the Electron desktop app too? HERMES_BROWSER_FULL_INSTALL=1 ./hermes/setup.sh"
-		else
-			ux_warning "npm install failed in ${browser_dir}"
-			ux_bullet "Retry: cd ${browser_dir} && npm install --workspaces=false"
-		fi
+		ux_warning "npm install failed in ${browser_dir}"
+		ux_bullet "Retry: cd ${browser_dir} && npm install ${npm_flag}"
 	fi
 
 	return 0

--- a/hermes/setup.sh
+++ b/hermes/setup.sh
@@ -1,0 +1,355 @@
+#!/bin/bash
+# hermes/setup.sh: Hermes Agent install + config activation
+#
+# PURPOSE: Make a fresh machine's Hermes Agent match this repo — symlink the
+#          tracked config, install the CLI, wire up a custom OpenAI-compatible
+#          LLM endpoint, and (optionally) prepare the browser automation tool
+#          for a TLS-intercepting network.
+# WHEN TO RUN: Via ./setup.sh (do NOT run manually)
+# SSOT: Symlink target declared in shell-common/config/symlinks.conf
+#       Endpoint credentials declared in hermes/llm_endpoint.local.sh
+#       (gitignored — copy hermes/llm_endpoint.local.example to create it)
+#
+# Failure policy: Part 1 (config symlink) hard-fails — a missing source means a
+# dangling link and hermes silently reverting to its defaults. Parts 2-5
+# soft-fail: they reach the network (installer, npm registry) or depend on
+# host-specific state (a certificate path, certutil) that this script cannot
+# fix, and everything they provide degrades gracefully — no CLI means the help
+# text still tells you how to install it, no endpoint config means hermes falls
+# back to its own provider defaults, no browser tool means the agent loses one
+# capability. Never abort the parent setup.sh — which runs under `set -e` —
+# over any of it: warn and move on.
+#
+# Optional inputs (all unset by default; each unset one skips its Part):
+#   HERMES_AGENT_BROWSER_DIR    — where agent-browser's package.json lives
+#   HERMES_BROWSER_FULL_INSTALL — 1 installs the desktop (Electron) workspace too
+#   HERMES_CORP_CA_CERT         — root CA to import into Chromium's NSS store
+# Opt out of the install halves with HERMES_SKIP_INSTALL=1 / HERMES_SKIP_BROWSER=1.
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTFILES_ROOT="${_SCRIPT_DIR%/hermes}"
+SHELL_COMMON="${DOTFILES_ROOT}/shell-common"
+
+source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"
+
+HERMES_CONFIG_SRC="${_SCRIPT_DIR}/config.yaml"
+HERMES_CONFIG_DIR="${HOME}/.hermes"
+HERMES_CONFIG_LINK="${HERMES_CONFIG_DIR}/config.yaml"
+HERMES_ENDPOINT_LOCAL="${_SCRIPT_DIR}/llm_endpoint.local.sh"
+HERMES_INSTALL_URL="https://hermes-agent.nousresearch.com/install.sh"
+
+ux_header "Hermes Agent Setup"
+
+# ============================================================================
+# Part 1: config symlink (hard-fail)
+# ============================================================================
+
+# The source must exist; without it the symlink would dangle and hermes would
+# silently fall back to its built-in defaults.
+if [ ! -f "${HERMES_CONFIG_SRC}" ]; then
+	ux_error "Source config not found: ${HERMES_CONFIG_SRC}"
+	exit 1
+fi
+
+# hermes creates this directory itself on first run, but setup.sh may run first.
+if [ ! -d "${HERMES_CONFIG_DIR}" ]; then
+	mkdir -p "${HERMES_CONFIG_DIR}" || { ux_error "Could not create: ${HERMES_CONFIG_DIR}"; exit 1; }
+	ux_success "Created: ~/.hermes"
+fi
+
+# A function so the "already correct" case returns early instead of nesting the
+# rewrite branch. Body matches herdr/setup.sh's _herdr_link_config.
+_hermes_link_config() {
+	if [ -L "${HERMES_CONFIG_LINK}" ]; then
+		local current_target
+		current_target=$(readlink "${HERMES_CONFIG_LINK}")
+		if [ "${current_target}" = "${HERMES_CONFIG_SRC}" ]; then
+			ux_success "Symlink already correct: ~/.hermes/config.yaml → ${HERMES_CONFIG_SRC}"
+			return 0
+		fi
+		ux_info "Updating symlink (was: ${current_target})"
+		rm "${HERMES_CONFIG_LINK}" || { ux_error "Could not remove stale symlink: ${HERMES_CONFIG_LINK}"; exit 1; }
+	elif [ -e "${HERMES_CONFIG_LINK}" ]; then
+		local backup="${HERMES_CONFIG_LINK}.backup"
+		rm -f "${backup}"
+		ux_info "Backing up existing file: ${backup}"
+		mv "${HERMES_CONFIG_LINK}" "${backup}" || { ux_error "Could not back up: ${HERMES_CONFIG_LINK}"; exit 1; }
+	fi
+
+	ln -s "${HERMES_CONFIG_SRC}" "${HERMES_CONFIG_LINK}" || { ux_error "Could not create symlink: ${HERMES_CONFIG_LINK}"; exit 1; }
+	ux_success "Created: ~/.hermes/config.yaml → ${HERMES_CONFIG_SRC}"
+}
+
+# `hermes config set` (Part 3) rewrites whatever ~/.hermes/config.yaml points
+# at. Left as a symlink, that write lands on the tracked hermes/config.yaml —
+# the exact leak F-2/NF-1 forbid. Detach the link into a real local copy
+# before any secret write; the next run's _hermes_link_config backs that copy
+# up and re-links from the repo, so tracked defaults still propagate.
+_hermes_materialize_config() {
+	if [ -L "${HERMES_CONFIG_LINK}" ]; then
+		local resolved
+		resolved=$(readlink "${HERMES_CONFIG_LINK}")
+		rm "${HERMES_CONFIG_LINK}" || { ux_error "Could not detach symlink: ${HERMES_CONFIG_LINK}"; return 1; }
+		cp "${resolved}" "${HERMES_CONFIG_LINK}" || { ux_error "Could not materialize config: ${HERMES_CONFIG_LINK}"; return 1; }
+	fi
+	return 0
+}
+
+_hermes_link_config
+
+# ============================================================================
+# Part 2: CLI install (soft-fail, idempotent)
+# ============================================================================
+
+_hermes_install_cli() {
+	if [ "${HERMES_SKIP_INSTALL:-0}" = "1" ]; then
+		ux_info "Hermes CLI install skipped (HERMES_SKIP_INSTALL=1)"
+		return 0
+	fi
+
+	# `hermes --version` is the idempotence check the acceptance criteria name.
+	if command -v hermes >/dev/null 2>&1; then
+		ux_success "hermes already installed: $(hermes --version 2>&1 | head -1)"
+		return 0
+	fi
+
+	if ! command -v curl >/dev/null 2>&1; then
+		ux_warning "curl not on PATH — Hermes CLI install skipped"
+		ux_bullet "Install curl, then re-run: ./hermes/setup.sh"
+		return 0
+	fi
+
+	ux_section "Hermes CLI"
+	ux_info "installing from ${HERMES_INSTALL_URL}"
+
+	# Piping the installer to sh is upstream's documented path. It is also the
+	# one step that reaches the public internet, so a proxied/offline machine
+	# fails here — say what to retry and move on.
+	if curl -fsSL "${HERMES_INSTALL_URL}" | sh; then
+		if command -v hermes >/dev/null 2>&1; then
+			ux_success "installed: $(hermes --version 2>&1 | head -1)"
+		else
+			# The installer usually drops the binary in a dir this shell's PATH
+			# picked up before the install ran; a new shell resolves it.
+			ux_success "installer finished — open a new shell so PATH picks up hermes"
+		fi
+	else
+		ux_warning "Hermes CLI install failed (network or proxy is the usual cause)"
+		ux_bullet "Retry: curl -fsSL ${HERMES_INSTALL_URL} | sh"
+		ux_bullet "Details: hermes-help install"
+	fi
+
+	return 0
+}
+
+_hermes_install_cli
+
+# ============================================================================
+# Part 3: custom LLM endpoint (soft-fail, optional)
+# ============================================================================
+
+# Why `hermes config set` and not the tracked config.yaml: the api_key must
+# never land in a git-tracked file (F-2). And why config.yaml at all rather
+# than ~/.hermes/.env — hermes host-gates OPENAI_API_KEY to openai.com /
+# openai.azure.com, so a .env key is silently dropped for a custom base_url and
+# the request comes back 401. See hermes-help pitfalls.
+_hermes_configure_endpoint() {
+	if [ ! -f "${HERMES_ENDPOINT_LOCAL}" ]; then
+		ux_info "No custom LLM endpoint configured — skipping"
+		ux_bullet "To wire one up: cp hermes/llm_endpoint.local.example hermes/llm_endpoint.local.sh"
+		ux_bullet "Fill in HERMES_LLM_BASE_URL / HERMES_LLM_API_KEY, then re-run ./hermes/setup.sh"
+		return 0
+	fi
+
+	# shellcheck source=/dev/null
+	. "${HERMES_ENDPOINT_LOCAL}" || { ux_warning "Could not source: ${HERMES_ENDPOINT_LOCAL}"; return 0; }
+
+	if [ -z "${HERMES_LLM_BASE_URL:-}" ] && [ -z "${HERMES_LLM_API_KEY:-}" ]; then
+		ux_warning "${HERMES_ENDPOINT_LOCAL} sets neither HERMES_LLM_BASE_URL nor HERMES_LLM_API_KEY — skipping"
+		return 0
+	fi
+
+	if ! command -v hermes >/dev/null 2>&1; then
+		ux_info "hermes not on PATH — endpoint configuration skipped"
+		ux_bullet "Install hermes first: hermes-help install"
+		return 0
+	fi
+
+	_hermes_materialize_config || { ux_warning "Could not detach ~/.hermes/config.yaml from the repo symlink — skipping endpoint write to avoid leaking a secret into a tracked file"; return 0; }
+
+	ux_section "Custom LLM endpoint"
+
+	if [ -n "${HERMES_LLM_BASE_URL:-}" ]; then
+		if hermes config set model.base_url "${HERMES_LLM_BASE_URL}" >/dev/null 2>&1; then
+			ux_success "set model.base_url (${HERMES_LLM_BASE_URL})"
+		else
+			ux_warning "Could not set model.base_url — run manually: hermes config set model.base_url <url>"
+		fi
+	fi
+
+	# The value is never echoed — only whether the write landed.
+	if [ -n "${HERMES_LLM_API_KEY:-}" ]; then
+		if hermes config set model.api_key "${HERMES_LLM_API_KEY}" >/dev/null 2>&1; then
+			ux_success "set model.api_key (value not printed)"
+		else
+			ux_warning "Could not set model.api_key — run manually: hermes config set model.api_key <key>"
+		fi
+	fi
+
+	ux_bullet "Verify: hermes doctor"
+	return 0
+}
+
+_hermes_configure_endpoint
+
+# ============================================================================
+# Part 4: agent-browser (soft-fail, optional)
+# ============================================================================
+
+# agent-browser is a root-package.json dependency that happens to sit in a
+# workspace tree shared with the Electron desktop app. `--workspaces=false`
+# installs the root only, which is all the CLI needs (pitfall 2).
+#
+# The install location is not fixed by this repo — it depends on how the
+# upstream installer laid things out on this host. Rather than hardcode a path
+# that may not exist, probe a couple of likely ones and otherwise ask the user.
+_hermes_find_browser_dir() {
+	local candidate
+	for candidate in "${HOME}/.hermes" "${HOME}/.local/share/hermes"; do
+		if [ -f "${candidate}/package.json" ]; then
+			printf '%s' "${candidate}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+_hermes_install_browser() {
+	if [ "${HERMES_SKIP_BROWSER:-0}" = "1" ]; then
+		ux_info "agent-browser install skipped (HERMES_SKIP_BROWSER=1)"
+		return 0
+	fi
+
+	local browser_dir="${HERMES_AGENT_BROWSER_DIR:-}"
+
+	if [ -n "${browser_dir}" ]; then
+		if [ ! -f "${browser_dir}/package.json" ]; then
+			ux_warning "HERMES_AGENT_BROWSER_DIR has no package.json: ${browser_dir} — skipping"
+			return 0
+		fi
+	else
+		browser_dir=$(_hermes_find_browser_dir) || {
+			ux_info "agent-browser install location not found — skipping"
+			ux_bullet "Point at it explicitly: HERMES_AGENT_BROWSER_DIR=<dir with package.json> ./hermes/setup.sh"
+			ux_bullet "Or install by hand — see: hermes-help install"
+			return 0
+		}
+	fi
+
+	if ! command -v npm >/dev/null 2>&1; then
+		ux_warning "npm not on PATH — agent-browser install skipped"
+		return 0
+	fi
+
+	ux_section "agent-browser"
+
+	local mode
+	if [ "${HERMES_BROWSER_FULL_INSTALL:-0}" = "1" ]; then
+		mode="full (desktop workspace included)"
+		ux_info "installing in ${browser_dir} — ${mode}"
+		if (cd "${browser_dir}" && npm install); then
+			ux_success "agent-browser dependencies installed (${mode})"
+		else
+			ux_warning "npm install failed in ${browser_dir}"
+			ux_bullet "Retry: cd ${browser_dir} && npm install"
+		fi
+	else
+		mode="root only (--workspaces=false)"
+		ux_info "installing in ${browser_dir} — ${mode}"
+		if (cd "${browser_dir}" && npm install --workspaces=false); then
+			ux_success "agent-browser dependencies installed (${mode})"
+			ux_bullet "Need the Electron desktop app too? HERMES_BROWSER_FULL_INSTALL=1 ./hermes/setup.sh"
+		else
+			ux_warning "npm install failed in ${browser_dir}"
+			ux_bullet "Retry: cd ${browser_dir} && npm install --workspaces=false"
+		fi
+	fi
+
+	return 0
+}
+
+_hermes_install_browser
+
+# ============================================================================
+# Part 5: root CA import for Chromium's NSS store (soft-fail, optional)
+# ============================================================================
+
+# Chromium — which agent-browser drives — reads its own NSS database, not the
+# system CA bundle. Behind a TLS-intercepting proxy that makes every navigation
+# fail with an SSL error while curl/pip/uv keep working (pitfall 3).
+#
+# Fallback source: a machine that already configured a corporate CA has the
+# path in shell-common/env/security.local.sh as $CA_CERT. Read it in a subshell
+# so that file's other exports (proxy vars, NODE_EXTRA_CA_CERTS) do not leak
+# into this setup run.
+_hermes_resolve_ca_cert() {
+	if [ -n "${HERMES_CORP_CA_CERT:-}" ]; then
+		printf '%s' "${HERMES_CORP_CA_CERT}"
+		return 0
+	fi
+
+	local security_local="${SHELL_COMMON}/env/security.local.sh"
+	[ -f "${security_local}" ] || return 1
+
+	local from_security
+	# shellcheck source=/dev/null
+	from_security=$(DOTFILES_FORCE_INIT=1 sh -c '. "$1" >/dev/null 2>&1; printf "%s" "${CA_CERT:-}"' _ "${security_local}" 2>/dev/null)
+	[ -n "${from_security}" ] || return 1
+
+	printf '%s' "${from_security}"
+	return 0
+}
+
+_hermes_import_ca() {
+	local cert_path
+	cert_path=$(_hermes_resolve_ca_cert) || {
+		# The common case on a normal network: nothing to do, and no sudo
+		# prompt (F-4).
+		return 0
+	}
+
+	ux_section "Chromium NSS root CA"
+
+	if [ ! -f "${cert_path}" ]; then
+		ux_warning "CA certificate not found: ${cert_path} — skipping NSS import"
+		return 0
+	fi
+
+	if ! command -v certutil >/dev/null 2>&1; then
+		ux_warning "certutil not found — agent-browser may fail with SSL errors behind a TLS-intercepting proxy"
+		ux_bullet "Install it: sudo apt install libnss3-tools   (then re-run ./hermes/setup.sh)"
+		return 0
+	fi
+
+	mkdir -p "${HOME}/.pki/nssdb"
+
+	# -A on an existing nickname replaces it, so re-running is idempotent.
+	if certutil -d "sql:${HOME}/.pki/nssdb" -A -t "C,," -n "corp-root-ca" -i "${cert_path}" >/dev/null 2>&1; then
+		ux_success "imported ${cert_path} into ~/.pki/nssdb as 'corp-root-ca'"
+		ux_bullet "Verify: certutil -d sql:\$HOME/.pki/nssdb -L"
+		ux_bullet "snap Chromium keeps a separate DB — see: hermes-help pitfalls"
+	else
+		ux_warning "certutil import failed for ${cert_path}"
+		ux_bullet "Retry: certutil -d sql:\$HOME/.pki/nssdb -A -t \"C,,\" -n corp-root-ca -i ${cert_path}"
+	fi
+
+	return 0
+}
+
+_hermes_import_ca
+
+ux_info "Details and pitfalls: hermes-help"
+
+# Install failures are warnings, never fatal — pin the status so the parent's
+# `set -e` cannot trip over Parts 2-5. See the header comment.
+exit 0

--- a/hermes/setup.sh
+++ b/hermes/setup.sh
@@ -327,7 +327,7 @@ _hermes_import_ca() {
 		return 0
 	fi
 
-	mkdir -p "${HOME}/.pki/nssdb"
+	mkdir -p "${HOME}/.pki/nssdb" || { ux_warning "Could not create ~/.pki/nssdb — skipping NSS import"; return 0; }
 
 	# -A on an existing nickname replaces it, so re-running is idempotent.
 	if certutil -d "sql:${HOME}/.pki/nssdb" -A -t "C,," -n "corp-root-ca" -i "${cert_path}" >/dev/null 2>&1; then

--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,7 @@ fi
 ./git/setup.sh
 ./obsidian/setup.sh            # Obsidian CLI wrapper → ~/.local/bin/obsidian (#1023)
 ./herdr/setup.sh               # herdr config → ~/.config/herdr/config.toml (symlinks.conf SSOT)
+./hermes/setup.sh              # Hermes Agent config → ~/.hermes/config.yaml (symlinks.conf SSOT, #1373)
 ./claude/setup.sh
 ./agy/setup.sh                 # Antigravity CLI (agy) 바이너리 존재 확인 (#1180)
 # Internal-PC AWS SSO/CLI seeding only (aws.local.sh + ~/.aws/config). Its old

--- a/shell-common/config/symlinks.conf
+++ b/shell-common/config/symlinks.conf
@@ -24,3 +24,7 @@ ${HOME}/.local/bin/obsidian|${HOME}/dotfiles/obsidian/bin/obsidian|Obsidian CLI 
 # herdr (agent multiplexer) — the running server reads the live path, so the
 # symlink is what makes the dotfiles copy authoritative.
 ${HOME}/.config/herdr/config.toml|${HOME}/dotfiles/herdr/config.toml|herdr config (managed by dotfiles)
+
+# Hermes Agent (#1373) — secrets stay out of this file; hermes/setup.sh injects
+# model.api_key via `hermes config set` from a gitignored local file.
+${HOME}/.hermes/config.yaml|${HOME}/dotfiles/hermes/config.yaml|hermes config (managed by dotfiles)

--- a/shell-common/functions/hermes_help.sh
+++ b/shell-common/functions/hermes_help.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# shell-common/functions/hermes_help.sh
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+_hermes_help_summary() {
+    ux_info "Usage: hermes-help [section|--list|--all]"
+    ux_bullet "sections"
+    ux_bullet_sub "concept: 코딩 에이전트 | 커스텀 OpenAI-compatible 엔드포인트"
+    ux_bullet_sub "install: 공식 install.sh | ./hermes/setup.sh 가 하는 5단계"
+    ux_bullet_sub "config: llm_endpoint.local.sh | hermes config set | 심링크 SSOT"
+    ux_bullet_sub "pitfalls: api_key 위치 | agent-browser workspace | TLS 인터셉션 CA"
+    ux_bullet_sub "browser: agent-browser 설치 옵션"
+    ux_bullet_sub "example | related"
+    ux_bullet_sub "details: hermes-help <section>  (example: hermes-help pitfalls)"
+}
+
+_hermes_help_list_sections() {
+    ux_bullet "sections"
+    ux_bullet_sub "concept"
+    ux_bullet_sub "install"
+    ux_bullet_sub "config"
+    ux_bullet_sub "pitfalls"
+    ux_bullet_sub "browser"
+    ux_bullet_sub "example"
+    ux_bullet_sub "related"
+}
+
+_hermes_help_rows_concept() {
+    ux_bullet "Hermes Agent (NousResearch) — 터미널에서 도는 코딩 에이전트"
+    ux_bullet "OpenAI-compatible 엔드포인트면 무엇이든 붙는다 — 자체 호스팅 모델, 사내 LLM 게이트웨이, Gemini 호환 엔드포인트"
+    ux_bullet "이 저장소는 ${UX_BOLD}설치와 설정의 재현${UX_RESET}만 관리 — 에이전트 기능 자체는 upstream 소관"
+    ux_bullet "config SSOT: ${UX_BOLD}hermes/config.yaml${UX_RESET} → ~/.hermes/config.yaml 심링크"
+}
+
+_hermes_help_rows_install() {
+    ux_bullet "공식 설치: ${UX_BOLD}curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh${UX_RESET}"
+    ux_bullet "dotfiles 경유(권장): ${UX_BOLD}./setup.sh${UX_RESET} 또는 ${UX_BOLD}./hermes/setup.sh${UX_RESET} — 멱등, 이미 설치돼 있으면 스킵"
+    ux_bullet "확인: ${UX_BOLD}hermes --version${UX_RESET} · ${UX_BOLD}hermes doctor${UX_RESET} (alias ${UX_BOLD}hermes-doctor${UX_RESET})"
+
+    ux_section "./hermes/setup.sh 가 하는 일 (5단계)"
+    ux_table_header "Part" "동작" "실패 정책"
+    ux_table_row "1" "hermes/config.yaml → ~/.hermes/config.yaml 심링크" "hard-fail"
+    ux_table_row "2" "공식 install.sh 실행 (설치돼 있으면 스킵)" "soft-fail"
+    ux_table_row "3" "llm_endpoint.local.sh 읽어 base_url/api_key 주입" "soft-fail, 옵션"
+    ux_table_row "4" "agent-browser npm 의존성 설치" "soft-fail, 옵션"
+    ux_table_row "5" "root CA 를 Chromium NSS 저장소에 임포트" "soft-fail, 옵션"
+    ux_bullet "Part 2-5 는 실패해도 경고만 — 부모 ./setup.sh 의 set -e 를 죽이지 않는다"
+
+    ux_section "환경변수 (전부 선택)"
+    ux_table_header "Variable" "효과"
+    ux_table_row "HERMES_SKIP_INSTALL=1" "Part 2 (CLI 설치) 건너뛰기"
+    ux_table_row "HERMES_SKIP_BROWSER=1" "Part 4 (agent-browser) 건너뛰기"
+    ux_table_row "HERMES_AGENT_BROWSER_DIR" "agent-browser 의 package.json 이 있는 디렉터리 직접 지정"
+    ux_table_row "HERMES_BROWSER_FULL_INSTALL=1" "데스크톱(Electron) workspace 까지 전체 설치"
+    ux_table_row "HERMES_CORP_CA_CERT" "NSS 저장소에 임포트할 root CA 인증서 경로"
+}
+
+_hermes_help_rows_config() {
+    ux_bullet "커스텀 엔드포인트 값은 git 추적 파일에 절대 넣지 않는다 — 로컬 파일 경유"
+    ux_bullet "cp hermes/llm_endpoint.local.example hermes/llm_endpoint.local.sh"
+    ux_bullet "HERMES_LLM_BASE_URL / HERMES_LLM_API_KEY 두 값을 채운 뒤 ./hermes/setup.sh 재실행"
+    ux_bullet "llm_endpoint.local.sh 는 .gitignore 의 ${UX_BOLD}*.local.sh${UX_RESET} 글롭이 커버 — 셸이 자동 source 하지 않고 setup.sh 만 읽는다"
+
+    ux_section "시크릿 흐름"
+    ux_bullet "hermes/llm_endpoint.local.example  (추적, 값 없음)"
+    ux_bullet_sub "cp ↓"
+    ux_bullet "hermes/llm_endpoint.local.sh      (gitignored, 실제 base_url/api_key)"
+    ux_bullet_sub "setup.sh Part 3 가 source ↓"
+    ux_bullet "hermes config set model.api_key <value>   → ~/.hermes/config.yaml"
+
+    ux_section "수동 설정"
+    ux_bullet "hermes config set model.base_url <url>    # OpenAI-compatible 엔드포인트 (/v1 포함)"
+    ux_bullet "hermes config set model.api_key <key>     # .env 아님 — 함정 1 참조"
+    ux_bullet "hermes doctor                             # 키/엔드포인트 인식 여부 확인"
+
+    ux_section "config.yaml 은 이 저장소 심링크 — 시크릿 주입 전 자동 detach"
+    ux_bullet "런타임 config (\$HOME/.hermes/config.yaml) 은 기본적으로 hermes/config.yaml 심링크"
+    ux_bullet "setup.sh 는 ${UX_BOLD}hermes config set${UX_RESET} 직전 그 심링크를 로컬 실파일로 바꿔치기한다 — api_key 는 저장소에 절대 안 들어감"
+}
+
+_hermes_help_rows_pitfalls() {
+    ux_section "1. 커스텀 provider 의 api_key 는 .env 가 아니라 config"
+    ux_bullet "증상: model.provider 를 custom 으로 두고 ~/.hermes/.env 에 OPENAI_API_KEY 를 넣었는데 401"
+    ux_bullet "원인: hermes 가 자격증명 유출 방지로 OPENAI_API_KEY 를 ${UX_BOLD}openai.com / openai.azure.com${UX_RESET} 호스트에만 전달 (host-gate)"
+    ux_bullet "해결: ${UX_BOLD}hermes config set model.api_key \"<key>\"${UX_RESET} 로 config 에 직접 주입"
+
+    ux_section "2. agent-browser 는 workspace 전체를 설치할 필요가 없다"
+    ux_bullet "증상: agent-browser 설치가 불필요하게 무겁고, 제한된 네트워크에서 잘 깨짐"
+    ux_bullet "원인: 데스크톱 앱(Electron)이 같은 npm workspace 트리에 있어 같이 끌려온다"
+    ux_bullet "해결: ${UX_BOLD}npm install --workspaces=false${UX_RESET} — agent-browser 는 루트 package.json 의존성이라 정상 동작"
+    ux_bullet "이 저장소 기본값이 이 경량 설치 — 데스크톱이 필요하면 HERMES_BROWSER_FULL_INSTALL=1"
+
+    ux_section "3. TLS 인터셉션 프록시 뒤에서 브라우저만 SSL 실패"
+    ux_bullet "증상: curl / pip / uv 는 되는데 agent-browser 탐색만 전부 SSL 오류"
+    ux_bullet "원인: Chromium 은 시스템 CA 번들이 아니라 자체 NSS 저장소를 본다 — ${UX_BOLD}~/.pki/nssdb${UX_RESET}"
+    ux_bullet "snap Chromium 이면 경로가 다르다: ${UX_BOLD}~/snap/chromium/<rev>/.pki/nssdb${UX_RESET}"
+    ux_bullet "해결: certutil (libnss3-tools) 로 회사 root CA 를 해당 NSS DB 에 임포트"
+    ux_bullet "certutil -d sql:\$HOME/.pki/nssdb -A -t \"C,,\" -n corp-root-ca -i <cert.crt>"
+    ux_bullet "setup.sh Part 5 가 대신 해준다 — HERMES_CORP_CA_CERT 지정 시 (미지정이면 sudo 프롬프트 없이 완전 스킵)"
+    ux_bullet "HERMES_CORP_CA_CERT 미지정이면 shell-common/env/security.local.sh 의 \$CA_CERT 를 폴백으로 쓴다"
+}
+
+_hermes_help_rows_browser() {
+    ux_bullet "agent-browser = hermes 의 브라우저 자동화 툴 (Chromium 구동)"
+    ux_table_header "설치 방식" "명령" "언제"
+    ux_table_row "루트 전용 (기본)" "npm install --workspaces=false" "CLI 만 쓰는 대다수"
+    ux_table_row "전체" "npm install" "Electron 데스크톱 앱도 필요할 때"
+    ux_bullet "setup.sh 는 package.json 위치를 ~/.hermes, ~/.local/share/hermes 순으로 탐색"
+    ux_bullet "못 찾으면 건너뛰고 안내만 — ${UX_BOLD}HERMES_AGENT_BROWSER_DIR=<dir>${UX_RESET} 로 직접 지정"
+    ux_bullet "TLS 인터셉션 환경이면 ${UX_BOLD}hermes-help pitfalls${UX_RESET} 3번 (NSS CA) 먼저 처리"
+}
+
+_hermes_help_rows_example() {
+    ux_bullet "./hermes/setup.sh                                  # 설치 + 심링크 (멱등)"
+    ux_bullet "cp hermes/llm_endpoint.local.example hermes/llm_endpoint.local.sh"
+    ux_bullet "\$EDITOR hermes/llm_endpoint.local.sh               # base_url + api_key 채우기"
+    ux_bullet "./hermes/setup.sh                                  # 재실행 — 엔드포인트 주입"
+    ux_bullet "hermes doctor                                      # 설정 인식 확인"
+    ux_bullet "HERMES_BROWSER_FULL_INSTALL=1 ./hermes/setup.sh    # 데스크톱 포함 설치"
+    ux_bullet "HERMES_CORP_CA_CERT=/path/to/root-ca.crt ./hermes/setup.sh   # NSS CA 임포트"
+}
+
+_hermes_help_rows_related() {
+    ux_bullet "Upstream: ${UX_BOLD}https://github.com/NousResearch/hermes-agent${UX_RESET}"
+    ux_bullet "모듈 문서: ${UX_BOLD}hermes/AGENTS.md${UX_RESET}"
+    ux_bullet "CA 인증서 일반: ${UX_BOLD}crt-help${UX_RESET} · 프록시: ${UX_BOLD}proxy-help${UX_RESET}"
+    ux_bullet "다른 코딩 에이전트: ${UX_BOLD}claude-help${UX_RESET} · ${UX_BOLD}codex-help${UX_RESET} · ${UX_BOLD}opencode-help${UX_RESET}"
+}
+
+_hermes_help_render_section() {
+    ux_section "$1"
+    "$2"
+}
+
+_hermes_help_section_rows() {
+    case "$1" in
+        concept)              _hermes_help_rows_concept ;;
+        install)              _hermes_help_rows_install ;;
+        config|configure)     _hermes_help_rows_config ;;
+        pitfall|pitfalls)     _hermes_help_rows_pitfalls ;;
+        browser|agent-browser) _hermes_help_rows_browser ;;
+        example|examples)     _hermes_help_rows_example ;;
+        related)              _hermes_help_rows_related ;;
+        *)
+            ux_error "Unknown hermes-help section: $1"
+            ux_info "Try: hermes-help --list"
+            return 1
+            ;;
+    esac
+}
+
+_hermes_help_full() {
+    ux_header "Hermes Agent - Coding Agent with Custom LLM Endpoints"
+    _hermes_help_render_section "Core Concept" _hermes_help_rows_concept
+    _hermes_help_render_section "Install" _hermes_help_rows_install
+    _hermes_help_render_section "Configuration" _hermes_help_rows_config
+    _hermes_help_render_section "Pitfalls" _hermes_help_rows_pitfalls
+    _hermes_help_render_section "agent-browser" _hermes_help_rows_browser
+    _hermes_help_render_section "Practical Example" _hermes_help_rows_example
+    _hermes_help_render_section "Related Help" _hermes_help_rows_related
+}
+
+hermes_help() {
+    case "${1:-}" in
+        ""|-h|--help|help) _hermes_help_summary ;;
+        --list|list|section|sections) _hermes_help_list_sections ;;
+        --all|all)          _hermes_help_full ;;
+        *)                  _hermes_help_section_rows "$1" ;;
+    esac
+}
+
+alias hermes-help='hermes_help'

--- a/shell-common/functions/my_help.sh
+++ b/shell-common/functions/my_help.sh
@@ -168,7 +168,7 @@ _register_default_help_categories() {
     # Category membership (space-separated topic keys)
     HELP_CATEGORY_MEMBERS[development]="${HELP_CATEGORY_MEMBERS[development]:-git gwt gbr devx uv py nvm npm bun pp cli ux du psql mytool ghes_mirror mirror_pages_activate}"
     HELP_CATEGORY_MEMBERS[devops]="${HELP_CATEGORY_MEMBERS[devops]:-docker dproxy sys proxy ssl mount mysql redis gpu network wsl_check window sync_to_deploy}"
-    HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc agy codex litellm ollama claude_plugins claude_skills_marketplace superpowers}"
+    HELP_CATEGORY_MEMBERS[ai]="${HELP_CATEGORY_MEMBERS[ai]:-claude cc agy codex hermes litellm ollama claude_plugins claude_skills_marketplace superpowers}"
     HELP_CATEGORY_MEMBERS[cli]="${HELP_CATEGORY_MEMBERS[cli]:-fzf fd fasd ripgrep pet bat zsh zsh_autosuggestions gc tmux herdr del_file}"
     HELP_CATEGORY_MEMBERS[config]="${HELP_CATEGORY_MEMBERS[config]:-p10k crt apt pip ghostty}"
     HELP_CATEGORY_MEMBERS[docs]="${HELP_CATEGORY_MEMBERS[docs]:-dot show_doc notion work_log work}"
@@ -259,6 +259,7 @@ _register_default_help_descriptions() {
     HELP_DESCRIPTIONS[ollama_help]="${HELP_DESCRIPTIONS[ollama_help]:-[AI/LLM] Ollama local models}"
     HELP_DESCRIPTIONS[tmux_help]="${HELP_DESCRIPTIONS[tmux_help]:-[CLI] tmux terminal multiplexer}"
     HELP_DESCRIPTIONS[herdr_help]="${HELP_DESCRIPTIONS[herdr_help]:-[CLI] herdr agent multiplexer}"
+    HELP_DESCRIPTIONS[hermes_help]="${HELP_DESCRIPTIONS[hermes_help]:-[AI] Hermes Agent — 코딩 에이전트, 커스텀 LLM 엔드포인트 지원}"
     HELP_DESCRIPTIONS[ghostty_help]="${HELP_DESCRIPTIONS[ghostty_help]:-[Config] Ghostty terminal config}"
     HELP_DESCRIPTIONS[opencode_help]="${HELP_DESCRIPTIONS[opencode_help]:-[System] OpenCode CLI setup}"
     HELP_DESCRIPTIONS[show_doc_help]="${HELP_DESCRIPTIONS[show_doc_help]:-[Docs] Documentation viewer}"

--- a/shell-common/tools/integrations/hermes.sh
+++ b/shell-common/tools/integrations/hermes.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# shell-common/tools/integrations/hermes.sh
+# Hermes Agent convenience aliases
+#
+# Deliberately minimal: the upstream installer puts a self-contained `hermes`
+# binary on PATH itself, so there is nothing here to export or wrap. Config is
+# owned by hermes/setup.sh (symlinks ~/.hermes/config.yaml into this repo).
+#
+# Setup:   ./hermes/setup.sh
+# Details: hermes-help
+
+# ========================================
+# Load UX Library
+# ========================================
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+if ! type ux_header >/dev/null 2>&1; then
+    _hermes_dir="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"
+    . "${_hermes_dir}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
+    unset _hermes_dir
+fi
+
+# ========================================
+# Hermes Aliases
+# ========================================
+alias hermes-doctor='hermes doctor'
+alias hermes-config='hermes config'

--- a/shell-common/tools/integrations/hermes.sh
+++ b/shell-common/tools/integrations/hermes.sh
@@ -9,17 +9,7 @@
 # Setup:   ./hermes/setup.sh
 # Details: hermes-help
 
-# ========================================
-# Load UX Library
-# ========================================
-
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
-
-if ! type ux_header >/dev/null 2>&1; then
-    _hermes_dir="${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}"
-    . "${_hermes_dir}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
-    unset _hermes_dir
-fi
 
 # ========================================
 # Hermes Aliases

--- a/tests/integration/test_help_compact_policy.py
+++ b/tests/integration/test_help_compact_policy.py
@@ -38,6 +38,7 @@ HELP_TOPICS = [
     "git_help",
     "gwt_help",
     "gpu_help",
+    "hermes_help",
     "litellm_help",
     "mytool_help",
     "mysql_help",

--- a/tests/integration/test_help_topics.py
+++ b/tests/integration/test_help_topics.py
@@ -41,6 +41,7 @@ HELP_TOPICS = [
     "gwt_help",
     "gpu_help",
     "herdr_help",
+    "hermes_help",
     "litellm_help",
     "mytool_help",
     "mysql_help",


### PR DESCRIPTION
## Summary
- `hermes/` 모듈 신설 — `herdr/`와 대칭 구조로 Hermes Agent 설치·설정을 dotfiles로 재현
- 실전에서 겪은 3가지 함정(호스트게이트로 인한 API 키 무시, agent-browser 불필요한 desktop workspace, TLS 인터셉션 프록시의 Chromium NSS CA 부재)을 자동화 + `hermes-help` 문서화로 재발 방지
- `shell-common` 3-step 툴 통합 패턴(`tools/integrations/hermes.sh` + `functions/hermes_help.sh` + `my_help.sh` 등록)을 적용

## Changes
- `hermes/setup.sh`: Part 1(config 심링크, hard-fail) / Part 2(공식 install.sh, soft-fail·멱등) / Part 3(커스텀 LLM 엔드포인트 주입, soft-fail·옵션) / Part 4(agent-browser 설치, soft-fail·옵션) / Part 5(TLS 인터셉션 프록시용 root CA를 Chromium NSS 저장소에 임포트, soft-fail·옵션)
- `hermes/setup.sh` 보안 강화: `hermes config set model.api_key`가 `~/.hermes/config.yaml`에 쓰기 직전 그 심링크를 로컬 실파일로 detach(`_hermes_materialize_config`)하여, 시크릿이 이 저장소의 git 추적 파일(`hermes/config.yaml`)에 절대 들어가지 않도록 함(F-2/NF-1). 다음 실행 시 Part 1이 그 사본을 백업하고 저장소 기본값으로 재심링크
- `hermes/llm_endpoint.local.example`: `HERMES_LLM_BASE_URL`/`HERMES_LLM_API_KEY` 템플릿 — Gemini의 OpenAI-compatible 엔드포인트 사용 예시 주석 포함
- `hermes/config.yaml`: 비밀 없는 최소 SSOT (스키마 미검증 키는 지어내지 않음)
- `hermes/AGENTS.md`: 모듈 문서 (80줄) — setup.sh 5단계, 시크릿 흐름, 3가지 함정, 검증되지 않은 부분(agent-browser 경로 탐색) 명시
- `shell-common/functions/hermes_help.sh` + `shell-common/tools/integrations/hermes.sh`: `hermes-help` 명령어 (concept/install/config/pitfalls/browser/example/related 섹션)
- `shell-common/functions/my_help.sh`: `ai` 카테고리에 `hermes` 등록
- `shell-common/config/symlinks.conf`: `hermes/config.yaml` → `~/.hermes/config.yaml` 심링크 SSOT 등록
- 루트 `setup.sh`: `./hermes/setup.sh` 호출 추가 (herdr 다음)
- `tests/integration/test_help_topics.py`, `test_help_compact_policy.py`: `hermes_help` 등록 (herdr 선례)
- `docs/guide/commands/hermes.md` + README/category 인덱스: `gen_command_docs.sh` 자동 생성 산출물

## Test plan
- [x] `bash -n hermes/setup.sh` / `sh -n` (functions, integrations) 문법 검사 통과
- [x] `shellcheck -x` clean
- [x] `pytest` 전체 1325 passed / 0 failed (caused), baseline 대비 신규 16건은 hermes 파라미터라이즈
- [x] `bats` 2012/2023 ok — 실패 11건 전부 hermes 무관 (env-var 아티팩트 2 + pristine HEAD 재현 pre-existing 9)
- [x] 격리된 임시 HOME + 스텁으로 setup.sh 8개 시나리오 검증 (심링크 생성/멱등/백업/hard-fail/Part3-5/CA 폴백) — `api_key` 값이 어떤 출력에도 노출되지 않음, 심링크 detach로 시크릿이 `git diff`에 나타나지 않음을 실측 확인
- [ ] 실제 hermes-agent 설치 후 Part 4(agent-browser 경로 탐색)와 Part 5(CA 인증서 경로)를 실환경에서 재검증 — upstream 설치 레이아웃을 확신할 수 없어 방어적으로만 구현됨

## Related
Closes #1373

---
<details>
<summary>🤖 AI Metrics · 📊 ~12500 tokens · 👤 ~24 h · 🤖 ~35 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~12500 tokens · 👤 ~24 h · 🤖 ~35 min
<!-- /ai-metrics:gh-pr -->

</details>
