### PR TITLE
feat(skills): #1410 Phase 3 — gh-pr-skills repo 생성

### DIFF
--- a/claude/hooks/skill_step_catalog.yml
+++ b/claude/hooks/skill_step_catalog.yml
@@ -73,3 +73,35 @@ gh-commit:
     - stage-commit
     - metrics-board-sync
     - report
+
+# --- #1410 Phase 3 migration (#1677) -----------------------------------------
+# The eight commit-to-merge skills moved to the `gh-pr-skills` repo, where the
+# plugin namespace `gh-pr` plus the de-prefixed directory names `create` /
+# `commit` spell markers the old keys above do not match. The migrated copies
+# therefore emit `[step:gh-pr-create/<id>]` and `[step:gh-pr-commit/<id>]`.
+#
+# The two keys below are ADDED, not renamed (#1677 D-12): the dotfiles
+# originals in `claude/skills/{gh-pr,gh-commit}/` are kept until Phase 4
+# (#1410 NF-1) and still emit the old markers, so deleting `gh-pr` / `gh-commit`
+# would strip their guard. Both paths are protected until Phase 4 removes the
+# originals and the old keys together.
+#
+# NF-4: each `required` list must stay identical to the key it mirrors —
+# migrating a skill does not change its steps.
+
+gh-pr-create:
+  enforce: true
+  description: "Create Pull Request from current branch (gh-pr-skills)"
+  required:
+    - push-and-create
+    - labels
+    - board-sync
+    - report
+
+gh-pr-commit:
+  enforce: true
+  description: "Git commit with issue linking (gh-pr-skills)"
+  required:
+    - stage-commit
+    - metrics-board-sync
+    - report

--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -21,5 +21,6 @@
   "spec-flow-skills": "dEitY719/spec-flow-skills",
   "authoring-skills": "dEitY719/authoring-skills",
   "gh-setup-skills": "dEitY719/gh-setup-skills",
-  "gh-issue-skills": "dEitY719/gh-issue-skills"
+  "gh-issue-skills": "dEitY719/gh-issue-skills",
+  "gh-pr-skills": "dEitY719/gh-pr-skills"
 }

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -10,6 +10,7 @@
     "document-skills@anthropic-agent-skills",
     "example-skills@anthropic-agent-skills",
     "gh-issue@gh-issue-skills",
+    "gh-pr@gh-pr-skills",
     "gh-resolve@gh-resolve-skills",
     "gh-setup@gh-setup-skills",
     "gh-verify@gh-verify-skills",

--- a/docs/public/changelog.d/2026-09-01-1677.md
+++ b/docs/public/changelog.d/2026-09-01-1677.md
@@ -1,0 +1,4 @@
+- 변경: **`gh-pr-skills` repo 신규 생성 (#1410 Phase 3)** — 커밋→PR→리뷰→머지 스킬 8종(`commit`/`create`/`review`/`reply`/`approve`/`merge`/`merge-emergency`/`merge-train`)을 `gh-pr` 플러그인으로 이관하고, 6개 하네스 매니페스트와 `harness-skills` reusable CI workflow 를 연결했다. dotfiles 원본은 그대로 남는다(삭제는 Phase 4).
+- 변경: **`gh:pr` 스킬 이름을 `gh-pr:create` 로 확정** — plugin 명과 디렉토리명이 유일하게 완전히 겹쳐 접두 제거로는 이름이 남지 않는 케이스라, 동작(PR 생성)을 살리고 `gh-issue:create` 와 대칭을 맞췄다. 후속 `gh-flow-skills` 의 hook 갱신이 이 이름을 그대로 쓴다.
+- 변경: **`claude/hooks/skill_step_catalog.yml` 에 `gh-pr-create`·`gh-pr-commit` 키 추가** — 이관본이 내보내는 새 마커(`[step:gh-pr-create/...]`)를 보호한다. 기존 `gh-pr`/`gh-commit` 키는 Phase 4 까지 남아 dotfiles 원본을 계속 보호한다.
+- 변경: **`claude/plugin/{marketplaces,plugins}.json` 에 `gh-pr-skills` 등록** — `restore.sh` 가 새 마켓플레이스와 `gh-pr@gh-pr-skills` 플러그인을 복원 대상으로 인식한다.

--- a/tests/bats/tools/claude_plugin_restore.bats
+++ b/tests/bats/tools/claude_plugin_restore.bats
@@ -274,5 +274,6 @@ notes-skills|dEitY719/notes-skills|notes
 authoring-skills|dEitY719/authoring-skills|authoring
 gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
 gh-issue-skills|dEitY719/gh-issue-skills|gh-issue
+gh-pr-skills|dEitY719/gh-pr-skills|gh-pr
 TABLE
 }

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -58,6 +58,7 @@ spec-flow-skills|dEitY719/spec-flow-skills|spec-flow
 authoring-skills|dEitY719/authoring-skills|authoring
 gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
 gh-issue-skills|dEitY719/gh-issue-skills|gh-issue
+gh-pr-skills|dEitY719/gh-pr-skills|gh-pr
 TABLE
 }
 
@@ -97,6 +98,7 @@ TABLE
 #1662|skill-create skill-check skill-refactor sh-check devx-ux-guidelines devx-command-rename
 #1658|gh-label-bootstrap gh-kanban-bootstrap gh-add-ai-metrics devx-docs-bootstrap
 #1676|gh-issue-read gh-issue-create gh-issue-implement gh-issue-proceed gh-discussion-create gh-discussion-convert
+#1677|gh-commit gh-pr gh-pr-review gh-pr-reply gh-pr-approve gh-pr-merge gh-pr-merge-emergency gh-pr-merge-train
 TABLE
 }
 


### PR DESCRIPTION
## Summary
- `dEitY719/gh-pr-skills` (public, MIT) 를 신규 생성하고 커밋→PR→리뷰→머지 스킬 8종을 `gh-pr` 플러그인으로 이관했다 (#1410 Phase 3). dotfiles 원본은 그대로 남는다 — 삭제는 Phase 4 (NF-1).
- 이 PR 의 diff 는 dotfiles 쪽 등록·보호 배선만 담는다. 실제 스킬 본문 95개 파일은 새 repo 에 있다.
- `gh:pr` 은 디렉토리명이 plugin 명과 완전히 겹치는 유일한 케이스라 접두 제거만으로는 이름이 남지 않는다 — `gh-pr:create` 로 확정했다 (§3).

## Changes
- `claude/plugin/marketplaces.json` · `plugins.json`: `gh-pr-skills` 마켓플레이스와 `gh-pr@gh-pr-skills` 플러그인 등록 (F-5).
- `claude/hooks/skill_step_catalog.yml`: `gh-pr-create` · `gh-pr-commit` 키 **추가** (F-8 / D-12). 기존 `gh-pr` / `gh-commit` 키는 지우지 않는다 — Phase 4 까지 남는 dotfiles 원본(NF-1)이 여전히 옛 마커를 내보내므로, 옛 키를 지우면 그 경로의 보호가 사라진다. `required` 목록은 옛 키와 동일 (NF-4).
- `tests/bats/tools/claude_plugin_{restore,scaffold}.bats`: #1658 이 세운 관례대로 세 테이블(#1410 등록 / NF-1 원본 보존 / restore.sh real-SSOT)에 한 줄씩 추가.
- `docs/public/changelog.d/2026-09-01-1677.md`: fragment 4줄.

## 새 repo 쪽 결정 (이 diff 밖)
- **교차참조**: §2 매핑대로 전부 최종 이름으로 옮겼다. §2 표가 누락한 세 건(`gh:label-bootstrap`, `gh:flow` — `gh:issue-flow` 오타, `ai-worktree:teardown`)도 #1410 §2 배정표로 이름이 일의적이고 남기면 dangling 참조가 되므로 `gh-setup:label-bootstrap` / `gh-flow:issue` / `session:worktree-teardown` 으로 같이 옮겼다.
- **dash-form 별칭**: `/gh-pr-merge` 류는 콜론 폼으로 합쳤다. 두 폼이 같은 새 이름으로 접히므로 그대로 두면 description 에 같은 이름이 두 번 들어간다.
- **`max-skill-lines: 197`**: `merge` 197 / `merge-train` 146 / `reply` 143 / `review` 110 이 100줄 한도를 넘은 채 넘어왔다. #1410 Non-Goals 가 이관 중 동작 변경을 금지하므로 파일을 자르는 대신 `gh-verify-skills`(215)와 같은 모양의 MIGRATION DEBT 주석과 함께 CI 입력을 올렸다.
- **남긴 런타임 결합 2건**: `merge` Step 5 의 `PMV_BLOCK` dotfiles 경로, `shell-common/functions/*.sh` 소싱. 둘 다 dispatch 문자열이라 이 이슈의 Non-Goals 가 Phase 4 로 미룬 항목이고, 호출부가 이미 soft-fail 이라 standalone 설치는 깨지지 않고 degrade 한다. repo `CLAUDE.md` → "Known migration debt" 에 열거했다.

## Test plan
- [x] `gh-pr-skills` CI green — run [33503650565](https://github.com/dEitY719/gh-pr-skills/actions/runs/33503650565), 12개 체크 스텝 전부 `success` (매니페스트 파싱, frontmatter, 라인 한도, description 예산, 버전 일치, shellcheck, no-emoji)
- [x] `claude plugin details gh-pr@gh-pr-skills` → `Skills (8) approve, commit, create, merge, merge-emergency, merge-train, reply, review`
- [x] `claude/plugin/restore.sh --dry-run` → `add: gh-pr-skills` + `install: gh-pr@gh-pr-skills` 인식
- [x] 배포된 clone 대상 §2 acceptance grep → 옛 이름 0건
- [x] 원본 8개 디렉토리 무변경 (`git status claude/skills/` 비어 있음) + 옛 마커 7개 그대로
- [x] 원본↔이관본 diff 914줄 전부 리네임 맵으로 설명됨 (자동 대조)
- [x] `gh-pr-create` / `gh-pr-commit` 의 `required` 가 `gh-pr` / `gh-commit` 과 동일함을 프로그램으로 단언 (NF-4)
- [x] dotfiles `mise run test` — pytest 1619 passed / 1 failed(`test_committed_docs_match_a_fresh_render`, baseline 동일), bats 48 not-ok 가 baseline 과 집합 일치. `pr_merge_train_cron` 의 폴링 횟수 단언 1건만 load average 38 에서 추가로 흔들렸고 격리 재실행에서 통과 — 이 PR 은 cron 코드를 건드리지 않는다.

## Related
Closes #1677

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~8 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~8 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
