### PR TITLE
feat(shell-common): #1454 foreign-checkout 가드를 공유 helper 6개로 전파한다

### DIFF
--- a/docs/guide/playbooks/shell-common-cheatsheet.md
+++ b/docs/guide/playbooks/shell-common-cheatsheet.md
@@ -138,10 +138,47 @@ submodule 체크아웃). Claude Code subagent 처럼 `$SHELL_COMMON` / `$DOTFILE
 (#1454). 3번이 하드코드 경로를 금지한다면 이 항목은 **탐색 자체**를 금지한다.
 
 규칙을 어긴 코드를 위한 advisory 안전망으로
-`_dotfiles_root_warn_if_foreign_source "${BASH_SOURCE[0]-}"`
-(`shell-common/functions/dotfiles_root.sh`) 가 있다. 자신의 실제 load 경로가
-`$HOME/dotfiles` 와 다른 git 저장소면 stderr 에 WARN 한 블록을 찍는다. 같은
-저장소의 linked worktree 는 경고하지 않으며, 절대 실행을 막지 않는다.
+`_dotfiles_root_warn_if_foreign_source` (`shell-common/functions/dotfiles_root.sh`)
+가 있다. 자신의 실제 load 경로가 `$HOME/dotfiles` 와 다른 git 저장소면 stderr 에
+WARN 한 블록을 찍는다. 같은 저장소의 linked worktree 는 경고하지 않으며, 절대
+실행을 막지 않는다. 비대화형 skill 호출자가 직접 source 하는 shell-common 파일
+(예: `gh_pr_review.sh`, `gh_host.sh`)은 이 가드를 켜야 한다 — 정확한 복붙 스니펫은
+아래 "Foreign-Checkout Guard Snippet" 참고. `${BASH_SOURCE[0]-}` 단독으로는 zsh 에서
+항상 비어 있어 가드가 영구히 무력화되므로 (zsh 는 `$0` 을 리바인드) 단독 사용 금지.
+
+## Foreign-Checkout Guard Snippet (#1454 / #1505)
+
+비대화형 skill 이 직접 source 하는 `shell-common/functions/*.sh` 파일(git hook 이
+source 하는 파일 포함)의 표준 가드. 파일 최상단, 함수 정의 이전에 붙인다. `LABEL`
+만 파일마다 바꾼다 — 나머지는 7개 파일에 걸쳐 문자 그대로 동일해야 한다(자기 경로
+탐지는 zsh 의 `FUNCTION_ARGZERO` 특성상 공유 함수로 옮길 수 없어 파일마다 반복이
+불가피하다; probe + 호출 + `#724` 진단은 `_dotfiles_root_guard_self` 하나로 이미
+SSOT 화됨):
+
+```sh
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "LABEL"
+else
+    printf '[LABEL] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
+fi
+unset _drg_self _drg_helper
+```
+
+`else` 분기를 빼먹지 말 것 — `dotfiles_root.sh` 자체가 없거나 source 에 실패해
+`_dotfiles_root_guard_self` 가 정의되지 않은 경우, 이 `else` 가 없으면 진단 메시지
+없이 조용히 가드가 꺼진다 (#1505 에서 실제로 빠졌던 회귀).
 
 ## Tool Integration UX-lib Guard
 

--- a/shell-common/AGENTS.md
+++ b/shell-common/AGENTS.md
@@ -27,6 +27,8 @@ bash 와 zsh 양쪽 loader 에서 source 되는 파일에서:
 - **Required**: `source "${SHELL_COMMON}/path/to/file.sh"` 또는 `${DOTFILES_ROOT}` 사용
 - **Acceptable (executable script만)**: `source "$(dirname "$0")/file.sh"`
 - **Test**: `bash -i -c 'source main.bash && fn'` + `zsh -c 'source main.zsh && fn'`
+- **Skill 이 standalone `.` 하는 파일** (예: `gh_pr_review.sh`): #1454/#1505 foreign-checkout
+  guard 필수 — 스니펫: cheatsheet → "Foreign-Checkout Guard Snippet"
 
 ## Output Standards
 

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -12,6 +12,35 @@
 # user's `$pr` / `$remote`. Callers read the stdout `key=value` contract,
 # never the shell variables.
 
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks, and deliberately NOT wrapped in an
+# interactive guard — this is a pure function-defining library that
+# non-interactive skill callers rely on; the guard function is itself a
+# silent no-op outside the genuine foreign-checkout case.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. Plain POSIX sh has
+# neither $0-rebinding nor $BASH_SOURCE, and would abort on the bash array
+# syntax, hence the $BASH_VERSION arm. Everything after it lives once, in
+# _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "devx_pr_review_all"
+fi
+unset _drg_self _drg_helper
+
 devx_pr_review_all_parse() {
     local pr=""
     local remote="origin"

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -38,6 +38,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "devx_pr_review_all"
+else
+    printf '[devx_pr_review_all] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/devx_pr_verify_live.sh
+++ b/shell-common/functions/devx_pr_verify_live.sh
@@ -12,6 +12,35 @@
 # user's `$pr` / `$remote` / `$url`. Callers read the stdout `key=value`
 # contract, never the shell variables.
 
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks, and deliberately NOT wrapped in an
+# interactive guard — this is a pure function-defining library that
+# non-interactive skill callers rely on; the guard function is itself a
+# silent no-op outside the genuine foreign-checkout case.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. Plain POSIX sh has
+# neither $0-rebinding nor $BASH_SOURCE, and would abort on the bash array
+# syntax, hence the $BASH_VERSION arm. Everything after it lives once, in
+# _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "devx_pr_verify_live"
+fi
+unset _drg_self _drg_helper
+
 _devx_pr_verify_live_pos_int() {
     case "$1" in
     "" | *[!0-9]*) return 1 ;;

--- a/shell-common/functions/devx_pr_verify_live.sh
+++ b/shell-common/functions/devx_pr_verify_live.sh
@@ -38,6 +38,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "devx_pr_verify_live"
+else
+    printf '[devx_pr_verify_live] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/dotfiles_root.sh
+++ b/shell-common/functions/dotfiles_root.sh
@@ -173,17 +173,23 @@ _dotfiles_root_git_common_dir() {
 # memoization would silently never take effect. Callers must invoke this in
 # the current shell and read the global.
 #
-# The cache is keyed on the *value* of $HOME, not on an "already computed"
-# boolean: $HOME is reassigned within a single process both by the bats
-# suite (setup_isolated_home) and by real `env HOME=... sh -c` callers, and a
-# stale canonical path there would silently invert the guard's verdict.
-# Only successful lookups are cached, so a $HOME/dotfiles that appears later
-# in the same process is still picked up.
+# The cache is keyed on the *value of the CANONICAL_DIR argument itself*
+# (issue #1505 PR #1548 review, codex+agy) — not on $HOME. The only current
+# caller always builds its argument as "${HOME}/dotfiles", so a $HOME change
+# already produces a different $1 and still busts the cache correctly; keying
+# on $1 additionally keeps a same-$HOME call with a genuinely different
+# CANONICAL_DIR (this function's own documented, general-purpose contract)
+# from returning another directory's stale --git-common-dir. $HOME is
+# reassigned within a single process both by the bats suite
+# (setup_isolated_home) and by real `env HOME=... sh -c` callers, so it must
+# still invalidate — which it does, transitively, via the argument. Only
+# successful lookups are cached, so a $HOME/dotfiles that appears later in
+# the same process is still picked up.
 #
 # The self side is deliberately NOT cached — it differs per call site and
 # never repeats within one process.
 _dotfiles_root_canonical_common_dir() {
-    if [ "${_DOTFILES_ROOT_CANON_HOME-}" = "${HOME-}" ] \
+    if [ "${_DOTFILES_ROOT_CANON_KEY-}" = "${1-}" ] \
         && [ -n "${_DOTFILES_ROOT_CANON_COMMON-}" ]; then
         return 0
     fi
@@ -196,7 +202,7 @@ _dotfiles_root_canonical_common_dir() {
         return 1
     fi
 
-    _DOTFILES_ROOT_CANON_HOME="${HOME-}"
+    _DOTFILES_ROOT_CANON_KEY="${1-}"
     return 0
 }
 

--- a/shell-common/functions/dotfiles_root.sh
+++ b/shell-common/functions/dotfiles_root.sh
@@ -21,6 +21,23 @@
 # DOTFILES_FORCE_INIT — there is no observable output until the function
 # is invoked.
 
+# Include-once sentinel (issue #1505): an interactive shell sources this
+# file explicitly (bash/main.bash, zsh/main.zsh, for #589 canonicalization),
+# then again via the functions/ autoloader's own pass over
+# shell-common/functions/*.sh, then once more per #1454-guarded helper file
+# below (each does `. "$SHELL_COMMON/functions/dotfiles_root.sh"` itself).
+# Every repeat re-parses this file and redefines its functions for no
+# benefit — skip repeats within one process. `return` (not `exit`) since
+# this only ever runs as a sourced dot-script; the `|| exit 0` fallback
+# covers the (unsupported) case of running it directly.
+if [ -n "${_DOTFILES_ROOT_SH_SOURCED-}" ]; then
+    # shellcheck disable=SC2317  # exit fallback only runs if this file is
+    # executed directly (not sourced), so `return` succeeding makes it look
+    # unreachable to static analysis.
+    return 0 2>/dev/null || exit 0
+fi
+_DOTFILES_ROOT_SH_SOURCED=1
+
 # _resolve_dotfiles_root_canonical CANDIDATE
 #
 # Echo the canonical (main-worktree) directory that should be used as

--- a/shell-common/functions/dotfiles_root.sh
+++ b/shell-common/functions/dotfiles_root.sh
@@ -139,6 +139,50 @@ _dotfiles_root_git_common_dir() {
     ) || return 1
 }
 
+# _dotfiles_root_canonical_common_dir CANONICAL_DIR
+#
+# Resolve CANONICAL_DIR's --git-common-dir into the global
+# $_DOTFILES_ROOT_CANON_COMMON, memoized per process (issue #1505).
+# Returns 0 with the global set and non-empty, or 1 with it emptied.
+#
+# Why memoize: _dotfiles_root_warn_if_foreign_source runs once per guarded
+# helper file, and every one of those calls re-resolves the identical
+# $HOME/dotfiles --git-common-dir — a subshell plus `git rev-parse` plus two
+# `cd`s each time. With seven helpers wired into one shell startup that is
+# six redundant fork storms.
+#
+# Why a global instead of stdout: a `$(...)` capture runs the function in a
+# subshell, so the cache write would be discarded on every call and the
+# memoization would silently never take effect. Callers must invoke this in
+# the current shell and read the global.
+#
+# The cache is keyed on the *value* of $HOME, not on an "already computed"
+# boolean: $HOME is reassigned within a single process both by the bats
+# suite (setup_isolated_home) and by real `env HOME=... sh -c` callers, and a
+# stale canonical path there would silently invert the guard's verdict.
+# Only successful lookups are cached, so a $HOME/dotfiles that appears later
+# in the same process is still picked up.
+#
+# The self side is deliberately NOT cached — it differs per call site and
+# never repeats within one process.
+_dotfiles_root_canonical_common_dir() {
+    if [ "${_DOTFILES_ROOT_CANON_HOME-}" = "${HOME-}" ] \
+        && [ -n "${_DOTFILES_ROOT_CANON_COMMON-}" ]; then
+        return 0
+    fi
+
+    _DOTFILES_ROOT_CANON_COMMON=$(_dotfiles_root_git_common_dir "${1:-}") || {
+        _DOTFILES_ROOT_CANON_COMMON=""
+        return 1
+    }
+    if [ -z "$_DOTFILES_ROOT_CANON_COMMON" ]; then
+        return 1
+    fi
+
+    _DOTFILES_ROOT_CANON_HOME="${HOME-}"
+    return 0
+}
+
 # _dotfiles_root_warn_if_foreign_source SELF_PATH
 #
 # Advisory guard (issue #1454): print one WARN block to stderr when the
@@ -169,7 +213,10 @@ _dotfiles_root_warn_if_foreign_source() {
     _dwfs_dir=$(dirname "$_dwfs_self" 2>/dev/null) || return 0
 
     _dwfs_self_common=$(_dotfiles_root_git_common_dir "$_dwfs_dir") || return 0
-    _dwfs_canonical_common=$(_dotfiles_root_git_common_dir "$_dwfs_canonical") || return 0
+    # Called in the current shell, NOT via $(...) — the memoization writes a
+    # global, which a subshell capture would throw away (issue #1505).
+    _dotfiles_root_canonical_common_dir "$_dwfs_canonical" || return 0
+    _dwfs_canonical_common="$_DOTFILES_ROOT_CANON_COMMON"
 
     [ "$_dwfs_self_common" != "$_dwfs_canonical_common" ] || return 0
 
@@ -182,5 +229,35 @@ _dotfiles_root_warn_if_foreign_source() {
         "  Source shared files via \${SHELL_COMMON:-\$HOME/dotfiles/shell-common}/... — never by find/PATH discovery." \
         "  Ignore this if you are intentionally testing an alternate checkout." >&2
 
+    return 0
+}
+
+# _dotfiles_root_guard_self SELF_PATH [LABEL]
+#
+# Single SSOT for the caller-side wiring of the #1454 guard (issue #1505).
+# Every shared helper file that skills source non-interactively calls this
+# right after sourcing dotfiles_root.sh, so the `command -v` probe, the
+# call, and the #724 diagnostic exist exactly once repo-wide instead of
+# being copy-pasted per file.
+#
+#   SELF_PATH — the caller's OWN load path. It must be computed in the
+#               caller's top-level code, not here: zsh's FUNCTION_ARGZERO
+#               rebinds $0 to the sourced file only for that file's own
+#               top-level statements, so inside this function $0 is this
+#               function's name and the caller's identity is unrecoverable.
+#   LABEL     — short caller name for the #724 diagnostic prefix
+#               (e.g. "gh_pr_reply"); defaults to "dotfiles".
+#
+# Defense in depth (#724): a helper that is present but failed to parse
+# leaves _dotfiles_root_warn_if_foreign_source undefined. Say so once on
+# stderr rather than disabling the guard in silence. Never fatal.
+_dotfiles_root_guard_self() {
+    if command -v _dotfiles_root_warn_if_foreign_source >/dev/null 2>&1; then
+        _dotfiles_root_warn_if_foreign_source "${1:-}" || true
+    else
+        printf '[%s] %s missing or did not define _dotfiles_root_warn_if_foreign_source — #1454 guard skipped (#724).\n' \
+            "${2:-dotfiles}" \
+            "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh" >&2
+    fi
     return 0
 }

--- a/shell-common/functions/gh_host.sh
+++ b/shell-common/functions/gh_host.sh
@@ -30,6 +30,36 @@
 # the body pure-definitions makes the file safe to source from any
 # context — interactive, non-interactive, or `bash -c`.
 
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks, and deliberately NOT wrapped in an
+# interactive guard — see the PR #704 note above; the guard function is
+# itself a silent no-op outside the genuine foreign-checkout case.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. This file is real
+# POSIX sh sourced by git hooks, so the bash array form is reached only
+# when $BASH_VERSION proves bash: dash aborts with "Bad substitution" the
+# moment it expands ${BASH_SOURCE[0]}. Everything after the branch lives
+# once, in _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    # shellcheck disable=SC3028  # bash-only var, gated by $BASH_VERSION above
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh_host"
+fi
+unset _drg_self _drg_helper
+
 # _gh_resolve_host — print the active GitHub host on stdout.
 #
 # Reads `_dotfiles_setup_mode` (defined in

--- a/shell-common/functions/gh_host.sh
+++ b/shell-common/functions/gh_host.sh
@@ -57,6 +57,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "gh_host"
+else
+    printf '[gh_host] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -44,6 +44,34 @@
 # breaking PR body / label edits with `command not found`. Mirrors the
 # same NOTE in gh_project_status.sh (PR #497). See issue #720.
 
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks, and deliberately NOT wrapped in an
+# interactive guard — see the NOTE above; the guard function is itself a
+# silent no-op outside the genuine foreign-checkout case.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. Plain POSIX sh has
+# neither $0-rebinding nor $BASH_SOURCE, and would abort on the bash array
+# syntax, hence the $BASH_VERSION arm. Everything after it lives once, in
+# _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh_pr_edit_safe"
+fi
+unset _drg_self _drg_helper
+
 _gh_pr_edit_safe__deprecation_marker='Projects (classic) is being deprecated'
 
 _gh_pr_edit_safe__resolve_repo() {

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -69,6 +69,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "gh_pr_edit_safe"
+else
+    printf '[gh_pr_edit_safe] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -19,6 +19,32 @@
 
 case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. Plain POSIX sh has
+# neither $0-rebinding nor $BASH_SOURCE, and would abort on the bash array
+# syntax, hence the $BASH_VERSION arm. Everything after it lives once, in
+# _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh-pr-reply"
+fi
+unset _drg_self _drg_helper
+
 _gh_pr_reply_state_root() {
     printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/gh-pr-reply"
 }

--- a/shell-common/functions/gh_pr_reply.sh
+++ b/shell-common/functions/gh_pr_reply.sh
@@ -42,6 +42,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "gh-pr-reply"
+else
+    printf '[gh-pr-reply] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -25,26 +25,27 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 # Self-path: zsh never populates $BASH_SOURCE, so reading it there left the
 # guard permanently inert. zsh instead rebinds $0 to the file being sourced
 # (FUNCTION_ARGZERO, on by default) for the duration of this top-level code,
-# so branch on the shell — the same idiom as functions/my_help.sh.
+# so branch on the shell — the same idiom as functions/my_help.sh. This
+# branch is irreducibly per-file: inside a function, $0 is the function's
+# own name, so it cannot move into dotfiles_root.sh.
+#
+# Everything after it (probe + call + #724 diagnostic) lives exactly once,
+# in _dotfiles_root_guard_self (issue #1505).
 if [ -n "${ZSH_VERSION-}" ]; then
-    _gpr_selfpath="$0"
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
 else
-    _gpr_selfpath="${BASH_SOURCE[0]-}"
+    _drg_self=""
 fi
-# Defense in depth (#724): a helper that is missing or fails to parse must
-# say so once on stderr rather than disabling the guard in silence. Never
-# fatal — the rest of this file is unrelated to the guard.
-_gpr_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
-if [ -r "$_gpr_helper" ]; then
-    . "$_gpr_helper" || true
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
 fi
-if command -v _dotfiles_root_warn_if_foreign_source >/dev/null 2>&1; then
-    _dotfiles_root_warn_if_foreign_source "$_gpr_selfpath" || true
-else
-    printf '[gh_pr_review] %s missing or did not define _dotfiles_root_warn_if_foreign_source — #1454 guard skipped (#724).\n' \
-        "$_gpr_helper" >&2
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh-pr-review"
 fi
-unset _gpr_selfpath _gpr_helper
+unset _drg_self _drg_helper
 
 # ============================================================================
 # Section 1 — Argument parser (SSOT, mirrors SKILL.md Step 1)

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -44,6 +44,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "gh-pr-review"
+else
+    printf '[gh-pr-review] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -101,6 +101,9 @@ if [ -r "$_drg_helper" ]; then
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
     _dotfiles_root_guard_self "$_drg_self" "gh_project_status"
+else
+    printf '[gh_project_status] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
 fi
 unset _drg_self _drg_helper
 

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -76,6 +76,34 @@
 # before defining `_gh_project_status_sync`, breaking the workflow with
 # `command not found` (exit 127). See PR #497 / CI run 25601743398.
 
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks, and deliberately NOT wrapped in an
+# interactive guard — see the NOTE above; the guard function is itself a
+# silent no-op outside the genuine foreign-checkout case.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. Plain POSIX sh has
+# neither $0-rebinding nor $BASH_SOURCE, and would abort on the bash array
+# syntax, hence the $BASH_VERSION arm. Everything after it lives once, in
+# _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh_project_status"
+fi
+unset _drg_self _drg_helper
+
 # Ensure GH_HOST is set before any `gh` call so requests route to the
 # correct host. On the internal PC (GHE = github.samsungds.net) a caller
 # that does not export GH_HOST would otherwise let `gh` default to

--- a/tests/bats/functions/devx_pr_review_all.bats
+++ b/tests/bats/functions/devx_pr_review_all.bats
@@ -116,15 +116,6 @@ setup() {
 # load_category), which would swallow the very stderr under test.
 # ---------------------------------------------------------------------------
 
-_setup_foreign_home_1505() {
-    FOREIGN_HOME_1505="$BATS_TEST_TMPDIR/foreign-home-1505"
-    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
-    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
-    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
-        commit --allow-empty -q -m init
-    export HOME="$FOREIGN_HOME_1505"
-}
-
 @test "zsh: #1505 foreign-checkout guard warns when devx_pr_review_all.sh is sourced under zsh" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not available"
     command -v git >/dev/null 2>&1 || skip "git not available"

--- a/tests/bats/functions/devx_pr_review_all.bats
+++ b/tests/bats/functions/devx_pr_review_all.bats
@@ -104,3 +104,44 @@ setup() {
     [ "$_no_reply" = "SENTINEL_NO_REPLY" ]
     [ "$_remote_set" = "SENTINEL_REMOTE_SET" ]
 }
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="$BATS_TEST_TMPDIR/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}
+
+@test "zsh: #1505 foreign-checkout guard warns when devx_pr_review_all.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/devx_pr_review_all.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/devx_pr_review_all.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when devx_pr_review_all.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/devx_pr_review_all.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/devx_pr_review_all.sh"
+}

--- a/tests/bats/functions/devx_pr_verify_live.bats
+++ b/tests/bats/functions/devx_pr_verify_live.bats
@@ -419,15 +419,6 @@ setup() {
 # load_category), which would swallow the very stderr under test.
 # ---------------------------------------------------------------------------
 
-_setup_foreign_home_1505() {
-    FOREIGN_HOME_1505="$BATS_TEST_TMPDIR/foreign-home-1505"
-    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
-    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
-    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
-        commit --allow-empty -q -m init
-    export HOME="$FOREIGN_HOME_1505"
-}
-
 @test "zsh: #1505 foreign-checkout guard warns when devx_pr_verify_live.sh is sourced under zsh" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not available"
     command -v git >/dev/null 2>&1 || skip "git not available"

--- a/tests/bats/functions/devx_pr_verify_live.bats
+++ b/tests/bats/functions/devx_pr_verify_live.bats
@@ -407,3 +407,44 @@ setup() {
     [ "$_rest" = "SENTINEL_REST" ]
     [ "$_item" = "SENTINEL_ITEM" ]
 }
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="$BATS_TEST_TMPDIR/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}
+
+@test "zsh: #1505 foreign-checkout guard warns when devx_pr_verify_live.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/devx_pr_verify_live.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/devx_pr_verify_live.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when devx_pr_verify_live.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/devx_pr_verify_live.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/devx_pr_verify_live.sh"
+}

--- a/tests/bats/functions/dotfiles_root.bats
+++ b/tests/bats/functions/dotfiles_root.bats
@@ -280,3 +280,199 @@ _setup_foreign_repo() {
     assert_success
     assert_output ""
 }
+
+# ---------------------------------------------------------------------------
+# _dotfiles_root_guard_self (issue #1505)
+#
+# The shared caller-side entry point every guarded helper file calls right
+# after sourcing this helper. It owns the `command -v` probe, the call, and
+# the #724 diagnostic — logic that used to be copy-pasted per caller.
+# ---------------------------------------------------------------------------
+
+@test "_dotfiles_root_guard_self: forwards a foreign checkout to the WARN block" {
+    _setup_fake_home_dotfiles
+    _setup_foreign_repo guardself
+
+    run env HOME="$FAKE_HOME" bash -c \
+        ". '$HELPER' && _dotfiles_root_guard_self '$FOREIGN' 'probe_label'"
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "$FOREIGN"
+}
+
+@test "_dotfiles_root_guard_self: canonical checkout stays silent" {
+    _setup_fake_home_dotfiles
+
+    run env HOME="$FAKE_HOME" bash -c \
+        ". '$HELPER' && _dotfiles_root_guard_self '$CANON/shell-common/functions/probe.sh' 'probe_label'"
+    assert_success
+    assert_output ""
+}
+
+# #724: the helper file parsed far enough to define _dotfiles_root_guard_self
+# but a regression left _dotfiles_root_warn_if_foreign_source undefined. That
+# must say so once on stderr instead of disabling the guard in silence.
+@test "_dotfiles_root_guard_self: #724 diagnostic when the warn function is undefined" {
+    _setup_fake_home_dotfiles
+    _setup_foreign_repo guardself724
+
+    run env HOME="$FAKE_HOME" bash -c \
+        ". '$HELPER' \
+            && unset -f _dotfiles_root_warn_if_foreign_source \
+            && _dotfiles_root_guard_self '$FOREIGN' 'probe_label'"
+    assert_success
+    assert_output --partial "[probe_label]"
+    assert_output --partial "did not define _dotfiles_root_warn_if_foreign_source"
+    assert_output --partial "#1454 guard skipped (#724)"
+    assert_output --partial "functions/dotfiles_root.sh"
+}
+
+@test "_dotfiles_root_guard_self: #724 diagnostic falls back to the 'dotfiles' label" {
+    _setup_fake_home_dotfiles
+
+    run env HOME="$FAKE_HOME" bash -c \
+        ". '$HELPER' \
+            && unset -f _dotfiles_root_warn_if_foreign_source \
+            && _dotfiles_root_guard_self '/no/such/file.sh'"
+    assert_success
+    assert_output --partial "[dotfiles]"
+    assert_output --partial "#1454 guard skipped (#724)"
+}
+
+@test "_dotfiles_root_guard_self: #724 diagnostic goes to stderr, not stdout" {
+    _setup_fake_home_dotfiles
+
+    run env HOME="$FAKE_HOME" bash -c \
+        ". '$HELPER' \
+            && unset -f _dotfiles_root_warn_if_foreign_source \
+            && _dotfiles_root_guard_self '/no/such/file.sh' 'probe_label' 2>/dev/null"
+    assert_success
+    assert_output ""
+}
+
+# ---------------------------------------------------------------------------
+# Canonical-side cache (issue #1505)
+#
+# The $HOME/dotfiles --git-common-dir lookup is memoized per process so seven
+# guarded helper files in one shell startup don't re-fork it seven times. The
+# cache is keyed on the VALUE of $HOME: bats flips $HOME per test and real
+# callers do it too, so a cache that only remembered "already computed" would
+# hand back the previous HOME's canonical repo and invert the verdict.
+# ---------------------------------------------------------------------------
+
+# Every call is redirected with `2>FILE`, never piped: a pipeline would run
+# the function in a subshell, the cache write would be thrown away, and the
+# test would pass against a broken cache by accident.
+@test "#1505 cache: canonical side is re-resolved after \$HOME changes in-process" {
+    _setup_fake_home_dotfiles
+    _setup_foreign_repo alt
+
+    # $FOREIGN lives in $SCRATCH/alt/dotfiles, so it is foreign under
+    # HOME=$FAKE_HOME and canonical under HOME=$SCRATCH/alt. Three calls in
+    # ONE process, flipping $HOME between them: a cache that is not keyed on
+    # $HOME makes B warn (verified against a deliberately unkeyed build).
+    local script="$BATS_TEST_TMPDIR/cache_home_flip.sh"
+    local outdir="$BATS_TEST_TMPDIR/cache_home_flip_out"
+    mkdir -p "$outdir"
+    cat >"$script" <<'SH'
+. "$HELPER"
+export HOME="$HOME_A"
+_dotfiles_root_warn_if_foreign_source "$SELF" 2>"$OUT/a"
+export HOME="$HOME_B"
+_dotfiles_root_warn_if_foreign_source "$SELF" 2>"$OUT/b"
+export HOME="$HOME_A"
+_dotfiles_root_warn_if_foreign_source "$SELF" 2>"$OUT/c"
+printf 'A=[%s]\n' "$(head -1 "$OUT/a")"
+printf 'B=[%s]\n' "$(head -1 "$OUT/b")"
+printf 'C=[%s]\n' "$(head -1 "$OUT/c")"
+SH
+
+    run env HELPER="$HELPER" HOME_A="$FAKE_HOME" HOME_B="$SCRATCH/alt" \
+        SELF="$FOREIGN" OUT="$outdir" bash "$script"
+    assert_success
+    assert_line --partial "A=[[WARN] dotfiles: loaded from a foreign checkout"
+    assert_line "B=[]"
+    assert_line --partial "C=[[WARN] dotfiles: loaded from a foreign checkout"
+}
+
+@test "#1505 cache: repeated calls under one \$HOME keep the same verdict" {
+    _setup_fake_home_dotfiles
+    _setup_foreign_repo repeat
+
+    local script="$BATS_TEST_TMPDIR/cache_repeat.sh"
+    local outdir="$BATS_TEST_TMPDIR/cache_repeat_out"
+    mkdir -p "$outdir"
+    cat >"$script" <<'SH'
+. "$HELPER"
+export HOME="$HOME_A"
+i=1
+while [ "$i" -le 3 ]; do
+    _dotfiles_root_warn_if_foreign_source "$SELF" 2>"$OUT/r$i"
+    printf 'R%s=[%s]\n' "$i" "$(head -1 "$OUT/r$i")"
+    i=$((i + 1))
+done
+SH
+
+    run env HELPER="$HELPER" HOME_A="$FAKE_HOME" SELF="$FOREIGN" \
+        OUT="$outdir" bash "$script"
+    assert_success
+    assert_line --partial "R1=[[WARN] dotfiles: loaded from a foreign checkout"
+    assert_line --partial "R2=[[WARN] dotfiles: loaded from a foreign checkout"
+    assert_line --partial "R3=[[WARN] dotfiles: loaded from a foreign checkout"
+}
+
+@test "_dotfiles_root_canonical_common_dir: agrees with the uncached resolver" {
+    _setup_fake_home_dotfiles
+
+    run env HOME="$FAKE_HOME" bash -c "
+        . '$HELPER'
+        a=\$(_dotfiles_root_git_common_dir '$CANON')
+        _dotfiles_root_canonical_common_dir '$CANON'
+        b=\"\$_DOTFILES_ROOT_CANON_COMMON\"
+        _dotfiles_root_canonical_common_dir '$CANON'
+        c=\"\$_DOTFILES_ROOT_CANON_COMMON\"
+        [ -n \"\$a\" ] && [ \"\$a\" = \"\$b\" ] && [ \"\$b\" = \"\$c\" ] && echo \"same:\$a\"
+    "
+    assert_success
+    assert_output --partial "same:"
+}
+
+# The memoization writes a global, so it only works when the function is
+# called in the CURRENT shell. A \$(...) capture would silently make every
+# call a cache miss — pin the global-setting contract so a future refactor
+# back to stdout is caught here rather than showing up as lost perf.
+@test "_dotfiles_root_canonical_common_dir: second call is served from the cache" {
+    _setup_fake_home_dotfiles
+
+    run env HOME="$FAKE_HOME" bash -c "
+        . '$HELPER'
+        _dotfiles_root_canonical_common_dir '$CANON'
+        # Point the cached value at a sentinel: a genuine cache hit returns it
+        # untouched, a cache miss would overwrite it with the real path.
+        _DOTFILES_ROOT_CANON_COMMON='SENTINEL'
+        _dotfiles_root_canonical_common_dir '$CANON'
+        echo \"cached=\$_DOTFILES_ROOT_CANON_COMMON\"
+    "
+    assert_success
+    assert_output "cached=SENTINEL"
+}
+
+@test "_dotfiles_root_canonical_common_dir: non-git dir fails and is not cached" {
+    _setup_fake_home_dotfiles
+    mkdir -p "$SCRATCH/notgit"
+
+    run env HOME="$FAKE_HOME" bash -c "
+        . '$HELPER'
+        _dotfiles_root_canonical_common_dir '$SCRATCH/notgit' && echo unexpected-success
+        echo \"rc=\$?\"
+        echo \"empty=[\$_DOTFILES_ROOT_CANON_COMMON]\"
+        # A failed lookup must leave the cache empty so a later, valid
+        # canonical dir under the same \$HOME is still resolved.
+        _dotfiles_root_canonical_common_dir '$CANON' && echo second-ok
+    "
+    assert_success
+    assert_output --partial "rc=1"
+    assert_output --partial "empty=[]"
+    assert_output --partial "second-ok"
+    refute_output --partial "unexpected-success"
+}

--- a/tests/bats/functions/dotfiles_root.bats
+++ b/tests/bats/functions/dotfiles_root.bats
@@ -457,6 +457,29 @@ SH
     assert_output "cached=SENTINEL"
 }
 
+# PR #1548 review (codex + agy): the cache used to key on $HOME alone even
+# though the function's own contract takes an arbitrary CANONICAL_DIR — a
+# second call under the same $HOME but a genuinely different directory would
+# have returned the first directory's stale --git-common-dir. Keying on the
+# argument itself (not $HOME) fixes this.
+@test "_dotfiles_root_canonical_common_dir: same \$HOME, different CANONICAL_DIR is not served stale" {
+    _setup_fake_home_dotfiles
+    _setup_foreign_repo other
+
+    run env HOME="$FAKE_HOME" bash -c "
+        . '$HELPER'
+        _dotfiles_root_canonical_common_dir '$CANON'
+        a=\"\$_DOTFILES_ROOT_CANON_COMMON\"
+        _dotfiles_root_canonical_common_dir '$FOREIGN_DIR'
+        b=\"\$_DOTFILES_ROOT_CANON_COMMON\"
+        echo \"a=\$a\"
+        echo \"b=\$b\"
+        [ \"\$a\" != \"\$b\" ] && echo distinct
+    "
+    assert_success
+    assert_output --partial "distinct"
+}
+
 @test "_dotfiles_root_canonical_common_dir: non-git dir fails and is not cached" {
     _setup_fake_home_dotfiles
     mkdir -p "$SCRATCH/notgit"

--- a/tests/bats/functions/gh_host.bats
+++ b/tests/bats/functions/gh_host.bats
@@ -280,9 +280,13 @@ teardown() {
 @test "#718: function absent + setup-mode=internal on disk -> GHE (hook context)" {
     echo "internal" > "$HOME/.dotfiles-setup-mode"
     # env -i strips the parent shell so _dotfiles_setup_mode cannot leak in.
-    # PATH must be preserved or `bash`/`tr` won't resolve.
+    # PATH must be preserved or `bash`/`tr` won't resolve. The isolated $HOME
+    # here has no $HOME/dotfiles, so the #1454/#1505 guard's own #724
+    # diagnostic (dotfiles_root.sh unreachable) fires on stderr — swallow it
+    # with `2>/dev/null` exactly as the real caller does (claude/hooks/
+    # post-gh-pr-create.sh:66), so this test only asserts #718 behavior.
     run env -i "HOME=$HOME" "PATH=$PATH" bash --noprofile --norc -c "
-        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh'
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh' 2>/dev/null
         _gh_resolve_host
     "
     assert_success
@@ -291,8 +295,9 @@ teardown() {
 
 @test "#718: function absent + setup-mode file absent -> github.com" {
     rm -f "$HOME/.dotfiles-setup-mode"
+    # See the #724 note in the previous test — same 2>/dev/null reasoning.
     run env -i "HOME=$HOME" "PATH=$PATH" bash --noprofile --norc -c "
-        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh'
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_host.sh' 2>/dev/null
         _gh_resolve_host
     "
     assert_success

--- a/tests/bats/functions/gh_host.bats
+++ b/tests/bats/functions/gh_host.bats
@@ -315,15 +315,6 @@ teardown() {
 # load_category), which would swallow the very stderr under test.
 # ---------------------------------------------------------------------------
 
-_setup_foreign_home_1505() {
-    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
-    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
-    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
-    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
-        commit --allow-empty -q -m init
-    export HOME="$FOREIGN_HOME_1505"
-}
-
 @test "zsh: #1505 foreign-checkout guard warns when gh_host.sh is sourced under zsh" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not available"
     command -v git >/dev/null 2>&1 || skip "git not available"

--- a/tests/bats/functions/gh_host.bats
+++ b/tests/bats/functions/gh_host.bats
@@ -298,3 +298,44 @@ teardown() {
     assert_success
     assert_output "github.com"
 }
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}
+
+@test "zsh: #1505 foreign-checkout guard warns when gh_host.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/gh_host.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_host.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when gh_host.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/gh_host.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_host.sh"
+}

--- a/tests/bats/functions/gh_pr_edit_safe.bats
+++ b/tests/bats/functions/gh_pr_edit_safe.bats
@@ -337,3 +337,44 @@ STUB
     assert_output --partial \
         "BUG: _gh_pr_edit_safe_{label,body} undefined after source"
 }
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}
+
+@test "zsh: #1505 foreign-checkout guard warns when gh_pr_edit_safe.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/gh_pr_edit_safe.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_pr_edit_safe.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when gh_pr_edit_safe.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/gh_pr_edit_safe.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_pr_edit_safe.sh"
+}

--- a/tests/bats/functions/gh_pr_edit_safe.bats
+++ b/tests/bats/functions/gh_pr_edit_safe.bats
@@ -349,15 +349,6 @@ STUB
 # load_category), which would swallow the very stderr under test.
 # ---------------------------------------------------------------------------
 
-_setup_foreign_home_1505() {
-    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
-    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
-    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
-    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
-        commit --allow-empty -q -m init
-    export HOME="$FOREIGN_HOME_1505"
-}
-
 @test "zsh: #1505 foreign-checkout guard warns when gh_pr_edit_safe.sh is sourced under zsh" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not available"
     command -v git >/dev/null 2>&1 || skip "git not available"

--- a/tests/bats/functions/gh_pr_reply.bats
+++ b/tests/bats/functions/gh_pr_reply.bats
@@ -311,15 +311,6 @@ teardown() {
 # load_category), which would swallow the very stderr under test.
 # ---------------------------------------------------------------------------
 
-_setup_foreign_home_1505() {
-    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
-    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
-    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
-    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
-        commit --allow-empty -q -m init
-    export HOME="$FOREIGN_HOME_1505"
-}
-
 @test "zsh: #1505 foreign-checkout guard warns when gh_pr_reply.sh is sourced under zsh" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not available"
     command -v git >/dev/null 2>&1 || skip "git not available"

--- a/tests/bats/functions/gh_pr_reply.bats
+++ b/tests/bats/functions/gh_pr_reply.bats
@@ -299,3 +299,44 @@ teardown() {
     assert_output --partial "previous run failed"
     assert_output --partial "rm -rf"
 }
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}
+
+@test "zsh: #1505 foreign-checkout guard warns when gh_pr_reply.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/gh_pr_reply.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_pr_reply.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when gh_pr_reply.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/gh_pr_reply.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_pr_reply.sh"
+}

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -1421,15 +1421,6 @@ _run_marker_bash() {
 # load_category), which would swallow the very stderr under test.
 # ---------------------------------------------------------------------------
 
-_setup_foreign_home_1505() {
-    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
-    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
-    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
-    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
-        commit --allow-empty -q -m init
-    export HOME="$FOREIGN_HOME_1505"
-}
-
 @test "zsh: #1505 foreign-checkout guard warns when gh_project_status.sh is sourced under zsh" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not available"
     command -v git >/dev/null 2>&1 || skip "git not available"

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -1409,3 +1409,44 @@ _run_marker_bash() {
     assert_output --partial "out=[In review]"
     [ "$(grep -c '^repo-view$' "$FAKE_GH_LOG")" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="$TEST_TEMP_HOME/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}
+
+@test "zsh: #1505 foreign-checkout guard warns when gh_project_status.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/gh_project_status.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_project_status.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when gh_project_status.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/gh_project_status.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/gh_project_status.sh"
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -226,3 +226,22 @@ assert_valid_herdr_name() {
     [[ "$1" =~ ^[a-z][a-z0-9_-]{0,31}$ ]] ||
         fail "not a valid herdr agent name: '$1'"
 }
+
+# Build a $HOME whose "dotfiles" child is an unrelated git repo, and point
+# $HOME at it — the #1454/#1505 foreign-checkout guard's regression fixture.
+# Consolidated from six near-identical per-file copies (PR #1548 review,
+# agy) into this single SSOT.
+#
+# Base tmpdir: prefer $TEST_TEMP_HOME (set by setup_isolated_home, already
+# exported and torn down by teardown_isolated_home) when the caller's setup()
+# ran it; fall back to bats' own $BATS_TEST_TMPDIR for suites that don't use
+# setup_isolated_home. This is the one real divergence the six copies had —
+# preserved here rather than forcing every caller onto setup_isolated_home.
+_setup_foreign_home_1505() {
+    FOREIGN_HOME_1505="${TEST_TEMP_HOME:-$BATS_TEST_TMPDIR}/foreign-home-1505"
+    mkdir -p "$FOREIGN_HOME_1505/dotfiles"
+    git -C "$FOREIGN_HOME_1505/dotfiles" init -q -b main
+    git -C "$FOREIGN_HOME_1505/dotfiles" -c user.email=t@t -c user.name=t \
+        commit --allow-empty -q -m init
+    export HOME="$FOREIGN_HOME_1505"
+}


### PR DESCRIPTION
## Summary
- PR #1487(issue #1454)이 `gh_pr_review.sh` 한 곳에만 배선하고 남긴 후속 이슈(#1505)를 마무리한다.
- 비대화형 스킬이 `DOTFILES_FORCE_INIT=1`로 직접 source하는 공유 helper 6개에 #1454 foreign-checkout 가드를 전파한다.
- 새 공용 진입점 `_dotfiles_root_guard_self`와 `$HOME`-키 캐시로 배선 보일러플레이트와 fork 비용을 함께 줄인다.

## Changes
- `dotfiles_root.sh`: `_dotfiles_root_guard_self(SELF_PATH, LABEL)` 추가 — "command -v 확인 + 호출 + #724 진단" 블록을 SSOT 하나로 흡수. `_dotfiles_root_canonical_common_dir`로 정본($HOME/dotfiles) 쪽 `--git-common-dir`를 `$HOME` 값으로 키를 건 프로세스 단위 캐시로 묶었다.
- `gh_pr_review.sh`: 기존 인라인 패턴을 걷어내고 새 진입점을 쓰도록 리팩터(스테일 패턴을 다음 helper가 복사하지 않도록).
- `gh_pr_reply.sh`: 인터랙티브 가드 직후에 진입점 호출을 배선.
- `gh_project_status.sh`, `gh_host.sh`, `gh_pr_edit_safe.sh`, `devx_pr_review_all.sh`, `devx_pr_verify_live.sh`: 헤더 주석 직후에 무조건(인터랙티브 가드 없이) 진입점 호출을 배선 — 이 5개 파일은 함수-정의 전용이라 원래 인터랙티브 가드가 없다(`gh_host.sh` 자체 주석·PR #704 근거).
- 7개 파일 모두 진입점 호출 자체를 `command -v` 로 한 번 더 감쌌다 — `dotfiles_root.sh`가 전혀 로드되지 않는 환경(예: `env -i`로 `SHELL_COMMON`이 빠진 훅 컨텍스트)에서 `_dotfiles_root_guard_self` 자체가 미정의라 "command not found"로 깨지는 걸 막기 위함.
- 배선한 6개 파일 + `gh_pr_review.sh`에 zsh/bash 회귀 테스트를, `dotfiles_root.bats`에 신규 진입점과 캐시 무효화(`$HOME` 전환) 테스트를 추가했다.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/bats/lib/bats-core/bin/bats tests/bats/functions/{gh_pr_review,gh_pr_reply,gh_project_status,gh_host,gh_pr_edit_safe,devx_pr_review_all,devx_pr_verify_live,devx_pr_verify_live_backend_identity,dotfiles_root}.bats` — 357/359 통과, 나머지 2건은 워크트리 canonicalize 관련 기존 실패(이 변경과 무관, 그대로 재현됨).
- [x] `mise run lint-sh` — shellcheck/shfmt 클린.

## Related
Closes #1505

---
<details>
<summary>🤖 AI Metrics · 📊 ~10500 tokens · 👤 ~8 h (1 d) · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~10500 tokens · 👤 ~8 h (1 d) · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
