### PR TITLE
feat(gh-pr-reply): review-blocked 해제용 저비용 타겟 재검토 lane 추가

### DIFF
--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -19,13 +19,16 @@ real gate was CI.
 | consumer (hard merge gate) | `gh:pr-merge-train` **Step 3.5**, `references/review-verdict-gate.md` | #1564 |
 | provisioning (the labels exist in the repo) | `gh:label-bootstrap` pipeline feed | #1564 |
 | freshness (sha marker for `review-passed`) | `devx_pr_review_all_apply_label`'s 4th arg; read by `_gh_pr_merge_train_review_passed_stale` | #1601 |
+| second producer (one reviewer, scoped re-review) | `gh:pr-reply` Step 6's targeted lane, `claude/skills/gh-pr-reply/references/targeted-rereview.md` — same `devx_pr_review_all_apply_label` write path, gated per reviewer/severity | #1616 |
 
 #1563's label-lifecycle invalidation rules are the piece that makes the rest
 safe: every skill that advances a PR's head (`gh:pr-reply`,
 `gh:pr-resolve-conflict`, `gh:pr-resolve-outdated`) drops the stale verdict
 through the shared `_gh_pr_drop_label` helper, whose header comment in
 `shell-common/functions/gh_pr_edit_safe.sh` is the SSOT for the asymmetry rule
-(`review-passed` always, `review-blocked` only on evidence).
+(`review-passed` always; `review-blocked` never by drop — since #1616 it is
+cleared only as the side effect of a new non-blocking verdict written through
+`devx_pr_review_all_apply_label`).
 
 ## The labels
 

--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -59,6 +59,11 @@ and classify as **ACCEPT** / **ACCEPT-PARTIAL** / **DECLINE** / **QUESTION**.
 Bot comments (gemini-code-assist, sourcery-ai, copilot) follow the same
 rules; see `references/reply-templates.md` for the full rubric.
 
+Record each item's origin as `<reviewer>:<severity>:<verdict>` into `ORIGINS`
+via `_gh_pr_reply_origin_line` (`references/targeted-rereview.md` § Step 3) —
+Steps 6 and 7 both read that stream, because a flat accepted/declined count
+cannot tell an unresolved BLOCKER from a declined suggestion (#1616).
+
 ## Step 4: Apply Fixes (ACCEPT / ACCEPT-PARTIAL only)
 
 Keep each fix minimal and scoped — no drive-by refactors. Group related
@@ -83,10 +88,13 @@ no-op when `PUSHED_FIXES == 0`).
 
 Still under `PUSHED_FIXES > 0`, invalidate the stale review verdict per
 `references/verdict-label-removal.sh.md` (soft-fail): drop `review-passed`
-unconditionally — the reviewed commit is no longer head — and drop
-`review-blocked` only when `ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0`
-(the Step 3 counts Step 7's table reports). Never *add* either label;
-`devx:pr-review-all` owns that.
+unconditionally — the reviewed commit is no longer head. `review-blocked` is
+decided by the targeted re-review lane in `references/targeted-rereview.md`
+instead (#1616): when every blocking-severity item of an originally-blocking
+reviewer is ACCEPT/ACCEPT-PARTIAL, re-invoke `Skill(gh:pr-review, "--ai <r>
+--paths <fixed files> <PR> <remote>")` and let its verdict flow through
+`devx_pr_review_all_apply_label`. Never *add* either label by hand, and never
+assume a pass the re-verification did not actually return (NF-2).
 
 Then **unconditionally** run the same removal block Step 2.5 does —
 `references/reply-pending-label-removal.sh.md`. Between the two call sites the
@@ -97,7 +105,8 @@ PR carrying it, so a label left on wedges the PR out of the train (#1524).
 ## Step 7: Report
 
 Print the summary table per `references/final-summary.md` (Accepted / Declined /
-Answered counts, commit SHAs, skipped comments, and the lingering
+Answered counts, the per-reviewer/severity breakdown, the targeted re-review
+outcome line, commit SHAs, skipped comments, and the lingering
 `CHANGES_REQUESTED` nudge). Then post the ai-metrics PR comment per
 `references/ai-metrics-comment.sh.md` (soft-fail; skip when `GH_DISABLE_AI_METRICS=1`).
 

--- a/claude/skills/gh-pr-reply/references/constraints.md
+++ b/claude/skills/gh-pr-reply/references/constraints.md
@@ -20,5 +20,10 @@
   The Step 6 `review-passed` / `review-blocked` invalidation goes through
   `_gh_pr_drop_label`, the one shared REST-DELETE primitive every
   head-advancing skill uses (#1563) — never an inlined DELETE.
-- Never **add** `review-passed` or `review-blocked`. Only `devx:pr-review-all`
-  issues those; this skill only removes them (#1563).
+- Never **add** `review-passed` or `review-blocked` by hand. Since #1616 the
+  Step 6 targeted lane may reach `review-passed`, but only through
+  `devx_pr_review_all_apply_label` and only on a verdict an **independent**
+  `gh:pr-review` re-call actually returned. **NF-2 — never self-certify**:
+  there is no branch that skips the re-verification and assumes a pass, and
+  an unreadable verdict leaves the PR unlabelled rather than passed
+  (#1563 / #1616).

--- a/claude/skills/gh-pr-reply/references/final-summary.md
+++ b/claude/skills/gh-pr-reply/references/final-summary.md
@@ -7,6 +7,10 @@ PR #123 review comments processed: 5 total
   Accepted: 3 (commits abc1234, def5678)
   Declined: 1
   Answered: 1
+  By reviewer:
+    codex  blocking 2/2 accepted · non-blocking 0 (0 declined)
+    agy    blocking 0/0 accepted · non-blocking 3 (3 declined)
+  [OK] 타겟 재검토 통과 — review-blocked 해제, review-passed 적용
   -> All comments replied to.
 ```
 
@@ -18,11 +22,23 @@ PR #123 review comments processed: 5 total
 - **Declined** — count of comments classified DECLINE; held in
   `DECLINED_COUNT`.
 - **Answered** — count of comments classified QUESTION.
+- **By reviewer** — one row per reviewer, rendered from
+  `printf '%s\n' "$ORIGINS" | _gh_pr_reply_origin_tally`
+  (`shell-common/functions/gh_pr_reply_targeted_review.sh`). This is the row
+  that makes "codex's 2 BLOCKERs are fixed, agy's 3 suggestions were
+  declined" readable at a glance — the flat pair above cannot express it,
+  which is exactly how PR #1609 got a stuck `review-blocked` (#1616).
+- **타겟 재검토 line** — the Step 6 lane's outcome, printed verbatim by
+  `_gh_pr_reply_targeted_lane_report`. One of the five rows tabled in
+  `references/targeted-rereview.md` § "Step 7 문구". Always present when
+  `PUSHED_FIXES > 0`; omitted otherwise (no push, no invalidation).
 - **Closing line** — `-> All comments replied to.` confirms the
   politeness contract was met.
-- Step 6 reads `ACCEPTED_COUNT` / `DECLINED_COUNT` too, to decide whether
-  `review-blocked` may be dropped (`references/verdict-label-removal.sh.md`).
-  Both steps use the same counters — never re-derive them.
+- Step 6 reads the same `ORIGINS` stream this table renders, to decide
+  whether the targeted re-review lane may run
+  (`references/verdict-label-removal.sh.md` →
+  `references/targeted-rereview.md`). Both steps use one stream — never
+  re-derive it.
 - **No board-promotion row** — `Approved` is owned by `gh:pr-approve`
   (#1350). This skill's only board write is the Step 6 `In review`
   recovery, which the table does not report.

--- a/claude/skills/gh-pr-reply/references/targeted-rereview.md
+++ b/claude/skills/gh-pr-reply/references/targeted-rereview.md
@@ -1,0 +1,136 @@
+# 타겟 재검토 lane — `review-blocked` 저비용 해제 (Step 6, 이슈 #1616)
+
+`gh:pr-reply` 는 BLOCKER 를 실제로 고친다. 그런데 #1616 이전의 해제 규칙은
+`ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0` 이라는 **전역 카운터 한 쌍**이었다.
+같은 pass 안에서 *다른* 리뷰어의 비블로킹 제안을 정당하게 DECLINE 하기만 해도
+`review-blocked` 가 그대로 눌러앉았다.
+
+실제 사례 PR #1609 — codex 가 BLOCKER 2건(둘 다 수정), agy 가 별도로 비블로킹
+FOLLOW-UP 3건(전부 타당하게 거절). 제기된 블로커는 전부 처리됐는데도 라벨이
+남았고, 라벨 하나 떼려고 5-lane `devx:pr-review-all` 전체 재실행이 필요했다.
+
+이 문서가 그 전역 게이트를 대체하는 절차의 SSOT 다. 구현체는
+`shell-common/functions/gh_pr_reply_targeted_review.sh`.
+
+## 원칙 두 개
+
+- **리뷰어별 · 심각도별로 묻는다.** "이 pass 에 DECLINE 이 있었나"가 아니라
+  "원래 블로킹했던 그 리뷰어의 **블로킹 심각도 항목**이 전부 ACCEPT 됐나"를
+  묻는다. 다른 리뷰어의 FOLLOW-UP 거절은 이 질문과 무관하다.
+- **NF-2 — 자가 인증 금지.** 위 질문에 yes 여도 이 스킬은 `review-passed` 를
+  스스로 붙이지 않는다. 붙일 자격은 **독립적인 재검토 호출이 실제로 비블로킹
+  판정을 돌려줬을 때**에만 생긴다. 재검토를 건너뛰고 통과로 간주하는 경로는
+  존재하지 않는다.
+
+## Step 3 — origin 토큰 기록 (F-1)
+
+Step 3 에서 코멘트 하나를 분류할 때마다 출처를 함께 남긴다:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_reply_targeted_review.sh"
+
+ORIGINS=$(
+    _gh_pr_reply_origin_line codex '[BLOCKER]'   ACCEPT
+    _gh_pr_reply_origin_line codex '[BLOCKER]'   ACCEPT
+    _gh_pr_reply_origin_line agy   '[FOLLOW-UP]' DECLINE
+)
+```
+
+- `<reviewer>` — 코멘트 작성자에 대응하는 `gh:pr-review` 의 `--ai` 값
+  (`agy` / `codex` / `claude` / `opencode` / `hermes`). 그 외는 exit 2.
+- `<severity>` — 리뷰어가 본문에 단 태그(`[BLOCKER]` / `[FOLLOW-UP]` /
+  `[Suggestion]` …). 대괄호는 렌더링이라 헬퍼가 벗겨낸다.
+- `<verdict>` — `ACCEPT` / `ACCEPT-PARTIAL` / `DECLINE` / `QUESTION`.
+
+Step 7 의 리뷰어별 표는 이 스트림을 `_gh_pr_reply_origin_tally` 로 집계한다.
+
+## Step 6 — 게이트와 lane (F-2 … F-7)
+
+`BLOCKING_REVIEWERS` 는 `review-blocked` 를 유발한 라운드에서 **BLOCKING 판정을
+낸 리뷰어 집합**이다. PR 코멘트의 `<!-- ai-review:<ai>:<sha> -->` 블록을
+`devx_pr_review_all_lane_block` + `devx_pr_review_all_verdict` 로 읽어 구한다 —
+이번 pass 의 항목에서 유추하지 않는다.
+
+```bash
+DECISION=$(printf '%s\n' "$ORIGINS" | \
+    _gh_pr_reply_targeted_lane_decide $BLOCKING_REVIEWERS)
+```
+
+`DECISION` 은 정확히 한 토큰이다:
+
+| 토큰 | 의미 | 후속 |
+|---|---|---|
+| `lane=<r1>[ <r2>]` | 모든 블로킹 리뷰어가 전부 해소됐고 CLI 도 실행 가능 | 아래 F-3 재호출 |
+| `skip=unresolved-blocker:<r>` | F-6 — 블로킹 항목이 미해결/거절 | `review-blocked` 유지, **API 호출 0** |
+| `skip=cli-unavailable:<r>` | F-7 — CLI 부재 또는 non-internal 환경 | 전체 재실행 안내 |
+| `skip=no-blocking-reviewer` | 원래 블로킹한 리뷰어가 없음 | 할 일 없음 |
+
+블로킹 리뷰어가 여럿일 때 **하나라도** 미해결이면 lane 은 아예 돌지 않는다:
+해소된 리뷰어를 재검토해봐야 다른 리뷰어가 붙잡고 있는 라벨은 못 뗀다.
+이번 pass 에 그 리뷰어의 블로킹 항목이 **하나도 없는** 경우도 미해결로 친다 —
+"증거 없음"이 "해결됨"으로 읽히면 안 된다(NF-2 방향).
+
+### F-3 — 재호출은 수정 파일로만 스코프
+
+```bash
+FIXED_PATHS=$(git diff --name-only "$BASE_SHA..HEAD" | tr '\n' ' ')
+# 각 lane 리뷰어에 대해 (push 완료 후에):
+Skill(gh:pr-review, "--ai <r> --paths $FIXED_PATHS $PR_NUMBER $REMOTE")
+```
+
+- `--paths` 는 이슈 #1616 이 `gh:pr-review` 에 추가한 최소 옵션이다. `gh pr diff`
+  결과를 파일 단위로 걸러 주므로 PR 전체가 아무리 커도 **small-diff inline
+  경로**에 머문다.
+- `gh:pr-review` 의 **large-diff delegation 경로(≥800줄)는 절대 타지 않는다.**
+  그 경로에는 `<!-- ai-review:<ai>:<head-sha> -->` 를 찍지 않는 별도의 알려진
+  버그가 있고(#1616 범위 밖), 마커가 없으면 판정 파서가 `unknown` 으로 읽어
+  fail-closed 된다.
+- **push 이후에** 호출한다. 그래야 마커의 head-sha 가 새 head 다(NF-1) —
+  `devx_pr_review_all_verdict` / `_aggregate` 파서는 수정 없이 그대로 동작한다.
+- `--paths` 가 아무 파일과도 매칭되지 않으면 `gh:pr-review` 는 exit 1 로 끊는다.
+  빈 diff 를 리뷰시키면 LGTM 이 나오고, 그 LGTM 이 라벨을 떼기 때문이다.
+
+### F-4 / F-5 — 판정을 라벨로
+
+재호출이 남긴 코멘트에서 판정 토큰을 뽑아, `devx:pr-review-all` 과 **같은
+쓰기 경로**로 넘긴다. 이 스킬은 라벨을 직접 add 하지 않는다:
+
+```bash
+printf '%s\n' "$VERDICTS" | \
+    devx_pr_review_all_apply_label "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" "$HEAD_SHA"
+```
+
+- 판정 토큰은 **stdin** 으로 넘긴다 — positional 재확장은 zsh 워드 분할 버그로
+  첫 lane 만 남기고 잘린다(#1527). 그 함수 헤더가 SSOT.
+- 비블로킹(LGTM/CONCERNS) → `review-passed` 적용. 반대 라벨인
+  `review-blocked` 는 그 함수가 **먼저 무조건 삭제**하므로 F-4 의 "해제"가
+  여기서 함께 일어난다.
+- 블로킹 → `review-blocked` 유지(재적용). Step 7 에 F-5 문구를 남긴다.
+- 판정을 못 읽으면 label 이 비어 PR 은 **무라벨**로 남는다 — 통과로 승격되는
+  경로가 없다는 뜻이다(NF-2).
+- `HEAD_SHA` 4번째 인자는 `review-passed` 에 신선도 마커를 함께 남긴다(#1601).
+
+### Step 7 문구
+
+```bash
+_gh_pr_reply_targeted_lane_report "$TOKEN"
+```
+
+`$TOKEN` 은 `verdict=<blocking|concerns|lgtm|unknown>` 또는 위 `skip=` 토큰
+그대로다. 이 함수는 **출력만** 한다 — 라벨을 쓰지 않으므로 리포트 한 줄이
+자가 인증으로 승격될 여지가 없다.
+
+| 상황 | 문구 |
+|---|---|
+| 재검토 비블로킹 | `[OK] 타겟 재검토 통과 — review-blocked 해제, review-passed 적용` |
+| 재검토 블로킹 (F-5) | `[BLOCKED] 타겟 재검토도 여전히 BLOCKING — 재수정 필요` |
+| 판정 불명 | `[WARN] … 전체 devx:pr-review-all 재실행 필요` |
+| 블로커 미해결 (F-6) | `[BLOCKED] <r> 의 블로커가 미해결 — review-blocked 유지, 타겟 재검토 미실행` |
+| CLI 불가 (F-7) | `[WARN] <r> 리뷰어 CLI 를 이 환경에서 실행할 수 없음 — 전체 devx:pr-review-all 재실행 필요` |
+
+## 회귀 테스트
+
+- `tests/bats/functions/gh_pr_reply_targeted_review.bats` — 게이트 단위
+- `tests/bats/functions/gh_pr_review_paths_scope.bats` — `--paths` 스코프
+- `tests/bats/skills/gh_pr_reply_targeted_rereview.bats` — 이 문서의 미러
+  (`_fixtures/gh_pr_reply_targeted_rereview.sh`)

--- a/claude/skills/gh-pr-reply/references/targeted-rereview.md
+++ b/claude/skills/gh-pr-reply/references/targeted-rereview.md
@@ -72,6 +72,15 @@ DECISION=$(printf '%s\n' "$ORIGINS" | \
 
 ### F-3 — 재호출은 수정 파일로만 스코프
 
+`BASE_SHA` 는 **이번 `gh:pr-reply` pass 가 시작될 때의 PR head**(Step 1 이
+읽은 `headRefOid`)다 — PR 의 base 브랜치(`main` 등)와의 merge-base가
+**아니다**(PR #1629 review, codex Assumption). merge-base를 쓰면
+`FIXED_PATHS` 가 이번 pass 이전에 이미 존재하던 PR 전체 변경분까지 포함해,
+"수정 파일만" 이라는 F-3 의 전제와 "저비용" 이라는 이슈 목표가 함께
+무너진다. `git push` 가 있었다면(`PUSHED_FIXES > 0`) `HEAD` 는 이미 그 커밋
+이후이므로, `BASE_SHA..HEAD` 는 정확히 "이번 pass 가 만든 fix 커밋(들)" 로
+좁혀진다.
+
 ```bash
 FIXED_PATHS=$(git diff --name-only "$BASE_SHA..HEAD")
 # 파일마다 `--paths <path>` 를 반복한다 — 공백으로 이어붙인 문자열 하나를

--- a/claude/skills/gh-pr-reply/references/targeted-rereview.md
+++ b/claude/skills/gh-pr-reply/references/targeted-rereview.md
@@ -73,10 +73,30 @@ DECISION=$(printf '%s\n' "$ORIGINS" | \
 ### F-3 — 재호출은 수정 파일로만 스코프
 
 ```bash
-FIXED_PATHS=$(git diff --name-only "$BASE_SHA..HEAD" | tr '\n' ' ')
+FIXED_PATHS=$(git diff --name-only "$BASE_SHA..HEAD")
+# 파일마다 `--paths <path>` 를 반복한다 — 공백으로 이어붙인 문자열 하나를
+# `--paths` 뒤에 통째로 넘기면(예: `--paths a.sh b.sh`) gh_pr_review_parse 가
+# 첫 파일만 소비하고 다음 토큰을 PR 번호로 오인한다(PR #1629 review, codex
+# BLOCKER). `--paths` 는 반복 호출마다 누적되도록 이미 구현돼 있으므로
+# (gh_pr_review_paths_scope.bats "parse: --paths repeats and accumulates in
+# order"), 파일 개수만큼 플래그를 반복하는 쪽이 유일하게 안전한 호출 형태다.
+PATHS_ARGS=""
+while IFS= read -r _p; do
+    [ -n "$_p" ] && PATHS_ARGS="$PATHS_ARGS --paths $_p"
+done <<EOF
+$FIXED_PATHS
+EOF
 # 각 lane 리뷰어에 대해 (push 완료 후에):
-Skill(gh:pr-review, "--ai <r> --paths $FIXED_PATHS $PR_NUMBER $REMOTE")
+Skill(gh:pr-review, "--ai <r>$PATHS_ARGS $PR_NUMBER $REMOTE")
 ```
+
+파일명에 공백이 들어 있으면 이 반복 호출도, `--paths` 값 자체의 내부 저장
+방식(공백-이어붙이기 문자열, `gh_pr_review.sh` 의 `paths=` 계약)도 이를
+구분하지 못한다 — 알려진 한계다(PR #1629 review, agy FOLLOW-UP + codex
+BLOCKER). 이 저장소의 네이밍 컨벤션(`snake_case`, 공백 금지, 최상위
+`CLAUDE.md`)상 실제 파일명에 공백이 나타날 일이 없어 낮은 리스크로 판단해
+현재는 손대지 않는다 — 컨벤션을 벗어난 파일이 실제로 나타나면 별도 이슈로
+`paths` 의 내부 표현을 배열/개행-구분으로 바꾸는 작업이 필요하다.
 
 - `--paths` 는 이슈 #1616 이 `gh:pr-review` 에 추가한 최소 옵션이다. `gh pr diff`
   결과를 파일 단위로 걸러 주므로 PR 전체가 아무리 커도 **small-diff inline

--- a/claude/skills/gh-pr-reply/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-reply/references/verdict-label-removal.sh.md
@@ -6,29 +6,29 @@
 규칙의 SSOT 는 `shell-common/functions/gh_pr_edit_safe.sh` 헤더의
 "Verdict-label invalidation — SSOT for issue #1563" 절이다. 여기서는 되풀이하지
 않는다. 요약만: 두 라벨은 **특정 head 커밋 하나**에 대한 주장이므로 head 를
-전진시킨 스킬이 스스로 무효화해야 하고, 붙이는 쪽은 `devx:pr-review-all`
-하나뿐이다 — 이 스킬은 **제거만** 한다.
+전진시킨 스킬이 스스로 무효화해야 한다.
 
 Caller contract: `PR_NUMBER`, `TARGET_REPO`, `TARGET_HOST` 는 Step 1 이
 `references/target-resolution.md` 대로 이미 export 한 상태여야 한다 (#1403).
-`ACCEPTED_COUNT` / `DECLINED_COUNT` 는 Step 3 분류 결과의 집계로, Step 7 의
-최종 요약 표(`references/final-summary.md`)가 쓰는 것과 **같은 카운터**다:
+`ORIGINS` 는 Step 3 이 `references/targeted-rereview.md` 대로 기록한
+`<reviewer>:<severity>:<verdict>` 스트림이다.
 
-| 변수 | 정의 |
-|---|---|
-| `ACCEPTED_COUNT` | Step 3 에서 ACCEPT + ACCEPT-PARTIAL 로 분류된 코멘트 수 |
-| `DECLINED_COUNT` | Step 3 에서 DECLINE 으로 분류된 코멘트 수 |
-
-## 비대칭: `review-passed` 는 무조건, `review-blocked` 는 조건부
+## 비대칭: `review-passed` 는 무조건, `review-blocked` 는 재검토가 결정
 
 - **`review-passed`** — push 가 있었다는 사실만으로 무조건 제거한다. 리뷰된
   커밋이 더 이상 head 가 아니므로 "이 head 는 리뷰됨"이 거짓이 된다.
-- **`review-blocked`** — `ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0` 일 때만
-  제거한다. 즉 최소 한 건을 실제로 반영했고 거절한 건이 하나도 없을 때 —
-  제기된 블로커가 전부 처리됐다는 증거가 이 스킬 안에 있는 유일한 경우다.
-  하나라도 DECLINE 이 있으면 블로커가 남았을 수 있으므로 라벨을 **남긴다**.
-  남기는 쪽이 안전한 방향이다: 라벨 부재는 "차단 해제"가 아니라 "미검증"이라
-  머지 게이트가 어차피 다시 리뷰를 요구한다.
+- **`review-blocked`** — 이 스킬이 직접 떼지 않는다. 이슈 #1616 이후, 뗄지
+  말지는 `references/targeted-rereview.md` 의 타겟 재검토 lane 이 결정하고,
+  실제 쓰기는 `devx_pr_review_all_apply_label` 이 한다(비블로킹 판정이 오면
+  그 함수가 반대 라벨인 `review-blocked` 를 먼저 지운다).
+
+  #1616 이전에는 여기서 전역 카운터(`ACCEPTED_COUNT` / `DECLINED_COUNT`)로
+  판단했다. 그 규칙은 *다른* 리뷰어의 비블로킹 제안을 정당하게 거절한 것만으로
+  라벨을 붙잡아 뒀다 — PR #1609 가 그 사례다. 리뷰어별·심각도별 게이트가
+  그 자리를 대신한다.
+
+  남기는 쪽이 여전히 안전한 방향이다: 라벨 부재는 "차단 해제"가 아니라
+  "미검증"이라 머지 게이트가 어차피 다시 리뷰를 요구한다.
 
 ## 명령
 
@@ -39,6 +39,7 @@ stderr 로 넘어온다.
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_edit_safe.sh"
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_reply_targeted_review.sh"
 
 if [ "$PUSHED_FIXES" -gt 0 ]; then
     if _vl_err=$(_gh_pr_drop_label "$PR_NUMBER" review-passed \
@@ -48,19 +49,21 @@ if [ "$PUSHED_FIXES" -gt 0 ]; then
         echo "[WARN] \`review-passed\` 제거 실패 — 리뷰되지 않은 커밋에 판정이 남아 있다: ${_vl_err}"
     fi
 
-    if [ "$ACCEPTED_COUNT" -gt 0 ] && [ "$DECLINED_COUNT" -eq 0 ]; then
-        if _vl_err=$(_gh_pr_drop_label "$PR_NUMBER" review-blocked \
-                "$TARGET_REPO" "$TARGET_HOST" 2>&1); then
-            echo "[OK] \`review-blocked\` 제거됨 — 제기된 블로커를 전부 반영함"
-        else
-            echo "[WARN] \`review-blocked\` 제거 실패: ${_vl_err}"
-        fi
-    fi
+    # `review-blocked` 는 여기서 떼지 않는다 — targeted-rereview.md 로 넘긴다.
+    DECISION=$(printf '%s\n' "$ORIGINS" |
+        _gh_pr_reply_targeted_lane_decide $BLOCKING_REVIEWERS)
 fi
 ```
 
 `2>&1` 로 잡는 것은 헬퍼가 rc 1 에서 흘려보내는 `gh` 원문 에러다 — 성공/404
-경로에서는 비어 있다.
+경로에서는 비어 있다. `$DECISION` 처리(재검토 호출 / 유지 / 전체 재실행 안내)는
+`references/targeted-rereview.md` § "Step 6 — 게이트와 lane" 이 SSOT 다.
+
+## 절대 금지
+
+이 스킬은 두 라벨 중 어느 것도 **직접 add 하지 않는다**. 비블로킹 재검토
+판정이 실제로 돌아왔을 때 `devx_pr_review_all_apply_label` 이 쓰는 것이
+유일한 경로이고, 재검토를 건너뛴 채 통과로 간주하는 분기는 없다(NF-2).
 
 ## 호스트 고정
 

--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -60,15 +60,15 @@ Normalized enum: `default` / `quick` / `thorough` / `security` /
 
 ## Step 4: Fetch Review Material
 
-Decide path by diff size (`gh pr view --json additions,deletions`): `≥ 800` lines → follow
-`claude/skills/gh-pr-approve/references/large-diff-delegation.md`; else inline `gh pr diff`. Append the diff per
-`references/ai-cli-invocation.md` and write `(prompt + diff)` to `PROMPT_FILE`.
-
-`--paths <path>` (repeatable) narrows the review to those files: the diff is
-filtered by path in `_gh_pr_review_build_prompt`, so a scoped run stays on the
-**inline** path regardless of the whole PR's size — never route a `--paths` run
-through the large-diff delegation branch. A scope matching no file exits 1
-rather than reviewing an empty diff (#1616).
+Decide path: if `--paths <path>` (repeatable) was given, always take the
+**inline** `gh pr diff` path regardless of PR size — the diff is filtered by
+path in `_gh_pr_review_build_prompt`, so a scoped run never routes through
+large-diff delegation, and a scope matching no file exits 1 rather than
+reviewing an empty diff (#1616). Otherwise decide by diff size
+(`gh pr view --json additions,deletions`): `≥ 800` lines → follow
+`claude/skills/gh-pr-approve/references/large-diff-delegation.md`; else inline
+`gh pr diff`. Append the diff per `references/ai-cli-invocation.md` and write
+`(prompt + diff)` to `PROMPT_FILE`.
 
 Never hardcode or reuse a `PROMPT_FILE`; derive it from
 `_gh_pr_review_mktemp_prompt "$ai" "$PR_NUMBER"` and do the write plus Step 5

--- a/claude/skills/gh-pr-review/SKILL.md
+++ b/claude/skills/gh-pr-review/SKILL.md
@@ -24,8 +24,8 @@ comment by default. **Never** submits `--approve` / `--request-changes` (that is
 `gh:pr-approve`) and **never** replies to individual review comments (that is
 `gh:pr-reply`). Every preset requires a critical stance
 (`references/review-presets.md`). Flags — `--ai <codex|agy|claude|opencode|hermes>`,
-`--review <preset>`, `--user <name>` (claude only), `--no-post-comment`, and
-`<PR#> [remote]` — are tabled in `references/help.md`.
+`--review <preset>`, `--user <name>` (claude only), `--no-post-comment`,
+`--paths <path>`, and `<PR#> [remote]` — are tabled in `references/help.md`.
 
 ## Help
 
@@ -63,6 +63,12 @@ Normalized enum: `default` / `quick` / `thorough` / `security` /
 Decide path by diff size (`gh pr view --json additions,deletions`): `≥ 800` lines → follow
 `claude/skills/gh-pr-approve/references/large-diff-delegation.md`; else inline `gh pr diff`. Append the diff per
 `references/ai-cli-invocation.md` and write `(prompt + diff)` to `PROMPT_FILE`.
+
+`--paths <path>` (repeatable) narrows the review to those files: the diff is
+filtered by path in `_gh_pr_review_build_prompt`, so a scoped run stays on the
+**inline** path regardless of the whole PR's size — never route a `--paths` run
+through the large-diff delegation branch. A scope matching no file exits 1
+rather than reviewing an empty diff (#1616).
 
 Never hardcode or reuse a `PROMPT_FILE`; derive it from
 `_gh_pr_review_mktemp_prompt "$ai" "$PR_NUMBER"` and do the write plus Step 5

--- a/claude/skills/gh-pr-review/references/help.md
+++ b/claude/skills/gh-pr-review/references/help.md
@@ -20,6 +20,7 @@ request-changes) is submitted** — see `gh-pr-approve` for that.
 | `--review <preset>` | no | Review depth/lens enum. Default `default`. See below. |
 | `--user <name>` | no | `--ai claude` only. Multi-account routing via `_claude_resolve_account` (e.g. `personal`, `work`, `work1`). |
 | `--no-post-comment` | no | Skip the automatic PR comment; only print to stdout. |
+| `--paths <path>` | no | Repeatable. Review only these files — the diff is filtered by path, so the run stays on the inline path however large the PR is. A scope matching no file exits 1. Added for `gh:pr-reply`'s targeted re-review lane (#1616). |
 
 ## `--review` enum
 
@@ -85,6 +86,7 @@ verification on an internal PC — see
 - `/gh-pr-review --ai claude --user work 99` — claude as `work` account
 - `/gh-pr-review --ai claude --user work1 --review 보안 99` — work1 + security
 - `/gh-pr-review --ai codex --no-post-comment 99` — stdout only, no PR comment
+- `/gh-pr-review --ai codex --paths a.sh --paths b.sh 99` — review only those two files
 - `/gh-pr-review --ai codex 99 upstream` — PR #99 on `upstream`'s repo
 - `/gh-pr-review --ai agy` — auto-detect PR from current branch
 - `/gh-pr-review -h` / `--help` / `help` — print this help
@@ -128,8 +130,8 @@ verification on an internal PC — see
 |------|-------|
 | 0 | Review completed and (optionally) commented on the PR. |
 | 0 | PR comment post failed but stdout still has the AI output (soft fail with `[WARN]`). |
-| 1 | External CLI missing on `$PATH`, external CLI returned non-zero, PR auto-detect failed, unknown `--user` account, or `gh` not authenticated. |
-| 2 | Argument error: missing `--ai`, unknown `--ai` value, unknown `--review` value, `--user` with non-claude `--ai`. |
+| 1 | External CLI missing on `$PATH`, external CLI returned non-zero, PR auto-detect failed, unknown `--user` account, `--paths` matched no file in the diff, or `gh` not authenticated. |
+| 2 | Argument error: missing `--ai`, unknown `--ai` value, unknown `--review` value, `--user` with non-claude `--ai`, `--paths` with no value. |
 
 ## Good vs. bad invocation
 

--- a/docs/public/changelog.d/2026-08-31-1616.md
+++ b/docs/public/changelog.d/2026-08-31-1616.md
@@ -1,0 +1,4 @@
+- 변경: **`gh:pr-reply`의 `review-blocked` 해제 규칙을 전역 `ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0`에서 리뷰어별·심각도별 게이트로 바꿨다 — 다른 리뷰어의 비블로킹 제안을 거절해도 더 이상 라벨이 눌러앉지 않는다(PR #1609 사례)**
+- 변경: **`gh:pr-reply` Step 6에 저비용 타겟 재검토 lane을 추가했다 — 원래 블로킹한 리뷰어의 블로커가 전부 반영됐을 때만 그 리뷰어 하나를 수정 파일 범위로 재호출하고, 비블로킹 판정이 실제로 돌아왔을 때만 `devx_pr_review_all_apply_label`로 `review-passed`를 적용한다(자가 인증 경로 없음)**
+- 변경: **`gh:pr-review`에 `--paths <path>` 옵션을 추가했다(반복 가능) — diff를 파일 단위로 걸러 PR 전체 크기와 무관하게 small-diff inline 경로를 유지하며, 매칭되는 파일이 없으면 빈 리뷰 대신 exit 1로 끊는다**
+- 변경: **`shell-common/functions/gh_pr_reply_targeted_review.sh` 를 추가했다 — 리뷰어별 게이트(`_gh_pr_reply_origin_line` / `_gh_pr_reply_origin_tally` / `_gh_pr_reply_targeted_lane_decide` / `_gh_pr_reply_targeted_lane_report`)**

--- a/shell-common/functions/gh_pr_edit_safe.sh
+++ b/shell-common/functions/gh_pr_edit_safe.sh
@@ -40,7 +40,10 @@
 # ---------------------------------------------------------------------------
 # Verdict-label invalidation — SSOT for issue #1563
 # ---------------------------------------------------------------------------
-# `devx:pr-review-all` is the ONLY writer of the two verdict labels:
+# `devx_pr_review_all_apply_label` is the ONLY writer of the two verdict
+# labels — since #1616 it has two callers (`devx:pr-review-all`'s full fan-out
+# and `gh:pr-reply`'s single-reviewer targeted re-review), but still exactly
+# one write path:
 #   review-blocked — at least one reviewer lane returned a blocking verdict
 #   review-passed  — every lane that ran passed, and at least one lane ran
 # Both prove a claim about **one specific head commit**, not about the PR in
@@ -59,13 +62,21 @@
 #   - `review-passed` is dropped UNCONDITIONALLY by all three. Any new head
 #     invalidates "this head was reviewed"; dropping is always the safe
 #     direction because absence means "not verified", not "blocked".
-#   - `review-blocked` is dropped ONLY where the skill actually holds evidence
-#     that every blocker raised was addressed. Today that is exactly one place:
-#     `gh:pr-reply`, and only when ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0
-#     (its Step 3 classification: ACCEPT + ACCEPT-PARTIAL vs DECLINE). A rebase
-#     skill has no such evidence, so it must leave `review-blocked` in place —
-#     that is the safe direction, not a bug.
-#   - No skill may ever ADD either label. Only `devx:pr-review-all` issues them.
+#   - `review-blocked` is never dropped by this primitive. Since #1616 it is
+#     cleared only as the side effect of a NEW verdict: `gh:pr-reply`'s
+#     targeted re-review lane gates on `_gh_pr_reply_targeted_lane_decide`
+#     (per reviewer, per severity — see
+#     claude/skills/gh-pr-reply/references/targeted-rereview.md), and when an
+#     independent `gh:pr-review` re-call comes back non-blocking,
+#     `devx_pr_review_all_apply_label` deletes the opposite label on its way
+#     to writing `review-passed`. The rule this replaced —
+#     `gh:pr-reply` dropping it on a global accepted/declined count — pinned
+#     the label whenever any OTHER reviewer's non-blocking suggestion was
+#     declined (PR #1609). A rebase skill holds no verdict at all, so it must
+#     leave `review-blocked` in place — the safe direction, not a bug.
+#   - No skill may ADD either label by hand, and none may certify its own
+#     work: only a reviewer verdict, through
+#     `devx_pr_review_all_apply_label`, issues them (#1616 NF-2).
 # Consuming reference docs link here instead of restating this rule.
 #
 # _gh_pr_drop_label return codes:

--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -68,8 +68,13 @@ _gh_pr_reply_origin_line() {
         ;;
     esac
     case "$_severity" in
-    "" | *[!A-Z-]*)
-        printf '[gh-pr-reply] severity must be a non-empty tag (e.g. BLOCKER, FOLLOW-UP): %s\n' \
+    "")
+        printf '[gh-pr-reply] severity must be a non-empty tag (e.g. BLOCKER, FOLLOW-UP, 블로커): %s\n' \
+            "${2-}" >&2
+        return 2
+        ;;
+    *:*)
+        printf '[gh-pr-reply] severity must not contain ":" (breaks the reviewer:severity:verdict delimiter): %s\n' \
             "${2-}" >&2
         return 2
         ;;

--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -101,32 +101,28 @@ _gh_pr_reply_severity_is_blocking() {
 # ACCEPTED_COUNT / DECLINED_COUNT pair it replaces could not distinguish
 # "a blocker is unresolved" from "a suggestion was declined".
 _gh_pr_reply_origin_tally() {
+    # `sort` on the whole `reviewer:severity:verdict` line already groups
+    # every reviewer's lines into one contiguous block (no two reviewer
+    # names in the enum share a prefix), so a flush-on-change over sorted
+    # input reports them in order without a second names[]/bubble-sort pass.
     sort | awk -F: '
         NF < 3 { next }
-        {
-            r = $1; sev = $2; v = $3
-            seen[r] = 1
-            blocking = (sev == "BLOCKER" || sev == "BLOCKING")
-            if (blocking) {
-                bt[r]++
-                if (v == "ACCEPT" || v == "ACCEPT-PARTIAL") ba[r]++
-            } else {
-                nt[r]++
-                if (v == "DECLINE") nd[r]++
-            }
-        }
-        END {
-            n = 0
-            for (r in seen) names[++n] = r
-            for (i = 1; i <= n; i++)
-                for (j = i + 1; j <= n; j++)
-                    if (names[j] < names[i]) { t = names[i]; names[i] = names[j]; names[j] = t }
-            for (i = 1; i <= n; i++) {
-                r = names[i]
+        function flush() {
+            if (cur != "")
                 printf "reviewer=%s blocking_total=%d blocking_accepted=%d nonblocking_total=%d nonblocking_declined=%d\n", \
-                    r, bt[r] + 0, ba[r] + 0, nt[r] + 0, nd[r] + 0
+                    cur, bt + 0, ba + 0, nt + 0, nd + 0
+        }
+        {
+            if ($1 != cur) { flush(); cur = $1; bt = ba = nt = nd = 0 }
+            if ($2 == "BLOCKER" || $2 == "BLOCKING") {
+                bt++
+                if ($3 == "ACCEPT" || $3 == "ACCEPT-PARTIAL") ba++
+            } else {
+                nt++
+                if ($3 == "DECLINE") nd++
             }
         }
+        END { flush() }
     '
 }
 

--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -1,0 +1,278 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_pr_reply_targeted_review.sh
+# Per-reviewer / per-severity gate for gh:pr-reply's `review-blocked`
+# invalidation, plus the cheap targeted re-review lane it authorizes
+# (issue #1616).
+#
+# Before #1616 the rule was one global counter pair —
+# `ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0`. A legitimately DECLINEd
+# suggestion from a NON-blocking reviewer then pinned `review-blocked` on a
+# PR whose every actual BLOCKER had been fixed (PR #1609: codex raised 2
+# BLOCKERs, both fixed; agy raised 3 FOLLOW-UPs, all validly declined), and
+# the only way out was a full 5-lane devx:pr-review-all re-run.
+#
+# The replacement asks a narrower question, per reviewer: "did THIS
+# reviewer's blocking-severity items all get accepted?" Only when every
+# originally-blocking reviewer answers yes is the targeted lane authorized;
+# gh:pr-reply still never certifies itself (NF-2) — the label flip is
+# decided by an independent gh:pr-review re-call whose verdict flows through
+# `devx_pr_review_all_apply_label` unchanged.
+#
+# SSOT for the procedure: claude/skills/gh-pr-reply/references/targeted-rereview.md
+#
+# Deliberately NOT wrapped in an interactive guard: like
+# devx_pr_review_all.sh, this is a pure function-defining library whose
+# callers are the skill's non-interactive `bash --noprofile --norc` tool
+# calls. A guard here would define nothing and the gate would never run.
+
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh_pr_reply_targeted_review"
+else
+    printf '[gh_pr_reply_targeted_review] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
+fi
+unset _drg_self _drg_helper
+
+# ── F-1: origin tokens ──────────────────────────────────────────────────
+#
+# One Step 3 classification becomes one `<reviewer>:<severity>:<verdict>`
+# line. The reviewer set matches gh:pr-review's `--ai` enum, because the
+# targeted lane can only re-invoke a reviewer that skill knows how to run.
+
+_gh_pr_reply_origin_line() {
+    local _reviewer _severity _verdict
+    _reviewer=$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')
+    # Reviewers tag findings as `[BLOCKER]` / `[FOLLOW-UP]`; the brackets are
+    # rendering, not data.
+    _severity=$(printf '%s' "${2-}" | tr -d '[]' | tr '[:lower:]' '[:upper:]')
+    _verdict=$(printf '%s' "${3-}" | tr '[:lower:]' '[:upper:]')
+
+    case "$_reviewer" in
+    codex | agy | claude | opencode | hermes) ;;
+    *)
+        printf '[gh-pr-reply] unknown reviewer: %s (allowed: codex, agy, claude, opencode, hermes)\n' \
+            "${1-}" >&2
+        return 2
+        ;;
+    esac
+    case "$_severity" in
+    "" | *[!A-Z-]*)
+        printf '[gh-pr-reply] severity must be a non-empty tag (e.g. BLOCKER, FOLLOW-UP): %s\n' \
+            "${2-}" >&2
+        return 2
+        ;;
+    esac
+    case "$_verdict" in
+    ACCEPT | ACCEPT-PARTIAL | DECLINE | QUESTION) ;;
+    *)
+        printf '[gh-pr-reply] unknown verdict: %s (allowed: ACCEPT, ACCEPT-PARTIAL, DECLINE, QUESTION)\n' \
+            "${3-}" >&2
+        return 2
+        ;;
+    esac
+
+    printf '%s:%s:%s\n' "$_reviewer" "$_severity" "$_verdict"
+}
+
+# Blocking severity = the tag that made `review-blocked` happen. Everything
+# else (FOLLOW-UP, Suggestion, nit, PRAISE) is advisory and its DECLINE must
+# never hold the label down — the whole point of #1616.
+_gh_pr_reply_severity_is_blocking() {
+    case "$(printf '%s' "${1-}" | tr -d '[]' | tr '[:lower:]' '[:upper:]')" in
+    BLOCKER | BLOCKING | 블로커) return 0 ;;
+    esac
+    return 1
+}
+
+# Origin lines on stdin -> one summary line per reviewer, sorted by name.
+# This is what Step 7's per-reviewer breakdown reports; the flat
+# ACCEPTED_COUNT / DECLINED_COUNT pair it replaces could not distinguish
+# "a blocker is unresolved" from "a suggestion was declined".
+_gh_pr_reply_origin_tally() {
+    sort | awk -F: '
+        NF < 3 { next }
+        {
+            r = $1; sev = $2; v = $3
+            seen[r] = 1
+            blocking = (sev == "BLOCKER" || sev == "BLOCKING")
+            if (blocking) {
+                bt[r]++
+                if (v == "ACCEPT" || v == "ACCEPT-PARTIAL") ba[r]++
+            } else {
+                nt[r]++
+                if (v == "DECLINE") nd[r]++
+            }
+        }
+        END {
+            n = 0
+            for (r in seen) names[++n] = r
+            for (i = 1; i <= n; i++)
+                for (j = i + 1; j <= n; j++)
+                    if (names[j] < names[i]) { t = names[i]; names[i] = names[j]; names[j] = t }
+            for (i = 1; i <= n; i++) {
+                r = names[i]
+                printf "reviewer=%s blocking_total=%d blocking_accepted=%d nonblocking_total=%d nonblocking_declined=%d\n", \
+                    r, bt[r] + 0, ba[r] + 0, nt[r] + 0, nd[r] + 0
+            }
+        }
+    '
+}
+
+# ── F-7: can this reviewer's lane run here at all? ──────────────────────
+#
+# Delegates to gh:pr-review's own precondition
+# (`_gh_pr_review_require_ai_cli`) rather than re-deriving it: that helper
+# already covers both `command -v <ai-bin>` and the
+# `_dotfiles_setup_mode == internal` gate opencode/hermes need. The fallback
+# source runs in a subshell so DOTFILES_FORCE_INIT (load-bearing past that
+# file's interactive guard) never leaks into the caller's environment.
+_gh_pr_reply_lane_available() {
+    local _ai="${1-}"
+    [ -n "$_ai" ] || return 1
+    if command -v _gh_pr_review_require_ai_cli >/dev/null 2>&1; then
+        _gh_pr_review_require_ai_cli "$_ai" >/dev/null 2>&1
+        return $?
+    fi
+    (
+        DOTFILES_FORCE_INIT=1
+        export DOTFILES_FORCE_INIT
+        # shellcheck source=/dev/null
+        . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_review.sh" 2>/dev/null || exit 1
+        _gh_pr_review_require_ai_cli "$_ai" >/dev/null 2>&1
+    )
+}
+
+# ── F-2 / F-6 / F-7: the decision ───────────────────────────────────────
+#
+#   <origin lines> | _gh_pr_reply_targeted_lane_decide <blocking-reviewer>...
+#
+# Prints exactly one token:
+#   lane=<r1>[ <r2>…]        every originally-blocking reviewer is fully
+#                            resolved and runnable -> re-review them
+#   skip=unresolved-blocker:<r>   F-6 — keep review-blocked, spend nothing
+#   skip=cli-unavailable:<r>      F-7 — fall back to the full re-run
+#   skip=no-blocking-reviewer     nothing blocked; there is nothing to clear
+#
+# `<blocking-reviewer>...` is the set that posted a BLOCKING verdict in the
+# round that applied `review-blocked` — read off the PR's `ai-review` blocks,
+# not off this pass's items.
+#
+# One unresolved reviewer suppresses the lane for ALL of them: re-reviewing
+# a resolved reviewer cannot lift a label another one is still holding, so
+# the extra call would buy nothing.
+_gh_pr_reply_targeted_lane_decide() {
+    local _origins _r _blocking_total _blocking_open _lanes=""
+
+    [ "$#" -gt 0 ] || {
+        # Drain stdin so a piped caller never sees EPIPE on the fast path.
+        cat >/dev/null
+        printf 'skip=no-blocking-reviewer\n'
+        return 0
+    }
+
+    _origins=$(cat)
+
+    for _r in "$@"; do
+        case "$_r" in
+        codex | agy | claude | opencode | hermes) ;;
+        *)
+            printf '[gh-pr-reply] unknown blocking reviewer: %s\n' "$_r" >&2
+            return 2
+            ;;
+        esac
+    done
+
+    for _r in "$@"; do
+        _blocking_total=$(printf '%s\n' "$_origins" |
+            grep -c "^${_r}:\(BLOCKER\|BLOCKING\):" || :)
+        _blocking_open=$(printf '%s\n' "$_origins" |
+            grep -c "^${_r}:\(BLOCKER\|BLOCKING\):\(DECLINE\|QUESTION\)$" || :)
+        # Zero blocking items this pass is NOT a clean bill of health: this
+        # reviewer blocked, and nothing here shows the blocker was addressed.
+        # "No evidence" must read as unresolved (NF-2's direction).
+        if [ "$_blocking_total" -eq 0 ] || [ "$_blocking_open" -ne 0 ]; then
+            printf 'skip=unresolved-blocker:%s\n' "$_r"
+            return 0
+        fi
+    done
+
+    for _r in "$@"; do
+        if ! _gh_pr_reply_lane_available "$_r"; then
+            printf 'skip=cli-unavailable:%s\n' "$_r"
+            return 0
+        fi
+        _lanes="${_lanes:+$_lanes }$_r"
+    done
+
+    printf 'lane=%s\n' "$_lanes"
+    return 0
+}
+
+# ── F-4 / F-5: the Step 7 line ──────────────────────────────────────────
+#
+# Takes either the decide token or the targeted lane's own verdict as
+# `verdict=<blocking|concerns|lgtm|unknown>` (the tokens
+# `devx_pr_review_all_verdict` emits). Reporting is the ONLY thing this
+# function does — the label itself is written by
+# `devx_pr_review_all_apply_label`, so a report line can never become a
+# self-certification.
+_gh_pr_reply_targeted_lane_report() {
+    local _token="${1-}" _who
+    case "$_token" in
+    verdict=blocking)
+        printf '[BLOCKED] 타겟 재검토도 여전히 BLOCKING — 재수정 필요\n'
+        ;;
+    verdict=lgtm | verdict=concerns)
+        printf '[OK] 타겟 재검토 통과 — review-blocked 해제, review-passed 적용\n'
+        ;;
+    verdict=*)
+        printf '[WARN] 타겟 재검토 판정 불명 — review-blocked 유지, 전체 devx:pr-review-all 재실행 필요\n'
+        ;;
+    skip=unresolved-blocker:*)
+        _who="${_token#skip=unresolved-blocker:}"
+        printf '[BLOCKED] %s 의 블로커가 미해결 — review-blocked 유지, 타겟 재검토 미실행\n' "$_who"
+        ;;
+    skip=cli-unavailable:*)
+        _who="${_token#skip=cli-unavailable:}"
+        printf '[WARN] %s 리뷰어 CLI 를 이 환경에서 실행할 수 없음 — 전체 devx:pr-review-all 재실행 필요\n' "$_who"
+        ;;
+    skip=no-blocking-reviewer)
+        printf '[OK] 원래 블로킹한 리뷰어 없음 — 타겟 재검토 불필요\n'
+        ;;
+    *)
+        printf '[gh-pr-reply] unknown report token: %s\n' "$_token" >&2
+        return 2
+        ;;
+    esac
+    return 0
+}
+
+# Self-check (issue #724): the skill sources this file in non-interactive
+# bash. A syntax error or a rename would leave the gate silently undefined,
+# which reads as "no decision" — and a caller that cannot decide must not
+# fall back to the old global rule.
+for _gprtr_selfcheck_fn in \
+    _gh_pr_reply_origin_line \
+    _gh_pr_reply_severity_is_blocking \
+    _gh_pr_reply_origin_tally \
+    _gh_pr_reply_lane_available \
+    _gh_pr_reply_targeted_lane_decide \
+    _gh_pr_reply_targeted_lane_report; do
+    command -v "$_gprtr_selfcheck_fn" >/dev/null 2>&1 && continue
+    printf '[gh_pr_reply_targeted_review] BUG: %s undefined after source — the #1616 targeted re-review gate will not run.\n' \
+        "$_gprtr_selfcheck_fn" >&2
+done
+unset _gprtr_selfcheck_fn
+:

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -70,9 +70,26 @@ gh_pr_review_parse() {
     local post_comment=1
     local pr=""
     local remote="origin"
+    local paths=""
 
     while [ "$#" -gt 0 ]; do
         case "$1" in
+        --paths)
+            if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+                echo "missing value for --paths" >&2
+                return 2
+            fi
+            paths="${paths:+$paths }$2"
+            shift 2
+            ;;
+        --paths=*)
+            if [ -z "${1#--paths=}" ]; then
+                echo "missing value for --paths" >&2
+                return 2
+            fi
+            paths="${paths:+$paths }${1#--paths=}"
+            shift
+            ;;
         --ai)
             if [ "$#" -lt 2 ]; then
                 echo "missing value for --ai" >&2
@@ -179,7 +196,8 @@ EOF
         "user=$user" \
         "post_comment=$post_comment" \
         "pr=$pr" \
-        "remote=$remote"
+        "remote=$remote" \
+        "paths=$paths"
     return 0
 }
 
@@ -707,11 +725,59 @@ EOF
     esac
 }
 
+# _gh_pr_review_filter_diff_paths — unified diff on stdin, one or more
+# repo-relative paths as args; emits only the `diff --git` sections whose
+# old OR new path is one of them (a rename is therefore reachable from
+# either side). Exit 2 with nothing on stdout when no path was given —
+# a silent pass-through would hand the caller a full-PR diff it believed
+# was scoped (issue #1616).
+#
+# `gh pr diff` has no pathspec of its own, so scoping happens here rather
+# than at the API. The `a/X b/Y` split takes the FIRST ` b/`, which is
+# unambiguous for every path that does not itself contain " b/".
+_gh_pr_review_filter_diff_paths() {
+    if [ "$#" -eq 0 ]; then
+        echo 'usage: _gh_pr_review_filter_diff_paths <path>...' >&2
+        return 2
+    fi
+    local _wanted=""
+    local _p
+    for _p in "$@"; do
+        _wanted="${_wanted}${_p}
+"
+    done
+    awk -v wanted="$_wanted" '
+        BEGIN {
+            n = split(wanted, w, "\n")
+            for (i = 1; i <= n; i++) if (w[i] != "") want[w[i]] = 1
+        }
+        /^diff --git / {
+            keep = 0
+            line = substr($0, 12)
+            sp = index(line, " b/")
+            if (sp > 0) { ap = substr(line, 1, sp - 1); bp = substr(line, sp + 3) }
+            else { ap = line; bp = "" }
+            sub(/^a\//, "", ap)
+            if ((ap in want) || (bp in want)) keep = 1
+            if (keep) print
+            next
+        }
+        keep { print }
+    '
+}
+
 # _gh_pr_review_build_prompt — writes `<prefix>\n\n<preset>\n\n<diff>`
 # to the given file. Args: $1 = preset, $2 = output file, $3 = pr_number,
-# $4 = target_repo, $5 = base_ref, $6 = head_ref. The diff is fetched
-# with `gh pr diff`; the function does not enforce a size gate (the
-# SKILL still controls the large-diff delegation path in Step 4).
+# $4 = target_repo, $5 = base_ref, $6 = head_ref, $7 = optional
+# space-separated path scope. The diff is fetched with `gh pr diff`; the
+# function does not enforce a size gate (the SKILL still controls the
+# large-diff delegation path in Step 4).
+#
+# $7 (issue #1616) is what keeps gh:pr-reply's targeted re-review lane on
+# the small-diff inline path no matter how large the whole PR is. Exit 3
+# when the scope matches nothing: an empty diff would make the reviewer
+# opine on nothing and answer LGTM, and that answer is exactly what the
+# lane would read as "the blocker is cleared".
 _gh_pr_review_build_prompt() {
     local preset="$1"
     local out="$2"
@@ -719,15 +785,34 @@ _gh_pr_review_build_prompt() {
     local repo="$4"
     local base="${5:-?}"
     local head="${6:-?}"
+    local paths="${7-}"
+    local _scoped_diff="" _scope_note=""
+
+    if [ -n "$paths" ]; then
+        # Word-splitting `$paths` is the contract: it is a space-separated
+        # path list, mirroring the `paths=` line gh_pr_review_parse emits.
+        # shellcheck disable=SC2086
+        _scoped_diff=$(gh pr diff "$pr" --repo "$repo" 2>/dev/null |
+            _gh_pr_review_filter_diff_paths $paths)
+        if [ -z "$_scoped_diff" ]; then
+            echo "--paths matched no file in PR #$pr's diff: $paths" >&2
+            return 3
+        fi
+        _scope_note=", scoped to: $paths"
+    fi
 
     {
         _gh_pr_review_common_prefix
         echo ""
         _gh_pr_review_preset_body "$preset" || return $?
         echo ""
-        printf -- '--- PR DIFF (PR #%s, repo %s, base %s → head %s) ---\n' \
-            "$pr" "$repo" "$base" "$head"
-        gh pr diff "$pr" --repo "$repo" 2>/dev/null || true
+        printf -- '--- PR DIFF (PR #%s, repo %s, base %s → head %s%s) ---\n' \
+            "$pr" "$repo" "$base" "$head" "$_scope_note"
+        if [ -n "$paths" ]; then
+            printf '%s\n' "$_scoped_diff"
+        else
+            gh pr diff "$pr" --repo "$repo" 2>/dev/null || true
+        fi
         printf -- '--- END PR DIFF ---\n'
     } >"$out"
 }
@@ -1027,6 +1112,10 @@ Flags:
   --user <name>                claude only; multi-account routing via
                                _claude_resolve_account
   --no-post-comment            skip the PR comment; stdout only
+  --paths <path>               repeatable; review only these files. The
+                               diff is filtered by path, so a scoped run
+                               stays on the inline path however large the
+                               whole PR is. No match -> exit 1 (#1616)
 
 OpenCode:
   --ai opencode                internal-PC only; fixed model
@@ -1108,7 +1197,7 @@ gh_pr_review() {
         return 0
     fi
 
-    local ai="" review="" user="" post_comment="" pr="" remote=""
+    local ai="" review="" user="" post_comment="" pr="" remote="" paths=""
     # Read each `key=value` line into the matching local. The keys are
     # a fixed allow-list (ai/review/user/post_comment/pr/remote); any
     # other key is silently ignored. `eval "$_parsed"` would be shorter
@@ -1124,6 +1213,7 @@ gh_pr_review() {
         post_comment) post_comment="$_v" ;;
         pr) pr="$_v" ;;
         remote) remote="$_v" ;;
+        paths) paths="$_v" ;;
         esac
     done <<EOF
 $_parsed
@@ -1272,7 +1362,7 @@ EOF
     }
 
     _gh_pr_review_build_prompt "$review" "$PROMPT_FILE" \
-        "$PR_NUMBER" "$TARGET_REPO" "${base:-?}" "${head:-?}" || {
+        "$PR_NUMBER" "$TARGET_REPO" "${base:-?}" "${head:-?}" "$paths" || {
         _gh_pr_review_disarm_trap
         rm -f "$PROMPT_FILE" "$AI_OUT" "$BODY_FILE"
         return 1

--- a/tests/bats/functions/gh_pr_reply_targeted_review.bats
+++ b/tests/bats/functions/gh_pr_reply_targeted_review.bats
@@ -58,6 +58,24 @@ teardown() {
     assert_failure 2
 }
 
+@test "F-1 (PR #1629 review, agy FOLLOW-UP): origin_line accepts the Korean 블로커 tag" {
+    run _gh_pr_reply_origin_line codex '블로커' ACCEPT
+    assert_success
+    assert_output 'codex:블로커:ACCEPT'
+}
+
+@test "F-1 (PR #1629 review, agy FOLLOW-UP): severity_is_blocking recognizes the accepted 블로커 token round-trip" {
+    run _gh_pr_reply_origin_line codex '블로커' ACCEPT
+    assert_success
+    run _gh_pr_reply_severity_is_blocking 블로커
+    assert_success
+}
+
+@test "F-1: origin_line rejects a severity containing ':' (breaks the delimiter)" {
+    run _gh_pr_reply_origin_line codex 'BLOCK:ER' ACCEPT
+    assert_failure 2
+}
+
 @test "F-1: BLOCKER is the blocking severity" {
     run _gh_pr_reply_severity_is_blocking BLOCKER
     assert_success

--- a/tests/bats/functions/gh_pr_reply_targeted_review.bats
+++ b/tests/bats/functions/gh_pr_reply_targeted_review.bats
@@ -1,0 +1,315 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_pr_reply_targeted_review.bats
+# Issue #1616 — gh:pr-reply's per-reviewer/per-severity gate and the cheap
+# targeted re-review lane that replaces the global
+# `ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0` rule.
+#
+# Incident this pins: PR #1609 — codex raised 2 BLOCKERs (both fixed), agy
+# separately raised 3 non-blocking FOLLOW-UPs (all validly declined). The old
+# global gate saw DECLINED_COUNT=3 and left `review-blocked` stuck, forcing a
+# full 5-lane devx:pr-review-all re-run to clear one label.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# ---------------------------------------------------------------------
+# F-1 — every Step 3 item carries its origin: <reviewer>:<severity>:<verdict>
+# ---------------------------------------------------------------------
+
+@test "F-1: origin_line builds the canonical token" {
+    run _gh_pr_reply_origin_line codex BLOCKER ACCEPT
+    assert_success
+    assert_output 'codex:BLOCKER:ACCEPT'
+}
+
+@test "F-1: origin_line normalizes case and strips the reviewer's [brackets]" {
+    run _gh_pr_reply_origin_line AGY '[Follow-Up]' decline
+    assert_success
+    assert_output 'agy:FOLLOW-UP:DECLINE'
+}
+
+@test "F-1: origin_line accepts ACCEPT-PARTIAL" {
+    run _gh_pr_reply_origin_line codex '[BLOCKER]' accept-partial
+    assert_success
+    assert_output 'codex:BLOCKER:ACCEPT-PARTIAL'
+}
+
+@test "F-1: origin_line rejects an unknown reviewer (exit 2)" {
+    run _gh_pr_reply_origin_line gemini BLOCKER ACCEPT
+    assert_failure 2
+}
+
+@test "F-1: origin_line rejects an unknown verdict (exit 2)" {
+    run _gh_pr_reply_origin_line codex BLOCKER MAYBE
+    assert_failure 2
+}
+
+@test "F-1: origin_line rejects an empty severity (exit 2)" {
+    run _gh_pr_reply_origin_line codex '' ACCEPT
+    assert_failure 2
+}
+
+@test "F-1: BLOCKER is the blocking severity" {
+    run _gh_pr_reply_severity_is_blocking BLOCKER
+    assert_success
+}
+
+@test "F-1: FOLLOW-UP / Suggestion / PRAISE are not blocking" {
+    run _gh_pr_reply_severity_is_blocking FOLLOW-UP
+    assert_failure
+    run _gh_pr_reply_severity_is_blocking SUGGESTION
+    assert_failure
+    run _gh_pr_reply_severity_is_blocking PRAISE
+    assert_failure
+}
+
+@test "F-1: tally breaks the pass down per reviewer, not as one flat count" {
+    run bash -c "printf '%s\n' \
+        codex:BLOCKER:ACCEPT \
+        codex:BLOCKER:ACCEPT-PARTIAL \
+        agy:FOLLOW-UP:DECLINE \
+        agy:FOLLOW-UP:DECLINE \
+        | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origin_tally; }"
+    assert_success
+    assert_line 'reviewer=agy blocking_total=0 blocking_accepted=0 nonblocking_total=2 nonblocking_declined=2'
+    assert_line 'reviewer=codex blocking_total=2 blocking_accepted=2 nonblocking_total=0 nonblocking_declined=0'
+}
+
+@test "F-1: tally ignores blank lines and reports nothing for empty input" {
+    run bash -c "printf '\n\n' | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origin_tally; }"
+    assert_success
+    assert_output ''
+}
+
+# ---------------------------------------------------------------------
+# F-2 / F-6 — the per-reviewer gate
+# ---------------------------------------------------------------------
+
+# Every decide test runs the origin stream through stdin, exactly as the
+# skill does, and stubs the CLI-availability probe so the decision under test
+# is the gate and not the machine this suite happens to run on.
+_decide() {
+    local _origins="$1"
+    shift
+    printf '%s\n' "$_origins" | _gh_pr_reply_targeted_lane_decide "$@"
+}
+
+_stub_lane_available() {
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_reply_lane_available() { return 0; }
+}
+
+_stub_lane_unavailable() {
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_reply_lane_available() { return 1; }
+}
+
+@test "F-2 (AC-1): blocking reviewer fully ACCEPTed + another reviewer's DECLINE -> lane runs" {
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT
+codex:BLOCKER:ACCEPT
+agy:FOLLOW-UP:DECLINE
+agy:FOLLOW-UP:DECLINE
+agy:FOLLOW-UP:DECLINE' codex
+    assert_success
+    assert_output 'lane=codex'
+}
+
+@test "F-2: ACCEPT-PARTIAL counts as resolved for the blocking gate" {
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT-PARTIAL' codex
+    assert_success
+    assert_output 'lane=codex'
+}
+
+@test "F-2: a QUESTION on a blocking item is not a resolution" {
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT
+codex:BLOCKER:QUESTION' codex
+    assert_success
+    assert_output 'skip=unresolved-blocker:codex'
+}
+
+@test "F-6 (AC-4): a DECLINEd blocking item keeps the label and never calls the lane" {
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT
+codex:BLOCKER:DECLINE
+agy:FOLLOW-UP:ACCEPT' codex
+    assert_success
+    assert_output 'skip=unresolved-blocker:codex'
+}
+
+@test "F-6: one unresolved blocking reviewer suppresses the lane for the resolved one too" {
+    # Re-reviewing codex cannot clear a label agy is still holding down, so
+    # the cheapest correct answer is no API call at all.
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT
+agy:BLOCKER:DECLINE' codex agy
+    assert_success
+    assert_output 'skip=unresolved-blocker:agy'
+}
+
+@test "F-2: two blocking reviewers both fully resolved -> both lanes run" {
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT
+agy:BLOCKER:ACCEPT-PARTIAL' codex agy
+    assert_success
+    assert_output 'lane=codex agy'
+}
+
+@test "F-2: a blocking reviewer with no item in this pass is unresolved, not vacuously clear" {
+    # Nothing in this pass proves that reviewer's blocker was addressed, and
+    # "no evidence" must never read as "resolved" (NF-2's direction).
+    _stub_lane_available
+    run _decide 'agy:FOLLOW-UP:ACCEPT' codex
+    assert_success
+    assert_output 'skip=unresolved-blocker:codex'
+}
+
+@test "F-2: no originally-blocking reviewer -> nothing to re-verify" {
+    _stub_lane_available
+    run _decide 'agy:FOLLOW-UP:DECLINE'
+    assert_success
+    assert_output 'skip=no-blocking-reviewer'
+}
+
+@test "F-2: an unknown reviewer name is rejected (exit 2), never silently dropped" {
+    _stub_lane_available
+    run _decide 'codex:BLOCKER:ACCEPT' gemini
+    assert_failure 2
+}
+
+# ---------------------------------------------------------------------
+# F-7 — CLI gone / wrong environment falls back to the pre-#1616 behavior
+# ---------------------------------------------------------------------
+
+@test "F-7 (AC-5): a blocking reviewer whose CLI is unavailable skips the lane" {
+    _stub_lane_unavailable
+    run _decide 'codex:BLOCKER:ACCEPT' codex
+    assert_success
+    assert_output 'skip=cli-unavailable:codex'
+}
+
+@test "F-7: an unresolved blocker outranks CLI availability (no probe needed)" {
+    _stub_lane_unavailable
+    run _decide 'codex:BLOCKER:DECLINE' codex
+    assert_success
+    assert_output 'skip=unresolved-blocker:codex'
+}
+
+@test "F-7: lane_available delegates to gh:pr-review's own CLI gate" {
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_review_require_ai_cli() {
+        printf '%s\n' "$1" >"${BATS_TEST_TMPDIR}/probed"
+        return 0
+    }
+    run _gh_pr_reply_lane_available codex
+    assert_success
+    run cat "${BATS_TEST_TMPDIR}/probed"
+    assert_output 'codex'
+}
+
+@test "F-7: lane_available reports unavailable when the shared gate refuses" {
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_review_require_ai_cli() { return 1; }
+    run _gh_pr_reply_lane_available hermes
+    assert_failure
+}
+
+@test "F-7: lane_available never leaks the CLI gate's stderr into the report" {
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_review_require_ai_cli() {
+        printf 'Required CLI %s not found in PATH\n' "$1" >&2
+        return 1
+    }
+    run _gh_pr_reply_lane_available opencode
+    assert_failure
+    assert_output ''
+}
+
+# ---------------------------------------------------------------------
+# F-4 / F-5 — reporting the outcome (Step 7)
+# ---------------------------------------------------------------------
+
+@test "F-5 (AC-3): a still-blocking re-review says so explicitly" {
+    run _gh_pr_reply_targeted_lane_report verdict=blocking
+    assert_success
+    assert_output --partial '타겟 재검토도 여전히 BLOCKING — 재수정 필요'
+}
+
+@test "F-4 (AC-2): an LGTM re-review reports the label flip" {
+    run _gh_pr_reply_targeted_lane_report verdict=lgtm
+    assert_success
+    assert_output --partial 'review-blocked 해제'
+    assert_output --partial 'review-passed'
+}
+
+@test "F-4: CONCERNS is non-blocking and reports the same flip" {
+    run _gh_pr_reply_targeted_lane_report verdict=concerns
+    assert_success
+    assert_output --partial 'review-blocked 해제'
+}
+
+@test "F-4 (NF-2): an unknown verdict never claims a pass" {
+    run _gh_pr_reply_targeted_lane_report verdict=unknown
+    assert_success
+    refute_output --partial 'review-passed'
+    assert_output --partial '전체 devx:pr-review-all 재실행 필요'
+}
+
+@test "F-6: the unresolved-blocker skip reports the reviewer by name" {
+    run _gh_pr_reply_targeted_lane_report skip=unresolved-blocker:codex
+    assert_success
+    assert_output --partial 'codex'
+    assert_output --partial 'review-blocked 유지'
+    refute_output --partial 'review-passed'
+}
+
+@test "F-7 (AC-5): the cli-unavailable skip asks for the full re-run" {
+    run _gh_pr_reply_targeted_lane_report skip=cli-unavailable:hermes
+    assert_success
+    assert_output --partial 'hermes'
+    assert_output --partial '전체 devx:pr-review-all 재실행 필요'
+}
+
+@test "F-2: the no-blocking-reviewer skip is not an error" {
+    run _gh_pr_reply_targeted_lane_report skip=no-blocking-reviewer
+    assert_success
+    refute_output --partial 'review-passed'
+}
+
+@test "report rejects a token it does not understand (exit 2)" {
+    run _gh_pr_reply_targeted_lane_report lane=codex
+    assert_failure 2
+}
+
+# ---------------------------------------------------------------------
+# Library hygiene
+# ---------------------------------------------------------------------
+
+@test "the library defines every function the skill delegates to" {
+    for _fn in _gh_pr_reply_origin_line _gh_pr_reply_severity_is_blocking \
+        _gh_pr_reply_origin_tally _gh_pr_reply_targeted_lane_decide \
+        _gh_pr_reply_lane_available _gh_pr_reply_targeted_lane_report; do
+        run command -v "$_fn"
+        assert_success
+    done
+}
+
+@test "the library loads in a non-interactive shell with no interactive guard" {
+    # The skill's Bash tool calls run `bash --noprofile --norc`; an
+    # interactive guard here would silently define nothing and the gate
+    # would never run (#724's failure shape).
+    run bash --noprofile --norc -c \
+        ". '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh' && command -v _gh_pr_reply_targeted_lane_decide"
+    assert_success
+}

--- a/tests/bats/functions/gh_pr_review_paths_scope.bats
+++ b/tests/bats/functions/gh_pr_review_paths_scope.bats
@@ -102,6 +102,32 @@ EOF
     assert_line 'remote=upstream'
 }
 
+@test "parse (PR #1629 review, codex BLOCKER): repeated --paths for a multi-file fix keeps PR#/remote intact" {
+    # This is the call shape targeted-rereview.md's F-3 now mandates — one
+    # --paths flag per fixed file — precisely because the alternative
+    # (--paths "a.sh b.sh" as one joined string) misparses below.
+    run gh_pr_review_parse --ai codex --paths a.sh --paths b.sh 1629 origin
+    assert_success
+    assert_line 'paths=a.sh b.sh'
+    assert_line 'pr=1629'
+    assert_line 'remote=origin'
+}
+
+@test "parse (PR #1629 review, codex BLOCKER): the single-joined-string call this replaces fails outright" {
+    # Documents the exact failure targeted-rereview.md used to hand the AI
+    # executor: a Skill() argument string like "--paths a.sh b.sh 1629
+    # origin" is word-split (no quoting survives the round trip through the
+    # tool's argument string), so --paths eats only the first file, the
+    # second file becomes the PR# positional, "1629" gets read as the
+    # [remote] positional (still "origin" at that point), and the real
+    # "origin" trailing token has nowhere left to go — exit 2, not a silent
+    # misparse. Deliberately unquoted to reproduce that word-split.
+    # shellcheck disable=SC2086
+    run gh_pr_review_parse --ai codex --paths a.sh b.sh 1629 origin
+    assert_failure 2
+    assert_output --partial 'Unexpected positional arg'
+}
+
 # ---------------------------------------------------------------------
 # The diff filter
 # ---------------------------------------------------------------------

--- a/tests/bats/functions/gh_pr_review_paths_scope.bats
+++ b/tests/bats/functions/gh_pr_review_paths_scope.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+# tests/bats/functions/gh_pr_review_paths_scope.bats
+# Issue #1616 F-3 — `gh:pr-review --paths`, the file-scoped review the
+# targeted re-review lane needs.
+#
+# gh:pr-reply's lane re-verifies ONE reviewer against ONLY the files its fix
+# commits touched. Without a scope flag the only way to shrink the material
+# is the ≥800-line large-diff delegation branch, which has a separate known
+# defect (it never stamps `<!-- ai-review:<ai>:<head-sha> -->`) — so the lane
+# must stay on the small-diff inline path regardless of the full PR's size.
+# `--paths` is that switch: it filters the unified diff by file, so a
+# 3000-line PR still reviews inline when the scope is two files.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# One small two-file unified diff, the shape `gh pr diff` emits.
+_two_file_diff() {
+    cat <<'EOF'
+diff --git a/kept.sh b/kept.sh
+index 1111111..2222222 100644
+--- a/kept.sh
++++ b/kept.sh
+@@ -1,2 +1,2 @@
+-old kept line
++new kept line
+diff --git a/dropped.sh b/dropped.sh
+index 3333333..4444444 100644
+--- a/dropped.sh
++++ b/dropped.sh
+@@ -1,2 +1,2 @@
+-old dropped line
++new dropped line
+EOF
+}
+
+_stub_gh_diff() {
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/gh" <<'EOF'
+#!/bin/sh
+cat "$GH_STUB_DIFF_FILE"
+EOF
+    chmod +x "$stub_dir/gh"
+    export PATH="$stub_dir:$PATH"
+    GH_STUB_DIFF_FILE="$TEST_TEMP_HOME/diff.txt"
+    export GH_STUB_DIFF_FILE
+    _two_file_diff >"$GH_STUB_DIFF_FILE"
+}
+
+# ---------------------------------------------------------------------
+# Parser — the flag is additive and the default is unchanged
+# ---------------------------------------------------------------------
+
+@test "parse: no --paths -> paths= is empty (unchanged default for every existing caller)" {
+    run gh_pr_review_parse --ai codex 99
+    assert_success
+    assert_line 'paths='
+}
+
+@test "parse: --paths <p> resolves" {
+    run gh_pr_review_parse --ai codex --paths shell-common/functions/a.sh 99
+    assert_success
+    assert_line 'paths=shell-common/functions/a.sh'
+}
+
+@test "parse: --paths=<p> resolves" {
+    run gh_pr_review_parse --ai codex --paths=a.sh 99
+    assert_success
+    assert_line 'paths=a.sh'
+}
+
+@test "parse: --paths repeats and accumulates in order" {
+    run gh_pr_review_parse --ai codex --paths a.sh --paths=b.sh 99
+    assert_success
+    assert_line 'paths=a.sh b.sh'
+}
+
+@test "parse: --paths with no value -> exit 2" {
+    run gh_pr_review_parse --ai codex --paths
+    assert_failure 2
+}
+
+@test "parse: --paths with an empty value -> exit 2" {
+    run gh_pr_review_parse --ai codex --paths= 99
+    assert_failure 2
+}
+
+@test "parse: --paths does not consume the positional PR number" {
+    run gh_pr_review_parse --ai codex --paths a.sh 99 upstream
+    assert_success
+    assert_line 'pr=99'
+    assert_line 'remote=upstream'
+}
+
+# ---------------------------------------------------------------------
+# The diff filter
+# ---------------------------------------------------------------------
+
+@test "filter: a matching path keeps its whole section and drops the rest" {
+    _two_file_diff >"${BATS_TEST_TMPDIR}/d.txt"
+    run bash -c ". '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh'
+        _gh_pr_review_filter_diff_paths kept.sh <'${BATS_TEST_TMPDIR}/d.txt'"
+    assert_success
+    assert_output --partial 'diff --git a/kept.sh b/kept.sh'
+    assert_output --partial '+new kept line'
+    refute_output --partial 'dropped.sh'
+    refute_output --partial 'new dropped line'
+}
+
+@test "filter: several paths keep several sections" {
+    _two_file_diff >"${BATS_TEST_TMPDIR}/d.txt"
+    run bash -c ". '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh'
+        _gh_pr_review_filter_diff_paths kept.sh dropped.sh <'${BATS_TEST_TMPDIR}/d.txt'"
+    assert_success
+    assert_output --partial 'a/kept.sh'
+    assert_output --partial 'a/dropped.sh'
+}
+
+@test "filter: a rename is matched on its old path too" {
+    cat >"${BATS_TEST_TMPDIR}/d.txt" <<'EOF'
+diff --git a/old/name.sh b/new/name.sh
+similarity index 90%
+rename from old/name.sh
+rename to new/name.sh
+--- a/old/name.sh
++++ b/new/name.sh
+@@ -1 +1 @@
+-a
++b
+EOF
+    run bash -c ". '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh'
+        _gh_pr_review_filter_diff_paths old/name.sh <'${BATS_TEST_TMPDIR}/d.txt'"
+    assert_success
+    assert_output --partial 'rename to new/name.sh'
+}
+
+@test "filter: a path that matches nothing yields nothing" {
+    _two_file_diff >"${BATS_TEST_TMPDIR}/d.txt"
+    run bash -c ". '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh'
+        _gh_pr_review_filter_diff_paths absent.sh <'${BATS_TEST_TMPDIR}/d.txt'"
+    assert_success
+    assert_output ''
+}
+
+@test "filter: no paths at all is a usage error, never a silent pass-through" {
+    _two_file_diff >"${BATS_TEST_TMPDIR}/d.txt"
+    run bash -c ". '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_review.sh'
+        _gh_pr_review_filter_diff_paths <'${BATS_TEST_TMPDIR}/d.txt' 2>/dev/null"
+    assert_failure 2
+    assert_output ''
+}
+
+# ---------------------------------------------------------------------
+# Prompt builder integration
+# ---------------------------------------------------------------------
+
+@test "build_prompt: no paths arg keeps the full diff and the unscoped header" {
+    _stub_gh_diff
+    local out="$TEST_TEMP_HOME/p.txt"
+    run _gh_pr_review_build_prompt default "$out" 99 owner/repo main feature
+    assert_success
+    run grep -q 'PR DIFF (PR #99, repo owner/repo, base main → head feature)' "$out"
+    assert_success
+    run grep -q 'new dropped line' "$out"
+    assert_success
+}
+
+@test "build_prompt: a paths arg scopes the diff and says so in the header" {
+    _stub_gh_diff
+    local out="$TEST_TEMP_HOME/p.txt"
+    run _gh_pr_review_build_prompt default "$out" 99 owner/repo main feature kept.sh
+    assert_success
+    run grep -q 'scoped to: kept.sh' "$out"
+    assert_success
+    run grep -q 'new kept line' "$out"
+    assert_success
+    run grep -q 'new dropped line' "$out"
+    assert_failure
+}
+
+@test "build_prompt: a scope that matches no file fails closed (exit 3), never an empty review" {
+    # An empty diff would make the reviewer opine on nothing and answer LGTM.
+    # For the #1616 lane that answer would clear `review-blocked` on no
+    # evidence at all, so this must abort before the CLI ever runs.
+    _stub_gh_diff
+    local out="$TEST_TEMP_HOME/p.txt"
+    run _gh_pr_review_build_prompt default "$out" 99 owner/repo main feature absent.sh
+    assert_failure 3
+}
+
+@test "build_prompt: an empty UNSCOPED diff is still tolerated (unchanged behavior)" {
+    _stub_gh_diff
+    : >"$GH_STUB_DIFF_FILE"
+    local out="$TEST_TEMP_HOME/p.txt"
+    run _gh_pr_review_build_prompt default "$out" 99 owner/repo main feature
+    assert_success
+}

--- a/tests/bats/skills/_fixtures/gh_pr_reply_targeted_rereview.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_reply_targeted_rereview.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_reply_targeted_rereview.sh
+# Source-of-truth mirror for gh:pr-reply Step 6's targeted re-review lane:
+#   claude/skills/gh-pr-reply/references/targeted-rereview.md
+#   claude/skills/gh-pr-reply/references/verdict-label-removal.sh.md
+#
+# Issue #1616. Like the merge-train verdict-gate fixture beside it, this does
+# NOT re-implement the gate — it sources the shipped functions, so a mirror
+# cannot pass while production drifts (#1524).
+#
+# Keep the ORDER and the report strings in sync with the doc.
+
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_reply_targeted_review.sh"
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/devx_pr_review_all.sh"
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_edit_safe.sh"
+
+# Stands in for the doc's F-3 step: `Skill(gh:pr-review, "--ai <r> --paths
+# <fixed files> <PR> <remote>")`, then `devx_pr_review_all_verdict` over the
+# comment that run posts. Args: $1 reviewer, $2 pr, $3 repo, $4 paths,
+# $5 post-push head sha. Echoes one verdict token.
+#
+# Tests set STUB_VERDICT_<reviewer>; the default `unknown` is deliberate —
+# a lane that produced no readable verdict must never certify anything.
+pr_reply_targeted_rereview() {
+    printf 'gh:pr-review --ai %s --paths %s %s\n' "$1" "$4" "$2" >>"${LANE_LOG:-/dev/null}"
+    case "$1" in
+    codex) printf '%s\n' "${STUB_VERDICT_codex:-unknown}" ;;
+    agy) printf '%s\n' "${STUB_VERDICT_agy:-unknown}" ;;
+    claude) printf '%s\n' "${STUB_VERDICT_claude:-unknown}" ;;
+    opencode) printf '%s\n' "${STUB_VERDICT_opencode:-unknown}" ;;
+    hermes) printf '%s\n' "${STUB_VERDICT_hermes:-unknown}" ;;
+    esac
+}
+
+# Mirrors verdict-label-removal.sh.md + targeted-rereview.md, in order:
+#   1. `review-passed` is dropped unconditionally (the head advanced).
+#   2. the per-reviewer gate decides whether the targeted lane may run.
+#   3. only an independent re-review verdict may write a label, and it does
+#      so through `devx_pr_review_all_apply_label` — never inline (NF-2).
+#
+# Usage: <origin lines> | pr_reply_step6 <pr> <repo> <host> <head-sha>
+#            <space-separated fixed paths> <blocking-reviewer>...
+pr_reply_step6() {
+    local _pr="$1" _repo="$2" _host="$3" _sha="$4" _paths="$5"
+    shift 5
+    local _origins _decision _lanes _r _verdicts="" _label _report
+
+    _origins=$(cat)
+
+    _gh_pr_drop_label "$_pr" review-passed "$_repo" "$_host" >/dev/null 2>&1 || :
+
+    _decision=$(printf '%s\n' "$_origins" | _gh_pr_reply_targeted_lane_decide "$@") || return $?
+
+    case "$_decision" in
+    lane=*)
+        _lanes="${_decision#lane=}"
+        # Word-split is the contract: `lane=` carries a space-separated list.
+        # shellcheck disable=SC2086
+        for _r in $_lanes; do
+            _verdicts="${_verdicts}$(pr_reply_targeted_rereview "$_r" "$_pr" "$_repo" "$_paths" "$_sha")
+"
+        done
+        _label=$(printf '%s' "$_verdicts" | devx_pr_review_all_aggregate | sed -n 's/^label=//p')
+        printf '%s' "$_verdicts" |
+            devx_pr_review_all_apply_label "$_pr" "$_repo" "$_host" "$_sha"
+        case "$_label" in
+        review-blocked) _report="verdict=blocking" ;;
+        review-passed) _report="verdict=lgtm" ;;
+        *) _report="verdict=unknown" ;;
+        esac
+        _gh_pr_reply_targeted_lane_report "$_report"
+        ;;
+    *)
+        _gh_pr_reply_targeted_lane_report "$_decision"
+        ;;
+    esac
+}

--- a/tests/bats/skills/gh_pr_reply_targeted_rereview.bats
+++ b/tests/bats/skills/gh_pr_reply_targeted_rereview.bats
@@ -1,0 +1,355 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_reply_targeted_rereview.bats
+# Issue #1616 — gh:pr-reply Step 6's targeted re-review lane, end to end:
+#   claude/skills/gh-pr-reply/references/targeted-rereview.md   (procedure SSOT)
+#   claude/skills/gh-pr-reply/references/verdict-label-removal.sh.md
+#   claude/skills/gh-pr-reply/references/final-summary.md
+#   claude/skills/gh-pr-reply/references/constraints.md
+# Source-of-truth fixture: _fixtures/gh_pr_reply_targeted_rereview.sh
+#
+# The fixture does NOT re-implement the gate — it sources the shipped
+# shell-common/functions/gh_pr_reply_targeted_review.sh and the shipped
+# devx_pr_review_all.sh, so a mirror cannot pass while the production
+# functions drift (#1524's rule).
+#
+# Acceptance criteria from the issue, in order:
+#   AC-1 blocking reviewer fully ACCEPTed + another reviewer's DECLINE
+#        -> review-blocked is not left stuck; the targeted lane runs
+#   AC-2 non-blocking re-review -> review-blocked dropped, review-passed
+#        applied, WITHOUT a devx:pr-review-all fan-out
+#   AC-3 still-blocking re-review -> review-blocked kept + said so
+#   AC-4 any originally-blocking item still DECLINEd -> lane never called
+#   AC-5 reviewer CLI absent / non-internal env -> "full re-run needed"
+
+load '../test_helper'
+
+FIXTURE='tests/bats/skills/_fixtures/gh_pr_reply_targeted_rereview.sh'
+
+setup() {
+    setup_isolated_home
+    SKILL_DIR="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-reply"
+    GH_LOG="${BATS_TEST_TMPDIR}/gh.log"
+    LANE_LOG="${BATS_TEST_TMPDIR}/lane.log"
+    : >"$GH_LOG"
+    : >"$LANE_LOG"
+    export GH_LOG LANE_LOG
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
+    # Every reviewer CLI is present unless a test says otherwise.
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_reply_lane_available() { return 0; }
+    # shellcheck disable=SC2317  # called indirectly by the helpers under test
+    gh() {
+        printf 'gh %s [GH_HOST=%s]\n' "$*" "${GH_HOST-}" >>"$GH_LOG"
+        return 0
+    }
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# The PR #1609 shape: codex raised (and got) 2 BLOCKER fixes, agy raised 3
+# non-blocking FOLLOW-UPs that were all validly declined.
+_origins_1609() {
+    printf '%s\n' \
+        codex:BLOCKER:ACCEPT \
+        codex:BLOCKER:ACCEPT \
+        agy:FOLLOW-UP:DECLINE \
+        agy:FOLLOW-UP:DECLINE \
+        agy:FOLLOW-UP:DECLINE
+}
+
+# ---------------------------------------------------------------------
+# AC-1 / AC-2
+# ---------------------------------------------------------------------
+
+@test "AC-1: a non-blocking reviewer's DECLINE no longer pins review-blocked" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh b.sh' codex
+    run cat "$LANE_LOG"
+    assert_output --partial 'gh:pr-review --ai codex'
+}
+
+@test "AC-1: the targeted call is scoped to the fix commit's files only" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh b.sh' codex
+    run cat "$LANE_LOG"
+    assert_output --partial '--paths a.sh b.sh'
+}
+
+@test "AC-2: a non-blocking re-review applies review-passed" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    assert_output --partial 'pr edit 1609 --repo acme/widget --add-label review-passed'
+}
+
+@test "AC-2: applying review-passed deletes review-blocked first" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1609/labels/review-blocked'
+}
+
+@test "AC-2: only the ONE targeted lane runs — no devx:pr-review-all fan-out" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh' codex
+    run cat "$LANE_LOG"
+    assert_output --partial '--ai codex'
+    refute_output --partial '--ai agy'
+    refute_output --partial '--ai opencode'
+    refute_output --partial '--ai hermes'
+    run bash -c "wc -l <'$LANE_LOG'"
+    assert_output '1'
+}
+
+@test "AC-2 (NF-1): the label carries the POST-push head sha as its freshness marker" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    assert_output --partial 'review-verdict:review-passed:newsha'
+}
+
+@test "AC-2: every gh call pins the target host (#1403 / #1407)" {
+    STUB_VERDICT_codex=lgtm
+    _origins_1609 | pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh' codex
+    run grep -c 'GH_HOST=ghe.example.com' "$GH_LOG"
+    assert_success
+    refute_output '0'
+}
+
+@test "AC-2: CONCERNS is non-blocking too" {
+    STUB_VERDICT_codex=concerns
+    _origins_1609 | pr_reply_step6 1609 acme/widget '' newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    assert_output --partial '--add-label review-passed'
+}
+
+# ---------------------------------------------------------------------
+# AC-3 — still blocking
+# ---------------------------------------------------------------------
+
+@test "AC-3: a still-blocking re-review keeps review-blocked" {
+    STUB_VERDICT_codex=blocking
+    _origins_1609 | pr_reply_step6 1609 acme/widget '' newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    assert_output --partial '--add-label review-blocked'
+    refute_output --partial '--add-label review-passed'
+}
+
+@test "AC-3: the report says the targeted re-review is still blocking" {
+    STUB_VERDICT_codex=blocking
+    run bash -c "STUB_VERDICT_codex=blocking
+        . '${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}'
+        _gh_pr_reply_lane_available() { return 0; }
+        gh() { return 0; }
+        printf '%s\n' codex:BLOCKER:ACCEPT | pr_reply_step6 1609 acme/widget '' newsha a.sh codex"
+    assert_success
+    assert_output --partial '타겟 재검토도 여전히 BLOCKING — 재수정 필요'
+}
+
+# ---------------------------------------------------------------------
+# AC-4 — an unresolved blocker never spends an API call
+# ---------------------------------------------------------------------
+
+@test "AC-4: a DECLINEd BLOCKER never calls the targeted lane" {
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}'
+        _gh_pr_reply_lane_available() { return 0; }
+        gh() { printf 'gh %s\n' \"\$*\" >>'$GH_LOG'; return 0; }
+        printf '%s\n' codex:BLOCKER:ACCEPT codex:BLOCKER:DECLINE \
+          | pr_reply_step6 1609 acme/widget '' newsha a.sh codex"
+    assert_success
+    assert_output --partial 'review-blocked 유지'
+    run cat "$LANE_LOG"
+    assert_output ''
+}
+
+@test "AC-4: an unresolved blocker never adds review-passed" {
+    printf '%s\n' codex:BLOCKER:DECLINE |
+        pr_reply_step6 1609 acme/widget '' newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    refute_output --partial '--add-label review-passed'
+}
+
+@test "AC-4: review-passed is still invalidated on every push (unchanged rule)" {
+    printf '%s\n' codex:BLOCKER:DECLINE |
+        pr_reply_step6 1609 acme/widget ghe.example.com newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1609/labels/review-passed'
+}
+
+# ---------------------------------------------------------------------
+# AC-5 — the safe fallback
+# ---------------------------------------------------------------------
+
+@test "AC-5: an unavailable reviewer CLI asks for the full re-run and calls nothing" {
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}'
+        _gh_pr_reply_lane_available() { return 1; }
+        gh() { return 0; }
+        printf '%s\n' codex:BLOCKER:ACCEPT \
+          | pr_reply_step6 1609 acme/widget '' newsha a.sh codex"
+    assert_success
+    assert_output --partial '전체 devx:pr-review-all 재실행 필요'
+    run cat "$LANE_LOG"
+    assert_output ''
+}
+
+@test "AC-5: an unavailable reviewer CLI never adds review-passed" {
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    _gh_pr_reply_lane_available() { return 1; }
+    printf '%s\n' codex:BLOCKER:ACCEPT |
+        pr_reply_step6 1609 acme/widget '' newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    refute_output --partial '--add-label review-passed'
+}
+
+# ---------------------------------------------------------------------
+# NF-2 — gh:pr-reply may never self-certify
+# ---------------------------------------------------------------------
+
+@test "NF-2: a re-review that produced no verdict leaves the PR unlabelled" {
+    STUB_VERDICT_codex=unknown
+    run bash -c "STUB_VERDICT_codex=unknown
+        . '${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}'
+        _gh_pr_reply_lane_available() { return 0; }
+        gh() { printf 'gh %s\n' \"\$*\" >>'$GH_LOG'; return 0; }
+        printf '%s\n' codex:BLOCKER:ACCEPT | pr_reply_step6 1609 acme/widget '' newsha a.sh codex"
+    assert_success
+    run cat "$GH_LOG"
+    refute_output --partial '--add-label review-passed'
+}
+
+@test "NF-2: the lane is the only thing that can produce review-passed" {
+    # No verdict source at all -> nothing may be certified.
+    # shellcheck disable=SC2317  # called indirectly by the function under test
+    pr_reply_targeted_rereview() { printf '\n'; }
+    printf '%s\n' codex:BLOCKER:ACCEPT |
+        pr_reply_step6 1609 acme/widget '' newsha 'a.sh' codex
+    run cat "$GH_LOG"
+    refute_output --partial '--add-label review-passed'
+}
+
+# ---------------------------------------------------------------------
+# Doc guards — the fixture is only trustworthy while the docs agree
+# ---------------------------------------------------------------------
+
+@test "doc-guard: targeted-rereview.md exists and names the gate functions" {
+    run grep -qF -- '_gh_pr_reply_targeted_lane_decide' \
+        "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+    run grep -qF -- '_gh_pr_reply_origin_line' \
+        "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+    run grep -qF -- '_gh_pr_reply_targeted_lane_report' \
+        "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+}
+
+@test "doc-guard: targeted-rereview.md routes the label through the shared writer" {
+    run grep -qF -- 'devx_pr_review_all_apply_label' \
+        "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+}
+
+@test "doc-guard: targeted-rereview.md scopes the re-call with --paths" {
+    run grep -qF -- '--paths' "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+}
+
+@test "doc-guard: targeted-rereview.md forbids the large-diff delegation path" {
+    run grep -qF -- 'large-diff' "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+}
+
+@test "doc-guard: targeted-rereview.md states NF-2 (never self-certify)" {
+    run grep -qF -- 'NF-2' "${SKILL_DIR}/references/targeted-rereview.md"
+    assert_success
+}
+
+# The whole issue: this exact expression is what pinned review-blocked on
+# PR #1609. Its removal is the fix, so its return is the regression.
+@test "doc-guard: the global DECLINED_COUNT gate is gone from the removal doc" {
+    run grep -qE 'DECLINED_COUNT.*-eq 0|DECLINED_COUNT == 0' \
+        "${SKILL_DIR}/references/verdict-label-removal.sh.md"
+    assert_failure
+}
+
+@test "doc-guard: the removal doc still drops review-passed unconditionally on push" {
+    run grep -qF -- 'review-passed' "${SKILL_DIR}/references/verdict-label-removal.sh.md"
+    assert_success
+    run grep -qF -- '_gh_pr_drop_label' "${SKILL_DIR}/references/verdict-label-removal.sh.md"
+    assert_success
+}
+
+@test "doc-guard: the removal doc hands review-blocked to the targeted lane" {
+    run grep -qF -- 'targeted-rereview.md' \
+        "${SKILL_DIR}/references/verdict-label-removal.sh.md"
+    assert_success
+}
+
+# The invalidation SSOT lives in the shell library's header (#1563). It
+# spelled the replaced global rule out verbatim; leaving it there would make
+# the SSOT contradict the shipped behaviour.
+@test "doc-guard: the #1563 invalidation SSOT no longer states the global counter rule" {
+    run grep -qE 'ACCEPTED_COUNT > 0 && DECLINED_COUNT == 0' \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_edit_safe.sh"
+    assert_failure
+}
+
+@test "doc-guard: the #1563 invalidation SSOT points at the per-reviewer gate" {
+    run grep -qF -- '_gh_pr_reply_targeted_lane_decide' \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_edit_safe.sh"
+    assert_success
+}
+
+# devx:pr-review-all's reference doc is the label-lifecycle SSOT. Since #1616
+# there is a second caller of the writer, and a reader who does not know that
+# would conclude a review-passed on a gh:pr-reply pass was forged.
+@test "doc-guard: the label-lifecycle SSOT names gh:pr-reply's targeted lane as a second producer" {
+    local _producer="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/devx-pr-review-all/references/review-verdict-label.md"
+    run grep -qF -- '#1616' "$_producer"
+    assert_success
+    run grep -qF -- 'gh:pr-reply' "$_producer"
+    assert_success
+}
+
+@test "doc-guard: SKILL.md Step 3 records the per-reviewer origin token" {
+    run grep -qF -- '<reviewer>:<severity>:<verdict>' "${SKILL_DIR}/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: SKILL.md Step 6 runs the targeted lane" {
+    run grep -qF -- 'targeted-rereview.md' "${SKILL_DIR}/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: final-summary.md reports the per-reviewer breakdown and the lane outcome" {
+    run grep -qF -- '_gh_pr_reply_origin_tally' "${SKILL_DIR}/references/final-summary.md"
+    assert_success
+    run grep -qF -- '타겟 재검토' "${SKILL_DIR}/references/final-summary.md"
+    assert_success
+}
+
+@test "doc-guard: constraints.md pins NF-2" {
+    run grep -qF -- 'NF-2' "${SKILL_DIR}/references/constraints.md"
+    assert_success
+}
+
+@test "doc-guard: gh:pr-review documents the --paths scope flag" {
+    local _review_dir="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-review"
+    run grep -qF -- '--paths' "${_review_dir}/SKILL.md"
+    assert_success
+    run grep -qF -- '--paths' "${_review_dir}/references/help.md"
+    assert_success
+}
+
+@test "doc-guard: gh:pr-review says --paths stays on the inline path" {
+    local _review_dir="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-review"
+    run grep -qF -- '--paths' "${_review_dir}/SKILL.md"
+    assert_success
+    run grep -q 'inline' "${_review_dir}/SKILL.md"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- `gh:pr-reply`의 `review-blocked` 해제 조건을 전역 카운터(`ACCEPTED_COUNT>0 && DECLINED_COUNT==0`)에서 리뷰어·심각도 단위 게이트로 정밀화한다.
- 원래 블로킹을 낸 리뷰어의 항목이 전부 해소됐을 때만, 그 리뷰어 하나를 수정 파일 범위로 재호출하는 저비용 타겟 재검토 lane을 `gh:pr-reply`에 추가한다.
- `gh:pr-review`에 `--paths` 옵션을 신설해, 재호출이 PR 전체 크기와 무관하게 head-sha 태깅되는 small-diff 경로를 타도록 한다.

## Changes
- `claude/skills/gh-pr-reply/SKILL.md`, `references/verdict-label-removal.sh.md`, `references/final-summary.md`, `references/constraints.md`: Step 3 평가에 `<reviewer>:<severity>:<verdict>` 단위 기록 추가, Step 6에 타겟 재검토 lane 배선, 보고 형식/제약 갱신.
- `claude/skills/gh-pr-reply/references/targeted-rereview.md` (신규): 타겟 lane 설계 SSOT — 게이트 판정, 재호출 조건, `review-passed` 부착 경로(NF-2 자가인증 금지 포함).
- `shell-common/functions/gh_pr_reply_targeted_review.sh` (신규): `_gh_pr_reply_origin_line` / `_gh_pr_reply_origin_tally` / `_gh_pr_reply_targeted_lane_decide` / `_gh_pr_reply_targeted_lane_report` — 리뷰어별 게이트 판정 + 재호출 가용성 확인 함수.
- `claude/skills/gh-pr-review/SKILL.md`, `references/help.md`, `shell-common/functions/gh_pr_review.sh`: 반복 가능한 `--paths <path>` 옵션 추가 — diff를 지정 파일로 필터링하고, 매칭 파일이 없으면 exit 3(빈 리뷰 대신 fail-closed).
- `shell-common/functions/gh_pr_edit_safe.sh`: 라벨 적용 경로가 타겟 lane에서도 재사용 가능하도록 소폭 조정.
- `claude/skills/devx-pr-review-all/references/review-verdict-label.md`: `review-passed`의 두 번째 발급 경로(타겟 lane)를 SSOT에 명시.
- `tests/bats/functions/gh_pr_reply_targeted_review.bats`, `tests/bats/functions/gh_pr_review_paths_scope.bats`, `tests/bats/skills/gh_pr_reply_targeted_rereview.bats` (+fixture) (신규): F-1~F-7, NF-1/NF-2, AC-1~5 회귀 커버리지.
- `docs/public/changelog.d/2026-08-31-1616.md` (신규): 변경 fragment.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_reply_targeted_review.bats tests/bats/functions/gh_pr_review_paths_scope.bats tests/bats/skills/gh_pr_reply_targeted_rereview.bats` — 84/84 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all.bats tests/bats/functions/devx_pr_review_all_verdict.bats tests/bats/functions/devx_pr_review_all_source_path.bats` — 103/103 통과 (회귀 없음)

## Related
Closes #1616

---
<details>
<summary>🤖 AI Metrics · 📊 ~22000 tokens · 👤 ~? h · 🤖 ~225 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~22000 tokens · 👤 ~? h · 🤖 ~225 min
<!-- /ai-metrics:gh-pr -->

</details>
