### PR TITLE
docs(gh-issue-flow): merge-train-wake.md 의 _AICRON fallback 근거를 실제 메커니즘으로 정정

### DIFF
--- a/claude/skills/gh-issue-flow/references/merge-train-wake.md
+++ b/claude/skills/gh-issue-flow/references/merge-train-wake.md
@@ -80,18 +80,38 @@ One consequence: the dispatcher's own exit code is never observed here —
 see "Soft-fail policy" below.
 
 **Why the `$HOME/dotfiles` fallback is intentional, not a portability gap.**
-The `${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}` chain
-mirrors the SSOT fallback used throughout this skill suite (e.g.
-`gh-issue-implement/references/claim.md` Step 3.4). Here it does double duty:
-`gh:issue-flow`'s own precondition is a dedicated feature-branch **worktree**,
-never the checkout at `$HOME/dotfiles` — but crontab always calls
-`$HOME/dotfiles/shell-common/tools/custom/aicron.sh` (see
+`gh:issue-flow`'s own precondition is a dedicated feature-branch
+**worktree**, never the checkout at `$HOME/dotfiles` — but crontab always
+calls `$HOME/dotfiles/shell-common/tools/custom/aicron.sh` (see
 `crontab -l`), never a worktree path, because a worktree is torn down after
 its PR merges while the crontab entry is permanent. Waking the *same*
 dispatcher instance cron uses — not a worktree-local copy that may not have
 `aicron`'s installed state/manifest, and would vanish with the worktree —
-is the correct target, so this step deliberately falls through past any
-worktree-scoped `SHELL_COMMON`/`DOTFILES_ROOT` to the live checkout.
+is the correct target. The `${SHELL_COMMON:-${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common}`
+chain reaches that target in two tiers, not by falling through past a
+worktree-scoped value:
+
+1. **`SHELL_COMMON` is already canonical (#589).** An interactive shell that
+   started this skill session sourced `bash/main.bash` / `zsh/main.zsh`,
+   which calls `_dotfiles_root_canonicalize` (`shell-common/functions/dotfiles_root.sh:110`)
+   at loader entry. That function walks a linked worktree back to the main
+   worktree via `git rev-parse --git-common-dir` and re-exports both
+   `DOTFILES_ROOT` and `SHELL_COMMON` (`dotfiles_root.sh:116`) to the main
+   checkout path — the same path crontab uses. So in the common case
+   `SHELL_COMMON` is picked first by the `:-` chain and is *already* the
+   live checkout; there is no fall-through happening.
+2. **`$HOME/dotfiles` is the last-resort tier**, used only when
+   `SHELL_COMMON`/`DOTFILES_ROOT` are both unset — a non-interactive
+   environment where no loader ran to canonicalize them.
+
+**Escape hatch interaction.** `DOTFILES_ROOT_NO_CANONICALIZE=1`
+(`_resolve_dotfiles_root_canonical` in `dotfiles_root.sh`) disables tier 1's
+canonicalization for a shell that intentionally wants to test a worktree's
+own dotfiles. If that variable is set in the shell running Step 2.4.1,
+`SHELL_COMMON` stays worktree-scoped and this step wakes the
+**worktree-local** `aicron.sh` instead of the live checkout — the exact
+outcome this section says is undesirable, since the worktree vanishes once
+its PR merges.
 
 ## Soft-fail policy (F-2)
 

--- a/claude/skills/gh-issue-flow/references/merge-train-wake.md
+++ b/claude/skills/gh-issue-flow/references/merge-train-wake.md
@@ -110,8 +110,7 @@ canonicalization for a shell that intentionally wants to test a worktree's
 own dotfiles. If that variable is set in the shell running Step 2.4.1,
 `SHELL_COMMON` stays worktree-scoped and this step wakes the
 **worktree-local** `aicron.sh` instead of the live checkout — the exact
-outcome this section says is undesirable, since the worktree vanishes once
-its PR merges.
+outcome this section says is undesirable.
 
 ## Soft-fail policy (F-2)
 

--- a/claude/skills/gh-issue-flow/references/merge-train-wake.md
+++ b/claude/skills/gh-issue-flow/references/merge-train-wake.md
@@ -104,6 +104,17 @@ worktree-scoped value:
    `SHELL_COMMON`/`DOTFILES_ROOT` are both unset — a non-interactive
    environment where no loader ran to canonicalize them.
 
+**Caveat on both tiers.** The split above assumes the running shell —
+interactive, or a non-interactive agent/automation session — itself sourced
+`bash/main.bash` / `zsh/main.zsh`, or inherited its environment from a parent
+that did. A shell that instead manually exports `SHELL_COMMON`/`DOTFILES_ROOT`,
+or inherits them from a process that never ran the loader, sits outside that
+guarantee: tier 1 can pick up a stale or non-canonical `SHELL_COMMON` value,
+and tier 2 only fires when both variables are literally unset, not merely
+stale. This degrades safely in practice — Step 2.4.1 is a best-effort
+background wake, never load-bearing for the flow itself — but the two tiers
+above describe the common case, not an invariant.
+
 **Escape hatch interaction.** `DOTFILES_ROOT_NO_CANONICALIZE=1`
 (`_resolve_dotfiles_root_canonical` in `dotfiles_root.sh`) disables tier 1's
 canonicalization for a shell that intentionally wants to test a worktree's


### PR DESCRIPTION
## Summary
- `merge-train-wake.md`의 "$HOME/dotfiles fallback" 근거 문단을 실제 메커니즘으로 정정한다.

## Changes
- `claude/skills/gh-issue-flow/references/merge-train-wake.md`: `${SHELL_COMMON:-...}` 체인이 worktree-scoped 값을 "지나쳐 떨어진다"는 잘못된 서술을 제거하고, 실제로는 #589 `_dotfiles_root_canonicalize`가 loader 진입 시 `SHELL_COMMON`/`DOTFILES_ROOT`를 이미 main worktree 경로로 재-export해두기 때문이라는 2단(tier) 구조로 재서술했다. `DOTFILES_ROOT_NO_CANONICALIZE=1` 이스케이프 해치가 켜진 셸에서 Step 2.4.1이 worktree-local `aicron.sh`를 깨우게 되는 상충도 각주로 명시했다.

## Test plan
- [x] `grep -rl "merge-train-wake" tests/` — 이 문서를 참조하는 테스트 없음을 확인 (docs-only 변경)
- [x] 문서 렌더링/링크 형식 육안 검토

## Related
Closes #1495

---
<details>
<summary>🤖 AI Metrics · 📊 ~1500 tokens · 👤 ~1 h · 🤖 ~9 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1500 tokens · 👤 ~1 h · 🤖 ~9 min
<!-- /ai-metrics:gh-pr -->

</details>
