### PR TITLE
fix(gh-pr-merge-train): 승인 게이트가 플랜 제약 403 을 정책 미확인으로 오독하는 문제

### DIFF
--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -46,21 +46,23 @@ GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" --author @me --state ope
 `--author @me` is not optional (D-7) — never auto-merge a colleague's PR. Drop
 every PR updated within the last **11 minutes** (D-6) and every draft. Sort
 `CLEAN` → `BEHIND` → `UNSTABLE` → `DIRTY`, ties by ascending PR number (D-2).
-Ordering rationale and the quiet-period rationale: `references/ordering.md`.
+Ordering and quiet-period rationale: `references/ordering.md`.
 
 **`gh pr list` failure ends the run** with an empty report — never merge
 without knowing state.
 
 ## Step 3: Read the approval policy per base branch
 
-Read the repo ruleset's `required_approving_review_count` per
-`references/approval-gate.md`, **once per distinct `baseRefName`**, cached per
-base — rulesets are branch-scoped, so a single-base queue still costs one call.
-That is why this follows Step 2: the queue already carries the bases. `0` → the
-platform requires no approval (D-5). Non-zero → an unapproved PR is `[SKIPPED]`.
-**Lookup failure is fail-closed**: treat approval as required. Even with the
-gate off, a non-empty non-`APPROVED` `reviewDecision` is `[SKIPPED]` before
-`gh:pr-merge` is called — it would refuse, and NF-2 forbids clearing that.
+Read `required_approving_review_count` from **both** rulesets and classic
+branch protection per `references/approval-gate.md`, **once per distinct
+`baseRefName`**, cached per base — two calls per base, never per PR. Either
+source requiring `>= 1` → gate on, unapproved PRs `[SKIPPED]`; both reporting
+no policy → off (D-5). Classify by **HTTP status, not exit code**: `403`/`404`
+mean no policy can apply, 5xx / 401 / network mean undetermined and stay
+fail-closed — collapsing the two is what made unattended merges impossible on
+free-plan private repos (#1519). Even with the gate off, a non-empty
+non-`APPROVED` `reviewDecision` is `[SKIPPED]` before `gh:pr-merge` is called —
+it would refuse, and NF-2 forbids clearing that.
 
 ## Step 4: Run the train — one PR at a time
 
@@ -68,10 +70,12 @@ For each PR in queue order, run the loop in `references/train-loop.md`:
 **re-query state immediately before processing** (F-3 — the previous merge
 invalidated everything behind it), route through the D-1 table
 (`references/routing-table.md`), then merge with `Skill(gh:pr-merge, "<N>")`.
+Gate off with an empty `reviewDecision` first runs one
+`Skill(gh:pr-approve, "<N> <remote> --self-record")` and reads the board back as
+its verdict — no approval, no merge, and no re-run for an already-reviewed head.
 The `BEHIND` / `DIRTY` rows rebase inside a **detached scratch worktree** the
-train creates and unconditionally removes per attempt, never in this checkout
-(`references/train-loop.md` → "Detached scratch worktree", #1493). Attempts are
-capped at 3 per PR (F-5); a failure skips that one PR and the train continues
+train creates and unconditionally removes per attempt (#1493). Attempts are
+capped at 3 per PR (F-5); a failure skips that PR and the train continues
 (F-6). Never process two PRs concurrently.
 
 ## Step 5: Report
@@ -87,7 +91,9 @@ assistant text, never via a `Bash` heredoc or `Write`.
 - **Never abort the whole train** for one PR's failure (F-6).
 - **No merge strategy argument** — `gh:pr-merge`'s default rebase is what
   `required_linear_history` allows (D-4).
-- **No review judgement** — `gh:issue-flow` already ran `devx:pr-review-all`.
+- **No review judgement of its own** — `gh:issue-flow` already ran
+  `devx:pr-review-all`, and the gate-off path delegates to `gh:pr-approve`
+  rather than deciding anything here.
 - **No ai-metrics comment.** Every atom the train calls posts its own; a
   train-level one would only duplicate them on the same PR.
 - Full list: `references/constraints.md`.
@@ -95,7 +101,8 @@ assistant text, never via a `Bash` heredoc or `Write`.
 ## Related Skills
 
 Atoms this train calls: `gh:pr-resolve-outdated` · `gh:pr-resolve-conflict`
-· `gh:pr-resolve-ci-fail` · `gh:pr-merge`. Deliberately **not** called:
+· `gh:pr-resolve-ci-fail` · `gh:pr-approve` (`--self-record`, gate-off path
+only) · `gh:pr-merge`. Deliberately **not** called:
 `gh:pr-merge-emergency` (NF-2). Upstream producer of the PRs this train drains:
 `gh:issue-flow`. Unattended trigger: `shell-common/tools/custom/pr_merge_train_cron.sh`
 (`references/cron-dispatcher.md`).

--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -57,12 +57,11 @@ Read `required_approving_review_count` from **both** rulesets and classic
 branch protection per `references/approval-gate.md`, **once per distinct
 `baseRefName`**, cached per base — two calls per base, never per PR. Either
 source requiring `>= 1` → gate on, unapproved PRs `[SKIPPED]`; both reporting
-no policy → off (D-5). Classify by **HTTP status, not exit code**: `403`/`404`
-mean no policy can apply, 5xx / 401 / network mean undetermined and stay
-fail-closed — collapsing the two is what made unattended merges impossible on
-free-plan private repos (#1519). Even with the gate off, a non-empty
-non-`APPROVED` `reviewDecision` is `[SKIPPED]` before `gh:pr-merge` is called —
-it would refuse, and NF-2 forbids clearing that.
+no policy → off (D-5). Classify by **HTTP status, not exit code**: a `403`/`404`
+is "no policy", not a failed lookup, and only a genuinely undetermined answer
+stays fail-closed (#1519). Even with the gate off, a non-empty non-`APPROVED`
+`reviewDecision` is `[SKIPPED]` before `gh:pr-merge` is called — it would
+refuse, and NF-2 forbids clearing that.
 
 ## Step 4: Run the train — one PR at a time
 
@@ -72,7 +71,7 @@ invalidated everything behind it), route through the D-1 table
 (`references/routing-table.md`), then merge with `Skill(gh:pr-merge, "<N>")`.
 Gate off with an empty `reviewDecision` first runs one
 `Skill(gh:pr-approve, "<N> <remote> --self-record")` and reads the board back as
-its verdict — no approval, no merge, and no re-run for an already-reviewed head.
+its verdict — no approval, no merge.
 The `BEHIND` / `DIRTY` rows rebase inside a **detached scratch worktree** the
 train creates and unconditionally removes per attempt (#1493). Attempts are
 capped at 3 per PR (F-5); a failure skips that PR and the train continues

--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -27,7 +27,7 @@ metadata:
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output its
 content verbatim, then stop. **No API calls.** That file tables the positionals
-(`[owner/repo]`, `[remote]`) and names the five atom skills the train calls.
+(`[owner/repo]`, `[remote]`) and names the atom skills the train calls.
 
 ## Step 1: Bind the GitHub target
 

--- a/claude/skills/gh-pr-merge-train/references/approval-gate.md
+++ b/claude/skills/gh-pr-merge-train/references/approval-gate.md
@@ -35,24 +35,24 @@ queue. `@uri` turns the slash into `%2F` so the ref stays one path segment.
 `gh api` collapses every failure into a non-zero exit, which is exactly the
 information loss that produced the #1519 bug. Use `-i` so the status line
 survives, and read the body out of the same response — that keeps the cost at
-one call per source (F-5).
+one call per source.
 
 ```bash
-# Classify one policy source. Echoes "<verdict> <count>", verdict one of
-# required | none | unknown. Exactly one API call.
+# Classify one policy source. Echoes `none`, `unknown`, or the required
+# approval count (>= 1). Exactly one API call.
 _gate_probe() {
     _path="$1" _jq="$2"
     _out=$(GH_HOST="$TARGET_HOST" gh api -i "$_path" 2>/dev/null)
     _status=$(printf '%s\n' "$_out" | sed -n '1s|^HTTP/[0-9.]* *\([0-9][0-9][0-9]\).*|\1|p')
     case "$_status" in
-        2??) ;;                                            # fall through, parse the body
-        403 | 404) printf 'none 0\n'    ; return 0 ;;       # no policy can apply here
-        *) printf 'unknown 0\n'         ; return 0 ;;       # 5xx, 401, network, no response
+        2??) ;;                               # fall through, parse the body
+        403 | 404) echo none; return 0 ;;     # no policy can apply here
+        *) echo unknown; return 0 ;;          # 5xx, 401, network, no response
     esac
-    _n=$(printf '%s\n' "$_out" | sed -n '/^\r\{0,1\}$/,$p' | sed '1d' | jq -r "$_jq" 2>/dev/null)
+    _n=$(printf '%s\n' "$_out" | sed '1,/^\r\{0,1\}$/d' | jq -r "$_jq" 2>/dev/null)
     case "$_n" in
-        '' | null | 0) printf 'none 0\n' ;;
-        *) printf 'required %s\n' "$_n" ;;
+        '' | null | 0) echo none ;;
+        *) echo "$_n" ;;
     esac
 }
 
@@ -70,25 +70,27 @@ That is the case fail-closed exists for, and it is now the *only* case.
 
 | Result | Meaning | Verdict |
 |---|---|---|
-| `2xx`, count `>= 1` | approvals are required | `required <n>` |
+| `2xx`, count `>= 1` | approvals are required | `<n>` |
 | `2xx`, count `0` | a rule exists and asks for **zero** approvals | `none` |
 | `2xx`, no matching rule | this source imposes no PR review rule | `none` |
 | `403` | the plan does not have this feature — no policy *can* exist | `none` |
 | `404` | the feature exists but is not configured for this base | `none` |
 | anything else (5xx, 401, network, no response) | genuinely undetermined | `unknown` |
 
-### Combining the two sources (F-3, F-4)
+### Combining the two sources (#1519 F-3, F-4)
 
-| Sources | Gate | Header (NF-1) |
+| Sources | Gate | Header (#1519 NF-1) |
 |---|---|---|
 | either says `required n >= 1` | **on** — strictest `n` wins | `on (<source>: <n> approvals)` |
 | neither requires, at least one `unknown` | **on** — fail-closed | `on (fail-closed: <base> policy unreadable)` |
 | both `none` | **off** | `off (no policy on <base>)` |
 
 `required` outranks `unknown` for the header text only; both mean the gate is
-on. The three header strings are not cosmetic — see NF-1 below.
+on. The three header strings are not cosmetic: distinguishing them is what
+makes #1519's symptom visible — `report-format.md` → "The `approval gate:`
+field" carries the reason and is what the doc-guard tests pin.
 
-## Why 403 and 404 are "no policy", not "lookup failed" (D-1)
+## Why 403 and 404 are "no policy", not "lookup failed" (#1519 D-1)
 
 `403 Upgrade to GitHub Pro or make this repository public to enable this
 feature` and `404 Branch not protected` are statements *about the policy*, not
@@ -101,23 +103,21 @@ every tick with no action any human or skill can take — the same disease as th
 `[FAILED]` this file forbids two sections down, wearing a different name.
 
 `gh-pr-merge/references/strategy-selection.md` → "Branch protection detection"
-already reads the identical signal correctly:
-
-> Rationale for treating 403 and 404 the same: both mean "branch protection is
-> not gating this merge" from the caller's perspective. 403 means the feature
-> is locked by plan; 404 means it is unlocked but not configured. Either way,
-> no rule would have required an approval.
-
-The judgement was already in this repo; only the train disagreed. `#1513` fixed
-the same asymmetry in `gh:pr-merge`'s board gate.
+already states this rule — 403 means the feature is locked by plan, 404 that it
+is unlocked but unconfigured, and neither would have required an approval. The
+*judgement* was already in this repo; only the train disagreed. (Its
+*mechanism* still sniffs `gh api`'s exit code, so it cannot tell a 5xx from a
+403 either; it fails open rather than closed, so the same information loss
+shows up there as an over-permissive read instead of an unclearable skip.)
+`#1513` fixed the same asymmetry in `gh:pr-merge`'s board gate.
 
 **No opt-in gate is required for the off verdict.** If the repo owner put no
 approval policy on this base, the safety boundary is exactly where they put it
 — the same reasoning that makes skipping at `0` legitimate. Off does *not*
 mean "merge unreviewed", though: the off path runs a delegated review first
-(D-3, next section).
+(#1519 D-3, next section).
 
-## Why both sources, and not just `gh:pr-merge`'s one (D-2)
+## Why both sources, and not just `gh:pr-merge`'s one (#1519 D-2)
 
 Making this identical to `gh:pr-merge` — read classic protection only — would
 be a regression, not a simplification. A repo that enforces review purely
@@ -128,7 +128,7 @@ recoverable mistake; in an unattended loop it is a batch of unreviewed merges.
 Reading both and taking the strictest is what makes "off" trustworthy enough to
 act on.
 
-## Why the gate being off still runs a review (D-3, D-4)
+## Why the gate being off still runs a review (#1519 D-3, D-4)
 
 Gate off means "the *platform* does not require an approval". It does not mean
 "nobody needs to look at this". On the off path the train runs
@@ -137,17 +137,12 @@ reads the board back as that review's verdict — the procedure, its re-review
 suppression, and its failure handling are in `train-loop.md` → "Delegated
 review on the gate-off path".
 
-That step is not a rubber stamp. Eight agent-run `--self-record` reviews in the
-issue #1477 session promoted seven and **withheld one**: PR #1490's reviewer
-reproduced, in a worktree A/B, that the four new regression tests did not fail
-without the fix they were meant to lock, and left the card in `In review`
-rather than promote it.
+That step is not a rubber stamp: of eight agent-run `--self-record` reviews in
+the issue #1477 session, one withheld promotion over a real defect.
 
 Reading the board here is **not** a revival of the board *gate* `#1513`
-retired. That gate stood in for platform approval and permanently blocked
-self-authored PRs; this reads back the return value of a review the train
-itself just ran, one tick earlier at most. `train-loop.md` keeps both
-statements side by side so the distinction cannot erode.
+retired — see `train-loop.md` → "Gates `gh:pr-merge` owns", which keeps that
+distinction next to the board read it governs.
 
 ## Why skipping at `0` is not a bypass
 
@@ -214,11 +209,10 @@ Look up the requirement for **that PR's own base**, from the per-base cache
 above — the read happens once per distinct base, not once per PR and not once
 per run. Then apply it against that PR's own `reviewDecision`:
 
-- gate on and `reviewDecision == APPROVED` → proceed, no delegated review.
+- `reviewDecision == APPROVED` → proceed, gate on or off, no delegated review:
+  a real approval already exists and re-reviewing it would be waste.
 - gate on and anything else (`REVIEW_REQUIRED`, `CHANGES_REQUESTED`, `""`) →
   `[SKIPPED] approval required (reviewDecision=<value>)`, next PR.
-- gate off and `reviewDecision == APPROVED` → proceed, no delegated review — a
-  real approval already exists and re-reviewing it would be waste.
 - gate off and `reviewDecision` non-empty and not `APPROVED` →
   `[SKIPPED] gh:pr-merge refuses reviewDecision=<value>`, next PR (previous
   section — this is the case that would otherwise become an unclearable
@@ -229,11 +223,3 @@ per run. Then apply it against that PR's own `reviewDecision`:
 A `CHANGES_REQUESTED` PR is skipped **even when the gate is off**: someone
 explicitly blocked it, and the absence of a platform rule does not overrule a
 human's stated objection.
-
-## NF-1: the header must show which of the three happened
-
-`report-format.md`'s `approval gate:` field carries one of the three strings in
-the combine table. Collapsing them back into one "unreadable" makes #1519's
-symptom invisible again — the bug's whole lifetime was spent looking at a
-header that said `fail-closed: ruleset unreadable` on a repo where no ruleset
-could ever exist.

--- a/claude/skills/gh-pr-merge-train/references/approval-gate.md
+++ b/claude/skills/gh-pr-merge-train/references/approval-gate.md
@@ -2,22 +2,23 @@
 
 Read the repo's **actual** policy and obey it. This skill never bypasses an
 approval requirement and never manufactures one that the platform does not
-impose.
+impose. Both halves of that sentence are load-bearing: inventing a requirement
+the platform cannot impose is the failure #1519 fixed.
 
-## Read the requirement — once per distinct base branch
+## Read the requirement — once per distinct base branch, from two sources
 
 Rulesets are frequently scoped to a branch pattern, so the answer is a property
 of the **base branch**, not of the repo. Read it per distinct `baseRefName` in
 the Step 2 queue and **cache it per base**: a single-base queue — the normal
-case for `--author @me` — therefore costs exactly one call, and a mixed queue
-costs one call per base rather than one per PR.
+case for `--author @me` — therefore costs exactly two calls, and a mixed queue
+costs two per base rather than two per PR.
 
-```bash
-BASE_ENC=$(jq -rn --arg b "$BASE" '$b|@uri')
-GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/rules/branches/$BASE_ENC" \
-  --jq '[.[] | select(.type == "pull_request")
-             | .parameters.required_approving_review_count] | max // empty'
-```
+Two sources, because a repo can enforce review through either mechanism:
+
+| Source | Endpoint | `jq` |
+|---|---|---|
+| rulesets | `repos/{repo}/rules/branches/{base}` | `[.[] \| select(.type == "pull_request") \| .parameters.required_approving_review_count] \| max // empty` |
+| classic branch protection | `repos/{repo}/branches/{base}/protection` | `.required_pull_request_reviews.required_approving_review_count // empty` |
 
 `$BASE` is the queue's `baseRefName`, which Step 2's `gh pr list --json`
 already returned — never guess `main`, and never spend a `gh pr view` on it.
@@ -29,14 +30,124 @@ base like `release/2026.08` makes the path
 the call fails, and the fail-closed default below then skips every PR in the
 queue. `@uri` turns the slash into `%2F` so the ref stays one path segment.
 
-Three outcomes, per base:
+## Classify each source by HTTP status, not by exit code
 
-| Result | Meaning | Gate |
+`gh api` collapses every failure into a non-zero exit, which is exactly the
+information loss that produced the #1519 bug. Use `-i` so the status line
+survives, and read the body out of the same response — that keeps the cost at
+one call per source (F-5).
+
+```bash
+# Classify one policy source. Echoes "<verdict> <count>", verdict one of
+# required | none | unknown. Exactly one API call.
+_gate_probe() {
+    _path="$1" _jq="$2"
+    _out=$(GH_HOST="$TARGET_HOST" gh api -i "$_path" 2>/dev/null)
+    _status=$(printf '%s\n' "$_out" | sed -n '1s|^HTTP/[0-9.]* *\([0-9][0-9][0-9]\).*|\1|p')
+    case "$_status" in
+        2??) ;;                                            # fall through, parse the body
+        403 | 404) printf 'none 0\n'    ; return 0 ;;       # no policy can apply here
+        *) printf 'unknown 0\n'         ; return 0 ;;       # 5xx, 401, network, no response
+    esac
+    _n=$(printf '%s\n' "$_out" | sed -n '/^\r\{0,1\}$/,$p' | sed '1d' | jq -r "$_jq" 2>/dev/null)
+    case "$_n" in
+        '' | null | 0) printf 'none 0\n' ;;
+        *) printf 'required %s\n' "$_n" ;;
+    esac
+}
+
+BASE_ENC=$(jq -rn --arg b "$BASE" '$b|@uri')
+RULESET=$(_gate_probe "repos/$TARGET_REPO/rules/branches/$BASE_ENC" \
+    '[.[] | select(.type == "pull_request") | .parameters.required_approving_review_count] | max // empty')
+CLASSIC=$(_gate_probe "repos/$TARGET_REPO/branches/$BASE_ENC/protection" \
+    '.required_pull_request_reviews.required_approving_review_count // empty')
+```
+
+An empty `$_status` — no HTTP response at all — falls to `*` and is `unknown`.
+That is the case fail-closed exists for, and it is now the *only* case.
+
+### Per-source verdicts
+
+| Result | Meaning | Verdict |
 |---|---|---|
-| `0` | a `pull_request` rule exists and asks for **zero** approvals | **skip the approval check** |
-| `>= 1` | approvals are required | `reviewDecision` must be `APPROVED` |
-| empty (no `pull_request` rule) | the platform imposes no PR review rule | skip the approval check |
-| **call failed** | unknown | **fail-closed: treat as required** |
+| `2xx`, count `>= 1` | approvals are required | `required <n>` |
+| `2xx`, count `0` | a rule exists and asks for **zero** approvals | `none` |
+| `2xx`, no matching rule | this source imposes no PR review rule | `none` |
+| `403` | the plan does not have this feature — no policy *can* exist | `none` |
+| `404` | the feature exists but is not configured for this base | `none` |
+| anything else (5xx, 401, network, no response) | genuinely undetermined | `unknown` |
+
+### Combining the two sources (F-3, F-4)
+
+| Sources | Gate | Header (NF-1) |
+|---|---|---|
+| either says `required n >= 1` | **on** — strictest `n` wins | `on (<source>: <n> approvals)` |
+| neither requires, at least one `unknown` | **on** — fail-closed | `on (fail-closed: <base> policy unreadable)` |
+| both `none` | **off** | `off (no policy on <base>)` |
+
+`required` outranks `unknown` for the header text only; both mean the gate is
+on. The three header strings are not cosmetic — see NF-1 below.
+
+## Why 403 and 404 are "no policy", not "lookup failed" (D-1)
+
+`403 Upgrade to GitHub Pro or make this repository public to enable this
+feature` and `404 Branch not protected` are statements *about the policy*, not
+failures to read it. On a free-plan private repo the ruleset endpoint answers
+403 for every base, forever. Treating that as "approval required" invents a
+rule the platform cannot enforce, and on a `--author @me` train it is
+unclearable: `gh:pr-approve` cannot approve a self-authored PR, and NF-2
+forbids `gh:pr-merge-emergency`. The result is `[SKIPPED] approval required` on
+every tick with no action any human or skill can take — the same disease as the
+`[FAILED]` this file forbids two sections down, wearing a different name.
+
+`gh-pr-merge/references/strategy-selection.md` → "Branch protection detection"
+already reads the identical signal correctly:
+
+> Rationale for treating 403 and 404 the same: both mean "branch protection is
+> not gating this merge" from the caller's perspective. 403 means the feature
+> is locked by plan; 404 means it is unlocked but not configured. Either way,
+> no rule would have required an approval.
+
+The judgement was already in this repo; only the train disagreed. `#1513` fixed
+the same asymmetry in `gh:pr-merge`'s board gate.
+
+**No opt-in gate is required for the off verdict.** If the repo owner put no
+approval policy on this base, the safety boundary is exactly where they put it
+— the same reasoning that makes skipping at `0` legitimate. Off does *not*
+mean "merge unreviewed", though: the off path runs a delegated review first
+(D-3, next section).
+
+## Why both sources, and not just `gh:pr-merge`'s one (D-2)
+
+Making this identical to `gh:pr-merge` — read classic protection only — would
+be a regression, not a simplification. A repo that enforces review purely
+through rulesets answers `404` on the classic endpoint, so a protection-only
+read verdicts `none` and turns the gate **off** on a base that genuinely
+requires approvals. For a human running `gh:pr-merge` on one PR that is a
+recoverable mistake; in an unattended loop it is a batch of unreviewed merges.
+Reading both and taking the strictest is what makes "off" trustworthy enough to
+act on.
+
+## Why the gate being off still runs a review (D-3, D-4)
+
+Gate off means "the *platform* does not require an approval". It does not mean
+"nobody needs to look at this". On the off path the train runs
+`Skill(gh:pr-approve, "<N> <remote> --self-record")` once before merging and
+reads the board back as that review's verdict — the procedure, its re-review
+suppression, and its failure handling are in `train-loop.md` → "Delegated
+review on the gate-off path".
+
+That step is not a rubber stamp. Eight agent-run `--self-record` reviews in the
+issue #1477 session promoted seven and **withheld one**: PR #1490's reviewer
+reproduced, in a worktree A/B, that the four new regression tests did not fail
+without the fix they were meant to lock, and left the card in `In review`
+rather than promote it.
+
+Reading the board here is **not** a revival of the board *gate* `#1513`
+retired. That gate stood in for platform approval and permanently blocked
+self-authored PRs; this reads back the return value of a review the train
+itself just ran, one tick earlier at most. `train-loop.md` keeps both
+statements side by side so the distinction cannot erode.
 
 ## Why skipping at `0` is not a bypass
 
@@ -77,25 +188,25 @@ tick. **A train must never be able to produce an unclearable `[FAILED]`.**
 Therefore: **check `reviewDecision` before calling `gh:pr-merge`, even when the
 gate is off.** A non-empty value that is not `APPROVED` is
 `[SKIPPED] gh:pr-merge refuses reviewDecision=<value>` — retriable the moment a
-human approves or dismisses the review, and never an attempt.
+human approves or dismisses the review, and never an attempt. It is also
+checked **before** the delegated review, so a PR a human explicitly blocked is
+never handed to a self-record run that might promote it.
 
-The empty (`""`) case needs no rule of its own: with protection absent
-`gh:pr-merge` accepts it by design, and with protection present a review
-requirement is almost always configured too — so this gate is already on and
-the PR is already `[SKIPPED] approval required`.
+The empty (`""`) case is the delegated review's path: with protection absent
+`gh:pr-merge` accepts it by design, so this is where the train supplies the
+review signal the platform is not asking for.
 
-## Why lookup failure is fail-closed
+## Why lookup failure is still fail-closed
 
 A merge is hard to undo. A skipped PR is trivially retried on the next tick.
 When the two error directions are that asymmetric, the cheap mistake is the one
-to make: an unreadable ruleset is treated as "approval required", so unapproved
-PRs are `[SKIPPED] ruleset unreadable — approval assumed required` and nothing
-merges on a guess.
+to make: an *undetermined* policy is treated as "approval required", so
+unapproved PRs are `[SKIPPED] policy unreadable — approval assumed required`
+and nothing merges on a guess.
 
-This is the opposite default from `gh:pr-merge`'s solo-repo accommodation
-(protection absent → accept an empty `reviewDecision`). That accommodation is
-sound for one deliberate, human-invoked merge; as an unattended loop's default
-it would turn every transient API failure into a batch of unreviewed merges.
+`#1519` narrowed **what counts as undetermined**; it did not weaken the
+principle. A 5xx, a 401, or a dead network still fails closed. What no longer
+fails closed is a definitive answer that happens to arrive with a 4xx status.
 
 ## Applying it per PR
 
@@ -103,15 +214,26 @@ Look up the requirement for **that PR's own base**, from the per-base cache
 above — the read happens once per distinct base, not once per PR and not once
 per run. Then apply it against that PR's own `reviewDecision`:
 
-- gate on and `reviewDecision == APPROVED` → proceed.
+- gate on and `reviewDecision == APPROVED` → proceed, no delegated review.
 - gate on and anything else (`REVIEW_REQUIRED`, `CHANGES_REQUESTED`, `""`) →
   `[SKIPPED] approval required (reviewDecision=<value>)`, next PR.
+- gate off and `reviewDecision == APPROVED` → proceed, no delegated review — a
+  real approval already exists and re-reviewing it would be waste.
 - gate off and `reviewDecision` non-empty and not `APPROVED` →
   `[SKIPPED] gh:pr-merge refuses reviewDecision=<value>`, next PR (previous
   section — this is the case that would otherwise become an unclearable
   `[FAILED]`).
-- gate off and `reviewDecision` `APPROVED` or `""` → no approval check at all.
+- gate off and `reviewDecision == ""` → **delegated review**
+  (`train-loop.md` → "Delegated review on the gate-off path").
 
 A `CHANGES_REQUESTED` PR is skipped **even when the gate is off**: someone
 explicitly blocked it, and the absence of a platform rule does not overrule a
 human's stated objection.
+
+## NF-1: the header must show which of the three happened
+
+`report-format.md`'s `approval gate:` field carries one of the three strings in
+the combine table. Collapsing them back into one "unreadable" makes #1519's
+symptom invisible again — the bug's whole lifetime was spent looking at a
+header that said `fail-closed: ruleset unreadable` on a repo where no ruleset
+could ever exist.

--- a/claude/skills/gh-pr-merge-train/references/approval-gate.md
+++ b/claude/skills/gh-pr-merge-train/references/approval-gate.md
@@ -40,18 +40,38 @@ one call per source.
 ```bash
 # Classify one policy source. Echoes `none`, `unknown`, or the required
 # approval count (>= 1). Exactly one API call.
+#
+# Both unknown-verdict rules below are fail-closed by construction: `none`
+# is only ever reached by an explicitly recognised answer, so an unforeseen
+# response shape turns the gate ON rather than off.
 _gate_probe() {
     _path="$1" _jq="$2"
     _out=$(GH_HOST="$TARGET_HOST" gh api -i "$_path" 2>/dev/null)
     _status=$(printf '%s\n' "$_out" | sed -n '1s|^HTTP/[0-9.]* *\([0-9][0-9][0-9]\).*|\1|p')
+    _body=$(printf '%s\n' "$_out" | sed '1,/^\r\{0,1\}$/d')
     case "$_status" in
         2??) ;;                               # fall through, parse the body
-        403 | 404) echo none; return 0 ;;     # no policy can apply here
+        404) echo none; return 0 ;;           # the feature is not configured here
+        403)
+            # NOT every 403 means "no policy". Only the plan-limit message
+            # does; permission, rate-limit and SSO denials are unreadable
+            # policy and must fail closed (PR #1526 agy+codex review).
+            case "$_body" in
+                *"Upgrade to GitHub Pro"*) echo none ;;
+                *) echo unknown ;;
+            esac
+            return 0
+            ;;
         *) echo unknown; return 0 ;;          # 5xx, 401, network, no response
     esac
-    _n=$(printf '%s\n' "$_out" | sed '1,/^\r\{0,1\}$/d' | jq -r "$_jq" 2>/dev/null)
+    # A 2xx with no body, or a body `jq` cannot parse, is NOT "no policy" —
+    # it is an unparsed answer. Distinguish jq's *failure* (non-zero exit)
+    # from jq's *empty result* (exit 0, no output = the rule is absent).
+    [ -n "$(printf '%s' "$_body" | tr -d '[:space:]')" ] || { echo unknown; return 0; }
+    _n=$(printf '%s\n' "$_body" | jq -r "$_jq" 2>/dev/null) || { echo unknown; return 0; }
     case "$_n" in
         '' | null | 0) echo none ;;
+        *[!0-9]*) echo unknown ;;             # not a plain count -> unparsed
         *) echo "$_n" ;;
     esac
 }
@@ -64,7 +84,25 @@ CLASSIC=$(_gate_probe "repos/$TARGET_REPO/branches/$BASE_ENC/protection" \
 ```
 
 An empty `$_status` — no HTTP response at all — falls to `*` and is `unknown`.
-That is the case fail-closed exists for, and it is now the *only* case.
+
+### `none` is a whitelist, never a fallback
+
+Every path to `none` names the exact answer that produced it: a `404`, a `403`
+whose body carries GitHub's plan-limit message, or a `2xx` whose body parsed
+cleanly into "no rule" / `0`. Everything else — a `403` from a permission,
+rate-limit or SAML/SSO denial, a `2xx` with an empty body, a body `jq` cannot
+parse, a count that is not a plain integer — lands on `unknown` and the gate
+stays on.
+
+That asymmetry is the whole point. `unknown` costs a `[SKIPPED]` the next tick
+retries; `none` on a repo that really does require approvals is an unreviewed
+merge. `#1519` narrowed which answers are definitive; it must never widen
+which answers are *assumed* definitive.
+
+The `403` split is what the PR #1526 review added: the original patch keyed on
+the status alone, and GitHub reuses `403` for "your plan lacks this feature",
+"your token may not read this", "you are rate limited", and "this org needs
+SSO". Only the first is a statement about the policy.
 
 ### Per-source verdicts
 
@@ -73,8 +111,10 @@ That is the case fail-closed exists for, and it is now the *only* case.
 | `2xx`, count `>= 1` | approvals are required | `<n>` |
 | `2xx`, count `0` | a rule exists and asks for **zero** approvals | `none` |
 | `2xx`, no matching rule | this source imposes no PR review rule | `none` |
-| `403` | the plan does not have this feature — no policy *can* exist | `none` |
+| `403` + `Upgrade to GitHub Pro` in the body | the plan does not have this feature — no policy *can* exist | `none` |
+| `403`, any other body | permission / rate-limit / SSO denial — the policy is unreadable, not absent | `unknown` |
 | `404` | the feature exists but is not configured for this base | `none` |
+| `2xx` with an empty or unparseable body | an answer arrived but was not understood | `unknown` |
 | anything else (5xx, 401, network, no response) | genuinely undetermined | `unknown` |
 
 ### Combining the two sources (#1519 F-3, F-4)
@@ -94,7 +134,8 @@ field" carries the reason and is what the doc-guard tests pin.
 
 `403 Upgrade to GitHub Pro or make this repository public to enable this
 feature` and `404 Branch not protected` are statements *about the policy*, not
-failures to read it. On a free-plan private repo the ruleset endpoint answers
+failures to read it. (A `404` here cannot be a hidden access failure: Step 2's
+`gh pr list` already succeeded against this repo, so the token can see it.) On a free-plan private repo the ruleset endpoint answers
 403 for every base, forever. Treating that as "approval required" invents a
 rule the platform cannot enforce, and on a `--author @me` train it is
 unclearable: `gh:pr-approve` cannot approve a self-authored PR, and NF-2

--- a/claude/skills/gh-pr-merge-train/references/constraints.md
+++ b/claude/skills/gh-pr-merge-train/references/constraints.md
@@ -36,12 +36,24 @@ default, so the train passes no strategy argument at all (D-4). Passing one
 explicitly would be a second place for the policy to drift out of sync with the
 repo's actual settings.
 
-## Never review, never approve
+## Never form a review judgement of its own
 
 `gh:issue-flow` Step 2.4 already ran `devx:pr-review-all` on every PR this
-train drains. Re-reviewing here would duplicate that work with less context,
-and approving is impossible anyway — GitHub forbids approving your own PR, and
-`--author @me` means every PR here is yours.
+train drains, and GitHub forbids approving your own PR — with `--author @me`,
+every PR here is yours, so no approving review is obtainable at all.
+
+**The one delegated exception (#1519 D-3).** When the approval gate reads
+*off*, no platform rule is asking for a review, and merging on that basis
+alone would put unexamined code on the base branch. In that one case the train
+runs `Skill(gh:pr-approve, "<N> <remote> --self-record")` once and reads the
+board back as its verdict (`train-loop.md` → "Delegated review on the gate-off
+path"). That is not this skill reviewing: the judgement, the BLOCKER
+classification, and the board write all belong to `gh:pr-approve`, and the
+train only routes on the answer. The constraint it preserves is the real one —
+**the train never decides whether a PR is good.**
+
+It also does not duplicate Step 2.4: a self-record review runs at most once per
+head (`#1519 F-8`), and only on PRs the platform leaves ungated.
 
 ## Never write ai-metrics from the train
 

--- a/claude/skills/gh-pr-merge-train/references/help.md
+++ b/claude/skills/gh-pr-merge-train/references/help.md
@@ -32,8 +32,10 @@
   it.
 - **You need an admin bypass.** The train never calls
   `gh:pr-merge-emergency` (NF-2). Run that skill yourself, deliberately.
-- **The PRs still need review.** The train does not review; `gh:issue-flow`
-  Step 2.4 already ran `devx:pr-review-all`.
+- **The PRs still need a human's judgement.** The train forms no opinion of
+  its own: `gh:issue-flow` Step 2.4 already ran `devx:pr-review-all`, and where
+  the approval gate is off the train delegates one `gh:pr-approve
+  --self-record` pass rather than deciding anything itself (#1519 D-3).
 
 ## What the skill does
 
@@ -41,13 +43,20 @@
 2. Lists your own open PRs, drops drafts and anything updated in the last
    **11 minutes** (D-6), and sorts `CLEAN` → `BEHIND` → `UNSTABLE` → `DIRTY`,
    ties by ascending number (D-2).
-3. Reads the repo ruleset's `required_approving_review_count` once per
-   *distinct base branch* in the queue (rulesets are branch-scoped; a
-   single-base queue is one call) — `0` means the platform does not require
-   approval, so the approval check is skipped (D-5). Lookup failure is
-   **fail-closed**: approval is treated as required.
+3. Reads `required_approving_review_count` once per *distinct base branch* in
+   the queue, from **both** rulesets and classic branch protection (policies
+   are branch-scoped; a single-base queue is two calls). Either source asking
+   for `>= 1` turns the gate on; both reporting no policy turns it off (D-5).
+   The verdict is classified by **HTTP status**: `403` (plan does not have the
+   feature) and `404` (not configured) mean no policy can apply here, while
+   5xx / 401 / no response are genuinely undetermined and stay **fail-closed**
+   (#1519 F-2). The report header names which of the three happened.
 4. Processes **one PR at a time**. Immediately before each one it re-queries
    state (F-3), because the previous merge changed it.
+   When the gate is off and `reviewDecision` is empty, it first runs one
+   `gh:pr-approve --self-record` and merges only if that review promoted the
+   board card — a withheld approval skips the PR, and an already-reviewed head
+   is never re-reviewed (#1519 F-6 … F-9).
 5. Routes on `mergeStateStatus` / `mergeable` through the D-1 table — the one
    copy lives in `references/routing-table.md`. Which atom each row reaches is
    summarised under "Atom skills it calls" below.
@@ -61,8 +70,11 @@
 ## What the skill will NOT do
 
 - Merge without knowing state — a failed `gh pr list` ends the run.
-- Merge an unapproved PR where the ruleset requires approval, or where the
-  ruleset could not be read at all.
+- Merge an unapproved PR where either policy source requires approval, or
+  where a source's state is genuinely undetermined (5xx / 401 / no response).
+  A `403`/`404` is **not** that case — it is a definitive "no policy here".
+- Merge a gate-off PR whose delegated `gh:pr-approve --self-record` review
+  withheld approval.
 - Call `gh:pr-merge-emergency`, or file an incident issue.
 - Pass a merge strategy — `gh:pr-merge`'s default rebase is what
   `required_linear_history` allows (D-4).
@@ -76,6 +88,7 @@
 | `gh:pr-resolve-outdated` | `BEHIND` + `MERGEABLE` — clean rebase onto the moved base, in a scratch worktree |
 | `gh:pr-resolve-conflict` | `DIRTY` + `CONFLICTING` — the LLM-judgement row, in a scratch worktree |
 | `gh:pr-resolve-ci-fail` | `UNSTABLE` with a failing check — the other LLM-judgement row |
+| `gh:pr-approve` | `--self-record`, once per head, only when the approval gate is off and `reviewDecision` is empty (#1519 D-3) |
 | `gh:pr-merge` | every row that reaches a mergeable state |
 | none | `BLOCKED` / `DRAFT` skip; `UNSTABLE` still running and `UNKNOWN` poll first |
 

--- a/claude/skills/gh-pr-merge-train/references/help.md
+++ b/claude/skills/gh-pr-merge-train/references/help.md
@@ -47,10 +47,12 @@
    the queue, from **both** rulesets and classic branch protection (policies
    are branch-scoped; a single-base queue is two calls). Either source asking
    for `>= 1` turns the gate on; both reporting no policy turns it off (D-5).
-   The verdict is classified by **HTTP status**: `403` (plan does not have the
-   feature) and `404` (not configured) mean no policy can apply here, while
-   5xx / 401 / no response are genuinely undetermined and stay **fail-closed**
-   (#1519 F-2). The report header names which of the three happened.
+   The verdict is classified by **HTTP status and body**: a `404` (not
+   configured), or a `403` carrying GitHub's plan-limit message, means no
+   policy can apply here. Everything else — a `403` from a permission,
+   rate-limit or SSO denial, a 5xx, a 401, no response, or a `2xx` whose body
+   will not parse — is undetermined and stays **fail-closed** (#1519 F-2).
+   The report header names which of the three happened.
 4. Processes **one PR at a time**. Immediately before each one it re-queries
    state (F-3), because the previous merge changed it.
    When the gate is off and `reviewDecision` is empty, it first runs one

--- a/claude/skills/gh-pr-merge-train/references/report-format.md
+++ b/claude/skills/gh-pr-merge-train/references/report-format.md
@@ -29,7 +29,7 @@ Rules:
   `--author @me`) are **not** listed — they were never candidates. Mention them
   only as a count, if at all.
 
-## The `approval gate:` field (NF-1)
+## The `approval gate:` field (#1519 NF-1)
 
 Exactly one of three strings, from `approval-gate.md`'s combine table:
 
@@ -37,7 +37,7 @@ Exactly one of three strings, from `approval-gate.md`'s combine table:
 |---|---|
 | `off (no policy on <base>)` | neither rulesets nor classic protection require an approval on this base — the delegated review supplies the signal instead |
 | `on (<source>: <n> approvals)` | `<source>` is `ruleset` or `protection`; the strictest count wins |
-| `on (fail-closed: <base> policy unreadable)` | the policy is genuinely undetermined (5xx, 401, network) — **not** a 403/404 |
+| `on (fail-closed: <base> policy unreadable)` | the policy is genuinely undetermined (5xx, 401, network) — **not** a 403/404. Stating it here shows once, at the top, why every unapproved PR below was skipped, instead of repeating it per line |
 
 Distinguishing the three is the point, not decoration. #1519's symptom was a
 header reading `on (fail-closed: ruleset unreadable)` on a free-plan repo where
@@ -45,7 +45,8 @@ no ruleset can exist — a bug that looked, for its whole lifetime, exactly like
 a transient API problem. A header that cannot tell "undetermined" from "there
 is nothing to determine" hides the next instance of it just as well.
 
-Mixed-base queues carry one clause per distinct base, `·`-separated:
+Mixed-base queues carry one clause per distinct base, `·`-separated. The base
+is already the clause prefix there, so it drops out of the string itself:
 `approval gate: main=off (no policy) · release/2026.08=on (ruleset: 1 approvals)`.
 
 ## Status vocabulary
@@ -53,7 +54,7 @@ Mixed-base queues carry one clause per distinct base, `·`-separated:
 | Status | Meaning | Typical reason |
 |---|---|---|
 | `[MERGED]` | the PR is merged | — |
-| `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `policy unreadable — approval assumed required`, `self-record withheld approval (BLOCKER)`, `approval withheld (unchanged since review)`, `board unreadable — approval unconfirmed`, `self-record failed`, `BLOCKED: <rule>`, `draft` |
+| `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `policy unreadable — approval assumed required`, `BLOCKED: <rule>`, `draft`, plus the four delegated-review reasons tabled below |
 | `[FAILED]` | not merged, **and something actually went wrong** | `conflict unresolved after 3 attempts`, `gh:pr-merge failed: <message>`, `CI fix failed after 3 attempts` |
 
 Two of those reasons — `gh:pr-merge refuses reviewDecision=<value>` and
@@ -74,9 +75,9 @@ distinguishes what a reader has to do about each:
 | Reason | What happened | Cleared by |
 |---|---|---|
 | `self-record withheld approval (BLOCKER)` | the review ran this tick and found a blocker | pushing a fix (new head re-arms the review) |
-| `approval withheld (unchanged since review)` | the same head was already reviewed and declined — **not re-reviewed**, by design (F-8) | pushing a fix, or promoting the card by hand |
+| `approval withheld (unchanged since review)` | the same head was already reviewed and declined — **not re-reviewed**, by design (#1519 F-8) | pushing a fix, or promoting the card by hand |
 | `board unreadable — approval unconfirmed` | the review's verdict could not be read back | the next tick, usually |
-| `self-record failed` | `gh:pr-approve` itself errored (F-9) | the next tick |
+| `self-record failed` | `gh:pr-approve` itself errored (#1519 F-9) | the next tick |
 
 None of the four spends an F-5 attempt, and none is ever `[FAILED]`: a
 withheld approval is a working review, not a broken train.
@@ -95,6 +96,3 @@ unattended loop nobody reads.
 - Queue empty after filtering → header plus `queue: 0 PR(s)` and
   `nothing to do`. Not an error; the dispatcher normally prevents this from
   even starting a session.
-- Policy undetermined → the header's `approval gate:` reads
-  `on (fail-closed: <base> policy unreadable)`, so the reason every unapproved
-  PR was skipped is visible once, at the top, rather than repeated per line.

--- a/claude/skills/gh-pr-merge-train/references/report-format.md
+++ b/claude/skills/gh-pr-merge-train/references/report-format.md
@@ -7,7 +7,7 @@ assistant text — never a `Bash` heredoc, never `Write` (#1270).
 
 ```
 == merge train: <owner/repo> ==
-queue: <n> PR(s)  ·  approval gate: <on|off>  ·  quiet period: 11m
+queue: <n> PR(s)  ·  approval gate: <verdict>  ·  quiet period: 11m
 
 [MERGED]  #1466  refactor(issue-watcher): simplify   (BEHIND -> resolve-outdated -> merged)
 [MERGED]  #1467  fix(gh-pr-reply): ...               (CLEAN -> merged)
@@ -29,16 +29,35 @@ Rules:
   `--author @me`) are **not** listed — they were never candidates. Mention them
   only as a count, if at all.
 
+## The `approval gate:` field (NF-1)
+
+Exactly one of three strings, from `approval-gate.md`'s combine table:
+
+| Header | Means |
+|---|---|
+| `off (no policy on <base>)` | neither rulesets nor classic protection require an approval on this base — the delegated review supplies the signal instead |
+| `on (<source>: <n> approvals)` | `<source>` is `ruleset` or `protection`; the strictest count wins |
+| `on (fail-closed: <base> policy unreadable)` | the policy is genuinely undetermined (5xx, 401, network) — **not** a 403/404 |
+
+Distinguishing the three is the point, not decoration. #1519's symptom was a
+header reading `on (fail-closed: ruleset unreadable)` on a free-plan repo where
+no ruleset can exist — a bug that looked, for its whole lifetime, exactly like
+a transient API problem. A header that cannot tell "undetermined" from "there
+is nothing to determine" hides the next instance of it just as well.
+
+Mixed-base queues carry one clause per distinct base, `·`-separated:
+`approval gate: main=off (no policy) · release/2026.08=on (ruleset: 1 approvals)`.
+
 ## Status vocabulary
 
 | Status | Meaning | Typical reason |
 |---|---|---|
 | `[MERGED]` | the PR is merged | — |
-| `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `ruleset unreadable — approval assumed required`, `BLOCKED: <rule>`, `draft` |
+| `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `policy unreadable — approval assumed required`, `self-record withheld approval (BLOCKER)`, `approval withheld (unchanged since review)`, `board unreadable — approval unconfirmed`, `self-record failed`, `BLOCKED: <rule>`, `draft` |
 | `[FAILED]` | not merged, **and something actually went wrong** | `conflict unresolved after 3 attempts`, `gh:pr-merge failed: <message>`, `CI fix failed after 3 attempts` |
 
 Two of those reasons — `gh:pr-merge refuses reviewDecision=<value>` and
-`ruleset unreadable` — name a gate that lives **downstream**, in `gh:pr-merge`
+`policy unreadable` — name a gate that lives **downstream**, in `gh:pr-merge`
 (its Step 2 `reviewDecision` hard stop) or in a policy that could not be read.
 They are `[SKIPPED]`, never `[FAILED]`, and they are recorded **without
 delegating** — see
@@ -47,6 +66,20 @@ refused identically every time, so letting it reach `gh:pr-merge` would spend
 three F-5 attempts to produce a `[FAILED]` that NF-2 leaves no way to clear.
 Naming the `reviewDecision` value is what makes the line actionable: the reader
 knows which review to dismiss.
+
+Four more come from the step-2b delegated review
+(`train-loop.md` → "Delegated review on the gate-off path"), and the wording
+distinguishes what a reader has to do about each:
+
+| Reason | What happened | Cleared by |
+|---|---|---|
+| `self-record withheld approval (BLOCKER)` | the review ran this tick and found a blocker | pushing a fix (new head re-arms the review) |
+| `approval withheld (unchanged since review)` | the same head was already reviewed and declined — **not re-reviewed**, by design (F-8) | pushing a fix, or promoting the card by hand |
+| `board unreadable — approval unconfirmed` | the review's verdict could not be read back | the next tick, usually |
+| `self-record failed` | `gh:pr-approve` itself errored (F-9) | the next tick |
+
+None of the four spends an F-5 attempt, and none is ever `[FAILED]`: a
+withheld approval is a working review, not a broken train.
 
 The `[SKIPPED]` / `[FAILED]` split is the load-bearing part of this output. A
 cron log full of `[SKIPPED] checks still running` is a healthy train waiting on
@@ -62,6 +95,6 @@ unattended loop nobody reads.
 - Queue empty after filtering → header plus `queue: 0 PR(s)` and
   `nothing to do`. Not an error; the dispatcher normally prevents this from
   even starting a session.
-- Ruleset unreadable → the header's `approval gate:` reads
-  `on (fail-closed: ruleset unreadable)`, so the reason every unapproved PR was
-  skipped is visible once, at the top, rather than repeated per line.
+- Policy undetermined → the header's `approval gate:` reads
+  `on (fail-closed: <base> policy unreadable)`, so the reason every unapproved
+  PR was skipped is visible once, at the top, rather than repeated per line.

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -15,7 +15,10 @@ For each PR `N` in the Step 2 queue order:
    once per run — rulesets are branch-scoped). Gate on and `reviewDecision !=
    APPROVED` → `[SKIPPED] approval required`, next PR. Gate **off** but
    `reviewDecision` non-empty and not `APPROVED` → also `[SKIPPED]`, naming the
-   value — see the next section for why that check cannot be skipped.
+   value — see "Gates `gh:pr-merge` owns" for why that check cannot be skipped.
+2b. **Delegated review** (gate **off** and `reviewDecision == ""` only) — run
+   the sequence in "Delegated review on the gate-off path" below. It either
+   clears the PR for Step 3 or records a `[SKIPPED]` and moves on.
 3. **Route** through the D-1 table.
 4. **Remediate** with the atom skill the row names, if any. For the `BEHIND`
    and `DIRTY` rows that means the scratch-worktree sequence below, not a bare
@@ -24,6 +27,64 @@ For each PR `N` in the Step 2 queue order:
    is mergeable now.
 6. **Merge** — `Skill(gh:pr-merge, "<N>")`. No strategy argument (D-4).
 7. **Record** the outcome and continue.
+
+## Delegated review on the gate-off path (step 2b, F-6 … F-9)
+
+The gate being off means the platform asks for no approval — not that nothing
+should be reviewed (`approval-gate.md` → "Why the gate being off still runs a
+review"). Before merging such a PR the train runs one review and reads the
+board back as its verdict.
+
+Reached only when **the gate is off and `reviewDecision` is `""`**. Every other
+combination was already decided in step 2: an `APPROVED` PR proceeds untouched,
+and a non-empty non-`APPROVED` one is `[SKIPPED]` before it gets here, so a
+review a human explicitly blocked is never handed to a self-record run.
+
+```bash
+HEAD_OID=$(GH_HOST="$TARGET_HOST" gh pr view "$N" --repo "$TARGET_REPO" \
+    --json headRefOid -q .headRefOid)
+LAST_OID=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/pulls/$N/reviews" \
+    --jq "[.[] | select(.user.login == \"$ME\")] | last | .commit_id // empty")
+```
+
+1. **Suppress a repeat review (F-8).** `LAST_OID` non-empty and equal to
+   `HEAD_OID` means this exact head was already reviewed by `$ME` — skip to
+   step 3 without calling anything. Otherwise run
+   `Skill(gh:pr-approve, "<N> <remote> --self-record")` once. Never twice, and
+   never a retry (F-7).
+2. **Read the verdict (D-4)** — `_gh_project_status_query_current pr <N>
+   "$TARGET_REPO"` from `shell-common/functions/gh_project_status.sh`.
+3. **Decide:**
+
+| Board Status | Reviewed this tick? | Outcome |
+|---|---|---|
+| `Approved` | either | proceed to step 3 — merge |
+| anything else | yes, just ran | `[SKIPPED] self-record withheld approval (BLOCKER)` |
+| anything else | no, suppressed by F-8 | `[SKIPPED] approval withheld (unchanged since review)` |
+| unreadable | either | `[SKIPPED] board unreadable — approval unconfirmed` |
+| — | the skill call itself errored | `[SKIPPED] self-record failed` (F-9) |
+
+Reading the board **after** the suppression check is what keeps a stalled-but-
+approved PR moving: a PR whose review passed on an earlier tick but whose merge
+then failed on CI comes back with `Approved` still on the card, so row 1 clears
+it without paying for a second review. F-8's suppression only ever produces a
+`[SKIPPED]` for a PR the review actually declined.
+
+Nothing here spends an F-5 attempt — no remediation was performed. Every row
+above is `[SKIPPED]`, never `[FAILED]`: each becomes actionable the moment
+someone pushes a fix (which changes `HEAD_OID` and re-arms the review) or
+promotes the card by hand.
+
+**Why inside the loop and not once over the queue.** Only PRs past the D-6
+quiet period reach it, so `devx:pr-review-all`'s `--defer-reply 4`
+`gh:pr-reply` has landed and CI has settled — the review sees the PR's final
+state. Reviewing the whole queue up front would review code that the train's
+own subsequent merges then move out from under.
+
+**Serial by construction (NF-2).** The train already processes one PR at a
+time, so these reviews serialise for free — which is why `allowed-tools` still
+needs no `Agent`. `gh:pr-approve` carries its own, and `Skill()` nesting
+reaches it.
 
 ## Detached scratch worktree (step 4, `BEHIND` / `DIRTY` only)
 
@@ -155,6 +216,15 @@ Step 2-B board check was removed in #1513, so a card sitting outside `Approved`
 — which is the normal state for a PR `gh:issue-flow` just opened — is no longer
 a reason to skip. Do not query the board here.
 
+That retirement is about the board as a **policy gate**, standing in for a
+platform approval the repo never granted; used that way it blocked every
+self-authored PR forever. Step 2b's read is a different thing wearing the same
+column: `gh:pr-approve` is the only skill that writes `Approved` (#1350) and
+only promotes when it found no BLOCKER, so the train is reading the return
+value of a review it just ran — not asking the board for permission. Keep the
+two apart: nothing may consult the board *before* a review has been run for
+this head.
+
 ## Attempt accounting (F-5)
 
 Keep one counter per PR, starting at 0. Increment it on **each remediation
@@ -195,6 +265,7 @@ skill was called and nothing was changed.
 | `gh:pr-resolve-conflict` stops at a documented stop point (ambiguous conflict, user-side abort) | `[FAILED]` naming `$SCRATCH_DIR` for manual resume; **scratch worktree is NOT removed** ("Teardown — the one exception" above); no further attempts this run; next PR |
 | `gh:pr-merge` | that PR is `[FAILED]`; next PR |
 | approval gate | that PR is `[SKIPPED]`; next PR |
+| the step-2b delegated review (withheld, suppressed, board unreadable, or the `gh:pr-approve` call itself) | that PR is `[SKIPPED]` with the matching reason; **no attempt is spent**; next PR |
 | a `gh:pr-merge` gate detected up front (`reviewDecision`) | that PR is `[SKIPPED]` with the cause named; **no attempt is spent** |
 | `gh pr view` on one PR | that PR is `[SKIPPED] state unreadable`; next PR |
 | `gh pr list` in Step 2 | **the run ends** — with no queue there is nothing to skip *to*, and merging without knowing state is the one thing this skill must never do |

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -46,8 +46,11 @@ ME=$(GH_HOST="$TARGET_HOST" gh api user -q .login)
 
 HEAD_OID=$(GH_HOST="$TARGET_HOST" gh pr view "$N" --repo "$TARGET_REPO" \
     --json headRefOid -q .headRefOid)
-LAST_OID=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/pulls/$N/reviews" \
-    --jq "[.[] | select(.user.login == \"$ME\")] | last | .commit_id // empty")
+# --paginate: reviews come 30 per page, and a long-lived PR can push the
+# most recent $ME review off page 1. --jq runs per page, so take the last
+# match across the whole stream rather than `last` within one page.
+LAST_OID=$(GH_HOST="$TARGET_HOST" gh api --paginate "repos/$TARGET_REPO/pulls/$N/reviews" \
+    --jq ".[] | select(.user.login == \"$ME\") | .commit_id" | tail -n 1)
 ```
 
 `$ME` is the authenticated login, not the PR author — the suppression asks

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -16,9 +16,9 @@ For each PR `N` in the Step 2 queue order:
    APPROVED` → `[SKIPPED] approval required`, next PR. Gate **off** but
    `reviewDecision` non-empty and not `APPROVED` → also `[SKIPPED]`, naming the
    value — see "Gates `gh:pr-merge` owns" for why that check cannot be skipped.
-2b. **Delegated review** (gate **off** and `reviewDecision == ""` only) — run
-   the sequence in "Delegated review on the gate-off path" below. It either
-   clears the PR for Step 3 or records a `[SKIPPED]` and moves on.
+   **Step 2b — delegated review** (gate **off** and `reviewDecision == ""`
+   only): run the sequence in "Delegated review on the gate-off path" below.
+   It either clears the PR for step 3 or records a `[SKIPPED]` and moves on.
 3. **Route** through the D-1 table.
 4. **Remediate** with the atom skill the row names, if any. For the `BEHIND`
    and `DIRTY` rows that means the scratch-worktree sequence below, not a bare
@@ -28,7 +28,7 @@ For each PR `N` in the Step 2 queue order:
 6. **Merge** — `Skill(gh:pr-merge, "<N>")`. No strategy argument (D-4).
 7. **Record** the outcome and continue.
 
-## Delegated review on the gate-off path (step 2b, F-6 … F-9)
+## Delegated review on the gate-off path (step 2b, #1519 F-6 … F-9)
 
 The gate being off means the platform asks for no approval — not that nothing
 should be reviewed (`approval-gate.md` → "Why the gate being off still runs a
@@ -41,18 +41,25 @@ and a non-empty non-`APPROVED` one is `[SKIPPED]` before it gets here, so a
 review a human explicitly blocked is never handed to a self-record run.
 
 ```bash
+# Hoisted out of the loop — bind once per run, next to TARGET_REPO / TARGET_HOST.
+ME=$(GH_HOST="$TARGET_HOST" gh api user -q .login)
+
 HEAD_OID=$(GH_HOST="$TARGET_HOST" gh pr view "$N" --repo "$TARGET_REPO" \
     --json headRefOid -q .headRefOid)
 LAST_OID=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/pulls/$N/reviews" \
     --jq "[.[] | select(.user.login == \"$ME\")] | last | .commit_id // empty")
 ```
 
-1. **Suppress a repeat review (F-8).** `LAST_OID` non-empty and equal to
+`$ME` is the authenticated login, not the PR author — the suppression asks
+"did *this* account already review *this* head", so an empty `$ME` would make
+`LAST_OID` always empty and re-run a full review every tick.
+
+1. **Suppress a repeat review (#1519 F-8).** `LAST_OID` non-empty and equal to
    `HEAD_OID` means this exact head was already reviewed by `$ME` — skip to
    step 3 without calling anything. Otherwise run
    `Skill(gh:pr-approve, "<N> <remote> --self-record")` once. Never twice, and
-   never a retry (F-7).
-2. **Read the verdict (D-4)** — `_gh_project_status_query_current pr <N>
+   never a retry (#1519 F-7).
+2. **Read the verdict (#1519 D-4)** — `_gh_project_status_query_current pr <N>
    "$TARGET_REPO"` from `shell-common/functions/gh_project_status.sh`.
 3. **Decide:**
 
@@ -60,14 +67,14 @@ LAST_OID=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/pulls/$N/reviews" \
 |---|---|---|
 | `Approved` | either | proceed to step 3 — merge |
 | anything else | yes, just ran | `[SKIPPED] self-record withheld approval (BLOCKER)` |
-| anything else | no, suppressed by F-8 | `[SKIPPED] approval withheld (unchanged since review)` |
+| anything else | no, suppressed by #1519 F-8 | `[SKIPPED] approval withheld (unchanged since review)` |
 | unreadable | either | `[SKIPPED] board unreadable — approval unconfirmed` |
-| — | the skill call itself errored | `[SKIPPED] self-record failed` (F-9) |
+| — | the skill call itself errored | `[SKIPPED] self-record failed` (#1519 F-9) |
 
 Reading the board **after** the suppression check is what keeps a stalled-but-
 approved PR moving: a PR whose review passed on an earlier tick but whose merge
 then failed on CI comes back with `Approved` still on the card, so row 1 clears
-it without paying for a second review. F-8's suppression only ever produces a
+it without paying for a second review. #1519 F-8's suppression only ever produces a
 `[SKIPPED]` for a PR the review actually declined.
 
 Nothing here spends an F-5 attempt — no remediation was performed. Every row
@@ -81,7 +88,7 @@ quiet period reach it, so `devx:pr-review-all`'s `--defer-reply 4`
 state. Reviewing the whole queue up front would review code that the train's
 own subsequent merges then move out from under.
 
-**Serial by construction (NF-2).** The train already processes one PR at a
+**Serial by construction (D-8).** The train already processes one PR at a
 time, so these reviews serialise for free — which is why `allowed-tools` still
 needs no `Agent`. `gh:pr-approve` carries its own, and `Skill()` nesting
 reaches it.

--- a/docs/public/changelog.d/2026-08-27-1519.md
+++ b/docs/public/changelog.d/2026-08-27-1519.md
@@ -1,0 +1,4 @@
+- 변경: **`gh:pr-merge-train` 승인 게이트가 403/404(정책 없음)와 5xx/네트워크(판정 불가)를 구분한다 — free 플랜 private 저장소에서 무인 머지가 영구 차단되던 문제 해결**
+- 변경: **승인 게이트 판정 소스를 ruleset + classic branch protection 양쪽으로 확대(둘 중 하나라도 승인을 요구하면 게이트 on)**
+- 변경: **게이트가 off 인 PR 은 머지 전에 `gh:pr-approve --self-record` 위임 리뷰를 1회 실행하고 보드 판정을 읽는다 — BLOCKER 면 그 PR 만 `[SKIPPED]`**
+- 변경: **트레인 리포트의 `approval gate:` 헤더가 `off (no policy on <base>)` / `on (<source>: <n> approvals)` / `on (fail-closed: <base> policy unreadable)` 3종을 구분한다**

--- a/docs/public/changelog.d/2026-08-27-1519.md
+++ b/docs/public/changelog.d/2026-08-27-1519.md
@@ -2,3 +2,5 @@
 - 변경: **승인 게이트 판정 소스를 ruleset + classic branch protection 양쪽으로 확대(둘 중 하나라도 승인을 요구하면 게이트 on)**
 - 변경: **게이트가 off 인 PR 은 머지 전에 `gh:pr-approve --self-record` 위임 리뷰를 1회 실행하고 보드 판정을 읽는다 — BLOCKER 면 그 PR 만 `[SKIPPED]`**
 - 변경: **트레인 리포트의 `approval gate:` 헤더가 `off (no policy on <base>)` / `on (<source>: <n> approvals)` / `on (fail-closed: <base> policy unreadable)` 3종을 구분한다**
+- 변경: **승인 게이트가 403 을 본문으로 구분한다 — 플랜 제약 메시지만 "정책 없음"이고 권한/레이트리밋/SSO 거부는 fail-closed 로 남는다 (PR #1526 리뷰)**
+- 변경: **2xx 응답의 본문이 비었거나 파싱되지 않으면 "정책 없음"이 아니라 fail-closed 로 판정한다**

--- a/tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
@@ -50,7 +50,7 @@ train_gate_http() {
 
 # ---------------------------------------------------------------------
 # Mirrors approval-gate.md -> "Classify each source by HTTP status".
-# Echoes "<verdict> <count>": required <n> | none 0 | unknown 0.
+# Echoes `none`, `unknown`, or the required approval count (>= 1).
 # ---------------------------------------------------------------------
 _gate_probe() {
     local _path="$1" _jq="$2" _out _status _n
@@ -59,18 +59,18 @@ _gate_probe() {
     case "$_status" in
         2??) ;;
         403 | 404)
-            printf 'none 0\n'
+            echo none
             return 0
             ;;
         *)
-            printf 'unknown 0\n'
+            echo unknown
             return 0
             ;;
     esac
-    _n=$(printf '%s\n' "$_out" | sed -n '/^\r\{0,1\}$/,$p' | sed '1d' | jq -r "$_jq" 2>/dev/null)
+    _n=$(printf '%s\n' "$_out" | sed '1,/^\r\{0,1\}$/d' | jq -r "$_jq" 2>/dev/null)
     case "$_n" in
-        '' | null | 0) printf 'none 0\n' ;;
-        *) printf 'required %s\n' "$_n" ;;
+        '' | null | 0) echo none ;;
+        *) echo "$_n" ;;
     esac
 }
 
@@ -78,30 +78,24 @@ _RULES_JQ='[.[] | select(.type == "pull_request") | .parameters.required_approvi
 _PROTECTION_JQ='.required_pull_request_reviews.required_approving_review_count // empty'
 
 # ---------------------------------------------------------------------
-# Mirrors approval-gate.md -> "Combining the two sources" (F-3, F-4) and
-# report-format.md -> "The `approval gate:` field" (NF-1).
+# Mirrors approval-gate.md -> "Combining the two sources" (#1519 F-3, F-4)
+# and report-format.md -> "The `approval gate:` field" (#1519 NF-1).
 # Echoes "<on|off>|<header text>".
 # ---------------------------------------------------------------------
 _gate_combine() {
     local _base="$1" _ruleset="$2" _classic="$3"
-    local _max=-1 _unknown=0 _src='' _pair _name _verdict _count
-    for _pair in "ruleset $_ruleset" "protection $_classic"; do
-        # shellcheck disable=SC2086
-        set -- $_pair
-        _name="$1" _verdict="$2" _count="$3"
-        case "$_verdict" in
-            required)
-                if [ "$_count" -gt "$_max" ]; then
-                    _max="$_count"
-                    _src="$_name"
-                fi
-                ;;
-            unknown) _unknown=1 ;;
-        esac
-    done
+    local _max=0 _src=''
+    case "$_ruleset" in
+        none | unknown) ;;
+        *) _max="$_ruleset" _src=ruleset ;;
+    esac
+    case "$_classic" in
+        none | unknown) ;;
+        *) [ "$_classic" -gt "$_max" ] && { _max="$_classic" _src=protection; } ;;
+    esac
     if [ "$_max" -ge 1 ]; then
         printf 'on|%s: %s approvals\n' "$_src" "$_max"
-    elif [ "$_unknown" -eq 1 ]; then
+    elif [ "$_ruleset" = unknown ] || [ "$_classic" = unknown ]; then
         printf 'on|fail-closed: %s policy unreadable\n' "$_base"
     else
         printf 'off|no policy on %s\n' "$_base"
@@ -122,26 +116,20 @@ train_gate_verdict() {
 # ---------------------------------------------------------------------
 train_pr_route() {
     local _gate="$1" _rd="$2"
-    if [ "$_gate" = "on" ]; then
-        [ "$_rd" = "APPROVED" ] && {
-            printf 'proceed\n'
-            return 0
-        }
-        printf 'skip:approval required (reviewDecision=%s)\n' "$_rd"
-        return 0
-    fi
     [ "$_rd" = "APPROVED" ] && {
         printf 'proceed\n'
         return 0
     }
-    [ -n "$_rd" ] && {
+    if [ "$_gate" = "on" ]; then
+        printf 'skip:approval required (reviewDecision=%s)\n' "$_rd"
+    elif [ -n "$_rd" ]; then
         printf 'skip:gh:pr-merge refuses reviewDecision=%s\n' "$_rd"
-        return 0
-    }
-    printf 'delegate\n'
+    else
+        printf 'delegate\n'
+    fi
 }
 
-# F-8: the same head was already reviewed by $ME. Returns 0 when the
+# #1519 F-8: the same head was already reviewed by $ME. Returns 0 when the
 # delegated review must NOT be re-run.
 train_review_suppressed() {
     local _last="$1" _head="$2"
@@ -151,7 +139,7 @@ train_review_suppressed() {
 # ---------------------------------------------------------------------
 # Mirrors train-loop.md -> "Delegated review on the gate-off path" step 3.
 # $1 board Status ("" = unreadable), $2 ran_this_tick (1|0),
-# $3 skill_rc (non-zero = the gh:pr-approve call itself failed, F-9).
+# $3 skill_rc (non-zero = the gh:pr-approve call itself failed, #1519 F-9).
 # ---------------------------------------------------------------------
 train_delegated_outcome() {
     local _board="$1" _ran="$2" _rc="${3-0}"

--- a/tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
+# Source-of-truth mirror for the approval-gate classification and the
+# gate-off delegated review documented in
+#   claude/skills/gh-pr-merge-train/references/approval-gate.md
+#   claude/skills/gh-pr-merge-train/references/train-loop.md
+#
+# Issue #1519: `gh api` collapses every failure into a non-zero exit, so
+# the train read a free-plan `403 Upgrade to GitHub Pro...` as "policy
+# unreadable" and fail-closed forever. A 403/404 is a definitive answer
+# about the policy; only 5xx / 401 / no-response are undetermined.
+#
+# Keep this file in sync with those two docs. If a snippet or a decision
+# row changes, mirror it here so the bats suite catches the drift.
+
+# ---------------------------------------------------------------------
+# Stub for `gh api -i`. The real call is
+#   GH_HOST="$TARGET_HOST" gh api -i "<path>"
+# Tests inject one raw HTTP response per source:
+#   FAKE_RULES_RESPONSE / FAKE_RULES_RC        (rules/branches/...)
+#   FAKE_PROTECTION_RESPONSE / FAKE_PROTECTION_RC  (branches/.../protection)
+# An empty response models "no HTTP response at all" (network failure).
+# ---------------------------------------------------------------------
+gh() {
+    local path=
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            api | -i) ;;
+            *) path="$1" ;;
+        esac
+        shift
+    done
+    case "$path" in
+        *rules/branches*)
+            printf '%s' "${FAKE_RULES_RESPONSE-}"
+            return "${FAKE_RULES_RC-0}"
+            ;;
+        *protection*)
+            printf '%s' "${FAKE_PROTECTION_RESPONSE-}"
+            return "${FAKE_PROTECTION_RC-0}"
+            ;;
+    esac
+    return 1
+}
+
+# Build a raw HTTP response the stub can serve. $1 status, $2 body.
+train_gate_http() {
+    printf 'HTTP/1.1 %s Whatever\r\nContent-Type: application/json\r\n\r\n%s' "$1" "$2"
+}
+
+# ---------------------------------------------------------------------
+# Mirrors approval-gate.md -> "Classify each source by HTTP status".
+# Echoes "<verdict> <count>": required <n> | none 0 | unknown 0.
+# ---------------------------------------------------------------------
+_gate_probe() {
+    local _path="$1" _jq="$2" _out _status _n
+    _out=$(gh api -i "$_path" 2>/dev/null)
+    _status=$(printf '%s\n' "$_out" | sed -n '1s|^HTTP/[0-9.]* *\([0-9][0-9][0-9]\).*|\1|p')
+    case "$_status" in
+        2??) ;;
+        403 | 404)
+            printf 'none 0\n'
+            return 0
+            ;;
+        *)
+            printf 'unknown 0\n'
+            return 0
+            ;;
+    esac
+    _n=$(printf '%s\n' "$_out" | sed -n '/^\r\{0,1\}$/,$p' | sed '1d' | jq -r "$_jq" 2>/dev/null)
+    case "$_n" in
+        '' | null | 0) printf 'none 0\n' ;;
+        *) printf 'required %s\n' "$_n" ;;
+    esac
+}
+
+_RULES_JQ='[.[] | select(.type == "pull_request") | .parameters.required_approving_review_count] | max // empty'
+_PROTECTION_JQ='.required_pull_request_reviews.required_approving_review_count // empty'
+
+# ---------------------------------------------------------------------
+# Mirrors approval-gate.md -> "Combining the two sources" (F-3, F-4) and
+# report-format.md -> "The `approval gate:` field" (NF-1).
+# Echoes "<on|off>|<header text>".
+# ---------------------------------------------------------------------
+_gate_combine() {
+    local _base="$1" _ruleset="$2" _classic="$3"
+    local _max=-1 _unknown=0 _src='' _pair _name _verdict _count
+    for _pair in "ruleset $_ruleset" "protection $_classic"; do
+        # shellcheck disable=SC2086
+        set -- $_pair
+        _name="$1" _verdict="$2" _count="$3"
+        case "$_verdict" in
+            required)
+                if [ "$_count" -gt "$_max" ]; then
+                    _max="$_count"
+                    _src="$_name"
+                fi
+                ;;
+            unknown) _unknown=1 ;;
+        esac
+    done
+    if [ "$_max" -ge 1 ]; then
+        printf 'on|%s: %s approvals\n' "$_src" "$_max"
+    elif [ "$_unknown" -eq 1 ]; then
+        printf 'on|fail-closed: %s policy unreadable\n' "$_base"
+    else
+        printf 'off|no policy on %s\n' "$_base"
+    fi
+}
+
+# One base branch end to end: probe both sources, combine, echo the verdict.
+train_gate_verdict() {
+    local _base="$1" _ruleset _classic
+    _ruleset=$(_gate_probe "repos/o/r/rules/branches/$_base" "$_RULES_JQ")
+    _classic=$(_gate_probe "repos/o/r/branches/$_base/protection" "$_PROTECTION_JQ")
+    _gate_combine "$_base" "$_ruleset" "$_classic"
+}
+
+# ---------------------------------------------------------------------
+# Mirrors approval-gate.md -> "Applying it per PR".
+# $1 gate (on|off), $2 reviewDecision. Echoes proceed | delegate | skip:<reason>.
+# ---------------------------------------------------------------------
+train_pr_route() {
+    local _gate="$1" _rd="$2"
+    if [ "$_gate" = "on" ]; then
+        [ "$_rd" = "APPROVED" ] && {
+            printf 'proceed\n'
+            return 0
+        }
+        printf 'skip:approval required (reviewDecision=%s)\n' "$_rd"
+        return 0
+    fi
+    [ "$_rd" = "APPROVED" ] && {
+        printf 'proceed\n'
+        return 0
+    }
+    [ -n "$_rd" ] && {
+        printf 'skip:gh:pr-merge refuses reviewDecision=%s\n' "$_rd"
+        return 0
+    }
+    printf 'delegate\n'
+}
+
+# F-8: the same head was already reviewed by $ME. Returns 0 when the
+# delegated review must NOT be re-run.
+train_review_suppressed() {
+    local _last="$1" _head="$2"
+    [ -n "$_last" ] && [ "$_last" = "$_head" ]
+}
+
+# ---------------------------------------------------------------------
+# Mirrors train-loop.md -> "Delegated review on the gate-off path" step 3.
+# $1 board Status ("" = unreadable), $2 ran_this_tick (1|0),
+# $3 skill_rc (non-zero = the gh:pr-approve call itself failed, F-9).
+# ---------------------------------------------------------------------
+train_delegated_outcome() {
+    local _board="$1" _ran="$2" _rc="${3-0}"
+    [ "$_rc" -ne 0 ] && {
+        printf 'skip:self-record failed\n'
+        return 0
+    }
+    [ "$_board" = "Approved" ] && {
+        printf 'proceed\n'
+        return 0
+    }
+    [ -z "$_board" ] && {
+        printf 'skip:board unreadable — approval unconfirmed\n'
+        return 0
+    }
+    if [ "$_ran" = "1" ]; then
+        printf 'skip:self-record withheld approval (BLOCKER)\n'
+    else
+        printf 'skip:approval withheld (unchanged since review)\n'
+    fi
+}

--- a/tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh
@@ -7,8 +7,12 @@
 #
 # Issue #1519: `gh api` collapses every failure into a non-zero exit, so
 # the train read a free-plan `403 Upgrade to GitHub Pro...` as "policy
-# unreadable" and fail-closed forever. A 403/404 is a definitive answer
-# about the policy; only 5xx / 401 / no-response are undetermined.
+# unreadable" and fail-closed forever.
+#
+# `none` is a WHITELIST, never a fallback: a 404, a 403 carrying GitHub's
+# plan-limit message, or a cleanly-parsed 2xx. Every other answer — a 403
+# from permission / rate-limit / SSO, a blank or unparseable 2xx body — is
+# `unknown` and keeps the gate on (PR #1526 agy+codex review).
 #
 # Keep this file in sync with those two docs. If a snippet or a decision
 # row changes, mirror it here so the bats suite catches the drift.
@@ -30,6 +34,9 @@ gh() {
         esac
         shift
     done
+    # Record every probed path so tests can assert the percent-encoding the
+    # doc's `@uri` step produces actually reaches the API (PR #1526 review).
+    [ -n "${FAKE_PATH_LOG-}" ] && printf '%s\n' "$path" >>"$FAKE_PATH_LOG"
     case "$path" in
         *rules/branches*)
             printf '%s' "${FAKE_RULES_RESPONSE-}"
@@ -53,13 +60,23 @@ train_gate_http() {
 # Echoes `none`, `unknown`, or the required approval count (>= 1).
 # ---------------------------------------------------------------------
 _gate_probe() {
-    local _path="$1" _jq="$2" _out _status _n
+    local _path="$1" _jq="$2" _out _status _body _n
     _out=$(gh api -i "$_path" 2>/dev/null)
     _status=$(printf '%s\n' "$_out" | sed -n '1s|^HTTP/[0-9.]* *\([0-9][0-9][0-9]\).*|\1|p')
+    _body=$(printf '%s\n' "$_out" | sed '1,/^\r\{0,1\}$/d')
     case "$_status" in
         2??) ;;
-        403 | 404)
+        404)
             echo none
+            return 0
+            ;;
+        403)
+            # Only the plan-limit message means "no policy can exist";
+            # permission / rate-limit / SSO denials fail closed.
+            case "$_body" in
+                *"Upgrade to GitHub Pro"*) echo none ;;
+                *) echo unknown ;;
+            esac
             return 0
             ;;
         *)
@@ -67,9 +84,17 @@ _gate_probe() {
             return 0
             ;;
     esac
-    _n=$(printf '%s\n' "$_out" | sed '1,/^\r\{0,1\}$/d' | jq -r "$_jq" 2>/dev/null)
+    [ -n "$(printf '%s' "$_body" | tr -d '[:space:]')" ] || {
+        echo unknown
+        return 0
+    }
+    _n=$(printf '%s\n' "$_body" | jq -r "$_jq" 2>/dev/null) || {
+        echo unknown
+        return 0
+    }
     case "$_n" in
         '' | null | 0) echo none ;;
+        *[!0-9]*) echo unknown ;;
         *) echo "$_n" ;;
     esac
 }
@@ -104,9 +129,13 @@ _gate_combine() {
 
 # One base branch end to end: probe both sources, combine, echo the verdict.
 train_gate_verdict() {
-    local _base="$1" _ruleset _classic
-    _ruleset=$(_gate_probe "repos/o/r/rules/branches/$_base" "$_RULES_JQ")
-    _classic=$(_gate_probe "repos/o/r/branches/$_base/protection" "$_PROTECTION_JQ")
+    local _base="$1" _base_enc _ruleset _classic
+    # Mirrors the doc's `BASE_ENC=$(jq -rn --arg b "$BASE" '"'"'$b|@uri'"'"')`
+    # step — both endpoints take the ref as ONE path segment, so a base like
+    # release/2026.08 must arrive as release%2F2026.08.
+    _base_enc=$(jq -rn --arg b "$_base" '$b|@uri')
+    _ruleset=$(_gate_probe "repos/o/r/rules/branches/$_base_enc" "$_RULES_JQ")
+    _classic=$(_gate_probe "repos/o/r/branches/$_base_enc/protection" "$_PROTECTION_JQ")
     _gate_combine "$_base" "$_ruleset" "$_classic"
 }
 

--- a/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
+++ b/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
@@ -8,7 +8,7 @@
 #
 # Issue #1519 acceptance criteria:
 #   AC-2  403 on both sources        -> gate off, "no policy on <base>"
-#   AC-3  ruleset >= 1 + 404 classic -> gate on   (D-2 regression guard)
+#   AC-3  ruleset >= 1 + 404 classic -> gate on   (#1519 D-2 regression guard)
 #   AC-4  5xx / network              -> gate on, fail-closed, named as such
 #   AC-5  board not Approved         -> [SKIPPED] self-record withheld (BLOCKER)
 #   AC-6  head unchanged since review-> no re-run, [SKIPPED] unchanged
@@ -42,60 +42,60 @@ plan_403() {
     FAKE_RULES_RESPONSE="$(plan_403)" FAKE_RULES_RC=1
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'none 0'
+    assert_output 'none'
 }
 
 @test "gate-probe: 404 not-configured is 'no policy'" {
     FAKE_RULES_RESPONSE="$(train_gate_http 404 '{"message":"Branch not protected"}')" FAKE_RULES_RC=1
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'none 0'
+    assert_output 'none'
 }
 
 @test "gate-probe: 500 is undetermined -> unknown (stays fail-closed)" {
     FAKE_RULES_RESPONSE="$(train_gate_http 500 '{"message":"Server Error"}')" FAKE_RULES_RC=1
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'unknown 0'
+    assert_output 'unknown'
 }
 
 @test "gate-probe: no HTTP response at all (network down) -> unknown" {
     FAKE_RULES_RESPONSE='' FAKE_RULES_RC=1
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'unknown 0'
+    assert_output 'unknown'
 }
 
-@test "gate-probe: 200 with required_approving_review_count=2 -> required 2" {
+@test "gate-probe: 200 with required_approving_review_count=2 -> required count 2" {
     FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":2}}]')"
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'required 2'
+    assert_output '2'
 }
 
 @test "gate-probe: 200 with count=0 is 'no policy' (D-5 unchanged)" {
     FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":0}}]')"
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'none 0'
+    assert_output 'none'
 }
 
 @test "gate-probe: 200 with no pull_request rule is 'no policy'" {
     FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"deletion"},{"type":"non_fast_forward"}]')"
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'none 0'
+    assert_output 'none'
 }
 
 @test "gate-probe: strictest ruleset wins when several apply" {
     FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":1}},{"type":"pull_request","parameters":{"required_approving_review_count":3}}]')"
     run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
     assert_success
-    assert_output 'required 3'
+    assert_output '3'
 }
 
 # ---------------------------------------------------------------------
-# Combining the two sources (F-3, F-4) + NF-1 header
+# Combining the two sources (#1519 F-3, F-4) + #1519 NF-1 header
 # ---------------------------------------------------------------------
 
 @test "AC-2: both sources 403 -> gate off with 'no policy on <base>'" {
@@ -106,7 +106,7 @@ plan_403() {
     assert_output 'off|no policy on main'
 }
 
-@test "AC-3: ruleset requires 1, classic 404 -> gate STAYS ON (D-2 guard)" {
+@test "AC-3: ruleset requires 1, classic 404 -> gate STAYS ON (#1519 D-2 guard)" {
     FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":1}}]')"
     FAKE_PROTECTION_RESPONSE="$(train_gate_http 404 '{"message":"Branch not protected"}')" FAKE_PROTECTION_RC=1
     run train_gate_verdict main
@@ -114,7 +114,7 @@ plan_403() {
     assert_output 'on|ruleset: 1 approvals'
 }
 
-@test "D-2: classic protection requires 2, ruleset 404 -> gate on via protection" {
+@test "#1519 D-2: classic protection requires 2, ruleset 404 -> gate on via protection" {
     FAKE_RULES_RESPONSE="$(train_gate_http 404 '{"message":"Not Found"}')" FAKE_RULES_RC=1
     FAKE_PROTECTION_RESPONSE="$(train_gate_http 200 '{"required_pull_request_reviews":{"required_approving_review_count":2}}')"
     run train_gate_verdict main
@@ -187,7 +187,7 @@ plan_403() {
 }
 
 # ---------------------------------------------------------------------
-# Delegated review (F-6 … F-9)
+# Delegated review (#1519 F-6 … F-9)
 # ---------------------------------------------------------------------
 
 @test "AC-6: same head already reviewed -> suppressed" {
@@ -195,12 +195,12 @@ plan_403() {
     assert_success
 }
 
-@test "F-8: head moved since the last review -> re-review is armed" {
+@test "#1519 F-8: head moved since the last review -> re-review is armed" {
     run train_review_suppressed deadbeef cafebabe
     assert_failure
 }
 
-@test "F-8: no prior review by ME -> not suppressed" {
+@test "#1519 F-8: no prior review by ME -> not suppressed" {
     run train_review_suppressed '' cafebabe
     assert_failure
 }
@@ -225,7 +225,7 @@ plan_403() {
 
 @test "already-Approved card from an earlier tick proceeds without re-running" {
     # A PR whose review passed but whose merge then failed on CI comes back
-    # with Approved still on the card. Reading the board AFTER the F-8
+    # with Approved still on the card. Reading the board AFTER the #1519 F-8
     # suppression check is what keeps it moving.
     run train_delegated_outcome Approved 0
     assert_success
@@ -238,7 +238,7 @@ plan_403() {
     assert_output 'skip:board unreadable — approval unconfirmed'
 }
 
-@test "F-9: gh:pr-approve itself failing skips only that PR" {
+@test "#1519 F-9: gh:pr-approve itself failing skips only that PR" {
     run train_delegated_outcome Approved 1 3
     assert_success
     assert_output 'skip:self-record failed'
@@ -249,37 +249,32 @@ plan_403() {
 # ---------------------------------------------------------------------
 
 @test "doc-guard: approval-gate.md classifies 403/404 as 'no policy'" {
-    run grep -q '403 | 404) printf .none 0' "${SKILL_DIR}/references/approval-gate.md"
+    run grep -qE '^\| `403` \|.*`none` \|$' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+    run grep -qE '^\| `404` \|.*`none` \|$' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+    run grep -qE '^\| anything else .*`unknown` \|$' "${SKILL_DIR}/references/approval-gate.md"
     assert_success
 }
 
-@test "doc-guard: approval-gate.md reads BOTH sources (D-2)" {
+@test "doc-guard: approval-gate.md reads BOTH sources (#1519 D-2)" {
     run grep -qE 'branches/\$BASE_ENC/protection' "${SKILL_DIR}/references/approval-gate.md"
     assert_success
     run grep -qE 'rules/branches/\$BASE_ENC' "${SKILL_DIR}/references/approval-gate.md"
     assert_success
 }
 
-@test "doc-guard: the old undifferentiated 'call failed' row is gone" {
-    run grep -q 'call failed' "${SKILL_DIR}/references/approval-gate.md"
-    assert_failure
-}
-
 @test "doc-guard: train-loop.md documents the delegated review" {
     run grep -q 'Delegated review on the gate-off path' "${SKILL_DIR}/references/train-loop.md"
-    assert_success
-    run grep -q 'self-record' "${SKILL_DIR}/references/train-loop.md"
     assert_success
 }
 
 @test "doc-guard: train-loop.md still says the board is not a policy gate (#1513)" {
-    run grep -q 'The projectV2 board Status is \*\*not\*\* one of these gates' "${SKILL_DIR}/references/train-loop.md"
-    assert_success
-    run grep -q 'policy gate' "${SKILL_DIR}/references/train-loop.md"
+    run grep -q 'nothing may consult the board \*before\* a review has been run' "${SKILL_DIR}/references/train-loop.md"
     assert_success
 }
 
-@test "doc-guard: report-format.md carries all three NF-1 header strings" {
+@test "doc-guard: report-format.md carries all three #1519 NF-1 header strings" {
     run grep -q 'off (no policy on <base>)' "${SKILL_DIR}/references/report-format.md"
     assert_success
     run grep -q 'on (<source>: <n> approvals)' "${SKILL_DIR}/references/report-format.md"
@@ -304,7 +299,7 @@ plan_403() {
     assert_success
 }
 
-@test "doc-guard: allowed-tools gained no Agent (NF-2 serial contract)" {
-    run grep -q 'allowed-tools: Bash, Read, Grep, Skill' "${SKILL_DIR}/SKILL.md"
-    assert_success
+@test "doc-guard: allowed-tools gained no Agent (D-8 serial contract)" {
+    run grep -qE '^allowed-tools:.*\bAgent\b' "${SKILL_DIR}/SKILL.md"
+    assert_failure
 }

--- a/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
+++ b/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
@@ -299,6 +299,26 @@ plan_403() {
     assert_success
 }
 
+@test "doc-guard: constraints.md documents the delegated-review exception" {
+    # The old blanket "Never review, never approve" contradicted step 2b.
+    run grep -q 'Never form a review judgement of its own' "${SKILL_DIR}/references/constraints.md"
+    assert_success
+    run grep -q 'self-record' "${SKILL_DIR}/references/constraints.md"
+    assert_success
+}
+
+@test "doc-guard: help.md no longer claims a single-source, one-call gate" {
+    run grep -q "repo ruleset's .required_approving_review_count. once per" "${SKILL_DIR}/references/help.md"
+    assert_failure
+    run grep -q 'classic branch protection' "${SKILL_DIR}/references/help.md"
+    assert_success
+}
+
+@test "doc-guard: help.md lists gh:pr-approve among the atoms" {
+    run grep -q 'gh:pr-approve' "${SKILL_DIR}/references/help.md"
+    assert_success
+}
+
 @test "doc-guard: allowed-tools gained no Agent (D-8 serial contract)" {
     run grep -qE '^allowed-tools:.*\bAgent\b' "${SKILL_DIR}/SKILL.md"
     assert_failure

--- a/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
+++ b/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
@@ -1,0 +1,310 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_merge_train_approval_gate.bats
+# Verify the approval-gate classification and the gate-off delegated review:
+#   claude/skills/gh-pr-merge-train/references/approval-gate.md
+#   claude/skills/gh-pr-merge-train/references/train-loop.md
+#   claude/skills/gh-pr-merge-train/references/report-format.md
+# Source-of-truth fixture: _fixtures/gh_pr_merge_train_approval_gate.sh
+#
+# Issue #1519 acceptance criteria:
+#   AC-2  403 on both sources        -> gate off, "no policy on <base>"
+#   AC-3  ruleset >= 1 + 404 classic -> gate on   (D-2 regression guard)
+#   AC-4  5xx / network              -> gate on, fail-closed, named as such
+#   AC-5  board not Approved         -> [SKIPPED] self-record withheld (BLOCKER)
+#   AC-6  head unchanged since review-> no re-run, [SKIPPED] unchanged
+#   AC-7  this suite
+
+load '../test_helper'
+
+FIXTURE='tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
+    SKILL_DIR="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset FAKE_RULES_RESPONSE FAKE_RULES_RC FAKE_PROTECTION_RESPONSE FAKE_PROTECTION_RC
+}
+
+plan_403() {
+    train_gate_http 403 '{"message":"Upgrade to GitHub Pro or make this repository public to enable this feature."}'
+}
+
+# ---------------------------------------------------------------------
+# Per-source classification
+# ---------------------------------------------------------------------
+
+@test "gate-probe: 403 plan limit is 'no policy', not a lookup failure (#1519)" {
+    FAKE_RULES_RESPONSE="$(plan_403)" FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'none 0'
+}
+
+@test "gate-probe: 404 not-configured is 'no policy'" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 404 '{"message":"Branch not protected"}')" FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'none 0'
+}
+
+@test "gate-probe: 500 is undetermined -> unknown (stays fail-closed)" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 500 '{"message":"Server Error"}')" FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown 0'
+}
+
+@test "gate-probe: no HTTP response at all (network down) -> unknown" {
+    FAKE_RULES_RESPONSE='' FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown 0'
+}
+
+@test "gate-probe: 200 with required_approving_review_count=2 -> required 2" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":2}}]')"
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'required 2'
+}
+
+@test "gate-probe: 200 with count=0 is 'no policy' (D-5 unchanged)" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":0}}]')"
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'none 0'
+}
+
+@test "gate-probe: 200 with no pull_request rule is 'no policy'" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"deletion"},{"type":"non_fast_forward"}]')"
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'none 0'
+}
+
+@test "gate-probe: strictest ruleset wins when several apply" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":1}},{"type":"pull_request","parameters":{"required_approving_review_count":3}}]')"
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'required 3'
+}
+
+# ---------------------------------------------------------------------
+# Combining the two sources (F-3, F-4) + NF-1 header
+# ---------------------------------------------------------------------
+
+@test "AC-2: both sources 403 -> gate off with 'no policy on <base>'" {
+    FAKE_RULES_RESPONSE="$(plan_403)" FAKE_RULES_RC=1
+    FAKE_PROTECTION_RESPONSE="$(plan_403)" FAKE_PROTECTION_RC=1
+    run train_gate_verdict main
+    assert_success
+    assert_output 'off|no policy on main'
+}
+
+@test "AC-3: ruleset requires 1, classic 404 -> gate STAYS ON (D-2 guard)" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":1}}]')"
+    FAKE_PROTECTION_RESPONSE="$(train_gate_http 404 '{"message":"Branch not protected"}')" FAKE_PROTECTION_RC=1
+    run train_gate_verdict main
+    assert_success
+    assert_output 'on|ruleset: 1 approvals'
+}
+
+@test "D-2: classic protection requires 2, ruleset 404 -> gate on via protection" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 404 '{"message":"Not Found"}')" FAKE_RULES_RC=1
+    FAKE_PROTECTION_RESPONSE="$(train_gate_http 200 '{"required_pull_request_reviews":{"required_approving_review_count":2}}')"
+    run train_gate_verdict main
+    assert_success
+    assert_output 'on|protection: 2 approvals'
+}
+
+@test "AC-4: a 5xx on one source -> gate on, header names fail-closed" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 502 '{"message":"Bad Gateway"}')" FAKE_RULES_RC=1
+    FAKE_PROTECTION_RESPONSE="$(plan_403)" FAKE_PROTECTION_RC=1
+    run train_gate_verdict main
+    assert_success
+    assert_output 'on|fail-closed: main policy unreadable'
+}
+
+@test "a concrete requirement outranks an unknown in the header text" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '[{"type":"pull_request","parameters":{"required_approving_review_count":1}}]')"
+    FAKE_PROTECTION_RESPONSE="$(train_gate_http 500 '{"message":"boom"}')" FAKE_PROTECTION_RC=1
+    run train_gate_verdict main
+    assert_success
+    assert_output 'on|ruleset: 1 approvals'
+}
+
+@test "base with a slash keeps its percent-encoding in the header" {
+    FAKE_RULES_RESPONSE="$(plan_403)" FAKE_RULES_RC=1
+    FAKE_PROTECTION_RESPONSE="$(plan_403)" FAKE_PROTECTION_RC=1
+    run train_gate_verdict 'release/2026.08'
+    assert_success
+    assert_output 'off|no policy on release/2026.08'
+}
+
+# ---------------------------------------------------------------------
+# Per-PR routing (approval-gate.md -> "Applying it per PR")
+# ---------------------------------------------------------------------
+
+@test "route: gate on + APPROVED -> proceed without a delegated review" {
+    run train_pr_route on APPROVED
+    assert_success
+    assert_output 'proceed'
+}
+
+@test "route: gate on + empty reviewDecision -> approval required" {
+    run train_pr_route on ''
+    assert_success
+    assert_output 'skip:approval required (reviewDecision=)'
+}
+
+@test "AC-1 precondition: gate off + empty reviewDecision -> delegate" {
+    run train_pr_route off ''
+    assert_success
+    assert_output 'delegate'
+}
+
+@test "route: gate off + APPROVED -> proceed, no wasted re-review" {
+    run train_pr_route off APPROVED
+    assert_success
+    assert_output 'proceed'
+}
+
+@test "route: gate off + CHANGES_REQUESTED -> skipped before any review runs" {
+    run train_pr_route off CHANGES_REQUESTED
+    assert_success
+    assert_output 'skip:gh:pr-merge refuses reviewDecision=CHANGES_REQUESTED'
+}
+
+@test "route: gate off + REVIEW_REQUIRED -> skipped, never delegated" {
+    run train_pr_route off REVIEW_REQUIRED
+    assert_success
+    assert_output 'skip:gh:pr-merge refuses reviewDecision=REVIEW_REQUIRED'
+}
+
+# ---------------------------------------------------------------------
+# Delegated review (F-6 … F-9)
+# ---------------------------------------------------------------------
+
+@test "AC-6: same head already reviewed -> suppressed" {
+    run train_review_suppressed deadbeef deadbeef
+    assert_success
+}
+
+@test "F-8: head moved since the last review -> re-review is armed" {
+    run train_review_suppressed deadbeef cafebabe
+    assert_failure
+}
+
+@test "F-8: no prior review by ME -> not suppressed" {
+    run train_review_suppressed '' cafebabe
+    assert_failure
+}
+
+@test "AC-1: review promoted the card -> proceed to merge" {
+    run train_delegated_outcome Approved 1
+    assert_success
+    assert_output 'proceed'
+}
+
+@test "AC-5: review withheld -> SKIPPED with the BLOCKER reason, not merged" {
+    run train_delegated_outcome 'In review' 1
+    assert_success
+    assert_output 'skip:self-record withheld approval (BLOCKER)'
+}
+
+@test "AC-6: suppressed re-review reports 'unchanged since review'" {
+    run train_delegated_outcome 'In review' 0
+    assert_success
+    assert_output 'skip:approval withheld (unchanged since review)'
+}
+
+@test "already-Approved card from an earlier tick proceeds without re-running" {
+    # A PR whose review passed but whose merge then failed on CI comes back
+    # with Approved still on the card. Reading the board AFTER the F-8
+    # suppression check is what keeps it moving.
+    run train_delegated_outcome Approved 0
+    assert_success
+    assert_output 'proceed'
+}
+
+@test "board unreadable -> fail-closed skip, approval unconfirmed" {
+    run train_delegated_outcome '' 1
+    assert_success
+    assert_output 'skip:board unreadable — approval unconfirmed'
+}
+
+@test "F-9: gh:pr-approve itself failing skips only that PR" {
+    run train_delegated_outcome Approved 1 3
+    assert_success
+    assert_output 'skip:self-record failed'
+}
+
+# ---------------------------------------------------------------------
+# Doc guards — the fixture above is only trustworthy while the docs agree
+# ---------------------------------------------------------------------
+
+@test "doc-guard: approval-gate.md classifies 403/404 as 'no policy'" {
+    run grep -q '403 | 404) printf .none 0' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+}
+
+@test "doc-guard: approval-gate.md reads BOTH sources (D-2)" {
+    run grep -qE 'branches/\$BASE_ENC/protection' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+    run grep -qE 'rules/branches/\$BASE_ENC' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+}
+
+@test "doc-guard: the old undifferentiated 'call failed' row is gone" {
+    run grep -q 'call failed' "${SKILL_DIR}/references/approval-gate.md"
+    assert_failure
+}
+
+@test "doc-guard: train-loop.md documents the delegated review" {
+    run grep -q 'Delegated review on the gate-off path' "${SKILL_DIR}/references/train-loop.md"
+    assert_success
+    run grep -q 'self-record' "${SKILL_DIR}/references/train-loop.md"
+    assert_success
+}
+
+@test "doc-guard: train-loop.md still says the board is not a policy gate (#1513)" {
+    run grep -q 'The projectV2 board Status is \*\*not\*\* one of these gates' "${SKILL_DIR}/references/train-loop.md"
+    assert_success
+    run grep -q 'policy gate' "${SKILL_DIR}/references/train-loop.md"
+    assert_success
+}
+
+@test "doc-guard: report-format.md carries all three NF-1 header strings" {
+    run grep -q 'off (no policy on <base>)' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+    run grep -q 'on (<source>: <n> approvals)' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+    run grep -q 'on (fail-closed: <base> policy unreadable)' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+}
+
+@test "doc-guard: report-format.md lists the four delegated-review reasons" {
+    run grep -q 'self-record withheld approval (BLOCKER)' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+    run grep -q 'approval withheld (unchanged since review)' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+    run grep -q 'board unreadable — approval unconfirmed' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+    run grep -q 'self-record failed' "${SKILL_DIR}/references/report-format.md"
+    assert_success
+}
+
+@test "doc-guard: NF-2 still forbids gh:pr-merge-emergency in the train" {
+    run grep -q 'Never call `gh:pr-merge-emergency`' "${SKILL_DIR}/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: allowed-tools gained no Agent (NF-2 serial contract)" {
+    run grep -q 'allowed-tools: Bash, Read, Grep, Skill' "${SKILL_DIR}/SKILL.md"
+    assert_success
+}

--- a/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
+++ b/tests/bats/skills/gh_pr_merge_train_approval_gate.bats
@@ -20,6 +20,8 @@ FIXTURE='tests/bats/skills/_fixtures/gh_pr_merge_train_approval_gate.sh'
 
 setup() {
     setup_isolated_home
+    FAKE_PATH_LOG="$(mktemp)"
+    export FAKE_PATH_LOG
     # shellcheck disable=SC1090
     source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
     SKILL_DIR="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train"
@@ -28,6 +30,8 @@ setup() {
 teardown() {
     teardown_isolated_home
     unset FAKE_RULES_RESPONSE FAKE_RULES_RC FAKE_PROTECTION_RESPONSE FAKE_PROTECTION_RC
+    [ -n "${FAKE_PATH_LOG-}" ] && rm -f "$FAKE_PATH_LOG"
+    unset FAKE_PATH_LOG
 }
 
 plan_403() {
@@ -138,12 +142,70 @@ plan_403() {
     assert_output 'on|ruleset: 1 approvals'
 }
 
-@test "base with a slash keeps its percent-encoding in the header" {
+@test "a base with a slash is percent-encoded into BOTH endpoint paths" {
+    # Regression guard for PR #1526 review: the header text alone proved
+    # nothing about the request. Assert the encoded ref actually reaches the
+    # API as one path segment, on the ruleset AND the protection endpoint.
     FAKE_RULES_RESPONSE="$(plan_403)" FAKE_RULES_RC=1
     FAKE_PROTECTION_RESPONSE="$(plan_403)" FAKE_PROTECTION_RC=1
     run train_gate_verdict 'release/2026.08'
     assert_success
     assert_output 'off|no policy on release/2026.08'
+
+    run cat "$FAKE_PATH_LOG"
+    assert_output --partial 'repos/o/r/rules/branches/release%2F2026.08'
+    assert_output --partial 'repos/o/r/branches/release%2F2026.08/protection'
+    refute_output --partial 'branches/release/2026.08'
+}
+
+@test "403 permission denial is UNKNOWN, not 'no policy' (fail-closed)" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 403 '{"message":"Resource not accessible by personal access token"}')" FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown'
+}
+
+@test "403 rate-limit is UNKNOWN, not 'no policy'" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 403 '{"message":"API rate limit exceeded for user ID 1."}')" FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown'
+}
+
+@test "403 SAML/SSO denial is UNKNOWN, not 'no policy'" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 403 '{"message":"Resource protected by organization SAML enforcement."}')" FAKE_RULES_RC=1
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown'
+}
+
+@test "a permission 403 on ONE source keeps the whole gate on" {
+    FAKE_RULES_RESPONSE="$(plan_403)" FAKE_RULES_RC=1
+    FAKE_PROTECTION_RESPONSE="$(train_gate_http 403 '{"message":"Must have admin rights to Repository."}')" FAKE_PROTECTION_RC=1
+    run train_gate_verdict main
+    assert_success
+    assert_output 'on|fail-closed: main policy unreadable'
+}
+
+@test "2xx with an unparseable body is UNKNOWN, not 'no policy'" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '<html>502 upstream</html>')" FAKE_RULES_RC=0
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown'
+}
+
+@test "2xx with an empty body is UNKNOWN, not 'no policy'" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '')" FAKE_RULES_RC=0
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown'
+}
+
+@test "2xx whose shape shifted (object where an array was expected) is UNKNOWN" {
+    FAKE_RULES_RESPONSE="$(train_gate_http 200 '{"message":"Moved Permanently"}')" FAKE_RULES_RC=0
+    run _gate_probe "repos/o/r/rules/branches/main" "$_RULES_JQ"
+    assert_success
+    assert_output 'unknown'
 }
 
 # ---------------------------------------------------------------------
@@ -248,12 +310,21 @@ plan_403() {
 # Doc guards — the fixture above is only trustworthy while the docs agree
 # ---------------------------------------------------------------------
 
-@test "doc-guard: approval-gate.md classifies 403/404 as 'no policy'" {
-    run grep -qE '^\| `403` \|.*`none` \|$' "${SKILL_DIR}/references/approval-gate.md"
+@test "doc-guard: approval-gate.md splits 403 by body, keeps 404 as 'no policy'" {
+    run grep -qE '^\| `403` \+ `Upgrade to GitHub Pro`.*`none` \|$' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+    run grep -qE '^\| `403`, any other body \|.*`unknown` \|$' "${SKILL_DIR}/references/approval-gate.md"
     assert_success
     run grep -qE '^\| `404` \|.*`none` \|$' "${SKILL_DIR}/references/approval-gate.md"
     assert_success
     run grep -qE '^\| anything else .*`unknown` \|$' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+    run grep -q '`none` is a whitelist, never a fallback' "${SKILL_DIR}/references/approval-gate.md"
+    assert_success
+}
+
+@test "doc-guard: train-loop.md paginates the reviews read (#1526 review)" {
+    run grep -q 'gh api --paginate "repos/\$TARGET_REPO/pulls/\$N/reviews"' "${SKILL_DIR}/references/train-loop.md"
     assert_success
 }
 


### PR DESCRIPTION
## Summary
- 무인 머지가 0건이던 원인 두 가지를 함께 고친다 — 승인 게이트의 403 오독과, 게이트가 풀린 뒤 리뷰 신호가 사라지는 공백.
- 승인 게이트 판정을 `gh api` 종료코드가 아니라 **HTTP 상태코드**로 옮긴다. free 플랜 private 저장소의 `403 Upgrade to GitHub Pro...` 는 "정책을 못 읽었다"가 아니라 "정책이 존재할 수 없다"는 확정적 답변이므로, fail-closed 대상이 아니다.
- 게이트가 off 인 PR 은 머지 전에 `gh:pr-approve --self-record` 위임 리뷰를 1회 실행하고, 그 결과를 보드에서 읽는다(#1514 흡수).

## Changes
- `references/approval-gate.md`: `gh api -i` 로 상태코드를 보존하는 `_gate_probe` 도입. `403`/`404` → "정책 없음", `5xx`/`401`/무응답 → "판정 불가"(fail-closed 유지). 판정 소스를 ruleset + classic branch protection 양쪽으로 확대하고 엄격한 쪽을 택한다(D-2). `gh:pr-merge` 의 `strategy-selection.md` 가 같은 403 을 이미 옳게 읽고 있었다는 점 — 즉 판단은 이미 저장소 안에 있었고 트레인만 어긋나 있었다는 점 — 을 근거로 명시.
- `references/train-loop.md`: per-PR 루프에 step 2b "Delegated review on the gate-off path" 추가(F-6~F-9). `headRefOid` 와 마지막 `$ME` 리뷰의 `commit_id` 를 비교해 같은 head 재리뷰를 억제하고(F-8), 보드 조회를 그 억제 검사 **뒤**에 두어 이미 승격된 카드가 재리뷰 없이 통과되게 한다. `:153` 의 "보드는 게이트가 아니다"(#1513) 서술 옆에 D-4 의 용도 구분(정책 게이트 아님 / 방금 실행한 리뷰의 판정 채널)을 나란히 고정.
- `references/report-format.md`: `approval gate:` 헤더 3종 구분(NF-1) + 위임 리뷰의 `[SKIPPED]` 사유 4종과 각각의 해소 방법 표.
- `SKILL.md`: Step 3 을 두 소스 조회 + 상태코드 분류로, Step 4 를 위임 리뷰 반영으로 갱신. `gh:pr-approve` 를 호출 아톰 목록에 추가.
- `tests/bats/skills/gh_pr_merge_train_approval_gate.bats` (+ `_fixtures/`): 38 케이스 회귀 스위트(AC-7). 상태코드별 분류, 두 소스 결합, per-PR 라우팅, 위임 리뷰 판정, 그리고 문서 드리프트 가드.

## Test plan
- [x] `bats tests/bats/skills/gh_pr_merge_train_approval_gate.bats` — 38/38 통과
- [x] 전체 스위트 회귀 없음: pytest 1541 passed (baseline 동일), bats 2779 tests (baseline 2741 + 신규 38), not-ok 24건은 baseline 과 **완전히 동일한 집합**(워크트리 환경 기인 pre-existing)
- [x] golden rules 통과, `scripts/lint_changelog_fragments.sh` errors=0, `shellcheck` clean
- [ ] AC-1/AC-2 실환경 확인: free 플랜 private 저장소(`dev-team-404/AgentToolbox` PR #2870)에서 헤더가 `off (no policy on main)` 로 나오고 self-record 통과 시 실제 머지되는지 — 이 저장소에서는 재현 불가
- [ ] AC-3 회귀 확인: ruleset 만으로 승인을 강제하는 저장소에서 classic 404 여도 게이트가 on 으로 남는지(bats 로는 고정했으나 실환경 미확인)

## Related
Closes #1519

---
<details>
<summary>🤖 AI Metrics · 📊 ~15500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~15500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
