### PR TITLE
test(bats): 비실행 chrome.exe 케이스에 출력 단언을 짝짓는다

### DIFF
--- a/tests/bats/functions/windows_chrome.bats
+++ b/tests/bats/functions/windows_chrome.bats
@@ -140,10 +140,8 @@ _stub_exe() {
     mkdir -p "$(dirname "$exe")"
     : > "$exe"
     _helper_bash '_windows_chrome_exe'
+    # A missing helper exits 127, which assert_failure alone accepts (#1419).
     assert_failure
-    # Pair the status assertion with an output one (as at the two
-    # assert_failure cases above): a missing helper makes the call exit 127
-    # with a "command not found" message, which assert_failure alone accepts.
     assert_output ""
 }
 

--- a/tests/bats/functions/windows_chrome.bats
+++ b/tests/bats/functions/windows_chrome.bats
@@ -141,6 +141,10 @@ _stub_exe() {
     : > "$exe"
     _helper_bash '_windows_chrome_exe'
     assert_failure
+    # Pair the status assertion with an output one (as at the two
+    # assert_failure cases above): a missing helper makes the call exit 127
+    # with a "command not found" message, which assert_failure alone accepts.
+    assert_output ""
 }
 
 # --- cross-shell ---------------------------------------------------

--- a/tests/bats/functions/windows_chrome.bats
+++ b/tests/bats/functions/windows_chrome.bats
@@ -140,8 +140,10 @@ _stub_exe() {
     mkdir -p "$(dirname "$exe")"
     : > "$exe"
     _helper_bash '_windows_chrome_exe'
-    # A missing helper exits 127, which assert_failure alone accepts (#1419).
-    assert_failure
+    # A missing helper exits 127, which a bare assert_failure accepts (#1419).
+    # _windows_chrome_exe returns 1 on every failure path, so pin the status
+    # and the silence the test name promises.
+    assert_failure 1
     assert_output ""
 }
 


### PR DESCRIPTION
## Summary
- `tests/bats/functions/windows_chrome.bats` 의 `_windows_chrome_exe: ignores a non-executable chrome.exe` 는 단언이 `assert_failure` 하나뿐이라 헬퍼(`shell-common/functions/windows_chrome.sh`)가 아예 없어도 통과했다.
- 헬퍼가 없으면 하네스의 `. "$HELPER"` 가 실패하고 함수가 정의되지 않아 bash 가 `command not found` 로 rc=127 을 돌려주는데, 이것도 `assert_failure` 를 만족한다. 즉 "비실행 후보를 올바르게 거부했다" 와 "함수가 없다" 를 구별하지 못했다.
- 같은 파일의 나머지 두 `assert_failure` 케이스(line 95, 134)가 이미 쓰고 있는 형태대로 `assert_output ""` 를 짝지어 그 구별을 복원했다.

## Changes
- `tests/bats/functions/windows_chrome.bats`: 문제 케이스에 `assert_output ""` 추가 + 왜 상태 단언만으로는 부족한지 설명하는 주석 3줄. 프로덕션 코드 변경 없음.

## Test plan
- [x] 헬퍼를 없앤 조건에서 스위트 재실행 → 14건 전부 실패 (수정 전에는 이 1건이 통과)
- [x] 정상 트리에서 `windows_chrome.bats` 14/14 통과 유지
- [x] pre-commit 훅 통과 · Step 4.5 lint guard 통과

검증 방법: 스위트의 `HELPER` 를 존재하지 않는 경로로 돌린 사본을 만들어 이슈가 기술한 "수정 이전 트리" 조건을 그대로 재현했다. 수정 전에는 해당 케이스가 `ok` 로 나오면서 bats 가 `exited with code 127, indicating 'Command not found'` (BW01) 경고를 같이 찍었고, 수정 후에는 14/14 가 모두 `not ok` 가 된다.

## Related
Closes #1419

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
