### PR TITLE
fix(claude-hooks): plugin-sync 자동 커밋 off 스위치 추가

### DIFF
--- a/claude/hooks/plugin-sync.sh
+++ b/claude/hooks/plugin-sync.sh
@@ -11,7 +11,14 @@
 # See docs/feature/superpowers-specs/2026-07-01-claude-plugin-manifest-design.md
 #
 # Always exits 0 — best-effort, never blocks the session.
+#
+# Set DOTFILES_PLUGIN_SYNC_DISABLED=1 (e.g. in settings.local.json's "env")
+# to turn manifest auto-sync/auto-commit off. plugin-sync-session.sh
+# (SessionStart/Stop) drives its add/remove work through this script too, so
+# gating here covers both the CLI path and the /plugin slash-command path.
 set -u
+
+[ -z "${DOTFILES_PLUGIN_SYNC_DISABLED-}" ] || exit 0
 
 # A PostToolUse hook always receives JSON on stdin. If stdin is a terminal
 # the script was launched by hand — bail before `cat` blocks forever.


### PR DESCRIPTION
## Summary
- `claude/hooks/plugin-sync.sh`에 `DOTFILES_PLUGIN_SYNC_DISABLED` 환경변수 가드를 추가해, plugin 매니페스트 자동 sync/자동 커밋(`chore(claude-plugin): sync manifest`)을 opt-out할 수 있게 한다.
- 기본 동작은 변경 없음 — 이 변수를 명시적으로 설정한 경우에만 no-op이 된다.

## Changes
- `claude/hooks/plugin-sync.sh`: `set -u` 직후, stdin을 읽기 전에 `[ -z "${DOTFILES_PLUGIN_SYNC_DISABLED-}" ] || exit 0` 가드 추가. `claude/hooks/plugin-sync-session.sh`(SessionStart/Stop)는 `_drive_sync`로 실제 add/remove 작업을 이 스크립트에 위임하는 구조라, 이 한 곳의 가드가 CLI 경로(`claude plugin ...`)와 `/plugin` 슬래시 커맨드 경로 둘 다를 막는다.

## Test plan
- [x] `shellcheck claude/hooks/plugin-sync.sh` — clean
- [x] `tests/bats/skills/plugin_sync_session_hook.bats` (7건) + `tests/bats/skills/plugin_sync_hook_registration.bats` (8건, 그중 `path-normalize runs BEFORE plugin-sync-session in SessionStart (#1098)` 1건은 이 변경 이전에도 실패하는 워크트리 baseline 이슈로 확인, 무관) + `tests/bats/tools/plugin_sync_title_smoke.bats` (4건) — 새 회귀 없음

추적 이슈 없음(사용자 요청으로 직접 진행) — changelog fragment는 파일명이 이슈 번호를 요구하는 규칙이라 생략.

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~10 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~10 min
<!-- /ai-metrics:gh-pr -->

</details>
