### PR TITLE
feat(devx-restart): 재개 전 디스크 상태 검증 + 재개 지점 정밀도 보완

### DIFF
--- a/claude/skills/devx-restart/SKILL.md
+++ b/claude/skills/devx-restart/SKILL.md
@@ -46,6 +46,19 @@ Do not re-invoke a process skill (`superpowers:brainstorming`,
 etc.) just because it appeared earlier — its output is already in the
 conversation. Resume from the implementation/edit step those skills led to.
 
+Run `git status --short` once to confirm the working tree actually matches
+what the picked task implies — self-reported TodoList status can lag disk
+reality (e.g. a task marked `completed` whose files are still uncommitted).
+If it contradicts the picked task, tell the user in one line before
+proceeding; don't silently resume over a mismatch.
+
+If the picked task is coarser than the actual interruption point (e.g. a
+todo like "구현 issue #N" when the prior turn died partway through it),
+don't guess — use the last completed tool result already in the
+conversation to pinpoint exactly where it died, then resume from there. If
+no completed tool result exists in context (e.g. the turn died at session
+start), fall back to rule 3 above and ask.
+
 ## Step 2: Announce + Plan Smaller Steps
 
 Print the announce line first (success template in


### PR DESCRIPTION
## Summary
- `devx:restart` Step 1(재개 지점 선택)에 디스크 상태 교차검증과, TodoList 항목이 거칠 때의 재개 지점 정밀도 폴백 규칙을 추가한다.

## Changes
- `feat(devx-restart)`: Step 1에 `git status --short` 확인(TodoList와 디스크 상태 모순 시 알림)과, TodoList 항목이 실제 중단 지점보다 거칠면 대화의 마지막 완료된 tool 결과로 재개 지점을 좁히는 폴백 규칙을 추가.

## Test plan
- [ ] `claude/skills/devx-restart/references/help.md`의 "When to invoke" 트리거 조건이 변경되지 않았는지 확인
- [ ] `claude/skills/devx-restart/references/output-format.md`의 hard-stop 템플릿이 변경되지 않았는지 확인
- [ ] 기존 constraints(프로세스 스킬 재호출 금지 등)가 그대로 유지되는지 확인

## Related
Closes #1461

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~4 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
