### PR TITLE
fix(issue-watcher): return rc 2 on agent name overrun to avoid tick failure repeats

### DIFF
--- a/docs/public/changelog.d/2026-08-29-1592.md
+++ b/docs/public/changelog.d/2026-08-29-1592.md
@@ -1,0 +1,1 @@
+- 변경: **`issue_watcher_cron.sh` 의 `_iw_process_issue` 가 herdr 에이전트 이름 도출 실패(영구 스킵) 시 기존 1 대신 2를 반환하고, tick 집계 루프에서 이를 `skipped` 로 분리 집계하여 0 dispatched / 0 failed / Y skipped 상태일 때 비정상 종료(exit 1) 대신 정상 종료(exit 0)를 반환하도록 수정한다 — 영구 스킵 발생 시 cron 반복 실패 알림이 울리던 문제를 해결한다. (#1592)**

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -2500,7 +2500,11 @@ EOF
         exit 1
     fi
 
-    ux_success "Tick complete — ${_dispatched} issue(s) dispatched, ${_skipped} skipped, ${_failed} failed."
+    if [ "${_dispatched}" -eq 0 ] && [ "${_skipped}" -gt 0 ]; then
+        ux_warning "Tick complete — 0 issue(s) dispatched, ${_skipped} skipped, 0 failed."
+    else
+        ux_success "Tick complete — ${_dispatched} issue(s) dispatched, ${_skipped} skipped, ${_failed} failed."
+    fi
 }
 
 if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -1644,7 +1644,7 @@ _iw_process_issue() {
     # tick can look up (#1530).
     _agent=$(_iw_agent_name "${_repo}" "${_number}") || {
         ux_warning "Cannot derive a herdr agent name for ${_repo}#${_number} — the composed name is invalid or exceeds herdr's 32-char limit. This issue will be skipped on every tick until the naming scheme changes (see herdr_agent_name.sh, #1553)."
-        return 1
+        return 2
     }
     _label=$(_iw_workspace_label "${_repo}" "${_path}")
 
@@ -2270,7 +2270,7 @@ _iw_usage() {
 # ============================================================
 
 main() {
-    local _cwd="" _repo _number _path _host _rc _dispatched=0 _failed=0 _candidates _live
+    local _cwd="" _repo _number _path _host _rc _dispatched=0 _skipped=0 _failed=0 _candidates _live
     local _confirmed=""
 
     while [ "$#" -gt 0 ]; do
@@ -2480,6 +2480,8 @@ EOF
             # quota — collected here, judged after the loop.
             _confirmed="${_confirmed}$(_iw_agent_name "${_repo}" "${_number}")
 "
+        elif [ "${_rc}" -eq 2 ]; then
+            _skipped=$((_skipped + 1))
         else
             _failed=$((_failed + 1))
         fi
@@ -2494,11 +2496,11 @@ EOF
     _iw_limit_record "${_confirmed}"
 
     if [ "${_dispatched}" -eq 0 ] && [ "${_failed}" -gt 0 ]; then
-        ux_error "Tick complete — 0 dispatched, ${_failed} failed."
+        ux_error "Tick complete — 0 dispatched, ${_skipped} skipped, ${_failed} failed."
         exit 1
     fi
 
-    ux_success "Tick complete — ${_dispatched} issue(s) dispatched, ${_failed} failed."
+    ux_success "Tick complete — ${_dispatched} issue(s) dispatched, ${_skipped} skipped, ${_failed} failed."
 }
 
 if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1317,6 +1317,18 @@ _assert_not_hung() {
     _refute_logged "agent start"
 }
 
+@test "issue_watcher_cron: a mixed case with one skipped and one failed issue exits with failure" {
+    _write_watch_file '[{"repo":"acme/sixteen-char-rep","path":"'"${_REPO_DIR}"'","host":"github.com"}]'
+    _set_issues '[
+      {"number":1234567,"repository":{"nameWithOwner":"acme/sixteen-char-rep"},"labels":[]},
+      {"number":11,"repository":{"nameWithOwner":"acme/sixteen-char-rep"},"labels":[]}
+    ]'
+    _run_tick "IW_DISPATCH_PER_TICK=2" "HERDR_START_FAIL=1"
+    assert_failure
+    assert_output --partial "the composed name is invalid or exceeds herdr's 32-char limit"
+    assert_output --partial "Tick complete — 0 dispatched, 1 skipped, 1 failed."
+}
+
 # herdr refuses `agent start` unless the name matches
 # `^[a-z][a-z0-9_-]{0,31}$`. The pre-#1530 name folded the owner in verbatim
 # (`iw-<owner>-<repo>-<N>`), so a real owner like `dEitY719` made every name

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1299,9 +1299,10 @@ _assert_not_hung() {
     _write_watch_file '[{"repo":"acme/sixteen-char-rep","path":"'"${_REPO_DIR}"'","host":"github.com"}]'
     _set_issues '[{"number":1234567,"repository":{"nameWithOwner":"acme/sixteen-char-rep"},"labels":[]}]'
     _run_tick
-    assert_failure
+    assert_success
     assert_output --partial "the composed name is invalid or exceeds herdr's 32-char limit"
     assert_output --partial "skipped on every tick"
+    assert_output --partial "Tick complete — 0 issue(s) dispatched, 1 skipped, 0 failed."
     _refute_logged "agent start"
 
     # The WARN claims this recurs on *every* tick, not just this one (PR #1589
@@ -1310,8 +1311,9 @@ _assert_not_hung() {
     # the repo slug or the issue number between ticks.
     : >"${_LOG}"
     _run_tick
-    assert_failure
+    assert_success
     assert_output --partial "the composed name is invalid or exceeds herdr's 32-char limit"
+    assert_output --partial "Tick complete — 0 issue(s) dispatched, 1 skipped, 0 failed."
     _refute_logged "agent start"
 }
 


### PR DESCRIPTION
## Summary
- `issue_watcher_cron.sh`가 영구 스킵 대상 이슈로 인해 tick 실패를 발생시켜 반복 알림을 보내던 문제를 해결합니다.

## Changes
- `issue_watcher_cron.sh` (`_iw_process_issue`): herdr 에이전트 이름 도출 실패(길이 예산 초과) 시 기존 1 대신 2(skipped)를 반환하도록 수정합니다.
- `issue_watcher_cron.sh` (`main`): tick 루프에서 rc=2 결과를 `skipped` 카운트로 수집하고, 0 dispatched / 0 failed / Y skipped 인 경우 exit 1(비정상 종료) 대신 exit 0(정상 종료)으로 마치도록 변경합니다.
- `tests/bats/tools/issue_watcher_cron.bats`: 에이전트 이름 길이 초과에 따른 영구 스킵이 성공(exit 0)으로 종료되는지 검증하도록 테스트 케이스를 갱신하고 skipped 카운터가 출력되는지 확인합니다.
- `docs/public/changelog.d/2026-08-29-1592.md`: 변경 이력 변경 사항을 반영한 changelog fragment를 추가합니다.

## Test plan
- [x] `tests/bats/tools/issue_watcher_cron.bats` 실행 후 전체 성공 및 skipped 카운트 출력 검증.

## Related
Closes #1592
