### PR TITLE
fix(gb): -D remote 삭제 후보에 브랜치 소유자 구분 추가

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -61,12 +61,13 @@ _gb_clean_remote() {
         emulate -L sh
     fi
 
-    local assume_yes=0 remote=""
+    local assume_yes=0 include_others=0 remote=""
 
     # Parse optional flags and an optional remote name (order-independent)
     while [ $# -gt 0 ]; do
         case "$1" in
             -y | --yes) assume_yes=1 ;;
+            --all) include_others=1 ;;
             -h | --help) _gb_help; return 0 ;;
             -*) ux_error "Unknown option: $1"; return 1 ;;
             *) remote="$1" ;;
@@ -84,48 +85,118 @@ _gb_clean_remote() {
     # Sync tracking refs with the server so the deletion list is accurate
     git fetch --prune "$remote" >/dev/null 2>&1 || true
 
-    # Build the deletable-branch list with a pure-shell loop: no per-line
-    # subprocess forks, and `case "$ref" in "$remote"/*)` matches the remote
-    # name *literally* — a remote whose name contains a regex metachar (e.g.
-    # '.') would mis-match under `grep "^$remote/"`. Emit short names (no
-    # "<remote>/" prefix) — that is what `git push --delete` wants. Branch
-    # names carry no whitespace, so `read`'s IFS-trimming of the "  origin/foo"
-    # indentation is safe, and the HEAD pointer line is skipped via " -> ".
-    local branches="" branch_count=0 ref b
-    while read -r ref; do
+    # Ownership check: a branch is "mine" when its tip commit's author email
+    # matches the local `git config user.email`. With no identity configured we
+    # cannot claim anything, so every branch falls into the "others" bucket and
+    # the safe default (delete nothing) applies.
+    local my_email=""
+    my_email=$(git config user.email 2>/dev/null) || my_email=""
+    if [ -z "$my_email" ]; then
+        ux_warning "git config user.email is unset — no branch can be identified as yours."
+    fi
+
+    # Build the deletable-branch lists with a pure-shell loop: one
+    # `git for-each-ref` call yields branch name *and* author email together —
+    # no per-branch subprocess forks. `case "$ref" in "$remote"/*)` matches the
+    # remote name *literally* — a remote whose name contains a regex metachar
+    # (e.g. '.') would mis-match under `grep "^$remote/"`. Emit short names (no
+    # "<remote>/" prefix) — that is what `git push --delete` wants.
+    # NOTE: unlike `git branch -r`, for-each-ref lists the symbolic
+    # refs/remotes/<remote>/HEAD as a plain "origin/HEAD <email>" line with no
+    # " -> " marker, so it must be skipped by name.
+    # `mine` holds one branch per line; `others` holds "<branch> <email>".
+    local mine="" others="" mine_count=0 other_count=0 ref email b
+    while read -r ref email; do
         [ -n "$ref" ] || continue
         case "$ref" in
-            *" -> "*) continue ;;
+            "$remote"/*) b="${ref#"$remote"/}" ;;
+            *) continue ;;
         esac
-        case "$ref" in
-            "$remote"/*)
-                b="${ref#"$remote"/}"
-                [ "$b" = "main" ] && continue
-                [ "$b" = "master" ] && continue
-                branch_count=$((branch_count + 1))
-                if [ -z "$branches" ]; then
-                    branches="$b"
-                else
-                    branches="${branches}
+        [ "$b" = "HEAD" ] && continue
+        [ "$b" = "main" ] && continue
+        [ "$b" = "master" ] && continue
+        # %(authoremail) renders as <user@example.com>
+        email="${email#<}"
+        email="${email%>}"
+        if [ -n "$my_email" ] && [ "$email" = "$my_email" ]; then
+            mine_count=$((mine_count + 1))
+            if [ -z "$mine" ]; then
+                mine="$b"
+            else
+                mine="${mine}
 ${b}"
-                fi
-                ;;
-        esac
+            fi
+        else
+            other_count=$((other_count + 1))
+            if [ -z "$others" ]; then
+                others="$b $email"
+            else
+                others="${others}
+${b} ${email}"
+            fi
+        fi
     done <<EOF
-$(git branch -r)
+$(git for-each-ref --format='%(refname:short) %(authoremail)' "refs/remotes/$remote")
 EOF
 
-    if [ "$branch_count" -eq 0 ]; then
+    if [ $((mine_count + other_count)) -eq 0 ]; then
         ux_info "No branches to delete on '$remote' (keeping main/master)"
         return 0
     fi
 
-    ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote':"
-    while IFS= read -r branch; do
-        [ -n "$branch" ] && ux_bullet_sub "$remote/$branch"
-    done <<EOF
-$branches
+    if [ "$mine_count" -eq 0 ] && [ "$include_others" -ne 1 ]; then
+        ux_info "No branches of yours to delete on '$remote' — skipped $other_count branch(es) owned by others (use --all to include them)."
+        return 0
+    fi
+
+    # Deletion target = mine, plus others only when --all was given
+    local branches="$mine" branch_count="$mine_count" line branch
+    if [ "$include_others" -eq 1 ] && [ "$other_count" -gt 0 ]; then
+        while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            b="${line%% *}"
+            if [ -z "$branches" ]; then
+                branches="$b"
+            else
+                branches="${branches}
+${b}"
+            fi
+            branch_count=$((branch_count + 1))
+        done <<EOF
+$others
 EOF
+    fi
+
+    if [ "$include_others" -eq 1 ] && [ "$other_count" -gt 0 ]; then
+        ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote', including OTHER PEOPLE'S branches:"
+    else
+        ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote':"
+    fi
+
+    if [ "$mine_count" -gt 0 ]; then
+        ux_bullet "Your branches ($mine_count) — will be deleted:"
+        while IFS= read -r branch; do
+            [ -n "$branch" ] && ux_bullet_sub "$remote/$branch"
+        done <<EOF
+$mine
+EOF
+    fi
+
+    if [ "$other_count" -gt 0 ]; then
+        if [ "$include_others" -eq 1 ]; then
+            ux_bullet "Other's branches ($other_count) — will ALSO be deleted (--all):"
+        else
+            ux_bullet "Other's branches ($other_count) — skipped (use --all to include):"
+        fi
+        while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            b="${line%% *}"
+            email="${line#* }"
+            ux_bullet_sub "$remote/$b (author: $email)"
+        done <<EOF
+$others
+EOF
+    fi
 
     if [ "$assume_yes" -ne 1 ]; then
         if ! ux_confirm "Permanently delete these remote branches?"; then
@@ -157,13 +228,14 @@ EOF
 }
 
 _gb_help() {
-    ux_info "Usage: gb [-D local] [-D remote [-y] [<remote>]] [git-branch-flags...]"
+    ux_info "Usage: gb [-D local] [-D remote [-y] [--all] [<remote>]] [git-branch-flags...]"
     ux_bullet "sub-commands"
-    ux_bullet_sub "gb -D local                          delete local branches (keeps: main + current + keywords)"
-    ux_bullet_sub "gb -D remote [-y] [<remote>]         delete branches on the remote SERVER (default: origin, e.g. origin, upstream, keeps: main/master)"
-    ux_bullet_sub "gb [flags]                           passthrough to git --no-pager branch"
+    ux_bullet_sub "gb -D local                              delete local branches (keeps: main + current + keywords)"
+    ux_bullet_sub "gb -D remote [-y] [--all] [<remote>]     delete YOUR OWN branches on the remote SERVER (default: origin, e.g. origin, upstream, keeps: main/master; others' branches are listed but skipped unless --all)"
+    ux_bullet_sub "gb [flags]                               passthrough to git --no-pager branch"
     ux_bullet "options"
     ux_bullet_sub "-y, --yes                 skip the confirmation prompt (remote deletion is permanent)"
+    ux_bullet_sub "    --all                 also delete branches authored by other people (default: your own only, matched by git config user.email)"
 }
 
 git_branch() {

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -104,7 +104,11 @@ _gb_clean_remote() {
     # NOTE: unlike `git branch -r`, for-each-ref lists the symbolic
     # refs/remotes/<remote>/HEAD as a plain "origin/HEAD <email>" line with no
     # " -> " marker, so it must be skipped by name.
-    # `mine` holds one branch per line; `others` holds "<branch> <email>".
+    # `mine` holds one branch per line; `others` holds "<branch> <email>". Both
+    # accumulate with a leading newline (harmless — stripped once below) so the
+    # append site needs no is-this-the-first-line branch.
+    local nl="
+"
     local mine="" others="" mine_count=0 other_count=0 ref email b
     while read -r ref email; do
         [ -n "$ref" ] || continue
@@ -120,24 +124,16 @@ _gb_clean_remote() {
         email="${email%>}"
         if [ -n "$my_email" ] && [ "$email" = "$my_email" ]; then
             mine_count=$((mine_count + 1))
-            if [ -z "$mine" ]; then
-                mine="$b"
-            else
-                mine="${mine}
-${b}"
-            fi
+            mine="${mine}${nl}${b}"
         else
             other_count=$((other_count + 1))
-            if [ -z "$others" ]; then
-                others="$b $email"
-            else
-                others="${others}
-${b} ${email}"
-            fi
+            others="${others}${nl}${b} ${email}"
         fi
     done <<EOF
 $(git for-each-ref --format='%(refname:short) %(authoremail)' "refs/remotes/$remote")
 EOF
+    mine="${mine#"$nl"}"
+    others="${others#"$nl"}"
 
     if [ $((mine_count + other_count)) -eq 0 ]; then
         ux_info "No branches to delete on '$remote' (keeping main/master)"
@@ -150,28 +146,23 @@ EOF
     fi
 
     # Deletion target = mine, plus others only when --all was given
-    local branches="$mine" branch_count="$mine_count" line branch
-    if [ "$include_others" -eq 1 ] && [ "$other_count" -gt 0 ]; then
+    local include_all_others=0 branches="$mine" branch_count="$mine_count" line branch
+    [ "$include_others" -eq 1 ] && [ "$other_count" -gt 0 ] && include_all_others=1
+    if [ "$include_all_others" -eq 1 ]; then
+        branch_count=$((mine_count + other_count))
         while IFS= read -r line; do
             [ -n "$line" ] || continue
             b="${line%% *}"
-            if [ -z "$branches" ]; then
-                branches="$b"
-            else
-                branches="${branches}
-${b}"
-            fi
-            branch_count=$((branch_count + 1))
+            branches="${branches}${nl}${b}"
         done <<EOF
 $others
 EOF
+        branches="${branches#"$nl"}"
     fi
 
-    if [ "$include_others" -eq 1 ] && [ "$other_count" -gt 0 ]; then
-        ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote', including OTHER PEOPLE'S branches:"
-    else
-        ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote':"
-    fi
+    local warn_suffix=""
+    [ "$include_all_others" -eq 1 ] && warn_suffix=", including OTHER PEOPLE'S branches"
+    ux_warning "About to PERMANENTLY DELETE $branch_count branch(es) on remote '$remote'$warn_suffix:"
 
     if [ "$mine_count" -gt 0 ]; then
         ux_bullet "Your branches ($mine_count) — will be deleted:"
@@ -183,11 +174,9 @@ EOF
     fi
 
     if [ "$other_count" -gt 0 ]; then
-        if [ "$include_others" -eq 1 ]; then
-            ux_bullet "Other's branches ($other_count) — will ALSO be deleted (--all):"
-        else
-            ux_bullet "Other's branches ($other_count) — skipped (use --all to include):"
-        fi
+        local others_label="Other's branches ($other_count) — skipped (use --all to include):"
+        [ "$include_all_others" -eq 1 ] && others_label="Other's branches ($other_count) — will ALSO be deleted (--all):"
+        ux_bullet "$others_label"
         while IFS= read -r line; do
             [ -n "$line" ] || continue
             b="${line%% *}"

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -174,8 +174,8 @@ EOF
     fi
 
     if [ "$other_count" -gt 0 ]; then
-        local others_label="Other's branches ($other_count) — skipped (use --all to include):"
-        [ "$include_all_others" -eq 1 ] && others_label="Other's branches ($other_count) — will ALSO be deleted (--all):"
+        local others_label="Others' branches ($other_count) — skipped (use --all to include):"
+        [ "$include_all_others" -eq 1 ] && others_label="Others' branches ($other_count) — will ALSO be deleted (--all):"
         ux_bullet "$others_label"
         while IFS= read -r line; do
             [ -n "$line" ] || continue

--- a/tests/bats/functions/git.bats
+++ b/tests/bats/functions/git.bats
@@ -97,6 +97,109 @@ teardown() {
     assert_output --partial "No branches to delete"
 }
 
+@test "bash: gb -D remote deletes only my branches by default when authors differ" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email mine@t; git config user.name mine
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git checkout -q -b mine-branch
+        git commit -q --allow-empty -m mine
+        git push -q origin HEAD:mine-branch
+        git config user.email other@t; git config user.name other
+        git checkout -q -b other-branch main
+        git commit -q --allow-empty -m other
+        git push -q origin HEAD:other-branch
+        git config user.email mine@t; git config user.name mine
+        _gb_clean_remote -y origin >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "other-branch"
+    refute_output --partial "mine-branch"
+}
+
+@test "bash: gb -D remote --all deletes other people's branches too" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email mine@t; git config user.name mine
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git checkout -q -b mine-branch
+        git commit -q --allow-empty -m mine
+        git push -q origin HEAD:mine-branch
+        git config user.email other@t; git config user.name other
+        git checkout -q -b other-branch main
+        git commit -q --allow-empty -m other
+        git push -q origin HEAD:other-branch
+        git config user.email mine@t; git config user.name mine
+        _gb_clean_remote --all -y origin >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "REMAINING: main"
+    refute_output --partial "mine-branch"
+    refute_output --partial "other-branch"
+}
+
+@test "bash: gb -D remote skips without prompting when nothing is mine" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email other@t; git config user.name other
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git checkout -q -b other-branch
+        git commit -q --allow-empty -m other
+        git push -q origin HEAD:other-branch
+        git config user.email third@t; git config user.name third
+        _gb_clean_remote origin </dev/null
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "No branches of yours to delete"
+    assert_output --partial "REMAINING: main other-branch"
+}
+
+@test "bash: gb -D remote deletes nothing and warns when user.email is unset" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:some-branch
+        git config --unset user.email
+        GIT_AUTHOR_EMAIL= GIT_COMMITTER_EMAIL= EMAIL= _gb_clean_remote origin </dev/null
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "user.email is unset"
+    assert_output --partial "REMAINING: main some-branch"
+}
+
 @test "bash: gb -D <remote-name> hints 'gb -D remote' instead of failing silently" {
     run_in_bash '
         tmp=$(mktemp -d)

--- a/tests/bats/functions/git.bats
+++ b/tests/bats/functions/git.bats
@@ -200,6 +200,109 @@ teardown() {
     assert_output --partial "REMAINING: main some-branch"
 }
 
+@test "zsh: gb -D remote deletes only my branches by default when authors differ" {
+    run_in_zsh '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email mine@t; git config user.name mine
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git checkout -q -b mine-branch
+        git commit -q --allow-empty -m mine
+        git push -q origin HEAD:mine-branch
+        git config user.email other@t; git config user.name other
+        git checkout -q -b other-branch main
+        git commit -q --allow-empty -m other
+        git push -q origin HEAD:other-branch
+        git config user.email mine@t; git config user.name mine
+        _gb_clean_remote -y origin >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "other-branch"
+    refute_output --partial "mine-branch"
+}
+
+@test "zsh: gb -D remote --all deletes other people's branches too" {
+    run_in_zsh '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email mine@t; git config user.name mine
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git checkout -q -b mine-branch
+        git commit -q --allow-empty -m mine
+        git push -q origin HEAD:mine-branch
+        git config user.email other@t; git config user.name other
+        git checkout -q -b other-branch main
+        git commit -q --allow-empty -m other
+        git push -q origin HEAD:other-branch
+        git config user.email mine@t; git config user.name mine
+        _gb_clean_remote --all -y origin >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "REMAINING: main"
+    refute_output --partial "mine-branch"
+    refute_output --partial "other-branch"
+}
+
+@test "zsh: gb -D remote skips without prompting when nothing is mine" {
+    run_in_zsh '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email other@t; git config user.name other
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git checkout -q -b other-branch
+        git commit -q --allow-empty -m other
+        git push -q origin HEAD:other-branch
+        git config user.email third@t; git config user.name third
+        _gb_clean_remote origin </dev/null
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "No branches of yours to delete"
+    assert_output --partial "REMAINING: main other-branch"
+}
+
+@test "zsh: gb -D remote deletes nothing and warns when user.email is unset" {
+    run_in_zsh '
+        tmp=$(mktemp -d)
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:some-branch
+        git config --unset user.email
+        GIT_AUTHOR_EMAIL= GIT_COMMITTER_EMAIL= EMAIL= _gb_clean_remote origin </dev/null
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        echo
+        rm -rf "$tmp"
+    '
+    assert_success
+    assert_output --partial "user.email is unset"
+    assert_output --partial "REMAINING: main some-branch"
+}
+
 @test "bash: gb -D <remote-name> hints 'gb -D remote' instead of failing silently" {
     run_in_bash '
         tmp=$(mktemp -d)


### PR DESCRIPTION
## Summary
- `gb -D remote`가 브랜치 소유자를 구분하지 않고 원격의 모든 non-main 브랜치를 삭제 후보로 삼던 문제를 수정
- 기본 동작은 이제 `git config user.email`과 일치하는 "내 브랜치"만 삭제하고, 남의 브랜치는 목록에는 보여주되 건너뜀
- 전체 삭제가 필요하면 새 `--all` 플래그로 명시적으로 옵트인

## Changes
- `shell-common/functions/git.sh`: `_gb_clean_remote`가 `git for-each-ref`(단일 호출)로 브랜치명+author email을 동시에 조회해 mine/others로 분리. `--all` 플래그 추가, `_gb_help` 갱신, `user.email` 미설정 시 안전 폴백(경고 후 아무것도 삭제 안 함).
- `tests/bats/functions/git.bats`: 소유자 구분 기본 동작 / `--all` / 내 브랜치 없음(스킵) / `user.email` 미설정 케이스 4개 추가. 기존 5개 테스트는 그대로 통과.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/git.bats` — 26/26 ok
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions` — 981 tests, 회귀 없음
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/git.sh` — clean

## Related
Closes #1387

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
