### PR TITLE
fix(merge-train): 진행 불가 큐를 자동 pause로 전환

### DIFF
--- a/shell-common/tools/custom/pr_merge_train_cron.sh
+++ b/shell-common/tools/custom/pr_merge_train_cron.sh
@@ -51,6 +51,17 @@ fi
 # shellcheck source=/dev/null
 . "${_PMT_SHELL_COMMON}/functions/gh_pr_merge_train.sh" || exit 1
 
+# The aicron job state, for the "nothing actionable" pause (#1714). Hard
+# failure for the same reason as the filter above: a tick that cannot record
+# the pause is a tick that keeps waking a session every three minutes for a
+# queue nothing in this repo can move — the waste the pause exists to stop.
+if [ ! -f "${_PMT_SHELL_COMMON}/tools/custom/lib/aicron_state.sh" ]; then
+    ux_error "aicron_state.sh not found under ${_PMT_SHELL_COMMON}/tools/custom/lib — cannot pause the cron job."
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "${_PMT_SHELL_COMMON}/tools/custom/lib/aicron_state.sh" || exit 1
+
 # ============================================================
 # Constants (SSOT for the dispatcher)
 # ============================================================
@@ -202,6 +213,11 @@ _PMT_DRY_RUN=0
 # The GitHub target, bound once in main() from the checkout's `origin` (#1403).
 _PMT_REPO=""
 _PMT_HOST=""
+# The aicron job this dispatcher is registered as, and therefore the job the
+# #1714 pause writes to and `aicron resume` takes. A literal, never derived
+# from _PMT_REPO: cron-jobs.json names exactly this one job, so a second
+# `--cwd` target still pauses the same schedule that woke it.
+_PMT_AICRON_JOB="merge-train"
 
 # ============================================================
 # Helpers — state paths and JSON
@@ -362,6 +378,7 @@ _pmt_target_count() {
         _gh_pr_merge_train_filter_targets --now "${_now}") || return 1
 
     _pmt_bind_fingerprint "${_filtered}"
+    _pmt_bind_actionable "${_filtered}"
 
     _PMT_TARGET_COUNT=$(printf '%s' "${_filtered}" | jq -r 'length' 2>/dev/null) ||
         return 1
@@ -508,6 +525,60 @@ _pmt_backoff_gate() {
     [ "${_window}" -le "${_PMT_BACKOFF_MAX}" ] || _window="${_PMT_BACKOFF_MAX}"
     _pmt_backoff_write "${_file}" "${_window}" "${_window}"
     return 1
+}
+
+# ============================================================
+# Precondition 5 — is anything in the queue actionable (#1714)
+# ============================================================
+
+# How many of this tick's targets the train could actually move, bound by
+# _pmt_target_count from the same filtered array the fingerprint is folded
+# from — a second `gh pr list` to answer this would be the round trip #1709
+# already refused to spend.
+_PMT_ACTIONABLE_COUNT=0
+
+# Actionable is `review-passed` and no `review-blocked` (#1714). BEHIND or a
+# pending check still counts: the routing table has rows for those and the next
+# tick acts on them. A PR with neither verdict label does not — it is waiting on
+# a review nothing in this loop performs, and waking a session for it is the
+# dozen identical ticks #1691/#1703 spent.
+#
+# The two predicates are `gh_pr_merge_train.sh`'s, called one object at a time
+# because that is their contract; re-deriving the label test in jq here is the
+# duplicated-logic bug #1524 removed.
+_pmt_bind_actionable() {
+    local _pr _n=0
+
+    # A here-doc, not a pipe: `while ... | read` runs the loop body in a
+    # subshell, where the count would be discarded at the last element.
+    while IFS= read -r _pr; do
+        [ -n "${_pr}" ] || continue
+        printf '%s' "${_pr}" | _gh_pr_merge_train_has_review_passed_label || continue
+        printf '%s' "${_pr}" | _gh_pr_merge_train_has_review_blocked_label && continue
+        _n=$((_n + 1))
+    done <<EOF
+$(printf '%s' "$1" | jq -c '.[]?' 2>/dev/null)
+EOF
+
+    _PMT_ACTIONABLE_COUNT="${_n}"
+}
+
+# Record the pause the "nothing actionable" exit takes, so cron stops paying a
+# session per period for a queue only a human can unstick. Idempotent: an
+# already-paused job is left alone rather than rewritten every tick.
+#
+# A failed write warns instead of ending the tick — the tick's own verdict
+# (do not wake a session) is already correct without it, and the only cost is
+# that the next period re-derives the same answer. That is the pre-#1714
+# behaviour, i.e. the safe direction, unlike the backoff counter above whose
+# unwritten decrement would open an unbounded window.
+_pmt_pause_job() {
+    aicron_state_paused "${_PMT_AICRON_JOB}" && return 0
+
+    if ! aicron_state_ensure || ! aicron_state_set "${_PMT_AICRON_JOB}" paused true; then
+        ux_warning "Could not record the pause for aicron job ${_PMT_AICRON_JOB} — the next tick will judge the queue again."
+        return 1
+    fi
 }
 
 # ============================================================
@@ -1186,6 +1257,12 @@ _pmt_usage() {
     ux_bullet_sub "any fingerprint change (a merge, a push, a verdict label) resets it to 1 and wakes a session"
     ux_bullet_sub "the window always expires — a board promotion the fingerprint cannot see is still picked up"
     ux_bullet_sub "an unwritable state file runs the tick, never skips one — an unbounded window is worse than no backoff"
+    ux_bullet "nothing-actionable pause (#1714)"
+    ux_bullet_sub "actionable = the review-passed label and no review-blocked (BEHIND or pending CI still counts)"
+    ux_bullet_sub "zero actionable targets -> no session is woken; the aicron job ${_PMT_AICRON_JOB} is paused"
+    ux_bullet_sub "an empty queue is that same case, logged as 'No target PR'"
+    ux_bullet_sub "resume with: aicron resume ${_PMT_AICRON_JOB} (an already-paused job is not rewritten)"
+    ux_bullet_sub "--dry-run reports the judgement and never pauses"
     ux_bullet "state"
     ux_bullet_sub "\${XDG_STATE_HOME:-\$HOME/.local/state}/${_PMT_STATE_SUBDIR}/${_PMT_LOCK_BASENAME}   (tick lock, one per machine)"
     ux_bullet_sub "\${XDG_STATE_HOME:-\$HOME/.local/state}/${_PMT_STATE_SUBDIR}/${_PMT_BACKOFF_BASENAME}-<host>-<owner>-<repo>   (queue fingerprint + backoff window, one per target)"
@@ -1288,8 +1365,14 @@ main() {
             ux_error "gh pr list failed for ${_PMT_REPO} — a real tick would end here."
             exit 1
         fi
-        ux_success "Dry run — ${_PMT_REPO} on ${_PMT_HOST}: ${_PMT_TARGET_COUNT} target PR(s)."
-        ux_bullet "would prompt agent ${_agent} with /gh-pr-merge-train ${_PMT_REPO}"
+        ux_success "Dry run — ${_PMT_REPO} on ${_PMT_HOST}: ${_PMT_TARGET_COUNT} target PR(s), ${_PMT_ACTIONABLE_COUNT} actionable."
+        # Reported, never written: the probe stays read-only, so it can be run
+        # against a live schedule without pausing it (#1714).
+        if [ "${_PMT_ACTIONABLE_COUNT}" -eq 0 ]; then
+            ux_bullet "would pause aicron job ${_PMT_AICRON_JOB} and wake nothing (resume: aicron resume ${_PMT_AICRON_JOB})"
+        else
+            ux_bullet "would prompt agent ${_agent} with /gh-pr-merge-train ${_PMT_REPO}"
+        fi
         exit 0
     fi
 
@@ -1310,8 +1393,17 @@ main() {
         exit 0
     fi
     _target="${_PMT_TARGET_COUNT}"
-    if [ "${_target}" -eq 0 ]; then
-        ux_info "No target PR on ${_PMT_REPO} — nothing to wake a session for."
+    # An empty queue is the zero-actionable case with one target, so the two
+    # share the exit — but not the wording: "no candidates at all" and "every
+    # candidate is blocked or unreviewed" are different things to read in a cron
+    # log, and the second is the one that names a human's next move (#1714).
+    if [ "${_PMT_ACTIONABLE_COUNT}" -eq 0 ]; then
+        if [ "${_target}" -eq 0 ]; then
+            ux_info "No target PR on ${_PMT_REPO} — nothing to wake a session for; pausing aicron job ${_PMT_AICRON_JOB} (resume: aicron resume ${_PMT_AICRON_JOB})."
+        else
+            ux_info "No actionable PR among ${_target} target(s) on ${_PMT_REPO} — each is review-blocked or carries no verdict label; pausing aicron job ${_PMT_AICRON_JOB} (resume: aicron resume ${_PMT_AICRON_JOB})."
+        fi
+        _pmt_pause_job || :
         exit 0
     fi
 

--- a/tests/bats/tools/pr_merge_train_cron.bats
+++ b/tests/bats/tools/pr_merge_train_cron.bats
@@ -36,6 +36,9 @@ setup() {
     _STATE_HOME="${_WORK_DIR}/state"
     _STATE_DIR="${_STATE_HOME}/pr-merge-train"
     _LOCK_FILE="${_STATE_DIR}/.lock"
+    # The aicron job state the #1714 pause is written to. `aicron` keeps its
+    # own directory under the same XDG_STATE_HOME the tick already isolates.
+    _AICRON_STATE="${_STATE_HOME}/aicron/merge-train.json"
     # One backoff file per target, not per machine (PR #1719 review) — the name
     # is `<basename>-<host>-<owner>-<repo>` over _make_repo's origin.
     _BACKOFF_FILE="${_STATE_DIR}/backoff-github.com-acme-dotfiles"
@@ -116,11 +119,19 @@ _make_second_repo() {
 # for a given PR number*, so every pre-#1709 caller keeps describing one
 # unchanging PR — which is what lets the backoff tests vary exactly one field at
 # a time.
+#
+# `review-passed` is in the default labels because since #1714 an unlabelled PR
+# is not actionable and pauses the job instead of waking a session. Every test
+# whose subject is something else ("is this a target", "was the lock released")
+# needs its fixture to be a PR the train would really act on, or it would be
+# asserting the pause path by accident.
 _pr_json() {
-    local _stamp
+    local _stamp _labels="${6:-}"
+    [ -n "${_labels}" ] || _labels='[{"name":"review-passed"}]'
     _stamp=$(_epoch_to_iso "$(($(date +%s) - $2 * 60))") || fail "cannot format a timestamp on this platform"
     printf '{"number":%s,"updatedAt":"%s","isDraft":%s,"headRefOid":"%s","mergeStateStatus":"%s","labels":%s,"mergeable":"%s"}' \
-        "$1" "${_stamp}" "${3:-false}" "${4:-oid$1}" "${5:-BEHIND}" "${6:-[]}" "${7:-MERGEABLE}"
+        "$1" "${_stamp}" "${3:-false}" "${4:-oid$1}" "${5:-BEHIND}" \
+        "${_labels}" "${7:-MERGEABLE}"
 }
 
 # A `gh pr list --json` element whose `updatedAt` cannot be read — the raw JSON
@@ -675,10 +686,14 @@ _hold_lock() {
 
 # A verdict label flipping is the #1709 scenario in reverse: the queue that had
 # nothing to do suddenly has something to do, and must not wait out a window.
+#
+# PR 11 carries `review-passed` throughout so the queue stays actionable and the
+# tick reaches the backoff gate at all — since #1714 an all-blocked queue pauses
+# the job instead, which is a different test (below).
 @test "pr_merge_train_cron: a verdict label change resets the backoff" {
     _assert_change_wakes_train \
-        "[$(_pr_json 11 30 false oid11 BEHIND '[{"name":"review-blocked"}]')]" \
-        "[$(_pr_json 11 30 false oid11 BEHIND '[{"name":"review-passed"}]')]"
+        "[$(_pr_json 11 30),$(_pr_json 12 30 false oid12 BEHIND '[{"name":"review-blocked"}]')]" \
+        "[$(_pr_json 11 30),$(_pr_json 12 30 false oid12 BEHIND '[{"name":"review-passed"}]')]"
 }
 
 @test "pr_merge_train_cron: a mergeStateStatus change resets the backoff" {
@@ -749,8 +764,8 @@ _hold_lock() {
 # from `mergeable` itself (PR #1719 review, codex FOLLOW-UP).
 @test "pr_merge_train_cron: a mergeable change resets the backoff" {
     _assert_change_wakes_train \
-        "[$(_pr_json 11 30 false oid11 BLOCKED '[]' MERGEABLE)]" \
-        "[$(_pr_json 11 30 false oid11 BLOCKED '[]' CONFLICTING)]"
+        "[$(_pr_json 11 30 false oid11 BLOCKED '[{"name":"review-passed"}]' MERGEABLE)]" \
+        "[$(_pr_json 11 30 false oid11 BLOCKED '[{"name":"review-passed"}]' CONFLICTING)]"
 }
 
 # Two checkouts, two repos, one machine — the `--cwd` invocation the help text
@@ -773,6 +788,150 @@ _hold_lock() {
     assert_success
     assert_output --partial "Queue unchanged"
     _refute_train_started
+}
+
+# ---------------------------------------------------------------------------
+# Nothing-actionable pause (#1714)
+#
+# A queue can be full and still have nothing the train can move: every PR
+# `review-blocked`, or none reviewed at all. Waking a session for that is what
+# #1691/#1703 spent a dozen identical ticks on, so the tick pauses the aicron
+# job and leaves the restart to a human.
+# ---------------------------------------------------------------------------
+
+# The two labels, as `gh pr list --json labels` answers with them.
+_labels_json() {
+    printf '['
+    local _sep="" _l
+    for _l in "$@"; do
+        printf '%s{"name":"%s"}' "${_sep}" "${_l}"
+        _sep=","
+    done
+    printf ']'
+}
+
+_assert_paused() {
+    [ -f "${_AICRON_STATE}" ] || fail "expected an aicron state file at ${_AICRON_STATE}"
+    run jq -r '.paused' "${_AICRON_STATE}"
+    assert_output "true"
+}
+
+@test "pr_merge_train_cron: an all-blocked queue pauses instead of waking a session" {
+    _set_prs "[$(_pr_json 11 30 false oid11 BEHIND "$(_labels_json review-blocked)"),\
+$(_pr_json 12 30 false oid12 BEHIND "$(_labels_json review-blocked)")]"
+    _run_tick
+    assert_success
+    assert_output --partial "No actionable PR among 2 target(s)"
+    assert_output --partial "aicron resume merge-train"
+    _refute_train_started
+    _assert_paused
+}
+
+@test "pr_merge_train_cron: an unreviewed queue is not actionable either" {
+    _set_prs "[$(_pr_json 11 30 false oid11 BEHIND '[]')]"
+    _run_tick
+    assert_success
+    assert_output --partial "No actionable PR among 1 target(s)"
+    _refute_train_started
+    _assert_paused
+}
+
+# `review-blocked` wins over `review-passed`: a PR carrying both is exactly the
+# PR a reviewer has just re-blocked, and the label pair is how that arrives.
+@test "pr_merge_train_cron: a PR carrying both verdict labels is not actionable" {
+    _set_prs "[$(_pr_json 11 30 false oid11 BEHIND "$(_labels_json review-passed review-blocked)")]"
+    _run_tick
+    assert_success
+    assert_output --partial "No actionable PR"
+    _refute_train_started
+    _assert_paused
+}
+
+# An empty queue is the same verdict, but it keeps its own sentence — a cron log
+# has to distinguish "nobody has an open PR" from "the open PRs are stuck".
+@test "pr_merge_train_cron: an empty queue pauses under its own log line" {
+    _set_prs '[]'
+    _run_tick
+    assert_success
+    assert_output --partial "No target PR"
+    refute_output --partial "No actionable PR"
+    assert_output --partial "aicron resume merge-train"
+    _assert_paused
+}
+
+# The positive control: BEHIND, which is what the default fixture is, stays
+# actionable — the next tick's train is what rebases it.
+@test "pr_merge_train_cron: a review-passed target is actionable and writes no pause" {
+    _run_tick
+    assert_success
+    _assert_logged "herdr agent prompt"
+    refute_output --partial "No actionable PR"
+    [ ! -e "${_AICRON_STATE}" ]
+}
+
+@test "pr_merge_train_cron: one actionable PR carries a blocked sibling through" {
+    _set_prs "[$(_pr_json 11 30 false oid11 BEHIND "$(_labels_json review-blocked)"),\
+$(_pr_json 12 30)]"
+    _run_tick
+    assert_success
+    _assert_logged "herdr agent prompt"
+    [ ! -e "${_AICRON_STATE}" ]
+}
+
+# Idempotency: the pause is a human's flag once set, and a tick that rewrote it
+# every three minutes would churn the state file for no new information.
+@test "pr_merge_train_cron: an already-paused job is not written again" {
+    mkdir -p "$(dirname "${_AICRON_STATE}")"
+    printf '%s\n' '{"paused":true,"last_run":"marker"}' >"${_AICRON_STATE}"
+    local _before
+    _before=$(cat "${_AICRON_STATE}")
+
+    _set_prs "[$(_pr_json 11 30 false oid11 BEHIND '[]')]"
+    _run_tick
+    assert_success
+    _refute_train_started
+    assert_equal "$(cat "${_AICRON_STATE}")" "${_before}"
+}
+
+# A state directory the tick cannot write is not a reason to wake a session —
+# the verdict "nothing to do" is already correct without the record.
+@test "pr_merge_train_cron: an unwritable aicron state dir warns but still skips" {
+    [ "$(id -u)" -ne 0 ] || skip "running as root — file permissions do not bite"
+    mkdir -p "$(dirname "${_AICRON_STATE}")"
+    chmod 555 "$(dirname "${_AICRON_STATE}")"
+
+    _set_prs '[]'
+    _run_tick
+    assert_success
+    assert_output --partial "Could not record the pause"
+    _refute_train_started
+
+    chmod 755 "$(dirname "${_AICRON_STATE}")"
+}
+
+@test "pr_merge_train_cron: --dry-run reports the actionable count and pauses nothing" {
+    _set_prs "[$(_pr_json 11 30 false oid11 BEHIND "$(_labels_json review-blocked)")]"
+    _run_tick -- --dry-run
+    assert_success
+    assert_output --partial "1 target PR(s), 0 actionable"
+    assert_output --partial "would pause"
+    _refute_train_started
+    [ ! -e "${_AICRON_STATE}" ]
+}
+
+@test "pr_merge_train_cron: --dry-run on an actionable queue still reports the prompt" {
+    _run_tick -- --dry-run
+    assert_success
+    assert_output --partial "1 target PR(s), 1 actionable"
+    assert_output --partial "would prompt agent"
+    [ ! -e "${_AICRON_STATE}" ]
+}
+
+@test "pr_merge_train_cron: --help documents the pause and its resume command" {
+    run bash "${SCRIPT}" --help
+    assert_success
+    assert_output --partial "nothing-actionable pause"
+    assert_output --partial "aicron resume merge-train"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- merge-train 크론 디스패처가 큐가 진행 불가(전부 `review-blocked` 또는 미검증)여도 매 tick 세션을 깨우던 문제를 고친다.
- `_pmt_target_count` 가 이미 쥔 필터링 배열을 재사용해 actionable(=`review-passed` 단독) 개수를 함께 계산하고, 0이면 세션을 깨우지 않고 aicron 잡을 pause 한다.

## Changes
- `shell-common/tools/custom/pr_merge_train_cron.sh`: `aicron_state.sh` 를 hard dependency 로 소스, `_pmt_bind_actionable`(같은 필터링 배열 재사용, `gh_pr_merge_train.sh` 의 기존 label predicate 재사용 — jq 재구현 없음)과 `_pmt_pause_job`(idempotent, 이미 paused 면 재기록 없음) 추가. `main()` 의 기존 `target -eq 0` 분기를 `actionable -eq 0` 분기로 흡수하되 로그 문구는 두 케이스를 구분한다. `--dry-run` 은 actionable 개수만 보고하고 아무것도 쓰지 않는다. `--help` 에 새 동작을 문서화.
- `tests/bats/tools/pr_merge_train_cron.bats`: `_pr_json` 기본 라벨을 `review-passed` 로 바꿔(기존 대다수 테스트가 pause 경로로 새는 것 방지) 11개 회귀 테스트 추가 — all-blocked/미검증 큐 pause, `review-passed` 단독 유지, 혼재 큐에서 actionable 만 진행, 빈 큐도 pause, 이미 paused 면 재기록 없음, state dir 쓰기 실패 시 warn, `--dry-run` 판정만 출력, `--help` 문서화.

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 ./tests/bats/lib/bats-core/bin/bats tests/bats/tools/pr_merge_train_cron.bats` — 118/118 green (107 기존 + 11 신규), pre-existing 실패 없음.
- [x] `shellcheck shell-common/tools/custom/pr_merge_train_cron.sh` — clean.

## Related
Closes #1714

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~2 h · 🤖 ~20 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~2 h · 🤖 ~20 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUnQaRWsapTpk4g27WX8Nh
