### PR TITLE
fix(devx-pr-review-all): 판정 파서 zsh/stale/템플릿 버그 3건 수정

### DIFF
--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -1,0 +1,234 @@
+# devx:pr-review-all — Review verdict → merge-gate label
+
+SSOT for how a reviewer lane's closing verdict line becomes a machine-readable
+PR label. Implementation: `shell-common/functions/devx_pr_review_all.sh`;
+regression suite: `tests/bats/functions/devx_pr_review_all_verdict.bats`.
+
+Why it exists: every `gh:pr-review` preset mandates a closing verdict line, and
+until #1527 nothing in the repo read it. PR #1518 collected two independent
+blocking verdicts and merged 32 minutes later, because the merge train's only
+real gate was CI.
+
+**Wiring status.** This document specifies the parser and the call convention
+only. The train-side hard gate is tracked in #1564 and the label-lifecycle
+invalidation rules in #1563; neither is implemented yet, so nothing consumes
+these labels today. Treat the call sites below as the contract those issues
+must build against, not as code already running.
+
+## The labels
+
+| label | meaning |
+|---|---|
+| `review-blocked` | at least one reviewer lane returned a blocking verdict |
+| `review-passed` | every lane that ran returned a non-blocking verdict, and at least one lane ran |
+
+Neither belongs to the 10-label SSOT (`gh-label-bootstrap/references/gh-labels.md`).
+Like `CI fail` and `conflict` they are **pipeline-state** labels, not
+issue-classification ones, and that document explicitly scopes such labels out.
+Provisioning them is part of #1564.
+
+**Absence is the third state, and it means "not verified".** A PR carrying
+neither label has not been shown to pass review. That is what makes a time
+backstop unnecessary here: a stuck PR is one label away from moving, and a
+human can add or remove it at any time.
+
+## The three helpers
+
+```
+devx_pr_review_all_lane_block <ai> [<head-sha>]   # comment bodies on stdin
+  -> that lane's raw block, or nothing
+devx_pr_review_all_verdict                        # one lane's raw text on stdin
+  -> blocking | concerns | lgtm | unknown
+devx_pr_review_all_aggregate                      # verdict tokens on stdin,
+                                                  #   one per line, one per lane
+  -> label=review-blocked | label=review-passed | label=    (+ lanes=N)
+```
+
+All three are pure: stdin in, stdout out, no network, no shell state.
+
+## Reading a lane's verdict
+
+Each reviewer lane (`agy`, `codex`, `opencode`, `hermes`) ends its output with
+a mandatory verdict line — `판정: [LGTM|우려있음|블로킹]` or
+`Verdict: [LGTM|CONCERNS|BLOCKING]` (`gh-pr-review/references/review-presets.md`,
+rendered at runtime by `_gh_pr_review_common_prefix` in `gh_pr_review.sh`).
+
+**Do not try to read that line out of the lane's return value.** `gh:pr-review`
+guarantees exactly one line back — `[OK] PR #<N> reviewed by <ai> … — comment:
+<URL>` — and each lane runs as a subagent, which returns a *summary* of what it
+did. Neither carries the verdict. A gate built on that would have every lane
+parse as `unknown`, never write a label, and skip every PR forever.
+
+Read it from the artifact the lane already wrote instead. `gh:pr-review` Step 6
+posts the reviewer's raw output to the PR wrapped in `<!-- ai-review:<ai> -->`
+markers, synchronously, before it returns — a durable machine-readable record
+rather than a summary. Fetch the comments **once**, then per lane:
+
+```sh
+. "${SHELL_COMMON}/functions/devx_pr_review_all.sh"
+
+BODIES=$(GH_HOST="$TARGET_HOST" gh api --paginate \
+    "repos/$TARGET_REPO/issues/$pr/comments" --jq '.[].body')
+
+verdict=$(printf '%s\n' "$BODIES" |
+    devx_pr_review_all_lane_block "$ai" |
+    devx_pr_review_all_verdict)
+# -> blocking | concerns | lgtm | unknown
+```
+
+`devx_pr_review_all_lane_block` takes the **last complete** block for that lane,
+so a re-review supersedes an earlier verdict, and it ignores an unterminated
+block — half a review is not a verdict.
+
+### Freshness: the optional head-sha
+
+Without a second argument the helper cannot tell a block this run just posted
+from one left by an earlier round. A run that posted nothing —
+`GH_DISABLE_AI_METRICS=1`, `--no-post-comment`, or a post that failed — would
+then silently reuse a stale verdict, and a stale verdict can authorize a merge
+of code it never saw.
+
+Pass the PR's head sha to close that hole:
+
+```sh
+head_sha=$(GH_HOST="$TARGET_HOST" gh pr view "$pr" --repo "$TARGET_REPO" \
+    --json headRefOid --jq .headRefOid)
+
+verdict=$(printf '%s\n' "$BODIES" |
+    devx_pr_review_all_lane_block "$ai" "$head_sha" |
+    devx_pr_review_all_verdict)
+```
+
+With a sha given, only `<!-- ai-review:<ai>:<head-sha> -->` … `<!-- /ai-review:<ai>:<head-sha> -->`
+blocks match, both markers must carry the same sha, and a lane with no block for
+that exact ai+sha pair yields nothing — which reads downstream as `unknown`,
+so no label, so no merge. Fail-closed.
+
+> **Producer caveat.** `gh:pr-review`'s marker writer
+> (`shell-common/functions/gh_pr_review.sh`) currently emits the plain
+> `<!-- ai-review:<ai> -->` form with no sha suffix. Passing a head sha against
+> today's comments therefore yields `unknown` for every lane. Emitting the
+> sha-tagged marker is part of the merge-gate wiring (#1564); until it lands,
+> callers should omit the second argument, which is exactly the behavior above
+> without the freshness check. The sha-aware path is fully specified and
+> tested here so the producer change is a one-sided edit when it happens.
+
+### What the verdict parser accepts
+
+- Case-insensitive, both `판정:` and `Verdict:`, fullwidth `：` normalized.
+- Surrounding markdown emphasis and a leading list dash are stripped.
+- Only lines that *start* with the verdict key count; a finding line such as
+  `[BLOCKER] a.sh:1 — …` is never mistaken for the verdict.
+- The last verdict line in the input wins — the presets put it last.
+- The **unanswered template** is rejected: a value that opens with `[` *and*
+  carries a `|` inside the brackets (`[LGTM|CONCERNS|BLOCKING]`) is a lane
+  echoing its own instructions back, and yields `unknown`.
+- A genuine answer that merely contains a pipe or a bracket elsewhere still
+  parses: `Verdict: BLOCKING | 5 findings` → `blocking`, `Verdict: [BLOCKING]`
+  → `blocking`, `판정: 블로킹 [BLOCKER 4건]` → `blocking`. Rejecting any line
+  containing `|` was #1527's bug; it left real blocking verdicts unlabelled.
+- Anything else — no verdict line, an unrecognized value — is `unknown`.
+
+## Aggregating the lanes
+
+`devx_pr_review_all_aggregate` reads **newline-delimited verdict tokens from
+stdin**, one line per lane that ran. It does *not* take positional arguments,
+and that is load-bearing rather than stylistic: the obvious call site
+`devx_pr_review_all_aggregate $VERDICTS` depends on the shell word-splitting an
+unquoted expansion, which zsh does not do without `SH_WORD_SPLIT`. In zsh the
+whole string arrived as one argument, so a two-lane PR reported `lanes=1` and
+dropped the blocking verdict outright — and zsh is this repo's default
+interactive shell. A newline-delimited stream behaves identically in bash, zsh
+and dash.
+
+Build the stream with `printf` inside the lane loop and pipe it straight in.
+Never stage the verdicts in a variable and re-expand it:
+
+```sh
+AGG=$(
+    for ai in agy codex opencode hermes; do
+        lane_ran "$ai" || continue          # a skipped lane contributes NOTHING
+        v=$(printf '%s\n' "$BODIES" |
+            devx_pr_review_all_lane_block "$ai" |
+            devx_pr_review_all_verdict)
+        printf '%s\n' "$v"
+    done | devx_pr_review_all_aggregate
+)
+label=$(printf '%s\n' "$AGG" | sed -n 's/^label=//p')
+lanes=$(printf '%s\n' "$AGG" | sed -n 's/^lanes=//p')
+```
+
+Read the two `key=value` lines with `sed`, not `eval` — the values are
+controlled, but a parser that cannot execute anything is the right default for
+something that gates a merge.
+
+| lanes that ran | outcome | `label` |
+|---|---|---|
+| any lane `blocking` | blocked | `review-blocked` |
+| ≥1 lane, all `lgtm`/`concerns` | passed | `review-passed` |
+| ≥1 lane, any `unknown` | verdict not established | *(empty)* |
+| zero | nothing was checked | *(empty)* |
+
+`우려있음`/`CONCERNS` is a **pass** — a non-blocking opinion, which `gh:pr-reply`
+still answers. `unknown` is not, because a lane whose output stopped parsing is
+indistinguishable from a lane that never reached a verdict.
+
+**A lane that did not run contributes no line at all.** `command -v` empty, a
+non-internal PC, a non-zero exit — every `[SKIP]`/`[WARN]` row of the report —
+is absent from the stream, not an `unknown`. "Not checked" and "checked and
+passed" must never collapse into the same state. The `/simplify` lane never
+contributes; it produces no verdict. Blank lines are ignored, so a stray one
+cannot inflate `lanes=` into a false "verified".
+
+## Applying the label
+
+Add through `_gh_pr_edit_safe_label` (`shell-common/functions/gh_pr_edit_safe.sh`),
+never bare `gh pr edit --add-label` — that silently exits 1 on repos with
+classic Projects attached (#326). Remove the opposite label through the REST
+endpoint, for the same reason. The whole block is **soft-fail**: a labelling
+failure leaves the PR unlabelled, which reads as "not verified".
+
+```sh
+. "${SHELL_COMMON}/functions/gh_pr_edit_safe.sh"
+
+if [ -z "$label" ]; then
+    echo "[WARN] no reviewer lane produced a verdict — PR #$pr left unlabelled"
+else
+    case "$label" in
+    review-blocked) opposite=review-passed ;;
+    *) opposite=review-blocked ;;
+    esac
+
+    GH_HOST="$TARGET_HOST" gh api -X DELETE \
+        "repos/$TARGET_REPO/issues/$pr/labels/$opposite" >/dev/null 2>&1 || :
+
+    _gh_pr_edit_safe_label "$pr" "$label" --repo "$TARGET_REPO"
+    case "$?" in
+    0) echo "[OK] PR #$pr labelled \`$label\` (${lanes} lane(s))" ;;
+    3) echo "[WARN] label \`$label\` missing in $TARGET_REPO — provision it first" ;;
+    *) echo "[WARN] labelling PR #$pr failed — treat the PR as unverified" ;;
+    esac
+fi
+```
+
+**The opposite label is removed first, and unconditionally.** A re-review that
+flips `review-blocked` to `review-passed` has to clear the old one, or a
+consumer sees both.
+
+`_gh_pr_edit_safe_label` returns 3 when the label does not exist in the repo and
+**refuses to auto-create it** (`feedback_gh_label_no_autocreate.md`, #326).
+Provisioning the two pipeline labels is therefore an explicit, human-invoked
+step, tracked with the rest of the wiring in #1564.
+
+## Why this lives in the producer
+
+The alternative — having the merge train grep review comment bodies — couples
+the merge gate to every reviewer CLI's output format. A reviewer reformatting
+its verdict line would then silently *unlock* the gate. Parsing here means the
+same reformat produces `unknown`, no label, and a skipped PR: the failure
+direction is the safe one.
+
+The decisive reason, though, is that **only the producer knows which lanes
+ran**. A consumer reading comment bodies cannot tell "lane skipped" from "lane
+ran and posted nothing" — and that distinction *is* the absence-is-not-a-pass
+invariant. It is not recoverable downstream at any level of parsing care.

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -136,22 +136,12 @@ devx_pr_review_all_parse() {
 
 # ── Review verdict -> merge-gate label (issue #1527, fixed in #1562) ──
 #
-# Every gh:pr-review preset mandates a closing verdict line — `판정:
-# [LGTM|우려있음|블로킹]` on a Korean-dominant diff, `Verdict:
-# [LGTM|CONCERNS|BLOCKING]` otherwise. Until #1527 nothing in the repo read
-# it: PR #1518 collected two independent blocking verdicts and merged 32
-# minutes later, because the train's only real gate was CI.
-#
-# That prompt is rendered at runtime by `_gh_pr_review_common_prefix`
-# (gh_pr_review.sh), copied verbatim from
-# claude/skills/gh-pr-review/references/review-presets.md — reword the tokens
-# in either place and the case arms below have to move with them.
-#
-# These three helpers turn that prose into a label the train can gate on.
-# Parsing lives here, in the *producer*, on purpose: if the train parsed
-# comment bodies instead, a reviewer changing its output format would
-# silently unlock the merge gate. Here a format change makes the lane
-# `unknown`, which is fail-closed — no label, no merge.
+# Turns a reviewer lane's mandatory closing verdict line (`판정: ...` /
+# `Verdict: ...`, rendered at runtime by `_gh_pr_review_common_prefix` in
+# gh_pr_review.sh) into a label the merge train can gate on. Full rationale —
+# the PR #1518 incident, the zsh word-splitting bug, the call-site contract —
+# lives in claude/skills/devx-pr-review-all/references/review-verdict-label.md,
+# which is the SSOT; this is the implementation.
 #
 #   devx_pr_review_all_lane_block <ai> [<head-sha>]  # comment bodies on stdin
 #     -> that lane's raw block, or nothing
@@ -160,12 +150,8 @@ devx_pr_review_all_parse() {
 #   devx_pr_review_all_aggregate                     # verdict tokens on stdin,
 #     -> label=review-blocked | label=review-passed | label=   (+ lanes=N)
 #
-# The aggregate reads stdin, NOT positional args, and that is load-bearing:
-# the natural call site `devx_pr_review_all_aggregate $VERDICTS` relies on the
-# shell word-splitting an unquoted expansion, which zsh does not do without
-# SH_WORD_SPLIT. In zsh every lane's verdict arrived as one argument, so a
-# two-lane PR reported `lanes=1` and lost the blocking verdict outright. A
-# newline-delimited stream behaves identically in bash, zsh and dash.
+# devx_pr_review_all_aggregate reads stdin, NOT positional args — load-bearing,
+# not stylistic; see the doc for the zsh bug that forces it.
 #
 # Skipped lanes contribute NO line — "not checked" and "checked and passed"
 # must never collapse into the same state (#1527 확정 사항).
@@ -253,31 +239,17 @@ devx_pr_review_all_aggregate() {
 }
 
 # Harvest one reviewer lane's raw output from the PR comment bodies on stdin.
+# Reads it back from the `<!-- ai-review:<ai> -->` … `<!-- /ai-review:<ai> -->`
+# markers `gh:pr-review` Step 6 posts (gh_pr_review.sh) — not from a lane's
+# subagent return value, which never carries the verdict. Full rationale:
+# claude/skills/devx-pr-review-all/references/review-verdict-label.md.
 #
-# Step 3 dispatches each lane as a subagent, and `gh:pr-review` guarantees only
-# a one-line `[OK] PR #N reviewed by <ai> — comment: <URL>` as its return
-# value — the verdict is nowhere in it. Reading the verdict out of a subagent's
-# prose would make the merge gate depend on how an agent chose to summarise
-# itself; every lane would land on `unknown`, no label would ever be written,
-# and the train would skip every PR forever.
-#
-# So the verdict is read back from the artifact the lane already wrote:
-# `gh:pr-review` Step 6 posts the reviewer's raw output wrapped in
-# `<!-- ai-review:<ai> -->` markers, synchronously, before it returns. That is
-# a durable machine-readable record, not a summary.
-#
-# The LAST complete block wins: a re-review posts a second comment and its
-# verdict supersedes. An unterminated block (a truncated or still-being-written
-# comment) is never harvested — half a review is not a verdict.
-#
-# The optional <head-sha> is the freshness gate. Without it a block from an
-# earlier round is indistinguishable from one this run just posted, so a run
-# that posted nothing (GH_DISABLE_AI_METRICS=1, --no-post-comment, a failed
-# post) silently reuses a stale verdict — and a stale verdict can authorize a
-# merge of code it never saw. Given a sha, only `<!-- ai-review:<ai>:<sha> -->`
-# blocks match, and a lane with no block for that exact sha yields nothing,
-# which reads downstream as `unknown`. Without it, sha-tagged and plain blocks
-# both match and no freshness claim is made.
+# Contract: the LAST complete block wins (a re-review supersedes); an
+# unterminated block is never harvested. The optional <head-sha> is a
+# freshness gate — given a sha, only `<!-- ai-review:<ai>:<sha> -->` blocks
+# match, and a miss yields nothing (-> `unknown` downstream, fail-closed).
+# Without it, sha-tagged and plain blocks both match and no freshness claim
+# is made.
 devx_pr_review_all_lane_block() {
     [ -n "${1-}" ] || return 0
     awk -v ai="$1" -v sha="${2-}" '

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -133,3 +133,179 @@ devx_pr_review_all_parse() {
     printf '%s\n' "reply_delay=$reply_delay"
     return 0
 }
+
+# ── Review verdict -> merge-gate label (issue #1527, fixed in #1562) ──
+#
+# Every gh:pr-review preset mandates a closing verdict line — `판정:
+# [LGTM|우려있음|블로킹]` on a Korean-dominant diff, `Verdict:
+# [LGTM|CONCERNS|BLOCKING]` otherwise. Until #1527 nothing in the repo read
+# it: PR #1518 collected two independent blocking verdicts and merged 32
+# minutes later, because the train's only real gate was CI.
+#
+# That prompt is rendered at runtime by `_gh_pr_review_common_prefix`
+# (gh_pr_review.sh), copied verbatim from
+# claude/skills/gh-pr-review/references/review-presets.md — reword the tokens
+# in either place and the case arms below have to move with them.
+#
+# These three helpers turn that prose into a label the train can gate on.
+# Parsing lives here, in the *producer*, on purpose: if the train parsed
+# comment bodies instead, a reviewer changing its output format would
+# silently unlock the merge gate. Here a format change makes the lane
+# `unknown`, which is fail-closed — no label, no merge.
+#
+#   devx_pr_review_all_lane_block <ai> [<head-sha>]  # comment bodies on stdin
+#     -> that lane's raw block, or nothing
+#   devx_pr_review_all_verdict                       # lane output on stdin
+#     -> blocking | concerns | lgtm | unknown
+#   devx_pr_review_all_aggregate                     # verdict tokens on stdin,
+#     -> label=review-blocked | label=review-passed | label=   (+ lanes=N)
+#
+# The aggregate reads stdin, NOT positional args, and that is load-bearing:
+# the natural call site `devx_pr_review_all_aggregate $VERDICTS` relies on the
+# shell word-splitting an unquoted expansion, which zsh does not do without
+# SH_WORD_SPLIT. In zsh every lane's verdict arrived as one argument, so a
+# two-lane PR reported `lanes=1` and lost the blocking verdict outright. A
+# newline-delimited stream behaves identically in bash, zsh and dash.
+#
+# Skipped lanes contribute NO line — "not checked" and "checked and passed"
+# must never collapse into the same state (#1527 확정 사항).
+
+devx_pr_review_all_verdict() {
+    local _line _value
+
+    # Normalize before matching: fullwidth colon -> ASCII, strip the markdown
+    # a reviewer may wrap the line in, drop a leading list dash. Then keep
+    # only lines that *start* with the verdict key — a finding line like
+    # `[BLOCKER] a.sh:1 — ...` must never be mistaken for the verdict.
+    # Last one wins: the presets require the verdict to be the final line.
+    _line=$(
+        sed -e 's/：/:/g' -e 's/[*`_#>]//g' \
+            -e 's/^[[:space:]]*-[[:space:]]*//' -e 's/^[[:space:]]*//' |
+            grep -iE '^(판정|verdict)[[:space:]]*:' |
+            tail -n 1
+    )
+
+    if [ -z "$_line" ]; then
+        printf 'unknown\n'
+        return 0
+    fi
+
+    _value=$(
+        printf '%s\n' "$_line" |
+            sed -e 's/^[^:]*://' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+    )
+
+    # The unanswered preset template echoed back verbatim is not a verdict.
+    # Its signature is the bracketed alternation `[A|B|C]` — the value opens
+    # with `[` AND carries a `|` inside the brackets. Keying on `|` alone
+    # (the #1527 attempt) threw away real answers like `Verdict: BLOCKING |
+    # 5 findings`; keying on the leading `[` alone throws away `Verdict:
+    # [BLOCKING]`. Both halves are required. The pattern's brackets and pipe
+    # are quoted so `case` reads them as literals, not a bracket expression.
+    case "$_value" in
+    '['*'|'*']'*)
+        printf 'unknown\n'
+        return 0
+        ;;
+    esac
+
+    _value=$(
+        printf '%s\n' "$_value" |
+            sed -e 's/[][]//g' -e 's/^[[:space:]]*//' |
+            tr '[:lower:]' '[:upper:]'
+    )
+
+    case "$_value" in
+    블로킹* | BLOCKING*) printf 'blocking\n' ;;
+    우려있음* | CONCERNS*) printf 'concerns\n' ;;
+    LGTM*) printf 'lgtm\n' ;;
+    *) printf 'unknown\n' ;;
+    esac
+}
+
+devx_pr_review_all_aggregate() {
+    local _lanes=0 _blocking=0 _unresolved=0 _v _label
+
+    # `|| [ -n "$_v" ]` so a final line with no trailing newline still counts.
+    while IFS= read -r _v || [ -n "$_v" ]; do
+        [ -n "$_v" ] || continue
+        _lanes=$((_lanes + 1))
+        case "$_v" in
+        blocking) _blocking=1 ;;
+        lgtm | concerns) ;;
+        # `unknown` and anything unrecognized are the same thing: the lane
+        # ran but its verdict could not be established. Fail closed.
+        *) _unresolved=1 ;;
+        esac
+    done
+
+    if [ "$_blocking" -eq 1 ]; then
+        _label="review-blocked"
+    elif [ "$_lanes" -eq 0 ] || [ "$_unresolved" -eq 1 ]; then
+        _label=""
+    else
+        _label="review-passed"
+    fi
+
+    printf '%s\n' "label=$_label"
+    printf '%s\n' "lanes=$_lanes"
+    return 0
+}
+
+# Harvest one reviewer lane's raw output from the PR comment bodies on stdin.
+#
+# Step 3 dispatches each lane as a subagent, and `gh:pr-review` guarantees only
+# a one-line `[OK] PR #N reviewed by <ai> — comment: <URL>` as its return
+# value — the verdict is nowhere in it. Reading the verdict out of a subagent's
+# prose would make the merge gate depend on how an agent chose to summarise
+# itself; every lane would land on `unknown`, no label would ever be written,
+# and the train would skip every PR forever.
+#
+# So the verdict is read back from the artifact the lane already wrote:
+# `gh:pr-review` Step 6 posts the reviewer's raw output wrapped in
+# `<!-- ai-review:<ai> -->` markers, synchronously, before it returns. That is
+# a durable machine-readable record, not a summary.
+#
+# The LAST complete block wins: a re-review posts a second comment and its
+# verdict supersedes. An unterminated block (a truncated or still-being-written
+# comment) is never harvested — half a review is not a verdict.
+#
+# The optional <head-sha> is the freshness gate. Without it a block from an
+# earlier round is indistinguishable from one this run just posted, so a run
+# that posted nothing (GH_DISABLE_AI_METRICS=1, --no-post-comment, a failed
+# post) silently reuses a stale verdict — and a stale verdict can authorize a
+# merge of code it never saw. Given a sha, only `<!-- ai-review:<ai>:<sha> -->`
+# blocks match, and a lane with no block for that exact sha yields nothing,
+# which reads downstream as `unknown`. Without it, sha-tagged and plain blocks
+# both match and no freshness claim is made.
+devx_pr_review_all_lane_block() {
+    [ -n "${1-}" ] || return 0
+    awk -v ai="$1" -v sha="${2-}" '
+        function tagof(line, pre, plen,   p, rest, e) {
+            p = index(line, pre)
+            if (p == 0) return ""
+            rest = substr(line, p + plen)
+            e = index(rest, " -->")
+            if (e == 0) return ""
+            return substr(rest, 1, e - 1)
+        }
+        function wanted(t) {
+            if (sha != "") return (t == ai ":" sha)
+            return (t == ai || substr(t, 1, length(ai) + 1) == ai ":")
+        }
+        BEGIN {
+            # `beg`/`fin`, not `open`/`close`: `close` is an awk built-in and
+            # using it as a variable is a syntax error in POSIX awk.
+            beg = "<!-- ai-review:"
+            fin = "<!-- /ai-review:"
+            blen = length(beg)
+            flen = length(fin)
+        }
+        wanted(tagof($0, beg, blen))     { collecting = 1; buf = ""; next }
+        collecting && wanted(tagof($0, fin, flen)) {
+            collecting = 0; last = buf; next
+        }
+        collecting                       { buf = buf $0 "\n" }
+        END                              { printf "%s", last }
+    '
+}

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -157,7 +157,7 @@ devx_pr_review_all_parse() {
 # must never collapse into the same state (#1527 확정 사항).
 
 devx_pr_review_all_verdict() {
-    local _line _value
+    local _line _value _bracket_inner
 
     # Normalize before matching: fullwidth colon -> ASCII, strip the markdown
     # a reviewer may wrap the line in, drop a leading list dash. Then keep
@@ -182,16 +182,21 @@ devx_pr_review_all_verdict() {
     )
 
     # The unanswered preset template echoed back verbatim is not a verdict.
-    # Its signature is the bracketed alternation `[A|B|C]` — the value opens
-    # with `[` AND carries a `|` inside the brackets. Keying on `|` alone
-    # (the #1527 attempt) threw away real answers like `Verdict: BLOCKING |
-    # 5 findings`; keying on the leading `[` alone throws away `Verdict:
-    # [BLOCKING]`. Both halves are required. The pattern's brackets and pipe
-    # are quoted so `case` reads them as literals, not a bracket expression.
+    # Its signature is the bracketed alternation `[A|B|C]` — the pipe sits
+    # INSIDE the first bracket pair. Checking for `[` and `|` anywhere in the
+    # value (PR #1573 review, agy FOLLOW-UP) misclassified a real verdict
+    # with a bracketed trailing detail, e.g. `[BLOCKING] | [5 findings]`, as
+    # the template. Extract only the first bracket group's content and test
+    # that for a pipe.
     case "$_value" in
-    '['*'|'*']'*)
-        printf 'unknown\n'
-        return 0
+    '['*)
+        _bracket_inner=$(printf '%s\n' "$_value" | sed -n 's/^\[\([^]]*\)\].*/\1/p')
+        case "$_bracket_inner" in
+        *'|'*)
+            printf 'unknown\n'
+            return 0
+            ;;
+        esac
         ;;
     esac
 
@@ -273,11 +278,32 @@ devx_pr_review_all_lane_block() {
             blen = length(beg)
             flen = length(fin)
         }
-        wanted(tagof($0, beg, blen))     { collecting = 1; buf = ""; next }
-        collecting && wanted(tagof($0, fin, flen)) {
-            collecting = 0; last = buf; next
+        {
+            # A collapsed block — open and close markers on the same line —
+            # must be handled before the open-tag rule below: that rule
+            # `next`s immediately, so a close tag trailing on that same line
+            # would never be inspected (PR #1573 review, agy+codex
+            # independently).
+            bp = index($0, beg)
+            if (bp > 0 && wanted(tagof($0, beg, blen))) {
+                bt = tagof($0, beg, blen)
+                rest = substr($0, bp + blen + length(bt) + 4)
+                fp = index(rest, fin)
+                if (fp > 0 && wanted(tagof(rest, fin, flen))) {
+                    last = substr(rest, 1, fp - 1)
+                    next
+                }
+                collecting = 1
+                buf = ""
+                next
+            }
+            if (collecting && wanted(tagof($0, fin, flen))) {
+                collecting = 0
+                last = buf
+                next
+            }
+            if (collecting) { buf = buf $0 "\n" }
         }
-        collecting                       { buf = buf $0 "\n" }
-        END                              { printf "%s", last }
+        END { printf "%s", last }
     '
 }

--- a/tests/bats/functions/devx_pr_review_all_verdict.bats
+++ b/tests/bats/functions/devx_pr_review_all_verdict.bats
@@ -173,6 +173,17 @@ EOF
     assert_output "blocking"
 }
 
+@test "verdict (PR #1573 review, agy FOLLOW-UP): bracketed detail after the pipe is not a template echo" {
+    # The template-detection glob used to match `[` and `|` anywhere in the
+    # value, so a real verdict with a *second* bracketed group after the pipe
+    # (e.g. a bracketed finding count) was misread as the unanswered preset
+    # template `[LGTM|우려있음|블로킹]`. Only a pipe INSIDE the first bracket
+    # group is the template's signature.
+    run devx_pr_review_all_verdict <<<"Verdict: [BLOCKING] | [5 findings]"
+    assert_success
+    assert_output "blocking"
+}
+
 # ── devx_pr_review_all_aggregate (stdin, newline-delimited) ──────────
 
 @test "aggregate: all lanes pass -> review-passed" {
@@ -337,6 +348,26 @@ EOF
 EOF
     assert_success
     assert_output ""
+}
+
+@test "lane block (PR #1573 review, agy+codex FOLLOW-UP): open and close markers on the same line are still harvested" {
+    # The open-tag rule used to `next` immediately on match, so a close tag
+    # trailing on that same line was never inspected and the block was lost
+    # entirely (degrading the lane to unknown downstream).
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:agy -->Verdict: LGTM<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_output "Verdict: LGTM"
+}
+
+@test "lane block (PR #1573 review, follow-up): a same-line block picks the right lane" {
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:codex -->판정: 블로킹<!-- /ai-review:codex -->
+<!-- ai-review:agy -->Verdict: LGTM<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_output "Verdict: LGTM"
 }
 
 @test "lane block: end-to-end -> verdict token" {

--- a/tests/bats/functions/devx_pr_review_all_verdict.bats
+++ b/tests/bats/functions/devx_pr_review_all_verdict.bats
@@ -1,0 +1,647 @@
+#!/usr/bin/env bats
+# tests/bats/functions/devx_pr_review_all_verdict.bats
+# Issue #1562 — correctness and portability of the reviewer-verdict parser.
+#
+# Background: the verdict line ("판정: 블로킹" / "Verdict: BLOCKING") that every
+# gh:pr-review preset mandates had no machine-readable consumer, so PR #1518
+# merged carrying two independent blocking reviews. #1527's first attempt at a
+# parser was abandoned with three defects still in it; this suite pins the
+# fixes:
+#
+#   1. aggregation lost lanes under zsh, because the call site relied on
+#      ambient word-splitting of an unquoted "$VERDICTS"
+#   2. a stale block from an earlier round was reused as if it were fresh
+#   3. `Verdict: BLOCKING | 5 findings` was misread as the unanswered template
+#
+# Fail-closed is the whole point: "no label" must never be reachable from
+# "everything passed", and "a lane ran but said nothing parseable" must never
+# be promoted to a pass.
+load '../test_helper'
+
+setup() {
+    # shellcheck disable=SC1090
+    source "${DOTFILES_ROOT:?}/shell-common/functions/devx_pr_review_all.sh"
+}
+
+# ── devx_pr_review_all_verdict: Korean verdicts ──────────────────────
+
+@test "verdict: Korean 블로킹 -> blocking" {
+    run devx_pr_review_all_verdict <<'EOF'
+[BLOCKER] a.sh:1 — breaks on empty input
+판정: 블로킹
+EOF
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: Korean 우려있음 -> concerns" {
+    run devx_pr_review_all_verdict <<<"판정: 우려있음"
+    assert_success
+    assert_output "concerns"
+}
+
+@test "verdict: Korean LGTM -> lgtm" {
+    run devx_pr_review_all_verdict <<<"판정: LGTM"
+    assert_success
+    assert_output "lgtm"
+}
+
+# ── devx_pr_review_all_verdict: English verdicts ─────────────────────
+
+@test "verdict: English BLOCKING -> blocking" {
+    run devx_pr_review_all_verdict <<<"Verdict: BLOCKING"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: English CONCERNS -> concerns" {
+    run devx_pr_review_all_verdict <<<"Verdict: CONCERNS"
+    assert_success
+    assert_output "concerns"
+}
+
+@test "verdict: English lgtm is case-insensitive" {
+    run devx_pr_review_all_verdict <<<"verdict: lgtm"
+    assert_success
+    assert_output "lgtm"
+}
+
+# ── devx_pr_review_all_verdict: real-world noise ─────────────────────
+
+@test "verdict: markdown bold + trailing detail still parses" {
+    run devx_pr_review_all_verdict <<<"**판정: 블로킹 (BLOCKER 4건)**"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: leading list dash still parses" {
+    run devx_pr_review_all_verdict <<<"- Verdict: LGTM"
+    assert_success
+    assert_output "lgtm"
+}
+
+@test "verdict: last verdict line wins" {
+    run devx_pr_review_all_verdict <<'EOF'
+판정: LGTM
+판정: 블로킹
+EOF
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict: a BLOCKER finding alone is not a verdict" {
+    # Findings are classified [BLOCKER|FOLLOW-UP|PRAISE]; only the mandatory
+    # last verdict line decides the lane. No verdict line -> unknown.
+    run devx_pr_review_all_verdict <<<"[BLOCKER] a.sh:1 — breaks on empty input"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict: empty lane output -> unknown" {
+    run devx_pr_review_all_verdict </dev/null
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict: unrecognized verdict value -> unknown" {
+    run devx_pr_review_all_verdict <<<"Verdict: MAYBE"
+    assert_success
+    assert_output "unknown"
+}
+
+# ── BUG 3: template detection is bracket+pipe, not "contains a pipe" ──
+# The abandoned parser dropped every candidate line containing `|`
+# (`grep -vF '|'`), so a genuine verdict with an explanatory tail after a
+# pipe was classified `unknown` — no label, PR silently un-mergeable. The
+# template's real signature is the bracketed alternation `[A|B|C]`.
+
+@test "verdict (bug 3): answered verdict with a trailing pipe -> blocking" {
+    run devx_pr_review_all_verdict <<<"Verdict: BLOCKING | 5 findings"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict (bug 3): Korean answered verdict with a trailing pipe -> blocking" {
+    run devx_pr_review_all_verdict <<<"판정: 블로킹 | BLOCKER 5건"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict (bug 3): answered LGTM with a trailing pipe -> lgtm" {
+    run devx_pr_review_all_verdict <<<"Verdict: LGTM | no findings"
+    assert_success
+    assert_output "lgtm"
+}
+
+@test "verdict (bug 3): the English template alternation is still rejected" {
+    run devx_pr_review_all_verdict <<<"Verdict: [LGTM|CONCERNS|BLOCKING]"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict (bug 3): the Korean template alternation is still rejected" {
+    # The preset prompt itself contains `판정: [LGTM|우려있음|블로킹]`. A lane
+    # that echoes its own instructions back must not be read as an LGTM.
+    run devx_pr_review_all_verdict <<<"판정: [LGTM|우려있음|블로킹]"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "verdict (bug 3): bracketed single verdict still parses (English)" {
+    run devx_pr_review_all_verdict <<<"Verdict: [BLOCKING]"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict (bug 3): bracketed single verdict still parses (Korean)" {
+    run devx_pr_review_all_verdict <<<"판정: [블로킹]"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict (bug 3): a bracket in the detail text is not a template echo" {
+    # Only a value that *opens* with `[` and carries a `|` inside is the
+    # template. A bracketed count after a real verdict must still parse.
+    run devx_pr_review_all_verdict <<<"판정: 블로킹 [BLOCKER 4건]"
+    assert_success
+    assert_output "blocking"
+}
+
+@test "verdict (bug 3): bracketed verdict followed by a piped tail parses" {
+    run devx_pr_review_all_verdict <<<"Verdict: [BLOCKING] | 5 findings"
+    assert_success
+    assert_output "blocking"
+}
+
+# ── devx_pr_review_all_aggregate (stdin, newline-delimited) ──────────
+
+@test "aggregate: all lanes pass -> review-passed" {
+    run devx_pr_review_all_aggregate <<'EOF'
+lgtm
+concerns
+EOF
+    assert_success
+    assert_line "label=review-passed"
+    assert_line "lanes=2"
+}
+
+@test "aggregate: a blocking lane outranks a passing one" {
+    run devx_pr_review_all_aggregate <<'EOF'
+lgtm
+blocking
+EOF
+    assert_success
+    assert_line "label=review-blocked"
+    assert_line "lanes=2"
+}
+
+@test "aggregate: zero lanes ran -> no label" {
+    run devx_pr_review_all_aggregate </dev/null
+    assert_success
+    assert_line "label="
+    assert_line "lanes=0"
+}
+
+@test "aggregate: an unknown lane is never promoted to a pass" {
+    run devx_pr_review_all_aggregate <<'EOF'
+lgtm
+unknown
+EOF
+    assert_success
+    assert_line "label="
+    assert_line "lanes=2"
+}
+
+@test "aggregate: blocking outranks unknown" {
+    run devx_pr_review_all_aggregate <<'EOF'
+unknown
+blocking
+EOF
+    assert_success
+    assert_line "label=review-blocked"
+}
+
+@test "aggregate: garbage token is treated as unknown, not a pass" {
+    run devx_pr_review_all_aggregate <<'EOF'
+lgtm
+ohai
+EOF
+    assert_success
+    assert_line "label="
+}
+
+@test "aggregate: blank lines are not lanes" {
+    # A skipped lane must contribute nothing at all; a stray empty line in
+    # the stream must not inflate the lane count into a false "verified".
+    run devx_pr_review_all_aggregate <<'EOF'
+
+lgtm
+
+EOF
+    assert_success
+    assert_line "label=review-passed"
+    assert_line "lanes=1"
+}
+
+@test "aggregate: a final verdict with no trailing newline still counts" {
+    run bash -c '
+        . "'"${DOTFILES_ROOT}"'/shell-common/functions/devx_pr_review_all.sh"
+        printf "lgtm\nblocking" | devx_pr_review_all_aggregate'
+    assert_success
+    assert_line "label=review-blocked"
+    assert_line "lanes=2"
+}
+
+@test "aggregate: reports the lane count it decided on" {
+    run devx_pr_review_all_aggregate <<'EOF'
+lgtm
+concerns
+blocking
+EOF
+    assert_success
+    assert_line "lanes=3"
+}
+
+# ── Lane block extraction ────────────────────────────────────────────
+# Step 3 dispatches each reviewer lane as a subagent, and `gh:pr-review`
+# guarantees only a one-line `[OK] PR #N reviewed by <ai> — comment: <URL>`
+# as its return value. Nothing carries the verdict back, so the verdict is
+# read from the artifact the lane already wrote: the raw output `gh:pr-review`
+# Step 6 posts inside `<!-- ai-review:<ai> -->` markers.
+
+@test "lane block: extracts the marked block for the named lane" {
+    run devx_pr_review_all_lane_block codex <<'EOF'
+<!-- ai-review:codex -->
+[BLOCKER] a.sh:1 — nope
+판정: 블로킹
+<!-- /ai-review:codex -->
+EOF
+    assert_success
+    assert_line "판정: 블로킹"
+}
+
+@test "lane block: picks the right lane when several are present" {
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:codex -->
+판정: 블로킹
+<!-- /ai-review:codex -->
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_line "Verdict: LGTM"
+    refute_output --partial "블로킹"
+}
+
+@test "lane block: the LAST block wins when a lane was re-reviewed" {
+    # A re-review posts a second comment; the newest verdict is the live one.
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+<!-- ai-review:agy -->
+Verdict: BLOCKING
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_line "Verdict: BLOCKING"
+    refute_output --partial "LGTM"
+}
+
+@test "lane block: absent lane yields nothing (-> unknown downstream)" {
+    run devx_pr_review_all_lane_block hermes <<'EOF'
+<!-- ai-review:codex -->
+판정: LGTM
+<!-- /ai-review:codex -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block: an unterminated block is not harvested" {
+    # A truncated comment must not hand back a half-read verdict.
+    run devx_pr_review_all_lane_block codex <<'EOF'
+<!-- ai-review:codex -->
+판정: 블로킹
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block: no ai argument yields nothing" {
+    run devx_pr_review_all_lane_block <<'EOF'
+<!-- ai-review:codex -->
+판정: 블로킹
+<!-- /ai-review:codex -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block: end-to-end -> verdict token" {
+    run bash -c '
+        . "'"${DOTFILES_ROOT}"'/shell-common/functions/devx_pr_review_all.sh"
+        printf "%s\n" "<!-- ai-review:agy -->" "Verdict: BLOCKING" "<!-- /ai-review:agy -->" \
+          | devx_pr_review_all_lane_block agy | devx_pr_review_all_verdict'
+    assert_success
+    assert_output "blocking"
+}
+
+# ── BUG 2: freshness via the optional head-sha argument ──────────────
+# Without a sha, a block posted in an earlier round is indistinguishable from
+# one this run just posted. A run that posted nothing (GH_DISABLE_AI_METRICS=1,
+# --no-post-comment, a failed post) would then reuse a stale verdict — and a
+# stale verdict can authorize a merge of code it never saw.
+
+@test "lane block (bug 2): a stale sha's block is not harvested for a new sha" {
+    run devx_pr_review_all_lane_block agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:0000111122223333 -->
+Verdict: LGTM
+<!-- /ai-review:agy:0000111122223333 -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block (bug 2): a stale block downstream reads as unknown" {
+    run bash -c '
+        . "'"${DOTFILES_ROOT}"'/shell-common/functions/devx_pr_review_all.sh"
+        printf "%s\n" \
+          "<!-- ai-review:agy:0000111122223333 -->" \
+          "Verdict: LGTM" \
+          "<!-- /ai-review:agy:0000111122223333 -->" \
+          | devx_pr_review_all_lane_block agy deadbeefdeadbeef \
+          | devx_pr_review_all_verdict'
+    assert_success
+    assert_output "unknown"
+}
+
+@test "lane block (bug 2): the matching sha's block is harvested" {
+    run devx_pr_review_all_lane_block agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:0000111122223333 -->
+Verdict: LGTM
+<!-- /ai-review:agy:0000111122223333 -->
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: BLOCKING
+<!-- /ai-review:agy:deadbeefdeadbeef -->
+EOF
+    assert_success
+    assert_line "Verdict: BLOCKING"
+    refute_output --partial "LGTM"
+}
+
+@test "lane block (bug 2): a sha-tagged block of another lane is not harvested" {
+    run devx_pr_review_all_lane_block agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:codex:deadbeefdeadbeef -->
+Verdict: BLOCKING
+<!-- /ai-review:codex:deadbeefdeadbeef -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block (bug 2): an untagged block does not satisfy a sha request" {
+    # The plain marker carries no freshness claim, so it must not be accepted
+    # as evidence for a specific head.
+    run devx_pr_review_all_lane_block agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block (bug 2): a sha-tagged block whose close tag is untagged is not harvested" {
+    run devx_pr_review_all_lane_block agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_output ""
+}
+
+@test "lane block (bug 2): no sha argument keeps today's behavior on plain markers" {
+    # The marker gh:pr-review actually emits today carries no sha. Passing no
+    # second argument must behave exactly as before: last complete block wins.
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+<!-- ai-review:agy -->
+Verdict: BLOCKING
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_line "Verdict: BLOCKING"
+    refute_output --partial "LGTM"
+}
+
+@test "lane block (bug 2): no sha argument makes no freshness claim" {
+    # Omitting the sha means "do not check freshness", so a sha-tagged block
+    # is still harvested — it is the caller that opted out of the check.
+    run devx_pr_review_all_lane_block agy <<'EOF'
+<!-- ai-review:agy:0000111122223333 -->
+Verdict: BLOCKING
+<!-- /ai-review:agy:0000111122223333 -->
+EOF
+    assert_success
+    assert_line "Verdict: BLOCKING"
+}
+
+@test "lane block (bug 2): an empty sha argument is the same as none" {
+    run devx_pr_review_all_lane_block agy "" <<'EOF'
+<!-- ai-review:agy -->
+Verdict: BLOCKING
+<!-- /ai-review:agy -->
+EOF
+    assert_success
+    assert_line "Verdict: BLOCKING"
+}
+
+# ── BUG 1: the documented call site must agree across bash/zsh/dash ──
+# The abandoned aggregate took positional args and its documented call site
+# was `AGG=$(devx_pr_review_all_aggregate $VERDICTS)` — an unquoted expansion
+# relying on the shell to word-split "lgtm blocking" into two arguments. zsh
+# does not word-split without SH_WORD_SPLIT, so the whole string arrived as
+# ONE argument: lanes=1 and the blocking verdict vanished. This repo's default
+# interactive shell is zsh, so the gate would have failed open there.
+#
+# These tests run the *documented* pipeline verbatim in all three shells. The
+# abandoned suite passed only because it called the function directly with
+# bash-native separate arguments, never simulating the real call site.
+
+_two_lane_fixture() {
+    cat >"${BATS_TEST_TMPDIR}/comments.md" <<'EOF'
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+<!-- ai-review:codex -->
+판정: 블로킹
+<!-- /ai-review:codex -->
+EOF
+}
+
+# The Step 5 call site from
+# claude/skills/devx-pr-review-all/references/review-verdict-label.md, with
+# `lane_ran` reduced to a fixed two-of-four so the other two lanes exercise
+# the skipped-lane invariant (they contribute no line at all).
+_two_lane_body() {
+    printf "BODIES_FILE='%s'\n" "${BATS_TEST_TMPDIR}/comments.md"
+    cat <<'BODY'
+AGG=$(
+    for ai in agy codex opencode hermes; do
+        case "$ai" in
+        agy | codex) ;;
+        *) continue ;;
+        esac
+        v=$(devx_pr_review_all_lane_block "$ai" <"$BODIES_FILE" | devx_pr_review_all_verdict)
+        printf '%s\n' "$v"
+    done | devx_pr_review_all_aggregate
+)
+label=$(printf '%s\n' "$AGG" | sed -n 's/^label=//p')
+lanes=$(printf '%s\n' "$AGG" | sed -n 's/^lanes=//p')
+printf 'RESULT label=%s lanes=%s\n' "$label" "$lanes"
+BODY
+}
+
+_run_in_dash() {
+    command -v dash >/dev/null 2>&1 || skip "dash not available"
+    run dash -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export HOME='${HOME}'
+        . '${DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh'
+        $1
+    "
+}
+
+@test "bug 1 (bash): two-lane pipeline -> review-blocked, lanes=2" {
+    _two_lane_fixture
+    run_in_bash "$(_two_lane_body)"
+    assert_success
+    assert_output --partial "RESULT label=review-blocked lanes=2"
+}
+
+@test "bug 1 (zsh): two-lane pipeline -> review-blocked, lanes=2" {
+    _two_lane_fixture
+    run_in_zsh "$(_two_lane_body)"
+    assert_success
+    assert_output --partial "RESULT label=review-blocked lanes=2"
+}
+
+@test "bug 1 (dash): two-lane pipeline -> review-blocked, lanes=2" {
+    _two_lane_fixture
+    _run_in_dash "$(_two_lane_body)"
+    assert_success
+    assert_output --partial "RESULT label=review-blocked lanes=2"
+}
+
+_four_pass_body() {
+    cat <<'BODY'
+AGG=$(
+    for v in lgtm concerns lgtm concerns; do
+        printf '%s\n' "$v"
+    done | devx_pr_review_all_aggregate
+)
+label=$(printf '%s\n' "$AGG" | sed -n 's/^label=//p')
+lanes=$(printf '%s\n' "$AGG" | sed -n 's/^lanes=//p')
+printf 'RESULT label=%s lanes=%s\n' "$label" "$lanes"
+BODY
+}
+
+# The bug-3 template guard is a `case` pattern with quoted `[`, `|` and `]`.
+# Quoting is what keeps them literal rather than a bracket expression, and
+# that reading has to be the same in every shell this file is sourced into.
+_classify_body() {
+    cat <<'BODY'
+for line in \
+    "Verdict: BLOCKING | 5 findings" \
+    "판정: [LGTM|우려있음|블로킹]" \
+    "Verdict: [LGTM|CONCERNS|BLOCKING]" \
+    "Verdict: [BLOCKING]" \
+    "판정: 블로킹 [BLOCKER 4건]"; do
+    printf 'RESULT %s\n' "$(printf '%s\n' "$line" | devx_pr_review_all_verdict)"
+done
+BODY
+}
+
+_assert_classified() {
+    assert_success
+    assert_line "RESULT blocking"
+    assert_line "RESULT unknown"
+    # 3 real verdicts, 2 template echoes.
+    [ "$(printf '%s\n' "$output" | grep -c '^RESULT blocking$')" -eq 3 ] ||
+        fail "expected 3 blocking classifications, got: $output"
+    [ "$(printf '%s\n' "$output" | grep -c '^RESULT unknown$')" -eq 2 ] ||
+        fail "expected 2 unknown classifications, got: $output"
+}
+
+@test "bug 3 (bash): template vs answered verdict classification" {
+    run_in_bash "$(_classify_body)"
+    _assert_classified
+}
+
+@test "bug 3 (zsh): template vs answered verdict classification" {
+    run_in_zsh "$(_classify_body)"
+    _assert_classified
+}
+
+@test "bug 3 (dash): template vs answered verdict classification" {
+    _run_in_dash "$(_classify_body)"
+    _assert_classified
+}
+
+@test "bug 1 (bash): four passing lanes -> review-passed, lanes=4" {
+    run_in_bash "$(_four_pass_body)"
+    assert_success
+    assert_output --partial "RESULT label=review-passed lanes=4"
+}
+
+@test "bug 1 (zsh): four passing lanes -> review-passed, lanes=4" {
+    run_in_zsh "$(_four_pass_body)"
+    assert_success
+    assert_output --partial "RESULT label=review-passed lanes=4"
+}
+
+@test "bug 1 (dash): four passing lanes -> review-passed, lanes=4" {
+    _run_in_dash "$(_four_pass_body)"
+    assert_success
+    assert_output --partial "RESULT label=review-passed lanes=4"
+}
+
+# A skipped lane contributes no line, so "nothing was checked" stays
+# distinguishable from "everything passed" in every shell.
+_all_skipped_body() {
+    cat <<'BODY'
+AGG=$(
+    for ai in agy codex opencode hermes; do
+        continue
+        printf '%s\n' lgtm
+    done | devx_pr_review_all_aggregate
+)
+label=$(printf '%s\n' "$AGG" | sed -n 's/^label=//p')
+lanes=$(printf '%s\n' "$AGG" | sed -n 's/^lanes=//p')
+printf 'RESULT label=[%s] lanes=%s\n' "$label" "$lanes"
+BODY
+}
+
+@test "bug 1 (bash): every lane skipped -> no label, lanes=0" {
+    run_in_bash "$(_all_skipped_body)"
+    assert_success
+    assert_output --partial "RESULT label=[] lanes=0"
+}
+
+@test "bug 1 (zsh): every lane skipped -> no label, lanes=0" {
+    run_in_zsh "$(_all_skipped_body)"
+    assert_success
+    assert_output --partial "RESULT label=[] lanes=0"
+}
+
+@test "bug 1 (dash): every lane skipped -> no label, lanes=0" {
+    _run_in_dash "$(_all_skipped_body)"
+    assert_success
+    assert_output --partial "RESULT label=[] lanes=0"
+}


### PR DESCRIPTION
## Summary
- #1527이 시도했다가 3라운드 BLOCKER로 폐기된(PR #1529) 판정 파서를, 정확성/이식성 버그만 분리해 다시 구현한다(#1562).
- 리뷰 판정을 머지 게이트가 읽을 수 있는 1급 신호로 만들기 위한 순수 파서 3함수(`devx_pr_review_all_verdict` / `_aggregate` / `_lane_block`)와 그 계약 문서를 추가한다.
- 실제 배선(train 하드 게이트 #1564, 라벨 수명 불변식 #1563)은 별도 이슈로 남는다 — 이 PR은 아직 아무것도 소비하지 않는 순수 함수다.

## Changes
- `shell-common/functions/devx_pr_review_all.sh`: 판정 파서 3함수 추가.
  - zsh 가 무인용 확장을 word-split 하지 않아 2개 이상 레인의 판정이 소실되던 버그 — `aggregate` 를 개행 구분 stdin 스트림으로 변경(bash/zsh/dash 동일 결과).
  - 새 코멘트가 없으면 이전 라운드 판정을 재사용하던 버그 — `lane_block` 에 선택적 head-sha 신선도 인자 추가(안 주면 기존 동작 유지).
  - `Verdict: BLOCKING | 5 findings` 처럼 진짜 판정이 파이프 부연 때문에 미응답 템플릿과 혼동되던 버그 — 템플릿 판별을 "괄호로 시작 + 파이프 포함" 동시 충족으로 좁힘.
- `claude/skills/devx-pr-review-all/references/review-verdict-label.md`: 위 계약의 SSOT 문서(신규) — 아직 아무것도 이 라벨을 소비하지 않는다는 "Wiring status" 경고 포함.
- `tests/bats/functions/devx_pr_review_all_verdict.bats`: 3버그 각각의 회귀 테스트 + bash/zsh/dash 교차 셸 테스트(58건, 뮤테이션 테스트로 고정 — 수정을 되돌리면 관련 테스트가 실제로 빨간불이 된다).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all.bats tests/bats/functions/devx_pr_review_all_verdict.bats` — 75/75 통과
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/devx_pr_review_all.sh` — clean
- [x] `shfmt -d -i 4 -ln bash shell-common/functions/devx_pr_review_all.sh` — clean
- [x] pytest 베이스라인 대비 회귀 없음 (1 pre-existing failure 유지, 무관: `test_cancelling_fzf_exits_cleanly[zsh]`)

## Related
Closes #1562

---
<details>
<summary>🤖 AI Metrics · 📊 ~11000 tokens · 👤 ~2 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~11000 tokens · 👤 ~2 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
