### PR TITLE
fix(issue-watcher): 재부트스트랩 직후 dispatch stall 경합 해소

### DIFF
--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -290,17 +290,29 @@ _iw_agent_status() {
 # the 5-minute tick interval, and hitting the cap still dispatches because the
 # stall retry in _iw_dispatch is the second line of defence.
 _iw_wait_for_idle() {
-    local _i=0 _status
+    local _i=0 _status _get_failed=0
 
     while [ "${_i}" -lt 10 ]; do
-        _status=$(_iw_agent_status) || _status=""
-        [ "${_status}" != "idle" ] || return 0
+        if _status=$(_iw_agent_status); then
+            [ "${_status}" != "idle" ] || return 0
+        else
+            _status=""
+            _get_failed=$((_get_failed + 1))
+        fi
         _i=$((_i + 1))
         [ "${_i}" -lt 10 ] || break
         sleep 0.5
     done
 
-    ux_warning "Agent ${_IW_AGENT_NAME} did not report idle within ~5s — dispatching anyway."
+    # Health-check failures (agent missing / pane closed) and a merely slow
+    # `starting` pane both fall through to this warning today — surface the
+    # failure count so a genuinely-gone agent doesn't read as "just slow"
+    # (PR #1400 codex review).
+    if [ "${_get_failed}" -gt 0 ]; then
+        ux_warning "Agent ${_IW_AGENT_NAME} did not report idle within ~5s (${_get_failed}/10 health-check failures) — dispatching anyway."
+    else
+        ux_warning "Agent ${_IW_AGENT_NAME} did not report idle within ~5s — dispatching anyway."
+    fi
 }
 
 # Echo herdr's JSON response on stdout; the exit code is herdr's own.
@@ -310,7 +322,7 @@ _iw_prompt_once() {
 }
 
 _iw_dispatch() {
-    local _json _code _rc=0
+    local _json _code _rc=0 _post_stall_status
 
     _json=$(_iw_prompt_once) || _rc=$?
 
@@ -321,10 +333,22 @@ _iw_dispatch() {
     if [ "${_rc}" -ne 0 ]; then
         _code=$(printf '%s' "${_json}" | _iw_json_value '.error.code')
         if [ "${_code}" = "agent_prompt_stalled" ]; then
-            ux_warning "herdr reported agent_prompt_stalled — retrying once."
-            sleep 1
-            _rc=0
-            _json=$(_iw_prompt_once) || _rc=$?
+            # `agent_prompt_stalled` only proves herdr saw no state change
+            # within its fixed 5s window — it does NOT prove the prompt was
+            # never submitted (PR #1400 codex review). `working` is positive
+            # evidence the first call *did* land, so retrying would type the
+            # same dispatcher text into an already-busy pane; any other
+            # status gives no such evidence, so the retry proceeds as before.
+            _post_stall_status=$(_iw_agent_status) || _post_stall_status=""
+            if [ "${_post_stall_status}" = "working" ]; then
+                ux_warning "herdr reported agent_prompt_stalled but agent is already working — treating as delivered, not retrying."
+                _rc=0
+            else
+                ux_warning "herdr reported agent_prompt_stalled — retrying once."
+                sleep 1
+                _rc=0
+                _json=$(_iw_prompt_once) || _rc=$?
+            fi
         fi
     fi
 

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -286,17 +286,18 @@ _iw_agent_status() {
 # dispatcher text is typed but never submitted and herdr's fixed 5s stall check
 # fires `agent_prompt_stalled` (issue #1399). The first-bootstrap path gets this
 # grace for free from the status query that follows it; this gives the
-# re-bootstrap path the same. Capped at ~5s (10 x 0.5s): far below the 5-minute
-# tick interval, and hitting the cap still dispatches because the stall retry in
-# _iw_dispatch is the second line of defence.
+# re-bootstrap path the same. Capped at ~5s (10 checks, 0.5s apart): far below
+# the 5-minute tick interval, and hitting the cap still dispatches because the
+# stall retry in _iw_dispatch is the second line of defence.
 _iw_wait_for_idle() {
     local _i=0 _status
 
     while [ "${_i}" -lt 10 ]; do
         _status=$(_iw_agent_status) || _status=""
         [ "${_status}" != "idle" ] || return 0
-        sleep 0.5
         _i=$((_i + 1))
+        [ "${_i}" -lt 10 ] || break
+        sleep 0.5
     done
 
     ux_warning "Agent ${_IW_AGENT_NAME} did not report idle within ~5s — dispatching anyway."

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -280,9 +280,54 @@ _iw_agent_status() {
     printf '%s' "${_json}" | _iw_json_value '.result.agent.agent_status'
 }
 
+# Wait for a freshly (re-)bootstrapped agent to report idle before prompting it.
+# `herdr agent start` only confirms the pane looks interactive — a claude process
+# can have drawn its prompt box before its key-input loop accepts Enter, so the
+# dispatcher text is typed but never submitted and herdr's fixed 5s stall check
+# fires `agent_prompt_stalled` (issue #1399). The first-bootstrap path gets this
+# grace for free from the status query that follows it; this gives the
+# re-bootstrap path the same. Capped at ~5s (10 x 0.5s): far below the 5-minute
+# tick interval, and hitting the cap still dispatches because the stall retry in
+# _iw_dispatch is the second line of defence.
+_iw_wait_for_idle() {
+    local _i=0 _status
+
+    while [ "${_i}" -lt 10 ]; do
+        _status=$(_iw_agent_status) || _status=""
+        [ "${_status}" != "idle" ] || return 0
+        sleep 0.5
+        _i=$((_i + 1))
+    done
+
+    ux_warning "Agent ${_IW_AGENT_NAME} did not report idle within ~5s — dispatching anyway."
+}
+
+# Echo herdr's JSON response on stdout; the exit code is herdr's own.
+_iw_prompt_once() {
+    herdr agent prompt "${_IW_AGENT_NAME}" "${_IW_PROMPT}" \
+        --wait --timeout "${_IW_TIMEOUT_MS}" 2>/dev/null
+}
+
 _iw_dispatch() {
-    if herdr agent prompt "${_IW_AGENT_NAME}" "${_IW_PROMPT}" \
-        --wait --timeout "${_IW_TIMEOUT_MS}" >/dev/null 2>&1; then
+    local _json _code _rc=0
+
+    _json=$(_iw_prompt_once) || _rc=$?
+
+    # Only `agent_prompt_stalled` is retried: it means the keystroke was dropped
+    # by a not-yet-ready input loop (issue #1399), which a second later is gone.
+    # Every other error is a real failure and must not be re-sent — a duplicate
+    # prompt would start a second dispatcher cycle.
+    if [ "${_rc}" -ne 0 ]; then
+        _code=$(printf '%s' "${_json}" | _iw_json_value '.error.code')
+        if [ "${_code}" = "agent_prompt_stalled" ]; then
+            ux_warning "herdr reported agent_prompt_stalled — retrying once."
+            sleep 1
+            _rc=0
+            _json=$(_iw_prompt_once) || _rc=$?
+        fi
+    fi
+
+    if [ "${_rc}" -eq 0 ]; then
         ux_success "Dispatched to ${_IW_AGENT_NAME}: ${_IW_PROMPT}"
         return 0
     fi
@@ -415,6 +460,7 @@ main() {
     *)
         ux_warning "Agent ${_IW_AGENT_NAME} unreachable (status: ${_status:-none}) — stale state, re-bootstrapping."
         _iw_bootstrap "${_cwd}" || exit 1
+        _iw_wait_for_idle
         _iw_dispatch || exit 1
         ;;
     esac

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -691,6 +691,38 @@ _hold_lock() {
     [ "$(_log_count 'agent prompt')" -eq 1 ]
 }
 
+@test "issue_watcher_cron: agent_prompt_stalled retry is skipped when the agent is already working" {
+    _install_herdr_stub
+
+    # Call 1 (main()'s idle|done check) reports idle, so dispatch is attempted.
+    # HERDR_PROMPT_MODE=stall makes the first `agent prompt` stall; call 2 is
+    # the pre-retry status check this fixes — it reports `working`, meaning
+    # the stalled call actually landed, so no second prompt should be sent
+    # (PR #1400 codex review: `agent_prompt_stalled` alone doesn't prove the
+    # keystroke was dropped).
+    _run_tick HERDR_AGENT_GET_SEQ="idle working" HERDR_PROMPT_MODE=stall
+    assert_success
+    assert_output --partial "already working"
+    refute_output --partial "retrying once"
+
+    [ "$(_log_count 'agent get')" -eq 2 ]
+    [ "$(_log_count 'agent prompt')" -eq 1 ]
+}
+
+@test "issue_watcher_cron: the idle-poll give-up warning reports health-check failure count" {
+    _install_herdr_stub
+    mkdir -p "${_STATE_DIR}"
+    printf '{ "workspace_id": "ws-stale", "pane_id": "ws-stale:p9", "agent_name": "iw-watch" }\n' \
+        >"${_STATE_FILE}"
+
+    # Every poll call (including the stale-state probe) reports agent_not_found:
+    # a genuinely gone agent, not merely a slow one.
+    _run_tick HERDR_AGENT_GET_SEQ="fail"
+    assert_success
+    assert_output --partial "did not report idle"
+    assert_output --partial "10/10 health-check failures"
+}
+
 @test "issue_watcher_cron: a stall on the retry falls through to the failure path" {
     _install_herdr_stub
 

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -54,10 +54,28 @@ teardown() {
 #   HERDR_AGENT_STATUS      status reported by `agent get` (default: idle)
 #   HERDR_AGENT_GET_FAIL=1  `agent get` returns the real agent_not_found error
 #                           payload and exits 1 (agent missing / pane closed)
+#   HERDR_AGENT_GET_SEQ     space-separated per-call `agent get` script, one
+#                           word consumed per invocation, last word repeating.
+#                           `fail` = agent_not_found + exit 1; anything else is
+#                           reported as that agent_status. Used to prove the
+#                           post-re-bootstrap idle poll really polls (#1399).
+#   HERDR_PROMPT_MODE       `agent prompt` behaviour (default: always ok)
+#                             stall-once  first call agent_prompt_stalled, rest ok
+#                             stall       every call agent_prompt_stalled
+#                             fail        every call a non-stall error
+# Each herdr invocation is a fresh process, so the per-call sequences count
+# through marker files next to ${HERDR_LOG} rather than through shell state.
 _install_herdr_stub() {
     cat >"${_BIN_DIR}/herdr" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$*" >>"${HERDR_LOG}"
+
+_bump() {
+    _n=$(cat "$1" 2>/dev/null || printf 0)
+    _n=$((_n + 1))
+    printf '%s' "${_n}" >"$1"
+}
+
 case "$1 $2" in
 "workspace create")
     printf '%s\n' '{"id":"cli:workspace:create","result":{"workspace":{"workspace_id":"ws-test-1"},"root_pane":{"pane_id":"ws-test-1:p1"}}}'
@@ -66,6 +84,20 @@ case "$1 $2" in
     printf '%s\n' '{"id":"cli:agent:start","result":{"agent":{"agent_status":"idle","pane_id":"ws-test-1:p1"}}}'
     ;;
 "agent get")
+    if [ -n "${HERDR_AGENT_GET_SEQ:-}" ]; then
+        _bump "${HERDR_LOG}.getcount"
+        # Word-splitting is the point: the sequence is a list of responses.
+        # shellcheck disable=SC2086
+        set -- ${HERDR_AGENT_GET_SEQ}
+        [ "${_n}" -le "$#" ] || _n=$#
+        eval "_resp=\${${_n}}"
+        if [ "${_resp}" = "fail" ]; then
+            printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target iw-watch not found"},"id":"cli:agent:get"}'
+            exit 1
+        fi
+        printf '{"id":"cli:agent:get","result":{"agent":{"agent_status":"%s"}}}\n' "${_resp}"
+        exit 0
+    fi
     if [ "${HERDR_AGENT_GET_FAIL:-0}" = "1" ]; then
         printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target iw-watch not found"},"id":"cli:agent:get"}'
         exit 1
@@ -73,6 +105,23 @@ case "$1 $2" in
     printf '{"id":"cli:agent:get","result":{"agent":{"agent_status":"%s"}}}\n' "${HERDR_AGENT_STATUS:-idle}"
     ;;
 "agent prompt")
+    case "${HERDR_PROMPT_MODE:-ok}" in
+    stall-once)
+        _bump "${HERDR_LOG}.promptcount"
+        if [ "${_n}" = "1" ]; then
+            printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}'
+            exit 1
+        fi
+        ;;
+    stall)
+        printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}'
+        exit 1
+        ;;
+    fail)
+        printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target iw-watch not found"},"id":"cli:agent:prompt"}'
+        exit 1
+        ;;
+    esac
     printf '%s\n' '{"id":"cli:agent:prompt","result":{"ok":true}}'
     ;;
 esac
@@ -573,6 +622,96 @@ _hold_lock() {
     run cat "${_STATE_FILE}"
     assert_output --partial '"workspace_id": "ws-test-1"'
     refute_output --partial "ws-stale"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch readiness after a re-bootstrap (issue #1399)
+#
+# A freshly started claude can render its prompt box before its key-input loop
+# accepts Enter; prompting into that gap loses the submission and herdr fails
+# the tick with `agent_prompt_stalled`. Two guards: poll for idle after the
+# re-bootstrap, and retry that one error class once.
+# ---------------------------------------------------------------------------
+
+@test "issue_watcher_cron: re-bootstrap polls for idle before dispatching" {
+    _install_herdr_stub
+    mkdir -p "${_STATE_DIR}"
+    printf '{ "workspace_id": "ws-stale", "pane_id": "ws-stale:p9", "agent_name": "iw-watch" }\n' \
+        >"${_STATE_FILE}"
+
+    # Call 1 is the stale-state probe that triggers the re-bootstrap; the poll
+    # that follows must keep asking until the agent stops being `starting`.
+    _run_tick HERDR_AGENT_GET_SEQ="fail starting starting idle"
+    assert_success
+
+    [ "$(_log_count 'agent get')" -eq 4 ]
+    [ "$(_log_count 'agent prompt')" -eq 1 ]
+
+    # The prompt is last: every status query happened before the dispatch.
+    run tail -n 1 "${_LOG}"
+    assert_output --partial "agent prompt iw-watch"
+}
+
+@test "issue_watcher_cron: the idle poll gives up after its cap and still dispatches" {
+    _install_herdr_stub
+    mkdir -p "${_STATE_DIR}"
+    printf '{ "workspace_id": "ws-stale", "pane_id": "ws-stale:p9", "agent_name": "iw-watch" }\n' \
+        >"${_STATE_FILE}"
+
+    # Never idle: the tick must not newly fail over a slow pane.
+    _run_tick HERDR_AGENT_GET_SEQ="fail starting"
+    assert_success
+    assert_output --partial "did not report idle"
+
+    [ "$(_log_count 'agent get')" -eq 11 ]
+    run grep -F -- "agent prompt iw-watch" "${_LOG}"
+    assert_success
+}
+
+@test "issue_watcher_cron: agent_prompt_stalled is retried once and then succeeds" {
+    _install_herdr_stub
+
+    _run_tick HERDR_PROMPT_MODE=stall-once
+    assert_success
+    assert_output --partial "agent_prompt_stalled"
+
+    [ "$(_log_count 'agent prompt')" -eq 2 ]
+}
+
+@test "issue_watcher_cron: a non-stall prompt failure is not retried" {
+    _install_herdr_stub
+
+    _run_tick HERDR_PROMPT_MODE=fail
+    assert_failure
+    assert_output --partial "herdr agent prompt failed"
+    refute_output --partial "retrying once"
+
+    [ "$(_log_count 'agent prompt')" -eq 1 ]
+}
+
+@test "issue_watcher_cron: a stall on the retry falls through to the failure path" {
+    _install_herdr_stub
+
+    _run_tick HERDR_PROMPT_MODE=stall
+    assert_failure
+    assert_output --partial "herdr agent prompt failed"
+
+    # Exactly one retry — never a loop.
+    [ "$(_log_count 'agent prompt')" -eq 2 ]
+}
+
+@test "issue_watcher_cron: a reused idle agent is dispatched without an extra poll" {
+    _install_herdr_stub
+    _run_tick
+    assert_success
+
+    : >"${_LOG}"
+    _run_tick
+    assert_success
+
+    # The reuse path is unchanged by #1399: one status query, then the prompt.
+    [ "$(_log_count 'agent get')" -eq 1 ]
+    [ "$(_log_count 'agent prompt')" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -74,6 +74,7 @@ _bump() {
     _n=$(cat "$1" 2>/dev/null || printf 0)
     _n=$((_n + 1))
     printf '%s' "${_n}" >"$1"
+    printf '%s' "${_n}"
 }
 
 case "$1 $2" in
@@ -85,12 +86,13 @@ case "$1 $2" in
     ;;
 "agent get")
     if [ -n "${HERDR_AGENT_GET_SEQ:-}" ]; then
-        _bump "${HERDR_LOG}.getcount"
+        _n=$(_bump "${HERDR_LOG}.getcount")
         # Word-splitting is the point: the sequence is a list of responses.
         # shellcheck disable=SC2086
         set -- ${HERDR_AGENT_GET_SEQ}
         [ "${_n}" -le "$#" ] || _n=$#
-        eval "_resp=\${${_n}}"
+        shift "$((_n - 1))"
+        _resp="$1"
         if [ "${_resp}" = "fail" ]; then
             printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target iw-watch not found"},"id":"cli:agent:get"}'
             exit 1
@@ -107,7 +109,7 @@ case "$1 $2" in
 "agent prompt")
     case "${HERDR_PROMPT_MODE:-ok}" in
     stall-once)
-        _bump "${HERDR_LOG}.promptcount"
+        _n=$(_bump "${HERDR_LOG}.promptcount")
         if [ "${_n}" = "1" ]; then
             printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}'
             exit 1


### PR DESCRIPTION
## Summary
- 재부트스트랩 분기가 idle 상태를 확인하지 않고 곧바로 dispatch해 herdr의 내부 고정 5초 stall 체크에 걸려 `agent_prompt_stalled`로 실패하던 경합을 해소한다.
- idle 폴링 버퍼(`_iw_wait_for_idle`, ~5초 상한)와 dispatch 1회 재시도를 조합해 두 겹으로 방어한다.

## Changes
- `shell-common/tools/custom/issue_watcher_cron.sh`: `_iw_wait_for_idle` 추가(재부트스트랩 후 idle 대기), `_iw_dispatch`가 herdr 응답의 `.error.code`를 읽어 `agent_prompt_stalled`만 감지해 1회 재시도하도록 수정, `main()`의 재부트스트랩(`*)`) 분기에 폴링 단계 삽입.
- `tests/bats/tools/issue_watcher_cron.bats`: herdr 스텁에 `HERDR_AGENT_GET_SEQ`/`HERDR_PROMPT_MODE` 마커 파일 기반 모드를 추가하고, idle 폴링·폴링 상한 초과 후에도 dispatch·stall 1회 재시도 성공·비-stall 실패는 무재시도·재시도에서도 stall 지속 5개 회귀 테스트와 재사용 경로 가드 1개를 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/issue_watcher_cron.bats` — 46 passed, 0 failed (기존 40 + 신규 6)
- [x] `bash -n shell-common/tools/custom/issue_watcher_cron.sh`
- [x] `shellcheck shell-common/tools/custom/issue_watcher_cron.sh` — clean

## Related
Closes #1399

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
