### PR TITLE
refactor(claude-plugin): _read_json_or 4중 중복을 shell-common 헬퍼로 공통화

### DIFF
--- a/claude/hooks/plugin-sync.sh
+++ b/claude/hooks/plugin-sync.sh
@@ -105,6 +105,34 @@ MAIN_ROOT="$HOME/dotfiles"
 # leaves _resolve_sync_title falling back to $SYNC_TITLE.
 # shellcheck disable=SC1091
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/plugin_sync_title.sh" 2>/dev/null || true
+# The manifest reader (_claude_plugin_read_json_or) is the same helper
+# reconcile.sh and restore.sh need, so it has a single home in shell-common
+# (#1696).
+# shellcheck disable=SC1091
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/claude_plugin_manifest.sh" 2>/dev/null || true
+
+# Bootstrap fallback, NOT a second implementation to maintain in parallel.
+# The title helper may go missing and the hook simply commits under the bare
+# subject, but the reader feeds `jq --argjson` for the merge itself: without it
+# the merged value comes out empty, _write_manifest refuses to write, and the
+# manifest update is lost silently. A stale install must still sync (pinned by
+# tests/bats/skills/plugin_sync_hook.bats "falls back to the bare subject when
+# the title helper is unavailable", which asserts the commit still lands).
+# Behavior changes belong in shell-common/functions/claude_plugin_manifest.sh;
+# this copy follows it.
+if ! command -v _claude_plugin_read_json_or >/dev/null 2>&1; then
+	_claude_plugin_read_json_or() {
+		local out=""
+		if [ -f "$1" ]; then
+			out=$(jq -c '.' "$1" 2>/dev/null)
+		fi
+		if [ -n "$out" ]; then
+			printf '%s' "$out"
+		else
+			printf '%s' "$2"
+		fi
+	}
+fi
 
 SRC="$HOME/.claude-shared/plugins"
 MP_SRC="$SRC/known_marketplaces.json"
@@ -175,15 +203,6 @@ _push_if_protected() {
 	fi
 }
 
-# Emit the compact JSON in file $1, or the default $2 when the file is
-# missing, empty (0-byte — `jq .` exits 0 with no output there, so a plain
-# `jq . || echo` fallback would not fire), or invalid JSON.
-_read_json_or() {
-	local out
-	out=$(jq -c '.' "$1" 2>/dev/null)
-	[ -n "$out" ] && printf '%s' "$out" || printf '%s' "$2"
-}
-
 # scope:user plugins from $PL_SRC whose marketplace (the part after `@`) is a
 # key of the marketplace map passed as $1 (mp_common → public, mp_internal →
 # private). Same filter for both sides; only the map differs.
@@ -246,9 +265,9 @@ if [ "$action" = "add" ]; then
 	# lands on disk and what _resolve_sync_title diffs the current manifest
 	# against (#1558) — computing it once is what stops the commit title and
 	# the commit content from ever disagreeing.
-	mp_pub=$(jq -n --argjson old "$(_read_json_or "$PUB_DIR/marketplaces.json" '{}')" \
+	mp_pub=$(jq -n --argjson old "$(_claude_plugin_read_json_or "$PUB_DIR/marketplaces.json" '{}')" \
 		--argjson new "$mp_common" '$old * $new')
-	pl_pub=$(jq -n --argjson old "$(_read_json_or "$PUB_DIR/plugins.json" '{"plugins":[]}')" \
+	pl_pub=$(jq -n --argjson old "$(_claude_plugin_read_json_or "$PUB_DIR/plugins.json" '{"plugins":[]}')" \
 		--argjson new "$plugins_common" \
 		'(($old.plugins? // []) + $new | unique | sort)')
 	pub_title=$(_resolve_sync_title \
@@ -261,9 +280,9 @@ if [ "$action" = "add" ]; then
 	if [ -d "$PRIV_DIR/.git" ] && [ "$mp_internal" != "{}" ]; then
 		# Its own commit over its own files, so its own title — reusing the
 		# public one would name public keys in a private-repo commit.
-		mp_priv=$(jq -n --argjson old "$(_read_json_or "$PRIV_DIR/marketplaces.json" '{}')" \
+		mp_priv=$(jq -n --argjson old "$(_claude_plugin_read_json_or "$PRIV_DIR/marketplaces.json" '{}')" \
 			--argjson new "$mp_internal" '$old * $new')
-		pl_priv=$(jq -n --argjson old "$(_read_json_or "$PRIV_DIR/plugins.json" '{"plugins":[]}')" \
+		pl_priv=$(jq -n --argjson old "$(_claude_plugin_read_json_or "$PRIV_DIR/plugins.json" '{"plugins":[]}')" \
 			--argjson new "$plugins_internal" \
 			'(($old.plugins? // []) + $new | unique | sort)')
 		priv_title=$(_resolve_sync_title \

--- a/claude/plugin/reconcile.sh
+++ b/claude/plugin/reconcile.sh
@@ -104,6 +104,32 @@ command -v jq >/dev/null 2>&1 || {
 # --check must keep working on a half-installed tree.
 # shellcheck disable=SC1091
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/plugin_sync_title.sh" 2>/dev/null || true
+# The manifest reader (_claude_plugin_read_json_or) is the same helper the
+# hook and restore.sh need, so it has a single home in shell-common (#1696).
+# shellcheck disable=SC1091
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/claude_plugin_manifest.sh" 2>/dev/null || true
+
+# Bootstrap fallback, NOT a second implementation to maintain in parallel.
+# Unlike the commit title, the reader is on --check's path, and --check is
+# required to work on a half-installed tree (the invariant stated above, pinned
+# by tests/bats/tools/claude_plugin_reconcile.bats "--check still works when
+# the ... helper cannot be sourced"). Degrading here would not fail loudly: an
+# unread manifest looks exactly like an empty one, so drift would be reported
+# backwards instead of being reported as an error. Behavior changes belong in
+# shell-common/functions/claude_plugin_manifest.sh; this copy follows it.
+if ! command -v _claude_plugin_read_json_or >/dev/null 2>&1; then
+	_claude_plugin_read_json_or() {
+		local out=""
+		if [ -f "$1" ]; then
+			out=$(jq -c '.' "$1" 2>/dev/null)
+		fi
+		if [ -n "$out" ]; then
+			printf '%s' "$out"
+		else
+			printf '%s' "$2"
+		fi
+	}
+fi
 
 PUB_DIR="$SCRIPT_DIR"
 PRIV_DIR="$SCRIPT_DIR/company"
@@ -165,25 +191,12 @@ _target_plugins_for_mp() {
 plugins_common=$(_target_plugins_for_mp "$target_common") || exit 1
 plugins_private=$(_target_plugins_for_mp "$target_private") || exit 1
 
-# Compact JSON of file $1, or default $2 when missing/empty/invalid.
-_read_json_or() {
-	local out=""
-	if [ -f "$1" ]; then
-		out=$(jq -c '.' "$1" 2>/dev/null)
-	fi
-	if [ -n "$out" ]; then
-		printf '%s' "$out"
-	else
-		printf '%s' "$2"
-	fi
-}
-
 # --- diff helpers ---------------------------------------------------------
 # Each prints drift lines to stdout and returns 1 when it found any.
 
 _diff_marketplaces() {
 	local current_file="$1" target="$2" current lines
-	current=$(_read_json_or "$current_file" '{}')
+	current=$(_claude_plugin_read_json_or "$current_file" '{}')
 	lines=$(jq -rn --argjson c "$current" --argjson t "$target" '
         [ ($t | to_entries[] | select($c[.key] == null) | "  + \(.key) (\(.value))"),
           ($c | to_entries[] | select($t[.key] == null) | "  - \(.key) (유령 — SSOT 에 없음)"),
@@ -198,7 +211,7 @@ _diff_marketplaces() {
 
 _diff_plugins() {
 	local current_file="$1" target="$2" current lines
-	current=$(_read_json_or "$current_file" '{"plugins":[]}')
+	current=$(_claude_plugin_read_json_or "$current_file" '{"plugins":[]}')
 	lines=$(jq -rn --argjson c "$current" --argjson t "$target" '
         ($c.plugins // []) as $cur |
         [ ($t[]   | select(. as $x | ($cur | index($x)) | not) | "  + \(.)"),

--- a/claude/plugin/restore.sh
+++ b/claude/plugin/restore.sh
@@ -38,6 +38,35 @@ else
 	UX_SUCCESS="" UX_ERROR="" UX_WARNING="" UX_MUTED="" UX_RESET=""
 fi
 
+# The manifest reader (_claude_plugin_read_json_or) is shared with
+# claude/plugin/reconcile.sh and claude/hooks/plugin-sync.sh, so it has a
+# single home in shell-common (#1696). Resolved via $SHELL_COMMON rather than
+# $SCRIPT_DIR because this script is also run from a copy that has no
+# shell-common sibling (bats fixtures).
+# shellcheck disable=SC1091
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/claude_plugin_manifest.sh" 2>/dev/null || true
+
+# Bootstrap fallback, NOT a second implementation to maintain in parallel.
+# Until #1696 this script sourced nothing at all, precisely so that a
+# half-installed tree (fresh PC mid-bootstrap — the situation restore.sh exists
+# for) could still run it. Sourcing the shared helper must not weaken that, so
+# an unreachable shell-common leaves the behavior exactly as it was. Behavior
+# changes belong in shell-common/functions/claude_plugin_manifest.sh; this copy
+# follows it.
+if ! command -v _claude_plugin_read_json_or >/dev/null 2>&1; then
+	_claude_plugin_read_json_or() {
+		local out=""
+		if [ -f "$1" ]; then
+			out=$(jq -c '.' "$1" 2>/dev/null)
+		fi
+		if [ -n "$out" ]; then
+			printf '%s' "$out"
+		else
+			printf '%s' "$2"
+		fi
+	}
+fi
+
 DRY_RUN=0
 SYNC=0
 ALL_ACCOUNTS=0
@@ -238,8 +267,7 @@ _local_marketplaces() {
 _local_plugins() {
 	[ -f "$PL_LOCAL" ] || return 0
 	local mp_src
-	mp_src=$(jq -c '.' "$MP_LOCAL" 2>/dev/null)
-	[ -n "$mp_src" ] || mp_src='{}'
+	mp_src=$(_claude_plugin_read_json_or "$MP_LOCAL" '{}')
 	jq -r --argjson m "$mp_src" '
         (.plugins // {}) | to_entries[]
         | select(any(.value[]?; .scope == "user"))

--- a/docs/public/changelog.d/2026-09-02-1696.md
+++ b/docs/public/changelog.d/2026-09-02-1696.md
@@ -1,0 +1,1 @@
+- 변경: **plugin 매니페스트 JSON 리더를 `shell-common/functions/claude_plugin_manifest.sh` 하나로 통합 (#1696)** — `claude/plugin/{reconcile,restore}.sh` 와 `claude/hooks/plugin-sync.sh`, `plugin_sync_title.sh` 에 각각 흩어져 있던 "compact JSON 또는 기본값"(파일 없음/0-byte/깨진 JSON) 규칙이 `_claude_plugin_read_json_or` 한 곳에서 관리된다. 세 스크립트는 shell-common 이 없는 반쯤 설치된 트리에서도 동작해야 하므로, 표기된 부트스트랩 폴백만 각자 남긴다. 동작 변화는 없다.

--- a/shell-common/functions/claude_plugin_manifest.sh
+++ b/shell-common/functions/claude_plugin_manifest.sh
@@ -16,15 +16,21 @@
 #                                   _plugin_sync_read_json_or
 #
 # They agreed by accident, not by construction. This file is the one copy the
-# rule is now maintained in; the three scripts above source it and keep only a
+# rule is now maintained in; all four files above source it and keep only a
 # clearly-labelled bootstrap fallback for the half-installed tree they are each
-# documented (and, for two of them, tested) to survive — see the comment at
+# documented (and, for three of them, tested) to survive — see the comment at
 # each fallback.
 #
+# The list above is the set of copies this file replaced, not every manifest
+# read in the tree: claude/hooks/plugin-sync-session.sh reads the same two
+# files through filtered jq programs (`keys`, `.mp_keys // []`), which do not
+# fit this helper's fixed `jq -c '.'`, and keeps its own reads.
+#
 # Like shell-common/functions/plugin_sync_title.sh, this file deliberately has
-# NO interactive guard: it only defines a function and produces no output at
-# file scope, so the guard would hide the function from the very callers that
-# need it (hooks and one-shot scripts sourcing it non-interactively).
+# NO interactive guard: apart from the advisory diagnostics below it defines a
+# function and produces no output at file scope, so the guard would hide the
+# function from the very callers that need it (hooks and one-shot scripts
+# sourcing it non-interactively).
 #
 # POSIX only — shell-common/functions/*.sh is auto-sourced by both the bash
 # and the zsh loader, so no bashisms (no arrays, no `local`, no `[[ ]]`) may
@@ -32,15 +38,36 @@
 #
 # Requires: jq.
 
+# Include-once sentinel (issue #1505, same rationale as dotfiles_root.sh): this
+# file is reached twice per interactive shell — once by the functions/ auto-
+# loader's own pass over shell-common/functions/*.sh, then again when that pass
+# reaches plugin_sync_title.sh, which sources this file itself. Repeats re-parse
+# the file, redefine the function and re-run the guard below (a `dirname` fork
+# plus an un-memoized `git rev-parse` subshell each time — dotfiles_root.sh
+# memoizes only the canonical side) for no benefit. `return` (not `exit`) since
+# this only ever runs as a sourced dot-script; the `|| exit 0` fallback covers
+# the (unsupported) case of running it directly.
+if [ -n "${_CLAUDE_PLUGIN_MANIFEST_SH_SOURCED-}" ]; then
+    # shellcheck disable=SC2317  # exit fallback only runs if this file is
+    # executed directly (not sourced), so `return` succeeding makes it look
+    # unreachable to static analysis.
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_PLUGIN_MANIFEST_SH_SOURCED=1
+
 # Advisory only (issue #1454, propagated by #1505): warn once on stderr when
 # this file was sourced from a checkout that is a different git repo than
-# $HOME/dotfiles. Mandated by shell-common/AGENTS.md for every functions/*.sh
-# a non-interactive hook or script sources directly, which is exactly how all
-# three callers reach this file. Never blocks, and deliberately NOT wrapped in
-# an interactive guard — see the header note above; the guard function is
-# itself a silent no-op outside the genuine foreign-checkout case. Without it a
-# stale sibling checkout could silently supply different manifest-read
-# semantics than the manifest writers assume.
+# $HOME/dotfiles. This is the standard guard that
+# docs/guide/playbooks/shell-common-cheatsheet.md → "Foreign-Checkout Guard
+# Snippet" requires be copied character-for-character (only the LABEL differs)
+# into each guarded shell-common/functions/*.sh. It speaks on the loader
+# auto-source path (shell-common/util/safe_source.sh treats */functions/* as
+# "important" and does not redirect its stderr); the four explicit callers all
+# source with `2>/dev/null`, so it is deliberately silent there. Never blocks,
+# and deliberately NOT wrapped in an interactive guard — see the header note
+# above; the guard function is itself a silent no-op outside the genuine
+# foreign-checkout case. Without it a stale sibling checkout could silently
+# supply different manifest-read semantics than the manifest writers assume.
 #
 # The self-path branch must stay here at file top level — zsh rebinds $0 to
 # the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
@@ -49,24 +76,24 @@
 # bash: dash aborts with "Bad substitution" the moment it expands
 # ${BASH_SOURCE[0]}.
 if [ -n "${ZSH_VERSION-}" ]; then
-    _cpm_self="$0"
+    _drg_self="$0"
 elif [ -n "${BASH_VERSION-}" ]; then
     # shellcheck disable=SC3028  # bash-only var, gated by $BASH_VERSION above
-    _cpm_self="${BASH_SOURCE[0]-}"
+    _drg_self="${BASH_SOURCE[0]-}"
 else
-    _cpm_self=""
+    _drg_self=""
 fi
-_cpm_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
-if [ -r "$_cpm_helper" ]; then
-    . "$_cpm_helper" || true
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
 fi
 if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
-    _dotfiles_root_guard_self "$_cpm_self" "claude_plugin_manifest"
+    _dotfiles_root_guard_self "$_drg_self" "claude_plugin_manifest"
 else
     printf '[claude_plugin_manifest] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
-        "$_cpm_helper" >&2
+        "$_drg_helper" >&2
 fi
-unset _cpm_self _cpm_helper
+unset _drg_self _drg_helper
 
 # _claude_plugin_read_json_or <file> <default>
 #

--- a/shell-common/functions/claude_plugin_manifest.sh
+++ b/shell-common/functions/claude_plugin_manifest.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# shell-common/functions/claude_plugin_manifest.sh
+# SSOT for reading a Claude plugin manifest file into a jq-safe JSON value.
+#
+# Every writer and reader of claude/plugin/{marketplaces,plugins}.json needs
+# the same three-way degradation before it can hand the file to
+# `jq --argjson`: a missing file, a 0-byte file and a corrupt file must all
+# collapse to a caller-chosen default rather than to the empty string (which
+# `--argjson` rejects outright). Four copies of that rule had grown up
+# independently (issue #1696):
+#
+#   claude/plugin/reconcile.sh      _read_json_or            (local function)
+#   claude/hooks/plugin-sync.sh     _read_json_or            (local function)
+#   claude/plugin/restore.sh        inlined at the call site
+#   shell-common/functions/plugin_sync_title.sh
+#                                   _plugin_sync_read_json_or
+#
+# They agreed by accident, not by construction. This file is the one copy the
+# rule is now maintained in; the three scripts above source it and keep only a
+# clearly-labelled bootstrap fallback for the half-installed tree they are each
+# documented (and, for two of them, tested) to survive — see the comment at
+# each fallback.
+#
+# Like shell-common/functions/plugin_sync_title.sh, this file deliberately has
+# NO interactive guard: it only defines a function and produces no output at
+# file scope, so the guard would hide the function from the very callers that
+# need it (hooks and one-shot scripts sourcing it non-interactively).
+#
+# POSIX only — shell-common/functions/*.sh is auto-sourced by both the bash
+# and the zsh loader, so no bashisms (no arrays, no `local`, no `[[ ]]`) may
+# appear here.
+#
+# Requires: jq.
+
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Mandated by shell-common/AGENTS.md for every functions/*.sh
+# a non-interactive hook or script sources directly, which is exactly how all
+# three callers reach this file. Never blocks, and deliberately NOT wrapped in
+# an interactive guard — see the header note above; the guard function is
+# itself a silent no-op outside the genuine foreign-checkout case. Without it a
+# stale sibling checkout could silently supply different manifest-read
+# semantics than the manifest writers assume.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. This file is real
+# POSIX sh, so the bash array form is reached only when $BASH_VERSION proves
+# bash: dash aborts with "Bad substitution" the moment it expands
+# ${BASH_SOURCE[0]}.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _cpm_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    # shellcheck disable=SC3028  # bash-only var, gated by $BASH_VERSION above
+    _cpm_self="${BASH_SOURCE[0]-}"
+else
+    _cpm_self=""
+fi
+_cpm_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_cpm_helper" ]; then
+    . "$_cpm_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_cpm_self" "claude_plugin_manifest"
+else
+    printf '[claude_plugin_manifest] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_cpm_helper" >&2
+fi
+unset _cpm_self _cpm_helper
+
+# _claude_plugin_read_json_or <file> <default>
+#
+# Emit the compact JSON in <file>, or <default> when that file is missing,
+# empty (a 0-byte file makes `jq .` exit 0 with NO output, so a plain
+# `jq . || echo` fallback would not fire), or invalid JSON.
+#
+# No trailing newline: every caller feeds the result straight into
+# `jq --argjson`, and the `if/else` form (rather than `[ -n ] && ... || ...`)
+# keeps the default branch reachable even if the success `printf` ever fails.
+_claude_plugin_read_json_or() {
+    _cprjo_out=""
+    if [ -f "$1" ]; then
+        _cprjo_out=$(jq -c '.' "$1" 2>/dev/null)
+    fi
+    if [ -n "$_cprjo_out" ]; then
+        printf '%s' "$_cprjo_out"
+    else
+        printf '%s' "$2"
+    fi
+}

--- a/shell-common/functions/plugin_sync_title.sh
+++ b/shell-common/functions/plugin_sync_title.sh
@@ -67,11 +67,33 @@ unset _drg_self _drg_helper
 # The manifest reader this file's two _changed_keys_* helpers need is shared
 # with claude/plugin/{reconcile,restore}.sh and claude/hooks/plugin-sync.sh,
 # so it lives in its own file rather than here (issue #1696). Sourced the same
-# best-effort way as dotfiles_root.sh above: both files ship together in
-# shell-common/functions/, so a checkout that can reach this one can reach that
-# one too.
+# best-effort way as dotfiles_root.sh above: both files normally ship together
+# in shell-common/functions/, but "normally" is not "always" — a stale/partial
+# checkout can carry this file without its newer sibling (agy + codex PR #1697
+# review, independently). Without a fallback, _changed_keys_marketplaces /
+# _changed_keys_plugins would call an undefined function the moment that
+# happens, exactly the "command not found" failure the other three #1696
+# call sites already guard against.
 # shellcheck disable=SC1091
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/claude_plugin_manifest.sh" 2>/dev/null || true
+
+# Bootstrap fallback, NOT a second implementation to maintain in parallel.
+# Behavior changes belong in shell-common/functions/claude_plugin_manifest.sh;
+# this copy follows it. POSIX only (no `local`) — this file is sourced by
+# both bash and zsh loaders.
+if ! command -v _claude_plugin_read_json_or >/dev/null 2>&1; then
+    _claude_plugin_read_json_or() {
+        _cprjo_fb_out=""
+        if [ -f "$1" ]; then
+            _cprjo_fb_out=$(jq -c '.' "$1" 2>/dev/null)
+        fi
+        if [ -n "$_cprjo_fb_out" ]; then
+            printf '%s' "$_cprjo_fb_out"
+        else
+            printf '%s' "$2"
+        fi
+    }
+fi
 
 # Back-compat alias for the pre-#1696 name. Kept because it is part of this
 # file's published surface (tests/bats/tools/plugin_sync_title_smoke.bats

--- a/shell-common/functions/plugin_sync_title.sh
+++ b/shell-common/functions/plugin_sync_title.sh
@@ -64,19 +64,20 @@ else
 fi
 unset _drg_self _drg_helper
 
-# Emit the compact JSON in file $1, or the default $2 when that file is
-# missing, empty (a 0-byte file makes `jq .` exit 0 with NO output, so a
-# plain `jq . || echo` fallback would not fire), or invalid JSON.
+# The manifest reader this file's two _changed_keys_* helpers need is shared
+# with claude/plugin/{reconcile,restore}.sh and claude/hooks/plugin-sync.sh,
+# so it lives in its own file rather than here (issue #1696). Sourced the same
+# best-effort way as dotfiles_root.sh above: both files ship together in
+# shell-common/functions/, so a checkout that can reach this one can reach that
+# one too.
+# shellcheck disable=SC1091
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/claude_plugin_manifest.sh" 2>/dev/null || true
+
+# Back-compat alias for the pre-#1696 name. Kept because it is part of this
+# file's published surface (tests/bats/tools/plugin_sync_title_smoke.bats
+# asserts it is defined) — new code should call _claude_plugin_read_json_or.
 _plugin_sync_read_json_or() {
-    _psrjo_out=""
-    if [ -f "$1" ]; then
-        _psrjo_out=$(jq -c '.' "$1" 2>/dev/null)
-    fi
-    if [ -n "$_psrjo_out" ]; then
-        printf '%s' "$_psrjo_out"
-    else
-        printf '%s' "$2"
-    fi
+    _claude_plugin_read_json_or "$@"
 }
 
 # _changed_keys_marketplaces <current_file> <target_json>
@@ -85,7 +86,7 @@ _plugin_sync_read_json_or() {
 # no explanatory text, unlike reconcile.sh's _diff_marketplaces — for
 # embedding in a commit title. <target_json> is a {name: repo} map.
 _changed_keys_marketplaces() {
-    _ckm_current=$(_plugin_sync_read_json_or "$1" '{}')
+    _ckm_current=$(_claude_plugin_read_json_or "$1" '{}')
     jq -rn --argjson c "$_ckm_current" --argjson t "$2" '
         [ ($t | to_entries[] | select($c[.key] == null) | "+\(.key)"),
           ($c | to_entries[] | select($t[.key] == null) | "-\(.key)"),
@@ -99,7 +100,7 @@ _changed_keys_marketplaces() {
 # Same idea for the plugins manifest. <target_json> is a flat array of
 # plugin names, so only "+"/"-" are possible (no value to change).
 _changed_keys_plugins() {
-    _ckp_current=$(_plugin_sync_read_json_or "$1" '{"plugins":[]}')
+    _ckp_current=$(_claude_plugin_read_json_or "$1" '{"plugins":[]}')
     jq -rn --argjson c "$_ckp_current" --argjson t "$2" '
         ($c.plugins // []) as $cur |
         [ ($t[]   | select(. as $x | ($cur | index($x)) | not) | "+\(.)"),

--- a/tests/bats/tools/claude_plugin_manifest.bats
+++ b/tests/bats/tools/claude_plugin_manifest.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# tests/bats/tools/claude_plugin_manifest.bats
+# shell-common/functions/claude_plugin_manifest.sh — direct unit coverage for
+# _claude_plugin_read_json_or (issue #1696, agy + codex PR #1697 review: the
+# unified helper itself had no dedicated test, only indirect coverage through
+# its four callers).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+FILE="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/claude_plugin_manifest.sh"
+
+@test "claude_plugin_manifest.sh sources cleanly under bash and defines the reader" {
+    run bash --noprofile --norc -c "
+        source '${FILE}'
+        command -v _claude_plugin_read_json_or >/dev/null 2>&1 || { echo missing; exit 1; }
+        echo defined
+    "
+    assert_success
+    assert_output --partial 'defined'
+}
+
+@test "claude_plugin_manifest.sh sources cleanly under zsh and defines the reader" {
+    run zsh --no-rcs -c "
+        source '${FILE}'
+        command -v _claude_plugin_read_json_or >/dev/null 2>&1 || { echo missing; exit 1; }
+        echo defined
+    "
+    assert_success
+    assert_output --partial 'defined'
+}
+
+@test "_claude_plugin_read_json_or returns the default when the file is missing" {
+    run bash --noprofile --norc -c "
+        source '${FILE}'
+        _claude_plugin_read_json_or '$TEST_TEMP_HOME/does-not-exist.json' '{}'
+    "
+    assert_success
+    assert_output '{}'
+}
+
+@test "_claude_plugin_read_json_or returns the default when the file is 0-byte" {
+    : > "$TEST_TEMP_HOME/empty.json"
+    run bash --noprofile --norc -c "
+        source '${FILE}'
+        _claude_plugin_read_json_or '$TEST_TEMP_HOME/empty.json' '{\"plugins\":[]}'
+    "
+    assert_success
+    assert_output '{"plugins":[]}'
+}
+
+@test "_claude_plugin_read_json_or returns the default when the file is malformed JSON" {
+    printf 'not json {' > "$TEST_TEMP_HOME/broken.json"
+    run bash --noprofile --norc -c "
+        source '${FILE}'
+        _claude_plugin_read_json_or '$TEST_TEMP_HOME/broken.json' '{}'
+    "
+    assert_success
+    assert_output '{}'
+}
+
+@test "_claude_plugin_read_json_or returns the file's compact JSON when valid" {
+    cat > "$TEST_TEMP_HOME/manifest.json" <<'JSON'
+{
+  "kept": "org/kept"
+}
+JSON
+    run bash --noprofile --norc -c "
+        source '${FILE}'
+        _claude_plugin_read_json_or '$TEST_TEMP_HOME/manifest.json' '{}'
+    "
+    assert_success
+    assert_output '{"kept":"org/kept"}'
+}

--- a/tests/bats/tools/plugin_sync_title_smoke.bats
+++ b/tests/bats/tools/plugin_sync_title_smoke.bats
@@ -42,6 +42,26 @@ FILE="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/plugin_sync_title.sh"
     assert_output --partial 'all-defined'
 }
 
+@test "_plugin_sync_read_json_or still works when claude_plugin_manifest.sh cannot be sourced (#1696 agy+codex PR #1697 review)" {
+    # A stale/partial shell-common checkout: this file is reachable (sourced
+    # directly by absolute path below, as every real caller does) but its
+    # sibling claude_plugin_manifest.sh is not (SHELL_COMMON points elsewhere).
+    # Without its own bootstrap fallback, _changed_keys_marketplaces /
+    # _changed_keys_plugins would hit "command not found" the moment that
+    # happens — this is what both reviewers flagged as a BLOCKER.
+    run bash --noprofile --norc -c "
+        SHELL_COMMON='$TEST_TEMP_HOME/no-such-shell-common'
+        source '${FILE}'
+        command -v _claude_plugin_read_json_or >/dev/null 2>&1 || { echo missing; exit 1; }
+        _claude_plugin_read_json_or '$TEST_TEMP_HOME/does-not-exist.json' '{}'
+    "
+    assert_success
+    # --partial, not exact: the #1454 dotfiles_root.sh guard also can't be
+    # sourced from the bogus SHELL_COMMON and prints its own advisory WARN to
+    # stderr, which `run` merges into $output — unrelated to this test's point.
+    assert_output --partial '{}'
+}
+
 @test "_plugin_sync_title composes an end-to-end title under bash" {
     cat > "$TEST_TEMP_HOME/current-mp.json" <<'JSON'
 {"kept": "org/kept"}


### PR DESCRIPTION
## Summary
- `_read_json_or`("compact JSON 또는 기본값" 리더)가 `claude/plugin/{reconcile,restore}.sh`, `claude/hooks/plugin-sync.sh`, `shell-common/functions/plugin_sync_title.sh` 네 곳에 근접 복제돼 있던 것을 `shell-common/functions/claude_plugin_manifest.sh` 하나로 통합했다.
- 세 스크립트(reconcile.sh --check, plugin-sync.sh, restore.sh)는 shell-common 없이도 동작해야 하는 기존 불변식을 가지며 그중 둘은 bats 로 고정돼 있어, 각자 "SSOT 를 따르는 부트스트랩 폴백"임을 명시한 최소 복제만 남겼다 — 물리적 중복은 완전히 제거되지 않았지만 동작 규칙은 한 곳(SSOT)에서만 관리된다.
- 동작 변화 없음(순수 리팩터).

## Changes
- `shell-common/functions/claude_plugin_manifest.sh` (신설): `_claude_plugin_read_json_or` SSOT. 헤더는 `plugin_sync_title.sh`의 `#1454`/`#1505` self-path guard 패턴을 그대로 따른다.
- `shell-common/functions/plugin_sync_title.sh`: 새 파일을 source, `_plugin_sync_read_json_or`는 하위호환 wrapper로 유지(`plugin_sync_title_smoke.bats`가 이름을 검증).
- `claude/plugin/reconcile.sh`: 로컬 `_read_json_or` 삭제, 새 헬퍼로 교체. `--check`가 shell-common 없이도 동작해야 한다는 기존 불변식(`claude_plugin_reconcile.bats` 로 고정)을 지키기 위해 라벨링된 부트스트랩 폴백을 남김.
- `claude/hooks/plugin-sync.sh`: 로컬 `_read_json_or` 삭제, 새 헬퍼로 교체. 훅이 없어도 커밋이 landing 해야 한다는 `plugin_sync_hook.bats` 기대를 지키기 위해 동일 패턴의 폴백을 남김.
- `claude/plugin/restore.sh`: 반쯤 설치된 트리에서도 동작해야 하는(지금까지 shell-common 을 아무것도 source 하지 않던) 기존 성질을 지키기 위해 동일 패턴의 폴백을 남기고 `_local_plugins`의 inline jq 표현을 헬퍼 호출로 교체.
- `docs/public/changelog.d/2026-09-02-1696.md`: changelog fragment 1건.

이슈 본문이 제안한 `#1685`(계약/오버레이/tombstone 분리) 대비 merge/overlay 대수 함수 3종은 이번 스코프에서 제외했다 — `#1685`가 아직 OPEN 이라 현재 호출자가 없는 상태에서 미리 만드는 것은 투기적 설계이기 때문이다.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/claude_plugin_restore.bats tests/bats/tools/claude_plugin_reconcile.bats tests/bats/tools/claude_plugin_scaffold.bats tests/bats/skills/plugin_sync_hook.bats tests/bats/skills/plugin_sync_hook_delete.bats tests/bats/skills/plugin_sync_hook_registration.bats tests/bats/tools/plugin_sync_title_smoke.bats` — 78/79 통과, 무수정. 유일한 실패(`plugin_sync_hook_registration.bats` #75, hook-ordering)는 이 diff 를 stash 로 제거한 baseline 에서도 동일하게 실패해 무관함을 확인.
- [x] `mise run lint-sh` — pass.
- [x] `mise run lint-docs` — pass (changelog fragment 포함).
- [x] `grep -n "_read_json_or() {"` — 이름 없는 중복 정의가 남아있지 않고, 라벨링된 부트스트랩 폴백만 `_claude_plugin_read_json_or() {`로 존재함을 확인.

## Related
Closes #1696

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~4 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~4 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HmCgdXMWRVE6hEKN61RJJ
