### PR TITLE
docs(gh-issue-flow): CI-fail 미해결 위임 사유 문서화

### DIFF
--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -36,10 +36,8 @@
   this flow reaches those steps, so a synchronous call would be
   meaningless; `gh:pr-merge-train` routes a CI-red PR to
   `gh:pr-resolve-ci-fail` whenever it next processes that PR — via Step
-  2.4.1's best-effort wake (which can silently skip on a non-matching
-  remote or warn on a missing `aicron.sh`) or its own cron backstop, not
-  a guarantee tied to the wake alone. Detail:
-  `gh-pr-merge-train/references/routing-table.md`.
+  2.4.1's best-effort wake (see above) or, failing that, its own cron
+  backstop. Detail: `gh-pr-merge-train/references/routing-table.md`.
 - **Never fall back to `_dotfiles_setup_mode` alone for the host (#1403).**
   Step 1 exports `GH_HOST`/`TARGET_REPO`/`TARGET_HOST` from the `[remote]`'s
   URL, and every GitHub-touching sub-skill receives `[remote]` as an explicit

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -35,7 +35,8 @@
   never `gh:pr-resolve-ci-fail`. CI checks haven't finished by the time
   this flow reaches those steps, so a synchronous call would be
   meaningless; Step 2.4.1's merge-train wake hands that off to
-  `gh:pr-merge-train`'s routing table once checks report.
+  `gh:pr-merge-train`'s routing table once checks report. Detail:
+  `gh-pr-merge-train/references/routing-table.md`.
 - **Never fall back to `_dotfiles_setup_mode` alone for the host (#1403).**
   Step 1 exports `GH_HOST`/`TARGET_REPO`/`TARGET_HOST` from the `[remote]`'s
   URL, and every GitHub-touching sub-skill receives `[remote]` as an explicit

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -34,8 +34,11 @@
   2.5.1 call only `gh:pr-resolve-conflict` / `gh:pr-resolve-outdated` —
   never `gh:pr-resolve-ci-fail`. CI checks haven't finished by the time
   this flow reaches those steps, so a synchronous call would be
-  meaningless; Step 2.4.1's merge-train wake hands that off to
-  `gh:pr-merge-train`'s routing table once checks report. Detail:
+  meaningless; `gh:pr-merge-train` routes a CI-red PR to
+  `gh:pr-resolve-ci-fail` whenever it next processes that PR — via Step
+  2.4.1's best-effort wake (which can silently skip on a non-matching
+  remote or warn on a missing `aicron.sh`) or its own cron backstop, not
+  a guarantee tied to the wake alone. Detail:
   `gh-pr-merge-train/references/routing-table.md`.
 - **Never fall back to `_dotfiles_setup_mode` alone for the host (#1403).**
   Step 1 exports `GH_HOST`/`TARGET_REPO`/`TARGET_HOST` from the `[remote]`'s

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -30,6 +30,12 @@
 - Step 2.5.1 (gh:pr-resolve-outdated) does a clean rebase-sync when the
   base moved forward with no conflicts; it is a no-op when the PR is
   already up to date.
+- **CI-fail resolution is out of scope for this chain.** Step 2.5 and
+  2.5.1 call only `gh:pr-resolve-conflict` / `gh:pr-resolve-outdated` —
+  never `gh:pr-resolve-ci-fail`. CI checks haven't finished by the time
+  this flow reaches those steps, so a synchronous call would be
+  meaningless; Step 2.4.1's merge-train wake hands that off to
+  `gh:pr-merge-train`'s routing table once checks report.
 - **Never fall back to `_dotfiles_setup_mode` alone for the host (#1403).**
   Step 1 exports `GH_HOST`/`TARGET_REPO`/`TARGET_HOST` from the `[remote]`'s
   URL, and every GitHub-touching sub-skill receives `[remote]` as an explicit

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -55,6 +55,5 @@ on a feature branch with a clean working tree.
   3 (PR) failed, the commit stays.
 - Create a worktree or branch — user must be on a feature branch already.
 - Resolve CI failures synchronously — checks haven't completed by the
-  time this flow finishes. Step 2.4.1 wakes the merge-train dispatcher,
-  which routes CI-red PRs through gh:pr-resolve-ci-fail once checks
-  report (gh-pr-merge-train's routing table).
+  time this flow finishes; Step 2.4.1's merge-train wake routes CI-red
+  PRs to gh:pr-resolve-ci-fail once checks report.

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -54,8 +54,6 @@ on a feature branch with a clean working tree.
 - Roll back partial progress — if step 2 (commit) succeeded but step
   3 (PR) failed, the commit stays.
 - Create a worktree or branch — user must be on a feature branch already.
-- Resolve CI failures synchronously — checks haven't completed by the
-  time this flow finishes; gh:pr-merge-train routes CI-red PRs to
-  gh:pr-resolve-ci-fail whenever it next processes the PR, via Step
-  2.4.1's best-effort wake or its own cron backstop — not a guarantee
-  of the wake itself.
+- Resolve CI failures — a fresh PR's checks have not reported yet.
+  `gh:pr-merge-train` routes CI-red PRs to `gh:pr-resolve-ci-fail`
+  whenever it next processes the PR.

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -54,3 +54,7 @@ on a feature branch with a clean working tree.
 - Roll back partial progress — if step 2 (commit) succeeded but step
   3 (PR) failed, the commit stays.
 - Create a worktree or branch — user must be on a feature branch already.
+- Resolve CI failures synchronously — checks haven't completed by the
+  time this flow finishes. Step 2.4.1 wakes the merge-train dispatcher,
+  which routes CI-red PRs through gh:pr-resolve-ci-fail once checks
+  report (gh-pr-merge-train's routing table).

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -55,5 +55,7 @@ on a feature branch with a clean working tree.
   3 (PR) failed, the commit stays.
 - Create a worktree or branch — user must be on a feature branch already.
 - Resolve CI failures synchronously — checks haven't completed by the
-  time this flow finishes; Step 2.4.1's merge-train wake routes CI-red
-  PRs to gh:pr-resolve-ci-fail once checks report.
+  time this flow finishes; gh:pr-merge-train routes CI-red PRs to
+  gh:pr-resolve-ci-fail whenever it next processes the PR, via Step
+  2.4.1's best-effort wake or its own cron backstop — not a guarantee
+  of the wake itself.


### PR DESCRIPTION
## Summary
- `gh:issue-flow`이 Step 2.5/2.5.1에서 `gh:pr-resolve-conflict`/`gh:pr-resolve-outdated`만 호출하고 `gh:pr-resolve-ci-fail`은 호출하지 않는 이유를 문서화한다 — 실제 누락이 아니라 설계 의도(PR 생성 직후에는 CI 체크가 아직 진행 중이라 동기 호출이 무의미)임을 명시한다.

## Changes
- `claude/skills/gh-issue-flow/references/help.md`: "What this skill will NOT do" 섹션에 CI-fail 미해결 관련 항목 추가
- `claude/skills/gh-issue-flow/references/constraints.md`: Step 2.5/2.5.1의 책임 범위를 명시하는 제약 한 줄 추가 — CI-fail 해결은 Step 2.4.1의 merge-train wake가 `gh:pr-merge-train`의 라우팅 테이블로 위임함을 명문화

## Test plan
- [x] `git diff --stat` — 문서 2개 파일, 10줄 추가만 존재
- [x] `pytest` 전체 스위트 사전 실행 — 1620 passed, 0 failed (문서만 변경했으므로 회귀 없음 확인)

## Related
Closes #1582

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~7 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~7 min
<!-- /ai-metrics:gh-pr -->

</details>
