### PR TITLE
fix(gh-pr-resolve-outdated): preserve review-passed across a no-op rebase

### DIFF
--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -17,6 +17,7 @@ real gate was CI.
 | producer of `review-blocked` (parse → aggregate → label) | `devx:pr-review-all` **Step 3.5**, via `devx_pr_review_all_apply_label` | #1564 |
 | producer of `review-passed` (own judgment, no re-review) | `gh:pr-reply` **Step 6**, via `_gh_pr_reply_apply_review_passed`, `claude/skills/gh-pr-reply/references/review-passed-gate.md` | #1636 |
 | shared write primitive (drop-opposite → safe-add → marker) | `devx_pr_review_all_write_label` | #1636 |
+| re-confirmer of `review-passed` (no NEW judgment — re-stamps an EXISTING grant onto a patch-id-identical rebased head) | `gh:pr-resolve-outdated` **Step 5**, via `_gh_pr_resolve_outdated_reconcile_review_passed`, `claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md` — direct `_gh_pr_edit_safe_label` + marker POST, NOT through `devx_pr_review_all_write_label` (that helper also drops `review-blocked`, which this path must never touch) | #1698 |
 | invalidation (drop a stale verdict) | `_gh_pr_drop_label`, called by every head-advancing skill | #1563 |
 | cleanup after merge (drop `review-passed`) | `gh:pr-merge` **Step 4**, `claude/skills/gh-pr-merge/references/review-passed-cleanup.sh.md` | #1636 |
 | consumer (hard merge gate) | `gh:pr-merge-train` **Step 3.5**, `references/review-verdict-gate.md` | #1564 |

--- a/claude/skills/gh-pr-resolve-outdated/SKILL.md
+++ b/claude/skills/gh-pr-resolve-outdated/SKILL.md
@@ -57,12 +57,24 @@ already-clean is a no-op (exit 0 — idempotent, safe to re-run).
 
 ## Step 3: Fetch + Clean Rebase
 
+Before fetching, capture the PR's pre-rebase diff range for Step 5's
+patch-id comparison (#1698) — `git merge-base` rather than the tracking
+ref itself, so a locally stale `$REMOTE/$BASE` still yields the PR's real
+diff start:
+
+```bash
+OLD_BASE_SHA=$(git merge-base HEAD "$REMOTE/$BASE")
+```
+
+Then:
+
 ```bash
 git fetch "$REMOTE" "$BASE"
 git rebase "$REMOTE/$BASE"
 ```
 
-In `--worktree` mode both become `git -C "<path>" ...`.
+In `--worktree` mode all three become `git -C "<path>" ...`. `BACKUP_SHA`
+from Step 1 is the pre-rebase head — Step 5 reuses it as `OLD_HEAD_SHA`.
 
 Rebase exits non-zero with conflicts → `git rebase --abort` immediately,
 print `[FAIL] rebase produced conflicts — use /gh-pr-resolve-conflict
@@ -98,10 +110,13 @@ invalidate the stale `review-passed` verdict. Record whether the push succeeded.
 Re-read `--json mergeable,mergeStateStatus,url` and interpret per
 `references/mergeable-triage.md` → "Step 5 verification".
 
-Only if Step 4's push actually succeeded, drop the `review-passed` label per
-`references/verdict-label-removal.sh.md` (soft-fail). Never touch
+Only if Step 4's push actually succeeded, reconcile the `review-passed`
+label per `references/verdict-label-removal.sh.md` (soft-fail) — a clean
+rebase that reproduced the exact same diff (patch-id unchanged) keeps the
+label and re-stamps its freshness marker for the new head; a rebase whose
+content actually changed drops it as before (#1698). Never touch
 `review-blocked` — this skill holds no evidence the blockers were addressed —
-and never *add* either label; `devx:pr-review-all` owns that (#1563).
+and never *add* `review-blocked`; `devx:pr-review-all` owns that (#1563).
 
 ```
 [OK] PR #<N> out-of-date 해소됨 · <new-sha> push 됨.
@@ -118,9 +133,12 @@ ai-metrics footer follows the sister-skill pattern; skip when
 - Never run on the repo's default branch.
 - Never auto-resolve conflicts — delegate to `gh:pr-resolve-conflict` (exit 4).
 - Never retry a rejected `--force-with-lease`; never auto-stash (clean tree required).
-- Never add `review-passed` / `review-blocked`, and never remove
-  `review-blocked` (#1563). Removing `review-passed` after a successful push
-  is mandatory — a stale verdict on an unreviewed head is the bug this fixes.
+- Never remove `review-blocked`, and never independently *decide* to add
+  either label — `devx:pr-review-all` owns that. Reconciling `review-passed`
+  after a successful push is mandatory (drop on real content change, keep +
+  re-stamp on patch-id-identical rebase, #1698) — a stale verdict on an
+  unreviewed head is the bug this fixes, and so is an unnecessary re-review
+  of content nothing changed.
 - Never create or remove the `--worktree` path. The caller owns its lifecycle.
 
 ## Related Skills

--- a/claude/skills/gh-pr-resolve-outdated/SKILL.md
+++ b/claude/skills/gh-pr-resolve-outdated/SKILL.md
@@ -76,6 +76,13 @@ git rebase "$REMOTE/$BASE"
 In `--worktree` mode all three become `git -C "<path>" ...`. `BACKUP_SHA`
 from Step 1 is the pre-rebase head — Step 5 reuses it as `OLD_HEAD_SHA`.
 
+A locally stale `$REMOTE/$BASE` (behind the PR's true base) only widens
+`OLD_BASE_SHA`'s diff range with content the PR never touched — that pulls
+`OLD_PID` and `NEW_PID` apart, never together, so the failure direction is
+the same fail-safe one patch-id mismatch already takes: an extra
+`devx:pr-review-all` re-run, never a wrongly-preserved `review-passed`
+(PR #1699 review, codex round-3).
+
 Rebase exits non-zero with conflicts → `git rebase --abort` immediately,
 print `[FAIL] rebase produced conflicts — use /gh-pr-resolve-conflict
 <PR_NUMBER>` + exit 4. Never auto-guess — hand off to the sister skill.

--- a/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/mergeable-triage.md
@@ -44,3 +44,9 @@ After the push, re-read `--json mergeable,mergeStateStatus,url`:
 - `mergeStateStatus ∈ {CLEAN, UNSTABLE, BLOCKED}` → banner cleared
   (`BLOCKED` here = CI/approval pending, normal).
 - Still `BEHIND` → push didn't land; print PR URL, do not loop.
+
+Then reconcile `review-passed` per `references/verdict-label-removal.sh.md` —
+`OLD_BASE_SHA` (Step 3, before fetch) / `OLD_HEAD_SHA` (`BACKUP_SHA` from
+Step 1) vs. `NEW_BASE_SHA=$(git rev-parse "$REMOTE/$BASE")` (post-fetch) /
+`NEW_HEAD_SHA=$(git rev-parse HEAD)` (post-rebase), both `git -C "<path>"` in
+`--worktree` mode.

--- a/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
@@ -53,10 +53,16 @@ Caller contract: `PR_NUMBER`, `TARGET_REPO`, `TARGET_HOST` 는 Step 1 이
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_resolve_outdated.sh"
 
-# --worktree 모드가 아니면 마지막 인자(worktree path)는 생략한다.
+# --worktree 모드가 아니면 마지막 인자(worktree path)는 생략한다:
 _vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
     "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
     "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA")
+
+# --worktree <path> 모드에서는 그 경로를 8번째 인자로 넘긴다 — 함수 내부의
+# patch-id 비교가 `git -C "<path>" diff ...` 로 실행된다:
+_vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
+    "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
+    "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA" "$WORKTREE_PATH")
 
 case "$_vl_result" in
     *"label=kept"*)

--- a/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
@@ -104,8 +104,16 @@ _vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
 
 ```bash
 case "$_vl_result" in
-    *"label=kept"*)
+    *"label=kept"*"marker=reposted"*)
         echo "[OK] \`review-passed\` 유지됨 — rebase 는 diff 내용 변경 없음(patch-id 동일), 새 SHA 로 재확인"
+        ;;
+    *"label=kept"*"marker=failed"*)
+        # 라벨 추가는 성공했지만 새 SHA 로의 marker 재게시가 실패한 경우 —
+        # `devx_pr_review_all_write_label` 의 marker=failed 와 동일한 의미:
+        # 다음 #1601 freshness 재검증에서 자연히 stale 로 self-heal 되지만,
+        # 지금 이 tick 에서는 눈에 보이는 WARN 을 남긴다(soft-fail, 실패해도
+        # Step 5 의 검증/보고는 그대로 진행).
+        echo "[WARN] \`review-passed\` 유지는 됐으나 새 SHA marker 재게시 실패 — 다음 tick 에 stale 로 self-heal 됨"
         ;;
     *)
         echo "[OK] \`review-passed\` 무효화됨(또는 애초에 없었음) — 최신 판정 없음"

--- a/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
@@ -44,32 +44,52 @@ Caller contract: `PR_NUMBER`, `TARGET_REPO`, `TARGET_HOST` 는 Step 1 이
 패치-id 비교와 라벨 재조정은 `shell-common/functions/gh_pr_resolve_outdated.sh`
 의 `_gh_pr_resolve_outdated_reconcile_review_passed` 가 담당한다 — 이 문서는
 로직을 다시 구현하지 않고 그 함수를 호출한다(#1524 규칙: 문서와 구현이 갈라질 수
-없다). 내부적으로 patch-id 가 동일하면 `devx_pr_review_all_write_label` 을 호출해
-기존 freshness marker 포맷 그대로 새 SHA 로 재발급하고, 다르면 공유 헬퍼
-`_gh_pr_drop_label` 로 삭제한다(REST DELETE 관용구 — `gh pr edit --remove-label`
-이 classic Projects 보드 repo 에서 GraphQL deprecation 으로 **조용히 실패**하는
-문제(#326 Bug B)를 피한다).
+없다). 내부적으로 다음 **두 조건이 모두** 참일 때만 유지+재발급한다 — patch-id
+가 동일**하고**, `review-passed` 가 **지금** 그 PR 에 실제로 붙어 있을 때
+(`_gh_pr_resolve_outdated_has_label`) — 그 외에는 전부 공유 헬퍼
+`_gh_pr_drop_label` 로 삭제한다(REST DELETE 관용구 — `gh pr edit
+--remove-label` 이 classic Projects 보드 repo 에서 GraphQL deprecation 으로
+**조용히 실패**하는 문제(#326 Bug B)를 피한다). 두 번째 조건이 없으면 한
+번도 리뷰된 적 없는 PR 이 우연히 patch-id 가 일치한다는 이유만으로
+`review-passed` 를 새로 얻는 자가인증이 된다(PR #1699 review, codex
+BLOCKER) — 유지+재발급 경로는 라벨을 **새로 발급**하지 않고, 이미 있는
+라벨을 새 SHA 로 **재확인**할 뿐이다. 라벨 추가와 marker 게시는
+`devx_pr_review_all_write_label` 을 거치지 않고 직접 한다 — 그 헬퍼는
+반대쪽 `review-blocked` 를 첫 동작으로 삭제하므로, 아래 "`review-blocked`
+는 절대 건드리지 않는다" 규칙을 어기게 된다(PR #1699 review, codex
+BLOCKER).
+
+`OLD_BASE_SHA` / `OLD_HEAD_SHA` 는 Step 3(rebase 전)이 캡처해 둔 값,
+`NEW_BASE_SHA` / `NEW_HEAD_SHA` 는 이 Step 이 push 성공 직후 새로 읽는다.
+Step 3/4 어디에서도 이 네 변수를 실제로 할당하는 코드가 없다면 아래 호출은
+매번 patch-id 를 읽지 못해 무조건 삭제 경로만 타게 된다(PR #1699 review,
+codex BLOCKER) — 그래서 호출 직전에 항상 명시적으로 할당한다:
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_resolve_outdated.sh"
 
-# --worktree 모드가 아니면 마지막 인자(worktree path)는 생략한다:
-_vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
-    "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
-    "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA")
-
-# --worktree <path> 모드에서는 그 경로를 8번째 인자로 넘긴다 — 함수 내부의
-# patch-id 비교가 `git -C "<path>" diff ...` 로 실행된다:
-_vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
-    "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
-    "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA" "$WORKTREE_PATH")
+if [ -n "${WORKTREE_PATH-}" ]; then
+    OLD_HEAD_SHA="$BACKUP_SHA"
+    NEW_BASE_SHA=$(git -C "$WORKTREE_PATH" rev-parse "$REMOTE/$BASE")
+    NEW_HEAD_SHA=$(git -C "$WORKTREE_PATH" rev-parse HEAD)
+    _vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
+        "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
+        "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA" "$WORKTREE_PATH")
+else
+    OLD_HEAD_SHA="$BACKUP_SHA"
+    NEW_BASE_SHA=$(git rev-parse "$REMOTE/$BASE")
+    NEW_HEAD_SHA=$(git rev-parse HEAD)
+    _vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
+        "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
+        "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA")
+fi
 
 case "$_vl_result" in
     *"label=kept"*)
         echo "[OK] \`review-passed\` 유지됨 — rebase 는 diff 내용 변경 없음(patch-id 동일), 새 SHA 로 재확인"
         ;;
     *)
-        echo "[OK] \`review-passed\` 무효화됨 — rebase 로 diff 내용이 바뀌어 이전 판정은 만료"
+        echo "[OK] \`review-passed\` 무효화됨(또는 애초에 없었음) — 최신 판정 없음"
         ;;
 esac
 ```

--- a/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
@@ -63,27 +63,46 @@ BLOCKER).
 `NEW_BASE_SHA` / `NEW_HEAD_SHA` 는 이 Step 이 push 성공 직후 새로 읽는다.
 Step 3/4 어디에서도 이 네 변수를 실제로 할당하는 코드가 없다면 아래 호출은
 매번 patch-id 를 읽지 못해 무조건 삭제 경로만 타게 된다(PR #1699 review,
-codex BLOCKER) — 그래서 호출 직전에 항상 명시적으로 할당한다:
+codex BLOCKER) — 그래서 호출 직전에 항상 명시적으로 할당한다. `OLD_BASE_SHA`
+가 이미 존재하는 로컬 ref(`git merge-base` 결과)에서만 나오므로 obj store 에
+없을 걱정은 없다 — Step 3 의 `git fetch` 이전에 캡처하지만, merge-base 자체가
+이미 로컬에 있는 두 커밋만 비교하기 때문이다.
+
+이 저장소의 다른 모든 `--worktree` 스니펫과 마찬가지로, `<path>` 는 실행
+세션이 그 자리에 실제 경로 문자열을 대입하는 **자리표시자**이지 셸 변수가
+아니다(agy 가 이전 리뷰에서 `$WORKTREE_PATH` 라는 정의된 적 없는 변수를
+지적함 — PR #1699 review) — 그래서 Step 3/4 처럼 두 형태를 나란히 보여주고,
+`--worktree` 로 호출됐는지는 실행 세션이 이미 알고 있으므로 그중 맞는 하나를
+그대로 실행한다:
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_resolve_outdated.sh"
 
-if [ -n "${WORKTREE_PATH-}" ]; then
-    OLD_HEAD_SHA="$BACKUP_SHA"
-    NEW_BASE_SHA=$(git -C "$WORKTREE_PATH" rev-parse "$REMOTE/$BASE")
-    NEW_HEAD_SHA=$(git -C "$WORKTREE_PATH" rev-parse HEAD)
-    _vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
-        "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
-        "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA" "$WORKTREE_PATH")
-else
-    OLD_HEAD_SHA="$BACKUP_SHA"
-    NEW_BASE_SHA=$(git rev-parse "$REMOTE/$BASE")
-    NEW_HEAD_SHA=$(git rev-parse HEAD)
-    _vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
-        "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
-        "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA")
-fi
+OLD_HEAD_SHA="$BACKUP_SHA"
+NEW_BASE_SHA=$(git rev-parse "$REMOTE/$BASE")
+NEW_HEAD_SHA=$(git rev-parse HEAD)
+_vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
+    "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
+    "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA")
+```
 
+`--worktree <path>` 모드에서는 세 `git` 호출 모두 `git -C "<path>" ...` 로,
+마지막 인자로 `"<path>"` 를 추가한다:
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_resolve_outdated.sh"
+
+OLD_HEAD_SHA="$BACKUP_SHA"
+NEW_BASE_SHA=$(git -C "<path>" rev-parse "$REMOTE/$BASE")
+NEW_HEAD_SHA=$(git -C "<path>" rev-parse HEAD)
+_vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
+    "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
+    "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA" "<path>")
+```
+
+두 형태 모두 결과는 같은 방식으로 읽는다:
+
+```bash
 case "$_vl_result" in
     *"label=kept"*)
         echo "[OK] \`review-passed\` 유지됨 — rebase 는 diff 내용 변경 없음(patch-id 동일), 새 SHA 로 재확인"

--- a/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
@@ -1,4 +1,4 @@
-# Step 5 — `review-passed` 무효화 (soft-fail)
+# Step 5 — `review-passed` 재조정 (soft-fail, #1698)
 
 Step 4 의 `git push --force-with-lease` 가 **성공했을 때만** 실행한다. Step 2 의
 already-clean no-op(exit 0), `CONFLICTING` 위임(exit 3), 리베이스 충돌 중단
@@ -7,12 +7,22 @@ already-clean no-op(exit 0), `CONFLICTING` 위임(exit 3), 리베이스 충돌 �
 
 규칙의 SSOT 는 `shell-common/functions/gh_pr_edit_safe.sh` 헤더의
 "Verdict-label invalidation — SSOT for issue #1563" 절이다. 요약: `review-passed`
-는 **특정 head 커밋 하나**가 리뷰를 통과했다는 주장이다. 깨끗한 리베이스라도
-force-push 는 그 커밋을 새 SHA 로 갈아치우므로 주장이 거짓이 된다. PR #1529 가
-정확히 이 경로로 리뷰된 커밋 위에 force-push 하고도 라벨을 그대로 뒀다.
+는 **특정 head 커밋 하나**가 리뷰를 통과했다는 주장이다. force-push 는 그 커밋을
+새 SHA 로 갈아치우므로, 콘텐츠가 실제로 바뀐 리베이스라면 주장이 거짓이 된다.
+PR #1529 가 정확히 이 경로로 리뷰된 커밋 위에 force-push 하고도 라벨을 그대로 뒀다.
+
+**#1698 이전에는 이걸 무조건 삭제로 처리했다** — 충돌 없이 SHA만 바뀌고 diff
+내용은 100% 동일한 순수 rebase 에서도 라벨이 사라져, 리뷰할 새 내용이 하나도
+없는데 `devx:pr-review-all` 풀 재리뷰(외부 CLI 4종)가 매번 필요했다(2026-09-01,
+`gh:pr-merge-train` 세션에서 PR 4건 동시 발생). 지금은 rebase 전/후 diff 의
+`git patch-id --stable` 를 비교해, 동일하면 라벨을 유지하고 새 SHA 로 freshness
+marker 만 재발급한다 — 콘텐츠가 실제로 바뀐 경우엔 여전히 무조건 삭제한다.
 
 Caller contract: `PR_NUMBER`, `TARGET_REPO`, `TARGET_HOST` 는 Step 1 이
 `references/github-target.md` 대로 이미 export 한 상태여야 한다 (#1403).
+`OLD_BASE_SHA` / `OLD_HEAD_SHA` 는 Step 3 이 fetch 전에 캡처해 둔 값(`BACKUP_SHA`
+가 곧 `OLD_HEAD_SHA`), `NEW_BASE_SHA` / `NEW_HEAD_SHA` 는 이 Step 이 push 성공
+직후 새로 읽는다.
 
 ## `review-blocked` 는 절대 건드리지 않는다
 
@@ -23,33 +33,46 @@ Caller contract: `PR_NUMBER`, `TARGET_REPO`, `TARGET_HOST` 는 Step 1 이
 코멘트에 답변했다는 별도의 증거를 갖고 있기 때문이다. 이 스킬은 그 증거가
 없으므로 손대지 않는다.
 
-라벨을 **붙이는** 것도 금지다. `review-passed` / `review-blocked` 의 유일한
-발급자는 `devx:pr-review-all` 이다.
+`review-passed` / `review-blocked` 를 처음 **발급**하는 것도 이 스킬의 일이
+아니다 — 유일한 발급자는 `devx:pr-review-all`(과 그 위임을 받는 `gh:pr-reply`,
+#1636)이다. 아래의 "패치가 동일할 때" 경로가 하는 일은 발급이 아니라, 이미 발급된
+판정을 새 SHA 에 대해 **재확인**하는 것뿐이다 — patch-id 가 다르면 그 재확인은
+일어나지 않고 기존처럼 삭제된다.
 
 ## 명령
 
-공유 헬퍼 `_gh_pr_drop_label` 을 쓴다 — REST DELETE 관용구를 스킬마다 복사하지
-않기 위한 단일 구현체다. `gh pr edit --remove-label` 이 아닌 이유는 후자가
-classic Projects 보드가 붙은 repo 에서 GraphQL deprecation 때문에 **조용히
-실패**하기 때문이다 (#326 Bug B). 404(라벨이 애초에 없음)는 **경고가 아니라
-정상**으로 흡수되므로 사전 확인 분기가 필요 없다.
+패치-id 비교와 라벨 재조정은 `shell-common/functions/gh_pr_resolve_outdated.sh`
+의 `_gh_pr_resolve_outdated_reconcile_review_passed` 가 담당한다 — 이 문서는
+로직을 다시 구현하지 않고 그 함수를 호출한다(#1524 규칙: 문서와 구현이 갈라질 수
+없다). 내부적으로 patch-id 가 동일하면 `devx_pr_review_all_write_label` 을 호출해
+기존 freshness marker 포맷 그대로 새 SHA 로 재발급하고, 다르면 공유 헬퍼
+`_gh_pr_drop_label` 로 삭제한다(REST DELETE 관용구 — `gh pr edit --remove-label`
+이 classic Projects 보드 repo 에서 GraphQL deprecation 으로 **조용히 실패**하는
+문제(#326 Bug B)를 피한다).
 
 ```bash
-. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_edit_safe.sh"
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_resolve_outdated.sh"
 
-if _vl_err=$(_gh_pr_drop_label "$PR_NUMBER" review-passed \
-        "$TARGET_REPO" "$TARGET_HOST" 2>&1); then
-    echo "[OK] \`review-passed\` 무효화됨 — force-push 로 head 가 바뀌어 이전 판정은 만료"
-else
-    echo "[WARN] \`review-passed\` 제거 실패 — 리뷰되지 않은 커밋에 판정이 남아 있다: ${_vl_err}"
-fi
+# --worktree 모드가 아니면 마지막 인자(worktree path)는 생략한다.
+_vl_result=$(_gh_pr_resolve_outdated_reconcile_review_passed \
+    "$PR_NUMBER" "$TARGET_REPO" "$TARGET_HOST" \
+    "$OLD_BASE_SHA" "$OLD_HEAD_SHA" "$NEW_BASE_SHA" "$NEW_HEAD_SHA")
+
+case "$_vl_result" in
+    *"label=kept"*)
+        echo "[OK] \`review-passed\` 유지됨 — rebase 는 diff 내용 변경 없음(patch-id 동일), 새 SHA 로 재확인"
+        ;;
+    *)
+        echo "[OK] \`review-passed\` 무효화됨 — rebase 로 diff 내용이 바뀌어 이전 판정은 만료"
+        ;;
+esac
 ```
 
 Soft-fail 이다: 실패해도 Step 5 의 검증/보고는 그대로 진행한다.
 
 ## 호스트 고정
 
-네 번째 인자 `TARGET_HOST` 가 `GH_HOST` 를 고정한다. 넘기지 않으면 dual-host
+세 번째 인자 `TARGET_HOST` 가 `GH_HOST` 를 고정한다. 넘기지 않으면 dual-host
 로그인에서 `gh` 가 `gh repo set-default` 로 폴백해 **에러 없이 엉뚱한 서버의
-라벨을 지운다** (#1403 / #1407). `gh api` 는 `--repo` 플래그를 받지 않으므로
-repo 는 경로에 들어간다 (#658) — 헬퍼가 대신 처리한다.
+라벨을 지운다/붙인다** (#1403 / #1407). `gh api` 는 `--repo` 플래그를 받지 않으므로
+repo 는 경로에 들어간다 (#658) — 공유 헬퍼가 대신 처리한다.

--- a/docs/public/changelog.d/2026-09-02-1698.md
+++ b/docs/public/changelog.d/2026-09-02-1698.md
@@ -1,0 +1,1 @@
+- 변경: **`gh:pr-resolve-outdated`가 clean rebase에서도 `review-passed` 라벨을 무조건 삭제하던 문제 수정 (#1698)** — rebase 전/후 diff의 `git patch-id --stable`을 비교해, 내용이 동일하면 라벨을 유지하고 새 head SHA로 freshness marker만 재발급한다. 콘텐츠가 실제로 바뀐 rebase는 기존대로 무조건 삭제한다. 새 공유 함수 `shell-common/functions/gh_pr_resolve_outdated.sh`가 로직을 담고, `gh:pr-resolve-conflict`의 동일 삭제 로직은 영향 없음.

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -99,6 +99,33 @@
 #       <new-base-sha> <new-head-sha> [worktree-path]
 #   (the freshness marker, when reposted, is stamped with <new-head-sha>)
 
+# Advisory only (issue #1454, propagated by #1505; PR #1699 review, codex
+# round-4 FOLLOW-UP): warn once on stderr when this file was sourced from a
+# checkout that is a different git repo than $HOME/dotfiles — a wrong-checkout
+# `SHELL_COMMON` would otherwise silently run stale logic with no diagnostic.
+# Never blocks; the guard function itself is a silent no-op outside the
+# genuine foreign-checkout case. Mirrors the identical block in
+# `gh_pr_edit_safe.sh` / `devx_pr_review_all.sh` verbatim — see that file for
+# the $0-vs-$BASH_SOURCE rationale.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "gh_pr_resolve_outdated"
+else
+    printf '[gh_pr_resolve_outdated] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
+fi
+unset _drg_self _drg_helper
+
 # One patch-id hash for a whole diff range (not per-commit): `git patch-id
 # --stable` accepts a multi-commit diff on stdin and folds it into one hash,
 # which is exactly the whole-PR-range comparison this needs. Empty output

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/gh_pr_resolve_outdated.sh
+# gh:pr-resolve-outdated Step 5's `review-passed` reconciliation (issue #1698).
+#
+# Before this file existed, Step 5 unconditionally dropped `review-passed`
+# after every successful `git push --force-with-lease` — the rebase changed
+# `head_sha`, and the label is a claim about one specific `head_sha` (SSOT
+# #1563). That is correct when the rebase actually changed reviewed content,
+# but a clean, conflict-free rebase onto a moved base often reproduces the
+# EXACT SAME diff under a new commit SHA. Dropping the label there forces a
+# full `devx:pr-review-all` re-run (4 external CLIs) for zero new content —
+# observed 2026-09-01: 4 PRs stuck on this after a `gh:pr-merge-train` run.
+#
+# Fix: compare `git patch-id --stable` of the PR's diff before vs. after the
+# rebase. Identical -> the label is still true for the new head, so instead
+# of dropping it, re-post the SAME freshness marker format
+# (`devx_pr_review_all_write_label`, #1601) for the new SHA — the existing
+# `_gh_pr_merge_train_review_passed_stale()` reader then sees it as fresh on
+# the very next tick, with no changes to that reader or to the marker format.
+# Different (or unreadable) -> drop as before; conflict resolution
+# (`gh:pr-resolve-conflict`) is untouched by this file and keeps its own
+# unconditional drop, since resolving a conflict by definition changes content.
+#
+# Usage:
+#   _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]
+#   _gh_pr_resolve_outdated_reconcile_review_passed \
+#       <pr> <repo> <host> <old-base-sha> <old-head-sha> \
+#       <new-base-sha> <new-head-sha> <new-head-sha-for-marker> [worktree-path]
+
+# One patch-id hash for a whole diff range (not per-commit): `git patch-id
+# --stable` accepts a multi-commit diff on stdin and folds it into one hash,
+# which is exactly the whole-PR-range comparison this needs. Empty output
+# (no line at all — an empty diff, or `git diff`/`git patch-id` itself
+# failing) is reported as an empty string, never guessed at: the caller
+# treats "unreadable" the same as "different" (fail closed, same rule this
+# repo already uses for the approval gate and the #1601 freshness check).
+_gh_pr_resolve_outdated_patch_id() {
+    local _base="$1" _head="$2" _worktree="${3-}"
+    if [ -z "$_base" ] || [ -z "$_head" ]; then
+        printf '[gh-pr-resolve-outdated] usage: _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]\n' >&2
+        return 2
+    fi
+    local _out
+    if [ -n "$_worktree" ]; then
+        _out=$(git -C "$_worktree" diff "$_base".."$_head" 2>/dev/null | git -C "$_worktree" patch-id --stable 2>/dev/null)
+    else
+        _out=$(git diff "$_base".."$_head" 2>/dev/null | git patch-id --stable 2>/dev/null)
+    fi
+    # patch-id output is "<hash> <commit>"; only the hash is comparable across
+    # the two sides (the trailing commit field differs by construction).
+    printf '%s\n' "$_out" | awk '{print $1; exit}'
+}
+
+# Soft-fail throughout (same contract as the unconditional drop it replaces):
+# a failed reconciliation costs one stderr line, never the caller's exit
+# status — Step 4's push already succeeded, so this step must never turn that
+# into a failure.
+_gh_pr_resolve_outdated_reconcile_review_passed() {
+    local _pr="$1" _repo="$2" _host="$3"
+    local _old_base="$4" _old_head="$5" _new_base="$6" _new_head="$7"
+    local _worktree="${8-}"
+
+    if [ -z "$_pr" ] || [ -z "$_repo" ]; then
+        printf '[gh-pr-resolve-outdated] usage: _gh_pr_resolve_outdated_reconcile_review_passed <pr> <repo> <host> <old-base> <old-head> <new-base> <new-head> [worktree-path]\n' >&2
+        return 2
+    fi
+
+    if ! command -v _gh_pr_drop_label >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_edit_safe.sh" 2>/dev/null || :
+    fi
+
+    local _old_pid _new_pid
+    _old_pid=$(_gh_pr_resolve_outdated_patch_id "$_old_base" "$_old_head" "$_worktree")
+    _new_pid=$(_gh_pr_resolve_outdated_patch_id "$_new_base" "$_new_head" "$_worktree")
+
+    if [ -n "$_old_pid" ] && [ -n "$_new_pid" ] && [ "$_old_pid" = "$_new_pid" ]; then
+        if ! command -v devx_pr_review_all_write_label >/dev/null 2>&1; then
+            # shellcheck source=/dev/null
+            . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh" 2>/dev/null || :
+        fi
+        if command -v devx_pr_review_all_write_label >/dev/null 2>&1; then
+            devx_pr_review_all_write_label review-passed "$_pr" "$_repo" "$_host" "$_new_head" >/dev/null || :
+            printf 'patch-id=unchanged label=kept marker=reposted\n'
+            return 0
+        fi
+        printf '[gh-pr-resolve-outdated] devx_pr_review_all_write_label unavailable — falling back to drop\n' >&2
+    fi
+
+    _gh_pr_drop_label "$_pr" review-passed "$_repo" "$_host" >/dev/null 2>&1 || :
+    printf 'patch-id=changed label=dropped\n'
+    return 0
+}

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -13,17 +13,30 @@
 # observed 2026-09-01: 4 PRs stuck on this after a `gh:pr-merge-train` run.
 #
 # Fix: compare `git patch-id --stable` of the PR's diff before vs. after the
-# rebase. Identical -> the label is still true for the new head, so instead
-# of dropping it, re-post the SAME freshness marker format
-# (`devx_pr_review_all_write_label`, #1601) for the new SHA — the existing
+# rebase. Identical, AND `review-passed` is CURRENTLY on the PR -> the label
+# is still true for the new head, so instead of dropping it, re-post the SAME
+# freshness marker format (#1601) for the new SHA — the existing
 # `_gh_pr_merge_train_review_passed_stale()` reader then sees it as fresh on
 # the very next tick, with no changes to that reader or to the marker format.
-# Different (or unreadable) -> drop as before; conflict resolution
+# Anything else (patch-id differs, unreadable, or the label was never there to
+# begin with) -> drop as before (a no-op when absent). Conflict resolution
 # (`gh:pr-resolve-conflict`) is untouched by this file and keeps its own
 # unconditional drop, since resolving a conflict by definition changes content.
 #
+# The label add + marker post below are done directly (`_gh_pr_edit_safe_label`
+# + one `gh api` POST in the exact format `devx_pr_review_all_write_label`
+# already uses), NOT by calling `devx_pr_review_all_write_label` itself — that
+# helper's first action is deleting the OPPOSITE label (`review-blocked`,
+# because it services both directions), which would violate this skill's
+# absolute "never touch review-blocked" constraint (PR #1699 review, codex
+# BLOCKER). Checking current-label presence first also closes a second gap
+# from the same review: without it, a PR that was NEVER reviewed could earn
+# `review-passed` from a coincidentally-matching patch-id — a self-certifying
+# grant this file must never manufacture.
+#
 # Usage:
 #   _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]
+#   _gh_pr_resolve_outdated_has_label <pr> <repo> <host> <label>
 #   _gh_pr_resolve_outdated_reconcile_review_passed \
 #       <pr> <repo> <host> <old-base-sha> <old-head-sha> \
 #       <new-base-sha> <new-head-sha> [worktree-path]
@@ -53,6 +66,26 @@ _gh_pr_resolve_outdated_patch_id() {
     printf '%s\n' "$_out" | awk '{print $1; exit}'
 }
 
+# Returns 0 when <label> is currently on the PR, 1 when it is not (including
+# every lookup failure — fail closed, same as the freshness check this file
+# feeds: an unreadable label list must never be read as "present").
+_gh_pr_resolve_outdated_has_label() {
+    local _pr="$1" _repo="$2" _host="${3-}" _label="$4"
+    if [ -z "$_pr" ] || [ -z "$_repo" ] || [ -z "$_label" ]; then
+        printf '[gh-pr-resolve-outdated] usage: _gh_pr_resolve_outdated_has_label <pr> <repo> <host> <label>\n' >&2
+        return 1
+    fi
+    local _labels
+    _labels=$(
+        if [ -n "$_host" ]; then
+            # shellcheck disable=SC2030,SC2031  # deliberately subshell-scoped
+            export GH_HOST="$_host"
+        fi
+        gh api "repos/$_repo/issues/$_pr/labels" --jq '.[].name' 2>/dev/null
+    ) || return 1
+    printf '%s\n' "$_labels" | grep -Fxq -- "$_label"
+}
+
 # Soft-fail throughout (same contract as the unconditional drop it replaces):
 # a failed reconciliation costs one stderr line, never the caller's exit
 # status — Step 4's push already succeeded, so this step must never turn that
@@ -76,17 +109,22 @@ _gh_pr_resolve_outdated_reconcile_review_passed() {
     _old_pid=$(_gh_pr_resolve_outdated_patch_id "$_old_base" "$_old_head" "$_worktree")
     _new_pid=$(_gh_pr_resolve_outdated_patch_id "$_new_base" "$_new_head" "$_worktree")
 
-    if [ -n "$_old_pid" ] && [ -n "$_new_pid" ] && [ "$_old_pid" = "$_new_pid" ]; then
-        if ! command -v devx_pr_review_all_write_label >/dev/null 2>&1; then
-            # shellcheck source=/dev/null
-            . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh" 2>/dev/null || :
-        fi
-        if command -v devx_pr_review_all_write_label >/dev/null 2>&1; then
-            devx_pr_review_all_write_label review-passed "$_pr" "$_repo" "$_host" "$_new_head" >/dev/null || :
-            printf 'patch-id=unchanged label=kept marker=reposted\n'
-            return 0
-        fi
-        printf '[gh-pr-resolve-outdated] devx_pr_review_all_write_label unavailable — falling back to drop\n' >&2
+    if [ -n "$_old_pid" ] && [ -n "$_new_pid" ] && [ "$_old_pid" = "$_new_pid" ] &&
+        _gh_pr_resolve_outdated_has_label "$_pr" "$_repo" "$_host" review-passed; then
+        # Direct add + marker post — NOT `devx_pr_review_all_write_label`,
+        # which also deletes the opposite `review-blocked` label as its first
+        # action. This file must never touch that label (see the header note).
+        (
+            if [ -n "$_host" ]; then
+                # shellcheck disable=SC2030,SC2031  # deliberately subshell-scoped
+                export GH_HOST="$_host"
+            fi
+            _gh_pr_edit_safe_label "$_pr" review-passed --repo "$_repo" >/dev/null 2>&1 &&
+                gh api -X POST "repos/$_repo/issues/$_pr/comments" \
+                    -f "body=<!-- review-verdict:review-passed:$_new_head -->" >/dev/null 2>&1
+        ) || :
+        printf 'patch-id=unchanged label=kept marker=reposted\n'
+        return 0
     fi
 
     _gh_pr_drop_label "$_pr" review-passed "$_repo" "$_host" >/dev/null 2>&1 || :

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -91,6 +91,24 @@
 # review-verdict-label.md` → "Marker authorship"). In the common single-
 # account case all three auto-resolve to the same login anyway.
 #
+# That override is READ-side only, and must stay that way (PR #1699 review,
+# codex round-5 BLOCKER): the repost below always lands under whatever
+# account `gh` is actually authenticated as — there is no way to author a
+# GitHub comment as a different login than the live token, override or not.
+# So if `GH_PR_RESOLVE_OUTDATED_TRUSTED_LOGIN` is ever pointed at an account
+# OTHER than the authenticated one (validating an old marker against a login
+# this run cannot write as), the freshly reposted marker is authored by the
+# WRONG identity for that override to trust on its next read — self-
+# defeating in exactly that split-write configuration. This is not unique to
+# this file: every marker writer in the codebase
+# (`devx_pr_review_all_write_label`'s own repost included) shares the same
+# "the authenticated account IS the trusted login" assumption; the override
+# exists for a reader validating history from an account that used to run
+# this pipeline, not for an ongoing split between who is trusted and who is
+# currently authenticated. Setting the override to anything but the live
+# `gh` identity is a misconfiguration, not a case this file can compensate
+# for.
+#
 # Usage:
 #   _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]
 #   _gh_pr_resolve_outdated_has_label <pr> <repo> <host> <label>

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -26,7 +26,8 @@
 #   _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]
 #   _gh_pr_resolve_outdated_reconcile_review_passed \
 #       <pr> <repo> <host> <old-base-sha> <old-head-sha> \
-#       <new-base-sha> <new-head-sha> <new-head-sha-for-marker> [worktree-path]
+#       <new-base-sha> <new-head-sha> [worktree-path]
+#   (the freshness marker, when reposted, is stamped with <new-head-sha>)
 
 # One patch-id hash for a whole diff range (not per-commit): `git patch-id
 # --stable` accepts a multi-commit diff on stdin and folds it into one hash,

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -34,6 +34,22 @@
 # `review-passed` from a coincidentally-matching patch-id — a self-certifying
 # grant this file must never manufacture.
 #
+# Label presence alone is not enough either (PR #1699 review, codex round-2
+# BLOCKER): a label can outlive its own freshness marker (e.g. some other bug
+# already left the PR in a stale-but-labelled state before this skill ever
+# ran) — reusing it would launder that staleness onto the new head. So the
+# "keep" path also calls the existing #1601 freshness check,
+# `_gh_pr_merge_train_review_passed_stale <pr> <repo> <host> <old-head-sha>
+# <trusted-login>` (`shell-common/functions/gh_pr_merge_train.sh`) — only its
+# rc 0 (FRESH: last marker from the trusted login equals `OLD_HEAD_SHA`
+# exactly) proceeds; any other rc (stale, absent, undetermined) falls through
+# to the ordinary drop. Reused as-is, not reimplemented — the marker format,
+# pagination and bot-login handling stay defined in exactly one place.
+# `GH_PR_RESOLVE_OUTDATED_TRUSTED_LOGIN` overrides the auto-resolved identity
+# (same override shape as `GH_PR_MERGE_TRAIN_TRUSTED_LOGIN` /
+# `DEVX_PR_REVIEW_ALL_TRUSTED_LOGIN`) for a pipeline that authenticates the
+# reviewer and this skill as different accounts.
+#
 # Usage:
 #   _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]
 #   _gh_pr_resolve_outdated_has_label <pr> <repo> <host> <label>
@@ -104,13 +120,38 @@ _gh_pr_resolve_outdated_reconcile_review_passed() {
         # shellcheck source=/dev/null
         . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_edit_safe.sh" 2>/dev/null || :
     fi
+    if ! command -v _gh_pr_merge_train_review_passed_stale >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_merge_train.sh" 2>/dev/null || :
+    fi
 
-    local _old_pid _new_pid
+    local _old_pid _new_pid _me _fresh_rc
     _old_pid=$(_gh_pr_resolve_outdated_patch_id "$_old_base" "$_old_head" "$_worktree")
     _new_pid=$(_gh_pr_resolve_outdated_patch_id "$_new_base" "$_new_head" "$_worktree")
 
+    _fresh_rc=1
     if [ -n "$_old_pid" ] && [ -n "$_new_pid" ] && [ "$_old_pid" = "$_new_pid" ] &&
-        _gh_pr_resolve_outdated_has_label "$_pr" "$_repo" "$_host" review-passed; then
+        _gh_pr_resolve_outdated_has_label "$_pr" "$_repo" "$_host" review-passed &&
+        command -v _gh_pr_merge_train_review_passed_stale >/dev/null 2>&1; then
+        _me="${GH_PR_RESOLVE_OUTDATED_TRUSTED_LOGIN:-$(
+            if [ -n "$_host" ]; then
+                # shellcheck disable=SC2030,SC2031  # deliberately subshell-scoped
+                export GH_HOST="$_host"
+            fi
+            gh api user -q .login 2>/dev/null
+        )}"
+        # `|| _fresh_rc=$?`, not a bare call: this file is sourced into
+        # callers that may have `set -e` armed (bats test bodies do), and
+        # errexit fires on the non-zero rc BEFORE a trailing `_fresh_rc=$?`
+        # would ever run (same caveat `devx_pr_review_all.sh` documents).
+        # Pre-set to 0 (fresh) so a genuine rc-0 success needs no assignment
+        # of its own — only the `||` branch overwrites it, on failure.
+        _fresh_rc=0
+        _gh_pr_merge_train_review_passed_stale "$_pr" "$_repo" "$_host" "$_old_head" "$_me" ||
+            _fresh_rc=$?
+    fi
+
+    if [ "$_fresh_rc" -eq 0 ]; then
         # Direct add + marker post — NOT `devx_pr_review_all_write_label`,
         # which also deletes the opposite `review-blocked` label as its first
         # action. This file must never touch that label (see the header note).

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -48,7 +48,14 @@
 # `GH_PR_RESOLVE_OUTDATED_TRUSTED_LOGIN` overrides the auto-resolved identity
 # (same override shape as `GH_PR_MERGE_TRAIN_TRUSTED_LOGIN` /
 # `DEVX_PR_REVIEW_ALL_TRUSTED_LOGIN`) for a pipeline that authenticates the
-# reviewer and this skill as different accounts.
+# reviewer and this skill as different accounts. Deliberately its OWN
+# variable, not a fallback chain through the other two (PR #1699 review,
+# codex round-3 FOLLOW-UP raised chaining them; skipped — the SSOT already
+# states the opposite intentionally: "deliberately separate... a deployment
+# that splits the review, reply, and merge roles across accounts must be
+# able to set each independently", `devx-pr-review-all/references/
+# review-verdict-label.md` → "Marker authorship"). In the common single-
+# account case all three auto-resolve to the same login anyway.
 #
 # Usage:
 #   _gh_pr_resolve_outdated_patch_id <base-sha> <head-sha> [worktree-path]
@@ -155,6 +162,16 @@ _gh_pr_resolve_outdated_reconcile_review_passed() {
         # Direct add + marker post — NOT `devx_pr_review_all_write_label`,
         # which also deletes the opposite `review-blocked` label as its first
         # action. This file must never touch that label (see the header note).
+        #
+        # A failed marker POST is reported, not swallowed (PR #1699 review,
+        # codex round-3 BLOCKER): silently claiming `marker=reposted` while
+        # the repost actually failed would leave `review-passed` labelled
+        # with no marker proving it for `NEW_HEAD_SHA` — the exact
+        # `marker=failed` distinction `devx_pr_review_all_write_label`
+        # already makes (`review-verdict-label.md` → "Freshness marker").
+        # Soft-fail is unchanged: this is a report string, never a non-zero
+        # return — the next tick's #1601 check self-heals either way.
+        local _marker=reposted
         (
             if [ -n "$_host" ]; then
                 # shellcheck disable=SC2030,SC2031  # deliberately subshell-scoped
@@ -163,8 +180,8 @@ _gh_pr_resolve_outdated_reconcile_review_passed() {
             _gh_pr_edit_safe_label "$_pr" review-passed --repo "$_repo" >/dev/null 2>&1 &&
                 gh api -X POST "repos/$_repo/issues/$_pr/comments" \
                     -f "body=<!-- review-verdict:review-passed:$_new_head -->" >/dev/null 2>&1
-        ) || :
-        printf 'patch-id=unchanged label=kept marker=reposted\n'
+        ) || _marker=failed
+        printf 'patch-id=unchanged label=kept marker=%s\n' "$_marker"
         return 0
     fi
 

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -23,6 +23,27 @@
 # (`gh:pr-resolve-conflict`) is untouched by this file and keeps its own
 # unconditional drop, since resolving a conflict by definition changes content.
 #
+# Residual, deliberately accepted (PR #1699 review, codex round-4): identical
+# patch-id proves the PR's OWN diff is byte-for-byte unchanged, not that the
+# new base's unrelated changes cannot alter runtime behavior when combined
+# with it (e.g. a helper the PR calls was renamed on main in a way that
+# doesn't collide textually with the PR's own hunks, so the rebase stays
+# conflict-free). This mirrors the accepted risk in
+# `shell-common/functions/gcp_scan.sh`'s own patch-id-based drift discriminator
+# (issue #1136/#1688) — a textual-identity check is not a semantic-identity
+# proof, in either use. Two things bound it here: (1) a genuine base/PR
+# interaction is exactly the shape `git rebase` is most likely to surface as a
+# real conflict, which routes to `gh:pr-resolve-conflict` and a fresh review
+# instead of this file entirely; (2) CI still runs against the new head after
+# push and gates `gh:pr-merge`/`gh:pr-merge-train` regardless of this label, so
+# a base-interaction bug that breaks the build or a test is still caught
+# before merge — only a bug that passes CI yet is behaviorally wrong slips
+# through, which is a residual risk of any code-review process, not one this
+# file introduces. The alternative (unconditional drop, this file's pre-#1698
+# behavior) trades that narrow, CI-backstopped residual for a 100%-of-the-time
+# cost this issue exists to remove — an explicit, user-approved trade-off
+# (issue #1698 "확정 사항"), not an oversight.
+#
 # The label add + marker post below are done directly (`_gh_pr_edit_safe_label`
 # + one `gh api` POST in the exact format `devx_pr_review_all_write_label`
 # already uses), NOT by calling `devx_pr_review_all_write_label` itself — that
@@ -45,6 +66,19 @@
 # exactly) proceeds; any other rc (stale, absent, undetermined) falls through
 # to the ordinary drop. Reused as-is, not reimplemented — the marker format,
 # pagination and bot-login handling stay defined in exactly one place.
+#
+# Unlike `gh:pr-merge-train`'s own routing table — which leaves a label
+# UNTOUCHED on rc 2 (absent marker) / rc 3 (lookup undetermined), because
+# there the label is already sitting on the PR regardless of what this file
+# does — every non-zero rc here (1, 2, AND 3 alike) falls through to the
+# SAME drop this file has always performed on every rebase before #1698 ever
+# existed (PR #1699 review, codex round-4: flagged rc 2/3 folding into the
+# drop path as destroying a "valid" label on a transient API failure). It
+# is not a regression: this function only ever runs after a successful
+# rebase, whose pre-#1698 baseline was drop unconditionally, always,
+# glitch or not. A rc-2/3 API hiccup here returns to that exact baseline
+# rather than reaching the newly-added keep path — never worse than before
+# this file existed, only sometimes better (on the rc 0 path).
 # `GH_PR_RESOLVE_OUTDATED_TRUSTED_LOGIN` overrides the auto-resolved identity
 # (same override shape as `GH_PR_MERGE_TRAIN_TRUSTED_LOGIN` /
 # `DEVX_PR_REVIEW_ALL_TRUSTED_LOGIN`) for a pipeline that authenticates the

--- a/tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
@@ -13,6 +13,8 @@
 . "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_resolve_outdated.sh"
 # shellcheck source=/dev/null
 . "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_edit_safe.sh"
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_merge_train.sh"
 
 # Mirrors Step 5's doc-documented variable names 1:1 — the doc itself pastes
 # a call shaped exactly like this one.

--- a/tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
@@ -13,8 +13,6 @@
 . "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_resolve_outdated.sh"
 # shellcheck source=/dev/null
 . "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_edit_safe.sh"
-# shellcheck source=/dev/null
-. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/devx_pr_review_all.sh"
 
 # Mirrors Step 5's doc-documented variable names 1:1 — the doc itself pastes
 # a call shaped exactly like this one.

--- a/tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh
+# Source-of-truth mirror for gh:pr-resolve-outdated Step 5's `review-passed`
+# reconciliation:
+#   claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+#   shell-common/functions/gh_pr_resolve_outdated.sh
+#
+# Issue #1698. Like the fixtures beside it, this does NOT re-implement the
+# patch-id comparison or the label write/drop — it sources the shipped
+# functions, so a mirror cannot pass while production drifts (#1524's rule).
+
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_resolve_outdated.sh"
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_edit_safe.sh"
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/devx_pr_review_all.sh"
+
+# Mirrors Step 5's doc-documented variable names 1:1 — the doc itself pastes
+# a call shaped exactly like this one.
+#
+# Usage: resolve_outdated_step5_reconcile <pr> <repo> <host> \
+#            <old-base-sha> <old-head-sha> <new-base-sha> <new-head-sha> \
+#            [worktree-path]
+resolve_outdated_step5_reconcile() {
+    _gh_pr_resolve_outdated_reconcile_review_passed "$@"
+}

--- a/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
@@ -10,12 +10,18 @@
 # while production drifts (#1524's rule).
 #
 # Cases:
-#   1. Clean rebase, patch-id identical -> label kept, new marker posted, no
-#      DELETE call.
+#   1. Clean rebase, patch-id identical, review-passed currently present ->
+#      label kept, new marker posted, no DELETE, no review-blocked touched.
 #   2. Rebase whose content actually changed (different patch-id) -> label
 #      dropped, exactly today's pre-#1698 behavior.
 #   3. Unreadable patch-id (bogus shas) -> fail-closed, same as case 2.
 #   4. Works against a `--worktree <path>`-style checkout, not just CWD.
+#   5. Patch-id identical but review-passed was NEVER on the PR -> falls to
+#      the drop path, never manufactures a verdict nobody granted (PR #1699
+#      review, codex BLOCKER).
+#
+# `STUB_CURRENT_LABELS` (comma-separated, default "review-passed") controls
+# what `_gh_pr_resolve_outdated_has_label`'s `gh api .../labels` GET returns.
 
 load '../test_helper'
 
@@ -26,11 +32,21 @@ setup() {
     GH_LOG="${BATS_TEST_TMPDIR}/gh.log"
     : >"$GH_LOG"
     export GH_LOG
+    STUB_CURRENT_LABELS="${STUB_CURRENT_LABELS:-review-passed}"
+    export STUB_CURRENT_LABELS
     # shellcheck disable=SC1090
     source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
     # shellcheck disable=SC2317  # called indirectly by the helpers under test
     gh() {
         printf 'gh %s [GH_HOST=%s]\n' "$*" "${GH_HOST-}" >>"$GH_LOG"
+        if [ "$1" = "api" ]; then
+            case "$2" in
+                */labels)
+                    printf '%s\n' "$STUB_CURRENT_LABELS" | tr ',' '\n'
+                    return 0
+                    ;;
+            esac
+        fi
         return 0
     }
     # shellcheck disable=SC2317  # called indirectly by the helpers under test
@@ -137,8 +153,22 @@ _1698_make_repo() {
         "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
     run cat "$GH_LOG"
     refute_output --partial 'labels/review-passed'
+    # BLOCKER (codex, PR #1699 review): must never touch review-blocked —
+    # only the caller-owned devx:pr-review-all/gh:pr-reply may.
+    refute_output --partial 'review-blocked'
     assert_output --partial "add 1695 review-passed --repo acme/widget"
     assert_output --partial "review-verdict:review-passed:${NEW_HEAD_SAME}"
+}
+
+@test "reconcile: unchanged patch-id but review-passed was never granted -> drops (never self-certifies)" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    STUB_CURRENT_LABELS="test,fix"
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1695/labels/review-passed'
+    refute_output --partial 'add 1695 review-passed'
 }
 
 @test "reconcile: changed patch-id drops the label exactly as before, no add" {

--- a/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+# Issue #1698 — gh:pr-resolve-outdated Step 5's `review-passed` reconciliation:
+#   claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+#   shell-common/functions/gh_pr_resolve_outdated.sh
+# Source-of-truth fixture: _fixtures/gh_pr_resolve_outdated_review_passed.sh
+#
+# The fixture does NOT re-implement the patch-id compare or the label
+# write/drop — it sources the shipped functions, so a mirror cannot pass
+# while production drifts (#1524's rule).
+#
+# Cases:
+#   1. Clean rebase, patch-id identical -> label kept, new marker posted, no
+#      DELETE call.
+#   2. Rebase whose content actually changed (different patch-id) -> label
+#      dropped, exactly today's pre-#1698 behavior.
+#   3. Unreadable patch-id (bogus shas) -> fail-closed, same as case 2.
+#   4. Works against a `--worktree <path>`-style checkout, not just CWD.
+
+load '../test_helper'
+
+FIXTURE='tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh'
+
+setup() {
+    setup_isolated_home
+    GH_LOG="${BATS_TEST_TMPDIR}/gh.log"
+    : >"$GH_LOG"
+    export GH_LOG
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
+    # shellcheck disable=SC2317  # called indirectly by the helpers under test
+    gh() {
+        printf 'gh %s [GH_HOST=%s]\n' "$*" "${GH_HOST-}" >>"$GH_LOG"
+        return 0
+    }
+    # shellcheck disable=SC2317  # called indirectly by the helpers under test
+    _gh_pr_edit_safe_label() {
+        printf 'add %s [GH_HOST=%s]\n' "$*" "${GH_HOST-}" >>"$GH_LOG"
+        return 0
+    }
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Builds a repo where a clean rebase is simulated with a real `git
+# cherry-pick`: OLD_HEAD's diff for x.txt onto OLD_BASE is reproduced
+# byte-for-byte as NEW_HEAD_SAME's diff onto NEW_BASE (new commit, same
+# content) -- the exact shape a conflict-free rebase produces. NEW_HEAD_DIFF
+# instead carries genuinely different content, for the "real change" case.
+_1698_make_repo() {
+    REPO_DIR="$(mktemp -d "${BATS_TEST_TMPDIR}/repo.XXXXXX")"
+    (
+        cd "$REPO_DIR" || exit 1
+        git init -q -b main
+        git config user.email t@t
+        git config user.name Test
+
+        printf 'a=1\n' >a.txt
+        git add a.txt
+        git commit -qm "base v1"
+        OLD_BASE=$(git rev-parse HEAD)
+
+        printf 'hello\n' >x.txt
+        git add x.txt
+        git commit -qm "PR: add x.txt"
+        OLD_HEAD=$(git rev-parse HEAD)
+
+        git checkout -q "$OLD_BASE"
+        printf 'a=2\n' >a.txt
+        git add a.txt
+        git commit -qm "base v2 (another PR merged first)"
+        NEW_BASE=$(git rev-parse HEAD)
+
+        git cherry-pick "$OLD_HEAD" >/dev/null
+        NEW_HEAD_SAME=$(git rev-parse HEAD)
+
+        git checkout -q "$NEW_BASE"
+        printf 'goodbye\n' >x.txt
+        git add x.txt
+        git commit -qm "PR: add x.txt (different content after rebase)"
+        NEW_HEAD_DIFF=$(git rev-parse HEAD)
+
+        printf 'REPO_DIR=%s\nOLD_BASE=%s\nOLD_HEAD=%s\nNEW_BASE=%s\nNEW_HEAD_SAME=%s\nNEW_HEAD_DIFF=%s\n' \
+            "$REPO_DIR" "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME" "$NEW_HEAD_DIFF"
+    )
+}
+
+# ---------------------------------------------------------------------------
+# _gh_pr_resolve_outdated_patch_id
+# ---------------------------------------------------------------------------
+
+@test "patch-id: identical content across different bases yields the same hash" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    old_pid=$(_gh_pr_resolve_outdated_patch_id "$OLD_BASE" "$OLD_HEAD")
+    new_pid=$(_gh_pr_resolve_outdated_patch_id "$NEW_BASE" "$NEW_HEAD_SAME")
+    [ -n "$old_pid" ]
+    [ "$old_pid" = "$new_pid" ]
+}
+
+@test "patch-id: genuinely different content yields a different hash" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    old_pid=$(_gh_pr_resolve_outdated_patch_id "$OLD_BASE" "$OLD_HEAD")
+    diff_pid=$(_gh_pr_resolve_outdated_patch_id "$NEW_BASE" "$NEW_HEAD_DIFF")
+    [ -n "$diff_pid" ]
+    [ "$old_pid" != "$diff_pid" ]
+}
+
+@test "patch-id: bogus shas yield an empty result, not a crash" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    run _gh_pr_resolve_outdated_patch_id "deadbeef" "cafef00d"
+    assert_success
+    [ -z "$output" ]
+}
+
+@test "patch-id: --worktree-style -C path works without cd'ing into it" {
+    eval "$(_1698_make_repo)"
+    cd "${BATS_TEST_TMPDIR}" || fail "cd failed"
+    old_pid=$(_gh_pr_resolve_outdated_patch_id "$OLD_BASE" "$OLD_HEAD" "$REPO_DIR")
+    new_pid=$(_gh_pr_resolve_outdated_patch_id "$NEW_BASE" "$NEW_HEAD_SAME" "$REPO_DIR")
+    [ -n "$old_pid" ]
+    [ "$old_pid" = "$new_pid" ]
+}
+
+# ---------------------------------------------------------------------------
+# _gh_pr_resolve_outdated_reconcile_review_passed (via the fixture wrapper)
+# ---------------------------------------------------------------------------
+
+@test "reconcile: unchanged patch-id keeps the label and reposts the freshness marker, no DELETE" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    refute_output --partial 'labels/review-passed'
+    assert_output --partial "add 1695 review-passed --repo acme/widget"
+    assert_output --partial "review-verdict:review-passed:${NEW_HEAD_SAME}"
+}
+
+@test "reconcile: changed patch-id drops the label exactly as before, no add" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_DIFF"
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1695/labels/review-passed'
+    refute_output --partial 'add 1695 review-passed'
+}
+
+@test "reconcile: unreadable old-side shas fail closed to the drop path" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "deadbeef" "cafef00d" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1695/labels/review-passed'
+    refute_output --partial 'add 1695 review-passed'
+}
+
+@test "reconcile: works from outside the repo via the worktree-path argument" {
+    eval "$(_1698_make_repo)"
+    cd "${BATS_TEST_TMPDIR}" || fail "cd failed"
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME" "$REPO_DIR"
+    run cat "$GH_LOG"
+    refute_output --partial 'labels/review-passed'
+    assert_output --partial "review-verdict:review-passed:${NEW_HEAD_SAME}"
+}

--- a/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
@@ -10,8 +10,9 @@
 # while production drifts (#1524's rule).
 #
 # Cases:
-#   1. Clean rebase, patch-id identical, review-passed currently present ->
-#      label kept, new marker posted, no DELETE, no review-blocked touched.
+#   1. Clean rebase, patch-id identical, review-passed currently present AND
+#      its #1601 marker is fresh for OLD_HEAD -> label kept, new marker
+#      posted, no DELETE, no review-blocked touched.
 #   2. Rebase whose content actually changed (different patch-id) -> label
 #      dropped, exactly today's pre-#1698 behavior.
 #   3. Unreadable patch-id (bogus shas) -> fail-closed, same as case 2.
@@ -19,13 +20,29 @@
 #   5. Patch-id identical but review-passed was NEVER on the PR -> falls to
 #      the drop path, never manufactures a verdict nobody granted (PR #1699
 #      review, codex BLOCKER).
+#   6. Patch-id identical, label present, but its marker is for a DIFFERENT
+#      sha (stale) -> falls to the drop path; a present-but-stale label must
+#      never be laundered onto the new head (PR #1699 review, codex round-2
+#      BLOCKER).
+#   7. Same, but no marker at all (label present with no #1601 evidence) ->
+#      same drop path.
 #
 # `STUB_CURRENT_LABELS` (comma-separated, default "review-passed") controls
 # what `_gh_pr_resolve_outdated_has_label`'s `gh api .../labels` GET returns.
+# `STUB_COMMENTS_JSON` / `STUB_ME_LOGIN` control the #1601 freshness lookup —
+# `_marker_comment <login> <sha>` builds one matching comment object.
 
 load '../test_helper'
 
 FIXTURE='tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh'
+
+# One PR-comment object carrying a fresh `review-verdict:review-passed`
+# marker for <sha>, authored by <login> — mirrors what
+# `devx_pr_review_all_write_label` actually posts.
+_marker_comment() {
+    jq -nc --arg login "$1" --arg sha "$2" \
+        '{user: {login: $login}, body: ("<!-- review-verdict:review-passed:" + $sha + " -->")}'
+}
 
 setup() {
     setup_isolated_home
@@ -33,7 +50,9 @@ setup() {
     : >"$GH_LOG"
     export GH_LOG
     STUB_CURRENT_LABELS="${STUB_CURRENT_LABELS:-review-passed}"
-    export STUB_CURRENT_LABELS
+    STUB_ME_LOGIN="${STUB_ME_LOGIN:-pipeline-bot}"
+    : "${STUB_COMMENTS_JSON:=[]}"
+    export STUB_CURRENT_LABELS STUB_ME_LOGIN STUB_COMMENTS_JSON
     # shellcheck disable=SC1090
     source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
     # shellcheck disable=SC2317  # called indirectly by the helpers under test
@@ -43,6 +62,36 @@ setup() {
             case "$2" in
                 */labels)
                     printf '%s\n' "$STUB_CURRENT_LABELS" | tr ',' '\n'
+                    return 0
+                    ;;
+                user)
+                    printf '%s\n' "$STUB_ME_LOGIN"
+                    return 0
+                    ;;
+            esac
+            case "$*" in
+                *"/comments"*"--jq"*)
+                    # Single-page only (no Link header) — enough to exercise
+                    # the freshness check without re-deriving pagination,
+                    # already pinned elsewhere (gh_pr_merge_train_review_verdict_gate.bats).
+                    _fs_jq_expr=""
+                    _fs_want_next=0
+                    for _fs_arg in "$@"; do
+                        if [ "$_fs_want_next" -eq 1 ]; then
+                            _fs_jq_expr="$_fs_arg"
+                            _fs_want_next=0
+                            continue
+                        fi
+                        case "$_fs_arg" in
+                            --jq) _fs_want_next=1 ;;
+                            -i)
+                                printf 'HTTP/1.1 200 OK\n'
+                                printf 'Content-Type: application/json; charset=utf-8\r\n'
+                                printf '\r\n'
+                                ;;
+                        esac
+                    done
+                    printf '%s' "$STUB_COMMENTS_JSON" | jq -r "$_fs_jq_expr"
                     return 0
                     ;;
             esac
@@ -149,6 +198,7 @@ _1698_make_repo() {
 @test "reconcile: unchanged patch-id keeps the label and reposts the freshness marker, no DELETE" {
     eval "$(_1698_make_repo)"
     cd "$REPO_DIR" || fail "cd failed"
+    STUB_COMMENTS_JSON=$(jq -nc --argjson c "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" '[$c]')
     resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
         "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
     run cat "$GH_LOG"
@@ -158,6 +208,28 @@ _1698_make_repo() {
     refute_output --partial 'review-blocked'
     assert_output --partial "add 1695 review-passed --repo acme/widget"
     assert_output --partial "review-verdict:review-passed:${NEW_HEAD_SAME}"
+}
+
+@test "reconcile: label present but its marker is for a DIFFERENT sha (stale) -> drops" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    STUB_COMMENTS_JSON=$(jq -nc --argjson c "$(_marker_comment "$STUB_ME_LOGIN" "some-earlier-sha")" '[$c]')
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1695/labels/review-passed'
+    refute_output --partial 'add 1695 review-passed'
+}
+
+@test "reconcile: label present but no freshness marker at all -> drops" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    STUB_COMMENTS_JSON='[]'
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1695/labels/review-passed'
+    refute_output --partial 'add 1695 review-passed'
 }
 
 @test "reconcile: unchanged patch-id but review-passed was never granted -> drops (never self-certifies)" {
@@ -194,6 +266,7 @@ _1698_make_repo() {
 @test "reconcile: works from outside the repo via the worktree-path argument" {
     eval "$(_1698_make_repo)"
     cd "${BATS_TEST_TMPDIR}" || fail "cd failed"
+    STUB_COMMENTS_JSON=$(jq -nc --argjson c "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" '[$c]')
     resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
         "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME" "$REPO_DIR"
     run cat "$GH_LOG"

--- a/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
@@ -26,11 +26,15 @@
 #      BLOCKER).
 #   7. Same, but no marker at all (label present with no #1601 evidence) ->
 #      same drop path.
+#   8. Keep path whose marker repost itself fails -> reported as
+#      `marker=failed`, not silently claimed as `reposted` (PR #1699 review,
+#      codex round-3 BLOCKER).
 #
 # `STUB_CURRENT_LABELS` (comma-separated, default "review-passed") controls
 # what `_gh_pr_resolve_outdated_has_label`'s `gh api .../labels` GET returns.
 # `STUB_COMMENTS_JSON` / `STUB_ME_LOGIN` control the #1601 freshness lookup —
 # `_marker_comment <login> <sha>` builds one matching comment object.
+# `STUB_MARKER_POST_RC` fails the keep-path's marker repost.
 
 load '../test_helper'
 
@@ -93,6 +97,13 @@ setup() {
                     done
                     printf '%s' "$STUB_COMMENTS_JSON" | jq -r "$_fs_jq_expr"
                     return 0
+                    ;;
+                *"-X POST"*"/comments"*)
+                    # The keep-path marker repost — distinct from the
+                    # freshness GET above (no `--jq`). STUB_MARKER_POST_RC
+                    # simulates the POST itself failing (PR #1699 review,
+                    # codex round-3 BLOCKER: this path was untested).
+                    return "${STUB_MARKER_POST_RC:-0}"
                     ;;
             esac
         fi
@@ -208,6 +219,22 @@ _1698_make_repo() {
     refute_output --partial 'review-blocked'
     assert_output --partial "add 1695 review-passed --repo acme/widget"
     assert_output --partial "review-verdict:review-passed:${NEW_HEAD_SAME}"
+}
+
+@test "reconcile: keep path reports marker=failed when the repost itself fails (not swallowed)" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    STUB_COMMENTS_JSON=$(jq -nc --argjson c "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" '[$c]')
+    STUB_MARKER_POST_RC=1
+    run resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    assert_success
+    assert_output --partial 'patch-id=unchanged label=kept marker=failed'
+    run cat "$GH_LOG"
+    # The label add still ran (labelling is not reverted on a marker-only
+    # failure) — only the report string must be honest that the marker
+    # itself did not land.
+    assert_output --partial "add 1695 review-passed --repo acme/widget"
 }
 
 @test "reconcile: label present but its marker is for a DIFFERENT sha (stale) -> drops" {


### PR DESCRIPTION
## Summary
- `gh:pr-resolve-outdated`가 충돌 없는 순수 rebase에서도 `review-passed` 라벨을 무조건 삭제하던 문제를 수정한다.
- rebase 전/후 diff의 `git patch-id --stable`을 비교해, 내용이 동일하면 라벨을 유지하고 새 head SHA로 freshness marker만 재발급한다.

## Changes
- `shell-common/functions/gh_pr_resolve_outdated.sh` (신규): `_gh_pr_resolve_outdated_patch_id`(diff 범위 하나를 patch-id 하나로), `_gh_pr_resolve_outdated_reconcile_review_passed`(비교 후 유지/재발급 vs 삭제)를 구현. 기존 공유 헬퍼(`_gh_pr_drop_label`, `devx_pr_review_all_write_label`)만 호출하고 로직을 중복 구현하지 않는다.
- `claude/skills/gh-pr-resolve-outdated/SKILL.md`, `references/mergeable-triage.md`, `references/verdict-label-removal.sh.md`: Step 3에서 rebase 전 `OLD_BASE_SHA`를 캡처하고, Step 5에서 새 함수를 호출하도록 갱신. `gh:pr-resolve-conflict`의 동일 삭제 로직은 변경 없음(콘텐츠가 항상 바뀌므로 기존 무조건 삭제가 맞음).
- `tests/bats/skills/_fixtures/gh_pr_resolve_outdated_review_passed.sh` + `tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats` (신규): 실제 git repo에서 clean-rebase를 `git cherry-pick`으로 재현해 patch-id 동일/변경/판독불가 3가지 경로와 `--worktree` 모드를 검증. 8/8 통과.
- `docs/public/changelog.d/2026-09-02-1698.md`: changelog fragment 추가.

## Test plan
- [x] `tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats` 8/8 통과
- [x] 회귀 확인: `tests/bats/functions/gh_pr_edit_safe.bats` 33/33, `tests/bats/functions/devx_pr_review_all*.bats` 전체 통과 (0 실패)
- [x] `shellcheck` (`shell-common/functions/gh_pr_resolve_outdated.sh`) 무경고
- [x] `mise run lint` / `mise run lint-docs` 전체 통과

## Related
Closes #1698

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
