### PR TITLE
test(issue-watcher): 게이트 부재와 구별되지 않던 단언 3건에 양성 대조를 붙인다

### DIFF
--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1943,6 +1943,25 @@ _two_repo_fixture() {
     [ ! -f "${_LIMIT_FILE}" ]
 }
 
+@test "issue_watcher_cron: repeated non-quota failures never close a gate holding a strike" {
+    mkdir -p "${_STATE_DIR}"
+    printf '{ "strikes": "1", "backoff_until": "0" }\n' >"${_LIMIT_FILE}"
+    _run_tick "HERDR_PROMPT_MODE=fail"
+    assert_failure
+    assert_output --partial "not a token-limit signature"
+    _set_issues '[{"number":12,"repository":{"nameWithOwner":"acme/dotfiles"},"labels":[]}]'
+    _run_tick "HERDR_PROMPT_MODE=fail"
+    assert_failure
+    # PR #1462 codex FOLLOW-UP: a strike already on record is the state where a
+    # miscounted non-quota failure tips the gate shut — one more reaches
+    # _IW_LIMIT_STRIKES. The clean-state sibling above cannot reach that edge,
+    # so the dirty start is the case that actually pins the classification.
+    assert_output --partial "not a token-limit signature"
+    refute_output --partial "Rate-limit gate closed"
+    run cat "${_LIMIT_FILE}"
+    assert_output --partial '"strikes": "1"'
+}
+
 @test "issue_watcher_cron: a gate that shuts mid-cycle stops the remaining issues" {
     _set_issues '[
       {"number":11,"repository":{"nameWithOwner":"acme/dotfiles"},"labels":[]},

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1922,10 +1922,8 @@ _two_repo_fixture() {
     printf '{ "strikes": "1", "backoff_until": "0" }\n' >"${_LIMIT_FILE}"
     _run_tick "HERDR_PROMPT_MODE=fail"
     assert_failure
-    # Positive control (issue #1442) — asserted before `run cat` replaces
-    # $output. The strike count standing still proves the gate classified the
-    # failure only if the gate saw it; a build with no gate leaves the file
-    # alone for the trivial reason that nothing reads it.
+    # Positive control (issue #1442; rationale at "a held tick leaves the gate
+    # deadline untouched") — must precede `run cat`, which replaces $output.
     assert_output --partial "not a token-limit signature"
     run cat "${_LIMIT_FILE}"
     assert_output --partial '"strikes": "1"'
@@ -1938,10 +1936,8 @@ _two_repo_fixture() {
     _set_issues '[{"number":12,"repository":{"nameWithOwner":"acme/dotfiles"},"labels":[]}]'
     _run_tick "HERDR_PROMPT_MODE=fail"
     assert_failure
-    # Two stalls in a row shut the gate; two broken panes must not. The
-    # positive control (issue #1442) is the classification line — it says the
-    # gate weighed this failure and let it pass, which the bare refute below
-    # cannot distinguish from a build that has no gate at all.
+    # Positive control (issue #1442; same rationale): two stalls in a row shut
+    # the gate, two non-quota failures must not.
     assert_output --partial "not a token-limit signature"
     refute_output --partial "Rate-limit gate closed"
     [ ! -f "${_LIMIT_FILE}" ]

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1852,6 +1852,11 @@ _two_repo_fixture() {
     printf '{ "strikes": "0", "backoff_until": "%s" }\n' "${_until}" >"${_LIMIT_FILE}"
     _run_tick
     assert_success
+    # Positive control (issue #1442): the deadline surviving is only evidence
+    # of a *working* gate if the gate ran at all. Without this line a build
+    # that never reads the state file passes too — absence and correctness
+    # would look identical.
+    assert_output --partial "Rate-limit gate closed"
     run cat "${_LIMIT_FILE}"
     assert_output --partial "\"backoff_until\": \"${_until}\""
 }
@@ -1917,8 +1922,29 @@ _two_repo_fixture() {
     printf '{ "strikes": "1", "backoff_until": "0" }\n' >"${_LIMIT_FILE}"
     _run_tick "HERDR_PROMPT_MODE=fail"
     assert_failure
+    # Positive control (issue #1442) — asserted before `run cat` replaces
+    # $output. The strike count standing still proves the gate classified the
+    # failure only if the gate saw it; a build with no gate leaves the file
+    # alone for the trivial reason that nothing reads it.
+    assert_output --partial "not a token-limit signature"
     run cat "${_LIMIT_FILE}"
     assert_output --partial '"strikes": "1"'
+}
+
+@test "issue_watcher_cron: repeated non-quota failures never close the gate" {
+    _run_tick "HERDR_PROMPT_MODE=fail"
+    assert_failure
+    assert_output --partial "not a token-limit signature"
+    _set_issues '[{"number":12,"repository":{"nameWithOwner":"acme/dotfiles"},"labels":[]}]'
+    _run_tick "HERDR_PROMPT_MODE=fail"
+    assert_failure
+    # Two stalls in a row shut the gate; two broken panes must not. The
+    # positive control (issue #1442) is the classification line — it says the
+    # gate weighed this failure and let it pass, which the bare refute below
+    # cannot distinguish from a build that has no gate at all.
+    assert_output --partial "not a token-limit signature"
+    refute_output --partial "Rate-limit gate closed"
+    [ ! -f "${_LIMIT_FILE}" ]
 }
 
 @test "issue_watcher_cron: a gate that shuts mid-cycle stops the remaining issues" {


### PR DESCRIPTION
## Summary
- rate-limit 게이트 테스트 3건이 **게이트가 없는 빌드에서도 통과**해, 게이트의 오작동 부재를 증명하지 못하던 문제를 고친다.
- 부재 단언(`refute_output`, "파일이 그대로다")에 같은 실행 안에서 게이트가 살아 있음을 보이는 **양성 대조(positive control)** 를 하나씩 붙였다.
- 판별력은 게이트 진입점 두 개를 no-op 으로 만든 **뮤턴트**로 실측했다 — 대상 3건 모두 `not ok`, 회귀 가드 3건은 그대로 `ok`.

## Changes
- `tests/bats/tools/issue_watcher_cron.bats` (+26)
  - `a held tick leaves the gate deadline untouched` — `assert_output --partial "Rate-limit gate closed"` 추가. 보류 tick 은 이 경고를 반드시 찍으므로, 마감이 유지된 것이 *동작하는* 게이트의 증거가 된다.
  - `a non-quota failure leaves an existing strike untouched` — `assert_output --partial "not a token-limit signature"` 추가. `run cat` 이 `$output` 을 덮기 전에 단언해야 해서 위치가 고정이다.
  - `repeated non-quota failures never close the gate` — **신규**. 이 이름의 케이스는 #1440 재작성(`c48de7bf`) 때 사라져 현재 파일에 없었고, 그래서 codex 리뷰 FOLLOW-UP 이 요구한 "비-쿼터 실패가 게이트를 닫지 않는다"는 증명 자체가 부재한 상태였다. 연속 두 번의 비-쿼터 실패를 분류 메시지 + `refute` 조합으로 다시 세운다.

### 왜 판별력이 없었나
셋 다 "어떤 상태가 변하지 않았다" 만 단언했다. 게이트가 없는 코드는 `rate-limit.json` 을 읽지도 쓰지도 않으므로 그 파일은 자명하게 그대로다 — **부재와 올바름이 같은 관측값을 낸다.** 판별력을 가진 대조군(`a non-quota dispatch failure earns no strike`)과의 유일한 차이는, 그쪽은 단언이 부재가 아니라 **게이트가 낸 메시지의 존재**를 본다는 것이었다.

### 검증 방식이 이슈 문면과 다른 점
이슈의 기준은 "PR 이전 코드(`25fa885c`)에서 실패한다" 지만, 그 사이 #1440 / #1453 이 `issue_watcher_cron.sh` 를 통째로 재작성해 **문자 그대로는 재현되지 않는다** — 그 리비전에서는 거의 모든 케이스가 게이트와 무관한 이유로 깨지므로, 그 실행은 판별력의 증거가 되지 못한다. 기준의 실질인 "게이트가 없으면 실패한다" 를 직접 재려고, 현재 코드에서 `_iw_limit_gate_check` 와 `_iw_limit_record` 두 진입점만 no-op 으로 만든 게이트-부재 뮤턴트를 세워 측정했다(측정 후 스크립트는 원본 복원, diff 는 bats 파일 단독).

| 케이스 | 게이트 있음 | 게이트 없음(뮤턴트) |
|---|---|---|
| `repeated non-quota failures never close the gate` | ok | **not ok** |
| `a non-quota failure leaves an existing strike untouched` | ok | **not ok** |
| `a held tick leaves the gate deadline untouched` | ok | **not ok** |
| `a state dir with no gate file ticks exactly as before` (회귀 가드) | ok | ok |
| `a stalled dispatch with the agent working earns no strike` (회귀 가드) | ok | ok |
| `a healthy dispatch leaves no rate-limit state behind` (회귀 가드) | ok | ok |

## Test plan
- [x] `bats tests/bats/tools/issue_watcher_cron.bats` — 150/150 통과 (베이스라인 149 + 신규 1, pre-existing 실패 0)
- [x] 게이트-부재 뮤턴트에서 대상 3건이 모두 실패 (판별력 확보)
- [x] 통과가 목적인 회귀 가드 3건은 뮤턴트에서도 통과 (과잉 단언 아님)
- [x] `mise run lint-sh` 통과
- [x] 검증 후 `issue_watcher_cron.sh` 원본 복원 확인 (`git status` 상 bats 파일만 변경)

## Related
Closes #1442

`docs/public/changelog.md` 는 갱신하지 않았다 — 테스트 판별력만 바뀌고 사용자 가시 동작·스키마·운영 절차 변경이 없다.

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
