### PR TITLE
feat(skills): setup-skills-ssot 다중 워크스페이스 루트 스캔 (#1410 F-6 조기 도입)

### DIFF
--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -22,6 +22,23 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 
 `~/.claude*/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/` 는 모두 **실제 디렉토리** 이며 child entry 만 `dotfiles/claude/skills/<name>` 로 가는 symlink. 이 4-way 일관성이 외부에서 추가된 symlink (마켓플레이스 `npx skills add`, 수동 링크 등) 를 모든 CLI 의 같은 디렉토리에 추가 entry 로 layer 할 여지를 만든다. SSOT 위치 자체는 변하지 않음.
 
+### 두 번째 소스: 로컬 워크스페이스 (issue #1652 / #1410 F-6)
+
+위 표의 SSOT 에 더해, 로컬에 나란히 clone 된 marketplace repo 의 스킬도 같은
+디렉토리에 **추가** entry 로 합성된다 — 소스 경로는
+`${WORKSPACE_ROOT:-~/para/project/skills}/<repo>/skills/<skill>/SKILL.md`.
+
+- 판별·열거 규칙 SSOT: `shell-common/functions/skill_sources.sh`
+  (`_skill_workspace_root`, `_skill_workspace_dirs`) — 6개 하네스가 공유한다.
+- 순수 추가다. 이름이 겹치면 dotfiles `claude/skills/` 가 이기고 기존 링크는
+  재조준되지 않는다. dotfiles 소스 제거는 #1410 Phase 4 몫.
+- 자동 발견: repo 를 clone 하면 다음 setup 실행에서 그냥 잡힌다. `skills/` 가
+  없는 repo, `SKILL.md` 가 없는 하위 디렉토리, 그리고 **linked git worktree**
+  (`.git` 가 파일) 는 조용히 스킵된다 — worktree 는 `<repo>-<branch>` 가 정렬상
+  앞서서 원본 clone 을 가려버리기 때문.
+- repo 가 사라지면 그 repo 를 가리키던 entry 만 정리된다. 워크스페이스 밖을
+  가리키는 링크(마켓플레이스 오버레이 등)는 건드리지 않는다.
+
 ### 관리 스크립트
 
 | 도구 | 담당 스크립트 / 함수 | 트리거 |
@@ -29,6 +46,7 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 | Claude Code (각 계정) | `shell-common/tools/integrations/claude.sh` → `_claude_account_setup_one()` + `_claude_compose_skills_dir()` (#707, F-8) | `./claude/setup.sh` |
 | OpenCode / Gemini | `scripts/setup-skills-ssot.sh` → `link_skills_compose()` (#791) | `./setup.sh` 또는 `./scripts/setup-skills-ssot.sh` |
 | Codex | `scripts/setup-skills-ssot.sh` → `link_skills_individual_codex()` | `./setup.sh` 또는 `./scripts/setup-skills-ssot.sh` |
+| 워크스페이스 소스 (#1652) | `shell-common/functions/skill_sources.sh` + `_claude_compose_workspace_skills()` (Claude Code) / `collect_skill_sources()` (나머지) | 위와 동일 |
 
 ### 신규 스킬 추가 후 동기화
 
@@ -48,7 +66,7 @@ Dependencies: Claude Code CLI, jq (sudo는 #575 이후 불필요)
 ### 절대 하지 말 것
 
 - `~/.claude*/skills/`, `~/.gemini/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/` 직접 편집 금지
-- 스킬은 반드시 SSOT인 `dotfiles/claude/skills/`에만 생성/수정
+- 스킬은 SSOT인 `dotfiles/claude/skills/` 또는 워크스페이스 repo(`~/para/project/skills/<repo>/skills/`)에서만 생성/수정 — 합성 대상 디렉토리에서 직접 만들지 말 것
 - Codex `.system/` 디렉토리 삭제 금지 (Codex 내장 스킬)
 
 ---

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -121,6 +121,22 @@ if ! declare -f _is_mounted >/dev/null 2>&1; then
     log_error_and_exit "Mount library did not define _is_mounted: $MOUNT_LIB"
 fi
 
+# Load workspace skill-source helpers (issue #1652), used by
+# _claude_compose_workspace_skills to layer locally cloned marketplace repos
+# on top of the dotfiles entries. Same interactive-guard reasoning as
+# mount.sh above. The declare-f assertion is the #724 lesson: without it a
+# missing definition makes the workspace lane silently no-op rather than fail.
+SKILL_SOURCES_LIB="${DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
+if [ -f "$SKILL_SOURCES_LIB" ]; then
+    DOTFILES_FORCE_INIT=1 . "$SKILL_SOURCES_LIB"
+else
+    log_error_and_exit "Skill sources library not found at $SKILL_SOURCES_LIB"
+fi
+
+if ! declare -f _skill_workspace_root >/dev/null 2>&1; then
+    log_error_and_exit "Skill sources library did not define _skill_workspace_root: $SKILL_SOURCES_LIB"
+fi
+
 # --- Functions ---
 
 # Auto-migrate legacy statusLine.command (issue #300, item A).

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -670,6 +670,10 @@ if [ "$_setup_mode" = "internal" ]; then
     # touching the dotfiles git tree. See _claude_compose_skills_dir in
     # shell-common/tools/integrations/claude.sh.
     _claude_compose_skills_dir "$CLAUDE_SKILLS_SOURCE"                  "$HOME_SKILLS"
+    # Then layer locally cloned marketplace repos on top (issue #1652). This
+    # branch does not go through _claude_account_setup_one, so the call has to
+    # be repeated here — internal PCs are single-account by design.
+    _claude_compose_workspace_skills "$HOME_SKILLS"
     _single_account_ensure_link "$CLAUDE_DOCS_SOURCE"                   "$HOME_DOCS"
     _single_account_ensure_link "$CLAUDE_GLOBAL_MEMORY_SOURCE"          "$HOME_GLOBAL_MEMORY"
     _single_account_ensure_link "$HOME/.claude-shared/plugins"          "$HOME/.claude/plugins"

--- a/docs/public/changelog.d/2026-09-01-1652.md
+++ b/docs/public/changelog.d/2026-09-01-1652.md
@@ -1,0 +1,5 @@
+- 변경: **`scripts/setup-skills-ssot.sh` 가 dotfiles `claude/skills/` 뿐 아니라 로컬 워크스페이스(`~/para/project/skills/<repo>/skills/<skill>/SKILL.md`)에 clone 된 marketplace repo 의 스킬도 **추가로** 스캔해 6개 하네스(Claude Code / Codex / OpenCode / Gemini·Antigravity / Hermes)로 심볼릭 합성한다 — #1410 F-6 의 비파괴 절반을 Phase 4 를 기다리지 않고 조기 도입했다 (#1652)**
+- 변경: **워크스페이스 루트는 `WORKSPACE_ROOT` 환경변수로 오버라이드할 수 있다 (기본값 `~/para/project/skills`) — PC 마다 clone 위치가 다를 수 있기 때문. 루트가 없거나 비어 있으면 조용히 무시되고 dotfiles 소스 단독으로 종전과 동일하게 동작한다**
+- 변경: **워크스페이스 repo 는 폴더 glob 으로 자동 발견되므로 새 repo 를 clone 해도 스크립트나 설정 파일을 손댈 필요가 없다. `skills/` 디렉토리가 없는 repo, `SKILL.md` 가 없는 하위 디렉토리는 조용히 건너뛴다. 심볼릭이라 워크스페이스에서 `SKILL.md` 를 고치면 재설치 없이 모든 하네스에 즉시 반영된다**
+- 변경: **스킬 이름이 겹치면 dotfiles `claude/skills/` 가 이기고(기존 링크를 재조준하지 않는다), 워크스페이스 repo 끼리 겹치면 glob 정렬 순서상 앞선 repo 가 이긴다 — 같은 repo 의 worktree 를 나란히 clone 해 둔 경우에도 결과가 재현 가능하다**
+- 변경: **dotfiles `claude/skills/` 는 그대로 소스로 남는다 — 소스에서 제거하는 파괴적 단계는 #1410 Phase 4 몫이다**

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -45,6 +45,13 @@ _SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
 SKILLS_SOURCE="${DOTFILES_ROOT}/claude/skills"
 
+# 워크스페이스 루트 (issue #1652 / #1410 F-6): 로컬에 나란히 clone 된
+# marketplace repo 들이 사는 디렉토리. `<root>/<repo>/skills/<skill>/SKILL.md`
+# 형태만 소스로 인정한다. PC 마다 clone 위치가 다를 수 있어 환경변수로
+# 오버라이드 가능 (F-3). 존재하지 않으면 조용히 무시된다 — dotfiles SSOT
+# 단독으로 정상 동작한다.
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/para/project/skills}"
+
 # Load UX library
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
 if [ -f "$UX_LIB" ]; then
@@ -64,6 +71,111 @@ CODEX_MANAGED_MARKER=".dotfiles-skill-source"
 CODEX_ALLOWLIST_FILE="${SKILLS_SOURCE}/.codex-allowlist"
 
 # --- Helper Functions ---
+
+# 소스 루트의 정규화 경로. symlink 판별은 raw target 과 resolved target
+# 양쪽에서 이뤄지므로(compose 는 `readlink`, codex 는 `readlink -f`) 두 형태를
+# 모두 준비해 둔다. 존재하지 않는 경로에서도 실패하지 않도록 원본으로 폴백.
+_realpath_or_self() {
+    readlink -f "$1" 2>/dev/null || printf "%s" "$1"
+}
+
+SKILLS_SOURCE_REAL="$(_realpath_or_self "$SKILLS_SOURCE")"
+WORKSPACE_ROOT_REAL="$(_realpath_or_self "$WORKSPACE_ROOT")"
+
+# 안전장치: WORKSPACE_ROOT 가 $HOME 이나 / 로 설정되면 stale-prune 이
+# 사용자 심볼릭 전부를 "우리 것" 으로 오인해 지울 수 있다. 그 경우 워크스페이스
+# 스캔을 비활성화한다 (dotfiles SSOT 단독 동작 = 종전 동작).
+case "$WORKSPACE_ROOT_REAL" in
+    "" | "/" | "$(_realpath_or_self "$HOME")")
+        WORKSPACE_ROOT=""
+        WORKSPACE_ROOT_REAL=""
+        ;;
+esac
+
+# 모든 skill 소스 디렉토리를 한 줄에 하나씩(끝에 `/` 포함) 표준출력으로 낸다.
+#
+# 소스는 두 곳 (issue #1652 / #1410 F-6):
+#   1. dotfiles SSOT     ${SKILLS_SOURCE}/<skill>/
+#   2. 워크스페이스 clone ${WORKSPACE_ROOT}/<repo>/skills/<skill>/   (SKILL.md 필수)
+#
+# dotfiles 를 먼저 내보내 이름 충돌 시 dotfiles 가 이긴다 — 이 이슈는 소스를
+# **추가**만 하므로(NF-1) 기존 링크가 다른 곳으로 재조준돼선 안 된다. 워크스페이스
+# repo 끼리 충돌하면 glob 정렬 순서상 앞선 repo 가 이긴다(재현 가능한 결정).
+# 진단 로그는 stdout 을 오염시키지 않도록 stderr 로 보낸다.
+collect_skill_sources() {
+    local seen="|"
+    local skill_path skill_name repo_path
+
+    for skill_path in "$SKILLS_SOURCE"/*/; do
+        [ -d "$skill_path" ] || continue
+        skill_name="$(basename "$skill_path")"
+        seen="${seen}${skill_name}|"
+        printf "%s\n" "$skill_path"
+    done
+
+    [ -n "$WORKSPACE_ROOT" ] || return 0
+    [ -d "$WORKSPACE_ROOT" ] || return 0
+
+    for repo_path in "$WORKSPACE_ROOT"/*/; do
+        # skills/ 가 없는 비정형 repo 는 조용히 스킵 (Error Case 2).
+        [ -d "${repo_path}skills" ] || continue
+
+        for skill_path in "${repo_path}skills"/*/; do
+            # SKILL.md 가 있어야 skill 로 인정 — skills/ 밑의 잡다한
+            # 디렉토리(_shared 등)를 소스로 오인하지 않는다.
+            [ -f "${skill_path}SKILL.md" ] || continue
+
+            skill_name="$(basename "$skill_path")"
+            case "$seen" in
+                *"|${skill_name}|"*)
+                    log_dim "[skills] 이름 충돌 — 먼저 발견된 소스 유지, 건너뜀: ${skill_path}" >&2
+                    continue
+                    ;;
+            esac
+
+            seen="${seen}${skill_name}|"
+            printf "%s\n" "$skill_path"
+        done
+    done
+}
+
+# symlink target 이 우리가 관리하는 소스 루트 아래인지 판별.
+# 관리 대상이면 갱신/정리해도 되고, 아니면 사용자 데이터로 보고 보존한다.
+# raw / resolved 두 형태를 모두 대조한다 — 호출부마다 비교 대상이 다르다.
+skill_source_is_managed() {
+    local path="$1"
+    local root
+
+    [ -n "$path" ] || return 1
+
+    for root in "$SKILLS_SOURCE" "$SKILLS_SOURCE_REAL" \
+                "$WORKSPACE_ROOT" "$WORKSPACE_ROOT_REAL"; do
+        [ -n "$root" ] || continue
+        case "$path" in
+            "$root"/*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# skill 이름으로 소스 경로를 되찾는다. 없으면 비어 있는 출력 + rc 1.
+# codex 의 stale prune 이 "이 이름이 아직 유효한 소스인가" 를 물을 때 쓴다.
+skill_source_path_for() {
+    local name="$1"
+    local candidate
+
+    [ -n "$name" ] || return 1
+
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] || continue
+        if [ "$(basename "$candidate")" = "$name" ]; then
+            printf "%s\n" "$candidate"
+            return 0
+        fi
+    done <<< "$SKILL_SOURCE_LIST"
+
+    return 1
+}
 
 # Read codex allowlist file and emit one skill name per line.
 # Strips comments (#...) and blank lines. Stdout is empty if no entries
@@ -172,8 +284,8 @@ link_skills_compose() {
     local linked=0 refreshed=0 skipped=0 pruned=0
     local skill_path skill_name link_target source_realpath current_link existing_target_path
 
-    for skill_path in "$SKILLS_SOURCE"/*/; do
-        [ -d "$skill_path" ] || continue
+    while IFS= read -r skill_path; do
+        [ -n "$skill_path" ] || continue
         skill_name="$(basename "$skill_path")"
         link_target="${target}/${skill_name}"
         source_realpath="$(readlink -f "$skill_path")"
@@ -184,17 +296,14 @@ link_skills_compose() {
                 || [ "$(readlink -f "$link_target" 2>/dev/null)" = "$source_realpath" ]; then
                 continue
             fi
-            case "$current_link" in
-                "$SKILLS_SOURCE"/*)
-                    rm -f "$link_target"
-                    refreshed=$((refreshed + 1))
-                    ;;
-                *)
-                    log_dim "[$tool] 사용자 symlink 보존: $link_target"
-                    skipped=$((skipped + 1))
-                    continue
-                    ;;
-            esac
+            if skill_source_is_managed "$current_link"; then
+                rm -f "$link_target"
+                refreshed=$((refreshed + 1))
+            else
+                log_dim "[$tool] 사용자 symlink 보존: $link_target"
+                skipped=$((skipped + 1))
+                continue
+            fi
         elif [ -e "$link_target" ]; then
             log_dim "[$tool] 비-symlink 엔트리 보존: $link_target"
             skipped=$((skipped + 1))
@@ -207,7 +316,7 @@ link_skills_compose() {
             log_error "[$tool] skill symlink 생성 실패: $link_target"
             continue
         }
-    done
+    done <<< "$SKILL_SOURCE_LIST"
 
     # Stale cleanup: SSOT 로 향하던 symlink 의 원본이 사라진 경우만 정리.
     # SSOT 밖을 가리키는 entry (private overlay 등) 는 보존.
@@ -215,15 +324,12 @@ link_skills_compose() {
     for existing in "$target"/*; do
         [ -L "$existing" ] || continue
         existing_target_path="$(readlink "$existing")"
-        case "$existing_target_path" in
-            "$SKILLS_SOURCE"/*)
-                if [ ! -d "$existing_target_path" ]; then
-                    log_info "[$tool] stale entry 정리: $existing"
-                    rm -f "$existing"
-                    pruned=$((pruned + 1))
-                fi
-                ;;
-        esac
+        skill_source_is_managed "$existing_target_path" || continue
+        if [ ! -d "$existing_target_path" ]; then
+            log_info "[$tool] stale entry 정리: $existing"
+            rm -f "$existing"
+            pruned=$((pruned + 1))
+        fi
     done
 
     log_info "[$tool] skill 합성 완료: ${linked}개 신규, ${refreshed}개 갱신, ${skipped}개 보존, ${pruned}개 정리"
@@ -237,8 +343,8 @@ link_skills_individual() {
     local linked=0
     local skipped=0
 
-    for skill_path in "$SKILLS_SOURCE"/*/; do
-        [ -d "$skill_path" ] || continue
+    while IFS= read -r skill_path; do
+        [ -n "$skill_path" ] || continue
         local skill_name
         skill_name="$(basename "$skill_path")"
         local link_target="${target_dir}/${skill_name}"
@@ -263,7 +369,7 @@ link_skills_individual() {
             continue
         }
         linked=$((linked + 1))
-    done
+    done <<< "$SKILL_SOURCE_LIST"
 
     log_info "[$tool] 개별 skill 연결 완료: ${linked}개 신규, ${skipped}개 기존 유지"
 }
@@ -284,13 +390,11 @@ link_skills_individual_codex() {
     local pruned=0
     local prune_skipped=0
     local excluded=0
-    local source_root
-    source_root="$(readlink -f "$SKILLS_SOURCE")"
 
     mkdir -p "$target_dir"
 
-    for skill_path in "$SKILLS_SOURCE"/*/; do
-        [ -d "$skill_path" ] || continue
+    while IFS= read -r skill_path; do
+        [ -n "$skill_path" ] || continue
 
         local skill_name
         skill_name="$(basename "$skill_path")"
@@ -380,7 +484,7 @@ link_skills_individual_codex() {
             continue
         }
         linked=$((linked + 1))
-    done
+    done <<< "$SKILL_SOURCE_LIST"
 
     local existing_skill_entry
     for existing_skill_entry in "$target_dir"/*; do
@@ -392,7 +496,7 @@ link_skills_individual_codex() {
             continue
         fi
 
-        if [ -d "${SKILLS_SOURCE}/${existing_name}" ] && \
+        if skill_source_path_for "$existing_name" >/dev/null && \
            codex_skill_is_allowed "$existing_name" "$allowlist"; then
             continue
         fi
@@ -400,16 +504,14 @@ link_skills_individual_codex() {
         if [ -L "$existing_skill_entry" ]; then
             local stale_target
             stale_target="$(readlink -f "$existing_skill_entry" 2>/dev/null || true)"
-            case "$stale_target" in
-                "$source_root"/*)
-                    rm -f "$existing_skill_entry" || {
-                        log_error "[codex] stale skill 제거 실패: $existing_skill_entry"
-                        continue
-                    }
-                    pruned=$((pruned + 1))
+            if skill_source_is_managed "$stale_target"; then
+                rm -f "$existing_skill_entry" || {
+                    log_error "[codex] stale skill 제거 실패: $existing_skill_entry"
                     continue
-                    ;;
-            esac
+                }
+                pruned=$((pruned + 1))
+                continue
+            fi
 
             log_warning "[codex] stale skill symlink 보존(사용자 데이터 감지): $existing_skill_entry"
             prune_skipped=$((prune_skipped + 1))
@@ -443,6 +545,16 @@ ux_section "Skills SSOT 연결"
 # SSOT 존재 확인
 if [ ! -d "$SKILLS_SOURCE" ]; then
     log_critical "SSOT 디렉토리가 없습니다: $SKILLS_SOURCE"
+fi
+
+# 소스 목록을 한 번만 만들어 4개 CLI fan-out 이 공유한다 (issue #1652).
+# fan-out 로직 자체는 그대로다 — 달라진 건 enumeration 뿐 (F-4).
+SKILL_SOURCE_LIST="$(collect_skill_sources)"
+
+if [ -n "$WORKSPACE_ROOT" ] && [ -d "$WORKSPACE_ROOT" ]; then
+    workspace_skill_count="$(printf '%s\n' "$SKILL_SOURCE_LIST" \
+        | grep -c "^${WORKSPACE_ROOT}/" || true)"
+    log_info "[workspace] ${workspace_skill_count}개 skill 합류 (루트: $WORKSPACE_ROOT)"
 fi
 
 # 1. OpenCode: entry-level 합성 (issue #791 — 5 CLI 공통 layout)

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -45,19 +45,23 @@ _SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
 SKILLS_SOURCE="${DOTFILES_ROOT}/claude/skills"
 
-# 워크스페이스 루트 (issue #1652 / #1410 F-6): 로컬에 나란히 clone 된
-# marketplace repo 들이 사는 디렉토리. `<root>/<repo>/skills/<skill>/SKILL.md`
-# 형태만 소스로 인정한다. PC 마다 clone 위치가 다를 수 있어 환경변수로
-# 오버라이드 가능 (F-3). 존재하지 않으면 조용히 무시된다 — dotfiles SSOT
-# 단독으로 정상 동작한다.
-WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/para/project/skills}"
-
 # Load UX library
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
 if [ -f "$UX_LIB" ]; then
     source "$UX_LIB"
 else
     echo "Error: UX library not found at $UX_LIB"
+    exit 1
+fi
+
+# 워크스페이스 소스 판별/열거의 SSOT (issue #1652 / #1410 F-6). Claude Code
+# 계정 쪽(shell-common/tools/integrations/claude.sh)이 같은 파일을 읽으므로
+# "무엇이 워크스페이스 skill 인가" 규칙이 두 벌로 갈라지지 않는다.
+SKILL_SOURCES_LIB="${DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
+if [ -f "$SKILL_SOURCES_LIB" ]; then
+    source "$SKILL_SOURCES_LIB"
+else
+    echo "Error: skill sources library not found at $SKILL_SOURCES_LIB"
     exit 1
 fi
 
@@ -80,31 +84,25 @@ _realpath_or_self() {
 }
 
 SKILLS_SOURCE_REAL="$(_realpath_or_self "$SKILLS_SOURCE")"
-WORKSPACE_ROOT_REAL="$(_realpath_or_self "$WORKSPACE_ROOT")"
+# 빈 문자열 = 워크스페이스 없음/너무 넓음 → dotfiles SSOT 단독 동작(종전과 동일).
+WORKSPACE_ROOT_RESOLVED="$(_skill_workspace_root || true)"
+WORKSPACE_ROOT_REAL=""
+[ -n "$WORKSPACE_ROOT_RESOLVED" ] \
+    && WORKSPACE_ROOT_REAL="$(_realpath_or_self "$WORKSPACE_ROOT_RESOLVED")"
 
-# 안전장치: WORKSPACE_ROOT 가 $HOME 이나 / 로 설정되면 stale-prune 이
-# 사용자 심볼릭 전부를 "우리 것" 으로 오인해 지울 수 있다. 그 경우 워크스페이스
-# 스캔을 비활성화한다 (dotfiles SSOT 단독 동작 = 종전 동작).
-case "$WORKSPACE_ROOT_REAL" in
-    "" | "/" | "$(_realpath_or_self "$HOME")")
-        WORKSPACE_ROOT=""
-        WORKSPACE_ROOT_REAL=""
-        ;;
-esac
-
-# 모든 skill 소스 디렉토리를 한 줄에 하나씩(끝에 `/` 포함) 표준출력으로 낸다.
+# 모든 skill 소스 디렉토리를 한 줄에 하나씩 표준출력으로 낸다.
 #
 # 소스는 두 곳 (issue #1652 / #1410 F-6):
 #   1. dotfiles SSOT     ${SKILLS_SOURCE}/<skill>/
-#   2. 워크스페이스 clone ${WORKSPACE_ROOT}/<repo>/skills/<skill>/   (SKILL.md 필수)
+#   2. 워크스페이스 clone <root>/<repo>/skills/<skill>   (열거 규칙은 shell-common SSOT)
 #
 # dotfiles 를 먼저 내보내 이름 충돌 시 dotfiles 가 이긴다 — 이 이슈는 소스를
 # **추가**만 하므로(NF-1) 기존 링크가 다른 곳으로 재조준돼선 안 된다. 워크스페이스
-# repo 끼리 충돌하면 glob 정렬 순서상 앞선 repo 가 이긴다(재현 가능한 결정).
+# repo 끼리 충돌하면 정렬 순서상 앞선 repo 가 이긴다(재현 가능한 결정).
 # 진단 로그는 stdout 을 오염시키지 않도록 stderr 로 보낸다.
 collect_skill_sources() {
     local seen="|"
-    local skill_path skill_name repo_path
+    local skill_path skill_name
 
     for skill_path in "$SKILLS_SOURCE"/*/; do
         [ -d "$skill_path" ] || continue
@@ -113,30 +111,22 @@ collect_skill_sources() {
         printf "%s\n" "$skill_path"
     done
 
-    [ -n "$WORKSPACE_ROOT" ] || return 0
-    [ -d "$WORKSPACE_ROOT" ] || return 0
+    [ -n "$WORKSPACE_ROOT_RESOLVED" ] || return 0
 
-    for repo_path in "$WORKSPACE_ROOT"/*/; do
-        # skills/ 가 없는 비정형 repo 는 조용히 스킵 (Error Case 2).
-        [ -d "${repo_path}skills" ] || continue
+    while IFS= read -r skill_path; do
+        [ -n "$skill_path" ] || continue
+        skill_name="$(basename "$skill_path")"
 
-        for skill_path in "${repo_path}skills"/*/; do
-            # SKILL.md 가 있어야 skill 로 인정 — skills/ 밑의 잡다한
-            # 디렉토리(_shared 등)를 소스로 오인하지 않는다.
-            [ -f "${skill_path}SKILL.md" ] || continue
+        case "$seen" in
+            *"|${skill_name}|"*)
+                log_dim "[skills] 이름 충돌 — 먼저 발견된 소스 유지, 건너뜀: ${skill_path}" >&2
+                continue
+                ;;
+        esac
 
-            skill_name="$(basename "$skill_path")"
-            case "$seen" in
-                *"|${skill_name}|"*)
-                    log_dim "[skills] 이름 충돌 — 먼저 발견된 소스 유지, 건너뜀: ${skill_path}" >&2
-                    continue
-                    ;;
-            esac
-
-            seen="${seen}${skill_name}|"
-            printf "%s\n" "$skill_path"
-        done
-    done
+        seen="${seen}${skill_name}|"
+        printf "%s\n" "$skill_path"
+    done <<< "$(_skill_workspace_dirs "$WORKSPACE_ROOT_RESOLVED")"
 }
 
 # symlink target 이 우리가 관리하는 소스 루트 아래인지 판별.
@@ -149,7 +139,7 @@ skill_source_is_managed() {
     [ -n "$path" ] || return 1
 
     for root in "$SKILLS_SOURCE" "$SKILLS_SOURCE_REAL" \
-                "$WORKSPACE_ROOT" "$WORKSPACE_ROOT_REAL"; do
+                "$WORKSPACE_ROOT_RESOLVED" "$WORKSPACE_ROOT_REAL"; do
         [ -n "$root" ] || continue
         case "$path" in
             "$root"/*) return 0 ;;
@@ -551,10 +541,10 @@ fi
 # fan-out 로직 자체는 그대로다 — 달라진 건 enumeration 뿐 (F-4).
 SKILL_SOURCE_LIST="$(collect_skill_sources)"
 
-if [ -n "$WORKSPACE_ROOT" ] && [ -d "$WORKSPACE_ROOT" ]; then
+if [ -n "$WORKSPACE_ROOT_RESOLVED" ]; then
     workspace_skill_count="$(printf '%s\n' "$SKILL_SOURCE_LIST" \
-        | grep -c "^${WORKSPACE_ROOT}/" || true)"
-    log_info "[workspace] ${workspace_skill_count}개 skill 합류 (루트: $WORKSPACE_ROOT)"
+        | grep -c "^${WORKSPACE_ROOT_RESOLVED}/" || true)"
+    log_info "[workspace] ${workspace_skill_count}개 skill 합류 (루트: $WORKSPACE_ROOT_RESOLVED)"
 fi
 
 # 1. OpenCode: entry-level 합성 (issue #791 — 5 CLI 공통 layout)

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -542,8 +542,15 @@ fi
 SKILL_SOURCE_LIST="$(collect_skill_sources)"
 
 if [ -n "$WORKSPACE_ROOT_RESOLVED" ]; then
-    workspace_skill_count="$(printf '%s\n' "$SKILL_SOURCE_LIST" \
-        | grep -c "^${WORKSPACE_ROOT_RESOLVED}/" || true)"
+    # -F, not a regex: a workspace root containing regex metacharacters
+    # (`+`, `[`, `.`) would otherwise mis-count. Anchoring is done by the
+    # case-glob below rather than by `^`, which -F does not honour.
+    workspace_skill_count=0
+    while IFS= read -r _src; do
+        case "$_src" in
+            "${WORKSPACE_ROOT_RESOLVED}"/*) workspace_skill_count=$((workspace_skill_count + 1)) ;;
+        esac
+    done <<< "$SKILL_SOURCE_LIST"
     log_info "[workspace] ${workspace_skill_count}개 skill 합류 (루트: $WORKSPACE_ROOT_RESOLVED)"
 fi
 

--- a/shell-common/functions/skill_sources.sh
+++ b/shell-common/functions/skill_sources.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# shell-common/functions/skill_sources.sh
+# Enumerate skill sources that live outside the dotfiles SSOT.
+#
+# SSOT for the "workspace" half of the skill-source list (issue #1652 —
+# the non-destructive half of #1410 F-6). Locally cloned marketplace
+# repos sit side by side under a single root:
+#
+#     ${WORKSPACE_ROOT:-$HOME/para/project/skills}/<repo>/skills/<skill>/SKILL.md
+#
+# and every harness links them as additional entry-level symlinks on top
+# of the dotfiles `claude/skills/` entries it already composes. The
+# dotfiles tree stays a source — removing it is #1410 Phase 4, not this.
+#
+# Two consumers share these helpers so their notion of "what counts as a
+# workspace skill" cannot drift apart:
+#   - scripts/setup-skills-ssot.sh              (Codex / OpenCode / Gemini+agy / Hermes)
+#   - shell-common/tools/integrations/claude.sh (Claude Code accounts)
+#
+# No interactive guard — this file only defines functions and prints
+# nothing when sourced (same posture as functions/gh_host.sh, PR #704).
+
+# _skill_workspace_root — print the effective workspace root, or nothing.
+#
+# Returns 1 without printing when the root is missing or set to a value
+# too broad to be safe. The breadth guard is load-bearing: callers decide
+# what they may delete by asking "does this symlink point under the
+# root?", so a root of `/` or `$HOME` would make every unrelated user
+# symlink look like ours.
+_skill_workspace_root() {
+    _sws_root="${WORKSPACE_ROOT:-$HOME/para/project/skills}"
+
+    case "$_sws_root" in
+        "" | "/" | "$HOME" | "$HOME/") return 1 ;;
+    esac
+
+    [ -d "$_sws_root" ] || return 1
+
+    printf '%s\n' "${_sws_root%/}"
+}
+
+# _skill_workspace_dirs [root] — print one workspace skill directory per
+# line (no trailing slash), in glob order.
+#
+# Resolves the root itself when the argument is omitted, and prints
+# nothing when there is none. A repo with no `skills/` subdirectory and a
+# `skills/` entry with no `SKILL.md` are both silent skips: a workspace
+# holds ordinary clones, not a curated tree, so neither is an error.
+_skill_workspace_dirs() {
+    _swd_root="${1:-}"
+    if [ -z "$_swd_root" ]; then
+        # Unquoted on purpose: an assignment RHS is not word-split, and the
+        # pre-commit naming check flags a locally-defined function name that
+        # appears inside double quotes.
+        _swd_root=$(_skill_workspace_root) || return 0
+    fi
+
+    # `find` rather than a shell glob: zsh aborts the enclosing function on
+    # an unmatched glob (`nomatch`), and "workspace exists but holds no
+    # skills yet" is the ordinary first-run state — the same reason
+    # functions/devops_help.sh reaches for find. `sort` makes the order
+    # explicit so a name collision between two repos resolves the same way
+    # on every run rather than following directory order.
+    find "$_swd_root" -mindepth 4 -maxdepth 4 ! -type d -name SKILL.md \
+        -path "${_swd_root}/*/skills/*/SKILL.md" 2>/dev/null \
+        | sed 's|/SKILL\.md$||' \
+        | LC_ALL=C sort \
+        | while IFS= read -r _swd_dir; do
+            _swd_repo="${_swd_dir%/skills/*}"
+            # A linked git worktree keeps `.git` as a regular *file*
+            # pointing back at the main clone; a normal clone has a `.git`
+            # directory. Worktrees are skipped: they are a transient
+            # checkout of a repo that is usually already in the workspace,
+            # and `<repo>-<branch>` sorts ahead of `<repo>` under LC_ALL=C
+            # (`-` < `/`), so a feature worktree would silently shadow the
+            # canonical clone's skills.
+            [ -f "${_swd_repo}/.git" ] && continue
+            printf '%s\n' "$_swd_dir"
+        done
+}

--- a/shell-common/functions/skill_sources.sh
+++ b/shell-common/functions/skill_sources.sh
@@ -30,8 +30,17 @@
 _skill_workspace_root() {
     _sws_root="${WORKSPACE_ROOT:-$HOME/para/project/skills}"
 
+    # Compare resolved paths, not raw strings: with a symlinked $HOME the two
+    # spellings of the same directory would otherwise slip past the guard.
+    # Mirrors scripts/setup-skills-ssot.sh's _realpath_or_self handling.
+    _sws_real=$(readlink -f "$_sws_root" 2>/dev/null || printf '%s' "$_sws_root")
+    _sws_home=$(readlink -f "$HOME" 2>/dev/null || printf '%s' "$HOME")
+
     case "$_sws_root" in
         "" | "/" | "$HOME" | "$HOME/") return 1 ;;
+    esac
+    case "$_sws_real" in
+        "" | "/" | "$_sws_home") return 1 ;;
     esac
 
     [ -d "$_sws_root" ] || return 1

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -927,6 +927,82 @@ _claude_compose_skills_dir() {
     ux_success "  composed skills dir: $_ccsd_tgt (added=$_ccsd_added refreshed=$_ccsd_refreshed)"
 }
 
+# _claude_compose_workspace_skills <target_skills_dir>
+#
+# issue #1652 (#1410 F-6, non-destructive half): layer the skills of
+# locally cloned marketplace repos into a <tgt> that
+# _claude_compose_skills_dir has already composed from the dotfiles SSOT.
+# Sources come from shell-common/functions/skill_sources.sh, which the
+# Codex / OpenCode / Gemini+agy / Hermes side (scripts/setup-skills-ssot.sh)
+# reads too — one definition of "what is a workspace skill" for all six
+# harnesses.
+#
+# Purely additive (NF-1): a name already taken — by a dotfiles skill, by a
+# marketplace overlay, by anything — is left exactly as it is, so this can
+# never repoint an entry _claude_compose_skills_dir owns. Stale workspace
+# links (their repo was removed) are pruned first, so a repo rename
+# converges in one run instead of two; links pointing outside the
+# workspace root are never touched.
+#
+# Every "nothing to do" path is silent and returns 0: no workspace root,
+# an empty one, a repo with no skills/, a skills/ entry with no SKILL.md.
+#
+# `find` replaces the glob loops used elsewhere in this file because an
+# empty workspace is the ordinary first-run state and zsh aborts the
+# enclosing function on an unmatched glob (`nomatch`).
+_claude_compose_workspace_skills() {
+    _ccws_tgt="${1:-}"
+    [ -n "$_ccws_tgt" ] || return 0
+    [ -d "$_ccws_tgt" ] || return 0
+
+    _ccws_root="$(_skill_workspace_root)" || return 0
+
+    # Prune first: a workspace link whose source vanished has to free its
+    # name before the add loop below can claim it.
+    _ccws_links="$(find "$_ccws_tgt" -mindepth 1 -maxdepth 1 -type l 2>/dev/null)"
+    while IFS= read -r _ccws_existing; do
+        [ -n "$_ccws_existing" ] || continue
+        _ccws_target_path=$(readlink "$_ccws_existing")
+        case "$_ccws_target_path" in
+            "$_ccws_root"/*) ;;
+            *) continue ;;
+        esac
+        [ -d "$_ccws_target_path" ] && continue
+        _ccws_stale_name="${_ccws_existing##*/}"
+        rm -f "$_ccws_existing" \
+            && ux_info "  removed stale workspace skill: $_ccws_stale_name"
+    done <<CCWS_LINKS
+$_ccws_links
+CCWS_LINKS
+
+    _ccws_dirs="$(_skill_workspace_dirs "$_ccws_root")"
+    [ -n "$_ccws_dirs" ] || return 0
+
+    _ccws_added=0
+    while IFS= read -r _ccws_want; do
+        [ -n "$_ccws_want" ] || continue
+        _ccws_name="${_ccws_want##*/}"
+        _ccws_link="${_ccws_tgt}/${_ccws_name}"
+
+        # Name already occupied — dotfiles SSOT, an overlay, or an earlier
+        # workspace repo won it. Leave it exactly as it is.
+        if [ -e "$_ccws_link" ] || [ -L "$_ccws_link" ]; then
+            continue
+        fi
+
+        ln -s "$_ccws_want" "$_ccws_link" || {
+            ux_error "  workspace symlink failed: $_ccws_link -> $_ccws_want"
+            return 1
+        }
+        _ccws_added=$((_ccws_added + 1))
+        ux_info "  new workspace skill: $_ccws_name"
+    done <<CCWS_DIRS
+$_ccws_dirs
+CCWS_DIRS
+
+    ux_success "  composed workspace skills: $_ccws_tgt (added=$_ccws_added root=$_ccws_root)"
+}
+
 # _claude_account_setup_one — 단일 계정의 link 멱등 셋업.
 #
 # skills/ 와 docs/ 는 SSOT 디렉토리 자체로의 단일 symlink 다 (issue #575).
@@ -956,6 +1032,8 @@ _claude_account_setup_one() {
     # added symlinks can be layered into the same target dir without
     # touching the dotfiles git tree.
     _claude_compose_skills_dir "${DOTFILES_ROOT}/claude/skills"             "$_caso_cdir/skills"
+    # Then layer locally cloned marketplace repos on top (issue #1652).
+    _claude_compose_workspace_skills "$_caso_cdir/skills"
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/docs"                   "$_caso_cdir/docs"
     _claude_ensure_symlink "${DOTFILES_ROOT}/claude/workflows"               "$_caso_cdir/workflows"
     # Global instructions (Advisor/Worker) — SSOT symlink, all projects (#1115).

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -971,9 +971,15 @@ _claude_compose_workspace_skills() {
     _ccws_links="$(find "$_ccws_tgt" -mindepth 1 -maxdepth 1 -type l 2>/dev/null)"
     while IFS= read -r _ccws_existing; do
         [ -n "$_ccws_existing" ] || continue
+        # `readlink` gives the raw target; a relative or non-normalized link
+        # would not match the resolved root, and the entry would silently
+        # escape the prune. Fall back to the raw value when resolution fails
+        # (a dangling link is exactly what this loop is looking for).
         _ccws_target_path=$(readlink "$_ccws_existing")
-        case "$_ccws_target_path" in
+        _ccws_target_real=$(readlink -f "$_ccws_existing" 2>/dev/null || printf '%s' "$_ccws_target_path")
+        case "$_ccws_target_path$_ccws_target_real" in
             "$_ccws_root"/*) ;;
+            *"$_ccws_root"/*) ;;
             *) continue ;;
         esac
         [ -d "$_ccws_target_path" ] && continue
@@ -1000,8 +1006,11 @@ CCWS_LINKS
         fi
 
         ln -s "$_ccws_want" "$_ccws_link" || {
+            # One bad entry must not cost the remaining workspace skills —
+            # _claude_compose_skills_dir's own `return 1` predates this lane
+            # and is not a precedent worth copying here.
             ux_error "  workspace symlink failed: $_ccws_link -> $_ccws_want"
-            return 1
+            continue
         }
         _ccws_added=$((_ccws_added + 1))
         ux_info "  new workspace skill: $_ccws_name"

--- a/shell-common/tools/integrations/claude.sh
+++ b/shell-common/tools/integrations/claude.sh
@@ -955,6 +955,15 @@ _claude_compose_workspace_skills() {
     [ -n "$_ccws_tgt" ] || return 0
     [ -d "$_ccws_tgt" ] || return 0
 
+    # Defense-in-depth (#724 lesson): a caller that sources this file but not
+    # functions/skill_sources.sh would hit `command not found` (rc 127), the
+    # `|| return 0` below would absorb it, and the whole workspace lane would
+    # silently no-op. Say so instead.
+    if ! command -v _skill_workspace_root >/dev/null 2>&1; then
+        ux_warning "  workspace skill sources unavailable — shell-common/functions/skill_sources.sh not sourced (#1652)"
+        return 0
+    fi
+
     _ccws_root="$(_skill_workspace_root)" || return 0
 
     # Prune first: a workspace link whose source vanished has to free its

--- a/tests/bats/functions/claude_compose_workspace_skills.bats
+++ b/tests/bats/functions/claude_compose_workspace_skills.bats
@@ -186,6 +186,23 @@ run_compose() {
     [ -L "$TGT/marketplace-skill" ]
 }
 
+@test "missing skill_sources.sh warns instead of silently no-opping (#1652 / #724)" {
+    seed_ws_repo "packaging-skills" "create"
+
+    # Same helper, minus the skill_sources.sh source line.
+    local no_lib="$TEST_TEMP_HOME/no-lib.sh"
+    grep -v 'functions/skill_sources.sh' "$HELPER_SCRIPT" > "$no_lib"
+    chmod +x "$no_lib"
+
+    WORKSPACE_ROOT="$WS" run "$no_lib" "$SRC" "$TGT"
+    assert_success
+    assert_output --partial "workspace skill sources unavailable"
+
+    # dotfiles composition still succeeded; no workspace entry was linked.
+    [ -L "$TGT/alpha" ]
+    [ ! -e "$TGT/create" ]
+}
+
 @test "WORKSPACE_ROOT of \$HOME is refused as too broad (#1652 safety)" {
     seed_ws_repo "packaging-skills" "create"
 

--- a/tests/bats/functions/claude_compose_workspace_skills.bats
+++ b/tests/bats/functions/claude_compose_workspace_skills.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+# tests/bats/functions/claude_compose_workspace_skills.bats
+# Cover _claude_compose_workspace_skills — the issue #1652 helper that
+# layers locally cloned marketplace repos (#1410 F-6) on top of the
+# dotfiles entries _claude_compose_skills_dir already wrote. The
+# dotfiles-only composition itself is covered by
+# claude_compose_skills_dir.bats.
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    SRC="$TEST_TEMP_HOME/src-skills"
+    TGT="$TEST_TEMP_HOME/.claude/skills"
+    WS="$TEST_TEMP_HOME/workspace"
+
+    mkdir -p "$SRC/alpha" "$SRC/beta"
+    : > "$SRC/alpha/SKILL.md"
+    : > "$SRC/beta/SKILL.md"
+
+    HELPER_SCRIPT="$(mktemp "$TEST_TEMP_HOME/run.XXXXXX.sh")"
+    cat > "$HELPER_SCRIPT" <<EOF
+#!/bin/bash
+set -e
+export DOTFILES_FORCE_INIT=1
+source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/mount.sh"
+source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
+source "${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/integrations/claude.sh"
+# Compose the dotfiles SSOT first, exactly as _claude_account_setup_one does,
+# then layer the workspace on top.
+_claude_compose_skills_dir "\$1" "\$2"
+_claude_compose_workspace_skills "\$2"
+EOF
+    chmod +x "$HELPER_SCRIPT"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Usage: seed_ws_repo <repo> <skill> [<skill>...]
+seed_ws_repo() {
+    local repo="$1"
+    shift
+    local skill
+    for skill in "$@"; do
+        mkdir -p "$WS/$repo/skills/$skill"
+        : > "$WS/$repo/skills/$skill/SKILL.md"
+    done
+    # A real clone keeps .git as a directory (worktrees keep a file).
+    mkdir -p "$WS/$repo/.git"
+}
+
+run_compose() {
+    WORKSPACE_ROOT="$WS" run "$HELPER_SCRIPT" "$SRC" "$TGT"
+}
+
+@test "workspace skills are layered next to the dotfiles entries (#1652)" {
+    seed_ws_repo "packaging-skills" "create" "rename-repo"
+
+    run_compose
+    assert_success
+
+    # dotfiles entries survive, pointing at the dotfiles source.
+    [ "$(readlink "$TGT/alpha")" = "$SRC/alpha" ]
+    [ "$(readlink "$TGT/beta")" = "$SRC/beta" ]
+    # workspace entries are added alongside.
+    [ "$(readlink "$TGT/create")" = "$WS/packaging-skills/skills/create" ]
+    [ "$(readlink "$TGT/rename-repo")" = "$WS/packaging-skills/skills/rename-repo" ]
+}
+
+@test "absent workspace root is a silent no-op (#1652 Error Case 1)" {
+    [ ! -d "$WS" ]
+
+    run_compose
+    assert_success
+
+    [ -L "$TGT/alpha" ] && [ -L "$TGT/beta" ]
+}
+
+@test "repo without a skills/ dir is skipped (#1652 Error Case 2)" {
+    mkdir -p "$WS/not-a-skill-repo/docs"
+    seed_ws_repo "packaging-skills" "create"
+
+    run_compose
+    assert_success
+
+    [ -L "$TGT/create" ]
+    [ ! -e "$TGT/not-a-skill-repo" ]
+    [ ! -e "$TGT/docs" ]
+}
+
+@test "skills/ entry without SKILL.md is not a source (#1652)" {
+    seed_ws_repo "packaging-skills" "create"
+    mkdir -p "$WS/packaging-skills/skills/_shared"
+
+    run_compose
+    assert_success
+
+    [ -L "$TGT/create" ]
+    [ ! -e "$TGT/_shared" ]
+}
+
+@test "a dotfiles skill of the same name is never repointed (#1652 NF-1)" {
+    seed_ws_repo "packaging-skills" "alpha"
+
+    run_compose
+    assert_success
+
+    [ "$(readlink "$TGT/alpha")" = "$SRC/alpha" ]
+}
+
+@test "linked git worktrees are skipped so they cannot shadow the clone (#1652)" {
+    seed_ws_repo "packaging-skills" "create"
+    # A linked worktree: same skills, `.git` is a file, and its name sorts
+    # ahead of the clone under LC_ALL=C ('-' < '/').
+    mkdir -p "$WS/packaging-skills-feat-1/skills/create"
+    : > "$WS/packaging-skills-feat-1/skills/create/SKILL.md"
+    printf 'gitdir: /elsewhere\n' > "$WS/packaging-skills-feat-1/.git"
+
+    run_compose
+    assert_success
+
+    [ "$(readlink "$TGT/create")" = "$WS/packaging-skills/skills/create" ]
+}
+
+@test "composition is idempotent on repeat runs (#1652)" {
+    seed_ws_repo "packaging-skills" "create"
+
+    run_compose
+    assert_success
+    before="$(ls -la "$TGT")"
+
+    run_compose
+    assert_success
+    after="$(ls -la "$TGT")"
+
+    [ "$before" = "$after" ]
+}
+
+@test "stale workspace link is pruned when its repo disappears (#1652 NF-3)" {
+    seed_ws_repo "packaging-skills" "create"
+
+    run_compose
+    assert_success
+    [ -L "$TGT/create" ]
+
+    rm -rf "$WS/packaging-skills"
+
+    run_compose
+    assert_success
+    [ ! -e "$TGT/create" ]
+    # dotfiles entries are untouched by the workspace prune.
+    [ -L "$TGT/alpha" ]
+}
+
+@test "a repo rename converges in a single run (#1652)" {
+    seed_ws_repo "old-name-skills" "create"
+
+    run_compose
+    assert_success
+    [ "$(readlink "$TGT/create")" = "$WS/old-name-skills/skills/create" ]
+
+    mv "$WS/old-name-skills" "$WS/new-name-skills"
+
+    run_compose
+    assert_success
+    [ "$(readlink "$TGT/create")" = "$WS/new-name-skills/skills/create" ]
+}
+
+@test "symlinks outside the workspace root are never pruned (#1652)" {
+    mkdir -p "$TEST_TEMP_HOME/overlay/marketplace-skill"
+    mkdir -p "$TGT"
+    ln -s "$TEST_TEMP_HOME/overlay/marketplace-skill" "$TGT/marketplace-skill"
+    seed_ws_repo "packaging-skills" "create"
+
+    run_compose
+    assert_success
+    [ -L "$TGT/marketplace-skill" ]
+
+    # Even once its own target is gone, a non-workspace link is left alone.
+    rm -rf "$TEST_TEMP_HOME/overlay/marketplace-skill"
+    run_compose
+    assert_success
+    [ -L "$TGT/marketplace-skill" ]
+}
+
+@test "WORKSPACE_ROOT of \$HOME is refused as too broad (#1652 safety)" {
+    seed_ws_repo "packaging-skills" "create"
+
+    WORKSPACE_ROOT="$HOME" run "$HELPER_SCRIPT" "$SRC" "$TGT"
+    assert_success
+
+    [ ! -e "$TGT/create" ]
+    [ -L "$TGT/alpha" ]
+}

--- a/tests/bats/functions/claude_compose_workspace_skills.bats
+++ b/tests/bats/functions/claude_compose_workspace_skills.bats
@@ -186,6 +186,23 @@ run_compose() {
     [ -L "$TGT/marketplace-skill" ]
 }
 
+@test "both claude/setup.sh compose sites layer the workspace (#1652)" {
+    # agy BLOCKER on PR #1670: the internal/single-account branch composes
+    # skills directly instead of going through _claude_account_setup_one, so
+    # the workspace call has to appear at BOTH sites or single-account PCs
+    # (the company setup) silently get dotfiles skills only.
+    local setup="${_BATS_REAL_DOTFILES_ROOT}/claude/setup.sh"
+    local integ="${_BATS_REAL_DOTFILES_ROOT}/shell-common/tools/integrations/claude.sh"
+
+    # Every _claude_compose_skills_dir call must be followed by a workspace call.
+    local compose_sites workspace_sites
+    compose_sites=$(grep -c '^[[:space:]]*_claude_compose_skills_dir ' "$setup" "$integ"         | awk -F: '{s+=$2} END {print s}')
+    workspace_sites=$(grep -c '^[[:space:]]*_claude_compose_workspace_skills ' "$setup" "$integ"         | awk -F: '{s+=$2} END {print s}')
+
+    [ "$compose_sites" -gt 0 ]
+    [ "$workspace_sites" -eq "$compose_sites" ]
+}
+
 @test "missing skill_sources.sh warns instead of silently no-opping (#1652 / #724)" {
     seed_ws_repo "packaging-skills" "create"
 

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -425,3 +425,263 @@ EOF
     [ -L "${FIXTURE_HOME}/.hermes/skills/dotfiles/alpha" ]
     [ -L "${FIXTURE_HOME}/.hermes/skills/dotfiles/gamma" ]
 }
+
+# ---------------------------------------------------------------------
+# issue #1652 — 다중 워크스페이스 루트 스캔 (#1410 F-6 조기 도입)
+# dotfiles claude/skills/ 스캔은 그대로 두고(F-2/NF-1), 로컬에 clone 된
+# marketplace repo 들(${WORKSPACE_ROOT}/<repo>/skills/<skill>/SKILL.md)을
+# 소스 목록에 **추가로** 합류시킨다. fan-out 로직은 손대지 않는다(F-4).
+# ---------------------------------------------------------------------
+
+# Seed a workspace repo under the given root.
+# Usage: seed_workspace_skill <workspace_root> <repo> <skill> [<skill>...]
+seed_workspace_skill() {
+    local root="$1" repo="$2"
+    shift 2
+    local skill
+    for skill in "$@"; do
+        mkdir -p "${root}/${repo}/skills/${skill}"
+        cat > "${root}/${repo}/skills/${skill}/SKILL.md" <<EOF
+---
+name: ${skill}
+description: workspace stub for ${repo}/${skill}
+---
+EOF
+    done
+}
+
+# The default workspace root the script derives from \$HOME (F-1).
+default_workspace_root() {
+    printf '%s\n' "${FIXTURE_HOME}/para/project/skills"
+}
+
+run_setup_with_workspace() {
+    WORKSPACE_ROOT="$1" HOME="$FIXTURE_HOME" \
+        run bash "${FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
+}
+
+@test "workspace: default root ~/para/project/skills is scanned (#1652 F-1)" {
+    seed_opencode_home
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta" "epsilon"
+
+    run_setup
+    assert_success
+
+    local oc_dir="${FIXTURE_HOME}/.config/opencode/skills"
+    for s in delta epsilon; do
+        [ -L "${oc_dir}/${s}" ]
+        [ "$(readlink -f "${oc_dir}/${s}")" \
+            = "$(readlink -f "$(default_workspace_root)/packaging-skills/skills/${s}")" ]
+    done
+}
+
+@test "workspace: dotfiles SSOT keeps being scanned in parallel (#1652 F-2/NF-1)" {
+    seed_opencode_home
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+
+    local oc_dir="${FIXTURE_HOME}/.config/opencode/skills"
+    # Both sources are represented at once.
+    for s in alpha beta gamma; do
+        [ -L "${oc_dir}/${s}" ]
+        [ "$(readlink -f "${oc_dir}/${s}")" \
+            = "$(readlink -f "${FIXTURE_DOTFILES}/claude/skills/${s}")" ]
+    done
+    [ -L "${oc_dir}/delta" ]
+}
+
+@test "workspace: skills reach every harness including codex (#1652 F-4)" {
+    seed_opencode_home
+    seed_gemini_home
+    seed_hermes_home
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
+    [ -L "${FIXTURE_HOME}/.gemini/skills/delta" ]
+    [ -L "${FIXTURE_HOME}/.hermes/skills/dotfiles/delta" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/delta" ]
+}
+
+@test "workspace: WORKSPACE_ROOT env var overrides the default path (#1652 F-3)" {
+    seed_opencode_home
+    local custom="${TEST_TEMP_HOME}/custom-workspace"
+    seed_workspace_skill "$custom" "other-skills" "zeta"
+    # The default location holds a different skill — it must NOT be used.
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
+
+    run_setup_with_workspace "$custom"
+    assert_success
+
+    local oc_dir="${FIXTURE_HOME}/.config/opencode/skills"
+    [ -L "${oc_dir}/zeta" ]
+    [ ! -e "${oc_dir}/delta" ]
+}
+
+@test "workspace: absent root is a silent no-op, dotfiles still linked (#1652 Error Case 1)" {
+    seed_opencode_home
+    [ ! -d "$(default_workspace_root)" ]
+
+    run_setup
+    assert_success
+    refute_output --partial "No such file"
+
+    for s in alpha beta gamma; do
+        [ -L "${FIXTURE_HOME}/.config/opencode/skills/${s}" ]
+    done
+}
+
+@test "workspace: repo without a skills/ dir is skipped silently (#1652 Error Case 2)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    mkdir -p "${ws}/not-a-skill-repo/docs"
+    printf 'readme\n' > "${ws}/not-a-skill-repo/README.md"
+    seed_workspace_skill "$ws" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/not-a-skill-repo" ]
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/docs" ]
+}
+
+@test "workspace: skills/ entry without SKILL.md is not a source (#1652 F-1)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "packaging-skills" "delta"
+    # A stray directory under skills/ that is not a skill.
+    mkdir -p "${ws}/packaging-skills/skills/_shared"
+    printf 'notes\n' > "${ws}/packaging-skills/skills/_shared/NOTES.md"
+
+    run_setup
+    assert_success
+
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/_shared" ]
+}
+
+@test "workspace: name collision keeps the dotfiles SSOT source (#1652 NF-1)" {
+    seed_opencode_home
+    # `alpha` already exists in the dotfiles SSOT.
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "alpha"
+
+    run_setup
+    assert_success
+
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/alpha")" \
+        = "$(readlink -f "${FIXTURE_DOTFILES}/claude/skills/alpha")" ]
+}
+
+@test "workspace: two repos exposing the same skill — first wins, deterministically (#1652)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    # Mirrors the real `packaging-skills` + `packaging-skills-feat-1`
+    # (a git worktree of the same repo) sitting side by side.
+    seed_workspace_skill "$ws" "aaa-skills" "delta"
+    seed_workspace_skill "$ws" "zzz-skills" "delta"
+
+    run_setup
+    assert_success
+
+    # Glob order is sorted, so the alphabetically first repo wins — and
+    # the choice must not flip between runs.
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
+        = "$(readlink -f "${ws}/aaa-skills/skills/delta")" ]
+
+    run_setup
+    assert_success
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
+        = "$(readlink -f "${ws}/aaa-skills/skills/delta")" ]
+}
+
+@test "workspace: stale entry is pruned when the repo disappears (#1652 NF-3)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
+
+    rm -rf "${ws}/packaging-skills"
+
+    run_setup
+    assert_success
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
+    # dotfiles-sourced entries are untouched.
+    [ -L "${FIXTURE_HOME}/.config/opencode/skills/alpha" ]
+}
+
+@test "workspace: codex prunes a workspace skill once its repo is gone (#1652 NF-3)" {
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+    [ -L "${FIXTURE_HOME}/.codex/skills/delta" ]
+
+    rm -rf "${ws}/packaging-skills"
+
+    run_setup
+    assert_success
+    [ ! -e "${FIXTURE_HOME}/.codex/skills/delta" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/alpha" ]
+}
+
+@test "workspace: SKILL.md edits are live through the composed link (#1652 NF-2)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+
+    # Edit the source in place — no re-install, no re-run.
+    printf 'EDITED-IN-WORKSPACE\n' \
+        >> "${ws}/packaging-skills/skills/delta/SKILL.md"
+
+    run grep -q 'EDITED-IN-WORKSPACE' \
+        "${FIXTURE_HOME}/.config/opencode/skills/delta/SKILL.md"
+    assert_success
+}
+
+@test "workspace: synthesis stays idempotent with a workspace present (#1652)" {
+    seed_opencode_home
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
+
+    run_setup
+    assert_success
+    local before
+    before="$(ls -la "${FIXTURE_HOME}/.config/opencode/skills")"
+
+    run_setup
+    assert_success
+    local after
+    after="$(ls -la "${FIXTURE_HOME}/.config/opencode/skills")"
+
+    [ "$before" = "$after" ]
+}
+
+@test "workspace: allowlist still gates codex for workspace skills (#1652 F-4)" {
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
+    printf 'alpha\ndelta\n' \
+        > "${FIXTURE_DOTFILES}/claude/skills/.codex-allowlist"
+
+    run_setup
+    assert_success
+
+    [ -L "${FIXTURE_HOME}/.codex/skills/alpha" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/delta" ]
+    [ ! -e "${FIXTURE_HOME}/.codex/skills/beta" ]
+}

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -8,6 +8,8 @@ load '../test_helper'
 SETUP_SSOT_SCRIPT="${DOTFILES_ROOT}/scripts/setup-skills-ssot.sh"
 DIAG_SCRIPT="${DOTFILES_ROOT}/scripts/maintenance/check_codex_skills_budget.py"
 UX_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+# Workspace source enumeration is shared with the Claude Code side (#1652).
+SKILL_SOURCES_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
 
 setup() {
     setup_isolated_home
@@ -22,10 +24,13 @@ setup() {
         "${FIXTURE_DOTFILES}/claude/skills/beta" \
         "${FIXTURE_DOTFILES}/claude/skills/gamma" \
         "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib" \
+        "${FIXTURE_DOTFILES}/shell-common/functions" \
         "${FIXTURE_HOME}/.codex/skills"
 
     cp "$SETUP_SSOT_SCRIPT" "${FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
     cp "$UX_LIB_SOURCE" "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib/ux_lib.sh"
+    cp "$SKILL_SOURCES_LIB_SOURCE" \
+        "${FIXTURE_DOTFILES}/shell-common/functions/skill_sources.sh"
 
     for s in alpha beta gamma; do
         cat > "${FIXTURE_DOTFILES}/claude/skills/${s}/SKILL.md" <<EOF
@@ -431,6 +436,8 @@ EOF
 # dotfiles claude/skills/ 스캔은 그대로 두고(F-2/NF-1), 로컬에 clone 된
 # marketplace repo 들(${WORKSPACE_ROOT}/<repo>/skills/<skill>/SKILL.md)을
 # 소스 목록에 **추가로** 합류시킨다. fan-out 로직은 손대지 않는다(F-4).
+# 워크스페이스 열거 규칙 자체의 SSOT 는 shell-common/functions/skill_sources.sh
+# 이고, Claude Code 계정 쪽 커버리지는 claude_compose_workspace_skills.bats.
 # ---------------------------------------------------------------------
 
 # Seed a workspace repo under the given root.
@@ -600,6 +607,37 @@ run_setup_with_workspace() {
     assert_success
     [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
         = "$(readlink -f "${ws}/aaa-skills/skills/delta")" ]
+}
+
+@test "workspace: a linked git worktree never shadows its clone (#1652)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "packaging-skills" "delta"
+    mkdir -p "${ws}/packaging-skills/.git"
+    # A linked worktree of the same repo: `.git` is a file, and the name
+    # sorts ahead of the clone under LC_ALL=C ('-' < '/').
+    seed_workspace_skill "$ws" "packaging-skills-feat-1" "delta"
+    printf 'gitdir: /elsewhere\n' > "${ws}/packaging-skills-feat-1/.git"
+
+    run_setup
+    assert_success
+
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
+        = "$(readlink -f "${ws}/packaging-skills/skills/delta")" ]
+}
+
+@test "workspace: WORKSPACE_ROOT of \$HOME is refused as too broad (#1652 safety)" {
+    seed_opencode_home
+    seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
+
+    run_setup_with_workspace "$FIXTURE_HOME"
+    assert_success
+
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
+    for s in alpha beta gamma; do
+        [ -L "${FIXTURE_HOME}/.config/opencode/skills/${s}" ]
+    done
 }
 
 @test "workspace: stale entry is pruned when the repo disappears (#1652 NF-3)" {


### PR DESCRIPTION
## Summary
- `#1410` F-6 의 **비파괴 절반만** 앞당겨 도입한다 — 로컬에 clone 해 둔 marketplace repo 의 스킬을 소스 목록에 **추가**한다. dotfiles `claude/skills/` 제거(파괴적 절반)는 NF-3 대로 Phase 4 에 그대로 남는다.
- 소스 경로는 `${WORKSPACE_ROOT:-~/para/project/skills}/<repo>/skills/<skill>/SKILL.md`. 6개 하네스의 fan-out 로직은 건드리지 않았다(F-4) — enumeration 만 다중화했다.
- 실측: 워크스페이스 6개 repo · 24개 skill 중 20개가 6개 하네스 전부에 합류했다(4개는 dotfiles 와 이름이 겹쳐 dotfiles 유지, worktree 1개 제외).

## Changes
- `shell-common/functions/skill_sources.sh` (신규): 워크스페이스 판별·열거의 SSOT. `_skill_workspace_root` (안전 가드 포함) + `_skill_workspace_dirs`.
- `scripts/setup-skills-ssot.sh`: `collect_skill_sources()` 가 dotfiles + 워크스페이스를 병합한 목록 하나를 만들고, Codex / OpenCode / Gemini(+agy) / Hermes 4개 fan-out 루프가 그 목록을 공유한다. `skill_source_is_managed()` / `skill_source_path_for()` 로 refresh·stale-prune 판정을 두 루트로 확장했다.
- `shell-common/tools/integrations/claude.sh`: `_claude_compose_workspace_skills()` 신설, `_claude_account_setup_one()` 이 dotfiles 합성 직후 호출한다.
- `tests/bats/tools/setup_skills_ssot.bats`: +16 케이스. `tests/bats/functions/claude_compose_workspace_skills.bats` (신규): 11 케이스.
- `claude/AGENTS.md` / `docs/public/changelog.d/2026-09-01-1652.md`: 문서.

## 설계 판단 (리뷰 포인트)

**1. 이슈 Impact 표를 넘어선 범위 — Claude Code 쪽도 함께 고쳤다.**
이슈는 `scripts/setup-skills-ssot.sh` 만 지목하지만, 그 스크립트의 fan-out 대상은 Codex / OpenCode / Gemini(+agy) / Hermes **4개**다. Claude Code 계정은 `claude.sh` 의 `_claude_compose_skills_dir()` 가 따로 합성한다. 수용 기준 1번과 F-4 가 말하는 "6개 하네스" 를 채우려면 양쪽이 다 필요해서 함께 넣었다. 스크립트 헤더 주석의 "5 CLI" 표기가 이 착시의 출처로 보인다.

**2. 열거 규칙을 `shell-common` 한 곳에 둔 이유.**
4개 CLI 는 bash 스크립트가, Claude Code 는 인터랙티브 셸에 source 되는 POSIX 함수가 합성한다. 방언도 호출부도 다르지만 "무엇이 워크스페이스 skill 인가" 는 반드시 일치해야 한다 — 두 벌로 갈라지면 하네스마다 다른 repo 가 같은 이름을 차지하는 조용한 버그가 된다.

**3. linked git worktree 스킵.**
`<repo>-<branch>` 는 `LC_ALL=C` 에서 `<repo>` 보다 **앞서** 정렬된다(`-` 0x2D < `/` 0x2F). 그대로 두면 feature 워크트리가 원본 clone 의 스킬을 가려버린다. 실제로 이 PR 을 작성하는 시점의 워크스페이스에 `packaging-skills` 와 그 워크트리 `packaging-skills-feat-1` 이 나란히 있었다. `.git` 이 디렉토리가 아니라 파일인 repo 를 스킵해 해결했다.

**4. glob 대신 `find`.**
zsh 는 매치 없는 glob 에서 함수를 통째로 중단시킨다(`nomatch`). "워크스페이스는 있는데 repo 가 아직 없음" 이 첫 실행의 정상 상태이므로 glob 을 쓸 수 없다. `shell-common/functions/devops_help.sh` 가 같은 이유로 이미 `find` 를 쓴다.

**5. `WORKSPACE_ROOT` 폭 가드.**
호출부가 "이 심볼릭이 루트 아래인가" 로 삭제 여부를 판단한다. 루트가 `/` 나 `$HOME` 이면 무관한 사용자 심볼릭까지 우리 것으로 오인해 지울 수 있어 그 경우 스캔을 끈다(= 종전 동작).

**6. 이름 충돌은 dotfiles 승.**
NF-1 이 "순수 추가" 이므로 기존 링크를 재조준하면 안 된다. 워크스페이스 repo 끼리 겹치면 정렬상 앞선 repo 가 이겨 재현 가능하다.

## Test plan
- [x] `tests/bats/tools/setup_skills_ssot.bats` 36/36, `tests/bats/functions/claude_compose_workspace_skills.bats` 11/11, `claude_compose_skills_dir.bats` 5/5 — 총 52건 중 실패 1건은 `check_codex_skills_budget` 의 컬럼 폭 어긋남으로 **HEAD 에서도 동일하게 실패**하는 기존 항목이다(`Skills:     3` 기대 vs `Skills:         3` 출력).
- [x] 실제 워크스페이스(`~/para/project/skills`, repo 6개) 대상 격리 HOME 스모크 — opencode/codex/gemini/hermes 각 93개(dotfiles 73 + 워크스페이스 20), Claude Code 합성도 동일하게 73+20.
- [x] `shellcheck -x` 신규·수정 셸 파일 통과, `lint-docs` errors=0.
- [ ] 리뷰어 확인 요청: 워크스페이스에 아무 repo 도 없는 PC 에서 `./setup.sh` 가 종전과 동일하게 동작하는지 (Error Case 1 — bats 로는 덮었으나 실기 확인이 있으면 좋다).

## Related
Closes #1652

---
<details>
<summary>🤖 AI Metrics · 📊 ~11000 tokens · 👤 ~24 h (3 d) · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~11000 tokens · 👤 ~24 h (3 d) · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
