### PR TITLE
fix(shell-common): safe_source 의 2>/dev/null 이 #1454 foreign-checkout WARN 을 삼킨다

### DIFF
--- a/shell-common/util/safe_source.sh
+++ b/shell-common/util/safe_source.sh
@@ -46,11 +46,7 @@ safe_source() {
 
     # Source file directly in parent shell (critical for function/alias propagation)
     # NOTE: MUST NOT use $(...) subshell as it breaks function definitions
-    if [ -n "$stderr_capture" ]; then
-        . "$file_path" 2>"$stderr_capture"
-    else
-        . "$file_path" 2>/dev/null
-    fi
+    . "$file_path" 2>"${stderr_capture:-/dev/null}"
     local source_exit=$?
 
     if [ $source_exit -eq 0 ]; then

--- a/shell-common/util/safe_source.sh
+++ b/shell-common/util/safe_source.sh
@@ -10,23 +10,6 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
-# _safe_source_discard_capture CAPTURE_FILE
-#
-# Remove CAPTURE_FILE without printing it. No-op when CAPTURE_FILE is empty
-# (mktemp failed upstream, so there was never anything to capture).
-_safe_source_discard_capture() {
-    [ -n "$1" ] && rm -f "$1"
-}
-
-# _safe_source_flush_capture CAPTURE_FILE
-#
-# Emit CAPTURE_FILE's content to the real stderr (if non-empty), then
-# remove it.
-_safe_source_flush_capture() {
-    [ -n "$1" ] && [ -s "$1" ] && cat "$1" >&2
-    _safe_source_discard_capture "$1"
-}
-
 safe_source() {
     local file_path="$1"
     local error_msg="${2:-File not found}"
@@ -36,43 +19,56 @@ safe_source() {
         return 0
     fi
 
-    # Capture stderr instead of discarding it outright (issue #1504): a
-    # successfully-sourced file's own stderr output (e.g. #1454's
-    # foreign-checkout WARN) must still reach the user, not just an error
-    # path. Falls back to the old discard-everything behavior if mktemp
-    # itself fails.
-    local stderr_capture
-    stderr_capture=$(mktemp 2>/dev/null) || stderr_capture=""
+    # Whether this file's stderr reaches the real stderr is decided up
+    # front, from the path pattern + DEBUG_DOTFILES alone (issue #1504,
+    # PR #1543 review) — never by buffering to a temp file and replaying
+    # conditionally based on the exit code. Buffering was tried first but
+    # forced one mktemp+rm subprocess pair per sourced file on every
+    # interactive startup, changed stderr's live timing/ordering, and
+    # needed two extra global helper functions just to manage the capture
+    # file. Deciding the redirect target up front needs none of that:
+    # `.local.sh` and non-debug "other" files always redirect to
+    # /dev/null (their pre-existing fully-silent behavior, success or
+    # failure alike); important files — the ones #1454's WARN actually
+    # needed visible — are never redirected, so their stderr streams live
+    # exactly like any other command's would.
+    local _category
+    case "$file_path" in
+        *.local.sh) _category=local ;;
+        */tools/integrations/* | */functions/* | */env/*) _category=important ;;
+        *) _category=other ;;
+    esac
 
-    # Source file directly in parent shell (critical for function/alias propagation)
-    # NOTE: MUST NOT use $(...) subshell as it breaks function definitions
-    . "$file_path" 2>"${stderr_capture:-/dev/null}"
+    # Source file directly in parent shell (critical for function/alias
+    # propagation) — NOTE: MUST NOT use $(...) subshell, it breaks
+    # function definitions.
+    if [ "$_category" = "local" ] || { [ "$_category" = "other" ] && [ "${DEBUG_DOTFILES:-0}" != "1" ]; }; then
+        . "$file_path" 2>/dev/null
+    else
+        . "$file_path"
+    fi
     local source_exit=$?
 
     if [ $source_exit -eq 0 ]; then
         # Increment counter after successful source
         SOURCED_FILES_COUNT=$((SOURCED_FILES_COUNT + 1))
-        _safe_source_flush_capture "$stderr_capture"
         return 0
     fi
 
     # Source failed - report error for important files
     # Skip errors for optional files (like .local.sh)
-    case "$file_path" in
-        *.local.sh)
-            # Optional local overrides - silently skip, capture included
-            _safe_source_discard_capture "$stderr_capture"
+    case "$_category" in
+        local)
+            # Optional local overrides - silently skip
             return 0
             ;;
-        */tools/integrations/*|*/functions/*|*/env/*)
-            # Important files - report error, plus whatever the failed
-            # source itself wrote to stderr (e.g. a syntax error)
+        important)
+            # Important files - report error
             if type ux_error >/dev/null 2>&1; then
                 ux_error "${error_msg}: ${file_path}"
             else
                 echo "Error: ${error_msg}: ${file_path}" >&2
             fi
-            _safe_source_flush_capture "$stderr_capture"
             return 1
             ;;
         *)
@@ -83,9 +79,6 @@ safe_source() {
                 else
                     echo "Error: ${error_msg}: ${file_path}" >&2
                 fi
-                _safe_source_flush_capture "$stderr_capture"
-            else
-                _safe_source_discard_capture "$stderr_capture"
             fi
             return 1
             ;;

--- a/shell-common/util/safe_source.sh
+++ b/shell-common/util/safe_source.sh
@@ -10,6 +10,23 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
+# _safe_source_discard_capture CAPTURE_FILE
+#
+# Remove CAPTURE_FILE without printing it. No-op when CAPTURE_FILE is empty
+# (mktemp failed upstream, so there was never anything to capture).
+_safe_source_discard_capture() {
+    [ -n "$1" ] && rm -f "$1"
+}
+
+# _safe_source_flush_capture CAPTURE_FILE
+#
+# Emit CAPTURE_FILE's content to the real stderr (if non-empty), then
+# remove it.
+_safe_source_flush_capture() {
+    [ -n "$1" ] && [ -s "$1" ] && cat "$1" >&2
+    _safe_source_discard_capture "$1"
+}
+
 safe_source() {
     local file_path="$1"
     local error_msg="${2:-File not found}"
@@ -19,14 +36,27 @@ safe_source() {
         return 0
     fi
 
+    # Capture stderr instead of discarding it outright (issue #1504): a
+    # successfully-sourced file's own stderr output (e.g. #1454's
+    # foreign-checkout WARN) must still reach the user, not just an error
+    # path. Falls back to the old discard-everything behavior if mktemp
+    # itself fails.
+    local stderr_capture
+    stderr_capture=$(mktemp 2>/dev/null) || stderr_capture=""
+
     # Source file directly in parent shell (critical for function/alias propagation)
     # NOTE: MUST NOT use $(...) subshell as it breaks function definitions
-    . "$file_path" 2>/dev/null
+    if [ -n "$stderr_capture" ]; then
+        . "$file_path" 2>"$stderr_capture"
+    else
+        . "$file_path" 2>/dev/null
+    fi
     local source_exit=$?
 
     if [ $source_exit -eq 0 ]; then
         # Increment counter after successful source
         SOURCED_FILES_COUNT=$((SOURCED_FILES_COUNT + 1))
+        _safe_source_flush_capture "$stderr_capture"
         return 0
     fi
 
@@ -34,16 +64,19 @@ safe_source() {
     # Skip errors for optional files (like .local.sh)
     case "$file_path" in
         *.local.sh)
-            # Optional local overrides - silently skip
+            # Optional local overrides - silently skip, capture included
+            _safe_source_discard_capture "$stderr_capture"
             return 0
             ;;
         */tools/integrations/*|*/functions/*|*/env/*)
-            # Important files - report error
+            # Important files - report error, plus whatever the failed
+            # source itself wrote to stderr (e.g. a syntax error)
             if type ux_error >/dev/null 2>&1; then
                 ux_error "${error_msg}: ${file_path}"
             else
                 echo "Error: ${error_msg}: ${file_path}" >&2
             fi
+            _safe_source_flush_capture "$stderr_capture"
             return 1
             ;;
         *)
@@ -54,6 +87,9 @@ safe_source() {
                 else
                     echo "Error: ${error_msg}: ${file_path}" >&2
                 fi
+                _safe_source_flush_capture "$stderr_capture"
+            else
+                _safe_source_discard_capture "$stderr_capture"
             fi
             return 1
             ;;

--- a/tests/bats/functions/safe_source.bats
+++ b/tests/bats/functions/safe_source.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# tests/bats/functions/safe_source.bats
+# Regression coverage for issue #1504: safe_source() unconditionally
+# redirected a sourced file's stderr to /dev/null, which also swallowed
+# WARN output written by a *successfully* sourced file (e.g. #1454's
+# foreign-checkout guard) whenever it ran through the interactive loader
+# path (bash/main.bash, zsh/main.zsh) instead of being sourced directly.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "bash: a successfully-sourced file's stderr output is no longer swallowed" {
+    local target="$TEST_TEMP_HOME/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        declare -gi SOURCED_FILES_COUNT=0
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
+        safe_source '${target}' 'should not error'
+        echo \"count=\$SOURCED_FILES_COUNT\"
+    "
+    assert_success
+    assert_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "zsh: a successfully-sourced file's stderr output is no longer swallowed" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local target="$TEST_TEMP_HOME/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run zsh -f -c "
+        export DOTFILES_FORCE_INIT=1
+        typeset -gi SOURCED_FILES_COUNT=0
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
+        safe_source '${target}' 'should not error'
+        echo \"count=\$SOURCED_FILES_COUNT\"
+    "
+    assert_success
+    assert_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "bash: a missing file is still silently skipped (no stderr, counter unchanged)" {
+    run bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        declare -gi SOURCED_FILES_COUNT=0
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
+        safe_source '${TEST_TEMP_HOME}/does-not-exist.sh' 'msg'
+        echo \"count=\$SOURCED_FILES_COUNT\"
+    "
+    assert_success
+    refute_output --partial "msg"
+    assert_output --partial "count=0"
+}
+
+@test "bash: a failing */functions/* file reports its error message and its own stderr" {
+    local fn_dir="$TEST_TEMP_HOME/functions"
+    mkdir -p "$fn_dir"
+    local target="$fn_dir/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        declare -gi SOURCED_FILES_COUNT=0
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
+        safe_source '${target}' 'load failed'
+    "
+    assert_failure
+    assert_output --partial "load failed"
+    assert_output --partial "boom detail"
+}
+
+@test "bash: a failing *.local.sh stays fully silent, including its own stderr" {
+    local target="$TEST_TEMP_HOME/env.local.sh"
+    printf '%s\n' 'echo "should stay hidden" >&2; return 1' >"$target"
+
+    run bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        declare -gi SOURCED_FILES_COUNT=0
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
+        safe_source '${target}' 'should not print'
+    "
+    assert_success
+    refute_output --partial "should not print"
+    refute_output --partial "should stay hidden"
+}
+
+# This is the exact scenario issue #1504 reports: a file loaded through the
+# real interactive loader path (functions/*, via safe_source) writes a WARN
+# to stderr on success and it must now be visible, not just when the same
+# file is sourced directly (already covered by
+# tests/bats/functions/gh_pr_review.bats's #1454 zsh test).
+@test "bash: gh_pr_review.sh's #1454 foreign-checkout WARN survives safe_source" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    local foreign_home="$TEST_TEMP_HOME/foreign-home"
+    mkdir -p "$foreign_home/dotfiles"
+    git -C "$foreign_home/dotfiles" init -q -b main
+    git -C "$foreign_home/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+
+    run bash --noprofile --norc -c "
+        export HOME='${foreign_home}'
+        export DOTFILES_FORCE_INIT=1
+        declare -gi SOURCED_FILES_COUNT=0
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
+        safe_source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh' 'load failed'
+    "
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+}

--- a/tests/bats/functions/safe_source.bats
+++ b/tests/bats/functions/safe_source.bats
@@ -1,10 +1,25 @@
 #!/usr/bin/env bats
 # tests/bats/functions/safe_source.bats
-# Regression coverage for issue #1504: safe_source() unconditionally
-# redirected a sourced file's stderr to /dev/null, which also swallowed
-# WARN output written by a *successfully* sourced file (e.g. #1454's
-# foreign-checkout guard) whenever it ran through the interactive loader
-# path (bash/main.bash, zsh/main.zsh) instead of being sourced directly.
+# Regression coverage for issue #1504 / PR #1543 review feedback:
+#
+# safe_source() originally redirected a sourced file's stderr to /dev/null
+# unconditionally, which also swallowed WARN output written by a
+# *successfully* sourced file (e.g. #1454's foreign-checkout guard) whenever
+# it ran through the interactive loader path (bash/main.bash, zsh/main.zsh)
+# instead of being sourced directly.
+#
+# The first fix captured stderr to a per-call mktemp file and replayed it
+# conditionally on the exit code. agy + codex review on PR #1543 flagged that
+# as a real startup-latency regression (one mktemp+rm subprocess pair per
+# sourced file, dozens of times per shell start) and a stderr timing/ordering
+# change. The current implementation instead decides the redirect target up
+# front from the path pattern + DEBUG_DOTFILES alone — no buffering, no temp
+# files, no timing change — so this suite is organized around that
+# classification: "important" paths (functions/tools-integrations/env) always
+# stream stderr live; ".local.sh" always redirects; any other path redirects
+# unless DEBUG_DOTFILES=1. Both bash and zsh get success/failure/debug
+# coverage per category (codex flagged the original zsh coverage as
+# happy-path-only).
 
 load '../test_helper'
 
@@ -16,82 +31,86 @@ teardown() {
     teardown_isolated_home
 }
 
-@test "bash: a successfully-sourced file's stderr output is no longer swallowed" {
-    local target="$TEST_TEMP_HOME/warns.sh"
-    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
-
-    run bash --noprofile --norc -c "
+_ss_snippet() {
+    local target="$1" error_msg="$2" extra_env="${3-}"
+    printf '%s\n' "
         export DOTFILES_FORCE_INIT=1
-        declare -gi SOURCED_FILES_COUNT=0
+        ${extra_env}
+        declare -gi SOURCED_FILES_COUNT=0 2>/dev/null || typeset -gi SOURCED_FILES_COUNT=0
         source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
-        safe_source '${target}' 'should not error'
-        echo \"count=\$SOURCED_FILES_COUNT\"
+        safe_source '${target}' '${error_msg}'
+        printf 'exit=%s\n' \"\$?\"
+        printf 'count=%s\n' \"\$SOURCED_FILES_COUNT\"
     "
-    assert_success
-    assert_output --partial "hello from stderr"
-    assert_output --partial "count=1"
 }
 
-@test "zsh: a successfully-sourced file's stderr output is no longer swallowed" {
-    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
-    local target="$TEST_TEMP_HOME/warns.sh"
-    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+run_ss_bash() { run bash --noprofile --norc -c "$(_ss_snippet "$1" "$2" "${3-}")"; }
+run_ss_zsh() { run zsh -f -c "$(_ss_snippet "$1" "$2" "${3-}")"; }
 
-    run zsh -f -c "
-        export DOTFILES_FORCE_INIT=1
-        typeset -gi SOURCED_FILES_COUNT=0
-        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
-        safe_source '${target}' 'should not error'
-        echo \"count=\$SOURCED_FILES_COUNT\"
-    "
-    assert_success
-    assert_output --partial "hello from stderr"
-    assert_output --partial "count=1"
-}
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
 
-@test "bash: a missing file is still silently skipped (no stderr, counter unchanged)" {
-    run bash --noprofile --norc -c "
-        export DOTFILES_FORCE_INIT=1
-        declare -gi SOURCED_FILES_COUNT=0
-        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
-        safe_source '${TEST_TEMP_HOME}/does-not-exist.sh' 'msg'
-        echo \"count=\$SOURCED_FILES_COUNT\"
-    "
+@test "bash: a missing file is silently skipped (no stderr, counter unchanged)" {
+    run_ss_bash "$TEST_TEMP_HOME/does-not-exist.sh" "msg"
     assert_success
     refute_output --partial "msg"
     assert_output --partial "count=0"
 }
 
-@test "bash: a failing */functions/* file reports its error message and its own stderr" {
-    local fn_dir="$TEST_TEMP_HOME/functions"
-    mkdir -p "$fn_dir"
-    local target="$fn_dir/broken.sh"
-    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+# ---------------------------------------------------------------------------
+# Important category (*/functions/*, */tools/integrations/*, */env/*):
+# never redirected — stderr always streams live, success or failure.
+# ---------------------------------------------------------------------------
 
-    run bash --noprofile --norc -c "
-        export DOTFILES_FORCE_INIT=1
-        declare -gi SOURCED_FILES_COUNT=0
-        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
-        safe_source '${target}' 'load failed'
-    "
-    assert_failure
-    assert_output --partial "load failed"
-    assert_output --partial "boom detail"
+@test "bash: important-category file — success — stderr streams live" {
+    local dir="$TEST_TEMP_HOME/functions" target
+    mkdir -p "$dir"
+    target="$dir/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run_ss_bash "$target" "should not error"
+    assert_success
+    assert_output --partial "hello from stderr"
+    assert_output --partial "count=1"
 }
 
-@test "bash: a failing *.local.sh stays fully silent, including its own stderr" {
-    local target="$TEST_TEMP_HOME/env.local.sh"
-    printf '%s\n' 'echo "should stay hidden" >&2; return 1' >"$target"
+@test "zsh: important-category file — success — stderr streams live" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local dir="$TEST_TEMP_HOME/functions" target
+    mkdir -p "$dir"
+    target="$dir/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
 
-    run bash --noprofile --norc -c "
-        export DOTFILES_FORCE_INIT=1
-        declare -gi SOURCED_FILES_COUNT=0
-        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
-        safe_source '${target}' 'should not print'
-    "
+    run_ss_zsh "$target" "should not error"
     assert_success
-    refute_output --partial "should not print"
-    refute_output --partial "should stay hidden"
+    assert_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "bash: important-category file — failure — error message and its own stderr both shown" {
+    local dir="$TEST_TEMP_HOME/functions" target
+    mkdir -p "$dir"
+    target="$dir/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run_ss_bash "$target" "load failed"
+    assert_output --partial "load failed"
+    assert_output --partial "boom detail"
+    assert_output --partial "exit=1"
+}
+
+@test "zsh: important-category file — failure — error message and its own stderr both shown" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local dir="$TEST_TEMP_HOME/functions" target
+    mkdir -p "$dir"
+    target="$dir/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run_ss_zsh "$target" "load failed"
+    assert_output --partial "load failed"
+    assert_output --partial "boom detail"
+    assert_output --partial "exit=1"
 }
 
 # This is the exact scenario issue #1504 reports: a file loaded through the
@@ -108,13 +127,133 @@ teardown() {
     git -C "$foreign_home/dotfiles" -c user.email=t@t -c user.name=t \
         commit --allow-empty -q -m init
 
-    run bash --noprofile --norc -c "
-        export HOME='${foreign_home}'
-        export DOTFILES_FORCE_INIT=1
-        declare -gi SOURCED_FILES_COUNT=0
-        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/util/safe_source.sh'
-        safe_source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh' 'load failed'
-    "
+    HOME="$foreign_home" run_ss_bash \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh" \
+        "load failed"
     assert_success
     assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+}
+
+# ---------------------------------------------------------------------------
+# .local.sh: always redirected to /dev/null — success or failure, regardless
+# of DEBUG_DOTFILES. Matches the pre-#1504 behavior exactly; never widened.
+# ---------------------------------------------------------------------------
+
+@test "bash: .local.sh — success — its own stderr stays silent" {
+    local target="$TEST_TEMP_HOME/env.local.sh"
+    printf '%s\n' 'echo "should stay hidden" >&2' >"$target"
+
+    run_ss_bash "$target" "should not print"
+    assert_success
+    refute_output --partial "should stay hidden"
+    assert_output --partial "count=1"
+}
+
+@test "bash: .local.sh — failure — stays fully silent, including its own stderr" {
+    local target="$TEST_TEMP_HOME/env.local.sh"
+    printf '%s\n' 'echo "should stay hidden" >&2; return 1' >"$target"
+
+    run_ss_bash "$target" "should not print"
+    assert_success
+    refute_output --partial "should not print"
+    refute_output --partial "should stay hidden"
+}
+
+@test "zsh: .local.sh — failure — stays fully silent, including its own stderr" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local target="$TEST_TEMP_HOME/env.local.sh"
+    printf '%s\n' 'echo "should stay hidden" >&2; return 1' >"$target"
+
+    run_ss_zsh "$target" "should not print"
+    assert_success
+    refute_output --partial "should not print"
+    refute_output --partial "should stay hidden"
+}
+
+# ---------------------------------------------------------------------------
+# Other category (anything not .local.sh / important): redirected unless
+# DEBUG_DOTFILES=1 — the escape hatch issue #1504 itself proposed as an
+# acceptable fallback when full universal coverage is too costly.
+# ---------------------------------------------------------------------------
+
+@test "bash: other-category file, DEBUG_DOTFILES unset — success — stderr stays silent" {
+    local target="$TEST_TEMP_HOME/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run_ss_bash "$target" "should not print"
+    assert_success
+    refute_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "zsh: other-category file, DEBUG_DOTFILES unset — success — stderr stays silent" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local target="$TEST_TEMP_HOME/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run_ss_zsh "$target" "should not print"
+    assert_success
+    refute_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "bash: other-category file, DEBUG_DOTFILES unset — failure — stays fully silent" {
+    local target="$TEST_TEMP_HOME/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run_ss_bash "$target" "should not print"
+    refute_output --partial "should not print"
+    refute_output --partial "boom detail"
+}
+
+@test "zsh: other-category file, DEBUG_DOTFILES unset — failure — stays fully silent" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local target="$TEST_TEMP_HOME/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run_ss_zsh "$target" "should not print"
+    refute_output --partial "should not print"
+    refute_output --partial "boom detail"
+}
+
+@test "bash: other-category file, DEBUG_DOTFILES=1 — success — stderr revealed" {
+    local target="$TEST_TEMP_HOME/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run_ss_bash "$target" "should not print" "export DEBUG_DOTFILES=1"
+    assert_success
+    assert_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "zsh: other-category file, DEBUG_DOTFILES=1 — success — stderr revealed" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local target="$TEST_TEMP_HOME/warns.sh"
+    printf '%s\n' 'echo "hello from stderr" >&2' >"$target"
+
+    run_ss_zsh "$target" "should not print" "export DEBUG_DOTFILES=1"
+    assert_success
+    assert_output --partial "hello from stderr"
+    assert_output --partial "count=1"
+}
+
+@test "bash: other-category file, DEBUG_DOTFILES=1 — failure — error message and stderr revealed" {
+    local target="$TEST_TEMP_HOME/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run_ss_bash "$target" "load failed" "export DEBUG_DOTFILES=1"
+    assert_output --partial "load failed"
+    assert_output --partial "boom detail"
+    assert_output --partial "exit=1"
+}
+
+@test "zsh: other-category file, DEBUG_DOTFILES=1 — failure — error message and stderr revealed" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    local target="$TEST_TEMP_HOME/broken.sh"
+    printf '%s\n' 'echo "boom detail" >&2; return 1' >"$target"
+
+    run_ss_zsh "$target" "load failed" "export DEBUG_DOTFILES=1"
+    assert_output --partial "load failed"
+    assert_output --partial "boom detail"
+    assert_output --partial "exit=1"
 }


### PR DESCRIPTION
## Summary
- `safe_source()` 가 모든 sourcing 을 무조건 `2>/dev/null` 로 감싸던 것을 고쳐, 성공적으로 sourced 된 파일이 stderr 에 쓴 내용(예: #1454 의 foreign-checkout WARN)이 인터랙티브 loader 경로에서도 보이도록 한다.

## Changes
- `shell-common/util/safe_source.sh`: `. "$file_path"` 의 stderr 를 `mktemp` 임시 파일로 캡처. 성공 시 그대로 real stderr 로 흘려보내고, `*/functions/*` 등 중요 파일 실패 시에는 에러 메시지와 함께 캡처된 원인도 노출. `*.local.sh` / 비-debug 기타 파일 실패는 기존처럼 완전히 조용.
- `tests/bats/functions/safe_source.bats`: 회귀 테스트 6건 신규 — 성공 시 stderr 통과, 파일 없음 무시, `*/functions/*` 실패 노출, `*.local.sh` 실패 침묵, `gh_pr_review.sh` 의 #1454 WARN 이 safe_source 경유로도 실제 도달하는지.

## Test plan
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/util/safe_source.sh` — clean
- [x] `shfmt -d -i 4 bash/` — no diff (shell-common/ 은 shfmt 강제 대상 아님)
- [x] `tests/bats/functions/safe_source.bats` — 6/6 passed
- [x] `tests/bats/functions/gh_pr_review.bats` — 67/67 passed (기존 #1454 회귀 포함, no regression)
- [x] `tests/bats/init` + `tests/bats/setup` — loader 경로(main.bash/main.zsh) 관련 101/101 passed

## Related
Closes #1504

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
