### PR TITLE
fix(herdr): sidebar agent 토큰 낮은 대비 고침

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -8,6 +8,15 @@ onboarding = false
 [ui]
 show_agent_labels_on_pane_borders = true
 
+# The nord theme renders the "tab" and "agent" tokens dim by default, which
+# made the tab label (e.g. "merge-train") and the second-row worktree/branch
+# label (e.g. "wt-dotfiles-issue-1527") read as low-contrast.
+[ui.sidebar.agents]
+rows = [
+    ["state_icon", "workspace", { token = "tab", dim = false }],
+    [{ token = "agent", dim = false }],
+]
+
 [ui.toast]
 delivery = "herdr"
 


### PR DESCRIPTION
## Summary
- herdr 사이드바(에이전트 리스트) 두번째 줄에 표시되는 워크트리/브랜치 라벨(`agent` 토큰)의 낮은 대비를 고친다.

## Changes
- `herdr/config.toml`: `[ui.sidebar.agents].rows` 두번째 행의 `agent` 토큰에 `dim = false`를 지정해, 첫번째 행의 `tab` 토큰에 이미 적용된 것과 동일한 nord 테마 고대비 오버라이드를 적용한다.

## Test plan
- [x] `herdr config check` — 구문 검증 통과
- [x] `herdr server reload-config` — 실행 중인 서버에 즉시 반영, 사이드바에서 워크트리 라벨 가시성 확인

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
