### PR TITLE
fix(tests): issue_watcher_cron.bats 의 실패 단언 이후 행을 막는다

### DIFF
--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -702,20 +702,89 @@ _hold_lock() {
 #             forever inside the tick. Opening it `<>` from this process is
 #             what keeps the reproduction free of a background writer that
 #             would itself have to be reaped.
-#   timeout   the outer bound. A regression must surface as a bounded 124, not
+#   watchdog  the outer bound. A regression must surface as a bounded 124, not
 #             as a hang that takes the whole suite down with it — every
 #             assertion below therefore refutes 124 explicitly.
-_run_child_suite() {
-    # No `timeout` means no bound, and an unbounded child bats is the very
-    # thing these cases refuse to allow — skip rather than risk it.
-    command -v timeout >/dev/null 2>&1 || skip "timeout(1) not available"
 
+# The bound a child bats run is held to. A child here runs one case and comes
+# back in well under a second even counting bats' own startup, so this is a
+# wide margin — and still short enough that a returning hang costs CI seconds
+# rather than the minutes the old 60 would have.
+_CHILD_SUITE_TIMEOUT=15
+
+# The bound, without `timeout(1)`. That binary is coreutils, and stock macOS
+# ships neither it nor a `gtimeout` on PATH — gating on it meant these cases
+# skipped wholesale on a platform this repo supports, quietly retiring the one
+# guarantee they exist to hold. So the bound is bash's own.
+#
+# The child runs as a background job under `set -m`, which makes it a process
+# *group* leader; a watchdog kills that whole group once the bound elapses.
+# The group, not the pid, is the point: a hung bats has grandchildren — issue
+# #1473 is exactly a grandchild blocked on a read — and killing only the
+# immediate child would leave them alive holding the fds the caller waits on.
+#
+# The child's real exit code reaches us only through a file it writes itself,
+# just before exiting. So a missing file *is* "the watchdog got there first",
+# with no need to tell a killed child's 137 from an honest one.
+_bounded_bats() {
+    local _out="${_WORK_DIR}/child.out"
+    local _rc="${_WORK_DIR}/child.rc"
+    rm -f "${_out}" "${_rc}" "${_rc}.part"
+
+    local _monitor=0
+    case $- in *m*) _monitor=1 ;; esac
+    set -m
+
+    {
+        "$@" >"${_out}" 2>&1
+        printf '%s\n' "$?" >"${_rc}.part"
+        mv -f "${_rc}.part" "${_rc}"
+    } &
+    local _child=$!
+
+    # The watchdog holds no stdout, no stdin and no fd 3. An inherited write
+    # end here would outlive the kill and stall the caller's capture — the
+    # same trap the orphaned `sleep` in `_hold_lock` documents.
+    #
+    # The pid kill after the group kill is the belt to that brace: should
+    # `set -m` ever not take, `-${_child}` names no group and the `wait` below
+    # would never return. A live leader owns its own pgid, so the negative
+    # form can only ever reach this job's own tree.
+    (
+        sleep "${_CHILD_SUITE_TIMEOUT}"
+        kill -9 -"${_child}" 2>/dev/null
+        kill -9 "${_child}" 2>/dev/null
+    ) >/dev/null 2>&1 <&- 3>&- &
+    local _watchdog=$!
+
+    [ "${_monitor}" -eq 1 ] || set +m
+
+    wait "${_child}" >/dev/null 2>&1
+
+    # Whichever of the two got there first, the other one goes now — by group
+    # as well, or the watchdog's `sleep` would outlive the subshell holding it.
+    kill -9 -"${_watchdog}" >/dev/null 2>&1
+    kill -9 "${_watchdog}" >/dev/null 2>&1
+    wait "${_watchdog}" >/dev/null 2>&1
+
+    cat "${_out}" 2>/dev/null
+
+    [ -f "${_rc}" ] || return 124
+    return "$(cat "${_rc}")"
+}
+
+_run_child_suite() {
     local _dir="${_WORK_DIR}/probe"
     local _file="${_dir}/probe.bats"
     mkdir -p "${_dir}"
 
     # `load '../test_helper'` resolves against the *child* file's directory, so
     # it has to be re-pointed at the real tree before the copy leaves it.
+    #
+    # Invariant this `sed` rests on: every `@test` in this file comes *after*
+    # the helper section, so cutting from the first one takes the helpers and
+    # nothing else. Move a case above them and the child suite silently
+    # swallows it.
     sed -e "/^@test /,\$d" \
         -e "s|^load '../test_helper'$|load '${DOTFILES_ROOT}/tests/bats/test_helper'|" \
         "${BATS_TEST_FILENAME}" >"${_file}"
@@ -723,14 +792,14 @@ _run_child_suite() {
 
     mkfifo "${_dir}/stdin"
     exec 8<>"${_dir}/stdin"
-    run timeout 60 "${DOTFILES_ROOT}/tests/bats/lib/bats-core/bin/bats" \
+    run _bounded_bats "${DOTFILES_ROOT}/tests/bats/lib/bats-core/bin/bats" \
         "${_file}" <&8
     exec 8>&-
 }
 
-# `$status` 124 is `timeout`'s "the child never finished" — the exact defect
-# these cases exist to catch, so it gets its own message rather than being
-# folded into a generic status assertion.
+# `$status` 124 is `_bounded_bats`' "the child never finished" — the exact
+# defect these cases exist to catch, so it gets its own message rather than
+# being folded into a generic status assertion.
 _assert_not_hung() {
     [ "${status}" -ne 124 ] || fail "the child bats run hung (timeout): $1"
 }

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -735,8 +735,14 @@ _bounded_bats() {
     case $- in *m*) _monitor=1 ;; esac
     set -m
 
+    # bats' `run` executes inside a command substitution, and POSIX says the
+    # stdin of an asynchronous list with no explicit redirection is `/dev/null`
+    # — `set -m` does not change that. Without `<&9` here, the child below runs
+    # on `/dev/null` instead of the fifo `_run_script` handed us, and every
+    # never-EOF-stdin regression case in this file passes for the wrong reason.
+    exec 9<&0
     {
-        "$@" >"${_out}" 2>&1
+        "$@" >"${_out}" 2>&1 <&9
         printf '%s\n' "$?" >"${_rc}.part"
         mv -f "${_rc}.part" "${_rc}"
     } &

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -57,6 +57,10 @@ setup() {
 }
 
 teardown() {
+    # `_run_child_suite` holds the child's stdin fifo open on fd 8. A bats
+    # assertion aborts the test body at the failing line, so closing it there
+    # is not enough — the same reason the two cleanups below live here.
+    exec 8>&- 2>/dev/null || true
     if [ -n "${_LOCK_HOLDER_PID}" ]; then
         kill "${_LOCK_HOLDER_PID}" 2>/dev/null || true
         wait "${_LOCK_HOLDER_PID}" 2>/dev/null || true
@@ -558,6 +562,24 @@ _install_stubs() {
 # NAME=VALUE. The VAR=VALUE assignments are appended after the defaults, and
 # `env` applies assignments left to right, so a test can override any of them
 # (PATH included) without restating the whole sandbox.
+#
+# `</dev/null 3>&-` on the invocation below is load-bearing, not tidiness
+# (issue #1473) — the same fd hazard `_hold_lock` documents, one layer out:
+#
+#   </dev/null  the tick shells out to the `gh` stub, whose `api graphql`
+#               branch drains stdin the way the real `gh api` does. Without
+#               this the stub inherits *bats' own* stdin, and whenever that is
+#               a pipe whose writer never closes (an agent harness, `ssh`
+#               without `-n`, any `cmd | bats` wrapper) the `cat` blocks
+#               forever: the tick never exits, `run` never returns and the test
+#               prints no TAP line at all — the whole run hangs with nothing to
+#               point at. The stub already excused a tty (PR #1469), which
+#               covered only the interactive case. The tick is a cron job, so
+#               /dev/null is also what it gets in production.
+#   3>&-        bats streams TAP on fd 3 and will not finish a test until every
+#               inheritor closes it. Closing it for the tick means a child that
+#               outlives the script cannot freeze the run into a result-less
+#               hang; the worst it can do is fail loudly.
 _run_tick() {
     local _unset=() _env=()
     while [ "$#" -gt 1 ] && [ "$1" = "-u" ]; do
@@ -583,7 +605,7 @@ _run_tick() {
         "IW_STALL_RECOVER_SLEEP=0" \
         "IW_LIMIT_OBSERVE_SLEEP=0" \
         "${_env[@]}" \
-        bash "${SCRIPT}" "$@"
+        bash "${SCRIPT}" "$@" </dev/null 3>&-
 }
 
 _log_count() {
@@ -649,6 +671,57 @@ _hold_lock() {
         _i=$((_i + 1))
     done
     [ -s "${_ready}" ]
+}
+
+# Run the @test cases fed on stdin as a throwaway suite in a *child* bats, and
+# leave that child's exit status and TAP output in `$status` / `$output`.
+#
+# This is how the "a red test reports red instead of hanging" guarantee becomes
+# a test: bats has no native "expect this case to fail", so the subject has to
+# be a bats run of its own. The child suite is this file's own helper section —
+# everything above the first `@test` — so it inherits the real setup, teardown
+# and stubs, and any future change to them is exercised here too.
+#
+# Two things make the child run the *hanging* configuration (issue #1473):
+#
+#   fd 8      a fifo opened read-write, so the child's stdin is a pipe with a
+#             live writer that never sends EOF — the shape an agent harness,
+#             `ssh` without `-n` or a `cmd | bats` wrapper hands to bats, and
+#             the shape that used to leave a stdin-draining stub blocked
+#             forever inside the tick. Opening it `<>` from this process is
+#             what keeps the reproduction free of a background writer that
+#             would itself have to be reaped.
+#   timeout   the outer bound. A regression must surface as a bounded 124, not
+#             as a hang that takes the whole suite down with it — every
+#             assertion below therefore refutes 124 explicitly.
+_run_child_suite() {
+    # No `timeout` means no bound, and an unbounded child bats is the very
+    # thing these cases refuse to allow — skip rather than risk it.
+    command -v timeout >/dev/null 2>&1 || skip "timeout(1) not available"
+
+    local _dir="${_WORK_DIR}/probe"
+    local _file="${_dir}/probe.bats"
+    mkdir -p "${_dir}"
+
+    # `load '../test_helper'` resolves against the *child* file's directory, so
+    # it has to be re-pointed at the real tree before the copy leaves it.
+    sed -e "/^@test /,\$d" \
+        -e "s|^load '../test_helper'$|load '${DOTFILES_ROOT}/tests/bats/test_helper'|" \
+        "${BATS_TEST_FILENAME}" >"${_file}"
+    cat >>"${_file}"
+
+    mkfifo "${_dir}/stdin"
+    exec 8<>"${_dir}/stdin"
+    run timeout 60 "${DOTFILES_ROOT}/tests/bats/lib/bats-core/bin/bats" \
+        "${_file}" <&8
+    exec 8>&-
+}
+
+# `$status` 124 is `timeout`'s "the child never finished" — the exact defect
+# these cases exist to catch, so it gets its own message rather than being
+# folded into a generic status assertion.
+_assert_not_hung() {
+    [ "${status}" -ne 124 ] || fail "the child bats run hung (timeout): $1"
 }
 
 # ---------------------------------------------------------------------------
@@ -1862,7 +1935,8 @@ _two_repo_fixture() {
     mkdir -p "${_tmp}"
     # Open-coded rather than via _run_tick: this test needs XDG_STATE_HOME
     # *absent*, and the helper always assigns it — `env` applies assignments
-    # after its own -u options, so -u could not win.
+    # after its own -u options, so -u could not win. The one thing it must not
+    # drop is the helper's `</dev/null 3>&-`; see _run_tick for why (#1473).
     run env -u HOME -u XDG_STATE_HOME \
         "PATH=${_BIN_DIR}:${PATH}" \
         "CALL_LOG=${_LOG}" \
@@ -1871,7 +1945,7 @@ _two_repo_fixture() {
         "TMPDIR=${_tmp}" \
         "IW_IDLE_POLL_SLEEP=0" \
         "IW_LIMIT_OBSERVE_SLEEP=0" \
-        bash "${SCRIPT}"
+        bash "${SCRIPT}" </dev/null 3>&-
     refute_output --partial "unbound variable"
 }
 
@@ -2273,4 +2347,67 @@ _two_repo_fixture() {
     assert_success
     assert_output --partial "Rate-limit gate open"
     refute_output --partial "herdr not found"
+}
+
+# ---------------------------------------------------------------------------
+# The suite fails loudly (issue #1473)
+# ---------------------------------------------------------------------------
+#
+# A red case in this file used to print no result line at all: the tick handed
+# its stubs bats' own stdin, a stub drained it, and on a stdin that never sends
+# EOF the drain blocked forever — one regression turned a red run into a stuck
+# one, in CI and in the terminal alike. These cases run a deliberately red
+# child suite under exactly that stdin and assert it comes back red *and*
+# bounded, so the harness can never go back to swallowing its own failures.
+
+@test "issue_watcher_cron: a red assertion after a healthy tick reports not ok" {
+    _run_child_suite <<'PROBE'
+@test "probe: healthy tick then a red assertion" {
+    _run_tick
+    assert_output --partial "THIS-STRING-CANNOT-APPEAR"
+}
+PROBE
+    _assert_not_hung "healthy tick"
+    assert_equal "${status}" 1
+    assert_output --partial "not ok 1 probe: healthy tick then a red assertion"
+}
+
+@test "issue_watcher_cron: a red assertion after a failed dispatch reports not ok" {
+    _run_child_suite <<'PROBE'
+@test "probe: failed dispatch then a red assertion" {
+    _run_tick "HERDR_PROMPT_MODE=fail"
+    assert_output --partial "THIS-STRING-CANNOT-APPEAR"
+}
+PROBE
+    _assert_not_hung "failed dispatch"
+    assert_equal "${status}" 1
+    assert_output --partial "not ok 1 probe: failed dispatch then a red assertion"
+}
+
+@test "issue_watcher_cron: a red assertion without a tick still reports not ok" {
+    # The control: this shape always reported red, and must keep doing so —
+    # it is what proves the two cases above measure the tick, not bats.
+    _run_child_suite <<'PROBE'
+@test "probe: no tick, just a red assertion" {
+    assert_equal "x" "y"
+}
+PROBE
+    _assert_not_hung "no tick"
+    assert_equal "${status}" 1
+    assert_output --partial "not ok 1 probe: no tick, just a red assertion"
+}
+
+@test "issue_watcher_cron: a green suite stays green on a never-EOF stdin" {
+    # The other half of the guarantee: the fix must not have bought a bounded
+    # red run by breaking the passing path. A full tick, same stdin, still 0.
+    _run_child_suite <<'PROBE'
+@test "probe: healthy tick, honest assertion" {
+    _run_tick
+    assert_success
+    assert_output --partial "dispatched"
+}
+PROBE
+    _assert_not_hung "green suite"
+    assert_equal "${status}" 0
+    assert_output --partial "ok 1 probe: healthy tick, honest assertion"
 }

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -57,9 +57,12 @@ setup() {
 }
 
 teardown() {
-    # `_run_child_suite` holds the child's stdin fifo open on fd 8. A bats
-    # assertion aborts the test body at the failing line, so closing it there
-    # is not enough — the same reason the two cleanups below live here.
+    # `_run_child_suite` opens the child's stdin fifo on fd 8 and closes it
+    # itself once the child bats run returns — but bash's `errexit` can abort
+    # the helper between the `mkfifo`/`exec` that opens fd 8 and the `exec`
+    # that closes it, leaving fd 8 open with no test-body assertion to blame.
+    # This backstop closes it unconditionally, the same reason the two
+    # cleanups below live here.
     exec 8>&- 2>/dev/null || true
     if [ -n "${_LOCK_HOLDER_PID}" ]; then
         kill "${_LOCK_HOLDER_PID}" 2>/dev/null || true
@@ -554,17 +557,9 @@ _install_stubs() {
 # Helpers
 # ---------------------------------------------------------------------------
 
-# Run one tick with the stubs on PATH and an isolated XDG_STATE_HOME.
-#
-#   _run_tick [-u VAR ...] [VAR=VALUE ...] [-- script-flag ...]
-#
-# `-u VAR` pairs must come first — `env` only parses options ahead of the first
-# NAME=VALUE. The VAR=VALUE assignments are appended after the defaults, and
-# `env` applies assignments left to right, so a test can override any of them
-# (PATH included) without restating the whole sandbox.
-#
-# `</dev/null 3>&-` on the invocation below is load-bearing, not tidiness
-# (issue #1473) — the same fd hazard `_hold_lock` documents, one layer out:
+# Run "$@" — an invocation ending in `bash "${SCRIPT}" ...` — with stdin and
+# bats' TAP fd closed. Load-bearing, not tidiness (issue #1473), the same fd
+# hazard `_hold_lock` documents, one layer out:
 #
 #   </dev/null  the tick shells out to the `gh` stub, whose `api graphql`
 #               branch drains stdin the way the real `gh api` does. Without
@@ -580,6 +575,22 @@ _install_stubs() {
 #               inheritor closes it. Closing it for the tick means a child that
 #               outlives the script cannot freeze the run into a result-less
 #               hang; the worst it can do is fail loudly.
+#
+# Every call site that invokes the tick script goes through this — not a
+# per-call-site `</dev/null 3>&-` — so a future call site cannot silently drop
+# the fix by omission.
+_run_script() {
+    "$@" </dev/null 3>&-
+}
+
+# Run one tick with the stubs on PATH and an isolated XDG_STATE_HOME.
+#
+#   _run_tick [-u VAR ...] [VAR=VALUE ...] [-- script-flag ...]
+#
+# `-u VAR` pairs must come first — `env` only parses options ahead of the first
+# NAME=VALUE. The VAR=VALUE assignments are appended after the defaults, and
+# `env` applies assignments left to right, so a test can override any of them
+# (PATH included) without restating the whole sandbox.
 _run_tick() {
     local _unset=() _env=()
     while [ "$#" -gt 1 ] && [ "$1" = "-u" ]; do
@@ -592,7 +603,7 @@ _run_tick() {
     done
     [ "$#" -eq 0 ] || shift
 
-    run env \
+    run _run_script env \
         "${_unset[@]}" \
         "PATH=${_BIN_DIR}:${PATH}" \
         "CALL_LOG=${_LOG}" \
@@ -605,7 +616,7 @@ _run_tick() {
         "IW_STALL_RECOVER_SLEEP=0" \
         "IW_LIMIT_OBSERVE_SLEEP=0" \
         "${_env[@]}" \
-        bash "${SCRIPT}" "$@" </dev/null 3>&-
+        bash "${SCRIPT}" "$@"
 }
 
 _log_count() {
@@ -1935,9 +1946,10 @@ _two_repo_fixture() {
     mkdir -p "${_tmp}"
     # Open-coded rather than via _run_tick: this test needs XDG_STATE_HOME
     # *absent*, and the helper always assigns it — `env` applies assignments
-    # after its own -u options, so -u could not win. The one thing it must not
-    # drop is the helper's `</dev/null 3>&-`; see _run_tick for why (#1473).
-    run env -u HOME -u XDG_STATE_HOME \
+    # after its own -u options, so -u could not win. Still routed through
+    # _run_script so the #1473 fd fix applies here too, structurally rather
+    # than by a restated redirect.
+    run _run_script env -u HOME -u XDG_STATE_HOME \
         "PATH=${_BIN_DIR}:${PATH}" \
         "CALL_LOG=${_LOG}" \
         "GH_ISSUES_FILE=${_WORK_DIR}/issues.json" \
@@ -1945,7 +1957,7 @@ _two_repo_fixture() {
         "TMPDIR=${_tmp}" \
         "IW_IDLE_POLL_SLEEP=0" \
         "IW_LIMIT_OBSERVE_SLEEP=0" \
-        bash "${SCRIPT}" </dev/null 3>&-
+        bash "${SCRIPT}"
     refute_output --partial "unbound variable"
 }
 


### PR DESCRIPTION
## Summary
- `issue_watcher_cron.bats` 에서 회귀가 발생하면 bats 가 `not ok` 를 내는 대신 조용히 행(hang)했다 — CI 는 빨간불이 아니라 멈춘 잡이 됐다.
- 진짜 트리거는 "`_run_tick` 이후 단언 실패"가 아니라 "tick 이 bats 자신의 stdin(EOF 없는 파이프)을 그대로 물려받는 상황에서 `gh` 스텁의 `api graphql` 분기가 그 stdin 을 drain 하며 영원히 막히는 것"이었다.
- `_run_tick`(및 유사 호출부 1곳)에 `</dev/null 3>&-` 를 붙여 근본 원인을 막고, 이 성질을 고정하는 회귀 테스트 4건을 추가했다.

## Changes
- `tests/bats/tools/issue_watcher_cron.bats`
  - `_run_tick`: `bash "${SCRIPT}" "$@"` 호출에 `</dev/null 3>&-` 추가 — 스텁이 bats 의 stdin/TAP fd 3 을 물려받지 못하게 근본 차단.
  - `XDG_STATE_HOME` 없이 여는 한 곳(2-repo 픽스처)에도 동일 리다이렉트 적용.
  - `teardown()`: `_run_child_suite` 가 여는 fd 8 을 안전하게 닫는 정리 추가 (`_LOCK_HOLDER_PID` 정리와 같은 이유 — 단언 실패로 본문이 중단돼도 정리가 스킵되지 않아야 함).
  - `_run_child_suite` / `_assert_not_hung` 헬퍼 + 회귀 케이스 4건 추가: 정상 tick 후 실패, 실패 dispatch 후 실패, tick 없이 실패(대조군), 정상 tick 유지 — 모두 자식 bats 를 never-EOF stdin 위에서 `timeout` 으로 bounded 하게 돌려, 회귀가 행이 아니라 `exit 124` 로 드러나게 한다.

## Test plan
- [x] `timeout 90 ./tests/bats/lib/bats-core/bin/bats tests/bats/tools/issue_watcher_cron.bats` — 175/175 통과, exit 0.
- [x] 새 회귀 케이스 4건 모두 통과 (정상 tick, 실패 dispatch, tick 없음 대조군, green 유지).
- [x] 수정 전 재현: 동일 케이스가 `not ok` 대신 `timeout` 킬(exit 124)로 행하는 것을 확인.

## Related
Closes #1473

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
