### PR TITLE
fix(gh-pr-merge-train): 다른 워크트리 head 브랜치도 스크래치 워크트리로 리베이스

### DIFF
--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -69,8 +69,8 @@ For each PR in queue order, run the loop in `references/train-loop.md`:
 invalidated everything behind it), route through the D-1 table
 (`references/routing-table.md`), then merge with `Skill(gh:pr-merge, "<N>")`.
 The `BEHIND` / `DIRTY` rows rebase inside a **detached scratch worktree** the
-train creates and unconditionally removes per attempt (#1493) — never in this
-checkout, whose branch may already be held by another worktree. Attempts are
+train creates and unconditionally removes per attempt, never in this checkout
+(`references/train-loop.md` → "Detached scratch worktree", #1493). Attempts are
 capped at 3 per PR (F-5); a failure skips that one PR and the train continues
 (F-6). Never process two PRs concurrently.
 

--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -68,8 +68,11 @@ For each PR in queue order, run the loop in `references/train-loop.md`:
 **re-query state immediately before processing** (F-3 — the previous merge
 invalidated everything behind it), route through the D-1 table
 (`references/routing-table.md`), then merge with `Skill(gh:pr-merge, "<N>")`.
-Attempts are capped at 3 per PR (F-5); a failure skips that one PR and the
-train continues (F-6). Never process two PRs concurrently.
+The `BEHIND` / `DIRTY` rows rebase inside a **detached scratch worktree** the
+train creates and unconditionally removes per attempt (#1493) — never in this
+checkout, whose branch may already be held by another worktree. Attempts are
+capped at 3 per PR (F-5); a failure skips that one PR and the train continues
+(F-6). Never process two PRs concurrently.
 
 ## Step 5: Report
 
@@ -91,7 +94,7 @@ assistant text, never via a `Bash` heredoc or `Write`.
 
 ## Related Skills
 
-Atoms this train calls unchanged: `gh:pr-resolve-outdated` · `gh:pr-resolve-conflict`
+Atoms this train calls: `gh:pr-resolve-outdated` · `gh:pr-resolve-conflict`
 · `gh:pr-resolve-ci-fail` · `gh:pr-merge`. Deliberately **not** called:
 `gh:pr-merge-emergency` (NF-2). Upstream producer of the PRs this train drains:
 `gh:issue-flow`. Unattended trigger: `shell-common/tools/custom/pr_merge_train_cron.sh`

--- a/claude/skills/gh-pr-merge-train/references/help.md
+++ b/claude/skills/gh-pr-merge-train/references/help.md
@@ -51,6 +51,9 @@
 5. Routes on `mergeStateStatus` / `mergeable` through the D-1 table — the one
    copy lives in `references/routing-table.md`. Which atom each row reaches is
    summarised under "Atom skills it calls" below.
+   The two rebase rows run in a **detached scratch worktree** the train creates
+   and deletes per attempt, so a head branch already checked out by
+   `gh:issue-flow` — and the operator's own checkout — are never touched.
 6. Caps remediation at **3 attempts per PR** (F-5). Over that, the PR is
    `[FAILED]` and the train moves on (F-6).
 7. Prints a per-PR `[MERGED]` / `[SKIPPED]` / `[FAILED]` report with reasons (F-9).
@@ -66,12 +69,12 @@
 - Abort the whole train because one PR failed.
 - Process two PRs at once.
 
-## Atom skills it calls (all unchanged)
+## Atom skills it calls
 
 | Skill | Called when |
 |---|---|
-| `gh:pr-resolve-outdated` | `BEHIND` + `MERGEABLE` — clean rebase onto the moved base |
-| `gh:pr-resolve-conflict` | `DIRTY` + `CONFLICTING` — the LLM-judgement row |
+| `gh:pr-resolve-outdated` | `BEHIND` + `MERGEABLE` — clean rebase onto the moved base, in a scratch worktree |
+| `gh:pr-resolve-conflict` | `DIRTY` + `CONFLICTING` — the LLM-judgement row, in a scratch worktree |
 | `gh:pr-resolve-ci-fail` | `UNSTABLE` with a failing check — the other LLM-judgement row |
 | `gh:pr-merge` | every row that reaches a mergeable state |
 | none | `BLOCKED` / `DRAFT` skip; `UNSTABLE` still running and `UNKNOWN` poll first |

--- a/claude/skills/gh-pr-merge-train/references/help.md
+++ b/claude/skills/gh-pr-merge-train/references/help.md
@@ -52,8 +52,8 @@
    copy lives in `references/routing-table.md`. Which atom each row reaches is
    summarised under "Atom skills it calls" below.
    The two rebase rows run in a **detached scratch worktree** the train creates
-   and deletes per attempt, so a head branch already checked out by
-   `gh:issue-flow` — and the operator's own checkout — are never touched.
+   and deletes per attempt (`references/train-loop.md` → "Detached scratch
+   worktree").
 6. Caps remediation at **3 attempts per PR** (F-5). Over that, the PR is
    `[FAILED]` and the train moves on (F-6).
 7. Prints a per-PR `[MERGED]` / `[SKIPPED]` / `[FAILED]` report with reasons (F-9).

--- a/claude/skills/gh-pr-merge-train/references/routing-table.md
+++ b/claude/skills/gh-pr-merge-train/references/routing-table.md
@@ -9,7 +9,7 @@ Immediately before processing each PR (F-3):
 
 ```bash
 STATE=$(GH_HOST="$TARGET_HOST" gh pr view "$N" --repo "$TARGET_REPO" \
-  --json number,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
+  --json number,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefName,url)
 ```
 
 Keep `$STATE`. Every question the rest of this file asks about the PR is
@@ -21,14 +21,19 @@ a round trip the state you already hold has covered.
 | `mergeStateStatus` | `mergeable` | Action |
 |---|---|---|
 | `CLEAN` | `MERGEABLE` | `Skill(gh:pr-merge, "<N>")` directly |
-| `BEHIND` | `MERGEABLE` | `Skill(gh:pr-resolve-outdated, "<N>")` → re-query → merge |
-| `DIRTY` | `CONFLICTING` | `Skill(gh:pr-resolve-conflict, "<N>")` → re-query → merge |
+| `BEHIND` | `MERGEABLE` | `gh:pr-resolve-outdated` in a scratch worktree → re-query → merge |
+| `DIRTY` | `CONFLICTING` | `gh:pr-resolve-conflict` in a scratch worktree → re-query → merge |
 | `UNSTABLE` | `MERGEABLE` | inspect `statusCheckRollup` — see below |
 | `BLOCKED` | — | record the reason, `[SKIPPED]` |
 | `UNKNOWN` | `UNKNOWN` | poll, then re-evaluate; `[SKIPPED]` after 3 polls |
 | `DRAFT` | — | `[SKIPPED]` (a draft is not a merge candidate) |
 
 `isDraft == true` short-circuits the table: skip before reading anything else.
+
+The two rebase rows (`BEHIND`, `DIRTY`) never operate on the current checkout.
+The train builds a detached scratch worktree for `headRefName` first and passes
+its path to the atom via `--worktree` — that is why `headRefName` is in the
+`--json` list above. Mechanics: `train-loop.md` → "Detached scratch worktree".
 
 ## `UNSTABLE` — split on the rollup, not on the status
 

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -40,16 +40,44 @@ Before delegating, with `<head>` = the `headRefName` already in `$STATE`:
 
 ```bash
 git fetch "$REMOTE" "<head>"
-GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
 SCRATCH_DIR="${GIT_COMMON_DIR}/pr-merge-train-scratch/pr-<N>"
+
+# Stale-leftover guard: a crashed/killed prior run, or an unresolved conflict
+# handoff (see "Teardown — the one exception" below), can leave this same
+# path behind. Never blindly wipe it — a leftover rebase-in-progress marker
+# means a human may be resolving it by hand right now.
+if [ -e "$SCRATCH_DIR" ]; then
+    if [ -e "$(git -C "$SCRATCH_DIR" rev-parse --git-path rebase-merge 2>/dev/null)" ] ||
+       [ -e "$(git -C "$SCRATCH_DIR" rev-parse --git-path rebase-apply 2>/dev/null)" ]; then
+        echo "[SKIPPED] scratch worktree at $SCRATCH_DIR still has an unresolved handoff — resolve manually or remove it, then re-run."
+        # skip this PR (F-6) — do not touch $SCRATCH_DIR, do not proceed below.
+    else
+        git worktree remove --force "$SCRATCH_DIR" 2>/dev/null || rm -rf "$SCRATCH_DIR"
+        git worktree prune
+    fi
+fi
+
 mkdir -p "$(dirname "$SCRATCH_DIR")"
 git worktree add --detach "$SCRATCH_DIR" "$REMOTE/<head>"
 ```
 
 The `fetch` is not optional: this session's checkout has no reason to hold a
-current `$REMOTE/<head>` — the branch was pushed from a *different* worktree —
-and starting the scratch worktree from a stale (or absent) tracking ref would
-have the atom force-push a rewind over commits it never saw.
+current `$REMOTE/<head>` — the branch was pushed from a *different* worktree.
+Fetching it explicitly first is what makes `$REMOTE/<head>` below trustworthy:
+with the standard clone fetch refspec (`+refs/heads/*:refs/remotes/<remote>/*`,
+the default for every `git remote add` / `git clone`) a plain `git fetch
+"$REMOTE" "<head>"` updates the remote-tracking ref `$REMOTE/<head>` itself,
+not only `FETCH_HEAD` — skipping the fetch is what would leave that ref stale
+(or absent) and have the atom force-push a rewind over commits it never saw.
+
+`--path-format=absolute` (git 2.31+) matters here: `--git-common-dir` alone
+prints a path **relative to the current working directory** in a plain
+repository (`.git`, or `../../.git` two levels down) — only a linked
+worktree's own `.git` file happens to store an absolute `gitdir:` target,
+which is why a relative `GIT_COMMON_DIR` can look harmless while testing from
+this repo's own worktree layout and still break the moment `$SCRATCH_DIR` is
+read from a different working directory or a plain non-worktree checkout.
 
 `--detach` is what makes this collide-free: the scratch worktree holds a commit,
 not the branch *name*, so it never contests the checkout any other worktree
@@ -72,20 +100,36 @@ an explicit refspec (`HEAD:refs/heads/<head>`), because a detached HEAD has no
 upstream to infer. That contract is the atoms' own — see their
 `references/preflight.md` / `references/rebase-flow.md`.
 
-### Teardown is unconditional
+### Teardown — the one exception
 
-Once the atom returns — **success, failure, or handoff, no exceptions**:
+Tear down once the atom returns, in every case **except** one:
+`gh:pr-resolve-conflict` stopping at one of its own documented stop points
+(`references/conflict-handling.md` → "Stop points" — an ambiguous conflict it
+refuses to auto-resolve, or a user-side abort). That stop leaves the tree
+**deliberately** conflicted for a human to finish by hand — the atom's own
+constraint already forbids it from deleting `--worktree`'s path itself; tearing
+it down here, right after, would just relocate the same mistake into the
+caller and destroy the exact state the atom promised to leave behind. In that
+one case: report `$SCRATCH_DIR` in the `[FAILED]` row instead of removing it,
+and skip this PR for the rest of the run — a human resumes it manually
+(`git -C "$SCRATCH_DIR" ...`, per the atom's own report) or re-runs the train
+once it's resolved and pushed. The stale-leftover guard above is what makes a
+later run safe to encounter that surviving path again.
+
+Every other outcome — clean success, a mechanical rebase failure
+`gh:pr-resolve-outdated` hands off with (exit 4, no human input taken yet),
+or `git worktree add` itself failing — tears down unconditionally:
 
 ```bash
 git worktree remove --force "$SCRATCH_DIR" ||
   { rm -rf "$SCRATCH_DIR" && git worktree prune; }
 ```
 
-The failure paths are exactly the ones that would leak: a PR that lands
-`[FAILED]` is retried on the next tick, and a train on a cron schedule would
-accumulate one abandoned worktree per tick per stuck PR — each one a full
-checkout, and each one still registered in `git worktree list`. Tearing down
-only on the happy path is how that starts.
+The failure paths are exactly the ones that would leak otherwise: a PR that
+lands `[FAILED]` is retried on the next tick, and a train on a cron schedule
+would accumulate one abandoned worktree per tick per stuck PR — each one a
+full checkout, and each one still registered in `git worktree list`. Tearing
+down only on the happy path is how that starts.
 
 Creating, delegating, and tearing down is **one** remediation round: the round
 still costs exactly one attempt, unchanged from the accounting below.
@@ -153,6 +197,7 @@ skill was called and nothing was changed.
 | What failed | Consequence |
 |---|---|
 | `gh:pr-resolve-*`, or the `git worktree add` that stages it | attempt +1; at 3, `[FAILED]`, next PR |
+| `gh:pr-resolve-conflict` stops at a documented stop point (ambiguous conflict, user-side abort) | `[FAILED]` naming `$SCRATCH_DIR` for manual resume; **scratch worktree is NOT removed** ("Teardown — the one exception" above); no further attempts this run; next PR |
 | `gh:pr-merge` | that PR is `[FAILED]`; next PR |
 | approval gate | that PR is `[SKIPPED]`; next PR |
 | a `gh:pr-merge` gate detected up front (`reviewDecision`, board status) | that PR is `[SKIPPED]` with the cause named; **no attempt is spent** |

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -33,7 +33,7 @@ the time the train reaches it. `git checkout <head>` in this session would fail
 with `fatal: '<branch>' is already used by worktree at '<path>'` — and even
 when it succeeded it would trample the branch the operator has open in the
 worktree they invoked the train from. So the train never checks the head branch
-out at all: it makes a throwaway detached checkout of that branch's tip, hands
+out at all: it makes a throwaway scratch worktree at that branch's tip, hands
 the path to the atom, and deletes it.
 
 Before delegating, with `<head>` = the `headRefName` already in `$STATE`:

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -17,11 +17,78 @@ For each PR `N` in the Step 2 queue order:
    `reviewDecision` non-empty and not `APPROVED` → also `[SKIPPED]`, naming the
    value — see the next section for why that check cannot be skipped.
 3. **Route** through the D-1 table.
-4. **Remediate** with the atom skill the row names, if any.
+4. **Remediate** with the atom skill the row names, if any. For the `BEHIND`
+   and `DIRTY` rows that means the scratch-worktree sequence below, not a bare
+   `Skill(...)` call.
 5. **Re-query and re-route.** An atom returning success does not prove the PR
    is mergeable now.
 6. **Merge** — `Skill(gh:pr-merge, "<N>")`. No strategy argument (D-4).
 7. **Record** the outcome and continue.
+
+## Detached scratch worktree (step 4, `BEHIND` / `DIRTY` only)
+
+`gh:issue-flow` opens each PR from the dedicated worktree that implemented the
+issue, so that PR's head branch is **already checked out somewhere else** by
+the time the train reaches it. `git checkout <head>` in this session would fail
+with `fatal: '<branch>' is already used by worktree at '<path>'` — and even
+when it succeeded it would trample the branch the operator has open in the
+worktree they invoked the train from. So the train never checks the head branch
+out at all: it makes a throwaway detached checkout of that branch's tip, hands
+the path to the atom, and deletes it.
+
+Before delegating, with `<head>` = the `headRefName` already in `$STATE`:
+
+```bash
+git fetch "$REMOTE" "<head>"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+SCRATCH_DIR="${GIT_COMMON_DIR}/pr-merge-train-scratch/pr-<N>"
+mkdir -p "$(dirname "$SCRATCH_DIR")"
+git worktree add --detach "$SCRATCH_DIR" "$REMOTE/<head>"
+```
+
+The `fetch` is not optional: this session's checkout has no reason to hold a
+current `$REMOTE/<head>` — the branch was pushed from a *different* worktree —
+and starting the scratch worktree from a stale (or absent) tracking ref would
+have the atom force-push a rewind over commits it never saw.
+
+`--detach` is what makes this collide-free: the scratch worktree holds a commit,
+not the branch *name*, so it never contests the checkout any other worktree
+already owns. `git worktree add` failing is an ordinary remediation failure —
+attempt +1 (F-5), and at 3 the PR is `[FAILED]` (F-6). It never ends the run.
+
+Then delegate to the atom the D-1 row named, pointing it at that path:
+
+```
+Skill(gh:pr-resolve-outdated, "<N> <remote> --worktree $SCRATCH_DIR")
+Skill(gh:pr-resolve-conflict, "<N> <remote> --worktree $SCRATCH_DIR")
+```
+
+Pass `<remote>` explicitly even when it is the default `origin` — the atoms
+read it as positional 2, and omitting it would leave `--worktree` sitting in
+that slot.
+
+The atom runs every git command as `git -C "$SCRATCH_DIR" ...` and pushes with
+an explicit refspec (`HEAD:refs/heads/<head>`), because a detached HEAD has no
+upstream to infer. That contract is the atoms' own — see their
+`references/preflight.md` / `references/rebase-flow.md`.
+
+### Teardown is unconditional
+
+Once the atom returns — **success, failure, or handoff, no exceptions**:
+
+```bash
+git worktree remove --force "$SCRATCH_DIR" ||
+  { rm -rf "$SCRATCH_DIR" && git worktree prune; }
+```
+
+The failure paths are exactly the ones that would leak: a PR that lands
+`[FAILED]` is retried on the next tick, and a train on a cron schedule would
+accumulate one abandoned worktree per tick per stuck PR — each one a full
+checkout, and each one still registered in `git worktree list`. Tearing down
+only on the happy path is how that starts.
+
+Creating, delegating, and tearing down is **one** remediation round: the round
+still costs exactly one attempt, unchanged from the accounting below.
 
 ## Gates `gh:pr-merge` owns — check them here, not by calling it
 
@@ -85,7 +152,7 @@ skill was called and nothing was changed.
 
 | What failed | Consequence |
 |---|---|
-| `gh:pr-resolve-*` | attempt +1; at 3, `[FAILED]`, next PR |
+| `gh:pr-resolve-*`, or the `git worktree add` that stages it | attempt +1; at 3, `[FAILED]`, next PR |
 | `gh:pr-merge` | that PR is `[FAILED]`; next PR |
 | approval gate | that PR is `[SKIPPED]`; next PR |
 | a `gh:pr-merge` gate detected up front (`reviewDecision`, board status) | that PR is `[SKIPPED]` with the cause named; **no attempt is spent** |

--- a/claude/skills/gh-pr-resolve-conflict/SKILL.md
+++ b/claude/skills/gh-pr-resolve-conflict/SKILL.md
@@ -25,7 +25,8 @@ output its content verbatim, then stop. No API calls.
 
 Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 5.
 
-Positional args: `[pr-number] [remote]`. Both optional.
+Positional args: `[pr-number] [remote]`. Both optional. One flag:
+`[--worktree <path>]`.
 
 - `remote` — default `origin`; missing → `git remote -v` and stop. Bind
   `TARGET_HOST` + `TARGET_REPO` from that one remote URL **before any `gh` call** per `references/github-target.md` (#1403).
@@ -33,6 +34,12 @@ Positional args: `[pr-number] [remote]`. Both optional.
   --json number,headRefName,baseRefName,url,mergeable` on the current branch.
   No PR for the branch → stop. No `--repo` on this one call — `gh` rejects
   `--repo` without a PR argument; `references/github-target.md` → "Exception".
+- `--worktree <path>` — run every git command as `git -C "<path>" ...` instead
+  of in the current checkout, and push with an explicit refspec. Makes
+  `pr-number` **mandatory** (a detached scratch worktree has no branch to
+  auto-detect from). Given by `gh:pr-merge-train`, which owns that worktree's
+  creation and removal. Details: `references/rebase-flow.md` → "`--worktree`
+  mode". Without the flag nothing in this skill behaves differently.
 
 **Mergeable preflight** — immediately after resolving `PR_NUMBER`, run the
 host-pinned `gh pr view --json mergeable` short-circuit per `references/rebase-flow.md`
@@ -46,13 +53,15 @@ host-pinned `gh pr view --json mergeable` short-circuit per `references/rebase-f
 - no in-progress rebase/merge/cherry-pick
 
 Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it so the user can
-`git reset --hard <sha>` if anything goes wrong.
+`git reset --hard <sha>` if anything goes wrong. In `--worktree` mode all of
+these run as `git -C "<path>" ...` and the auto-stash never fires — see
+`references/safety.md`.
 
 ## Step 2: Fetch + Rebase
 
-Run `git fetch "$REMOTE" "$BASE"` then `git rebase "$REMOTE/$BASE"`. Full
-rebase mechanics, stash handling, and abort instructions live in
-`references/rebase-flow.md`.
+Run `git fetch "$REMOTE" "$BASE"` then `git rebase "$REMOTE/$BASE"` (with
+`-C "<path>"` in `--worktree` mode). Full rebase mechanics, stash handling, and
+abort instructions live in `references/rebase-flow.md`.
 
 ## Step 3: Conflict Resolution Loop
 
@@ -66,7 +75,9 @@ conflicts.
 ## Step 4: Push with `--force-with-lease`
 
 Only after `git rebase` exits 0 and the working tree is clean, run
-`git push --force-with-lease "$REMOTE" HEAD`.
+`git push --force-with-lease "$REMOTE" HEAD`. In `--worktree` mode that becomes
+`git -C "<path>" push --force-with-lease "$REMOTE" HEAD:refs/heads/$HEAD_REF` —
+a detached HEAD names no destination branch, so the refspec must be explicit.
 
 Never plain `--force`. If `--force-with-lease` is rejected (someone
 pushed while you rebased), stop and surface the upstream per
@@ -93,6 +104,7 @@ Helper policy (each soft-fail, applies only when `mergeable == MERGEABLE`):
 - Never auto-resolve ambiguous conflicts. Ask the user.
 - Never retry a rejected `--force-with-lease` by fetching and re-rebasing on the user's behalf. Surface divergence and stop.
 - Never skip Step 5. The whole point is clearing the PR warning.
+- Never create or remove the `--worktree` path. The caller owns its lifecycle.
 
 ## Related Skills
 

--- a/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
@@ -1,5 +1,19 @@
 # gh:pr-resolve-conflict — Conflict Handling
 
+## `--worktree <path>`: paths are not relative to this session
+
+Every `git` command below takes `-C "<path>"`, and `git status --short` then
+prints paths relative to **that** worktree, not to the session's working
+directory. `Read` and `Edit` have no `-C`, so join them yourself — call the
+tools on `<path>/<relative-path>` (an absolute path, since the train passes an
+absolute `<path>`). Editing the unjoined path silently rewrites the same file
+in whatever checkout this session happens to be sitting in — a wrong-repo edit
+that no rebase step would catch.
+
+Shell commands have the same gap: run any lockfile regeneration with the
+worktree as its working directory, e.g. `(cd "<path>" && uv lock)`, since `uv`
+/ `npm` / `pnpm` / `cargo` take no `-C`.
+
 ## Per-commit loop
 
 After `git rebase` stops on a conflict, repeat until `git rebase --continue`

--- a/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/conflict-handling.md
@@ -108,3 +108,10 @@ Rebase aborted (HEAD = BACKUP_SHA). No changes pushed.
   be inferred from the commit message — stop and ask.
 - Any edit that would drop a hunk the user hasn't seen — show the hunk
   first.
+
+In `--worktree` mode, the "leave the tree in its conflicted state" instruction
+above still applies — at `<path>`, not the session's own checkout. This skill
+never deletes `--worktree`'s path itself (SKILL.md constraint); when the
+caller is `gh:pr-merge-train`, it reports `<path>` and leaves it in place too
+for the same reason — see `gh-pr-merge-train/references/train-loop.md` →
+"Teardown — the one exception".

--- a/claude/skills/gh-pr-resolve-conflict/references/help.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/help.md
@@ -6,6 +6,7 @@
 |--------|-------------|---------|
 | `[pr-number]` | Positional 1 — target PR to resolve, e.g. `168`. | PR attached to the current branch |
 | `[remote]` | Positional 2 — git remote whose repo owns the PR. | `origin` |
+| `--worktree <path>` | Run every git command in `<path>` instead of the current checkout. Requires an explicit `pr-number`. | current checkout |
 | `-h` / `--help` / `help` | Print this help verbatim and stop. No API calls. | — |
 
 ## Usage
@@ -14,8 +15,15 @@
 /gh-pr-resolve-conflict              # PR attached to current branch, origin
 /gh-pr-resolve-conflict 168          # explicit PR, origin
 /gh-pr-resolve-conflict 168 upstream # explicit PR, upstream remote
+/gh-pr-resolve-conflict 168 origin --worktree /path/to/scratch   # rebase there
 /gh-pr-resolve-conflict -h           # this help
 ```
+
+`--worktree` exists for `gh:pr-merge-train`: the PR's head branch is usually
+already checked out in the worktree `gh:issue-flow` opened it from, so the train
+hands over a detached scratch worktree it created and will destroy. The push
+then uses an explicit `HEAD:refs/heads/<head>` refspec, since a detached HEAD
+names no branch, and the auto-stash never fires — the scratch tree is clean.
 
 ## When to use this skill
 
@@ -53,7 +61,10 @@
 - **Backup SHA** printed before the rebase — `git reset --hard <sha>`
   restores the pre-rebase state; `git reflog` is always available too.
 - **Stash** — only auto-applied if preflight detects a dirty tree, and
-  always announced. Popped at the end even on failure paths.
+  always announced. Popped at the end even on failure paths. Never fires
+  under `--worktree`, where the tree is clean by construction.
+- **Worktree lifecycle is the caller's** — with `--worktree <path>` the skill
+  operates inside that path but never creates or removes it.
 - **`--force-with-lease`** — rejects the push if someone else pushed to
   the branch while you rebased. The skill stops; it does NOT silently
   re-fetch and re-rebase.

--- a/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
@@ -3,6 +3,21 @@
 Every `gh` call below assumes `TARGET_HOST` / `TARGET_REPO` are already bound
 and exported by Step 1 per `references/github-target.md` (#1403, #1407).
 
+## `--worktree` mode
+
+When Step 1 parsed `--worktree <path>`, every **git** command in this file runs
+as `git -C "<path>" ...` — preconditions, base resolution, fetch, rebase,
+status, push. The `gh` calls are unaffected: they read the PR from the API, not
+from a checkout. The push additionally switches to an explicit refspec (see
+"Push"). No `cd`, ever: leaving the session's own working directory alone is
+the reason the flag exists.
+
+The path is a detached scratch worktree `gh:pr-merge-train` created for exactly
+this call and will remove afterwards (#1493) — this skill never creates or
+deletes it.
+
+Without the flag every command below is read literally, unchanged.
+
 ## Preconditions (parallel batch)
 
 Run all four in a single tool message. Any failure → stop immediately.
@@ -33,13 +48,24 @@ Stop conditions:
 Dirty working tree is NOT a stop — it triggers the stash flow in
 `safety.md`.
 
+In `--worktree` mode a freshly created detached worktree is headless and clean,
+so `git status --porcelain` is empty by construction (no stash flow) and
+`--abbrev-ref HEAD` answers `HEAD` rather than a branch name — the
+default-branch refusal is made against `HEAD_REF` instead, per `safety.md` →
+"Never run on the default branch". The git-repo and in-progress-marker checks
+still run under `-C "<path>"`: a scratch directory left behind by an interrupted
+run can be handed over mid-rebase.
+
 ## Resolve base branch
 
-Prefer the PR's actual base (not the repo default):
+Prefer the PR's actual base (not the repo default). Read the head ref in the
+same call — `--worktree` mode's push needs it:
 
 ```bash
-BASE=$(GH_HOST="$TARGET_HOST" gh pr view "$PR" --repo "$TARGET_REPO" \
-    --json baseRefName -q .baseRefName)
+REFS=$(GH_HOST="$TARGET_HOST" gh pr view "$PR" --repo "$TARGET_REPO" \
+    --json baseRefName,headRefName)
+BASE=$(printf '%s' "$REFS" | jq -r .baseRefName)
+HEAD_REF=$(printf '%s' "$REFS" | jq -r .headRefName)
 ```
 
 Fall back to `GH_HOST="$TARGET_HOST" gh repo view --repo "$TARGET_REPO" --json
@@ -55,6 +81,9 @@ echo "backup SHA: $BACKUP_SHA  (git reset --hard $BACKUP_SHA to undo)"
 git rebase "$REMOTE/$BASE"
 ```
 
+`--worktree` mode: `git -C "<path>" fetch ...`, `git -C "<path>" rev-parse HEAD`,
+`git -C "<path>" rebase ...`.
+
 Exit codes:
 
 | Exit | Meaning | Action |
@@ -69,6 +98,13 @@ Only after `git rebase` exits 0 and `git status` is clean:
 
 ```bash
 git push --force-with-lease "$REMOTE" HEAD
+```
+
+In `--worktree` mode, spell the destination out — the worktree is detached, so
+bare `HEAD` gives `git` no branch to push to:
+
+```bash
+git -C "<path>" push --force-with-lease "$REMOTE" HEAD:refs/heads/$HEAD_REF
 ```
 
 Rejection modes:

--- a/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/rebase-flow.md
@@ -53,7 +53,7 @@ so `git status --porcelain` is empty by construction (no stash flow) and
 `--abbrev-ref HEAD` answers `HEAD` rather than a branch name — the
 default-branch refusal is made against `HEAD_REF` instead, per `safety.md` →
 "Never run on the default branch". The git-repo and in-progress-marker checks
-still run under `-C "<path>"`: a scratch directory left behind by an interrupted
+still run under `-C "<path>"`: a scratch worktree left behind by an interrupted
 run can be handed over mid-rebase.
 
 ## Resolve base branch

--- a/claude/skills/gh-pr-resolve-conflict/references/safety.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/safety.md
@@ -24,9 +24,15 @@ recoverable.
 
 Triggered only when preflight detects a non-empty working tree
 (`git status --porcelain` prints any line). In `--worktree` mode that trigger
-can never fire — the caller created the scratch worktree seconds earlier and
-nothing has written to it — so the whole stash flow is skipped, and the final
-report's `Stash:` line is omitted.
+can never fire *for a freshly created scratch worktree this round* — the
+caller (`gh:pr-merge-train`) just ran `git worktree add`, and nothing has
+written to it yet — so the whole stash flow is skipped, and the final
+report's `Stash:` line is omitted. This is distinct from a worktree the
+caller is *reusing* after an interrupted prior round (a crashed process, or
+one this skill itself left conflicted at a stop point below) — that tree can
+absolutely be dirty or mid-rebase, which is exactly what the in-progress
+operation guard right below exists to catch. "Clean by construction" is a
+claim about the fresh-add case only, never about an arbitrary `<path>`.
 
 1. Announce before running:
 

--- a/claude/skills/gh-pr-resolve-conflict/references/safety.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/safety.md
@@ -23,7 +23,10 @@ recoverable.
 ## Auto-stash
 
 Triggered only when preflight detects a non-empty working tree
-(`git status --porcelain` prints any line).
+(`git status --porcelain` prints any line). In `--worktree` mode that trigger
+can never fire — the caller created the scratch worktree seconds earlier and
+nothing has written to it — so the whole stash flow is skipped, and the final
+report's `Stash:` line is omitted.
 
 1. Announce before running:
 
@@ -57,6 +60,10 @@ Triggered only when preflight detects a non-empty working tree
 Always resolve marker paths through `git rev-parse --git-path`. In a git
 worktree the actual paths are under `.git/worktrees/<wt>/`, and hardcoded
 `.git/<name>` checks silently miss the marker.
+
+In `--worktree` mode this guard still runs — a scratch worktree abandoned
+mid-rebase by an interrupted run is exactly what it catches — with every `git`
+below taking `-C "<path>"`.
 
 ```bash
 for name in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD; do
@@ -108,6 +115,12 @@ fi
 The default branch should never be force-pushed by this skill. If the
 PR's head IS the default branch (cross-fork PR where the head came from
 a fork), that's out of scope — tell the user and stop.
+
+In `--worktree` mode `git -C "<path>" rev-parse --abbrev-ref HEAD` answers
+`HEAD` — the worktree is detached and has no branch to compare. The guard is
+not dropped, it moves to the thing that is actually at risk: compare `HEAD_REF`
+(the PR's `headRefName`, which the push refspec targets) against `DEFAULT`, and
+refuse on a match.
 
 ## Recovery cheat-sheet (for the final report)
 

--- a/claude/skills/gh-pr-resolve-outdated/SKILL.md
+++ b/claude/skills/gh-pr-resolve-outdated/SKILL.md
@@ -29,11 +29,19 @@ Record `START_TS=$(date +%s)` immediately for Step 5.
 |---|---|---|
 | `[pr-number]` | PR to resolve; auto-detect from branch if omitted | branch PR |
 | `[remote]` | Remote owning the PR's repo | `origin` |
+| `[--worktree <path>]` | Run every git command in `<path>` instead of the current checkout | current checkout |
+
+`--worktree <path>` makes `pr-number` **mandatory** — the caller
+(`gh:pr-merge-train`) hands over a detached worktree, which has no current
+branch to auto-detect a PR from. Everything else in this skill is unchanged;
+without the flag the behaviour is exactly what it was.
 
 Bind `TARGET_HOST` + `TARGET_REPO` from the remote's URL **before any `gh`
 call** (`references/github-target.md`, #1403), check `gh` auth, and enforce the
 hard preconditions (git repo · not default branch · clean tree · no in-progress
-rebase) per `references/preflight.md`. Capture `BACKUP_SHA=$(git rev-parse HEAD)`.
+rebase) per `references/preflight.md` — that file also lists which of them
+`--worktree` mode drops and why. Capture `BACKUP_SHA=$(git rev-parse HEAD)`
+(in `--worktree` mode, `git -C "<path>" rev-parse HEAD`).
 
 ## Step 2: Mergeable Triage
 
@@ -54,6 +62,8 @@ git fetch "$REMOTE" "$BASE"
 git rebase "$REMOTE/$BASE"
 ```
 
+In `--worktree` mode both become `git -C "<path>" ...`.
+
 Rebase exits non-zero with conflicts → `git rebase --abort` immediately,
 print `[FAIL] rebase produced conflicts — use /gh-pr-resolve-conflict
 <PR_NUMBER>` + exit 4. Never auto-guess — hand off to the sister skill.
@@ -65,6 +75,16 @@ Only after `git rebase` exits 0 and the tree is clean:
 ```bash
 git push --force-with-lease "$REMOTE" HEAD
 ```
+
+In `--worktree` mode, use the explicit refspec instead — a detached HEAD has
+no branch for `git` to infer a destination from, and a bare `HEAD` would be
+refused:
+
+```bash
+git -C "<path>" push --force-with-lease "$REMOTE" HEAD:refs/heads/$HEAD_REF
+```
+
+`HEAD_REF` is the `headRefName` Step 2 already read.
 
 Never plain `--force`. Rejected (remote advanced while rebasing) →
 `[FAIL] remote advanced — re-fetch and retry` + exit 6. Never silently
@@ -90,6 +110,7 @@ ai-metrics footer follows the sister-skill pattern; skip when
 - Never run on the repo's default branch.
 - Never auto-resolve conflicts — delegate to `gh:pr-resolve-conflict` (exit 4).
 - Never retry a rejected `--force-with-lease`; never auto-stash (clean tree required).
+- Never create or remove the `--worktree` path. The caller owns its lifecycle.
 
 ## Related Skills
 

--- a/claude/skills/gh-pr-resolve-outdated/references/help.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/help.md
@@ -6,6 +6,7 @@
 |--------|-------------|---------|
 | `[pr-number]` | Positional 1 — target PR to sync, e.g. `782`. | PR attached to the current branch |
 | `[remote]` | Positional 2 — git remote whose repo owns the PR. | `origin` |
+| `--worktree <path>` | Run every git command in `<path>` instead of the current checkout. Requires an explicit `pr-number`. | current checkout |
 | `-h` / `--help` / `help` | Print this help verbatim and stop. No API calls. | — |
 
 ## Usage
@@ -14,8 +15,15 @@
 /gh-pr-resolve-outdated              # PR attached to current branch, origin
 /gh-pr-resolve-outdated 782          # explicit PR, origin
 /gh-pr-resolve-outdated 782 upstream # explicit PR, upstream remote
+/gh-pr-resolve-outdated 782 origin --worktree /path/to/scratch   # rebase there
 /gh-pr-resolve-outdated -h           # this help
 ```
+
+`--worktree` exists for `gh:pr-merge-train`: the PR's head branch is usually
+already checked out in the worktree `gh:issue-flow` opened it from, so the train
+hands over a detached scratch worktree it created and will destroy. The push
+then uses an explicit `HEAD:refs/heads/<head>` refspec, since a detached HEAD
+names no branch.
 
 ## When to use this skill
 
@@ -68,7 +76,9 @@
   and re-rebase (lost-update risk).
 - **Default-branch refusal** — exit 2 if run while checked out on
   `main` (or the repo's configured default).
-- **Worktree-safe** — only the current worktree's branch is touched.
+- **Worktree-safe** — only the current worktree's branch is touched, or, with
+  `--worktree <path>`, only that path. The skill never creates or removes the
+  worktree it is pointed at; the caller owns it.
 
 ## Exit codes
 

--- a/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
@@ -1,7 +1,8 @@
 # Mergeable triage matrix
 
 Step 2 maps the host-pinned `gh pr view --repo "$TARGET_REPO" --json
-mergeable,mergeStateStatus` (see `references/github-target.md`) to an action:
+mergeable,mergeStateStatus,baseRefName,headRefName,url` (see
+`references/github-target.md`) to an action:
 
 | `mergeable` | `mergeStateStatus` | Action |
 |---|---|---|

--- a/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
@@ -12,6 +12,30 @@ mergeable,mergeStateStatus` (see `references/github-target.md`) to an action:
 
 `BLOCKED` alone (CI/approval pending) is not an out-of-date case — not handled here.
 
+Step 2's `--json` list already carries `headRefName` alongside `baseRefName`;
+keep it, `--worktree` mode's push needs it (below).
+
+## Step 3/4 in `--worktree <path>` mode
+
+Same two commands, redirected — no `cd`, and the session's checkout is left
+alone:
+
+```bash
+git -C "<path>" fetch "$REMOTE" "$BASE"
+git -C "<path>" rebase "$REMOTE/$BASE"
+```
+
+The push is the one place the command itself changes shape. The scratch
+worktree is detached, so `HEAD` alone names no destination branch and `git`
+refuses it; spell the refspec out with the `headRefName` from Step 2:
+
+```bash
+git -C "<path>" push --force-with-lease "$REMOTE" HEAD:refs/heads/$HEAD_REF
+```
+
+Without `--worktree` nothing here changes: bare `git fetch` / `git rebase`, and
+`git push --force-with-lease "$REMOTE" HEAD`.
+
 ## Step 5 verification
 
 After the push, re-read `--json mergeable,mergeStateStatus,url`:

--- a/claude/skills/gh-pr-resolve-outdated/references/preflight.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/preflight.md
@@ -50,6 +50,6 @@ skill just operates inside it.
   *refusal* is not dropped, it retargets: compare the PR's `headRefName` (what
   the push refspec writes to) against the repo default and stop on a match.
 - Keep the git-repo and no-in-progress-operation checks, scoped with
-  `-C "<path>"` — a stale scratch directory left by an interrupted run can
+  `-C "<path>"` — a stale scratch worktree left by an interrupted run can
   still be handed over.
 - This skill never creates or removes `<path>`. The caller owns it.

--- a/claude/skills/gh-pr-resolve-outdated/references/preflight.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/preflight.md
@@ -1,6 +1,7 @@
 # Step 1 — args, repo resolution, and hard preconditions
 
-Positional args: `[pr-number] [remote]`, both optional.
+Positional args: `[pr-number] [remote]`, both optional. One flag:
+`[--worktree <path>]`.
 
 - `remote` — default `origin`; missing → `git remote -v` + exit 2. Bind
   `TARGET_HOST` + `TARGET_REPO` from that one remote URL **before any `gh`
@@ -27,3 +28,28 @@ Positional args: `[pr-number] [remote]`, both optional.
 
 Capture `BACKUP_SHA=$(git rev-parse HEAD)` and print it for
 `git reset --hard <sha>` recovery.
+
+## `--worktree <path>` mode
+
+`gh:pr-merge-train` cannot check the PR's head branch out here: `gh:issue-flow`
+opened that PR from its own worktree, which still holds the branch. It passes a
+**detached scratch worktree** it created and will destroy instead, and this
+skill just operates inside it.
+
+- `pr-number` becomes **mandatory**. Auto-detect is unavailable — a detached
+  worktree has no current branch, so `gh pr view` has nothing to resolve a PR
+  from. Missing → `[FAIL] --worktree requires an explicit PR number` + exit 2.
+- Every git command in this skill runs as `git -C "<path>" ...` — preconditions,
+  fetch, rebase, push, status. No `cd`; the session's own checkout is never
+  touched, which is half the point of the flag.
+- `BACKUP_SHA=$(git -C "<path>" rev-parse HEAD)`.
+- **Skip** the clean-working-tree and current-branch-≠-default checks as
+  written. A worktree created seconds ago by `git worktree add --detach` is
+  clean by construction, and `--abbrev-ref HEAD` answers `HEAD` because it is
+  detached — neither check can return anything else. The default-branch
+  *refusal* is not dropped, it retargets: compare the PR's `headRefName` (what
+  the push refspec writes to) against the repo default and stop on a match.
+- Keep the git-repo and no-in-progress-operation checks, scoped with
+  `-C "<path>"` — a stale scratch directory left by an interrupted run can
+  still be handed over.
+- This skill never creates or removes `<path>`. The caller owns it.

--- a/docs/public/changelog.d/2026-08-27-1493.md
+++ b/docs/public/changelog.d/2026-08-27-1493.md
@@ -1,0 +1,2 @@
+- 변경: **gh:pr-merge-train 이 BEHIND/DIRTY PR 을 detached 스크래치 워크트리에서 리베이스하도록 바꿔, head 브랜치가 다른 워크트리에 체크아웃돼 있어도 트레인이 죽지 않는다 (#1493)**
+- 변경: **gh:pr-resolve-outdated / gh:pr-resolve-conflict 에 선택적 `--worktree <path>` 플래그 추가 — 모든 git 작업을 그 경로에서 수행하고 명시적 refspec 으로 push 한다 (플래그 없으면 기존 동작 그대로)**


### PR DESCRIPTION
## Summary
- `gh:pr-merge-train`이 BEHIND/DIRTY PR을 정리하려 할 때, 그 PR의 head 브랜치가 이미 다른 (이슈별) 워크트리에 체크아웃돼 있으면 `git checkout`이 `already used by worktree`로 즉시 실패해 트레인 전체가 죽던 결함을 고친다.
- `gh:issue-flow`가 PR을 항상 전용 워크트리에서 여는 이 저장소의 표준 패턴에서는 사실상 매번 재현되는 결함이었다.
- 해결: 리메디에이션마다 무조건 detached 스크래치 워크트리를 만들어 그 안에서 리베이스하고(브랜치 이름이 아니라 커밋만 물기 때문에 다른 워크트리와 충돌하지 않는다), 명시적 refspec으로 push한 뒤 트레인이 직접 정리한다.

## Changes
- `claude/skills/gh-pr-merge-train/references/train-loop.md`: "Detached scratch worktree" 절 신설 — `git fetch` → `git worktree add --detach` → 원자 스킬에 `--worktree` 위임 → 성공/실패 무관 무조건 `git worktree remove --force` (실패 시 `rm -rf` + `git worktree prune` 폴백). F-6 실패표에 `git worktree add` 실패 행 추가.
- `claude/skills/gh-pr-merge-train/references/routing-table.md`: STATE 조회에 `headRefName` 추가.
- `claude/skills/gh-pr-merge-train/SKILL.md`, `references/help.md`: Step 4 설명과 Related Skills를 스크래치 워크트리 동작에 맞게 갱신.
- `claude/skills/gh-pr-resolve-outdated/`, `claude/skills/gh-pr-resolve-conflict/` (SKILL.md + 각 references): 선택적 `--worktree <path>` 플래그 추가 — 지정 시 모든 git 명령을 `git -C "<path>"`로 실행하고, detached HEAD가 push 대상을 추론할 수 없으므로 명시적 refspec(`HEAD:refs/heads/<head>`)으로 push한다. 플래그 없이 호출되면 기존 동작 그대로(순수 추가적 변경).
  - `gh-pr-resolve-outdated/references/preflight.md`, `mergeable-triage.md`: `--worktree` 모드의 전제조건/명령 재작성.
  - `gh-pr-resolve-conflict/references/rebase-flow.md`: 동일 처리 + `baseRefName`과 함께 `headRefName`도 조회.
  - `gh-pr-resolve-conflict/references/safety.md`: 스크래치 워크트리는 항상 clean하므로 auto-stash가 발동하지 않음을 명시; default-branch 거부 검사는 detached HEAD에서 의미가 없으므로 `headRefName` 대상으로 재조준.
  - `gh-pr-resolve-conflict/references/conflict-handling.md`: `--worktree` 모드에서 `git status --short`의 상대 경로를 `Read`/`Edit` 전에 절대 경로로 조인해야 함을 명시; lockfile 재생성은 `(cd "<path>" && ...)`로 실행.
- `docs/public/changelog.d/2026-08-27-1493.md` (신설): 변경 기록 fragment.

## Test plan
- [x] `pytest tests/integration/test_gh_skill_host_pinning.py -q` — 새/수정된 모든 `gh` 호출이 host+repo pinning 규약을 지키는지 검증하는 회귀 게이트, 통과.
- [x] `pytest tests/integration/test_skill_check_docs.py -q` — 통과.
- [x] `pytest -q` (전체 1541건) — 편집 전 baseline과 동일하게 전부 통과, 회귀 없음.
- [x] `mise run lint-docs` — errors=0 (경고 36건은 모두 이 변경과 무관한 기존 legacy 파일명).

## Related
Closes #1493

---
<details>
<summary>🤖 AI Metrics · 📊 ~9500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
