### PR TITLE
feat(skills): #1410 Phase 3 — gh-flow-skills repo 생성 + hook dual-form 전환

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -52,8 +52,8 @@ Edit `claude/settings.json` to change behavior across all PCs:
 - **Status line** — `statusLine.command` points at the dotfiles SSOT script
   (`${HOME}/dotfiles/claude/statusline-command.sh`); works across multi-account
   `CLAUDE_CONFIG_DIR` targets without per-account symlinks (issue #296).
-- **Hooks** — `Stop` / `PostToolUse` entries already wired for `gh:issue-flow`
-  and `gh:pr` flows.
+- **Hooks** — `Stop` / `PostToolUse` entries already wired for `gh-flow:issue`
+  and `gh-pr:create` flows.
 - **Plugins** — `enabledPlugins` controls which Claude plugins load.
 - **Sandboxing / permissions** — add Claude Code permission rules here if you
   want them shipped across all your PCs; per-PC overrides go in the local

--- a/claude/hooks/devx_autopilot_stop_guard.py
+++ b/claude/hooks/devx_autopilot_stop_guard.py
@@ -107,18 +107,18 @@ _STEP_LABELS: dict[str, str] = {
     "pr-reply": "Step 5 — Skill(gh-pr:reply, <PR_NUM>) (emit the marker even with no comments / [SKIP])",
 }
 
-# Skill names whose `[step:<name>/<id>] OK` markers this guard honours: the
-# dotfiles-native `devx-autopilot` and, since #1410 Phase 3, the migrated
-# `gh-flow-autopilot` (D-12, issue #1678). Both are accepted for the whole
-# transition — NF-1 keeps the dotfiles original emitting the old marker until
-# Phase 4, while anyone running the `gh-flow-skills` plugin emits the new one.
-_MARKER_SKILL_NAMES: tuple[str, ...] = ("devx-autopilot", "gh-flow-autopilot")
-
 # Strict step-marker regex. Requires the literal `[step:<skill>/<id>] OK`
 # so a partial `[step:devx-autopilot/plan]` without ` OK` does NOT match.
-_STEP_MARKER_RE: re.Pattern[str] = re.compile(
-    r"\[step:(?:" + "|".join(re.escape(n) for n in _MARKER_SKILL_NAMES) + r")/([a-z-]+)\]\s+OK\b"
-)
+#
+# Two skill names are honoured: the dotfiles-native `devx-autopilot` and,
+# since #1410 Phase 3, the migrated `gh-flow-autopilot` (D-12, issue #1678).
+# Both are accepted for the whole transition — NF-1 keeps the dotfiles
+# original emitting the old marker until Phase 4, while anyone running the
+# `gh-flow-skills` plugin emits the new one. Both are spelled out literally
+# here, like the `TERMINAL_PATTERNS` twins just below and the (a')-(d')
+# boundary twins further down, so that a `grep gh-flow-autopilot` surfaces
+# every namespace-sensitive site including the pattern actually compiled.
+_STEP_MARKER_RE: re.Pattern[str] = re.compile(r"\[step:(?:devx-autopilot|gh-flow-autopilot)/([a-z-]+)\]\s+OK\b")
 
 # Terminal markers — presence in any *assistant text* block after the boundary
 # means the flow has finished (or hard-failed) and the model may stop.

--- a/claude/hooks/devx_autopilot_stop_guard.py
+++ b/claude/hooks/devx_autopilot_stop_guard.py
@@ -99,17 +99,26 @@ REQUIRED_STEPS: list[str] = [
 # Human-facing label for each step, surfaced in the block reason.
 _STEP_LABELS: dict[str, str] = {
     "plan": "Step 0a — Skill(superpowers:writing-plans)",
-    "issue": "Step 0b — Skill(gh:issue-create)",
+    "issue": "Step 0b — Skill(gh-issue:create)",
     "mode": "Step 1 — mode selection (log mode=<sdd|inline> reason=...)",
     "implement": "Step 2 — SDD skill OR inline TDD + Advisor 검증",
-    "pr": "Step 3 — Skill(gh:pr, <ISSUE_NUM>)",
+    "pr": "Step 3 — Skill(gh-pr:create, <ISSUE_NUM>)",
     "simplify": "Step 4 — Skill(simplify, <PR_NUM>)",
-    "pr-reply": "Step 5 — Skill(gh-pr-reply, <PR_NUM>) (emit the marker even with no comments / [SKIP])",
+    "pr-reply": "Step 5 — Skill(gh-pr:reply, <PR_NUM>) (emit the marker even with no comments / [SKIP])",
 }
 
-# Strict step-marker regex. Requires the literal `[step:devx-autopilot/<id>] OK`
+# Skill names whose `[step:<name>/<id>] OK` markers this guard honours: the
+# dotfiles-native `devx-autopilot` and, since #1410 Phase 3, the migrated
+# `gh-flow-autopilot` (D-12, issue #1678). Both are accepted for the whole
+# transition — NF-1 keeps the dotfiles original emitting the old marker until
+# Phase 4, while anyone running the `gh-flow-skills` plugin emits the new one.
+_MARKER_SKILL_NAMES: tuple[str, ...] = ("devx-autopilot", "gh-flow-autopilot")
+
+# Strict step-marker regex. Requires the literal `[step:<skill>/<id>] OK`
 # so a partial `[step:devx-autopilot/plan]` without ` OK` does NOT match.
-_STEP_MARKER_RE: re.Pattern[str] = re.compile(r"\[step:devx-autopilot/([a-z-]+)\]\s+OK\b")
+_STEP_MARKER_RE: re.Pattern[str] = re.compile(
+    r"\[step:(?:" + "|".join(re.escape(n) for n in _MARKER_SKILL_NAMES) + r")/([a-z-]+)\]\s+OK\b"
+)
 
 # Terminal markers — presence in any *assistant text* block after the boundary
 # means the flow has finished (or hard-failed) and the model may stop.
@@ -117,6 +126,10 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
     "[step:devx-autopilot/report] OK",
     "[OK] devx:autopilot",
     "[FAIL] devx:autopilot",
+    # Post-migration twins (#1678, D-12).
+    "[step:gh-flow-autopilot/report] OK",
+    "[OK] gh-flow:autopilot",
+    "[FAIL] gh-flow:autopilot",
 )
 
 # Issue #1275 — spans Claude Code injects into user-role messages that are
@@ -209,6 +222,14 @@ _HARNESS_INJECTION_RE: re.Pattern[str] = _line_anchored_alternation(_HARNESS_INJ
 #       emits when a user invokes the slash command interactively
 #   (c) the `Base directory for this skill: …/devx-autopilot` expansion marker
 #   (d) the SKILL.md H1 line `# devx:autopilot — …`
+# Each has a primed twin (a')–(d') for the post-migration `gh-flow:autopilot`
+# namespace (#1678, D-12). Without them the widened markers above would be
+# unreachable for anyone running the migrated plugin: the guard would never
+# arm, so it would never look for a marker in either namespace. (c') allows
+# arbitrary path segments between `gh-flow` and `/autopilot`: an installed
+# plugin's base dir is `plugins/marketplaces/gh-flow-skills/skills/autopilot`
+# or `plugins/cache/gh-flow-skills/gh-flow/<version>/skills/autopilot`, not
+# `<plugin>/skills/<skill>` (measured).
 # `(?m)` anchors `^` to per-line starts. tool_result payloads are excluded by
 # `_iter_text_blocks(..., include_tool_results=False)` at the call site.
 _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
@@ -222,11 +243,25 @@ _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
         ^Base\s+directory\s+for\s+this\s+skill:\s+.*devx-autopilot\b  # (c) skill base dir
         |
         ^\#\s+devx:autopilot\s+—                                  # (d) SKILL.md H1
+        |
+        ^\s*/gh-flow[-:]autopilot(?![\w-])                        # (a') new namespace
+        |
+        <command-name>\s*/gh-flow[-:]autopilot\s*</command-name>  # (b') new namespace
+        |
+        ^Base\s+directory\s+for\s+this\s+skill:\s+
+            .*gh-flow(?:-autopilot(?![\w-])|[\w./-]*/autopilot(?![\w-]))  # (c') new namespace
+        |
+        ^\#\s+gh-flow:autopilot\s+—                               # (d') new namespace
     )
     """,
     re.VERBOSE,
 )
-FLOW_SKILL_NAMES: set[str] = {"devx-autopilot", "devx:autopilot"}
+FLOW_SKILL_NAMES: set[str] = {
+    "devx-autopilot",
+    "devx:autopilot",
+    "gh-flow-autopilot",
+    "gh-flow:autopilot",
+}
 
 
 def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -163,6 +163,42 @@ SUB_SKILL_NAMES: set[str] = {n for forms in EXPECTED_CHAIN for n in forms}
 # slot would count as two distinct steps.
 _SUB_SKILL_CANONICAL: dict[str, str] = {n: forms[0] for forms in EXPECTED_CHAIN for n in forms}
 
+# The one alias `_next_step_label` quotes alongside the canonical name, so a
+# session running only the migrated plugin is told a skill it actually has.
+# Spelled out per slot rather than taken positionally out of EXPECTED_CHAIN
+# (`forms[-1]`): those tuples are alias *sets* whose order carries no meaning
+# past element 0, so adding a form later would silently change which name the
+# model is told to invoke (agy review, PR #1693). `_assert_hint_aliases_known`
+# below turns any drift between the two into an import-time failure rather
+# than a wrong hint at block time.
+_SUB_SKILL_HINT_ALIAS: dict[str, str] = {
+    "gh-issue-implement": "gh-issue:implement",
+    "gh-commit": "gh-pr:commit",
+    "gh-pr": "gh-pr:create",
+    "devx-pr-review-all": "gh-verify:review-all",
+    "gh-pr-resolve-conflict": "gh-resolve:conflict",
+    "gh-pr-resolve-outdated": "gh-resolve:outdated",
+}
+
+
+def _assert_hint_aliases_known() -> None:
+    """Every slot has exactly one hint alias, and it addresses that same slot.
+
+    Runs at import. A hook that fails open on a malformed transcript must
+    still refuse to ship an internally inconsistent chain table — a hint
+    naming the wrong slot's skill would route the model to the wrong step.
+    """
+    for forms in EXPECTED_CHAIN:
+        canonical = forms[0]
+        alias = _SUB_SKILL_HINT_ALIAS.get(canonical)
+        if alias is None:
+            raise AssertionError(f"_SUB_SKILL_HINT_ALIAS is missing a hint for slot {canonical!r}")
+        if alias not in forms:
+            raise AssertionError(f"hint alias {alias!r} does not address slot {canonical!r} ({forms!r})")
+
+
+_assert_hint_aliases_known()
+
 # Human-facing SKILL.md step labels, parallel to EXPECTED_CHAIN. These are
 # NOT derived arithmetically because gh-pr-resolve-outdated is labeled
 # "Step 2.5.1" in SKILL.md (it runs after the "Step 2.5" resolve-conflict
@@ -889,6 +925,9 @@ def _next_step_label(seen: list[str]) -> str:
     a skill that does not exist there. The canonical name stays first and
     unparenthesised, which is also what keeps the existing
     `"Step 2.2 — Skill(gh-commit)"` substring assertions matching.
+
+    The alias comes from `_SUB_SKILL_HINT_ALIAS`, keyed by slot — never from
+    a position inside the slot's alias tuple.
     """
     canonical = [forms[0] for forms in EXPECTED_CHAIN]
     next_idx = 0
@@ -897,7 +936,7 @@ def _next_step_label(seen: list[str]) -> str:
             next_idx = i + 1
     if next_idx >= len(canonical):
         return "Step 3 — emit the final 'gh:issue-flow complete (#N)' / 'gh-flow:issue complete (#N)' report"
-    alias = EXPECTED_CHAIN[next_idx][-1]
+    alias = _SUB_SKILL_HINT_ALIAS[canonical[next_idx]]
     return f"{STEP_LABELS[next_idx]} — Skill({canonical[next_idx]}) (or Skill({alias}))"
 
 

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -125,17 +125,43 @@ def _trace(message: str, *, layer: str | None = None) -> None:
             pass
 
 
-# Sub-skill names accepted in either hyphen or colon namespace form.
-# Order matters — it's the canonical 6-step gh-issue-flow chain.
-EXPECTED_CHAIN: list[tuple[str, str]] = [
-    ("gh-issue-implement", "gh:issue-implement"),
-    ("gh-commit", "gh:commit"),
-    ("gh-pr", "gh:pr"),
-    ("devx-pr-review-all", "devx:pr-review-all"),
-    ("gh-pr-resolve-conflict", "gh:pr-resolve-conflict"),
-    ("gh-pr-resolve-outdated", "gh:pr-resolve-outdated"),
+# One entry per slot of the canonical 6-step gh-issue-flow chain; order
+# matters. Each entry lists EVERY name that addresses that slot — the
+# dotfiles-native pair (hyphen, colon) plus, since #1410 Phase 3, the
+# post-migration pair the skill answers to once installed from its own
+# plugin repo (D-12, issue #1678).
+#
+# Why both, and not a swap: NF-1 keeps the dotfiles originals in place until
+# Phase 4, and the live automation in `shell-common/functions/gh_flow.sh` +
+# `shell-common/tools/custom/issue_watcher_cron.sh` still dispatches the old
+# slash commands. Narrowing this list to the new names would drop the
+# harness guard off that operational path the moment it landed; ignoring the
+# new names would leave anyone running the migrated plugin unguarded. Phase 4
+# removes the old forms, here and there, together.
+#
+# Element 0 is the CANONICAL name of the slot: it is what `seen` records and
+# what `_next_step_label` quotes back to the model. It stays the old hyphen
+# form on purpose — the copy actually installed in this repo is still the one
+# the model is being told to invoke.
+EXPECTED_CHAIN: list[tuple[str, ...]] = [
+    # `gh-issue-implement`'s hyphen form is unchanged by the migration; only
+    # its colon form moves namespace (`gh:issue-implement` → `gh-issue:implement`).
+    ("gh-issue-implement", "gh:issue-implement", "gh-issue:implement"),
+    ("gh-commit", "gh:commit", "gh-pr-commit", "gh-pr:commit"),
+    ("gh-pr", "gh:pr", "gh-pr-create", "gh-pr:create"),
+    ("devx-pr-review-all", "devx:pr-review-all", "gh-verify-review-all", "gh-verify:review-all"),
+    ("gh-pr-resolve-conflict", "gh:pr-resolve-conflict", "gh-resolve-conflict", "gh-resolve:conflict"),
+    ("gh-pr-resolve-outdated", "gh:pr-resolve-outdated", "gh-resolve-outdated", "gh-resolve:outdated"),
 ]
-SUB_SKILL_NAMES: set[str] = {n for pair in EXPECTED_CHAIN for n in pair}
+SUB_SKILL_NAMES: set[str] = {n for forms in EXPECTED_CHAIN for n in forms}
+
+# Alias → canonical slot name. This replaces the old `skill.replace(":", "-")`
+# normalization, which only ever worked because a slot's colon and hyphen
+# forms were the same string modulo the separator. That stops being true
+# under the migration — `gh-pr:commit` normalizes to `gh-pr-commit`, which is
+# NOT `gh-commit` — so the mapping has to be explicit or two aliases of one
+# slot would count as two distinct steps.
+_SUB_SKILL_CANONICAL: dict[str, str] = {n: forms[0] for forms in EXPECTED_CHAIN for n in forms}
 
 # Human-facing SKILL.md step labels, parallel to EXPECTED_CHAIN. These are
 # NOT derived arithmetically because gh-pr-resolve-outdated is labeled
@@ -152,11 +178,19 @@ STEP_LABELS: list[str] = [
 
 # Terminal Step 3 markers — presence in any assistant text after the
 # gh-issue-flow boundary means the flow has finished and the model may stop.
+# The `gh-flow:issue` / `gh-flow-issue` half is the post-migration name
+# (#1678, D-12). Each pattern keeps the trailing space or `(#` that follows
+# the skill name, which is also what keeps the sibling `gh-flow:issue-relay`
+# out: its name continues with `-relay` exactly where these demand a space.
 TERMINAL_PATTERNS: tuple[str, ...] = (
     "gh:issue-flow complete (#",
     "gh:issue-flow stopped at step",
     "gh-issue-flow complete (#",
     "gh-issue-flow stopped at step",
+    "gh-flow:issue complete (#",
+    "gh-flow:issue stopped at step",
+    "gh-flow-issue complete (#",
+    "gh-flow-issue stopped at step",
 )
 
 # Issue #1270 — terminal marker as it appears in the `Bash` fallback
@@ -169,8 +203,15 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
 # 'gh:issue-flow stopped at step'` — therefore cannot match, while a real
 # report (`gh:issue-flow complete (#1270)`, `gh:issue-flow stopped at step
 # 2/6`) does.
+#
+# The two namespaces are kept as SEPARATE alternatives rather than folded
+# into one character class (#1678 Error Cases): `gh[-:]issue-flow` and
+# `gh-flow[-:]issue` share no safe common shape, and a naive merge would
+# widen the match in ways neither name intends. The shared report shape is
+# factored out instead, so the two branches can never drift apart.
+_TERMINAL_REPORT_SHAPE: str = r"(?:complete\s+\(#\d+\)|stopped\s+at\s+step\s+\d)"
 _TERMINAL_COMMAND_RE: re.Pattern[str] = re.compile(
-    r"gh[-:]issue-flow\s+(?:complete\s+\(#\d+\)|stopped\s+at\s+step\s+\d)",
+    rf"(?:gh[-:]issue-flow|gh-flow[-:]issue)\s+{_TERMINAL_REPORT_SHAPE}",
 )
 
 # Issue #1274 — report-SHAPE requirement, applied to the paired
@@ -288,6 +329,19 @@ _HARNESS_INJECTION_RE: re.Pattern[str] = _line_anchored_alternation(_HARNESS_INJ
 #       (issue #608 — second wrapper-independent anchor, useful if the
 #       `<command-name>` / `Base directory` lines ever stop being emitted).
 #
+# Each of the four has a primed twin (a')–(d') for the post-migration
+# `gh-flow:issue` / `gh-flow-issue` namespace (#1678, D-12). Those twins end
+# on `(?![\w-])` rather than `\b`: a word boundary sits between `issue` and
+# the `-relay` of the sibling `gh-flow:issue-relay`, so `\b` would arm this
+# six-step chain guard on a skill that has no such chain.
+#
+# (c') allows arbitrary path segments between `gh-flow` and `/issue` because
+# an installed plugin's base directory is not `<plugin>/skills/<skill>` —
+# measured, the two real Claude Code layouts are
+# `plugins/marketplaces/gh-flow-skills/skills/issue` and
+# `plugins/cache/gh-flow-skills/gh-flow/<version>/skills/issue`. A pattern
+# pinned to one nesting depth silently matches neither.
+#
 # The `(?m)` prefix anchors `^` to per-line starts so a mid-sentence
 # mention like "I was reading about /gh-issue-flow..." stays out.
 # False-positive guards for `tool_result` payloads (e.g. SKILL.md being
@@ -304,11 +358,25 @@ _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
         ^Base\s+directory\s+for\s+this\s+skill:\s+.*gh-issue-flow\b  # (c) skill base dir
         |
         ^\#\s+gh:issue-flow\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d) SKILL.md H1
+        |
+        ^\s*/gh-flow[-:]issue(?![\w-])                       # (a') new namespace
+        |
+        <command-name>\s*/gh-flow[-:]issue\s*</command-name>  # (b') new namespace
+        |
+        ^Base\s+directory\s+for\s+this\s+skill:\s+
+            .*gh-flow(?:-issue(?![\w-])|[\w./-]*/issue(?![\w-]))  # (c') new namespace
+        |
+        ^\#\s+gh-flow:issue\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d') new namespace
     )
     """,
     re.VERBOSE,
 )
-FLOW_SKILL_NAMES: set[str] = {"gh-issue-flow", "gh:issue-flow"}
+FLOW_SKILL_NAMES: set[str] = {
+    "gh-issue-flow",
+    "gh:issue-flow",
+    "gh-flow-issue",
+    "gh-flow:issue",
+}
 
 
 def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:
@@ -560,7 +628,7 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     """Walk forward from the boundary.
 
     Returns (terminal_seen, ordered_distinct_sub_skill_invocations).
-    Sub-skill names are normalized to the hyphen form for comparison.
+    Sub-skill names are normalized to their slot's canonical name.
 
     Issue #608 (layer L1.5) — terminal-marker scan is restricted to
     `role=assistant` text blocks, with `include_tool_results=False`,
@@ -673,7 +741,7 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
         for skill in _iter_skill_uses(msg):
             if skill not in SUB_SKILL_NAMES:
                 continue
-            normalized = skill.replace(":", "-")
+            normalized = _SUB_SKILL_CANONICAL[skill]
             if normalized not in seen:
                 seen.append(normalized)
     return terminal, seen
@@ -812,15 +880,25 @@ def _count_fresh_user_prompts(messages: list[dict[str, Any]], start: int) -> int
 
 
 def _next_step_label(seen: list[str]) -> str:
-    """Map the highest-index sub-skill seen to a human label for the *next* one."""
-    canonical = [hyphen for hyphen, _ in EXPECTED_CHAIN]
+    """Map the highest-index sub-skill seen to a human label for the *next* one.
+
+    Both names of the slot are quoted (#1678): the canonical dotfiles one the
+    model is most likely to have installed, and the post-migration alias. A
+    session running the `gh-flow-skills` plugin has only the latter, so naming
+    the canonical form alone would answer a block with an instruction to invoke
+    a skill that does not exist there. The canonical name stays first and
+    unparenthesised, which is also what keeps the existing
+    `"Step 2.2 — Skill(gh-commit)"` substring assertions matching.
+    """
+    canonical = [forms[0] for forms in EXPECTED_CHAIN]
     next_idx = 0
     for i, name in enumerate(canonical):
         if name in seen:
             next_idx = i + 1
     if next_idx >= len(canonical):
-        return "Step 3 — emit the final 'gh:issue-flow complete (#N)' report"
-    return f"{STEP_LABELS[next_idx]} — Skill({canonical[next_idx]})"
+        return "Step 3 — emit the final 'gh:issue-flow complete (#N)' / 'gh-flow:issue complete (#N)' report"
+    alias = EXPECTED_CHAIN[next_idx][-1]
+    return f"{STEP_LABELS[next_idx]} — Skill({canonical[next_idx]}) (or Skill({alias}))"
 
 
 def _resolve_transcript_path(event: dict[str, Any]) -> tuple[str | None, str]:

--- a/claude/plugin/marketplaces.json
+++ b/claude/plugin/marketplaces.json
@@ -22,5 +22,6 @@
   "authoring-skills": "dEitY719/authoring-skills",
   "gh-setup-skills": "dEitY719/gh-setup-skills",
   "gh-issue-skills": "dEitY719/gh-issue-skills",
-  "gh-pr-skills": "dEitY719/gh-pr-skills"
+  "gh-pr-skills": "dEitY719/gh-pr-skills",
+  "gh-flow-skills": "dEitY719/gh-flow-skills"
 }

--- a/claude/plugin/plugins.json
+++ b/claude/plugin/plugins.json
@@ -9,6 +9,7 @@
     "devenv@devenv-skills",
     "document-skills@anthropic-agent-skills",
     "example-skills@anthropic-agent-skills",
+    "gh-flow@gh-flow-skills",
     "gh-issue@gh-issue-skills",
     "gh-pr@gh-pr-skills",
     "gh-resolve@gh-resolve-skills",

--- a/docs/.ssot/env-vars.md
+++ b/docs/.ssot/env-vars.md
@@ -4,7 +4,15 @@ Cross-skill / cross-tool env vars that change runtime behaviour. New
 toggles MUST land here so operators can grep one file before adopting
 a new repo or workspace.
 
-## `gh:*` skills
+> **스킬 이름 표기 (#1410 Phase 3, #1678)** — 이 문서는 스킬을 분리 후
+> 플러그인 네임스페이스(`gh-issue:create`, `gh-pr:create`, `gh-flow:issue` …)로
+> 적는다. dotfiles 의 `claude/skills/` 원본은 Phase 4 까지 그대로 남아 있고
+> **옛 이름(`/gh-issue-create`, `/gh-pr`, `/gh-issue-flow` …)으로도 계속
+> 호출된다** — `gh_flow.sh` · `issue_watcher_cron.sh` 같은 운영 자동화가
+> 아직 옛 슬래시 명령을 dispatch 하기 때문이다 (#1410 NF-1, D-12). 본문의
+> `claude/skills/<dir>/` 경로는 그 원본을 가리키므로 옛 이름 그대로다.
+
+## `gh-*` skills
 
 ### `GH_DISABLE_AI_METRICS`
 
@@ -19,17 +27,17 @@ a new repo or workspace.
 When the variable is `1`, the following skills skip ai-metrics
 attachment and produce identical artifacts otherwise:
 
-- `gh:issue-create` — issue body footer
-- `gh:pr` — PR body footer
-- `gh:commit` — linked-issue comment
-- `gh:pr-reply`, `gh:pr-approve`, `gh:pr-merge`, `gh:pr-resolve-conflict` — PR comment
-- `gh:pr-merge-emergency` — incident issue body footer
-- `gh:issue-flow` — flow-aggregate issue comment (Step 2.6)
+- `gh-issue:create` — issue body footer
+- `gh-pr:create` — PR body footer
+- `gh-pr:commit` — linked-issue comment
+- `gh-pr:reply`, `gh-pr:approve`, `gh-pr:merge`, `gh-resolve:conflict` — PR comment
+- `gh-pr:merge-emergency` — incident issue body footer
+- `gh-flow:issue` — flow-aggregate issue comment (Step 2.6)
 
-`gh:issue-implement` and `gh:issue-read` print metrics to stdout only,
+`gh-issue:implement` and `gh-issue:read` print metrics to stdout only,
 so the env var has no effect there.
 
-`gh:add-ai-metrics` is the **deliberate retrofit** path and **ignores**
+`gh-setup:add-ai-metrics` is the **deliberate retrofit** path and **ignores**
 this var — that is its entire purpose.
 
 Use cases:
@@ -41,8 +49,8 @@ Use cases:
 Per-call examples:
 
 ```bash
-GH_DISABLE_AI_METRICS=1 /gh-pr 399
-GH_DISABLE_AI_METRICS=1 /gh-commit
+GH_DISABLE_AI_METRICS=1 /gh-pr:create 399
+GH_DISABLE_AI_METRICS=1 /gh-pr:commit
 ```
 
 Persist for a session:
@@ -53,7 +61,7 @@ export GH_DISABLE_AI_METRICS=1
 
 ### `GH_PR_MERGE_SKIP_BOARD_CHECK` (retired, #1513)
 
-Removed together with `gh:pr-merge` Step 2-B — there is no longer a
+Removed together with `gh-pr:merge` Step 2-B — there is no longer a
 board approval gate to bypass. Setting it has no effect. Rationale:
 `claude/skills/gh-pr-merge/references/board-policy.md`.
 
@@ -109,7 +117,7 @@ typo could sync a different repo's board.
 |---|---|
 | Default | `900000` (15 min) |
 | Active when | set to a millisecond count |
-| Scope | `gh:pr-post-merge-verify` — the `herdr agent prompt --wait --until idle` cap |
+| Scope | `gh-verify:post-merge-verify` — the `herdr agent prompt --wait --until idle` cap |
 | Source SSOT | `claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md` |
 | Issue | [#1511](https://github.com/dEitY719/dotfiles/issues/1511) |
 

--- a/docs/.ssot/github-project-board.md
+++ b/docs/.ssot/github-project-board.md
@@ -15,8 +15,16 @@ SSOT이다.
   (정책 SSOT: [`discussions-policy.md`](./discussions-policy.md)). `Auto-add to project` 워크플로우 필터는 `is:issue,pr` 만
   매칭하므로 Discussion 은 자동 추가되지 않는다.
 - 자동화 수단: GitHub Projects v2 빌트인 워크플로우 + dotfiles 스킬 보정
-- 관련 스킬: `gh:issue-create`, `gh:pr`, `gh:pr-merge`,
-  `gh:pr-merge-emergency`, `gh:issue-flow`
+- 관련 스킬: `gh-issue:create`, `gh-pr:create`, `gh-pr:merge`,
+  `gh-pr:merge-emergency`, `gh-flow:issue`
+
+> **스킬 이름 표기 (#1410 Phase 3, #1678)** — 이 문서는 스킬을 분리 후
+> 플러그인 네임스페이스(`gh-issue:create`, `gh-pr:create`, `gh-flow:issue` …)로
+> 적는다. dotfiles 의 `claude/skills/` 원본은 Phase 4 까지 그대로 남아 있고
+> **옛 이름(`/gh-issue-create`, `/gh-pr`, `/gh-issue-flow` …)으로도 계속
+> 호출된다** — `gh_flow.sh` · `issue_watcher_cron.sh` 같은 운영 자동화가
+> 아직 옛 슬래시 명령을 dispatch 하기 때문이다 (#1410 NF-1, D-12). 본문의
+> `claude/skills/<dir>/` 경로는 그 원본을 가리키므로 옛 이름 그대로다.
 
 차용 원본: `agent-toolbox`의 `.claude/workflow.md`와 `.claude/github-integration.md`.
 dotfiles는 동일 원칙을 따르되 범위(단일 repo)와 자동화 수준(별도
@@ -43,8 +51,8 @@ Status 필드는 아래 6개 옵션을 이 순서로 가진다:
   후 `In review`로 수동 복귀시킨 뒤 이어서 `Approved → Done`
   으로 진행한다.
   단 `dEitY719/dotfiles` 에서는 `Approved` 가 **머지 전제조건이
-  아니다** (#1513). 컬럼 자체는 남아 있고 `/gh-pr-approve` 로
-  수동 기록할 수 있지만, `/gh-pr-merge` 는 보드 Status 를 읽지
+  아니다** (#1513). 컬럼 자체는 남아 있고 `/gh-pr:approve` 로
+  수동 기록할 수 있지만, `/gh-pr:merge` 는 보드 Status 를 읽지
   않으므로 카드가 `In review` 에 있어도 머지된다 — `Approved` 는
   이 저장소에서 강제성 없는 참고 표시다.
 
@@ -96,7 +104,7 @@ Project 보드와 일관된 운영 방식 확보가 목적.
 1. **PR 템플릿** (`.github/pull_request_template.md`)에
    `Closes #` 자리표시자를 포함한다. 사람이 웹/CLI로 직접 PR을
    만들어도 템플릿이 채워진다.
-2. **`gh:pr` 스킬의 PR 본문 템플릿**
+2. **`gh-pr:create` 스킬의 PR 본문 템플릿**
    (`claude/skills/gh-pr/references/pr-body-template.md`)은 이슈
    번호가 해결된 경우 `## Related` 섹션에 `Closes #<N>` 줄을
    **반드시** 포함한다. 누락되면 Done 자동 전환이 끊긴다.
@@ -151,26 +159,26 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
 없다.
 
 - **Issue 카드 `Backlog → In progress`** (두 경로):
-  1. `/gh-flow` 워커 또는 `/gh-commit` 단독 실행이 커밋 메시지에서
+  1. `/gh-flow:issue` 워커 또는 `/gh-pr:commit` 단독 실행이 커밋 메시지에서
      `Closes|Fixes|Refs #N` 을 찾으면 자동 전환한다. `--only-from Backlog`
      가드가 적용되어 follow-up 커밋이 들어와도 상태를 되돌리지 않는다.
      raw `git commit` 경로에선 수동 이동.
-  2. `/gh-pr` 또는 `project-board-sync.yml` (PR opened 이벤트) 가 PR 생성
+  2. `/gh-pr:create` 또는 `project-board-sync.yml` (PR opened 이벤트) 가 PR 생성
      직후 `_gh_project_status_sync issue … "In progress" --only-from "Backlog,Ready,In review"` 를
      호출한다. 이는 GitHub 빌트인 `Pull request linked to issue` (#3) 가
      Issue 카드를 `In review` 로 잘못 이동시키는 것을 즉시 교정한다 (#289). 가드에
      `In review` 가 포함되어 있어 빌트인이 먼저 발화한 뒤에도 보정이 동작하며,
      `Done` 만은 가드에서 제외해 닫힌 Issue 가 재오픈된 PR 로 인해 역행하지 않는다
      (#309).
-- **PR 카드 `Backlog → In review`**: `/gh-flow` 워커 또는 `/gh-pr`
+- **PR 카드 `Backlog → In review`**: `/gh-flow:issue` 워커 또는 `/gh-pr:create`
   단독 실행이 PR 생성 직후 자동 전환한다. raw `gh pr create` 로
   PR 을 만든 경우엔 수동 이동이 필요하다. `project-board-sync.yml` 의
   `pull_request.opened` 핸들러도 동일 동작을 수행하므로 어느 경로든
   수렴한다.
 - **PR 카드 `In review → Approved`**: 사람이 명시적으로 승인 행위를
   했을 때만 전환된다 (#1350). 쓰기 주체는 아래 둘뿐이며, 스킬 중에서는
-  `/gh-pr-approve` 가 유일한 소유자다.
-  1. `/gh-pr-approve` 가 4a/4b (실제 `--approve`) 또는 self-PR
+  `/gh-pr:approve` 가 유일한 소유자다.
+  1. `/gh-pr:approve` 가 4a/4b (실제 `--approve`) 또는 self-PR
      `--self-record` 경로에서 전환한다. 1인 repo 에서는 GitHub 정책상
      PR 작성자가 자기 PR 을 Approve 할 수 없어 빌트인
      `Code review approved` 가 영원히 트리거되지 않는데,
@@ -187,20 +195,20 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
   거부한다. `Backlog`/`In progress` 를 포함하는 이유: 외부 Approve 는
   카드가 `In review` 로 옮겨지기 전에 도착할 수 있고, `Changes
   requested` 빌트인이 카드를 `In progress` 로 떨어뜨린 뒤 복귀가
-  자동이 아닌 경로(수동 push, `/gh-pr-resolve-ci-fail`, 전건 Declined
-  인 reply 라운드)가 존재하기 때문이다. 그대로 두면 `/gh-pr-approve`
+  자동이 아닌 경로(수동 push, `/gh-resolve:ci-fail`, 전건 Declined
+  인 reply 라운드)가 존재하기 때문이다. 그대로 두면 `/gh-pr:approve`
   가 승격을 거부해 정상 리뷰를 거친 PR 의 카드가 장부상 `In progress`
-  에 잔류한다 (#1513 이전에는 여기에 더해 `gh:pr-merge` Step 2-B 가
+  에 잔류한다 (#1513 이전에는 여기에 더해 `gh-pr:merge` Step 2-B 가
   `Status != Approved` 로 fail-close 해 emergency 머지 경로로 밀려났다
   — 그 머지 게이트는 폐지됐다).
   어느 쪽이든 `Done` 은 `--only-from` 목록에 없으므로, 이미 머지된 PR
   에 잘못 호출되어도 카드가 역행하지 않는다 — `Done` 배제가 이 필터의
   실질적 방어 지점이다.
-  `/gh-pr-reply` 는 이 전환을 하지 않는다. reply 답변과 `agy`/`codex`
+  `/gh-pr:reply` 는 이 전환을 하지 않는다. reply 답변과 `agy`/`codex`
   리뷰는 모두 `COMMENTED` 라 `reviewDecision` 을 바꾸지 않으므로,
   자동 전환은 BLOCKING 판정 PR 까지 `Approved` 로 올려보냈다 (PR #1349).
 - **PR 카드 `Approved → Done`**: 두 갈래로 보정한다.
-  - `/gh-pr-merge` / `/gh-pr-merge-emergency` 경유 머지: 스킬이 머지
+  - `/gh-pr:merge` / `/gh-pr:merge-emergency` 경유 머지: 스킬이 머지
     성공 직후 in-skill Step 4(a) 에서 직접 전환한다.
   - 웹 UI / 모바일 / raw `gh pr merge` 경유 머지 (#266): `project-board-sync.yml`
     이 `pull_request.closed && merged == true` 에 자동 fire 하여 동일
@@ -221,17 +229,17 @@ dotfiles 의 스킬이 공용 헬퍼 `_gh_project_status_sync`
 - **PR 카드 `In progress → In review` (재리뷰 요청 시)**:
   `Changes requested` 루프에서 수정·재푸시 후 리뷰가 다시 달리기를
   기대할 때 복귀시킨다. Projects v2 빌트인에는 이 전환이 없고, 스킬
-  중에서는 두 곳만 자동화한다 — `/gh-pr-reply` Step 6.5 와
-  `/gh-pr-resolve-conflict` Step 5 이며, 둘 다
+  중에서는 두 곳만 자동화한다 — `/gh-pr:reply` Step 6.5 와
+  `/gh-resolve:conflict` Step 5 이며, 둘 다
   `--only-from "In progress,Changes requested"` 로 호출하고
   **실제로 커밋을 push 했을 때만** 동작한다 (#591). 따라서 수동 push,
-  `/gh-pr-resolve-ci-fail`, 전건 Declined 인 reply 라운드에서는 카드가
+  `/gh-resolve:ci-fail`, 전건 Declined 인 reply 라운드에서는 카드가
   `In progress` 에 남으므로 **수동** 복귀가 필요하다. 이 갭 때문에
   `In review → Approved` 승격 가드가 `Backlog,In progress,In review`
   로 넓게 잡혀 있다 (위 항목 참조). 이 외의 PR 전환 (`→ Done`) 은
   빌트인 `Pull request merged` / `Item closed` 가 자동 처리한다.
 - **Issue 카드 `In progress → Done` (PR-Closes 경로 보강)**:
-  `/gh-pr-merge` 와 `project-board-sync.yml` 둘 다 머지 직후 PR 의
+  `/gh-pr:merge` 와 `project-board-sync.yml` 둘 다 머지 직후 PR 의
   `closingIssuesReferences` 를 순회하며 각 Issue 카드를 `Done` 으로
   강제 이동한다. 빌트인 `Item closed` 워크플로우는 best-effort delivery
   이므로 드물게 Status 업데이트 이벤트가 누락되어 Issue 카드가
@@ -260,9 +268,9 @@ repo 의 보드를 건드릴지 다음 순서로 정한다 (먼저 맞는 것이
 갱신될 수 있다. 명시로 넘긴 값이 형식에 안 맞으면 자동 감지로 흘러가지
 않고 실패한다 — 오타가 다른 repo 재획득으로 가려지면 안 되기 때문이다.
 
-`[remote]` 를 받는 스킬(`gh:pr-merge`, `gh:pr-reply`, `gh:pr-approve`,
-`gh:pr-resolve-conflict`, `gh:issue-implement`, `gh:issue-proceed`,
-`gh:discussion-convert`, `devx:pr-verify-live` 등)은 Step 1 에서 해소한
+`[remote]` 를 받는 스킬(`gh-pr:merge`, `gh-pr:reply`, `gh-pr:approve`,
+`gh-resolve:conflict`, `gh-issue:implement`, `gh-issue:proceed`,
+`gh-issue:discussion-convert`, `gh-verify:live` 등)은 Step 1 에서 해소한
 `$TARGET_REPO` 를 `--repo` 로 명시해 넘긴다. `project-board-sync.yml` 과
 `claude/hooks/post-gh-pr-create.sh` 는 `GH_REPO` 를 export 하므로 2번
 규칙으로 이미 올바르다.
@@ -332,32 +340,32 @@ gh auth refresh -s project
 
 - PR 본문에 `Closes #N`이 빠지면 머지 후에도 Issue가 열려 있고
   Issue 카드가 `Done`으로 가지 않는다 (PR 카드는 `Pull request
-  merged`로 Done 이동). PR 템플릿과 `gh:pr` 스킬이 이를 방지하지만,
+  merged`로 Done 이동). PR 템플릿과 `gh-pr:create` 스킬이 이를 방지하지만,
   사람이 수동으로 본문을 지울 경우를 대비해 머지 전에 한 번 더
   확인한다.
 - Issue 카드의 `Backlog → In progress` 는 두 경로로 자동화된다:
-  (1) `/gh-flow` 워커 또는 `/gh-commit` 이 커밋 메시지에서 `Closes|Fixes|Refs #N`
-  을 감지할 때; (2) `/gh-pr` 또는 `project-board-sync.yml` 이 PR 생성 직후
+  (1) `/gh-flow:issue` 워커 또는 `/gh-pr:commit` 이 커밋 메시지에서 `Closes|Fixes|Refs #N`
+  을 감지할 때; (2) `/gh-pr:create` 또는 `project-board-sync.yml` 이 PR 생성 직후
   linked Issue 를 `In progress` 로 이동할 때 (#289). raw `git commit` 또는
   raw `gh pr create` 경로에선 수동 이동이 필요하다.
-- PR 카드 `Backlog → In review` 는 dotfiles 스킬 (`/gh-flow`,
-  `/gh-pr`) 사용 시 자동, raw `gh pr create` 사용 시에만 수동이다.
-  `In review → Approved` 는 사람이 `/gh-pr-approve` 를 명시적으로
+- PR 카드 `Backlog → In review` 는 dotfiles 스킬 (`/gh-flow:issue`,
+  `/gh-pr:create`) 사용 시 자동, raw `gh pr create` 사용 시에만 수동이다.
+  `In review → Approved` 는 사람이 `/gh-pr:approve` 를 명시적으로
   호출할 때만 일어난다 (#1350). 1인 repo 에서 self-approve 불가로
   빌트인 `Code review approved` 가 영원히 트리거되지 않는 갭은
-  `/gh-pr-approve <N> --self-record` 가 메운다. `In progress → In
+  `/gh-pr:approve <N> --self-record` 가 메운다. `In progress → In
   review` (`Changes requested` 루프 탈출 시) 는 fix 커밋을 push 한
-  `/gh-pr-reply` · `/gh-pr-resolve-conflict` 에서만 자동이고, 그 밖의
+  `/gh-pr:reply` · `/gh-resolve:conflict` 에서만 자동이고, 그 밖의
   경로에서는 수동이다 — 그래서 `Approved` 승격 가드는 `In progress`
   도 시작 컬럼으로 받는다.
-- 보드가 없는 repo 에서 `/gh-pr`, `/gh-commit`, `/gh-pr-reply`,
-  `/gh-pr-approve`, `/gh-pr-merge`, 또는 `/gh-pr-merge-emergency` 를
+- 보드가 없는 repo 에서 `/gh-pr:create`, `/gh-pr:commit`, `/gh-pr:reply`,
+  `/gh-pr:approve`, `/gh-pr:merge`, 또는 `/gh-pr:merge-emergency` 를
   실행하면 공용 헬퍼
   `_gh_project_status_sync` 가 `projectItems` 가 0건임을 자동
   감지하고 조용히 no-op 한다 (별도 분기 불필요).
 - Projects v2 빌트인 워크플로우는 best-effort delivery 라 드물게
   Status 업데이트 이벤트가 누락된다. PR-Closes 경로 (PR 머지로 Issue
-  가 auto-close 되는 경로) 는 `/gh-pr-merge` 의 Step 4 post-merge
+  가 auto-close 되는 경로) 는 `/gh-pr:merge` 의 Step 4 post-merge
   reconciliation 이 자동 보강한다. 그 외 경로 (수동 close, 다른 도구로
   close) 에서 Issue 카드가 `In review` 등에 잔류하면 카드를 수동으로
   `Done` 으로 옮긴다.
@@ -389,7 +397,7 @@ gh auth refresh -s project
   - `claude/skills/gh-pr-merge/SKILL.md`
   - `claude/skills/gh-issue-flow/SKILL.md`
 - 관련 헬퍼: `shell-common/functions/gh_project_status.sh` (공용
-  `_gh_project_status_sync` — `/gh-flow`, `/gh-pr`, `/gh-commit`,
-  `/gh-pr-reply`, `/gh-pr-merge` 가 모두 호출). 대상 repo 해석 순서는
+  `_gh_project_status_sync` — `/gh-flow:issue`, `/gh-pr:create`, `/gh-pr:commit`,
+  `/gh-pr:reply`, `/gh-pr:merge` 가 모두 호출). 대상 repo 해석 순서는
   위 "헬퍼의 대상 repo 해석 순서 (#1405)" 참고.
 - 관련 템플릿: `.github/pull_request_template.md`.

--- a/docs/.ssot/local-test-policy.md
+++ b/docs/.ssot/local-test-policy.md
@@ -104,7 +104,7 @@ Before/After 측정:
 |--------|------|
 | 외부 기여자 mise 미설치 → 회귀 누락 | reviewer 수동 `mise run test` (PR 머지 전 checklist) |
 | 로컬 환경 차이 (Python/OS) 로 인한 위양성 | mise toolchain pinned in `mise.toml` |
-| `pre-push` 통과 후 머지 직전 회귀 | `gh:pr-merge` skill 의 pre-merge 검증 옵션 (별도 이슈) |
+| `pre-push` 통과 후 머지 직전 회귀 | `gh-pr:merge` skill 의 pre-merge 검증 옵션 (별도 이슈) |
 | `--no-verify` 남용 | `git/hooks/install-hooks.sh` 출력에 경고 추가, 코드 리뷰에서 차단 |
 
 ### 롤백 트리거 (이 정책을 뒤집을 신호)

--- a/docs/public/changelog.d/2026-09-01-1678.md
+++ b/docs/public/changelog.d/2026-09-01-1678.md
@@ -1,0 +1,4 @@
+- 변경: **`gh-flow-skills` repo 신규 생성 (#1410 Phase 3 완료)** — 이슈→PR 컴포지션 스킬 4종(`issue`/`autopilot`/`issue-relay`/`relay-merge`)을 `gh-flow` 플러그인으로 이관하고, 6개 하네스 매니페스트와 `harness-skills` reusable CI workflow 를 연결했다. dotfiles 원본은 그대로 남는다(삭제는 Phase 4).
+- 변경: **`claude/plugin/{marketplaces,plugins}.json` 에 `gh-flow-skills` 등록** — `restore.sh` 가 새 마켓플레이스와 `gh-flow@gh-flow-skills` 플러그인을 복원 대상으로 인식한다.
+- 변경: **두 Stop hook 이 옛 이름과 새 이름을 모두 인식한다 (D-12)** — `gh_issue_flow_stop_guard.py` 는 `/gh-flow:issue` 경계와 6단계 체인의 새 스킬명(`gh-issue:implement`·`gh-pr:commit`·`gh-pr:create`·`gh-verify:review-all`·`gh-resolve:conflict`·`gh-resolve:outdated`)을, `devx_autopilot_stop_guard.py` 는 `[step:gh-flow-autopilot/<id>] OK` 마커와 `[OK]/[FAIL] gh-flow:autopilot` 리포트를 옛 형태와 나란히 받는다. 옛 이름 지원은 Phase 4 에서 걷어낸다.
+- 변경: **`docs/.ssot/{github-project-board,env-vars,local-test-policy}.md` 와 `claude/README.md` 의 스킬명 표기를 플러그인 네임스페이스로 갱신** — 앞의 두 문서에는 "옛 슬래시 명령도 Phase 4 까지 계속 동작한다"는 전환기 주석을 함께 넣었다.

--- a/tests/bats/tools/claude_plugin_restore.bats
+++ b/tests/bats/tools/claude_plugin_restore.bats
@@ -275,5 +275,6 @@ authoring-skills|dEitY719/authoring-skills|authoring
 gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
 gh-issue-skills|dEitY719/gh-issue-skills|gh-issue
 gh-pr-skills|dEitY719/gh-pr-skills|gh-pr
+gh-flow-skills|dEitY719/gh-flow-skills|gh-flow
 TABLE
 }

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -63,6 +63,31 @@ gh-flow-skills|dEitY719/gh-flow-skills|gh-flow
 TABLE
 }
 
+# A composition plugin is only runnable if the plugins owning the steps it
+# delegates to are registered too. PR #1693 shipped `gh-flow` while `gh-pr`
+# was still unregistered on that branch, so a plugin-only restore could load
+# `/gh-flow:issue` and then fail at Step 2.2 with no `gh-pr:commit` to call
+# (codex BLOCKER). A marketplace-mapping row cannot catch that — it only ever
+# asserts one plugin at a time — so the dependency edges get their own table.
+@test "composition plugins have every plugin they delegate to registered (#1693)" {
+    while IFS='|' read -r plugin deps; do
+        run jq -er --arg p "${plugin}" \
+            '.plugins | map(split("@")[0]) | if index($p) then "present" else "absent" end' \
+            "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/plugins.json"
+        assert_output "present"
+
+        for dep in ${deps}; do
+            run jq -er --arg d "${dep}" \
+                '.plugins | map(split("@")[0]) | if index($d) then "present" else "absent" end' \
+                "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/plugins.json"
+            [ "$output" = "present" ] \
+                || fail "plugin '${plugin}' delegates to '${dep}', which is not in claude/plugin/plugins.json — a plugin-only restore cannot run it"
+        done
+    done <<'TABLE'
+gh-flow|gh-issue gh-pr gh-verify gh-resolve session
+TABLE
+}
+
 @test "pkm-skills marketplace and pkm plugin are registered (#1644)" {
     run jq -e '."pkm-skills" == "dEitY719/pkm-skills"' \
         "${_BATS_REAL_DOTFILES_ROOT}/claude/plugin/marketplaces.json"

--- a/tests/bats/tools/claude_plugin_scaffold.bats
+++ b/tests/bats/tools/claude_plugin_scaffold.bats
@@ -59,6 +59,7 @@ authoring-skills|dEitY719/authoring-skills|authoring
 gh-setup-skills|dEitY719/gh-setup-skills|gh-setup
 gh-issue-skills|dEitY719/gh-issue-skills|gh-issue
 gh-pr-skills|dEitY719/gh-pr-skills|gh-pr
+gh-flow-skills|dEitY719/gh-flow-skills|gh-flow
 TABLE
 }
 
@@ -99,6 +100,7 @@ TABLE
 #1658|gh-label-bootstrap gh-kanban-bootstrap gh-add-ai-metrics devx-docs-bootstrap
 #1676|gh-issue-read gh-issue-create gh-issue-implement gh-issue-proceed gh-discussion-create gh-discussion-convert
 #1677|gh-commit gh-pr gh-pr-review gh-pr-reply gh-pr-approve gh-pr-merge gh-pr-merge-emergency gh-pr-merge-train
+#1678|gh-issue-flow devx-autopilot gh-issue-relay-flow gh-relay-merge
 TABLE
 }
 

--- a/tests/integration/test_devx_autopilot_stop_guard.py
+++ b/tests/integration/test_devx_autopilot_stop_guard.py
@@ -1100,3 +1100,159 @@ def test_hook_callable_two_ways(tmp_path: Path, exec_form: list[str]) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# D-12 dual-form namespace recognition (#1678)
+#
+# Phase 3 of #1410 migrates this skill into the `gh-flow-skills` repo as
+# `gh-flow:autopilot`, while NF-1 keeps the dotfiles original (emitting the
+# old `[step:devx-autopilot/...]` markers) alive until Phase 4. The guard
+# must recognize BOTH marker namespaces at once. Every case below is an
+# ADDITION — no existing assertion above is modified (issue #1678, NF-4).
+# ---------------------------------------------------------------------------
+
+
+def _step_markers_result_new(*step_ids: str) -> dict[str, Any]:
+    """`_step_markers_result`'s post-migration twin (`gh-flow-autopilot`)."""
+    body = "\n".join(f"[step:gh-flow-autopilot/{sid}] OK" for sid in step_ids)
+    return _user_tool_result(body)
+
+
+@pytest.mark.parametrize(
+    ("label", "boundary"),
+    [
+        ("colon-form", "/gh-flow:autopilot"),
+        ("hyphen-form", "/gh-flow-autopilot"),
+        ("command-name-wrapper", "<command-name>/gh-flow:autopilot</command-name>"),
+        (
+            "skill-base-dir-marketplace",
+            "Base directory for this skill: /home/u/.claude/plugins/marketplaces/gh-flow-skills/skills/autopilot",
+        ),
+        (
+            "skill-base-dir-cache",
+            "Base directory for this skill: "
+            "/home/u/.claude/plugins/cache/gh-flow-skills/gh-flow/0.1.0/skills/autopilot",
+        ),
+        ("skill-base-dir-flat", "Base directory for this skill: /home/u/.claude/skills/gh-flow/skills/autopilot"),
+        ("skill-h1", "# gh-flow:autopilot — spec → PR"),
+    ],
+)
+def test_new_namespace_boundary_surfaces(tmp_path: Path, label: str, boundary: str) -> None:
+    """The post-migration name opens a Stage-B flow on every boundary surface.
+
+    Without this the F-9 marker widening would be unreachable: the guard
+    never arms, so it never looks for a marker in either namespace.
+    """
+    transcript = _write_transcript(tmp_path, [_user_text(boundary), _assistant_text("done!")])
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"{label}: expected a block, got empty stdout"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_new_namespace_step_markers_are_counted(tmp_path: Path) -> None:
+    """`[step:gh-flow-autopilot/<id>] OK` satisfies the same required steps."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:autopilot"),
+            _step_markers_result_new("plan", "issue"),
+            _assistant_text("continuing..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "2/7" in decision["reason"], decision["reason"]
+    assert "mode" in decision["reason"], decision["reason"]
+
+
+def test_old_namespace_step_markers_still_counted_after_widening(tmp_path: Path) -> None:
+    """Regression twin of the case above: the old marker keeps working."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:autopilot"),
+            _step_markers_result("plan", "issue"),
+            _assistant_text("continuing..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "2/7" in decision["reason"], decision["reason"]
+
+
+def test_mixed_namespace_step_markers_reach_all_seven(tmp_path: Path) -> None:
+    """A run that switches namespace mid-flow still completes its step set."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan", "issue", "mode"),
+            _step_markers_result_new("implement", "pr", "simplify", "pr-reply"),
+            _assistant_text("continuing..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "all 7 Stage-B step" in decision["reason"], decision["reason"]
+
+
+@pytest.mark.parametrize(
+    ("label", "terminal"),
+    [
+        ("report-marker", "[step:gh-flow-autopilot/report] OK"),
+        ("ok-report", "[OK] gh-flow:autopilot #1678 — PR https://github.com/o/r/pull/1"),
+        ("fail-report", "[FAIL] gh-flow:autopilot #1678 — stopped at Step 3"),
+    ],
+)
+def test_new_namespace_terminal_markers_allow_stop(tmp_path: Path, label: str, terminal: str) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:autopilot"),
+            _step_markers_result_new("plan", "issue", "mode", "implement", "pr", "simplify", "pr-reply"),
+            _assistant_text(terminal),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"{label}: expected allow, got {result.stdout!r}"
+
+
+def test_partial_new_marker_without_ok_does_not_count(tmp_path: Path) -> None:
+    """The strictness of the marker regex survives the widening."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:autopilot"),
+            _user_tool_result("[step:gh-flow-autopilot/plan]"),
+            _assistant_text("continuing..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "0/7" in decision["reason"], decision["reason"]
+
+
+def test_step_labels_name_the_post_migration_sub_skills(tmp_path: Path) -> None:
+    """F-9: the human-facing `issue` / `pr` labels quote the new skill names."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/devx-autopilot"),
+            _step_markers_result("plan"),
+            _assistant_text("continuing..."),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert "gh-issue:create" in json.loads(result.stdout)["reason"]

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -3100,3 +3100,34 @@ def test_new_namespace_sibling_base_dirs_are_not_boundaries(tmp_path: Path, labe
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip() == "", f"{label}: must not arm the guard. stdout={result.stdout!r}"
+
+
+def test_hint_alias_table_is_consistent_with_the_chain(tmp_path: Path) -> None:
+    """The per-slot hint alias must address the slot it is keyed under (PR #1693).
+
+    `_SUB_SKILL_HINT_ALIAS` used to be read positionally out of the chain
+    (`forms[-1]`), which silently picks a different name the moment a slot
+    gains another alias. The hook asserts the table at import, so a drifted
+    table makes the hook fail to start rather than emit a hint naming the
+    wrong step's skill — this test pins that the module still imports and
+    that each slot's hint reaches the model.
+    """
+    checks = [
+        ("gh-issue-implement", "Skill(gh-issue:implement)", []),
+        ("gh-commit", "Skill(gh-pr:commit)", ["gh-issue-implement"]),
+        ("gh-pr", "Skill(gh-pr:create)", ["gh-issue-implement", "gh-commit"]),
+    ]
+    for canonical, expected_hint, prefix in checks:
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_text("/gh-flow:issue 1693"),
+                *(_assistant_skill(n) for n in prefix),
+                _assistant_text("continuing"),
+            ],
+            name=f"transcript-{canonical}.jsonl",
+        )
+        result = _run_hook(_hook_event(transcript))
+        assert result.returncode == 0
+        reason = json.loads(result.stdout)["reason"]
+        assert expected_hint in reason, f"{canonical}: {reason}"

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -2823,3 +2823,280 @@ def test_async_wait_limit_one_allows_exactly_one(tmp_path: Path, marker_count: i
         assert json.loads(result.stdout)["decision"] == "block"
     else:
         assert result.stdout.strip() == "", f"streak {marker_count} is within limit 1. stdout={result.stdout!r}"
+
+
+# ---------------------------------------------------------------------------
+# D-12 dual-form namespace recognition (#1678)
+#
+# Phase 3 of #1410 migrates this composition into the `gh-flow-skills` repo
+# as `gh-flow:issue`, while NF-1 keeps the dotfiles original alive (and the
+# automation in `gh_flow.sh` / `issue_watcher_cron.sh` still dispatches the
+# old `/gh-issue-flow`) until Phase 4. The guard must therefore recognize
+# BOTH namespaces at once. Every case below is an ADDITION — no existing
+# assertion above is modified (issue #1678, NF-4).
+# ---------------------------------------------------------------------------
+
+# The same six chain slots as `_ALL_SIX_SUB_SKILLS`, addressed by their
+# post-migration names. Restated as literals for the same reason: the tests
+# drive the hook as a black box, so a silent drift in EXPECTED_CHAIN must
+# break them loudly.
+_ALL_SIX_SUB_SKILLS_NEW = [
+    "gh-issue:implement",
+    "gh-pr:commit",
+    "gh-pr:create",
+    "gh-verify:review-all",
+    "gh-resolve:conflict",
+    "gh-resolve:outdated",
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "boundary"),
+    [
+        ("colon-form", "/gh-flow:issue 1678"),
+        ("hyphen-form", "/gh-flow-issue 1678"),
+    ],
+)
+def test_new_namespace_slash_command_is_a_boundary(tmp_path: Path, label: str, boundary: str) -> None:
+    """`/gh-flow:issue` and `/gh-flow-issue` open a chain just like the old names."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text(boundary),
+            _assistant_text("done!"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"{label}: expected a block, got empty stdout"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+@pytest.mark.parametrize(
+    ("label", "boundary"),
+    [
+        ("command-name-wrapper", "<command-name>/gh-flow:issue</command-name>"),
+        ("command-name-wrapper-hyphen", "<command-name>/gh-flow-issue</command-name>"),
+        # The two real Claude Code install layouts, plus a flat dev checkout.
+        (
+            "skill-base-dir-marketplace",
+            "Base directory for this skill: /home/u/.claude/plugins/marketplaces/gh-flow-skills/skills/issue",
+        ),
+        (
+            "skill-base-dir-cache",
+            "Base directory for this skill: /home/u/.claude/plugins/cache/gh-flow-skills/gh-flow/0.1.0/skills/issue",
+        ),
+        ("skill-base-dir-flat", "Base directory for this skill: /home/u/.claude/skills/gh-flow/skills/issue"),
+        ("skill-h1", "# gh-flow:issue — Issue → PR composition"),
+    ],
+)
+def test_new_namespace_boundary_surfaces(tmp_path: Path, label: str, boundary: str) -> None:
+    """All four boundary surfaces have a new-namespace twin."""
+    transcript = _write_transcript(tmp_path, [_user_text(boundary), _assistant_text("done!")])
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), f"{label}: expected a block, got empty stdout"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_new_namespace_sibling_relay_skill_is_not_a_boundary(tmp_path: Path) -> None:
+    """`/gh-flow:issue-relay` shares a prefix with `/gh-flow:issue` but is a different skill.
+
+    A `\\b`-terminated boundary pattern would match it (the word break sits
+    between `issue` and `-relay`), silently arming the six-step chain guard
+    on the relay flow, which has no such chain.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue-relay 1678"),
+            _assistant_text("relay done"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"relay flow must not arm the guard. stdout={result.stdout!r}"
+
+
+def test_new_namespace_sub_skills_are_all_recognized(tmp_path: Path) -> None:
+    """All six chain slots count when invoked under their post-migration names."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue 1678"),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS_NEW),
+            _assistant_text("all done"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    reason = json.loads(result.stdout)["reason"]
+    assert "6/6 sub-skills" in reason, reason
+
+
+def test_old_and_new_alias_of_one_slot_count_once(tmp_path: Path) -> None:
+    """`gh-commit` and `gh-pr:commit` are the same chain slot, not two."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-issue-flow 1678"),
+            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr:commit"),
+            _assistant_text("committed"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    reason = json.loads(result.stdout)["reason"]
+    assert "1/6 sub-skills" in reason, reason
+
+
+def test_mixed_old_and_new_names_complete_the_chain(tmp_path: Path) -> None:
+    """A chain half-invoked under each namespace still reaches 6/6.
+
+    This is the transition-period shape D-12 exists for: the dotfiles copy
+    and the `gh-flow-skills` copy can both be installed at once.
+    """
+    mixed = [
+        "gh:issue-implement",
+        "gh-pr:commit",
+        "gh-pr",
+        "gh-verify:review-all",
+        "gh-pr-resolve-conflict",
+        "gh-resolve:outdated",
+    ]
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow-issue 1678"),
+            *(_assistant_skill(n) for n in mixed),
+            _assistant_text("all done"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    reason = json.loads(result.stdout)["reason"]
+    assert "6/6 sub-skills" in reason, reason
+    assert "Step 3" in reason, reason
+
+
+@pytest.mark.parametrize(
+    ("label", "marker"),
+    [
+        ("colon-complete", "gh-flow:issue complete (#1678)"),
+        ("colon-stopped", "gh-flow:issue stopped at step 2/6"),
+        ("hyphen-complete", "gh-flow-issue complete (#1678)"),
+        ("hyphen-stopped", "gh-flow-issue stopped at step 2/6"),
+    ],
+)
+def test_new_namespace_terminal_marker_allows_stop(tmp_path: Path, label: str, marker: str) -> None:
+    """The Step 3 report emitted under the new name still ends the chain."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue 1678"),
+            _assistant_text(f"[OK] {marker}\n  PR URL: https://github.com/o/r/pull/1"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"{label}: expected allow, got {result.stdout!r}"
+
+
+def test_new_namespace_terminal_marker_via_bash_channel(tmp_path: Path) -> None:
+    """The #1270 Bash fallback channel accepts the new-name marker too."""
+    command = "printf 'gh-flow:issue complete (#1678)\\n'"
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue 1678"),
+            _assistant_bash(command, block_id="toolu_report"),
+            _user_tool_result(
+                "gh-flow:issue complete (#1678)\n  PR URL: https://github.com/o/r/pull/1",
+                tool_use_id="toolu_report",
+            ),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"expected allow, got {result.stdout!r}"
+
+
+def test_new_namespace_relay_report_does_not_terminate_a_flow(tmp_path: Path) -> None:
+    """`gh-flow:issue-relay complete (#N)` must not satisfy `gh-flow:issue`'s terminal.
+
+    The two markers differ only by the `-relay` suffix, so a terminal
+    pattern that stopped at `issue` would let the sibling skill's own
+    report close this chain (issue #1678 Error Cases).
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue 1678"),
+            _assistant_text("[OK] gh-flow:issue-relay complete (#1678)"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip(), "the relay report must not terminate the issue flow"
+    assert json.loads(result.stdout)["decision"] == "block"
+
+
+def test_next_step_hint_names_both_namespaces(tmp_path: Path) -> None:
+    """A block's "next action" must be invocable under either namespace (#1678).
+
+    A session running only the migrated `gh-flow-skills` plugin has no
+    `gh-commit` skill, so a hint naming that alone answers the block with an
+    instruction it cannot follow.
+    """
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue 1678"),
+            _assistant_skill("gh-issue:implement"),
+            _assistant_text("implemented"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    reason = json.loads(result.stdout)["reason"]
+    assert "Skill(gh-commit)" in reason, reason
+    assert "Skill(gh-pr:commit)" in reason, reason
+
+
+def test_terminal_hint_after_full_chain_names_both_report_forms(tmp_path: Path) -> None:
+    """The Step 3 nudge quotes the old and new terminal marker (#1678)."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text("/gh-flow:issue 1678"),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS_NEW),
+            _assistant_text("all done"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    reason = json.loads(result.stdout)["reason"]
+    assert "gh:issue-flow complete (#N)" in reason, reason
+    assert "gh-flow:issue complete (#N)" in reason, reason
+
+
+@pytest.mark.parametrize(
+    ("label", "base_dir"),
+    [
+        ("relay-sibling", "/home/u/.claude/plugins/marketplaces/gh-flow-skills/skills/issue-relay"),
+        ("relay-merge-sibling", "/home/u/.claude/plugins/marketplaces/gh-flow-skills/skills/relay-merge"),
+    ],
+)
+def test_new_namespace_sibling_base_dirs_are_not_boundaries(tmp_path: Path, label: str, base_dir: str) -> None:
+    """The base-dir surface must not arm on a sibling skill in the same plugin."""
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _user_text(f"Base directory for this skill: {base_dir}"),
+            _assistant_text("done"),
+        ],
+    )
+    result = _run_hook(_hook_event(transcript))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", f"{label}: must not arm the guard. stdout={result.stdout!r}"


### PR DESCRIPTION
## Summary
- `dEitY719/gh-flow-skills`(public, MIT)를 신규 생성하고 컴포지션 스킬 4종을 `gh-flow` 플러그인으로 이관했다 — #1410 Phase 3 의 마지막 repo다.
- 두 Stop hook 을 dual-form 으로 넓혀 옛 이름과 새 이름을 **모두** 인식하게 했다 (D-12). Phase 4 까지 dotfiles 원본과 운영 자동화가 옛 이름으로 계속 돌기 때문에 "교체"가 아니라 "확장"이다.
- Phase 3 세 repo 이름이 모두 확정됐으므로 §6 이 예고한 docs 참조 일괄 갱신도 여기서 처리했다.

## Changes
- **신규 repo `gh-flow-skills`** — `skills/{issue,autopilot,issue-relay,relay-merge}` (도메인 접두 제거), 6개 하네스 매니페스트, `harness-skills` reusable CI workflow 호출. 교차참조는 #1410 §2 매핑대로 전부 최종 이름으로 갱신. `issue/SKILL.md` 는 117줄이라 CI 의 100줄 상한에 걸려서 progressive disclosure 를 실제로 적용했다 (Step 2.4.1 블록 14줄 → 5줄, 상세는 이미 `references/merge-train-wake.md` 에 있음).
- **`gh_issue_flow_stop_guard.py` (F-8)** — `EXPECTED_CHAIN` 을 슬롯당 4-form 별칭 튜플로, `_USER_BOUNDARY_RE`/`FLOW_SKILL_NAMES`/`TERMINAL_PATTERNS`/`_TERMINAL_COMMAND_RE` 에 `gh-flow:issue`/`gh-flow-issue` 분기 추가.
- **`devx_autopilot_stop_guard.py` (F-9)** — `_STEP_MARKER_RE` 가 `gh-flow-autopilot` 마커도 매칭, `TERMINAL_PATTERNS` 3건 추가, `_STEP_LABELS` 의 사람-facing 스킬명 갱신.
- **`claude/plugin/{marketplaces,plugins}.json` (F-5)** — `gh-flow-skills` / `gh-flow@gh-flow-skills` 등록. 회귀는 기존 세 테이블에 한 줄씩.
- **docs (F-12)** — `docs/.ssot/{github-project-board,env-vars,local-test-policy}.md` + `claude/README.md` 의 스킬명을 플러그인 네임스페이스로 갱신.
- **테스트 (F-11)** — 두 stop-guard 스위트에 새 이름 케이스 추가. 기존 케이스는 한 줄도 수정하지 않았다 (NF-4).

## 이슈 사양에서 벗어난 판단 3건

1. **F-9 를 이슈가 적은 것보다 넓게 갔다.** 이슈는 autopilot 가드의 마커/터미널만 넓히라고 했지만, `_USER_BOUNDARY_RE`/`FLOW_SKILL_NAMES` 도 같이 넓혔다. 그러지 않으면 `/gh-flow:autopilot` 에서 가드가 **애초에 무장하지 않아** F-9 의 확장이 도달 불가능한 죽은 코드가 된다 — D-12 가 보호하려는 바로 그 사용자에게.
2. **§2 가 빠뜨린 교차참조 3건을 채웠다** — `gh:pr-reply` → `gh-pr:reply`, `gh:pr-merge-train` → `gh-pr:merge-train`, `devx:schedule` → `session:schedule`. #1410 §2 배정표 + §4 접두 제거 규칙으로 일의적으로 정해지고, 남겨 두면 이관본에 dangling 참조가 생긴다 (#1676 이 자기 몫 3건에 내린 것과 같은 판단). **작업 중 #1677 이 머지되어 `gh-pr-skills` 의 실제 스킬 디렉토리명 8개를 조회해 확인했다 — 규칙으로 유도한 이름과 전부 일치한다.**
3. **`_next_step_label` 이 두 이름을 함께 인용한다.** `gh-flow-skills` 만 설치한 세션에는 `gh-commit` 이 없으므로, block 이 "존재하지 않는 스킬을 호출하라"고 지시하게 된다. 마이그레이션이 스스로 만들어내는 결함이라 같이 고쳤다. 정규 이름이 앞에 오므로 기존 `"Step 2.2 — Skill(gh-commit)"` 부분문자열 단언은 그대로 통과한다.

## 구현 중 드러난 함정 3가지

- **`skill.replace(":", "-")` 정규화가 이름 변경에 깨진다.** 한 슬롯의 콜론형·하이픈형이 구분자만 다른 같은 문자열일 때만 성립했는데, `gh-pr:commit` → `gh-pr-commit` 이고 이건 `gh-commit` 이 아니다. 그대로 두면 한 슬롯의 두 별칭이 서로 다른 단계로 집계돼 5단계 체인을 6/6 으로 오판한다. alias→canonical dict 로 명시화했다.
- **`\b` 는 형제 스킬이 접두를 공유할 때 잘못된 종결자다.** `issue` 와 `-relay` 사이에 워드 경계가 있어 `/gh-flow:issue-relay` 가 6단계 체인 가드를 무장시킨다. `(?![\w-])` 로 닫고 회귀 테스트를 붙였다. 같은 함정이 치환 과정에서도 두 번 나왔다 (`/gh-pr` 이 `/gh-pr:commit` 을 먹어 `/gh-pr:create:commit` 생성).
- **base-dir 분기 정규식이 실제 설치 경로를 하나도 매칭하지 않았다.** 방금 설치한 플러그인으로 측정해서 발견 — Claude Code 는 `plugins/marketplaces/gh-flow-skills/skills/issue` 와 `plugins/cache/gh-flow-skills/gh-flow/<version>/skills/issue` 로 푼다. `<plugin>/skills/<skill>` 이 아니다. 중첩 깊이에 고정한 패턴은 둘 다 조용히 놓친다.

## 남는 우려 (F-12)

이 문서들이 설명하는 명령을 사용자는 **지금** 옛 이름으로 친다. 이슈가 명시적으로 요구했으므로 그대로 갱신하되, 두 SSOT 문서에 "옛 슬래시 명령은 Phase 4 까지 계속 동작한다"는 전환기 주석을 넣었다. `claude/skills/<dir>/` 경로는 원본을 가리키므로 옛 이름 그대로 뒀다 (NF-1).

## Test plan
- [x] `gh-flow-skills` CI green — run 33504452383, 33504559242
- [x] `claude plugin install gh-flow@gh-flow-skills` → `plugin details` 가 스킬 4개(autopilot/issue/issue-relay/relay-merge) 로드 확인
- [x] `restore.sh --dry-run` 이 신규 marketplace + plugin 둘 다 인식
- [x] §2 acceptance grep — 이관본에서 옛 이름 0건 (D-12 를 설명하는 의도적 리터럴 1건 제외)
- [x] 7개 매니페스트 버전 일치, 이모지 0건, SKILL.md 4개 모두 ≤100줄
- [x] pytest 1650 passed / 1 failed — `test_command_docs` 의 `gcp.md`·`mytool.md` stale, 편집 전 baseline 과 동일
- [x] bats 3699 ok / 42 not-ok — pristine HEAD 워크트리를 별도로 만들어 돌린 결과와 **실패 집합이 완전히 동일**
- [x] `ruff check` / `ruff format` / `mypy` / `lint-docs` green
- [x] NF-4 — 두 테스트 파일 `git diff --numstat` 삭제 0줄
- [x] NF-1 — `claude/skills/` 원본 무변경

## Related
Closes #1678

---
<details>
<summary>🤖 AI Metrics · 📊 ~17000 tokens · 👤 ~24 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~17000 tokens · 👤 ~24 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
