### PR TITLE
feat(skills): #1410 Phase 2 — session-skills repo 생성

### DIFF
--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -15,5 +15,6 @@
   "pkm-skills": "dEitY719/pkm-skills",
   "notes-skills": "dEitY719/notes-skills",
   "visuals-skills": "dEitY719/visuals-skills",
-  "gh-resolve-skills": "dEitY719/gh-resolve-skills"
+  "gh-resolve-skills": "dEitY719/gh-resolve-skills",
+  "session-skills": "dEitY719/session-skills"
 }

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -21,6 +21,7 @@
     "ponytail@ponytail",
     "ralph-loop@claude-plugins-official",
     "session-report@claude-plugins-official",
+    "session@session-skills",
     "superpowers@claude-plugins-official",
     "understand-anything@understand-anything",
     "visuals@visuals-skills"

--- a/docs/public/changelog.d/2026-09-01-1661.md
+++ b/docs/public/changelog.d/2026-09-01-1661.md
@@ -1,0 +1,5 @@
+- 변경: **`dEitY719/session-skills` 레포를 신설하고 `{devx-restart,devx-session-close,devx-session-handoff,devx-rate-limit-guard,devx-resume-after-limit,devx-schedule,ai-worktree-spawn,ai-worktree-teardown}` 8개 스킬을 `session` 플러그인으로 이관했다 — #1410 스킬 마켓플레이스 분리 계획의 Phase 2. 도메인이 아니라 "언제 호출되는가"(세션 수명주기)로 자른 축이라, 이름은 git 도구인 `ai-worktree-*` 도 트리거가 "새 작업 시작/정리"라 같은 레포에 들어간다 (#1661)**
+- 변경: **새 레포에서는 플러그인명과 중복되는 `devx-`/`ai-worktree-` 접두를 떼 `/session:close`, `/session:worktree-spawn` 형태로 호출한다 (#1410 F-4) — dotfiles 의 `claude/skills/` 원본 8개는 그대로 남아 `/devx:session-close`, `/ai-worktree:spawn` 호출도 계속 동작한다(NF-1, 삭제는 Phase 4)**
+- 변경: **`session-skills` CI 는 `harness-skills` 의 재사용 워크플로(#1410 D-10)를 처음부터 호출한다 — 공용 게이트를 통과시키느라 `restart` 스킬의 SKILL.md 를 108줄에서 87줄로 줄였고(100줄 상한), 덜어낸 Step 1 상세는 `references/resume-target.md` 로 그대로 옮겼다**
+- 변경: **워크트리 스킬이 쓰는 런타임 파일명 `$(git rev-parse --git-common-dir)/ai-worktree-spawn.log`·`.lock` 은 리네임하지 않고 유지한다 — 이관본과 dotfiles 원본이 공존하는 Phase 2~4 구간에 락이 갈라지고 기존 로그가 고아가 되기 때문이다**
+- 변경: **`claude/plugin/marketplaces.json` 에 `session-skills`, `claude/plugin/plugins.json` 에 `session@session-skills` 를 등록했다 — `claude/plugin/restore.sh` 가 새 항목을 복원 대상으로 인식한다**

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -66,41 +66,28 @@ TABLE
     assert_success
 }
 
-# #1410 NF-1: a Phase-1 split copies its skills out, it does not move them.
+# #1410 NF-1: a phase split copies its skills out, it does not move them.
 # The dotfiles originals must survive until Phase 4 retires them deliberately,
-# so `/write:rca` keeps working for anyone who has not installed the plugin.
-# When Phase 4 does delete them, this test is the thing that must be removed
-# in the same commit — that is the point: the removal becomes a decision
-# someone makes, not a side effect nobody notices.
-@test "notes-skills split left the claude/skills/write-* originals in place (#1643)" {
-    for skill in rca insight release-note task-history blog-dev-learnings; do
-        [ -f "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/write-${skill}/SKILL.md" ] \
-            || fail "claude/skills/write-${skill}/SKILL.md is missing — #1410 NF-1 says Phase 1 copies, never moves"
-    done
-}
-
-# #1410 NF-1 의 Phase 2 판(#1660). 존재 이유와 Phase 4 삭제 규약은 바로 위
-# #1643 주석과 동일하다 — 여기서 다른 것은 대상뿐이다: gh-resolve-skills 가
-# 복사해 간 세 스킬의 원본이 남아 있어야 플러그인 미설치 환경에서도
-# /gh:pr-resolve-* 계열 호출이 계속 동작한다.
-@test "gh-resolve-skills split left the claude/skills/gh-pr-resolve-* originals in place (#1660)" {
-    for skill in ci-fail conflict outdated; do
-        [ -f "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-resolve-${skill}/SKILL.md" ] \
-            || fail "claude/skills/gh-pr-resolve-${skill}/SKILL.md is missing — #1410 NF-1 says Phase 2 copies, never moves"
-    done
-}
-
-# Same NF-1 guarantee for the Phase 2 session-skills split (#1661). The eight
-# skills moved out under new, prefix-stripped names (`devx-session-close` ->
-# `/session:close`), so the dotfiles originals are the only thing still
-# answering `/devx:session-close`. They stay until Phase 4 retires them.
-@test "session-skills split left the claude/skills originals in place (#1661)" {
-    for skill in devx-restart devx-session-close devx-session-handoff \
-                 devx-rate-limit-guard devx-resume-after-limit devx-schedule \
-                 ai-worktree-spawn ai-worktree-teardown; do
-        [ -f "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}/SKILL.md" ] \
-            || fail "claude/skills/${skill}/SKILL.md is missing — #1410 NF-1 says a phase split copies, never moves"
-    done
+# so `/write:rca`, `/gh:pr-resolve-conflict` and `/devx:session-close` keep
+# working for anyone who has not installed the plugin.
+#
+# One row per phase — the same convention the registration table above uses,
+# because this check grows the same way (#1643 was the first; #1660 and #1661
+# followed). The row, not a whole hand-copied @test block, is what a new phase
+# adds. When Phase 4 deletes a phase's originals, its row goes in the same
+# commit: the removal stays a decision someone makes, not a side effect nobody
+# notices, and the failure message names which phase broke.
+@test "split-out phases left their claude/skills originals in place (#1410 NF-1)" {
+    while IFS='|' read -r issue skills; do
+        for skill in ${skills}; do
+            [ -f "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}/SKILL.md" ] \
+                || fail "claude/skills/${skill}/SKILL.md is missing (${issue}) — #1410 NF-1 says a phase split copies, never moves"
+        done
+    done <<'TABLE'
+#1643|write-rca write-insight write-release-note write-task-history write-blog-dev-learnings
+#1660|gh-pr-resolve-ci-fail gh-pr-resolve-conflict gh-pr-resolve-outdated
+#1661|devx-restart devx-session-close devx-session-handoff devx-rate-limit-guard devx-resume-after-limit devx-schedule ai-worktree-spawn ai-worktree-teardown
+TABLE
 }
 
 # claude-plugin-visuals 는 #1646 에서 visuals-skills 로 rename 됐다. GitHub 이

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -52,6 +52,7 @@ devenv-skills|dEitY719/devenv-skills|devenv
 notes-skills|dEitY719/notes-skills|notes
 visuals-skills|dEitY719/visuals-skills|visuals
 gh-resolve-skills|dEitY719/gh-resolve-skills|gh-resolve
+session-skills|dEitY719/session-skills|session
 TABLE
 }
 
@@ -86,6 +87,19 @@ TABLE
     for skill in ci-fail conflict outdated; do
         [ -f "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-resolve-${skill}/SKILL.md" ] \
             || fail "claude/skills/gh-pr-resolve-${skill}/SKILL.md is missing — #1410 NF-1 says Phase 2 copies, never moves"
+    done
+}
+
+# Same NF-1 guarantee for the Phase 2 session-skills split (#1661). The eight
+# skills moved out under new, prefix-stripped names (`devx-session-close` ->
+# `/session:close`), so the dotfiles originals are the only thing still
+# answering `/devx:session-close`. They stay until Phase 4 retires them.
+@test "session-skills split left the claude/skills originals in place (#1661)" {
+    for skill in devx-restart devx-session-close devx-session-handoff \
+                 devx-rate-limit-guard devx-resume-after-limit devx-schedule \
+                 ai-worktree-spawn ai-worktree-teardown; do
+        [ -f "${_BATS_REAL_DOTFILES_ROOT}/claude/skills/${skill}/SKILL.md" ] \
+            || fail "claude/skills/${skill}/SKILL.md is missing — #1410 NF-1 says a phase split copies, never moves"
     done
 }
 


### PR DESCRIPTION
## Summary
- `dEitY719/session-skills`(public, MIT)를 신규 생성하고 세션 수명주기·작업공간 8개 스킬을 `session` 플러그인으로 이관했다 — #1410 §6 마이그레이션 Phase 2.
- 새 repo 는 6개 하네스 매니페스트를 갖추고, CI 는 `harness-skills` 의 재사용 워크플로(D-10)를 처음부터 호출한다.
- 이 PR 의 dotfiles 쪽 diff 는 등록 3줄 + 회귀 테스트 + changelog 뿐이다 — 스킬 본체는 새 repo 에 있고, `claude/skills/` 원본 8개는 손대지 않았다(NF-1).

## Changes
- `claude/plugin/marketplaces.json` · `plugins.json`: `session-skills` / `session@session-skills` 등록 (F-5). `restore.sh --dry-run` 이 두 항목을 복원 대상으로 인식한다.
- `tests/bats/tools/claude_plugin_scaffold.bats`: #1410 등록 테이블에 `session-skills|dEitY719/session-skills|session` 한 줄 추가 + Phase 2 판(NF-1 원본 존치 검사) 추가. #1643 이 세운 계보를 잇는다 — 상위 참조무결성 테스트는 dangling 만 잡고 "빠짐"은 못 잡기 때문이다.
- `docs/public/changelog.d/2026-09-01-1661.md`: 신규 fragment.

## 새 repo 에서 내린 결정 (이 PR diff 에는 안 보이는 부분)
- **접두를 뗐다.** `pkm-skills` 는 `obsidian-`/`karakeep-` 를 유지했지만(한 플러그인 안의 서로 다른 외부 서비스), 여기선 `devx-`/`ai-worktree-` 가 플러그인명 `session` 과 중복이라 `/session:devx-restart` 가 된다. #1410 F-4 / §4 확정 예시대로 `/session:close`, `/session:worktree-spawn` 형태다.
- **`restart` SKILL.md 108줄 → 87줄.** 공용 CI 의 100줄 상한을 넘겨서, Step 1 상세 4개 블록을 `references/resume-target.md` 로 그대로 옮기고 본문은 라우터만 남겼다. 삭제한 내용은 없다.
- **`rate-limit-guard` 의 스크립트 경로.** `python3 claude/skills/devx-rate-limit-guard/references/compute-fire-time.py` 는 dotfiles 체크아웃 루트 기준이라 플러그인 설치 위치에서 해석되지 않는다. `close` 가 이미 쓰던 `${SKILL_DIR}` 규약으로 바꿨다.
- **워크트리 런타임 파일명은 유지.** `.git/ai-worktree-spawn.log` / `.lock` 은 리네임하지 않았다 — 이관본과 dotfiles 원본이 공존하는 Phase 2~4 구간에 락이 갈라지고 기존 로그가 고아가 된다. 새 repo `CLAUDE.md` 에 규칙으로 명시했다.
- **`ai-worktree:list`** 는 존재한 적 없는 스킬을 가리키고 있었다. `git worktree list` 안내로 바꿨다.

## Test plan
- [x] 새 repo CI green — `harness-skills` 재사용 워크플로, run 33480115167 (17s)
- [x] 격리된 `CLAUDE_CONFIG_DIR` 에서 `/plugin install session@session-skills` 로 8개 스킬 로드 확인 (라이브 설정 무영향, 확인 후 제거)
- [x] `claude/plugin/restore.sh --dry-run` 이 `add: session-skills` + `install: session@session-skills` 출력
- [x] `scripts/measure-skill-descriptions.sh --skills-dir <new repo>/skills` → 총 1,842자 / 예산 5,440자의 33% (NF-4)
- [x] `claude/skills/` 원본 8개 무변경 (`git status --porcelain claude/skills/` 비어 있음, NF-1)
- [x] `claude_plugin_scaffold.bats` + `claude_plugin_restore.bats` 전 항목 통과
- [x] `mise run lint-docs` errors=0
- [x] pytest 1619 passed / 1 failed — `test_command_docs` 의 `gcp.md`·`mytool.md` stale, 이 변경과 무관한 pre-existing

## Related
Closes #1661

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~8 h (1 d) · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~8 h (1 d) · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
