### PR TITLE
fix(gh-pr-merge): Step 5 의 post-merge-verify 를 셸 블록으로 강제하고 train 이 impl 탭을 닫는다

### DIFF
--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -80,6 +80,10 @@ invalidated everything behind it), route through the D-1 table
 Gate off with an empty `reviewDecision` first runs one
 `Skill(gh:pr-approve, "<N> <remote> --self-record")` and reads the board back as
 its verdict — no approval, no merge.
+After a **successful** merge, close that PR's implementation tab when its herdr
+agent is `idle` — the block in `references/train-loop.md` → "Closing the merged
+PR's implementation tab". A merged PR whose tab stays open keeps counting toward
+issue-watcher's `_IW_MAX_PER_REPO` budget and starves the pipeline (#1565).
 The `BEHIND` / `DIRTY` rows rebase inside a **detached scratch worktree** the
 train creates and unconditionally removes per attempt (#1493). Attempts are
 capped at 3 per PR (F-5); a failure skips that PR and the train continues

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -56,12 +56,25 @@ if command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
     PMT_WT=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/<head>" \
         '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) {print p; exit}}')
     if [ -n "$PMT_WT" ] && PMT_AGENTS=$(herdr agent list 2>/dev/null); then
-        # `first`: two agents on one cwd is abnormal — take the first, ignore
-        # the rest, warn about nothing (same rule as the Step 4 hint). The idle
-        # gate stays inside jq, so a tab id exists only for a closable tab —
-        # nothing has to carry a status back out through a delimiter.
-        PMT_TAB=$(printf '%s' "$PMT_AGENTS" | jq -r --arg cwd "$PMT_WT" \
-            '[.result.agents[]? | select(.cwd == $cwd)] | first
+        # Resolve symlinks before comparing: `git worktree list` reports the
+        # path as it was created, herdr reports where the pane actually stands,
+        # and a single symlinked component makes those two strings differ.
+        PMT_PHYS=$( (cd -P "$PMT_WT" 2>/dev/null && pwd -P) || printf '%s\n' "$PMT_WT")
+        # Same predicate as pmv_tab_for_cwd
+        # (../../gh-pr-post-merge-verify/references/dispatch.sh.md) and as
+        # `_iw_live_agents` — the counter whose starvation this block exists to
+        # prevent: match BOTH `cwd` (where the pane was opened) and
+        # `foreground_cwd` (where its shell stands now), on a path BOUNDARY, so
+        # an agent that `cd`-ed one level inside the worktree is still found
+        # while `/work/repo-11` never matches `/work/repo-1`.
+        # `first`: two agents on one worktree is abnormal — take the first,
+        # ignore the rest, warn about nothing (same rule as the Step 4 hint).
+        # The idle gate stays inside jq, so a tab id exists only for a closable
+        # tab — nothing has to carry a status back out through a delimiter.
+        PMT_TAB=$(printf '%s' "$PMT_AGENTS" | jq -r --arg p "$PMT_PHYS" \
+            'def under($b): . == $b or startswith($b + "/");
+             [.result.agents[]?
+              | select(((.cwd // "") | under($p)) or ((.foreground_cwd // "") | under($p)))] | first
              | select(.agent_status == "idle") | .tab_id // empty' 2>/dev/null)
         if [ -n "$PMT_TAB" ]; then
             if herdr tab close "$PMT_TAB" >/dev/null 2>&1; then

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -26,7 +26,65 @@ For each PR `N` in the Step 2 queue order:
 5. **Re-query and re-route.** An atom returning success does not prove the PR
    is mergeable now.
 6. **Merge** — `Skill(gh:pr-merge, "<N>")`. No strategy argument (D-4).
-7. **Record** the outcome and continue.
+7. **Close the merged PR's implementation tab** — only on a successful merge,
+   only when that tab is `idle`. The block is below ("Closing the merged PR's
+   implementation tab").
+8. **Record** the outcome and continue.
+
+## Closing the merged PR's implementation tab (step 7, #1565)
+
+`gh:pr-merge` Step 5 already closes this tab as part of its post-merge
+verification dispatch. This is the belt-and-braces half: run it anyway, right
+after a successful merge, because a tab that stays open is not a cosmetic leak.
+`_iw_live_agents` in `shell-common/tools/custom/issue_watcher_cron.sh` counts a
+`wt/issue-*` worktree as running whenever a herdr agent sits on it, so three
+merged-but-open tabs exhaust `_IW_MAX_PER_REPO=3` and issue-watcher silently
+stops dispatching for that repo — the pipeline starves itself. On 2026-08-27 a
+train merged 10 PRs and left all 10 tabs open.
+
+`<head>` is the `headRefName` already in `$STATE` from step 1 — no extra API
+call. Run this **only after** `gh:pr-merge` reported success; a `[SKIPPED]` or
+`[FAILED]` PR still has work parked in its worktree.
+
+```bash
+# Idle-only, exactly the judgement gh:pr-merge's Step 4 herdr hint already
+# makes (../../gh-pr-merge/references/herdr-tab-notify.sh.md): a `working` or
+# `blocked` agent is a live session, and closing its tab kills work in flight.
+# Everything else here is a silent skip — this runs after the merge, so it can
+# never fail the PR it just merged.
+if command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    PMT_WT=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/<head>" \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+    if [ -n "$PMT_WT" ] && PMT_AGENTS=$(herdr agent list 2>/dev/null); then
+        # head -1: two agents on one cwd is abnormal — take the first, ignore
+        # the rest, warn about nothing (same rule as the Step 4 hint).
+        PMT_MATCH=$(printf '%s' "$PMT_AGENTS" | jq -r --arg cwd "$PMT_WT" \
+            '.result.agents[]? | select(.cwd == $cwd)
+             | "\(.tab_id)\t\(.agent_status)"' 2>/dev/null | head -1)
+        PMT_TAB=$(printf '%s' "$PMT_MATCH" | cut -f1)
+        PMT_STATUS=$(printf '%s' "$PMT_MATCH" | cut -f2)
+        if [ -n "$PMT_TAB" ] && [ "$PMT_STATUS" = "idle" ]; then
+            if herdr tab close "$PMT_TAB" >/dev/null 2>&1; then
+                printf '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).\n' \
+                    "$PMT_TAB" "$PMT_WT"
+            else
+                printf '[WARN] gh:pr-merge-train: herdr tab close %s failed — continuing.\n' \
+                    "$PMT_TAB"
+            fi
+        fi
+    fi
+fi
+```
+
+Closing a tab `gh:pr-merge` already closed is not a conflict: the second lookup
+simply finds no agent on that path and prints nothing. The two halves are
+deliberately redundant — if the Step 5 dispatch is skipped again, this one still
+keeps the live count flat across a whole train.
+
+`tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats` pins both halves of
+the rule (idle closes, non-idle never does) against the executable mirror
+`tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh`. Change the
+block above, change that fixture.
 
 ## Delegated review on the gate-off path (step 2b, #1519 F-6 … F-9)
 

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -54,16 +54,16 @@ call. Run this **only after** `gh:pr-merge` reported success; a `[SKIPPED]` or
 # never fail the PR it just merged.
 if command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
     PMT_WT=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/<head>" \
-        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) {print p; exit}}')
     if [ -n "$PMT_WT" ] && PMT_AGENTS=$(herdr agent list 2>/dev/null); then
-        # head -1: two agents on one cwd is abnormal — take the first, ignore
-        # the rest, warn about nothing (same rule as the Step 4 hint).
-        PMT_MATCH=$(printf '%s' "$PMT_AGENTS" | jq -r --arg cwd "$PMT_WT" \
-            '.result.agents[]? | select(.cwd == $cwd)
-             | "\(.tab_id)\t\(.agent_status)"' 2>/dev/null | head -1)
-        PMT_TAB=$(printf '%s' "$PMT_MATCH" | cut -f1)
-        PMT_STATUS=$(printf '%s' "$PMT_MATCH" | cut -f2)
-        if [ -n "$PMT_TAB" ] && [ "$PMT_STATUS" = "idle" ]; then
+        # `first`: two agents on one cwd is abnormal — take the first, ignore
+        # the rest, warn about nothing (same rule as the Step 4 hint). The idle
+        # gate stays inside jq, so a tab id exists only for a closable tab —
+        # nothing has to carry a status back out through a delimiter.
+        PMT_TAB=$(printf '%s' "$PMT_AGENTS" | jq -r --arg cwd "$PMT_WT" \
+            '[.result.agents[]? | select(.cwd == $cwd)] | first
+             | select(.agent_status == "idle") | .tab_id // empty' 2>/dev/null)
+        if [ -n "$PMT_TAB" ]; then
             if herdr tab close "$PMT_TAB" >/dev/null 2>&1; then
                 printf '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).\n' \
                     "$PMT_TAB" "$PMT_WT"

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -125,12 +125,20 @@ if [ -n "$VERIFY_SKILL" ]; then
     # fence is taken — the file's later snippets are documentation, not steps.
     PMV_FENCE=$(printf '\140\140\140')
     if [ -r "$PMV_BLOCK" ] && PMV_SH=$(mktemp 2>/dev/null); then
+        # The staged file must not outlive this block. The sourced dispatch
+        # returns early on most of its paths, and a caller running under
+        # `set -e` can leave the shell entirely between the two lines below —
+        # so cleanup is armed before anything can go wrong and cleared on the
+        # success path, the same shape as _PMT_ERRF in
+        # shell-common/tools/custom/pr_merge_train_cron.sh.
+        trap 'rm -f "$PMV_SH"' EXIT INT TERM
         awk -v f="$PMV_FENCE" \
             '$0 == f "bash" && !b { b = 1; next } $0 == f && b { exit } b' \
             "$PMV_BLOCK" >"$PMV_SH"
         # shellcheck source=/dev/null
         . "$PMV_SH"
         rm -f "$PMV_SH"
+        trap - EXIT INT TERM
     else
         printf '[WARN] gh:pr-merge: could not stage %s — post-merge verification skipped.\n' "$PMV_BLOCK"
     fi

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -93,9 +93,13 @@ Print **only** the compact report (format in `references/strategy-selection.md` 
 post-merge verification gate **and** its dispatch, in one run:
 
 ```bash
-# Substitute the four values before running; every one of them is already in
-# hand from Steps 1-2, so nothing here re-queries GitHub.
+# Substitute the five values before running; every one of them is already in
+# hand from Steps 1-2, so nothing here re-queries GitHub. Bind them all, even
+# the ones an earlier step already set: each block runs in its own shell, and
+# an unbound TARGET_REPO makes the registry lookup below answer empty — the
+# silent no-dispatch #1565 is about.
 PR_NUMBER=<N>                 # the merged PR
+TARGET_REPO=<owner/repo>      # Step 1's single remote URL, the registry key
 HEAD_BRANCH=<headRefName>     # Step 2's `gh pr view` already read it
 BASE_BRANCH=<baseRefName>     # ditto — never a hardcoded `main`
 REMOTE=<remote>               # the `[remote]` positional, default `origin`

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -89,22 +89,54 @@ GH_HOST="$TARGET_HOST" gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -
 
 Print **only** the compact report (format in `references/strategy-selection.md` → "Final report format").
 
-**After** the report has printed, gate on the #1511 watched-repos registry:
+**After** the report has printed, paste this block verbatim — it is the
+post-merge verification gate **and** its dispatch, in one run:
 
 ```bash
+# Substitute the four values before running; every one of them is already in
+# hand from Steps 1-2, so nothing here re-queries GitHub.
+PR_NUMBER=<N>                 # the merged PR
+HEAD_BRANCH=<headRefName>     # Step 2's `gh pr view` already read it
+BASE_BRANCH=<baseRefName>     # ditto — never a hardcoded `main`
+REMOTE=<remote>               # the `[remote]` positional, default `origin`
+
 WATCHED_FILE="${DOTFILES_ROOT:-$HOME/dotfiles}/docs/.ssot/watched-repos.json"
 VERIFY_SKILL=""
 if command -v jq >/dev/null 2>&1 && [ -r "$WATCHED_FILE" ]; then
     VERIFY_SKILL=$(jq -r --arg r "$TARGET_REPO" '.[$r].verify_skill // empty' "$WATCHED_FILE" 2>/dev/null)
 fi
+# Empty VERIFY_SKILL — repo not registered, no registry, or no jq, so the
+# feature is simply unavailable — means do nothing at all: no output, no
+# dispatch, and no [WARN] either. An unwatched repo stays byte-identical to
+# its pre-#1511 behavior.
+if [ -n "$VERIFY_SKILL" ]; then
+    # gh:pr-post-merge-verify's dispatch block is READ from its SSOT and run
+    # here, rather than reached through `Skill(gh:pr-post-merge-verify, ...)`.
+    # As a Skill() call this step ran 0/10 inside gh:pr-merge-train and 1/1 at
+    # top level, while every pasted block in Step 4 ran 10/10 — and a tab that
+    # is never closed starves issue-watcher's _IW_MAX_PER_REPO budget (#1565).
+    PMV_BLOCK="${DOTFILES_ROOT:-$HOME/dotfiles}/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md"
+    # The fence marker is built with printf, never typed, so this block can sit
+    # inside a fenced block of its own without closing it. Only the FIRST bash
+    # fence is taken — the file's later snippets are documentation, not steps.
+    PMV_FENCE=$(printf '\140\140\140')
+    if [ -r "$PMV_BLOCK" ] && PMV_SH=$(mktemp 2>/dev/null); then
+        awk -v f="$PMV_FENCE" \
+            '$0 == f "bash" && !b { b = 1; next } $0 == f && b { exit } b' \
+            "$PMV_BLOCK" >"$PMV_SH"
+        # shellcheck source=/dev/null
+        . "$PMV_SH"
+        rm -f "$PMV_SH"
+    else
+        printf '[WARN] gh:pr-merge: could not stage %s — post-merge verification skipped.\n' "$PMV_BLOCK"
+    fi
+fi
 ```
 
-Empty `VERIFY_SKILL` (repo not registered, no registry, or no `jq` — the
-feature is then simply unavailable) → **do nothing at all**: no output, no
-dispatch, and no `[WARN]` either. Otherwise call
-`Skill(gh:pr-post-merge-verify, "<N> <remote>")` and stop — that skill owns
-every step and every failure mode (all soft-fail, so this report stands
-regardless). Detail: `claude/skills/gh-pr-post-merge-verify/SKILL.md`.
+The dispatch owns every step and every failure mode from there (all soft-fail,
+so the report above stands regardless), and re-runs the same registry gate on
+its own so it stays usable standalone. Detail:
+`claude/skills/gh-pr-post-merge-verify/SKILL.md`.
 
 ## Constraints
 
@@ -116,4 +148,6 @@ regardless). Detail: `claude/skills/gh-pr-post-merge-verify/SKILL.md`.
 
 `gh:pr-approve` produces the approval this skill gates on · `gh:pr-merge-emergency`
 is the admin-override path when approval cannot be obtained · `gh:pr-post-merge-verify`
-is dispatched at the end of Step 5 for repos registered in `docs/.ssot/watched-repos.json`.
+owns the dispatch block Step 5 runs inline for repos registered in
+`docs/.ssot/watched-repos.json`, and stays a standalone manual entry point
+(`/gh-pr-post-merge-verify <N>`).

--- a/claude/skills/gh-pr-post-merge-verify/SKILL.md
+++ b/claude/skills/gh-pr-post-merge-verify/SKILL.md
@@ -96,7 +96,10 @@ Every decision above is mirrored executably in
 
 ## Related Skills
 
-`gh:pr-merge` invokes this at the end of its Step 5 · `devx:pr-verify-merged`
+`gh:pr-merge` reads `references/dispatch.sh.md` and runs it inline at the end of
+its Step 5 — never `Skill(gh:pr-post-merge-verify, ...)`, which vanished inside
+`gh:pr-merge-train`'s loop (#1565); this skill stays the standalone manual entry
+point and the SSOT for that block · `devx:pr-verify-merged`
 / `devx:pr-verify-live` are what the dispatched session actually runs (the
 registry picks which) · `gh:pr-merge-train` shares the herdr
 workspace→tab→agent→prompt sequence via `pr_merge_train_cron.sh`.

--- a/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
@@ -4,6 +4,10 @@ Step 3 pastes this. It expects `PR_NUMBER`, `TARGET_REPO` and `TARGET_HOST`
 already bound (Step 2), and it is a no-op for any repo missing from
 `docs/.ssot/watched-repos.json`.
 
+`gh:pr-merge` Step 5 does not paste a copy: it extracts the **first** `bash`
+fence below and sources it, so this file stays the single source (#1565). Keep
+the dispatch in that first fence — the later snippets are documentation.
+
 Executable mirror + regression suite:
 `tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh` and
 `tests/bats/skills/gh_pr_post_merge_verify.bats`. Change one, change both.

--- a/docs/public/changelog.d/2026-08-28-1565.md
+++ b/docs/public/changelog.d/2026-08-28-1565.md
@@ -1,0 +1,2 @@
+- 변경: **`gh:pr-merge` Step 5 의 post-merge-verify 를 `Skill()` 호출 대신 `dispatch.sh.md` 를 읽어 실행하는 셸 블록으로 바꿔, `gh:pr-merge-train` 루프 안에서 유실되던 검증 디스패치를 기계적으로 강제한다**
+- 변경: **`gh:pr-merge-train` 이 머지 성공 직후 해당 PR 의 impl 탭을 닫는다(`agent_status` 가 `idle` 일 때만) — 머지된 PR 의 탭이 남아 issue-watcher 의 `_IW_MAX_PER_REPO` 예산을 잠식하던 파이프라인 굶주림을 막는다**

--- a/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
+# Source-of-truth mirror for the step-7 impl-tab close documented in
+# claude/skills/gh-pr-merge-train/references/train-loop.md (issue #1565).
+#
+# The train itself runs inside a Claude session, but this step is a small bash
+# block: given the merged PR's head branch, does it find the local worktree,
+# match the herdr agent parked on that cwd, and close its tab only when that
+# agent is idle?
+#
+# Keep this file in sync with the bash block in that reference doc. If the doc
+# block changes, mirror the change here so the bats suite catches drift.
+#
+# Test seams: `git`, `herdr`, and `jq` are resolved through the shell's normal
+# command lookup, so the bats suite shadows them with functions. Nothing is
+# stubbed inside the fixture — the block below is meant to read as the doc
+# block does.
+
+# Mirrors the block in
+# claude/skills/gh-pr-merge-train/references/train-loop.md → "Closing the
+# merged PR's implementation tab", which SKILL.md Step 4 delegates to. Any
+# change here must propagate to that block, and vice versa.
+#
+# Usage: gh_pr_merge_train_close_impl_tab "$HEAD_REF"
+#   $1 — the merged PR's headRefName, already in $STATE from the loop's step 1.
+#
+# Always returns 0: this runs after the merge already succeeded, so it can
+# never fail the PR it just merged. It is the belt-and-braces half of #1565 —
+# gh:pr-merge Step 5's dispatch closes the same tab first, and finding nothing
+# to close is the expected outcome when that worked.
+gh_pr_merge_train_close_impl_tab() {
+    local _branch="$1"
+
+    # Idle-only, exactly the judgement gh:pr-merge's Step 4 herdr hint already
+    # makes: a `working` or `blocked` agent is a live session, and closing its
+    # tab kills work in flight. Every gate below is a silent skip.
+    command -v herdr >/dev/null 2>&1 || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    # Locate the local worktree checked out on the merged branch. substr()
+    # rather than $2 so a worktree path containing spaces still resolves; an
+    # empty branch matches nothing, so that case falls out of this same gate.
+    local _wt_path
+    _wt_path=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${_branch}" \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+    [ -n "$_wt_path" ] || return 0
+
+    local _agent_json
+    _agent_json=$(herdr agent list 2>/dev/null) || return 0
+
+    # head -1: two agents on one cwd is abnormal — take the first, ignore the
+    # rest, warn about nothing (same rule as the Step 4 hint).
+    local _match _tab_id _agent_status
+    _match=$(printf '%s' "$_agent_json" | jq -r --arg cwd "$_wt_path" \
+        '.result.agents[]? | select(.cwd == $cwd)
+         | "\(.tab_id)\t\(.agent_status)"' 2>/dev/null | head -1)
+    _tab_id=$(printf '%s' "$_match" | cut -f1)
+    _agent_status=$(printf '%s' "$_match" | cut -f2)
+
+    [ -n "$_tab_id" ] || return 0
+    [ "$_agent_status" = "idle" ] || return 0
+
+    if herdr tab close "$_tab_id" >/dev/null 2>&1; then
+        printf '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).\n' \
+            "$_tab_id" "$_wt_path"
+    else
+        printf '[WARN] gh:pr-merge-train: herdr tab close %s failed — continuing.\n' \
+            "$_tab_id"
+    fi
+
+    return 0
+}

--- a/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
@@ -42,23 +42,22 @@ gh_pr_merge_train_close_impl_tab() {
     # empty branch matches nothing, so that case falls out of this same gate.
     local _wt_path
     _wt_path=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${_branch}" \
-        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' | head -1)
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) {print p; exit}}')
     [ -n "$_wt_path" ] || return 0
 
     local _agent_json
     _agent_json=$(herdr agent list 2>/dev/null) || return 0
 
-    # head -1: two agents on one cwd is abnormal — take the first, ignore the
-    # rest, warn about nothing (same rule as the Step 4 hint).
-    local _match _tab_id _agent_status
-    _match=$(printf '%s' "$_agent_json" | jq -r --arg cwd "$_wt_path" \
-        '.result.agents[]? | select(.cwd == $cwd)
-         | "\(.tab_id)\t\(.agent_status)"' 2>/dev/null | head -1)
-    _tab_id=$(printf '%s' "$_match" | cut -f1)
-    _agent_status=$(printf '%s' "$_match" | cut -f2)
+    # `first`: two agents on one cwd is abnormal — take the first, ignore the
+    # rest, warn about nothing (same rule as the Step 4 hint). The idle gate
+    # stays inside jq, so a tab id exists only for a closable tab — nothing has
+    # to carry a status back out through a delimiter.
+    local _tab_id
+    _tab_id=$(printf '%s' "$_agent_json" | jq -r --arg cwd "$_wt_path" \
+        '[.result.agents[]? | select(.cwd == $cwd)] | first
+         | select(.agent_status == "idle") | .tab_id // empty' 2>/dev/null)
 
     [ -n "$_tab_id" ] || return 0
-    [ "$_agent_status" = "idle" ] || return 0
 
     if herdr tab close "$_tab_id" >/dev/null 2>&1; then
         printf '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).\n' \

--- a/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh
@@ -48,13 +48,27 @@ gh_pr_merge_train_close_impl_tab() {
     local _agent_json
     _agent_json=$(herdr agent list 2>/dev/null) || return 0
 
-    # `first`: two agents on one cwd is abnormal — take the first, ignore the
-    # rest, warn about nothing (same rule as the Step 4 hint). The idle gate
-    # stays inside jq, so a tab id exists only for a closable tab — nothing has
-    # to carry a status back out through a delimiter.
+    # Resolve symlinks before comparing: `git worktree list` reports the path
+    # as it was created, herdr reports where the pane actually stands, and a
+    # single symlinked component makes those two strings differ.
+    local _phys
+    _phys=$( (cd -P "$_wt_path" 2>/dev/null && pwd -P) || printf '%s\n' "$_wt_path")
+
+    # Same predicate as pmv_tab_for_cwd (gh-pr-post-merge-verify's
+    # references/dispatch.sh.md) and as `_iw_live_agents` — the counter whose
+    # starvation this block exists to prevent: match BOTH `cwd` (where the pane
+    # was opened) and `foreground_cwd` (where its shell stands now), on a path
+    # BOUNDARY, so an agent that `cd`-ed one level inside the worktree is still
+    # found while `/work/repo-11` never matches `/work/repo-1`.
+    # `first`: two agents on one worktree is abnormal — take the first, ignore
+    # the rest, warn about nothing (same rule as the Step 4 hint). The idle
+    # gate stays inside jq, so a tab id exists only for a closable tab —
+    # nothing has to carry a status back out through a delimiter.
     local _tab_id
-    _tab_id=$(printf '%s' "$_agent_json" | jq -r --arg cwd "$_wt_path" \
-        '[.result.agents[]? | select(.cwd == $cwd)] | first
+    _tab_id=$(printf '%s' "$_agent_json" | jq -r --arg p "$_phys" \
+        'def under($b): . == $b or startswith($b + "/");
+         [.result.agents[]?
+          | select(((.cwd // "") | under($p)) or ((.foreground_cwd // "") | under($p)))] | first
          | select(.agent_status == "idle") | .tab_id // empty' 2>/dev/null)
 
     [ -n "$_tab_id" ] || return 0

--- a/tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
+++ b/tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
@@ -377,10 +377,10 @@ branch refs/heads/wt/issue-2/1
     local fixture="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh"
     local f pat
     for pat in \
-        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) {print p; exit}}' \
         '.result.agents[]? | select(.cwd == $cwd)' \
-        '"\(.tab_id)\t\(.agent_status)"' \
-        '= "idle" ]' \
+        'select(.agent_status == "idle")' \
+        '.tab_id // empty' \
         '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).' \
         '[WARN] gh:pr-merge-train: herdr tab close %s failed'; do
         for f in "$doc" "$fixture"; do

--- a/tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
+++ b/tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
@@ -19,6 +19,10 @@
 #   5. herdr tab close fails                       → [WARN], never fatal
 #   6. anti-starvation regression: the live count does not grow across N merges
 #   7. doc/fixture drift guard + the SKILL.md pointer
+#   8. PR #1567 review: the lookup matches `.cwd` OR `.foreground_cwd`, on a
+#      path boundary, against the PHYSICAL path — a shell that `cd`'d inside
+#      the worktree and a symlinked worktree path both still resolve, while a
+#      sibling sharing the prefix still does not.
 
 load '../test_helper'
 
@@ -97,6 +101,21 @@ _agents_json() {
     printf '%s]}}' "$out"
 }
 
+# Same, but `cwd` and `foreground_cwd` are set independently:
+# `cwd|foreground_cwd|tab_id|status`. `cwd` is where the pane was opened,
+# `foreground_cwd` where its shell stands now — they diverge the moment the
+# session `cd`s, which is the case _iw_live_agents already counts as live.
+_agents_json_fg() {
+    local spec sep="" out='{"result":{"agents":['
+    local cwd fg tab st
+    for spec in "$@"; do
+        IFS='|' read -r cwd fg tab st <<<"$spec"
+        out+="${sep}{\"cwd\":\"${cwd}\",\"foreground_cwd\":\"${fg}\",\"tab_id\":\"${tab}\",\"agent_status\":\"${st}\"}"
+        sep=","
+    done
+    printf '%s]}}' "$out"
+}
+
 # --- 1. the happy path ----------------------------------------------------
 
 @test "close-impl-tab: an idle agent on the merged worktree gets its tab closed" {
@@ -129,6 +148,96 @@ branch refs/heads/wt/issue-1565/1
     FAKE_AGENT_JSON="$(_agents_json \
         "/home/dev/wt/issue-1000|tab-other|idle" \
         "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+# --- 1b. the moved shell and the symlinked path (PR #1567 review) ---------
+#
+# `_iw_live_agents` matches `.cwd` OR `.foreground_cwd`, and pmv_tab_for_cwd
+# matches both on a path boundary against the PHYSICAL path. A lookup that
+# compared only `.cwd`, as a string, left exactly the sessions this step exists
+# to reclaim: the count stayed pinned while the backstop reported nothing to do.
+
+@test "close-impl-tab: an agent whose shell cd'd into a subdir is still closed" {
+    FAKE_AGENT_JSON="$(_agents_json_fg "${WT_DIR}|${WT_DIR}/docs/.ssot|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+@test "close-impl-tab: a pane opened inside the worktree (cwd under it) is closed" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}/claude/skills|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+@test "close-impl-tab: foreground_cwd alone is enough to match the worktree" {
+    # The pane was opened on the main checkout and the shell walked into the
+    # worktree — `.cwd` never matches, `_iw_live_agents` still counts it.
+    FAKE_AGENT_JSON="$(_agents_json_fg "/home/dev/dotfiles|${WT_DIR}/tests|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+@test "close-impl-tab: a subdir match still obeys the idle gate" {
+    FAKE_AGENT_JSON="$(_agents_json_fg "${WT_DIR}|${WT_DIR}/docs|tab-7|working")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: a sibling path sharing the prefix is not a match" {
+    # `/…/issue-1565` must not swallow `/…/issue-15650` — the boundary is why
+    # the filter appends a slash to the prefix instead of matching it bare.
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}0|tab-other|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: a symlinked worktree path still resolves to the agent" {
+    # `git worktree list` answers the path as it was created; herdr answers
+    # where the pane really stands. One symlinked component made the old
+    # string compare miss, and the tab silently survived the merge.
+    local real="${TEST_TEMP_HOME}/real/wt-issue-1565"
+    local link="${TEST_TEMP_HOME}/link-wt"
+    mkdir -p "$real"
+    ln -sfn "$real" "$link"
+
+    FAKE_WORKTREE_LIST="worktree ${link}
+HEAD cccc
+branch refs/heads/wt/issue-1565/1
+"
+    # The agent reports the physical path — the two strings are not equal.
+    FAKE_AGENT_JSON="$(_agents_json "$(cd -P "$real" && pwd -P)|tab-7|idle")"
+    [ "$link" != "$real" ]
+
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+@test "close-impl-tab: an unresolvable worktree path falls back to the raw string" {
+    # `cd -P` fails for a path that no longer exists on disk; the lookup must
+    # degrade to the literal path rather than to an empty prefix that matches
+    # every agent.
+    FAKE_AGENT_JSON="$(_agents_json \
+        "/home/dev/somewhere-else|tab-other|idle" \
+        "${WT_DIR}|tab-7|idle")"
+    [ ! -e "$WT_DIR" ]
     run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
     assert_success
     run cat "$FAKE_CLOSED_LOG"
@@ -378,7 +487,9 @@ branch refs/heads/wt/issue-2/1
     local f pat
     for pat in \
         '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) {print p; exit}}' \
-        '.result.agents[]? | select(.cwd == $cwd)' \
+        '" 2>/dev/null && pwd -P)' \
+        'def under($b): . == $b or startswith($b + "/");' \
+        'select(((.cwd // "") | under($p)) or ((.foreground_cwd // "") | under($p)))] | first' \
         'select(.agent_status == "idle")' \
         '.tab_id // empty' \
         '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).' \

--- a/tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
+++ b/tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
@@ -1,0 +1,415 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_merge_train_close_impl_tab.bats
+# Verify the step-7 impl-tab close documented in
+#   claude/skills/gh-pr-merge-train/SKILL.md → references/train-loop.md
+# Source-of-truth fixture: _fixtures/gh_pr_merge_train_close_impl_tab.sh.
+#
+# Issue #1565: gh:pr-merge Step 5's post-merge-verify dispatch was prose
+# ("call `Skill(gh:pr-post-merge-verify, ...)`") at the tail of a skill the
+# train invokes in a loop, and it executed 0/10 times inside that loop. The
+# impl tabs of 10 merged PRs stayed open, `_iw_live_agents` in
+# shell-common/tools/custom/issue_watcher_cron.sh counted their worktrees as
+# running, and `_IW_MAX_PER_REPO=3` stopped issue-watcher after ~3 merges.
+#
+# Cases:
+#   1. idle agent on the merged branch's worktree → tab closed, one [INFO]
+#   2. agent_status == working / blocked           → NEVER closed, no output
+#   3. no worktree / no herdr / no jq / dead herdr  → silent skip, rc 0
+#   4. two agents on one cwd                       → first wins, closed once
+#   5. herdr tab close fails                       → [WARN], never fatal
+#   6. anti-starvation regression: the live count does not grow across N merges
+#   7. doc/fixture drift guard + the SKILL.md pointer
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1091
+    source "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh"
+
+    WT_DIR="/home/dev/wt/issue-1565"
+    export WT_DIR
+
+    FAKE_WORKTREE_LIST="worktree /home/dev/dotfiles
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree ${WT_DIR}
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/wt/issue-1565/1
+"
+    export FAKE_WORKTREE_LIST
+
+    FAKE_CALL_LOG="${TEST_TEMP_HOME}/calls.log"
+    export FAKE_CALL_LOG
+    : >"$FAKE_CALL_LOG"
+
+    # Shadow `git` so `git worktree list --porcelain` reads a fixed table
+    # instead of this repo's real worktrees.
+    git() {
+        printf 'git %s\n' "$*" >>"$FAKE_CALL_LOG"
+        if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
+            printf '%s' "${FAKE_WORKTREE_LIST-}"
+            return 0
+        fi
+        command git "$@"
+    }
+
+    # Shadow `herdr`. `agent list` is canned and steerable; `tab close` records
+    # the tab it was asked to close so the tests assert on calls made, not only
+    # on printed text. FAKE_CLOSE_RC simulates a refusal.
+    herdr() {
+        printf 'herdr %s\n' "$*" >>"$FAKE_CALL_LOG"
+        if [ "$1" = "agent" ] && [ "$2" = "list" ]; then
+            [ "${FAKE_AGENT_RC:-0}" -eq 0 ] || return "$FAKE_AGENT_RC"
+            printf '%s' "${FAKE_AGENT_JSON-}"
+            return 0
+        fi
+        if [ "$1" = "tab" ] && [ "$2" = "close" ]; then
+            [ "${FAKE_CLOSE_RC:-0}" -eq 0 ] || return "$FAKE_CLOSE_RC"
+            printf '%s\n' "$3" >>"${FAKE_CLOSED_LOG:-/dev/null}"
+            return 0
+        fi
+        return 1
+    }
+
+    FAKE_CLOSED_LOG="${TEST_TEMP_HOME}/closed.log"
+    export FAKE_CLOSED_LOG
+    : >"$FAKE_CLOSED_LOG"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset -f git herdr 2>/dev/null || true
+    unset WT_DIR FAKE_WORKTREE_LIST FAKE_AGENT_JSON FAKE_AGENT_RC FAKE_CALL_LOG \
+        FAKE_CLOSE_RC FAKE_CLOSED_LOG
+}
+
+# Build an agent-list payload from `cwd|tab_id|status` specs.
+_agents_json() {
+    local spec sep="" out='{"result":{"agents":['
+    local cwd tab st
+    for spec in "$@"; do
+        IFS='|' read -r cwd tab st <<<"$spec"
+        out+="${sep}{\"cwd\":\"${cwd}\",\"foreground_cwd\":\"${cwd}\",\"tab_id\":\"${tab}\",\"agent_status\":\"${st}\"}"
+        sep=","
+    done
+    printf '%s]}}' "$out"
+}
+
+# --- 1. the happy path ----------------------------------------------------
+
+@test "close-impl-tab: an idle agent on the merged worktree gets its tab closed" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    assert_output --partial '[INFO] gh:pr-merge-train: closed implementation tab tab-7'
+    assert_output --partial "(${WT_DIR})"
+    [ "${#lines[@]}" -eq 1 ]
+}
+
+@test "close-impl-tab: the close really is invoked, with that tab id" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+@test "close-impl-tab: the branch decides the worktree, not the directory name" {
+    # Two worktrees, one agent each; only the merged branch's tab may close.
+    FAKE_WORKTREE_LIST="worktree /home/dev/wt/issue-1000
+HEAD aaaa
+branch refs/heads/wt/issue-1000/1
+
+worktree ${WT_DIR}
+HEAD bbbb
+branch refs/heads/wt/issue-1565/1
+"
+    FAKE_AGENT_JSON="$(_agents_json \
+        "/home/dev/wt/issue-1000|tab-other|idle" \
+        "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-7"
+}
+
+# --- 2. non-idle is never closed (the decision that keeps work alive) ------
+
+@test "close-impl-tab: agent_status=working is NEVER closed and prints nothing" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|working")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: agent_status=blocked is NEVER closed" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|blocked")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: an unknown future status is treated as not-idle" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|compacting")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: a null agent_status is treated as not-idle" {
+    FAKE_AGENT_JSON="{\"result\":{\"agents\":[{\"cwd\":\"${WT_DIR}\",\"tab_id\":\"tab-7\"}]}}"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: no herdr call is made at all for a working tab beyond the list" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|working")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    run bash -c "grep -c 'herdr tab close' '$FAKE_CALL_LOG' || true"
+    assert_output "0"
+}
+
+# --- 3. the silent skips --------------------------------------------------
+
+@test "close-impl-tab: no local worktree for the merged branch → silent skip" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "feature/merged-elsewhere"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: an empty head branch → silent skip" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab ""
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "close-impl-tab: herdr not installed → silent skip, rc=0" {
+    local bin="${TEST_TEMP_HOME}/nobin"
+    mkdir -p "$bin"
+    local tool
+    for tool in awk jq cut head; do
+        ln -sf "$(command -v "$tool")" "$bin/$tool"
+    done
+    unset -f herdr
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+
+    local old_path="$PATH"
+    PATH="$bin"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    PATH="$old_path"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "close-impl-tab: herdr agent list fails → silent skip, nothing closed" {
+    FAKE_AGENT_RC=1
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: an empty agent set → silent skip" {
+    FAKE_AGENT_JSON='{"result":{"agents":[]}}'
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "close-impl-tab: garbage from herdr agent list → silent skip" {
+    FAKE_AGENT_JSON='not json at all'
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output ""
+}
+
+@test "close-impl-tab: agents exist but none sit on the worktree → silent skip" {
+    FAKE_AGENT_JSON="$(_agents_json "/home/dev/somewhere-else|tab-9|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+# The gh:pr-merge Step 5 dispatch closes this tab first when it ran. Finding
+# nothing is therefore the EXPECTED outcome of a healthy pipeline, not an error.
+@test "close-impl-tab: a tab gh:pr-merge already closed is a quiet no-op" {
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    FAKE_AGENT_JSON='{"result":{"agents":[]}}'
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ -z "$output" ]
+}
+
+# --- 4/5. abnormal states -------------------------------------------------
+
+@test "close-impl-tab: two agents on one cwd → first wins, closed once" {
+    FAKE_AGENT_JSON="$(_agents_json \
+        "${WT_DIR}|tab-first|idle" \
+        "${WT_DIR}|tab-second|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    [ "${#lines[@]}" -eq 1 ]
+    assert_output --partial 'tab-first'
+    refute_output --partial 'tab-second'
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-first"
+}
+
+@test "close-impl-tab: a failing herdr tab close warns and never fails the merge" {
+    FAKE_CLOSE_RC=1
+    FAKE_AGENT_JSON="$(_agents_json "${WT_DIR}|tab-7|idle")"
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1565/1"
+    assert_success
+    assert_output --partial '[WARN] gh:pr-merge-train: herdr tab close tab-7 failed'
+}
+
+# --- 6. the anti-starvation regression gate -------------------------------
+#
+# The failure #1565 describes is not a missing [INFO] line: it is that
+# `_iw_live_agents` counts a `wt/issue-*` worktree as running whenever a herdr
+# agent sits on it, so merged-but-open tabs fill `_IW_MAX_PER_REPO=3` and
+# issue-watcher stops dispatching. This drives N merges against a mutable
+# registry and asserts the live count never grows — the pre-fix train left it
+# pinned at N.
+
+# Count the worktrees `_iw_live_agents` would call live: a `wt/issue-*`
+# worktree with a herdr agent standing on it (same predicate, same jq shape).
+_live_count() {
+    printf '%s' "$FAKE_AGENT_JSON" |
+        jq -r '[.result.agents[]? | (.cwd // empty)
+               | select(test("/wt/issue-"))] | length'
+}
+
+# Drop the agent whose tab_id was just closed, the way a real herdr does.
+_forget_closed_tab() {
+    FAKE_AGENT_JSON=$(printf '%s' "$FAKE_AGENT_JSON" |
+        jq -c --arg t "$1" '.result.agents |= map(select(.tab_id != $t))')
+}
+
+@test "close-impl-tab: the live worktree count does not grow across N merges" {
+    local n=5 i specs=() wt_list="" counts=""
+
+    for ((i = 1; i <= n; i++)); do
+        wt_list+="worktree /home/dev/wt/issue-${i}
+HEAD ${i}${i}${i}${i}
+branch refs/heads/wt/issue-${i}/1
+
+"
+        specs+=("/home/dev/wt/issue-${i}|tab-${i}|idle")
+    done
+    FAKE_WORKTREE_LIST="$wt_list"
+    FAKE_AGENT_JSON="$(_agents_json "${specs[@]}")"
+
+    # Before the train runs, all N merged PRs are counted as live sessions —
+    # this is the state that starved issue-watcher.
+    [ "$(_live_count)" -eq "$n" ] || fail "expected ${n} live worktrees to start"
+
+    local prev="$n" now
+    for ((i = 1; i <= n; i++)); do
+        run gh_pr_merge_train_close_impl_tab "wt/issue-${i}/1"
+        assert_success
+        assert_output --partial "closed implementation tab tab-${i}"
+        _forget_closed_tab "tab-${i}"
+        now="$(_live_count)"
+        counts+="${now} "
+        [ "$now" -le "$prev" ] \
+            || fail "live count grew from ${prev} to ${now} at merge ${i}"
+        prev="$now"
+    done
+
+    [ "$prev" -eq 0 ] || fail "after ${n} merges ${prev} tabs are still live (${counts})"
+}
+
+@test "close-impl-tab: a working tab keeps its slot — starvation is not traded for lost work" {
+    # The counter-case to the test above: the count staying flat must come from
+    # closing idle tabs, never from closing tabs that still have work in them.
+    FAKE_WORKTREE_LIST="worktree /home/dev/wt/issue-1
+HEAD aaaa
+branch refs/heads/wt/issue-1/1
+
+worktree /home/dev/wt/issue-2
+HEAD bbbb
+branch refs/heads/wt/issue-2/1
+"
+    FAKE_AGENT_JSON="$(_agents_json \
+        "/home/dev/wt/issue-1|tab-1|idle" \
+        "/home/dev/wt/issue-2|tab-2|working")"
+
+    run gh_pr_merge_train_close_impl_tab "wt/issue-1/1"
+    assert_success
+    _forget_closed_tab "tab-1"
+
+    run gh_pr_merge_train_close_impl_tab "wt/issue-2/1"
+    assert_success
+    [ -z "$output" ]
+
+    [ "$(_live_count)" -eq 1 ] || fail "the working session must still be counted live"
+    run cat "$FAKE_CLOSED_LOG"
+    assert_output "tab-1"
+}
+
+# --- 7. doc/fixture correspondence ----------------------------------------
+
+@test "close-impl-tab: reference doc and fixture have not drifted apart" {
+    local doc="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/references/train-loop.md"
+    local fixture="${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_train_close_impl_tab.sh"
+    local f pat
+    for pat in \
+        '/^worktree /{p=substr($0,10)} /^branch /{if (substr($0,8)==b) print p}' \
+        '.result.agents[]? | select(.cwd == $cwd)' \
+        '"\(.tab_id)\t\(.agent_status)"' \
+        '= "idle" ]' \
+        '[INFO] gh:pr-merge-train: closed implementation tab %s (%s).' \
+        '[WARN] gh:pr-merge-train: herdr tab close %s failed'; do
+        for f in "$doc" "$fixture"; do
+            run grep -F -- "$pat" "$f"
+            assert_success
+        done
+    done
+}
+
+@test "close-impl-tab: the train-loop close block is gated on idle, never unconditional" {
+    local doc="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/references/train-loop.md"
+    # `herdr tab close` may appear only inside the idle-gated branch: the one
+    # thing this step must never become is a blanket close.
+    run bash -c "grep -c 'herdr tab close \"' '$doc'"
+    assert_output "1"
+}
+
+@test "close-impl-tab: the merge-train SKILL.md points at the close step" {
+    local skill="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/SKILL.md"
+    run grep -qF -- "Closing the merged" "$skill"
+    assert_success
+    run grep -qF -- "_IW_MAX_PER_REPO" "$skill"
+    assert_success
+}
+
+@test "close-impl-tab: the close runs only after a successful merge" {
+    local doc="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/references/train-loop.md"
+    run grep -qF -- "only after" "$doc"
+    assert_success
+    run grep -qF -- "only on a successful merge" "$doc"
+    assert_success
+}

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -756,6 +756,89 @@ _PMV_EXTRACT_AWK='$0 == f "bash" && !b { b = 1; next } $0 == f && b { exit } b'
     [ -z "$output" ]
 }
 
+# --- the soft-fail exit-code contract (PR #1567 review) --------------------
+#
+# Every path through the dispatch is a soft-fail: gh:pr-merge sources it after
+# the merge already happened and after its own report is written, so a non-zero
+# status would abort a caller running under `set -e` over work that succeeded.
+# The tests above pin the *shape* of each terminator; these pin the status.
+
+@test "1565: no path in the extracted dispatch block exits non-zero" {
+    local _out
+    _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    # `return N` inside pmv_tab_for_cwd is a helper's answer to its caller, not
+    # a status the block ever leaves with — only `exit` ends the dispatch.
+    run bash -c "grep -nE 'exit[[:space:]]+[1-9]' '${_out}'"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "1565: the extracted block exits 0 on its unregistered-repo gate" {
+    local _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    local _root="${TEST_TEMP_HOME}/fakeroot"
+    mkdir -p "${_root}/docs/.ssot"
+    cp "$WATCHED" "${_root}/docs/.ssot/watched-repos.json"
+
+    run env DOTFILES_ROOT="$_root" TARGET_REPO="acme/not-watched" \
+        TARGET_HOST="github.com" PR_NUMBER="7" bash "$_out"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "1565: the extracted block exits 0 on the paths that stop with a WARN" {
+    local _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    local _root="${TEST_TEMP_HOME}/fakeroot"
+    mkdir -p "${_root}/docs/.ssot"
+
+    # A herdr stub keeps the run off this machine's real herdr; the block only
+    # needs `command -v herdr` to succeed before it reaches these stops.
+    local _bin="${TEST_TEMP_HOME}/stubbin"
+    mkdir -p "$_bin"
+    printf '#!/bin/sh\nexit 0\n' >"${_bin}/herdr"
+    chmod +x "${_bin}/herdr"
+
+    # 1. A verify_skill outside the allowlist: WARN, stop, status 0.
+    cat >"${_root}/docs/.ssot/watched-repos.json" <<'JSON'
+{ "acme/dotfiles": { "verify_skill": "evil:do-something-else" } }
+JSON
+    run env PATH="${_bin}:${PATH}" DOTFILES_ROOT="$_root" TARGET_REPO="acme/dotfiles" \
+        TARGET_HOST="github.com" PR_NUMBER="7" bash "$_out"
+    assert_success
+    assert_output --partial 'is not one of devx:pr-verify-merged'
+
+    # 2. The deliberate stale-main-checkout stop: WARN, stop, status 0. Nothing
+    #    has been closed or rebased at that point, and it must stay that way.
+    mkdir -p "${_root}/shell-common/functions"
+    cp "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/herdr_agent_name.sh" \
+        "${_root}/shell-common/functions/herdr_agent_name.sh"
+    cat >"${_root}/docs/.ssot/watched-repos.json" <<JSON
+{ "acme/dotfiles": { "verify_skill": "devx:pr-verify-merged",
+  "main_checkout": "${TEST_TEMP_HOME}/not-a-repo" } }
+JSON
+    run env PATH="${_bin}:${PATH}" DOTFILES_ROOT="$_root" TARGET_REPO="acme/dotfiles" \
+        TARGET_HOST="github.com" PR_NUMBER="7" bash "$_out"
+    assert_success
+    assert_output --partial 'is not a git worktree root'
+}
+
+@test "1565: gh:pr-merge Step 5 cannot leak the staged temp file" {
+    # mktemp'd, sourced, and removed — but the sourced block returns early on
+    # most paths and the caller may run under `set -e`, so the removal has to
+    # be armed as a trap before anything can go wrong.
+    local _skill
+    _skill="$(_pmv_merge_skill)"
+    run grep -qF -- "trap 'rm -f \"\$PMV_SH\"' EXIT INT TERM" "$_skill"
+    assert_success
+    run grep -qF -- 'trap - EXIT INT TERM' "$_skill"
+    assert_success
+}
+
 @test "1565: gh:pr-post-merge-verify survives as a standalone entry point" {
     # Removing the skill would take `/gh-pr-post-merge-verify <N>` — the manual
     # re-run — with it. Step 5 borrows its block; it does not absorb it.

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -671,3 +671,113 @@ pane_of() { printf '%s' "$1" | pmv_json_first pane_id; }
         "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md"
     assert_output "1"
 }
+
+# --- #1565: gh:pr-merge Step 5 runs the dispatch, it does not call a Skill --
+#
+# The dispatch used to be prose at the very tail of gh:pr-merge ("Otherwise
+# call `Skill(gh:pr-post-merge-verify, "<N> <remote>")`"), inside a skill
+# gh:pr-merge-train invokes in a loop. It executed 0/10 times in that loop and
+# 1/1 at top level, while every pasted shell block in the same skill's Step 4
+# ran 10/10. The form is the fix: a block that is there to run cannot be
+# forgotten the way an instruction to call something else can.
+
+_pmv_merge_skill() { printf '%s' "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge/SKILL.md"; }
+_pmv_dispatch_doc() { printf '%s' "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md"; }
+
+# The exact awk program gh:pr-merge Step 5 uses to take the FIRST bash fence
+# out of dispatch.sh.md. Pinned here and then actually run below, so an edit to
+# either side turns this suite red instead of silently extracting nothing.
+_PMV_EXTRACT_AWK='$0 == f "bash" && !b { b = 1; next } $0 == f && b { exit } b'
+
+@test "1565: gh:pr-merge Step 5 no longer delegates through Skill()" {
+    # Comment lines are skipped — the rationale for NOT calling it is allowed
+    # to name it (same carve-out as R-6 above).
+    run bash -c "grep -vE '^[[:space:]]*#' '$(_pmv_merge_skill)' | grep -n 'Skill(gh:pr-post-merge-verify'"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "1565: gh:pr-merge Step 5 reads the dispatch SSOT instead of copying it" {
+    run grep -qF -- 'claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md' \
+        "$(_pmv_merge_skill)"
+    assert_success
+    # Sourced, not described.
+    run grep -qF -- '. "$PMV_SH"' "$(_pmv_merge_skill)"
+    assert_success
+}
+
+@test "1565: gh:pr-merge Step 5 carries the extraction program verbatim" {
+    run grep -qF -- "$_PMV_EXTRACT_AWK" "$(_pmv_merge_skill)"
+    assert_success
+}
+
+@test "1565: gh:pr-merge Step 5 binds the inputs the dispatch reads" {
+    local _v
+    for _v in PR_NUMBER HEAD_BRANCH BASE_BRANCH REMOTE; do
+        run grep -qE "^${_v}=" "$(_pmv_merge_skill)"
+        assert_success
+    done
+}
+
+@test "1565: the extraction yields the dispatch block, not a doc snippet" {
+    local _out
+    _out="${TEST_TEMP_HOME}/extracted.sh"
+    run bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    assert_success
+    run head -n 2 "$_out"
+    assert_output --partial 'WATCHED_FILE='
+    run tail -n 1 "$_out"
+    assert_output --partial 'attach: herdr agent attach'
+    # The file's later fences are documentation — the standalone head/base ref
+    # recovery must not be swept into the executed block.
+    run grep -c 'gh pr view' "$_out"
+    assert_output "0"
+}
+
+@test "1565: the extracted dispatch block is syntactically valid shell" {
+    local _out
+    _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    run bash -n "$_out"
+    assert_success
+}
+
+@test "1565: the extracted block returns rather than exiting when sourced" {
+    # Every early exit is `return 0 2>/dev/null || exit 0` so that sourcing it
+    # from Step 5 cannot kill the caller's shell mid-report.
+    local _out
+    _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    run bash -c "grep -n 'exit 0' '${_out}' | grep -v 'return 0 2>/dev/null || exit 0'"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "1565: gh:pr-post-merge-verify survives as a standalone entry point" {
+    # Removing the skill would take `/gh-pr-post-merge-verify <N>` — the manual
+    # re-run — with it. Step 5 borrows its block; it does not absorb it.
+    local _skill="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-post-merge-verify/SKILL.md"
+    [ -r "$_skill" ]
+    run grep -qF -- 'name: gh:pr-post-merge-verify' "$_skill"
+    assert_success
+    run grep -qF -- 'references/dispatch.sh.md' "$_skill"
+    assert_success
+    [ -r "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-post-merge-verify/references/help.md" ]
+}
+
+@test "1565: top-level gh:pr-merge behavior is otherwise untouched" {
+    # The merge itself, the report, and the unwatched-repo silence are what a
+    # top-level `/gh-pr-merge <N>` run is judged on — Step 5 gained a block,
+    # it did not gain a gate.
+    local _skill
+    _skill="$(_pmv_merge_skill)"
+    run grep -qF -- 'gh pr merge <N> --repo "$TARGET_REPO" --<strategy> --delete-branch' "$_skill"
+    assert_success
+    run grep -qF -- 'Print **only** the compact report' "$_skill"
+    assert_success
+    run grep -qF -- 'no output, no' "$_skill"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- `gh:pr-merge` Step 5 의 post-merge-verify 디스패치가 중첩 호출(`gh:pr-merge-train` -> `Skill(gh:pr-merge)`)에서 유실돼 무인 train 10건 중 **0건** 실행되던 문제를 고친다 (#1565).
- impl 탭이 안 닫혀 `_iw_live_agents` 가 슬롯을 채우고 issue-watcher 가 3건 후 멈추던 굶주림도 함께 막는다.

## Changes
- **Step 5 를 붙여넣는 셸 블록으로 전환.** `Skill()` 호출은 기억해야 하는 지시이고, 같은 스킬에서 셸 블록으로 표현된 Step 4 하위 항목들은 train 안에서 10/10 실행됐다. 표현 형식이 실행률을 갈랐다.
- 블록은 `gh-pr-post-merge-verify/references/dispatch.sh.md` 의 **첫 bash fence 만** 추출해 source 한다 — SSOT 중복 없음, bats fixture 미러 유지.
- **belt-and-braces**: `gh:pr-merge-train` 이 머지 성공 직후 impl 탭을 닫는다. `agent_status = idle` 일 때만 — `working` 탭은 절대 닫지 않는다.
- `gh:pr-post-merge-verify` 는 단독 스킬로 유지 (수동 재실행 경로).

## Test plan
- [x] `gh_pr_post_merge_verify.bats` 72/72 (신규 9건)
- [x] `gh_pr_merge_train_close_impl_tab.bats` 24/24 (신규)
- [x] `gh_pr_merge_herdr_notify.bats` 19/19
- [x] `pr_merge_train_cron.bats` 52/52
- [x] 추출 블록 `bash -n` 통과 (235줄), stray `gh pr view` 0건
- [x] 굶주림 회귀 테스트: 5회 머지 동안 live 카운트가 증가하지 않고 0 으로 끝남 (수정 전에는 5 로 고정)
- [x] `mise run lint-sh` / `lint-docs` 통과

## Note
`gh-pr-merge/SKILL.md` 가 121 -> 153 줄이 됐다. 이슈의 수정안이 인라인을 전제했고 간접 참조가 한 단계 적어 그대로 뒀다 — `references/` 로 옮기는 편이 낫다면 후속으로 처리 가능.

## Related
Closes #1565
Refs #1531