### PR TITLE
feat(aicron): list STATUS 컬럼 통합 + last-run exit code literal 표기

### DIFF
--- a/docs/public/changelog.d/2026-08-31-1632.md
+++ b/docs/public/changelog.d/2026-08-31-1632.md
@@ -1,0 +1,3 @@
+- 변경: **`aicron list`의 `INSTALLED / PAUSED` 두 컬럼을 `STATUS`(running/paused/not installed/unknown) 한 컬럼으로 통합했다.**
+- 변경: **`aicron list`가 미설치 job이 있을 때 `aicron add <job>` 힌트를 표시한다.**
+- 변경: **`aicron list`/`aicron status`의 `LAST RUN` exit code 표기를 숫자에서 `ok`/`failed(N)` literal로 바꿨다.**

--- a/shell-common/tools/custom/aicron.sh
+++ b/shell-common/tools/custom/aicron.sh
@@ -94,7 +94,7 @@ aicron_usage() {
     ux_info "Usage: aicron <command> [arguments]"
     ux_info ""
     ux_section "Commands"
-    ux_table_row "list [--json]" "every manifest job: installed, paused, last run"
+    ux_table_row "list [--json]" "every manifest job: status (running/paused/not installed), last run"
     ux_table_row "add <job>" "install the job's crontab block (--schedule <expr> to override)"
     ux_table_row "remove <job>" "drop the job's crontab block (also cleans a doctor orphan); the state file is kept"
     ux_table_row "pause <job>" "stop running the job; the crontab entry stays"

--- a/shell-common/tools/custom/lib/aicron_report.sh
+++ b/shell-common/tools/custom/lib/aicron_report.sh
@@ -30,8 +30,13 @@
 # One line summarising the last run, or "never". The three keys are written
 # together by aicron_state_record, so they are read together too — one jq over
 # the state file instead of one per key, on a path `list` walks per job.
+#
+# The exit code renders as a literal (ok / failed(N)) rather than the bare
+# number — there is no standard name table for shell exit codes the way HTTP
+# has status text, so 0-vs-nonzero plus the code is the honest amount of
+# literal-ness; anything fancier would be guessing at what the code means.
 aicron_report_last() {
-    local _f _v _run
+    local _f _v _run _exit _dur _lit
     _f=$(aicron_state_file "$1")
     _v=""
     [ -f "${_f}" ] && _v=$(jq -r '
@@ -43,7 +48,14 @@ aicron_report_last() {
         return 0
     fi
     _v="${_v#*|}"
-    printf '%s (exit %s, %ss)' "${_run}" "${_v%%|*}" "${_v#*|}"
+    _exit="${_v%%|*}"
+    _dur="${_v#*|}"
+    case "${_exit}" in
+    0) _lit=ok ;;
+    '?') _lit='exit ?' ;;
+    *) _lit="failed(${_exit})" ;;
+    esac
+    printf '%s (%s, %ss)' "${_run}" "${_lit}" "${_dur}"
 }
 
 # Said once per view, on stderr, when the crontab could not be read.
@@ -116,7 +128,7 @@ aicron_report_job_json() {
 
 # <1> is "json" or "text".
 aicron_report_list() {
-    local _tmp _table _ok _n _inst _paused _last _mf _sd
+    local _tmp _table _ok _n _inst _paused _status _any_missing _last _mf _sd
     _tmp=$(aicron_mktemp aicron-list) || {
         ux_error "could not create a temp file for the job list"
         return 1
@@ -147,20 +159,33 @@ aicron_report_list() {
     fi
 
     ux_header "aicron jobs"
-    ux_table_header "JOB" "INSTALLED / PAUSED" "LAST RUN"
+    ux_table_header "JOB" "STATUS" "LAST RUN"
+    _any_missing=0
     while IFS= read -r _n; do
         [ -n "${_n}" ] || continue
         _inst=$(aicron_report_installed_text "${_table}" "${_ok}" "${_n}")
         _paused=no
         aicron_state_paused "${_n}" && _paused=yes
+        case "${_inst}" in
+        unknown) _status=unknown ;;
+        no)
+            _status="not installed"
+            _any_missing=1
+            ;;
+        yes)
+            _status=running
+            [ "${_paused}" = yes ] && _status=paused
+            ;;
+        esac
         _last=$(aicron_report_last "${_n}")
-        ux_table_row "${_n}" "installed=${_inst}  paused=${_paused}" "${_last}"
+        ux_table_row "${_n}" "${_status}" "${_last}"
     done <"${_tmp}"
     rm -f "${_tmp}" "${_table}"
 
     _mf=$(aicron_manifest_file)
     _sd=$(aicron_state_dir)
     ux_info ""
+    [ "${_any_missing}" = "1" ] && ux_bullet_sub "not installed → aicron add <job>"
     ux_bullet_sub "manifest: ${_mf}"
     ux_bullet_sub "state:    ${_sd}"
     return 0

--- a/tests/bats/tools/aicron.bats
+++ b/tests/bats/tools/aicron.bats
@@ -409,13 +409,26 @@ _capture_json() {
 # list
 # ---------------------------------------------------------------------------
 
-@test "aicron: list prints every manifest job with installed / paused / last run" {
+@test "aicron: list prints every manifest job with status and last run" {
     _aicron list
     assert_success
     assert_output --partial "hello"
     assert_output --partial "boom"
     assert_output --partial "ghost"
-    assert_output --partial "installed"
+    assert_output --partial "STATUS"
+    assert_output --partial "not installed"
+    assert_output --partial "aicron add <job>"
+
+    _aicron add hello
+    assert_success
+    _aicron list
+    assert_success
+    assert_output --partial "running"
+
+    _aicron pause hello
+    assert_success
+    _aicron list
+    assert_success
     assert_output --partial "paused"
 }
 
@@ -978,11 +991,11 @@ EOF
     assert_success
 }
 
-@test "aicron: list reports installed as unknown, not no, when the crontab cannot be read" {
+@test "aicron: list reports status as unknown, not not-installed, when the crontab cannot be read" {
     _break_crontab_dump
     _aicron list
     assert_success
-    assert_output --partial "installed=unknown"
+    assert_output --partial "unknown"
     assert_output --partial "could not read the crontab"
 
     # The warning goes to stderr so --json stays parseable, and the unknown


### PR DESCRIPTION
## Summary
- `aicron list`의 `INSTALLED / PAUSED` 두 컬럼을 `STATUS`(running/paused/not installed/unknown) 한 컬럼으로 통합했다.
- `LAST RUN`의 exit code를 숫자 대신 `ok`/`failed(N)` literal로 표기한다.

## Changes
- `shell-common/tools/custom/lib/aicron_report.sh`: `aicron_report_list()`가 크론탭 판독 실패 → 미설치 → paused → running 우선순위로 STATUS를 파생시키고, 미설치 job이 있을 때만 `aicron add <job>` 힌트를 footer에 추가한다. `aicron_report_last()`는 exit code를 `ok`/`failed(N)` literal로 렌더링한다.
- `shell-common/tools/custom/aicron.sh`: help 텍스트의 `list` 행 설명을 새 포맷에 맞게 갱신.
- `tests/bats/tools/aicron.bats`: 관련 테스트 2건을 새 STATUS 값 기준으로 갱신.
- `docs/public/changelog.d/2026-08-31-1632.md`: 변경 기록 fragment 추가.

`--json` 출력의 `installed`/`paused`/`last_exit` 필드는 그대로 유지했다 — 텍스트 렌더링 함수만 수정했다.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/aicron.bats` — 81/81 통과
- [x] `mise run lint-docs` — changelog fragment 포맷 검증 통과
- [x] 실제 `aicron list` 실행으로 STATUS/힌트/exit-literal 렌더링 육안 확인

## Related
Closes #1632

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
