### PR TITLE
fix(pr-merge-train-cron): agent_pane_busy 를 재시도하고 실패한 tab 을 정리한다

### DIFF
--- a/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
+++ b/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
@@ -86,8 +86,14 @@ gone, the name is released) earns a new workspace/tab/agent.
 | `gh pr list` fails | end the tick, launch nothing — never merge without knowing state |
 | herdr launch fails | end the tick; the next tick retries |
 | `agent start` says `agent_name_taken` | prompt the name's existing holder instead — a second pane under that name is impossible, and failing here would repeat every period |
+| `agent start` says `agent_pane_busy` | retry up to 3 times with a short backoff — a pane's shell is not interactive the instant `tab create` answers (#1512). Still failing after that: close the tab and end the tick |
 | a train is already live | end the tick quietly (NF-1) |
 | zero target PRs | end the tick quietly |
 
 Every one of these is "do nothing and try again next period". A dispatcher that
-retried harder would be the thing most likely to produce two trains.
+retried a *prompt* harder would be the thing most likely to produce two trains —
+a prompt that looked stalled may well have landed. The `agent_pane_busy` retry
+is not that: it repeats a start that registered no agent at all, on a pane that
+holds none, so no attempt can produce a second train. The failed start also
+leaves its tab behind, which is why that path closes it (#1512) — cron ticks
+every few minutes, and the workspace had collected dozens of dead tabs.

--- a/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
+++ b/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
@@ -84,9 +84,9 @@ gone, the name is released) earns a new workspace/tab/agent.
 | Failure | Dispatcher's response |
 |---|---|
 | `gh pr list` fails | end the tick, launch nothing — never merge without knowing state |
-| herdr launch fails | end the tick; the next tick retries |
+| herdr launch fails | end the tick, closing the tab this tick opened if no agent was ever placed on it (#1512); the next tick retries |
 | `agent start` says `agent_name_taken` | prompt the name's existing holder instead — a second pane under that name is impossible, and failing here would repeat every period |
-| `agent start` says `agent_pane_busy` | retry up to 3 times with a short backoff — a pane's shell is not interactive the instant `tab create` answers (#1512). Still failing after that: close the tab and end the tick |
+| `agent start` says `agent_pane_busy` | make up to 3 start attempts with a short backoff — a pane's shell is not interactive the instant `tab create` answers (#1512) |
 | a train is already live | end the tick quietly (NF-1) |
 | zero target PRs | end the tick quietly |
 
@@ -94,6 +94,12 @@ Every one of these is "do nothing and try again next period". A dispatcher that
 retried a *prompt* harder would be the thing most likely to produce two trains —
 a prompt that looked stalled may well have landed. The `agent_pane_busy` retry
 is not that: it repeats a start that registered no agent at all, on a pane that
-holds none, so no attempt can produce a second train. The failed start also
-leaves its tab behind, which is why that path closes it (#1512) — cron ticks
-every few minutes, and the workspace had collected dozens of dead tabs.
+holds none, so no attempt can produce a second train. A start that never places
+an agent also leaves its tab behind, which is why every such path closes the tab
+it opened (#1512) — cron ticks every few minutes, and the workspace had
+collected dozens of dead tabs. Tabs that predate the fix need a manual sweep.
+
+A failed `agent start` now also carries herdr's own first stderr line as an
+indented `원인:` under the error — #1458's idiom. Without it a busy pane, a dead
+server and a rejected account all read as the same sentence in the cron log,
+which is why #1512 went unnoticed for weeks of failed ticks.

--- a/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
+++ b/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
@@ -85,7 +85,7 @@ gone, the name is released) earns a new workspace/tab/agent.
 |---|---|
 | `gh pr list` fails | end the tick, launch nothing — never merge without knowing state |
 | herdr launch fails | end the tick, closing the tab this tick opened if no agent was ever placed on it (#1512); the next tick retries |
-| `agent start` says `agent_name_taken` | prompt the name's existing holder instead — a second pane under that name is impossible, and failing here would repeat every period |
+| `agent start` says `agent_name_taken` | close this tick's tab, then prompt the name's existing holder — a second pane under that name is impossible, and failing here would repeat every period. The holder is on another pane, so the tab this tick opened holds nothing and is closed like any other failed start (#1512) |
 | `agent start` says `agent_pane_busy` | make up to 3 start attempts with a short backoff — a pane's shell is not interactive the instant `tab create` answers (#1512) |
 | a train is already live | end the tick quietly (NF-1) |
 | zero target PRs | end the tick quietly |

--- a/docs/public/changelog.d/2026-08-27-1512.md
+++ b/docs/public/changelog.d/2026-08-27-1512.md
@@ -1,0 +1,1 @@
+- 변경: **merge-train cron 디스패처가 갓 만든 pane 의 `agent_pane_busy` 경합을 최대 3회 재시도하고, 그래도 실패하면 herdr stderr 의 원인 한 줄을 로그에 싣고 방금 연 탭을 닫는다 (#1512)**

--- a/docs/public/changelog.d/2026-08-27-1512.md
+++ b/docs/public/changelog.d/2026-08-27-1512.md
@@ -1,1 +1,1 @@
-- 변경: **merge-train cron 디스패처가 갓 만든 pane 의 `agent_pane_busy` 경합을 최대 3회 재시도하고, 그래도 실패하면 herdr stderr 의 원인 한 줄을 로그에 싣고 방금 연 탭을 닫는다 (#1512)**
+- 변경: **merge-train cron 디스패처가 갓 만든 pane 의 `agent_pane_busy` 경합을 최대 3회까지 시도하고, 그래도 실패하면 herdr stderr 의 원인 한 줄을 로그에 싣고 방금 연 탭을 닫는다 (#1512)**

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -85,6 +85,18 @@ _PMT_TIMEOUT_MS="240000"
 _PMT_IDLE_POLL_MAX="10"
 _PMT_IDLE_POLL_SLEEP="${PMT_IDLE_POLL_SLEEP:-0.5}"
 
+# `herdr agent start` attempts on a freshly created pane (see _pmt_launch_fresh,
+# issue #1512). A pane's shell is not interactive the instant `tab create`
+# answers, so the start can be refused with `agent_pane_busy` — a timing race
+# against a pane that is perfectly good a moment later. herdr rejects it
+# immediately rather than waiting, so `--timeout` (which only extends the
+# readiness wait) cannot help; another attempt can. Bounded at 3 because cron
+# re-runs anyway: a tick that kept trying would hold the lock while the *next*
+# tick is the one that should be deciding. The gap is overridable for the same
+# reason _PMT_IDLE_POLL_SLEEP is — the bats suite pays no real sleep.
+_PMT_START_RETRY_MAX="3"
+_PMT_START_RETRY_SLEEP="${PMT_START_RETRY_SLEEP:-2}"
+
 # CLAUDE_CONFIG_DIR for the pane this tick opens. Resolved once, and only on
 # the path that actually opens one (see _pmt_bind_config_dir).
 _PMT_CONFIG_DIR=""
@@ -429,17 +441,39 @@ _pmt_workspace_for_label() {
     printf '%s' "${_ws}"
 }
 
-# Open the train's tab and echo its pane id. The response also carries a
-# `tab_id`, which nothing here needs: the agent is addressed by pane, and the
-# *next* tick finds this session by agent name, not by tab.
+# Open the train's tab and echo `<pane_id> <tab_id>`, space separated. Nothing
+# here used to need the `tab_id` — the agent is addressed by pane, and the
+# *next* tick finds this session by agent name, not by tab. Orphan cleanup is
+# what needs it now (#1512): when no agent can be started on this pane the
+# caller closes the tab it just opened, so a cron period that fails stops
+# leaving a dead tab behind on every tick.
+#
+# The pane id is required; the tab id is not, so a response that omits it
+# yields a trailing empty field rather than a failed tab creation.
 _pmt_tab_create() {
-    local _ws="$1" _cwd="$2" _label="$3" _json _pane
+    local _ws="$1" _cwd="$2" _label="$3" _json _pane _tab
 
     _json=$(_pmt_herdr_create "${_cwd}" "${_label}" tab create --workspace "${_ws}") || return 1
 
     _pane=$(printf '%s' "${_json}" | _pmt_json_first pane_id)
     [ -n "${_pane}" ] || return 1
-    printf '%s' "${_pane}"
+    _tab=$(printf '%s' "${_json}" | _pmt_json_first tab_id)
+    printf '%s %s' "${_pane}" "${_tab}"
+}
+
+# Best-effort close of a tab this tick opened but could never put an agent on.
+# The workspace had collected 40+ of these before #1512, one per cron period,
+# because the start failure returned without touching the pane it had just
+# been handed. Never changes the tick's verdict: the tick has already failed,
+# and a herdr that cannot close the tab is not a second, different failure to
+# report. A missing tab id is a no-op, not an error.
+_pmt_tab_close() {
+    local _tab="$1"
+
+    [ -n "${_tab}" ] || return 0
+    herdr tab close "${_tab}" >/dev/null 2>&1 ||
+        ux_warning "Could not close orphaned tab ${_tab} — close it by hand if it lingers."
+    return 0
 }
 
 # `-- ARG...` is passed through to the pane's claude invocation. Echoes herdr's
@@ -454,9 +488,31 @@ _pmt_tab_create() {
 # forbids the train from ever calling `gh:pr-merge-emergency`, so the platform's
 # own protections stay in force, and the approval gate (D-5, `approval-gate.md`)
 # is fail-closed, so an unreadable policy skips the PR rather than merging it.
+#
+# stderr goes to the file named by $3 rather than /dev/null (#1512, same defect
+# class as #1458): herdr is free to answer on either stream and in cron it
+# answers on stderr, so discarding it threw away the one sentence that named
+# the failure — `agent_pane_busy`. stdout stays on the pipe because the caller
+# reads `.error.code` off it, which is why this is a file and not a `2>&1`.
 _pmt_agent_start() {
     herdr agent start "$1" --kind claude --pane "$2" \
-        -- --dangerously-skip-permissions 2>/dev/null
+        -- --dangerously-skip-permissions 2>"$3"
+}
+
+# Echo the herdr error code behind a failed `agent start`: <1> is herdr's
+# stdout, <2> the file its stderr was captured to. stdout first, stderr as the
+# fallback. Both are consulted because the stream herdr picks is not ours to
+# choose — and in production it picked the one nobody was reading, which is why
+# even the `agent_name_taken` branch below could never fire. Echoes nothing
+# when neither stream carried a parsable error document.
+_pmt_start_error_code() {
+    local _json="$1" _errfile="$2" _code
+
+    _code=$(printf '%s' "${_json}" | _pmt_json_value '.error.code')
+    if [ -z "${_code}" ] && [ -s "${_errfile}" ]; then
+        _code=$(_pmt_json_value '.error.code' <"${_errfile}")
+    fi
+    printf '%s' "${_code}"
 }
 
 # Wait for a freshly started agent to report idle before prompting it.
@@ -509,7 +565,8 @@ _pmt_prompt_train() {
 
 # Open a fresh workspace/tab/agent for the train and prompt it.
 _pmt_launch_fresh() {
-    local _agent="$1" _cwd="$2" _label _ws _pane _start_json _code
+    local _agent="$1" _cwd="$2" _label _ws _created _pane _tab
+    local _start_json _code _errf _attempt=1 _rc=0 _msg _cause
 
     _label=$(_pmt_slug "${_PMT_WORKSPACE_PREFIX}" "$(_pmt_target_key)")
 
@@ -524,26 +581,78 @@ _pmt_launch_fresh() {
         ux_error "No herdr workspace for ${_label} — ending this tick."
         return 1
     }
-    _pane=$(_pmt_tab_create "${_ws}" "${_cwd}" "merge-train") || {
+    _created=$(_pmt_tab_create "${_ws}" "${_cwd}" "merge-train") || {
         ux_error "herdr tab create failed for ${_PMT_REPO} — ending this tick."
         return 1
     }
-    _start_json=$(_pmt_agent_start "${_agent}" "${_pane}") || {
+    # `<pane> <tab>`, and the tab half can be absent — command substitution has
+    # already eaten the trailing space by then, so the split has to test for the
+    # separator rather than assume it. `set -u` leaves no room for a guess here.
+    _pane="${_created%% *}"
+    _tab=""
+    case "${_created}" in
+    *' '*) _tab="${_created#* }" ;;
+    esac
+
+    _errf=$(mktemp) || {
+        ux_error "cannot open a capture file for herdr's stderr — ending this tick."
+        _pmt_tab_close "${_tab}"
+        return 1
+    }
+
+    # Each attempt truncates ${_errf}, so a retry that fails differently can
+    # never be reported with the previous attempt's cause.
+    while :; do
+        _rc=0
+        _start_json=$(_pmt_agent_start "${_agent}" "${_pane}" "${_errf}") || _rc=$?
+        [ "${_rc}" -ne 0 ] || break
+
+        _code=$(_pmt_start_error_code "${_start_json}" "${_errf}")
+
         # Backstop for the race _pmt_train_state cannot close: the name can be
         # claimed between the probe and the start (a train launched by a manual
         # run, say). herdr answers `agent_name_taken` and the holder is by
         # definition a usable agent, so prompt it rather than ending every
         # future tick on the same collision. NF-1 is preserved — the name is
         # what makes "one train" true, and we are talking to its holder.
-        _code=$(printf '%s' "${_start_json}" | _pmt_json_value '.error.code')
+        #
+        # No tab close on this path: the agent we hand the train to lives on
+        # some other pane and is healthy, so there is no failed launch to clean
+        # up after — closing here would only kill a usable session.
         if [ "${_code}" = "agent_name_taken" ]; then
+            rm -f "${_errf}"
             ux_warning "Agent ${_agent} is already registered — prompting the existing session instead of a second one."
             _pmt_prompt_train "${_agent}"
             return
         fi
-        ux_error "herdr agent start ${_agent} failed on pane ${_pane} — ending this tick."
+
+        # The one failure worth another attempt (#1512): the pane was created
+        # moments ago and its shell is not interactive yet. Only this code —
+        # a failure that does not name itself is not a race we understand, and
+        # ending the tick immediately keeps that contract intact.
+        if [ "${_code}" = "agent_pane_busy" ] && [ "${_attempt}" -lt "${_PMT_START_RETRY_MAX}" ]; then
+            ux_warning "Agent ${_agent} start failed with agent_pane_busy on pane ${_pane} (attempt ${_attempt}/${_PMT_START_RETRY_MAX}) — retrying in ${_PMT_START_RETRY_SLEEP}s."
+            [ "${_PMT_START_RETRY_SLEEP}" = "0" ] || sleep "${_PMT_START_RETRY_SLEEP}"
+            _attempt=$((_attempt + 1))
+            continue
+        fi
+
+        # One line, plus the sentence herdr actually gave, indented under it
+        # (#1458's idiom). Without it every cause — a busy pane, a dead server,
+        # a rejected account — converged on the same unhelpful sentence, which
+        # is precisely why #1512 went unnoticed for weeks of failed ticks. Only
+        # the first line: enough to tell those apart, short enough for a log.
+        _msg="herdr agent start ${_agent} failed on pane ${_pane} — ending this tick."
+        _cause=$(head -1 "${_errf}" 2>/dev/null) || _cause=""
+        [ -n "${_cause}" ] || _cause="${_code}"
+        [ -z "${_cause}" ] || _msg="${_msg}
+    원인: ${_cause}"
+        ux_error "${_msg}"
+        rm -f "${_errf}"
+        _pmt_tab_close "${_tab}"
         return 1
-    }
+    done
+    rm -f "${_errf}"
 
     _pmt_wait_for_idle "${_agent}"
     _pmt_prompt_train "${_agent}"

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -92,14 +92,22 @@ _PMT_IDLE_POLL_SLEEP="${PMT_IDLE_POLL_SLEEP:-0.5}"
 # immediately rather than waiting, so `--timeout` (which only extends the
 # readiness wait) cannot help; another attempt can. Bounded at 3 because cron
 # re-runs anyway: a tick that kept trying would hold the lock while the *next*
-# tick is the one that should be deciding. The gap is overridable for the same
-# reason _PMT_IDLE_POLL_SLEEP is — the bats suite pays no real sleep.
-_PMT_START_RETRY_MAX="3"
+# tick is the one that should be deciding. Bounded in *attempts*, not retries,
+# so the `attempt N/MAX` warning reads exactly true. The gap between them is
+# overridable for the same reason _PMT_IDLE_POLL_SLEEP is — the bats suite pays
+# no real sleep.
+_PMT_START_ATTEMPT_MAX="3"
 _PMT_START_RETRY_SLEEP="${PMT_START_RETRY_SLEEP:-2}"
 
 # CLAUDE_CONFIG_DIR for the pane this tick opens. Resolved once, and only on
 # the path that actually opens one (see _pmt_bind_config_dir).
 _PMT_CONFIG_DIR=""
+# The pane the train's agent starts on, and the tab holding it — both bound by
+# _pmt_tab_create. Globals rather than a packed return value because that is
+# this file's idiom for a helper with more than one result (cf. _PMT_REPO /
+# _PMT_HOST, _PMT_CONFIG_DIR). The tab id is what orphan cleanup closes (#1512).
+_PMT_PANE_ID=""
+_PMT_TAB_ID=""
 # Set by --dry-run: report what the tick would do, mutate nothing.
 _PMT_DRY_RUN=0
 # The GitHub target, bound once in main() from the checkout's `origin` (#1403).
@@ -441,24 +449,23 @@ _pmt_workspace_for_label() {
     printf '%s' "${_ws}"
 }
 
-# Open the train's tab and echo `<pane_id> <tab_id>`, space separated. Nothing
-# here used to need the `tab_id` — the agent is addressed by pane, and the
-# *next* tick finds this session by agent name, not by tab. Orphan cleanup is
-# what needs it now (#1512): when no agent can be started on this pane the
-# caller closes the tab it just opened, so a cron period that fails stops
-# leaving a dead tab behind on every tick.
+# Open the train's tab, binding _PMT_PANE_ID and _PMT_TAB_ID. Nothing here used
+# to need the `tab_id` — the agent is addressed by pane, and the *next* tick
+# finds this session by agent name, not by tab. Orphan cleanup is what needs it
+# now (#1512): when no agent can be started on this pane the caller closes the
+# tab it just opened, so a cron period that fails stops leaving a dead tab
+# behind on every tick.
 #
 # The pane id is required; the tab id is not, so a response that omits it
-# yields a trailing empty field rather than a failed tab creation.
+# leaves _PMT_TAB_ID empty rather than failing the tab creation.
 _pmt_tab_create() {
-    local _ws="$1" _cwd="$2" _label="$3" _json _pane _tab
+    local _ws="$1" _cwd="$2" _label="$3" _json
 
     _json=$(_pmt_herdr_create "${_cwd}" "${_label}" tab create --workspace "${_ws}") || return 1
 
-    _pane=$(printf '%s' "${_json}" | _pmt_json_first pane_id)
-    [ -n "${_pane}" ] || return 1
-    _tab=$(printf '%s' "${_json}" | _pmt_json_first tab_id)
-    printf '%s %s' "${_pane}" "${_tab}"
+    _PMT_PANE_ID=$(printf '%s' "${_json}" | _pmt_json_first pane_id)
+    [ -n "${_PMT_PANE_ID}" ] || return 1
+    _PMT_TAB_ID=$(printf '%s' "${_json}" | _pmt_json_first tab_id)
 }
 
 # Best-effort close of a tab this tick opened but could never put an agent on.
@@ -499,13 +506,14 @@ _pmt_agent_start() {
         -- --dangerously-skip-permissions 2>"$3"
 }
 
-# Echo the herdr error code behind a failed `agent start`: <1> is herdr's
-# stdout, <2> the file its stderr was captured to. stdout first, stderr as the
-# fallback. Both are consulted because the stream herdr picks is not ours to
-# choose — and in production it picked the one nobody was reading, which is why
-# even the `agent_name_taken` branch below could never fire. Echoes nothing
-# when neither stream carried a parsable error document.
-_pmt_start_error_code() {
+# Echo the herdr error code behind a failed call: <1> is herdr's stdout, <2>
+# the file its stderr was captured to. stdout first, stderr as the fallback.
+# Both are consulted because the stream herdr picks is not ours to choose — and
+# in production it picked the one nobody was reading, which is why even the
+# `agent_name_taken` branch below could never fire. Nothing here is specific to
+# `agent start`; the next call site that captures stderr can use it as is.
+# Echoes nothing when neither stream carried a parsable error document.
+_pmt_herdr_error_code() {
     local _json="$1" _errfile="$2" _code
 
     _code=$(printf '%s' "${_json}" | _pmt_json_value '.error.code')
@@ -513,6 +521,40 @@ _pmt_start_error_code() {
         _code=$(_pmt_json_value '.error.code' <"${_errfile}")
     fi
     printf '%s' "${_code}"
+}
+
+# Set by _pmt_start_agent_retrying to the code of the attempt it gave up on —
+# empty when herdr named none on either stream.
+_PMT_START_CODE=""
+
+# Start agent <1> on pane <2>, retrying only the #1512 `agent_pane_busy` race;
+# herdr's stderr lands in the file named by <3>. 0 = an agent is running on the
+# pane, 1 = gave up, with _PMT_START_CODE naming the last failure and <3>
+# holding herdr's own sentence about it.
+#
+# Each attempt truncates <3>, so a retry that fails differently can never be
+# reported with the previous attempt's cause.
+_pmt_start_agent_retrying() {
+    local _agent="$1" _pane="$2" _errf="$3" _json _attempt=1
+
+    _PMT_START_CODE=""
+    while :; do
+        _json=$(_pmt_agent_start "${_agent}" "${_pane}" "${_errf}") && return 0
+        _PMT_START_CODE=$(_pmt_herdr_error_code "${_json}" "${_errf}")
+
+        # The one failure worth another attempt (#1512): the pane was created
+        # moments ago and its shell is not interactive yet. Only this code —
+        # a failure that does not name itself is not a race we understand, and
+        # ending the tick immediately keeps that contract intact.
+        if [ "${_PMT_START_CODE}" != "agent_pane_busy" ] ||
+            [ "${_attempt}" -ge "${_PMT_START_ATTEMPT_MAX}" ]; then
+            return 1
+        fi
+
+        ux_warning "Agent ${_agent} start failed with agent_pane_busy on pane ${_pane} (attempt ${_attempt}/${_PMT_START_ATTEMPT_MAX}) — retrying in ${_PMT_START_RETRY_SLEEP}s."
+        [ "${_PMT_START_RETRY_SLEEP}" = "0" ] || sleep "${_PMT_START_RETRY_SLEEP}"
+        _attempt=$((_attempt + 1))
+    done
 }
 
 # Wait for a freshly started agent to report idle before prompting it.
@@ -565,8 +607,7 @@ _pmt_prompt_train() {
 
 # Open a fresh workspace/tab/agent for the train and prompt it.
 _pmt_launch_fresh() {
-    local _agent="$1" _cwd="$2" _label _ws _created _pane _tab
-    local _start_json _code _errf _attempt=1 _rc=0 _msg _cause
+    local _agent="$1" _cwd="$2" _label _ws _errf _msg _cause
 
     _label=$(_pmt_slug "${_PMT_WORKSPACE_PREFIX}" "$(_pmt_target_key)")
 
@@ -581,81 +622,54 @@ _pmt_launch_fresh() {
         ux_error "No herdr workspace for ${_label} — ending this tick."
         return 1
     }
-    _created=$(_pmt_tab_create "${_ws}" "${_cwd}" "merge-train") || {
+    _pmt_tab_create "${_ws}" "${_cwd}" "merge-train" || {
         ux_error "herdr tab create failed for ${_PMT_REPO} — ending this tick."
         return 1
     }
-    # `<pane> <tab>`, and the tab half can be absent — command substitution has
-    # already eaten the trailing space by then, so the split has to test for the
-    # separator rather than assume it. `set -u` leaves no room for a guess here.
-    _pane="${_created%% *}"
-    _tab=""
-    case "${_created}" in
-    *' '*) _tab="${_created#* }" ;;
-    esac
 
     _errf=$(mktemp) || {
         ux_error "cannot open a capture file for herdr's stderr — ending this tick."
-        _pmt_tab_close "${_tab}"
+        _pmt_tab_close "${_PMT_TAB_ID}"
         return 1
     }
-
-    # Each attempt truncates ${_errf}, so a retry that fails differently can
-    # never be reported with the previous attempt's cause.
-    while :; do
-        _rc=0
-        _start_json=$(_pmt_agent_start "${_agent}" "${_pane}" "${_errf}") || _rc=$?
-        [ "${_rc}" -ne 0 ] || break
-
-        _code=$(_pmt_start_error_code "${_start_json}" "${_errf}")
-
-        # Backstop for the race _pmt_train_state cannot close: the name can be
-        # claimed between the probe and the start (a train launched by a manual
-        # run, say). herdr answers `agent_name_taken` and the holder is by
-        # definition a usable agent, so prompt it rather than ending every
-        # future tick on the same collision. NF-1 is preserved — the name is
-        # what makes "one train" true, and we are talking to its holder.
-        #
-        # No tab close on this path: the agent we hand the train to lives on
-        # some other pane and is healthy, so there is no failed launch to clean
-        # up after — closing here would only kill a usable session.
-        if [ "${_code}" = "agent_name_taken" ]; then
-            rm -f "${_errf}"
-            ux_warning "Agent ${_agent} is already registered — prompting the existing session instead of a second one."
-            _pmt_prompt_train "${_agent}"
-            return
-        fi
-
-        # The one failure worth another attempt (#1512): the pane was created
-        # moments ago and its shell is not interactive yet. Only this code —
-        # a failure that does not name itself is not a race we understand, and
-        # ending the tick immediately keeps that contract intact.
-        if [ "${_code}" = "agent_pane_busy" ] && [ "${_attempt}" -lt "${_PMT_START_RETRY_MAX}" ]; then
-            ux_warning "Agent ${_agent} start failed with agent_pane_busy on pane ${_pane} (attempt ${_attempt}/${_PMT_START_RETRY_MAX}) — retrying in ${_PMT_START_RETRY_SLEEP}s."
-            [ "${_PMT_START_RETRY_SLEEP}" = "0" ] || sleep "${_PMT_START_RETRY_SLEEP}"
-            _attempt=$((_attempt + 1))
-            continue
-        fi
-
-        # One line, plus the sentence herdr actually gave, indented under it
-        # (#1458's idiom). Without it every cause — a busy pane, a dead server,
-        # a rejected account — converged on the same unhelpful sentence, which
-        # is precisely why #1512 went unnoticed for weeks of failed ticks. Only
-        # the first line: enough to tell those apart, short enough for a log.
-        _msg="herdr agent start ${_agent} failed on pane ${_pane} — ending this tick."
-        _cause=$(head -1 "${_errf}" 2>/dev/null) || _cause=""
-        [ -n "${_cause}" ] || _cause="${_code}"
-        [ -z "${_cause}" ] || _msg="${_msg}
-    원인: ${_cause}"
-        ux_error "${_msg}"
+    if _pmt_start_agent_retrying "${_agent}" "${_PMT_PANE_ID}" "${_errf}"; then
         rm -f "${_errf}"
-        _pmt_tab_close "${_tab}"
-        return 1
-    done
+        _pmt_wait_for_idle "${_agent}"
+        _pmt_prompt_train "${_agent}"
+        return
+    fi
+    # herdr's own sentence about the failure, read before the file goes away.
+    # Only the first line: enough to tell causes apart, short enough for a log.
+    _cause=$(head -n 1 "${_errf}" 2>/dev/null)
     rm -f "${_errf}"
 
-    _pmt_wait_for_idle "${_agent}"
-    _pmt_prompt_train "${_agent}"
+    # Backstop for the race _pmt_train_state cannot close: the name can be
+    # claimed between the probe and the start (a train launched by a manual
+    # run, say). herdr answers `agent_name_taken` and the holder is by
+    # definition a usable agent, so prompt it rather than ending every future
+    # tick on the same collision. NF-1 is preserved — the name is what makes
+    # "one train" true, and we are talking to its holder.
+    #
+    # No tab close on this path: the agent we hand the train to lives on some
+    # other pane and is healthy, so there is no failed launch to clean up
+    # after — closing here would only kill a usable session.
+    if [ "${_PMT_START_CODE}" = "agent_name_taken" ]; then
+        ux_warning "Agent ${_agent} is already registered — prompting the existing session instead of a second one."
+        _pmt_prompt_train "${_agent}"
+        return
+    fi
+
+    # One line, plus the sentence herdr actually gave, indented under it
+    # (#1458's idiom). Without it every cause — a busy pane, a dead server, a
+    # rejected account — converged on the same unhelpful sentence, which is
+    # precisely why #1512 went unnoticed for weeks of failed ticks.
+    [ -n "${_cause}" ] || _cause="${_PMT_START_CODE}"
+    _msg="herdr agent start ${_agent} failed on pane ${_PMT_PANE_ID} — ending this tick."
+    [ -z "${_cause}" ] || _msg="${_msg}
+    원인: ${_cause}"
+    ux_error "${_msg}"
+    _pmt_tab_close "${_PMT_TAB_ID}"
+    return 1
 }
 
 # ============================================================

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -108,6 +108,11 @@ _PMT_CONFIG_DIR=""
 # _PMT_HOST, _PMT_CONFIG_DIR). The tab id is what orphan cleanup closes (#1512).
 _PMT_PANE_ID=""
 _PMT_TAB_ID=""
+# The stderr capture file handed to _pmt_agent_start. Global, not local, so the
+# EXIT/INT/TERM trap that removes it can still name it after the function that
+# created it has returned — a `local` would be unset by then and `set -u` would
+# turn the cleanup into its own error (PR #1517 review, agy).
+_PMT_ERRF=""
 # Set by --dry-run: report what the tick would do, mutate nothing.
 _PMT_DRY_RUN=0
 # The GitHub target, bound once in main() from the checkout's `origin` (#1403).
@@ -474,6 +479,14 @@ _pmt_tab_create() {
 # been handed. Never changes the tick's verdict: the tick has already failed,
 # and a herdr that cannot close the tab is not a second, different failure to
 # report. A missing tab id is a no-op, not an error.
+#
+# Raw `herdr`, not _pmt_herdr_create: that wrapper exists to append the
+# pane-*creation* flags (--cwd/--label/--no-focus/--env CLAUDE_CONFIG_DIR),
+# and `herdr tab close` takes a bare positional tab id and rejects options.
+# The account routing it carries is for the claude process a new pane starts,
+# not for herdr's own connection, so closing a tab by id needs none of it —
+# same reason `agent get`, `workspace list` and `agent prompt` all call herdr
+# directly (PR #1517 review, codex).
 _pmt_tab_close() {
     local _tab="$1"
 
@@ -521,6 +534,22 @@ _pmt_herdr_error_code() {
         _code=$(_pmt_json_value '.error.code' <"${_errfile}")
     fi
     printf '%s' "${_code}"
+}
+
+# The human half of the same document: herdr's own sentence about the failure,
+# from the stderr file <1>. `.error.message` first, because what herdr writes
+# to stderr is a JSON document and dumping it raw into a cron log buries the
+# sentence inside braces (PR #1517 review, codex). Falls back to the first raw
+# line, which is what a non-JSON stderr (a crash, a shell error) carries — and
+# is also what keeps this working if herdr ever changes its JSON shape. Echoes
+# nothing when the file is empty.
+_pmt_herdr_error_message() {
+    local _errfile="$1" _msg
+
+    [ -s "${_errfile}" ] || return 0
+    _msg=$(_pmt_json_value '.error.message' <"${_errfile}")
+    [ -n "${_msg}" ] || _msg=$(head -n 1 "${_errfile}" 2>/dev/null)
+    printf '%s' "${_msg}"
 }
 
 # Set by _pmt_start_agent_retrying to the code of the attempt it gave up on —
@@ -607,7 +636,7 @@ _pmt_prompt_train() {
 
 # Open a fresh workspace/tab/agent for the train and prompt it.
 _pmt_launch_fresh() {
-    local _agent="$1" _cwd="$2" _label _ws _errf _msg _cause
+    local _agent="$1" _cwd="$2" _label _ws _msg _cause
 
     _label=$(_pmt_slug "${_PMT_WORKSPACE_PREFIX}" "$(_pmt_target_key)")
 
@@ -627,21 +656,27 @@ _pmt_launch_fresh() {
         return 1
     }
 
-    _errf=$(mktemp) || {
+    # The trap covers the window where a signal can land between mktemp and the
+    # rm below — a cron tick killed mid-start otherwise leaves the file in /tmp
+    # forever (PR #1517 review, agy). It is cleared, not left armed, so the
+    # function's own `rm` stays the normal path and nothing fires twice.
+    _PMT_ERRF=$(mktemp) || {
         ux_error "cannot open a capture file for herdr's stderr — ending this tick."
         _pmt_tab_close "${_PMT_TAB_ID}"
         return 1
     }
-    if _pmt_start_agent_retrying "${_agent}" "${_PMT_PANE_ID}" "${_errf}"; then
-        rm -f "${_errf}"
+    trap 'rm -f "${_PMT_ERRF}"' EXIT INT TERM
+    if _pmt_start_agent_retrying "${_agent}" "${_PMT_PANE_ID}" "${_PMT_ERRF}"; then
+        trap - EXIT INT TERM
+        rm -f "${_PMT_ERRF}"
         _pmt_wait_for_idle "${_agent}"
         _pmt_prompt_train "${_agent}"
         return
     fi
     # herdr's own sentence about the failure, read before the file goes away.
-    # Only the first line: enough to tell causes apart, short enough for a log.
-    _cause=$(head -n 1 "${_errf}" 2>/dev/null)
-    rm -f "${_errf}"
+    _cause=$(_pmt_herdr_error_message "${_PMT_ERRF}")
+    trap - EXIT INT TERM
+    rm -f "${_PMT_ERRF}"
 
     # Backstop for the race _pmt_train_state cannot close: the name can be
     # claimed between the probe and the start (a train launched by a manual
@@ -650,11 +685,14 @@ _pmt_launch_fresh() {
     # tick on the same collision. NF-1 is preserved — the name is what makes
     # "one train" true, and we are talking to its holder.
     #
-    # No tab close on this path: the agent we hand the train to lives on some
-    # other pane and is healthy, so there is no failed launch to clean up
-    # after — closing here would only kill a usable session.
+    # The tab still closes. The agent we prompt lives on some *other* pane —
+    # this tick's tab never received one and is exactly the orphan #1512 is
+    # about, so keeping it would leak a dead tab on every probe/start race
+    # (PR #1517 review, codex). Closing precedes the prompt so a prompt that
+    # fails cannot strand it either.
     if [ "${_PMT_START_CODE}" = "agent_name_taken" ]; then
         ux_warning "Agent ${_agent} is already registered — prompting the existing session instead of a second one."
+        _pmt_tab_close "${_PMT_TAB_ID}"
         _pmt_prompt_train "${_agent}"
         return
     fi

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -626,14 +626,36 @@ _hold_lock() {
     assert_output --partial "is not an available shell"
 }
 
-# The name-taken path hands the tick to a *live* agent on some other pane, and
-# the fresh tab is the one this tick just opened — but the agent it wanted is
-# elsewhere and healthy, so there is no failed launch to clean up after and the
-# close would be the tick's only destructive act.
-@test "pr_merge_train_cron: an agent_name_taken start does not close the tab" {
+# What herdr writes to stderr is a JSON document, so dumping its first line
+# verbatim buries the sentence inside braces exactly where a cron log is read
+# in a hurry. The cause line carries `.error.message` alone; the raw document
+# must not reach the log (PR #1517 review, codex).
+@test "pr_merge_train_cron: the cause line carries the message, not the raw JSON" {
+    _run_tick HERDR_START_PANE_BUSY=99
+    assert_failure
+    refute_output --partial '{"error"'
+}
+
+# The name-taken path hands the tick to a *live* agent, and the fresh tab is
+# the one this tick just opened, on which no agent was ever placed. The holder
+# we go on to prompt lives on some *other* pane, so this tab
+# is orphan state of exactly the kind #1512 exists to stop leaking — one per
+# probe/start race, on a job that ticks every few minutes. Prompting the holder
+# and closing the tab are independent acts; doing only the first is the leak.
+@test "pr_merge_train_cron: an agent_name_taken start closes the tab it opened" {
     _run_tick HERDR_START_NAME_TAKEN=1
     assert_success
-    _refute_logged "herdr tab close"
+    _assert_logged "herdr tab close ws-test-1:t9"
+    _assert_logged "herdr agent prompt"
+}
+
+# Order matters, and only in one direction: the close precedes the prompt so a
+# prompt that fails cannot strand the tab behind it. Asserted as a failed tick
+# that still cleaned up, which is the case the ordering exists for.
+@test "pr_merge_train_cron: a name_taken tab is closed even when the prompt fails" {
+    _run_tick HERDR_START_NAME_TAKEN=1 HERDR_PROMPT_FAIL=1
+    assert_failure
+    _assert_logged "herdr tab close ws-test-1:t9"
 }
 
 # Only the one known race is retried. An `agent start` that fails without

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -153,10 +153,22 @@ EOF
 #                         ever run — `agent get` exits 1 with agent_not_found.
 #   HERDR_WORKSPACE_EXISTS=1  `workspace list` already carries the label
 #   HERDR_TAB_FAIL=1      `tab create` errors
-#   HERDR_START_FAIL=1    `agent start` errors
+#   HERDR_START_FAIL=1    `agent start` errors, saying nothing at all — the
+#                         unexplained failure, with no parsable error code
 #   HERDR_START_NAME_TAKEN=1  `agent start` refuses because a live agent still
 #                         holds the name (herdr's real `agent_name_taken`)
+#   HERDR_START_PANE_BUSY=N   the first N `agent start` calls lose the #1512
+#                         race (`agent_pane_busy`), the rest succeed. Counted
+#                         in a file, not an env var: the stub is a fresh
+#                         process per call, so nothing it exports survives.
+#   HERDR_START_PANE_BUSY_ALWAYS=1  every `agent start` loses that race
+#   HERDR_TAB_CLOSE_FAIL=1  `tab close` errors — the cleanup of an orphaned tab
+#                         is best effort and must not become a second failure
 #   HERDR_PROMPT_FAIL=1   `agent prompt` errors
+#
+# The `agent_pane_busy` document goes to **stderr**, which is not decoration:
+# that is where herdr really put it, and a dispatcher that redirects the stream
+# to /dev/null sees an unexplained failure instead of a named race (#1512).
 _install_herdr_stub() {
     cat >"${_BIN_DIR}/herdr" <<'EOF'
 #!/bin/sh
@@ -192,7 +204,25 @@ case "$1 $2" in
         printf '%s\n' '{"error":{"code":"agent_name_taken","message":"agent name is already used; candidates: status=Idle"},"id":"cli:agent:start"}'
         exit 1
     fi
+    if [ "${HERDR_START_PANE_BUSY_ALWAYS:-0}" = "1" ]; then
+        printf '%s\n' '{"error":{"code":"agent_pane_busy","message":"agent target pane ws-test-1:p9 is not an available shell"},"id":"cli:agent:start"}' >&2
+        exit 1
+    fi
+    if [ "${HERDR_START_PANE_BUSY:-0}" != "0" ]; then
+        _seen_file="${CALL_LOG%/*}/start-attempts"
+        _seen=$(cat "${_seen_file}" 2>/dev/null) || _seen=0
+        _seen=$((_seen + 1))
+        printf '%s\n' "${_seen}" >"${_seen_file}"
+        if [ "${_seen}" -le "${HERDR_START_PANE_BUSY}" ]; then
+            printf '%s\n' '{"error":{"code":"agent_pane_busy","message":"agent target pane ws-test-1:p9 is not an available shell"},"id":"cli:agent:start"}' >&2
+            exit 1
+        fi
+    fi
     printf '%s\n' '{"id":"cli:agent:start","result":{"agent":{"agent_status":"idle","pane_id":"ws-test-1:p9"}}}'
+    ;;
+"tab close")
+    [ "${HERDR_TAB_CLOSE_FAIL:-0}" = "1" ] && exit 1
+    printf '%s\n' '{"id":"cli:tab:close","result":{"ok":true}}'
     ;;
 "agent prompt")
     if [ "${HERDR_PROMPT_FAIL:-0}" = "1" ]; then
@@ -236,6 +266,7 @@ _run_tick() {
         "GH_PRS_FILE=${_WORK_DIR}/prs.json" \
         "XDG_STATE_HOME=${_STATE_HOME}" \
         "PMT_IDLE_POLL_SLEEP=0" \
+        "PMT_START_RETRY_SLEEP=0" \
         "${_env[@]}" \
         bash "${SCRIPT}" --cwd "${_REPO_DIR}" "$@"
 }
@@ -546,6 +577,83 @@ _hold_lock() {
     assert_failure
     _assert_logged "herdr agent start"
     _refute_logged "herdr agent prompt"
+}
+
+# ---------------------------------------------------------------------------
+# #1512 — the `agent_pane_busy` race on a pane that was just created
+# ---------------------------------------------------------------------------
+#
+# A tab's shell is not interactive the instant `tab create` answers, so
+# `agent start` on it can be refused with `agent_pane_busy` and return
+# immediately. In cron that lost every single tick for weeks. It is a timing
+# race, not a defect in the pane, so the second attempt is the fix — the pane
+# is fine a moment later.
+
+@test "pr_merge_train_cron: a transient agent_pane_busy is retried and the train still starts" {
+    _run_tick HERDR_START_PANE_BUSY=1
+    assert_success
+    [ "$(_log_count 'herdr agent start')" -eq 2 ]
+    _assert_logged "/gh-pr-merge-train acme/dotfiles"
+}
+
+# The retry is bounded, and the bound is the whole point: cron re-runs every
+# few minutes anyway, so a tick that kept trying would only hold the lock
+# while the *next* tick is the thing that should be deciding.
+@test "pr_merge_train_cron: a permanent agent_pane_busy stops after the retry budget" {
+    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1
+    assert_failure
+    [ "$(_log_count 'herdr agent start')" -eq 3 ]
+    _refute_logged "herdr agent prompt"
+}
+
+# The tab was opened by this tick and now holds nothing. Leaving it behind is
+# what filled the merge-train workspace with 40+ dead tabs, one per cron
+# period — the failure was invisible, but its litter was not.
+@test "pr_merge_train_cron: a start that never succeeds closes the tab it opened" {
+    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1
+    assert_failure
+    _assert_logged "herdr tab close ws-test-1:t9"
+}
+
+# The #1458 regression guard. herdr names this race precisely, on stderr; the
+# dispatcher used to throw that stream away and report a generic failure, so
+# the log said only "start failed" for weeks. Restoring `2>/dev/null` to
+# _pmt_agent_start must make this test red.
+@test "pr_merge_train_cron: a failed start reports the cause herdr gave on stderr" {
+    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1
+    assert_failure
+    assert_output --partial "agent_pane_busy"
+    assert_output --partial "원인:"
+    assert_output --partial "is not an available shell"
+}
+
+# The name-taken path hands the tick to a *live* agent on some other pane, and
+# the fresh tab is the one this tick just opened — but the agent it wanted is
+# elsewhere and healthy, so there is no failed launch to clean up after and the
+# close would be the tick's only destructive act.
+@test "pr_merge_train_cron: an agent_name_taken start does not close the tab" {
+    _run_tick HERDR_START_NAME_TAKEN=1
+    assert_success
+    _refute_logged "herdr tab close"
+}
+
+# Only the one known race is retried. An `agent start` that fails without
+# naming itself is not a race we understand, and ending the tick immediately —
+# the contract since #1470 — keeps it that way. It still gets the cleanup.
+@test "pr_merge_train_cron: an unexplained start failure is not retried but is cleaned up" {
+    _run_tick HERDR_START_FAIL=1
+    assert_failure
+    [ "$(_log_count 'herdr agent start')" -eq 1 ]
+    _assert_logged "herdr tab close ws-test-1:t9"
+}
+
+# Cleanup is best effort by design: the tick has already failed, and a herdr
+# that cannot close the tab is not a second, different verdict to report.
+@test "pr_merge_train_cron: a failing tab close does not change the tick's verdict" {
+    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1 HERDR_TAB_CLOSE_FAIL=1
+    assert_failure
+    _assert_logged "herdr tab close ws-test-1:t9"
+    assert_output --partial "agent_pane_busy"
 }
 
 @test "pr_merge_train_cron: a failed prompt is reported as a failed tick" {

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -158,10 +158,12 @@ EOF
 #   HERDR_START_NAME_TAKEN=1  `agent start` refuses because a live agent still
 #                         holds the name (herdr's real `agent_name_taken`)
 #   HERDR_START_PANE_BUSY=N   the first N `agent start` calls lose the #1512
-#                         race (`agent_pane_busy`), the rest succeed. Counted
-#                         in a file, not an env var: the stub is a fresh
-#                         process per call, so nothing it exports survives.
-#   HERDR_START_PANE_BUSY_ALWAYS=1  every `agent start` loses that race
+#                         race (`agent_pane_busy`), the rest succeed; a number
+#                         above the attempt budget loses it every time.
+#                         Counted in a file, not an env var: the stub is a
+#                         fresh process per call, so nothing it exports
+#                         survives. The counter is per-test — `${CALL_LOG}`
+#                         lives in a `mktemp -d` made fresh by `setup()`.
 #   HERDR_TAB_CLOSE_FAIL=1  `tab close` errors — the cleanup of an orphaned tab
 #                         is best effort and must not become a second failure
 #   HERDR_PROMPT_FAIL=1   `agent prompt` errors
@@ -204,12 +206,8 @@ case "$1 $2" in
         printf '%s\n' '{"error":{"code":"agent_name_taken","message":"agent name is already used; candidates: status=Idle"},"id":"cli:agent:start"}'
         exit 1
     fi
-    if [ "${HERDR_START_PANE_BUSY_ALWAYS:-0}" = "1" ]; then
-        printf '%s\n' '{"error":{"code":"agent_pane_busy","message":"agent target pane ws-test-1:p9 is not an available shell"},"id":"cli:agent:start"}' >&2
-        exit 1
-    fi
     if [ "${HERDR_START_PANE_BUSY:-0}" != "0" ]; then
-        _seen_file="${CALL_LOG%/*}/start-attempts"
+        _seen_file="${CALL_LOG}.start-attempts"
         _seen=$(cat "${_seen_file}" 2>/dev/null) || _seen=0
         _seen=$((_seen + 1))
         printf '%s\n' "${_seen}" >"${_seen_file}"
@@ -596,11 +594,12 @@ _hold_lock() {
     _assert_logged "/gh-pr-merge-train acme/dotfiles"
 }
 
-# The retry is bounded, and the bound is the whole point: cron re-runs every
+# The retrying is bounded, and the bound is the whole point: cron re-runs every
 # few minutes anyway, so a tick that kept trying would only hold the lock
-# while the *next* tick is the thing that should be deciding.
-@test "pr_merge_train_cron: a permanent agent_pane_busy stops after the retry budget" {
-    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1
+# while the *next* tick is the thing that should be deciding. Three *attempts*
+# — one initial plus two retries — is what _PMT_START_ATTEMPT_MAX names.
+@test "pr_merge_train_cron: a permanent agent_pane_busy stops after the attempt budget" {
+    _run_tick HERDR_START_PANE_BUSY=99
     assert_failure
     [ "$(_log_count 'herdr agent start')" -eq 3 ]
     _refute_logged "herdr agent prompt"
@@ -610,7 +609,7 @@ _hold_lock() {
 # what filled the merge-train workspace with 40+ dead tabs, one per cron
 # period — the failure was invisible, but its litter was not.
 @test "pr_merge_train_cron: a start that never succeeds closes the tab it opened" {
-    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1
+    _run_tick HERDR_START_PANE_BUSY=99
     assert_failure
     _assert_logged "herdr tab close ws-test-1:t9"
 }
@@ -620,7 +619,7 @@ _hold_lock() {
 # the log said only "start failed" for weeks. Restoring `2>/dev/null` to
 # _pmt_agent_start must make this test red.
 @test "pr_merge_train_cron: a failed start reports the cause herdr gave on stderr" {
-    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1
+    _run_tick HERDR_START_PANE_BUSY=99
     assert_failure
     assert_output --partial "agent_pane_busy"
     assert_output --partial "원인:"
@@ -650,7 +649,7 @@ _hold_lock() {
 # Cleanup is best effort by design: the tick has already failed, and a herdr
 # that cannot close the tab is not a second, different verdict to report.
 @test "pr_merge_train_cron: a failing tab close does not change the tick's verdict" {
-    _run_tick HERDR_START_PANE_BUSY_ALWAYS=1 HERDR_TAB_CLOSE_FAIL=1
+    _run_tick HERDR_START_PANE_BUSY=99 HERDR_TAB_CLOSE_FAIL=1
     assert_failure
     _assert_logged "herdr tab close ws-test-1:t9"
     assert_output --partial "agent_pane_busy"


### PR DESCRIPTION
## Summary
- merge-train cron 디스패처가 갓 만든 pane 에서 `herdr agent start` 가 `agent_pane_busy` 로 거절될 때 재시도하지 않고 tick 을 끝내던 문제를 고친다.
- 그 실패가 왜 몇 주 동안 보이지 않았는지도 함께 고친다 — `2>/dev/null` 이 herdr 의 stderr 를 통째로 버려서 로그에 원인이 한 번도 뜨지 않았다.
- 실패가 남기던 고아 tab 을 정리한다. 워크스페이스에 40개 넘게 쌓여 있었다.

## Changes
- `shell-common/tools/custom/pr_merge_train_cron.sh`
  - `_pmt_agent_start` 가 stderr 를 호출자가 준 파일로 받는다(`2>"$3"`). stdout 은 그대로 둔다 — 호출자가 거기서 `.error.code` 를 읽으므로 `2>&1` 병합이 아니라 파일이어야 한다.
  - `_pmt_start_error_code <stdout-json> <errfile>` 신설: stdout 을 먼저, stderr 를 폴백으로 본다. 프로덕션에서 herdr 가 고른 스트림은 아무도 읽지 않는 쪽이었고, 그래서 기존 `agent_name_taken` 분기조차 실제로는 발화할 수 없었다.
  - `agent_pane_busy` 만 최대 3회 재시도(`_PMT_START_RETRY_MAX`, 간격은 `PMT_START_RETRY_SLEEP` 로 덮어쓰기 가능). 자기 자신을 설명하지 못하는 실패는 우리가 아는 경합이 아니므로 재시도하지 않는다.
  - 끝내 실패하면 herdr 문장의 첫 줄을 `원인:` 으로 들여써 남기고(#1458 관용구), 방금 연 tab 을 `herdr tab close` 로 닫는다. `_pmt_tab_create` 가 `<pane_id> <tab_id>` 를 함께 돌려주도록 바뀐 이유다.
  - `agent_name_taken` 경로는 tab 을 닫지 않는다 — 그 train 은 다른 pane 에서 멀쩡히 살아 있다.
- `tests/bats/tools/pr_merge_train_cron.bats` — 스텁에 `HERDR_START_PANE_BUSY=N` / `..._ALWAYS=1`(둘 다 에러 JSON 을 **stderr** 로 낸다), `tab close`(+`HERDR_TAB_CLOSE_FAIL=1`) 추가. 회귀 7건 추가로 41 -> 48 통과.
- `claude/skills/gh-pr-merge-train/references/cron-dispatcher.md` — Failure behaviour 표에 `agent_pane_busy` 행 추가. "더 재시도하면 train 이 둘 생긴다"는 기존 문장은 *prompt* 재시도에만 해당한다는 점을 명시했다 — 이 재시도는 agent 가 등록되지 않은 pane 을 다시 시도하는 것이라 두 번째 train 이 생길 수 없다.
- `docs/public/changelog.d/2026-08-27-1512.md` — changelog fragment.

## Test plan
- [x] `bash -n shell-common/tools/custom/pr_merge_train_cron.sh`
- [x] `bats tests/bats/tools/pr_merge_train_cron.bats` — 48/48 통과 (기존 41 + 신규 7)
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/tools/custom/pr_merge_train_cron.sh`
- [x] `sh scripts/lint_changelog_fragments.sh` / `sh scripts/lint_docs_filenames.sh` — errors=0
- [ ] (운영 검증) 대상 PR 이 있는 상태로 실제 cron tick 을 1회 유발해 `herdr agent get pmt-...` 가 `idle`/`working` 을 응답하는지 확인
- [ ] (운영 정리) 이미 쌓인 40여 개 고아 tab 은 이 PR 범위 밖 — 수동/별도 정리 필요

## Related
Closes #1512

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
