### PR TITLE
fix(herdr-dispatch): herdr 기동 뒤 13초 정착 대기를 세 디스패처에 통일한다

### DIFF
--- a/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
@@ -59,6 +59,32 @@ pmv_json_first() {
 # is ever interpolated into the jq program text.
 pmv_error_code() { jq -r '.error.code // empty' 2>/dev/null || return 0; }
 pmv_physical_path() { (cd -P "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"; }
+
+# Settle wait after a herdr call that brings something up (#1571). One value
+# for both of this repo's herdr races, because they are the same race seen
+# twice and splitting them is how a fix keeps missing a third site:
+#   `tab create` -> `agent start`  the pane answers before its shell is
+#       interactive, so the start is refused with `agent_pane_busy`
+#       (issue_watcher_cron.sh's _IW_START_RETRY_SLEEP comment documents it).
+#   `agent start` -> `agent prompt`  herdr answers `"agent_status":"idle"`
+#       straight away, but a freshly drawn claude TUI is idle while its
+#       key-input loop is still unattached, so the prompt is swallowed (#1560).
+# Measured on herdr 0.7.5: ~5s fails every time, ~13s lands. 13 is the repo
+# standard — the twins are _IW_SETTLE_SECONDS / _IW_START_RETRY_SLEEP in
+# shell-common/tools/custom/issue_watcher_cron.sh and _PMT_SETTLE_SECONDS /
+# _PMT_START_RETRY_SLEEP in shell-common/tools/custom/pr_merge_train_cron.sh.
+# Change one, change all five: #1530/#1549 and #1560/#1571 are both the same
+# defect recurring because two of three dispatchers were fixed.
+#
+# The other two dispatchers also *retry* `agent start` on `agent_pane_busy`;
+# this one deliberately does not (#1571 D-3). A wait shrinks the race, a retry
+# survives it — the retry belongs here too, but as part of #1569's shared
+# helper, not as a fourth hand-rolled copy that unification would undo.
+#
+# Overridable, and `0` disables it outright, so the bats suite never sleeps for
+# real (same convention as _IW_IDLE_POLL_SLEEP).
+PMV_SETTLE_SECONDS="${PMV_SETTLE_SECONDS:-13}"
+pmv_settle() { [ "$PMV_SETTLE_SECONDS" = "0" ] || sleep "$PMV_SETTLE_SECONDS"; }
 # herdr agent names come from one SSOT, sourced — never re-implemented here.
 # Three call sites each carrying their own `tr -c 'A-Za-z0-9._-' '-'` copy is
 # what produced #1530: that set keeps uppercase and dots, both of which herdr's
@@ -214,9 +240,15 @@ if ! PMV_AGENT=$(herdr_agent_name mv "$TARGET_REPO" "pr-${PR_NUMBER}"); then
     printf '[WARN] gh:pr-post-merge-verify: cannot derive an agent name for %s — verification skipped.\n' "$TARGET_REPO"
     return 0 2>/dev/null || exit 0
 fi
+# The pane from step 4 is seconds old and its shell may not be interactive yet;
+# starting an agent on it now is what `agent_pane_busy` is. Waited for here
+# rather than right after `tab create` so a repo whose name cannot be derived
+# skips out without paying 13s first.
+pmv_settle
 # `--dangerously-skip-permissions` is required, not a convenience: nobody is at
 # the keyboard of this pane, so one permission prompt would park the
 # verification forever instead of failing it (same reason as #1393).
+PMV_FRESH_START=1
 if ! START_JSON=$(herdr agent start "$PMV_AGENT" --kind claude --pane "$NEW_PANE" \
     -- --dangerously-skip-permissions 2>/dev/null); then
     # Race backstop: the name can be claimed between the probe and the start,
@@ -229,7 +261,12 @@ if ! START_JSON=$(herdr agent start "$PMV_AGENT" --kind claude --pane "$NEW_PANE
         return 0 2>/dev/null || exit 0
     fi
     printf '[WARN] gh:pr-post-merge-verify: agent %s already registered — prompting the existing session.\n' "$PMV_AGENT"
+    PMV_FRESH_START=0
 fi
+# A just-started claude is idle but not yet listening; a session that was
+# already registered has been up for a while and takes the prompt at once, so
+# the fallback path must not pay this (same rule as _pmt_launch_fresh).
+[ "$PMV_FRESH_START" = "0" ] || pmv_settle
 
 # --- 6. F-5: hand the verification over -----------------------------------
 # The registry stores the skill id (`devx:pr-verify-merged`); a pane is typed
@@ -260,6 +297,7 @@ printf '  attach: herdr agent attach %s\n' "$PMV_AGENT"
 | `BASE_BRANCH` | caller | The merged PR's base branch (`baseRefName`). Empty → the main checkout's current branch, and a detached HEAD stops the run |
 | `REMOTE` | Step 1, optional | The `[remote]` positional; default `origin`. `fetch`/`rebase` use it, never a hardcoded `origin` |
 | `PMV_PROMPT_TIMEOUT_MS` | env, optional | `herdr agent prompt --wait` cap, default 900000 (15 min) |
+| `PMV_SETTLE_SECONDS` | env, optional | Wait after each herdr call that brings something up, default 13; `0` disables both waits (#1571) |
 
 `--wait --until idle` waits for the dispatched session to settle, so the
 timeout is generous. Hitting it is a `[WARN]`, not a failure: the prompt has

--- a/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
@@ -248,7 +248,6 @@ pmv_settle
 # `--dangerously-skip-permissions` is required, not a convenience: nobody is at
 # the keyboard of this pane, so one permission prompt would park the
 # verification forever instead of failing it (same reason as #1393).
-PMV_FRESH_START=1
 if ! START_JSON=$(herdr agent start "$PMV_AGENT" --kind claude --pane "$NEW_PANE" \
     -- --dangerously-skip-permissions 2>/dev/null); then
     # Race backstop: the name can be claimed between the probe and the start,
@@ -260,13 +259,14 @@ if ! START_JSON=$(herdr agent start "$PMV_AGENT" --kind claude --pane "$NEW_PANE
             "$PMV_AGENT" "$NEW_PANE" "${START_CODE:-unknown}"
         return 0 2>/dev/null || exit 0
     fi
+    # This session was already registered, so it has been up for a while and
+    # takes the prompt at once — no need to pay the settle wait below.
     printf '[WARN] gh:pr-post-merge-verify: agent %s already registered — prompting the existing session.\n' "$PMV_AGENT"
-    PMV_FRESH_START=0
+else
+    # A just-started claude is idle but not yet listening (#1571) — this
+    # settle wait is what lets it start listening before the prompt lands.
+    pmv_settle
 fi
-# A just-started claude is idle but not yet listening; a session that was
-# already registered has been up for a while and takes the prompt at once, so
-# the fallback path must not pay this (same rule as _pmt_launch_fresh).
-[ "$PMV_FRESH_START" = "0" ] || pmv_settle
 
 # --- 6. F-5: hand the verification over -----------------------------------
 # The registry stores the skill id (`devx:pr-verify-merged`); a pane is typed

--- a/docs/public/changelog.d/2026-08-28-1571.md
+++ b/docs/public/changelog.d/2026-08-28-1571.md
@@ -1,0 +1,6 @@
+- 변경: **gh:pr-post-merge-verify 디스패치가 `herdr agent start` 성공 후 `agent prompt` 앞에서 13초 정착 대기를 한다 — 대기가 없어 프롬프트가 삼켜지고 검증 세션이 빈 껍데기로 남던 결함 수정 (#1571)**
+- 변경: **같은 디스패치가 `herdr tab create` 와 `agent start` 사이에도 13초를 기다린다 — 셸이 아직 인터랙티브하지 않은 팬에 대한 `agent_pane_busy` 경쟁을 다른 두 디스패처와 달리 맨몸으로 맞고 있었다 (#1571)**
+- 변경: **`agent_name_taken` fallback 경로는 정착 대기를 하지 않는다 — 이미 떠 있던 따뜻한 세션이라 대기가 낭비다 (#1571)**
+- 변경: **`PMV_SETTLE_SECONDS` 환경변수로 대기 시간을 조정할 수 있고 `0` 이면 두 대기가 모두 사라진다 (#1571)**
+- 변경: **issue-watcher / merge-train 의 `agent start` 재시도 간격(`IW_START_RETRY_SLEEP` / `PMT_START_RETRY_SLEEP`) 기본값이 2초에서 13초로 올라간다 — 실패로 실측된 5초보다도 짧았다 (#1571)**
+- 변경: **herdr 기동 대기 13초를 저장소 표준으로 못 박고, 세 디스패처의 다섯 상수가 서로를 주석으로 가리키며 bats 드리프트 가드가 값을 고정한다 (#1571)**

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -168,6 +168,14 @@ _IW_IDLE_POLL_SLEEP="${IW_IDLE_POLL_SLEEP:-0.5}"
 # once and must not pay this. Overridable (to 0) for the same reason
 # _IW_IDLE_POLL_SLEEP is: the bats suite must not sleep 13 real seconds per
 # dispatch test.
+#
+# 13 is the repo-wide constant for "herdr just brought something up, wait
+# before touching it" (#1571). Its four twins are _IW_START_RETRY_SLEEP below,
+# _PMT_SETTLE_SECONDS / _PMT_START_RETRY_SLEEP in pr_merge_train_cron.sh, and
+# PMV_SETTLE_SECONDS in
+# claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md. Change one,
+# change all five — #1530/#1549 and #1560/#1571 are both the same defect
+# recurring because only two of the three dispatchers were fixed.
 _IW_SETTLE_SECONDS="${IW_SETTLE_SECONDS:-13}"
 
 # Round-robin cursor (issue #1453 D-3). Its own file, so `rate-limit.json` and
@@ -199,8 +207,17 @@ _IW_STALL_RECOVER_SLEEP="${IW_STALL_RECOVER_SLEEP:-2}"
 # Bounded in *attempts*, not retries, so the `start N/MAX` warning reads exactly
 # true. The gap is overridable for the same reason _IW_STALL_RECOVER_SLEEP is —
 # the bats suite must not pay a real wait per retry test.
+#
+# The gap is 13s, not the 2s it shipped with (#1571): this is the *same* class
+# of wait as _IW_SETTLE_SECONDS above — herdr answered before the thing it
+# brought up was usable — and 2s was shorter than the 5s already measured to
+# fail. Its twins are _IW_SETTLE_SECONDS above, _PMT_SETTLE_SECONDS /
+# _PMT_START_RETRY_SLEEP in pr_merge_train_cron.sh, and PMV_SETTLE_SECONDS in
+# claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md; all five
+# move together. The wait and this retry are complements, not substitutes — 13s
+# shrinks the race, the retry survives what is left of it.
 _IW_START_ATTEMPT_MAX="3"
-_IW_START_RETRY_SLEEP="${IW_START_RETRY_SLEEP:-2}"
+_IW_START_RETRY_SLEEP="${IW_START_RETRY_SLEEP:-13}"
 
 # Rate-limit gate (issue #1436; judgment input rebuilt in #1444). Rationale for
 # each value sits with the gate functions below; the values themselves live here

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -121,6 +121,14 @@ _PMT_IDLE_POLL_SLEEP="${PMT_IDLE_POLL_SLEEP:-0.5}"
 # the reuse path prompts a session that has been up for a whole cron period and
 # must not pay 13s per PR. Overridable (to 0) so the bats suite does not sleep
 # for real.
+#
+# 13 is the repo-wide constant for "herdr just brought something up, wait
+# before touching it" (#1571). Its four twins are _PMT_START_RETRY_SLEEP below,
+# _IW_SETTLE_SECONDS / _IW_START_RETRY_SLEEP in issue_watcher_cron.sh, and
+# PMV_SETTLE_SECONDS in
+# claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md. Change one,
+# change all five — #1530/#1549 and #1560/#1571 are both the same defect
+# recurring because only two of the three dispatchers were fixed.
 _PMT_SETTLE_SECONDS="${PMT_SETTLE_SECONDS:-13}"
 
 # `herdr agent start` attempts on a freshly created pane (see _pmt_launch_fresh,
@@ -134,8 +142,17 @@ _PMT_SETTLE_SECONDS="${PMT_SETTLE_SECONDS:-13}"
 # so the `attempt N/MAX` warning reads exactly true. The gap between them is
 # overridable for the same reason _PMT_IDLE_POLL_SLEEP is — the bats suite pays
 # no real sleep.
+#
+# The gap is 13s, not the 2s it shipped with (#1571): this is the *same* class
+# of wait as _PMT_SETTLE_SECONDS above — herdr answered before the thing it
+# brought up was usable — and 2s was shorter than the 5s already measured to
+# fail. Its twins are _PMT_SETTLE_SECONDS above, _IW_SETTLE_SECONDS /
+# _IW_START_RETRY_SLEEP in issue_watcher_cron.sh, and PMV_SETTLE_SECONDS in
+# claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md; all five
+# move together. The wait and this retry are complements, not substitutes — 13s
+# shrinks the race, the retry survives what is left of it.
 _PMT_START_ATTEMPT_MAX="3"
-_PMT_START_RETRY_SLEEP="${PMT_START_RETRY_SLEEP:-2}"
+_PMT_START_RETRY_SLEEP="${PMT_START_RETRY_SLEEP:-13}"
 
 # CLAUDE_CONFIG_DIR for the pane this tick opens. Resolved once, and only on
 # the path that actually opens one (see _pmt_bind_config_dir).

--- a/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
@@ -417,7 +417,7 @@ pmv_agent_prompt() {
 gh_pr_post_merge_verify() {
     local _pr="$1" _repo="$2" _host="$3" _main="$4" _branch="$5" _file="$6"
     local _remote="${7:-origin}" _base="${8-}"
-    local _skill _rc _wt _tab _tabrc _ws _pane _agent _newtab _out _code _fresh
+    local _skill _rc _wt _tab _tabrc _ws _pane _agent _newtab _out _code
 
     _skill=$(pmv_gate "$_file" "$_repo")
     _rc=$?
@@ -496,7 +496,6 @@ gh_pr_post_merge_verify() {
     # for here rather than right after the tab create so a repo whose name
     # cannot be derived skips out without paying 13s first.
     pmv_settle
-    _fresh=1
     if ! _out=$(pmv_agent_start "$_agent" "$_pane"); then
         # Race backstop, same as _pmt_launch_fresh: the name can be claimed
         # between the probe and the start, and its holder is by definition a
@@ -507,13 +506,14 @@ gh_pr_post_merge_verify() {
                 "$_agent" "$_pane" "${_code:-unknown}"
             return 0
         fi
+        # This session was already registered, so it has been up for a while
+        # and takes the prompt at once — no need to pay the settle wait below.
         printf '[WARN] gh:pr-post-merge-verify: agent %s already registered — prompting the existing session.\n' "$_agent"
-        _fresh=0
+    else
+        # A just-started claude is idle but not yet listening (#1571) — this
+        # settle wait is what lets it start listening before the prompt lands.
+        pmv_settle
     fi
-    # A just-started claude is idle but not yet listening; a session that was
-    # already registered has been up for a while, so the fallback path must not
-    # pay this (same rule as _pmt_launch_fresh).
-    [ "$_fresh" = "0" ] || pmv_settle
 
     # --- 6. hand the verification over ---
     if ! _out=$(pmv_agent_prompt "$_agent" "$(pmv_verify_prompt "$_skill" "$_pr")"); then

--- a/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
@@ -38,6 +38,15 @@ _pmv_herdr() {
     return "${!_rc:-0}"
 }
 
+# Stand-in for `sleep`. Records the wait into the herdr log instead of paying
+# it, so the settle waits (#1571) can be asserted — and ordered against the
+# herdr calls they sit between — without the suite sleeping 26 real seconds per
+# dispatch test.
+_pmv_sleep() {
+    [ -z "${FAKE_HERDR_LOG-}" ] || printf 'sleep %s\n' "$1" >>"$FAKE_HERDR_LOG"
+    return 0
+}
+
 # Stand-in for `git -C <root> worktree list --porcelain`.
 _pmv_git_worktree_list() {
     printf '%s' "${FAKE_WORKTREE_PORCELAIN-}"
@@ -374,6 +383,18 @@ pmv_agent_start() {
     _pmv_herdr agent start "$1" --kind claude --pane "$2" -- --dangerously-skip-permissions
 }
 
+# Mirrors dispatch.sh.md's `pmv_settle`: one settle wait for both of this
+# repo's herdr races — `tab create` -> `agent start` (the pane's shell is not
+# interactive yet, `agent_pane_busy`) and `agent start` -> `agent prompt` (a
+# fresh claude TUI reports idle while its key-input loop is still unattached,
+# #1560). 13s is the repo standard; the twins are _IW_SETTLE_SECONDS /
+# _IW_START_RETRY_SLEEP and _PMT_SETTLE_SECONDS / _PMT_START_RETRY_SLEEP.
+# `0` disables it, the same escape _IW_IDLE_POLL_SLEEP has.
+pmv_settle() {
+    local _s="${PMV_SETTLE_SECONDS:-13}"
+    [ "$_s" = "0" ] || _pmv_sleep "$_s"
+}
+
 # pmv_agent_prompt <agent> <text>. Same contract as pmv_agent_start.
 pmv_agent_prompt() {
     _pmv_herdr agent prompt "$1" "$2" \
@@ -396,7 +417,7 @@ pmv_agent_prompt() {
 gh_pr_post_merge_verify() {
     local _pr="$1" _repo="$2" _host="$3" _main="$4" _branch="$5" _file="$6"
     local _remote="${7:-origin}" _base="${8-}"
-    local _skill _rc _wt _tab _tabrc _ws _pane _agent _newtab _out _code
+    local _skill _rc _wt _tab _tabrc _ws _pane _agent _newtab _out _code _fresh
 
     _skill=$(pmv_gate "$_file" "$_repo")
     _rc=$?
@@ -471,6 +492,11 @@ gh_pr_post_merge_verify() {
         printf '[WARN] gh:pr-post-merge-verify: cannot derive an agent name for %s — verification skipped.\n' "$_repo"
         return 0
     fi
+    # The pane is seconds old and its shell may not be interactive yet. Waited
+    # for here rather than right after the tab create so a repo whose name
+    # cannot be derived skips out without paying 13s first.
+    pmv_settle
+    _fresh=1
     if ! _out=$(pmv_agent_start "$_agent" "$_pane"); then
         # Race backstop, same as _pmt_launch_fresh: the name can be claimed
         # between the probe and the start, and its holder is by definition a
@@ -482,7 +508,12 @@ gh_pr_post_merge_verify() {
             return 0
         fi
         printf '[WARN] gh:pr-post-merge-verify: agent %s already registered — prompting the existing session.\n' "$_agent"
+        _fresh=0
     fi
+    # A just-started claude is idle but not yet listening; a session that was
+    # already registered has been up for a while, so the fallback path must not
+    # pay this (same rule as _pmt_launch_fresh).
+    [ "$_fresh" = "0" ] || pmv_settle
 
     # --- 6. hand the verification over ---
     if ! _out=$(pmv_agent_prompt "$_agent" "$(pmv_verify_prompt "$_skill" "$_pr")"); then

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -1000,16 +1000,17 @@ JSON
 }
 
 @test "1571: dispatch.sh.md settles between agent start and agent prompt, fresh only" {
-    local _doc _start _guard _prompt
+    local _doc _start _settle _prompt
     _doc="$(_pmv_dispatch_doc)"
     _start=$(grep -n 'herdr agent start "\$PMV_AGENT"' "$_doc" | head -1 | cut -d: -f1)
-    _guard=$(grep -n '^\[ "\$PMV_FRESH_START" = "0" \] || pmv_settle$' "$_doc" | head -1 | cut -d: -f1)
+    _settle=$(grep -n 'pmv_settle$' "$_doc" | awk -F: -v s="$_start" '$1 > s {print $1; exit}' | cut -d: -f1)
     _prompt=$(grep -n 'herdr agent prompt "\$PMV_AGENT"' "$_doc" | head -1 | cut -d: -f1)
-    [ -n "$_start" ] && [ -n "$_guard" ] && [ -n "$_prompt" ]
-    [ "$_start" -lt "$_guard" ]
-    [ "$_guard" -lt "$_prompt" ]
-    # The fallback branch is the one that clears the flag.
-    run grep -qF -- 'PMV_FRESH_START=0' "$_doc"
+    [ -n "$_start" ] && [ -n "$_settle" ] && [ -n "$_prompt" ]
+    [ "$_start" -lt "$_settle" ]
+    [ "$_settle" -lt "$_prompt" ]
+    # The settle call sits in the `else` branch of the start guard — reached
+    # only on a fresh start, never on the agent_name_taken fallback path.
+    run grep -qF -- 'already registered — prompting the existing session' "$_doc"
     assert_success
 }
 

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -80,7 +80,7 @@ branch refs/heads/wt/issue-77/1
 
 teardown() {
     teardown_isolated_home
-    unset PMV_PROMPT_TIMEOUT_MS
+    unset PMV_PROMPT_TIMEOUT_MS PMV_SETTLE_SECONDS
     unset FAKE_HERDR_PRESENT FAKE_JQ_PRESENT FAKE_HERDR_LOG FAKE_GIT_LOG FAKE_WORKTREE_PORCELAIN \
         FAKE_WORKTREE_RC FAKE_MAIN_DIRTY FAKE_SYNC_RC FAKE_MAIN_BRANCH FAKE_MAIN_TOPLEVEL \
         FAKE_HERDR_OUT_AGENT_LIST FAKE_HERDR_OUT_WORKTREE_LIST \
@@ -93,6 +93,13 @@ dispatch() {
     gh_pr_post_merge_verify 77 "${1:-acme/dotfiles}" github.com "$MAIN_ROOT" wt/issue-77/1 \
         "$WATCHED" "${2-}" "${3-}"
 }
+
+# The settle waits (#1571) are recorded into the herdr log by the fixture's
+# `_pmv_sleep`, so their *order* against `tab create` / `agent start` /
+# `agent prompt` is assertable — a wait that lands on the wrong side of a call
+# is exactly the defect, and a "did it sleep at all" check would miss it.
+_pmv_log_line() { grep -n -- "$1" "$FAKE_HERDR_LOG" | head -1 | cut -d: -f1; }
+_pmv_log_count() { grep -c -- "$1" "$FAKE_HERDR_LOG" || true; }
 
 # --- F-1: the watched-repos.json gate -------------------------------------
 
@@ -862,5 +869,205 @@ JSON
     run grep -qF -- 'Print **only** the compact report' "$_skill"
     assert_success
     run grep -qF -- 'no output, no' "$_skill"
+    assert_success
+}
+
+# --- #1571: the herdr settle waits ----------------------------------------
+#
+# Two calls in this dispatch bring something up that is not usable the instant
+# herdr answers: `tab create` returns a pane whose shell is not interactive yet
+# (`agent start` on it is refused with `agent_pane_busy`), and `agent start`
+# returns `"agent_status":"idle"` for a claude TUI whose key-input loop is not
+# attached yet (the prompt is swallowed and the session sits empty — the #1571
+# report). ~5s was measured to fail every time and ~13s to land (#1560), so 13
+# is the repo standard at both points.
+#
+# Observed by the recorded `sleep` calls, never by wall clock: a timing test
+# that measured elapsed seconds would make the suite pay 26 real seconds per
+# dispatch and still not prove where in the sequence the wait fell.
+
+@test "1571: a fresh dispatch settles before agent start AND before the prompt" {
+    run dispatch
+    assert_success
+    [ "$(_pmv_log_count '^sleep 13$')" -eq 2 ]
+    local _tab _s1 _start _s2 _prompt
+    _tab=$(_pmv_log_line 'herdr tab create')
+    _start=$(_pmv_log_line 'herdr agent start')
+    _prompt=$(_pmv_log_line 'herdr agent prompt')
+    _s1=$(grep -n '^sleep 13$' "$FAKE_HERDR_LOG" | sed -n '1p' | cut -d: -f1)
+    _s2=$(grep -n '^sleep 13$' "$FAKE_HERDR_LOG" | sed -n '2p' | cut -d: -f1)
+    # tab create < settle < agent start < settle < agent prompt
+    [ "$_tab" -lt "$_s1" ]
+    [ "$_s1" -lt "$_start" ]
+    [ "$_start" -lt "$_s2" ]
+    [ "$_s2" -lt "$_prompt" ]
+}
+
+@test "1571: the agent_name_taken fallback settles the pane but not the prompt" {
+    # The pane is still brand new, so the wait before `agent start` is owed
+    # either way; the session the fallback prompts was started by someone else
+    # and is warm by definition, so the second wait is not (#1571 D-2, the same
+    # rule _pmt_launch_fresh follows).
+    FAKE_HERDR_RC_AGENT_START=1
+    FAKE_HERDR_OUT_AGENT_START='{"error":{"code":"agent_name_taken"}}'
+    run dispatch
+    assert_success
+    assert_output --partial "already registered — prompting the existing session"
+    [ "$(_pmv_log_count '^sleep 13$')" -eq 1 ]
+    local _s _start _prompt
+    _s=$(_pmv_log_line '^sleep 13$')
+    _start=$(_pmv_log_line 'herdr agent start')
+    _prompt=$(_pmv_log_line 'herdr agent prompt')
+    [ "$_s" -lt "$_start" ]
+    [ "$_prompt" -gt "$_start" ]
+}
+
+@test "1571: a failed agent start never reaches the prompt settle" {
+    FAKE_HERDR_RC_AGENT_START=1
+    FAKE_HERDR_OUT_AGENT_START='{"error":{"code":"pane_not_ready"}}'
+    run dispatch
+    assert_success
+    assert_output --partial "herdr agent start mv-dotfiles-pr-77 failed"
+    # Only the pre-start wait ran; the dispatch stopped before the prompt one.
+    [ "$(_pmv_log_count '^sleep 13$')" -eq 1 ]
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "agent prompt"
+}
+
+@test "1571: a failed tab create never settles at all" {
+    FAKE_HERDR_RC_TAB_CREATE=1
+    run dispatch
+    assert_success
+    assert_output --partial "herdr tab create failed for label pr-77"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "sleep"
+}
+
+@test "1571: a repo with no derivable agent name settles neither wait" {
+    # The wait sits after the name derivation on purpose: a repo that cannot
+    # produce a herdr-legal name skips out, and paying 13s first would be pure
+    # waste on a path that never touches the pane again.
+    cat >"$WATCHED" <<'JSON'
+{ "acme/...": { "verify_skill": "devx:pr-verify-merged" } }
+JSON
+    run dispatch 'acme/...'
+    assert_success
+    assert_output --partial "cannot derive an agent name"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "sleep"
+}
+
+@test "1571: PMV_SETTLE_SECONDS=0 removes both waits" {
+    # The bats suite must never sleep 13 real seconds twice per dispatch — the
+    # same escape hatch _IW_IDLE_POLL_SLEEP established.
+    export PMV_SETTLE_SECONDS=0
+    run dispatch
+    assert_success
+    assert_output --partial "post-merge verification dispatched"
+    run cat "$FAKE_HERDR_LOG"
+    assert_output --partial "agent start mv-dotfiles-pr-77"
+    assert_output --partial "agent prompt mv-dotfiles-pr-77"
+    refute_output --partial "sleep"
+}
+
+@test "1571: PMV_SETTLE_SECONDS overrides the duration at both points" {
+    export PMV_SETTLE_SECONDS=7
+    run dispatch
+    assert_success
+    [ "$(_pmv_log_count '^sleep 7$')" -eq 2 ]
+    [ "$(_pmv_log_count '^sleep 13$')" -eq 0 ]
+}
+
+# --- #1571: the shipped block, not just the mirror -------------------------
+
+@test "1571: dispatch.sh.md declares the settle constant with the 13s default" {
+    run grep -qF -- 'PMV_SETTLE_SECONDS="${PMV_SETTLE_SECONDS:-13}"' "$(_pmv_dispatch_doc)"
+    assert_success
+    run grep -qF -- 'pmv_settle() { [ "$PMV_SETTLE_SECONDS" = "0" ] || sleep "$PMV_SETTLE_SECONDS"; }' \
+        "$(_pmv_dispatch_doc)"
+    assert_success
+}
+
+@test "1571: dispatch.sh.md settles between tab create and agent start" {
+    local _doc _tab _settle _start
+    _doc="$(_pmv_dispatch_doc)"
+    _tab=$(grep -n 'TAB_JSON=$(herdr tab create' "$_doc" | head -1 | cut -d: -f1)
+    _settle=$(grep -n '^pmv_settle$' "$_doc" | head -1 | cut -d: -f1)
+    _start=$(grep -n 'herdr agent start "\$PMV_AGENT"' "$_doc" | head -1 | cut -d: -f1)
+    [ -n "$_tab" ] && [ -n "$_settle" ] && [ -n "$_start" ]
+    [ "$_tab" -lt "$_settle" ]
+    [ "$_settle" -lt "$_start" ]
+}
+
+@test "1571: dispatch.sh.md settles between agent start and agent prompt, fresh only" {
+    local _doc _start _guard _prompt
+    _doc="$(_pmv_dispatch_doc)"
+    _start=$(grep -n 'herdr agent start "\$PMV_AGENT"' "$_doc" | head -1 | cut -d: -f1)
+    _guard=$(grep -n '^\[ "\$PMV_FRESH_START" = "0" \] || pmv_settle$' "$_doc" | head -1 | cut -d: -f1)
+    _prompt=$(grep -n 'herdr agent prompt "\$PMV_AGENT"' "$_doc" | head -1 | cut -d: -f1)
+    [ -n "$_start" ] && [ -n "$_guard" ] && [ -n "$_prompt" ]
+    [ "$_start" -lt "$_guard" ]
+    [ "$_guard" -lt "$_prompt" ]
+    # The fallback branch is the one that clears the flag.
+    run grep -qF -- 'PMV_FRESH_START=0' "$_doc"
+    assert_success
+}
+
+@test "1571: dispatch.sh.md does not grow a fourth agent_pane_busy retry loop" {
+    # #1569 unifies the three dispatchers' start logic; a hand-rolled retry
+    # here would be a copy that unification has to undo (#1571 D-3). Comment
+    # lines are skipped — the rationale for NOT retrying names the error code
+    # it is about (same carve-out as R-6 above).
+    run bash -c "grep -vE '^[[:space:]]*#' '$(_pmv_dispatch_doc)' | grep -n 'agent_pane_busy'"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+# --- #1571: the cross-file drift guard ------------------------------------
+#
+# This repo has now shipped the same defect twice by fixing two of the three
+# herdr dispatchers (#1530 -> #1549, #1560 -> #1571). The comments name each
+# other; this pins the values, so the third site cannot quietly stay behind.
+
+_pmv_wait_files() {
+    printf '%s\n' \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/custom/issue_watcher_cron.sh" \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/custom/pr_merge_train_cron.sh" \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md"
+}
+
+_PMV_WAIT_ASSIGN='^(_IW_SETTLE_SECONDS|_PMT_SETTLE_SECONDS|PMV_SETTLE_SECONDS|_IW_START_RETRY_SLEEP|_PMT_START_RETRY_SLEEP)='
+
+@test "1571: all five herdr wait constants exist across the three dispatchers" {
+    local _n
+    _n=$(_pmv_wait_files | xargs grep -hE "$_PMV_WAIT_ASSIGN" | wc -l)
+    [ "$_n" -eq 5 ]
+}
+
+@test "1571: no herdr wait constant has drifted off 13" {
+    local _bad
+    _bad=$(_pmv_wait_files | xargs grep -hE "$_PMV_WAIT_ASSIGN" | grep -vE ':-13\}"$' || true)
+    [ -z "$_bad" ] || fail "wait constant not defaulted to 13: ${_bad}"
+}
+
+@test "1571: every herdr wait constant stays env-overridable" {
+    local _bad
+    _bad=$(_pmv_wait_files | xargs grep -hE "$_PMV_WAIT_ASSIGN" |
+        grep -vE '="\$\{[A-Z_]+:-13\}"$' || true)
+    [ -z "$_bad" ] || fail "wait constant is not env-overridable: ${_bad}"
+}
+
+@test "1571: the three dispatchers' wait comments name each other" {
+    local _iw _pmt _doc
+    _iw="${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/custom/issue_watcher_cron.sh"
+    _pmt="${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/custom/pr_merge_train_cron.sh"
+    _doc="$(_pmv_dispatch_doc)"
+    run grep -qF -- 'PMV_SETTLE_SECONDS' "$_iw"
+    assert_success
+    run grep -qF -- 'PMV_SETTLE_SECONDS' "$_pmt"
+    assert_success
+    run grep -qF -- '_IW_SETTLE_SECONDS' "$_doc"
+    assert_success
+    run grep -qF -- '_PMT_SETTLE_SECONDS' "$_doc"
     assert_success
 }

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1893,6 +1893,45 @@ _two_repo_fixture() {
     assert_output --partial "retrying in 0s"
 }
 
+# The gap itself is 13s since #1571, not the 2s this shipped with: `tab create`
+# answering before the pane's shell is interactive is the *same* class of race
+# as the settle wait above, and 2s was shorter than the 5s already measured to
+# fail. Asserted through the message rather than a `sleep` line because the
+# settle wait logs `sleep 13` too — the sentence is what pins which wait this is.
+@test "issue_watcher_cron: the start retry gap defaults to 13s" {
+    # An empty assignment beats _run_tick's own `IW_START_RETRY_SLEEP=0` and
+    # still lets `${IW_START_RETRY_SLEEP:-13}` fall through to the default.
+    _run_tick "HERDR_START_PANE_BUSY=1" "IW_START_RETRY_SLEEP="
+    assert_success
+    assert_output --partial "retrying in 13s"
+}
+
+@test "issue_watcher_cron: the start retry gap stays env-overridable" {
+    _run_tick "HERDR_START_PANE_BUSY=1" "IW_START_RETRY_SLEEP=4"
+    assert_success
+    assert_output --partial "retrying in 4s"
+    refute_output --partial "retrying in 13s"
+}
+
+# The SSOT line itself, so a change that only moves the default out of the
+# ${VAR:-13} form (and with it the `0` escape the suite depends on) is caught
+# here rather than as a mysteriously slow suite.
+@test "issue_watcher_cron: both herdr wait constants are 13 and overridable" {
+    run grep -qF -- '_IW_SETTLE_SECONDS="${IW_SETTLE_SECONDS:-13}"' "${SCRIPT}"
+    assert_success
+    run grep -qF -- '_IW_START_RETRY_SLEEP="${IW_START_RETRY_SLEEP:-13}"' "${SCRIPT}"
+    assert_success
+}
+
+# #1530/#1549 and #1560/#1571 were both "two of the three dispatchers were
+# fixed". The comment naming the other two is the guard against a third round.
+@test "issue_watcher_cron: the wait comments name the other two dispatchers" {
+    run grep -qF -- '_PMT_SETTLE_SECONDS' "${SCRIPT}"
+    assert_success
+    run grep -qF -- 'PMV_SETTLE_SECONDS' "${SCRIPT}"
+    assert_success
+}
+
 # The inner retrying is bounded, and the bound is the point: cron re-runs every
 # few minutes anyway. Three inner *attempts* per outer attempt, three outer
 # attempts — the two layers are independent and both still hold.

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -677,6 +677,45 @@ _hold_lock() {
     _assert_logged "/gh-pr-merge-train acme/dotfiles"
 }
 
+# The gap itself is 13s since #1571, not the 2s this shipped with: `tab create`
+# answering before the pane's shell is interactive is the *same* class of race
+# as the settle wait above, and 2s was shorter than the 5s already measured to
+# fail. Asserted through the message rather than a `sleep` line because the
+# settle wait logs `sleep 13` too — the sentence is what pins which wait this is.
+@test "pr_merge_train_cron: the start retry gap defaults to 13s" {
+    # An empty assignment beats _run_tick's own `PMT_START_RETRY_SLEEP=0` and
+    # still lets `${PMT_START_RETRY_SLEEP:-13}` fall through to the default.
+    _run_tick HERDR_START_PANE_BUSY=1 "PMT_START_RETRY_SLEEP="
+    assert_success
+    assert_output --partial "retrying in 13s"
+}
+
+@test "pr_merge_train_cron: the start retry gap stays env-overridable" {
+    _run_tick HERDR_START_PANE_BUSY=1 "PMT_START_RETRY_SLEEP=4"
+    assert_success
+    assert_output --partial "retrying in 4s"
+    refute_output --partial "retrying in 13s"
+}
+
+# The SSOT lines themselves, so a change that only moves a default out of the
+# ${VAR:-13} form (and with it the `0` escape the suite depends on) is caught
+# here rather than as a mysteriously slow suite.
+@test "pr_merge_train_cron: both herdr wait constants are 13 and overridable" {
+    run grep -qF -- '_PMT_SETTLE_SECONDS="${PMT_SETTLE_SECONDS:-13}"' "${SCRIPT}"
+    assert_success
+    run grep -qF -- '_PMT_START_RETRY_SLEEP="${PMT_START_RETRY_SLEEP:-13}"' "${SCRIPT}"
+    assert_success
+}
+
+# #1530/#1549 and #1560/#1571 were both "two of the three dispatchers were
+# fixed". The comment naming the other two is the guard against a third round.
+@test "pr_merge_train_cron: the wait comments name the other two dispatchers" {
+    run grep -qF -- '_IW_SETTLE_SECONDS' "${SCRIPT}"
+    assert_success
+    run grep -qF -- 'PMV_SETTLE_SECONDS' "${SCRIPT}"
+    assert_success
+}
+
 # The retrying is bounded, and the bound is the whole point: cron re-runs every
 # few minutes anyway, so a tick that kept trying would only hold the lock
 # while the *next* tick is the thing that should be deciding. Three *attempts*


### PR DESCRIPTION
## Summary
- `gh:pr-post-merge-verify` 디스패치 블록에만 herdr 정착 대기가 빠져 있어, `agent start` 직후 `agent prompt` 가 아직 키 입력 루프가 붙지 않은 claude TUI 에 삼켜지고 있었다 — 탭과 agent 는 뜨지만 검증이 한 줄도 실행되지 않는 빈 껍데기가 남는 결함(#1560 이 다른 두 디스패처에서만 고쳤던 것).
- 이슈 코멘트로 범위가 확대되어, `tab create` → `agent start` 경쟁까지 포함해 herdr 관련 대기 값을 저장소 표준인 13초로 세 디스패처 전부 통일했다.

## Changes
- `dispatch.sh.md`: `PMV_SETTLE_SECONDS`(기본 13, `0`이면 비활성)와 `pmv_settle`을 추가해 `tab create` → `agent start`, `agent start` → `agent prompt` 두 지점에 적용. `agent_name_taken` fallback(이미 따뜻한 세션)은 제외.
- `issue_watcher_cron.sh` / `pr_merge_train_cron.sh`: `_IW_START_RETRY_SLEEP` / `_PMT_START_RETRY_SLEEP` 을 2초 → 13초로 상향(같은 클래스의 대기인데 실측 실패 임계값인 5초보다도 짧았음).
- 세 파일 다섯 상수의 주석이 서로를 가리키도록 교차 링크 — #1530/#1549, #1560/#1571 이 모두 "셋 중 둘만 고침" 재발 패턴이었기 때문.
- 픽스처 미러(`gh_pr_post_merge_verify.sh`)를 프로덕션 블록과 함께 갱신.
- `docs/public/changelog.d/2026-08-28-1571.md` 추가.

## Test plan
- [x] `tests/bats/skills/gh_pr_post_merge_verify.bats` — 대기 위치·횟수·오버라이드 pin, 전량 통과.
- [x] `tests/bats/tools/issue_watcher_cron.bats`, `tests/bats/tools/pr_merge_train_cron.bats` — 재시도 간격 13초·오버라이드 pin, 전량 통과.
- [ ] 실측: 다음 PR 머지 후 `mv-<repo>-pr-<N>` 팬이 `working` 으로 전이하고 검증 리포트가 게시되는지 확인.

## Related
Closes #1571

---
<details>
<summary>🤖 AI Metrics · 📊 ~8500 tokens · 👤 ~2 h · 🤖 ~6 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~8500 tokens · 👤 ~2 h · 🤖 ~6 min
<!-- /ai-metrics:gh-pr -->

</details>
