### PR TITLE
fix(gh-pr-merge): Step 5 게이트가 빈 바인딩을 이름과 함께 드러낸다

### DIFF
--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -104,12 +104,21 @@ HEAD_BRANCH=<headRefName>     # Step 2's `gh pr view` already read it
 BASE_BRANCH=<baseRefName>     # ditto — never a hardcoded `main`
 REMOTE=<remote>               # the `[remote]` positional, default `origin`
 
-# An empty value is a *binding* mistake, not an opt-out, and the lookup below
-# cannot tell it from an unwatched repo (#1576: PR #1572 left no trace). Name
-# every empty one, and never look up a half-bound run — the dispatch closes
-# tabs and rebases the main checkout.
+# A binding mistake is not just an empty value — it is also an unsubstituted
+# placeholder (`<owner/repo>` left as-is) or a whitespace-only value, both of
+# which pass `[ -n ]` and would silently reproduce this same #1576 bug (PR
+# #1603 review, agy + codex: "non-empty" != "correctly substituted"). None of
+# the three can be told apart from an unwatched repo by the lookup below, so
+# name every offender and never look up a half-bound run — the dispatch
+# closes tabs and rebases the main checkout.
 PMV_MISSING=""
-_pmv_need() { [ -n "$2" ] || PMV_MISSING="${PMV_MISSING:+$PMV_MISSING, }$1"; }
+_pmv_need() {
+    case "$2" in
+    '' | '<'*'>') PMV_MISSING="${PMV_MISSING:+$PMV_MISSING, }$1" ;;
+    *[!" "]*) ;;
+    *) PMV_MISSING="${PMV_MISSING:+$PMV_MISSING, }$1" ;;
+    esac
+}
 _pmv_need PR_NUMBER "${PR_NUMBER-}"
 _pmv_need TARGET_REPO "${TARGET_REPO-}"
 _pmv_need HEAD_BRANCH "${HEAD_BRANCH-}"
@@ -119,7 +128,7 @@ _pmv_need REMOTE "${REMOTE-}"
 WATCHED_FILE="${IW_WATCHED_REPOS:-${HOME}/.agent-factory/avatars/issue-watcher/watched-repos.json}"
 VERIFY_SKILL=""
 if [ -n "$PMV_MISSING" ]; then
-    printf '[WARN] gh:pr-merge: post-merge verification gate has empty bindings (%s) — substitute all five values and re-run this block.\n' \
+    printf '[WARN] gh:pr-merge: post-merge verification gate has unbound values (%s) — substitute all five values (no placeholders, no blanks) and re-run this block.\n' \
         "$PMV_MISSING"
 elif command -v jq >/dev/null 2>&1 && [ -r "$WATCHED_FILE" ]; then
     VERIFY_SKILL=$(jq -r --arg r "$TARGET_REPO" \

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -104,16 +104,34 @@ HEAD_BRANCH=<headRefName>     # Step 2's `gh pr view` already read it
 BASE_BRANCH=<baseRefName>     # ditto — never a hardcoded `main`
 REMOTE=<remote>               # the `[remote]` positional, default `origin`
 
+# A value left empty here is a *binding* mistake, not an opt-out — and the
+# registry lookup below answers empty for an empty TARGET_REPO exactly as it
+# does for an unwatched repo, so the two are indistinguishable from the
+# outside. That ambiguity is #1576: PR #1572 dispatched nothing and left no
+# trace of why. Name the offenders on one line, and never look up a half-bound
+# run: the dispatch closes tabs and rebases the main checkout.
+PMV_MISSING=""
+for _pmv_v in "PR_NUMBER=${PR_NUMBER-}" "TARGET_REPO=${TARGET_REPO-}" \
+    "HEAD_BRANCH=${HEAD_BRANCH-}" "BASE_BRANCH=${BASE_BRANCH-}" "REMOTE=${REMOTE-}"; do
+    case "$_pmv_v" in
+    *=) PMV_MISSING="${PMV_MISSING:+$PMV_MISSING, }${_pmv_v%=}" ;;
+    esac
+done
+
 WATCHED_FILE="${IW_WATCHED_REPOS:-${HOME}/.agent-factory/avatars/issue-watcher/watched-repos.json}"
 VERIFY_SKILL=""
-if command -v jq >/dev/null 2>&1 && [ -r "$WATCHED_FILE" ]; then
+if [ -n "$PMV_MISSING" ]; then
+    printf '[WARN] gh:pr-merge: post-merge verification gate has empty bindings (%s) — substitute all five values and re-run this block.\n' \
+        "$PMV_MISSING"
+elif command -v jq >/dev/null 2>&1 && [ -r "$WATCHED_FILE" ]; then
     VERIFY_SKILL=$(jq -r --arg r "$TARGET_REPO" \
         '(if type == "array" then . else (.repos // []) end) | .[] | select(.repo == $r) | .verify_skill // empty' "$WATCHED_FILE" 2>/dev/null)
 fi
-# Empty VERIFY_SKILL — repo not registered, no registry, or no jq, so the
-# feature is simply unavailable — means do nothing at all: no output, no
-# dispatch, and no [WARN] either. An unwatched repo stays byte-identical to
-# its pre-#1511 behavior.
+# Empty VERIFY_SKILL with all five values bound — repo not registered, no
+# registry, or no jq, so the feature is simply unavailable — means do nothing
+# at all: no output, no dispatch, and no [WARN] either. An unwatched repo
+# stays byte-identical to its pre-#1511 behavior. Only an empty *binding*
+# speaks up, above.
 if [ -n "$VERIFY_SKILL" ]; then
     # gh:pr-post-merge-verify's dispatch block is READ from its SSOT and run
     # here, rather than reached through `Skill(gh:pr-post-merge-verify, ...)`.

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -104,19 +104,17 @@ HEAD_BRANCH=<headRefName>     # Step 2's `gh pr view` already read it
 BASE_BRANCH=<baseRefName>     # ditto — never a hardcoded `main`
 REMOTE=<remote>               # the `[remote]` positional, default `origin`
 
-# A value left empty here is a *binding* mistake, not an opt-out — and the
-# registry lookup below answers empty for an empty TARGET_REPO exactly as it
-# does for an unwatched repo, so the two are indistinguishable from the
-# outside. That ambiguity is #1576: PR #1572 dispatched nothing and left no
-# trace of why. Name the offenders on one line, and never look up a half-bound
-# run: the dispatch closes tabs and rebases the main checkout.
+# An empty value is a *binding* mistake, not an opt-out, and the lookup below
+# cannot tell it from an unwatched repo (#1576: PR #1572 left no trace). Name
+# every empty one, and never look up a half-bound run — the dispatch closes
+# tabs and rebases the main checkout.
 PMV_MISSING=""
-for _pmv_v in "PR_NUMBER=${PR_NUMBER-}" "TARGET_REPO=${TARGET_REPO-}" \
-    "HEAD_BRANCH=${HEAD_BRANCH-}" "BASE_BRANCH=${BASE_BRANCH-}" "REMOTE=${REMOTE-}"; do
-    case "$_pmv_v" in
-    *=) PMV_MISSING="${PMV_MISSING:+$PMV_MISSING, }${_pmv_v%=}" ;;
-    esac
-done
+_pmv_need() { [ -n "$2" ] || PMV_MISSING="${PMV_MISSING:+$PMV_MISSING, }$1"; }
+_pmv_need PR_NUMBER "${PR_NUMBER-}"
+_pmv_need TARGET_REPO "${TARGET_REPO-}"
+_pmv_need HEAD_BRANCH "${HEAD_BRANCH-}"
+_pmv_need BASE_BRANCH "${BASE_BRANCH-}"
+_pmv_need REMOTE "${REMOTE-}"
 
 WATCHED_FILE="${IW_WATCHED_REPOS:-${HOME}/.agent-factory/avatars/issue-watcher/watched-repos.json}"
 VERIFY_SKILL=""
@@ -130,8 +128,7 @@ fi
 # Empty VERIFY_SKILL with all five values bound — repo not registered, no
 # registry, or no jq, so the feature is simply unavailable — means do nothing
 # at all: no output, no dispatch, and no [WARN] either. An unwatched repo
-# stays byte-identical to its pre-#1511 behavior. Only an empty *binding*
-# speaks up, above.
+# stays byte-identical to its pre-#1511 behavior.
 if [ -n "$VERIFY_SKILL" ]; then
     # gh:pr-post-merge-verify's dispatch block is READ from its SSOT and run
     # here, rather than reached through `Skill(gh:pr-post-merge-verify, ...)`.

--- a/docs/public/changelog.d/2026-08-31-1576.md
+++ b/docs/public/changelog.d/2026-08-31-1576.md
@@ -1,0 +1,1 @@
+- 변경: **gh:pr-merge Step 5 의 post-merge 검증 게이트가 다섯 값(`PR_NUMBER`/`TARGET_REPO`/`HEAD_BRANCH`/`BASE_BRANCH`/`REMOTE`) 중 비어 있는 것을 registry 조회 전에 한 줄 `[WARN]` 으로 이름과 함께 드러낸다 — 지금까지는 바인딩 누락과 "watched-repos 에 없는 repo" 가 똑같이 무출력이라 PR #1572 처럼 검증이 통째로 누락돼도 흔적이 남지 않았다. 다섯 값이 모두 채워진 미등록 repo 는 종전대로 완전 무출력(#1511 계약 유지). (#1576)**

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -1220,3 +1220,152 @@ _PMV_WAIT_ASSIGN='^(_IW_SETTLE_SECONDS|_PMT_SETTLE_SECONDS|PMV_SETTLE_SECONDS|_I
     run grep -qF -- 'closed the empty verification tab' "$_doc"
     assert_success
 }
+
+# --- #1576: an empty binding in Step 5's gate is named, never silent -------
+#
+# The gate looks one registry key up and does nothing when the answer is empty.
+# An unwatched repo and a TARGET_REPO that was never substituted both produce
+# that same empty answer, so PR #1572's missing dispatch left no trace at all:
+# no pr-<N> tab, no rebase, and not one line to say which of the two happened.
+# The lookup only means "unwatched" once the five values are known to be bound,
+# so the binding check runs first and names the offenders. The unwatched-repo
+# silence (#1511 A-1) is what must NOT change, and is pinned here too.
+
+# Step 5's gate is the first bash fence under "## Step 5" — the one opened by
+# the `# Substitute the five values` comment, not Step 3's merge command or
+# Step 5's own `gh pr view`. Taken out of the shipped SKILL.md, never a copy.
+_PMV_GATE_AWK='$0 == f "bash" { inb = 1; p = 0; next }
+inb && $0 == f { if (p) exit; inb = 0; next }
+inb && !p && $0 ~ /^# Substitute the five values/ { p = 1 }
+p { print }'
+
+_pmv_gate_block() {
+    local _out="${TEST_TEMP_HOME}/gate-block.sh"
+    awk -v f="$(printf '\140\140\140')" "$_PMV_GATE_AWK" "$(_pmv_merge_skill)" >"$_out"
+    printf '%s' "$_out"
+}
+
+# Paste it the way Step 5 instructs: the five placeholders are replaced by the
+# caller's values — an empty one is exactly the mistake under test.
+_pmv_gate_bind() {
+    local _out="${TEST_TEMP_HOME}/gate-bound.sh"
+    sed -e "s|^PR_NUMBER=<N>.*|PR_NUMBER=${1-}|" \
+        -e "s|^TARGET_REPO=<owner/repo>.*|TARGET_REPO=${2-}|" \
+        -e "s|^HEAD_BRANCH=<headRefName>.*|HEAD_BRANCH=${3-}|" \
+        -e "s|^BASE_BRANCH=<baseRefName>.*|BASE_BRANCH=${4-}|" \
+        -e "s|^REMOTE=<remote>.*|REMOTE=${5-}|" "$(_pmv_gate_block)" >"$_out"
+    printf '%s' "$_out"
+}
+
+# A herdr that records instead of acting: an empty binding must never reach it.
+_pmv_gate_bin() {
+    local _bin="${TEST_TEMP_HOME}/gatebin"
+    mkdir -p "$_bin"
+    printf '#!/bin/sh\nprintf "%%s\\n" "$*" >>"%s"\nexit 0\n' "$FAKE_HERDR_LOG" >"${_bin}/herdr"
+    chmod +x "${_bin}/herdr"
+    printf '%s' "$_bin"
+}
+
+@test "1576: Step 5's gate block extracts, binds, and is valid shell" {
+    local _bound
+    _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 main origin)"
+    run head -n 1 "$_bound"
+    assert_output --partial 'Substitute the five values'
+    run tail -n 1 "$_bound"
+    assert_output "fi"
+    # A renamed placeholder would leave the assignments unsubstituted and make
+    # every test below pass for the wrong reason.
+    run grep -cE '^(PR_NUMBER|TARGET_REPO|HEAD_BRANCH|BASE_BRANCH|REMOTE)=<' "$_bound"
+    assert_output "0"
+    run bash -n "$_bound"
+    assert_success
+}
+
+@test "1576: an empty TARGET_REPO is named instead of read as 'unwatched'" {
+    local _bound _bin
+    _bound="$(_pmv_gate_bind 77 "" wt/issue-77/1 main origin)"
+    _bin="$(_pmv_gate_bin)"
+    run env PATH="${_bin}:${PATH}" IW_WATCHED_REPOS="$WATCHED" \
+        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    assert_success
+    assert_output --partial '[WARN] gh:pr-merge:'
+    assert_output --partial 'TARGET_REPO'
+    # Named, and stopped: nothing may be closed or rebased on a half-bound run.
+    refute_output --partial 'gh:pr-post-merge-verify'
+    run cat "$FAKE_HERDR_LOG"
+    assert_output ""
+}
+
+@test "1576: whichever of the five is empty is the one the WARN names" {
+    local _bound _bin _v
+    _bin="$(_pmv_gate_bin)"
+    for _v in PR_NUMBER TARGET_REPO HEAD_BRANCH BASE_BRANCH REMOTE; do
+        case "$_v" in
+        PR_NUMBER) _bound="$(_pmv_gate_bind "" acme/dotfiles wt/issue-77/1 main origin)" ;;
+        TARGET_REPO) _bound="$(_pmv_gate_bind 77 "" wt/issue-77/1 main origin)" ;;
+        HEAD_BRANCH) _bound="$(_pmv_gate_bind 77 acme/dotfiles "" main origin)" ;;
+        BASE_BRANCH) _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 "" origin)" ;;
+        REMOTE) _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 main "")" ;;
+        esac
+        run env PATH="${_bin}:${PATH}" IW_WATCHED_REPOS="$WATCHED" \
+            DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+        assert_success
+        assert_output --partial "$_v"
+        [ "${#lines[@]}" -eq 1 ]
+    done
+    run cat "$FAKE_HERDR_LOG"
+    assert_output ""
+}
+
+@test "1576: several empty bindings share one WARN line, not one each" {
+    local _bound
+    _bound="$(_pmv_gate_bind "" "" wt/issue-77/1 main "")"
+    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$WATCHED" \
+        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    assert_success
+    [ "${#lines[@]}" -eq 1 ]
+    assert_output --partial 'PR_NUMBER'
+    assert_output --partial 'TARGET_REPO'
+    assert_output --partial 'REMOTE'
+    refute_output --partial 'HEAD_BRANCH'
+    refute_output --partial 'BASE_BRANCH'
+}
+
+@test "1576: a fully bound but unwatched repo is still silent (#1511 A-1)" {
+    # The regression this fix must not cause: an unregistered repo stays
+    # byte-identical to its pre-#1511 behavior — no WARN, no output at all.
+    local _bound
+    _bound="$(_pmv_gate_bind 77 other/repo wt/issue-77/1 main origin)"
+    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$WATCHED" \
+        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    assert_success
+    assert_output ""
+    run cat "$FAKE_HERDR_LOG"
+    assert_output ""
+}
+
+@test "1576: a fully bound registered repo still reaches the dispatch" {
+    # The other half of the same guard: the binding check must gate nothing
+    # when all five are bound. The registry points the dispatch at a path that
+    # is not a git worktree root, so it stops with its own WARN before any
+    # side effect — proof the staged block ran.
+    local _bound _reg
+    _reg="${TEST_TEMP_HOME}/bound-watched.json"
+    printf '[{"repo":"acme/dotfiles","verify_skill":"devx:pr-verify-merged","path":"%s"}]\n' \
+        "${TEST_TEMP_HOME}/not-a-repo" >"$_reg"
+    _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 main origin)"
+    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$_reg" \
+        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    assert_success
+    assert_output --partial '[WARN] gh:pr-post-merge-verify:'
+    assert_output --partial 'is not a git worktree root'
+}
+
+@test "1576: the binding check runs before the registry lookup" {
+    local _skill _check _lookup
+    _skill="$(_pmv_merge_skill)"
+    _check=$(grep -n 'PMV_MISSING=""' "$_skill" | head -1 | cut -d: -f1)
+    _lookup=$(grep -n 'VERIFY_SKILL=\$(jq -r --arg r' "$_skill" | head -1 | cut -d: -f1)
+    [ -n "$_check" ] && [ -n "$_lookup" ]
+    [ "$_check" -lt "$_lookup" ]
+}

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -1246,14 +1246,17 @@ _pmv_gate_block() {
 }
 
 # Paste it the way Step 5 instructs: the five placeholders are replaced by the
-# caller's values — an empty one is exactly the mistake under test.
+# caller's values — an empty one is exactly the mistake under test. Quoted so
+# a whitespace-only value survives the substitution instead of collapsing to
+# an unquoted no-op (an unquoted `TARGET_REPO=   ` assigns empty anyway,
+# which would silently retest the plain-empty case).
 _pmv_gate_bind() {
     local _out="${TEST_TEMP_HOME}/gate-bound.sh"
-    sed -e "s|^PR_NUMBER=<N>.*|PR_NUMBER=${1-}|" \
-        -e "s|^TARGET_REPO=<owner/repo>.*|TARGET_REPO=${2-}|" \
-        -e "s|^HEAD_BRANCH=<headRefName>.*|HEAD_BRANCH=${3-}|" \
-        -e "s|^BASE_BRANCH=<baseRefName>.*|BASE_BRANCH=${4-}|" \
-        -e "s|^REMOTE=<remote>.*|REMOTE=${5-}|" "$(_pmv_gate_block)" >"$_out"
+    sed -e "s|^PR_NUMBER=<N>.*|PR_NUMBER=\"${1-}\"|" \
+        -e "s|^TARGET_REPO=<owner/repo>.*|TARGET_REPO=\"${2-}\"|" \
+        -e "s|^HEAD_BRANCH=<headRefName>.*|HEAD_BRANCH=\"${3-}\"|" \
+        -e "s|^BASE_BRANCH=<baseRefName>.*|BASE_BRANCH=\"${4-}\"|" \
+        -e "s|^REMOTE=<remote>.*|REMOTE=\"${5-}\"|" "$(_pmv_gate_block)" >"$_out"
     printf '%s' "$_out"
 }
 
@@ -1296,6 +1299,31 @@ _pmv_gate_run() {
     assert_output --partial '[WARN] gh:pr-merge:'
     assert_output --partial 'TARGET_REPO'
     # Named, and stopped: nothing may be closed or rebased on a half-bound run.
+    refute_output --partial 'gh:pr-post-merge-verify'
+    run cat "$FAKE_HERDR_LOG"
+    assert_output ""
+}
+
+# PR #1603 review (agy + codex): "non-empty" is not "correctly substituted" —
+# a forgotten placeholder or a whitespace-only paste both pass a bare
+# `[ -n ]` check and would silently reproduce the exact #1576 bug this gate
+# exists to surface.
+
+@test "1576: an unsubstituted placeholder is named, not read as a real value" {
+    _pmv_gate_run "$WATCHED" 77 '<owner/repo>' wt/issue-77/1 main origin
+    assert_success
+    assert_output --partial '[WARN] gh:pr-merge:'
+    assert_output --partial 'TARGET_REPO'
+    refute_output --partial 'gh:pr-post-merge-verify'
+    run cat "$FAKE_HERDR_LOG"
+    assert_output ""
+}
+
+@test "1576: a whitespace-only value is named, not read as bound" {
+    _pmv_gate_run "$WATCHED" 77 '   ' wt/issue-77/1 main origin
+    assert_success
+    assert_output --partial '[WARN] gh:pr-merge:'
+    assert_output --partial 'TARGET_REPO'
     refute_output --partial 'gh:pr-post-merge-verify'
     run cat "$FAKE_HERDR_LOG"
     assert_output ""
@@ -1352,6 +1380,11 @@ _pmv_gate_run() {
     assert_success
     assert_output --partial '[WARN] gh:pr-post-merge-verify:'
     assert_output --partial 'is not a git worktree root'
+    # codex review (PR #1603): the warning text alone doesn't prove the
+    # dispatch actually ran rather than being skipped — pin that no herdr
+    # call happened either, which is what this stop point guarantees.
+    run cat "$FAKE_HERDR_LOG"
+    assert_output ""
 }
 
 @test "1576: the binding check runs before the registry lookup" {

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -1266,6 +1266,15 @@ _pmv_gate_bin() {
     printf '%s' "$_bin"
 }
 
+# Bind and run the gate in one call, the way Step 5 pastes it: $1 is the
+# registry, then the five values. Leaves `run`'s $status/$output/$lines set.
+_pmv_gate_run() {
+    local _reg="$1"
+    shift
+    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$_reg" \
+        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$(_pmv_gate_bind "$@")"
+}
+
 @test "1576: Step 5's gate block extracts, binds, and is valid shell" {
     local _bound
     _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 main origin)"
@@ -1282,11 +1291,7 @@ _pmv_gate_bin() {
 }
 
 @test "1576: an empty TARGET_REPO is named instead of read as 'unwatched'" {
-    local _bound _bin
-    _bound="$(_pmv_gate_bind 77 "" wt/issue-77/1 main origin)"
-    _bin="$(_pmv_gate_bin)"
-    run env PATH="${_bin}:${PATH}" IW_WATCHED_REPOS="$WATCHED" \
-        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    _pmv_gate_run "$WATCHED" 77 "" wt/issue-77/1 main origin
     assert_success
     assert_output --partial '[WARN] gh:pr-merge:'
     assert_output --partial 'TARGET_REPO'
@@ -1297,18 +1302,15 @@ _pmv_gate_bin() {
 }
 
 @test "1576: whichever of the five is empty is the one the WARN names" {
-    local _bound _bin _v
-    _bin="$(_pmv_gate_bin)"
+    local _v
     for _v in PR_NUMBER TARGET_REPO HEAD_BRANCH BASE_BRANCH REMOTE; do
         case "$_v" in
-        PR_NUMBER) _bound="$(_pmv_gate_bind "" acme/dotfiles wt/issue-77/1 main origin)" ;;
-        TARGET_REPO) _bound="$(_pmv_gate_bind 77 "" wt/issue-77/1 main origin)" ;;
-        HEAD_BRANCH) _bound="$(_pmv_gate_bind 77 acme/dotfiles "" main origin)" ;;
-        BASE_BRANCH) _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 "" origin)" ;;
-        REMOTE) _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 main "")" ;;
+        PR_NUMBER) _pmv_gate_run "$WATCHED" "" acme/dotfiles wt/issue-77/1 main origin ;;
+        TARGET_REPO) _pmv_gate_run "$WATCHED" 77 "" wt/issue-77/1 main origin ;;
+        HEAD_BRANCH) _pmv_gate_run "$WATCHED" 77 acme/dotfiles "" main origin ;;
+        BASE_BRANCH) _pmv_gate_run "$WATCHED" 77 acme/dotfiles wt/issue-77/1 "" origin ;;
+        REMOTE) _pmv_gate_run "$WATCHED" 77 acme/dotfiles wt/issue-77/1 main "" ;;
         esac
-        run env PATH="${_bin}:${PATH}" IW_WATCHED_REPOS="$WATCHED" \
-            DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
         assert_success
         assert_output --partial "$_v"
         [ "${#lines[@]}" -eq 1 ]
@@ -1318,10 +1320,7 @@ _pmv_gate_bin() {
 }
 
 @test "1576: several empty bindings share one WARN line, not one each" {
-    local _bound
-    _bound="$(_pmv_gate_bind "" "" wt/issue-77/1 main "")"
-    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$WATCHED" \
-        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    _pmv_gate_run "$WATCHED" "" "" wt/issue-77/1 main ""
     assert_success
     [ "${#lines[@]}" -eq 1 ]
     assert_output --partial 'PR_NUMBER'
@@ -1334,10 +1333,7 @@ _pmv_gate_bin() {
 @test "1576: a fully bound but unwatched repo is still silent (#1511 A-1)" {
     # The regression this fix must not cause: an unregistered repo stays
     # byte-identical to its pre-#1511 behavior — no WARN, no output at all.
-    local _bound
-    _bound="$(_pmv_gate_bind 77 other/repo wt/issue-77/1 main origin)"
-    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$WATCHED" \
-        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    _pmv_gate_run "$WATCHED" 77 other/repo wt/issue-77/1 main origin
     assert_success
     assert_output ""
     run cat "$FAKE_HERDR_LOG"
@@ -1349,13 +1345,10 @@ _pmv_gate_bin() {
     # when all five are bound. The registry points the dispatch at a path that
     # is not a git worktree root, so it stops with its own WARN before any
     # side effect — proof the staged block ran.
-    local _bound _reg
-    _reg="${TEST_TEMP_HOME}/bound-watched.json"
+    local _reg="${TEST_TEMP_HOME}/bound-watched.json"
     printf '[{"repo":"acme/dotfiles","verify_skill":"devx:pr-verify-merged","path":"%s"}]\n' \
         "${TEST_TEMP_HOME}/not-a-repo" >"$_reg"
-    _bound="$(_pmv_gate_bind 77 acme/dotfiles wt/issue-77/1 main origin)"
-    run env PATH="$(_pmv_gate_bin):${PATH}" IW_WATCHED_REPOS="$_reg" \
-        DOTFILES_ROOT="$_BATS_REAL_DOTFILES_ROOT" bash "$_bound"
+    _pmv_gate_run "$_reg" 77 acme/dotfiles wt/issue-77/1 main origin
     assert_success
     assert_output --partial '[WARN] gh:pr-post-merge-verify:'
     assert_output --partial 'is not a git worktree root'


### PR DESCRIPTION
## Summary
- `gh:pr-merge` Step 5의 post-merge 검증 게이트가, 다섯 값(`PR_NUMBER`/`TARGET_REPO`/`HEAD_BRANCH`/`BASE_BRANCH`/`REMOTE`) 중 하나가 substitution 실수로 비어도 "watched-repos에 없는 repo"와 똑같이 완전 무출력을 내던 문제를 고친다.

## Changes
- `claude/skills/gh-pr-merge/SKILL.md`: registry 조회 전에 다섯 값의 공백 여부를 먼저 검사해, 비어 있는 값이 있으면 그 이름을 담은 `[WARN]` 한 줄을 남기고 조회를 건너뛴다. 다섯 값이 모두 채워진 미등록 repo는 여전히 완전 무출력(#1511 계약 유지).
- `tests/bats/skills/gh_pr_post_merge_verify.bats`: 실제 SKILL.md에서 Step 5 게이트 블록을 추출해 실행하는 방식으로 7개 테스트를 추가 — 빈 바인딩이 이름과 함께 경고되는지, 미등록 repo는 여전히 무출력인지, 등록된 repo는 여전히 dispatch에 도달하는지 pin.
- `docs/public/changelog.d/2026-08-31-1576.md`: changelog fragment 추가.

## Test plan
- [x] `DOTFILES_ROOT="$(pwd)" ./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_post_merge_verify.bats` — 105/105 통과 (기존 98 + 신규 7)
- [x] 인접 SKILL.md-grep 스위트(`gh_pr_merge_board_gate_retired.bats`, `gh_pr_merge_herdr_notify.bats`) — 24/24 통과, 회귀 없음
- [x] `scripts/lint_changelog_fragments.sh` — errors=0

## Related
Closes #1576

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~2 h · 🤖 ~11 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~2 h · 🤖 ~11 min
<!-- /ai-metrics:gh-pr -->

</details>
