### PR TITLE
docs(gh-issue-flow): non-origin remote CI-fail 자동화 갭 문서화

### DIFF
--- a/claude/skills/gh-issue-flow/SKILL.md
+++ b/claude/skills/gh-issue-flow/SKILL.md
@@ -80,13 +80,15 @@ bullets** (see CRITICAL CONTRACT). After each call, proceed to the next.
    literal `<remote>` (substituted fresh into this Bash call, never read
    from `$REMOTE`) resolves to the same repo URL as `$HOME/dotfiles`'s own
    `origin` (silently skipped otherwise, #1498 — the dispatcher only tracks
-   that one remote), fires `aicron run merge-train` **in the background, not
+   that one URL), fires `aicron run merge-train` **in the background, not
    awaited** (a real train launch can block ~4 min on its own `--wait`
    confirmation, which the rebase steps below don't need) so the dispatcher
-   checks immediately instead of waiting up to the cron backstop period.
-   Only a missing `aicron.sh` prints a `[WARN]` line; the dispatcher's own
-   NF-1 locking already prevents a duplicate train. Detail:
-   `references/merge-train-wake.md`.
+   checks immediately instead of waiting up to the cron backstop period. A
+   non-matching `<remote>` gets neither this wake nor the cron backstop —
+   no automated CI-fail remediation trigger at all (#1610, detail:
+   `references/constraints.md`). Only a missing `aicron.sh` prints a
+   `[WARN]` line; the dispatcher's own NF-1 locking already prevents a
+   duplicate train. Detail: `references/merge-train-wake.md`.
 6. **Step 2.5 — gh:pr-resolve-conflict** (only if 2.4 succeeded) —
    rebase-resolve; a fresh PR usually prints "이미 충돌 없음 — skip".
    `Skill(gh:pr-resolve-conflict, "<PR_NUM>")`

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -38,9 +38,9 @@
   `gh:pr-resolve-ci-fail` whenever it next processes that PR — via Step
   2.4.1's best-effort wake (see above) or, failing that, its own cron
   backstop. Detail: `gh-pr-merge-train/references/routing-table.md`.
-  **Neither path exists for a non-`origin`, non-dotfiles remote** (#1610):
-  the wake silently skips any `<remote>` that isn't `$HOME/dotfiles`'s own
-  `origin` (#1498), and this machine's crontab only runs the backstop with
+  **Neither path exists for any other `<remote>`** (#1610): the wake
+  silently skips every `<remote>` but `$HOME/dotfiles`'s own `origin`
+  (#1498), and this machine's crontab only runs the backstop with
   `--cwd ~/dotfiles`. A PR opened via `/gh-issue-flow <N> <other-remote>`
   that lands CI-red has no automated remediation trigger at all — the human
   must call `/gh-pr-merge-train <other-remote>` manually.

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -38,6 +38,12 @@
   `gh:pr-resolve-ci-fail` whenever it next processes that PR — via Step
   2.4.1's best-effort wake (see above) or, failing that, its own cron
   backstop. Detail: `gh-pr-merge-train/references/routing-table.md`.
+  **Neither path exists for a non-`origin`, non-dotfiles remote** (#1610):
+  the wake silently skips any `<remote>` that isn't `$HOME/dotfiles`'s own
+  `origin` (#1498), and this machine's crontab only runs the backstop with
+  `--cwd ~/dotfiles`. A PR opened via `/gh-issue-flow <N> <other-remote>`
+  that lands CI-red has no automated remediation trigger at all — the human
+  must call `/gh-pr-merge-train <other-remote>` manually.
 - **Never fall back to `_dotfiles_setup_mode` alone for the host (#1403).**
   Step 1 exports `GH_HOST`/`TARGET_REPO`/`TARGET_HOST` from the `[remote]`'s
   URL, and every GitHub-touching sub-skill receives `[remote]` as an explicit

--- a/claude/skills/gh-issue-flow/references/constraints.md
+++ b/claude/skills/gh-issue-flow/references/constraints.md
@@ -39,9 +39,13 @@
   2.4.1's best-effort wake (see above) or, failing that, its own cron
   backstop. Detail: `gh-pr-merge-train/references/routing-table.md`.
   **Neither path exists for any other `<remote>`** (#1610): the wake
-  silently skips every `<remote>` but `$HOME/dotfiles`'s own `origin`
-  (#1498), and this machine's crontab only runs the backstop with
-  `--cwd ~/dotfiles`. A PR opened via `/gh-issue-flow <N> <other-remote>`
+  silently skips every `<remote>` whose resolved URL isn't `$HOME/dotfiles`'s
+  own `origin` (#1498 — URL comparison, not a remote-name match: a
+  differently-named remote pointing at that same URL still fires), and this
+  machine's `merge-train` cron entry — `shell-common/tools/custom/cron-jobs.json`,
+  installed via `aicron add merge-train`, never a hand-edited crontab line
+  (`gh-pr-merge-train/references/cron-dispatcher.md`) — only targets
+  `--cwd $HOME/dotfiles`. A PR opened via `/gh-issue-flow <N> <other-remote>`
   that lands CI-red has no automated remediation trigger at all — the human
   must call `/gh-pr-merge-train <other-remote>` manually.
 - **Never fall back to `_dotfiles_setup_mode` alone for the host (#1403).**

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -55,10 +55,9 @@ on a feature branch with a clean working tree.
   3 (PR) failed, the commit stays.
 - Create a worktree or branch — user must be on a feature branch already.
 - Resolve CI failures — a fresh PR's checks have not reported yet.
-  `gh:pr-merge-train` routes CI-red PRs to `gh:pr-resolve-ci-fail`, but only
-  when something actually triggers it to process the PR again: Step 2.4.1's
-  wake fires solely for `<remote>`s that resolve to `$HOME/dotfiles`'s own
-  `origin` (#1498), and this machine's cron backstop is likewise configured
-  for `~/dotfiles` only. A PR opened on any other `<remote>` gets **no**
-  automated CI-fail remediation trigger — run `/gh-pr-merge-train <remote>`
-  by hand (#1610).
+  `gh:pr-merge-train` routes CI-red PRs to `gh:pr-resolve-ci-fail` once
+  something triggers it to reprocess the PR, but (see step 4 above) only
+  `origin`'s own `$HOME/dotfiles` remote has a trigger at all. Any other
+  `<remote>` gets **no** automated CI-fail remediation — run
+  `/gh-pr-merge-train <remote>` by hand (#1610). Detail:
+  `references/constraints.md`.

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -21,7 +21,7 @@ This skill invokes **6 skills in sequence** (each step runs only if the previous
 2. **`gh:commit <N> <remote>`** — creates a commit for the changes with a message derived from the conversation (follows the repo's commit style); the ai-metrics comment and board sync go to `<remote>`'s repo (#1405).
 3. **`gh:pr <N> <remote>`** — pushes the branch to `<remote>` and opens the PR there, auto-linking `Closes #<N>` (#1405).
 4. **`devx:pr-review-all` `<PR_NUM> <remote> --defer-reply 4`** — one delegated call runs the post-PR quality gate (soft-fail, parallel): agy ∥ codex second-opinion reviews (each skipped if its CLI is absent) ∥ built-in `/simplify` on the branch diff. Any simplify changes are committed + pushed synchronously before it returns (so they land before the rebase steps), and `/gh-pr-reply <PR_NUM>` is scheduled 4 minutes later — giving CI and reviewers time to post before the reply pass runs. Failures warn and continue — they never stop the chain.
-   - **`aicron run merge-train`** (non-fatal, not a `Skill()` call; only when `<remote>` resolves to the same repo URL as `$HOME/dotfiles`'s own `origin`, silently skipped otherwise — the dispatcher only tracks that one remote, #1498) — fires the merge-train dispatcher once, in the background (not awaited — a real train launch can block minutes), so it checks the new PR immediately instead of waiting for the cron backstop. A missing binary is the only synchronously-observed failure on the matching-remote path, printed as a single `[WARN]` line; the dispatcher's own locking prevents a duplicate train.
+   - **`aicron run merge-train`** (non-fatal, not a `Skill()` call; only when `<remote>` resolves to the same repo URL as `$HOME/dotfiles`'s own `origin`, silently skipped otherwise — the dispatcher only tracks that one URL, not a remote name, #1498) — fires the merge-train dispatcher once, in the background (not awaited — a real train launch can block minutes), so it checks the new PR immediately **on that one matching-remote path** instead of waiting for the cron backstop; a non-matching `<remote>` has no cron backstop either (see "What this skill will NOT do" below). A missing binary is the only synchronously-observed failure on the matching-remote path, printed as a single `[WARN]` line; the dispatcher's own locking prevents a duplicate train.
 5. **`gh:pr-resolve-conflict` `<PR_NUM>`** — checks and resolves any merge conflicts in the new PR via rebase. Exits cleanly if the PR has no conflicts (expected for a freshly created branch).
 6. **`gh:pr-resolve-outdated` `<PR_NUM>`** — clean rebase-sync when the base branch has moved forward with no conflicts. No-op if the PR is already up to date.
 
@@ -57,7 +57,8 @@ on a feature branch with a clean working tree.
 - Resolve CI failures — a fresh PR's checks have not reported yet.
   `gh:pr-merge-train` routes CI-red PRs to `gh:pr-resolve-ci-fail` once
   something triggers it to reprocess the PR, but (see step 4 above) only
-  `origin`'s own `$HOME/dotfiles` remote has a trigger at all. Any other
+  `$HOME/dotfiles`'s own `origin` remote has a trigger at all — the wake and
+  the cron backstop are both scoped to that one repo URL. Any other
   `<remote>` gets **no** automated CI-fail remediation — run
   `/gh-pr-merge-train <remote>` by hand (#1610). Detail:
   `references/constraints.md`.

--- a/claude/skills/gh-issue-flow/references/help.md
+++ b/claude/skills/gh-issue-flow/references/help.md
@@ -55,5 +55,10 @@ on a feature branch with a clean working tree.
   3 (PR) failed, the commit stays.
 - Create a worktree or branch — user must be on a feature branch already.
 - Resolve CI failures — a fresh PR's checks have not reported yet.
-  `gh:pr-merge-train` routes CI-red PRs to `gh:pr-resolve-ci-fail`
-  whenever it next processes the PR.
+  `gh:pr-merge-train` routes CI-red PRs to `gh:pr-resolve-ci-fail`, but only
+  when something actually triggers it to process the PR again: Step 2.4.1's
+  wake fires solely for `<remote>`s that resolve to `$HOME/dotfiles`'s own
+  `origin` (#1498), and this machine's cron backstop is likewise configured
+  for `~/dotfiles` only. A PR opened on any other `<remote>` gets **no**
+  automated CI-fail remediation trigger — run `/gh-pr-merge-train <remote>`
+  by hand (#1610).


### PR DESCRIPTION
## Summary
- `gh:issue-flow` 의 `help.md`/`constraints.md` 가 CI-fail 자동 remediation을 `gh:pr-merge-train`이 처리한다고만 적어, 이 경로가 `$HOME/dotfiles`의 자기 `origin` 에서만 동작한다는 사실을 감춰왔다(PR #1602 재리뷰 agy/codex 지적).
- non-`origin` remote 로 연 PR 은 CI-red 가 돼도 Step 2.4.1 wake(#1498)와 cron backstop 둘 다 대상이 아니라, 자동 remediation 트리거가 전혀 없다는 사실을 명시한다.

## Changes
- `constraints.md`: "CI-fail resolution is out of scope" 항목에 non-origin remote 캐비어트 추가 — 수동 `/gh-pr-merge-train <remote>` 호출이 유일한 경로임을 명시.
- `help.md`: "Resolve CI failures" 항목을 같은 갭으로 갱신.

## Test plan
- [x] `mise run lint` — clean
- [x] `mise run lint-docs` — clean
- [x] `mise run test` — 1619 passed, 1 pre-existing failure (`test_committed_docs_match_a_fresh_render`, `mytool.md` — 이 변경과 무관함을 stash 로 재확인)

## Related
Closes #1610

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~1 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~1 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
