### PR TITLE
fix(devx-pr-review-all): 동일 head-sha 중복 리뷰를 사전 감지해 skip

### DIFF
--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -52,21 +52,27 @@ and `START_TS`.
 ## Step 3: Review + auto-fix gate (dispatch all lanes in ONE turn)
 
 **Duplicate-review guard first (#1613).** Before dispatching anything, read
-`head_sha` once (`gh pr view "$pr" -R "$TARGET_REPO" --json headRefOid`) and
-`BODIES` once (`gh api --paginate "repos/$TARGET_REPO/issues/$pr/comments"`).
-Then, unless `force_review=1`, skip any reviewer lane for which
+`head_sha` once (`gh pr view "$pr" -R "$TARGET_REPO" --json headRefOid --jq
+.headRefOid`) and `BODIES` once
+(`gh api --paginate "repos/$TARGET_REPO/issues/$pr/comments"`). Then, unless
+`force_review=1`, skip any reviewer lane for which
 `devx_pr_review_all_already_reviewed "$ai" "$head_sha"` (fed `$BODIES` on
 stdin) returns 0 — print
 `[SKIP] <ai> already reviewed head <head_sha> — pass --force-review to re-run`
 and do **not** dispatch that lane's Agent. Two sessions reviewing the same head
 concurrently is what posted duplicate agy/codex comments on PR #1608. Fail
 open: if either fetch errors, treat every lane as not-yet-reviewed and dispatch
-normally. Full rationale: `references/duplicate-review-guard.md`.
+normally. This is a read-before-write check, not a lock — two sessions can
+still both read "not yet reviewed" and both fan out; see
+`references/duplicate-review-guard.md` → "Known limitation" for why that race
+is accepted rather than closed with a lock file.
 
 The five lanes dispatch together in a single turn. agy/codex/opencode/hermes
 are comment-only; `/simplify` may mutate and commit. Each lane is soft-fail.
-A lane skipped by the guard counts as `[SKIP]` for Steps 3.5 and 6, exactly
-like a missing CLI — it contributes no verdict line.
+A lane skipped by the guard because it was **already reviewed** is not the
+same as a lane skipped for a **missing CLI** — the former still has a valid
+verdict for this exact head and Step 3.5 must harvest it (see Step 3.5's
+"guard-skipped lanes" note below); only the latter contributes no verdict line.
 
 - **agy** — if `command -v agy`, an Agent runs
   `Skill(gh:pr-review, "--ai agy <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
@@ -97,16 +103,27 @@ Full runnable block, exit codes, and rationale: `references/review-verdict-label
 In short — bind `TARGET_HOST` from the same `<remote>` URL as `TARGET_REPO`
 (the block in `references/reply-pending-label.sh.md` step 0), then:
 
-1. `head_sha` — one `gh pr view "$pr" -R "$TARGET_REPO" --json headRefOid`.
+1. `head_sha` — one `gh pr view "$pr" -R "$TARGET_REPO" --json headRefOid --jq
+   .headRefOid`.
 2. `BODIES` — one `gh api --paginate "repos/$TARGET_REPO/issues/$pr/comments"`.
-3. For **each lane that actually ran** in Step 3 (a `[SKIP]`/`[WARN]` lane
-   contributes nothing, and `/simplify` never contributes), pipe `BODIES`
-   through `devx_pr_review_all_lane_block "$ai" "$head_sha"` →
+3. For **each lane that either ran fresh in Step 3 OR was skipped by the
+   duplicate-review guard** (i.e. every lane except one skipped for a
+   **missing CLI / non-internal PC** — `/simplify` never contributes either),
+   pipe `BODIES` through `devx_pr_review_all_lane_block "$ai" "$head_sha"` →
    `devx_pr_review_all_verdict`, and pipe that stream straight into
    `devx_pr_review_all_apply_label "$pr" "$TARGET_REPO" "$TARGET_HOST" "$head_sha"`
    — the trailing `$head_sha` stamps a freshness marker when the verdict is
    `review-passed` (#1601), so `gh:pr-merge-train`'s gate can tell this exact
    head from a stale one.
+   **Why a guard-skipped lane must still be included (#1613, agy+codex PR
+   #1623 BLOCKER):** the guard skipped it precisely because it already has a
+   verdict for `$head_sha` — dropping that lane from the stream would let a
+   partial re-run (e.g. only one lane force-re-reviewed) silently overwrite an
+   existing `review-blocked` verdict with `review-passed`, because the
+   aggregator only sees the lanes fed to it. Since `devx_pr_review_all_lane_block`
+   reads whatever marker already exists in `$BODIES` regardless of which
+   session or run posted it, including a guard-skipped lane costs nothing extra
+   — the same call that decided to skip it already proved the marker exists.
    Never stage the verdicts in a variable and re-expand it — zsh does not
    word-split, and a two-lane PR would silently report one.
 

--- a/claude/skills/devx-pr-review-all/SKILL.md
+++ b/claude/skills/devx-pr-review-all/SKILL.md
@@ -24,7 +24,7 @@ review comments inline or deferred. No
 approve/request-changes decision and no manual per-comment authoring. Every reviewer lane is soft-fail.
 This skill is the **only** writer of `review-blocked` / `review-passed`
 (`references/review-verdict-label.md`); `gh:pr-merge-train` is their only reader.
-Argument/flag table (`<PR#> [remote] [--defer-reply M] [--no-reply]`): `references/help.md`.
+Argument/flag table (`<PR#> [remote] [--defer-reply M] [--no-reply] [--force-review]`): `references/help.md`.
 
 ## Help
 
@@ -36,7 +36,8 @@ it verbatim, then stop. No API calls.
 Source and delegate to `devx_pr_review_all_parse`:
 `source "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"` then
 `devx_pr_review_all_parse "$@"`. On help, follow Help; on exit 2, print stderr
-and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
+and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, `force_review`,
+and `START_TS`.
 
 ## Step 2: Pre-flight
 
@@ -50,8 +51,22 @@ and stop. Capture `pr`, `remote`, `reply_mode`, `reply_delay`, and `START_TS`.
 
 ## Step 3: Review + auto-fix gate (dispatch all lanes in ONE turn)
 
+**Duplicate-review guard first (#1613).** Before dispatching anything, read
+`head_sha` once (`gh pr view "$pr" -R "$TARGET_REPO" --json headRefOid`) and
+`BODIES` once (`gh api --paginate "repos/$TARGET_REPO/issues/$pr/comments"`).
+Then, unless `force_review=1`, skip any reviewer lane for which
+`devx_pr_review_all_already_reviewed "$ai" "$head_sha"` (fed `$BODIES` on
+stdin) returns 0 — print
+`[SKIP] <ai> already reviewed head <head_sha> — pass --force-review to re-run`
+and do **not** dispatch that lane's Agent. Two sessions reviewing the same head
+concurrently is what posted duplicate agy/codex comments on PR #1608. Fail
+open: if either fetch errors, treat every lane as not-yet-reviewed and dispatch
+normally. Full rationale: `references/duplicate-review-guard.md`.
+
 The five lanes dispatch together in a single turn. agy/codex/opencode/hermes
 are comment-only; `/simplify` may mutate and commit. Each lane is soft-fail.
+A lane skipped by the guard counts as `[SKIP]` for Steps 3.5 and 6, exactly
+like a missing CLI — it contributes no verdict line.
 
 - **agy** — if `command -v agy`, an Agent runs
   `Skill(gh:pr-review, "--ai agy <pr> <remote>")`; absent or non-zero exit → SKIP/WARN.
@@ -94,6 +109,10 @@ In short — bind `TARGET_HOST` from the same `<remote>` URL as `TARGET_REPO`
    head from a stale one.
    Never stage the verdicts in a variable and re-expand it — zsh does not
    word-split, and a two-lane PR would silently report one.
+
+Fetch both again here rather than reusing Step 3's duplicate-guard values: no
+push has happened in between so `head_sha` is unchanged, but the lanes just
+posted new comments, and this step needs the **fresh** `BODIES`.
 
 The whole step is **soft-fail**: a labelling failure never blocks Steps 4-6,
 and an unlabelled PR reads downstream as "not verified", which

--- a/claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
+++ b/claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
@@ -1,0 +1,68 @@
+# devx:pr-review-all — Duplicate-review guard
+
+SSOT for how Step 3 avoids re-running a reviewer lane that already reviewed the
+PR's current head. Implementation: `devx_pr_review_all_already_reviewed` in
+`shell-common/functions/devx_pr_review_all.sh`; regression suite:
+`tests/bats/functions/devx_pr_review_all_dedupe.bats`. Issue: #1613.
+
+Why it exists: nothing gated the fan-out on "has this already been reviewed?".
+On PR #1608 two sessions reviewed the same head sha `2d7bbdca` 36 minutes
+apart, so agy and codex each ran twice and posted duplicate review comments —
+wasted reviewer budget, and a comment thread where a reader cannot tell a
+re-review from a second opinion.
+
+## The algorithm
+
+Once, before any lane is dispatched:
+
+```sh
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"
+
+head_sha=$(GH_HOST="$TARGET_HOST" gh pr view "$pr" --repo "$TARGET_REPO" \
+    --json headRefOid --jq .headRefOid)
+
+BODIES=$(GH_HOST="$TARGET_HOST" gh api --paginate \
+    "repos/$TARGET_REPO/issues/$pr/comments" --jq '.[].body')
+```
+
+Then per lane, before dispatching its Agent:
+
+```sh
+if [ "$force_review" != "1" ] &&
+    printf '%s\n' "$BODIES" | devx_pr_review_all_already_reviewed "$ai" "$head_sha"; then
+    echo "[SKIP] $ai already reviewed head $head_sha — pass --force-review to re-run"
+    continue
+fi
+```
+
+`devx_pr_review_all_already_reviewed` is a thin wrapper over
+`devx_pr_review_all_lane_block "$ai" "$head_sha"`: rc 0 when that lane has a
+complete `<!-- ai-review:<ai>:<head-sha> -->` block, rc 1 otherwise. One parser
+for the marker grammar, so the guard and Step 3.5's verdict harvester can never
+disagree about what "already reviewed" means. The `<head-sha>` is mandatory
+here — without it an older, untagged block would match and every re-review
+would be skipped forever.
+
+A guard-skipped lane reports `[SKIP]` and contributes **no** verdict line to
+Step 3.5, exactly like a missing CLI. Its earlier verdict is still on the PR
+under the same head sha, so the label that run wrote still stands.
+
+## Why here, not inside `gh:pr-review`
+
+`gh:pr-review` is single-shot per invocation: one AI, one PR, one comment. It
+has no concept of "another session already ran this lane", and adding one would
+put a network read in front of every direct `/gh-pr-review` call — including
+the deliberate re-reviews that skill exists to serve. The fan-out orchestrator
+is the only layer that knows it is issuing a *batch* and can amortize one
+shared `head_sha`/`BODIES` fetch across all of it.
+
+## Why it fails open
+
+A `gh pr view` / `gh api` error here must not abort the review: treat every
+lane as not-yet-reviewed and dispatch normally. The worst case is the duplicate
+comment this guard merely optimizes away, whereas failing closed would skip a
+real review and leave the PR unverified. Same NF-1 soft-fail posture as the
+3.3b duplicate-open-PR guard in `gh:issue-implement`, which this parallels —
+and the opposite of Step 3.5's fail-**closed** freshness rule
+(`review-verdict-label.md`), correctly so: that gate authorizes a merge, this
+one only decides whether to spend a reviewer.

--- a/claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
+++ b/claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
@@ -43,9 +43,19 @@ disagree about what "already reviewed" means. The `<head-sha>` is mandatory
 here — without it an older, untagged block would match and every re-review
 would be skipped forever.
 
-A guard-skipped lane reports `[SKIP]` and contributes **no** verdict line to
-Step 3.5, exactly like a missing CLI. Its earlier verdict is still on the PR
-under the same head sha, so the label that run wrote still stands.
+A guard-skipped lane reports `[SKIP]`, but — unlike a lane skipped for a
+missing CLI — it still **must** contribute a verdict line to Step 3.5 (agy +
+codex, PR #1623 BLOCKER): its earlier verdict is still on the PR under the
+same head sha, and Step 3.5's aggregator has no other way to see it. Dropping
+a guard-skipped lane from the aggregation stream would let a partial re-run —
+say, only one lane force-re-reviewed while the rest sit guard-skipped — silently
+overwrite an existing `review-blocked` verdict with `review-passed`, because
+the aggregator only ever sees the lanes actually fed to it. Since
+`devx_pr_review_all_lane_block "$ai" "$head_sha"` reads whatever marker already
+exists in `$BODIES`, regardless of which run posted it, feeding a guard-skipped
+lane through the same harvester the fresh lanes use costs nothing extra — the
+guard already proved the marker exists by skipping it. See `SKILL.md` → Step
+3.5 for the corrected aggregation loop.
 
 ## Why here, not inside `gh:pr-review`
 
@@ -66,3 +76,24 @@ real review and leave the PR unverified. Same NF-1 soft-fail posture as the
 and the opposite of Step 3.5's fail-**closed** freshness rule
 (`review-verdict-label.md`), correctly so: that gate authorizes a merge, this
 one only decides whether to spend a reviewer.
+
+## Known limitation: this is a check, not a lock (codex, PR #1623 BLOCKER)
+
+The guard is a **read-before-write (TOCTOU) check**: it reads `BODIES`, decides
+"not yet reviewed", and only then dispatches. Two sessions can both read the
+same pre-review `BODIES` snapshot within the same race window and both
+conclude "not yet reviewed" — the guard does not serialize concurrent runs, so
+the exact scenario it targets (PR #1608's two overlapping sessions) can still
+slip through if both sessions start close enough together.
+
+This is accepted, not overlooked. Issue #1613 weighed two designs — this
+pre-dispatch check (Option 1) versus a file-based lock mirroring
+`gh:pr-merge-train`'s NF-1 flock (Option 2) — and chose Option 1 as the
+priority: a lock file is awkward to place consistently across the multiple
+worktrees/accounts this repo's sessions run from, while the check reuses
+`devx_pr_review_all_lane_block`, a helper that already existed for Step 3.5.
+The check does not need to close the race to be worth shipping — it converts
+"two sessions racing 36 minutes apart" (PR #1608's actual reproduction) from a
+certainty into a narrow same-instant coincidence, at zero added infrastructure.
+A lock-based Option 2 remains available as a follow-up if the residual race
+proves to matter in practice.

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -21,7 +21,7 @@ request-changes) — that is `gh:pr-approve`.
 |------|---------|-------------|
 | `--defer-reply M` / `--defer-reply=M` | off (inline) | Schedule `/gh-pr-reply` M **minutes** later via `devx:schedule` instead of replying inline. |
 | `--no-reply` | off | Skip the reply step entirely. |
-| `--force-review` | off | Bypass the duplicate-review guard and re-run every lane even if the current head sha was already reviewed. |
+| `--force-review` | off | Bypass the duplicate-review guard and re-run every reviewer lane (agy/codex/opencode/hermes) even if the current head sha was already reviewed. Does not affect `/simplify`, which always runs regardless of this flag. |
 | `-h` / `--help` / `help` | — | Print this help and stop. |
 
 `--defer-reply` and `--no-reply` together → `--no-reply` wins (reply skipped).

--- a/claude/skills/devx-pr-review-all/references/help.md
+++ b/claude/skills/devx-pr-review-all/references/help.md
@@ -21,6 +21,7 @@ request-changes) — that is `gh:pr-approve`.
 |------|---------|-------------|
 | `--defer-reply M` / `--defer-reply=M` | off (inline) | Schedule `/gh-pr-reply` M **minutes** later via `devx:schedule` instead of replying inline. |
 | `--no-reply` | off | Skip the reply step entirely. |
+| `--force-review` | off | Bypass the duplicate-review guard and re-run every lane even if the current head sha was already reviewed. |
 | `-h` / `--help` / `help` | — | Print this help and stop. |
 
 `--defer-reply` and `--no-reply` together → `--no-reply` wins (reply skipped).
@@ -31,6 +32,7 @@ request-changes) — that is `gh:pr-approve`.
 - `/devx-pr-review-all 99 upstream` — same, targeting the `upstream` repo
 - `/devx-pr-review-all 99 --defer-reply 8` — review now, schedule the reply 8 min later
 - `/devx-pr-review-all 99 --no-reply` — review only; skip the reply pass
+- `/devx-pr-review-all 99 --force-review` — force every lane to re-run even if this head was already reviewed
 - `/devx-pr-review-all -h` / `--help` / `help` — print this help
 
 ## What the skill does
@@ -39,7 +41,9 @@ request-changes) — that is `gh:pr-approve`.
 2. Pre-flight: PR must be `OPEN` and non-draft, `gh auth` must be live, and
    check out the PR head branch if not already on it (so `/simplify` acts on
    the right tree).
-3. Review + auto-fix gate — dispatch agy, codex, opencode, hermes, and the
+3. Review + auto-fix gate — first skip any reviewer lane that already posted a
+   review for the PR's current head sha (the duplicate-review guard, #1613;
+   `--force-review` bypasses it), then dispatch the remaining lanes plus the
    auto-fix pass as
    Agent subagents **in one turn**. agy/codex/opencode/hermes delegate to
    `gh:pr-review --ai <name>` (streams findings + posts a PR comment) and run

--- a/docs/public/changelog.d/2026-08-31-1613.md
+++ b/docs/public/changelog.d/2026-08-31-1613.md
@@ -1,0 +1,1 @@
+- 변경: **`devx:pr-review-all` 이 리뷰어 레인 dispatch 전에 현재 head sha 의 중복 리뷰를 감지해 `[SKIP]` 하도록 개선 — 동시 세션이 같은 head 를 두 번 리뷰해 중복 코멘트를 남기던 문제(#1608) 해소, `--force-review` 로 우회 가능**

--- a/shell-common/functions/devx_pr_review_all.sh
+++ b/shell-common/functions/devx_pr_review_all.sh
@@ -51,6 +51,7 @@ devx_pr_review_all_parse() {
     local reply_delay="8"
     local _no_reply=0
     local _remote_set=0
+    local _force_review=0
 
     while [ "$#" -gt 0 ]; do
         case "$1" in
@@ -70,6 +71,10 @@ devx_pr_review_all_parse() {
             ;;
         --no-reply)
             _no_reply=1
+            shift
+            ;;
+        --force-review)
+            _force_review=1
             shift
             ;;
         -h | --help | help)
@@ -131,6 +136,7 @@ devx_pr_review_all_parse() {
     printf '%s\n' "remote=$remote"
     printf '%s\n' "reply_mode=$reply_mode"
     printf '%s\n' "reply_delay=$reply_delay"
+    printf '%s\n' "force_review=$_force_review"
     return 0
 }
 
@@ -153,6 +159,9 @@ devx_pr_review_all_parse() {
 #     tokens on stdin -> aggregates, then writes the label to the PR. One
 #     `[OK]`/`[WARN]` line. [head-sha], when given, stamps a freshness marker
 #     alongside a `review-passed` label (#1601) — see that function's header.
+#   devx_pr_review_all_already_reviewed <ai> <head-sha>  # bodies on stdin
+#     -> rc 0 when that lane already posted a block for this exact head
+#     (#1613 duplicate-review guard) — see that function's header.
 #
 # devx_pr_review_all_aggregate reads stdin, NOT positional args — load-bearing,
 # not stylistic; see the doc for the zsh bug that forces it.
@@ -313,6 +322,31 @@ devx_pr_review_all_lane_block() {
     '
 }
 
+# Duplicate-review guard (issue #1613): has <ai> ALREADY reviewed this exact
+# head? Reads the PR's comment bodies on stdin; rc 0 = yes (skip the lane),
+# rc 1 = no (dispatch it). SSOT for the policy around it:
+# claude/skills/devx-pr-review-all/references/duplicate-review-guard.md.
+#
+# Deliberately a thin wrapper over devx_pr_review_all_lane_block — the marker
+# grammar has exactly one parser, so a future change to the `<!-- ai-review:
+# <ai>:<sha> -->` shape cannot make the guard and the verdict harvester
+# disagree. A non-empty block for that ai+sha pair is the evidence; anything
+# else (no block, another sha, another lane, empty stdin) is "not yet
+# reviewed", which fails OPEN — a missed skip only costs a duplicate review,
+# while a false skip would silently lose a lane's verdict.
+#
+# <head-sha> is REQUIRED here, unlike in lane_block: without it an untagged or
+# older block would match and every re-review would be skipped forever.
+devx_pr_review_all_already_reviewed() {
+    local _ai="${1-}" _sha="${2-}" _block
+
+    [ -n "$_ai" ] || return 1
+    [ -n "$_sha" ] || return 1
+
+    _block=$(devx_pr_review_all_lane_block "$_ai" "$_sha")
+    [ -n "$_block" ]
+}
+
 # Aggregate the verdict stream and WRITE the resulting label to the PR.
 # This is the producer half of the merge gate (#1564): without it the two
 # labels are never issued, `gh:pr-merge-train` reads "not verified" on every
@@ -460,6 +494,7 @@ for _dpra_selfcheck_fn in \
     devx_pr_review_all_verdict \
     devx_pr_review_all_aggregate \
     devx_pr_review_all_lane_block \
+    devx_pr_review_all_already_reviewed \
     devx_pr_review_all_apply_label; do
     command -v "$_dpra_selfcheck_fn" >/dev/null 2>&1 && continue
     printf '[devx_pr_review_all] BUG: %s undefined after source — the review verdict gate will not run. See dotfiles #724 / #1564.\n' \

--- a/tests/bats/functions/devx_pr_review_all.bats
+++ b/tests/bats/functions/devx_pr_review_all.bats
@@ -81,20 +81,48 @@ setup() {
     assert_failure 2
 }
 
+@test "no --force-review -> force_review=0 (guard armed by default)" {
+    run devx_pr_review_all_parse 123
+    assert_success
+    assert_line "force_review=0"
+}
+
+@test "--force-review -> force_review=1" {
+    run devx_pr_review_all_parse 123 --force-review
+    assert_success
+    assert_line "force_review=1"
+}
+
+@test "--force-review combines with --defer-reply" {
+    run devx_pr_review_all_parse 123 --defer-reply 8 --force-review
+    assert_success
+    assert_line "force_review=1"
+    assert_output --partial "reply_mode=defer"
+    assert_output --partial "reply_delay=8"
+}
+
+@test "--force-review combines with a remote positional" {
+    run devx_pr_review_all_parse 123 upstream --force-review
+    assert_success
+    assert_line "force_review=1"
+    assert_output --partial "remote=upstream"
+}
+
 @test "help flag -> help_requested" {
     run devx_pr_review_all_parse --help
     assert_success
     assert_output --partial "help_requested=1"
 }
 
-@test "parse does not leak pr/remote/reply_mode/reply_delay/_no_reply/_remote_set into the caller's shell" {
+@test "parse does not leak pr/remote/reply_mode/reply_delay/_no_reply/_remote_set/_force_review into the caller's shell" {
     pr="SENTINEL_PR"
     remote="SENTINEL_REMOTE"
     reply_mode="SENTINEL_REPLY_MODE"
     reply_delay="SENTINEL_REPLY_DELAY"
     _no_reply="SENTINEL_NO_REPLY"
     _remote_set="SENTINEL_REMOTE_SET"
-    devx_pr_review_all_parse 123 upstream --defer-reply 8 >/dev/null
+    _force_review="SENTINEL_FORCE_REVIEW"
+    devx_pr_review_all_parse 123 upstream --defer-reply 8 --force-review >/dev/null
     _rc=$?
     [ "$_rc" -eq 0 ]
     [ "$pr" = "SENTINEL_PR" ]
@@ -103,6 +131,7 @@ setup() {
     [ "$reply_delay" = "SENTINEL_REPLY_DELAY" ]
     [ "$_no_reply" = "SENTINEL_NO_REPLY" ]
     [ "$_remote_set" = "SENTINEL_REMOTE_SET" ]
+    [ "$_force_review" = "SENTINEL_FORCE_REVIEW" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/bats/functions/devx_pr_review_all_dedupe.bats
+++ b/tests/bats/functions/devx_pr_review_all_dedupe.bats
@@ -129,6 +129,32 @@ Verdict: LGTM
     assert_line "RUN codex"
 }
 
+# ── accepted TOCTOU race (codex, PR #1623 BLOCKER) ──────────────────
+# The guard is a read-before-write check, not a lock: two sessions reading the
+# SAME pre-review BODIES snapshot before either one posts will both conclude
+# "not yet reviewed" and both dispatch — exactly PR #1608's original failure,
+# just with a narrower window. This test pins that as documented, accepted
+# behavior (references/duplicate-review-guard.md -> "Known limitation"), not
+# as a bug to fix here — a lock file was explicitly deprioritized in #1613.
+
+@test "already_reviewed: two sessions racing on the same pre-review snapshot both see 'not reviewed'" {
+    # Neither session has posted yet, so both read the identical empty-of-agy
+    # BODIES. A lock would serialize this; the check does not.
+    local shared_snapshot='Unrelated conversation comment.'
+
+    run bash -c '
+        . "'"${DOTFILES_ROOT}"'/shell-common/functions/devx_pr_review_all.sh"
+        SNAPSHOT="'"$shared_snapshot"'"
+        printf "%s\n" "$SNAPSHOT" | devx_pr_review_all_already_reviewed agy deadbeef
+        session_a=$?
+        printf "%s\n" "$SNAPSHOT" | devx_pr_review_all_already_reviewed agy deadbeef
+        session_b=$?
+        printf "session_a=%s session_b=%s\n" "$session_a" "$session_b"
+    '
+    assert_success
+    assert_output --partial "session_a=1 session_b=1"
+}
+
 # ── doc guards ───────────────────────────────────────────────────────
 # Same rule as the verdict suite's doc-guards: the SKILL step must CALL the
 # shared helper by its literal call shape, not paraphrase the guard into prose
@@ -143,5 +169,21 @@ Verdict: LGTM
 @test "doc-guard: the SKILL documents the --force-review bypass" {
     run grep -qF -- '--force-review' \
         "${DOTFILES_ROOT}/claude/skills/devx-pr-review-all/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard (#1623 agy BLOCKER): a guard-skipped lane must still be aggregated in Step 3.5" {
+    run grep -qF -- 'each lane that actually ran' \
+        "${DOTFILES_ROOT}/claude/skills/devx-pr-review-all/SKILL.md"
+    assert_failure
+
+    run grep -qF -- 'either ran fresh in Step 3 OR was skipped by the' \
+        "${DOTFILES_ROOT}/claude/skills/devx-pr-review-all/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard (#1623 codex BLOCKER): the TOCTOU limitation is documented" {
+    run grep -qF -- 'Known limitation: this is a check, not a lock' \
+        "${DOTFILES_ROOT}/claude/skills/devx-pr-review-all/references/duplicate-review-guard.md"
     assert_success
 }

--- a/tests/bats/functions/devx_pr_review_all_dedupe.bats
+++ b/tests/bats/functions/devx_pr_review_all_dedupe.bats
@@ -2,18 +2,13 @@
 # tests/bats/functions/devx_pr_review_all_dedupe.bats
 # Issue #1613 — the pre-dispatch duplicate-review guard.
 #
-# Background: devx:pr-review-all had no concurrency guard, so two sessions
-# reviewing the same PR at the same head sha both fanned out and agy/codex each
-# posted a duplicate review comment (reproduced on PR #1608, head 2d7bbdca,
-# reviewed twice 36 minutes apart). Step 3 now asks
-# `devx_pr_review_all_already_reviewed <ai> <head-sha>` before dispatching each
-# lane, and `--force-review` bypasses it.
-#
-# Fail-OPEN is the whole point here, the opposite of the verdict gate's
-# fail-closed rule: anything short of a complete block for that exact ai+sha
-# pair means "not yet reviewed", so the lane runs. A missed skip costs a
-# duplicate comment; a false skip would silently lose a lane's verdict.
-# SSOT: claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
+# Step 3 now asks `devx_pr_review_all_already_reviewed <ai> <head-sha>` before
+# dispatching each lane, and `--force-review` bypasses it. Fail-OPEN is the
+# whole point here, the opposite of the verdict gate's fail-closed rule:
+# anything short of a complete block for that exact ai+sha pair means "not yet
+# reviewed", so the lane runs.
+# Background + full rationale (SSOT):
+# claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
 load '../test_helper'
 
 setup() {

--- a/tests/bats/functions/devx_pr_review_all_dedupe.bats
+++ b/tests/bats/functions/devx_pr_review_all_dedupe.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# tests/bats/functions/devx_pr_review_all_dedupe.bats
+# Issue #1613 — the pre-dispatch duplicate-review guard.
+#
+# Background: devx:pr-review-all had no concurrency guard, so two sessions
+# reviewing the same PR at the same head sha both fanned out and agy/codex each
+# posted a duplicate review comment (reproduced on PR #1608, head 2d7bbdca,
+# reviewed twice 36 minutes apart). Step 3 now asks
+# `devx_pr_review_all_already_reviewed <ai> <head-sha>` before dispatching each
+# lane, and `--force-review` bypasses it.
+#
+# Fail-OPEN is the whole point here, the opposite of the verdict gate's
+# fail-closed rule: anything short of a complete block for that exact ai+sha
+# pair means "not yet reviewed", so the lane runs. A missed skip costs a
+# duplicate comment; a false skip would silently lose a lane's verdict.
+# SSOT: claude/skills/devx-pr-review-all/references/duplicate-review-guard.md
+load '../test_helper'
+
+setup() {
+    # shellcheck disable=SC1090
+    source "${DOTFILES_ROOT:?}/shell-common/functions/devx_pr_review_all.sh"
+}
+
+@test "already_reviewed: a block for this ai+sha -> already reviewed (rc 0)" {
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: LGTM
+<!-- /ai-review:agy:deadbeefdeadbeef -->
+EOF
+    assert_success
+}
+
+@test "already_reviewed: a block for a DIFFERENT sha -> not reviewed (rc 1)" {
+    # The head moved since that review; the lane must run again.
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:0000111122223333 -->
+Verdict: LGTM
+<!-- /ai-review:agy:0000111122223333 -->
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: a block for a DIFFERENT ai -> not reviewed (rc 1)" {
+    # codex having reviewed this head says nothing about agy.
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:codex:deadbeefdeadbeef -->
+Verdict: LGTM
+<!-- /ai-review:codex:deadbeefdeadbeef -->
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: no marker at all -> not reviewed (rc 1)" {
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef <<'EOF'
+Thanks, LGTM from me.
+Rebased onto main.
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: empty stdin -> not reviewed (rc 1)" {
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef </dev/null
+    assert_failure 1
+}
+
+@test "already_reviewed: an untagged block does not satisfy a sha request" {
+    # A pre-#1564 comment carries no freshness claim, so it must not be read
+    # as evidence that THIS head was reviewed.
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy -->
+Verdict: LGTM
+<!-- /ai-review:agy -->
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: an unterminated block is not evidence" {
+    # Half a review is not a review — the lane must run.
+    run devx_pr_review_all_already_reviewed agy deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: LGTM
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: the right lane is found among several" {
+    run devx_pr_review_all_already_reviewed codex deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: LGTM
+<!-- /ai-review:agy:deadbeefdeadbeef -->
+<!-- ai-review:codex:deadbeefdeadbeef -->
+판정: 블로킹
+<!-- /ai-review:codex:deadbeefdeadbeef -->
+EOF
+    assert_success
+}
+
+@test "already_reviewed: a missing sha argument never claims 'reviewed'" {
+    # Without a sha the wrapper cannot make a freshness claim, and guessing
+    # would skip every re-review forever. Fail open instead.
+    run devx_pr_review_all_already_reviewed agy <<'EOF'
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: LGTM
+<!-- /ai-review:agy:deadbeefdeadbeef -->
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: a missing ai argument never claims 'reviewed'" {
+    run devx_pr_review_all_already_reviewed "" deadbeefdeadbeef <<'EOF'
+<!-- ai-review:agy:deadbeefdeadbeef -->
+Verdict: LGTM
+<!-- /ai-review:agy:deadbeefdeadbeef -->
+EOF
+    assert_failure 1
+}
+
+@test "already_reviewed: usable as a plain if-guard in a pipeline" {
+    # The documented Step 3 call shape: BODIES piped in, rc drives the skip.
+    run bash -c '
+        . "'"${DOTFILES_ROOT}"'/shell-common/functions/devx_pr_review_all.sh"
+        BODIES="<!-- ai-review:agy:deadbeef -->
+Verdict: LGTM
+<!-- /ai-review:agy:deadbeef -->"
+        for ai in agy codex; do
+            if printf "%s\n" "$BODIES" | devx_pr_review_all_already_reviewed "$ai" deadbeef; then
+                printf "SKIP %s\n" "$ai"
+            else
+                printf "RUN %s\n" "$ai"
+            fi
+        done'
+    assert_success
+    assert_line "SKIP agy"
+    assert_line "RUN codex"
+}
+
+# ── doc guards ───────────────────────────────────────────────────────
+# Same rule as the verdict suite's doc-guards: the SKILL step must CALL the
+# shared helper by its literal call shape, not paraphrase the guard into prose
+# an LLM can quietly skip.
+
+@test "doc-guard: devx:pr-review-all Step 3 calls the shared dedupe helper" {
+    run grep -qF -- 'devx_pr_review_all_already_reviewed "$ai" "$head_sha"' \
+        "${DOTFILES_ROOT}/claude/skills/devx-pr-review-all/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: the SKILL documents the --force-review bypass" {
+    run grep -qF -- '--force-review' \
+        "${DOTFILES_ROOT}/claude/skills/devx-pr-review-all/SKILL.md"
+    assert_success
+}

--- a/tests/bats/functions/devx_pr_review_all_source_path.bats
+++ b/tests/bats/functions/devx_pr_review_all_source_path.bats
@@ -2,7 +2,7 @@
 # tests/bats/functions/devx_pr_review_all_source_path.bats
 # Issue #1612 — sourcing devx_pr_review_all.sh from a clean, non-interactive
 # shell (no dotfiles rc, no $SHELL_COMMON — the exact shape of Claude Code's
-# own Bash tool) must define all five public functions, whether the caller
+# own Bash tool) must define every public function, whether the caller
 # sources the file by a relative or an absolute path. #1612 found several
 # skill docs telling agents to source it via a bare `${SHELL_COMMON}/...`
 # with no `$HOME` fallback; when that expands empty, an agent can fall back
@@ -13,7 +13,7 @@
 
 load '../test_helper'
 
-FUNCS="devx_pr_review_all_parse devx_pr_review_all_verdict devx_pr_review_all_aggregate devx_pr_review_all_lane_block devx_pr_review_all_apply_label"
+FUNCS="devx_pr_review_all_parse devx_pr_review_all_verdict devx_pr_review_all_aggregate devx_pr_review_all_lane_block devx_pr_review_all_already_reviewed devx_pr_review_all_apply_label"
 
 setup() {
     setup_isolated_home
@@ -38,19 +38,19 @@ run_clean_source() {
     "
 }
 
-@test "relative-path source defines all five functions in a clean shell" {
+@test "relative-path source defines every public function in a clean shell" {
     run run_clean_source "shell-common/functions/devx_pr_review_all.sh"
     assert_success
     assert_output --partial "ALL_DEFINED"
 }
 
-@test "absolute-path source defines all five functions in a clean shell (positive control)" {
+@test "absolute-path source defines every public function in a clean shell (positive control)" {
     run run_clean_source "\"${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/devx_pr_review_all.sh\""
     assert_success
     assert_output --partial "ALL_DEFINED"
 }
 
-@test "\${SHELL_COMMON:-\$HOME/dotfiles/shell-common} fallback idiom defines all five functions when SHELL_COMMON is unset" {
+@test "\${SHELL_COMMON:-\$HOME/dotfiles/shell-common} fallback idiom defines every public function when SHELL_COMMON is unset" {
     run run_clean_source '"${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"'
     assert_success
     assert_output --partial "ALL_DEFINED"


### PR DESCRIPTION
## Summary
- `devx:pr-review-all` Step 3에 사전 중복-리뷰 가드를 추가 — 같은 head sha를 이미 리뷰한 lane은 다시 dispatch하지 않는다.

## Changes
- `shell-common/functions/devx_pr_review_all.sh`: `--force-review` 플래그 + `force_review=` 파서 출력, 신규 순수 함수 `devx_pr_review_all_already_reviewed <ai> <head-sha>` (`devx_pr_review_all_lane_block`의 얇은 래퍼), self-check 목록 갱신.
- `claude/skills/devx-pr-review-all/SKILL.md`: Step 3 시작부에 head_sha/BODIES 사전 fetch + per-lane skip 로직, Step 3.5는 재fetch 이유 명시.
- `claude/skills/devx-pr-review-all/references/help.md`: `--force-review` 플래그·사용 예시·Step 3 설명 갱신.
- `claude/skills/devx-pr-review-all/references/duplicate-review-guard.md` (신규): 가드의 SSOT — 알고리즘, fail-open 근거, `gh:pr-review`가 아니라 여기 사는 이유.
- 테스트: `tests/bats/functions/devx_pr_review_all.bats`(4개), 신규 `devx_pr_review_all_dedupe.bats`(13개), `devx_pr_review_all_source_path.bats`(FUNCS 목록 갱신) — 총 120 tests 통과.
- `docs/public/changelog.d/2026-08-31-1613.md` 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all{,_verdict,_source_path,_dedupe}.bats` — 120 passed, 0 failed
- [x] `mise run lint-sh` — shellcheck/shfmt clean
- [x] `mise run lint-docs` — changelog fragment format 통과

## Related
Fixes #1613

---
<details>
<summary>🤖 AI Metrics · 📊 ~46500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~46500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
