### PR TITLE
fix(gh-pr-merge-train): workspace 라벨이 herdr_agent_name 을 우회하던 문제를 고친다

### DIFF
--- a/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
+++ b/claude/skills/gh-pr-merge-train/references/cron-dispatcher.md
@@ -60,15 +60,18 @@ base. It is built by `herdr_agent_name`
 (`shell-common/functions/herdr_agent_name.sh`), the SSOT shared with
 `issue_watcher_cron.sh` and `gh:pr-post-merge-verify`.
 
-The workspace label is still `mt-<host>-<owner>-<repo>` — host-qualified, for
-the #1403/#1407 reason that `owner/repo` is only unique per server. The agent
-name is not, and that asymmetry is deliberate (#1530): herdr validates agent
-names against `^[a-z][a-z0-9_-]{0,31}$` and refuses anything else, and the
-old host-qualified `pmt-<host>-<owner>-<repo>` was rejected on all 56 attempts
-— a dot, plus uppercase from a real owner. Labels carry no such rule and no
-length budget, so they keep the wider form; the agent name spends its 32
-characters on the repo. Two hosts sharing a repo name would now collide on one
-train agent; the trade-off and its expiry condition are recorded at the helper.
+The workspace label is the *same string* as the agent name (#1549) — no longer
+`mt-<host>-<owner>-<repo>`. Pre-#1549 the label kept its own host-qualified
+fold while the agent name had already moved to `herdr_agent_name` (#1530), so
+the same train answered to two different names: `herdr workspace list` showed
+one, `herdr agent get` the other, with no way to cross-reference them. Dropping
+host/owner from the label rides on the same one-repo-in-watched-repos.json
+guard the agent name already accepted (#1530): herdr validates agent names
+against `^[a-z][a-z0-9_-]{0,31}$`, which has no room for a host, so a second
+host or a second owner sharing a repo name collides on both names now, not
+just the agent name. The trade-off and its expiry condition (a short digest
+appended to both names together) are recorded at the helper
+(`shell-common/functions/herdr_agent_name.sh`).
 
 An agent that still **resolves** — `idle`, but also `done` or a status herdr
 does not name — means the previous train's pane is still open and still holds

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -94,13 +94,6 @@ _PMT_PR_LIMIT="50"
 # 32-character budget; the rationale and its expiry condition live in
 # shell-common/functions/herdr_agent_name.sh.
 _PMT_AGENT_PREFIX="mt"
-# Workspace label prefix. issue-watcher labels its workspaces with the repo
-# directory's basename; the train must not land in those tabs, so it carries
-# its own prefix (issue #1470, Impact). Unlike the agent name this stays
-# host-qualified: herdr does not validate labels, the label is how an
-# already-open workspace is found, and shortening it would strand the existing
-# workspace for nothing.
-_PMT_WORKSPACE_PREFIX="mt-"
 
 # `herdr agent prompt --wait` 한 번의 상한 — 4분. train 자체는 수십 분을 돌 수
 # 있지만 `--wait` 는 프롬프트가 *접수* 될 때까지만 기다린다. tick 이 겹치지 않게
@@ -313,23 +306,16 @@ _pmt_acquire_lock() {
     fi
 }
 
-# Echo the tick's herdr *workspace label* — e.g. `mt-github.com-acme-dotfiles`.
-# Host and repo come from the one remote URL _pmt_bind_target read them out of;
-# the label is host-qualified because `owner/repo` is only unique per server
-# (#1403/#1407).
-#
-# This builds a label and nothing else since #1530. The agent name used to come
-# from the same generic `<prefix><slug>` helper, and that fold *keeps* uppercase
-# and dots (both are inside the `tr -c` set) — which herdr's
-# `^[a-z][a-z0-9_-]{0,31}$` rejects, so the train never started once. Labels are
-# not validated by herdr and carry no length budget, so they keep the wider,
-# host-qualified form; agent names go through `herdr_agent_name` over
-# `_PMT_REPO` alone, because 32 characters have no room for the host (see the
-# _PMT_AGENT_PREFIX comment). Taking no prefix argument is what keeps the two
-# apart: there is no longer a generic slug helper an agent tag can be fed to.
+# Echo the tick's herdr *workspace label* — the same string as the agent name
+# (#1549). Before #1549 this built its own host-qualified fold
+# (`mt-github.com-<owner>-<repo>`), so the same train answered to two names:
+# `herdr workspace list` showed one, `herdr agent get` the other, with no way
+# to cross-reference them. herdr does not validate labels, but "workspace ==
+# agent" is a user decision (#1549), not a validation requirement — dropping
+# host/owner here rides on the same one-repo-in-watched-repos.json guard
+# `herdr_agent_name.sh` documents, and expires together with it.
 _pmt_workspace_label() {
-    printf '%s%s' "${_PMT_WORKSPACE_PREFIX}" \
-        "$(printf '%s/%s' "${_PMT_HOST}" "${_PMT_REPO}" | tr -c 'A-Za-z0-9._-' '-')"
+    herdr_agent_name "${_PMT_AGENT_PREFIX}" "${_PMT_REPO}"
 }
 
 # Echo the agent status (idle|working|blocked|done|unknown). Returns non-zero
@@ -668,7 +654,10 @@ _pmt_prompt_train() {
 _pmt_launch_fresh() {
     local _agent="$1" _cwd="$2" _label _ws _msg _cause
 
-    _label=$(_pmt_workspace_label)
+    _label=$(_pmt_workspace_label) || {
+        ux_error "Cannot derive a herdr workspace label from ${_PMT_REPO} — ending this tick."
+        return 1
+    }
 
     # Only this path opens a pane, so this is the only path that needs an
     # account to open it with. Resolving it in main() would make every reuse

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -93,6 +93,12 @@ _PMT_PR_LIMIT="50"
 # once in 56 attempts. Dropping the host is the concession that buys the
 # 32-character budget; the rationale and its expiry condition live in
 # shell-common/functions/herdr_agent_name.sh.
+#
+# The prefix also keeps the *workspace label* — the same string since #1549 —
+# clear of issue_watcher_cron.sh, which labels its workspaces with the bare
+# checkout basename (`dotfiles`). Drop the `mt` and the train lands in
+# issue-watcher's tabs (#1470, Impact); that collision surfaces as panes opening
+# in the wrong workspace, not as a test failure.
 _PMT_AGENT_PREFIX="mt"
 
 # `herdr agent prompt --wait` 한 번의 상한 — 4분. train 자체는 수십 분을 돌 수
@@ -304,18 +310,6 @@ _pmt_acquire_lock() {
         ux_warning "another pr_merge_train_cron tick is already running — skip"
         return 1
     fi
-}
-
-# Echo the tick's herdr *workspace label* — the same string as the agent name
-# (#1549). Before #1549 this built its own host-qualified fold
-# (`mt-github.com-<owner>-<repo>`), so the same train answered to two names:
-# `herdr workspace list` showed one, `herdr agent get` the other, with no way
-# to cross-reference them. herdr does not validate labels, but "workspace ==
-# agent" is a user decision (#1549), not a validation requirement — dropping
-# host/owner here rides on the same one-repo-in-watched-repos.json guard
-# `herdr_agent_name.sh` documents, and expires together with it.
-_pmt_workspace_label() {
-    herdr_agent_name "${_PMT_AGENT_PREFIX}" "${_PMT_REPO}"
 }
 
 # Echo the agent status (idle|working|blocked|done|unknown). Returns non-zero
@@ -654,10 +648,11 @@ _pmt_prompt_train() {
 _pmt_launch_fresh() {
     local _agent="$1" _cwd="$2" _label _ws _msg _cause
 
-    _label=$(_pmt_workspace_label) || {
-        ux_error "Cannot derive a herdr workspace label from ${_PMT_REPO} — ending this tick."
-        return 1
-    }
+    # The workspace label *is* the agent name (#1549), so `herdr workspace list`
+    # and `herdr agent get` name the same train. Assigning it rather than
+    # re-deriving it is what keeps the two from drifting apart again; main()
+    # already validated this string when it built the agent name.
+    _label="${_agent}"
 
     # Only this path opens a pane, so this is the only path that needs an
     # account to open it with. Resolving it in main() would make every reuse

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -704,12 +704,10 @@ _hold_lock() {
     _assert_logged "herdr agent get mt-dotfiles"
 }
 
-# The workspace label equals the agent name (#1549) — herdr does not validate
-# the label, but a train being findable under two different names (`mt-dotfiles`
-# for the agent, `mt-github.com-acme-dotfiles` for the workspace) is exactly the
-# observability gap #1549 fixes. Host/owner stay out of both, same as the agent
-# name (#1530): a second host or owner joining the watch list is the digest
-# case `herdr_agent_name.sh` documents, and it moves both names together.
+# The workspace label equals the agent name (#1549): a train findable as
+# `mt-dotfiles` under `herdr agent get` but `mt-github.com-acme-dotfiles` under
+# `herdr workspace list` is the observability gap #1549 closes. The second half
+# pins host-invariance — re-introducing a host-qualified fold must fail here.
 @test "pr_merge_train_cron: the workspace label matches the agent name" {
     _run_tick
     assert_success
@@ -728,9 +726,13 @@ _hold_lock() {
     _assert_logged "--label mt-dotfiles"
     _refute_logged "--label mt-github.samsungds.net-acme-dotfiles"
 
+    # `_assert_logged` is a substring match, so it would also pass on a label
+    # that merely starts with `mt-dotfiles`. Pin the whole field instead — the
+    # property under test is "label == agent name", not herdr's agent-name
+    # regex, which does not constrain labels at all.
     local _label
     _label=$(awk '{for (i = 1; i <= NF; i++) if ($i == "--label") { print $(i + 1); exit }}' "${_LOG}")
-    assert_valid_herdr_name "${_label}"
+    assert_equal "${_label}" "mt-dotfiles"
 }
 
 @test "pr_merge_train_cron: the dispatcher never writes to GitHub" {

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -280,6 +280,12 @@ _log_count() {
     grep -c -- "$1" "${_LOG}" 2>/dev/null || true
 }
 
+# The value passed to the first `--label` flag in the call log. Field-position
+# lookup, not a fixed column, so it survives flag reordering upstream.
+_pmt_logged_label() {
+    awk '{for (i = 1; i <= NF; i++) if ($i == "--label") { print $(i + 1); exit }}' "${_LOG}"
+}
+
 # A PATH that carries only the stub dir plus symlinks to the system binaries
 # the tick needs — minus the ones named as arguments. Deleting a stub is not
 # enough to make a binary missing: `command -v` keeps walking the inherited
@@ -714,6 +720,15 @@ _hold_lock() {
     _assert_logged "--label mt-dotfiles"
     _refute_logged "--label mt-github.com-acme-dotfiles"
 
+    # `_assert_logged` is a substring match, so it would also pass on a label
+    # that merely starts with `mt-dotfiles`. Pin the whole field instead — the
+    # property under test is "label == agent name", not herdr's agent-name
+    # regex, which does not constrain labels at all. Checked on *both* ticks
+    # below (github.com and GHES), not only the last one — each host gets its
+    # own log, so neither exact match can hide behind the other's pass (#1556
+    # review, agy).
+    assert_equal "$(_pmt_logged_label)" "mt-dotfiles"
+
     local _ghe="${_WORK_DIR}/ghe-dotfiles"
     mkdir -p "${_ghe}"
     git -C "${_ghe}" init -q
@@ -725,14 +740,7 @@ _hold_lock() {
     assert_success
     _assert_logged "--label mt-dotfiles"
     _refute_logged "--label mt-github.samsungds.net-acme-dotfiles"
-
-    # `_assert_logged` is a substring match, so it would also pass on a label
-    # that merely starts with `mt-dotfiles`. Pin the whole field instead — the
-    # property under test is "label == agent name", not herdr's agent-name
-    # regex, which does not constrain labels at all.
-    local _label
-    _label=$(awk '{for (i = 1; i <= NF; i++) if ($i == "--label") { print $(i + 1); exit }}' "${_LOG}")
-    assert_equal "${_label}" "mt-dotfiles"
+    assert_equal "$(_pmt_logged_label)" "mt-dotfiles"
 }
 
 @test "pr_merge_train_cron: the dispatcher never writes to GitHub" {

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -176,7 +176,7 @@ case "$1 $2" in
 "workspace list")
     if [ "${HERDR_WORKSPACE_EXISTS:-0}" = "1" ]; then
         printf '{"id":"cli:workspace:list","result":{"workspaces":[{"label":"%s","workspace_id":"ws-existing"}]}}\n' \
-            "${HERDR_WORKSPACE_LABEL:-mt-github.com-acme-dotfiles}"
+            "${HERDR_WORKSPACE_LABEL:-mt-dotfiles}"
     else
         printf '%s\n' '{"id":"cli:workspace:list","result":{"workspaces":[]}}'
     fi
@@ -704,14 +704,17 @@ _hold_lock() {
     _assert_logged "herdr agent get mt-dotfiles"
 }
 
-# The workspace label is NOT an agent name — herdr does not validate it, and
-# the label is what finds an already-open workspace. It stays host-qualified
-# (#1403/#1407): dropping the host there would strand the existing workspace
-# and buys nothing, because labels have no 32-character budget to save.
-@test "pr_merge_train_cron: the workspace label stays qualified by the host" {
+# The workspace label equals the agent name (#1549) — herdr does not validate
+# the label, but a train being findable under two different names (`mt-dotfiles`
+# for the agent, `mt-github.com-acme-dotfiles` for the workspace) is exactly the
+# observability gap #1549 fixes. Host/owner stay out of both, same as the agent
+# name (#1530): a second host or owner joining the watch list is the digest
+# case `herdr_agent_name.sh` documents, and it moves both names together.
+@test "pr_merge_train_cron: the workspace label matches the agent name" {
     _run_tick
     assert_success
-    _assert_logged "--label mt-github.com-acme-dotfiles"
+    _assert_logged "--label mt-dotfiles"
+    _refute_logged "--label mt-github.com-acme-dotfiles"
 
     local _ghe="${_WORK_DIR}/ghe-dotfiles"
     mkdir -p "${_ghe}"
@@ -722,8 +725,12 @@ _hold_lock() {
 
     _run_tick
     assert_success
-    _assert_logged "--label mt-github.samsungds.net-acme-dotfiles"
-    _refute_logged "--label mt-github.com-acme-dotfiles"
+    _assert_logged "--label mt-dotfiles"
+    _refute_logged "--label mt-github.samsungds.net-acme-dotfiles"
+
+    local _label
+    _label=$(awk '{for (i = 1; i <= NF; i++) if ($i == "--label") { print $(i + 1); exit }}' "${_LOG}")
+    assert_valid_herdr_name "${_label}"
 }
 
 @test "pr_merge_train_cron: the dispatcher never writes to GitHub" {


### PR DESCRIPTION
## Summary
- workspace 라벨이 agent 이름과 다른 host-qualified 문자열을 써서, 같은 merge-train 이 `herdr workspace list` 와 `herdr agent get` 에서 서로 다른 두 이름으로 보이던 관측성 결함을 고친다.

## Changes
- `shell-common/tools/custom/pr_merge_train_cron.sh`: `_pmt_workspace_label` 이 옛 `tr -c 'A-Za-z0-9._-' '-'` 폴드 대신 `herdr_agent_name` 을 호출하도록 바꿔, agent 이름과 동일한 문자열(`mt-<repo>`)을 쓰게 했다. 헬퍼가 실패(rc 1)할 때 빈 라벨로 workspace 를 만드는 대신 tick 을 중단하도록 호출부에 가드를 추가했고, 더 이상 쓰이지 않는 `_PMT_WORKSPACE_PREFIX` 를 제거했다.
- `tests/bats/tools/pr_merge_train_cron.bats`: workspace 라벨이 host-qualified 로 남는다는 옛 기대를 걷어내고, agent 이름과 동일한 herdr-valid 이름(`mt-dotfiles`)을 낸다는 것으로 테스트를 바꿨다. `HERDR_WORKSPACE_LABEL` 스텁 기본값도 새 라벨에 맞춰 갱신했다.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/pr_merge_train_cron.bats` — 52 passed, 0 failed.
- [x] `grep -rn "tr -c 'A-Za-z0-9" shell-common/ claude/` — 실제 코드 히트 0 (주석만 남음).
- [x] `bash -n` + `shellcheck -x -e SC1090,SC1091` — clean.
- [ ] `aicron run merge-train` 실전 실행 후 `herdr workspace list` 에 `mt-dotfiles` 만 뜨는지 확인 (수동, 다음 스케줄된 tick 에서 검증).

## Related
Fixes #1549

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~6 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics:gh-pr -->

</details>
