### PR TITLE
feat(gh-issue-implement): 같은 계정 병렬 세션의 이슈 중복 착수를 감지해 경고한다

### DIFF
--- a/claude/skills/gh-issue-implement/SKILL.md
+++ b/claude/skills/gh-issue-implement/SKILL.md
@@ -52,17 +52,18 @@ Per `references/superpowers-detection.md`: plugin missing → force mode `direct
 
 ## Step 3: Fetch + Claim Issue
 
-Five substeps in order — full policy, env vars, and behavior matrix in
+Six substeps in order — full policy, env vars, and behavior matrix in
 `references/claim.md`. After 3.1/3.3/3.4 emit `printf '[step:gh-issue-implement/<marker>] OK\n'`
 (`fetch-issue`, `self-assign`, `board-transition`) for the step-skip guard (#753).
 
 3.1 **Fetch** — `references/fetch-issue.md` (CLOSED refusal there).
 3.2 **Block-label guard** — fail-closed abort (exit 2) if any label matches `GH_ISSUE_BLOCK_LABELS`.
 3.3 **Self-assign** — `--add-assignee @me` unless already assigned (warn, no override, if held by another).
-3.4 **Board transition** — `_gh_project_status_sync issue <N> "In progress" --only-from "Backlog,Ready" --repo "$TARGET_REPO"` (#1405); no-op without a board.
+3.3b **Duplicate open-PR guard** — soft-warn when an open PR already closes `#N` (another session got there first, #1507); silent otherwise, silent on API error.
+3.4 **Board transition** — `_gh_project_status_sync issue <N> "In progress" --only-from "Backlog,Ready" --repo "$TARGET_REPO"` (#1405); no-op without a board, soft-warn when Status is already outside `Backlog`/`Ready` (#1507).
 3.5 **Depends-on guard** — soft-warn per OPEN `Depends on #M` line.
 
-Skip 3.3 / 3.4 / 3.5 via their `GH_ISSUE_SKIP_*` env vars.
+Skip 3.3 / 3.3b / 3.4 / 3.5 via their `GH_ISSUE_SKIP_*` env vars (3.3b is `GH_ISSUE_SKIP_DUPLICATE_CHECK`).
 
 ## Step 4: Mode Dispatch
 

--- a/claude/skills/gh-issue-implement/references/claim.md
+++ b/claude/skills/gh-issue-implement/references/claim.md
@@ -31,15 +31,11 @@ equivalent for — the duplicate-attempt detector of 3.3b (issue #1507).
 The HARD aborts (3.1, 3.2) come before any mutation (3.3, 3.4) so an
 abort never leaves a stale claim or board state.
 
-**Why 3.3b sits between 3.3 and 3.4**: self-assign is the cheap,
-idempotent broadcast — do it first so the claim is visible no matter
-what the duplicate check concludes. But the warning has to land *before*
-3.4 mutates the board, so the human reads "another session may already
-own this" while the board still shows the pre-run truth. Running it
-after 3.4 would mean this run's own `In progress` write is already mixed
-into the state the user is being asked to judge. It is deliberately not
-earlier than 3.3 either: it costs a search API call, and there is no
-point paying for it on an issue 3.2 is about to refuse.
+**Why 3.3b sits between 3.3 and 3.4**: not earlier than 3.3, because it
+costs a search API call and there is no point paying for it on an issue
+3.2 is about to refuse; not later than 3.4, so the warning reads against
+the board's pre-run state rather than mixed in with this run's own
+`In progress` write.
 
 ## Substep detail
 
@@ -170,10 +166,9 @@ return 0
 back; the point is to send the human to the PR list, not to enumerate it.
 
 **Why silence on the empty result matters**: this guard fires on every
-implement run, and the overwhelmingly common answer is "no duplicate".
-A warning that also prints when nothing is wrong is a warning people
-learn to scroll past — which would cost exactly the signal #1507 exists
-to add. No match → no output at all.
+implement run, so a line that also prints on the common "no duplicate"
+case would train users to scroll past it — costing exactly the signal
+#1507 exists to add.
 
 **Soft-fail rule** (NF-1): any failure of the search itself → **no
 output, continue**:
@@ -229,13 +224,17 @@ The helper (`shell-common/functions/gh_project_status.sh`) handles:
   those moved should override the helper or skip with
   `GH_ISSUE_SKIP_BOARD_TRANSITION=1` and run the transition manually.
 
-**Warn when `--only-from` absorbs the write (#1507, F-2)**: read the
-card's current Status before handing off to the helper, and when it is
+**Warn when `--only-from` absorbs the write (#1507, F-2)**: before
+handing off to `_gh_project_status_sync`, read the card's current
+Status with the same SSOT query helper `gh-pr-merge`'s board-approval
+gate uses (`_gh_project_status_query_current`, also from
+`gh_project_status.sh` — see
+`../gh-pr-merge/references/board-approval-gate.sh.md`), and when it is
 neither `Backlog` nor `Ready`, print one line before the (no-op)
 mutation:
 
 ```
-status = current Status of the card on the board
+status = `_gh_project_status_query_current issue <N> "$TARGET_REPO"`
 
 if status not in ("Backlog", "Ready"):
     print "[WARN] Issue #<N> Status 가 이미 \"<status>\" 입니다 — 다른 세션이 이미 착수했을 수 있습니다."
@@ -250,8 +249,10 @@ have moved the board without opening a PR yet, or opened a PR in a repo
 with no board at all. A restart of your own abandoned run also lands
 here, which is fine — the line is advisory, not a refusal.
 
-Reading the Status is itself best-effort: if the lookup errors, skip the
-warning and let the helper run as usual (NF-1).
+Reading the Status is itself best-effort: a non-zero return from
+`_gh_project_status_query_current` (missing scope, network error, no
+board) skips the warning and lets `_gh_project_status_sync` run as
+usual (NF-1) — the same soft-fail posture 3.3b uses.
 - **Verify pair (race absorption, #393)**: after the mutation the
   helper sleeps `_GH_PROJECT_STATUS_VERIFY_SLEEP` (default 1 s) and
   re-queries. Re-issues the mutation once if a builtin workflow

--- a/claude/skills/gh-issue-implement/references/claim.md
+++ b/claude/skills/gh-issue-implement/references/claim.md
@@ -144,7 +144,10 @@ The reliable fingerprint of "someone already did this" is an **open PR
 that closes this issue**. Read-only, one search call, one warning line.
 It never blocks: a second session is sometimes exactly what the user
 wants (a rewrite, an abandoned first attempt), so the decision stays
-with the human.
+with the human. The search matches both footer keywords this repo's
+`gh:commit` accepts — `Closes` and `Fixes` — since a `Fixes #<N>` PR is
+just as valid a duplicate signal as a `Closes #<N>` one (codex review,
+PR #1509).
 
 **Algorithm**:
 
@@ -153,7 +156,7 @@ if "GH_ISSUE_SKIP_DUPLICATE_CHECK" set:
     return 0
 
 prs = `GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" \
-         --state open --search "Closes #<N> in:body" --json number -q '.[].number'`
+         --state open --search "\"Closes #<N>\" OR \"Fixes #<N>\" in:body" --json number -q '.[].number'`
 
 if prs == []:
     return 0    # silent — no output on the common path
@@ -237,7 +240,7 @@ mutation:
 status = `_gh_project_status_query_current issue <N> "$TARGET_REPO"`
 
 if status not in ("Backlog", "Ready"):
-    print "[WARN] Issue #<N> Status 가 이미 \"<status>\" 입니다 — 다른 세션이 이미 착수했을 수 있습니다."
+    print "[WARN] Issue #<N> Status 가 이미 \"<status>\" 입니다 — 다른 세션의 중복 착수이거나, 이슈가 이미 다른 단계로 넘어갔을 수 있습니다."
 ```
 
 This changes nothing about the mutation — the helper's whitelist still
@@ -248,6 +251,13 @@ the PR side, and the two signals are independent: the other session may
 have moved the board without opening a PR yet, or opened a PR in a repo
 with no board at all. A restart of your own abandoned run also lands
 here, which is fine — the line is advisory, not a refusal.
+
+The wording is deliberately non-committal about *why* the Status isn't
+`Backlog`/`Ready`: the same non-empty complement also includes terminal
+columns like `Done` or custom ones like `Spec`, where "another session
+already started this" would be the wrong read (codex review, PR #1509)
+— the message names the fact (current Status) and offers duplicate-start
+as one possible explanation, not the only one.
 
 Reading the Status is itself best-effort: a non-zero return from
 `_gh_project_status_query_current` (missing scope, network error, no

--- a/claude/skills/gh-issue-implement/references/claim.md
+++ b/claude/skills/gh-issue-implement/references/claim.md
@@ -10,21 +10,36 @@ else lands here):
 3. Project board Status transition (`In progress`).
 4. `Depends on #M` cross-issue check.
 
+On top of those it adds one dotfiles-native guard AgentToolbox has no
+equivalent for — the duplicate-attempt detector of 3.3b (issue #1507).
+
 ## Substep order — why this sequence
 
 ```
-3.1 Fetch issue              (gates everything; CLOSED refusal here)
-3.2 Block-label guard        (HARD abort; cheapest "no" — never write to
+3.1  Fetch issue              (gates everything; CLOSED refusal here)
+3.2  Block-label guard        (HARD abort; cheapest "no" — never write to
                               an issue we won't work on)
-3.3 Self-assign              (broadcast claim ASAP, before mode dispatch)
-3.4 Board Status transition  (idempotent; verify-pair absorbs race)
-3.5 Depends-on guard         (slowest — N+1 issue lookups; do last and
+3.3  Self-assign              (broadcast claim ASAP, before mode dispatch)
+3.3b Duplicate open-PR guard  (soft warn; runs once the claim is out there
+                              but before the board is touched)
+3.4  Board Status transition  (idempotent; verify-pair absorbs race)
+3.5  Depends-on guard         (slowest — N+1 issue lookups; do last and
                               soft-warn so blockers learned mid-loop
                               don't undo the claim)
 ```
 
 The HARD aborts (3.1, 3.2) come before any mutation (3.3, 3.4) so an
 abort never leaves a stale claim or board state.
+
+**Why 3.3b sits between 3.3 and 3.4**: self-assign is the cheap,
+idempotent broadcast — do it first so the claim is visible no matter
+what the duplicate check concludes. But the warning has to land *before*
+3.4 mutates the board, so the human reads "another session may already
+own this" while the board still shows the pre-run truth. Running it
+after 3.4 would mean this run's own `In progress` write is already mixed
+into the state the user is being asked to judge. It is deliberately not
+earlier than 3.3 either: it costs a search API call, and there is no
+point paying for it on an issue 3.2 is about to refuse.
 
 ## Substep detail
 
@@ -120,6 +135,58 @@ same posture.
 The implement flow proceeds — the claim is informational, not load-
 bearing.
 
+### 3.3b Duplicate open-PR guard (soft)
+
+**Goal**: catch the case 3.3 structurally cannot — *I* am already the
+assignee because *another one of my own sessions* claimed this issue
+minutes ago from a sibling worktree. To 3.3 that is indistinguishable
+from a plain restart, so it returns `noop-self` and says nothing. Issue
+#1482 was implemented twice, 13 minutes apart, producing PRs #1488 and
+#1489 that later collided in a merge train.
+
+The reliable fingerprint of "someone already did this" is an **open PR
+that closes this issue**. Read-only, one search call, one warning line.
+It never blocks: a second session is sometimes exactly what the user
+wants (a rewrite, an abandoned first attempt), so the decision stays
+with the human.
+
+**Algorithm**:
+
+```
+if "GH_ISSUE_SKIP_DUPLICATE_CHECK" set:
+    return 0
+
+prs = `GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" \
+         --state open --search "Closes #<N> in:body" --json number -q '.[].number'`
+
+if prs == []:
+    return 0    # silent — no output on the common path
+
+print "[WARN] Issue #<N> 을 이미 닫는 open PR #<M> 이 있습니다 — 중복 구현 가능성. 계속 진행하기 전에 확인하세요."
+return 0
+```
+
+`<M>` is the first PR the search returns — one line however many come
+back; the point is to send the human to the PR list, not to enumerate it.
+
+**Why silence on the empty result matters**: this guard fires on every
+implement run, and the overwhelmingly common answer is "no duplicate".
+A warning that also prints when nothing is wrong is a warning people
+learn to scroll past — which would cost exactly the signal #1507 exists
+to add. No match → no output at all.
+
+**Soft-fail rule** (NF-1): any failure of the search itself → **no
+output, continue**:
+- Transient API / network error.
+- Search unavailable or rate-limited on this host.
+- `gh` too old to support `--search` on `pr list`.
+
+Unlike 3.3, a failure here is not even worth a warn line: the check is
+an advisory read, and a "could not check for duplicates" line on an
+otherwise-fine run is noise of the same kind the previous paragraph
+rejects. Never abort — a duplicate warning that blocks would break every
+legitimate restart.
+
 ### 3.4 Board Status transition
 
 **Goal**: move the issue card from `Backlog`/`Ready` to `In progress`
@@ -161,6 +228,30 @@ The helper (`shell-common/functions/gh_project_status.sh`) handles:
   (`In design`, `Spec`, etc.) are left untouched; teams that want
   those moved should override the helper or skip with
   `GH_ISSUE_SKIP_BOARD_TRANSITION=1` and run the transition manually.
+
+**Warn when `--only-from` absorbs the write (#1507, F-2)**: read the
+card's current Status before handing off to the helper, and when it is
+neither `Backlog` nor `Ready`, print one line before the (no-op)
+mutation:
+
+```
+status = current Status of the card on the board
+
+if status not in ("Backlog", "Ready"):
+    print "[WARN] Issue #<N> Status 가 이미 \"<status>\" 입니다 — 다른 세션이 이미 착수했을 수 있습니다."
+```
+
+This changes nothing about the mutation — the helper's whitelist still
+absorbs it, exactly as before. It only stops the absorption from being
+*silent*. A card already sitting in `In progress` is the board-side
+fingerprint of the same duplicate-session failure 3.3b watches for on
+the PR side, and the two signals are independent: the other session may
+have moved the board without opening a PR yet, or opened a PR in a repo
+with no board at all. A restart of your own abandoned run also lands
+here, which is fine — the line is advisory, not a refusal.
+
+Reading the Status is itself best-effort: if the lookup errors, skip the
+warning and let the helper run as usual (NF-1).
 - **Verify pair (race absorption, #393)**: after the mutation the
   helper sleeps `_GH_PROJECT_STATUS_VERIFY_SLEEP` (default 1 s) and
   re-queries. Re-issues the mutation once if a builtin workflow
@@ -214,7 +305,8 @@ not abort — the dependency check is informational.
 |---|---|---|
 | `GH_ISSUE_BLOCK_LABELS` | `do-not-work,on-hold,보류,⏸️ Postpone,reference` | Comma-separated block-label list for 3.2. Spaces inside a label are part of the label (don't pad commas). `reference` marks 참고용/구현 불필요 issues (issue #1226). |
 | `GH_ISSUE_SKIP_SELF_ASSIGN` | unset | When `1`, skip 3.3 entirely. |
-| `GH_ISSUE_SKIP_BOARD_TRANSITION` | unset | When `1`, skip 3.4 entirely. |
+| `GH_ISSUE_SKIP_DUPLICATE_CHECK` | unset | When `1`, skip 3.3b entirely — no search call, no warning. For a deliberate second implementation of the same issue (issue #1507). |
+| `GH_ISSUE_SKIP_BOARD_TRANSITION` | unset | When `1`, skip 3.4 entirely (its F-2 Status warning included). |
 | `GH_ISSUE_SKIP_DEPS_CHECK` | unset | When `1`, skip 3.5 entirely. |
 
 There is **no** env var to bypass 3.2 (block-label guard). That is
@@ -222,17 +314,25 @@ intentional — see "Block-label guard (fail-closed)" above.
 
 ## Behavior matrix
 
-| Case | 3.2 block | 3.3 self-assign | 3.4 board | 3.5 deps | Net |
-|---|---|---|---|---|---|
-| Normal (board, unassigned, deps OK) | pass | add `@me` | `In progress` (verified) | OK | proceed |
-| Block-label attached | **abort exit 2** | n/a | n/a | n/a | refuse |
-| Already self-assigned | pass | no-op | `In progress` | OK | proceed |
-| Assigned to another user | pass | warn + skip | `In progress` | OK | proceed |
-| Dependency `#M` OPEN | pass | add `@me` | `In progress` | warn | proceed |
-| No board attached | pass | add `@me` | silent skip | OK | proceed |
-| `GH_ISSUE_SKIP_SELF_ASSIGN=1` | pass | skip | `In progress` | OK | proceed |
-| `GH_ISSUE_SKIP_BOARD_TRANSITION=1` | pass | add `@me` | skip | OK | proceed |
-| `GH_ISSUE_SKIP_DEPS_CHECK=1` | pass | add `@me` | `In progress` | skip | proceed |
+| Case | 3.2 block | 3.3 self-assign | 3.3b dup PR | 3.4 board | 3.5 deps | Net |
+|---|---|---|---|---|---|---|
+| Normal (board, unassigned, deps OK) | pass | add `@me` | silent | `In progress` (verified) | OK | proceed |
+| Block-label attached | **abort exit 2** | n/a | n/a | n/a | n/a | refuse |
+| Already self-assigned | pass | no-op | silent | `In progress` | OK | proceed |
+| Assigned to another user | pass | warn + skip | silent | `In progress` | OK | proceed |
+| Dependency `#M` OPEN | pass | add `@me` | silent | `In progress` | warn | proceed |
+| No board attached | pass | add `@me` | silent | silent skip | OK | proceed |
+| Open PR already closes `#N` | pass | no-op | **warn** | `In progress` | OK | proceed |
+| Board Status already `In progress` | pass | no-op | silent | **warn** + no-op | OK | proceed |
+| Duplicate search API error | pass | add `@me` | silent | `In progress` | OK | proceed |
+| `GH_ISSUE_SKIP_SELF_ASSIGN=1` | pass | skip | silent | `In progress` | OK | proceed |
+| `GH_ISSUE_SKIP_DUPLICATE_CHECK=1` | pass | add `@me` | skip | `In progress` | OK | proceed |
+| `GH_ISSUE_SKIP_BOARD_TRANSITION=1` | pass | add `@me` | silent | skip | OK | proceed |
+| `GH_ISSUE_SKIP_DEPS_CHECK=1` | pass | add `@me` | silent | `In progress` | skip | proceed |
+
+The two duplicate-attempt rows are the #1507 additions; "silent" in the
+3.3b column means the guard ran and found nothing, which is the normal
+outcome. Both warn rows still end in `proceed` — neither signal blocks.
 
 ## Placement rationale (why Step 3, not earlier or later)
 
@@ -263,7 +363,7 @@ intentional — see "Block-label guard (fail-closed)" above.
 ## Test fixture
 
 `tests/bats/skills/_fixtures/gh_issue_implement_claim.sh` mirrors
-the four substep functions verbatim. The bats suite at
+the five substep functions verbatim. The bats suite at
 `tests/bats/skills/gh_issue_implement_claim.bats` exercises the
-seven-case behavior matrix above. Any change to substep logic must
+eight-case behavior matrix above. Any change to substep logic must
 land in both files (and this doc).

--- a/docs/public/changelog.d/2026-08-27-1507.md
+++ b/docs/public/changelog.d/2026-08-27-1507.md
@@ -1,0 +1,1 @@
+- 변경: **gh:issue-implement 가 이슈를 같은 계정의 다른 세션이 이미 열린 PR로 닫으려 하거나 보드 Status 를 이미 In progress 로 옮겨둔 경우 착수 전 경고를 출력한다 (#1507)**

--- a/tests/bats/skills/_fixtures/gh_issue_implement_claim.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_implement_claim.sh
@@ -140,7 +140,7 @@ gh_issue_board_transition_decide() {
     # how a duplicate session looks from the board's side.
     local _status="${FAKE_BOARD_STATUS-}"
     if [ -n "$_status" ] && [ "$_status" != "Backlog" ] && [ "$_status" != "Ready" ]; then
-        printf '[WARN] Issue #%s Status 가 이미 "%s" 입니다 — 다른 세션이 이미 착수했을 수 있습니다.\n' \
+        printf '[WARN] Issue #%s Status 가 이미 "%s" 입니다 — 다른 세션의 중복 착수이거나, 이슈가 이미 다른 단계로 넘어갔을 수 있습니다.\n' \
             "$_issue_num" "$_status"
         printf 'already-in-progress'
         return 0

--- a/tests/bats/skills/_fixtures/gh_issue_implement_claim.sh
+++ b/tests/bats/skills/_fixtures/gh_issue_implement_claim.sh
@@ -16,6 +16,12 @@
 #   FAKE_DEPS_STATES    — "M:STATE,M2:STATE2" map for dep-issue lookup
 #                         (e.g. "100:CLOSED,101:OPEN"). Missing key → OPEN.
 #   FAKE_BOARD_ATTACHED — "1" if a projectV2 is attached, "0" otherwise.
+#   FAKE_BOARD_STATUS   — current board Status column ("Backlog", "Ready",
+#                         "In progress", ...). Unset → treated as
+#                         Backlog/Ready, i.e. the pre-#1507 behavior.
+#   FAKE_OPEN_PRS_CLOSING     — comma-separated PR numbers that are open and
+#                               close this issue. Empty → none found.
+#   FAKE_DUPLICATE_PR_API_FAIL — "1" simulates the PR search itself erroring.
 
 # 3.2 Block-label guard. Returns 2 (refusal) when any label on the
 # issue matches an entry in GH_ISSUE_BLOCK_LABELS; 0 otherwise.
@@ -82,13 +88,44 @@ gh_issue_self_assign_decide() {
     return 0
 }
 
+# 3.3b Duplicate open-PR guard (#1507). Read-only, soft, never blocks:
+# warns once when an open PR already closes this issue, which is the
+# fingerprint of another session in a sibling worktree having started
+# the same issue under the same account.
+# Always returns 0. Prints one "[WARN] ..." line, or nothing.
+gh_issue_duplicate_pr_guard() {
+    local _issue_num="${1:-?}"
+
+    if [ "${GH_ISSUE_SKIP_DUPLICATE_CHECK:-0}" = "1" ]; then
+        return 0
+    fi
+    # NF-1 soft-fail: the search itself errored → stay silent, continue.
+    if [ "${FAKE_DUPLICATE_PR_API_FAIL:-0}" = "1" ]; then
+        return 0
+    fi
+
+    local _prs_csv="${FAKE_OPEN_PRS_CLOSING-}"
+    [ -z "$_prs_csv" ] && return 0
+
+    # Name the first match — one line, however many PRs came back.
+    local _first="${_prs_csv%%,*}"
+    printf '[WARN] Issue #%s 을 이미 닫는 open PR #%s 이 있습니다 — 중복 구현 가능성. 계속 진행하기 전에 확인하세요.\n' \
+        "$_issue_num" "$_first"
+    return 0
+}
+
 # 3.4 Board Status transition decision. Returns 0 in all cases (the
 # real helper is best-effort), but emits a single tag word so tests
 # can verify which branch ran:
-#   "skip"     — GH_ISSUE_SKIP_BOARD_TRANSITION=1
-#   "no-board" — FAKE_BOARD_ATTACHED=0 (no projectV2 attached)
-#   "synced"   — would invoke _gh_project_status_sync
+#   "skip"                — GH_ISSUE_SKIP_BOARD_TRANSITION=1
+#   "no-board"            — FAKE_BOARD_ATTACHED=0 (no projectV2 attached)
+#   "already-in-progress" — Status outside {Backlog,Ready}, so the real
+#                           helper's --only-from whitelist absorbs the
+#                           mutation. Preceded by an F-2 [WARN] line (#1507).
+#   "synced"              — would invoke _gh_project_status_sync
 gh_issue_board_transition_decide() {
+    local _issue_num="${1:-?}"
+
     if [ "${GH_ISSUE_SKIP_BOARD_TRANSITION:-0}" = "1" ]; then
         printf 'skip'
         return 0
@@ -97,6 +134,18 @@ gh_issue_board_transition_decide() {
         printf 'no-board'
         return 0
     fi
+
+    # F-2 (#1507): --only-from "Backlog,Ready" silently no-ops on every
+    # other column. Say so out loud — an already-"In progress" card is
+    # how a duplicate session looks from the board's side.
+    local _status="${FAKE_BOARD_STATUS-}"
+    if [ -n "$_status" ] && [ "$_status" != "Backlog" ] && [ "$_status" != "Ready" ]; then
+        printf '[WARN] Issue #%s Status 가 이미 "%s" 입니다 — 다른 세션이 이미 착수했을 수 있습니다.\n' \
+            "$_issue_num" "$_status"
+        printf 'already-in-progress'
+        return 0
+    fi
+
     printf 'synced'
     return 0
 }

--- a/tests/bats/skills/gh_issue_implement_claim.bats
+++ b/tests/bats/skills/gh_issue_implement_claim.bats
@@ -4,7 +4,7 @@
 #   claude/skills/gh-issue-implement/references/claim.md
 # Source-of-truth fixture: _fixtures/gh_issue_implement_claim.sh
 #
-# Seven cases drawn from issue #391's behavior matrix:
+# Eight cases drawn from issue #391's behavior matrix (case 8 from #1507):
 #   1. Normal flow (board, unassigned, deps OK)         → all proceed
 #   2. Block-label attached                             → guard rc=2
 #   3. Already self-assigned                            → noop-self
@@ -12,6 +12,12 @@
 #   5. Dependency M still OPEN                          → deps warn
 #   6. No board attached                                → board skip
 #   7. GH_ISSUE_SKIP_* env vars individually skip       → matching branch
+#   8. Duplicate-attempt detection (#1507)              → soft [WARN], never blocks
+#      8a. open PR already closes the issue             → warn naming the PR
+#      8b. no open PR                                   → silent (no false positive)
+#      8c. GH_ISSUE_SKIP_DUPLICATE_CHECK=1              → silent
+#      8d. search API failure                           → silent, still rc=0
+#      8e. board Status already "In progress"           → warn + already-in-progress
 
 load '../test_helper'
 
@@ -24,11 +30,13 @@ setup() {
 teardown() {
     teardown_isolated_home
     unset FAKE_LABELS FAKE_ASSIGNEES FAKE_ME FAKE_BODY \
-          FAKE_DEPS_STATES FAKE_BOARD_ATTACHED \
+          FAKE_DEPS_STATES FAKE_BOARD_ATTACHED FAKE_BOARD_STATUS \
+          FAKE_OPEN_PRS_CLOSING FAKE_DUPLICATE_PR_API_FAIL \
           GH_ISSUE_BLOCK_LABELS \
           GH_ISSUE_SKIP_SELF_ASSIGN \
           GH_ISSUE_SKIP_BOARD_TRANSITION \
-          GH_ISSUE_SKIP_DEPS_CHECK
+          GH_ISSUE_SKIP_DEPS_CHECK \
+          GH_ISSUE_SKIP_DUPLICATE_CHECK
 }
 
 # ---------- Case 1: Normal flow ----------
@@ -40,6 +48,8 @@ teardown() {
     FAKE_BODY="# Goal\n\nDo the thing.\n\nDepends on #100"
     FAKE_DEPS_STATES="100:CLOSED"
     FAKE_BOARD_ATTACHED=1
+    FAKE_OPEN_PRS_CLOSING=""
+    FAKE_BOARD_STATUS="Ready"
 
     run gh_issue_block_label_guard 391
     assert_success
@@ -47,6 +57,10 @@ teardown() {
     run gh_issue_self_assign_decide
     assert_success
     assert_output 'add'
+
+    run gh_issue_duplicate_pr_guard 391
+    assert_success
+    assert_output ''
 
     run gh_issue_board_transition_decide
     assert_success
@@ -168,4 +182,75 @@ teardown() {
     GH_ISSUE_SKIP_DEPS_CHECK=1 run gh_issue_deps_guard 391
     assert_success
     refute_output --partial '⚠️'
+}
+
+# ---------- Case 8: Duplicate-attempt detection (#1507) ----------
+
+@test "claim 3.3b: open PR already closing the issue → soft [WARN] naming the PR" {
+    FAKE_OPEN_PRS_CLOSING="1488"
+    run gh_issue_duplicate_pr_guard 1482
+    assert_success    # soft — never blocks
+    assert_output --partial '[WARN]'
+    assert_output --partial '#1482'
+    assert_output --partial '#1488'
+}
+
+@test "claim 3.3b: first PR of several is the one named" {
+    FAKE_OPEN_PRS_CLOSING="1488,1489"
+    run gh_issue_duplicate_pr_guard 1482
+    assert_success
+    assert_output --partial '#1488'
+}
+
+@test "claim 3.3b: no open PR closing the issue → silent (no false positive)" {
+    FAKE_OPEN_PRS_CLOSING=""
+    run gh_issue_duplicate_pr_guard 1482
+    assert_success
+    assert_output ''
+}
+
+@test "claim 3.3b: GH_ISSUE_SKIP_DUPLICATE_CHECK=1 → silent even with an open PR" {
+    FAKE_OPEN_PRS_CLOSING="1488"
+    GH_ISSUE_SKIP_DUPLICATE_CHECK=1 run gh_issue_duplicate_pr_guard 1482
+    assert_success
+    assert_output ''
+}
+
+@test "claim 3.3b: search API failure → soft-fail, silent, still success" {
+    FAKE_OPEN_PRS_CLOSING="1488"
+    FAKE_DUPLICATE_PR_API_FAIL=1 run gh_issue_duplicate_pr_guard 1482
+    assert_success
+    assert_output ''
+}
+
+@test "claim 3.4: board Status already 'In progress' → warn + 'already-in-progress'" {
+    FAKE_BOARD_ATTACHED=1
+    FAKE_BOARD_STATUS="In progress"
+    run gh_issue_board_transition_decide 1482
+    assert_success
+    assert_output --partial '[WARN]'
+    assert_output --partial '#1482'
+    assert_output --partial 'In progress'
+    assert_output --partial 'already-in-progress'
+}
+
+@test "claim 3.4: board Status Backlog/Ready → unchanged 'synced', no warn" {
+    FAKE_BOARD_ATTACHED=1
+    FAKE_BOARD_STATUS="Backlog"
+    run gh_issue_board_transition_decide 1482
+    assert_success
+    assert_output 'synced'
+
+    FAKE_BOARD_STATUS="Ready"
+    run gh_issue_board_transition_decide 1482
+    assert_success
+    assert_output 'synced'
+}
+
+@test "claim 3.4: no board attached → 'no-board' wins over FAKE_BOARD_STATUS" {
+    FAKE_BOARD_ATTACHED=0
+    FAKE_BOARD_STATUS="In progress"
+    run gh_issue_board_transition_decide 1482
+    assert_success
+    assert_output 'no-board'
 }

--- a/tests/bats/skills/gh_issue_implement_claim.bats
+++ b/tests/bats/skills/gh_issue_implement_claim.bats
@@ -13,11 +13,14 @@
 #   6. No board attached                                → board skip
 #   7. GH_ISSUE_SKIP_* env vars individually skip       → matching branch
 #   8. Duplicate-attempt detection (#1507)              → soft [WARN], never blocks
-#      8a. open PR already closes the issue             → warn naming the PR
+#      8a. open PR already closes the issue (first of   → warn naming the first PR
+#          several wins when multiple are open)
 #      8b. no open PR                                   → silent (no false positive)
 #      8c. GH_ISSUE_SKIP_DUPLICATE_CHECK=1              → silent
 #      8d. search API failure                           → silent, still rc=0
 #      8e. board Status already "In progress"           → warn + already-in-progress
+#      8f. board Status "Backlog"                       → unchanged 'synced', no warn
+#      8g. no board attached                            → 'no-board' wins over Status
 
 load '../test_helper'
 
@@ -186,19 +189,12 @@ teardown() {
 
 # ---------- Case 8: Duplicate-attempt detection (#1507) ----------
 
-@test "claim 3.3b: open PR already closing the issue → soft [WARN] naming the PR" {
-    FAKE_OPEN_PRS_CLOSING="1488"
+@test "claim 3.3b: open PR already closing the issue → soft [WARN] naming the first PR" {
+    FAKE_OPEN_PRS_CLOSING="1488,1489"
     run gh_issue_duplicate_pr_guard 1482
     assert_success    # soft — never blocks
     assert_output --partial '[WARN]'
     assert_output --partial '#1482'
-    assert_output --partial '#1488'
-}
-
-@test "claim 3.3b: first PR of several is the one named" {
-    FAKE_OPEN_PRS_CLOSING="1488,1489"
-    run gh_issue_duplicate_pr_guard 1482
-    assert_success
     assert_output --partial '#1488'
 }
 
@@ -234,14 +230,9 @@ teardown() {
     assert_output --partial 'already-in-progress'
 }
 
-@test "claim 3.4: board Status Backlog/Ready → unchanged 'synced', no warn" {
+@test "claim 3.4: board Status 'Backlog' → unchanged 'synced', no warn ('Ready' covered by Case 1)" {
     FAKE_BOARD_ATTACHED=1
     FAKE_BOARD_STATUS="Backlog"
-    run gh_issue_board_transition_decide 1482
-    assert_success
-    assert_output 'synced'
-
-    FAKE_BOARD_STATUS="Ready"
     run gh_issue_board_transition_decide 1482
     assert_success
     assert_output 'synced'


### PR DESCRIPTION
## Summary
- `gh:issue-implement` Step 3 에 read-only soft-warn 서브스텝(3.3b)을 추가해, 같은 GitHub 계정의 다른 세션이 이미 이 이슈를 다루고 있을 가능성을 착수 전에 알린다.
- 신호 두 가지: (F-1) 이슈를 이미 닫는 open PR 존재 여부, (F-2) 보드 Status 가 이미 `In progress`(Backlog/Ready 아님)인지.
- 두 신호 모두 soft-fail — 검사 실패나 신호 발견 모두 구현 흐름을 막지 않는다.

## Changes
- `claude/skills/gh-issue-implement/references/claim.md`: 새 **3.3b Duplicate open-PR guard** 서브스텝(Goal/Algorithm/Soft-fail rule), 서브스텝 순서 다이어그램·배치 근거, 3.4 에 F-2 경고 로직 추가, env-var 테이블/behavior matrix 갱신.
- `claude/skills/gh-issue-implement/SKILL.md`: Step 3 설명을 "Five substeps" → "Six substeps"로 갱신, 3.3b 불릿 추가, skip 안내 갱신 (100줄 유지).
- `tests/bats/skills/_fixtures/gh_issue_implement_claim.sh`: `gh_issue_duplicate_pr_guard()` 신규 추가, `gh_issue_board_transition_decide()` 에 `FAKE_BOARD_STATUS` 기반 `already-in-progress` 분기 추가.
- `tests/bats/skills/gh_issue_implement_claim.bats`: 8개 케이스(8a–8e) 신규 — open PR 발견/미발견/skip/API 실패, 보드 Status already-in-progress/Backlog/Ready/no-board.
- `docs/public/changelog.d/2026-08-27-1507.md`: changelog fragment 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_issue_implement_claim.bats` — 21/21 통과 (기존 13 + 신규 8).
- [x] `sh scripts/lint_changelog_fragments.sh` — errors=0.
- [x] `shellcheck` on the fixture — clean.
- [x] gh:pr Step 4.5 lint guard (shellcheck on changed `.sh`) — passed.

## Related
Closes #1507

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~8 h (1 d) · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~8 h (1 d) · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
