### PR TITLE
fix(gh-pr-post-merge-verify): agent start 실패 시 방금 만든 탭을 정리하지 않아 누수된다

### DIFF
--- a/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
@@ -255,6 +255,17 @@ if ! START_JSON=$(herdr agent start "$PMV_AGENT" --kind claude --pane "$NEW_PANE
     # failing the dispatch (same backstop as _pmt_launch_fresh).
     START_CODE=$(printf '%s' "$START_JSON" | pmv_error_code)
     if [ "$START_CODE" != "agent_name_taken" ]; then
+        # The tab from step 4 is agent-less at this point — nothing lost by
+        # closing it. Only this run's own tab, and only when its id is known
+        # (#1554): guessing which tab to close from a failed read would risk
+        # closing someone else's.
+        if [ -n "$NEW_TAB" ]; then
+            if herdr tab close "$NEW_TAB" >/dev/null 2>&1; then
+                printf '[INFO] gh:pr-post-merge-verify: closed the empty verification tab %s.\n' "$NEW_TAB"
+            else
+                printf '[WARN] gh:pr-post-merge-verify: could not close tab %s — close it by hand.\n' "$NEW_TAB"
+            fi
+        fi
         printf '[WARN] gh:pr-post-merge-verify: herdr agent start %s failed on pane %s (%s) — verification skipped.\n' \
             "$PMV_AGENT" "$NEW_PANE" "${START_CODE:-unknown}"
         return 0 2>/dev/null || exit 0

--- a/docs/public/changelog.d/2026-08-28-1554.md
+++ b/docs/public/changelog.d/2026-08-28-1554.md
@@ -1,0 +1,1 @@
+- 변경: **gh:pr-post-merge-verify 디스패치가 `herdr agent start` 실패(`agent_name_taken` 제외) 시 방금 만든 빈 검증 탭을 닫는다 — 실패가 지속되면 머지 수만큼 고아 탭이 쌓이던 자원 누수 수정 (#1554)**

--- a/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
@@ -503,11 +503,11 @@ gh_pr_post_merge_verify() {
         _code=$(printf '%s' "$_out" | pmv_error_code)
         if [ "$_code" != "agent_name_taken" ]; then
             # The tab from step 4 is agent-less at this point — nothing lost
-            # by closing it. Only this run's own tab, and only when its id is
-            # known (#1554, "-" is pmv_tab_create's own placeholder for
-            # "unknown"): guessing which tab to close from a failed read
-            # would risk closing someone else's.
-            if [ -n "$_newtab" ] && [ "$_newtab" != "-" ]; then
+            # by closing it. Only when its id is known (#1554): guessing which
+            # tab to close from a failed read would risk closing someone
+            # else's. `pmv_tab_create` always returns a non-empty first
+            # field, so the only "unknown" case is its own "-" placeholder.
+            if [ "$_newtab" != "-" ]; then
                 if _pmv_herdr tab close "$_newtab" >/dev/null 2>&1; then
                     printf '[INFO] gh:pr-post-merge-verify: closed the empty verification tab %s.\n' "$_newtab"
                 else

--- a/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
@@ -502,6 +502,18 @@ gh_pr_post_merge_verify() {
         # usable agent — prompt it rather than failing the dispatch.
         _code=$(printf '%s' "$_out" | pmv_error_code)
         if [ "$_code" != "agent_name_taken" ]; then
+            # The tab from step 4 is agent-less at this point — nothing lost
+            # by closing it. Only this run's own tab, and only when its id is
+            # known (#1554, "-" is pmv_tab_create's own placeholder for
+            # "unknown"): guessing which tab to close from a failed read
+            # would risk closing someone else's.
+            if [ -n "$_newtab" ] && [ "$_newtab" != "-" ]; then
+                if _pmv_herdr tab close "$_newtab" >/dev/null 2>&1; then
+                    printf '[INFO] gh:pr-post-merge-verify: closed the empty verification tab %s.\n' "$_newtab"
+                else
+                    printf '[WARN] gh:pr-post-merge-verify: could not close tab %s — close it by hand.\n' "$_newtab"
+                fi
+            fi
             printf '[WARN] gh:pr-post-merge-verify: herdr agent start %s failed on pane %s (%s) — verification skipped.\n' \
                 "$_agent" "$_pane" "${_code:-unknown}"
             return 0

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -1072,3 +1072,72 @@ _PMV_WAIT_ASSIGN='^(_IW_SETTLE_SECONDS|_PMT_SETTLE_SECONDS|PMV_SETTLE_SECONDS|_I
     run grep -qF -- '_PMT_SETTLE_SECONDS' "$_doc"
     assert_success
 }
+
+# --- #1554: don't leak the just-created verification tab on agent-start failure
+
+@test "1554: an agent start failure closes the just-created verification tab" {
+    FAKE_HERDR_RC_AGENT_START=1
+    FAKE_HERDR_OUT_AGENT_START='{"error":{"code":"pane_not_ready"}}'
+    run dispatch
+    assert_success
+    assert_output --partial "closed the empty verification tab wV:t99"
+    assert_output --partial "herdr agent start mv-dotfiles-pr-77 failed"
+    run cat "$FAKE_HERDR_LOG"
+    assert_output --partial "tab close wV:t99"
+}
+
+@test "1554: a failing tab close warns but does not stop the dispatch" {
+    FAKE_HERDR_RC_AGENT_START=1
+    FAKE_HERDR_OUT_AGENT_START='{"error":{"code":"pane_not_ready"}}'
+    FAKE_HERDR_RC_TAB_CLOSE=1
+    run dispatch
+    assert_success
+    assert_output --partial "could not close tab wV:t99 — close it by hand"
+    assert_output --partial "herdr agent start mv-dotfiles-pr-77 failed"
+}
+
+@test "1554: agent_name_taken reuses the tab instead of closing it" {
+    FAKE_HERDR_RC_AGENT_START=1
+    FAKE_HERDR_OUT_AGENT_START='{"error":{"code":"agent_name_taken"}}'
+    run dispatch
+    assert_success
+    refute_output --partial "closed the empty verification tab"
+    refute_output --partial "could not close tab"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "tab close wV:t99"
+}
+
+@test "1554: a failing agent prompt leaves the live verification tab alone" {
+    FAKE_HERDR_RC_AGENT_PROMPT=1
+    FAKE_HERDR_OUT_AGENT_PROMPT='{"error":{"code":"agent_prompt_stalled"}}'
+    run dispatch
+    assert_success
+    refute_output --partial "closed the empty verification tab"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "tab close wV:t99"
+}
+
+@test "1554: an unreadable tab id is never guessed at for cleanup" {
+    FAKE_HERDR_OUT_TAB_CREATE='{"result":{"pane":{"pane_id":"wV:p99"}}}'
+    FAKE_HERDR_RC_AGENT_START=1
+    FAKE_HERDR_OUT_AGENT_START='{"error":{"code":"pane_not_ready"}}'
+    run dispatch
+    assert_success
+    refute_output --partial "closed the empty verification tab"
+    refute_output --partial "could not close tab"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "tab close -"
+}
+
+@test "1554: dispatch.sh.md closes the verification tab on the same agent-start failure branch" {
+    local _doc _start _close
+    _doc="$(_pmv_dispatch_doc)"
+    _start=$(grep -n 'herdr agent start "\$PMV_AGENT"' "$_doc" | head -1 | cut -d: -f1)
+    _close=$(grep -n 'herdr tab close "\$NEW_TAB"' "$_doc" | head -1 | cut -d: -f1)
+    [ -n "$_start" ] && [ -n "$_close" ]
+    [ "$_start" -lt "$_close" ]
+    run grep -qF -- 'closed the empty verification tab' "$_doc"
+    assert_success
+    run grep -qF -- 'if [ -n "$NEW_TAB" ]; then' "$_doc"
+    assert_success
+}

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -1138,6 +1138,4 @@ _PMV_WAIT_ASSIGN='^(_IW_SETTLE_SECONDS|_PMT_SETTLE_SECONDS|PMV_SETTLE_SECONDS|_I
     [ "$_start" -lt "$_close" ]
     run grep -qF -- 'closed the empty verification tab' "$_doc"
     assert_success
-    run grep -qF -- 'if [ -n "$NEW_TAB" ]; then' "$_doc"
-    assert_success
 }


### PR DESCRIPTION
## Summary
- `gh:pr-post-merge-verify` 디스패치가 `herdr agent start` 실패 시 방금 만든 빈 검증 탭을 정리하지 않아, 실패가 지속되면 머지 1건당 고아 탭 1개씩 쌓이던 자원 누수를 고친다.

## Changes
- `claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md`: `agent start` 가 `agent_name_taken` 이외의 코드로 실패하는 분기에서, `$NEW_TAB` 이 non-empty 일 때만 `herdr tab close`를 호출하도록 추가 (`agent_name_taken` 재사용 경로와 `agent prompt` 실패 경로는 그대로 둔다 — 전자는 탭을 재사용하고, 후자는 이미 살아 있는 세션이라 사람이 attach 로 이어받을 수 있어서다).
- `tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh`: 동일한 분기를 오케스트레이터 함수에 미러 (`"-"` 는 `pmv_tab_create`의 "tab id 미확보" placeholder이므로 non-empty 가드에서 함께 제외).
- `tests/bats/skills/gh_pr_post_merge_verify.bats`: agent-start 실패/close 실패/`agent_name_taken`/`agent prompt` 실패/tab id 미확보 5개 경로 + `dispatch.sh.md` 자체를 검사하는 드리프트 가드 1개, 총 6개 회귀 테스트 추가.
- `docs/public/changelog.d/2026-08-28-1554.md`: changelog fragment.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_post_merge_verify.bats` — 97/97 통과 (기존 91 + 신규 6).
- [x] `shellcheck` on the fixture — clean.
- [x] `mise run lint-docs` (changelog fragment lint) — clean.
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/` 전체 — 이 변경으로 인한 신규 실패 없음 (기존 3개 무관 pre-existing 실패는 base 에서도 동일하게 재현됨: doc-guard ai-metrics, fixture-mirrors-SKILL.md drift, path-normalize ordering).

## Related
Closes #1554

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~15 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~15 min
<!-- /ai-metrics:gh-pr -->

</details>
