### PR TITLE
fix(gcp-scan): 대량 배치에서 Stage-1.6 무력화와 conflict 1건의 전체 포기 버그 수정

### DIFF
--- a/shell-common/functions/gcp.sh
+++ b/shell-common/functions/gcp.sh
@@ -187,6 +187,8 @@ _gcp_help_rows_scan() {
     ux_table_row "skip list" "registered SHAs skipped silently" "ignored under --author=all"
     ux_table_row "--show-skip-paths" "print path-excluded paths" "git/config/gcp-scan-skip-paths.conf"
     ux_table_row "skip paths" "commits touching only listed paths skipped" "ignored under --author=all"
+    ux_table_row "behavior" "unpredicted conflict -> rolled back, batch continues" "reported under Needs manual resolution (issue #1647)"
+    ux_table_row "--stop-on-conflict" "abort whole remaining batch on first conflict" "legacy all-or-nothing behavior"
 }
 
 _gcp_help_rows_theirs() {

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -1615,8 +1615,10 @@ $deferred_list
 EOF
         if type ux_info >/dev/null 2>&1; then
             ux_info "Resolve each manually, or — if HEAD is already a superset of the change — register it in git/config/gcp-scan-skip.conf."
+            ux_info "Also review the commits that DID apply after the ones above: static prediction can't see cross-file dependencies, so an already-applied commit may silently assume content a deferred commit was supposed to add (issue #1647, codex review PR #1649)."
         else
             echo "ℹ Resolve each manually, or — if HEAD is already a superset of the change — register it in git/config/gcp-scan-skip.conf." >&2
+            echo "ℹ Also review the commits that DID apply after the ones above: static prediction can't see cross-file dependencies, so an already-applied commit may silently assume content a deferred commit was supposed to add (issue #1647, codex review PR #1649)." >&2
         fi
     fi
 

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -223,15 +223,28 @@ _gcp_scan_pick_list_prior() {
     # _gcp_scan_predict_content_conflict, which used to each hand-roll this
     # walk separately.
     local target="$1" pick_list="$2"
-    local _p prior=""
+    local _p prior="" found=0
     while IFS= read -r _p; do
         [ -z "$_p" ] && continue
-        [ "$_p" = "$target" ] && break
+        if [ "$_p" = "$target" ]; then
+            found=1
+            break
+        fi
         prior="${prior}${_p}
 "
     done <<EOF
 $pick_list
 EOF
+    # $target absent from pick_list entirely -> the whole list was just
+    # accumulated as `prior` above (unchanged pre-#1647 fallback behavior).
+    # stderr-only (agy review, PR #1649): callers read this function's stdout
+    # as data, so a warning on stdout would corrupt it. Not expected to fire
+    # in practice — every call site draws $target from the same list it
+    # passes as pick_list — so this is a silent-drift detector, not a normal
+    # code path.
+    if [ "$found" -eq 0 ]; then
+        printf '[gcp-scan] %s not found in its own pick_list — using the full list as precedent (unexpected).\n' "$target" >&2
+    fi
     printf '%s' "$prior"
 }
 
@@ -1300,7 +1313,14 @@ EOF
     # tree. The read-only Analysis phase above (including Stage-2's
     # stash/pop'd probes) is unaffected — only the confirm+execute phase gates
     # here.
-    if ! git diff --quiet || ! git diff --cached --quiet; then
+    #
+    # `git status --porcelain` (not `git diff` / `git diff --cached`) is
+    # deliberate: it also catches UNTRACKED files, which neither `diff`
+    # variant reports (agy review, PR #1649). That coverage is what makes the
+    # execution loop's own untracked cleanup below safe — it can only assume
+    # "any untracked file present after a rollback came from the failed
+    # cherry-pick" because this gate already proved none pre-existed.
+    if [ -n "$(git status --porcelain)" ]; then
         if type ux_error >/dev/null 2>&1; then
             ux_error "Working tree is dirty — cherry-pick execution refuses to start."
             ux_error "Run 'git stash push -u' first, then re-run this scan."
@@ -1501,6 +1521,14 @@ $sha
                 _gcp_scan_report_conflict_stop "$sha"
                 return 1
             fi
+            # `--abort` / `reset --hard` only restore TRACKED content — a
+            # failed cherry-pick can also leave behind untracked files (e.g.
+            # a conflict side that added a new file) that neither command
+            # touches (agy review, PR #1649). Safe to sweep unconditionally
+            # here: the defect-C precondition above already refused to start
+            # on a tree with ANY pre-existing untracked file, so anything
+            # untracked now present was created by this failed attempt.
+            git clean -fd >/dev/null 2>&1
             deferred_list="${deferred_list}${sha}
 "
             deferred_count=$((deferred_count + 1))

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -162,7 +162,16 @@ _gcp_scan_preflight_is_noop() {
                     real_content_conflict=1
                     break
                 fi
-                git checkout HEAD -- "$f"
+                # `$f` may not exist in HEAD at all (e.g. both sides added it
+                # independently) -> checkout fails with a stray "pathspec …
+                # did not match" that used to leak into scan output (issue
+                # #1647, defect E). Silence it explicitly: a file that can't
+                # be restored to a HEAD state can't be called a no-op, so it
+                # is deliberately left unresolved — the resulting unmerged
+                # index already fails the staged-diff check below, which is
+                # the SAME "real work" verdict this produced before. Judgment
+                # unchanged, only the noise is gone.
+                git checkout HEAD -- "$f" 2>/dev/null || :
             done <<EOF
 $conflicted
 EOF
@@ -210,9 +219,31 @@ _gcp_scan_check_file_deps() {
     #
     # For every missing dependency it prints one "F<TAB>short_creator_sha" line
     # to stdout so the caller can name the offending file + precedent commit.
+    #
+    # pick_list ORDER matters (issue #1647, defect A): the execution loop
+    # applies pick_list in order, so a creator commit AFTER $sha in that order
+    # cannot have run yet — it is not a precedent. Only count commits BEFORE
+    # $sha. This prefix is itself an over-approximation (an earlier entry may
+    # still get skipped as a dup/no-op/path-excluded and never actually
+    # apply), but that bias is deliberately toward DEFERRING judgment rather
+    # than wrongly skipping a real dependency — the execution loop's own
+    # rollback-and-continue handling absorbs any false negative that slips
+    # through.
     local sha="$1" base="$2" source="$3" pick_list="$4"
-    local changes st f up_add rc=0 tab
+    local changes st f up_add rc=0 tab prior_prefix="" _p
     tab=$(printf '\t')
+    while IFS= read -r _p; do
+        [ -z "$_p" ] && continue
+        [ "$_p" = "$sha" ] && break
+        if [ -z "$prior_prefix" ]; then
+            prior_prefix="$_p"
+        else
+            prior_prefix="${prior_prefix}
+${_p}"
+        fi
+    done <<EOF
+$pick_list
+EOF
     # name-status of the candidate (single-parent diff -> one status letter).
     changes=$(git diff-tree --no-commit-id -r --name-status "$sha" 2>/dev/null)
     while IFS="$tab" read -r st f; do
@@ -235,11 +266,11 @@ _gcp_scan_check_file_deps() {
         # No known creator in source -> not a recognizable dependency; leave it
         # for Stage-2 / the real cherry-pick rather than guess.
         [ -z "$up_add" ] && continue
-        # Creator is among the commits we will pick first -> not missing
+        # Creator is among the commits we will pick BEFORE $sha -> not missing
         # (the --author=all path). Newline-wrapped match avoids prefix
         # collisions, mirroring the Stage-2 noop_list membership test.
         case "
-$pick_list
+$prior_prefix
 " in
             *"
 $up_add
@@ -385,12 +416,18 @@ _gcp_scan_predict_content_conflict() {
     # lines would be misread as conflicting file paths.
     conflicted=$(printf '%s\n' "$merge_out" | awk 'NR>1 { if ($0=="") exit; print }')
     [ -z "$conflicted" ] && return 0
-    # Build the set of paths touched by every OTHER pick_list commit, for the
-    # --author=all false-positive guard.
+    # Build the set of paths touched by every pick_list commit BEFORE $sha, for
+    # the --author=all false-positive guard. pick_list ORDER matters (issue
+    # #1647, defect A): the execution loop applies picks in order, so nothing
+    # AFTER $sha can have changed HEAD's copy by the time $sha is picked — it
+    # is not a precedent. `break` (not `continue`) on the self-match stops
+    # accumulating once $sha is reached, so only genuinely-prior candidates
+    # count. If $sha is absent from pick_list, the loop reads the whole list
+    # as a fallback (unchanged from before).
     other_files=""
     while IFS= read -r p; do
         [ -z "$p" ] && continue
-        [ "$p" = "$sha" ] && continue
+        [ "$p" = "$sha" ] && break
         other_files="${other_files}$(git diff-tree --no-commit-id -r --name-only "$p" 2>/dev/null)
 "
     done <<EOF
@@ -649,6 +686,7 @@ _gcp_scan() {
     local arg1="" arg2=""
     local show_skip_list=0
     local show_skip_paths=0
+    local stop_on_conflict=0
 
     # Check for incomplete cherry-pick
     if git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1; then
@@ -690,6 +728,9 @@ _gcp_scan() {
             ;;
         --show-skip-paths)
             show_skip_paths=1
+            ;;
+        --stop-on-conflict)
+            stop_on_conflict=1
             ;;
         *)
             # Store positional arguments without array syntax
@@ -1232,6 +1273,27 @@ EOF
 $final_selected_list
 EOF
 
+    # Clean-worktree precondition (issue #1647, defect C): the execution
+    # loop's rollback path (below) recovers from an unpredicted conflict with
+    # `git cherry-pick --abort` / `git reset --hard`, either of which would
+    # also wipe unrelated uncommitted work. Refuse to even prompt on a dirty
+    # tree. The read-only Analysis phase above (including Stage-2's
+    # stash/pop'd probes) is unaffected — only the confirm+execute phase gates
+    # here.
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        if type ux_error >/dev/null 2>&1; then
+            ux_error "Working tree is dirty — cherry-pick execution refuses to start."
+            ux_error "Run 'git stash push -u' first, then re-run this scan."
+        else
+            echo "Error: Working tree is dirty — cherry-pick execution refuses to start." >&2
+            echo "Run 'git stash push -u' first, then re-run this scan." >&2
+        fi
+        if [ $_xtrace_set -eq 1 ]; then
+            set -x
+        fi
+        return 1
+    fi
+
     # Interactive Confirmation
     if ! type ux_confirm >/dev/null 2>&1; then
         return 0
@@ -1260,6 +1322,7 @@ EOF
     local conflict_skipped=0
     local kr_skipped=0
     local pe_skipped=0
+    local deferred_list="" deferred_count=0
     # Cache the .git dir BEFORE any cherry-pick runs, while config is still
     # readable (issue #1213). A real conflict in a tracked-and-[include]-d
     # git/.gitconfig poisons config, so the later CHERRY_PICK_HEAD check must
@@ -1387,21 +1450,62 @@ $sha
             if [ ! -f "${_gcp_git_dir}/CHERRY_PICK_HEAD" ]; then
                 continue
             fi
-            # Genuine conflict (the pre-flight already excluded redundant ones):
-            # leave it in place with git's own conflict output for the user.
-            if type ux_error >/dev/null 2>&1; then
-                ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
+            # Genuine conflict (the pre-flight already excluded redundant
+            # ones — Stage-1.5/1.6 are static approximations that WILL miss
+            # some at scale, issue #1647). `--stop-on-conflict` restores the
+            # legacy behavior: abort the whole remaining batch here, exactly
+            # as before.
+            if [ "$stop_on_conflict" -eq 1 ]; then
+                if type ux_error >/dev/null 2>&1; then
+                    ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
+                fi
+                return 1
             fi
-            return 1
+
+            # Default (issue #1647, defect B): roll back this ONE commit and
+            # keep going, instead of losing the whole remaining batch to a
+            # single unpredicted conflict. Read the conflicted files first —
+            # the rollback below erases that information.
+            local _conflict_files _short_sha
+            _conflict_files=$(git diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ' ')
+            _short_sha=$(git rev-parse --short "$sha" 2>/dev/null)
+            git cherry-pick --abort >/dev/null 2>&1 || {
+                git cherry-pick --quit >/dev/null 2>&1
+                git reset --hard HEAD >/dev/null 2>&1
+            }
+            # Verify the rollback actually cleared the sequencer with a plain
+            # file test, not `git rev-parse` (issue #1213: the conflict itself
+            # can poison a tracked, [include]-d git config, and every git
+            # invocation dies from that instant on). If it's still there,
+            # never continue the batch on top of a live sequencer — fall
+            # through to the legacy error path instead.
+            if [ -f "${_gcp_git_dir}/CHERRY_PICK_HEAD" ]; then
+                if type ux_error >/dev/null 2>&1; then
+                    ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
+                fi
+                return 1
+            fi
+            deferred_list="${deferred_list}${sha}
+"
+            deferred_count=$((deferred_count + 1))
+            if type ux_warning >/dev/null 2>&1; then
+                ux_warning "Deferred ${_short_sha} — unpredicted conflict in ${_conflict_files}; rolled back, continuing with the rest."
+            else
+                echo "⚠ Deferred ${_short_sha} — unpredicted conflict in ${_conflict_files}; rolled back, continuing with the rest." >&2
+            fi
+            continue
         fi
     done <<EOF
 $selected_list
 EOF
 
-    # Reaching here means no unresolved conflict (a real conflict returns 1
-    # above), so report 0 conflicts.
+    # Reaching here means no UNRESOLVED sequencer state is left behind (a
+    # rollback failure returns 1 above) — deferred_count carries how many
+    # commits hit a real, unpredicted conflict and were rolled back rather
+    # than applied (issue #1647, defect D; was hardcoded "0 conflicts"
+    # regardless of outcome).
     if type ux_success >/dev/null 2>&1; then
-        ux_success "$picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        ux_success "$picked applied, $dup_skipped skipped (dup), $deferred_count deferred (conflict)"
         if [ "$kr_skipped" -gt 0 ]; then
             ux_info "($kr_skipped commit(s) skipped — known-resolved)"
         fi
@@ -1421,7 +1525,7 @@ EOF
             ux_info "($empty_skipped empty commit(s) also skipped)"
         fi
     else
-        echo "✓ $picked applied, $dup_skipped skipped (dup), 0 conflicts"
+        echo "✓ $picked applied, $dup_skipped skipped (dup), $deferred_count deferred (conflict)"
         if [ "$kr_skipped" -gt 0 ]; then
             echo "  ($kr_skipped commit(s) skipped — known-resolved)"
         fi
@@ -1442,10 +1546,48 @@ EOF
         fi
     fi
 
+    # "Needs manual resolution" (issue #1647, defect D): name every deferred
+    # commit with a copy-pasteable retry line, plus how to permanently silence
+    # a false positive (the known-resolved skip list).
+    if [ "$deferred_count" -gt 0 ]; then
+        if type ux_section >/dev/null 2>&1; then
+            ux_section "Needs manual resolution"
+        else
+            echo "=== Needs manual resolution ==="
+        fi
+        while IFS= read -r _def_sha; do
+            [ -z "$_def_sha" ] && continue
+            local _def_title _def_short
+            _def_title=$(git log --no-walk --format='%s' "$_def_sha" 2>/dev/null)
+            _def_short=$(git rev-parse --short "$_def_sha" 2>/dev/null)
+            if type ux_bullet >/dev/null 2>&1; then
+                ux_bullet "${_def_short} ${_def_title}"
+                ux_bullet "  git cherry-pick ${_def_sha}"
+            else
+                echo "  ${_def_short} ${_def_title}"
+                echo "  git cherry-pick ${_def_sha}"
+            fi
+        done <<EOF
+$deferred_list
+EOF
+        if type ux_info >/dev/null 2>&1; then
+            ux_info "Resolve each manually, or — if HEAD is already a superset of the change — register it in git/config/gcp-scan-skip.conf."
+        else
+            echo "ℹ Resolve each manually, or — if HEAD is already a superset of the change — register it in git/config/gcp-scan-skip.conf." >&2
+        fi
+    fi
+
     # Restore tracing if it was enabled
     if [ $_xtrace_set -eq 1 ]; then
         set -x
     fi
+
+    # Unfinished work (>=1 deferred commit) must not read as success to a
+    # caller/script (issue #1647, defect D).
+    if [ "$deferred_count" -gt 0 ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Note: 'gcp_scan' / 'gcp-scan' aliases live in gcp.sh and route through

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -204,6 +204,37 @@ $2
 EOF
 }
 
+_gcp_scan_report_conflict_stop() {
+    # Shared "Failed at $sha, resolve manually" message for the execution
+    # loop's two abort-the-batch exits (--stop-on-conflict, and the rollback
+    # itself failing to clear the sequencer) — issue #1647, defect B.
+    local sha="$1"
+    if type ux_error >/dev/null 2>&1; then
+        ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
+    fi
+}
+
+_gcp_scan_pick_list_prior() {
+    # Return the newline-joined pick_list entries strictly BEFORE $1 in $2's
+    # order (issue #1647, defect A). pick_list ORDER matters: the execution
+    # loop applies picks in order, so an entry AFTER $1 cannot have run yet
+    # and is not a precedent — `break` (not `continue`) on the self-match
+    # stops accumulation there. Shared by _gcp_scan_check_file_deps and
+    # _gcp_scan_predict_content_conflict, which used to each hand-roll this
+    # walk separately.
+    local target="$1" pick_list="$2"
+    local _p prior=""
+    while IFS= read -r _p; do
+        [ -z "$_p" ] && continue
+        [ "$_p" = "$target" ] && break
+        prior="${prior}${_p}
+"
+    done <<EOF
+$pick_list
+EOF
+    printf '%s' "$prior"
+}
+
 _gcp_scan_check_file_deps() {
     # File-dependency pre-check (issue #1033). Returns 1 when cherry-picking
     # commit $1 would hit a modify/delete conflict because a file it
@@ -222,28 +253,18 @@ _gcp_scan_check_file_deps() {
     #
     # pick_list ORDER matters (issue #1647, defect A): the execution loop
     # applies pick_list in order, so a creator commit AFTER $sha in that order
-    # cannot have run yet — it is not a precedent. Only count commits BEFORE
-    # $sha. This prefix is itself an over-approximation (an earlier entry may
-    # still get skipped as a dup/no-op/path-excluded and never actually
-    # apply), but that bias is deliberately toward DEFERRING judgment rather
-    # than wrongly skipping a real dependency — the execution loop's own
-    # rollback-and-continue handling absorbs any false negative that slips
-    # through.
+    # cannot have run yet — it is not a precedent. `_gcp_scan_pick_list_prior`
+    # (shared with _gcp_scan_predict_content_conflict) gives only the commits
+    # BEFORE $sha. This prefix is itself an over-approximation (an earlier
+    # entry may still get skipped as a dup/no-op/path-excluded and never
+    # actually apply), but that bias is deliberately toward DEFERRING
+    # judgment rather than wrongly skipping a real dependency — the execution
+    # loop's own rollback-and-continue handling absorbs any false negative
+    # that slips through.
     local sha="$1" base="$2" source="$3" pick_list="$4"
-    local changes st f up_add rc=0 tab prior_prefix="" _p
+    local changes st f up_add rc=0 tab prior_prefix
     tab=$(printf '\t')
-    while IFS= read -r _p; do
-        [ -z "$_p" ] && continue
-        [ "$_p" = "$sha" ] && break
-        if [ -z "$prior_prefix" ]; then
-            prior_prefix="$_p"
-        else
-            prior_prefix="${prior_prefix}
-${_p}"
-        fi
-    done <<EOF
-$pick_list
-EOF
+    prior_prefix=$(_gcp_scan_pick_list_prior "$sha" "$pick_list")
     # name-status of the candidate (single-parent diff -> one status letter).
     changes=$(git diff-tree --no-commit-id -r --name-status "$sha" 2>/dev/null)
     while IFS="$tab" read -r st f; do
@@ -395,7 +416,7 @@ _gcp_scan_predict_content_conflict() {
     #
     # Prints the first guaranteed-conflict file path to stdout when it flags.
     local sha="$1" pick_list="$2"
-    local parent merge_out conflicted f other_files p rc
+    local parent merge_out conflicted f other_files p rc prior_shas
     # Root commit (no parent) or merge commit (2+ parents): the cherry-pick
     # merge base is undefined/ambiguous -> out of scope, defer to the real
     # cherry-pick rather than probe with the wrong base.
@@ -420,18 +441,17 @@ _gcp_scan_predict_content_conflict() {
     # the --author=all false-positive guard. pick_list ORDER matters (issue
     # #1647, defect A): the execution loop applies picks in order, so nothing
     # AFTER $sha can have changed HEAD's copy by the time $sha is picked — it
-    # is not a precedent. `break` (not `continue`) on the self-match stops
-    # accumulating once $sha is reached, so only genuinely-prior candidates
-    # count. If $sha is absent from pick_list, the loop reads the whole list
-    # as a fallback (unchanged from before).
+    # is not a precedent. `_gcp_scan_pick_list_prior` stops at the self-match
+    # so only genuinely-prior candidates count; if $sha is absent from
+    # pick_list it reads the whole list as a fallback (unchanged from before).
     other_files=""
+    prior_shas=$(_gcp_scan_pick_list_prior "$sha" "$pick_list")
     while IFS= read -r p; do
         [ -z "$p" ] && continue
-        [ "$p" = "$sha" ] && break
         other_files="${other_files}$(git diff-tree --no-commit-id -r --name-only "$p" 2>/dev/null)
 "
     done <<EOF
-$pick_list
+$prior_shas
 EOF
     while IFS= read -r f; do
         [ -z "$f" ] && continue
@@ -1456,9 +1476,7 @@ $sha
             # legacy behavior: abort the whole remaining batch here, exactly
             # as before.
             if [ "$stop_on_conflict" -eq 1 ]; then
-                if type ux_error >/dev/null 2>&1; then
-                    ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
-                fi
+                _gcp_scan_report_conflict_stop "$sha"
                 return 1
             fi
 
@@ -1480,9 +1498,7 @@ $sha
             # never continue the batch on top of a live sequencer — fall
             # through to the legacy error path instead.
             if [ -f "${_gcp_git_dir}/CHERRY_PICK_HEAD" ]; then
-                if type ux_error >/dev/null 2>&1; then
-                    ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
-                fi
+                _gcp_scan_report_conflict_stop "$sha"
                 return 1
             fi
             deferred_list="${deferred_list}${sha}
@@ -1557,14 +1573,13 @@ EOF
         fi
         while IFS= read -r _def_sha; do
             [ -z "$_def_sha" ] && continue
-            local _def_title _def_short
-            _def_title=$(git log --no-walk --format='%s' "$_def_sha" 2>/dev/null)
-            _def_short=$(git rev-parse --short "$_def_sha" 2>/dev/null)
+            local _def_line
+            _def_line=$(git log --no-walk --format='%h %s' "$_def_sha" 2>/dev/null)
             if type ux_bullet >/dev/null 2>&1; then
-                ux_bullet "${_def_short} ${_def_title}"
+                ux_bullet "${_def_line}"
                 ux_bullet "  git cherry-pick ${_def_sha}"
             else
-                echo "  ${_def_short} ${_def_title}"
+                echo "  ${_def_line}"
                 echo "  git cherry-pick ${_def_sha}"
             fi
         done <<EOF

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -397,7 +397,7 @@ FIXTURE
     # so it is a real commit, never reported as a "duplicate subject".
     refute_output --partial "(duplicate subject)"
     # All three source commits are applied; nothing skipped as a dup.
-    assert_output --partial "3 applied, 0 skipped (dup), 0 conflicts"
+    assert_output --partial "3 applied, 0 skipped (dup), 0 deferred (conflict)"
     refute_output --partial "CONFLICT"
 }
 
@@ -445,7 +445,7 @@ FIXTURE
     '
     assert_success
     refute_output --partial "(duplicate subject)"
-    assert_output --partial "2 applied, 0 skipped (dup), 0 conflicts"
+    assert_output --partial "2 applied, 0 skipped (dup), 0 deferred (conflict)"
     assert_output --partial "HAS_FA"
     assert_output --partial "HAS_FB"
 }
@@ -469,7 +469,7 @@ FIXTURE
         git cat-file -e HEAD:f2.txt && echo HAS_F2
     '
     assert_success
-    assert_output --partial "2 applied, 0 skipped (dup), 0 conflicts"
+    assert_output --partial "2 applied, 0 skipped (dup), 0 deferred (conflict)"
     assert_output --partial "HAS_F1"
     assert_output --partial "HAS_F2"
     refute_output --partial "no-op pre-flight"
@@ -724,7 +724,12 @@ FIXTURE
         # will corrupt.
         rm -f "$HOME/.gitconfig"
         printf "[include]\n\tpath = %s/git/.gitconfig\n" "$repo" > "$HOME/.gitconfig"
-        printf "y\n" | _gcp_scan main source --author=all
+        # --stop-on-conflict (issue #1647): pins the legacy immediate-stop
+        # behavior this test exercises. The DEFAULT behavior since #1647 is to
+        # roll the commit back and continue the batch instead (covered by the
+        # "scan #1647" tests below) — orthogonal to what this test actually
+        # guards: that the CHERRY_PICK_HEAD check survives config poisoning.
+        printf "y\n" | _gcp_scan main source --author=all --stop-on-conflict
         echo "scan_rc=$?"
         # PR #1228 review (codex): assert the sequencer state itself, not just
         # the message text — guards against a future regression that clears
@@ -928,7 +933,7 @@ FIXTURE
     # Stage-2 pre-flight catches the context-drift commit in Analysis phase;
     # shown as "Already in HEAD (no-op)" there, no conflict ever surfaced.
     assert_output --partial "Already in HEAD (no-op):"
-    assert_output --partial "0 conflicts"
+    assert_output --partial "0 deferred (conflict)"
     refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
 }
@@ -1064,7 +1069,7 @@ FIXTURE
     # Analysis Result counter.
     assert_output --partial "Dep-missing (skipped): 1"
     # The independent commit still applied; no conflict ever surfaced.
-    assert_output --partial "0 conflicts"
+    assert_output --partial "0 deferred (conflict)"
     refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
 }
@@ -1177,7 +1182,7 @@ FIXTURE
     # Analysis Result counter.
     assert_output --partial "Content-conflict (skipped): 1"
     # The independent commit still applied; no real conflict ever surfaced.
-    assert_output --partial "0 conflicts"
+    assert_output --partial "0 deferred (conflict)"
     refute_output --partial "CONFLICT"
     refute_output --partial "Resolve and run"
 }
@@ -1669,7 +1674,7 @@ FIXTURE
     assert_success
     # The twin carries distinct content -> applied, never skipped as a dup.
     refute_output --partial "(duplicate subject)"
-    assert_output --partial "1 applied, 0 skipped (dup), 0 conflicts"
+    assert_output --partial "1 applied, 0 skipped (dup), 0 deferred (conflict)"
     # Its payload must reach main — dropping it would be the #1136 data loss.
     assert_output --partial "HAS_F2"
 }
@@ -1700,4 +1705,166 @@ FIXTURE
     assert_success
     assert_output --partial "Already in HEAD (no-op): 2"
     assert_output --partial "Nothing to do"
+}
+
+# ---------------------------------------------------------------------------
+# Issue #1647 — scan at scale: 300+ candidates applied 0 commits and left a
+# conflicted worktree. Two compounding defects:
+#
+#   A. The Stage-1.5/1.6 "precedent" guards built their pick_list membership set
+#      from the ENTIRE list instead of the commits BEFORE the candidate in pick
+#      order. With hundreds of candidates almost every conflicting file collided
+#      with SOME later commit, so the guards were effectively disabled.
+#   B. The execution loop aborted the whole remaining batch on the first
+#      unpredicted conflict. Static prediction is an approximation, so at scale
+#      one always slips through — and it took the other 356 picks down with it.
+#      The default is now: roll the single commit back, defer it, keep going.
+#      `--stop-on-conflict` restores the legacy all-or-nothing behavior.
+#   C. Because the rollback runs --abort / reset --hard, the execution phase now
+#      refuses to start on a dirty worktree (the Analysis phase is unaffected).
+#   D. The summary reports the real deferred count and lists the deferred
+#      commits under "Needs manual resolution"; a non-empty list exits 1.
+# ---------------------------------------------------------------------------
+
+_gcp1647_make_repo() {
+    # Emits shell that builds the #1647 deferred-conflict fixture and cds in.
+    #
+    #   A "conf: top edit"    — touches conf.txt far from main's edit -> merges
+    #                           cleanly, and acts as the pick_list PRECEDENT that
+    #                           makes Stage-1.6 defer B's verdict.
+    #   B "conf: bottom edit" — same line main changed -> a REAL conflict that
+    #                           only surfaces at the actual cherry-pick.
+    #   C "add clean.txt"     — an independent, conflict-free candidate AFTER B.
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp1647.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        printf 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n' > conf.txt
+        echo init > a.txt
+        git add conf.txt a.txt && git commit -qm "init"
+        git checkout -q -b source
+        printf 'A1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n' > conf.txt
+        git add conf.txt && git commit -qm "conf: top edit"
+        printf 'A1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nB10\n' > conf.txt
+        git add conf.txt && git commit -qm "conf: bottom edit"
+        echo clean > clean.txt && git add clean.txt && git commit -qm "add clean.txt"
+        git checkout -q main
+        printf 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nM10\n' > conf.txt
+        git add conf.txt && git commit -qm "main: bottom edit"
+FIXTURE
+}
+
+@test "scan #1647: a LATER pick_list commit is no precedent — verdict stays flagged (unit)" {
+    # Defect A. The precedent guard must only count commits BEFORE the candidate
+    # in pick order: the loop applies picks in order, so nothing after the
+    # candidate can have changed HEAD's copy by the time the candidate is picked.
+    # Pre-fix the whole list was scanned, so c2 (later) wrongly "covered"
+    # conf.txt and c1's guaranteed conflict was deferred (rc=0, silent).
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp1647u.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Me\" GIT_AUTHOR_EMAIL=\"me@me\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        printf 'A\nB\nC\n' > foo.txt && git add foo.txt && git commit -qm 'init'
+        git checkout -q -b source
+        printf 'A\nB2\nC\n' > foo.txt && git add foo.txt && git commit -qm 'B->B2'
+        c1=\$(git rev-parse HEAD)
+        # A LATER commit that also touches foo.txt — must NOT count as precedent.
+        printf 'A\nB3\nC\n' > foo.txt && git add foo.txt && git commit -qm 'B2->B3'
+        c2=\$(git rev-parse HEAD)
+        git checkout -q main
+        printf 'A\nBmain\nC\n' > foo.txt && git add foo.txt && git commit -qm 'main diverges'
+        out=\$(_gcp_scan_predict_content_conflict \"\$c1\" \"\$c1
+\$c2\"); rc=\$?
+        echo \"rc=\$rc out=\$out\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+    assert_output --partial "foo.txt"
+    refute_output --partial "rc=0"
+}
+
+@test "scan #1647: unpredicted conflict is deferred, batch continues, report lists it" {
+    # Defect B + D. B's conflict is invisible to Stage-1.6 (precedent A covers
+    # conf.txt) and to Stage-2 (it brings genuinely new content), so it only
+    # surfaces at the real cherry-pick. The single commit is rolled back and the
+    # batch keeps going: A and C still land, the sequencer is clean, and the
+    # report names B under "Needs manual resolution" with a copy-pasteable line.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+        git cat-file -e HEAD:clean.txt 2>/dev/null && echo HAS_CLEAN || echo NO_CLEAN
+        # Plain-file test, not rev-parse (issue #1213 precedent).
+        [ -f \"\$repo/.git/CHERRY_PICK_HEAD\" ] && echo CPH_PRESENT || echo CPH_MISSING
+        git show HEAD:conf.txt
+    "
+    assert_output --partial "Deferred"
+    assert_output --partial "conf.txt"
+    assert_output --partial "rolled back, continuing with the rest"
+    assert_output --partial "Needs manual resolution"
+    assert_output --partial "git cherry-pick "
+    assert_output --partial "gcp-scan-skip.conf"
+    # 1 deferred is reported instead of the old hardcoded "0 conflicts".
+    assert_output --partial "1 deferred (conflict)"
+    refute_output --partial "0 conflicts"
+    # The batch continued: the later clean candidate still landed.
+    assert_output --partial "HAS_CLEAN"
+    # Rollback verified — no sequencer state left behind.
+    assert_output --partial "CPH_MISSING"
+    # Unfinished work -> non-zero exit.
+    assert_output --partial "scan_rc=1"
+    # The precedent applied; the conflicting edit did not.
+    assert_output --partial "A1"
+    assert_output --partial "M10"
+    refute_output --partial "B10"
+}
+
+@test "scan #1647: --stop-on-conflict restores the legacy all-or-nothing abort" {
+    # Defect B opt-out. With the flag the first unpredicted conflict aborts the
+    # whole remaining batch exactly as before: the sequencer stays ACTIVE for the
+    # user to resolve, and later candidates are never attempted.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        printf 'y\n' | _gcp_scan main source --author=all --stop-on-conflict
+        echo \"scan_rc=\$?\"
+        git cat-file -e HEAD:clean.txt 2>/dev/null && echo HAS_CLEAN || echo NO_CLEAN
+        [ -f \"\$repo/.git/CHERRY_PICK_HEAD\" ] && echo CPH_PRESENT || echo CPH_MISSING
+    "
+    assert_output --partial "Resolve and run"
+    assert_output --partial "scan_rc=1"
+    assert_output --partial "CPH_PRESENT"
+    # Legacy behavior: the batch stopped, so the later candidate never applied.
+    assert_output --partial "NO_CLEAN"
+    refute_output --partial "rolled back, continuing with the rest"
+}
+
+@test "scan #1647: dirty worktree blocks execution BEFORE the confirmation prompt" {
+    # Defect C. The rollback path runs --abort / reset --hard, so uncommitted
+    # work must never be in the tree when the execution phase starts. The
+    # read-only Analysis phase still runs to completion on a dirty tree (Stage-2
+    # stashes/pops internally) — only the prompt + cherry-pick are refused.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        echo localedit >> a.txt
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+        grep -q localedit a.txt && echo EDIT_KEPT || echo EDIT_LOST
+        git cat-file -e HEAD:clean.txt 2>/dev/null && echo HAS_CLEAN || echo NO_CLEAN
+    "
+    # Analysis phase still ran on the dirty tree.
+    assert_output --partial "Analysis Result"
+    assert_output --partial "Commit List"
+    # Blocked before the y/N prompt, with stash guidance.
+    refute_output --partial "Do you want to cherry-pick"
+    assert_output --partial "git stash push -u"
+    assert_output --partial "scan_rc=1"
+    # Nothing was cherry-picked and the local edit is untouched.
+    assert_output --partial "EDIT_KEPT"
+    assert_output --partial "NO_CLEAN"
 }

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1973,4 +1973,8 @@ FIXTURE
     # The MITIGATION: the report still names the true deferred commit so a
     # human reviewing it can catch the dependency manually.
     assert_output --partial "conf: bottom edit"
+    # The MITIGATION, strengthened (codex review, PR #1649 follow-up): the
+    # report now explicitly warns to also check the commits that DID apply,
+    # not just the deferred ones — closing the exact gap this test pins.
+    assert_output --partial "Also review the commits that DID apply"
 }

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1349,7 +1349,7 @@ FIXTURE
         export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
                GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
         git init -q -b main
-        skipf="$repo/skip.conf"
+        skipf=$(mktemp "${TMPDIR:-/tmp}/gcp_skip.XXXXXX")
         printf "deadbeef  # inline reason\n# whole-line comment\n\ncafebabe\n" > "$skipf"
         export GCP_SCAN_SKIP_FILE="$skipf"
         _gcp_scan main upstream/main --show-skip-list
@@ -1381,7 +1381,7 @@ FIXTURE
     run_in_bash "
         $(_gcp1037_make_repo)
         conflict_sha=\$(git rev-parse source~1)
-        skipf=\"\$repo/skip.conf\"
+        skipf=\$(mktemp \"\${TMPDIR:-/tmp}/gcp_skip.XXXXXX\")
         printf '%s  # manually resolved, already in HEAD\n' \"\$conflict_sha\" > \"\$skipf\"
         export GCP_SCAN_SKIP_FILE=\"\$skipf\"
         printf 'y\n' | _gcp_scan main source --author=Me
@@ -1402,7 +1402,7 @@ FIXTURE
     run_in_bash "
         $(_gcp1037_make_repo)
         conflict_sha=\$(git rev-parse source~1)
-        skipf=\"\$repo/skip.conf\"
+        skipf=\$(mktemp \"\${TMPDIR:-/tmp}/gcp_skip.XXXXXX\")
         printf '%s\n' \"\$conflict_sha\" > \"\$skipf\"
         export GCP_SCAN_SKIP_FILE=\"\$skipf\"
         printf 'y\n' | _gcp_scan main source --author=Me >/dev/null 2>&1
@@ -1422,7 +1422,7 @@ FIXTURE
     run_in_bash "
         $(_gcp1037_make_repo)
         conflict_sha=\$(git rev-parse source~1)
-        skipf=\"\$repo/skip.conf\"
+        skipf=\$(mktemp \"\${TMPDIR:-/tmp}/gcp_skip.XXXXXX\")
         printf '%s\n' \"\$conflict_sha\" > \"\$skipf\"
         export GCP_SCAN_SKIP_FILE=\"\$skipf\"
         printf 'y\n' | _gcp_scan main source --author=all
@@ -1437,7 +1437,7 @@ FIXTURE
     run_in_bash "
         $(_gcp1037_make_repo)
         conflict_short=\$(git rev-parse --short=8 source~1)
-        skipf=\"\$repo/skip.conf\"
+        skipf=\$(mktemp \"\${TMPDIR:-/tmp}/gcp_skip.XXXXXX\")
         printf '%s  # short form\n' \"\$conflict_short\" > \"\$skipf\"
         export GCP_SCAN_SKIP_FILE=\"\$skipf\"
         printf 'y\n' | _gcp_scan main source --author=Me
@@ -1454,7 +1454,7 @@ FIXTURE
     # be detected by Stage-1.6 (i.e. the wildcard did NOT silence it).
     run_in_bash "
         $(_gcp1037_make_repo)
-        skipf=\"\$repo/skip.conf\"
+        skipf=\$(mktemp \"\${TMPDIR:-/tmp}/gcp_skip.XXXXXX\")
         printf '%s\n' '*' '?' '0' 'zz12' '012' > \"\$skipf\"
         export GCP_SCAN_SKIP_FILE=\"\$skipf\"
         printf 'y\n' | _gcp_scan main source --author=Me
@@ -1472,7 +1472,7 @@ FIXTURE
         trap "rm -rf $repo" EXIT
         cd "$repo" || exit 1
         git init -q -b main
-        skipf="$repo/skip.conf"
+        skipf=$(mktemp "${TMPDIR:-/tmp}/gcp_skip.XXXXXX")
         printf "%s\n" "*" "0" "deadbeef" "ab12  # ok" > "$skipf"
         export GCP_SCAN_SKIP_FILE="$skipf"
         _gcp_scan main upstream/main --show-skip-list
@@ -1526,7 +1526,7 @@ _gcp_pathskip_make_repo() {
         git add unrelated.txt claude/plugin/marketplaces.json \
             && git commit -qm "feat: real change"
         git checkout -q main
-        skipf="$repo/skip-paths.conf"
+        skipf=$(mktemp "${TMPDIR:-/tmp}/gcp_skip_paths.XXXXXX")
         printf 'claude/plugin/plugins.json\nclaude/plugin/marketplaces.json\n' > "$skipf"
         export GCP_SCAN_SKIP_PATHS_FILE="$skipf"
 FIXTURE
@@ -1590,7 +1590,7 @@ FIXTURE
         trap "rm -rf $repo" EXIT
         cd "$repo" || exit 1
         git init -q -b main
-        skipf="$repo/skip-paths.conf"
+        skipf=$(mktemp "${TMPDIR:-/tmp}/gcp_skip_paths.XXXXXX")
         printf "claude/plugin/plugins.json  # inline reason\n# whole-line comment\n\nclaude/plugin/marketplaces.json\n" > "$skipf"
         export GCP_SCAN_SKIP_PATHS_FILE="$skipf"
         _gcp_scan main upstream/main --show-skip-paths
@@ -1867,4 +1867,110 @@ FIXTURE
     # Nothing was cherry-picked and the local edit is untouched.
     assert_output --partial "EDIT_KEPT"
     assert_output --partial "NO_CLEAN"
+}
+
+@test "scan #1649: an untracked file (not just a tracked edit) also blocks execution" {
+    # Defect C follow-up (agy review, PR #1649): `git diff` / `git diff
+    # --cached` never report untracked files, so the original precondition
+    # missed this case entirely — an untracked file could survive into the
+    # rollback path's `git clean -fd` and be deleted as if it were debris
+    # from a failed pick. `git status --porcelain` covers it.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        echo scratch > untracked.txt
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+        [ -f untracked.txt ] && echo UNTRACKED_KEPT || echo UNTRACKED_LOST
+        git cat-file -e HEAD:clean.txt 2>/dev/null && echo HAS_CLEAN || echo NO_CLEAN
+    "
+    refute_output --partial "Do you want to cherry-pick"
+    assert_output --partial "git stash push -u"
+    assert_output --partial "scan_rc=1"
+    assert_output --partial "UNTRACKED_KEPT"
+    assert_output --partial "NO_CLEAN"
+}
+
+@test "scan #1649: untracked debris from a rolled-back conflict is cleaned up" {
+    # Defect B follow-up (agy review, PR #1649 — "Assumption" flag): `--abort`
+    # / `reset --hard` only restore TRACKED content. A failed cherry-pick that
+    # brought a genuinely new file alongside its conflicting edit would
+    # otherwise leave that file behind as untracked debris even after the
+    # commit is correctly reported as deferred. Safe to `git clean -fd`
+    # unconditionally here because defect C's precondition (previous two
+    # tests) already refused to start on a tree with ANY pre-existing
+    # untracked file.
+    run_in_bash "
+        repo=\"\$(mktemp -d \"\${TMPDIR:-/tmp}/gcp1649.XXXXXX\")\"
+        trap \"rm -rf \$repo\" EXIT
+        cd \"\$repo\" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME=\"Test\" GIT_AUTHOR_EMAIL=\"t@t\" \
+               GIT_COMMITTER_NAME=\"Test\" GIT_COMMITTER_EMAIL=\"t@t\"
+        git init -q -b main
+        printf 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n' > conf.txt
+        echo init > a.txt
+        git add conf.txt a.txt && git commit -qm 'init'
+        git checkout -q -b source
+        printf 'A1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n' > conf.txt
+        git add conf.txt && git commit -qm 'conf: top edit'
+        # The conflicting commit ALSO brings a brand-new untracked-once-reverted file.
+        printf 'A1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nB10\n' > conf.txt
+        echo debris > debris.txt
+        git add conf.txt debris.txt && git commit -qm 'conf: bottom edit + debris.txt'
+        echo clean > clean.txt && git add clean.txt && git commit -qm 'add clean.txt'
+        git checkout -q main
+        printf 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nM10\n' > conf.txt
+        git add conf.txt && git commit -qm 'main: bottom edit'
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+        [ -e debris.txt ] && echo DEBRIS_PRESENT || echo DEBRIS_GONE
+        git status --porcelain
+    "
+    assert_output --partial "Deferred"
+    assert_output --partial "1 deferred (conflict)"
+    assert_output --partial "scan_rc=1"
+    # debris.txt travelled with the deferred commit — it must not survive
+    # the rollback as orphaned untracked cruft.
+    assert_output --partial "DEBRIS_GONE"
+}
+
+@test "scan #1649: a later commit depending on a deferred one applies silently — known limitation, surfaced only via Needs manual resolution" {
+    # codex review, PR #1649 BLOCKER: static prediction cannot see semantic
+    # dependencies across files, so a later commit that logically depends on
+    # a deferred commit's content can still apply cleanly (git sees no
+    # textual conflict) — the series is left semantically incomplete with no
+    # error from git itself. This is an INHERENT limit of any
+    # approximate-prediction + partial-automation design (the issue body
+    # itself: "Stage-1.5/1.6 은 정적 근사이므로 이 규모에서 예측 실패는
+    # 필연이다"), not a regression this PR introduces — a fully general fix
+    # would require a real dependency-graph solver, out of scope here. This
+    # test pins the CURRENT, documented behavior instead of leaving it an
+    # undocumented gap: the dependent commit applies without complaint, but
+    # the true culprit (the deferred commit carrying the missing prerequisite)
+    # is still named correctly in "Needs manual resolution" — the mitigation
+    # a human review of that section is expected to catch.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        # D3 (a NEW commit after clean.txt) depends on helper content that
+        # only D2 ('conf: bottom edit') would have introduced, but touches a
+        # DIFFERENT file so git sees no conflict of its own.
+        git checkout -q source
+        echo 'source helper.sh' > caller.sh && git add caller.sh \
+            && git commit -qm 'add caller.sh (depends on conf.txt content D2 would add)'
+        git checkout -q main
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+        # D2 ('conf: bottom edit') is the one that actually conflicted+deferred.
+        git cat-file -e HEAD:caller.sh 2>/dev/null && echo HAS_CALLER || echo NO_CALLER
+        git cat-file -e HEAD:clean.txt 2>/dev/null && echo HAS_CLEAN || echo NO_CLEAN
+    "
+    assert_output --partial "scan_rc=1"
+    assert_output --partial "Needs manual resolution"
+    # The KNOWN LIMITATION: caller.sh (semantically dependent on the deferred
+    # commit) still applies — no error surfaces from that commit itself.
+    assert_output --partial "HAS_CALLER"
+    # The independent clean.txt candidate still applies too (batch continued).
+    assert_output --partial "HAS_CLEAN"
+    # The MITIGATION: the report still names the true deferred commit so a
+    # human reviewing it can catch the dependency manually.
+    assert_output --partial "conf: bottom edit"
 }


### PR DESCRIPTION
## Summary
- `gcp scan`이 후보 수백 건 규모에서 커밋 0건 적용에 그치고 충돌 worktree를 남기는 문제(#1647)를 고친다.
- precedent 판정(Stage-1.5/1.6)을 pick 순서 기준 앞선 prefix로만 한정하고, 실행 루프 기본 동작을 "conflict 1건만 롤백하고 배치 계속"으로 바꾼다.
- dirty tree 사전 차단, 정확한 deferred 커밋 카운트 리포트("Needs manual resolution" 섹션 + exit 1), Stage-2 preflight의 stderr 노이즈 제거를 함께 반영한다.

## Changes
- `shell-common/functions/gcp_scan.sh`: `_gcp_scan_predict_content_conflict` / `_gcp_scan_check_file_deps`의 precedent 판정을 pick_list 전체가 아니라 후보 이전 prefix로 한정. 실행 루프에 단일-커밋 롤백(CHERRY_PICK_HEAD 평문 검사로 검증) + `--stop-on-conflict` 레거시 opt-in 추가. 확인 프롬프트 전 dirty-tree 가드. 요약을 "N deferred (conflict)" + "Needs manual resolution" 섹션으로 교체. Stage-2 preflight의 stray stderr 침묵.
- `shell-common/functions/gcp.sh`: `--stop-on-conflict` 및 새 배치-계속 동작을 `gcp help scan` 테이블에 반영.
- `tests/bats/functions/gcp.bats`: 신규 4건(#1647) 추가. 기존 `scan #1213` 테스트는 `--stop-on-conflict`를 명시해 원래 검증 대상(CHERRY_PICK_HEAD 평문 검사가 config 오염에서도 살아남는지)을 그대로 유지하면서 새 기본 동작(배치 계속)과 충돌하지 않도록 갱신. 기존 "0 conflicts" 문자열 단언 7건은 새 "N deferred (conflict)" 포맷에 맞춰 갱신.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gcp.bats` — 92/92 통과 (신규 4건 포함, 회귀 없음)
- [x] `shellcheck` / `shfmt` (`mise run lint-sh`) — 클린
- [ ] 사내 미러에서 대량 배치(300+ 후보) 재현 확인 (이슈 본문의 실측 재현 조건 기준, 참고용)

## Related
Closes #1647

---
<details>
<summary>🤖 AI Metrics · 📊 ~9000 tokens · 👤 ~2 h · 🤖 ~25 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~2 h · 🤖 ~25 min
<!-- /ai-metrics:gh-pr -->

</details>
