### PR TITLE
fix(scripts): lint_shell_common_fallback.sh를 BSD/macOS 호환 패턴으로 바꾼다

### DIFF
--- a/docs/public/changelog.d/2026-08-31-1612.md
+++ b/docs/public/changelog.d/2026-08-31-1612.md
@@ -1,2 +1,3 @@
 - 변경: **claude/skills 문서 5곳의 `${SHELL_COMMON}/functions/...` 소싱 지시문에 `$HOME` 폴백을 추가해, `$SHELL_COMMON`이 비어 있는 셸에서 라벨링 함수가 조용히 사라지던 결함을 고쳤다**
 - 변경: **`mise run lint-docs`에 `${SHELL_COMMON}` `$HOME` 폴백 누락을 잡는 린터(`scripts/lint_shell_common_fallback.sh`)를 추가했다**
+- 변경: **`lint_shell_common_fallback.sh`의 GNU 전용 `grep -r --include=`를 형제 린터와 같은 `find` 기반 이식 가능 패턴으로 바꿨다 (BSD/macOS 호환)**

--- a/scripts/lint_shell_common_fallback.sh
+++ b/scripts/lint_shell_common_fallback.sh
@@ -33,19 +33,22 @@ fail() {
     errors=$((errors + 1))
 }
 
-# `${SHELL_COMMON}/` 를 그대로 찾는다 — functions/ 뿐 아니라 tools/ 등 모든
-# 하위 경로를 잡는다. `${SHELL_COMMON:-...}` 는 여는 중괄호 바로 뒤가 `:` 이므로
-# 이 리터럴 패턴과 매치되지 않는다.
-matches=$(grep -rn '${SHELL_COMMON}/' "$SKILLS_DIR" --include='*.md' || true)
-
-if [ -n "$matches" ]; then
+# `${SHELL_COMMON}/` 를 하위 경로 무관하게 그대로 찾는다 — `${SHELL_COMMON:-...}`
+# 는 여는 중괄호 바로 뒤가 `:` 이므로 이 리터럴 패턴과 매치되지 않는다.
+# `find` + 파일별 grep — 형제 린터 lint_docs_filenames.sh 와 동일한 이식 가능
+# 패턴이다. GNU 전용 `grep -r --include=` 는 BSD/macOS grep 에서 지원이
+# 불확실해 지원 대상 플랫폼(WSL·Linux·macOS, 루트 AGENTS.md) 에서
+# `mise run lint-docs` 자체가 깨질 수 있다 (PR #1614 codex 리뷰).
+for file in $(find "$SKILLS_DIR" -type f -name '*.md' | sort); do
+    matches=$(grep -n '${SHELL_COMMON}/' "$file" || true)
+    [ -n "$matches" ] || continue
     while IFS= read -r line; do
         [ -n "$line" ] || continue
-        fail "$line — \${SHELL_COMMON:-\$HOME/dotfiles/shell-common}/ 로 고치세요."
+        fail "$file:$line — \${SHELL_COMMON:-\$HOME/dotfiles/shell-common}/ 로 고치세요."
     done <<EOF
 $matches
 EOF
-fi
+done
 
 echo "lint-shell-common-fallback: errors=${errors} (dir: ${SKILLS_DIR})"
 


### PR DESCRIPTION
## Summary
- `scripts/lint_shell_common_fallback.sh`의 GNU 전용 `grep -r --include=`를 형제 린터(`lint_docs_filenames.sh`)와 같은 `find` 기반 이식 가능 패턴으로 바꿨다.

## Changes
- `scripts/lint_shell_common_fallback.sh`: `grep -rn ... --include='*.md'` → `find "$SKILLS_DIR" -type f -name '*.md' | sort` 순회 + 파일별 `grep -n` (BSD/macOS grep 호환)
- `docs/public/changelog.d/2026-08-31-1612.md`: 항목 1줄 추가

## Test plan
- [x] `sh scripts/lint_shell_common_fallback.sh` — errors=0
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all_source_path.bats tests/bats/lint/shell_common_fallback.bats` — 9개 전부 통과
- [x] `shellcheck -x -e SC1090,SC1091 -S warning scripts/lint_shell_common_fallback.sh` — clean

## Related
closed PR #1614의 codex 리뷰(BLOCKER)가 지적한 내용을 반영. #1614 자체는 #1618/#1619와 중복이라 close 처리했지만, 이 지적은 유효해 별도로 반영한다.
