### PR TITLE
fix(pr-merge-train): agent prompt 의 --wait 타임아웃을 디스패치 실패로 오판하지 않는다

### DIFF
--- a/docs/public/changelog.d/2026-08-28-1551.md
+++ b/docs/public/changelog.d/2026-08-28-1551.md
@@ -1,0 +1,1 @@
+- 변경: **`pr_merge_train_cron.sh` 의 `_pmt_prompt_train` 이 `herdr agent prompt --wait` 의 `timeout`/`agent_prompt_stalled` 를 디스패치 성공으로 계수하고, stderr 를 파일로 캡처해 실패 사유를 `(unknown)` 대신 실제 에러 코드로 기록한다 — 프롬프트가 실제로는 전달됐는데도 `Tick complete` 로그가 남지 않던 결함을 고친다**

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -661,23 +661,58 @@ _pmt_settle() {
 
 # Hand the whole train over to the session. This is the one place where the
 # dispatcher's job ends and the skill's begins (D-8).
+#
+# stderr goes to a file rather than /dev/null (#1551, same defect class as
+# #1512/#1458): herdr answers `agent prompt`'s error document on stderr too,
+# and discarding it is what turned a real timeout into an unexplained
+# "(unknown)" reason with no `Tick complete` ever logged. A file rather than
+# `2>&1` for the same reason `_pmt_agent_start` uses one (line ~543) — stdout
+# stays on its own pipe because `.error.code` is read off it first.
 _pmt_prompt_train() {
-    local _agent="$1" _prompt _json _code _rc=0
+    local _agent="$1" _prompt _json _code _rc=0 _errf _cause
 
     _prompt="/gh-pr-merge-train ${_PMT_REPO}"
 
+    _errf=$(mktemp) || {
+        ux_error "cannot open a capture file for herdr's stderr — ending this tick."
+        return 1
+    }
+    trap 'rm -f "${_errf}"' EXIT INT TERM
     _json=$(herdr agent prompt "${_agent}" "${_prompt}" \
-        --wait --timeout "${_PMT_TIMEOUT_MS}" 2>/dev/null) || _rc=$?
+        --wait --timeout "${_PMT_TIMEOUT_MS}" 2>"${_errf}") || _rc=$?
     if [ "${_rc}" -eq 0 ]; then
+        trap - EXIT INT TERM
+        rm -f "${_errf}"
         ux_success "Dispatched to ${_agent}: ${_prompt}"
         return 0
     fi
 
+    _code=$(_pmt_herdr_error_code "${_json}" "${_errf}")
+
     # No retry, and deliberately none: a prompt that *did* land but looked
     # stalled would earn a second train on the same repo, which is precisely
-    # what NF-1 forbids. The next tick re-evaluates from scratch.
-    _code=$(printf '%s' "${_json}" | _pmt_json_value '.error.code')
-    ux_error "herdr agent prompt failed for agent ${_agent} (${_code:-unknown})."
+    # what NF-1 forbids. The next tick re-evaluates from scratch. `timeout`
+    # and `agent_prompt_stalled` are exactly that case — the submission
+    # succeeded and only the --wait observation window expired — so they
+    # count as dispatched rather than failed, or #1531's `Tick complete`
+    # acceptance criterion never fires on a train that is actually running.
+    case "${_code}" in
+    timeout | agent_prompt_stalled)
+        trap - EXIT INT TERM
+        rm -f "${_errf}"
+        ux_warning "Prompt submitted to ${_agent} but its state was not observed within the wait window (${_code}) — treating as dispatched."
+        ux_success "Dispatched to ${_agent}: ${_prompt}"
+        return 0
+        ;;
+    esac
+
+    _cause=$(_pmt_herdr_error_message "${_errf}")
+    trap - EXIT INT TERM
+    rm -f "${_errf}"
+    _msg="herdr agent prompt failed for agent ${_agent} (${_code:-unknown})."
+    [ -z "${_cause}" ] || _msg="${_msg}
+    원인: ${_cause}"
+    ux_error "${_msg}"
     return 1
 }
 

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -669,10 +669,13 @@ _pmt_settle() {
 # `2>&1` for the same reason `_pmt_agent_start` uses one (line ~543) — stdout
 # stays on its own pipe because `.error.code` is read off it first.
 _pmt_prompt_train() {
-    local _agent="$1" _prompt _json _code _rc=0 _errf _cause
+    local _agent="$1" _prompt _json _rc=0 _errf _code="" _cause="" _msg
 
     _prompt="/gh-pr-merge-train ${_PMT_REPO}"
 
+    # A `local` capture file is enough here where _pmt_launch_fresh needs the
+    # _PMT_ERRF global (line ~149): the trap is disarmed at the single exit
+    # below, so it can never fire once _errf has gone out of scope.
     _errf=$(mktemp) || {
         ux_error "cannot open a capture file for herdr's stderr — ending this tick."
         return 1
@@ -680,14 +683,22 @@ _pmt_prompt_train() {
     trap 'rm -f "${_errf}"' EXIT INT TERM
     _json=$(herdr agent prompt "${_agent}" "${_prompt}" \
         --wait --timeout "${_PMT_TIMEOUT_MS}" 2>"${_errf}") || _rc=$?
+
+    # Read both halves of herdr's answer *before* the file goes away, so the
+    # branches below only decide what to print. One disarm and one `rm`, on the
+    # single path every outcome passes through: a classification added later
+    # cannot forget to clean up, which three copies of this pair invited.
+    if [ "${_rc}" -ne 0 ]; then
+        _code=$(_pmt_herdr_error_code "${_json}" "${_errf}")
+        _cause=$(_pmt_herdr_error_message "${_errf}")
+    fi
+    trap - EXIT INT TERM
+    rm -f "${_errf}"
+
     if [ "${_rc}" -eq 0 ]; then
-        trap - EXIT INT TERM
-        rm -f "${_errf}"
         ux_success "Dispatched to ${_agent}: ${_prompt}"
         return 0
     fi
-
-    _code=$(_pmt_herdr_error_code "${_json}" "${_errf}")
 
     # No retry, and deliberately none: a prompt that *did* land but looked
     # stalled would earn a second train on the same repo, which is precisely
@@ -698,17 +709,12 @@ _pmt_prompt_train() {
     # acceptance criterion never fires on a train that is actually running.
     case "${_code}" in
     timeout | agent_prompt_stalled)
-        trap - EXIT INT TERM
-        rm -f "${_errf}"
         ux_warning "Prompt submitted to ${_agent} but its state was not observed within the wait window (${_code}) — treating as dispatched."
         ux_success "Dispatched to ${_agent}: ${_prompt}"
         return 0
         ;;
     esac
 
-    _cause=$(_pmt_herdr_error_message "${_errf}")
-    trap - EXIT INT TERM
-    rm -f "${_errf}"
     _msg="herdr agent prompt failed for agent ${_agent} (${_code:-unknown})."
     [ -z "${_cause}" ] || _msg="${_msg}
     원인: ${_cause}"

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -809,6 +809,16 @@ _hold_lock() {
     assert_output --partial "(agent_not_found)"
 }
 
+# PR #1572 review (codex): the test above pins the *code* but not herdr's own
+# sentence about the failure — a regression that dropped the `원인:` message
+# while keeping the code intact would slip through unnoticed. This pins both.
+@test "pr_merge_train_cron: a non-timeout prompt error preserves herdr's own message" {
+    _run_tick HERDR_PROMPT_CODE=agent_not_found HERDR_PROMPT_MESSAGE="agent target not found for real"
+    assert_failure
+    assert_output --partial "원인:"
+    assert_output --partial "agent target not found for real"
+}
+
 # herdr refuses `agent start` unless the name matches
 # `^[a-z][a-z0-9_-]{0,31}$`. The pre-#1530 name (`pmt-github.com-acme-dotfiles`)
 # carried both a dot and, on a real owner like `dEitY719`, uppercase — so every

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -157,7 +157,12 @@ EOF
 #                         lives in a `mktemp -d` made fresh by `setup()`.
 #   HERDR_TAB_CLOSE_FAIL=1  `tab close` errors — the cleanup of an orphaned tab
 #                         is best effort and must not become a second failure
-#   HERDR_PROMPT_FAIL=1   `agent prompt` errors
+#   HERDR_PROMPT_FAIL=1   `agent prompt` errors with `agent_not_found` on
+#                         stdout — a real failure, not a #1551 timeout
+#   HERDR_PROMPT_CODE=X   `agent prompt` errors with code X on **stderr** —
+#                         where herdr really answers a prompt failure
+#                         (#1551), same as `agent start`'s agent_pane_busy
+#                         below
 #
 # The `agent_pane_busy` document goes to **stderr**, which is not decoration:
 # that is where herdr really put it, and a dispatcher that redirects the stream
@@ -214,6 +219,11 @@ case "$1 $2" in
     printf '%s\n' '{"id":"cli:tab:close","result":{"ok":true}}'
     ;;
 "agent prompt")
+    if [ -n "${HERDR_PROMPT_CODE:-}" ]; then
+        printf '{"error":{"code":"%s","message":"%s"},"id":"cli:agent:prompt"}\n' \
+            "${HERDR_PROMPT_CODE}" "${HERDR_PROMPT_MESSAGE:-stub prompt error}" >&2
+        exit 1
+    fi
     if [ "${HERDR_PROMPT_FAIL:-0}" = "1" ]; then
         printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target not found"},"id":"cli:agent:prompt"}'
         exit 1
@@ -754,6 +764,49 @@ _hold_lock() {
     _run_tick HERDR_PROMPT_FAIL=1
     assert_failure
     assert_output --partial "prompt failed"
+}
+
+# #1551: `--wait` only bounds the *observation* of a state change after
+# submission — a `timeout` here means the prompt landed and only the wait
+# window expired, not that dispatch failed. Counting it as a failure is what
+# kept #1531's `Tick complete` acceptance criterion from ever firing on a
+# train that was actually running.
+@test "pr_merge_train_cron: a prompt timeout is treated as dispatched, not failed" {
+    _run_tick HERDR_PROMPT_CODE=timeout
+    assert_success
+    assert_output --partial "treating as dispatched"
+    assert_output --partial "Dispatched to"
+    refute_output --partial "prompt failed"
+}
+
+@test "pr_merge_train_cron: a stalled prompt is also treated as dispatched" {
+    _run_tick HERDR_PROMPT_CODE=agent_prompt_stalled
+    assert_success
+    assert_output --partial "treating as dispatched"
+}
+
+# The same defect this fixes also swallowed the error *cause* (#1551's other
+# half): `2>/dev/null` threw away herdr's error document, so every failure —
+# timeout included — logged as "(unknown)". This pins that the code now
+# reads from stderr, where herdr actually answers.
+@test "pr_merge_train_cron: a prompt timeout names the code, not 'unknown'" {
+    _run_tick HERDR_PROMPT_CODE=timeout
+    assert_success
+    assert_output --partial "(timeout)"
+    refute_output --partial "(unknown)"
+}
+
+@test "pr_merge_train_cron: a prompt timeout is not retried" {
+    _run_tick HERDR_PROMPT_CODE=timeout
+    assert_success
+    [ "$(_log_count 'herdr agent prompt')" -eq 1 ]
+}
+
+@test "pr_merge_train_cron: a non-timeout prompt error on stderr still fails the tick" {
+    _run_tick HERDR_PROMPT_CODE=agent_not_found
+    assert_failure
+    assert_output --partial "prompt failed"
+    assert_output --partial "(agent_not_found)"
 }
 
 # herdr refuses `agent start` unless the name matches


### PR DESCRIPTION
## Summary
- `_pmt_prompt_train` 이 `herdr agent prompt --wait` 의 `timeout`/`agent_prompt_stalled` 를 디스패치 실패로 오판하던 결함을 고친다 — 프롬프트는 실제로 전달됐는데도 `Tick complete` 가 로그에 남지 않던 문제(#1531 의 무인 완주 지표를 막던 블로커).
- 원인을 버리던 `2>/dev/null` 을 `herdr agent start` 경로(#1512)와 같은 stderr-to-file 패턴으로 바꿔, 실패 사유가 항상 `(unknown)` 으로만 찍히던 것도 함께 고친다.

## Changes
- `shell-common/tools/custom/pr_merge_train_cron.sh`: `_pmt_prompt_train` 이 stderr 를 임시 파일로 캡처하고 기존 `_pmt_herdr_error_code`/`_pmt_herdr_error_message` 로 읽는다. `timeout`/`agent_prompt_stalled` 코드는 디스패치 성공으로 재분류하고(재시도는 추가하지 않음, NF-1), 그 외 코드는 기존대로 실패 처리한다.
- `tests/bats/tools/pr_merge_train_cron.bats`: `herdr` 스텁에 `HERDR_PROMPT_CODE` 를 추가해 stderr 로 임의 에러 코드를 낼 수 있게 하고, timeout/stalled 성공 재분류·`(unknown)` 대신 실제 코드 기록·재시도 없음·비-timeout 코드는 여전히 실패 5개 케이스를 추가한다.
- `docs/public/changelog.d/2026-08-28-1551.md`: 변경 기록 fragment 추가.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/bats/lib/bats-core/bin/bats tests/bats/tools/pr_merge_train_cron.bats` — 73 passed, 0 failed (기존 68 + 신규 5).
- [x] `shellcheck -s bash shell-common/tools/custom/pr_merge_train_cron.sh` — clean.
- [x] `shfmt -i 4 -d shell-common/tools/custom/pr_merge_train_cron.sh` — no diff.

## Related
Closes #1551

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~3 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~3 min
<!-- /ai-metrics:gh-pr -->

</details>
