### PR TITLE
fix(issue-watcher-cron): agent_pane_busy 를 같은 pane 에서 재시도한다

### DIFF
--- a/docs/public/changelog.d/2026-08-27-1525.md
+++ b/docs/public/changelog.d/2026-08-27-1525.md
@@ -1,1 +1,1 @@
-- 변경: **issue-watcher tick 이 `agent_pane_busy` 로 거절된 `herdr agent start` 를 같은 pane 에서 최대 3회(`IW_START_RETRY_SLEEP` 간격, 기본 2초) 재시도하고, herdr 가 stderr 로 준 실패 원인을 로그에 남긴다 — 130 tick 동안 디스패치 0건이던 원인 (#1525)**
+- 변경: **issue-watcher tick 이 `agent_pane_busy` 로 거절된 `herdr agent start` 를 같은 pane 에서 최대 3회 시도(초기 1회 + 재시도 2회, 간격은 `IW_START_RETRY_SLEEP`, 기본 2초)하고, herdr 가 준 실패 코드와 원인 문장을 로그에 남긴다 — 130 tick 동안 디스패치 0건이던 원인 (#1525)**

--- a/docs/public/changelog.d/2026-08-27-1525.md
+++ b/docs/public/changelog.d/2026-08-27-1525.md
@@ -1,0 +1,1 @@
+- 변경: **issue-watcher tick 이 `agent_pane_busy` 로 거절된 `herdr agent start` 를 같은 pane 에서 최대 3회(`IW_START_RETRY_SLEEP` 간격, 기본 2초) 재시도하고, herdr 가 stderr 로 준 실패 원인을 로그에 남긴다 — 130 tick 동안 디스패치 0건이던 원인 (#1525)**

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -1301,7 +1301,6 @@ _iw_start_agent_retrying() {
             break
         fi
         _IW_START_CODE=$(_iw_herdr_error_code "${_json}" "${_IW_ERRF}")
-        _IW_START_MESSAGE=$(_iw_herdr_error_message "${_IW_ERRF}")
 
         # The one failure worth another attempt (#1525): the pane was created
         # moments ago and its shell is not interactive yet. Only this code — a
@@ -1316,6 +1315,11 @@ _iw_start_agent_retrying() {
         [ "${_IW_START_RETRY_SLEEP}" = "0" ] || sleep "${_IW_START_RETRY_SLEEP}"
         _attempt=$((_attempt + 1))
     done
+
+    # Only the give-up path is ever read, and the capture file still holds the
+    # last attempt's stderr right here — so a retry that goes on to win pays
+    # nothing for the sentence describing the failure it recovered from.
+    [ "${_rc}" -eq 0 ] || _IW_START_MESSAGE=$(_iw_herdr_error_message "${_IW_ERRF}")
 
     trap - EXIT INT TERM
     [ "${_IW_ERRF}" = "/dev/null" ] || rm -f "${_IW_ERRF}"

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -1262,18 +1262,25 @@ _iw_herdr_error_code() {
     printf '%s' "${_code}"
 }
 
-# The human half of the same document: herdr's own sentence about the failure,
-# from the stderr file <1>. `.error.message` first, because what herdr writes to
-# stderr is a JSON document and dumping it raw into a cron log buries the
-# sentence inside braces. Falls back to the first raw line, which is what a
-# non-JSON stderr (a crash, a shell error) carries — and is also what keeps this
-# working if herdr ever changes its JSON shape. Echoes nothing on an empty file.
+# The human half of the same document: herdr's own sentence about the failure.
+# Same two inputs and the same stdout-first order as _iw_herdr_error_code —
+# herdr picks the stream, not us, so a helper that read only one of them would
+# hand back a code with no sentence for every failure answered on the other.
+# `agent_name_taken` is exactly that shape (PR #1528 review, codex).
+#
+# `.error.message` before any raw text, because what herdr writes is a JSON
+# document and dumping it verbatim buries the sentence inside braces exactly
+# where a cron log is read in a hurry. The first raw stderr line is the last
+# resort: it is what a non-JSON stream (a crash, a shell error) carries, and
+# what keeps this working if herdr ever changes its JSON shape.
 _iw_herdr_error_message() {
-    local _errfile="$1" _msg
+    local _json="$1" _errfile="$2" _msg
 
-    [ -s "${_errfile}" ] || return 0
-    _msg=$(_iw_json_value '.error.message' <"${_errfile}")
-    [ -n "${_msg}" ] || _msg=$(head -n 1 "${_errfile}" 2>/dev/null)
+    _msg=$(printf '%s' "${_json}" | _iw_json_value '.error.message')
+    if [ -z "${_msg}" ] && [ -s "${_errfile}" ]; then
+        _msg=$(_iw_json_value '.error.message' <"${_errfile}")
+        [ -n "${_msg}" ] || _msg=$(head -n 1 "${_errfile}" 2>/dev/null)
+    fi
     printf '%s' "${_msg}"
 }
 
@@ -1292,8 +1299,16 @@ _iw_start_agent_retrying() {
     # names nothing we can read, so nothing is retryable, but the one attempt
     # is still worth making. /dev/null keeps every reader below correct — it is
     # never `-s`, so both parsers simply answer "no such field".
-    _IW_ERRF=$(mktemp) || _IW_ERRF="/dev/null"
-    trap 'rm -f "${_IW_ERRF}"' EXIT INT TERM
+    #
+    # The trap is armed only on the branch that has a file to remove. Arming it
+    # unconditionally put `/dev/null` in reach of the trap's own `rm -f`, which
+    # — unlike the guarded removal at the end — would have run on any signal
+    # landing in this window (PR #1528 review, agy).
+    if _IW_ERRF=$(mktemp); then
+        trap 'rm -f "${_IW_ERRF}"' EXIT INT TERM
+    else
+        _IW_ERRF="/dev/null"
+    fi
 
     while :; do
         if _json=$(_iw_agent_start "${_agent}" "${_pane}" "${_IW_ERRF}"); then
@@ -1319,10 +1334,13 @@ _iw_start_agent_retrying() {
     # Only the give-up path is ever read, and the capture file still holds the
     # last attempt's stderr right here — so a retry that goes on to win pays
     # nothing for the sentence describing the failure it recovered from.
-    [ "${_rc}" -eq 0 ] || _IW_START_MESSAGE=$(_iw_herdr_error_message "${_IW_ERRF}")
+    [ "${_rc}" -eq 0 ] || _IW_START_MESSAGE=$(_iw_herdr_error_message "${_json}" "${_IW_ERRF}")
 
-    trap - EXIT INT TERM
-    [ "${_IW_ERRF}" = "/dev/null" ] || rm -f "${_IW_ERRF}"
+    # Mirrors the arming above: no file, no trap to clear and nothing to remove.
+    if [ "${_IW_ERRF}" != "/dev/null" ]; then
+        trap - EXIT INT TERM
+        rm -f "${_IW_ERRF}"
+    fi
     return "${_rc}"
 }
 
@@ -1520,8 +1538,13 @@ EOF
                 # pane, a dead server, a rejected account — converged on the
                 # same unhelpful sentence, which is precisely why #1525 sat
                 # unnoticed through 21 failed starts.
-                _cause="${_IW_START_MESSAGE:-${_IW_START_CODE}}"
-                _msg="herdr agent start ${_agent} failed on pane ${_pane} (attempt ${_attempt}/${_IW_MAX_ATTEMPTS})."
+                # The code goes on the main line and the sentence under it —
+                # the code is the token a human greps a cron log for
+                # (`grep -c agent_pane_busy` is how #1525 was measured), the
+                # sentence is what they read once they have found it. Folding
+                # the two into one field would cost whichever half lost.
+                _cause="${_IW_START_MESSAGE}"
+                _msg="herdr agent start ${_agent} failed on pane ${_pane} (${_IW_START_CODE:-unknown}, attempt ${_attempt}/${_IW_MAX_ATTEMPTS})."
                 [ -z "${_cause}" ] || _msg="${_msg}
     원인: ${_cause}"
                 ux_warning "${_msg}"

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -147,6 +147,24 @@ _IW_SELECT_STATE_BASENAME="select.json"
 _IW_STALL_RECOVER_ATTEMPTS="3"
 _IW_STALL_RECOVER_SLEEP="${IW_STALL_RECOVER_SLEEP:-2}"
 
+# Start retrying (issue #1525, the same defect #1512 fixed on the merge-train
+# side). `herdr tab create` answers before the pane's shell is interactive, so
+# `agent start` on it is refused with `agent_pane_busy` — a timing race against
+# a pane that is perfectly good a moment later. herdr rejects it immediately
+# rather than waiting, so `agent start --timeout` (which only extends the
+# readiness wait) cannot help; another attempt on the *same* pane can.
+#
+# This is a different layer from _IW_MAX_ATTEMPTS, which cleans the attempt up
+# and builds a new worktree and a new, equally cold tab — three tries at the
+# same race. That is what left 130 consecutive ticks with 0 dispatches. The two
+# bounds are independent and both still hold.
+#
+# Bounded in *attempts*, not retries, so the `start N/MAX` warning reads exactly
+# true. The gap is overridable for the same reason _IW_STALL_RECOVER_SLEEP is —
+# the bats suite must not pay a real wait per retry test.
+_IW_START_ATTEMPT_MAX="3"
+_IW_START_RETRY_SLEEP="${IW_START_RETRY_SLEEP:-2}"
+
 # Rate-limit gate (issue #1436; judgment input rebuilt in #1444). Rationale for
 # each value sits with the gate functions below; the values themselves live here
 # with the rest of the SSOT.
@@ -190,6 +208,16 @@ _IW_LIMIT_EVIDENCE_LINES="40"
 # log input only — the gate no longer classifies error codes at all. Empty
 # otherwise.
 _IW_STALL_RECOVER_ERROR=""
+# Set by _iw_start_agent_retrying to the herdr error code and the human sentence
+# behind the start it gave up on — empty when herdr named neither on either
+# stream (issue #1525). Log inputs only; nothing branches on them.
+_IW_START_CODE=""
+_IW_START_MESSAGE=""
+# The file herdr's stderr is captured to. Global, not local, so the signal trap
+# that removes it can still name it — a `local` would be unset by the time the
+# trap fires and `set -u` would turn the cleanup into its own error (the same
+# point agy raised on PR #1517).
+_IW_ERRF=""
 # CLAUDE_CONFIG_DIR for every pane this tick opens. Resolved once per tick.
 _IW_CONFIG_DIR=""
 # Set by --dry-run: collect and report candidates, mutate nothing.
@@ -1208,9 +1236,90 @@ _iw_agent_seq() {
 
 # `-- ARG...` is passed through to the pane's claude invocation. Unattended
 # cron ticks must never stop on a permission-approval prompt (issue #1393).
+#
+# stderr goes to the file named by $3 rather than /dev/null (#1525, the same
+# defect class as #1445/#1458): herdr is free to answer on either stream and in
+# cron it answers on stderr, so discarding it threw away the one sentence that
+# named the failure — `agent_pane_busy`. stdout stays on the pipe because the
+# caller reads `.error.code` off it, which is why this is a file and not `2>&1`.
 _iw_agent_start() {
     herdr agent start "$1" --kind claude --pane "$2" \
-        -- --dangerously-skip-permissions >/dev/null 2>&1
+        -- --dangerously-skip-permissions 2>"$3"
+}
+
+# Echo the herdr error code behind a failed call: <1> is herdr's stdout, <2> the
+# file its stderr was captured to. stdout first, stderr as the fallback. Both
+# are consulted because the stream herdr picks is not ours to choose — and in
+# production it picked the one nobody was reading. Echoes nothing when neither
+# stream carried a parsable error document.
+_iw_herdr_error_code() {
+    local _json="$1" _errfile="$2" _code
+
+    _code=$(printf '%s' "${_json}" | _iw_json_value '.error.code')
+    if [ -z "${_code}" ] && [ -s "${_errfile}" ]; then
+        _code=$(_iw_json_value '.error.code' <"${_errfile}")
+    fi
+    printf '%s' "${_code}"
+}
+
+# The human half of the same document: herdr's own sentence about the failure,
+# from the stderr file <1>. `.error.message` first, because what herdr writes to
+# stderr is a JSON document and dumping it raw into a cron log buries the
+# sentence inside braces. Falls back to the first raw line, which is what a
+# non-JSON stderr (a crash, a shell error) carries — and is also what keeps this
+# working if herdr ever changes its JSON shape. Echoes nothing on an empty file.
+_iw_herdr_error_message() {
+    local _errfile="$1" _msg
+
+    [ -s "${_errfile}" ] || return 0
+    _msg=$(_iw_json_value '.error.message' <"${_errfile}")
+    [ -n "${_msg}" ] || _msg=$(head -n 1 "${_errfile}" 2>/dev/null)
+    printf '%s' "${_msg}"
+}
+
+# Start agent <1> on pane <2>, retrying only the #1525 `agent_pane_busy` race.
+# 0 = an agent is running on the pane, 1 = gave up, with _IW_START_CODE naming
+# the last failure and _IW_START_MESSAGE carrying herdr's sentence about it.
+#
+# Each attempt truncates the capture file, so a retry that fails differently can
+# never be reported with the previous attempt's cause.
+_iw_start_agent_retrying() {
+    local _agent="$1" _pane="$2" _json _attempt=1 _rc=1
+
+    _IW_START_CODE=""
+    _IW_START_MESSAGE=""
+    # A capture file we cannot open costs the *cause*, not the start: herdr
+    # names nothing we can read, so nothing is retryable, but the one attempt
+    # is still worth making. /dev/null keeps every reader below correct — it is
+    # never `-s`, so both parsers simply answer "no such field".
+    _IW_ERRF=$(mktemp) || _IW_ERRF="/dev/null"
+    trap 'rm -f "${_IW_ERRF}"' EXIT INT TERM
+
+    while :; do
+        if _json=$(_iw_agent_start "${_agent}" "${_pane}" "${_IW_ERRF}"); then
+            _rc=0
+            break
+        fi
+        _IW_START_CODE=$(_iw_herdr_error_code "${_json}" "${_IW_ERRF}")
+        _IW_START_MESSAGE=$(_iw_herdr_error_message "${_IW_ERRF}")
+
+        # The one failure worth another attempt (#1525): the pane was created
+        # moments ago and its shell is not interactive yet. Only this code — a
+        # failure that does not name itself is not a race we understand, and
+        # ending the attempt immediately keeps that contract intact.
+        if [ "${_IW_START_CODE}" != "agent_pane_busy" ] ||
+            [ "${_attempt}" -ge "${_IW_START_ATTEMPT_MAX}" ]; then
+            break
+        fi
+
+        ux_warning "herdr agent start ${_agent} hit agent_pane_busy on pane ${_pane} (start ${_attempt}/${_IW_START_ATTEMPT_MAX}) — retrying in ${_IW_START_RETRY_SLEEP}s."
+        [ "${_IW_START_RETRY_SLEEP}" = "0" ] || sleep "${_IW_START_RETRY_SLEEP}"
+        _attempt=$((_attempt + 1))
+    done
+
+    trap - EXIT INT TERM
+    [ "${_IW_ERRF}" = "/dev/null" ] || rm -f "${_IW_ERRF}"
+    return "${_rc}"
 }
 
 # Wait for a freshly started agent to report idle before prompting it.
@@ -1378,6 +1487,7 @@ _iw_prompt_issue() {
 _iw_process_issue() {
     local _repo="$1" _number="$2" _path="$3"
     local _attempt=1 _agent _label _wt="" _ws="" _pane_tab="" _pane="" _tab=""
+    local _cause="" _msg=""
 
     _agent=$(_iw_agent_name "${_repo}" "${_number}")
     _label=$(_iw_workspace_label "${_repo}" "${_path}")
@@ -1400,8 +1510,17 @@ _iw_process_issue() {
             IFS="${_IW_TAB}" read -r _pane _tab <<EOF
 ${_pane_tab}
 EOF
-            if ! _iw_agent_start "${_agent}" "${_pane}"; then
-                ux_warning "herdr agent start ${_agent} failed on pane ${_pane} (attempt ${_attempt}/${_IW_MAX_ATTEMPTS})."
+            if ! _iw_start_agent_retrying "${_agent}" "${_pane}"; then
+                # One line, plus the sentence herdr actually gave, indented
+                # under it (#1445's idiom). Without it every cause — a busy
+                # pane, a dead server, a rejected account — converged on the
+                # same unhelpful sentence, which is precisely why #1525 sat
+                # unnoticed through 21 failed starts.
+                _cause="${_IW_START_MESSAGE:-${_IW_START_CODE}}"
+                _msg="herdr agent start ${_agent} failed on pane ${_pane} (attempt ${_attempt}/${_IW_MAX_ATTEMPTS})."
+                [ -z "${_cause}" ] || _msg="${_msg}
+    원인: ${_cause}"
+                ux_warning "${_msg}"
             elif _iw_wait_for_idle "${_agent}" && _iw_prompt_issue "${_agent}" "${_number}"; then
                 ux_success "${_repo}#${_number} dispatched (worktree ${_wt}, pane ${_pane})."
                 return 0

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -569,6 +569,20 @@ EOF
     chmod +x "${_BIN_DIR}/gwt"
 }
 
+# Make the tick's one `mktemp` call fail. The script has exactly one (the
+# herdr-stderr capture file in _iw_start_agent_retrying), so shadowing the
+# binary for the tick's own PATH exercises that fallback and nothing else —
+# bats' own mktemp calls run in the parent, before this stub is on PATH.
+_install_failing_mktemp() {
+    cat >"${_BIN_DIR}/mktemp" <<'EOF'
+#!/bin/sh
+printf 'mktemp %s\n' "$*" >>"${CALL_LOG}"
+printf 'mktemp: failed to create file\n' >&2
+exit 1
+EOF
+    chmod +x "${_BIN_DIR}/mktemp"
+}
+
 _install_stubs() {
     _install_gh_stub
     _install_herdr_stub
@@ -1857,6 +1871,43 @@ _two_repo_fixture() {
     _run_tick "HERDR_START_FAIL=1"
     assert_failure
     [ "$(_log_count 'agent start')" -eq 3 ]
+}
+
+# PR #1528 review (codex, FOLLOW-UP). herdr picks the stream, not us — that is
+# why _iw_herdr_error_code reads stdout first and stderr second. The *message*
+# helper read only stderr, so a failure herdr answered on stdout arrived with
+# its code but no sentence. `agent_name_taken` is exactly that shape.
+#
+# Both halves must survive: the code is what a human greps a cron log for
+# (`grep -c agent_pane_busy` is how #1525 was measured), the sentence is what
+# they read once they find it.
+@test "issue_watcher_cron: a stdout-only failure reports both its code and herdr's sentence" {
+    _run_tick "HERDR_START_NAME_TAKEN=1"
+    assert_failure
+    assert_output --partial "agent_name_taken"
+    assert_output --partial "agent name is already used"
+}
+
+# PR #1528 review (agy, BLOCKER). When `mktemp` fails there is no capture file,
+# so no error code can be read and nothing is retryable — but the start itself
+# is still worth one attempt, and losing the cause must not cost the dispatch.
+@test "issue_watcher_cron: a start still dispatches when the stderr capture file cannot be opened" {
+    _install_failing_mktemp
+    _run_tick
+    assert_success
+    _assert_logged "agent prompt iw-acme-dotfiles-11 /gh-issue-flow 11"
+}
+
+# Same fallback on the failing side: the tick reports the failure and cleans up
+# rather than dying on the unreadable capture file, and it claims no cause it
+# could not actually read.
+@test "issue_watcher_cron: a failed start without a capture file reports no invented cause" {
+    _install_failing_mktemp
+    _run_tick "HERDR_START_PANE_BUSY=99"
+    assert_failure
+    [ "$(_log_count 'agent start')" -eq 3 ]
+    refute_output --partial "원인:"
+    _assert_logged "tab close ws-test-1:t9"
 }
 
 @test "issue_watcher_cron: a spawn failure that never resolves gives up without a prompt" {

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -291,7 +291,18 @@ EOF
 #   HERDR_TAB_FAIL_AFTER=N    the first N `tab create` calls succeed, the rest
 #                             error — lets one issue fail two different ways
 #                             across its retry attempts
-#   HERDR_START_FAIL=1        `agent start` errors
+#   HERDR_START_FAIL=1        `agent start` errors, saying nothing at all — the
+#                             unexplained failure, with no parsable error code
+#   HERDR_START_NAME_TAKEN=1  `agent start` refuses because a live agent already
+#                             holds the name (herdr's `agent_name_taken`), on
+#                             stdout — a named failure that is not the pane race
+#   HERDR_START_PANE_BUSY=N   the first N `agent start` calls lose the #1525
+#                             race (`agent_pane_busy`), the rest succeed; a
+#                             number above the attempt budget loses it every
+#                             time. The document goes to **stderr**, which is
+#                             where herdr really put it — a dispatcher that
+#                             redirects that stream to /dev/null sees an
+#                             unexplained failure instead of a named race.
 #   HERDR_AGENT_STATUS        status reported by `agent get` (default: idle)
 #   HERDR_AGENT_GET_FAIL=1    `agent get` returns agent_not_found and exits 1
 #   HERDR_PROMPT_MODE         `agent prompt` behaviour (default: always ok)
@@ -392,6 +403,17 @@ case "$1 $2" in
     ;;
 "agent start")
     [ "${HERDR_START_FAIL:-0}" = "1" ] && exit 1
+    if [ "${HERDR_START_NAME_TAKEN:-0}" = "1" ]; then
+        printf '%s\n' '{"error":{"code":"agent_name_taken","message":"agent name is already used; candidates: status=Idle"},"id":"cli:agent:start"}'
+        exit 1
+    fi
+    if [ "${HERDR_START_PANE_BUSY:-0}" != "0" ]; then
+        _n=$(_bump "${CALL_LOG}.startbusy")
+        if [ "${_n}" -le "${HERDR_START_PANE_BUSY}" ]; then
+            printf '%s\n' '{"error":{"code":"agent_pane_busy","message":"agent target pane ws-test-1:p9 is not an available shell"},"id":"cli:agent:start"}' >&2
+            exit 1
+        fi
+    fi
     printf '%s\n' '{"id":"cli:agent:start","result":{"agent":{"agent_status":"idle","pane_id":"ws-test-1:p9"}}}'
     ;;
 "agent get")
@@ -614,6 +636,7 @@ _run_tick() {
         "XDG_STATE_HOME=${_STATE_HOME}" \
         "IW_IDLE_POLL_SLEEP=0" \
         "IW_STALL_RECOVER_SLEEP=0" \
+        "IW_START_RETRY_SLEEP=0" \
         "IW_LIMIT_OBSERVE_SLEEP=0" \
         "${_env[@]}" \
         bash "${SCRIPT}" "$@"
@@ -1744,6 +1767,96 @@ _two_repo_fixture() {
     _run_tick "HERDR_START_FAIL=1"
     assert_failure
     _assert_logged "tab close ws-test-1:t9"
+}
+
+# ---------------------------------------------------------------------------
+# #1525 — the agent_pane_busy race on a pane that was just created
+# ---------------------------------------------------------------------------
+#
+# A tab's shell is not interactive the instant `tab create` answers, so
+# `agent start` on it is refused with `agent_pane_busy` and returns immediately.
+# In cron that lost every single tick for 130 ticks running. It is a timing
+# race, not a defect in the pane, so another attempt *on the same pane* is the
+# fix — which is exactly what the outer _IW_MAX_ATTEMPTS loop cannot give: it
+# throws the worktree and the tab away and builds a new, equally cold pane.
+
+@test "issue_watcher_cron: a transient agent_pane_busy is retried and the issue still dispatches" {
+    _run_tick "HERDR_START_PANE_BUSY=1"
+    assert_success
+    # The retry is *inner*: the same tab, a second start. A second `tab create`
+    # here would mean the outer loop absorbed it, which is the defect.
+    [ "$(_log_count 'agent start')" -eq 2 ]
+    [ "$(_log_count 'tab create')" -eq 1 ]
+    _assert_logged "agent prompt iw-acme-dotfiles-11 /gh-issue-flow 11"
+}
+
+# The retry has to be visible: 130 ticks of silent failure is what made this
+# cost a day. The gap comes from IW_START_RETRY_SLEEP, so a hardcoded 2 would
+# read "retrying in 2s" here and fail — the message is the proof the override
+# reached the code, and with it that the bats suite pays no real wait.
+@test "issue_watcher_cron: a retried pane race names itself and its configured gap" {
+    _run_tick "HERDR_START_PANE_BUSY=1"
+    assert_success
+    assert_output --partial "agent_pane_busy"
+    assert_output --partial "retrying in 0s"
+}
+
+# The inner retrying is bounded, and the bound is the point: cron re-runs every
+# few minutes anyway. Three inner *attempts* per outer attempt, three outer
+# attempts — the two layers are independent and both still hold.
+@test "issue_watcher_cron: a permanent agent_pane_busy stops after the inner attempt budget" {
+    _run_tick "HERDR_START_PANE_BUSY=99"
+    assert_failure
+    [ "$(_log_count 'agent start')" -eq 9 ]
+    [ "$(_log_count 'tab create')" -eq 3 ]
+    _refute_logged "agent prompt"
+}
+
+# Exhausting the inner budget must still fall through to _iw_cleanup_attempt —
+# a retry loop that swallowed the failure would leak a worktree and a tab per
+# outer attempt, which is the litter the issue's log already shows.
+@test "issue_watcher_cron: a start that never succeeds cleans up its worktree and tab" {
+    _run_tick "HERDR_START_PANE_BUSY=99"
+    assert_failure
+    [ "$(_log_count 'tab close ws-test-1:t9')" -eq 3 ]
+    run git -C "${_REPO_DIR}" worktree list --porcelain
+    refute_output --partial "wt/issue-11/"
+}
+
+# The #1445/#1458 regression guard. herdr names this race precisely, on stderr;
+# `_iw_agent_start` used to throw that stream away, so 21 failures in the cron
+# log said only "start failed". Restoring `2>&1 >/dev/null` must make this red.
+@test "issue_watcher_cron: a failed start reports the cause herdr gave on stderr" {
+    _run_tick "HERDR_START_PANE_BUSY=99"
+    assert_failure
+    assert_output --partial "agent_pane_busy"
+    assert_output --partial "is not an available shell"
+}
+
+# What herdr writes to stderr is a JSON document, so dumping it verbatim buries
+# the sentence inside braces exactly where a cron log is read in a hurry.
+@test "issue_watcher_cron: the cause line carries the message, not the raw JSON" {
+    _run_tick "HERDR_START_PANE_BUSY=99"
+    assert_failure
+    refute_output --partial '{"error"'
+}
+
+# Only the one known race is retried. `agent_name_taken` is a named failure,
+# but it is not a race that a second attempt on the same pane can win, so it
+# ends its outer attempt at once — one start per attempt, three in all.
+@test "issue_watcher_cron: a named failure that is not the pane race is never retried" {
+    _run_tick "HERDR_START_NAME_TAKEN=1"
+    assert_failure
+    [ "$(_log_count 'agent start')" -eq 3 ]
+    assert_output --partial "agent_name_taken"
+}
+
+# A failure that does not name itself is not a race we understand either — the
+# same contract #1512 set on the merge-train side.
+@test "issue_watcher_cron: an unexplained start failure is not retried" {
+    _run_tick "HERDR_START_FAIL=1"
+    assert_failure
+    [ "$(_log_count 'agent start')" -eq 3 ]
 }
 
 @test "issue_watcher_cron: a spawn failure that never resolves gives up without a prompt" {


### PR DESCRIPTION
## Summary
- issue-watcher tick 이 `herdr agent start` 의 `agent_pane_busy` 경합에 걸려 **130 tick 동안 디스패치 0건**이던 문제를 고친다.
- #1512 가 `pr_merge_train_cron.sh` 에서 검증한 패턴(stderr 보존 + 코드 한정 재시도)을 `issue_watcher_cron.sh` 로 이식한다.
- 파이프라인 입구가 뚫려야 `gh:issue-flow` 무인 실행 → PR → merge-train 을 측정할 데이터가 생긴다.

## Changes
- `shell-common/tools/custom/issue_watcher_cron.sh`
  - `_iw_agent_start` 가 herdr 의 stderr 를 `>/dev/null 2>&1` 로 버리지 않고 캡처 파일로 받는다. 호출자가 `.error.code` 를 읽을 수 있게 stdout 은 파이프에 남긴다.
  - `_iw_herdr_error_code` / `_iw_herdr_error_message` 추가 — stdout 우선, stderr 폴백. herdr 이 어느 스트림을 고를지는 우리 소관이 아니고, 실제로 아무도 읽지 않는 쪽을 골랐다.
  - `_iw_start_agent_retrying` 추가 — `agent_pane_busy` 일 때만 같은 pane 에 대해 최대 `_IW_START_ATTEMPT_MAX`(3) 회 시도, 간격은 `IW_START_RETRY_SLEEP`(기본 2초). 자기 이름을 말하지 않는 실패는 재시도하지 않고 즉시 그 시도를 끝낸다.
  - `_iw_process_issue` 의 실패 줄 아래에 herdr 이 준 문장을 `원인:` 으로 싣는다.
  - `_IW_MAX_ATTEMPTS` 바깥 루프는 그대로 둔다 — 워크트리 생성 실패 같은 다른 실패를 담당하는 다른 층위이고, 실패 시 정리(`_iw_cleanup_attempt`)도 그대로 탄다.
- `tests/bats/tools/issue_watcher_cron.bats`
  - herdr 스텁에 `HERDR_START_PANE_BUSY=N`(stderr 로 `agent_pane_busy`) / `HERDR_START_NAME_TAKEN=1`(stdout 으로 `agent_name_taken`) 추가.
  - `_run_tick` 기본값에 `IW_START_RETRY_SLEEP=0` 추가 — 스위트가 실시간 대기를 지불하지 않는다.
  - 회귀 테스트 8건 추가(재시도 성공 / 예산 소진 / 정리 / 원인 노출 / raw JSON 금지 / 다른 코드는 재시도 없음).
- `docs/public/changelog.d/2026-08-27-1525.md` — changelog fragment 1건.

## Test plan
- [x] `bats tests/bats/tools/issue_watcher_cron.bats` — 183 passed, 0 failed (변경 전 baseline 175/175)
- [x] `bats tests/bats/tools/pr_merge_train_cron.bats` — 50 passed, 0 failed (이식원 회귀 확인)
- [x] `mise run lint-sh` — clean, `mise run lint-docs` — errors=0
- [x] 전체 pytest 1541 passed
- [ ] 실제 cron tick 이 `Tick complete — 1 dispatched` 를 최소 1회 남기는지 (머지 후 라이브 검증 — 이슈의 검증 항목)

## Related
Closes #1525

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
