### PR TITLE
fix(herdr-dispatch): 정착 판정 창을 넓히고 안정 판정을 3회로 강화한다

### DIFF
--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -207,15 +207,23 @@ _IW_IDLE_POLL_SLEEP="${IW_IDLE_POLL_SLEEP:-0.5}"
 # a settle has a pane to read.
 _IW_SETTLE_SECONDS="${IW_SETTLE_SECONDS:-13}"
 # Gap between settle polls, and how many pane lines each poll reads. The gap is
-# overridable (to 0) for the same reason _IW_IDLE_POLL_SLEEP is. Three lines is
-# enough to see the prompt line and whatever banner sits above it — the
-# 40-line read is _iw_limit_evidence's, a different call for a different job,
-# and reading 40 lines here would only make two frames differ over a scrolling
-# tail that has nothing to do with readiness.
+# overridable (to 0) for the same reason _IW_IDLE_POLL_SLEEP is.
+#
+# 15, not 3 (PR #1611 review, live herdr 0.7.5 test): a real claude TUI's
+# bottom `--lines N` window is `[status/banner line] [divider] [input line]
+# [divider] [footer status bar]` — 3 lines captures only the footer, which
+# renders and stabilises immediately and never contains the banner or input
+# row at all. `_IW_SETTLE_NOT_READY_MARK` below could never actually match a
+# real "Not logged in" pane with a 3-line window; it was checking a footer
+# that looks the same whether the pane is broken or fine. 15 comfortably
+# covers that whole block plus a wrapped multi-line status bar. The 40-line
+# read is still _iw_limit_evidence's own, larger, different-purpose call —
+# reading that wide here would make two frames differ over scrolling
+# conversation history that has nothing to do with readiness.
 _IW_SETTLE_POLL_SLEEP="${IW_SETTLE_POLL_SLEEP:-1}"
-_IW_SETTLE_READ_LINES="3"
+_IW_SETTLE_READ_LINES="15"
 # The pane text herdr shows while claude is up but unusable (#1561). Stable
-# across reads, so the "two frames agree" test alone would take it for ready —
+# across reads, so the "frames agree" test alone would take it for ready —
 # and a bare state_change_seq comparison could not tell it apart at all.
 _IW_SETTLE_NOT_READY_MARK="Not logged in"
 
@@ -1733,28 +1741,42 @@ _iw_pane_text() {
     printf '%s' "${_text}"
 }
 
-# True when two consecutive pane reads say the agent is listening.
-#   $1 = this read, $2 = the previous one
+# True when three consecutive pane reads say the agent is listening.
+#   $1 = this read, $2 = the previous one, $3 = the one before that
 #
-# Three conditions, each earning its place. Non-empty: a pane that has drawn
+# Three-in-a-row, not two (PR #1611 review, codex, 5th pass): two identical
+# reads only proves the *render* stopped changing between one poll gap, and
+# the render settling is not evidence the key-input loop has too — that gap
+# is exactly what #1560 exists to describe, and an active probe to prove
+# input-readiness directly turned out not to be viable (state_change_seq did
+# not move for typed-but-unsubmitted keystrokes in a live herdr 0.7.5 test —
+# it tracks submission-level events, not raw terminal content, so there is no
+# cheap corroborating signal available pre-prompt). A third agreeing frame
+# does not *prove* input-readiness either, but it does raise the bar past a
+# single lucky poll gap, cutting the odds of firing into a merely-rendered,
+# not-yet-listening pane without adding an unverified new mechanism.
+#
+# Four conditions, each earning its place. Non-empty: a pane that has drawn
 # nothing yet reads empty, and so does one herdr refused to read, so "empty
-# twice" is the opposite of evidence. Identical: a TUI still painting changes
-# between reads. Not the login banner: that frame is perfectly stable and means
-# claude is up and unusable (#1561) — the case a state_change_seq comparison
-# cannot see at all, which is why the pane text is the signal here and the
-# counter stays with _iw_stall_recover_via_enter.
+# three times" is the opposite of evidence. Identical across all three: a TUI
+# still painting changes somewhere in that window. Not the login banner: that
+# frame is perfectly stable and means claude is up and unusable (#1561) — the
+# case a state_change_seq comparison cannot see at all, which is why the pane
+# text is the signal here and the counter stays with _iw_stall_recover_via_enter.
 #
-# Known gap (PR #1611 review, codex): "any stable, non-empty, non-`Not logged
-# in` text" is not proven ready — only proven not to be that one banner. A
-# different steady pre-ready or error frame could still false-positive. Not
-# fixed here: the only evidence available is what herdr 0.7.5 has actually
-# been observed to show (#1560's measurement), and this repo has no fixture
-# for a second stable-but-unready frame to design against. The cap (13s) is
-# the backstop either way — a false-positive settle is not a new failure mode,
-# just a prompt sent slightly earlier than warranted.
+# Known gap (PR #1611 review, codex, 2nd/3rd pass): "any stable, non-empty,
+# non-`Not logged in` text" is still not *proven* ready — only proven not to
+# be that one banner, and not proven to be the input loop rather than the
+# render loop. A different steady pre-ready or error frame could still
+# false-positive. Not fixed here: the only evidence available is what herdr
+# 0.7.5 has actually been observed to show (#1560's measurement, and this
+# PR's own live probing), and this repo has no fixture for a second
+# stable-but-unready frame to design against. The cap (13s) is the backstop
+# either way — a false-positive settle is not a new failure mode, just a
+# prompt sent slightly earlier than warranted.
 _iw_pane_settled() {
     [ -n "$1" ] || return 1
-    [ "$1" = "$2" ] || return 1
+    [ "$1" = "$2" ] && [ "$2" = "$3" ] || return 1
     case "$1" in
     *"${_IW_SETTLE_NOT_READY_MARK}"*) return 1 ;;
     esac
@@ -1831,7 +1853,7 @@ _iw_settle_max_polls() {
 # beyond it. At the default 1s gap that is 13s becoming at most ~14s, still
 # bounded and still no worse than the unconditional 13s this replaced.
 _iw_settle() {
-    local _agent="$1" _i=0 _prev="" _text _now _deadline="" _max_polls
+    local _agent="$1" _i=0 _prev="" _prev2="" _text _now _deadline="" _max_polls
 
     [ "${_IW_SETTLE_SECONDS}" = "0" ] && return 0
     # A fractional cap cannot bound a poll count. It predates #1570 and still
@@ -1866,7 +1888,8 @@ _iw_settle() {
             [ -z "${_now}" ] || [ "${_now}" -lt "${_deadline}" ] || break
         fi
         _text=$(_iw_pane_text "${_agent}")
-        ! _iw_pane_settled "${_text}" "${_prev}" || return 0
+        ! _iw_pane_settled "${_text}" "${_prev}" "${_prev2}" || return 0
+        _prev2="${_prev}"
         _prev="${_text}"
         _i=$((_i + 1))
         [ "${_i}" -lt "${_max_polls}" ] || break

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -136,11 +136,13 @@ _PMT_IDLE_POLL_SLEEP="${PMT_IDLE_POLL_SLEEP:-0.5}"
 _PMT_SETTLE_SECONDS="${PMT_SETTLE_SECONDS:-13}"
 # Gap between settle polls, and how many pane lines each poll reads — the twins
 # of _IW_SETTLE_POLL_SLEEP / _IW_SETTLE_READ_LINES, overridable (to 0) for the
-# same reason _PMT_IDLE_POLL_SLEEP is.
+# same reason _PMT_IDLE_POLL_SLEEP is. 15, not 3 — see _IW_SETTLE_READ_LINES
+# for the live herdr 0.7.5 test that found a 3-line window never reaches the
+# banner/input row at all (PR #1611 review).
 _PMT_SETTLE_POLL_SLEEP="${PMT_SETTLE_POLL_SLEEP:-1}"
-_PMT_SETTLE_READ_LINES="3"
+_PMT_SETTLE_READ_LINES="15"
 # The pane text herdr shows while claude is up but unusable (#1561). Stable
-# across reads, so the "two frames agree" test alone would take it for ready.
+# across reads, so the "frames agree" test alone would take it for ready.
 _PMT_SETTLE_NOT_READY_MARK="Not logged in"
 _PMT_PROMPT_ATTEMPT_MAX="3"
 
@@ -694,14 +696,15 @@ _pmt_pane_text() {
     printf '%s' "${_text}"
 }
 
-# True when two consecutive pane reads say the agent is listening.
-#   $1 = this read, $2 = the previous one
+# True when three consecutive pane reads say the agent is listening.
+#   $1 = this read, $2 = the previous one, $3 = the one before that
 #
 # The twin of _iw_pane_settled, whose comment carries the reasoning for all
-# three conditions — non-empty, identical, and not the login banner.
+# four conditions — non-empty, identical across all three, not the login
+# banner, and why three-in-a-row (not two) since PR #1611's 5th review pass.
 _pmt_pane_settled() {
     [ -n "$1" ] || return 1
-    [ "$1" = "$2" ] || return 1
+    [ "$1" = "$2" ] && [ "$2" = "$3" ] || return 1
     case "$1" in
     *"${_PMT_SETTLE_NOT_READY_MARK}"*) return 1 ;;
     esac
@@ -734,7 +737,7 @@ _pmt_settle_max_polls() {
 # ready signal warns and proceeds, exactly the pre-#1570 behaviour. The poll
 # can only make the wait shorter, never introduce a new failure mode.
 _pmt_settle() {
-    local _agent="$1" _i=0 _prev="" _text _now _deadline="" _max_polls
+    local _agent="$1" _i=0 _prev="" _prev2="" _text _now _deadline="" _max_polls
 
     [ "${_PMT_SETTLE_SECONDS}" = "0" ] && return 0
     # A fractional cap cannot bound a poll count; it still means the flat wait
@@ -762,7 +765,8 @@ _pmt_settle() {
             [ -z "${_now}" ] || [ "${_now}" -lt "${_deadline}" ] || break
         fi
         _text=$(_pmt_pane_text "${_agent}")
-        ! _pmt_pane_settled "${_text}" "${_prev}" || return 0
+        ! _pmt_pane_settled "${_text}" "${_prev}" "${_prev2}" || return 0
+        _prev2="${_prev}"
         _prev="${_text}"
         _i=$((_i + 1))
         [ "${_i}" -lt "${_max_polls}" ] || break

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1483,22 +1483,26 @@ _assert_not_hung() {
     _run_tick
     assert_success
     _assert_logged "agent prompt iw-dotfiles-issue-11"
-    # Two agreeing reads end the poll, so one gap is spent, not thirteen.
-    [ "$(_log_count '^sleep 1$')" -eq 1 ]
+    # Three agreeing reads end the poll (PR #1611 review, 5th pass — two was
+    # not enough evidence the input loop, not just the render, had settled),
+    # so two gaps are spent, not thirteen.
+    [ "$(_log_count '^sleep 1$')" -eq 2 ]
     refute_output --partial "never settled"
 }
 
 @test "issue_watcher_cron: the settle poll reads the pane, not the sequence counter" {
     _run_tick
     assert_success
-    _assert_logged "agent read iw-dotfiles-issue-11 --lines 3 --format text"
+    # 15 lines, not 3 (PR #1611 review, 5th pass) — a real pane's banner and
+    # input row sit above what a 3-line tail window ever reaches.
+    _assert_logged "agent read iw-dotfiles-issue-11 --lines 15 --format text"
 }
 
 @test "issue_watcher_cron: the settle poll happens after the idle check, not before" {
     _run_tick
     assert_success
     _idle_line=$(grep -n "agent get iw-dotfiles-issue-11" "${_LOG}" | head -1 | cut -d: -f1)
-    _settle_line=$(grep -n "agent read iw-dotfiles-issue-11 --lines 3" "${_LOG}" | head -1 | cut -d: -f1)
+    _settle_line=$(grep -n "agent read iw-dotfiles-issue-11 --lines 15" "${_LOG}" | head -1 | cut -d: -f1)
     _prompt_line=$(grep -n "agent prompt iw-dotfiles-issue-11" "${_LOG}" | head -1 | cut -d: -f1)
     [ "${_idle_line}" -lt "${_settle_line}" ]
     [ "${_settle_line}" -lt "${_prompt_line}" ]
@@ -1531,8 +1535,9 @@ _assert_not_hung() {
     _run_tick "HERDR_SETTLE_READ_SEQUENCE=~|~|> claude ready"
     assert_success
     _assert_logged "agent prompt iw-dotfiles-issue-11"
-    # Reads 1-2 are empty, 3 and 4 agree — three gaps, still well inside 13.
-    [ "$(_log_count '^sleep 1$')" -eq 3 ]
+    # Reads 1-2 are empty, 3-5 agree (three-in-a-row, PR #1611 review 5th
+    # pass) — four gaps, still well inside 13.
+    [ "$(_log_count '^sleep 1$')" -eq 4 ]
     refute_output --partial "never settled"
 }
 
@@ -1549,7 +1554,7 @@ _assert_not_hung() {
     assert_success
     _assert_logged "agent prompt iw-dotfiles-issue-11"
     _refute_logged "sleep "
-    _refute_logged "agent read iw-dotfiles-issue-11 --lines 3"
+    _refute_logged "agent read iw-dotfiles-issue-11 --lines 15"
 }
 
 @test "issue_watcher_cron: IW_SETTLE_SECONDS caps the poll, not one flat sleep" {
@@ -1567,7 +1572,7 @@ _assert_not_hung() {
     assert_success
     _assert_logged "sleep 0.5"
     _assert_logged "agent prompt iw-dotfiles-issue-11"
-    _refute_logged "agent read iw-dotfiles-issue-11 --lines 3"
+    _refute_logged "agent read iw-dotfiles-issue-11 --lines 15"
 }
 
 @test "issue_watcher_cron: the settle poll interval is overridable" {

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -626,21 +626,25 @@ _hold_lock() {
     _run_tick
     assert_success
     _assert_logged "herdr agent prompt"
-    [ "$(_log_count '^sleep 1$')" -eq 1 ]
+    # Three agreeing reads, not two — see issue_watcher_cron.bats's twin test
+    # (PR #1611 review, 5th pass).
+    [ "$(_log_count '^sleep 1$')" -eq 2 ]
     refute_output --partial "never settled"
 }
 
 @test "pr_merge_train_cron: the settle poll reads the pane" {
     _run_tick
     assert_success
-    _assert_logged "herdr agent read mt-dotfiles --lines 3 --format text"
+    # 15 lines, not 3 — see issue_watcher_cron.bats's twin test (PR #1611
+    # review, 5th pass).
+    _assert_logged "herdr agent read mt-dotfiles --lines 15 --format text"
 }
 
 @test "pr_merge_train_cron: the settle poll happens after the idle check, not before" {
     _run_tick
     assert_success
     _start_line=$(grep -n "herdr agent start" "${_LOG}" | head -1 | cut -d: -f1)
-    _settle_line=$(grep -n "herdr agent read mt-dotfiles --lines 3" "${_LOG}" | head -1 | cut -d: -f1)
+    _settle_line=$(grep -n "herdr agent read mt-dotfiles --lines 15" "${_LOG}" | head -1 | cut -d: -f1)
     _prompt_line=$(grep -n "herdr agent prompt" "${_LOG}" | head -1 | cut -d: -f1)
     [ "${_start_line}" -lt "${_settle_line}" ]
     [ "${_settle_line}" -lt "${_prompt_line}" ]


### PR DESCRIPTION
## Summary
- #1570의 PR #1611이, 5차 리뷰(codex BLOCKING)가 코드를 고치는 사이 stale `review-passed` 라벨로 인해 merge-train에 의해 4차 통과 상태(codex 5차 리뷰 이전)로 먼저 머지됐습니다 — 5차 리뷰가 실제로 지적한 두 가지는 아직 main에 반영되지 않은 상태입니다.
- 이 PR은 그 두 가지를 마무리합니다: (1) `herdr agent read --lines 3`은 실제 pane 레이아웃에서 하단 상태바만 보고 로그인 배너/입력줄은 절대 보지 못한다는 걸 라이브 herdr 0.7.5 실험으로 확인 — 15줄로 넓혔습니다. (2) state_change_seq를 이용한 능동 probe는 실제로 타이핑한 키 입력에도 카운터가 움직이지 않아 아키텍처적으로 성립하지 않음을 같은 실험으로 확인 — 대신 연속 안정 판정 횟수를 2회에서 3회로 올려 렌더-정착과 입력-준비 사이의 오탐 가능성을 줄였습니다.

## Changes
- `shell-common/tools/custom/issue_watcher_cron.sh` / `pr_merge_train_cron.sh`: `_IW_SETTLE_READ_LINES` / `_PMT_SETTLE_READ_LINES`를 3→15로, `_iw_pane_settled` / `_pmt_pane_settled`를 2-in-a-row→3-in-a-row로 변경.
- `tests/bats/tools/*.bats`: 7개 기존 테스트를 새 폴링 횟수/줄 수 기대값에 맞게 갱신.

## Process note
- 5차 리뷰의 BLOCKING 판정 이후, 코드를 직접 고치는 데 집중하면서 `devx_pr_review_all_apply_label`을 다시 돌려 라벨을 `review-blocked`로 갱신하지 않았습니다 — 그 사이 merge-train이 남아있던(4차 리뷰 시점의) `review-passed` 라벨을 보고 병합을 진행했습니다. 이번 PR부터는 각 리뷰 라운드 직후 반드시 라벨 재적용을 실행합니다.

## Test plan
- [x] `tests/bats/tools/issue_watcher_cron.bats` + `tests/bats/tools/pr_merge_train_cron.bats` — 333 passed, 0 failed.
- [x] `shellcheck -x -e SC1090,SC1091` — 두 스크립트 모두 clean.
- [x] 라이브 herdr 0.7.5 실험(임시 workspace, 작업 후 정리 완료)으로 두 근본 원인을 직접 재현·확인.

## Related
Closes #1570
