### PR TITLE
fix(gh-pr-review): hermes CLI invocation을 -z로 교정한다

### DIFF
--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -77,12 +77,19 @@ quote the first stderr line and exit 1.
 ## `--ai agy`
 
 ```sh
-agy --print < "$PROMPT_FILE"
+agy --print "$(cat "$PROMPT_FILE")"
 ```
 
-`agy --print` runs the Antigravity CLI non-interactively, reading the
-prompt (and appended diff) from stdin. Model selection intentionally
-falls back to agy's own default; no `--model` flag is passed.
+`agy --print` runs the Antigravity CLI non-interactively, but takes the
+prompt (and appended diff) as a **value argument**, not stdin. Model
+selection intentionally falls back to agy's own default; no `--model`
+flag is passed.
+
+Like `hermes -z` below, this carries the `MAX_ARG_STRLEN` (131072-byte)
+argv-limit guard: a prompt of 131072 bytes or more is refused up front
+rather than blowing up as a bare "Argument list too long" exec failure.
+Both CLIs share the same guard implementation
+(`_gh_pr_review_argv_prompt_or_fail` in `gh_pr_review.sh`).
 
 Stderr policy is identical to codex: non-zero exit → noise-filtered
 summary + full stderr tail + persistent stderr log on disk. The stderr

--- a/claude/skills/gh-pr-review/references/ai-cli-invocation.md
+++ b/claude/skills/gh-pr-review/references/ai-cli-invocation.md
@@ -3,9 +3,10 @@
 Maps the five supported `--ai` values to concrete CLI commands. The
 prompt (built from `references/review-presets.md`) is passed via
 **stdin** by default; the PR diff is appended to that same stdin
-payload. Exceptions: `agy --print` takes the prompt as an argv string,
-and `opencode run` / `hermes exec` receive a short instruction as argv plus
-`--file "$PROMPT_FILE"` because stdin is not their supported review path.
+payload. Exceptions: `agy --print` and `hermes -z` take the whole prompt as
+an argv string value, and `opencode run` receives a short instruction as
+argv plus `--file "$PROMPT_FILE"` because stdin is not its supported review
+path.
 
 ## PATH pre-flight
 
@@ -172,6 +173,14 @@ passes it with `--dir`, and removes it after the run. The PR worktree is
 not the OpenCode process directory, so relative agent writes do not leak
 into the caller checkout or race with `/simplify`.
 
+**Runs slow — budget 8–10 minutes.** The CodeMate backend can take several
+minutes for a full review. Any caller that dispatches this lane through a
+subagent Bash call must raise that call's timeout explicitly instead of
+relying on the ambient 2-minute default: a short timeout kills the run
+mid-flight and leaves truncated/garbage stdout (typically a one-line plan
+fragment such as "먼저 관련 파일을 확인하겠습니다"), which must never be
+posted as a completed review.
+
 ## `--ai hermes`
 
 ```sh
@@ -181,26 +190,33 @@ into the caller checkout or race with `/simplify`.
     exit 1
 }
 
-hermes exec "첨부 파일의 지시사항에 따라 위 PR diff를 리뷰해줘." \
-    --file "$PROMPT_FILE"
+hermes -z "$(cat "$PROMPT_FILE")"
 ```
 
 `hermes` is the Samsung DS internal AI coding CLI (setup module: `hermes/`),
 so the lane is gated to internal PCs exactly like `opencode` — a stray
 binary on a personal PC cannot reach the internal provider.
 
-**Assumption pending real-CLI verification (issue #1377 Open Questions):**
-hermes-agent's non-interactive review subcommand is not yet confirmed —
-`hermes-help` and `hermes/AGENTS.md` document `hermes doctor`,
-`hermes config`, and `hermes --version` only. The invocation above mirrors
-the opencode pattern (short instruction argv + `--file "$PROMPT_FILE"`)
-with `exec` as the verb, matching codex's naming for agentic dev CLIs.
-Revisit once `hermes --help` is checked on an internal PC. Until then a
-wrong verb surfaces as a normal non-zero exit → soft SKIP in
-`devx:pr-review-all`, never a hard failure of the other lanes.
+`hermes -z` (long form `--oneshot`) is hermes's one-shot non-interactive
+flag. This is confirmed against real `hermes --help` output on an internal
+PC (issue #1452): the actual subcommand list is `chat, model, moa, …,
+send, …` — there is **no** `exec` subcommand, so the earlier
+`hermes exec … --file` shape could never have worked.
+
+Like `agy --print`, `hermes -z` takes the prompt as a **value argument**,
+not via `--file` or stdin, so this lane carries the same `MAX_ARG_STRLEN`
+guard: a prompt of 131072 bytes or more is refused up front with
+`hermes -z: prompt is <n> bytes, over the 131072-byte argv limit
+(MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.`
+rather than blowing up as a bare "Argument list too long" exec failure.
 
 No `--model` flag is passed; hermes uses whatever endpoint its own config
 resolves (custom LLM endpoints are handled by `hermes/setup.sh`).
+
+**Runs slow — budget 8–10 minutes**, for the same reason as `--ai opencode`
+above (shared internal backend). A caller dispatching this lane via a
+subagent Bash call must set a long timeout; a short one kills the run and
+leaves truncated stdout that must not be posted as a completed review.
 
 ## Step 5 dispatch procedure (`_gh_pr_review_run_ai`)
 
@@ -209,7 +225,7 @@ Step 5 of the skill delegates to `_gh_pr_review_run_ai` in
 `PROMPT_FILE` into the chosen CLI with the exact invocation shape
 documented above (`codex exec --color=never`, `agy --print`, `claude -p`,
 `opencode run ... --model codemate/CodeLLMPro --dir ... --file`, or
-`hermes exec ... --file`, plus the
+`hermes -z "$(cat "$PROMPT_FILE")"`, plus the
 `CLAUDE_CONFIG_DIR` injection for `--user`). Stdout streams to
 the user verbatim — no reformatting, no summarization, no truncation.
 

--- a/docs/public/changelog.d/2026-08-26-1452.md
+++ b/docs/public/changelog.d/2026-08-26-1452.md
@@ -1,0 +1,2 @@
+- 변경: **`--ai hermes` PR 리뷰 호출 방식 수정** — 존재하지 않는 `hermes exec` 서브커맨드 대신 `hermes -z`(oneshot) 값-인자 호출로 전환, agy와 동일한 MAX_ARG_STRLEN 가드 추가.
+- 변경: **opencode/hermes 리뷰 레인 문서에 긴 timeout 경고 추가** — 짧은 ambient timeout이 중간에 죽여 잘린 출력이 완료된 리뷰로 오인 게시되는 문제 방지.

--- a/docs/public/changelog.d/2026-08-26-1452.md
+++ b/docs/public/changelog.d/2026-08-26-1452.md
@@ -1,2 +1,2 @@
 - 변경: **`--ai hermes` PR 리뷰 호출 방식 수정** — 존재하지 않는 `hermes exec` 서브커맨드 대신 `hermes -z`(oneshot) 값-인자 호출로 전환, agy와 동일한 MAX_ARG_STRLEN 가드 추가.
-- 변경: **opencode/hermes 리뷰 레인 문서에 긴 timeout 경고 추가** — 짧은 ambient timeout이 중간에 죽여 잘린 출력이 완료된 리뷰로 오인 게시되는 문제 방지.
+- 변경: **opencode/hermes 리뷰 레인 문서에 긴 timeout 경고 추가** — 짧은 ambient timeout이 중간에 죽여 잘린 출력이 완료된 리뷰로 오인 게시될 위험을 문서로 경고(호출부 timeout 강제는 별도 후속 작업).

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -221,7 +221,10 @@ _gh_pr_review_argv_prompt_or_fail() {
     local _prompt_file="$2"
     local _err_file="$3"
     local _size
-    _size=$(wc -c <"$_prompt_file")
+    if ! _size=$(wc -c <"$_prompt_file"); then
+        printf '%s: could not determine prompt file size\n' "$_cli_label" >"$_err_file"
+        return 1
+    fi
     if [ "$_size" -ge 131072 ]; then
         printf '%s: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
             "$_cli_label" "$_size" 131072 >"$_err_file"

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -205,6 +205,31 @@ _gh_pr_review_require_internal_cli() {
     return 0
 }
 
+# _gh_pr_review_argv_prompt_or_fail — shared MAX_ARG_STRLEN guard for AI
+# CLIs that take the whole prompt as a value argument instead of --file or
+# stdin (agy --print, hermes -z). The kernel caps a single argv string at
+# MAX_ARG_STRLEN (32 pages = 131072 bytes on Linux) — passing an oversized
+# prompt straight through would blow past that as a bare "Argument list
+# too long" exec failure, so this guards it explicitly up front.
+# Args: $1 = CLI label for the error message (e.g. "agy --print"),
+#       $2 = prompt_file to read, $3 = file to write an over-limit or
+#       read-error message to.
+# On success prints the prompt content on stdout and returns 0; on
+# failure returns 1 with nothing on stdout.
+_gh_pr_review_argv_prompt_or_fail() {
+    local _cli_label="$1"
+    local _prompt_file="$2"
+    local _err_file="$3"
+    local _size
+    _size=$(wc -c <"$_prompt_file")
+    if [ "$_size" -ge 131072 ]; then
+        printf '%s: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
+            "$_cli_label" "$_size" 131072 >"$_err_file"
+        return 1
+    fi
+    cat "$_prompt_file" 2>"$_err_file"
+}
+
 # _gh_pr_review_resolve_claude_account — for --ai claude --user <name>,
 # loads the claude integration helper (`_claude_resolve_account`) and
 # returns the resolved CLAUDE_CONFIG_DIR on stdout. Exits 1 with the
@@ -353,13 +378,10 @@ _gh_pr_review_run_ai() {
         }
     fi
     local _rc=0
-    local _prompt_size
     local _prompt_content
     local _opencode_workdir
     # Used by the opencode case below only: opencode takes a short
     # instruction as argv with the diff attached via --file "$prompt_file".
-    # hermes does NOT use this — `hermes -z` takes the full prompt content
-    # as its argv value (see the hermes case).
     local _ai_file_instruction="첨부 파일의 지시사항에 따라 위 PR diff를 리뷰해줘."
     case "$ai" in
     codex)
@@ -367,19 +389,12 @@ _gh_pr_review_run_ai() {
         ;;
     agy)
         # `agy --print` runs the Antigravity CLI non-interactively but
-        # takes the prompt as a value argument, not stdin. The kernel caps
-        # a single argv string at MAX_ARG_STRLEN (32 pages = 131072 bytes
-        # on Linux) — a large PR diff would blow past that as a bare
-        # "Argument list too long" exec failure, so guard it explicitly.
-        _prompt_size=$(wc -c <"$prompt_file")
-        if [ "$_prompt_size" -ge 131072 ]; then
-            printf 'agy --print: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
-                "$_prompt_size" 131072 >"$_stderr_file"
-            _rc=1
-        elif ! _prompt_content=$(cat "$prompt_file" 2>"$_stderr_file"); then
-            _rc=1
-        else
+        # takes the prompt as a value argument, not stdin — guarded by
+        # _gh_pr_review_argv_prompt_or_fail (shared with the hermes case).
+        if _prompt_content=$(_gh_pr_review_argv_prompt_or_fail "agy --print" "$prompt_file" "$_stderr_file"); then
             agy --print "$_prompt_content" 2>>"$_stderr_file" || _rc=$?
+        else
+            _rc=1
         fi
         ;;
     claude)
@@ -393,22 +408,14 @@ _gh_pr_review_run_ai() {
         # Confirmed against real `hermes --help` output on an internal PC
         # (issue #1452): there is no `exec` subcommand — the one-shot
         # non-interactive flag is `-z` / `--oneshot`, and like `agy --print`
-        # it takes the prompt as a value argument rather than --file/stdin.
-        # So this mirrors the agy case exactly, MAX_ARG_STRLEN guard
-        # included.
+        # it takes the prompt as a value argument rather than --file/stdin,
+        # guarded by the same _gh_pr_review_argv_prompt_or_fail helper.
         if ! _gh_pr_review_require_internal_cli hermes >"$_stderr_file" 2>&1; then
             _rc=1
+        elif _prompt_content=$(_gh_pr_review_argv_prompt_or_fail "hermes -z" "$prompt_file" "$_stderr_file"); then
+            hermes -z "$_prompt_content" 2>>"$_stderr_file" || _rc=$?
         else
-            _prompt_size=$(wc -c <"$prompt_file")
-            if [ "$_prompt_size" -ge 131072 ]; then
-                printf 'hermes -z: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
-                    "$_prompt_size" 131072 >"$_stderr_file"
-                _rc=1
-            elif ! _prompt_content=$(cat "$prompt_file" 2>"$_stderr_file"); then
-                _rc=1
-            else
-                hermes -z "$_prompt_content" 2>>"$_stderr_file" || _rc=$?
-            fi
+            _rc=1
         fi
         ;;
     opencode)

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -356,9 +356,10 @@ _gh_pr_review_run_ai() {
     local _prompt_size
     local _prompt_content
     local _opencode_workdir
-    # Shared by the opencode and hermes cases below — both CLIs get the
-    # exact same short instruction as argv, with the diff attached via
-    # --file "$prompt_file".
+    # Used by the opencode case below only: opencode takes a short
+    # instruction as argv with the diff attached via --file "$prompt_file".
+    # hermes does NOT use this — `hermes -z` takes the full prompt content
+    # as its argv value (see the hermes case).
     local _ai_file_instruction="첨부 파일의 지시사항에 따라 위 PR diff를 리뷰해줘."
     case "$ai" in
     codex)
@@ -389,17 +390,25 @@ _gh_pr_review_run_ai() {
         fi
         ;;
     hermes)
-        # Assumption pending real-CLI verification (issue #1377 Open
-        # Questions): hermes-agent's non-interactive review subcommand is
-        # not yet confirmed (hermes-help documents doctor/config/--version
-        # only). Mirrors the opencode pattern — short instruction argv +
-        # --file "$PROMPT_FILE" — as the first-pass shape; revisit once
-        # `hermes --help` is checked on an internal PC.
+        # Confirmed against real `hermes --help` output on an internal PC
+        # (issue #1452): there is no `exec` subcommand — the one-shot
+        # non-interactive flag is `-z` / `--oneshot`, and like `agy --print`
+        # it takes the prompt as a value argument rather than --file/stdin.
+        # So this mirrors the agy case exactly, MAX_ARG_STRLEN guard
+        # included.
         if ! _gh_pr_review_require_internal_cli hermes >"$_stderr_file" 2>&1; then
             _rc=1
         else
-            hermes exec "$_ai_file_instruction" \
-                --file "$prompt_file" 2>"$_stderr_file" || _rc=$?
+            _prompt_size=$(wc -c <"$prompt_file")
+            if [ "$_prompt_size" -ge 131072 ]; then
+                printf 'hermes -z: prompt is %s bytes, over the %s-byte argv limit (MAX_ARG_STRLEN) — use --ai codex or --ai claude for this PR instead.\n' \
+                    "$_prompt_size" 131072 >"$_stderr_file"
+                _rc=1
+            elif ! _prompt_content=$(cat "$prompt_file" 2>"$_stderr_file"); then
+                _rc=1
+            else
+                hermes -z "$_prompt_content" 2>>"$_stderr_file" || _rc=$?
+            fi
         fi
         ;;
     opencode)

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1145,6 +1145,20 @@ EOF
     refute_output --partial "[exec]"
 }
 
+@test "run_ai hermes: prompt one byte under MAX_ARG_STRLEN (131071 bytes) → still succeeds, hermes invoked" {
+    _source_module
+    _dotfiles_setup_mode() { echo internal; }
+    _stub_hermes_echo
+    local f="$TEST_TEMP_HOME/almost-big.txt"
+    # 131071 bytes — one under the guard's `-ge 131072` boundary.
+    head -c 131071 /dev/zero | tr '\0' 'x' >"$f"
+
+    run _gh_pr_review_run_ai hermes "$f"
+    assert_success
+    assert_output --partial "hermes args: [-z]"
+    refute_output --partial "over the 131072-byte argv limit"
+}
+
 @test "run_ai hermes: prompt at/over MAX_ARG_STRLEN (131072 bytes) → fails with clear message, hermes never invoked" {
     _source_module
     _dotfiles_setup_mode() { echo internal; }

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1110,7 +1110,9 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# _gh_pr_review_run_ai — hermes transport (issue #1377)
+# _gh_pr_review_run_ai — hermes transport (issue #1377, corrected in #1452:
+# hermes has no `exec` subcommand — the one-shot flag is `-z` and it takes the
+# prompt as a value argument, so it shares agy's MAX_ARG_STRLEN guard)
 # ---------------------------------------------------------------------------
 
 _stub_hermes_echo() {
@@ -1129,7 +1131,7 @@ EOF
     export PATH="$stub_dir:$PATH"
 }
 
-@test "run_ai hermes: internal mode invokes exec and attaches prompt file" {
+@test "run_ai hermes: small prompt → passed as value argument, not stdin" {
     _source_module
     _dotfiles_setup_mode() { echo internal; }
     _stub_hermes_echo
@@ -1138,8 +1140,23 @@ EOF
 
     run _gh_pr_review_run_ai hermes "$f"
     assert_success
-    assert_output --partial "hermes args: [exec]"
-    assert_output --partial "[--file] [$f]"
+    assert_output --partial "hermes args: [-z] [review this diff]"
+    refute_output --partial "[--file]"
+    refute_output --partial "[exec]"
+}
+
+@test "run_ai hermes: prompt at/over MAX_ARG_STRLEN (131072 bytes) → fails with clear message, hermes never invoked" {
+    _source_module
+    _dotfiles_setup_mode() { echo internal; }
+    _stub_hermes_echo
+    local f="$TEST_TEMP_HOME/big.txt"
+    # 131072 bytes exactly — the guard's `-ge` boundary.
+    head -c 131072 /dev/zero | tr '\0' 'x' >"$f"
+
+    run _gh_pr_review_run_ai hermes "$f"
+    assert_failure
+    assert_output --partial "over the 131072-byte argv limit"
+    refute_output --partial "hermes args:"
 }
 
 @test "run_ai hermes: non-internal mode refuses without invoking hermes" {


### PR DESCRIPTION
## Summary
- `--ai hermes`가 존재하지 않는 `hermes exec` 서브커맨드를 호출해 100% 실패하던 문제를 수정한다.
- 실측한 `hermes --help` 기준 `-z`(oneshot) 플래그로 교체하고 agy와 동일한 MAX_ARG_STRLEN 가드를 추가한다.
- opencode/hermes 문서에 CodeMate 백엔드의 긴 실행 시간(짧은 timeout에 잘려 오인 게시되는 위험) 경고를 추가한다.

## Changes
- `shell-common/functions/gh_pr_review.sh`: hermes 케이스를 `hermes exec ... --file` → `hermes -z "$_prompt_content"` + MAX_ARG_STRLEN 가드로 교체.
- `tests/bats/functions/gh_pr_review.bats`: hermes 테스트를 agy 패턴에 맞춰 값-인자 테스트 + MAX_ARG_STRLEN 경계 테스트로 갱신.
- `claude/skills/gh-pr-review/references/ai-cli-invocation.md`: hermes 섹션을 실측 내용으로 교체하고 opencode/hermes 둘 다에 8~10분 timeout 경고 추가.
- `docs/public/changelog.d/2026-08-26-1452.md`: changelog fragment 추가.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_review.bats` — 63/63 통과
- [x] `mise run lint-docs` — errors=0 (changelog fragment 검증 포함)

## Related
Fixes #1452

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~2 h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~2 h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
