### PR TITLE
feat(gh-pr-reply): --review-pass / --review-block 수동 판정 오버라이드 플래그 추가

### DIFF
--- a/claude/skills/gh-pr-reply/SKILL.md
+++ b/claude/skills/gh-pr-reply/SKILL.md
@@ -38,6 +38,16 @@ Read `references/target-resolution.md` and follow it: positional args
 `gh`'s default-repo heuristic), the fork tradeoff. Every later `gh` call runs as
 `GH_HOST="$TARGET_HOST" gh ... --repo "$TARGET_REPO"` (#1403, #1407).
 
+## Step 1.5: Manual Verdict Override (`--review-pass` / `--review-block`)
+
+If `--review-pass` or `--review-block` was passed, read
+`references/manual-override.md` and follow it: strip the flag from arg
+parsing (it may appear anywhere among the positional args), swap the
+`review-passed`/`review-blocked` labels directly via
+`devx_pr_review_all_write_label` — no BLOCKER gate, no evidence check, this
+is the user asserting the verdict directly (#1726) — then **stop**. Steps
+2–7 do not run. Both flags together is a usage error handled before Step 1.
+
 ## Step 2: Fetch All Review Comments
 
 Read `references/comment-fetching.md` for the three API endpoints, field

--- a/claude/skills/gh-pr-reply/evals/trigger-eval.json
+++ b/claude/skills/gh-pr-reply/evals/trigger-eval.json
@@ -4,6 +4,15 @@
     "should_trigger": true
   },
   {
+    "query": "/gh-pr-reply 1707 --review-pass",
+    "should_trigger": true,
+    "note": "slash-literal manual override flag (#1726): update if the skill is renamed (#1410)"
+  },
+  {
+    "query": "이 PR 내가 직접 확인했어, review-blocked 떼고 review-passed 강제로 붙여줘",
+    "should_trigger": true
+  },
+  {
     "query": "gemini 봇이 달아준 인라인 코멘트들 아직 아무 답이 없는데 정리해줘",
     "should_trigger": true
   },

--- a/claude/skills/gh-pr-reply/references/constraints.md
+++ b/claude/skills/gh-pr-reply/references/constraints.md
@@ -22,8 +22,12 @@
   head-advancing skill uses (#1563) — never an inlined DELETE.
 - Never **add** `review-passed` or `review-blocked` by hand — no bare
   `gh pr edit --add-label`, no inlined REST POST. The Step 6 gate helper
-  `_gh_pr_reply_apply_review_passed` is the only path, and it writes through
-  the shared `devx_pr_review_all_write_label` primitive.
+  `_gh_pr_reply_apply_review_passed` is the only automatic path, and it
+  writes through the shared `devx_pr_review_all_write_label` primitive. The
+  one other path is the explicit `--review-pass` / `--review-block` flags
+  (Step 1.5, `references/manual-override.md`, #1726) — a user-invoked
+  override, not a second automatic judgment — which calls the same
+  `devx_pr_review_all_write_label` primitive directly, bypassing the gate.
 - **NF-2 — "never self-certify" — is deliberately RELAXED here, on this one
   path (#1636).** State it plainly rather than quietly: this skill now applies
   `review-passed` **from its own judgment, with no external AI CLI re-call**,
@@ -45,3 +49,10 @@
     ever. A failed label write leaves the PR unlabelled, and unlabelled still
     reads downstream as "not verified", never as a pass. `review-blocked` is
     still issued only by an external reviewer's verdict.
+- **A second, narrower exception: `--review-pass` / `--review-block`
+  (#1726).** Unlike the #1636 gate above, this one skips BLOCKER/evidence
+  evaluation entirely — the human operator is asserting the verdict, not
+  asking the skill to judge it. It requires the flag on the exact
+  invocation; there is no automatic or cron-triggered path to it, and a
+  plain `/gh:pr-reply <N>` is unaffected. See
+  `references/manual-override.md`.

--- a/claude/skills/gh-pr-reply/references/help.md
+++ b/claude/skills/gh-pr-reply/references/help.md
@@ -6,12 +6,18 @@
 |---|------|---------|-------------|
 | 1 | PR number, or `-h`/`--help`/`help` | current-branch PR | Target PR, e.g. `123` |
 | 2 | remote name | `origin` | Git remote used to resolve the target repo (`owner/repo`) — pins the repo when multiple remotes share one GitHub host |
+| — | `--review-pass` | off | Skip comment processing; drop `review-blocked`, apply `review-passed` directly. Mutually exclusive with `--review-block`. May appear anywhere among the args. |
+| — | `--review-block` | off | Skip comment processing; drop `review-passed`, apply `review-blocked` directly. Mutually exclusive with `--review-pass`. May appear anywhere among the args. |
 
 ## Usage
 
 - `/gh-pr-reply` — process review comments on the PR for the current branch
 - `/gh-pr-reply 123` — process review comments on PR #123 explicitly
 - `/gh-pr-reply 123 upstream` — target PR #123 on the `upstream` remote's repo
+- `/gh-pr-reply 123 --review-pass` — skip comment processing; force
+  `review-passed` on PR #123 (drops `review-blocked` first)
+- `/gh-pr-reply 123 --review-block` — skip comment processing; force
+  `review-blocked` on PR #123 (drops `review-passed` first)
 - `/gh-pr-reply -h` / `--help` / `help` — print this help
 
 ## What the skill does
@@ -37,6 +43,16 @@
 6. Pushes fix commits (`git push`, never force) if any landed.
 7. Prints a compact summary: Accepted / Declined / Answered counts plus
    commit SHAs, and lists any comments skipped as "already replied".
+
+## Manual verdict override
+
+`--review-pass` / `--review-block` bypass everything above — no comment
+fetch, no evaluation, no fixes, no reply, no push. They swap the verdict
+label directly and stop. This is an explicit, user-invoked override: the
+BLOCKER gate that the normal flow uses to decide `review-passed`
+(`references/review-passed-gate.md`) is not consulted. Use it when you have
+verified the PR through channels the skill cannot see and need the label to
+reflect that now. See `references/manual-override.md`.
 
 ## What the skill will NOT do
 

--- a/claude/skills/gh-pr-reply/references/manual-override.md
+++ b/claude/skills/gh-pr-reply/references/manual-override.md
@@ -1,0 +1,71 @@
+# `--review-pass` / `--review-block` — Manual Verdict Override (issue #1726)
+
+The Step 6 gate (`references/review-passed-gate.md`) is the only path that
+writes `review-passed` from this skill's own judgment, and it fail-closes:
+no `review-passed` while a BLOCKER-severity item is unresolved, and none
+without `ai-review` marker evidence. That is correct for the automatic
+path, but it also means a PR the user has manually verified — through
+channels this skill cannot see, e.g. a human re-read of the diff — has no
+way back to `review-passed` short of editing the label by hand outside the
+skill, which `references/constraints.md` forbids everywhere else.
+
+These two flags are that way back: an **explicit, user-invoked** override,
+not a second automatic path. The caller is asserting the verdict directly;
+this skill does not evaluate anything.
+
+## Recognizing the flags
+
+`--review-pass` and `--review-block` may appear anywhere among the
+positional args (`references/target-resolution.md`'s `<pr-number>
+[remote]`), e.g. `/gh:pr-reply 123 --review-pass` or `/gh:pr-reply
+--review-pass 123 upstream`. Strip them before parsing the remaining args
+positionally — same treatment `-h`/`--help` already gets.
+
+Both flags together is a usage error: print `--review-pass and
+--review-block are mutually exclusive` and stop before Step 1 runs. Neither
+label is touched.
+
+## Step 1.5 — override and stop
+
+Runs immediately after Step 1 (target resolution — needs `PR_NUMBER`,
+`TARGET_REPO`, `TARGET_HOST`) and **before** Step 2. When either flag was
+given, this replaces Steps 2–7 entirely: no comment fetch, no evaluation,
+no fixes, no reply pass, no push, no ai-metrics comment.
+
+```bash
+. "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/devx_pr_review_all.sh"
+
+HEAD_SHA=$(GH_HOST="$TARGET_HOST" gh pr view "$PR_NUMBER" \
+    --repo "$TARGET_REPO" --json headRefOid -q .headRefOid)
+
+# LABEL is "review-passed" for --review-pass, "review-blocked" for --review-block.
+WRITE=$(devx_pr_review_all_write_label "$LABEL" "$PR_NUMBER" "$TARGET_REPO" \
+    "$TARGET_HOST" "$HEAD_SHA")
+
+devx_pr_review_all_report_write_result "$WRITE" "$PR_NUMBER" "$TARGET_REPO" "$LABEL" \
+    "[OK] 수동 오버라이드: \`$LABEL\` 적용됨 (반대 라벨 제거 포함, 게이트 미평가, #1726)" \
+    "[WARN] PR #$PR_NUMBER 수동 오버라이드 적용 실패 — 라벨 상태 확인 필요"
+```
+
+This is the same primitive `references/verdict-label-removal.sh.md`'s
+"직접 add 금지" section names as the write-side of the automatic gate
+(`devx_pr_review_all_write_label` → the shared REST-DELETE-then-POST
+sequence, freshness marker included for `review-passed`). Reusing it here
+means the override gets the same opposite-label cleanup, the same
+`_gh_pr_edit_safe_label` add path (classic-Projects safe, #326), and the
+same `#1601` freshness marker `gh:pr-merge-train` checks — no bespoke
+label-write code, no drift from the automatic path's semantics.
+
+## Step 7 (report)
+
+Skipped along with the rest of Steps 2–7. Print only the one-line result
+above, then stop. No summary table.
+
+## Why this does not weaken NF-2 further
+
+`references/constraints.md` already documents one relaxation of "never
+self-certify" (#1636 — the automatic gate, still evidence- and
+BLOCKER-gated). This is a second, narrower one: it requires the human
+operator to explicitly type the flag on this exact invocation. It carries
+no automatic trigger, no cron path, and no default — a plain `/gh:pr-reply
+<N>` with neither flag runs the normal gated flow unchanged.


### PR DESCRIPTION
## Summary

- `/gh:pr-reply` 에 `--review-pass` / `--review-block` 플래그를 추가한다. 각각
  Step 2-7(코멘트 fetch/평가/수정/답변)과 게이트(#1636)를 모두 건너뛰고, 반대
  라벨을 지운 뒤 지정한 라벨을 바로 붙이고 종료한다.
- 새 셸 함수 없이 기존 공유 프리미티브 `devx_pr_review_all_write_label` /
  `devx_pr_review_all_report_write_result` 를 재사용한다 — 반대 라벨 삭제,
  `_gh_pr_edit_safe_label` 경유 부착, `review-passed` freshness 마커까지 그대로
  적용.
- `references/constraints.md` 에 이 플래그를 "라벨 직접 add 금지" 규칙의 두 번째
  명시적 예외로 문서화했다 (#1636 게이트가 첫 번째).
- 새 레퍼런스 `references/manual-override.md` 가 SSOT.

## Background

#1710 복기 문서 기준 `review-passed` 부여 경로는 게이트 하나뿐이라, 사용자가
스킬이 볼 수 없는 채널로 PR을 직접 검증해도 라벨을 되돌릴 방법이 없었다.
사용자가 반복 요청한 "무조건 자동 부여"는 여전히 반대하되(NF-2/BLOCKER
리스크), 매 호출마다 명시적으로 선언해야 하는 수동 오버라이드로 절충했다.
자세한 배경/설계는 issue #1726.

## Test plan

- [x] `bash scripts/lint_changelog_fragments.sh` (fragment 자체는 CLAUDE.md
      2026-09-02 정책 변경으로 이번 PR엔 포함하지 않음)
- [x] `python3 -c "import json; json.load(open('claude/skills/gh-pr-reply/evals/trigger-eval.json'))"`
- [ ] 실제 PR에 `/gh-pr-reply <N> --review-pass` / `--review-block` 수동 실행

Closes #1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWw9Q8SLjfpDLHea6LE3GE