### PR TITLE
feat(merge-train): quiet period가 train 자신이 방금 준비한 PR까지 배제하는 문제 해결

### DIFF
--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -40,9 +40,15 @@ the same remote URL (#1403/#1407). An explicit `owner/repo` positional pins
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_merge_train.sh"
-GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" --author @me --state open \
-  --limit 50 --json number,updatedAt,isDraft,mergeable,mergeStateStatus,baseRefName,title,labels \
-  | _gh_pr_merge_train_filter_targets --now "$(date +%s)"
+# One file per PR, holding the head sha THIS train pushed (#1708). Same
+# `--path-format=absolute` care `references/train-loop.md` → "Detached scratch
+# worktree" already documents for `--git-common-dir` — see there for why.
+STATE_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/pr-merge-train-pushed-sha"
+
+RAW=$(GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" --author @me --state open \
+  --limit 50 --json number,updatedAt,isDraft,mergeable,mergeStateStatus,baseRefName,title,labels,headRefOid)
+FILTERED=$(printf '%s' "$RAW" | _gh_pr_merge_train_filter_targets --now "$(date +%s)")
+QUEUE=$(printf '%s' "$RAW" | _gh_pr_merge_train_readmit_own_pushes "$STATE_DIR" "$FILTERED")
 ```
 
 `--author @me` is not optional (D-7) — never auto-merge a colleague's PR.
@@ -52,7 +58,20 @@ D-6 quiet period — the exact same function
 `shell-common/tools/custom/pr_merge_train_cron.sh` runs, so the two can never
 disagree. **Do not re-implement or paraphrase that filter here** — run it.
 
-Sort the surviving array `CLEAN` → `BEHIND` → `UNSTABLE` → `DIRTY`, ties by
+`_gh_pr_merge_train_readmit_own_pushes` is a **separate, additive second pass**
+that runs AFTER it and **never changes what the shared filter does** (#1708) —
+the dispatcher's own pre-check keeps calling the untouched filter alone. It
+re-admits only a PR the filter dropped *solely* for the quiet period whose
+current `headRefOid` is one this train recorded pushing in an earlier run's
+Step 4 remediation (`references/train-loop.md`); `reply-pending` and `isDraft`
+always win over it. `headRefOid` is in the `--json` list for this pass. Print
+one line per re-admitted PR so a PR that looks "too fresh" is not mysterious:
+
+```
+[INFO] gh:pr-merge-train: PR #<N> re-admitted — this train pushed its current head (#1708 D-6 exemption).
+```
+
+Sort `QUEUE` — the union, not `FILTERED` — `CLEAN` → `BEHIND` → `UNSTABLE` → `DIRTY`, ties by
 ascending PR number (D-2). Ordering, the label, and the quiet-period rationale:
 `references/ordering.md`.
 

--- a/claude/skills/gh-pr-merge-train/references/ordering.md
+++ b/claude/skills/gh-pr-merge-train/references/ordering.md
@@ -164,3 +164,42 @@ session on a queue that would come out empty. This skill re-runs the filter
 **authoritatively**, because minutes pass between that count and the moment
 each PR is actually processed, and a PR can be touched — or labelled — again
 in between. Same code, later clock.
+
+### Exemption — the train's own just-finished push (#1708)
+
+The quiet period asks "has outside work on this PR settled?", and `updatedAt`
+is its proxy for the answer. The proxy breaks when the train is the one that
+moved the PR: a Step 4 `BEHIND` / `DIRTY` remediation rebases and pushes the
+head, `updatedAt` becomes *now*, and the next queue build drops the PR the
+train just finished fixing. The tick after that re-remediates it and drops it
+again. Nothing is inbound on such a PR — there is nothing left to wait for.
+
+So a PR the filter dropped **solely** for the quiet period rejoins the queue
+when its current `headRefOid` is one this train recorded pushing:
+
+| Function | Where it runs | What it does |
+|---|---|---|
+| `_gh_pr_merge_train_record_pushed_sha` | `train-loop.md`, right after the remediation's re-query | stamps the head the atom just pushed as this train's own |
+| `_gh_pr_merge_train_readmit_own_pushes` | `SKILL.md` Step 2, after the filter | re-admits the PRs whose current head carries that stamp |
+| `_gh_pr_merge_train_forget_pushed_sha` | `train-loop.md` step 8, successful merge only | drops the record so the state dir stays bounded |
+
+**`_gh_pr_merge_train_filter_targets` is not touched by any of this.** The
+re-admission is a *second, additive pass over the same raw list*, never a new
+clause in the shared filter — which is the point: the filter is the one
+implementation this skill and the cron dispatcher both run, and the dispatcher
+has no business granting an exemption only the authoritative run can even
+record. The filter behaves identically for both callers, before and after
+#1708.
+
+`reply-pending` **always wins over the exemption** — a PR carrying it is never
+re-admitted, however certain the train is that it pushed the head itself,
+because the label answers a different question (is a reply pass still
+outstanding) that a rebase does nothing to settle. Plain label presence, no
+staleness window: expiry belongs to the label's own lifecycle, defined once by
+`_gh_pr_merge_train_reply_pending_stale_minutes` above and not re-derived here.
+Drafts are likewise never re-admitted — DRAFT is a D-1 skip row, not a
+quiet-period drop, so the exemption has nothing to release.
+
+A head that has moved past the recorded sha stops matching, and the quiet
+period stands: someone else's commit is on the branch now, which is exactly
+the case D-6 exists for.

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -268,13 +268,30 @@ just fixed, on every following tick, forever (`ordering.md` → "Exemption — t
 train's own just-finished push"). Right after step 5's mandatory re-query has
 refreshed `$STATE` (the atom's success alone proves nothing —
 `routing-table.md` → "After every remediation: re-query, do not assume"), stamp
-the head it now reports as this train's own:
+the head it now reports as this train's own — but **only when that re-query's
+head actually changed**:
 
 ```bash
-# Not dead code: this is what lets Step 2 re-admit the PR next tick (#1708).
-_gh_pr_merge_train_record_pushed_sha "$STATE_DIR" "<N>" \
-    "$(printf '%s' "$STATE" | jq -r '.headRefOid')" || true
+# $OLD_HEAD_OID is loop step 1's F-3 headRefOid, captured BEFORE the atom ran
+# (i.e. from the $STATE this same PR's iteration first read at the top of the
+# loop, not from a previous PR). A BEHIND row's atom (gh:pr-resolve-outdated)
+# has a documented no-op path — "already up to date" — that returns success
+# WITHOUT pushing anything (its own Step 2 mergeable-triage). Recording in that
+# case would stamp a head the train never touched as its own, and a later,
+# unrelated updatedAt bump on that same unchanged head (e.g. a label add) would
+# then wrongly clear the quiet period for it (codex, PR #1724 review, BLOCKER).
+NEW_HEAD_OID=$(printf '%s' "$STATE" | jq -r '.headRefOid')
+if [ "$NEW_HEAD_OID" != "$OLD_HEAD_OID" ]; then
+    # Not dead code: this is what lets Step 2 re-admit the PR next tick (#1708).
+    _gh_pr_merge_train_record_pushed_sha "$STATE_DIR" "<N>" "$NEW_HEAD_OID" || true
+fi
 ```
+
+`$OLD_HEAD_OID` must be bound at loop step 1 (F-3), right after the initial
+`gh pr view` for this PR's turn (`routing-table.md` → "Reading the state") —
+`OLD_HEAD_OID=$(printf '%s' "$STATE" | jq -r '.headRefOid')` — before step 4's
+remediation runs. Comparing against a stale value from a previous PR's
+iteration would defeat the guard; each PR's turn binds its own.
 
 `$STATE_DIR` is the variable Step 2 bound, threaded across these reference
 files the same way `$TARGET_REPO` / `$TARGET_HOST` already are — same run, same

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -24,12 +24,19 @@ For each PR `N` in the Step 2 queue order:
    and `DIRTY` rows that means the scratch-worktree sequence below, not a bare
    `Skill(...)` call.
 5. **Re-query and re-route.** An atom returning success does not prove the PR
-   is mergeable now.
+   is mergeable now. On the `BEHIND` / `DIRTY` rows, that re-query is also what
+   records the sha this train just pushed — see "Recording the push" below.
 6. **Merge** — `Skill(gh:pr-merge, "<N>")`. No strategy argument (D-4).
 7. **Close the merged PR's implementation tab** — only on a successful merge,
    only when that tab is `idle`. The block is below ("Closing the merged PR's
    implementation tab").
-8. **Record** the outcome and continue.
+8. **Record** the outcome and continue. After a **successful** merge only, drop
+   that PR's pushed-sha record — otherwise the state dir grows one file per
+   merged PR forever (#1708). Best-effort; it can never fail the merge:
+
+   ```bash
+   _gh_pr_merge_train_forget_pushed_sha "$STATE_DIR" "<N>" || true
+   ```
 
 ## Closing the merged PR's implementation tab (step 7, #1565)
 
@@ -252,6 +259,28 @@ The atom runs every git command as `git -C "$SCRATCH_DIR" ...` and pushes with
 an explicit refspec (`HEAD:refs/heads/<head>`), because a detached HEAD has no
 upstream to infer. That contract is the atoms' own — see their
 `references/preflight.md` / `references/rebase-flow.md`.
+
+### Recording the push (#1708)
+
+The atom's push bumps this PR's `updatedAt` to *now*, so the next Step 2 queue
+build would drop it inside the D-6 quiet period — the train excluding the PR it
+just fixed, on every following tick, forever (`ordering.md` → "Exemption — the
+train's own just-finished push"). Right after step 5's mandatory re-query has
+refreshed `$STATE` (the atom's success alone proves nothing —
+`routing-table.md` → "After every remediation: re-query, do not assume"), stamp
+the head it now reports as this train's own:
+
+```bash
+# Not dead code: this is what lets Step 2 re-admit the PR next tick (#1708).
+_gh_pr_merge_train_record_pushed_sha "$STATE_DIR" "<N>" \
+    "$(printf '%s' "$STATE" | jq -r '.headRefOid')" || true
+```
+
+`$STATE_DIR` is the variable Step 2 bound, threaded across these reference
+files the same way `$TARGET_REPO` / `$TARGET_HOST` already are — same run, same
+turn sequence, no export mechanism of its own. Failing to record costs only the
+exemption, never the remediation: continue routing through the D-1 table
+either way.
 
 ### Teardown — the one exception
 

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -628,7 +628,14 @@ _gh_pr_merge_train_review_passed_stale() {
 #        above), and re-deriving it here would be a second definition of it.
 #        The check reuses `_gh_pr_merge_train_has_reply_pending_label` rather
 #        than re-writing its jq, for the same reason F-3 does;
-#     4. `.headRefOid` matches this train's recorded push for that PR.
+#     4. `.updatedAt` is present and parseable. Without this check a PR the
+#        shared filter dropped for its OWN fail-closed reason (rule 3 above:
+#        missing/unparseable `updatedAt`, never the ordinary quiet-period
+#        timing) could still be re-admitted on a sha match, silently
+#        overriding a data-integrity refusal this pass has no business
+#        overriding (codex, PR #1724 review, BLOCKER) — this pass may only
+#        undo the ordinary timing drop, never the fail-closed one;
+#     5. `.headRefOid` matches this train's recorded push for that PR.
 #   In other words: the ONLY thing this pass can undo is a drop caused SOLELY
 #   by the quiet period, on a head the train itself put there.
 #
@@ -709,7 +716,10 @@ _gh_pr_merge_train_readmit_own_pushes() {
         [ -n "$_elem" ] || continue
         _num=$(printf '%s' "$_elem" | jq -r '.number // empty' 2>/dev/null)
         case "$_num" in
-            '' | *[!0-9]*) continue ;;
+            '' | *[!0-9]*)
+                printf '[gh-pr-merge-train] readmit: skipping a raw element with no numeric .number\n' >&2
+                continue
+                ;;
         esac
         # 1. already a target on its own merit — nothing was dropped.
         printf '%s' "$_filtered" | jq -e --argjson n "$_num" \
@@ -718,7 +728,11 @@ _gh_pr_merge_train_readmit_own_pushes() {
         printf '%s' "$_elem" | jq -e '(.isDraft // false)' >/dev/null 2>&1 && continue
         # 3. the label always wins (#1708 AC2).
         printf '%s' "$_elem" | _gh_pr_merge_train_has_reply_pending_label && continue
-        # 4. is this head the one the train itself pushed?
+        # 4. only undo the ORDINARY quiet-period drop, never the shared
+        # filter's own fail-closed one (missing/unparseable updatedAt).
+        printf '%s' "$_elem" | jq -e '((.updatedAt // "") | fromdateiso8601?) != null' \
+            >/dev/null 2>&1 || continue
+        # 5. is this head the one the train itself pushed?
         _gh_pr_merge_train_pushed_sha_matches "$_dir" "$_num" \
             "$(printf '%s' "$_elem" | jq -r '.headRefOid // empty' 2>/dev/null)" || continue
         printf '%s\n' "$_num"

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -21,6 +21,10 @@
 #   <one gh-pr-view JSON object> | _gh_pr_merge_train_has_reply_pending_label
 #   <one gh-pr-view JSON object> | _gh_pr_merge_train_has_review_blocked_label
 #   <one gh-pr-view JSON object> | _gh_pr_merge_train_has_review_passed_label
+#   _gh_pr_merge_train_record_pushed_sha <state-dir> <pr> <sha>
+#   _gh_pr_merge_train_pushed_sha_matches <state-dir> <pr> <sha>
+#   _gh_pr_merge_train_forget_pushed_sha <state-dir> <pr>
+#   <raw gh-pr-list JSON array> | _gh_pr_merge_train_readmit_own_pushes <state-dir> <filtered-json>
 #
 # `_gh_pr_merge_train_quiet_minutes`
 #   Echo the quiet period in minutes. Default 11; override with the env var
@@ -547,6 +551,190 @@ _gh_pr_merge_train_review_passed_stale() {
     return 2
 }
 
+# The train's own pushes — a quiet-period exemption (issue #1708).
+#
+# The D-6 quiet period drops any PR whose `updatedAt` is too recent, because a
+# deferred `gh:pr-reply` pass (scheduled 4 minutes after the PR opens, by
+# `gh:issue-flow` Step 2.4's `--defer-reply 4`) may still be inbound. That is
+# the right default for work arriving from OUTSIDE the train. It is exactly
+# wrong for work the train did ITSELF: a Step 4 `BEHIND`/`DIRTY` remediation
+# rebases and pushes the PR, which bumps `updatedAt` to "just now", so the very
+# next Step 2 queue build drops the PR the train just finished fixing — and the
+# next tick repeats the whole remediation, forever. Nothing is pending on such
+# a PR; there is nothing left for the quiet period to wait for.
+#
+# The fix is deliberately an ADDITIVE SECOND PASS, not a new clause in
+# `_gh_pr_merge_train_filter_targets`. That filter is the one implementation
+# this skill and `shell-common/tools/custom/pr_merge_train_cron.sh` both run
+# (#1524), and the whole value of it is that the two callers cannot disagree —
+# the dispatcher's cheap "is there anything worth waking a session for"
+# pre-check has no business granting this exemption, since only the
+# authoritative skill run records the pushes in the first place. So the filter
+# stays untouched and byte-for-byte the same for both callers, and the skill
+# alone re-admits, over the SAME raw list, the PRs it can prove it pushed.
+#
+# "Can prove it pushed" is a tiny piece of state: one file per PR under a
+# caller-supplied directory (`SKILL.md` Step 2 binds it under the git common
+# dir), holding the head sha the train pushed. The directory is a PARAMETER,
+# never resolved internally via `git`, for the same reason `--now` is required
+# above: these functions stay pure and the bats suite tests them without
+# mocking anything external.
+#
+# `_gh_pr_merge_train_record_pushed_sha <state-dir> <pr> <sha>`
+#   Write `<sha>` as "the head this train pushed for `<pr>`", creating
+#   `<state-dir>` if needed. Called from `references/train-loop.md`'s
+#   remediation path, right after the mandatory post-remediation re-query has
+#   confirmed the new head. Best-effort: rc 1 on a usage error or an
+#   unwritable state dir (one stderr line, so a broken dir is not invisible
+#   forever), and the caller ignores it — a failure to record only costs the
+#   exemption, never the merge.
+#
+# `_gh_pr_merge_train_pushed_sha_matches <state-dir> <pr> <sha>`
+#   Predicate, no stdout, same shape as the label predicates above. rc 0 iff a
+#   record exists for `<pr>` and equals `<sha>` exactly. rc 1 for: no record,
+#   a different sha (the head moved past what the train pushed — someone
+#   else's commit is on it now and the quiet period must stand), or a `<sha>`
+#   that is empty or the literal string `null` (`jq -r '.headRefOid'` on a
+#   missing field emits `null`, which is the caller's unresolved state, never
+#   evidence — the same fail-closed reading `_gh_pr_merge_train_review_passed_stale`
+#   applies to its own `<head-oid>`).
+#
+# `_gh_pr_merge_train_forget_pushed_sha <state-dir> <pr>`
+#   Drop the record. Called after a successful merge so the state dir does not
+#   grow one file per merged PR forever. Always rc 0 unless `<pr>` is invalid:
+#   removing a record that was never written is not an error.
+#
+#   All three validate `<pr>` against `^[0-9]+$` and refuse anything else,
+#   because `<pr>` becomes a path component — same fail-closed posture as the
+#   login validator in `_gh_pr_merge_train_review_passed_marker_sha`.
+#
+# `_gh_pr_merge_train_readmit_own_pushes <state-dir> <filtered-json>`
+#   The pass itself. Reads the RAW `gh pr list --json ...` array on stdin —
+#   the same array `_gh_pr_merge_train_filter_targets` was given, except it
+#   MUST also carry `headRefOid` (this function needs it; the shared filter
+#   never reads it) — and takes that filter's own output as `<filtered-json>`.
+#   Echoes `<filtered-json>` with the exempt elements APPENDED, unmodified and
+#   whole (same "never project fields away" rule the filter follows). Order is
+#   irrelevant: Step 2's D-2 sort runs over the union afterwards.
+#
+#   An element is re-admitted only when ALL of these hold:
+#     1. it is not already in `<filtered-json>` — never duplicate an element
+#        that survived the ordinary filter on its own;
+#     2. `.isDraft` is not true — DRAFT is a skip row in the D-1 table, not a
+#        quiet-period drop, so there is nothing here to release;
+#     3. it does not carry `reply-pending` — the label ALWAYS wins over this
+#        exemption (#1708 AC2). Simple presence, no staleness window: label
+#        expiry is `_gh_pr_merge_train_filter_targets`'s own business (rule 2
+#        above), and re-deriving it here would be a second definition of it.
+#        The check reuses `_gh_pr_merge_train_has_reply_pending_label` rather
+#        than re-writing its jq, for the same reason F-3 does;
+#     4. `.headRefOid` matches this train's recorded push for that PR.
+#   In other words: the ONLY thing this pass can undo is a drop caused SOLELY
+#   by the quiet period, on a head the train itself put there.
+#
+#   Return codes mirror the shared filter's: 0 with the array on stdout, 1 on
+#   a usage error or unparsable input (nothing on stdout).
+#
+#   A shell loop plus a per-element `jq`, not one jq expression, because
+#   conditions 3 and 4 are shell functions — jq cannot call them, and
+#   re-deriving them inline is exactly the drift this file exists to prevent.
+
+_gh_pr_merge_train_record_pushed_sha() {
+    local _dir="${1-}" _pr="${2-}" _sha="${3-}"
+
+    case "$_pr" in
+        '' | *[!0-9]*)
+            printf '[gh-pr-merge-train] refusing to record a pushed sha for a non-numeric PR: %s\n' \
+                "$_pr" >&2
+            return 1
+            ;;
+    esac
+    if [ -z "$_dir" ]; then
+        printf '[gh-pr-merge-train] usage: _gh_pr_merge_train_record_pushed_sha <state-dir> <pr> <sha>\n' >&2
+        return 1
+    fi
+
+    if ! mkdir -p "$_dir" 2>/dev/null || ! printf '%s\n' "$_sha" >"$_dir/$_pr" 2>/dev/null; then
+        printf '[gh-pr-merge-train] could not record the pushed sha for PR %s under %s — the D-6 exemption (#1708) will not apply.\n' \
+            "$_pr" "$_dir" >&2
+        return 1
+    fi
+}
+
+_gh_pr_merge_train_pushed_sha_matches() {
+    local _dir="${1-}" _pr="${2-}" _sha="${3-}" _recorded
+
+    case "$_pr" in
+        '' | *[!0-9]*) return 1 ;;
+    esac
+    case "$_sha" in
+        '' | null) return 1 ;;
+    esac
+    [ -n "$_dir" ] || return 1
+    [ -f "$_dir/$_pr" ] || return 1
+
+    # `$(...)` strips the trailing newline the recorder writes.
+    _recorded=$(cat "$_dir/$_pr" 2>/dev/null) || return 1
+    [ "$_recorded" = "$_sha" ]
+}
+
+_gh_pr_merge_train_forget_pushed_sha() {
+    local _dir="${1-}" _pr="${2-}"
+
+    case "$_pr" in
+        '' | *[!0-9]*) return 1 ;;
+    esac
+    [ -n "$_dir" ] || return 1
+
+    rm -f "$_dir/$_pr" 2>/dev/null
+    return 0
+}
+
+_gh_pr_merge_train_readmit_own_pushes() {
+    local _dir="${1-}" _filtered="${2-}" _raw _nums _out
+
+    if [ -z "$_dir" ] || [ -z "$_filtered" ]; then
+        printf '[gh-pr-merge-train] usage: _gh_pr_merge_train_readmit_own_pushes <state-dir> <filtered-json>\n' >&2
+        return 1
+    fi
+
+    _raw=$(cat)
+    [ -n "$_raw" ] || return 1
+    printf '%s' "$_raw" | jq -e 'type == "array"' >/dev/null 2>&1 || return 1
+
+    # The four conditions, per element. The loop runs in a subshell (it is the
+    # tail of a pipeline), so it carries its verdict out as PR numbers on
+    # stdout rather than by mutating a variable.
+    _nums=$(printf '%s' "$_raw" | jq -c '.[]?' | while IFS= read -r _elem; do
+        [ -n "$_elem" ] || continue
+        _num=$(printf '%s' "$_elem" | jq -r '.number // empty' 2>/dev/null)
+        case "$_num" in
+            '' | *[!0-9]*) continue ;;
+        esac
+        # 1. already a target on its own merit — nothing was dropped.
+        printf '%s' "$_filtered" | jq -e --argjson n "$_num" \
+            'any(.[]?; .number == $n)' >/dev/null 2>&1 && continue
+        # 2. drafts are a D-1 skip row, not a quiet-period drop.
+        printf '%s' "$_elem" | jq -e '(.isDraft // false)' >/dev/null 2>&1 && continue
+        # 3. the label always wins (#1708 AC2).
+        printf '%s' "$_elem" | _gh_pr_merge_train_has_reply_pending_label && continue
+        # 4. is this head the one the train itself pushed?
+        _gh_pr_merge_train_pushed_sha_matches "$_dir" "$_num" \
+            "$(printf '%s' "$_elem" | jq -r '.headRefOid // empty' 2>/dev/null)" || continue
+        printf '%s\n' "$_num"
+    done)
+
+    # `--argjson filtered` also validates it: an unparsable argument fails the
+    # whole call rather than answering with a half-built queue.
+    _out=$(printf '%s' "$_raw" | jq -c --argjson filtered "$_filtered" --arg nums "$_nums" '
+        ($nums | split("\n") | map(select(length > 0) | tonumber)) as $keep
+        | $filtered + [ .[]? | select(.number as $n | $keep | index($n)) ]
+    ' 2>/dev/null) || return 1
+    [ -n "$_out" ] || return 1
+
+    printf '%s\n' "$_out"
+}
+
 # Self-check (issue #724): catch silent breakage where this file sources
 # cleanly but its public functions never get defined — an interactive-guard
 # regression, a syntax error mid-file, a future rename. Both call sites treat a
@@ -560,7 +748,11 @@ for _gh_pmt_selfcheck_fn in \
     _gh_pr_merge_train_has_review_blocked_label \
     _gh_pr_merge_train_has_review_passed_label \
     _gh_pr_merge_train_review_passed_marker_sha \
-    _gh_pr_merge_train_review_passed_stale; do
+    _gh_pr_merge_train_review_passed_stale \
+    _gh_pr_merge_train_record_pushed_sha \
+    _gh_pr_merge_train_pushed_sha_matches \
+    _gh_pr_merge_train_forget_pushed_sha \
+    _gh_pr_merge_train_readmit_own_pushes; do
     command -v "$_gh_pmt_selfcheck_fn" >/dev/null 2>&1 && continue
     printf '[gh_pr_merge_train] BUG: %s undefined after source — the merge-train target filter will not run. See dotfiles #724 / #1524.\n' \
         "$_gh_pmt_selfcheck_fn" >&2

--- a/tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats
+++ b/tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats
@@ -208,6 +208,42 @@ _readmit_numbers() {
 
 # AC2: the label always wins. A deferred reply pass is outstanding whatever the
 # train did to the branch.
+# codex, PR #1724 review, BLOCKER: an element the shared filter dropped for
+# its OWN fail-closed reason (unreadable `updatedAt`) must never be readmitted
+# on a sha match alone — that would silently override a data-integrity refusal
+# this pass has no business overriding. Only the ordinary quiet-period drop
+# (readable, recent `updatedAt`) may be undone.
+@test "own_push: a PR with no updatedAt at all is never readmitted, even with a matching sha" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers \
+        '[{"number":11,"headRefOid":"deadbeef","isDraft":false,"labels":[]}]' '[]'
+    assert_success
+    assert_output ""
+}
+
+@test "own_push: a null updatedAt is never readmitted, even with a matching sha" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers \
+        '[{"number":11,"updatedAt":null,"headRefOid":"deadbeef","isDraft":false,"labels":[]}]' '[]'
+    assert_success
+    assert_output ""
+}
+
+@test "own_push: an unparseable updatedAt is never readmitted, even with a matching sha" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers \
+        '[{"number":11,"updatedAt":"not-a-timestamp","headRefOid":"deadbeef","isDraft":false,"labels":[]}]' '[]'
+    assert_success
+    assert_output ""
+}
+
+@test "own_push: an invalid raw element with no numeric number warns to stderr and is skipped" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run bash -c "printf '%s' '[{\"headRefOid\":\"deadbeef\",\"isDraft\":false,\"labels\":[]}]' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}' '[]'; }"
+    assert_success
+    assert_output --partial "no numeric .number"
+}
+
 @test "own_push: reply-pending blocks the exemption" {
     _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
     run _readmit_numbers \
@@ -327,5 +363,27 @@ _readmit_numbers() {
 # callers run is untouched by this feature.
 @test "own_push: ordering.md still names the shared filter as unchanged" {
     run grep -qF -- "_gh_pr_merge_train_filter_targets" "${TRAIN_ORDERING}"
+    assert_success
+}
+
+# codex, PR #1724 review, FOLLOW-UP: the re-admission INFO line had no defined
+# format anywhere a future edit would notice it drifted. Pin the exact string.
+@test "own_push: SKILL.md pins the re-admission INFO line format" {
+    run grep -qF -- \
+        "[INFO] gh:pr-merge-train: PR #<N> re-admitted — this train pushed its current head (#1708 D-6 exemption)." \
+        "${TRAIN_SKILL}"
+    assert_success
+}
+
+# codex, PR #1724 review, BLOCKER: recording must be conditioned on the head
+# having actually changed, not fired unconditionally after every remediation —
+# a no-op atom (e.g. gh:pr-resolve-outdated's "already up to date" path) must
+# never be recorded as a push the train made.
+@test "own_push: train-loop.md only records when the head actually changed" {
+    run grep -qF -- "NEW_HEAD_OID" "${TRAIN_LOOP}"
+    assert_success
+    run grep -qF -- "OLD_HEAD_OID" "${TRAIN_LOOP}"
+    assert_success
+    run grep -qE -- '\[ "\$NEW_HEAD_OID" != "\$OLD_HEAD_OID" \]' "${TRAIN_LOOP}"
     assert_success
 }

--- a/tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats
+++ b/tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats
+# Tests for the quiet-period exemption the train grants its OWN pushes (#1708).
+#
+# The D-6 quiet period drops any PR whose `updatedAt` is too recent, because a
+# deferred `gh:pr-reply` pass may still be inbound. But when the train ITSELF is
+# what just touched the PR — a Step 4 `BEHIND`/`DIRTY` remediation pushed a
+# rebase — there is nothing left to wait for, and the PR is dropped forever on
+# every following tick. The fix is an ADDITIVE second pass over the same raw
+# list, never a change to `_gh_pr_merge_train_filter_targets` (AC3): that filter
+# is the SSOT both this skill and the cron dispatcher run, and
+# tests/bats/skills/gh_pr_merge_train_quiet_period.bats still pins its behaviour
+# unchanged.
+#
+# Same purity rule as the sibling suite: the state directory is a parameter, so
+# nothing here mocks `git`, `date` or a real git-common-dir.
+
+load '../test_helper'
+
+HELPER="${DOTFILES_ROOT}/shell-common/functions/gh_pr_merge_train.sh"
+TRAIN_SKILL="${DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/SKILL.md"
+TRAIN_LOOP="${DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/references/train-loop.md"
+TRAIN_ORDERING="${DOTFILES_ROOT}/claude/skills/gh-pr-merge-train/references/ordering.md"
+
+setup() {
+    _NOW=1800000000
+    STATE_DIR=$(mktemp -d)
+    # shellcheck source=/dev/null
+    . "${HELPER}"
+}
+
+teardown() {
+    [ -n "${STATE_DIR}" ] && rm -rf "${STATE_DIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures — same shape as gh_pr_merge_train_quiet_period.bats's `_pr`, plus
+# the `headRefOid` field this pass needs (the shared filter never reads it).
+# ---------------------------------------------------------------------------
+
+# PR <1>, updated <2> minutes before _NOW, head sha <3>, draft <4> (default
+# false), labels <5> (raw JSON array, default `[]`).
+_pr_oid() {
+    local _stamp
+    _stamp=$(_epoch_to_iso "$((_NOW - $2 * 60))") \
+        || fail "cannot format a timestamp on this platform"
+    printf '{"number":%s,"updatedAt":"%s","headRefOid":"%s","isDraft":%s,"labels":%s,"mergeStateStatus":"CLEAN"}' \
+        "$1" "${_stamp}" "$3" "${4:-false}" "${5:-[]}"
+}
+
+# RAW on stdin, `<filtered-json>` as the argument — the real call shape.
+_readmit() {
+    printf '%s' "$1" | _gh_pr_merge_train_readmit_own_pushes "${STATE_DIR}" "$2"
+}
+
+_readmit_numbers() {
+    _readmit "$1" "$2" | jq -r '.[].number'
+}
+
+# ---------------------------------------------------------------------------
+# Sanity
+# ---------------------------------------------------------------------------
+
+@test "own_push: sourcing defines all four new functions" {
+    run bash -c ". '${HELPER}' && command -v _gh_pr_merge_train_record_pushed_sha && command -v _gh_pr_merge_train_pushed_sha_matches && command -v _gh_pr_merge_train_forget_pushed_sha && command -v _gh_pr_merge_train_readmit_own_pushes"
+    assert_success
+}
+
+# ---------------------------------------------------------------------------
+# The state store — record / match / forget
+# ---------------------------------------------------------------------------
+
+@test "own_push: a recorded sha matches itself" {
+    run _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    assert_success
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 deadbeef
+    assert_success
+}
+
+@test "own_push: a recorded sha does not match a different sha" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 cafebabe
+    assert_failure
+}
+
+@test "own_push: no record at all does not match" {
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 deadbeef
+    assert_failure
+}
+
+# A recorded sha is per-PR: PR 12's record must never answer for PR 11.
+@test "own_push: a record for another PR does not match" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 12 deadbeef
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 deadbeef
+    assert_failure
+}
+
+@test "own_push: an empty or null sha never matches" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 ""
+    assert_failure
+    # `jq -r '.headRefOid'` on a missing field emits the STRING `null` — a
+    # caller's unresolved state, never evidence that this train pushed it.
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 null
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 null
+    assert_failure
+}
+
+@test "own_push: recording creates the state dir when it does not exist" {
+    local _nested="${STATE_DIR}/does/not/exist/yet"
+    run _gh_pr_merge_train_record_pushed_sha "${_nested}" 11 deadbeef
+    assert_success
+    run _gh_pr_merge_train_pushed_sha_matches "${_nested}" 11 deadbeef
+    assert_success
+}
+
+@test "own_push: re-recording replaces the previous sha" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 cafebabe
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 deadbeef
+    assert_failure
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 cafebabe
+    assert_success
+}
+
+@test "own_push: forgetting a record stops it matching" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _gh_pr_merge_train_forget_pushed_sha "${STATE_DIR}" 11
+    assert_success
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" 11 deadbeef
+    assert_failure
+}
+
+# Cleanup runs after a merge, best-effort — a record that was never written (or
+# already gone) is not an error the train should ever notice.
+@test "own_push: forgetting a nonexistent record still succeeds" {
+    run _gh_pr_merge_train_forget_pushed_sha "${STATE_DIR}" 11
+    assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Path safety — `<pr>` becomes a path component, so it is validated fail-closed
+# in all three, the same posture as the login validator in
+# `_gh_pr_merge_train_review_passed_marker_sha`.
+# ---------------------------------------------------------------------------
+
+@test "own_push: record rejects a non-numeric PR number" {
+    run _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" "../escape" deadbeef
+    assert_failure
+    [ ! -e "${STATE_DIR}/../escape" ] || fail "wrote outside the state dir"
+}
+
+@test "own_push: matches rejects a non-numeric PR number" {
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" "../escape" deadbeef
+    assert_failure
+}
+
+@test "own_push: forget rejects a non-numeric PR number" {
+    run _gh_pr_merge_train_forget_pushed_sha "${STATE_DIR}" "11 12"
+    assert_failure
+}
+
+@test "own_push: an empty PR number is rejected everywhere" {
+    run _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" "" deadbeef
+    assert_failure
+    run _gh_pr_merge_train_pushed_sha_matches "${STATE_DIR}" "" deadbeef
+    assert_failure
+    run _gh_pr_merge_train_forget_pushed_sha "${STATE_DIR}" ""
+    assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# The readmission pass
+# ---------------------------------------------------------------------------
+
+# The #1708 case itself: the train rebased and pushed this PR on an earlier
+# run, so `updatedAt` is "just now" and the shared filter dropped it — but the
+# sha it carries is the one the train pushed, so nothing is pending on it.
+@test "own_push: a PR dropped only by the quiet period is readmitted" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers "[$(_pr_oid 11 2 deadbeef)]" '[]'
+    assert_success
+    assert_output "11"
+}
+
+@test "own_push: a readmitted PR passes through unchanged" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run bash -c "printf '%s' '[$(_pr_oid 11 2 deadbeef)]' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}' '[]'; } | jq -c '.[0]'"
+    assert_success
+    assert_output --partial '"mergeStateStatus":"CLEAN"'
+    assert_output --partial '"headRefOid":"deadbeef"'
+}
+
+@test "own_push: a PR with no recorded sha stays excluded" {
+    run _readmit_numbers "[$(_pr_oid 11 2 deadbeef)]" '[]'
+    assert_success
+    assert_output ""
+}
+
+# The head moved past what the train pushed — someone else's commit is on it
+# now, so the quiet period is doing exactly its job and must stand.
+@test "own_push: a stale recorded sha does not readmit" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers "[$(_pr_oid 11 2 cafebabe)]" '[]'
+    assert_success
+    assert_output ""
+}
+
+# AC2: the label always wins. A deferred reply pass is outstanding whatever the
+# train did to the branch.
+@test "own_push: reply-pending blocks the exemption" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers \
+        "[$(_pr_oid 11 2 deadbeef false '[{"name":"reply-pending"}]')]" '[]'
+    assert_success
+    assert_output ""
+}
+
+@test "own_push: an unrelated label does not block the exemption" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers \
+        "[$(_pr_oid 11 2 deadbeef false '[{"name":"enhancement"}]')]" '[]'
+    assert_success
+    assert_output "11"
+}
+
+# DRAFT is a skip row in the D-1 table — never a quiet-period drop, so the
+# exemption has nothing to release.
+@test "own_push: a draft is never readmitted" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers "[$(_pr_oid 11 2 deadbeef true)]" '[]'
+    assert_success
+    assert_output ""
+}
+
+@test "own_push: a PR already in the filtered array is not duplicated" {
+    local _p
+    _p=$(_pr_oid 11 30 deadbeef)
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run _readmit_numbers "[${_p}]" "[${_p}]"
+    assert_success
+    assert_output "11"
+}
+
+@test "own_push: nothing to readmit leaves the filtered array as it was" {
+    run _readmit "[$(_pr_oid 11 2 deadbeef)]" '[]'
+    assert_success
+    assert_output "[]"
+}
+
+@test "own_push: an empty raw array leaves the filtered array as it was" {
+    local _p
+    _p=$(_pr_oid 12 30 cafebabe)
+    run _readmit_numbers '[]' "[${_p}]"
+    assert_success
+    assert_output "12"
+}
+
+# The pass is additive: what the filter kept survives alongside what this
+# readmits, and the D-2 sort in Step 2 runs over the union afterwards.
+@test "own_push: readmitted PRs are appended to the filtered ones" {
+    _gh_pr_merge_train_record_pushed_sha "${STATE_DIR}" 11 deadbeef
+    run bash -c "printf '%s' '[$(_pr_oid 11 2 deadbeef),$(_pr_oid 12 30 cafebabe)]' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}' '[$(_pr_oid 12 30 cafebabe)]'; } | jq -r '.[].number' | sort"
+    assert_success
+    assert_output "11
+12"
+}
+
+# ---------------------------------------------------------------------------
+# Usage errors — rc 1, nothing on stdout (same posture as the shared filter)
+# ---------------------------------------------------------------------------
+
+@test "own_push: readmit with missing arguments fails" {
+    run bash -c "printf '%s' '[]' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}'; }"
+    assert_failure
+}
+
+@test "own_push: readmit refuses unparseable raw stdin" {
+    run bash -c "printf '%s' 'not json' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}' '[]'; }"
+    assert_failure
+}
+
+@test "own_push: readmit refuses an unparseable filtered argument" {
+    run bash -c "printf '%s' '[]' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}' 'not json'; }"
+    assert_failure
+}
+
+@test "own_push: readmit refuses empty stdin" {
+    run bash -c "printf '' | { . '${HELPER}'; _gh_pr_merge_train_readmit_own_pushes '${STATE_DIR}' '[]'; }"
+    assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# Drift guard — the wiring is what makes any of this reachable
+# ---------------------------------------------------------------------------
+#
+# Both halves live in prose executed by an LLM, so a future edit can drop them
+# without touching a line of shell. Same spirit as the quiet-period suite's own
+# drift guard on `_gh_pr_merge_train_filter_targets`.
+
+@test "own_push: SKILL.md Step 2 runs the readmission pass" {
+    run grep -qF -- "_gh_pr_merge_train_readmit_own_pushes" "${TRAIN_SKILL}"
+    assert_success
+}
+
+@test "own_push: SKILL.md still asks gh pr list for headRefOid" {
+    run grep -qE -- '--json [^|]*headRefOid' "${TRAIN_SKILL}"
+    assert_success
+}
+
+@test "own_push: train-loop.md records the sha the remediation pushed" {
+    run grep -qF -- "_gh_pr_merge_train_record_pushed_sha" "${TRAIN_LOOP}"
+    assert_success
+}
+
+@test "own_push: train-loop.md forgets the record after a merge" {
+    run grep -qF -- "_gh_pr_merge_train_forget_pushed_sha" "${TRAIN_LOOP}"
+    assert_success
+}
+
+@test "own_push: ordering.md documents the D-6 exemption" {
+    run grep -qF -- "_gh_pr_merge_train_readmit_own_pushes" "${TRAIN_ORDERING}"
+    assert_success
+}
+
+# AC3 made visible in the doc, not only true in code: the shared filter both
+# callers run is untouched by this feature.
+@test "own_push: ordering.md still names the shared filter as unchanged" {
+    run grep -qF -- "_gh_pr_merge_train_filter_targets" "${TRAIN_ORDERING}"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- `gh:pr-merge-train`의 D-6 quiet period(11분)가 train 자신이 remediation으로 이미
  push해 놓은 PR까지 매 tick 다시 배제하던 문제를 고친다.
- 공유 필터 `_gh_pr_merge_train_filter_targets`(cron dispatcher와 공유되는 SSOT)는
  전혀 건드리지 않고, Step 2 필터 뒤에 별도의 추가(additive) 재편입 패스를 둔다.

## Changes
- `shell-common/functions/gh_pr_merge_train.sh`: train이 자신이 push한 head sha를
  기록/조회/삭제하는 3개 함수(`_gh_pr_merge_train_record_pushed_sha` /
  `_pushed_sha_matches` / `_forget_pushed_sha`)와, 이를 이용해 quiet period로만
  탈락한 PR을 재편입시키는 `_gh_pr_merge_train_readmit_own_pushes`를 추가.
  `reply-pending` 라벨과 draft는 항상 이 면제를 이긴다.
- `claude/skills/gh-pr-merge-train/SKILL.md`: Step 2에서 `headRefOid`를 함께
  조회하고, 기존 필터 호출을 그대로 둔 채 새 재편입 패스를 추가 실행하도록 갱신.
- `claude/skills/gh-pr-merge-train/references/train-loop.md`: BEHIND/DIRTY
  remediation 성공 후 재조회 시점에 push한 sha를 기록하고, 머지 성공 후 그 기록을
  정리(forget)하도록 Step 4 루프에 반영.
- `claude/skills/gh-pr-merge-train/references/ordering.md`: D-6 문서에 새 면제
  메커니즘 설명 섹션 추가 — 공유 필터는 바뀌지 않는다는 점을 명시.
- `tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats`: 신규 4개 함수의
  단위 테스트 + 재편입 매트릭스(면제/미기록/stale sha/reply-pending/draft/중복
  방지) + SKILL.md·train-loop.md·ordering.md 배선을 확인하는 drift guard 35건.

## Test plan
- [x] `tests/bats/skills/gh_pr_merge_train_own_push_exemption.bats` — 35 ok
- [x] `tests/bats/skills/gh_pr_merge_train_quiet_period.bats` (미수정 파일) — 52 ok,
      기존 필터 동작이 그대로임을 확인
- [x] `bash -n shell-common/functions/gh_pr_merge_train.sh` + `shellcheck` clean
- [ ] 실제 cron tick에서 재편입 로그(`[INFO] ... 재편입`)가 의도한 PR에서만
      찍히는지 운영 관찰

## Related
Closes #1708

---
<details>
<summary>🤖 AI Metrics · 📊 ~9000 tokens · 👤 ~24 h (3 d) · 🤖 ~6 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~9000 tokens · 👤 ~24 h (3 d) · 🤖 ~6 min
<!-- /ai-metrics:gh-pr -->

</details>
