### PR TITLE
docs(gh-issue-flow): merge-train 즉시-깨우기의 효과 서술을 정숙 기간 실제 동작에 맞게 정정한다

### DIFF
--- a/claude/skills/gh-issue-flow/references/merge-train-wake.md
+++ b/claude/skills/gh-issue-flow/references/merge-train-wake.md
@@ -10,9 +10,27 @@ itself succeeded, soft-failed, or warned. It sits between Step 2.4 and Step
 Before #1482, the only thing that could start a merge attempt on a fresh PR
 was `pr_merge_train_cron.sh` firing on its own schedule (`*/23 * * * *`
 originally). A PR finished by `gh:issue-flow` could therefore sit idle for up
-to 23 minutes before anything looked at it. This step closes that gap by
-calling the same dispatcher script the cron job calls, once, right after the
-PR exists — cutting the idle time to effectively zero in the common case.
+to 23 minutes before anything looked at it. This step closes part of that gap
+by calling the same dispatcher script the cron job calls, once, right after
+the PR exists.
+
+**It does not, however, cut the triggering PR's own idle time to zero.** The
+dispatcher's target count excludes any PR updated within the last
+`_PMT_QUIET_MINUTES` (11 minutes — D-6 quiet period, see
+`shell-common/tools/custom/pr_merge_train_cron.sh` →
+`_pmt_target_count`, and `gh-pr-merge-train/references/ordering.md` for why
+11). The PR this step just created has an `updatedAt` of "just now", so it
+fails that filter on this very tick — if no other PR in the queue has already
+cleared the quiet period, the wake call ends in "No target PR — nothing to
+wake a session for" and the triggering PR is not touched. It only becomes
+eligible once its own 11-minute quiet period elapses, and from there the
+`*/5 * * * *` cron backstop picks it up within another 5 minutes at most —
+so the triggering PR's real idle time is **~11–16 minutes**, not zero.
+
+What this step *does* reliably shorten is the idle time of **other** PRs
+already sitting in the queue past their quiet period (the common case when
+several `gh:issue-flow` runs are in flight) — those get swept up to 5 minutes
+earlier than waiting for the next cron tick would have.
 
 The cron job is not removed. Its backstop period is shortened to `*/5 * * *
 *` (`shell-common/tools/custom/cron-jobs.json`) so that a dropped or missed

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -57,9 +57,10 @@ _PMT_LOCK_BASENAME=".lock"
 # PR, because minutes pass between this count and that decision.
 #
 # This filter also excludes the PR that just triggered Step 2.4.1's immediate
-# wake call (gh-issue-flow/references/merge-train-wake.md) — its updatedAt is
-# "just now", so it can't be its own tick's target. That doc documents the
-# resulting ~11-16min real latency for the triggering PR (issue #1515).
+# wake call (claude/skills/gh-issue-flow/references/merge-train-wake.md) — its
+# updatedAt is "just now", so it can't be its own tick's target. That doc
+# documents the resulting ~11-16min real latency for the triggering PR
+# (issue #1515).
 _PMT_QUIET_MINUTES="11"
 
 # Upper bound on the open-PR window. The dispatcher only needs "more than

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -55,6 +55,11 @@ _PMT_LOCK_BASENAME=".lock"
 # purpose: it only has to answer "is there anything worth waking a session
 # for". The skill re-applies it authoritatively at the moment it processes each
 # PR, because minutes pass between this count and that decision.
+#
+# This filter also excludes the PR that just triggered Step 2.4.1's immediate
+# wake call (gh-issue-flow/references/merge-train-wake.md) — its updatedAt is
+# "just now", so it can't be its own tick's target. That doc documents the
+# resulting ~11-16min real latency for the triggering PR (issue #1515).
 _PMT_QUIET_MINUTES="11"
 
 # Upper bound on the open-PR window. The dispatcher only needs "more than


### PR DESCRIPTION
## Summary
- `gh:issue-flow` Step 2.4.1(즉시-깨우기)이 유발 PR 자신의 idle 시간을 0으로 줄인다고 서술한 `merge-train-wake.md`의 과장을 D-6 정숙 기간(11분)의 실제 동작에 맞게 정정한다.
- 실질 이득은 "유발 PR 처리"가 아니라 "이미 정숙 기간을 지난 백로그를 최대 5분 앞당겨 배수"라는 점을 명시하고, 유발 PR의 실질 지연(~11–16분)을 적는다.
- `pr_merge_train_cron.sh`의 `_PMT_QUIET_MINUTES` 옆에 이 문서로의 교차 링크를 남겨 둘 사이 상호작용이 향후에도 드러나게 한다.

## Changes
- `claude/skills/gh-issue-flow/references/merge-train-wake.md`: "Why this exists" 절을 정정 — 유발 PR은 이 tick에서 처리되지 않음을 명시하고, 실제 이득(백로그 배수)과 실질 지연(~11–16분)을 추가.
- `shell-common/tools/custom/pr_merge_train_cron.sh`: `_PMT_QUIET_MINUTES` 옆에 `merge-train-wake.md`로의 교차 링크 주석 추가.

## Test plan
- [x] `mise run lint-docs` — errors=0 (경고 36건은 기존 legacy 파일명 경고, 이 변경과 무관)
- 코드 동작 변화 없음 — 문서/주석 전용 변경.

## Related
Closes #1515

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~1 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~1 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
