### PR TITLE
fix(shell-common): postgresql.sh 의 mapfile을 zsh 호환 while-read로 교체

### DIFF
--- a/shell-common/tools/integrations/postgresql.sh
+++ b/shell-common/tools/integrations/postgresql.sh
@@ -38,8 +38,11 @@ _pg_service_lines() {
 _load_services() {
     services=()
     if [[ -f "$PG_SERVICES_FILE" ]]; then
-        # POSIX 호환 방식으로 배열에 데이터 할당 (mapfile 대신 while read 사용)
-        while IFS= read -r _line; do
+        # bash/zsh 호환 방식으로 배열에 데이터 할당 (mapfile 대신 while read 사용).
+        # `|| [[ -n "$_line" ]]` 은 파일이 trailing newline 없이 끝나도 마지막
+        # 줄을 잃지 않게 한다 (마지막 read 는 실패를 리턴하지만 변수는 채운다).
+        local _line
+        while IFS= read -r _line || [[ -n "$_line" ]]; do
             [[ -n "$_line" ]] && services+=("$_line")
         done < <(_pg_service_lines)
     fi
@@ -649,8 +652,10 @@ psql_sync() {
     # Get list of all DBs (excluding templates and postgres core)
     local all_dbs=()
     local _db_line
-    # POSIX 호환 방식으로 배열에 데이터 할당 (mapfile 대신 while read 사용)
-    while IFS= read -r _db_line; do
+    # bash/zsh 호환 방식으로 배열에 데이터 할당 (mapfile 대신 while read 사용).
+    # `|| [[ -n "$_db_line" ]]` 은 trailing newline 없는 출력에서도 마지막
+    # 행을 잃지 않게 한다.
+    while IFS= read -r _db_line || [[ -n "$_db_line" ]]; do
         [[ -n "$_db_line" ]] && all_dbs+=("$_db_line")
     done < <(_admin_sql "postgres" "SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres';" -tA)
 

--- a/shell-common/tools/integrations/postgresql.sh
+++ b/shell-common/tools/integrations/postgresql.sh
@@ -29,12 +29,19 @@ if [[ ! -f "$PG_SERVICES_FILE" ]]; then
     chmod 0600 "$PG_SERVICES_FILE"
 fi
 
+# Filter out comments and empty lines from the services file
+_pg_service_lines() {
+    grep -v '^[[:space:]]*#' "$PG_SERVICES_FILE" | grep -v '^[[:space:]]*$'
+}
+
 # Load services from file (Skip comments and empty lines)
 _load_services() {
+    services=()
     if [[ -f "$PG_SERVICES_FILE" ]]; then
-        mapfile -t services < <(grep -v '^[[:space:]]*#' "$PG_SERVICES_FILE" | grep -v '^[[:space:]]*$')
-    else
-        services=()
+        # POSIX 호환 방식으로 배열에 데이터 할당 (mapfile 대신 while read 사용)
+        while IFS= read -r _line; do
+            [[ -n "$_line" ]] && services+=("$_line")
+        done < <(_pg_service_lines)
     fi
 }
 _load_services
@@ -640,8 +647,12 @@ psql_sync() {
     echo ""
 
     # Get list of all DBs (excluding templates and postgres core)
-    local all_dbs
-    mapfile -t all_dbs < <(_admin_sql "postgres" "SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres';" -tA)
+    local all_dbs=()
+    local _db_line
+    # POSIX 호환 방식으로 배열에 데이터 할당 (mapfile 대신 while read 사용)
+    while IFS= read -r _db_line; do
+        [[ -n "$_db_line" ]] && all_dbs+=("$_db_line")
+    done < <(_admin_sql "postgres" "SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres';" -tA)
 
     local found_new=false
 


### PR DESCRIPTION
## Summary
- zsh에서 `postgresql.sh`가 자동 소싱될 때마다 `command not found: mapfile` 에러가 나던 문제를 고친다.

## Changes
- `shell-common/tools/integrations/postgresql.sh`: `_load_services`, `psql_sync` 두 곳의 bash 전용 `mapfile`을 zsh/bash 겸용 `while read` 루프로 교체했다(같은 저장소 `litellm.sh`의 기존 컨벤션과 동일). `_load_services`의 grep 필터는 별도 헬퍼(`_pg_service_lines`)로 분리해, pre-commit pipe-loop 훅이 process substitution 내부 파이프를 `done ... | pipe`로 오탐하는 것도 함께 피했다.

## Test plan
- [x] `DOTFILES_FORCE_INIT=1 zsh -c 'source shell-common/tools/integrations/postgresql.sh'` — 에러 없이 종료
- [x] 동일 커맨드를 bash에서도 실행 — 정상 동작
- [x] `mise run lint-sh` (shellcheck + shfmt) 통과
- [x] `./tests/test` 전체 스위트 — pytest 1595 passed, 0 failed (bats는 이 워크트리에 bats-core submodule 미체크아웃으로 스킵됨 — 이 변경과 무관한 pre-existing 환경 갭)

## Related
Closes #1557

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
