### PR TITLE
docs(gh-pr-review): post-comment.md 토큰 추정 예시를 #1474 이후 코드에 맞춘다

### DIFF
--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -152,13 +152,24 @@ are calibration starting points, not gospel — tighten when
 
 ## Token estimation
 
+`_gh_pr_review_estimate_tokens` (`shell-common/functions/gh_pr_review.sh`)
+takes a byte count and applies the pure arithmetic — divide by 4, round to
+the nearest 500, floor 1000:
+
 ```sh
-# Sum prompt template + diff bytes, divide by 4, round to nearest 500.
-RAW_BYTES=$(wc -c < "$PROMPT_FILE")
-TOKENS_RAW=$(( RAW_BYTES / 4 ))
-TOKENS=$(( (TOKENS_RAW + 250) / 500 * 500 ))
-[ "$TOKENS" -lt 1000 ] && TOKENS=1000
+tokens=$((raw / 4))
+tokens=$(((tokens + 250) / 500 * 500))
+[ "$tokens" -lt 1000 ] && tokens=1000
 ```
+
+The byte count itself is measured by the Step 6 caller **right after the
+prompt is written**, not re-read at comment-post time — issue #1474 fixed a
+prior bug where a late re-read could return 0 for a since-vanished prompt
+file, and the floor rule then dressed that 0 up as a plausible "~1000
+tokens" estimate. A failed read is now reported (`[WARN] Could not read
+prompt file for the token estimate — file missing?`), never silently
+folded into 0. Per "Step 6 delegation" above, this doc does not duplicate
+the measurement site or the arithmetic — read the shell function for both.
 
 The 4-bytes-per-token heuristic is conservative for English/Korean
 mixed PR bodies. Refine when a tokenizer-backed metric becomes part

--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -162,14 +162,11 @@ tokens=$(((tokens + 250) / 500 * 500))
 [ "$tokens" -lt 1000 ] && tokens=1000
 ```
 
-The byte count itself is measured by the Step 6 caller **right after the
-prompt is written**, not re-read at comment-post time — issue #1474 fixed a
-prior bug where a late re-read could return 0 for a since-vanished prompt
-file, and the floor rule then dressed that 0 up as a plausible "~1000
-tokens" estimate. A failed read is now reported (`[WARN] Could not read
-prompt file for the token estimate — file missing?`), never silently
-folded into 0. Per "Step 6 delegation" above, this doc does not duplicate
-the measurement site or the arithmetic — read the shell function for both.
+The byte count itself is measured right after Step 3+4 builds the prompt,
+not re-read at Step 6 comment-post time — the issue #1474 fix. Read the
+comment above `_gh_pr_review_estimate_tokens` and its caller in
+`gh_pr_review.sh` for the full rationale and the exact `[WARN]` text; this
+doc only tracks the arithmetic shown above.
 
 The 4-bytes-per-token heuristic is conservative for English/Korean
 mixed PR bodies. Refine when a tokenizer-backed metric becomes part

--- a/claude/skills/gh-pr-review/references/post-comment.md
+++ b/claude/skills/gh-pr-review/references/post-comment.md
@@ -163,10 +163,11 @@ tokens=$(((tokens + 250) / 500 * 500))
 ```
 
 The byte count itself is measured right after Step 3+4 builds the prompt,
-not re-read at Step 6 comment-post time — the issue #1474 fix. Read the
-comment above `_gh_pr_review_estimate_tokens` and its caller in
-`gh_pr_review.sh` for the full rationale and the exact `[WARN]` text; this
-doc only tracks the arithmetic shown above.
+not re-read at Step 6 comment-post time — the issue #1474 mitigation (the
+file-vanishing root cause itself is still open; only the measurement timing
+was fixed). Read the comment above `_gh_pr_review_estimate_tokens` and its
+caller in `gh_pr_review.sh` for the full rationale and the exact `[WARN]`
+text; this doc only tracks the arithmetic shown above.
 
 The 4-bytes-per-token heuristic is conservative for English/Korean
 mixed PR bodies. Refine when a tokenizer-backed metric becomes part


### PR DESCRIPTION
## Summary
- `gh:pr-review` 스킬의 `post-comment.md` "Token estimation" 예시가 #1474 이전 late-read 패턴을 그대로 보여주던 문제를 고친다.

## Changes
- docs(gh-pr-review): 예시 코드 블록에서 `PROMPT_FILE` 재측정 부분을 제거하고 순수 산술만 남긴다. 실제 측정 시점(프롬프트 작성 직후)과 읽기 실패 시 `[WARN]` 처리는 `_gh_pr_review_estimate_tokens` 및 그 호출부(`shell-common/functions/gh_pr_review.sh`)로 위임한다고 명시해, "Step 6 delegation" 절의 기존 위임 원칙과 일관시켰다.

## Test plan
- [x] `mise run lint-docs` — errors=0 (docs-only 변경, 코드 변경 없음)

## Related
Closes #1503

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
