### PR TITLE
chore(aicron): throttle automated workflow

### DIFF
--- a/docs/public/changelog.d/2026-08-31-1627.md
+++ b/docs/public/changelog.d/2026-08-31-1627.md
@@ -1,0 +1,1 @@
+- 변경: **issue-watcher 기본 동시 실행 상한을 저장소별 7→3, 전체 17→5로 낮추고 cron 주기를 3→4분으로 조정한다. merge-train cron 주기도 2→3분으로 조정하며, tick당 투입 상한은 1로 유지한다. 변경된 스케줄을 적용하려면 각 잡을 `aicron remove` 후 `aicron add`로 재설치해야 한다. (#1627)**

--- a/shell-common/tools/custom/aicron.sh
+++ b/shell-common/tools/custom/aicron.sh
@@ -118,7 +118,7 @@ aicron_usage() {
     ux_info ""
     ux_section "Examples"
     ux_bullet_sub "aicron list"
-    ux_bullet_sub "aicron add issue-watcher --schedule '*/3 * * * *'"
+    ux_bullet_sub "aicron add issue-watcher --schedule '*/4 * * * *'"
     ux_bullet_sub "aicron pause merge-train"
     ux_bullet_sub "aicron status issue-watcher --json | jq .last_exit"
     return 0

--- a/shell-common/tools/custom/cron-jobs.json
+++ b/shell-common/tools/custom/cron-jobs.json
@@ -10,7 +10,7 @@
     {
       "name": "issue-watcher",
       "script": "shell-common/tools/custom/issue_watcher_cron.sh",
-      "schedule": "*/3 * * * *",
+      "schedule": "*/4 * * * *",
       "args": ["--cwd", "$HOME/dotfiles"],
       "env": {},
       "description": "할당 이슈 감시 후 gh:issue-flow 디스패치"
@@ -18,7 +18,7 @@
     {
       "name": "merge-train",
       "script": "shell-common/tools/custom/pr_merge_train_cron.sh",
-      "schedule": "*/2 * * * *",
+      "schedule": "*/3 * * * *",
       "args": ["--cwd", "$HOME/dotfiles"],
       "env": {},
       "description": "열린 PR 을 순차 정리·머지"

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -130,7 +130,7 @@ _iw_cap() {
 }
 
 _IW_MAX_PER_REPO=$(_iw_cap "${IW_MAX_PER_REPO-}" 3 IW_MAX_PER_REPO)
-_IW_MAX_CONCURRENT=$(_iw_cap "${IW_MAX_CONCURRENT-}" 17 IW_MAX_CONCURRENT)
+_IW_MAX_CONCURRENT=$(_iw_cap "${IW_MAX_CONCURRENT-}" 5 IW_MAX_CONCURRENT)
 _IW_DISPATCH_PER_TICK=$(_iw_cap "${IW_DISPATCH_PER_TICK-}" 1 IW_DISPATCH_PER_TICK)
 # How long a pane has to keep looking stopped before the tick believes it.
 # A single tick sees one snapshot, and in that snapshot a finished session and
@@ -3292,7 +3292,7 @@ _iw_usage() {
     ux_bullet_sub "the resolved directory must already exist — the tick fails fast otherwise"
     ux_bullet_sub "it must also hold a parseable .credentials.json — a logged-out account stalls every prompt"
     ux_bullet "crontab"
-    ux_bullet_sub "*/3 * * * * /path/to/issue_watcher_cron.sh >> ~/.local/state/issue-watcher/cron.log 2>&1"
+    ux_bullet_sub "*/4 * * * * /path/to/issue_watcher_cron.sh >> ~/.local/state/issue-watcher/cron.log 2>&1"
 }
 
 # ============================================================

--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -999,7 +999,7 @@ _pmt_usage() {
     ux_bullet_sub "that directory must exist and hold a parseable .credentials.json"
     ux_bullet_sub "  (a logged-out account stalls every prompt — the tick fails fast instead)"
     ux_bullet "crontab"
-    ux_bullet_sub "*/2 * * * * /path/to/pr_merge_train_cron.sh --cwd ~/dotfiles >> ~/.local/state/pr-merge-train/cron.log 2>&1"
+    ux_bullet_sub "*/3 * * * * /path/to/pr_merge_train_cron.sh --cwd ~/dotfiles >> ~/.local/state/pr-merge-train/cron.log 2>&1"
 }
 
 # ============================================================

--- a/tests/bats/tools/aicron.bats
+++ b/tests/bats/tools/aicron.bats
@@ -1378,12 +1378,12 @@ _shipped_env() {
     _shipped_manifest_call aicron_manifest_env "$1"
 }
 
-@test "aicron: the shipped issue-watcher job runs every 3 minutes (#1579)" {
+@test "aicron: the shipped issue-watcher job runs every 4 minutes (#1627)" {
     # Installing this is a separate step — the crontab keeps whatever schedule
     # it was added with, and `aicron doctor` is what reports the drift.
     run _shipped_manifest_call aicron_manifest_schedule issue-watcher
     assert_success
-    assert_output "*/3 * * * *"
+    assert_output "*/4 * * * *"
 }
 
 @test "aicron: the shipped issue-watcher job is routed at the work1 account" {
@@ -1398,10 +1398,10 @@ _shipped_env() {
     assert_line "CLAUDE_DEFAULT_ACCOUNT=work1"
 }
 
-@test "aicron: the shipped merge-train job runs every 2 minutes (#1586)" {
+@test "aicron: the shipped merge-train job runs every 3 minutes (#1627)" {
     # Installing this is a separate step — the crontab keeps whatever schedule
     # it was added with, and `aicron doctor` is what reports the drift.
     run _shipped_manifest_call aicron_manifest_schedule merge-train
     assert_success
-    assert_output "*/2 * * * *"
+    assert_output "*/3 * * * *"
 }

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -1002,11 +1002,11 @@ _assert_not_hung() {
 
 @test "issue_watcher_cron: --help documents the crontab registration example" {
     # #1579 codex review: the example must match the shipped cron-jobs.json
-    # cadence (*/3), or a reader following --help literally installs a
-    # cron entry running 6x less often than the manifest's own default.
+    # cadence (*/4), or a reader following --help literally installs a
+    # cron entry running more slowly than the manifest's own default.
     run bash "${SCRIPT}" --help
     assert_success
-    assert_output --partial "*/3 * * * *"
+    assert_output --partial "*/4 * * * *"
     assert_output --partial "issue_watcher_cron.sh"
     assert_output --partial "cron.log"
 }

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -403,12 +403,12 @@ _hold_lock() {
 
 @test "pr_merge_train_cron: --help documents the crontab registration example" {
     # #1586: the example must match the shipped cron-jobs.json cadence
-    # (*/2), or a reader following --help literally installs a cron entry
-    # running 2.5x slower than the manifest's own default — the same drift
+    # (*/3), or a reader following --help literally installs a cron entry
+    # running more slowly than the manifest's own default — the same drift
     # class #1579/#1580 caught for issue-watcher's own --help example.
     run bash "${SCRIPT}" --help
     assert_success
-    assert_output --partial "*/2 * * * *"
+    assert_output --partial "*/3 * * * *"
     assert_output --partial "pr_merge_train_cron.sh"
     assert_output --partial "cron.log"
 }


### PR DESCRIPTION
## Summary
- issue-watcher의 기본 동시 실행 상한을 저장소별 3개, 전체 5개로 제한한다.
- watcher와 merge-train의 cron backstop 주기를 각각 4분과 3분으로 조정한다.

## Changes
- cron-jobs.json 및 각 cron 도움말의 스케줄을 동기화한다.
- aicron 도움말, Bats 기대값, changelog fragment를 새 운영 정책에 맞춘다.

## Test plan
- [x] mise run lint
- [x] 변경 스크립트 Bash/Zsh 문법 검사, manifest 스케줄 확인, changelog lint
- [ ] mise run test — Bats submodule 부재로 shell unit test가 실행되지 않았고, integration pytest는 worker 대기 상태로 종료했다.

## Related
Closes #1627

---
<details>
<summary>AI Metrics · ~2000 tokens · ~0.5 h · ~0 min</summary>

<!-- ai-metrics:gh-pr -->
~2000 tokens · ~0.5 h · ~0 min
<!-- /ai-metrics:gh-pr -->

</details>