### PR TITLE
fix(claude-skills): SHELL_COMMON $HOME 폴백 검사 범위를 tools/ 등으로 넓힌다

### DIFF
--- a/claude/skills/devx-symlink-manager/references/function-templates.md
+++ b/claude/skills/devx-symlink-manager/references/function-templates.md
@@ -79,4 +79,4 @@ ux_bullet "<app>_edit_<config> : <filename> 파일 편집"
 - `ux_lib`은 인터랙티브 셸에서 자동 로드됨 (`shell-common/tools/ux_lib/ux_lib.sh`).
 - `<app>_init` / `<app>_edit_*` 함수가 비인터랙티브 호출(예: 스크립트)에서도
   실행될 수 있다면 함수 진입부에 `command -v ux_info >/dev/null 2>&1 ||
-  source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh"` 가드를 권장.
+  source "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/tools/ux_lib/ux_lib.sh"` 가드를 권장.

--- a/claude/skills/devx-ux-guidelines/references/refactoring-playbook.md
+++ b/claude/skills/devx-ux-guidelines/references/refactoring-playbook.md
@@ -17,7 +17,7 @@ Prefer approved path handling and conditional loading:
 
 ```bash
 if ! declare -f ux_header >/dev/null 2>&1; then
-    source "${SHELL_COMMON}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
+    source "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/tools/ux_lib/ux_lib.sh" 2>/dev/null || true
 fi
 ```
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,9 +9,10 @@
 - **Review**: open in markdown viewer (VS Code, grip)
 - **Line count**: `wc -l docs/**/*.md`
 - **Markdown lint**: 비활성화 — 자동 실행 금지
-- **Docs 린트**: `mise run lint-docs` — 두 개를 순차 실행한다.
+- **Docs 린트**: `mise run lint-docs` — 세 개를 순차 실행한다.
   - `scripts/lint_docs_filenames.sh` — docs 파일명 kebab-case 검사 (`adr/`·`requirement/` 강제, 나머지 warn-only, #1027)
   - `scripts/lint_changelog_fragments.sh` — `public/changelog.d/` fragment 의 파일명·내용 형식 강제 (#1471)
+  - `scripts/lint_shell_common_fallback.sh` — `claude/skills/**/*.md` 안 `${SHELL_COMMON}/...` 소싱 지시문의 `$HOME` 폴백 누락 강제 (#1612)
 
 # Golden Rules
 

--- a/docs/public/changelog.d/2026-08-31-1614.md
+++ b/docs/public/changelog.d/2026-08-31-1614.md
@@ -1,0 +1,2 @@
+- 변경: **`${SHELL_COMMON}` `$HOME` 폴백 누락(#1612)이 `claude/skills/**` 전체에서 2곳 더 남아 있던 것(`devx-symlink-manager`, `devx-ux-guidelines`의 `tools/ux_lib/ux_lib.sh` 소싱)을 마저 고쳤다**
+- 변경: **`scripts/lint_shell_common_fallback.sh`의 검사 범위를 `${SHELL_COMMON}/functions/...`에서 `${SHELL_COMMON}/...` 전체(`tools/` 등 다른 하위 경로 포함)로 넓혔다**

--- a/scripts/lint_shell_common_fallback.sh
+++ b/scripts/lint_shell_common_fallback.sh
@@ -5,9 +5,9 @@
 #   - `claude/skills/**/*.md` 안의 소싱 지시문은 Claude Code의 Bash tool
 #     (`bash --noprofile --norc`, dotfiles rc 미실행)처럼 $SHELL_COMMON 이
 #     비어 있는 셸에서도 그대로 복붙 실행 가능해야 한다.
-#   - 그러려면 모든 `${SHELL_COMMON}/functions/...` 참조는
-#     `${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/...` 폴백
-#     관용구를 갖춰야 한다 (devx-pr-review-all/SKILL.md:116 이 기존 표준).
+#   - 그러려면 모든 `${SHELL_COMMON}/...` 참조(functions/ 뿐 아니라 tools/ 등
+#     다른 하위 경로도 포함)는 `${SHELL_COMMON:-$HOME/dotfiles/shell-common}/...`
+#     폴백 관용구를 갖춰야 한다 (devx-pr-review-all/SKILL.md:116 이 기존 표준).
 #   - 폴백이 빠지면 `$SHELL_COMMON` 이 비었을 때 상대경로로 대체 source 하기
 #     쉬운데, 그 경로는 가드 체인과 상호작용해 함수가 조용히 안 정의되는
 #     실패로 이어진다(#1612 재현 스크립트 참고) — 즉시 에러가 나는 쪽보다도
@@ -33,14 +33,15 @@ fail() {
     errors=$((errors + 1))
 }
 
-# `${SHELL_COMMON}/functions/` 를 그대로 찾는다 — `${SHELL_COMMON:-...}` 는
-# 여는 중괄호 바로 뒤가 `:` 이므로 이 리터럴 패턴과 매치되지 않는다.
-matches=$(grep -rn '${SHELL_COMMON}/functions/' "$SKILLS_DIR" --include='*.md' || true)
+# `${SHELL_COMMON}/` 를 그대로 찾는다 — functions/ 뿐 아니라 tools/ 등 모든
+# 하위 경로를 잡는다. `${SHELL_COMMON:-...}` 는 여는 중괄호 바로 뒤가 `:` 이므로
+# 이 리터럴 패턴과 매치되지 않는다.
+matches=$(grep -rn '${SHELL_COMMON}/' "$SKILLS_DIR" --include='*.md' || true)
 
 if [ -n "$matches" ]; then
     while IFS= read -r line; do
         [ -n "$line" ] || continue
-        fail "$line — \${SHELL_COMMON:-\$HOME/dotfiles/shell-common}/functions/ 로 고치세요."
+        fail "$line — \${SHELL_COMMON:-\$HOME/dotfiles/shell-common}/ 로 고치세요."
     done <<EOF
 $matches
 EOF


### PR DESCRIPTION
## Summary
- PR #1618(#1612 수정)이 놓친 `${SHELL_COMMON}/tools/ux_lib/ux_lib.sh` 형태의 소싱 지시문 2곳을 마저 고쳤다 — PR #1614가 별도 감사에서 발견한 부분.
- `scripts/lint_shell_common_fallback.sh`의 검사 범위를 `${SHELL_COMMON}/functions/...`에서 `${SHELL_COMMON}/...` 전체로 넓혀, `functions/` 외 하위 경로(`tools/` 등)도 앞으로 자동으로 잡히게 했다.

## Changes
- `claude/skills/devx-symlink-manager/references/function-templates.md`: `${SHELL_COMMON}/tools/ux_lib/ux_lib.sh` → `$HOME` 폴백 추가
- `claude/skills/devx-ux-guidelines/references/refactoring-playbook.md`: 동일
- `scripts/lint_shell_common_fallback.sh`: 검사 패턴을 `/functions/` 한정에서 `${SHELL_COMMON}/` 전체로 일반화
- `docs/AGENTS.md`: `lint-docs` 설명에 3번째 린터(`lint_shell_common_fallback.sh`) 반영
- `docs/public/changelog.d/2026-08-31-1614.md`: changelog fragment

## Test plan
- [x] `sh scripts/lint_shell_common_fallback.sh` — errors=0 (넓어진 패턴으로 재검사)
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all_source_path.bats tests/bats/lint/shell_common_fallback.bats` — 9개 전부 통과 (패턴 변경 후 회귀 없음)
- [x] `sh scripts/lint_changelog_fragments.sh` — errors=0

## Related
동일 근본 원인 #1612에 대한 추가 수정. PR #1614가 이 두 파일을 먼저 발견했으나, 겹치는 5개 파일은 이미 PR #1618로 머지되어 conflicting 상태가 됐다 — 이 PR로 대체하고 #1614는 close 처리한다.
