### PR TITLE
fix(pipeline): review-verdict:revoked 마커로 review-passed 부활 방지

### DIFF
--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -426,6 +426,53 @@ PR (PR #1608 review, agy + codex BLOCKER: silently losing the marker meant a
 no trace of why). Since #1636 that producer is `gh:pr-reply`
 (`_gh_pr_reply_apply_review_passed`), which prints the same wording.
 
+## Revoking a stale `review-passed` by hand (#1706)
+
+The marker above is append-only — nothing in this repo ever edits or deletes
+one. That left no way to *withdraw* a verdict: a human who spots a problem and
+pulls the `review-passed` label off in the GitHub UI (without opening a formal
+`review-blocked` round) removes only the label, not the evidence. The next
+content-identical rebase then finds patch-id identical, the marker still fresh
+for the old head, and no `review-blocked` — and
+`gh:pr-resolve-outdated` / `gh:pr-resolve-conflict` Step 5 re-grants the label,
+silently overriding the human.
+
+A second marker type withdraws the verdict without touching the first:
+
+```
+<!-- review-verdict:revoked:<sha> -->
+```
+
+It is a plain issue comment, posted exactly like the `review-passed` marker —
+never an edit or a delete of the earlier one, so the audit trail stays intact
+and both the grant and its withdrawal remain visible on the PR.
+
+**Read-side rule: the single LAST marker of EITHER type from the trusted login
+wins, by comment order.** If that last marker is a `revoked` one, the freshness
+check reads as if no `review-passed` marker had ever been posted — a *confirmed
+absence* (`rc 2`), not a lookup failure. The sha in `revoked:<sha>` is therefore
+audit metadata only and is **never compared against anything** — not the
+current head, not the sha the revoked marker named. Ordering alone decides, so
+a revocation cancels the grant before it whatever sha either one carries.
+
+Revocation is not permanent: a genuine re-review posts a new `review-passed`
+marker, which is then the last one and wins again.
+
+To revoke by hand, after removing the label:
+
+```
+gh pr comment <PR> --repo <owner>/<repo> --body '<!-- review-verdict:revoked:<current-head-sha> -->'
+```
+
+The trust boundary is unchanged: only markers from the pipeline's own login
+count, so a revocation from any other commenter is ignored exactly as a forged
+grant is.
+
+`_gh_pr_merge_train_review_passed_marker_sha` and
+`_gh_pr_merge_train_review_passed_stale`
+(`shell-common/functions/gh_pr_merge_train.sh`) implement the reading side, for
+both the merge-train gate and the Step 5 reconcile.
+
 ## Why this lives in the producer
 
 The alternative — having the merge train grep review comment bodies — couples

--- a/claude/skills/devx-pr-review-all/references/review-verdict-label.md
+++ b/claude/skills/devx-pr-review-all/references/review-verdict-label.md
@@ -461,12 +461,27 @@ marker, which is then the last one and wins again.
 To revoke by hand, after removing the label:
 
 ```
-gh pr comment <PR> --repo <owner>/<repo> --body '<!-- review-verdict:revoked:<current-head-sha> -->'
+GH_HOST="<target-host>" gh pr comment <PR> --repo <owner>/<repo> --body '<!-- review-verdict:revoked:<current-head-sha> -->'
 ```
 
-The trust boundary is unchanged: only markers from the pipeline's own login
-count, so a revocation from any other commenter is ignored exactly as a forged
-grant is.
+`GH_HOST` is not optional here (same cross-host contract as every other `gh`
+call in this pipeline, `references/github-target.md`): a bare `gh pr comment`
+follows `gh`'s own `gh repo set-default`, which on a dual-host login can post
+the marker to the wrong server without an error (#1403).
+
+The trust boundary is unchanged: only markers from the pipeline's own
+login — `_gh_pr_merge_train_review_passed_marker_sha`'s `<expected-login>`,
+`GH_PR_MERGE_TRAIN_TRUSTED_LOGIN` when set, otherwise `gh api user -q .login`
+in the reading context — count, so a revocation from any other commenter is
+ignored exactly as a forged grant is. **Run the command above authenticated as
+that login** — `gh auth status` shows which account the current `gh` session
+is; on this repo's single-account setup that is simply the repo owner's own
+login, so a human revoking under their normal `gh` session already matches.
+On a deployment that splits the review/reply/merge pipeline onto a separate
+bot account, a revocation posted under a human's personal login is silently
+ignored (a real gap flagged in PR #1713 review, codex BLOCKER) — post it
+authenticated as that bot account instead, or from wherever
+`GH_PR_MERGE_TRAIN_TRUSTED_LOGIN` is set to.
 
 `_gh_pr_merge_train_review_passed_marker_sha` and
 `_gh_pr_merge_train_review_passed_stale`

--- a/claude/skills/gh-pr-merge-train/references/review-verdict-gate.md
+++ b/claude/skills/gh-pr-merge-train/references/review-verdict-gate.md
@@ -128,6 +128,23 @@ This still does not make the train a comment parser in the sense "What this
 gate is not" forbids below: it never reads a *reviewer's* verdict line, only
 a fixed machine stamp this same subsystem writes for exactly this check.
 
+### Revocation (#1706)
+
+A second marker type, `<!-- review-verdict:revoked:<sha> -->`, withdraws an
+earlier `review-passed` marker — the explicit act a human takes after pulling
+the label by hand, so a later content-identical rebase cannot re-grant it off
+the surviving evidence. The lookup takes the LAST marker of *either* type from
+the trusted login, by comment order; the sha a revocation names is audit
+metadata and is never compared. Full spec (format, how to post one, the trust
+boundary):
+`devx-pr-review-all/references/review-verdict-label.md` → "Revoking a stale
+`review-passed` by hand".
+
+No new gate outcome: a revoked latest marker reads as ABSENT, so the decision
+table's `review-passed` only, no marker at all from the trusted login row
+covers it — same `[SKIPPED] review-passed not confirmed for this head — no
+freshness marker found` line, and the label is likewise left untouched.
+
 ### Marker authorship (PR #1608 review, agy + codex BLOCKER)
 
 A plain comment has no write-permission floor the way a label does — on most

--- a/claude/skills/gh-pr-merge-train/references/review-verdict-gate.md
+++ b/claude/skills/gh-pr-merge-train/references/review-verdict-gate.md
@@ -145,6 +145,16 @@ table's `review-passed` only, no marker at all from the trusted login row
 covers it — same `[SKIPPED] review-passed not confirmed for this head — no
 freshness marker found` line, and the label is likewise left untouched.
 
+**The #1615 pagination bound (page 1 XOR the last page, never both) does not
+create a resurrection risk for revocation** (PR #1713 review, codex BLOCKER —
+declined): a `revoked` marker is by construction posted *after* the
+`review-passed` marker it cancels, so on a multi-page PR it can never age off
+the fetched (most-recent) page while the older `review-passed` marker it
+targets is still on it — whichever of the two survives the window, the newer
+one (the revocation, if either) does. The only failure this bound can cause is
+both markers aging off together, which reads as ABSENT — the same fail-safe
+direction the "STALE, ABSENT" row above already takes, not a resurrection.
+
 ### Marker authorship (PR #1608 review, agy + codex BLOCKER)
 
 A plain comment has no write-permission floor the way a label does — on most

--- a/claude/skills/gh-pr-resolve-conflict/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-conflict/references/verdict-label-removal.sh.md
@@ -134,6 +134,10 @@ case "$_vl_result" in
         echo "[WARN] \`review-passed\` 재확인 실패 — 라벨 추가 자체가 실패해 아무것도 부여되지 않음"
         ;;
     *)
+        # 자매 스킬과 같은 헬퍼를 쓰므로 취소 마커
+        # (`<!-- review-verdict:revoked:<sha> -->`) 도 그대로 여기로 떨어진다(#1706).
+        # 남기는 방법은 `devx-pr-review-all/references/review-verdict-label.md` →
+        # "Revoking a stale `review-passed` by hand" 참고.
         echo "[OK] \`review-passed\` 무효화됨(또는 애초에 없었음) — 최신 판정 없음"
         ;;
 esac

--- a/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
+++ b/claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md
@@ -160,6 +160,13 @@ case "$_vl_result" in
         echo "[WARN] \`review-passed\` 재확인 실패 — 라벨 추가 자체가 실패해 아무것도 부여되지 않음"
         ;;
     *)
+        # 여기로 떨어지는 "재확인 근거 없음"에는 취소 마커
+        # (`<!-- review-verdict:revoked:<sha> -->`)로 이전 판정을 명시적으로
+        # 거둬들인 경우도 포함된다(#1706). 사람이 UI 에서 라벨만 떼면 마커는
+        # 그대로 남아 다음 내용-동일 리베이스에서 재부여되므로, 취소는 마커를
+        # 남기는 별도 행위여야 한다. 남기는 방법은
+        # `devx-pr-review-all/references/review-verdict-label.md` →
+        # "Revoking a stale `review-passed` by hand" 참고.
         echo "[OK] \`review-passed\` 무효화됨(또는 애초에 없었음) — 최신 판정 없음"
         ;;
 esac

--- a/docs/public/changelog.d/2026-09-02-1706.md
+++ b/docs/public/changelog.d/2026-09-02-1706.md
@@ -1,0 +1,1 @@
+- 변경: **`review-verdict:revoked:<sha>` 취소 마커 도입으로, 사람이 손으로 뗀 `review-passed` 가 내용-동일 리베이스에서 조용히 부활하지 않는다.**

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -313,6 +313,22 @@ _gh_pr_merge_train_has_review_passed_label() {
 #   exists. AT MOST TWO `gh api` calls, regardless of how many comment
 #   pages the PR has (#1615).
 #
+#   Revocation (#1706): a second marker type,
+#   `<!-- review-verdict:revoked:<sha> -->`, cancels an earlier
+#   `review-passed` marker. Both types are matched in ONE pass and the single
+#   LAST one wins BY COMMENT ORDER — not by sha. If that last marker is a
+#   `revoked` one, this function prints NOTHING and returns 0: for reading
+#   purposes a revocation is indistinguishable from "no marker was ever
+#   posted" (a CONFIRMED absence, rc 2 out of `_stale` below — never rc 1/3).
+#   The sha inside `revoked:<sha>` is audit metadata only; it is never
+#   compared against anything, so a revocation naming any sha still cancels
+#   the `review-passed` marker before it. Ordering, not sha, decides.
+#   Revocation is not permanent: a later `review-passed` marker (a genuine
+#   re-review) is then the last one and wins again. Existing markers are
+#   never edited or deleted — the audit trail is append-only. Full spec:
+#   `devx-pr-review-all/references/review-verdict-label.md` → "Revoking a
+#   stale review-passed by hand".
+#
 #   Why not `--paginate` (#1615): the first cut walked EVERY comment page to
 #   find the last marker, so a long-running PR cost one HTTP round trip per
 #   100 comments on EVERY merge-train tick — flagged independently by three
@@ -372,7 +388,7 @@ _gh_pr_merge_train_has_review_passed_label() {
 #   before.
 _gh_pr_merge_train_review_passed_marker_sha() {
     local _pr="$1" _repo="$2" _host="${3-}" _login="${4-}" \
-        _jq _raw _rc _login_base _headers _bodies _link _last
+        _jq _raw _rc _login_base _headers _bodies _link _last _last_marker
 
     _login_base="$_login"
     case "$_login_base" in
@@ -440,10 +456,21 @@ _gh_pr_merge_train_review_passed_marker_sha() {
         _bodies=$(printf '%s\n' "$_raw" | sed '1,/^\r\{0,1\}$/d')
     fi
 
-    printf '%s\n' "$_bodies" |
-        grep -oE '<!-- review-verdict:review-passed:[0-9a-f]+ -->' |
-        tail -n 1 |
-        sed -E 's/^<!-- review-verdict:review-passed:([0-9a-f]+) -->$/\1/'
+    # BOTH marker types in one pass, so `tail -n 1` picks the chronologically
+    # last one whichever type it is — "latest marker wins", not "latest
+    # review-passed wins" (#1706).
+    _last_marker=$(printf '%s\n' "$_bodies" |
+        grep -oE '<!-- review-verdict:(review-passed|revoked):[0-9a-f]+ -->' |
+        tail -n 1)
+
+    case "$_last_marker" in
+        # No marker at all, or a revocation — both print NOTHING (zero bytes,
+        # not a bare newline: the pre-#1706 pipeline emitted nothing here and
+        # the documented contract above says "empty").
+        '' | *':revoked:'*) ;;
+        *) printf '%s\n' "$_last_marker" |
+            sed -E 's/^<!-- review-verdict:review-passed:([0-9a-f]+) -->$/\1/' ;;
+    esac
 
     return 0
 }
@@ -469,6 +496,21 @@ _gh_pr_merge_train_review_passed_marker_sha() {
 #          unacceptable operational cliff — a re-review clears it exactly as
 #          cheaply either way, so there is nothing to gain by deleting rather
 #          than merely not trusting it.
+#
+#          Since #1706 this is also the answer when the LAST marker from
+#          `<expected-login>` is a revocation
+#          (`<!-- review-verdict:revoked:<sha> -->`) rather than a
+#          `review-passed` one: a revocation is deliberately
+#          indistinguishable from "no marker at all" here, because both mean
+#          the same thing to this check — there is no standing verdict for
+#          any head. It is a confirmed absence, so it is rc 2, never rc 1
+#          (nothing was proven stale) and never rc 3 (the lookup completed
+#          fine). Which marker is last is decided by COMMENT ORDER alone —
+#          the sha a revocation names is audit metadata and is never compared
+#          against `<head-oid>` or against the earlier marker's sha. That
+#          means the caller still does not self-heal: a hand-revoked
+#          `review-passed` label is left attached and merely not trusted,
+#          exactly like the pre-existing absent case.
 #   rc 3 — STALE, UNDETERMINED: the underlying lookup itself failed (network,
 #          auth, rate limit) or `<expected-login>` was invalid, so nothing
 #          was confirmed either way. Route as unverified this tick (fail-

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -388,7 +388,7 @@ _gh_pr_merge_train_has_review_passed_label() {
 #   before.
 _gh_pr_merge_train_review_passed_marker_sha() {
     local _pr="$1" _repo="$2" _host="${3-}" _login="${4-}" \
-        _jq _raw _rc _login_base _headers _bodies _link _last _last_marker
+        _jq _raw _rc _login_base _headers _bodies _link _last
 
     _login_base="$_login"
     case "$_login_base" in
@@ -458,19 +458,13 @@ _gh_pr_merge_train_review_passed_marker_sha() {
 
     # BOTH marker types in one pass, so `tail -n 1` picks the chronologically
     # last one whichever type it is — "latest marker wins", not "latest
-    # review-passed wins" (#1706).
-    _last_marker=$(printf '%s\n' "$_bodies" |
+    # review-passed wins" (#1706). The trailing `sed` then drops a revoked
+    # last marker outright (prints NOTHING, zero bytes — same as no marker at
+    # all, per the documented contract above) and otherwise extracts the sha.
+    printf '%s\n' "$_bodies" |
         grep -oE '<!-- review-verdict:(review-passed|revoked):[0-9a-f]+ -->' |
-        tail -n 1)
-
-    case "$_last_marker" in
-        # No marker at all, or a revocation — both print NOTHING (zero bytes,
-        # not a bare newline: the pre-#1706 pipeline emitted nothing here and
-        # the documented contract above says "empty").
-        '' | *':revoked:'*) ;;
-        *) printf '%s\n' "$_last_marker" |
-            sed -E 's/^<!-- review-verdict:review-passed:([0-9a-f]+) -->$/\1/' ;;
-    esac
+        tail -n 1 |
+        sed -E '/:revoked:/d; s/^<!-- review-verdict:review-passed:([0-9a-f]+) -->$/\1/'
 
     return 0
 }

--- a/shell-common/functions/gh_pr_resolve_outdated.sh
+++ b/shell-common/functions/gh_pr_resolve_outdated.sh
@@ -86,6 +86,15 @@
 # `_gh_pr_resolve_outdated_has_label` survives as a function, but its call
 # site is now purely DIAGNOSTIC — it fills the report's `prior=` field.
 #
+# Indestructible evidence needed a withdraw path, though (#1706): a human who
+# pulls `review-passed` off in the UI removes the label but not the marker, so
+# the next content-identical rebase re-granted it and silently overrode them.
+# A `<!-- review-verdict:revoked:<sha> -->` comment now cancels the marker
+# before it — appended, never a delete, so the audit trail survives — and the
+# freshness check reads it as rc 2 (ABSENT), landing on the same drop path.
+# See `devx-pr-review-all/references/review-verdict-label.md` → "Revoking a
+# stale `review-passed` by hand".
+#
 # A surviving marker proves a verdict was ISSUED for that head, not that it is
 # still the CURRENT one (PR #1703 review, codex BLOCKER). Nothing deletes a
 # marker — the property #1700 leans on — but that cuts both ways: when

--- a/tests/bats/skills/_fixtures/review_passed_gh_stub.sh
+++ b/tests/bats/skills/_fixtures/review_passed_gh_stub.sh
@@ -20,6 +20,17 @@ _marker_comment() {
         '{user: {login: $login}, body: ("<!-- review-verdict:review-passed:" + $sha + " -->")}'
 }
 
+# The #1706 counterpart: one PR-comment object carrying a REVOCATION marker,
+# the thing a human posts by hand after removing `review-passed` from the UI.
+# Read side: the last marker of either type wins by comment order, and a
+# revocation reads as "no verdict at all" — see
+# `devx-pr-review-all/references/review-verdict-label.md` → "Revoking a stale
+# review-passed by hand".
+_revoked_marker_comment() {
+    jq -nc --arg login "$1" --arg sha "$2" \
+        '{user: {login: $login}, body: ("<!-- review-verdict:revoked:" + $sha + " -->")}'
+}
+
 # Call from setup(), AFTER GH_LOG/STUB_* are exported and the skill-specific
 # fixture is sourced — defines the `gh` and `_gh_pr_edit_safe_label` stubs
 # both suites share verbatim.

--- a/tests/bats/skills/_fixtures/review_passed_gh_stub.sh
+++ b/tests/bats/skills/_fixtures/review_passed_gh_stub.sh
@@ -12,23 +12,17 @@
 # were identical between the two files. Kept in one place per #1524 (a test
 # helper must not be free to drift from the fixture it exercises).
 
-# One PR-comment object carrying a fresh `review-verdict:review-passed`
-# marker for <sha>, authored by <login> — mirrors what
-# `devx_pr_review_all_write_label` actually posts.
-_marker_comment() {
-    jq -nc --arg login "$1" --arg sha "$2" \
-        '{user: {login: $login}, body: ("<!-- review-verdict:review-passed:" + $sha + " -->")}'
-}
-
-# The #1706 counterpart: one PR-comment object carrying a REVOCATION marker,
-# the thing a human posts by hand after removing `review-passed` from the UI.
-# Read side: the last marker of either type wins by comment order, and a
-# revocation reads as "no verdict at all" — see
+# One PR-comment object carrying a fresh `review-verdict:<verdict>` marker
+# for <sha>, authored by <login> — mirrors what `devx_pr_review_all_write_label`
+# actually posts. <verdict> defaults to `review-passed`; pass `revoked` for
+# the #1706 counterpart, the marker a human posts by hand after removing
+# `review-passed` from the UI. Read side: the last marker of either type wins
+# by comment order, and a revocation reads as "no verdict at all" — see
 # `devx-pr-review-all/references/review-verdict-label.md` → "Revoking a stale
 # review-passed by hand".
-_revoked_marker_comment() {
-    jq -nc --arg login "$1" --arg sha "$2" \
-        '{user: {login: $login}, body: ("<!-- review-verdict:revoked:" + $sha + " -->")}'
+_marker_comment() {
+    jq -nc --arg login "$1" --arg sha "$2" --arg verdict "${3:-review-passed}" \
+        '{user: {login: $login}, body: ("<!-- review-verdict:" + $verdict + ":" + $sha + " -->")}'
 }
 
 # Call from setup(), AFTER GH_LOG/STUB_* are exported and the skill-specific

--- a/tests/bats/skills/gh_pr_merge_train_review_verdict_gate.bats
+++ b/tests/bats/skills/gh_pr_merge_train_review_verdict_gate.bats
@@ -385,6 +385,64 @@ more text')" '[$c]')
     assert_output '2222222'
 }
 
+# ── #1706: the revocation marker ──
+# `<!-- review-verdict:revoked:<sha> -->` cancels an earlier `review-passed`
+# marker. The rule is "the LAST marker of EITHER type from the trusted login
+# wins, by comment order" — the sha a revocation names is audit metadata and
+# is never compared against anything.
+
+@test "freshness (#1706): a revoked marker after a review-passed one yields nothing, rc 0" {
+    # rc 0, not rc 1: a revocation is a CONFIRMED absence (the lookup ran and
+    # answered "no standing verdict"), which is a different thing from the
+    # lookup itself having failed.
+    _freshness_stub
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson c1 "$(_comment bot '<!-- review-verdict:review-passed:1111111 -->')" \
+        --argjson c2 "$(_comment bot '<!-- review-verdict:revoked:1111111 -->')" \
+        '[$c1, $c2]')
+    run _gh_pr_merge_train_review_passed_marker_sha 11 acme/widget '' bot
+    assert_success
+    assert_output ''
+}
+
+@test "freshness (#1706): a revocation naming a DIFFERENT sha still cancels — order decides, not sha" {
+    _freshness_stub
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson c1 "$(_comment bot '<!-- review-verdict:review-passed:1111111 -->')" \
+        --argjson c2 "$(_comment bot '<!-- review-verdict:revoked:9999999 -->')" \
+        '[$c1, $c2]')
+    run _gh_pr_merge_train_review_passed_marker_sha 11 acme/widget '' bot
+    assert_success
+    assert_output ''
+}
+
+@test "freshness (#1706): a revocation that is NOT last does not poison a later re-review" {
+    # Revocation only wins while it is the last marker. A genuine re-review
+    # afterwards stamps a new `review-passed` and that one is now last.
+    _freshness_stub
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson c1 "$(_comment bot '<!-- review-verdict:review-passed:1111111 -->')" \
+        --argjson c2 "$(_comment bot '<!-- review-verdict:revoked:1111111 -->')" \
+        --argjson c3 "$(_comment bot '<!-- review-verdict:review-passed:3333333 -->')" \
+        '[$c1, $c2, $c3]')
+    run _gh_pr_merge_train_review_passed_marker_sha 11 acme/widget '' bot
+    assert_success
+    assert_output '3333333'
+}
+
+@test "freshness (#1706): a revocation from ANY OTHER commenter is ignored" {
+    # Same trust boundary as every other marker in this file: an untrusted
+    # login can neither grant nor revoke. The trusted marker still wins.
+    _freshness_stub
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson real "$(_comment bot '<!-- review-verdict:review-passed:1111111 -->')" \
+        --argjson forged "$(_comment some-random-contributor '<!-- review-verdict:revoked:1111111 -->')" \
+        '[$real, $forged]')
+    run _gh_pr_merge_train_review_passed_marker_sha 11 acme/widget '' bot
+    assert_success
+    assert_output '1111111'
+}
+
 @test "freshness: marker_sha pins GH_HOST on the lookup" {
     _freshness_stub
     STUB_COMMENTS_JSON=$(jq -nc --argjson c "$(_comment bot '<!-- review-verdict:review-passed:abc1234 -->')" '[$c]')
@@ -577,6 +635,20 @@ more text')" '[$c]')
     STUB_COMMENTS_JSON=$(jq -nc --argjson c "$(_comment bot '<!-- review-verdict:review-passed:deadbeef -->')" '[$c]')
     run _gh_pr_merge_train_review_passed_stale 11 acme/widget '' deadbeef bot
     assert_success
+}
+
+@test "freshness (#1706): a revoked latest marker is ABSENT (rc 2), not MISMATCH or UNDETERMINED" {
+    # The revocation names the CURRENT head, so a sha-comparing implementation
+    # would answer rc 0 (fresh) — the whole point is that a revocation is not
+    # compared at all, it just erases the standing verdict. rc 2 also means
+    # the caller leaves the label alone rather than self-healing it away.
+    _freshness_stub
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson c1 "$(_comment bot '<!-- review-verdict:review-passed:deadbeef -->')" \
+        --argjson c2 "$(_comment bot '<!-- review-verdict:revoked:deadbeef -->')" \
+        '[$c1, $c2]')
+    run _gh_pr_merge_train_review_passed_stale 11 acme/widget '' deadbeef bot
+    [ "$status" -eq 2 ]
 }
 
 @test "freshness (BLOCKER fix): a lookup failure is UNDETERMINED (rc 3), not MISMATCH or ABSENT" {

--- a/tests/bats/skills/gh_pr_resolve_conflict_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_conflict_review_passed.bats
@@ -138,6 +138,23 @@ _1700_make_repo() {
     assert_output --partial 'patch-id=changed'
     assert_output --partial 'label=dropped'
     refute_output --partial 'context-identical'
+}
+
+@test "conflict Step 5 (#1706): a hand-revoked review-passed is not resurrected here either" {
+    eval "$(_1700_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    # Smoke-level, same reasoning as the #1703 case above: the revocation
+    # semantics themselves are pinned in the sister suite and in
+    # gh_pr_merge_train_review_verdict_gate.bats. What this pins is that THIS
+    # skill's zero-conflict rebase path reaches the shared helper and so
+    # inherits the #1706 fix — the label must not come back on a
+    # content-identical rebase once the marker was revoked.
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson passed "$(_marker_comment "$STUB_ME_LOGIN" "$BACKUP")" \
+        --argjson revoked "$(_revoked_marker_comment "$STUB_ME_LOGIN" "$BACKUP")" \
+        '[$passed, $revoked]')
+    resolve_conflict_step5_reconcile 1687 acme/widget ghe.example.com \
+        "$OLD_BASE" "$BACKUP" "$NEW_BASE" "$NEW_HEAD_SAME"
     run cat "$GH_LOG"
     assert_output --partial 'api -X DELETE repos/acme/widget/issues/1687/labels/review-passed'
     refute_output --partial 'add 1687 review-passed'

--- a/tests/bats/skills/gh_pr_resolve_conflict_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_conflict_review_passed.bats
@@ -151,7 +151,7 @@ _1700_make_repo() {
     # content-identical rebase once the marker was revoked.
     STUB_COMMENTS_JSON=$(jq -nc \
         --argjson passed "$(_marker_comment "$STUB_ME_LOGIN" "$BACKUP")" \
-        --argjson revoked "$(_revoked_marker_comment "$STUB_ME_LOGIN" "$BACKUP")" \
+        --argjson revoked "$(_marker_comment "$STUB_ME_LOGIN" "$BACKUP" revoked)" \
         '[$passed, $revoked]')
     resolve_conflict_step5_reconcile 1687 acme/widget ghe.example.com \
         "$OLD_BASE" "$BACKUP" "$NEW_BASE" "$NEW_HEAD_SAME"

--- a/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
@@ -250,7 +250,7 @@ _1704_make_repo() {
     # cancels the evidence the reconcile reads.
     STUB_COMMENTS_JSON=$(jq -nc \
         --argjson passed "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
-        --argjson revoked "$(_revoked_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        --argjson revoked "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD" revoked)" \
         '[$passed, $revoked]')
     resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
         "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
@@ -267,7 +267,7 @@ _1704_make_repo() {
     # the normal #1698/#1700 keep path resumes.
     STUB_COMMENTS_JSON=$(jq -nc \
         --argjson passed "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
-        --argjson revoked "$(_revoked_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        --argjson revoked "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD" revoked)" \
         --argjson again "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
         '[$passed, $revoked, $again]')
     resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \

--- a/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
+++ b/tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats
@@ -237,6 +237,47 @@ _1704_make_repo() {
     refute_output --partial 'add 1695 review-passed'
 }
 
+@test "reconcile (#1706): patch-id identical but review-passed was revoked by hand -> drops, does not resurrect" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    # The #1706 scenario end to end: sha A passed review (label + marker), a
+    # human spotted something and pulled the `review-passed` LABEL by hand
+    # without opening a formal `review-blocked` round, then a content-identical
+    # rebase landed. Every other precondition still holds — patch-id identical,
+    # marker authored by the trusted login, no `review-blocked` — so before the
+    # revocation marker existed the label came straight back and silently
+    # overrode the human's judgment. The revocation is the explicit act that
+    # cancels the evidence the reconcile reads.
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson passed "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        --argjson revoked "$(_revoked_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        '[$passed, $revoked]')
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    assert_output --partial 'api -X DELETE repos/acme/widget/issues/1695/labels/review-passed'
+    refute_output --partial 'add 1695 review-passed'
+}
+
+@test "reconcile (#1706): a revocation followed by a genuine re-review re-grants again" {
+    eval "$(_1698_make_repo)"
+    cd "$REPO_DIR" || fail "cd failed"
+    # The revocation must not be a permanent poison pill: once the PR is
+    # actually re-reviewed, the newest marker is a `review-passed` again and
+    # the normal #1698/#1700 keep path resumes.
+    STUB_COMMENTS_JSON=$(jq -nc \
+        --argjson passed "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        --argjson revoked "$(_revoked_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        --argjson again "$(_marker_comment "$STUB_ME_LOGIN" "$OLD_HEAD")" \
+        '[$passed, $revoked, $again]')
+    resolve_outdated_step5_reconcile 1695 acme/widget ghe.example.com \
+        "$OLD_BASE" "$OLD_HEAD" "$NEW_BASE" "$NEW_HEAD_SAME"
+    run cat "$GH_LOG"
+    refute_output --partial 'labels/review-passed'
+    assert_output --partial "add 1695 review-passed --repo acme/widget"
+    assert_output --partial "review-verdict:review-passed:${NEW_HEAD_SAME}"
+}
+
 @test "reconcile (PR #1703): patch-id identical + fresh marker but review-blocked is attached -> drops" {
     eval "$(_1698_make_repo)"
     cd "$REPO_DIR" || fail "cd failed"


### PR DESCRIPTION
## Summary
- `<!-- review-verdict:revoked:<sha> -->` 취소 마커를 도입해, 사람이 손으로 뗀 `review-passed` 가 내용-동일 리베이스에서 조용히 부활하는 문제(#1706)를 고쳤다.
- `_gh_pr_merge_train_review_passed_marker_sha` 한 곳만 고쳐 `gh:pr-merge-train` 게이트와 `gh:pr-resolve-outdated`/`gh:pr-resolve-conflict` 재조정 두 소비자가 함께 수정된다.

## Changes
- `shell-common/functions/gh_pr_merge_train.sh`: `review-passed`/`revoked` 두 마커 타입을 한 grep 패스로 매칭해 코멘트 순서상 가장 최근 마커를 승자로 삼는다. 승자가 `revoked` 면 마커가 아예 없던 것과 동일하게(rc 2 ABSENT) 취급 — 마커가 담은 sha 는 비교하지 않는다.
- `shell-common/functions/gh_pr_resolve_outdated.sh`: 헤더 주석에 #1706 설명만 추가(로직은 공유 함수를 통해 자동으로 고쳐짐).
- `claude/skills/devx-pr-review-all/references/review-verdict-label.md`: 취소 마커 포맷 + "최신 마커 우선" 판정 규칙을 정의하는 producer SSOT 절 추가.
- `claude/skills/gh-pr-merge-train/references/review-verdict-gate.md`: freshness 절에서 SSOT 절을 참조하도록 보강.
- `claude/skills/gh-pr-resolve-outdated/references/verdict-label-removal.sh.md`, `claude/skills/gh-pr-resolve-conflict/references/verdict-label-removal.sh.md`: 재조정 skip 리포트에서 취소 마커 문서를 참조하는 포인터 추가.
- 테스트: `tests/bats/skills/gh_pr_merge_train_review_verdict_gate.bats`, `tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats`, `tests/bats/skills/gh_pr_resolve_conflict_review_passed.bats`, 공유 픽스처 `tests/bats/skills/_fixtures/review_passed_gh_stub.sh`.
- `docs/public/changelog.d/2026-09-02-1706.md`: changelog fragment.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_merge_train_review_verdict_gate.bats` — 전체 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_resolve_outdated_review_passed.bats` — 전체 통과 (AC #3 회귀 테스트 포함)
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/skills/gh_pr_resolve_conflict_review_passed.bats` — 전체 통과
- [x] `mise run lint-docs`

## Related
Closes #1706

---
<details>
<summary>🤖 AI Metrics · 📊 ~6500 tokens · 👤 ~2 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6500 tokens · 👤 ~2 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
