### PR TITLE
fix(gh-pr-post-merge-verify): 검증 세션을 전용 scratch 워크트리에서 돌린다

### DIFF
--- a/claude/skills/gh-pr-post-merge-verify/SKILL.md
+++ b/claude/skills/gh-pr-post-merge-verify/SKILL.md
@@ -78,9 +78,13 @@ Paste `references/dispatch.sh.md` verbatim. It performs, in order:
    only once `MAIN_ROOT` is a git worktree root and its HEAD is on
    `BASE_BRANCH`. Dirty tree, wrong/detached branch, or conflict → `[WARN]`,
    `rebase --abort`, **stop** (F-3).
-4. `herdr tab create --workspace <ws> --cwd "$MAIN_ROOT" --label "pr-<N>"`, then
+4. `git worktree add --detach "$PMV_SCRATCH" "$REMOTE/$BASE_BRANCH"` where
+   `PMV_SCRATCH` is `<git-common-dir>/pr-post-merge-verify/pr-<N>` — created if
+   absent, reused if present, never torn down here. Then
+   `herdr tab create --workspace <ws> --cwd "$PMV_SCRATCH" --label "pr-<N>"` and
    `herdr agent start mv-<repo>-pr-<N> --kind claude --pane <pane>
-   -- --dangerously-skip-permissions` (F-4).
+   -- --dangerously-skip-permissions` (F-4). The session does **not** live in
+   `MAIN_ROOT`: that checkout is shared, and step 3 rebases it (#1577).
 5. `herdr agent prompt <agent> "/<verify-skill> <N>" --wait --until idle` (F-5),
    then report the new `tab_id`, the agent name, and the `attach` hint.
 

--- a/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
@@ -223,6 +223,13 @@ if ! (git -C "$MAIN_ROOT" fetch "$REMOTE" "$BASE_BRANCH" &&
 fi
 
 # --- 4. F-4: the verification tab -----------------------------------------
+# The workspace is still looked up from $MAIN_ROOT, deliberately, even though
+# the tab below opens somewhere else: `herdr worktree list --cwd P --json`
+# answers the workspace *P's repository* is open in, and WS_ID only says which
+# herdr workspace the new tab is grouped under. The scratch worktree created a
+# few lines down is seconds old and has no workspace of its own on a first
+# dispatch, so asking about it would answer nothing at all. Grouping is the
+# main checkout's; the tab's own directory is `--cwd`, and those are separate.
 WS_JSON=$(herdr worktree list --cwd "$MAIN_ROOT" --json 2>/dev/null) || WS_JSON=""
 WS_ID=$(printf '%s' "$WS_JSON" | jq -r --arg p "$MAIN_ROOT" '
     [ (.result.source.source_workspace_id? // empty),
@@ -235,16 +242,54 @@ if [ -z "$WS_ID" ]; then
     return 0 2>/dev/null || exit 0
 fi
 
+# The verification session gets its OWN detached worktree (#1577). It used to
+# open in $MAIN_ROOT, and that checkout is shared: humans and other AI sessions
+# check branches out in it, and step 3 right above *rebases* it — so on
+# back-to-back merges the N+1th dispatch moved the ground under the Nth
+# session. Tab `pr-1567` disappeared exactly that way. This is the isolation
+# `iw-*` tabs already have, in the shape gh:pr-merge-train's scratch worktree
+# uses (`references/train-loop.md` → "Detached scratch worktree").
+PMV_COMMON_DIR=$(git -C "$MAIN_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+if [ -z "$PMV_COMMON_DIR" ]; then
+    # Never fall back to $MAIN_ROOT: that fallback IS the defect being fixed.
+    printf '[WARN] gh:pr-post-merge-verify: cannot resolve the git common dir of %s — verification skipped.\n' "$MAIN_ROOT"
+    return 0 2>/dev/null || exit 0
+fi
+# One directory per PR, so two verifications running at once never share one.
+PMV_SCRATCH="${PMV_COMMON_DIR}/pr-post-merge-verify/pr-${PR_NUMBER}"
+if [ -d "$PMV_SCRATCH" ]; then
+    # Create if absent, reuse if present: a second dispatch for the same PR (a
+    # manual re-run over a tab that is still open) must be idempotent, not a
+    # duplicate and not an error. There is deliberately NO teardown here — the
+    # worktree's lifetime is the tab's, and who removes it when is left to a
+    # later tab-close rule rather than guessed at now (#1577).
+    printf '[INFO] gh:pr-post-merge-verify: reusing verification worktree %s.\n' "$PMV_SCRATCH"
+else
+    mkdir -p "$(dirname "$PMV_SCRATCH")"
+    # A registration whose directory someone removed by hand would make the
+    # add below fail on every future dispatch. Pruning drops only entries git
+    # already considers gone, so it cannot touch a live worktree.
+    git -C "$MAIN_ROOT" worktree prune >/dev/null 2>&1 || true
+    # `--detach` is what makes this collide-free: it holds a commit, not the
+    # branch *name*, so it never contests the base branch $MAIN_ROOT has
+    # checked out. No fetch here — step 3 just fetched "$REMOTE/$BASE_BRANCH"
+    # and rebased $MAIN_ROOT onto it, so that ref is current by construction.
+    if ! git -C "$MAIN_ROOT" worktree add --detach "$PMV_SCRATCH" "${REMOTE}/${BASE_BRANCH}" >/dev/null 2>&1; then
+        printf '[WARN] gh:pr-post-merge-verify: could not create the verification worktree %s — verification skipped.\n' "$PMV_SCRATCH"
+        return 0 2>/dev/null || exit 0
+    fi
+fi
+
 # Spelled out twice rather than accumulated with `set --`: this block is pasted
 # at the top level of the caller's shell, where `set --` would destroy the
 # caller's own "$1", "$2", … POSIX sh has no arrays, so an if/else over the
 # full command line is the only form that is both safe and portable.
 if [ -n "${CLAUDE_CONFIG_DIR-}" ]; then
-    TAB_JSON=$(herdr tab create --workspace "$WS_ID" --cwd "$MAIN_ROOT" \
+    TAB_JSON=$(herdr tab create --workspace "$WS_ID" --cwd "$PMV_SCRATCH" \
         --label "pr-${PR_NUMBER}" --no-focus \
         --env "CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR}" 2>/dev/null) || TAB_JSON=""
 else
-    TAB_JSON=$(herdr tab create --workspace "$WS_ID" --cwd "$MAIN_ROOT" \
+    TAB_JSON=$(herdr tab create --workspace "$WS_ID" --cwd "$PMV_SCRATCH" \
         --label "pr-${PR_NUMBER}" --no-focus 2>/dev/null) || TAB_JSON=""
 fi
 NEW_PANE=$(printf '%s' "$TAB_JSON" | pmv_json_first pane_id)
@@ -336,6 +381,9 @@ fi
 # --- 7. report ------------------------------------------------------------
 printf 'post-merge verification dispatched\n'
 printf '  tab:    %s (label pr-%s)\n' "${NEW_TAB:--}" "$PR_NUMBER"
+# Reported because nothing removes it: the operator who closes the tab is the
+# one who can also drop this directory (#1577 leaves teardown unautomated).
+printf '  cwd:    %s\n' "$PMV_SCRATCH"
 printf '  agent:  %s\n' "$PMV_AGENT"
 printf '  verify: %s\n' "$VERIFY_PROMPT"
 printf '  attach: herdr agent attach %s\n' "$PMV_AGENT"

--- a/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md
@@ -257,7 +257,16 @@ if [ -z "$PMV_COMMON_DIR" ]; then
 fi
 # One directory per PR, so two verifications running at once never share one.
 PMV_SCRATCH="${PMV_COMMON_DIR}/pr-post-merge-verify/pr-${PR_NUMBER}"
+# Existence alone is not proof of a live worktree (agy/codex, PR #1605 review):
+# a directory git's own bookkeeping has forgotten — pruned, or hand-removed and
+# recreated as a plain folder — passes `-d` but is not a checkout `herdr tab
+# create` can safely open. Cross-check it against `worktree list` instead.
+PMV_SCRATCH_REGISTERED=""
 if [ -d "$PMV_SCRATCH" ]; then
+    PMV_SCRATCH_REGISTERED=$(git -C "$MAIN_ROOT" worktree list --porcelain 2>/dev/null |
+        awk -v p="$(pmv_physical_path "$PMV_SCRATCH")" '$0 == "worktree " p { print "1"; exit }')
+fi
+if [ -n "$PMV_SCRATCH_REGISTERED" ]; then
     # Create if absent, reuse if present: a second dispatch for the same PR (a
     # manual re-run over a tab that is still open) must be idempotent, not a
     # duplicate and not an error. There is deliberately NO teardown here — the
@@ -265,10 +274,15 @@ if [ -d "$PMV_SCRATCH" ]; then
     # later tab-close rule rather than guessed at now (#1577).
     printf '[INFO] gh:pr-post-merge-verify: reusing verification worktree %s.\n' "$PMV_SCRATCH"
 else
+    # An unregistered directory at this path cannot be reused (git refuses to
+    # `worktree add` over an existing, non-empty target) and cannot be trusted
+    # as a checkout either — clear it before recreating, same as the
+    # stale-leftover guard in gh:pr-merge-train's own scratch worktree
+    # (`references/train-loop.md` → "Detached scratch worktree").
+    [ -d "$PMV_SCRATCH" ] && rm -rf "$PMV_SCRATCH"
     mkdir -p "$(dirname "$PMV_SCRATCH")"
-    # A registration whose directory someone removed by hand would make the
-    # add below fail on every future dispatch. Pruning drops only entries git
-    # already considers gone, so it cannot touch a live worktree.
+    # Pruning drops only entries git already considers gone, so it cannot
+    # touch a live worktree — safe to run unconditionally before every add.
     git -C "$MAIN_ROOT" worktree prune >/dev/null 2>&1 || true
     # `--detach` is what makes this collide-free: it holds a commit, not the
     # branch *name*, so it never contests the base branch $MAIN_ROOT has

--- a/claude/skills/gh-pr-post-merge-verify/references/help.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/help.md
@@ -33,14 +33,21 @@ dispatch soft-failed and you want to retry it.
    argument 2 and the base branch is the PR's `baseRefName` — neither is
    hardcoded, because a watched repo may default to `master`/`develop` or be
    reached through `upstream`.
-6. `herdr tab create --cwd <main checkout> --label pr-<N>`.
-7. `herdr agent start mv-<repo>-pr-<N> --kind claude --pane <pane>
+6. `git worktree add --detach <git-common-dir>/pr-post-merge-verify/pr-<N> <remote>/<base>`
+   — the verification session's own directory, created if absent and reused if
+   it is already there. It is **not** the main checkout: that one is shared
+   with humans and other sessions, and step 5 rebases it (#1577).
+7. `herdr tab create --cwd <that worktree> --label pr-<N>`. The herdr
+   *workspace* is still looked up from the main checkout — it only groups the
+   tab, and a worktree created a second ago has no workspace of its own.
+8. `herdr agent start mv-<repo>-pr-<N> --kind claude --pane <pane>
    -- --dangerously-skip-permissions`.
-8. `herdr agent prompt <agent> "/<verify-skill> <N>" --wait --until idle`,
+9. `herdr agent prompt <agent> "/<verify-skill> <N>" --wait --until idle`,
    where `<verify-skill>` is the registry's `verify_skill` for that repo —
    allowlisted to `devx:pr-verify-merged` or `devx:pr-verify-live`, because it
    reaches the prompt of a `--dangerously-skip-permissions` session.
-9. Prints the new tab id, the agent name, and a `herdr agent attach` hint.
+10. Prints the new tab id, the worktree it opened in, the agent name, and a
+    `herdr agent attach` hint.
 
 ## What it will NOT do
 
@@ -53,6 +60,9 @@ dispatch soft-failed and you want to retry it.
   hard stop in the skill.
 - Open more than one session per PR, batch several PRs into one session, or
   retry a failed dispatch.
+- Remove the verification worktree it created. Its lifetime is the tab's, and
+  the tab is closed by the operator once they have read the result — so a
+  teardown here would delete the directory a live session is standing in.
 - Make any *mutating* GitHub call — no PR, board, or label writes. Its only
   API call is reading the PR's `headRefName`/`baseRefName`, and only when the
   caller did not already pass them down.

--- a/claude/skills/gh-pr-post-merge-verify/references/rationale.md
+++ b/claude/skills/gh-pr-post-merge-verify/references/rationale.md
@@ -78,6 +78,43 @@ picking sides in a conflict stays the human's call, but leaving the user's
 main checkout parked mid-rebase would be a worse failure than the one being
 reported.
 
+## Why the verification session gets its own worktree (#1577)
+
+The tab used to open in `MAIN_ROOT`, and the reasoning was sound as far as it
+went: `devx:pr-verify-merged` makes its own fresh clone, and the merged PR's
+implementation worktree is being torn down, so the session needs no checkout of
+its own. What that missed is that the main checkout is **shared**. Humans
+`git pull` and check branches out in it, other AI sessions work in it, and
+step 3 of this very dispatch rebases it — so on back-to-back merges the N+1th
+dispatch moves the ground under the Nth session while it is still running. On
+2026-08-28 the `pr-1567` tab disappeared exactly that way, with `~/dotfiles`'s
+reflog showing an unrelated branch checkout and merge inside the verification
+window.
+
+So each PR gets `<git-common-dir>/pr-post-merge-verify/pr-<N>`, a detached
+scratch worktree in the shape `gh:pr-merge-train` already uses
+(`../gh-pr-merge-train/references/train-loop.md` → "Detached scratch
+worktree"). `--detach` is what makes it collide-free: it holds a commit, not a
+branch name, so it never contests the base branch `MAIN_ROOT` has checked out.
+No second `fetch` is issued for it — step 3 has just fetched
+`$REMOTE/$BASE_BRANCH` and rebased onto it, so the ref is current by
+construction. And `MAIN_ROOT` itself is unchanged: it is still the registry's
+`path`, still what step 3 rebases. Only the tab's `--cwd` moved.
+
+The herdr **workspace** is still looked up from `MAIN_ROOT`. That id only says
+which workspace the new tab is grouped under; a worktree created seconds ago
+has no workspace of its own on a first dispatch, so asking `herdr worktree
+list` about it would answer nothing. Grouping and working directory are two
+different questions here.
+
+Lifetime is the tab's: created if absent, **reused** if present, so a manual
+re-dispatch over a still-open tab is idempotent. There is deliberately no
+teardown in this block — the operating rule until the pipeline stabilises is
+that the human closes `pr-*` tabs after reading the result, and deleting the
+directory a live session stands in is the failure being fixed, not a cleanup.
+Who removes it, and when, belongs to a later tab-close hook or an
+`_iw_cleanup_worktrees`-style "closed issue + no fan" rule.
+
 ## Why `herdr agent list` emptiness is "unknown", not "nothing running"
 
 Lesson carried over from `_iw_live_agents` in

--- a/docs/public/changelog.d/2026-08-31-1577.md
+++ b/docs/public/changelog.d/2026-08-31-1577.md
@@ -1,0 +1,1 @@
+- 변경: **gh:pr-post-merge-verify 검증 세션이 공용 메인 체크아웃 대신 PR 전용 detached scratch 워크트리(`<git-common-dir>/pr-post-merge-verify/pr-<N>`)에서 돈다**

--- a/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
@@ -85,6 +85,39 @@ _pmv_git_rebase_abort() {
     return 0
 }
 
+# Stand-in for `git -C <root> rev-parse --path-format=absolute --git-common-dir`,
+# which answers `<main-checkout>/.git`. A test can empty it (FAKE_GIT_COMMON_DIR="")
+# to prove the block refuses to guess a scratch path rather than falling back to
+# the shared main checkout (#1577).
+_pmv_git_common_dir() {
+    [ -z "${FAKE_GIT_LOG-}" ] || printf 'common-dir %s\n' "$1" >>"$FAKE_GIT_LOG"
+    printf '%s' "${FAKE_GIT_COMMON_DIR-$1/.git}"
+}
+
+# Stand-in for `[ -d "$PMV_SCRATCH" ]` — the create-if-absent / reuse-if-present
+# knob. Default 0 (absent), so an ordinary dispatch creates the worktree.
+_pmv_dir_exists() {
+    [ "${FAKE_SCRATCH_EXISTS:-0}" = "1" ]
+}
+
+# Stand-in for `mkdir -p <dir>`.
+_pmv_mkdir_p() {
+    [ -z "${FAKE_GIT_LOG-}" ] || printf 'mkdir-p %s\n' "$1" >>"$FAKE_GIT_LOG"
+    return 0
+}
+
+# Stand-in for `git -C <root> worktree prune`.
+_pmv_git_worktree_prune() {
+    [ -z "${FAKE_GIT_LOG-}" ] || printf 'worktree-prune %s\n' "$1" >>"$FAKE_GIT_LOG"
+    return 0
+}
+
+# Stand-in for `git -C <root> worktree add --detach <path> <ref>`.
+_pmv_git_worktree_add() {
+    [ -z "${FAKE_GIT_LOG-}" ] || printf 'worktree-add %s %s %s\n' "$1" "$2" "$3" >>"$FAKE_GIT_LOG"
+    return "${FAKE_WORKTREE_ADD_RC:-0}"
+}
+
 # ============================================================
 # JSON helpers
 # ============================================================
@@ -341,6 +374,48 @@ pmv_workspace_for_root() {
     printf '%s' "$_ws"
 }
 
+# pmv_scratch_dir <main_root> <pr>  ->  the verification session's own worktree
+# path, one directory per PR. rc 1 with no output when git cannot say where the
+# common dir is: the block must never fall back to <main_root>, because living
+# in the shared main checkout is the defect #1577 removes.
+pmv_scratch_dir() {
+    local _common
+    _common=$(_pmv_git_common_dir "$1")
+    [ -n "$_common" ] || return 1
+    printf '%s/pr-post-merge-verify/pr-%s' "$_common" "$2"
+}
+
+# pmv_ensure_scratch <main_root> <scratch> <remote> <base>. rc 0 = usable.
+#
+# Create if absent, reuse if present — a second dispatch for the same PR (a
+# manual re-run over a still-open tab) is idempotent, never a duplicate and
+# never an error. There is deliberately NO teardown: the worktree's lifetime is
+# the tab's, and who removes it when is left to a later tab-close rule (#1577).
+#
+# No fetch: pmv_sync_main has just fetched `<remote>/<base>` and rebased the
+# main checkout onto it, so the ref is current by construction. `--detach`
+# holds a commit rather than the branch name, so the scratch worktree never
+# contests the base branch the main checkout has checked out.
+pmv_ensure_scratch() {
+    local _root="$1" _scratch="$2" _remote="${3:-origin}" _base="$4"
+
+    if _pmv_dir_exists "$_scratch"; then
+        printf '[INFO] gh:pr-post-merge-verify: reusing verification worktree %s.\n' "$_scratch"
+        return 0
+    fi
+
+    _pmv_mkdir_p "${_scratch%/*}"
+    # A registration whose directory someone removed by hand would make the add
+    # fail on every future dispatch; prune drops only entries git already
+    # considers gone, so it cannot touch a live worktree.
+    _pmv_git_worktree_prune "$_root"
+    if ! _pmv_git_worktree_add "$_root" "$_scratch" "${_remote}/${_base}"; then
+        printf '[WARN] gh:pr-post-merge-verify: could not create the verification worktree %s — verification skipped.\n' "$_scratch"
+        return 1
+    fi
+    return 0
+}
+
 # pmv_tab_create <workspace> <cwd> <label>  ->  "<tab_id> <pane_id>", rc 1 on failure.
 pmv_tab_create() {
     local _ws="$1" _cwd="$2" _label="$3" _json _tab _pane
@@ -438,7 +513,7 @@ pmv_escalate_prompt_stall() {
 gh_pr_post_merge_verify() {
     local _pr="$1" _repo="$2" _host="$3" _main="$4" _branch="$5" _file="$6"
     local _remote="${7:-origin}" _base="${8-}"
-    local _skill _rc _wt _tab _tabrc _ws _pane _agent _newtab _out _code _try _prompt
+    local _skill _rc _wt _tab _tabrc _ws _pane _agent _newtab _out _code _try _prompt _scratch
 
     _skill=$(pmv_gate "$_file" "$_repo")
     _rc=$?
@@ -492,13 +567,32 @@ gh_pr_post_merge_verify() {
     pmv_sync_main "$_main" "$_remote" "$_base" || return 0
 
     # --- 4. the verification tab ---
+    # The workspace is still resolved from the main checkout even though the
+    # tab opens elsewhere: `herdr worktree list --cwd P` answers the workspace
+    # P's *repository* is open in, and the scratch worktree below has none of
+    # its own on a first dispatch. Grouping and working directory are separate.
     _ws=$(pmv_workspace_for_root "$_main")
     if [ -z "$_ws" ]; then
         printf '[WARN] gh:pr-post-merge-verify: no herdr workspace for %s — verification tab not created.\n' "$_main"
         return 0
     fi
 
-    if ! _out=$(pmv_tab_create "$_ws" "$_main" "pr-$_pr"); then
+    # dispatch.sh.md assigns step 3's fallback into $BASE_BRANCH itself, so the
+    # effective base survives into step 4. The mirror keeps pmv_sync_main free
+    # of out-parameters and recomputes it here instead — same value, one extra
+    # stand-in call, and never an `origin/` with an empty branch after it.
+    [ -n "$_base" ] || _base=$(_pmv_git_current_branch "$_main")
+
+    # The session lives in its own detached worktree, never in the shared main
+    # checkout that step 3 has just rebased and that humans check branches out
+    # in (#1577).
+    if ! _scratch=$(pmv_scratch_dir "$_main" "$_pr"); then
+        printf '[WARN] gh:pr-post-merge-verify: cannot resolve the git common dir of %s — verification skipped.\n' "$_main"
+        return 0
+    fi
+    pmv_ensure_scratch "$_main" "$_scratch" "$_remote" "$_base" || return 0
+
+    if ! _out=$(pmv_tab_create "$_ws" "$_scratch" "pr-$_pr"); then
         printf '[WARN] gh:pr-post-merge-verify: herdr tab create failed for label pr-%s — verification skipped.\n' "$_pr"
         return 0
     fi
@@ -579,6 +673,9 @@ gh_pr_post_merge_verify() {
     # --- 7. report ---
     printf 'post-merge verification dispatched\n'
     printf '  tab:    %s (label pr-%s)\n' "$_newtab" "$_pr"
+    # Reported because nothing removes it: the operator who closes the tab is
+    # the one who can also drop this directory (teardown is unautomated, #1577).
+    printf '  cwd:    %s\n' "$_scratch"
     printf '  agent:  %s\n' "$_agent"
     printf '  verify: %s\n' "$_prompt"
     printf '  attach: herdr agent attach %s\n' "$_agent"

--- a/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh
@@ -100,6 +100,24 @@ _pmv_dir_exists() {
     [ "${FAKE_SCRATCH_EXISTS:-0}" = "1" ]
 }
 
+# Stand-in for the `worktree list --porcelain` membership check that proves an
+# existing directory is actually a registered worktree, not merely a directory
+# git's own bookkeeping has forgotten (pruned) or a hand-made folder at the same
+# path (agy/codex, PR #1605 review). Defaults to FAKE_SCRATCH_EXISTS so every
+# pre-#1605-review test — which only ever meant "a real worktree is already
+# there" by setting that flag — keeps its original meaning; a test can set
+# FAKE_SCRATCH_REGISTERED=0 on its own to simulate a stale/unregistered one.
+_pmv_worktree_registered() {
+    [ "${FAKE_SCRATCH_REGISTERED:-${FAKE_SCRATCH_EXISTS:-0}}" = "1" ]
+}
+
+# Stand-in for `rm -rf <dir>` — reached only when a directory sits at the
+# scratch path but `_pmv_worktree_registered` says it isn't a real worktree.
+_pmv_rm_rf() {
+    [ -z "${FAKE_GIT_LOG-}" ] || printf 'rm-rf %s\n' "$1" >>"$FAKE_GIT_LOG"
+    return 0
+}
+
 # Stand-in for `mkdir -p <dir>`.
 _pmv_mkdir_p() {
     [ -z "${FAKE_GIT_LOG-}" ] || printf 'mkdir-p %s\n' "$1" >>"$FAKE_GIT_LOG"
@@ -399,11 +417,18 @@ pmv_scratch_dir() {
 pmv_ensure_scratch() {
     local _root="$1" _scratch="$2" _remote="${3:-origin}" _base="$4"
 
-    if _pmv_dir_exists "$_scratch"; then
+    if _pmv_dir_exists "$_scratch" && _pmv_worktree_registered "$_scratch"; then
         printf '[INFO] gh:pr-post-merge-verify: reusing verification worktree %s.\n' "$_scratch"
         return 0
     fi
 
+    # A directory at this path that isn't a registered worktree can't be
+    # reused (stale/unregistered) and can't be added over either (git refuses
+    # a non-empty target) — clear it first, mirroring gh:pr-merge-train's own
+    # stale-leftover guard for its scratch worktree.
+    if _pmv_dir_exists "$_scratch"; then
+        _pmv_rm_rf "$_scratch"
+    fi
     _pmv_mkdir_p "${_scratch%/*}"
     # A registration whose directory someone removed by hand would make the add
     # fail on every future dispatch; prune drops only entries git already
@@ -476,7 +501,8 @@ pmv_agent_prompt() {
 }
 
 pmv_escalate_prompt_stall() {
-    local _tab="$1" _agent="$2" _pr="$3" _label="pr-${_pr}-STUCK"
+    local _tab="$1" _agent="$2" _pr="$3"
+    local _label="pr-${_pr}-STUCK"
     local _body="pr-${_pr} verification prompt failed repeatedly — herdr agent attach ${_agent}"
 
     if [ -n "$_tab" ]; then

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -87,7 +87,7 @@ teardown() {
         FAKE_HERDR_RC_AGENT_LIST FAKE_HERDR_RC_TAB_CREATE FAKE_HERDR_RC_TAB_CLOSE \
         FAKE_HERDR_RC_AGENT_START FAKE_HERDR_RC_AGENT_PROMPT FAKE_HERDR_RC_TAB_RENAME \
         FAKE_HERDR_RC_NOTIFICATION_SHOW \
-        FAKE_GIT_COMMON_DIR FAKE_SCRATCH_EXISTS FAKE_WORKTREE_ADD_RC
+        FAKE_GIT_COMMON_DIR FAKE_SCRATCH_EXISTS FAKE_SCRATCH_REGISTERED FAKE_WORKTREE_ADD_RC
 }
 
 dispatch() {
@@ -1462,6 +1462,41 @@ _pmv_scratch_for() { printf '%s/.git/pr-post-merge-verify/pr-%s' "$MAIN_ROOT" "$
     refute_output --partial "worktree-add"
     run cat "$FAKE_HERDR_LOG"
     assert_output --partial "--cwd $(_pmv_scratch_for 77) --label pr-77"
+}
+
+@test "1605 review: a directory that exists but is not a registered worktree is wiped and recreated" {
+    FAKE_SCRATCH_EXISTS=1
+    FAKE_SCRATCH_REGISTERED=0
+    run dispatch
+    assert_success
+    refute_output --partial "reusing verification worktree"
+    run cat "$FAKE_GIT_LOG"
+    assert_output --partial "rm-rf $(_pmv_scratch_for 77)"
+    assert_output --partial "worktree-add ${MAIN_ROOT} $(_pmv_scratch_for 77) origin/main"
+}
+
+@test "1605 review: the stale directory is removed before worktree-add runs, not after" {
+    FAKE_SCRATCH_EXISTS=1
+    FAKE_SCRATCH_REGISTERED=0
+    run dispatch
+    assert_success
+    run cat "$FAKE_GIT_LOG"
+    _rm_line=$(printf '%s\n' "$output" | grep -n "^rm-rf " | head -1 | cut -d: -f1)
+    _add_line=$(printf '%s\n' "$output" | grep -n "^worktree-add " | head -1 | cut -d: -f1)
+    [ -n "$_rm_line" ]
+    [ -n "$_add_line" ]
+    [ "$_rm_line" -lt "$_add_line" ]
+}
+
+@test "1605 review: a registered worktree is reused without ever being removed" {
+    FAKE_SCRATCH_EXISTS=1
+    FAKE_SCRATCH_REGISTERED=1
+    run dispatch
+    assert_success
+    assert_output --partial "reusing verification worktree $(_pmv_scratch_for 77)"
+    run cat "$FAKE_GIT_LOG"
+    refute_output --partial "rm-rf"
+    refute_output --partial "worktree-add"
 }
 
 @test "1577: two PRs get two different worktrees" {

--- a/tests/bats/skills/gh_pr_post_merge_verify.bats
+++ b/tests/bats/skills/gh_pr_post_merge_verify.bats
@@ -86,7 +86,8 @@ teardown() {
         FAKE_HERDR_OUT_TAB_CREATE FAKE_HERDR_OUT_AGENT_START FAKE_HERDR_OUT_AGENT_PROMPT \
         FAKE_HERDR_RC_AGENT_LIST FAKE_HERDR_RC_TAB_CREATE FAKE_HERDR_RC_TAB_CLOSE \
         FAKE_HERDR_RC_AGENT_START FAKE_HERDR_RC_AGENT_PROMPT FAKE_HERDR_RC_TAB_RENAME \
-        FAKE_HERDR_RC_NOTIFICATION_SHOW
+        FAKE_HERDR_RC_NOTIFICATION_SHOW \
+        FAKE_GIT_COMMON_DIR FAKE_SCRATCH_EXISTS FAKE_WORKTREE_ADD_RC
 }
 
 dispatch() {
@@ -208,7 +209,9 @@ _pmv_log_count() { grep -c -- "$1" "$FAKE_HERDR_LOG" || true; }
 
     run cat "$FAKE_HERDR_LOG"
     assert_output --partial "herdr tab close wV:t42"
-    assert_output --partial "herdr tab create --workspace wV --cwd ${MAIN_ROOT} --label pr-77 --no-focus"
+    # `--cwd` is the PR's own detached worktree, never the shared main checkout
+    # (#1577); the 1577 block below is where that is pinned in detail.
+    assert_output --partial "herdr tab create --workspace wV --cwd ${MAIN_ROOT}/.git/pr-post-merge-verify/pr-77 --label pr-77 --no-focus"
     assert_output --partial "herdr agent start mv-dotfiles-pr-77 --kind claude --pane wV:p99 -- --dangerously-skip-permissions"
     assert_output --partial "herdr agent prompt mv-dotfiles-pr-77 /devx-pr-verify-merged 77 --wait --until idle"
 }
@@ -1394,4 +1397,173 @@ _pmv_gate_run() {
     _lookup=$(grep -n 'VERIFY_SKILL=\$(jq -r --arg r' "$_skill" | head -1 | cut -d: -f1)
     [ -n "$_check" ] && [ -n "$_lookup" ]
     [ "$_check" -lt "$_lookup" ]
+}
+
+# --- #1577: the verification session lives in its own detached worktree ----
+#
+# The tab used to open in $MAIN_ROOT — the shared main checkout that humans and
+# other AI sessions check branches out in, and that step 3 of THIS dispatch
+# rebases. On back-to-back merges the N+1th dispatch moved the ground under the
+# Nth session; tab `pr-1567` vanished that way (2026-08-28). Each PR now gets
+# `<git-common-dir>/pr-post-merge-verify/pr-<N>`, created detached off the ref
+# step 3 already fetched, reused when it is already there, and never torn down
+# here (its lifetime is the tab's — cleanup timing is a later decision).
+
+_pmv_scratch_for() { printf '%s/.git/pr-post-merge-verify/pr-%s' "$MAIN_ROOT" "$1"; }
+
+@test "1577: the verification tab opens in the PR's own worktree, not the main checkout" {
+    run dispatch
+    assert_success
+    run cat "$FAKE_HERDR_LOG"
+    assert_output --partial "herdr tab create --workspace wV --cwd $(_pmv_scratch_for 77) --label pr-77 --no-focus"
+    # The whole point: the shared checkout is no longer the session's home.
+    refute_output --partial "--cwd ${MAIN_ROOT} --label pr-77"
+}
+
+@test "1577: the report names the worktree the session lives in" {
+    run dispatch
+    assert_success
+    assert_output --partial "cwd:    $(_pmv_scratch_for 77)"
+}
+
+@test "1577: an absent worktree is created detached at the merged base" {
+    run dispatch
+    assert_success
+    run cat "$FAKE_GIT_LOG"
+    assert_output --partial "worktree-add ${MAIN_ROOT} $(_pmv_scratch_for 77) origin/main"
+    assert_output --partial "mkdir-p ${MAIN_ROOT}/.git/pr-post-merge-verify"
+}
+
+@test "1577: the remote and base branch reach the worktree, never a hardcoded origin/main" {
+    FAKE_MAIN_BRANCH=develop
+    run dispatch acme/dotfiles upstream develop
+    assert_success
+    run cat "$FAKE_GIT_LOG"
+    assert_output --partial "worktree-add ${MAIN_ROOT} $(_pmv_scratch_for 77) upstream/develop"
+}
+
+@test "1577: an empty base branch reaches the worktree as step 3's own fallback" {
+    # `origin/` with nothing after it would detach at whatever that resolves to.
+    FAKE_MAIN_BRANCH=master
+    run dispatch
+    assert_success
+    run cat "$FAKE_GIT_LOG"
+    assert_output --partial "worktree-add ${MAIN_ROOT} $(_pmv_scratch_for 77) origin/master"
+    refute_output --partial "origin/ "
+}
+
+@test "1577: an existing worktree is reused, never added a second time" {
+    FAKE_SCRATCH_EXISTS=1
+    run dispatch
+    assert_success
+    assert_output --partial "reusing verification worktree $(_pmv_scratch_for 77)"
+    assert_output --partial "post-merge verification dispatched"
+    run cat "$FAKE_GIT_LOG"
+    refute_output --partial "worktree-add"
+    run cat "$FAKE_HERDR_LOG"
+    assert_output --partial "--cwd $(_pmv_scratch_for 77) --label pr-77"
+}
+
+@test "1577: two PRs get two different worktrees" {
+    run gh_pr_post_merge_verify 77 acme/dotfiles github.com "$MAIN_ROOT" wt/issue-77/1 "$WATCHED"
+    assert_success
+    run gh_pr_post_merge_verify 88 acme/dotfiles github.com "$MAIN_ROOT" wt/issue-88/1 "$WATCHED"
+    assert_success
+    run cat "$FAKE_HERDR_LOG"
+    assert_output --partial "--cwd $(_pmv_scratch_for 77) --label pr-77"
+    assert_output --partial "--cwd $(_pmv_scratch_for 88) --label pr-88"
+    [ "$(_pmv_scratch_for 77)" != "$(_pmv_scratch_for 88)" ]
+}
+
+@test "1577: step 3 still rebases the main checkout, never the scratch worktree" {
+    run dispatch
+    assert_success
+    run cat "$FAKE_GIT_LOG"
+    assert_output --partial "sync ${MAIN_ROOT} origin main"
+    refute_output --partial "sync $(_pmv_scratch_for 77)"
+}
+
+@test "1577: the workspace lookup still asks about the main checkout" {
+    # WS_ID only groups the tab; a worktree created seconds ago has no herdr
+    # workspace of its own on a first dispatch, so asking about it answers
+    # nothing. Grouping is the main checkout's, the working directory is not.
+    run dispatch
+    assert_success
+    run cat "$FAKE_HERDR_LOG"
+    assert_output --partial "herdr worktree list --cwd ${MAIN_ROOT} --json"
+}
+
+@test "1577: a worktree that cannot be created stops before the tab" {
+    FAKE_WORKTREE_ADD_RC=1
+    run dispatch
+    assert_success
+    assert_output --partial "could not create the verification worktree $(_pmv_scratch_for 77)"
+    refute_output --partial "post-merge verification dispatched"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "tab create"
+}
+
+@test "1577: an unresolvable git common dir never falls back to the main checkout" {
+    FAKE_GIT_COMMON_DIR=""
+    run dispatch
+    assert_success
+    assert_output --partial "cannot resolve the git common dir of ${MAIN_ROOT}"
+    refute_output --partial "post-merge verification dispatched"
+    run cat "$FAKE_HERDR_LOG"
+    refute_output --partial "tab create"
+    run cat "$FAKE_GIT_LOG"
+    refute_output --partial "worktree-add"
+}
+
+@test "1577: nothing here tears the worktree down" {
+    # Decided out of scope: the worktree's lifetime is the tab's, and the tab
+    # is closed by the operator after reading the result. A teardown here would
+    # delete a directory a live session is standing in.
+    run dispatch
+    assert_success
+    run cat "$FAKE_GIT_LOG"
+    refute_output --partial "worktree-remove"
+}
+
+@test "1577: dispatch.sh.md opens the tab on the scratch worktree, both argv forms" {
+    local _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    run grep -c -- 'herdr tab create --workspace "$WS_ID" --cwd "$PMV_SCRATCH"' "$_out"
+    assert_output "2"
+    run grep -c -- 'herdr tab create --workspace "$WS_ID" --cwd "$MAIN_ROOT"' "$_out"
+    assert_output "0"
+}
+
+@test "1577: dispatch.sh.md derives the path per PR under the git common dir" {
+    local _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    run grep -qF -- 'PMV_SCRATCH="${PMV_COMMON_DIR}/pr-post-merge-verify/pr-${PR_NUMBER}"' "$_out"
+    assert_success
+    # `--path-format=absolute` (git 2.31+): a bare --git-common-dir prints a
+    # path relative to the cwd, which would place the worktree anywhere.
+    run grep -qF -- 'rev-parse --path-format=absolute --git-common-dir' "$_out"
+    assert_success
+}
+
+@test "1577: dispatch.sh.md creates it detached, off the ref step 3 already fetched" {
+    local _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    run grep -qF -- 'worktree add --detach "$PMV_SCRATCH" "${REMOTE}/${BASE_BRANCH}"' "$_out"
+    assert_success
+    # A second fetch would be redundant: step 3's is the only one in the block.
+    run grep -c -- 'git -C "$MAIN_ROOT" fetch' "$_out"
+    assert_output "1"
+}
+
+@test "1577: dispatch.sh.md reuses an existing worktree and tears none down" {
+    local _out="${TEST_TEMP_HOME}/extracted.sh"
+    bash -c "awk -v f=\"\$(printf '\\140\\140\\140')\" '${_PMV_EXTRACT_AWK}' \
+        '$(_pmv_dispatch_doc)' > '${_out}'"
+    run grep -qF -- 'if [ -d "$PMV_SCRATCH" ]; then' "$_out"
+    assert_success
+    run grep -c -- 'worktree remove' "$_out"
+    assert_output "0"
 }


### PR DESCRIPTION
## Summary
- `gh:pr-post-merge-verify` 검증 herdr 탭의 `--cwd` 를 공용 메인 체크아웃(`$MAIN_ROOT`)에서 PR별 전용 detached scratch 워크트리로 옮긴다 — 다른 세션이 메인 체크아웃에서 브랜치를 바꿔도 검증 탭이 휩쓸리지 않는다.

## Changes
- `dispatch.sh.md`: Step 4 에서 `${git-common-dir}/pr-post-merge-verify/pr-<N>` 를 부재 시 생성(detached)/존재 시 재사용하고, `herdr tab create --cwd` 를 그 경로로 바꿨다. `herdr worktree list --cwd` 의 workspace(WS_ID) 조회는 여전히 `$MAIN_ROOT` 를 본다(그룹핑은 메인 체크아웃 소속, scratch 워크트리는 첫 디스패치 시점엔 자기 workspace 가 없음 — 이유는 인라인 comment 로 남겼다). Step 3 의 `$MAIN_ROOT` fetch+rebase 로직은 그대로 두었고, 자동 철거 로직은 넣지 않았다(탭 수명에 맞춘 정리는 후속 과제로 남긴다).
- `SKILL.md` / `references/rationale.md` / `references/help.md`: 옛 "메인 체크아웃에서 연다"는 서술을 새 동작(전용 워크트리, teardown 없음)에 맞춰 갱신.
- `tests/bats/skills/_fixtures/gh_pr_post_merge_verify.sh`: dispatch 변경을 그대로 미러링(새 stand-in: `_pmv_git_common_dir`, `_pmv_dir_exists`, `_pmv_git_worktree_add` 등).
- `tests/bats/skills/gh_pr_post_merge_verify.bats`: `1577:` 섹션 15건 추가 — 검증 탭 cwd 가 `$MAIN_ROOT` 가 아님, 워크트리 부재 시 생성/존재 시 재사용, PR 번호별로 서로 다른 디렉터리, Step 3 rebase 는 불변, teardown 없음을 pin.
- `docs/public/changelog.d/2026-08-31-1577.md`: 변경 기록 fragment 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_post_merge_verify.bats` — 114/114 pass
- [x] `tests/bats/skills/` 전체 재실행 — 이 변경과 무관한 pre-existing 실패 3건만 확인(doc-guard ai-metrics, helper_fallback_nf1 drift-guard, path-normalize 순서), 손대지 않음

## Related
Closes #1577

---
<details>
<summary>🤖 AI Metrics · 📊 ~8500 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~8500 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
