### PR TITLE
feat(skills): #1410 Phase 2 — gh-setup-skills repo 생성

### DIFF
--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -19,5 +19,6 @@
   "session-skills": "dEitY719/session-skills",
   "gh-verify-skills": "dEitY719/gh-verify-skills",
   "spec-flow-skills": "dEitY719/spec-flow-skills",
-  "authoring-skills": "dEitY719/authoring-skills"
+  "authoring-skills": "dEitY719/authoring-skills",
+  "gh-setup-skills": "dEitY719/gh-setup-skills"
 }

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -10,6 +10,7 @@
     "document-skills@anthropic-agent-skills",
     "example-skills@anthropic-agent-skills",
     "gh-resolve@gh-resolve-skills",
+    "gh-setup@gh-setup-skills",
     "gh-verify@gh-verify-skills",
     "harness@harness-skills",
     "hookify@claude-plugins-official",

--- a/docs/public/changelog.d/2026-09-01-1658.md
+++ b/docs/public/changelog.d/2026-09-01-1658.md
@@ -1,0 +1,6 @@
+- 변경: **`dEitY719/gh-setup-skills` 레포를 신설하고 `gh-label-bootstrap` · `gh-kanban-bootstrap` · `gh-add-ai-metrics` · `devx-docs-bootstrap` 4개 스킬을 `gh-setup` 플러그인으로 이관했다 — #1410 스킬 마켓플레이스 분리 계획의 Phase 2. 이 플러그인의 축은 "1회성 repo 초기화"다: 라벨 SSOT 동기화, Projects v2 칸반 보드, docs/ 골격, ai-metrics footer 소급 부착 (#1658)**
+- 변경: **새 레포에서는 스킬 디렉터리의 `gh-` / `devx-` 접두가 빠져 `/gh-setup:label-bootstrap` 형태로 호출한다 (#1410 F-4 — `/gh-setup:gh-label-bootstrap` 은 접두가 중복된다). dotfiles 의 `claude/skills/gh-label-bootstrap` 등 원본 4개는 그대로 남아 `/gh:label-bootstrap` · `/devx:docs-bootstrap` 호출도 계속 동작한다 (NF-1, 삭제는 Phase 4)**
+- 변경: **레포에 6개 하네스 매니페스트(Claude Code / Codex / Kimi / Hermes / OpenCode / Gemini·Antigravity)를 갖췄고, 하네스별 툴 매핑은 복제하지 않고 `harness-skills` 를 링크한다 (#1410 F-5 / NF-2)**
+- 변경: **`gh-setup-skills` CI 는 처음부터 `harness-skills` 의 재사용 워크플로(#1410 D-10)를 `plugin-name: gh-setup` 으로 호출한다 — 독립 workflow 로 시작하면 곧바로 전환 후속 작업이 생기기 때문이다**
+- 변경: **재사용 워크플로의 `allow-emoji-paths` 입력을 `skills/add-ai-metrics/` 한 경로에만 적용했다 — `add-ai-metrics` 는 ai-metrics footer 를 쓰는 스킬이고 그 footer 의 차트/사람/로봇 글리프는 #317 F-2 + PR #320 으로 확정된 의도된 시각 디자인이라 references 가 이를 그대로 인용한다. 레포의 나머지 전역 이모지 금지는 그대로다**
+- 변경: **`claude/plugin/marketplaces.json` 에 `gh-setup-skills`, `claude/plugin/plugins.json` 에 `gh-setup@gh-setup-skills` 를 등록했다 — `claude/plugin/restore.sh` 가 새 항목을 복원 대상으로 인식한다**

--- a/tests/bats/tools/claude_plugin_restore.bats
+++ b/tests/bats/tools/claude_plugin_restore.bats
@@ -274,3 +274,10 @@ notes-skills|dEitY719/notes-skills|notes
 authoring-skills|dEitY719/authoring-skills|authoring
 TABLE
 }
+
+@test "restore.sh --dry-run installs gh-setup@gh-setup-skills from its marketplace (#1658)" {
+    run "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/restore.sh" --dry-run
+    assert_success
+    assert_output --partial 'add: gh-setup-skills (dEitY719/gh-setup-skills)'
+    assert_output --partial 'install: gh-setup@gh-setup-skills'
+}

--- a/tests/bats/tools/claude_plugin_restore.bats
+++ b/tests/bats/tools/claude_plugin_restore.bats
@@ -272,12 +272,6 @@ JSON
     done <<'TABLE'
 notes-skills|dEitY719/notes-skills|notes
 authoring-skills|dEitY719/authoring-skills|authoring
+gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
 TABLE
-}
-
-@test "restore.sh --dry-run installs gh-setup@gh-setup-skills from its marketplace (#1658)" {
-    run "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/restore.sh" --dry-run
-    assert_success
-    assert_output --partial 'add: gh-setup-skills (dEitY719/gh-setup-skills)'
-    assert_output --partial 'install: gh-setup@gh-setup-skills'
 }

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -56,6 +56,7 @@ session-skills|dEitY719/session-skills|session
 gh-verify-skills|dEitY719/gh-verify-skills|gh-verify
 spec-flow-skills|dEitY719/spec-flow-skills|spec-flow
 authoring-skills|dEitY719/authoring-skills|authoring
+gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
 TABLE
 }
 
@@ -93,6 +94,7 @@ TABLE
 #1659|devx-pr-review-all devx-pr-verify-live devx-pr-verify-merged devx-exception-merge-checklist gh-pr-post-merge-verify
 #1657|devx-prd-to-trd devx-trd-to-issues devx-pr-to-ssot-issue devx-reverse-engineering-analysis devx-claude-to-codex
 #1662|skill-create skill-check skill-refactor sh-check devx-ux-guidelines devx-command-rename
+#1658|gh-label-bootstrap gh-kanban-bootstrap gh-add-ai-metrics devx-docs-bootstrap
 TABLE
 }
 


### PR DESCRIPTION
## Summary
- `dEitY719/gh-setup-skills`(public, MIT)를 신규 생성하고 4개 스킬을 `gh-setup` 플러그인으로 이관했다 — #1410 스킬 마켓플레이스 분리 계획의 Phase 2.
- 이 플러그인의 축은 #1410 §1 표의 "1회성 repo 초기화"다: 라벨 SSOT 동기화, Projects v2 칸반 보드, `docs/` 골격, ai-metrics footer 소급 부착.
- dotfiles 쪽 변경은 마켓플레이스 등록 + 회귀 테스트 + changelog 세 갈래뿐이다. 스킬 원본은 건드리지 않았다(NF-1).

## Changes
- **신규 repo `gh-setup-skills`** (이 PR 범위 밖 산출물): `skills/{label-bootstrap,kanban-bootstrap,add-ai-metrics,docs-bootstrap}/` + 6개 하네스 매니페스트 + `.github/workflows/validate.yml`. 스킬 디렉터리에서 `gh-` / `devx-` 접두를 뗐다 — `/gh-setup:gh-label-bootstrap`은 접두가 중복되기 때문이다(#1410 F-4). 하네스별 툴 매핑은 복제하지 않고 `harness-skills`를 링크한다(F-5 / NF-2).
- **CI**: 처음부터 `harness-skills`의 재사용 워크플로(D-10)를 `plugin-name: gh-setup`으로 호출한다. 다만 공용 워크플로의 emoji 게이트가 `add-ai-metrics`를 막는다 — 이 스킬이 쓰는 ai-metrics footer의 차트/사람/로봇 글리프는 #317 F-2 + PR #320으로 확정된 의도된 시각 디자인이고 `references/`가 footer를 그대로 인용한다. `notes-skills`(#1643)가 같은 사유로 추가해 둔 `allow-emoji-paths` 입력에 `skills/add-ai-metrics/` 한 경로만 실어 우회했다. 레포의 나머지 전역 이모지 금지는 그대로다.
- **`claude/plugin/marketplaces.json` · `plugins.json`**: `gh-setup-skills` / `gh-setup@gh-setup-skills` 등록.
- **`tests/bats/tools/claude_plugin_scaffold.bats`**: 등록 회귀는 #1642가 접어 둔 #1410 테이블에 한 줄로 이었다 — 개별 테스트를 새로 만들지 않는 게 그 테이블의 관례다(#1643 리뷰). NF-1 원본 보존은 `notes-skills` 선례를 따라 별도 테스트로 못박는다.
- **`docs/public/changelog.d/2026-09-01-1658.md`**: fragment 1개 추가.

## Test plan
- [x] `gh-setup-skills` CI green — [run 33479599288](https://github.com/dEitY719/gh-setup-skills/actions/runs/33479599288)
- [x] 격리된 `CLAUDE_CONFIG_DIR`에서 `/plugin marketplace add` + `/plugin install`로 스킬 4개 로드 확인 (라이브 설정 무영향)
- [x] `claude/plugin/restore.sh --dry-run`이 `add: gh-setup-skills` / `install: gh-setup@gh-setup-skills` 인식
- [x] 7개 매니페스트 버전 `0.1.0` 일치, 모든 `name` 필드 `gh-setup`, SKILL.md 4개 모두 100줄 미만(98/99/91/84), description 합계 881/5440자
- [x] `claude/skills/` 원본 4개 무변경 (`git status --porcelain` 빈 출력)
- [x] dotfiles pytest 1619 passed / 1 failed, bats 40 not-ok — **편집 전 baseline과 실패 집합 완전 동일**(caused failure 0건). pre-existing 1건은 `test_committed_docs_match_a_fresh_render`(`gcp.md`, `mytool.md`)
- [x] `mise run lint-docs` errors=0

## Related
Closes #1658

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
