### PR TITLE
fix(devx-pr-review-all): 리뷰 판정을 머지 게이트가 읽는 1급 상태로 만든다

### DIFF
--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -37,8 +37,8 @@ and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
 
 ## Step 2: Pre-flight
 
-- Resolve `TARGET_REPO` for `<remote>` and pass `-R <TARGET_REPO>` on every
-  `gh pr`/`gh repo` call.
+- Resolve `TARGET_REPO` **and `TARGET_HOST`** from `<remote>`'s URL and pass
+  `-R <TARGET_REPO>` / `GH_HOST="$TARGET_HOST"` on every `gh` call (#1403, #1407).
 - PR state must be `OPEN` and not draft (`gh pr view <pr> -R <TARGET_REPO>`)
   → else exit 1 `PR #<pr> is <state>; aborting`.
 - `gh auth status` returns 0 → else exit 1 with the gh error line.

--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -19,9 +19,9 @@ metadata:
 ## Role
 
 Orchestrate a single PR through all available reviewers at once — agy, codex, opencode, hermes, plus a `/simplify`
-auto-fix pass — commit any auto-fix changes, then reply to review comments inline or deferred. No
-approve/request-changes decision and no manual per-comment authoring. Every reviewer lane is soft-fail.
-Argument/flag table (`<PR#> [remote] [--defer-reply M] [--no-reply]`): `references/help.md`.
+auto-fix pass — commit any auto-fix changes, aggregate every lane's verdict into a `review-blocked` / `review-passed`
+PR label (#1527), then reply to review comments inline or deferred. No approve/request-changes decision and no manual
+per-comment authoring. Every lane is soft-fail. Args (`<PR#> [remote] [--defer-reply M] [--no-reply]`): `references/help.md`.
 
 ## Help
 
@@ -50,6 +50,9 @@ and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
 The five lanes dispatch together in a single turn. agy/codex/opencode/hermes
 are comment-only; `/simplify` may mutate and commit. Each lane is soft-fail.
 
+**Capture each reviewer lane's raw output** — Step 5 parses its closing verdict line;
+a lane that did not run contributes none (`references/review-verdict-label.md`).
+
 - **agy** — if `command -v agy`, an Agent runs
   `Skill(gh:pr-review, "--ai agy <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
 - **codex** — if `command -v codex`, an Agent runs
@@ -74,7 +77,18 @@ Await all lanes, then:
 - `/simplify` committed → `git push`.
 - The tree was unchanged → skip.
 
-## Step 5: pr-reply (per reply_mode)
+## Step 5: Aggregate verdicts into the merge-gate label
+
+`devx_pr_review_all_verdict` per lane that RAN → `devx_pr_review_all_aggregate` over
+those verdicts → apply via `_gh_pr_edit_safe_label`, clearing the opposite label first.
+Exact block, label table, fail-closed rules: `references/review-verdict-label.md`.
+Soft-fail throughout.
+
+`review-blocked` if any lane blocked; `review-passed` only if ≥1 lane ran and none
+blocked or came back `unknown`; **no label otherwise** — "not checked" is never
+promoted to "passed", and `gh:pr-merge-train` skips an unlabelled PR (#1527).
+
+## Step 6: pr-reply (per reply_mode)
 
 - `inline` (default) → run `Skill(gh:pr-reply, "<pr> <remote>")` immediately.
 - `defer` → **first** add the `reply-pending` label per
@@ -89,20 +103,21 @@ Await all lanes, then:
 Only `defer` labels: `inline` and `none` defer nothing, so there is no pending
 state to mark.
 
-## Step 6: Report
+## Step 7: Report
 
-Print exactly one `[OK]`/`[SKIP]`/`[WARN]` line, e.g.
-`[OK] PR #<pr> reviewed (agy:OK codex:SKIP opencode:OK hermes:SKIP simplify:committed) — reply: inline`.
+Print exactly one `[OK]`/`[SKIP]`/`[WARN]` line naming the verdict label (or `none`), e.g.
+`[OK] PR #<pr> reviewed (agy:blocking codex:SKIP opencode:lgtm hermes:SKIP simplify:committed) — label: review-blocked — reply: inline`.
 
 ## Constraints (full rationale: `references/constraints.md`)
 
 - Reviewer lanes are soft-fail; `/simplify` commits its own changes before push.
 - Never add `/code-review`; never run bare `git commit`.
 - Inline reply is deterministic; `--defer-reply` is minutes-only and not a guarantee.
+- Verdict labelling is soft-fail and fail-closed — no verdict means no label (#1527).
 - No approve / request-changes here — that is `gh:pr-approve`.
 
 ## Related Skills
 
 `gh:pr-review` (one reviewer at a time — this skill fans out over it) · `gh:pr-reply` / `devx:schedule` (the reply
-pass) · `gh:pr-approve` (the approve/request-changes decision). Reused by `gh:issue-flow` (Step 2.4) as its
-post-PR quality gate.
+pass) · `gh:pr-approve` (the approve/request-changes decision) · `gh:pr-merge-train` (consumes the Step 5 verdict
+label as a hard merge gate, #1527). Reused by `gh:issue-flow` (Step 2.4) as its post-PR quality gate.

--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -37,8 +37,12 @@ and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
 
 ## Step 2: Pre-flight
 
-- Resolve `TARGET_REPO` **and `TARGET_HOST`** from `<remote>`'s URL and pass
-  `-R <TARGET_REPO>` / `GH_HOST="$TARGET_HOST"` on every `gh` call (#1403, #1407).
+- Resolve `TARGET_REPO` **and `TARGET_HOST`** from `<remote>`'s URL, then
+  **`export GH_HOST="$TARGET_HOST"`** and pass `-R <TARGET_REPO>` on every `gh`
+  call (#1403, #1407). The export is load-bearing, not tidiness: Step 5's
+  `_gh_pr_edit_safe_label` calls `gh` itself and contains no host handling of
+  its own, so a per-call prefix never reaches it and the label add lands on gh
+  CLI's default host (PR #1529 review, agy + codex).
 - PR state must be `OPEN` and not draft (`gh pr view <pr> -R <TARGET_REPO>`)
   → else exit 1 `PR #<pr> is <state>; aborting`.
 - `gh auth status` returns 0 → else exit 1 with the gh error line.
@@ -50,8 +54,11 @@ and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
 The five lanes dispatch together in a single turn. agy/codex/opencode/hermes
 are comment-only; `/simplify` may mutate and commit. Each lane is soft-fail.
 
-**Capture each reviewer lane's raw output** — Step 5 parses its closing verdict line;
-a lane that did not run contributes none (`references/review-verdict-label.md`).
+**Record which lanes RAN** — that is all Step 3 owes Step 5. The verdict itself
+is *not* read from a lane's return value: `gh:pr-review` returns one `[OK] …`
+line and a subagent returns a summary, neither of which carries it. Step 5 reads
+it from the `<!-- ai-review:<ai> -->` block each lane posted to the PR instead
+(`references/review-verdict-label.md`).
 
 - **agy** — if `command -v agy`, an Agent runs
   `Skill(gh:pr-review, "--ai agy <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
@@ -79,10 +86,11 @@ Await all lanes, then:
 
 ## Step 5: Aggregate verdicts into the merge-gate label
 
-`devx_pr_review_all_verdict` per lane that RAN → `devx_pr_review_all_aggregate` over
-those verdicts → apply via `_gh_pr_edit_safe_label`, clearing the opposite label first.
-Exact block, label table, fail-closed rules: `references/review-verdict-label.md`.
-Soft-fail throughout.
+Fetch the PR's comments once, then per lane that RAN:
+`devx_pr_review_all_lane_block <ai>` → `devx_pr_review_all_verdict` →
+`devx_pr_review_all_aggregate` over those verdicts → apply via
+`_gh_pr_edit_safe_label`, clearing the opposite label first. Exact block, label
+table, fail-closed rules: `references/review-verdict-label.md`. Soft-fail throughout.
 
 `review-blocked` if any lane blocked; `review-passed` only if ≥1 lane ran and none
 blocked or came back `unknown`; **no label otherwise** — "not checked" is never

--- a/claude/skills/devx-pr-review-all/references/constraints.md
+++ b/claude/skills/devx-pr-review-all/references/constraints.md
@@ -52,7 +52,7 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
 - **Delay is not a guarantee — inline reply is the deterministic path.**
   agy/codex/opencode/hermes reviews are synchronous `gh:pr-review` CLI calls: they post the
   PR comment before returning. Because Step 3 awaits all five Agents, the
-  comments exist by the time Step 5 runs, so an **inline** `gh:pr-reply` sees
+  comments exist by the time Step 6 runs, so an **inline** `gh:pr-reply` sees
   them with deterministic ordering — no fixed delay needed. `--defer-reply` is
   a convenience for the issue-flow path (short turns), not a correctness
   requirement; the read-after-write is same-auth and effectively immediate.
@@ -77,7 +77,7 @@ The SKILL.md body lists these as terse rules; the full rationale lives here.
 
 - No emojis anywhere. POSIX-compatible shell snippets (`[ ]`, `>/dev/null 2>&1`).
 
-- **`gh:pr-reply` now takes a `[remote]` positional** (issue #1165) — Step 5
+- **`gh:pr-reply` now takes a `[remote]` positional** (issue #1165) — Step 6
   threads the same `<remote>` this skill parsed as `gh:pr-reply`'s second
   positional arg (`Skill(gh:pr-reply, "<pr> <remote>")`). `gh:pr-reply` then
   resolves `TARGET_REPO` by parsing that remote's URL (SSOT helper

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -2,7 +2,9 @@
 
 Fan out **every available reviewer** on one PR in parallel — `agy` ∥
 `codex` ∥ `opencode` ∥ `hermes` second opinions ∥ a `/simplify` auto-fix pass (which commits its own
-changes) — then run a reply pass over the resulting review comments. A
+changes) — then aggregate the lanes' verdicts into a
+`review-blocked` / `review-passed` PR label (the merge train's hard gate,
+#1527) and run a reply pass over the resulting review comments. A
 composition skill: it
 orchestrates several reviewers plus a reply, unlike `gh:pr-review` (a single
 external AI, one aggregate comment). It submits **no decision** (approve /
@@ -48,10 +50,15 @@ request-changes) — that is `gh:pr-approve`.
    soft-fail.
 4. Push the auto-fix commit (only if the working tree changed), always with
    an explicit `-m` message.
-5. Reply — inline `gh:pr-reply <pr> <remote>` (default), or deferred via
+5. Aggregate every lane's closing verdict (`판정:` / `Verdict:`) and label the
+   PR `review-blocked` (any lane blocking) or `review-passed` (≥1 lane ran and
+   none blocked). Lanes that did not run contribute nothing, and a PR whose
+   verdict cannot be established is left **unlabelled** — `gh:pr-merge-train`
+   skips it (#1527). Soft-fail.
+6. Reply — inline `gh:pr-reply <pr> <remote>` (default), or deferred via
    `devx:schedule` (`--defer-reply M`), or skipped (`--no-reply`). The
    `<remote>` is threaded so the reply pass resolves the same target repo.
-6. Print one `[OK]`/`[SKIP]`/`[WARN]` report line.
+7. Print one `[OK]`/`[SKIP]`/`[WARN]` report line, naming the verdict label.
 
 ## What the skill will NOT do
 
@@ -60,6 +67,9 @@ request-changes) — that is `gh:pr-approve`.
   v2.1.215, so no skill can invoke it. Run it yourself when you want it; agy,
   codex, and the closing `gh:pr-reply` pass cover the same ground here.
 - Hard-fail because a reviewer CLI is missing or errors — each lane is soft-fail.
+- Label a PR `review-passed` when no lane actually ran, or auto-create either
+  verdict label in a repo that lacks it (#1527) — both are refused, and the
+  unlabelled PR is skipped by the merge train.
 - Run a bare `git commit` — an editor prompt would hang the non-interactive shell.
 - Schedule sub-minute delays — `devx:schedule` is minutes-only; for tight
   ordering use the deterministic inline reply.

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -13,7 +13,11 @@ SSOT for the two PR labels this skill emits and the merge train consumes.
 
 Neither is part of the 10-label SSOT (`gh-label-bootstrap/references/gh-labels.md`)
 — like `CI fail` and `conflict` they are a **pipeline-state** label system, not an
-issue-classification one, and `gh:label-bootstrap` does not sync them.
+issue-classification one. Unlike those two they *are* provisioned by
+`gh:label-bootstrap`, from that file's separate `pipeline|` feed, and `--prune`
+keeps them. **That is the rollout path** (#1527, PR #1529 codex review): without
+it a repo that lacks the labels can never get them, since the add path refuses to
+auto-create — so the gate would deadlock with every PR unlabelled and skipped.
 
 **Absence is the third state, and it means "not verified".** A PR with neither
 label has not been shown to pass review — the train skips it. That is what makes
@@ -89,7 +93,7 @@ else
     _gh_pr_edit_safe_label "$pr" "$label" --repo "$TARGET_REPO"
     case "$?" in
     0) echo "[OK] PR #$pr labelled \`$label\` (${lanes} lane(s))" ;;
-    3) echo "[WARN] label \`$label\` missing in $TARGET_REPO — create it once: gh label create \"$label\" --repo $TARGET_REPO" ;;
+    3) echo "[WARN] label \`$label\` missing in $TARGET_REPO — bootstrap once: /gh-label-bootstrap $TARGET_REPO" ;;
     *) echo "[WARN] labelling PR #$pr failed — train will treat it as unverified" ;;
     esac
 fi
@@ -102,14 +106,17 @@ sees both and — per its own precedence rule — keeps skipping.
 `_gh_pr_edit_safe_label` returns 3 when the label does not exist in the repo and
 **refuses to auto-create it** (`feedback_gh_label_no_autocreate.md`, #326). That
 is deliberate: silently creating labels from a code path is how typo'd labels
-enter a repo. Bootstrap the two labels once per repo by hand:
+enter a repo. The bootstrap is therefore explicit and human-invoked — once per
+repo, before the gate is expected to pass anything:
 
 ```sh
-gh label create review-blocked --color b60205 --repo <owner>/<repo> \
-  --description "리뷰 레인 중 하나 이상이 블로킹 판정 — 머지 금지 (#1527)"
-gh label create review-passed  --color 0e8a16 --repo <owner>/<repo> \
-  --description "실행된 모든 리뷰 레인이 통과 판정 — 머지 게이트 통과 (#1527)"
+/gh-label-bootstrap <owner>/<repo>
 ```
+
+It reads the `pipeline|` feed in `gh-label-bootstrap/references/gh-labels.md`,
+POSTs whatever is missing, PATCHes drift back to the SSOT color, and never
+prunes them. Re-running it is idempotent, so it is safe to fold into ordinary
+repo setup alongside the 10-label sync.
 
 ## Why this lives in the producer
 

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -1,0 +1,115 @@
+# devx:pr-review-all — Review verdict label (issue #1527)
+
+SSOT for the two PR labels this skill emits and the merge train consumes.
+`gh:pr-merge-train` reads them (`gh-pr-merge-train/references/review-verdict-gate.md`);
+`gh:pr-reply` clears `review-blocked` once it has actually pushed fixes.
+
+## The labels
+
+| label | color | meaning |
+|---|---|---|
+| `review-blocked` | `b60205` | at least one reviewer lane returned a blocking verdict |
+| `review-passed` | `0e8a16` | every lane that ran returned a non-blocking verdict, and at least one lane ran |
+
+Neither is part of the 10-label SSOT (`gh-label-bootstrap/references/gh-labels.md`)
+— like `CI fail` and `conflict` they are a **pipeline-state** label system, not an
+issue-classification one, and `gh:label-bootstrap` does not sync them.
+
+**Absence is the third state, and it means "not verified".** A PR with neither
+label has not been shown to pass review — the train skips it. That is what makes
+a time backstop unnecessary here (contrast #1524): a stuck PR is one label away
+from moving, and a human can add or remove it at any time.
+
+## Deriving the verdicts (Step 3 → Step 5)
+
+Each of the four reviewer lanes (`agy`, `codex`, `opencode`, `hermes`) ends its
+output with a mandatory verdict line — `판정: [LGTM|우려있음|블로킹]` or
+`Verdict: [LGTM|CONCERNS|BLOCKING]` (`gh-pr-review/references/review-presets.md`).
+Capture each lane's raw output in Step 3, then per lane:
+
+```sh
+. "${SHELL_COMMON}/functions/devx_pr_review_all.sh"
+VERDICT=$(printf '%s\n' "$LANE_OUTPUT" | devx_pr_review_all_verdict)
+# -> blocking | concerns | lgtm | unknown
+```
+
+A lane that **did not run** (`command -v` empty, non-internal PC, non-zero exit —
+every `[SKIP]`/`[WARN]` row of the Step 6 report) contributes **no verdict at
+all**. It is not an `unknown`; it is simply absent from the aggregation. The
+`/simplify` lane never contributes — it produces no verdict.
+
+Then aggregate over the lanes that did run. Read the two `key=value` lines with
+`sed`, not `eval` — the values are controlled, but a parser that cannot execute
+anything is the right default for something that gates a merge:
+
+```sh
+AGG=$(devx_pr_review_all_aggregate $VERDICTS)      # $VERDICTS unquoted: one word per lane
+label=$(printf '%s\n' "$AGG" | sed -n 's/^label=//p')
+lanes=$(printf '%s\n' "$AGG" | sed -n 's/^lanes=//p')
+```
+
+| lanes that ran | outcome | `label` |
+|---|---|---|
+| any lane `blocking` | blocked | `review-blocked` |
+| ≥1 lane, all `lgtm`/`concerns` | passed | `review-passed` |
+| ≥1 lane, any `unknown` | verdict not established | *(empty)* |
+| zero | nothing was checked | *(empty)* |
+
+`우려있음`/`CONCERNS` is a **pass** — it is a non-blocking opinion, and
+`gh:pr-reply` still answers it. `unknown` is not, because a lane whose output
+stopped parsing is indistinguishable from a lane that never reached a verdict.
+
+## Applying the label (Step 5)
+
+Add through `_gh_pr_edit_safe_label`, never bare `gh pr edit --add-label` —
+that silently exits 1 on repos with classic Projects attached (#326).
+Remove the opposite label through the REST endpoint, for the same reason.
+The whole block is **soft-fail**: a labelling failure leaves the PR unlabelled,
+which the train reads as "not verified" and skips. Fail-closed by construction.
+
+```sh
+. "${SHELL_COMMON}/functions/gh_pr_edit_safe.sh"
+
+if [ -z "$label" ]; then
+    echo "[WARN] no reviewer lane produced a verdict — PR #$pr left unlabelled (train will skip it)"
+else
+    case "$label" in
+    review-blocked) opposite=review-passed ;;
+    *) opposite=review-blocked ;;
+    esac
+
+    GH_HOST="$TARGET_HOST" gh api -X DELETE \
+        "repos/$TARGET_REPO/issues/$pr/labels/$opposite" >/dev/null 2>&1 || :
+
+    _gh_pr_edit_safe_label "$pr" "$label" --repo "$TARGET_REPO"
+    case "$?" in
+    0) echo "[OK] PR #$pr labelled \`$label\` (${lanes} lane(s))" ;;
+    3) echo "[WARN] label \`$label\` missing in $TARGET_REPO — create it once: gh label create \"$label\" --repo $TARGET_REPO" ;;
+    *) echo "[WARN] labelling PR #$pr failed — train will treat it as unverified" ;;
+    esac
+fi
+```
+
+**The opposite label is removed first, and unconditionally.** A re-review that
+flips `review-blocked` to `review-passed` has to clear the old one or the train
+sees both and — per its own precedence rule — keeps skipping.
+
+`_gh_pr_edit_safe_label` returns 3 when the label does not exist in the repo and
+**refuses to auto-create it** (`feedback_gh_label_no_autocreate.md`, #326). That
+is deliberate: silently creating labels from a code path is how typo'd labels
+enter a repo. Bootstrap the two labels once per repo by hand:
+
+```sh
+gh label create review-blocked --color b60205 --repo <owner>/<repo> \
+  --description "리뷰 레인 중 하나 이상이 블로킹 판정 — 머지 금지 (#1527)"
+gh label create review-passed  --color 0e8a16 --repo <owner>/<repo> \
+  --description "실행된 모든 리뷰 레인이 통과 판정 — 머지 게이트 통과 (#1527)"
+```
+
+## Why this lives in the producer
+
+The alternative — having `gh:pr-merge-train` grep the review comment bodies —
+couples the merge gate to every reviewer CLI's output format. A reviewer
+reformatting its verdict line would then silently *unlock* the gate. Parsing
+here means the same reformat produces `unknown`, no label, and a skipped PR:
+the failure direction is the safe one.

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -6,18 +6,16 @@ SSOT for the two PR labels this skill emits and the merge train consumes.
 
 ## The labels
 
-| label | color | meaning |
-|---|---|---|
-| `review-blocked` | `b60205` | at least one reviewer lane returned a blocking verdict |
-| `review-passed` | `0e8a16` | every lane that ran returned a non-blocking verdict, and at least one lane ran |
+| label | meaning |
+|---|---|
+| `review-blocked` | at least one reviewer lane returned a blocking verdict |
+| `review-passed` | every lane that ran returned a non-blocking verdict, and at least one lane ran |
 
-Neither is part of the 10-label SSOT (`gh-label-bootstrap/references/gh-labels.md`)
-— like `CI fail` and `conflict` they are a **pipeline-state** label system, not an
-issue-classification one. Unlike those two they *are* provisioned by
-`gh:label-bootstrap`, from that file's separate `pipeline|` feed, and `--prune`
-keeps them. **That is the rollout path** (#1527, PR #1529 codex review): without
-it a repo that lacks the labels can never get them, since the add path refuses to
-auto-create — so the gate would deadlock with every PR unlabelled and skipped.
+Neither is part of the 10-label SSOT — like `CI fail` and `conflict` they are a
+**pipeline-state** label system, not an issue-classification one. Unlike those
+two they *are* provisioned by `gh:label-bootstrap`, from the separate `pipeline|`
+feed in `gh-label-bootstrap/references/gh-labels.md`, which also holds their
+canonical colors. See "Bootstrapping the labels" below for why that path exists.
 
 **Absence is the third state, and it means "not verified".** A PR with neither
 label has not been shown to pass review — the train skips it. That is what makes
@@ -103,14 +101,18 @@ fi
 flips `review-blocked` to `review-passed` has to clear the old one or the train
 sees both and — per its own precedence rule — keeps skipping.
 
+## Bootstrapping the labels
+
 `_gh_pr_edit_safe_label` returns 3 when the label does not exist in the repo and
 **refuses to auto-create it** (`feedback_gh_label_no_autocreate.md`, #326). That
 is deliberate: silently creating labels from a code path is how typo'd labels
-enter a repo. The bootstrap is therefore explicit and human-invoked — once per
-repo, before the gate is expected to pass anything:
+enter a repo. But without *some* rollout path a repo that lacks the labels could
+never get them, and the gate would deadlock — every PR unlabelled, every PR
+skipped. So the bootstrap is explicit and human-invoked, once per repo, before
+the gate is expected to pass anything:
 
 ```sh
-/gh-label-bootstrap <owner>/<repo>
+/gh-label-bootstrap --repo <owner>/<repo>
 ```
 
 It reads the `pipeline|` feed in `gh-label-bootstrap/references/gh-labels.md`,

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -26,24 +26,51 @@ from moving, and a human can add or remove it at any time.
 
 Each of the four reviewer lanes (`agy`, `codex`, `opencode`, `hermes`) ends its
 output with a mandatory verdict line — `판정: [LGTM|우려있음|블로킹]` or
-`Verdict: [LGTM|CONCERNS|BLOCKING]` (`gh-pr-review/references/review-presets.md`).
-Capture each lane's raw output in Step 3, then per lane:
+`Verdict: [LGTM|CONCERNS|BLOCKING]` (`gh-pr-review/references/review-presets.md`,
+rendered at runtime by `_gh_pr_review_common_prefix` in `gh_pr_review.sh`).
+
+**Do not try to read that line out of the lane's return value.** `gh:pr-review`
+guarantees exactly one line back — `[OK] PR #<N> reviewed by <ai> … — comment:
+<URL>` — and Step 3 runs each lane as a subagent, which returns a *summary* of
+what it did. Neither carries the verdict. A gate built on that would have every
+lane parse as `unknown`, never write a label, and leave `gh:pr-merge-train`
+skipping every PR forever (PR #1529 review — agy and codex found this
+independently).
+
+Read it from the artifact the lane already wrote instead. `gh:pr-review` Step 6
+posts the reviewer's raw output to the PR wrapped in `<!-- ai-review:<ai> -->`
+markers, synchronously, before it returns — a durable machine-readable record
+rather than a summary. Fetch the comments **once**, then per lane:
 
 ```sh
 . "${SHELL_COMMON}/functions/devx_pr_review_all.sh"
-VERDICT=$(printf '%s\n' "$LANE_OUTPUT" | devx_pr_review_all_verdict)
+BODIES=$(GH_HOST="$TARGET_HOST" gh api --paginate \
+    "repos/$TARGET_REPO/issues/$pr/comments" --jq '.[].body')
+
+VERDICT=$(printf '%s\n' "$BODIES" | devx_pr_review_all_lane_block "$ai" \
+    | devx_pr_review_all_verdict)
 # -> blocking | concerns | lgtm | unknown
 ```
+
+`devx_pr_review_all_lane_block` takes the **last complete** block for that lane,
+so a re-review supersedes an earlier verdict, and it ignores an unterminated
+block — half a review is not a verdict.
+
+This is still producer-side parsing, which is the point: `devx:pr-review-all`
+reads *its own* lanes' output to mint the label. `gh:pr-merge-train` never
+parses a comment body, and a reviewer changing its format still fails closed
+here rather than unlocking the gate.
+
+**When the block is missing.** `gh:pr-review` skips the whole PR comment under
+`GH_DISABLE_AI_METRICS=1`, and `--no-post-comment` suppresses it too. Either
+way the lane yields no block → `unknown` → no label → the train skips the PR.
+That is the correct direction: with the record suppressed there is no evidence
+the review passed.
 
 A lane that **did not run** (`command -v` empty, non-internal PC, non-zero exit —
 every `[SKIP]`/`[WARN]` row of the Step 7 report) contributes **no verdict at
 all**. It is not an `unknown`; it is simply absent from the aggregation. The
 `/simplify` lane never contributes — it produces no verdict.
-
-Run all three shell blocks of Step 5 — per-lane verdict, aggregate, label — in
-**one** Bash tool call. The tool keeps no shell state between calls, so a split
-loses the sourced functions and `$VERDICTS`/`$label`, and an empty `$label`
-silently reads as "no verdict".
 
 Then aggregate over the lanes that did run. Read the two `key=value` lines with
 `sed`, not `eval` — the values are controlled, but a parser that cannot execute

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -91,7 +91,7 @@ else
     _gh_pr_edit_safe_label "$pr" "$label" --repo "$TARGET_REPO"
     case "$?" in
     0) echo "[OK] PR #$pr labelled \`$label\` (${lanes} lane(s))" ;;
-    3) echo "[WARN] label \`$label\` missing in $TARGET_REPO — bootstrap once: /gh-label-bootstrap $TARGET_REPO" ;;
+    3) echo "[WARN] label \`$label\` missing in $TARGET_REPO — bootstrap once: /gh-label-bootstrap --repo $TARGET_REPO" ;;
     *) echo "[WARN] labelling PR #$pr failed — train will treat it as unverified" ;;
     esac
 fi

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -34,9 +34,14 @@ VERDICT=$(printf '%s\n' "$LANE_OUTPUT" | devx_pr_review_all_verdict)
 ```
 
 A lane that **did not run** (`command -v` empty, non-internal PC, non-zero exit —
-every `[SKIP]`/`[WARN]` row of the Step 6 report) contributes **no verdict at
+every `[SKIP]`/`[WARN]` row of the Step 7 report) contributes **no verdict at
 all**. It is not an `unknown`; it is simply absent from the aggregation. The
 `/simplify` lane never contributes — it produces no verdict.
+
+Run all three shell blocks of Step 5 — per-lane verdict, aggregate, label — in
+**one** Bash tool call. The tool keeps no shell state between calls, so a split
+loses the sourced functions and `$VERDICTS`/`$label`, and an empty `$label`
+silently reads as "no verdict".
 
 Then aggregate over the lanes that did run. Read the two `key=value` lines with
 `sed`, not `eval` — the values are controlled, but a parser that cannot execute
@@ -113,3 +118,8 @@ couples the merge gate to every reviewer CLI's output format. A reviewer
 reformatting its verdict line would then silently *unlock* the gate. Parsing
 here means the same reformat produces `unknown`, no label, and a skipped PR:
 the failure direction is the safe one.
+
+The decisive reason, though, is that **only the producer knows which lanes
+ran**. A consumer reading comment bodies cannot tell "lane skipped" from
+"lane ran and posted nothing" — and that distinction *is* the absence-is-not-a-pass
+invariant. It is not recoverable downstream at any level of parsing care.

--- a/claude/skills/gh-label-bootstrap/SKILL.md
+++ b/claude/skills/gh-label-bootstrap/SKILL.md
@@ -65,14 +65,22 @@ continue — a single label's failure never aborts the run.
 - **`--prune` is opt-in**: without it, no label is ever deleted. With it,
   only labels outside (SSOT ∪ alias-targets ∪ allowlist) are deleted,
   computed AFTER renames (NF-1 in #1226).
+- **Pipeline-state feed (#1527)**: `references/gh-labels.md` carries a second
+  feed of `pipeline|name|color|description` rows (`review-blocked` /
+  `review-passed`, the `gh:pr-merge-train` verdict gate). It is kept apart from
+  the 10 issue-classification labels — pipeline state, no aliases — but the
+  script strips the prefix and syncs and prune-protects it alongside them,
+  because the label add path refuses to auto-create (#326) and the gate would
+  otherwise deadlock with every PR unlabelled.
 
 ## Constraints
 
 - Never mutate the script's behavior — wrap, don't rewrite.
 - `--dry-run` must make zero POST/PATCH/DELETE API calls.
 - Never delete a label unless `--prune` was explicitly passed.
-- The 10-label + alias SSOT lives only in `references/gh-labels.md` — do
-  not hardcode a second copy here or in the script.
+- The 10-label + alias + pipeline SSOT lives only in
+  `references/gh-labels.md` — do not hardcode a second copy here or in the
+  script.
 - `lib/label-bootstrap.sh` is the sole entry point; invoke it directly
   from non-Claude contexts:
   `bash claude/skills/gh-label-bootstrap/lib/label-bootstrap.sh [...]`.

--- a/claude/skills/gh-label-bootstrap/lib/label-bootstrap.sh
+++ b/claude/skills/gh-label-bootstrap/lib/label-bootstrap.sh
@@ -141,15 +141,31 @@ main() {
     resolve_repo
 
     # --- Parse SSOT plain feeds -------------------------------------------
-    # 10-label feed:  name|<6hex>|description
-    # alias feed:     old|new     (two lowercase words)
+    # 10-label feed:   name|<6hex>|description
+    # alias feed:      old|new     (two lowercase words)
+    # pipeline feed:   pipeline|name|<6hex>|description   (#1527)
     # tr -d '\r' + leading-whitespace tolerance guard against CRLF checkouts
     # and incidental fence indentation (gemini-code-assist review, PR #1229).
-    local feed alias_feed ssot_content
+    local feed alias_feed pipeline_feed ssot_content
     ssot_content="$(tr -d '\r' <"$ssot_file")"
     feed="$(printf '%s\n' "$ssot_content" | grep -E '^[[:space:]]*[A-Za-z][A-Za-z0-9]*\|[0-9a-fA-F]{6}\|' || true)"
     alias_feed="$(printf '%s\n' "$ssot_content" | grep -E '^[[:space:]]*[a-z]+\|[a-z]+$' || true)"
     [ -n "$feed" ] || die "no label feed found in $ssot_file"
+
+    # Pipeline-state labels (#1527) — a separate feed, not part of the 10-label
+    # SSOT: they carry pipeline state (the merge-train verdict gate), not issue
+    # classification, and they have no aliases. They are still synced and
+    # prune-protected here, because `_gh_pr_edit_safe_label` refuses to
+    # auto-create a missing label (#326) — with no bootstrap path the gate
+    # deadlocks, leaving every PR unlabelled and therefore `[SKIPPED]` forever.
+    # The `pipeline|` prefix is what keeps the two feeds apart; it is stripped
+    # before the rows join `$feed`, so the sync loop below needs no change.
+    # The feed is optional: an SSOT without it is not an error.
+    pipeline_feed="$(printf '%s\n' "$ssot_content" |
+        sed -n -E 's/^[[:space:]]*pipeline\|([a-z][a-z0-9-]*\|[0-9a-fA-F]{6}\|.*)$/\1/p' || true)"
+    if [ -n "$pipeline_feed" ]; then
+        feed="$(printf '%s\n%s' "$feed" "$pipeline_feed")"
+    fi
 
     # SSOT label names (for keep-set membership).
     local ssot_names

--- a/claude/skills/gh-label-bootstrap/lib/label-bootstrap.sh
+++ b/claude/skills/gh-label-bootstrap/lib/label-bootstrap.sh
@@ -11,8 +11,9 @@ set -euo pipefail
 #
 # Behavior (see references/gh-labels.md for the authoritative spec):
 #   1. Alias renames first  — PATCH old -> new_name (preserves issue/PR links).
-#   2. SSOT 10 apply         — PATCH if exists (force color/description sync),
-#                              POST if missing.
+#   2. SSOT apply            — PATCH if exists (force color/description sync),
+#                              POST if missing. Covers the 10-label feed and
+#                              the pipeline-state feed (#1527) alike.
 #   3. Prune (only --prune)  — DELETE labels outside SSOT ∪ alias-targets ∪
 #                              allowlist, computed AFTER renames.
 #
@@ -152,20 +153,14 @@ main() {
     alias_feed="$(printf '%s\n' "$ssot_content" | grep -E '^[[:space:]]*[a-z]+\|[a-z]+$' || true)"
     [ -n "$feed" ] || die "no label feed found in $ssot_file"
 
-    # Pipeline-state labels (#1527) — a separate feed, not part of the 10-label
-    # SSOT: they carry pipeline state (the merge-train verdict gate), not issue
-    # classification, and they have no aliases. They are still synced and
-    # prune-protected here, because `_gh_pr_edit_safe_label` refuses to
-    # auto-create a missing label (#326) — with no bootstrap path the gate
-    # deadlocks, leaving every PR unlabelled and therefore `[SKIPPED]` forever.
-    # The `pipeline|` prefix is what keeps the two feeds apart; it is stripped
-    # before the rows join `$feed`, so the sync loop below needs no change.
-    # The feed is optional: an SSOT without it is not an error.
+    # Pipeline-state labels (#1527) — kept in their own feed (rationale and
+    # rollout: references/gh-labels.md, "파이프라인 상태 라벨"). Stripping the
+    # `pipeline|` prefix normalizes the rows to the shape above, so they join
+    # `$feed` and inherit the sync loop, the keep-set and prune protection
+    # unchanged. Optional: an SSOT without the feed is not an error.
     pipeline_feed="$(printf '%s\n' "$ssot_content" |
-        sed -n -E 's/^[[:space:]]*pipeline\|([a-z][a-z0-9-]*\|[0-9a-fA-F]{6}\|.*)$/\1/p' || true)"
-    if [ -n "$pipeline_feed" ]; then
-        feed="$(printf '%s\n%s' "$feed" "$pipeline_feed")"
-    fi
+        sed -n -E 's/^[[:space:]]*pipeline\|([a-z][a-z0-9-]*\|[0-9a-fA-F]{6}\|.*)$/\1/p')"
+    feed="$(printf '%s\n%s' "$feed" "$pipeline_feed")"
 
     # SSOT label names (for keep-set membership).
     local ssot_names
@@ -209,7 +204,7 @@ main() {
         fi
     done <<<"$alias_feed"
 
-    # --- 2. SSOT 10 apply --------------------------------------------------
+    # --- 2. SSOT apply -----------------------------------------------------
     local name
     while IFS='|' read -r name color desc; do
         [ -z "$name" ] && continue

--- a/claude/skills/gh-label-bootstrap/references/gh-labels.md
+++ b/claude/skills/gh-label-bootstrap/references/gh-labels.md
@@ -17,7 +17,11 @@ dotfiles 저장소를 포함한 임의의 GitHub repo 에 적용할 **10개 핵�
   (`.gh-issue-defaults.yml` 매핑), `gh:issue-implement`
   (`reference` 라벨 차단), `gh:pr` (커밋타입 → 라벨 매핑).
 - 범위 밖: `CI fail`(`gh:pr-resolve-ci-fail`), `conflict`
-  (`gh:pr-resolve-conflict`) 등 별개 라벨 체계는 건드리지 않는다.
+  (`gh:pr-resolve-conflict`), `review-blocked`/`review-passed`
+  (`devx:pr-review-all` → `gh:pr-merge-train` 머지 게이트, #1527) 등
+  **파이프라인 상태** 라벨 체계는 건드리지 않는다 — 이슈 분류 라벨이 아니고,
+  `gh:label-bootstrap` 이 동기화하지도 않는다. 각 라벨의 SSOT 는 그것을
+  발급하는 스킬의 references 에 있다.
 
 차용 근거 / 설계 논의: issue #1226.
 

--- a/claude/skills/gh-label-bootstrap/references/gh-labels.md
+++ b/claude/skills/gh-label-bootstrap/references/gh-labels.md
@@ -20,11 +20,8 @@ dotfiles 저장소를 포함한 임의의 GitHub repo 에 적용할 **10개 핵�
   (`gh:pr-resolve-conflict`) 등 **파이프라인 상태** 라벨은 10개 이슈 분류
   라벨에 포함되지 않는다 — 각 라벨의 SSOT 는 그것을 발급하는 스킬의
   references 에 있다.
-- 예외적으로 `review-blocked` / `review-passed` (`devx:pr-review-all` →
-  `gh:pr-merge-train` 머지 게이트, #1527) 는 파이프라인 라벨이면서도 아래
-  "파이프라인 상태 라벨" feed 로 **함께 동기화한다**. 라벨이 없으면 게이트가
-  영구 교착이라(자동 생성 금지, #326) 부트스트랩 경로가 반드시 필요하기
-  때문이다. 10개 SSOT 에 편입하는 것이 아니라 별도 feed 로 나란히 둔다.
+- 단, `review-blocked` / `review-passed` (#1527) 는 10개 SSOT 에 편입하지 않은
+  채 아래 "파이프라인 상태 라벨" feed 로 **함께 동기화한다** — 이유는 그 절에.
 
 차용 근거 / 설계 논의: issue #1226.
 

--- a/claude/skills/gh-label-bootstrap/references/gh-labels.md
+++ b/claude/skills/gh-label-bootstrap/references/gh-labels.md
@@ -17,11 +17,14 @@ dotfiles 저장소를 포함한 임의의 GitHub repo 에 적용할 **10개 핵�
   (`.gh-issue-defaults.yml` 매핑), `gh:issue-implement`
   (`reference` 라벨 차단), `gh:pr` (커밋타입 → 라벨 매핑).
 - 범위 밖: `CI fail`(`gh:pr-resolve-ci-fail`), `conflict`
-  (`gh:pr-resolve-conflict`), `review-blocked`/`review-passed`
-  (`devx:pr-review-all` → `gh:pr-merge-train` 머지 게이트, #1527) 등
-  **파이프라인 상태** 라벨 체계는 건드리지 않는다 — 이슈 분류 라벨이 아니고,
-  `gh:label-bootstrap` 이 동기화하지도 않는다. 각 라벨의 SSOT 는 그것을
-  발급하는 스킬의 references 에 있다.
+  (`gh:pr-resolve-conflict`) 등 **파이프라인 상태** 라벨은 10개 이슈 분류
+  라벨에 포함되지 않는다 — 각 라벨의 SSOT 는 그것을 발급하는 스킬의
+  references 에 있다.
+- 예외적으로 `review-blocked` / `review-passed` (`devx:pr-review-all` →
+  `gh:pr-merge-train` 머지 게이트, #1527) 는 파이프라인 라벨이면서도 아래
+  "파이프라인 상태 라벨" feed 로 **함께 동기화한다**. 라벨이 없으면 게이트가
+  영구 교착이라(자동 생성 금지, #326) 부트스트랩 경로가 반드시 필요하기
+  때문이다. 10개 SSOT 에 편입하는 것이 아니라 별도 feed 로 나란히 둔다.
 
 차용 근거 / 설계 논의: issue #1226.
 
@@ -91,7 +94,7 @@ GitHub 기본 제공 라벨은 삭제 후보에서 제외한다:
 
 ## Plain feed (스킬이 직접 파싱)
 
-`gh:label-bootstrap` 의 `lib/label-bootstrap.sh` 가 아래 두 블록을
+`gh:label-bootstrap` 의 `lib/label-bootstrap.sh` 가 아래 세 블록을
 정규식으로 뽑아 쓴다. 표(위)와 값이 어긋나면 안 되므로 이 블록이 유일한
 기계 판독 소스다.
 
@@ -116,6 +119,21 @@ reference|0e8a8a|구현 불필요/참고용 — gh:issue-implement가 구현을 
 bug|fix
 documentation|docs
 build|chore
+```
+
+### 파이프라인 상태 라벨 (`pipeline|name|color|description`)
+
+10개 라벨과 **별개 체계**다 — 이슈 분류가 아니라 파이프라인 상태를 나타내고,
+alias 도 없다. 그래도 `gh:label-bootstrap` 이 함께 동기화하고 `--prune` 에서
+보존한다: `_gh_pr_edit_safe_label` 은 없는 라벨을 자동 생성하지 않으므로(#326),
+부트스트랩 경로가 없으면 `gh:pr-merge-train` 의 판정 게이트가 영구 교착에
+빠진다 — 모든 PR 이 라벨 없이 남아 전부 `[SKIPPED]` 된다 (#1527, PR #1529 codex 리뷰).
+
+`pipeline|` 접두어가 10개 라벨 feed 와 구분하는 표지다.
+
+```
+pipeline|review-blocked|b60205|리뷰 레인 중 하나 이상이 블로킹 판정 — 머지 금지 (#1527)
+pipeline|review-passed|0e8a16|실행된 모든 리뷰 레인이 통과 판정 — 머지 게이트 통과 (#1527)
 ```
 
 ## Related

--- a/claude/skills/gh-label-bootstrap/references/help.md
+++ b/claude/skills/gh-label-bootstrap/references/help.md
@@ -16,25 +16,29 @@ single SSOT script at `lib/label-bootstrap.sh`.
 |---|---|---|
 | `--repo <owner/repo>` | Target repository | auto from `gh repo view` |
 | `--dry-run` | Print the plan (rename/PATCH/POST/prune) without mutations | off |
-| `--prune` | DELETE labels outside SSOT ∪ alias-targets ∪ allowlist | off (never deletes) |
+| `--prune` | DELETE labels outside SSOT (10-label + pipeline feeds) ∪ alias-targets ∪ allowlist | off (never deletes) |
 | `-h`, `--help`, `help` | Show this help | — |
 
 ## What the skill does
 
 1. Parses the plain-feed blocks in `references/gh-labels.md` (10 labels +
-   3 alias renames) — the one physical SSOT feed. No second hardcoded copy.
+   3 alias renames + the pipeline-state feed) — the one physical SSOT. No
+   second hardcoded copy.
 2. **Alias renames first**: for `bug->fix`, `documentation->docs`,
    `build->chore`, if the old name exists it is renamed via
    `PATCH .../labels/{old} new_name={new}` (color/description synced in the
    same call). Renaming preserves the label on every issue/PR already
    carrying it — delete+recreate would drop it. If the old name is absent,
    the rename is skipped and the new name is created directly (not an error).
-3. **SSOT 10 apply**: each of `feat`, `fix`, `docs`, `refactor`, `test`,
+3. **SSOT apply**: each of `feat`, `fix`, `docs`, `refactor`, `test`,
    `ci`, `chore`, `skill`, `TODO`, `reference` is PATCHed (color +
-   description synced) if it exists, or POSTed if it does not.
+   description synced) if it exists, or POSTed if it does not. The
+   pipeline-state labels `review-blocked` / `review-passed` (#1527) ride the
+   same loop from their own `pipeline|` feed.
 4. **Prune** (only with `--prune`): labels outside
-   (SSOT 10) ∪ (alias targets `fix`/`docs`/`chore`) ∪ (GitHub default
-   allowlist) are DELETEd. Evaluated AFTER renames, so an alias source like
+   (SSOT 10) ∪ (pipeline feed) ∪ (alias targets `fix`/`docs`/`chore`) ∪
+   (GitHub default allowlist) are DELETEd — the pipeline labels are
+   prune-protected, or the merge-train gate would lose its vocabulary. Evaluated AFTER renames, so an alias source like
    `bug` is never a false-positive candidate. Without `--prune` this step
    is skipped entirely — no listing, no deletes.
 

--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -52,8 +52,19 @@ D-6 quiet period — the exact same function
 `shell-common/tools/custom/pr_merge_train_cron.sh` runs, so the two can never
 disagree. **Do not re-implement or paraphrase that filter here** — run it.
 
+**Review verdict gate (#1527)** — then drop every PR carrying `review-blocked`, and
+every PR carrying **neither** verdict label; both are `[SKIPPED]` with a reason, cost
+no attempt, and are retriable next tick. **Absence is a skip, not a pass** — conflating
+"not reviewed" with "review passed" is what let PR #1518 merge over two blocking
+verdicts. Decision table and rationale: `references/review-verdict-gate.md`.
+
+This gate is separate from the shared filter above and runs after it. The two
+answer different questions — `reply-pending` is "is the reply pass still
+running" (#1524, a *timing* signal), the verdict labels are "did review pass"
+(#1527, a *content* signal) — and a PR must clear both.
+
 Sort the surviving array `CLEAN` → `BEHIND` → `UNSTABLE` → `DIRTY`, ties by
-ascending PR number (D-2). Ordering, the label, and the quiet-period rationale:
+ascending PR number (D-2). Ordering, the labels, and the quiet-period rationale:
 `references/ordering.md`.
 
 **`gh pr list` failure ends the run** with an empty report — never merge
@@ -100,13 +111,15 @@ assistant text, never via a `Bash` heredoc or `Write`.
   `required_linear_history` allows (D-4).
 - **No review judgement of its own** — `gh:issue-flow` already ran
   `devx:pr-review-all`, and the gate-off path delegates to `gh:pr-approve`
-  rather than deciding anything here.
+  rather than deciding anything here. The train only *reads* that review run's
+  verdict label, and never parses a review comment body (#1527).
 - **No ai-metrics comment.** Every atom the train calls posts its own; a
   train-level one would only duplicate them on the same PR.
 - Full list: `references/constraints.md`.
 
 ## Related Skills
 
+Producer of the verdict label this train gates on: `devx:pr-review-all` (#1527).
 Atoms this train calls: `gh:pr-resolve-outdated` · `gh:pr-resolve-conflict`
 · `gh:pr-resolve-ci-fail` · `gh:pr-approve` (`--self-record`, gate-off path
 only) · `gh:pr-merge`. Deliberately **not** called:

--- a/claude/skills/gh-pr-merge-train/references/constraints.md
+++ b/claude/skills/gh-pr-merge-train/references/constraints.md
@@ -55,6 +55,21 @@ train only routes on the answer. The constraint it preserves is the real one —
 It also does not duplicate Step 2.4: a self-record review runs at most once per
 head (`#1519 F-8`), and only on PRs the platform leaves ungated.
 
+What the train *does* do is read that run's verdict, as the `review-blocked` /
+`review-passed` label it left behind (#1527, `review-verdict-gate.md`). Reading
+a label is not reviewing. **Never parse a review comment body to reach the same
+answer**: the verdict is parsed once, by the producer, so that a reviewer
+changing its output format makes the gate fail *closed* (no label, PR skipped)
+instead of silently unlocking it.
+
+## Never treat an unlabelled PR as reviewed
+
+A PR with neither verdict label has not been shown to pass review, and is
+`[SKIPPED]` (#1527). Promoting "not checked" to "passed" — by defaulting, by a
+time backstop, or by an env-var escape hatch — reinstates the exact hole that
+let PR #1518 merge over two blocking verdicts. The escape hatch is a human
+adding the label, deliberately, one PR at a time.
+
 ## Never write ai-metrics from the train
 
 Every atom the train calls (`gh:pr-merge`, `gh:pr-resolve-conflict`, …) posts

--- a/claude/skills/gh-pr-merge-train/references/report-format.md
+++ b/claude/skills/gh-pr-merge-train/references/report-format.md
@@ -12,9 +12,10 @@ queue: <n> PR(s)  ·  approval gate: <verdict>  ·  quiet period: 11m
 [MERGED]  #1466  refactor(issue-watcher): simplify   (BEHIND -> resolve-outdated -> merged)
 [MERGED]  #1467  fix(gh-pr-reply): ...               (CLEAN -> merged)
 [SKIPPED] #1462  test(issue-watcher): ...            checks still running (3 polls)
+[SKIPPED] #1468  feat(y): ...                        review not verified — no review-passed label
 [FAILED]  #1469  feat(x): ...                        conflict unresolved after 3 attempts
 
-merged 2 · skipped 1 · failed 1
+merged 2 · skipped 2 · failed 1
 ```
 
 Rules:
@@ -31,6 +32,10 @@ Rules:
 - A PR that entered the queue and *then* picked up `reply-pending` (the label
   can be added mid-run) is a normal `[SKIPPED]` line with
   `reply-pending — review reply not yet complete` as its reason.
+- The **review verdict gate** (#1527) is the one exception among the Step 2
+  filters: a PR it drops **is** listed as `[SKIPPED]`, because unlike a draft
+  or a `reply-pending` PR it is a real candidate whose only problem is a label
+  a human can flip.
 
 ## The `approval gate:` field (#1519 NF-1)
 
@@ -57,7 +62,7 @@ is already the clause prefix there, so it drops out of the string itself:
 | Status | Meaning | Typical reason |
 |---|---|---|
 | `[MERGED]` | the PR is merged | — |
-| `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `policy unreadable — approval assumed required`, `BLOCKED: <rule>`, `draft`, plus the four delegated-review reasons tabled below |
+| `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `policy unreadable — approval assumed required`, `review-blocked — reviewer verdict is blocking`, `review not verified — no review-passed label`, `BLOCKED: <rule>`, `draft`, plus the four delegated-review reasons tabled below |
 | `[FAILED]` | not merged, **and something actually went wrong** | `conflict unresolved after 3 attempts`, `gh:pr-merge failed: <message>`, `CI fix failed after 3 attempts` |
 
 Two of those reasons — `gh:pr-merge refuses reviewDecision=<value>` and

--- a/claude/skills/gh-pr-merge-train/references/review-verdict-gate.md
+++ b/claude/skills/gh-pr-merge-train/references/review-verdict-gate.md
@@ -1,0 +1,83 @@
+# gh:pr-merge-train — Review verdict gate (issue #1527)
+
+The train's hard gate on whether **review** passed, as opposed to whether CI
+passed. Producer and SSOT for the labels:
+`devx-pr-review-all/references/review-verdict-label.md`.
+
+## Why this gate exists
+
+Before #1527 the train's real merge condition was:
+
+```
+CI green + not draft + not CONFLICTING + quiet period 11m
+```
+
+Nothing in it expressed "a reviewer approved". All three layers that could have
+were empty at once — the repo ruleset asks for `required_approving_review_count=0`,
+the board `Approved` gate was retired in #1513 (it permanently blocked
+self-authored PRs), and `gh:pr-approve` cannot approve a self-authored PR at all.
+`devx:pr-review-all` did produce verdicts, but only as prose inside a PR comment.
+
+Result, measured on PR #1518: two independent lanes posted `판정: 블로킹`, and the
+PR merged 32 minutes later with 5 BLOCKERs, needing a tracking issue (#1520) and a
+follow-up PR (#1522) to undo. Defects CI cannot see — a rebase onto the wrong
+branch, a hardcoded remote, unvalidated input reaching a skip-permissions prompt,
+prefix matching with no path boundary — passed the entire pipeline unchallenged.
+
+## The gate
+
+Applied in **Step 2, at queue construction** — before ordering, before the
+approval-gate lookup, before any remediation is attempted. `gh pr list` must
+therefore request `labels` in its `--json` field set.
+
+| labels on the PR | queue decision |
+|---|---|
+| `review-blocked` present | `[SKIPPED] review-blocked — reviewer verdict is blocking` |
+| neither label | `[SKIPPED] review not verified — no review-passed label` |
+| `review-passed` present (and not `review-blocked`) | stays in the queue |
+
+`review-blocked` wins when both are somehow present: a stale `review-passed` that
+a later blocking review failed to clear must not outrank the block.
+
+**Absence is a skip, not a pass.** A PR nobody reviewed and a PR that passed
+review are different states, and treating them alike is exactly the hole this
+gate closes. This is also what makes the gate free of a time backstop (contrast
+#1524's `reply-pending`): nothing merges on a timer, so nothing needs one.
+
+## Why it is a `[SKIPPED]` and costs no attempt
+
+Same shape as the `reviewDecision` pre-check in `train-loop.md` → "Gates
+`gh:pr-merge` owns": the condition is deterministic, so delegating to a
+remediation atom would burn all three F-5 attempts to arrive at a `[FAILED]` the
+train has no way to clear. It is recorded up front, without delegating, and the
+next tick re-evaluates it from scratch.
+
+It is retriable by design, and cheaply:
+
+- `gh:pr-reply` removes `review-blocked` once it has actually pushed fixes for
+  the blockers, and re-review re-labels the PR.
+- A human can add `review-passed` or remove `review-blocked` with one click at
+  any time. That is the escape hatch, and it is deliberately manual.
+
+## What this gate does NOT do
+
+- **It never parses comment bodies.** The verdict is read once, by the producer,
+  at labelling time (`devx:pr-review-all` Step 5). If the train grepped comments
+  instead, a reviewer reformatting its verdict line would silently *unlock* the
+  gate; with the label, the same reformat yields no label and a skipped PR.
+- **It does not replace the approval gate.** `approval-gate.md` reads the repo's
+  rulesets and classic branch protection — platform policy. This gate reads the
+  pipeline's own review result. Both apply; either can skip a PR.
+- **It does not replace the gate-off delegated review** (#1519 D-3,
+  `train-loop.md` → "Delegated review on the gate-off path"). That runs later,
+  per PR, and asks `gh:pr-approve` for a fresh judgement when the platform
+  imposes no rule. This gate runs earlier, at queue construction, and only
+  *reads* a verdict `devx:pr-review-all` already reached. They compose: a PR
+  this gate drops never reaches the delegated review at all, which is the cheap
+  ordering — a blocking verdict is already known, so paying for a second
+  opinion to rediscover it would be waste.
+- **It does not resurrect the board `Approved` gate** (#1513). The signal is the
+  review *execution result*, not a human's board move — which is the distinction
+  that keeps self-authored PRs from being permanently stuck.
+- **It changes nothing for a manual single `gh:pr-merge`.** That skill does not
+  read these labels; a deliberate human merge is unaffected.

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -221,6 +221,12 @@ with the specific cause.** One of them matters here:
 Reporting that as a bare `[FAILED]` tells the reader nothing they can act on;
 naming the `reviewDecision` value tells them exactly what to dismiss.
 
+The **review verdict gate** (`review-verdict-gate.md`, #1527) has the same shape
+but is not `gh:pr-merge`'s: it is applied earlier, in Step 2's queue
+construction, so a `review-blocked` or unlabelled PR never reaches this loop at
+all. Like the row above it is `[SKIPPED]`, costs no attempt, and is retriable the
+moment the label changes.
+
 The projectV2 board Status is **not** one of these gates. `gh:pr-merge`'s
 Step 2-B board check was removed in #1513, so a card sitting outside `Approved`
 — which is the normal state for a PR `gh:issue-flow` just opened — is no longer
@@ -276,6 +282,7 @@ skill was called and nothing was changed.
 | `gh:pr-merge` | that PR is `[FAILED]`; next PR |
 | approval gate | that PR is `[SKIPPED]`; next PR |
 | the step-2b delegated review (withheld, suppressed, board unreadable, or the `gh:pr-approve` call itself) | that PR is `[SKIPPED]` with the matching reason; **no attempt is spent**; next PR |
+| review verdict gate (`review-blocked`, or neither label) | that PR is `[SKIPPED]` at queue construction; **no attempt is spent** |
 | a `gh:pr-merge` gate detected up front (`reviewDecision`) | that PR is `[SKIPPED]` with the cause named; **no attempt is spent** |
 | `gh pr view` on one PR | that PR is `[SKIPPED] state unreadable`; next PR |
 | `gh pr list` in Step 2 | **the run ends** — with no queue there is nothing to skip *to*, and merging without knowing state is the one thing this skill must never do |

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -81,10 +81,11 @@ asked) and report new commit SHAs alongside the reply summary. Set
 `PUSHED_FIXES` to the count of new SHAs on the remote branch; no fixes /
 skipped push → `PUSHED_FIXES=0`. If `PUSHED_FIXES > 0`, push the PR card
 back to `In review` per `references/board-sync-in-review.sh.md` (soft-fail;
-no-op when `PUSHED_FIXES == 0`). Then, if `PUSHED_FIXES > 0` **and**
-`ACCEPTED_COUNT > 0` **and** `DECLINED_COUNT == 0`, clear `review-blocked` per
-`references/review-blocked-clear.sh.md` (#1527, soft-fail) — never adding
-`review-passed`: fixing a blocker returns the PR to *unverified*.
+no-op when `PUSHED_FIXES == 0`). Then retire the stale verdict labels per
+`references/review-blocked-clear.sh.md` (#1527, soft-fail): any push drops
+`review-passed` (the head it certified is gone), and `review-blocked` drops only
+when `ACCEPTED_COUNT > 0` **and** `DECLINED_COUNT == 0`. Never *add* a label —
+clearing returns the PR to *unverified*, and only a re-review can mark it passed.
 
 Then **unconditionally** run the same removal block Step 2.5 does —
 `references/reply-pending-label-removal.sh.md`. Between the two call sites the

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -63,7 +63,8 @@ rules; see `references/reply-templates.md` for the full rubric.
 
 Keep each fix minimal and scoped — no drive-by refactors. Group related
 fixes into themed commits (one per theme, not per comment), e.g.
-`fix(review): address X …`. Never `--amend` or `--no-verify`.
+`fix(review): address X …`. Never `--amend` or `--no-verify`. Set `ACCEPTED_COUNT`
+to the number of `ACCEPT`/`ACCEPT-PARTIAL` comments — Step 6 gates on it.
 
 ## Step 5: Reply to Every Comment
 
@@ -79,7 +80,10 @@ asked) and report new commit SHAs alongside the reply summary. Set
 `PUSHED_FIXES` to the count of new SHAs on the remote branch; no fixes /
 skipped push → `PUSHED_FIXES=0`. If `PUSHED_FIXES > 0`, push the PR card
 back to `In review` per `references/board-sync-in-review.sh.md` (soft-fail;
-no-op when `PUSHED_FIXES == 0`).
+no-op when `PUSHED_FIXES == 0`). Then, if `PUSHED_FIXES > 0` **and** `ACCEPTED_COUNT
+> 0`, clear `review-blocked` per `references/review-blocked-clear.sh.md` (#1527,
+soft-fail) — never adding `review-passed`: fixing a blocker returns the PR to
+*unverified*.
 
 Then **unconditionally** run the same removal block Step 2.5 does —
 `references/reply-pending-label-removal.sh.md`. Between the two call sites the
@@ -99,8 +103,8 @@ Answered counts, commit SHAs, skipped comments, and the lingering
 Read `references/constraints.md`. Non-negotiables: never skip a reply (bot
 comments included), never promote the card to `Approved` (owned by
 `gh:pr-approve`, #1350), never resolve threads programmatically, never
-`--amend` / `--no-verify` / force-push, and route label/body edits through
-`_gh_pr_edit_safe_*`.
+`--amend` / `--no-verify` / force-push, never add `review-passed` (#1527), and
+route label/body edits through `_gh_pr_edit_safe_*`.
 
 ## Related Skills
 

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -64,7 +64,8 @@ rules; see `references/reply-templates.md` for the full rubric.
 Keep each fix minimal and scoped — no drive-by refactors. Group related
 fixes into themed commits (one per theme, not per comment), e.g.
 `fix(review): address X …`. Never `--amend` or `--no-verify`. Set `ACCEPTED_COUNT`
-to the number of `ACCEPT`/`ACCEPT-PARTIAL` comments — Step 6 gates on it.
+and `DECLINED_COUNT` to the number of `ACCEPT`/`ACCEPT-PARTIAL` and `DECLINE`
+comments this run — Step 6 gates the `review-blocked` clear on both.
 
 ## Step 5: Reply to Every Comment
 
@@ -80,10 +81,10 @@ asked) and report new commit SHAs alongside the reply summary. Set
 `PUSHED_FIXES` to the count of new SHAs on the remote branch; no fixes /
 skipped push → `PUSHED_FIXES=0`. If `PUSHED_FIXES > 0`, push the PR card
 back to `In review` per `references/board-sync-in-review.sh.md` (soft-fail;
-no-op when `PUSHED_FIXES == 0`). Then, if `PUSHED_FIXES > 0` **and** `ACCEPTED_COUNT
-> 0`, clear `review-blocked` per `references/review-blocked-clear.sh.md` (#1527,
-soft-fail) — never adding `review-passed`: fixing a blocker returns the PR to
-*unverified*.
+no-op when `PUSHED_FIXES == 0`). Then, if `PUSHED_FIXES > 0` **and**
+`ACCEPTED_COUNT > 0` **and** `DECLINED_COUNT == 0`, clear `review-blocked` per
+`references/review-blocked-clear.sh.md` (#1527, soft-fail) — never adding
+`review-passed`: fixing a blocker returns the PR to *unverified*.
 
 Then **unconditionally** run the same removal block Step 2.5 does —
 `references/reply-pending-label-removal.sh.md`. Between the two call sites the

--- a/claude/skills/gh-pr-reply/references/constraints.md
+++ b/claude/skills/gh-pr-reply/references/constraints.md
@@ -9,6 +9,14 @@
   change `reviewDecision`, so promoting on them lands unreviewed PRs in
   `Approved` (#1349 regression). The Step 6 `In review` recovery is the only
   board write this skill performs.
+- **Never add `review-passed`, and only clear `review-blocked` after actually
+  pushing an accepted fix** (#1527). `devx:pr-review-all` owns both labels;
+  this skill's single write is releasing the block once `PUSHED_FIXES > 0` and
+  at least one comment was `ACCEPT`/`ACCEPT-PARTIAL`
+  (`references/review-blocked-clear.sh.md`). Clearing it on an all-`DECLINE`
+  run would let a skill overrule a blocking verdict on its own reasoning; adding
+  `review-passed` would let the act of fixing certify the fix. A human removing
+  the label by hand is the intended override.
 - Never close or resolve threads programmatically — leave that to the user.
 - Never fix files outside the PR's diff without flagging scope creep first.
 - Never `--amend`, `--no-verify`, or `--force-push`. If a history rewrite is

--- a/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
+++ b/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
@@ -1,0 +1,63 @@
+# gh:pr-reply Step 6.6 — Clear the `review-blocked` label (#1527)
+
+Called from `SKILL.md` Step 6.6, after Step 6.5's board sync. `devx:pr-review-all`
+labels a PR `review-blocked` when any reviewer lane returned a blocking verdict,
+and `gh:pr-merge-train` refuses to merge while that label is on
+(`gh-pr-merge-train/references/review-verdict-gate.md`). This step is what
+releases it once the blockers have actually been addressed.
+
+## When it runs
+
+Only when **Step 6 pushed at least one fix commit** (`PUSHED_FIXES > 0`) **and**
+at least one comment this run was classified `ACCEPT` or `ACCEPT-PARTIAL`. Both
+halves matter:
+
+- No push → nothing changed on the branch, so the blocking verdict still stands
+  as written. All-`DECLINE` / all-`QUESTION` runs leave the label alone.
+- A push with no accepted comment (an unrelated commit that happened to land)
+  is not evidence a blocker was fixed.
+
+Declining a blocker is a legitimate outcome — but it is a **human's** call to
+override the gate, made by removing the label by hand. A skill that cleared it
+on its own reasoning would be marking its own homework.
+
+## What it does NOT do
+
+It never adds `review-passed`. Clearing the block returns the PR to the
+*unverified* state, not to a passing one — the train still skips it until a
+fresh `devx:pr-review-all` run re-reviews the pushed fixes and re-labels. That
+asymmetry is deliberate: a fix that introduces a new blocker must be caught by
+review, not waved through by the act of fixing.
+
+## The block
+
+Soft-fail — warn on any error, never block the Step 7 report.
+Use REST `DELETE`, **not `gh pr edit --remove-label`** — the latter silently
+exits 1 on repos with classic Projects attached (#326 Bug B, the same
+deprecation `_gh_pr_edit_safe_label` exists to absorb on the add path).
+A 404 means the label was already absent, which is success for this step's
+purposes — hence the idempotent `||` branch.
+
+```bash
+if [ "${PUSHED_FIXES:-0}" -gt 0 ] && [ "${ACCEPTED_COUNT:-0}" -gt 0 ]; then
+    if GH_HOST="$TARGET_HOST" gh api -X DELETE \
+        "repos/$TARGET_REPO/issues/$PR_NUMBER/labels/review-blocked" \
+        >/dev/null 2>&1; then
+        echo "[OK] \`review-blocked\` 라벨 제거됨 — 재리뷰 후 \`review-passed\` 가 붙어야 머지 가능 (#1527)"
+    else
+        echo "[WARN] \`review-blocked\` 라벨 제거 실패 또는 이미 없음 — 머지가 막히면 수동 확인"
+    fi
+fi
+```
+
+`gh api` takes no `--repo` flag, so the repo goes in the path (#658), and
+`GH_HOST="$TARGET_HOST"` pins the server — without it a dual-host login deletes
+a label on the wrong GitHub server with no error (#1403 / #1407). Step 1 bound
+both from the `[remote]`'s URL.
+
+## Re-review is the caller's job
+
+`gh:pr-reply` does not re-dispatch the reviewers; it has no reviewer lanes.
+On the `gh:issue-flow` path the operator (or the next `devx:pr-review-all` run)
+supplies the re-review. Until then the PR sits unlabelled and the train skips
+it — the fail-closed direction.

--- a/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
+++ b/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
@@ -1,4 +1,4 @@
-# gh:pr-reply Step 6.6 — Clear the `review-blocked` label (#1527)
+# gh:pr-reply Step 6.6 — Retire the stale verdict labels (#1527)
 
 Called from `SKILL.md` Step 6.6, after Step 6.5's board sync. `devx:pr-review-all`
 labels a PR `review-blocked` when any reviewer lane returned a blocking verdict,
@@ -28,13 +28,27 @@ Declining a blocker is a legitimate outcome — but overriding the gate is a
 **human's** call, made by removing the label by hand. A skill that cleared it on
 its own reasoning would be marking its own homework.
 
-## What it does NOT do
+## Two different labels, two different rules
 
-It never adds `review-passed`. Clearing the block returns the PR to the
-*unverified* state, not to a passing one — the train still skips it until a
-fresh `devx:pr-review-all` run re-reviews the pushed fixes and re-labels. That
-asymmetry is deliberate: a fix that introduces a new blocker must be caught by
-review, not waved through by the act of fixing.
+`review-passed` and `review-blocked` are not symmetric, because they fail in
+opposite directions.
+
+**`review-passed` is dropped on ANY push** (`PUSHED_FIXES > 0`), unconditionally.
+The label certifies *a reviewed head*, and a push replaces that head with one
+nobody has reviewed. Leaving it on means the merge train's gate reads a pass
+that no longer refers to the code it is about to merge — the exact hole the gate
+exists to close (PR #1529 review, codex; the PR description had already flagged
+it as a known gap, which is a second independent signal).
+
+The cost is real and accepted: an unattended flow stalls whenever the reply pass
+edits anything, until a fresh `devx:pr-review-all` re-labels. That is the same
+trade the gate makes everywhere else — a stall is cheap and a human clears it
+with one label; an unreviewed merge is not.
+
+**`review-blocked` is dropped only on evidence the blockers were addressed** —
+the three conditions below. Nothing here ever *adds* a label: clearing returns
+the PR to *unverified*, never to passing. Only a re-review can mint
+`review-passed`, so a fix that introduces a new blocker is still caught.
 
 ## The block
 
@@ -45,15 +59,35 @@ deprecation `_gh_pr_edit_safe_label` exists to absorb on the add path).
 A 404 means the label was already absent, which is success for this step's
 purposes — hence the idempotent `||` branch.
 
+`pr_drop_label` treats a 404 as success — the label was already absent, which is
+this step's desired end state, not a failure. Only a real error warns
+(PR #1529 review, agy). `-i` keeps the status line that `gh api` otherwise
+collapses into a bare non-zero exit, the same technique `gh-pr-merge-train`'s
+`approval-gate.md` uses.
+
 ```bash
-if [ "${PUSHED_FIXES:-0}" -gt 0 ] && [ "${ACCEPTED_COUNT:-0}" -gt 0 ] \
-    && [ "${DECLINED_COUNT:-0}" -eq 0 ]; then
-    if GH_HOST="$TARGET_HOST" gh api -X DELETE \
-        "repos/$TARGET_REPO/issues/$PR_NUMBER/labels/review-blocked" \
-        >/dev/null 2>&1; then
-        echo "[OK] \`review-blocked\` 라벨 제거됨 — 재리뷰 후 \`review-passed\` 가 붙어야 머지 가능 (#1527)"
-    else
-        echo "[WARN] \`review-blocked\` 라벨 제거 실패 또는 이미 없음 — 머지가 막히면 수동 확인"
+# Drop one label; 0 = gone (or never there), 1 = a real failure worth a warning.
+pr_drop_label() {
+    _out=$(GH_HOST="$TARGET_HOST" gh api -i -X DELETE \
+        "repos/$TARGET_REPO/issues/$PR_NUMBER/labels/$1" 2>/dev/null)
+    _st=$(printf '%s\n' "$_out" | sed -n '1s|^HTTP/[0-9.]* *\([0-9][0-9][0-9]\).*|\1|p')
+    case "$_st" in
+    2?? | 404) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+if [ "${PUSHED_FIXES:-0}" -gt 0 ]; then
+    # The head moved, so any prior pass no longer describes it.
+    pr_drop_label review-passed ||
+        echo "[WARN] \`review-passed\` 라벨 제거 실패 — 머지 전 수동 확인 (#1527)"
+
+    if [ "${ACCEPTED_COUNT:-0}" -gt 0 ] && [ "${DECLINED_COUNT:-0}" -eq 0 ]; then
+        if pr_drop_label review-blocked; then
+            echo "[OK] verdict 라벨 정리됨 — 재리뷰가 \`review-passed\` 를 다시 붙여야 머지 가능 (#1527)"
+        else
+            echo "[WARN] \`review-blocked\` 라벨 제거 실패 — 머지가 막히면 수동 확인"
+        fi
     fi
 fi
 ```

--- a/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
+++ b/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
@@ -8,18 +8,32 @@ releases it once the blockers have actually been addressed.
 
 ## When it runs
 
-Only when **Step 6 pushed at least one fix commit** (`PUSHED_FIXES > 0`) **and**
-at least one comment this run was classified `ACCEPT` or `ACCEPT-PARTIAL`. Both
-halves matter:
+All three must hold:
+
+1. Step 6 pushed at least one fix commit (`PUSHED_FIXES > 0`).
+2. At least one comment this run was `ACCEPT` / `ACCEPT-PARTIAL`
+   (`ACCEPTED_COUNT > 0`).
+3. **No comment this run was `DECLINE`** (`DECLINED_COUNT == 0`).
+
+Why each:
 
 - No push → nothing changed on the branch, so the blocking verdict still stands
   as written. All-`DECLINE` / all-`QUESTION` runs leave the label alone.
 - A push with no accepted comment (an unrelated commit that happened to land)
   is not evidence a blocker was fixed.
+- **A single `DECLINE` anywhere in the run blocks the clear** (#1527, PR #1529
+  codex review). `gh:pr-reply` does not know which comments the reviewer
+  considered blocking — the verdict is one line for the whole review, not
+  per-comment. So "I accepted one thing and declined another" is
+  indistinguishable from "I declined the blocker and fixed a nit", and clearing
+  on the first would silently release the gate on the second.
 
-Declining a blocker is a legitimate outcome — but it is a **human's** call to
-override the gate, made by removing the label by hand. A skill that cleared it
-on its own reasoning would be marking its own homework.
+That third rule is deliberately blunt, and it errs the same direction as the
+gate itself: declining an out-of-scope nit costs a manual label removal, while
+the looser rule costs an unreviewed merge. Declining a blocker is a legitimate
+outcome — but overriding the gate is a **human's** call, made by removing the
+label by hand. A skill that cleared it on its own reasoning would be marking its
+own homework.
 
 ## What it does NOT do
 
@@ -39,7 +53,8 @@ A 404 means the label was already absent, which is success for this step's
 purposes — hence the idempotent `||` branch.
 
 ```bash
-if [ "${PUSHED_FIXES:-0}" -gt 0 ] && [ "${ACCEPTED_COUNT:-0}" -gt 0 ]; then
+if [ "${PUSHED_FIXES:-0}" -gt 0 ] && [ "${ACCEPTED_COUNT:-0}" -gt 0 ] \
+    && [ "${DECLINED_COUNT:-0}" -eq 0 ]; then
     if GH_HOST="$TARGET_HOST" gh api -X DELETE \
         "repos/$TARGET_REPO/issues/$PR_NUMBER/labels/review-blocked" \
         >/dev/null 2>&1; then

--- a/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
+++ b/claude/skills/gh-pr-reply/references/review-blocked-clear.sh.md
@@ -8,32 +8,25 @@ releases it once the blockers have actually been addressed.
 
 ## When it runs
 
-All three must hold:
+All three must hold — each rules out a different way the clear would be wrong:
 
-1. Step 6 pushed at least one fix commit (`PUSHED_FIXES > 0`).
-2. At least one comment this run was `ACCEPT` / `ACCEPT-PARTIAL`
-   (`ACCEPTED_COUNT > 0`).
-3. **No comment this run was `DECLINE`** (`DECLINED_COUNT == 0`).
+- **`PUSHED_FIXES > 0`** — no push means nothing changed on the branch, so the
+  blocking verdict still stands exactly as written.
+- **`ACCEPTED_COUNT > 0`** — a push carrying no `ACCEPT` / `ACCEPT-PARTIAL`
+  comment (an unrelated commit that happened to land) is not evidence a blocker
+  was fixed.
+- **`DECLINED_COUNT == 0`** — one `DECLINE` anywhere in the run holds the label
+  (#1527, PR #1529 codex review). The verdict is a single line for the whole
+  review, not per-comment, so `gh:pr-reply` cannot tell which comment the
+  reviewer considered blocking: "accepted one thing, declined another" is
+  indistinguishable from "declined the blocker, fixed a nit". The rule is
+  deliberately blunt and errs the way the gate itself does — declining an
+  out-of-scope nit costs a manual label removal, the looser rule costs an
+  unreviewed merge.
 
-Why each:
-
-- No push → nothing changed on the branch, so the blocking verdict still stands
-  as written. All-`DECLINE` / all-`QUESTION` runs leave the label alone.
-- A push with no accepted comment (an unrelated commit that happened to land)
-  is not evidence a blocker was fixed.
-- **A single `DECLINE` anywhere in the run blocks the clear** (#1527, PR #1529
-  codex review). `gh:pr-reply` does not know which comments the reviewer
-  considered blocking — the verdict is one line for the whole review, not
-  per-comment. So "I accepted one thing and declined another" is
-  indistinguishable from "I declined the blocker and fixed a nit", and clearing
-  on the first would silently release the gate on the second.
-
-That third rule is deliberately blunt, and it errs the same direction as the
-gate itself: declining an out-of-scope nit costs a manual label removal, while
-the looser rule costs an unreviewed merge. Declining a blocker is a legitimate
-outcome — but overriding the gate is a **human's** call, made by removing the
-label by hand. A skill that cleared it on its own reasoning would be marking its
-own homework.
+Declining a blocker is a legitimate outcome — but overriding the gate is a
+**human's** call, made by removing the label by hand. A skill that cleared it on
+its own reasoning would be marking its own homework.
 
 ## What it does NOT do
 

--- a/docs/public/changelog.d/2026-08-27-1527.md
+++ b/docs/public/changelog.d/2026-08-27-1527.md
@@ -1,3 +1,5 @@
 - 변경: **리뷰 판정이 머지 게이트로 전달된다** — `devx:pr-review-all` 이 모든 리뷰 레인의 판정(`판정:`/`Verdict:`)을 집계해 PR 에 `review-blocked` / `review-passed` 라벨을 남기고, `gh:pr-merge-train` 이 Step 2 큐 구성에서 이를 하드 게이트로 쓴다. 라벨이 없으면(= 리뷰 확인 안 됨) `[SKIPPED]` — 부재는 통과가 아니다 (#1527)
 - 변경: **`gh:pr-reply` 가 블로커 수정 푸시 후 `review-blocked` 를 뗀다** — `review-passed` 는 절대 붙이지 않으며, 재리뷰가 다시 판정해야 머지 가능 (#1527)
 - 변경: **`review-blocked` / `review-passed` 라벨은 대상 repo 에 미리 생성해야 한다** — 자동 생성하지 않는다(`gh label create review-blocked --color b60205`, `gh label create review-passed --color 0e8a16`). 없으면 라벨이 안 붙고 train 이 해당 PR 을 건너뛴다 (#1527)
+- 변경: **`gh:label-bootstrap` 이 `review-blocked`/`review-passed` 를 프로비저닝한다** — `gh-labels.md` 의 별도 `pipeline|` feed 를 읽어 POST/PATCH 하고 `--prune` 에서 보존한다. 라벨 자동 생성 금지(#326) 아래에서 판정 게이트가 영구 교착되지 않게 하는 롤아웃 경로 (#1527, PR #1529 codex 리뷰)
+- 변경: **`gh:pr-reply` 의 `review-blocked` 해제 조건에 `DECLINED_COUNT == 0` 추가** — 같은 런에서 DECLINE 이 하나라도 있으면 라벨을 떼지 않는다. 판정은 리뷰 전체에 한 줄이라 어떤 코멘트가 블로커였는지 스킬이 알 수 없기 때문 (#1527, PR #1529 codex 리뷰)

--- a/docs/public/changelog.d/2026-08-27-1527.md
+++ b/docs/public/changelog.d/2026-08-27-1527.md
@@ -1,5 +1,4 @@
 - 변경: **리뷰 판정이 머지 게이트로 전달된다** — `devx:pr-review-all` 이 모든 리뷰 레인의 판정(`판정:`/`Verdict:`)을 집계해 PR 에 `review-blocked` / `review-passed` 라벨을 남기고, `gh:pr-merge-train` 이 Step 2 큐 구성에서 이를 하드 게이트로 쓴다. 라벨이 없으면(= 리뷰 확인 안 됨) `[SKIPPED]` — 부재는 통과가 아니다 (#1527)
 - 변경: **`gh:pr-reply` 가 블로커 수정 푸시 후 `review-blocked` 를 뗀다** — `review-passed` 는 절대 붙이지 않으며, 재리뷰가 다시 판정해야 머지 가능 (#1527)
-- 변경: **`review-blocked` / `review-passed` 라벨은 대상 repo 에 미리 생성해야 한다** — 자동 생성하지 않는다(`gh label create review-blocked --color b60205`, `gh label create review-passed --color 0e8a16`). 없으면 라벨이 안 붙고 train 이 해당 PR 을 건너뛴다 (#1527)
 - 변경: **`gh:label-bootstrap` 이 `review-blocked`/`review-passed` 를 프로비저닝한다** — `gh-labels.md` 의 별도 `pipeline|` feed 를 읽어 POST/PATCH 하고 `--prune` 에서 보존한다. 라벨 자동 생성 금지(#326) 아래에서 판정 게이트가 영구 교착되지 않게 하는 롤아웃 경로 (#1527, PR #1529 codex 리뷰)
 - 변경: **`gh:pr-reply` 의 `review-blocked` 해제 조건에 `DECLINED_COUNT == 0` 추가** — 같은 런에서 DECLINE 이 하나라도 있으면 라벨을 떼지 않는다. 판정은 리뷰 전체에 한 줄이라 어떤 코멘트가 블로커였는지 스킬이 알 수 없기 때문 (#1527, PR #1529 codex 리뷰)

--- a/docs/public/changelog.d/2026-08-27-1527.md
+++ b/docs/public/changelog.d/2026-08-27-1527.md
@@ -1,0 +1,3 @@
+- 변경: **리뷰 판정이 머지 게이트로 전달된다** — `devx:pr-review-all` 이 모든 리뷰 레인의 판정(`판정:`/`Verdict:`)을 집계해 PR 에 `review-blocked` / `review-passed` 라벨을 남기고, `gh:pr-merge-train` 이 Step 2 큐 구성에서 이를 하드 게이트로 쓴다. 라벨이 없으면(= 리뷰 확인 안 됨) `[SKIPPED]` — 부재는 통과가 아니다 (#1527)
+- 변경: **`gh:pr-reply` 가 블로커 수정 푸시 후 `review-blocked` 를 뗀다** — `review-passed` 는 절대 붙이지 않으며, 재리뷰가 다시 판정해야 머지 가능 (#1527)
+- 변경: **`review-blocked` / `review-passed` 라벨은 대상 repo 에 미리 생성해야 한다** — 자동 생성하지 않는다(`gh label create review-blocked --color b60205`, `gh label create review-passed --color 0e8a16`). 없으면 라벨이 안 붙고 train 이 해당 PR 을 건너뛴다 (#1527)

--- a/docs/public/changelog.d/2026-08-27-1527.md
+++ b/docs/public/changelog.d/2026-08-27-1527.md
@@ -2,3 +2,7 @@
 - 변경: **`gh:pr-reply` 가 블로커 수정 푸시 후 `review-blocked` 를 뗀다** — `review-passed` 는 절대 붙이지 않으며, 재리뷰가 다시 판정해야 머지 가능 (#1527)
 - 변경: **`gh:label-bootstrap` 이 `review-blocked`/`review-passed` 를 프로비저닝한다** — `gh-labels.md` 의 별도 `pipeline|` feed 를 읽어 POST/PATCH 하고 `--prune` 에서 보존한다. 라벨 자동 생성 금지(#326) 아래에서 판정 게이트가 영구 교착되지 않게 하는 롤아웃 경로 (#1527, PR #1529 codex 리뷰)
 - 변경: **`gh:pr-reply` 의 `review-blocked` 해제 조건에 `DECLINED_COUNT == 0` 추가** — 같은 런에서 DECLINE 이 하나라도 있으면 라벨을 떼지 않는다. 판정은 리뷰 전체에 한 줄이라 어떤 코멘트가 블로커였는지 스킬이 알 수 없기 때문 (#1527, PR #1529 codex 리뷰)
+- 변경: **판정을 서브에이전트 반환값이 아니라 PR 코멘트의 `<!-- ai-review:<ai> -->` 블록에서 읽는다** — `gh:pr-review` 는 `[OK] ...` 한 줄만 반환하고 서브에이전트는 요약을 반환해 판정이 어디에도 실리지 않았다. 그대로면 전 레인이 `unknown` 이라 라벨이 영구 미부착되고 train 이 모든 PR 을 건너뛴다 (#1527, PR #1529 agy·codex 리뷰)
+- 변경: **`devx:pr-review-all` 이 `GH_HOST` 를 export 한다** — `_gh_pr_edit_safe_label` 은 자체 호스트 처리가 없어 호출별 prefix 가 닿지 않았고, dual-host 에서 라벨이 기본 호스트로 갔다 (#1527, PR #1529 리뷰)
+- 변경: **`Verdict: [BLOCKING]` 처럼 괄호를 남긴 판정도 인식한다** — 템플릿 판정 기준을 `[` 시작이 아니라 `|` 교체 표기로 바꿨다. 실제 판정이 `unknown` 으로 유실되던 문제 (#1527, PR #1529 리뷰)
+- 변경: **`gh:pr-reply` 가 푸시하면 `review-passed` 를 무조건 뗀다** — 라벨은 리뷰된 head 를 증명하는데 푸시가 그 head 를 갈아치우므로, 남겨두면 아무도 안 본 코드가 통과 라벨을 단 채 머지된다 (#1527, PR #1529 codex 리뷰)

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -168,15 +168,17 @@ devx_pr_review_all_verdict() {
     # a reviewer may wrap the line in, drop a leading list dash. Then keep
     # only lines that *start* with the verdict key — a finding line like
     # `[BLOCKER] a.sh:1 — ...` must never be mistaken for the verdict.
-    # A value that opens with `[` is the preset's own template echoed back
-    # (`판정: [LGTM|우려있음|블로킹]`) and is dropped; a bracket later in the
-    # line is ordinary detail (`판정: 블로킹 [4건]`) and is kept. Last one
-    # wins: the presets require the verdict to be the final line.
+    # The preset's own template echoed back (`판정: [LGTM|우려있음|블로킹]`) is
+    # dropped, keyed on the `|` alternation that only a template carries — NOT
+    # on the leading `[`, which a reviewer legitimately keeps around a real
+    # answer (`Verdict: [BLOCKING]`, PR #1529 review, agy). Brackets are then
+    # stripped from the value so both spellings land on the same token. Last
+    # one wins: the presets require the verdict to be the final line.
     _line=$(
         sed -e 's/：/:/g' -e 's/[*`_#>]//g' \
             -e 's/^[[:space:]]*-[[:space:]]*//' -e 's/^[[:space:]]*//' |
             grep -iE '^(판정|verdict)[[:space:]]*:' |
-            grep -viE '^(판정|verdict)[[:space:]]*:[[:space:]]*\[' |
+            grep -vF '|' |
             tail -n 1
     )
 
@@ -187,7 +189,7 @@ devx_pr_review_all_verdict() {
 
     _value=$(
         printf '%s\n' "$_line" |
-            sed -e 's/^[^:]*://' -e 's/^[[:space:]]*//' |
+            sed -e 's/^[^:]*://' -e 's/[][]//g' -e 's/^[[:space:]]*//' |
             tr '[:lower:]' '[:upper:]'
     )
 
@@ -224,4 +226,44 @@ devx_pr_review_all_aggregate() {
     printf '%s\n' "label=$_label"
     printf '%s\n' "lanes=$_lanes"
     return 0
+}
+
+# Harvest one reviewer lane's raw output from the PR comment bodies on stdin.
+#
+# Step 3 dispatches each lane as a subagent, and `gh:pr-review` guarantees only
+# a one-line `[OK] PR #N reviewed by <ai> — comment: <URL>` as its return
+# value — the verdict is nowhere in it. Reading the verdict out of a subagent's
+# prose would make the merge gate depend on how an agent chose to summarise
+# itself; every lane would land on `unknown`, no label would ever be written,
+# and the train would skip every PR forever (PR #1529 review, agy + codex,
+# independently).
+#
+# So the verdict is read back from the artifact the lane already wrote:
+# `gh:pr-review` Step 6 posts the reviewer's raw output wrapped in
+# `<!-- ai-review:<ai> -->` markers, synchronously, before it returns. That is
+# a durable machine-readable record, not a summary.
+#
+# This is still producer-side parsing: `devx:pr-review-all` reads *its own*
+# lanes' output to mint the label. `gh:pr-merge-train` never parses a comment.
+#
+#   devx_pr_review_all_lane_block <ai>   # comment bodies on stdin
+#     -> that lane's raw block, or nothing
+#
+# The LAST complete block wins: a re-review posts a second comment and its
+# verdict supersedes. An unterminated block (a truncated or still-being-written
+# comment) is never harvested — half a review is not a verdict.
+devx_pr_review_all_lane_block() {
+    [ -n "${1-}" ] || return 0
+    # `beg`/`fin`, not `open`/`close`: `close` is an awk built-in and using it
+    # as a variable is a syntax error in POSIX awk.
+    awk -v ai="$1" '
+        BEGIN {
+            beg = "<!-- ai-review:"  ai " -->"
+            fin = "<!-- /ai-review:" ai " -->"
+        }
+        index($0, beg)               { collecting = 1; buf = ""; next }
+        collecting && index($0, fin) { collecting = 0; last = buf; next }
+        collecting                   { buf = buf $0 "\n" }
+        END                          { printf "%s", last }
+    '
 }

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -133,3 +133,90 @@ devx_pr_review_all_parse() {
     printf '%s\n' "reply_delay=$reply_delay"
     return 0
 }
+
+# ── Review verdict -> merge-gate label (issue #1527) ─────────────────
+#
+# Every gh:pr-review preset mandates a closing verdict line — `판정:
+# [LGTM|우려있음|블로킹]` on a Korean-dominant diff, `Verdict:
+# [LGTM|CONCERNS|BLOCKING]` otherwise. Until #1527 nothing in the repo read
+# it: PR #1518 collected two independent blocking verdicts and merged 32
+# minutes later, because the train's only real gate was CI.
+#
+# These two helpers turn that prose into a label the train can gate on.
+# Parsing lives here, in the *producer*, on purpose: if the train parsed
+# comment bodies instead, a reviewer changing its output format would
+# silently unlock the merge gate. Here a format change makes the lane
+# `unknown`, which is fail-closed — no label, no merge.
+#
+#   devx_pr_review_all_verdict                 # lane output on stdin
+#     -> blocking | concerns | lgtm | unknown
+#   devx_pr_review_all_aggregate <verdict>...  # one arg per lane that RAN
+#     -> label=review-blocked | label=review-passed | label=   (+ lanes=N)
+#
+# Skipped lanes contribute NO argument — "not checked" and "checked and
+# passed" must never collapse into the same state (#1527 확정 사항).
+
+devx_pr_review_all_verdict() {
+    local _line _value
+
+    # Normalize before matching: fullwidth colon -> ASCII, strip the markdown
+    # a reviewer may wrap the line in, drop a leading list dash. Then keep
+    # only lines that *start* with the verdict key — a finding line like
+    # `[BLOCKER] a.sh:1 — ...` must never be mistaken for the verdict.
+    # A value that opens with `[` is the preset's own template echoed back
+    # (`판정: [LGTM|우려있음|블로킹]`) and is dropped; a bracket later in the
+    # line is ordinary detail (`판정: 블로킹 [4건]`) and is kept. Last one
+    # wins: the presets require the verdict to be the final line.
+    _line=$(
+        sed -e 's/：/:/g' -e 's/[*`_#>]//g' \
+            -e 's/^[[:space:]]*-[[:space:]]*//' -e 's/^[[:space:]]*//' |
+            grep -iE '^(판정|verdict)[[:space:]]*:' |
+            grep -viE '^(판정|verdict)[[:space:]]*:[[:space:]]*\[' |
+            tail -n 1
+    )
+
+    if [ -z "$_line" ]; then
+        printf 'unknown\n'
+        return 0
+    fi
+
+    _value=$(
+        printf '%s\n' "$_line" |
+            sed -e 's/^[^:]*://' -e 's/^[[:space:]]*//' |
+            tr '[:lower:]' '[:upper:]'
+    )
+
+    case "$_value" in
+    블로킹* | BLOCKING*) printf 'blocking\n' ;;
+    우려있음* | CONCERNS*) printf 'concerns\n' ;;
+    LGTM*) printf 'lgtm\n' ;;
+    *) printf 'unknown\n' ;;
+    esac
+}
+
+devx_pr_review_all_aggregate() {
+    local _lanes=0 _blocking=0 _unresolved=0 _v _label
+
+    for _v in "$@"; do
+        _lanes=$((_lanes + 1))
+        case "$_v" in
+        blocking) _blocking=1 ;;
+        lgtm | concerns) ;;
+        # `unknown` and anything unrecognized are the same thing: the lane
+        # ran but its verdict could not be established. Fail closed.
+        *) _unresolved=1 ;;
+        esac
+    done
+
+    if [ "$_blocking" -eq 1 ]; then
+        _label="review-blocked"
+    elif [ "$_lanes" -eq 0 ] || [ "$_unresolved" -eq 1 ]; then
+        _label=""
+    else
+        _label="review-passed"
+    fi
+
+    printf '%s\n' "label=$_label"
+    printf '%s\n' "lanes=$_lanes"
+    return 0
+}

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -142,6 +142,11 @@ devx_pr_review_all_parse() {
 # it: PR #1518 collected two independent blocking verdicts and merged 32
 # minutes later, because the train's only real gate was CI.
 #
+# That prompt is rendered at runtime by `_gh_pr_review_common_prefix`
+# (gh_pr_review.sh), copied verbatim from
+# claude/skills/gh-pr-review/references/review-presets.md — reword the tokens
+# in either place and the case arm below has to move with them.
+#
 # These two helpers turn that prose into a label the train can gate on.
 # Parsing lives here, in the *producer*, on purpose: if the train parsed
 # comment bodies instead, a reviewer changing its output format would

--- a/tests/bats/functions/devx_pr_review_all_verdict.bats
+++ b/tests/bats/functions/devx_pr_review_all_verdict.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# tests/bats/functions/devx_pr_review_all_verdict.bats
+# Issue #1527 — the reviewer verdict ("판정: 블로킹" / "Verdict: BLOCKING")
+# had no machine-readable consumer anywhere in the repo, so a PR carrying two
+# independent blocking reviews (PR #1518) merged unchanged. These are the unit
+# tests for the two pure helpers that turn lane output into the merge gate's
+# first-class signal:
+#
+#   devx_pr_review_all_verdict    — one lane's raw output -> verdict token
+#   devx_pr_review_all_aggregate  — N lane verdicts -> PR label (or none)
+#
+# Fail-closed is the whole point: "no label" must never be reachable from
+# "everything passed", and "a lane ran but said nothing parseable" must never
+# be promoted to a pass.
+load '../test_helper'
+
+setup() {
+    # shellcheck disable=SC1090
+    source "${DOTFILES_ROOT:?}/shell-common/functions/devx_pr_review_all.sh"
+}
+
+# ── devx_pr_review_all_verdict: Korean verdicts ──────────────────────
+
+@test "verdict: Korean 블로킹 -> blocking" {
+    run devx_pr_review_all_verdict <<'EOF'
+[BLOCKER] a.sh:1 — breaks on empty input
+판정: 블로킹
+EOF
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: Korean 우려있음 -> concerns" {
+    run devx_pr_review_all_verdict <<<"판정: 우려있음"
+    assert_success
+    assert_output "concerns"
+}
+
+@test "verdict: Korean LGTM -> lgtm" {
+    run devx_pr_review_all_verdict <<<"판정: LGTM"
+    assert_success
+    assert_output "lgtm"
+}
+
+# ── devx_pr_review_all_verdict: English verdicts ─────────────────────
+
+@test "verdict: English BLOCKING -> blocking" {
+    run devx_pr_review_all_verdict <<<"Verdict: BLOCKING"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: English CONCERNS -> concerns" {
+    run devx_pr_review_all_verdict <<<"Verdict: CONCERNS"
+    assert_success
+    assert_output "concerns"
+}
+
+@test "verdict: English lgtm is case-insensitive" {
+    run devx_pr_review_all_verdict <<<"verdict: lgtm"
+    assert_success
+    assert_output "lgtm"
+}
+
+# ── devx_pr_review_all_verdict: real-world noise ─────────────────────
+
+@test "verdict: markdown bold + trailing detail still parses" {
+    run devx_pr_review_all_verdict <<<"**판정: 블로킹 (BLOCKER 4건)**"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: leading list dash still parses" {
+    run devx_pr_review_all_verdict <<<"- Verdict: LGTM"
+    assert_success
+    assert_output "lgtm"
+}
+
+@test "verdict: the prompt template line is NOT a verdict" {
+    # The preset prompt itself contains `판정: [LGTM|우려있음|블로킹]`. A lane
+    # that echoes its own instructions back must not be read as an LGTM.
+    run devx_pr_review_all_verdict <<<"판정: [LGTM|우려있음|블로킹]"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict: a bracket in the detail text is not a template echo" {
+    # Only a value that *opens* with `[` is the preset template. A bracketed
+    # count after a real verdict must still parse — dropping it would leave
+    # the PR unlabelled and silently un-mergeable.
+    run devx_pr_review_all_verdict <<<"판정: 블로킹 [BLOCKER 4건]"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: last verdict line wins" {
+    run devx_pr_review_all_verdict <<'EOF'
+판정: LGTM
+판정: 블로킹
+EOF
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: a BLOCKER finding alone is not a verdict" {
+    # Findings are classified [BLOCKER|FOLLOW-UP|PRAISE]; only the mandatory
+    # last verdict line decides the lane. No verdict line -> unknown.
+    run devx_pr_review_all_verdict <<<"[BLOCKER] a.sh:1 — breaks on empty input"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict: empty lane output -> unknown" {
+    run devx_pr_review_all_verdict </dev/null
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict: unrecognized verdict value -> unknown" {
+    run devx_pr_review_all_verdict <<<"Verdict: MAYBE"
+    assert_success
+    assert_output "unknown"
+}
+
+# ── devx_pr_review_all_aggregate ─────────────────────────────────────
+
+@test "aggregate: one blocking lane -> review-blocked" {
+    run devx_pr_review_all_aggregate lgtm blocking
+    assert_success
+    assert_output --partial "label=review-blocked"
+}
+
+@test "aggregate: all lanes pass -> review-passed" {
+    run devx_pr_review_all_aggregate lgtm concerns
+    assert_success
+    assert_output --partial "label=review-passed"
+}
+
+@test "aggregate: zero lanes ran -> no label" {
+    run devx_pr_review_all_aggregate
+    assert_success
+    assert_output --partial "label="
+    refute_output --partial "review-passed"
+    refute_output --partial "review-blocked"
+}
+
+@test "aggregate: an unknown lane is never promoted to a pass" {
+    run devx_pr_review_all_aggregate lgtm unknown
+    assert_success
+    refute_output --partial "review-passed"
+    refute_output --partial "review-blocked"
+}
+
+@test "aggregate: blocking outranks unknown" {
+    run devx_pr_review_all_aggregate unknown blocking
+    assert_success
+    assert_output --partial "label=review-blocked"
+}
+
+@test "aggregate: garbage token is treated as unknown, not a pass" {
+    run devx_pr_review_all_aggregate lgtm ohai
+    assert_success
+    refute_output --partial "review-passed"
+}
+
+@test "aggregate: reports the lane count it decided on" {
+    run devx_pr_review_all_aggregate lgtm concerns blocking
+    assert_success
+    assert_output --partial "lanes=3"
+}

--- a/tests/bats/functions/devx_pr_review_all_verdict.bats
+++ b/tests/bats/functions/devx_pr_review_all_verdict.bats
@@ -139,16 +139,13 @@ EOF
 @test "aggregate: zero lanes ran -> no label" {
     run devx_pr_review_all_aggregate
     assert_success
-    assert_output --partial "label="
-    refute_output --partial "review-passed"
-    refute_output --partial "review-blocked"
+    assert_line "label="
 }
 
 @test "aggregate: an unknown lane is never promoted to a pass" {
     run devx_pr_review_all_aggregate lgtm unknown
     assert_success
-    refute_output --partial "review-passed"
-    refute_output --partial "review-blocked"
+    assert_line "label="
 }
 
 @test "aggregate: blocking outranks unknown" {
@@ -160,7 +157,7 @@ EOF
 @test "aggregate: garbage token is treated as unknown, not a pass" {
     run devx_pr_review_all_aggregate lgtm ohai
     assert_success
-    refute_output --partial "review-passed"
+    assert_line "label="
 }
 
 @test "aggregate: reports the lane count it decided on" {

--- a/tests/bats/functions/devx_pr_review_all_verdict.bats
+++ b/tests/bats/functions/devx_pr_review_all_verdict.bats
@@ -165,3 +165,111 @@ EOF
     assert_success
     assert_output --partial "lanes=3"
 }
+
+# ── Lane block extraction (PR #1529 review, agy+codex BLOCKER) ────────
+# Step 3 dispatches each reviewer lane as a subagent, and `gh:pr-review`
+# guarantees only a one-line `[OK] PR #N reviewed by <ai> — comment: <URL>`
+# as its return value. Nothing carries the verdict back, so every lane would
+# parse as `unknown` → no label → `gh:pr-merge-train` skips every PR forever.
+#
+# The fix is to stop depending on subagent prose: `gh:pr-review` Step 6 posts
+# the reviewer's raw output inside `<!-- ai-review:<ai> -->` markers before it
+# returns, so the verdict is read back from that artifact instead.
+
+@test "lane block: extracts the marked block for the named lane" {
+    run devx_pr_review_all_lane_block codex <<'EOF'
+<!-- ai-review:codex -->
+[BLOCKER] a.sh:1 — nope
+판정: 블로킹
+<!-- /ai-review:codex -->
+EOF
+    assert_success
+    assert_line "판정: 블로킹"
+}
+
+@test "lane block: picks the right lane when several are present" {
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:codex -->
+판정: 블로킹
+<!-- /ai-review:codex -->
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_line "Verdict: LGTM"
+    refute_output --partial "블로킹"
+}
+
+@test "lane block: the LAST block wins when a lane was re-reviewed" {
+    # A re-review posts a second comment; the newest verdict is the live one.
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+<!-- ai-review:agy -->
+Verdict: BLOCKING
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_line "Verdict: BLOCKING"
+    refute_output --partial "LGTM"
+}
+
+@test "lane block: absent lane yields nothing (-> unknown downstream)" {
+    run devx_pr_review_all_lane_block hermes <<'EOF'
+<!-- ai-review:codex -->
+판정: LGTM
+<!-- /ai-review:codex -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block: an unterminated block is not harvested" {
+    # A truncated comment must not hand back a half-read verdict.
+    run devx_pr_review_all_lane_block codex <<'EOF'
+<!-- ai-review:codex -->
+판정: 블로킹
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block: end-to-end -> verdict token" {
+    run bash -c '
+        . "'"${DOTFILES_ROOT}"'/shell-common/functions/devx_pr_review_all.sh"
+        printf "%s\n" "<!-- ai-review:agy -->" "Verdict: BLOCKING" "<!-- /ai-review:agy -->" \
+          | devx_pr_review_all_lane_block agy | devx_pr_review_all_verdict'
+    assert_success
+    assert_output "blocking"
+}
+
+# ── Bracketed single verdict (PR #1529 review, agy BLOCKER) ───────────
+# The template guard dropped any value opening with `[`, which also threw away
+# a real verdict a reviewer left bracketed. Only the template's `|` alternation
+# marks an echo; a single bracketed token is a genuine verdict.
+
+@test "verdict: bracketed single verdict still parses (English)" {
+    run devx_pr_review_all_verdict <<<"Verdict: [BLOCKING]"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: bracketed single verdict still parses (Korean)" {
+    run devx_pr_review_all_verdict <<<"판정: [블로킹]"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: the full template alternation is still rejected" {
+    run devx_pr_review_all_verdict <<<"Verdict: [LGTM|CONCERNS|BLOCKING]"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict: the Korean template alternation is still rejected" {
+    run devx_pr_review_all_verdict <<<"판정: [LGTM|우려있음|블로킹]"
+    assert_success
+    assert_output "unknown"
+}

--- a/tests/bats/skills/gh_label_bootstrap.bats
+++ b/tests/bats/skills/gh_label_bootstrap.bats
@@ -178,3 +178,48 @@ run_bootstrap() {
     assert_success
     assert_output --partial "[dry-run] PATCH label 'feat' (color=fbca04)"
 }
+
+# ── Pipeline-state labels (#1527) ─────────────────────────────────────
+# `review-blocked` / `review-passed` are the merge-train's verdict gate.
+# `_gh_pr_edit_safe_label` refuses to auto-create a missing label (#326), so
+# without a bootstrap path the gate deadlocks: every PR stays unlabelled and
+# `gh:pr-merge-train` skips all of them forever (PR #1529 codex review).
+# They live in their own SSOT feed, kept apart from the 10 issue-classification
+# labels — no aliases, but prune must never delete them.
+
+@test "pipeline labels are POSTed when missing (#1527)" {
+    set_existing ""
+    run_bootstrap
+    assert_success
+    grep -q 'repos/acme/widget/labels -X POST -f name=review-blocked -f color=b60205' "$MOCK_LOG"
+    grep -q 'repos/acme/widget/labels -X POST -f name=review-passed -f color=0e8a16' "$MOCK_LOG"
+}
+
+@test "existing pipeline label is PATCHed to the SSOT color (#1527)" {
+    set_existing review-blocked
+    run_bootstrap
+    assert_success
+    grep -q 'repos/acme/widget/labels/review-blocked -X PATCH' "$MOCK_LOG"
+    grep -q 'color=b60205' "$MOCK_LOG"
+}
+
+@test "prune never deletes a pipeline label (#1527)" {
+    set_existing review-blocked review-passed
+    run_bootstrap --prune
+    assert_success
+    if grep -q 'labels/review-blocked -X DELETE' "$MOCK_LOG"; then
+        echo "prune must not delete the verdict gate label" && return 1
+    fi
+    if grep -q 'labels/review-passed -X DELETE' "$MOCK_LOG"; then
+        echo "prune must not delete the verdict gate label" && return 1
+    fi
+}
+
+@test "pipeline labels are not treated as rename aliases (#1527)" {
+    set_existing review-blocked
+    run_bootstrap
+    assert_success
+    if grep -q 'labels/review-blocked -X PATCH -f new_name=review-passed' "$MOCK_LOG"; then
+        echo "pipeline labels have no alias mapping" && return 1
+    fi
+}

--- a/tests/bats/skills/gh_label_bootstrap.bats
+++ b/tests/bats/skills/gh_label_bootstrap.bats
@@ -180,12 +180,10 @@ run_bootstrap() {
 }
 
 # ── Pipeline-state labels (#1527) ─────────────────────────────────────
-# `review-blocked` / `review-passed` are the merge-train's verdict gate.
-# `_gh_pr_edit_safe_label` refuses to auto-create a missing label (#326), so
-# without a bootstrap path the gate deadlocks: every PR stays unlabelled and
-# `gh:pr-merge-train` skips all of them forever (PR #1529 codex review).
-# They live in their own SSOT feed, kept apart from the 10 issue-classification
-# labels — no aliases, but prune must never delete them.
+# `review-blocked` / `review-passed` are the merge-train's verdict gate. They
+# live in their own SSOT feed, kept apart from the 10 issue-classification
+# labels — no aliases, but prune must never delete them. Why the bootstrap
+# path has to exist at all: gh-labels.md, "파이프라인 상태 라벨".
 
 @test "pipeline labels are POSTed when missing (#1527)" {
     set_existing ""
@@ -207,12 +205,11 @@ run_bootstrap() {
     set_existing review-blocked review-passed
     run_bootstrap --prune
     assert_success
-    if grep -q 'labels/review-blocked -X DELETE' "$MOCK_LOG"; then
-        echo "prune must not delete the verdict gate label" && return 1
-    fi
-    if grep -q 'labels/review-passed -X DELETE' "$MOCK_LOG"; then
-        echo "prune must not delete the verdict gate label" && return 1
-    fi
+    for label in review-blocked review-passed; do
+        if grep -q "labels/${label} -X DELETE" "$MOCK_LOG"; then
+            echo "prune must not delete the verdict gate label ${label}" && return 1
+        fi
+    done
 }
 
 @test "pipeline labels are not treated as rename aliases (#1527)" {

--- a/tests/bats/skills/review_verdict_gate.bats
+++ b/tests/bats/skills/review_verdict_gate.bats
@@ -112,7 +112,8 @@ teardown() {
 @test "#1527: gh:pr-reply removes the label via REST DELETE, not gh pr edit --remove-label" {
     run grep -F "gh pr edit --remove-label" \
         "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
-    assert_output --partial "not"
+    # mentioned only as the thing NOT to use
+    assert_output --partial "not \`gh pr edit --remove-label\`"
     run grep -F "gh api -X DELETE" \
         "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
     assert_success

--- a/tests/bats/skills/review_verdict_gate.bats
+++ b/tests/bats/skills/review_verdict_gate.bats
@@ -119,6 +119,31 @@ teardown() {
     assert_success
 }
 
+@test "#1527: the verdict labels have a bootstrap path in gh:label-bootstrap" {
+    # PR #1529 codex BLOCKER: the add path refuses to auto-create (#326), so
+    # without a provisioning route a repo lacking the labels deadlocks — every
+    # PR unlabelled, every PR skipped, forever.
+    run grep -F "pipeline|review-blocked|b60205" \
+        "${SKILLS}/gh-label-bootstrap/references/gh-labels.md"
+    assert_success
+    run grep -F "pipeline|review-passed|0e8a16" \
+        "${SKILLS}/gh-label-bootstrap/references/gh-labels.md"
+    assert_success
+    run grep -F "pipeline_feed" \
+        "${SKILLS}/gh-label-bootstrap/lib/label-bootstrap.sh"
+    assert_success
+}
+
+@test "#1527: clearing review-blocked requires no DECLINE in the run" {
+    # PR #1529 codex FOLLOW-UP: PUSHED_FIXES + ACCEPTED_COUNT alone releases the
+    # gate even when a blocker was declined in the same run. The verdict is one
+    # line for the whole review, so the skill cannot tell which comment was the
+    # blocker — a DECLINE anywhere must hold the label.
+    run grep -F 'DECLINED_COUNT:-0}" -eq 0' \
+        "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+}
+
 # ── the retired gate must not come back (#1513 interaction) ──────────
 
 @test "#1527: the fix does not resurrect the board Approved gate (#1513)" {

--- a/tests/bats/skills/review_verdict_gate.bats
+++ b/tests/bats/skills/review_verdict_gate.bats
@@ -114,8 +114,39 @@ teardown() {
         "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
     # mentioned only as the thing NOT to use
     assert_output --partial "not \`gh pr edit --remove-label\`"
-    run grep -F "gh api -X DELETE" \
+    # `-i` keeps the HTTP status that `gh api` otherwise collapses into a bare
+    # non-zero exit, so a 404 (label already absent) is not reported as failure.
+    run grep -F "gh api -i -X DELETE" \
         "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+}
+
+@test "#1527: any push retires review-passed (PR #1529 codex BLOCKER)" {
+    # The label certifies a reviewed head; a push replaces that head. Leaving it
+    # on lets the train merge code nobody reviewed — the hole the gate exists to
+    # close. Unconditional on PUSHED_FIXES, unlike the review-blocked clear.
+    run grep -F "pr_drop_label review-passed" \
+        "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+}
+
+@test "#1527: the verdict is read from the PR comment block, not a lane return" {
+    # PR #1529 agy+codex BLOCKER: gh:pr-review returns one `[OK] ...` line and a
+    # subagent returns a summary — neither carries the verdict. Reading it from
+    # the `<!-- ai-review:<ai> -->` artifact is what makes the gate work at all.
+    run grep -F "devx_pr_review_all_lane_block" \
+        "${SKILLS}/devx-pr-review-all/references/review-verdict-label.md"
+    assert_success
+    run grep -F "ai-review:<ai>" \
+        "${SKILLS}/devx-pr-review-all/references/review-verdict-label.md"
+    assert_success
+}
+
+@test "#1527: GH_HOST is exported, not just prefixed (PR #1529 BLOCKER)" {
+    # _gh_pr_edit_safe_label calls `gh` itself and has no host handling of its
+    # own, so a per-call prefix never reaches it.
+    run grep -F 'export GH_HOST="$TARGET_HOST"' \
+        "${SKILLS}/devx-pr-review-all/SKILL.md"
     assert_success
 }
 
@@ -152,4 +183,104 @@ teardown() {
     run grep -F "GH_PR_MERGE_SKIP_BOARD_CHECK" \
         "${SKILLS}/gh-pr-merge-train/references/review-verdict-gate.md"
     assert_failure
+}
+
+# ── End-to-end orchestration (PR #1529 review, codex FOLLOW-UP) ───────
+# Everything above is a doc-drift grep. codex's point: the contract can read
+# correctly while the actual path — lane comment -> block -> verdict ->
+# aggregate -> label decision -> train action — is empty or wrong. These
+# exercise that path against realistic PR comment bodies, no network.
+
+lane_comments_fixture() {
+    cat <<'FIX'
+### AI Metrics — gh-pr-review
+some unrelated comment body
+<details><summary>AI Review · agy · --review=default</summary>
+<!-- ai-review:agy -->
+[BLOCKER] a.sh:1 — breaks on empty input
+Assumption: none found.
+Verdict: BLOCKING
+<!-- /ai-review:agy -->
+</details>
+<details><summary>AI Review · codex · --review=default</summary>
+<!-- ai-review:codex -->
+[PRAISE] b.sh:9 — nice
+판정: LGTM
+<!-- /ai-review:codex -->
+</details>
+FIX
+}
+
+# Mirrors the Step 5 pipeline: bodies -> per-lane block -> verdict -> aggregate.
+run_gate() {
+    local bodies="$1" verdicts="" ai v
+    shift
+    for ai in "$@"; do
+        v=$(printf '%s\n' "$bodies" | devx_pr_review_all_lane_block "$ai" | devx_pr_review_all_verdict)
+        verdicts="$verdicts $v"
+    done
+    # shellcheck disable=SC2086
+    devx_pr_review_all_aggregate $verdicts
+}
+
+@test "#1527 e2e: one blocking lane in real comment bodies -> review-blocked" {
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh"
+    run run_gate "$(lane_comments_fixture)" agy codex
+    assert_success
+    assert_output --partial "label=review-blocked"
+    assert_output --partial "lanes=2"
+}
+
+@test "#1527 e2e: a lane that did not run contributes nothing, not unknown" {
+    # hermes never ran, so it is simply not passed to the aggregator. The two
+    # lanes that did run decide the label on their own.
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh"
+    run run_gate "$(lane_comments_fixture)" codex
+    assert_success
+    assert_output --partial "label=review-passed"
+    assert_output --partial "lanes=1"
+}
+
+@test "#1527 e2e: a lane that ran but posted no block is unknown -> no label" {
+    # The #1529 failure mode: the lane returned, but nothing machine-readable
+    # reached the PR (GH_DISABLE_AI_METRICS=1, --no-post-comment, a crash).
+    # It must NOT be promoted to a pass.
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh"
+    run run_gate "$(lane_comments_fixture)" codex hermes
+    assert_success
+    assert_line "label="
+    assert_output --partial "lanes=2"
+}
+
+@test "#1527 e2e: a re-review supersedes the earlier verdict" {
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh"
+    local bodies
+    bodies="$(lane_comments_fixture)
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->"
+    run run_gate "$bodies" agy codex
+    assert_success
+    assert_output --partial "label=review-passed"
+}
+
+@test "#1527 e2e: the train's three actions follow from the label" {
+    # The gate contract gh:pr-merge-train implements, exercised as data.
+    for row in "review-blocked:SKIPPED" ":SKIPPED" "review-passed:PROCEED"; do
+        label="${row%%:*}"
+        expected="${row##*:}"
+        case "$label" in
+        review-blocked) actual=SKIPPED ;;
+        review-passed) actual=PROCEED ;;
+        *) actual=SKIPPED ;;
+        esac
+        [ "$actual" = "$expected" ] || {
+            echo "label '${label}' -> ${actual}, expected ${expected}"
+            return 1
+        }
+    done
 }

--- a/tests/bats/skills/review_verdict_gate.bats
+++ b/tests/bats/skills/review_verdict_gate.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# tests/bats/skills/review_verdict_gate.bats
+# Issue #1527 — the review verdict is now a first-class pipeline state:
+# devx:pr-review-all emits `review-blocked` / `review-passed`, and
+# gh:pr-merge-train gates on it. Those three skills are Claude-driven, not
+# shell functions, so what bats can pin here is that the contract does not
+# silently drift back out of their instructions — the same drift-guard shape
+# as gh_pr_merge_board_gate_retired.bats (#1513).
+#
+# The parsing/aggregation logic itself is unit-tested in
+# tests/bats/functions/devx_pr_review_all_verdict.bats.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    SKILLS="${_BATS_REAL_DOTFILES_ROOT}/claude/skills"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ── producer: devx:pr-review-all ─────────────────────────────────────
+
+@test "#1527: devx:pr-review-all has a verdict-label reference" {
+    run test -f "${SKILLS}/devx-pr-review-all/references/review-verdict-label.md"
+    assert_success
+}
+
+@test "#1527: devx:pr-review-all SKILL.md has a verdict aggregation step" {
+    run grep -F "Aggregate verdicts into the merge-gate label" \
+        "${SKILLS}/devx-pr-review-all/SKILL.md"
+    assert_success
+}
+
+@test "#1527: devx:pr-review-all names both helper functions" {
+    run grep -F "devx_pr_review_all_verdict" "${SKILLS}/devx-pr-review-all/SKILL.md"
+    assert_success
+    run grep -F "devx_pr_review_all_aggregate" "${SKILLS}/devx-pr-review-all/SKILL.md"
+    assert_success
+}
+
+@test "#1527: the label is applied through _gh_pr_edit_safe_label, not bare gh pr edit" {
+    # Projects-classic GraphQL deprecation makes `gh pr edit --add-label`
+    # exit 1 with the label silently dropped (#326).
+    run grep -F "_gh_pr_edit_safe_label" \
+        "${SKILLS}/devx-pr-review-all/references/review-verdict-label.md"
+    assert_success
+    run grep -F "gh pr edit --add-label" \
+        "${SKILLS}/devx-pr-review-all/references/review-verdict-label.md"
+    # mentioned only as the thing NOT to use
+    assert_output --partial "never bare"
+}
+
+# ── consumer: gh:pr-merge-train ──────────────────────────────────────
+
+@test "#1527: gh:pr-merge-train has a review-verdict gate reference" {
+    run test -f "${SKILLS}/gh-pr-merge-train/references/review-verdict-gate.md"
+    assert_success
+}
+
+@test "#1527: the train's queue query requests labels" {
+    # Without `labels` in the --json field set the gate has nothing to read.
+    run grep -F "baseRefName,title,labels" "${SKILLS}/gh-pr-merge-train/SKILL.md"
+    assert_success
+}
+
+@test "#1527: the train's SKILL.md declares the verdict gate at queue construction" {
+    run grep -F "Review verdict gate (#1527)" "${SKILLS}/gh-pr-merge-train/SKILL.md"
+    assert_success
+}
+
+@test "#1527: absence of a label is a skip, never a pass" {
+    # The load-bearing rule. If this phrasing disappears the gate is a no-op
+    # for every PR that was never reviewed — the exact #1518 hole.
+    run grep -F "Absence is a skip, not a pass" "${SKILLS}/gh-pr-merge-train/SKILL.md"
+    assert_success
+}
+
+@test "#1527: the train is forbidden from treating an unlabelled PR as reviewed" {
+    run grep -F "Never treat an unlabelled PR as reviewed" \
+        "${SKILLS}/gh-pr-merge-train/references/constraints.md"
+    assert_success
+}
+
+@test "#1527: the train does not parse review comment bodies" {
+    run grep -F "never parses a review comment body" \
+        "${SKILLS}/gh-pr-merge-train/SKILL.md"
+    assert_success
+}
+
+# ── release path: gh:pr-reply ────────────────────────────────────────
+
+@test "#1527: gh:pr-reply has a review-blocked clear reference" {
+    run test -f "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+}
+
+@test "#1527: gh:pr-reply clears review-blocked only after pushing an accepted fix" {
+    run grep -F "PUSHED_FIXES" "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+    run grep -F "ACCEPTED_COUNT" "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+}
+
+@test "#1527: gh:pr-reply must never add review-passed" {
+    run grep -F "never add \`review-passed\`" "${SKILLS}/gh-pr-reply/SKILL.md"
+    assert_success
+}
+
+@test "#1527: gh:pr-reply removes the label via REST DELETE, not gh pr edit --remove-label" {
+    run grep -F "gh pr edit --remove-label" \
+        "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_output --partial "not"
+    run grep -F "gh api -X DELETE" \
+        "${SKILLS}/gh-pr-reply/references/review-blocked-clear.sh.md"
+    assert_success
+}
+
+# ── the retired gate must not come back (#1513 interaction) ──────────
+
+@test "#1527: the fix does not resurrect the board Approved gate (#1513)" {
+    run grep -RF "Step 2-B" "${SKILLS}/devx-pr-review-all/"
+    assert_failure
+    run grep -F "GH_PR_MERGE_SKIP_BOARD_CHECK" \
+        "${SKILLS}/gh-pr-merge-train/references/review-verdict-gate.md"
+    assert_failure
+}


### PR DESCRIPTION
## Summary
- 리뷰어의 판정(`판정: 블로킹` / `Verdict: BLOCKING`)을 소비하는 코드가 저장소에 하나도 없어, 블로킹 리뷰 2건을 받은 PR #1518 이 그대로 머지된 문제를 고친다.
- `devx:pr-review-all` 이 레인별 판정을 집계해 `review-blocked` / `review-passed` PR 라벨로 내보내고, `gh:pr-merge-train` 이 Step 2 큐 구성에서 이를 하드 게이트로 쓴다.
- **라벨 부재 = 차단.** "리뷰 확인 안 됨" 을 "통과" 로 승격시키지 않으므로 시간 백스톱이 필요 없고, 막힌 PR 은 사람이 라벨 하나로 즉시 푼다.

## Changes
- `shell-common/functions/devx_pr_review_all.sh`: 순수 헬퍼 2개 추가 — `devx_pr_review_all_verdict` (레인 출력 → `blocking`/`concerns`/`lgtm`/`unknown`), `devx_pr_review_all_aggregate` (레인 판정들 → `label=` + `lanes=`). 프리셋 템플릿(`판정: [LGTM|...]`)의 자기 반복은 판정으로 읽지 않고, 파싱 불가 레인은 `unknown` 으로 떨어뜨려 fail-closed 로 만든다.
- `devx:pr-review-all`: Step 5 신설(판정 집계 → 라벨 부여). `_gh_pr_edit_safe_label` 경유이며 반대편 라벨을 먼저 제거한다. 전 구간 soft-fail — 라벨이 안 붙으면 train 이 건너뛴다.
- `gh:pr-merge-train`: Step 2 큐 쿼리에 `labels` 추가 + 판정 게이트. `review-blocked` 또는 라벨 없음 → `[SKIPPED]`(attempt 미소모, 다음 tick 재시도). 새 reference `review-verdict-gate.md`, `train-loop.md` / `report-format.md` / `constraints.md` 반영.
- `gh:pr-reply`: 블로커를 실제로 고쳐 푸시했을 때만(`PUSHED_FIXES > 0 && ACCEPTED_COUNT > 0`) `review-blocked` 제거. `review-passed` 는 절대 붙이지 않는다 — 고치는 행위가 그 수정을 스스로 인증할 수는 없다.
- `gh:label-bootstrap`: 두 라벨을 10-label SSOT 범위 밖(`CI fail`/`conflict` 와 같은 파이프라인 상태 라벨)으로 명시.
- 테스트: `devx_pr_review_all_verdict.bats` 21건(파싱/집계 단위) + `review_verdict_gate.bats` 15건(3개 스킬 계약 drift guard).

## Test plan
- [x] `bats tests/bats/functions/devx_pr_review_all_verdict.bats` — 21/21 pass
- [x] `bats tests/bats/skills/review_verdict_gate.bats` — 15/15 pass
- [x] 전체 스위트: pytest 1541 pass / bats 2777 pass. 실패 18건은 HEAD 에서도 **동일한 집합**(diff 결과 IDENTICAL)인 pre-existing
- [x] cross-shell: bash / zsh(native + `emulate -L sh`) / dash 에서 동일 출력 확인
- [x] `shellcheck` + `shfmt -d` + `lint_changelog_fragments.sh` clean
- [ ] 머지 후 실제 `devx:pr-review-all` 실행에서 라벨이 붙는지, train 이 게이트로 쓰는지 확인

## 알려진 사항 (Known notes)
- **라벨 사전 생성 필요** — `_gh_pr_edit_safe_label` 은 라벨을 자동 생성하지 않는다(#326). `dEitY719/dotfiles` 에는 `review-blocked`(`b60205`) / `review-passed`(`0e8a16`) 를 이미 생성해 두었다. 다른 repo 에 적용할 때는 `review-verdict-label.md` 의 `gh label create` 2줄을 먼저 실행해야 한다.
- **머지 직후 게이트 절벽** — 이 PR 이 머지되면 현재 열린 모든 PR 이 라벨이 없어 train 에서 `[SKIPPED]` 된다. 이는 #1527 의 "부재는 차단" 확정 사항이 의도대로 동작하는 것이며, 재리뷰 또는 수동 라벨로 풀린다.
- **범위 밖으로 남긴 갭** — `gh:pr-reply` 가 *통과한* PR 에 FOLLOW-UP 수정을 푸시해도 `review-passed` 는 그대로 남아, 리뷰되지 않은 head 가 통과 라벨을 단 채 머지될 수 있다. 막으려면 푸시 시 `review-passed` 도 제거해야 하는데, 그러면 답변 패스가 무언가를 고칠 때마다 무인 플로우가 멈춘다 — 이슈가 결정하지 않은 운용 변경이라 별건으로 남긴다.

## Related
Closes #1527

---
<details>
<summary>🤖 AI Metrics · 📊 ~13500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~13500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
