### PR TITLE
fix(aicron): help 표의 status --json 을 선택 인자로 정정한다

### DIFF
--- a/shell-common/tools/custom/aicron.sh
+++ b/shell-common/tools/custom/aicron.sh
@@ -99,7 +99,7 @@ aicron_usage() {
     ux_table_row "remove <job>" "drop the job's crontab block (also cleans a doctor orphan); the state file is kept"
     ux_table_row "pause <job>" "stop running the job; the crontab entry stays"
     ux_table_row "resume <job>" "undo pause"
-    ux_table_row "status <job> --json" "running now, schedule, last run result"
+    ux_table_row "status <job>" "running now, schedule, last run result (--json for machine-readable)"
     ux_table_row "run <job>" "one execution, identical to the one cron performs"
     ux_table_row "doctor" "check manifest, crontab and state against each other"
     ux_table_row "help" "this text (also -h, --help)"


### PR DESCRIPTION
## Summary
- `aicron` help 표에서 `status <job> --json` 표기가 필수 인자처럼 읽히는 문제를 고친다

## Changes
- `shell-common/tools/custom/aicron.sh`: `status <job> --json` → `status <job>` 로 라벨을 줄이고, 설명문에 `(--json for machine-readable)` 를 덧붙여 `--json` 이 선택 플래그임을 명시했다. 같은 표의 `list [--json]` 대괄호 규약과 다시 일치한다.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/aicron.bats` — 72 tests passed
- [x] `bash shell-common/tools/custom/aicron.sh help` 출력으로 표기 확인

## Related
Closes #1499

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
