### PR TITLE
fix(skills): unbreak two gh --json fetch blocks that never ran as written

### DIFF
--- a/claude/skills/gh-issue-read/SKILL.md
+++ b/claude/skills/gh-issue-read/SKILL.md
@@ -53,12 +53,12 @@ Substeps and error templates in `references/repo-resolution.md`.
 
 ```bash
 GH_HOST="$TARGET_HOST" gh issue view <N> --repo "$TARGET_REPO" --json \
-  number,title,body,author,labels,state,stateReason,\
-  comments,assignees,createdAt,updatedAt,url
+  number,title,body,author,labels,state,comments,assignees,createdAt,updatedAt,url
 ```
 
-On error (issue not found, auth failure), print `gh` stderr verbatim
-and stop — do not attempt fallback.
+On error (issue not found, auth failure), print `gh` stderr verbatim and stop —
+do not attempt fallback. A CLOSED issue needs one extra REST read for the Header
+close reason: `references/output-format.md` → "Close reason".
 
 ## Step 3: Format Output
 

--- a/claude/skills/gh-issue-read/references/output-format.md
+++ b/claude/skills/gh-issue-read/references/output-format.md
@@ -12,7 +12,8 @@ The skill prints sections in this exact order. Empty sections are omitted except
 ```
 
 `state` is one of `OPEN`, `CLOSED`. If the issue is closed as `not_planned` or `completed`, include that in parens:
-`(CLOSED — completed)`.
+`(CLOSED — completed)`. That reason comes from the extra read below, not from
+`gh issue view` — see "Close reason".
 
 ### 2. Summary (2-4 lines)
 
@@ -69,8 +70,7 @@ Checklist:
 
 ```bash
 GH_HOST="$TARGET_HOST" gh issue view <N> --repo "$TARGET_REPO" --json \
-  number,title,body,author,labels,state,stateReason,\
-  comments,assignees,createdAt,updatedAt,url
+  number,title,body,author,labels,state,comments,assignees,createdAt,updatedAt,url
 ```
 
 `GH_HOST` + `--repo` are both mandatory — see `references/repo-resolution.md`
@@ -78,4 +78,25 @@ GH_HOST="$TARGET_HOST" gh issue view <N> --repo "$TARGET_REPO" --json \
 
 `comments` items: `{author, body, createdAt}`.
 `labels` items: `{name}`.
+
+## Close reason
+
+`gh issue view --json` grew a `stateReason` field only in later `gh` releases;
+asking for it on an older one aborts the whole fetch before anything is printed:
+
+```
+Unknown JSON field: "stateReason"
+```
+
+So the Header's `(CLOSED — <reason>)` parenthetical reads the REST field instead,
+which every `gh` version exposes. Run it only when `state` is `CLOSED`:
+
+```bash
+GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/issues/<N>" --jq '.state_reason'
+```
+
+`completed` / `not_planned` / `null`. This is a second **read** — it mutates
+nothing, so the skill's read-only contract holds. It is also non-fatal: if the
+call fails or yields `null`, print the Header without the parenthetical rather
+than aborting a fetch that already succeeded.
 `author`, `assignees` items: `{login}`.

--- a/claude/skills/gh-pr-merge/references/strategy-selection.md
+++ b/claude/skills/gh-pr-merge/references/strategy-selection.md
@@ -33,8 +33,7 @@ Do NOT silently switch strategies.
 
 ```bash
 GH_HOST="$TARGET_HOST" gh pr view <N> --repo "$TARGET_REPO" --json \
-  number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,\
-  baseRefName,headRefName,url
+  number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,url
 ```
 
 ## Hard-stop decisions

--- a/docs/feature/superpowers-plans/2026-04-22-gh-skills-expansion.md
+++ b/docs/feature/superpowers-plans/2026-04-22-gh-skills-expansion.md
@@ -253,8 +253,7 @@ Checklist:
 
 ```bash
 gh issue view <N> --repo "$TARGET_REPO" --json \
-  number,title,body,author,labels,state,stateReason,\
-  comments,assignees,createdAt,updatedAt,url
+  number,title,body,author,labels,state,comments,assignees,createdAt,updatedAt,url
 ```
 
 `comments` items: `{author, body, createdAt}`.
@@ -309,8 +308,7 @@ Substeps and error templates in `references/repo-resolution.md`.
 
 ```bash
 gh issue view <N> --repo "$TARGET_REPO" --json \
-  number,title,body,author,labels,state,stateReason,\
-  comments,assignees,createdAt,updatedAt,url
+  number,title,body,author,labels,state,comments,assignees,createdAt,updatedAt,url
 ```
 
 On error (issue not found, auth failure), print `gh` stderr verbatim
@@ -473,8 +471,7 @@ Do NOT silently switch strategies.
 
 ```bash
 gh pr view <N> --repo "$TARGET_REPO" --json \
-  number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,\
-  baseRefName,headRefName,author
+  number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,author
 ```
 
 ## Hard-stop decisions


### PR DESCRIPTION
Found while documenting `gh-issue-skills`: running `gh-issue-read` exactly as its own SKILL.md prescribes fails before printing anything. Two independent defects sit in the same fetch command, both surfaced by *executing* the documented blocks rather than reading them.

## 1. `stateReason` is not a `--json` field on older gh

`gh 2.45.0` answers `Unknown JSON field: "stateReason"` and exits 1, so the whole fetch dies. The field is load-bearing — `output-format.md`'s Header spec uses it for the `(CLOSED — completed)` parenthetical — so the lookup moves to the REST field, which every gh version exposes:

```bash
GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/issues/<N>" --jq '.state_reason'
```

Runs only when `state` is CLOSED, is a GET so the read-only contract holds, and is non-fatal: on failure or `null` the Header omits the parenthetical instead of aborting a fetch that already succeeded.

## 2. Split `--json` field lists

Three lists were broken across two backslash-continued lines. The second line's indentation acts as an argument separator, so gh sees two values:

```
gh issue view ... --json   ->  accepts 1 arg(s), received 2
gh pr view    ... --json   ->  accepts at most 1 arg(s), received 2
```

Collapsed to a single continued line in `gh-issue-read` (SKILL.md + output-format.md) and `gh-pr-merge` (strategy-selection.md). `gh-issue-implement` and `gh-issue-proceed` continue only one line each and were never affected.

## Verification

Each block was extracted from its own document and run:

| Block | Result |
|---|---|
| `gh-issue-read/SKILL.md` Step 2 | exit 0, 13,889 bytes |
| `output-format.md` JSON fields | exit 0, 13,889 bytes |
| Close reason, #1676 | `completed` |
| Close reason, #1665 | `not_planned` |
| Close reason, OPEN #1678 | skipped, no parenthetical |
| `gh-pr-merge/strategy-selection.md` | exit 0, all 9 keys |

## Notes

- Mirrors the same fix already on `dEitY719/gh-issue-skills` main (`a8bb602`).
- The Phase-4 removal of these copies (#1410 NF-1 / NF-3) is unaffected.
- The freshly created `gh-pr-skills` repo inherited defect 2 in `skills/merge/references/strategy-selection.md`; not touched here.
- `docs/feature/superpowers-plans/2026-04-22-gh-skills-expansion.md` carries the same pattern in three places. Left as a historical planning record.