### PR TITLE
feat(skills): #1410 Phase 0 — packaging-skills 마켓플레이스 repo 등록

### DIFF
--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -8,5 +8,6 @@
   "agentmemory": "rohitg00/agentmemory",
   "ponytail": "DietrichGebert/ponytail",
   "caveman": "JuliusBrussee/caveman",
-  "last30days-skill": "mvanhorn/last30days-skill"
+  "last30days-skill": "mvanhorn/last30days-skill",
+  "packaging-skills": "dEitY719/packaging-skills"
 }

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -10,6 +10,7 @@
     "hookify@claude-plugins-official",
     "last30days@last30days-skill",
     "obsidian@obsidian-skills",
+    "packaging@packaging-skills",
     "playwright@claude-plugins-official",
     "plugin-dev@claude-plugins-official",
     "ponytail@ponytail",

--- a/docs/public/changelog.d/2026-08-31-1638.md
+++ b/docs/public/changelog.d/2026-08-31-1638.md
@@ -1,0 +1,4 @@
+- 변경: **`dEitY719/packaging-skills` 레포를 신설하고 `claude-plugin-{create,rename-repo,structure-check,structure-refactor}` 4개 스킬을 `packaging` 플러그인으로 이관했다 — #1410 스킬 마켓플레이스 분리 계획의 Phase 0. 스킬 디렉터리에서 `claude-plugin-` 접두사를 떼고 호출 형식은 `/claude-plugin:structure-check` → `/packaging:structure-check` 로 바뀐다 (#1638)**
+- 변경: **새 레포는 6개 하네스 매니페스트(Claude Code / Codex / Kimi / Hermes / OpenCode / Gemini·Antigravity)를 레포 루트에 두고 `skills/` 단일 평면 트리를 가리키는 구조다 — `plugins/<name>/skills/` 중첩(mono) 레이아웃은 Claude Code 만 인식하므로 의도적으로 쓰지 않았다**
+- 변경: **`claude/plugin/marketplaces.json` 에 `packaging-skills`, `claude/plugin/plugins.json` 에 `packaging@packaging-skills` 를 등록했다 — `claude/plugin/restore.sh` 가 새 항목을 복원 대상으로 인식한다**
+- 변경: **dotfiles 의 기존 `claude/skills/claude-plugin-*` 4개 디렉터리는 그대로 남는다 — 삭제는 #1410 Phase 4 의 별도 이슈 몫이다**

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -18,3 +18,20 @@ load '../test_helper'
     run git -C "${_BATS_REAL_DOTFILES_ROOT}" check-ignore -q claude/plugin/company/dummy.json
     assert_success
 }
+
+@test "every plugins.json entry's marketplace key exists in marketplaces.json" {
+    run jq -e --slurpfile mp "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/marketplaces.json" \
+        '[.plugins[] | split("@")[1]] - ($mp[0] | keys) == []' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/plugins.json"
+    assert_success
+}
+
+@test "packaging-skills marketplace and packaging plugin are registered (#1638)" {
+    run jq -e '."packaging-skills" == "dEitY719/packaging-skills"' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/marketplaces.json"
+    assert_success
+
+    run jq -e '.plugins | index("packaging@packaging-skills") != null' \
+        "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/plugins.json"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- #1410 Phase 0을 실행해 `dEitY719/packaging-skills` 마켓플레이스 repo를 신설하고, `claude-plugin-{create,rename-repo,structure-check,structure-refactor}` 4개 스킬을 `packaging` 플러그인으로 이관했다.
- 새 repo는 6개 하네스(Claude Code/Codex/Kimi/Hermes/opencode/Gemini·Antigravity) 매니페스트를 repo 루트에 두고 `skills/` 단일 평면 트리를 가리키는 구조다 — `claude-plugin:create` 스킬의 기본 "mono" 레이아웃(`plugins/<name>/skills/` 중첩)은 Claude Code 전용이라 #1410 P-1이 지적한 문제를 그대로 재현하므로 사용하지 않았다.
- dotfiles `claude/plugin/{marketplaces,plugins}.json`에 새 repo/plugin을 등록했다.

## Changes
- `claude/plugin/marketplaces.json`, `claude/plugin/plugins.json`: `packaging-skills` 마켓플레이스와 `packaging@packaging-skills` 플러그인 항목 추가 — `restore.sh --dry-run`이 신규 항목을 인식함을 확인.
- `docs/public/changelog.d/2026-08-31-1638.md`: 변경 기록 fragment 추가.
- (새 repo, 이 PR에는 포함되지 않음) `dEitY719/packaging-skills`: 4개 스킬 이관 + 6-하네스 스켈레톤 신규 생성, public/MIT, 초기 커밋에 `Extracted from dotfiles@01733387` 표기.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/test` — pytest 1619 passed / 1 pre-existing failure(`test_committed_docs_match_a_fresh_render`), bats 12/149 pre-existing failures — 변경 전/후 실패 집합 동일, 회귀 없음.
- [x] `claude/plugin/restore.sh --dry-run`이 `packaging-skills` / `packaging@packaging-skills`를 신규 항목으로 인식.
- [x] dotfiles `claude/skills/claude-plugin-*` 4개 원본 디렉터리 무변경 확인 (`git status --porcelain` empty).
- [ ] 새 repo에서 Claude Code `/plugin marketplace add dEitY719/packaging-skills` + `/plugin install packaging` 실제 설치 확인 (수동, 이 PR 범위 밖).

## Related
Closes #1638

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~8 h (1 d) · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~8 h (1 d) · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
