### PR TITLE
fix(devx-pr-review-all): SHELL_COMMON 소싱 지시문에 $HOME 폴백을 추가한다

### DIFF
--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -34,7 +34,7 @@ it verbatim, then stop. No API calls.
 ## Step 1: Parse Args
 
 Source and delegate to `devx_pr_review_all_parse`:
-`source "${SHELL_COMMON}/functions/devx_pr_review_all.sh"` then
+`source "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"` then
 `devx_pr_review_all_parse "$@"`. On help, follow Help; on exit 2, print stderr
 and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
 

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -82,7 +82,7 @@ a durable machine-readable record rather than a summary. Fetch the comments
 **once**, then per lane:
 
 ```sh
-. "${SHELL_COMMON}/functions/devx_pr_review_all.sh"
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"
 
 head_sha=$(GH_HOST="$TARGET_HOST" gh pr view "$pr" --repo "$TARGET_REPO" \
     --json headRefOid --jq .headRefOid)

--- a/claude/skills/devx-pr-verify-live/SKILL.md
+++ b/claude/skills/devx-pr-verify-live/SKILL.md
@@ -42,7 +42,7 @@ verbatim, then stop. No API calls, no browser.
 
 ## Step 1: Parse Args
 
-`source "${SHELL_COMMON}/functions/devx_pr_verify_live.sh"` then `devx_pr_verify_live_parse "$@"` — 플래그 표는
+`source "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_verify_live.sh"` then `devx_pr_verify_live_parse "$@"` — 플래그 표는
 `references/help.md`. On `help_requested=1` follow Help; on exit 2 print the stderr line and stop. Capture `pr`
 `remote` `url` `api_url` `start_cmd` `matrix` `viewports` `locales` `issue_mode` `allow_remote_host`
 `post_comment`. Record `START_TS=$(date +%s)`.

--- a/claude/skills/devx-pr-verify-live/references/discovery.md
+++ b/claude/skills/devx-pr-verify-live/references/discovery.md
@@ -190,7 +190,7 @@ dev 서버 PID 는 재기동으로 세션 중에 바뀐다. 실측: 같은 런 �
 # DOTFILES_FORCE_INIT=1 은 load-bearing 이다: 이 파일의 인터랙티브 가드가
 # 비대화형 셸에서 조기 return 하면 헬퍼가 아예 정의되지 않는다.
 export DOTFILES_FORCE_INIT=1
-. "${SHELL_COMMON}/functions/gh_pr_review.sh"
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_review.sh"
 TARGET_REPO=$(_gh_pr_review_resolve_target_repo "${remote:-origin}") || {
   echo "Cannot resolve remote '${remote:-origin}' to a repo" >&2; exit 1; }
 PR=$(_gh_pr_review_resolve_pr_number "$pr")   # 인자 우선, 없으면 현재 브랜치

--- a/claude/skills/gh-pr-reply/references/target-resolution.md
+++ b/claude/skills/gh-pr-reply/references/target-resolution.md
@@ -30,7 +30,7 @@ URL (network-free):
 # never defined. `remote` is the [remote] positional; ${remote:-origin}
 # keeps the block self-contained whether or not it was set.
 export DOTFILES_FORCE_INIT=1
-. "${SHELL_COMMON}/functions/gh_pr_review.sh"
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_review.sh"
 . "${DOTFILES_ROOT:-$HOME/dotfiles}/shell-common/functions/gh_host.sh"
 REMOTE_URL=$(git remote get-url "${remote:-origin}") || {
   echo "Cannot resolve remote '${remote:-origin}' to a repo" >&2; exit 1; }

--- a/docs/public/changelog.d/2026-08-31-1612.md
+++ b/docs/public/changelog.d/2026-08-31-1612.md
@@ -1,0 +1,2 @@
+- 변경: **claude/skills 문서 5곳의 `${SHELL_COMMON}/functions/...` 소싱 지시문에 `$HOME` 폴백을 추가해, `$SHELL_COMMON`이 비어 있는 셸에서 라벨링 함수가 조용히 사라지던 결함을 고쳤다**
+- 변경: **`mise run lint-docs`에 `${SHELL_COMMON}` `$HOME` 폴백 누락을 잡는 린터(`scripts/lint_shell_common_fallback.sh`)를 추가했다**

--- a/mise.toml
+++ b/mise.toml
@@ -52,13 +52,15 @@ run = [
 ]
 
 [tasks.lint-docs]
-description = "Docs 린터 (파일명 kebab-case #1027 + changelog fragment #1471)"
+description = "Docs 린터 (파일명 kebab-case #1027 + changelog fragment #1471 + SHELL_COMMON 폴백 #1612)"
 # adr/ + requirement/ 는 강제(FAIL), 나머지 docs/ 는 warn-only.
 # 레거시 위반 일괄 정리는 별도 이슈로 분리한다.
 # changelog fragment 규칙과 그 근거는 scripts/lint_changelog_fragments.sh 헤더가 SSOT.
+# ${SHELL_COMMON} $HOME 폴백 규칙과 근거는 scripts/lint_shell_common_fallback.sh 헤더가 SSOT.
 run = [
     "sh scripts/lint_docs_filenames.sh",
     "sh scripts/lint_changelog_fragments.sh",
+    "sh scripts/lint_shell_common_fallback.sh",
 ]
 
 # ─── Test gate ───────────────────────────────────────────────────────

--- a/scripts/lint_shell_common_fallback.sh
+++ b/scripts/lint_shell_common_fallback.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# lint_shell_common_fallback.sh — ${SHELL_COMMON} $HOME 폴백 검사 (issue #1612)
+#
+# 정책:
+#   - `claude/skills/**/*.md` 안의 소싱 지시문은 Claude Code의 Bash tool
+#     (`bash --noprofile --norc`, dotfiles rc 미실행)처럼 $SHELL_COMMON 이
+#     비어 있는 셸에서도 그대로 복붙 실행 가능해야 한다.
+#   - 그러려면 모든 `${SHELL_COMMON}/functions/...` 참조는
+#     `${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/...` 폴백
+#     관용구를 갖춰야 한다 (devx-pr-review-all/SKILL.md:116 이 기존 표준).
+#   - 폴백이 빠지면 `$SHELL_COMMON` 이 비었을 때 상대경로로 대체 source 하기
+#     쉬운데, 그 경로는 가드 체인과 상호작용해 함수가 조용히 안 정의되는
+#     실패로 이어진다(#1612 재현 스크립트 참고) — 즉시 에러가 나는 쪽보다도
+#     나쁘다.
+#
+# 사용:
+#   sh scripts/lint_shell_common_fallback.sh
+#   CLAUDE_SKILLS_DIR=path/to/skills sh scripts/lint_shell_common_fallback.sh
+
+set -eu
+
+SKILLS_DIR="${CLAUDE_SKILLS_DIR:-claude/skills}"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+    echo "lint-shell-common-fallback: '$SKILLS_DIR' 디렉터리를 찾을 수 없습니다." >&2
+    exit 2
+fi
+
+errors=0
+
+fail() {
+    echo "FAIL  $1" >&2
+    errors=$((errors + 1))
+}
+
+# `${SHELL_COMMON}/functions/` 를 그대로 찾는다 — `${SHELL_COMMON:-...}` 는
+# 여는 중괄호 바로 뒤가 `:` 이므로 이 리터럴 패턴과 매치되지 않는다.
+matches=$(grep -rn '${SHELL_COMMON}/functions/' "$SKILLS_DIR" --include='*.md' || true)
+
+if [ -n "$matches" ]; then
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        fail "$line — \${SHELL_COMMON:-\$HOME/dotfiles/shell-common}/functions/ 로 고치세요."
+    done <<EOF
+$matches
+EOF
+fi
+
+echo "lint-shell-common-fallback: errors=${errors} (dir: ${SKILLS_DIR})"
+
+[ "$errors" -eq 0 ] || exit 1

--- a/tests/bats/functions/devx_pr_review_all_source_path.bats
+++ b/tests/bats/functions/devx_pr_review_all_source_path.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# tests/bats/functions/devx_pr_review_all_source_path.bats
+# Issue #1612 — sourcing devx_pr_review_all.sh from a clean, non-interactive
+# shell (no dotfiles rc, no $SHELL_COMMON — the exact shape of Claude Code's
+# own Bash tool) must define all five public functions, whether the caller
+# sources the file by a relative or an absolute path. #1612 found several
+# skill docs telling agents to source it via a bare `${SHELL_COMMON}/...`
+# with no `$HOME` fallback; when that expands empty, an agent can fall back
+# to a relative-path `source` instead — this test pins that both paths work
+# so a future regression in the guard chain (dotfiles_root.sh) is caught
+# here instead of silently dropping `review-passed`/`review-blocked` labels
+# again.
+
+load '../test_helper'
+
+FUNCS="devx_pr_review_all_parse devx_pr_review_all_verdict devx_pr_review_all_aggregate devx_pr_review_all_lane_block devx_pr_review_all_apply_label"
+
+setup() {
+    setup_isolated_home
+    ln -s "$_BATS_REAL_DOTFILES_ROOT" "$HOME/dotfiles"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# A truly clean, non-interactive shell: no inherited $SHELL_COMMON/$DOTFILES_ROOT,
+# no rc files — matching the environment #1612 traces the failure to.
+run_clean_source() {
+    local src_expr="$1"
+    env -i HOME="$HOME" bash --noprofile --norc -c "
+        cd '${_BATS_REAL_DOTFILES_ROOT}' || exit 99
+        source ${src_expr} || exit 98
+        for f in ${FUNCS}; do
+            declare -f \"\$f\" >/dev/null 2>&1 || { echo \"MISSING:\$f\"; exit 1; }
+        done
+        echo ALL_DEFINED
+    "
+}
+
+@test "relative-path source defines all five functions in a clean shell" {
+    run run_clean_source "shell-common/functions/devx_pr_review_all.sh"
+    assert_success
+    assert_output --partial "ALL_DEFINED"
+}
+
+@test "absolute-path source defines all five functions in a clean shell (positive control)" {
+    run run_clean_source "\"${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh\""
+    assert_success
+    assert_output --partial "ALL_DEFINED"
+}
+
+@test "\${SHELL_COMMON:-\$HOME/dotfiles/shell-common} fallback idiom defines all five functions when SHELL_COMMON is unset" {
+    run run_clean_source '"${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"'
+    assert_success
+    assert_output --partial "ALL_DEFINED"
+}

--- a/tests/bats/lint/shell_common_fallback.bats
+++ b/tests/bats/lint/shell_common_fallback.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# tests/bats/lint/shell_common_fallback.bats
+# Issue #1612 — scripts/lint_shell_common_fallback.sh 회귀 가드.
+#
+# claude/skills/**/*.md 안의 `${SHELL_COMMON}/functions/...` 소싱 지시문에
+# `$HOME` 폴백이 빠지면, $SHELL_COMMON 이 비어 있는 셸(Claude Code의 Bash
+# tool)에서 agent 가 상대경로로 우회하다 라벨링 함수가 조용히 사라지는
+# 실패로 이어진다 — 그 실패를 재현/고정한 회귀 테스트는
+# devx_pr_review_all_source_path.bats. 이 파일은 그 원인이 된 문서 결함
+# 자체를 잡는 린터를 검사한다.
+
+load '../test_helper'
+
+LINTER="${_BATS_REAL_DOTFILES_ROOT}/scripts/lint_shell_common_fallback.sh"
+
+setup() {
+    setup_isolated_home
+    SKILLS_DIR="$BATS_TEST_TMPDIR/skills"
+    mkdir -p "$SKILLS_DIR/some-skill/references"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+run_linter() {
+    run env CLAUDE_SKILLS_DIR="$SKILLS_DIR" sh "$LINTER"
+}
+
+@test "missing skills directory fails closed" {
+    rm -rf "$SKILLS_DIR"
+    run_linter
+    assert_failure 2
+    assert_output --partial "찾을 수 없습니다"
+}
+
+@test "bare \${SHELL_COMMON}/functions/ with no \$HOME fallback fails" {
+    printf '`source "${SHELL_COMMON}/functions/some_lib.sh"` then run it.\n' \
+        >"$SKILLS_DIR/some-skill/SKILL.md"
+    run_linter
+    assert_failure 1
+    assert_output --partial "some-skill/SKILL.md"
+}
+
+@test "same line with the \$HOME fallback idiom passes (positive control)" {
+    printf '`source "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/some_lib.sh"` then run it.\n' \
+        >"$SKILLS_DIR/some-skill/SKILL.md"
+    run_linter
+    assert_success
+}
+
+@test "violation nested under references/ is still caught" {
+    printf '. "${SHELL_COMMON}/functions/some_lib.sh"\n' \
+        >"$SKILLS_DIR/some-skill/references/detail.md"
+    run_linter
+    assert_failure 1
+    assert_output --partial "references/detail.md"
+}
+
+@test "a directory with no violations passes" {
+    printf '. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/some_lib.sh"\n' \
+        >"$SKILLS_DIR/some-skill/SKILL.md"
+    printf 'no shell-common references here\n' \
+        >"$SKILLS_DIR/some-skill/references/detail.md"
+    run_linter
+    assert_success
+}
+
+@test "the repository's own claude/skills passes" {
+    run env CLAUDE_SKILLS_DIR="${_BATS_REAL_DOTFILES_ROOT}/claude/skills" \
+        sh "$LINTER"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- `claude/skills/**` 문서 5곳의 `${SHELL_COMMON}/functions/...` 소싱 지시문에 `$HOME` 폴백을 추가해, `$SHELL_COMMON`이 비어 있는 셸에서 `devx_pr_review_all_apply_label` 등 라벨링 함수가 조용히 사라지던 결함을 고쳤다.
- 재발 방지용 `mise run lint-docs` 린터(`scripts/lint_shell_common_fallback.sh`)와 회귀 bats 테스트 2건을 추가했다.

## Changes
- `claude/skills/devx-pr-review-all/SKILL.md`, `references/review-verdict-label.md`: `${SHELL_COMMON}/functions/devx_pr_review_all.sh` → `${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh` (기존 SKILL.md:116의 표준 관용구와 통일)
- `claude/skills/devx-pr-verify-live/SKILL.md`, `references/discovery.md`: 동일 폴백 추가
- `claude/skills/gh-pr-reply/references/target-resolution.md`: 동일 폴백 추가
- `mise.toml`: `lint-docs` 태스크에 `scripts/lint_shell_common_fallback.sh` 실행 추가
- `scripts/lint_shell_common_fallback.sh`: `claude/skills/**/*.md`에서 `$HOME` 폴백 없는 `${SHELL_COMMON}/functions/...` 참조를 잡는 신규 린터
- `tests/bats/functions/devx_pr_review_all_source_path.bats`: 클린 셸(`env -i bash --noprofile --norc`)에서 상대/절대경로 양쪽으로 source해도 5개 함수가 전부 정의되는지 고정하는 회귀 테스트
- `tests/bats/lint/shell_common_fallback.bats`: 신규 린터 자체의 positive/negative 케이스
- `docs/public/changelog.d/2026-08-31-1612.md`: changelog fragment

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all_source_path.bats tests/bats/lint/shell_common_fallback.bats` — 9개 전부 통과
- [x] `mise run lint-docs` — errors=0 (신규 린터 포함)
- [x] `#1607`, `#1608`에 절대경로로 `devx_pr_review_all_apply_label`을 직접 호출해 `review-passed`/`review-blocked` 라벨이 정상 적용됨을 실측 확인

## Related
Fixes #1612

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~40 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~40 min
<!-- /ai-metrics:gh-pr -->

</details>
