### PR TITLE
fix(ux_lib): ux_table_row 20자 초과 라벨의 표 정렬 붕괴를 고친다

### DIFF
--- a/docs/public/changelog.d/2026-08-27-1501.md
+++ b/docs/public/changelog.d/2026-08-27-1501.md
@@ -1,0 +1,2 @@
+- 변경: **`ux_table_row` 이 20자를 넘는 라벨을 두 줄로 감싸 표 정렬이 깨지지 않게 한다 — 20자 이하 행의 출력은 그대로다**
+- 변경: **라벨 폭 정책(20자 기준, lint 강제 없음)을 `shell-common/tools/ux_lib/UX_GUIDELINES.md` 의 Table Formatting 절에 명시했다**

--- a/shell-common/tools/ux_lib/UX_GUIDELINES.md
+++ b/shell-common/tools/ux_lib/UX_GUIDELINES.md
@@ -62,6 +62,14 @@ The library automatically handles the paths for its internal Python dependencies
 *   Use `mytool/demo_ux.sh` to interactively test UX features.
 *   Run `mytool/check_ux_consistency.sh` to ensure adherence to guidelines.
 
+## Table Formatting
+
+`ux_table_row` 의 첫 컬럼(라벨)은 20칸으로 정렬된다.
+
+*   줄일 수 있는 라벨은 20자 이하로 유지한다.
+*   정확한 명령 구문처럼 줄일 수 없는 라벨(예: `claude mcp remove <name>`)은 그대로 넘긴다. 20자를 넘으면 `ux_table_row` 가 라벨을 한 줄에 먼저 출력하고 설명을 다음 줄로 넘겨 구분자 정렬을 유지한다.
+*   따라서 호출부에서 긴 라벨을 따로 처리할 필요가 없다. 라벨 길이를 강제하는 lint 는 두지 않는다 (#1501).
+
 ## Best Practices
 
 *   **Never hardcode colors**: Always use `UX_PRIMARY`, `UX_SUCCESS`, etc.

--- a/shell-common/tools/ux_lib/UX_GUIDELINES.md
+++ b/shell-common/tools/ux_lib/UX_GUIDELINES.md
@@ -66,8 +66,8 @@ The library automatically handles the paths for its internal Python dependencies
 
 `ux_table_row` 의 첫 컬럼(라벨)은 20칸으로 정렬된다.
 
-*   줄일 수 있는 라벨은 20자 이하로 유지한다.
-*   정확한 명령 구문처럼 줄일 수 없는 라벨(예: `claude mcp remove <name>`)은 그대로 넘긴다. 20자를 넘으면 `ux_table_row` 가 라벨을 한 줄에 먼저 출력하고 설명을 다음 줄로 넘겨 구분자 정렬을 유지한다.
+*   줄일 수 있는 라벨은 20칸(표시 폭) 이하로 유지한다.
+*   정확한 명령 구문처럼 줄일 수 없는 라벨(예: `claude mcp remove <name>`)은 그대로 넘긴다. 표시 폭이 20칸을 넘으면 `ux_table_row` 가 라벨을 한 줄에 먼저 출력하고 설명을 다음 줄로 넘겨 구분자 정렬을 유지한다.
 *   따라서 호출부에서 긴 라벨을 따로 처리할 필요가 없다. 라벨 길이를 강제하는 lint 는 두지 않는다 (#1501).
 
 ## Best Practices

--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -464,7 +464,12 @@ ux_table_row() {
     # 20자를 넘는 라벨은 %-20s 가 자르지 않고 그대로 밀어내 구분자와 뒤 컬럼의
     # 정렬을 깨뜨린다. 라벨을 따로 한 줄에 내보내고 이어지는 줄의 라벨 칸을
     # 비워, 구분자가 평범한 행과 같은 열에 오게 한다.
-    if [ "${#col1}" -gt 20 ]; then
+    # ${#col1}은 문자 수를 셀 뿐 터미널 표시 폭이 아니다 — CJK/한글처럼 2칸을
+    # 차지하는 wide character가 섞이면 어긋난다(ux_header와 동일 이유).
+    # `wc -L`로 locale-aware 표시 폭을 구한다.
+    local col1_width
+    col1_width=$(printf '%s' "$col1" | wc -L)
+    if [ "$col1_width" -gt 20 ]; then
         printf "  ${UX_PRIMARY}%s${UX_RESET}\n" "$col1"
         label=""
     fi

--- a/shell-common/tools/ux_lib/ux_lib.sh
+++ b/shell-common/tools/ux_lib/ux_lib.sh
@@ -459,11 +459,20 @@ ux_table_row() {
     local col1="$1"
     local col2="$2"
     local col3="${3:-}"
+    local label="$col1"
+
+    # 20자를 넘는 라벨은 %-20s 가 자르지 않고 그대로 밀어내 구분자와 뒤 컬럼의
+    # 정렬을 깨뜨린다. 라벨을 따로 한 줄에 내보내고 이어지는 줄의 라벨 칸을
+    # 비워, 구분자가 평범한 행과 같은 열에 오게 한다.
+    if [ "${#col1}" -gt 20 ]; then
+        printf "  ${UX_PRIMARY}%s${UX_RESET}\n" "$col1"
+        label=""
+    fi
 
     if [ -n "$col3" ]; then
-        printf "  ${UX_PRIMARY}%-20s${UX_RESET} ${UX_MUTED}│${UX_RESET} %-30s ${UX_MUTED}│${UX_RESET} %s\n" "$col1" "$col2" "$col3"
+        printf "  ${UX_PRIMARY}%-20s${UX_RESET} ${UX_MUTED}│${UX_RESET} %-30s ${UX_MUTED}│${UX_RESET} %s\n" "$label" "$col2" "$col3"
     else
-        printf "  ${UX_PRIMARY}%-20s${UX_RESET} ${UX_MUTED}:${UX_RESET} %s\n" "$col1" "$col2"
+        printf "  ${UX_PRIMARY}%-20s${UX_RESET} ${UX_MUTED}:${UX_RESET} %s\n" "$label" "$col2"
     fi
 }
 

--- a/tests/bats/tools/ux_lib_table_row.bats
+++ b/tests/bats/tools/ux_lib_table_row.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# tests/bats/tools/ux_lib_table_row.bats
+# ux_table_row 의 라벨 폭 정책(#1501) 회귀 검증.
+# `%-20s` 는 20자를 넘는 라벨을 자르지도 감싸지도 않아 구분자와 뒤 컬럼을
+# 오른쪽으로 밀어버린다(#1481 에서 aicron 한 곳만 라벨 축약으로 땜질).
+# 정책: 20자 이하 라벨은 기존 한 줄 출력을 바이트 단위로 유지하고,
+# 20자를 넘는 라벨만 라벨 줄 + 이어붙임 줄로 감싸 구분자 위치를 보존한다.
+
+load '../test_helper'
+
+_run_ux_table_row() {
+    bash --noprofile --norc -c "
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        source '${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh'
+        ux_table_row \"\$@\"
+    " _ "$@"
+}
+
+# 첫 구분자 앞부분의 표시 폭(display width)을 돌려준다.
+_sep_column() {
+    local line="$1" sep="$2" prefix
+    prefix="${line%%"$sep"*}"
+    printf '%s' "$prefix" | wc -L
+}
+
+@test "ux_table_row: 20-char label (2-arg) renders exactly as the legacy single line" {
+    run _run_ux_table_row "12345678901234567890" "twenty char label"
+    assert_success
+    [ "${#lines[@]}" -eq 1 ]
+    [ "$output" = "$(printf '  %-20s : %s' '12345678901234567890' 'twenty char label')" ]
+}
+
+@test "ux_table_row: short label (2-arg) renders exactly as the legacy single line" {
+    run _run_ux_table_row "aicron" "Cron helper"
+    assert_success
+    [ "${#lines[@]}" -eq 1 ]
+    [ "$output" = "$(printf '  %-20s : %s' 'aicron' 'Cron helper')" ]
+}
+
+@test "ux_table_row: short label (3-arg) renders exactly as the legacy single line" {
+    run _run_ux_table_row "aicron" "Cron helper" "see aicron --help"
+    assert_success
+    [ "${#lines[@]}" -eq 1 ]
+    [ "$output" = "$(printf '  %-20s │ %-30s │ %s' 'aicron' 'Cron helper' 'see aicron --help')" ]
+}
+
+@test "ux_table_row: 21-char label (2-arg) wraps onto a second line" {
+    run _run_ux_table_row "123456789012345678901" "just over the limit"
+    assert_success
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "  123456789012345678901" ]
+    [ "${lines[1]}" = "$(printf '  %-20s : %s' '' 'just over the limit')" ]
+}
+
+@test "ux_table_row: long label (2-arg) keeps the label intact and the description whole" {
+    run _run_ux_table_row "claude mcp remove <name>" "Remove a registered MCP server"
+    assert_success
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "  claude mcp remove <name>" ]
+    assert_output --partial "claude mcp remove <name>"
+    assert_output --partial "Remove a registered MCP server"
+}
+
+@test "ux_table_row: long label (3-arg) wraps and preserves col2/col3" {
+    run _run_ux_table_row "ollama-models [--docker]" "List local models" "docker exec variant"
+    assert_success
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "  ollama-models [--docker]" ]
+    [ "${lines[1]}" = "$(printf '  %-20s │ %-30s │ %s' '' 'List local models' 'docker exec variant')" ]
+    assert_output --partial "ollama-models [--docker]"
+    assert_output --partial "List local models"
+    assert_output --partial "docker exec variant"
+}
+
+@test "ux_table_row: wrapped continuation separator aligns with a normal row (2-arg)" {
+    run _run_ux_table_row "aicron" "Cron helper"
+    assert_success
+    local normal_col
+    normal_col=$(_sep_column "${lines[0]}" ":")
+
+    run _run_ux_table_row "redis-config-get <param>" "Read one redis config value"
+    assert_success
+    local wrapped_col
+    wrapped_col=$(_sep_column "${lines[1]}" ":")
+
+    [ "$normal_col" -eq "$wrapped_col" ]
+}
+
+@test "ux_table_row: wrapped continuation separator aligns with a normal row (3-arg)" {
+    run _run_ux_table_row "aicron" "Cron helper" "extra"
+    assert_success
+    local normal_col
+    normal_col=$(_sep_column "${lines[0]}" "│")
+
+    run _run_ux_table_row "WSL_CHECK_CDRIVE_MIN_GB" "Free-space threshold" "default 20"
+    assert_success
+    local wrapped_col
+    wrapped_col=$(_sep_column "${lines[1]}" "│")
+
+    [ "$normal_col" -eq "$wrapped_col" ]
+}

--- a/tests/bats/tools/ux_lib_table_row.bats
+++ b/tests/bats/tools/ux_lib_table_row.bats
@@ -100,3 +100,29 @@ _sep_column() {
 
     [ "$normal_col" -eq "$wrapped_col" ]
 }
+
+@test "ux_table_row: CJK label with display width > 20 but char count <= 20 wraps (PR #1546 agy/codex)" {
+    # 11 Korean syllables = 11 chars but 22 display columns (wc -L). A
+    # character-count check (${#col1}, the pre-fix implementation) would not
+    # trigger the wrap here even though the visible label overflows — the
+    # exact false negative agy and codex both flagged on PR #1546.
+    run _run_ux_table_row "한글표시폭테스트라벨용" "CJK 폭 회귀 테스트"
+    assert_success
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "  한글표시폭테스트라벨용" ]
+    assert_output --partial "CJK 폭 회귀 테스트"
+}
+
+@test "ux_table_row: wrapped CJK continuation separator aligns with a normal row" {
+    run _run_ux_table_row "aicron" "Cron helper"
+    assert_success
+    local normal_col
+    normal_col=$(_sep_column "${lines[0]}" ":")
+
+    run _run_ux_table_row "한글표시폭테스트라벨용" "CJK 폭 회귀 테스트"
+    assert_success
+    local wrapped_col
+    wrapped_col=$(_sep_column "${lines[1]}" ":")
+
+    [ "$normal_col" -eq "$wrapped_col" ]
+}


### PR DESCRIPTION
## Summary
- `ux_table_row` 라벨이 20자를 넘으면 구분자와 뒤 컬럼이 밀려 표 정렬이 깨지던 결함을 고쳤다
- 라벨 폭 정책(20자 기준, lint 강제 없음)을 `UX_GUIDELINES.md` 에 문서화했다

## Changes
- fix(ux_lib): `ux_table_row` 가 20자 초과 라벨을 감지하면 라벨을 먼저 한 줄에 출력하고, 설명은 라벨 칸을 비운 다음 줄로 넘겨 구분자 정렬을 유지한다. 20자 이하 라벨의 렌더링은 기존과 바이트 단위로 동일하다. 기존 30여개 호출부는 손대지 않았다.
- 회귀 테스트(`tests/bats/tools/ux_lib_table_row.bats`) 8건 추가.
- changelog fragment 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/ux_lib_table_row.bats tests/bats/tools/ux_lib_header.bats` — 13 passed
- [x] `pytest tests/integration/test_help_topics.py` — 283 passed
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/tools/ux_lib/ux_lib.sh` — clean

## Related
Closes #1501

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
