### PR TITLE
feat(skills): #1410 Phase 4-3 — 자동화 dispatch 문자열 신규 이름 전환

### DIFF
--- a/shell-common/functions/gh_flow.sh
+++ b/shell-common/functions/gh_flow.sh
@@ -51,14 +51,14 @@ _gh_flow_get_state() {
 # Post-condition helpers (worker uses these to verify each step did real work)
 # ============================================================================
 
-# Returns 0 if the current tree has something /gh-commit could commit:
+# Returns 0 if the current tree has something /gh-pr:commit could commit:
 # staged, unstaged, or untracked changes. (Runs inside the worktree.)
 _gh_flow_has_work_for_commit() {
     [ -n "$(git status --porcelain 2>/dev/null | head -n1)" ]
 }
 
 # Returns 0 if the current branch has at least one commit ahead of
-# the upstream default branch (origin/HEAD). Used to verify /gh-commit.
+# the upstream default branch (origin/HEAD). Used to verify /gh-pr:commit.
 _gh_flow_has_branch_commits() {
     local _base _count
     _base="$(git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/||')"
@@ -108,7 +108,7 @@ _gh_flow_require_ai_cli() {
 # Pre-flight health check for the gh CLI token. Returns 0 if `gh api user`
 # succeeds (token valid + network reachable), non-zero otherwise. Run by the
 # worker BEFORE `gwt spawn` so an expired token cannot waste an AI turn on
-# /gh-issue-implement (issue #378, #437 incident).
+# /gh-issue:implement (issue #378, #437 incident).
 _gh_flow_check_gh_auth() {
     gh api user --jq .login >/dev/null 2>&1
 }
@@ -224,7 +224,7 @@ EOF
             else
                 case "$_pr_decision" in
                 CHANGES_REQUESTED)
-                    _verdict="comments arrived — worker about to run /gh-pr-reply"
+                    _verdict="comments arrived — worker about to run /gh-pr:reply"
                     ;;
                 *)
                     _verdict="awaiting first review"
@@ -680,9 +680,9 @@ gh_flow_help() {
     ux_bullet "gh-flow -h|--help|help           this help"
     ux_info ""
     ux_info "Spawn pipeline (each worker runs these sequentially):"
-    ux_bullet "gwt spawn → /gh-issue-implement → /gh-commit → /gh-pr"
-    ux_bullet "poll reviews → /gh-pr-reply (once, if comments)"
-    ux_bullet "poll for APPROVED → /gh-pr-merge → gwt teardown"
+    ux_bullet "gwt spawn → /gh-issue:implement → /gh-pr:commit → /gh-pr:create"
+    ux_bullet "poll reviews → /gh-pr:reply (once, if comments)"
+    ux_bullet "poll for APPROVED → /gh-pr:merge → gwt teardown"
     ux_info ""
     ux_info "Examples:"
     ux_bullet "gh-flow 13                  # single issue"
@@ -1010,53 +1010,53 @@ _gh_flow_worker() {
         return 1
     }
 
-    # ---- Step 2a: implement (selected ai runs /gh-issue-implement) ----
-    # The original single `/gh-issue-flow` call was unreliable in
+    # ---- Step 2a: implement (selected ai runs /gh-issue:implement) ----
+    # The original single `/gh-flow:issue` call was unreliable in
     # non-interactive mode: it often stopped after the implement phase and printed
     # a "Next: …" hint without running commit/PR. We invoke the 3 atomic skills
     # ourselves so each phase has a distinct state + post-condition check.
     _gh_flow_set_state "$_dir" "implementing"
     _gh_project_status_sync issue "$_issue" "In progress"
-    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-issue-implement $_issue direct" "/gh-issue-implement $_issue direct"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-issue:implement $_issue direct" "/gh-issue:implement $_issue direct"; then
         _gh_flow_set_state "$_dir" "failed:implementing"
-        printf '[gh-flow-worker] /gh-issue-implement failed\n' >&2
+        printf '[gh-flow-worker] /gh-issue:implement failed\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: implementing)"
         return 1
     fi
     if ! _gh_flow_has_work_for_commit; then
         _gh_flow_set_state "$_dir" "failed:implementing"
-        printf '[gh-flow-worker] /gh-issue-implement produced no changes\n' >&2
+        printf '[gh-flow-worker] /gh-issue:implement produced no changes\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: implementing/no-op)"
         return 1
     fi
 
-    # ---- Step 2b: commit (selected ai runs /gh-commit) ----
+    # ---- Step 2b: commit (selected ai runs /gh-pr:commit) ----
     _gh_flow_set_state "$_dir" "committing"
-    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-commit" "/gh-commit"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr:commit" "/gh-pr:commit"; then
         _gh_flow_set_state "$_dir" "failed:committing"
-        printf '[gh-flow-worker] /gh-commit failed\n' >&2
+        printf '[gh-flow-worker] /gh-pr:commit failed\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: committing)"
         return 1
     fi
     if ! _gh_flow_has_branch_commits; then
         _gh_flow_set_state "$_dir" "failed:committing"
-        printf '[gh-flow-worker] /gh-commit left no new commit on branch\n' >&2
+        printf '[gh-flow-worker] /gh-pr:commit left no new commit on branch\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: committing/no-commit)"
         return 1
     fi
 
-    # ---- Step 2c: open PR (selected ai runs /gh-pr) ----
+    # ---- Step 2c: open PR (selected ai runs /gh-pr:create) ----
     _gh_flow_set_state "$_dir" "opening-pr"
-    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr $_issue" "/gh-pr $_issue"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr:create $_issue" "/gh-pr:create $_issue"; then
         _gh_flow_set_state "$_dir" "failed:opening-pr"
-        printf '[gh-flow-worker] /gh-pr failed\n' >&2
+        printf '[gh-flow-worker] /gh-pr:create failed\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: opening-pr)"
         return 1
     fi
     _pr="$(gh pr view --json number --jq '.number' 2>/dev/null)"
     if [ -z "$_pr" ]; then
         _gh_flow_set_state "$_dir" "failed:opening-pr"
-        printf '[gh-flow-worker] /gh-pr did not create a PR\n' >&2
+        printf '[gh-flow-worker] /gh-pr:create did not create a PR\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: opening-pr/no-pr)"
         return 1
     fi
@@ -1084,13 +1084,13 @@ _gh_flow_worker() {
                 2>/dev/null)"
             if [ -n "$_comments" ] && [ "$_comments" -gt 0 ]; then
                 _gh_flow_set_state "$_dir" "replying"
-                printf '[gh-flow-worker] running /gh-pr-reply (%s review(s))\n' "$_comments"
-                if _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr-reply" "/gh-pr-reply"; then
+                printf '[gh-flow-worker] running /gh-pr:reply (%s review(s))\n' "$_comments"
+                if _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr:reply" "/gh-pr:reply"; then
                     touch "$_dir/reply.done"
                     _gh_flow_set_state "$_dir" "polling"
                 else
                     _gh_flow_set_state "$_dir" "failed:replying"
-                    printf '[gh-flow-worker] /gh-pr-reply failed\n' >&2
+                    printf '[gh-flow-worker] /gh-pr:reply failed\n' >&2
                     _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: replying)"
                     return 1
                 fi
@@ -1100,9 +1100,9 @@ _gh_flow_worker() {
 
     # ---- Step 4: merge ----
     _gh_flow_set_state "$_dir" "merging"
-    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr-merge" "/gh-pr-merge"; then
+    if ! _gh_flow_run_ai_prompt "$_ai" "$_usage_log" "/gh-pr:merge" "/gh-pr:merge"; then
         _gh_flow_set_state "$_dir" "failed:merging"
-        printf '[gh-flow-worker] /gh-pr-merge failed\n' >&2
+        printf '[gh-flow-worker] /gh-pr:merge failed\n' >&2
         _ai_usage_summary "$_usage_log" "Token Usage (issue #$_issue — failed: merging)"
         return 1
     fi
@@ -1124,8 +1124,8 @@ _gh_flow_worker() {
 # ============================================================================
 # Project board Status sync
 # ============================================================================
-# Helper extracted to shell-common/functions/gh_project_status.sh so /gh-pr
-# and /gh-commit (single-skill execution paths, not the gh-flow worker) can
+# Helper extracted to shell-common/functions/gh_project_status.sh so /gh-pr:create
+# and /gh-pr:commit (single-skill execution paths, not the gh-flow worker) can
 # also push board transitions. The worker calls _gh_project_status_sync at
 # Step 2a (implement → "In progress") and after Step 2c (PR opened →
 # "In review"); see lines 412 and 454.

--- a/shell-common/tools/custom/issue_watcher_cron.sh
+++ b/shell-common/tools/custom/issue_watcher_cron.sh
@@ -4,7 +4,7 @@
 #
 # cron 이 주기마다 이 스크립트를 호출하면 tick 1회를 수행한다. tick 은 감시부터
 # 디스패치까지를 직접 수행한다 — 판단이 필요한 지점은 마지막 한 곳,
-# 디스패치된 pane 안에서 도는 `/gh-issue-flow <N>` 뿐이다 (issue #1440):
+# 디스패치된 pane 안에서 도는 `/gh-flow:issue <N>` 뿐이다 (issue #1440):
 #   1) 끝난 이슈의 워크트리 회수 (closed + agent 없음 + 미커밋 변경 없음)
 #   2) 살아있는 per-issue agent 수가 상한이면 이번 tick 보류
 #   3) `gh search issues` 로 할당된 open 이슈를 교차 저장소 한 번에 조회
@@ -12,7 +12,7 @@
 #   5) repo 라운드로빈 · 이슈 번호 오름차순으로 후보 정렬
 #   6) 이미 실행 중 / 이미 처리됨(이슈를 닫는 open PR) / blockedBy OPEN 스킵
 #   7) tick 당 최대 _IW_DISPATCH_PER_TICK 건만 워크트리 + herdr tab + agent 생성
-#   8) `/gh-issue-flow <N>` 프롬프트 전달
+#   8) `/gh-flow:issue <N>` 프롬프트 전달
 # 토큰 한도 게이트가 닫혀 있으면 사이클 전체를 보류한다 (issue #1436, #1444).
 #
 # 워크트리 존재 여부는 어떤 판정에도 쓰이지 않는다 (issue #1453 NF-1) — 순수
@@ -331,7 +331,7 @@ _IW_SATURATION_STATE_BASENAME="saturation.json"
 _IW_LIMIT_STRIKES="2"
 _IW_LIMIT_BACKOFF_SECONDS="1800"
 # How long a *confirmed* dispatch has to hold `working` before the tick accepts
-# it as proof the quota is intact (issue #1444). One `/gh-issue-flow` runs for
+# it as proof the quota is intact (issue #1444). One `/gh-flow:issue` runs for
 # minutes — review gate included — so a prompt that provably reached the pane
 # and is idle again a minute later did not finish early, it never started.
 _IW_LIMIT_OBSERVE_SEC="60"
@@ -2062,7 +2062,7 @@ _iw_escalate_prompt_stall() {
         "issue #${_number} prompt failure" || true
 }
 
-# Send `/gh-issue-flow <N>` to the issue's agent.
+# Send `/gh-flow:issue <N>` to the issue's agent.
 #
 # The prompt is a slash command, not prose: pre-#1440 this channel carried an
 # instruction to *run another agent*, and the receiving session had to work out
@@ -2072,7 +2072,7 @@ _iw_escalate_prompt_stall() {
 _iw_prompt_issue() {
     local _agent="$1" _number="$2" _tab="${3-}" _attempt="${4-}" _prompt _json _code _rc=0 _seq0 _post_stall_status _fail_code
 
-    _prompt="/gh-issue-flow ${_number}"
+    _prompt="/gh-flow:issue ${_number}"
     _IW_STALL_RECOVER_ERROR=""
     _IW_PROMPT_KEEP_ATTEMPT=0
 
@@ -2254,7 +2254,7 @@ EOF
 #      failed proves nothing about the quota: it is an input-loop or transport
 #      problem, so the gate is left exactly as it was.
 #   2. Did the submitted work hold? A confirmed dispatch is polled for
-#      `_IW_LIMIT_OBSERVE_SEC`. One `/gh-issue-flow` runs for minutes, so an
+#      `_IW_LIMIT_OBSERVE_SEC`. One `/gh-flow:issue` runs for minutes, so an
 #      agent that never reaches `working`, or falls back to `idle`/`done`
 #      inside that window, did not do the work it was handed. That is the
 #      shape quota exhaustion takes, and it earns the strike.
@@ -3239,7 +3239,7 @@ _iw_acquire_lock() {
 _iw_usage() {
     ux_header "issue_watcher_cron"
     ux_info "Usage: issue_watcher_cron.sh [--cwd <PATH>] [--dry-run] | --status | [-h|--help|help]"
-    ux_info "Runs one issue-watcher tick: find assigned issues, dispatch /gh-issue-flow."
+    ux_info "Runs one issue-watcher tick: find assigned issues, dispatch /gh-flow:issue."
     ux_bullet "options"
     ux_bullet_sub "--cwd <PATH>   run the tick from PATH; relative watch-list paths resolve against it"
     ux_bullet_sub "--dry-run      print the issues this tick would dispatch, change nothing"

--- a/tests/bats/functions/gh_flow.bats
+++ b/tests/bats/functions/gh_flow.bats
@@ -387,7 +387,7 @@ STUB
     run_in_bash "cd '$REPO_DIR' && _gh_flow_verdict 220"
     assert_success
     assert_output --partial "comments arrived"
-    assert_output --partial "/gh-pr-reply"
+    assert_output --partial "/gh-pr:reply"
     assert_output --partial "still working"
 }
 

--- a/tests/bats/tools/issue_watcher_cron.bats
+++ b/tests/bats/tools/issue_watcher_cron.bats
@@ -586,7 +586,7 @@ case "$1 $2" in
         exit 0
     fi
     if [ "$5" = "40" ]; then
-        printf '> /gh-issue-flow 11\n5-hour limit reached. Resets at 3pm.\n'
+        printf '> /gh-flow:issue 11\n5-hour limit reached. Resets at 3pm.\n'
         exit 0
     fi
     _seq="${HERDR_SETTLE_READ_SEQUENCE:-> claude ready}"
@@ -1093,13 +1093,13 @@ _assert_not_hung() {
     _assert_logged "gwt spawn --wt-name issue-11"
     _assert_logged "tab create --workspace"
     _assert_logged "agent start iw-dotfiles-issue-11 --kind claude --pane ws-test-1:p9"
-    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-issue-flow 11"
+    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-flow:issue 11"
 }
 
 @test "issue_watcher_cron: the prompt is the slash command, not a subagent instruction" {
     _run_tick
     assert_success
-    _assert_logged "/gh-issue-flow 11"
+    _assert_logged "/gh-flow:issue 11"
     # The pre-#1440 prompt told the receiving session to run another agent,
     # which is the ambiguity #1394 was about. Nothing may reintroduce it.
     _refute_logged "issue-watcher:dispatcher"
@@ -1220,7 +1220,7 @@ _assert_not_hung() {
 }
 
 @test "issue_watcher_cron: an existing worktree no longer retires the issue" {
-    # The bug this replaces: /gh-issue-flow stops at "PR opened", so a worktree
+    # The bug this replaces: /gh-flow:issue stops at "PR opened", so a worktree
     # removed before the merge used to re-dispatch, and one kept until the merge
     # piled up — while an issue whose session had died was never offered again,
     # because its worktree was still there. A worktree is a workspace now.
@@ -2442,7 +2442,7 @@ _two_repo_fixture() {
     # here would mean the outer loop absorbed it, which is the defect.
     [ "$(_log_count 'agent start')" -eq 2 ]
     [ "$(_log_count 'tab create')" -eq 1 ]
-    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-issue-flow 11"
+    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-flow:issue 11"
 }
 
 # The retry has to be visible: 130 ticks of silent failure is what made this
@@ -2586,7 +2586,7 @@ _two_repo_fixture() {
     _install_failing_mktemp
     _run_tick
     assert_success
-    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-issue-flow 11"
+    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-flow:issue 11"
 }
 
 # Same fallback on the failing side: the tick reports the failure and cleans up
@@ -2611,7 +2611,7 @@ _two_repo_fixture() {
 @test "issue_watcher_cron: a spawn that fails once then succeeds still dispatches" {
     _run_tick "GWT_SPAWN_FAIL_TIMES=1"
     assert_success
-    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-issue-flow 11"
+    _assert_logged "agent prompt iw-dotfiles-issue-11 /gh-flow:issue 11"
 }
 
 @test "issue_watcher_cron: a non-stall prompt failure is not retried within the attempt" {
@@ -3066,7 +3066,7 @@ _two_repo_fixture() {
 
 @test "issue_watcher_cron: a confirmed dispatch that never reaches working records a strike" {
     # The prompt landed — `agent prompt` succeeded — and a minute later the pane
-    # is still idle. One /gh-issue-flow runs for minutes, so the work never
+    # is still idle. One /gh-flow:issue runs for minutes, so the work never
     # started.
     _run_tick
     assert_success


### PR DESCRIPTION
## Summary
- #1410 §6 Phase 4-3: 운영 중인 자동화 스크립트가 실제로 dispatch하는 슬래시 명령 문자열을 옛 이름에서 신규 이름으로 전환
- #1676/#1678(15-repo 스킬 분리)이 CLOSED 상태임을 확인하고, 신규 이름이 이 머신에서 유효한 명령임을 스킬 목록으로 확인 후 착수

## Changes
- `shell-common/tools/custom/issue_watcher_cron.sh`: `/gh-issue-flow` → `/gh-flow:issue` (F-1), 주변 주석 6곳 동시 갱신 (F-3)
- `shell-common/functions/gh_flow.sh`: `/gh-issue-implement` → `/gh-issue:implement` (F-2)
- `shell-common/functions/gh_flow.sh`: F-4 재확인으로 발견한 나머지 직접 호출도 동일 원칙으로 교체 — `/gh-commit` → `/gh-pr:commit`, `/gh-pr` → `/gh-pr:create`, `/gh-pr-reply` → `/gh-pr:reply`, `/gh-pr-merge` → `/gh-pr:merge`
- 두 파일의 주변 주석·docstring도 신규 이름으로 갱신
- `tests/bats/tools/issue_watcher_cron.bats`, `tests/bats/functions/gh_flow.bats`: 관련 어서션을 새 문자열 기준으로 갱신

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_flow.bats` — 53/53 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/issue_watcher_cron.bats` — 263/264 통과 (나머지 1건은 이 변경과 무관한 기존 실패: `--help`가 문서화한 `17 running in total`/`7 in one repo`가 실제 기본값 5/3과 어긋나는 사전 존재 버그)
- [x] `grep -n "gh-issue-flow\|gh-issue-implement" shell-common/tools/custom/issue_watcher_cron.sh shell-common/functions/gh_flow.sh` — 빈 결과 확인

## Related
Closes #1682

---
<details>
<summary>🤖 AI Metrics · 📊 ~5500 tokens · 👤 ~4 h · 🤖 ~20 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5500 tokens · 👤 ~4 h · 🤖 ~20 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdBtxi6zrpbWHQaHPhjy1v
