### PR TITLE
feat(pr-merge-train): CI 왕복 N회 문제 해결 — merge queue 대신 strict 완화로

### DIFF
--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -60,24 +60,23 @@ merged — they are not candidates, they are unfinished business (#1707).
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_merge_train.sh"
 GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" --author @me --state merged \
   --limit 30 --json number,title,state,labels \
-  | jq -c '.[]?' \
-  | while IFS= read -r _pr; do
-        printf '%s' "$_pr" | _gh_pr_merge_train_needs_finalize || continue
-        printf '%s\n' "$(printf '%s' "$_pr" | jq -r '.number')"
-    done
+  | _gh_pr_merge_train_finalize_targets \
+  | jq -r '.[].number'
 ```
 
 Each number that comes out gets **one**
 `Skill(gh:pr-merge, "<N> rebase <remote> --finalize")`, then a
 `[FINALIZED] #<N> <title>` line in the Step 5 report.
 
-`_gh_pr_merge_train_needs_finalize` is the **shared** predicate in
-`shell-common/functions/gh_pr_merge_train.sh`, beside the label predicates
-Step 3.5 uses — run it, do not paraphrase it. It answers "MERGED **and** still
-carrying `review-passed`", and that combination is the signal precisely because
-`gh:pr-merge` drops that label as the last step of a completed merge (#1636):
-a merged PR that still has it is a PR whose completion steps never ran, which
-is what an enqueued (`--auto`) merge leaves behind.
+`_gh_pr_merge_train_finalize_targets` is the **shared** array-level filter in
+`shell-common/functions/gh_pr_merge_train.sh`, same shape as Step 2's
+`_gh_pr_merge_train_filter_targets` — run it, do not paraphrase it. It answers
+"MERGED **and** still carrying `review-passed`" for the whole list in one pass
+(the same rule `_gh_pr_merge_train_needs_finalize` answers for a single PR),
+and that combination is the signal precisely because `gh:pr-merge` drops that
+label as the last step of a completed merge (#1636): a merged PR that still
+has it is a PR whose completion steps never ran, which is what an enqueued
+(`--auto`) merge leaves behind.
 
 The finalize work itself is **not done here**. The train writes nothing to
 GitHub of its own (`references/constraints.md`); `gh:pr-merge --finalize` owns

--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -58,8 +58,9 @@ merged — they are not candidates, they are unfinished business (#1707).
 
 ```bash
 . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_merge_train.sh"
-GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" --author @me --state merged \
-  --limit 30 --json number,title,state,labels \
+GH_HOST="$TARGET_HOST" gh search prs --repo "$TARGET_REPO" --author @me \
+  --merged --label review-passed \
+  --limit 100 --json number,title,state,labels \
   | _gh_pr_merge_train_finalize_targets \
   | jq -r '.[].number'
 ```
@@ -78,12 +79,34 @@ label as the last step of a completed merge (#1636): a merged PR that still
 has it is a PR whose completion steps never ran, which is what an enqueued
 (`--auto`) merge leaves behind.
 
+The query asks the **search index by label**, not `gh pr list` by recency (PR
+#1725, codex BLOCKER). `gh pr list --state merged --limit 30` returned "the 30
+most recently merged PRs" and filtered those — so a PR that genuinely still
+owed a finalize pass fell out of the sweep forever once 30 further merges had
+happened, silently, with no error and no report line. Exactly the PRs a long
+outage or a merge burst strands are the ones that window drops. `is:merged
+label:review-passed` returns that set directly, with no recency cap, however
+long ago they merged; `--limit 100` is a sanity bound on a set that is normally
+empty and never legitimately large — if it is ever hit, the leftovers are a
+real incident, not a window to widen.
+
+The tradeoff taken knowingly: the search index is eventually consistent, so a
+PR merged (or labelled) seconds ago may not appear for a tick or two. That
+delays a finalize by minutes on a train that ticks every 3, against a bug that
+lost it permanently.
+
+`_gh_pr_merge_train_finalize_targets` still runs over the result even though
+the query already filters to the same rule. It is not redundant belt-and-braces:
+`gh search` reports `state` lowercase (`"merged"`), `gh pr list` uppercase
+(`"MERGED"`), and the shared filter is the one place that normalises — routing
+the search output through it is what keeps the *rule* in one place, so a future
+change of query or of `gh`'s output shape cannot quietly turn the sweep into
+"finalize everything the API returned".
+
 The finalize work itself is **not done here**. The train writes nothing to
 GitHub of its own (`references/constraints.md`); `gh:pr-merge --finalize` owns
 every one of those mutations already, and the sequence it runs is defined in
-`../gh-pr-merge/references/finalize-merged-pr.sh.md`. `--state merged` with
-`--limit 30` bounds the sweep: a PR older than that window and still labelled
-is a human's problem, not a loop's.
+`../gh-pr-merge/references/finalize-merged-pr.sh.md`.
 
 ## Step 2: Collect and order the queue
 
@@ -177,10 +200,22 @@ It answers two questions with the shared predicates in
   strict checks are off on this base, so the D-1 table's `BEHIND` row merges
   directly instead of rebasing locally (`references/routing-table.md`).
   Anything unread or unclear is `no` — the pre-#1707 local remediation.
+- `_gh_pr_merge_train_base_strict_confirmed` → `$BASE_STRICT_CONFIRMED`. `yes`
+  only when the rules body was readable and **positively** confirms strict is
+  still on for every `required_status_checks` rule found — the one base that is
+  exempt from the unreadable-base halt, because it never depended on this net.
+  This is a separate question from `$BEHIND_DIRECT`, not its negation: keying
+  the halt off `$BEHIND_DIRECT` let a failed rules lookup disable the halt
+  outright (PR #1725).
 - `_gh_pr_merge_train_base_ci_red` → is the base's tip already failing a check
   **it requires**? If so, every PR on that base is `[SKIPPED] <base> is red`
   and the merge phase does not run for it. Never `[FAILED]`: the next tick
   proceeds the moment the base is green.
+
+Either lookup coming back **unreadable** halts the merge phase for that base
+with `[SKIPPED] base health unreadable on <base>` unless
+`$BASE_STRICT_CONFIRMED` is `yes` — an empty rules body also empties the
+required-context list, so the red check would silently pass a broken base.
 
 This is the safety net that replaces what strict mode used to guarantee. It
 cannot prevent one bad merge — nothing can, once strict is off — but it stops

--- a/claude/skills/gh-pr-merge-train/SKILL.md
+++ b/claude/skills/gh-pr-merge-train/SKILL.md
@@ -23,6 +23,21 @@ metadata:
 **충돌 해결과 CI 수정 두 지점에서만** 필요하다 — 그 둘은 원자 스킬에 위임한다.
 한 PR 이 막혀도 그 PR 만 건너뛰고 train 은 계속한다.
 
+머지는 **fire-and-forget** 이다 (#1707): `gh:pr-merge` 를 `--auto` 로 호출해
+merge queue 에 넣고 기다리지 않으며, 실제 머지 후 처리는 다음 tick 의 Step 0
+finalize sweep 이 맡는다. 이 저장소에서 merge queue 자체는 **쓸 수 없고**(조직
+소유 저장소 전용), 그 조사 결과와 사람이 직접 실행해야 하는 활성화 절차는
+`references/merge-queue-investigation.md` 에 있다 — 이 스킬은 그 명령을
+실행하지 않는다.
+
+N번의 직렬 CI 왕복을 실제로 없앤 것은 큐가 아니라 **`main` ruleset 의 strict
+required-status-checks 해제**다 (#1707). 그래서 `BEHIND` + `MERGEABLE` PR 은
+로컬 리베이스 없이 바로 머지되고, 그 대가로 "리베이스된 결과가 착지 전에는
+CI 를 거치지 않는다" 는 위험을 받아들인다. 무엇을 얻고 무엇을 잃었는지, 그
+위험을 받치는 안전망(Step 3.6 + `main` push CI)은
+`references/strict-mode-relaxation.md` 에 있다. `DIRTY` 는 이 완화의 영향을
+전혀 받지 않는다 — 실제 충돌은 언제나 `gh:pr-resolve-conflict` 가 먼저다.
+
 ## Help
 
 If arg #1 is `-h`, `--help`, or `help`, read `references/help.md` and output its
@@ -35,6 +50,41 @@ Copy the binding block from `references/github-target.md` and run it **before
 any `gh` call** — `TARGET_REPO` / `TARGET_HOST` / `GH_HOST` come from one and
 the same remote URL (#1403/#1407). An explicit `owner/repo` positional pins
 `TARGET_REPO` directly; the host still comes from the remote URL.
+
+## Step 0: Finalize PRs the merge queue merged since the last tick
+
+Runs **before** Step 2 builds this tick's queue, because these PRs are already
+merged — they are not candidates, they are unfinished business (#1707).
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_merge_train.sh"
+GH_HOST="$TARGET_HOST" gh pr list --repo "$TARGET_REPO" --author @me --state merged \
+  --limit 30 --json number,title,state,labels \
+  | jq -c '.[]?' \
+  | while IFS= read -r _pr; do
+        printf '%s' "$_pr" | _gh_pr_merge_train_needs_finalize || continue
+        printf '%s\n' "$(printf '%s' "$_pr" | jq -r '.number')"
+    done
+```
+
+Each number that comes out gets **one**
+`Skill(gh:pr-merge, "<N> rebase <remote> --finalize")`, then a
+`[FINALIZED] #<N> <title>` line in the Step 5 report.
+
+`_gh_pr_merge_train_needs_finalize` is the **shared** predicate in
+`shell-common/functions/gh_pr_merge_train.sh`, beside the label predicates
+Step 3.5 uses — run it, do not paraphrase it. It answers "MERGED **and** still
+carrying `review-passed`", and that combination is the signal precisely because
+`gh:pr-merge` drops that label as the last step of a completed merge (#1636):
+a merged PR that still has it is a PR whose completion steps never ran, which
+is what an enqueued (`--auto`) merge leaves behind.
+
+The finalize work itself is **not done here**. The train writes nothing to
+GitHub of its own (`references/constraints.md`); `gh:pr-merge --finalize` owns
+every one of those mutations already, and the sequence it runs is defined in
+`../gh-pr-merge/references/finalize-merged-pr.sh.md`. `--state merged` with
+`--limit 30` bounds the sweep: a PR older than that window and still labelled
+is a human's problem, not a loop's.
 
 ## Step 2: Collect and order the queue
 
@@ -114,12 +164,38 @@ before it is actually acted on, at Step 4's F-3 re-query
 (`references/routing-table.md`) — the same point that already re-derives
 everything else Step 2/3.5 could not have seen coming.
 
+## Step 3.6: Read the base's check policy and health — once per base
+
+Run the block in `references/strict-mode-relaxation.md` → "New: the train
+refuses to pile onto a red base", **once per distinct `baseRefName`**, cached
+per base like Step 3's approval lookup. It costs one extra read-only REST call
+per base (the rules body is the one Step 3 already fetches) and **none** per PR.
+
+It answers two questions with the shared predicates in
+`shell-common/functions/gh_pr_merge_train.sh` — run them, do not paraphrase:
+
+- `_gh_pr_merge_train_behind_may_merge_directly` → `$BEHIND_DIRECT`. `yes` means
+  strict checks are off on this base, so the D-1 table's `BEHIND` row merges
+  directly instead of rebasing locally (`references/routing-table.md`).
+  Anything unread or unclear is `no` — the pre-#1707 local remediation.
+- `_gh_pr_merge_train_base_ci_red` → is the base's tip already failing a check
+  **it requires**? If so, every PR on that base is `[SKIPPED] <base> is red`
+  and the merge phase does not run for it. Never `[FAILED]`: the next tick
+  proceeds the moment the base is green.
+
+This is the safety net that replaces what strict mode used to guarantee. It
+cannot prevent one bad merge — nothing can, once strict is off — but it stops
+the train from stacking more onto a base already known to be broken. Scope,
+limits, and the accepted risk: `references/strict-mode-relaxation.md`.
+
 ## Step 4: Run the train — one PR at a time
 
 For each PR in queue order, run the loop in `references/train-loop.md`:
 **re-query state immediately before processing** (F-3 — the previous merge
 invalidated everything behind it), route through the D-1 table
-(`references/routing-table.md`), then merge with `Skill(gh:pr-merge, "<N>")`.
+(`references/routing-table.md`), then merge with
+`Skill(gh:pr-merge, "<N> rebase <remote> --auto")` — fire-and-forget, so a
+`[QUEUED]` answer ends that PR's turn rather than starting a wait (#1707).
 Gate off with an empty `reviewDecision` first runs one
 `Skill(gh:pr-approve, "<N> <remote> --self-record")` and reads the board back as
 its verdict — no approval, no merge.
@@ -127,24 +203,29 @@ After a **successful** merge, close that PR's implementation tab when its herdr
 agent is `idle` — the block in `references/train-loop.md` → "Closing the merged
 PR's implementation tab". A merged PR whose tab stays open keeps counting toward
 issue-watcher's `_IW_MAX_PER_REPO` budget and starves the pipeline (#1565).
-The `BEHIND` / `DIRTY` rows rebase inside a **detached scratch worktree** the
-train creates and unconditionally removes per attempt (#1493). Attempts are
+The `DIRTY` row — and `BEHIND` only when Step 3.6 left `$BEHIND_DIRECT` at `no`
+— rebases inside a **detached scratch worktree** the train creates and
+unconditionally removes per attempt (#1493). With `$BEHIND_DIRECT = yes`,
+`BEHIND` merges directly and builds no worktree at all (#1707). Attempts are
 capped at 3 per PR (F-5); a failure skips that PR and the train continues
 (F-6). Never process two PRs concurrently.
 
 ## Step 5: Report
 
-Emit the structured `[MERGED]` / `[SKIPPED]` / `[FAILED]` report — one line per
-PR with a reason — per `references/report-format.md` (F-9). Always as plain
-assistant text, never via a `Bash` heredoc or `Write`.
+Emit the structured `[FINALIZED]` / `[MERGED]` / `[QUEUED]` / `[SKIPPED]` /
+`[FAILED]` report — one line per PR with a reason — per
+`references/report-format.md` (F-9). Always as plain assistant text, never via
+a `Bash` heredoc or `Write`.
 
 ## Constraints
 
 - **Never call `gh:pr-merge-emergency`** (NF-2). Admin bypass is not this
   skill's path; an unmergeable PR is `[SKIPPED]` with a reason.
 - **Never abort the whole train** for one PR's failure (F-6).
-- **No merge strategy argument** — `gh:pr-merge`'s default rebase is what
-  `required_linear_history` allows (D-4).
+- **No merge strategy choice** — `rebase` is the only value the train ever
+  passes, and it is `gh:pr-merge`'s own default, which is what
+  `required_linear_history` allows (D-4). It is spelled out only because
+  `--auto` is a flag that cannot sit in a positional slot (#1707).
 - **No review judgement of its own** — `gh:issue-flow` already ran
   `devx:pr-review-all`, and the gate-off path delegates to `gh:pr-approve`
   rather than deciding anything here. Step 3.5 reads that fan-out's verdict

--- a/claude/skills/gh-pr-merge-train/references/constraints.md
+++ b/claude/skills/gh-pr-merge-train/references/constraints.md
@@ -29,12 +29,24 @@ The serial dependency is the design (D-8): each merge invalidates the rest of
 the queue, so a parallel train would be racing its own merges into each other's
 base. Do not dispatch sub-agents per PR.
 
-## Never pass a merge strategy
+#1707 made that invalidation **cheap for `BEHIND`** — a base with strict checks
+off rebases server-side, so nothing local is thrown away
+(`references/strict-mode-relaxation.md`) — but it did not make it *absent*, and
+it changed nothing at all for `DIRTY`, whose conflict resolution is still
+redone against a base that moved. Cheaper serial work is still serial work.
+
+## Never choose a merge strategy
 
 `required_linear_history` forbids merge commits, and rebase is `gh:pr-merge`'s
-default, so the train passes no strategy argument at all (D-4). Passing one
-explicitly would be a second place for the policy to drift out of sync with the
-repo's actual settings.
+default, so `rebase` is the only value the train ever passes (D-4). Choosing
+between strategies would be a second place for the policy to drift out of sync
+with the repo's actual settings.
+
+Since #1707 the word `rebase` does appear in the call —
+`Skill(gh:pr-merge, "<N> rebase <remote> --auto")` — for a purely syntactic
+reason: `--auto` is a flag, and the strategy and remote positionals sit in
+front of it. It is still the default being restated, not a choice being made;
+if `gh:pr-merge`'s default ever changes, this line changes with it.
 
 ## Never form a review judgement of its own
 
@@ -74,6 +86,16 @@ Step 5 report, and that goes to the operator (or the cron log), not to GitHub.
 
 Corollary: **this skill makes no writes to GitHub of its own.** Every mutation
 it causes happens inside an atom skill that already owns that mutation's rules.
+
+Step 0's finalize sweep (#1707) is bound by that corollary, not an exception to
+it. The sweep itself is two read-only calls — one `gh pr list --state merged`
+and the shared `_gh_pr_merge_train_needs_finalize` predicate over its output.
+Every write it triggers (board sync, ai-metrics comment, `review-passed`
+delete, tab close, post-merge-verify dispatch) happens inside
+`gh:pr-merge --finalize`, running the sequence defined in
+`../../gh-pr-merge/references/finalize-merged-pr.sh.md` — the same sequence the
+immediate merge path runs. A raw `gh api` mutation in the train, even a "small"
+label delete, would be the start of a second implementation of that sequence.
 
 ## Never bypass a gate that belongs to `gh:pr-merge`
 

--- a/claude/skills/gh-pr-merge-train/references/constraints.md
+++ b/claude/skills/gh-pr-merge-train/references/constraints.md
@@ -88,8 +88,9 @@ Corollary: **this skill makes no writes to GitHub of its own.** Every mutation
 it causes happens inside an atom skill that already owns that mutation's rules.
 
 Step 0's finalize sweep (#1707) is bound by that corollary, not an exception to
-it. The sweep itself is two read-only calls — one `gh pr list --state merged`
-and the shared `_gh_pr_merge_train_needs_finalize` predicate over its output.
+it. The sweep itself is one read-only call — `gh search prs --merged --label
+review-passed` — and the shared `_gh_pr_merge_train_finalize_targets` filter
+(the array-level form of `_gh_pr_merge_train_needs_finalize`) over its output.
 Every write it triggers (board sync, ai-metrics comment, `review-passed`
 delete, tab close, post-merge-verify dispatch) happens inside
 `gh:pr-merge --finalize`, running the sequence defined in

--- a/claude/skills/gh-pr-merge-train/references/github-target.md
+++ b/claude/skills/gh-pr-merge-train/references/github-target.md
@@ -68,8 +68,13 @@ train was invoked with a non-default remote, so the whole train lands on one
 server:
 
 ```
-Skill(gh:pr-merge, "<N> rebase <remote>")
+Skill(gh:pr-merge, "<N> rebase <remote> --auto")
 ```
 
 With the default `origin` the positional may be omitted — the atoms already
 default to it.
+
+`--auto` (#1707) is a flag, not a positional, so it sits after whatever
+positionals are present. `rebase` is written out here for the same reason: a
+flag cannot occupy the strategy slot. It is still D-4's default and not a
+strategy argument in the sense `constraints.md` forbids.

--- a/claude/skills/gh-pr-merge-train/references/help.md
+++ b/claude/skills/gh-pr-merge-train/references/help.md
@@ -39,6 +39,11 @@
 
 ## What the skill does
 
+0. **Finalizes leftovers first** (#1707): any of your PRs that is already
+   `MERGED` but still carries `review-passed` was merged by the **merge queue**
+   with no session watching, so its post-merge steps never ran. Each gets one
+   `gh:pr-merge --finalize` and a `[FINALIZED]` line. Predicate:
+   `_gh_pr_merge_train_needs_finalize`.
 1. Binds `TARGET_REPO` / `TARGET_HOST` from one remote URL (`references/github-target.md`).
 2. Lists your own open PRs and runs them through the shared filter
    `_gh_pr_merge_train_filter_targets` (`shell-common/functions/gh_pr_merge_train.sh`,
@@ -75,7 +80,10 @@
    worktree").
 7. Caps remediation at **3 attempts per PR** (F-5). Over that, the PR is
    `[FAILED]` and the train moves on (F-6).
-8. Prints a per-PR `[MERGED]` / `[SKIPPED]` / `[FAILED]` report with reasons (F-9).
+8. Prints a per-PR `[FINALIZED]` / `[MERGED]` / `[QUEUED]` / `[SKIPPED]` /
+   `[FAILED]` report with reasons (F-9). `[QUEUED]` means the PR went to the
+   merge queue and has **not** merged yet — step 0 of a later tick finishes it
+   (#1707).
 
 ## What the skill will NOT do
 
@@ -88,8 +96,10 @@
 - Merge a PR carrying `review-blocked`, or one carrying no verdict label at
   all — and it will not read a review comment body to second-guess either.
 - Call `gh:pr-merge-emergency`, or file an incident issue.
-- Pass a merge strategy — `gh:pr-merge`'s default rebase is what
-  `required_linear_history` allows (D-4).
+- Choose a merge strategy — `rebase`, `gh:pr-merge`'s own default, is the only
+  value it ever passes, and it is what `required_linear_history` allows (D-4).
+- Wait for a queued merge to land. Merges are fire-and-forget since #1707
+  (`gh:pr-merge --auto`); the queue owns the merge and step 0 owns the cleanup.
 - Abort the whole train because one PR failed.
 - Process two PRs at once.
 

--- a/claude/skills/gh-pr-merge-train/references/help.md
+++ b/claude/skills/gh-pr-merge-train/references/help.md
@@ -42,8 +42,9 @@
 0. **Finalizes leftovers first** (#1707): any of your PRs that is already
    `MERGED` but still carries `review-passed` was merged by the **merge queue**
    with no session watching, so its post-merge steps never ran. Each gets one
-   `gh:pr-merge --finalize` and a `[FINALIZED]` line. Predicate:
-   `_gh_pr_merge_train_needs_finalize`.
+   `gh:pr-merge --finalize` and a `[FINALIZED]` line. Found by label search
+   (`is:merged label:review-passed`), so a leftover cannot age out of a recency
+   window; predicate: `_gh_pr_merge_train_needs_finalize`.
 1. Binds `TARGET_REPO` / `TARGET_HOST` from one remote URL (`references/github-target.md`).
 2. Lists your own open PRs and runs them through the shared filter
    `_gh_pr_merge_train_filter_targets` (`shell-common/functions/gh_pr_merge_train.sh`,

--- a/claude/skills/gh-pr-merge-train/references/merge-queue-investigation.md
+++ b/claude/skills/gh-pr-merge-train/references/merge-queue-investigation.md
@@ -1,0 +1,185 @@
+# GitHub merge queue on `dEitY719/dotfiles` — findings and the manual activation step
+
+Issue #1707, AC1.
+
+> **Looking for what #1707 actually shipped?** That is
+> `strict-mode-relaxation.md`, not this page. This page is the **why not the
+> merge queue** — the investigation that found the queue categorically
+> unavailable here, plus the manual activation procedure kept for a possible
+> future org transfer. Everything on this page is inert. The fix that replaced
+> it, and that is live on `main` right now, is the strict-checks relaxation
+> documented next door.
+
+**Nothing in this repository executes anything on this page.** Enabling a merge queue rewrites how every future PR reaches `main` on
+a repo whose merge train runs unattended every 5 minutes
+(`shell-common/tools/custom/cron-jobs.json`), so the activation is a human's
+deliberate act, taken *after* the code that depends on it is merged — never a
+side effect of merging it.
+
+## Blocker first: the queue is not available on this repo today
+
+> Pull request merge queues are available in any public repository owned by an
+> **organization**, or in private repositories owned by organizations using
+> GitHub Enterprise Cloud.
+>
+> — [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+
+`dEitY719/dotfiles` is public, but its owner is a **personal user account**,
+not an organization:
+
+```console
+$ gh api repos/dEitY719/dotfiles --jq '{owner_type: .owner.type, visibility}'
+{"owner_type":"User","visibility":"public"}
+```
+
+So the gate is **ownership type, not plan tier**. No ruleset payload makes the
+queue work here; the prerequisite is transferring the repo to an organization.
+Until that happens the `merge_queue` rule below cannot be added at all.
+
+This corrects the premise this work started from. "Public repo ⇒ merge queue is
+free" is true only for org-owned public repos.
+
+### The second blocker, if the first is ever cleared
+
+`gh pr merge` cannot enqueue a PR on a repo whose `allow_auto_merge` is
+`false`. It only ever calls the `enablePullRequestAutoMerge` GraphQL mutation
+— `enqueuePullRequest` appears nowhere in the CLI — and GitHub rejects that
+mutation when the repo setting is off. This is
+[cli/cli#13398](https://github.com/cli/cli/issues/13398), open, and it
+reproduces on v2.45.0, the version installed here. This repo is currently
+`allow_auto_merge: false`, so **both** of these would have to be flipped:
+
+```console
+$ gh api repos/dEitY719/dotfiles --jq '.allow_auto_merge'
+false
+```
+
+Legacy branch protection implicitly forced `allow_auto_merge` on, which is why
+this was never visible before rulesets.
+
+## The premise that was wrong in the other direction
+
+`main` **is** protected. The 404 that suggested otherwise comes from the
+*legacy* endpoint, which 404s whenever protection is ruleset-based rather than
+classic — the absence of a classic record, not the absence of protection:
+
+```console
+$ gh api repos/dEitY719/dotfiles/branches/main/protection
+gh: Not Found (HTTP 404)
+
+$ gh api repos/dEitY719/dotfiles/rulesets --jq '.[] | {id, name, enforcement}'
+{"id":16849266,"name":"main-protection","enforcement":"active"}
+```
+
+Ruleset `16849266` currently carries `deletion`, `non_fast_forward`,
+`required_linear_history`, `pull_request`
+(`required_approving_review_count: 0`, `allowed_merge_methods: [squash, rebase]`)
+and `required_status_checks` (`Lint (mise)`, `Shell Lint (mise)`). There is no
+`merge_queue` rule.
+
+`strict_required_status_checks_policy` on that last rule read `true` when this
+investigation was written; it is **`false` now** — that flip is what #1707
+actually shipped, and it is documented in `strict-mode-relaxation.md`.
+
+This matters beyond bookkeeping: `gh:pr-merge`'s Step 2 protection probe uses
+that same legacy endpoint (`references/strategy-selection.md` → "Branch
+protection detection") and therefore reads this repo as **unprotected**. It is
+a conservative misread — it only widens the empty-`reviewDecision` exception on
+a repo whose ruleset asks for 0 approvals anyway — but it is a misread, and
+worth its own issue rather than a silent fix here.
+
+## The activation command (manual, for a human, after this PR is merged)
+
+Only meaningful once **both blockers above are cleared** (org-owned repo, and
+either `allow_auto_merge: true` or a `gh` release that calls
+`enqueuePullRequest`).
+
+`PATCH /repos/{owner}/{repo}/rulesets/{id}` replaces the whole `rules` array,
+so every existing rule has to be re-sent alongside the new one. Read the
+current ruleset first and diff the payload against it — do not retype it from
+this page, which is a snapshot:
+
+```sh
+# The activation targets one host and one repo explicitly. Bind both the way
+# every gh:* skill's Step 1 does (#1403 / #1407) rather than typing a bare
+# slug: `--repo`/a path slug carries no host, and a dual-host login would
+# otherwise resolve it against `gh repo set-default`.
+TARGET_HOST=github.com
+TARGET_REPO=dEitY719/dotfiles
+RULESET_ID=16849266
+
+# 1. Read and keep the current state. This is the rollback artifact.
+GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/rulesets/$RULESET_ID" \
+    > /tmp/ruleset-before.json
+
+# 2. Build the new rules array from that file — the four existing rules
+#    unchanged, plus merge_queue.
+jq '{rules: (.rules + [{
+      type: "merge_queue",
+      parameters: {
+        check_response_timeout_minutes: 60,
+        grouping_strategy: "ALLGREEN",
+        max_entries_to_build: 5,
+        max_entries_to_merge: 5,
+        merge_method: "REBASE",
+        min_entries_to_merge: 1,
+        min_entries_to_merge_wait_minutes: 5
+      }
+    }])}' /tmp/ruleset-before.json > /tmp/ruleset-patch.json
+
+# 3. Apply.
+GH_HOST="$TARGET_HOST" gh api -X PATCH "repos/$TARGET_REPO/rulesets/$RULESET_ID" \
+    --input /tmp/ruleset-patch.json
+
+# Rollback: PATCH again with {rules: .rules} taken from /tmp/ruleset-before.json.
+```
+
+### The parameters, and why these values
+
+Every one of the seven is **required** by the schema — the API documents no
+defaults, so all seven must be sent on every PATCH. Allowed values are from the
+[rules REST schema](https://docs.github.com/en/rest/repos/rules).
+
+| Parameter | Value | Why |
+|---|---|---|
+| `merge_method` | `REBASE` | The only choice consistent with the ruleset's own `required_linear_history` and its `allowed_merge_methods: [squash, rebase]`. `MERGE` would create a merge commit and violate linear history. Also matches D-4. Allowed: `MERGE` / `SQUASH` / `REBASE`. |
+| `grouping_strategy` | `ALLGREEN` | Only a fully green batch merges; one red PR does not drag the batch in. Allowed: `ALLGREEN` / `HEADGREEN`. |
+| `max_entries_to_build` | `5` | The batch width — this is the number that turns N CI round trips into one. 5 covers the observed queue depth (7 PRs was the worst case measured). Range 0-100. |
+| `max_entries_to_merge` | `5` | Matched to the build width; merging more than was built together defeats the batch. Range 0-100. |
+| `min_entries_to_merge` | `1` | A single PR must still merge on its own — this train is often one PR deep. Range 0-100. |
+| `min_entries_to_merge_wait_minutes` | `5` | How long a partial batch waits for company before merging anyway. Aligned with the 5-minute cron tick, so a PR waits at most one extra tick. Range 0-360. |
+| `check_response_timeout_minutes` | `60` | How long the queue waits for checks before giving up on an entry. Range 1-360. |
+
+The numbers above (other than `merge_method`) are the values GitHub's web UI
+pre-fills when the rule is first enabled. They are **not** documented API
+defaults — the schema lists all seven as required with no `default` key — so
+treat them as this repo's chosen configuration, not as "the defaults".
+
+### Two things to check at activation time, not now
+
+- **`strict_required_status_checks_policy` is now `false`** (#1707,
+  `strict-mode-relaxation.md`) — it was `true` when this section was written.
+  GitHub documents the queue as *providing the same benefit* ("does not require
+  a pull request author to update their branch and wait for status checks"),
+  but does **not** document the two as incompatible or the strict flag as
+  ignored. Unverified either way. If the queue is ever activated, decide
+  deliberately whether to restore strict: the queue would then be supplying the
+  pre-merge verification the relaxation gave up, which is the one condition
+  under which turning it back on costs nothing.
+- **`--delete-branch` on a genuinely deferred merge.** `gh pr merge` returns
+  before the merge happens and skips branch deletion entirely in that run, with
+  no warning (verified in cli/cli v2.45.0 `merge.go`). Head-branch cleanup then
+  depends on the repo's "Automatically delete head branches" setting. Nothing
+  in this train depends on the remote branch being gone, but the setting should
+  be turned on so merged branches do not accumulate.
+
+## What this repo ships in the meantime
+
+`gh:pr-merge --auto` and the Step 0 finalize sweep are in place and inert:
+with no queue on the base, `--auto` collapses to the immediate merge for the
+`CLEAN` PRs the train merges (verified in cli/cli v2.45.0: `autoMerge = --auto
+AND NOT isImmediatelyMergeable(state)`, and `CLEAN` is immediately mergeable),
+and a PR that merges immediately has its `review-passed` label dropped in the
+same run, so `_gh_pr_merge_train_needs_finalize` never matches and the sweep
+finds nothing. The behavior is unchanged until a human performs the activation
+above.

--- a/claude/skills/gh-pr-merge-train/references/ordering.md
+++ b/claude/skills/gh-pr-merge-train/references/ordering.md
@@ -26,6 +26,11 @@ That is wrong here, and the reason is mechanical:
 > **Every merge invalidates every PR still in the queue.** So the LLM work must
 > happen as late as possible.
 
+(Invalidation still happens after #1707 — every merge still moves the base. What
+changed is its *price*: on a base with strict checks off it costs a `BEHIND` PR
+nothing, and it costs a `DIRTY` PR exactly as much as it always did. The
+sentence above is about the expensive half, and the expensive half is `DIRTY`.)
+
 Resolve `DIRTY` first and each subsequent merge can re-conflict it — the same
 file, resolved again, against a base that has moved. Resolve it **last** and it
 is resolved exactly once, against the **final** base. One expensive operation
@@ -56,6 +61,35 @@ you reach the second PR, and acting on it would route the PR down the wrong row
 of the D-1 table.
 
 Treat the Step 2 queue as an **ordering**, not as a state snapshot.
+
+### The merge queue does not change D-2 or D-3 (#1707)
+
+`--auto` addresses the **merge wait** — the train no longer blocks until each
+PR lands, so the platform can batch the builds. D-2 and D-3 are about the cost
+of **local remediation**, which the queue does not touch: a `DIRTY` PR still
+needs an LLM to resolve real content conflicts, that work is still invalidated
+by every merge ahead of it, and it is therefore still done last and
+just-in-time. Both reasonings survive intact; they were never about waiting.
+
+### What did move: `BEHIND` costs no local rebase on a relaxed base (#1707)
+
+D-3's arithmetic above counts a rebase per PR per merge. On a base with
+`strict_required_status_checks_policy: false` — which `main` now is
+(`references/strict-mode-relaxation.md`) — **the `BEHIND` term drops out
+entirely**: GitHub rebases server-side at merge time, so a merely-behind PR
+never pays a local rebase or a CI cycle, no matter how many merges landed ahead
+of it. The row usually stops appearing at all, because GitHub reports such a PR
+as `CLEAN`.
+
+So read the "clean up just-in-time" rationale as being about **`DIRTY`** now.
+That row is unchanged and unchangeable: an LLM still has to resolve real
+content conflicts, that work is still invalidated by every merge ahead of it,
+and it is therefore still ordered last (D-2) and done at the last moment (D-3).
+No relaxation and no queue resolves a content conflict.
+
+D-2's ordering itself is untouched. `BEHIND` still sorts at rank 2 — it is now
+a cheaper rank, not a differently-ordered one, and on a relaxed base the PRs
+that would have filled it arrive as `CLEAN` at rank 1 anyway.
 
 ## D-6 — the 11-minute quiet period
 

--- a/claude/skills/gh-pr-merge-train/references/report-format.md
+++ b/claude/skills/gh-pr-merge-train/references/report-format.md
@@ -9,14 +9,20 @@ assistant text — never a `Bash` heredoc, never `Write` (#1270).
 == merge train: <owner/repo> ==
 queue: <n> PR(s)  ·  approval gate: <verdict>  ·  quiet period: 11m
 
+[FINALIZED] #1461  chore(docs): ...                  (merge queue merged it on a previous tick)
 [MERGED]  #1466  refactor(issue-watcher): simplify   (BEHIND -> resolve-outdated -> merged)
-[MERGED]  #1467  fix(gh-pr-reply): ...               (CLEAN -> merged)
+[QUEUED]  #1467  fix(gh-pr-reply): ...               (CLEAN -> enqueued, not yet merged)
 [SKIPPED] #1462  test(issue-watcher): ...            checks still running (3 polls)
 [SKIPPED] #1470  fix(y): ...                         review-blocked — reviewer verdict is blocking
 [FAILED]  #1469  feat(x): ...                        conflict unresolved after 3 attempts
 
-merged 2 · skipped 2 · failed 1
+finalized 1 · merged 1 · queued 1 · skipped 2 · failed 1
 ```
+
+`[FINALIZED]` lines come from Step 0's sweep and describe PRs merged on an
+**earlier** tick, so they are printed first, above the queue this tick built.
+The counts line names every non-zero bucket; a run that queued nothing prints
+no `queued` term, exactly as it prints no `failed 0`.
 
 Rules:
 
@@ -62,6 +68,8 @@ is already the clause prefix there, so it drops out of the string itself:
 | Status | Meaning | Typical reason |
 |---|---|---|
 | `[MERGED]` | the PR is merged | — |
+| `[QUEUED]` | **added to the merge queue, not yet merged** (#1707) — nothing went wrong and nothing is finished; the platform owns the merge from here, and Step 0's sweep will finalize the PR on a later tick | `enqueued, not yet merged` |
+| `[FINALIZED]` | a PR the merge queue merged on an **earlier** tick, whose post-merge completion steps ran on this one (#1707) | `merge queue merged it on a previous tick` |
 | `[SKIPPED]` | not merged, **and expected to be retriable** next tick | `checks still running`, `mergeability still UNKNOWN`, `approval required (reviewDecision=<value>)`, `gh:pr-merge refuses reviewDecision=<value>`, `policy unreadable — approval assumed required`, `BLOCKED: <rule>`, `draft`, plus the two verdict-gate reasons and the four delegated-review reasons tabled below |
 | `[FAILED]` | not merged, **and something actually went wrong** | `conflict unresolved after 3 attempts`, `gh:pr-merge failed: <message>`, `CI fix failed after 3 attempts` |
 
@@ -105,6 +113,14 @@ distinguishes what a reader has to do about each:
 
 None of the four spends an F-5 attempt, and none is ever `[FAILED]`: a
 withheld approval is a working review, not a broken train.
+
+`[QUEUED]` is deliberately its own bucket rather than a flavour of the two
+either side of it (#1707). Reporting it as `[MERGED]` would claim a merge that
+has not happened, and a reader chasing "which commit went in" would find
+nothing. Reporting it as `[SKIPPED]` would say the train declined to act, and
+the next tick would re-queue a PR the platform is already merging — the
+double-work `--auto` exists to remove. It spends no F-5 attempt and is never
+`[FAILED]`: handing a PR to the queue is the train succeeding at its new job.
 
 The `[SKIPPED]` / `[FAILED]` split is the load-bearing part of this output. A
 cron log full of `[SKIPPED] checks still running` is a healthy train waiting on

--- a/claude/skills/gh-pr-merge-train/references/routing-table.md
+++ b/claude/skills/gh-pr-merge-train/references/routing-table.md
@@ -24,8 +24,8 @@ a round trip the state you already hold has covered.
 
 | `mergeStateStatus` | `mergeable` | Action |
 |---|---|---|
-| `CLEAN` | `MERGEABLE` | `Skill(gh:pr-merge, "<N>")` directly |
-| `BEHIND` | `MERGEABLE` | `gh:pr-resolve-outdated` in a scratch worktree → re-query → merge |
+| `CLEAN` | `MERGEABLE` | `Skill(gh:pr-merge, "<N> rebase <remote> --auto")` directly |
+| `BEHIND` | `MERGEABLE` | `$BEHIND_DIRECT = yes` → `Skill(gh:pr-merge, "<N> rebase <remote> --auto")` directly, same as `CLEAN`. Otherwise `gh:pr-resolve-outdated` in a scratch worktree → re-query → merge |
 | `DIRTY` | `CONFLICTING` | `gh:pr-resolve-conflict` in a scratch worktree → re-query → merge |
 | `UNSTABLE` | `MERGEABLE` | inspect `statusCheckRollup` — see below |
 | `BLOCKED` | — | record the reason, `[SKIPPED]` |
@@ -111,6 +111,62 @@ merge on the strength of a snapshot.
 of the array filter — same `gh_pr_merge_train.sh` sourced in Step 2, same
 predicates Step 3.5 ran, so the checks cannot drift apart the way the
 quiet-minutes number used to. Do not re-derive the `jq` here.
+
+## Every merge in this table is `--auto` (#1707)
+
+The `CLEAN` row above, and the merge that follows remediation on the `BEHIND` /
+`DIRTY` / `UNSTABLE` rows, all call
+`Skill(gh:pr-merge, "<N> rebase <remote> --auto")`. `rebase` is written out
+because `--auto` is a flag and the positionals in front of it are positional —
+it is still D-4's default, not a strategy choice, and `<remote>` follows
+`github-target.md`'s own rule (the default `origin` may be omitted).
+
+`--auto` is what makes the train stop paying N serial CI cycles for N PRs
+(#1707). Without it the train merges PR1, which advances `main`, which puts
+every remaining queued PR `BEHIND`, which forces a rebase and a full CI cycle
+per PR. With it the train enqueues and moves on, and the platform batches the
+builds. The train must therefore **not** wait for a `--auto` merge to land: a
+`[QUEUED]` answer is the expected one, and the PR is finished on a later tick
+by Step 0's finalize sweep.
+
+On a base with no merge queue `--auto` degrades to the plain merge
+`gh:pr-merge` has always run (its Step 3 retries without the flag), so this row
+behaves exactly as it did before #1707 until the ruleset is actually flipped —
+see `merge-queue-investigation.md`, which is also where the manual activation
+step lives.
+
+## `BEHIND` skips the local rebase when the base says it may (#1707)
+
+`$BEHIND_DIRECT` is set **once per distinct base branch** by Step 3.6, from the
+same `repos/{repo}/rules/branches/{base}` body `approval-gate.md` already
+fetches — it is not a per-PR lookup, and this row must not make one. `yes`
+means the shared predicate
+`_gh_pr_merge_train_behind_may_merge_directly` found
+`strict_required_status_checks_policy: false` on that base: GitHub does not
+require the head to be current, so it performs the rebase itself at merge time
+and a merely-behind PR merges without a local rebase and without a fresh CI
+cycle. That is the entire N-round-trips fix (#1707).
+
+**The shortcut is a property of the base, never a universal rule.** It is read,
+not assumed, precisely so it cannot be wrong: a PR based on something other
+than `main`, a base where strict is still on, a future repo without the
+relaxation, or a rules lookup that simply failed all leave `$BEHIND_DIRECT` at
+`no`, and this row then behaves exactly as it did before #1707 —
+`gh:pr-resolve-outdated` in a scratch worktree. Fail-closed costs a rebase;
+guessing the other way costs three F-5 attempts against a refusal that cannot
+change.
+
+In practice this row goes quiet on a relaxed base rather than taking the fast
+path: `BEHIND` is GitHub saying "out of date **and this base requires
+otherwise**", so with strict off a behind-but-clean PR is reported `CLEAN` and
+routes down the first row. The `BEHIND` branch remains for the bases that still
+report it. Both halves — what changed, what it costs — are in
+`strict-mode-relaxation.md`.
+
+**`DIRTY` is completely unaffected.** A real content conflict is a real content
+conflict whatever the base's check policy says; it still routes through
+`gh:pr-resolve-conflict` first, always, and no relaxation anywhere may weaken
+that.
 
 The two rebase rows (`BEHIND`, `DIRTY`) never operate on the current checkout.
 The train builds a detached scratch worktree for `headRefName` first and passes

--- a/claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md
+++ b/claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md
@@ -1,0 +1,265 @@
+# Strict required-status-checks is OFF on `main` — what that bought, what it cost
+
+Issue #1707. This is the change that actually fixed the N-serial-CI-round-trips
+problem. `merge-queue-investigation.md` is the sibling page: it explains why
+GitHub's **merge queue** — the mechanism this work originally set out to use —
+is categorically unavailable on this repo, and what inert groundwork was
+shipped against a possible future org transfer. **That page is the "why not the
+queue"; this page is the "what instead".**
+
+Unlike that page, the change described here has **already been applied** to
+live infrastructure. It is not a manual step waiting for a human.
+
+## The one field that changed
+
+```console
+$ gh api -X PUT repos/dEitY719/dotfiles/rulesets/16849266   # ruleset "main-protection"
+```
+
+`required_status_checks.parameters.strict_required_status_checks_policy`:
+`true` → `false`. Nothing else in the ruleset moved. It still carries
+`deletion`, `non_fast_forward`, `required_linear_history`, `pull_request`
+(0 required approvals) and `required_status_checks` over the same two contexts:
+
+```console
+$ gh api repos/dEitY719/dotfiles/rules/branches/main \
+    --jq '[.[] | select(.type=="required_status_checks")
+                | {strict: .parameters.strict_required_status_checks_policy,
+                   contexts: [.parameters.required_status_checks[].context]}]'
+[{"contexts":["Lint (mise)","Shell Lint (mise)"],"strict":false}]
+```
+
+### Rollback
+
+The full pre-change ruleset was captured before the PUT and is the rollback
+artifact — do **not** retype the payload from this page:
+
+```sh
+# Bind host and repo the way every gh:* skill's Step 1 does (#1403 / #1407):
+# a bare slug carries no host, and a dual-host login would otherwise resolve
+# it against `gh repo set-default`.
+TARGET_HOST=github.com
+TARGET_REPO=dEitY719/dotfiles
+RULESET_ID=16849266
+
+# The snapshot below is the whole pre-change ruleset. A PUT replaces the entire
+# object, so restoring it restores every rule, not just the one field.
+SNAPSHOT=/tmp/claude-1000/-home-bwyoon-dotfiles-issue-1707-1/ab994565-f203-4004-aaac-0200d1196e51/scratchpad/ruleset-before.json
+
+GH_HOST="$TARGET_HOST" gh api -X PUT "repos/$TARGET_REPO/rulesets/$RULESET_ID" \
+    --input "$SNAPSHOT"
+```
+
+That path is session-scoped. If it is gone, re-capture the current ruleset with
+`GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/rulesets/$RULESET_ID"` and
+edit `strict_required_status_checks_policy` back to `true` before the PUT —
+that is the only field this change touched.
+
+## Why this was the fix, and local batch-rebasing was not
+
+GitHub ties a required check's satisfaction to **one specific commit SHA**.
+With strict on, a PR must be exactly up to date with the base before it may
+merge — so every merge ahead of it in the queue invalidates it, forcing a fresh
+rebase and a fresh full CI run on the new SHA. That is the entire cost the
+issue measured: PR #1694 rebased twice, PR #1690 rebased twice, ~2-4 minutes a
+cycle, N PRs ⇒ N serial CI round trips.
+
+The issue's original suggestion — batch the rebases locally, up front — only
+parallelises the **first** round. Under strict mode every PR after the first
+merge still needs its own fresh rebase and its own fresh CI cycle, because the
+first merge moved the base again. A small win, not the fix.
+
+With strict off, a PR that is behind the base but has no textual conflict
+against it merges immediately. GitHub performs the rebase server-side at merge
+time and does not demand a fresh CI run on the rebased commit, because "must be
+current" was exactly the gate strict mode was providing.
+
+### The observable proof that it took effect
+
+`mergeStateStatus: BEHIND` is not a fact about the branch; it is GitHub saying
+"the head is out of date **and this base requires it not to be**". With strict
+off, GitHub stops reporting it. Measured on this repo immediately after the
+PUT, with `main` at `448f14641f65`:
+
+| PR | its `base.sha` | up to date with `main`? | `mergeStateStatus` |
+|---|---|---|---|
+| #1719 | `d56cc232be6e` | no | `CLEAN` |
+| #1718 | `89d68eee617c` | no | `CLEAN` |
+| #1713 | `d56cc232be6e` | no | `CLEAN` |
+
+All three are genuinely behind and all three report `CLEAN`. Before the flip
+every one of them was `BEHIND` and owed a local rebase plus a CI cycle.
+
+## The risk this accepts — stated plainly, not buried
+
+**The code that lands on `main` after such a merge was never itself run through
+CI before landing.** What CI verified was the PR's diff against its *original*,
+now-stale base. GitHub then replays that diff onto a base that has moved, and
+merges the result unverified.
+
+For independent changes this is safe, and almost everything this train drains
+is independent. The failure mode it opens is narrow and real: **two PRs that
+touch overlapping logic in behaviourally incompatible but textually
+non-conflicting ways.** Git sees no conflict, so `mergeable` stays `MERGEABLE`,
+so nothing in the pre-merge path objects — and the combination is broken.
+
+This is the same class of staleness risk this repo has been careful about
+before (#1601's sha-freshness check on `review-passed`; #1700, where a
+`review-passed` label was destroyed by the wrong actor and could not be
+recovered). The tradeoff was chosen deliberately over the safer-but-weaker
+local batch rebase, **conditional on the safety net below existing.**
+
+`DIRTY` / `CONFLICTING` is untouched by any of this. A real conflict is a real
+conflict with or without strict mode, and it still routes through
+`gh:pr-resolve-conflict` first, always.
+
+## The safety net, and exactly how far it actually reaches
+
+### 1. `main`'s own CI already runs the identical required checks (pre-existing)
+
+This is the load-bearing piece, and it needed no new code — only confirming.
+Both required contexts are produced by workflows that trigger on **push to
+`main`**, not only on `pull_request`:
+
+| Workflow | Check | Triggers |
+|---|---|---|
+| `.github/workflows/ci.yml` | `Lint (mise)` | `push: [main, develop]`, `pull_request: [main, develop]` |
+| `.github/workflows/test.yml` | `Shell Lint (mise)` | `push: [main, develop]`, `pull_request: [main]` |
+
+Confirmed live on the current tip of `main`:
+
+```console
+$ gh api repos/dEitY719/dotfiles/commits/main/check-runs \
+    --jq '[.check_runs[] | {name, conclusion}]'
+[{"name":"Shell Lint (mise)","conclusion":"success"},
+ {"name":"Lint (mise)","conclusion":"success"}, ...]
+```
+
+So the rebased result **is** verified by the same two checks that gated the PR
+— after it lands rather than before. **Coverage is unchanged; only the timing
+moved.** That is the honest reason removing strict mode costs less than it
+looks like it should.
+
+**Do not read that as "CI runs the tests on the merged result."** It does not,
+and it did not before this change either. `Test (mise)` was removed from CI in
+#754: pytest and bats run in the local `pre-push` git hook
+(`docs/.ssot/local-test-policy.md`), never on the runner. Both the pre-merge
+gate and the post-merge gate are **lint-only**. Nothing was lost here — the two
+gates are the same two checks — but a reader must not credit this net with test
+coverage it has never had.
+
+### 2. New: the train refuses to pile onto a red base
+
+Push CI detects a bad landing but nothing acted on it, so the train would have
+merged PR2 and PR3 onto a broken `main` and left three suspects for one
+failure. That is the one piece worth automating, and it is Step 3.6.
+
+The shared predicates are `_gh_pr_merge_train_behind_may_merge_directly` and
+`_gh_pr_merge_train_base_ci_red`, in
+`shell-common/functions/gh_pr_merge_train.sh` beside the label predicates —
+their full contracts are the comments above each. Both are answered from calls
+the train makes **once per distinct base branch**, never per PR, so the guard
+adds no per-PR round trip. The rules body is the one
+`references/approval-gate.md` already fetches for the approval count.
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/gh_pr_merge_train.sh"
+
+BASE_ENC=$(jq -rn --arg b "$BASE" '$b|@uri')
+BASE_RULES=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/rules/branches/$BASE_ENC" 2>/dev/null) \
+    || BASE_RULES=''
+
+# Does BEHIND still owe a local rebase on this base? (routing-table.md D-1)
+BEHIND_DIRECT=no
+printf '%s' "$BASE_RULES" | _gh_pr_merge_train_behind_may_merge_directly && BEHIND_DIRECT=yes
+
+# Is the base already broken?  Fail closed: an unreadable answer halts.
+# An array, not a string — a context like `Lint (mise)` contains a space, and
+# word-splitting it would ask about two checks that do not exist.
+BASE_CONTEXTS=()
+while IFS= read -r _ctx; do
+    [ -n "$_ctx" ] && BASE_CONTEXTS+=("$_ctx")
+done <<EOF
+$(printf '%s' "$BASE_RULES" | jq -r '.[]? | select(.type == "required_status_checks")
+                                          | .parameters.required_status_checks[]?.context' 2>/dev/null)
+EOF
+
+BASE_CHECKS=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/commits/$BASE_ENC/check-runs" 2>/dev/null) \
+    || BASE_CHECKS=''
+
+if [ "$BEHIND_DIRECT" = yes ] && [ -z "$BASE_CHECKS" ]; then
+    echo "[SKIPPED] base health unreadable on $BASE — not merging onto an unverified base"
+elif printf '%s' "$BASE_CHECKS" | _gh_pr_merge_train_base_ci_red "${BASE_CONTEXTS[@]}"; then
+    echo "[SKIPPED] $BASE is red — halting the merge phase until it is green"
+fi
+```
+
+The condition is `BEHIND_DIRECT = yes` for the unreadable case on purpose: a
+base that never relaxed strict mode never depended on this net, and must not
+start being blocked by a lookup it never needed.
+
+Three properties of that guard, each a deliberate limit:
+
+- **It halts the merge phase, not one PR.** Everything queued this tick is
+  `[SKIPPED]` with the base's name as the reason. Never `[FAILED]` — the next
+  tick re-reads and proceeds the moment `main` is green again, so a red base
+  can never become the unclearable state `approval-gate.md` warns about.
+- **Required contexts only.** `main`'s tip also carries runs nobody gated on
+  (the weekly `Contract + drift` audit; a paths-filtered package build).
+  Halting on those would wedge the train on a failure no queued PR caused and
+  no merge could clear.
+- **Concluded failures only; pending is not red.** The train ticks every 3
+  minutes and lint takes 1-2, so treating a still-running check as red would
+  stall the train for a full CI cycle after every merge — reinstating exactly
+  the serialisation this change removed, under a new name.
+
+**What it does not do:** it cannot prevent the *first* bad merge. Nothing can,
+once strict is off — that is the accepted risk, restated. What it does is turn
+"N PRs merged onto a broken base" into "one bad merge, then a stop", which is
+the difference between a five-minute bisect and an afternoon.
+
+### 3. `gh:pr-post-merge-verify` — real on this repo, but advisory
+
+`gh:pr-merge` Step 5 dispatches it, gated on the watched-repos registry
+(`${IW_WATCHED_REPOS:-${HOME}/.agent-factory/avatars/issue-watcher/watched-repos.json}`).
+**This repo is registered** — checked, not assumed:
+
+```json
+[{"repo": "dEitY719/dotfiles", "path": "/home/bwyoon/dotfiles",
+  "host": "github.com", "verify_skill": "devx:pr-verify-merged"}]
+```
+
+So the dispatch does fire here, and `devx:pr-verify-merged` re-runs the repo's
+own test command in a **fresh clone of the merge commit** — which is the only
+thing in this whole chain that exercises bats and pytest against the merged
+result at all, given #754.
+
+Weigh it honestly, though. It opens a herdr session for a human to read; it
+does not block anything, it does not gate the next merge, and on the `--auto`
+path it fires at finalize time rather than at merge time. It is a good
+detector, not a gate. **Item 2 above is the only mechanism that changes what
+the train does.**
+
+## AC4 — the expected-mechanism argument, and what has not been measured
+
+The claim AC4 asks about is that N PRs now cost fewer than N CI round trips.
+Per-PR, after this change:
+
+| Row | Before (strict on) | After (strict off) |
+|---|---|---|
+| `CLEAN` | merge | merge — unchanged |
+| `BEHIND` + `MERGEABLE` | local rebase → push → **full CI cycle** → merge | GitHub rebases at merge time; **no round trip**, and GitHub no longer reports the row at all (table above) |
+| `DIRTY` / `CONFLICTING` | resolve → push → full CI cycle → merge | unchanged — still one round trip, still just-in-time |
+
+So the cost goes from N round trips to **one per genuinely conflicting PR**. A
+queue of N independent PRs — the normal case for this train — now costs zero
+extra CI cycles beyond the ones each PR already paid before it was queued.
+
+**This has not been measured end to end.** Nobody has run
+`gh:pr-merge-train` against a live multi-PR queue since the flip, and no number
+on this page is a measurement of one. What is measured is the mechanism's
+precondition: the three open PRs above really are behind `main` and really do
+report `CLEAN`, which is the specific state change the whole argument rests on.
+Empirical confirmation arrives on its own on the next real cron tick after this
+merges — the Step 5 report will show `[MERGED]` lines without the
+`gh:pr-resolve-outdated` runs that used to precede them.

--- a/claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md
+++ b/claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md
@@ -198,7 +198,14 @@ $(printf '%s' "$BASE_RULES" | jq -r '.[]? | select(.type == "required_status_che
                                           | .parameters.required_status_checks[]?.context' 2>/dev/null)
 EOF
 
-BASE_CHECKS=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/commits/$BASE_ENC/check-runs" 2>/dev/null) \
+# `--paginate` (#1707, codex FOLLOW-UP): the check-runs endpoint pages at 30
+# per the default page size, and `gh api --paginate` on this object-shaped
+# response (`{total_count, check_runs: [...]}`) merges the `check_runs` array
+# across pages into one combined object rather than concatenating separate
+# JSON documents — verified empirically against this repo's own `main`. A base
+# with more than 30 check runs would otherwise silently drop a later, possibly
+# failing required context off the one page an un-paginated call sees.
+BASE_CHECKS=$(GH_HOST="$TARGET_HOST" gh api --paginate "repos/$TARGET_REPO/commits/$BASE_ENC/check-runs" 2>/dev/null) \
     || BASE_CHECKS=''
 # Same normalisation, same reason: `_gh_pr_merge_train_base_ci_red` answers
 # "no proof of red" for a malformed body, which must not read as "green".

--- a/claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md
+++ b/claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md
@@ -154,10 +154,11 @@ Push CI detects a bad landing but nothing acted on it, so the train would have
 merged PR2 and PR3 onto a broken `main` and left three suspects for one
 failure. That is the one piece worth automating, and it is Step 3.6.
 
-The shared predicates are `_gh_pr_merge_train_behind_may_merge_directly` and
+The shared predicates are `_gh_pr_merge_train_behind_may_merge_directly`,
+`_gh_pr_merge_train_base_strict_confirmed` and
 `_gh_pr_merge_train_base_ci_red`, in
 `shell-common/functions/gh_pr_merge_train.sh` beside the label predicates —
-their full contracts are the comments above each. Both are answered from calls
+their full contracts are the comments above each. All are answered from calls
 the train makes **once per distinct base branch**, never per PR, so the guard
 adds no per-PR round trip. The rules body is the one
 `references/approval-gate.md` already fetches for the approval count.
@@ -168,10 +169,23 @@ adds no per-PR round trip. The rules body is the one
 BASE_ENC=$(jq -rn --arg b "$BASE" '$b|@uri')
 BASE_RULES=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/rules/branches/$BASE_ENC" 2>/dev/null) \
     || BASE_RULES=''
+# ONE sentinel for "unreadable", not two. A failed call and a 200 carrying
+# something that is not the expected array (a proxy interstitial, a truncated
+# body) are equally unreadable, so both become the empty string here and every
+# test below can just ask `-z`. Without this, a malformed body sails past the
+# `-z` guard while every predicate reading it still answers its own fail-closed
+# rc 1 — which is silence, not a halt.
+printf '%s' "$BASE_RULES" | jq -e 'type == "array"' >/dev/null 2>&1 || BASE_RULES=''
 
 # Does BEHIND still owe a local rebase on this base? (routing-table.md D-1)
 BEHIND_DIRECT=no
 printf '%s' "$BASE_RULES" | _gh_pr_merge_train_behind_may_merge_directly && BEHIND_DIRECT=yes
+
+# A SEPARATE question from the one above, deliberately: can we PROVE this base
+# is still fully strict, and therefore never depended on the net below? Only a
+# readable body that positively confirms strict-on everywhere is an exemption.
+BASE_STRICT_CONFIRMED=no
+printf '%s' "$BASE_RULES" | _gh_pr_merge_train_base_strict_confirmed && BASE_STRICT_CONFIRMED=yes
 
 # Is the base already broken?  Fail closed: an unreadable answer halts.
 # An array, not a string — a context like `Lint (mise)` contains a space, and
@@ -186,19 +200,54 @@ EOF
 
 BASE_CHECKS=$(GH_HOST="$TARGET_HOST" gh api "repos/$TARGET_REPO/commits/$BASE_ENC/check-runs" 2>/dev/null) \
     || BASE_CHECKS=''
+# Same normalisation, same reason: `_gh_pr_merge_train_base_ci_red` answers
+# "no proof of red" for a malformed body, which must not read as "green".
+printf '%s' "$BASE_CHECKS" | jq -e 'has("check_runs")' >/dev/null 2>&1 || BASE_CHECKS=''
 
-if [ "$BEHIND_DIRECT" = yes ] && [ -z "$BASE_CHECKS" ]; then
+# EITHER lookup being unreadable is an unreadable base. An empty $BASE_RULES is
+# not merely "one of two answers missing": it also empties $BASE_CONTEXTS, so
+# the red check below has nothing to match and a genuinely red base would read
+# as green. The only exemption is a base proven still-strict.
+if [ "$BASE_STRICT_CONFIRMED" = no ] && { [ -z "$BASE_RULES" ] || [ -z "$BASE_CHECKS" ]; }; then
     echo "[SKIPPED] base health unreadable on $BASE — not merging onto an unverified base"
 elif printf '%s' "$BASE_CHECKS" | _gh_pr_merge_train_base_ci_red "${BASE_CONTEXTS[@]}"; then
     echo "[SKIPPED] $BASE is red — halting the merge phase until it is green"
 fi
 ```
 
-The condition is `BEHIND_DIRECT = yes` for the unreadable case on purpose: a
-base that never relaxed strict mode never depended on this net, and must not
-start being blocked by a lookup it never needed.
+The exemption is keyed on `BASE_STRICT_CONFIRMED`, **not** on `BEHIND_DIRECT`,
+and that distinction is the whole point (PR #1725, codex BLOCKER). The rule
+being preserved is unchanged: *a base that never relaxed strict mode never
+depended on this net, and must not start being blocked by a lookup it never
+needed.* What changed is what counts as proof of "never relaxed".
+`BEHIND_DIRECT = no` is not that proof — it is the answer to a different
+question (`_gh_pr_merge_train_behind_may_merge_directly`'s contract collapses
+"strict is on", "no rule found" and "the body was unreadable" into one rc 1),
+so keying the halt off `BEHIND_DIRECT = yes` meant a **failed RULES lookup
+switched the halt off**: exactly the case with the least information got the
+least protection. And when the same outage took the check-runs call with it,
+`_gh_pr_merge_train_base_ci_red` on an empty body is rc 1 ("no proof of red")
+by its own contract, so the `elif` stayed quiet too and the tick merged CLEAN
+PRs onto a base nothing had verified — the CLEAN row never consults
+`$BEHIND_DIRECT` at all (`references/routing-table.md`), so this guard was the
+only thing between an API outage and an unverified merge.
 
-Three properties of that guard, each a deliberate limit:
+`_gh_pr_merge_train_base_strict_confirmed` answers the exemption question
+directly and positively: rc 0 only for a readable body in which every
+`required_status_checks` rule found has strict **on**. Unreadable, no rule, or
+any relaxed rule → rc 1 → halt-eligible. So the four cases are:
+
+| `BASE_RULES` | `BASE_CHECKS` | Outcome |
+|---|---|---|
+| confirms strict ON everywhere | anything | exempt — no unreadable-halt (a red tip still halts on the `elif`) |
+| relaxed, or no rule found | readable | proceed; red tip halts normally |
+| relaxed, or no rule found | unreadable | **halt** — base health unreadable |
+| unreadable | readable **or** unreadable | **halt** — cannot even name the required contexts |
+
+"Unreadable" means the empty sentinel above, which by then covers both a failed
+call and a 200 whose body is not the expected shape.
+
+Four properties of that guard, each a deliberate limit:
 
 - **It halts the merge phase, not one PR.** Everything queued this tick is
   `[SKIPPED]` with the base's name as the reason. Never `[FAILED]` — the next
@@ -212,6 +261,12 @@ Three properties of that guard, each a deliberate limit:
   minutes and lint takes 1-2, so treating a still-running check as red would
   stall the train for a full CI cycle after every merge — reinstating exactly
   the serialisation this change removed, under a new name.
+- **An unread answer halts; only a positively-strict base is exempt.** The two
+  `gh api` calls fail together in an outage far more often than separately, and
+  the failure modes of both predicates point the same way ("no proof of red",
+  "no shortcut"), so nothing downstream would notice a double failure on its
+  own. The halt is the only thing that does, and it is deliberately keyed on
+  raw unreadability rather than on any predicate's verdict.
 
 **What it does not do:** it cannot prevent the *first* bad merge. Nothing can,
 once strict is off — that is the accepted risk, restated. What it does is turn

--- a/claude/skills/gh-pr-merge-train/references/train-loop.md
+++ b/claude/skills/gh-pr-merge-train/references/train-loop.md
@@ -26,13 +26,20 @@ For each PR `N` in the Step 2 queue order:
 5. **Re-query and re-route.** An atom returning success does not prove the PR
    is mergeable now. On the `BEHIND` / `DIRTY` rows, that re-query is also what
    records the sha this train just pushed — see "Recording the push" below.
-6. **Merge** — `Skill(gh:pr-merge, "<N>")`. No strategy argument (D-4).
+6. **Merge** — `Skill(gh:pr-merge, "<N> rebase <remote> --auto")` (#1707).
+   `rebase` is spelled out only because `--auto` is a flag behind two
+   positionals; it is still D-4's default, never a strategy choice. `--auto`
+   enqueues instead of blocking, so this step returns without waiting.
 7. **Close the merged PR's implementation tab** — only on a successful merge,
    only when that tab is `idle`. The block is below ("Closing the merged PR's
-   implementation tab").
-8. **Record** the outcome and continue. After a **successful** merge only, drop
-   that PR's pushed-sha record — otherwise the state dir grows one file per
-   merged PR forever (#1708). Best-effort; it can never fail the merge:
+   implementation tab"). A `[QUEUED]` PR is **not** a successful merge: its
+   worktree is still the thing the queue is about to merge, so its tab stays.
+8. **Record** the outcome — `[MERGED]`, `[QUEUED]`, `[SKIPPED]` or `[FAILED]`
+   (`report-format.md`) — and continue. A `[QUEUED]` PR is done for this tick;
+   Step 0's sweep finalizes it on a later one. After a **successful merge only**
+   (`[MERGED]`, never `[QUEUED]`), drop that PR's pushed-sha record —
+   otherwise the state dir grows one file per merged PR forever (#1708).
+   Best-effort; it can never fail the merge:
 
    ```bash
    _gh_pr_merge_train_forget_pushed_sha "$STATE_DIR" "<N>" || true

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -184,14 +184,13 @@ Then run the herdr idle-tab hint per `references/herdr-tab-notify.sh.md` — one
 tab (soft-fail and read-only; skip entirely when there is no local worktree, no
 `herdr`, or the agent is not idle — never close a tab or delete a worktree).
 
-Then drop the now-readerless `review-passed` label per
-`references/review-passed-cleanup.sh.md` — `_gh_pr_drop_label "$PR_NUMBER"
-review-passed "$TARGET_REPO" "$TARGET_HOST"` (#1636, soft-fail: the merge
-already succeeded, so a failed delete is one `[WARN]` line and never touches
-the Step 5 report or the exit status).
-
 After the board sync completes, post the ai-metrics PR comment per
 `references/ai-metrics-comment.sh.md` (soft-fail; skip entirely when `GH_DISABLE_AI_METRICS=1`).
+
+The `review-passed` label is **not** dropped here — it is the last thing Step 5
+does, after every other write and after the post-merge verification dispatch.
+That ordering is load-bearing, not tidiness: see
+`references/finalize-merged-pr.sh.md`.
 
 ## Step 5: Fetch Merge SHA + Report
 
@@ -289,6 +288,21 @@ The dispatch owns every step and every failure mode from there (all soft-fail,
 so the report above stands regardless), and re-runs the same registry gate on
 its own so it stays usable standalone. Detail:
 `claude/skills/gh-pr-post-merge-verify/SKILL.md`.
+
+**Last of all** — after the report, after ai-metrics, after the dispatch block
+above has returned — drop the now-readerless `review-passed` label per
+`references/review-passed-cleanup.sh.md` — `_gh_pr_drop_label "$PR_NUMBER"
+review-passed "$TARGET_REPO" "$TARGET_HOST"` (#1636, soft-fail: the merge
+already succeeded, so a failed delete is one `[WARN]` line and never touches
+the report or the exit status).
+
+This is the **last** write of the sequence on purpose (PR #1725, codex
+BLOCKER). That label is the only signal `_gh_pr_merge_train_needs_finalize`
+matches on, so dropping it while any later step is still outstanding makes a
+run that dies in between permanently undiscoverable by the next tick's Step 0
+sweep. Ordering it here bounds an interrupted run to "gets swept again next
+tick" — every step above is idempotent enough to repeat.
+`references/finalize-merged-pr.sh.md` owns the full rationale.
 
 ## Constraints
 

--- a/claude/skills/gh-pr-merge/SKILL.md
+++ b/claude/skills/gh-pr-merge/SKILL.md
@@ -31,6 +31,19 @@ Record `START_TS=$(date +%s)` immediately for elapsed-time tracking in Step 4.
 - `remote` — default `origin`. Bind `TARGET_REPO` **and** `TARGET_HOST` from
   that one remote URL and `export GH_HOST` per `references/github-target.md`
   (#1403/#1407). Missing remote → list `git remote -v`, stop (no silent fallback).
+- `--auto` — optional flag, any position after the positionals (#1707). Merge
+  **fire-and-forget**: hand the PR to the base branch's merge queue instead of
+  blocking until it merges. Step 3 and Step 3.5 below own the behavior.
+- `--finalize` — optional flag, any position (#1707). Run **only** the
+  post-merge completion sequence on a PR that is **already merged**, then stop:
+  skip Step 2 and Step 3 entirely, jump straight to Step 4 per
+  `references/finalize-merged-pr.sh.md`, and print `[FINALIZED] #<N>` instead
+  of `[OK] PR #<N> merged`. `gh:pr-merge-train`'s Step 0 sweep is its only
+  caller. If `gh pr view <N> --json state` is not `MERGED`, print
+  `[FAIL] PR #<N> not finalized — state is <state>, expected MERGED` and stop:
+  every step in that sequence is a GitHub write that assumes a merge happened.
+  `--auto` and `--finalize` together is a usage error — they are the two halves
+  of one deferred merge, never one invocation.
 
 ## Step 2: Pre-flight (parallel)
 
@@ -56,8 +69,62 @@ here. Rationale + the retired Step 2-B in `references/board-policy.md`.
 
 ## Step 3: Merge (no confirmation)
 
+Without `--auto` — the default, unchanged:
+
 ```bash
 GH_HOST="$TARGET_HOST" gh pr merge <N> --repo "$TARGET_REPO" --<strategy> --delete-branch
+```
+
+With `--auto` (#1707), paste this block instead. It **tries the queue-aware
+form first and falls back to the line above**, so the flag can never be the
+reason a merge that would otherwise have worked does not:
+
+```bash
+# Substitute PR_NUMBER / TARGET_REPO / TARGET_HOST / STRATEGY_FLAG (one of
+# --rebase / --squash / --merge, per references/strategy-selection.md).
+#
+# `--auto` is the whole point of #1707: with a merge queue active on the base,
+# it hands the PR to the queue and returns immediately, so N PRs cost ONE
+# batched CI cycle instead of N serial rebase+CI round trips.
+#
+# What `--auto` does on a base with NO merge queue, verified against
+# cli/cli v2.45.0 `pkg/cmd/pr/merge/merge.go` (the version installed here):
+# gh computes `autoMerge = --auto AND NOT isImmediatelyMergeable(state)`, and
+# `CLEAN` IS immediately mergeable — so for the only PRs the train ever merges
+# (the D-1 `CLEAN`/`MERGEABLE` row), `--auto` collapses to the ordinary
+# `mergePullRequest` mutation and the PR merges immediately, exit 0, branch
+# deleted. The flag is a genuine no-op there, not a hopeful one.
+#
+# The fallback covers the case that is NOT a no-op: a PR gh does not consider
+# immediately mergeable, where `--auto` really does reach
+# `enablePullRequestAutoMerge` — a mutation GitHub refuses outright when the
+# repo has `allow_auto_merge: false`, which is the CURRENT state of
+# dEitY719/dotfiles. Without the retry, that path would fail a merge the
+# pre-#1707 skill would have completed, on a train the 5-minute cron runs
+# unattended. See
+# ../../gh-pr-merge-train/references/merge-queue-investigation.md.
+#
+# Deliberately NO error-string matching: gh's and GitHub's wording for
+# "auto-merge is not available here" has several forms and is not a stable
+# API. Retrying the plain merge on ANY failure costs one extra call on a path
+# that was already failing, and the second failure is the one reported — which
+# is exactly the error the pre-#1707 skill would have printed.
+#
+# Caveat, same source: when a merge really IS deferred, gh returns before the
+# merge happens and `--delete-branch` silently does nothing in that run (it
+# returns early on the deferred path, with no warning). The head branch is
+# then GitHub's "Automatically delete head branches" setting to clean up, not
+# this skill's. Nothing downstream depends on it: the train's tab-close reads
+# the LOCAL worktree branch, which `--delete-branch` never touched anyway.
+if MERGE_OUT=$(GH_HOST="$TARGET_HOST" gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" \
+        "$STRATEGY_FLAG" --delete-branch --auto 2>&1); then
+    printf '%s\n' "$MERGE_OUT"
+else
+    printf '[INFO] gh:pr-merge: --auto refused (%s) — retrying the plain merge.\n' \
+        "$(printf '%s' "$MERGE_OUT" | tr '\n' ' ')"
+    GH_HOST="$TARGET_HOST" gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" \
+        "$STRATEGY_FLAG" --delete-branch
+fi
 ```
 
 Flag mapping in `references/strategy-selection.md`. If `gh` returns
@@ -65,7 +132,46 @@ Flag mapping in `references/strategy-selection.md`. If `gh` returns
 `references/strategy-selection.md` and stop. **Never** silently switch
 strategies.
 
+## Step 3.5: Did it actually merge? (`--auto` only)
+
+Skip this step entirely unless `--auto` was given — without the flag, Step 3
+returning success means the PR is merged, exactly as before.
+
+With `--auto`, success means "GitHub accepted responsibility for the merge",
+which is **not** the same as "the PR is merged". Ask:
+
+```bash
+GH_HOST="$TARGET_HOST" gh pr view <N> --repo "$TARGET_REPO" --json state,mergedAt
+```
+
+| `state` | Meaning | Do |
+|---|---|---|
+| `MERGED` | the queue was off, or the PR merged immediately | continue to Step 4 exactly as today |
+| `OPEN` | **queued, not yet merged** | print the `[QUEUED]` report below and **stop** — run none of Step 4, none of Step 5 |
+| `CLOSED` | someone closed it out from under us | `[FAIL] PR #<N> not merged — closed` |
+
+```
+[QUEUED] PR #<N> added to merge queue — not yet merged
+  Branch:  <headRefName> → <baseRefName>
+  URL:     <pr-url>
+```
+
+`[QUEUED]` is a **third outcome**, not a dressed-up success and not a failure:
+nothing went wrong, and nothing is finished. Running Step 4/5 here would sync
+a board to `Done`, post an ai-metrics footer and dispatch a post-merge
+verification for a merge that has not happened — and dropping `review-passed`
+would destroy the one signal that says this PR still owes a completion pass.
+`gh:pr-merge-train`'s Step 0 sweep finalizes it on a later tick
+(`_gh_pr_merge_train_needs_finalize`, `references/finalize-merged-pr.sh.md`).
+
 ## Step 4: Sync Project Board Status
+
+Steps 4 and 5 together are **the post-merge completion sequence**, and its
+membership and order are defined once in `references/finalize-merged-pr.sh.md`
+(#1707). `--finalize` re-enters at exactly this point, running the same six
+steps against a PR the merge queue merged with no session watching — same
+order, same SSOT blocks, only the Step 5 report line differs (`[FINALIZED]`
+rather than `[OK]`). Change the sequence there, not only here.
 
 Run the two post-merge board reconciliations (PR card → Done; linked Issue cards
 → Done) per `references/project-board-sync.md` — paste the snippets verbatim
@@ -94,6 +200,9 @@ GH_HOST="$TARGET_HOST" gh pr view <N> --repo "$TARGET_REPO" --json mergeCommit -
 ```
 
 Print **only** the compact report (format in `references/strategy-selection.md` → "Final report format").
+Under `--finalize` the same report is printed with `[FINALIZED] #<N>` as its
+verdict line — the merge SHA and branch fields are identical, only the claim
+"this run merged it" is not made twice (#1707).
 
 **After** the report has printed, paste this block verbatim — it is the
 post-merge verification gate **and** its dispatch, in one run:
@@ -186,6 +295,10 @@ its own so it stays usable standalone. Detail:
 - Never ask for confirmation — running the skill is the confirmation.
 - Never merge an un-approved PR; redirect to `gh:pr-merge-emergency`. Never bypass CI.
 - Never swap strategy if the chosen one fails. Always `--delete-branch`.
+- Never run Step 4/5's completion steps for a PR that is not `MERGED` (#1707).
+  A `[QUEUED]` PR keeps its `review-passed` label — that label is what a later
+  `gh:pr-merge-train` Step 0 sweep matches on, and dropping it early makes the
+  finalize pass unfindable.
 
 ## Related Skills
 
@@ -194,4 +307,7 @@ is the admin-override path when approval cannot be obtained · `gh:pr-post-merge
 owns the dispatch block Step 5 runs inline for repos registered in
 `${IW_WATCHED_REPOS:-${HOME}/.agent-factory/avatars/issue-watcher/watched-repos.json}`,
 and stays a standalone manual entry point
-(`/gh-pr-post-merge-verify <N>`).
+(`/gh-pr-post-merge-verify <N>`) · `gh:pr-merge-train` is the only caller of
+`--auto` and `--finalize`: its per-PR merge passes the first, and its Step 0
+sweep passes the second to finish PRs the merge queue merged unattended
+(#1707).

--- a/claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
+++ b/claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
@@ -82,14 +82,9 @@ retroactive duration would be worse than reporting a short one.
 When `--auto` was used and the post-merge `gh pr view` still reports
 `state == "OPEN"`, the PR was **enqueued, not merged** — none of the six steps
 above may run, because the merge they all assume has not happened yet. That is
-neither success nor failure in the existing sense; it is a third outcome with
-its own report shape (`SKILL.md` Step 3.5):
-
-```
-[QUEUED] PR #<N> added to merge queue — not yet merged
-  Branch:  <headRefName> → <baseRefName>
-  URL:     <pr-url>
-```
+neither success nor failure in the existing sense; it is a third outcome whose
+report shape is `SKILL.md` Step 3.5's `[QUEUED]` block — this file is an index
+over the sequence, not a second copy of that block.
 
 The PR keeps its `review-passed` label precisely because step 3 did not run,
 and that is what a later `gh:pr-merge-train` Step 0 sweep matches on.

--- a/claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
+++ b/claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
@@ -1,0 +1,95 @@
+# Finalize a merged PR — the post-merge completion sequence (SSOT)
+
+Issue #1707. This file defines **the order and the membership** of everything
+`gh:pr-merge` does *after* a PR is actually merged. It is not a second copy of
+those steps — each one already has its own SSOT file, listed below — it is the
+one place that says *which* steps make up "the merge is finished" and *in what
+order*, so the two callers cannot drift apart:
+
+| Caller | When | Report line |
+|---|---|---|
+| `gh:pr-merge` Steps 4 + 5 | immediately, in the same run that merged the PR | `[OK] PR #<N> merged (<strategy>)` |
+| `gh:pr-merge` `--finalize` | later, on a PR the **merge queue** merged with no session watching | `[FINALIZED] #<N> <title>` |
+
+The second entry point exists because of `--auto` (#1707). With a merge queue
+active on the base, `gh pr merge --auto` returns success while the PR is still
+`OPEN` — GitHub merges it minutes later, server-side, and nothing is running at
+that moment to sync the board, post ai-metrics, drop the label or close the
+implementation tab. `gh:pr-merge-train`'s Step 0 sweep finds those PRs on a
+later tick (`_gh_pr_merge_train_needs_finalize`) and re-enters here.
+
+## The sequence
+
+Run these **in this order**. Every one is soft-fail: the merge already
+happened, so nothing here may change an exit status or suppress the report.
+
+| # | Step | SSOT |
+|---|---|---|
+| 1 | PR card → `Done`, linked Issue cards → `Done` | `references/project-board-sync.md` |
+| 2 | herdr idle-tab hint (read-only, one `[INFO]` line) | `references/herdr-tab-notify.sh.md` |
+| 3 | drop the now-readerless `review-passed` label | `references/review-passed-cleanup.sh.md` |
+| 4 | ai-metrics PR comment (skipped when `GH_DISABLE_AI_METRICS=1`) | `references/ai-metrics-comment.sh.md` |
+| 5 | fetch the merge SHA, print the report line | `references/strategy-selection.md` → "Final report format" |
+| 6 | post-merge verification dispatch | `SKILL.md` Step 5's staging block, which reads `claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md` |
+
+Step 3 is **last among the writes on purpose**, and that ordering is
+load-bearing beyond tidiness: dropping `review-passed` is what makes
+`_gh_pr_merge_train_needs_finalize` stop matching this PR. Drop it first and a
+sweep interrupted halfway leaves a PR that is neither finalized nor findable.
+Drop it after the other writes and an interrupted sweep simply gets picked up
+again on the next tick — every step above is idempotent, so a repeat costs
+nothing (the board sync is a no-op on an already-`Done` card, the label delete
+absorbs its own 404, the tab is already closed, and the PMV dispatch re-runs
+its own registry gate).
+
+The one step that is **not** idempotent in that sense is #4: a second
+ai-metrics comment would land a second footer on the same PR. Ordering #3 last
+bounds the exposure to a sweep that dies between #4 and #3, which is one API
+call wide.
+
+## Required bindings
+
+Identical for both entry points; all of them come from Step 1's single remote
+URL plus Step 2's `gh pr view` (`references/github-target.md`, #1403 / #1407):
+
+| Variable | Source |
+|---|---|
+| `PR_NUMBER` | the positional |
+| `TARGET_REPO` / `TARGET_HOST` | the resolved remote |
+| `HEAD_REF` / `BASE_BRANCH` | `gh pr view --json headRefName,baseRefName` |
+| `REMOTE` | the `[remote]` positional, default `origin` |
+| `START_TS` | Step 1's `date +%s` |
+
+`START_TS` is the one binding that differs in meaning between the two entry
+points. In the immediate path it measures the merge run, which is what the
+ai-metrics footer claims. In a `--finalize` pass it measures the sweep, which
+is a few seconds and says nothing about the PR — so a `--finalize` run binds
+`START_TS` at its own start anyway and lets the footer report that. Inventing a
+retroactive duration would be worse than reporting a short one.
+
+## What is NOT in the sequence
+
+- **The pre-flight gates and the merge itself** (`SKILL.md` Steps 2 and 3).
+  `--finalize` skips both by construction: the PR is already merged, so there
+  is nothing left to gate and nothing left to merge. It verifies exactly one
+  thing before running the sequence — that `state == "MERGED"` — and refuses
+  otherwise, because every step here is a write that assumes a merge happened.
+- **Anything conditional on the strategy.** By the time this runs, the merge
+  method is history; only the report line names it.
+
+## The `[QUEUED]` third outcome
+
+When `--auto` was used and the post-merge `gh pr view` still reports
+`state == "OPEN"`, the PR was **enqueued, not merged** — none of the six steps
+above may run, because the merge they all assume has not happened yet. That is
+neither success nor failure in the existing sense; it is a third outcome with
+its own report shape (`SKILL.md` Step 3.5):
+
+```
+[QUEUED] PR #<N> added to merge queue — not yet merged
+  Branch:  <headRefName> → <baseRefName>
+  URL:     <pr-url>
+```
+
+The PR keeps its `review-passed` label precisely because step 3 did not run,
+and that is what a later `gh:pr-merge-train` Step 0 sweep matches on.

--- a/claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
+++ b/claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
@@ -27,25 +27,33 @@ happened, so nothing here may change an exit status or suppress the report.
 |---|---|---|
 | 1 | PR card → `Done`, linked Issue cards → `Done` | `references/project-board-sync.md` |
 | 2 | herdr idle-tab hint (read-only, one `[INFO]` line) | `references/herdr-tab-notify.sh.md` |
-| 3 | drop the now-readerless `review-passed` label | `references/review-passed-cleanup.sh.md` |
-| 4 | ai-metrics PR comment (skipped when `GH_DISABLE_AI_METRICS=1`) | `references/ai-metrics-comment.sh.md` |
-| 5 | fetch the merge SHA, print the report line | `references/strategy-selection.md` → "Final report format" |
-| 6 | post-merge verification dispatch | `SKILL.md` Step 5's staging block, which reads `claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md` |
+| 3 | ai-metrics PR comment (skipped when `GH_DISABLE_AI_METRICS=1`) | `references/ai-metrics-comment.sh.md` |
+| 4 | fetch the merge SHA, print the report line | `references/strategy-selection.md` → "Final report format" |
+| 5 | post-merge verification dispatch | `SKILL.md` Step 5's staging block, which reads `claude/skills/gh-pr-post-merge-verify/references/dispatch.sh.md` |
+| 6 | drop the now-readerless `review-passed` label | `references/review-passed-cleanup.sh.md` |
 
-Step 3 is **last among the writes on purpose**, and that ordering is
-load-bearing beyond tidiness: dropping `review-passed` is what makes
-`_gh_pr_merge_train_needs_finalize` stop matching this PR. Drop it first and a
-sweep interrupted halfway leaves a PR that is neither finalized nor findable.
-Drop it after the other writes and an interrupted sweep simply gets picked up
-again on the next tick — every step above is idempotent, so a repeat costs
-nothing (the board sync is a no-op on an already-`Done` card, the label delete
-absorbs its own 404, the tab is already closed, and the PMV dispatch re-runs
-its own registry gate).
+Dropping `review-passed` is **step 6 of 6, after every other step including the
+dispatch**, and that ordering is load-bearing beyond tidiness: that label is
+what makes `_gh_pr_merge_train_needs_finalize` match this PR at all. While it
+is on, an unfinished PR is findable; the moment it comes off, the PR is done as
+far as the next tick's Step 0 sweep can tell. So the label must not come off
+until there is nothing left to find the PR *for*. Ordered last, a run
+interrupted anywhere in 1-5 simply gets swept again on the next tick — every
+step is idempotent enough to repeat (the board sync is a no-op on an
+already-`Done` card, the label delete absorbs its own 404, the tab is already
+closed, and the PMV dispatch re-runs its own registry gate).
 
-The one step that is **not** idempotent in that sense is #4: a second
-ai-metrics comment would land a second footer on the same PR. Ordering #3 last
-bounds the exposure to a sweep that dies between #4 and #3, which is one API
-call wide.
+Until PR #1725 this step sat at #3 — before the ai-metrics comment and before
+the dispatch — while this paragraph claimed it was last. A run that died
+between them dropped the label with two steps still owed, and no later sweep
+could ever find the PR again (codex BLOCKER on #1725). Anything added to this
+sequence in future goes **above** the label drop, never below it.
+
+The one step that is **not** idempotent in that sense is #3: a second
+ai-metrics comment would land a second footer on the same PR. That exposure is
+inherent to a resumable sweep and is not what the ordering trades against — a
+duplicated footer is visible and harmless, whereas a PR that no sweep can find
+is silent and permanent.
 
 ## Required bindings
 
@@ -86,5 +94,5 @@ neither success nor failure in the existing sense; it is a third outcome whose
 report shape is `SKILL.md` Step 3.5's `[QUEUED]` block — this file is an index
 over the sequence, not a second copy of that block.
 
-The PR keeps its `review-passed` label precisely because step 3 did not run,
+The PR keeps its `review-passed` label precisely because step 6 did not run,
 and that is what a later `gh:pr-merge-train` Step 0 sweep matches on.

--- a/claude/skills/gh-pr-merge/references/help.md
+++ b/claude/skills/gh-pr-merge/references/help.md
@@ -8,12 +8,21 @@
 | 2 | strategy | `rebase` | One of `rebase`, `squash`, `merge` |
 | 3 | remote-name | `origin` | Git remote whose repo owns the PR |
 
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--auto` | Hand the PR to the base branch's **merge queue** instead of blocking until it merges (#1707). With no queue active it falls back to the ordinary immediate merge, so the flag is safe everywhere. When the PR is queued rather than merged, the skill prints `[QUEUED]` and runs none of the post-merge steps — `gh:pr-merge-train`'s Step 0 sweep finalizes it later. |
+| `--finalize` | Run **only** the post-merge completion sequence on an already-`MERGED` PR (board sync, ai-metrics, `review-passed` cleanup, tab hint, post-merge verify) and print `[FINALIZED]`. Refuses any PR that is not `MERGED`. Mutually exclusive with `--auto`. |
+
 ## Usage
 
 - `/gh-pr-merge 51` — rebase-merge PR #51 on `origin`'s repo (immediate, no confirmation)
 - `/gh-pr-merge 51 squash` — squash-merge
 - `/gh-pr-merge 51 merge` — create a merge commit (preserve history)
 - `/gh-pr-merge 51 rebase upstream` — rebase-merge against `upstream` remote
+- `/gh-pr-merge 51 rebase origin --auto` — enqueue rather than wait (merge-queue bases)
+- `/gh-pr-merge 51 rebase origin --finalize` — post-merge housekeeping only, for a PR the queue already merged
 - `/gh-pr-merge -h` / `--help` / `help` — print this help
 
 ## Strategy guide

--- a/claude/skills/gh-pr-merge/references/review-passed-cleanup.sh.md
+++ b/claude/skills/gh-pr-merge/references/review-passed-cleanup.sh.md
@@ -1,7 +1,12 @@
 # `review-passed` Cleanup — post-merge label removal (soft-fail)
 
-Runs inside Step 4 (post-merge housekeeping), after the board reconciliations
-and the herdr hint. Issue #1636, F-5.
+Runs at the very **end** of Step 5 — step 6 of 6 in the post-merge completion
+sequence, after the board reconciliations, the herdr hint, the ai-metrics
+comment, the report line and the post-merge-verify dispatch. Issue #1636, F-5;
+moved from #3 to #6 by PR #1725 (see
+`references/finalize-merged-pr.sh.md`: while the label is on, the train's Step
+0 sweep can still find a PR whose completion never finished — so nothing that
+can still be owed may run after the drop).
 
 Why: `review-passed` is a claim about **one head commit of an open PR**, read
 by exactly one consumer — `gh:pr-merge-train`'s Step 3.5 gate. Once the PR is

--- a/docs/public/changelog.d/2026-09-02-1707.md
+++ b/docs/public/changelog.d/2026-09-02-1707.md
@@ -5,3 +5,6 @@
 - 변경: **`main` ruleset 16849266 의 `strict_required_status_checks_policy` 를 `false` 로 전환 — base 보다 뒤처졌지만 충돌이 없는 PR 이 로컬 리베이스와 추가 CI 왕복 없이 바로 머지된다. 리베이스 결과가 착지 전에는 CI 를 거치지 않는 위험을 감수하며, 롤백 명령과 안전망은 `claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md` 에 있다 (#1707)**
 - 변경: **`gh:pr-merge-train` 에 Step 3.6 추가 — base 브랜치 tip 의 required check 가 이미 실패해 있으면 그 base 의 PR 을 모두 `[SKIPPED]` 처리하고 머지 단계를 중단한다. base 당 1회 조회이며 PR 당 추가 왕복은 없다 (#1707)**
 - 변경: **`gh:pr-merge-train` 의 `BEHIND` + `MERGEABLE` 라우팅이 base 의 strict 설정을 읽어 결정된다 — strict 가 꺼진 base 면 `gh:pr-resolve-outdated` 없이 바로 머지, 그 외에는 기존대로 scratch worktree 리베이스. `DIRTY` 경로는 변경 없음 (#1707)**
+- 변경: **`gh:pr-merge` 의 post-merge 완료 시퀀스에서 `review-passed` 라벨 제거가 마지막 단계(6/6)로 이동 — ai-metrics 코멘트와 post-merge-verify 디스패치보다 뒤에 실행된다. 중간에 중단된 완료 패스를 다음 tick 의 Step 0 sweep 이 다시 찾을 수 있게 하는 유일한 신호이므로, 그 앞에서 떼면 미완료 PR 이 영구히 발견 불가능해진다 (#1707)**
+- 변경: **`gh:pr-merge-train` Step 0 finalize sweep 이 최근 머지 30건이 아니라 라벨 검색(`gh search prs --merged --label review-passed`)으로 대상을 찾는다 — 장애나 머지 폭주로 밀린 PR 이 recency 창 밖으로 밀려나 영구히 누락되던 문제 해결 (#1707)**
+- 변경: **`gh:pr-merge-train` Step 3.6 의 base 건강 확인 중단 조건이 `BEHIND_DIRECT` 대신 새 `_gh_pr_merge_train_base_strict_confirmed` 판정에 연결됨 — ruleset 조회 자체가 실패한 경우에도 중단이 정상 동작한다(기존에는 정보가 가장 없는 상황에서 안전망이 조용히 꺼졌다). strict 가 켜져 있음이 확인된 base 는 종전대로 면제 (#1707)**

--- a/docs/public/changelog.d/2026-09-02-1707.md
+++ b/docs/public/changelog.d/2026-09-02-1707.md
@@ -1,0 +1,7 @@
+- 변경: **`gh:pr-merge` 에 `--auto` / `--finalize` 플래그 추가 — merge queue 가 있는 base 에서는 머지를 기다리지 않고 큐에 넣고(`[QUEUED]`), 실제 머지 후 처리는 나중에 `--finalize` 로 수행한다 (#1707)**
+- 변경: **`gh:pr-merge-train` 이 PR 을 fire-and-forget 으로 머지하고, 새 Step 0 finalize sweep 이 큐가 머지한 PR 의 보드 동기화·ai-metrics·`review-passed` 정리를 다음 tick 에 마무리한다 (#1707)**
+- 변경: **머지 트레인 리포트에 `[QUEUED]` / `[FINALIZED]` 상태 버킷 추가 (#1707)**
+- 변경: **`dEitY719/dotfiles` 는 개인 계정 소유라 GitHub merge queue 를 쓸 수 없음(조직 소유 저장소 전용)을 확인. `main` 은 legacy 엔드포인트가 404 를 낼 뿐 ruleset 16849266 으로 보호되고 있으며, 활성화 절차는 `claude/skills/gh-pr-merge-train/references/merge-queue-investigation.md` 에 수동 단계로만 기록했다 (#1707)**
+- 변경: **`main` ruleset 16849266 의 `strict_required_status_checks_policy` 를 `false` 로 전환 — base 보다 뒤처졌지만 충돌이 없는 PR 이 로컬 리베이스와 추가 CI 왕복 없이 바로 머지된다. 리베이스 결과가 착지 전에는 CI 를 거치지 않는 위험을 감수하며, 롤백 명령과 안전망은 `claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md` 에 있다 (#1707)**
+- 변경: **`gh:pr-merge-train` 에 Step 3.6 추가 — base 브랜치 tip 의 required check 가 이미 실패해 있으면 그 base 의 PR 을 모두 `[SKIPPED]` 처리하고 머지 단계를 중단한다. base 당 1회 조회이며 PR 당 추가 왕복은 없다 (#1707)**
+- 변경: **`gh:pr-merge-train` 의 `BEHIND` + `MERGEABLE` 라우팅이 base 의 strict 설정을 읽어 결정된다 — strict 가 꺼진 base 면 `gh:pr-resolve-outdated` 없이 바로 머지, 그 외에는 기존대로 scratch worktree 리베이스. `DIRTY` 경로는 변경 없음 (#1707)**

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -28,6 +28,7 @@
 #   <one gh-pr-view JSON object> | _gh_pr_merge_train_needs_finalize
 #   <gh-pr-list JSON array>       | _gh_pr_merge_train_finalize_targets
 #   <rules/branches/<base> JSON>  | _gh_pr_merge_train_behind_may_merge_directly
+#   <rules/branches/<base> JSON>  | _gh_pr_merge_train_base_strict_confirmed
 #   <commits/<base>/check-runs JSON> | _gh_pr_merge_train_base_ci_red <ctx>...
 #
 # `_gh_pr_merge_train_quiet_minutes`
@@ -320,26 +321,37 @@ _gh_pr_merge_train_has_review_passed_label() {
 # Composes with `_gh_pr_merge_train_has_review_passed_label` above rather than
 # re-deriving its label-index jq, for the same reason the header's "one place
 # the predicate lives" rule exists for the quiet-minutes number.
+#
+# `.state` is compared case-INSENSITIVELY (#1707, PR #1725): `gh pr list` and
+# `gh pr view` answer `"MERGED"`, but `gh search prs` — which is what Step 0's
+# sweep now calls, so that a leftover cannot age out of a `--limit` window —
+# answers `"merged"`. A case-sensitive compare would make the sweep silently
+# match nothing, which looks exactly like "no leftovers" and is the same class
+# of invisible failure this whole predicate exists to prevent.
 _gh_pr_merge_train_needs_finalize() {
     local _json
     _json=$(cat)
-    printf '%s' "$_json" | jq -e '.state == "MERGED"' >/dev/null 2>&1 || return 1
+    printf '%s' "$_json" | jq -e '((.state // "") | ascii_upcase) == "MERGED"' \
+        >/dev/null 2>&1 || return 1
     printf '%s' "$_json" | _gh_pr_merge_train_has_review_passed_label
 }
 
 # Array-level sibling of the predicate above (#1707 follow-up), same shape as
-# `_gh_pr_merge_train_filter_targets`: a `gh pr list --json ...` array on
-# stdin, the filtered array back on stdout. Step 0 of `gh:pr-merge-train`
-# calls THIS, not a per-element loop over the single-PR predicate — a
-# `--limit 30` sweep would otherwise fork `jq` up to twice per element just to
+# `_gh_pr_merge_train_filter_targets`: a `gh pr list` / `gh search prs`
+# `--json ...` array on stdin, the filtered array back on stdout. Step 0 of
+# `gh:pr-merge-train` calls THIS, not a per-element loop over the single-PR
+# predicate — a sweep would otherwise fork `jq` up to twice per element just to
 # filter an array it already has in hand.
+#
+# Same case-insensitive `.state` compare, for the same reason (PR #1725): Step 0
+# feeds this `gh search prs --merged` output, whose `state` is `"merged"`.
 _gh_pr_merge_train_finalize_targets() {
     local _json _out
     _json=$(cat)
     [ -n "$_json" ] || return 1
     _out=$(printf '%s' "$_json" \
         | jq -c '[ .[]?
-            | select(.state == "MERGED")
+            | select(((.state // "") | ascii_upcase) == "MERGED")
             | select(([ .labels[]?.name? ] | index("review-passed")) != null)
           ]' 2>/dev/null) || return 1
     [ -n "$_out" ] || return 1
@@ -375,6 +387,43 @@ _gh_pr_merge_train_behind_may_merge_directly() {
     jq -e '[ .[]? | select(.type == "required_status_checks") ] as $r
            | ($r | length) > 0
              and all($r[]; .parameters.strict_required_status_checks_policy == false)' \
+        >/dev/null 2>&1
+}
+
+# Is this base PROVABLY still fully strict? (#1707, PR #1725 codex BLOCKER.)
+#
+# Same stdin as the predicate above — the whole
+# `repos/{repo}/rules/branches/{base}` response — but it answers a DIFFERENT
+# question, and conflating the two was the bug this exists to fix.
+#
+# `_gh_pr_merge_train_behind_may_merge_directly` answers the ROUTING question
+# ("may a BEHIND PR skip its local rebase"), where rc 1 correctly collapses
+# three inputs — strict on, no rule found, body unreadable — into one safe "no".
+# The Step 3.6 red-base guard needs the SAFETY-NET question instead ("does this
+# base still carry the strict guarantee that made the net unnecessary"), and
+# for that the collapse is wrong: an unreadable body must not read as "strict is
+# on, so this base never needed the net". Before this function existed, the
+# guard keyed its unreadable-base halt off `BEHIND_DIRECT = yes`, so a failed
+# RULES lookup — the situation with the LEAST information — silently disabled
+# the halt entirely.
+#
+# rc 0 = the body was readable, at least one `required_status_checks` rule was
+#        found, and EVERY one of them has strict on. Only then may the caller
+#        skip its unreadable-base halt: this base never relaxed strict mode, so
+#        it never depended on the net.
+# rc 1 = everything else — strict relaxed on any rule, no rule found, or the
+#        body was unreadable. All three mean "cannot prove this base is still
+#        fully strict", which is halt-eligible.
+#
+# Note this is NOT the boolean negation of the predicate above, and must never
+# be refactored into one. Both answer rc 1 for an unreadable body and for a base
+# with no `required_status_checks` rule, on purpose: each fails closed in its
+# own direction (no shortcut / no exemption), and an input that is unknown is
+# never evidence for either.
+_gh_pr_merge_train_base_strict_confirmed() {
+    jq -e '[ .[]? | select(.type == "required_status_checks") ] as $r
+           | ($r | length) > 0
+             and all($r[]; .parameters.strict_required_status_checks_policy == true)' \
         >/dev/null 2>&1
 }
 
@@ -899,6 +948,7 @@ for _gh_pmt_selfcheck_fn in \
     _gh_pr_merge_train_needs_finalize \
     _gh_pr_merge_train_finalize_targets \
     _gh_pr_merge_train_behind_may_merge_directly \
+    _gh_pr_merge_train_base_strict_confirmed \
     _gh_pr_merge_train_base_ci_red \
     _gh_pr_merge_train_review_passed_marker_sha \
     _gh_pr_merge_train_review_passed_stale \

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -25,6 +25,9 @@
 #   _gh_pr_merge_train_pushed_sha_matches <state-dir> <pr> <sha>
 #   _gh_pr_merge_train_forget_pushed_sha <state-dir> <pr>
 #   <raw gh-pr-list JSON array> | _gh_pr_merge_train_readmit_own_pushes <state-dir> <filtered-json>
+#   <one gh-pr-view JSON object> | _gh_pr_merge_train_needs_finalize
+#   <rules/branches/<base> JSON>  | _gh_pr_merge_train_behind_may_merge_directly
+#   <commits/<base>/check-runs JSON> | _gh_pr_merge_train_base_ci_red <ctx>...
 #
 # `_gh_pr_merge_train_quiet_minutes`
 #   Echo the quiet period in minutes. Default 11; override with the env var
@@ -287,6 +290,112 @@ _gh_pr_merge_train_has_review_blocked_label() {
 
 _gh_pr_merge_train_has_review_passed_label() {
     jq -e '[ .labels[]?.name? ] | index("review-passed")' >/dev/null 2>&1
+}
+
+# The merge-queue finalize predicate (#1707).
+#
+# One PR object on stdin — the shape `gh pr list --json state,labels,...`
+# answers with. rc 0 = this PR is MERGED but its post-merge completion steps
+# never ran, so `gh:pr-merge --finalize` still owes it a pass. rc 1 = nothing
+# to do (still open, or already finalized, or malformed).
+#
+# Why `state == MERGED` AND `review-passed` is the signal, rather than a
+# queue-side lookup: `gh:pr-merge` Step 4 drops `review-passed` as the LAST
+# thing it does after a merge (`references/review-passed-cleanup.sh.md`, #1636),
+# and it is the only writer of that drop. So a MERGED PR still carrying the
+# label is, by construction, a PR whose completion steps did not run — which is
+# exactly what happens when the merge was ENQUEUED rather than performed
+# (`--auto`, #1707): `gh pr merge` returned success, the PR stayed OPEN, and
+# minutes later the queue merged it with no session watching. Reusing the label
+# this way costs no extra API call — the train's Step 0 sweep already has to
+# list PRs — and needs no new state file to go stale.
+#
+# The inverse is safe too: a PR merged the ordinary immediate way had its label
+# dropped in the same run, so it never matches here and is never finalized
+# twice. A PR that was merged without ever earning the label (a hand-merge, a
+# pre-#1636 merge) also never matches — the sweep is deliberately conservative,
+# because every step it would re-run is a GitHub write.
+_gh_pr_merge_train_needs_finalize() {
+    jq -e '(.state == "MERGED")
+           and (([ .labels[]?.name? ] | index("review-passed")) != null)' \
+        >/dev/null 2>&1
+}
+
+# Does a merely-BEHIND PR on this base need a LOCAL rebase before it can
+# merge? (#1707, `references/strict-mode-relaxation.md`.)
+#
+# The whole `repos/{repo}/rules/branches/{base}` response on stdin — the same
+# endpoint `references/approval-gate.md`'s `_gate_probe` already reads for the
+# approval count, so this answer is free if the caller keeps that body.
+#
+# rc 0 = strict required-status-checks is DEFINITIVELY off on this base, so
+#        GitHub rebases at merge time and a BEHIND PR may go straight to
+#        `gh:pr-merge`. rc 1 = everything else: strict is on, no
+#        required_status_checks rule was found, or the body was unreadable.
+#
+# The asymmetry is deliberate and points the same way every other gate in this
+# skill points. rc 1 keeps the pre-#1707 behaviour — remediate locally through
+# `gh:pr-resolve-outdated` — which is merely slower, and slower is the cost
+# this repo has always been willing to pay for an unread answer. Never invert
+# it: reading "unknown" as "strict is off" would send a PR to a merge the
+# platform then refuses, burning F-5 attempts on a deterministic refusal.
+#
+# Absence of a `required_status_checks` rule is rc 1 rather than rc 0 on
+# purpose. "No required checks at all" does mean GitHub will not block the
+# merge — but it also means the base-CI guard below has nothing to watch, so
+# the safety net that justifies the shortcut is not there either. A base with
+# no checks is a base this shortcut has no evidence about.
+_gh_pr_merge_train_behind_may_merge_directly() {
+    jq -e '[ .[]? | select(.type == "required_status_checks") ] as $r
+           | ($r | length) > 0
+             and all($r[]; .parameters.strict_required_status_checks_policy == false)' \
+        >/dev/null 2>&1
+}
+
+# Is the base branch's tip commit RED on a check this base actually requires?
+# (#1707, `references/strict-mode-relaxation.md` — the safety net.)
+#
+# `repos/{repo}/commits/{base}/check-runs` on stdin; the required contexts as
+# arguments (from the same rules body the predicate above reads). rc 0 = at
+# least one REQUIRED check has COMPLETED with a non-green conclusion, i.e.
+# positive proof that what is already on the base is broken.
+#
+# This is what replaces the guarantee strict mode used to give. Strict mode
+# verified the rebased result BEFORE it landed; `on: push` CI verifies the
+# identical checks AFTER it lands (`.github/workflows/ci.yml`, `test.yml`).
+# The coverage is the same set of checks — only the timing moved — so the one
+# thing left to add was somebody reading the answer. That is this.
+#
+# Two scoping rules, both load-bearing:
+#
+#   * REQUIRED contexts only. A base tip also carries check runs from
+#     workflows nobody gated on (this repo's weekly `Contract + drift` audit,
+#     a paths-filtered package build). Halting the train on those would wedge
+#     it on a failure no PR in the queue caused and no merge can clear — the
+#     unclearable-skip disease `references/approval-gate.md` documents at
+#     length. An empty context list is therefore rc 1, not rc 0.
+#
+#   * COMPLETED runs only. A check still `in_progress` on the tip is the
+#     ordinary state 30 seconds after a merge, and the train ticks every 3
+#     minutes. Treating pending as red would stall the train for one full CI
+#     cycle after every single merge — which is precisely the serialisation
+#     removing strict mode was meant to end, reintroduced under a new name.
+#     Only a concluded failure halts.
+#
+# Green is a whitelist (`success` / `neutral` / `skipped`), so an unfamiliar
+# conclusion — `startup_failure`, or whatever GitHub adds next — halts rather
+# than passing unread. A malformed or empty body is rc 1 because this
+# predicate only ever answers "is there proof of red"; the caller classifies
+# an unreadable response as its own fail-closed case, the way `_gate_probe`
+# does, and neither concern belongs in the other.
+_gh_pr_merge_train_base_ci_red() {
+    [ "$#" -gt 0 ] || return 1
+    jq -e '[ .check_runs[]?
+             | select(.name as $n | $ARGS.positional | index($n))
+             | select(.status == "completed")
+             | select([(.conclusion // "")]
+                      | inside(["success", "neutral", "skipped"]) | not)
+           ] | length > 0' --args "$@" >/dev/null 2>&1
 }
 
 # Sha-freshness check for `review-passed` (#1601).
@@ -761,6 +870,9 @@ for _gh_pmt_selfcheck_fn in \
     _gh_pr_merge_train_has_reply_pending_label \
     _gh_pr_merge_train_has_review_blocked_label \
     _gh_pr_merge_train_has_review_passed_label \
+    _gh_pr_merge_train_needs_finalize \
+    _gh_pr_merge_train_behind_may_merge_directly \
+    _gh_pr_merge_train_base_ci_red \
     _gh_pr_merge_train_review_passed_marker_sha \
     _gh_pr_merge_train_review_passed_stale \
     _gh_pr_merge_train_record_pushed_sha \

--- a/shell-common/functions/gh_pr_merge_train.sh
+++ b/shell-common/functions/gh_pr_merge_train.sh
@@ -26,6 +26,7 @@
 #   _gh_pr_merge_train_forget_pushed_sha <state-dir> <pr>
 #   <raw gh-pr-list JSON array> | _gh_pr_merge_train_readmit_own_pushes <state-dir> <filtered-json>
 #   <one gh-pr-view JSON object> | _gh_pr_merge_train_needs_finalize
+#   <gh-pr-list JSON array>       | _gh_pr_merge_train_finalize_targets
 #   <rules/branches/<base> JSON>  | _gh_pr_merge_train_behind_may_merge_directly
 #   <commits/<base>/check-runs JSON> | _gh_pr_merge_train_base_ci_red <ctx>...
 #
@@ -315,10 +316,35 @@ _gh_pr_merge_train_has_review_passed_label() {
 # twice. A PR that was merged without ever earning the label (a hand-merge, a
 # pre-#1636 merge) also never matches — the sweep is deliberately conservative,
 # because every step it would re-run is a GitHub write.
+#
+# Composes with `_gh_pr_merge_train_has_review_passed_label` above rather than
+# re-deriving its label-index jq, for the same reason the header's "one place
+# the predicate lives" rule exists for the quiet-minutes number.
 _gh_pr_merge_train_needs_finalize() {
-    jq -e '(.state == "MERGED")
-           and (([ .labels[]?.name? ] | index("review-passed")) != null)' \
-        >/dev/null 2>&1
+    local _json
+    _json=$(cat)
+    printf '%s' "$_json" | jq -e '.state == "MERGED"' >/dev/null 2>&1 || return 1
+    printf '%s' "$_json" | _gh_pr_merge_train_has_review_passed_label
+}
+
+# Array-level sibling of the predicate above (#1707 follow-up), same shape as
+# `_gh_pr_merge_train_filter_targets`: a `gh pr list --json ...` array on
+# stdin, the filtered array back on stdout. Step 0 of `gh:pr-merge-train`
+# calls THIS, not a per-element loop over the single-PR predicate — a
+# `--limit 30` sweep would otherwise fork `jq` up to twice per element just to
+# filter an array it already has in hand.
+_gh_pr_merge_train_finalize_targets() {
+    local _json _out
+    _json=$(cat)
+    [ -n "$_json" ] || return 1
+    _out=$(printf '%s' "$_json" \
+        | jq -c '[ .[]?
+            | select(.state == "MERGED")
+            | select(([ .labels[]?.name? ] | index("review-passed")) != null)
+          ]' 2>/dev/null) || return 1
+    [ -n "$_out" ] || return 1
+
+    printf '%s\n' "$_out"
 }
 
 # Does a merely-BEHIND PR on this base need a LOCAL rebase before it can
@@ -871,6 +897,7 @@ for _gh_pmt_selfcheck_fn in \
     _gh_pr_merge_train_has_review_blocked_label \
     _gh_pr_merge_train_has_review_passed_label \
     _gh_pr_merge_train_needs_finalize \
+    _gh_pr_merge_train_finalize_targets \
     _gh_pr_merge_train_behind_may_merge_directly \
     _gh_pr_merge_train_base_ci_red \
     _gh_pr_merge_train_review_passed_marker_sha \

--- a/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
@@ -26,6 +26,13 @@ merge_queue_needs_finalize() {
     printf '%s' "$1" | _gh_pr_merge_train_needs_finalize
 }
 
+# Usage: merge_queue_finalize_targets '<gh pr list --json ... array>'
+# Echoes the filtered array (the real shared array-level filter, same rule as
+# the single-PR predicate above).
+merge_queue_finalize_targets() {
+    printf '%s' "$1" | _gh_pr_merge_train_finalize_targets
+}
+
 # --- the two strict-relaxation predicates (Step 3.6) ----------------------
 #
 # Same rule as above: these call the real shipped functions, never a copy.

--- a/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
+# Source-of-truth mirror for the merge-queue path added by issue #1707:
+#   claude/skills/gh-pr-merge/SKILL.md            (Step 1 flags, Step 3, Step 3.5)
+#   claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
+#   claude/skills/gh-pr-merge-train/SKILL.md      (Step 0 finalize sweep)
+#
+# Two different kinds of thing live here, and the difference matters:
+#
+#   * `merge_queue_needs_finalize` does NOT re-implement its predicate — it
+#     sources the shipped `gh_pr_merge_train.sh` and calls the real
+#     `_gh_pr_merge_train_needs_finalize`, so a mirror can never pass while
+#     production drifts (#1524's rule, same as the verdict-gate fixture).
+#   * `merge_step3_auto` / `merge_step3_5` mirror bash blocks that only exist
+#     as prose in a SKILL.md. Those are pinned by the drift-guard tests at the
+#     bottom of gh_pr_merge_queue.bats — change the doc, change this file.
+
+# shellcheck source=/dev/null
+. "${_BATS_REAL_DOTFILES_ROOT:-${DOTFILES_ROOT}}/shell-common/functions/gh_pr_merge_train.sh"
+
+# --- the real shared predicate (gh:pr-merge-train Step 0) -----------------
+#
+# Usage: merge_queue_needs_finalize '<one gh pr list element>'
+# rc 0 = this MERGED PR still owes a finalize pass.
+merge_queue_needs_finalize() {
+    printf '%s' "$1" | _gh_pr_merge_train_needs_finalize
+}
+
+# --- the two strict-relaxation predicates (Step 3.6) ----------------------
+#
+# Same rule as above: these call the real shipped functions, never a copy.
+#
+# Usage: train_behind_may_merge_directly '<rules/branches/<base> JSON>'
+train_behind_may_merge_directly() {
+    printf '%s' "$1" | _gh_pr_merge_train_behind_may_merge_directly
+}
+
+# Usage: train_base_ci_red '<check-runs JSON>' <required-context>...
+train_base_ci_red() {
+    local _json="$1"
+    shift
+    printf '%s' "$_json" | _gh_pr_merge_train_base_ci_red "$@"
+}
+
+# --- gh:pr-merge-train Step 3.6, the per-base guard -----------------------
+#
+# Mirrors the block in
+# gh-pr-merge-train/references/strict-mode-relaxation.md → "New: the train
+# refuses to pile onto a red base". Pinned by the drift guards at the bottom of
+# gh_pr_merge_queue.bats — change the doc, change this file.
+#
+# Echoes the verdict line the train reports, or nothing when the merge phase
+# may proceed. `$BASE_RULES` / `$BASE_CHECKS` stand in for the two `gh api`
+# responses so the tests can drive every branch without a network.
+#
+# Usage: train_step3_6 <base> <rules-json-or-empty> <checks-json-or-empty>
+train_step3_6() {
+    local BASE="$1" BASE_RULES="$2" BASE_CHECKS="$3" BEHIND_DIRECT=no _ctx
+    local BASE_CONTEXTS=()
+
+    printf '%s' "$BASE_RULES" | _gh_pr_merge_train_behind_may_merge_directly && BEHIND_DIRECT=yes
+
+    while IFS= read -r _ctx; do
+        [ -n "$_ctx" ] && BASE_CONTEXTS+=("$_ctx")
+    done <<EOF
+$(printf '%s' "$BASE_RULES" | jq -r '.[]? | select(.type == "required_status_checks")
+                                          | .parameters.required_status_checks[]?.context' 2>/dev/null)
+EOF
+
+    printf 'BEHIND_DIRECT=%s\n' "$BEHIND_DIRECT"
+    if [ "$BEHIND_DIRECT" = yes ] && [ -z "$BASE_CHECKS" ]; then
+        echo "[SKIPPED] base health unreadable on $BASE — not merging onto an unverified base"
+    elif printf '%s' "$BASE_CHECKS" | _gh_pr_merge_train_base_ci_red "${BASE_CONTEXTS[@]}"; then
+        echo "[SKIPPED] $BASE is red — halting the merge phase until it is green"
+    fi
+}
+
+# --- gh:pr-merge Step 3, the `--auto` form -------------------------------
+#
+# Mirrors SKILL.md Step 3's `--auto` block. The fallback is the contract: any
+# failure of the `--auto` form retries the exact command the skill has always
+# run, so the flag can never be the reason a merge fails. No error-string
+# matching, deliberately.
+#
+# Usage: merge_step3_auto <pr> <repo> <host> <strategy-flag>
+merge_step3_auto() {
+    local PR_NUMBER="$1" TARGET_REPO="$2" TARGET_HOST="$3" STRATEGY_FLAG="$4" MERGE_OUT
+    if MERGE_OUT=$(GH_HOST="$TARGET_HOST" gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" \
+        "$STRATEGY_FLAG" --delete-branch --auto 2>&1); then
+        printf '%s\n' "$MERGE_OUT"
+    else
+        printf '[INFO] gh:pr-merge: --auto refused (%s) — retrying the plain merge.\n' \
+            "$(printf '%s' "$MERGE_OUT" | tr '\n' ' ')"
+        GH_HOST="$TARGET_HOST" gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" \
+            "$STRATEGY_FLAG" --delete-branch
+    fi
+}
+
+# --- gh:pr-merge Step 3.5, the third outcome ------------------------------
+#
+# Mirrors SKILL.md Step 3.5. `--auto` returning success means GitHub accepted
+# responsibility for the merge, NOT that the PR is merged: re-read the state
+# and route on it. OPEN means queued — print `[QUEUED]` and run none of the
+# completion sequence, so the `review-passed` label survives as the signal
+# gh:pr-merge-train's Step 0 sweep matches on.
+#
+# `merge_finalize_sequence` stands in for Steps 4+5, whose real blocks each
+# have their own SSOT (references/finalize-merged-pr.sh.md indexes them). The
+# tests only need to observe WHETHER it ran.
+#
+# Usage: merge_step3_5 <pr> <repo> <host>
+merge_step3_5() {
+    local _pr="$1" _repo="$2" _host="$3" _state _head _base _url _json
+    _json=$(GH_HOST="$_host" gh pr view "$_pr" --repo "$_repo" \
+        --json state,mergedAt,headRefName,baseRefName,url)
+    _state=$(printf '%s' "$_json" | jq -r '.state // empty')
+    case "$_state" in
+    MERGED)
+        merge_finalize_sequence "$_pr"
+        ;;
+    OPEN)
+        _head=$(printf '%s' "$_json" | jq -r '.headRefName // empty')
+        _base=$(printf '%s' "$_json" | jq -r '.baseRefName // empty')
+        _url=$(printf '%s' "$_json" | jq -r '.url // empty')
+        merge_queued_report "$_pr" "$_head" "$_base" "$_url"
+        ;;
+    *)
+        printf '[FAIL] PR #%s not merged — closed\n' "$_pr"
+        ;;
+    esac
+}
+
+# The `[QUEUED]` report shape, verbatim from SKILL.md Step 3.5.
+merge_queued_report() {
+    printf '[QUEUED] PR #%s added to merge queue — not yet merged\n' "$1"
+    printf '  Branch:  %s → %s\n' "$2" "$3"
+    printf '  URL:     %s\n' "$4"
+}
+
+# Stand-in for the Steps 4+5 completion sequence. Records that it ran so the
+# tests can assert the `[QUEUED]` branch skips it entirely.
+merge_finalize_sequence() {
+    printf 'finalize:%s\n' "$1" >>"${FINALIZE_LOG:-/dev/null}"
+    printf '[OK] PR #%s merged (rebase)\n' "$1"
+}

--- a/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
+++ b/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh
@@ -42,6 +42,11 @@ train_behind_may_merge_directly() {
     printf '%s' "$1" | _gh_pr_merge_train_behind_may_merge_directly
 }
 
+# Usage: train_base_strict_confirmed '<rules/branches/<base> JSON>'
+train_base_strict_confirmed() {
+    printf '%s' "$1" | _gh_pr_merge_train_base_strict_confirmed
+}
+
 # Usage: train_base_ci_red '<check-runs JSON>' <required-context>...
 train_base_ci_red() {
     local _json="$1"
@@ -63,9 +68,17 @@ train_base_ci_red() {
 # Usage: train_step3_6 <base> <rules-json-or-empty> <checks-json-or-empty>
 train_step3_6() {
     local BASE="$1" BASE_RULES="$2" BASE_CHECKS="$3" BEHIND_DIRECT=no _ctx
+    local BASE_STRICT_CONFIRMED=no
     local BASE_CONTEXTS=()
 
+    # The two normalisations the doc block does right after each `gh api` call:
+    # a malformed body is as unreadable as a failed call, and collapsing both to
+    # the empty string keeps ONE sentinel for the `-z` tests below.
+    printf '%s' "$BASE_RULES" | jq -e 'type == "array"' >/dev/null 2>&1 || BASE_RULES=''
+    printf '%s' "$BASE_CHECKS" | jq -e 'has("check_runs")' >/dev/null 2>&1 || BASE_CHECKS=''
+
     printf '%s' "$BASE_RULES" | _gh_pr_merge_train_behind_may_merge_directly && BEHIND_DIRECT=yes
+    printf '%s' "$BASE_RULES" | _gh_pr_merge_train_base_strict_confirmed && BASE_STRICT_CONFIRMED=yes
 
     while IFS= read -r _ctx; do
         [ -n "$_ctx" ] && BASE_CONTEXTS+=("$_ctx")
@@ -75,7 +88,7 @@ $(printf '%s' "$BASE_RULES" | jq -r '.[]? | select(.type == "required_status_che
 EOF
 
     printf 'BEHIND_DIRECT=%s\n' "$BEHIND_DIRECT"
-    if [ "$BEHIND_DIRECT" = yes ] && [ -z "$BASE_CHECKS" ]; then
+    if [ "$BASE_STRICT_CONFIRMED" = no ] && { [ -z "$BASE_RULES" ] || [ -z "$BASE_CHECKS" ]; }; then
         echo "[SKIPPED] base health unreadable on $BASE — not merging onto an unverified base"
     elif printf '%s' "$BASE_CHECKS" | _gh_pr_merge_train_base_ci_red "${BASE_CONTEXTS[@]}"; then
         echo "[SKIPPED] $BASE is red — halting the merge phase until it is green"

--- a/tests/bats/skills/gh_pr_merge_queue.bats
+++ b/tests/bats/skills/gh_pr_merge_queue.bats
@@ -1,0 +1,788 @@
+#!/usr/bin/env bats
+# tests/bats/skills/gh_pr_merge_queue.bats
+# Issue #1707 — merge the train's PRs through GitHub's merge queue instead of
+# one blocking merge + one full CI cycle per PR:
+#   claude/skills/gh-pr-merge/SKILL.md                          (Step 1/3/3.5)
+#   claude/skills/gh-pr-merge/references/finalize-merged-pr.sh.md
+#   claude/skills/gh-pr-merge-train/SKILL.md                    (Step 0 sweep)
+#   claude/skills/gh-pr-merge-train/references/report-format.md ([QUEUED])
+#   shell-common/functions/gh_pr_merge_train.sh                 (the predicate)
+# Source-of-truth fixture: _fixtures/gh_pr_merge_queue.sh
+#
+# The bug being fixed: merging serially means every merge advances `main`,
+# which puts every remaining queued PR BEHIND, which forces a rebase + a full
+# CI cycle per PR. A queue can only batch if MULTIPLE PRs are enqueued before
+# any of them is waited on — so the merge has to become fire-and-forget, and
+# the completion steps that used to run right after it have to move to a later
+# sweep.
+
+load '../test_helper'
+
+FIXTURE='tests/bats/skills/_fixtures/gh_pr_merge_queue.sh'
+
+setup() {
+    setup_isolated_home
+    MERGE_SKILL="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge"
+    TRAIN_SKILL="${_BATS_REAL_DOTFILES_ROOT}/claude/skills/gh-pr-merge-train"
+    GH_LOG="${BATS_TEST_TMPDIR}/gh.log"
+    FINALIZE_LOG="${BATS_TEST_TMPDIR}/finalize.log"
+    : >"$GH_LOG"
+    : >"$FINALIZE_LOG"
+    export GH_LOG FINALIZE_LOG
+    # shellcheck disable=SC1090
+    source "${_BATS_REAL_DOTFILES_ROOT}/${FIXTURE}"
+}
+
+teardown() {
+    teardown_isolated_home
+    unset -f gh 2>/dev/null || true
+}
+
+# One `gh pr list --json number,title,state,labels` element.
+_pr_json() {
+    printf '{"number":%s,"title":"fix: x","state":"%s","labels":%s}' "$1" "$2" "$3"
+}
+
+# --------------------------------------------------------------------------
+# _gh_pr_merge_train_needs_finalize — the Step 0 sweep predicate
+# --------------------------------------------------------------------------
+#
+# MERGED + `review-passed` is the signal because gh:pr-merge drops that label
+# as the LAST step of a completed merge (#1636). A merged PR still carrying it
+# is therefore a PR whose completion steps never ran — which is exactly what an
+# enqueued (`--auto`) merge leaves behind.
+
+@test "needs-finalize: MERGED + review-passed -> true" {
+    run merge_queue_needs_finalize "$(_pr_json 51 MERGED '[{"name":"review-passed"}]')"
+    assert_success
+}
+
+@test "needs-finalize: an OPEN PR carrying review-passed -> false" {
+    # The ordinary pre-merge state of every train candidate. Finalizing one
+    # would sync a board to Done for a PR that has not merged.
+    run merge_queue_needs_finalize "$(_pr_json 51 OPEN '[{"name":"review-passed"}]')"
+    assert_failure
+}
+
+@test "needs-finalize: MERGED without the label -> false (already finalized)" {
+    # The ordinary immediate-merge path drops the label in the same run, so a
+    # PR merged that way must never be finalized a second time.
+    run merge_queue_needs_finalize "$(_pr_json 51 MERGED '[]')"
+    assert_failure
+}
+
+@test "needs-finalize: MERGED with only unrelated labels -> false" {
+    run merge_queue_needs_finalize "$(_pr_json 51 MERGED '[{"name":"fix"},{"name":"ai"}]')"
+    assert_failure
+}
+
+@test "needs-finalize: MERGED + review-passed among other labels -> true" {
+    run merge_queue_needs_finalize \
+        "$(_pr_json 51 MERGED '[{"name":"fix"},{"name":"review-passed"}]')"
+    assert_success
+}
+
+@test "needs-finalize: CLOSED + review-passed -> false" {
+    # Closed-without-merging has no completion sequence to owe.
+    run merge_queue_needs_finalize "$(_pr_json 51 CLOSED '[{"name":"review-passed"}]')"
+    assert_failure
+}
+
+@test "needs-finalize: a missing state field -> false" {
+    run merge_queue_needs_finalize '{"number":51,"labels":[{"name":"review-passed"}]}'
+    assert_failure
+}
+
+@test "needs-finalize: a missing labels field -> false" {
+    run merge_queue_needs_finalize '{"number":51,"state":"MERGED"}'
+    assert_failure
+}
+
+@test "needs-finalize: malformed JSON -> false, never a crash" {
+    run merge_queue_needs_finalize 'not json at all'
+    assert_failure
+    assert_output ''
+}
+
+@test "needs-finalize: review-blocked on a merged PR is not a finalize signal" {
+    run merge_queue_needs_finalize "$(_pr_json 51 MERGED '[{"name":"review-blocked"}]')"
+    assert_failure
+}
+
+@test "needs-finalize: the shared function is defined by the shipped file" {
+    # #724's rule: the self-check at the bottom of gh_pr_merge_train.sh must
+    # cover the new function, or a rename breaks the sweep silently.
+    run grep -qF -- '_gh_pr_merge_train_needs_finalize' \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_merge_train.sh"
+    assert_success
+    run bash -c "grep -c '_gh_pr_merge_train_needs_finalize' \
+        '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_merge_train.sh'"
+    # header usage line + definition + self-check list = at least 3
+    [ "$output" -ge 3 ]
+}
+
+# --------------------------------------------------------------------------
+# gh:pr-merge Step 3 — the `--auto` command
+# --------------------------------------------------------------------------
+
+_stub_gh_merge_ok() {
+    # shellcheck disable=SC2317  # called indirectly
+    gh() {
+        printf 'gh %s\n' "$*" >>"$GH_LOG"
+        return 0
+    }
+}
+
+# `--auto` is refused — the state of any repo with allow_auto_merge=false,
+# which is dEitY719/dotfiles today. The plain merge must still happen.
+_stub_gh_auto_refused() {
+    # shellcheck disable=SC2317  # called indirectly
+    gh() {
+        printf 'gh %s\n' "$*" >>"$GH_LOG"
+        case "$*" in
+        *--auto*)
+            printf 'Auto merge is not allowed for this repository\n' >&2
+            return 1
+            ;;
+        esac
+        return 0
+    }
+}
+
+# Both forms fail — a genuinely unmergeable PR. The SECOND failure is the one
+# that surfaces, i.e. exactly what the pre-#1707 skill would have reported.
+_stub_gh_both_fail() {
+    # shellcheck disable=SC2317  # called indirectly
+    gh() {
+        printf 'gh %s\n' "$*" >>"$GH_LOG"
+        printf 'Pull request is not mergeable\n' >&2
+        return 1
+    }
+}
+
+@test "step3: --auto is in the merge command" {
+    _stub_gh_merge_ok
+    run merge_step3_auto 51 acme/widget github.com --rebase
+    assert_success
+    run cat "$GH_LOG"
+    assert_output --partial 'pr merge 51 --repo acme/widget --rebase --delete-branch --auto'
+}
+
+@test "step3: --delete-branch survives the --auto form" {
+    _stub_gh_merge_ok
+    merge_step3_auto 51 acme/widget github.com --rebase
+    run cat "$GH_LOG"
+    assert_output --partial '--delete-branch'
+}
+
+@test "step3: the strategy flag is passed through unchanged, never swapped" {
+    _stub_gh_merge_ok
+    merge_step3_auto 51 acme/widget github.com --squash
+    run cat "$GH_LOG"
+    assert_output --partial '--squash --delete-branch --auto'
+    refute_output --partial '--rebase'
+}
+
+@test "step3: a successful --auto never runs the plain merge too" {
+    _stub_gh_merge_ok
+    merge_step3_auto 51 acme/widget github.com --rebase
+    run bash -c "grep -c 'pr merge' '$GH_LOG'"
+    assert_output "1"
+}
+
+@test "step3: a refused --auto falls back to the plain merge" {
+    # The load-bearing backward-compatibility guarantee: on a repo where
+    # auto-merge is not available, the flag must be a no-op, not a breakage.
+    _stub_gh_auto_refused
+    run merge_step3_auto 51 acme/widget github.com --rebase
+    assert_success
+    run cat "$GH_LOG"
+    assert_output --partial '--rebase --delete-branch --auto'
+    assert_output --partial 'pr merge 51 --repo acme/widget --rebase --delete-branch'
+}
+
+@test "step3: the fallback merge carries no --auto" {
+    _stub_gh_auto_refused
+    merge_step3_auto 51 acme/widget github.com --rebase
+    run bash -c "grep -c -- '--auto' '$GH_LOG'"
+    assert_output "1"
+}
+
+@test "step3: the fallback says why it retried" {
+    _stub_gh_auto_refused
+    run merge_step3_auto 51 acme/widget github.com --rebase
+    assert_output --partial '[INFO] gh:pr-merge: --auto refused'
+    assert_output --partial 'retrying the plain merge'
+    assert_output --partial 'Auto merge is not allowed'
+}
+
+@test "step3: when both forms fail the failure is not swallowed" {
+    _stub_gh_both_fail
+    run merge_step3_auto 51 acme/widget github.com --rebase
+    assert_failure
+}
+
+@test "step3: the target host is pinned on both attempts (#1403 / #1407)" {
+    # shellcheck disable=SC2317  # called indirectly
+    gh() {
+        printf 'gh %s [GH_HOST=%s]\n' "$*" "${GH_HOST-}" >>"$GH_LOG"
+        case "$*" in
+        *--auto*) return 1 ;;
+        esac
+        return 0
+    }
+    merge_step3_auto 51 acme/widget ghe.example.com --rebase
+    run bash -c "grep -c 'GH_HOST=ghe.example.com' '$GH_LOG'"
+    assert_output "2"
+}
+
+# --------------------------------------------------------------------------
+# gh:pr-merge Step 3.5 — the third outcome
+# --------------------------------------------------------------------------
+
+# `gh pr view --json state,...` answers OPEN: accepted by the queue, not merged.
+_stub_gh_view_state() {
+    # A global, not a `local`: the `gh` function below runs after this helper
+    # has returned, so a dynamically-scoped local would already be gone.
+    FAKE_PR_STATE="$1"
+    # shellcheck disable=SC2317  # called indirectly
+    gh() {
+        printf 'gh %s\n' "$*" >>"$GH_LOG"
+        printf '{"state":"%s","mergedAt":null,"headRefName":"wt/issue-1707/1","baseRefName":"main","url":"https://github.com/acme/widget/pull/51"}\n' \
+            "$FAKE_PR_STATE"
+        return 0
+    }
+}
+
+@test "step3.5: an OPEN PR after --auto prints the [QUEUED] report" {
+    _stub_gh_view_state OPEN
+    run merge_step3_5 51 acme/widget github.com
+    assert_success
+    assert_line --index 0 '[QUEUED] PR #51 added to merge queue — not yet merged'
+    assert_line --index 1 '  Branch:  wt/issue-1707/1 → main'
+    assert_line --index 2 '  URL:     https://github.com/acme/widget/pull/51'
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "step3.5: a QUEUED PR runs NONE of the completion sequence" {
+    # The whole point: syncing the board, posting ai-metrics, dispatching a
+    # post-merge verification or dropping `review-passed` here would all be
+    # claims about a merge that has not happened.
+    _stub_gh_view_state OPEN
+    run merge_step3_5 51 acme/widget github.com
+    assert_success
+    run cat "$FINALIZE_LOG"
+    assert_output ''
+}
+
+@test "step3.5: a QUEUED PR is neither [OK] nor [FAIL]" {
+    _stub_gh_view_state OPEN
+    run merge_step3_5 51 acme/widget github.com
+    refute_output --partial '[OK]'
+    refute_output --partial '[FAIL]'
+}
+
+@test "step3.5: a MERGED PR runs the completion sequence exactly as before" {
+    _stub_gh_view_state MERGED
+    run merge_step3_5 51 acme/widget github.com
+    assert_success
+    assert_output --partial '[OK] PR #51 merged'
+    run cat "$FINALIZE_LOG"
+    assert_output 'finalize:51'
+}
+
+@test "step3.5: a CLOSED PR is a failure, not a queue entry" {
+    _stub_gh_view_state CLOSED
+    run merge_step3_5 51 acme/widget github.com
+    assert_output --partial '[FAIL] PR #51 not merged'
+    run cat "$FINALIZE_LOG"
+    assert_output ''
+}
+
+# --------------------------------------------------------------------------
+# Doc guards — the blocks above exist only as prose in a SKILL.md
+# --------------------------------------------------------------------------
+
+@test "doc-guard: SKILL.md Step 3 and the fixture have not drifted apart" {
+    local pat f
+    for pat in \
+        '"$STRATEGY_FLAG" --delete-branch --auto 2>&1); then' \
+        '[INFO] gh:pr-merge: --auto refused (%s) — retrying the plain merge.' \
+        '[QUEUED] PR #' \
+        'added to merge queue — not yet merged' \
+        '  Branch:  ' \
+        '  URL:     '; do
+        for f in "${MERGE_SKILL}/SKILL.md" \
+            "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh"; do
+            run grep -F -- "$pat" "$f"
+            assert_success
+        done
+    done
+}
+
+@test "doc-guard: gh:pr-merge documents both new flags" {
+    local f
+    for f in "${MERGE_SKILL}/SKILL.md" "${MERGE_SKILL}/references/help.md"; do
+        run grep -qF -- '--auto' "$f"
+        assert_success
+        run grep -qF -- '--finalize' "$f"
+        assert_success
+    done
+}
+
+@test "doc-guard: --finalize refuses a PR that is not MERGED" {
+    run grep -qF -- 'expected MERGED' "${MERGE_SKILL}/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: the finalize sequence has one SSOT, cited by both callers" {
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    [ -r "$doc" ]
+    run grep -qF -- 'references/finalize-merged-pr.sh.md' "${MERGE_SKILL}/SKILL.md"
+    assert_success
+    run grep -qF -- 'finalize-merged-pr.sh.md' "${TRAIN_SKILL}/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: the finalize SSOT names every step of the sequence" {
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    local pat
+    for pat in \
+        'references/project-board-sync.md' \
+        'references/herdr-tab-notify.sh.md' \
+        'references/review-passed-cleanup.sh.md' \
+        'references/ai-metrics-comment.sh.md' \
+        'dispatch.sh.md'; do
+        run grep -qF -- "$pat" "$doc"
+        assert_success
+    done
+}
+
+@test "doc-guard: the finalize SSOT is an index, not a second copy of the blocks" {
+    # #1524's rule in the other direction: this file must not grow its own
+    # copies of blocks that already have an SSOT, or there are two again.
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    run bash -c "grep -c -e '_gh_pr_drop_label' -e '_gh_project_status_sync' -e 'gh api' '$doc' || true"
+    assert_output "0"
+}
+
+@test "doc-guard: the train routes CLEAN through --auto" {
+    run grep -qF -- 'Skill(gh:pr-merge, "<N> rebase <remote> --auto")' \
+        "${TRAIN_SKILL}/references/routing-table.md"
+    assert_success
+    run grep -qF -- '--auto' "${TRAIN_SKILL}/references/train-loop.md"
+    assert_success
+}
+
+@test "doc-guard: no train call site still passes the bare '<N>' merge form" {
+    # The regression this would be: one row left blocking, and the whole
+    # batching benefit is gone for any queue it lands in.
+    local f
+    for f in "${TRAIN_SKILL}/SKILL.md" \
+        "${TRAIN_SKILL}/references/routing-table.md" \
+        "${TRAIN_SKILL}/references/train-loop.md" \
+        "${TRAIN_SKILL}/references/github-target.md"; do
+        run grep -F -- 'Skill(gh:pr-merge, "<N>")' "$f"
+        assert_failure
+    done
+}
+
+@test "doc-guard: report-format documents [QUEUED] and [FINALIZED]" {
+    local doc="${TRAIN_SKILL}/references/report-format.md"
+    run grep -qF -- '[QUEUED]' "$doc"
+    assert_success
+    run grep -qF -- '[FINALIZED]' "$doc"
+    assert_success
+    run grep -qF -- 'not yet merged' "$doc"
+    assert_success
+}
+
+@test "doc-guard: the train's Step 0 runs the shared predicate, not a paraphrase" {
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run grep -qF -- '_gh_pr_merge_train_needs_finalize' "$skill"
+    assert_success
+    run grep -qF -- 'Skill(gh:pr-merge, "<N> rebase <remote> --finalize")' "$skill"
+    assert_success
+}
+
+@test "doc-guard: the train's Step 0 makes no GitHub write of its own" {
+    # constraints.md's corollary. The sweep may only READ; every mutation
+    # belongs to gh:pr-merge --finalize.
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run bash -c "grep -n 'gh api\|-X POST\|-X DELETE\|-X PATCH\|gh pr edit' '$skill'"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "doc-guard: BEHIND still has a local-remediation branch to fall back to" {
+    # The shortcut is conditional on the base, so the pre-#1707 path must stay
+    # documented and reachable — a base with strict still on needs it.
+    run grep -qF -- 'gh:pr-resolve-outdated' "${TRAIN_SKILL}/references/routing-table.md"
+    assert_success
+    run grep -qF -- '$BEHIND_DIRECT' "${TRAIN_SKILL}/references/routing-table.md"
+    assert_success
+}
+
+@test "doc-guard: ordering.md says the queue does not move D-2/D-3" {
+    run grep -qF -- 'does not change D-2 or D-3' \
+        "${TRAIN_SKILL}/references/ordering.md"
+    assert_success
+}
+
+# --------------------------------------------------------------------------
+# #1707, the change that actually shipped: strict required-status-checks is
+# OFF on `main`, so a BEHIND-but-clean PR merges without a local rebase and
+# without a fresh CI cycle. Doc: references/strict-mode-relaxation.md
+# --------------------------------------------------------------------------
+
+# One `repos/{repo}/rules/branches/{base}` response carrying a
+# required_status_checks rule with the given strict flag.
+_rules_json() {
+    printf '[{"type":"pull_request","parameters":{"required_approving_review_count":0}},
+             {"type":"required_status_checks","parameters":{
+                "strict_required_status_checks_policy":%s,
+                "required_status_checks":[{"context":"Lint (mise)"},
+                                          {"context":"Shell Lint (mise)"}]}}]' "$1"
+}
+
+# One `commits/{base}/check-runs` response.
+_checks_json() {
+    printf '{"check_runs":[%s]}' "$1"
+}
+
+_run_json() {
+    printf '{"name":"%s","status":"%s","conclusion":%s}' "$1" "$2" "$3"
+}
+
+@test "behind-direct: strict off -> a BEHIND PR may merge without a local rebase" {
+    run train_behind_may_merge_directly "$(_rules_json false)"
+    assert_success
+}
+
+@test "behind-direct: strict on -> keep the pre-#1707 local remediation" {
+    run train_behind_may_merge_directly "$(_rules_json true)"
+    assert_failure
+}
+
+@test "behind-direct: no required_status_checks rule -> no, not yes" {
+    # "No required checks" does mean GitHub will not block the merge, but it
+    # also means the Step 3.6 red-base guard has nothing to watch — so the
+    # safety net justifying the shortcut is absent and the shortcut is refused.
+    run train_behind_may_merge_directly '[{"type":"pull_request","parameters":{}}]'
+    assert_failure
+}
+
+@test "behind-direct: an unreadable rules body fails closed" {
+    # Never invert this: reading "unknown" as "strict is off" sends the PR to a
+    # merge the platform then refuses, burning all three F-5 attempts on a
+    # deterministic refusal that no retry can change.
+    run train_behind_may_merge_directly 'not json at all'
+    assert_failure
+    run train_behind_may_merge_directly ''
+    assert_failure
+}
+
+@test "behind-direct: a second stricter rule wins over a relaxed one" {
+    # More than one ruleset can apply to a base; the shortcut is only safe if
+    # EVERY applicable required_status_checks rule has strict off.
+    run train_behind_may_merge_directly \
+        "$(printf '[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false}},
+                    {"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true}}]')"
+    assert_failure
+}
+
+@test "base-ci-red: a required check that FAILED on the tip is red" {
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")" \
+        'Lint (mise)' 'Shell Lint (mise)'
+    assert_success
+}
+
+@test "base-ci-red: a NON-required check failing is not red" {
+    # This repo's weekly `Contract + drift` audit and its paths-filtered
+    # package build both land on main's tip. Halting the train on those would
+    # wedge it on a failure no queued PR caused and no merge can clear.
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"success"'),
+                          $(_run_json 'Contract + drift' completed '"failure"')")" \
+        'Lint (mise)' 'Shell Lint (mise)'
+    assert_failure
+}
+
+@test "base-ci-red: a still-running required check is not red" {
+    # The ordinary state 30 seconds after a merge. Treating pending as red
+    # would stall the train for a full CI cycle after every single merge —
+    # exactly the serialisation dropping strict mode was meant to end.
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' in_progress null)")" \
+        'Lint (mise)'
+    assert_failure
+}
+
+@test "base-ci-red: green is a whitelist — an unfamiliar conclusion halts" {
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"startup_failure"')")" \
+        'Lint (mise)'
+    assert_success
+}
+
+@test "base-ci-red: neutral and skipped are green" {
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"neutral"'),
+                          $(_run_json 'Shell Lint (mise)' completed '"skipped"')")" \
+        'Lint (mise)' 'Shell Lint (mise)'
+    assert_failure
+}
+
+@test "base-ci-red: no required contexts -> nothing to be red about" {
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")"
+    assert_failure
+}
+
+@test "base-ci-red: a context name containing a space is matched whole" {
+    # `Lint (mise)` word-split would ask about `Lint` and `(mise)`, neither of
+    # which exists, and the guard would silently never fire.
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")" \
+        'Lint (mise)'
+    assert_success
+    run train_base_ci_red \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")" \
+        'Lint' '(mise)'
+    assert_failure
+}
+
+@test "base-ci-red: malformed and empty bodies are not 'red'" {
+    # This predicate only ever answers "is there PROOF of red"; classifying an
+    # unreadable response is the caller's job (train_step3_6 below).
+    run train_base_ci_red 'not json at all' 'Lint (mise)'
+    assert_failure
+    run train_base_ci_red '' 'Lint (mise)'
+    assert_failure
+}
+
+# --------------------------------------------------------------------------
+# Step 3.6 — the per-base guard as a whole
+# --------------------------------------------------------------------------
+
+@test "step3.6: relaxed base, green tip -> proceed with the shortcut on" {
+    run train_step3_6 main "$(_rules_json false)" \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"success"'),
+                          $(_run_json 'Shell Lint (mise)' completed '"success"')")"
+    assert_line 'BEHIND_DIRECT=yes'
+    refute_output --partial '[SKIPPED]'
+}
+
+@test "step3.6: a red required check halts the merge phase for that base" {
+    run train_step3_6 main "$(_rules_json false)" \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")"
+    assert_output --partial '[SKIPPED] main is red'
+    assert_output --partial 'halting the merge phase'
+}
+
+@test "step3.6: the halt is a SKIP, never a FAILED" {
+    # NF-2 leaves no way to clear a [FAILED], so a red base must never produce
+    # one — the next tick proceeds the moment main goes green again.
+    run train_step3_6 main "$(_rules_json false)" \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")"
+    refute_output --partial '[FAILED]'
+}
+
+@test "step3.6: an unreadable check-runs body halts a RELAXED base" {
+    run train_step3_6 main "$(_rules_json false)" ''
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+}
+
+@test "step3.6: an unreadable check-runs body does NOT halt a strict base" {
+    # A base that never relaxed strict mode never depended on this net, and
+    # must not start being blocked by a lookup it never needed.
+    run train_step3_6 main "$(_rules_json true)" ''
+    assert_line 'BEHIND_DIRECT=no'
+    refute_output --partial '[SKIPPED]'
+}
+
+@test "step3.6: a strict base with a red tip still halts" {
+    # The guard is about the base being broken, not about the shortcut.
+    run train_step3_6 main "$(_rules_json true)" \
+        "$(_checks_json "$(_run_json 'Shell Lint (mise)' completed '"failure"')")"
+    assert_output --partial '[SKIPPED] main is red'
+}
+
+@test "step3.6: an unreadable rules body cannot enable the shortcut" {
+    run train_step3_6 main 'not json' "$(_checks_json "$(_run_json 'Lint (mise)' completed '"success"')")"
+    assert_line 'BEHIND_DIRECT=no'
+}
+
+# --------------------------------------------------------------------------
+# Doc guards for the relaxation
+# --------------------------------------------------------------------------
+
+@test "doc-guard: the strict-relaxation doc exists and states the rollback" {
+    local doc="${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    [ -r "$doc" ]
+    run grep -qF -- 'strict_required_status_checks_policy' "$doc"
+    assert_success
+    run grep -qF -- 'ruleset-before.json' "$doc"
+    assert_success
+    run grep -qF -- 'rulesets/16849266' "$doc"
+    assert_success
+}
+
+@test "doc-guard: the accepted risk is stated, not buried" {
+    # The user's approval was conditioned on this being prominent.
+    local doc="${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    run grep -qF -- 'never itself run through' "$doc"
+    assert_success
+    run grep -qF -- 'textually' "$doc"
+    assert_success
+}
+
+@test "doc-guard: the doc does not oversell CI as running the test suite" {
+    # #754 removed `Test (mise)` from CI; both the pre- and post-merge gates
+    # are lint-only. Claiming otherwise would make the net look stronger than
+    # it is, which is the one thing this page must not do.
+    local doc="${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    run grep -qF -- '#754' "$doc"
+    assert_success
+    run grep -qF -- 'lint-only' "$doc"
+    assert_success
+}
+
+@test "doc-guard: the safety net names the push-triggered workflows" {
+    local doc="${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    local pat
+    for pat in '.github/workflows/ci.yml' 'test.yml' 'Lint (mise)' 'Shell Lint (mise)'; do
+        run grep -qF -- "$pat" "$doc"
+        assert_success
+    done
+}
+
+@test "doc-guard: both required checks really do run on push to the base" {
+    # The entire safety net rests on this. If a future edit narrows either
+    # workflow to pull_request only, the net silently disappears.
+    local wf
+    for wf in ci test; do
+        run bash -c "sed -n '/^on:/,/^jobs:/p' \
+            '${_BATS_REAL_DOTFILES_ROOT}/.github/workflows/${wf}.yml' \
+            | grep -A3 'push:' | grep -q 'main'"
+        assert_success
+    done
+}
+
+@test "doc-guard: Step 3.6 runs the shared predicates, not a paraphrase" {
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run grep -qF -- '_gh_pr_merge_train_behind_may_merge_directly' "$skill"
+    assert_success
+    run grep -qF -- '_gh_pr_merge_train_base_ci_red' "$skill"
+    assert_success
+    run grep -qF -- 'strict-mode-relaxation.md' "$skill"
+    assert_success
+}
+
+@test "doc-guard: Step 3.6 is a per-base lookup, never per-PR" {
+    # The whole point of #1707 is removing per-PR round trips; a guard that
+    # added one back would be self-defeating.
+    run grep -qF -- 'once per distinct `baseRefName`' "${TRAIN_SKILL}/SKILL.md"
+    assert_success
+}
+
+@test "doc-guard: the Step 3.6 block and the fixture have not drifted apart" {
+    local pat f
+    for pat in \
+        '_gh_pr_merge_train_behind_may_merge_directly && BEHIND_DIRECT=yes' \
+        '[SKIPPED] base health unreadable on $BASE — not merging onto an unverified base' \
+        '[SKIPPED] $BASE is red — halting the merge phase until it is green'; do
+        for f in "${TRAIN_SKILL}/references/strict-mode-relaxation.md" \
+            "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh"; do
+            run grep -F -- "$pat" "$f"
+            assert_success
+        done
+    done
+}
+
+@test "doc-guard: DIRTY is never routed around by the relaxation" {
+    # The one line that must survive every future edit to this row.
+    local f
+    for f in "${TRAIN_SKILL}/references/routing-table.md" \
+        "${TRAIN_SKILL}/references/strict-mode-relaxation.md" \
+        "${TRAIN_SKILL}/SKILL.md"; do
+        run grep -qF -- 'gh:pr-resolve-conflict' "$f"
+        assert_success
+    done
+    run grep -qF -- '`DIRTY` is completely unaffected' \
+        "${TRAIN_SKILL}/references/routing-table.md"
+    assert_success
+}
+
+@test "doc-guard: the two #1707 docs cross-reference each other" {
+    # A reader must land on the right one: the investigation is why the merge
+    # queue is blocked, the relaxation is what actually shipped.
+    run grep -qF -- 'strict-mode-relaxation.md' \
+        "${TRAIN_SKILL}/references/merge-queue-investigation.md"
+    assert_success
+    run grep -qF -- 'merge-queue-investigation.md' \
+        "${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    assert_success
+}
+
+@test "doc-guard: the investigation doc no longer claims strict is on" {
+    run grep -F -- '`strict_required_status_checks_policy: true`** is currently on' \
+        "${TRAIN_SKILL}/references/merge-queue-investigation.md"
+    assert_failure
+}
+
+@test "doc-guard: the new predicates are in the shipped self-check list" {
+    # #724's rule: a rename that breaks Step 3.6 must be loud, not silent.
+    local f="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_merge_train.sh"
+    local fn
+    for fn in _gh_pr_merge_train_behind_may_merge_directly _gh_pr_merge_train_base_ci_red; do
+        run bash -c "sed -n '/^for _gh_pmt_selfcheck_fn in/,/^done/p' '$f' | grep -qF -- '$fn'"
+        assert_success
+    done
+}
+
+@test "doc-guard: nothing in this change executes the ruleset PUT" {
+    # Same rule the merge-queue activation follows: live infrastructure is a
+    # human's deliberate act. The PUT is recorded, never run.
+    local f
+    for f in "${TRAIN_SKILL}/SKILL.md" \
+        "${TRAIN_SKILL}/references/routing-table.md" \
+        "${TRAIN_SKILL}/references/train-loop.md"; do
+        run grep -F -- 'rulesets/16849266' "$f"
+        assert_failure
+    done
+}
+
+@test "doc-guard: the investigation doc exists and is flagged manual-only" {
+    local doc="${TRAIN_SKILL}/references/merge-queue-investigation.md"
+    [ -r "$doc" ]
+    run grep -qF -- 'merge-queue-investigation.md' "${TRAIN_SKILL}/SKILL.md"
+    assert_success
+    run grep -qF -- '16849266' "$doc"
+    assert_success
+    run grep -qF -- 'merge_queue' "$doc"
+    assert_success
+}
+
+@test "doc-guard: the investigation doc corrects the 404 premise" {
+    local doc="${TRAIN_SKILL}/references/merge-queue-investigation.md"
+    run grep -qF -- '404' "$doc"
+    assert_success
+    run grep -qF -- 'branches/main/protection' "$doc"
+    assert_success
+}
+
+@test "doc-guard: nothing in this change executes the ruleset PATCH" {
+    # The activation is a human's deliberate act on live infrastructure: a
+    # 5-minute cron drives this train, and flipping the rule from inside the
+    # code that depends on it would break the running pipeline mid-flight.
+    local f
+    for f in "${TRAIN_SKILL}/SKILL.md" \
+        "${TRAIN_SKILL}/references/routing-table.md" \
+        "${TRAIN_SKILL}/references/train-loop.md" \
+        "${MERGE_SKILL}/SKILL.md"; do
+        run grep -F -- 'rulesets/16849266' "$f"
+        assert_failure
+    done
+}

--- a/tests/bats/skills/gh_pr_merge_queue.bats
+++ b/tests/bats/skills/gh_pr_merge_queue.bats
@@ -122,6 +122,44 @@ _pr_json() {
 }
 
 # --------------------------------------------------------------------------
+# _gh_pr_merge_train_finalize_targets — the array-level Step 0 filter
+# --------------------------------------------------------------------------
+#
+# Same rule as `_gh_pr_merge_train_filter_targets` (Step 2): the sweep filters
+# the whole `gh pr list --json ...` array in one `jq` pass instead of forking
+# per element, and Step 0 must call this, not loop over the single-PR
+# predicate above.
+
+@test "finalize-targets: keeps only MERGED + review-passed elements" {
+    local result
+    result=$(merge_queue_finalize_targets \
+        "[$(_pr_json 51 MERGED '[{"name":"review-passed"}]'), \
+          $(_pr_json 52 OPEN '[{"name":"review-passed"}]'), \
+          $(_pr_json 53 MERGED '[]')]")
+    run jq -c '[.[].number]' <<<"$result"
+    assert_success
+    assert_output '[51]'
+}
+
+@test "finalize-targets: no matches -> empty array, not a failure" {
+    run merge_queue_finalize_targets \
+        "[$(_pr_json 51 OPEN '[{"name":"review-passed"}]')]"
+    assert_success
+    assert_output '[]'
+}
+
+@test "finalize-targets: malformed JSON -> failure, never a crash" {
+    run merge_queue_finalize_targets 'not json at all'
+    assert_failure
+}
+
+@test "finalize-targets: the shared function is defined by the shipped file" {
+    run grep -qF -- '_gh_pr_merge_train_finalize_targets' \
+        "${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_merge_train.sh"
+    assert_success
+}
+
+# --------------------------------------------------------------------------
 # gh:pr-merge Step 3 — the `--auto` command
 # --------------------------------------------------------------------------
 
@@ -739,18 +777,6 @@ _run_json() {
     for fn in _gh_pr_merge_train_behind_may_merge_directly _gh_pr_merge_train_base_ci_red; do
         run bash -c "sed -n '/^for _gh_pmt_selfcheck_fn in/,/^done/p' '$f' | grep -qF -- '$fn'"
         assert_success
-    done
-}
-
-@test "doc-guard: nothing in this change executes the ruleset PUT" {
-    # Same rule the merge-queue activation follows: live infrastructure is a
-    # human's deliberate act. The PUT is recorded, never run.
-    local f
-    for f in "${TRAIN_SKILL}/SKILL.md" \
-        "${TRAIN_SKILL}/references/routing-table.md" \
-        "${TRAIN_SKILL}/references/train-loop.md"; do
-        run grep -F -- 'rulesets/16849266' "$f"
-        assert_failure
     done
 }
 

--- a/tests/bats/skills/gh_pr_merge_queue.bats
+++ b/tests/bats/skills/gh_pr_merge_queue.bats
@@ -725,6 +725,14 @@ _run_json() {
     assert_success
 }
 
+@test "doc-guard: the check-runs fetch is paginated" {
+    # codex FOLLOW-UP, PR #1725: a base with more than one page of check runs
+    # must not silently drop a later, possibly-failing required context.
+    run grep -qF -- 'gh api --paginate "repos/$TARGET_REPO/commits/$BASE_ENC/check-runs"' \
+        "${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    assert_success
+}
+
 @test "doc-guard: the Step 3.6 block and the fixture have not drifted apart" {
     local pat f
     for pat in \

--- a/tests/bats/skills/gh_pr_merge_queue.bats
+++ b/tests/bats/skills/gh_pr_merge_queue.bats
@@ -729,6 +729,10 @@ _run_json() {
     local pat f
     for pat in \
         '_gh_pr_merge_train_behind_may_merge_directly && BEHIND_DIRECT=yes' \
+        '_gh_pr_merge_train_base_strict_confirmed && BASE_STRICT_CONFIRMED=yes' \
+        "printf '%s' \"\$BASE_RULES\" | jq -e 'type == \"array\"' >/dev/null 2>&1 || BASE_RULES=''" \
+        "printf '%s' \"\$BASE_CHECKS\" | jq -e 'has(\"check_runs\")' >/dev/null 2>&1 || BASE_CHECKS=''" \
+        'if [ "$BASE_STRICT_CONFIRMED" = no ] && { [ -z "$BASE_RULES" ] || [ -z "$BASE_CHECKS" ]; }; then' \
         '[SKIPPED] base health unreadable on $BASE — not merging onto an unverified base' \
         '[SKIPPED] $BASE is red — halting the merge phase until it is green'; do
         for f in "${TRAIN_SKILL}/references/strict-mode-relaxation.md" \
@@ -811,4 +815,313 @@ _run_json() {
         run grep -F -- 'rulesets/16849266' "$f"
         assert_failure
     done
+}
+
+# --------------------------------------------------------------------------
+# PR #1725, codex BLOCKER 1 — the `review-passed` drop must be the LAST step
+# of the post-merge completion sequence, not the third of six.
+#
+# The label is the ONLY thing `_gh_pr_merge_train_needs_finalize` matches on.
+# While it is on, an unfinished PR is findable by the next tick's Step 0
+# sweep; the moment it comes off, that PR is invisible forever. So no step
+# that can still be owed may run after the drop — and until #1725 two did
+# (the ai-metrics comment and the post-merge-verify dispatch).
+# --------------------------------------------------------------------------
+
+# First line number carrying a fixed string, or empty if absent.
+_line_of() {
+    grep -nF -- "$2" "$1" | head -n 1 | cut -d: -f1
+}
+
+@test "drop-last: the finalize SSOT orders the label drop after ai-metrics" {
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    local metrics drop
+    metrics=$(_line_of "$doc" 'references/ai-metrics-comment.sh.md')
+    drop=$(_line_of "$doc" 'references/review-passed-cleanup.sh.md')
+    [ -n "$metrics" ]
+    [ -n "$drop" ]
+    [ "$drop" -gt "$metrics" ]
+}
+
+@test "drop-last: the finalize SSOT orders the label drop after the PMV dispatch" {
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    local dispatch drop
+    dispatch=$(_line_of "$doc" 'dispatch.sh.md')
+    drop=$(_line_of "$doc" 'references/review-passed-cleanup.sh.md')
+    [ -n "$dispatch" ]
+    [ "$drop" -gt "$dispatch" ]
+}
+
+@test "drop-last: the finalize SSOT numbers the label drop 6 of 6" {
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    run grep -qE '^\| 6 \|.*review-passed' "$doc"
+    assert_success
+}
+
+@test "drop-last: the SSOT prose no longer claims the drop is step 3" {
+    # The exact false statement #1725 found: the doc said "Step 3 is last among
+    # the writes on purpose" while sitting 3rd of 6 with two writes after it.
+    local doc="${MERGE_SKILL}/references/finalize-merged-pr.sh.md"
+    run grep -F -- 'Step 3 is **last among the writes on purpose**' "$doc"
+    assert_failure
+}
+
+@test "drop-last: gh:pr-merge runs the drop after ai-metrics and after the dispatch" {
+    local skill="${MERGE_SKILL}/SKILL.md"
+    local metrics dispatch drop
+    metrics=$(_line_of "$skill" 'references/ai-metrics-comment.sh.md')
+    dispatch=$(_line_of "$skill" 'gh-pr-post-merge-verify/references/dispatch.sh.md')
+    drop=$(_line_of "$skill" 'references/review-passed-cleanup.sh.md')
+    [ -n "$metrics" ]
+    [ -n "$dispatch" ]
+    [ -n "$drop" ]
+    [ "$drop" -gt "$metrics" ]
+    [ "$drop" -gt "$dispatch" ]
+}
+
+@test "drop-last: gh:pr-merge Step 4 explicitly says the drop is not there" {
+    # A reader following Step 4 top to bottom must not re-add it in place.
+    run grep -qF -- 'is **not** dropped here' "${MERGE_SKILL}/SKILL.md"
+    assert_success
+}
+
+@test "drop-last: the cleanup SSOT states where in the sequence it runs" {
+    local doc="${MERGE_SKILL}/references/review-passed-cleanup.sh.md"
+    run grep -qF -- 'step 6 of 6' "$doc"
+    assert_success
+    run grep -qF -- '#1725' "$doc"
+    assert_success
+}
+
+# --------------------------------------------------------------------------
+# PR #1725, codex BLOCKER 2 (agy FOLLOW-UP) — a failed RULES lookup must not
+# silently disable the red-base safety net.
+#
+# The old guard was `[ "$BEHIND_DIRECT" = yes ] && [ -z "$BASE_CHECKS" ]`.
+# `_gh_pr_merge_train_behind_may_merge_directly` returns rc 1 for an
+# unreadable body just as it does for "strict is on", so a failed rules call
+# set BEHIND_DIRECT=no and the halt could never fire — in the exact situation
+# with the least information. `_gh_pr_merge_train_base_strict_confirmed`
+# answers the exemption question directly instead.
+# --------------------------------------------------------------------------
+
+@test "strict-confirmed: strict on everywhere -> yes, this base is exempt" {
+    run train_base_strict_confirmed "$(_rules_json true)"
+    assert_success
+}
+
+@test "strict-confirmed: strict off -> no, this base depends on the net" {
+    run train_base_strict_confirmed "$(_rules_json false)"
+    assert_failure
+}
+
+@test "strict-confirmed: an unreadable body is NOT an exemption" {
+    # The whole bug: "we could not read the rules" must never be read as
+    # "strict is still on, so this base never needed the guard".
+    run train_base_strict_confirmed 'not json at all'
+    assert_failure
+    run train_base_strict_confirmed ''
+    assert_failure
+}
+
+@test "strict-confirmed: no required_status_checks rule -> not confirmed" {
+    # Symmetric with behind_may_merge_directly's own `length > 0` requirement:
+    # zero rules is an absence of evidence, not evidence of strictness.
+    run train_base_strict_confirmed '[{"type":"pull_request","parameters":{}}]'
+    assert_failure
+}
+
+@test "strict-confirmed: one relaxed rule among strict ones -> not confirmed" {
+    run train_base_strict_confirmed \
+        "$(printf '[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true}},
+                    {"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false}}]')"
+    assert_failure
+}
+
+@test "strict-confirmed: it is not the negation of behind_may_merge_directly" {
+    # Both are rc 1 for an unreadable body and for a base with no rule. A
+    # future refactor that made one `! other` would silently re-open the bug.
+    local body
+    for body in 'not json at all' '[{"type":"pull_request","parameters":{}}]'; do
+        run train_behind_may_merge_directly "$body"
+        assert_failure
+        run train_base_strict_confirmed "$body"
+        assert_failure
+    done
+}
+
+@test "step3.6: BOTH lookups failing halts — the correlated-outage case" {
+    # codex FOLLOW-UP #2. Before #1725 this printed nothing at all: the first
+    # branch needed BEHIND_DIRECT=yes (impossible with unreadable rules) and
+    # the elif's base_ci_red is rc 1 on an empty body by its own contract.
+    run train_step3_6 main '' ''
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+}
+
+@test "step3.6: an unreadable rules body alone halts, even with readable checks" {
+    # Not defensive padding: with no rules body, BASE_CONTEXTS is empty, so
+    # base_ci_red has nothing to match and a red base reads as green.
+    run train_step3_6 main '' \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"success"')")"
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+}
+
+@test "step3.6: a MALFORMED body is as unreadable as a failed call" {
+    # `-z` alone only catches the `|| BASE_RULES=''` path. A 200 carrying a
+    # proxy interstitial is non-empty, and every predicate reading it answers
+    # its own fail-closed rc 1 — which is silence, not a halt. Hence the
+    # normalisation to the same empty sentinel.
+    run train_step3_6 main 'not json' \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"success"')")"
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+
+    run train_step3_6 main "$(_rules_json false)" 'not json either'
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+}
+
+@test "step3.6: rules unreadable + checks genuinely RED still halts" {
+    # The OR must not let a red base through just because the other call failed.
+    run train_step3_6 main 'not json' \
+        "$(_checks_json "$(_run_json 'Lint (mise)' completed '"failure"')")"
+    assert_output --partial '[SKIPPED]'
+    refute_output --partial '[FAILED]'
+}
+
+@test "step3.6: a confirmed-strict base is still exempt from the unreadable halt" {
+    # The preserved rule: a base that never relaxed strict mode never depended
+    # on this net and must not start being blocked by a lookup it never needed.
+    run train_step3_6 main "$(_rules_json true)" ''
+    assert_line 'BEHIND_DIRECT=no'
+    refute_output --partial '[SKIPPED]'
+}
+
+@test "step3.6: a relaxed base with unreadable checks halts, as before" {
+    run train_step3_6 main "$(_rules_json false)" ''
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+}
+
+@test "step3.6: a base with no required-checks rule halts when checks are unreadable" {
+    # It cannot be proven strict, so it is not exempt — and with no contexts
+    # the red check could never speak for it either.
+    run train_step3_6 main '[{"type":"pull_request","parameters":{}}]' ''
+    assert_output --partial '[SKIPPED] base health unreadable on main'
+}
+
+@test "step3.6: the halt never depends on BEHIND_DIRECT any more" {
+    # BEHIND_DIRECT is the ROUTING answer; conflating it with safety-net
+    # eligibility is the bug. Assert the guard does not mention it.
+    local f
+    for f in "${TRAIN_SKILL}/references/strict-mode-relaxation.md" \
+        "${_BATS_REAL_DOTFILES_ROOT}/tests/bats/skills/_fixtures/gh_pr_merge_queue.sh"; do
+        run grep -F -- '[ "$BEHIND_DIRECT" = yes ] && [ -z "$BASE_CHECKS" ]' "$f"
+        assert_failure
+    done
+}
+
+@test "doc-guard: the new predicate is in the shipped self-check list" {
+    local f="${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_merge_train.sh"
+    run bash -c "sed -n '/^for _gh_pmt_selfcheck_fn in/,/^done/p' '$f' \
+        | grep -qF -- '_gh_pr_merge_train_base_strict_confirmed'"
+    assert_success
+}
+
+@test "doc-guard: Step 3.6 names the exemption predicate, not a paraphrase" {
+    run grep -qF -- '_gh_pr_merge_train_base_strict_confirmed' "${TRAIN_SKILL}/SKILL.md"
+    assert_success
+    run grep -qF -- '_gh_pr_merge_train_base_strict_confirmed' \
+        "${TRAIN_SKILL}/references/strict-mode-relaxation.md"
+    assert_success
+}
+
+# --------------------------------------------------------------------------
+# PR #1725, codex BLOCKER 3 — the finalize sweep must query by LABEL, not by
+# recency. `gh pr list --limit 30` lost a still-unfinalized PR forever once 30
+# further merges had happened, with no error and no report line.
+# --------------------------------------------------------------------------
+
+@test "finalize-targets: gh search's lowercase \"merged\" state matches" {
+    # `gh search prs --json state` answers "merged"; `gh pr list` answers
+    # "MERGED". A case-sensitive compare would make the new sweep silently
+    # return nothing — indistinguishable from "no leftovers".
+    local result
+    result=$(merge_queue_finalize_targets \
+        "[$(_pr_json 51 merged '[{"name":"review-passed"}]')]")
+    run jq -c '[.[].number]' <<<"$result"
+    assert_success
+    assert_output '[51]'
+}
+
+@test "needs-finalize: lowercase \"merged\" + review-passed -> true" {
+    run merge_queue_needs_finalize "$(_pr_json 51 merged '[{"name":"review-passed"}]')"
+    assert_success
+}
+
+@test "finalize-targets: lowercase \"closed\" is still not a finalize target" {
+    # Search reports a closed-unmerged PR as "closed". Case-insensitivity must
+    # not widen the rule beyond MERGED.
+    run merge_queue_finalize_targets \
+        "[$(_pr_json 51 closed '[{"name":"review-passed"}]')]"
+    assert_success
+    assert_output '[]'
+}
+
+@test "finalize-targets: lowercase \"open\" is still not a finalize target" {
+    run merge_queue_finalize_targets \
+        "[$(_pr_json 51 open '[{"name":"review-passed"}]')]"
+    assert_success
+    assert_output '[]'
+}
+
+@test "sweep: Step 0 queries the search index by label, not gh pr list" {
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run grep -qF -- 'gh search prs --repo "$TARGET_REPO" --author @me' "$skill"
+    assert_success
+    run grep -qF -- '--merged --label review-passed' "$skill"
+    assert_success
+}
+
+@test "sweep: the recency-capped call is gone" {
+    # `--limit 30` may still be NAMED in the prose that explains the bug; what
+    # must be gone is the invocation. Assert on the command, not the mention.
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run grep -F -- 'gh pr list --repo "$TARGET_REPO" --author @me --state merged' "$skill"
+    assert_failure
+    run grep -qF -- '--limit 100 --json number,title,state,labels' "$skill"
+    assert_success
+}
+
+@test "sweep: the prose no longer calls an aged-out leftover a human's problem" {
+    # That sentence justified the bug. It must not survive the fix.
+    run grep -F -- "is a human's problem, not a loop's" "${TRAIN_SKILL}/SKILL.md"
+    assert_failure
+}
+
+@test "sweep: --author @me survives the switch to search (D-7)" {
+    # Never sweep — and therefore never finalize — a colleague's PR.
+    run grep -qF -- '--author @me' "${TRAIN_SKILL}/SKILL.md"
+    assert_success
+}
+
+@test "sweep: the shared filter still runs over the search result" {
+    # The query and the filter now encode the same rule; the filter is what
+    # keeps that rule in ONE place and normalises `state` across both sources.
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run grep -qF -- '| _gh_pr_merge_train_finalize_targets' "$skill"
+    assert_success
+}
+
+@test "sweep: the sweep is still read-only (constraints.md corollary)" {
+    local skill="${TRAIN_SKILL}/SKILL.md"
+    run bash -c "grep -n 'gh api\|-X POST\|-X DELETE\|-X PATCH\|gh pr edit' '$skill'"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "sweep: constraints.md describes the same call the skill makes" {
+    run grep -qF -- 'gh search prs --merged --label' \
+        "${TRAIN_SKILL}/references/constraints.md"
+    assert_success
+    run grep -F -- 'one `gh pr list --state merged`' \
+        "${TRAIN_SKILL}/references/constraints.md"
+    assert_failure
 }


### PR DESCRIPTION
## Summary
- `gh:pr-merge-train` 이 PR을 한 번에 하나씩 머지하면서 매 머지마다 나머지 PR 전원이 BEHIND 로 무효화돼, N개 PR = N회 직렬 CI 왕복이 들던 문제(#1707)를 해결한다.
- 1순위 후보였던 GitHub merge queue 는 이 저장소(개인 계정 소유)에서 근본적으로 불가능함을 조사·확인했다 — org 전용 기능 + gh CLI 버그(cli/cli#13398) 이중 블로커.
- 실제 해결책은 main 브랜치 ruleset 의 `strict_required_status_checks_policy` 를 false 로 전환하는 것 — 이미 live 로 적용 완료, rollback 스냅샷 보존.

## Changes
- `claude/skills/gh-pr-merge-train/references/merge-queue-investigation.md` (신규): merge queue 불가 사유 조사 전문 + 만약을 위한 수동 활성화 절차.
- `claude/skills/gh-pr-merge-train/references/strict-mode-relaxation.md` (신규): 실제 적용한 변경(무엇이·왜·롤백 명령), 감수한 위험, 안전망(신규 Step 3.6 + 기존 push-트리거 CI + `gh:pr-post-merge-verify`)을 숨김없이 기록.
- `claude/skills/gh-pr-merge-train/{SKILL.md,references/{routing-table,ordering,constraints,train-loop,report-format,help,github-target}.md}`: `BEHIND` 행이 strict 완화된 base 에서는 로컬 rebase 없이 바로 merge, 신규 Step 3.6(base CI red 감지 시 그 tick 의 merge 단계 전체 halt), `[QUEUED]` 리포트 상태 추가.
- `claude/skills/gh-pr-merge/{SKILL.md,references/{help,finalize-merged-pr.sh.md}}`: `--auto` 플래그 추가(merge queue 대비, 현재는 strict 완화만으로 즉시 merge 로 수렴해 inert) + 완료 절차(board sync·ai-metrics·tab close·post-merge-verify)를 재사용 가능한 색인 문서로 추출.
- `shell-common/functions/gh_pr_merge_train.sh`: `_gh_pr_merge_train_needs_finalize`, `_gh_pr_merge_train_behind_may_merge_directly`, `_gh_pr_merge_train_base_ci_red` 3개 공유 함수 + self-check 등록.
- `tests/bats/skills/gh_pr_merge_queue.bats` + fixture: 신규 로직 74건 회귀 테스트(문서-fixture drift guard 포함).
- `docs/public/changelog.d/2026-09-02-1707.md`: 운영 변경 changelog fragment.

## Test plan
- [x] `tests/bats/skills/gh_pr_merge_queue.bats` 74/74 pass
- [x] `tests/bats/skills/ tests/bats/functions/ tests/bats/tools/` 전체 bats — exit 0, 회귀 없음
- [x] `pytest -k host_pinning` 26/26 pass (rollback 블록의 #1403/#1407 host-pinning 계약 포함)
- [x] `mise run lint` / `mise run lint-docs` — errors=0
- [ ] 실제 cron tick 에서 BEHIND PR 이 로컬 rebase 없이 `[MERGED]` 되는지 육안 확인 (AC4 최종 실측 — 메커니즘 전제조건은 이미 문서에 실측 기록됨)

## Related
Closes #1707

---
<details>
<summary>🤖 AI Metrics · 📊 ~29500 tokens · 👤 ~24 h (3 d) · 🤖 ~113 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~29500 tokens · 👤 ~24 h (3 d) · 🤖 ~113 min
<!-- /ai-metrics:gh-pr -->

</details>
