### PR TITLE
fix(issue-watcher): agent prompt 실패 원인 파싱을 복구하고 working agent 철거를 막는다

### DIFF
--- a/docs/public/changelog.d/2026-08-28-1559.md
+++ b/docs/public/changelog.d/2026-08-28-1559.md
@@ -1,0 +1,1 @@
+- 변경: **issue-watcher 의 agent prompt 실패 원인 파싱을 복구하고, working 중인 agent 는 정리 대상에서 제외한다**

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -1463,8 +1463,16 @@ _iw_settle() {
 }
 
 # Echo herdr's JSON response on stdout; the exit code is herdr's own.
+#
+# herdr writes its error JSON to stderr and its success payload to stdout, so
+# the two must be merged here — dropping stderr leaves `.error.code` unreadable
+# and every recovery branch below unreachable (#1559, the same defect class as
+# #1445/#1458/#1525). Merged rather than split into a capture file the way
+# _iw_agent_start does: the only reader is `_iw_json_value '.error.code'`, which
+# already fails silently on non-JSON noise, and the success path never reaches
+# it — rc 0 short-circuits ahead of the parse.
 _iw_prompt_once() {
-    herdr agent prompt "$1" "$2" --wait --timeout "${_IW_TIMEOUT_MS}" 2>/dev/null
+    herdr agent prompt "$1" "$2" --wait --timeout "${_IW_TIMEOUT_MS}" 2>&1
 }
 
 # Recover a stalled prompt by *submitting* what is already typed (issue #1443).
@@ -1642,6 +1650,19 @@ EOF
             elif _iw_wait_for_idle "${_agent}" && _iw_settle &&
                 _iw_prompt_issue "${_agent}" "${_number}"; then
                 ux_success "${_repo}#${_number} dispatched (worktree ${_wt}, pane ${_pane})."
+                return 0
+            elif [ "$(_iw_agent_status "${_agent}")" = "working" ]; then
+                # A `working` agent is never torn down, whatever the dispatch
+                # reported (#1559). One tick killed a session that was doing
+                # real work three times over, because a failed attempt ran
+                # _iw_cleanup_attempt unconditionally — the prompt call had
+                # failed, the agent had not. Deliberately independent of the
+                # `.error.code` fix in _iw_prompt_once: that parsing is what
+                # silently broke in production, so it is not the only thing
+                # standing between a live session and `gwt remove`.
+                # Only `working` counts — an empty answer is an unreachable
+                # agent, not evidence of work, and still cleans up below.
+                ux_warning "${_agent} reports working despite the failed prompt — keeping worktree ${_wt} and pane ${_pane}, not retrying."
                 return 0
             fi
         fi

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -1647,23 +1647,33 @@ EOF
                 [ -z "${_cause}" ] || _msg="${_msg}
     원인: ${_cause}"
                 ux_warning "${_msg}"
-            elif _iw_wait_for_idle "${_agent}" && _iw_settle &&
-                _iw_prompt_issue "${_agent}" "${_number}"; then
-                ux_success "${_repo}#${_number} dispatched (worktree ${_wt}, pane ${_pane})."
-                return 0
-            elif [ "$(_iw_agent_status "${_agent}")" = "working" ]; then
-                # A `working` agent is never torn down, whatever the dispatch
-                # reported (#1559). One tick killed a session that was doing
-                # real work three times over, because a failed attempt ran
-                # _iw_cleanup_attempt unconditionally — the prompt call had
-                # failed, the agent had not. Deliberately independent of the
-                # `.error.code` fix in _iw_prompt_once: that parsing is what
-                # silently broke in production, so it is not the only thing
-                # standing between a live session and `gwt remove`.
-                # Only `working` counts — an empty answer is an unreachable
-                # agent, not evidence of work, and still cleans up below.
-                ux_warning "${_agent} reports working despite the failed prompt — keeping worktree ${_wt} and pane ${_pane}, not retrying."
-                return 0
+            elif _iw_wait_for_idle "${_agent}" && _iw_settle; then
+                if _iw_prompt_issue "${_agent}" "${_number}"; then
+                    ux_success "${_repo}#${_number} dispatched (worktree ${_wt}, pane ${_pane})."
+                    return 0
+                elif [ "$(_iw_agent_status "${_agent}")" = "working" ]; then
+                    # A `working` agent is never torn down, whatever the dispatch
+                    # reported (#1559). One tick killed a session that was doing
+                    # real work three times over, because a failed attempt ran
+                    # _iw_cleanup_attempt unconditionally — the prompt call had
+                    # failed, the agent had not. Deliberately independent of the
+                    # `.error.code` fix in _iw_prompt_once: that parsing is what
+                    # silently broke in production, so it is not the only thing
+                    # standing between a live session and `gwt remove`.
+                    # Only `working` counts — an empty answer is an unreachable
+                    # agent, not evidence of work, and still cleans up below.
+                    #
+                    # Scoped to *after* _iw_prompt_issue actually ran (agy/codex
+                    # PR #1578 review): this branch used to sit alongside
+                    # _iw_wait_for_idle in the same `&&` chain, so a plain idle
+                    # timeout — the prompt for THIS issue never even sent — could
+                    # also match "working" (the agent busy with unrelated, stale
+                    # state) and get reported as delivered. Nesting it here means
+                    # the guard only ever fires once a prompt attempt for this
+                    # issue was actually made.
+                    ux_warning "${_agent} reports working despite the failed prompt — keeping worktree ${_wt} and pane ${_pane}, not retrying."
+                    return 0
+                fi
             fi
         fi
 

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -313,6 +313,12 @@ EOF
 #                               fail        every call a non-stall error
 #   HERDR_PROMPT_FAIL_TIMES   first N `agent prompt` calls stall, then ok
 #
+# Every one of those failures writes its error document to **stderr** and only
+# the success payload to stdout — the same split `agent start` already models
+# above, measured on a live herdr (issue #1559). A dispatcher that sends that
+# stream to /dev/null reads every failure as `(unknown)`, which is what made
+# both recovery branches below dead code in production.
+#
 # Stall recovery (issue #1443). A stall leaves the command typed but unsent, so
 # the tick presses Enter rather than retyping; `state_change_seq` is what proves
 # the keystroke landed.
@@ -479,7 +485,7 @@ case "$1 $2" in
     if [ -n "${HERDR_PROMPT_FAIL_TIMES:-}" ]; then
         _n=$(_bump "${CALL_LOG}.promptcount")
         if [ "${_n}" -le "${HERDR_PROMPT_FAIL_TIMES}" ]; then
-            printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}'
+            printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}' >&2
             exit 1
         fi
         printf '%s\n' '{"id":"cli:agent:prompt","result":{"ok":true}}'
@@ -487,11 +493,11 @@ case "$1 $2" in
     fi
     case "${HERDR_PROMPT_MODE:-ok}" in
     stall)
-        printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}'
+        printf '%s\n' '{"error":{"code":"agent_prompt_stalled","message":"no agent state change observed within 5000ms"},"id":"cli:agent:prompt"}' >&2
         exit 1
         ;;
     fail)
-        printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target not found"},"id":"cli:agent:prompt"}'
+        printf '%s\n' '{"error":{"code":"agent_not_found","message":"agent target not found"},"id":"cli:agent:prompt"}' >&2
         exit 1
         ;;
     esac
@@ -2137,6 +2143,95 @@ _two_repo_fixture() {
     run cat "${_LIMIT_FILE}"
     assert_output --partial '"strikes": "1"'
     refute_output --partial '"strikes": "2"'
+}
+
+# ---------------------------------------------------------------------------
+# The prompt error document arrives on stderr (issue #1559)
+# ---------------------------------------------------------------------------
+#
+# `_iw_prompt_once` used to send stderr to /dev/null, and herdr answers a failed
+# `agent prompt` on exactly that stream. So `.error.code` was empty on every
+# failure, every branch keyed on it was unreachable, and every cron line read
+# `(unknown)`. These pin the code back to the name herdr gave it — the whole
+# suite above only ever passed because the stub answered on stdout.
+
+@test "issue_watcher_cron: a stall herdr reported on stderr is still named agent_prompt_stalled" {
+    _run_tick "HERDR_PROMPT_MODE=stall" "HERDR_AGENT_STATUS=idle"
+    assert_failure
+    assert_output --partial "herdr agent prompt failed for agent iw-dotfiles-issue-11 (agent_prompt_stalled)"
+    refute_output --partial "(unknown)"
+}
+
+@test "issue_watcher_cron: a stall on stderr still reaches the already-working short-circuit" {
+    _run_tick "HERDR_PROMPT_MODE=stall" "HERDR_AGENT_STATUS=working"
+    assert_success
+    assert_output --partial "treating as delivered"
+    # The branch is reachable only when `.error.code` parses, so a silent
+    # regression to `2>/dev/null` would press Enter into a busy pane instead.
+    _refute_logged "agent send-keys"
+}
+
+@test "issue_watcher_cron: a stall on stderr still triggers the Enter recovery" {
+    _run_tick "HERDR_PROMPT_MODE=stall" "HERDR_AGENT_STATUS=idle" "HERDR_SENDKEYS_MODE=ok"
+    assert_success
+    _assert_logged "agent send-keys iw-dotfiles-issue-11 Enter"
+    assert_output --partial "Dispatched to iw-dotfiles-issue-11"
+}
+
+@test "issue_watcher_cron: a failed send-keys outranks the stall code it recovered from" {
+    _run_tick "HERDR_PROMPT_MODE=stall" "HERDR_AGENT_STATUS=idle" "HERDR_SENDKEYS_MODE=fail"
+    assert_failure
+    assert_output --partial "herdr_send_keys_failed"
+    refute_output --partial "(unknown)"
+}
+
+@test "issue_watcher_cron: a non-stall failure on stderr is named, not reported as unknown" {
+    _run_tick "HERDR_PROMPT_MODE=fail"
+    assert_failure
+    assert_output --partial "herdr agent prompt failed for agent iw-dotfiles-issue-11 (agent_not_found)"
+    refute_output --partial "(unknown)"
+}
+
+# ---------------------------------------------------------------------------
+# A working agent is never torn down (issue #1559 follow-up)
+# ---------------------------------------------------------------------------
+#
+# The incident: a session that was dispatched and doing real work was torn down
+# three times in one tick, because a failed attempt ran _iw_cleanup_attempt
+# unconditionally. Independent of the error-code fix above on purpose — that
+# parsing is what failed in production, so it is not trusted alone.
+
+@test "issue_watcher_cron: a working agent survives a prompt failure instead of being torn down" {
+    _run_tick "HERDR_PROMPT_MODE=fail" "HERDR_AGENT_STATUS=working"
+    assert_success
+    # One attempt, and no teardown of the pane the agent is working in.
+    [ "$(_log_count 'gwt spawn')" -eq 1 ]
+    _refute_logged "gwt remove"
+    _refute_logged "tab close"
+    refute_output --partial "Giving up"
+    run git -C "${_REPO_DIR}" worktree list --porcelain
+    assert_output --partial "wt/issue-11/"
+}
+
+@test "issue_watcher_cron: an idle agent is still torn down and retried after a prompt failure" {
+    # The negative half: the guard above must not become a blanket skip.
+    _run_tick "HERDR_PROMPT_MODE=fail" "HERDR_AGENT_STATUS=idle"
+    assert_failure
+    [ "$(_log_count 'gwt spawn')" -eq 3 ]
+    [ "$(_log_count 'gwt remove')" -eq 3 ]
+    [ "$(_log_count 'tab close')" -eq 3 ]
+    assert_output --partial "Giving up on acme/dotfiles#11 after 3 attempts"
+    run git -C "${_REPO_DIR}" worktree list --porcelain
+    refute_output --partial "wt/issue-11/"
+}
+
+@test "issue_watcher_cron: an unreachable agent is torn down rather than assumed working" {
+    # `agent get` errors once the agent has been prompted, so the guard has no
+    # status at all — an unanswered query is not evidence of work in progress.
+    _run_tick "HERDR_PROMPT_MODE=fail" "HERDR_GET_FAIL_AFTER_PROMPT=1"
+    assert_failure
+    [ "$(_log_count 'gwt remove')" -eq 3 ]
+    assert_output --partial "Giving up on acme/dotfiles#11 after 3 attempts"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_iw_prompt_once` 가 `2>/dev/null` 로 herdr 의 에러 JSON(stderr)을 버려 `.error.code` 파싱이 항상 비었고, 그 결과 #1399/#1400/#1443/#1449 에 걸쳐 만든 stall 복구 장치 전체가 도달 불가능한 죽은 코드였다.
- 스트림을 `2>&1` 로 합쳐 파싱을 복구하고, `working` 인 agent 는 어떤 이유로도 재시도/포기 경로에서 철거하지 않는 독립적인 안전장치를 추가한다(2026-08-28 tick 에서 일하던 세션이 3회 철거된 실제 사고에 대한 대응).
- 8개 bats 케이스를 추가해 두 수정을 모두 고정한다.

## Changes
- `_iw_prompt_once` (`shell-common/tools/custom/issue_watcher_cron.sh`): `2>/dev/null` → `2>&1`, 근거 주석 갱신. `pr_merge_train_cron.sh` 의 mktemp 캡처 패턴과 의도적으로 다른 선택(사유는 커밋 메시지 참고).
- `_iw_process_issue`: 재시도 루프에서 `_iw_agent_status` 로 `working` 여부를 재확인해, `working` 이면 철거를 건너뛰고 성공으로 처리한다.
- `tests/bats/tools/issue_watcher_cron.bats`: herdr 스텁의 `agent prompt` 에러 JSON 을 stderr 로 정정(기존 스텁이 stdout 에 써서 결함이 테스트 통과 뒤에 위장돼 있었다), 8개 신규 테스트 추가.
- `docs/public/changelog.d/2026-08-28-1559.md`: changelog fragment 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/issue_watcher_cron.bats` — 207 ok / 0 not ok (기존 199 + 신규 8, pre-existing 실패 없음).
- [x] `mise run lint`, `mise run lint-docs` — errors=0.

## Related
Fixes #1559

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~-8 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~-8 min
<!-- /ai-metrics:gh-pr -->

</details>
