### PR TITLE
fix(stop-guard): 백그라운드 Agent 위임을 방치로 오탐하는 Stop hook 가드를 고친다

### DIFF
--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -82,15 +82,16 @@ _DEFAULT_ASYNC_WAIT_LIMIT: int = 2
 #
 #   [flow:async-wait] step=<skill>/<step> agent=<agent-id> reason=background-worker-delegated
 #
-# `agent` is captured for audit/logging only and is deliberately NOT used in
-# any matching or streak logic. The issue's own fix plan proposed comparing
-# the agent id across turns to detect "no progress", but that requires the
-# model to reproduce one exact literal string turn after turn — fragile in
-# exactly the situation the marker exists for. Counting consecutive
-# occurrences with no intervening progress event is sufficient evidence of
-# stagnation on its own, and needs nothing from the model but the marker.
+# `agent` is required in the line — the transcript itself is the audit trail —
+# but deliberately NOT captured and NOT used in any matching or streak logic.
+# The issue's own fix plan proposed comparing the agent id across turns to
+# detect "no progress", but that requires the model to reproduce one exact
+# literal string turn after turn — fragile in exactly the situation the marker
+# exists for. Counting consecutive occurrences with no intervening progress
+# event is sufficient evidence of stagnation on its own, and needs nothing
+# from the model but the marker.
 _ASYNC_WAIT_RE: re.Pattern[str] = re.compile(
-    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=(?P<agent>\S+)\s+reason=background-worker-delegated\s*$"
+    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=\S+\s+reason=background-worker-delegated\s*$"
 )
 
 
@@ -671,97 +672,68 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     return terminal, seen
 
 
-def _last_sub_skill_index(messages: list[dict[str, Any]], start: int) -> int:
-    """Return the index of the LAST sub-skill `Skill()` call after `start` (#1550).
-
-    Falls back to `start` itself when no sub-skill ran after the boundary, so
-    the caller always gets a usable "last progress happened here" index.
-
-    A dedicated forward walk rather than an extra return value threaded out
-    of `_scan_after_boundary`: that function is already carrying two
-    orthogonal jobs, and this module's style is one small single-purpose
-    walker per question. Never raises — same isinstance discipline as every
-    other walker here (`_iter_skill_uses` is fully guarded).
-    """
-    last = start
-    for offset, entry in enumerate(messages[start + 1 :], start=start + 1):
-        msg = _message_payload(entry)
-        for skill in _iter_skill_uses(msg):
-            if skill in SUB_SKILL_NAMES:
-                last = offset
-                break
-    return last
-
-
-def _async_wait_streak(messages: list[dict[str, Any]], boundary: int, seen: list[str]) -> int:
+def _async_wait_streak(messages: list[dict[str, Any]], boundary: int) -> int:
     """Count `[flow:async-wait]` markers since the last progress event (#1550).
 
     "Progress event" for the OUTER chain is a sub-skill `Skill()` invocation:
     the chain moved forward, so whatever the model was waiting on is done and
-    the streak restarts from zero. When no sub-skill has run yet (`seen`
-    empty) the boundary itself is the last progress point — which is also why
-    `seen` is taken as a parameter: it lets the common no-progress case skip
-    the extra walk entirely.
+    the streak restarts from zero. Walking BACKWARD from the end and stopping
+    at the first sub-skill call answers that in one partial pass — no need to
+    locate the progress index first and then re-walk from it. When no
+    sub-skill ran at all, the walk simply runs back to the boundary.
 
     Markers are read from `role=assistant` text blocks only, with
-    `include_tool_results=False`. That is deliberate and asymmetric with the
-    sister hook's `[step:.../...] OK` scan (which does read `tool_result`,
-    because those markers come from a `printf` in a Bash call). The
-    async-wait marker is only ever the model's own turn-ending prose, while a
-    `tool_result` can carry arbitrary file content — including this very
-    file and `references/stop-guard.md`, both of which now document the
-    marker literally. Reading tool_results here would false-positive on any
-    `Read` of those files (the issue #608 precedent, applied to a new
-    marker).
+    `include_tool_results=False` — see `_ASYNC_WAIT_RE` for why that is
+    deliberately asymmetric with the sister hook's `[step:.../...] OK` scan
+    and must stay that way.
 
     Never raises; a malformed entry can only yield a smaller count.
     """
-    progress_idx = _last_sub_skill_index(messages, boundary) if seen else boundary
     streak = 0
-    for entry in messages[progress_idx + 1 :]:
+    for entry in reversed(messages[boundary + 1 :]):
         msg = _message_payload(entry)
+        if any(skill in SUB_SKILL_NAMES for skill in _iter_skill_uses(msg)):
+            break
         if msg.get("role") != "assistant":
             continue
         for text in _iter_text_blocks(msg, include_tool_results=False):
-            streak += len(_ASYNC_WAIT_RE.findall(text))
+            streak += sum(1 for _ in _ASYNC_WAIT_RE.finditer(text))
     return streak
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a non-negative int knob from the environment, or `default`.
+
+    Shared by `_async_wait_grace_limit` (#1550) and `_max_stale_user_turns`
+    (#1270), which had identical bodies:
+      - a valid non-negative int → use it (`0` means "disabled"),
+      - unset / unparseable / negative → `default` (unset reaches the
+        `ValueError` arm via the `""` default).
+    Never raises — a bad value silently degrades to the default.
+    """
+    try:
+        value = int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+    return value if value >= 0 else default
 
 
 def _async_wait_grace_limit() -> int:
     """Read the async-wait grace limit from the environment (#1550).
 
-    Env var: `GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT`. Same shape as
-    `_max_stale_user_turns`:
-      - a valid non-negative int  → use it,
-      - `0`                       → grace disabled (the very first marker
-                                    occurrence already blocks),
-      - unset / unparseable / negative → `_DEFAULT_ASYNC_WAIT_LIMIT`
-        (unset reaches the `ValueError` arm via the `""` default).
-    Never raises — a bad value silently degrades to the default.
+    Env var: `GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT`; `0` disables the
+    grace entirely (the very first marker occurrence already blocks).
     """
-    try:
-        value = int(os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT", ""))
-    except ValueError:
-        return _DEFAULT_ASYNC_WAIT_LIMIT
-    return value if value >= 0 else _DEFAULT_ASYNC_WAIT_LIMIT
+    return _env_int("GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT", _DEFAULT_ASYNC_WAIT_LIMIT)
 
 
 def _max_stale_user_turns() -> int:
     """Read the boundary-expiry threshold from the environment (#1270).
 
-    Env var: `GH_ISSUE_FLOW_STOP_GUARD_MAX_USER_TURNS`.
-      - a valid non-negative int  → use it,
-      - `0`                       → expiry disabled (never fail open on
-                                    staleness alone),
-      - unset / unparseable / negative → `_DEFAULT_MAX_STALE_USER_TURNS`
-        (unset reaches the `ValueError` arm via the `""` default).
-    Never raises — a bad value silently degrades to the default.
+    Env var: `GH_ISSUE_FLOW_STOP_GUARD_MAX_USER_TURNS`; `0` disables expiry
+    entirely (never fail open on staleness alone).
     """
-    try:
-        value = int(os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_MAX_USER_TURNS", ""))
-    except ValueError:
-        return _DEFAULT_MAX_STALE_USER_TURNS
-    return value if value >= 0 else _DEFAULT_MAX_STALE_USER_TURNS
+    return _env_int("GH_ISSUE_FLOW_STOP_GUARD_MAX_USER_TURNS", _DEFAULT_MAX_STALE_USER_TURNS)
 
 
 def _count_fresh_user_prompts(messages: list[dict[str, Any]], start: int) -> int:
@@ -921,7 +893,7 @@ def main() -> int:
     # diagnostic line stays complete.
     async_wait_limit = _async_wait_grace_limit()
     async_wait_streak = (
-        _async_wait_streak(messages, boundary, seen) if _TRACE_ENABLED or (not terminal and async_wait_limit > 0) else 0
+        _async_wait_streak(messages, boundary) if _TRACE_ENABLED or (not terminal and async_wait_limit > 0) else 0
     )
     if _TRACE_ENABLED:
         _trace(
@@ -950,7 +922,8 @@ def main() -> int:
     # on the record, that it delegated the outstanding work to a background
     # Agent and is waiting — not that it abandoned the flow. Past the limit
     # the marker stops buying anything and the ordinary block resumes.
-    if async_wait_limit > 0 and 0 < async_wait_streak <= async_wait_limit:
+    # (`limit <= 0` needs no separate guard: it makes the range unsatisfiable.)
+    if 0 < async_wait_streak <= async_wait_limit:
         return _allow(
             f"async-wait grace ({async_wait_streak}/{async_wait_limit}) — background "
             f"delegation in progress, not abandonment",

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -90,8 +90,15 @@ _DEFAULT_ASYNC_WAIT_LIMIT: int = 2
 # exists for. Counting consecutive occurrences with no intervening progress
 # event is sufficient evidence of stagnation on its own, and needs nothing
 # from the model but the marker.
+#
+# Optional spaces around each `=` and optional double-quotes around each
+# value are tolerated (agy review, PR #1594 FOLLOW-UP) — an LLM asked to
+# reproduce a fixed-format line is prone to exactly this class of minor
+# formatting drift, and a rigid regex turns that drift into a spurious block
+# instead of the grace it was supposed to grant.
 _ASYNC_WAIT_RE: re.Pattern[str] = re.compile(
-    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=\S+\s+reason=background-worker-delegated\s*$"
+    r'(?m)^\[flow:async-wait\]\s+step\s*=\s*"?(?P<step>[^\s"]+)"?'
+    r'\s+agent\s*=\s*"?[^\s"]+"?\s+reason\s*=\s*"?background-worker-delegated"?\s*$'
 )
 
 
@@ -673,14 +680,29 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
 
 
 def _async_wait_streak(messages: list[dict[str, Any]], boundary: int) -> int:
-    """Count `[flow:async-wait]` markers since the last progress event (#1550).
+    """Count TRAILING consecutive `[flow:async-wait]`-bearing turns (#1550).
+
+    A streak of N means: the last N assistant messages since the last
+    progress event EACH carried the marker, with no gap. It is deliberately
+    NOT a flat total of every marker seen in that window — codex + agy
+    review (PR #1594) both flagged the original flat-total version: it let
+    ONE early marker grant grace forever after, because a later stop attempt
+    whose own latest turn carried no marker at all still inherited the old
+    count. The fix here is to walk backward and stop the count dead the
+    first time a message fails to renew the claim — so the model must
+    re-assert the wait on every turn it wants graced, not just once.
 
     "Progress event" for the OUTER chain is a sub-skill `Skill()` invocation:
-    the chain moved forward, so whatever the model was waiting on is done and
-    the streak restarts from zero. Walking BACKWARD from the end and stopping
-    at the first sub-skill call answers that in one partial pass — no need to
-    locate the progress index first and then re-walk from it. When no
-    sub-skill ran at all, the walk simply runs back to the boundary.
+    the chain moved forward, so whatever the model was waiting on is done —
+    walking BACKWARD from the end and stopping there answers that in one
+    partial pass. When no sub-skill ran at all, the walk runs back to the
+    boundary.
+
+    Each assistant message contributes AT MOST 1 to the streak (a boolean
+    "did this turn carry the marker", not a count of matches within it) —
+    agy also flagged that `sum(finditer)` let a turn with multiple marker
+    lines (e.g. one quoted inside explanatory prose) burn through the grace
+    limit in a single turn.
 
     Markers are read from `role=assistant` text blocks only, with
     `include_tool_results=False` — see `_ASYNC_WAIT_RE` for why that is
@@ -696,8 +718,10 @@ def _async_wait_streak(messages: list[dict[str, Any]], boundary: int) -> int:
             break
         if msg.get("role") != "assistant":
             continue
-        for text in _iter_text_blocks(msg, include_tool_results=False):
-            streak += sum(1 for _ in _ASYNC_WAIT_RE.finditer(text))
+        has_marker = any(_ASYNC_WAIT_RE.search(text) for text in _iter_text_blocks(msg, include_tool_results=False))
+        if not has_marker:
+            break
+        streak += 1
     return streak
 
 

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -30,6 +30,8 @@ Safety rails (each is critical — never accidentally trap the user):
   - No gh-issue-flow boundary in the transcript → exit 0 (not our flow).
   - Terminal Step 3 marker present → exit 0 (chain finished cleanly).
   - Boundary went stale (N fresh user prompts since it) → exit 0 (#1270).
+  - `[flow:async-wait]` marker streak within the grace limit → exit 0
+    (#1550 — work delegated to a background Agent, not abandoned).
   - Any unexpected exception → exit 0 (fail open).
 
 Terminal-marker channels: assistant **text** blocks (canonical), plus a
@@ -66,6 +68,30 @@ _TRACE_ENABLED: bool = os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_TRACE") == "1"
 # emitted a Step 3 marker would keep blocking every unrelated turn for the
 # rest of the session (cross-turn session hijacking).
 _DEFAULT_MAX_STALE_USER_TURNS: int = 3
+
+# Issue #1550 — how many CONSECUTIVE `[flow:async-wait]` markers may end a
+# turn, with no intervening progress, before the guard resumes blocking.
+# Rationale for a count instead of an agent-id comparison: see
+# `_ASYNC_WAIT_RE`.
+_DEFAULT_ASYNC_WAIT_LIMIT: int = 2
+
+# Issue #1550 — the marker the model prints as plain assistant text right
+# before ending a turn whose remaining work it has handed to a
+# background/async `Agent` (the Advisor/Worker delegation the user's global
+# CLAUDE.md mandates for multi-file implementation work). Shape:
+#
+#   [flow:async-wait] step=<skill>/<step> agent=<agent-id> reason=background-worker-delegated
+#
+# `agent` is captured for audit/logging only and is deliberately NOT used in
+# any matching or streak logic. The issue's own fix plan proposed comparing
+# the agent id across turns to detect "no progress", but that requires the
+# model to reproduce one exact literal string turn after turn — fragile in
+# exactly the situation the marker exists for. Counting consecutive
+# occurrences with no intervening progress event is sufficient evidence of
+# stagnation on its own, and needs nothing from the model but the marker.
+_ASYNC_WAIT_RE: re.Pattern[str] = re.compile(
+    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=(?P<agent>\S+)\s+reason=background-worker-delegated\s*$"
+)
 
 
 def _trace(message: str, *, layer: str | None = None) -> None:
@@ -645,6 +671,81 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     return terminal, seen
 
 
+def _last_sub_skill_index(messages: list[dict[str, Any]], start: int) -> int:
+    """Return the index of the LAST sub-skill `Skill()` call after `start` (#1550).
+
+    Falls back to `start` itself when no sub-skill ran after the boundary, so
+    the caller always gets a usable "last progress happened here" index.
+
+    A dedicated forward walk rather than an extra return value threaded out
+    of `_scan_after_boundary`: that function is already carrying two
+    orthogonal jobs, and this module's style is one small single-purpose
+    walker per question. Never raises — same isinstance discipline as every
+    other walker here (`_iter_skill_uses` is fully guarded).
+    """
+    last = start
+    for offset, entry in enumerate(messages[start + 1 :], start=start + 1):
+        msg = _message_payload(entry)
+        for skill in _iter_skill_uses(msg):
+            if skill in SUB_SKILL_NAMES:
+                last = offset
+                break
+    return last
+
+
+def _async_wait_streak(messages: list[dict[str, Any]], boundary: int, seen: list[str]) -> int:
+    """Count `[flow:async-wait]` markers since the last progress event (#1550).
+
+    "Progress event" for the OUTER chain is a sub-skill `Skill()` invocation:
+    the chain moved forward, so whatever the model was waiting on is done and
+    the streak restarts from zero. When no sub-skill has run yet (`seen`
+    empty) the boundary itself is the last progress point — which is also why
+    `seen` is taken as a parameter: it lets the common no-progress case skip
+    the extra walk entirely.
+
+    Markers are read from `role=assistant` text blocks only, with
+    `include_tool_results=False`. That is deliberate and asymmetric with the
+    sister hook's `[step:.../...] OK` scan (which does read `tool_result`,
+    because those markers come from a `printf` in a Bash call). The
+    async-wait marker is only ever the model's own turn-ending prose, while a
+    `tool_result` can carry arbitrary file content — including this very
+    file and `references/stop-guard.md`, both of which now document the
+    marker literally. Reading tool_results here would false-positive on any
+    `Read` of those files (the issue #608 precedent, applied to a new
+    marker).
+
+    Never raises; a malformed entry can only yield a smaller count.
+    """
+    progress_idx = _last_sub_skill_index(messages, boundary) if seen else boundary
+    streak = 0
+    for entry in messages[progress_idx + 1 :]:
+        msg = _message_payload(entry)
+        if msg.get("role") != "assistant":
+            continue
+        for text in _iter_text_blocks(msg, include_tool_results=False):
+            streak += len(_ASYNC_WAIT_RE.findall(text))
+    return streak
+
+
+def _async_wait_grace_limit() -> int:
+    """Read the async-wait grace limit from the environment (#1550).
+
+    Env var: `GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT`. Same shape as
+    `_max_stale_user_turns`:
+      - a valid non-negative int  → use it,
+      - `0`                       → grace disabled (the very first marker
+                                    occurrence already blocks),
+      - unset / unparseable / negative → `_DEFAULT_ASYNC_WAIT_LIMIT`
+        (unset reaches the `ValueError` arm via the `""` default).
+    Never raises — a bad value silently degrades to the default.
+    """
+    try:
+        value = int(os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT", ""))
+    except ValueError:
+        return _DEFAULT_ASYNC_WAIT_LIMIT
+    return value if value >= 0 else _DEFAULT_ASYNC_WAIT_LIMIT
+
+
 def _max_stale_user_turns() -> int:
     """Read the boundary-expiry threshold from the environment (#1270).
 
@@ -814,11 +915,20 @@ def main() -> int:
     fresh_prompts = (
         _count_fresh_user_prompts(messages, boundary) if _TRACE_ENABLED or (not terminal and limit > 0) else 0
     )
+    # Issue #1550 — same hot-path discipline as the fresh-prompt count above:
+    # the streak feeds nothing but the grace valve, so skip the walk whenever
+    # its result provably cannot be used. Trace mode forces it so the L1.5
+    # diagnostic line stays complete.
+    async_wait_limit = _async_wait_grace_limit()
+    async_wait_streak = (
+        _async_wait_streak(messages, boundary, seen) if _TRACE_ENABLED or (not terminal and async_wait_limit > 0) else 0
+    )
     if _TRACE_ENABLED:
         _trace(
             f"boundary={boundary} sub_skills_seen={len(seen)}/{len(EXPECTED_CHAIN)} "
             f"({','.join(seen) if seen else 'none'}) terminal={terminal} "
-            f"fresh_user_prompts={fresh_prompts}",
+            f"fresh_user_prompts={fresh_prompts} "
+            f"async_wait_streak={async_wait_streak} async_wait_limit={async_wait_limit}",
             layer="L1.5",
         )
     if terminal:
@@ -830,6 +940,20 @@ def main() -> int:
         return _allow(
             f"stale boundary expiry — {fresh_prompts} fresh user prompt(s) since the "
             f"gh-issue-flow boundary (limit {limit}); flow abandoned, failing open",
+            layer="L1.5",
+        )
+
+    # Issue #1550 — async-wait grace. Sits AFTER the terminal and
+    # stale-boundary checks on purpose: both of those still take priority,
+    # so this valve only ever changes the outcome on the path that would
+    # otherwise block. A streak inside the limit means the model told us,
+    # on the record, that it delegated the outstanding work to a background
+    # Agent and is waiting — not that it abandoned the flow. Past the limit
+    # the marker stops buying anything and the ordinary block resumes.
+    if async_wait_limit > 0 and 0 < async_wait_streak <= async_wait_limit:
+        return _allow(
+            f"async-wait grace ({async_wait_streak}/{async_wait_limit}) — background "
+            f"delegation in progress, not abandonment",
             layer="L1.5",
         )
 

--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -30,6 +30,9 @@ Safety rails (each critical — never accidentally trap the user):
   - Catalog file missing / unparseable YAML → exit 0 (fail-open + warn).
   - `GH_SKILL_GUARD_BYPASS=1` → exit 0 (manual escape hatch).
   - All required step IDs present after the most recent boundary → exit 0.
+  - Every still-missing step covered by a `[flow:async-wait]` marker
+    within the grace limit → exit 0 (#1550 — work delegated to a
+    background Agent, not abandoned).
   - Any unexpected exception → exit 0 (fail open).
 
 The hook only ever does two things: emit nothing (allow), or emit one
@@ -67,6 +70,39 @@ _DEFAULT_CATALOG: Path = Path(__file__).resolve().parent / "skill_step_catalog.y
 # and the hook source uses the regex form which doesn't satisfy the literal).
 _STEP_EMIT_RE: re.Pattern[str] = re.compile(
     r"\[step:(?P<skill>[A-Za-z0-9_:.-]+)/(?P<step>[A-Za-z0-9_.-]+)\]\s+OK\b",
+)
+
+# Issue #1550 — how many CONSECUTIVE `[flow:async-wait]` markers may stand in
+# for one still-unemitted required step before the guard resumes blocking it.
+_DEFAULT_ASYNC_WAIT_LIMIT: int = 2
+
+# Issue #1550 — the marker the model prints as plain assistant text right
+# before ending a turn whose remaining work it has handed to a
+# background/async `Agent` (the Advisor/Worker delegation the user's global
+# CLAUDE.md mandates for multi-file implementation work). Shape:
+#
+#   [flow:async-wait] step=<skill>/<step> agent=<agent-id> reason=background-worker-delegated
+#
+# Identical pattern to the one in `gh_issue_flow_stop_guard.py` — the two
+# hooks read the same marker, they just derive different things from it (that
+# one counts a streak per chain, this one per required step id).
+#
+# `agent` is captured for audit/logging only and is deliberately NOT used in
+# any matching logic: making the grace depend on the model reproducing one
+# exact literal id string turn after turn would be fragile in precisely the
+# situation the marker exists for. A repeated marker with no intervening step
+# emit is sufficient evidence of stagnation on its own.
+#
+# Scanned in `role=assistant` text blocks ONLY, with
+# `include_tool_results=False` — asymmetric with `_STEP_EMIT_RE` above, which
+# must read `tool_result` because the step markers come from a `printf` in a
+# Bash call. This marker is only ever the model's own turn-ending prose, and a
+# `tool_result` can carry arbitrary file content — including this file and
+# `claude/skills/gh-issue-flow/references/stop-guard.md`, both of which now
+# document the marker literally. Reading tool_results here would
+# false-positive on any `Read` of those files (the issue #608 precedent).
+_ASYNC_WAIT_RE: re.Pattern[str] = re.compile(
+    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=(?P<agent>\S+)\s+reason=background-worker-delegated\s*$"
 )
 
 
@@ -350,6 +386,89 @@ def _scan_steps_in_section(
     return seen
 
 
+def _async_wait_grace_limit() -> int:
+    """Read the async-wait grace limit from the environment (#1550).
+
+    Env var: `GH_SKILL_GUARD_ASYNC_WAIT_LIMIT`.
+      - a valid non-negative int  → use it,
+      - `0`                       → grace disabled (the very first marker
+                                    occurrence already blocks),
+      - unset / unparseable / negative → `_DEFAULT_ASYNC_WAIT_LIMIT`
+        (unset reaches the `ValueError` arm via the `""` default).
+    Never raises — a bad value silently degrades to the default.
+    """
+    try:
+        value = int(os.environ.get("GH_SKILL_GUARD_ASYNC_WAIT_LIMIT", ""))
+    except ValueError:
+        return _DEFAULT_ASYNC_WAIT_LIMIT
+    return value if value >= 0 else _DEFAULT_ASYNC_WAIT_LIMIT
+
+
+def _count_async_waits_in_section(
+    messages: list[dict[str, Any]],
+    start: int,
+    end: int,
+    skill: str,
+) -> dict[str, int]:
+    """Count `[flow:async-wait]` markers per step id in a section (#1550).
+
+    Only `role=assistant` text blocks are read, with
+    `include_tool_results=False` — see `_ASYNC_WAIT_RE` for why that is
+    asymmetric with the step-emit scan and must stay that way.
+
+    The captured `step=` value is `<skill>/<step-id>`; its skill half goes
+    through `_normalize_skill` before comparison, so
+    `step=gh:issue-implement/implement` and
+    `step=gh-issue-implement/implement` are both accepted. A value that does
+    not name this section's skill is ignored — grace never crosses skills.
+    """
+    counts: dict[str, int] = {}
+    for entry in messages[start + 1 : end]:
+        msg = _message_payload(entry)
+        if msg.get("role") != "assistant":
+            continue
+        for text in _iter_text_blocks(msg, include_tool_results=False):
+            for m in _ASYNC_WAIT_RE.finditer(text):
+                matched_skill, _, step_id = m.group("step").rpartition("/")
+                if not matched_skill or not step_id:
+                    continue
+                if _normalize_skill(matched_skill) != skill:
+                    continue
+                counts[step_id] = counts.get(step_id, 0) + 1
+    return counts
+
+
+def _async_wait_reprieved(
+    messages: list[dict[str, Any]],
+    start: int,
+    end: int,
+    skill: str,
+    missing: list[str],
+    limit: int,
+) -> tuple[list[str], dict[str, int]]:
+    """Partition `missing` by the async-wait grace (#1550).
+
+    Returns `(still_missing, reprieved_counts)`. A step id is *reprieved*
+    when its marker count is `> 0` and `<= limit`: the model said on the
+    record that the work is delegated and in flight. Zero markers means it
+    never said anything (no free pass), and a count past `limit` means it
+    kept saying it with no step emit in between — stagnation, so the step
+    returns to the blocked list.
+
+    The reprieved counts come back alongside the surviving subset purely so
+    the caller's trace line can name what was excused and why.
+
+    Applies uniformly to every catalog skill — there is deliberately no
+    special case for `gh-issue-implement`, and the catalog schema is
+    unchanged.
+    """
+    if limit <= 0 or not missing:
+        return list(missing), {}
+    counts = _count_async_waits_in_section(messages, start, end, skill)
+    reprieved = {step: counts[step] for step in missing if 0 < counts.get(step, 0) <= limit}
+    return [step for step in missing if step not in reprieved], reprieved
+
+
 def main() -> int:
     if _BYPASS_ENABLED:
         return _allow("GH_SKILL_GUARD_BYPASS=1")
@@ -398,21 +517,35 @@ def main() -> int:
     seen = _scan_steps_in_section(messages, boundary_idx, end_idx, skill)
     missing = [step for step in required if step not in seen]
 
+    # Issue #1550 — a step whose work was delegated to a background/async
+    # Agent cannot honestly emit its `OK` marker yet, but the turn ending is
+    # a legitimate wait, not abandonment. Steps that said so via
+    # `[flow:async-wait]` (within the grace limit) drop out of the blocking
+    # set; everything else stays outstanding and is what the model is told
+    # about.
+    async_wait_limit = _async_wait_grace_limit()
+    outstanding, reprieved = _async_wait_reprieved(messages, boundary_idx, end_idx, skill, missing, async_wait_limit)
+
     if _TRACE_ENABLED:
+        reprieved_desc = ", ".join(f"{step}={reprieved[step]}" for step in sorted(reprieved)) or "none"
         _trace(
             f"skill={skill} boundary={boundary_idx} section_end={end_idx} "
-            f"seen={sorted(seen) or 'none'} missing={missing or 'none'} enforce={enforce}",
+            f"seen={sorted(seen) or 'none'} missing={missing or 'none'} "
+            f"async_wait_limit={async_wait_limit} async_wait_reprieved={reprieved_desc} "
+            f"outstanding={outstanding or 'none'} enforce={enforce}",
             layer="L1.5",
         )
 
-    if not missing:
+    if not outstanding:
+        if reprieved:
+            return _allow(f"{skill}: all required steps emitted or async-wait-reprieved", layer="L1.5")
         return _allow(f"{skill}: all required steps emitted", layer="L1.5")
 
     if not enforce:
         return _allow(f"{skill}: missing steps but enforce=false", layer="L1.5")
 
     description = entry.get("description") or skill
-    missing_list = ", ".join(missing)
+    missing_list = ", ".join(outstanding)
     reason = (
         f"{skill} ({description}) incomplete: missing required step "
         f"emit(s) [{missing_list}]. The SKILL.md for this skill declares "

--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -87,11 +87,12 @@ _DEFAULT_ASYNC_WAIT_LIMIT: int = 2
 # hooks read the same marker, they just derive different things from it (that
 # one counts a streak per chain, this one per required step id).
 #
-# `agent` is captured for audit/logging only and is deliberately NOT used in
-# any matching logic: making the grace depend on the model reproducing one
-# exact literal id string turn after turn would be fragile in precisely the
-# situation the marker exists for. A repeated marker with no intervening step
-# emit is sufficient evidence of stagnation on its own.
+# `agent` is required in the line — the transcript itself is the audit trail —
+# but deliberately NOT captured and NOT used in any matching logic: making the
+# grace depend on the model reproducing one exact literal id string turn after
+# turn would be fragile in precisely the situation the marker exists for. A
+# repeated marker with no intervening step emit is sufficient evidence of
+# stagnation on its own.
 #
 # Scanned in `role=assistant` text blocks ONLY, with
 # `include_tool_results=False` — asymmetric with `_STEP_EMIT_RE` above, which
@@ -102,7 +103,7 @@ _DEFAULT_ASYNC_WAIT_LIMIT: int = 2
 # document the marker literally. Reading tool_results here would
 # false-positive on any `Read` of those files (the issue #608 precedent).
 _ASYNC_WAIT_RE: re.Pattern[str] = re.compile(
-    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=(?P<agent>\S+)\s+reason=background-worker-delegated\s*$"
+    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=\S+\s+reason=background-worker-delegated\s*$"
 )
 
 
@@ -461,10 +462,12 @@ def _async_wait_reprieved(
     Applies uniformly to every catalog skill — there is deliberately no
     special case for `gh-issue-implement`, and the catalog schema is
     unchanged.
+
+    The `limit > 0 and missing` test is a pure walk-skip on the healthy path:
+    with either falsy the comprehension below is already unsatisfiable, so
+    the scan could not have changed the answer.
     """
-    if limit <= 0 or not missing:
-        return list(missing), {}
-    counts = _count_async_waits_in_section(messages, start, end, skill)
+    counts = _count_async_waits_in_section(messages, start, end, skill) if limit > 0 and missing else {}
     reprieved = {step: counts[step] for step in missing if 0 < counts.get(step, 0) <= limit}
     return [step for step in missing if step not in reprieved], reprieved
 
@@ -537,9 +540,8 @@ def main() -> int:
         )
 
     if not outstanding:
-        if reprieved:
-            return _allow(f"{skill}: all required steps emitted or async-wait-reprieved", layer="L1.5")
-        return _allow(f"{skill}: all required steps emitted", layer="L1.5")
+        qualifier = " or async-wait-reprieved" if reprieved else ""
+        return _allow(f"{skill}: all required steps emitted{qualifier}", layer="L1.5")
 
     if not enforce:
         return _allow(f"{skill}: missing steps but enforce=false", layer="L1.5")

--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -102,8 +102,15 @@ _DEFAULT_ASYNC_WAIT_LIMIT: int = 2
 # `claude/skills/gh-issue-flow/references/stop-guard.md`, both of which now
 # document the marker literally. Reading tool_results here would
 # false-positive on any `Read` of those files (the issue #608 precedent).
+#
+# Optional spaces around each `=` and optional double-quotes around each
+# value are tolerated (agy review, PR #1594 FOLLOW-UP) — an LLM asked to
+# reproduce a fixed-format line is prone to exactly this class of minor
+# formatting drift, and a rigid regex turns that drift into a spurious block
+# instead of the grace it was supposed to grant.
 _ASYNC_WAIT_RE: re.Pattern[str] = re.compile(
-    r"(?m)^\[flow:async-wait\]\s+step=(?P<step>\S+)\s+agent=\S+\s+reason=background-worker-delegated\s*$"
+    r'(?m)^\[flow:async-wait\]\s+step\s*=\s*"?(?P<step>[^\s"]+)"?'
+    r'\s+agent\s*=\s*"?[^\s"]+"?\s+reason\s*=\s*"?background-worker-delegated"?\s*$'
 )
 
 
@@ -411,7 +418,24 @@ def _count_async_waits_in_section(
     end: int,
     skill: str,
 ) -> dict[str, int]:
-    """Count `[flow:async-wait]` markers per step id in a section (#1550).
+    """Count TRAILING consecutive `[flow:async-wait]` turns, per step id (#1550).
+
+    A step's count is how many of the TRAILING consecutive assistant
+    messages in the section (walking backward from the section's last
+    message) carried THAT step's marker — not a flat total across the whole
+    section. codex + agy review (PR #1594) both flagged the original
+    flat-total version: an early marker for a step kept excusing it forever
+    after, even on a later turn whose own latest message named no marker at
+    all (or a real `[step:.../...] OK` for a DIFFERENT step, or plain
+    prose). The walk stops the instant a message fails to renew a given
+    step's claim, so the model must keep re-asserting the wait, turn after
+    turn, for grace to keep applying to that step.
+
+    Each assistant message contributes AT MOST 1 to a step's streak — a
+    per-message "did this turn name this step" set, not a count of regex
+    matches within it — so a single turn that happens to mention the marker
+    more than once (e.g. quoted inside explanatory prose) cannot burn
+    through the grace limit by itself (agy review).
 
     Only `role=assistant` text blocks are read, with
     `include_tool_results=False` — see `_ASYNC_WAIT_RE` for why that is
@@ -423,11 +447,12 @@ def _count_async_waits_in_section(
     `step=gh-issue-implement/implement` are both accepted. A value that does
     not name this section's skill is ignored — grace never crosses skills.
     """
-    counts: dict[str, int] = {}
+    per_message_steps: list[set[str]] = []
     for entry in messages[start + 1 : end]:
         msg = _message_payload(entry)
         if msg.get("role") != "assistant":
             continue
+        steps_here: set[str] = set()
         for text in _iter_text_blocks(msg, include_tool_results=False):
             for m in _ASYNC_WAIT_RE.finditer(text):
                 matched_skill, _, step_id = m.group("step").rpartition("/")
@@ -435,7 +460,19 @@ def _count_async_waits_in_section(
                     continue
                 if _normalize_skill(matched_skill) != skill:
                     continue
-                counts[step_id] = counts.get(step_id, 0) + 1
+                steps_here.add(step_id)
+        per_message_steps.append(steps_here)
+
+    all_steps: set[str] = set().union(*per_message_steps) if per_message_steps else set()
+    counts: dict[str, int] = {}
+    for step_id in all_steps:
+        streak = 0
+        for steps_here in reversed(per_message_steps):
+            if step_id not in steps_here:
+                break
+            streak += 1
+        if streak:
+            counts[step_id] = streak
     return counts
 
 

--- a/claude/hooks/skill_step_catalog.yml
+++ b/claude/hooks/skill_step_catalog.yml
@@ -36,6 +36,11 @@
 #     missing IDs.
 #   - Bypass any check globally with `GH_SKILL_GUARD_BYPASS=1`.
 #   - Trace what the hook is doing with `GH_SKILL_GUARD_TRACE=1` (stderr).
+#   - A step whose work was handed to a background Agent may stand in a
+#     `[flow:async-wait] step=<skill>/<step-id> agent=<id>
+#     reason=background-worker-delegated` line instead of its OK marker, for
+#     up to `GH_SKILL_GUARD_ASYNC_WAIT_LIMIT` turns (`0` disables). Default
+#     and mechanism: `claude/skills/gh-issue-flow/references/stop-guard.md`.
 #
 # Coexistence with gh_issue_flow_stop_guard.py:
 #   Stop hooks chain in `claude/settings.json` and run independently. Both

--- a/claude/skills/gh-issue-flow/references/critical-contract.md
+++ b/claude/skills/gh-issue-flow/references/critical-contract.md
@@ -35,6 +35,19 @@ with `--no-next-hint`).
    See `references/stop-guard.md` for the detection logic, safety rails,
    and how to disable it temporarily for debugging.
 
+**One narrow exception — async delegation (#1550).** When a sub-skill's own
+work is itself handed to a background/async `Agent` mid-chain (the
+Advisor/Worker delegation the global `CLAUDE.md` mandates for multi-file
+implementation), the outstanding step genuinely cannot finish inside this
+turn. Print the single line `[flow:async-wait] step=<skill>/<step>
+agent=<id> reason=background-worker-delegated` as assistant text and end the
+turn; the harness guard grants up to 2 consecutive grace turns before
+blocking resumes (mechanism: `references/stop-guard.md` → "Async-wait
+exception (#1550)"). This is **not** a license to stop mid-Step-2 for any
+other reason, and it does not relax guard #2 — the marker line is the only
+prose permitted, everything else in the zero-conversational-text rule
+stands.
+
 If you edit Step 2 in any way, re-verify all three guards are still in
 place. The harness guard is a backstop, not a license to weaken the
 prose rules — Claude can still emit verbose text BEFORE attempting to

--- a/claude/skills/gh-issue-flow/references/critical-contract.md
+++ b/claude/skills/gh-issue-flow/references/critical-contract.md
@@ -41,9 +41,9 @@ Advisor/Worker delegation the global `CLAUDE.md` mandates for multi-file
 implementation), the outstanding step genuinely cannot finish inside this
 turn. Print the single line `[flow:async-wait] step=<skill>/<step>
 agent=<id> reason=background-worker-delegated` as assistant text and end the
-turn; the harness guard grants up to 2 consecutive grace turns before
-blocking resumes (mechanism: `references/stop-guard.md` → "Async-wait
-exception (#1550)"). This is **not** a license to stop mid-Step-2 for any
+turn; the harness guard grants a small number of consecutive grace turns
+before blocking resumes (limit and mechanism: `references/stop-guard.md` →
+"Async-wait exception (#1550)"). This is **not** a license to stop mid-Step-2 for any
 other reason, and it does not relax guard #2 — the marker line is the only
 prose permitted, everything else in the zero-conversational-text rule
 stands.

--- a/claude/skills/gh-issue-flow/references/stop-guard.md
+++ b/claude/skills/gh-issue-flow/references/stop-guard.md
@@ -190,6 +190,67 @@ When `GH_ISSUE_FLOW_STOP_GUARD_TRACE=1`, each decision logs a
 `[stop-guard] … layer=L1|L1.5` line on stderr so the layer
 attribution is greppable in post-mortems.
 
+## Async-wait exception (#1550)
+
+Everything above treats "the model tried to stop with real work undone" as
+abandonment. That is right except in one case: the model *delegated* the
+undone work to a background/async `Agent` and is waiting for it — the
+Advisor/Worker pattern the user's global `CLAUDE.md` mandates for multi-file
+implementation. Following the policy therefore tripped both this hook and
+its sister `skill_completion_guard.py` every time, and the only escape was
+`GH_SKILL_GUARD_BYPASS=1`, which leaves no record of *why* the turn ended.
+
+**The marker.** Right before ending such a turn, the model prints one
+`(?m)^`-anchored line as plain assistant text:
+
+```
+[flow:async-wait] step=<skill>/<step> agent=<agent-id> reason=background-worker-delegated
+```
+
+`<skill>` is the hyphen-form skill name. For this outer guard `<step>` is
+not parsed semantically — the marker's mere presence is the signal — while
+`skill_completion_guard.py` matches it against a specific required step id.
+`<agent-id>` and the literal `reason=` are recorded for audit only. This is
+the marker's whole point over the bypass flag: the transcript says which
+step, which agent, and on what grounds the turn ended.
+
+**Assistant text only.** Unlike the sister hook's `[step:<skill>/<id>] OK`
+scan — which *must* read `tool_result`, because those markers come out of a
+`printf` in a Bash call — this marker is scanned with
+`include_tool_results=False`, exactly like the L1.5 terminal-marker scan
+above. Same #608 reasoning: a `tool_result` carries arbitrary file content,
+and both `gh_issue_flow_stop_guard.py` and this very document now contain
+the marker line literally as documentation. Reading tool_results for it
+would hand a free grace turn to any `Read` of either file. The asymmetry
+between the two hooks is deliberate; do not "fix" it.
+
+**Count-based, not agent-id-based.** The grace is a *streak*: markers found
+after the last progress event, where progress for this hook means a
+sub-skill `Skill()` invocation. Up to
+`GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT` (default 2) consecutive markers
+with no progress in between are allowed; from the next one the ordinary
+block resumes, with the ordinary reason naming the next chain step. `0`
+disables the grace entirely, so the first marker already blocks. A real
+sub-skill call resets the count to zero, which is what stops a streak
+accumulating across a whole flow.
+
+The issue's own fix plan proposed comparing `agent=` across turns to detect
+"no progress". That was rejected: it makes the guard depend on the model
+reproducing one exact literal id string turn after turn — fragile in
+precisely the situation the marker exists for, and a typo'd or regenerated
+id would silently grant unlimited grace. A repeated marker with nothing else
+happening in between is already sufficient evidence of stagnation, and needs
+nothing from the model but the marker itself.
+
+The check sits **after** the terminal-marker and stale-boundary decisions,
+so both still take priority; the grace only ever changes the outcome on the
+path that would otherwise block. The streak and limit are appended to the
+existing L1.5 trace line.
+
+The marker is a stop-gap for the wait, never a substitute for the real
+completion signal: when the delegated work lands, the genuine step-emit
+markers and the Step 3 report must still be produced normally.
+
 ## SubagentStop registration (#1434)
 
 ### Why
@@ -418,5 +479,22 @@ Re-install via `./setup.sh` to restore the default behaviour.
   falling back), a mid-flow subagent transcript → block, an
   unrelated subagent stop → allow, and the six existing fail-open rails
   re-asserted against a `SubagentStop`-shaped payload.
+- #1550 (async-wait grace): 1 marker → allow, 2 → allow (at the default
+  limit), 3 → block with the ordinary "gh-issue-flow incomplete" reason
+  naming the next sub-skill; a marker followed by a real `Skill(gh:commit)`
+  → the streak resets and the normal 2/6 block applies; the marker inside a
+  `tool_result` is ignored (the #608 class, applied to this marker); and
+  `GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT=0` blocks on the first marker
+  while `=1` allows exactly one.
 
 Run: `pytest tests/integration/test_gh_issue_flow_stop_guard.py -v`.
+
+The sister hook's half of #1550 lives in
+`tests/integration/test_skill_completion_guard.py`: grace reprieves only the
+step its own marker names (a sibling step with no marker still blocks and is
+the only one listed in the reason), colon-form `step=gh:issue-implement/…`
+is accepted, markers never cross skills, a 3rd marker returns the step to
+the blocked list, a real `[step:…] OK` after the marker satisfies the step
+through the ordinary path, the marker inside a `tool_result` is ignored
+(load-bearing here — that hook's step-OK scan *does* read tool_results), and
+`GH_SKILL_GUARD_ASYNC_WAIT_LIMIT` `0` / `1` behave as documented.

--- a/claude/skills/gh-issue-implement/references/implementation-flow.md
+++ b/claude/skills/gh-issue-implement/references/implementation-flow.md
@@ -90,6 +90,36 @@ Unchanged legacy flow — always available, never degraded.
 3. If fail → **Test-failure loop** (below).
 4. Report.
 
+### Async delegation of Step 5 (#1550)
+
+Applies to **both** paths above — either one's implementation work may be
+delegated. Per the global `CLAUDE.md` Advisor/Worker policy, open-ended
+multi-file implementation SHOULD go to a background/async subagent
+(`Agent`, `model: "opus"`) rather than run inline in the current turn. The
+`Agent` tool returns immediately and notifies on completion, so the turn
+ends with the work genuinely still in flight.
+
+When that happens, print this single line as assistant text and end the
+turn:
+
+```
+[flow:async-wait] step=gh-issue-implement/implement agent=<id> reason=background-worker-delegated
+```
+
+Use `step=gh-issue-implement/report` instead when only the final report step
+is still pending. `claude/hooks/skill_completion_guard.py` then excuses that
+step for up to 2 consecutive turns (env: `GH_SKILL_GUARD_ASYNC_WAIT_LIMIT`,
+`0` disables) before blocking resumes — mechanism and rationale in
+`claude/skills/gh-issue-flow/references/stop-guard.md` → "Async-wait
+exception (#1550)". Grace is per step: a step with no marker of its own is
+still reported as outstanding and still blocks.
+
+The marker is a stop-gap for the wait, **never a substitute for the real
+completion marker**. Once the delegated work actually finishes, verify it
+(see the global policy — a Worker's self-report is not evidence), then emit
+the genuine `[step:gh-issue-implement/implement] OK` /
+`[step:gh-issue-implement/report] OK` lines and the final report as usual.
+
 ## Test-failure loop (max 3 iterations, fallback path only)
 
 Uses `pre_existing_failures` from common step 4 above.

--- a/claude/skills/gh-issue-implement/references/implementation-flow.md
+++ b/claude/skills/gh-issue-implement/references/implementation-flow.md
@@ -108,11 +108,12 @@ turn:
 
 Use `step=gh-issue-implement/report` instead when only the final report step
 is still pending. `claude/hooks/skill_completion_guard.py` then excuses that
-step for up to 2 consecutive turns (env: `GH_SKILL_GUARD_ASYNC_WAIT_LIMIT`,
-`0` disables) before blocking resumes — mechanism and rationale in
+step for a limited number of consecutive turns before blocking resumes. Grace
+is per step: a step with no marker of its own is still reported as
+outstanding and still blocks. The limit, its env override, and the full
+rationale live in the SSOT —
 `claude/skills/gh-issue-flow/references/stop-guard.md` → "Async-wait
-exception (#1550)". Grace is per step: a step with no marker of its own is
-still reported as outstanding and still blocks.
+exception (#1550)".
 
 The marker is a stop-gap for the wait, **never a substitute for the real
 completion marker**. Once the delegated work actually finishes, verify it

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -2587,3 +2587,176 @@ def test_subagent_dispatch_prompt_is_boundary_not_a_fresh_prompt(tmp_path: Path)
         f"the boundary, expiring it immediately. stdout={result.stdout!r}"
     )
     assert json.loads(result.stdout)["decision"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1550 — the `[flow:async-wait]` grace. The guard could not tell
+# "the model abandoned the chain" from "the model delegated the outstanding
+# work to a background/async Agent and is waiting for it" — the Advisor/Worker
+# pattern the user's global CLAUDE.md mandates for multi-file implementation.
+# Following the policy therefore tripped the guard every time, and the only
+# escape was an unaudited `GH_SKILL_GUARD_BYPASS=1`.
+#
+# The marker is a single `(?m)^`-anchored line the model prints as plain
+# assistant text right before ending such a turn. Grace is COUNT-based (a
+# streak of markers with no intervening sub-skill invocation), never
+# agent-id-based: requiring the model to reproduce one exact literal id
+# string turn after turn would be fragile in exactly this situation.
+# ---------------------------------------------------------------------------
+
+_ASYNC_WAIT_LIMIT_ENV = "GH_ISSUE_FLOW_STOP_GUARD_ASYNC_WAIT_LIMIT"
+
+
+def _async_wait_marker(step: str = "gh-issue-implement/implement", agent: str = "a1") -> str:
+    """The literal marker line, built the way SKILL.md documents it."""
+    return f"[flow:async-wait] step={step} agent={agent} reason=background-worker-delegated"
+
+
+def _async_wait_text(step: str = "gh-issue-implement/implement", agent: str = "a1") -> dict[str, Any]:
+    """One assistant-text turn carrying nothing but the marker."""
+    return _assistant_text(_async_wait_marker(step, agent))
+
+
+def test_single_async_wait_marker_allows_stop(tmp_path: Path) -> None:
+    """1/6 sub-skills done + ONE async-wait marker → allow (streak 1 of 2)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _async_wait_text(),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"a single async-wait marker must buy one grace turn. stdout={result.stdout!r}"
+
+
+def test_two_consecutive_async_wait_markers_still_allow_stop(tmp_path: Path) -> None:
+    """Streak 2 sits exactly AT the default limit, so it is still allowed."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _async_wait_text(agent="a1"),
+            _async_wait_text(agent="a2"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"streak 2 is at the default limit and must still allow. stdout={result.stdout!r}"
+    )
+
+
+def test_three_consecutive_async_wait_markers_block(tmp_path: Path) -> None:
+    """Past the limit the marker stops buying anything — ordinary block resumes.
+
+    The block reason must be the NORMAL incomplete-chain one naming the next
+    sub-skill: the grace valve only ever decides allow-vs-block, it never
+    rewrites what the model is told to do.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _async_wait_text(agent="a1"),
+            _async_wait_text(agent="a2"),
+            _async_wait_text(agent="a3"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "3 markers with no progress is stagnation and must block"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "gh-issue-flow incomplete" in decision["reason"]
+    assert "Step 2.2 — Skill(gh-commit)" in decision["reason"]
+
+
+def test_progress_resets_the_async_wait_streak(tmp_path: Path) -> None:
+    """A real sub-skill call after a marker restarts the count from zero.
+
+    Marker → `Skill(gh:commit)` (progress) → stop with no further marker.
+    The pre-progress marker must not carry over, so the ordinary 2/6 block
+    applies. This is what stops a streak accumulating across a whole flow.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _async_wait_text(),
+            _assistant_skill("gh:commit"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        f"the streak must reset on progress, leaving the normal block. stdout={result.stdout!r}"
+    )
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "2/6 sub-skills" in decision["reason"]
+
+
+def test_async_wait_marker_inside_tool_result_does_not_count(tmp_path: Path) -> None:
+    """A marker in a `tool_result` is file content, never a turn-ending signal.
+
+    The #608 regression class applied to the new marker: this hook's own
+    source and `references/stop-guard.md` both now contain the literal marker
+    line as documentation, so a `Read` of either lands it in a `tool_result`.
+    Counting that would hand every such read two free grace turns.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _user_tool_result(
+                "Excerpt from references/stop-guard.md:\n"
+                f"{_async_wait_marker()}\n"
+                "…the harness grants up to 2 consecutive grace turns.\n"
+            ),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        f"a tool_result marker must be ignored, leaving the normal block. stdout={result.stdout!r}"
+    )
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_async_wait_limit_zero_disables_the_grace(tmp_path: Path) -> None:
+    """`…_ASYNC_WAIT_LIMIT=0` → the very first marker already blocks."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _async_wait_text(),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript), env={_ASYNC_WAIT_LIMIT_ENV: "0"})
+    assert result.returncode == 0
+    assert result.stdout.strip(), "limit 0 means zero grace"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+@pytest.mark.parametrize(
+    ("marker_count", "should_block"),
+    [(1, False), (2, True)],
+)
+def test_async_wait_limit_one_allows_exactly_one(tmp_path: Path, marker_count: int, should_block: bool) -> None:
+    """`…_ASYNC_WAIT_LIMIT=1` → 1 occurrence allows, the 2nd blocks."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            *[_async_wait_text(agent=f"a{i}") for i in range(marker_count)],
+        ],
+    )
+    result = _run_hook(_hook_event(transcript), env={_ASYNC_WAIT_LIMIT_ENV: "1"})
+    assert result.returncode == 0
+    if should_block:
+        assert result.stdout.strip(), f"streak {marker_count} exceeds limit 1 and must block"
+        assert json.loads(result.stdout)["decision"] == "block"
+    else:
+        assert result.stdout.strip() == "", f"streak {marker_count} is within limit 1. stdout={result.stdout!r}"

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -2698,6 +2698,69 @@ def test_progress_resets_the_async_wait_streak(tmp_path: Path) -> None:
     assert "2/6 sub-skills" in decision["reason"]
 
 
+def test_marker_in_history_but_absent_from_latest_turn_blocks(tmp_path: Path) -> None:
+    """A stale marker must not keep excusing a turn that omits it (PR #1594 review).
+
+    Marker → plain assistant text with no marker and no progress → stop.
+    The original flat-total streak let the FIRST marker grant grace
+    forever; codex and agy both flagged this as BLOCKING. The trailing
+    streak must stop dead at the marker-less message, so this must block —
+    a stale claim from an earlier turn buys nothing on a turn that renews
+    nothing.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _async_wait_text(),
+            _assistant_text("Checking on the background worker's status."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), (
+        f"a stale marker not renewed on the latest turn must not grant grace. stdout={result.stdout!r}"
+    )
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_two_markers_in_one_turn_only_counts_once(tmp_path: Path) -> None:
+    """A turn with the marker repeated (e.g. quoted in explanatory prose) still
+    contributes only 1 to the streak, not 2 (agy review, `findall` regression)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _assistant_text(f"{_async_wait_marker()}\n{_async_wait_marker()}"),
+            _async_wait_text(),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"two markers in one turn plus one more turn is streak 2, still within the default limit. "
+        f"stdout={result.stdout!r}"
+    )
+
+
+def test_async_wait_marker_tolerates_spacing_and_quotes(tmp_path: Path) -> None:
+    """A minor formatting variation (extra spaces, quoted values) still matches
+    (agy review FOLLOW-UP: the regex was too rigid for LLM-reproduced text)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_mid_flow_messages(),
+            _assistant_text(
+                '[flow:async-wait] step = "gh-issue-implement/implement" '
+                'agent="a1" reason="background-worker-delegated"'
+            ),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"quoted/spaced variant must still match. stdout={result.stdout!r}"
+
+
 def test_async_wait_marker_inside_tool_result_does_not_count(tmp_path: Path) -> None:
     """A marker in a `tool_result` is file content, never a turn-ending signal.
 

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -735,3 +735,255 @@ def test_hook_callable_two_ways(tmp_path: Path, exec_form: list[str]) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Issue #1550 — the `[flow:async-wait]` grace, per required step.
+#
+# A step whose work was handed to a background/async Agent cannot honestly
+# emit its `[step:<skill>/<id>] OK` marker in the same turn, but the turn
+# ending is a legitimate wait, not abandonment. The model says so on the
+# record with a `[flow:async-wait]` line; the guard excuses THAT step (and
+# only that step) for up to `GH_SKILL_GUARD_ASYNC_WAIT_LIMIT` consecutive
+# turns. The grace is catalog-generic — no skill is special-cased.
+# ---------------------------------------------------------------------------
+
+_ASYNC_WAIT_LIMIT_ENV = "GH_SKILL_GUARD_ASYNC_WAIT_LIMIT"
+
+
+def _async_wait_marker(step: str = "gh-issue-implement/implement", agent: str = "a1") -> str:
+    """The literal marker line, built the way the SKILL.md docs specify it."""
+    return f"[flow:async-wait] step={step} agent={agent} reason=background-worker-delegated"
+
+
+def _async_wait_text(step: str = "gh-issue-implement/implement", agent: str = "a1") -> dict[str, Any]:
+    """One assistant-text turn carrying nothing but the marker."""
+    return _assistant_text(_async_wait_marker(step, agent))
+
+
+def _partially_implemented() -> list[dict[str, Any]]:
+    """The exact incident state from #1550.
+
+    `fetch-issue` / `self-assign` / `board-transition` genuinely completed
+    and were emitted honestly; `implement` and `report` are the delegated
+    work that has not happened yet.
+    """
+    return [
+        _user_text("/gh-issue-implement 42"),
+        _emit_marker("gh-issue-implement", "fetch-issue"),
+        _emit_marker("gh-issue-implement", "self-assign"),
+        _emit_marker("gh-issue-implement", "board-transition"),
+    ]
+
+
+def test_async_wait_reprieves_only_its_own_step(tmp_path: Path) -> None:
+    """Grace covers the marked step and nothing else — the easy thing to get wrong.
+
+    `implement` carries an async-wait marker, `report` carries neither a
+    marker nor an OK. So the hook must still BLOCK, and the reason must name
+    `report` while NOT naming `implement`: a step with zero markers gets no
+    free ride just because a sibling step was reprieved.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "`report` is genuinely outstanding — must still block"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "report" in decision["reason"]
+    assert "implement" not in decision["reason"].split("emit(s) [")[1].split("]")[0], (
+        f"`implement` was reprieved and must not appear in the missing list. reason={decision['reason']!r}"
+    )
+
+
+def test_async_wait_covering_every_outstanding_step_allows_stop(tmp_path: Path) -> None:
+    """When every still-missing step is reprieved, the turn may end."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement"),
+            _async_wait_text("gh-issue-implement/report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"all outstanding steps are async-wait-reprieved. stdout={result.stdout!r}"
+
+
+def test_colon_form_step_prefix_accepted(tmp_path: Path) -> None:
+    """`step=gh:issue-implement/implement` normalizes to the catalog key."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh:issue-implement/implement"),
+            _async_wait_text("gh:issue-implement/report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"colon form must be accepted. stdout={result.stdout!r}"
+
+
+def test_async_wait_marker_for_another_skill_does_not_reprieve(tmp_path: Path) -> None:
+    """Grace never crosses skills — a `gh-pr/report` marker cannot excuse
+    `gh-issue-implement/report`."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement"),
+            _async_wait_text("gh-pr/report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "report" in decision["reason"]
+
+
+def test_three_async_wait_markers_return_the_step_to_the_blocked_list(tmp_path: Path) -> None:
+    """Repeating the marker with no `OK` in between is stagnation, not waiting."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/report"),
+            _async_wait_text("gh-issue-implement/implement", agent="a1"),
+            _async_wait_text("gh-issue-implement/implement", agent="a2"),
+            _async_wait_text("gh-issue-implement/implement", agent="a3"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "3 markers for one step exceeds the default limit"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    missing_list = decision["reason"].split("emit(s) [")[1].split("]")[0]
+    assert "implement" in missing_list, f"stagnating step must return to the list. got {missing_list!r}"
+    assert "report" not in missing_list, f"`report` is still within grace. got {missing_list!r}"
+
+
+def test_real_ok_marker_after_async_wait_satisfies_normally(tmp_path: Path) -> None:
+    """The async-wait marker is a stop-gap, never a substitute for the real one.
+
+    Once the delegated work lands and the genuine
+    `[step:gh-issue-implement/implement] OK` is emitted, the step is
+    satisfied through the ordinary path — proven here by repeating the
+    marker far past the grace limit, which would otherwise re-block it.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement", agent="a1"),
+            _async_wait_text("gh-issue-implement/implement", agent="a2"),
+            _async_wait_text("gh-issue-implement/implement", agent="a3"),
+            _emit_marker("gh-issue-implement", "implement"),
+            _emit_marker("gh-issue-implement", "report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"a real OK marker satisfies the step regardless of the streak. stdout={result.stdout!r}"
+    )
+
+
+def test_async_wait_marker_inside_tool_result_does_not_reprieve(tmp_path: Path) -> None:
+    """The marker is assistant-text-only, unlike the step-OK marker.
+
+    This hook DOES read `tool_result` for `[step:.../...] OK` (Bash printf
+    output lands there), so the assistant-text-only scoping of the
+    async-wait marker is a real, separately-implemented decision rather than
+    an inherited default. A `Read` of this hook's source or of
+    `stop-guard.md` puts the literal marker into a `tool_result`; counting it
+    would hand every such read two free turns.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _user_tool_result(
+                "Excerpt from references/stop-guard.md:\n"
+                f"{_async_wait_marker('gh-issue-implement/implement')}\n"
+                f"{_async_wait_marker('gh-issue-implement/report')}\n"
+            ),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "a tool_result marker must be ignored"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    missing_list = decision["reason"].split("emit(s) [")[1].split("]")[0]
+    assert "implement" in missing_list
+    assert "report" in missing_list
+
+
+def test_async_wait_limit_zero_disables_the_grace(tmp_path: Path) -> None:
+    """`GH_SKILL_GUARD_ASYNC_WAIT_LIMIT=0` → the first marker already blocks."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement"),
+            _async_wait_text("gh-issue-implement/report"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript), env={_ASYNC_WAIT_LIMIT_ENV: "0"})
+    assert result.returncode == 0
+    assert result.stdout.strip(), "limit 0 means zero grace"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    missing_list = decision["reason"].split("emit(s) [")[1].split("]")[0]
+    assert "implement" in missing_list
+    assert "report" in missing_list
+
+
+@pytest.mark.parametrize(
+    ("marker_count", "should_block"),
+    [(1, False), (2, True)],
+)
+def test_async_wait_limit_one_allows_exactly_one(tmp_path: Path, marker_count: int, should_block: bool) -> None:
+    """`GH_SKILL_GUARD_ASYNC_WAIT_LIMIT=1` → 1 occurrence allows, the 2nd blocks."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/report"),
+            *[_async_wait_text("gh-issue-implement/implement", agent=f"a{i}") for i in range(marker_count)],
+        ],
+    )
+    result = _run_hook(_hook_event(transcript), env={_ASYNC_WAIT_LIMIT_ENV: "1"})
+    assert result.returncode == 0
+    if should_block:
+        assert result.stdout.strip(), f"streak {marker_count} exceeds limit 1 and must block"
+        assert json.loads(result.stdout)["decision"] == "block"
+    else:
+        assert result.stdout.strip() == "", f"streak {marker_count} is within limit 1. stdout={result.stdout!r}"
+
+
+def test_trace_reports_async_wait_reprieve(tmp_path: Path) -> None:
+    """The L1.5 trace must name which steps were excused and by how many markers."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript), env={"GH_SKILL_GUARD_TRACE": "1"})
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["decision"] == "block"
+    assert "async_wait_reprieved=implement=1" in result.stderr
+    assert "async_wait_limit=2" in result.stderr
+    assert "outstanding=['report']" in result.stderr

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -803,13 +803,21 @@ def test_async_wait_reprieves_only_its_own_step(tmp_path: Path) -> None:
 
 
 def test_async_wait_covering_every_outstanding_step_allows_stop(tmp_path: Path) -> None:
-    """When every still-missing step is reprieved, the turn may end."""
+    """When every still-missing step is reprieved ON THE LATEST TURN, the turn may end.
+
+    Both markers land in the SAME assistant message — the realistic shape of
+    a turn that is deferring two steps at once. Splitting them across two
+    separate turns (the pre-fix shape of this test) would mean the FIRST
+    step's claim was never renewed on the final turn, which the trailing-
+    streak fix correctly treats as unclaimed (PR #1594 review).
+    """
     transcript = _write_transcript(
         tmp_path,
         [
             *_partially_implemented(),
-            _async_wait_text("gh-issue-implement/implement"),
-            _async_wait_text("gh-issue-implement/report"),
+            _assistant_text(
+                f"{_async_wait_marker('gh-issue-implement/implement')}\n{_async_wait_marker('gh-issue-implement/report')}"
+            ),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -823,8 +831,9 @@ def test_colon_form_step_prefix_accepted(tmp_path: Path) -> None:
         tmp_path,
         [
             *_partially_implemented(),
-            _async_wait_text("gh:issue-implement/implement"),
-            _async_wait_text("gh:issue-implement/report"),
+            _assistant_text(
+                f"{_async_wait_marker('gh:issue-implement/implement')}\n{_async_wait_marker('gh:issue-implement/report')}"
+            ),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -851,15 +860,25 @@ def test_async_wait_marker_for_another_skill_does_not_reprieve(tmp_path: Path) -
 
 
 def test_three_async_wait_markers_return_the_step_to_the_blocked_list(tmp_path: Path) -> None:
-    """Repeating the marker with no `OK` in between is stagnation, not waiting."""
+    """Repeating the marker with no `OK` in between is stagnation, not waiting.
+
+    `implement` is reasserted on all 3 trailing turns (streak 3, past the
+    default limit 2) and must return to the blocked list. `report` is
+    reasserted only on the LAST of those turns (streak 1, within limit) and
+    must stay reprieved — each step's grace is judged by its OWN trailing
+    streak, independent of the other's.
+    """
     transcript = _write_transcript(
         tmp_path,
         [
             *_partially_implemented(),
-            _async_wait_text("gh-issue-implement/report"),
             _async_wait_text("gh-issue-implement/implement", agent="a1"),
             _async_wait_text("gh-issue-implement/implement", agent="a2"),
-            _async_wait_text("gh-issue-implement/implement", agent="a3"),
+            _assistant_text(
+                _async_wait_marker("gh-issue-implement/implement", agent="a3")
+                + "\n"
+                + _async_wait_marker("gh-issue-implement/report")
+            ),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -870,6 +889,78 @@ def test_three_async_wait_markers_return_the_step_to_the_blocked_list(tmp_path: 
     missing_list = decision["reason"].split("emit(s) [")[1].split("]")[0]
     assert "implement" in missing_list, f"stagnating step must return to the list. got {missing_list!r}"
     assert "report" not in missing_list, f"`report` is still within grace. got {missing_list!r}"
+
+
+def test_marker_in_history_but_absent_from_latest_turn_blocks(tmp_path: Path) -> None:
+    """A stale marker must not keep excusing a step on a turn that omits it.
+
+    Marker for `implement` → plain assistant text with no marker at all →
+    stop. The original flat-total count let that first marker grant grace
+    forever; codex and agy both flagged this as BLOCKING (PR #1594) and agy
+    specifically noted this exact scenario had no test coverage. The
+    trailing streak must be 0 here, so `implement` returns to `missing`.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _async_wait_text("gh-issue-implement/implement"),
+            _assistant_text("Checking on the background worker's status."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "a stale marker not renewed on the latest turn must not grant grace"
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    missing_list = decision["reason"].split("emit(s) [")[1].split("]")[0]
+    assert "implement" in missing_list, f"the un-renewed step must return to the list. got {missing_list!r}"
+
+
+def test_two_markers_for_same_step_in_one_turn_only_counts_once(tmp_path: Path) -> None:
+    """A turn with the marker repeated for one step still contributes 1 to that
+    step's streak, not 2 (agy review, `findall`-per-step regression).
+
+    `report` is satisfied with a real `OK` marker up front so it drops out
+    of `missing` entirely — isolating this test to `implement`'s streak.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _emit_marker("gh-issue-implement", "report"),
+            _assistant_text(
+                f"{_async_wait_marker('gh-issue-implement/implement')}\n{_async_wait_marker('gh-issue-implement/implement')}"
+            ),
+            _async_wait_text("gh-issue-implement/implement"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"two markers in one turn plus one more turn is streak 2, still within the default limit. "
+        f"stdout={result.stdout!r}"
+    )
+
+
+def test_async_wait_marker_tolerates_spacing_and_quotes(tmp_path: Path) -> None:
+    """A minor formatting variation (extra spaces, quoted values) still matches
+    (agy review FOLLOW-UP: the regex was too rigid for LLM-reproduced text)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_partially_implemented(),
+            _assistant_text(
+                '[flow:async-wait] step = "gh-issue-implement/implement" '
+                'agent="a1" reason="background-worker-delegated"\n'
+                '[flow:async-wait] step = "gh-issue-implement/report" '
+                'agent="a1" reason="background-worker-delegated"'
+            ),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"quoted/spaced variant must still match. stdout={result.stdout!r}"
 
 
 def test_real_ok_marker_after_async_wait_satisfies_normally(tmp_path: Path) -> None:
@@ -954,12 +1045,17 @@ def test_async_wait_limit_zero_disables_the_grace(tmp_path: Path) -> None:
     [(1, False), (2, True)],
 )
 def test_async_wait_limit_one_allows_exactly_one(tmp_path: Path, marker_count: int, should_block: bool) -> None:
-    """`GH_SKILL_GUARD_ASYNC_WAIT_LIMIT=1` → 1 occurrence allows, the 2nd blocks."""
+    """`GH_SKILL_GUARD_ASYNC_WAIT_LIMIT=1` → 1 trailing occurrence allows, the 2nd blocks.
+
+    `report` is satisfied with a real `OK` marker up front so it drops out
+    of `missing` entirely — isolating this parametrization to `implement`'s
+    own trailing streak, independent of any other step's grace state.
+    """
     transcript = _write_transcript(
         tmp_path,
         [
             *_partially_implemented(),
-            _async_wait_text("gh-issue-implement/report"),
+            _emit_marker("gh-issue-implement", "report"),
             *[_async_wait_text("gh-issue-implement/implement", agent=f"a{i}") for i in range(marker_count)],
         ],
     )


### PR DESCRIPTION
## Summary
- gh-issue-flow / gh-issue-implement 의 Stop hook 가드 2개(`gh_issue_flow_stop_guard.py`, `skill_completion_guard.py`)가 백그라운드 Agent 위임(Advisor/Worker 정책)을 "방치"로 오판해 매턴 `GH_SKILL_GUARD_BYPASS=1` 수동 우회가 필요했던 문제를 고친다.
- `[flow:async-wait] step=<skill>/<step> agent=<id> reason=background-worker-delegated` 마커와, 진행 없이 반복된 횟수를 세는 카운트 기반 grace(기본 2회, 두 개 env var 로 조정 가능)를 두 가드에 도입한다.

## Changes
- `claude/hooks/gh_issue_flow_stop_guard.py`: 외부 6-스킬 체인용 grace — 마지막 sub-skill 호출 이후 마커 스트릭을 세어 1~2회는 허용, 3회부터 기존 차단으로 복귀.
- `claude/hooks/skill_completion_guard.py`: 카탈로그 범용 grace — 아직 미완료인 required step 각각에 대해 마커가 있으면 그 스텝만 개별적으로 유예(다른 스킬로는 넘어가지 않음).
- `claude/skills/gh-issue-flow/references/critical-contract.md`, `references/stop-guard.md`, `claude/skills/gh-issue-implement/references/implementation-flow.md`: 마커 형식·근거(에이전트 id 비교 대신 카운트 기반을 택한 이유, tool_result 를 읽지 않는 이유)를 문서화.
- `tests/integration/test_gh_issue_flow_stop_guard.py`, `tests/integration/test_skill_completion_guard.py`: streak/grace/env override/tool_result 제외/스킬 간 미유출 등 17개 케이스 추가.

## Test plan
- [x] `python3 -m pytest tests/integration/test_gh_issue_flow_stop_guard.py tests/integration/test_skill_completion_guard.py` — 164 passed
- [x] `mise run lint-py` (ruff check/format + mypy) — clean
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 uv run pytest tests/integration` — 1613 passed, 1 failed (기존에도 실패하던 `test_cancelling_fzf_exits_cleanly[zsh]` — `mapfile` 미존재, 이번 변경과 무관, stash 비교로 확인)

## Related
Closes #1550

---
<details>
<summary>🤖 AI Metrics · 📊 ~12500 tokens · 👤 ~2 h · 🤖 ~8 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~12500 tokens · 👤 ~2 h · 🤖 ~8 min
<!-- /ai-metrics:gh-pr -->

</details>
