### PR TITLE
feat(skills): #1410 Phase 3 — gh-issue-skills repo 생성

### DIFF
--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -20,5 +20,6 @@
   "gh-verify-skills": "dEitY719/gh-verify-skills",
   "spec-flow-skills": "dEitY719/spec-flow-skills",
   "authoring-skills": "dEitY719/authoring-skills",
-  "gh-setup-skills": "dEitY719/gh-setup-skills"
+  "gh-setup-skills": "dEitY719/gh-setup-skills",
+  "gh-issue-skills": "dEitY719/gh-issue-skills"
 }

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -9,6 +9,7 @@
     "devenv@devenv-skills",
     "document-skills@anthropic-agent-skills",
     "example-skills@anthropic-agent-skills",
+    "gh-issue@gh-issue-skills",
     "gh-resolve@gh-resolve-skills",
     "gh-setup@gh-setup-skills",
     "gh-verify@gh-verify-skills",

--- a/docs/public/changelog.d/2026-09-01-1676.md
+++ b/docs/public/changelog.d/2026-09-01-1676.md
@@ -1,0 +1,2 @@
+- 변경: **`gh-issue-skills` repo 신규 생성 (#1410 Phase 3)** — 이슈·디스커션 라이프사이클 스킬 6종(`read`/`create`/`implement`/`proceed`/`discussion-create`/`discussion-convert`)을 `gh-issue` 플러그인으로 이관하고, 6개 하네스 매니페스트와 `harness-skills` reusable CI workflow 를 연결했다. dotfiles 원본은 그대로 남는다(삭제는 Phase 4).
+- 변경: **`claude/plugin/{marketplaces,plugins}.json` 에 `gh-issue-skills` 등록** — `restore.sh` 가 새 마켓플레이스와 `gh-issue@gh-issue-skills` 플러그인을 복원 대상으로 인식한다.

--- a/tests/bats/tools/claude_plugin_restore.bats
+++ b/tests/bats/tools/claude_plugin_restore.bats
@@ -273,5 +273,6 @@ JSON
 notes-skills|dEitY719/notes-skills|notes
 authoring-skills|dEitY719/authoring-skills|authoring
 gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
+gh-issue-skills|dEitY719/gh-issue-skills|gh-issue
 TABLE
 }

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -57,6 +57,7 @@ gh-verify-skills|dEitY719/gh-verify-skills|gh-verify
 spec-flow-skills|dEitY719/spec-flow-skills|spec-flow
 authoring-skills|dEitY719/authoring-skills|authoring
 gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
+gh-issue-skills|dEitY719/gh-issue-skills|gh-issue
 TABLE
 }
 
@@ -95,6 +96,7 @@ TABLE
 #1657|devx-prd-to-trd devx-trd-to-issues devx-pr-to-ssot-issue devx-reverse-engineering-analysis devx-claude-to-codex
 #1662|skill-create skill-check skill-refactor sh-check devx-ux-guidelines devx-command-rename
 #1658|gh-label-bootstrap gh-kanban-bootstrap gh-add-ai-metrics devx-docs-bootstrap
+#1676|gh-issue-read gh-issue-create gh-issue-implement gh-issue-proceed gh-discussion-create gh-discussion-convert
 TABLE
 }
 


### PR DESCRIPTION
## Summary
- #1410 §6 마이그레이션 Phase 3 의 첫 repo 로 `dEitY719/gh-issue-skills`(public, MIT)를 신규 생성하고, 이슈·디스커션 라이프사이클 스킬 6종을 `gh-issue` 플러그인으로 이관했다.
- 이 PR 이 dotfiles 쪽에 남기는 변경은 **등록과 기록뿐**이다 — 스킬 원본은 그대로 두고(NF-1, 삭제는 Phase 4), 신규 repo 를 `claude/plugin/*.json` 에 등록하고 등록 계약 회귀를 기존 테이블에 잇는다.
- Phase 2 와 달리 교차참조를 **최종 새 네임스페이스로 전부** 갱신했다. Phase 3 세 repo 의 이름이 이슈 작성 시점에 확정돼 있어서, 아직 존재하지 않는 자매 repo 를 가리키더라도 지금 정확히 쓰는 편이 §6 취지에 맞는다.

## Changes
- `claude/plugin/marketplaces.json` · `plugins.json`: `gh-issue-skills` / `gh-issue@gh-issue-skills` 등록 (F-5). `restore.sh --dry-run` 이 두 항목을 인식한다.
- `tests/bats/tools/claude_plugin_scaffold.bats`: #1410 등록 테이블에 `gh-issue-skills|dEitY719/gh-issue-skills|gh-issue` 한 줄, NF-1 원본 보존 테이블에 `#1676|...` 한 줄 추가. #1658 이 세운 관례대로 테스트를 새로 만들지 않고 테이블만 잇는다.
- `tests/bats/tools/claude_plugin_restore.bats`: real-SSOT 테이블에 같은 한 줄 추가.
- `docs/public/changelog.d/2026-09-01-1676.md`: 신규 fragment 2줄.

### 신규 repo 쪽 (이 PR 의 diff 에는 없지만 이 이슈의 산출물)
- `skills/{read,create,implement,proceed,discussion-create,discussion-convert}/` — `gh-issue-`/`gh-` 접두 제거 (#1410 F-4). frontmatter `name:` 은 bare 로 바꿔 디렉토리명과 일치시켰다(CI 가 `:` 를 거부한다).
- 6개 하네스 매니페스트 + `CLAUDE.md`/`AGENTS.md`(symlink)/`README.md`/`GEMINI.md`/`LICENSE`.
- `.github/workflows/validate.yml` → `dEitY719/harness-skills/.github/workflows/skill-check.yml@main` (`plugin-name: gh-issue`, D-10). 검사 로직 복제 없음(NF-2).

## 판단이 들어간 지점
- **F-1 vs F-3 충돌**: F-1 은 `packaging:create` 사용을 지시하지만 그 스킬은 중첩 mono 레이아웃을 만든다. Claude Code 외 다섯 하네스는 repo 루트에서 매니페스트를 찾으므로 중첩하면 플러그인이 조용히 Claude-Code 전용이 된다(기존 14개 자매 repo 가 전부 플랫인 이유). §1 스켈레톤을 따르고 `packaging:create` 에서는 git init → repo create → push 순서만 가져왔다.
- **§2 표 밖 3건 추가 이관**: `gh:pr-merge` → `gh-pr:merge`, `gh:pr-merge-emergency` → `gh-pr:merge-emergency`, `devx:trd-to-issues` → `spec-flow:trd-to-issues`. 셋 다 #1410 §2 배정표 + F-4 로 최종 이름이 일의적이고, 남기면 이관본에 dangling 참조가 생겨 Goal("모든 교차참조를 최종 새 네임스페이스로 갱신")과 어긋난다. repo README 의 cross-repo 표에 명시했다.
- **원본 스냅샷의 깨진 링크 5건은 그대로 이관**: 예) `implement/references/{fetch-issue,help}.md` 가 가리키는 `references/claim-issue.md` 는 dotfiles 에서 이미 `claim.md` 로 개명된 파일이다. 이관 손상이 아니라 원본 결함이라 고치면 스냅샷이 아니게 된다. 정리를 원하면 후속 이슈.

## NF-4 (마커 문자열 불변)
`[step:gh-issue-implement/...]` 는 손대지 않았다 — plugin명 `gh-issue` + 새 디렉토리명 `implement` 가 옛 catalog 키와 우연히 같은 문자열이라 변경이 불필요하다. `gh-issue-proceed` 의 마커도 같은 이유로 그대로다. 원본/이관본 마커 `diff` 결과 동일.

## Test plan
- [x] `gh-issue-skills` CI green — [run 33497377510](https://github.com/dEitY719/gh-issue-skills/actions/runs/33497377510) (매니페스트/frontmatter/라인수/description 예산/버전 일치/emoji)
- [x] `claude plugin install gh-issue@gh-issue-skills` 후 `claude plugin details` 가 **Skills (6)** 로드 확인
- [x] `restore.sh --dry-run` 이 `add: gh-issue-skills` / `install: gh-issue@gh-issue-skills` 출력
- [x] 수용기준 grep: 이관본에서 §2 옛 이름 0건
- [x] 원본 6개 디렉토리 그대로, 원본의 옛 교차참조도 그대로 (NF-1)
- [x] `mise run lint-docs` errors=0 (changelog fragment 포함)
- [x] `mise run test`: pytest 1619 passed / 1 failed, bats 48 not-ok — 편집 전 baseline 과 실패 집합 동일. `plugin_sync_hook.bats` 는 pristine HEAD 와 실패 **이름**까지 일치(15/19, 원인은 픽스처 temp repo 의 초기 커밋 부재)

## Related
Closes #1676

---
<details>
<summary>🤖 AI Metrics · 📊 ~3500 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3500 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
