### PR TITLE
chore(docs): changelog fragment 규칙 잠정 중단 (토큰 절감)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,6 @@ Direct-Exec Guard pattern, Bash/Zsh compatibility rules, and diagnostic design s
 
 See **[Claude Code](./claude/AGENTS.md)** for skills management, multi-CLI registry, and commands.
 
-# 변경 기록 (changelog)
+# 변경 기록 (changelog) — 중단 (2026-09-02)
 
-- 사용자 가시·운영·스키마·배포·비자명 동작 변경 완료 시 `docs/public/changelog.d/<YYYY-MM-DD>-<issue>.md` 를 새로 추가한다(불필요하면 이유 명시). 단일 `changelog.md` 는 #1471 에서 제거됐다.
-- 날짜는 파일명이 갖는다 — 파일 안에 `##` 헤더를 쓰지 않는다. 한 줄 = 한 항목, `- 변경: **요약**`.
-- 포맷 강제: `mise run lint-docs` (`scripts/lint_changelog_fragments.sh`).
-- 일일/주간 보고 허브(my-share)가 이 fragment 들을 수집한다.
+- fragment 작성 요구는 중단됐다 — 상세와 재개 조건은 `CLAUDE.md` → "변경 기록 (changelog)" 참고.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,11 +100,8 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 - No emojis anywhere (token efficiency) — **단 하나의 예외**: `ai-metrics` footer (`<details>` 래퍼 및 `<!-- ai-metrics -->` 블록) 내부의 `📊 👤 🤖` 글리프. 이는 GitHub Issue/PR 카드 footer 의 의도된 시각 디자인이며 #317 F-2 요구사항 + PR #320 으로 SSOT 확정됨 (#367 의 `<details><summary>🤖 AI Metrics</summary>` 래퍼 포함). 다른 어떤 위치에도 이모지 사용 금지.
 - For AGENTS.md files, aim to keep them under 100 lines each
 
-## 변경 기록 (changelog)
+## 변경 기록 (changelog) — 중단 (2026-09-02)
 
-- 사용자 가시·운영·스키마·배포·비자명 동작 변경을 완료하면 `docs/public/changelog.d/` 에 **fragment 파일 1개**를 추가한다(항목이 불필요하면 그 이유를 명시). 단일 `changelog.md` 는 #1471 에서 제거됐다 — 모든 PR 이 같은 줄에 삽입해 충돌이 상시화되고 중복 날짜 헤더까지 뚫렸기 때문이다.
-- 파일명은 `<YYYY-MM-DD>-<issue>.md` (예: `docs/public/changelog.d/2026-08-26-1471.md`). 날짜를 파일명이 들고 있으므로 **파일 안에는 `##` 날짜 헤더를 쓰지 않는다**.
-- 내용은 한 줄 = 한 항목, `- 변경: **요약**` 형식. 한 이슈가 항목을 여러 개 남기면 같은 파일에 여러 줄로 적는다. 줄바꿈·하위 불릿은 금지(수집기가 비어 있지 않은 모든 줄을 항목으로 싣는다).
-- 같은 날짜 안 정렬은 파일명 오름차순이다.
-- 포맷 강제: `mise run lint-docs` (`scripts/lint_changelog_fragments.sh`). 회귀 테스트는 `tests/bats/lint/changelog_fragments.bats`.
-- 이 changelog는 일일/주간 보고 허브(my-share)가 수집해 보고서를 생성한다.
+- fragment 작성 요구는 **중단됐다** — 토큰 소모가 커서 잠정 정지. 완료 후 fragment 파일을 만들지 않는다.
+- `mise run lint-docs` 에서도 `scripts/lint_changelog_fragments.sh` 호출을 뺐다 — 게이트 비활성.
+- 과거 규칙(파일명 `<YYYY-MM-DD>-<issue>.md`, `- 변경: **요약**` 포맷)과 스크립트/`tests/bats/lint/changelog_fragments.bats` 는 재개를 위해 그대로 남겨뒀다. 재개 시 이 섹션과 `mise.toml` 의 `lint-docs` 를 되돌린다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,4 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 - fragment 작성 요구는 **중단됐다** — 토큰 소모가 커서 잠정 정지. 완료 후 fragment 파일을 만들지 않는다.
 - `mise run lint-docs` 에서도 `scripts/lint_changelog_fragments.sh` 호출을 뺐다 — 게이트 비활성.
 - 과거 규칙(파일명 `<YYYY-MM-DD>-<issue>.md`, `- 변경: **요약**` 포맷)과 스크립트/`tests/bats/lint/changelog_fragments.bats` 는 재개를 위해 그대로 남겨뒀다. 재개 시 이 섹션과 `mise.toml` 의 `lint-docs` 를 되돌린다.
+- **my-share 영향**: 일일/주간 보고 허브(`my-share`)의 수집기(`scripts/report_range.py`)는 `changelog.d/` 가 비어 있어도 에러 없이 빈 결과를 반환한다 — 이 기간 동안 dotfiles 항목은 보고서에서 조용히 빠진다(수집기 오작동이 아니라 fragment 부재의 정상 결과). 재개 전까지는 dotfiles 변경 사항을 daily/weekly 보고서에서 볼 수 없다는 뜻이다.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,9 +9,8 @@
 - **Review**: open in markdown viewer (VS Code, grip)
 - **Line count**: `wc -l docs/**/*.md`
 - **Markdown lint**: 비활성화 — 자동 실행 금지
-- **Docs 린트**: `mise run lint-docs` — 세 개를 순차 실행한다.
+- **Docs 린트**: `mise run lint-docs` — 두 개를 순차 실행한다 (changelog fragment 검사는 2026-09-02 중단, `CLAUDE.md` 참고).
   - `scripts/lint_docs_filenames.sh` — docs 파일명 kebab-case 검사 (`adr/`·`requirement/` 강제, 나머지 warn-only, #1027)
-  - `scripts/lint_changelog_fragments.sh` — `public/changelog.d/` fragment 의 파일명·내용 형식 강제 (#1471)
   - `scripts/lint_shell_common_fallback.sh` — `claude/skills/**/*.md` 안 `${SHELL_COMMON}/...` 소싱 지시문의 `$HOME` 폴백 누락 강제 (#1612)
 
 # Golden Rules

--- a/mise.toml
+++ b/mise.toml
@@ -52,14 +52,14 @@ run = [
 ]
 
 [tasks.lint-docs]
-description = "Docs 린터 (파일명 kebab-case #1027 + changelog fragment #1471 + SHELL_COMMON 폴백 #1612)"
+description = "Docs 린터 (파일명 kebab-case #1027 + SHELL_COMMON 폴백 #1612)"
 # adr/ + requirement/ 는 강제(FAIL), 나머지 docs/ 는 warn-only.
 # 레거시 위반 일괄 정리는 별도 이슈로 분리한다.
-# changelog fragment 규칙과 그 근거는 scripts/lint_changelog_fragments.sh 헤더가 SSOT.
+# changelog fragment 검사(scripts/lint_changelog_fragments.sh)는 토큰 소모 문제로
+# 2026-09-02 중단했다 — 재개 조건은 CLAUDE.md "변경 기록 (changelog)" 참고.
 # ${SHELL_COMMON} $HOME 폴백 규칙과 근거는 scripts/lint_shell_common_fallback.sh 헤더가 SSOT.
 run = [
     "sh scripts/lint_docs_filenames.sh",
-    "sh scripts/lint_changelog_fragments.sh",
     "sh scripts/lint_shell_common_fallback.sh",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -55,8 +55,8 @@ run = [
 description = "Docs 린터 (파일명 kebab-case #1027 + SHELL_COMMON 폴백 #1612)"
 # adr/ + requirement/ 는 강제(FAIL), 나머지 docs/ 는 warn-only.
 # 레거시 위반 일괄 정리는 별도 이슈로 분리한다.
-# changelog fragment 검사(scripts/lint_changelog_fragments.sh)는 토큰 소모 문제로
-# 2026-09-02 중단했다 — 재개 조건은 CLAUDE.md "변경 기록 (changelog)" 참고.
+# changelog fragment 검사(scripts/lint_changelog_fragments.sh) 중단(2026-09-02) —
+# 근거/재개 조건은 CLAUDE.md "변경 기록 (changelog)" 가 SSOT.
 # ${SHELL_COMMON} $HOME 폴백 규칙과 근거는 scripts/lint_shell_common_fallback.sh 헤더가 SSOT.
 run = [
     "sh scripts/lint_docs_filenames.sh",


### PR DESCRIPTION
## Summary
- changelog fragment 작성 규칙(#1471)을 잠정 중단한다 — 매 작업마다 요구하던 fragment 작성 + lint 게이트가 토큰 소모를 키우고 있었다.
- 강제 규칙 자체는 `mise.toml`/`CLAUDE.md`/`AGENTS.md`/`docs/AGENTS.md`에서 빠지지만, 검사 스크립트와 회귀 테스트는 재개를 대비해 그대로 남긴다.

## Changes
- `CLAUDE.md`: "변경 기록 (changelog)" 섹션을 중단 공지로 교체 — 과거 포맷 규칙과 재개 조건을 함께 기록.
- `AGENTS.md`(루트): 동일 섹션을 CLAUDE.md 참조 한 줄로 축약.
- `docs/AGENTS.md`: `mise run lint-docs` 설명을 "세 개" → "두 개"로 수정하고 changelog 항목 삭제.
- `mise.toml`: `lint-docs` 태스크 `run` 목록에서 `sh scripts/lint_changelog_fragments.sh` 호출 제거, description/주석 갱신.
- `scripts/lint_changelog_fragments.sh`, `tests/bats/lint/changelog_fragments.bats`는 **무변경** — 재개 시 `mise.toml` 한 줄만 되돌리면 되도록 유지.

## Test plan
- [x] `mise run lint-docs` 통과 확인 (changelog 검사 없이 2개만 실행)
- [x] `sh scripts/lint_changelog_fragments.sh` 단독 실행 시 여전히 정상 동작 (재개 대비 무변경 검증)

## Related
Closes #1716

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~0.5 h · 🤖 ~5 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~0.5 h · 🤖 ~5 min
<!-- /ai-metrics:gh-pr -->

</details>
