### PR TITLE
feat(gh-pr-merge): 머지 후 herdr tab idle 상태를 감지해 정리를 제안한다

### DIFF
--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -73,6 +73,11 @@ Run the two post-merge board reconciliations (PR card → Done; linked Issue car
 auto-detect repos without a projectV2 attachment and silently return; failures
 hit stderr, never block the report.
 
+Then run the herdr idle-tab hint per `references/herdr-tab-notify.sh.md` — one
+`[INFO]` line when the merged branch's local worktree still has an idle herdr
+tab (soft-fail and read-only; skip entirely when there is no local worktree, no
+`herdr`, or the agent is not idle — never close a tab or delete a worktree).
+
 After the board sync completes, post the ai-metrics PR comment per
 `references/ai-metrics-comment.sh.md` (soft-fail; skip entirely when `GH_DISABLE_AI_METRICS=1`).
 

--- a/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md
+++ b/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md
@@ -1,0 +1,101 @@
+# herdr Tab Notify — post-merge idle-tab hint (soft-fail, read-only)
+
+Runs inside Step 4 (post-merge housekeeping), after the board
+reconciliations. `HEAD_REF` is the merged PR's `headRefName`, already
+fetched by Step 2's `gh pr view --json ...,headRefName,...` — carry that
+value forward, do **not** re-fetch it. Step 3's `--delete-branch` removes
+the *remote* branch; the local branch a worktree is checked out on is
+untouched, so the `git worktree list` lookup below still resolves.
+
+Purpose: when the merged branch was implemented in a local git worktree
+that still has a `herdr` agent tab parked on it, and that tab is `idle`,
+print **one** informational line so the human can tear it down. Nothing is
+closed, removed, or otherwise mutated — every herdr/git call here is a
+read-only `list` (NF-2). A `working`/`blocked` agent prints nothing at
+all: silence, not a second info line (F-4).
+
+```bash
+# F-1: locate the local worktree checked out on the merged branch.
+# substr() rather than $2 so a worktree path containing spaces still
+# resolves; --porcelain guarantees the "worktree <path>" / "branch <ref>"
+# line pairing this relies on.
+BRANCH="${HEAD_REF}"
+WT_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${BRANCH}" \
+    '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+
+# NF-1: every gate below is a silent skip. No worktree (the merge ran on a
+# different machine), no herdr, no jq → the merge report is unaffected.
+if [ -n "$WT_PATH" ] && command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    # F-2: read-only agent enumeration; match on cwd == worktree path.
+    if AGENT_JSON=$(herdr agent list 2>/dev/null); then
+        # head -1: two agents on one cwd is abnormal — take the first,
+        # ignore the rest, warn about nothing (Error Cases).
+        MATCH=$(printf '%s' "$AGENT_JSON" | jq -r --arg cwd "$WT_PATH" \
+            '.result.agents[]? | select(.cwd == $cwd)
+             | "\(.tab_id)\t\(.agent_status)\t\(.workspace_id)"' 2>/dev/null | head -1)
+
+        if [ -n "$MATCH" ]; then
+            TAB_ID=$(printf '%s' "$MATCH" | cut -f1)
+            AGENT_STATUS=$(printf '%s' "$MATCH" | cut -f2)
+            WS_ID=$(printf '%s' "$MATCH" | cut -f3)
+
+            # F-4: working/blocked/anything-but-idle prints nothing at all,
+            # and does not even pay for the second lookup.
+            if [ "$AGENT_STATUS" = "idle" ]; then
+                # Label is cosmetic — fall back to the raw workspace id when
+                # this read-only lookup fails or the workspace is unlabeled.
+                WS_LABEL=$(herdr workspace list 2>/dev/null | jq -r --arg id "$WS_ID" \
+                    '.result.workspaces[]? | select(.workspace_id == $id) | .label' 2>/dev/null | head -1)
+
+                # F-3: exactly one line, only for an idle agent.
+                printf "[INFO] herdr tab %s/%s is idle for the merged branch's worktree (%s) — consider: herdr tab close %s / ai-worktree:teardown\n" \
+                    "${WS_LABEL:-$WS_ID}" "$TAB_ID" "$WT_PATH" "$TAB_ID"
+            fi
+        fi
+    fi
+fi
+```
+
+## Failure modes
+
+Every one of these is a silent skip that leaves the Step 5 merge report
+byte-identical (NF-1). None of them warn, and none of them return
+non-zero to the caller.
+
+- **`HEAD_REF` empty / no local worktree on that branch** — the usual case
+  when the PR was implemented on another machine, or the worktree was
+  already torn down. `WT_PATH` is empty → nothing printed.
+- **`herdr` not installed** — `command -v herdr` fails → nothing printed,
+  and the rest of `gh:pr-merge` runs normally. This is the expected state
+  on any machine without the agent runner.
+- **`jq` not installed** — same silent skip; the agent JSON cannot be
+  parsed, and a hint is not worth a hand-rolled parser.
+- **`herdr agent list` fails** (daemon down, no local herdr server, non-zero
+  exit) — the `if AGENT_JSON=...` guard swallows it → nothing printed.
+- **No agent whose `cwd` equals the worktree path** — the worktree exists
+  but no tab is parked on it → `MATCH` empty → nothing printed.
+- **Agent found but `agent_status != "idle"`** (`working`, `blocked`, any
+  future value) — nothing printed (F-4). Suggesting cleanup for a tab that
+  is mid-run would be wrong, and a "still working" line would be noise.
+- **Two or more agents on the same `cwd`** — abnormal; `head -1` takes the
+  first, the rest are ignored, and no warning is emitted.
+- **`herdr workspace list` fails, or the workspace has no label** —
+  `WS_LABEL` is empty and `${WS_LABEL:-$WS_ID}` prints the raw workspace id.
+  The hint still goes out; only its cosmetic prefix degrades.
+
+## Read-only contract (NF-2)
+
+This substep calls `git worktree list`, `herdr agent list`, and
+`herdr workspace list` — enumerations only. It never closes a tab, never
+deletes a worktree, and never writes to the herdr server. The suggested
+cleanup commands are printed for a human to decide on and run.
+
+`tests/bats/skills/gh_pr_merge_herdr_notify.bats` enforces this
+mechanically: it greps this file and its fixture mirror for the literal
+invocation substrings and fails if either appears.
+
+## Mirror
+
+`tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh` mirrors the bash
+block above as the function `gh_pr_merge_herdr_notify "$HEAD_REF"`. If the
+block here changes, mirror the change there so the bats suite catches drift.

--- a/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md
+++ b/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md
@@ -46,7 +46,7 @@ if command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
                 # Label is cosmetic — fall back to the raw workspace id when
                 # this read-only lookup fails or the workspace is unlabeled.
                 WS_LABEL=$(herdr workspace list 2>/dev/null | jq -r --arg id "$WS_ID" \
-                    '.result.workspaces[]? | select(.workspace_id == $id) | .label' 2>/dev/null | head -1)
+                    '.result.workspaces[]? | select(.workspace_id == $id) | .label // empty' 2>/dev/null | head -1)
 
                 # F-3: exactly one line, only for an idle agent.
                 printf "[INFO] herdr tab %s/%s is idle for the merged branch's worktree (%s) — consider: herdr tab close %s / ai-worktree:teardown\n" \

--- a/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md
+++ b/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md
@@ -15,19 +15,22 @@ read-only `list` (NF-2). A `working`/`blocked` agent prints nothing at
 all: silence, not a second info line (F-4).
 
 ```bash
-# F-1: locate the local worktree checked out on the merged branch.
-# substr() rather than $2 so a worktree path containing spaces still
-# resolves; --porcelain guarantees the "worktree <path>" / "branch <ref>"
-# line pairing this relies on.
-BRANCH="${HEAD_REF}"
-WT_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${BRANCH}" \
-    '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+# NF-1: every gate here is a silent skip. Either tool missing (the expected
+# state on any machine without the agent runner), or no worktree (the merge
+# ran on a different machine) → the merge report is unaffected. The two
+# builtin `command -v` gates come first so that common case never pays for
+# the worktree scan below.
+if command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    # F-1: locate the local worktree checked out on the merged branch.
+    # substr() rather than $2 so a worktree path containing spaces still
+    # resolves; --porcelain guarantees the "worktree <path>" / "branch <ref>"
+    # line pairing this relies on.
+    BRANCH="${HEAD_REF}"
+    WT_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${BRANCH}" \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
 
-# NF-1: every gate below is a silent skip. No worktree (the merge ran on a
-# different machine), no herdr, no jq → the merge report is unaffected.
-if [ -n "$WT_PATH" ] && command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
     # F-2: read-only agent enumeration; match on cwd == worktree path.
-    if AGENT_JSON=$(herdr agent list 2>/dev/null); then
+    if [ -n "$WT_PATH" ] && AGENT_JSON=$(herdr agent list 2>/dev/null); then
         # head -1: two agents on one cwd is abnormal — take the first,
         # ignore the rest, warn about nothing (Error Cases).
         MATCH=$(printf '%s' "$AGENT_JSON" | jq -r --arg cwd "$WT_PATH" \
@@ -35,9 +38,7 @@ if [ -n "$WT_PATH" ] && command -v herdr >/dev/null 2>&1 && command -v jq >/dev/
              | "\(.tab_id)\t\(.agent_status)\t\(.workspace_id)"' 2>/dev/null | head -1)
 
         if [ -n "$MATCH" ]; then
-            TAB_ID=$(printf '%s' "$MATCH" | cut -f1)
-            AGENT_STATUS=$(printf '%s' "$MATCH" | cut -f2)
-            WS_ID=$(printf '%s' "$MATCH" | cut -f3)
+            IFS=$'\t' read -r TAB_ID AGENT_STATUS WS_ID <<<"$MATCH"
 
             # F-4: working/blocked/anything-but-idle prints nothing at all,
             # and does not even pay for the second lookup.

--- a/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
+# Source-of-truth mirror for the Step 4 herdr idle-tab hint documented in
+# claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md (issue #1508).
+#
+# The skill itself runs inside a Claude session, but the hint logic is a
+# small bash block that can be tested in isolation: given a branch name,
+# does it find a local worktree, match an agent parked on that cwd, and
+# print exactly one [INFO] line when that agent is idle?
+#
+# Keep this file in sync with the bash block in that reference doc. If the
+# doc block changes, mirror the change here so the bats suite catches drift.
+#
+# Test seams: `git`, `herdr`, and `jq` are resolved through the shell's
+# normal command lookup, so the bats suite shadows them with functions.
+# Nothing here is stubbed inside the fixture — the block below is meant to
+# read as the doc block does.
+
+# Mirrors the block in
+# claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md, which
+# SKILL.md Step 4 delegates to. Any change here must propagate to that
+# block, and vice versa.
+#
+# Usage: gh_pr_merge_herdr_notify "$HEAD_REF"
+#   $1 — the merged PR's headRefName, carried forward from Step 2's
+#        already-fetched `gh pr view --json ...,headRefName,...`.
+#
+# Always returns 0 (NF-1): this is post-merge housekeeping and must never
+# fail, block, or alter the merge report. Read-only (NF-2): only `list`
+# enumerations are invoked, never a state-changing herdr/git command.
+gh_pr_merge_herdr_notify() {
+    local _branch="$1"
+    [ -n "$_branch" ] || return 0
+
+    # F-1: locate the local worktree checked out on the merged branch.
+    # substr() rather than $2 so a worktree path containing spaces still
+    # resolves; --porcelain guarantees the "worktree <path>" / "branch <ref>"
+    # line pairing this relies on.
+    local _wt_path
+    _wt_path=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${_branch}" \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+
+    # NF-1: every gate below is a silent skip. No worktree (the merge ran on
+    # a different machine), no herdr, no jq → the merge report is unaffected.
+    [ -n "$_wt_path" ] || return 0
+    command -v herdr >/dev/null 2>&1 || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    # F-2: read-only agent enumeration; match on cwd == worktree path.
+    local _agent_json
+    _agent_json=$(herdr agent list 2>/dev/null) || return 0
+
+    # head -1: two agents on one cwd is abnormal — take the first, ignore
+    # the rest, warn about nothing.
+    local _match
+    _match=$(printf '%s' "$_agent_json" | jq -r --arg cwd "$_wt_path" \
+        '.result.agents[]? | select(.cwd == $cwd)
+         | "\(.tab_id)\t\(.agent_status)\t\(.workspace_id)"' 2>/dev/null | head -1)
+    [ -n "$_match" ] || return 0
+
+    local _tab_id _agent_status _ws_id _ws_label
+    _tab_id=$(printf '%s' "$_match" | cut -f1)
+    _agent_status=$(printf '%s' "$_match" | cut -f2)
+    _ws_id=$(printf '%s' "$_match" | cut -f3)
+
+    # F-4: working/blocked/anything-but-idle prints nothing at all.
+    [ "$_agent_status" = "idle" ] || return 0
+
+    # Label is cosmetic — fall back to the raw workspace id when the second
+    # read-only lookup fails or the workspace is unlabeled.
+    _ws_label=$(herdr workspace list 2>/dev/null | jq -r --arg id "$_ws_id" \
+        '.result.workspaces[]? | select(.workspace_id == $id) | .label' 2>/dev/null | head -1)
+
+    # F-3: exactly one line, only for an idle agent.
+    printf "[INFO] herdr tab %s/%s is idle for the merged branch's worktree (%s) — consider: herdr tab close %s / ai-worktree:teardown\n" \
+        "${_ws_label:-$_ws_id}" "$_tab_id" "$_wt_path" "$_tab_id"
+
+    return 0
+}

--- a/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
@@ -30,21 +30,24 @@
 # enumerations are invoked, never a state-changing herdr/git command.
 gh_pr_merge_herdr_notify() {
     local _branch="$1"
-    [ -n "$_branch" ] || return 0
+
+    # NF-1: every gate here is a silent skip. Either tool missing (the
+    # expected state on any machine without the agent runner), or no worktree
+    # (the merge ran on a different machine) → the merge report is unaffected.
+    # The two builtin `command -v` gates come first so that common case never
+    # pays for the worktree scan below.
+    command -v herdr >/dev/null 2>&1 || return 0
+    command -v jq >/dev/null 2>&1 || return 0
 
     # F-1: locate the local worktree checked out on the merged branch.
     # substr() rather than $2 so a worktree path containing spaces still
     # resolves; --porcelain guarantees the "worktree <path>" / "branch <ref>"
-    # line pairing this relies on.
+    # line pairing this relies on. An empty branch matches nothing, so the
+    # empty-HEAD_REF case falls out of this same gate.
     local _wt_path
     _wt_path=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${_branch}" \
         '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
-
-    # NF-1: every gate below is a silent skip. No worktree (the merge ran on
-    # a different machine), no herdr, no jq → the merge report is unaffected.
     [ -n "$_wt_path" ] || return 0
-    command -v herdr >/dev/null 2>&1 || return 0
-    command -v jq >/dev/null 2>&1 || return 0
 
     # F-2: read-only agent enumeration; match on cwd == worktree path.
     local _agent_json
@@ -59,9 +62,7 @@ gh_pr_merge_herdr_notify() {
     [ -n "$_match" ] || return 0
 
     local _tab_id _agent_status _ws_id _ws_label
-    _tab_id=$(printf '%s' "$_match" | cut -f1)
-    _agent_status=$(printf '%s' "$_match" | cut -f2)
-    _ws_id=$(printf '%s' "$_match" | cut -f3)
+    IFS=$'\t' read -r _tab_id _agent_status _ws_id <<<"$_match"
 
     # F-4: working/blocked/anything-but-idle prints nothing at all.
     [ "$_agent_status" = "idle" ] || return 0

--- a/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh
@@ -70,7 +70,7 @@ gh_pr_merge_herdr_notify() {
     # Label is cosmetic — fall back to the raw workspace id when the second
     # read-only lookup fails or the workspace is unlabeled.
     _ws_label=$(herdr workspace list 2>/dev/null | jq -r --arg id "$_ws_id" \
-        '.result.workspaces[]? | select(.workspace_id == $id) | .label' 2>/dev/null | head -1)
+        '.result.workspaces[]? | select(.workspace_id == $id) | .label // empty' 2>/dev/null | head -1)
 
     # F-3: exactly one line, only for an idle agent.
     printf "[INFO] herdr tab %s/%s is idle for the merged branch's worktree (%s) — consider: herdr tab close %s / ai-worktree:teardown\n" \

--- a/tests/bats/skills/gh_pr_merge_herdr_notify.bats
+++ b/tests/bats/skills/gh_pr_merge_herdr_notify.bats
@@ -1,0 +1,241 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_merge_herdr_notify.bats
+# Verify the Step 4 herdr idle-tab hint documented in
+#   claude/skills/gh-pr-merge/SKILL.md → references/herdr-tab-notify.sh.md
+# Source-of-truth fixture: _fixtures/gh_pr_merge_herdr_notify.sh.
+#
+# Cases drawn from issue #1508's acceptance criteria:
+#   1. local worktree + idle agent      → one [INFO] line, label/tab/path filled
+#   2. agent_status == "working"        → no [INFO] line (F-4: silence)
+#   3. no worktree on the merged branch → empty output, rc=0
+#   4. herdr not installed              → empty output, rc=0
+#   5. herdr agent list empty / no cwd match → empty output, rc=0
+#   6. two agents on the same cwd       → first wins, printed once, no error
+#   7. read-only (NF-2)                 → neither the doc nor the fixture
+#                                         contains a state-changing invocation
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh"
+
+    WT_DIR="/home/dev/wt/issue-1508"
+    export WT_DIR
+
+    # Shadow `git` so the fixture's `git worktree list --porcelain` reads a
+    # fixed table instead of this repo's real worktrees. Function definitions
+    # win over PATH lookups in the same shell, which is all the fixture uses.
+    FAKE_WORKTREE_LIST="worktree /home/dev/dotfiles
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree ${WT_DIR}
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/wt/issue-1508/1
+"
+    export FAKE_WORKTREE_LIST
+
+    git() {
+        if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
+            printf '%s' "${FAKE_WORKTREE_LIST-}"
+            return 0
+        fi
+        command git "$@"
+    }
+
+    # Shadow `herdr` with the two read-only enumerations the fixture calls.
+    # FAKE_AGENT_RC lets a test simulate a dead local herdr server.
+    herdr() {
+        if [ "$1" = "agent" ] && [ "$2" = "list" ]; then
+            [ "${FAKE_AGENT_RC:-0}" -eq 0 ] || return "$FAKE_AGENT_RC"
+            printf '%s' "${FAKE_AGENT_JSON-}"
+            return 0
+        fi
+        if [ "$1" = "workspace" ] && [ "$2" = "list" ]; then
+            printf '%s' "${FAKE_WORKSPACE_JSON-}"
+            return 0
+        fi
+        return 1
+    }
+
+    FAKE_WORKSPACE_JSON='{"result":{"workspaces":[
+        {"workspace_id":"ws-1","label":"dotfiles"},
+        {"workspace_id":"ws-2","label":"other"}
+    ]}}'
+    export FAKE_WORKSPACE_JSON
+}
+
+teardown() {
+    teardown_isolated_home
+    unset -f git herdr 2>/dev/null || true
+    unset WT_DIR FAKE_WORKTREE_LIST FAKE_AGENT_JSON FAKE_WORKSPACE_JSON FAKE_AGENT_RC
+}
+
+# Build an agent-list JSON payload from one or more `cwd|tab_id|status|ws_id`
+# specs, so each test states only the fields it cares about.
+_agents_json() {
+    local spec sep="" out='{"result":{"agents":['
+    for spec in "$@"; do
+        local cwd="${spec%%|*}" rest="${spec#*|}"
+        local tab="${rest%%|*}"; rest="${rest#*|}"
+        local st="${rest%%|*}"; local ws="${rest#*|}"
+        out+="${sep}{\"cwd\":\"${cwd}\",\"tab_id\":\"${tab}\",\"agent_status\":\"${st}\",\"workspace_id\":\"${ws}\"}"
+        sep=","
+    done
+    printf '%s]}}' "$out"
+}
+
+@test "herdr-notify: idle agent on the merged branch's worktree → one [INFO] hint" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-1")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    assert_output --partial '[INFO] herdr tab dotfiles/tab-7 is idle'
+    assert_output --partial "(${WT_DIR})"
+    assert_output --partial 'ai-worktree:teardown'
+    # Exactly one line — this step is a single informational line, never a block.
+    [ "${#lines[@]}" -eq 1 ]
+}
+
+@test "herdr-notify: unlabeled/unknown workspace falls back to the raw workspace id" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-missing")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    assert_output --partial '[INFO] herdr tab ws-missing/tab-7 is idle'
+}
+
+@test "herdr-notify: agent_status=working → no hint at all (F-4)" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|working|ws-1")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    refute_output --partial '[INFO]'
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: agent_status=blocked → no hint (any non-idle is silent)" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|blocked|ws-1")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    refute_output --partial '[INFO]'
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: no local worktree for the merged branch → silent skip" {
+    # The usual case when the PR was implemented on another machine.
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-1")"
+    run gh_pr_merge_herdr_notify "feature/merged-elsewhere"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: empty HEAD_REF → silent skip" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-1")"
+    run gh_pr_merge_herdr_notify ""
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: herdr not installed → silent skip, rc=0" {
+    # `herdr` is a real binary on some dev machines, so removing the shell
+    # function is not enough — PATH is narrowed to a dir holding only the
+    # externals the fixture actually needs (awk/jq/cut/head).
+    local bin="${TEST_TEMP_HOME}/nobin"
+    mkdir -p "$bin"
+    local tool
+    for tool in awk jq cut head; do
+        ln -sf "$(command -v "$tool")" "$bin/$tool"
+    done
+    unset -f herdr
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-1")"
+
+    local old_path="$PATH"
+    PATH="$bin"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    PATH="$old_path"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: herdr agent list returns an empty agent set → silent skip" {
+    FAKE_AGENT_JSON='{"result":{"agents":[]}}'
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: agents exist but none match the worktree cwd → silent skip" {
+    FAKE_AGENT_JSON="$(_agents_json "/home/dev/somewhere-else|tab-9|idle|ws-1")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: herdr agent list fails → silent skip, merge report unaffected" {
+    FAKE_AGENT_RC=1
+    export FAKE_AGENT_RC
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-1")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: herdr agent list emits non-JSON garbage → silent skip" {
+    FAKE_AGENT_JSON='not json at all'
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "herdr-notify: two agents on the same cwd → first wins, printed once" {
+    # Abnormal state; documented behavior is take-the-first, ignore the rest,
+    # no warning and no double-print.
+    FAKE_AGENT_JSON="$(_agents_json \
+        "${WT_DIR}|tab-first|idle|ws-1" \
+        "${WT_DIR}|tab-second|working|ws-2")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    [ "${#lines[@]}" -eq 1 ]
+    assert_output --partial 'herdr tab dotfiles/tab-first is idle'
+    refute_output --partial 'tab-second'
+}
+
+# --- NF-2: read-only verification -----------------------------------------
+
+@test "herdr-notify (NF-2): reference doc contains no state-changing invocation" {
+    local doc="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md"
+    [ -r "$doc" ]
+    # `tab close` / `worktree remove` legitimately appear once, inside the F-3
+    # printf's advisory text (a suggested command for a human to run, never
+    # executed here) — exclude that line and assert nothing else matches.
+    run bash -c "grep -n -e 'tab close' -e 'worktree remove' '$doc' | grep -v printf"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "herdr-notify (NF-2): fixture contains no state-changing invocation" {
+    local fixture="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh"
+    [ -r "$fixture" ]
+    run bash -c "grep -n -e 'tab close' -e 'worktree remove' '$fixture' | grep -v printf"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "herdr-notify (NF-2): every herdr/git call in the fixture is a read-only list" {
+    local fixture="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh"
+    # Every `herdr <noun> <verb>` occurrence — code and comments alike, minus
+    # the F-3 printf's advisory text ("herdr tab close ...", never executed) —
+    # must be one of the two read-only enumerations.
+    run bash -c "grep -v printf '$fixture' | grep -oE 'herdr [a-z]+ [a-z]+' | sort -u"
+    assert_output 'herdr agent list
+herdr workspace list'
+    # git is used exactly once, for the porcelain worktree enumeration.
+    run bash -c "grep -oE 'git [a-z]+ [a-z]+' '$fixture' | sort -u"
+    assert_output 'git worktree list'
+}
+
+@test "herdr-notify: SKILL.md Step 4 points at the reference doc" {
+    local skill="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge/SKILL.md"
+    run grep -n 'references/herdr-tab-notify.sh.md' "$skill"
+    assert_success
+}

--- a/tests/bats/skills/gh_pr_merge_herdr_notify.bats
+++ b/tests/bats/skills/gh_pr_merge_herdr_notify.bats
@@ -37,7 +37,15 @@ branch refs/heads/wt/issue-1508/1
 "
     export FAKE_WORKTREE_LIST
 
+    # Every stubbed subcommand is appended here, so NF-2 can be asserted on the
+    # calls actually made rather than only on the source text (cf.
+    # gh_pr_merge_board_gate.bats' FAKE_HELPER_LOG).
+    FAKE_CALL_LOG="${TEST_TEMP_HOME}/calls.log"
+    export FAKE_CALL_LOG
+    : >"$FAKE_CALL_LOG"
+
     git() {
+        printf 'git %s\n' "$*" >>"$FAKE_CALL_LOG"
         if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
             printf '%s' "${FAKE_WORKTREE_LIST-}"
             return 0
@@ -48,6 +56,7 @@ branch refs/heads/wt/issue-1508/1
     # Shadow `herdr` with the two read-only enumerations the fixture calls.
     # FAKE_AGENT_RC lets a test simulate a dead local herdr server.
     herdr() {
+        printf 'herdr %s\n' "$*" >>"$FAKE_CALL_LOG"
         if [ "$1" = "agent" ] && [ "$2" = "list" ]; then
             [ "${FAKE_AGENT_RC:-0}" -eq 0 ] || return "$FAKE_AGENT_RC"
             printf '%s' "${FAKE_AGENT_JSON-}"
@@ -70,17 +79,16 @@ branch refs/heads/wt/issue-1508/1
 teardown() {
     teardown_isolated_home
     unset -f git herdr 2>/dev/null || true
-    unset WT_DIR FAKE_WORKTREE_LIST FAKE_AGENT_JSON FAKE_WORKSPACE_JSON FAKE_AGENT_RC
+    unset WT_DIR FAKE_WORKTREE_LIST FAKE_AGENT_JSON FAKE_WORKSPACE_JSON FAKE_AGENT_RC FAKE_CALL_LOG
 }
 
 # Build an agent-list JSON payload from one or more `cwd|tab_id|status|ws_id`
 # specs, so each test states only the fields it cares about.
 _agents_json() {
     local spec sep="" out='{"result":{"agents":['
+    local cwd tab st ws
     for spec in "$@"; do
-        local cwd="${spec%%|*}" rest="${spec#*|}"
-        local tab="${rest%%|*}"; rest="${rest#*|}"
-        local st="${rest%%|*}"; local ws="${rest#*|}"
+        IFS='|' read -r cwd tab st ws <<<"$spec"
         out+="${sep}{\"cwd\":\"${cwd}\",\"tab_id\":\"${tab}\",\"agent_status\":\"${st}\",\"workspace_id\":\"${ws}\"}"
         sep=","
     done
@@ -109,7 +117,7 @@ _agents_json() {
     FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|working|ws-1")"
     run gh_pr_merge_herdr_notify "wt/issue-1508/1"
     assert_success
-    refute_output --partial '[INFO]'
+    # Empty output is the stronger assertion — it subsumes "no [INFO] line".
     [ -z "$output" ]
 }
 
@@ -117,7 +125,6 @@ _agents_json() {
     FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|blocked|ws-1")"
     run gh_pr_merge_herdr_notify "wt/issue-1508/1"
     assert_success
-    refute_output --partial '[INFO]'
     [ -z "$output" ]
 }
 
@@ -232,6 +239,40 @@ herdr workspace list'
     # git is used exactly once, for the porcelain worktree enumeration.
     run bash -c "grep -oE 'git [a-z]+ [a-z]+' '$fixture' | sort -u"
     assert_output 'git worktree list'
+}
+
+@test "herdr-notify (NF-2): a full idle run invokes only read-only subcommands" {
+    # Runtime counterpart to the two static greps above: whatever the source
+    # text looks like, every call this step actually made must be an
+    # enumeration — a mutating call built through indirection would show up
+    # here even though it matches no literal grep.
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-1")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    run bash -c "cut -d' ' -f1-3 '$FAKE_CALL_LOG' | sort -u"
+    assert_output 'git worktree list
+herdr agent list
+herdr workspace list'
+}
+
+@test "herdr-notify: reference doc and fixture have not drifted apart" {
+    # The fixture is a hand-kept mirror of the doc's bash block (house pattern,
+    # cf. helper_fallback_nf1.bats). Pin the load-bearing literals so editing
+    # only one side turns this suite red instead of silently diverging.
+    local doc="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md"
+    local fixture="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh"
+    local f pat
+    for pat in \
+        "[INFO] herdr tab %s/%s is idle for the merged branch's worktree (%s)" \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' \
+        '.result.agents[]? | select(.cwd == $cwd)' \
+        '.result.workspaces[]? | select(.workspace_id == $id) | .label' \
+        '= "idle" ]'; do
+        for f in "$doc" "$fixture"; do
+            run grep -F -- "$pat" "$f"
+            assert_success
+        done
+    done
 }
 
 @test "herdr-notify: SKILL.md Step 4 points at the reference doc" {

--- a/tests/bats/skills/gh_pr_merge_herdr_notify.bats
+++ b/tests/bats/skills/gh_pr_merge_herdr_notify.bats
@@ -113,6 +113,20 @@ _agents_json() {
     assert_output --partial '[INFO] herdr tab ws-missing/tab-7 is idle'
 }
 
+@test "herdr-notify: workspace record exists with a JSON null label → falls back to raw id, not the string 'null'" {
+    # `jq -r '.label'` on a null value prints the literal text "null", which
+    # is neither unset nor empty — so `${WS_LABEL:-$WS_ID}` alone would not
+    # catch it. The `// empty` in the jq filter is what makes the fallback
+    # actually fire here. Workspace id deliberately avoids containing "null"
+    # itself, so the assertion below isn't a false negative on the raw id.
+    FAKE_WORKSPACE_JSON='{"result":{"workspaces":[{"workspace_id":"ws-3","label":null}]}}'
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle|ws-3")"
+    run gh_pr_merge_herdr_notify "wt/issue-1508/1"
+    assert_success
+    assert_output --partial '[INFO] herdr tab ws-3/tab-7 is idle'
+    refute_output --partial 'null/tab-7'
+}
+
 @test "herdr-notify: agent_status=working → no hint at all (F-4)" {
     FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|working|ws-1")"
     run gh_pr_merge_herdr_notify "wt/issue-1508/1"
@@ -266,7 +280,7 @@ herdr workspace list'
         "[INFO] herdr tab %s/%s is idle for the merged branch's worktree (%s)" \
         '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' \
         '.result.agents[]? | select(.cwd == $cwd)' \
-        '.result.workspaces[]? | select(.workspace_id == $id) | .label' \
+        '.result.workspaces[]? | select(.workspace_id == $id) | .label // empty' \
         '= "idle" ]'; do
         for f in "$doc" "$fixture"; do
             run grep -F -- "$pat" "$f"


### PR DESCRIPTION
## Summary
- 머지된 PR을 구현한 로컬 워크트리에 herdr tab이 여전히 열려 있고 idle 상태면, `gh:pr-merge` 리포트에 정리를 제안하는 한 줄 안내를 추가한다.
- 자동으로 tab을 닫거나 워크트리를 지우지는 않는다 — 감지 + 안내만.

## Changes
- `claude/skills/gh-pr-merge/SKILL.md`: Step 4(post-merge housekeeping)에 herdr idle-tab 안내 서브스텝 포인터를 board sync 다음, ai-metrics 코멘트 이전에 추가.
- `claude/skills/gh-pr-merge/references/herdr-tab-notify.sh.md`: `git worktree list` → herdr `agent list`/`workspace list` 로 이어지는 read-only 탐지 로직을 문서화(soft-fail, 8가지 실패 케이스, NF-2 read-only contract).
- `tests/bats/skills/_fixtures/gh_pr_merge_herdr_notify.sh` + `tests/bats/skills/gh_pr_merge_herdr_notify.bats`: 기존 `gh_pr_merge_board_gate.sh` 패턴을 그대로 따르는 fixture-mirror 함수와 16개 회귀 테스트(idle/working/blocked/워크트리 없음/herdr 미설치/조회 실패/다중 매치/read-only 검증 포함).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_merge_herdr_notify.bats` — 16/16 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_merge_board_gate.bats` — 11/11, 회귀 없음
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/` 전체 — 편집 전 baseline과 동일한 3건의 무관한 기존 실패만 남고 신규 실패 없음
- [x] `shellcheck -x` on the new fixture — 경고 없음

## Related
Closes #1508

---
<details>
<summary>🤖 AI Metrics · 📊 ~7000 tokens · 👤 ~8 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~7000 tokens · 👤 ~8 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
